### PR TITLE
Browser: per-feature icons + in-place feature rename (#1264)

### DIFF
--- a/app/browser.go
+++ b/app/browser.go
@@ -25,8 +25,11 @@ import (
 // clickable: selecting it puts that handle in the session's selection set (so e.g.
 // clicking "XY Plane" selects the plane to sketch on).
 type BrowserNode struct {
-	Label    string
-	Kind     string // "document" | "origin" | "workplane" | "workaxis" | "workpoint" | "parameters" | "parameter" | "bodies" | "body" | "sketch" | "sketch3d" | "feature" | "occurrence" | "features" | "assemblyFeature"
+	Label string
+	Kind  string // "document" | "origin" | "workplane" | "workaxis" | "workpoint" | "parameters" | "parameter" | "bodies" | "body" | "sketch" | "sketch3d" | "feature" | "occurrence" | "features" | "assemblyFeature"
+	// Icon is the head's icon-asset key drawn before the label (e.g. "extrude", "fillet"), so a
+	// feature reads by glyph, not just by name. Empty means no icon (the head draws label only).
+	Icon     string
 	Select   Selectable
 	Children []BrowserNode
 }
@@ -37,10 +40,12 @@ func (n *BrowserNode) child(label, kind string) *BrowserNode {
 	return &n.Children[len(n.Children)-1]
 }
 
-// selectableChild appends a child whose click selects sel.
-func (n *BrowserNode) selectableChild(label, kind string, sel Selectable) {
+// selectableChild appends a child whose click selects sel, returning it so a caller can set
+// an icon (the return value is ignored by callers that don't need one).
+func (n *BrowserNode) selectableChild(label, kind string, sel Selectable) *BrowserNode {
 	c := n.child(label, kind)
 	c.Select = sel
+	return c
 }
 
 // selectableBranch appends a child that is BOTH selectable and a parent (a feature row that
@@ -372,7 +377,7 @@ func appendTopLevelSketchEntries(entries []timelineEntry, part *compdef.PartComp
 			continue
 		}
 		entries = append(entries, timelineEntry{sk.Seq(), func(root *BrowserNode) {
-			root.selectableChild(sk.Name(), "sketch", SketchHandle{Sketch: sk})
+			root.selectableChild(sk.Name(), "sketch", SketchHandle{Sketch: sk}).Icon = "create-sketch"
 		}})
 	}
 	return entries
@@ -386,7 +391,7 @@ func appendSketch3DEntries(entries []timelineEntry, part *compdef.PartComponentD
 	for i := 0; i < sketches.Count(); i++ {
 		sk := sketches.Item(i)
 		entries = append(entries, timelineEntry{sk.Seq(), func(root *BrowserNode) {
-			root.selectableChild(sk.Name(), "sketch3d", Sketch3DHandle{Sketch3D: sk})
+			root.selectableChild(sk.Name(), "sketch3d", Sketch3DHandle{Sketch3D: sk}).Icon = "create-sketch-3d"
 		}})
 	}
 	return entries
@@ -400,14 +405,38 @@ func appendFeatureEntries(entries []timelineEntry, part *compdef.PartComponentDe
 		f := features.Item(i)
 		entries = append(entries, timelineEntry{f.Seq(), func(root *BrowserNode) {
 			node := root.selectableBranch(featureLabel(f), "feature", FeatureHandle{Feature: f})
+			node.Icon = featureIcon(f.Kind())
 			for _, sk := range f.ConsumedSketches() {
 				if absorber[sk] == f {
-					node.selectableChild(sk.Name(), "sketch", SketchHandle{Sketch: sk})
+					node.selectableChild(sk.Name(), "sketch", SketchHandle{Sketch: sk}).Icon = "create-sketch"
 				}
 			}
 		}})
 	}
 	return entries
+}
+
+// featureIconByKind maps a feature's Kind() to the head icon-asset key drawn before its
+// browser label, so the feature reads by glyph not just by name. Kinds that share a glyph
+// (the fillet/pattern families) collapse onto one asset; a kind with no dedicated asset is
+// absent and falls through to featureIcon's default.
+var featureIconByKind = map[string]string{
+	"extrude": "extrude", "revolve": "revolve", "sweep": "sweep", "loft": "loft",
+	"coil": "coil", "emboss": "emboss", "rib": "rib", "thicken": "thicken",
+	"hole": "hole", "boss": "boss", "thread": "thread", "combine": "combine",
+	"fillet": "fillet", "face-fillet": "fillet", "full-round-fillet": "fillet", "rule-fillet": "fillet",
+	"chamfer": "chamfer", "shell": "shell", "draft": "draft",
+	"mirror": "mirror", "move": "move", "decal": "decal", "directEdit": "direct-edit",
+	"split": "split", "derived": "derive", "derivedAssembly": "derive",
+}
+
+// featureIcon returns the icon-asset key for a feature kind, defaulting to a generic
+// "extrude" glyph for an unmapped kind so every feature row still carries an icon (#1264).
+func featureIcon(kind string) string {
+	if key, ok := featureIconByKind[kind]; ok {
+		return key
+	}
+	return "extrude"
 }
 
 // featureLabel is a feature's browser label, with an "(out of date)" badge when it is a

--- a/app/browser_feature_icon_test.go
+++ b/app/browser_feature_icon_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// TestFeatureIconMapsKinds: known kinds map to their glyph, fillet variants collapse onto one,
+// and an unknown kind falls back to the default so every feature row still carries an icon.
+func TestFeatureIconMapsKinds(t *testing.T) {
+	cases := map[string]string{
+		"extrude": "extrude", "revolve": "revolve", "hole": "hole",
+		"face-fillet": "fillet", "rule-fillet": "fillet", "chamfer": "chamfer",
+	}
+	for kind, want := range cases {
+		if got := featureIcon(kind); got != want {
+			t.Errorf("featureIcon(%q) = %q, want %q", kind, got, want)
+		}
+	}
+	if got := featureIcon("totally-unknown-kind"); got == "" {
+		t.Error("an unmapped kind should still get a default icon, got empty")
+	}
+}
+
+// TestBrowserFeatureNodeCarriesIcon: a feature in the history gets its glyph key on the browser
+// node so the head can draw it (#1264).
+func TestBrowserFeatureNodeCarriesIcon(t *testing.T) {
+	s, def := emptyPartSession(t)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	c0 := sk.Points().Add(math.P2(0, 0))
+	c1 := sk.Points().Add(math.P2(2, 0))
+	c2 := sk.Points().Add(math.P2(2, 2))
+	c3 := sk.Points().Add(math.P2(0, 2))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+	feature.NewExtrudeFeatures(def.Features()).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 3 })
+	def.Recompute()
+
+	node := findBrowserNode(BuildBrowser(s), "feature", "Extrusion1")
+	if node == nil {
+		t.Fatal("no Extrusion1 feature node in the browser tree")
+	}
+	if node.Icon != "extrude" {
+		t.Errorf("extrude feature node Icon = %q, want %q", node.Icon, "extrude")
+	}
+}

