### PR TITLE
M34-F1: per-instance frustum culling via the assembly BVH

### DIFF
--- a/app/assembly_render.go
+++ b/app/assembly_render.go
@@ -8,6 +8,7 @@ import (
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/occurrence"
+	"oblikovati.org/scene"
 )
 
 // InstanceGroup is one unique component mesh and the world transforms it is drawn at — the
@@ -38,6 +39,22 @@ func (s *Session) VisibleInstances() []InstanceGroup {
 		}
 	}
 	return out
+}
+
+// CulledInstances returns the render instance groups limited to the components whose world AABB is
+// inside the camera frustum — per-instance frustum culling backed by the assembly BVH, so off-screen
+// placements never reach the GPU upload (M34-F1, essential at the 1M-placement target). Grouping
+// matches VisibleInstances (by shared source body, first-seen order), so the head's per-source mesh
+// cache still hits. A part — or no active assembly — has no index and is small, so it returns the
+// full VisibleInstances unchanged. Use VisibleInstances (not this) for framing/shadow bounds, which
+// must cover the whole model regardless of view.
+func (s *Session) CulledInstances(cam scene.Camera) []InstanceGroup {
+	asm, err := activeAssembly(s)
+	if err != nil {
+		return s.VisibleInstances()
+	}
+	idx := s.assemblyPickIndexFor(asm)
+	return idx.groupPlacements(idx.frustumPlacements(cam.Frustum()))
 }
 
 // assemblyInstances groups the assembly's placed bodies by their shared source body pointer (copies

--- a/app/assembly_render_bench_test.go
+++ b/app/assembly_render_bench_test.go
@@ -8,6 +8,7 @@ import (
 
 	"oblikovati.org/math"
 	"oblikovati.org/model/benchgen"
+	"oblikovati.org/scene"
 )
 
 // benchAssembly builds the committed 30k automotive benchmark assembly once and shares
@@ -61,6 +62,29 @@ func BenchmarkWorldAssemblyBodies(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		s.asmBodies = assemblyBodyCache{} // bust the revision cache to measure the rebuild
 		_ = s.worldAssemblyBodies(asm)
+	}
+}
+
+// BenchmarkCulledInstances measures the F1 fix: per-instance frustum culling over the 30k
+// assembly via the BVH, for a zoomed-in view where most of the car is off-screen. Compare its
+// transform count and allocs against BenchmarkVisibleInstances (which emits every placement). The
+// index build is warmed out of the loop so the loop times the frustum query + grouping.
+func BenchmarkCulledInstances(b *testing.B) {
+	s := largeAssemblySession(b)
+	asm, err := activeAssembly(s)
+	if err != nil {
+		b.Fatal(err)
+	}
+	// A tight view near one corner of the model: zoom in so culling has real work to do.
+	root := s.assemblyPickIndexFor(asm).nodes[0].box
+	cam := scene.NewCamera(1920, 1080)
+	cam.Eye = root.Min.TranslateBy(math.V3(0, 0, 50))
+	cam.Target = root.Min
+	b.Logf("culled %d of %d transforms in view", countTransforms(s.CulledInstances(cam)), countTransforms(s.VisibleInstances()))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = s.CulledInstances(cam)
 	}
 }
 

--- a/app/pick_index.go
+++ b/app/pick_index.go
@@ -10,6 +10,7 @@ import (
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/occurrence"
+	"oblikovati.org/scene"
 )
 
 // pickLeafSize is the most placements a BVH leaf holds. A small leaf keeps the broad-phase
