### PR TITLE
M35 Phase 2: scale exchange import/export by the document working scale (#1248)

### DIFF
--- a/model/compdef/part.go
+++ b/model/compdef/part.go
@@ -98,10 +98,11 @@ func NewPartComponentDefinition() *PartComponentDefinition {
 		props:       attr.NewPropertySets(),
 		pointClouds: pointcloud.NewPointClouds(),
 	}
-	d.features.SetResourceStore(d)       // re-derive imported bodies from the resource table on open
-	d.features.SetFontResolver(d)        // resolve text/emboss fonts from embedded/app-provided resources
-	d.sketches.ShareParameters(params)   // dimension expressions resolve against user params (live + restore)
-	d.sketches3D.ShareParameters(params) // same for 3D sketches
+	d.features.SetResourceStore(d)                                                       // re-derive imported bodies from the resource table on open
+	d.features.SetFontResolver(d)                                                        // resolve text/emboss fonts from embedded/app-provided resources
+	d.features.SetWorkingScaleResolver(func() float64 { return d.units.WorkingScale() }) // re-import scales into the doc working unit
+	d.sketches.ShareParameters(params)                                                   // dimension expressions resolve against user params (live + restore)
+	d.sketches3D.ShareParameters(params)                                                 // same for 3D sketches
 	return d
 }
 

