### PR TITLE
Compact the nightly build stamp to YYMMDDTHH

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,7 +4,7 @@ Two channels, both automated by GitHub Actions:
 
 | Channel | Trigger | Workflow | Result |
 |---------|---------|----------|--------|
-| **Nightly** | daily cron + manual `workflow_dispatch`, on `develop` | `.github/workflows/nightly.yml` | rolling `nightly` **prerelease** (skipped if no new commits) |
+| **Nightly** | 6-hourly cron + manual `workflow_dispatch`, on `develop` | `.github/workflows/nightly.yml` | rolling `nightly` **prerelease** (skipped unless commits merged since the last stable release) |
 | **Stable** | push to `release` (merge a PR `develop` → `release`) | `.github/workflows/release.yml` | GitHub release tagged `v{MANUAL_MAJOR}.{API_VERSION}.{MINOR}.{PATCH}` |
 
 Both build the **GUI head + CLI** for Windows, Linux (AppImage), and macOS (one
@@ -21,8 +21,8 @@ Add-ins are **not** shipped; they are maintained by external vendors.
 - **MINOR** / **PATCH** — auto-numbered from the **conventional-commit scope** since the
   last stable release, per SemVer: a `feat` (or a breaking change) bumps **MINOR** and
   resets PATCH; a `fix` bumps **PATCH**. They **reset to `0.0`** whenever MANUAL_MAJOR or
-  API_VERSION changes (a new line gets its own sequence). Nightlies append
-  `-nightly.<timestamp>` (a semver prerelease).
+  API_VERSION changes (a new line gets its own sequence). Nightlies append a compact
+  UTC build stamp `-nightly.YYMMDDTHH` (two-digit year, date, hour — a semver prerelease).
 
 [`cmd/obkversion`](cmd/obkversion) computes the whole string; its logic lives in the
 tested [`release`](release) package. It reads `version.yaml`, the api pin, and git
@@ -30,7 +30,7 @@ tags + commit history — so it needs a full checkout (`fetch-depth: 0`):
 
 ```sh
 go run ./cmd/obkversion stable    # -> 0.000200.1.0          (e.g.)
-go run ./cmd/obkversion nightly   # -> 0.000200.1.0-nightly.20260602T120000
+go run ./cmd/obkversion nightly   # -> 0.000200.1.0-nightly.260602T12
 ```
 
 ### Bumping the version

--- a/cmd/obkversion/main.go
+++ b/cmd/obkversion/main.go
@@ -5,7 +5,7 @@
 // The release and nightly workflows call it to stamp the build:
 //
 //	go run ./cmd/obkversion stable    # -> 0.000200.1.0
-//	go run ./cmd/obkversion nightly   # -> 0.000200.1.0-nightly.20260615T030000
+//	go run ./cmd/obkversion nightly   # -> 0.000200.1.0-nightly.260615T03
 //
 // MINOR.PATCH come from git tags + conventional-commit scope and reset to 0.0 when
 // MANUAL_MAJOR or API_VERSION change, so the tool needs full history and tags.
@@ -65,7 +65,9 @@ func assemble(channel string, major int, apiField string, repo gitRepo, now time
 	case "stable":
 		return v, nil
 	case "nightly":
-		return v + "-nightly." + now.UTC().Format("20060102T150405"), nil
+		// Compact build stamp: two-digit year, date, and hour only (YYMMDDTHH) — minutes
+		// and seconds dropped so the build number stays short (e.g. 260622T11).
+		return v + "-nightly." + now.UTC().Format("060102T15"), nil
 	default:
 		return "", fmt.Errorf("unknown channel %q (want stable|nightly)", channel)
 	}

--- a/cmd/obkversion/main_test.go
+++ b/cmd/obkversion/main_test.go
@@ -30,7 +30,7 @@ func (f fakeRepo) newestTag(pattern string) string {
 func (f fakeRepo) commitsSince(ref string) []string { return f.commits[ref] }
 
 func TestAssemble(t *testing.T) {
-	noon := time.Date(2026, 6, 15, 3, 0, 0, 0, time.UTC)
+	noon := time.Date(2026, 6, 15, 3, 47, 51, 0, time.UTC) // non-zero min/sec: the stamp must drop them
 	cases := []struct {
 		name    string
 		repo    fakeRepo
@@ -71,10 +71,10 @@ func TestAssemble(t *testing.T) {
 			want:    "0.000200.0.1", // reset to 0.0, then a fix
 		},
 		{
-			name:    "nightly appends the timestamp",
+			name:    "nightly appends the compact stamp (YYMMDDTHH, no minutes/seconds)",
 			repo:    fakeRepo{commits: map[string][]string{"": {"feat: thing"}}},
 			channel: "nightly",
-			want:    "0.000200.1.0-nightly.20260615T030000",
+			want:    "0.000200.1.0-nightly.260615T03",
 		},
 	}
 	for _, c := range cases {

--- a/update/channel.go
+++ b/update/channel.go
@@ -32,7 +32,7 @@ const (
 )
 
 // nightlySuffix is the semver prerelease identifier cmd/obkversion gives a nightly
-// build, followed by ".<timestamp>" (e.g. "0.000200.1.0-nightly.20260614T120000").
+// build, followed by ".<timestamp>" (e.g. "0.000200.1.0-nightly.260614T12").
 const nightlySuffix = "-nightly"
 
 // String renders the channel for user-facing text and logs.

--- a/update/version.go
+++ b/update/version.go
@@ -14,8 +14,8 @@ import (
 // share a core, the sortable UTC timestamp breaks the tie.
 //
 //	IsNewer("0.000200.2.0", "0.000200.1.5")                                    // => true
-//	IsNewer("0.000200.1.0-nightly.20260615T030000",
-//	        "0.000200.1.0-nightly.20260614T030000")                            // => true
+//	IsNewer("0.000200.1.0-nightly.260615T03",
+//	        "0.000200.1.0-nightly.260614T03")                                  // => true
 func IsNewer(latest, current string) bool {
 	if c := compareCore(latest, current); c != 0 {
 		return c > 0
@@ -55,7 +55,7 @@ func coreParts(v string) [4]int64 {
 }
 
 // nightlyStamp returns the sortable timestamp a nightly version carries after
-// "-nightly." (e.g. "20260615T030000"), or "" for a stable build — the tiebreaker
+// "-nightly." (e.g. "260615T03"), or "" for a stable build — the tiebreaker
 // between two nightlies that share a numeric core.
 func nightlyStamp(v string) string {
 	_, after, found := strings.Cut(v, nightlySuffix+".")

--- a/update/version_test.go
+++ b/update/version_test.go
@@ -21,6 +21,13 @@ func TestIsNewer(t *testing.T) {
 		{"0.000200.1.0-nightly.20260614T030000", "0.000200.1.0-nightly.20260615T030000", false}, // older stamp
 		{"0.000200.1.0-nightly.20260615T030000", "0.000200.1.0-nightly.20260615T030000", false}, // equal nightly
 		{"0.000200.2.0-nightly.20260101T000000", "0.000200.1.0-nightly.20260615T030000", true},  // minor beats a newer stamp
+		// Compact YYMMDDTHH stamps still compare chronologically by string.
+		{"0.000200.1.0-nightly.260616T03", "0.000200.1.0-nightly.260615T09", true},  // next day beats a later hour
+		{"0.000200.1.0-nightly.260615T09", "0.000200.1.0-nightly.260615T03", true},  // later hour, same day
+		{"0.000200.1.0-nightly.260615T03", "0.000200.1.0-nightly.260615T03", false}, // equal compact stamp
+		// The format switch is monotonic: any new compact stamp (26…) sorts above every
+		// old long stamp (2026… → "20…"), so the first post-switch nightly reads as newer.
+		{"0.000200.1.0-nightly.260622T11", "0.000200.1.0-nightly.20260622T110000", true},
 	}
 	for _, c := range cases {
 		if got := IsNewer(c.latest, c.current); got != c.want {


### PR DESCRIPTION
## What

Shortens the nightly build number's timestamp:

- **Year → two digits** and **minutes/seconds dropped** (hour kept): `YYYYMMDDTHHMMSS` → `YYMMDDTHH`.
- Example: `0.008700.1.0-nightly.20260622T111151` → `0.008700.1.0-nightly.260622T11`.

The change is one `time.Format` layout in `cmd/obkversion` (`20060102T150405` → `060102T15`); docs and examples updated to match.

## Why

Requested — a shorter, less noisy build number.

## Correctness

The update checker (`update.IsNewer`) breaks ties between two nightlies by **string-comparing** the stamp after `-nightly.`. The new `YYMMDDTHH` form stays lexicographically chronological, and the format switch is **monotonic**: every old long stamp starts `2026…` ("20…") which sorts **below** every new compact stamp (`26…`), so the first post-switch nightly is still seen as newer than any prior nightly. Added regression cases covering both the new format and the old→new transition.

## Tests

- `cmd/obkversion`: the nightly case now asserts the compact stamp, with a fixture time carrying **non-zero minutes/seconds** to prove they're dropped.
- `update`: new `IsNewer` cases for compact stamps + the cross-format transition.
- Verified the real generator: `go run ./cmd/obkversion nightly` → `…-nightly.260622T12`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)