### PR TITLE
Color sketch origin grid lines by axis (X red, Y green)

### DIFF
--- a/head/ui/grid_overlay.go
+++ b/head/ui/grid_overlay.go
@@ -17,37 +17,43 @@ const gridCells = 20
 
 // gridOverlay builds the sketch grid: lines parallel to the plane's axes, spaced by
 // spacing (model units), centred on the plane origin (the sketch's 0,0). Minor, major
-// (every `major` lines) and the two axis lines are separate colored items. Returns nil
-// when spacing is non-positive.
+// (every `major` lines) and the two origin axis lines are separate colored items: the
+// origin lines take the universal CAD axis colors (X red, Y green) so users read axis
+// identity by color exactly as on the orientation triad. Returns nil when spacing is
+// non-positive.
 func gridOverlay(plane sketch.Plane, spacing float64, major int) []renderer.DrawItem {
 	if spacing <= 0 {
 		return nil
 	}
-	minor, maj, axis := &segAccum{}, &segAccum{}, &segAccum{}
+	minor, maj := &segAccum{}, &segAccum{}
+	xAxis, yAxis := &segAccum{}, &segAccum{}
 	half := float64(gridCells) * spacing
 	for i := -gridCells; i <= gridCells; i++ {
-		acc := gridAccum(i, major, minor, maj, axis)
 		c := float64(i) * spacing
-		acc.seg(plane, math.P2(c, -half), math.P2(c, half)) // line of constant u
-		acc.seg(plane, math.P2(-half, c), math.P2(half, c)) // line of constant v
+		uAcc, vAcc := gridLineAccum(i, major, minor, maj, xAxis, yAxis)
+		uAcc.seg(plane, math.P2(c, -half), math.P2(c, half)) // line of constant u (the Y axis at i==0)
+		vAcc.seg(plane, math.P2(-half, c), math.P2(half, c)) // line of constant v (the X axis at i==0)
 	}
 	var items []renderer.DrawItem
 	items = appendGrid(items, minor, gridMinorColor)
 	items = appendGrid(items, maj, gridMajorColor)
-	items = appendGrid(items, axis, gridAxisColor)
+	items = appendGrid(items, xAxis, axisColorX)
+	items = appendGrid(items, yAxis, axisColorY)
 	return items
 }
 