--- a/model/exchange/dispatch.go
+++ b/model/exchange/dispatch.go
@@ -34,7 +34,7 @@ func Import(part *compdef.PartComponentDefinition, path string, format types.Exc
 	if err != nil {
 		return ImportResult{}, fmt.Errorf("import: read %q: %w", path, err)
 	}
-	bodies, warns, err := feature.ImportBodiesFromData(format, data)
+	bodies, warns, err := feature.ImportBodiesFromData(format, data, workingUnitMM(part))
 	if err != nil {
 		return ImportResult{}, fmt.Errorf("import %q: %w", path, err)
 	}
@@ -93,9 +93,17 @@ func Export(part *compdef.PartComponentDefinition, path string, format types.Exc
 // sees (Oblikovati/Oblikovati#146).
 func exportUnits(part *compdef.PartComponentDefinition) exchange.TranslationOptions {
 	return exchange.TranslationOptions{
-		TargetUnitMM: exchange.DBUnitMM,
+		TargetUnitMM: workingUnitMM(part),
 		FileUnit:     part.Units().PreferredName(param.Length),
 	}
+}
+
+// workingUnitMM is the millimetre size of one of the part's stored (working) length units —
+// the database-unit size the translators scale against (ADR-0042 Phase 2). It is the working
+// scale (centimetres per working unit) times the centimetre's millimetre size, so a cm
+// document (working scale 1) yields the historical 10 mm and is unchanged.
+func workingUnitMM(part *compdef.PartComponentDefinition) float64 {
+	return part.Units().WorkingScale() * exchange.DBUnitMM
 }
 
 // FormatFromPath infers the exchange format from a file's extension (case-insensitive), so the

--- a/model/exchange/exchange.go
+++ b/model/exchange/exchange.go
@@ -62,7 +62,7 @@ func (MeshExchange) ImportInto(part *compdef.PartComponentDefinition, path strin
 		return ImportResult{}, fmt.Errorf("import: read %q: %w", path, err)
 	}
 	feat := fmt.Sprintf("import:%s#0", format)
-	body, warns, err := meshio.ImportBody(format, data, feat, 0, exchange.TranslationOptions{TargetUnitMM: exchange.DBUnitMM})
+	body, warns, err := meshio.ImportBody(format, data, feat, 0, exchange.TranslationOptions{TargetUnitMM: workingUnitMM(part)})
 	if err != nil {
 		return ImportResult{}, fmt.Errorf("import %q: %w", path, err)
 	}

--- a/model/exchange/working_scale_test.go
+++ b/model/exchange/working_scale_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package exchange
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/exchange"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/param"
+)
+
+// TestWorkingUnitMMTracksDocumentScale is the ADR-0042 Phase 2 exchange boundary (#1248): the
+// translators' database-unit size in millimetres follows the document's working scale, so a
+// document centred on a non-cm working unit exports/imports at the correct scale. A cm document
+// (working scale 1) yields the historical 10 mm — unchanged.
+func TestWorkingUnitMMTracksDocumentScale(t *testing.T) {
+	part := compdef.NewPartComponentDefinition()
+
+	if got := workingUnitMM(part); got != exchange.DBUnitMM {
+		t.Errorf("cm document workingUnitMM = %v, want %v (10 mm)", got, exchange.DBUnitMM)
+	}
+	if opts := exportUnits(part); opts.TargetUnitMM != exchange.DBUnitMM {
+		t.Errorf("cm document export TargetUnitMM = %v, want %v", opts.TargetUnitMM, exchange.DBUnitMM)
+	}
+
+	// Centre the document on micrometres: 1 working unit = 1 µm = 1e-4 cm ⇒ 1e-3 mm.
+	um, err := part.Units().CenteredOnLength("µm")
+	if err != nil {
+		t.Fatal(err)
+	}
+	part.SetUnits(um)
+	if got, want := workingUnitMM(part), 1e-4*exchange.DBUnitMM; got != want {
+		t.Errorf("µm document workingUnitMM = %v, want %v (1e-3 mm)", got, want)
+	}
+	if opts := exportUnits(part); opts.TargetUnitMM != 1e-4*exchange.DBUnitMM {
+		t.Errorf("µm document export TargetUnitMM = %v, want %v", opts.TargetUnitMM, 1e-4*exchange.DBUnitMM)
+	}
+	// The export still declares the document's preferred display unit as the file unit.
+	if u := exportUnits(part).FileUnit; u != part.Units().PreferredName(param.Length) {
+		t.Errorf("export FileUnit = %q, want the document preferred unit %q", u, part.Units().PreferredName(param.Length))
+	}
+}

--- a/model/feature/engine.go
+++ b/model/feature/engine.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"oblikovati.org/kernel/exchange"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/model/health"
@@ -24,14 +25,15 @@ const eopAll = -1
 // the clean prefix, isolates failures as feature health, and supports
 // reorder/rename/suppression and the end-of-part marker (ADR-0010).
 type PartFeatures struct {
-	items     []*PartFeature
-	byID      map[ID]*PartFeature
-	params    *param.Parameters
-	keys      *identity.KeyManager
-	eop       int
-	result    []*topo.Body
-	resources ResourceStore
-	fonts     text.FontResolver
+	items        []*PartFeature
+	byID         map[ID]*PartFeature
+	params       *param.Parameters
+	keys         *identity.KeyManager
+	eop          int
+	result       []*topo.Body
+	resources    ResourceStore
+	fonts        text.FontResolver
+	workingScale func() float64 // ADR-0042 Phase 2: live working scale (cm per working unit) for re-import
 }
 
 // ResourceStore reads embedded imported-file bytes by their document resource UUID
@@ -45,6 +47,22 @@ type ResourceStore interface {
 // read imported files by UUID. Set by the owning content after construction (the engine is
 // recreated on a recipe reset, so this must be re-wired each time).
 func (fs *PartFeatures) SetResourceStore(rs ResourceStore) { fs.resources = rs }
+
+// SetWorkingScaleResolver wires a getter for the live working scale (centimetres per working
+// length unit), so re-importing an embedded foreign file on reopen scales it into the
+// document's working coordinates (ADR-0042 Phase 2). Like the resource store it is re-wired
+// after a recipe reset. When unset, re-import falls back to the centimetre default.
+func (fs *PartFeatures) SetWorkingScaleResolver(fn func() float64) { fs.workingScale = fn }
+
+// workingTargetMM resolves the working-unit millimetre size for a re-import (the working scale
+// in centimetres × the centimetre's millimetre size), or 0 when no resolver is wired
+// (ImportBodiesFromData then applies the centimetre default).
+func (fs *PartFeatures) workingTargetMM() float64 {
+	if fs.workingScale == nil {
+		return 0
+	}
+	return fs.workingScale() * exchange.DBUnitMM
+}
 
 // SetFontResolver wires the document's font resolver (resource-aware) into the engine so a
 // text/emboss feature resolves its font from the document's embedded/app-provided faces. Like

--- a/model/feature/serialize_import.go
+++ b/model/feature/serialize_import.go
@@ -13,28 +13,35 @@ import (
 	"oblikovati.org/kernel/topo"
 )
 
-// ImportBodies reads path and translates it via [ImportBodiesFromData]. The interactive
-// importer uses it to read a file once before embedding its bytes as a document resource.
-func ImportBodies(format types.ExchangeFormat, path string) ([]*topo.Body, []string, error) {
+// ImportBodies reads path and translates it via [ImportBodiesFromData], scaling the file's
+// declared unit into the document's working unit (targetUnitMM = mm per working unit; 0 ⇒ the
+// centimetre default). The interactive importer uses it to read a file once before embedding
+// its bytes as a document resource.
+func ImportBodies(format types.ExchangeFormat, path string, targetUnitMM float64) ([]*topo.Body, []string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, nil, fmt.Errorf("import: read %q: %w", path, err)
 	}
-	return ImportBodiesFromData(format, data)
+	return ImportBodiesFromData(format, data, targetUnitMM)
 }
 
 // ImportBodiesFromData translates raw file bytes into kernel bodies, routing by format: a mesh
 // format (STL/OBJ/3MF) yields one welded body; STEP yields every B-rep solid in the file. It is
 // the shared reader for both an interactive import and a recipe re-import-from-resource — the
 // bytes come from the file the first time and from the embedded document resource on reopen.
-func ImportBodiesFromData(format types.ExchangeFormat, data []byte) ([]*topo.Body, []string, error) {
+// targetUnitMM is the millimetre size of one working (database) length unit; 0 selects the
+// centimetre default so the file's declared unit scales into the document's working coordinates
+// (ADR-0042 Phase 2).
+func ImportBodiesFromData(format types.ExchangeFormat, data []byte, targetUnitMM float64) ([]*topo.Body, []string, error) {
+	if targetUnitMM <= 0 {
+		targetUnitMM = exchange.DBUnitMM
+	}
 	switch {
 	case format == types.FormatSTEP:
-		// The kernel works in centimetres; the reader scales the file's declared unit into it.
-		return step.Reader{}.ImportSolids(data, exchange.TranslationOptions{TargetUnitMM: exchange.DBUnitMM})
+		return step.Reader{}.ImportSolids(data, exchange.TranslationOptions{TargetUnitMM: targetUnitMM})
 	case format.IsMesh():
 		body, warns, err := meshio.ImportBody(format, data, fmt.Sprintf("import:%s#0", format), 0,
-			exchange.TranslationOptions{TargetUnitMM: exchange.DBUnitMM})
+			exchange.TranslationOptions{TargetUnitMM: targetUnitMM})
 		if err != nil {
 			return nil, nil, err
 		}
@@ -74,7 +81,7 @@ func restoreImportedBody(fs *PartFeatures, d *ImportData) (*PartFeature, error) 
 	if !ok {
 		return nil, fmt.Errorf("imported-body re-import: resource %q not present in the document", d.Resource)
 	}
-	bodies, _, err := ImportBodiesFromData(types.ExchangeFormat(d.Format), data)
+	bodies, _, err := ImportBodiesFromData(types.ExchangeFormat(d.Format), data, fs.workingTargetMM())
 	if err != nil {
 		return nil, fmt.Errorf("imported-body re-import (resource %q): %w", d.Resource, err)
 	}

--- a/model/feature/working_scale_import_test.go
+++ b/model/feature/working_scale_import_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/exchange"
+	"oblikovati.org/kernel/exchange/meshio"
+	"oblikovati.org/kernel/exchange/step"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/identity"
+	"oblikovati.org/model/param"
+)
+
+// cubeSTLBytes builds a side-2 cube as binary STL — file bytes for the import readers.
+func cubeSTLBytes(t *testing.T) []byte {
+	t.Helper()
+	body, _, err := meshio.SolidOrSurface(unitCubeSoup(2), "fixture#0", meshio.DefaultWeldTolerance)
+	if err != nil {
+		t.Fatalf("build cube: %v", err)
+	}
+	return meshio.EncodeBinarySTL(body, ops.DefaultQuality())
+}
+
+// TestImportBodiesFromDataScalesByTargetUnit verifies the ADR-0042 Phase 2 import boundary
+// (#1248): a smaller working-unit millimetre size yields proportionally larger working
+// coordinates, so the same file imports into the document's working scale.
+func TestImportBodiesFromDataScalesByTargetUnit(t *testing.T) {
+	data := cubeSTLBytes(t)
+
+	coarse, _, err := ImportBodiesFromData(types.FormatSTL, data, 10) // 10 mm per working unit (cm)
+	if err != nil {
+		t.Fatalf("import at 10mm: %v", err)
+	}
+	fine, _, err := ImportBodiesFromData(types.FormatSTL, data, 5) // 5 mm per working unit
+	if err != nil {
+		t.Fatalf("import at 5mm: %v", err)
+	}
+	// Halving the working-unit size doubles the working coordinates.
+	cd := float64(coarse[0].RangeBox().Diagonal().Length())
+	fd := float64(fine[0].RangeBox().Diagonal().Length())
+	if cd <= 0 || fd/cd < 1.9 || fd/cd > 2.1 {
+		t.Errorf("diagonal ratio fine/coarse = %v, want ~2", fd/cd)
+	}
+
+	// targetUnitMM 0 selects the centimetre default (== importing at DBUnitMM).
+	def, _, err := ImportBodiesFromData(types.FormatSTL, data, 0)
+	if err != nil {
+		t.Fatalf("import at default: %v", err)
+	}
+	dd := float64(def[0].RangeBox().Diagonal().Length())
+	if dd/cd < 0.99 || dd/cd > 1.01 {
+		t.Errorf("default (0) should equal DBUnitMM (%v): ratio %v", exchange.DBUnitMM, dd/cd)
+	}
+
+	if _, _, err := ImportBodiesFromData("nope", data, 10); err == nil {
+		t.Error("unsupported format should error")
+	}
+
+	// The STEP branch scales the same way (covers the B-rep reader path).
+	cube, _, err := meshio.SolidOrSurface(unitCubeSoup(2), "fixture#0", meshio.DefaultWeldTolerance)
+	if err != nil {
+		t.Fatalf("build cube: %v", err)
+	}
+	stepData, _, err := step.Writer{}.ExportSolids([]*topo.Body{cube}, exchange.TranslationOptions{TargetUnitMM: exchange.DBUnitMM, FileUnit: "mm"})
+	if err != nil {
+		t.Fatalf("export step: %v", err)
+	}
+	if bodies, _, err := ImportBodiesFromData(types.FormatSTEP, stepData, 10); err != nil || len(bodies) == 0 {
+		t.Fatalf("import step = %d bodies, err %v; want ≥1", len(bodies), err)
+	}
+}
+
+// TestImportBodiesReadsFile covers the path-reading wrapper.
+func TestImportBodiesReadsFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cube.stl")
+	if err := os.WriteFile(path, cubeSTLBytes(t), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bodies, _, err := ImportBodies(types.FormatSTL, path, 10)
+	if err != nil || len(bodies) != 1 {
+		t.Fatalf("ImportBodies = %d bodies, err %v; want 1", len(bodies), err)
+	}
+	if _, _, err := ImportBodies(types.FormatSTL, filepath.Join(t.TempDir(), "missing.stl"), 10); err == nil {
+		t.Error("missing file should error")
+	}
+}
+
+// TestWorkingScaleResolverFeedsReimport checks the engine resolver: a re-import reads the live
+// working scale (cm per working unit) and converts it to the millimetre target, falling back to
+// the centimetre default when no resolver is wired.
+func TestWorkingScaleResolverFeedsReimport(t *testing.T) {
+	fs := NewPartFeatures(param.NewParameters(), identity.NewKeyManager())
+	if got := fs.workingTargetMM(); got != 0 {
+		t.Errorf("unwired resolver workingTargetMM = %v, want 0 (default applied downstream)", got)
+	}
+	fs.SetWorkingScaleResolver(func() float64 { return 1e-4 }) // µm working scale
+	if got, want := fs.workingTargetMM(), 1e-4*exchange.DBUnitMM; got != want {
+		t.Errorf("workingTargetMM = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## What

The exchange ↔ file-unit boundary now follows the document **working scale** (ADR-0042 Phase 2) instead of a hardcoded centimetre database unit. The translators' `TargetUnitMM` is set to the working-unit millimetre size (`WorkingScale()` cm × 10 mm/cm), so a document centred on a non-cm working unit imports and exports at the correct scale. A cm document (working scale 1) yields the historical 10 mm — **unchanged**.

## Changes

- `model/exchange` import/export build `TranslationOptions` from a new `workingUnitMM(part)` helper.
- The imported-body **recompute re-import** (`restoreImportedBody`) reads the live working scale via a resolver wired into the feature engine (`SetWorkingScaleResolver`, alongside the existing resource/font injections), so a reopened document re-derives its embedded foreign bodies into the working unit.
- `feature.ImportBodies` / `ImportBodiesFromData` take an explicit `targetUnitMM` (0 ⇒ centimetre default).

## Safety

Default working scale 1 ⇒ every value resolves to the historical `DBUnitMM` (10 mm). Full `go test ./...` green; lint clean.

## Tests

`model/exchange/working_scale_test.go` — `workingUnitMM`/`exportUnits` track the document scale (cm → 10 mm, µm → 1e-3 mm) and still declare the preferred display unit as the file unit.

Closes #1248. Builds on #1245 (#1253).

🤖 Generated with [Claude Code](https://claude.com/claude-code)