### PR TITLE
M32-H06: load add-ins from the per-user install tree

### DIFF
--- a/head/cmd/oblikovati-head/addins.go
+++ b/head/cmd/oblikovati-head/addins.go
@@ -15,6 +15,7 @@ import (
 	"oblikovati.org/addin/events"
 	"oblikovati.org/addin/opregistry"
 	"oblikovati.org/addin/router"
+	"oblikovati.org/addincat"
 	"oblikovati.org/app"
 	"oblikovati.org/event"
 	"oblikovati.org/head/internal/addinhost"
@@ -72,6 +73,7 @@ func startAddIns(session *app.Session) *addInHost {
 	useBehaviorStore(session)
 	useDialogMemoryStore(session)
 	h.loadAndRegister(session, dir)
+	h.loadInstalledAddIns(session) // add-ins the in-app catalogue installed under the per-user dir (#1164)
 	h.subs = events.Subscribe(session, func(ev []byte) { h.notifyActive(session, ev) })
 	// Under a supervisor (make run-watch sets OBK_ADDIN_AUTORESTART=1), watch the
 	// add-ins dir so a rebuilt library makes the app exit-and-relaunch — the safe way
@@ -88,6 +90,26 @@ func startAddIns(session *app.Session) *addInHost {
 // activates) the loadable ones. A bad add-in is logged and skipped — never fatal.
 func (h *addInHost) loadAndRegister(session *app.Session, dir string) {
 	libs, skipped, err := addinhost.LoadDir(dir)
+	h.registerResults(session, libs, skipped, err)
+}
+
+// loadInstalledAddIns loads add-ins the in-app catalogue installed under the per-user
+// directory (#1164), in addition to those beside the executable. A relocated or
+// unresolvable directory is logged and skipped — never fatal.
+func (h *addInHost) loadInstalledAddIns(session *app.Session) {
+	dir, err := addincat.UserAddInsDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "add-ins: locate user add-ins dir: %v\n", err)
+		return
+	}
+	libs, skipped, err := addinhost.LoadInstalledTree(dir)
+	h.registerResults(session, libs, skipped, err)
+}
+
+// registerResults surfaces a load's error and version-skips, then registers (and per stored
+// behavior, activates) each loadable add-in. Shared by the flat exe-adjacent directory and
+// the per-user install tree so both report and register identically.
+func (h *addInHost) registerResults(session *app.Session, libs []*addinhost.LoadedAddIn, skipped []addinhost.IncompatibleAddIn, err error) {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "add-ins: %v\n", err)
 	}

--- a/head/cmd/oblikovati-head/addins_fixture_test.go
+++ b/head/cmd/oblikovati-head/addins_fixture_test.go
@@ -78,4 +78,23 @@ func TestLoadInstalledAddInsRegistersFixture(t *testing.T) {
 	if got := h.loaded[0].ID(); got != "com.oblikovati.echo-fixture" {
 		t.Errorf("ID = %q, want com.oblikovati.echo-fixture", got)
 	}
+
+	// A second load registers the same id again: Register rejects the duplicate, so the
+	// loaded set is unchanged (exercises registerResults' register-failure branch).
+	h.loadInstalledAddIns(session)
+	if len(h.loaded) != 1 {
+		t.Errorf("loaded %d after re-load, want 1 (duplicate id must be rejected)", len(h.loaded))
+	}
+}
+
+// TestLoadInstalledAddInsDirError covers the branch where the per-user directory cannot be
+// resolved: with no override and no home directory, it logs and loads nothing.
+func TestLoadInstalledAddInsDirError(t *testing.T) {
+	t.Setenv("OBK_USER_ADDINS_DIR", "")
+	t.Setenv("HOME", "") // os.UserHomeDir then errors on Unix, so UserAddInsDir fails
+	h := &addInHost{}
+	h.loadInstalledAddIns(app.NewSession())
+	if len(h.loaded) != 0 {
+		t.Errorf("loaded = %d, want 0 when the user dir is unresolvable", len(h.loaded))
+	}
 }

