### PR TITLE
fix: sketch dimensions respect document Length/Angle precision

### DIFF
--- a/app/sketch_constraints.go
+++ b/app/sketch_constraints.go
@@ -324,16 +324,19 @@ func addDimensionFor(dims *sketch.DimensionConstraints, units param.UnitsOfMeasu
 	}
 }
 
-// lengthExpr formats a database-unit length as a parseable expression in the document's
-// length unit (e.g. 2.5 cm → "25 mm").
+// lengthExpr formats a database-unit length as a parseable expression in the document's length
+// unit, rounded to the document's display precision so a freshly placed dimension reads as the
+// clean on-screen number ("10 mm") instead of the raw measured float ("9.999999998 mm"). The
+// rounded value is emitted in plain decimal so it always round-trips through the expression
+// parser, whatever the display format (fractional/architectural/DMS are display-only).
 func lengthExpr(units param.UnitsOfMeasure, dbValue float64) string {
-	return units.Format(param.Quantity{Value: dbValue, Unit: param.Length})
+	return units.DisplayRoundedExpr(param.Quantity{Value: dbValue, Unit: param.Length})
 }
 
-// angleExpr formats a radian angle as a parseable expression in the document's angle
-// unit (e.g. "30 deg").
+// angleExpr formats a radian angle as a parseable expression in the document's angle unit,
+// rounded to the document's angle precision (e.g. "30 deg" rather than "29.999999998 deg").
 func angleExpr(units param.UnitsOfMeasure, radians float64) string {
-	return units.Format(param.Quantity{Value: radians, Unit: param.Angle})
+	return units.DisplayRoundedExpr(param.Quantity{Value: radians, Unit: param.Angle})
 }
 
 // lineAngle returns the angle (radians, [0,π]) between two lines.

--- a/app/sketch_dimension_precision_test.go
+++ b/app/sketch_dimension_precision_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/model/param"
+)
+
+// TestDimensionSeedRespectsPrecision: a dimension placed on geometry measured with float noise
+// seeds a CLEAN, precision-rounded expression ("10 mm"), not the raw "9.999999998 mm" — so the
+// stored parameter carries the on-screen number (Oblikovati/Oblikovati#146 follow-up).
+func TestDimensionSeedRespectsPrecision(t *testing.T) {
+	units := param.DefaultUnitsOfMeasure() // mm, 3 length decimals; deg, 2 angle decimals
+	if got := lengthExpr(units, 0.9999999998); got != "10 mm" {
+		t.Errorf("length seed = %q, want \"10 mm\"", got)
+	}
+	// 30° with float noise → clean "30 deg".
+	if got := angleExpr(units, stdmath.Pi/6+1e-12); got != "30 deg" {
+		t.Errorf("angle seed = %q, want \"30 deg\"", got)
+	}
+}
+
+// TestDimensionLabelRespectsPrecision: the on-screen label is formatted DOWN from the live
+// measured float to the document's display precision, never printed losslessly.
+func TestDimensionLabelRespectsPrecision(t *testing.T) {
+	units := param.DefaultUnitsOfMeasure()
+	if got := lengthLabel(units, 0.9999999998); got != "10.000 mm" {
+		t.Errorf("length label = %q, want \"10.000 mm\"", got)
+	}
+	if got := angleLabel(units, stdmath.Pi/6+1e-12); got != "30.00 deg" {
+		t.Errorf("angle label = %q, want \"30.00 deg\"", got)
+	}
+}

--- a/app/sketch_dimension_view.go
+++ b/app/sketch_dimension_view.go
@@ -62,17 +62,30 @@ func dimensionView(d *sketch.DimensionConstraint, units param.UnitsOfMeasure) (D
 		if a == nil || b == nil {
 			return DimensionView{}, false
 		}
-		return distanceView(d, a.Position(), b.Position(), lengthExpr(units, d.Measured())), true
+		return distanceView(d, a.Position(), b.Position(), lengthLabel(units, d.Measured())), true
 	case sketch.RadiusDim:
-		return circleView(d, refs, radiusPrefix+lengthExpr(units, d.Measured()), false)
+		return circleView(d, refs, radiusPrefix+lengthLabel(units, d.Measured()), false)
 	case sketch.DiameterDim:
-		return circleView(d, refs, diameterPrefix+lengthExpr(units, d.Measured()), true)
+		return circleView(d, refs, diameterPrefix+lengthLabel(units, d.Measured()), true)
 	case sketch.AngleDim:
-		return angleView(d, refs, angleExpr(units, d.Measured()))
+		return angleView(d, refs, angleLabel(units, d.Measured()))
 	case sketch.ArcLengthDim:
-		return arcLengthView(d, refs, lengthExpr(units, d.Measured()))
+		return arcLengthView(d, refs, lengthLabel(units, d.Measured()))
 	}
 	return DimensionView{}, false
