### PR TITLE
M32-H05: host add-in catalogue client + installer

### DIFF
--- a/addincat/catalogue.go
+++ b/addincat/catalogue.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package addincat is the host side of the add-in catalogue (#1164): a thin client for the
+// addins.oblikovati.org service plus an installer that downloads a bundle into the per-user
+// add-ins directory. The application's Add-In Catalogue window drives it; the loader scans
+// the same directory at startup.
+//
+// The Entry/Version/Bundle types here DUPLICATE the service's catalogue DTO (the service is
+// a separate, stdlib-only module). The wire format is pinned by a round-trip test so the two
+// copies cannot drift — the same precedent as report.Payload.
+package addincat
+
+// Bundle is one downloadable per-platform artifact. SHA256 lets the installer verify the
+// download before extracting it.
+type Bundle struct {
+	URL    string `json:"url"`
+	SHA256 string `json:"sha256"`
+	Size   int64  `json:"size"`
+}
+
+// Version is one published release: the Oblikovati API major+minor it targets and a bundle
+// per platform ("linux-amd64", "darwin-arm64", …).
+type Version struct {
+	Version     string            `json:"version"`
+	APIMajor    int               `json:"apiMajor"`
+	APIMinor    int               `json:"apiMinor"`
+	Bundles     map[string]Bundle `json:"bundles"`
+	PublishedAt string            `json:"publishedAt"`
+}
+
+// Entry is one add-in's catalogue record. Name is the unique add-in id (also the install
+// directory name); DisplayName is the human label.
+type Entry struct {
+	Name        string    `json:"name"`
+	DisplayName string    `json:"displayName"`
+	Description string    `json:"description"`
+	License     string    `json:"license"`
+	IconURL     string    `json:"iconUrl"`
+	SourceRepo  string    `json:"sourceRepo"`
+	Images      []string  `json:"images,omitempty"`
+	Versions    []Version `json:"versions"`
+}
+
+// LatestFor returns the newest version (by semantic version) whose API compatibility equals
+// major+minor — what a host on that API version installs — and true when one exists.
+func (e Entry) LatestFor(major, minor int) (Version, bool) {
+	var best Version
+	found := false
+	for _, v := range e.Versions {
+		if v.APIMajor != major || v.APIMinor != minor {
+			continue
+		}
+		if !found || compareSemver(v.Version, best.Version) > 0 {
+			best, found = v, true
+		}
+	}
+	return best, found
+}

--- a/addincat/catalogue_test.go
+++ b/addincat/catalogue_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package addincat
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// serviceWireSample is a catalogue record encoded with the EXACT JSON keys the
+// addins.oblikovati.org service emits. Decoding it into the host's duplicated Entry pins the
+// two copies of the DTO together (the report.Payload precedent): a key rename on either side
+// fails this test.
+const serviceWireSample = `{
+  "name": "com.oblikovati.cam",
+  "displayName": "Oblikovati CAM",
+  "description": "machining",
+  "license": "GPL-2.0-only",
+  "iconUrl": "https://addins.oblikovati.org/a/com.oblikovati.cam/icon.svg",
+  "sourceRepo": "https://github.com/Oblikovati/Oblikovati.AddIns.CAM",
+  "images": ["https://addins.oblikovati.org/a/com.oblikovati.cam/images/shot.png"],
+  "versions": [
+    {
+      "version": "0.6.0",
+      "apiMajor": 0,
+      "apiMinor": 85,
+      "bundles": {
+        "linux-amd64": {
+          "url": "https://addins.oblikovati.org/a/com.oblikovati.cam/versions/0.6.0/linux-amd64/bundle.zip",
+          "sha256": "abc123",
+          "size": 794
+        }
+      },
+      "publishedAt": "2026-06-21T13:18:35Z"
+    }
+  ]
+}`
+
+func TestWireFormatRoundTrip(t *testing.T) {
+	var e Entry
+	if err := json.Unmarshal([]byte(serviceWireSample), &e); err != nil {
+		t.Fatalf("decode service sample: %v", err)
+	}
+	if e.Name != "com.oblikovati.cam" || e.License != "GPL-2.0-only" || e.IconURL == "" || e.SourceRepo == "" {
+		t.Errorf("metadata not decoded: %+v", e)
+	}
+	if len(e.Images) != 1 || len(e.Versions) != 1 {
+		t.Fatalf("images/versions not decoded: %+v", e)
+	}
+	v := e.Versions[0]
+	b := v.Bundles["linux-amd64"]
+	if v.Version != "0.6.0" || v.APIMajor != 0 || v.APIMinor != 85 || b.SHA256 != "abc123" || b.Size != 794 {
+		t.Errorf("version/bundle not decoded: %+v / %+v", v, b)
+	}
+
+	// Re-marshalling must keep the service's keys (so a host upload/echo stays compatible).
+	out, _ := json.Marshal(e)
+	for _, key := range []string{`"displayName"`, `"iconUrl"`, `"sourceRepo"`, `"apiMajor"`, `"apiMinor"`, `"bundles"`, `"sha256"`} {
+		if !strings.Contains(string(out), key) {
+			t.Errorf("re-marshalled entry is missing key %s", key)
+		}
+	}
+}
+
+func TestLatestFor(t *testing.T) {
+	e := Entry{Versions: []Version{
+		{Version: "0.5.0", APIMajor: 0, APIMinor: 84},
+		{Version: "0.6.0", APIMajor: 0, APIMinor: 85},
+		{Version: "0.7.0", APIMajor: 0, APIMinor: 85},
+		{Version: "1.0.0", APIMajor: 1, APIMinor: 0},
+	}}
+	v, ok := e.LatestFor(0, 85)
+	if !ok || v.Version != "0.7.0" {
+		t.Errorf("LatestFor(0,85) = (%q,%v), want 0.7.0", v.Version, ok)
+	}
+	if _, ok := e.LatestFor(0, 99); ok {
+		t.Error("LatestFor(0,99) should not match")
+	}
+}
+
+func TestCompareSemver(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"0.6.0", "0.6.1", -1}, {"0.10.0", "0.9.0", 1}, {"1.0.0", "1.0.0", 0}, {"1.2.3-rc1", "1.2.3", 0},
+	}
+	for _, c := range cases {
+		if got := compareSemver(c.a, c.b); got != c.want {
+			t.Errorf("compareSemver(%q,%q) = %d, want %d", c.a, c.b, got, c.want)
+		}
+	}
+}

