### PR TITLE
M34-F2b: cache body edge/face/vertex derivation

### DIFF
--- a/architecture/performance/large-assembly-baseline.md
+++ b/architecture/performance/large-assembly-baseline.md
@@ -106,7 +106,10 @@ driven by the per-frame allocation churn — not GPU submission.
    occurrence revision does not capture a child part's geometry edit, and `PlacedBodies` must read
    live child bodies — caching them would return stale geometry. The remaining `topo.*.Edges`
    re-derivation (~28% of orbit alloc, a render-path cost on the immutable kernel body, not the
-   flatten) is split out as **F2b cache body edge/face derivation (#1212)**.
+   flatten) is split out as **F2b cache body edge/face derivation (#1212). ✅ RESOLVED**: the
+   distinct face/edge/vertex lists are now precomputed once at body finalization (immutable
+   topology) and returned from cache — per-query 6 allocs/223 ns → 1 alloc/21 ns, full-frame 30k
+   orbit allocation 738 MB → 603 MB.
 4. **F4 — Vulkan frames-in-flight + DEVICE_LOCAL geometry (#1203).** Not isolable on
    lavapipe, but the architecture (per-frame full stall + per-frame HOST_VISIBLE
    re-upload of the whole scene) is the next wall on real GPUs once F1/F2 cut the CPU

--- a/kernel/topo/body.go
+++ b/kernel/topo/body.go
@@ -10,12 +10,24 @@ import (
 
 // Body (SurfaceBody) is the top of the topology graph: one or more shells. A solid
 // body is bounded by closed shells; a surface body may have open shells.
+//
+// derived/cached* memoize the distinct face/edge/vertex lists, which the render hot paths
+// (range box, drawlist) re-query every frame — re-deriving them rebuilt a dedup map each call,
+// ~28% of orbit allocation at 30k (M34-F2b). They are written exactly once, by finalizeDerived
+// at the end of every body-construction path (RegroupShells / BodyFromShells / MergeBodies), and
+// read-only afterward, so reads need no lock even under the parallel flatten (which never queries
+// them). Before finalize (derived==false) the accessors derive live, so a partially-built body —
+// e.g. RegroupShells querying Faces() mid-regroup — still sees current geometry.
 type Body struct {
-	id      uint64
-	shells  []*Shell
-	wires   []*Wire
-	solid   bool
-	lineage Lineage
+	id             uint64
+	shells         []*Shell
+	wires          []*Wire
+	solid          bool
+	lineage        Lineage
+	derived        bool
+	cachedFaces    []*Face
+	cachedEdges    []*Edge
+	cachedVertices []*Vertex
 }
 
 func (b *Body) ID() uint64           { return b.id }
@@ -29,8 +41,47 @@ func (b *Body) IsSolid() bool { return b.solid }
 // Shells returns the body's shells.
 func (b *Body) Shells() []*Shell { return append([]*Shell(nil), b.shells...) }
 
-// Faces returns every face in the body, across all shells.
+// Faces returns every face in the body, across all shells. The result is a fresh slice the
+// caller may keep; once the body is finalized it is a copy of the cached list.
 func (b *Body) Faces() []*Face {
+	if b.derived {
+		return append([]*Face(nil), b.cachedFaces...)
+	}
+	return b.deriveFaces()
+}
+
+// Edges returns every distinct edge in the body.
+func (b *Body) Edges() []*Edge {
+	if b.derived {
+		return append([]*Edge(nil), b.cachedEdges...)
+	}
+	return deriveEdgesFrom(b.deriveFaces())
+}
+
+// Vertices returns every distinct vertex in the body.
+func (b *Body) Vertices() []*Vertex {
+	if b.derived {
+		return append([]*Vertex(nil), b.cachedVertices...)
+	}
+	return deriveVerticesFrom(deriveEdgesFrom(b.deriveFaces()))
+}
+
+// finalizeDerived precomputes the distinct face/edge/vertex lists once the body's shells are
+// final, so later queries return a cached copy instead of rebuilding a dedup map every call. It
+// must be the last step of every construction path; reads after it are race-free because the
+// lists are written here once and never mutated.
+func (b *Body) finalizeDerived() {
+	b.cachedFaces = b.deriveFaces()
+	for _, f := range b.cachedFaces {
+		f.finalizeDerived()
+	}
+	b.cachedEdges = deriveEdgesFrom(b.cachedFaces)
+	b.cachedVertices = deriveVerticesFrom(b.cachedEdges)
+	b.derived = true
+}
+
+// deriveFaces collects the faces across all shells in shell order (the live, uncached form).
+func (b *Body) deriveFaces() []*Face {
 	var out []*Face
 	for _, s := range b.shells {
 		out = append(out, s.faces...)
@@ -38,11 +89,11 @@ func (b *Body) Faces() []*Face {
 	return out
 }
 
-// Edges returns every distinct edge in the body.
-func (b *Body) Edges() []*Edge {
+// deriveEdgesFrom returns the distinct edges of the given faces, in first-seen order.
+func deriveEdgesFrom(faces []*Face) []*Edge {
 	seen := map[*Edge]bool{}
 	var out []*Edge
-	for _, f := range b.Faces() {
+	for _, f := range faces {
 		for _, e := range f.Edges() {
 			if !seen[e] {
 				seen[e] = true
@@ -53,11 +104,11 @@ func (b *Body) Edges() []*Edge {
 	return out
 }
 
-// Vertices returns every distinct vertex in the body.
-func (b *Body) Vertices() []*Vertex {
+// deriveVerticesFrom returns the distinct vertices of the given edges, in first-seen order.
+func deriveVerticesFrom(edges []*Edge) []*Vertex {
 	seen := map[*Vertex]bool{}
 	var out []*Vertex
-	for _, e := range b.Edges() {
+	for _, e := range edges {
 		for _, v := range e.Vertices() {
 			if !seen[v] {
 				seen[v] = true
@@ -125,6 +176,7 @@ func BodyFromShells(lineage Lineage, solid bool, shells ...*Shell) *Body {
 		sh.body = body
 		body.shells = append(body.shells, sh)
 	}
+	body.finalizeDerived()
 	return body
 }
 
@@ -139,5 +191,6 @@ func MergeBodies(lineage Lineage, solid bool, bodies ...*Body) *Body {
 			merged.shells = append(merged.shells, sh)
 		}
 	}
+	merged.finalizeDerived()
 	return merged
 }

--- a/kernel/topo/derived_cache_test.go
+++ b/kernel/topo/derived_cache_test.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package topo
+
+import "testing"
+
+func sameEdges(a, b []*Edge) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func sameVertices(a, b []*Vertex) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestDerivedCacheMatchesLiveDerivation is the F2b correctness contract: the cached adjacency lists
+// a finalized body returns must be exactly the distinct faces/edges/vertices a fresh derivation
+// produces — same elements, same first-seen order — or every consumer (range box, drawlist, picking,
+// keys) shifts. A tetra has 4 faces, 6 edges, 4 vertices.
+func TestDerivedCacheMatchesLiveDerivation(t *testing.T) {
+	b := linedTetra(componentLineage)
+	if !b.derived {
+		t.Fatal("Build should finalize the derived caches")
+	}
+	if len(b.Faces()) != 4 || len(b.Edges()) != 6 || len(b.Vertices()) != 4 {
+		t.Fatalf("tetra faces=%d edges=%d verts=%d, want 4/6/4", len(b.Faces()), len(b.Edges()), len(b.Vertices()))
+	}
+	if !sameEdges(b.Edges(), deriveEdgesFrom(b.deriveFaces())) {
+		t.Error("cached body edges differ from a fresh derivation")
+	}
+	if !sameVertices(b.Vertices(), deriveVerticesFrom(deriveEdgesFrom(b.deriveFaces()))) {
+		t.Error("cached body vertices differ from a fresh derivation")
+	}
+}
+
+// TestDerivedCacheLivePathEqualsCached pins that the pre-finalize live path (derived==false, as
+// during RegroupShells) yields the same result as the finalized cache, so finalization is
+// transparent.
+func TestDerivedCacheLivePathEqualsCached(t *testing.T) {
+	b := linedTetra(componentLineage)
+	cached := b.Edges()
+	b.derived = false // force the uncached path the body uses mid-build
+	if !sameEdges(cached, b.Edges()) {
+		t.Error("live edge derivation differs from the finalized cache")
+	}
+}
+
+// TestDerivedCacheReturnsCopy guards the fresh-slice contract: mutating a returned slice must not
+// corrupt the cache, so a careless consumer cannot poison every later query.
+func TestDerivedCacheReturnsCopy(t *testing.T) {
+	b := linedTetra(componentLineage)
+	edges := b.Edges()
+	edges[0] = nil
+	if b.Edges()[0] == nil {
+		t.Error("Edges() handed out the cached backing slice; a mutation leaked into the cache")
+	}
+	faces := b.Faces()
+	faces[0] = nil
+	if b.Faces()[0] == nil {
+		t.Error("Faces() handed out the cached backing slice")
+	}
+}
+
+// TestFaceCacheFinalizedWithBody checks each face is finalized when its body is and returns its
+// three bounding edges from the cache.
+func TestFaceCacheFinalizedWithBody(t *testing.T) {
+	b := linedTetra(componentLineage)
+	for i, f := range b.Faces() {
+		if !f.derived {
+			t.Fatalf("face %d not finalized with its body", i)
+		}
+		if len(f.Edges()) != 3 {
+			t.Errorf("tetra face %d edges = %d, want 3", i, len(f.Edges()))
+		}
+		if !sameEdges(f.Edges(), f.deriveEdges()) {
+			t.Errorf("face %d cached edges differ from live derivation", i)
+		}
+	}
+}
+
+// TestMergeBodiesFinalizesUnion checks MergeBodies finalizes the merged body and its caches are the
+// union of the inputs (two disjoint tetra = 8 faces / 12 edges / 8 vertices).
+func TestMergeBodiesFinalizesUnion(t *testing.T) {
+	a := linedTetra(componentLineage)
+	c := linedTetra(placedLineage(1))
+	m := MergeBodies(NewLineage(Tok("m", "body", 0)), true, a, c)
+	if !m.derived {
+		t.Fatal("MergeBodies should finalize the derived caches")
+	}
+	if len(m.Faces()) != 8 || len(m.Edges()) != 12 || len(m.Vertices()) != 8 {
+		t.Errorf("merged faces=%d edges=%d verts=%d, want 8/12/8", len(m.Faces()), len(m.Edges()), len(m.Vertices()))
+	}
+}
+
+// BenchmarkBodyEdgesCachedVsLive contrasts the finalized cached query against the pre-F2b live
+// derivation (rebuilding the dedup map every call) — the per-frame cost the cache removes.
+func BenchmarkBodyEdgesCachedVsLive(b *testing.B) {
+	body := linedTetra(componentLineage)
+	b.Run("cached", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = body.Edges()
+		}
+	})
+	b.Run("live", func(b *testing.B) {
+		body.derived = false
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = body.Edges()
+		}
+		body.derived = true
+	})
+}

--- a/kernel/topo/shell.go
+++ b/kernel/topo/shell.go
@@ -66,6 +66,7 @@ func (s *Shell) RangeBox() math.Box {
 func RegroupShells(b *Body) {
 	faces := b.Faces()
 	if len(faces) == 0 {
+		b.finalizeDerived() // finalize even an empty body so its accessors take the cached path
 		return
 	}
 	groups := connectedFaceGroups(faces)
@@ -77,6 +78,7 @@ func RegroupShells(b *Body) {
 		}
 		b.shells[i] = sh
 	}
+	b.finalizeDerived() // shells are now final — precompute the adjacency lists once (M34-F2b)
 }
 
 // connectedFaceGroups partitions faces into edge-connected groups, preserving

--- a/kernel/topo/topology.go
+++ b/kernel/topo/topology.go
@@ -178,6 +178,12 @@ type Face struct {
 	shell    *Shell
 	lineage  Lineage
 	reversed bool
+	// derived/cached* memoize the face's distinct edges/vertices, re-queried per frame by the
+	// drawlist and range-box paths (M34-F2b). Written once by finalizeDerived when the owning body
+	// is finalized (the loops are complete by then); before that the accessors derive live.
+	derived        bool
+	cachedEdges    []*Edge
+	cachedVertices []*Vertex
 }
 
 func (f *Face) ID() uint64           { return f.id }
@@ -197,8 +203,33 @@ func (f *Face) Reversed() bool { return f.reversed }
 // Loops returns the face's boundary loops (outer first by construction).
 func (f *Face) Loops() []*Loop { return append([]*Loop(nil), f.loops...) }
 
-// Edges returns the distinct edges bounding the face.
+// Edges returns the distinct edges bounding the face. The result is a fresh slice the caller may
+// keep; once the owning body is finalized it is a copy of the cached list (M34-F2b).
 func (f *Face) Edges() []*Edge {
+	if f.derived {
+		return append([]*Edge(nil), f.cachedEdges...)
+	}
+	return f.deriveEdges()
+}
+
+// Vertices returns the distinct vertices bounding the face.
+func (f *Face) Vertices() []*Vertex {
+	if f.derived {
+		return append([]*Vertex(nil), f.cachedVertices...)
+	}
+	return deriveVerticesFrom(f.deriveEdges())
+}
+
+// finalizeDerived precomputes the face's distinct edge/vertex lists once its loops are complete
+// (the owning body is being finalized). Written once, read-only after — see Body.finalizeDerived.
+func (f *Face) finalizeDerived() {
+	f.cachedEdges = f.deriveEdges()
+	f.cachedVertices = deriveVerticesFrom(f.cachedEdges)
+	f.derived = true
+}
+
+// deriveEdges collects the distinct edges across the face's loops in first-seen order (live form).
+func (f *Face) deriveEdges() []*Edge {
 	seen := map[*Edge]bool{}
 	var out []*Edge
 	for _, l := range f.loops {
@@ -206,21 +237,6 @@ func (f *Face) Edges() []*Edge {
 			if !seen[u.edge] {
 				seen[u.edge] = true
 				out = append(out, u.edge)
-			}
-		}
-	}
-	return out
-}
-
-// Vertices returns the distinct vertices bounding the face.
-func (f *Face) Vertices() []*Vertex {
-	seen := map[*Vertex]bool{}
-	var out []*Vertex
-	for _, e := range f.Edges() {
-		for _, v := range e.Vertices() {
-			if !seen[v] {
-				seen[v] = true
-				out = append(out, v)
 			}
 		}
 	}


### PR DESCRIPTION
## What

`topo.Body.Edges/Faces/Vertices` and `topo.Face.Edges/Vertices` now return a **precomputed cached list** instead of rebuilding a dedup map + slice on every call.

Closes #1212 (M34-F2b), the render-path half split out of #1201 (F2).

## Why

The baseline (M34-B6) attributed **~28% of orbit allocation** at 30k to `topo.*.Edges` being re-derived every frame (range box + drawlist re-query them). Each call allocated a `map[*Edge]bool` (plus per-face maps) — pure garbage, since a body's topology is immutable once built.

## How — and why it's safe on a shared kernel type

A body's faces/edges/vertices are fixed once construction finishes, so they're precomputed **once** in `finalizeDerived`, called at the end of every body-construction path: `RegroupShells` (the last step of `Builder.Build`), `BodyFromShells`, and `MergeBodies`. Key safety properties (verified, not assumed):

- **Write-once, read-only:** the lists are written only in `finalizeDerived` at build time (single-threaded) and never mutated after — so reads are race-free even under the F2 parallel flatten (which never queries them). `go test -race` clean.
- **Mid-build correctness:** before finalize (`derived == false`) the accessors derive live, so `RegroupShells` querying `Faces()` *mid-regroup* (before the shell order is final) still sees current geometry. The cache is only populated once shells are final.
- **No post-build mutation:** the only mutations of `Shell.faces` / `Face.loops` are in `kernel/topo/builder.go` during construction (the two ops that append to a `.loops` field do so on local `filletFace`/`weldedFace` builder structs, not `topo.Face`).
- **Fresh-slice contract preserved:** a *copy* is returned, so a careless caller cannot poison the cache (a regression test asserts this).

## Result

| query | before (live) | after (cached) |
|---|---|---|
| `Body.Edges()` (tetra) | 6 allocs / 223 ns | **1 alloc / 21 ns** |

The dropped dedup map scales with edge count, so dense bodies gain far more. Full-frame 30k orbit allocation **738 MB → 603 MB**.

## Tests & verification

- Cache == fresh derivation (elements + order) for body and face; live path == cached path; `MergeBodies` union; **returned-slice-is-a-copy** guard.
- **All 101 packages pass** (incl. tessellation volume/area regression + booleans + STEP); `go test -race` clean on topo; `gofmt`/`vet`/`golangci-lint` clean; head builds.
- **Live-confirmed**: 30k assembly renders byte-identical to before (no dropped edges/geometry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)