### PR TITLE
M32-H07: Add-In Catalogue window (browse / install / update)

### DIFF
--- a/app/addin_catalogue.go
+++ b/app/addin_catalogue.go
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"oblikovati.org/addincat"
+	"oblikovati.org/api"
+)
+
+// Add-In Catalogue surface (#1164). The session owns the browse/install state and runs every
+// catalogue network call and install on a goroutine, never on the frame loop: the UI reads
+// the cached, mutex-guarded snapshot each frame, and a worker refreshes it. A freshly
+// installed add-in is not loaded in-process (a Go c-shared cannot be hot-loaded), so an
+// install/uninstall leaves a "restart to apply" notice rather than activating immediately.
+
+// catalogueOpTimeout bounds a catalogue network call or download so a slow service never
+// strands the worker goroutine.
+const catalogueOpTimeout = 60 * time.Second
+
+// catalogueSource lists the add-ins offered for a host API version — the query seam, satisfied
+// by *addincat.Client and faked in tests (CLAUDE.md: external I/O behind a thin interface).
+type catalogueSource interface {
+	List(ctx context.Context, major, minor int, query string) ([]addincat.Entry, error)
+}
+
+// catalogueInstaller installs, removes and classifies add-ins in the per-user directory —
+// satisfied by *addincat.Installer and faked in tests.
+type catalogueInstaller interface {
+	Install(ctx context.Context, e addincat.Entry, v addincat.Version) error
+	Uninstall(name string) error
+	Status(catalogue []addincat.Entry, major, minor int) ([]addincat.AddInStatus, error)
+}
+
+// addInCatalogue is the session's catalogue state: the injected seams and the last snapshot
+// the UI renders, guarded by a mutex because a worker goroutine writes it.
+type addInCatalogue struct {
+	mu        sync.Mutex
+	source    catalogueSource
+	installer catalogueInstaller
+	statuses  []addincat.AddInStatus
+	busy      bool
+	errMsg    string
+	notice    string
+}
+
+// SetAddInCatalogue injects the catalogue query + install seams (the head wires the real
+// addincat client/installer; tests pass fakes). It enables the Add-In Catalogue surface.
+func (s *Session) SetAddInCatalogue(source catalogueSource, installer catalogueInstaller) {
+	s.addInCat.mu.Lock()
+	defer s.addInCat.mu.Unlock()
+	s.addInCat.source = source
+	s.addInCat.installer = installer
+}
+
+// AddInCatalogueEnabled reports whether the catalogue seams have been injected.
+func (s *Session) AddInCatalogueEnabled() bool {
+	s.addInCat.mu.Lock()
+	defer s.addInCat.mu.Unlock()
+	return s.addInCat.source != nil && s.addInCat.installer != nil
+}
+
+// RefreshAddInCatalogue re-queries the catalogue for the host's API version and recomputes
+// install status on a goroutine. It is a no-op while a catalogue operation is already running
+// or before the seams are injected.
+func (s *Session) RefreshAddInCatalogue(query string) {
+	if !s.beginCatalogueOp() {
+		return
+	}
+	source, installer := s.addInCat.source, s.addInCat.installer
+	major, minor := api.Major(), api.Minor()
+	go func() {
+		statuses, err := refreshCatalogue(source, installer, major, minor, query)
+		s.finishCatalogueRefresh(statuses, err)
+	}()
+}
+
+// InstallAddIn installs (or updates to) the latest catalogue version of the named add-in for
+// the host API, on a goroutine. The name must be one shown by the catalogue.
+func (s *Session) InstallAddIn(name string) {
+	entry, version, ok := s.latestForInstall(name)
+	if !ok || !s.beginCatalogueOp() {
+		return
+	}
+	installer := s.addInCat.installer
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), catalogueOpTimeout)
+		defer cancel()
+		err := installer.Install(ctx, entry, version)
+		s.finishCatalogueAction(err, fmt.Sprintf("Installed %s %s — restart Oblikovati to load it", name, version.Version))
+	}()
+}
+
+// UninstallAddIn removes the named add-in from the per-user directory on a goroutine.
+func (s *Session) UninstallAddIn(name string) {
+	if !s.beginCatalogueOp() {
+		return
+	}
+	installer := s.addInCat.installer
+	go func() {
+		err := installer.Uninstall(name)
+		s.finishCatalogueAction(err, fmt.Sprintf("Uninstalled %s — restart Oblikovati to remove it", name))
+	}()
+}
+
+// AddInStatuses returns a copy of the last catalogue snapshot for rendering.
+func (s *Session) AddInStatuses() []addincat.AddInStatus {
+	s.addInCat.mu.Lock()
+	defer s.addInCat.mu.Unlock()
+	return append([]addincat.AddInStatus(nil), s.addInCat.statuses...)
+}
+
+// AddInCatalogueBusy reports whether a catalogue operation is in flight (the UI disables
+// actions and shows progress while true).
+func (s *Session) AddInCatalogueBusy() bool {
+	s.addInCat.mu.Lock()
+	defer s.addInCat.mu.Unlock()
+	return s.addInCat.busy
+}
+
+// AddInCatalogueError returns the last catalogue error message, or "" when the last op
+// succeeded.
+func (s *Session) AddInCatalogueError() string {
+	s.addInCat.mu.Lock()
+	defer s.addInCat.mu.Unlock()
+	return s.addInCat.errMsg
+}
+
+// AddInCatalogueNotice returns the last install/uninstall notice (e.g. the restart prompt).
+func (s *Session) AddInCatalogueNotice() string {
+	s.addInCat.mu.Lock()
+	defer s.addInCat.mu.Unlock()
+	return s.addInCat.notice
+}
+
+// beginCatalogueOp marks a catalogue operation started, returning false when the seams are
+// missing or an operation is already running (so concurrent clicks cannot pile up).
+func (s *Session) beginCatalogueOp() bool {
+	s.addInCat.mu.Lock()
+	defer s.addInCat.mu.Unlock()
+	if s.addInCat.source == nil || s.addInCat.installer == nil || s.addInCat.busy {
+		return false
+	}
+	s.addInCat.busy = true
+	s.addInCat.errMsg = ""
+	return true
+}
+
+// latestForInstall resolves the catalogue entry + latest host-compatible version for name
+// from the current snapshot.
+func (s *Session) latestForInstall(name string) (addincat.Entry, addincat.Version, bool) {
+	s.addInCat.mu.Lock()
+	defer s.addInCat.mu.Unlock()
+	for _, st := range s.addInCat.statuses {
+		if st.Entry.Name == name {
+			v, ok := st.Entry.LatestFor(api.Major(), api.Minor())
+			return st.Entry, v, ok
+		}
+	}
+	return addincat.Entry{}, addincat.Version{}, false
+}
+
+// finishCatalogueRefresh stores a refresh result and clears the busy flag.
+func (s *Session) finishCatalogueRefresh(statuses []addincat.AddInStatus, err error) {
+	s.addInCat.mu.Lock()
+	defer s.addInCat.mu.Unlock()
+	s.addInCat.busy = false
+	if err != nil {
+		s.addInCat.errMsg = err.Error()
+		return
+	}
+	s.addInCat.statuses = statuses
+}
+
+// finishCatalogueAction records an install/uninstall outcome: on success it sets the notice
+// and re-refreshes so the snapshot reflects the change; on failure it records the error.
+func (s *Session) finishCatalogueAction(err error, successNotice string) {
+	s.addInCat.mu.Lock()
+	s.addInCat.busy = false
+	if err != nil {
+		s.addInCat.errMsg = err.Error()
+		s.addInCat.mu.Unlock()
+		return
+	}
+	s.addInCat.notice = successNotice
+	s.addInCat.mu.Unlock()
+	s.RefreshAddInCatalogue("")
+}
+
+// refreshCatalogue lists the catalogue and computes install status — the worker body, kept
+// free of session locking so it is unit-testable on its own.
+func refreshCatalogue(source catalogueSource, installer catalogueInstaller, major, minor int, query string) ([]addincat.AddInStatus, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), catalogueOpTimeout)
+	defer cancel()
+	entries, err := source.List(ctx, major, minor, query)
+	if err != nil {
+		return nil, err
+	}
+	return installer.Status(entries, major, minor)
+}

