### PR TITLE
feat(kernel): model-relative tolerance context (Resolution) [M35-P1-01]

### DIFF
--- a/kernel/ops/resolution.go
+++ b/kernel/ops/resolution.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Phase 1 of ADR-0042 (Oblikovati/Oblikovati#1242): a single, model-relative
+// source of truth for "how close is coincident in this model". Every weld /
+// coincidence / on-line / on-plane test should derive its tolerance from the
+// SIZE of the geometry it operates on, rather than reading a cm-anchored absolute
+// constant. Absolute constants are scale-blind: a part authored at nm/pm scale has
+// all its coordinates closer than a 1e-6 cm weld and is merged out of existence,
+// while a km-scale part gets needlessly tight tolerances. A size-relative
+// resolution makes the modeller faithful across scales.
+//
+// This file only introduces the concept and the derived tolerances; the kernel
+// ops are migrated onto it in #1243, and the pm→km scale-invariance is the
+// acceptance gate in #1244. Nothing here changes behaviour until call sites adopt
+// it.
+
+// epsRel is the base relative coincidence precision: two points within
+// epsRel × modelSize count as the same vertex. 1e-9 is the precedent already set
+// by the bounds-relative convex-hull (convexhull.go) and surface-query
+// (geom/evaluator_surface_query.go) tolerances, and sits ~7 orders inside
+// float64's ~16 significant digits, leaving ample headroom for arithmetic.
+const epsRel = 1e-9
+
+// minModelSize floors the model size so a degenerate, single-point or empty
+// operand still yields a strictly positive resolution. 1 (one database
+// centimetre) matches the long-standing convex-hull fallback (boundsDiagonal
+// returns 1 for a zero-extent point set), so adopting Resolution there is a no-op.
+const minModelSize = 1.0
+
+// Per-purpose tolerance coefficients, as multiples of the base resolution
+// (epsRel × size). They differ ON PURPOSE — a vertex weld is tight, a default sew
+// gap is deliberately generous — and are calibrated so that at a 1 cm reference
+// part (size = 1) each reproduces the historical absolute constant it replaces in
+// #1243. This preserves today's behaviour at typical (~1 cm) scale while making
+// every tolerance scale with the model.
+const (
+	weldCoef  = 1      // vertex / arrangement weld   (≈1e-9 cm @ 1cm: arrWeld, weldPointTol)
+	planeCoef = 100    // coplanar / on-plane test    (≈1e-7 cm @ 1cm: csgEps)
+	gridCoef  = 1000   // weld grid / on-line test    (≈1e-6 cm @ 1cm: weldGrid, onLineTol)
+	sewCoef   = 100000 // default sew gap            (≈1e-4 cm @ 1cm: defaultSewTolerance)
+)
+
+// volCoef is the relative volume tolerance for boolean result classification,
+// reproducing boolean.go's 1e-6 cm³ at a 1 cm reference part (size = 1). Volume
+// scales with size³, so this keeps the classification scale-faithful.
+const volCoef = 1e-6
+
+// Resolution is a model's size-relative coincidence scale: the single value from
+// which all weld / on-line / on-plane / sew / volume tolerances are derived. Build
+// it from the geometry an op is about to work on (its bounding-box diagonal) and
+// read the purpose-specific tolerance you need.
+//
+//	res := ResolutionForBody(b)
+//	if p.DistanceTo(q) < res.Weld() { /* same vertex */ }
+type Resolution struct {
+	size float64 // the model size (bounding-box diagonal) this resolution derives from
+}
+
+// ResolutionForSize builds a Resolution from an explicit model size (a
+// bounding-box diagonal in database units), flooring it at minModelSize so the
+// result is always strictly positive.
+func ResolutionForSize(size float64) Resolution {
+	if stdmath.IsNaN(size) || size < minModelSize {
+		size = minModelSize
+	}
+	return Resolution{size: size}
+}
+
+// ResolutionForPoints builds a Resolution from a point set's bounding-box
+// diagonal — the entry point for point-based ops (convex hull, arrangements).
+func ResolutionForPoints(pts []math.Point3) Resolution {
+	if len(pts) == 0 {
+		return ResolutionForSize(minModelSize)
+	}
+	return ResolutionForSize(boundsDiagonal(pts))
+}
+
+// ResolutionForBody builds a Resolution from a body's true bounding-box diagonal
+// (curved edges included, via RangeBox) — the entry point for B-rep ops (boolean,
+// CSG, sew, weld).
+func ResolutionForBody(b *topo.Body) Resolution {
+	if b == nil {
+		return ResolutionForSize(minModelSize)
+	}
+	box := b.RangeBox()
+	if box.IsEmpty() {
+		return ResolutionForSize(minModelSize)
+	}
+	return ResolutionForSize(float64(box.Diagonal().Length()))
+}
+
+// Size is the model size (bounding-box diagonal) this resolution derives from.
+func (r Resolution) Size() float64 { return r.size }
+
+// Weld is the vertex/arrangement coincidence tolerance: two points closer than
+// this are the same vertex (replaces arrWeld, weldPointTol).
+func (r Resolution) Weld() float64 { return weldCoef * epsRel * r.size }
+
+// Plane is the coplanar / on-plane classification tolerance (replaces csgEps).
+func (r Resolution) Plane() float64 { return planeCoef * epsRel * r.size }
+
+// Grid is the weld-grid / on-line tolerance for CSG output and segment-interior
+// tests (replaces weldGrid, onLineTol).
+func (r Resolution) Grid() float64 { return gridCoef * epsRel * r.size }
+
+// Sew is the default gap a Sew with tolerance 0 closes — deliberately generous
+// (replaces defaultSewTolerance).
+func (r Resolution) Sew() float64 { return sewCoef * epsRel * r.size }
+
+// Volume is the relative volume tolerance for boolean result classification
+// (replaces boolean.go's absolute 1e-6 cm³). It scales with size³.
+func (r Resolution) Volume() float64 { return volCoef * r.size * r.size * r.size }

--- a/kernel/ops/resolution_test.go
+++ b/kernel/ops/resolution_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/kernel/subd"
+	"oblikovati.org/kernel/topo"
+	gmath "oblikovati.org/math"
+)
+
+// TestResolutionForSizeFloorsDegenerate covers the positive-resolution guarantee:
+// zero, negative and NaN sizes all floor to minModelSize so a degenerate operand
+// still has a strictly positive resolution (ADR-0042 §Phase 1).
+func TestResolutionForSizeFloorsDegenerate(t *testing.T) {
+	for _, size := range []float64{0, -5, 0.001, math.NaN()} {
+		got := ResolutionForSize(size).Size()
+		if got != minModelSize {
+			t.Errorf("ResolutionForSize(%v).Size() = %v, want floor %v", size, got, minModelSize)
+		}
+	}
+	if got := ResolutionForSize(50).Size(); got != 50 {
+		t.Errorf("ResolutionForSize(50).Size() = %v, want 50", got)
+	}
+}
+
+// TestResolutionScalesLinearlyWithSize is the core property: every length
+// tolerance scales linearly with the model size, and the volume tolerance with
+// size³. A 1000× larger model gets 1000× looser length tolerances — this is what
+// makes the kernel scale-faithful instead of cm-anchored.
+func TestResolutionScalesLinearlyWithSize(t *testing.T) {
+	small := ResolutionForSize(1)
+	big := ResolutionForSize(1000)
+	const k = 1000.0
+
+	lengths := []struct {
+		name string
+		of   func(Resolution) float64
+	}{
+		{"Weld", Resolution.Weld},
+		{"Plane", Resolution.Plane},
+		{"Grid", Resolution.Grid},
+		{"Sew", Resolution.Sew},
+	}
+	for _, l := range lengths {
+		if got, want := l.of(big), l.of(small)*k; !approxRel(got, want) {
+			t.Errorf("%s: big=%v, want small×%g=%v", l.name, got, k, want)
+		}
+	}
+	if got, want := big.Volume(), small.Volume()*k*k*k; !approxRel(got, want) {
+		t.Errorf("Volume: big=%v, want small×%g³=%v", got, k, want)
+	}
+}
+
+// TestResolutionReproducesHistoricalConstants pins the calibration: at a 1 cm
+// reference part (size = 1) each derived tolerance equals the absolute constant it
+// replaces in #1243, so the migration is behaviour-preserving at typical scale.
+func TestResolutionReproducesHistoricalConstants(t *testing.T) {
+	r := ResolutionForSize(1)
+	cases := []struct {
+		name string
+		got  float64
+		want float64 // the historical cm/cm³ constant
+	}{
+		{"Weld (arrWeld/weldPointTol)", r.Weld(), 1e-9},
+		{"Plane (csgEps)", r.Plane(), 1e-7},
+		{"Grid (weldGrid/onLineTol)", r.Grid(), 1e-6},
+		{"Sew (defaultSewTolerance)", r.Sew(), 1e-4},
+		{"Volume (boolean tol)", r.Volume(), 1e-6},
+	}
+	for _, c := range cases {
+		if !approxRel(c.got, c.want) {
+			t.Errorf("%s = %v, want historical %v", c.name, c.got, c.want)
+		}
+	}
+}
+
+// TestResolutionForPoints derives the size from a point set's bbox diagonal and
+// floors an empty/degenerate set.
+func TestResolutionForPoints(t *testing.T) {
+	if got := ResolutionForPoints(nil).Size(); got != minModelSize {
+		t.Errorf("ResolutionForPoints(nil).Size() = %v, want floor %v", got, minModelSize)
+	}
+	// A 3-4-5... actually a unit cube: diagonal = sqrt(3).
+	cube := []gmath.Point3{
+		gmath.P3(0, 0, 0), gmath.P3(2, 0, 0), gmath.P3(2, 2, 0), gmath.P3(0, 2, 0),
+		gmath.P3(0, 0, 2), gmath.P3(2, 0, 2), gmath.P3(2, 2, 2), gmath.P3(0, 2, 2),
+	}
+	want := math.Sqrt(2*2 + 2*2 + 2*2) // 2-unit cube diagonal
+	if got := ResolutionForPoints(cube).Size(); !approxRel(got, want) {
+		t.Errorf("ResolutionForPoints(cube).Size() = %v, want %v", got, want)
+	}
+}
+
+// TestResolutionForBody covers the body entry point: nil floors, and a populated
+// body derives its size from the true RangeBox diagonal.
+func TestResolutionForBody(t *testing.T) {
+	if got := ResolutionForBody(nil).Size(); got != minModelSize {
+		t.Errorf("ResolutionForBody(nil).Size() = %v, want floor %v", got, minModelSize)
+	}
+	if got := ResolutionForBody(&topo.Body{}).Size(); got != minModelSize {
+		t.Errorf("ResolutionForBody(empty).Size() = %v, want floor %v", got, minModelSize)
+	}
+	box := subd.ToBody(subd.Box(3, 4, 12), "box") // 3-4-12 box: diagonal = 13
+	if got := ResolutionForBody(box).Size(); !approxRel(got, 13) {
+		t.Errorf("ResolutionForBody(3×4×12 box).Size() = %v, want 13", got)
+	}
+}
+
+// approxRel reports whether got and want agree to a tight relative tolerance,
+// independent of their magnitude (the values span 1e-9 to 1e-4).
+func approxRel(got, want float64) bool {
+	if want == 0 {
+		return got == 0
+	}
+	return math.Abs(got-want)/math.Abs(want) < 1e-12
+}


