### PR TITLE
feat(router): implement body.minimumDistance (transient-probe distance)

### DIFF
--- a/addin/router/body_m07_test.go
+++ b/addin/router/body_m07_test.go
@@ -49,6 +49,33 @@ func TestBodyListAndShells(t *testing.T) {
 	}
 }
 
+// TestBodyMinimumDistance: a transient travel polyline measured against the box — clearance above
+// the top face, tool-radius widening, and a piercing move clamped to 0; plus the malformed-input
+// guard. Distances are database units (cm); the box top is at z=5.
+func TestBodyMinimumDistance(t *testing.T) {
+	r, s := boxPartSession(t)
+	var md wire.MinimumDistanceResult
+
+	call(t, r, s, "body.minimumDistance", `{"bodyIndex":0,"points":[0,1.5,10,4,1.5,10]}`, &md)
+	if stdmath.Abs(md.Distance-5) > 1e-6 {
+		t.Errorf("above-box distance = %g cm, want 5", md.Distance)
+	}
+	// A 1 cm tool radius shrinks the clearance to 4 cm.
+	call(t, r, s, "body.minimumDistance", `{"bodyIndex":0,"points":[0,1.5,10,4,1.5,10],"radius":1}`, &md)
+	if stdmath.Abs(md.Distance-4) > 1e-6 {
+		t.Errorf("radius-widened distance = %g cm, want 4", md.Distance)
+	}
+	// A move through the block clamps at 0.
+	call(t, r, s, "body.minimumDistance", `{"bodyIndex":0,"points":[2,1.5,2,2,1.5,3]}`, &md)
+	if md.Distance != 0 {
+		t.Errorf("through-box distance = %g, want 0", md.Distance)
+	}
+	// A points list that is not a multiple of three is rejected, not truncated.
+	if err := tryCall(t, r, s, "body.minimumDistance", `{"bodyIndex":0,"points":[0,1.5]}`); err == nil {
+		t.Error("malformed probe points should error")
+	}
+}
+
 // TestBodyPointAndRayQueries: locate, ray, containment.
 func TestBodyPointAndRayQueries(t *testing.T) {
 	r, s := boxPartSession(t)

--- a/addin/router/body_query.go
+++ b/addin/router/body_query.go
@@ -12,6 +12,7 @@ import (
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
+	"oblikovati.org/model/analysis"
 )
 
 // Body point/ray/validity queries over the wire (M07-F07, #630).
@@ -149,6 +150,42 @@ func containmentSpelling(c ops.PointContainment) string {
 	default:
 		return types.OutsideContainment.String()
 	}
+}
+
+// bodyMinimumDistance serves wire.MethodBodyMinimumDistance: the closest approach between the body
+// and a transient probe polyline (a CAM travel path), optionally widened by the tool radius. The
+// out-of-process projection of MeasureTools.GetMinimumDistance for a transient operand (#630).
+func bodyMinimumDistance(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.MinimumDistanceArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	b, err := resolveBody(s, in.BodyIndex)
+	if err != nil {
+		return nil, err
+	}
+	probe, err := probePolyline(in.Points)
+	if err != nil {
+		return nil, err
+	}
+	dist := analysis.MinDistanceProbeToBody(probe, b, ops.DefaultQuality()) - in.Radius
+	if dist < 0 {
+		dist = 0
+	}
+	return json.Marshal(wire.MinimumDistanceResult{Distance: dist})
+}
+
+// probePolyline decodes a flat [x,y,z, ...] list (database units) into points; it requires a
+// non-empty multiple of three so the offending shape is reported rather than silently truncated.
+func probePolyline(flat []float64) ([]math.Point3, error) {
+	if len(flat) == 0 || len(flat)%3 != 0 {
+		return nil, fmt.Errorf("probe points = %d floats, want a non-empty multiple of 3 (x,y,z per point)", len(flat))
+	}
+	pts := make([]math.Point3, 0, len(flat)/3)
+	for i := 0; i < len(flat); i += 3 {
+		pts = append(pts, math.V3(math.Scalar(flat[i]), math.Scalar(flat[i+1]), math.Scalar(flat[i+2])).AsPoint())
+	}
+	return pts, nil
 }
 
 // bodyConvexityEdges serves wire.MethodBodyConvexityEdges.

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -385,6 +385,7 @@ func (r *Router) registerMaterialHandlers() {
 	r.handlers[wire.MethodBodyFindUsingRay] = bodyFindUsingRay
 	r.handlers[wire.MethodBodyIsPointInside] = bodyIsPointInside
 	r.handlers[wire.MethodBodyConvexityEdges] = bodyConvexityEdges
+	r.handlers[wire.MethodBodyMinimumDistance] = bodyMinimumDistance
 	r.handlers[wire.MethodBodyValidate] = bodyValidate
 	r.handlers[wire.MethodBodyRangeBox] = bodyRangeBox
 	r.handlers[wire.MethodBodyBindTransientKey] = bodyBindTransientKey

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.84.0
+	oblikovati.org/api v0.85.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.84.0
+	oblikovati.org/api v0.85.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/analysis/mindistance.go
+++ b/model/analysis/mindistance.go
@@ -53,6 +53,47 @@ func (e MeasureEntity) simplices(q ops.Quality) ([]segment, []triangle) {
 	return nil, nil
 }
 
+// MinDistanceProbeToBody returns the minimum distance, in database units (cm), between a transient
+// probe polyline and a body — the closest approach of an arbitrary travel path (e.g. a CAM linking
+// move) to the part. The probe reduces to its segments (a lone point becomes a zero-length segment),
+// the body to its face triangles, and the result is the smallest segment-triangle distance. It is
+// +Inf when the probe or the body has no geometry, and 0 when they touch or intersect. This is the
+// transient-operand counterpart of MinDistanceMm (which measures two resolved model entities), the
+// out-of-process projection of MeasureTools.GetMinimumDistance — Oblikovati/Oblikovati#630.
+func MinDistanceProbeToBody(probe []math.Point3, body *topo.Body, q ops.Quality) float64 {
+	segs := probeSegments(probe)
+	if len(segs) == 0 {
+		return stdmath.Inf(1)
+	}
+	// Distance to a *solid*, not just its skin: a probe point inside the material is a collision
+	// (distance 0) even when no segment crosses a boundary face — a fully interior travel move would
+	// otherwise report the gap to the nearest wall. A segment that merely passes through is caught by
+	// the segment-triangle pass below (it crosses the boundary). Matches OCC distToShape's overlap=0.
+	for _, p := range probe {
+		if ops.BodyContainment(body, p, q, 1e-6) == ops.ContainInside {
+			return 0
+		}
+	}
+	best := stdmath.Inf(1)
+	for _, f := range body.Faces() {
+		best = minSegTri(best, segs, faceTriangles(f, q))
+	}
+	return best
+}
+
+// probeSegments turns a probe polyline into its consecutive segments; a single point becomes one
+// zero-length segment so it still measures point-to-body.
+func probeSegments(probe []math.Point3) []segment {
+	if len(probe) == 1 {
+		return []segment{{probe[0], probe[0]}}
+	}
+	segs := make([]segment, 0, len(probe))
+	for i := 1; i < len(probe); i++ {
+		segs = append(segs, segment{probe[i-1], probe[i]})
+	}
+	return segs
+}
+
 func edgeSegments(e *topo.Edge, q ops.Quality) []segment {
 	pts := ops.TessellateEdge(e, q)
 	segs := make([]segment, 0, len(pts))

--- a/model/analysis/mindistance_test.go
+++ b/model/analysis/mindistance_test.go
@@ -63,6 +63,36 @@ func TestMinDistanceBox(t *testing.T) {
 	}
 }
 
+// TestMinDistanceProbeToBody checks the transient-probe distance on the same 4×3×5 cm block: a
+// travel segment above the top face clears it by the gap, a segment piercing the block touches (0),
+// a lone point measures point-to-body, and an empty probe is +Inf. Results are database units (cm).
+func TestMinDistanceProbeToBody(t *testing.T) {
+	block, err := brep.SolidBlock(gmath.P3(0, 0, 0), gmath.P3(4, 3, 5), "block")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	q := ops.DefaultQuality()
+
+	// A horizontal travel segment 5 cm above the top face (z=5).
+	above := []gmath.Point3{gmath.P3(0, 1.5, 10), gmath.P3(4, 1.5, 10)}
+	if d := MinDistanceProbeToBody(above, block, q); math.Abs(d-5) > 1e-6 {
+		t.Errorf("above-box probe distance = %g cm, want 5", d)
+	}
+	// A segment piercing the block touches it.
+	through := []gmath.Point3{gmath.P3(2, 1.5, 2), gmath.P3(2, 1.5, 3)}
+	if d := MinDistanceProbeToBody(through, block, q); d > 1e-6 {
+		t.Errorf("through-box probe distance = %g cm, want 0", d)
+	}
+	// A lone point 2 cm beyond the +x face.
+	if d := MinDistanceProbeToBody([]gmath.Point3{gmath.P3(6, 1.5, 2.5)}, block, q); math.Abs(d-2) > 1e-6 {
+		t.Errorf("point probe distance = %g cm, want 2", d)
+	}
+	// No probe geometry → +Inf.
+	if d := MinDistanceProbeToBody(nil, block, q); !math.IsInf(d, 1) {
+		t.Errorf("empty probe distance = %g, want +Inf", d)
+	}
+}
+
 // sameSet reports whether got contains exactly the wanted values (within tolerance, any order).
 func sameSet(got, want []float64) bool {
 	if len(got) != len(want) {


### PR DESCRIPTION
## What

Implements `body.minimumDistance` (shipped in `oblikovati.org/api` v0.85.0): the closest approach between a document body and a **transient probe polyline**, with an optional swept-tool radius.

- `model/analysis.MinDistanceProbeToBody` — reduces the probe to segments and measures against the body's face triangles via the **existing simplex min-distance engine** that already backs `analysis.measure{minDistance}`. A probe point inside the solid short-circuits to `0` (via `ops.BodyContainment`) so a fully-interior travel move reads as a collision, matching OCC `distToShape`'s overlap semantics.
- `addin/router.bodyMinimumDistance` — decodes the flat `x,y,z` probe list, subtracts the tool radius, clamps at 0.
- pin `oblikovati.org/api` → v0.85.0.

Tests: model fixture (4×3×5 cm block — clearance above, pierce → 0, point-to-body, empty → +Inf) and the router round-trip (clearance, radius-widening, pierce-clamp, malformed-input guard). The `TestEveryWireMethodHasAHandler` parity guard now passes for the new method.

## Why

Out-of-process add-ins could measure minimum distance only between document entities by reference key. A CAM travel move / swept tool is transient and has no reference key, so collision-aware toolpath linking (keep-tool-down vs. always-retract) had no host query. This is the `/source` half of the two-part API change (ADR-0018); the contract (PR Oblikovati.API#206) shipped as the out-of-process projection of `MeasureTools.GetMinimumDistance` for a transient operand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)