### PR TITLE
Project origin/work geometry into sketches; auto-project origin centre (#1262)

### DIFF
--- a/addin/router/sketch_project.go
+++ b/addin/router/sketch_project.go
@@ -9,6 +9,7 @@ import (
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
 	"oblikovati.org/model/sketch"
 )
 
@@ -47,14 +48,29 @@ func projectRefs(part *compdef.PartComponentDefinition, sk *sketch.Sketch, refs 
 	return created, healthy
 }
 
-// projectRef resolves one reference key to an edge or vertex among the part's bodies and
-// projects it, returning the created sketch entity.
+// projectRef resolves one reference to a B-rep edge/vertex or a datum (work point/axis/plane)
+// among the part's geometry and projects it, returning the created sketch entity. Datum
+// references use the public [types.WorkRef] vocabulary (e.g. "origin/point/center"), so an
+// automation client projects the origin centre point, axes and planes the same way the
+// interactive tool does (#1262).
 func projectRef(part *compdef.PartComponentDefinition, sk *sketch.Sketch, ref string) (sketch.Entity, bool) {
 	if part.EdgeKeyResolves(ref) {
 		return sk.ProjectCurve(compdef.NewEdgeRefSource(part, ref)), true
 	}
 	if part.VertexKeyResolves(ref) {
 		return sk.ProjectPoint(compdef.NewVertexRefSource(part, ref)), true
+	}
+	if part.WorkPointKeyResolves(ref) {
+		return sk.ProjectPoint(compdef.NewWorkPointRefSource(part, feature.WorkRef(ref))), true
+	}
+	if part.WorkAxisKeyResolves(ref) {
+		return sk.ProjectCurve(compdef.NewWorkAxisRefSource(part, feature.WorkRef(ref))), true
+	}
+	if part.WorkPlaneKeyResolves(ref) {
+		if !part.WorkPlaneIntersectsSketch(feature.WorkRef(ref), sk.Plane()) {
+			return nil, false // parallel to the sketch: no intersection line to project
+		}
+		return sk.ProjectCurve(compdef.NewWorkPlaneRefSource(part, feature.WorkRef(ref), sk.Plane())), true
 	}
 	return nil, false
 }

--- a/addin/router/sketch_test.go
+++ b/addin/router/sketch_test.go
@@ -951,6 +951,43 @@ func TestSketchProjectGeometry(t *testing.T) {
 	}
 }
 
+// TestSketchProjectDatumGeometry projects the part's origin datum geometry over the wire using
+// the public WorkRef vocabulary: the centre point, the X axis and the XZ plane onto an XY
+// sketch. The point becomes a projected point; the axis and the plane↔sketch intersection both
+// become projected curves (#1262).
+func TestSketchProjectDatumGeometry(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+
+	var proj wire.ProjectGeometryResult
+	args := `{"sketchIndex":0,"refs":["origin/point/center","origin/axis/x","origin/plane/xz"]}`
+	call(t, r, s, "sketch.project", args, &proj)
+	if len(proj.Created) != 3 || !proj.Healthy {
+		t.Fatalf("project datums = %+v, want 3 created / healthy", proj)
+	}
+
+	var ents wire.EnumerateEntitiesResult
+	call(t, r, s, "sketch.entities", `{"sketchIndex":0}`, &ents)
+	if got := countKind(ents.Entities, "projectedPoint"); got != 1 {
+		t.Errorf("want 1 projectedPoint (origin centre), got %d", got)
+	}
+	if got := countKind(ents.Entities, "projectedCurve"); got != 2 {
+		t.Errorf("want 2 projectedCurve (X axis + XZ∩XY), got %d", got)
+	}
+}
+
+// TestSketchProjectParallelPlaneIsUnhealthy: projecting the XY origin plane onto an XY sketch is
+// parallel — there is no intersection line, so it reports unhealthy and creates nothing.
+func TestSketchProjectParallelPlaneIsUnhealthy(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	var proj wire.ProjectGeometryResult
+	call(t, r, s, "sketch.project", `{"sketchIndex":0,"refs":["origin/plane/xy"]}`, &proj)
+	if proj.Healthy || len(proj.Created) != 0 {
+		t.Fatalf("project of a parallel plane = %+v, want unhealthy / nothing created", proj)
+	}
+}
+
 func TestSketchProjectUnknownRefIsUnhealthy(t *testing.T) {
 	r, s := emptyPartSession(t)
 	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})

--- a/app/sketch_env.go
+++ b/app/sketch_env.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	"oblikovati.org/kernel/geom"
+	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/param"
 	"oblikovati.org/model/sketch"
@@ -56,8 +57,22 @@ func (s *Session) CreateSketch(plane sketch.Plane) (*sketch.Sketch, error) {
 	}
 	sk := host.Sketches().Add(plane)
 	sk.SetParameters(host.Parameters()) // dimension expressions resolve in the host's table
+	autoProjectOrigin(host, sk)
 	s.EnterSketch(sk)
 	return sk, nil
+}
+
+// autoProjectOrigin projects the part's origin centre point into a freshly created sketch, so
+// every new sketch carries the projected origin as a constrainable reference at (0,0) — the
+// Inventor default the bug report (#1262) asked for. It is a no-op for hosts without an origin
+// centre point (an assembly), and the projection is associative like any other (it re-derives
+// through recompute via the [feature.OriginCenter] reference).
+func autoProjectOrigin(host sketchHost, sk *sketch.Sketch) {
+	part, ok := host.(*compdef.PartComponentDefinition)
+	if !ok {
+		return
+	}
+	sk.ProjectPoint(compdef.NewWorkPointRefSource(part, feature.OriginCenter))
 }
 
 // CreateSketchOnOrigin creates a sketch on one of the part's origin planes (XY/XZ/YZ),

