### PR TITLE
Wire Extrude To-Face into the features API (add-in/MCP drivable)

### DIFF
--- a/addin/opregistry/extrude.go
+++ b/addin/opregistry/extrude.go
@@ -23,10 +23,11 @@ type extrudeArgs struct {
 	ProfileIndex   int    `json:"profileIndex"`
 	Distance       string `json:"distance"`                 // e.g. "50 mm", "5 cm"
 	Operation      string `json:"operation"`                // join|cut|intersect|new (default new)
-	Extent         string `json:"extent,omitempty"`         // distance|through-all|to-next (default distance)
+	Extent         string `json:"extent,omitempty"`         // distance|through-all|to-next|to-face (default distance)
 	Direction      string `json:"direction,omitempty"`      // positive|negative|symmetric (default positive)
 	SecondDistance string `json:"secondDistance,omitempty"` // asymmetric two-direction depth
 	Taper          string `json:"taper,omitempty"`          // draft angle, e.g. "3 deg"
+	ToFace         string `json:"toFace,omitempty"`         // to-face target: a planar face key, "plane/N", or "origin/plane/xy"
 }
 
 const extrudeSchema = `{
@@ -36,10 +37,11 @@ const extrudeSchema = `{
     "profileIndex": {"type": "integer", "minimum": 0, "default": 0, "description": "Which closed profile of the sketch to extrude."},
     "distance": {"type": "string", "description": "Extrude depth with units, e.g. \"50 mm\" or \"5 cm\". Required for distance and distance-from-face extents."},
     "operation": {"type": "string", "enum": ["new", "join", "cut", "intersect"], "default": "new", "description": "Boolean against existing bodies."},
-    "extent": {"type": "string", "enum": ["distance", "through-all", "to-next"], "default": "distance", "description": "How the extrude terminates."},
+    "extent": {"type": "string", "enum": ["distance", "through-all", "to-next", "to-face"], "default": "distance", "description": "How the extrude terminates."},
     "direction": {"type": "string", "enum": ["positive", "negative", "symmetric"], "default": "positive", "description": "Which side(s) of the sketch plane to grow."},
     "secondDistance": {"type": "string", "description": "Asymmetric two-direction depth on the negative side, e.g. \"10 mm\"."},
-    "taper": {"type": "string", "description": "Draft angle, e.g. \"3 deg\" (positive widens away from the sketch)."}
+    "taper": {"type": "string", "description": "Draft angle, e.g. \"3 deg\" (positive widens away from the sketch)."},
+    "toFace": {"type": "string", "description": "Termination target for the to-face extent: a planar face reference key (from model.referenceKeys), a work plane (\"plane/N\"), or an origin plane (\"origin/plane/xy\")."}
   },
   "required": ["sketchIndex"]
 }`
@@ -99,17 +101,40 @@ func resolveExtrude(part *compdef.PartComponentDefinition, raw json.RawMessage) 
 	return in, sk, extent, op, taper, nil
 }
 
-// buildExtent assembles the model extent from the request: the extent type and direction,
-// plus the distance(s) for the distance extent.
+// buildExtent assembles the model extent from the request: the extent type and direction, plus
+// the distance(s) for the distance extent or the termination plane for the to-face extent.
 func buildExtent(part *compdef.PartComponentDefinition, in extrudeArgs) (feature.Extent, error) {
 	etype, err := parseExtentType(in.Extent)
 	if err != nil {
 		return feature.Extent{}, err
 	}
 	ext := feature.Extent{Type: etype, Direction: parseExtentDirection(in.Direction)}
-	if etype != feature.DistanceExtent {
+	switch etype {
+	case feature.ToFaceExtent:
+		return withToFaceTarget(part, ext, in.ToFace)
+	case feature.DistanceExtent:
+		return withDistance(part, ext, in)
+	default:
 		return ext, nil // through-all / to-next are gauged from the model, not a distance
 	}
+}
+
+// withToFaceTarget resolves the to-face termination reference (a planar face key, "plane/N", or
+// "origin/plane/xy") onto the extent's ToPlane.
+func withToFaceTarget(part *compdef.PartComponentDefinition, ext feature.Extent, ref string) (feature.Extent, error) {
+	if strings.TrimSpace(ref) == "" {
+		return feature.Extent{}, errors.New(`extrude: to-face extent requires "toFace" (a planar face key, "plane/N", or "origin/plane/xy")`)
+	}
+	wp, err := part.WorkGeometry().PlaneTargetFromRef(ref)
+	if err != nil {
+		return feature.Extent{}, fmt.Errorf("extrude: to-face target %q: %w", ref, err)
+	}
+	ext.ToPlane = wp
+	return ext, nil
+}
+
+// withDistance fills the distance extent's primary (and optional asymmetric) depth.
+func withDistance(part *compdef.PartComponentDefinition, ext feature.Extent, in extrudeArgs) (feature.Extent, error) {
 	dist, err := lengthClosure(part, in.Distance, "extrude: distance")
 	if err != nil {
 		return feature.Extent{}, err
@@ -140,9 +165,9 @@ func parseTaperAngle(part *compdef.PartComponentDefinition, expr string) (float6
 	return a.Value, nil
 }
 
-// parseExtentType maps an extent name to its model type (empty ⇒ distance). Reference
-// extents (to-face / from-to / distance-from-face) need a target plane and are not yet
-// exposed over the JSON API.
+// parseExtentType maps an extent name to its model type (empty ⇒ distance). The to-face extent
+// terminates at a plane the request names via "toFace"; the remaining reference extents (from-to /
+// distance-from-face) are not yet exposed over the JSON API.
 func parseExtentType(name string) (feature.ExtentType, error) {
 	switch strings.ToLower(strings.TrimSpace(name)) {
 	case "", "distance":
@@ -151,8 +176,10 @@ func parseExtentType(name string) (feature.ExtentType, error) {
 		return feature.ThroughAllExtent, nil
 	case "to-next", "tonext":
 		return feature.ToNextExtent, nil
+	case "to-face", "toface":
+		return feature.ToFaceExtent, nil
 	default:
-		return 0, fmt.Errorf("extrude: unknown extent %q (want distance|through-all|to-next)", name)
+		return 0, fmt.Errorf("extrude: unknown extent %q (want distance|through-all|to-next|to-face)", name)
 	}
 }
 

--- a/addin/opregistry/extrude_toface_test.go
+++ b/addin/opregistry/extrude_toface_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"testing"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/compdef"
+)
+
+// topFaceKey returns the reference key of the body's highest face (greatest range-box centre z) —
+// a planar cap to use as a to-face termination target.
+func topFaceKey(b *topo.Body) string {
+	var best *topo.Face
+	for _, f := range b.Faces() {
+		if best == nil || f.RangeBox().Center().Z > best.RangeBox().Center().Z {
+			best = f
+		}
+	}
+	return string(best.ReferenceKey())
+}
+
+// TestExtrudeToFaceApply exercises the to-face extent in-package: extrude a profile up to an
+// existing body's top face (given by key), proving the op resolves the termination plane and
+// produces a healthy body. This is the coverage twin of the router/wire test (#1226 → API).
+func TestExtrudeToFaceApply(t *testing.T) {
+	s := profiledPart(t)
+	if _, err := apply(t, s, "extrude", `{"sketchIndex":0,"distance":"10 mm"}`); err != nil {
+		t.Fatalf("seed extrude: %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	top := topFaceKey(def.SurfaceBodies().Item(0))
+
+	args, _ := json.Marshal(map[string]any{
+		"sketchIndex": 1, "profileIndex": 0, "extent": "to-face", "toFace": top, "operation": "new",
+	})
+	out, err := apply(t, s, "extrude", string(args))
+	if err != nil {
+		t.Fatalf("to-face extrude: %v", err)
+	}
+	var res struct {
+		Bodies  int  `json:"bodies"`
+		Healthy bool `json:"healthy"`
+	}
+	if err := json.Unmarshal(out, &res); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !res.Healthy || res.Bodies != 2 {
+		t.Fatalf("to-face result = %+v, want healthy with 2 bodies", res)
+	}
+}
+
+// TestExtrudeToFaceApplyErrors covers the to-face guard rails: a missing target and an
+// unresolvable target reference are both clear errors, not silent successes.
+func TestExtrudeToFaceApplyErrors(t *testing.T) {
+	if _, err := apply(t, profiledPart(t), "extrude", `{"sketchIndex":0,"extent":"to-face"}`); err == nil {
+		t.Error("to-face without a toFace target should error")
+	}
+	if _, err := apply(t, profiledPart(t), "extrude", `{"sketchIndex":0,"extent":"to-face","toFace":"plane/99"}`); err == nil {
+		t.Error("to-face with an unresolvable target should error")
+	}
+}

--- a/addin/router/extrude_toface_wire_test.go
+++ b/addin/router/extrude_toface_wire_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// featureAddResult mirrors the opregistry featureResult shape returned by features.add.
+type featureAddResult struct {
+	Bodies  int    `json:"bodies"`
+	Healthy bool   `json:"healthy"`
+	Reason  string `json:"reason"`
+}
+
+// TestExtrudeToFaceOverWire drives the new "to-face" extent through features.add (the path an
+// add-in or MCP client uses): extrude a profile up to an existing body's planar face, given by its
+// reference key. The new body must terminate at that face, not at a typed distance (#1226 engine
+// → API). This is the add-in-drivable form of Extrude To-Face.
+func TestExtrudeToFaceOverWire(t *testing.T) {
+	r, s := boxPartSession(t) // base body: 40×30×50 mm, top face at z = 5 cm
+
+	var keys wire.ReferenceKeysResult
+	call(t, r, s, "model.referenceKeys", `{}`, &keys)
+	top := faceKeyAtZ(keys.Bodies[0].Faces, 4.9)
+	if top == "" {
+		t.Fatal("no top face found on the base body")
+	}
+
+	// A second profile on XY, extruded "to face" up to the base body's top face.
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":1,"width":"10 mm","height":"10 mm"}`, &wire.SketchRectangleResult{})
+	args, _ := json.Marshal(map[string]any{
+		"kind": "extrude",
+		"args": map[string]any{
+			"sketchIndex": 1, "profileIndex": 0, "extent": "to-face", "toFace": top, "operation": "new",
+		},
+	})
+	var res featureAddResult
+	call(t, r, s, "features.add", string(args), &res)
+	if !res.Healthy {
+		t.Fatalf("to-face extrude unhealthy: %s", res.Reason)
+	}
+	if res.Bodies != 2 {
+		t.Fatalf("bodies = %d, want 2 (base + to-face body)", res.Bodies)
+	}
+
+	// The new body must reach the target plane (top face z ≈ 5), proving it terminated there.
+	call(t, r, s, "model.referenceKeys", `{}`, &keys)
+	if got := maxFaceZ(keys.Bodies[1].Faces); got < 4.9 || got > 5.1 {
+		t.Errorf("to-face body top z = %v, want ~5 (terminated at the picked face)", got)
+	}
+}
+
+// TestExtrudeToFaceRequiresTarget: the to-face extent without a toFace reference is a clear error,
+// not a silent default.
+func TestExtrudeToFaceRequiresTarget(t *testing.T) {
+	r, s := boxPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":1,"width":"10 mm","height":"10 mm"}`, &wire.SketchRectangleResult{})
+	if _, err := r.Handle(s, "features.add", []byte(`{"kind":"extrude","args":{"sketchIndex":1,"extent":"to-face"}}`)); err == nil {
+		t.Fatal("to-face extrude without a toFace target should error")
+	}
+}
+
+// faceKeyAtZ returns the key of the first face whose representative point sits at or above minZ.
+func faceKeyAtZ(faces []wire.TopologyRef, minZ float64) string {
+	for _, f := range faces {
+		if len(f.Point) == 3 && f.Point[2] >= minZ {
+			return f.Key
+		}
+	}
+	return ""
+}
+
+// maxFaceZ returns the greatest representative-point z over the faces.
+func maxFaceZ(faces []wire.TopologyRef) float64 {
+	max := -1e18
+	for _, f := range faces {
+		if len(f.Point) == 3 && f.Point[2] > max {
+			max = f.Point[2]
+		}
+	}
+	return max
+}