--- a/head/ui/browser_node_decor.go
+++ b/head/ui/browser_node_decor.go
@@ -1,0 +1,106 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"fmt"
+	"os"
+
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// Browser-row decoration: the per-feature-type icon drawn before a node's label, and the
+// in-place rename of a feature node. Both live here so browser_view.go stays focused on the
+// tree structure (#1264).
+
+// browserIconPx is the browser-row icon size in pixels (matches a tree row's text height).
+const browserIconPx = 16
+
+// drawNodeIcon draws the node's icon glyph followed by SameLine, so the label that the caller
+// renders next sits to its right. A node with no icon, or a glyph that fails to rasterize, draws
+// nothing (the label still renders) so the tree degrades gracefully.
+func drawNodeIcon(n app.BrowserNode) {
+	if n.Icon == "" || icons == nil {
+		return
+	}
+	tex, ok := icons.texture(n.Icon, "", browserIconPx)
+	if !ok {
+		return
+	}
+	native.Image(tex, browserIconPx, browserIconPx)
+	native.SameLine()
+}
+
+// browserRename holds the in-place feature rename: the node being edited (nil when none), the
+// edit buffer, and a one-frame flag to grab keyboard focus when the field first appears.
+type browserRenameState struct {
+	target app.Selectable
+	buf    [128]byte
+	focus  bool
+}
+
+var browserRename browserRenameState
+
+// beginRename opens the in-place editor for a feature node, seeding the buffer with its current
+// name and requesting focus on the next frame.
+func beginRename(n app.BrowserNode) {
+	browserRename.target = n.Select
+	browserRename.focus = true
+	setBuf(browserRename.buf[:], featureNodeName(n))
+}
+
+// renaming reports whether n is the node currently being renamed in place.
+func renaming(n app.BrowserNode) bool {
+	return browserRename.target != nil && browserRename.target == n.Select
+}
+
+// drawRenameField draws the in-place rename input for n in place of its label. Enter (or a
+// committed focus-loss) applies the new name via app.Session.RenameFeature — which enforces a
+// non-empty, document-unique name and keeps the stable id; Escape or an unedited focus-loss
+// cancels. A rejected name (empty/duplicate) is logged and the edit is dropped.
+func drawRenameField(s *app.Session, n app.BrowserNode) {
+	first := browserRename.focus
+	if first {
+		native.SetKeyboardFocusHere()
+		browserRename.focus = false
+	}
+	native.SetNextItemWidth(-1)
+	enter := native.InputTextSubmit("##rename", browserRename.buf[:])
+	switch {
+	case enter || native.IsItemDeactivatedAfterEdit():
+		applyRename(s, n)
+	case !first && !native.IsItemActive():
+		browserRename.target = nil // Escape or click-away with no committed edit: cancel
+	}
+}
+
+// applyRename commits the buffer to the feature behind n, then closes the editor.
+func applyRename(s *app.Session, n app.BrowserNode) {
+	if h, ok := n.Select.(app.FeatureHandle); ok {
+		if name := bufString(browserRename.buf[:]); name != "" {
+			if err := s.RenameFeature(h.Feature, name); err != nil {
+				fmt.Fprintf(os.Stderr, "rename feature: %v\n", err)
+			}
+		}
+	}
+	browserRename.target = nil
+}
+
+// featureNodeName returns the editable feature name for a node — its handle's current name,
+// falling back to the label (the label may carry a status badge, so prefer the raw name).
+func featureNodeName(n app.BrowserNode) string {
+	if h, ok := n.Select.(app.FeatureHandle); ok {
+		return h.Feature.Name()
+	}
+	return n.Label
+}
+
+// isRenameableFeature reports whether n is a feature node (the only node kind the in-place
+// rename currently targets — its backend enforces document-unique names, #1264).
+func isRenameableFeature(n app.BrowserNode) bool {
+	_, ok := n.Select.(app.FeatureHandle)
+	return ok
+}

