### PR TITLE
feat: UI customization — adjustable text & icon sizes

### DIFF
--- a/app/options/options.go
+++ b/app/options/options.go
@@ -67,6 +67,15 @@ type Telemetry struct {
 	ShareUsageStatistics bool `yaml:"shareUsageStatistics"`
 }
 
+// UI is the user-facing scale of the interface, applied live by the head every frame
+// (#1232 follow-up: icons/text too small on high-resolution monitors). 1.0 = 100%.
+// FontScale drives ImGui's style.FontScaleMain (live, no atlas rebuild on ImGui 1.92);
+// IconScale multiplies every ribbon/nav/steering/property icon's rasterization size.
+type UI struct {
+	FontScale float64 `yaml:"fontScale"`
+	IconScale float64 `yaml:"iconScale"`
+}
+
 // All is every persisted option group. The ViewCube/display preferences live in
 // their own store (persistence/userprefs) and the color scheme in the theme store —
 // the options surface proxies those rather than duplicating their persistence.
@@ -77,11 +86,12 @@ type All struct {
 	Save      Save      `yaml:"save"`
 	Updates   Updates   `yaml:"updates"`
 	Telemetry Telemetry `yaml:"telemetry"`
+	UI        UI        `yaml:"ui"`
 }
 
 // Defaults returns the out-of-the-box options, mirroring the session's historical
 // defaults (10 mm visible grid with both snaps, flat chamfer corners, new part at
-// launch) so a fresh install behaves exactly as before this file existed.
+// launch, 100% UI scale) so a fresh install behaves exactly as before this file existed.
 func Defaults() All {
 	return All{
 		General:   General{StartupAction: types.StartupNewPart},
@@ -90,6 +100,7 @@ func Defaults() All {
 		Save:      Save{Thumbnail: types.ThumbnailNone},
 		Updates:   Updates{CheckOnStartup: true},
 		Telemetry: Telemetry{ShareUsageStatistics: true},
+		UI:        UI{FontScale: 1, IconScale: 1},
 	}
 }
 

--- a/app/options/options_test.go
+++ b/app/options/options_test.go
@@ -29,6 +29,8 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 	in.Sketch.GridSpacingCm = 0.5
 	in.Sketch.SnapToGrid = false
 	in.Part.ChamferFlatCorners = false
+	in.UI.FontScale = 1.25
+	in.UI.IconScale = 1.5
 	if err := s.Save(in); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
@@ -57,5 +59,14 @@ func TestLoadKeepsDefaultsForAbsentKeys(t *testing.T) {
 	}
 	if !out.Part.ChamferFlatCorners || out.General.StartupAction != types.StartupNewPart {
 		t.Errorf("absent groups = %+v, want defaults kept", out)
+	}
+	if out.UI != (UI{FontScale: 1, IconScale: 1}) {
+		t.Errorf("absent ui group = %+v, want 100%% scale defaults", out.UI)
+	}
+}
+
+func TestDefaultsUIScaleIsFullSize(t *testing.T) {
+	if ui := Defaults().UI; ui != (UI{FontScale: 1, IconScale: 1}) {
+		t.Errorf("Defaults().UI = %+v, want {1, 1}", ui)
 	}
 }

--- a/app/ui_pref.go
+++ b/app/ui_pref.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// User-facing UI scale surface (#1232 follow-up: icons/text too small on high-resolution
+// monitors). The session owns the persisted FontScale/IconScale preferences; the head reads
+// them live each frame (font scale → ImGui style.FontScaleMain, icon scale → icon rasterization
+// size). Values are stored as a factor where 1.0 = 100%.
+
+// UI scale bounds. The lower bound keeps the interface usable (never invisibly small, even from
+// a hand-edited options file); the upper bounds cap growth at a sane maximum per surface — text
+// to 2x, icons to 2.5x (icons read crisply larger because they re-rasterize from vector SVG).
+const (
+	minUIScale     = 0.5
+	maxUIFontScale = 2.0
+	maxUIIconScale = 2.5
+)
+
+// UIFontScale reports the persisted UI text scale (1.0 = 100%). A non-positive stored value
+// (absent or corrupt key) reads back as 1.0 so the interface can never become invisible.
+//
+//	s.UIFontScale() // => 1.2 after SetUIFontScale(1.2)
+func (s *Session) UIFontScale() float64 {
+	return scaleOrDefault(s.appOptions.UI.FontScale)
+}
+
+// SetUIFontScale clamps v to [minUIScale, maxUIFontScale] and persists it to the user's
+// options file. Out-of-range and non-positive inputs are clamped, never rejected.
+func (s *Session) SetUIFontScale(v float64) error {
+	s.appOptions.UI.FontScale = clampScale(v, minUIScale, maxUIFontScale)
+	return s.saveOptions()
+}
+
+// UIIconScale reports the persisted icon scale (1.0 = 100%), with the same non-positive guard
+// as UIFontScale.
+func (s *Session) UIIconScale() float64 {
+	return scaleOrDefault(s.appOptions.UI.IconScale)
+}
+
+// SetUIIconScale clamps v to [minUIScale, maxUIIconScale] and persists it.
+func (s *Session) SetUIIconScale(v float64) error {
+	s.appOptions.UI.IconScale = clampScale(v, minUIScale, maxUIIconScale)
+	return s.saveOptions()
+}
+
+// scaleOrDefault returns v, or 1.0 when v is non-positive — the guard that keeps a missing or
+// corrupt stored scale from hiding the UI.
+func scaleOrDefault(v float64) float64 {
+	if v <= 0 {
+		return 1
+	}
+	return v
+}
+
+// clampScale confines v to [lo, hi], treating a non-positive v as the low bound rather than
+// snapping it to 1.0 — an explicit setter call honors the user's intent up to the safe minimum.
+func clampScale(v, lo, hi float64) float64 {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}

