### PR TITLE
fix(head): revert F4 geometry dirty-flag (bodies rendered blank on zoom)

### DIFF
--- a/architecture/performance/large-assembly-baseline.md
+++ b/architecture/performance/large-assembly-baseline.md
@@ -114,15 +114,15 @@ driven by the per-frame allocation churn — not GPU submission.
    distinct face/edge/vertex lists are now precomputed once at body finalization (immutable
    topology) and returned from cache — per-query 6 allocs/223 ns → 1 alloc/21 ns, full-frame 30k
    orbit allocation 738 MB → 603 MB.
-4. **F4 — DEVICE_LOCAL geometry + dirty-flag re-upload (#1203). ✅ RESOLVED.** The native pass
-   rebuilt two `std::vector`s by concatenating all six streams and re-uploaded the whole scene
-   through HOST_VISIBLE memory *every frame*, even when (post-F1b) the geometry was unchanged. Now
-   the geometry lives in DEVICE_LOCAL buffers, uploaded via a staging copy + barrier only when the
-   geometry key changes; an orbit reuses the buffers and skips the concatenation and copy entirely.
-   **30k orbit wall time 523 ms → 274 ms** (native per-frame concatenation/upload eliminated;
-   instance matrices stay HOST_VISIBLE, per-frame). The remaining per-frame `vkWaitForFences` CPU
-   stall is split out as **F4b (#1218)** — it needs a real discrete GPU to measure and an
-   offscreen→ImGui GPU-semaphore (or double-buffered targets), so it is not validatable on lavapipe.
+4. **F4 — DEVICE_LOCAL geometry + dirty-flag re-upload (#1203). ⚠️ REVERTED (correctness).** The
+   native pass rebuilds two `std::vector`s and re-uploads the scene every frame even when the
+   geometry is unchanged. F4 added a geometry-key dirty-flag (skip the concatenation + upload when
+   unchanged), reaching 523 ms → 274 ms orbit — but it rendered **blank** across viewport-target
+   recreation / dock-layout transitions: a geometry buffer uploaded on one frame and reused after
+   the offscreen target is recreated draws nothing (the skip-upload holds in steady state but not
+   across that transition). Validated on a real AMD GPU; reverted to the unconditional per-frame
+   upload for correctness. The dirty-flag is viable but needs the offscreen-buffer-reuse interaction
+   root-caused first — tracked with the frames-in-flight rework in **F4b (#1218)**.
 5. **F3 — virtualized browser tree (#1202). ✅ RESOLVED.** `BuildBrowser` itself is cheap (4.8 MB /
    1.1 ms); the cost was the `drawNode` cgo walk over every node every frame. Now any long
    contiguous run of leaf sibling rows (bodies, occurrences) is drawn through an `ImGuiListClipper`

--- a/head/internal/native/smoke.go
+++ b/head/internal/native/smoke.go
@@ -63,7 +63,7 @@ func RunViewportSmoke(maxFrames int) int {
 	for i := 0; i < maxFrames && !w.ShouldClose(); i++ {
 		w.BeginFrame()
 		w.RenderViewport(0, 1280, 720, mvp[:], eye, verts, len(verts)/16, idx,
-			nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil, len(idx), nil, nil, nil, 0)
+			nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil, len(idx), nil, nil, nil)
 		w.EndFrame(0.10, 0.10, 0.12)
 	}
 	if path := os.Getenv("OBK_SMOKE_PNG"); path != "" {

--- a/head/internal/native/viewport.cpp
+++ b/head/internal/native/viewport.cpp
@@ -131,13 +131,8 @@ struct Viewport {
     // single-view target; the quad layout uses up to kMaxTiles.
     Target          targets[kMaxTiles];
 
-    GpuBuffer       vbuf, ibuf;     // DEVICE_LOCAL geometry (M34-F4), uploaded only when geomKey changes
-    GpuBuffer       vstage, istage; // HOST_VISIBLE staging sources copied into vbuf/ibuf on a geometry change
-    GpuBuffer       instbuf;        // per-instance model matrices (binding 1, ADR-0038), HOST_VISIBLE (per-frame)
-    // lastGeomKey is the geometry signature the device-local buffers currently hold; a render whose
-    // geomKey matches reuses them and skips the concatenation + staging copy entirely (M34-F4). 0
-    // means "unknown" (legacy non-instanced path), which always re-uploads.
-    unsigned long long lastGeomKey = 0;
+    GpuBuffer       vbuf, ibuf; // concatenated vertex + index geometry (HOST_VISIBLE, uploaded per frame)
+    GpuBuffer       instbuf;    // per-instance model matrices (binding 1, ADR-0038)
 
     // Background the 3D pass clears to (themed; ADR-0021). Defaults reproduce the
     // pre-theming look so an un-themed build is unchanged.
@@ -457,21 +452,6 @@ void upload(HeadContext* c, GpuBuffer* b, VkBufferUsageFlags usage, const void* 
     vkMapMemory(c->device, b->memory, 0, bytes, 0, &mapped);
     std::memcpy(mapped, data, (size_t)bytes);
     vkUnmapMemory(c->device, b->memory);
-}
-
-// stage_to_device copies host data into a DEVICE_LOCAL buffer via a HOST_VISIBLE staging buffer: it
-// fills the staging buffer now and records a buffer copy into cmd (which must be recording, before
-// the render pass). DEVICE_LOCAL geometry is faster for the GPU to read each frame; combined with
-// the geomKey dirty-flag the staging copy runs only when the geometry actually changes (M34-F4).
-void stage_to_device(HeadContext* c, VkCommandBuffer cmd, GpuBuffer* dst, GpuBuffer* staging,
-                     VkBufferUsageFlags usage, const void* data, VkDeviceSize bytes) {
-    if (bytes == 0) return;
-    upload(c, staging, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, data, bytes); // HOST_VISIBLE memcpy
-    ensure_buffer(c, dst, VK_BUFFER_USAGE_TRANSFER_DST_BIT | usage,
-                  VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, bytes);
-    VkBufferCopy region{};
-    region.size = bytes;
-    vkCmdCopyBuffer(cmd, staging->buffer, dst->buffer, 1, &region);
 }
 
 VkImageView make_image(HeadContext* c, VkFormat fmt, VkImageUsageFlags usage,
@@ -1015,8 +995,7 @@ void obk_viewport_render(void* h, int slot, int w, int hh, const float* mvp, con
                          const float* topTriV, int topTriVC, const uint32_t* topTriIdx, int topTriIC,
                          const float* topLineV, int topLineVC, const uint32_t* topLineIdx, int topLineIC,
                          int triBiasFirst, const float* clip,
-                         const float* mats, int matCount, const int32_t* recs, int recCount,
-                         unsigned long long geomKey) {
+                         const float* mats, int matCount, const int32_t* recs, int recCount) {
     HeadContext* c = (HeadContext*)h;
     Viewport* v = c->viewport;
     if (!v || w <= 0 || hh <= 0) return;
@@ -1032,30 +1011,29 @@ void obk_viewport_render(void* h, int slot, int w, int hh, const float* mvp, con
     const int occFirst = 0, triFirst = occIC, lineFirst = occIC + triIC, hidFirst = occIC + triIC + lineIC;
     const int topTriFirst = hidFirst + hidIC, topLineFirst = topTriFirst + topTriIC;
 
-    // Geometry is uploaded to DEVICE_LOCAL only when its signature (geomKey) changes; an orbit reuses
-    // the buffers and skips the concatenation + staging copy entirely (M34-F4). geomKey 0 marks the
-    // legacy non-instanced path, which always re-uploads. The concatenation below runs only when
-    // dirty, so a steady frame builds no vectors and copies nothing.
-    const bool geomDirty =
-        geomKey == 0 || geomKey != v->lastGeomKey || v->vbuf.buffer == VK_NULL_HANDLE;
+    // Concatenate the six streams into one vertex + one index buffer and upload them every frame.
+    // (M34-F4 tried to skip this on unchanged geometry: it holds in steady state but renders blank
+    // across viewport-target recreation/dock-layout transitions — a fragile offscreen-buffer-reuse
+    // interaction — so geometry is uploaded unconditionally for correctness; see #1218 for the
+    // careful re-attempt.)
     std::vector<float> verts;
+    verts.reserve((size_t)(occVC + triVC + lineVC + hidVC + topTriVC + topLineVC) * kVertexFloats);
+    verts.insert(verts.end(), occV, occV + (size_t)occVC * kVertexFloats);
+    verts.insert(verts.end(), triV, triV + (size_t)triVC * kVertexFloats);
+    verts.insert(verts.end(), lineV, lineV + (size_t)lineVC * kVertexFloats);
+    verts.insert(verts.end(), hidV, hidV + (size_t)hidVC * kVertexFloats);
+    verts.insert(verts.end(), topTriV, topTriV + (size_t)topTriVC * kVertexFloats);
+    verts.insert(verts.end(), topLineV, topLineV + (size_t)topLineVC * kVertexFloats);
     std::vector<uint32_t> idx;
-    if (geomDirty) {
-        verts.reserve((size_t)(occVC + triVC + lineVC + hidVC + topTriVC + topLineVC) * kVertexFloats);
-        verts.insert(verts.end(), occV, occV + (size_t)occVC * kVertexFloats);
-        verts.insert(verts.end(), triV, triV + (size_t)triVC * kVertexFloats);
-        verts.insert(verts.end(), lineV, lineV + (size_t)lineVC * kVertexFloats);
-        verts.insert(verts.end(), hidV, hidV + (size_t)hidVC * kVertexFloats);
-        verts.insert(verts.end(), topTriV, topTriV + (size_t)topTriVC * kVertexFloats);
-        verts.insert(verts.end(), topLineV, topLineV + (size_t)topLineVC * kVertexFloats);
-        idx.reserve((size_t)(occIC + triIC + lineIC + hidIC + topTriIC + topLineIC));
-        idx.insert(idx.end(), occIdx, occIdx + occIC);
-        idx.insert(idx.end(), triIdx, triIdx + triIC);
-        idx.insert(idx.end(), lineIdx, lineIdx + lineIC);
-        idx.insert(idx.end(), hidIdx, hidIdx + hidIC);
-        idx.insert(idx.end(), topTriIdx, topTriIdx + topTriIC);
-        idx.insert(idx.end(), topLineIdx, topLineIdx + topLineIC);
-    }
+    idx.reserve((size_t)(occIC + triIC + lineIC + hidIC + topTriIC + topLineIC));
+    idx.insert(idx.end(), occIdx, occIdx + occIC);
+    idx.insert(idx.end(), triIdx, triIdx + triIC);
+    idx.insert(idx.end(), lineIdx, lineIdx + lineIC);
+    idx.insert(idx.end(), hidIdx, hidIdx + hidIC);
+    idx.insert(idx.end(), topTriIdx, topTriIdx + topTriIC);
+    idx.insert(idx.end(), topLineIdx, topLineIdx + topLineIC);
+    upload(c, &v->vbuf, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, verts.data(), verts.size() * sizeof(float));
+    upload(c, &v->ibuf, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, idx.data(), idx.size() * sizeof(uint32_t));
 
     // Per-instance model matrices (binding 1, ADR-0038) are small and change every frame (the
     // frustum-culled set), so they stay HOST_VISIBLE and upload each frame. With matrices supplied,
@@ -1077,25 +1055,6 @@ void obk_viewport_render(void* h, int slot, int w, int hh, const float* mvp, con
     bi.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
     bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
     vkBeginCommandBuffer(v->cmd, &bi);
-
-    // On a geometry change, copy the new vertex/index data into the DEVICE_LOCAL buffers and barrier
-    // it before the vertex-input stage reads it. Recorded into the render command buffer so it runs
-    // ahead of the render pass on the GPU timeline — no extra submit (M34-F4).
-    if (geomDirty) {
-        stage_to_device(c, v->cmd, &v->vbuf, &v->vstage, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
-                        verts.data(), verts.size() * sizeof(float));
-        stage_to_device(c, v->cmd, &v->ibuf, &v->istage, VK_BUFFER_USAGE_INDEX_BUFFER_BIT,
-                        idx.data(), idx.size() * sizeof(uint32_t));
-        VkMemoryBarrier mb{};
-        mb.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
-        mb.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-        mb.dstAccessMask = VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT | VK_ACCESS_INDEX_READ_BIT;
-        vkCmdPipelineBarrier(v->cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
-                             VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, 0, 1, &mb, 0, nullptr, 0, nullptr);
-        if (geomKey != 0) {
-            v->lastGeomKey = geomKey;
-        }
-    }
 
     // Shadow pass: render the casters' depth from the sun's POV into the shadow map, when
     // shadows are enabled and there is geometry to cast. The light matrix rides the mvp slot.
@@ -1525,10 +1484,10 @@ void obk_viewport_destroy(HeadContext* c) {
     Viewport* v = c->viewport;
     if (!v) return;
     for (int i = 0; i < kMaxTiles; i++) destroy_target(c, &v->targets[i]);
-    // Free every geometry buffer including the F4 DEVICE_LOCAL staging sources (vstage/istage):
-    // omitting these leaked VkDeviceMemory past vkDestroyDevice (VUID-vkDestroyDevice-device-05137,
-    // surfaced by object-lifetime validation on a real GPU — lavapipe did not flag it). M34-F4.
-    GpuBuffer* geom[] = {&v->vbuf, &v->ibuf, &v->instbuf, &v->vstage, &v->istage};
+    // Free the geometry buffers before vkDestroyDevice so no VkDeviceMemory leaks past device
+    // teardown (VUID-vkDestroyDevice-device-05137, surfaced by object-lifetime validation on a real
+    // GPU — lavapipe did not flag it).
+    GpuBuffer* geom[] = {&v->vbuf, &v->ibuf, &v->instbuf};
     for (GpuBuffer* b : geom) {
         if (b->buffer) vkDestroyBuffer(c->device, b->buffer, nullptr);
         if (b->memory) vkFreeMemory(c->device, b->memory, nullptr);

--- a/head/internal/native/viewport.go
+++ b/head/internal/native/viewport.go
@@ -20,8 +20,7 @@ void     obk_viewport_render(void* h, int slot, int w, int hh, const float* mvp,
                              const float* topTriV, int topTriVC, const uint32_t* topTriIdx, int topTriIC,
                              const float* topLineV, int topLineVC, const uint32_t* topLineIdx, int topLineIC,
                              int triBiasFirst, const float* clip,
-                             const float* mats, int matCount, const int32_t* recs, int recCount,
-                             unsigned long long geomKey);
+                             const float* mats, int matCount, const int32_t* recs, int recCount);
 void     obk_viewport_set_clear(void* h, float r, float g, float b);
 void     obk_viewport_set_normal_debug(void* h, int on);
 void     obk_viewport_set_lighting(void* h, const float* data, int n);
@@ -79,7 +78,7 @@ func (win *Window) RenderViewport(slot, w, h int, mvp []float32, camPos []float3
 	topTriVerts []float32, topTriVCount int, topTriIdx []uint32,
 	topLineVerts []float32, topLineVCount int, topLineIdx []uint32,
 	triBiasFirst int, clip []float32,
-	mats []float32, recs []int32, geomKey uint64,
+	mats []float32, recs []int32,
 ) {
 	C.obk_viewport_render(win.handle, C.int(slot), C.int(w), C.int(h),
 		(*C.float)(unsafe.Pointer(&mvp[0])), floatPtr(camPos),
@@ -90,8 +89,7 @@ func (win *Window) RenderViewport(slot, w, h int, mvp []float32, camPos []float3
 		floatPtr(topTriVerts), C.int(topTriVCount), uint32Ptr(topTriIdx), C.int(len(topTriIdx)),
 		floatPtr(topLineVerts), C.int(topLineVCount), uint32Ptr(topLineIdx), C.int(len(topLineIdx)),
 		C.int(triBiasFirst), floatPtr(clip),
-		floatPtr(mats), C.int(len(mats)/16), int32Ptr(recs), C.int(len(recs)/recDrawInts),
-		C.ulonglong(geomKey))
+		floatPtr(mats), C.int(len(mats)/16), int32Ptr(recs), C.int(len(recs)/recDrawInts))
 }
 
 // recDrawInts is the int32 stride of one instanced draw record (ADR-0038): stream, firstIndex,

--- a/head/ui/browser_clipper_test.go
+++ b/head/ui/browser_clipper_test.go
@@ -12,24 +12,6 @@ import (
 	"oblikovati.org/head/internal/native"
 )
 
-// TestGeomKeyFor pins the F4 geometry key: deterministic, non-zero (0 means "always re-upload"), and
-// distinct keys hash apart so the native side re-uploads only on a real geometry change.
-func TestGeomKeyFor(t *testing.T) {
-	a := geomKeyFor("ver1|ov:ab")
-	if a == 0 {
-		t.Fatal("geomKeyFor must never return 0")
-	}
-	if a != geomKeyFor("ver1|ov:ab") {
-		t.Error("geomKeyFor must be deterministic for the same key")
-	}
-	if a == geomKeyFor("ver2|ov:ab") {
-		t.Error("a different geometry key must hash to a different value")
-	}
-	if geomKeyFor("") == 0 {
-		t.Error("even the empty key must map to a non-zero geomKey")
-	}
-}
-
 // TestLeafRunLengths pins how drawChildren partitions a child list into the contiguous leaf runs it
 // virtualizes: branches break runs, leaves between/around them form runs (M34-F3). This is the
 // flat-assembly case — a long run of occurrence leaves beside the Origin/Parameters branches.

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -380,7 +380,7 @@ func updateViewportCamera(s *app.Session, pw, ph int, overCube bool) (scene.Came
 // overlay/ground tail as one identity instance, returning the merged mesh + per-instance matrices +
 // draw records. It falls back to a single legacy flatten of the whole list (nil mats/recs) when
 // instancing does not apply — mesh-color debug mode (its own builder) or no keyable geometry.
-func frameMeshAndInstances(s *app.Session, cam scene.Camera, list renderer.DrawList, bodyCount int, ground []renderer.DrawItem, groups, culled []app.InstanceGroup) (viewport.Mesh, []float32, []int32, uint64) {
+func frameMeshAndInstances(s *app.Session, cam scene.Camera, list renderer.DrawList, bodyCount int, ground []renderer.DrawItem, groups, culled []app.InstanceGroup) (viewport.Mesh, []float32, []int32) {
 	if bodyCount < 0 || bodyCount > len(list.Items) {
 		bodyCount = len(list.Items)
 	}
@@ -400,12 +400,12 @@ func frameMeshAndInstances(s *app.Session, cam scene.Camera, list renderer.DrawL
 		decorate := func(l renderer.DrawList) renderer.DrawList {
 			return highlightSelection(l, s.Selection().First(), sources)
 		}
-		if m, mats, recs, geomKey, ok := buildInstancedFrame(groups, culled, overlay, cam, s.SurfaceLookup(), s.VisualStyle(), decorate, instancedSourceKey(s)); ok {
-			return m, mats, recs, geomKey
+		if m, mats, recs, ok := buildInstancedFrame(groups, culled, overlay, cam, s.SurfaceLookup(), s.VisualStyle(), decorate, instancedSourceKey(s)); ok {
+			return m, mats, recs
 		}
 	}
 	list.Items = append(list.Items, ground...) // legacy: one flatten of the whole (world-space) list
-	return viewport.Flatten(list), nil, nil, 0 // geomKey 0 → native always re-uploads (no stable atlas here)
+	return viewport.Flatten(list), nil, nil
 }
 
 // frameBounds is the model bounds for shadow + ground framing: the instance groups' transformed
@@ -460,7 +460,7 @@ func renderViewportImage(win *native.Window, s *app.Session, slot int, cam scene
 	// Draw only the instances inside the view frustum (M34-F1) — off-screen placements never reach
 	// the GPU upload. The bounds above still use the full set so shadows/framing don't shift on orbit.
 	// allGroups builds the retained vertex atlas (stable on orbit); culled drives the per-frame draws.
-	m, mats, recs, geomKey := frameMeshAndInstances(s, cam, list, bodyCount, ground, groups, s.CulledInstances(cam))
+	m, mats, recs := frameMeshAndInstances(s, cam, list, bodyCount, ground, groups, s.CulledInstances(cam))
 	frameStats.buildNs = time.Since(tb).Nanoseconds()
 	mvp := renderer.ViewProjection(cam, viewportNear, viewportFarPlane(s, cam, mn, mx, hasGeom))
 	eye := []float32{float32(cam.Eye.X), float32(cam.Eye.Y), float32(cam.Eye.Z)}
@@ -477,7 +477,7 @@ func renderViewportImage(win *native.Window, s *app.Session, slot int, cam scene
 		m.TopTriVerts, m.TopTriVCount, m.TopTriIndices,
 		m.TopLineVerts, m.TopLineVCount, m.TopLineIndices,
 		m.TriBiasFirst, s.ActiveSectionClip(), // section-plane clip (M12-F04)
-		mats, recs, geomKey) // instanced draw (ADR-0038); geomKey lets native skip re-upload on orbit (M34-F4)
+		mats, recs) // instanced draw (ADR-0038); nil mats/recs ⇒ legacy one-identity-instance path
 	frameStats.gpuNs = time.Since(tg).Nanoseconds()
 	if tex := win.ViewportTexture(slot); tex != 0 {
 		native.SetCursorPos(cx, cy) // draw the image back over the invisible button

--- a/head/ui/instancing_cache_test.go
+++ b/head/ui/instancing_cache_test.go
@@ -109,7 +109,7 @@ func TestBuildInstancedFrameDedupes(t *testing.T) {
 		t.Fatalf("VisibleInstances = %d groups, want 1 (copies share one mesh)", len(groups))
 	}
 	n := len(groups[0].Transforms)
-	m, mats, recs, _, ok := buildInstancedFrame(groups, groups, renderer.DrawList{}, instCamera(), nullSurface, renderer.Shaded, nil, "k")
+	m, mats, recs, ok := buildInstancedFrame(groups, groups, renderer.DrawList{}, instCamera(), nullSurface, renderer.Shaded, nil, "k")
 	if !ok {
 		t.Fatal("buildInstancedFrame returned ok=false")
 	}

--- a/head/ui/viewport_instancing.go
+++ b/head/ui/viewport_instancing.go
@@ -131,7 +131,6 @@ func (b *instanceBuilder) finishAtlas(key string) frameAtlas {
 // overlay changes — not when the camera orbits (M34-F1b).
 type frameAtlas struct {
 	key     string
-	geomKey uint64 // non-zero hash of key, passed to native so it re-uploads the DEVICE_LOCAL geometry only on change (M34-F4)
 	mesh    viewport.Mesh
 	recs    [][5]int32 // absolute templates: stream, firstIndex, indexCount, vertexOffset, biased
 	regions []atlasRegion
@@ -219,9 +218,9 @@ func sortRecsByStream(recs [][7]int32) [][7]int32 {
 func buildInstancedFrame(allGroups, culledGroups []app.InstanceGroup, overlay renderer.DrawList, cam scene.Camera,
 	lookup renderer.SurfaceLookup, style renderer.VisualStyle,
 	decorate func(renderer.DrawList) renderer.DrawList, sourceKey string,
-) (viewport.Mesh, []float32, []int32, uint64, bool) {
+) (viewport.Mesh, []float32, []int32, bool) {
 	if len(allGroups) == 0 && len(overlay.Items) == 0 {
-		return viewport.Mesh{}, nil, nil, 0, false
+		return viewport.Mesh{}, nil, nil, false
 	}
 	atlas := cachedFrameAtlas(allGroups, overlay, cam, lookup, style, decorate, sourceKey)
 	visible := make(map[*topo.Body][]math.Matrix4, len(culledGroups))
@@ -229,7 +228,7 @@ func buildInstancedFrame(allGroups, culledGroups []app.InstanceGroup, overlay re
 		visible[g.Source] = g.Transforms
 	}
 	mats, recs := atlas.assemble(visible)
-	return atlas.mesh, mats, recs, atlas.geomKey, len(recs) > 0
+	return atlas.mesh, mats, recs, len(recs) > 0
 }
 
 // frameAtlasCache retains the last built atlas. The render loop is single-threaded, so a single
@@ -260,19 +259,7 @@ func cachedFrameAtlas(allGroups []app.InstanceGroup, overlay renderer.DrawList, 
 		b.addSource(nil, overlayMesh) // the overlay region: one identity instance in assemble
 	}
 	frameAtlasCache = b.finishAtlas(key)
-	frameAtlasCache.geomKey = geomKeyFor(key)
 	return frameAtlasCache
-}
-
-// geomKeyFor hashes an atlas key to the non-zero uint64 the native side compares to decide whether
-// to re-upload the device-local geometry (M34-F4). Non-zero because 0 means "unknown/always upload".
-func geomKeyFor(key string) uint64 {
-	h := fnv.New64a()
-	_, _ = h.Write([]byte(key))
-	if k := h.Sum64(); k != 0 {
-		return k
-	}
-	return 1
 }
 
 // overlayHash is an order-sensitive FNV-1a digest of the overlay mesh's streams, so the atlas cache


### PR DESCRIPTION
## What

Reverts the **M34-F4** geometry dirty-flag (skip per-frame upload when the geometry key is unchanged + DEVICE_LOCAL staging). It caused a **visible regression**: bodies disappeared / flickered while zooming. Reopens #1203.

## The bug (reported by the user)

> the bodies are not showing up, as I change the zoom the body flickers and shows … the demo cube document presents the issue

## Root cause (diagnosed on the real AMD Radeon 8060S / RADV)

Reproduced with a zoom-sweep harness + native instrumentation, under the Khronos validation layer with **synchronization + GPU-assisted validation** (which reported **zero errors** — it is *not* a barrier/sync hazard):

- **Skip-upload works in steady state** — a geometry buffer uploaded once and reused across later frames renders correctly (confirmed by a controlled experiment).
- It renders **blank when the buffer is uploaded on one frame and then reused after the offscreen target is recreated** (viewport resize / dock-layout transition). The buffer is valid and bound and the draw records are correct, yet nothing draws on that reuse frame. Per-frame re-upload always works.

`buildInstancedFrame` (app side) was verified correct throughout — it always produced the right mesh + matrices + draw records; the fault was purely the native skip-upload across target recreation.

## Fix

Restore the unconditional per-frame HOST_VISIBLE geometry upload (pre-F4, known correct) and remove the geomKey plumbing, DEVICE_LOCAL staging, and `vstage`/`istage` buffers. (`obk_viewport_destroy` still frees the geometry buffers — the #1221 leak fix is preserved.)

## Verification

- Zoom-sweep render on lavapipe **and** the real AMD GPU: the body is present at **every** zoom level (was blank/flickering before).
- Full `head/ui` in-window suite passes; root + head build green; `gofmt` clean.
- Real-AMD validation (sync + GPU-assisted): zero findings.

## Follow-up

The dirty-flag is viable (523 ms → 274 ms orbit at 30k) but needs the offscreen-buffer-reuse-across-resize interaction root-caused first. Findings + plan recorded on **#1218** (to be done with the frames-in-flight rework and real-GPU validation). #1203 reopened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)