### PR TITLE
feat(addin): render add-in-provided command icon SVG

### DIFF
--- a/addin/router/commands.go
+++ b/addin/router/commands.go
@@ -11,6 +11,10 @@ import (
 	"oblikovati.org/app"
 )
 
+// maxInlineIconSVGBytes caps an add-in's inline command glyph (wire IconSVG). A 24×24 line icon is
+// a few hundred bytes; 16 KiB leaves generous headroom while rejecting a runaway payload.
+const maxInlineIconSVGBytes = 16 * 1024
+
 // listCommands returns every registered command and whether it can run now.
 func listCommands(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
 	all := s.Commands().All()
@@ -21,7 +25,7 @@ func listCommands(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
 			Tab: c.Tab(), Category: c.Category(), Environment: c.Environment(),
 			Alias: c.Alias(), Tooltip: c.Tooltip(),
 			TooltipTitle: c.TooltipTitle(), TooltipExpanded: c.TooltipExpanded(),
-			Icon: c.Icon(), ButtonStyle: c.ButtonStyle(),
+			Icon: c.Icon(), IconSVG: c.InlineIconSVG(), ButtonStyle: c.ButtonStyle(),
 			Enabled: c.IsEnabled(s),
 		}
 	}
@@ -43,9 +47,14 @@ func createCommand(s *app.Session, args json.RawMessage) (json.RawMessage, error
 	if in.Ribbon != "" && !in.Ribbon.Valid() {
 		return nil, fmt.Errorf("commands.create: unknown ribbon %q (one of ZeroDoc/Part/Assembly/Drawing/Presentation/iFeatures/UnknownDocument)", in.Ribbon)
 	}
+	// Cap the inline glyph so a stray payload cannot bloat the ribbon; a real 24×24 icon is well
+	// under this. The head rasterizes it through the same theming as a bundled glyph.
+	if len(in.IconSVG) > maxInlineIconSVGBytes {
+		return nil, fmt.Errorf("commands.create: iconSvg is %d bytes, over the %d-byte limit", len(in.IconSVG), maxInlineIconSVGBytes)
+	}
 	cmd := app.NewCommand(in.ID, in.DisplayName, in.Category, func(*app.Session) error { return nil }).
 		WithTab(in.Tab).WithEnvironment(in.Environment).WithAlias(in.Alias).WithTooltip(in.Tooltip).
-		WithIcon(in.Icon).WithButtonStyle(in.ButtonStyle).WithKind(in.Kind).
+		WithIcon(in.Icon).WithInlineIconSVG(in.IconSVG).WithButtonStyle(in.ButtonStyle).WithKind(in.Kind).
 		WithTooltipDetail(in.TooltipTitle, in.TooltipExpanded)
 	if in.Ribbon != "" {
 		cmd.WithRibbons(in.Ribbon)

--- a/addin/router/router_test.go
+++ b/addin/router/router_test.go
@@ -145,6 +145,29 @@ func TestCommandsCreateAddsRibbonButtonAndNotifiesOnExecute(t *testing.T) {
 	}
 }
 
+// TestCommandsCreateInlineIconSVG checks an add-in can ship its own button glyph as inline SVG: it
+// is stored on the command (so the head renders it instead of a bundled key), and an oversized
+// payload is rejected.
+func TestCommandsCreateInlineIconSVG(t *testing.T) {
+	r, s := seededSession(t)
+	svg := `<svg viewBox="0 0 24 24"><rect width="24" height="24" fill="#00ff00"/></svg>`
+	call(t, r, s, "commands.create",
+		`{"id":"AddIn.Glyph","displayName":"Glyph","category":"Demo","iconSvg":`+jsonString(svg)+`,"buttonStyle":2}`, nil)
+
+	panel, ok := app.BuildRibbon(s).Panel("Demo")
+	if !ok || len(panel.Buttons) != 1 {
+		t.Fatalf("Demo panel = %+v ok=%v, want one add-in button", panel, ok)
+	}
+	if got := panel.Buttons[0].Command.InlineIconSVG(); got != svg {
+		t.Errorf("InlineIconSVG = %q, want the supplied markup", got)
+	}
+
+	big := `{"id":"AddIn.Big","displayName":"Big","iconSvg":` + jsonString("<svg>"+strings.Repeat("x", 17*1024)+"</svg>") + `}`
+	if _, err := r.Handle(s, "commands.create", []byte(big)); err == nil {
+		t.Error("oversized iconSvg accepted, want rejected")
+	}
+}
+
 func TestDocumentsCreateListActivate(t *testing.T) {
 	r, s := seededSession(t)
 	var created wire.DocumentInfo

--- a/app/command.go
+++ b/app/command.go
@@ -50,6 +50,7 @@ type CommandDefinition struct {
 	tooltipTitle     string      // progressive tooltip title (M05-F09)
 	tooltipExpanded  string      // progressive tooltip long text, shown after a longer hover
 	iconKey          string      // icon asset key (e.g. "extrude"); empty ⇒ no icon
+	inlineIconSVG    string      // add-in-supplied inline SVG glyph; takes precedence over iconKey
 	buttonStyle      ButtonStyle // ribbon render style; zero value ⇒ text-only
 	ribbons          []RibbonKey // ribbons this command appears on; empty ⇒ the Part ribbon
 	environment      Environment // ribbon environment; BaseEnvironment ⇒ always shown
@@ -112,6 +113,14 @@ func (c *CommandDefinition) TooltipExpanded() string { return c.tooltipExpanded 
 // Pair it with WithButtonStyle to make the ribbon show the icon; a key with the
 // text-only style is ignored by the renderer.
 func (c *CommandDefinition) WithIcon(key string) *CommandDefinition { c.iconKey = key; return c }
+
+// WithInlineIconSVG sets an add-in-supplied inline SVG glyph for the command, used when the add-in
+// ships its own icon rather than naming a host-bundled key (wire CreateCommandArgs.IconSVG). It
+// takes precedence over WithIcon; the head renders it through the same theming as a bundled glyph.
+func (c *CommandDefinition) WithInlineIconSVG(svg string) *CommandDefinition {
+	c.inlineIconSVG = svg
+	return c
+}
 
 // WithButtonStyle sets how the command renders in the ribbon (text/small-icon/
 // large-icon). Inventor's large buttons head a panel; small ones fill dense grids.
@@ -234,6 +243,7 @@ func (c *CommandDefinition) Kind() ControlKind        { return c.kind }
 func (c *CommandDefinition) Alias() string            { return c.alias }
 func (c *CommandDefinition) Tooltip() string          { return c.tooltip }
 func (c *CommandDefinition) Icon() string             { return c.iconKey }
+func (c *CommandDefinition) InlineIconSVG() string    { return c.inlineIconSVG }
 func (c *CommandDefinition) ButtonStyle() ButtonStyle { return c.buttonStyle }
 func (c *CommandDefinition) Environment() Environment { return c.environment }
 

--- a/app/command_test.go
+++ b/app/command_test.go
@@ -33,6 +33,23 @@ func TestCommandRegistrationAndLookup(t *testing.T) {
 	}
 }
 
+// TestCommandInlineIconSVG checks an add-in's own glyph is carried on the command: WithInlineIconSVG
+// stores the markup and InlineIconSVG reads it back, distinct from the bundled-key Icon.
+func TestCommandInlineIconSVG(t *testing.T) {
+	svg := `<svg viewBox="0 0 24 24"><rect width="24" height="24"/></svg>`
+	c := NewCommand("AddIn.Glyph", "Glyph", "Demo", func(*Session) error { return nil }).
+		WithIcon("fallback-key").WithInlineIconSVG(svg)
+	if got := c.InlineIconSVG(); got != svg {
+		t.Errorf("InlineIconSVG = %q, want the supplied markup", got)
+	}
+	if got := c.Icon(); got != "fallback-key" {
+		t.Errorf("Icon = %q, want the bundled key kept alongside the inline SVG", got)
+	}
+	if NewCommand("x", "X", "Demo", func(*Session) error { return nil }).InlineIconSVG() != "" {
+		t.Error("a command with no inline glyph should report an empty InlineIconSVG")
+	}
+}
+
 func TestCommandManagerRejectsDuplicates(t *testing.T) {
 	m := NewCommandManager()
 	_ = m.Add(NewCommand("x", "X", "C", func(*Session) error { return nil }).WithAlias("A"))

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.85.0
+	oblikovati.org/api v0.86.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.85.0
+	oblikovati.org/api v0.86.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/ui/chrome_ribbon.go
+++ b/head/ui/chrome_ribbon.go
@@ -294,7 +294,7 @@ func drawButtonControl(btn app.RibbonButton) bool {
 		defer native.PopStyleColor(3)
 	}
 	if px, ok := iconSizeFor(btn.Command.ButtonStyle()); ok {
-		if tex, ok := icons.texture(btn.Command.Icon(), px); ok {
+		if tex, ok := icons.texture(btn.Command.Icon(), btn.Command.InlineIconSVG(), px); ok {
 			return drawIconButton(btn, tex, float32(px))
 		}
 	}

--- a/head/ui/icon_cache.go
+++ b/head/ui/icon_cache.go
@@ -45,7 +45,8 @@ type iconCache struct {
 }
 
 type iconKey struct {
-	name string
+	name string // bundled asset key, or "" when inline SVG is supplied
+	svg  string // add-in-supplied inline SVG markup; takes precedence over name
 	px   int
 }
 
@@ -75,14 +76,15 @@ func (c *iconCache) beginFrame(themeRevision uint64) {
 }
 
 // texture returns the ImGui texture handle for an icon at the given pixel size,
-// composing and uploading it on first use after a theme change. It returns (0,false)
-// when the key has no bundled asset or rasterization/upload fails, so the caller falls
-// back to text. A failed lookup is cached too, so a bad glyph is not retried per frame.
-func (c *iconCache) texture(name string, px int) (uint64, bool) {
-	if name == "" || px <= 0 {
+// composing and uploading it on first use after a theme change. The glyph comes from the
+// inline SVG when an add-in supplied one, otherwise from the bundled asset key. It returns
+// (0,false) when there is no asset or rasterization/upload fails, so the caller falls back to
+// text. A failed lookup is cached too, so a bad glyph is not retried per frame.
+func (c *iconCache) texture(name, svg string, px int) (uint64, bool) {
+	if (name == "" && svg == "") || px <= 0 {
 		return 0, false
 	}
-	k := iconKey{name, px}
+	k := iconKey{name: name, svg: svg, px: px}
 	if t, ok := c.tex[k]; ok {
 		return t, t != 0
 	}
@@ -107,11 +109,16 @@ func (c *iconCache) compose(k iconKey) uint64 {
 }
 
 // rasterizeRoles renders one glyph's role masks, or nil when the asset is missing or
-// invalid (the nil is cached so the failure costs once, not every frame).
+// invalid (the nil is cached so the failure costs once, not every frame). An add-in's inline
+// SVG is used directly; otherwise the bundled asset is looked up by key.
 func rasterizeRoles(k iconKey) *icon.RoleMasks {
-	svg, ok := icon.SVG(k.name)
-	if !ok {
-		return nil
+	svg := []byte(k.svg)
+	if k.svg == "" {
+		bundled, ok := icon.SVG(k.name)
+		if !ok {
+			return nil
+		}
+		svg = bundled
 	}
 	masks, err := icon.RasterizeRoles(svg, k.px)
 	if err != nil {

--- a/head/ui/navigation_bar.go
+++ b/head/ui/navigation_bar.go
@@ -49,7 +49,7 @@ func drawNavigationBar(s *app.Session, ox, oy float32, pw, ph int) {
 	x := ox + float32(pw) - cell - navBarMargin
 	y := oy + (float32(ph)-cell*float32(len(navBarButtons)))/2
 	for _, b := range navBarButtons {
-		tex, ok := icons.texture(b.icon, navBarIconPx)
+		tex, ok := icons.texture(b.icon, "", navBarIconPx)
 		if !ok {
 			continue
 		}

--- a/head/ui/property_panel.go
+++ b/head/ui/property_panel.go
@@ -247,7 +247,7 @@ func drawBooleanPropertyRow(id string, current ops.PartFeatureOperation, set fun
 // drawPropertyToggleControl draws the toggle's clickable control: the icon at the small
 // glyph size, or a text button when the asset is missing/unuploadable.
 func drawPropertyToggleControl(group, key, tip string) bool {
-	if tex, ok := icons.texture(key, smallIconPx); ok {
+	if tex, ok := icons.texture(key, "", smallIconPx); ok {
 		px := float32(smallIconPx)
 		return native.ImageButton(group+"-"+key, tex, px, px, identityTint)
 	}

--- a/head/ui/ribbon_icons_test.go
+++ b/head/ui/ribbon_icons_test.go
@@ -32,6 +32,19 @@ func TestRibbonCommandIconsResolve(t *testing.T) {
 	}
 }
 
+// TestRasterizeRolesUsesInlineSVG checks the renderer draws an add-in's own glyph: an iconKey
+// carrying inline SVG rasterizes to role masks directly (no bundled-asset lookup), while a missing
+// bundled key with no inline SVG yields nil so the button falls back to text.
+func TestRasterizeRolesUsesInlineSVG(t *testing.T) {
+	inline := iconKey{svg: `<svg viewBox="0 0 24 24"><rect width="24" height="24" fill="#00ff00"/></svg>`, px: 16}
+	if rasterizeRoles(inline) == nil {
+		t.Error("an inline SVG should rasterize to role masks")
+	}
+	if rasterizeRoles(iconKey{name: "definitely-not-a-bundled-icon", px: 16}) != nil {
+		t.Error("a missing bundled key with no inline SVG should yield nil masks (text fallback)")
+	}
+}
+
 // TestRibbonIconCommandsHaveButtonStyle guards that a command which names an icon also sets
 // a (small/large) button style — the renderer only draws the glyph when both are present, so
 // an icon with the default text-only style silently renders as a text button (the bug that

--- a/head/ui/steering_wheel.go
+++ b/head/ui/steering_wheel.go
@@ -48,7 +48,7 @@ func drawSteeringWheel(s *app.Session, ox, oy float32) {
 	cx, cy := ox+float32(vcx), oy+float32(vcy)
 	drawSteeringRing(cx, cy)
 	for i, tool := range steeringWheelTools {
-		tex, ok := icons.texture(tool.icon, steeringIconPx)
+		tex, ok := icons.texture(tool.icon, "", steeringIconPx)
 		if !ok {
 			continue
 		}


### PR DESCRIPTION
## What

Host implementation of the inline command-icon feature (api **v0.86.0** `wire.CreateCommandArgs.IconSVG`). An add-in can now ship its **own** ribbon-button glyph as inline SVG instead of being limited to the icon keys the host bundles in `head/icon/assets`.

## How

- **`app.CommandDefinition`** gains `WithInlineIconSVG` / `InlineIconSVG()` storing the inline markup.
- **`addin/router` createCommand** threads `IconSVG` onto the command and caps it (16 KiB) to guard against a runaway payload; **listCommands** returns it in `CommandInfo`.
- **head ribbon icon cache** keys on the inline SVG when present and rasterizes it through the same theming/role machinery as a bundled glyph, falling back to the bundled key (then a text button) otherwise.

## Tests

- `addin/router` `TestCommandsCreateInlineIconSVG`: the inline SVG is stored on the ribbon button and an oversized payload is rejected.
- `head/ui` `TestRasterizeRolesUsesInlineSVG`: an inline-SVG icon key rasterizes to role masks; a missing bundled key yields the text fallback.

Pins api v0.86.0. Contract half merged in Oblikovati.API#207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)