### PR TITLE
M35 Phase 2 foundation: working-scale storage in param (#1245)

### DIFF
--- a/model/param/quantity.go
+++ b/model/param/quantity.go
@@ -4,10 +4,14 @@ package param
 
 import "fmt"
 
-// Quantity is a dimensioned value: its Value is ALWAYS in database units (cm,
-// radians, cm², …) for the given Unit. User units exist only at the parse/
-// display boundary ([UnitsOfMeasure]). Quantity is an immutable value type;
-// arithmetic returns new quantities and enforces dimensional consistency.
+// Quantity is a dimensioned value: its Value is in WORKING (database) units for the
+// given Unit. The working length unit is the centimetre by default, so historically a
+// length Value was simply centimetres; under ADR-0042 Phase 2 a document may centre its
+// working unit elsewhere (µm, km) for conditioning, in which case realCm = Value ×
+// workingScale^L. Either way the conversion to a named user unit happens only at the
+// parse/display boundary ([UnitsOfMeasure]); the kernel math is unit-agnostic and operates
+// on the raw Value. Quantity is an immutable value type; arithmetic returns new quantities
+// and enforces dimensional consistency.
 type Quantity struct {
 	Value float64
 	Unit  Unit

--- a/model/param/units_of_measure.go
+++ b/model/param/units_of_measure.go
@@ -57,6 +57,14 @@ type UnitsOfMeasure struct {
 	anglePrecision  int             // angle display precision (decimal places)
 	lengthFormat    types.ParameterDisplayFormat
 	angleFormat     AngleFormat
+	// workingScale is the centimetre size of one stored (working/database) length unit —
+	// the key to ADR-0042 Phase 2. A [Quantity]'s Value is in WORKING units, not always
+	// centimetres: realCm = workingValue × workingScale^L (L = the unit's length exponent,
+	// 1 for Length, 2 for Area, 3 for Volume). Default 1.0 ⇒ working unit IS the centimetre,
+	// so every existing document and stored value is unchanged. Centring it on the document's
+	// length unit (e.g. 1e-4 for µm, 1e5 for km) keeps coordinates O(1) so sub-µm and km-scale
+	// parts stay well-conditioned and out of the primitive-construction underflow floor.
+	workingScale float64
 }
 
 // AngleFormat is how an angle is rendered for display: as decimal degrees or as
@@ -82,6 +90,7 @@ func DefaultUnitsOfMeasure() UnitsOfMeasure {
 		anglePrecision:  2,
 		lengthFormat:    types.DisplayFormatDecimal,
 		angleFormat:     AngleDecimal,
+		workingScale:    1, // working unit = centimetre (back-compatible default)
 	}
 }
 
@@ -157,6 +166,63 @@ func (m UnitsOfMeasure) preferredFactor(category Unit) (factor float64, name str
 	return namedUnits[name].factor, name
 }
 
+// WorkingScale is the centimetre size of one stored (working/database) length unit
+// (ADR-0042 Phase 2). 1.0 means working coordinates are centimetres — the default.
+func (m UnitsOfMeasure) WorkingScale() float64 { return m.effectiveWorkingScale() }
+
+// effectiveWorkingScale guards a zero/negative or absent (older-struct) working scale,
+// treating it as the centimetre default so a value is never divided by zero.
+func (m UnitsOfMeasure) effectiveWorkingScale() float64 {
+	if m.workingScale <= 0 {
+		return 1
+	}
+	return m.workingScale
+}
+
+// WithWorkingScale returns a copy whose working unit is cmPerUnit centimetres — the
+// general lever behind [UnitsOfMeasure.CenteredOnLength]. A non-positive value is
+// rejected (the working unit must have a positive size).
+func (m UnitsOfMeasure) WithWorkingScale(cmPerUnit float64) (UnitsOfMeasure, error) {
+	if cmPerUnit <= 0 {
+		return m, fmt.Errorf("param: working scale %g is not positive (cm per working unit)", cmPerUnit)
+	}
+	out := m.Clone()
+	out.workingScale = cmPerUnit
+	return out, nil
+}
+
+// CenteredOnLength returns a copy whose working unit equals the named length unit, so a
+// length authored in that unit is stored as an O(1) coordinate (ADR-0042 Phase 2): a µm
+// document keeps sub-micron features out of the primitive-construction underflow floor,
+// a km document avoids needlessly tight tolerances. The name must be a registered length
+// unit.
+func (m UnitsOfMeasure) CenteredOnLength(name string) (UnitsOfMeasure, error) {
+	def, ok := lookupUnit(name)
+	if !ok || def.category != Length {
+		return m, fmt.Errorf("param: %q is not a registered length unit", name)
+	}
+	return m.WithWorkingScale(def.factor)
+}
+
+// wsFactor is workingScale raised to the unit's length exponent (Length¹, Area², Volume³,
+// 0 otherwise) — the multiplier converting a working-unit Value to centimetres. An explicit
+// switch keeps the common exponents exact (no Pow round-off).
+func (m UnitsOfMeasure) wsFactor(u Unit) float64 {
+	ws := m.effectiveWorkingScale()
+	switch dimensions[u].l {
+	case 0:
+		return 1
+	case 1:
+		return ws
+	case 2:
+		return ws * ws
+	case 3:
+		return ws * ws * ws
+	default:
+		return stdmath.Pow(ws, float64(dimensions[u].l))
+	}
+}
+
 // Parse converts a user string ("25 mm", "30 deg", "5") to a database-unit
 // [Quantity]. A bare number is interpreted in the preferred unit of defaultCat;
 // an explicit unit suffix overrides both the factor and the category. This is
@@ -169,13 +235,13 @@ func (m UnitsOfMeasure) Parse(s string, defaultCat Unit) (Quantity, error) {
 	}
 	if unitName == "" {
 		factor, _ := m.preferredFactor(defaultCat)
-		return Quantity{value * factor, defaultCat}, nil
+		return Quantity{value * factor / m.wsFactor(defaultCat), defaultCat}, nil
 	}
 	def, ok := lookupUnit(unitName)
 	if !ok {
 		return Quantity{}, fmt.Errorf("param: unknown unit %q in %q", unitName, s)
 	}
-	return Quantity{value * def.factor, def.category}, nil
+	return Quantity{value * def.factor / m.wsFactor(def.category), def.category}, nil
 }
 
 // Format renders a database-unit quantity in its category's preferred unit, with