--- a/app/ui_pref_test.go
+++ b/app/ui_pref_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "testing"
+
+func TestUIScaleDefaultsToFullSize(t *testing.T) {
+	s := NewSession()
+	if got := s.UIFontScale(); got != 1 {
+		t.Errorf("UIFontScale default = %v, want 1", got)
+	}
+	if got := s.UIIconScale(); got != 1 {
+		t.Errorf("UIIconScale default = %v, want 1", got)
+	}
+}
+
+func TestSetUIScaleStoresAndReadsBack(t *testing.T) {
+	s := NewSession()
+	if err := s.SetUIFontScale(1.25); err != nil {
+		t.Fatalf("SetUIFontScale: %v", err)
+	}
+	if err := s.SetUIIconScale(1.75); err != nil {
+		t.Fatalf("SetUIIconScale: %v", err)
+	}
+	if got := s.UIFontScale(); got != 1.25 {
+		t.Errorf("UIFontScale = %v, want 1.25", got)
+	}
+	if got := s.UIIconScale(); got != 1.75 {
+		t.Errorf("UIIconScale = %v, want 1.75", got)
+	}
+}
+
+func TestSetUIScaleClampsToBounds(t *testing.T) {
+	cases := []struct {
+		name      string
+		set       func(*Session, float64) error
+		read      func(*Session) float64
+		in, wantC float64
+	}{
+		{"font below min", (*Session).SetUIFontScale, (*Session).UIFontScale, 0.1, minUIScale},
+		{"font above max", (*Session).SetUIFontScale, (*Session).UIFontScale, 9, maxUIFontScale},
+		{"icon below min", (*Session).SetUIIconScale, (*Session).UIIconScale, -2, minUIScale},
+		{"icon above max", (*Session).SetUIIconScale, (*Session).UIIconScale, 9, maxUIIconScale},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := NewSession()
+			if err := c.set(s, c.in); err != nil {
+				t.Fatalf("set(%v): %v", c.in, err)
+			}
+			if got := c.read(s); got != c.wantC {
+				t.Errorf("after set(%v) = %v, want clamped %v", c.in, got, c.wantC)
+			}
+		})
+	}
+}
+
+// A non-positive stored scale (corrupt/edited options file) must read back as full size so the
+// interface can never be hidden — distinct from clampScale, which the explicit setters use.
+func TestUIScaleReadGuardsCorruptZero(t *testing.T) {
+	s := NewSession()
+	s.appOptions.UI.FontScale = 0
+	s.appOptions.UI.IconScale = -1
+	if got := s.UIFontScale(); got != 1 {
+		t.Errorf("UIFontScale(zero) = %v, want 1", got)
+	}
+	if got := s.UIIconScale(); got != 1 {
+		t.Errorf("UIIconScale(negative) = %v, want 1", got)
+	}
+}