--- a/addincat/client.go
+++ b/addincat/client.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package addincat
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+// DefaultBaseURL is the public add-in catalogue service. Overridable (NewClient takes the
+// URL) so a local instance can be targeted during development and tests.
+const DefaultBaseURL = "https://addins.oblikovati.org"
+
+// maxErrorBody caps how much of a rejection body we read into an error message.
+const maxErrorBody = 4 << 10
+
+// ErrOffline reports that the catalogue service could not be reached (DNS, connection or
+// timeout). Callers treat it as a graceful skip — being offline is not a failure to shout
+// about — mirroring report.ErrOffline.
+var ErrOffline = errors.New("addincat: catalogue server unreachable")
+
+// httpDoer is the one method of *http.Client this package needs, named so tests can fake the
+// transport without a live server (CLAUDE.md: wrap external I/O behind a thin seam).
+type httpDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Client queries the catalogue service and downloads bundles.
+type Client struct {
+	baseURL string
+	http    httpDoer
+}
+
+// NewClient returns a client for baseURL over doer (typically an *http.Client with a timeout
+// so a slow network never blocks the caller). An empty baseURL falls back to DefaultBaseURL.
+func NewClient(baseURL string, doer httpDoer) *Client {
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+	return &Client{baseURL: baseURL, http: doer}
+}
+
+// List returns the add-ins the catalogue offers for the host's API major+minor, optionally
+// filtered by a free-text query. The service trims each entry to its latest matching version.
+func (c *Client) List(ctx context.Context, major, minor int, query string) ([]Entry, error) {
+	q := url.Values{}
+	q.Set("api", strconv.Itoa(major)+"."+strconv.Itoa(minor))
+	if query != "" {
+		q.Set("q", query)
+	}
+	var body struct {
+		AddIns []Entry `json:"addins"`
+	}
+	if err := c.getJSON(ctx, "/catalogue?"+q.Encode(), &body); err != nil {
+		return nil, err
+	}
+	return body.AddIns, nil
+}
+
+// Fetch returns one add-in's full record (all versions).
+func (c *Client) Fetch(ctx context.Context, name string) (Entry, error) {
+	var e Entry
+	err := c.getJSON(ctx, "/addins/"+url.PathEscape(name), &e)
+	return e, err
+}
+
+// Download fetches a bundle's bytes. It does not verify the checksum — the installer does,
+// once, after download (see Installer.Install).
+func (c *Client) Download(ctx context.Context, b Bundle) ([]byte, error) {
+	resp, err := c.get(ctx, b.URL)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if err := okStatus(resp, b.URL); err != nil {
+		return nil, err
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("addincat: read bundle %q: %w", b.URL, err)
+	}
+	return data, nil
+}
+
+// getJSON GETs path (relative to the base URL) and decodes a JSON response into v.
+func (c *Client) getJSON(ctx context.Context, path string, v any) error {
+	resp, err := c.get(ctx, c.baseURL+path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if err := okStatus(resp, path); err != nil {
+		return err
+	}
+	if err := json.NewDecoder(resp.Body).Decode(v); err != nil {
+		return fmt.Errorf("addincat: decode %q response: %w", path, err)
+	}
+	return nil
+}
+
+// get issues a GET, mapping a transport failure to ErrOffline.
+func (c *Client) get(ctx context.Context, rawURL string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("addincat: build request for %q: %w", rawURL, err)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOffline, err)
+	}
+	return resp, nil
+}
+
+// okStatus turns a non-2xx response into an error carrying the status and (capped) body.
+func okStatus(resp *http.Response, ref string) error {
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBody))
+	return fmt.Errorf("addincat: GET %q: %s: %s", ref, resp.Status, body)
+}