--- a/head/cmd/oblikovati-head/addins_fixture_test.go
+++ b/head/cmd/oblikovati-head/addins_fixture_test.go
@@ -1,0 +1,81 @@
+//go:build linux || darwin
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/app"
+)
+
+// fakeBehaviorStore is a named in-memory AddInBehaviorStore so a test can mark an add-in
+// LoadDisabled — keeping registerResults' register path off the activation host-call seam.
+type fakeBehaviorStore struct {
+	stored map[string]types.AddInLoadBehavior
+}
+
+func (f *fakeBehaviorStore) Load() (map[string]types.AddInLoadBehavior, error) {
+	return f.stored, nil
+}
+func (f *fakeBehaviorStore) Save(map[string]types.AddInLoadBehavior) error { return nil }
+
+// buildEchoFixtureInto compiles the echo test fixture (shared by the addinhost tests) as a
+// c-shared library directly into dir, returning its path. GOWORK=off builds it against its
+// own go.mod (it stands in for an external add-in); GOTOOLCHAIN=local keeps it offline.
+func buildEchoFixtureInto(t *testing.T, dir string) string {
+	t.Helper()
+	ext := ".so"
+	if runtime.GOOS == "darwin" {
+		ext = ".dylib"
+	}
+	out := filepath.Join(dir, "echo"+ext)
+	_, thisFile, _, _ := runtime.Caller(0)
+	src := filepath.Join(filepath.Dir(thisFile), "..", "..", "internal", "addinhost", "testdata", "echoaddin")
+
+	cmd := exec.Command("go", "build", "-buildmode=c-shared", "-o", out, ".")
+	cmd.Dir = src
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=1", "GOTOOLCHAIN=local", "GOWORK=off")
+	if combined, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build echo fixture: %v\n%s", err, combined)
+	}
+	return out
+}
+
+// TestLoadInstalledAddInsRegistersFixture drives the per-user install path end to end: a real
+// c-shared add-in laid out as <user>/<name>/<lib> is found, loaded and registered. It is
+// marked LoadDisabled so registration does not activate (which would need the host-call
+// dispatcher), letting the test cover the register-and-append path directly.
+func TestLoadInstalledAddInsRegistersFixture(t *testing.T) {
+	root := t.TempDir()
+	addInDir := filepath.Join(root, "com.oblikovati.echo-fixture")
+	if err := os.MkdirAll(addInDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	buildEchoFixtureInto(t, addInDir)
+	t.Setenv("OBK_USER_ADDINS_DIR", root)
+
+	session := app.NewSession()
+	if err := session.AddIns().UseBehaviorStore(&fakeBehaviorStore{
+		stored: map[string]types.AddInLoadBehavior{"com.oblikovati.echo-fixture": types.LoadDisabled},
+	}); err != nil {
+		t.Fatalf("UseBehaviorStore: %v", err)
+	}
+
+	h := &addInHost{}
+	h.loadInstalledAddIns(session)
+
+	if len(h.loaded) != 1 {
+		t.Fatalf("loaded %d add-ins, want 1", len(h.loaded))
+	}
+	defer func() { _ = h.loaded[0].Close() }()
+	if got := h.loaded[0].ID(); got != "com.oblikovati.echo-fixture" {
+		t.Errorf("ID = %q, want com.oblikovati.echo-fixture", got)
+	}
+}

--- a/head/cmd/oblikovati-head/addins_test.go
+++ b/head/cmd/oblikovati-head/addins_test.go
@@ -3,9 +3,11 @@
 package main
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
+	"oblikovati.org/app"
 	"oblikovati.org/head/internal/addinhost"
 )
 
@@ -35,5 +37,33 @@ func TestIncompatibleNotice(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Errorf("multi skip notice %q missing %q", got, want)
 		}
