### PR TITLE
Browser: extend icons + rename to sketches and work features (#1264)

### DIFF
--- a/app/browser.go
+++ b/app/browser.go
@@ -335,7 +335,7 @@ func appendWorkPlaneEntries(entries []timelineEntry, part *compdef.PartComponent
 			continue
 		}
 		entries = append(entries, timelineEntry{wp.Seq(), func(root *BrowserNode) {
-			root.selectableChild(wp.Name(), "workplane", WorkPlaneHandle{Plane: wp})
+			root.selectableChild(wp.Name(), "workplane", WorkPlaneHandle{Plane: wp}).Icon = iconWorkPlane
 		}})
 	}
 	return entries
@@ -351,7 +351,7 @@ func appendWorkAxisPointEntries(entries []timelineEntry, part *compdef.PartCompo
 			continue
 		}
 		entries = append(entries, timelineEntry{a.Seq(), func(root *BrowserNode) {
-			root.selectableChild(a.Name(), "workaxis", WorkAxisHandle{Axis: a})
+			root.selectableChild(a.Name(), "workaxis", WorkAxisHandle{Axis: a}).Icon = iconWorkAxis
 		}})
 	}
 	points := part.WorkPoints()
@@ -361,7 +361,7 @@ func appendWorkAxisPointEntries(entries []timelineEntry, part *compdef.PartCompo
 			continue
 		}
 		entries = append(entries, timelineEntry{p.Seq(), func(root *BrowserNode) {
-			root.selectableChild(p.Name(), "workpoint", WorkPointHandle{Point: p})
+			root.selectableChild(p.Name(), "workpoint", WorkPointHandle{Point: p}).Icon = iconWorkPoint
 		}})
 	}
 	return entries
@@ -416,6 +416,14 @@ func appendFeatureEntries(entries []timelineEntry, part *compdef.PartComponentDe
 	return entries
 }
 
+// Icon-asset keys for the non-feature browser rows (work features). Sketch rows use
+// "create-sketch"/"create-sketch-3d" inline at their build sites.
+const (
+	iconWorkPlane = "work-plane-offset" // a generic work-plane glyph for origin + user planes
+	iconWorkAxis  = "line"              // a line glyph stands in for a datum axis
+	iconWorkPoint = "point"             // a point glyph for a datum point
+)
+
 // featureIconByKind maps a feature's Kind() to the head icon-asset key drawn before its
 // browser label, so the feature reads by glyph not just by name. Kinds that share a glyph
 // (the fillet/pattern families) collapse onto one asset; a kind with no dedicated asset is
@@ -455,18 +463,18 @@ func featureLabel(f *feature.PartFeature) string {
 func addOriginBranch(root *BrowserNode, wg *feature.WorkGeometry) {
 	origin := root.child("Origin", "origin")
 	for _, wp := range wg.OriginPlanes() {
-		origin.selectableChild(wp.Name(), "workplane", WorkPlaneHandle{Plane: wp})
+		origin.selectableChild(wp.Name(), "workplane", WorkPlaneHandle{Plane: wp}).Icon = iconWorkPlane
 	}
 	axes := wg.WorkAxes()
 	for i := 0; i < axes.Count(); i++ {
 		if a := axes.Item(i); a.IsCoordinateSystemElement() {
-			origin.selectableChild(a.Name(), "workaxis", WorkAxisHandle{Axis: a})
+			origin.selectableChild(a.Name(), "workaxis", WorkAxisHandle{Axis: a}).Icon = iconWorkAxis
 		}
 	}
 	points := wg.WorkPoints()
 	for i := 0; i < points.Count(); i++ {
 		if p := points.Item(i); p.IsCoordinateSystemElement() {
-			origin.selectableChild(p.Name(), "workpoint", WorkPointHandle{Point: p})
+			origin.selectableChild(p.Name(), "workpoint", WorkPointHandle{Point: p}).Icon = iconWorkPoint
 		}
 	}
 }

--- a/app/browser_feature_icon_test.go
+++ b/app/browser_feature_icon_test.go
@@ -52,3 +52,44 @@ func TestBrowserFeatureNodeCarriesIcon(t *testing.T) {
 		t.Errorf("extrude feature node Icon = %q, want %q", node.Icon, "extrude")
 	}
 }
