### PR TITLE
fix(compdef): share part parameter DAG into restored sketches

### DIFF
--- a/model/compdef/part.go
+++ b/model/compdef/part.go
@@ -98,8 +98,10 @@ func NewPartComponentDefinition() *PartComponentDefinition {
 		props:       attr.NewPropertySets(),
 		pointClouds: pointcloud.NewPointClouds(),
 	}
-	d.features.SetResourceStore(d) // re-derive imported bodies from the resource table on open
-	d.features.SetFontResolver(d)  // resolve text/emboss fonts from embedded/app-provided resources
+	d.features.SetResourceStore(d)       // re-derive imported bodies from the resource table on open
+	d.features.SetFontResolver(d)        // resolve text/emboss fonts from embedded/app-provided resources
+	d.sketches.ShareParameters(params)   // dimension expressions resolve against user params (live + restore)
+	d.sketches3D.ShareParameters(params) // same for 3D sketches
 	return d
 }
 

--- a/model/compdef/sketch_param_dimension_test.go
+++ b/model/compdef/sketch_param_dimension_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef_test
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/sketch"
+)
+
+// TestParameterDrivenDimensionResolvesAfterRestore guards the part restore path against a
+// regression where a restored sketch kept its own empty parameter set, so a dimension
+// expression that references a user parameter ("width") resolved to 0 and collapsed the
+// geometry. The fix shares the part's parameter DAG into every sketch at creation
+// (compdef wires it via Sketches.ShareParameters), mirroring the live and assembly paths.
+func TestParameterDrivenDimensionResolvesAfterRestore(t *testing.T) {
+	src := compdef.NewPartComponentDefinition()
+	if _, err := src.Parameters().AddUserParameter("width", "40 mm"); err != nil {
+		t.Fatalf("AddUserParameter: %v", err)
+	}
+	s := src.Sketches().Add(sketch.XYPlane())
+	a := s.Points().Add(math.P2(0, 0))
+	b := s.Points().Add(math.P2(4, 0)) // 4 cm == 40 mm
+	if _, err := s.DimensionConstraints().AddDistance(a, b, "width"); err != nil {
+		t.Fatalf("AddDistance: %v", err)
+	}
+
+	model, err := src.MarshalRecipe()
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	dst := compdef.NewPartComponentDefinition()
+	if err := dst.ApplyRecipe(model); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+
+	got := dst.Sketches().Item(0).DimensionConstraints().Item(0)
+	// 40 mm resolves to 4 db units; a regression makes "width" unknown → ~0.
+	if measured := got.Measured(); measured < 3.999 || measured > 4.001 {
+		t.Errorf("restored param-driven dimension measured %v, want ~4 (40 mm)", measured)
+	}
+}

--- a/model/compdef/sketch_param_dimension_test.go
+++ b/model/compdef/sketch_param_dimension_test.go
@@ -42,3 +42,34 @@ func TestParameterDrivenDimensionResolvesAfterRestore(t *testing.T) {
 		t.Errorf("restored param-driven dimension measured %v, want ~4 (40 mm)", measured)
 	}
 }
+
+// TestParameterDriven3DDimensionResolvesAfterRestore is the 3D-sketch counterpart: the
+// same parameter-DAG sharing must reach restored 3D sketches (Sketches3D.ShareParameters,
+// wired in NewPartComponentDefinition), so a 3D dimension expression that references a user
+// parameter resolves on reopen instead of collapsing to 0.
+func TestParameterDriven3DDimensionResolvesAfterRestore(t *testing.T) {
+	src := compdef.NewPartComponentDefinition()
+	if _, err := src.Parameters().AddUserParameter("len", "40 mm"); err != nil {
+		t.Fatalf("AddUserParameter: %v", err)
+	}
+	s := src.Sketches3D().Add()
+	a := s.AddPoint3D(math.P3(0, 0, 0))
+	b := s.AddPoint3D(math.P3(4, 0, 0)) // 4 cm == 40 mm
+	if _, err := s.DimensionConstraints3D().AddDistance(a, b, "len"); err != nil {
+		t.Fatalf("AddDistance(3D): %v", err)
+	}
+
+	model, err := src.MarshalRecipe()
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	dst := compdef.NewPartComponentDefinition()
+	if err := dst.ApplyRecipe(model); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+
+	got := dst.Sketches3D().Item(0).DimensionConstraints3D().Item(0)
+	if measured := got.Measured(); measured < 3.999 || measured > 4.001 {
+		t.Errorf("restored param-driven 3D dimension measured %v, want ~4 (40 mm)", measured)
+	}
+}

--- a/model/sketch/share_parameters_test.go
+++ b/model/sketch/share_parameters_test.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"testing"
+
+	"oblikovati.org/model/param"
+)
+
+// TestSketchesShareParametersWiresNewSketch covers the fix: a collection given a shared
+// parameter DAG hands it to every sketch it creates (so dimensions resolve), and a bare
+// collection leaves a sketch with its own set.
+func TestSketchesShareParametersWiresNewSketch(t *testing.T) {
+	ps := param.NewParameters()
+	shared := NewSketches()
+	shared.ShareParameters(ps)
+	if got := shared.Add(XYPlane()).Parameters(); got != ps {
+		t.Errorf("shared collection: sketch params = %p, want the shared set %p", got, ps)
+	}
+
+	bare := NewSketches()
+	if got := bare.Add(XYPlane()).Parameters(); got == nil || got == ps {
+		t.Error("bare collection: sketch should keep its own non-shared parameter set")
+	}
+}
+
+// TestSketches3DShareParametersWiresNewSketch is the 3D counterpart.
+func TestSketches3DShareParametersWiresNewSketch(t *testing.T) {
+	ps := param.NewParameters()
+	shared := NewSketches3D()
+	shared.ShareParameters(ps)
+	if got := shared.Add().Parameters(); got != ps {
+		t.Errorf("shared 3D collection: sketch params = %p, want the shared set %p", got, ps)
+	}
+
+	bare := NewSketches3D()
+	if got := bare.Add().Parameters(); got == nil || got == ps {
+		t.Error("bare 3D collection: sketch should keep its own non-shared parameter set")
+	}
+}

