### PR TITLE
M35 Phase 2: persist working scale + unit round-trip (.obk) (#1246)

### DIFF
--- a/model/compdef/serialize.go
+++ b/model/compdef/serialize.go
@@ -320,6 +320,7 @@ const (
 	keyAnglePrecision  = "anglePrecision"
 	keyLengthFormat    = "lengthFormat"
 	keyAngleFormat     = "angleFormat"
+	keyWorkingScale    = "workingScale" // ADR-0042 Phase 2: cm size of one stored working length unit
 )
 
 // unitsRecipeFor captures the preferred display-unit name for each category plus
@@ -334,6 +335,13 @@ func unitsRecipeFor(u param.UnitsOfMeasure) map[string]string {
 	out[keyAnglePrecision] = strconv.Itoa(u.AnglePrecision())
 	out[keyLengthFormat] = u.LengthFormat().String()
 	out[keyAngleFormat] = angleFormatName(u.AngleFormat())
+	// Persist the working scale only when it is not the centimetre default (ADR-0042
+	// Phase 2). Omitting it keeps every existing cm document's .obk byte-identical and
+	// makes the migration automatic: a recipe with no key restores the cm default — which
+	// is exactly what a pre-Phase-2 (cm-stored) document is.
+	if ws := u.WorkingScale(); ws != 1 {
+		out[keyWorkingScale] = strconv.FormatFloat(ws, 'g', -1, 64)
+	}
 	return out
 }
 
@@ -388,6 +396,12 @@ func applyReservedUnitKey(u *param.UnitsOfMeasure, name, val string) (bool, erro
 		}
 		u.SetAngleFormat(f)
 		return true, nil
+	case keyWorkingScale:
+		ws, err := strconv.ParseFloat(val, 64)
+		if err != nil {
+			return true, fmt.Errorf("compdef: working scale %q is not a number: %w", val, err)
+		}
+		return true, u.SetWorkingScale(ws)
 	}
 	return false, nil
 }

--- a/model/compdef/units_test.go
+++ b/model/compdef/units_test.go
@@ -78,3 +78,45 @@ func TestApplyUnitsToReservedKeys(t *testing.T) {
 		}
 	}
 }
+
+// TestWorkingScaleRecipeRoundTrip is the ADR-0042 Phase 2 .obk round-trip (#1246): a
+// document centred on a non-cm working unit persists and restores its working scale, so a
+// reloaded µm part keeps its O(1) coordinates instead of being misread as cm.
+func TestWorkingScaleRecipeRoundTrip(t *testing.T) {
+	src, err := param.DefaultUnitsOfMeasure().CenteredOnLength("µm") // working scale 1e-4
+	if err != nil {
+		t.Fatal(err)
+	}
+	recipe := unitsRecipeFor(src)
+	if recipe[keyWorkingScale] == "" {
+		t.Fatalf("recipe omits %s for a non-cm document: %v", keyWorkingScale, recipe)
+	}
+	restored := param.DefaultUnitsOfMeasure().Clone()
+	if err := applyUnitsTo(&restored, recipe); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if restored.WorkingScale() != 1e-4 {
+		t.Errorf("restored WorkingScale = %v, want 1e-4", restored.WorkingScale())
+	}
+}
+
+// TestWorkingScaleDefaultOmittedAndMigrates covers two halves of one guarantee: a cm document
+// omits the key (so existing .obk stay byte-identical), and a legacy recipe lacking the key
+// restores the cm default (the automatic migration for pre-Phase-2 documents).
+func TestWorkingScaleDefaultOmittedAndMigrates(t *testing.T) {
+	if _, present := unitsRecipeFor(param.DefaultUnitsOfMeasure())[keyWorkingScale]; present {
+		t.Error("cm document should omit the workingScale key")
+	}
+	legacy := param.DefaultUnitsOfMeasure().Clone()
+	if err := applyUnitsTo(&legacy, map[string]string{"length": "mm"}); err != nil {
+		t.Fatalf("legacy restore: %v", err)
+	}
+	if legacy.WorkingScale() != 1 {
+		t.Errorf("legacy (no key) WorkingScale = %v, want cm default 1", legacy.WorkingScale())
+	}
+	// A corrupt value is rejected, not silently dropped.
+	bad := param.DefaultUnitsOfMeasure().Clone()
+	if err := applyUnitsTo(&bad, map[string]string{keyWorkingScale: "0"}); err == nil {
+		t.Error("workingScale 0 should be rejected")
+	}
+}

