### PR TITLE
Keep parameter-driven offsets & pattern spacing live (#1230)

### DIFF
--- a/addin/router/model_length_closure_test.go
+++ b/addin/router/model_length_closure_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/addin/modelaccess"
+)
+
+// TestModelLengthClosureStaysLiveForParamExpr is the regression guard for issue #1230: a distance
+// argument that references a parameter (e.g. a work-plane offset "h" or a sketch-pattern spacing
+// "L - 2*m") must stay LIVE, so editing the parameter re-evaluates it on the next recompute. The
+// earlier fast path baked any expression that evaluated at creation time — including parameter
+// expressions — which froze work-plane offsets and pattern spacings (the NopSCAD loft + pcb
+// failures). A pure literal has no parameter dependency and is baked.
+func TestModelLengthClosureStaysLiveForParamExpr(t *testing.T) {
+	_, s := emptyPartSession(t)
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		t.Fatalf("active part: %v", err)
+	}
+	if _, err := part.Parameters().AddUserParameter("h", "10 mm"); err != nil {
+		t.Fatalf("add parameter: %v", err)
+	}
+
+	// A parameter expression: the closure must track an edit to the parameter.
+	live, err := modelLengthClosure(part, "h")
+	if err != nil {
+		t.Fatalf("modelLengthClosure(h): %v", err)
+	}
+	before := live()
+	if before <= 0 {
+		t.Fatalf("offset at h=10mm = %v, want > 0", before)
+	}
+	p, _ := part.Parameters().ByName("h")
+	if err := part.Parameters().SetExpression(p.ID(), "25 mm"); err != nil {
+		t.Fatalf("set h: %v", err)
+	}
+	part.Recompute()
+	after := live()
+	if math.Abs(after-2.5*before) > 1e-9 {
+		t.Errorf("after h 10mm→25mm offset = %v, want %v (2.5×) — the parameter expression was frozen", after, 2.5*before)
+	}
+
+	// A pure literal has no parameter dependency: it is a constant value.
+	lit, err := modelLengthClosure(part, "5 mm")
+	if err != nil {
+		t.Fatalf("modelLengthClosure(5 mm): %v", err)
+	}
+	if got := lit(); math.Abs(got-0.5) > 1e-9 { // database unit is the centimetre (5 mm = 0.5 cm)
+		t.Errorf("literal 5 mm = %v, want 0.5 (cm)", got)
+	}
+}

--- a/addin/router/param_expr.go
+++ b/addin/router/param_expr.go
@@ -31,3 +31,15 @@ func resolveQuantity(part quantitySource, src string, dim param.Unit) (param.Qua
 	}
 	return part.Units().Parse(src, dim)
 }
+
+// literalLength parses src as a pure literal quantity in dim WITHOUT consulting the parameter
+// table — the discriminator a LIVE closure needs to tell a constant ("5 mm") from a parameter
+// expression ("h", "L - 2*m") that must stay live (a parameter name has no unit, so it fails to
+// parse here). ok is false for anything that is not a bare literal. This is a sanctioned
+// Units().Parse site (it lives in param_expr.go alongside resolveQuantity's literal fallback — see
+// TestRouterUnitStringsGoThroughResolver); callers that need parameter-expression support compose
+// it with the auto-parameter path (see modelLengthClosure), they do not bypass the resolver.
+func literalLength(host quantitySource, src string, dim param.Unit) (param.Quantity, bool) {
+	q, err := host.Units().Parse(src, dim)
+	return q, err == nil
+}

--- a/addin/router/work_planes.go
+++ b/addin/router/work_planes.go
@@ -363,13 +363,15 @@ func toWorkRefs(refs []string) []feature.WorkRef {
 // classification lives in feature.ParseWorkRef so the router and the op registry share it.
 func toWorkRef(r string) feature.WorkRef { return feature.ParseWorkRef(r) }
 
-// modelLengthClosure turns a distance argument into a live, parameter-aware value: a
-// plain literal is constant; an expression ("h", "h/2") is backed by an auto model
-// parameter, so editing the parameter and recomputing re-reads it (a work plane is
-// re-evaluated by the host's Recompute). Mirrors opregistry's lengthClosure for the router
-// args that feed func() float64 (work-plane offset).
+// modelLengthClosure turns a distance argument into a live, parameter-aware value. A plain
+// literal ("5 mm") has no parameter dependency, so its value is baked. ANY expression that
+// references parameters ("h", "h/2", "L - 2*m") must stay LIVE — it is backed by an auto model
+// parameter and re-read on every recompute, so a later edit to L/h re-offsets the work plane or
+// re-spaces the sketch pattern that uses it (issue #1230). The discriminator is a pure-literal
+// parse: only Units().Parse (which never consults the parameter table) may bake; the previous
+// resolveQuantity fast path baked parameter expressions too, freezing them.
 func modelLengthClosure(host workHost, expr string) (func() float64, error) {
-	if q, err := resolveQuantity(host, expr, param.Length); err == nil {
+	if q, ok := literalLength(host, expr, param.Length); ok {
 		v := q.Value
 		return func() float64 { return v }, nil
 	}


### PR DESCRIPTION
Fixes #1230. Unblocks the MCP-bridge to-face e2e (Oblikovati.AddIns.MCPBridge#81) by clearing the pre-existing NopSCAD loft/pcb failures.

## Root cause
`addin/router.modelLengthClosure` — used for **work-plane offsets** and **sketch rectangular-pattern spacing** — baked the value of any expression that evaluated at creation time (it went through `resolveQuantity`, which consults the parameter table first). So a parameter expression (`"h"`, `"L - 2*m"`) was frozen: editing the parameter and recomputing never moved the offset work plane (or the loft/sketch built on it) or re-spaced the pattern.

## Fix
Bake **only a pure literal** (new `literalLength` helper, which never consults the parameter table — a bare parameter name has no unit and fails to parse there); any **parameter expression stays live** via the existing auto-parameter path and is re-read on recompute. `literalLength` lives in `param_expr.go`, the sanctioned home for `Units().Parse`, so `TestRouterUnitStringsGoThroughResolver` stays green.

## Regression
`TestModelLengthClosureStaysLiveForParamExpr` — a `"h"` offset tracks an edit `10mm→25mm` (×2.5); a `"5 mm"` literal stays constant. Fails on the old code, passes on the fix.

## Validation
- `go test ./addin/... ./model/...` green; `golangci-lint` 0 issues.
- The three failing MCP-bridge e2e tests (`TestNopLoftFrustum`, `TestNopLoftPipe`, `TestNopPcbHoleGrid`) **pass** against this source, as does the to-face e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)