--- a/addin/router/work_planes.go
+++ b/addin/router/work_planes.go
@@ -5,7 +5,6 @@ package router
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"oblikovati.org/addin/modelaccess"
 	"oblikovati.org/api/types"
@@ -360,29 +359,9 @@ func toWorkRefs(refs []string) []feature.WorkRef {
 // ("vertex/…") — passes through verbatim; any other string is a B-rep topology reference key
 // (from model.referenceKeys) and is tagged as a FaceRef so the resolver builds the plane on
 // that body face. This lets a user work point/plane/axis feed another work feature over the
-// wire (e.g. a three-point plane through three created points, or a redefine re-pick).
-func toWorkRef(r string) feature.WorkRef {
-	if isWorkFeatureRef(r) {
-		return feature.WorkRef(r)
-	}
-	return feature.FaceRef([]byte(r))
-}
-
-// workFeatureRefPrefixes are the reference-string prefixes that name a work feature (an origin
-// element, a user plane/axis/point/coordinate-system, or an encoded vertex) rather than a raw
-// B-rep face key.
-var workFeatureRefPrefixes = []string{"origin/", "plane/", "axis/", "point/", "ucs/", "vertex/"}
-
-// isWorkFeatureRef reports whether r names a work feature (so it is passed through as a plane/
-// axis/point ref) rather than a raw face key.
-func isWorkFeatureRef(r string) bool {
-	for _, p := range workFeatureRefPrefixes {
-		if strings.HasPrefix(r, p) {
-			return true
-		}
-	}
-	return false
-}
+// wire (e.g. a three-point plane through three created points, or a redefine re-pick). The
+// classification lives in feature.ParseWorkRef so the router and the op registry share it.
+func toWorkRef(r string) feature.WorkRef { return feature.ParseWorkRef(r) }
 
 // modelLengthClosure turns a distance argument into a live, parameter-aware value: a
 // plain literal is constant; an expression ("h", "h/2") is backed by an auto model

--- a/architecture/decisions/ADR-0041-selection-engine.md
+++ b/architecture/decisions/ADR-0041-selection-engine.md
@@ -63,9 +63,28 @@ edges/profiles are outlined, work planes/axes use their overlays.
 - **Intersect a tool's filter with the ambient user filter.** Deferred: a tool's declared kinds win
   while it runs (v1), as before; intersurfacing them is a possible later refinement.
 
+## API / add-in exposure
+
+The engine is **not** exposed over the wire, and deliberately so: add-ins drive the model by
+*reference*, not by interactive picking. A feature that takes a geometric input takes a reference
+key — and the host resolves it the same way a viewport pick would. So **Extrude "To Face" is
+add-in-/MCP-drivable through the existing `features.add` path** (no new wire method): the extrude
+kind's schema gains `extent: "to-face"` + a `toFace` reference (a planar face key from
+`model.referenceKeys`, a work plane `"plane/N"`, or an origin plane `"origin/plane/xy"`), resolved
+by the shared `feature.WorkGeometry.PlaneTargetFromRef` (also used by the router's plane re-pick, via
+`feature.ParseWorkRef`, so the two never drift). The selection-*set* is already
+read/mutable over the wire (`model.select` / `deselect` / `clearSelection` / `selection` +
+`selection.changed`). The interactive engine (`AcceptedKinds`/`Picks`, the ambient filter) stays a
+host concern — there is no live cursor for a headless add-in — so wiring it would add surface with
+no consumer. If a future add-in genuinely needs to constrain the *user's* ambient selection, that is
+a small get/set on the `SelectionFilterState` (#1222), added then, not speculatively.
+
 ## Out of scope (follow-ups)
 
-- Public-API/MCP exposure of the engine and cross-restart persistence of the ambient filter.
+- Cross-restart persistence of the ambient filter; a get/set wire surface for it only if an add-in
+  needs to steer the user's selection.
+- The remaining reference extents over the API (from-to, distance-from-face) — the same
+  `PlaneTargetFromRef` seam, wired when needed.
 - Geometric sub-type filters (planar vs cylindrical faces, linear vs circular edges) beyond the
   coarse `SelectionKind` taxonomy.
 - Highlighting body/path/sketch-entity picks that the per-kind renderer currently draws as no-ops.

--- a/model/feature/work_ref_parse.go
+++ b/model/feature/work_ref_parse.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "strings"
+
+// workFeatureRefPrefixes are the reference-string prefixes that name a work feature — an origin
+// datum, a user plane/axis/point, a UCS, or a model vertex — rather than a raw B-rep face key.
+var workFeatureRefPrefixes = []string{"origin/", "plane/", "axis/", "point/", "ucs/", "vertex/"}
+
+// ParseWorkRef classifies a raw reference string from the wire: a work-feature reference is kept
+// verbatim; any other string is treated as a raw B-rep face key and wrapped as a face ref. It is
+// the single place the wire reference vocabulary is interpreted, shared by the add-in router and
+// the operation registry (so the two never drift).
+func ParseWorkRef(r string) WorkRef {
+	for _, p := range workFeatureRefPrefixes {
+		if strings.HasPrefix(r, p) {
+			return WorkRef(r)
+		}
+	}
+	return faceRef([]byte(r))
+}
+
+// PlaneTargetFromRef resolves a raw plane reference — a work plane ("plane/N"), an origin plane
+// ("origin/plane/xy"), or a planar B-rep face key — to a *WorkPlane usable as a feature target,
+// e.g. an extrude's to-face termination. A work/origin plane resolves to its datum; a planar face
+// key yields a transient fixed plane ([NewFixedWorkPlane]). An unresolvable reference is an error.
+func (g *WorkGeometry) PlaneTargetFromRef(ref string) (*WorkPlane, error) {
+	wr := ParseWorkRef(ref)
+	if wp, err := g.WorkPlaneByRef(wr); err == nil {
+		return wp, nil
+	}
+	pl, err := g.plane(wr)
+	if err != nil {
+		return nil, err
+	}
+	return NewFixedWorkPlane(pl), nil
+}

--- a/model/feature/work_ref_parse_test.go
+++ b/model/feature/work_ref_parse_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+)
+
+// TestParseWorkRefClassifies: work-feature refs pass through verbatim; anything else is wrapped as
+// a face ref (and decodes back to the original key).
+func TestParseWorkRefClassifies(t *testing.T) {
+	if got := ParseWorkRef("origin/plane/xy"); got != WorkRef("origin/plane/xy") {
+		t.Errorf("work-feature ref = %q, want it verbatim", got)
+	}
+	if got := ParseWorkRef("plane/3"); got != WorkRef("plane/3") {
+		t.Errorf("user plane ref = %q, want it verbatim", got)
+	}
+	key := []byte("some-face-key")
+	wr := ParseWorkRef(string(key))
+	if back, ok := FaceRefKey(wr); !ok || string(back) != string(key) {
+		t.Errorf("raw key was not wrapped as a face ref: got %q (decoded %q, ok=%v)", wr, back, ok)
+	}
+}
+
+// TestPlaneTargetFromRefResolvesPlanes: an origin plane and a user work plane both resolve to a
+// *WorkPlane target, and an unknown reference errors.
+func TestPlaneTargetFromRefResolvesPlanes(t *testing.T) {
+	g := NewWorkGeometry()
+
+	xy, err := g.PlaneTargetFromRef("origin/plane/xy")
+	if err != nil {
+		t.Fatalf("origin XY: %v", err)
+	}
+	if n := xy.Plane().Normal().AsVector(); stdmath.Abs(float64(n.Z)) < 0.999 {
+		t.Errorf("origin XY normal = %v, want ±Z", n)
+	}
+
+	off := g.WorkPlanes().AddByPlaneAndOffset(OriginXYPlane, func() float64 { return 5 }) // z = 5
+	wp, err := g.PlaneTargetFromRef(string(off.Key()))
+	if err != nil {
+		t.Fatalf("user plane: %v", err)
+	}
+	if z := float64(wp.Plane().Origin().Z); stdmath.Abs(z-5) > 1e-6 {
+		t.Errorf("offset plane origin z = %v, want 5", z)
+	}
+
+	if _, err := g.PlaneTargetFromRef("plane/99"); err == nil {
+		t.Error("an unknown plane reference should error")
+	}
+}


