### PR TITLE
Drop the T separator from the nightly build stamp

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,7 +22,7 @@ Add-ins are **not** shipped; they are maintained by external vendors.
   last stable release, per SemVer: a `feat` (or a breaking change) bumps **MINOR** and
   resets PATCH; a `fix` bumps **PATCH**. They **reset to `0.0`** whenever MANUAL_MAJOR or
   API_VERSION changes (a new line gets its own sequence). Nightlies append a compact
-  UTC build stamp `-nightly.YYMMDDTHH` (two-digit year, date, hour — a semver prerelease).
+  UTC build stamp `-nightly.YYMMDDHH` (two-digit year, date, hour — a semver prerelease).
 
 [`cmd/obkversion`](cmd/obkversion) computes the whole string; its logic lives in the
 tested [`release`](release) package. It reads `version.yaml`, the api pin, and git
@@ -30,7 +30,7 @@ tags + commit history — so it needs a full checkout (`fetch-depth: 0`):
 
 ```sh
 go run ./cmd/obkversion stable    # -> 0.000200.1.0          (e.g.)
-go run ./cmd/obkversion nightly   # -> 0.000200.1.0-nightly.260602T12
+go run ./cmd/obkversion nightly   # -> 0.000200.1.0-nightly.26060212
 ```
 
 ### Bumping the version

--- a/cmd/obkversion/main.go
+++ b/cmd/obkversion/main.go
@@ -5,7 +5,7 @@
 // The release and nightly workflows call it to stamp the build:
 //
 //	go run ./cmd/obkversion stable    # -> 0.000200.1.0
-//	go run ./cmd/obkversion nightly   # -> 0.000200.1.0-nightly.260615T03
+//	go run ./cmd/obkversion nightly   # -> 0.000200.1.0-nightly.26061503
 //
 // MINOR.PATCH come from git tags + conventional-commit scope and reset to 0.0 when
 // MANUAL_MAJOR or API_VERSION change, so the tool needs full history and tags.
@@ -65,9 +65,9 @@ func assemble(channel string, major int, apiField string, repo gitRepo, now time
 	case "stable":
 		return v, nil
 	case "nightly":
-		// Compact build stamp: two-digit year, date, and hour only (YYMMDDTHH) — minutes
-		// and seconds dropped so the build number stays short (e.g. 260622T11).
-		return v + "-nightly." + now.UTC().Format("060102T15"), nil
+		// Compact build stamp: two-digit year, date, and hour only (YYMMDDHH) — minutes
+		// and seconds dropped so the build number stays short (e.g. 26062211).
+		return v + "-nightly." + now.UTC().Format("06010215"), nil
 	default:
 		return "", fmt.Errorf("unknown channel %q (want stable|nightly)", channel)
 	}