+}
+
+// lengthLabel / angleLabel render a database-unit measurement for a dimension's on-screen label
+// at the document's display precision and FORMAT (decimal/fractional/architectural, decimal-deg/
+// DMS). Unlike the seed expression (lengthExpr), the label is recomputed from live geometry each
+// frame, so it must format down from the raw measured float (e.g. 9.999999998 cm → "10.00 mm")
+// rather than print it losslessly.
+func lengthLabel(units param.UnitsOfMeasure, dbValue float64) string {
+	return units.FormatDisplay(param.Quantity{Value: dbValue, Unit: param.Length})
+}
+
+func angleLabel(units param.UnitsOfMeasure, radians float64) string {
+	return units.FormatDisplay(param.Quantity{Value: radians, Unit: param.Angle})
 }
 
 // distanceView offsets the dimension line off the measured segment by a perpendicular

--- a/model/param/format_display.go
+++ b/model/param/format_display.go
@@ -73,6 +73,61 @@ func (m UnitsOfMeasure) formatAngleDisplay(q Quantity) string {
 	return formatFixed(m.ToPreferred(q), m.anglePrecision)
 }
 
+// DisplayRoundedExpr renders q rounded to the granularity the document's display precision/format
+// actually shows, as a plain, always-parseable decimal expression in the displayed unit
+// ("10 mm", "30 deg", "0.125 in"). A dimension seeded with this stores exactly the clean on-screen
+// number instead of the raw measured float ("9.999999998 mm") (Oblikovati/Oblikovati#146
+// follow-up). The value is rounded in the displayed unit and emitted as decimal even when the
+// FORMAT is fractional/architectural/DMS — so it round-trips through the expression parser
+// (which has no fraction/°/feet literals) without the db→preferred float noise that re-dividing a
+// db value would reintroduce for an irrational unit factor (e.g. degrees↔radians). Categories
+// without a rich display fall back to the lossless form.
+//
+// Example: with mm units at precision 3, DisplayRoundedExpr(Q(0.9999999998, Length)) → "10 mm".
+func (m UnitsOfMeasure) DisplayRoundedExpr(q Quantity) string {
+	switch q.Unit {
+	case Length:
+		switch m.lengthFormat {
+		case types.DisplayFormatFractional:
+			return decimalExpr(roundToFraction(m.ToPreferred(q), m.fractionDenominator()), m.PreferredName(Length))
+		case types.DisplayFormatArchitectural:
+			return decimalExpr(roundToFraction(m.inchesOf(q), m.fractionDenominator()), "in")
+		default:
+			return decimalExpr(roundToDecimals(m.ToPreferred(q), m.lengthPrecision), m.PreferredName(Length))
+		}
+	case Angle:
+		if m.angleFormat == AngleDMS {
+			return decimalExpr(roundToDecimals(m.degreesOf(q)*3600, 0)/3600, "deg") // nearest arcsecond
+		}
+		return decimalExpr(roundToDecimals(m.ToPreferred(q), m.anglePrecision), m.PreferredName(Angle))
+	default:
+		return m.Format(q)
+	}
+}
+
+// decimalExpr joins a shortest-decimal value with a unit name into a parseable expression.
+func decimalExpr(v float64, unit string) string {
+	s := strconv.FormatFloat(v, 'g', -1, 64)
+	if unit == "" {
+		return s
+	}
+	return s + " " + unit
+}
+
+// roundToDecimals rounds v to places decimal places (places < 0 treated as 0).
+func roundToDecimals(v float64, places int) float64 {
+	if places < 0 {
+		places = 0
+	}
+	scale := stdmath.Pow(10, float64(places))
+	return stdmath.Round(v*scale) / scale
+}
+
+// roundToFraction rounds v to the nearest 1/denom.
+func roundToFraction(v float64, denom int) float64 {
+	return stdmath.Round(v*float64(denom)) / float64(denom)
+}
+
 // fractionDenominator maps the length precision to a power-of-two fraction
 // denominator: precision 1→halves, 3→eighths, 6→sixty-fourths, clamped to the
 // 1/2…1/128 range Inventor offers.