### PR DESCRIPTION
## What & why

Follow-up to the selection engine (#1226). **Extrude "To Face" is now drivable by add-ins / MCP** through the existing `features.add` path — no new wire method or DTO.

The extrude feature-kind schema (served from `/source` opregistry, discovered by MCP via `list_feature_kinds`) gains:
- `extent: "to-face"`
- `toFace`: the termination reference — a planar **face key** (from `model.referenceKeys`), a work plane (`"plane/N"`), or an origin plane (`"origin/plane/xy"`).

So an add-in calls `add_feature` with `{kind:"extrude", args:{sketchIndex, extent:"to-face", toFace:<ref>}}` and the host resolves the target the same way a viewport pick would.

## How
- New shared resolver in the `feature` package: `ParseWorkRef` (classifies a wire ref: work-feature ref vs raw face key) + `WorkGeometry.PlaneTargetFromRef` (→ `*WorkPlane`, using `NewFixedWorkPlane` for a face key). The router's `toWorkRef` now **delegates** to `ParseWorkRef`, removing the duplicated prefix list so the router and op registry never drift.
- `addin/opregistry/extrude.go`: `to-face` extent + `toFace` ref → `Extent.ToPlane`, with a clear error when `toFace` is missing.

## Selection engine as an API?
Assessed and **intentionally not exposed** (recorded in ADR-0041): add-ins drive features by *reference*, not by interactive picking (there's no live cursor for a headless add-in). The selection *set* is already wire-read/mutable (`model.select`/`deselect`/`clearSelection`/`selection`). A get/set for the user's ambient filter is a small, on-demand follow-up — added when an add-in actually needs it, not speculatively.

## Validation
- New tests: `feature` resolver unit tests (ref classification + plane/origin/error resolution); router wire tests — `features.add` extrude `to-face` terminates a new body at the picked face, and missing `toFace` errors.
- Full root `go test ./...` green; `golangci-lint` 0 issues on touched packages; whole module builds. No API-repo or MCP-bridge change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)