### PR TITLE
Selection engine: tools declare selection; one host owns filtering, picking & highlight

### DIFF
--- a/app/assembly_constraint_tools.go
+++ b/app/assembly_constraint_tools.go
@@ -37,10 +37,14 @@ func NewAssemblyConstraintTool(label string, need int, build constraintBuild) *A
 // Name is the tool's display name.
 func (t *AssemblyConstraintTool) Name() string { return t.label }
 
-// Start restricts picking to component faces.
-func (t *AssemblyConstraintTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectFace))
-}
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *AssemblyConstraintTool) Start(*Session) {}
+
+// AcceptedKinds declares the constraint picks component faces.
+func (t *AssemblyConstraintTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectFace} }
+
+// Picks reports the picked component faces for the unified highlight.
+func (t *AssemblyConstraintTool) Picks() []Selectable { return faceSelectables(t.faces) }
 
 // Pick appends a picked face until the constraint has all the inputs it needs.
 func (t *AssemblyConstraintTool) Pick(_ *Session, sel Selectable) {
@@ -60,7 +64,6 @@ func (t *AssemblyConstraintTool) CanCommit() bool { return len(t.faces) == t.nee
 // Cancel abandons the picks and clears the face filter.
 func (t *AssemblyConstraintTool) Cancel(s *Session) {
 	t.faces = nil
-	s.Selection().SetFilter(NewSelectionFilter())
 }
 
 // Commit resolves the picks, creates the constraint, solves the assembly, and records the edit.
@@ -80,7 +83,6 @@ func (t *AssemblyConstraintTool) Commit(s *Session) error {
 	c := t.build(asm.Constraints(), refs)
 	asm.SolveConstraints()
 	s.recordEdit(asm, c.Name())
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 

--- a/app/assembly_dressup_tools.go
+++ b/app/assembly_dressup_tools.go
@@ -39,9 +39,14 @@ type assemblyEdgeSelectTool struct {
 
 // Start restricts picking to edges, so a click selects a participant edge rather than the whole
 // occurrence (the SelectEdge filter bypasses occurrence selection — see #769).
-func (t *assemblyEdgeSelectTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectEdge))
-}
+func (t *assemblyEdgeSelectTool) Start(*Session) {}
+
+// AcceptedKinds declares the assembly dress-up picks component edges (the SelectEdge filter
+// bypasses occurrence selection — see #769).
+func (t *assemblyEdgeSelectTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectEdge} }
+
+// Picks reports the picked component edges for the unified highlight.
+func (t *assemblyEdgeSelectTool) Picks() []Selectable { return edgeSelectables(t.edges) }
 
 // Pick appends a picked edge (ignoring a repeat, so a double-click does not duplicate it).
 func (t *assemblyEdgeSelectTool) Pick(_ *Session, sel Selectable) {
@@ -62,7 +67,6 @@ func (t *assemblyEdgeSelectTool) hasEdge(e EdgeHandle) bool {
 // Cancel abandons the picks and clears the edge filter.
 func (t *assemblyEdgeSelectTool) Cancel(s *Session) {
 	t.edges = nil
-	s.Selection().SetFilter(NewSelectionFilter())
 }
 
 // resolve returns the active assembly and the component-local suffix of each picked edge, erroring
@@ -88,7 +92,6 @@ func (t *assemblyEdgeSelectTool) finish(s *Session, asm *compdef.AssemblyCompone
 	af.SetName(asm.Features().UniqueName(af.Kind()))
 	asm.RecomputeFeatures()
 	s.recordEdit(asm, af.Kind())
-	s.Selection().SetFilter(NewSelectionFilter())
 }
 
 // --- Chamfer --------------------------------------------------------------

--- a/app/assembly_joint_tools.go
+++ b/app/assembly_joint_tools.go
@@ -33,10 +33,14 @@ func NewAssemblyJointTool(label string, build jointBuild) *AssemblyJointTool {
 // Name is the tool's display name.
 func (t *AssemblyJointTool) Name() string { return t.label }
 
-// Start restricts picking to component faces.
-func (t *AssemblyJointTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectFace))
-}
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *AssemblyJointTool) Start(*Session) {}
+
+// AcceptedKinds declares the joint picks component faces (the two joint-origin faces).
+func (t *AssemblyJointTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectFace} }
+
+// Picks reports the picked component faces for the unified highlight.
+func (t *AssemblyJointTool) Picks() []Selectable { return faceSelectables(t.faces) }
 
 // Pick appends a picked face until the joint has its two origins.
 func (t *AssemblyJointTool) Pick(_ *Session, sel Selectable) {
@@ -56,7 +60,6 @@ func (t *AssemblyJointTool) CanCommit() bool { return len(t.faces) == 2 }
 // Cancel abandons the picks and clears the face filter.
 func (t *AssemblyJointTool) Cancel(s *Session) {
 	t.faces = nil
-	s.Selection().SetFilter(NewSelectionFilter())
 }
 
 // Commit resolves the picks, creates the joint, solves the assembly, and records the edit.
@@ -76,6 +79,5 @@ func (t *AssemblyJointTool) Commit(s *Session) error {
 	j := t.build(asm.Joints(), refs)
 	asm.SolveConstraints()
 	s.recordEdit(asm, j.Name())
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }

--- a/app/chamfer_tool.go
+++ b/app/chamfer_tool.go
@@ -36,8 +36,13 @@ func (t *ChamferTool) Name() string { return "Chamfer" }
 func (t *ChamferTool) Start(s *Session) {
 	t.flatCorners = s.ChamferFlatCorners()
 	t.concaveStrategy = s.ChamferConcaveStrategy()
-	s.Selection().SetFilter(NewSelectionFilter(SelectEdge))
 }
+
+// AcceptedKinds declares chamfer picks edges (the edges to bevel).
+func (t *ChamferTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectEdge} }
+
+// Picks reports the picked edges for the unified highlight.
+func (t *ChamferTool) Picks() []Selectable { return edgeSelectables(t.Edges()) }
 
 // SetFlatCorners/FlatCorners choose whether a vertex where three picked edges meet is
 // blended into a flat triangular face (true) or left pointy (false).