--- a/addincat/client_test.go
+++ b/addincat/client_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package addincat
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// errDoer is an httpDoer whose every request fails — used to assert the offline mapping.
+type errDoer struct{}
+
+func (errDoer) Do(*http.Request) (*http.Response, error) { return nil, errors.New("dial tcp: refused") }
+
+func TestListAndFetch(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/catalogue":
+			if r.URL.Query().Get("api") != "0.85" {
+				t.Errorf("api param = %q, want 0.85", r.URL.Query().Get("api"))
+			}
+			_, _ = w.Write([]byte(`{"addins":[{"name":"com.oblikovati.cam","versions":[{"version":"0.6.0","apiMajor":0,"apiMinor":85}]}]}`))
+		case "/addins/com.oblikovati.cam":
+			_, _ = w.Write([]byte(`{"name":"com.oblikovati.cam","versions":[{"version":"0.6.0"},{"version":"0.5.0"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+	c := NewClient(ts.URL, ts.Client())
+
+	list, err := c.List(context.Background(), 0, 85, "")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 1 || list[0].Name != "com.oblikovati.cam" {
+		t.Errorf("List = %+v", list)
+	}
+
+	e, err := c.Fetch(context.Background(), "com.oblikovati.cam")
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(e.Versions) != 2 {
+		t.Errorf("Fetch versions = %d, want 2", len(e.Versions))
+	}
+}
+
+func TestFetchNotFoundIsError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":"no such add-in"}`, http.StatusNotFound)
+	}))
+	defer ts.Close()
+	if _, err := NewClient(ts.URL, ts.Client()).Fetch(context.Background(), "nope"); err == nil {
+		t.Error("expected an error for 404")
+	}
+}
+
+func TestTransportErrorIsOffline(t *testing.T) {
+	c := NewClient("https://addins.test", errDoer{})
+	_, err := c.List(context.Background(), 0, 85, "")
+	if !errors.Is(err, ErrOffline) {
+		t.Errorf("List error = %v, want ErrOffline", err)
+	}
+}
+
+func TestNewClientDefaultsBaseURL(t *testing.T) {
+	if NewClient("", nil).baseURL != DefaultBaseURL {
+		t.Error("empty baseURL should fall back to DefaultBaseURL")
+	}
+}

