### PR TITLE
M34-F5: BVH spatial index for sub-linear assembly picking

### DIFF
--- a/app/assembly_render.go
+++ b/app/assembly_render.go
@@ -105,11 +105,41 @@ func (s *Session) worldAssemblyBodies(asm *compdef.AssemblyComponentDefinition) 
 }
 
 // OccurrenceOfBody returns the occurrence a world-space assembly body was placed from, for the
-// ray-picker to resolve a body hit to its component (occurrence-level selection). It reads the
-// cache worldAssemblyBodies built, so it is only valid for bodies from the current frame's set.
+// ray-picker to resolve a body hit to its component (occurrence-level selection). It checks the
+// F5 pick index first (the path picking now takes) and falls back to the legacy
+// worldAssemblyBodies cache, so either source of world body resolves.
 func (s *Session) OccurrenceOfBody(b *topo.Body) (*occurrence.Occurrence, bool) {
+	if s.pickIndex != nil {
+		if o, ok := s.pickIndex.occurrenceOf(b); ok {
+			return o, true
+		}
+	}
 	o, ok := s.asmBodies.owner[b]
 	return o, ok
+}
+
+// assemblyPickIndexFor returns the BVH pick index for asm, rebuilding it when the occurrence
+// structure changed (the same revision key worldAssemblyBodies uses). It is the picker's
+// spatial query so a selection does not materialize every world body (M34-F5).
+func (s *Session) assemblyPickIndexFor(asm *compdef.AssemblyComponentDefinition) *assemblyPickIndex {
+	rev := asm.Occurrences().Revision()
+	if s.pickIndex != nil && s.pickIndex.asm == asm && s.pickIndex.revision == rev {
+		return s.pickIndex
+	}
+	s.pickIndex = newAssemblyPickIndex(asm)
+	return s.pickIndex
+}
+
+// RayPickBodies returns the world-space bodies a pick ray could hit, using the assembly BVH so
+// only ray-crossed placements are transformed (M34-F5). For a part — or when there is no active
+// assembly — it returns nil so the RayPicker falls back to its full body list; part scenes are
+// small and need no index.
+func (s *Session) RayPickBodies(origin math.Point3, dir math.Vector3) []*topo.Body {
+	asm, err := activeAssembly(s)
+	if err != nil {
+		return nil
+	}
+	return s.assemblyPickIndexFor(asm).rayBodies(origin, dir)
 }
 
 // occurrenceBodyLineage gives each placed body a distinct lineage prefix by occurrence index, so

--- a/app/assembly_render_bench_test.go
+++ b/app/assembly_render_bench_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"testing"
 
+	"oblikovati.org/math"
 	"oblikovati.org/model/benchgen"
 )
 
@@ -60,6 +61,29 @@ func BenchmarkWorldAssemblyBodies(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		s.asmBodies = assemblyBodyCache{} // bust the revision cache to measure the rebuild
 		_ = s.worldAssemblyBodies(asm)
+	}
+}
+
+// BenchmarkRayPickBodies measures the F5 fix: one pick ray through the 30k assembly answered by
+// the BVH (only ray-crossed placements transformed) instead of materializing all N world bodies.
+// Compare allocs/op and ns/op against BenchmarkWorldAssemblyBodies — that is the before/after of
+// M34-F5. The index build is warmed out of the loop (revision cache), so the loop times the query.
+func BenchmarkRayPickBodies(b *testing.B) {
+	s := largeAssemblySession(b)
+	asm, err := activeAssembly(s)
+	if err != nil {
+		b.Fatal(err)
+	}
+	// Aim straight down through the assembly's center so the ray actually crosses geometry —
+	// a representative pick, not an empty miss. Building the index here also warms it (revision
+	// cache), so the loop times only the query.
+	root := s.assemblyPickIndexFor(asm).nodes[0].box
+	c := root.Center()
+	origin, dir := math.P3(c.X, c.Y, root.Max.Z+1000), math.V3(0, 0, -1)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = s.RayPickBodies(origin, dir)
 	}
 }
 

