### PR TITLE
feat(feature): geometric references for dress-up selections (M8/ADR-0040)

### DIFF
--- a/model/feature/dressup.go
+++ b/model/feature/dressup.go
@@ -146,6 +146,7 @@ func (c *ChamferFeature) Recompute(in Input) (Output, error) {
 type ShellDefinition struct {
 	RemovedFaceKeys [][]byte
 	Thickness       func() float64
+	GeomFaces       []topo.GeometricFaceRef // externally-authored removed faces by geometric descriptor (ADR-0040)
 }
 
 // ShellFeature hollows a solid.
@@ -160,14 +161,19 @@ func (s *ShellFeature) Kind() string                 { return "shell" }
 // Recompute hollows the running body to the wall thickness, opening the removed faces. See
 // shell.go.
 func (s *ShellFeature) Recompute(in Input) (Output, error) {
-	return shellBody(in, s.def.RemovedFaceKeys, callOrZero(s.def.Thickness), featOr(s.featName, "shell"))
+	keys, err := bindGeomFaces(in, s.def.RemovedFaceKeys, s.def.GeomFaces, featOr(s.featName, "shell"))
+	if err != nil {
+		return Output{}, err
+	}
+	return shellBody(in, keys, callOrZero(s.def.Thickness), featOr(s.featName, "shell"))
 }
 
 // FaceDraftDefinition tapers selected faces by an angle about a pull direction.
 type FaceDraftDefinition struct {
-	FaceKeys [][]byte
-	PullDir  math.Vector3
-	Angle    func() float64
+	FaceKeys  [][]byte
+	PullDir   math.Vector3
+	Angle     func() float64
+	GeomFaces []topo.GeometricFaceRef // externally-authored drafted faces by geometric descriptor (ADR-0040)
 }
 
 // FaceDraftFeature applies draft to faces.
@@ -178,7 +184,11 @@ func (d *FaceDraftFeature) Kind() string                     { return "draft" }
 
 // Recompute tapers the picked faces about the pull direction by the angle (see draft.go).
 func (d *FaceDraftFeature) Recompute(in Input) (Output, error) {
-	return draftBody(in, d.def.FaceKeys, d.def.PullDir, callOrZero(d.def.Angle), "draft")
+	keys, err := bindGeomFaces(in, d.def.FaceKeys, d.def.GeomFaces, "draft")
+	if err != nil {
+		return Output{}, err
+	}
+	return draftBody(in, keys, d.def.PullDir, callOrZero(d.def.Angle), "draft")
 }
 
 // ThreadDefinition applies thread data to a cylindrical face. Cut=false is a cosmetic thread
@@ -399,6 +409,20 @@ func (c *DressUpFeatures) AddDraft(faceKeys [][]byte, angle func() float64) *Par
 // AddDraftPull tapers the given faces by angle about an explicit pull direction.
 func (c *DressUpFeatures) AddDraftPull(faceKeys [][]byte, pull math.Vector3, angle func() float64) *PartFeature {
 	return c.engine.Add(&FaceDraftFeature{def: &FaceDraftDefinition{FaceKeys: faceKeys, PullDir: pull, Angle: angle}})
+}
+
+// addShell / addFaceDraft add a face dress-up from a fully-built definition (used by the
+// recipe restore to carry geometric face refs the public builders don't take).
+func (c *DressUpFeatures) addShell(def *ShellDefinition) *PartFeature {
+	sf := &ShellFeature{def: def}
+	pf := c.engine.Add(sf)
+	pf.SetName(c.engine.UniqueName("Shell"))
+	sf.featName = pf.name
+	return pf
+}
+
+func (c *DressUpFeatures) addFaceDraft(def *FaceDraftDefinition) *PartFeature {
+	return c.engine.Add(&FaceDraftFeature{def: def})
 }
 
 // AddThread tags a cylindrical face with thread data; cut=true models a real (cut) thread,

--- a/model/feature/dressup.go
+++ b/model/feature/dressup.go
@@ -59,6 +59,12 @@ type FilletDefinition struct {
 	EdgeSets        []FilletEdgeSet
 	CornerType      FilletCornerType
 	ConcaveStrategy types.FilletConcaveStrategy // concave edges: outward fill (zero/default) or inward recess
+	// GeomEdges are edges selected by a serialized GEOMETRIC descriptor rather than an
+	// Oblikovati lineage key — the path an external author (the NX exporter, M8/ADR-0040)
+	// uses, since it cannot synthesize lineage. They bind to the running body's edges at
+	// recompute (see bindGeomEdges) and fold into the edge list; absent for a normal
+	// Oblikovati-authored fillet.
+	GeomEdges []topo.GeometricEdgeRef
 }
 
 // FilletType reports the definition's discriminator: always an edge fillet for now (the
@@ -80,7 +86,11 @@ func (f *FilletFeature) Recompute(in Input) (Output, error) {
 	if len(f.def.EdgeSets) > 0 {
 		return filletBodySets(in, f.def.EdgeSets, f.def.CornerType, f.def.ConcaveStrategy, "fillet")
 	}
-	return filletBody(in, f.def.EdgeKeys, callOrZero(f.def.Radius), f.def.CornerType, f.def.ConcaveStrategy, "fillet")
+	keys, err := bindGeomEdges(in, f.def.EdgeKeys, f.def.GeomEdges, "fillet")
+	if err != nil {
+		return Output{}, err
+	}
+	return filletBody(in, keys, callOrZero(f.def.Radius), f.def.CornerType, f.def.ConcaveStrategy, "fillet")
 }
 
 // ChamferType aliases the public chamfer-mode discriminator (ADR-0018).
@@ -103,7 +113,8 @@ type ChamferDefinition struct {
 	Angle           func() float64 // distanceAndAngle: chamfer-face angle (radians)
 	Type            ChamferType    // zero value ⇒ equal-distance
 	FlatCorners     bool
-	ConcaveStrategy ChamferConcaveStrategy // zero value ⇒ outward (fill the inside corner)
+	ConcaveStrategy ChamferConcaveStrategy  // zero value ⇒ outward (fill the inside corner)
+	GeomEdges       []topo.GeometricEdgeRef // externally-authored edges by geometric descriptor (see FilletDefinition.GeomEdges)
 }
 
 // ChamferFeature bevels selected edges (equal-distance, two-distance, or distance-and-angle).
@@ -124,7 +135,11 @@ func (c *ChamferFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	return chamferEdges(in, c.def.EdgeKeys, d1, d2, featOr(c.featName, "chamfer"), c.def.FlatCorners, c.def.ConcaveStrategy)
+	keys, err := bindGeomEdges(in, c.def.EdgeKeys, c.def.GeomEdges, "chamfer")
+	if err != nil {
+		return Output{}, err
+	}
+	return chamferEdges(in, keys, d1, d2, featOr(c.featName, "chamfer"), c.def.FlatCorners, c.def.ConcaveStrategy)
 }
 
 // ShellDefinition hollows a body, removing the selected faces, to a wall thickness.
@@ -286,6 +301,12 @@ func (c *DressUpFeatures) AddFillet(edgeKeys [][]byte, radius func() float64) *P
 // Concave edges fill outward (the default); use [AddFilletConcave] to round a recess inward.
 func (c *DressUpFeatures) AddFilletCorner(edgeKeys [][]byte, radius func() float64, corner FilletCornerType) *PartFeature {
 	return c.engine.Add(&FilletFeature{def: &FilletDefinition{EdgeKeys: edgeKeys, Radius: radius, CornerType: corner}})
+}
+
+// addFillet adds a fillet from a fully-built definition (used by the recipe restore to
+// carry fields the public builders don't take, e.g. geometric edge refs).
+func (c *DressUpFeatures) addFillet(def *FilletDefinition) *PartFeature {
+	return c.engine.Add(&FilletFeature{def: def})
 }
 
 // AddFilletConcave rounds the given edges to radius with an explicit concave-edge strategy: outward

--- a/model/feature/fillet.go
+++ b/model/feature/fillet.go
@@ -8,7 +8,38 @@ import (
 	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
 )
+
+// geomEdgeBindTol is the model-space distance within which a geometric edge descriptor's
+// midpoint must match a running-body edge's midpoint to bind. Generous enough to absorb
+// unit-conversion and tessellation drift, tight enough that distinct edges stay
+// unambiguous (the resolver also requires direction alignment and is unique-or-fail).
+const geomEdgeBindTol = math.Scalar(1e-3)
+
+// bindGeomEdges resolves any geometric edge descriptors against the running body and folds
+// the bound edges' current lineage keys into keys, so the rest of the dress-up pipeline is
+// unchanged. An external author (the NX exporter, ADR-0040) supplies these because it
+// cannot mint Oblikovati lineage keys. A descriptor that does not bind is an error so the
+// feature goes Sick honestly (rather than silently dropping the selection).
+func bindGeomEdges(in Input, keys [][]byte, geom []topo.GeometricEdgeRef, feat string) ([][]byte, error) {
+	if len(geom) == 0 {
+		return keys, nil
+	}
+	body, err := runningBody(in)
+	if err != nil {
+		return nil, err
+	}
+	out := append([][]byte(nil), keys...)
+	for _, g := range geom {
+		e, ok := body.FindEdgeByGeometry(g, geomEdgeBindTol)
+		if !ok {
+			return nil, fmt.Errorf("%s: geometric edge reference did not bind near midpoint %v", feat, g.Midpoint)
+		}
+		out = append(out, e.ReferenceKey())
+	}
+	return out, nil
+}
 
 // cornerStrategy maps the public corner-type discriminator to the kernel's 2-edge corner strategy.
 func cornerStrategy(t types.FilletCornerType) ops.CornerStrategy {

--- a/model/feature/fillet.go
+++ b/model/feature/fillet.go
@@ -41,6 +41,29 @@ func bindGeomEdges(in Input, keys [][]byte, geom []topo.GeometricEdgeRef, feat s
 	return out, nil
 }
 
+// bindGeomFaces is the face counterpart of [bindGeomEdges]: it resolves geometric face
+// descriptors (centroid + outward normal) against the running body via
+// topo.Body.FindFaceByGeometry and folds the bound faces' lineage keys into keys, so the
+// shell/draft/hole pipelines are unchanged. A descriptor that binds nothing is an error.
+func bindGeomFaces(in Input, keys [][]byte, geom []topo.GeometricFaceRef, feat string) ([][]byte, error) {
+	if len(geom) == 0 {
+		return keys, nil
+	}
+	body, err := runningBody(in)
+	if err != nil {
+		return nil, err
+	}
+	out := append([][]byte(nil), keys...)
+	for _, g := range geom {
+		f, ok := body.FindFaceByGeometry(g, geomEdgeBindTol)
+		if !ok {
+			return nil, fmt.Errorf("%s: geometric face reference did not bind near centroid %v", feat, g.Centroid)
+		}
+		out = append(out, f.ReferenceKey())
+	}
+	return out, nil
+}
+
 // cornerStrategy maps the public corner-type discriminator to the kernel's 2-edge corner strategy.
 func cornerStrategy(t types.FilletCornerType) ops.CornerStrategy {
 	switch t {

--- a/model/feature/geom_edge_ref_test.go
+++ b/model/feature/geom_edge_ref_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/subd"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+func geomRefBox() *topo.Body { return subd.ToBody(subd.Box(4, 4, 4), "box") }
+
+// TestGeometricEdgeFilletBindsAndRounds proves the M8/ADR-0040 path: a fillet whose edge
+// is given only by a GEOMETRIC descriptor (no Oblikovati lineage key — what the NX exporter
+// can supply) binds to the running body's edge and actually rounds it, reducing volume.
+func TestGeometricEdgeFilletBindsAndRounds(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	box := geomRefBox()
+	NewBaseFeatures(fs).AddBase(box)
+
+	ref := topo.DescribeEdge(box.Edges()[0])
+	pf := NewDressUpFeatures(fs).addFillet(&FilletDefinition{
+		GeomEdges: []topo.GeometricEdgeRef{ref},
+		Radius:    constFloat(0.5),
+	})
+	fs.Recompute()
+
+	if !pf.Health().OK() {
+		t.Fatalf("geometric-edge fillet is not healthy: %+v", pf.Health())
+	}
+	res := fs.Result()
+	if len(res) != 1 {
+		t.Fatalf("result has %d bodies, want 1", len(res))
+	}
+	boxVol := ops.BodyGeometryProperties(geomRefBox(), ops.DefaultQuality()).Volume
+	gotVol := ops.BodyGeometryProperties(res[0], ops.DefaultQuality()).Volume
+	if !(gotVol < boxVol) {
+		t.Errorf("fillet did not reduce volume: got %g, box %g", gotVol, boxVol)
+	}
+}
+
+// TestGeometricEdgeFilletMissGoesSick confirms a descriptor that binds nothing fails the
+// feature honestly rather than silently dropping the selection.
+func TestGeometricEdgeFilletMissGoesSick(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(geomRefBox())
+	far := topo.GeometricEdgeRef{Midpoint: math.P3(100, 100, 100)}
+	pf := NewDressUpFeatures(fs).addFillet(&FilletDefinition{
+		GeomEdges: []topo.GeometricEdgeRef{far},
+		Radius:    constFloat(0.5),
+	})
+	fs.Recompute()
+	if pf.Health().OK() {
+		t.Error("a fillet whose geometric edge binds nothing should not be healthy")
+	}
+}
+
+// TestGeometricEdgeRefSurvivesRecipeRoundTrip checks the geomEdges encoding round-trips
+// through serialize → restore (the exporter writes this; the reader must restore it).
+func TestGeometricEdgeRefSurvivesRecipeRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	ref := topo.DescribeEdge(geomRefBox().Edges()[0])
+	pf := NewDressUpFeatures(fs).addFillet(&FilletDefinition{
+		GeomEdges: []topo.GeometricEdgeRef{ref},
+		Radius:    constFloat(0.5),
+	})
+
+	fd, err := serializeFeature(pf, nil, map[ID]int{})
+	if err != nil {
+		t.Fatalf("serializeFeature: %v", err)
+	}
+	if fd.Fillet == nil || len(fd.Fillet.GeomEdges) != 1 {
+		t.Fatalf("recipe did not carry the geometric edge ref: %+v", fd.Fillet)
+	}
+
+	dst := NewPartFeatures(nil, nil)
+	rpf, err := buildFeature(dst, fd, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("buildFeature: %v", err)
+	}
+	ff, ok := rpf.feature.(*FilletFeature)
+	if !ok {
+		t.Fatalf("restored feature is %T, want *FilletFeature", rpf.feature)
+	}
+	if len(ff.def.GeomEdges) != 1 {
+		t.Fatalf("restored fillet has %d geom edges, want 1", len(ff.def.GeomEdges))
+	}
+	if ff.def.GeomEdges[0].Midpoint.DistanceTo(ref.Midpoint) > 1e-9 {
+		t.Errorf("restored midpoint %v != original %v", ff.def.GeomEdges[0].Midpoint, ref.Midpoint)
+	}
+}

--- a/model/feature/geom_face_ref_test.go
+++ b/model/feature/geom_face_ref_test.go
@@ -59,6 +59,37 @@ func TestGeometricFaceHoleBindsAndDrills(t *testing.T) {
 	}
 }
 
+// TestGeometricFaceHoleRecipeRoundTrips checks the single-face geomFace encoding (a hole's
+// placement face) round-trips through serialize → restore.
+func TestGeometricFaceHoleRecipeRoundTrips(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	ref := topo.DescribeFace(geomRefBox().Faces()[0])
+	pf := NewHoleFeatures(fs).addHole(&HoleDefinition{
+		GeomFace: &ref, Diameter: constFloat(0.5), Depth: constFloat(1), Type: DrilledHole,
+	})
+
+	fd, err := serializeFeature(pf, nil, map[ID]int{})
+	if err != nil {
+		t.Fatalf("serializeFeature: %v", err)
+	}
+	if fd.Hole == nil || fd.Hole.GeomFace == nil {
+		t.Fatalf("recipe did not carry the hole's geometric placement face: %+v", fd.Hole)
+	}
+
+	dst := NewPartFeatures(nil, nil)
+	rpf, err := buildFeature(dst, fd, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("buildFeature: %v", err)
+	}
+	hf := rpf.feature.(*HoleFeature)
+	if hf.def.GeomFace == nil {
+		t.Fatal("restored hole lost its geometric placement face")
+	}
+	if hf.def.GeomFace.Centroid.DistanceTo(ref.Centroid) > 1e-9 {
+		t.Errorf("restored centroid %v != original %v", hf.def.GeomFace.Centroid, ref.Centroid)
+	}
+}
+
 // TestGeometricFaceShellRecipeRoundTrips checks the geomFaces encoding round-trips through
 // serialize → restore.
 func TestGeometricFaceShellRecipeRoundTrips(t *testing.T) {

--- a/model/feature/geom_face_ref_test.go
+++ b/model/feature/geom_face_ref_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+)
+
+// TestGeometricFaceShellBindsAndHollows proves the face path (M8/ADR-0040): a shell whose
+// removed face is given only by a geometric descriptor binds and hollows the body.
+func TestGeometricFaceShellBindsAndHollows(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	box := geomRefBox()
+	NewBaseFeatures(fs).AddBase(box)
+
+	ref := topo.DescribeFace(box.Faces()[0])
+	pf := NewDressUpFeatures(fs).addShell(&ShellDefinition{
+		GeomFaces: []topo.GeometricFaceRef{ref},
+		Thickness: constFloat(0.5),
+	})
+	fs.Recompute()
+
+	if !pf.Health().OK() {
+		t.Fatalf("geometric-face shell is not healthy: %+v", pf.Health())
+	}
+	boxVol := ops.BodyGeometryProperties(geomRefBox(), ops.DefaultQuality()).Volume
+	gotVol := ops.BodyGeometryProperties(fs.Result()[0], ops.DefaultQuality()).Volume
+	if !(gotVol < boxVol) {
+		t.Errorf("shell did not hollow the body: got %g, box %g", gotVol, boxVol)
+	}
+}
+
+// TestGeometricFaceHoleBindsAndDrills proves a hole placed on a geometrically-described
+// face binds and removes material.
+func TestGeometricFaceHoleBindsAndDrills(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	box := geomRefBox()
+	NewBaseFeatures(fs).AddBase(box)
+
+	ref := topo.DescribeFace(box.Faces()[0])
+	pf := NewHoleFeatures(fs).addHole(&HoleDefinition{
+		GeomFace: &ref,
+		Diameter: constFloat(0.5),
+		Depth:    constFloat(1),
+		Type:     DrilledHole,
+	})
+	fs.Recompute()
+
+	if !pf.Health().OK() {
+		t.Fatalf("geometric-face hole is not healthy: %+v", pf.Health())
+	}
+	boxVol := ops.BodyGeometryProperties(geomRefBox(), ops.DefaultQuality()).Volume
+	gotVol := ops.BodyGeometryProperties(fs.Result()[0], ops.DefaultQuality()).Volume
+	if !(gotVol < boxVol) {
+		t.Errorf("hole did not remove material: got %g, box %g", gotVol, boxVol)
+	}
+}
+
+// TestGeometricFaceShellRecipeRoundTrips checks the geomFaces encoding round-trips through
+// serialize → restore.
+func TestGeometricFaceShellRecipeRoundTrips(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	ref := topo.DescribeFace(geomRefBox().Faces()[0])
+	pf := NewDressUpFeatures(fs).addShell(&ShellDefinition{
+		GeomFaces: []topo.GeometricFaceRef{ref},
+		Thickness: constFloat(0.5),
+	})
+
+	fd, err := serializeFeature(pf, nil, map[ID]int{})
+	if err != nil {
+		t.Fatalf("serializeFeature: %v", err)
+	}
+	if fd.Shell == nil || len(fd.Shell.GeomFaces) != 1 {
+		t.Fatalf("recipe did not carry the geometric face ref: %+v", fd.Shell)
+	}
+
+	dst := NewPartFeatures(nil, nil)
+	rpf, err := buildFeature(dst, fd, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("buildFeature: %v", err)
+	}
+	sf := rpf.feature.(*ShellFeature)
+	if len(sf.def.GeomFaces) != 1 {
+		t.Fatalf("restored shell has %d geom faces, want 1", len(sf.def.GeomFaces))
+	}
+	if sf.def.GeomFaces[0].Centroid.DistanceTo(ref.Centroid) > 1e-9 {
+		t.Errorf("restored centroid %v != original %v", sf.def.GeomFaces[0].Centroid, ref.Centroid)
+	}
+}

--- a/model/feature/hole_boss.go
+++ b/model/feature/hole_boss.go
@@ -41,6 +41,7 @@ const (
 // type, and optional tap data.
 type HoleDefinition struct {
 	PlacementFaceKey []byte
+	GeomFace         *topo.GeometricFaceRef // externally-authored placement face by geometric descriptor (ADR-0040)
 	Diameter         func() float64
 	Depth            func() float64
 	ThroughAll       bool           // drill all the way through (depth ignored)
@@ -83,7 +84,7 @@ func (h *HoleFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	face, ok := body.FindFaceByKey(h.def.PlacementFaceKey)
+	face, ok := resolveHoleFace(body, h.def)
 	if !ok {
 		return Output{}, fmt.Errorf("hole: placement face reference lost")
 	}
@@ -318,6 +319,18 @@ func (c *HoleFeatures) AddTapped(faceKey []byte, diameter, depth func() float64,
 
 // addHole adds a hole feature, naming it (Hole1, Hole2, …) so its generated topology has
 // a stable, distinct lineage.
+// resolveHoleFace finds the hole's placement face: by lineage key when present, else by a
+// geometric descriptor (the externally-authored path, ADR-0040), else lost.
+func resolveHoleFace(body *topo.Body, def *HoleDefinition) (*topo.Face, bool) {
+	if len(def.PlacementFaceKey) > 0 {
+		return body.FindFaceByKey(def.PlacementFaceKey)
+	}
+	if def.GeomFace != nil {
+		return body.FindFaceByGeometry(*def.GeomFace, geomEdgeBindTol)
+	}
+	return nil, false
+}
+
 func (c *HoleFeatures) addHole(def *HoleDefinition) *PartFeature {
 	hf := &HoleFeature{def: def}
 	pf := c.engine.Add(hf)

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -143,7 +143,7 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 			fd.Fillet = &EdgeDressData{Sets: serializeFilletSets(f.def.EdgeSets), CornerType: int32(f.def.CornerType)}
 			break
 		}
-		fd.Fillet = &EdgeDressData{Edges: encodeKeys(f.def.EdgeKeys), Value: evalFloat(f.def.Radius), CornerType: int32(f.def.CornerType)}
+		fd.Fillet = &EdgeDressData{Edges: encodeKeys(f.def.EdgeKeys), Value: evalFloat(f.def.Radius), CornerType: int32(f.def.CornerType), GeomEdges: encodeGeomEdges(f.def.GeomEdges)}
 	case *FaceFilletFeature:
 		fd.FaceFillet = &FaceFilletData{FacesA: encodeKeys(f.def.FaceKeysA), FacesB: encodeKeys(f.def.FaceKeysB), Value: evalFloat(f.def.Radius)}
 	case *FullRoundFilletFeature:
@@ -160,6 +160,7 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 		fd.Chamfer = &EdgeDressData{
 			Edges: encodeKeys(f.def.EdgeKeys), Value: evalFloat(f.def.Distance), FlatCorners: &flat,
 			ChamferType: int32(f.def.Type), Value2: evalFloat(f.def.Distance2), Angle: evalFloat(f.def.Angle),
+			GeomEdges: encodeGeomEdges(f.def.GeomEdges),
 		}
 	case *ShellFeature:
 		fd.Shell = &FaceDressData{Faces: encodeKeys(f.def.RemovedFaceKeys), Value: evalFloat(f.def.Thickness)}
@@ -457,7 +458,9 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		if err != nil {
 			return nil, err
 		}
-		return du.AddFilletCorner(d.keys, constFloat(d.value), corner), nil
+		return du.addFillet(&FilletDefinition{
+			EdgeKeys: d.keys, GeomEdges: d.geom, Radius: constFloat(d.value), CornerType: corner,
+		}), nil
 	case "face-fillet":
 		if fd.FaceFillet == nil {
 			return nil, fmt.Errorf("face-fillet feature is missing its payload")
@@ -513,7 +516,7 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		// Build the def directly so the stored flat-corner flag round-trips for EVERY mode
 		// (the asymmetric builders default it to true, but a recipe carries the saved value).
 		def := &ChamferDefinition{
-			EdgeKeys: d.keys, Distance: constFloat(d.value),
+			EdgeKeys: d.keys, GeomEdges: d.geom, Distance: constFloat(d.value),
 			Type: types.ChamferType(fd.Chamfer.ChamferType), FlatCorners: chamferFlatCornersOr(fd.Chamfer.FlatCorners),
 		}
 		switch def.Type {

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -163,10 +163,10 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 			GeomEdges: encodeGeomEdges(f.def.GeomEdges),
 		}
 	case *ShellFeature:
-		fd.Shell = &FaceDressData{Faces: encodeKeys(f.def.RemovedFaceKeys), Value: evalFloat(f.def.Thickness)}
+		fd.Shell = &FaceDressData{Faces: encodeKeys(f.def.RemovedFaceKeys), Value: evalFloat(f.def.Thickness), GeomFaces: encodeGeomFaces(f.def.GeomFaces)}
 	case *FaceDraftFeature:
 		p := f.def.PullDir
-		fd.Draft = &FaceDressData{Faces: encodeKeys(f.def.FaceKeys), Value: evalFloat(f.def.Angle), Pull: []float64{p.X, p.Y, p.Z}}
+		fd.Draft = &FaceDressData{Faces: encodeKeys(f.def.FaceKeys), Value: evalFloat(f.def.Angle), Pull: []float64{p.X, p.Y, p.Z}, GeomFaces: encodeGeomFaces(f.def.GeomFaces)}
 	case *LipFeature:
 		fd.Lip = &LipData{Edges: encodeKeys(f.def.EdgeKeys), Width: evalFloat(f.def.Width), Height: evalFloat(f.def.Height), Groove: f.def.Groove}
 	case *SimplifyFeature:
@@ -543,13 +543,17 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		if err != nil {
 			return nil, err
 		}
-		return du.AddShell(d.keys, constFloat(d.value)), nil
+		return du.addShell(&ShellDefinition{
+			RemovedFaceKeys: d.keys, GeomFaces: d.geomFaces, Thickness: constFloat(d.value),
+		}), nil
 	case "draft":
 		d, err := requireFaceDress(fd.Draft, "draft")
 		if err != nil {
 			return nil, err
 		}
-		return du.AddDraftPull(d.keys, draftPull(fd.Draft.Pull), constFloat(d.value)), nil
+		return du.addFaceDraft(&FaceDraftDefinition{
+			FaceKeys: d.keys, GeomFaces: d.geomFaces, PullDir: draftPull(fd.Draft.Pull), Angle: constFloat(d.value),
+		}), nil
 	case "thread":
 		if fd.Thread == nil {
 			return nil, fmt.Errorf("thread feature is missing its payload")

--- a/model/feature/serialize_dressup.go
+++ b/model/feature/serialize_dressup.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 )
 
@@ -43,6 +44,18 @@ type EdgeDressData struct {
 	Angle       float64 `yaml:"angle,omitempty"`
 	// Fillet-only: the shared-corner treatment. FilletCornerType 0 (or absent) ⇒ the miter default.
 	CornerType int32 `yaml:"cornerType,omitempty"`
+	// GeomEdges are edges selected by a serialized GEOMETRIC descriptor (ADR-0040), the path
+	// an external author (the NX exporter) uses because it cannot mint Oblikovati lineage
+	// keys. Empty for an Oblikovati-authored dress-up (which uses Edges).
+	GeomEdges []GeomEdgeRefData `yaml:"geomEdges,omitempty"`
+}
+
+// GeomEdgeRefData is the serialized form of a geometric edge descriptor: the edge's
+// midpoint and (sign-agnostic) direction in model space. It binds to a running-body edge
+// at recompute via [topo.Body.FindEdgeByGeometry] (ADR-0040).
+type GeomEdgeRefData struct {
+	Midpoint  []float64 `yaml:"midpoint,flow"`
+	Direction []float64 `yaml:"direction,omitempty,flow"`
 }
 
 // FilletSetData is one serialized fillet edge set: constant (Radius) or variable
@@ -177,10 +190,12 @@ type ThreadData struct {
 	ModelDiameter string `yaml:"modelDiameter,omitempty"`
 }
 
-// dressInputs is the decoded (keys, value) pair shared by edge/face dress-ups.
+// dressInputs is the decoded (keys, value) pair shared by edge/face dress-ups, plus any
+// geometric edge descriptors (externally-authored selections, ADR-0040).
 type dressInputs struct {
 	keys  [][]byte
 	value float64
+	geom  []topo.GeometricEdgeRef
 }
 
 func requireEdgeDress(d *EdgeDressData, kind string) (dressInputs, error) {
@@ -191,7 +206,32 @@ func requireEdgeDress(d *EdgeDressData, kind string) (dressInputs, error) {
 	if err != nil {
 		return dressInputs{}, err
 	}
-	return dressInputs{keys: keys, value: d.Value}, nil
+	return dressInputs{keys: keys, value: d.Value, geom: decodeGeomEdges(d.GeomEdges)}, nil
+}
+
+// encodeGeomEdges / decodeGeomEdges convert geometric edge descriptors to and from their
+// serialized form. A descriptor with no direction (degenerate) still round-trips by
+// midpoint alone.
+func encodeGeomEdges(geom []topo.GeometricEdgeRef) []GeomEdgeRefData {
+	if len(geom) == 0 {
+		return nil
+	}
+	out := make([]GeomEdgeRefData, len(geom))
+	for i, g := range geom {
+		out[i] = GeomEdgeRefData{Midpoint: encodePoint3(g.Midpoint), Direction: encodeVec3(g.Direction)}
+	}
+	return out
+}
+
+func decodeGeomEdges(data []GeomEdgeRefData) []topo.GeometricEdgeRef {
+	if len(data) == 0 {
+		return nil
+	}
+	out := make([]topo.GeometricEdgeRef, len(data))
+	for i, d := range data {
+		out[i] = topo.GeometricEdgeRef{Midpoint: decodePoint3(d.Midpoint), Direction: decodeVec3(d.Direction)}
+	}
+	return out
 }
 
 func requireFaceDress(d *FaceDressData, kind string) (dressInputs, error) {

--- a/model/feature/serialize_dressup.go
+++ b/model/feature/serialize_dressup.go
@@ -147,6 +147,18 @@ type FaceDressData struct {
 	Faces []string  `yaml:"faces"`
 	Value float64   `yaml:"value"`
 	Pull  []float64 `yaml:"pull,omitempty"` // draft pull direction (dx,dy,dz); absent ⇒ +Z
+	// GeomFaces are faces selected by a serialized GEOMETRIC descriptor (ADR-0040), the
+	// path the NX exporter uses since it cannot mint Oblikovati lineage keys. Empty for an
+	// Oblikovati-authored dress-up (which uses Faces).
+	GeomFaces []GeomFaceRefData `yaml:"geomFaces,omitempty"`
+}
+
+// GeomFaceRefData is the serialized form of a geometric face descriptor: the face's
+// centroid and outward normal in model space. It binds to a running-body face at recompute
+// via [topo.Body.FindFaceByGeometry] (ADR-0040).
+type GeomFaceRefData struct {
+	Centroid []float64 `yaml:"centroid,flow"`
+	Normal   []float64 `yaml:"normal,omitempty,flow"`
 }
 
 // FaceFilletData persists a face fillet (#694): the two face-set reference keys and the radius.
@@ -193,9 +205,10 @@ type ThreadData struct {
 // dressInputs is the decoded (keys, value) pair shared by edge/face dress-ups, plus any
 // geometric edge descriptors (externally-authored selections, ADR-0040).
 type dressInputs struct {
-	keys  [][]byte
-	value float64
-	geom  []topo.GeometricEdgeRef
+	keys      [][]byte
+	value     float64
+	geom      []topo.GeometricEdgeRef
+	geomFaces []topo.GeometricFaceRef
 }
 
 func requireEdgeDress(d *EdgeDressData, kind string) (dressInputs, error) {
@@ -242,7 +255,47 @@ func requireFaceDress(d *FaceDressData, kind string) (dressInputs, error) {
 	if err != nil {
 		return dressInputs{}, err
 	}
-	return dressInputs{keys: keys, value: d.Value}, nil
+	return dressInputs{keys: keys, value: d.Value, geomFaces: decodeGeomFaces(d.GeomFaces)}, nil
+}
+
+// encodeGeomFaces / decodeGeomFaces convert geometric face descriptors to and from their
+// serialized form (centroid + outward normal).
+func encodeGeomFaces(geom []topo.GeometricFaceRef) []GeomFaceRefData {
+	if len(geom) == 0 {
+		return nil
+	}
+	out := make([]GeomFaceRefData, len(geom))
+	for i, g := range geom {
+		out[i] = GeomFaceRefData{Centroid: encodePoint3(g.Centroid), Normal: encodeVec3(g.Normal)}
+	}
+	return out
+}
+
+func decodeGeomFaces(data []GeomFaceRefData) []topo.GeometricFaceRef {
+	if len(data) == 0 {
+		return nil
+	}
+	out := make([]topo.GeometricFaceRef, len(data))
+	for i, d := range data {
+		out[i] = topo.GeometricFaceRef{Centroid: decodePoint3(d.Centroid), Normal: decodeVec3(d.Normal)}
+	}
+	return out
+}
+
+// encodeGeomFacePtr / decodeGeomFacePtr handle a single optional geometric face descriptor
+// (a hole's placement face).
+func encodeGeomFacePtr(g *topo.GeometricFaceRef) *GeomFaceRefData {
+	if g == nil {
+		return nil
+	}
+	return &GeomFaceRefData{Centroid: encodePoint3(g.Centroid), Normal: encodeVec3(g.Normal)}
+}
+
+func decodeGeomFacePtr(d *GeomFaceRefData) *topo.GeometricFaceRef {
+	if d == nil {
+		return nil
+	}
+	return &topo.GeometricFaceRef{Centroid: decodePoint3(d.Centroid), Normal: decodeVec3(d.Normal)}
 }
 
 // encodeKeys / decodeKeys base64-encode reference keys (opaque lineage bytes) so they

--- a/model/feature/serialize_solid.go
+++ b/model/feature/serialize_solid.go
@@ -23,6 +23,9 @@ type HoleData struct {
 	Type            string  `yaml:"type"`
 	Tapped          bool    `yaml:"tapped,omitempty"`
 	Designation     string  `yaml:"designation,omitempty"`
+	// GeomFace selects the placement face by a GEOMETRIC descriptor (ADR-0040) when the
+	// hole is externally authored (NX exporter) and Face (the lineage key) is empty.
+	GeomFace *GeomFaceRefData `yaml:"geomFace,omitempty"`
 }
 
 // BossData is a boss's recipe: a raised cylinder on a placement face.
@@ -56,6 +59,7 @@ func serializeHole(def *HoleDefinition) (*HoleData, error) {
 		Type:            kind,
 		Tapped:          def.Tap.Tapped,
 		Designation:     def.Tap.Designation,
+		GeomFace:        encodeGeomFacePtr(def.GeomFace),
 	}, nil
 }
 
@@ -89,6 +93,7 @@ func restoreHole(fs *PartFeatures, h *HoleData) (*PartFeature, error) {
 	def.Type = holeType
 	def.ThroughAll = h.ThroughAll
 	def.PointAngle = constFloat(h.PointAngle)
+	def.GeomFace = decodeGeomFacePtr(h.GeomFace)
 	return pf, nil
 }
 


### PR DESCRIPTION
Implements the **/source** half of M8 Tier B (ADR-0040): let dress-up features bind their edge/face selections from a **serialized geometric descriptor**, so an external author (the NX exporter) that cannot mint Oblikovati lineage keys can still place fillets, chamfers, shells, drafts, and holes.

## How
Each dress-up definition gains an optional geometric-reference list alongside its lineage-key list. At recompute, the descriptor binds to the running body via the resolver from PR #1208 (`topo.Body.FindEdgeByGeometry` / `FindFaceByGeometry`) and the bound entity's **current lineage key** is folded into the existing pipeline — so all downstream dress-up machinery is unchanged. An unbound descriptor fails the feature honestly (Sick), never silently dropped.

- **Edges** (fillet, chamfer): recipe `geomEdges: [{midpoint, direction}]`.
- **Faces** (shell removed-faces, draft faces): recipe `geomFaces: [{centroid, normal}]`.
- **Hole** placement face: recipe `geomFace: {centroid, normal}`.

Non-identity by design (ADR-0040): the descriptor never enters a key's identity bytes, preserving the M31-F07 rule that the drift-prone anchor stays out of identity. Oblikovati-authored lineage keys are completely unchanged.

## Tests
- A geometric-edge fillet rounds a box (volume drops); a miss goes Sick; `geomEdges` survives serialize/restore.
- A geometric-face shell hollows a box; a geometric-face hole drills it; `geomFaces` survives serialize/restore.

Follow-up: the NX exporter emits these descriptors (separate repo PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)