--- a/cmd/obkversion/main_test.go
+++ b/cmd/obkversion/main_test.go
@@ -71,10 +71,10 @@ func TestAssemble(t *testing.T) {
 			want:    "0.000200.0.1", // reset to 0.0, then a fix
 		},
 		{
-			name:    "nightly appends the compact stamp (YYMMDDTHH, no minutes/seconds)",
+			name:    "nightly appends the compact stamp (YYMMDDHH, no minutes/seconds)",
 			repo:    fakeRepo{commits: map[string][]string{"": {"feat: thing"}}},
 			channel: "nightly",
-			want:    "0.000200.1.0-nightly.260615T03",
+			want:    "0.000200.1.0-nightly.26061503",
 		},
 	}
 	for _, c := range cases {

--- a/update/channel.go
+++ b/update/channel.go
@@ -32,7 +32,7 @@ const (
 )
 
 // nightlySuffix is the semver prerelease identifier cmd/obkversion gives a nightly
-// build, followed by ".<timestamp>" (e.g. "0.000200.1.0-nightly.260614T12").
+// build, followed by ".<timestamp>" (e.g. "0.000200.1.0-nightly.26061412").
 const nightlySuffix = "-nightly"
 
 // String renders the channel for user-facing text and logs.

--- a/update/version.go
+++ b/update/version.go
@@ -14,8 +14,8 @@ import (
 // share a core, the sortable UTC timestamp breaks the tie.
 //
 //	IsNewer("0.000200.2.0", "0.000200.1.5")                                    // => true
-//	IsNewer("0.000200.1.0-nightly.260615T03",
-//	        "0.000200.1.0-nightly.260614T03")                                  // => true
+//	IsNewer("0.000200.1.0-nightly.26061503",
+//	        "0.000200.1.0-nightly.26061403")                                   // => true
 func IsNewer(latest, current string) bool {
 	if c := compareCore(latest, current); c != 0 {
 		return c > 0
@@ -55,7 +55,7 @@ func coreParts(v string) [4]int64 {
 }
 
 // nightlyStamp returns the sortable timestamp a nightly version carries after
-// "-nightly." (e.g. "260615T03"), or "" for a stable build — the tiebreaker
+// "-nightly." (e.g. "26061503"), or "" for a stable build — the tiebreaker
 // between two nightlies that share a numeric core.
 func nightlyStamp(v string) string {
 	_, after, found := strings.Cut(v, nightlySuffix+".")

--- a/update/version_test.go
+++ b/update/version_test.go
@@ -21,13 +21,13 @@ func TestIsNewer(t *testing.T) {
 		{"0.000200.1.0-nightly.20260614T030000", "0.000200.1.0-nightly.20260615T030000", false}, // older stamp
 		{"0.000200.1.0-nightly.20260615T030000", "0.000200.1.0-nightly.20260615T030000", false}, // equal nightly
 		{"0.000200.2.0-nightly.20260101T000000", "0.000200.1.0-nightly.20260615T030000", true},  // minor beats a newer stamp
-		// Compact YYMMDDTHH stamps still compare chronologically by string.
-		{"0.000200.1.0-nightly.260616T03", "0.000200.1.0-nightly.260615T09", true},  // next day beats a later hour
-		{"0.000200.1.0-nightly.260615T09", "0.000200.1.0-nightly.260615T03", true},  // later hour, same day
-		{"0.000200.1.0-nightly.260615T03", "0.000200.1.0-nightly.260615T03", false}, // equal compact stamp
+		// Compact YYMMDDHH stamps still compare chronologically by string.
+		{"0.000200.1.0-nightly.26061603", "0.000200.1.0-nightly.26061509", true},  // next day beats a later hour
+		{"0.000200.1.0-nightly.26061509", "0.000200.1.0-nightly.26061503", true},  // later hour, same day
+		{"0.000200.1.0-nightly.26061503", "0.000200.1.0-nightly.26061503", false}, // equal compact stamp
 		// The format switch is monotonic: any new compact stamp (26…) sorts above every
 		// old long stamp (2026… → "20…"), so the first post-switch nightly reads as newer.
-		{"0.000200.1.0-nightly.260622T11", "0.000200.1.0-nightly.20260622T110000", true},
+		{"0.000200.1.0-nightly.26062211", "0.000200.1.0-nightly.20260622T110000", true},
 	}
 	for _, c := range cases {
 		if got := IsNewer(c.latest, c.current); got != c.want {


### PR DESCRIPTION
## What

Removes the literal `T` from the compact nightly stamp: `YYMMDDTHH` → `YYMMDDHH`.

- Example: `0.008700.1.0-nightly.260622T11` → `0.008700.1.0-nightly.26062211`.
- One `time.Format` layout change (`060102T15` → `06010215`).

## Why

Requested — an all-digit build number.

## Correctness

Still fixed-width and all-numeric, so the update checker's string-compare tiebreaker (`update.IsNewer`) stays chronological, and the old long stamps (`2026…` → "20…") still sort below the new compact ones (`26…`), keeping the format switch monotonic. Regression cases updated accordingly.

Verified: `go run ./cmd/obkversion nightly` → `…-nightly.26062212`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)