### PR TITLE
M35: activate working-scale documents (auto-centre + report contract) (#1259)

### DIFF
--- a/addin/router/units.go
+++ b/addin/router/units.go
@@ -48,6 +48,7 @@ func unitsInfoOf(u param.UnitsOfMeasure) wire.DocumentUnitsInfo {
 		LengthDisplayPrecision: u.LengthPrecision(),
 		AngleDisplayPrecision:  u.AnglePrecision(),
 		LengthDisplayFormat:    u.LengthFormat().String(),
+		WorkingScaleCm:         u.WorkingScale(),
 	}
 }
 

--- a/addin/router/units_test.go
+++ b/addin/router/units_test.go
@@ -25,6 +25,13 @@ func TestDocumentUnitsRoundTripOverWire(t *testing.T) {
 		t.Fatalf("default precision/format = %+v, want 3/2/decimal", got)
 	}
 
+	// The wire exposes the working scale (ADR-0042 Phase 2); this already-modeled document keeps
+	// the centimetre default (auto-centring only applies to a still-empty document — covered in
+	// model/compdef).
+	if got.WorkingScaleCm != 1 {
+		t.Errorf("working scale = %v, want 1 (cm)", got.WorkingScaleCm)
+	}
+
 	call(t, r, s, "documents.setUnits", `{"lengthUnit":"in","lengthDisplayPrecision":4,"lengthDisplayFormat":"fractional"}`, &got)
 	if got.LengthUnit != "in" || got.LengthDisplayPrecision != 4 || got.LengthDisplayFormat != "fractional" {
 		t.Errorf("after set = %+v, want in/4/fractional", got)

--- a/architecture/decisions/ADR-0042-model-scale-and-relative-tolerances.md
+++ b/architecture/decisions/ADR-0042-model-scale-and-relative-tolerances.md
@@ -160,6 +160,26 @@ Tracked by milestone **M35: Model Scale & Relative Tolerances**.
 - #1247 — assembly mixing: convert at the placement boundary (`childWS/ownerWS` scale term) ✅
 - #1248 — exchange: working-scale ↔ STEP mm (`TargetUnitMM` = working-unit mm) ✅
 - #1249 — span-ceiling diagnostic (`geom.SpanCeilingWarning` / `PartComponentDefinition.FeatureScaleWarning`) ✅
+- #1259 — activation: auto-centre + working-unit report contract ✅
+
+### Activation & the report contract (#1259)
+
+Turning the storage on for users settled on a **working-unit report contract**: the kernel stores
+and reports every geometric quantity in the document's working length unit (the centimetre by
+default, so existing documents are byte-identical), and unit conversion happens only at the two
+boundaries that already own it — **input** (the parser/expression solver converts an explicit-unit
+value like `5 mm`; a bare number is taken in the working unit) and **output** (the user picks the
+file unit on export). The working scale is exposed (`wire.DocumentUnitsInfo.WorkingScaleCm`) so an
+add-in can recover centimetres from a raw geometry quantity by the appropriate power. This avoids a
+fragile per-call-site "convert everything to cm" audit and keeps every reported value internally
+consistent.
+
+A fresh document **auto-centres** its working scale on its chosen length unit
+(`PartComponentDefinition.SetLengthUnit` / `SetUnits` → `param.RecommendedWorkingScale`): band
+units (mm…ft) keep the centimetre scale; extreme units (µm/nm/pm, km) centre on themselves so
+coordinates stay O(1). Once geometry exists the scale is frozen (changing it would reinterpret
+stored coordinates), so a later unit change is display-only. This is what makes the nm/pm
+semiconductor (and km urban) scales modellable end to end.
 
 ### Span-ceiling diagnostic (#1249)
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.88.0
+	oblikovati.org/api v0.89.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.88.0
+	oblikovati.org/api v0.89.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/compdef/part.go
+++ b/model/compdef/part.go
@@ -215,15 +215,48 @@ func (d *PartComponentDefinition) Units() param.UnitsOfMeasure { return d.units 
 // into an assembly of a different working unit (1.0 ⇒ the centimetre default).
 func (d *PartComponentDefinition) WorkingScale() float64 { return d.units.WorkingScale() }
 
-// SetLengthUnit sets the document's preferred length unit (e.g. "mm", "in").
+// SetLengthUnit sets the document's preferred length unit (e.g. "mm", "in"). On a still-empty
+// document it also centres the working scale on that unit (ADR-0042 Phase 2) so coordinates
+// authored next are O(1) — the activation that lets a µm/pm or km document model without the
+// cm-storage extremes. Once geometry exists the working scale is left alone (changing it would
+// reinterpret stored coordinates); a unit change is then display-only.
 func (d *PartComponentDefinition) SetLengthUnit(name string) error {
-	return d.units.SetPreferred(param.Length, name)
+	if err := d.units.SetPreferred(param.Length, name); err != nil {
+		return err
+	}
+	d.centerWorkingScaleIfEmpty(name)
+	return nil
 }
 
-// SetUnits replaces the document's display units wholesale — the way the units
-// API and the Units settings dialog apply an edited preferences object (build
-// it from Units().Clone()).
-func (d *PartComponentDefinition) SetUnits(u param.UnitsOfMeasure) { d.units = u }
+// SetUnits replaces the document's display units wholesale — the way the units API and the Units
+// settings dialog apply an edited preferences object (build it from Units().Clone()). On a
+// still-empty document whose incoming working scale is the centimetre default, it centres the
+// working scale on the chosen length unit (ADR-0042 Phase 2); an explicitly-set working scale
+// (e.g. via CenteredOnLength) is respected.
+func (d *PartComponentDefinition) SetUnits(u param.UnitsOfMeasure) {
+	d.units = u
+	if u.WorkingScale() == 1 {
+		d.centerWorkingScaleIfEmpty(u.PreferredName(param.Length))
+	}
+}
+
+// centerWorkingScaleIfEmpty centres the working scale on the named length unit when the part has
+// no modeled content yet, so re-scaling cannot reinterpret existing geometry (ADR-0042 Phase 2).
+func (d *PartComponentDefinition) centerWorkingScaleIfEmpty(lengthUnit string) {
+	if !d.isEmptyForRescale() {
+		return
+	}
+	if ws, ok := param.RecommendedWorkingScale(lengthUnit); ok {
+		_ = d.units.SetWorkingScale(ws)
+	}
+}
+
+// isEmptyForRescale reports whether the part holds no modeled content yet, so re-centring the
+// working scale cannot reinterpret existing geometry (ADR-0042 Phase 2).
+func (d *PartComponentDefinition) isEmptyForRescale() bool {
+	return d.features.Count() == 0 && len(d.bodies.All()) == 0 &&
+		d.sketches.Count() == 0 && d.sketches3D.Count() == 0
+}
 
 // FeatureScaleWarning returns a non-empty diagnostic when a feature of the given size (in the
 // part's working unit) is below what this model can resolve at its current extent, and "" when

--- a/model/compdef/working_scale_activation_test.go
+++ b/model/compdef/working_scale_activation_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/param"
+)
+
+// TestSetLengthUnitCentresEmptyDocument is the ADR-0042 Phase 2 activation (#1259): choosing an
+// extreme length unit on a fresh part centres the working scale on it (so coordinates stay O(1)),
+// while a band unit (mm…ft) keeps the centimetre default — existing documents are unchanged.
+func TestSetLengthUnitCentresEmptyDocument(t *testing.T) {
+	for _, tc := range []struct {
+		unit string
+		want float64
+	}{{"µm", 1e-4}, {"km", 1e5}, {"mm", 1}, {"in", 1}} {
+		d := NewPartComponentDefinition()
+		if err := d.SetLengthUnit(tc.unit); err != nil {
+			t.Fatalf("SetLengthUnit(%q): %v", tc.unit, err)
+		}
+		if got := d.WorkingScale(); got != tc.want {
+			t.Errorf("after SetLengthUnit(%q) WorkingScale = %v, want %v", tc.unit, got, tc.want)
+		}
+	}
+}
+
+// TestSetLengthUnitLeavesModeledDocumentAlone is the guard: once geometry exists, changing the
+// length unit must NOT re-scale the working scale (that would reinterpret stored coordinates).
+func TestSetLengthUnitLeavesModeledDocumentAlone(t *testing.T) {
+	d := partWithBlock(t, math.P3(0, 0, 0), math.P3(2, 2, 2)) // centimetre block, has a feature
+	if err := d.SetLengthUnit("µm"); err != nil {
+		t.Fatal(err)
+	}
+	if got := d.WorkingScale(); got != 1 {
+		t.Errorf("modeled document re-scaled to %v; want unchanged 1 (display-only unit change)", got)
+	}
+}
+
+// TestSetUnitsCentresEmptyDocument covers the dialog path (SetUnits): an incoming default-scale
+// units object on a fresh part centres on its length unit, while an explicitly-centred one
+// (CenteredOnLength) is respected.
+func TestSetUnitsCentresEmptyDocument(t *testing.T) {
+	// Dialog-style: default working scale, µm preferred ⇒ auto-centres.
+	u := param.DefaultUnitsOfMeasure().Clone()
+	if err := u.SetPreferred(param.Length, "µm"); err != nil {
+		t.Fatal(err)
+	}
+	d := NewPartComponentDefinition()
+	d.SetUnits(u)
+	if got := d.WorkingScale(); got != 1e-4 {
+		t.Errorf("SetUnits(µm, default scale) ⇒ WorkingScale %v, want 1e-4", got)
+	}
+
+	// Explicit working scale is respected, not overridden.
+	ex, err := param.DefaultUnitsOfMeasure().CenteredOnLength("km")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d2 := NewPartComponentDefinition()
+	d2.SetUnits(ex)
+	if got := d2.WorkingScale(); got != 1e5 {
+		t.Errorf("SetUnits(explicit km scale) ⇒ WorkingScale %v, want 1e5", got)
+	}
+}
+
+// TestActivationLetsPicometreDocumentBuild is the end-to-end proof of the activation: on a part
+// centred on picometres, a bare "5" parses to an O(1) working coordinate, so a primitive builds
+// as a valid solid — whereas the same physical 5 pm in a centimetre document is ~5e-10 and the
+// primitive collapses (the underflow ADR-0042 Phase 1 could not reach). This is why Phase 2 makes
+// the nm/pm semiconductor scales usable.
+func TestActivationLetsPicometreDocumentBuild(t *testing.T) {
+	pm := NewPartComponentDefinition()
+	if err := pm.SetLengthUnit("pm"); err != nil {
+		t.Fatal(err)
+	}
+	q, err := pm.Units().Parse("5", param.Length) // bare ⇒ working (pm) unit
+	if err != nil {
+		t.Fatal(err)
+	}
+	if q.Value < 0.9 || q.Value > 5.1 { // O(1), not 5e-10
+		t.Fatalf("pm document: bare 5 parsed to %v working units, want ~5 (O(1))", q.Value)
+	}
+	body, err := brep.SolidBlock(math.P3(0, 0, 0), math.P3(q.Value, q.Value, q.Value), "pmbox")
+	if err != nil {
+		t.Fatalf("pm box build: %v", err)
+	}
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("pm box is not a valid solid: %+v", r)
+	}
+
+	// Control: the same physical size in a centimetre document underflows to a degenerate box.
+	cm := NewPartComponentDefinition() // working scale 1 (cm)
+	qcm, _ := cm.Units().Parse("5 pm", param.Length)
+	if qcm.Value > 1e-6 {
+		t.Fatalf("cm document: 5 pm parsed to %v, want ~5e-10 (the underflow case)", qcm.Value)
+	}
+}