--- a/model/sketch/sketch.go
+++ b/model/sketch/sketch.go
@@ -431,7 +431,17 @@ type Sketches struct {
 	// blockDefs is the part-level block-definition registry every sketch of
 	// the part places instances from (M06-F07, #622).
 	blockDefs *BlockDefinitions
+	// params is the document's parameter DAG, shared into every sketch added to the
+	// collection so dimension expressions referencing user parameters resolve. Nil for
+	// a bare collection (tests), which leaves each sketch with its own empty set.
+	params *param.Parameters
 }
+
+// ShareParameters makes the collection hand the document's parameter DAG to every
+// sketch it creates (live or on restore), so a dimension expression like "width"
+// resolves against user parameters. Wiring at creation matters: the restore path adds a
+// sketch's dimensions immediately, and SetParameters must precede them.
+func (c *Sketches) ShareParameters(ps *param.Parameters) { c.params = ps }
 
 // NewSketches returns an empty collection.
 func NewSketches() *Sketches {
@@ -473,6 +483,9 @@ func (c *Sketches) nameTaken(name string) bool {
 func (c *Sketches) AddNamed(name string, plane Plane) *Sketch {
 	s := &Sketch{base: newBase(name), plane: plane}
 	s.initCollections()
+	if c.params != nil {
+		s.SetParameters(c.params) // before any dimensions are added (live or on restore)
+	}
 	c.items = append(c.items, s)
 	c.byID[s.id] = s
 	return s

--- a/model/sketch/sketch3d.go
+++ b/model/sketch/sketch3d.go
@@ -217,15 +217,20 @@ func (s *Sketch3D) DegreesOfFreedom() int { return s.AnalyzeConstraints().DOF }
 
 // Sketches3D is the collection of 3D sketches owned by a component definition.
 type Sketches3D struct {
-	items []*Sketch3D
-	byID  map[ID]*Sketch3D
-	seq   int // running counter behind the "3D Sketch1", "3D Sketch2", … auto-names
+	items  []*Sketch3D
+	byID   map[ID]*Sketch3D
+	seq    int               // running counter behind the "3D Sketch1", "3D Sketch2", … auto-names
+	params *param.Parameters // shared into every 3D sketch so dimensions resolve (see Sketches.ShareParameters)
 }
 
 // NewSketches3D returns an empty collection.
 func NewSketches3D() *Sketches3D {
 	return &Sketches3D{byID: map[ID]*Sketch3D{}}
 }
+
+// ShareParameters makes the collection hand the document's parameter DAG to every 3D
+// sketch it creates, so dimension expressions resolve (mirrors [Sketches.ShareParameters]).
+func (c *Sketches3D) ShareParameters(ps *param.Parameters) { c.params = ps }
 
 // Add creates a 3D sketch with the next free auto-name ("3D Sketch1", "3D Sketch2", …).
 func (c *Sketches3D) Add() *Sketch3D { return c.AddNamed(c.nextName()) }
@@ -234,6 +239,9 @@ func (c *Sketches3D) Add() *Sketch3D { return c.AddNamed(c.nextName()) }
 func (c *Sketches3D) AddNamed(name string) *Sketch3D {
 	s := &Sketch3D{base: newBase(name)}
 	s.initSketch3D()
+	if c.params != nil {
+		s.SetParameters(c.params) // before any dimensions are added (live or on restore)
+	}
 	c.items = append(c.items, s)
 	c.byID[s.id] = s
 	return s


### PR DESCRIPTION
## What

Wire the part's parameter DAG into its `Sketches`/`Sketches3D` collections so every sketch they create — live or during restore — shares it **before** any dimensions are added.

## Why

A part's sketches each started with their own empty parameter set, and the part **restore** path never re-pointed them at the document's parameter DAG. Only the live creation paths (`addin/router/sketch.go`, `app/sketch_env.go`) and the **assembly** restore path (`model/compdef/assembly_serialize.go`) did this.

As a result, reopening a part whose sketch has a dimension expression that references a user parameter (e.g. `width`) left that expression unresolved: it evaluated to ~0, **collapsing the sketch geometry** so no closed profile was detected (an extrude on that profile would then fail/empty).

`Sketch.SetParameters` only re-points the store ("call before adding dimensions"), so wiring it *after* `ApplyRecipe` is too late — the dimension's backing parameter has already been created in the empty set. The fix shares the DAG at the collection level so it is applied at sketch creation, which is the point the restore path adds dimensions.

## How it was found

Surfaced while building an external exporter that emits native `.opd` parts with parameter-driven sketch dimensions: a fully-constrained rectangle (DOF 0) round-tripped to **4 zero-area open profiles** with `width`/`height` resolving to ~3e-9, while literal `40 mm`/`30 mm` worked. Tracing the resolution showed the restored sketch used its own empty param set.

## Tests

- New regression test `TestParameterDrivenDimensionResolvesAfterRestore` in `model/compdef`: a `"width"` (40 mm) distance dimension resolves to ~4 db units after a `MarshalRecipe`→`ApplyRecipe` round-trip (would be ~0 before the fix).
- `go test ./model/... ./addin/router/... ./app/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)