### PR TITLE
M34-F4: DEVICE_LOCAL geometry + dirty-flag re-upload

### DIFF
--- a/architecture/performance/large-assembly-baseline.md
+++ b/architecture/performance/large-assembly-baseline.md
@@ -114,10 +114,15 @@ driven by the per-frame allocation churn — not GPU submission.
    distinct face/edge/vertex lists are now precomputed once at body finalization (immutable
    topology) and returned from cache — per-query 6 allocs/223 ns → 1 alloc/21 ns, full-frame 30k
    orbit allocation 738 MB → 603 MB.
-4. **F4 — Vulkan frames-in-flight + DEVICE_LOCAL geometry (#1203).** Not isolable on
-   lavapipe, but the architecture (per-frame full stall + per-frame HOST_VISIBLE
-   re-upload of the whole scene) is the next wall on real GPUs once F1/F2 cut the CPU
-   churn; first-frame upload is already multi-second.
+4. **F4 — DEVICE_LOCAL geometry + dirty-flag re-upload (#1203). ✅ RESOLVED.** The native pass
+   rebuilt two `std::vector`s by concatenating all six streams and re-uploaded the whole scene
+   through HOST_VISIBLE memory *every frame*, even when (post-F1b) the geometry was unchanged. Now
+   the geometry lives in DEVICE_LOCAL buffers, uploaded via a staging copy + barrier only when the
+   geometry key changes; an orbit reuses the buffers and skips the concatenation and copy entirely.
+   **30k orbit wall time 523 ms → 274 ms** (native per-frame concatenation/upload eliminated;
+   instance matrices stay HOST_VISIBLE, per-frame). The remaining per-frame `vkWaitForFences` CPU
+   stall is split out as **F4b (#1218)** — it needs a real discrete GPU to measure and an
+   offscreen→ImGui GPU-semaphore (or double-buffered targets), so it is not validatable on lavapipe.
 5. **F3 — virtualized browser tree (#1202). ✅ RESOLVED.** `BuildBrowser` itself is cheap (4.8 MB /
    1.1 ms); the cost was the `drawNode` cgo walk over every node every frame. Now any long
    contiguous run of leaf sibling rows (bodies, occurrences) is drawn through an `ImGuiListClipper`

--- a/head/internal/native/smoke.go
+++ b/head/internal/native/smoke.go
@@ -63,7 +63,7 @@ func RunViewportSmoke(maxFrames int) int {
 	for i := 0; i < maxFrames && !w.ShouldClose(); i++ {
 		w.BeginFrame()
 		w.RenderViewport(0, 1280, 720, mvp[:], eye, verts, len(verts)/16, idx,
-			nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil, len(idx), nil, nil, nil)
+			nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil, len(idx), nil, nil, nil, 0)
 		w.EndFrame(0.10, 0.10, 0.12)
 	}
 	if path := os.Getenv("OBK_SMOKE_PNG"); path != "" {

--- a/head/internal/native/viewport.cpp
+++ b/head/internal/native/viewport.cpp
@@ -131,8 +131,13 @@ struct Viewport {
     // single-view target; the quad layout uses up to kMaxTiles.
     Target          targets[kMaxTiles];
 
-    GpuBuffer       vbuf, ibuf;
-    GpuBuffer       instbuf; // per-instance model matrices (binding 1, ADR-0038)
+    GpuBuffer       vbuf, ibuf;     // DEVICE_LOCAL geometry (M34-F4), uploaded only when geomKey changes
+    GpuBuffer       vstage, istage; // HOST_VISIBLE staging sources copied into vbuf/ibuf on a geometry change
+    GpuBuffer       instbuf;        // per-instance model matrices (binding 1, ADR-0038), HOST_VISIBLE (per-frame)
+    // lastGeomKey is the geometry signature the device-local buffers currently hold; a render whose
+    // geomKey matches reuses them and skips the concatenation + staging copy entirely (M34-F4). 0
+    // means "unknown" (legacy non-instanced path), which always re-uploads.
+    unsigned long long lastGeomKey = 0;
 
     // Background the 3D pass clears to (themed; ADR-0021). Defaults reproduce the
     // pre-theming look so an un-themed build is unchanged.
@@ -417,34 +422,56 @@ VkPipeline create_skybox_pipeline(HeadContext* c, Viewport* v) {
     return p;
 }
 
+// ensure_buffer (re)creates b sized >= bytes with the given usage and memory properties, growing
+// (never shrinking) so a steady scene stops reallocating. It returns whether it (re)allocated.
+bool ensure_buffer(HeadContext* c, GpuBuffer* b, VkBufferUsageFlags usage,
+                   VkMemoryPropertyFlags props, VkDeviceSize bytes) {
+    if (b->buffer && b->size >= bytes) return false;
+    if (b->buffer) vkDestroyBuffer(c->device, b->buffer, nullptr);
+    if (b->memory) vkFreeMemory(c->device, b->memory, nullptr);
+    VkBufferCreateInfo bi{};
+    bi.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    bi.size = bytes;
+    bi.usage = usage;
+    bi.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    vkCreateBuffer(c->device, &bi, nullptr, &b->buffer);
+    VkMemoryRequirements req;
+    vkGetBufferMemoryRequirements(c->device, b->buffer, &req);
+    VkMemoryAllocateInfo ai{};
+    ai.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    ai.allocationSize = req.size;
+    ai.memoryTypeIndex = obk_find_memory_type(c->physical, req.memoryTypeBits, props);
+    vkAllocateMemory(c->device, &ai, nullptr, &b->memory);
+    vkBindBufferMemory(c->device, b->buffer, b->memory, 0);
+    b->size = bytes;
+    return true;
+}
+
 void upload(HeadContext* c, GpuBuffer* b, VkBufferUsageFlags usage, const void* data,
             VkDeviceSize bytes) {
     if (bytes == 0) return;
-    if (b->size < bytes) { // grow
-        if (b->buffer) vkDestroyBuffer(c->device, b->buffer, nullptr);
-        if (b->memory) vkFreeMemory(c->device, b->memory, nullptr);
-        VkBufferCreateInfo bi{};
-        bi.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-        bi.size = bytes;
-        bi.usage = usage;
-        bi.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-        vkCreateBuffer(c->device, &bi, nullptr, &b->buffer);
-        VkMemoryRequirements req;
-        vkGetBufferMemoryRequirements(c->device, b->buffer, &req);
-        VkMemoryAllocateInfo ai{};
-        ai.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-        ai.allocationSize = req.size;
-        ai.memoryTypeIndex = obk_find_memory_type(c->physical, req.memoryTypeBits,
-            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-        vkAllocateMemory(c->device, &ai, nullptr, &b->memory);
-        vkBindBufferMemory(c->device, b->buffer, b->memory, 0);
-        b->size = bytes;
-    }
+    ensure_buffer(c, b, usage,
+                  VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, bytes);
     if (!data) return; // allocation only (e.g. a readback staging buffer filled by the GPU)
     void* mapped = nullptr;
     vkMapMemory(c->device, b->memory, 0, bytes, 0, &mapped);
     std::memcpy(mapped, data, (size_t)bytes);
     vkUnmapMemory(c->device, b->memory);
+}
+
+// stage_to_device copies host data into a DEVICE_LOCAL buffer via a HOST_VISIBLE staging buffer: it
+// fills the staging buffer now and records a buffer copy into cmd (which must be recording, before
+// the render pass). DEVICE_LOCAL geometry is faster for the GPU to read each frame; combined with
+// the geomKey dirty-flag the staging copy runs only when the geometry actually changes (M34-F4).
+void stage_to_device(HeadContext* c, VkCommandBuffer cmd, GpuBuffer* dst, GpuBuffer* staging,
+                     VkBufferUsageFlags usage, const void* data, VkDeviceSize bytes) {
+    if (bytes == 0) return;
+    upload(c, staging, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, data, bytes); // HOST_VISIBLE memcpy
+    ensure_buffer(c, dst, VK_BUFFER_USAGE_TRANSFER_DST_BIT | usage,
+                  VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, bytes);
+    VkBufferCopy region{};
+    region.size = bytes;
+    vkCmdCopyBuffer(cmd, staging->buffer, dst->buffer, 1, &region);
 }
 
 VkImageView make_image(HeadContext* c, VkFormat fmt, VkImageUsageFlags usage,
@@ -988,7 +1015,8 @@ void obk_viewport_render(void* h, int slot, int w, int hh, const float* mvp, con
                          const float* topTriV, int topTriVC, const uint32_t* topTriIdx, int topTriIC,
                          const float* topLineV, int topLineVC, const uint32_t* topLineIdx, int topLineIC,
                          int triBiasFirst, const float* clip,
-                         const float* mats, int matCount, const int32_t* recs, int recCount) {
+                         const float* mats, int matCount, const int32_t* recs, int recCount,
+                         unsigned long long geomKey) {
     HeadContext* c = (HeadContext*)h;
     Viewport* v = c->viewport;
     if (!v || w <= 0 || hh <= 0) return;
@@ -1003,29 +1031,36 @@ void obk_viewport_render(void* h, int slot, int w, int hh, const float* mvp, con
     const int topTriBase = hidBase + hidVC, topLineBase = topTriBase + topTriVC;
     const int occFirst = 0, triFirst = occIC, lineFirst = occIC + triIC, hidFirst = occIC + triIC + lineIC;
     const int topTriFirst = hidFirst + hidIC, topLineFirst = topTriFirst + topTriIC;
+
+    // Geometry is uploaded to DEVICE_LOCAL only when its signature (geomKey) changes; an orbit reuses
+    // the buffers and skips the concatenation + staging copy entirely (M34-F4). geomKey 0 marks the
+    // legacy non-instanced path, which always re-uploads. The concatenation below runs only when
+    // dirty, so a steady frame builds no vectors and copies nothing.
+    const bool geomDirty =
+        geomKey == 0 || geomKey != v->lastGeomKey || v->vbuf.buffer == VK_NULL_HANDLE;
     std::vector<float> verts;
-    verts.reserve((size_t)(occVC + triVC + lineVC + hidVC + topTriVC + topLineVC) * kVertexFloats);
-    verts.insert(verts.end(), occV, occV + (size_t)occVC * kVertexFloats);
-    verts.insert(verts.end(), triV, triV + (size_t)triVC * kVertexFloats);
-    verts.insert(verts.end(), lineV, lineV + (size_t)lineVC * kVertexFloats);
-    verts.insert(verts.end(), hidV, hidV + (size_t)hidVC * kVertexFloats);
-    verts.insert(verts.end(), topTriV, topTriV + (size_t)topTriVC * kVertexFloats);
-    verts.insert(verts.end(), topLineV, topLineV + (size_t)topLineVC * kVertexFloats);
     std::vector<uint32_t> idx;
-    idx.reserve((size_t)(occIC + triIC + lineIC + hidIC + topTriIC + topLineIC));
-    idx.insert(idx.end(), occIdx, occIdx + occIC);
-    idx.insert(idx.end(), triIdx, triIdx + triIC);
-    idx.insert(idx.end(), lineIdx, lineIdx + lineIC);
-    idx.insert(idx.end(), hidIdx, hidIdx + hidIC);
-    idx.insert(idx.end(), topTriIdx, topTriIdx + topTriIC);
-    idx.insert(idx.end(), topLineIdx, topLineIdx + topLineIC);
-    upload(c, &v->vbuf, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, verts.data(),
-           verts.size() * sizeof(float));
-    upload(c, &v->ibuf, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, idx.data(),
-           idx.size() * sizeof(uint32_t));
-    // Per-instance model matrices (binding 1, ADR-0038). With matrices supplied, recs drive
-    // instanced per-(source,stream) draws; otherwise every stream draws as one identity instance
-    // (geometry in its own world space — unchanged output).
+    if (geomDirty) {
+        verts.reserve((size_t)(occVC + triVC + lineVC + hidVC + topTriVC + topLineVC) * kVertexFloats);
+        verts.insert(verts.end(), occV, occV + (size_t)occVC * kVertexFloats);
+        verts.insert(verts.end(), triV, triV + (size_t)triVC * kVertexFloats);
+        verts.insert(verts.end(), lineV, lineV + (size_t)lineVC * kVertexFloats);
+        verts.insert(verts.end(), hidV, hidV + (size_t)hidVC * kVertexFloats);
+        verts.insert(verts.end(), topTriV, topTriV + (size_t)topTriVC * kVertexFloats);
+        verts.insert(verts.end(), topLineV, topLineV + (size_t)topLineVC * kVertexFloats);
+        idx.reserve((size_t)(occIC + triIC + lineIC + hidIC + topTriIC + topLineIC));
+        idx.insert(idx.end(), occIdx, occIdx + occIC);
+        idx.insert(idx.end(), triIdx, triIdx + triIC);
+        idx.insert(idx.end(), lineIdx, lineIdx + lineIC);
+        idx.insert(idx.end(), hidIdx, hidIdx + hidIC);
+        idx.insert(idx.end(), topTriIdx, topTriIdx + topTriIC);
+        idx.insert(idx.end(), topLineIdx, topLineIdx + topLineIC);
+    }
+
+    // Per-instance model matrices (binding 1, ADR-0038) are small and change every frame (the
+    // frustum-culled set), so they stay HOST_VISIBLE and upload each frame. With matrices supplied,
+    // recs drive instanced per-(source,stream) draws; otherwise every stream draws as one identity
+    // instance (geometry in its own world space — unchanged output).
     static const float kIdentity[16] = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
     if (matCount > 0 && mats) {
         upload(c, &v->instbuf, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, mats, (size_t)matCount * 16 * sizeof(float));
@@ -1042,6 +1077,25 @@ void obk_viewport_render(void* h, int slot, int w, int hh, const float* mvp, con
     bi.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
     bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
     vkBeginCommandBuffer(v->cmd, &bi);
+
+    // On a geometry change, copy the new vertex/index data into the DEVICE_LOCAL buffers and barrier
+    // it before the vertex-input stage reads it. Recorded into the render command buffer so it runs
+    // ahead of the render pass on the GPU timeline — no extra submit (M34-F4).
+    if (geomDirty) {
+        stage_to_device(c, v->cmd, &v->vbuf, &v->vstage, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
+                        verts.data(), verts.size() * sizeof(float));
+        stage_to_device(c, v->cmd, &v->ibuf, &v->istage, VK_BUFFER_USAGE_INDEX_BUFFER_BIT,
+                        idx.data(), idx.size() * sizeof(uint32_t));
+        VkMemoryBarrier mb{};
+        mb.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+        mb.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        mb.dstAccessMask = VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT | VK_ACCESS_INDEX_READ_BIT;
+        vkCmdPipelineBarrier(v->cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                             VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, 0, 1, &mb, 0, nullptr, 0, nullptr);
+        if (geomKey != 0) {
+            v->lastGeomKey = geomKey;
+        }
+    }
 
     // Shadow pass: render the casters' depth from the sun's POV into the shadow map, when
     // shadows are enabled and there is geometry to cast. The light matrix rides the mvp slot.

--- a/head/internal/native/viewport.go
+++ b/head/internal/native/viewport.go
@@ -20,7 +20,8 @@ void     obk_viewport_render(void* h, int slot, int w, int hh, const float* mvp,
                              const float* topTriV, int topTriVC, const uint32_t* topTriIdx, int topTriIC,
                              const float* topLineV, int topLineVC, const uint32_t* topLineIdx, int topLineIC,
                              int triBiasFirst, const float* clip,
-                             const float* mats, int matCount, const int32_t* recs, int recCount);
+                             const float* mats, int matCount, const int32_t* recs, int recCount,
+                             unsigned long long geomKey);
 void     obk_viewport_set_clear(void* h, float r, float g, float b);
 void     obk_viewport_set_normal_debug(void* h, int on);
 void     obk_viewport_set_lighting(void* h, const float* data, int n);
@@ -78,7 +79,7 @@ func (win *Window) RenderViewport(slot, w, h int, mvp []float32, camPos []float3
 	topTriVerts []float32, topTriVCount int, topTriIdx []uint32,
 	topLineVerts []float32, topLineVCount int, topLineIdx []uint32,
 	triBiasFirst int, clip []float32,
-	mats []float32, recs []int32,
+	mats []float32, recs []int32, geomKey uint64,
 ) {
 	C.obk_viewport_render(win.handle, C.int(slot), C.int(w), C.int(h),
 		(*C.float)(unsafe.Pointer(&mvp[0])), floatPtr(camPos),
@@ -89,7 +90,8 @@ func (win *Window) RenderViewport(slot, w, h int, mvp []float32, camPos []float3
 		floatPtr(topTriVerts), C.int(topTriVCount), uint32Ptr(topTriIdx), C.int(len(topTriIdx)),
 		floatPtr(topLineVerts), C.int(topLineVCount), uint32Ptr(topLineIdx), C.int(len(topLineIdx)),
 		C.int(triBiasFirst), floatPtr(clip),
-		floatPtr(mats), C.int(len(mats)/16), int32Ptr(recs), C.int(len(recs)/recDrawInts))
+		floatPtr(mats), C.int(len(mats)/16), int32Ptr(recs), C.int(len(recs)/recDrawInts),
+		C.ulonglong(geomKey))
 }
 
 // recDrawInts is the int32 stride of one instanced draw record (ADR-0038): stream, firstIndex,

--- a/head/ui/browser_clipper_test.go
+++ b/head/ui/browser_clipper_test.go
@@ -12,6 +12,24 @@ import (
 	"oblikovati.org/head/internal/native"
 )
 
+// TestGeomKeyFor pins the F4 geometry key: deterministic, non-zero (0 means "always re-upload"), and
+// distinct keys hash apart so the native side re-uploads only on a real geometry change.
+func TestGeomKeyFor(t *testing.T) {
+	a := geomKeyFor("ver1|ov:ab")
+	if a == 0 {
+		t.Fatal("geomKeyFor must never return 0")
+	}
+	if a != geomKeyFor("ver1|ov:ab") {
+		t.Error("geomKeyFor must be deterministic for the same key")
+	}
+	if a == geomKeyFor("ver2|ov:ab") {
+		t.Error("a different geometry key must hash to a different value")
+	}
+	if geomKeyFor("") == 0 {
+		t.Error("even the empty key must map to a non-zero geomKey")
+	}
+}
+
 // TestLeafRunLengths pins how drawChildren partitions a child list into the contiguous leaf runs it
 // virtualizes: branches break runs, leaves between/around them form runs (M34-F3). This is the
 // flat-assembly case — a long run of occurrence leaves beside the Origin/Parameters branches.

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -380,7 +380,7 @@ func updateViewportCamera(s *app.Session, pw, ph int, overCube bool) (scene.Came
 // overlay/ground tail as one identity instance, returning the merged mesh + per-instance matrices +
 // draw records. It falls back to a single legacy flatten of the whole list (nil mats/recs) when
 // instancing does not apply — mesh-color debug mode (its own builder) or no keyable geometry.
-func frameMeshAndInstances(s *app.Session, cam scene.Camera, list renderer.DrawList, bodyCount int, ground []renderer.DrawItem, groups, culled []app.InstanceGroup) (viewport.Mesh, []float32, []int32) {
+func frameMeshAndInstances(s *app.Session, cam scene.Camera, list renderer.DrawList, bodyCount int, ground []renderer.DrawItem, groups, culled []app.InstanceGroup) (viewport.Mesh, []float32, []int32, uint64) {
 	if bodyCount < 0 || bodyCount > len(list.Items) {
 		bodyCount = len(list.Items)
 	}
@@ -400,12 +400,12 @@ func frameMeshAndInstances(s *app.Session, cam scene.Camera, list renderer.DrawL
 		decorate := func(l renderer.DrawList) renderer.DrawList {
 			return highlightSelection(l, s.Selection().First(), sources)
 		}
-		if m, mats, recs, ok := buildInstancedFrame(groups, culled, overlay, cam, s.SurfaceLookup(), s.VisualStyle(), decorate, instancedSourceKey(s)); ok {
-			return m, mats, recs
+		if m, mats, recs, geomKey, ok := buildInstancedFrame(groups, culled, overlay, cam, s.SurfaceLookup(), s.VisualStyle(), decorate, instancedSourceKey(s)); ok {
+			return m, mats, recs, geomKey
 		}
 	}
 	list.Items = append(list.Items, ground...) // legacy: one flatten of the whole (world-space) list
-	return viewport.Flatten(list), nil, nil
+	return viewport.Flatten(list), nil, nil, 0 // geomKey 0 → native always re-uploads (no stable atlas here)
 }
 
 // frameBounds is the model bounds for shadow + ground framing: the instance groups' transformed
@@ -460,7 +460,7 @@ func renderViewportImage(win *native.Window, s *app.Session, slot int, cam scene
 	// Draw only the instances inside the view frustum (M34-F1) — off-screen placements never reach
 	// the GPU upload. The bounds above still use the full set so shadows/framing don't shift on orbit.
 	// allGroups builds the retained vertex atlas (stable on orbit); culled drives the per-frame draws.
-	m, mats, recs := frameMeshAndInstances(s, cam, list, bodyCount, ground, groups, s.CulledInstances(cam))
+	m, mats, recs, geomKey := frameMeshAndInstances(s, cam, list, bodyCount, ground, groups, s.CulledInstances(cam))
 	frameStats.buildNs = time.Since(tb).Nanoseconds()
 	mvp := renderer.ViewProjection(cam, viewportNear, viewportFarPlane(s, cam, mn, mx, hasGeom))
 	eye := []float32{float32(cam.Eye.X), float32(cam.Eye.Y), float32(cam.Eye.Z)}
@@ -477,7 +477,7 @@ func renderViewportImage(win *native.Window, s *app.Session, slot int, cam scene
 		m.TopTriVerts, m.TopTriVCount, m.TopTriIndices,
 		m.TopLineVerts, m.TopLineVCount, m.TopLineIndices,
 		m.TriBiasFirst, s.ActiveSectionClip(), // section-plane clip (M12-F04)
-		mats, recs) // instanced draw (ADR-0038); nil mats/recs ⇒ legacy one-identity-instance path
+		mats, recs, geomKey) // instanced draw (ADR-0038); geomKey lets native skip re-upload on orbit (M34-F4)
 	frameStats.gpuNs = time.Since(tg).Nanoseconds()
 	if tex := win.ViewportTexture(slot); tex != 0 {
 		native.SetCursorPos(cx, cy) // draw the image back over the invisible button

--- a/head/ui/instancing_cache_test.go
+++ b/head/ui/instancing_cache_test.go
@@ -109,7 +109,7 @@ func TestBuildInstancedFrameDedupes(t *testing.T) {
 		t.Fatalf("VisibleInstances = %d groups, want 1 (copies share one mesh)", len(groups))
 	}
 	n := len(groups[0].Transforms)
-	m, mats, recs, ok := buildInstancedFrame(groups, groups, renderer.DrawList{}, instCamera(), nullSurface, renderer.Shaded, nil, "k")
+	m, mats, recs, _, ok := buildInstancedFrame(groups, groups, renderer.DrawList{}, instCamera(), nullSurface, renderer.Shaded, nil, "k")
 	if !ok {
 		t.Fatal("buildInstancedFrame returned ok=false")
 	}

--- a/head/ui/viewport_instancing.go
+++ b/head/ui/viewport_instancing.go
@@ -131,6 +131,7 @@ func (b *instanceBuilder) finishAtlas(key string) frameAtlas {
 // overlay changes — not when the camera orbits (M34-F1b).
 type frameAtlas struct {
 	key     string
+	geomKey uint64 // non-zero hash of key, passed to native so it re-uploads the DEVICE_LOCAL geometry only on change (M34-F4)
 	mesh    viewport.Mesh
 	recs    [][5]int32 // absolute templates: stream, firstIndex, indexCount, vertexOffset, biased
 	regions []atlasRegion
@@ -218,9 +219,9 @@ func sortRecsByStream(recs [][7]int32) [][7]int32 {
 func buildInstancedFrame(allGroups, culledGroups []app.InstanceGroup, overlay renderer.DrawList, cam scene.Camera,
 	lookup renderer.SurfaceLookup, style renderer.VisualStyle,
 	decorate func(renderer.DrawList) renderer.DrawList, sourceKey string,
-) (viewport.Mesh, []float32, []int32, bool) {
+) (viewport.Mesh, []float32, []int32, uint64, bool) {
 	if len(allGroups) == 0 && len(overlay.Items) == 0 {
-		return viewport.Mesh{}, nil, nil, false
+		return viewport.Mesh{}, nil, nil, 0, false
 	}
 	atlas := cachedFrameAtlas(allGroups, overlay, cam, lookup, style, decorate, sourceKey)
 	visible := make(map[*topo.Body][]math.Matrix4, len(culledGroups))
@@ -228,7 +229,7 @@ func buildInstancedFrame(allGroups, culledGroups []app.InstanceGroup, overlay re
 		visible[g.Source] = g.Transforms
 	}
 	mats, recs := atlas.assemble(visible)
-	return atlas.mesh, mats, recs, len(recs) > 0
+	return atlas.mesh, mats, recs, atlas.geomKey, len(recs) > 0
 }
 
 // frameAtlasCache retains the last built atlas. The render loop is single-threaded, so a single
@@ -259,7 +260,19 @@ func cachedFrameAtlas(allGroups []app.InstanceGroup, overlay renderer.DrawList, 
 		b.addSource(nil, overlayMesh) // the overlay region: one identity instance in assemble
 	}
 	frameAtlasCache = b.finishAtlas(key)
+	frameAtlasCache.geomKey = geomKeyFor(key)
 	return frameAtlasCache
+}
+
+// geomKeyFor hashes an atlas key to the non-zero uint64 the native side compares to decide whether
+// to re-upload the device-local geometry (M34-F4). Non-zero because 0 means "unknown/always upload".
+func geomKeyFor(key string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(key))
+	if k := h.Sum64(); k != 0 {
+		return k
+	}
+	return 1
 }
 
 // overlayHash is an order-sensitive FNV-1a digest of the overlay mesh's streams, so the atlas cache


### PR DESCRIPTION
## What

The viewport's geometry now lives in **DEVICE_LOCAL** buffers and is re-uploaded only when it actually changes, instead of being re-concatenated and re-uploaded through HOST_VISIBLE memory every frame.

Closes #1203 (M34-F4). The remaining per-frame fence stall is split out as #1218 (F4b).

## Why

`obk_viewport_render` rebuilt two `std::vector`s by concatenating all six vertex/index streams and re-uploaded the whole scene every frame — even when, after F1b, the merged geometry was identical frame to frame. The B6 baseline named this per-frame HOST_VISIBLE re-upload a wall.

## How

- **DEVICE_LOCAL + staging:** geometry goes into `DEVICE_LOCAL` `vbuf`/`ibuf`, uploaded via a HOST_VISIBLE staging copy + a `TRANSFER → VERTEX_INPUT` barrier recorded into the render command buffer (no extra submit). DEVICE_LOCAL is also faster for the GPU to read each frame on real hardware.
- **Dirty-flag (`geomKey`):** the head hashes the retained `frameAtlas` key to a non-zero `geomKey`; native compares it to the key its buffers hold and **skips the concatenation + copy entirely when unchanged**. An orbit uploads nothing. Only the per-instance matrices (small, change with the frustum-culled set) stay HOST_VISIBLE and per-frame. `geomKey 0` (legacy non-instanced path) always re-uploads.

## Result (perfbench auto30k orbit)

| stage | orbit wall time |
|---|---|
| after F1b | 523 ms |
| **after F4** | **274 ms** |

(The native per-frame concatenation + upload is eliminated.)

## Tests & verification

- `geomKeyFor`: deterministic, non-zero, distinct keys hash apart.
- Full `head/ui` in-window suite (real Vulkan) exercises the DEVICE_LOCAL staging + barrier path.
- **Live-confirmed**: 30k assembly renders byte-identical across a 12-frame orbit — geometry uploaded once at frame 1 and reused, proving the staged copy + barrier + dirty-flag reuse are sound.
- `gofmt`/lint clean (my files); root + head build green.

## Scope note (F4b, #1218)

The per-frame `vkWaitForFences(UINT64_MAX)` CPU stall is **not** addressed here: removing it needs an offscreen→ImGui GPU semaphore (or double-buffered targets) and a **real discrete GPU** to validate — on lavapipe the software rasterizer dominates and the stall isn't isolable. Tracked as #1218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)