--- a/model/param/units_of_measure.go
+++ b/model/param/units_of_measure.go
@@ -215,6 +215,32 @@ func (m UnitsOfMeasure) CenteredOnLength(name string) (UnitsOfMeasure, error) {
 	return m.WithWorkingScale(def.factor)
 }
 
+// safeWorkingBand brackets the centimetre size of length units that store well at the centimetre
+// working scale (ADR-0042 Phase 2). Units inside it (mm … ft) keep centimetre coordinates — so
+// existing documents are unchanged — while units outside (µm/nm/pm and km and larger) get a
+// working unit matching the document unit, keeping coordinates O(1) and clear of the
+// underflow/precision extremes.
+const (
+	safeWorkingBandLoCm = 1e-3
+	safeWorkingBandHiCm = 1e4
+)
+
+// RecommendedWorkingScale returns the working scale (centimetres per working unit) to centre a
+// fresh document on the named length unit: the unit's own size when it is extreme enough that
+// centimetre storage would lose conditioning, else 1.0 (the centimetre default). ok is false for
+// an unknown or non-length unit. This is the policy the document layer applies when a new
+// document's length unit is chosen.
+func RecommendedWorkingScale(lengthUnitName string) (scaleCm float64, ok bool) {
+	def, found := lookupUnit(lengthUnitName)
+	if !found || def.category != Length {
+		return 1, false
+	}
+	if def.factor < safeWorkingBandLoCm || def.factor > safeWorkingBandHiCm {
+		return def.factor, true
+	}
+	return 1, true
+}
+
 // wsFactor is workingScale raised to the unit's length exponent (Length¹, Area², Volume³,
 // 0 otherwise) — the multiplier converting a working-unit Value to centimetres. An explicit
 // switch keeps the common exponents exact (no Pow round-off).

