### PR TITLE
Fix release builds shipping Version=dev (#1228)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,10 @@ on:
         required: false
 
 env:
-  # Stamp build.{Version,Commit,Date}; Commit/Date are filled per job.
-  CORE: oblikovati
+  # The Go module path, used to address the build.{Version,Commit,Date} symbols for `-ldflags -X`
+  # (Commit/Date are filled per job). It MUST equal the module path in go.mod — a mismatch makes
+  # the linker silently ignore the -X and ship Version="dev" (issue #1228).
+  CORE: oblikovati.org
 
 jobs:
   # CLI — pure Go, cross-compiled for every target in one job.

--- a/build/stamp_workflow_test.go
+++ b/build/stamp_workflow_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package build
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestReleaseWorkflowStampsCorrectSymbolPath is the regression guard for issue #1228: the release
+// build (.github/workflows/build.yml) addresses build.Version/Commit/Date with
+// `-ldflags -X ${CORE}/build.Version=…`, and CORE MUST equal the module path in go.mod. When it did
+// not ("oblikovati" vs "oblikovati.org"), the linker silently ignored every -X and shipped builds
+// stamped Version="dev", so the channel-aware update check treated nightlies as dev and never
+// offered updates. A linker -X to a non-existent symbol is a no-op, so only this static check
+// catches the drift.
+func TestReleaseWorkflowStampsCorrectSymbolPath(t *testing.T) {
+	module := readModulePath(t)
+	core := readWorkflowCore(t)
+	if core != module {
+		t.Fatalf("build.yml CORE = %q but go.mod module = %q; -ldflags -X %s/build.Version would be\n"+
+			"ignored, shipping Version=%q (issue #1228). Set CORE to the module path.",
+			core, module, core, Version)
+	}
+}
+
+// readModulePath returns the module path from the repo-root go.mod (the build package lives at the
+// module root, so go.mod is one directory up).
+func readModulePath(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile("../go.mod")
+	if err != nil {
+		t.Fatalf("read go.mod: %v", err)
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		if rest, ok := strings.CutPrefix(strings.TrimSpace(line), "module "); ok {
+			return strings.TrimSpace(rest)
+		}
+	}
+	t.Fatal("no module directive in go.mod")
+	return ""
+}
+
+// readWorkflowCore returns the CORE env value from the reusable build workflow.
+func readWorkflowCore(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile("../.github/workflows/build.yml")
+	if err != nil {
+		t.Fatalf("read build.yml: %v", err)
+	}
+	m := regexp.MustCompile(`(?m)^\s*CORE:\s*(\S+)\s*$`).FindStringSubmatch(string(b))
+	if m == nil {
+		t.Fatal("no CORE: entry in build.yml")
+	}
+	return m[1]
+}


### PR DESCRIPTION
Fixes #1228.

## Root cause
The reusable build workflow (`.github/workflows/build.yml`) stamps the build metadata with `-ldflags "-X ${CORE}/build.Version=… -X ${CORE}/build.Commit=… -X ${CORE}/build.Date=…"`, where `CORE: oblikovati`. But the Go module path is **`oblikovati.org`** (see `go.mod`). A linker `-X` to a symbol that doesn't exist (`oblikovati/build.Version`) is **silently ignored**, so every nightly *and* stable artifact shipped with the defaults: `Version="dev"`, `Commit="none"`, `Date="unknown"` — exactly what the bug report shows.

Because `update.DetectChannel` maps `"dev"` → the Dev channel (which never checks for updates), nightly users were never offered the next nightly.

Reproduced locally:
```
-X oblikovati/build.Version=NIGHTLY1      → dev        (wrong path, ignored)
-X oblikovati.org/build.Version=NIGHTLY1  → NIGHTLY1   (correct)
```

## Fix
`CORE: oblikovati` → `CORE: oblikovati.org` (one line; covers both `nightly.yml` and `release.yml`, which share this reusable build).

## Regression guard
A linker `-X` to a missing symbol fails *silently*, so no build error would ever catch this. Added a Go test (`build/stamp_workflow_test.go`) that asserts `build.yml`'s `CORE` equals the `go.mod` module path — it fails on the old value and passes on the fix.

## Validation
`go test ./build/` green, `golangci-lint` 0 issues. The version stamping itself can only be fully confirmed by the next nightly run, but the symbol-path fix is reproduced above and locked by the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)