### PR TITLE
Browser: framed icon tiles + label centered on the icon (#1264)

### DIFF
--- a/head/ui/browser_node_decor.go
+++ b/head/ui/browser_node_decor.go
@@ -20,10 +20,12 @@ import (
 // height so the per-feature glyphs read clearly (#1264).
 const browserIconPx = 32
 
-// drawNodeIcon draws the node's icon glyph followed by SameLine, so the label that the caller
-// renders next sits to its right. A node with no icon, or a glyph that fails to rasterize, draws
-// nothing (the label still renders) so the tree degrades gracefully.
-func drawNodeIcon(n app.BrowserNode) {
+// drawNodeIcon draws the node's icon as a framed tile (the ribbon's button background, so the
+// glyph reads against the dark tree) and then advances the cursor so the label the caller renders
+// next sits to its right, vertically centred on the tile. Clicking the tile selects the node, like
+// clicking its label. A node with no icon, or a glyph that fails to rasterize, draws nothing (the
+// label still renders) so the tree degrades gracefully (#1264).
+func drawNodeIcon(s *app.Session, n app.BrowserNode) {
 	if n.Icon == "" || icons == nil {
 		return
 	}
@@ -31,8 +33,13 @@ func drawNodeIcon(n app.BrowserNode) {
 	if !ok {
 		return
 	}
-	native.Image(tex, browserIconPx, browserIconPx)
+	if native.ImageButton("##nodeicon", tex, browserIconPx, browserIconPx, identityTint) {
+		s.SelectBrowserNode(n)
+	}
 	native.SameLine()
+	m := native.Metrics()
+	x, y := native.GetCursorScreenPos()
+	native.SetCursorScreenPos(x, y+(browserIconPx+2*m.FramePadY-native.TextLineHeight())/2)
 }
 
 // browserRename holds the in-place feature rename: the node being edited (nil when none), the

--- a/head/ui/browser_view.go
+++ b/head/ui/browser_view.go
@@ -261,7 +261,7 @@ func drawSelectableBranchNode(s *app.Session, n app.BrowserNode) {
 		return
 	}
 	current := s.Selection().First()
-	drawNodeIcon(n)
+	drawNodeIcon(s, n)
 	open := native.TreeNodeSelectable(n.Label, current == n.Select)
 	if native.IsItemClicked(native.MouseLeft) {
 		s.SelectBrowserNode(n)
@@ -286,7 +286,7 @@ func drawSelectableNode(s *app.Session, n app.BrowserNode) {
 		return
 	}
 	current := s.Selection().First()
-	drawNodeIcon(n)
+	drawNodeIcon(s, n)
 	if native.Selectable(n.Label, current == n.Select) {
 		s.SelectBrowserNode(n)
 	}


### PR DESCRIPTION
Follow-up to #1266. Two readability fixes the user asked for on the browser feature-history icons.

## What

- **Background tile** — each icon now draws as a framed tile using the ribbon's button background, so the glyph stands out against the dark tree (it was too hard to see on a transparent background).
- **Vertical centering** — the node label is now vertically centered on the icon tile (it previously sat at the top of the taller 200% icon).
- Clicking the tile selects the node, like clicking its label.

## How

`head/ui/browser_node_decor.go`: `drawNodeIcon` draws the glyph via `ImageButton` (the themed button frame = the ribbon background) and offsets the cursor by `(iconPx + 2·FramePadY − TextLineHeight)/2` so the following label/tree-node centers on the tile — the same centering the ribbon's labeled icon buttons use (`drawLabeledIconButton`). Call sites pass the session so the tile click routes to `SelectBrowserNode`.

Head-only; no app/model/API change.

## Verification

`go build ./...`, full `head/ui` suite passes; `gofmt` + `golangci-lint` clean.

**Live-confirmed** offscreen: the extrude/sketch/work-plane glyphs now sit on visible gray tiles and each label ("Base Plate", "Sketch2", "Lid Plane") is centered on its icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)