@@ -126,7 +131,6 @@ func (t *ChamferTool) Commit(s *Session) error {
 	if !t.added.Health().OK() {
 		return errors.New("chamfer: " + t.added.Health().Reason)
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 
@@ -166,7 +170,6 @@ func (t *ChamferTool) Cancel(s *Session) {
 		cancelFeatureEdit(s, t.target, t.restoreDef)
 		return
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 }
 
 // commitEdit writes the panel state back into the committed chamfer's definition.

--- a/app/coil_tool.go
+++ b/app/coil_tool.go
@@ -35,8 +35,19 @@ func NewCoilTool() *CoilTool {
 // Name implements [Tool].
 func (t *CoilTool) Name() string { return "Coil" }
 
-// Start sets the selection filter to profiles so clicks pick a region.
-func (t *CoilTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectProfile)) }
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *CoilTool) Start(*Session) {}
+
+// AcceptedKinds declares coil picks a closed sketch region (profile).
+func (t *CoilTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectProfile} }
+
+// Picks reports the picked region for the unified highlight.
+func (t *CoilTool) Picks() []Selectable {
+	if t.profile == nil {
+		return nil
+	}
+	return []Selectable{*t.profile}
+}
 
 // Pick captures the region the user clicked.
 func (t *CoilTool) Pick(_ *Session, sel Selectable) {
@@ -107,7 +118,6 @@ func (t *CoilTool) Commit(s *Session) error {
 	if !t.added.Health().OK() {
 		return errors.New("coil: " + t.added.Health().Reason)
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 
@@ -178,7 +188,6 @@ func (t *CoilTool) Cancel(s *Session) {
 		cancelFeatureEdit(s, t.target, t.restoreDef)
 		return
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 }
 
 // ClearProfile empties the picked profile — the property panel's selector clear (⊗) —

--- a/app/coil_tool.go
+++ b/app/coil_tool.go
@@ -42,12 +42,7 @@ func (t *CoilTool) Start(*Session) {}
 func (t *CoilTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectProfile} }
 
 // Picks reports the picked region for the unified highlight.
-func (t *CoilTool) Picks() []Selectable {
-	if t.profile == nil {
-		return nil
-	}
-	return []Selectable{*t.profile}
-}
+func (t *CoilTool) Picks() []Selectable { return singlePick(t.profile) }
 
 // Pick captures the region the user clicked.
 func (t *CoilTool) Pick(_ *Session, sel Selectable) {

--- a/app/commands_assembly.go
+++ b/app/commands_assembly.go
@@ -66,7 +66,7 @@ func jointCommand(id, name, icon, tooltip string, build jointBuild) *CommandDefi
 func assemblyModelingCommands() []*CommandDefinition {
 	return []*CommandDefinition{
 		NewCommand("Assembly.CreateSketch", "Create 2D Sketch", "Sketch", func(s *Session) error {
-			if s.SelectedWorkPlane() != nil {
+			if _, ok := s.SelectedSketchHostPlane(); ok {
 				_, err := s.CreateSketchOnSelectedPlane()
 				return err
 			}

--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -159,9 +159,10 @@ func workFeatureCommands() []*CommandDefinition {
 func modelTabCommands() []*CommandDefinition {
 	cmds := []*CommandDefinition{
 		NewCommand("Sketch.Create2D", "Create 2D Sketch", "Sketch", func(s *Session) error {
-			// With a plane already selected, sketch on it immediately; otherwise start
-			// the tool and let the user pick a plane in the 3D view or the browser.
-			if s.SelectedWorkPlane() != nil {
+			// With a host (work plane or planar face) already selected, sketch on it
+			// immediately; otherwise start the tool and let the user pick one in the 3D
+			// view or the browser.
+			if _, ok := s.SelectedSketchHostPlane(); ok {
 				_, err := s.CreateSketchOnSelectedPlane()
 				return err
 			}

--- a/app/create_sketch_face_host_test.go
+++ b/app/create_sketch_face_host_test.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/scene"
+)
+
+// downLookingBoxWithPlanes builds the box and installs a real RayPicker (bodies AND work planes)
+// looking straight down — the production pick setup, so the create-sketch hover/pick path runs
+// against genuine geometry with the origin planes hidden behind the solid (the bug's setting).
+func downLookingBoxWithPlanes(t *testing.T) *Session {
+	t.Helper()
+	s := extrudedBox(t, 2, 4) // [0,2]×[0,2]×[0,4]
+	cam := scene.NewCamera(400, 400)
+	cam.Eye, cam.Target, cam.Up = math.P3(1, 1, 20), math.P3(1, 1, 0), math.V3(0, 1, 0)
+	s.SetCamera(cam)
+	s.SetPicker(NewRayPicker(cam, partBodies(s)).
+		WithPlanes(func() []*feature.WorkPlane { return s.PickableWorkPlanes() }))
+	return s
+}
+
+// TestCreateSketchToolAcceptsFaceAndPlaneHosts pins that Create 2D Sketch lets BOTH valid sketch
+// hosts highlight/pick: a work plane and a planar face. Before the fix the filter admitted only
+// work planes, so a face never highlighted and a click over it picked the origin plane behind it.
+func TestCreateSketchToolAcceptsFaceAndPlaneHosts(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	tool := NewCreateSketchTool()
+	tool.Start(s)
+	f := s.Selection().Filter()
+	if !f.Accepts(SelectWorkPlane) || !f.Accepts(SelectFace) {
+		t.Errorf("create-sketch filter must accept work planes AND faces; accepts(plane)=%v accepts(face)=%v",
+			f.Accepts(SelectWorkPlane), f.Accepts(SelectFace))
+	}
+	if f.Accepts(SelectEdge) {
+		t.Error("create-sketch filter should not accept edges (not a sketch host)")
+	}
+}
+
+// TestCreateSketchPicksFaceNotPlaneBehind is the regression for the reported bug: with the tool
+// active and a solid present, a pick over the top face must resolve to the FACE — not the XY origin
+// plane hidden behind the box — and clicking it enters a sketch on that face's plane.
+func TestCreateSketchPicksFaceNotPlaneBehind(t *testing.T) {
+	s := downLookingBoxWithPlanes(t)
+	s.StartTool(NewCreateSketchTool())
+
+	sel, ok := s.PickAt(200, 200, s.Selection().Filter())
+	if !ok {
+		t.Fatal("create-sketch pick over the top face returned nothing")
+	}
+	if _, isFace := sel.(FaceHandle); !isFace {
+		t.Fatalf("pick over a face = %T, want FaceHandle (not the plane behind the box)", sel)
+	}
+
+	s.Click(200, 200) // auto-commit onto the face
+	if s.ActiveTool() != nil || !s.InSketch() {
+		t.Fatal("clicking a planar face must end the tool and enter the sketch environment")
+	}
+	pl := s.ActiveSketch().Plane()
+	if n := pl.Normal().AsVector(); stdmath.Abs(float64(n.Z)) < 0.999 {
+		t.Errorf("sketch plane normal = %v, want the top cap (±Z)", n)
+	}
+	if z := float64(pl.Origin().Z); stdmath.Abs(z-4) > 1e-6 {
+		t.Errorf("sketch plane origin z = %v, want 4 (on the top cap)", z)
+	}
+}
+
+// TestCreateSketchToolIgnoresNonPlanarFace: a cylindrical face cannot host a sketch, so feeding it
+// to the tool must not arm a commit (and committing then errors rather than sketching on garbage).
+func TestCreateSketchToolIgnoresNonPlanarFace(t *testing.T) {
+	s, body := newPartWithCylinder(t)
+	tool := NewCreateSketchTool()
+	tool.Start(s)
+	tool.Pick(s, FaceHandle{Face: cylinderFaceOf(t, body), Body: body})
+	if tool.CanCommit() {
+		t.Fatal("a non-planar (cylindrical) face must not arm the sketch commit")
+	}
+	if err := tool.Commit(s); err == nil {
+		t.Error("committing with only a non-planar face picked should error")
+	}
+}
+
+// TestSketchPlaneFromFace: a planar face yields its plane (matching normal); a curved one does not.
+func TestSketchPlaneFromFace(t *testing.T) {
+	s := downLookingBoxWithPlanes(t)
+	sel, _ := s.PickAt(200, 200, NewSelectionFilter(SelectFace))
+	pl, ok := sketchPlaneFromFace(sel.(FaceHandle))
+	if !ok {
+		t.Fatal("a planar face must yield a sketch plane")
+	}
+	faceNormal := sel.(FaceHandle).Face.Geometry().(geom.Plane).Normal()
+	if !sameDir(pl.Normal().AsVector(), faceNormal) {
+		t.Errorf("derived plane normal %v != face normal %v", pl.Normal().AsVector(), faceNormal)
+	}
+
+	_, body := newPartWithCylinder(t)
+	if _, ok := sketchPlaneFromFace(FaceHandle{Face: cylinderFaceOf(t, body), Body: body}); ok {
+		t.Error("a cylindrical face must not yield a sketch plane")
+	}
+}
+
+// TestSelectedSketchHostPlaneFromFace: a pre-selected planar face is a sketch host, so running
+// Create 2D Sketch with a face selected sketches on it immediately (no tool) — Inventor's
+// "select a face, then Create Sketch" flow.
+func TestSelectedSketchHostPlaneFromFace(t *testing.T) {
+	s := downLookingBoxWithPlanes(t)
+	sel, _ := s.PickAt(200, 200, NewSelectionFilter(SelectFace))
+	s.Selection().Add(sel)
+
+	if _, ok := s.SelectedSketchHostPlane(); !ok {
+		t.Fatal("a selected planar face must be reported as a sketch host")
+	}
+	sk, err := s.CreateSketchOnSelectedPlane()
+	if err != nil {
+		t.Fatalf("CreateSketchOnSelectedPlane on a face: %v", err)
+	}
+	if z := float64(sk.Plane().Origin().Z); stdmath.Abs(z-4) > 1e-6 {
+		t.Errorf("sketch on selected face: origin z = %v, want 4", z)
+	}
+}
+
+// sameDir reports whether two vectors point the same or exactly opposite way (a plane's normal
+// sign is orientation-dependent; either matches the host face).
+func sameDir(a, b math.Vector3) bool {
+	d := float64(a.AsUnit().Dot(b.AsUnit()))
+	return stdmath.Abs(stdmath.Abs(d)-1) < 1e-6
+}

--- a/app/create_sketch_face_host_test.go
+++ b/app/create_sketch_face_host_test.go
@@ -31,8 +31,7 @@ func downLookingBoxWithPlanes(t *testing.T) *Session {
 // work planes, so a face never highlighted and a click over it picked the origin plane behind it.
 func TestCreateSketchToolAcceptsFaceAndPlaneHosts(t *testing.T) {
 	s, _ := emptyPartSession(t)
-	tool := NewCreateSketchTool()
-	tool.Start(s)
+	s.StartTool(NewCreateSketchTool()) // the engine installs the filter from AcceptedKinds
 	f := s.Selection().Filter()
 	if !f.Accepts(SelectWorkPlane) || !f.Accepts(SelectFace) {
 		t.Errorf("create-sketch filter must accept work planes AND faces; accepts(plane)=%v accepts(face)=%v",

--- a/app/create_sketch_tool.go
+++ b/app/create_sketch_tool.go
@@ -5,51 +5,61 @@ package app
 import (
 	"errors"
 
-	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
 )
 
 // CreateSketchTool is Inventor's "Create 2D Sketch" interaction: after the command
-// starts it, the user picks the work plane (or, later, a planar face) to sketch on —
-// in the 3D view or the browser — and the sketch is created and opened on that plane
-// the instant it is clicked (auto-commit). It restricts the selection filter to work
-// planes while active, so only valid sketch hosts highlight/pick.
+// starts it, the user picks a sketch host — a work plane OR a planar face, in the 3D
+// view or the browser — and the sketch is created and opened on that plane the instant
+// it is clicked (auto-commit). It restricts the selection filter to the valid hosts
+// (work planes and faces) while active, so only those highlight/pick — and a click on a
+// face starts the sketch on that face rather than on a plane hidden behind it.
 type CreateSketchTool struct {
-	plane      *feature.WorkPlane
+	plane      sketch.Plane
+	picked     bool
 	prevFilter *SelectionFilter
 }
 
-// NewCreateSketchTool returns a sketch-plane selection tool.
+// NewCreateSketchTool returns a sketch-host selection tool.
 func NewCreateSketchTool() *CreateSketchTool { return &CreateSketchTool{} }
 
 // Name implements [Tool].
 func (t *CreateSketchTool) Name() string { return "Create 2D Sketch" }
 
-// Start filters selection to work planes (the valid sketch hosts) for the pick.
+// Start filters selection to the valid sketch hosts — work planes and planar faces — so
+// both highlight and pick while the tool is active (a face in front wins over the origin
+// plane behind it, which is why the face must be accepted, not just the plane).
 func (t *CreateSketchTool) Start(s *Session) {
 	t.prevFilter = s.Selection().Filter()
-	s.Selection().SetFilter(NewSelectionFilter(SelectWorkPlane))
+	s.Selection().SetFilter(NewSelectionFilter(SelectWorkPlane, SelectFace))
 }
 
-// Pick records the chosen work plane.
+// Pick records the chosen sketch host: a work plane directly, or the plane of a picked
+// planar face. A non-planar face is ignored (it cannot host a sketch).
 func (t *CreateSketchTool) Pick(_ *Session, sel Selectable) {
-	if h, ok := sel.(WorkPlaneHandle); ok {
-		t.plane = h.Plane
+	switch h := sel.(type) {
+	case WorkPlaneHandle:
+		t.plane, t.picked = h.Plane.Plane(), true
+	case FaceHandle:
+		if pl, ok := sketchPlaneFromFace(h); ok {
+			t.plane, t.picked = pl, true
+		}
 	}
 }
 
-// CanCommit is true once a plane has been picked.
-func (t *CreateSketchTool) CanCommit() bool { return t.plane != nil }
+// CanCommit is true once a host plane has been picked.
+func (t *CreateSketchTool) CanCommit() bool { return t.picked }
 
-// AutoCommitOnPick makes the tool enter the sketch as soon as a plane is clicked.
+// AutoCommitOnPick makes the tool enter the sketch as soon as a host is clicked.
 func (t *CreateSketchTool) AutoCommitOnPick() bool { return true }
 
 // Commit creates the sketch on the picked plane and opens the sketch environment.
 func (t *CreateSketchTool) Commit(s *Session) error {
 	s.Selection().SetFilter(t.prevFilter)
-	if t.plane == nil {
-		return errors.New("create sketch: no plane selected")
+	if !t.picked {
+		return errors.New("create sketch: no work plane or planar face selected")
 	}
-	_, err := s.CreateSketch(t.plane.Plane())
+	_, err := s.CreateSketch(t.plane)
 	return err
 }
 

--- a/app/create_sketch_tool.go
+++ b/app/create_sketch_tool.go
@@ -11,13 +11,13 @@ import (
 // CreateSketchTool is Inventor's "Create 2D Sketch" interaction: after the command
 // starts it, the user picks a sketch host — a work plane OR a planar face, in the 3D
 // view or the browser — and the sketch is created and opened on that plane the instant
-// it is clicked (auto-commit). It restricts the selection filter to the valid hosts
-// (work planes and faces) while active, so only those highlight/pick — and a click on a
-// face starts the sketch on that face rather than on a plane hidden behind it.
+// it is clicked (auto-commit). It is the canonical selection-engine consumer: it DECLARES
+// that it picks work planes and planar faces (AcceptedKinds), so the host installs that
+// filter and highlights both — a click on a face starts the sketch on that face rather
+// than on a plane hidden behind it (the bug that motivated the engine). See ADR-0041.
 type CreateSketchTool struct {
-	plane      sketch.Plane
-	picked     bool
-	prevFilter *SelectionFilter
+	plane  sketch.Plane
+	picked bool
 }
 
 // NewCreateSketchTool returns a sketch-host selection tool.
@@ -26,13 +26,18 @@ func NewCreateSketchTool() *CreateSketchTool { return &CreateSketchTool{} }
 // Name implements [Tool].
 func (t *CreateSketchTool) Name() string { return "Create 2D Sketch" }
 
-// Start filters selection to the valid sketch hosts — work planes and planar faces — so
-// both highlight and pick while the tool is active (a face in front wins over the origin
-// plane behind it, which is why the face must be accepted, not just the plane).
-func (t *CreateSketchTool) Start(s *Session) {
-	t.prevFilter = s.Selection().Filter()
-	s.Selection().SetFilter(NewSelectionFilter(SelectWorkPlane, SelectFace))
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *CreateSketchTool) Start(*Session) {}
+
+// AcceptedKinds declares the valid sketch hosts: work planes and planar faces. Declaring the
+// face here (not just the plane) is what lets a face in front win over the origin plane behind it.
+func (t *CreateSketchTool) AcceptedKinds() []SelectionKind {
+	return []SelectionKind{SelectWorkPlane, SelectFace}
 }
+
+// Picks reports nothing: the tool auto-commits on the pick, so there is never a lingering
+// selection to highlight (the hover preselect already lights the host under the cursor).
+func (t *CreateSketchTool) Picks() []Selectable { return nil }
 
 // Pick records the chosen sketch host: a work plane directly, or the plane of a picked
 // planar face. A non-planar face is ignored (it cannot host a sketch).
@@ -55,7 +60,6 @@ func (t *CreateSketchTool) AutoCommitOnPick() bool { return true }
 
 // Commit creates the sketch on the picked plane and opens the sketch environment.
 func (t *CreateSketchTool) Commit(s *Session) error {
-	s.Selection().SetFilter(t.prevFilter)
 	if !t.picked {
 		return errors.New("create sketch: no work plane or planar face selected")
 	}
@@ -63,8 +67,8 @@ func (t *CreateSketchTool) Commit(s *Session) error {
 	return err
 }
 
-// Cancel restores the previous selection filter with no change.
-func (t *CreateSketchTool) Cancel(s *Session) { s.Selection().SetFilter(t.prevFilter) }
+// Cancel abandons the tool; the engine restores the ambient filter.
+func (t *CreateSketchTool) Cancel(*Session) {}
 
 // Prompt guides the user to pick a sketch plane (Inventor's status-bar prompt).
 func (t *CreateSketchTool) Prompt(*Session) string {

--- a/app/create_sketch_tool_test.go
+++ b/app/create_sketch_tool_test.go
@@ -117,11 +117,13 @@ func TestCreateSketchToolCancelRestoresFilter(t *testing.T) {
 	s, _ := emptyPartSession(t)
 	tool := NewCreateSketchTool()
 	s.StartTool(tool)
-	if s.Selection().Filter().Accepts(SelectFace) {
-		t.Error("Create Sketch tool should restrict the filter to work planes")
+	// The tool restricts to the sketch hosts (work planes and planar faces), so edges
+	// (not a host) are excluded while it is active.
+	if !s.Selection().Filter().IsRestricted() || s.Selection().Filter().Accepts(SelectEdge) {
+		t.Error("Create Sketch tool should restrict the filter to sketch hosts (planes and faces)")
 	}
 	s.CancelTool()
-	if !s.Selection().Filter().Accepts(SelectFace) {
+	if !s.Selection().Filter().Accepts(SelectEdge) {
 		t.Error("cancelling should restore the all-accepting filter")
 	}
 }

--- a/app/decal_tool.go
+++ b/app/decal_tool.go
@@ -21,8 +21,19 @@ func NewDecalTool() *DecalTool { return &DecalTool{} }
 // Name implements [Tool].
 func (t *DecalTool) Name() string { return "Decal" }
 
-// Start filters selection to faces.
-func (t *DecalTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectFace)) }
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *DecalTool) Start(*Session) {}
+
+// AcceptedKinds declares decal picks a face (the surface to project onto).
+func (t *DecalTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectFace} }
+
+// Picks reports the picked face for the unified highlight.
+func (t *DecalTool) Picks() []Selectable {
+	if t.face == nil {
+		return nil
+	}
+	return []Selectable{*t.face}
+}
 
 // Pick captures the target face.
 func (t *DecalTool) Pick(_ *Session, sel Selectable) {
@@ -61,12 +72,11 @@ func (t *DecalTool) Commit(s *Session) error {
 	t.added = feature.NewCosmeticFeatures(part.Features()).AddDecal(t.face.Face.ReferenceKey(), t.image)
 	part.Recompute()
 	s.recordEdit(part, "Decal")
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 
-// Cancel restores the default selection filter.
-func (t *DecalTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+// Cancel is a no-op; the engine restores the ambient filter.
+func (t *DecalTool) Cancel(*Session) {}
 
 // AddedFeature returns the decal created on commit (for inspection/tests).
 func (t *DecalTool) AddedFeature() *feature.DecalFeature { return t.added }

--- a/app/decal_tool.go
+++ b/app/decal_tool.go
@@ -28,12 +28,7 @@ func (t *DecalTool) Start(*Session) {}
 func (t *DecalTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectFace} }
 
 // Picks reports the picked face for the unified highlight.
-func (t *DecalTool) Picks() []Selectable {
-	if t.face == nil {
-		return nil
-	}
-	return []Selectable{*t.face}
-}
+func (t *DecalTool) Picks() []Selectable { return singlePick(t.face) }
 
 // Pick captures the target face.
 func (t *DecalTool) Pick(_ *Session, sel Selectable) {

--- a/app/delete_face_tool.go
+++ b/app/delete_face_tool.go
@@ -22,8 +22,14 @@ func NewDeleteFaceTool() *DeleteFaceTool { return &DeleteFaceTool{} }
 // Name implements [Tool].
 func (t *DeleteFaceTool) Name() string { return "Delete Face" }
 
-// Start sets the selection filter to faces.
-func (t *DeleteFaceTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectFace)) }
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *DeleteFaceTool) Start(*Session) {}
+
+// AcceptedKinds declares delete-face picks faces (the faces to remove).
+func (t *DeleteFaceTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectFace} }
+
+// Picks reports the picked faces for the unified highlight.
+func (t *DeleteFaceTool) Picks() []Selectable { return faceSelectables(t.faces) }
 
 // Pick appends the clicked face (ignoring a duplicate).
 func (t *DeleteFaceTool) Pick(_ *Session, sel Selectable) {
@@ -62,7 +68,6 @@ func (t *DeleteFaceTool) Commit(s *Session) error {
 	if !t.added.Health().OK() {
 		return errors.New("delete face: " + t.added.Health().Reason)
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 
@@ -92,8 +97,8 @@ func (t *DeleteFaceTool) Prompt(*Session) string {
 	return "Click OK to delete and heal"
 }
 
-// Cancel restores the default selection filter.
-func (t *DeleteFaceTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+// Cancel is a no-op; the engine restores the ambient filter.
+func (t *DeleteFaceTool) Cancel(*Session) {}
 
 // ClearFaces empties the picked faces — the property panel's selector clear (⊗) —
 // returning the tool to its pick-faces step.

--- a/app/draft_tool.go
+++ b/app/draft_tool.go
@@ -29,8 +29,14 @@ func NewDraftTool() *DraftTool { return &DraftTool{angleDeg: 3} }
 // Name implements [Tool].
 func (t *DraftTool) Name() string { return "Draft" }
 
-// Start sets the selection filter to faces.
-func (t *DraftTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectFace)) }
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *DraftTool) Start(*Session) {}
+
+// AcceptedKinds declares draft picks faces (the faces to taper).
+func (t *DraftTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectFace} }
+
+// Picks reports the picked faces for the unified highlight.
+func (t *DraftTool) Picks() []Selectable { return faceSelectables(t.faces) }
 
 // Pick appends the clicked face (ignoring a duplicate).
 func (t *DraftTool) Pick(_ *Session, sel Selectable) {
@@ -90,7 +96,6 @@ func (t *DraftTool) Commit(s *Session) error {
 	if !t.added.Health().OK() {
 		return errors.New("draft: " + t.added.Health().Reason)
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 
@@ -124,13 +129,12 @@ func (t *DraftTool) Prompt(*Session) string {
 	return "Set the angle, then click OK"
 }
 
-// Cancel restores the default selection filter.
+// Cancel abandons the tool; the engine restores the ambient filter.
 func (t *DraftTool) Cancel(s *Session) {
 	if t.IsEditing() {
 		cancelFeatureEdit(s, t.target, t.restoreDef)
 		return
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 }
 
 // commitEdit writes the panel state back into the committed draft's definition.

--- a/app/emboss_tool.go
+++ b/app/emboss_tool.go
@@ -24,8 +24,14 @@ func NewEmbossTool() *EmbossTool { return &EmbossTool{depth: 1} }
 // Name implements [Tool].
 func (t *EmbossTool) Name() string { return "Emboss" }
 
-// Start filters selection to closed regions so clicks pick a profile.
-func (t *EmbossTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectProfile)) }
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *EmbossTool) Start(*Session) {}
+
+// AcceptedKinds declares emboss picks closed sketch regions (profiles).
+func (t *EmbossTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectProfile} }
+
+// Picks reports the picked regions for the unified highlight.
+func (t *EmbossTool) Picks() []Selectable { return profileSelectables(t.profiles) }
 
 // Pick captures a single clicked region (replacing any previous selection).
 func (t *EmbossTool) Pick(_ *Session, sel Selectable) {
@@ -85,7 +91,6 @@ func (t *EmbossTool) Commit(s *Session) error {
 	if !t.added.Health().OK() {
 		return errors.New("emboss: " + t.added.Health().Reason)
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 

--- a/app/emboss_tool.go
+++ b/app/emboss_tool.go
@@ -112,7 +112,7 @@ func (t *EmbossTool) DraftFeature(*Session) (feature.Feature, bool) {
 }
 
 // Cancel restores the default selection filter.
-func (t *EmbossTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *EmbossTool) Cancel(*Session) {}
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *EmbossTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/extend_tool.go
+++ b/app/extend_tool.go
@@ -23,8 +23,14 @@ func NewExtendTool() *ExtendTool { return &ExtendTool{distance: 1} }
 // Name implements [Tool].
 func (t *ExtendTool) Name() string { return "Extend" }
 
-// Start filters selection to edges so clicks pick a boundary edge.
-func (t *ExtendTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectEdge)) }
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *ExtendTool) Start(*Session) {}
+
+// AcceptedKinds declares extend picks edges (the surface boundary edges to extend).
+func (t *ExtendTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectEdge} }
+
+// Picks reports the picked edges for the unified highlight.
+func (t *ExtendTool) Picks() []Selectable { return edgeSelectables(t.Edges()) }
 
 // Pick captures the boundary edge to extend.
 func (t *ExtendTool) Pick(_ *Session, sel Selectable) {
@@ -66,7 +72,6 @@ func (t *ExtendTool) Commit(s *Session) error {
 	if !t.added.Health().OK() {
 		return errors.New("extend: " + t.added.Health().Reason)
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 

--- a/app/extend_tool.go
+++ b/app/extend_tool.go
@@ -92,7 +92,7 @@ func (t *ExtendTool) DraftFeature(*Session) (feature.Feature, bool) {
 }
 
 // Cancel restores the default selection filter.
-func (t *ExtendTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *ExtendTool) Cancel(*Session) {}
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *ExtendTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/extrude_toface_test.go
+++ b/app/extrude_toface_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+)
+
+// planeAtZ (a horizontal sketch plane at height z, the "to face" termination target) is shared
+// with loft_tool_test.go.
+
+// TestExtrudeToFaceStepsAndTarget pins the engine-driven two-step flow: extrude picks a profile,
+// and once "to face" is chosen it switches to accepting a termination face/plane, gates commit on
+// it, and folds it into the extent (#1222 selection engine, the To-Face proof case).
+func TestExtrudeToFaceStepsAndTarget(t *testing.T) {
+	tool := NewExtrudeTool()
+	if k := tool.AcceptedKinds(); len(k) != 1 || k[0] != SelectProfile {
+		t.Fatalf("initial AcceptedKinds = %v, want [SelectProfile]", k)
+	}
+	tool.Pick(nil, ProfileHandle{})
+	tool.SetExtentType(feature.ToFaceExtent)
+
+	k := tool.AcceptedKinds()
+	if !kindsContain(k, SelectFace) || !kindsContain(k, SelectWorkPlane) {
+		t.Fatalf("to-face AcceptedKinds = %v, want face + work plane", k)
+	}
+	if tool.CanCommit() {
+		t.Fatal("to-face must not be committable before a termination target is picked")
+	}
+	tool.Pick(nil, WorkPlaneHandle{Plane: feature.NewFixedWorkPlane(planeAtZ(3))})
+	if !tool.CanCommit() {
+		t.Fatal("to-face should be committable once a termination is picked")
+	}
+	if tool.buildExtent().ToPlane == nil {
+		t.Fatal("buildExtent must carry the to-face termination plane")
+	}
+}
+
+// TestExtrudeToFaceTerminatesAtPlane drives the whole flow and asserts the solid actually
+// terminates at the picked plane (height = the plane's z), not at a typed distance.
+func TestExtrudeToFaceTerminatesAtPlane(t *testing.T) {
+	s, profile := newPartWithSquare(t, 2)
+	tool := NewExtrudeTool()
+	s.StartTool(tool)
+	tool.Pick(s, profile)
+	tool.SetExtentType(feature.ToFaceExtent)
+	tool.Pick(s, WorkPlaneHandle{Plane: feature.NewFixedWorkPlane(planeAtZ(3))})
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK (to-face extrude): %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	body := def.SurfaceBodies().Item(0)
+	if h := float64(body.RangeBox().Diagonal().Z); h < 2.99 || h > 3.01 {
+		t.Errorf("to-face extrude height = %v, want ~3 (terminated at the picked plane)", h)
+	}
+}
+
+// TestExtrudeToFacePicksIncludeTermination: the termination face shows in the tool's Picks so the
+// engine highlights it like any other selection.
+func TestExtrudeToFacePicksIncludeTermination(t *testing.T) {
+	s := downLookingBoxWithPlanes(t)
+	tool := NewExtrudeTool()
+	s.StartTool(tool)
+	tool.Pick(s, ProfileHandle{})
+	tool.SetExtentType(feature.ToFaceExtent)
+	sel, _ := s.PickAt(200, 200, NewSelectionFilter(SelectFace))
+	tool.Pick(s, sel)
+	picks := tool.Picks()
+	if len(picks) == 0 {
+		t.Fatal("Picks must include the picked termination face")
+	}
+	if _, ok := picks[len(picks)-1].(FaceHandle); !ok {
+		t.Fatalf("last pick = %T, want the termination FaceHandle", picks[len(picks)-1])
+	}
+}
+
+func kindsContain(ks []SelectionKind, want SelectionKind) bool {
+	for _, k := range ks {
+		if k == want {
+			return true
+		}
+	}
+	return false
+}

--- a/app/extrude_tool.go
+++ b/app/extrude_tool.go
@@ -29,6 +29,8 @@ type ExtrudeTool struct {
 	asymmetric      bool
 	operation       ops.PartFeatureOperation
 	added           *feature.PartFeature
+	toPlane         *feature.WorkPlane // "to face" termination target (a work plane or a face's plane)
+	toFace          *FaceHandle        // the picked termination face, for the highlight (nil for a work plane)
 }
 
 // NewExtrudeTool returns an extrude tool defaulting to a positive distance extrusion that
@@ -40,14 +42,41 @@ func NewExtrudeTool() *ExtrudeTool {
 // Name implements [Tool].
 func (t *ExtrudeTool) Name() string { return "Extrude" }
 
-// Start sets the selection filter to profiles (so clicks pick a region).
-func (t *ExtrudeTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectProfile)) }
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *ExtrudeTool) Start(*Session) {}
 
-// Pick captures the region the user clicked, replacing any previous selection (a plain
-// click selects a single region).
+// AcceptedKinds declares extrude's selection per step: it picks sketch regions (profiles), and
+// once at least one region is picked AND the extent is "to face", it switches to picking the
+// termination face (or work plane) the extrude runs up to — the engine re-derives this after each
+// pick, so the same tool drives both steps with no manual filter juggling.
+func (t *ExtrudeTool) AcceptedKinds() []SelectionKind {
+	if t.extent == feature.ToFaceExtent && len(t.profiles) > 0 {
+		return []SelectionKind{SelectFace, SelectWorkPlane}
+	}
+	return []SelectionKind{SelectProfile}
+}
+
+// Picks reports the picked regions plus the termination face for the unified highlight.
+func (t *ExtrudeTool) Picks() []Selectable {
+	picks := profileSelectables(t.profiles)
+	if t.toFace != nil {
+		picks = append(picks, *t.toFace)
+	}
+	return picks
+}
+
+// Pick captures the region the user clicked, or — during the "to face" step — the termination
+// face/work-plane the extrude runs up to. A plain region click selects a single region.
 func (t *ExtrudeTool) Pick(_ *Session, sel Selectable) {
-	if p, ok := sel.(ProfileHandle); ok {
-		t.profiles = []ProfileHandle{p}
+	switch h := sel.(type) {
+	case ProfileHandle:
+		t.profiles = []ProfileHandle{h}
+	case FaceHandle:
+		if pl, ok := sketchPlaneFromFace(h); ok {
+			t.toPlane, t.toFace = feature.NewFixedWorkPlane(pl), &h
+		}
+	case WorkPlaneHandle:
+		t.toPlane = h.Plane
 	}
 }
 
@@ -57,6 +86,7 @@ func (t *ExtrudeTool) Pick(_ *Session, sel Selectable) {
 func (t *ExtrudeTool) PickWithMods(s *Session, sel Selectable, mods Modifier) {
 	p, ok := sel.(ProfileHandle)
 	if !ok {
+		t.Pick(s, sel) // a "to face" termination pick (face/work-plane) — not a region
 		return
 	}
 	if !mods.Has(CtrlMod) {
@@ -131,6 +161,9 @@ func (t *ExtrudeTool) buildExtent() feature.Extent {
 			ext.Distance2 = func() float64 { return d2 }
 		}
 	}
+	if t.extent == feature.ToFaceExtent {
+		ext.ToPlane = t.toPlane
+	}
 	return ext
 }
 
@@ -153,10 +186,19 @@ func (t *ExtrudeTool) PickedProfile() (ProfileHandle, bool) {
 func (t *ExtrudeTool) SetOperation(op ops.PartFeatureOperation) { t.operation = op }
 func (t *ExtrudeTool) Operation() ops.PartFeatureOperation      { return t.operation }
 
-// CanCommit reports whether enough input is gathered: at least one region, and — for a
-// distance-gauged extent — a non-zero distance.
+// CanCommit reports whether enough input is gathered: at least one region, a non-zero distance
+// for a distance-gauged extent, and a termination target for a "to face" extent.
 func (t *ExtrudeTool) CanCommit() bool {
-	return len(t.profiles) > 0 && (!t.needsDistance() || t.distance != 0)
+	if len(t.profiles) == 0 {
+		return false
+	}
+	if t.needsDistance() && t.distance == 0 {
+		return false
+	}
+	if t.extent == feature.ToFaceExtent && t.toPlane == nil {
+		return false
+	}
+	return true
 }
 
 // Commit adds the extrude feature to the active part and recomputes; a sick feature
@@ -178,7 +220,6 @@ func (t *ExtrudeTool) Commit(s *Session) error {
 	if !t.added.Health().OK() {
 		return errors.New("extrude: " + t.added.Health().Reason)
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 
@@ -302,7 +343,6 @@ func (t *ExtrudeTool) Cancel(s *Session) {
 		cancelFeatureEdit(s, t.target, t.restoreDef)
 		return
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 }
 
 // activePart returns the active document's part component definition, or an error.

--- a/app/extrude_tool.go
+++ b/app/extrude_tool.go
@@ -58,11 +58,7 @@ func (t *ExtrudeTool) AcceptedKinds() []SelectionKind {
 
 // Picks reports the picked regions plus the termination face for the unified highlight.
 func (t *ExtrudeTool) Picks() []Selectable {
-	picks := profileSelectables(t.profiles)
-	if t.toFace != nil {
-		picks = append(picks, *t.toFace)
-	}
-	return picks
+	return appendPick(profileSelectables(t.profiles), t.toFace)
 }
 
 // Pick captures the region the user clicked, or — during the "to face" step — the termination

--- a/app/face_fillet_tool.go
+++ b/app/face_fillet_tool.go
@@ -28,8 +28,14 @@ func NewFaceFilletTool() *FaceFilletTool { return &FaceFilletTool{radius: 1} }
 // Name implements [Tool].
 func (t *FaceFilletTool) Name() string { return "Face Fillet" }
 
-// Start sets the selection filter to faces so clicks pick faces to round between.
-func (t *FaceFilletTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectFace)) }
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *FaceFilletTool) Start(*Session) {}
+
+// AcceptedKinds declares face-fillet picks faces (the two face sets to blend between).
+func (t *FaceFilletTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectFace} }
+
+// Picks reports every picked face for the unified highlight.
+func (t *FaceFilletTool) Picks() []Selectable { return faceSelectables(t.Faces()) }
 
 // Pick appends the clicked face to the active set, ignoring a face already in either set.
 func (t *FaceFilletTool) Pick(_ *Session, sel Selectable) {
@@ -117,7 +123,6 @@ func (t *FaceFilletTool) Commit(s *Session) error {
 	if !t.added.Health().OK() {
 		return errors.New("face fillet: " + t.added.Health().Reason)
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 
@@ -167,5 +172,4 @@ func (t *FaceFilletTool) Cancel(s *Session) {
 		cancelFeatureEdit(s, t.target, t.restoreDef)
 		return
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 }

--- a/app/face_offset_tool.go
+++ b/app/face_offset_tool.go
@@ -113,7 +113,7 @@ func (t *FaceOffsetTool) Prompt(*Session) string {
 }
 
 // Cancel restores the default selection filter.
-func (t *FaceOffsetTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *FaceOffsetTool) Cancel(*Session) {}
 
 // ClearFaces empties the picked faces — the property panel's selector clear (⊗) —
 // returning the tool to its pick-faces step.

--- a/app/face_offset_tool.go
+++ b/app/face_offset_tool.go
@@ -24,8 +24,14 @@ func NewFaceOffsetTool() *FaceOffsetTool { return &FaceOffsetTool{distance: 1} }
 // Name implements [Tool].
 func (t *FaceOffsetTool) Name() string { return "Offset Face" }
 
-// Start sets the selection filter to faces.
-func (t *FaceOffsetTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectFace)) }
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *FaceOffsetTool) Start(*Session) {}
+
+// AcceptedKinds declares offset-face picks faces (the faces to move).
+func (t *FaceOffsetTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectFace} }
+
+// Picks reports the picked faces for the unified highlight.
+func (t *FaceOffsetTool) Picks() []Selectable { return faceSelectables(t.faces) }
 
 // Pick appends the clicked face (ignoring a duplicate).
 func (t *FaceOffsetTool) Pick(_ *Session, sel Selectable) {
@@ -75,7 +81,6 @@ func (t *FaceOffsetTool) Commit(s *Session) error {
 	if !t.added.Health().OK() {
 		return errors.New("offset face: " + t.added.Health().Reason)
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 

--- a/app/feature_edit.go
+++ b/app/feature_edit.go
@@ -100,13 +100,23 @@ func (t *FeatureEditTool) Cancel(s *Session) {
 	})
 }
 
-// Arm puts the i-th reference slot into pick mode (its kind's filter); ClearSlot empties it.
+// Arm puts the i-th reference slot into pick mode; the engine then installs that slot's kind
+// filter from AcceptedKinds. ClearSlot empties it.
 func (t *FeatureEditTool) Arm(s *Session, i int) {
 	if i < 0 || i >= len(t.refs) {
 		return
 	}
 	t.armed = i
-	s.Selection().SetFilter(NewSelectionFilter(filterKinds(t.refs[i].Kind)...))
+	s.installToolFilter()
+}
+
+// AcceptedKinds declares the kinds the armed reference slot accepts (nil when no slot is armed, so
+// clicks fall through to the ambient filter and the tool's Pick ignores them).
+func (t *FeatureEditTool) AcceptedKinds() []SelectionKind {
+	if t.armed < 0 || t.armed >= len(t.refs) {
+		return nil
+	}
+	return filterKinds(t.refs[t.armed].Kind)
 }
 
 // ClearSlot removes every reference from the i-th slot and recomputes (no-op for a slot that
@@ -137,7 +147,7 @@ func (t *FeatureEditTool) ArmedSlot() int { return t.armed }
 
 func (t *FeatureEditTool) disarm(s *Session) {
 	t.armed = -1
-	s.Selection().SetFilter(NewSelectionFilter())
+	s.installToolFilter() // armed = -1 ⇒ no restriction (back to the ambient filter)
 }
 
 func (t *FeatureEditTool) recompute(s *Session) {

--- a/app/feature_edit_mode.go
+++ b/app/feature_edit_mode.go
@@ -54,7 +54,6 @@ func commitFeatureEdit(s *Session, f *feature.PartFeature) error {
 	part.Recompute()
 	s.recordEdit(part, "Edit "+f.Name())
 	s.EmitFeatureLifecycle(FeatureEdited, f) // featureEdited for UI-driven edits (#1085)
-	s.Selection().SetFilter(NewSelectionFilter())
 	if !f.Health().OK() {
 		return errors.New("feature edit: " + f.Health().Reason)
 	}
@@ -72,7 +71,6 @@ func cancelFeatureEdit(s *Session, f *feature.PartFeature, restore func()) {
 		part.Features().MarkDirty(f)
 		part.Recompute()
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 }
 
 // editToolFor builds the creation tool re-opened over a committed feature, or false for

--- a/app/feature_extra_tools.go
+++ b/app/feature_extra_tools.go
@@ -96,7 +96,7 @@ func (t *BossTool) Commit(s *Session) error {
 }
 
 // Cancel restores the default selection filter.
-func (t *BossTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *BossTool) Cancel(*Session) {}
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *BossTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/feature_extra_tools.go
+++ b/app/feature_extra_tools.go
@@ -34,8 +34,14 @@ func NewBossTool() *BossTool { return &BossTool{diameter: 1, height: 1} }
 // Name implements [Tool].
 func (t *BossTool) Name() string { return "Boss" }
 
-// Start filters selection to faces so clicks pick the placement face.
-func (t *BossTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectFace)) }
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *BossTool) Start(*Session) {}
+
+// AcceptedKinds declares boss picks a face (the placement face).
+func (t *BossTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectFace} }
+
+// Picks reports the placement face for the unified highlight.
+func (t *BossTool) Picks() []Selectable { return faceSelectables(t.Faces()) }
 
 // Pick captures the planar face the stud grows from.
 func (t *BossTool) Pick(_ *Session, sel Selectable) {
@@ -83,7 +89,6 @@ func (t *BossTool) Commit(s *Session) error {
 		Add(t.face.Face.ReferenceKey(), func() float64 { return d }, func() float64 { return h })
 	part.Recompute()
 	s.recordEdit(part, "Boss")
-	s.Selection().SetFilter(NewSelectionFilter())
 	if !t.added.Health().OK() {
 		return errors.New("boss: " + t.added.Health().Reason)
 	}
@@ -241,10 +246,14 @@ func NewDirectEditTool() *DirectEditTool {
 // Name implements [Tool].
 func (t *DirectEditTool) Name() string { return "Direct Edit" }
 
-// Start filters selection to faces.
-func (t *DirectEditTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectFace))
-}
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *DirectEditTool) Start(*Session) {}
+
+// AcceptedKinds declares direct-edit picks faces (the faces to move/rotate/scale/etc.).
+func (t *DirectEditTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectFace} }
+
+// Picks reports the picked faces for the unified highlight.
+func (t *DirectEditTool) Picks() []Selectable { return faceSelectables(t.faces) }
 
 // Pick collects the faces the operation acts on.
 func (t *DirectEditTool) Pick(_ *Session, sel Selectable) {
@@ -313,7 +322,6 @@ func (t *DirectEditTool) Commit(s *Session) error {
 	t.added = feature.NewModifyFeatures(part.Features()).AddDirectEdit(t.definition())
 	part.Recompute()
 	s.recordEdit(part, "Direct Edit")
-	s.Selection().SetFilter(NewSelectionFilter())
 	if !t.added.Health().OK() {
 		return errors.New("direct edit: " + t.added.Health().Reason)
 	}
@@ -350,7 +358,6 @@ func (t *DirectEditTool) fillOperationInputs(def *feature.DirectEditDefinition) 
 
 // Cancel restores the default selection filter.
 func (t *DirectEditTool) Cancel(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter())
 	t.faces = nil
 }
 

--- a/app/feature_modify_tools.go
+++ b/app/feature_modify_tools.go
@@ -37,11 +37,15 @@ type MoveFaceTool struct {
 	added      *feature.PartFeature
 }
 
-func NewMoveFaceTool() *MoveFaceTool { return &MoveFaceTool{} }
-func (t *MoveFaceTool) Name() string { return "Move Face" }
-func (t *MoveFaceTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectFace))
-}
+func NewMoveFaceTool() *MoveFaceTool   { return &MoveFaceTool{} }
+func (t *MoveFaceTool) Name() string   { return "Move Face" }
+func (t *MoveFaceTool) Start(*Session) {}
+
+// AcceptedKinds declares move-face picks faces (the faces to move).
+func (t *MoveFaceTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectFace} }
+
+// Picks reports the picked faces for the unified highlight.
+func (t *MoveFaceTool) Picks() []Selectable { return faceSelectables(t.faces) }
 
 func (t *MoveFaceTool) Pick(_ *Session, sel Selectable) {
 	if f, ok := sel.(FaceHandle); ok {
@@ -53,7 +57,6 @@ func (t *MoveFaceTool) Pick(_ *Session, sel Selectable) {
 func (t *MoveFaceTool) Faces() []FaceHandle { return append([]FaceHandle(nil), t.faces...) }
 
 func (t *MoveFaceTool) Cancel(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter())
 	t.faces = nil
 }
 
@@ -80,7 +83,6 @@ func (t *MoveFaceTool) Commit(s *Session) error {
 	t.added = feature.NewModifyFeatures(part.Features()).AddMoveFace(keys, math.V3(math.Scalar(t.dx), math.Scalar(t.dy), math.Scalar(t.dz)))
 	part.Recompute()
 	s.recordEdit(part, "Move Face")
-	s.Selection().SetFilter(NewSelectionFilter())
 	if !t.added.Health().OK() {
 		return errors.New("move face: " + t.added.Health().Reason)
 	}
@@ -105,11 +107,12 @@ type CombineTool struct {
 	added  *feature.PartFeature
 }
 
-func NewCombineTool() *CombineTool  { return &CombineTool{op: ops.Join} }
-func (t *CombineTool) Name() string { return "Combine" }
-func (t *CombineTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectBody))
-}
+func NewCombineTool() *CombineTool    { return &CombineTool{op: ops.Join} }
+func (t *CombineTool) Name() string   { return "Combine" }
+func (t *CombineTool) Start(*Session) {}
+
+// AcceptedKinds declares combine picks solid bodies (target then tool body).
+func (t *CombineTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectBody} }
 
 func (t *CombineTool) Pick(_ *Session, sel Selectable) {
 	if b, ok := sel.(BodyHandle); ok {
@@ -118,7 +121,6 @@ func (t *CombineTool) Pick(_ *Session, sel Selectable) {
 }
 
 func (t *CombineTool) Cancel(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter())
 	t.bodies = nil
 }
 
@@ -139,7 +141,6 @@ func (t *CombineTool) Commit(s *Session) error {
 	t.added = feature.NewModifyFeatures(part.Features()).AddCombine(ti, tj, t.op)
 	part.Recompute()
 	s.recordEdit(part, "Combine")
-	s.Selection().SetFilter(NewSelectionFilter())
 	if !t.added.Health().OK() {
 		return errors.New("combine: " + t.added.Health().Reason)
 	}
@@ -164,11 +165,12 @@ type MoveBodyTool struct {
 	added      *feature.PartFeature
 }
 
-func NewMoveBodyTool() *MoveBodyTool { return &MoveBodyTool{} }
-func (t *MoveBodyTool) Name() string { return "Move Bodies" }
-func (t *MoveBodyTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectBody))
-}
+func NewMoveBodyTool() *MoveBodyTool   { return &MoveBodyTool{} }
+func (t *MoveBodyTool) Name() string   { return "Move Bodies" }
+func (t *MoveBodyTool) Start(*Session) {}
+
+// AcceptedKinds declares move-bodies picks solid bodies (the bodies to move).
+func (t *MoveBodyTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectBody} }
 
 func (t *MoveBodyTool) Pick(_ *Session, sel Selectable) {
 	if b, ok := sel.(BodyHandle); ok {
@@ -177,7 +179,6 @@ func (t *MoveBodyTool) Pick(_ *Session, sel Selectable) {
 }
 
 func (t *MoveBodyTool) Cancel(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter())
 	t.bodies = nil
 }
 
@@ -205,7 +206,6 @@ func (t *MoveBodyTool) Commit(s *Session) error {
 	t.added = feature.NewModifyFeatures(part.Features()).AddMove(idx, xf)
 	part.Recompute()
 	s.recordEdit(part, "Move Bodies")
-	s.Selection().SetFilter(NewSelectionFilter())
 	if !t.added.Health().OK() {
 		return errors.New("move: " + t.added.Health().Reason)
 	}

--- a/app/fillet_tool.go
+++ b/app/fillet_tool.go
@@ -81,8 +81,14 @@ func (t *FilletTool) SetCornerTypeIndex(i int) {
 // Name implements [Tool].
 func (t *FilletTool) Name() string { return "Fillet" }
 
-// Start sets the selection filter to edges so clicks pick edges to round.
-func (t *FilletTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectEdge)) }
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *FilletTool) Start(*Session) {}
+
+// AcceptedKinds declares fillet picks edges (the edges to round).
+func (t *FilletTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectEdge} }
+
+// Picks reports the picked edges for the unified highlight.
+func (t *FilletTool) Picks() []Selectable { return edgeSelectables(t.Edges()) }
 
 // Pick appends the clicked edge (ignoring one already chosen).
 func (t *FilletTool) Pick(_ *Session, sel Selectable) {
@@ -177,7 +183,6 @@ func (t *FilletTool) Commit(s *Session) error {
 	if !t.added.Health().OK() {
 		return errors.New("fillet: " + t.added.Health().Reason)
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 
@@ -210,7 +215,6 @@ func (t *FilletTool) Cancel(s *Session) {
 		cancelFeatureEdit(s, t.target, t.restoreDef)
 		return
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 }
 
 // addFillet appends the picked edges in the active mode: the legacy constant-radius

--- a/app/full_round_fillet_tool.go
+++ b/app/full_round_fillet_tool.go
@@ -29,10 +29,14 @@ func NewFullRoundFilletTool() *FullRoundFilletTool { return &FullRoundFilletTool
 // Name implements [Tool].
 func (t *FullRoundFilletTool) Name() string { return "Full Round Fillet" }
 
-// Start sets the selection filter to faces so clicks pick the center and side faces.
-func (t *FullRoundFilletTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectFace))
-}
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *FullRoundFilletTool) Start(*Session) {}
+
+// AcceptedKinds declares full-round-fillet picks faces (the center and side face sets).
+func (t *FullRoundFilletTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectFace} }
+
+// Picks reports every picked face for the unified highlight.
+func (t *FullRoundFilletTool) Picks() []Selectable { return faceSelectables(t.Faces()) }
 
 // Pick appends the clicked face to the active set, ignoring a face already in any set.
 func (t *FullRoundFilletTool) Pick(_ *Session, sel Selectable) {
@@ -113,7 +117,6 @@ func (t *FullRoundFilletTool) Commit(s *Session) error {
 	if !t.added.Health().OK() {
 		return errors.New("full round fillet: " + t.added.Health().Reason)
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 
@@ -163,5 +166,4 @@ func (t *FullRoundFilletTool) Cancel(s *Session) {
 		cancelFeatureEdit(s, t.target, t.restoreDef)
 		return
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 }

--- a/app/grill_tool.go
+++ b/app/grill_tool.go
@@ -108,7 +108,7 @@ func (t *GrillTool) DraftFeature(*Session) (feature.Feature, bool) {
 }
 
 // Cancel restores the default selection filter.
-func (t *GrillTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *GrillTool) Cancel(*Session) {}
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *GrillTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/grill_tool.go
+++ b/app/grill_tool.go
@@ -24,8 +24,14 @@ func NewGrillTool() *GrillTool { return &GrillTool{} }
 // Name implements [Tool].
 func (t *GrillTool) Name() string { return "Grill" }
 
-// Start filters selection to closed regions so clicks pick a boundary profile.
-func (t *GrillTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectProfile)) }
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *GrillTool) Start(*Session) {}
+
+// AcceptedKinds declares grill picks closed boundary regions (profiles).
+func (t *GrillTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectProfile} }
+
+// Picks reports the picked boundaries for the unified highlight.
+func (t *GrillTool) Picks() []Selectable { return profileSelectables(t.profiles) }
 
 // Pick captures a single clicked region (replacing any previous selection).
 func (t *GrillTool) Pick(_ *Session, sel Selectable) {
@@ -80,7 +86,6 @@ func (t *GrillTool) Commit(s *Session) error {
 	if !t.added.Health().OK() {
 		return errors.New("grill: " + t.added.Health().Reason)
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 

--- a/app/grip_snap_tool.go
+++ b/app/grip_snap_tool.go
@@ -36,8 +36,14 @@ func NewGripSnapTool() *GripSnapTool { return &GripSnapTool{} }
 // Name is the tool's display name.
 func (t *GripSnapTool) Name() string { return "Grip Snap" }
 
-// Start restricts picking to component faces.
-func (t *GripSnapTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectFace)) }
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *GripSnapTool) Start(*Session) {}
+
+// AcceptedKinds declares grip-snap picks component faces (the moving face, then the target face).
+func (t *GripSnapTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectFace} }
+
+// Picks reports the picked faces for the unified highlight.
+func (t *GripSnapTool) Picks() []Selectable { return faceSelectables(t.faces) }
 
 // Pick appends a face until both the moving and the target geometry are chosen.
 func (t *GripSnapTool) Pick(_ *Session, sel Selectable) {
@@ -64,7 +70,6 @@ func (t *GripSnapTool) CanCommit() bool { return len(t.faces) == 2 }
 // Cancel abandons the picks and clears the filter.
 func (t *GripSnapTool) Cancel(s *Session) {
 	t.faces = nil
-	s.Selection().SetFilter(NewSelectionFilter())
 }
 
 // PreferIndex returns the selected Constraint override as a [GripSnapPreferOptions] index.
@@ -110,7 +115,6 @@ func (t *GripSnapTool) Commit(s *Session) error {
 	t.inferred = kind.String()
 	s.SetNotice(fmt.Sprintf("Grip Snap: created a %s constraint.", kind))
 	s.recordEdit(asm, c.Name())
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 

--- a/app/hole_tool.go
+++ b/app/hole_tool.go
@@ -45,12 +45,7 @@ func (t *HoleTool) Start(*Session) {}
 func (t *HoleTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectFace} }
 
 // Picks reports the placement face for the unified highlight.
-func (t *HoleTool) Picks() []Selectable {
-	if t.face == nil {
-		return nil
-	}
-	return []Selectable{*t.face}
-}
+func (t *HoleTool) Picks() []Selectable { return singlePick(t.face) }
 
 // Pick captures the planar face the user clicked.
 func (t *HoleTool) Pick(_ *Session, sel Selectable) {

--- a/app/hole_tool.go
+++ b/app/hole_tool.go
@@ -38,8 +38,19 @@ func NewHoleTool() *HoleTool {
 // Name implements [Tool].
 func (t *HoleTool) Name() string { return "Hole" }
 
-// Start sets the selection filter to faces so clicks pick a placement face.
-func (t *HoleTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectFace)) }
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *HoleTool) Start(*Session) {}
+
+// AcceptedKinds declares hole picks a face (the placement face).
+func (t *HoleTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectFace} }
+
+// Picks reports the placement face for the unified highlight.
+func (t *HoleTool) Picks() []Selectable {
+	if t.face == nil {
+		return nil
+	}
+	return []Selectable{*t.face}
+}
 
 // Pick captures the planar face the user clicked.
 func (t *HoleTool) Pick(_ *Session, sel Selectable) {
@@ -163,7 +174,6 @@ func (t *HoleTool) Commit(s *Session) error {
 	if !t.added.Health().OK() {
 		return errors.New("hole: " + t.added.Health().Reason)
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 
@@ -247,5 +257,4 @@ func (t *HoleTool) Cancel(s *Session) {
 		cancelFeatureEdit(s, t.target, t.restoreDef)
 		return
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 }

--- a/app/lip_tool.go
+++ b/app/lip_tool.go
@@ -26,8 +26,14 @@ func NewLipTool() *LipTool { return &LipTool{width: 1, height: 1} }
 // Name implements [Tool].
 func (t *LipTool) Name() string { return "Lip" }
 
-// Start sets the selection filter to edges so clicks pick the bead path.
-func (t *LipTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectEdge)) }
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *LipTool) Start(*Session) {}
+
+// AcceptedKinds declares lip picks edges (the edges to build the lip/groove along).
+func (t *LipTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectEdge} }
+
+// Picks reports the picked edges for the unified highlight.
+func (t *LipTool) Picks() []Selectable { return edgeSelectables(t.Edges()) }
 
 // Pick appends the clicked edge (ignoring one already chosen, so a double-click does not
 // duplicate it).
@@ -86,7 +92,6 @@ func (t *LipTool) Commit(s *Session) error {
 	if !t.added.Health().OK() {
 		return errors.New("lip: " + t.added.Health().Reason)
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 

--- a/app/lip_tool.go
+++ b/app/lip_tool.go
@@ -121,7 +121,7 @@ func (t *LipTool) DraftFeature(*Session) (feature.Feature, bool) {
 }
 
 // Cancel restores the default selection filter.
-func (t *LipTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *LipTool) Cancel(*Session) {}
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *LipTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/loft_tool.go
+++ b/app/loft_tool.go
@@ -50,11 +50,18 @@ func NewLoftTool() *LoftTool { return &LoftTool{operation: ops.NewBody} }
 // Name implements [Tool].
 func (t *LoftTool) Name() string { return "Loft" }
 
-// Start lets clicks pick sketch regions (profiles), points (vertices / work points) for an apex,
-// a body face the loft can leave tangent, or an open sketch path as a guide rail.
-func (t *LoftTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectProfile, SelectVertex, SelectWorkPoint, SelectFace, SelectPath))
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *LoftTool) Start(*Session) {}
+
+// AcceptedKinds declares loft picks sketch regions (profiles), points (vertices / work points) for
+// an apex, a body face it can leave tangent, or an open sketch path as a guide rail.
+func (t *LoftTool) AcceptedKinds() []SelectionKind {
+	return []SelectionKind{SelectProfile, SelectVertex, SelectWorkPoint, SelectFace, SelectPath}
 }
+
+// Picks reports the picked profile cross-sections for the unified highlight (point/face sections
+// have nothing to outline, matching the prior PickedProfiles-based highlight).
+func (t *LoftTool) Picks() []Selectable { return profileSelectables(t.PickedProfiles()) }
 
 // Pick routes the clicked entity: a profile/point/face is the next cross-section (a profile
 // already in the list is ignored so a double-click doesn't duplicate it); an open path is a
@@ -168,7 +175,6 @@ func (t *LoftTool) Commit(s *Session) error {
 	if !t.added.Health().OK() {
 		return errors.New("loft: " + t.added.Health().Reason)
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 

--- a/app/loft_tool.go
+++ b/app/loft_tool.go
@@ -283,7 +283,7 @@ func (t *LoftTool) DraftFeature(*Session) (feature.Feature, bool) {
 }
 
 // Cancel restores the default selection filter.
-func (t *LoftTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *LoftTool) Cancel(*Session) {}
 
 // ClearSections empties the picked cross-sections — the property panel's selector
 // clear (⊗) on the Sections chip.

--- a/app/measure_tool.go
+++ b/app/measure_tool.go
@@ -30,9 +30,12 @@ func NewMeasureTool() *MeasureTool { return &MeasureTool{} }
 // Name is the tool's display name.
 func (t *MeasureTool) Name() string { return "Measure" }
 
-// Start lets the user pick any face, edge or vertex.
-func (t *MeasureTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectFace, SelectEdge, SelectVertex))
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *MeasureTool) Start(*Session) {}
+
+// AcceptedKinds declares measure picks faces, edges and vertices (the entities it measures).
+func (t *MeasureTool) AcceptedKinds() []SelectionKind {
+	return []SelectionKind{SelectFace, SelectEdge, SelectVertex}
 }
 
 // Pick adds an entity (starting a fresh selection when the pick can't extend the current one) and
@@ -93,11 +96,10 @@ func (t *MeasureTool) Commit(s *Session) error {
 	return nil
 }
 
-// Cancel clears the picks and the filter.
-func (t *MeasureTool) Cancel(s *Session) {
+// Cancel clears the picks; the engine restores the ambient filter.
+func (t *MeasureTool) Cancel(*Session) {
 	t.picks = nil
 	t.readout = ""
-	s.Selection().SetFilter(NewSelectionFilter())
 }
 
 // measurePickFrom resolves a selection handle to a measurement entity.

--- a/app/measure_tool.go
+++ b/app/measure_tool.go
@@ -92,7 +92,6 @@ func (t *MeasureTool) CanCommit() bool { return len(t.picks) > 0 }
 
 // Commit closes the tool, leaving the last readout in the status bar.
 func (t *MeasureTool) Commit(s *Session) error {
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 

--- a/app/offset_plane_tool.go
+++ b/app/offset_plane_tool.go
@@ -19,7 +19,6 @@ type OffsetWorkPlaneTool struct {
 	hasBase  bool
 	distance float64 // offset in model units; 0 until the user sets it (so OK stays disabled)
 	added    *feature.WorkPlane
-	prev     *SelectionFilter
 }
 
 // NewOffsetWorkPlaneTool returns an offset-plane tool awaiting a plane pick and distance.
@@ -28,15 +27,18 @@ func NewOffsetWorkPlaneTool() *OffsetWorkPlaneTool { return &OffsetWorkPlaneTool
 // Name implements [Tool].
 func (t *OffsetWorkPlaneTool) Name() string { return "Offset Plane" }
 
-// Start filters selection to work planes and planar faces and seeds the base from a
-// pre-selected plane (so a user who picked a plane first only needs to enter the distance).
+// Start seeds the base from a pre-selected plane (so a user who picked a plane first only needs to
+// enter the distance); the engine installs the filter from AcceptedKinds.
 func (t *OffsetWorkPlaneTool) Start(s *Session) {
-	t.prev = s.Selection().Filter()
 	if wp := s.SelectedWorkPlane(); wp != nil {
 		t.baseRef, t.hasBase = wp.Key(), true
 	}
 	s.Selection().Clear()
-	s.Selection().SetFilter(NewSelectionFilter(SelectWorkPlane, SelectFace))
+}
+
+// AcceptedKinds declares offset-plane picks the plane or planar face to offset from.
+func (t *OffsetWorkPlaneTool) AcceptedKinds() []SelectionKind {
+	return []SelectionKind{SelectWorkPlane, SelectFace}
 }
 
 // Pick records the plane or planar face to offset from.
@@ -64,7 +66,6 @@ func (t *OffsetWorkPlaneTool) CanCommit() bool { return t.hasBase && t.distance 
 
 // Commit creates the offset work plane at the entered distance and recomputes.
 func (t *OffsetWorkPlaneTool) Commit(s *Session) error {
-	s.Selection().SetFilter(t.prev)
 	if !t.hasBase {
 		return errors.New("offset plane: no base plane or face picked")
 	}
@@ -78,8 +79,8 @@ func (t *OffsetWorkPlaneTool) Commit(s *Session) error {
 	return nil
 }
 
-// Cancel restores the prior selection filter with no change.
-func (t *OffsetWorkPlaneTool) Cancel(s *Session) { s.Selection().SetFilter(t.prev) }
+// Cancel is a no-op; the engine restores the ambient filter.
+func (t *OffsetWorkPlaneTool) Cancel(*Session) {}
 
 // Prompt guides the user through the two steps (Inventor's status-bar prompts).
 func (t *OffsetWorkPlaneTool) Prompt(*Session) string {

--- a/app/patch_tool.go
+++ b/app/patch_tool.go
@@ -22,8 +22,19 @@ func NewPatchTool() *PatchTool { return &PatchTool{} }
 // Name implements [Tool].
 func (t *PatchTool) Name() string { return "Patch" }
 
-// Start filters selection to closed regions.
-func (t *PatchTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectProfile)) }
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *PatchTool) Start(*Session) {}
+
+// AcceptedKinds declares patch picks a closed sketch region (profile).
+func (t *PatchTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectProfile} }
+
+// Picks reports the picked region for the unified highlight.
+func (t *PatchTool) Picks() []Selectable {
+	if t.profile == nil {
+		return nil
+	}
+	return []Selectable{*t.profile}
+}
 
 // Pick captures the clicked closed region.
 func (t *PatchTool) Pick(_ *Session, sel Selectable) {
@@ -59,7 +70,6 @@ func (t *PatchTool) Commit(s *Session) error {
 	if !t.added.Health().OK() {
 		return errors.New("patch: " + t.added.Health().Reason)
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 

--- a/app/patch_tool.go
+++ b/app/patch_tool.go
@@ -29,12 +29,7 @@ func (t *PatchTool) Start(*Session) {}
 func (t *PatchTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectProfile} }
 
 // Picks reports the picked region for the unified highlight.
-func (t *PatchTool) Picks() []Selectable {
-	if t.profile == nil {
-		return nil
-	}
-	return []Selectable{*t.profile}
-}
+func (t *PatchTool) Picks() []Selectable { return singlePick(t.profile) }
 
 // Pick captures the clicked closed region.
 func (t *PatchTool) Pick(_ *Session, sel Selectable) {

--- a/app/patch_tool.go
+++ b/app/patch_tool.go
@@ -89,7 +89,7 @@ func (t *PatchTool) DraftFeature(*Session) (feature.Feature, bool) {
 }
 
 // Cancel restores the default selection filter.
-func (t *PatchTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *PatchTool) Cancel(*Session) {}
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *PatchTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/replace_face_tool.go
+++ b/app/replace_face_tool.go
@@ -24,8 +24,20 @@ func NewReplaceFaceTool() *ReplaceFaceTool { return &ReplaceFaceTool{} }
 // Name implements [Tool].
 func (t *ReplaceFaceTool) Name() string { return "Replace Face" }
 
-// Start sets the selection filter to faces.
-func (t *ReplaceFaceTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectFace)) }
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *ReplaceFaceTool) Start(*Session) {}
+
+// AcceptedKinds declares replace-face picks faces (the faces to replace, then the target face).
+func (t *ReplaceFaceTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectFace} }
+
+// Picks reports the faces to replace plus the target face for the unified highlight.
+func (t *ReplaceFaceTool) Picks() []Selectable {
+	picks := faceSelectables(t.faces)
+	if t.target != nil {
+		picks = append(picks, *t.target)
+	}
+	return picks
+}
 
 // Pick routes a click to the target slot when in target mode, else appends a face to replace.
 func (t *ReplaceFaceTool) Pick(_ *Session, sel Selectable) {
@@ -85,7 +97,6 @@ func (t *ReplaceFaceTool) Commit(s *Session) error {
 	if !t.added.Health().OK() {
 		return errors.New("replace face: " + t.added.Health().Reason)
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 

--- a/app/replace_face_tool.go
+++ b/app/replace_face_tool.go
@@ -32,11 +32,7 @@ func (t *ReplaceFaceTool) AcceptedKinds() []SelectionKind { return []SelectionKi
 
 // Picks reports the faces to replace plus the target face for the unified highlight.
 func (t *ReplaceFaceTool) Picks() []Selectable {
-	picks := faceSelectables(t.faces)
-	if t.target != nil {
-		picks = append(picks, *t.target)
-	}
-	return picks
+	return appendPick(faceSelectables(t.faces), t.target)
 }
 
 // Pick routes a click to the target slot when in target mode, else appends a face to replace.

--- a/app/replace_face_tool.go
+++ b/app/replace_face_tool.go
@@ -130,7 +130,7 @@ func (t *ReplaceFaceTool) Prompt(*Session) string {
 }
 
 // Cancel restores the default selection filter.
-func (t *ReplaceFaceTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *ReplaceFaceTool) Cancel(*Session) {}
 
 // ClearFaces / ClearTarget empty one pick set each — the property panel's selector
 // clear (⊗) affordances on the replace-faces and target chips.

--- a/app/rest_tool.go
+++ b/app/rest_tool.go
@@ -113,7 +113,7 @@ func (t *RestTool) DraftFeature(*Session) (feature.Feature, bool) {
 }
 
 // Cancel restores the default selection filter.
-func (t *RestTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *RestTool) Cancel(*Session) {}
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *RestTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/rest_tool.go
+++ b/app/rest_tool.go
@@ -25,8 +25,14 @@ func NewRestTool() *RestTool { return &RestTool{depth: 1} }
 // Name implements [Tool].
 func (t *RestTool) Name() string { return "Rest" }
 
-// Start filters selection to closed regions so clicks pick a profile.
-func (t *RestTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectProfile)) }
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *RestTool) Start(*Session) {}
+
+// AcceptedKinds declares rest picks closed sketch regions (profiles).
+func (t *RestTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectProfile} }
+
+// Picks reports the picked regions for the unified highlight.
+func (t *RestTool) Picks() []Selectable { return profileSelectables(t.profiles) }
 
 // Pick captures a single clicked region (replacing any previous selection).
 func (t *RestTool) Pick(_ *Session, sel Selectable) {
@@ -86,7 +92,6 @@ func (t *RestTool) Commit(s *Session) error {
 	if !t.added.Health().OK() {
 		return errors.New("rest: " + t.added.Health().Reason)
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 

--- a/app/revolve_tool.go
+++ b/app/revolve_tool.go
@@ -68,8 +68,29 @@ func NewRevolveTool() *RevolveTool {
 // Name implements [Tool].
 func (t *RevolveTool) Name() string { return "Revolve" }
 
-// Start sets the selection filter to profiles so clicks pick a region.
-func (t *RevolveTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectProfile)) }
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *RevolveTool) Start(*Session) {}
+
+// AcceptedKinds declares revolve's two steps: pick the region (profile), then — once a profile is
+// set — pick the centerline axis (a sketch entity). The engine re-derives this after each pick.
+func (t *RevolveTool) AcceptedKinds() []SelectionKind {
+	if t.profile == nil {
+		return []SelectionKind{SelectProfile}
+	}
+	return []SelectionKind{SelectSketchEntity}
+}
+
+// Picks reports the picked region and centerline for the unified highlight.
+func (t *RevolveTool) Picks() []Selectable {
+	var picks []Selectable
+	if t.profile != nil {
+		picks = append(picks, *t.profile)
+	}
+	if t.centerline != nil {
+		picks = append(picks, SketchEntityHandle{Entity: t.centerline})
+	}
+	return picks
+}
 
 // Pick captures the region (then auto-advances to the centerline axis, pre-selecting one per
 // Inventor's rules) or, once a profile is set, a centerline the user clicks to override it.
@@ -93,7 +114,7 @@ func (t *RevolveTool) advanceToCenterline(s *Session) {
 	if sk, line, ok := preselectCenterline(t.profile.Sketch, visiblePartSketches(s)); ok {
 		t.centerline, t.centerlineSk = line, sk
 	}
-	s.Selection().SetFilter(NewSelectionFilter(SelectSketchEntity))
+	// The engine re-derives the filter (now SketchEntity) from AcceptedKinds after this pick.
 }
 
 // visiblePartSketches returns the active part's visible 2D sketches (the centerline candidates).
@@ -341,7 +362,6 @@ func (t *RevolveTool) Cancel(s *Session) {
 		cancelFeatureEdit(s, t.target, t.restoreDef)
 		return
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 }
 
 // FullTurn is the swept angle of a complete revolution, for the property window's

--- a/app/revolve_tool.go
+++ b/app/revolve_tool.go
@@ -270,7 +270,6 @@ func (t *RevolveTool) Commit(s *Session) error {
 	if !t.added.Health().OK() {
 		return errors.New("revolve: " + t.added.Health().Reason)
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 

--- a/app/selecting.go
+++ b/app/selecting.go
@@ -79,10 +79,9 @@ func (s *Session) installToolFilter() {
 // ambient setting. The Session calls it when a tool ends (commit/cancel).
 func (s *Session) restoreSelectionFilter() { s.selection.SetFilter(NewSelectionFilter()) }
 
-// ToolPicks returns the active tool's current picks — the uniform source the head highlights. A
-// tool implementing the Picking contract reports them directly; tools not yet migrated fall back
-// to the legacy duck-typed accessors (legacyToolPicks) so highlighting keeps working through the
-// migration. The fallback is removed once every selecting tool implements Picking.
+// ToolPicks returns the active tool's current picks — the uniform source the head highlights,
+// from the Picking contract. A tool that does not implement Picking contributes nothing (its
+// feedback, if any, comes from a dedicated overlay).
 func (s *Session) ToolPicks() []Selectable {
 	if s.tool == nil {
 		return nil
@@ -90,36 +89,5 @@ func (s *Session) ToolPicks() []Selectable {
 	if p, ok := s.tool.tool.(Picking); ok {
 		return p.Picks()
 	}
-	return legacyToolPicks(s.tool.tool)
-}
-
-// legacyToolPicks gathers a not-yet-migrated tool's picks from whichever bespoke accessor it
-// happens to implement. TRANSITIONAL: delete once all tools implement Picking.
-func legacyToolPicks(t Tool) []Selectable {
-	var picks []Selectable
-	if el, ok := t.(interface{ Edges() []EdgeHandle }); ok {
-		for _, e := range el.Edges() {
-			picks = append(picks, e)
-		}
-	}
-	if fl, ok := t.(interface{ Faces() []FaceHandle }); ok {
-		for _, f := range fl.Faces() {
-			picks = append(picks, f)
-		}
-	}
-	if pl, ok := t.(interface{ PickedProfiles() []ProfileHandle }); ok {
-		for _, p := range pl.PickedProfiles() {
-			picks = append(picks, p)
-		}
-	} else if pp, ok := t.(interface{ PickedProfile() (ProfileHandle, bool) }); ok {
-		if ph, has := pp.PickedProfile(); has {
-			picks = append(picks, ph)
-		}
-	}
-	if hf, ok := t.(interface{ PickedFace() (FaceHandle, bool) }); ok {
-		if fh, has := hf.PickedFace(); has {
-			picks = append(picks, fh)
-		}
-	}
-	return picks
+	return nil
 }

--- a/app/selecting.go
+++ b/app/selecting.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// The selection engine: tools DECLARE what they select (Selecting) and REPORT what they have
+// picked (Picking), and the Session centrally derives the active selection filter from those
+// declarations. This replaces the old pattern where every tool imperatively called
+// Selection().SetFilter(...) in Start/Cancel/Commit and exposed bespoke pick accessors — a
+// source of inconsistent highlighting and filter bugs (e.g. a tool that forgot to accept a
+// kind, or named its accessor so the head could not find it). With these contracts the host
+// owns filtering and highlighting uniformly for every tool. See ADR-0041.
+
+// Selecting is implemented by every interactive tool that picks geometry. AcceptedKinds reports
+// the selection kinds pickable AT THE TOOL'S CURRENT STEP — it is re-read after each pick, so a
+// multi-step tool returns different kinds as it advances (e.g. Extrude: a profile, then, once a
+// "to face" extent is chosen, a termination face). An empty result means "no restriction": the
+// session falls back to the ambient SelectionFilterState (the user's Selection Filter, #1222).
+type Selecting interface {
+	AcceptedKinds() []SelectionKind
+}
+
+// Picking exposes what a tool has selected so far, as a uniform list — the single contract the
+// head reads to highlight a tool's picks (replacing the previous duck-typed accessors). Order is
+// the tool's pick order; the head highlights each by its SelectionKind.
+type Picking interface {
+	Picks() []Selectable
+}
+
+// installToolFilter derives the active selection filter from the running tool's declaration. A
+// tool implementing Selecting with a non-empty AcceptedKinds gets exactly those kinds; an empty
+// declaration (or a tool that does not implement Selecting) leaves the filter unrestricted so the
+// ambient SelectionFilterState applies via pickFilter. Called on tool start and after every pick
+// so per-step kind changes take effect immediately.
+func (s *Session) installToolFilter() {
+	if s.tool == nil {
+		return
+	}
+	sel, ok := s.tool.tool.(Selecting)
+	if !ok {
+		return // a tool that does not declare its selection manages its own filter (or none)
+	}
+	if kinds := sel.AcceptedKinds(); len(kinds) > 0 {
+		s.selection.SetFilter(NewSelectionFilter(kinds...))
+		return
+	}
+	s.restoreSelectionFilter()
+}
+
+// restoreSelectionFilter returns the stored filter to unrestricted (accept-all). It is NOT a
+// reset to "select anything": when no tool is active, pickFilter layers the user's ambient
+// SelectionFilterState on top of an unrestricted filter, so this hands selection back to the
+// ambient setting. The Session calls it when a tool ends (commit/cancel).
+func (s *Session) restoreSelectionFilter() { s.selection.SetFilter(NewSelectionFilter()) }
+
+// toolPicks returns the active tool's current picks via the Picking contract, or nil — the
+// uniform source the head highlights. Tools that do not implement Picking contribute nothing
+// here (their feedback, if any, comes from a dedicated overlay).
+func (s *Session) toolPicks() []Selectable {
+	if s.tool == nil {
+		return nil
+	}
+	if p, ok := s.tool.tool.(Picking); ok {
+		return p.Picks()
+	}
+	return nil
+}

--- a/app/selecting.go
+++ b/app/selecting.go
@@ -52,15 +52,47 @@ func (s *Session) installToolFilter() {
 // ambient setting. The Session calls it when a tool ends (commit/cancel).
 func (s *Session) restoreSelectionFilter() { s.selection.SetFilter(NewSelectionFilter()) }
 
-// toolPicks returns the active tool's current picks via the Picking contract, or nil — the
-// uniform source the head highlights. Tools that do not implement Picking contribute nothing
-// here (their feedback, if any, comes from a dedicated overlay).
-func (s *Session) toolPicks() []Selectable {
+// ToolPicks returns the active tool's current picks — the uniform source the head highlights. A
+// tool implementing the Picking contract reports them directly; tools not yet migrated fall back
+// to the legacy duck-typed accessors (legacyToolPicks) so highlighting keeps working through the
+// migration. The fallback is removed once every selecting tool implements Picking.
+func (s *Session) ToolPicks() []Selectable {
 	if s.tool == nil {
 		return nil
 	}
 	if p, ok := s.tool.tool.(Picking); ok {
 		return p.Picks()
 	}
-	return nil
+	return legacyToolPicks(s.tool.tool)
+}
+
+// legacyToolPicks gathers a not-yet-migrated tool's picks from whichever bespoke accessor it
+// happens to implement. TRANSITIONAL: delete once all tools implement Picking.
+func legacyToolPicks(t Tool) []Selectable {
+	var picks []Selectable
+	if el, ok := t.(interface{ Edges() []EdgeHandle }); ok {
+		for _, e := range el.Edges() {
+			picks = append(picks, e)
+		}
+	}
+	if fl, ok := t.(interface{ Faces() []FaceHandle }); ok {
+		for _, f := range fl.Faces() {
+			picks = append(picks, f)
+		}
+	}
+	if pl, ok := t.(interface{ PickedProfiles() []ProfileHandle }); ok {
+		for _, p := range pl.PickedProfiles() {
+			picks = append(picks, p)
+		}
+	} else if pp, ok := t.(interface{ PickedProfile() (ProfileHandle, bool) }); ok {
+		if ph, has := pp.PickedProfile(); has {
+			picks = append(picks, ph)
+		}
+	}
+	if hf, ok := t.(interface{ PickedFace() (FaceHandle, bool) }); ok {
+		if fh, has := hf.PickedFace(); has {
+			picks = append(picks, fh)
+		}
+	}
+	return picks
 }

--- a/app/selecting.go
+++ b/app/selecting.go
@@ -26,6 +26,33 @@ type Picking interface {
 	Picks() []Selectable
 }
 
+// faceSelectables / edgeSelectables / profileSelectables / vertexSelectables widen a tool's typed
+// pick slice to []Selectable for its Picks() implementation, so the engine highlights them
+// uniformly without each tool writing a loop.
+func faceSelectables(fs []FaceHandle) []Selectable {
+	out := make([]Selectable, len(fs))
+	for i, f := range fs {
+		out[i] = f
+	}
+	return out
+}
+
+func edgeSelectables(es []EdgeHandle) []Selectable {
+	out := make([]Selectable, len(es))
+	for i, e := range es {
+		out[i] = e
+	}
+	return out
+}
+
+func profileSelectables(ps []ProfileHandle) []Selectable {
+	out := make([]Selectable, len(ps))
+	for i, p := range ps {
+		out[i] = p
+	}
+	return out
+}
+
 // installToolFilter derives the active selection filter from the running tool's declaration. A
 // tool implementing Selecting with a non-empty AcceptedKinds gets exactly those kinds; an empty
 // declaration (or a tool that does not implement Selecting) leaves the filter unrestricted so the

--- a/app/selecting.go
+++ b/app/selecting.go
@@ -26,9 +26,19 @@ type Picking interface {
 	Picks() []Selectable
 }
 
-// faceSelectables / edgeSelectables / profileSelectables / vertexSelectables widen a tool's typed
-// pick slice to []Selectable for its Picks() implementation, so the engine highlights them
-// uniformly without each tool writing a loop.
+// singlePick widens a tool's optional single pick (a *FaceHandle/*EdgeHandle/*ProfileHandle, nil
+// until picked) to the []Selectable its Picks() returns — the shared form of the common
+// "one optional pick" tool, so each does not repeat the nil-check.
+func singlePick[T Selectable](p *T) []Selectable {
+	if p == nil {
+		return nil
+	}
+	return []Selectable{*p}
+}
+
+// faceSelectables / edgeSelectables / profileSelectables widen a tool's typed pick slice to
+// []Selectable for its Picks() implementation, so the engine highlights them uniformly without
+// each tool writing a loop.
 func faceSelectables(fs []FaceHandle) []Selectable {
 	out := make([]Selectable, len(fs))
 	for i, f := range fs {

--- a/app/selecting.go
+++ b/app/selecting.go
@@ -36,6 +36,15 @@ func singlePick[T Selectable](p *T) []Selectable {
 	return []Selectable{*p}
 }
 
+// appendPick appends a tool's optional single pick (nil until picked) to its running Picks() list —
+// the shared form of a multi-step tool that reports a base set plus one further pick.
+func appendPick[T Selectable](picks []Selectable, p *T) []Selectable {
+	if p == nil {
+		return picks
+	}
+	return append(picks, *p)
+}
+
 // faceSelectables / edgeSelectables / profileSelectables widen a tool's typed pick slice to
 // []Selectable for its Picks() implementation, so the engine highlights them uniformly without
 // each tool writing a loop.
@@ -59,6 +68,14 @@ func profileSelectables(ps []ProfileHandle) []Selectable {
 	out := make([]Selectable, len(ps))
 	for i, p := range ps {
 		out[i] = p
+	}
+	return out
+}
+
+func vertexSelectables(vs []VertexHandle) []Selectable {
+	out := make([]Selectable, len(vs))
+	for i, v := range vs {
+		out[i] = v
 	}
 	return out
 }

--- a/app/selecting_test.go
+++ b/app/selecting_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "testing"
+
+// fakeSelectingTool is a minimal tool that declares its accepted kinds (changing after the first
+// pick, like a multi-step tool) and reports its picks — exercising the selection engine without
+// any real geometry.
+type fakeSelectingTool struct {
+	step      int
+	picks     []Selectable
+	commitErr error
+}
+
+func (t *fakeSelectingTool) Name() string   { return "Fake" }
+func (t *fakeSelectingTool) Start(*Session) {}
+func (t *fakeSelectingTool) Pick(_ *Session, sel Selectable) {
+	t.picks = append(t.picks, sel)
+	t.step++
+}
+func (t *fakeSelectingTool) CanCommit() bool       { return false }
+func (t *fakeSelectingTool) Commit(*Session) error { return t.commitErr }
+func (t *fakeSelectingTool) Cancel(*Session)       {}
+func (t *fakeSelectingTool) Picks() []Selectable   { return t.picks }
+func (t *fakeSelectingTool) AcceptedKinds() []SelectionKind {
+	if t.step == 0 {
+		return []SelectionKind{SelectProfile}
+	}
+	return []SelectionKind{SelectFace, SelectWorkPlane} // a later step accepts a termination face
+}
+
+func TestStartToolInstallsDeclaredFilter(t *testing.T) {
+	s := NewSession()
+	s.StartTool(&fakeSelectingTool{})
+	f := s.Selection().Filter()
+	if !f.Accepts(SelectProfile) || f.Accepts(SelectFace) {
+		t.Fatalf("start step filter = %+v, want only profiles", f)
+	}
+}
+
+func TestFeedPickReinstallsFilterForNextStep(t *testing.T) {
+	s := NewSession()
+	tool := &fakeSelectingTool{}
+	s.StartTool(tool)
+	s.feedPick(ProfileHandle{}) // advance to step 1
+	f := s.Selection().Filter()
+	if !f.Accepts(SelectFace) || f.Accepts(SelectProfile) {
+		t.Fatalf("after the first pick the filter = %+v, want the next step's face/plane kinds", f)
+	}
+}
+
+// emptyKindsTool declares no restriction, so the engine must leave the filter unrestricted (the
+// ambient SelectionFilterState then governs via pickFilter).
+type emptyKindsTool struct{ fakeSelectingTool }
+
+func (emptyKindsTool) AcceptedKinds() []SelectionKind { return nil }
+
+func TestEmptyAcceptedKindsLeavesFilterUnrestricted(t *testing.T) {
+	s := NewSession()
+	s.StartTool(&emptyKindsTool{})
+	if s.Selection().Filter().IsRestricted() {
+		t.Fatal("a tool declaring no kinds must leave the filter unrestricted for the ambient state")
+	}
+}
+
+func TestCommitRestoresUnrestrictedFilter(t *testing.T) {
+	s := NewSession()
+	tool := &fakeSelectingTool{}
+	s.StartTool(tool)
+	if !s.Selection().Filter().IsRestricted() {
+		t.Fatal("the tool's declared filter should be restricted while it runs")
+	}
+	tool.commitErr = nil
+	// Make it committable so OK clears it.
+	s.tool.tool = &committableSelectingTool{}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if s.Selection().Filter().IsRestricted() {
+		t.Fatal("after commit the filter must be unrestricted (handed back to the ambient state)")
+	}
+}
+
+func TestCancelRestoresUnrestrictedFilter(t *testing.T) {
+	s := NewSession()
+	s.StartTool(&fakeSelectingTool{})
+	s.CancelTool()
+	if s.Selection().Filter().IsRestricted() {
+		t.Fatal("after cancel the filter must be unrestricted")
+	}
+}
+
+// committableSelectingTool is ready to commit immediately, for the OK path.
+type committableSelectingTool struct{ fakeSelectingTool }
+
+func (committableSelectingTool) CanCommit() bool { return true }
+
+func TestToolPicksReportsViaPickingContract(t *testing.T) {
+	s := NewSession()
+	tool := &fakeSelectingTool{}
+	s.StartTool(tool)
+	s.feedPick(EdgeHandle{})
+	got := s.toolPicks()
+	if len(got) != 1 {
+		t.Fatalf("toolPicks = %d, want 1 picked edge", len(got))
+	}
+	if _, ok := got[0].(EdgeHandle); !ok {
+		t.Fatalf("toolPicks[0] = %T, want EdgeHandle", got[0])
+	}
+}

--- a/app/selecting_test.go
+++ b/app/selecting_test.go
@@ -101,11 +101,11 @@ func TestToolPicksReportsViaPickingContract(t *testing.T) {
 	tool := &fakeSelectingTool{}
 	s.StartTool(tool)
 	s.feedPick(EdgeHandle{})
-	got := s.toolPicks()
+	got := s.ToolPicks()
 	if len(got) != 1 {
-		t.Fatalf("toolPicks = %d, want 1 picked edge", len(got))
+		t.Fatalf("ToolPicks = %d, want 1 picked edge", len(got))
 	}
 	if _, ok := got[0].(EdgeHandle); !ok {
-		t.Fatalf("toolPicks[0] = %T, want EdgeHandle", got[0])
+		t.Fatalf("ToolPicks[0] = %T, want EdgeHandle", got[0])
 	}
 }

--- a/app/selecting_tools_coverage_test.go
+++ b/app/selecting_tools_coverage_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "testing"
+
+// migratedSelectingTools constructs one of every tool that declares its selection through the
+// engine (ADR-0041). Constructors that take a build closure get nil — it is only invoked on
+// commit, which this test does not reach.
+func migratedSelectingTools() []Tool {
+	return []Tool{
+		NewDraftTool(), NewDeleteFaceTool(), NewShellTool(), NewDecalTool(),
+		NewFaceFilletTool(), NewFullRoundFilletTool(), NewFaceOffsetTool(), NewReplaceFaceTool(),
+		NewGripSnapTool(), NewHoleTool(), NewThreadTool(), NewPatchTool(),
+		NewChamferTool(), NewFilletTool(), NewLipTool(), NewExtendTool(),
+		NewCoilTool(), NewEmbossTool(), NewGrillTool(), NewRestTool(), NewRuledSurfaceTool(),
+		NewSheetMetalFaceTool(), NewCreateSketchTool(), NewExtrudeTool(), NewMeasureTool(),
+		NewSweepTool(), NewProjectGeometryTool(), NewSplitTool(), NewSurfaceTrimTool(),
+		NewOffsetWorkPlaneTool(), NewRevolveTool(), NewLoftTool(), NewBossTool(),
+		NewDirectEditTool(), NewMoveFaceTool(), NewCombineTool(), NewMoveBodyTool(),
+		NewSheetMetalFlangeTool(), NewSheetMetalLipTool(), NewSheetMetalRipTool(),
+		NewSheetMetalPunchTool(), NewSheetMetalCosmeticBendTool(), NewSheetMetalBendTool(),
+		NewSheetMetalFoldTool(), NewSheetMetalCornerTool(), NewSheetMetalCornerSeamTool(),
+		NewSheetMetalCutTool(), NewSheetMetalHemTool(), NewSheetMetalContourFlangeTool(),
+		NewSheetMetalLoftedFlangeTool(), NewSheetMetalContourRollTool(),
+		NewIncludeGeometry3DTool(), NewSurfaceCurve3DTool(), NewThickenTool(),
+		NewAssemblyConstraintTool("Mate", 2, nil), NewAssemblyJointTool("Rigid", nil),
+		NewAssemblyChamferTool(), NewAssemblyFilletTool(),
+	}
+}
+
+// TestEverySelectingToolDeclaresAndReportsPicks drives the engine over every migrated tool: starting
+// it installs the filter from AcceptedKinds (restricted when the tool declares kinds), reporting
+// Picks is empty before any pick, and cancelling hands the filter back to the ambient state. This is
+// the uniform contract the host relies on (ADR-0041) — and the regression guard that a tool's
+// declared kinds actually take effect, the bug class the engine removes.
+func TestEverySelectingToolDeclaresAndReportsPicks(t *testing.T) {
+	for _, tool := range migratedSelectingTools() {
+		s := NewSession()
+		s.StartTool(tool)
+
+		if sel, ok := tool.(Selecting); ok && len(sel.AcceptedKinds()) > 0 {
+			if !s.Selection().Filter().IsRestricted() {
+				t.Errorf("%s declares kinds %v but the engine left the filter unrestricted",
+					tool.Name(), sel.AcceptedKinds())
+			}
+		}
+		if picks := s.ToolPicks(); len(picks) != 0 {
+			t.Errorf("%s reports %d picks before any pick, want 0", tool.Name(), len(picks))
+		}
+
+		s.CancelTool()
+		if s.Selection().Filter().IsRestricted() {
+			t.Errorf("%s left the filter restricted after cancel", tool.Name())
+		}
+	}
+}

--- a/app/session_input.go
+++ b/app/session_input.go
@@ -36,6 +36,7 @@ func (s *Session) StartTool(t Tool) {
 	s.notice = ""
 	s.tool = &ToolInstance{tool: t}
 	t.Start(s)
+	s.installToolFilter() // derive the filter from the tool's declared AcceptedKinds (engine)
 }
 
 // ActiveTool returns the running tool instance, or nil.
@@ -79,6 +80,7 @@ func (s *Session) OK() error {
 	}
 	s.notice = ""
 	s.tool = nil
+	s.restoreSelectionFilter()      // hand selection back to the ambient filter (engine)
 	s.Graphics().ClearInteraction() // a committed command's transient preview vanishes
 	s.dropCommandMiniToolbars()     // command-bound mini-toolbars die with the tool (M05-F07)
 	s.dropCommandGizmos()           // and the command-bound triad/manipulators (M05-F13)
@@ -91,6 +93,7 @@ func (s *Session) CancelTool() {
 	if s.tool != nil {
 		s.tool.tool.Cancel(s)
 		s.tool = nil
+		s.restoreSelectionFilter()      // hand selection back to the ambient filter (engine)
 		s.Graphics().ClearInteraction() // a cancelled command's transient preview vanishes
 		s.dropCommandMiniToolbars()     // command-bound mini-toolbars die with the tool (M05-F07)
 		s.dropCommandGizmos()           // and the command-bound triad/manipulators (M05-F13)
@@ -109,6 +112,9 @@ type autoCommitter interface {
 func (s *Session) feedPick(sel Selectable) {
 	s.tool.tool.Pick(s, sel)
 	s.autoCommitAfterPick()
+	if s.tool != nil {
+		s.installToolFilter() // re-derive the filter for the tool's next step
+	}
 }
 
 // modifierPicker is a Tool whose pick behavior depends on held modifiers — e.g. Extrude
@@ -126,6 +132,9 @@ func (s *Session) feedPickMods(sel Selectable, mods Modifier) {
 		s.tool.tool.Pick(s, sel)
 	}
 	s.autoCommitAfterPick()
+	if s.tool != nil {
+		s.installToolFilter() // re-derive the filter for the tool's next step
+	}
 }
 
 // autoCommitAfterPick commits the active tool when it opts into auto-commit and is now

--- a/app/sheet_metal_access.go
+++ b/app/sheet_metal_access.go
@@ -43,7 +43,6 @@ func commitSheetMetalFeature(s *Session, part *compdef.PartComponentDefinition, 
 	if !added.Health().OK() {
 		return errors.New(label + ": " + added.Health().Reason)
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 

--- a/app/sheet_metal_f03_tools.go
+++ b/app/sheet_metal_f03_tools.go
@@ -35,13 +35,8 @@ func (t *SheetMetalLipTool) Start(*Session) {}
 func (t *SheetMetalLipTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectEdge} }
 
 // Picks reports the picked edge for the unified highlight.
-func (t *SheetMetalLipTool) Picks() []Selectable {
-	if t.edge == nil {
-		return nil
-	}
-	return []Selectable{*t.edge}
-}
-func (t *SheetMetalLipTool) Cancel(*Session) {}
+func (t *SheetMetalLipTool) Picks() []Selectable { return singlePick(t.edge) }
+func (t *SheetMetalLipTool) Cancel(*Session)     {}
 func (t *SheetMetalLipTool) Pick(_ *Session, sel Selectable) {
 	if e, ok := sel.(EdgeHandle); ok {
 		t.edge = &e
@@ -180,13 +175,8 @@ func (t *SheetMetalPunchTool) Start(*Session) {}
 func (t *SheetMetalPunchTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectProfile} }
 
 // Picks reports the picked region for the unified highlight.
-func (t *SheetMetalPunchTool) Picks() []Selectable {
-	if t.profile == nil {
-		return nil
-	}
-	return []Selectable{*t.profile}
-}
-func (t *SheetMetalPunchTool) Cancel(*Session) {}
+func (t *SheetMetalPunchTool) Picks() []Selectable { return singlePick(t.profile) }
+func (t *SheetMetalPunchTool) Cancel(*Session)     {}
 func (t *SheetMetalPunchTool) Pick(_ *Session, sel Selectable) {
 	if p, ok := sel.(ProfileHandle); ok {
 		t.profile = &p

--- a/app/sheet_metal_f03_tools.go
+++ b/app/sheet_metal_f03_tools.go
@@ -28,11 +28,20 @@ func NewSheetMetalLipTool() *SheetMetalLipTool {
 	return &SheetMetalLipTool{height: 1.0, returnLen: 0.3, angle: halfPiAngle}
 }
 
-func (t *SheetMetalLipTool) Name() string { return "Sheet Metal Lip" }
-func (t *SheetMetalLipTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectEdge))
+func (t *SheetMetalLipTool) Name() string   { return "Sheet Metal Lip" }
+func (t *SheetMetalLipTool) Start(*Session) {}
+
+// AcceptedKinds declares the sheet-metal lip picks an edge.
+func (t *SheetMetalLipTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectEdge} }
+
+// Picks reports the picked edge for the unified highlight.
+func (t *SheetMetalLipTool) Picks() []Selectable {
+	if t.edge == nil {
+		return nil
+	}
+	return []Selectable{*t.edge}
 }
-func (t *SheetMetalLipTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *SheetMetalLipTool) Cancel(*Session) {}
 func (t *SheetMetalLipTool) Pick(_ *Session, sel Selectable) {
 	if e, ok := sel.(EdgeHandle); ok {
 		t.edge = &e
@@ -95,11 +104,14 @@ type SheetMetalRipTool struct {
 // NewSheetMetalRipTool returns a rip tool defaulting to a 0.1 mm kerf.
 func NewSheetMetalRipTool() *SheetMetalRipTool { return &SheetMetalRipTool{gap: 0.01} }
 
-func (t *SheetMetalRipTool) Name() string { return "Sheet Metal Rip" }
-func (t *SheetMetalRipTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectSketchEntity))
+func (t *SheetMetalRipTool) Name() string   { return "Sheet Metal Rip" }
+func (t *SheetMetalRipTool) Start(*Session) {}
+
+// AcceptedKinds declares the rip picks a sketch entity (the slit line).
+func (t *SheetMetalRipTool) AcceptedKinds() []SelectionKind {
+	return []SelectionKind{SelectSketchEntity}
 }
-func (t *SheetMetalRipTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *SheetMetalRipTool) Cancel(*Session) {}
 func (t *SheetMetalRipTool) Pick(_ *Session, sel Selectable) {
 	if h, ok := sel.(SketchEntityHandle); ok {
 		t.line = &h
@@ -161,11 +173,20 @@ type SheetMetalPunchTool struct {
 // NewSheetMetalPunchTool returns a punch tool awaiting a profile.
 func NewSheetMetalPunchTool() *SheetMetalPunchTool { return &SheetMetalPunchTool{} }
 
-func (t *SheetMetalPunchTool) Name() string { return "Sheet Metal Punch" }
-func (t *SheetMetalPunchTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectProfile))
+func (t *SheetMetalPunchTool) Name() string   { return "Sheet Metal Punch" }
+func (t *SheetMetalPunchTool) Start(*Session) {}
+
+// AcceptedKinds declares the punch picks a closed sketch region (profile).
+func (t *SheetMetalPunchTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectProfile} }
+
+// Picks reports the picked region for the unified highlight.
+func (t *SheetMetalPunchTool) Picks() []Selectable {
+	if t.profile == nil {
+		return nil
+	}
+	return []Selectable{*t.profile}
 }
-func (t *SheetMetalPunchTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *SheetMetalPunchTool) Cancel(*Session) {}
 func (t *SheetMetalPunchTool) Pick(_ *Session, sel Selectable) {
 	if p, ok := sel.(ProfileHandle); ok {
 		t.profile = &p
@@ -214,13 +235,14 @@ func NewSheetMetalCosmeticBendTool() *SheetMetalCosmeticBendTool {
 	return &SheetMetalCosmeticBendTool{angle: halfPiAngle}
 }
 
-func (t *SheetMetalCosmeticBendTool) Name() string { return "Sheet Metal Cosmetic Bend" }
-func (t *SheetMetalCosmeticBendTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectSketchEntity))
+func (t *SheetMetalCosmeticBendTool) Name() string   { return "Sheet Metal Cosmetic Bend" }
+func (t *SheetMetalCosmeticBendTool) Start(*Session) {}
+
+// AcceptedKinds declares the cosmetic bend picks a sketch entity (the bend line).
+func (t *SheetMetalCosmeticBendTool) AcceptedKinds() []SelectionKind {
+	return []SelectionKind{SelectSketchEntity}
 }
-func (t *SheetMetalCosmeticBendTool) Cancel(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter())
-}
+func (t *SheetMetalCosmeticBendTool) Cancel(*Session) {}
 func (t *SheetMetalCosmeticBendTool) Pick(_ *Session, sel Selectable) {
 	if h, ok := sel.(SketchEntityHandle); ok {
 		t.line = &h

--- a/app/sheet_metal_face_tool.go
+++ b/app/sheet_metal_face_tool.go
@@ -24,10 +24,14 @@ func NewSheetMetalFaceTool() *SheetMetalFaceTool { return &SheetMetalFaceTool{} 
 // Name implements [Tool].
 func (t *SheetMetalFaceTool) Name() string { return "Sheet Metal Face" }
 
-// Start filters selection to closed sketch profiles.
-func (t *SheetMetalFaceTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectProfile))
-}
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *SheetMetalFaceTool) Start(*Session) {}
+
+// AcceptedKinds declares the sheet-metal face picks closed sketch regions (profiles).
+func (t *SheetMetalFaceTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectProfile} }
+
+// Picks reports the picked regions for the unified highlight.
+func (t *SheetMetalFaceTool) Picks() []Selectable { return profileSelectables(t.profiles) }
 
 // Pick captures the clicked profile (a single region; a re-pick replaces it).
 func (t *SheetMetalFaceTool) Pick(_ *Session, sel Selectable) {
@@ -68,7 +72,7 @@ func (t *SheetMetalFaceTool) addFace(part *compdef.PartComponentDefinition, fs *
 }
 
 // Cancel abandons the tool.
-func (t *SheetMetalFaceTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *SheetMetalFaceTool) Cancel(*Session) {}
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *SheetMetalFaceTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/sheet_metal_flange_tool.go
+++ b/app/sheet_metal_flange_tool.go
@@ -37,12 +37,7 @@ func (t *SheetMetalFlangeTool) Start(*Session) {}
 func (t *SheetMetalFlangeTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectEdge} }
 
 // Picks reports the picked edge for the unified highlight.
-func (t *SheetMetalFlangeTool) Picks() []Selectable {
-	if t.edge == nil {
-		return nil
-	}
-	return []Selectable{*t.edge}
-}
+func (t *SheetMetalFlangeTool) Picks() []Selectable { return singlePick(t.edge) }
 
 // Pick captures the clicked edge (a re-pick replaces it).
 func (t *SheetMetalFlangeTool) Pick(_ *Session, sel Selectable) {

--- a/app/sheet_metal_flange_tool.go
+++ b/app/sheet_metal_flange_tool.go
@@ -30,9 +30,18 @@ const halfPiAngle = 1.5707963267948966
 // Name implements [Tool].
 func (t *SheetMetalFlangeTool) Name() string { return "Sheet Metal Flange" }
 
-// Start filters selection to edges so a click picks the edge to flange from.
-func (t *SheetMetalFlangeTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectEdge))
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *SheetMetalFlangeTool) Start(*Session) {}
+
+// AcceptedKinds declares flange picks an edge (the straight edge to fold from).
+func (t *SheetMetalFlangeTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectEdge} }
+
+// Picks reports the picked edge for the unified highlight.
+func (t *SheetMetalFlangeTool) Picks() []Selectable {
+	if t.edge == nil {
+		return nil
+	}
+	return []Selectable{*t.edge}
 }
 
 // Pick captures the clicked edge (a re-pick replaces it).
@@ -79,7 +88,7 @@ func (t *SheetMetalFlangeTool) addFlange(fs *feature.PartFeatures) *feature.Part
 }
 
 // Cancel abandons the tool.
-func (t *SheetMetalFlangeTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *SheetMetalFlangeTool) Cancel(*Session) {}
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *SheetMetalFlangeTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/sheet_metal_modify_tools.go
+++ b/app/sheet_metal_modify_tools.go
@@ -203,12 +203,7 @@ func (t *SheetMetalCutTool) Start(*Session) {}
 func (t *SheetMetalCutTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectProfile} }
 
 // Picks reports the picked region for the unified highlight.
-func (t *SheetMetalCutTool) Picks() []Selectable {
-	if t.profile == nil {
-		return nil
-	}
-	return []Selectable{*t.profile}
-}
+func (t *SheetMetalCutTool) Picks() []Selectable { return singlePick(t.profile) }
 func (t *SheetMetalCutTool) Pick(_ *Session, sel Selectable) {
 	if p, ok := sel.(ProfileHandle); ok {
 		t.profile = &p

--- a/app/sheet_metal_modify_tools.go
+++ b/app/sheet_metal_modify_tools.go
@@ -20,9 +20,12 @@ type SheetMetalBendTool struct {
 // NewSheetMetalBendTool returns a bend tool awaiting a sketch line.
 func NewSheetMetalBendTool() *SheetMetalBendTool { return &SheetMetalBendTool{} }
 
-func (t *SheetMetalBendTool) Name() string { return "Sheet Metal Bend" }
-func (t *SheetMetalBendTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectSketchEntity))
+func (t *SheetMetalBendTool) Name() string   { return "Sheet Metal Bend" }
+func (t *SheetMetalBendTool) Start(*Session) {}
+
+// AcceptedKinds declares the bend picks a sketch entity (the bend line).
+func (t *SheetMetalBendTool) AcceptedKinds() []SelectionKind {
+	return []SelectionKind{SelectSketchEntity}
 }
 func (t *SheetMetalBendTool) Pick(_ *Session, sel Selectable) {
 	if h, ok := sel.(SketchEntityHandle); ok {
@@ -30,7 +33,7 @@ func (t *SheetMetalBendTool) Pick(_ *Session, sel Selectable) {
 	}
 }
 func (t *SheetMetalBendTool) CanCommit() bool                    { return t.line != nil }
-func (t *SheetMetalBendTool) Cancel(s *Session)                  { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *SheetMetalBendTool) Cancel(s *Session)                  {}
 func (t *SheetMetalBendTool) AddedFeature() *feature.PartFeature { return t.added }
 
 func (t *SheetMetalBendTool) Commit(s *Session) error {
@@ -58,9 +61,12 @@ type SheetMetalFoldTool struct {
 // NewSheetMetalFoldTool returns a fold tool awaiting a sketch line.
 func NewSheetMetalFoldTool() *SheetMetalFoldTool { return &SheetMetalFoldTool{} }
 
-func (t *SheetMetalFoldTool) Name() string { return "Sheet Metal Fold" }
-func (t *SheetMetalFoldTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectSketchEntity))
+func (t *SheetMetalFoldTool) Name() string   { return "Sheet Metal Fold" }
+func (t *SheetMetalFoldTool) Start(*Session) {}
+
+// AcceptedKinds declares the fold picks a sketch entity (the fold line).
+func (t *SheetMetalFoldTool) AcceptedKinds() []SelectionKind {
+	return []SelectionKind{SelectSketchEntity}
 }
 func (t *SheetMetalFoldTool) Pick(_ *Session, sel Selectable) {
 	if h, ok := sel.(SketchEntityHandle); ok {
@@ -68,7 +74,7 @@ func (t *SheetMetalFoldTool) Pick(_ *Session, sel Selectable) {
 	}
 }
 func (t *SheetMetalFoldTool) CanCommit() bool                    { return t.line != nil }
-func (t *SheetMetalFoldTool) Cancel(s *Session)                  { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *SheetMetalFoldTool) Cancel(s *Session)                  {}
 func (t *SheetMetalFoldTool) AddedFeature() *feature.PartFeature { return t.added }
 
 func (t *SheetMetalFoldTool) Commit(s *Session) error {
@@ -99,10 +105,14 @@ type SheetMetalCornerTool struct {
 // NewSheetMetalCornerTool returns a corner tool defaulting to a 3 mm chamfer.
 func NewSheetMetalCornerTool() *SheetMetalCornerTool { return &SheetMetalCornerTool{size: 0.3} }
 
-func (t *SheetMetalCornerTool) Name() string { return "Sheet Metal Corner" }
-func (t *SheetMetalCornerTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectEdge))
-}
+func (t *SheetMetalCornerTool) Name() string   { return "Sheet Metal Corner" }
+func (t *SheetMetalCornerTool) Start(*Session) {}
+
+// AcceptedKinds declares the corner picks edges (the corner edges to treat).
+func (t *SheetMetalCornerTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectEdge} }
+
+// Picks reports the picked edges for the unified highlight.
+func (t *SheetMetalCornerTool) Picks() []Selectable { return edgeSelectables(t.edges) }
 func (t *SheetMetalCornerTool) Pick(_ *Session, sel Selectable) {
 	if e, ok := sel.(EdgeHandle); ok {
 		t.edges = append(t.edges, e)
@@ -111,7 +121,7 @@ func (t *SheetMetalCornerTool) Pick(_ *Session, sel Selectable) {
 func (t *SheetMetalCornerTool) SetSize(v float64)                  { t.size = v }
 func (t *SheetMetalCornerTool) Size() float64                      { return t.size }
 func (t *SheetMetalCornerTool) CanCommit() bool                    { return len(t.edges) > 0 && t.size > 0 }
-func (t *SheetMetalCornerTool) Cancel(s *Session)                  { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *SheetMetalCornerTool) Cancel(s *Session)                  {}
 func (t *SheetMetalCornerTool) AddedFeature() *feature.PartFeature { return t.added }
 
 func (t *SheetMetalCornerTool) Commit(s *Session) error {
@@ -141,10 +151,16 @@ func NewSheetMetalCornerSeamTool() *SheetMetalCornerSeamTool {
 	return &SheetMetalCornerSeamTool{gap: 0.02}
 }
 
-func (t *SheetMetalCornerSeamTool) Name() string { return "Sheet Metal Corner Seam" }
-func (t *SheetMetalCornerSeamTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectEdge))
+func (t *SheetMetalCornerSeamTool) Name() string   { return "Sheet Metal Corner Seam" }
+func (t *SheetMetalCornerSeamTool) Start(*Session) {}
+
+// AcceptedKinds declares the corner seam picks edges (the corner edges to seam).
+func (t *SheetMetalCornerSeamTool) AcceptedKinds() []SelectionKind {
+	return []SelectionKind{SelectEdge}
 }
+
+// Picks reports the picked edges for the unified highlight.
+func (t *SheetMetalCornerSeamTool) Picks() []Selectable { return edgeSelectables(t.edges) }
 func (t *SheetMetalCornerSeamTool) Pick(_ *Session, sel Selectable) {
 	if e, ok := sel.(EdgeHandle); ok {
 		t.edges = append(t.edges, e)
@@ -153,7 +169,7 @@ func (t *SheetMetalCornerSeamTool) Pick(_ *Session, sel Selectable) {
 func (t *SheetMetalCornerSeamTool) SetGap(v float64)                   { t.gap = v }
 func (t *SheetMetalCornerSeamTool) Gap() float64                       { return t.gap }
 func (t *SheetMetalCornerSeamTool) CanCommit() bool                    { return len(t.edges) > 0 && t.gap > 0 }
-func (t *SheetMetalCornerSeamTool) Cancel(s *Session)                  { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *SheetMetalCornerSeamTool) Cancel(s *Session)                  {}
 func (t *SheetMetalCornerSeamTool) AddedFeature() *feature.PartFeature { return t.added }
 
 func (t *SheetMetalCornerSeamTool) Commit(s *Session) error {
@@ -180,9 +196,18 @@ type SheetMetalCutTool struct {
 // NewSheetMetalCutTool returns a cut tool awaiting a profile.
 func NewSheetMetalCutTool() *SheetMetalCutTool { return &SheetMetalCutTool{} }
 
-func (t *SheetMetalCutTool) Name() string { return "Sheet Metal Cut" }
-func (t *SheetMetalCutTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectProfile))
+func (t *SheetMetalCutTool) Name() string   { return "Sheet Metal Cut" }
+func (t *SheetMetalCutTool) Start(*Session) {}
+
+// AcceptedKinds declares the cut picks a closed sketch region (profile).
+func (t *SheetMetalCutTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectProfile} }
+
+// Picks reports the picked region for the unified highlight.
+func (t *SheetMetalCutTool) Picks() []Selectable {
+	if t.profile == nil {
+		return nil
+	}
+	return []Selectable{*t.profile}
 }
 func (t *SheetMetalCutTool) Pick(_ *Session, sel Selectable) {
 	if p, ok := sel.(ProfileHandle); ok {
@@ -190,7 +215,7 @@ func (t *SheetMetalCutTool) Pick(_ *Session, sel Selectable) {
 	}
 }
 func (t *SheetMetalCutTool) CanCommit() bool                    { return t.profile != nil }
-func (t *SheetMetalCutTool) Cancel(s *Session)                  { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *SheetMetalCutTool) Cancel(s *Session)                  {}
 func (t *SheetMetalCutTool) AddedFeature() *feature.PartFeature { return t.added }
 
 func (t *SheetMetalCutTool) Commit(s *Session) error {

--- a/app/sheet_metal_style_tool.go
+++ b/app/sheet_metal_style_tool.go
@@ -82,7 +82,6 @@ func (t *SheetMetalStyleTool) Commit(s *Session) error {
 	part.Features().MarkAllDirty()
 	part.Recompute()
 	s.recordEdit(part, "Sheet Metal Style")
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 

--- a/app/sheet_metal_wall_tools.go
+++ b/app/sheet_metal_wall_tools.go
@@ -22,9 +22,18 @@ type SheetMetalHemTool struct {
 // NewSheetMetalHemTool returns a hem tool defaulting to a 6 mm fold-back.
 func NewSheetMetalHemTool() *SheetMetalHemTool { return &SheetMetalHemTool{length: 0.6} }
 
-func (t *SheetMetalHemTool) Name() string { return "Sheet Metal Hem" }
-func (t *SheetMetalHemTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectEdge))
+func (t *SheetMetalHemTool) Name() string   { return "Sheet Metal Hem" }
+func (t *SheetMetalHemTool) Start(*Session) {}
+
+// AcceptedKinds declares the hem picks an edge (the edge to hem).
+func (t *SheetMetalHemTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectEdge} }
+
+// Picks reports the picked edge for the unified highlight.
+func (t *SheetMetalHemTool) Picks() []Selectable {
+	if t.edge == nil {
+		return nil
+	}
+	return []Selectable{*t.edge}
 }
 func (t *SheetMetalHemTool) Pick(_ *Session, sel Selectable) {
 	if e, ok := sel.(EdgeHandle); ok {
@@ -34,7 +43,7 @@ func (t *SheetMetalHemTool) Pick(_ *Session, sel Selectable) {
 func (t *SheetMetalHemTool) SetLength(l float64)                { t.length = l }
 func (t *SheetMetalHemTool) Length() float64                    { return t.length }
 func (t *SheetMetalHemTool) CanCommit() bool                    { return t.edge != nil && t.length > 0 }
-func (t *SheetMetalHemTool) Cancel(s *Session)                  { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *SheetMetalHemTool) Cancel(*Session)                    {}
 func (t *SheetMetalHemTool) AddedFeature() *feature.PartFeature { return t.added }
 
 func (t *SheetMetalHemTool) Commit(s *Session) error {
@@ -64,9 +73,24 @@ func NewSheetMetalContourFlangeTool() *SheetMetalContourFlangeTool {
 	return &SheetMetalContourFlangeTool{}
 }
 
-func (t *SheetMetalContourFlangeTool) Name() string { return "Sheet Metal Contour Flange" }
-func (t *SheetMetalContourFlangeTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectEdge, SelectProfile))
+func (t *SheetMetalContourFlangeTool) Name() string   { return "Sheet Metal Contour Flange" }
+func (t *SheetMetalContourFlangeTool) Start(*Session) {}
+
+// AcceptedKinds declares the contour flange picks an edge and a profile (the contour to sweep).
+func (t *SheetMetalContourFlangeTool) AcceptedKinds() []SelectionKind {
+	return []SelectionKind{SelectEdge, SelectProfile}
+}
+
+// Picks reports the picked edge and profile for the unified highlight.
+func (t *SheetMetalContourFlangeTool) Picks() []Selectable {
+	var picks []Selectable
+	if t.edge != nil {
+		picks = append(picks, *t.edge)
+	}
+	if t.profile != nil {
+		picks = append(picks, *t.profile)
+	}
+	return picks
 }
 func (t *SheetMetalContourFlangeTool) Pick(_ *Session, sel Selectable) {
 	switch h := sel.(type) {
@@ -78,7 +102,6 @@ func (t *SheetMetalContourFlangeTool) Pick(_ *Session, sel Selectable) {
 }
 func (t *SheetMetalContourFlangeTool) CanCommit() bool { return t.edge != nil && t.profile != nil }
 func (t *SheetMetalContourFlangeTool) Cancel(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter())
 }
 func (t *SheetMetalContourFlangeTool) AddedFeature() *feature.PartFeature { return t.added }
 
@@ -107,10 +130,16 @@ func NewSheetMetalLoftedFlangeTool() *SheetMetalLoftedFlangeTool {
 	return &SheetMetalLoftedFlangeTool{}
 }
 
-func (t *SheetMetalLoftedFlangeTool) Name() string { return "Sheet Metal Lofted Flange" }
-func (t *SheetMetalLoftedFlangeTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectProfile))
+func (t *SheetMetalLoftedFlangeTool) Name() string   { return "Sheet Metal Lofted Flange" }
+func (t *SheetMetalLoftedFlangeTool) Start(*Session) {}
+
+// AcceptedKinds declares the lofted flange picks two closed sketch regions (profiles).
+func (t *SheetMetalLoftedFlangeTool) AcceptedKinds() []SelectionKind {
+	return []SelectionKind{SelectProfile}
 }
+
+// Picks reports the picked regions for the unified highlight.
+func (t *SheetMetalLoftedFlangeTool) Picks() []Selectable { return profileSelectables(t.profiles) }
 func (t *SheetMetalLoftedFlangeTool) Pick(_ *Session, sel Selectable) {
 	if p, ok := sel.(ProfileHandle); ok && len(t.profiles) < 2 {
 		t.profiles = append(t.profiles, p)
@@ -118,7 +147,6 @@ func (t *SheetMetalLoftedFlangeTool) Pick(_ *Session, sel Selectable) {
 }
 func (t *SheetMetalLoftedFlangeTool) CanCommit() bool { return len(t.profiles) == 2 }
 func (t *SheetMetalLoftedFlangeTool) Cancel(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter())
 }
 func (t *SheetMetalLoftedFlangeTool) AddedFeature() *feature.PartFeature { return t.added }
 
@@ -149,9 +177,21 @@ func NewSheetMetalContourRollTool() *SheetMetalContourRollTool {
 	return &SheetMetalContourRollTool{angle: halfPiAngle}
 }
 
-func (t *SheetMetalContourRollTool) Name() string { return "Sheet Metal Contour Roll" }
-func (t *SheetMetalContourRollTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectProfile, SelectSketchEntity))
+func (t *SheetMetalContourRollTool) Name() string   { return "Sheet Metal Contour Roll" }
+func (t *SheetMetalContourRollTool) Start(*Session) {}
+
+// AcceptedKinds declares the contour roll picks a profile (the contour) and a sketch entity (the
+// roll axis line).
+func (t *SheetMetalContourRollTool) AcceptedKinds() []SelectionKind {
+	return []SelectionKind{SelectProfile, SelectSketchEntity}
+}
+
+// Picks reports the picked profile for the unified highlight (the axis is a sketch line).
+func (t *SheetMetalContourRollTool) Picks() []Selectable {
+	if t.profile == nil {
+		return nil
+	}
+	return []Selectable{*t.profile}
 }
 func (t *SheetMetalContourRollTool) Pick(_ *Session, sel Selectable) {
 	switch h := sel.(type) {
@@ -167,7 +207,6 @@ func (t *SheetMetalContourRollTool) CanCommit() bool {
 	return t.profile != nil && t.axis != nil && t.angle > 0
 }
 func (t *SheetMetalContourRollTool) Cancel(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter())
 }
 func (t *SheetMetalContourRollTool) AddedFeature() *feature.PartFeature { return t.added }
 

--- a/app/sheet_metal_wall_tools.go
+++ b/app/sheet_metal_wall_tools.go
@@ -78,14 +78,7 @@ func (t *SheetMetalContourFlangeTool) AcceptedKinds() []SelectionKind {
 
 // Picks reports the picked edge and profile for the unified highlight.
 func (t *SheetMetalContourFlangeTool) Picks() []Selectable {
-	var picks []Selectable
-	if t.edge != nil {
-		picks = append(picks, *t.edge)
-	}
-	if t.profile != nil {
-		picks = append(picks, *t.profile)
-	}
-	return picks
+	return appendPick(appendPick(nil, t.edge), t.profile)
 }
 func (t *SheetMetalContourFlangeTool) Pick(_ *Session, sel Selectable) {
 	switch h := sel.(type) {

--- a/app/sheet_metal_wall_tools.go
+++ b/app/sheet_metal_wall_tools.go
@@ -29,12 +29,7 @@ func (t *SheetMetalHemTool) Start(*Session) {}
 func (t *SheetMetalHemTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectEdge} }
 
 // Picks reports the picked edge for the unified highlight.
-func (t *SheetMetalHemTool) Picks() []Selectable {
-	if t.edge == nil {
-		return nil
-	}
-	return []Selectable{*t.edge}
-}
+func (t *SheetMetalHemTool) Picks() []Selectable { return singlePick(t.edge) }
 func (t *SheetMetalHemTool) Pick(_ *Session, sel Selectable) {
 	if e, ok := sel.(EdgeHandle); ok {
 		t.edge = &e
@@ -187,12 +182,7 @@ func (t *SheetMetalContourRollTool) AcceptedKinds() []SelectionKind {
 }
 
 // Picks reports the picked profile for the unified highlight (the axis is a sketch line).
-func (t *SheetMetalContourRollTool) Picks() []Selectable {
-	if t.profile == nil {
-		return nil
-	}
-	return []Selectable{*t.profile}
-}
+func (t *SheetMetalContourRollTool) Picks() []Selectable { return singlePick(t.profile) }
 func (t *SheetMetalContourRollTool) Pick(_ *Session, sel Selectable) {
 	switch h := sel.(type) {
 	case ProfileHandle:

--- a/app/shell_tool.go
+++ b/app/shell_tool.go
@@ -25,8 +25,14 @@ func NewShellTool() *ShellTool { return &ShellTool{thickness: 1} }
 // Name implements [Tool].
 func (t *ShellTool) Name() string { return "Shell" }
 
-// Start sets the selection filter to faces so clicks pick faces to open.
-func (t *ShellTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectFace)) }
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *ShellTool) Start(*Session) {}
+
+// AcceptedKinds declares shell picks faces (the faces to open).
+func (t *ShellTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectFace} }
+
+// Picks reports the picked faces for the unified highlight.
+func (t *ShellTool) Picks() []Selectable { return faceSelectables(t.faces) }
 
 // Pick appends the clicked face (ignoring one already chosen, so a double-click does not
 // duplicate it).
@@ -89,7 +95,6 @@ func (t *ShellTool) Commit(s *Session) error {
 	if !t.added.Health().OK() {
 		return errors.New("shell: " + t.added.Health().Reason)
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 
@@ -129,7 +134,6 @@ func (t *ShellTool) Cancel(s *Session) {
 		cancelFeatureEdit(s, t.target, t.restoreDef)
 		return
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 }
 
 // commitEdit writes the panel state back into the committed shell's definition.

--- a/app/sketch3d_reference_tools.go
+++ b/app/sketch3d_reference_tools.go
@@ -26,9 +26,21 @@ func NewIncludeGeometry3DTool() *IncludeGeometry3DTool { return &IncludeGeometry
 // Name implements [Tool].
 func (t *IncludeGeometry3DTool) Name() string { return "Include Geometry" }
 
-// Start restricts the selection to includable references (edges and vertices).
-func (t *IncludeGeometry3DTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectEdge, SelectVertex))
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *IncludeGeometry3DTool) Start(*Session) {}
+
+// AcceptedKinds declares include-geometry picks includable references: edges and vertices.
+func (t *IncludeGeometry3DTool) AcceptedKinds() []SelectionKind {
+	return []SelectionKind{SelectEdge, SelectVertex}
+}
+
+// Picks reports the picked edges and vertices for the unified highlight.
+func (t *IncludeGeometry3DTool) Picks() []Selectable {
+	picks := edgeSelectables(t.edges)
+	for _, v := range t.vertices {
+		picks = append(picks, v)
+	}
+	return picks
 }
 
 // Pick records a clicked edge or vertex (ignoring other kinds).
@@ -64,7 +76,6 @@ func (t *IncludeGeometry3DTool) Commit(s *Session) error {
 	for _, v := range t.vertices {
 		sk.IncludePoint3D(compdef.NewVertexRefSource(part, string(v.Vertex.ReferenceKey())))
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 
@@ -90,10 +101,14 @@ func NewSurfaceCurve3DTool() *SurfaceCurve3DTool {
 // Name implements [Tool].
 func (t *SurfaceCurve3DTool) Name() string { return "Surface Curve" }
 
-// Start restricts the selection to faces.
-func (t *SurfaceCurve3DTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectFace))
-}
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *SurfaceCurve3DTool) Start(*Session) {}
+
+// AcceptedKinds declares surface-curve picks faces (the surfaces to intersect).
+func (t *SurfaceCurve3DTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectFace} }
+
+// Picks reports the picked faces for the unified highlight.
+func (t *SurfaceCurve3DTool) Picks() []Selectable { return faceSelectables(t.faces) }
 
 // Pick records a clicked face.
 func (t *SurfaceCurve3DTool) Pick(_ *Session, sel Selectable) {
@@ -137,7 +152,6 @@ func (t *SurfaceCurve3DTool) Commit(s *Session) error {
 		b := compdef.NewFaceRefSource(part, string(t.faces[1].Face.ReferenceKey()))
 		sk.AddIntersectionCurve3DRef(a, b, geom.SurfaceGrid{})
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 

--- a/app/sketch3d_reference_tools.go
+++ b/app/sketch3d_reference_tools.go
@@ -36,11 +36,7 @@ func (t *IncludeGeometry3DTool) AcceptedKinds() []SelectionKind {
 
 // Picks reports the picked edges and vertices for the unified highlight.
 func (t *IncludeGeometry3DTool) Picks() []Selectable {
-	picks := edgeSelectables(t.edges)
-	for _, v := range t.vertices {
-		picks = append(picks, v)
-	}
-	return picks
+	return append(edgeSelectables(t.edges), vertexSelectables(t.vertices)...)
 }
 
 // Pick records a clicked edge or vertex (ignoring other kinds).

--- a/app/sketch_env.go
+++ b/app/sketch_env.go
@@ -5,6 +5,7 @@ package app
 import (
 	"errors"
 
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/param"
 	"oblikovati.org/model/sketch"
@@ -65,14 +66,48 @@ func (s *Session) CreateSketchOnOrigin(p OriginPlane) (*sketch.Sketch, error) {
 	return s.CreateSketch(p.plane())
 }
 
-// CreateSketchOnSelectedPlane starts a sketch on the selected work plane (picked in the
-// 3D view or the browser), falling back to the XY origin plane when nothing usable is
-// selected — the action behind the Create 2D Sketch ribbon command.
+// CreateSketchOnSelectedPlane starts a sketch on the selected sketch host (a work plane
+// OR a planar face picked in the 3D view or the browser), falling back to the XY origin
+// plane when nothing usable is selected — the action behind the Create 2D Sketch ribbon
+// command.
 func (s *Session) CreateSketchOnSelectedPlane() (*sketch.Sketch, error) {
-	if wp := s.SelectedWorkPlane(); wp != nil {
-		return s.CreateSketch(wp.Plane())
+	if plane, ok := s.SelectedSketchHostPlane(); ok {
+		return s.CreateSketch(plane)
 	}
 	return s.CreateSketchOnOrigin(OriginXY)
+}
+
+// SelectedSketchHostPlane returns the sketch plane of the first selected valid host — a
+// work plane or a planar face — so a pre-selected face (not just a work plane) sketches
+// immediately. ok is false when nothing in the selection can host a sketch.
+func (s *Session) SelectedSketchHostPlane() (sketch.Plane, bool) {
+	for _, it := range s.selection.Items() {
+		if h, ok := it.(WorkPlaneHandle); ok {
+			return h.Plane.Plane(), true
+		}
+		if h, ok := it.(FaceHandle); ok {
+			if pl, ok := sketchPlaneFromFace(h); ok {
+				return pl, true
+			}
+		}
+	}
+	return sketch.Plane{}, false
+}
+
+// sketchPlaneFromFace derives a sketch plane from a picked planar face (its underlying
+// geometry plane), or ok=false for a non-planar face — the seam that lets a planar face
+// act as a sketch host wherever a work plane can. The face's geometry is the same plane
+// pickedPlaneRef uses for plane-driven features (feature_edit.go).
+func sketchPlaneFromFace(fh FaceHandle) (sketch.Plane, bool) {
+	pl, ok := fh.Face.Geometry().(geom.Plane)
+	if !ok {
+		return sketch.Plane{}, false
+	}
+	sp, err := sketch.NewPlane(pl.Origin, pl.UAxis, pl.VAxis)
+	if err != nil {
+		return sketch.Plane{}, false
+	}
+	return sp, true
 }
 
 // SelectedWorkPlane returns the first selected work plane, or nil.

--- a/app/sketch_project_tool.go
+++ b/app/sketch_project_tool.go
@@ -35,11 +35,7 @@ func (t *ProjectGeometryTool) AcceptedKinds() []SelectionKind {
 
 // Picks reports the picked edges and vertices for the unified highlight.
 func (t *ProjectGeometryTool) Picks() []Selectable {
-	picks := edgeSelectables(t.edges)
-	for _, v := range t.vertices {
-		picks = append(picks, v)
-	}
-	return picks
+	return append(edgeSelectables(t.edges), vertexSelectables(t.vertices)...)
 }
 
 // Pick records a clicked edge or vertex (ignoring other kinds).

--- a/app/sketch_project_tool.go
+++ b/app/sketch_project_tool.go
@@ -25,9 +25,21 @@ func NewProjectGeometryTool() *ProjectGeometryTool { return &ProjectGeometryTool
 // Name implements [Tool].
 func (t *ProjectGeometryTool) Name() string { return "Project Geometry" }
 
-// Start restricts the selection to projectable references (edges and vertices).
-func (t *ProjectGeometryTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectEdge, SelectVertex))
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *ProjectGeometryTool) Start(*Session) {}
+
+// AcceptedKinds declares project-geometry picks projectable references: edges and vertices.
+func (t *ProjectGeometryTool) AcceptedKinds() []SelectionKind {
+	return []SelectionKind{SelectEdge, SelectVertex}
+}
+
+// Picks reports the picked edges and vertices for the unified highlight.
+func (t *ProjectGeometryTool) Picks() []Selectable {
+	picks := edgeSelectables(t.edges)
+	for _, v := range t.vertices {
+		picks = append(picks, v)
+	}
+	return picks
 }
 
 // Pick records a clicked edge or vertex (ignoring other kinds).
@@ -63,7 +75,6 @@ func (t *ProjectGeometryTool) Commit(s *Session) error {
 	for _, v := range t.vertices {
 		sk.ProjectPoint(compdef.NewVertexRefSource(part, string(v.Vertex.ReferenceKey())))
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 

--- a/app/split_tool.go
+++ b/app/split_tool.go
@@ -119,7 +119,7 @@ func (t *SplitTool) DraftFeature(*Session) (feature.Feature, bool) {
 }
 
 // Cancel restores the default selection filter.
-func (t *SplitTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *SplitTool) Cancel(*Session) {}
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *SplitTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/split_tool.go
+++ b/app/split_tool.go
@@ -24,12 +24,22 @@ func NewSplitTool() *SplitTool { return &SplitTool{keep: feature.SplitBoth} }
 // Name implements [Tool].
 func (t *SplitTool) Name() string { return "Split" }
 
-// Start adopts a pre-selected work plane and filters selection to work planes.
+// Start adopts a pre-selected work plane; the engine installs the filter from AcceptedKinds.
 func (t *SplitTool) Start(s *Session) {
 	if wp := s.SelectedWorkPlane(); wp != nil {
 		t.plane = wp
 	}
-	s.Selection().SetFilter(NewSelectionFilter(SelectWorkPlane))
+}
+
+// AcceptedKinds declares split picks a work plane (the cutting plane).
+func (t *SplitTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectWorkPlane} }
+
+// Picks reports the picked cutting plane for the unified highlight.
+func (t *SplitTool) Picks() []Selectable {
+	if t.plane == nil {
+		return nil
+	}
+	return []Selectable{WorkPlaneHandle{Plane: t.plane}}
 }
 
 // Pick captures the work plane the user clicked.
@@ -86,7 +96,6 @@ func (t *SplitTool) Commit(s *Session) error {
 	if !t.added.Health().OK() {
 		return errors.New("split: " + t.added.Health().Reason)
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 

--- a/app/surface_edit_tools.go
+++ b/app/surface_edit_tools.go
@@ -117,7 +117,7 @@ func (t *RuledSurfaceTool) Commit(s *Session) error {
 }
 
 // Cancel restores the default selection filter.
-func (t *RuledSurfaceTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *RuledSurfaceTool) Cancel(*Session) {}
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *RuledSurfaceTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/surface_edit_tools.go
+++ b/app/surface_edit_tools.go
@@ -40,9 +40,18 @@ func (t *RuledSurfaceTool) Prompt(*Session) string {
 	return "Select a closed profile, set the direction and distance, then OK."
 }
 
-// Start filters selection to closed regions.
-func (t *RuledSurfaceTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectProfile))
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *RuledSurfaceTool) Start(*Session) {}
+
+// AcceptedKinds declares ruled-surface picks a closed sketch region (profile).
+func (t *RuledSurfaceTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectProfile} }
+
+// Picks reports the picked region for the unified highlight.
+func (t *RuledSurfaceTool) Picks() []Selectable {
+	if t.profile == nil {
+		return nil
+	}
+	return []Selectable{*t.profile}
 }
 
 // Pick captures the clicked closed region.
@@ -104,7 +113,6 @@ func (t *RuledSurfaceTool) Commit(s *Session) error {
 	if t.added.Health().Status == health.Sick {
 		return errors.New("ruled surface: " + t.added.Health().Reason)
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 

--- a/app/surface_edit_tools.go
+++ b/app/surface_edit_tools.go
@@ -47,12 +47,7 @@ func (t *RuledSurfaceTool) Start(*Session) {}
 func (t *RuledSurfaceTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectProfile} }
 
 // Picks reports the picked region for the unified highlight.
-func (t *RuledSurfaceTool) Picks() []Selectable {
-	if t.profile == nil {
-		return nil
-	}
-	return []Selectable{*t.profile}
-}
+func (t *RuledSurfaceTool) Picks() []Selectable { return singlePick(t.profile) }
 
 // Pick captures the clicked closed region.
 func (t *RuledSurfaceTool) Pick(_ *Session, sel Selectable) {

--- a/app/surface_trim_tool.go
+++ b/app/surface_trim_tool.go
@@ -23,12 +23,22 @@ func NewSurfaceTrimTool() *SurfaceTrimTool { return &SurfaceTrimTool{keepPositiv
 // Name implements [Tool].
 func (t *SurfaceTrimTool) Name() string { return "Trim" }
 
-// Start adopts a pre-selected work plane and filters selection to work planes.
+// Start adopts a pre-selected work plane; the engine installs the filter from AcceptedKinds.
 func (t *SurfaceTrimTool) Start(s *Session) {
 	if wp := s.SelectedWorkPlane(); wp != nil {
 		t.plane = wp
 	}
-	s.Selection().SetFilter(NewSelectionFilter(SelectWorkPlane))
+}
+
+// AcceptedKinds declares surface-trim picks a work plane (the cutting plane).
+func (t *SurfaceTrimTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectWorkPlane} }
+
+// Picks reports the picked cutting plane for the unified highlight.
+func (t *SurfaceTrimTool) Picks() []Selectable {
+	if t.plane == nil {
+		return nil
+	}
+	return []Selectable{WorkPlaneHandle{Plane: t.plane}}
 }
 
 // Pick captures the cutting work plane.
@@ -65,7 +75,6 @@ func (t *SurfaceTrimTool) Commit(s *Session) error {
 	if !t.added.Health().OK() {
 		return errors.New("trim: " + t.added.Health().Reason)
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 

--- a/app/surface_trim_tool.go
+++ b/app/surface_trim_tool.go
@@ -95,7 +95,7 @@ func (t *SurfaceTrimTool) DraftFeature(*Session) (feature.Feature, bool) {
 }
 
 // Cancel restores the default selection filter.
-func (t *SurfaceTrimTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *SurfaceTrimTool) Cancel(*Session) {}
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *SurfaceTrimTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/sweep_tool.go
+++ b/app/sweep_tool.go
@@ -29,9 +29,24 @@ func NewSweepTool() *SweepTool { return &SweepTool{operation: ops.NewBody} }
 // Name implements [Tool].
 func (t *SweepTool) Name() string { return "Sweep" }
 
-// Start accepts both profile and path picks.
-func (t *SweepTool) Start(s *Session) {
-	s.Selection().SetFilter(NewSelectionFilter(SelectProfile, SelectPath))
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *SweepTool) Start(*Session) {}
+
+// AcceptedKinds declares sweep picks a closed region (profile) and a path to sweep it along.
+func (t *SweepTool) AcceptedKinds() []SelectionKind {
+	return []SelectionKind{SelectProfile, SelectPath}
+}
+
+// Picks reports the picked profile and path for the unified highlight.
+func (t *SweepTool) Picks() []Selectable {
+	var picks []Selectable
+	if t.profile != nil {
+		picks = append(picks, *t.profile)
+	}
+	if t.path != nil {
+		picks = append(picks, *t.path)
+	}
+	return picks
 }
 
 // Pick routes a profile pick to the profile slot and a path pick to the path slot.
@@ -100,7 +115,6 @@ func (t *SweepTool) Commit(s *Session) error {
 	if !t.added.Health().OK() {
 		return errors.New("sweep: " + t.added.Health().Reason)
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 

--- a/app/sweep_tool.go
+++ b/app/sweep_tool.go
@@ -39,14 +39,7 @@ func (t *SweepTool) AcceptedKinds() []SelectionKind {
 
 // Picks reports the picked profile and path for the unified highlight.
 func (t *SweepTool) Picks() []Selectable {
-	var picks []Selectable
-	if t.profile != nil {
-		picks = append(picks, *t.profile)
-	}
-	if t.path != nil {
-		picks = append(picks, *t.path)
-	}
-	return picks
+	return appendPick(appendPick(nil, t.profile), t.path)
 }
 
 // Pick routes a profile pick to the profile slot and a path pick to the path slot.

--- a/app/sweep_tool.go
+++ b/app/sweep_tool.go
@@ -175,4 +175,4 @@ func (t *SweepTool) DraftFeature(*Session) (feature.Feature, bool) {
 }
 
 // Cancel restores the default selection filter.
-func (t *SweepTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *SweepTool) Cancel(*Session) {}

--- a/app/thicken_tool.go
+++ b/app/thicken_tool.go
@@ -24,8 +24,11 @@ func NewThickenTool() *ThickenTool { return &ThickenTool{thickness: 1} }
 // Name implements [Tool].
 func (t *ThickenTool) Name() string { return "Thicken" }
 
-// Start clears the selection filter (thicken needs no picks).
-func (t *ThickenTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+// Start is a no-op; thicken needs no picks.
+func (t *ThickenTool) Start(*Session) {}
+
+// AcceptedKinds declares no restriction (thicken acts on the whole body and gathers no picks).
+func (t *ThickenTool) AcceptedKinds() []SelectionKind { return nil }
 
 // Pick is a no-op — thicken acts on the running surface body, not a selection.
 
@@ -82,5 +85,5 @@ func (t *ThickenTool) DraftFeature(*Session) (feature.Feature, bool) {
 // Prompt guides the user.
 func (t *ThickenTool) Prompt(*Session) string { return "Set the thickness, then click OK" }
 
-// Cancel restores the default selection filter.
-func (t *ThickenTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+// Cancel is a no-op; the engine restores the ambient filter.
+func (t *ThickenTool) Cancel(*Session) {}

--- a/app/thread_tool.go
+++ b/app/thread_tool.go
@@ -40,12 +40,7 @@ func (t *ThreadTool) Start(*Session) {}
 func (t *ThreadTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectFace} }
 
 // Picks reports the picked cylindrical face for the unified highlight.
-func (t *ThreadTool) Picks() []Selectable {
-	if t.face == nil {
-		return nil
-	}
-	return []Selectable{*t.face}
-}
+func (t *ThreadTool) Picks() []Selectable { return singlePick(t.face) }
 
 // Pick accepts a clicked cylindrical face (ignoring non-cylindrical picks).
 func (t *ThreadTool) Pick(_ *Session, sel Selectable) {

--- a/app/thread_tool.go
+++ b/app/thread_tool.go
@@ -209,7 +209,7 @@ func (t *ThreadTool) addThread(dress *feature.DressUpFeatures) (*feature.PartFea
 }
 
 // Cancel abandons the tool.
-func (t *ThreadTool) Cancel(s *Session) { s.Selection().SetFilter(NewSelectionFilter()) }
+func (t *ThreadTool) Cancel(*Session) {}
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
 func (t *ThreadTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/thread_tool.go
+++ b/app/thread_tool.go
@@ -33,8 +33,19 @@ func NewThreadTool() *ThreadTool { return &ThreadTool{} }
 // Name implements [Tool].
 func (t *ThreadTool) Name() string { return "Thread" }
 
-// Start sets the selection filter to faces.
-func (t *ThreadTool) Start(s *Session) { s.Selection().SetFilter(NewSelectionFilter(SelectFace)) }
+// Start is a no-op; the engine installs the filter from AcceptedKinds.
+func (t *ThreadTool) Start(*Session) {}
+
+// AcceptedKinds declares thread picks a face (the cylindrical face to thread).
+func (t *ThreadTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectFace} }
+
+// Picks reports the picked cylindrical face for the unified highlight.
+func (t *ThreadTool) Picks() []Selectable {
+	if t.face == nil {
+		return nil
+	}
+	return []Selectable{*t.face}
+}
 
 // Pick accepts a clicked cylindrical face (ignoring non-cylindrical picks).
 func (t *ThreadTool) Pick(_ *Session, sel Selectable) {
@@ -178,7 +189,6 @@ func (t *ThreadTool) Commit(s *Session) error {
 	if !t.added.Health().OK() {
 		return errors.New("thread: " + t.added.Health().Reason)
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 	return nil
 }
 

--- a/app/work_plane_edit.go
+++ b/app/work_plane_edit.go
@@ -82,7 +82,6 @@ func (t *WorkPlaneEditTool) Commit(s *Session) error {
 	s.endEditScope()
 	part.Recompute()
 	s.recordEdit(part, "Edit "+t.plane.Name())
-	s.Selection().SetFilter(NewSelectionFilter())
 	if !t.plane.Health().OK() {
 		return errors.New("work plane edit: " + t.plane.Health().Reason)
 	}
@@ -99,16 +98,24 @@ func (t *WorkPlaneEditTool) Cancel(s *Session) {
 	if part, err := activePart(s); err == nil {
 		part.Recompute()
 	}
-	s.Selection().SetFilter(NewSelectionFilter())
 }
 
-// Arm puts the i-th reference slot into pick mode (its kind's filter).
+// Arm puts the i-th reference slot into pick mode; the engine installs that slot's kind filter
+// from AcceptedKinds.
 func (t *WorkPlaneEditTool) Arm(s *Session, i int) {
 	if i < 0 || i >= len(t.slots) {
 		return
 	}
 	t.armed = i
-	s.Selection().SetFilter(NewSelectionFilter(workRefFilterKinds(t.slots[i].Kind)...))
+	s.installToolFilter()
+}
+
+// AcceptedKinds declares the kinds the armed redefine slot accepts (nil when no slot is armed).
+func (t *WorkPlaneEditTool) AcceptedKinds() []SelectionKind {
+	if t.armed < 0 || t.armed >= len(t.slots) {
+		return nil
+	}
+	return workRefFilterKinds(t.slots[t.armed].Kind)
 }
 
 // ArmedSlot returns the index of the reference slot currently collecting picks, or -1.
@@ -116,7 +123,7 @@ func (t *WorkPlaneEditTool) ArmedSlot() int { return t.armed }
 
 func (t *WorkPlaneEditTool) disarm(s *Session) {
 	t.armed = -1
-	s.Selection().SetFilter(NewSelectionFilter())
+	s.installToolFilter() // armed = -1 ⇒ no restriction (back to the ambient filter)
 }
 
 func (t *WorkPlaneEditTool) recompute(s *Session) {

--- a/architecture/decisions/ADR-0041-selection-engine.md
+++ b/architecture/decisions/ADR-0041-selection-engine.md
@@ -1,0 +1,71 @@
+# ADR-0041 — Tools declare their selection; one engine owns filtering, picking and highlight
+
+**Status:** Accepted (2026-06-22) · **Touches:** the `app` selection subsystem
+(`app/selecting.go` — the `Selecting` and `Picking` contracts and `Session.installToolFilter` /
+`Session.ToolPicks`; `app/selection.go`, `app/selection_priority.go`, `app/selection_filter_state.go`
+— the existing filter/ambient state from #1222), the tool lifecycle (`app/session_input.go`), every
+interactive tool under `app/*tool*.go` / `*_tools.go`, and the head highlight layer
+(`head/ui/tool_highlight.go`).
+
+## Context
+
+Selection was **bespoke per tool**. Each of ~49 tools imperatively called
+`s.Selection().SetFilter(NewSelectionFilter(...))` in `Start` and restored it in `Cancel`/`Commit`,
+re-stating its accepted kinds inline. The head highlighted a tool's picks by **duck-typing** five
+magic accessor names (`Faces()`, `Edges()`, `PickedProfile()`, `PickedProfiles()`, `PickedFace()`);
+a tool that named its accessor anything else silently got no highlight, and work planes/axes were
+highlighted by separate ad-hoc queries.
+
+This produced real defects: Create 2D Sketch declared a work-plane-only filter, so hovering a solid's
+planar face highlighted nothing and a click resolved to the origin plane hidden behind the body —
+you could not sketch on a face. The same shape of bug could recur in any tool, and "any tool that can
+select a planar face highlights it" was not guaranteed (e.g. Extrude had no termination-face step at
+all).
+
+## Decision
+
+**Tools declare what they select; the host owns filtering, picking and highlight.** Two small
+contracts in `app/selecting.go`:
+
+- `Selecting { AcceptedKinds() []SelectionKind }` — the kinds pickable at the tool's *current step*.
+  Re-read after every pick, so a multi-step tool (Extrude: profile → termination face; Revolve:
+  profile → centerline; the redefine tools: per armed slot) changes its accepted kinds reactively.
+  Empty ⇒ no restriction (the ambient Selection Filter, #1222, applies).
+- `Picking { Picks() []Selectable }` — the tool's current picks, as one uniform list.
+
+The `Session` derives the active filter from the running tool's declaration
+(`installToolFilter`, called on tool start and after each pick) and restores the ambient filter when
+the tool ends (`restoreSelectionFilter` in `OK`/`CancelTool`). The head highlights preselection (the
+hover candidate the filter would pick) and the tool's `ToolPicks()` through **one per-kind renderer**
+(`drawSelectable`, keyed on `Selectable.SelectionKind()`): a face is outlined **and** tinted with a
+translucent on-top fill (an outline alone z-fights with the model's own edges into invisibility),
+edges/profiles are outlined, work planes/axes use their overlays.
+
+**Rules (enforced by convention + review):**
+- A tool **never** calls `Selection().SetFilter` and **never** exposes bespoke highlight accessors.
+  It declares `AcceptedKinds` and reports `Picks`.
+- A selection kind's highlight appearance is defined **once**, in the per-kind renderer.
+
+## Consequences
+
+- The Create-Sketch face-host bug class is gone: a tool's pickable kinds are declared in one place,
+  and every tool that accepts a kind highlights it identically. Extrude **To Face** was added as the
+  first new consumer (kernel/model already supported `ToFaceExtent`) and got face selection +
+  highlight for free.
+- The ~49 imperative `SetFilter` call-sites and the head's five duck-typed accessors are removed.
+- Selection state still lives in `app` (the head is a thin renderer); no public-API change, matching
+  how `SelectionPriority`/`SelectionFilterState` (#1222) shipped.
+
+## Alternatives considered
+
+- **Keep per-tool `SetFilter` + a permanent duck-typed pick adapter.** Rejected: it leaves the
+  bespoke coupling and silent-no-highlight failure mode the engine exists to remove.
+- **Intersect a tool's filter with the ambient user filter.** Deferred: a tool's declared kinds win
+  while it runs (v1), as before; intersurfacing them is a possible later refinement.
+
+## Out of scope (follow-ups)
+
+- Public-API/MCP exposure of the engine and cross-restart persistence of the ambient filter.
+- Geometric sub-type filters (planar vs cylindrical faces, linear vs circular edges) beyond the
+  coarse `SelectionKind` taxonomy.
+- Highlighting body/path/sketch-entity picks that the per-kind renderer currently draws as no-ops.

--- a/head/icon/assets/extent-to-face.svg
+++ b/head/icon/assets/extent-to-face.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M4 18 L20 18"/><path d="M4 6 L20 6" stroke="#ff0000"/><path d="M12 18 L12 9 M9 12 L12 9 L15 12" stroke="#ff0000"/></svg>

--- a/head/ui/create_sketch_face_highlight_shot_test.go
+++ b/head/ui/create_sketch_face_highlight_shot_test.go
@@ -89,3 +89,31 @@ func TestInWindowCreateSketchHoversFaceHighlight(t *testing.T) {
 		t.Logf("SaveWindowPNG: %v", err)
 	}
 }
+
+// TestInWindowToolFaceHighlightGeneralizes proves the unified face highlight is not bespoke to
+// Create Sketch: a DIFFERENT face-picking tool (Shell, which declares AcceptedKinds = {Face}) lights
+// the hovered face through the same engine path, with no Shell-specific head code (ADR-0041).
+func TestInWindowToolFaceHighlightGeneralizes(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+
+	s := boxHostSession(t)
+	frameCameraOn(s, s.VisibleBodies()[0].RangeBox())
+	s.StartTool(app.NewShellTool())
+
+	cx, cy := float32(480), float32(400)
+	for i := 0; i < 10; i++ {
+		native.InjectMousePos(cx, cy)
+		viewportFrame(win, s)
+	}
+	ox, oy := native.ItemRectMin()
+	sel, ok := s.PickAt(float64(cx-ox), float64(cy-oy), s.Selection().Filter())
+	if _, isFace := sel.(app.FaceHandle); !ok || !isFace {
+		t.Fatalf("Shell hover over a face resolved to %T (ok=%v); want a FaceHandle", sel, ok)
+	}
+	if err := win.SaveWindowPNG(filepath.Join(outDir(), "shell-face-hover.png")); err != nil {
+		t.Logf("SaveWindowPNG: %v", err)
+	}
+}

--- a/head/ui/create_sketch_face_highlight_shot_test.go
+++ b/head/ui/create_sketch_face_highlight_shot_test.go
@@ -113,6 +113,19 @@ func TestInWindowToolFaceHighlightGeneralizes(t *testing.T) {
 	if _, isFace := sel.(app.FaceHandle); !ok || !isFace {
 		t.Fatalf("Shell hover over a face resolved to %T (ok=%v); want a FaceHandle", sel, ok)
 	}
+
+	// Click the face so the tool holds a pick, then render more frames — exercising the SELECTED
+	// highlight path (toolSelectedHighlight → ToolPicks → the per-kind renderer) too.
+	native.InjectMouseButton(native.MouseLeft, true)
+	viewportFrame(win, s)
+	native.InjectMouseButton(native.MouseLeft, false)
+	for i := 0; i < 3; i++ {
+		native.InjectMousePos(cx, cy)
+		viewportFrame(win, s)
+	}
+	if picks := s.ToolPicks(); len(picks) == 0 {
+		t.Error("clicking the face did not register a Shell pick for the selected highlight")
+	}
 	if err := win.SaveWindowPNG(filepath.Join(outDir(), "shell-face-hover.png")); err != nil {
 		t.Logf("SaveWindowPNG: %v", err)
 	}

--- a/head/ui/create_sketch_face_highlight_shot_test.go
+++ b/head/ui/create_sketch_face_highlight_shot_test.go
@@ -1,0 +1,91 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// boxHostSession builds a part with one extruded box and a production-like picker (bodies AND work
+// planes), so the Create 2D Sketch hover path resolves real geometry with the origin planes hidden
+// behind the solid — the setting where the face-host bug showed up.
+func boxHostSession(t *testing.T) *app.Session {
+	t.Helper()
+	s := app.NewSession()
+	if err := app.RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	pd, err := compdef.AddPart(s.Workspace(), "facehost.opd", true)
+	if err != nil {
+		t.Fatalf("add part: %v", err)
+	}
+	_ = s.Workspace().SetActiveDocument(pd)
+	def := pd.Content().(*compdef.PartComponentDefinition)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	c0 := sk.Points().Add(math.P2(0, 0))
+	c1 := sk.Points().Add(math.P2(6, 0))
+	c2 := sk.Points().Add(math.P2(6, 6))
+	c3 := sk.Points().Add(math.P2(0, 6))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+	feature.NewExtrudeFeatures(def.Features()).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 6 })
+	def.Recompute()
+	s.SetPicker(app.NewRayPicker(s.Camera(), func() []*topo.Body { return def.SurfaceBodies().All() }).
+		WithPlanes(func() []*feature.WorkPlane { return s.PickableWorkPlanes() }))
+	return s
+}
+
+// TestInWindowCreateSketchHoversFaceHighlight is the live confirmation for the reported bug: with
+// Create 2D Sketch active and the cursor over a solid's planar face, the face must highlight (the
+// tool now accepts faces as sketch hosts, not just work planes). It drives real DrawChrome frames
+// with the cursor parked over the box in the live window and saves a PNG to read back. Skips
+// cleanly without a display/Vulkan.
+func TestInWindowCreateSketchHoversFaceHighlight(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+
+	s := boxHostSession(t)
+	frameCameraOn(s, s.VisibleBodies()[0].RangeBox())
+	s.StartTool(app.NewCreateSketchTool())
+	if s.ActiveTool() == nil {
+		t.Fatal("Create 2D Sketch tool did not start")
+	}
+
+	cx, cy := float32(480), float32(400) // fullscreen viewport ⇒ over the box's front-right face
+
+	// Settle the layout + camera and establish hover over the face (an ImGui item is not reported
+	// hovered on its first appearance), then draw several frames so the hover-highlight overlay
+	// (toolHoverHighlight → drawSelectable on the FaceHandle) renders into the captured frame.
+	for i := 0; i < 10; i++ {
+		native.InjectMousePos(cx, cy)
+		viewportFrame(win, s)
+	}
+
+	// Live regression for the reported bug: with the tool active, the cursor over the box must
+	// resolve to the FACE through the production picker — not the XY origin plane behind the solid.
+	ox, oy := native.ItemRectMin()
+	sel, ok := s.PickAt(float64(cx-ox), float64(cy-oy), s.Selection().Filter())
+	if _, isFace := sel.(app.FaceHandle); !ok || !isFace {
+		t.Fatalf("Create 2D Sketch hover over a face resolved to %T (ok=%v); want a FaceHandle", sel, ok)
+	}
+
+	if err := win.SaveWindowPNG(filepath.Join(outDir(), "create-sketch-face-hover.png")); err != nil {
+		t.Logf("SaveWindowPNG: %v", err)
+	}
+}

--- a/head/ui/extrude_dialog.go
+++ b/head/ui/extrude_dialog.go
@@ -117,16 +117,19 @@ var extrudeDirectionToggles = propertyToggleSet{
 }
 
 var extrudeExtentToggles = propertyToggleSet{
-	keys: []string{"extent-distance", "extent-through-all", "extent-to-next"},
+	keys: []string{"extent-distance", "extent-through-all", "extent-to-next", "extent-to-face"},
 	tips: []string{
 		"Distance — extrude exactly Distance A",
 		"Through All — extrude through all existing material",
 		"To Next — extrude up to the next face",
+		"To Face — extrude up to a face or work plane you then pick",
 	},
 }
 
 // extrudeExtentTypes lists the extents in the extent toggle row's order.
-var extrudeExtentTypes = []feature.ExtentType{feature.DistanceExtent, feature.ThroughAllExtent, feature.ToNextExtent}
+var extrudeExtentTypes = []feature.ExtentType{
+	feature.DistanceExtent, feature.ThroughAllExtent, feature.ToNextExtent, feature.ToFaceExtent,
+}
 
 // drawExtrudeBehavior is the Behavior section: the direction toggle row, the Distance A
 // field with the extent toggles beside it, and the Distance B field while asymmetric.

--- a/head/ui/tool_highlight.go
+++ b/head/ui/tool_highlight.go
@@ -81,8 +81,34 @@ func toolHoverHighlight(s *app.Session) []renderer.DrawItem {
 	if !ok {
 		return nil
 	}
-	return drawSelectable(sel, sketchCandidateColor)
+	items := drawSelectable(sel, sketchCandidateColor)
+	// A face's outline coincides with the model's own edges, so an at-depth wireframe alone is
+	// nearly invisible. Tint the whole hovered face (Inventor's preselect look) so picking a face
+	// — e.g. choosing a planar face as a sketch host — gives unmistakable feedback.
+	if fh, isFace := sel.(app.FaceHandle); isFace {
+		items = append(items, faceHoverFill(fh, sketchCandidateColor))
+	}
+	return items
 }
+
+// faceHoverFill returns a translucent, always-on-top tint of a face's tessellation in the candidate
+// colour — the visible part of the face preselect highlight (the cursor's face is the front-most
+// hit, so drawing it on top reads cleanly without z-fighting the model's edges).
+func faceHoverFill(fh app.FaceHandle, color [4]float32) renderer.DrawItem {
+	mesh := ops.TessellateFace(fh.Face, ops.DefaultQuality())
+	return renderer.DrawItem{
+		Primitive: renderer.Triangles,
+		Positions: mesh.Positions,
+		Normals:   mesh.Normals,
+		Indices:   mesh.Indices,
+		Color:     color,
+		Opacity:   faceHoverOpacity,
+		OnTop:     true,
+	}
+}
+
+// faceHoverOpacity keeps the hovered-face tint translucent so the face's shading still reads through.
+const faceHoverOpacity = 0.5
 
 // toolSelectedHighlight outlines everything the active tool has picked, in the selection colour —
 // gathered from the tool's existing accessors (toolPicks), so all tools highlight their picks.

--- a/head/ui/tool_highlight.go
+++ b/head/ui/tool_highlight.go
@@ -13,15 +13,18 @@ import (
 )
 
 // Unified tool highlighting: every interactive tool gives the SAME feedback — the selectable
-// under the cursor (that the tool's filter would pick) is outlined in the candidate colour, and
-// what the tool has already picked is outlined in the selection colour. Both run off one per-kind
-// dispatcher (drawSelectable) and the tool's existing pick accessors (toolPicks), so a new tool
-// needs no head-side highlight code. Work planes and sketch curves keep their own overlays
-// (planesOverlay/hoveredPlane and revolveCenterlineHighlight) since they are not B-rep selectables.
+// under the cursor (that the tool's filter would pick) is highlighted in the candidate colour, and
+// what the tool has already picked (reported through the app.Picking contract) is highlighted in
+// the selection colour. Both run off one per-kind renderer (drawSelectable), so a tool that
+// accepts a kind highlights it identically with no head-side per-tool code (ADR-0041). Work planes
+// and axes keep their own overlays (planesOverlay/hoveredPlane), but go through the same
+// preselect path via hoveredPlane.
 
-// drawSelectable returns the overlay wireframe for one selectable in colour — the kinds tools
-// pick in the 3D view (a sketch profile region, a B-rep edge, a B-rep face). Other kinds (work
-// planes, sketch entities) are drawn by their dedicated overlays and return nil here.
+// drawSelectable returns the overlay for one selectable in colour, keyed on its kind — the single
+// place a selection kind's highlight appearance is defined. A face is both outlined AND tinted
+// with a translucent on-top fill, because a face's outline coincides with the model's own edges
+// and z-fights into invisibility on its own. Kinds drawn by dedicated overlays (work planes/axes,
+// sketch entities) return nil here.
 func drawSelectable(sel app.Selectable, color [4]float32) []renderer.DrawItem {
 	switch h := sel.(type) {
 	case app.ProfileHandle:
@@ -29,7 +32,7 @@ func drawSelectable(sel app.Selectable, color [4]float32) []renderer.DrawItem {
 	case app.EdgeHandle:
 		return edgeWire([]*topo.Edge{h.Edge}, color)
 	case app.FaceHandle:
-		return edgeWire(h.Face.Edges(), color)
+		return append(edgeWire(h.Face.Edges(), color), faceFill(h, color))
 	}
 	return nil
 }
@@ -66,8 +69,9 @@ func highlightSetItems(s *app.Session) []renderer.DrawItem {
 	return items
 }
 
-// toolHoverHighlight outlines the selectable under the cursor that the active tool would pick,
-// in the candidate colour — the same hover feedback for every tool.
+// toolHoverHighlight highlights the selectable under the cursor that the active tool would pick,
+// in the candidate colour — the same preselect feedback for every tool, through the one per-kind
+// renderer.
 func toolHoverHighlight(s *app.Session) []renderer.DrawItem {
 	if s.ActiveTool() == nil || !native.IsItemHovered() {
 		return nil
@@ -81,20 +85,13 @@ func toolHoverHighlight(s *app.Session) []renderer.DrawItem {
 	if !ok {
 		return nil
 	}
-	items := drawSelectable(sel, sketchCandidateColor)
-	// A face's outline coincides with the model's own edges, so an at-depth wireframe alone is
-	// nearly invisible. Tint the whole hovered face (Inventor's preselect look) so picking a face
-	// — e.g. choosing a planar face as a sketch host — gives unmistakable feedback.
-	if fh, isFace := sel.(app.FaceHandle); isFace {
-		items = append(items, faceHoverFill(fh, sketchCandidateColor))
-	}
-	return items
+	return drawSelectable(sel, sketchCandidateColor)
 }
 
-// faceHoverFill returns a translucent, always-on-top tint of a face's tessellation in the candidate
-// colour — the visible part of the face preselect highlight (the cursor's face is the front-most
-// hit, so drawing it on top reads cleanly without z-fighting the model's edges).
-func faceHoverFill(fh app.FaceHandle, color [4]float32) renderer.DrawItem {
+// faceFill returns a translucent, always-on-top tint of a face's tessellation — the visible part
+// of a face highlight (the highlighted face is the front-most hit, so drawing it on top reads
+// cleanly without z-fighting the model's own edges). Used for both preselect and selected faces.
+func faceFill(fh app.FaceHandle, color [4]float32) renderer.DrawItem {
 	mesh := ops.TessellateFace(fh.Face, ops.DefaultQuality())
 	return renderer.DrawItem{
 		Primitive: renderer.Triangles,
@@ -102,57 +99,21 @@ func faceHoverFill(fh app.FaceHandle, color [4]float32) renderer.DrawItem {
 		Normals:   mesh.Normals,
 		Indices:   mesh.Indices,
 		Color:     color,
-		Opacity:   faceHoverOpacity,
+		Opacity:   faceFillOpacity,
 		OnTop:     true,
 	}
 }
 
-// faceHoverOpacity keeps the hovered-face tint translucent so the face's shading still reads through.
-const faceHoverOpacity = 0.5
+// faceFillOpacity keeps the face tint translucent so the face's shading still reads through.
+const faceFillOpacity = 0.5
 
-// toolSelectedHighlight outlines everything the active tool has picked, in the selection colour —
-// gathered from the tool's existing accessors (toolPicks), so all tools highlight their picks.
+// toolSelectedHighlight highlights everything the active tool has picked, in the selection colour —
+// the picks come from the uniform app.Picking contract (s.ToolPicks), so every tool highlights its
+// selection through the same renderer with no per-tool head code.
 func toolSelectedHighlight(s *app.Session) []renderer.DrawItem {
-	at := s.ActiveTool()
-	if at == nil {
-		return nil
-	}
 	var items []renderer.DrawItem
-	for _, sel := range toolPicks(at.Tool()) {
+	for _, sel := range s.ToolPicks() {
 		items = append(items, drawSelectable(sel, selectionHighlight)...)
 	}
 	return items
-}
-
-// toolPicks gathers the selectables a tool has picked from whichever accessor interfaces it
-// already implements (Edges/Faces/PickedProfiles/PickedProfile/PickedFace) — no per-tool method.
-func toolPicks(t app.Tool) []app.Selectable {
-	var picks []app.Selectable
-	if el, ok := t.(interface{ Edges() []app.EdgeHandle }); ok {
-		for _, e := range el.Edges() {
-			picks = append(picks, e)
-		}
-	}
-	if fl, ok := t.(interface{ Faces() []app.FaceHandle }); ok {
-		for _, f := range fl.Faces() {
-			picks = append(picks, f)
-		}
-	}
-	if pl, ok := t.(interface{ PickedProfiles() []app.ProfileHandle }); ok {
-		for _, p := range pl.PickedProfiles() {
-			picks = append(picks, p)
-		}
-	} else if pp, ok := t.(interface {
-		PickedProfile() (app.ProfileHandle, bool)
-	}); ok {
-		if ph, has := pp.PickedProfile(); has {
-			picks = append(picks, ph)
-		}
-	}
-	if hf, ok := t.(interface{ PickedFace() (app.FaceHandle, bool) }); ok {
-		if fh, has := hf.PickedFace(); has {
-			picks = append(picks, fh)
-		}
-	}
-	return picks
 }

--- a/model/feature/work_plane.go
+++ b/model/feature/work_plane.go
@@ -117,6 +117,14 @@ func (w *WorkPlane) Health() health.Health { return w.health }
 // Plane returns the current datum plane, also usable directly as a sketch host.
 func (w *WorkPlane) Plane() sketch.Plane { return w.plane }
 
+// NewFixedWorkPlane returns a transient work plane fixed at the given plane, not part of any
+// work-geometry collection. It is used as an extent target — e.g. a "to face" termination derived
+// from a picked planar face — where only Plane() is consulted. It carries no key/provenance, so it
+// is not persisted as a datum; persisting a face-based to-face target is a follow-up.
+func NewFixedWorkPlane(plane sketch.Plane) *WorkPlane {
+	return &WorkPlane{id: nextID(), plane: plane, displaySize: defaultOriginPlaneSize, visible: true}
+}
+
 // DisplaySize is the half-edge length of the square the plane is drawn/picked as.
 func (w *WorkPlane) DisplaySize() float64 { return w.displaySize }
 


### PR DESCRIPTION
## What & why

Selection was **bespoke per tool**: ~49 tools each imperatively called `Selection().SetFilter(...)` and the head highlighted picks by **duck-typing five magic accessor names**. This caused real bugs (Create 2D Sketch couldn't sketch on a planar face — it picked the origin plane hidden behind the body) and meant "any tool that can select a face highlights it" was not guaranteed (Extrude had no termination-face step at all).

This PR introduces a clearly-defined **selection engine** (ADR-0041): tools **declare** what they select and **report** what they picked; the host owns filtering, picking, and highlight.

## How

Two small contracts in `app/selecting.go`:
- `Selecting { AcceptedKinds() []SelectionKind }` — the kinds pickable at the tool's *current step*, re-read after every pick (multi-step tools change reactively).
- `Picking { Picks() []Selectable }` — the tool's picks, one uniform list.

The `Session` derives the active filter from the running tool (`installToolFilter`, on start + after each pick) and restores the ambient filter on commit/cancel. The head highlights preselection and `ToolPicks()` through **one per-kind renderer** keyed on `Selectable.SelectionKind()` — a face is outlined **and** tinted with a translucent on-top fill (an outline alone z-fights into invisibility); the duck-typed accessors are gone.

**Every selecting tool migrated** (face/edge/profile dress-ups, sweep/loft/revolve, assembly, sheet-metal, the redefine tools, …). Rules: a tool never calls `SetFilter` and never exposes bespoke highlight accessors.

### Bugs fixed / capability added
- **Create 2D Sketch** now accepts planar faces as hosts (the canonical engine consumer) — fixes the reported "hovering a face/work plane doesn't highlight" bug.
- **Extrude → To Face**: added the termination-face pick step (kernel/model already supported `ToFaceExtent`) as the engine's proof case; it gets face selection + highlight for free.

## Validation
- Full root `go test ./...` green; `app` + `model/feature` suites green; root `golangci-lint` 0 issues; both modules build.
- New tests: engine core (filter per step, restore, `Picks`), Create-Sketch face hosts, Extrude To-Face (tool flow + terminates at the picked plane).
- **Live (lavapipe + xvfb):** in-window captures confirm the unified face highlight renders for Create Sketch **and** generalizes to a non-sketch tool (Shell), and that the cursor resolves to the face (not the plane behind).
- No public-API change (in-proc, consistent with #1222).

🤖 Generated with [Claude Code](https://claude.com/claude-code)