### PR DESCRIPTION
## What

Introduces `Resolution` (`kernel/ops/resolution.go`): a single, model-relative source of truth for *"how close is coincident in this model"*. Every weld / on-plane / on-line / sew / volume tolerance is derived from the **size** of the geometry an op operates on (its bounding-box diagonal), via `ResolutionForSize` / `ResolutionForPoints` / `ResolutionForBody`.

## Why

The kernel's geometric tolerances are mostly **absolute constants anchored at cm** (`1e-6` boolean weld, `1e-7` csgEps, `1e-6` weldGrid/onLineTol, `1e-4` sew, `1e-9` arrWeld/weldPointTol). These are **scale-blind**: a semiconductor part authored at nm/pm scale has all its coordinates closer than the weld tolerance and is merged out of existence; a km-scale urban model gets needlessly tight, inconsistent tolerances. `convexhull` and `surface_query` already scale tolerance by model bounds — this generalises that to one concept.

See **ADR-0042 §Phase 1**.

## Scope

**Foundation only — additive, no behaviour change.** No call site adopts it yet:
- #1243 migrates `boolean`/`csg`/`csg_body`/`sew`/`union_holes`/`edge_discretize` onto it.
- #1244 is the pm→km scale-sweep acceptance gate.

The per-purpose coefficients (`weldCoef`/`planeCoef`/`gridCoef`/`sewCoef`/`volCoef`) are calibrated to **reproduce today's absolute constants at a 1 cm reference part**, so the #1243 migration is behaviour-preserving at typical scale.

## Tests

`kernel/ops/resolution_test.go` — degenerate/NaN/empty flooring, linear-in-size (length) and cubic-in-size (volume) scaling, historical-constant reproduction at size 1, and the points/body entry points. **100% coverage** of the new file; `golangci-lint` clean.

Closes #1242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)