### PR TITLE
M34-F6: DAG cycle + depth guard in the assembly flatten

### DIFF
--- a/architecture/performance/large-assembly-baseline.md
+++ b/architecture/performance/large-assembly-baseline.md
@@ -118,7 +118,10 @@ driven by the per-frame allocation churn — not GPU submission.
    `BuildBrowser` is only 4.8 MB / 1.1 ms at 30k. The real cost is the `drawNode` cgo
    walk (every node, every frame), which `OBK_FRAME_TIMING`'s new `browserNs` phase now
    measures in-app — re-rank after an in-app capture with the tree expanded.
-6. **F6 — DAG cycle/depth guard (#1205).** Safety before 1M stress runs.
+6. **F6 — DAG cycle/depth guard (#1205). ✅ RESOLVED.** The flatten now tracks the sub-assembly
+   definitions on the current branch (cycle set) and caps recursion at `maxAssemblyDepth` (256), so
+   a self-containing or pathologically deep occurrence DAG degrades to a bounded, finite flatten
+   instead of overflowing the stack. No measurable overhead (guard touches only interior nodes).
 7. **F7 — LOD / impostors (#1206).** The vertex-throughput wall at true 1M, after F1–F5.
 
 ## Reproduce

--- a/model/compdef/assembly_derive.go
+++ b/model/compdef/assembly_derive.go
@@ -36,7 +36,7 @@ const parallelFlattenMinRoots = 4
 // flattenSerial walks the whole tree on one goroutine — the small-assembly path and the reference
 // the parallel path must match exactly.
 func flattenSerial(occs *occurrence.Occurrences) []feature.PlacedBody {
-	w := placeWalker{}
+	w := newPlaceWalker()
 	w.walk(occs, math.Identity4(), nil)
 	return w.out
 }
@@ -59,7 +59,7 @@ func flattenParallel(occs *occurrence.Occurrences) []feature.PlacedBody {
 		wg.Add(1)
 		go func(slot, lo, hi int) {
 			defer wg.Done()
-			w := placeWalker{}
+			w := newPlaceWalker()
 			for i := lo; i < hi; i++ {
 				w.place(occs.Item(i), math.Identity4(), nil)
 			}
@@ -103,8 +103,22 @@ func concatPlaced(parts [][]feature.PlacedBody) []feature.PlacedBody {
 // allocated either. Output is byte-for-byte identical to the previous recursion — same DFS order,
 // same paths — so this is a pure allocation cut, not a behaviour change.
 type placeWalker struct {
-	stack []string // current occurrence-name path, reused across the whole walk
-	out   []feature.PlacedBody
+	stack  []string // current occurrence-name path, reused across the whole walk
+	out    []feature.PlacedBody
+	active map[occurrence.Composite]bool // sub-assembly definitions on the current branch (cycle guard)
+	depth  int                           // current recursion depth (depth guard)
+}
+
+// maxAssemblyDepth caps the occurrence-DAG recursion. Real assemblies are 6–8 levels (the
+// automotive benchmark is 7); 256 is a generous backstop so a pathologically deep — or
+// definition-cyclic — tree degrades to a bounded, finite flatten instead of overflowing the stack
+// (M34-F6). The cycle set catches a definition reached through itself directly; the depth cap is the
+// belt-and-braces limit for any other runaway nesting.
+const maxAssemblyDepth = 256
+
+// newPlaceWalker returns a walker with its cycle-guard set initialised.
+func newPlaceWalker() placeWalker {
+	return placeWalker{active: map[occurrence.Composite]bool{}}
 }
 
 // walk descends one occurrence level, composing each child's transform with parent's. flexParent,
@@ -133,13 +147,28 @@ func (w *placeWalker) place(o *occurrence.Occurrence, parent math.Matrix4, flexP
 			w.out = append(w.out, feature.PlacedBody{Body: b, Transform: world, Source: o, Path: w.clonePath()})
 		}
 	case occurrence.Composite: // a sub-assembly: recurse, carrying flexible-child overrides
-		var nextFlex *occurrence.Occurrence // reset: a non-flexible sub-assembly clears the override
-		if o.Flexible() {
-			nextFlex = o
-		}
-		w.walk(def.Occurrences(), world, nextFlex)
+		w.descend(def, o, world)
 	}
 	w.stack = w.stack[:len(w.stack)-1]
+}
+
+// descend recurses into a sub-assembly under the cycle and depth guards (M34-F6): a definition
+// already on the current branch (a self-containing assembly) or a branch past maxAssemblyDepth is
+// skipped, so a malformed DAG degrades to a bounded flatten instead of overflowing the stack. The
+// flexible-child override resets unless this occurrence is itself flexible.
+func (w *placeWalker) descend(def occurrence.Composite, o *occurrence.Occurrence, world math.Matrix4) {
+	if w.depth >= maxAssemblyDepth || w.active[def] {
+		return
+	}
+	var nextFlex *occurrence.Occurrence // reset: a non-flexible sub-assembly clears the override
+	if o.Flexible() {
+		nextFlex = o
+	}
+	w.active[def] = true
+	w.depth++
+	w.walk(def.Occurrences(), world, nextFlex)
+	w.depth--
+	delete(w.active, def)
 }
 
 // clonePath returns an owned copy of the current name path; each PlacedBody retains its own, so a

--- a/model/compdef/assembly_derive_guard_test.go
+++ b/model/compdef/assembly_derive_guard_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestFlattenStopsOnCyclicDAG builds a definition cycle — assembly A contains B, B contains A —
+// and checks PlacedBodies terminates with a bounded result instead of recursing forever (M34-F6).
+// Without the cycle guard this test would hang / overflow the stack.
+func TestFlattenStopsOnCyclicDAG(t *testing.T) {
+	part := partWithBlock(t, math.P3(0, 0, 0), math.P3(1, 1, 1))
+	a := NewAssemblyComponentDefinition()
+	b := NewAssemblyComponentDefinition()
+	a.Place("p", part, math.Identity4())
+	a.Place("toB", b, math.Identity4())
+	b.Place("toA", a, math.Identity4())
+
+	placed := a.PlacedBodies() // must return, not hang
+	if len(placed) == 0 {
+		t.Fatal("expected the part to be emitted at least once")
+	}
+	if len(placed) > 8 {
+		t.Errorf("cyclic flatten emitted %d bodies; guard should keep it small/bounded", len(placed))
+	}
+}
+
+// TestFlattenDepthCapBoundsDeepChain nests assemblies far past maxAssemblyDepth with a part only at
+// the very bottom, and a part at the top. The shallow part is emitted; the part beyond the depth cap
+// is not — proving the depth backstop engages and the walk stays finite (M34-F6).
+func TestFlattenDepthCapBoundsDeepChain(t *testing.T) {
+	part := partWithBlock(t, math.P3(0, 0, 0), math.P3(1, 1, 1))
+	top := NewAssemblyComponentDefinition()
+	top.Place("shallow", part, math.Identity4())
+
+	cur := top
+	for i := 0; i < maxAssemblyDepth+50; i++ {
+		next := NewAssemblyComponentDefinition()
+		cur.Place("child", next, math.Identity4())
+		cur = next
+	}
+	cur.Place("deep", part, math.Identity4()) // sits below the depth cap
+
+	placed := top.PlacedBodies()
+	if len(placed) != 1 {
+		t.Fatalf("got %d bodies, want 1 (only the shallow part; the deep one is past the cap)", len(placed))
+	}
+}


### PR DESCRIPTION
## What

The assembly flatten (`placeWalker`) now guards against a cyclic or pathologically deep occurrence DAG.

Closes #1205 (M34-F6).

## Why

The flatten recurses through the occurrence tree to compose world transforms. A malformed model — a sub-assembly that (transitively) contains its own definition, or runaway nesting — would recurse forever and overflow the stack. There was no guard; this is a safety prerequisite before 1M-scale stress runs.

## How

- **Cycle set:** the walker tracks the sub-assembly *definitions* on the current branch; descending into a definition already on the branch is skipped.
- **Depth cap:** recursion stops at `maxAssemblyDepth` (256 — real assemblies are 6–8 deep; the benchmark is 7), a belt-and-braces backstop for any other runaway nesting.

A bad DAG degrades to a bounded, finite flatten instead of hanging. The guard only touches interior (sub-assembly) nodes, so there is **no measurable cost** (BenchmarkCollectPlacedBodies unchanged at 3.48 ms / 30k).

## Tests

- `A↔B` definition cycle: `PlacedBodies` terminates with a small bounded result (would hang without the guard).
- Chain nested past the depth cap: deep content is dropped, the walk stays finite, shallow content still emitted.
- Existing flatten + parallel-equality tests unchanged; race + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)