+
+// TestBrowserWorkAndSketchNodesCarryIcons: top-level sketches, 3D sketches, and the user/origin
+// work planes, axes and points all carry their glyph keys on the browser node (#1264).
+func TestBrowserWorkAndSketchNodesCarryIcons(t *testing.T) {
+	s, def := emptyPartSession(t)
+	def.Sketches().Add(sketch.XYPlane()) // top-level 2D sketch
+	def.Sketches3D().Add()               // 3D sketch
+	def.WorkPlanes().AddByPlaneAndOffset(feature.OriginXYPlane, func() float64 { return 2 })
+	def.WorkAxes().AddByPlaneIntersection(feature.OriginXYPlane, feature.OriginXZPlane)
+	def.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(1, 1, 1) })
+	def.Recompute()
+
+	root := BuildBrowser(s)
+	wants := map[string]string{ // node kind -> expected icon key
+		"sketch": "create-sketch", "sketch3d": "create-sketch-3d",
+		"workplane": iconWorkPlane, "workaxis": iconWorkAxis, "workpoint": iconWorkPoint,
+	}
+	for kind, icon := range wants {
+		n, ok := firstNodeOfKind(root, kind)
+		if !ok {
+			t.Errorf("no %q node in the browser", kind)
+			continue
+		}
+		if n.Icon != icon {
+			t.Errorf("%q node icon = %q, want %q", kind, n.Icon, icon)
+		}
+	}
+}
+
+// firstNodeOfKind returns the first node of the given kind that carries an icon, depth-first.
+func firstNodeOfKind(n BrowserNode, kind string) (BrowserNode, bool) {
+	if n.Kind == kind && n.Icon != "" {
+		return n, true
+	}
+	for _, c := range n.Children {
+		if got, ok := firstNodeOfKind(c, kind); ok {
+			return got, true
+		}
+	}
+	return BrowserNode{}, false
+}