--- a/head/ui/browser_node_decor_test.go
+++ b/head/ui/browser_node_decor_test.go
@@ -1,0 +1,132 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// featurePartSession returns a session whose active part has two extrude features, plus the
+// browser node for the first ("Extrusion1") — the fixture for the in-place rename.
+func featurePartSession(t *testing.T) (*app.Session, app.BrowserNode) {
+	t.Helper()
+	s := app.NewSession()
+	pd, err := compdef.AddPart(s.Workspace(), "p.opd", true)
+	if err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	def := pd.Content().(*compdef.PartComponentDefinition)
+	addBox(def, 0)
+	addBox(def, 6)
+	def.Recompute()
+	f, ok := def.Features().ByName("Extrusion1")
+	if !ok {
+		t.Fatal("expected an Extrusion1 feature")
+	}
+	return s, app.BrowserNode{Label: "Extrusion1", Kind: "feature", Select: app.FeatureHandle{Feature: f}}
+}
+
+func addBox(def *compdef.PartComponentDefinition, x float64) {
+	sk := def.Sketches().Add(sketch.XYPlane())
+	c0 := sk.Points().Add(math.P2(x, 0))
+	c1 := sk.Points().Add(math.P2(x+2, 0))
+	c2 := sk.Points().Add(math.P2(x+2, 2))
+	c3 := sk.Points().Add(math.P2(x, 2))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+	feature.NewExtrudeFeatures(def.Features()).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 3 })
+}
+
+func TestRenameStateHelpers(t *testing.T) {
+	_, n := featurePartSession(t)
+	browserRename = browserRenameState{} // reset
+	if renaming(n) {
+		t.Error("nothing should be renaming initially")
+	}
+	if !isRenameableFeature(n) {
+		t.Error("a feature node should be renameable")
+	}
+	if got := featureNodeName(n); got != "Extrusion1" {
+		t.Errorf("featureNodeName = %q, want Extrusion1", got)
+	}
+	beginRename(n)
+	if !renaming(n) {
+		t.Error("beginRename should mark the node as renaming")
+	}
+	if got := bufString(browserRename.buf[:]); got != "Extrusion1" {
+		t.Errorf("rename buffer seeded with %q, want Extrusion1", got)
+	}
+}
+
+// TestApplyRenameCommits: applyRename renames the feature (stable id) and closes the editor.
+func TestApplyRenameCommits(t *testing.T) {
+	s, n := featurePartSession(t)
+	beginRename(n)
+	setBuf(browserRename.buf[:], "Mounting Boss")
+	applyRename(s, n)
+	if browserRename.target != nil {
+		t.Error("applyRename should close the editor")
+	}
+	if got := n.Select.(app.FeatureHandle).Feature.Name(); got != "Mounting Boss" {
+		t.Errorf("feature name = %q, want Mounting Boss", got)
+	}
+}
+
+// TestApplyRenameRejectsDuplicate: a name already used by another feature is rejected by the
+// backend and the original name is kept (the document-unique invariant, #1264).
+func TestApplyRenameRejectsDuplicate(t *testing.T) {
+	s, n := featurePartSession(t)
+	beginRename(n)
+	setBuf(browserRename.buf[:], "Extrusion2") // already taken by the second feature
+	applyRename(s, n)
+	if got := n.Select.(app.FeatureHandle).Feature.Name(); got != "Extrusion1" {
+		t.Errorf("duplicate rename should be rejected; name = %q, want Extrusion1", got)
+	}
+}
+
+// TestIsRenameableFeatureRejectsNonFeature: a non-feature node is not renameable.
+func TestIsRenameableFeatureRejectsNonFeature(t *testing.T) {
+	n := app.BrowserNode{Label: "Solid Bodies", Kind: "bodies"}
+	if isRenameableFeature(n) {
+		t.Error("a non-feature node must not be renameable")
+	}
+	if got := featureNodeName(n); got != "Solid Bodies" {
+		t.Errorf("featureNodeName of a non-feature node = %q, want its label", got)
+	}
+}
+
+// TestInWindowBrowserDrawsIconAndRenameField renders the real browser: first the feature row
+// (covering the per-feature icon draw), then the same row with the in-place rename editor open
+// (covering the rename input). Skips cleanly without a Vulkan device.
+func TestInWindowBrowserDrawsIconAndRenameField(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false // rebuild the default layout for this fresh window/context
+	icons = nil         // rebind the icon cache to this fresh window
+	browserRename = browserRenameState{}
+	s, n := featurePartSession(t)
+
+	frame := func() {
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.1)
+	}
+	frame()
+	frame() // settle the dock layout and draw the browser with feature icons
+
+	beginRename(n) // open the in-place editor; next frames draw the rename input
+	frame()
+	frame()
+	browserRename = browserRenameState{} // leave globals clean for other tests
+}

