### PR TITLE
feat(brep): surface offset — brep.offsetFaces (CAM Gap 3)

### DIFF
--- a/addin/router/brep.go
+++ b/addin/router/brep.go
@@ -275,6 +275,28 @@ func brepSilhouette(s *app.Session, raw json.RawMessage) (json.RawMessage, error
 	return json.Marshal(wire.BrepWiresResult{Handle: tb.Handle(), Wires: wirePolylines(sil)})
 }
 
+// brepOffsetFaces serves wire.MethodBrepOffsetFaces: the named faces of the source, offset by
+// Distance along their normals, come back as a new transient surface body to sample.
+func brepOffsetFaces(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.BrepOffsetFacesArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	src, err := brepSource(s, in.Source)
+	if err != nil {
+		return nil, err
+	}
+	keys := make([][]byte, len(in.FaceKeys))
+	for i, k := range in.FaceKeys {
+		keys[i] = []byte(k)
+	}
+	off, err := ops.OffsetFaceSurfaces(src.Topo(), keys, in.Distance, in.Reverse)
+	if err != nil {
+		return nil, err
+	}
+	return brepHandleReply(s.TransientBodies().Adopt(off))
+}
+
 // brepRuledSurface serves wire.MethodBrepRuledSurface.
 func brepRuledSurface(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	var in wire.BrepRuledSurfaceArgs

--- a/addin/router/brep_test.go
+++ b/addin/router/brep_test.go
@@ -264,6 +264,32 @@ func TestBrepSilhouetteOnDocumentCylinder(t *testing.T) {
 	}
 }
 
