### PR TITLE
M35 Phase 2: convert component units at the assembly placement boundary (#1247)

### DIFF
--- a/model/compdef/assembly.go
+++ b/model/compdef/assembly.go
@@ -373,6 +373,11 @@ func (a *AssemblyComponentDefinition) OrientedMinimumRangeBox() math.OrientedBox
 // Units returns the document's display units (default metric — mm).
 func (a *AssemblyComponentDefinition) Units() param.UnitsOfMeasure { return a.units }
 
+// WorkingScale is the centimetre size of one of the assembly's stored (working) length units
+// (ADR-0042 Phase 2) — the owner scale the placement walker converts each component into, and
+// the scale a parent assembly converts THIS sub-assembly's frame from (1.0 ⇒ centimetre).
+func (a *AssemblyComponentDefinition) WorkingScale() float64 { return a.units.WorkingScale() }
+
 // SetLengthUnit sets the assembly's preferred length unit (e.g. "mm", "in").
 func (a *AssemblyComponentDefinition) SetLengthUnit(name string) error {
 	return a.units.SetPreferred(param.Length, name)

--- a/model/compdef/assembly_derive.go
+++ b/model/compdef/assembly_derive.go
@@ -24,9 +24,9 @@ var _ feature.AssemblyBodySource = (*AssemblyComponentDefinition)(nil)
 // what shrinkwrap will simplify (M11-F06).
 func (a *AssemblyComponentDefinition) PlacedBodies() []feature.PlacedBody {
 	if a.occurrences.Count() >= parallelFlattenMinRoots {
-		return flattenParallel(a.occurrences)
+		return flattenParallel(a.occurrences, a.WorkingScale())
 	}
-	return flattenSerial(a.occurrences)
+	return flattenSerial(a.occurrences, a.WorkingScale())
 }
 
 // parallelFlattenMinRoots is the top-level occurrence count at or above which PlacedBodies fans the
@@ -35,9 +35,9 @@ const parallelFlattenMinRoots = 4
 
 // flattenSerial walks the whole tree on one goroutine — the small-assembly path and the reference
 // the parallel path must match exactly.
-func flattenSerial(occs *occurrence.Occurrences) []feature.PlacedBody {
+func flattenSerial(occs *occurrence.Occurrences, rootWS float64) []feature.PlacedBody {
 	w := newPlaceWalker()
-	w.walk(occs, math.Identity4(), nil)
+	w.walk(occs, math.Identity4(), nil, rootWS)
 	return w.out
 }
 
@@ -46,7 +46,7 @@ func flattenSerial(occs *occurrence.Occurrences) []feature.PlacedBody {
 // occurrence order. The walk is read-only over immutable topology and each worker owns its walker
 // and output, so there is no shared mutable state; the contiguous, in-order concat makes the result
 // byte-for-byte identical to flattenSerial. This is the M34-F2 wall-time cut over the deep DAG.
-func flattenParallel(occs *occurrence.Occurrences) []feature.PlacedBody {
+func flattenParallel(occs *occurrence.Occurrences, rootWS float64) []feature.PlacedBody {
 	n := occs.Count()
 	workers := runtime.GOMAXPROCS(0)
 	if workers > n {
@@ -61,7 +61,7 @@ func flattenParallel(occs *occurrence.Occurrences) []feature.PlacedBody {
 			defer wg.Done()
 			w := newPlaceWalker()
 			for i := lo; i < hi; i++ {
-				w.place(occs.Item(i), math.Identity4(), nil)
+				w.place(occs.Item(i), math.Identity4(), nil, rootWS)
 			}
 			parts[slot] = w.out
 		}(wkr, lo, hi)
@@ -126,37 +126,63 @@ func newPlaceWalker() placeWalker {
 // uses that placement's independent override transform when one is set, so two placements of one
 // flexible sub-assembly show components in different positions (M12-F06). The path disambiguates a
 // shared flyweight reached through several placements (M11-F08).
-func (w *placeWalker) walk(occs *occurrence.Occurrences, parent math.Matrix4, flexParent *occurrence.Occurrence) {
+func (w *placeWalker) walk(occs *occurrence.Occurrences, parent math.Matrix4, flexParent *occurrence.Occurrence, ownerWS float64) {
 	for i := 0; i < occs.Count(); i++ {
-		w.place(occs.Item(i), parent, flexParent)
+		w.place(occs.Item(i), parent, flexParent, ownerWS)
 	}
 }
 
 // place emits one occurrence's bodies (a leaf part) or recurses into it (a sub-assembly), at its
 // world placement under parent. Suppressed occurrences are skipped. It pushes the occurrence name
 // before descending and pops it after, so the shared stack always holds the current branch's path.
-func (w *placeWalker) place(o *occurrence.Occurrence, parent math.Matrix4, flexParent *occurrence.Occurrence) {
+func (w *placeWalker) place(o *occurrence.Occurrence, parent math.Matrix4, flexParent *occurrence.Occurrence, ownerWS float64) {
 	if o.Suppressed() {
 		return
 	}
-	world := parent.Mul(childTransform(o, flexParent))
+	// Convert at the placement boundary (ADR-0042 Phase 2): the component's geometry is in its
+	// own working unit; scale it into the owning assembly's working unit before placing. The
+	// scale (childWS / ownerWS) is 1 when units match — every same-unit (and all-centimetre)
+	// assembly is therefore unchanged.
+	childWS := childWorkingScale(o.Definition(), ownerWS)
+	world := parent.Mul(childTransform(o, flexParent).Mul(unitScale(childWS, ownerWS)))
 	w.stack = append(w.stack, o.Name())
 	switch def := o.Definition().(type) {
 	case bodyDefinition: // a leaf part: emit its bodies placed in the assembly
 		for _, b := range def.SurfaceBodies().All() {
 			w.out = append(w.out, feature.PlacedBody{Body: b, Transform: world, Source: o, Path: w.clonePath()})
 		}
-	case occurrence.Composite: // a sub-assembly: recurse, carrying flexible-child overrides
-		w.descend(def, o, world)
+	case occurrence.Composite: // a sub-assembly: recurse, its children converted from ITS working unit
+		w.descend(def, o, world, childWS)
 	}
 	w.stack = w.stack[:len(w.stack)-1]
+}
+
+// childWorkingScale reports a definition's working scale (centimetres per working unit), or the
+// owner's scale when the definition does not carry one (so no conversion is applied — patterns,
+// test fakes). ADR-0042 Phase 2.
+func childWorkingScale(def occurrence.Definition, ownerWS float64) float64 {
+	if ws, ok := def.(interface{ WorkingScale() float64 }); ok {
+		return ws.WorkingScale()
+	}
+	return ownerWS
+}
+
+// unitScale is the uniform similarity that converts a component's working-unit geometry into its
+// owning assembly's working unit (childWS / ownerWS). It is the identity when the units match or
+// either scale is degenerate, so the common path allocates the cheap identity matrix.
+func unitScale(childWS, ownerWS float64) math.Matrix4 {
+	if ownerWS <= 0 || childWS <= 0 || childWS == ownerWS {
+		return math.Identity4()
+	}
+	s := math.Scalar(childWS / ownerWS)
+	return math.Scale4(s, s, s)
 }
 
 // descend recurses into a sub-assembly under the cycle and depth guards (M34-F6): a definition
 // already on the current branch (a self-containing assembly) or a branch past maxAssemblyDepth is
 // skipped, so a malformed DAG degrades to a bounded flatten instead of overflowing the stack. The
 // flexible-child override resets unless this occurrence is itself flexible.
-func (w *placeWalker) descend(def occurrence.Composite, o *occurrence.Occurrence, world math.Matrix4) {
+func (w *placeWalker) descend(def occurrence.Composite, o *occurrence.Occurrence, world math.Matrix4, defWS float64) {
 	if w.depth >= maxAssemblyDepth || w.active[def] {
 		return
 	}
@@ -166,7 +192,8 @@ func (w *placeWalker) descend(def occurrence.Composite, o *occurrence.Occurrence
 	}
 	w.active[def] = true
 	w.depth++
-	w.walk(def.Occurrences(), world, nextFlex)
+	// The sub-assembly's children are authored in ITS working unit, so it is their owner scale.
+	w.walk(def.Occurrences(), world, nextFlex, defWS)
 	w.depth--
 	delete(w.active, def)
 }

--- a/model/compdef/assembly_derive_parallel_test.go
+++ b/model/compdef/assembly_derive_parallel_test.go
@@ -32,8 +32,8 @@ func wideAssembly(t *testing.T) *AssemblyComponentDefinition {
 // transforms, sources and paths — or picking/derivation built on PlacedBodies would shift.
 func TestFlattenParallelMatchesSerial(t *testing.T) {
 	top := wideAssembly(t)
-	serial := flattenSerial(top.occurrences)
-	parallel := flattenParallel(top.occurrences)
+	serial := flattenSerial(top.occurrences, 1)
+	parallel := flattenParallel(top.occurrences, 1)
 	if len(serial) != len(parallel) {
 		t.Fatalf("parallel produced %d bodies, serial %d", len(parallel), len(serial))
 	}
@@ -92,7 +92,7 @@ func TestPlacedBodiesParallelAndSerialPathsAgree(t *testing.T) {
 	if top.occurrences.Count() < parallelFlattenMinRoots {
 		t.Fatalf("fixture has %d roots, need ≥ %d to exercise the parallel path", top.occurrences.Count(), parallelFlattenMinRoots)
 	}
-	if got, want := len(top.PlacedBodies()), len(flattenSerial(top.occurrences)); got != want {
+	if got, want := len(top.PlacedBodies()), len(flattenSerial(top.occurrences, 1)); got != want {
 		t.Errorf("public PlacedBodies = %d bodies, serial reference = %d", got, want)
 	}
 }

--- a/model/compdef/assembly_mixing_test.go
+++ b/model/compdef/assembly_mixing_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestAssemblyMixingConvertsAtPlacement is the ADR-0042 Phase 2 mixed-unit boundary (#1247): a
+// component whose working unit differs from the assembly's is scaled into the assembly's unit at
+// the placement transform, so its geometry lands at the right size. A same-unit placement is
+// unchanged.
+func TestAssemblyMixingConvertsAtPlacement(t *testing.T) {
+	// Same block geometry, but the part's working unit is the millimetre (0.1 cm), while the
+	// assembly works in centimetres. Placing it must shrink the stored coordinates by 0.1.
+	part := partWithBlock(t, math.P3(0, 0, 0), math.P3(2, 2, 2))
+	mm, err := part.Units().CenteredOnLength("mm")
+	if err != nil {
+		t.Fatal(err)
+	}
+	part.SetUnits(mm) // part working scale = 0.1 cm/unit
+
+	asm := NewAssemblyComponentDefinition() // assembly working scale = 1 (cm)
+	asm.Place("p", part, math.Identity4())
+
+	placed := asm.PlacedBodies()
+	if len(placed) != 1 {
+		t.Fatalf("PlacedBodies = %d, want 1", len(placed))
+	}
+	// The placement transform carries the unit conversion 0.1, so the placed bounding box is the
+	// part's box scaled by 0.1.
+	box := placed[0].Body.RangeBox().Transform(placed[0].Transform)
+	if d := float64(box.Diagonal().Length()); d < 0.9*0.1*twoCubeDiag || d > 1.1*0.1*twoCubeDiag {
+		t.Errorf("placed diagonal = %v, want ~%v (0.1 × part)", d, 0.1*twoCubeDiag)
+	}
+
+	// Control: a same-unit (cm) part is placed unscaled.
+	cmPart := partWithBlock(t, math.P3(0, 0, 0), math.P3(2, 2, 2))
+	asm2 := NewAssemblyComponentDefinition()
+	asm2.Place("p", cmPart, math.Identity4())
+	cb := asm2.PlacedBodies()[0]
+	box2 := cb.Body.RangeBox().Transform(cb.Transform)
+	if d := float64(box2.Diagonal().Length()); d < 0.9*twoCubeDiag || d > 1.1*twoCubeDiag {
+		t.Errorf("same-unit placed diagonal = %v, want ~%v (unscaled)", d, twoCubeDiag)
+	}
+}
+
+// twoCubeDiag is the body diagonal of a 2×2×2 block (√12).
+var twoCubeDiag = float64(math.V3(2, 2, 2).Length())

--- a/model/compdef/part.go
+++ b/model/compdef/part.go
@@ -209,6 +209,11 @@ func (d *PartComponentDefinition) Parameters() *param.Parameters { return d.para
 // and dimensions present values in these units.
 func (d *PartComponentDefinition) Units() param.UnitsOfMeasure { return d.units }
 
+// WorkingScale is the centimetre size of one of the part's stored (working) length units
+// (ADR-0042 Phase 2). The assembly placement walker reads it to convert a component placed
+// into an assembly of a different working unit (1.0 ⇒ the centimetre default).
+func (d *PartComponentDefinition) WorkingScale() float64 { return d.units.WorkingScale() }
+
 // SetLengthUnit sets the document's preferred length unit (e.g. "mm", "in").
 func (d *PartComponentDefinition) SetLengthUnit(name string) error {
 	return d.units.SetPreferred(param.Length, name)


### PR DESCRIPTION
## What

A component placed into an assembly whose **working unit differs** is now converted into the assembly's unit at the placement transform (ADR-0042 Phase 2). The flatten walker multiplies each occurrence's transform by `childWS / ownerWS`, so a millimetre part dropped into a centimetre assembly lands at the correct size; the conversion composes correctly through nested sub-assemblies (each sub-assembly is the owner scale for its own children).

## How

- `PartComponentDefinition` / `AssemblyComponentDefinition` expose `WorkingScale()`.
- The placement walker (`assembly_derive.go`) threads the owner assembly's working scale and applies `unitScale(childWS, ownerWS)` per placement. It reads the child scale via an **optional interface**, so pattern elements / test fakes that carry no working scale simply inherit the owner's unit (no conversion) — no interface churn.

## Safety

`unitScale` is the identity when the units match (or either is degenerate), so every same-unit and all-centimetre assembly is **byte-for-byte unchanged** — the serial/parallel flatten equality contract still holds.

## Tests

`model/compdef/assembly_mixing_test.go` — a mm part in a cm assembly is placed scaled by 0.1; a same-unit control is unscaled. 100% coverage of the new walker helpers; lint clean; full `go test ./model/...` green.

Closes #1247. Builds on #1245 (#1253).

🤖 Generated with [Claude Code](https://claude.com/claude-code)