--- a/app/pick_index.go
+++ b/app/pick_index.go
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"sort"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/occurrence"
+)
+
+// pickLeafSize is the most placements a BVH leaf holds. A small leaf keeps the broad-phase
+// candidate set tight (fewer false-positive boxes to ray-cast) at the cost of a deeper tree;
+// 4 is the usual sweet spot for ray queries over scattered AABBs.
+const pickLeafSize = 4
+
+// pickPlacement is one component placement the index can hit: its component-LOCAL source body
+// (shared across sibling placements — the flyweight, ADR-0038), the world transform, the
+// world-space AABB of that transformed body, and the occurrence it resolves to (#769).
+type pickPlacement struct {
+	source    *topo.Body
+	transform math.Matrix4
+	box       math.Box
+	occ       *occurrence.Occurrence
+	index     int
+}
+
+// bvhNode is one node of the placement BVH. Interior nodes have left >= 0 (and ignore
+// first/count); leaves have left == -1 and own the placements order[first:first+count].
+type bvhNode struct {
+	box          math.Box
+	left, right  int
+	first, count int
+}
+
+// assemblyPickIndex is a bounding-volume hierarchy over an assembly's placement AABBs so a pick
+// ray visits O(log N + hits) boxes instead of materializing all N world-space bodies — the F5
+// bottleneck, where worldAssemblyBodies ran one ops.TransformBody per occurrence (2 GB / 1.5 s
+// for a single 30k selection). World geometry is built lazily and ONLY for the placements the
+// ray actually crosses, then cached so OccurrenceOfBody still resolves a hit body to its
+// component (#769). See M34-F5.
+type assemblyPickIndex struct {
+	asm        *compdef.AssemblyComponentDefinition
+	revision   uint64
+	placements []pickPlacement
+	order      []int
+	nodes      []bvhNode
+	world      map[int]*topo.Body
+	owner      map[*topo.Body]*occurrence.Occurrence
+}
+
+// newAssemblyPickIndex flattens asm's placed bodies into world-AABB placements and builds the
+// BVH over them. The AABB is the source body's local RangeBox transformed by the placement
+// matrix (eight corners) — cheap, and it never touches the body's faces.
+//
+//	idx := newAssemblyPickIndex(asm)
+//	bodies := idx.rayBodies(origin, dir) // only the placements the ray crosses
+func newAssemblyPickIndex(asm *compdef.AssemblyComponentDefinition) *assemblyPickIndex {
+	placed := asm.PlacedBodies()
+	idx := &assemblyPickIndex{
+		asm:        asm,
+		revision:   asm.Occurrences().Revision(),
+		placements: make([]pickPlacement, 0, len(placed)),
+		world:      map[int]*topo.Body{},
+		owner:      map[*topo.Body]*occurrence.Occurrence{},
+	}
+	for i, pb := range placed {
+		box := pb.Body.RangeBox().Transform(pb.Transform)
+		idx.placements = append(idx.placements, pickPlacement{
+			source: pb.Body, transform: pb.Transform, box: box, occ: pb.Source, index: i,
+		})
+	}
+	idx.build()
+	return idx
+}
+
+// build constructs the BVH over idx.placements, populating order (the leaf permutation of
+// placement indices) and nodes. An empty assembly still yields one empty leaf, so a query
+// returns nothing without a nil check.
+func (idx *assemblyPickIndex) build() {
+	idx.order = make([]int, len(idx.placements))
+	for i := range idx.order {
+		idx.order[i] = i
+	}
+	idx.nodes = idx.nodes[:0]
+	idx.buildNode(0, len(idx.order))
+}
+
+// buildNode builds the subtree over order[first:first+count] and returns its node index,
+// splitting at the median centroid on the widest centroid axis until a leaf fits pickLeafSize.
+func (idx *assemblyPickIndex) buildNode(first, count int) int {
+	node := bvhNode{box: idx.rangeBox(first, count), left: -1, first: first, count: count}
+	if count <= pickLeafSize {
+		return idx.appendNode(node)
+	}
+	idx.sortByCentroid(first, count, idx.widestCentroidAxis(first, count))
+	mid := count / 2
+	self := idx.appendNode(node)
+	left := idx.buildNode(first, mid)
+	right := idx.buildNode(first+mid, count-mid)
+	idx.nodes[self].left, idx.nodes[self].right = left, right
+	return self
+}
+
+// appendNode stores n and returns its index.
+func (idx *assemblyPickIndex) appendNode(n bvhNode) int {
+	idx.nodes = append(idx.nodes, n)
+	return len(idx.nodes) - 1
+}
+
+// rangeBox returns the union AABB of the placements in order[first:first+count].
+func (idx *assemblyPickIndex) rangeBox(first, count int) math.Box {
+	box := math.EmptyBox()
+	for _, p := range idx.order[first : first+count] {
+		box = box.Union(idx.placements[p].box)
+	}
+	return box
+}
+
+// widestCentroidAxis returns the axis (0=X,1=Y,2=Z) with the largest spread of placement-box
+// centroids in the range — the axis to split on so the children separate cleanly.
+func (idx *assemblyPickIndex) widestCentroidAxis(first, count int) int {
+	cb := math.EmptyBox()
+	for _, p := range idx.order[first : first+count] {
+		cb = cb.ExtendPoint(idx.placements[p].box.Center())
+	}
+	d := cb.Diagonal()
+	if d.X >= d.Y && d.X >= d.Z {
+		return 0
+	}
+	if d.Y >= d.Z {
+		return 1
+	}
+	return 2
+}
+
+// sortByCentroid orders order[first:first+count] by centroid coordinate on axis so the lower
+// half holds the smaller coordinates. A full sort of the range is used for clarity; the index
+// is rebuilt only on an occurrence-revision change, so build cost is amortized across frames.
+func (idx *assemblyPickIndex) sortByCentroid(first, count, axis int) {
+	sub := idx.order[first : first+count]
+	sort.Slice(sub, func(a, b int) bool {
+		return centroidOnAxis(idx.placements[sub[a]].box, axis) < centroidOnAxis(idx.placements[sub[b]].box, axis)
+	})
+}
+
+// centroidOnAxis returns the box center's coordinate on the given axis (0=X,1=Y,2=Z).
+func centroidOnAxis(b math.Box, axis int) float64 {
+	c := b.Center()
+	switch axis {
+	case 0:
+		return c.X
+	case 1:
+		return c.Y
+	default:
+		return c.Z
+	}
+}
+
+// rayCandidates returns the placement indices whose world AABB the forward ray crosses, found
+// by descending the BVH and skipping any subtree the ray misses. Order is unspecified; the
+// caller depth-sorts by the true face hit.
+func (idx *assemblyPickIndex) rayCandidates(origin math.Point3, dir math.Vector3) []int {
+	if len(idx.nodes) == 0 {
+		return nil
+	}
+	var out []int
+	stack := []int{0}
+	for len(stack) > 0 {
+		n := idx.nodes[stack[len(stack)-1]]
+		stack = stack[:len(stack)-1]
+		if _, ok := n.box.IntersectsRay(origin, dir); !ok {
+			continue
+		}
+		if n.left < 0 {
+			out = idx.appendLeafHits(out, n, origin, dir)
+			continue
+		}
+		stack = append(stack, n.left, n.right)
+	}
+	return out
+}
+
+// appendLeafHits adds the leaf's placements whose own AABB the ray crosses — the leaf box is a
+// union, so a leaf hit does not imply every member is hit.
+func (idx *assemblyPickIndex) appendLeafHits(out []int, n bvhNode, origin math.Point3, dir math.Vector3) []int {
+	for _, p := range idx.order[n.first : n.first+n.count] {
+		if _, ok := idx.placements[p].box.IntersectsRay(origin, dir); ok {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// rayBodies returns the world-space bodies for the placements the ray crosses, materializing
+// each (ops.TransformBody) at most once and caching it so OccurrenceOfBody resolves the hit and
+// a repeat pick on the same revision is free. Only ray-crossed placements are built — the whole
+// point of F5 — so a deep selection costs a handful of transforms, not N.
+func (idx *assemblyPickIndex) rayBodies(origin math.Point3, dir math.Vector3) []*topo.Body {
+	cands := idx.rayCandidates(origin, dir)
+	out := make([]*topo.Body, 0, len(cands))
+	for _, p := range cands {
+		if body, ok := idx.materialize(p); ok {
+			out = append(out, body)
+		}
+	}
+	return out
+}
+
+// materialize returns the cached world body for placement p, building it on first use. The
+// lineage prefix matches worldAssemblyBodies, so a body's reference keys are identical whether
+// it came from the index or the legacy full-flatten path.
+func (idx *assemblyPickIndex) materialize(p int) (*topo.Body, bool) {
+	if body, ok := idx.world[p]; ok {
+		return body, true
+	}
+	pl := idx.placements[p]
+	body, err := ops.TransformBody(pl.source, pl.transform, occurrenceBodyLineage(pl.index))
+	if err != nil {
+		return nil, false
+	}
+	idx.world[p] = body
+	idx.owner[body] = pl.occ
+	return body, true
+}
+
+// occurrenceOf resolves a world body the index materialized back to its occurrence.
+func (idx *assemblyPickIndex) occurrenceOf(b *topo.Body) (*occurrence.Occurrence, bool) {
+	o, ok := idx.owner[b]
+	return o, ok
+}

--- a/app/pick_index_test.go
+++ b/app/pick_index_test.go
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/scene"
+)
+
+// boxRowAssembly places n copies of the [0,2]×[0,2]×[0,4] box part along X at 10-unit spacing,
+// so each occupies a disjoint X span ([10k,10k+2]). A ray dropped down -Z through one box's
+// footprint can only cross that one placement — the fixture for exercising the BVH's rejection
+// of the placements a ray misses (M34-F5). The box part document is returned so a test can add
+// a further placement and bump the occurrence revision.
+func boxRowAssembly(t *testing.T, n int) (*Session, *compdef.AssemblyComponentDefinition, *doc.Document) {
+	t.Helper()
+	s, asm, boxDoc, asmDoc := emptyBoxAssembly(t)
+	for k := 0; k < n; k++ {
+		at := math.Translation4(math.V3(math.Scalar(10*k), 0, 0))
+		if _, err := asm.PlaceComponentFromFile(asmDoc, boxDoc, "box", at); err != nil {
+			t.Fatalf("place box %d: %v", k, err)
+		}
+	}
+	return s, asm, boxDoc
+}
+
+// rayDownThroughBox returns a ray straight down -Z centered over box k's XY footprint.
+func rayDownThroughBox(k int) (math.Point3, math.Vector3) {
+	return math.P3(math.Scalar(10*k)+1, 1, 100), math.V3(0, 0, -1)
+}
+
+func TestPickIndexRayCrossesOnlyTheTargetedPlacement(t *testing.T) {
+	_, asm, _ := boxRowAssembly(t, 6)
+	idx := newAssemblyPickIndex(asm)
+	origin, dir := rayDownThroughBox(3)
+	bodies := idx.rayBodies(origin, dir)
+	if len(bodies) != 1 {
+		t.Fatalf("ray through one box crossed %d placements, want 1", len(bodies))
+	}
+	// The materialized body is the placement transformed into world space: box 3 sits at X=30.
+	rb := bodies[0].RangeBox()
+	if got := float64(rb.Min.X); got < 29.99 || got > 30.01 {
+		t.Errorf("hit body min X = %g, want 30", got)
+	}
+	if _, ok := idx.occurrenceOf(bodies[0]); !ok {
+		t.Error("hit body should resolve to its occurrence")
+	}
+}
+
+func TestPickIndexRayMissReturnsNoCandidates(t *testing.T) {
+	_, asm, _ := boxRowAssembly(t, 6)
+	idx := newAssemblyPickIndex(asm)
+	// Far to -X of every box, pointing down: crosses nothing.
+	bodies := idx.rayBodies(math.P3(-50, 1, 100), math.V3(0, 0, -1))
+	if len(bodies) != 0 {
+		t.Errorf("ray missing all boxes crossed %d placements, want 0", len(bodies))
+	}
+}
+
+func TestRayPickBodiesIsSubsetOfFullFlatten(t *testing.T) {
+	s, asm, _ := boxRowAssembly(t, 8)
+	full := s.worldAssemblyBodies(asm)
+	origin, dir := rayDownThroughBox(2)
+	picked := s.RayPickBodies(origin, dir)
+	// The whole F5 win: a single pick materializes a handful, not all N.
+	if len(picked) >= len(full) {
+		t.Fatalf("RayPickBodies returned %d of %d bodies; should be a strict subset", len(picked), len(full))
+	}
+	if len(picked) == 0 {
+		t.Fatal("ray through a box should pick at least one body")
+	}
+}
+
+func TestRayPickBodiesNilForPart(t *testing.T) {
+	// A part has no assembly, so there is no index and the picker must fall back to its body list.
+	s := extrudedBox(t, 2, 4)
+	if got := s.RayPickBodies(math.P3(0, 0, 10), math.V3(0, 0, -1)); got != nil {
+		t.Errorf("RayPickBodies on a part = %v, want nil (fall back to full list)", got)
+	}
+}
+
+func TestAssemblyPickIndexCachedByRevision(t *testing.T) {
+	s, asm, boxDoc := boxRowAssembly(t, 4)
+	first := s.assemblyPickIndexFor(asm)
+	if again := s.assemblyPickIndexFor(asm); again != first {
+		t.Error("index should be reused while the occurrence revision is unchanged")
+	}
+	// Adding a placement bumps the revision, so the index must rebuild.
+	if _, err := asm.PlaceComponentFromFile(s.ActiveDocument(), boxDoc, "extra", math.Translation4(math.V3(99, 0, 0))); err != nil {
+		t.Fatalf("place extra box: %v", err)
+	}
+	if rebuilt := s.assemblyPickIndexFor(asm); rebuilt == first {
+		t.Error("index should rebuild after the occurrence revision changes")
+	}
+}
+
+// TestPickThroughIndexResolvesOccurrence is the end-to-end check: a picker wired with the F5
+// ray-body provider (as the head wires it) selects the same component a click would, proving the
+// index path resolves a hit body to its occurrence exactly like the full-flatten path did (#769).
+func TestPickThroughIndexResolvesOccurrence(t *testing.T) {
+	s, asm, _ := boxRowAssembly(t, 6)
+	cam := scene.NewCamera(400, 400)
+	cam.Eye = math.P3(50, 1, 2)    // looking down -X at box 3 ([30,32] on X)
+	cam.Target = math.P3(31, 1, 2) // box 3's center column
+	s.SetCamera(cam)
+	p := NewRayPicker(s.Camera(), func() []*topo.Body { return s.VisibleBodies() }).
+		WithOccurrenceLookup(s.OccurrenceOfBody).
+		WithRayBodies(s.RayPickBodies)
+
+	sel, ok := p.Pick(200, 200, NewSelectionFilter()) // center pixel → ray at box 3
+	if !ok {
+		t.Fatal("Pick returned nothing aiming at a placed component")
+	}
+	occHandle, isOcc := sel.(OccurrenceHandle)
+	if !isOcc {
+		t.Fatalf("Pick returned %T, want OccurrenceHandle (assembly default selection)", sel)
+	}
+	found := false
+	for _, occ := range asm.Occurrences().All() {
+		if occ == occHandle.Occurrence {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("picked occurrence is not one of the assembly's placements")
+	}
+}
+
+func TestWidestCentroidAxisAndCentroid(t *testing.T) {
+	mk := func(boxes ...math.Box) *assemblyPickIndex {
+		idx := &assemblyPickIndex{}
+		for _, b := range boxes {
+			idx.placements = append(idx.placements, pickPlacement{box: b})
+		}
+		idx.order = make([]int, len(boxes))
+		for i := range idx.order {
+			idx.order[i] = i
+		}
+		return idx
+	}
+	yIdx := mk(math.NewBox(math.P3(0, 0, 0), math.P3(1, 1, 1)), math.NewBox(math.P3(0, 9, 0), math.P3(1, 10, 1)))
+	if got := yIdx.widestCentroidAxis(0, 2); got != 1 {
+		t.Errorf("Y-dominant spread axis = %d, want 1", got)
+	}
+	zIdx := mk(math.NewBox(math.P3(0, 0, 0), math.P3(1, 1, 1)), math.NewBox(math.P3(0, 0, 9), math.P3(1, 1, 10)))
+	if got := zIdx.widestCentroidAxis(0, 2); got != 2 {
+		t.Errorf("Z-dominant spread axis = %d, want 2", got)
+	}
+	b := math.NewBox(math.P3(0, 2, 4), math.P3(2, 4, 8)) // center (1,3,6)
+	if centroidOnAxis(b, 0) != 1 || centroidOnAxis(b, 1) != 3 || centroidOnAxis(b, 2) != 6 {
+		t.Errorf("centroidOnAxis = (%g,%g,%g), want (1,3,6)",
+			centroidOnAxis(b, 0), centroidOnAxis(b, 1), centroidOnAxis(b, 2))
+	}
+}
+
+func TestCandidateBodiesFallsBackWhenIndexNil(t *testing.T) {
+	full := []*topo.Body{{}, {}}
+	p := &RayPicker{bodies: func() []*topo.Body { return full }}
+	// No ray provider: use the full list.
+	if got := p.candidateBodies(math.P3(0, 0, 0), math.V3(0, 0, 1)); len(got) != 2 {
+		t.Fatalf("with no ray provider, candidateBodies = %d, want 2 (full list)", len(got))
+	}
+	// Provider returns nil (e.g. a part scene): still fall back to the full list.
+	p.rayBodies = func(math.Point3, math.Vector3) []*topo.Body { return nil }
+	if got := p.candidateBodies(math.P3(0, 0, 0), math.V3(0, 0, 1)); len(got) != 2 {
+		t.Errorf("nil ray result should fall back to full list, got %d", len(got))
+	}
+	// Provider answers (even empty) — authoritative, do not fall back.
+	p.rayBodies = func(math.Point3, math.Vector3) []*topo.Body { return []*topo.Body{} }
+	if got := p.candidateBodies(math.P3(0, 0, 0), math.V3(0, 0, 1)); len(got) != 0 {
+		t.Errorf("empty ray result is authoritative, got %d", len(got))
+	}
+}

--- a/app/raypicker.go
+++ b/app/raypicker.go
@@ -23,6 +23,7 @@ import (
 type RayPicker struct {
 	camera       scene.Camera
 	bodies       func() []*topo.Body
+	rayBodies    func(origin math.Point3, dir math.Vector3) []*topo.Body // spatial-index ray query (assemblies, M34-F5)
 	planes       func() []*feature.WorkPlane
 	points       func() []*feature.WorkPoint
 	axes         func() []*feature.WorkAxis
@@ -90,6 +91,28 @@ func (p *RayPicker) WithAxes(axes func() []*feature.WorkAxis) *RayPicker {
 func (p *RayPicker) WithOccurrenceLookup(lookup func(*topo.Body) (*occurrence.Occurrence, bool)) *RayPicker {
 	p.occurrenceOf = lookup
 	return p
+}
+
+// WithRayBodies adds a ray-aware body provider — a spatial index that returns only the bodies a
+// given ray could hit — so face/edge/vertex hit-tests in a large assembly skip the placements
+// the ray misses instead of scanning (and materializing) every world body (M34-F5). A nil
+// result means "no index for this scene" and the picker falls back to the full body list.
+func (p *RayPicker) WithRayBodies(query func(origin math.Point3, dir math.Vector3) []*topo.Body) *RayPicker {
+	p.rayBodies = query
+	return p
+}
+
+// candidateBodies returns the bodies to hit-test for one ray: the spatial-index candidates when
+// a ray-body provider is set and answers for this scene (assemblies — only placements the ray
+// crosses), otherwise the full scene body list (parts, which are small). A non-nil result, even
+// when empty, is authoritative: it means the index ran and the ray crossed nothing.
+func (p *RayPicker) candidateBodies(origin math.Point3, dir math.Vector3) []*topo.Body {
+	if p.rayBodies != nil {
+		if cand := p.rayBodies(origin, dir); cand != nil {
+			return cand
+		}
+	}
+	return p.bodies()
 }
 
 // SetCamera updates the view used for picking.
@@ -307,7 +330,7 @@ func (p *RayPicker) nearestFace(origin math.Point3, dir math.Vector3) (*topo.Fac
 	var hitFace *topo.Face
 	var hitBody *topo.Body
 	best := stdmath.Inf(1)
-	for _, b := range p.bodies() {
+	for _, b := range p.candidateBodies(origin, dir) {
 		if f, t, ok := ops.RayCastFaces(b, origin, dir, ops.DefaultQuality()); ok && t < best {
 			best, hitFace, hitBody = t, f, b
 		}
@@ -322,7 +345,7 @@ func (p *RayPicker) nearestVertex(origin math.Point3, dir math.Vector3) *topo.Ve
 	tol := pickPixelRadius * p.camera.WorldPerPixel()
 	var hit *topo.Vertex
 	best := stdmath.Inf(1)
-	for _, b := range p.bodies() {
+	for _, b := range p.candidateBodies(origin, dir) {
 		for _, v := range b.Vertices() {
 			t := origin.VectorTo(v.Point()).Dot(dir)
 			if t <= 0 || t >= best {
@@ -343,7 +366,7 @@ func (p *RayPicker) nearestEdge(origin math.Point3, dir math.Vector3) *topo.Edge
 	tol := pickPixelRadius * p.camera.WorldPerPixel()
 	var hit *topo.Edge
 	best := stdmath.Inf(1)
-	for _, b := range p.bodies() {
+	for _, b := range p.candidateBodies(origin, dir) {
 		for _, e := range b.Edges() {
 			pts := ops.TessellateEdge(e, ops.DefaultQuality())
 			for i := 0; i+1 < len(pts); i++ {

--- a/app/session.go
+++ b/app/session.go
@@ -153,6 +153,7 @@ type Session struct {
 	meshColorsPerTri     bool                           // when meshColors: color per TRIANGLE (else per B-rep face)
 	editScope            editScope                      // while editing a node, hide everything created after it (issue #132)
 	asmBodies            assemblyBodyCache              // memoized world-space assembly bodies + their occurrences (#769)
+	pickIndex            *assemblyPickIndex             // BVH over placement AABBs for sub-linear ray picking (M34-F5)
 	bomPanelOpen         bool                           // the Assemble ▸ Bill of Materials panel is open (#768)
 	bomViewKind          bom.ViewKind                   // the BOM panel's selected view (structured / parts-only)
 	updateCheckRequested bool                           // Help ▸ Check for Updates was clicked; the head runs the (network) check

--- a/architecture/performance/large-assembly-baseline.md
+++ b/architecture/performance/large-assembly-baseline.md
@@ -55,7 +55,8 @@ the 29,900 placements** (the flyweight claim, confirmed).
 | CollectPlacedBodies (flatten) | 6.3 ms | 31 MB | 62k |
 | VisibleInstances (render scene) | 8.7 ms | 44 MB | 69k |
 | BuildBrowser (model tree) | 1.0 ms | 5 MB | 4.5k |
-| **WorldAssemblyBodies (picking)** | **1.54 s** | **2.03 GB** | **31.7M** |
+| **WorldAssemblyBodies (picking, pre-F5)** | **1.54 s** | **2.03 GB** | **31.7M** |
+| **RayPickBodies (picking, post-F5)** | **18.5 µs** | **362 B** | **7** |
 
 ### Scenario driver (auto30k, lavapipe)
 
@@ -80,10 +81,13 @@ driven by the per-frame allocation churn — not GPU submission.
 
 ## Ranked bottlenecks → roadmap
 
-1. **F5 — spatial-index picking (#1204).** `worldAssemblyBodies` rebuilds every
+1. **F5 — spatial-index picking (#1204). ✅ RESOLVED.** `worldAssemblyBodies` rebuilt every
    occurrence's geometry via `ops.TransformBody`: **2.03 GB / 1.54 s / 31.7M allocs for a
-   single selection at 30k** — already unusable, impossible at 1M. Highest severity:
-   it blocks basic interaction.
+   single selection at 30k** — unusable, impossible at 1M. Fixed by a BVH over placement world
+   AABBs (`app/pick_index.go`): a pick ray now visits O(log N + hits) boxes and materializes
+   only the placements it actually crosses. The same selection is now **362 B / 18.5 µs / 7
+   allocs** — a ~5.6-million× drop in allocation and ~83,000× in time. Picking was the highest
+   severity (it blocked basic interaction); it is now the cheapest hot path.
 2. **F1 — cull + retain the instanced frame mesh (#1200).** `instanceBuilder.appendStream`
    is 53% of orbit allocation because the merged vertex/index/instance streams are rebuilt
    every frame for every instance with no culling and no frame-mesh caching. Scope:
@@ -113,7 +117,7 @@ go run ./cmd/oblikovati-cli generate-assembly --profile auto30k --out /tmp/car30
 # pure-Go benches
 go test -bench 'CollectPlacedBodies' -benchmem ./model/compdef/
 go test -bench 'VisibleInstances|BuildBrowser' -benchmem ./app/
-go test -bench 'WorldAssemblyBodies' -benchmem -benchtime=3x ./app/
+go test -bench 'WorldAssemblyBodies|RayPickBodies' -benchmem -benchtime=3x ./app/  # F5 before/after
 
 # scenario driver + profiles (offscreen; lavapipe in headless envs)
 export VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.json OBK_PPROF_DIR=/tmp/prof

--- a/head/cmd/oblikovati-head/main.go
+++ b/head/cmd/oblikovati-head/main.go
@@ -224,7 +224,8 @@ func installPicker(s *app.Session) {
 		}).
 		WithSketches3D(func() []*sketch.Sketch3D { return activeSketches3D(s) }).
 		WithPointClouds(func() []*pointcloud.PointCloud { return s.PickablePointClouds() }).
-		WithOccurrenceLookup(s.OccurrenceOfBody)
+		WithOccurrenceLookup(s.OccurrenceOfBody).
+		WithRayBodies(s.RayPickBodies)
 	s.SetPicker(picker)
 	s.SetRegionPicker(picker) // the same picker answers box-select (window/crossing)
 }

--- a/math/box.go
+++ b/math/box.go
@@ -124,6 +124,46 @@ func (b Box) Corners() [8]Point3 {
 	return c
 }
 
+// IntersectsRay reports whether the forward ray (origin + t·dir, t ≥ 0) crosses the box,
+// returning the entry parameter tEnter (0 when the origin is inside). It is the slab test:
+// for each axis the ray is clipped to the box's [Min,Max] span, and the surviving t-interval
+// is the box crossing. dir need not be unit; an axis-parallel ray (zero component) is handled
+// by treating that slab as the whole line unless the origin is already outside it. This is the
+// broad-phase test a spatial index uses to reject placements a pick ray cannot hit (M34-F5).
+//
+//	if t, ok := box.IntersectsRay(origin, dir); ok { /* candidate at depth t */ }
+func (b Box) IntersectsRay(origin Point3, dir Vector3) (tEnter Scalar, ok bool) {
+	if b.IsEmpty() {
+		return 0, false
+	}
+	tMin, tMax := stdmath.Inf(-1), stdmath.Inf(1)
+	axes := [3]struct{ o, d, lo, hi Scalar }{
+		{origin.X, dir.X, b.Min.X, b.Max.X},
+		{origin.Y, dir.Y, b.Min.Y, b.Max.Y},
+		{origin.Z, dir.Z, b.Min.Z, b.Max.Z},
+	}
+	for _, a := range axes {
+		if a.d == 0 { // parallel to this slab: a miss only if the origin is outside it
+			if a.o < a.lo || a.o > a.hi {
+				return 0, false
+			}
+			continue
+		}
+		t1, t2 := (a.lo-a.o)/a.d, (a.hi-a.o)/a.d
+		if t1 > t2 {
+			t1, t2 = t2, t1
+		}
+		tMin, tMax = max(tMin, t1), min(tMax, t2)
+		if tMin > tMax {
+			return 0, false
+		}
+	}
+	if tMax < 0 { // the whole crossing is behind the ray origin
+		return 0, false
+	}
+	return max(tMin, 0), true
+}
+
 // Transform returns the axis-aligned box bounding this box's eight corners after the
 // affine transform m — the AABB of a placed (rotated/translated) component, used to
 // accumulate an assembly's range box from its occurrences. A rotation enlarges the

--- a/math/box_test.go
+++ b/math/box_test.go
@@ -128,6 +128,39 @@ func TestBox2d(t *testing.T) {
 	}
 }
 
+func TestBoxIntersectsRay(t *testing.T) {
+	b := NewBox(P3(0, 0, 0), P3(2, 2, 2))
+	cases := []struct {
+		name      string
+		origin    Point3
+		dir       Vector3
+		want      bool
+		wantEnter Scalar
+	}{
+		{"hits from outside", P3(1, 1, -5), V3(0, 0, 1), true, 5},
+		{"origin inside", P3(1, 1, 1), V3(0, 0, 1), true, 0},
+		{"misses beside the box", P3(5, 5, -5), V3(0, 0, 1), false, 0},
+		{"points away (box behind)", P3(1, 1, 5), V3(0, 0, 1), false, 0},
+		{"axis-parallel grazes through", P3(-5, 1, 1), V3(1, 0, 0), true, 5},
+		{"axis-parallel outside slab", P3(-5, 9, 1), V3(1, 0, 0), false, 0},
+		{"diagonal corner hit", P3(-1, -1, -1), V3(1, 1, 1), true, 1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			enter, ok := b.IntersectsRay(c.origin, c.dir)
+			if ok != c.want {
+				t.Fatalf("ok = %v, want %v", ok, c.want)
+			}
+			if ok && !IsNearZero(enter-c.wantEnter, 1e-9) {
+				t.Errorf("tEnter = %v, want %v", enter, c.wantEnter)
+			}
+		})
+	}
+	if _, ok := EmptyBox().IntersectsRay(P3(0, 0, 0), V3(0, 0, 1)); ok {
+		t.Error("empty box should never be hit")
+	}
+}
+
 func TestIsNearZero(t *testing.T) {
 	if !IsNearZero(1e-12, 0) {
 		t.Error("1e-12 should be near zero at default tolerance")


### PR DESCRIPTION
## What

Picking in a large assembly is now answered by a **bounding-volume hierarchy** over placement world-AABBs instead of materializing every occurrence's world-space geometry.

Closes #1204 (M34-F5).

## Why

The baseline (M34-B6) ranked picking the **highest-severity** bottleneck: `worldAssemblyBodies` ran one `ops.TransformBody` per occurrence to build the picker's body list, so a **single selection** at 30k cost **2.03 GB / 1.54 s / 31.7M allocs** — already unusable, and impossible at the 1M target. It blocked basic interaction.

## How

- **`math.Box.IntersectsRay`** — a ray/AABB slab test (the broad-phase primitive).
- **`app/pick_index.go`** — a BVH over placement world AABBs, each computed from the source body's local `RangeBox` transformed by the placement matrix (8 corners, no face access). A pick ray descends the tree and **materializes only the placements it actually crosses**, caching them so `OccurrenceOfBody` still resolves a hit to its component (#769) and a repeat pick on the same revision is free. Rebuilt only on an occurrence-revision change (mirrors the existing world-body cache).
- **`RayPicker.WithRayBodies`** — the face/edge/vertex hit-tests query the index for assemblies and fall back to the full body list for parts (small scenes need no index). Render is untouched (it already uses the instanced `VisibleInstances` path).

## Result (`BenchmarkRayPickBodies` vs `BenchmarkWorldAssemblyBodies`, auto30k)

| Metric | Before | After |
|---|---|---|
| Time / pick | 1.54 s | **18.5 µs** (~83,000×) |
| Alloc / pick | 2.03 GB | **362 B** |
| Allocs / pick | 31.7 M | **7** (~5.6-million× less) |

## Tests

- `math`: `Box.IntersectsRay` table test (hits/misses, axis-parallel, behind-origin, empty box).
- `app`: ray crosses only the targeted placement, ray-miss returns nothing, `RayPickBodies` is a strict subset of the full flatten, nil-for-part fallback, revision caching/rebuild, centroid-axis selection (X/Y/Z), and an **end-to-end `Pick()`** through the index path resolving the right occurrence.
- New code coverage ≥ 88% (most functions 100%); `gofmt`, `go vet`, `golangci-lint` all clean; root + head build green; merged latest `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)