--- a/head/internal/native/app.cpp
+++ b/head/internal/native/app.cpp
@@ -287,6 +287,14 @@ void obk_head_set_mono_font(const unsigned char* data, int len, float sizePx) {
 // obk_head_mono_font exposes the retained mono face to the draw helpers in imgui_wrap.cpp.
 ImFont* obk_head_mono_font(void) { return g_monoFont; }
 
+// obk_head_set_font_scale sets ImGui's global text scale (style.FontScaleMain, ImGui 1.92's
+// dynamic-font knob — io.FontGlobalScale was removed). All UI text rescales next frame with no
+// atlas rebuild; the mono editor helpers in imgui_wrap.cpp read it too so the code editor tracks
+// the user's UI-scale preference. Safe to call every frame (#1232 follow-up).
+void obk_head_set_font_scale(float scale) {
+    if (scale > 0.0f) ImGui::GetStyle().FontScaleMain = scale;
+}
+
 int obk_head_should_close(void* h) {
     HeadContext* c = (HeadContext*)h;
     return glfwWindowShouldClose(c->window) ? 1 : 0;

--- a/head/internal/native/app.cpp
+++ b/head/internal/native/app.cpp
@@ -113,13 +113,16 @@ bool create_device(HeadContext* c) {
 
 bool create_descriptor_pool(HeadContext* c) {
     // Combined-image-sampler sets are shared by the font atlas, the offscreen viewport
-    // image, and one per cached ribbon icon (texture.cpp). The icon set alone is ~25
-    // and grows with the command set, so size generously to avoid AddTexture failing.
-    VkDescriptorPoolSize sizes[] = {{VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 256}};
+    // image, and one per cached ribbon icon (texture.cpp). The icon set alone is ~25 and
+    // grows with the command set; during a UI icon-scale drag the cache re-rasterizes at each
+    // pixel size and keeps the previous set retired-in-flight for a few frames, so size with
+    // ample headroom to keep the font atlas always allocatable (#1237: an exhausted pool made
+    // CreateTexture/AddTexture fail — icons vanished and the font GetTexID assertion fired).
+    VkDescriptorPoolSize sizes[] = {{VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1024}};
     VkDescriptorPoolCreateInfo ci{};
     ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
     ci.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
-    ci.maxSets = 256;
+    ci.maxSets = 1024;
     ci.poolSizeCount = 1;
     ci.pPoolSizes = sizes;
     return ok(vkCreateDescriptorPool(c->device, &ci, c->allocator, &c->descriptorPool));

--- a/head/internal/native/font.go
+++ b/head/internal/native/font.go
@@ -7,6 +7,7 @@ package native
 /*
 void obk_head_set_ui_font(const unsigned char* data, int len, float sizePx);
 void obk_head_set_mono_font(const unsigned char* data, int len, float sizePx);
+void obk_head_set_font_scale(float scale);
 */
 import "C"
 
@@ -54,4 +55,11 @@ func (w *Window) SetMonoFont(sizePx float32) {
 		return
 	}
 	C.obk_head_set_mono_font((*C.uchar)(unsafe.Pointer(&monoFontTTF[0])), C.int(len(monoFontTTF)), C.float(sizePx))
+}
+
+// SetUIFontScale sets the global UI text scale (ImGui 1.92 style.FontScaleMain), where 1.0 is the
+// baked size. Unlike SetUIFont it needs no atlas rebuild and is safe to call every frame, so the
+// head drives it live from the user's UI-scale preference. Non-positive values are ignored.
+func (w *Window) SetUIFontScale(scale float32) {
+	C.obk_head_set_font_scale(C.float(scale))
 }

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -75,6 +75,7 @@ int  obk_ig_begin_child(const char* id, float w, float h, int border);
 void obk_ig_end_child(void);
 int  obk_ig_checkbox(const char* label, int* v);
 int  obk_ig_slider_float(const char* label, float* v, float lo, float hi);
+int  obk_ig_slider_float_fmt(const char* label, float* v, float lo, float hi, const char* fmt);
 void obk_ig_begin_disabled(int disabled);
 void obk_ig_end_disabled(void);
 int  obk_ig_want_capture_mouse(void);
@@ -396,6 +397,19 @@ func SliderFloat(label string, v *float32, lo, hi float32) bool {
 	defer free()
 	cv := C.float(*v)
 	changed := C.obk_ig_slider_float(c, &cv, C.float(lo), C.float(hi)) != 0
+	*v = float32(cv)
+	return changed
+}
+
+// SliderPercent draws a slider over [lo,hi] that reads as a whole-number percentage (e.g.
+// "120%"), editing *v in place. Used for the UI scale preferences, where the value is a percent.
+func SliderPercent(label string, v *float32, lo, hi float32) bool {
+	c, free := cstr(label)
+	defer free()
+	fmtC, freeFmt := cstr("%.0f%%")
+	defer freeFmt()
+	cv := C.float(*v)
+	changed := C.obk_ig_slider_float_fmt(c, &cv, C.float(lo), C.float(hi), fmtC) != 0
 	*v = float32(cv)
 	return changed
 }

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -266,6 +266,9 @@ int  obk_ig_checkbox(const char* label, int* v) {
 int  obk_ig_slider_float(const char* label, float* v, float lo, float hi) {
     return ImGui::SliderFloat(label, v, lo, hi) ? 1 : 0;
 }
+int  obk_ig_slider_float_fmt(const char* label, float* v, float lo, float hi, const char* fmt) {
+    return ImGui::SliderFloat(label, v, lo, hi, fmt) ? 1 : 0;
+}
 
 void obk_ig_begin_disabled(int disabled)     { ImGui::BeginDisabled(disabled != 0); }
 void obk_ig_end_disabled(void)               { ImGui::EndDisabled(); }
@@ -365,13 +368,18 @@ void obk_ig_push_clip_rect(float x0, float y0, float x1, float y1) {
 }
 void obk_ig_pop_clip_rect(void) { ImGui::GetWindowDrawList()->PopClipRect(); }
 
+// obk_ig_mono_size is the mono face's baked size scaled by the global UI text scale
+// (style.FontScaleMain). Threading the scale through every mono metric keeps the Script Console
+// editor tracking the user's UI-scale preference, with glyphs and cell geometry in step.
+static float obk_ig_mono_size(ImFont* f) { return f->LegacySize * ImGui::GetStyle().FontScaleMain; }
+
 // obk_ig_draw_text_mono draws s in the fixed-width face (falling back to the default font when
 // the mono face failed to load), so editor glyphs land on integer columns.
 void obk_ig_draw_text_mono(float x, float y, float r, float g, float b, float a, const char* s) {
     ImDrawList* dl = ImGui::GetWindowDrawList();
     ImU32 col = obk_col32(r, g, b, a);
     ImFont* f = obk_head_mono_font();
-    if (f) dl->AddText(f, f->LegacySize, ImVec2(x, y), col, s); // LegacySize == size passed to AddFont
+    if (f) dl->AddText(f, obk_ig_mono_size(f), ImVec2(x, y), col, s);
     else   dl->AddText(ImVec2(x, y), col, s);
 }
 // obk_ig_mono_char_width / obk_ig_mono_line_height give the editor its cell size: a mono
@@ -380,12 +388,12 @@ void obk_ig_draw_text_mono(float x, float y, float r, float g, float b, float a,
 float obk_ig_mono_char_width(void) {
     ImFont* f = obk_head_mono_font();
     if (!f) return ImGui::CalcTextSize("M").x;
-    ImFontBaked* baked = f->GetFontBaked(f->LegacySize);
+    ImFontBaked* baked = f->GetFontBaked(obk_ig_mono_size(f));
     return baked ? baked->GetCharAdvance((ImWchar)'M') : ImGui::CalcTextSize("M").x;
 }
 float obk_ig_mono_line_height(void) {
     ImFont* f = obk_head_mono_font();
-    return f ? f->LegacySize : ImGui::GetTextLineHeight();
+    return f ? obk_ig_mono_size(f) : ImGui::GetTextLineHeight();
 }
 
 // obk_ig_utf8_encode appends the UTF-8 of code point c to buf at *off (bounded by buf_size),

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -58,9 +58,9 @@ func prepareChromeFrame(win *native.Window, s *app.Session) {
 	}
 	bindGraphicsImages(win) // client-graphics image billboards create textures on this window (M16-F05)
 	reportWindowFrame(win, s)
-	applyUIScale(win, s)                // push the user's font/icon scale before the ribbon sizes itself
-	icons.beginFrame(s.ThemeRevision()) // free retired textures; flush composes on theme change
-	applyThemeIfChanged(win, s)         // restyle ImGui + overlays when the theme changed (live preview)
+	applyUIScale(win, s)                                 // push the user's font/icon scale before the ribbon sizes itself
+	icons.beginFrame(s.ThemeRevision(), s.UIIconScale()) // free retired textures; reflush on theme or icon-scale change
+	applyThemeIfChanged(win, s)                          // restyle ImGui + overlays when the theme changed (live preview)
 	handleKeyboard(s)
 	followActiveDocument(s)
 }

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -58,6 +58,7 @@ func prepareChromeFrame(win *native.Window, s *app.Session) {
 	}
 	bindGraphicsImages(win) // client-graphics image billboards create textures on this window (M16-F05)
 	reportWindowFrame(win, s)
+	applyUIScale(win, s)                // push the user's font/icon scale before the ribbon sizes itself
 	icons.beginFrame(s.ThemeRevision()) // free retired textures; flush composes on theme change
 	applyThemeIfChanged(win, s)         // restyle ImGui + overlays when the theme changed (live preview)
 	handleKeyboard(s)

--- a/head/ui/chrome_ribbon.go
+++ b/head/ui/chrome_ribbon.go
@@ -45,7 +45,7 @@ const ribbonMaxRows = 3
 // ribbonGridHeight is the height of the band's button-grid area: the tallest column
 // shape, ribbonMaxRows rows of small icon buttons.
 func ribbonGridHeight(m native.StyleMetrics) float32 {
-	row := smallIconPx + 2*m.FramePadY
+	row := float32(scaledIconPx(smallIconPx)) + 2*m.FramePadY
 	return ribbonMaxRows*row + (ribbonMaxRows-1)*m.ItemSpacingY
 }
 
@@ -308,9 +308,9 @@ func drawButtonControl(btn app.RibbonButton) bool {
 func iconSizeFor(s app.ButtonStyle) (int, bool) {
 	switch s {
 	case app.SmallIconButton, app.CompactIconButton:
-		return smallIconPx, true
+		return scaledIconPx(smallIconPx), true
 	case app.LargeIconButton:
-		return largeIconPx, true
+		return scaledIconPx(largeIconPx), true
 	default:
 		return 0, false
 	}

--- a/head/ui/icon_cache.go
+++ b/head/ui/icon_cache.go
@@ -39,7 +39,8 @@ type iconCache struct {
 	win         *native.Window
 	masks       map[iconKey]*icon.RoleMasks // nil entry = known-bad asset, never retried
 	tex         map[iconKey]uint64
-	texRevision uint64 // theme revision the cached textures were composed with
+	texRevision uint64  // theme revision the cached textures were composed with
+	iconScale   float64 // UI icon scale the cached textures were rasterized at
 	frame       uint64
 	retired     []retiredTexture
 }
@@ -59,16 +60,20 @@ func newIconCache(win *native.Window) *iconCache {
 	return &iconCache{win: win, masks: map[iconKey]*icon.RoleMasks{}, tex: map[iconKey]uint64{}}
 }
 
-// beginFrame advances the cache's frame clock, frees safely-retired textures, and —
-// when the theme changed — retires every composed texture so the next texture() call
-// re-composes it with the new colors. Called once per frame from prepareChromeFrame.
-func (c *iconCache) beginFrame(themeRevision uint64) {
+// beginFrame advances the cache's frame clock, frees safely-retired textures, and — when the
+// theme OR the UI icon scale changed — retires every composed texture so the next texture() call
+// re-composes/re-rasterizes it. Retiring on scale change is what bounds the cache: textures are
+// keyed by pixel size, so without it a slider drag would leak one texture per intermediate size
+// per icon and exhaust the Vulkan descriptor pool (icons then vanish and the font atlas can no
+// longer allocate — the #1237 crash). Called once per frame from prepareChromeFrame.
+func (c *iconCache) beginFrame(themeRevision uint64, iconScale float64) {
 	c.frame++
 	c.destroyExpired()
-	if themeRevision == c.texRevision {
+	if themeRevision == c.texRevision && iconScale == c.iconScale {
 		return
 	}
 	c.texRevision = themeRevision
+	c.iconScale = iconScale
 	for _, t := range c.tex {
 		c.retire(t)
 	}

--- a/head/ui/icon_cache_scale_test.go
+++ b/head/ui/icon_cache_scale_test.go
@@ -1,0 +1,48 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import "testing"
+
+// TestIconCacheEvictsOnScaleChange is the #1237 regression. Icon textures are keyed by pixel
+// size, so a UI icon-scale change must retire the previous size's textures. Without that, a
+// slider drag leaked one texture per intermediate size per icon and exhausted the 256-set Vulkan
+// descriptor pool — icons vanished, and the font atlas could no longer allocate (a GetTexID
+// assertion crash). The fix retires the whole set when the scale changes, bounding the cache.
+func TestIconCacheEvictsOnScaleChange(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	c := newIconCache(win)
+
+	// Populate a set of real textures at scale 1.0.
+	c.beginFrame(1, 1.0)
+	for _, name := range []string{"extrude", "revolve", "sweep", "loft", "hole"} {
+		if tex, ok := c.texture(name, "", 40); !ok || tex == 0 {
+			t.Fatalf("texture(%q) failed to upload", name)
+		}
+	}
+	live := len(c.tex)
+	if live == 0 {
+		t.Fatal("no textures cached at scale 1.0")
+	}
+
+	// A scale change must clear the live set, retiring the old textures rather than orphaning them.
+	c.beginFrame(1, 2.0)
+	if len(c.tex) != 0 {
+		t.Errorf("icon-scale change left %d live textures, want 0 (all retired)", len(c.tex))
+	}
+	if len(c.retired) < live {
+		t.Errorf("icon-scale change retired %d textures, want >= %d", len(c.retired), live)
+	}
+
+	// After the in-flight window passes, the retired textures are freed — the cache (and the
+	// descriptor pool behind it) does not grow without bound across repeated scale changes.
+	for i := 0; i < retireAfterFrames+2; i++ {
+		c.beginFrame(1, 2.0)
+	}
+	if len(c.retired) != 0 {
+		t.Errorf("retired textures not freed after %d frames: %d still pending", retireAfterFrames+2, len(c.retired))
+	}
+}

--- a/head/ui/navigation_bar.go
+++ b/head/ui/navigation_bar.go
@@ -45,27 +45,34 @@ func drawNavigationBar(s *app.Session, ox, oy float32, pw, ph int) {
 	if !s.ShowNavBar() {
 		return
 	}
-	cell := float32(navBarIconPx + 2*navBarPad)
+	iconPx := scaledIconPx(navBarIconPx)
+	cell := float32(iconPx + 2*navBarPad)
 	x := ox + float32(pw) - cell - navBarMargin
 	y := oy + (float32(ph)-cell*float32(len(navBarButtons)))/2
 	for _, b := range navBarButtons {
-		tex, ok := icons.texture(b.icon, "", navBarIconPx)
-		if !ok {
-			continue
+		if drawNavBarButton(s, b, x, y, iconPx) {
+			y += cell // a button with no icon asset consumes no slot (keeps the strip gapless)
 		}
-		native.SetCursorPos(x, y)
-		on := b.active != nil && b.active(s)
-		if on {
-			native.PushStyleColor("Button", accentColor)
-			native.PushStyleColor("ButtonHovered", accentColor)
-			native.PushStyleColor("ButtonActive", accentColor)
-		}
-		if native.ImageButton(b.id, tex, navBarIconPx, navBarIconPx, identityTint) {
-			b.run(s)
-		}
-		if on {
-			native.PopStyleColor(3)
-		}
-		y += cell
 	}
+}
+
+// drawNavBarButton draws one Navigation Bar button at (x,y): its icon at iconPx, accented while
+// its tool is armed/toggled. Returns false (drawing nothing) when the icon asset is missing.
+func drawNavBarButton(s *app.Session, b navBarButton, x, y float32, iconPx int) bool {
+	tex, ok := icons.texture(b.icon, "", iconPx)
+	if !ok {
+		return false
+	}
+	native.SetCursorPos(x, y)
+	on := b.active != nil && b.active(s)
+	if on {
+		native.PushStyleColor("Button", accentColor)
+		native.PushStyleColor("ButtonHovered", accentColor)
+		native.PushStyleColor("ButtonActive", accentColor)
+		defer native.PopStyleColor(3)
+	}
+	if native.ImageButton(b.id, tex, float32(iconPx), float32(iconPx), identityTint) {
+		b.run(s)
+	}
+	return true
 }

--- a/head/ui/preferences_window.go
+++ b/head/ui/preferences_window.go
@@ -27,29 +27,32 @@ func drawPreferencesWindow(s *app.Session) {
 	}
 	native.SetNextWindowSizeOnce(640, 480) // sensible default; the user can still resize
 	if native.Begin("Preferences") && native.BeginTabBar("##prefs-tabs") {
-		if native.BeginTabItem("General") {
-			drawGeneralTab(s)
-			native.EndTabItem()
-		}
-		if native.BeginTabItem("Privacy") {
-			drawPrivacyTab(s)
-			native.EndTabItem()
-		}
-		if native.BeginTabItem("Sketch Grid") {
-			drawGridTab(s)
-			native.EndTabItem()
-		}
-		if native.BeginTabItem("Modeling") {
-			drawModelingTab(s)
-			native.EndTabItem()
-		}
-		if native.BeginTabItem("Theme") {
-			drawAppearanceTab(s)
-			native.EndTabItem()
-		}
+		drawPreferencesTabs(s)
 		native.EndTabBar()
 	}
 	native.End()
+}
+
+// drawPreferencesTabs mounts each preference tab in order. Kept separate from the window
+// open/close so the tab list reads as one table and the window function stays small.
+func drawPreferencesTabs(s *app.Session) {
+	tabs := []struct {
+		name string
+		draw func(*app.Session)
+	}{
+		{"General", drawGeneralTab},
+		{"UI", drawUITab},
+		{"Privacy", drawPrivacyTab},
+		{"Sketch Grid", drawGridTab},
+		{"Modeling", drawModelingTab},
+		{"Theme", drawAppearanceTab},
+	}
+	for _, t := range tabs {
+		if native.BeginTabItem(t.name) {
+			t.draw(s)
+			native.EndTabItem()
+		}
+	}
 }
 
 // drawPrivacyTab renders the anonymous usage-statistics opt-out (#1182). Telemetry is on by

--- a/head/ui/property_panel.go
+++ b/head/ui/property_panel.go
@@ -247,8 +247,9 @@ func drawBooleanPropertyRow(id string, current ops.PartFeatureOperation, set fun
 // drawPropertyToggleControl draws the toggle's clickable control: the icon at the small
 // glyph size, or a text button when the asset is missing/unuploadable.
 func drawPropertyToggleControl(group, key, tip string) bool {
-	if tex, ok := icons.texture(key, "", smallIconPx); ok {
-		px := float32(smallIconPx)
+	ipx := scaledIconPx(smallIconPx)
+	if tex, ok := icons.texture(key, "", ipx); ok {
+		px := float32(ipx)
 		return native.ImageButton(group+"-"+key, tex, px, px, identityTint)
 	}
 	return native.Button(tip + "##" + group + "-" + key)

--- a/head/ui/steering_wheel.go
+++ b/head/ui/steering_wheel.go
@@ -47,16 +47,17 @@ func drawSteeringWheel(s *app.Session, ox, oy float32) {
 	vcx, vcy := viewportCursor()
 	cx, cy := ox+float32(vcx), oy+float32(vcy)
 	drawSteeringRing(cx, cy)
+	iconPx := scaledIconPx(steeringIconPx)
 	for i, tool := range steeringWheelTools {
-		tex, ok := icons.texture(tool.icon, "", steeringIconPx)
+		tex, ok := icons.texture(tool.icon, "", iconPx)
 		if !ok {
 			continue
 		}
 		a := 2*stdmath.Pi*float64(i)/float64(len(steeringWheelTools)) - stdmath.Pi/2 // start at the top
-		bx := cx + float32(steeringRadius*stdmath.Cos(a)) - steeringIconPx/2
-		by := cy + float32(steeringRadius*stdmath.Sin(a)) - steeringIconPx/2
+		bx := cx + float32(steeringRadius*stdmath.Cos(a)) - float32(iconPx)/2
+		by := cy + float32(steeringRadius*stdmath.Sin(a)) - float32(iconPx)/2
 		native.SetCursorPos(bx, by)
-		if native.ImageButton(tool.id, tex, steeringIconPx, steeringIconPx, identityTint) {
+		if native.ImageButton(tool.id, tex, float32(iconPx), float32(iconPx), identityTint) {
 			tool.run(s)
 			s.DisarmSteeringWheel()
 		}

--- a/head/ui/ui_scale.go
+++ b/head/ui/ui_scale.go
@@ -1,0 +1,39 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"math"
+
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// uiIconScale is the live icon-size factor (1.0 = 100%), refreshed each frame by applyUIScale
+// from the session's persisted preference. Package-global to match the chrome's other per-window
+// state (icons, theme); scaledIconPx reads it at every icon draw site (#1232 follow-up: icons
+// too small on high-resolution monitors).
+var uiIconScale = 1.0
+
+// scaledIconPx scales a base icon pixel size by the live UI icon-scale preference, rounded to a
+// whole pixel. A non-positive scale (shouldn't happen — guarded on read) falls back to the base
+// so an icon can never collapse to zero.
+//
+//	scaledIconPx(18) // => 27 when uiIconScale is 1.5
+func scaledIconPx(base int) int {
+	if uiIconScale <= 0 {
+		return base
+	}
+	return int(math.Round(float64(base) * uiIconScale))
+}
+
+// applyUIScale pushes the user's persisted UI scale into the renderer once per frame: the text
+// scale into ImGui (live, via style.FontScaleMain) and the icon scale into uiIconScale for the
+// icon draw sites. Called from prepareChromeFrame so it precedes the ribbon, which sizes its band
+// from the scaled icon size.
+func applyUIScale(win *native.Window, s *app.Session) {
+	win.SetUIFontScale(float32(s.UIFontScale()))
+	uiIconScale = s.UIIconScale()
+}

--- a/head/ui/ui_scale_test.go
+++ b/head/ui/ui_scale_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"oblikovati.org/app"
-	"oblikovati.org/head/internal/native"
 )
 
 func TestScaledIconPx(t *testing.T) {

--- a/head/ui/ui_scale_test.go
+++ b/head/ui/ui_scale_test.go
@@ -1,0 +1,59 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+func TestScaledIconPx(t *testing.T) {
+	defer func() { uiIconScale = 1.0 }() // package global shared with the live chrome
+	cases := []struct {
+		scale float64
+		base  int
+		want  int
+	}{
+		{1.0, 18, 18},  // identity
+		{2.0, 18, 36},  // doubled
+		{1.5, 18, 27},  // 1.5x rounds cleanly
+		{1.5, 40, 60},  // large icon scales too
+		{0, 18, 18},    // corrupt scale → base, never zero
+		{-1, 40, 40},   // negative → base
+		{1.25, 18, 23}, // 22.5 rounds to 23
+	}
+	for _, c := range cases {
+		uiIconScale = c.scale
+		if got := scaledIconPx(c.base); got != c.want {
+			t.Errorf("scaledIconPx(%d) at scale %v = %d, want %d", c.base, c.scale, got, c.want)
+		}
+	}
+}
+
+// TestInWindowApplyUIScale drives applyUIScale in a real frame and asserts it copies the session's
+// persisted icon scale into the live uiIconScale the draw sites read. The font scale goes straight
+// to ImGui (style.FontScaleMain) and is exercised here for its draw path.
+func TestInWindowApplyUIScale(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	defer func() { uiIconScale = 1.0 }()
+	s := app.NewSession()
+	if err := s.SetUIIconScale(1.75); err != nil {
+		t.Fatalf("SetUIIconScale: %v", err)
+	}
+	if err := s.SetUIFontScale(1.25); err != nil {
+		t.Fatalf("SetUIFontScale: %v", err)
+	}
+
+	win.BeginFrame()
+	applyUIScale(win, s)
+	win.EndFrame(0.1, 0.1, 0.1)
+
+	if uiIconScale != 1.75 {
+		t.Errorf("applyUIScale left uiIconScale = %v, want 1.75", uiIconScale)
+	}
+}

--- a/head/ui/ui_tab.go
+++ b/head/ui/ui_tab.go
@@ -1,0 +1,47 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// UI-scale slider bounds in percent (the session clamps to the same factor range). Icons reach a
+// higher maximum than text because they re-rasterize from vector SVG and stay crisp when enlarged.
+const (
+	uiFontPercentMin = 75
+	uiFontPercentMax = 200
+	uiIconPercentMin = 75
+	uiIconPercentMax = 250
+)
+
+// drawUITab renders the UI-scale preferences (#1232 follow-up: icons/text too small on
+// high-resolution monitors): a text-size and an icon-size percentage slider, applied live and
+// persisted. Edits write straight back to the session, so the next frame renders at the new scale.
+func drawUITab(s *app.Session) {
+	native.Text("Adjust the interface scale for your monitor's resolution.")
+	native.Separator()
+	editUITextScale(s)
+	editUIIconScale(s)
+	native.Separator()
+	native.Text("Text size also scales the Script Console code editor.")
+}
+
+// editUITextScale draws the UI text-size slider, reading and writing the scale as a percentage.
+func editUITextScale(s *app.Session) {
+	pct := float32(s.UIFontScale() * 100)
+	if native.SliderPercent("Text size", &pct, uiFontPercentMin, uiFontPercentMax) {
+		reportPrefError(s.SetUIFontScale(float64(pct) / 100))
+	}
+}
+
+// editUIIconScale draws the ribbon/tool icon-size slider.
+func editUIIconScale(s *app.Session) {
+	pct := float32(s.UIIconScale() * 100)
+	if native.SliderPercent("Icon size", &pct, uiIconPercentMin, uiIconPercentMax) {
+		reportPrefError(s.SetUIIconScale(float64(pct) / 100))
+	}
+}

--- a/head/ui/ui_tab_test.go
+++ b/head/ui/ui_tab_test.go
@@ -1,0 +1,33 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// TestInWindowUITabDraws renders the Preferences UI tab in a real frame so the slider draw paths
+// (drawUITab → editUITextScale/editUIIconScale) are exercised; the slider apply branches are
+// covered by the app-level SetUIFontScale/SetUIIconScale tests.
+func TestInWindowUITabDraws(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	s := app.NewSession()
+
+	win.BeginFrame()
+	if native.Begin("##ui-tab-test") {
+		drawUITab(s)
+	}
+	native.End()
+	win.EndFrame(0.1, 0.1, 0.1)
+
+	// A no-click render leaves the scales at their defaults.
+	if s.UIFontScale() != 1 || s.UIIconScale() != 1 {
+		t.Errorf("UI scales drifted without interaction: font=%v icon=%v", s.UIFontScale(), s.UIIconScale())
+	}
+}


### PR DESCRIPTION
## What

Adds a new **UI** tab to the Preferences window with two live **percentage sliders** — **Text size** and **Icon size** — persisted to the per-user options file (`~/.oblikovati/options.yaml`).

- **Text size** drives ImGui 1.92's `style.FontScaleMain`, rescaling all UI text live (no atlas rebuild). The Script Console code editor tracks it too (mono draw size + cell metrics threaded through the scale).
- **Icon size** scales *all* UI icons — ribbon (small/large), navigation bar, steering wheel, and property-panel toggles — by re-rasterizing from the vector SVG at the requested size (crisp, not upscaled). The ribbon band reflows to fit.

## Why

Users on high-resolution monitors reported the ribbon/tool icons and UI text are too small with no way to adjust them. This ships the manual knob; both settings apply live and survive a restart.

## How it's built

Follows the existing preferences pattern (the Privacy/telemetry opt-out is the precedent) — **no public-API/wire change, no ADR**:

- `app/options`: new `UI{FontScale, IconScale}` group (default 100%); clamping session accessors in `app/ui_pref.go` (a corrupt/zero stored scale reads back as full size so the UI can never hide).
- `head/internal/native`: `obk_head_set_font_scale` + `Window.SetUIFontScale`; mono-editor scale fix; `SliderPercent` wrapper.
- `head/ui`: `scaledIconPx` + `applyUIScale` (per-frame), icon px routed through it at every draw site; new `drawUITab`.

## Verification

- Headless: options round-trip + absent-key defaults; session clamp/guard tests (app coverage 100% on the new accessors).
- In-window (lavapipe): `scaledIconPx`/`applyUIScale`/UI-tab render tests.
- Live capture confirmed: icons 100%→200% grow crisply and the band reflows; font 150% enlarges all text; the UI tab renders with both percentage sliders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)