+// TestBrepOffsetFaces offsets the cylindrical side face of an extruded disc and checks the result is
+// a one-face transient surface body (the offset wall to sample).
+func TestBrepOffsetFaces(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"circle","points":[[0,0]],"radius":"20 mm"}`, &struct{}{})
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":0,"profileIndex":0,"distance":"50 mm"}}`, &struct{}{})
+	var copied wire.BrepHandleResult
+	call(t, r, s, "brep.copy", `{"source":{"bodyIndex":0}}`, &copied)
+
+	args, _ := json.Marshal(wire.BrepOffsetFacesArgs{
+		Source: wire.BrepBodyRef{Handle: copied.Handle}, FaceKeys: []string{sideFaceKey(t, s, copied.Handle)}, Distance: 5,
+	})
+	var off wire.BrepHandleResult
+	call(t, r, s, "brep.offsetFaces", string(args), &off)
+	if off.Handle == 0 || off.Stats.Faces != 1 {
+		t.Fatalf("offset result = %+v, want one offset face on a new transient body", off)
+	}
+
+	// No faces selected is an error.
+	if _, err := r.Handle(s, "brep.offsetFaces",
+		[]byte(fmt.Sprintf(`{"source":{"handle":%d},"faceKeys":[],"distance":5}`, copied.Handle))); err == nil {
+		t.Error("offsetFaces with no faces should error")
+	}
+}
+
 // sideFaceKey returns the transient copy's curved (cylindrical) side face
 // key, probed directly on the registry — the wire surface addresses faces by
 // key but does not enumerate a transient body's faces (the document's

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -409,6 +409,7 @@ func (r *Router) registerMaterialHandlers() {
 	r.handlers[wire.MethodBrepDeleteFaces] = brepDeleteFaces
 	r.handlers[wire.MethodBrepSilhouette] = brepSilhouette
 	r.handlers[wire.MethodBrepRuledSurface] = brepRuledSurface
+	r.handlers[wire.MethodBrepOffsetFaces] = brepOffsetFaces
 	r.handlers[wire.MethodBrepImprint] = brepImprint
 	r.handlers[wire.MethodBrepIdenticalBodies] = brepIdenticalBodies
 	r.handlers[wire.MethodBrepCreateFromDefinition] = brepCreateFromDefinition

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.86.0
+	oblikovati.org/api v0.87.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.86.0
+	oblikovati.org/api v0.87.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/kernel/geom/offset_surface.go
+++ b/kernel/geom/offset_surface.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import "oblikovati.org/math"
+
+// OffsetSurface is the parallel surface a fixed signed Distance from a base surface along its
+// normal: S_d(u,v) = S(u,v) + Distance·N(u,v). It shares the base's (u,v) parameterization, so its
+// normal at (u,v) equals the base normal there and its ParamAt is the base's — which is exactly what
+// lets a face be offset by swapping its surface and KEEPING its loops: the trimmed-face tessellator
+// projects the loop to (u,v) through ParamAt and evaluates through PointAt, so the same UV region is
+// re-evaluated on the offset surface (no edge/loop surgery). CAM uses it to offset a part face by the
+// tool radius and then sample the offset for drop-cutter projection.
+//
+// The offset is exact for the analytic surfaces (plane/cylinder/sphere/cone/torus, whose normal is
+// closed-form); a large inward Distance on a tightly curved surface can self-intersect (the offset
+// of a cylinder by more than its radius inverts), which the caller must avoid — there is no
+// self-intersection trimming here.
+type OffsetSurface struct {
+	Base     Surface
+	Distance float64
+}
+
+var _ Surface = OffsetSurface{}
+
+// PointAt evaluates the base point displaced along the base normal by Distance.
+func (o OffsetSurface) PointAt(u, v float64) math.Point3 {
+	return o.Base.PointAt(u, v).TranslateBy(o.Base.NormalAt(u, v).Scale(math.Scalar(o.Distance)))
+}
+
+// NormalAt returns the base normal: a parallel surface has the same normal field as its base.
+func (o OffsetSurface) NormalAt(u, v float64) math.Vector3 { return o.Base.NormalAt(u, v) }
+
+// offsetParamStep is the half-width of the central difference used to take the normal field's rate
+// of change; small enough to be accurate on the analytic surfaces' [0,2π] angular domains.
+const offsetParamStep = 1e-6
+
+// DerivativesAt returns the offset surface's partials, ∂S_d/∂u = ∂S/∂u + Distance·∂N/∂u (and v): the
+// base's exact partials plus the Distance-scaled rate of change of the normal (by central
+// difference, since the Surface interface exposes no second derivative).
+func (o OffsetSurface) DerivativesAt(u, v float64) (du, dv math.Vector3) {
+	bdu, bdv := o.Base.DerivativesAt(u, v)
+	dNdu := centralDiff(o.Base.NormalAt(u+offsetParamStep, v), o.Base.NormalAt(u-offsetParamStep, v))
+	dNdv := centralDiff(o.Base.NormalAt(u, v+offsetParamStep), o.Base.NormalAt(u, v-offsetParamStep))
+	d := math.Scalar(o.Distance)
+	return bdu.Add(dNdu.Scale(d)), bdv.Add(dNdv.Scale(d))
+}
+
+// centralDiff returns (hi − lo) / (2·offsetParamStep).
+func centralDiff(hi, lo math.Vector3) math.Vector3 {
+	return hi.Add(lo.Scale(-1)).Scale(math.Scalar(1.0 / (2 * offsetParamStep)))
+}
+
+// UDomain / VDomain are the base's: offsetting along the normal does not change the parameter range.
+func (o OffsetSurface) UDomain() (lo, hi float64) { return o.Base.UDomain() }
+func (o OffsetSurface) VDomain() (lo, hi float64) { return o.Base.VDomain() }
+
+// ParamAt returns the base parameters of p. For a point on the offset surface this reproduces its
+// (u,v) (the analytic surfaces' radial/perpendicular projection is offset-invariant), which is what
+// the tessellator needs when the offset face reuses the base loops.
+func (o OffsetSurface) ParamAt(p math.Point3) (u, v float64) { return o.Base.ParamAt(p) }

--- a/kernel/geom/offset_surface_test.go
+++ b/kernel/geom/offset_surface_test.go
@@ -37,3 +37,37 @@ func TestOffsetSurfaceDefiningProperty(t *testing.T) {
 		}
 	}
 }
+
+// TestOffsetSurfaceInterface covers the rest of the Surface contract on the offset surface: the
+// derivatives cross to the (parallel) normal, the parameter domains are the base's, and ParamAt
+// inverts PointAt for a point of the offset surface.
+func TestOffsetSurfaceInterface(t *testing.T) {
+	cyl, err := NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	off := OffsetSurface{Base: cyl, Distance: 2}
+
+	du, dv := off.DerivativesAt(1, 3)
+	n := du.Cross(dv)
+	bn := off.NormalAt(1, 3)
+	// ∂u×∂v points along the surface normal (same direction once normalized).
+	cosang := float64(n.Dot(bn)) / float64(n.Length())
+	if stdmath.Abs(cosang-1) > 1e-3 {
+		t.Errorf("∂u×∂v not aligned with the normal: cos = %g", cosang)
+	}
+
+	ulo, uhi := off.UDomain()
+	bulo, buhi := cyl.UDomain()
+	vlo, vhi := off.VDomain()
+	bvlo, bvhi := cyl.VDomain()
+	if ulo != bulo || uhi != buhi || vlo != bvlo || vhi != bvhi {
+		t.Error("offset surface domains must equal the base's")
+	}
+
+	p := off.PointAt(1.2, 4)
+	u, v := off.ParamAt(p)
+	if back := off.PointAt(u, v); back.DistanceTo(p) > 1e-6 {
+		t.Errorf("ParamAt did not invert PointAt: off by %g", back.DistanceTo(p))
+	}
+}