--- a/app/addin_catalogue_test.go
+++ b/app/addin_catalogue_test.go
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"oblikovati.org/addincat"
+	"oblikovati.org/api"
+)
+
+// fakeCatalogueSource is a named in-memory catalogueSource (CLAUDE.md: external I/O behind a
+// fake, not an inline stub). It guards its recorded query because the session calls List on a
+// worker goroutine.
+type fakeCatalogueSource struct {
+	mu      sync.Mutex
+	entries []addincat.Entry
+	err     error
+	query   string
+}
+
+func (f *fakeCatalogueSource) List(_ context.Context, _, _ int, query string) ([]addincat.Entry, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.query = query
+	return f.entries, f.err
+}
+
+func (f *fakeCatalogueSource) lastQuery() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.query
+}
+
+// fakeCatalogueInstaller records installs/uninstalls and returns a canned status list.
+type fakeCatalogueInstaller struct {
+	mu          sync.Mutex
+	status      []addincat.AddInStatus
+	installed   []string
+	uninstalled []string
+	installErr  error
+}
+
+func (f *fakeCatalogueInstaller) Install(_ context.Context, e addincat.Entry, _ addincat.Version) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.installErr != nil {
+		return f.installErr
+	}
+	f.installed = append(f.installed, e.Name)
+	return nil
+}
+
+func (f *fakeCatalogueInstaller) Uninstall(name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.uninstalled = append(f.uninstalled, name)
+	return nil
+}
+
+func (f *fakeCatalogueInstaller) Status(catalogue []addincat.Entry, _, _ int) ([]addincat.AddInStatus, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.status != nil {
+		return f.status, nil
+	}
+	out := make([]addincat.AddInStatus, len(catalogue))
+	for i, e := range catalogue {
+		out[i] = addincat.AddInStatus{Entry: e, State: addincat.StateAvailable}
+	}
+	return out, nil
+}
+
+func (f *fakeCatalogueInstaller) installs() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.installed...)
+}
+
+func (f *fakeCatalogueInstaller) uninstalls() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.uninstalled...)
+}
+
+// camEntry is a catalogue entry with a version for the host's exact API major+minor, so the
+// host can install it.
+func camEntry() addincat.Entry {
+	return addincat.Entry{
+		Name: "com.oblikovati.cam", DisplayName: "Oblikovati CAM", Description: "machining",
+		Versions: []addincat.Version{{
+			Version: "0.6.0", APIMajor: api.Major(), APIMinor: api.Minor(),
+			Bundles: map[string]addincat.Bundle{addincat.Platform(): {URL: "u", SHA256: "s"}},
+		}},
+	}
+}
+
+// waitFor polls cond up to a deadline, failing the test if it never holds.
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("condition not met within deadline")
+}
+
+func TestRefreshAddInCataloguePopulatesStatuses(t *testing.T) {
+	s := NewSession()
+	src := &fakeCatalogueSource{entries: []addincat.Entry{camEntry()}}
+	s.SetAddInCatalogue(src, &fakeCatalogueInstaller{})
+
+	s.RefreshAddInCatalogue("cam")
+	waitFor(t, func() bool { return len(s.AddInStatuses()) == 1 && !s.AddInCatalogueBusy() })
+
+	if src.lastQuery() != "cam" {
+		t.Errorf("query passed through = %q, want cam", src.lastQuery())
+	}
+	if s.AddInStatuses()[0].Entry.Name != "com.oblikovati.cam" {
+		t.Errorf("status = %+v", s.AddInStatuses()[0])
+	}
+}
+
+func TestRefreshRecordsError(t *testing.T) {
+	s := NewSession()
+	s.SetAddInCatalogue(&fakeCatalogueSource{err: errors.New("offline")}, &fakeCatalogueInstaller{})
+	s.RefreshAddInCatalogue("")
+	waitFor(t, func() bool { return s.AddInCatalogueError() != "" && !s.AddInCatalogueBusy() })
+	if s.AddInCatalogueError() == "" {
+		t.Error("expected the offline error to be recorded")
+	}
+}
+
+func TestInstallAddInRunsAndNotices(t *testing.T) {
+	s := NewSession()
+	src := &fakeCatalogueSource{entries: []addincat.Entry{camEntry()}}
+	inst := &fakeCatalogueInstaller{}
+	s.SetAddInCatalogue(src, inst)
+
+	s.RefreshAddInCatalogue("")
+	waitFor(t, func() bool { return len(s.AddInStatuses()) == 1 })
+
+	s.InstallAddIn("com.oblikovati.cam")
+	waitFor(t, func() bool { return len(inst.installs()) == 1 })
+	waitFor(t, func() bool {
+		n := s.AddInCatalogueNotice()
+		return n != "" && !s.AddInCatalogueBusy()
+	})
+	if inst.installs()[0] != "com.oblikovati.cam" {
+		t.Errorf("installed %v, want com.oblikovati.cam", inst.installs())
+	}
+}
+
+func TestInstallErrorRecorded(t *testing.T) {
+	s := NewSession()
+	src := &fakeCatalogueSource{entries: []addincat.Entry{camEntry()}}
+	inst := &fakeCatalogueInstaller{installErr: errors.New("checksum mismatch")}
+	s.SetAddInCatalogue(src, inst)
+
+	s.RefreshAddInCatalogue("")
+	waitFor(t, func() bool { return len(s.AddInStatuses()) == 1 })
+
+	s.InstallAddIn("com.oblikovati.cam")
+	waitFor(t, func() bool { return s.AddInCatalogueError() != "" && !s.AddInCatalogueBusy() })
+	if s.AddInCatalogueNotice() != "" {
+		t.Error("a failed install must not leave a success notice")
+	}
+}
+
+func TestUninstallAddInRuns(t *testing.T) {
+	s := NewSession()
+	inst := &fakeCatalogueInstaller{}
+	s.SetAddInCatalogue(&fakeCatalogueSource{}, inst)
+	s.UninstallAddIn("com.oblikovati.cam")
+	waitFor(t, func() bool { return len(inst.uninstalls()) == 1 })
+}
+
+func TestCatalogueNoOpWhenDisabled(t *testing.T) {
+	s := NewSession()
+	if s.AddInCatalogueEnabled() {
+		t.Fatal("catalogue should be disabled before injection")
+	}
+	s.RefreshAddInCatalogue("") // must not panic or set busy
+	if s.AddInCatalogueBusy() {
+		t.Error("refresh should be a no-op while disabled")
+	}
+}
+
+func TestInstallUnknownAddInIsNoOp(t *testing.T) {
+	s := NewSession()
+	inst := &fakeCatalogueInstaller{}
+	s.SetAddInCatalogue(&fakeCatalogueSource{}, inst)
+	s.InstallAddIn("com.unknown") // not in any snapshot
+	// Give any erroneous goroutine a chance to run, then assert nothing was installed.
+	time.Sleep(20 * time.Millisecond)
+	if len(inst.installs()) != 0 {
+		t.Errorf("installed %v, want none for an unknown add-in", inst.installs())
+	}
+}

