### PR TITLE
Fix sketch Delete key + Customize Keyboard window (#1232)

### DIFF
--- a/app/bindings.go
+++ b/app/bindings.go
@@ -24,6 +24,7 @@ import (
 const (
 	ActionUndo             = "edit.undo"
 	ActionRedo             = "edit.redo"
+	ActionDelete           = "edit.delete"
 	ActionSave             = "file.save"
 	ActionCancel           = "tool.cancel"
 	ActionCommit           = "tool.commit"
@@ -54,6 +55,7 @@ func builtinActions() []builtinAction {
 		{id: ActionUndo, displayName: "Undo", defaultChord: mustChord("Ctrl+Z"), dispatch: dispatchUndo},
 		{id: ActionRedo, displayName: "Redo", defaultChord: mustChord("Ctrl+Y"),
 			extraChords: []types.KeyChord{mustChord("Ctrl+Shift+Z")}, dispatch: dispatchRedo},
+		{id: ActionDelete, displayName: "Delete", defaultChord: mustChord("Delete"), dispatch: dispatchDelete},
 		{id: ActionSave, displayName: "Save", defaultChord: mustChord("Ctrl+S"), dispatch: dispatchSave},
 		{id: ActionCancel, displayName: "Cancel / Deselect", defaultChord: mustChord("Escape"), dispatch: dispatchCancel},
 		{id: ActionCommit, displayName: "Finish Command", defaultChord: mustChord("Enter"), dispatch: dispatchCommit},
@@ -126,6 +128,11 @@ func dispatchToggleVisibility(s *Session) error {
 	s.ToggleSelectedWorkPlaneVisibility()
 	return nil
 }
+
+// dispatchDelete is the Delete key: it removes the selected sketch entities while editing a
+// sketch (issue #1232). With no sketch open / nothing selected it is a no-op, so it never
+// destroys 3D geometry by accident — feature/body delete stays on the browser menu.
+func dispatchDelete(s *Session) error { return s.DeleteSelectedSketchEntities() }
 
 // dispatchSave saves the active document (Ctrl+S / the "SAVE" command word, M26 F05).
 func dispatchSave(s *Session) error { return s.SaveActiveDocument() }

--- a/app/bindings_catalog.go
+++ b/app/bindings_catalog.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"sort"
+	"strings"
+)
+
+// The Customize Keyboard window's read model: the bindable catalog sorted and filtered for
+// display (issue #1232: the raw Catalog is in registration order and offers no way to find a
+// command by name). Kept in the app layer so the sort/filter is unit-tested headlessly; the
+// head window is a thin renderer over CatalogFiltered.
+
+// CatalogFiltered returns the bindable catalog sorted alphabetically by command name and,
+// when query is non-empty, narrowed to the actions whose name or alias contains it
+// (case-insensitive). An empty query returns the whole catalog, still sorted.
+//
+//	s.Bindings().CatalogFiltered("dim") // every dimension command, A→Z
+func (b *Bindings) CatalogFiltered(query string) []Binding {
+	q := strings.ToLower(strings.TrimSpace(query))
+	full := b.Catalog()
+	out := make([]Binding, 0, len(full))
+	for _, bd := range full {
+		if q == "" || bindingMatchesQuery(bd, q) {
+			out = append(out, bd)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return strings.ToLower(out[i].DisplayName) < strings.ToLower(out[j].DisplayName)
+	})
+	return out
+}
+
+// bindingMatchesQuery reports whether the binding's command name or alias contains the
+// (already lower-cased) query — the Customize Keyboard filter predicate.
+func bindingMatchesQuery(b Binding, lowerQuery string) bool {
+	return strings.Contains(strings.ToLower(b.DisplayName), lowerQuery) ||
+		strings.Contains(strings.ToLower(b.Alias), lowerQuery)
+}

--- a/app/bindings_catalog_filter_test.go
+++ b/app/bindings_catalog_filter_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestCatalogFilteredIsAlphabetical guards the Customize Keyboard sort (issue #1232): the
+// filtered catalog is ordered by command name case-insensitively, regardless of the
+// registration order the raw Catalog preserves.
+func TestCatalogFilteredIsAlphabetical(t *testing.T) {
+	s := NewSession()
+	got := s.Bindings().CatalogFiltered("")
+	if len(got) < 2 {
+		t.Fatalf("catalog has %d entries, want several built-ins", len(got))
+	}
+	names := make([]string, len(got))
+	for i, b := range got {
+		names[i] = strings.ToLower(b.DisplayName)
+	}
+	if !sort.StringsAreSorted(names) {
+		t.Errorf("CatalogFiltered is not alphabetical: %v", names)
+	}
+}
+
+// TestCatalogFilteredNarrowsByName guards the filter (issue #1232): a query returns only the
+// actions whose name contains it (case-insensitive), and includes the new Delete action.
+func TestCatalogFilteredNarrowsByName(t *testing.T) {
+	s := NewSession()
+	got := s.Bindings().CatalogFiltered("del")
+	if len(got) == 0 {
+		t.Fatal("filter \"del\" returned nothing, want the Delete action")
+	}
+	foundDelete := false
+	for _, b := range got {
+		if !strings.Contains(strings.ToLower(b.DisplayName), "del") &&
+			!strings.Contains(strings.ToLower(b.Alias), "del") {
+			t.Errorf("filter \"del\" returned non-matching action %q", b.DisplayName)
+		}
+		if b.ActionID == ActionDelete {
+			foundDelete = true
+		}
+	}
+	if !foundDelete {
+		t.Errorf("filter \"del\" did not include the Delete action (%s)", ActionDelete)
+	}
+}
+
+// TestCatalogFilteredEmptyForNoMatch: a query matching nothing returns an empty slice.
+func TestCatalogFilteredEmptyForNoMatch(t *testing.T) {
+	s := NewSession()
+	if got := s.Bindings().CatalogFiltered("zzz-no-such-command"); len(got) != 0 {
+		t.Errorf("filter for a missing command returned %d entries, want 0", len(got))
+	}
+}

--- a/app/sketch_delete.go
+++ b/app/sketch_delete.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "oblikovati.org/event"
+
+// DeleteSelectedSketchEntities removes the sketch entities currently selected in the 2D
+// sketch editor — the Delete-key action (issue #1232: pressing Delete on selected sketch
+// geometry did nothing because no action was bound). It drops each entity along with its
+// orphaned points and the constraints bound to them (sketch.DeleteEntities), clears the
+// selection, recomputes the active part so downstream features see the change, and records
+// one undoable edit. It is a no-op (nil) when not editing a sketch, a tool is mid-operation,
+// or nothing is selected.
+func (s *Session) DeleteSelectedSketchEntities() error {
+	if s.activeSketch == nil || s.tool != nil {
+		return nil
+	}
+	ents := s.selectedSketchEntities()
+	if len(ents) == 0 {
+		return nil
+	}
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	if s.activeSketch.DeleteEntities(ents) == 0 {
+		return nil
+	}
+	s.selection.Clear()
+	event.Emit(s.bus, event.After, SelectionChanged{Count: 0})
+	part.Recompute()
+	s.recordEdit(part, "Delete Sketch Entities")
+	return nil
+}

--- a/app/sketch_delete_test.go
+++ b/app/sketch_delete_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// selectSketchEntities replaces the selection with the given sketch entities (the state a
+// user reaches by clicking them in the editor).
+func selectSketchEntities(s *Session, ents ...sketch.Entity) {
+	s.selection.Clear()
+	for _, e := range ents {
+		s.selection.Add(SketchEntityHandle{Entity: e})
+	}
+}
+
+// TestDeleteSelectedSketchEntitiesRemovesThem is the regression guard for issue #1232:
+// selecting sketch geometry and deleting it actually removes it from the active sketch.
+func TestDeleteSelectedSketchEntitiesRemovesThem(t *testing.T) {
+	s, def := emptyPartSession(t)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	s.EnterSketch(sk)
+	keep := sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0))
+	gone := sk.Lines().AddByTwoPoints(math.P2(0, 1), math.P2(4, 1))
+	selectSketchEntities(s, gone)
+
+	if err := s.DeleteSelectedSketchEntities(); err != nil {
+		t.Fatalf("DeleteSelectedSketchEntities: %v", err)
+	}
+	if sk.Lines().Count() != 1 || sk.Lines().Item(0) != keep {
+		t.Errorf("after delete, lines = %d, want only the kept line", sk.Lines().Count())
+	}
+	if s.selection.Count() != 0 {
+		t.Errorf("selection after delete = %d, want 0 (cleared)", s.selection.Count())
+	}
+}
+
+// TestDeleteKeyDeletesSketchEntities proves the binding: the Delete key routed through the
+// engine reaches DeleteSelectedSketchEntities and removes the selection (issue #1232).
+func TestDeleteKeyDeletesSketchEntities(t *testing.T) {
+	s, def := emptyPartSession(t)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	s.EnterSketch(sk)
+	l := sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0))
+	selectSketchEntities(s, l)
+
+	if _, ok := s.Bindings().ResolveChord(keyEventToChord(KeyEvent{Key: "Delete"})); !ok {
+		t.Fatal("the Delete key is not bound to any action")
+	}
+	if err := s.PressKey(KeyEvent{Key: "Delete"}); err != nil {
+		t.Fatalf("PressKey(Delete): %v", err)
+	}
+	if sk.Lines().Count() != 0 {
+		t.Errorf("after Delete key, lines = %d, want 0", sk.Lines().Count())
+	}
+}
+
+// TestDeleteSelectedSketchEntitiesNoOps: outside a sketch, mid-tool, or with nothing
+// selected, Delete does nothing and never errors — it must not destroy 3D geometry.
+func TestDeleteSelectedSketchEntitiesNoOps(t *testing.T) {
+	s, def := emptyPartSession(t)
+
+	// No active sketch.
+	if err := s.DeleteSelectedSketchEntities(); err != nil {
+		t.Fatalf("delete with no sketch: %v", err)
+	}
+
+	sk := def.Sketches().Add(sketch.XYPlane())
+	s.EnterSketch(sk)
+	l := sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0))
+
+	// Nothing selected.
+	if err := s.DeleteSelectedSketchEntities(); err != nil || sk.Lines().Count() != 1 {
+		t.Fatalf("delete with empty selection mutated the sketch (err=%v, lines=%d)", err, sk.Lines().Count())
+	}
+
+	// A tool is mid-operation: the selection must be left to the tool, not deleted.
+	selectSketchEntities(s, l)
+	s.StartTool(NewRectangleTool())
+	if err := s.DeleteSelectedSketchEntities(); err != nil || sk.Lines().Count() != 1 {
+		t.Fatalf("delete mid-tool mutated the sketch (err=%v, lines=%d)", err, sk.Lines().Count())
+	}
+}