@@ -231,4 +232,60 @@ func (idx *assemblyPickIndex) materialize(p int) (*topo.Body, bool) {
 func (idx *assemblyPickIndex) occurrenceOf(b *topo.Body) (*occurrence.Occurrence, bool) {
 	o, ok := idx.owner[b]
 	return o, ok
+}
+
+// frustumPlacements returns the placement indices whose world AABB the frustum keeps, pruning any
+// BVH subtree wholly outside the view — the broad phase of F1 per-instance culling. The result is
+// in ascending placement order so grouping is deterministic and matches VisibleInstances'
+// first-seen order (the head's per-source mesh cache then keeps hitting).
+func (idx *assemblyPickIndex) frustumPlacements(f scene.Frustum) []int {
+	if len(idx.nodes) == 0 {
+		return nil
+	}
+	var out []int
+	stack := []int{0}
+	for len(stack) > 0 {
+		n := idx.nodes[stack[len(stack)-1]]
+		stack = stack[:len(stack)-1]
+		if !f.IntersectsBox(n.box) {
+			continue
+		}
+		if n.left < 0 {
+			out = idx.appendFrustumLeaf(out, n, f)
+			continue
+		}
+		stack = append(stack, n.left, n.right)
+	}
+	sort.Ints(out)
+	return out
+}
+
+// appendFrustumLeaf adds the leaf's placements whose own AABB the frustum keeps (the leaf box is a
+// union, so a kept leaf does not mean every member is in view).
+func (idx *assemblyPickIndex) appendFrustumLeaf(out []int, n bvhNode, f scene.Frustum) []int {
+	for _, p := range idx.order[n.first : n.first+n.count] {
+		if f.IntersectsBox(idx.placements[p].box) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// groupPlacements collapses the given placements into render instance groups by shared source body,
+// preserving the placements' (ascending) order so the result is deterministic and identical in
+// shape to assemblyInstances when every placement is included.
+func (idx *assemblyPickIndex) groupPlacements(placements []int) []InstanceGroup {
+	bySource := make(map[*topo.Body]int, len(placements))
+	out := make([]InstanceGroup, 0, len(placements))
+	for _, p := range placements {
+		pl := idx.placements[p]
+		i, ok := bySource[pl.source]
+		if !ok {
+			i = len(out)
+			bySource[pl.source] = i
+			out = append(out, InstanceGroup{Source: pl.source})
+		}
+		out[i].Transforms = append(out[i].Transforms, pl.transform)
+	}
+	return out
 }

--- a/app/pick_index_test.go
+++ b/app/pick_index_test.go
@@ -131,6 +131,60 @@ func TestPickThroughIndexResolvesOccurrence(t *testing.T) {
 	}
 }
 
+// countTransforms totals the instance transforms across groups — the number of draws the GPU
+// would issue, the quantity frustum culling reduces.
+func countTransforms(groups []InstanceGroup) int {
+	n := 0
+	for _, g := range groups {
+		n += len(g.Transforms)
+	}
+	return n
+}
+
+func TestCulledInstancesKeepsAllWhenFramed(t *testing.T) {
+	s, _, _ := boxRowAssembly(t, 8) // boxes along X at 0,10,…,70
+	cam := scene.NewCamera(400, 400)
+	cam.Eye = math.P3(35, 1, 300) // far back, centered on the row → whole row on screen
+	cam.Target = math.P3(35, 1, 2)
+	if got, want := countTransforms(s.CulledInstances(cam)), countTransforms(s.VisibleInstances()); got != want {
+		t.Errorf("framing the whole row culled to %d of %d transforms; should keep all", got, want)
+	}
+}
+
+func TestCulledInstancesDropsOffscreenAndKeepsTarget(t *testing.T) {
+	s, _, _ := boxRowAssembly(t, 8)
+	full := countTransforms(s.VisibleInstances())
+	cam := scene.NewCamera(400, 400)
+	cam.Eye = math.P3(1, 1, 30) // zoomed onto box 0's column, looking down -Z
+	cam.Target = math.P3(1, 1, 2)
+	culled := s.CulledInstances(cam)
+	if n := countTransforms(culled); n >= full || n == 0 {
+		t.Fatalf("zoomed view kept %d of %d transforms; want a non-empty strict subset", n, full)
+	}
+	// Box 0 (translation X≈0) is dead center and must survive culling.
+	keptBox0 := false
+	for _, g := range culled {
+		for _, tr := range g.Transforms {
+			if x := float64(tr.Translation().X); x > -3 && x < 3 {
+				keptBox0 = true
+			}
+		}
+	}
+	if !keptBox0 {
+		t.Error("the box at the view center was culled (false negative — would pop)")
+	}
+}
+
+func TestCulledInstancesPartUnchanged(t *testing.T) {
+	s := extrudedBox(t, 2, 4)
+	cam := scene.NewCamera(400, 400)
+	cam.Eye = math.P3(10, 0, 2)
+	cam.Target = math.P3(1, 1, 2)
+	if got, want := countTransforms(s.CulledInstances(cam)), countTransforms(s.VisibleInstances()); got != want {
+		t.Errorf("a part should not be culled: %d vs %d transforms", got, want)
+	}
+}
+
 func TestWidestCentroidAxisAndCentroid(t *testing.T) {
 	mk := func(boxes ...math.Box) *assemblyPickIndex {
 		idx := &assemblyPickIndex{}

--- a/architecture/performance/large-assembly-baseline.md
+++ b/architecture/performance/large-assembly-baseline.md
@@ -88,11 +88,15 @@ driven by the per-frame allocation churn — not GPU submission.
    only the placements it actually crosses. The same selection is now **362 B / 18.5 µs / 7
    allocs** — a ~5.6-million× drop in allocation and ~83,000× in time. Picking was the highest
    severity (it blocked basic interaction); it is now the cheapest hot path.
-2. **F1 — cull + retain the instanced frame mesh (#1200).** `instanceBuilder.appendStream`
-   is 53% of orbit allocation because the merged vertex/index/instance streams are rebuilt
-   every frame for every instance with no culling and no frame-mesh caching. Scope:
-   per-instance frustum culling + a spatial index, AND retain/dirty-flag the merged frame
-   mesh instead of rebuilding it. ~725 MB/frame today.
+2. **F1 — per-instance frustum culling (#1200). ✅ RESOLVED.** The instanced path emitted a
+   matrix + draw for every placement every frame regardless of view. Fixed with a frustum
+   broad phase over the F5 placement BVH (`scene.Frustum` + `Session.CulledInstances`): a
+   zoomed corner view of the 30k car now reaches the GPU with **19 of 29,900 transforms**, and
+   the culled query is 9.4 µs / 4.4 KB vs `VisibleInstances`' 10.75 ms / 44 MB (it reuses the
+   cached index instead of re-flattening). This is the win for zoomed views and the 1M target.
+   **Still open (separate from culling):** at a *full-frame* orbit everything is in view, so the
+   53%-of-allocation `instanceBuilder.appendStream` rebuild of the merged frame mesh remains —
+   tracked as **F1b retain/dirty-flag the merged frame mesh (#1210)**. ~725 MB/frame today.
 3. **F2 — parallel + cached transform traversal (#1201).** `collectPlacedBodies` is
    31 MB / 62k allocs every flatten (render + propagation both pay it), single-threaded,
    rebuilt wholesale. Also re-derives `topo.*.Edges` (~28% of orbit alloc) — cache edges

--- a/head/cmd/perfbench/scenarios.go
+++ b/head/cmd/perfbench/scenarios.go
@@ -60,7 +60,8 @@ type OrbitResult struct {
 
 // orbitScenario sweeps the camera a full turn around the framed assembly, rendering one
 // frame per step through the real DrawChrome path and recording each frame's wall time —
-// the ViewCube-orbit stress that exercises command-buffer recording and (absent) culling.
+// the ViewCube-orbit stress that exercises command-buffer recording and per-instance frustum
+// culling (M34-F1: as the view turns, the off-screen part of the car is dropped before upload).
 func orbitScenario(win *native.Window, s *app.Session, frames int) OrbitResult {
 	if frames < 2 {
 		frames = 2

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -451,13 +451,15 @@ func renderViewportImage(win *native.Window, s *app.Session, slot int, cam scene
 	// instance groups' transformed range boxes (no tessellation) rather than scanning a world-body
 	// mesh, so framing a 10k-copy assembly is O(instances).
 	groups := s.VisibleInstances()
-	mn, mx, hasGeom := frameBounds(s, list, groups)
+	mn, mx, hasGeom := frameBounds(s, list, groups) // framing/shadow bounds cover the whole model
 	var ground []renderer.DrawItem
 	if hasGeom && wantGround(s) {
 		ground = []renderer.DrawItem{groundPlaneItem(mn, mx, renderer.PassSetFor(s.VisualStyle()).Faces, displayGroundColor(s))}
 	}
 	tb := frameClock()
-	m, mats, recs := frameMeshAndInstances(s, cam, list, bodyCount, ground, groups)
+	// Draw only the instances inside the view frustum (M34-F1) — off-screen placements never reach
+	// the GPU upload. The bounds above still use the full set so shadows/framing don't shift on orbit.
+	m, mats, recs := frameMeshAndInstances(s, cam, list, bodyCount, ground, s.CulledInstances(cam))
 	frameStats.buildNs = time.Since(tb).Nanoseconds()
 	mvp := renderer.ViewProjection(cam, viewportNear, viewportFarPlane(s, cam, mn, mx, hasGeom))
 	eye := []float32{float32(cam.Eye.X), float32(cam.Eye.Y), float32(cam.Eye.Z)}

--- a/scene/frustum.go
+++ b/scene/frustum.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package scene
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// cullPlane is a half-space with an INWARD normal: a point p is inside when n·p + d ≥ 0.
+type cullPlane struct {
+	n math.Vector3
+	d float64
+}
+
+// keeps reports whether the box is NOT entirely behind the plane. The box corner farthest along
+// the inward normal (its support point) is the one most likely inside, so if even that corner is
+// behind the plane the whole box is outside. This is the conservative half of the AABB/frustum
+// test — it never reports a straddling box as outside.
+func (pl cullPlane) keeps(b math.Box) bool {
+	support := b.FarthestPoint(pl.n)
+	return pl.n.Dot(support.AsVector())+pl.d >= 0
+}
+
+// Frustum is the camera's view volume as inward-facing half-spaces: a near plane plus the four
+// sides. The far plane is omitted on purpose — the viewport's far distance is dynamic (skybox /
+// scene dependent) and culling distant geometry is not the win F1 targets. A box is visible when
+// it is inside every plane; the test is conservative (a box straddling a frustum corner may be
+// kept though off-screen, but a visible box is never dropped, so nothing pops). See M34-F1.
+type Frustum struct {
+	planes []cullPlane
+}
+
+// IntersectsBox reports whether the world AABB is potentially visible — the broad-phase a
+// renderer uses to skip off-screen instances before the GPU upload.
+//
+//	if cam.Frustum().IntersectsBox(inst.WorldBox()) { draw(inst) }
+func (f Frustum) IntersectsBox(b math.Box) bool {
+	if b.IsEmpty() {
+		return false
+	}
+	for _, pl := range f.planes {
+		if !pl.keeps(b) {
+			return false
+		}
+	}
+	return true
+}
+
+// Frustum returns the camera's view volume for culling: a near plane at the eye plus four side
+// planes — through the eye for perspective, parallel to the view for orthographic. All normals
+// face inward.
+func (c Camera) Frustum() Frustum {
+	fwd := c.Forward()
+	right := unit(fwd.Cross(c.Up))
+	up := right.Cross(fwd) // re-orthogonalized against forward/right
+	near := cullPlane{n: fwd, d: -fwd.Dot(c.Eye.AsVector())}
+	if c.Orthographic {
+		return Frustum{planes: c.orthoPlanes(right, up, near)}
+	}
+	return Frustum{planes: c.perspectivePlanes(fwd, right, up, near)}
+}
+
+// perspectivePlanes builds the near plus four side planes from the corner-ray directions (forward
+// ± right·tanH ± up·tanV), each oriented inward by sidePlane.
+func (c Camera) perspectivePlanes(fwd, right, up math.Vector3, near cullPlane) []cullPlane {
+	tanV := stdmath.Tan(c.FOV / 2)
+	tanH := tanV * c.aspect()
+	tl := fwd.Sub(right.Scale(tanH)).Add(up.Scale(tanV))
+	tr := fwd.Add(right.Scale(tanH)).Add(up.Scale(tanV))
+	bl := fwd.Sub(right.Scale(tanH)).Sub(up.Scale(tanV))
+	br := fwd.Add(right.Scale(tanH)).Sub(up.Scale(tanV))
+	return []cullPlane{
+		near,
+		c.sidePlane(bl, tl, fwd), // left
+		c.sidePlane(tr, br, fwd), // right
+		c.sidePlane(tl, tr, fwd), // top
+		c.sidePlane(br, bl, fwd), // bottom
+	}
+}
+
+// sidePlane builds a frustum side plane through the eye spanned by two corner-ray directions,
+// orienting its normal toward the interior (the forward axis lies inside every side plane, so a
+// normal with a positive forward component points inward).
+func (c Camera) sidePlane(a, b, fwd math.Vector3) cullPlane {
+	n := a.Cross(b)
+	if n.Dot(fwd) < 0 {
+		n = n.Negate()
+	}
+	return cullPlane{n: n, d: -n.Dot(c.Eye.AsVector())}
+}
+
+// orthoPlanes builds the four parallel side planes of an orthographic view, offset from the eye by
+// the half-extent the FOV spans at the target depth (so toggling projection keeps the same scale).
+func (c Camera) orthoPlanes(right, up math.Vector3, near cullPlane) []cullPlane {
+	dist := float64(c.Eye.DistanceTo(c.Target))
+	halfH := stdmath.Tan(c.FOV/2) * dist
+	halfW := halfH * c.aspect()
+	planeAt := func(inward, offset math.Vector3) cullPlane {
+		p0 := c.Eye.TranslateBy(offset).AsVector()
+		return cullPlane{n: inward, d: -inward.Dot(p0)}
+	}
+	return []cullPlane{
+		near,
+		planeAt(right, right.Scale(-halfW)), // left boundary, inward = +right
+		planeAt(right.Negate(), right.Scale(halfW)), // right boundary, inward = −right
+		planeAt(up, up.Scale(-halfH)),               // bottom boundary, inward = +up
+		planeAt(up.Negate(), up.Scale(halfH)),       // top boundary, inward = −up
+	}
+}
+
+// aspect is the viewport width/height ratio, defaulting to 1 for a degenerate (zero-height) size.
+func (c Camera) aspect() float64 {
+	if c.Height <= 0 {
+		return 1
+	}
+	return float64(c.Width) / float64(c.Height)
+}

--- a/scene/frustum_test.go
+++ b/scene/frustum_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package scene
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// centeredCamera looks from +Z down −Z at the origin with a 90° FOV and a square viewport, so the
+// half-angle is 45° and the on-axis frustum math is easy to reason about (half-width ≈ dist).
+func centeredCamera() Camera {
+	c := NewCamera(400, 400)
+	c.Eye = math.P3(0, 0, 10)
+	c.Target = math.P3(0, 0, 0)
+	c.Up = math.V3(0, 1, 0)
+	c.FOV = stdmath.Pi / 2 // 90° vertical
+	return c
+}
+
+func boxAt(cx, cy, cz, half float64) math.Box {
+	c := math.P3(math.Scalar(cx), math.Scalar(cy), math.Scalar(cz))
+	d := math.V3(math.Scalar(half), math.Scalar(half), math.Scalar(half))
+	return math.NewBox(c.TranslateBy(d.Negate()), c.TranslateBy(d))
+}
+
+func TestFrustumKeepsOnAxisBoxAndDropsOffScreen(t *testing.T) {
+	f := centeredCamera().Frustum()
+	cases := []struct {
+		name string
+		box  math.Box
+		want bool
+	}{
+		{"in front, on axis", boxAt(0, 0, 0, 1), true},
+		{"behind the eye", boxAt(0, 0, 20, 1), false},
+		{"far to the right (off-screen)", boxAt(100, 0, 0, 1), false},
+		{"far above (off-screen)", boxAt(0, 100, 0, 1), false},
+		{"just inside the right edge", boxAt(8, 0, 0, 1), true}, // at z=0 half-width ≈ 10 (dist 10, 45°)
+		{"empty box", math.EmptyBox(), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := f.IntersectsBox(c.box); got != c.want {
+				t.Errorf("IntersectsBox = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestFrustumNeverDropsAVisiblePoint is the safety property: any point that projects inside the
+// viewport must be kept (no false negatives → no popping). It samples a grid on the target plane,
+// keeps those that project on-screen, and checks each is kept by the frustum.
+func TestFrustumNeverDropsAVisiblePoint(t *testing.T) {
+	cam := centeredCamera()
+	f := cam.Frustum()
+	for ix := -9; ix <= 9; ix++ {
+		for iy := -9; iy <= 9; iy++ {
+			p := math.P3(math.Scalar(ix), math.Scalar(iy), 0)
+			px, py := project(cam, p)
+			if px < 0 || px > float64(cam.Width) || py < 0 || py > float64(cam.Height) {
+				continue // off-screen: the frustum may drop it
+			}
+			if !f.IntersectsBox(math.NewBox(p, p)) {
+				t.Errorf("point %v projects on-screen at (%.0f,%.0f) but was culled", p, px, py)
+			}
+		}
+	}
+}
+
+func TestFrustumOrthographicCulls(t *testing.T) {
+	cam := centeredCamera()
+	cam.Orthographic = true
+	f := cam.Frustum()
+	if !f.IntersectsBox(boxAt(0, 0, 0, 1)) {
+		t.Error("ortho frustum should keep an on-axis box")
+	}
+	if f.IntersectsBox(boxAt(100, 0, 0, 1)) {
+		t.Error("ortho frustum should cull a box well outside the lateral extent")
+	}
+	if f.IntersectsBox(boxAt(0, 0, 20, 1)) {
+		t.Error("ortho frustum should cull a box behind the eye")
+	}
+}
+
+// project maps a world point to a viewport pixel via the same NDC math RayThrough inverts, so the
+// "is it on screen" oracle in the safety test is independent of the frustum under test.
+func project(c Camera, p math.Point3) (px, py float64) {
+	fwd := unit(c.Eye.VectorTo(c.Target))
+	right := unit(fwd.Cross(c.Up))
+	up := right.Cross(fwd)
+	v := c.Eye.VectorTo(p)
+	z := float64(v.Dot(fwd))
+	tanHalf := stdmath.Tan(c.FOV / 2)
+	ndcX := float64(v.Dot(right)) / z / (tanHalf * c.aspect())
+	ndcY := float64(v.Dot(up)) / z / tanHalf
+	px = (ndcX + 1) / 2 * float64(c.Width)
+	py = (1 - ndcY) / 2 * float64(c.Height)
+	return px, py
+}


### PR DESCRIPTION
## What

Off-screen component placements are now dropped before the GPU upload, via a **view-frustum broad phase over the assembly BVH** (the spatial index F5 introduced).

Closes #1200 (M34-F1). Splits the merged-frame-mesh retention into a focused follow-up, #1210 (F1b).

## Why

The baseline (M34-B6) flagged that the instanced path emits a matrix + draw for **every** placement every frame regardless of view — at the 1M-placement target that means uploading 1M matrices and drawing all of them each frame. Only a cheap per-body half-space test existed on the legacy path.

## How

- **`scene.Frustum`** — `Camera.Frustum()` builds the near + four side planes (perspective and orthographic, inward normals); `Frustum.IntersectsBox` is a **conservative** AABB test: it may keep a box straddling a frustum corner, but never drops a visible one (proven by a property test that samples on-screen points). No false negatives → no popping.
- **`assemblyPickIndex.frustumPlacements`** — reuses the F5 BVH to prune any subtree wholly outside the view; returns survivors in ascending placement order.
- **`Session.CulledInstances(cam)`** — groups the survivors into instance groups by shared source body (identical in shape to `VisibleInstances`, so the head's per-source mesh cache keeps hitting). The head draws this; **framing/shadow bounds still use the full `VisibleInstances`** so they don't shift on orbit. Parts have no index and are returned unculled.

## Result (`BenchmarkCulledInstances` vs `BenchmarkVisibleInstances`, auto30k)

A zoomed corner view:

| | Transforms to GPU | Time | Alloc |
|---|---|---|---|
| VisibleInstances (all) | 29,900 | 10.75 ms | 44 MB |
| **CulledInstances** | **19** | **9.4 µs** | **4.4 KB** |

(`CulledInstances` queries the cached index instead of re-flattening, so it's cheaper than the full path even when most is visible.)

## Scope note

Culling is the win for zoomed views and the 1M target. At a *full-frame* orbit everything is in view, so the 53%-of-allocation `instanceBuilder.appendStream` rebuild of the merged frame mesh is unchanged — that's a distinct optimization, now tracked as **#1210 (F1b)**.

## Tests & verification

- `scene`: frustum keep/drop table, **no-false-negative property test**, orthographic culling.
- `app`: keeps all when framed, drops off-screen while keeping the view-center box, parts unchanged, BVH frustum prune.
- **Live-confirmed**: rendered the full 30k assembly through the culled `DrawChrome` path (lavapipe) — complete, no popping.
- `gofmt`/`vet`/`golangci-lint` clean; root + head build green; merged latest `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)