--- a/app/sketch_project_origin_test.go
+++ b/app/sketch_project_origin_test.go
@@ -48,13 +48,19 @@ func TestProjectGeometryToolProjectsDatums(t *testing.T) {
 	xAxis, _ := def.WorkGeometry().AxisByRef(feature.OriginXAxis)
 	xzPlane, _ := def.WorkGeometry().WorkPlaneByRef(feature.OriginXZPlane)
 
+	xyPlane, _ := def.WorkGeometry().WorkPlaneByRef(feature.OriginXYPlane) // parallel to the sketch
+
 	tool := NewProjectGeometryTool()
 	s.StartTool(tool)
 	tool.Pick(s, WorkPointHandle{Point: center})
 	tool.Pick(s, WorkAxisHandle{Axis: xAxis})
 	tool.Pick(s, WorkPlaneHandle{Plane: xzPlane})
+	tool.Pick(s, WorkPlaneHandle{Plane: xyPlane}) // parallel: must be skipped on commit
 	if !tool.CanCommit() {
 		t.Fatal("tool should be ready after picking datum geometry")
+	}
+	if got := len(tool.Picks()); got != 4 {
+		t.Errorf("Picks() = %d, want 4 datum picks for the highlight", got)
 	}
 	if err := s.OK(); err != nil {
 		t.Fatalf("OK: %v", err)

--- a/app/sketch_project_origin_test.go
+++ b/app/sketch_project_origin_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// TestCreateSketchAutoProjectsOrigin: a freshly created sketch carries the projected origin
+// centre point at (0,0), the Inventor default the bug report (#1262) asked for.
+func TestCreateSketchAutoProjectsOrigin(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	sk, err := s.CreateSketch(sketch.XYPlane())
+	if err != nil {
+		t.Fatalf("CreateSketch: %v", err)
+	}
+	var origins []*sketch.ProjectedPoint
+	for _, e := range sk.Entities() {
+		if pp, ok := e.(*sketch.ProjectedPoint); ok {
+			origins = append(origins, pp)
+		}
+	}
+	if len(origins) != 1 {
+		t.Fatalf("new sketch has %d projected points, want 1 (the origin centre)", len(origins))
+	}
+	if got := origins[0].Position(); !got.IsEqualTo(math.P2(0, 0), 1e-9) {
+		t.Errorf("projected origin at %v, want (0,0)", got)
+	}
+	if origins[0].SourceID() != string(feature.OriginCenter) {
+		t.Errorf("projected origin source = %q, want %q", origins[0].SourceID(), feature.OriginCenter)
+	}
+}
+
+// TestProjectGeometryToolProjectsDatums drives the Project Geometry tool on the part's datum
+// geometry — the origin centre point, an origin axis and an origin plane (the references a user
+// reaches from the browser tree) — and confirms each becomes reference geometry (#1262). The
+// XZ origin plane meets the XY sketch along the X axis, so it projects a line.
+func TestProjectGeometryToolProjectsDatums(t *testing.T) {
+	s, def := emptyPartSession(t)
+	if _, err := s.CreateSketch(sketch.XYPlane()); err != nil {
+		t.Fatalf("CreateSketch: %v", err)
+	}
+	center, _ := def.WorkGeometry().WorkPointByRef(feature.OriginCenter)
+	xAxis, _ := def.WorkGeometry().AxisByRef(feature.OriginXAxis)
+	xzPlane, _ := def.WorkGeometry().WorkPlaneByRef(feature.OriginXZPlane)
+
+	tool := NewProjectGeometryTool()
+	s.StartTool(tool)
+	tool.Pick(s, WorkPointHandle{Point: center})
+	tool.Pick(s, WorkAxisHandle{Axis: xAxis})
+	tool.Pick(s, WorkPlaneHandle{Plane: xzPlane})
+	if !tool.CanCommit() {
+		t.Fatal("tool should be ready after picking datum geometry")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+
+	sk := s.ActiveSketch()
+	var points, curves int
+	for _, e := range sk.Entities() {
+		switch e.(type) {
+		case *sketch.ProjectedPoint:
+			points++
+		case *sketch.ProjectedCurve:
+			curves++
+		}
+	}
+	// 2 points = auto-projected origin (CreateSketch) + the explicitly projected centre point;
+	// 2 curves = the projected origin X axis + the XZ-plane∩sketch intersection line.
+	if points != 2 || curves != 2 {
+		t.Fatalf("projected %d points / %d curves, want 2 / 2", points, curves)
+	}
+}

--- a/app/sketch_project_tool.go
+++ b/app/sketch_project_tool.go
@@ -6,17 +6,24 @@ import (
 	"errors"
 
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/sketch"
 )
 
 // ProjectGeometryTool is the interactive 2D "Project Geometry" command: while editing a
-// sketch, click part edges/vertices to project them onto the sketch plane as associative
-// reference geometry (they re-derive through recompute via their reference keys, and other
-// sketch geometry can be constrained to the projected anchors). Picks arrive as edge/vertex
-// handles; Commit projects each onto the active 2D sketch.
+// sketch, click part edges/vertices — or the part's datum geometry (the origin centre point,
+// origin/work axes and planes, in the viewport or the browser tree) — to project them onto the
+// sketch plane as associative reference geometry (they re-derive through recompute via their
+// reference keys, and other sketch geometry can be constrained to the projected anchors). A
+// projected work axis/plane becomes a reference line (the axis, or the plane↔sketch
+// intersection); a work point becomes a reference point. Commit projects each onto the active
+// 2D sketch (#1262).
 type ProjectGeometryTool struct {
 	dialogTool
-	edges    []EdgeHandle
-	vertices []VertexHandle
+	edges      []EdgeHandle
+	vertices   []VertexHandle
+	workPoints []WorkPointHandle
+	workAxes   []WorkAxisHandle
+	workPlanes []WorkPlaneHandle
 }
 
 // NewProjectGeometryTool returns a project-geometry tool.
@@ -28,28 +35,48 @@ func (t *ProjectGeometryTool) Name() string { return "Project Geometry" }
 // Start is a no-op; the engine installs the filter from AcceptedKinds.
 func (t *ProjectGeometryTool) Start(*Session) {}
 
-// AcceptedKinds declares project-geometry picks projectable references: edges and vertices.
+// AcceptedKinds declares project-geometry picks projectable references: B-rep edges and
+// vertices, plus the part's datum geometry (work points, axes and planes — the Origin folder
+// and user work features).
 func (t *ProjectGeometryTool) AcceptedKinds() []SelectionKind {
-	return []SelectionKind{SelectEdge, SelectVertex}
+	return []SelectionKind{SelectEdge, SelectVertex, SelectWorkPoint, SelectWorkAxis, SelectWorkPlane}
 }
 
-// Picks reports the picked edges and vertices for the unified highlight.
+// Picks reports every picked reference for the unified highlight.
 func (t *ProjectGeometryTool) Picks() []Selectable {
-	return append(edgeSelectables(t.edges), vertexSelectables(t.vertices)...)
+	picks := append(edgeSelectables(t.edges), vertexSelectables(t.vertices)...)
+	for _, h := range t.workPoints {
+		picks = append(picks, h)
+	}
+	for _, h := range t.workAxes {
+		picks = append(picks, h)
+	}
+	for _, h := range t.workPlanes {
+		picks = append(picks, h)
+	}
+	return picks
 }
 
-// Pick records a clicked edge or vertex (ignoring other kinds).
+// Pick records a clicked edge, vertex or datum reference (ignoring other kinds).
 func (t *ProjectGeometryTool) Pick(_ *Session, sel Selectable) {
 	switch h := sel.(type) {
 	case EdgeHandle:
 		t.edges = append(t.edges, h)
 	case VertexHandle:
 		t.vertices = append(t.vertices, h)
+	case WorkPointHandle:
+		t.workPoints = append(t.workPoints, h)
+	case WorkAxisHandle:
+		t.workAxes = append(t.workAxes, h)
+	case WorkPlaneHandle:
+		t.workPlanes = append(t.workPlanes, h)
 	}
 }
 
 // CanCommit reports whether at least one reference is picked.
-func (t *ProjectGeometryTool) CanCommit() bool { return len(t.edges)+len(t.vertices) > 0 }
+func (t *ProjectGeometryTool) CanCommit() bool {
+	return len(t.edges)+len(t.vertices)+len(t.workPoints)+len(t.workAxes)+len(t.workPlanes) > 0
+}
 
 // Commit projects each picked edge/vertex onto the active 2D sketch as associative
 // reference geometry.
@@ -59,7 +86,7 @@ func (t *ProjectGeometryTool) Commit(s *Session) error {
 		return errors.New("project geometry: not editing a 2D sketch")
 	}
 	if !t.CanCommit() {
-		return errors.New("project geometry: pick at least one edge or vertex")
+		return errors.New("project geometry: pick at least one edge, vertex or datum reference")
 	}
 	part, err := activePart(s)
 	if err != nil {
@@ -71,7 +98,25 @@ func (t *ProjectGeometryTool) Commit(s *Session) error {
 	for _, v := range t.vertices {
 		sk.ProjectPoint(compdef.NewVertexRefSource(part, string(v.Vertex.ReferenceKey())))
 	}
+	t.projectDatums(sk, part)
 	return nil
+}
+
+// projectDatums projects the picked datum geometry onto sk: the origin/work points as
+// reference points, the axes and the (non-parallel) planes as reference lines (#1262).
+func (t *ProjectGeometryTool) projectDatums(sk *sketch.Sketch, part *compdef.PartComponentDefinition) {
+	for _, p := range t.workPoints {
+		sk.ProjectPoint(compdef.NewWorkPointRefSource(part, p.Point.Key()))
+	}
+	for _, a := range t.workAxes {
+		sk.ProjectCurve(compdef.NewWorkAxisRefSource(part, a.Axis.Key()))
+	}
+	for _, p := range t.workPlanes {
+		if !part.WorkPlaneIntersectsSketch(p.Plane.Key(), sk.Plane()) {
+			continue // a plane parallel to the sketch has no intersection line to project
+		}
+		sk.ProjectCurve(compdef.NewWorkPlaneRefSource(part, p.Plane.Key(), sk.Plane()))
+	}
 }
 
 // Cancel implements [Tool] (no model change to roll back before commit).

--- a/app/sketch_reference_tools_test.go
+++ b/app/sketch_reference_tools_test.go
@@ -52,8 +52,9 @@ func TestProjectGeometryToolEndToEnd(t *testing.T) {
 	}
 
 	sk := s.ActiveSketch()
-	if got := projectedCount(sk); got != 2 {
-		t.Fatalf("active sketch has %d projected entities, want 2", got)
+	// 3 = the auto-projected origin centre point (#1262) + the picked edge + the picked vertex.
+	if got := projectedCount(sk); got != 3 {
+		t.Fatalf("active sketch has %d projected entities, want 3 (origin + edge + vertex)", got)
 	}
 }
 

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -498,6 +498,7 @@ func sketchOverlays(s *app.Session, cam scene.Camera, list renderer.DrawList) (r
 		list.Items = append(gridOverlay(plane, g.SpacingModel(), g.MajorEvery), list.Items...)
 	}
 	list.Items = append(list.Items, onTop(sketchOverlay(s.ActiveSketch(), s.IsSelectedEntity, hoverCandidate(s)))...)
+	list.Items = append(list.Items, onTop(projectedCurveOverlay(s.ActiveSketch()))...)
 	dims := s.SketchDimensions()
 	list.Items = append(list.Items, onTop(dimensionLines(plane, dims))...)
 	if item, ok := pointsOverlay(plane, s.ActiveSketch(), pointMarkerPixels*cam.WorldPerPixel()); ok {

--- a/head/ui/projected_overlay_test.go
+++ b/head/ui/projected_overlay_test.go
@@ -1,0 +1,60 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// projectedSketch returns an XY sketch on a fresh part with the origin centre point and the YZ
+// origin plane projected into it (a reference point and a reference line, #1262).
+func projectedSketch(t *testing.T) *sketch.Sketch {
+	t.Helper()
+	s := app.NewSession()
+	pd, err := compdef.AddPart(s.Workspace(), "p.opd", true)
+	if err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	def := pd.Content().(*compdef.PartComponentDefinition)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	sk.ProjectPoint(compdef.NewWorkPointRefSource(def, feature.OriginCenter))
+	sk.ProjectCurve(compdef.NewWorkPlaneRefSource(def, feature.OriginYZPlane, sketch.XYPlane()))
+	return sk
+}
+
+// TestProjectedCurveOverlayDrawsReferenceLines: a projected curve becomes a drawn polyline.
+func TestProjectedCurveOverlayDrawsReferenceLines(t *testing.T) {
+	if got := projectedCurveOverlay(projectedSketch(t)); len(got) != 1 {
+		t.Fatalf("projectedCurveOverlay = %d items, want 1 (the projected reference line)", len(got))
+	}
+	if got := projectedCurveOverlay(nil); got != nil {
+		t.Errorf("projectedCurveOverlay(nil) = %v, want nil", got)
+	}
+}
+
+// TestProjectedCurveOverlayEmptyWhenNoProjection: a plain sketch projects no curves.
+func TestProjectedCurveOverlayEmptyWhenNoProjection(t *testing.T) {
+	s := app.NewSession()
+	pd, _ := compdef.AddPart(s.Workspace(), "q.opd", true)
+	sk := pd.Content().(*compdef.PartComponentDefinition).Sketches().Add(sketch.XYPlane())
+	if got := projectedCurveOverlay(sk); got != nil {
+		t.Errorf("projectedCurveOverlay of a curve-less sketch = %v, want nil", got)
+	}
+}
+
+// TestPointsOverlayIncludesProjectedPoint: the projected origin anchor is glyphed alongside
+// regular sketch points (so the auto-projected centre point is visible, #1262).
+func TestPointsOverlayIncludesProjectedPoint(t *testing.T) {
+	sk := projectedSketch(t)
+	item, ok := pointsOverlay(sk.Plane(), sk, 0.1)
+	if !ok || len(item.Positions) == 0 {
+		t.Fatal("pointsOverlay should glyph the projected origin point")
+	}
+}

--- a/head/ui/sketch_overlay.go
+++ b/head/ui/sketch_overlay.go
@@ -123,6 +123,7 @@ func partSketchOverlays(s *app.Session) []renderer.DrawItem {
 			continue
 		}
 		items = append(items, sketchOverlay(sk, allEntitiesWhenSelected(sk, selected), nil)...)
+		items = append(items, projectedCurveOverlay(sk)...)
 	}
 	return items
 }
@@ -176,6 +177,24 @@ func sketchOverlay(sk *sketch.Sketch, selected func(sketch.Entity) bool, candida
 	}
 	normal, sel, cand := sketchSegmentsFor(sk, selected, candidate)
 	return sketchItems(normal, sel, cand)
+}
+
+// projectedCurveOverlay draws a sketch's projected reference curves — the lines projected from
+// edges or datum geometry (axes, plane↔sketch intersections, #1262). They live in the entity
+// list rather than the typed Lines/Arcs collections, so sketchOverlay misses them; this draws
+// each as a polyline in the sketch colour. Returns nil when the sketch projects no curves.
+func projectedCurveOverlay(sk *sketch.Sketch) []renderer.DrawItem {
+	if sk == nil {
+		return nil
+	}
+	plane := sk.Plane()
+	acc := &segAccum{}
+	for _, e := range sk.Entities() {
+		if pc, ok := e.(*sketch.ProjectedCurve); ok {
+			acc.polyline(plane, pc.Points(), false)
+		}
+	}
+	return appendGrid(nil, acc, sketchColor)
 }
 
 func sketchSegmentsFor(sk *sketch.Sketch, selected func(sketch.Entity) bool, candidate sketch.Entity) (*segAccum, *segAccum, *segAccum) {

--- a/head/ui/snap_glyph.go
+++ b/head/ui/snap_glyph.go
@@ -62,6 +62,13 @@ func pointsOverlay(plane sketch.Plane, sk *sketch.Sketch, hWorld float64) (rende
 	for i := 0; i < pts.Count(); i++ {
 		acc.targetMarker(plane, pts.Item(i).Position(), hWorld)
 	}
+	// Projected point anchors (e.g. the auto-projected origin centre, #1262) live in the
+	// entity list, not the typed Points collection, so glyph them here too.
+	for _, e := range sk.Entities() {
+		if pp, ok := e.(*sketch.ProjectedPoint); ok {
+			acc.targetMarker(plane, pp.Position(), hWorld)
+		}
+	}
 	if len(acc.pos) == 0 {
 		return renderer.DrawItem{}, false
 	}

--- a/model/compdef/work_reference_source.go
+++ b/model/compdef/work_reference_source.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// Projecting the part's datum geometry — the origin centre point, the origin/user work axes
+// and planes — into a sketch needs associative handles like the B-rep edge/vertex sources
+// (reference_source.go), but resolved through the part's [feature.WorkGeometry] by
+// [feature.WorkRef] instead of by topology key. They re-resolve on every read so a moved
+// user datum re-projects, and report lost when the reference no longer resolves. They
+// structurally satisfy sketch.PointSource / sketch.CurveSource without this package importing
+// the sketch seam types (#1262).
+
+// referenceLineHalfSpan is the default half-length (model units) a projected work axis or
+// plane-intersection reference line extends from its anchor when the part carries no geometry
+// yet to size the line against (e.g. an origin axis on an empty part).
+const referenceLineHalfSpan = 10.0
+
+// WorkPointRefSource adapts a datum work point (by WorkRef) to a sketch point source: it
+// re-resolves the point through the part's work geometry and yields its position.
+type WorkPointRefSource struct {
+	ref  feature.WorkRef
+	work func() *feature.WorkGeometry
+}
+
+// NewWorkPointRefSource binds an associative point source to the datum point with reference
+// ref on part. The closure (not a bound value) is used so it always sees the current work
+// geometry.
+func NewWorkPointRefSource(part *PartComponentDefinition, ref feature.WorkRef) WorkPointRefSource {
+	return WorkPointRefSource{ref: ref, work: func() *feature.WorkGeometry { return part.WorkGeometry() }}
+}
+
+// SourceID returns the datum reference (its stable cross-recompute identity).
+func (s WorkPointRefSource) SourceID() string { return string(s.ref) }
+
+// Position re-resolves the datum point by reference; ok=false when it no longer resolves.
+func (s WorkPointRefSource) Position() (math.Point3, bool) {
+	w, ok := s.work().WorkPointByRef(s.ref)
+	if !ok {
+		return math.Point3{}, false
+	}
+	return w.Point(), true
+}
+
+// WorkAxisRefSource adapts a datum work axis (by WorkRef) to a sketch curve source: it
+// samples the axis as a segment centred on its origin, so projecting it (the orthogonal map
+// onto the sketch plane in ProjectCurve) yields the projected reference line — or a point
+// when the axis is perpendicular to the sketch plane, matching Inventor.
+type WorkAxisRefSource struct {
+	ref  feature.WorkRef
+	work func() *feature.WorkGeometry
+	span func() float64
+}
+
+// NewWorkAxisRefSource binds an associative curve source to the datum axis with reference ref.
+func NewWorkAxisRefSource(part *PartComponentDefinition, ref feature.WorkRef) WorkAxisRefSource {
+	return WorkAxisRefSource{
+		ref:  ref,
+		work: func() *feature.WorkGeometry { return part.WorkGeometry() },
+		span: part.referenceLineHalfSpan,
+	}
+}
+
+// SourceID returns the datum axis reference.
+func (s WorkAxisRefSource) SourceID() string { return string(s.ref) }
+
+// SamplePoints re-resolves the axis and returns its two endpoints at ±span from the origin;
+// ok=false when the axis no longer resolves.
+func (s WorkAxisRefSource) SamplePoints() ([]math.Point3, bool) {
+	a, ok := s.work().AxisByRef(s.ref)
+	if !ok {
+		return nil, false
+	}
+	step := a.Direction().AsVector().Scale(s.span())
+	return []math.Point3{a.Origin().TranslateBy(step.Scale(-1)), a.Origin().TranslateBy(step)}, true
+}
+
+// WorkPlaneRefSource adapts a datum work plane (by WorkRef) to a sketch curve source: it
+// returns the line where the work plane meets the target sketch plane — Inventor projects a
+// work plane as that intersection line. ok=false when the planes are parallel (no line) or
+// the reference is lost. The target sketch plane is fixed at construction, matching how a
+// projected curve binds to one sketch plane (model/sketch projection.go).
+type WorkPlaneRefSource struct {
+	ref    feature.WorkRef
+	target sketch.Plane
+	work   func() *feature.WorkGeometry
+	span   func() float64
+}
+
+// NewWorkPlaneRefSource binds an associative curve source to the datum plane with reference
+// ref, projected onto the target sketch plane.
+func NewWorkPlaneRefSource(part *PartComponentDefinition, ref feature.WorkRef, target sketch.Plane) WorkPlaneRefSource {
+	return WorkPlaneRefSource{
+		ref:    ref,
+		target: target,
+		work:   func() *feature.WorkGeometry { return part.WorkGeometry() },
+		span:   part.referenceLineHalfSpan,
+	}
+}
+
+// SourceID returns the datum plane reference.
+func (s WorkPlaneRefSource) SourceID() string { return string(s.ref) }
+
+// SamplePoints re-resolves the work plane and returns the two endpoints of its intersection
+// line with the target sketch plane, at ±span from the line's anchor point; ok=false when
+// the planes are parallel or the reference is lost.
+func (s WorkPlaneRefSource) SamplePoints() ([]math.Point3, bool) {
+	wp, err := s.work().WorkPlaneByRef(s.ref)
+	if err != nil {
+		return nil, false
+	}
+	at, dir, err := feature.PlaneIntersectionLine(wp.Plane(), s.target)
+	if err != nil {
+		return nil, false
+	}
+	step := dir.AsVector().Scale(s.span())
+	return []math.Point3{at.TranslateBy(step.Scale(-1)), at.TranslateBy(step)}, true
+}
+
+// referenceLineHalfSpan sizes a projected work-axis / plane-intersection reference line: half
+// the model range-box diagonal when the part has geometry, else the default span so an origin
+// datum on an empty part still projects a visible line.
+func (d *PartComponentDefinition) referenceLineHalfSpan() float64 {
+	box := d.RangeBox()
+	if box.IsEmpty() {
+		return referenceLineHalfSpan
+	}
+	if half := box.Diagonal().Length() / 2; half > referenceLineHalfSpan {
+		return half
+	}
+	return referenceLineHalfSpan
+}
+
+// WorkPlaneIntersectsSketch reports whether the datum plane ref meets the target sketch plane
+// in a line — false when they are parallel (no reference line to project). Callers probe this
+// before projecting a work plane so a parallel pick is skipped rather than producing a dead,
+// geometry-less reference curve (#1262).
+func (d *PartComponentDefinition) WorkPlaneIntersectsSketch(ref feature.WorkRef, target sketch.Plane) bool {
+	_, ok := NewWorkPlaneRefSource(d, ref, target).SamplePoints()
+	return ok
+}
+
+// WorkPointKeyResolves / WorkAxisKeyResolves / WorkPlaneKeyResolves report whether a WorkRef
+// currently binds to a datum point/axis/plane — the router uses them to classify a projected
+// reference (mirroring EdgeKeyResolves for B-rep references).
+func (d *PartComponentDefinition) WorkPointKeyResolves(ref string) bool {
+	_, ok := d.work.WorkPointByRef(feature.WorkRef(ref))
+	return ok
+}
+
+// WorkAxisKeyResolves reports whether a WorkRef currently binds to a datum axis.
+func (d *PartComponentDefinition) WorkAxisKeyResolves(ref string) bool {
+	_, ok := d.work.AxisByRef(feature.WorkRef(ref))
+	return ok
+}
+
+// WorkPlaneKeyResolves reports whether a WorkRef currently binds to a datum plane.
+func (d *PartComponentDefinition) WorkPlaneKeyResolves(ref string) bool {
+	_, err := d.work.WorkPlaneByRef(feature.WorkRef(ref))
+	return err == nil
+}

--- a/model/compdef/work_reference_source_test.go
+++ b/model/compdef/work_reference_source_test.go
@@ -5,6 +5,7 @@ package compdef
 import (
 	"testing"
 
+	"oblikovati.org/kernel/ops"
 	"oblikovati.org/math"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/sketch"
@@ -99,6 +100,85 @@ func TestWorkKeyResolvesClassifiesDatums(t *testing.T) {
 	}
 	if d.WorkPointKeyResolves("not-a-datum") {
 		t.Error("a non-datum reference must not resolve as a work point")
+	}
+}
+
+// TestWorkAxisAndPlaneSourceID: the axis/plane sources report their datum reference.
+func TestWorkAxisAndPlaneSourceID(t *testing.T) {
+	d := NewPartComponentDefinition()
+	if got := NewWorkAxisRefSource(d, feature.OriginXAxis).SourceID(); got != string(feature.OriginXAxis) {
+		t.Errorf("axis SourceID = %q, want %q", got, feature.OriginXAxis)
+	}
+	if got := NewWorkPlaneRefSource(d, feature.OriginXZPlane, sketch.XYPlane()).SourceID(); got != string(feature.OriginXZPlane) {
+		t.Errorf("plane SourceID = %q, want %q", got, feature.OriginXZPlane)
+	}
+}
+
+// TestWorkAxisRefSourceLostReference / TestWorkPlaneRefSourceLostReference: an unknown datum
+// reference reports lost rather than panicking.
+func TestWorkAxisRefSourceLostReference(t *testing.T) {
+	d := NewPartComponentDefinition()
+	if _, ok := NewWorkAxisRefSource(d, "origin/axis/bogus").SamplePoints(); ok {
+		t.Error("unknown datum axis should report ok=false")
+	}
+}
+
+func TestWorkPlaneRefSourceLostReference(t *testing.T) {
+	d := NewPartComponentDefinition()
+	if _, ok := NewWorkPlaneRefSource(d, "origin/plane/bogus", sketch.XYPlane()).SamplePoints(); ok {
+		t.Error("unknown datum plane should report ok=false")
+	}
+}
+
+// TestWorkPlaneIntersectsSketch: the viability probe is true for a meeting plane, false for a
+// parallel one.
+func TestWorkPlaneIntersectsSketch(t *testing.T) {
+	d := NewPartComponentDefinition()
+	if !d.WorkPlaneIntersectsSketch(feature.OriginXZPlane, sketch.XYPlane()) {
+		t.Error("XZ plane should meet the XY sketch in a line")
+	}
+	if d.WorkPlaneIntersectsSketch(feature.OriginXYPlane, sketch.XYPlane()) {
+		t.Error("XY plane is parallel to the XY sketch — no intersection line")
+	}
+}
+
+// TestReferenceLineHalfSpanScalesWithModel: a large body grows the reference-line span beyond
+// the empty-part default (half the model range-box diagonal).
+func TestReferenceLineHalfSpanScalesWithModel(t *testing.T) {
+	d := NewPartComponentDefinition()
+	sk := d.Sketches().Add(sketch.XYPlane())
+	c0 := sk.Points().Add(math.P2(0, 0))
+	c1 := sk.Points().Add(math.P2(100, 0))
+	c2 := sk.Points().Add(math.P2(100, 100))
+	c3 := sk.Points().Add(math.P2(0, 100))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+	feature.NewExtrudeFeatures(d.Features()).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 100 })
+	d.Recompute()
+	if got := d.referenceLineHalfSpan(); got <= referenceLineHalfSpan {
+		t.Errorf("large-model span = %v, want > default %v", got, referenceLineHalfSpan)
+	}
+}
+
+// TestReferenceLineHalfSpanSmallModelKeepsDefault: a tiny body (half-diagonal below the
+// default) keeps the default span so the reference line stays visible.
+func TestReferenceLineHalfSpanSmallModelKeepsDefault(t *testing.T) {
+	d := NewPartComponentDefinition()
+	sk := d.Sketches().Add(sketch.XYPlane())
+	c0 := sk.Points().Add(math.P2(0, 0))
+	c1 := sk.Points().Add(math.P2(1, 0))
+	c2 := sk.Points().Add(math.P2(1, 1))
+	c3 := sk.Points().Add(math.P2(0, 1))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+	feature.NewExtrudeFeatures(d.Features()).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 1 })
+	d.Recompute()
+	if got := d.referenceLineHalfSpan(); got != referenceLineHalfSpan {
+		t.Errorf("small-model span = %v, want default %v", got, referenceLineHalfSpan)
 	}
 }
 

