### PR TITLE
Drill holes at an explicit center, not only the face centroid

### DIFF
--- a/model/feature/geom_face_ref_test.go
+++ b/model/feature/geom_face_ref_test.go
@@ -7,6 +7,7 @@ import (
 
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
 )
 
 // TestGeometricFaceShellBindsAndHollows proves the face path (M8/ADR-0040): a shell whose
@@ -87,6 +88,38 @@ func TestGeometricFaceHoleRecipeRoundTrips(t *testing.T) {
 	}
 	if hf.def.GeomFace.Centroid.DistanceTo(ref.Centroid) > 1e-9 {
 		t.Errorf("restored centroid %v != original %v", hf.def.GeomFace.Centroid, ref.Centroid)
+	}
+}
+
+// TestHoleExplicitCenterRoundTrips checks an externally-authored hole's explicit drill point
+// survives serialize → restore (nil center stays nil).
+func TestHoleExplicitCenterRoundTrips(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	ref := topo.DescribeFace(geomRefBox().Faces()[0])
+	center := math.P3(0.2, 0.3, 0.5)
+	pf := NewHoleFeatures(fs).addHole(&HoleDefinition{
+		GeomFace: &ref, Center: &center, Diameter: constFloat(0.5), Depth: constFloat(1), Type: DrilledHole,
+	})
+
+	fd, err := serializeFeature(pf, nil, map[ID]int{})
+	if err != nil {
+		t.Fatalf("serializeFeature: %v", err)
+	}
+	if fd.Hole == nil || len(fd.Hole.Center) != 3 {
+		t.Fatalf("recipe did not carry the hole's explicit center: %+v", fd.Hole)
+	}
+
+	dst := NewPartFeatures(nil, nil)
+	rpf, err := buildFeature(dst, fd, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("buildFeature: %v", err)
+	}
+	got := rpf.feature.(*HoleFeature).def.Center
+	if got == nil {
+		t.Fatal("restored hole lost its explicit center")
+	}
+	if got.DistanceTo(center) > 1e-9 {
+		t.Errorf("restored center %v != original %v", *got, center)
 	}
 }
 

--- a/model/feature/hole_boss.go
+++ b/model/feature/hole_boss.go
@@ -13,14 +13,15 @@ import (
 )
 
 // Hole and boss features place parametric cylindrical cuts/bosses on a picked placement
-// face (held by reference key, re-resolved each recompute). A hole drills at the face
-// centroid along the inward normal with an EXACT cylinder wall (K1b): a Through All hole on a
+// face (held by reference key, re-resolved each recompute). A hole drills at an explicit
+// Center (externally-authored holes) or the face centroid, along the inward normal with an
+// EXACT cylinder wall (K1b): a Through All hole on a
 // planar slab via brep.CutCylindricalHole, a blind hole via brep.CutBlindCylindricalHole
 // (flat bottom, or a conical drill point when PointAngle is set). A counterbore adds a flat
 // recess + shoulder; a countersink a true cone recess (exact-only). Unsupported drilled/
 // counterbore shapes fall back to the faceted boolean. A boss is the join-side mirror of the
 // drilled hole: the same tool cylinder grown OUT of the face and unioned (#327). A lost
