### PR TITLE
H06: startup telemetry upload + opt-out preference (#1188)

### DIFF
--- a/app/options/options.go
+++ b/app/options/options.go
@@ -59,15 +59,24 @@ type Updates struct {
 	CheckOnStartup bool `yaml:"checkOnStartup"`
 }
 
+// Telemetry is the anonymous usage-statistics behavior (#1182). When ShareUsageStatistics is
+// on, the head submits one anonymous installation snapshot (OS, hardware, version, installed
+// add-ins) to stats.oblikovati.org during the startup update-check. It is opt-out: on by
+// default, toggled from the same preferences surface as the update check.
+type Telemetry struct {
+	ShareUsageStatistics bool `yaml:"shareUsageStatistics"`
+}
+
 // All is every persisted option group. The ViewCube/display preferences live in
 // their own store (persistence/userprefs) and the color scheme in the theme store —
 // the options surface proxies those rather than duplicating their persistence.
 type All struct {
-	General General `yaml:"general"`
-	Sketch  Sketch  `yaml:"sketch"`
-	Part    Part    `yaml:"part"`
-	Save    Save    `yaml:"save"`
-	Updates Updates `yaml:"updates"`
+	General   General   `yaml:"general"`
+	Sketch    Sketch    `yaml:"sketch"`
+	Part      Part      `yaml:"part"`
+	Save      Save      `yaml:"save"`
+	Updates   Updates   `yaml:"updates"`
+	Telemetry Telemetry `yaml:"telemetry"`
 }
 
 // Defaults returns the out-of-the-box options, mirroring the session's historical
@@ -75,11 +84,12 @@ type All struct {
 // launch) so a fresh install behaves exactly as before this file existed.
 func Defaults() All {
 	return All{
-		General: General{StartupAction: types.StartupNewPart},
-		Sketch:  Sketch{GridSpacingCm: 1, GridVisible: true, GridMajorEvery: 5, SnapToPoints: true, SnapToGrid: true, HeadsUpDisplay: true},
-		Part:    Part{ChamferFlatCorners: true},
-		Save:    Save{Thumbnail: types.ThumbnailNone},
-		Updates: Updates{CheckOnStartup: true},
+		General:   General{StartupAction: types.StartupNewPart},
+		Sketch:    Sketch{GridSpacingCm: 1, GridVisible: true, GridMajorEvery: 5, SnapToPoints: true, SnapToGrid: true, HeadsUpDisplay: true},
+		Part:      Part{ChamferFlatCorners: true},
+		Save:      Save{Thumbnail: types.ThumbnailNone},
+		Updates:   Updates{CheckOnStartup: true},
+		Telemetry: Telemetry{ShareUsageStatistics: true},
 	}
 }
 

--- a/app/telemetry_pref.go
+++ b/app/telemetry_pref.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "oblikovati.org/app/options"
+
+// Anonymous usage-statistics surface (#1182). The session owns the user-visible opt-out
+// preference; the head reads it before submitting an installation snapshot during the
+// startup update-check (the network I/O lives in the head, off the UI thread, exactly like
+// the update check — see usagestats and head/cmd/oblikovati-head/metrics.go).
+
+// TelemetryEnabled reports whether anonymous usage statistics may be shared (the persisted
+// Telemetry.ShareUsageStatistics preference, on by default — it is opt-out).
+func (s *Session) TelemetryEnabled() bool { return s.appOptions.Telemetry.ShareUsageStatistics }
+
+// SetTelemetryEnabled stores the usage-statistics opt-out preference, persisting it to the
+// user's options file.
+func (s *Session) SetTelemetryEnabled(on bool) error {
+	s.appOptions.Telemetry = options.Telemetry{ShareUsageStatistics: on}
+	return s.saveOptions()
+}

--- a/app/telemetry_pref_test.go
+++ b/app/telemetry_pref_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "testing"
+
+func TestTelemetryEnabledDefaultsOn(t *testing.T) {
+	if !NewSession().TelemetryEnabled() {
+		t.Fatal("telemetry must default to on (opt-out)")
+	}
+}
+
+func TestSetTelemetryEnabledTogglesAndPersists(t *testing.T) {
+	s := NewSession()
+	if err := s.SetTelemetryEnabled(false); err != nil {
+		t.Fatalf("SetTelemetryEnabled(false): %v", err)
+	}
+	if s.TelemetryEnabled() {
+		t.Error("telemetry should be off after opting out")
+	}
+	if err := s.SetTelemetryEnabled(true); err != nil {
+		t.Fatalf("SetTelemetryEnabled(true): %v", err)
+	}
+	if !s.TelemetryEnabled() {
+		t.Error("telemetry should be on again after re-enabling")
+	}
+}

--- a/head/cmd/oblikovati-head/main.go
+++ b/head/cmd/oblikovati-head/main.go
@@ -67,8 +67,9 @@ func run(session *app.Session, maxFrames int) error {
 	ui.SetScriptMethods(addins.methods)   // seed the editor's autocomplete with the host API
 
 	updates := newUpdatePoller()
-	startupUpdateCheck(session, updates) // silent check on launch (honors the user's preference)
-	reportUsage(session, win)            // anonymous installation telemetry, opt-out (#1182)
+	startupUpdateCheck(session, updates)     // silent check on launch (honors the user's preference)
+	gpu, vulkanVersion := win.GPUInfo()      // read once from the live renderer for telemetry
+	reportUsage(session, gpu, vulkanVersion) // anonymous installation telemetry, opt-out (#1182)
 
 	for frame := 0; ; frame++ {
 		if maxFrames > 0 && frame >= maxFrames {

--- a/head/cmd/oblikovati-head/main.go
+++ b/head/cmd/oblikovati-head/main.go
@@ -68,6 +68,7 @@ func run(session *app.Session, maxFrames int) error {
 
 	updates := newUpdatePoller()
 	startupUpdateCheck(session, updates) // silent check on launch (honors the user's preference)
+	reportUsage(session, win)            // anonymous installation telemetry, opt-out (#1182)
 
 	for frame := 0; ; frame++ {
 		if maxFrames > 0 && frame >= maxFrames {

--- a/head/cmd/oblikovati-head/metrics.go
+++ b/head/cmd/oblikovati-head/metrics.go
@@ -1,0 +1,87 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package main
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"runtime"
+	"time"
+
+	"oblikovati.org/addincat"
+	"oblikovati.org/app"
+	"oblikovati.org/build"
+	"oblikovati.org/head/internal/native"
+	"oblikovati.org/usagestats"
+)
+
+// usageReportTimeout bounds the telemetry upload so a slow or missing network never strands
+// the goroutine (the submit is best-effort — offline and errors are silently dropped).
+const usageReportTimeout = 8 * time.Second
+
+// reportUsage submits one anonymous installation snapshot during startup, off the UI thread,
+// when the user has not opted out (#1182). It is fire-and-forget: telemetry must never block
+// launch or surface an error. The GPU/Vulkan strings come from the live renderer; everything
+// else from usagestats. OBLIKOVATI_STATS_ENDPOINT overrides the service URL (for dev/tests).
+func reportUsage(session *app.Session, win *native.Window) {
+	if !session.TelemetryEnabled() {
+		return
+	}
+	gpu, vulkanVersion := win.GPUInfo()
+	snap := assembleSnapshot(gpu, vulkanVersion)
+	go func() { _ = submitSnapshot(snap) }() // best-effort; offline/errors intentionally dropped
+}
+
+// submitSnapshot POSTs one snapshot to the telemetry service, honoring the
+// OBLIKOVATI_STATS_ENDPOINT override (default stats.oblikovati.org). Synchronous and
+// error-returning so it is unit-testable against a local server; reportUsage runs it on a
+// goroutine and ignores the result.
+func submitSnapshot(snap usagestats.Snapshot) error {
+	ctx, cancel := context.WithTimeout(context.Background(), usageReportTimeout)
+	defer cancel()
+	sub := usagestats.NewSubmitter(os.Getenv("OBLIKOVATI_STATS_ENDPOINT"), &http.Client{Timeout: usageReportTimeout})
+	return sub.Submit(ctx, snap)
+}
+
+// assembleSnapshot gathers the machine's anonymous installation snapshot. The GPU and Vulkan
+// version are passed in (only the renderer knows them); the rest comes from usagestats. It is
+// pure given those inputs, so the assembly is unit-tested without a window.
+func assembleSnapshot(gpu, vulkanVersion string) usagestats.Snapshot {
+	id, _ := usagestats.MachineUUID() // a generation failure just yields an empty id
+	hw := usagestats.GatherHardware()
+	return usagestats.Snapshot{
+		MachineUUID:   id,
+		OS:            runtime.GOOS,
+		Arch:          runtime.GOARCH,
+		RAMBytes:      hw.RAMBytes,
+		CPU:           hw.CPU,
+		CPUCores:      hw.CPUCores,
+		StorageBytes:  hw.StorageBytes,
+		GPU:           gpu,
+		VulkanVersion: vulkanVersion,
+		AppVersion:    build.Version,
+		AddIns:        installedAddInsForTelemetry(),
+	}
+}
+
+// installedAddInsForTelemetry lists the user's installed add-ins (id + version) for the
+// snapshot, reusing the catalogue installer's scan of the user add-ins directory. Any
+// resolution error yields no add-ins rather than failing the snapshot.
+func installedAddInsForTelemetry() []usagestats.AddIn {
+	dir, err := addincat.UserAddInsDir()
+	if err != nil {
+		return nil
+	}
+	installed, err := addincat.NewInstaller(dir, nil).Installed()
+	if err != nil {
+		return nil
+	}
+	out := make([]usagestats.AddIn, 0, len(installed))
+	for _, a := range installed {
+		out = append(out, usagestats.AddIn{ID: a.Name, Version: a.Version})
+	}
+	return out
+}

--- a/head/cmd/oblikovati-head/metrics.go
+++ b/head/cmd/oblikovati-head/metrics.go
@@ -14,7 +14,6 @@ import (
 	"oblikovati.org/addincat"
 	"oblikovati.org/app"
 	"oblikovati.org/build"
-	"oblikovati.org/head/internal/native"
 	"oblikovati.org/usagestats"
 )
 
@@ -24,13 +23,13 @@ const usageReportTimeout = 8 * time.Second
 
 // reportUsage submits one anonymous installation snapshot during startup, off the UI thread,
 // when the user has not opted out (#1182). It is fire-and-forget: telemetry must never block
-// launch or surface an error. The GPU/Vulkan strings come from the live renderer; everything
-// else from usagestats. OBLIKOVATI_STATS_ENDPOINT overrides the service URL (for dev/tests).
-func reportUsage(session *app.Session, win *native.Window) {
+// launch or surface an error. The GPU/Vulkan strings come from the live renderer (read by the
+// caller, the only holder of the window); everything else from usagestats.
+// OBLIKOVATI_STATS_ENDPOINT overrides the service URL (for dev/tests).
+func reportUsage(session *app.Session, gpu, vulkanVersion string) {
 	if !session.TelemetryEnabled() {
 		return
 	}
-	gpu, vulkanVersion := win.GPUInfo()
 	snap := assembleSnapshot(gpu, vulkanVersion)
 	go func() { _ = submitSnapshot(snap) }() // best-effort; offline/errors intentionally dropped
 }

--- a/head/cmd/oblikovati-head/metrics_test.go
+++ b/head/cmd/oblikovati-head/metrics_test.go
@@ -1,0 +1,100 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"oblikovati.org/build"
+	"oblikovati.org/usagestats"
+)
+
+func TestAssembleSnapshotFillsPlatformAndRenderer(t *testing.T) {
+	t.Setenv("OBK_USER_GLOBALS_FILE", filepath.Join(t.TempDir(), "globals"))
+	t.Setenv("OBK_USER_ADDINS_DIR", t.TempDir()) // no add-ins installed
+
+	snap := assembleSnapshot("llvmpipe", "1.3.255")
+	if snap.OS != runtime.GOOS || snap.Arch != runtime.GOARCH {
+		t.Errorf("OS/Arch = %s/%s, want %s/%s", snap.OS, snap.Arch, runtime.GOOS, runtime.GOARCH)
+	}
+	if snap.GPU != "llvmpipe" || snap.VulkanVersion != "1.3.255" {
+		t.Errorf("renderer fields not carried: GPU=%q Vulkan=%q", snap.GPU, snap.VulkanVersion)
+	}
+	if snap.AppVersion != build.Version {
+		t.Errorf("AppVersion = %q, want build.Version %q", snap.AppVersion, build.Version)
+	}
+	if snap.MachineUUID == "" {
+		t.Error("MachineUUID should be generated")
+	}
+	if snap.CPUCores < 1 {
+		t.Errorf("CPUCores = %d, want >= 1", snap.CPUCores)
+	}
+}
+
+func TestInstalledAddInsForTelemetryReadsUserDir(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("OBK_USER_ADDINS_DIR", dir)
+	// Two installed add-ins, each a subdir with a manifest.json.
+	writeManifest(t, filepath.Join(dir, "cam"), `{"id":"com.oblikovati.cam","version":"0.6.0"}`)
+	writeManifest(t, filepath.Join(dir, "mcp"), `{"id":"com.oblikovati.mcp-bridge","version":"0.2.0"}`)
+
+	got := installedAddInsForTelemetry()
+	if len(got) != 2 {
+		t.Fatalf("found %d add-ins, want 2: %+v", len(got), got)
+	}
+	ids := map[string]string{}
+	for _, a := range got {
+		ids[a.ID] = a.Version
+	}
+	if ids["com.oblikovati.cam"] != "0.6.0" || ids["com.oblikovati.mcp-bridge"] != "0.2.0" {
+		t.Errorf("add-in id/version map wrong: %v", ids)
+	}
+}
+
+func TestInstalledAddInsForTelemetryEmptyDir(t *testing.T) {
+	t.Setenv("OBK_USER_ADDINS_DIR", t.TempDir())
+	if got := installedAddInsForTelemetry(); len(got) != 0 {
+		t.Errorf("empty dir yielded %d add-ins, want 0", len(got))
+	}
+}
+
+func TestSubmitSnapshotPostsToConfiguredEndpoint(t *testing.T) {
+	var gotAuth string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	t.Setenv("OBLIKOVATI_STATS_ENDPOINT", srv.URL)
+
+	snap := usagestats.Snapshot{MachineUUID: "m", OS: "linux", Arch: "amd64", AppVersion: "0.1.0"}
+	if err := submitSnapshot(snap); err != nil {
+		t.Fatalf("submitSnapshot: %v", err)
+	}
+	if len(gotBody) == 0 {
+		t.Fatal("server received no body")
+	}
+	if gotAuth != usagestats.Token(gotBody) {
+		t.Errorf("authorization %q is not the CRC of the body", gotAuth)
+	}
+}
+
+func writeManifest(t *testing.T, dir, body string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "manifest.json"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+}

--- a/head/cmd/oblikovati-head/metrics_test.go
+++ b/head/cmd/oblikovati-head/metrics_test.go
@@ -11,8 +11,11 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
+	"time"
 
+	"oblikovati.org/app"
 	"oblikovati.org/build"
 	"oblikovati.org/usagestats"
 )
@@ -86,6 +89,43 @@ func TestSubmitSnapshotPostsToConfiguredEndpoint(t *testing.T) {
 	}
 	if gotAuth != usagestats.Token(gotBody) {
 		t.Errorf("authorization %q is not the CRC of the body", gotAuth)
+	}
+}
+
+func TestReportUsageHonorsOptOut(t *testing.T) {
+	t.Setenv("OBK_USER_GLOBALS_FILE", filepath.Join(t.TempDir(), "globals"))
+	t.Setenv("OBK_USER_ADDINS_DIR", t.TempDir())
+	got := make(chan string, 4)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		got <- string(b)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	t.Setenv("OBLIKOVATI_STATS_ENDPOINT", srv.URL)
+
+	// Opted out: must not post (reportUsage returns before spawning the upload).
+	off := app.NewSession()
+	if err := off.SetTelemetryEnabled(false); err != nil {
+		t.Fatalf("opt out: %v", err)
+	}
+	reportUsage(off, "gpu", "1.0")
+
+	// Default (opted in): must post the snapshot, carrying the renderer's GPU string.
+	reportUsage(app.NewSession(), "llvmpipe", "1.4.318")
+	select {
+	case body := <-got:
+		if !strings.Contains(body, "llvmpipe") {
+			t.Errorf("posted body missing GPU: %s", body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("opted-in telemetry did not post")
+	}
+	// No second request: the opted-out session must have sent nothing.
+	select {
+	case extra := <-got:
+		t.Errorf("opted-out session posted a snapshot: %s", extra)
+	case <-time.After(200 * time.Millisecond):
 	}
 }
 

--- a/head/internal/native/app.cpp
+++ b/head/internal/native/app.cpp
@@ -446,6 +446,25 @@ void obk_head_end_frame(void* h, float r, float g, float b) {
     }
 }
 
+// obk_head_gpu_info reports the selected physical device's name and Vulkan API version for
+// anonymous installation telemetry (#1182). nameOut is filled NUL-terminated up to nameCap
+// bytes; apiVersionOut receives the raw VkPhysicalDeviceProperties.apiVersion (the Go side
+// formats major.minor.patch). On macOS the device runs over MoltenVK, so this reports the
+// MoltenVK-backed Vulkan version. Safe any time after obk_head_create; yields ""/0 if no
+// device was selected.
+void obk_head_gpu_info(void* h, char* nameOut, int nameCap, unsigned int* apiVersionOut) {
+    HeadContext* c = (HeadContext*)h;
+    if (apiVersionOut) *apiVersionOut = 0;
+    if (nameCap > 0) nameOut[0] = '\0';
+    if (!c || c->physical == VK_NULL_HANDLE) return;
+    VkPhysicalDeviceProperties props;
+    vkGetPhysicalDeviceProperties(c->physical, &props);
+    if (apiVersionOut) *apiVersionOut = props.apiVersion;
+    int i = 0;
+    for (; i + 1 < nameCap && props.deviceName[i] != '\0'; i++) nameOut[i] = props.deviceName[i];
+    if (nameCap > 0) nameOut[i] = '\0';
+}
+
 void obk_head_destroy(void* h) {
     HeadContext* c = (HeadContext*)h;
     if (!c) return;

--- a/head/internal/native/native.go
+++ b/head/internal/native/native.go
@@ -24,11 +24,13 @@ void  obk_head_end_frame(void* h, float r, float g, float b);
 void  obk_head_destroy(void* h);
 void  obk_head_get_window_state(void* h, int* x, int* y, int* w, int* hh, int* maximized);
 void  obk_head_apply_window_state(void* h, int x, int y, int maximized);
+void  obk_head_gpu_info(void* h, char* nameOut, int nameCap, unsigned int* apiVersionOut);
 */
 import "C"
 
 import (
 	"errors"
+	"fmt"
 	"unsafe"
 )
 
@@ -94,6 +96,26 @@ func (w *Window) BeginFrame() { C.obk_head_begin_frame(w.handle) }
 // background color) and presents it.
 func (w *Window) EndFrame(r, g, b float32) {
 	C.obk_head_end_frame(w.handle, C.float(r), C.float(g), C.float(b))
+}
+
+// GPUInfo reports the selected Vulkan physical device's name and API version (formatted
+// "major.minor.patch"), for anonymous installation telemetry (#1182). On macOS the device
+// runs over MoltenVK, so the version is the MoltenVK-backed Vulkan version. Both are "" when
+// no device is available (e.g. a software-only or torn-down window).
+func (w *Window) GPUInfo() (name, vulkanVersion string) {
+	var buf [256]C.char
+	var apiVer C.uint
+	C.obk_head_gpu_info(w.handle, &buf[0], C.int(len(buf)), &apiVer)
+	return C.GoString(&buf[0]), formatVulkanVersion(uint32(apiVer))
+}
+
+// formatVulkanVersion renders a packed VkPhysicalDeviceProperties.apiVersion as
+// "major.minor.patch" (the Vulkan version bit layout), or "" for a zero (no device) value.
+func formatVulkanVersion(v uint32) string {
+	if v == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d.%d.%d", (v>>22)&0x7f, (v>>12)&0x3ff, v&0xfff)
 }
 
 // Destroy tears down ImGui, the Vulkan device, and the window.

--- a/head/ui/preferences_privacy_inwindow_test.go
+++ b/head/ui/preferences_privacy_inwindow_test.go
@@ -31,3 +31,24 @@ func TestInWindowPrivacyTabDraws(t *testing.T) {
 		t.Error("telemetry must remain on by default when no opt-out click is injected")
 	}
 }
+
+// TestInWindowPreferencesWindowOpensWithPrivacyTab drives the full Preferences window (the tab
+// wiring, including the new Privacy tab) for a few real frames, so drawPreferencesWindow's
+// branch that mounts the Privacy tab is exercised. It is a smoke render — it asserts no panic
+// and that the window state flag round-trips.
+func TestInWindowPreferencesWindowOpensWithPrivacyTab(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	s := app.NewSession()
+
+	showPreferences = true
+	defer func() { showPreferences = false }()
+	for i := 0; i < 3; i++ { // a few frames so the tab bar settles
+		win.BeginFrame()
+		drawPreferencesWindow(s)
+		win.EndFrame(0.1, 0.1, 0.1)
+	}
+	if !showPreferences {
+		t.Error("Preferences window should still be open")
+	}
+}

--- a/head/ui/preferences_privacy_inwindow_test.go
+++ b/head/ui/preferences_privacy_inwindow_test.go
@@ -1,0 +1,33 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// TestInWindowPrivacyTabDraws renders the Preferences Privacy tab in a real frame so the
+// telemetry opt-out toggle's draw path is exercised (#1182). It asserts the default stays on
+// when no click is injected; the toggle behavior itself is covered by the app-level
+// SetTelemetryEnabled test. Skips when no display/Vulkan is available (e.g. some CI lanes).
+func TestInWindowPrivacyTabDraws(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	s := app.NewSession()
+
+	win.BeginFrame()
+	if native.Begin("##privacy-tab-test") {
+		drawPrivacyTab(s)
+	}
+	native.End()
+	win.EndFrame(0.1, 0.1, 0.1)
+
+	if !s.TelemetryEnabled() {
+		t.Error("telemetry must remain on by default when no opt-out click is injected")
+	}
+}

--- a/head/ui/preferences_window.go
+++ b/head/ui/preferences_window.go
@@ -31,6 +31,10 @@ func drawPreferencesWindow(s *app.Session) {
 			drawGeneralTab(s)
 			native.EndTabItem()
 		}
+		if native.BeginTabItem("Privacy") {
+			drawPrivacyTab(s)
+			native.EndTabItem()
+		}
 		if native.BeginTabItem("Sketch Grid") {
 			drawGridTab(s)
 			native.EndTabItem()
@@ -46,6 +50,18 @@ func drawPreferencesWindow(s *app.Session) {
 		native.EndTabBar()
 	}
 	native.End()
+}
+
+// drawPrivacyTab renders the anonymous usage-statistics opt-out (#1182). Telemetry is on by
+// default; unchecking it stops the startup snapshot upload to stats.oblikovati.org.
+func drawPrivacyTab(s *app.Session) {
+	native.Text("Oblikovati can share anonymous usage statistics to guide development.")
+	native.Text("No personal data is collected — only OS, hardware, version and installed add-ins.")
+	native.Separator()
+	share := s.TelemetryEnabled()
+	if native.Checkbox("Share anonymous usage statistics", &share) {
+		reportPrefError(s.SetTelemetryEnabled(share))
+	}
 }
 
 // drawModelingTab renders modeling-feature preferences (the default chamfer corner


### PR DESCRIPTION
Part of #1182 (M33). Wires the usagestats pipeline (H05) into the head and adds the opt-out control.

## What
- `options.Telemetry{ShareUsageStatistics}` (default **on**) + `Session.TelemetryEnabled/SetTelemetryEnabled`; a **Privacy** tab in Preferences toggles it ("Share anonymous usage statistics").
- `head/cmd/oblikovati-head/metrics.go`: at startup, when not opted out, assemble the snapshot (machine UUID + hardware + `build.Version` + installed add-ins + the live renderer's GPU name and Vulkan/MoltenVK version) and POST it **off the UI thread**, best-effort (offline/errors dropped). `OBLIKOVATI_STATS_ENDPOINT` override.
- Native `obk_head_gpu_info` reads the selected `VkPhysicalDevice` name + apiVersion; `native.Window.GPUInfo` exposes them to Go (formatted major.minor.patch).

## Verification
`go test` (options default, Session toggle, snapshot assembly, installed-add-in scan, submit-to-endpoint) + an in-window Privacy-tab draw test. **Live-confirmed over Vulkan (lavapipe):** the running head reported GPU `llvmpipe (LLVM 20.1.2, 256 bits)` / Vulkan `1.4.318` to a local stats service; with the opt-out set, **nothing is sent** (0 installs).