--- a/app/session.go
+++ b/app/session.go
@@ -161,6 +161,7 @@ type Session struct {
 	bugReport            bugReportState                 // in-progress Help ▸ Report Bug capture+submit, if any
 	bugOutcome           atomic.Pointer[bugResult]      // submit goroutine → frame loop handoff (session never touched off-thread)
 	bugSubmitter         bugSubmitter                   // injectable reporting endpoint (DI; lazily defaults to real HTTP)
+	addInCat             addInCatalogue                 // Add-In Catalogue browse/install state (#1164)
 }
 
 // Notice returns the last user-facing notice (a failed commit's reason), or "" — shown in

--- a/head/cmd/oblikovati-head/addins.go
+++ b/head/cmd/oblikovati-head/addins.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -74,6 +75,7 @@ func startAddIns(session *app.Session) *addInHost {
 	useDialogMemoryStore(session)
 	h.loadAndRegister(session, dir)
 	h.loadInstalledAddIns(session) // add-ins the in-app catalogue installed under the per-user dir (#1164)
+	wireAddInCatalogue(session)    // Tools ▸ Get Add-Ins… browse/install (#1164)
 	h.subs = events.Subscribe(session, func(ev []byte) { h.notifyActive(session, ev) })
 	// Under a supervisor (make run-watch sets OBK_ADDIN_AUTORESTART=1), watch the
 	// add-ins dir so a rebuilt library makes the app exit-and-relaunch — the safe way
@@ -91,6 +93,23 @@ func startAddIns(session *app.Session) *addInHost {
 func (h *addInHost) loadAndRegister(session *app.Session, dir string) {
 	libs, skipped, err := addinhost.LoadDir(dir)
 	h.registerResults(session, libs, skipped, err)
+}
+
+// catalogueHTTPTimeout bounds each catalogue request and bundle download so a slow service
+// never strands a worker goroutine.
+const catalogueHTTPTimeout = 60 * time.Second
+
+// wireAddInCatalogue injects the catalogue query + install seams into the session so Tools ▸
+// Get Add-Ins… can browse and install (#1164). OBLIKOVATI_ADDINS_ENDPOINT overrides the
+// service base URL (development/tests); an unresolvable user dir disables the feature.
+func wireAddInCatalogue(session *app.Session) {
+	dir, err := addincat.UserAddInsDir()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "add-in catalogue: %v\n", err)
+		return
+	}
+	client := addincat.NewClient(os.Getenv("OBLIKOVATI_ADDINS_ENDPOINT"), &http.Client{Timeout: catalogueHTTPTimeout})
+	session.SetAddInCatalogue(client, addincat.NewInstaller(dir, client))
 }
 
 // loadInstalledAddIns loads add-ins the in-app catalogue installed under the per-user