--- a/app/rename_browser_entities.go
+++ b/app/rename_browser_entities.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+	"fmt"
+
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// Renaming the other browser-history entities — sketches, 3D sketches, and the user work
+// planes/axes/points — mirrors RenameFeature (feature_lifecycle.go): a non-empty name that is
+// unique among its siblings, recorded as one undo edit, with the stable id untouched. The
+// grounded origin coordinate-system datums (the Origin folder) are not renameable (#1264).
+
+// RenameSketch renames a 2D sketch; the name must be non-empty and unique among the part's 2D
+// sketches.
+func (s *Session) RenameSketch(sk *sketch.Sketch, name string) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	if name == "" {
+		return errors.New("app: RenameSketch: name must be non-empty")
+	}
+	cs := part.Sketches()
+	for i := 0; i < cs.Count(); i++ {
+		if o := cs.Item(i); o != sk && o.Name() == name {
+			return fmt.Errorf("app: RenameSketch: name %q is already used by another sketch", name)
+		}
+	}
+	sk.SetName(name)
+	s.recordEdit(part, "Rename Sketch")
+	return nil
+}
+
+// RenameSketch3D renames a 3D sketch; unique among the part's 3D sketches.
+func (s *Session) RenameSketch3D(sk *sketch.Sketch3D, name string) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	if name == "" {
+		return errors.New("app: RenameSketch3D: name must be non-empty")
+	}
+	cs := part.Sketches3D()
+	for i := 0; i < cs.Count(); i++ {
+		if o := cs.Item(i); o != sk && o.Name() == name {
+			return fmt.Errorf("app: RenameSketch3D: name %q is already used by another 3D sketch", name)
+		}
+	}
+	sk.SetName(name)
+	s.recordEdit(part, "Rename Sketch")
+	return nil
+}
+
+// RenameWorkPlane renames a user work plane; unique among the part's work planes. An origin
+// coordinate-system plane (XY/XZ/YZ) cannot be renamed.
+func (s *Session) RenameWorkPlane(wp *feature.WorkPlane, name string) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	if wp.IsCoordinateSystemElement() {
+		return errors.New("app: RenameWorkPlane: origin coordinate-system planes cannot be renamed")
+	}
+	if name == "" {
+		return errors.New("app: RenameWorkPlane: name must be non-empty")
+	}
+	cs := part.WorkPlanes()
+	for i := 0; i < cs.Count(); i++ {
+		if o := cs.Item(i); o != wp && o.Name() == name {
+			return fmt.Errorf("app: RenameWorkPlane: name %q is already used by another work plane", name)
+		}
+	}
+	wp.SetName(name)
+	s.recordEdit(part, "Rename Work Plane")
+	return nil
+}
+
+// RenameWorkAxis renames a user work axis; unique among the part's work axes. An origin
+// coordinate-system axis (X/Y/Z) cannot be renamed.
+func (s *Session) RenameWorkAxis(wa *feature.WorkAxis, name string) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	if wa.IsCoordinateSystemElement() {
+		return errors.New("app: RenameWorkAxis: origin coordinate-system axes cannot be renamed")
+	}
+	if name == "" {
+		return errors.New("app: RenameWorkAxis: name must be non-empty")
+	}
+	cs := part.WorkAxes()
+	for i := 0; i < cs.Count(); i++ {
+		if o := cs.Item(i); o != wa && o.Name() == name {
+			return fmt.Errorf("app: RenameWorkAxis: name %q is already used by another work axis", name)
+		}
+	}
+	wa.SetName(name)
+	s.recordEdit(part, "Rename Work Axis")
+	return nil
+}
+
+// RenameWorkPoint renames a user work point; unique among the part's work points. The origin
+// centre point cannot be renamed.
+func (s *Session) RenameWorkPoint(wp *feature.WorkPoint, name string) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	if wp.IsCoordinateSystemElement() {
+		return errors.New("app: RenameWorkPoint: the origin centre point cannot be renamed")
+	}
+	if name == "" {
+		return errors.New("app: RenameWorkPoint: name must be non-empty")
+	}
+	cs := part.WorkPoints()
+	for i := 0; i < cs.Count(); i++ {
+		if o := cs.Item(i); o != wp && o.Name() == name {
+			return fmt.Errorf("app: RenameWorkPoint: name %q is already used by another work point", name)
+		}
+	}
+	wp.SetName(name)
+	s.recordEdit(part, "Rename Work Point")
+	return nil
+}