-// gridAccum routes line index i to the axis (0), major (every `major`), or minor group.
-func gridAccum(i, major int, minor, maj, axis *segAccum) *segAccum {
-	switch {
-	case i == 0:
-		return axis
-	case major > 0 && i%major == 0:
-		return maj
-	default:
-		return minor
+// gridLineAccum returns the accumulators for the two grid lines at index i: the
+// constant-u line (uAcc) and the constant-v line (vAcc). Off-origin lines share one
+// minor/major group; at the origin (i==0) the constant-u line is the Y axis and the
+// constant-v line is the X axis, so each goes to its own axis-colored group.
+func gridLineAccum(i, major int, minor, maj, xAxis, yAxis *segAccum) (uAcc, vAcc *segAccum) {
+	if i == 0 {
+		return yAxis, xAxis
 	}
+	if major > 0 && i%major == 0 {
+		return maj, maj
+	}
+	return minor, minor
 }
 
 // appendGrid adds a colored line item for a non-empty accumulator.

--- a/head/ui/grid_overlay_test.go
+++ b/head/ui/grid_overlay_test.go
@@ -1,0 +1,95 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+	"oblikovati.org/renderer"
+)
+
+// xyPlane is the model XY plane, so ToModel(P2(u,v)) == (u, v, 0) and grid lines map
+// straight onto the world axes for assertion.
+func xyPlane(t *testing.T) sketch.Plane {
+	t.Helper()
+	p, err := sketch.NewPlane(math.P3(0, 0, 0), math.V3(1, 0, 0).AsUnit(), math.V3(0, 1, 0).AsUnit())
+	if err != nil {
+		t.Fatalf("NewPlane: %v", err)
+	}
+	return p
+}
+
+func itemWithColor(items []renderer.DrawItem, color [4]float32) (renderer.DrawItem, bool) {
+	for _, it := range items {
+		if it.Color == color {
+			return it, true
+		}
+	}
+	return renderer.DrawItem{}, false
+}
+
+func TestGridOverlayNonPositiveSpacing(t *testing.T) {
+	if got := gridOverlay(xyPlane(t), 0, 5); got != nil {
+		t.Errorf("spacing 0: got %d items, want nil", len(got))
+	}
+	if got := gridOverlay(xyPlane(t), -1, 5); got != nil {
+		t.Errorf("spacing -1: got %d items, want nil", len(got))
+	}
+}
+
+// TestGridOverlayOriginAxisColors: the line through the origin along X is red (axisColorX)
+// and the line along Y is green (axisColorY), each a single segment spanning the grid.
+func TestGridOverlayOriginAxisColors(t *testing.T) {
+	const spacing = 1.0
+	half := float64(gridCells) * spacing
+	items := gridOverlay(xyPlane(t), spacing, 5)
+
+	xItem, ok := itemWithColor(items, axisColorX)
+	if !ok {
+		t.Fatalf("no X-axis (red) grid item; colors=%v", colorsOf(items))
+	}
+	assertAxisSegment(t, "X", xItem, math.P3(-half, 0, 0), math.P3(half, 0, 0))
+
+	yItem, ok := itemWithColor(items, axisColorY)
+	if !ok {
+		t.Fatalf("no Y-axis (green) grid item; colors=%v", colorsOf(items))
+	}
+	assertAxisSegment(t, "Y", yItem, math.P3(0, -half, 0), math.P3(0, half, 0))
+}
+
+// TestGridOverlayKeepsMinorAndMajor: the axis split does not drop the minor/major groups.
+func TestGridOverlayKeepsMinorAndMajor(t *testing.T) {
+	items := gridOverlay(xyPlane(t), 1.0, 5)
+	if _, ok := itemWithColor(items, gridMinorColor); !ok {
+		t.Errorf("no minor grid item; colors=%v", colorsOf(items))
+	}
+	if _, ok := itemWithColor(items, gridMajorColor); !ok {
+		t.Errorf("no major grid item; colors=%v", colorsOf(items))
+	}
+}
+
+func assertAxisSegment(t *testing.T, name string, it renderer.DrawItem, p, q math.Point3) {
+	t.Helper()
+	if it.Primitive != renderer.Lines {
+		t.Errorf("%s axis: primitive=%v, want Lines", name, it.Primitive)
+	}
+	if len(it.Positions) != 2 || len(it.Indices) != 2 {
+		t.Fatalf("%s axis: %d positions / %d indices, want a single segment", name, len(it.Positions), len(it.Indices))
+	}
+	// The XY plane maps integer grid coords exactly, so direct equality is safe here.
+	if it.Positions[0] != p || it.Positions[1] != q {
+		t.Errorf("%s axis endpoints = %v..%v, want %v..%v", name, it.Positions[0], it.Positions[1], p, q)
+	}
+}
+
+func colorsOf(items []renderer.DrawItem) [][4]float32 {
+	out := make([][4]float32, len(items))
+	for i, it := range items {
+		out[i] = it.Color
+	}
+	return out
+}

--- a/head/ui/theme_apply.go
+++ b/head/ui/theme_apply.go
@@ -20,7 +20,7 @@ import (
 // overwritten from the active theme whenever it changes (ADR-0021). The overlay files
 // read these vars by name exactly as before.
 var (
-	gridMinorColor, gridMajorColor, gridAxisColor          [4]float32
+	gridMinorColor, gridMajorColor                         [4]float32
 	sketchColor, sketchSelectedColor, sketchCandidateColor [4]float32
 	previewColor                                           [4]float32 // rubber-band preview
 	dimensionColor, dimensionDrivenColor                   [4]float32
@@ -91,7 +91,6 @@ func refreshThemeColors(t contract.Theme) {
 func refreshGridThemeColors(arr func(types.ThemeToken) [4]float32) {
 	gridMinorColor = arr(types.TokenGridMinor)
 	gridMajorColor = arr(types.TokenGridMajor)
-	gridAxisColor = arr(types.TokenGridAxis)
 }
 
 func refreshSketchThemeColors(arr func(types.ThemeToken) [4]float32) {


### PR DESCRIPTION
## What

The sketch editor's grid lines that cross the origin are now colored by axis identity: the **X axis line is red** and the **Y axis line is green**, instead of both drawing in a single grey "axis" color.

## Why

Users could not tell which way the sketch was oriented from the grid — there was no visual axis cue. Red-X / green-Y is the universal CAD convention (and already what the orientation triad uses), so the grid now matches the triad and every other CAD app.

## How

- `head/ui/grid_overlay.go` — split the single origin "axis" line group into two. At the origin (`i==0`) the constant-u line (vertical) is the Y axis → green and the constant-v line (horizontal) is the X axis → red; off-origin lines still share the minor/major groups. Reuses the existing theme-independent `axisColorX`/`axisColorY` from the triad (`axis_gizmo.go`) — no duplication, colors stay consistent app-wide.
- `head/ui/theme_apply.go` — drop the now-unused `gridAxisColor` var/assignment (the public `TokenGridAxis` theme token is left intact).
- `head/ui/grid_overlay_test.go` (new) — covers nil on non-positive spacing, the red origin X line spanning the grid, the green origin Y line, and that minor/major groups survive the split.

Head-only change — no public API / wire surface touched.

## Verification

- `go build ./...` + full `head/ui` test suite pass; `gofmt` clean.
- Live-confirmed by rendering a real sketch grid offscreen and sampling pixels: vertical line `R=107 G=189 B=71` (green `axisColorY`), horizontal line `R=229 G=59 B=69` (red `axisColorX`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)