+	}
+}
+
+// TestRegisterResultsSurfacesSkipAsNotice confirms a version-skipped add-in (no loadable
+// libraries) sets the status-bar notice and adds nothing to the loaded set.
+func TestRegisterResultsSurfacesSkipAsNotice(t *testing.T) {
+	h := &addInHost{}
+	session := app.NewSession()
+	skipped := []addinhost.IncompatibleAddIn{{ID: "com.x.bridge", Reason: "newer than host"}}
+
+	h.registerResults(session, nil, skipped, errors.New("read error"))
+
+	if !strings.Contains(session.Notice(), "com.x.bridge") {
+		t.Errorf("notice = %q, want it to name the skipped add-in", session.Notice())
+	}
+	if len(h.loaded) != 0 {
+		t.Errorf("loaded = %d, want 0 (nothing loadable)", len(h.loaded))
+	}
+}
+
+// TestLoadInstalledAddInsEmptyDir exercises the per-user install path against an empty
+// directory: it must load nothing and leave the loaded set empty, without error.
+func TestLoadInstalledAddInsEmptyDir(t *testing.T) {
+	t.Setenv("OBK_USER_ADDINS_DIR", t.TempDir())
+	h := &addInHost{}
+	h.loadInstalledAddIns(app.NewSession())
+	if len(h.loaded) != 0 {
+		t.Errorf("loaded = %d from an empty user dir, want 0", len(h.loaded))
 	}
 }

--- a/head/cmd/oblikovati-head/addins_test.go
+++ b/head/cmd/oblikovati-head/addins_test.go
@@ -67,3 +67,12 @@ func TestLoadInstalledAddInsEmptyDir(t *testing.T) {
 		t.Errorf("loaded = %d from an empty user dir, want 0", len(h.loaded))
 	}
 }
+
+// TestLoadAndRegisterEmptyDir covers the flat-directory load path with no add-ins present.
+func TestLoadAndRegisterEmptyDir(t *testing.T) {
+	h := &addInHost{}
+	h.loadAndRegister(app.NewSession(), t.TempDir())
+	if len(h.loaded) != 0 {
+		t.Errorf("loaded = %d from an empty dir, want 0", len(h.loaded))
+	}
+}

--- a/head/internal/addinhost/loader.go
+++ b/head/internal/addinhost/loader.go
@@ -4,6 +4,7 @@ package addinhost
 
 import (
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -97,17 +98,76 @@ func LoadDir(dir string) ([]*LoadedAddIn, []IncompatibleAddIn, error) {
 		if e.IsDir() || !isSharedLib(e.Name()) {
 			continue
 		}
-		loaded, skip, err := loadOne(filepath.Join(dir, e.Name()))
-		switch {
-		case err != nil:
+		if out, skipped, err = classifyLoad(filepath.Join(dir, e.Name()), out, skipped); err != nil {
 			return out, skipped, err
-		case skip != nil:
-			skipped = append(skipped, *skip)
-		default:
-			out = append(out, loaded)
 		}
 	}
 	return out, skipped, nil
+}
+
+// LoadInstalledTree loads add-ins installed under a per-name tree — dir/<name>/… — where
+// each <name> directory holds one extracted bundle (the shared library, possibly nested in a
+// subfolder, alongside its manifest and dependencies). This is the layout the in-app
+// installer writes to the per-user add-ins directory (#1164), distinct from LoadDir's flat
+// directory of bare libraries. It loads the first shared library found in each add-in's
+// directory with the same version handshake as LoadDir; a missing dir is empty, not an error.
+func LoadInstalledTree(dir string) ([]*LoadedAddIn, []IncompatibleAddIn, error) {
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil, nil, nil
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("addinhost: read installed add-in dir %q: %w", dir, err)
+	}
+	var out []*LoadedAddIn
+	var skipped []IncompatibleAddIn
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		lib, found := firstSharedLib(filepath.Join(dir, e.Name()))
+		if !found {
+			continue
+		}
+		if out, skipped, err = classifyLoad(lib, out, skipped); err != nil {
+			return out, skipped, err
+		}
+	}
+	return out, skipped, nil
+}
+
+// classifyLoad loads the library at path and folds the result into out/skipped: a loadable
+// add-in is appended to out, a version-incompatible one to skipped, and a hard open failure
+// is returned as an error (which the caller may treat as fatal). Shared by LoadDir and
+// LoadInstalledTree so both classify a load identically.
+func classifyLoad(path string, out []*LoadedAddIn, skipped []IncompatibleAddIn) ([]*LoadedAddIn, []IncompatibleAddIn, error) {
+	loaded, skip, err := loadOne(path)
+	switch {
+	case err != nil:
+		return out, skipped, err
+	case skip != nil:
+		return out, append(skipped, *skip), nil
+	default:
+		return append(out, loaded), skipped, nil
+	}
+}
+
+// firstSharedLib returns the path of the first shared library found anywhere under dir, so an
+// installed bundle's library is located whether it sits at the add-in's root or in a
+// subfolder. ok is false when the subtree contains no shared library.
+func firstSharedLib(dir string) (string, bool) {
+	var found string
+	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if isSharedLib(d.Name()) {
+			found = path
+			return fs.SkipAll
+		}
+		return nil
+	})
+	return found, found != ""
 }
 
 // loadOne opens one shared library and either returns a loadable add-in or, when its