--- a/app/rename_browser_entities_test.go
+++ b/app/rename_browser_entities_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// TestRenameSketchUniqueAndNonEmpty: a 2D sketch renames, but an empty or duplicate name is
+// rejected and the original kept.
+func TestRenameSketchUniqueAndNonEmpty(t *testing.T) {
+	s, def := emptyPartSession(t)
+	a := def.Sketches().Add(sketch.XYPlane())
+	b := def.Sketches().Add(sketch.XYPlane())
+	if err := s.RenameSketch(a, "Profile"); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	if a.Name() != "Profile" {
+		t.Errorf("sketch name = %q, want Profile", a.Name())
+	}
+	if err := s.RenameSketch(b, "Profile"); err == nil {
+		t.Error("a duplicate sketch name should be rejected")
+	}
+	if err := s.RenameSketch(a, ""); err == nil {
+		t.Error("an empty sketch name should be rejected")
+	}
+}
+
+// TestRenameSketch3D: a 3D sketch renames through its own method.
+func TestRenameSketch3D(t *testing.T) {
+	s, def := emptyPartSession(t)
+	sk := def.Sketches3D().Add()
+	other := def.Sketches3D().Add()
+	if err := s.RenameSketch3D(sk, "Wire Path"); err != nil {
+		t.Fatalf("rename 3D: %v", err)
+	}
+	if sk.Name() != "Wire Path" {
+		t.Errorf("3D sketch name = %q, want Wire Path", sk.Name())
+	}
+	if err := s.RenameSketch3D(other, "Wire Path"); err == nil {
+		t.Error("a duplicate 3D-sketch name should be rejected")
+	}
+	if err := s.RenameSketch3D(sk, ""); err == nil {
+		t.Error("an empty 3D-sketch name should be rejected")
+	}
+}
+
+// TestRenameWorkPlaneUserAndOrigin: a user work plane renames (unique), but the grounded origin
+// planes cannot be renamed.
+func TestRenameWorkPlaneUserAndOrigin(t *testing.T) {
+	s, def := emptyPartSession(t)
+	p1 := def.WorkPlanes().AddByPlaneAndOffset(feature.OriginXYPlane, func() float64 { return 2 })
+	p2 := def.WorkPlanes().AddByPlaneAndOffset(feature.OriginXYPlane, func() float64 { return 4 })
+	def.Recompute()
+
+	if err := s.RenameWorkPlane(p1, "Mount Face"); err != nil {
+		t.Fatalf("rename work plane: %v", err)
+	}
+	if p1.Name() != "Mount Face" {
+		t.Errorf("work plane name = %q, want Mount Face", p1.Name())
+	}
+	if err := s.RenameWorkPlane(p2, "Mount Face"); err == nil {
+		t.Error("a duplicate work-plane name should be rejected")
+	}
+	origin, _ := def.WorkPlaneByName("XY Plane")
+	if err := s.RenameWorkPlane(origin, "Base"); err == nil {
+		t.Error("an origin coordinate-system plane must not be renameable")
+	}
+}
+
+// TestRenameWorkAxisAndPoint: a user work axis and work point rename, and their origin
+// counterparts are rejected.
+func TestRenameWorkAxisAndPoint(t *testing.T) {
+	s, def := emptyPartSession(t)
+	axis := def.WorkAxes().AddByPlaneIntersection(feature.OriginXYPlane, feature.OriginXZPlane)
+	axis2 := def.WorkAxes().AddByPlaneIntersection(feature.OriginXYPlane, feature.OriginYZPlane)
+	point := def.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(1, 2, 3) })
+	point2 := def.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(4, 5, 6) })
+	def.Recompute()
+
+	if err := s.RenameWorkAxis(axis, "Spin Axis"); err != nil {
+		t.Fatalf("rename axis: %v", err)
+	}
+	if axis.Name() != "Spin Axis" {
+		t.Errorf("axis name = %q, want Spin Axis", axis.Name())
+	}
+	if err := s.RenameWorkAxis(axis2, "Spin Axis"); err == nil {
+		t.Error("a duplicate work-axis name should be rejected")
+	}
+	if err := s.RenameWorkPoint(point, "Pivot"); err != nil {
+		t.Fatalf("rename point: %v", err)
+	}
+	if point.Name() != "Pivot" {
+		t.Errorf("point name = %q, want Pivot", point.Name())
+	}
+	if err := s.RenameWorkPoint(point2, "Pivot"); err == nil {
+		t.Error("a duplicate work-point name should be rejected")
+	}
+
+	xAxis, _ := def.WorkGeometry().AxisByRef(feature.OriginXAxis)
+	if err := s.RenameWorkAxis(xAxis, "Roll"); err == nil {
+		t.Error("an origin coordinate-system axis must not be renameable")
+	}
+	center, _ := def.WorkGeometry().WorkPointByRef(feature.OriginCenter)
+	if err := s.RenameWorkPoint(center, "Hub"); err == nil {
+		t.Error("the origin centre point must not be renameable")
+	}
+}