--- a/model/compdef/work_reference_source_test.go
+++ b/model/compdef/work_reference_source_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+const refEps = 1e-9
+
+// TestWorkPointRefSourceResolvesOriginCenter: the origin centre point projects to (0,0,0).
+func TestWorkPointRefSourceResolvesOriginCenter(t *testing.T) {
+	d := NewPartComponentDefinition()
+	src := NewWorkPointRefSource(d, feature.OriginCenter)
+	if src.SourceID() != string(feature.OriginCenter) {
+		t.Errorf("SourceID = %q, want %q", src.SourceID(), feature.OriginCenter)
+	}
+	pos, ok := src.Position()
+	if !ok {
+		t.Fatal("origin centre point should resolve")
+	}
+	if !pos.IsEqualTo(math.P3(0, 0, 0), refEps) {
+		t.Errorf("origin centre = %v, want (0,0,0)", pos)
+	}
+}
+
+// TestWorkPointRefSourceLostReference: an unknown datum reference reports lost, not a panic.
+func TestWorkPointRefSourceLostReference(t *testing.T) {
+	d := NewPartComponentDefinition()
+	if _, ok := NewWorkPointRefSource(d, "origin/point/bogus").Position(); ok {
+		t.Error("unknown datum point should report ok=false")
+	}
+}
+
+// TestWorkAxisRefSourceSamplesAlongAxis: the origin X axis samples a segment centred on the
+// origin and directed along +X, sized by the default half-span on an empty part.
+func TestWorkAxisRefSourceSamplesAlongAxis(t *testing.T) {
+	d := NewPartComponentDefinition()
+	pts, ok := NewWorkAxisRefSource(d, feature.OriginXAxis).SamplePoints()
+	if !ok || len(pts) != 2 {
+		t.Fatalf("X axis sample = %v (ok=%v), want two endpoints", pts, ok)
+	}
+	wantLo, wantHi := math.P3(-referenceLineHalfSpan, 0, 0), math.P3(referenceLineHalfSpan, 0, 0)
+	if !pts[0].IsEqualTo(wantLo, refEps) || !pts[1].IsEqualTo(wantHi, refEps) {
+		t.Errorf("X axis endpoints = %v..%v, want %v..%v", pts[0], pts[1], wantLo, wantHi)
+	}
+}
+
+// TestWorkPlaneRefSourceIntersectsSketchPlane: projecting the origin XZ plane onto an XY sketch
+// yields the X axis line (the planes meet along y=0, z=0).
+func TestWorkPlaneRefSourceIntersectsSketchPlane(t *testing.T) {
+	d := NewPartComponentDefinition()
+	pts, ok := NewWorkPlaneRefSource(d, feature.OriginXZPlane, sketch.XYPlane()).SamplePoints()
+	if !ok || len(pts) != 2 {
+		t.Fatalf("XZ∩XY sample = %v (ok=%v), want two endpoints", pts, ok)
+	}
+	for _, p := range pts {
+		if !math.IsNearZero(p.Y, refEps) || !math.IsNearZero(p.Z, refEps) {
+			t.Errorf("intersection point %v not on the X axis (y=z=0)", p)
+		}
+	}
+	if math.IsNearZero(p2pSpanX(pts), refEps) {
+		t.Error("intersection line has no extent along X")
+	}
+}
+
+// TestWorkPlaneRefSourceParallelHasNoLine: an XY work plane projected onto an XY sketch is
+// parallel — there is no intersection line, so the source reports lost.
+func TestWorkPlaneRefSourceParallelHasNoLine(t *testing.T) {
+	d := NewPartComponentDefinition()
+	if _, ok := NewWorkPlaneRefSource(d, feature.OriginXYPlane, sketch.XYPlane()).SamplePoints(); ok {
+		t.Error("parallel planes should report ok=false (no intersection line)")
+	}
+}
+
+// TestReferenceLineHalfSpanDefaultsOnEmptyPart: with no geometry the span is the default.
+func TestReferenceLineHalfSpanDefaultsOnEmptyPart(t *testing.T) {
+	if got := NewPartComponentDefinition().referenceLineHalfSpan(); got != referenceLineHalfSpan {
+		t.Errorf("empty-part span = %v, want %v", got, referenceLineHalfSpan)
+	}
+}
+
+// TestWorkKeyResolvesClassifiesDatums: the resolves helpers classify each origin reference and
+// reject a B-rep-style key.
+func TestWorkKeyResolvesClassifiesDatums(t *testing.T) {
+	d := NewPartComponentDefinition()
+	if !d.WorkPointKeyResolves(string(feature.OriginCenter)) {
+		t.Error("origin centre should resolve as a work point")
+	}
+	if !d.WorkAxisKeyResolves(string(feature.OriginXAxis)) {
+		t.Error("origin X axis should resolve as a work axis")
+	}
+	if !d.WorkPlaneKeyResolves(string(feature.OriginXYPlane)) {
+		t.Error("origin XY plane should resolve as a work plane")
+	}
+	if d.WorkPointKeyResolves("not-a-datum") {
+		t.Error("a non-datum reference must not resolve as a work point")
+	}
+}
+
+func p2pSpanX(pts []math.Point3) float64 { return pts[1].X - pts[0].X }

