### PR TITLE
feat: sub-millimetre length units (µm dropdown, parser down to pm)

### DIFF
--- a/app/units_settings.go
+++ b/app/units_settings.go
@@ -30,7 +30,7 @@ func (s *Session) SetDocumentUnits(u param.UnitsOfMeasure) {
 // LengthUnitOptions / AngleUnitOptions / MassUnitOptions / TimeUnitOptions are the
 // unit names the Units dialog offers per category, so the head needs no unit
 // vocabulary of its own.
-func LengthUnitOptions() []string { return []string{"mm", "cm", "m", "in", "ft"} }
+func LengthUnitOptions() []string { return []string{"µm", "mm", "cm", "m", "in", "ft"} }
 func AngleUnitOptions() []string  { return []string{"deg", "rad"} }
 func MassUnitOptions() []string   { return []string{"kg", "g", "lb"} }
 func TimeUnitOptions() []string   { return []string{"s", "ms", "min", "hr"} }

--- a/app/units_settings_test.go
+++ b/app/units_settings_test.go
@@ -69,6 +69,10 @@ func TestUnitOptionLists(t *testing.T) {
 	if !has(LengthUnitOptions(), "mm") || !has(LengthUnitOptions(), "in") {
 		t.Error("length options missing mm/in")
 	}
+	// Micrometres are now the smallest selectable length unit.
+	if LengthUnitOptions()[0] != "µm" {
+		t.Errorf("smallest length option = %q, want \"µm\"", LengthUnitOptions()[0])
+	}
 	if !has(AngleUnitOptions(), "deg") || !has(AngleUnitOptions(), "rad") {
 		t.Error("angle options missing deg/rad")
 	}

--- a/model/param/expr_token.go
+++ b/model/param/expr_token.go
@@ -109,6 +109,12 @@ func (l *lexer) skipSpaces() {
 	}
 }
 
-func isDigit(c byte) bool      { return c >= '0' && c <= '9' }
-func isIdentStart(c byte) bool { return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') }
-func isIdentPart(c byte) bool  { return isIdentStart(c) || isDigit(c) }
+func isDigit(c byte) bool { return c >= '0' && c <= '9' }
+
+// isIdentStart/isIdentPart accept any non-ASCII byte (c >= 0x80) so a multi-byte UTF-8 rune is
+// taken as part of an identifier — this is what lets a unit name carry a symbol such as the micro
+// sign in "µm" (and tolerates Unicode parameter names generally).
+func isIdentStart(c byte) bool {
+	return c == '_' || c >= 0x80 || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+func isIdentPart(c byte) bool { return isIdentStart(c) || isDigit(c) }

--- a/model/param/units_of_measure.go
+++ b/model/param/units_of_measure.go
@@ -22,7 +22,9 @@ type unitDef struct {
 // vocabulary). Database units are the factor-1 member of each category: cm for
 // length, radian for angle, and so on.
 var namedUnits = map[string]unitDef{
-	// Length (database unit: cm).
+	// Length (database unit: cm). Sub-millimetre metric units down to picometres are accepted by
+	// the parser; "µm" and its ASCII spelling "um" are the same micrometre.
+	"pm": {Length, 1e-10}, "nm": {Length, 1e-7}, "um": {Length, 1e-4}, "µm": {Length, 1e-4},
 	"mm": {Length, 0.1}, "cm": {Length, 1}, "m": {Length, 100}, "km": {Length, 100000},
 	"in": {Length, 2.54}, "ft": {Length, 30.48},
 	// Angle (database unit: radian).

--- a/model/param/units_service_test.go
+++ b/model/param/units_service_test.go
@@ -8,6 +8,44 @@ import (
 	"oblikovati.org/api/types"
 )
 
+// TestSubMillimetreUnits: the parser accepts metric length units down to picometres (and the
+// micro sign µ), each converting to the correct database-unit (cm) value.
+func TestSubMillimetreUnits(t *testing.T) {
+	ps := NewParameters()
+	cases := map[string]float64{ // expression → database cm
+		"1 µm":    1e-4,   // micrometre via the micro sign
+		"1 um":    1e-4,   // ASCII spelling of the same
+		"2500 nm": 2.5e-4, // nanometre
+		"1000 pm": 1e-7,   // picometre
+	}
+	for expr, want := range cases {
+		q, err := ps.EvaluateExpression(expr)
+		if err != nil {
+			t.Errorf("EvaluateExpression(%q) error: %v", expr, err)
+			continue
+		}
+		if q.Unit != Length || !approxScalar(q.Value, want) {
+			t.Errorf("%q = (%g, %v), want (%g, Length)", expr, q.Value, q.Unit, want)
+		}
+	}
+}
+
+// TestMicrometrePreferredUnit: a document can select micrometres as its length unit, and values
+// display in it.
+func TestMicrometrePreferredUnit(t *testing.T) {
+	m := DefaultUnitsOfMeasure().Clone()
+	if err := m.SetPreferred(Length, "µm"); err != nil {
+		t.Fatalf("SetPreferred µm: %v", err)
+	}
+	// 0.05 cm = 500 µm.
+	if got := m.FormatValue(Q(0.05, Length)); got != "500" {
+		t.Errorf("0.05 cm in µm = %q, want \"500\"", got)
+	}
+	if got := m.PreferredName(Length); got != "µm" {
+		t.Errorf("preferred name = %q, want \"µm\"", got)
+	}
+}
+
 func TestConvertValue(t *testing.T) {
 	got, err := ConvertValue(1, "in", "cm")
 	if err != nil || !approxScalar(got, 2.54) {


### PR DESCRIPTION
## What
- **Document Settings** now offers **micrometres (µm)** as the smallest selectable length unit (was millimetres).
- The **expression parser** accepts the finer metric length units down to **picometres**: `pm`, `nm`, `µm` (and the ASCII spelling `um`). So `250 nm`, `1200 pm`, `5 µm` all evaluate to the right database value.

## How
- Added the units to the parser's named-unit registry (cm-based factors: µm 1e-4, nm 1e-7, pm 1e-10).
- The lexer now treats any non-ASCII byte as an identifier char, so a unit name can carry the micro sign `µ` (also tolerates Unicode parameter names). The embedded UI font renders `µ` (Latin-1) — confirmed live in the Units dialog.
- Added `µm` to `LengthUnitOptions` as the first/smallest entry.

## Verification
- Parser: `TestSubMillimetreUnits` (µm/um/nm/pm → correct cm values).
- Display: `TestMicrometrePreferredUnit` (a document can select µm; 0.05 cm → "500" µm).
- Dropdown: `TestUnitOptionLists` asserts µm is the smallest option.
- Live: the Units dialog renders `Length: µm` correctly.
- Whole module green; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)