--- a/head/ui/keymap_window.go
+++ b/head/ui/keymap_window.go
@@ -17,15 +17,20 @@ import (
 
 const keymapBufLen = 48
 
+const keymapFilterBufLen = 64
+
 // keymapUI is the panel's cross-frame state: per-action edit buffers (seeded lazily, then
-// dropped after an apply so the canonical value re-seeds) and the last apply error.
+// dropped after an apply so the canonical value re-seeds), the command-name filter buffer,
+// and the last apply error.
 var keymapUI = struct {
 	chord   map[string][]byte
 	alias   map[string][]byte
+	filter  []byte
 	lastErr string
 }{}
 
-// drawKeymapEditor renders the customization panel while it is open.
+// drawKeymapEditor renders the customization panel while it is open. The title-bar X closes
+// it (issue #1232: the window had no close button), alongside the Done button.
 func drawKeymapEditor(s *app.Session) {
 	if !s.KeymapEditorOpen() {
 		return
@@ -34,27 +39,48 @@ func drawKeymapEditor(s *app.Session) {
 		dropKeymapBuffers()
 	}
 	native.SetNextWindowSizeOnce(720, 560)
-	if native.Begin("Customize Keyboard") {
-		native.Text("Type a shortcut (e.g. Ctrl+Shift+E) or an alias, then Enter. Empty clears it.")
-		if keymapUI.lastErr != "" {
-			native.Text("! " + keymapUI.lastErr)
-		}
-		native.Separator()
-		drawKeymapTable(s)
-		native.Separator()
-		if native.Button("Reset All") {
-			recordKeymapResult(s.Bindings().ResetAll())
-			dropKeymapBuffers()
-		}
-		native.SameLine()
-		if native.Button("Done") {
-			s.CloseKeymapEditor()
-		}
+	visible, open := native.BeginClosable("Customize Keyboard")
+	if visible {
+		drawKeymapBody(s)
 	}
 	native.End()
+	if !open {
+		s.CloseKeymapEditor()
+	}
 }
 
-// drawKeymapTable renders the catalog as an editable four-column table.
+// drawKeymapBody renders the panel contents: the help line, the filter box, the editable
+// table, and the footer buttons.
+func drawKeymapBody(s *app.Session) {
+	native.Text("Type a shortcut (e.g. Ctrl+Shift+E) or an alias, then Enter. Empty clears it.")
+	if keymapUI.lastErr != "" {
+		native.Text("! " + keymapUI.lastErr)
+	}
+	native.Separator()
+	drawKeymapFilter()
+	drawKeymapTable(s)
+	native.Separator()
+	if native.Button("Reset All") {
+		recordKeymapResult(s.Bindings().ResetAll())
+		dropKeymapBuffers()
+	}
+	native.SameLine()
+	if native.Button("Done") {
+		s.CloseKeymapEditor()
+	}
+}
+
+// drawKeymapFilter renders the command-name filter box (issue #1232: there was no way to
+// find a command by name in the unsorted list).
+func drawKeymapFilter() {
+	native.Text("Filter")
+	native.SameLine()
+	native.SetNextItemWidth(-1)
+	native.InputText("##keymap-filter", keymapUI.filter)
+}
+
+// drawKeymapTable renders the catalog as an editable four-column table, alphabetically
+// sorted and narrowed by the filter box (issue #1232).
 func drawKeymapTable(s *app.Session) {
 	if !native.BeginTable("##keymap", 4, 0, 0) {
 		return
@@ -65,7 +91,7 @@ func drawKeymapTable(s *app.Session) {
 	native.TableSetupColumn("")
 	native.TableSetupScrollFreeze(0, 1)
 	native.TableHeadersRow()
-	for _, b := range s.Bindings().Catalog() {
+	for _, b := range s.Bindings().CatalogFiltered(bufString(keymapUI.filter)) {
 		drawKeymapRow(s, b)
 	}
 	native.EndTable()
@@ -128,8 +154,12 @@ func recordKeymapResult(err error) {
 	keymapUI.lastErr = ""
 }
 
-// dropKeymapBuffers forces every field to re-seed from the model (after a reset-all).
+// dropKeymapBuffers forces every field to re-seed from the model (after a reset-all). It
+// keeps the filter buffer allocated so the active filter survives a Reset All.
 func dropKeymapBuffers() {
 	keymapUI.chord = map[string][]byte{}
 	keymapUI.alias = map[string][]byte{}
+	if keymapUI.filter == nil {
+		keymapUI.filter = make([]byte, keymapFilterBufLen)
+	}
 }

--- a/head/ui/keymap_window_test.go
+++ b/head/ui/keymap_window_test.go
@@ -1,0 +1,51 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// TestInWindowKeymapEditorDraws opens the real Customize Keyboard window and runs frames,
+// exercising the sorted/filtered table, the filter input, the per-row edit fields, and the
+// footer/close buttons without tripping Dear ImGui's Begin/End assertions (issue #1232).
+func TestInWindowKeymapEditorDraws(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+	s := framedSession()
+	if err := app.RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+
+	s.OpenKeymapEditor()
+	defer s.CloseKeymapEditor()
+
+	// Unfiltered: the whole catalog renders, sorted.
+	drawKeymapFrames(win, s, 3)
+	if !s.KeymapEditorOpen() {
+		t.Error("Customize Keyboard should stay open across frames")
+	}
+
+	// Filtered: seed the filter buffer so the narrowed path renders too.
+	copyText(keymapUI.filter, "dim")
+	drawKeymapFrames(win, s, 3)
+	if !s.KeymapEditorOpen() {
+		t.Error("Customize Keyboard should stay open while filtering")
+	}
+}
+
+// drawKeymapFrames renders n full chrome frames (the window draws as part of chrome).
+func drawKeymapFrames(win *native.Window, s *app.Session, n int) {
+	for i := 0; i < n; i++ {
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.1)
+	}
+}

--- a/model/sketch/blocks_create.go
+++ b/model/sketch/blocks_create.go
@@ -163,13 +163,20 @@ func (s *Sketch) dropConstraintsTouching(ents []Entity) {
 			moved[&p.Y] = true
 		}
 	}
+	s.dropConstraintsOnVars(moved)
+}
+
+// dropConstraintsOnVars removes every geometric constraint and dimension that reads any
+// of the given solver variables (matched by scalar-pointer identity) — the shared half of
+// the move-into-block (dropConstraintsTouching) and delete (DeleteEntities) paths.
+func (s *Sketch) dropConstraintsOnVars(vars map[*math.Scalar]bool) {
 	for _, c := range s.geomCons.All() {
-		if constraintTouches(c, moved) {
+		if constraintTouches(c, vars) {
 			s.geomCons.Delete(c)
 		}
 	}
 	for _, d := range append([]*DimensionConstraint(nil), s.dimCons.items...) {
-		if constraintTouches(d, moved) {
+		if constraintTouches(d, vars) {
 			s.dimCons.Delete(d)
 		}
 	}

--- a/model/sketch/edit_delete.go
+++ b/model/sketch/edit_delete.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import "oblikovati.org/math"
+
+// DeleteEntities removes a set of sketch entities — the model behind the Delete key in the
+// 2D sketch editor (issue #1232). Each entity is dropped from the geometry list and its
+// typed collection; then the points no surviving entity references any longer (curve
+// endpoints/centers and standalone points) are pruned, and the geometric constraints and
+// dimensions bound to those dropped points are removed so no dangling relation survives.
+// nil and not-present entities are skipped. Returns the number of entities actually removed.
+//
+//	n := sk.DeleteEntities([]Entity{line, circle}) // n == 2; their orphaned points + constraints go too
+func (s *Sketch) DeleteEntities(ents []Entity) int {
+	removed := 0
+	for _, e := range ents {
+		if e == nil {
+			continue
+		}
+		before := len(s.ents)
+		s.deleteEntity(e)
+		if len(s.ents) < before {
+			removed++
+		}
+	}
+	if removed == 0 {
+		return 0
+	}
+	s.dropConstraintsOnVars(droppedPointVars(s.pruneOrphanPoints()))
+	return removed
+}
+
+// pruneOrphanPoints rebuilds the constrainable-point list from the surviving entities,
+// dropping the points no remaining entity references, and returns the dropped points so
+// their constraints can be detached. It mirrors [Sketch3D.pruneOrphanPoints3D].
+func (s *Sketch) pruneOrphanPoints() []*Point {
+	live := map[*Point]bool{}
+	for _, e := range s.ents {
+		for _, p := range entityPoints(e) {
+			live[p] = true
+		}
+	}
+	kept := make([]*Point, 0, len(s.pts))
+	var dropped []*Point
+	for _, p := range s.pts {
+		if live[p] {
+			kept = append(kept, p)
+		} else {
+			dropped = append(dropped, p)
+		}
+	}
+	s.pts = kept
+	return dropped
+}
+
+// droppedPointVars returns the solver-variable set (the X/Y scalars) of the dropped points,
+// the key dropConstraintsOnVars matches constraints against by pointer identity.
+func droppedPointVars(dropped []*Point) map[*math.Scalar]bool {
+	vars := make(map[*math.Scalar]bool, len(dropped)*2)
+	for _, p := range dropped {
+		vars[&p.X] = true
+		vars[&p.Y] = true
+	}
+	return vars
+}

--- a/model/sketch/edit_delete_test.go
+++ b/model/sketch/edit_delete_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"testing"
+
+	gmath "oblikovati.org/math"
+)
+
+// TestDeleteEntitiesRemovesEntityAndOrphanPoints is the regression guard for issue #1232:
+// deleting a lone line drops the entity and the two endpoints no other entity references.
+func TestDeleteEntitiesRemovesEntityAndOrphanPoints(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	l := s.Lines().AddByTwoPoints(gmath.P2(0, 0), gmath.P2(4, 0))
+
+	if n := s.DeleteEntities([]Entity{l}); n != 1 {
+		t.Fatalf("DeleteEntities returned %d, want 1", n)
+	}
+	if s.EntityCount() != 0 {
+		t.Errorf("entities after delete = %d, want 0", s.EntityCount())
+	}
+	if got := len(s.AllPoints()); got != 0 {
+		t.Errorf("points after delete = %d, want 0 (both endpoints pruned)", got)
+	}
+}
+
+// TestDeleteEntitiesKeepsSharedPoints: a point shared with a surviving entity is not pruned.
+func TestDeleteEntitiesKeepsSharedPoints(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	a := s.NewPoint(gmath.P2(0, 0))
+	b := s.NewPoint(gmath.P2(4, 0))
+	c := s.NewPoint(gmath.P2(4, 3))
+	first := s.Lines().Add(a, b)
+	second := s.Lines().Add(b, c) // shares b with first
+
+	if n := s.DeleteEntities([]Entity{first}); n != 1 {
+		t.Fatalf("DeleteEntities returned %d, want 1", n)
+	}
+	if s.EntityCount() != 1 {
+		t.Errorf("entities after delete = %d, want 1 (second line survives)", s.EntityCount())
+	}
+	// b and c remain (second references them); a is pruned.
+	if got := len(s.AllPoints()); got != 2 {
+		t.Errorf("points after delete = %d, want 2 (shared b + c kept, a pruned)", got)
+	}
+	_ = second
+}
+
+// TestDeleteEntitiesDropsBoundConstraints: a dimension/constraint on a deleted point's
+// variables is removed, so no dangling relation survives the delete (issue #1232).
+func TestDeleteEntitiesDropsBoundConstraints(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	l := s.Lines().AddByTwoPoints(gmath.P2(0, 0), gmath.P2(4, 0))
+	if _, err := s.DimensionConstraints().AddDistance(l.A, l.B, "5 cm"); err != nil {
+		t.Fatalf("AddDistance: %v", err)
+	}
+	s.GeometricConstraints().AddHorizontal(l.A, l.B)
+	if s.DimensionConstraints().Count() == 0 || s.GeometricConstraints().Count() == 0 {
+		t.Fatal("setup: expected one dimension and one geometric constraint")
+	}
+
+	s.DeleteEntities([]Entity{l})
+
+	if got := s.DimensionConstraints().Count(); got != 0 {
+		t.Errorf("dimensions after delete = %d, want 0 (bound to the deleted line)", got)
+	}
+	if got := s.GeometricConstraints().Count(); got != 0 {
+		t.Errorf("geometric constraints after delete = %d, want 0 (bound to the deleted line)", got)
+	}
+}
+
+// TestDeleteEntitiesSkipsNilAndAbsent: nil and not-in-sketch entities are ignored, and the
+// returned count reflects only what was actually removed.
+func TestDeleteEntitiesSkipsNilAndAbsent(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	l := s.Lines().AddByTwoPoints(gmath.P2(0, 0), gmath.P2(1, 0))
+	stranger := s.Lines().AddByTwoPoints(gmath.P2(2, 0), gmath.P2(3, 0))
+	_ = s.DeleteEntities([]Entity{stranger}) // remove it so it is now absent
+
+	if n := s.DeleteEntities([]Entity{nil, stranger, l}); n != 1 {
+		t.Fatalf("DeleteEntities returned %d, want 1 (only l present)", n)
+	}
+}


### PR DESCRIPTION
Closes #1232.

A user bug report (Part1) surfaced four problems; this PR fixes all of them.

## What

**1. The Delete key now deletes selected sketch entities.**
Pressing Delete on selected sketch geometry did nothing — no action was bound to the key, and there was no model/session capability to remove a set of sketch entities at all.

- `sketch.DeleteEntities` drops each entity, prunes the points no surviving entity references, and removes the constraints/dimensions bound to those points (sharing the constraint-drop helper with the existing move-into-block path).
- `Session.DeleteSelectedSketchEntities` applies it to the current selection while editing a 2D sketch, clears the selection, recomputes the part, and records one undoable edit.
- A new `edit.delete` built-in action binds it to **Delete**. It is a no-op outside a sketch or mid-tool, so it never destroys 3D geometry — feature/body delete stays on the browser menu.

**2–4. Customize Keyboard window: sort, filter, and a close button.**
The list was in registration order, had no way to filter by command name, and the window had no X to close it.

- `Bindings.CatalogFiltered` returns the catalog **sorted alphabetically** and narrowed by a **case-insensitive name/alias filter** (unit-tested in the app layer).
- The window renders a **Filter** input above the table and opens with a title-bar **X** (`BeginClosable`) alongside Done.

## Why

These are direct fixes for the reported workflow breakage; deleting sketch geometry is a core editing action that was entirely missing.

## Tests

- Model: `DeleteEntities` removes entity + orphan points, keeps shared points, drops bound constraints, skips nil/absent (`model/sketch/edit_delete_test.go`).
- App: delete-via-method and **delete-via-Delete-key through the real binding engine**, plus the no-op guards (`app/sketch_delete_test.go`); catalog sort/filter (`app/bindings_catalog_filter_test.go`).
- New-code coverage 86.7%–100% per function.

## Live confirmation

Captured against the running head (lavapipe + DrawChrome) with a throwaway driver (not committed):
- Customize Keyboard window shows the **X**, the **Filter** box, and **A→Z** order (3D Arc → … → Angle → Arc → Back → Ball → Base View).
- Sketch editor: selecting one of two lines and pressing **Delete** removes it and clears the selection ("1 selected" → "0 selected"), the other line surviving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)