### PR TITLE
Selection Filter & Priority window (#1222)

### DIFF
--- a/app/commands_selection_priority.go
+++ b/app/commands_selection_priority.go
@@ -15,6 +15,27 @@ var selectionPrioritySpecs = []selectionPrioritySpec{
 	{PriorityEdge, "Select.Priority.Edge", "Edge Priority", "A click selects edges."},
 }
 
+// OpenSelectionFilterWindow / CloseSelectionFilterWindow / ToggleSelectionFilterWindow drive the
+// Selection Filter & Priority window's visibility (#1222); SelectionFilterWindowOpen reports it.
+func (s *Session) OpenSelectionFilterWindow()  { s.selectionFilterWindowOpen = true }
+func (s *Session) CloseSelectionFilterWindow() { s.selectionFilterWindowOpen = false }
+func (s *Session) ToggleSelectionFilterWindow() {
+	s.selectionFilterWindowOpen = !s.selectionFilterWindowOpen
+}
+func (s *Session) SelectionFilterWindowOpen() bool { return s.selectionFilterWindowOpen }
+
+// selectionFilterCommand is the View tab's Select panel button that opens the Selection Filter &
+// Priority window — the full per-kind enable + drag-to-prioritise editor behind the quick combo
+// presets (#1222).
+func selectionFilterCommand() *CommandDefinition {
+	return NewCommand("Select.Filter", "Selection Filter", "Select", func(s *Session) error {
+		s.ToggleSelectionFilterWindow()
+		return nil
+	}).WithTab("View").WithKind(ButtonControl).
+		WithTooltip("Choose which entity types are selectable and their pick priority.").
+		WithActive(func(s *Session) bool { return s.SelectionFilterWindowOpen() })
+}
+
 // selectionPriorityCommands are the View tab's Select panel: a mutually-exclusive combo (like the
 // Visual Style box) that sets the no-tool selection priority, biasing both click and box-select
 // picking (#912 / Inventor's Select dropdown).

--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -693,6 +693,7 @@ func viewTabCommands() []*CommandDefinition {
 	cmds = append(cmds, displayViewCommands()...)
 	cmds = append(cmds, colorStylesCommand())
 	cmds = append(cmds, selectionPriorityCommands()...)
+	cmds = append(cmds, selectionFilterCommand())
 	cmds = append(cmds, visualStyleCommands()...)
 	cmds = append(cmds, colorSchemeCommands()...)
 	cmds = append(cmds, lightingViewCommands()...)

--- a/app/raypicker.go
+++ b/app/raypicker.go
@@ -31,6 +31,50 @@ type RayPicker struct {
 	sketches3D   func() []*sketch.Sketch3D
 	pointClouds  func() []*pointcloud.PointCloud                 // attached scans whose points snap (#645)
 	occurrenceOf func(*topo.Body) (*occurrence.Occurrence, bool) // maps an assembly body hit to its component (#769)
+	priorityRank func(SelectionKind) int                         // user pick-priority ranking for ambiguous hits (#1222); nil ⇒ default order
+}
+
+// SetPriorityRank installs the user-defined pick priority (lower rank = higher priority). The
+// Session pushes its SelectionFilterState.Rank so reordering the Selection Filter window changes
+// which kind wins an ambiguous pick (#1222). A nil ranker keeps the historical default order.
+func (p *RayPicker) SetPriorityRank(rank func(SelectionKind) int) { p.priorityRank = rank }
+
+// defaultRankByKind is the historical pick precedence used when no user ranking is installed:
+// the snapPick exact targets (datum point/axis, cloud point, vertex, edge) outrank the
+// depth-sorted occurrence/body/face/plane/profile/sketch hits, matching the old fixed snapPick
+// sequence and RayPicker.Pick append order.
+var defaultRankByKind = func() map[SelectionKind]int {
+	m := make(map[SelectionKind]int)
+	for i, k := range defaultFilterableKinds() {
+		m[k] = i
+	}
+	return m
+}()
+
+// rankOf returns the priority rank of a kind (0 = highest); unranked kinds sort last.
+func (p *RayPicker) rankOf(k SelectionKind) int {
+	if p.priorityRank != nil {
+		return p.priorityRank(k)
+	}
+	if r, ok := defaultRankByKind[k]; ok {
+		return r
+	}
+	return len(defaultRankByKind)
+}
+
+// highestPriority returns the candidate with the lowest rank (the user's top priority among the
+// co-located exact snaps), or false when there are none.
+func (p *RayPicker) highestPriority(cands []Selectable) (Selectable, bool) {
+	best, bestRank := -1, stdmath.MaxInt
+	for i, c := range cands {
+		if r := p.rankOf(c.SelectionKind()); r < bestRank {
+			best, bestRank = i, r
+		}
+	}
+	if best < 0 {
+		return nil, false
+	}
+	return cands[best], true
 }
 
 // pickPixelRadius is how close (in pixels) the cursor must be to a datum point or axis to
@@ -153,7 +197,7 @@ func (p *RayPicker) Pick(x, y float64, filter *SelectionFilter) (Selectable, boo
 	if sel, t, ok := p.nearestSketch3DEntity(origin, dir, filter); ok {
 		cands = append(cands, pickCandidate{t, sel})
 	}
-	return nearestCandidate(cands)
+	return p.nearestCandidate(cands)
 }
 
 // nearestSketch3DEntity returns the 3D-sketch entity (curve or standalone point) the
@@ -233,26 +277,28 @@ func (p *RayPicker) nearestSketchCurve(origin math.Point3, dir math.Vector3, fil
 	return hit, best, hit != nil
 }
 
-// snapPick returns the precise snap the cursor lands on — a datum point, datum axis, body
-// vertex, then edge — each winning over the face behind it (Inventor's snap order). These
-// are exact targets (within the pixel-snap radius), so the first accepted one wins.
+// snapPick returns the precise snap the cursor lands on — a datum point, datum axis, cloud
+// point, body vertex, or edge — each an exact target within the pixel-snap radius that wins over
+// the face behind it. When several are co-located the user's priority order decides which wins
+// (#1222); by default that is the historical point→axis→cloud→vertex→edge precedence.
 func (p *RayPicker) snapPick(origin math.Point3, dir math.Vector3, filter *SelectionFilter) (Selectable, bool) {
+	var snaps []Selectable
 	if pt, _ := p.nearestPoint(origin, dir); pt != nil && filter.Accepts(SelectWorkPoint) {
-		return WorkPointHandle{Point: pt}, true
+		snaps = append(snaps, WorkPointHandle{Point: pt})
 	}
 	if ax, _ := p.nearestAxis(origin, dir); ax != nil && filter.Accepts(SelectWorkAxis) {
-		return WorkAxisHandle{Axis: ax}, true
+		snaps = append(snaps, WorkAxisHandle{Axis: ax})
 	}
 	if pt, cloud, ok := p.nearestCloudPoint(origin, dir); ok && filter.Accepts(SelectPointCloudPoint) {
-		return PointCloudPointHandle{Cloud: cloud, Point: pt}, true
+		snaps = append(snaps, PointCloudPointHandle{Cloud: cloud, Point: pt})
 	}
 	if v := p.nearestVertex(origin, dir); v != nil && filter.Accepts(SelectVertex) {
-		return VertexHandle{Vertex: v}, true
+		snaps = append(snaps, VertexHandle{Vertex: v})
 	}
 	if e := p.nearestEdge(origin, dir); e != nil && filter.Accepts(SelectEdge) {
-		return EdgeHandle{Edge: e}, true
+		snaps = append(snaps, EdgeHandle{Edge: e})
 	}
-	return nil, false
+	return p.highestPriority(snaps)
 }
 
 // pickCandidate is one ray hit: its forward parameter and the selectable it resolves to.
@@ -261,19 +307,39 @@ type pickCandidate struct {
 	sel Selectable
 }
 
-// nearestCandidate returns the candidate with the smallest ray parameter (the first one
-// on ties, preserving the face→plane→profile precedence), or false when there are none.
-func nearestCandidate(cands []pickCandidate) (Selectable, bool) {
-	best, bestT := -1, stdmath.Inf(1)
-	for i, c := range cands {
-		if c.t < bestT {
-			best, bestT = i, c.t
-		}
-	}
-	if best < 0 {
+// nearestCandidate returns the candidate the click resolves to: the one nearest along the ray,
+// breaking near-coincident ties (within a screen-scaled depth window) by the user's pick priority
+// so the Selection Filter ordering decides an ambiguous pick (#1222). With the default order the
+// window collapses to the historical occurrence→face→plane→profile append precedence, and a
+// candidate genuinely in front (more than the window nearer) always wins regardless of priority.
+func (p *RayPicker) nearestCandidate(cands []pickCandidate) (Selectable, bool) {
+	if len(cands) == 0 {
 		return nil, false
 	}
+	minT := stdmath.Inf(1)
+	for _, c := range cands {
+		if c.t < minT {
+			minT = c.t
+		}
+	}
+	eps := p.depthTieEpsilon()
+	best, bestRank := -1, stdmath.MaxInt
+	for i, c := range cands {
+		if c.t > minT+eps {
+			continue // genuinely behind the front candidate — proximity wins over priority
+		}
+		if r := p.rankOf(c.sel.SelectionKind()); r < bestRank {
+			best, bestRank = i, r
+		}
+	}
 	return cands[best].sel, true
+}
+
+// depthTieEpsilon is the world-space depth window within which two hits count as the same pick
+// for priority resolution — one pixel-snap radius at the view scale. A zero/unset camera yields
+// 0, so only exact ties resolve by priority (the historical behaviour).
+func (p *RayPicker) depthTieEpsilon() float64 {
+	return pickPixelRadius * p.camera.WorldPerPixel()
 }
 
 // nearestProfile returns the closest sketch profile region the ray lands inside (mapped

--- a/app/raypicker_priority_test.go
+++ b/app/raypicker_priority_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/topo"
+)
+
+// stubVertex/stubEdge stand in only as distinct selectables for ranking tests; the resolution
+// logic under test (highestPriority, nearestCandidate) depends solely on each candidate's kind.
+
+func TestHighestPriorityDefaultOrder(t *testing.T) {
+	p := &RayPicker{}
+	// Vertex outranks edge by default (the historical snap order), independent of insertion order.
+	got, ok := p.highestPriority([]Selectable{EdgeHandle{}, VertexHandle{}})
+	if !ok {
+		t.Fatal("highestPriority returned none")
+	}
+	if _, isVertex := got.(VertexHandle); !isVertex {
+		t.Fatalf("default order: got %T, want VertexHandle (vertex outranks edge)", got)
+	}
+}
+
+func TestHighestPriorityHonoursUserRank(t *testing.T) {
+	p := &RayPicker{}
+	st := NewSelectionFilterState()
+	st.Move(st.Rank(SelectEdge), 0) // drag Edges above Vertices
+	p.SetPriorityRank(st.Rank)
+	got, _ := p.highestPriority([]Selectable{VertexHandle{}, EdgeHandle{}})
+	if _, isEdge := got.(EdgeHandle); !isEdge {
+		t.Fatalf("after reordering edge to top: got %T, want EdgeHandle", got)
+	}
+}
+
+func TestNearestCandidateProximityWinsBeyondWindow(t *testing.T) {
+	p := &RayPicker{} // zero camera ⇒ depthTieEpsilon 0, so only the nearer hit qualifies
+	cands := []pickCandidate{
+		{t: 5.0, sel: ProfileHandle{}}, // nearer (in front)
+		{t: 9.0, sel: FaceHandle{}},    // behind, higher default priority
+	}
+	got, ok := p.nearestCandidate(cands)
+	if !ok {
+		t.Fatal("nearestCandidate returned none")
+	}
+	if _, isProfile := got.(ProfileHandle); !isProfile {
+		t.Fatalf("a hit genuinely in front must win regardless of priority: got %T", got)
+	}
+}
+
+func TestNearestCandidateCoincidentResolvesByPriority(t *testing.T) {
+	p := &RayPicker{}
+	// Exactly coincident depth (within the zero-epsilon window): default order prefers the face
+	// over the profile (a solid on its sketch), matching the historical append precedence.
+	cands := []pickCandidate{
+		{t: 5.0, sel: ProfileHandle{}},
+		{t: 5.0, sel: FaceHandle{}},
+	}
+	got, _ := p.nearestCandidate(cands)
+	if _, isFace := got.(FaceHandle); !isFace {
+		t.Fatalf("coincident default: got %T, want FaceHandle", got)
+	}
+}
+
+// TestSessionPushesPriorityRankToPicker pins the SetPicker wiring: the picker resolves a
+// coincident vertex+edge by the live SelectionFilterState order, and reordering then re-pushing
+// flips the winner — the seam the Selection Filter window relies on (#1222).
+func TestSessionPushesPriorityRankToPicker(t *testing.T) {
+	s := NewSession()
+	p := NewRayPicker(s.Camera(), func() []*topo.Body { return nil })
+	s.SetPicker(p) // pushes s.selectionFilterState.Rank
+
+	if got, _ := p.highestPriority([]Selectable{EdgeHandle{}, VertexHandle{}}); !isVertexHandle(got) {
+		t.Fatalf("default pushed rank: got %T, want VertexHandle", got)
+	}
+	st := s.SelectionFilterState()
+	st.Move(st.Rank(SelectEdge), 0) // mutate the live state the closure reads
+	if got, _ := p.highestPriority([]Selectable{EdgeHandle{}, VertexHandle{}}); isVertexHandle(got) {
+		t.Fatal("after reordering edge above vertex, the picker must prefer the edge")
+	}
+}
+
+func isVertexHandle(s Selectable) bool { _, ok := s.(VertexHandle); return ok }

--- a/app/selection.go
+++ b/app/selection.go
@@ -166,9 +166,12 @@ func (WorkPointHandle) SelectionKind() SelectionKind { return SelectWorkPoint }
 func (WorkAxisHandle) SelectionKind() SelectionKind  { return SelectWorkAxis }
 
 // SelectionFilter restricts which selection kinds a pick accepts — Inventor's
-// SelectionFilterEnum. A zero filter (no kinds) accepts everything.
+// SelectionFilterEnum. A zero filter (no kinds) accepts everything; a blocking
+// filter (every kind deactivated via the Selection Filter window, #1222) accepts
+// nothing so a click selects nothing at all.
 type SelectionFilter struct {
-	kinds map[SelectionKind]bool
+	kinds    map[SelectionKind]bool
+	blockAll bool
 }
 
 // NewSelectionFilter accepts only the given kinds; with none it accepts all.
@@ -180,9 +183,20 @@ func NewSelectionFilter(kinds ...SelectionKind) *SelectionFilter {
 	return f
 }
 
-// Accepts reports whether the filter admits a kind (an empty filter admits all).
+// newBlockingFilter accepts no kind at all — the "Deselect All" state of the
+// Selection Filter window (#1222), distinct from the empty accept-all filter.
+func newBlockingFilter() *SelectionFilter { return &SelectionFilter{blockAll: true} }
+
+// Accepts reports whether the filter admits a kind (an empty filter admits all,
+// a blocking filter admits none).
 func (f *SelectionFilter) Accepts(k SelectionKind) bool {
-	if f == nil || len(f.kinds) == 0 {
+	if f == nil {
+		return true
+	}
+	if f.blockAll {
+		return false
+	}
+	if len(f.kinds) == 0 {
 		return true
 	}
 	return f.kinds[k]
@@ -190,7 +204,9 @@ func (f *SelectionFilter) Accepts(k SelectionKind) bool {
 
 // IsRestricted reports whether the filter limits the accepted kinds (i.e. it is not the
 // accept-everything default) — so a caller can tell an explicitly-set filter from the default.
-func (f *SelectionFilter) IsRestricted() bool { return f != nil && len(f.kinds) > 0 }
+func (f *SelectionFilter) IsRestricted() bool {
+	return f != nil && (f.blockAll || len(f.kinds) > 0)
+}
 
 // Selection is the current selection set — Inventor's SelectSet. It is an ordered,
 // de-duplicated list of selectables with an active filter.

--- a/app/selection_filter_integration_test.go
+++ b/app/selection_filter_integration_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/scene"
+)
+
+// downLookingBox builds a box and installs a real RayPicker with a camera looking straight down,
+// so a centre-pixel click resolves to the top face — the production pick path the selection
+// workflows use, not a stub.
+func downLookingBox(t *testing.T) *Session {
+	t.Helper()
+	s := extrudedBox(t, 2, 4) // [0,2]×[0,2]×[0,4]
+	cam := scene.NewCamera(400, 400)
+	cam.Eye, cam.Target, cam.Up = math.P3(1, 1, 20), math.P3(1, 1, 0), math.V3(0, 1, 0)
+	s.SetCamera(cam)
+	s.SetPicker(NewRayPicker(cam, partBodies(s)))
+	return s
+}
+
+// TestAmbientFilterGovernsFacePreselection drives the no-tool face pre-selection that
+// sketch-on-face and feature pre-selection depend on, through the real picker (#1222): the
+// default filter selects the face, disabling Faces stops it, Deselect All blocks everything, and
+// Select All restores it.
+func TestAmbientFilterGovernsFacePreselection(t *testing.T) {
+	s := downLookingBox(t)
+
+	s.Click(200, 200)
+	if _, ok := s.Selection().First().(FaceHandle); !ok {
+		t.Fatalf("default ambient filter: want a pre-selected FaceHandle, got %T", s.Selection().First())
+	}
+
+	s.Selection().Clear()
+	s.SelectionFilterState().SetEnabled(SelectFace, false)
+	s.Click(200, 200)
+	if _, ok := s.Selection().First().(FaceHandle); ok {
+		t.Fatal("Faces disabled: a click must not pre-select a face")
+	}
+
+	s.Selection().Clear()
+	s.SelectionFilterState().DisableAll()
+	s.Click(200, 200)
+	if got := s.Selection().First(); got != nil {
+		t.Fatalf("Deselect All: a click must select nothing, got %T", got)
+	}
+
+	s.Selection().Clear()
+	s.SelectionFilterState().EnableAll()
+	s.Click(200, 200)
+	if _, ok := s.Selection().First().(FaceHandle); !ok {
+		t.Fatalf("Select All restored: want a FaceHandle, got %T", s.Selection().First())
+	}
+}
+
+// TestToolFilterWinsOverDisabledAmbient confirms an active tool's filter still governs picking
+// even when the user has ambiently disabled everything in the Selection Filter window — so the
+// offset-work-plane-from-face workflow keeps working regardless of the ambient setting (#1222).
+func TestToolFilterWinsOverDisabledAmbient(t *testing.T) {
+	s := downLookingBox(t)
+	s.SelectionFilterState().DisableAll() // user blocked every kind ambiently
+
+	tool := NewOffsetWorkPlaneTool() // Start sets a {WorkPlane, Face} filter
+	s.StartTool(tool)
+	s.Click(200, 200) // pick the top planar face through the real picker
+	if !tool.BasePicked() {
+		t.Fatal("an active tool's face filter must win over the disabled ambient filter")
+	}
+}

--- a/app/selection_filter_state.go
+++ b/app/selection_filter_state.go
@@ -119,8 +119,8 @@ func (st *SelectionFilterState) Filter() *SelectionFilter {
 	}
 }
 
-// selectionKindLabel is the human label shown for a kind in the Selection Filter window.
-func selectionKindLabel(k SelectionKind) string {
+// SelectionKindLabel is the human label shown for a kind in the Selection Filter window.
+func SelectionKindLabel(k SelectionKind) string {
 	switch k {
 	case SelectWorkPoint:
 		return "Work Points"

--- a/app/selection_filter_state.go
+++ b/app/selection_filter_state.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// SelectionFilterState is the user-controlled, no-tool ambient selection setting that the
+// Selection Filter & Priority window edits (#1222). It holds, over the viewport-pickable
+// SelectionKinds, (a) which kinds are enabled (pickable) and (b) their priority order — the
+// kind nearer the top wins an ambiguous pick (see RayPicker, #1222 PBI 2). It is the single
+// source of truth for the ambient filter: SelectionPriority presets write into it, and
+// Session.pickFilter reads its Filter() when no tool has restricted selection.
+//
+// Example: disable SelectFace so a click can no longer grab a face, leaving the edge behind
+// it pickable.
+type SelectionFilterState struct {
+	enabled map[SelectionKind]bool
+	order   []SelectionKind
+}
+
+// defaultFilterableKinds is the ordered set of kinds a viewport pick (RayPicker) can produce,
+// in the priority order that reproduces the historical pick behaviour: the exact "snap"
+// targets (datum point/axis, cloud point, vertex, edge) outrank the depth-sorted face/plane/
+// profile/sketch hits, matching snapPick + the append order in RayPicker.Pick. Reordering in
+// the window deviates from this default; until then nothing changes.
+func defaultFilterableKinds() []SelectionKind {
+	return []SelectionKind{
+		SelectWorkPoint,
+		SelectWorkAxis,
+		SelectPointCloudPoint,
+		SelectVertex,
+		SelectEdge,
+		SelectOccurrence,
+		SelectBody,
+		SelectFace,
+		SelectWorkPlane,
+		SelectProfile,
+		SelectSketchEntity,
+	}
+}
+
+// NewSelectionFilterState returns the default state: every kind enabled in the default
+// priority order, which is equivalent to the context-default accept-all pick.
+func NewSelectionFilterState() *SelectionFilterState {
+	order := defaultFilterableKinds()
+	enabled := make(map[SelectionKind]bool, len(order))
+	for _, k := range order {
+		enabled[k] = true
+	}
+	return &SelectionFilterState{enabled: enabled, order: order}
+}
+
+// Enabled reports whether picks of kind k are currently allowed.
+func (st *SelectionFilterState) Enabled(k SelectionKind) bool { return st.enabled[k] }
+
+// SetEnabled activates or deactivates picking of kind k.
+func (st *SelectionFilterState) SetEnabled(k SelectionKind, on bool) { st.enabled[k] = on }
+
+// Order returns a copy of the priority order, top (highest priority) first.
+func (st *SelectionFilterState) Order() []SelectionKind {
+	out := make([]SelectionKind, len(st.order))
+	copy(out, st.order)
+	return out
+}
+
+// Move relocates the kind at index from to index to, shifting the rest — the drag-and-drop
+// reorder of the priority list. Out-of-range or no-op indices leave the order unchanged.
+func (st *SelectionFilterState) Move(from, to int) {
+	n := len(st.order)
+	if from < 0 || from >= n || to < 0 || to >= n || from == to {
+		return
+	}
+	k := st.order[from]
+	st.order = append(st.order[:from], st.order[from+1:]...)
+	st.order = append(st.order[:to], append([]SelectionKind{k}, st.order[to:]...)...)
+}
+
+// EnableAll activates every kind — the window's "Select All" button.
+func (st *SelectionFilterState) EnableAll() {
+	for _, k := range st.order {
+		st.enabled[k] = true
+	}
+}
+
+// DisableAll deactivates every kind — the window's "Deselect All" button; a click then
+// selects nothing (Filter reports a blocking filter).
+func (st *SelectionFilterState) DisableAll() {
+	for _, k := range st.order {
+		st.enabled[k] = false
+	}
+}
+
+// Rank returns the priority index of kind k (0 = highest); kinds not managed here sort last
+// so an unlisted candidate never outranks a listed one during ambiguous-pick resolution.
+func (st *SelectionFilterState) Rank(k SelectionKind) int {
+	for i, kk := range st.order {
+		if kk == k {
+			return i
+		}
+	}
+	return len(st.order)
+}
+
+// Filter builds the SelectionFilter a no-tool pick honours: accept-all when every kind is
+// enabled (the default, equal to the context default), a kind-restricted filter when some are
+// disabled, and a blocking filter when none are enabled.
+func (st *SelectionFilterState) Filter() *SelectionFilter {
+	kinds := make([]SelectionKind, 0, len(st.order))
+	for _, k := range st.order {
+		if st.enabled[k] {
+			kinds = append(kinds, k)
+		}
+	}
+	switch len(kinds) {
+	case len(st.order):
+		return NewSelectionFilter() // all enabled — accept everything (context default)
+	case 0:
+		return newBlockingFilter() // Deselect All — accept nothing
+	default:
+		return NewSelectionFilter(kinds...)
+	}
+}
+
+// selectionKindLabel is the human label shown for a kind in the Selection Filter window.
+func selectionKindLabel(k SelectionKind) string {
+	switch k {
+	case SelectWorkPoint:
+		return "Work Points"
+	case SelectWorkAxis:
+		return "Work Axes"
+	case SelectPointCloudPoint:
+		return "Point-Cloud Points"
+	case SelectVertex:
+		return "Vertices"
+	case SelectEdge:
+		return "Edges"
+	case SelectOccurrence:
+		return "Components"
+	case SelectBody:
+		return "Solid Bodies"
+	case SelectFace:
+		return "Faces"
+	case SelectWorkPlane:
+		return "Work Planes"
+	case SelectProfile:
+		return "Sketch Profiles/Areas"
+	case SelectSketchEntity:
+		return "Sketch Elements"
+	default:
+		return "Unknown"
+	}
+}

--- a/app/selection_filter_state.go
+++ b/app/selection_filter_state.go
@@ -119,32 +119,25 @@ func (st *SelectionFilterState) Filter() *SelectionFilter {
 	}
 }
 
+// selectionKindLabels are the human labels shown per kind in the Selection Filter window.
+var selectionKindLabels = map[SelectionKind]string{
+	SelectWorkPoint:       "Work Points",
+	SelectWorkAxis:        "Work Axes",
+	SelectPointCloudPoint: "Point-Cloud Points",
+	SelectVertex:          "Vertices",
+	SelectEdge:            "Edges",
+	SelectOccurrence:      "Components",
+	SelectBody:            "Solid Bodies",
+	SelectFace:            "Faces",
+	SelectWorkPlane:       "Work Planes",
+	SelectProfile:         "Sketch Profiles/Areas",
+	SelectSketchEntity:    "Sketch Elements",
+}
+
 // SelectionKindLabel is the human label shown for a kind in the Selection Filter window.
 func SelectionKindLabel(k SelectionKind) string {
-	switch k {
-	case SelectWorkPoint:
-		return "Work Points"
-	case SelectWorkAxis:
-		return "Work Axes"
-	case SelectPointCloudPoint:
-		return "Point-Cloud Points"
-	case SelectVertex:
-		return "Vertices"
-	case SelectEdge:
-		return "Edges"
-	case SelectOccurrence:
-		return "Components"
-	case SelectBody:
-		return "Solid Bodies"
-	case SelectFace:
-		return "Faces"
-	case SelectWorkPlane:
-		return "Work Planes"
-	case SelectProfile:
-		return "Sketch Profiles/Areas"
-	case SelectSketchEntity:
-		return "Sketch Elements"
-	default:
-		return "Unknown"
+	if label, ok := selectionKindLabels[k]; ok {
+		return label
 	}
+	return "Unknown"
 }

--- a/app/selection_filter_state_test.go
+++ b/app/selection_filter_state_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "testing"
+
+func TestSelectionFilterStateDefaultAcceptsAll(t *testing.T) {
+	st := NewSelectionFilterState()
+	f := st.Filter()
+	if f.IsRestricted() {
+		t.Fatal("default state must build an unrestricted (accept-all) filter")
+	}
+	for _, k := range st.Order() {
+		if !st.Enabled(k) || !f.Accepts(k) {
+			t.Errorf("default state should enable and accept kind %d", k)
+		}
+	}
+}
+
+func TestSelectionFilterStateDisableRestricts(t *testing.T) {
+	st := NewSelectionFilterState()
+	st.SetEnabled(SelectFace, false)
+	f := st.Filter()
+	if !f.IsRestricted() {
+		t.Fatal("disabling a kind must produce a restricted filter")
+	}
+	if f.Accepts(SelectFace) {
+		t.Error("a disabled face must not be accepted")
+	}
+	if !f.Accepts(SelectEdge) {
+		t.Error("a still-enabled edge must be accepted")
+	}
+}
+
+func TestSelectionFilterStateDeselectAllBlocks(t *testing.T) {
+	st := NewSelectionFilterState()
+	st.DisableAll()
+	f := st.Filter()
+	if !f.IsRestricted() {
+		t.Fatal("Deselect All must produce a restricted (blocking) filter, not accept-all")
+	}
+	for _, k := range st.Order() {
+		if f.Accepts(k) {
+			t.Errorf("Deselect All must reject every kind, accepted %d", k)
+		}
+	}
+}
+
+func TestSelectionFilterStateEnableAllRestoresDefault(t *testing.T) {
+	st := NewSelectionFilterState()
+	st.DisableAll()
+	st.EnableAll()
+	if st.Filter().IsRestricted() {
+		t.Error("Select All must restore the accept-all filter")
+	}
+}
+
+func TestSelectionFilterStateMoveReordersRank(t *testing.T) {
+	st := NewSelectionFilterState()
+	if st.Rank(SelectEdge) >= st.Rank(SelectFace) {
+		t.Fatalf("default: edge (%d) should outrank face (%d)", st.Rank(SelectEdge), st.Rank(SelectFace))
+	}
+	face := st.Rank(SelectFace)
+	st.Move(face, 0) // drag Faces to the top
+	if st.Rank(SelectFace) != 0 {
+		t.Errorf("after moving face to top, rank = %d, want 0", st.Rank(SelectFace))
+	}
+	if st.Rank(SelectFace) >= st.Rank(SelectEdge) {
+		t.Error("face moved to top must now outrank edge")
+	}
+}
+
+func TestSelectionFilterStateMoveIgnoresOutOfRange(t *testing.T) {
+	st := NewSelectionFilterState()
+	before := st.Order()
+	st.Move(-1, 0)
+	st.Move(0, len(before))
+	st.Move(2, 2)
+	after := st.Order()
+	for i := range before {
+		if before[i] != after[i] {
+			t.Fatalf("out-of-range/no-op Move changed the order at %d", i)
+		}
+	}
+}
+
+func TestSelectionFilterStateOrderIsCopy(t *testing.T) {
+	st := NewSelectionFilterState()
+	got := st.Order()
+	got[0] = SelectFace
+	if st.Order()[0] == SelectFace && len(defaultFilterableKinds()) > 0 && defaultFilterableKinds()[0] != SelectFace {
+		t.Error("Order() must return a copy; mutating it changed internal state")
+	}
+}
+
+// TestSelectionPriorityPresetsMatchPriorityFilter pins that the four priority presets write the
+// exact kind set priorityFilter defines, so the ribbon combo and the window agree (#1222).
+func TestSelectionPriorityPresetsMatchPriorityFilter(t *testing.T) {
+	priorities := []SelectionPriority{PriorityGeneral, PriorityPart, PriorityFace, PriorityEdge}
+	kinds := []SelectionKind{SelectFace, SelectEdge, SelectBody, SelectOccurrence, SelectVertex, SelectProfile}
+	for _, p := range priorities {
+		st := NewSelectionFilterState()
+		st.applyPriorityPreset(p)
+		got, want := st.Filter(), priorityFilter(p)
+		for _, k := range kinds {
+			if got.Accepts(k) != want.Accepts(k) {
+				t.Errorf("priority %d kind %d: preset accepts %v, priorityFilter accepts %v",
+					p, k, got.Accepts(k), want.Accepts(k))
+			}
+		}
+	}
+}
+
+func TestPickFilterReflectsAmbientState(t *testing.T) {
+	s := NewSession()
+	s.SelectionFilterState().SetEnabled(SelectFace, false)
+	if s.pickFilter().Accepts(SelectFace) {
+		t.Error("with no tool, pickFilter must reflect the ambient state (face disabled)")
+	}
+	if !s.pickFilter().Accepts(SelectEdge) {
+		t.Error("with no tool, an enabled edge must still be accepted")
+	}
+}

--- a/app/selection_filter_state_test.go
+++ b/app/selection_filter_state_test.go
@@ -111,6 +111,47 @@ func TestSelectionPriorityPresetsMatchPriorityFilter(t *testing.T) {
 	}
 }
 
+func TestSelectionFilterWindowOpenAccessors(t *testing.T) {
+	s := NewSession()
+	if s.SelectionFilterWindowOpen() {
+		t.Fatal("the window must start closed")
+	}
+	s.OpenSelectionFilterWindow()
+	if !s.SelectionFilterWindowOpen() {
+		t.Fatal("Open must open the window")
+	}
+	s.ToggleSelectionFilterWindow()
+	if s.SelectionFilterWindowOpen() {
+		t.Fatal("Toggle must close an open window")
+	}
+	s.OpenSelectionFilterWindow()
+	s.CloseSelectionFilterWindow()
+	if s.SelectionFilterWindowOpen() {
+		t.Fatal("Close must close the window")
+	}
+}
+
+func TestSelectionFilterCommandTogglesWindow(t *testing.T) {
+	s := NewSession()
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	if err := s.Execute("Select.Filter"); err != nil {
+		t.Fatalf("execute Select.Filter: %v", err)
+	}
+	if !s.SelectionFilterWindowOpen() {
+		t.Error("the Select.Filter command must open the Selection Filter window")
+	}
+}
+
+func TestSelectionKindLabelCoversFilterableKinds(t *testing.T) {
+	for _, k := range defaultFilterableKinds() {
+		if label := SelectionKindLabel(k); label == "" || label == "Unknown" {
+			t.Errorf("filterable kind %d has no human label (got %q)", k, label)
+		}
+	}
+}
+
 func TestPickFilterReflectsAmbientState(t *testing.T) {
 	s := NewSession()
 	s.SelectionFilterState().SetEnabled(SelectFace, false)

--- a/app/selection_priority.go
+++ b/app/selection_priority.go
@@ -25,16 +25,36 @@ const (
 // SelectionPriority returns the active no-tool selection priority.
 func (s *Session) SelectionPriority() SelectionPriority { return s.selectionPriority }
 
-// SetSelectionPriority sets the no-tool selection priority.
-func (s *Session) SetSelectionPriority(p SelectionPriority) { s.selectionPriority = p }
+// SetSelectionPriority sets the no-tool selection priority. The four priorities are presets of
+// the richer SelectionFilterState (#1222): they enable just the kinds the priority accepts, so
+// the combo on the View tab and the Selection Filter window stay a single source of truth.
+func (s *Session) SetSelectionPriority(p SelectionPriority) {
+	s.selectionPriority = p
+	s.selectionFilterState.applyPriorityPreset(p)
+}
+
+// applyPriorityPreset enables exactly the kinds the priority accepts (General enables all). It
+// reuses priorityFilter so the preset→kinds mapping is defined once.
+func (st *SelectionFilterState) applyPriorityPreset(p SelectionPriority) {
+	if p == PriorityGeneral {
+		st.EnableAll()
+		return
+	}
+	st.DisableAll()
+	for _, k := range st.order {
+		if priorityFilter(p).Accepts(k) {
+			st.SetEnabled(k, true)
+		}
+	}
+}
 
 // pickFilter is the filter a viewport pick honours. An active tool's filter, or any explicitly
 // restricted filter, always wins; only when nothing has restricted it (no tool, default
-// accept-all filter) does the selection priority apply. The no-tool click (Session.Pointer) and
-// box-select consult it so a priority biases both.
+// accept-all filter) does the user's ambient SelectionFilterState apply. The no-tool click
+// (Session.Pointer) and box-select consult it so the filter/priority biases both.
 func (s *Session) pickFilter() *SelectionFilter {
 	if s.tool == nil && !s.selection.Filter().IsRestricted() {
-		return priorityFilter(s.selectionPriority)
+		return s.selectionFilterState.Filter()
 	}
 	return s.selection.Filter()
 }

--- a/app/session.go
+++ b/app/session.go
@@ -37,133 +37,134 @@ import (
 // it through Execute / the input methods (Click, PressKey…) — there is no GPU or
 // window involved, so "operating the UI" is fully unit-testable (ADR-0014/0004).
 type Session struct {
-	workspace            *doc.Workspace
-	store                doc.Store                // the workspace's persistence backend; nil for in-memory sessions
-	sketchInference      *sketch.InferenceOptions // session inference prefs (M06-F10; nil ⇒ defaults)
-	facetStore           *facetstore.FacetStore   // tolerance-keyed facet/stroke cache (M07 #293; lazy)
-	transientBodies      *bodyapi.TransientBRep   // transient B-rep registry (M07 #628; lazy)
-	commands             *CommandManager
-	bindings             *Bindings              // keyboard shortcut + alias resolver (M05-F17)
-	histories            map[doc.ID]*docHistory // per-document transaction-event streams (undo/redo)
-	viewState            viewstate.Store        // per-user document view/camera persistence (nil ⇒ disabled)
-	prefs                userprefs.Prefs        // global user preferences (ViewCube show/lock/compass/size/…)
-	prefsStore           userprefs.Store        // persists prefs to the user config dir (nil ⇒ in-session only)
-	bus                  *event.Bus
-	selection            *Selection
-	highlightSets        *HighlightSets // named, colored emphasis groups for add-ins (#157)
-	tool                 *ToolInstance
-	picker               Picker
-	regionPicker         RegionPicker          // resolves a box-select rectangle (nil ⇒ box-select disabled)
-	boxSelect            BoxSelection          // the in-progress rubber-band rectangle, if any
-	zoomWindow           BoxSelection          // the in-progress Zoom Window rubber-band, if any (#913 N16)
-	zoomWindowArmed      bool                  // the Zoom Window tool is armed: the next left-drag zooms
-	constrainedOrbit     bool                  // the Constrained Orbit tool is active: left-drag turntables (#913 N10)
-	steeringWheel        bool                  // the SteeringWheels radial nav menu is shown at the cursor (#913 N26)
-	entityDrag           sketchDrag            // the in-progress direct drag of sketch entities, if any
-	cloudMove            cloudMoveDrag         // the in-progress interactive drag of a point cloud, if any (#645)
-	relaxMode            bool                  // Relax Mode: drag over/fully-constrained sketch geometry (#791)
-	hudEnabled           bool                  // the 2D-sketch dynamic-input HUD is enabled (#790)
-	sketchHUD            sketchHUD             // the dynamic-input HUD's live typing state (#790)
-	dimDrag              dimDragState          // the in-progress drag of a drawing dimension's text/line
-	selectOther          selectOther           // the in-progress Select Other cycle, if any
-	viewHistory          viewHistory           // recorded views for Previous View (F5)
-	selectionPriority    SelectionPriority     // biases no-tool picking (Edge/Face/Part) (#912)
-	selectionFilterState *SelectionFilterState // user-editable no-tool ambient filter + priority order (#1222)
-	camera               scene.Camera
-	camTween             cameraTween
-	driveAnim            driveAnimation
-	sketchReturnCam      scene.Camera
-	activeSketch         *sketch.Sketch
-	activeSketch3D       *sketch.Sketch3D
-	pendingDim           *sketch.DimensionConstraint
-	overlays             []renderer.DrawItem
-	hiddenBodyKeys       map[string]bool                  // scratch hidden-body set used only when no document is active
-	hiddenBodyKeysByDoc  map[doc.ID]map[string]bool       // browser-driven body visibility, scoped per document (#1105)
-	graphics             *clientgraphics.Store            // scratch store used only when no document is active
-	graphicsByDoc        map[doc.ID]*clientgraphics.Store // add-in client/interaction graphics, scoped per document (M05-F05)
-	addins               *AddInManager
-	clientApps           *ClientApplicationRegistry        // external automation drivers (M05-F01)
-	browserPanes         *AddInBrowserPanes                // add-in browser panes (M05-F03)
-	dockableWindows      *AddInDockableWindows             // add-in dockable windows (M05-F03)
-	appOptions           options.All                       // typed per-user option groups (M05-F11)
-	optionsStore         options.Store                     // persists appOptions (nil ⇒ in-session only)
-	statusText           string                            // wire-set status-bar message (M05-F09)
-	messageCenter        *MessageCenter                    // sectioned errors/warnings tree (M05-F09)
-	messageCenterOpen    bool                              // the Messages panel is open
-	progress             *ProgressLedger                   // live progress bars (M05-F09)
-	balloonTips          *BalloonTipCenter                 // notification balloons (M05-F09)
-	prompts              *PromptCenter                     // declarative prompts (M05-F09)
-	dialogMemoryStore    dialogmemory.Store                // persists suppressions + remembered answers
-	miniToolbars         *MiniToolbarRack                  // in-canvas mini-toolbars (M05-F07)
-	fileDialogQueue      []FileDialogRequest               // pending add-in file-dialog asks (M05-F08)
-	webViews             map[string]wire.WebDialogSpec     // presented web views (M05-F08)
-	webViewOrder         []string                          // web views in creation order
-	urlOpener            URLOpener                         // platform URL opener (head-injected)
-	windowFrame          WindowFrameStatus                 // mirrored host-window state (M05-F10)
-	triad                TriadGizmo                        // the move/rotate triad (M05-F13)
-	manipulators         *ManipulatorBoard                 // add-in drag handles (M05-F13)
-	helpSources          map[string]string                 // add-in help bases by source (M05-F14)
-	helpInterceptor      HelpInterceptor                   // before-help veto hook (M05-F14)
-	documentSubTypes     map[doc.SubTypeID]DocumentSubType // registered flavors (M05-F15)
-	documentSubTypeOrder []doc.SubTypeID
-	addinEnvironments    map[Environment]string                           // registered add-in environments (M05-F16)
-	activeAddInEnv       Environment                                      // the entered add-in environment (base when none)
-	markingMenus         map[Environment]wire.MarkingMenuView             // radial menus per environment (M05-F12)
-	contextMenus         map[string]map[string][]wire.ContextMenuItemSpec // add-in menu injections by kind
-	lastCommandID        string                                           // the most recently invoked command, for right-click Repeat (#915 C5)
-	classicContextMenu   bool                                             // right-click shows the classic linear menu instead of the radial marking menu (#915 C8)
-	objectVisibility     wire.ObjectVisibilityView                        // View ▸ Object-visibility toggles
-	cmdInput             commandInput                                     // command-alias input box state (M05-F17)
-	cmdLine              *CommandLine                                     // Command Window REPL engine (M26)
-	commandWindowHidden  bool                                             // Command Window docked panel hidden? (M26; inverted so zero ⇒ visible)
-	commandFocusWanted   bool                                             // a cancel/ESC asked to refocus the command input (M26; head clears it)
-	grid                 *GridSettings
-	themes               *theme.Library
-	themeStore           *theme.Store
-	materials            *material.Library
-	materialStore        *material.Store
-	recentDocuments      []string                       // recently opened/saved paths, most recent first (M04-F05)
-	fileMetadata         map[doc.ID][]FileMetadataValue // last save's PopulateFileMetadata harvest (M04-F05)
-	notice               string                         // last user-facing notice (e.g. a failed-commit reason)
-	visualStyle          renderer.VisualStyle           // how the scene is drawn (View tab's Visual Style)
-	lightingStyle        renderer.LightingStyleID       // active lighting preset (View tab's Lighting Style)
-	lighting             renderer.SceneLighting         // the live lighting rig (resolved from the style, then edited)
-	colorSchemes         *colorscheme.Registry          // application color schemes — viewport bg + highlight/select palette (M16-F06 #642)
-	colorSchemeRev       uint64                         // bumped on scheme/background change; the head re-applies the viewport colors (live preview)
-	styles               *style.Manager                 // document color styles + style-library cascade (M16-F02 #403/#408)
-	bodyColorStyles      map[string]string              // body reference key → assigned color-style name (M16-F02 #403/#408)
-	displayOptions       display.Options                // app-level display options that parameterize the display modes (M16-F07 #643)
-	chamferFlatCorners   bool                           // default three-edge-corner treatment for new chamfers
-	chamferConcaveOut    bool                           // default concave-edge strategy for new chamfers (true ⇒ outward fill)
-	paramsDialogOpen     bool                           // the Manage ▸ Parameters dialog is open
-	keymapEditorOpen     bool                           // the Tools ▸ Customize Keyboard panel is open (M05-F17)
-	lightingPanelOpen    bool                           // the View ▸ Lighting settings panel is open
-	namedViewsPanelOpen  bool                           // the View ▸ Named Views panel is open (M16-F03 #404)
-	colorStylesPanelOpen bool                           // the Color Styles panel is open (M16-F02 #403/#408)
-	displaySettingsOpen  bool                           // the Display Settings dialog is open (M16-F07 #643)
-	unitsSettingsOpen    bool                           // the Document Settings ▸ Units dialog is open (#146)
-	historyBrowserOpen   bool                           // the Edit ▸ History Browser window is open
-	loadEnvRequested     bool                           // a "Load HDR…" was requested; the head opens the file dialog
-	meshImportRequested  bool                           // a "Place Mesh…" was requested; the head opens the file dialog (#700)
-	pointCloudRequested  bool                           // an "Import Point Cloud…" was requested; the head opens the file dialog (#645)
-	scriptConsoleOpen    bool                           // the Manage ▸ Scripts ▸ Script Console panel is open
-	capturePath          string                         // a requested viewport PNG capture path; the head writes it after render
-	captureWindowPath    string                         // a requested whole-window PNG capture path; the head writes it after the frame composites
-	normalDebug          bool                           // viewport normal-debug render (front green / back red); head reads each frame
-	meshColors           bool                           // viewport mesh-debug-colors render (each face/triangle a distinct color)
-	meshColorsPerTri     bool                           // when meshColors: color per TRIANGLE (else per B-rep face)
-	editScope            editScope                      // while editing a node, hide everything created after it (issue #132)
-	asmBodies            assemblyBodyCache              // memoized world-space assembly bodies + their occurrences (#769)
-	pickIndex            *assemblyPickIndex             // BVH over placement AABBs for sub-linear ray picking (M34-F5)
-	bomPanelOpen         bool                           // the Assemble ▸ Bill of Materials panel is open (#768)
-	bomViewKind          bom.ViewKind                   // the BOM panel's selected view (structured / parts-only)
-	updateCheckRequested bool                           // Help ▸ Check for Updates was clicked; the head runs the (network) check
-	pendingUpdate        *update.Result                 // last update-check outcome to show in the update window; nil = closed
-	txEvents             []sessionTxEvent               // append-only transaction log since app open (for bug reports)
-	bugReport            bugReportState                 // in-progress Help ▸ Report Bug capture+submit, if any
-	bugOutcome           atomic.Pointer[bugResult]      // submit goroutine → frame loop handoff (session never touched off-thread)
-	bugSubmitter         bugSubmitter                   // injectable reporting endpoint (DI; lazily defaults to real HTTP)
-	addInCat             addInCatalogue                 // Add-In Catalogue browse/install state (#1164)
+	workspace                 *doc.Workspace
+	store                     doc.Store                // the workspace's persistence backend; nil for in-memory sessions
+	sketchInference           *sketch.InferenceOptions // session inference prefs (M06-F10; nil ⇒ defaults)
+	facetStore                *facetstore.FacetStore   // tolerance-keyed facet/stroke cache (M07 #293; lazy)
+	transientBodies           *bodyapi.TransientBRep   // transient B-rep registry (M07 #628; lazy)
+	commands                  *CommandManager
+	bindings                  *Bindings              // keyboard shortcut + alias resolver (M05-F17)
+	histories                 map[doc.ID]*docHistory // per-document transaction-event streams (undo/redo)
+	viewState                 viewstate.Store        // per-user document view/camera persistence (nil ⇒ disabled)
+	prefs                     userprefs.Prefs        // global user preferences (ViewCube show/lock/compass/size/…)
+	prefsStore                userprefs.Store        // persists prefs to the user config dir (nil ⇒ in-session only)
+	bus                       *event.Bus
+	selection                 *Selection
+	highlightSets             *HighlightSets // named, colored emphasis groups for add-ins (#157)
+	tool                      *ToolInstance
+	picker                    Picker
+	regionPicker              RegionPicker          // resolves a box-select rectangle (nil ⇒ box-select disabled)
+	boxSelect                 BoxSelection          // the in-progress rubber-band rectangle, if any
+	zoomWindow                BoxSelection          // the in-progress Zoom Window rubber-band, if any (#913 N16)
+	zoomWindowArmed           bool                  // the Zoom Window tool is armed: the next left-drag zooms
+	constrainedOrbit          bool                  // the Constrained Orbit tool is active: left-drag turntables (#913 N10)
+	steeringWheel             bool                  // the SteeringWheels radial nav menu is shown at the cursor (#913 N26)
+	entityDrag                sketchDrag            // the in-progress direct drag of sketch entities, if any
+	cloudMove                 cloudMoveDrag         // the in-progress interactive drag of a point cloud, if any (#645)
+	relaxMode                 bool                  // Relax Mode: drag over/fully-constrained sketch geometry (#791)
+	hudEnabled                bool                  // the 2D-sketch dynamic-input HUD is enabled (#790)
+	sketchHUD                 sketchHUD             // the dynamic-input HUD's live typing state (#790)
+	dimDrag                   dimDragState          // the in-progress drag of a drawing dimension's text/line
+	selectOther               selectOther           // the in-progress Select Other cycle, if any
+	viewHistory               viewHistory           // recorded views for Previous View (F5)
+	selectionPriority         SelectionPriority     // biases no-tool picking (Edge/Face/Part) (#912)
+	selectionFilterState      *SelectionFilterState // user-editable no-tool ambient filter + priority order (#1222)
+	selectionFilterWindowOpen bool                  // the Selection Filter & Priority window is open (#1222)
+	camera                    scene.Camera
+	camTween                  cameraTween
+	driveAnim                 driveAnimation
+	sketchReturnCam           scene.Camera
+	activeSketch              *sketch.Sketch
+	activeSketch3D            *sketch.Sketch3D
+	pendingDim                *sketch.DimensionConstraint
+	overlays                  []renderer.DrawItem
+	hiddenBodyKeys            map[string]bool                  // scratch hidden-body set used only when no document is active
+	hiddenBodyKeysByDoc       map[doc.ID]map[string]bool       // browser-driven body visibility, scoped per document (#1105)
+	graphics                  *clientgraphics.Store            // scratch store used only when no document is active
+	graphicsByDoc             map[doc.ID]*clientgraphics.Store // add-in client/interaction graphics, scoped per document (M05-F05)
+	addins                    *AddInManager
+	clientApps                *ClientApplicationRegistry        // external automation drivers (M05-F01)
+	browserPanes              *AddInBrowserPanes                // add-in browser panes (M05-F03)
+	dockableWindows           *AddInDockableWindows             // add-in dockable windows (M05-F03)
+	appOptions                options.All                       // typed per-user option groups (M05-F11)
+	optionsStore              options.Store                     // persists appOptions (nil ⇒ in-session only)
+	statusText                string                            // wire-set status-bar message (M05-F09)
+	messageCenter             *MessageCenter                    // sectioned errors/warnings tree (M05-F09)
+	messageCenterOpen         bool                              // the Messages panel is open
+	progress                  *ProgressLedger                   // live progress bars (M05-F09)
+	balloonTips               *BalloonTipCenter                 // notification balloons (M05-F09)
+	prompts                   *PromptCenter                     // declarative prompts (M05-F09)
+	dialogMemoryStore         dialogmemory.Store                // persists suppressions + remembered answers
+	miniToolbars              *MiniToolbarRack                  // in-canvas mini-toolbars (M05-F07)
+	fileDialogQueue           []FileDialogRequest               // pending add-in file-dialog asks (M05-F08)
+	webViews                  map[string]wire.WebDialogSpec     // presented web views (M05-F08)
+	webViewOrder              []string                          // web views in creation order
+	urlOpener                 URLOpener                         // platform URL opener (head-injected)
+	windowFrame               WindowFrameStatus                 // mirrored host-window state (M05-F10)
+	triad                     TriadGizmo                        // the move/rotate triad (M05-F13)
+	manipulators              *ManipulatorBoard                 // add-in drag handles (M05-F13)
+	helpSources               map[string]string                 // add-in help bases by source (M05-F14)
+	helpInterceptor           HelpInterceptor                   // before-help veto hook (M05-F14)
+	documentSubTypes          map[doc.SubTypeID]DocumentSubType // registered flavors (M05-F15)
+	documentSubTypeOrder      []doc.SubTypeID
+	addinEnvironments         map[Environment]string                           // registered add-in environments (M05-F16)
+	activeAddInEnv            Environment                                      // the entered add-in environment (base when none)
+	markingMenus              map[Environment]wire.MarkingMenuView             // radial menus per environment (M05-F12)
+	contextMenus              map[string]map[string][]wire.ContextMenuItemSpec // add-in menu injections by kind
+	lastCommandID             string                                           // the most recently invoked command, for right-click Repeat (#915 C5)
+	classicContextMenu        bool                                             // right-click shows the classic linear menu instead of the radial marking menu (#915 C8)
+	objectVisibility          wire.ObjectVisibilityView                        // View ▸ Object-visibility toggles
+	cmdInput                  commandInput                                     // command-alias input box state (M05-F17)
+	cmdLine                   *CommandLine                                     // Command Window REPL engine (M26)
+	commandWindowHidden       bool                                             // Command Window docked panel hidden? (M26; inverted so zero ⇒ visible)
+	commandFocusWanted        bool                                             // a cancel/ESC asked to refocus the command input (M26; head clears it)
+	grid                      *GridSettings
+	themes                    *theme.Library
+	themeStore                *theme.Store
+	materials                 *material.Library
+	materialStore             *material.Store
+	recentDocuments           []string                       // recently opened/saved paths, most recent first (M04-F05)
+	fileMetadata              map[doc.ID][]FileMetadataValue // last save's PopulateFileMetadata harvest (M04-F05)
+	notice                    string                         // last user-facing notice (e.g. a failed-commit reason)
+	visualStyle               renderer.VisualStyle           // how the scene is drawn (View tab's Visual Style)
+	lightingStyle             renderer.LightingStyleID       // active lighting preset (View tab's Lighting Style)
+	lighting                  renderer.SceneLighting         // the live lighting rig (resolved from the style, then edited)
+	colorSchemes              *colorscheme.Registry          // application color schemes — viewport bg + highlight/select palette (M16-F06 #642)
+	colorSchemeRev            uint64                         // bumped on scheme/background change; the head re-applies the viewport colors (live preview)
+	styles                    *style.Manager                 // document color styles + style-library cascade (M16-F02 #403/#408)
+	bodyColorStyles           map[string]string              // body reference key → assigned color-style name (M16-F02 #403/#408)
+	displayOptions            display.Options                // app-level display options that parameterize the display modes (M16-F07 #643)
+	chamferFlatCorners        bool                           // default three-edge-corner treatment for new chamfers
+	chamferConcaveOut         bool                           // default concave-edge strategy for new chamfers (true ⇒ outward fill)
+	paramsDialogOpen          bool                           // the Manage ▸ Parameters dialog is open
+	keymapEditorOpen          bool                           // the Tools ▸ Customize Keyboard panel is open (M05-F17)
+	lightingPanelOpen         bool                           // the View ▸ Lighting settings panel is open
+	namedViewsPanelOpen       bool                           // the View ▸ Named Views panel is open (M16-F03 #404)
+	colorStylesPanelOpen      bool                           // the Color Styles panel is open (M16-F02 #403/#408)
+	displaySettingsOpen       bool                           // the Display Settings dialog is open (M16-F07 #643)
+	unitsSettingsOpen         bool                           // the Document Settings ▸ Units dialog is open (#146)
+	historyBrowserOpen        bool                           // the Edit ▸ History Browser window is open
+	loadEnvRequested          bool                           // a "Load HDR…" was requested; the head opens the file dialog
+	meshImportRequested       bool                           // a "Place Mesh…" was requested; the head opens the file dialog (#700)
+	pointCloudRequested       bool                           // an "Import Point Cloud…" was requested; the head opens the file dialog (#645)
+	scriptConsoleOpen         bool                           // the Manage ▸ Scripts ▸ Script Console panel is open
+	capturePath               string                         // a requested viewport PNG capture path; the head writes it after render
+	captureWindowPath         string                         // a requested whole-window PNG capture path; the head writes it after the frame composites
+	normalDebug               bool                           // viewport normal-debug render (front green / back red); head reads each frame
+	meshColors                bool                           // viewport mesh-debug-colors render (each face/triangle a distinct color)
+	meshColorsPerTri          bool                           // when meshColors: color per TRIANGLE (else per B-rep face)
+	editScope                 editScope                      // while editing a node, hide everything created after it (issue #132)
+	asmBodies                 assemblyBodyCache              // memoized world-space assembly bodies + their occurrences (#769)
+	pickIndex                 *assemblyPickIndex             // BVH over placement AABBs for sub-linear ray picking (M34-F5)
+	bomPanelOpen              bool                           // the Assemble ▸ Bill of Materials panel is open (#768)
+	bomViewKind               bom.ViewKind                   // the BOM panel's selected view (structured / parts-only)
+	updateCheckRequested      bool                           // Help ▸ Check for Updates was clicked; the head runs the (network) check
+	pendingUpdate             *update.Result                 // last update-check outcome to show in the update window; nil = closed
+	txEvents                  []sessionTxEvent               // append-only transaction log since app open (for bug reports)
+	bugReport                 bugReportState                 // in-progress Help ▸ Report Bug capture+submit, if any
+	bugOutcome                atomic.Pointer[bugResult]      // submit goroutine → frame loop handoff (session never touched off-thread)
+	bugSubmitter              bugSubmitter                   // injectable reporting endpoint (DI; lazily defaults to real HTTP)
+	addInCat                  addInCatalogue                 // Add-In Catalogue browse/install state (#1164)
 }
 
 // Notice returns the last user-facing notice (a failed commit's reason), or "" — shown in

--- a/app/session.go
+++ b/app/session.go
@@ -53,21 +53,22 @@ type Session struct {
 	highlightSets        *HighlightSets // named, colored emphasis groups for add-ins (#157)
 	tool                 *ToolInstance
 	picker               Picker
-	regionPicker         RegionPicker      // resolves a box-select rectangle (nil ⇒ box-select disabled)
-	boxSelect            BoxSelection      // the in-progress rubber-band rectangle, if any
-	zoomWindow           BoxSelection      // the in-progress Zoom Window rubber-band, if any (#913 N16)
-	zoomWindowArmed      bool              // the Zoom Window tool is armed: the next left-drag zooms
-	constrainedOrbit     bool              // the Constrained Orbit tool is active: left-drag turntables (#913 N10)
-	steeringWheel        bool              // the SteeringWheels radial nav menu is shown at the cursor (#913 N26)
-	entityDrag           sketchDrag        // the in-progress direct drag of sketch entities, if any
-	cloudMove            cloudMoveDrag     // the in-progress interactive drag of a point cloud, if any (#645)
-	relaxMode            bool              // Relax Mode: drag over/fully-constrained sketch geometry (#791)
-	hudEnabled           bool              // the 2D-sketch dynamic-input HUD is enabled (#790)
-	sketchHUD            sketchHUD         // the dynamic-input HUD's live typing state (#790)
-	dimDrag              dimDragState      // the in-progress drag of a drawing dimension's text/line
-	selectOther          selectOther       // the in-progress Select Other cycle, if any
-	viewHistory          viewHistory       // recorded views for Previous View (F5)
-	selectionPriority    SelectionPriority // biases no-tool picking (Edge/Face/Part) (#912)
+	regionPicker         RegionPicker          // resolves a box-select rectangle (nil ⇒ box-select disabled)
+	boxSelect            BoxSelection          // the in-progress rubber-band rectangle, if any
+	zoomWindow           BoxSelection          // the in-progress Zoom Window rubber-band, if any (#913 N16)
+	zoomWindowArmed      bool                  // the Zoom Window tool is armed: the next left-drag zooms
+	constrainedOrbit     bool                  // the Constrained Orbit tool is active: left-drag turntables (#913 N10)
+	steeringWheel        bool                  // the SteeringWheels radial nav menu is shown at the cursor (#913 N26)
+	entityDrag           sketchDrag            // the in-progress direct drag of sketch entities, if any
+	cloudMove            cloudMoveDrag         // the in-progress interactive drag of a point cloud, if any (#645)
+	relaxMode            bool                  // Relax Mode: drag over/fully-constrained sketch geometry (#791)
+	hudEnabled           bool                  // the 2D-sketch dynamic-input HUD is enabled (#790)
+	sketchHUD            sketchHUD             // the dynamic-input HUD's live typing state (#790)
+	dimDrag              dimDragState          // the in-progress drag of a drawing dimension's text/line
+	selectOther          selectOther           // the in-progress Select Other cycle, if any
+	viewHistory          viewHistory           // recorded views for Previous View (F5)
+	selectionPriority    SelectionPriority     // biases no-tool picking (Edge/Face/Part) (#912)
+	selectionFilterState *SelectionFilterState // user-editable no-tool ambient filter + priority order (#1222)
 	camera               scene.Camera
 	camTween             cameraTween
 	driveAnim            driveAnimation
@@ -197,14 +198,15 @@ func NewSessionWithStore(store doc.Store) *Session { return newSession(store) }
 
 func newSession(store doc.Store) *Session {
 	s := &Session{
-		store:          store,
-		workspace:      doc.NewWorkspace(store),
-		commands:       NewCommandManager(),
-		histories:      map[doc.ID]*docHistory{},
-		bus:            event.NewBus(),
-		selection:      NewSelection(),
-		camera:         scene.NewCamera(800, 600),
-		hiddenBodyKeys: map[string]bool{}, hiddenBodyKeysByDoc: map[doc.ID]map[string]bool{},
+		store:                store,
+		workspace:            doc.NewWorkspace(store),
+		commands:             NewCommandManager(),
+		histories:            map[doc.ID]*docHistory{},
+		bus:                  event.NewBus(),
+		selection:            NewSelection(),
+		selectionFilterState: NewSelectionFilterState(),
+		camera:               scene.NewCamera(800, 600),
+		hiddenBodyKeys:       map[string]bool{}, hiddenBodyKeysByDoc: map[doc.ID]map[string]bool{},
 		graphics: clientgraphics.NewStore(), graphicsByDoc: map[doc.ID]*clientgraphics.Store{},
 		addins:          NewAddInManager(),
 		clientApps:      NewClientApplicationRegistry(),
@@ -348,6 +350,11 @@ func (s *Session) Workspace() *doc.Workspace { return s.workspace }
 func (s *Session) Commands() *CommandManager { return s.commands }
 func (s *Session) Events() *event.Bus        { return s.bus }
 func (s *Session) Selection() *Selection     { return s.selection }
+
+// SelectionFilterState returns the user-editable no-tool ambient selection filter and priority
+// order (the Selection Filter & Priority window, #1222). Mutating it re-pushes the priority
+// order into the picker.
+func (s *Session) SelectionFilterState() *SelectionFilterState { return s.selectionFilterState }
 
 // ActiveDocument returns the workspace's active document, or nil.
 func (s *Session) ActiveDocument() *doc.Document { return s.workspace.ActiveDocument() }

--- a/app/session.go
+++ b/app/session.go
@@ -199,15 +199,14 @@ func NewSessionWithStore(store doc.Store) *Session { return newSession(store) }
 
 func newSession(store doc.Store) *Session {
 	s := &Session{
-		store:                store,
-		workspace:            doc.NewWorkspace(store),
-		commands:             NewCommandManager(),
-		histories:            map[doc.ID]*docHistory{},
-		bus:                  event.NewBus(),
-		selection:            NewSelection(),
-		selectionFilterState: NewSelectionFilterState(),
-		camera:               scene.NewCamera(800, 600),
-		hiddenBodyKeys:       map[string]bool{}, hiddenBodyKeysByDoc: map[doc.ID]map[string]bool{},
+		store:     store,
+		workspace: doc.NewWorkspace(store),
+		commands:  NewCommandManager(),
+		histories: map[doc.ID]*docHistory{},
+		bus:       event.NewBus(),
+		selection: NewSelection(), selectionFilterState: NewSelectionFilterState(),
+		camera:         scene.NewCamera(800, 600),
+		hiddenBodyKeys: map[string]bool{}, hiddenBodyKeysByDoc: map[doc.ID]map[string]bool{},
 		graphics: clientgraphics.NewStore(), graphicsByDoc: map[doc.ID]*clientgraphics.Store{},
 		addins:          NewAddInManager(),
 		clientApps:      NewClientApplicationRegistry(),

--- a/app/session_input.go
+++ b/app/session_input.go
@@ -13,8 +13,17 @@ import (
 // They implement Inventor's mouse/keyboard behavior at the logic level; the actual
 // device events come from the window in production and from tests headlessly.
 
-// SetPicker installs the hit-test used to resolve clicks to selectables.
-func (s *Session) SetPicker(p Picker) { s.picker = p }
+// SetPicker installs the hit-test used to resolve clicks to selectables. When the picker
+// honours a priority ranking (RayPicker), the live SelectionFilterState ordering is pushed so
+// reordering the Selection Filter window changes ambiguous-pick resolution (#1222).
+func (s *Session) SetPicker(p Picker) {
+	s.picker = p
+	if pr, ok := p.(interface {
+		SetPriorityRank(func(SelectionKind) int)
+	}); ok {
+		pr.SetPriorityRank(s.selectionFilterState.Rank)
+	}
+}
 
 // StartTool activates an interactive tool, cancelling any tool already running.
 func (s *Session) StartTool(t Tool) {

--- a/head/cmd/selfiltershot/main.go
+++ b/head/cmd/selfiltershot/main.go
@@ -1,0 +1,85 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+// selfiltershot is a throwaway live-confirmation driver for the Selection Filter & Priority
+// window (#1222): it builds a box part, opens the window through the real Session, draws several
+// real DrawChrome frames, and saves a full-window PNG so the window can be verified visually.
+package main
+
+import (
+	"flag"
+	"log"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+	"oblikovati.org/head/ui"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+func main() {
+	out := flag.String("out", "/tmp/selfiltershot.png", "output PNG path")
+	frames := flag.Int("frames", 30, "frames to render before capture")
+	reorder := flag.Bool("reorder", false, "move Faces to the top and disable Vertices to show an edited state")
+	flag.Parse()
+	if err := run(*out, *frames, *reorder); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run(out string, frames int, reorder bool) error {
+	s := app.NewSession()
+	if err := app.RegisterStandardCommands(s); err != nil {
+		return err
+	}
+	buildBox(s)
+	if err := s.SetViewOrientation(types.IsoTopRightViewOrientation, true); err != nil {
+		return err
+	}
+	s.TickCameraAnimation(100)
+
+	s.OpenSelectionFilterWindow()
+	if reorder {
+		st := s.SelectionFilterState()
+		st.Move(st.Rank(app.SelectFace), 0)
+		st.SetEnabled(app.SelectVertex, false)
+	}
+
+	win, err := native.CreateWindow(1280, 800, "selfiltershot")
+	if err != nil {
+		return err
+	}
+	defer win.Destroy()
+	win.InitViewport()
+	for i := 0; i < frames; i++ {
+		win.BeginFrame()
+		ui.DrawChrome(win, s)
+		win.EndFrame(ui.WindowClearColor())
+	}
+	return win.SaveWindowPNG(out)
+}
+
+func buildBox(s *app.Session) {
+	pd, err := compdef.AddPart(s.Workspace(), "selfilter.opd", true)
+	if err != nil {
+		panic(err)
+	}
+	_ = s.Workspace().SetActiveDocument(pd)
+	def := pd.Content().(*compdef.PartComponentDefinition)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	c0 := sk.Points().Add(math.P2(0, 0))
+	c1 := sk.Points().Add(math.P2(6, 0))
+	c2 := sk.Points().Add(math.P2(6, 6))
+	c3 := sk.Points().Add(math.P2(0, 6))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+	feature.NewExtrudeFeatures(def.Features()).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 6 })
+	def.Recompute()
+}

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -29,6 +29,12 @@ int  obk_ig_begin_tab_bar(const char* id);
 int  obk_ig_begin_tab_item_ex(const char* label, int setSelected);
 int  obk_ig_begin_tab_item_closable(const char* label, int setSelected, int* open);
 int  obk_ig_selectable(const char* label, int selected);
+int  obk_ig_begin_drag_drop_source(void);
+void obk_ig_set_drag_drop_payload_int(const char* type, int v);
+void obk_ig_end_drag_drop_source(void);
+int  obk_ig_begin_drag_drop_target(void);
+int  obk_ig_accept_drag_drop_payload_int(const char* type, int* out);
+void obk_ig_end_drag_drop_target(void);
 void obk_ig_end_tab_bar(void);
 int  obk_ig_begin_tab_item(const char* label);
 void obk_ig_end_tab_item(void);
@@ -654,6 +660,40 @@ func Selectable(label string, selected bool) bool {
 	defer free()
 	return C.obk_ig_selectable(c, cBool(selected)) != 0
 }
+
+// BeginDragDropSource reports whether the last item is being dragged this frame; if so set a
+// payload and draw a preview before EndDragDropSource. Used to reorder the Selection Filter
+// priority list by dragging a row (#1222).
+func BeginDragDropSource() bool { return C.obk_ig_begin_drag_drop_source() != 0 }
+
+// SetDragDropPayloadInt attaches an int payload (the dragged row index) under a type tag.
+func SetDragDropPayloadInt(payloadType string, v int) {
+	c, free := cstr(payloadType)
+	defer free()
+	C.obk_ig_set_drag_drop_payload_int(c, C.int(v))
+}
+
+// EndDragDropSource closes a BeginDragDropSource block.
+func EndDragDropSource() { C.obk_ig_end_drag_drop_source() }
+
+// BeginDragDropTarget reports whether the last item can receive a drop this frame; if so call
+// AcceptDragDropPayloadInt before EndDragDropTarget.
+func BeginDragDropTarget() bool { return C.obk_ig_begin_drag_drop_target() != 0 }
+
+// AcceptDragDropPayloadInt returns the dropped int payload (and true) when a payload of the
+// given type is released on the current target this frame.
+func AcceptDragDropPayloadInt(payloadType string) (int, bool) {
+	c, free := cstr(payloadType)
+	defer free()
+	var out C.int
+	if C.obk_ig_accept_drag_drop_payload_int(c, &out) != 0 {
+		return int(out), true
+	}
+	return 0, false
+}
+
+// EndDragDropTarget closes a BeginDragDropTarget block.
+func EndDragDropTarget() { C.obk_ig_end_drag_drop_target() }
 
 // CollapsingHeader draws a collapsible section header; reports whether it is open.
 func CollapsingHeader(label string) bool {

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -110,6 +110,22 @@ int  obk_ig_selectable(const char* label, int selected) {
     return ImGui::Selectable(label, selected != 0) ? 1 : 0;
 }
 
+// Drag-and-drop: reorder a list by dragging a row onto another (#1222). The payload is a single
+// int (the dragged row index); SetDragDropPayload copies it internally so a local is safe.
+int  obk_ig_begin_drag_drop_source(void) { return ImGui::BeginDragDropSource() ? 1 : 0; }
+void obk_ig_set_drag_drop_payload_int(const char* type, int v) {
+    ImGui::SetDragDropPayload(type, &v, sizeof(int));
+}
+void obk_ig_end_drag_drop_source(void)   { ImGui::EndDragDropSource(); }
+int  obk_ig_begin_drag_drop_target(void) { return ImGui::BeginDragDropTarget() ? 1 : 0; }
+// Writes *out and returns 1 when a payload of this type was dropped on the current target.
+int  obk_ig_accept_drag_drop_payload_int(const char* type, int* out) {
+    const ImGuiPayload* pl = ImGui::AcceptDragDropPayload(type);
+    if (pl && pl->DataSize == (int)sizeof(int)) { *out = *(const int*)pl->Data; return 1; }
+    return 0;
+}
+void obk_ig_end_drag_drop_target(void)   { ImGui::EndDragDropTarget(); }
+
 int  obk_ig_collapsing_header(const char* l) { return ImGui::CollapsingHeader(l) ? 1 : 0; }
 void obk_ig_set_next_item_open(int open, int first_use) {
     ImGui::SetNextItemOpen(open != 0, first_use != 0 ? ImGuiCond_FirstUseEver : ImGuiCond_Always);

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -153,13 +153,14 @@ func drawChromeWindows(s *app.Session) {
 	drawUnitsSettingsWindow(s)   // Tools ▸ Document Settings — Units (#146)
 	drawHistoryBrowserWindow(s)  // Edit ▸ History Browser (per-document timelines, side by side)
 	drawScriptConsole(s)
-	drawKeymapEditor(s)         // Tools ▸ Customize Keyboard (M05-F17)
-	drawCommandInput(s)         // command-alias input box (M05-F17)
-	drawCommandWindow(s)        // docked Command Window REPL panel (M26 F04)
-	drawUpdateWindow(s)         // Help ▸ Check for Updates notification
-	drawReportBugDialog(s)      // Help ▸ Report Bug
-	drawAddInCatalogueWindow(s) // Tools ▸ Get Add-Ins… (#1164)
-	drawAddInPanels(s)          // add-in dockable windows (M05-F03)
+	drawKeymapEditor(s)          // Tools ▸ Customize Keyboard (M05-F17)
+	drawCommandInput(s)          // command-alias input box (M05-F17)
+	drawCommandWindow(s)         // docked Command Window REPL panel (M26 F04)
+	drawUpdateWindow(s)          // Help ▸ Check for Updates notification
+	drawReportBugDialog(s)       // Help ▸ Report Bug
+	drawAddInCatalogueWindow(s)  // Tools ▸ Get Add-Ins… (#1164)
+	drawSelectionFilterWindow(s) // View ▸ Selection Filter & priority (#1222)
+	drawAddInPanels(s)           // add-in dockable windows (M05-F03)
 	// M26 F03: toasts / prompt modal / message-center windows are retired — every message
 	// now funnels into the docked Command Window, and prompts are answered inline there.
 	drawWebViews(s)          // web dialogs/views (M05-F08)

--- a/head/ui/chrome_menubar.go
+++ b/head/ui/chrome_menubar.go
@@ -160,6 +160,9 @@ func drawToolsMenu(s *app.Session) {
 		if native.MenuItem(checkLabel("Command Window", s.CommandWindowOpen())) { // M26 F04: docked REPL
 			s.ToggleCommandWindow()
 		}
+		if native.MenuItem(checkLabel("Selection Filter", s.SelectionFilterWindowOpen())) { // #1222
+			s.ToggleSelectionFilterWindow()
+		}
 		native.Separator()
 		if native.MenuItem(checkLabel("Normal Debug (front green / back red)", normalDebugOn)) {
 			normalDebugOn = !normalDebugOn

--- a/head/ui/selection_filter_window.go
+++ b/head/ui/selection_filter_window.go
@@ -1,0 +1,84 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// selectionFilterPayload tags the drag-and-drop payload carrying a priority-row index, so a
+// dropped row only reorders within this window (#1222).
+const selectionFilterPayload = "OBK_SELFILTER_ROW"
+
+// drawSelectionFilterWindow renders the Selection Filter & Priority window while it is open
+// (#1222): one checkbox per pickable entity type (enable/disable picking it) over a drag-to-
+// reorder priority list where the top row wins an ambiguous pick, plus Select All / Deselect All.
+// The X in the title bar closes it. Every edit writes straight back to the session's
+// SelectionFilterState, so the next click honours it immediately.
+func drawSelectionFilterWindow(s *app.Session) {
+	if !s.SelectionFilterWindowOpen() {
+		return
+	}
+	native.SetNextWindowSizeOnce(280, 380)
+	visible, open := native.BeginClosable("Selection Filter###selection-filter")
+	if visible {
+		drawSelectionFilterBody(s)
+	}
+	native.End()
+	if !open {
+		s.CloseSelectionFilterWindow()
+	}
+}
+
+// drawSelectionFilterBody draws the explanatory header, the reorderable kind rows, and the
+// Select All / Deselect All buttons.
+func drawSelectionFilterBody(s *app.Session) {
+	st := s.SelectionFilterState()
+	native.Text("Tick to allow picking. Drag a row to set priority")
+	native.Text("(the topmost type wins an ambiguous pick).")
+	native.Separator()
+	drawSelectionFilterRows(st)
+	native.Separator()
+	if native.Button("Select All") {
+		st.EnableAll()
+	}
+	native.SameLine()
+	if native.Button("Deselect All") {
+		st.DisableAll()
+	}
+}
+
+// drawSelectionFilterRows draws one checkbox+label row per kind in priority order; each row is a
+// drag source and drop target so dragging one onto another reorders the priority list.
+func drawSelectionFilterRows(st *app.SelectionFilterState) {
+	for i, k := range st.Order() {
+		native.PushIDInt(i)
+		on := st.Enabled(k)
+		if native.Checkbox("##enabled", &on) {
+			st.SetEnabled(k, on)
+		}
+		native.SameLine()
+		native.Selectable(app.SelectionKindLabel(k), false) // the draggable row handle
+		reorderSelectionFilterRow(st, i, k)
+		native.PopID()
+	}
+}
+
+// reorderSelectionFilterRow wires the last-drawn row as a drag source (carrying its index) and a
+// drop target that moves the dragged row to this position.
+func reorderSelectionFilterRow(st *app.SelectionFilterState, i int, k app.SelectionKind) {
+	if native.BeginDragDropSource() {
+		native.SetDragDropPayloadInt(selectionFilterPayload, i)
+		native.Text(app.SelectionKindLabel(k))
+		native.EndDragDropSource()
+	}
+	if native.BeginDragDropTarget() {
+		if from, ok := native.AcceptDragDropPayloadInt(selectionFilterPayload); ok {
+			st.Move(from, i)
+		}
+		native.EndDragDropTarget()
+	}
+}

--- a/head/ui/selection_filter_window.go
+++ b/head/ui/selection_filter_window.go
@@ -22,7 +22,7 @@ func drawSelectionFilterWindow(s *app.Session) {
 	if !s.SelectionFilterWindowOpen() {
 		return
 	}
-	native.SetNextWindowSizeOnce(280, 380)
+	native.SetNextWindowSizeOnce(340, 400)
 	visible, open := native.BeginClosable("Selection Filter###selection-filter")
 	if visible {
 		drawSelectionFilterBody(s)

--- a/head/ui/selection_filter_window_test.go
+++ b/head/ui/selection_filter_window_test.go
@@ -1,0 +1,39 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+)
+
+// TestInWindowSelectionFilterWindowDraws opens the real window with the Selection Filter window
+// visible and runs frames, exercising the per-kind checkbox rows, the drag-source/target wiring,
+// and the Select All / Deselect All buttons without tripping Dear ImGui's Begin/End assertions
+// (#1222). A mixed state (one kind disabled, the list reordered) makes every row branch draw.
+func TestInWindowSelectionFilterWindowDraws(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+	s := framedSession()
+
+	s.OpenSelectionFilterWindow()
+	defer s.CloseSelectionFilterWindow()
+
+	st := s.SelectionFilterState()
+	st.SetEnabled(app.SelectVertex, false) // a disabled row draws unticked
+	st.Move(st.Rank(app.SelectFace), 0)    // a reordered list draws in the new order
+
+	for i := 0; i < 3; i++ {
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.1)
+	}
+	if !s.SelectionFilterWindowOpen() {
+		t.Error("the Selection Filter window should stay open across frames")
+	}
+}


### PR DESCRIPTION
## What

Adds a dedicated, closeable **Selection Filter & Priority** window (Issue #1222): a checkbox per viewport-pickable entity type to enable/disable picking it, a drag-and-drop reorderable priority list where the topmost type wins an ambiguous pick, and Select All / Deselect All buttons. Opened from a View-tab Select-panel button and a Tools-menu toggle; the title-bar X closes it.

## Why

Tools already constrain selection (a fillet tool accepts only edges), but the user had no way to (a) filter which entity types are pickable when no tool is driving, or (b) define a priority order for resolving an ambiguous pick (e.g. prefer an edge over the face behind it). This gives the user that control without disturbing tool-driven selection.

## How it's built (integrates with existing machinery, no API change)

- **`SelectionFilterState`** (`app/selection_filter_state.go`) — the single source of truth for the no-tool *ambient* selection: a per-kind enable set + an ordered priority list over the pickable `SelectionKind`s. `Session.pickFilter` reads it when no tool has restricted selection (the one seam both click and box-select already consult). The four `SelectionPriority` values become presets that write into it, so the View-tab combo and the window stay consistent. `SelectionFilter` gains a blocking state so *Deselect All* selects nothing.
- **Priority-aware pick resolution** (`app/raypicker.go`) — `snapPick` and `nearestCandidate` rank co-located hits by a pushed priority function instead of a hardcoded sequence; a hit genuinely in front still wins on proximity. The default order reproduces the historical snap/append precedence, so **picking is unchanged until the user reorders**.
- **Native ImGui drag-and-drop binding** (`head/internal/native`) — new source/target wrappers (int payload) for the reorder interaction; none was bound before.
- **The window** (`head/ui/selection_filter_window.go`) — `BeginClosable` window, registered in `drawChromeWindows`.

Consistent with how `SelectionPriority` shipped (app + ribbon only), this is in-proc state with **no `Oblikovati.API` change**; scriptability/persistence are noted follow-ups.

## Validation

- New headless tests: state model, preset round-trips, priority resolution (default-regression + reordered), and **real-RayPicker integration tests for the selection-dependent workflows** — no-tool face pre-selection (sketch-on-face / feature pre-selection) honours the filter, and an active tool's filter still wins over a fully-disabled ambient (offset-work-plane-from-face). Full `app` suite green; `go vet` + `golangci-lint` clean; root + head build.
- **Live visual confirmation** via the new `head/cmd/selfiltershot` driver (offscreen Vulkan → DrawChrome → full-window PNG): the window renders with all rows + checkboxes + buttons + X; dragging Faces to the top and disabling Vertices both reflect correctly.

Closes #1222

🤖 Generated with [Claude Code](https://claude.com/claude-code)