--- a/model/param/working_scale_test.go
+++ b/model/param/working_scale_test.go
@@ -160,3 +160,24 @@ func approxRelWS(got, want float64) bool {
 	}
 	return math.Abs(got-want)/math.Abs(want) < 1e-9
 }
+
+// TestRecommendedWorkingScale pins the auto-centre policy (ADR-0042 Phase 2 activation): units in
+// the safe centimetre band (mm…ft) stay at cm (1.0) so existing documents are unchanged; extreme
+// units (µm/nm/pm, km) centre on themselves so coordinates stay O(1).
+func TestRecommendedWorkingScale(t *testing.T) {
+	for _, tc := range []struct {
+		unit string
+		want float64
+	}{
+		{"mm", 1}, {"cm", 1}, {"m", 1}, {"in", 1}, {"ft", 1}, // band → centimetre
+		{"µm", 1e-4}, {"nm", 1e-7}, {"pm", 1e-10}, {"km", 1e5}, // extreme → centre
+	} {
+		got, ok := RecommendedWorkingScale(tc.unit)
+		if !ok || got != tc.want {
+			t.Errorf("RecommendedWorkingScale(%q) = %v,%v; want %v,true", tc.unit, got, ok, tc.want)
+		}
+	}
+	if _, ok := RecommendedWorkingScale("deg"); ok {
+		t.Error("RecommendedWorkingScale(deg) should be ok=false (not a length unit)")
+	}
+}