--- a/head/ui/browser_view.go
+++ b/head/ui/browser_view.go
@@ -256,7 +256,12 @@ func drawNode(s *app.Session, n app.BrowserNode) {
 // that nests its consumed sketch. The disclosure arrow toggles it open; a click on the label
 // selects it (and a double-click opens its editor), so expansion and selection don't fight.
 func drawSelectableBranchNode(s *app.Session, n app.BrowserNode) {
+	if renaming(n) {
+		drawRenameField(s, n)
+		return
+	}
 	current := s.Selection().First()
+	drawNodeIcon(n)
 	open := native.TreeNodeSelectable(n.Label, current == n.Select)
 	if native.IsItemClicked(native.MouseLeft) {
 		s.SelectBrowserNode(n)
@@ -276,7 +281,12 @@ func drawSelectableBranchNode(s *app.Session, n app.BrowserNode) {
 // drawSelectableNode draws a clickable row that selects the node, offers its context menu,
 // and scrolls itself into view when it is the node the selection just changed to.
 func drawSelectableNode(s *app.Session, n app.BrowserNode) {
+	if renaming(n) {
+		drawRenameField(s, n)
+		return
+	}
 	current := s.Selection().First()
+	drawNodeIcon(n)
 	if native.Selectable(n.Label, current == n.Select) {
 		s.SelectBrowserNode(n)
 	}
@@ -334,7 +344,8 @@ func drawBranchNode(s *app.Session, n app.BrowserNode) {
 // the action behind a clicked item. Nodes whose kind has no menu draw nothing.
 func drawNodeMenu(s *app.Session, n app.BrowserNode) {
 	items := app.BrowserMenuFor(s, n) // built-ins + add-in injections (M05-F12)
-	if len(items) == 0 {
+	renameable := isRenameableFeature(n)
+	if len(items) == 0 && !renameable {
 		return
 	}
 	if !native.BeginPopupContextItem("##menu-" + n.Kind + "/" + n.Label) {
@@ -346,6 +357,9 @@ func drawNodeMenu(s *app.Session, n app.BrowserNode) {
 				fmt.Fprintf(os.Stderr, "browser %q: %v\n", it.Label, err)
 			}
 		}
+	}
+	if renameable && native.MenuItemEx("Rename", "", true) {
+		beginRename(n) // in-place edit; commit enforces a document-unique name (#1264)
 	}
 	native.EndPopup()
 }


### PR DESCRIPTION
Closes #1264.

## What

The model browser's feature history is now readable by glyph and editable:

1. **Per-feature-type icons** — each feature row shows an icon for its type (extrude, revolve, sweep, loft, hole, fillet, chamfer, shell, draft, coil, …); sketch rows get the sketch glyph too. So a design is recognizable at a glance, not only by name.
2. **In-place feature rename** — right-click a feature → **Rename** opens an inline editor. Enter commits, Escape/click-away cancels. The new name is the user's organizing label; the stable internal id is untouched, and the name must be **non-empty and unique within the document**.

## How

- `app/browser.go`: `BrowserNode` gains an `Icon` key; the part browser maps each feature's `Kind()` to an icon asset (`featureIconByKind`; the fillet family collapses onto one glyph, an unmapped kind falls back to a default) and tags sketch/3D-sketch rows.
- `head/ui/browser_node_decor.go` (new): draws the glyph before the label (reusing the ribbon icon cache) and runs the in-place rename — seeded from the feature's name, committed via the existing `Session.RenameFeature`, which enforces the non-empty + document-unique invariant and keeps the id stable.
- `head/ui/browser_view.go`: feature rows draw their icon and, while being renamed, show the editor instead of the label; the context menu gains a **Rename** entry for feature nodes.

The rename **backend already existed** (id/name split on `PartFeature`, uniqueness in `RenameFeature`, `.obk` persistence, `feature.rename` wire method) — this wires it to the UI and adds the icons. **No public API change.**

## Tests

- `app`: feature-kind → icon mapping (incl. fillet-family collapse + default fallback); a feature browser node carries its icon key.
- `head/ui`: rename state helpers; `applyRename` commits and rejects a duplicate (keeps the original name); plus an in-window smoke test that draws the browser with feature icons and with the rename editor open (covers the icon/input draw under lavapipe).

## Verification

`go build ./...`, full `app` and `head/ui` suites pass; `gofmt` + `golangci-lint` clean.

**Live-confirmed** offscreen: feature rows render the extrude glyph before the label, and a feature renamed via `RenameFeature` ("Extrusion1" → "Base Plate") shows the new name in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)