@@ -193,7 +259,7 @@ func (m UnitsOfMeasure) Format(q Quantity) string {
 // the shortest exact decimal so parse/format round-trips without loss.
 func (m UnitsOfMeasure) FormatValue(q Quantity) string {
 	factor, _ := m.preferredFactor(q.Unit)
-	return strconv.FormatFloat(q.Value/factor, 'g', -1, 64)
+	return strconv.FormatFloat(q.Value*m.wsFactor(q.Unit)/factor, 'g', -1, 64)
 }
 
 // unitName returns the preferred display-unit name for a category.
@@ -209,14 +275,14 @@ func (m UnitsOfMeasure) PreferredName(category Unit) string { return m.unitName(
 // the value a UI edits (vs the database-unit value stored in the model).
 func (m UnitsOfMeasure) ToPreferred(q Quantity) float64 {
 	factor, _ := m.preferredFactor(q.Unit)
-	return q.Value / factor
+	return q.Value * m.wsFactor(q.Unit) / factor
 }
 
 // FromPreferred builds a database-unit [Quantity] from a value given in category's
 // preferred unit — the inverse of [UnitsOfMeasure.ToPreferred].
 func (m UnitsOfMeasure) FromPreferred(value float64, category Unit) Quantity {
 	factor, _ := m.preferredFactor(category)
-	return Quantity{value * factor, category}
+	return Quantity{value * factor / m.wsFactor(category), category}
 }
 
 // splitNumberUnit separates the leading numeric literal from a trailing unit

--- a/model/param/working_scale_test.go
+++ b/model/param/working_scale_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package param
+
+import (
+	"math"
+	"testing"
+)
+
+// TestWorkingScaleDefaultIsCentimetre is the back-compatibility guarantee: the default
+// working scale is 1 (the centimetre), so every parse/format/convert is byte-identical to
+// the pre-Phase-2 behaviour — a stored length Value is still centimetres.
+func TestWorkingScaleDefaultIsCentimetre(t *testing.T) {
+	m := DefaultUnitsOfMeasure()
+	if m.WorkingScale() != 1 {
+		t.Fatalf("default WorkingScale = %v, want 1", m.WorkingScale())
+	}
+	q, err := m.Parse("5", Length) // preferred mm
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !approxRelWS(q.Value, 0.5) { // 5 mm = 0.5 cm, stored in cm
+		t.Errorf("Parse(5 mm) Value = %v, want 0.5 cm", q.Value)
+	}
+}
+
+// TestCenteredOnLengthStoresWorkingUnit is the heart of ADR-0042 Phase 2: a length authored
+// in the document's unit is stored as an O(1) working coordinate, and round-trips back.
+func TestCenteredOnLengthStoresWorkingUnit(t *testing.T) {
+	for _, tc := range []struct {
+		unit    string
+		cmPer   float64
+		entered float64 // value entered AND its preferred display unit = tc.unit
+	}{
+		{"µm", 1e-4, 5}, {"mm", 0.1, 5}, {"km", 1e5, 5}, {"pm", 1e-10, 5},
+	} {
+		m, err := DefaultUnitsOfMeasure().CenteredOnLength(tc.unit)
+		if err != nil {
+			t.Fatalf("CenteredOnLength(%q): %v", tc.unit, err)
+		}
+		if err := m.SetPreferred(Length, tc.unit); err != nil {
+			t.Fatal(err)
+		}
+		q, err := m.Parse("5", Length)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Stored as the working unit ⇒ O(1), equal to the entered number.
+		if !approxRelWS(q.Value, tc.entered) {
+			t.Errorf("%s: stored Value = %v, want %v (working = display unit)", tc.unit, q.Value, tc.entered)
+		}
+		// realCm matches the unit's centimetre size × 5.
+		if got := q.Value * m.WorkingScale(); !approxRelWS(got, 5*tc.cmPer) {
+			t.Errorf("%s: realCm = %v, want %v", tc.unit, got, 5*tc.cmPer)
+		}
+		// Round-trips through Format.
+		if got := m.FormatValue(q); got != "5" {
+			t.Errorf("%s: FormatValue = %q, want \"5\"", tc.unit, got)
+		}
+	}
+}
+
+// TestWorkingScaleCrossUnitDisplay checks a working value displays correctly in a DIFFERENT
+// unit than the working one: 5 working µm shown in mm is 5e-3 mm.
+func TestWorkingScaleCrossUnitDisplay(t *testing.T) {
+	m, _ := DefaultUnitsOfMeasure().CenteredOnLength("µm") // working = µm
+	if err := m.SetPreferred(Length, "mm"); err != nil {   // but DISPLAY in mm
+		t.Fatal(err)
+	}
+	q := Quantity{Value: 5, Unit: Length} // 5 working µm
+	if got := m.ToPreferred(q); !approxRelWS(got, 5e-3) {
+		t.Errorf("5 µm in mm = %v, want 5e-3", got)
+	}
+}
+
+// TestWorkingScaleAreaVolumeExponent verifies the working scale is raised to the unit's
+// length exponent: an area uses workingScale², a volume workingScale³.
+func TestWorkingScaleAreaVolumeExponent(t *testing.T) {
+	m, _ := DefaultUnitsOfMeasure().CenteredOnLength("µm") // ws = 1e-4
+	// 1 mm² = (1000 µm)² = 1e6 working µm².
+	area, err := m.Parse("1 mm^2", Area)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !approxRelWS(area.Value, 1e6) {
+		t.Errorf("1 mm² in working µm² = %v, want 1e6", area.Value)
+	}
+	// 1 mm³ = (1000 µm)³ = 1e9 working µm³.
+	vol, err := m.Parse("1 mm^3", Volume)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !approxRelWS(vol.Value, 1e9) {
+		t.Errorf("1 mm³ in working µm³ = %v, want 1e9", vol.Value)
+	}
+}
+
+// TestToFromPreferredRoundTripScaled round-trips at a non-cm working scale.
+func TestToFromPreferredRoundTripScaled(t *testing.T) {
+	m, _ := DefaultUnitsOfMeasure().CenteredOnLength("km")
+	if err := m.SetPreferred(Length, "m"); err != nil {
+		t.Fatal(err)
+	}
+	q := m.FromPreferred(2500, Length) // 2500 m
+	if got := m.ToPreferred(q); !approxRelWS(got, 2500) {
+		t.Errorf("round-trip 2500 m = %v", got)
+	}
+	if !approxRelWS(q.Value*m.WorkingScale(), 250000) { // 2500 m = 250000 cm
+		t.Errorf("2500 m realCm = %v, want 250000", q.Value*m.WorkingScale())
+	}
+}
+
+// TestWorkingScaleGuardsAndRejects covers the validation: a zero-value units object reads as
+// the cm default, and invalid scale/unit are rejected naming the offending value.
+func TestWorkingScaleGuardsAndRejects(t *testing.T) {
+	var zero UnitsOfMeasure // workingScale field == 0
+	if zero.WorkingScale() != 1 {
+		t.Errorf("zero-value WorkingScale = %v, want 1 (guarded)", zero.WorkingScale())
+	}
+	if _, err := DefaultUnitsOfMeasure().WithWorkingScale(0); err == nil {
+		t.Error("WithWorkingScale(0) should be rejected")
+	}
+	if _, err := DefaultUnitsOfMeasure().WithWorkingScale(-1); err == nil {
+		t.Error("WithWorkingScale(-1) should be rejected")
+	}
+	if _, err := DefaultUnitsOfMeasure().CenteredOnLength("deg"); err == nil {
+		t.Error("CenteredOnLength(deg) should be rejected (not a length unit)")
+	}
+}
+
+// TestCloneKeepsWorkingScale ensures the working scale survives a Clone.
+func TestCloneKeepsWorkingScale(t *testing.T) {
+	m, _ := DefaultUnitsOfMeasure().CenteredOnLength("µm")
+	if got := m.Clone().WorkingScale(); got != 1e-4 {
+		t.Errorf("cloned WorkingScale = %v, want 1e-4", got)
+	}
+}
+
+func approxRelWS(got, want float64) bool {
+	if want == 0 {
+		return math.Abs(got) < 1e-12
+	}
+	return math.Abs(got-want)/math.Abs(want) < 1e-9
+}


### PR DESCRIPTION
## What

The storage foundation for **ADR-0042 Phase 2**: a per-document **working scale** in `param.UnitsOfMeasure` — the centimetre size of one stored (working/database) length unit.

A `Quantity`'s `Value` is now defined as **working units** rather than always centimetres: `realCm = Value × workingScale^L` where `L` is the unit's length exponent (1 length / 2 area / 3 volume). New API:

- `WorkingScale()` — the cm size of one working unit (default 1.0).
- `WithWorkingScale(cmPerUnit)` — set it explicitly (rejects ≤ 0).
- `CenteredOnLength(name)` — set the working unit to a named length unit so coordinates are O(1).

## Why

Phase 1 (relative tolerances) made the kernel scale-invariant from ~1 µm to ~1 km, but **could not** reach nm/pm: below ~1 µm the floor is the fundamental vector-normalisation epsilon in **primitive construction** (a cross-product of pm-length edges underflows). That epsilon has no model context to scale by — the only fix is keeping coordinates O(1), i.e. storing in the document's working unit. This PR is that storage layer.

## Safety — zero behaviour change

Default working scale is **1.0 (working unit = centimetre)**, so every existing document and every stored value is byte-identical to before; all parse/format/`ToPreferred`/`FromPreferred` paths reduce to the previous formulas (a zero-value `UnitsOfMeasure` is guarded to read as 1.0 too). Confirmed: full `go test ./...` green, existing param tests unchanged.

## Scope — foundation only (Part of #1245)

No production document is flipped onto a non-cm working scale yet, **on purpose**: doing so safely requires the consumers that this API unblocks —

- **#1246** persist values in working scale + record the unit in `.obk` (without this, a µm part would reload as cm),
- **#1248** the exchange ↔ STEP mm boundary (`DBUnitMM`) must read the working scale,
- plus the display-side touchpoints (mass-property units, tessellation chord tolerance).

So this lands the tested API and the dependent issues build real documents on it. #1245 stays open until a document is actually centred on its unit (gated on #1246/#1248).

## Tests

`model/param/working_scale_test.go` — default-is-cm back-compat, centring on µm/mm/km/pm (O(1) storage + round-trip), cross-unit display, area/volume exponent (ws²/ws³), scaled `To`/`FromPreferred` round-trip, guards/rejections, Clone preservation. `golangci-lint` clean; SPDX present.

Part of #1245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)