--- a/kernel/geom/offset_surface_test.go
+++ b/kernel/geom/offset_surface_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestOffsetSurfaceDefiningProperty checks the parallel-surface identities on a cylinder: a point of
+// the offset surface is the base point displaced by Distance along the base normal, and the offset
+// normal equals the base normal. Exercised over several (u,v) and both offset directions.
+func TestOffsetSurfaceDefiningProperty(t *testing.T) {
+	cyl, err := NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, d := range []float64{2, -1.5} {
+		off := OffsetSurface{Base: cyl, Distance: d}
+		for _, u := range []float64{0, 1, 2.5, 4} {
+			for _, v := range []float64{-3, 0, 6} {
+				want := cyl.PointAt(u, v).TranslateBy(cyl.NormalAt(u, v).Scale(math.Scalar(d)))
+				if got := off.PointAt(u, v); got.DistanceTo(want) > 1e-9 {
+					t.Errorf("d=%g PointAt(%g,%g) off by %g", d, u, v, got.DistanceTo(want))
+				}
+				if n, bn := off.NormalAt(u, v), cyl.NormalAt(u, v); n.Add(bn.Scale(-1)).Length() > 1e-12 {
+					t.Errorf("d=%g NormalAt(%g,%g) != base normal", d, u, v)
+				}
+				// A point of the offset cylinder lies at radius (5+d) from the Z axis.
+				p := off.PointAt(u, v)
+				if r := stdmath.Hypot(float64(p.X), float64(p.Y)); stdmath.Abs(r-(5+d)) > 1e-9 {
+					t.Errorf("d=%g radius = %g, want %g", d, r, 5+d)
+				}
+			}
+		}
+	}
+}

--- a/kernel/ops/offset_faces.go
+++ b/kernel/ops/offset_faces.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+)
+
+// OffsetFaces returns a sheet body holding just the named faces of b, each on its surface offset by
+// distance along the face's outward (material) normal. It is the surface-offset primitive CAM uses
+// for 3D surfacing tool compensation: offset the part face by the tool radius, then sample the result
+// for drop-cutter projection. reverse offsets the opposite way (into the solid).
+//
+// Each face keeps its loops; only the surface is swapped for a geom.OffsetSurface. Because the offset
+// surface shares the base's (u,v) parameterization and ParamAt, the trimmed-face tessellator
+// re-evaluates the same UV region on the offset surface — so the offset face tessellates and samples
+// correctly with no edge surgery. The result is a surface (non-solid) body.
+func OffsetFaceSurfaces(b *topo.Body, faceKeys [][]byte, distance float64, reverse bool) (*topo.Body, error) {
+	if len(faceKeys) == 0 {
+		return nil, fmt.Errorf("ops.OffsetFaceSurfaces: no faces selected")
+	}
+	// Swap each selected face's surface for its offset while the body is still the original solid
+	// (single shell), then keep only those faces — so ReplaceFaceSurface never sees a split body.
+	out := b
+	for _, key := range faceKeys {
+		f, ok := out.FindFaceByKey(key)
+		if !ok {
+			return nil, fmt.Errorf("ops.OffsetFaceSurfaces: no face with key %x", key)
+		}
+		off := geom.OffsetSurface{Base: f.Geometry(), Distance: signedOffset(distance, reverse, f.Reversed())}
+		var err error
+		if out, err = ReplaceFaceSurface(out, key, off); err != nil {
+			return nil, fmt.Errorf("ops.OffsetFaceSurfaces: offset face %x: %w", key, err)
+		}
+	}
+	kept, err := DropFaces(out, faceKeys, true)
+	if err != nil {
+		return nil, fmt.Errorf("ops.OffsetFaceSurfaces: isolate offset faces: %w", err)
+	}
+	return kept, nil
+}
+
+// signedOffset resolves the offset distance so a positive distance moves the face along its OUTWARD
+// (material) normal: reverse flips it, and a reversed face (whose surface normal points into material)
+// flips it again, so the surface offset always runs away from the solid for a positive distance.
+func signedOffset(distance float64, reverse, faceReversed bool) float64 {
+	if reverse {
+		distance = -distance
+	}
+	if faceReversed {
+		distance = -distance
+	}
+	return distance
+}

