### PR TITLE
fix(head): free F4 staging buffers at viewport teardown (Vulkan validation)

### DIFF
--- a/head/internal/native/viewport.cpp
+++ b/head/internal/native/viewport.cpp
@@ -1525,12 +1525,14 @@ void obk_viewport_destroy(HeadContext* c) {
     Viewport* v = c->viewport;
     if (!v) return;
     for (int i = 0; i < kMaxTiles; i++) destroy_target(c, &v->targets[i]);
-    if (v->vbuf.buffer) vkDestroyBuffer(c->device, v->vbuf.buffer, nullptr);
-    if (v->vbuf.memory) vkFreeMemory(c->device, v->vbuf.memory, nullptr);
-    if (v->ibuf.buffer) vkDestroyBuffer(c->device, v->ibuf.buffer, nullptr);
-    if (v->ibuf.memory) vkFreeMemory(c->device, v->ibuf.memory, nullptr);
-    if (v->instbuf.buffer) vkDestroyBuffer(c->device, v->instbuf.buffer, nullptr);
-    if (v->instbuf.memory) vkFreeMemory(c->device, v->instbuf.memory, nullptr);
+    // Free every geometry buffer including the F4 DEVICE_LOCAL staging sources (vstage/istage):
+    // omitting these leaked VkDeviceMemory past vkDestroyDevice (VUID-vkDestroyDevice-device-05137,
+    // surfaced by object-lifetime validation on a real GPU — lavapipe did not flag it). M34-F4.
+    GpuBuffer* geom[] = {&v->vbuf, &v->ibuf, &v->instbuf, &v->vstage, &v->istage};
+    for (GpuBuffer* b : geom) {
+        if (b->buffer) vkDestroyBuffer(c->device, b->buffer, nullptr);
+        if (b->memory) vkFreeMemory(c->device, b->memory, nullptr);
+    }
     destroy_env_image(c, v);
     if (v->envSampler) vkDestroySampler(c->device, v->envSampler, nullptr);
     if (v->shadowFB) vkDestroyFramebuffer(c->device, v->shadowFB, nullptr);


### PR DESCRIPTION
## What

Free the F4 DEVICE_LOCAL **staging buffers** (`vstage`/`istage`) in `obk_viewport_destroy`, fixing a `VkDeviceMemory` leak past `vkDestroyDevice`.

## Why — found by running on a real GPU under validation

Per the request to validate beyond lavapipe, I ran the head on the real **AMD Radeon 8060S (RADV GFX1151)** under the Khronos validation layer with **synchronization** and **GPU-assisted** validation:

- **`VUID-vkDestroyDevice-device-05137`** (×4): device memory still alive at device destruction. The F4 staging buffers were allocated but never freed at teardown (`obk_viewport_destroy` freed `vbuf`/`ibuf`/`instbuf` but not `vstage`/`istage`). lavapipe never surfaced this; the real driver did.
- **No synchronization hazards** and **no other validation errors** — F4's staging copy + `TRANSFER → VERTEX_INPUT` barrier is correct on real hardware.

## Fix

Free all geometry buffers (`vbuf`/`ibuf`/`instbuf`/`vstage`/`istage`) in one loop at teardown.

## Verification (real AMD GPU)

Re-ran on RADV with sync + GPU-assisted validation:
- **Zero validation findings** — no leaks, no sync hazards.
- 30k assembly renders correctly; orbit **~195 ms** on real hardware (vs ~274 ms on lavapipe) — the M34 pipeline (instancing, frustum + detail culling, atlas retention, DEVICE_LOCAL) works end-to-end on real silicon.
- `head/ui` in-window suite passes; root + head build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)