### PR TITLE
M34-F3: virtualize wide browser leaf runs with ImGuiListClipper

### DIFF
--- a/architecture/performance/large-assembly-baseline.md
+++ b/architecture/performance/large-assembly-baseline.md
@@ -118,10 +118,12 @@ driven by the per-frame allocation churn — not GPU submission.
    lavapipe, but the architecture (per-frame full stall + per-frame HOST_VISIBLE
    re-upload of the whole scene) is the next wall on real GPUs once F1/F2 cut the CPU
    churn; first-frame upload is already multi-second.
-5. **F3 — virtualized browser tree (#1202).** Lower than first expected:
-   `BuildBrowser` is only 4.8 MB / 1.1 ms at 30k. The real cost is the `drawNode` cgo
-   walk (every node, every frame), which `OBK_FRAME_TIMING`'s new `browserNs` phase now
-   measures in-app — re-rank after an in-app capture with the tree expanded.
+5. **F3 — virtualized browser tree (#1202). ✅ RESOLVED.** `BuildBrowser` itself is cheap (4.8 MB /
+   1.1 ms); the cost was the `drawNode` cgo walk over every node every frame. Now any long
+   contiguous run of leaf sibling rows (bodies, occurrences) is drawn through an `ImGuiListClipper`
+   (new native binding), so only the rows in the scroll viewport make cgo calls — O(visible) instead
+   of O(N). Runs are clipped even beside the Origin/Parameters branches, so a flat assembly's
+   thousands of occurrences virtualize. Branches and short runs stay recursive (non-uniform height).
 6. **F6 — DAG cycle/depth guard (#1205). ✅ RESOLVED.** The flatten now tracks the sub-assembly
    definitions on the current branch (cycle set) and caps recursion at `maxAssemblyDepth` (256), so
    a self-containing or pathologically deep occurrence DAG degrades to a bounded, finite flatten

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -39,6 +39,14 @@ int  obk_ig_tree_node_selectable(const char* label, int selected);
 void obk_ig_tree_pop(void);
 void obk_ig_bullet_text(const char* s);
 void obk_ig_set_item_tooltip(const char* s);
+void obk_ig_clipper_begin(int items);
+void obk_ig_clipper_include_item(int item);
+int  obk_ig_clipper_step(void);
+int  obk_ig_clipper_display_start(void);
+int  obk_ig_clipper_display_end(void);
+void obk_ig_clipper_end(void);
+void obk_ig_indent(float w);
+void obk_ig_unindent(float w);
 void obk_ig_progress_bar(float fraction, float w, const char* overlay);
 void obk_ig_main_viewport_size(float* w, float* h);
 float obk_ig_hover_seconds(void);
@@ -675,6 +683,33 @@ func TreeNodeSelectable(label string, selected bool) bool {
 	return C.obk_ig_tree_node_selectable(c, cBool(selected)) != 0
 }
 func TreePop() { C.obk_ig_tree_pop() }
+
+// ClipperBegin starts an ImGuiListClipper over items uniform-height rows, so only the rows that
+// fall inside the scroll viewport are submitted — the virtualization behind the large model
+// browser (M34-F3). Drive it with ClipperStep/ClipperRange and finish with ClipperEnd. Row height
+// is auto-measured from the first submitted row, so all rows must be the same height.
+func ClipperBegin(items int) { C.obk_ig_clipper_begin(C.int(items)) }
+
+// ClipperIncludeItem forces a row index to be submitted even when off-screen — used so a selected
+// row that is scrolled out can still call SetScrollHereY to bring itself into view. Call BEFORE the
+// first ClipperStep.
+func ClipperIncludeItem(item int) { C.obk_ig_clipper_include_item(C.int(item)) }
+
+// ClipperStep advances the clipper; it reports whether there is a visible range to draw this step.
+func ClipperStep() bool { return C.obk_ig_clipper_step() != 0 }
+
+// ClipperRange is the [start,end) row index range to draw for the current step.
+func ClipperRange() (int, int) {
+	return int(C.obk_ig_clipper_display_start()), int(C.obk_ig_clipper_display_end())
+}
+
+// ClipperEnd finishes the clipper, restoring the cursor to past the full virtual list height.
+func ClipperEnd() { C.obk_ig_clipper_end() }
+
+// Indent / Unindent shift the cursor by w pixels, used to render a flattened tree row at its depth
+// (the clipper draws a flat list, so nesting indentation is applied manually).
+func Indent(w float32)   { C.obk_ig_indent(C.float(w)) }
+func Unindent(w float32) { C.obk_ig_unindent(C.float(w)) }
 
 // BulletText draws a leaf row with a bullet (browser leaves).
 func BulletText(s string) {

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -125,6 +125,19 @@ int  obk_ig_tree_node_selectable(const char* label, int selected) {
 }
 void obk_ig_tree_pop(void)                   { ImGui::TreePop(); }
 void obk_ig_bullet_text(const char* s)       { ImGui::BulletText("%s", s); }
+
+// ImGuiListClipper virtualizes a uniform-height row list: only the rows inside the scroll viewport
+// are submitted (M34-F3, the large model browser). The render loop is single-threaded and these
+// flat leaf lists never nest a clipper inside another, so one static instance is reused per frame.
+static ImGuiListClipper g_obk_clipper;
+void obk_ig_clipper_begin(int items)         { g_obk_clipper.Begin(items, -1.0f); }
+void obk_ig_clipper_include_item(int item)   { g_obk_clipper.IncludeItemByIndex(item); }
+int  obk_ig_clipper_step(void)               { return g_obk_clipper.Step() ? 1 : 0; }
+int  obk_ig_clipper_display_start(void)      { return g_obk_clipper.DisplayStart; }
+int  obk_ig_clipper_display_end(void)        { return g_obk_clipper.DisplayEnd; }
+void obk_ig_clipper_end(void)                { g_obk_clipper.End(); }
+void obk_ig_indent(float w)                  { ImGui::Indent(w); }
+void obk_ig_unindent(float w)                { ImGui::Unindent(w); }
 void obk_ig_set_item_tooltip(const char* s)  { ImGui::SetItemTooltip("%s", s); }
 // progress_bar draws a determinate bar of the given pixel width; overlay text ("")
 // falls back to ImGui's percentage.

--- a/head/ui/browser_clipper_test.go
+++ b/head/ui/browser_clipper_test.go
@@ -1,0 +1,99 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"fmt"
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// TestLeafRunLengths pins how drawChildren partitions a child list into the contiguous leaf runs it
+// virtualizes: branches break runs, leaves between/around them form runs (M34-F3). This is the
+// flat-assembly case — a long run of occurrence leaves beside the Origin/Parameters branches.
+func TestLeafRunLengths(t *testing.T) {
+	branch := app.BrowserNode{Label: "p", Children: []app.BrowserNode{{Label: "c"}}}
+	leaf := app.BrowserNode{Label: "leaf"}
+	cases := []struct {
+		name string
+		in   []app.BrowserNode
+		want []int
+	}{
+		{"all leaves", []app.BrowserNode{leaf, leaf, leaf}, []int{3}},
+		{"leading branches then run", []app.BrowserNode{branch, branch, leaf, leaf, leaf}, []int{3}},
+		{"runs split by a branch", []app.BrowserNode{leaf, leaf, branch, leaf}, []int{2, 1}},
+		{"only branches", []app.BrowserNode{branch, branch}, nil},
+		{"empty", nil, nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := leafRunLengths(c.in)
+			if len(got) != len(c.want) {
+				t.Fatalf("runs = %v, want %v", got, c.want)
+			}
+			for i := range got {
+				if got[i] != c.want[i] {
+					t.Errorf("run %d = %d, want %d", i, got[i], c.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestInWindowBrowserClipsWideLeafList drives the real clipper path in an open Dear ImGui window: a
+// wide all-leaf list is drawn through drawChildren over several frames. A mismatched clipper
+// Begin/Step/End or a bad per-row id would trip ImGui's assertions, and the test pins the id
+// invariant — browserNodeSeq must advance by exactly one per leaf (no descendants), regardless of
+// how many rows the clipper actually submitted, so sibling nodes after the list keep their ids.
+func TestInWindowBrowserClipsWideLeafList(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	s := app.NewSession()
+
+	const n = 600 // well over browserClipThreshold
+	leaves := make([]app.BrowserNode, n)
+	for i := range leaves {
+		leaves[i] = app.BrowserNode{Label: fmt.Sprintf("body %d", i), Kind: "body"}
+	}
+
+	for f := 0; f < 3; f++ {
+		win.BeginFrame()
+		native.Begin("clip-test")
+		browserNodeSeq = 7
+		drawChildren(s, leaves)
+		got := browserNodeSeq
+		native.End()
+		win.EndFrame(0, 0, 0)
+		if got != 7+n {
+			t.Fatalf("browserNodeSeq = %d after a clipped %d-leaf list, want %d (one id per leaf)", got, n, 7+n)
+		}
+	}
+}
+
+// TestInWindowBrowserSmallListUnclipped checks the sub-threshold path still draws and advances the
+// id counter by one per leaf (the recursive walk), so the two paths agree on id accounting.
+func TestInWindowBrowserSmallListUnclipped(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	s := app.NewSession()
+
+	const n = 5 // under browserClipThreshold → recursive path
+	leaves := make([]app.BrowserNode, n)
+	for i := range leaves {
+		leaves[i] = app.BrowserNode{Label: fmt.Sprintf("leaf %d", i)}
+	}
+	win.BeginFrame()
+	native.Begin("small-test")
+	browserNodeSeq = 0
+	drawChildren(s, leaves)
+	got := browserNodeSeq
+	native.End()
+	win.EndFrame(0, 0, 0)
+	if got != n {
+		t.Fatalf("browserNodeSeq = %d after a %d-leaf recursive list, want %d", got, n, n)
+	}
+}

--- a/head/ui/browser_view.go
+++ b/head/ui/browser_view.go
@@ -122,6 +122,113 @@ func reportDoubleClick(s *app.Session, paneID, nodeID string) {
 	}
 }
 
+// browserClipThreshold is the child count above which a node's (all-leaf) children are drawn through
+// an ImGuiListClipper, so a body/occurrence list with thousands of rows only makes cgo calls for the
+// rows on screen — not all of them every frame (M34-F3). Below it the clipper's overhead isn't worth
+// it and the rows draw normally.
+const browserClipThreshold = 64
+
+// drawChildren renders a branch's children, virtualizing any long CONTIGUOUS RUN of leaf siblings
+// with a clipper and walking branches (and short runs) normally. Clipping runs — not just whole
+// all-leaf lists — means a flat assembly's 10k occurrences are virtualized even though they sit
+// beside the Origin/Parameters branches under the root (M34-F3). A run is uniform-height (every row
+// is a leaf), which is what the clipper requires; branches have variable height (an open branch is
+// taller) so they stay recursive. Leaves are contiguous in pre-order, so a run's ids stay correct.
+func drawChildren(s *app.Session, children []app.BrowserNode) {
+	for i := 0; i < len(children); {
+		if len(children[i].Children) > 0 { // a branch: recurse (advances browserNodeSeq by its subtree)
+			drawNode(s, children[i])
+			i++
+			continue
+		}
+		j := i
+		for j < len(children) && len(children[j].Children) == 0 {
+			j++
+		}
+		drawLeafRun(s, children[i:j])
+		i = j
+	}
+}
+
+// drawLeafRun draws a contiguous run of leaf siblings: clipped when long enough to be worth it,
+// else one by one (the clipper has fixed per-list overhead not worth paying for a few rows).
+func drawLeafRun(s *app.Session, run []app.BrowserNode) {
+	if len(run) >= browserClipThreshold {
+		drawClippedLeaves(s, run)
+		return
+	}
+	for k := range run {
+		drawNode(s, run[k])
+	}
+}
+
+// leafRunLengths returns the lengths of the maximal contiguous leaf runs in children, in order —
+// the structure drawChildren virtualizes. Exposed for testing the run partition without a window.
+func leafRunLengths(children []app.BrowserNode) []int {
+	var runs []int
+	for i := 0; i < len(children); {
+		if len(children[i].Children) > 0 {
+			i++
+			continue
+		}
+		j := i
+		for j < len(children) && len(children[j].Children) == 0 {
+			j++
+		}
+		runs = append(runs, j-i)
+		i = j
+	}
+	return runs
+}
+
+// drawClippedLeaves draws a wide leaf list through the clipper. It reserves exactly the per-row
+// ImGui ids the recursive walk would (one per leaf, contiguous from browserNodeSeq), force-includes
+// the selected row so scroll-to-selection still works when it is off-screen, and advances
+// browserNodeSeq past the whole list (each leaf consumes one id and has no descendants), so sibling
+// nodes after this branch keep the ids they had before.
+func drawClippedLeaves(s *app.Session, leaves []app.BrowserNode) {
+	base := browserNodeSeq
+	native.ClipperBegin(len(leaves))
+	if i := selectedLeafIndex(s, leaves); i >= 0 {
+		native.ClipperIncludeItem(i) // force-submit the selection so its SetScrollHereY runs (after Begin, before Step)
+	}
+	for native.ClipperStep() {
+		lo, hi := native.ClipperRange()
+		for i := lo; i < hi; i++ {
+			native.PushIDInt(base + 1 + i)
+			drawLeafRow(s, leaves[i])
+			native.PopID()
+		}
+	}
+	native.ClipperEnd()
+	browserNodeSeq = base + len(leaves)
+}
+
+// drawLeafRow draws one leaf: a selectable row (selection + double-click edit + context menu +
+// scroll-into-view) or a plain bullet.
+func drawLeafRow(s *app.Session, n app.BrowserNode) {
+	if n.Select != nil {
+		drawSelectableNode(s, n)
+		return
+	}
+	native.BulletText(n.Label)
+}
+
+// selectedLeafIndex returns the index of the leaf that is the current selection, or -1 — so the
+// clipper can force-submit it and its SetScrollHereY runs even when it is scrolled out of view.
+func selectedLeafIndex(s *app.Session, leaves []app.BrowserNode) int {
+	current := s.Selection().First()
+	if current == nil {
+		return -1
+	}
+	for i := range leaves {
+		if leaves[i].Select == current {
+			return i
+		}
+	}
+	return -1
+}
+
 // drawNode renders a browser node and its children: a selectable node as a clickable,
 // highlightable row; a branch as a collapsible tree node; a plain leaf as a bullet row.
 //
@@ -162,9 +269,7 @@ func drawSelectableBranchNode(s *app.Session, n app.BrowserNode) {
 	if !open {
 		return
 	}
-	for _, child := range n.Children {
-		drawNode(s, child)
-	}
+	drawChildren(s, n.Children)
 	native.TreePop()
 }
 
@@ -221,9 +326,7 @@ func drawBranchNode(s *app.Session, n app.BrowserNode) {
 	if !open {
 		return
 	}
-	for _, child := range n.Children {
-		drawNode(s, child)
-	}
+	drawChildren(s, n.Children)
 	native.TreePop()
 }
 


### PR DESCRIPTION
## What

The model browser now draws long runs of leaf rows through an **`ImGuiListClipper`**, so only the rows inside the scroll viewport make cgo calls.

Closes #1202 (M34-F3).

## Why

`drawNode` walked **every** browser node every frame — `PushID`/`TreeNode`/`Selectable`/context-menu per node, O(N) cgo calls regardless of how many rows are on screen. `BuildBrowser` itself is cheap (4.8 MB / 1.1 ms); this walk was the per-frame browser cost over a large tree.

## How

- **New native binding:** `ImGuiListClipper` (begin / step / range / include-item / end) + `Indent`/`Unindent`.
- **Clip leaf runs:** `drawChildren` partitions a node's children into contiguous runs of leaf siblings and branches. A long leaf run is drawn via the clipper (O(visible)); branches and short runs stay on the recursive walk (an open branch has non-uniform row height, which a clipper can't virtualize).
- **Flat assemblies covered:** clipping *runs* (not just whole all-leaf lists) means a flat assembly's thousands of occurrence rows virtualize even though they sit beside the Origin/Parameters branches under the root.
- **Correctness:** leaves are contiguous in pre-order, so a clipped run reserves exactly the per-row ImGui ids the recursive walk would and advances `browserNodeSeq` by the run length — sibling ids stay stable. The current selection is `IncludeItemByIndex`-forced so scroll-to-selection works when the selected row is off-screen. Per-row interaction (select / double-click edit / context menu) is unchanged — clipped rows call the same `drawSelectableNode`.

## Tests & verification

- `leafRunLengths` partition (branches break runs; runs around/between branches).
- In-window (real Vulkan): clip a 600-row list with no ImGui assertion + the id-advance invariant; sub-threshold recursive path.
- Full `head/ui` suite passes; `gofmt`/lint clean (my files); **live-confirmed** a 120-occurrence assembly browser renders identically.

## Scope note

Virtualizes wide *leaf* runs (the row-count hotspot: bodies, occurrences, deep fastener lists). A level that interleaves many branches isn't a uniform-height list and stays recursive — but such levels are narrow in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)