--- a/kernel/ops/offset_faces_test.go
+++ b/kernel/ops/offset_faces_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// meshArea sums the triangle areas of a mesh.
+func meshArea(m *ops.Mesh) float64 {
+	area := 0.0
+	for i := 0; i+2 < len(m.Indices); i += 3 {
+		a, b, c := m.Positions[m.Indices[i]], m.Positions[m.Indices[i+1]], m.Positions[m.Indices[i+2]]
+		area += 0.5 * float64(a.VectorTo(b).Cross(a.VectorTo(c)).Length())
+	}
+	return area
+}
+
+// cylindricalFaceKey returns the reference key of the body's lateral cylindrical face.
+func cylindricalFaceKey(t *testing.T, b *topo.Body) []byte {
+	t.Helper()
+	for _, f := range b.Faces() {
+		if _, ok := f.Geometry().(geom.Cylinder); ok {
+			return f.ReferenceKey()
+		}
+	}
+	t.Fatal("no cylindrical face found")
+	return nil
+}
+
+// TestOffsetFaceSurfacesCylinderArea is the offset oracle: offsetting a radius-5, height-10 cylinder's
+// lateral face outward by 2 yields a radius-7 cylindrical surface, whose tessellated area must match
+// the analytic lateral area 2π·7·10 (per the tessellation-correctness rule, validated against the
+// closed form). The reverse direction gives the radius-3 inner surface (2π·3·10).
+func TestOffsetFaceSurfacesCylinderArea(t *testing.T) {
+	const r, h = 5.0, 10.0
+	body, err := brep.SolidCylinderCone(math.P3(0, 0, 0), math.P3(0, 0, h), r, r, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := cylindricalFaceKey(t, body)
+
+	cases := []struct {
+		name    string
+		dist    float64
+		reverse bool
+		wantR   float64
+	}{
+		{"outward", 2, false, r + 2},
+		{"inward", 2, true, r - 2},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			off, err := ops.OffsetFaceSurfaces(body, [][]byte{key}, c.dist, c.reverse)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(off.Faces()) != 1 {
+				t.Fatalf("offset body has %d faces, want 1 (just the offset wall)", len(off.Faces()))
+			}
+			got := meshArea(ops.TessellateFace(off.Faces()[0], ops.DefaultQuality()))
+			want := 2 * stdmath.Pi * c.wantR * h
+			if stdmath.Abs(got-want)/want > 0.02 {
+				t.Errorf("offset (%s) area = %.3f, want %.3f (2π·%g·%g)", c.name, got, want, c.wantR, h)
+			}
+		})
+	}
+
+	if _, err := ops.OffsetFaceSurfaces(body, nil, 1, false); err == nil {
+		t.Error("offsetting no faces must error")
+	}
+}

--- a/kernel/ops/offset_faces_test.go
+++ b/kernel/ops/offset_faces_test.go
@@ -76,4 +76,7 @@ func TestOffsetFaceSurfacesCylinderArea(t *testing.T) {
 	if _, err := ops.OffsetFaceSurfaces(body, nil, 1, false); err == nil {
 		t.Error("offsetting no faces must error")
 	}
+	if _, err := ops.OffsetFaceSurfaces(body, [][]byte{[]byte("nope")}, 1, false); err == nil {
+		t.Error("offsetting an unknown face key must error")
+	}
 }


### PR DESCRIPTION
## What

Implements `brep.offsetFaces` (api **v0.87.0**) — **the last public-API gap of the CAM port** (`cam-port/gaps.md` Gap 3). Offset a body's named faces by a distance along their normals into a transient **surface body** to sample (3D surfacing tool compensation: offset the part by the tool radius, then drop the tool onto the offset).

## How

- **`geom.OffsetSurface`** — the parallel surface `S(u,v) + d·N(u,v)` of a base surface. It shares the base's `(u,v)` parameterization, `NormalAt`, and `ParamAt`. That's the key: a face is offset by **swapping its surface for the offset and keeping its loops** — the trimmed-face tessellator projects the loop to `(u,v)` through `ParamAt` and re-evaluates the **same UV region** on the offset surface, so the offset geometry comes out correct with **no edge/loop surgery**. Exact for the analytic surfaces (plane/cylinder/sphere/cone/torus); first derivatives use the base's exact partials plus a central-difference of the normal field.
- **`ops.OffsetFaceSurfaces`** — swaps each selected face's surface (along its outward normal; `reverse` offsets into the solid) via the existing `ReplaceFaceSurface`, then isolates them into a surface body.
- **`addin/router` `brep.offsetFaces`** — resolves the source + face keys → `OffsetFaceSurfaces` → a new transient body.

## Oracle / tests

- `geom`: the parallel-surface identities on a cylinder (point at radius `r±d`, normal preserved).
- `ops`: **tessellation oracle** — a radius-5 cylinder face offset by ±2 tessellates to the analytic lateral area `2π·7·10` / `2π·3·10` (within 2%), validating the offset geometry end-to-end (per the tessellation-correctness rule).
- `addin/router`: offsets an extruded disc's side face → a one-face transient surface body.

Pins api v0.87.0. With this the CAM port's three architectural API gaps (Gap 1 client-side, Gap 2 `body.faceEvaluate`, Gap 3 `brep.offsetFaces`) are all closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)