--- a/model/compdef/units_test.go
+++ b/model/compdef/units_test.go
@@ -114,9 +114,12 @@ func TestWorkingScaleDefaultOmittedAndMigrates(t *testing.T) {
 	if legacy.WorkingScale() != 1 {
 		t.Errorf("legacy (no key) WorkingScale = %v, want cm default 1", legacy.WorkingScale())
 	}
-	// A corrupt value is rejected, not silently dropped.
-	bad := param.DefaultUnitsOfMeasure().Clone()
-	if err := applyUnitsTo(&bad, map[string]string{keyWorkingScale: "0"}); err == nil {
-		t.Error("workingScale 0 should be rejected")
+	// A corrupt value is rejected, not silently dropped — both a non-positive number and a
+	// non-numeric string.
+	for _, badVal := range []string{"0", "-1", "abc"} {
+		bad := param.DefaultUnitsOfMeasure().Clone()
+		if err := applyUnitsTo(&bad, map[string]string{keyWorkingScale: badVal}); err == nil {
+			t.Errorf("workingScale %q should be rejected", badVal)
+		}
 	}
 }

--- a/model/param/units_of_measure.go
+++ b/model/param/units_of_measure.go
@@ -191,6 +191,17 @@ func (m UnitsOfMeasure) WithWorkingScale(cmPerUnit float64) (UnitsOfMeasure, err
 	return out, nil
 }
 
+// SetWorkingScale sets the working unit to cmPerUnit centimetres in place (the mutating
+// counterpart of [UnitsOfMeasure.WithWorkingScale]) — used by the .obk restore path. A
+// non-positive value is rejected.
+func (m *UnitsOfMeasure) SetWorkingScale(cmPerUnit float64) error {
+	if cmPerUnit <= 0 {
+		return fmt.Errorf("param: working scale %g is not positive (cm per working unit)", cmPerUnit)
+	}
+	m.workingScale = cmPerUnit
+	return nil
+}
+
 // CenteredOnLength returns a copy whose working unit equals the named length unit, so a
 // length authored in that unit is stored as an O(1) coordinate (ADR-0042 Phase 2): a µm
 // document keeps sub-micron features out of the primitive-construction underflow floor,

--- a/model/param/working_scale_test.go
+++ b/model/param/working_scale_test.go
@@ -128,6 +128,24 @@ func TestWorkingScaleGuardsAndRejects(t *testing.T) {
 	}
 }
 
+// TestSetWorkingScale covers the in-place mutating setter (the .obk restore path): it sets a
+// positive scale and rejects a non-positive one naming the value.
+func TestSetWorkingScale(t *testing.T) {
+	m := DefaultUnitsOfMeasure()
+	if err := m.SetWorkingScale(1e-4); err != nil {
+		t.Fatalf("SetWorkingScale(1e-4): %v", err)
+	}
+	if m.WorkingScale() != 1e-4 {
+		t.Errorf("WorkingScale after set = %v, want 1e-4", m.WorkingScale())
+	}
+	if err := m.SetWorkingScale(0); err == nil {
+		t.Error("SetWorkingScale(0) should be rejected")
+	}
+	if err := m.SetWorkingScale(-2); err == nil {
+		t.Error("SetWorkingScale(-2) should be rejected")
+	}
+}
+
 // TestCloneKeepsWorkingScale ensures the working scale survives a Clone.
 func TestCloneKeepsWorkingScale(t *testing.T) {
 	m, _ := DefaultUnitsOfMeasure().CenteredOnLength("µm")


### PR DESCRIPTION
## What

Round-trips the document **working scale** through the `.obk` units recipe (ADR-0042 Phase 2). A `workingScale` reserved key is added to the units map; a document centred on a non-cm working unit now reloads with its O(1) coordinates intact instead of being misread as centimetres.

## Safety + migration

The key is written **only when it differs from the cm default**, so:
- every existing cm document's `.obk` stays **byte-identical** (no churn),
- the migration is **automatic** — a recipe with no key restores the cm default, which is exactly what a pre-Phase-2 (cm-stored) document is.

A corrupt/non-positive value is rejected, not silently dropped. Adds `param.SetWorkingScale` (the mutating restore counterpart of `WithWorkingScale`).

## Tests

`model/compdef/units_test.go` — non-cm recipe round-trip (working scale preserved), cm document omits the key, legacy recipe without the key migrates to cm, corrupt value rejected. Full `go test ./model/...` green; lint clean; SPDX present.

Closes #1246. Builds on the #1245 storage foundation (#1253).

🤖 Generated with [Claude Code](https://claude.com/claude-code)