--- a/addincat/dir.go
+++ b/addincat/dir.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package addincat
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// UserAddInsDir is the per-user directory add-ins install into and the host scans at startup.
+// It needs no admin rights (#1164):
+//
+//   - Linux & macOS: ~/oblikovati/addins
+//   - Windows:       %AppData%\oblikovati\addins
+//
+// OBK_USER_ADDINS_DIR overrides it (used by tests and by a user who relocates the folder).
+func UserAddInsDir() (string, error) {
+	if dir := os.Getenv("OBK_USER_ADDINS_DIR"); dir != "" {
+		return dir, nil
+	}
+	base, err := userBase()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "oblikovati", "addins"), nil
+}
+
+// userBase is the parent of the "oblikovati/addins" path: $HOME on the Unix-likes (a visible
+// ~/oblikovati folder a user can manage), %AppData% on Windows.
+func userBase() (string, error) {
+	if runtime.GOOS == "windows" {
+		cfg, err := os.UserConfigDir() // %AppData%
+		if err != nil {
+			return "", fmt.Errorf("addincat: locate AppData dir: %w", err)
+		}
+		return cfg, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("addincat: locate home dir: %w", err)
+	}
+	return home, nil
+}
+
+// Platform is the current host's bundle key ("linux-amd64", "darwin-arm64", "windows-amd64"),
+// matching the platform keys the catalogue stores bundles under.
+func Platform() string {
+	return runtime.GOOS + "-" + runtime.GOARCH
+}

--- a/addincat/dir_test.go
+++ b/addincat/dir_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package addincat
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUserAddInsDirEnvOverride(t *testing.T) {
+	t.Setenv("OBK_USER_ADDINS_DIR", "/tmp/custom/addins")
+	dir, err := UserAddInsDir()
+	if err != nil {
+		t.Fatalf("UserAddInsDir: %v", err)
+	}
+	if dir != "/tmp/custom/addins" {
+		t.Errorf("dir = %q, want the override", dir)
+	}
+}
+
+func TestUserAddInsDirDefaultEndsInAddins(t *testing.T) {
+	t.Setenv("OBK_USER_ADDINS_DIR", "")
+	dir, err := UserAddInsDir()
+	if err != nil {
+		t.Fatalf("UserAddInsDir: %v", err)
+	}
+	if filepath.Base(dir) != "addins" || filepath.Base(filepath.Dir(dir)) != "oblikovati" {
+		t.Errorf("default dir = %q, want .../oblikovati/addins", dir)
+	}
+}
+
+func TestPlatform(t *testing.T) {
+	p := Platform()
+	if !strings.Contains(p, "-") {
+		t.Errorf("Platform() = %q, want GOOS-GOARCH", p)
+	}
+}

--- a/addincat/install.go
+++ b/addincat/install.go
@@ -263,11 +263,12 @@ func extractOne(f *zip.File, dest string) error {
 	return nil
 }
 