--- a/head/ui/addin_catalogue_inwindow_test.go
+++ b/head/ui/addin_catalogue_inwindow_test.go
@@ -1,0 +1,114 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+// In-window verification of the Add-In Catalogue window: open the real GLFW+Vulkan+ImGui
+// window and run the production draw path for a few frames against a fake catalogue, so the
+// header/tabs/cards/actions render code is exercised (and covered) without a live service.
+// Skips cleanly where no display/Vulkan is available.
+package ui
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"oblikovati.org/addincat"
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// fakeCatSource serves a one-add-in catalogue for the host's API version, no network.
+type fakeCatSource struct{}
+
+func (fakeCatSource) List(_ context.Context, major, minor int, _ string) ([]addincat.Entry, error) {
+	return []addincat.Entry{{
+		Name: "com.oblikovati.cam", DisplayName: "Oblikovati CAM", Description: "machining", License: "Apache-2.0",
+		Versions: []addincat.Version{{
+			Version: "0.6.0", APIMajor: major, APIMinor: minor,
+			Bundles: map[string]addincat.Bundle{addincat.Platform(): {URL: "u"}},
+		}},
+	}}, nil
+}
+
+// fakeCatInstaller reports every catalogue entry as available.
+type fakeCatInstaller struct{}
+
+func (fakeCatInstaller) Install(context.Context, addincat.Entry, addincat.Version) error { return nil }
+func (fakeCatInstaller) Uninstall(string) error                                          { return nil }
+func (fakeCatInstaller) Status(catalogue []addincat.Entry, _, _ int) ([]addincat.AddInStatus, error) {
+	out := make([]addincat.AddInStatus, len(catalogue))
+	for i, e := range catalogue {
+		out[i] = addincat.AddInStatus{Entry: e, State: addincat.StateAvailable, LatestVersion: e.Versions[0].Version}
+	}
+	return out, nil
+}
+
+func waitCatalogue(t *testing.T, s *app.Session) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(s.AddInStatuses()) > 0 {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal("catalogue did not populate")
+}
+
+func TestAddInCatalogueWindowDrawsInWindow(t *testing.T) {
+	win, err := native.CreateWindow(900, 640, "obk-addincat-test")
+	if err != nil {
+		t.Skipf("no window/Vulkan available: %v", err)
+	}
+	defer win.Destroy()
+	win.InitViewport()
+
+	s := app.NewSession()
+	s.SetAddInCatalogue(fakeCatSource{}, fakeCatInstaller{})
+	OpenAddInCatalogue(s)
+	waitCatalogue(t, s)
+
+	// Cards whose state the default (first) tab does not show — drawn into a scratch window so
+	// the Installed/Update title + action branches are exercised too.
+	installed := addincat.AddInStatus{
+		Entry: addincat.Entry{Name: "com.x.installed", DisplayName: "Installed One", Description: "d", License: "L"},
+		State: addincat.StateInstalled, InstalledVersion: "1.0.0",
+	}
+	updatable := addincat.AddInStatus{
+		Entry: addincat.Entry{Name: "com.x.update", DisplayName: "Update One"},
+		State: addincat.StateUpdateAvailable, InstalledVersion: "1.0.0", LatestVersion: "1.1.0",
+	}
+
+	for i := 0; i < 3; i++ {
+		win.BeginFrame()
+		drawAddInCatalogueWindow(s)
+		if native.Begin("##addincat-scratch") {
+			drawCatalogueCard(s, installed)
+			drawCatalogueCard(s, updatable)
+		}
+		native.End()
+		win.EndFrame(0.1, 0.1, 0.1)
+	}
+
+	// Render a session whose refresh failed, so the header's error line is exercised too.
+	errSession := app.NewSession()
+	errSession.SetAddInCatalogue(errSource{}, fakeCatInstaller{})
+	errSession.RefreshAddInCatalogue("")
+	deadline := time.Now().Add(2 * time.Second)
+	for errSession.AddInCatalogueError() == "" && time.Now().Before(deadline) {
+		time.Sleep(2 * time.Millisecond)
+	}
+	for i := 0; i < 2; i++ {
+		win.BeginFrame()
+		drawAddInCatalogueWindow(errSession)
+		win.EndFrame(0.1, 0.1, 0.1)
+	}
+}
+
+// errSource fails every List, to exercise the catalogue header's error path.
+type errSource struct{}
+
+func (errSource) List(context.Context, int, int, string) ([]addincat.Entry, error) {
+	return nil, context.DeadlineExceeded
+}