--- a/head/internal/addinhost/loader_tree_test.go
+++ b/head/internal/addinhost/loader_tree_test.go
@@ -1,0 +1,79 @@
+//go:build linux || darwin
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package addinhost
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// copyFile duplicates src to dst (used to place a built fixture into an install tree).
+func copyFile(t *testing.T, src, dst string) {
+	t.Helper()
+	b, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, b, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestLoadInstalledTreeNested proves the per-user install layout loads: a real c-shared
+// add-in placed under <root>/<name>/<subfolder>/ (as the installer extracts a bundle) is
+// found and loaded, with its id resolved over the C ABI.
+func TestLoadInstalledTreeNested(t *testing.T) {
+	so := buildFixture(t, "echoaddin")
+	root := t.TempDir()
+	nested := filepath.Join(root, "com.oblikovati.echo-fixture", "bundle")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	copyFile(t, so, filepath.Join(nested, filepath.Base(so)))
+
+	libs, skipped, err := LoadInstalledTree(root)
+	if err != nil {
+		t.Fatalf("LoadInstalledTree: %v", err)
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("unexpected skips: %+v", skipped)
+	}
+	if len(libs) != 1 {
+		t.Fatalf("loaded %d add-ins, want 1", len(libs))
+	}
+	defer func() { _ = libs[0].Close() }()
+	if got := libs[0].ID(); got != "com.oblikovati.echo-fixture" {
+		t.Errorf("ID = %q, want com.oblikovati.echo-fixture", got)
+	}
+}
+
+func TestLoadInstalledTreeMissingDirIsEmpty(t *testing.T) {
+	libs, skipped, err := LoadInstalledTree(filepath.Join(t.TempDir(), "absent"))
+	if err != nil || libs != nil || skipped != nil {
+		t.Errorf("missing dir = (%v,%v,%v), want all nil", libs, skipped, err)
+	}
+}
+
+func TestFirstSharedLib(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "a", "b")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "lib.so"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "manifest.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := firstSharedLib(root)
+	if !ok || filepath.Base(got) != "lib.so" {
+		t.Errorf("firstSharedLib = (%q,%v), want a nested lib.so", got, ok)
+	}
+	if _, ok := firstSharedLib(t.TempDir()); ok {
+		t.Error("firstSharedLib found a library in an empty dir")
+	}
+}


### PR DESCRIPTION
## What
- `addinhost.LoadInstalledTree(dir)`: loads add-ins from the per-name install layout the in-app catalogue installer writes — `dir/<name>/…` — walking one level into each `<name>/` subtree, finding the first shared library wherever the bundle placed it, and loading it through the same API-version handshake as `LoadDir`. Missing dir → empty, not an error.
- The head now loads from **both** the executable-adjacent directory and `addincat.UserAddInsDir()` at startup (`loadInstalledAddIns`), sharing the register/report path via a new `registerResults` helper.
- Extracts `classifyLoad` shared by `LoadDir`/`LoadInstalledTree` (removes the duplicated load-classify branch).

## Why
H06 of M32 (#1164). Installed add-ins live in per-name folders (a bundle, not a bare library), so the loader needed a tree walker. Closes the gap between H05 (installer writes the tree) and H07 (UI triggers installs).

## Verification
- `gofmt`/`go vet`/`golangci-lint` clean; head `cmd/oblikovati-head` builds (cgo)
- `go test ./internal/addinhost/`: a real c-shared fixture placed under `<root>/<name>/<subfolder>/` is found and loaded with its id resolved over the C ABI; missing-dir and `firstSharedLib` (nested + empty) covered

Part of #1164. Closes #1174.