### PR TITLE
fix: drawing dimensions respect the drafting standard's precision

### DIFF
--- a/model/drawing/content.go
+++ b/model/drawing/content.go
@@ -63,8 +63,16 @@ func NewContent() *Content {
 	c.sheets.lookup = c.resolveProperty
 	c.sheets.bodyResolve = c.resolveBody
 	c.sheets.bomResolve = c.resolveBOM
+	c.sheets.dimPrecision = c.dimDecimals
 	c.sheets.addDefault()
 	return c
+}
+
+// dimDecimals returns the active drafting standard's dimension decimal places, the precision a
+// sheet's dimensions format their values to. Drives drawing-dimension precision the way the part
+// document's Units settings drive sketch-dimension precision.
+func (c *Content) dimDecimals() int {
+	return c.styles.ActiveStyle().DimensionStyle().DecimalPlaces()
 }
 
 // DocumentType identifies this as drawing content.

--- a/model/drawing/dimension.go
+++ b/model/drawing/dimension.go
@@ -70,13 +70,37 @@ func (d *DrawingDimension) TextAnchorMM() (x, y float64) {
 // dimension's view and project through it) and the body-resolution hook (to re-bind the attached
 // vertices on recompute).
 type DrawingDimensions struct {
-	items []*DrawingDimension
-	views *DrawingViews
-	body  bodyLookup
+	items     []*DrawingDimension
+	views     *DrawingViews
+	body      bodyLookup
+	precision func() int // active drafting standard's decimal places; set by the owning sheet
 }
 
-func newDrawingDimensions(views *DrawingViews, body bodyLookup) *DrawingDimensions {
-	return &DrawingDimensions{views: views, body: body}
+func newDrawingDimensions(views *DrawingViews, body bodyLookup, precision func() int) *DrawingDimensions {
+	return &DrawingDimensions{views: views, body: body, precision: precision}
+}
+
+// defaultDimDecimals is the fallback decimal places when no drafting-standard precision provider
+// is wired (e.g. a bare DrawingDimensions in a unit test) — the ISO default.
+const defaultDimDecimals = 2
+
+// decimals returns the active drafting standard's dimension decimal places, or the ISO default
+// when no precision provider is wired (clamped non-negative).
+func (ds *DrawingDimensions) decimals() int {
+	if ds.precision == nil {
+		return defaultDimDecimals
+	}
+	if p := ds.precision(); p >= 0 {
+		return p
+	}
+	return 0
+}
+
+// formatDimValue renders a dimension value at the active drafting standard's precision — fixed
+// decimal places, so a value measured as 9.999999998 reads as the clean "10.00" and honors the
+// configured precision instead of a bare 4-significant-figure float (Oblikovati/Oblikovati#146).
+func formatDimValue(v float64, decimals int) string {
+	return strconv.FormatFloat(v, 'f', decimals, 64)
 }
 
 // AddLinear adds a linear dimension on the named base view between two pick points (sheet mm),
@@ -404,7 +428,7 @@ func (ds *DrawingDimensions) recomputeOrdinate(d *DrawingDimension, view *Drawin
 	} else {
 		d.valueMM = math.Abs(float64(pp.Y-pd.Y)) * cmToMM
 	}
-	d.text = strconv.FormatFloat(d.valueMM, 'g', 4, 64)
+	d.text = formatDimValue(d.valueMM, ds.decimals())
 	curves, mx, my, nx, ny := ordinateDimensionCurves(view, view.place(pp), d.axisHorizontal)
 	d.curves = curves
 	d.setTextAnchor(mx, my, nx, ny, 1)
@@ -419,7 +443,7 @@ func (ds *DrawingDimensions) recomputeAngular(d *DrawingDimension, view *Drawing
 		return
 	}
 	d.valueDeg = angleBetweenDeg(a.dir, b.dir)
-	d.text = strconv.FormatFloat(d.valueDeg, 'g', 4, 64) + "°"
+	d.text = formatDimValue(d.valueDeg, ds.decimals()) + "°"
 	curves, mx, my, nx, ny := angularDimensionCurves(a, b)
 	d.curves = curves
 	d.setTextAnchor(mx, my, nx, ny, 1)
@@ -435,7 +459,7 @@ func (ds *DrawingDimensions) recomputeLinear(d *DrawingDimension, view *DrawingV
 	p1 := hlr.ProjectPoint(basis, va.Point())
 	p2 := hlr.ProjectPoint(basis, vb.Point())
 	d.valueMM = measureMM(d.dimType, p1, p2)
-	d.text = strconv.FormatFloat(d.valueMM, 'g', 4, 64)
+	d.text = formatDimValue(d.valueMM, ds.decimals())
 	s1, s2 := view.place(p1), view.place(p2)
 	ax, ay := dimensionAxis(d.dimType, s1, s2)
 	var mx, my float64
@@ -476,10 +500,10 @@ func (ds *DrawingDimensions) recomputeRadial(d *DrawingDimension, view *DrawingV
 		d.valueMM = 2 * radiusMM
 		// Ø (U+00D8) is the diameter prefix: it is in the head's Latin-1 font, unlike the
 		// typographic ⌀ (U+2300), which renders as a missing-glyph box.
-		d.text = "Ø" + strconv.FormatFloat(d.valueMM, 'g', 4, 64)
+		d.text = "Ø" + formatDimValue(d.valueMM, ds.decimals())
 	} else {
 		d.valueMM = radiusMM
-		d.text = "R" + strconv.FormatFloat(d.valueMM, 'g', 4, 64)
+		d.text = "R" + formatDimValue(d.valueMM, ds.decimals())
 	}
 	center := view.place(hlr.ProjectPoint(basis, circle.Center))
 	arc := view.place(hlr.ProjectPoint(basis, circle.PointAt(0)))
@@ -515,7 +539,7 @@ func (ds *DrawingDimensions) recomputeArcLength(d *DrawingDimension, view *Drawi
 		return
 	}
 	d.valueMM = lengthCM * cmToMM
-	d.text = strconv.FormatFloat(d.valueMM, 'g', 4, 64)
+	d.text = formatDimValue(d.valueMM, ds.decimals())
 	const samples = 32
 	pts := make([]gmath.Point2, 0, samples+1)
 	for i := 0; i <= samples; i++ {

--- a/model/drawing/dimension_test.go
+++ b/model/drawing/dimension_test.go
@@ -349,14 +349,35 @@ func TestLinearDimensionMeasuresTrueModelSize(t *testing.T) {
 	if math.Abs(d.ValueMM()-20) > 1e-6 {
 		t.Errorf("value = %v mm, want 20 (the box's 2 cm X-width)", d.ValueMM())
 	}
-	if d.Text() != "20" {
-		t.Errorf("text = %q, want %q", d.Text(), "20")
+	// Text honors the active drafting standard's precision (ISO default = 2 decimals).
+	if d.Text() != "20.00" {
+		t.Errorf("text = %q, want %q", d.Text(), "20.00")
 	}
 	if d.CurveCount() == 0 {
 		t.Error("dimension produced no glyph curves")
 	}
 	if d.Type() != types.HorizontalDimension || d.ViewName() != "FRONT" {
 		t.Errorf("dimension = (%v on %q), want a horizontal dim on FRONT", d.Type(), d.ViewName())
+	}
+}
+
+// TestDimensionTextFollowsStandardPrecision: a dimension's displayed value honors the active
+// drafting standard's decimal places, and re-formats when the standard changes (ISO 2 → ANSI 3).
+func TestDimensionTextFollowsStandardPrecision(t *testing.T) {
+	c := drawingWithBox(t)
+	frontBase(t, c.Sheets().Active().Views())
+	dims := c.Sheets().Active().Dimensions()
+	d, err := dims.AddLinear("D1", "FRONT", types.HorizontalDimension, 88, 80, 112, 80, -12)
+	if err != nil {
+		t.Fatalf("AddLinear: %v", err)
+	}
+	if d.Text() != "20.00" { // ISO default: 2 decimals
+		t.Errorf("ISO text = %q, want \"20.00\"", d.Text())
+	}
+	c.Styles().SetActiveStandard(types.DraftingANSI) // ANSI: 3 decimals
+	dims.Recompute()
+	if d.Text() != "20.000" {
+		t.Errorf("ANSI text = %q, want \"20.000\"", d.Text())
 	}
 }
 

--- a/model/drawing/recipe.go
+++ b/model/drawing/recipe.go
@@ -174,6 +174,7 @@ func (c *Content) ApplyRecipe(model []byte) error {
 	c.sheets = newSheets()
 	c.sheets.lookup = c.resolveProperty
 	c.sheets.bodyResolve = c.resolveBody
+	c.sheets.dimPrecision = c.dimDecimals
 	for _, sr := range r.Sheets {
 		if err := c.sheets.restore(sr); err != nil {
 			return err
@@ -327,7 +328,7 @@ func (s *Sheets) restore(rec sheetRecipe) error {
 	if err != nil {
 		return err
 	}
-	sh := &Sheet{name: rec.Name, size: size, orientation: orient, width: w, height: h, views: newDrawingViews(s.bodyResolve), bomResolve: s.bomResolve}
+	sh := &Sheet{name: rec.Name, size: size, orientation: orient, width: w, height: h, views: newDrawingViews(s.bodyResolve), bomResolve: s.bomResolve, dimPrecision: s.dimPrecision}
 	if rec.Border {
 		sh.border = newBorder(DefaultBorderDefinition())
 	}

--- a/model/drawing/sheet.go
+++ b/model/drawing/sheet.go
@@ -17,18 +17,19 @@ type propertyLookup func(set, name string) (string, bool)
 // Sheet is one sheet of a drawing: its size/orientation (which fix its laid-out width
 // and height in millimetres), its border, and its title block.
 type Sheet struct {
-	name        string
-	size        types.SheetSize
-	orientation types.SheetOrientation
-	width       float64 // laid-out mm (orientation applied)
-	height      float64
-	border      *Border
-	titleBlock  *TitleBlock
-	views       *DrawingViews
-	annotations *DrawingAnnotations
-	dimensions  *DrawingDimensions
-	sketches    *DrawingSketches
-	bomResolve  bomLookup // parts-list BOM source, captured from the owning Sheets
+	name         string
+	size         types.SheetSize
+	orientation  types.SheetOrientation
+	width        float64 // laid-out mm (orientation applied)
+	height       float64
+	border       *Border
+	titleBlock   *TitleBlock
+	views        *DrawingViews
+	annotations  *DrawingAnnotations
+	dimensions   *DrawingDimensions
+	sketches     *DrawingSketches
+	bomResolve   bomLookup  // parts-list BOM source, captured from the owning Sheets
+	dimPrecision func() int // active drafting-standard decimal places, captured from the owning Sheets
 }
 
 // Views returns the sheet's drawing views (projections of the referenced model).
@@ -53,7 +54,7 @@ func (s *Sheet) Sketches() *DrawingSketches {
 // Dimensions returns the sheet's drawing dimensions (associative linear measurements on views).
 func (s *Sheet) Dimensions() *DrawingDimensions {
 	if s.dimensions == nil {
-		s.dimensions = newDrawingDimensions(s.views, s.views.body)
+		s.dimensions = newDrawingDimensions(s.views, s.views.body, s.dimPrecision)
 	}
 	return s.dimensions
 }
@@ -98,11 +99,12 @@ func (s *Sheet) TitleBlock() contract.DrawingTitleBlock {
 
 // Sheets is a drawing's ordered, named sheet collection, tracking which sheet is active.
 type Sheets struct {
-	items       []*Sheet
-	active      int
-	lookup      propertyLookup // handed to each new title block; set by the owning Content
-	bodyResolve bodyLookup     // handed to each sheet's views; set by the owning Content
-	bomResolve  bomLookup      // handed to each sheet's annotations (parts lists); set by Content
+	items        []*Sheet
+	active       int
+	lookup       propertyLookup // handed to each new title block; set by the owning Content
+	bodyResolve  bodyLookup     // handed to each sheet's views; set by the owning Content
+	bomResolve   bomLookup      // handed to each sheet's annotations (parts lists); set by Content
+	dimPrecision func() int     // handed to each sheet's dimensions (decimal places); set by Content
 }
 
 func newSheets() *Sheets { return &Sheets{} }
@@ -130,10 +132,11 @@ func (s *Sheets) Add(spec SheetSpec) (*Sheet, error) {
 	}
 	sh := &Sheet{
 		name: name, size: spec.Size, orientation: spec.Orientation, width: w, height: h,
-		border:     newBorder(DefaultBorderDefinition()),
-		titleBlock: newTitleBlock(DefaultTitleBlockDefinition(), s.lookup),
-		views:      newDrawingViews(s.bodyResolve),
-		bomResolve: s.bomResolve,
+		border:       newBorder(DefaultBorderDefinition()),
+		titleBlock:   newTitleBlock(DefaultTitleBlockDefinition(), s.lookup),
+		views:        newDrawingViews(s.bodyResolve),
+		bomResolve:   s.bomResolve,
+		dimPrecision: s.dimPrecision,
 	}
 	s.items = append(s.items, sh)
 	s.active = len(s.items) - 1


### PR DESCRIPTION
Follow-up to #1239 (sketch dimensions), answering "is it working the same for drawing dimensions too?" — it wasn't.

## Problem
Drawing dimension text was built with a hardcoded 4-significant-figure float (`strconv.FormatFloat(v, 'g', 4, 64)`), so it ignored the drawing's configured precision (the active drafting standard's decimal places). A value like `123.456` showed `123.5`, and the precision setting had no effect.

## Fix
Thread the active drafting standard's `DimensionStyle.DecimalPlaces()` (ISO = 2, ANSI = 3) through `Content → Sheets → Sheet → DrawingDimensions` (mirroring the existing `bomResolve` callback wiring), and format every dimension value at that **fixed precision** via a single `formatDimValue` helper. Covers linear, aligned, ordinate, angular (`…°`), radius (`R…`) and diameter (`Ø…`).

The measured value (`valueMM`/`valueDeg`) stays exact for associativity — only the displayed text is rounded. When no precision provider is wired (bare unit-test object), it falls back to the ISO default of 2.

## Verification
- `TestDimensionTextFollowsStandardPrecision`: a dimension reads `20.00` under ISO and re-formats to `20.000` after switching to ANSI.
- Updated the existing measure test (`20` → `20.00`).
- Whole module green; lint clean.

## Note
Drawing-dimension formatting lives entirely in the model layer (`DrawingDimension.Text()`), which the head renders verbatim — so this is fully covered headlessly; there's no head-side formatting to capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)