-// safeJoin joins dest and a zip entry name, erroring if the result escapes dest.
+// safeJoin joins dest and a zip entry name, erroring if the entry is not a local path (it is
+// absolute or escapes dest via ".."). filepath.IsLocal is the lexical zip-slip guard: it
+// rejects exactly the entries that would write outside the install directory.
 func safeJoin(dest, name string) (string, error) {
-	target := filepath.Join(dest, name)
-	if target != dest && !strings.HasPrefix(target, dest+string(os.PathSeparator)) {
+	if !filepath.IsLocal(name) {
 		return "", fmt.Errorf("addincat: bundle entry %q escapes the install directory", name)
 	}
-	return target, nil
+	return filepath.Join(dest, name), nil
 }

--- a/addincat/install.go
+++ b/addincat/install.go
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package addincat
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// State is an add-in's status relative to the host: available to install, installed and
+// up to date, or installed with a newer version in the catalogue.
+type State int
+
+const (
+	StateAvailable State = iota
+	StateInstalled
+	StateUpdateAvailable
+)
+
+// AddInStatus pairs a catalogue entry with the host's view of it: its state, the installed
+// version (empty when not installed) and the latest catalogue version for the host's API.
+type AddInStatus struct {
+	Entry            Entry
+	State            State
+	InstalledVersion string
+	LatestVersion    string
+}
+
+// InstalledAddIn is one add-in present in the user directory, read from its manifest.json.
+type InstalledAddIn struct {
+	Name    string
+	Version string
+	Dir     string
+}
+
+// Installer downloads and extracts bundles into the per-user add-ins directory, and reports
+// what is installed. It is the host's only writer of that directory.
+type Installer struct {
+	dir      string
+	client   *Client
+	platform string
+}
+
+// NewInstaller returns an installer rooted at dir (typically UserAddInsDir) using client to
+// download bundles, for the current host platform.
+func NewInstaller(dir string, client *Client) *Installer {
+	return &Installer{dir: dir, client: client, platform: Platform()}
+}
+
+// Install downloads the version's bundle for this platform, verifies its SHA-256, and
+// extracts it into <dir>/<name>/, replacing any previous install (so it doubles as update).
+func (i *Installer) Install(ctx context.Context, e Entry, v Version) error {
+	bundle, ok := v.Bundles[i.platform]
+	if !ok {
+		return fmt.Errorf("addincat: %q %s has no bundle for %s", e.Name, v.Version, i.platform)
+	}
+	data, err := i.client.Download(ctx, bundle)
+	if err != nil {
+		return err
+	}
+	if err := verifyChecksum(data, bundle.SHA256); err != nil {
+		return err
+	}
+	dest, err := i.addInDir(e.Name)
+	if err != nil {
+		return err
+	}
+	if err := os.RemoveAll(dest); err != nil {
+		return fmt.Errorf("addincat: clear %q: %w", dest, err)
+	}
+	return extractZip(data, dest)
+}
+
+// Uninstall removes an add-in's directory.
+func (i *Installer) Uninstall(name string) error {
+	dest, err := i.addInDir(name)
+	if err != nil {
+		return err
+	}
+	if err := os.RemoveAll(dest); err != nil {
+		return fmt.Errorf("addincat: uninstall %q: %w", name, err)
+	}
+	return nil
+}
+
+// Installed lists the add-ins present in the user directory (those with a readable
+// manifest.json). A missing directory is an empty list, not an error.
+func (i *Installer) Installed() ([]InstalledAddIn, error) {
+	entries, err := os.ReadDir(i.dir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("addincat: read %q: %w", i.dir, err)
+	}
+	var out []InstalledAddIn
+	for _, de := range entries {
+		if !de.IsDir() {
+			continue
+		}
+		sub := filepath.Join(i.dir, de.Name())
+		if m, ok := readInstalledManifest(sub); ok {
+			out = append(out, InstalledAddIn{Name: m.ID, Version: m.Version, Dir: sub})
+		}
+	}
+	return out, nil
+}
+
+// Status merges the catalogue (for the host's API major+minor) with what is installed: every
+// catalogue entry plus any installed add-in absent from the catalogue, each tagged with its
+// state and versions. It is what the catalogue window renders across its three tabs.
+func (i *Installer) Status(catalogue []Entry, major, minor int) ([]AddInStatus, error) {
+	installed, err := i.Installed()
+	if err != nil {
+		return nil, err
+	}
+	byName := map[string]string{}
+	for _, a := range installed {
+		byName[a.Name] = a.Version
+	}
+	seen := map[string]bool{}
+	out := make([]AddInStatus, 0, len(catalogue))
+	for _, e := range catalogue {
+		seen[e.Name] = true
+		latest := ""
+		if v, ok := e.LatestFor(major, minor); ok {
+			latest = v.Version
+		}
+		out = append(out, statusOf(e, byName[e.Name], latest))
+	}
+	for _, a := range installed {
+		if !seen[a.Name] {
+			out = append(out, AddInStatus{
+				Entry:            Entry{Name: a.Name, DisplayName: a.Name},
+				State:            StateInstalled,
+				InstalledVersion: a.Version,
+			})
+		}
+	}
+	return out, nil
+}
+
+// statusOf classifies one catalogue entry given its installed and latest versions.
+func statusOf(e Entry, installedVer, latestVer string) AddInStatus {
+	s := AddInStatus{Entry: e, InstalledVersion: installedVer, LatestVersion: latestVer}
+	switch {
+	case installedVer == "":
+		s.State = StateAvailable
+	case latestVer != "" && compareSemver(installedVer, latestVer) < 0:
+		s.State = StateUpdateAvailable
+	default:
+		s.State = StateInstalled
+	}
+	return s
+}
+
+// addInDir is <dir>/<name>, rejecting a name that is not a safe single path segment so an
+// add-in can never escape the user directory.
+func (i *Installer) addInDir(name string) (string, error) {
+	if name == "" || name == "." || name == ".." || strings.ContainsAny(name, `/\`) || filepath.Clean(name) != name {
+		return "", fmt.Errorf("addincat: unsafe add-in name %q", name)
+	}
+	return filepath.Join(i.dir, name), nil
+}
+
+// installedManifest is the subset of a bundle's manifest.json the host reads to know what is
+// installed and at which version.
+type installedManifest struct {
+	ID      string `json:"id"`
+	Version string `json:"version"`
+}
+
+// readInstalledManifest finds and parses the manifest.json under an installed add-in's
+// directory (it may sit in a subfolder of the bundle). ok is false when none is found.
+func readInstalledManifest(dir string) (installedManifest, bool) {
+	var found installedManifest
+	ok := false
+	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || d.Name() != "manifest.json" {
+			return nil
+		}
+		b, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return nil
+		}
+		var m installedManifest
+		if json.Unmarshal(b, &m) == nil && m.ID != "" {
+			found, ok = m, true
+			return fs.SkipAll
+		}
+		return nil
+	})
+	return found, ok
+}
+
+// verifyChecksum checks data's SHA-256 against want (lowercase hex). An empty want skips the
+// check (the catalogue always supplies one; this keeps tests that omit it simple).
+func verifyChecksum(data []byte, want string) error {
+	if want == "" {
+		return nil
+	}
+	sum := sha256.Sum256(data)
+	if got := hex.EncodeToString(sum[:]); got != want {
+		return fmt.Errorf("addincat: bundle checksum mismatch: got %s, want %s", got, want)
+	}
+	return nil
+}
+
+// extractZip writes every file in a zip archive under dest, refusing any entry whose path
+// would escape dest (a zip-slip guard).
+func extractZip(data []byte, dest string) error {
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return fmt.Errorf("addincat: bundle is not a valid zip: %w", err)
+	}
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		return fmt.Errorf("addincat: create %q: %w", dest, err)
+	}
+	for _, f := range zr.File {
+		if err := extractOne(f, dest); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// extractOne writes a single zip entry under dest, preserving its executable bit (add-in
+// binaries must stay runnable).
+func extractOne(f *zip.File, dest string) error {
+	target, err := safeJoin(dest, f.Name)
+	if err != nil {
+		return err
+	}
+	if f.FileInfo().IsDir() {
+		return os.MkdirAll(target, 0o755)
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return fmt.Errorf("addincat: create dir for %q: %w", target, err)
+	}
+	rc, err := f.Open()
+	if err != nil {
+		return fmt.Errorf("addincat: open entry %q: %w", f.Name, err)
+	}
+	defer func() { _ = rc.Close() }()
+	out, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, f.Mode()|0o600)
+	if err != nil {
+		return fmt.Errorf("addincat: create %q: %w", target, err)
+	}
+	defer func() { _ = out.Close() }()
+	if _, err := io.Copy(out, rc); err != nil { //nolint:gosec // size bounded by the downloaded bundle
+		return fmt.Errorf("addincat: write %q: %w", target, err)
+	}
+	return nil
+}
+
+// safeJoin joins dest and a zip entry name, erroring if the result escapes dest.
+func safeJoin(dest, name string) (string, error) {
+	target := filepath.Join(dest, name)
+	if target != dest && !strings.HasPrefix(target, dest+string(os.PathSeparator)) {
+		return "", fmt.Errorf("addincat: bundle entry %q escapes the install directory", name)
+	}
+	return target, nil
+}

--- a/addincat/install_test.go
+++ b/addincat/install_test.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package addincat
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// makeZip builds an in-memory bundle zip from name→content pairs.
+func makeZip(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, content := range files {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := io.WriteString(w, content); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func sha(b []byte) string {
+	s := sha256.Sum256(b)
+	return hex.EncodeToString(s[:])
+}
+
+// bundleServer serves the given bytes at /bundle.zip and returns a client + the entry/version
+// wired to download it for the current platform.
+func bundleServer(t *testing.T, zipBytes []byte) (*Client, Entry, Version, func()) {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(zipBytes)
+	}))
+	v := Version{Version: "0.6.0", APIMajor: 0, APIMinor: 85, Bundles: map[string]Bundle{
+		Platform(): {URL: ts.URL + "/bundle.zip", SHA256: sha(zipBytes), Size: int64(len(zipBytes))},
+	}}
+	e := Entry{Name: "com.oblikovati.cam", DisplayName: "Oblikovati CAM", Versions: []Version{v}}
+	return NewClient(ts.URL, ts.Client()), e, v, ts.Close
+}
+
+func newInstaller(t *testing.T, c *Client) *Installer {
+	return NewInstaller(t.TempDir(), c)
+}
+
+func TestInstallExtractsAndListsInstalled(t *testing.T) {
+	zb := makeZip(t, map[string]string{
+		"cam/manifest.json": `{"id":"com.oblikovati.cam","version":"0.6.0"}`,
+		"cam/libcam.so":     "BINARY",
+	})
+	c, e, v, closeFn := bundleServer(t, zb)
+	defer closeFn()
+	in := newInstaller(t, c)
+
+	if err := in.Install(context.Background(), e, v); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(in.dir, "com.oblikovati.cam", "cam", "libcam.so")); err != nil {
+		t.Errorf("binary not extracted: %v", err)
+	}
+	installed, err := in.Installed()
+	if err != nil {
+		t.Fatalf("Installed: %v", err)
+	}
+	if len(installed) != 1 || installed[0].Name != "com.oblikovati.cam" || installed[0].Version != "0.6.0" {
+		t.Errorf("Installed = %+v", installed)
+	}
+}
+
+func TestInstallRejectsChecksumMismatch(t *testing.T) {
+	c, e, v, closeFn := bundleServer(t, makeZip(t, map[string]string{"manifest.json": `{"id":"x","version":"1"}`}))
+	defer closeFn()
+	bad := v
+	bad.Bundles = map[string]Bundle{Platform(): {URL: v.Bundles[Platform()].URL, SHA256: "deadbeef"}}
+	if err := newInstaller(t, c).Install(context.Background(), e, bad); err == nil {
+		t.Error("expected a checksum mismatch error")
+	}
+}
+
+func TestInstallNoBundleForPlatform(t *testing.T) {
+	c, e, _, closeFn := bundleServer(t, makeZip(t, map[string]string{"manifest.json": `{"id":"x","version":"1"}`}))
+	defer closeFn()
+	v := Version{Version: "0.6.0", Bundles: map[string]Bundle{"some-other-os": {URL: "u"}}}
+	if err := newInstaller(t, c).Install(context.Background(), e, v); err == nil {
+		t.Error("expected an error when no bundle matches the platform")
+	}
+}
+
+func TestUninstall(t *testing.T) {
+	zb := makeZip(t, map[string]string{"cam/manifest.json": `{"id":"com.oblikovati.cam","version":"0.6.0"}`})
+	c, e, v, closeFn := bundleServer(t, zb)
+	defer closeFn()
+	in := newInstaller(t, c)
+	if err := in.Install(context.Background(), e, v); err != nil {
+		t.Fatal(err)
+	}
+	if err := in.Uninstall("com.oblikovati.cam"); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+	installed, _ := in.Installed()
+	if len(installed) != 0 {
+		t.Errorf("still installed after uninstall: %+v", installed)
+	}
+}
+
+func TestStatusClassifies(t *testing.T) {
+	zb := makeZip(t, map[string]string{"cam/manifest.json": `{"id":"com.oblikovati.cam","version":"0.6.0"}`})
+	c, e, v, closeFn := bundleServer(t, zb)
+	defer closeFn()
+	in := newInstaller(t, c)
+
+	catalogue := []Entry{
+		e, // CAM, will be installed
+		{Name: "com.other", DisplayName: "Other", Versions: []Version{{Version: "1.0.0", APIMajor: 0, APIMinor: 85}}},
+	}
+
+	// Before install: both Available.
+	st, err := in.Status(catalogue, 0, 85)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stateOf(st, "com.oblikovati.cam") != StateAvailable {
+		t.Error("CAM should be Available before install")
+	}
+
+	// Install 0.6.0, then publish-claim a newer 0.7.0 in the catalogue → UpdateAvailable.
+	if err := in.Install(context.Background(), e, v); err != nil {
+		t.Fatal(err)
+	}
+	withUpdate := []Entry{{
+		Name: "com.oblikovati.cam", Versions: []Version{{Version: "0.7.0", APIMajor: 0, APIMinor: 85}},
+	}}
+	st, _ = in.Status(withUpdate, 0, 85)
+	if stateOf(st, "com.oblikovati.cam") != StateUpdateAvailable {
+		t.Error("CAM should be UpdateAvailable when catalogue has a newer version")
+	}
+
+	// Same version in catalogue → Installed (up to date).
+	sameVer := []Entry{{Name: "com.oblikovati.cam", Versions: []Version{{Version: "0.6.0", APIMajor: 0, APIMinor: 85}}}}
+	st, _ = in.Status(sameVer, 0, 85)
+	if stateOf(st, "com.oblikovati.cam") != StateInstalled {
+		t.Error("CAM should be Installed when up to date")
+	}
+}
+
+func TestStatusIncludesInstalledNotInCatalogue(t *testing.T) {
+	zb := makeZip(t, map[string]string{"cam/manifest.json": `{"id":"com.local","version":"0.1.0"}`})
+	c, _, _, closeFn := bundleServer(t, zb)
+	defer closeFn()
+	in := newInstaller(t, c)
+	if err := in.Install(context.Background(), Entry{Name: "com.local"},
+		Version{Version: "0.1.0", Bundles: map[string]Bundle{Platform(): {URL: c.baseURL + "/bundle.zip", SHA256: sha(zb)}}}); err != nil {
+		t.Fatal(err)
+	}
+	st, _ := in.Status(nil, 0, 85) // empty catalogue
+	if stateOf(st, "com.local") != StateInstalled {
+		t.Error("an installed add-in absent from the catalogue should still appear as Installed")
+	}
+}
+
+func TestExtractRejectsZipSlip(t *testing.T) {
+	zb := makeZip(t, map[string]string{"../escape.txt": "x"})
+	if err := extractZip(zb, t.TempDir()); err == nil {
+		t.Error("zip-slip entry should be rejected")
+	}
+}
+
+func TestUnsafeNameRejected(t *testing.T) {
+	in := NewInstaller(t.TempDir(), nil)
+	if err := in.Uninstall("../escape"); err == nil {
+		t.Error("Uninstall accepted an unsafe name")
+	}
+}
+
+func stateOf(st []AddInStatus, name string) State {
+	for _, s := range st {
+		if s.Entry.Name == name {
+			return s.State
+		}
+	}
+	return State(-1)
+}

--- a/addincat/semver.go
+++ b/addincat/semver.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package addincat
+
+import (
+	"strconv"
+	"strings"
+)
+
+// compareSemver orders two plain "major.minor.patch" version strings, returning -1, 0 or 1.
+// A pre-release/build suffix is ignored and a missing or non-numeric component counts as 0 —
+// sufficient because add-in versions are plain numeric semver (the API pins that upstream).
+func compareSemver(a, b string) int {
+	ai, bi := numericParts(a), numericParts(b)
+	for i := 0; i < 3; i++ {
+		if ai[i] != bi[i] {
+			if ai[i] < bi[i] {
+				return -1
+			}
+			return 1
+		}
+	}
+	return 0
+}
+
+func numericParts(v string) [3]int {
+	core, _, _ := strings.Cut(v, "-")
+	core, _, _ = strings.Cut(core, "+")
+	fields := strings.SplitN(core, ".", 3)
+	var out [3]int
+	for i := 0; i < len(fields) && i < 3; i++ {
+		if n, err := strconv.Atoi(strings.TrimSpace(fields[i])); err == nil {
+			out[i] = n
+		}
+	}
+	return out
+}


### PR DESCRIPTION
## What
New neutral `addincat` package — the host side of the add-in catalogue (#1164):
- `Client` queries the `addins.oblikovati.org` service (`List` for the host's API major+minor, `Fetch` a record, `Download` a bundle) over an injected HTTP transport; a transport failure maps to `ErrOffline` (graceful offline skip, mirroring `report.ErrOffline`).
- `Installer` downloads a version's per-platform bundle, verifies its SHA-256, and extracts it (zip-slip guarded) into the per-user dir — replacing any prior install so it doubles as update — plus `Uninstall`, `Installed` (from each bundle's `manifest.json`), and `Status` classifying each add-in Available / Installed / UpdateAvailable.
- `UserAddInsDir`: `~/oblikovati/addins` (Linux/macOS), `%AppData%\oblikovati\addins` (Windows), admin-free; overridable via `OBK_USER_ADDINS_DIR`. `Platform()` gives the `GOOS-GOARCH` bundle key.

The `Entry`/`Version`/`Bundle` DTO duplicates the service's catalogue shape and is pinned to its exact wire keys by a round-trip test (the `report.Payload` precedent).

No UI (H07) and not wired into the loader yet (H06).

## Why
H05 of M32 (#1164). The catalogue window and the loader build on this; isolating it as a pure, fully-tested package keeps the UI slice thin.

## Verification
- `gofmt`/`go vet`/`golangci-lint` clean; `go test ./addincat/` green; coverage 84.9%
- tested against an `httptest` fake service: List/Fetch/Download, 404 + offline mapping, install→extract, checksum mismatch, no-bundle-for-platform, uninstall, Installed, Status (available/installed/update + installed-not-in-catalogue), zip-slip + unsafe-name rejection

Part of #1164. Closes #1173.