--- a/model/param/format_display_test.go
+++ b/model/param/format_display_test.go
@@ -113,6 +113,48 @@ func TestFractionHelpers(t *testing.T) {
 	}
 }
 
+// TestDisplayRoundedExpr verifies a raw measured float collapses to the clean value the display
+// precision shows, emitted as a parseable decimal expression (no float noise — the whole point).
+func TestDisplayRoundedExpr(t *testing.T) {
+	m := DefaultUnitsOfMeasure() // mm, 3 length decimals; deg, 2 angle decimals
+	deg := namedUnits["deg"].factor
+	cases := []struct {
+		q    Quantity
+		want string
+	}{
+		{Q(0.9999999998, Length), "10 mm"},     // ~10 mm edge with float noise → clean
+		{Q(1.234567, Length), "12.346 mm"},     // rounds to 3 mm-decimals
+		{Q(29.999999998*deg, Angle), "30 deg"}, // angle noise → clean (no deg↔rad round-trip noise)
+		{Q(30.126*deg, Angle), "30.13 deg"},    // rounds to 2 angle-decimals
+	}
+	for _, c := range cases {
+		if got := m.DisplayRoundedExpr(c.q); got != c.want {
+			t.Errorf("DisplayRoundedExpr(%v) = %q, want %q", c.q, got, c.want)
+		}
+	}
+	// A category without a rich display falls back to the lossless form.
+	if got := m.DisplayRoundedExpr(Q(2.5, Mass)); got != m.Format(Q(2.5, Mass)) {
+		t.Errorf("mass expr = %q, want lossless %q", got, m.Format(Q(2.5, Mass)))
+	}
+}
+
+// TestDisplayRoundedExprFractional: a fractional-format document seeds a decimal expression that
+// still parses (the parser has no fraction literal), rounded to the fraction granularity.
+func TestDisplayRoundedExprFractional(t *testing.T) {
+	m := DefaultUnitsOfMeasure().Clone()
+	if err := m.SetPreferred(Length, "in"); err != nil {
+		t.Fatal(err)
+	}
+	m.SetLengthFormat(types.DisplayFormatFractional)
+	if err := m.SetLengthPrecision(3); err != nil { // eighths
+		t.Fatal(err)
+	}
+	// 0.124 in ≈ 1/8 in → rounds to exactly 0.125 in, emitted as decimal.
+	if got := m.DisplayRoundedExpr(Q(0.124*2.54, Length)); got != "0.125 in" {
+		t.Errorf("fractional expr = %q, want \"0.125 in\"", got)
+	}
+}
+
 // TestFormatDisplayEdgeCases covers the fallback, clamp, and negative paths.
 func TestFormatDisplayEdgeCases(t *testing.T) {
 	m := DefaultUnitsOfMeasure()


### PR DESCRIPTION
## Problem
Placing a sketch dimension showed/stored raw float noise like `9.999999999999998 mm` instead of `10 mm` — the value ignored the document's **Length/Angle Precision** (Document Settings ▸ Units).

## Cause
Both the seeded dimension expression (`lengthExpr`/`angleExpr`) and the on-screen label rendered via the **lossless** `UnitsOfMeasure.Format` (shortest *exact* decimal), which faithfully prints the measured float's noise.

## Fix
- **Seed** → new `param.DisplayRoundedExpr`: rounds the measured value to the document's display granularity (decimal places / power-of-two fraction / arcsecond) and emits it as a **plain decimal** expression that always round-trips through the expression parser. It rounds in the *preferred* unit (not via the database value) so an irrational unit factor (deg↔rad) doesn't reintroduce noise.
- **Label** → `dimensionView` now formats the live measured value down with `FormatDisplay`, so the drawn text honors precision **and** format (decimal / fractional / architectural / DMS) on every recompute.

## Verification
- Live: a placed distance dimension renders `4.000 mm` (display precision).
- Tests: `DisplayRoundedExpr` (length, angle, fractional, deg↔rad noise case), and app-level seed/label tests proving `0.9999999998 cm → "10 mm"` / `"10.000 mm"`.
- Whole module green (109 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)