--- a/model/feature/work_axis_point.go
+++ b/model/feature/work_axis_point.go
@@ -291,6 +291,14 @@ func (c *WorkPoints) Item(i int) *WorkPoint { return c.items[i] }
 
 // planeIntersectionLine returns a point on, and the direction of, the line where two
 // planes meet (error if they are parallel).
+// PlaneIntersectionLine returns a point on, and the unit direction of, the line where two
+// planes meet; it errors when the planes are parallel (no line). Exported so projecting a
+// work plane onto a sketch (model/compdef) reuses the same intersection math rather than
+// re-deriving it (#1262).
+func PlaneIntersectionLine(p1, p2 sketch.Plane) (math.Point3, math.UnitVector3, error) {
+	return planeIntersectionLine(p1, p2)
+}
+
 func planeIntersectionLine(p1, p2 sketch.Plane) (math.Point3, math.UnitVector3, error) {
 	n1, n2 := p1.Normal().AsVector(), p2.Normal().AsVector()
 	cross := n1.Cross(n2)

--- a/model/feature/work_geometry.go
+++ b/model/feature/work_geometry.go
@@ -203,6 +203,21 @@ func (g *WorkGeometry) AxisByRef(ref WorkRef) (*WorkAxis, bool) {
 	return a, true
 }
 
+// WorkPointByRef returns the datum work point with the given reference (e.g. [OriginCenter]),
+// or false when none exists — the exported lookup projecting the origin centre point into a
+// sketch uses (#1262). It resolves only datum points (origin frame + user work points), not
+// B-rep vertex references.
+func (g *WorkGeometry) WorkPointByRef(ref WorkRef) (*WorkPoint, bool) {
+	if i, ok := userIndex(ref, "point"); ok {
+		if i < 0 || i >= g.points.Count() {
+			return nil, false
+		}
+		return g.points.Item(i), true
+	}
+	w, ok := g.points.byKey[ref]
+	return w, ok
+}
+
 func (g *WorkGeometry) point(ref WorkRef) (math.Point3, error) {
 	if p, isVertex, err := g.vertexPoint(ref); isVertex {
 		return p, err

--- a/model/feature/work_reference_export_test.go
+++ b/model/feature/work_reference_export_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// TestPlaneIntersectionLineExported: the exported helper returns the meeting line of two planes
+// and errors when they are parallel (#1262).
+func TestPlaneIntersectionLineExported(t *testing.T) {
+	at, dir, err := PlaneIntersectionLine(sketch.XZPlane(), sketch.XYPlane())
+	if err != nil {
+		t.Fatalf("XZ∩XY: %v", err)
+	}
+	// The XZ and XY planes meet along the X axis: every point has y=z=0 and the direction is ±X.
+	if !math.IsNearZero(at.Y, 1e-9) || !math.IsNearZero(at.Z, 1e-9) {
+		t.Errorf("intersection anchor %v not on the X axis", at)
+	}
+	if d := dir.AsVector(); math.IsNearZero(d.X, 1e-9) {
+		t.Errorf("intersection direction %v not along X", d)
+	}
+	if _, _, err := PlaneIntersectionLine(sketch.XYPlane(), sketch.XYPlane()); err == nil {
+		t.Error("parallel planes should error (no intersection line)")
+	}
+}
+
+// TestWorkPointByRef: the exported lookup resolves the origin centre and user work points, and
+// reports false for an unknown reference.
+func TestWorkPointByRef(t *testing.T) {
+	g := NewWorkGeometry()
+	if w, ok := g.WorkPointByRef(OriginCenter); !ok || w.Name() != "Center Point" {
+		t.Fatalf("WorkPointByRef(OriginCenter) = %v, ok=%v; want the Center Point", w, ok)
+	}
+	if _, ok := g.WorkPointByRef("origin/point/bogus"); ok {
+		t.Error("an unknown datum reference should report ok=false")
+	}
+
+	// A user work point resolves by its "point/N" reference; an out-of-range index reports false.
+	up := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(1, 2, 3) })
+	if w, ok := g.WorkPointByRef(up.Key()); !ok || w != up {
+		t.Errorf("WorkPointByRef(%q) = %v, ok=%v; want the user point", up.Key(), w, ok)
+	}
+	if _, ok := g.WorkPointByRef("point/999"); ok {
+		t.Error("an out-of-range user point index should report ok=false")
+	}
+}


### PR DESCRIPTION
Fixes #1262.

## What

Two user-reported gaps, both fixed:

1. **New sketches now auto-project the origin centre point** at (0,0) — the Inventor default. Creating a sketch (Create 2D Sketch) projects [`feature.OriginCenter`] as an associative reference point.
2. **Project Geometry now accepts the part's datum geometry** — the origin centre point, the origin/work **axes** and **planes** — picked in the viewport *or* clicked in the browser tree, not just B-rep edges/vertices.
   - a datum **point** → reference point
   - a work **axis** → reference line (the axis projected onto the sketch)
   - a work **plane** → its **intersection line** with the sketch (skipped when parallel — no line to draw)

The same datum references work over the wire (`sketch.project`) using the existing public `WorkRef` vocabulary (e.g. `"origin/point/center"`), so automation/MCP projects them the same way — no API change.

### Bonus fix: projected geometry was invisible

Projected reference entities live in the sketch's entity list, not the typed point/line collections, so the viewport overlay never drew them — the existing Project Geometry feature created geometry you couldn't see. Now projected point anchors render as target glyphs and projected curves as polylines, both while editing and on finished sketches.

## How

- **`model/compdef/work_reference_source.go`** (new) — `WorkPointRefSource` / `WorkAxisRefSource` / `WorkPlaneRefSource` resolve a `WorkRef` through the part's `WorkGeometry` (associative, re-resolved each read), satisfying `sketch.PointSource`/`CurveSource`. Plus `*KeyResolves` classifiers and `WorkPlaneIntersectsSketch` viability check. Reference-line span scales with the model range box (default when empty).
- **`model/feature`** — export `PlaneIntersectionLine` (reused for plane↔sketch projection) and add `WorkGeometry.WorkPointByRef`.
- **`app/sketch_project_tool.go`** — accept `SelectWorkPoint/Axis/Plane`, project each on commit. Browser→tool picking already worked via `SelectBrowserNode`→`feedPick`.
- **`app/sketch_env.go`** — `CreateSketch` auto-projects the origin centre (part hosts only).
- **`addin/router/sketch_project.go`** — `projectRef` also resolves datum `WorkRef`s.
- **`head/ui`** — render projected curves (`projectedCurveOverlay`) and projected point anchors (extended `pointsOverlay`), in the in-sketch overlay and on finished sketches.

## Tests

- `model/compdef` — datum source resolution (origin centre/axis/plane), parallel-plane → no line, lost reference, span default, key classifiers.
- `app` — `CreateSketch` auto-projects the origin at (0,0); Project Geometry tool projects datum point + axis + plane.
- `addin/router` — `sketch.project` over the wire projects datum refs (1 point + 2 curves) and reports a parallel plane unhealthy.
- `head/ui` — projected curves/points render (and nil/empty cases).

## Verification

`go build ./...`, full `app` / `model` / `addin` / `kernel` / `head/ui` suites pass; `gofmt` + `golangci-lint` clean on touched files.

**Live-confirmed** (offscreen Vulkan): a fresh XY sketch shows the projected origin centre as a target marker at (0,0), and projecting the YZ origin plane draws its intersection reference line through the origin.

## Known follow-up (pre-existing, not this issue)

Projected geometry is recomputed associatively but not yet persisted to `.obk` (true for *all* projections today), so projected entities — including the auto-projected origin — are reconstructed in-session rather than reloaded. Persisting projection sources is a separate, already-known tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)