--- a/head/ui/browser_node_decor.go
+++ b/head/ui/browser_node_decor.go
@@ -16,8 +16,9 @@ import (
 // in-place rename of a feature node. Both live here so browser_view.go stays focused on the
 // tree structure (#1264).
 
-// browserIconPx is the browser-row icon size in pixels (matches a tree row's text height).
-const browserIconPx = 16
+// browserIconPx is the browser-row icon size in pixels. Sized at 200% of a tree row's text
+// height so the per-feature glyphs read clearly (#1264).
+const browserIconPx = 32
 
 // drawNodeIcon draws the node's icon glyph followed by SameLine, so the label that the caller
 // renders next sits to its right. A node with no icon, or a glyph that fails to rasterize, draws
@@ -44,12 +45,12 @@ type browserRenameState struct {
 
 var browserRename browserRenameState
 
-// beginRename opens the in-place editor for a feature node, seeding the buffer with its current
-// name and requesting focus on the next frame.
+// beginRename opens the in-place editor for a renameable node, seeding the buffer with its
+// current name and requesting focus on the next frame.
 func beginRename(n app.BrowserNode) {
 	browserRename.target = n.Select
 	browserRename.focus = true
-	setBuf(browserRename.buf[:], featureNodeName(n))
+	setBuf(browserRename.buf[:], nodeName(n))
 }
 
 // renaming reports whether n is the node currently being renamed in place.
@@ -77,30 +78,72 @@ func drawRenameField(s *app.Session, n app.BrowserNode) {
 	}
 }
 
-// applyRename commits the buffer to the feature behind n, then closes the editor.
+// applyRename commits the buffer to the entity behind n, then closes the editor. The per-type
+// backend keeps the stable id and enforces a non-empty, sibling-unique name.
 func applyRename(s *app.Session, n app.BrowserNode) {
-	if h, ok := n.Select.(app.FeatureHandle); ok {
-		if name := bufString(browserRename.buf[:]); name != "" {
-			if err := s.RenameFeature(h.Feature, name); err != nil {
-				fmt.Fprintf(os.Stderr, "rename feature: %v\n", err)
-			}
+	if name := bufString(browserRename.buf[:]); name != "" {
+		if err := renameNode(s, n, name); err != nil {
+			fmt.Fprintf(os.Stderr, "rename: %v\n", err)
 		}
 	}
 	browserRename.target = nil
 }
 
-// featureNodeName returns the editable feature name for a node — its handle's current name,
-// falling back to the label (the label may carry a status badge, so prefer the raw name).
-func featureNodeName(n app.BrowserNode) string {
-	if h, ok := n.Select.(app.FeatureHandle); ok {
-		return h.Feature.Name()
+// renameNode dispatches the rename to the session method for the node's handle type.
+func renameNode(s *app.Session, n app.BrowserNode, name string) error {
+	switch h := n.Select.(type) {
+	case app.FeatureHandle:
+		return s.RenameFeature(h.Feature, name)
+	case app.SketchHandle:
+		return s.RenameSketch(h.Sketch, name)
+	case app.Sketch3DHandle:
+		return s.RenameSketch3D(h.Sketch3D, name)
+	case app.WorkPlaneHandle:
+		return s.RenameWorkPlane(h.Plane, name)
+	case app.WorkAxisHandle:
+		return s.RenameWorkAxis(h.Axis, name)
+	case app.WorkPointHandle:
+		return s.RenameWorkPoint(h.Point, name)
+	default:
+		return nil
 	}
-	return n.Label
 }
 
-// isRenameableFeature reports whether n is a feature node (the only node kind the in-place
-// rename currently targets — its backend enforces document-unique names, #1264).
-func isRenameableFeature(n app.BrowserNode) bool {
-	_, ok := n.Select.(app.FeatureHandle)
-	return ok
+// nodeName returns the editable name for a node — its handle's current name, falling back to the
+// label (the label may carry a status badge, so prefer the raw name).
+func nodeName(n app.BrowserNode) string {
+	switch h := n.Select.(type) {
+	case app.FeatureHandle:
+		return h.Feature.Name()
+	case app.SketchHandle:
+		return h.Sketch.Name()
+	case app.Sketch3DHandle:
+		return h.Sketch3D.Name()
+	case app.WorkPlaneHandle:
+		return h.Plane.Name()
+	case app.WorkAxisHandle:
+		return h.Axis.Name()
+	case app.WorkPointHandle:
+		return h.Point.Name()
+	default:
+		return n.Label
+	}
+}
+
+// isRenameableNode reports whether n is a node the in-place rename targets: a feature, a 2D/3D
+// sketch, or a user work plane/axis/point. The grounded origin coordinate-system datums (the
+// Origin folder) are excluded — their names are fixed (#1264).
+func isRenameableNode(n app.BrowserNode) bool {
+	switch h := n.Select.(type) {
+	case app.FeatureHandle, app.SketchHandle, app.Sketch3DHandle:
+		return true
+	case app.WorkPlaneHandle:
+		return !h.Plane.IsCoordinateSystemElement()
+	case app.WorkAxisHandle:
+		return !h.Axis.IsCoordinateSystemElement()
+	case app.WorkPointHandle:
+		return !h.Point.IsCoordinateSystemElement()
+	default:
+		return false
+	}
 }

--- a/head/ui/browser_node_decor_test.go
+++ b/head/ui/browser_node_decor_test.go
@@ -54,11 +54,11 @@ func TestRenameStateHelpers(t *testing.T) {
 	if renaming(n) {
 		t.Error("nothing should be renaming initially")
 	}
-	if !isRenameableFeature(n) {
+	if !isRenameableNode(n) {
 		t.Error("a feature node should be renameable")
 	}
-	if got := featureNodeName(n); got != "Extrusion1" {
-		t.Errorf("featureNodeName = %q, want Extrusion1", got)
+	if got := nodeName(n); got != "Extrusion1" {
+		t.Errorf("nodeName = %q, want Extrusion1", got)
 	}
 	beginRename(n)
 	if !renaming(n) {
@@ -95,14 +95,106 @@ func TestApplyRenameRejectsDuplicate(t *testing.T) {
 	}
 }
 
-// TestIsRenameableFeatureRejectsNonFeature: a non-feature node is not renameable.
-func TestIsRenameableFeatureRejectsNonFeature(t *testing.T) {
+// TestIsRenameableNodeRejectsNonRenameable: a plain folder node is not renameable.
+func TestIsRenameableNodeRejectsNonRenameable(t *testing.T) {
 	n := app.BrowserNode{Label: "Solid Bodies", Kind: "bodies"}
-	if isRenameableFeature(n) {
-		t.Error("a non-feature node must not be renameable")
+	if isRenameableNode(n) {
+		t.Error("a non-renameable node must not be renameable")
 	}
-	if got := featureNodeName(n); got != "Solid Bodies" {
-		t.Errorf("featureNodeName of a non-feature node = %q, want its label", got)
+	if got := nodeName(n); got != "Solid Bodies" {
+		t.Errorf("nodeName of a non-handle node = %q, want its label", got)
+	}
+}
+
+// TestRenameSketchAndWorkFeatures: sketches and user work features rename through the browser
+// dispatch, while the grounded origin datums are rejected (#1264).
+func TestRenameSketchAndWorkFeatures(t *testing.T) {
+	s := app.NewSession()
+	pd, err := compdef.AddPart(s.Workspace(), "w.opd", true)
+	if err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	def := pd.Content().(*compdef.PartComponentDefinition)
+	sk := def.Sketches().Add(sketch.XYPlane())
+
+	skNode := app.BrowserNode{Kind: "sketch", Select: app.SketchHandle{Sketch: sk}}
+	if !isRenameableNode(skNode) {
+		t.Fatal("a sketch node should be renameable")
+	}
+	if err := renameNode(s, skNode, "Profile"); err != nil {
+		t.Fatalf("rename sketch: %v", err)
+	}
+	if sk.Name() != "Profile" {
+		t.Errorf("sketch name = %q, want Profile", sk.Name())
+	}
+
+	// The origin centre point is a grounded coordinate-system datum: not renameable, and the
+	// backend rejects a rename attempt.
+	center, _ := def.WorkGeometry().WorkPointByRef(feature.OriginCenter)
+	xPlane, _ := def.WorkGeometry().WorkPlaneByRef(feature.OriginXYPlane)
+	xAxis, _ := def.WorkGeometry().AxisByRef(feature.OriginXAxis)
+	originNodes := []app.BrowserNode{
+		{Kind: "workpoint", Select: app.WorkPointHandle{Point: center}},
+		{Kind: "workplane", Select: app.WorkPlaneHandle{Plane: xPlane}},
+		{Kind: "workaxis", Select: app.WorkAxisHandle{Axis: xAxis}},
+	}
+	for _, n := range originNodes {
+		if isRenameableNode(n) {
+			t.Errorf("origin datum %T must not be renameable", n.Select)
+		}
+	}
+	if err := s.RenameWorkPoint(center, "Nope"); err == nil {
+		t.Error("renaming a coordinate-system datum should error")
+	}
+}
+
+// TestNodeNameAndRenameDispatchAllTypes exercises nodeName and renameNode for every renameable
+// handle type, so the per-type dispatch is covered end to end (#1264).
+func TestNodeNameAndRenameDispatchAllTypes(t *testing.T) {
+	s := app.NewSession()
+	pd, err := compdef.AddPart(s.Workspace(), "a.opd", true)
+	if err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	def := pd.Content().(*compdef.PartComponentDefinition)
+	addBox(def, 0)
+	sk2 := def.Sketches().Add(sketch.XYPlane())
+	sk3 := def.Sketches3D().Add()
+	wp := def.WorkPlanes().AddByPlaneAndOffset(feature.OriginXYPlane, func() float64 { return 2 })
+	wa := def.WorkAxes().AddByPlaneIntersection(feature.OriginXYPlane, feature.OriginXZPlane)
+	wpt := def.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(1, 1, 1) })
+	def.Recompute()
+	feat, _ := def.Features().ByName("Extrusion1")
+
+	cases := []struct {
+		node    app.BrowserNode
+		newName string
+		current func() string
+	}{
+		{app.BrowserNode{Select: app.FeatureHandle{Feature: feat}}, "Feat", feat.Name},
+		{app.BrowserNode{Select: app.SketchHandle{Sketch: sk2}}, "Sk2", sk2.Name},
+		{app.BrowserNode{Select: app.Sketch3DHandle{Sketch3D: sk3}}, "Sk3", sk3.Name},
+		{app.BrowserNode{Select: app.WorkPlaneHandle{Plane: wp}}, "WP", wp.Name},
+		{app.BrowserNode{Select: app.WorkAxisHandle{Axis: wa}}, "WA", wa.Name},
+		{app.BrowserNode{Select: app.WorkPointHandle{Point: wpt}}, "WPt", wpt.Name},
+	}
+	for _, c := range cases {
+		before := c.current()
+		if !isRenameableNode(c.node) {
+			t.Errorf("node %T should be renameable", c.node.Select)
+		}
+		if got := nodeName(c.node); got != before {
+			t.Errorf("nodeName = %q, want %q", got, before)
+		}
+		if err := renameNode(s, c.node, c.newName); err != nil {
+			t.Errorf("renameNode to %q: %v", c.newName, err)
+		}
+		if got := c.current(); got != c.newName {
+			t.Errorf("after rename = %q, want %q", got, c.newName)
+		}
+	}
+	if err := renameNode(s, app.BrowserNode{Label: "x"}, "y"); err != nil {
+		t.Errorf("renameNode of a non-handle node should be a no-op, got %v", err)
 	}
 }
 

--- a/head/ui/browser_view.go
+++ b/head/ui/browser_view.go
@@ -344,7 +344,7 @@ func drawBranchNode(s *app.Session, n app.BrowserNode) {
 // the action behind a clicked item. Nodes whose kind has no menu draw nothing.
 func drawNodeMenu(s *app.Session, n app.BrowserNode) {
 	items := app.BrowserMenuFor(s, n) // built-ins + add-in injections (M05-F12)
-	renameable := isRenameableFeature(n)
+	renameable := isRenameableNode(n)
 	if len(items) == 0 && !renameable {
 		return
 	}

--- a/model/feature/work_axis_point.go
+++ b/model/feature/work_axis_point.go
@@ -84,6 +84,7 @@ func (w *WorkAxis) ID() ID                          { return w.id }
 func (w *WorkAxis) Seq() uint64                     { return w.seq }
 func (w *WorkAxis) Key() WorkRef                    { return w.key }
 func (w *WorkAxis) Name() string                    { return w.name }
+func (w *WorkAxis) SetName(n string)                { w.name = n }
 func (w *WorkAxis) Health() health.Health           { return w.health }
 func (w *WorkAxis) Origin() math.Point3             { return w.origin }
 func (w *WorkAxis) Direction() math.UnitVector3     { return w.dir }
@@ -225,6 +226,7 @@ func (w *WorkPoint) ID() ID                          { return w.id }
 func (w *WorkPoint) Seq() uint64                     { return w.seq }
 func (w *WorkPoint) Key() WorkRef                    { return w.key }
 func (w *WorkPoint) Name() string                    { return w.name }
+func (w *WorkPoint) SetName(n string)                { w.name = n }
 func (w *WorkPoint) Health() health.Health           { return w.health }
 func (w *WorkPoint) Point() math.Point3              { return w.point }
 func (w *WorkPoint) IsCoordinateSystemElement() bool { return w.coordinateSystem }


### PR DESCRIPTION
Follow-up to #1265 (feature icons + rename). Extends both to the rest of the model history.

## What

- **Icons** now show for **2D/3D sketches** and **work planes/axes/points** (user features *and* the Origin folder datums), in addition to part features.
- **In-place rename** now works for **sketches, 3D sketches, and user work planes/axes/points** — right-click → **Rename**, inline edit, Enter commits / Escape cancels. Names are non-empty and unique among siblings; the stable id is untouched.
- The grounded **origin coordinate-system datums** (Center Point, X/Y/Z axes, XY/XZ/YZ planes) get glyphs but are **not renameable** (their names are fixed).
- **Icons bumped to 200%** (16→32 px) so the glyphs read clearly — per request.

## How

- `app/browser.go`: tag sketch (`create-sketch`), 3D-sketch (`create-sketch-3d`), work-plane (`work-plane-offset`), work-axis (`line`) and work-point (`point`) rows with icon keys, including the Origin folder.
- `app/rename_browser_entities.go` (new): `RenameSketch` / `RenameSketch3D` / `RenameWorkPlane` / `RenameWorkAxis` / `RenameWorkPoint` — each enforces non-empty + sibling-unique, records one undo edit, keeps the id, and rejects the grounded origin datums. `model/feature`: `WorkAxis`/`WorkPoint` gain `SetName` (WorkPlane already had it).
- `head/ui/browser_node_decor.go`: the rename helpers generalize from feature-only to any renameable node (`isRenameableNode`, `nodeName`, `renameNode` dispatch); `browserIconPx` → 32.

No public API change (the per-type rename is `/source`-internal; the head reaches it through the session).

## Tests

- `app`: every browser row kind carries its icon key; each rename method (success + empty + duplicate rejection + origin-datum rejection).
- `head/ui`: `nodeName`/`renameNode`/`isRenameableNode` across all handle types incl. origin datums; in-window smoke test draws the browser with icons + the rename editor.

## Verification

`go build ./...`, full `app` / `model/feature` / `head/ui` suites pass; `gofmt` + `golangci-lint` clean.

**Live-confirmed** offscreen (200% icons): the extrude glyph on a renamed feature ("Base Plate"), the sketch glyph on a top-level sketch, and the work-plane glyph on a renamed work plane ("Lid Plane").

🤖 Generated with [Claude Code](https://claude.com/claude-code)