### PR DESCRIPTION
## What

Turns on **ADR-0042 Phase 2** for users, with the **working-unit report contract** chosen for #1259.

- **Auto-centre:** a fresh part centres its working scale on its chosen length unit (`SetLengthUnit` / `SetUnits` → `param.RecommendedWorkingScale`). Band units (mm…ft) keep the centimetre scale — **existing documents are byte-identical**; extreme units (µm/nm/pm, km) centre on themselves so coordinates stay O(1). Once geometry exists the scale is **frozen** (a later unit change is display-only, never reinterpreting stored coordinates).
- **Report contract:** the kernel keeps reporting geometry in working units; the working scale is exposed over the wire (`DocumentUnitsInfo.WorkingScaleCm`, api v0.89.0) so an add-in can recover centimetres. Unit conversion stays at the boundaries that already own it — **input** (parser/expression solver; bare number = working unit, explicit unit converted) and **output** (user picks the file unit on export). No fragile per-call-site "convert everything to cm" audit.

## Why this contract

Converting every physical-quantity readout to cm at its source spans many subsystems and risks silent wrong data on any miss. Reporting consistently in working units (cm for existing docs) + exposing the scale is consistent, safe, and leverages the conversion the parser/export already do.

## Result

End-to-end (`TestActivationLetsPicometreDocumentBuild`): a picometre document parses a bare `5` to an O(1) coordinate and builds a **valid solid**, where the same physical 5 pm in a centimetre document underflows — the nm/pm semiconductor scale Phase 1 could not reach.

## Tests

`param.RecommendedWorkingScale` policy; compdef auto-centre (empty centres, modeled document frozen, dialog vs explicit-scale paths); the pm end-to-end build + cm-underflow control; wire exposure of `WorkingScaleCm`. Full `go test ./...` green; lint + markdownlint clean.

Closes #1259. Depends on Oblikovati.API v0.89.0 (#210, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)