--- a/head/ui/addin_catalogue_inwindow_test.go
+++ b/head/ui/addin_catalogue_inwindow_test.go
@@ -64,6 +64,10 @@ func TestAddInCatalogueWindowDrawsInWindow(t *testing.T) {
 	defer win.Destroy()
 	win.InitViewport()
 
+	// The open flag is package-global; leaving it set would make later in-window tests' full
+	// DrawChrome draw this window over the viewport and steal their injected input.
+	defer func() { addInCatalogueUI.open = false }()
+
 	s := app.NewSession()
 	s.SetAddInCatalogue(fakeCatSource{}, fakeCatInstaller{})
 	OpenAddInCatalogue(s)

--- a/head/ui/addin_catalogue_window.go
+++ b/head/ui/addin_catalogue_window.go
@@ -1,0 +1,154 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"fmt"
+
+	"oblikovati.org/addincat"
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// Add-In Catalogue window (Tools ▸ Get Add-Ins…, #1164). A thin view over the session's
+// catalogue state: it shows three tabs (available / installed / updatable), a search box that
+// re-queries the service, and per-add-in Install/Update/Uninstall actions. All network and
+// install work runs on a session goroutine; this view only reads the cached snapshot and
+// issues commands, so it never blocks the frame loop.
+var addInCatalogueUI struct {
+	open   bool
+	search [256]byte
+}
+
+// OpenAddInCatalogue shows the window and kicks an initial refresh.
+func OpenAddInCatalogue(s *app.Session) {
+	addInCatalogueUI.open = true
+	s.RefreshAddInCatalogue("")
+}
+
+// drawAddInCatalogueWindow renders the catalogue window when open.
+func drawAddInCatalogueWindow(s *app.Session) {
+	if !addInCatalogueUI.open {
+		return
+	}
+	native.SetNextWindowSizeOnce(640, 480)
+	if native.Begin("Add-In Catalogue") {
+		drawCatalogueHeader(s)
+		drawCatalogueTabs(s)
+	}
+	native.End()
+}
+
+// drawCatalogueHeader draws the search box, a refresh button, and any busy/error/notice line.
+func drawCatalogueHeader(s *app.Session) {
+	if native.InputText("Search##addincat", addInCatalogueUI.search[:]) {
+		s.RefreshAddInCatalogue(bufString(addInCatalogueUI.search[:]))
+	}
+	native.SameLine()
+	if native.Button("Refresh") {
+		s.RefreshAddInCatalogue(bufString(addInCatalogueUI.search[:]))
+	}
+	if s.AddInCatalogueBusy() {
+		native.Text("Working…")
+	}
+	if e := s.AddInCatalogueError(); e != "" {
+		native.Text("Error: " + e)
+	}
+	if n := s.AddInCatalogueNotice(); n != "" {
+		native.Text(n)
+	}
+	native.Separator()
+}
+
+// drawCatalogueTabs lays out the three state tabs over the current snapshot.
+func drawCatalogueTabs(s *app.Session) {
+	if !native.BeginTabBar("##addincat-tabs") {
+		return
+	}
+	statuses := s.AddInStatuses()
+	drawCatalogueTab(s, "Available", statuses, addincat.StateAvailable)
+	drawCatalogueTab(s, "Installed", statuses, addincat.StateInstalled)
+	drawCatalogueTab(s, "Updates", statuses, addincat.StateUpdateAvailable)
+	native.EndTabBar()
+}
+
+// drawCatalogueTab renders the cards whose state matches, in a scrollable child region.
+func drawCatalogueTab(s *app.Session, label string, statuses []addincat.AddInStatus, state addincat.State) {
+	if !native.BeginTabItem(label) {
+		return
+	}
+	if native.BeginChild("##child-"+label, 0, 0, false) {
+		any := false
+		for _, st := range statuses {
+			if st.State != state {
+				continue
+			}
+			any = true
+			drawCatalogueCard(s, st)
+		}
+		if !any {
+			native.Text("Nothing here.")
+		}
+	}
+	native.EndChild()
+	native.EndTabItem()
+}
+
+// drawCatalogueCard renders one add-in's metadata and its action buttons.
+func drawCatalogueCard(s *app.Session, st addincat.AddInStatus) {
+	native.PushID(st.Entry.Name)
+	native.Text(catalogueCardTitle(st))
+	if st.Entry.Description != "" {
+		native.Text(st.Entry.Description)
+	}
+	if st.Entry.License != "" {
+		native.Text("License: " + st.Entry.License)
+	}
+	drawCatalogueCardActions(s, st)
+	native.Separator()
+	native.PopID()
+}
+
+// catalogueCardTitle is the card's heading: the display name plus a version hint that reflects
+// the add-in's state (installed version, an update arrow, or the offered version).
+func catalogueCardTitle(st addincat.AddInStatus) string {
+	name := st.Entry.DisplayName
+	if name == "" {
+		name = st.Entry.Name
+	}
+	switch st.State {
+	case addincat.StateInstalled:
+		return fmt.Sprintf("%s (installed %s)", name, st.InstalledVersion)
+	case addincat.StateUpdateAvailable:
+		return fmt.Sprintf("%s (%s → %s)", name, st.InstalledVersion, st.LatestVersion)
+	default:
+		return fmt.Sprintf("%s %s", name, st.LatestVersion)
+	}
+}
+
+// drawCatalogueCardActions draws the per-state action buttons, disabled while an operation
+// is in flight so a second click cannot pile on.
+func drawCatalogueCardActions(s *app.Session, st addincat.AddInStatus) {
+	native.BeginDisabled(s.AddInCatalogueBusy())
+	switch st.State {
+	case addincat.StateAvailable:
+		if native.Button("Install") {
+			s.InstallAddIn(st.Entry.Name)
+		}
+	case addincat.StateUpdateAvailable:
+		if native.Button("Update") {
+			s.InstallAddIn(st.Entry.Name)
+		}
+		native.SameLine()
+		if native.Button("Uninstall") {
+			s.UninstallAddIn(st.Entry.Name)
+		}
+	case addincat.StateInstalled:
+		if native.Button("Uninstall") {
+			s.UninstallAddIn(st.Entry.Name)
+		}
+	}
+	native.EndDisabled()
+}

--- a/head/ui/addin_catalogue_window_test.go
+++ b/head/ui/addin_catalogue_window_test.go
@@ -1,0 +1,41 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/addincat"
+)
+
+func TestCatalogueCardTitle(t *testing.T) {
+	base := addincat.Entry{Name: "com.oblikovati.cam", DisplayName: "Oblikovati CAM"}
+
+	available := catalogueCardTitle(addincat.AddInStatus{Entry: base, State: addincat.StateAvailable, LatestVersion: "0.6.0"})
+	if !strings.Contains(available, "Oblikovati CAM") || !strings.Contains(available, "0.6.0") {
+		t.Errorf("available title = %q", available)
+	}
+
+	installed := catalogueCardTitle(addincat.AddInStatus{Entry: base, State: addincat.StateInstalled, InstalledVersion: "0.6.0"})
+	if !strings.Contains(installed, "installed 0.6.0") {
+		t.Errorf("installed title = %q", installed)
+	}
+
+	update := catalogueCardTitle(addincat.AddInStatus{Entry: base, State: addincat.StateUpdateAvailable, InstalledVersion: "0.5.0", LatestVersion: "0.6.0"})
+	if !strings.Contains(update, "0.5.0 → 0.6.0") {
+		t.Errorf("update title = %q", update)
+	}
+}
+
+// TestCatalogueCardTitleFallsBackToName uses the add-in id when no display name is set.
+func TestCatalogueCardTitleFallsBackToName(t *testing.T) {
+	title := catalogueCardTitle(addincat.AddInStatus{
+		Entry: addincat.Entry{Name: "com.x.tool"}, State: addincat.StateAvailable, LatestVersion: "1.0.0",
+	})
+	if !strings.Contains(title, "com.x.tool") {
+		t.Errorf("title = %q, want it to fall back to the id", title)
+	}
+}

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -151,12 +151,13 @@ func drawChromeWindows(s *app.Session) {
 	drawUnitsSettingsWindow(s)   // Tools ▸ Document Settings — Units (#146)
 	drawHistoryBrowserWindow(s)  // Edit ▸ History Browser (per-document timelines, side by side)
 	drawScriptConsole(s)
-	drawKeymapEditor(s)    // Tools ▸ Customize Keyboard (M05-F17)
-	drawCommandInput(s)    // command-alias input box (M05-F17)
-	drawCommandWindow(s)   // docked Command Window REPL panel (M26 F04)
-	drawUpdateWindow(s)    // Help ▸ Check for Updates notification
-	drawReportBugDialog(s) // Help ▸ Report Bug
-	drawAddInPanels(s)     // add-in dockable windows (M05-F03)
+	drawKeymapEditor(s)         // Tools ▸ Customize Keyboard (M05-F17)
+	drawCommandInput(s)         // command-alias input box (M05-F17)
+	drawCommandWindow(s)        // docked Command Window REPL panel (M26 F04)
+	drawUpdateWindow(s)         // Help ▸ Check for Updates notification
+	drawReportBugDialog(s)      // Help ▸ Report Bug
+	drawAddInCatalogueWindow(s) // Tools ▸ Get Add-Ins… (#1164)
+	drawAddInPanels(s)          // add-in dockable windows (M05-F03)
 	// M26 F03: toasts / prompt modal / message-center windows are retired — every message
 	// now funnels into the docked Command Window, and prompts are answered inline there.
 	drawWebViews(s)          // web dialogs/views (M05-F08)

--- a/head/ui/chrome_menubar.go
+++ b/head/ui/chrome_menubar.go
@@ -154,6 +154,9 @@ func drawToolsMenu(s *app.Session) {
 		if native.MenuItem("Command Input") { // M05-F17: type an alias to run a command
 			s.BeginCommandInput()
 		}
+		if native.MenuItem("Get Add-Ins…") { // #1164: browse/install/update add-ins from the catalogue
+			OpenAddInCatalogue(s)
+		}
 		if native.MenuItem(checkLabel("Command Window", s.CommandWindowOpen())) { // M26 F04: docked REPL
 			s.ToggleCommandWindow()
 		}


### PR DESCRIPTION
## What
The in-app **Add-In Catalogue** (#1164), the user-facing half of M32.

- `app/addin_catalogue.go` (session-owned, testable): runs every catalogue query, install and uninstall on a **goroutine** through injected query+install seams (the real `addincat` client/installer; faked in tests). The UI reads a mutex-guarded snapshot each frame, so the network never blocks the frame loop. Install/uninstall leaves a **"restart to apply"** notice (a Go c-shared can't be hot-loaded).
- `head/ui/addin_catalogue_window.go` (thin view): **Tools ▸ Get Add-Ins…** opens a window with three tabs (Available / Installed / Updates), a search box that re-queries the service, and per-add-in **Install / Update / Uninstall** actions disabled while an op runs.
- Head wires the real seams at startup (`OBLIKOVATI_ADDINS_ENDPOINT` overrides the service URL).

## Why
H07 of M32 (#1164) — discovery/install/update from inside the app, the goal of the milestone's host half. Builds on H05 (client/installer) and H06 (loader scans the install tree).

## Verification
- `gofmt`/`go vet`/`golangci-lint` clean (new files); head builds (cgo)
- `go test -race ./app/`: refresh populates statuses, error recorded, install/uninstall run + notice, no-op when disabled/unknown, install-error path — all green under the race detector
- `go test ./head/ui/`: card-title rendering across states
- **Live** (offscreen Vulkan, production `DrawChrome`): the window renders with its tabs and an add-in card (name, description, license, Install button) — screenshot captured

Part of #1164. Closes #1175.