-// placement face → Sick. Point placement (vs. the face centroid) is a follow-up.
+// placement face → Sick.
 
 // HoleTapInfo carries thread data for a tapped hole, consumed by hole tables (M14).
 type HoleTapInfo struct {
@@ -42,15 +43,18 @@ const (
 type HoleDefinition struct {
 	PlacementFaceKey []byte
 	GeomFace         *topo.GeometricFaceRef // externally-authored placement face by geometric descriptor (ADR-0040)
-	Diameter         func() float64
-	Depth            func() float64
-	ThroughAll       bool           // drill all the way through (depth ignored)
-	CounterDiameter  func() float64 // recess/sink diameter (Counterbore + Countersink)
-	CounterDepth     func() float64 // counterbore recess depth (CounterboreHole)
-	CounterAngle     func() float64 // countersink included angle, radians (CountersinkHole)
-	PointAngle       func() float64 // drilled blind-hole point: included angle, radians (0 = flat)
-	Type             HoleType
-	Tap              HoleTapInfo
+	// Center is an explicit drill point in model space (e.g. an exporter reading the host's
+	// real hole position). Nil means drill at the placement face centroid (interactive default).
+	Center          *math.Point3
+	Diameter        func() float64
+	Depth           func() float64
+	ThroughAll      bool           // drill all the way through (depth ignored)
+	CounterDiameter func() float64 // recess/sink diameter (Counterbore + Countersink)
+	CounterDepth    func() float64 // counterbore recess depth (CounterboreHole)
+	CounterAngle    func() float64 // countersink included angle, radians (CountersinkHole)
+	PointAngle      func() float64 // drilled blind-hole point: included angle, radians (0 = flat)
+	Type            HoleType
+	Tap             HoleTapInfo
 }
 
 // HoleFeature drills a hole into the running solid.
@@ -77,8 +81,8 @@ func (h *HoleFeature) Operation() ops.PartFeatureOperation { return ops.Cut }
 // the dominant cut — so a pattern of one reproduces its bores. Implements [ToolFeature].
 func (h *HoleFeature) ToolBody() *topo.Body { return h.tool }
 
-// Recompute resolves the placement face, then drills at its centroid along the inward normal
-// (see drill), subtracting the hole from the running body.
+// Recompute resolves the placement face, then drills at the explicit center (or the face
+// centroid) along the inward normal (see drill), subtracting the hole from the running body.
 func (h *HoleFeature) Recompute(in Input) (Output, error) {
 	body, err := runningBody(in)
 	if err != nil {
@@ -99,13 +103,34 @@ func (h *HoleFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, fmt.Errorf("hole: placement face has no normal")
 	}
-	center := centroidOf(faceVertexPoints(face))
+	center := holeCenter(h.def, face)
 	h.tool = h.buildTool(body, center, into, r, depth)
 	res, err := h.drill(body, center, into, r, depth)
 	if err != nil {
 		return Output{}, err
 	}
 	return Output{Bodies: replaceBody(in.Bodies, body, res)}, nil
+}
+
+// holeCenter is the drill start point: an explicit center (projected onto the placement face's
+// plane so the bore starts exactly at the surface), or the face centroid when none is set.
+func holeCenter(def *HoleDefinition, face *topo.Face) math.Point3 {
+	if def.Center == nil {
+		return centroidOf(faceVertexPoints(face))
+	}
+	return projectOntoFacePlane(*def.Center, face)
+}
+
+// projectOntoFacePlane drops a model-space point onto a planar face's plane along its normal.
+func projectOntoFacePlane(p math.Point3, face *topo.Face) math.Point3 {
+	n, err := math.UnitVector3FromVector(face.Geometry().NormalAt(0, 0))
+	if err != nil {
+		return p
+	}
+	nv := n.AsVector()
+	root := centroidOf(faceVertexPoints(face))
+	d := root.VectorTo(p).Dot(nv)
+	return p.TranslateBy(nv.Scale(-d))
 }
 
 // buildTool returns the clean drill cylinder a pattern replicates: the bore radius along the

--- a/model/feature/hole_boss_test.go
+++ b/model/feature/hole_boss_test.go
@@ -130,6 +130,44 @@ func TestHoleDrillsThroughForReal(t *testing.T) {
 	}
 }
 
+func TestHoleDrillsAtExplicitCenter(t *testing.T) {
+	// An 8×8×2 block. Drill a Ø2 through hole with an EXPLICIT off-centre drill point at
+	// (2,3) instead of the face centroid (4,4): the bore must land there, not at the middle.
+	block := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 8, Y: 0}, {X: 8, Y: 8}, {X: 0, Y: 8}}, sketch.XYPlane(), span{near: 0, far: 2}, 0, "blk")
+	top := block.Faces()[1].ReferenceKey() // z=2 cap, normal +Z
+
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(block)
+	hole := NewHoleFeatures(fs).AddDrilledThrough(top, func() float64 { return 2 })
+	center := math.P3(2, 3, 2)
+	hole.feature.(*HoleFeature).def.Center = &center
+	fs.Recompute()
+	if !hole.Health().OK() {
+		t.Fatalf("explicit-centre hole sick: %+v", hole.Health())
+	}
+
+	res := fs.Result()
+	if r := ops.Validate(res[0]); !r.Valid || !res[0].IsSolid() {
+		t.Fatalf("drilled body not a valid solid: %+v", r)
+	}
+	var bore *geom.Cylinder
+	for _, f := range res[0].Faces() {
+		if c, ok := f.Geometry().(geom.Cylinder); ok {
+			bore = &c
+		}
+	}
+	if bore == nil {
+		t.Fatal("no cylinder face: the through bore was not cut")
+	}
+	if stdmath.Abs(bore.Origin.X-2) > 1e-6 || stdmath.Abs(bore.Origin.Y-3) > 1e-6 {
+		t.Errorf("bore axis at (%g,%g), want the explicit centre (2,3)", bore.Origin.X, bore.Origin.Y)
+	}
+	want := 64 - stdmath.Pi*1*1*2 // block − Ø2 through cylinder
+	if got := ops.BodyGeometryProperties(res[0], ops.DefaultQuality()).Volume; (want-got)/want > 0.03 {
+		t.Errorf("drilled volume = %g, want a hair under %g (64 − Ø2 through hole)", got, want)
+	}
+}
+
 func TestHoleThroughAllProducesCylinderWall(t *testing.T) {
 	// A 4×4×2 block, Ø2 hole through the top face. ThroughAll routes through the curved
 	// boolean → a TRUE cylinder wall (one curved face), not a 32-gon prism.

--- a/model/feature/serialize_pattern.go
+++ b/model/feature/serialize_pattern.go
@@ -163,6 +163,22 @@ func decodePoint3(s []float64) math.Point3 {
 	return math.P3(s[0], s[1], s[2])
 }
 
+// encodePoint3Ptr / decodePoint3Ptr round-trip an optional point: nil <-> empty slice.
+func encodePoint3Ptr(p *math.Point3) []float64 {
+	if p == nil {
+		return nil
+	}
+	return encodePoint3(*p)
+}
+
+func decodePoint3Ptr(s []float64) *math.Point3 {
+	if len(s) < 3 {
+		return nil
+	}
+	p := math.P3(s[0], s[1], s[2])
+	return &p
+}
+
 func decodePoints(s [][]float64) []math.Point3 {
 	out := make([]math.Point3, len(s))
 	for i, p := range s {

--- a/model/feature/serialize_solid.go
+++ b/model/feature/serialize_solid.go
@@ -26,6 +26,9 @@ type HoleData struct {
 	// GeomFace selects the placement face by a GEOMETRIC descriptor (ADR-0040) when the
 	// hole is externally authored (NX exporter) and Face (the lineage key) is empty.
 	GeomFace *GeomFaceRefData `yaml:"geomFace,omitempty"`
+	// Center is the explicit drill point [x,y,z] in model space (externally-authored holes).
+	// Empty means drill at the placement face centroid.
+	Center []float64 `yaml:"center,omitempty,flow"`
 }
 
 // BossData is a boss's recipe: a raised cylinder on a placement face.
@@ -60,6 +63,7 @@ func serializeHole(def *HoleDefinition) (*HoleData, error) {
 		Tapped:          def.Tap.Tapped,
 		Designation:     def.Tap.Designation,
 		GeomFace:        encodeGeomFacePtr(def.GeomFace),
+		Center:          encodePoint3Ptr(def.Center),
 	}, nil
 }
 
@@ -94,6 +98,7 @@ func restoreHole(fs *PartFeatures, h *HoleData) (*PartFeature, error) {
 	def.ThroughAll = h.ThroughAll
 	def.PointAngle = constFloat(h.PointAngle)
 	def.GeomFace = decodeGeomFacePtr(h.GeomFace)
+	def.Center = decodePoint3Ptr(h.Center)
 	return pf, nil
 }
 


### PR DESCRIPTION
## What
`HoleDefinition` gains an optional `Center` (model-space drill point), serialized as `center` in the hole recipe. At recompute the point is projected onto the placement face's plane and used as the bore start; `nil` keeps the existing centroid behavior.

## Why
A hole always drilled at its placement face's **centroid**. Externally-authored holes (the Inventor exporter) therefore couldn't reproduce the host's real hole position, and two holes on the same face collapsed onto each other. This was already flagged in the file header (`"Point placement (vs. the face centroid) is a follow-up"`).

## Tests
- `TestHoleDrillsAtExplicitCenter`: an 8×8×2 block with a Ø2 through hole authored at an off-centre `(2,3)` — the resulting bore cylinder's axis lands at `(2,3)`, not the centroid `(4,4)`, and the volume matches a clean through bore.
- `TestHoleExplicitCenterRoundTrips`: the `center` survives serialize → restore (nil stays nil).
- Full `model/feature` suite green; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)