### PR TITLE
Fix coincident-to-projected-point + persist projected geometry (#1268)

### DIFF
--- a/app/coincident_projected_test.go
+++ b/app/coincident_projected_test.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// TestCoincidentToProjectedOriginMovesGeometry reproduces #1268: with the origin centre point
+// projected into a sketch, a coincident constraint between a free point and the projected anchor
+// must pick the anchor and pull the geometry to it. Before the fix the anchor was absent from the
+// pick set (AllPoints), so the constraint could never be formed and nothing moved.
+func TestCoincidentToProjectedOriginMovesGeometry(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	sk, err := s.CreateSketch(sketch.XYPlane()) // auto-projects the origin centre at (0,0)
+	if err != nil {
+		t.Fatalf("CreateSketch: %v", err)
+	}
+	free := sk.Points().Add(math.P2(3, 3))
+
+	// The real pick path: nearestEntityPoint gathers AllPoints, which must now include the
+	// projected anchor so a click at the origin selects it.
+	anchorEnt, ok := s.nearestEntityPoint(math.P2(0, 0), 0.5)
+	if !ok {
+		t.Fatal("the projected origin anchor is not pickable at (0,0)")
+	}
+	if _, isPoint := anchorEnt.(*sketch.Point); !isPoint {
+		t.Fatalf("picked entity at the origin is %T, want a *sketch.Point anchor", anchorEnt)
+	}
+
+	if err := applyCoincident(s, []sketch.Entity{anchorEnt, free}); err != nil {
+		t.Fatalf("applyCoincident: %v", err)
+	}
+	if !free.Position().IsEqualTo(math.P2(0, 0), 1e-9) {
+		t.Errorf("free point at %v, want pulled to the projected origin (0,0)", free.Position())
+	}
+}

--- a/model/compdef/reference_source.go
+++ b/model/compdef/reference_source.go
@@ -37,6 +37,9 @@ func NewEdgeRefSource(part *PartComponentDefinition, ref string) EdgeRefSource {
 // SourceID returns the edge's reference key (its stable cross-recompute identity).
 func (s EdgeRefSource) SourceID() string { return s.ref }
 
+// SourceKind tags this as an edge reference for projection persistence/rebind (#1268).
+func (s EdgeRefSource) SourceKind() string { return "edge" }
+
 // SamplePoints re-resolves the edge by key and samples its curve; ok=false when lost.
 func (s EdgeRefSource) SamplePoints() ([]math.Point3, bool) {
 	key := []byte(s.ref)
@@ -61,6 +64,9 @@ func NewVertexRefSource(part *PartComponentDefinition, ref string) VertexRefSour
 
 // SourceID returns the vertex's reference key.
 func (s VertexRefSource) SourceID() string { return s.ref }
+
+// SourceKind tags this as a vertex reference for projection persistence/rebind (#1268).
+func (s VertexRefSource) SourceKind() string { return "vertex" }
 
 // Position re-resolves the vertex by key; ok=false when lost.
 func (s VertexRefSource) Position() (math.Point3, bool) {

--- a/model/compdef/serialize.go
+++ b/model/compdef/serialize.go
@@ -288,6 +288,7 @@ func (d *PartComponentDefinition) applyRecipeStruct(r partRecipe) error {
 	if r.EndOfPart != nil {
 		d.SetEndOfPart(*r.EndOfPart)
 	}
+	d.rebindSketchProjections() // re-attach live sources to restored projections before recompute (#1268)
 	d.Recompute()
 	return nil
 }

--- a/model/compdef/sketch_projection_persist_test.go
+++ b/model/compdef/sketch_projection_persist_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef_test
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// projectedOf returns the first projected point and curve in a sketch (nil when absent).
+func projectedOf(sk *sketch.Sketch) (*sketch.ProjectedPoint, *sketch.ProjectedCurve) {
+	var pp *sketch.ProjectedPoint
+	var pc *sketch.ProjectedCurve
+	for _, e := range sk.Entities() {
+		switch v := e.(type) {
+		case *sketch.ProjectedPoint:
+			pp = v
+		case *sketch.ProjectedCurve:
+			pc = v
+		}
+	}
+	return pp, pc
+}
+
+// TestProjectedGeometryRoundTrips: a sketch with a projected origin centre point, a projected
+// work plane (→ reference line), and a coincident constraint to the projected anchor now
+// serializes (it used to fail with "no codec" — the save-breaking #1268 regression) and restores
+// re-linked/associative with its geometry, ids and constraint intact.
+func TestProjectedGeometryRoundTrips(t *testing.T) {
+	def := compdef.NewPartComponentDefinition()
+	sk := def.Sketches().Add(sketch.XYPlane())
+	pp := sk.ProjectPoint(compdef.NewWorkPointRefSource(def, feature.OriginCenter))              // → (0,0)
+	sk.ProjectCurve(compdef.NewWorkPlaneRefSource(def, feature.OriginYZPlane, sketch.XYPlane())) // YZ∩XY = Y axis line
+	free := sk.Points().Add(math.P2(3, 3))
+	sk.GeometricConstraints().AddCoincident(free, pp.Anchor())
+	def.Recompute()
+
+	model, err := def.MarshalRecipe()
+	if err != nil {
+		t.Fatalf("MarshalRecipe must not fail on projected geometry: %v", err)
+	}
+
+	got := compdef.NewPartComponentDefinition()
+	if err := got.ApplyRecipe(model); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+
+	sk2 := got.Sketches().Item(0)
+	pp2, pc2 := projectedOf(sk2)
+	if pp2 == nil || pc2 == nil {
+		t.Fatalf("projected geometry lost on reload: point=%v curve=%v", pp2, pc2)
+	}
+	if !pp2.Position().IsEqualTo(math.P2(0, 0), 1e-9) {
+		t.Errorf("restored projected point at %v, want (0,0)", pp2.Position())
+	}
+	if !pp2.Linked() || pp2.SourceID() != string(feature.OriginCenter) {
+		t.Errorf("projected point not re-linked to its source: linked=%v src=%q", pp2.Linked(), pp2.SourceID())
+	}
+	if !pc2.Linked() {
+		t.Error("projected curve should be re-linked (associative) after restore")
+	}
+	if len(sk2.Constraints()) == 0 {
+		t.Error("the coincident constraint to the projected anchor was lost on reload")
+	}
+}

--- a/model/compdef/sketch_projection_rebind.go
+++ b/model/compdef/sketch_projection_rebind.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// A saved sketch restores its projected reference geometry (the projected origin centre point,
+// projected edges/datums) frozen at its last position, carrying only a (kind, id) source
+// descriptor — model/sketch cannot rebuild the part-owned source itself. rebindSketchProjections
+// re-attaches a live, self-resolving source built from that descriptor, so projections become
+// associative again after a reload. It runs after sketches/work geometry are restored and before
+// Recompute, whose UpdateProjections then re-projects from the live sources (#1268).
+func (d *PartComponentDefinition) rebindSketchProjections() {
+	for i := 0; i < d.sketches.Count(); i++ {
+		sk := d.sketches.Item(i)
+		for _, e := range sk.Entities() {
+			d.rebindProjection(e, sk.Plane())
+		}
+	}
+}
+
+// rebindProjection re-attaches one projected entity's live source from its persisted descriptor;
+// an unknown/empty kind leaves the entity frozen.
+func (d *PartComponentDefinition) rebindProjection(e sketch.Entity, plane sketch.Plane) {
+	switch v := e.(type) {
+	case *sketch.ProjectedPoint:
+		if kind, id := v.SourceDescriptor(); kind != "" {
+			if src, ok := d.pointRefSource(kind, id); ok {
+				v.Rebind(src)
+			}
+		}
+	case *sketch.ProjectedCurve:
+		if kind, id := v.SourceDescriptor(); kind != "" {
+			if src, ok := d.curveRefSource(kind, id, plane); ok {
+				v.Rebind(src)
+			}
+		}
+	}
+}
+
+// pointRefSource rebuilds a point projection source from its descriptor.
+func (d *PartComponentDefinition) pointRefSource(kind, id string) (sketch.PointSource, bool) {
+	switch kind {
+	case "vertex":
+		return NewVertexRefSource(d, id), true
+	case "workPoint":
+		return NewWorkPointRefSource(d, feature.WorkRef(id)), true
+	default:
+		return nil, false
+	}
+}
+
+// curveRefSource rebuilds a curve projection source from its descriptor; a work-plane projection
+// also needs the target sketch plane it intersects.
+func (d *PartComponentDefinition) curveRefSource(kind, id string, plane sketch.Plane) (sketch.CurveSource, bool) {
+	switch kind {
+	case "edge":
+		return NewEdgeRefSource(d, id), true
+	case "workAxis":
+		return NewWorkAxisRefSource(d, feature.WorkRef(id)), true
+	case "workPlane":
+		return NewWorkPlaneRefSource(d, feature.WorkRef(id), plane), true
+	default:
+		return nil, false
+	}
+}

--- a/model/compdef/sketch_projection_rebind_test.go
+++ b/model/compdef/sketch_projection_rebind_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"testing"
+
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// TestProjectionSourceKindTags: each reference source reports the kind tag persistence uses to
+// rebuild it (#1268).
+func TestProjectionSourceKindTags(t *testing.T) {
+	d := NewPartComponentDefinition()
+	cases := []struct {
+		kind string
+		got  string
+	}{
+		{"edge", NewEdgeRefSource(d, "k").SourceKind()},
+		{"vertex", NewVertexRefSource(d, "k").SourceKind()},
+		{"workPoint", NewWorkPointRefSource(d, feature.OriginCenter).SourceKind()},
+		{"workAxis", NewWorkAxisRefSource(d, feature.OriginXAxis).SourceKind()},
+		{"workPlane", NewWorkPlaneRefSource(d, feature.OriginXYPlane, sketch.XYPlane()).SourceKind()},
+	}
+	for _, c := range cases {
+		if c.got != c.kind {
+			t.Errorf("SourceKind = %q, want %q", c.got, c.kind)
+		}
+	}
+}
+
+// TestProjectionSourceBuilders: the rebind builders construct a source for every known kind and
+// reject an unknown one (the frozen fallback).
+func TestProjectionSourceBuilders(t *testing.T) {
+	d := NewPartComponentDefinition()
+	if _, ok := d.pointRefSource("vertex", "k"); !ok {
+		t.Error("vertex point source should build")
+	}
+	if _, ok := d.pointRefSource("workPoint", string(feature.OriginCenter)); !ok {
+		t.Error("workPoint source should build")
+	}
+	if _, ok := d.pointRefSource("mystery", "k"); ok {
+		t.Error("unknown point kind must not build")
+	}
+	plane := sketch.XYPlane()
+	if _, ok := d.curveRefSource("edge", "k", plane); !ok {
+		t.Error("edge curve source should build")
+	}
+	if _, ok := d.curveRefSource("workAxis", string(feature.OriginXAxis), plane); !ok {
+		t.Error("workAxis source should build")
+	}
+	if _, ok := d.curveRefSource("workPlane", string(feature.OriginXZPlane), plane); !ok {
+		t.Error("workPlane source should build")
+	}
+	if _, ok := d.curveRefSource("mystery", "k", plane); ok {
+		t.Error("unknown curve kind must not build")
+	}
+}

--- a/model/compdef/work_reference_source.go
+++ b/model/compdef/work_reference_source.go
@@ -38,6 +38,9 @@ func NewWorkPointRefSource(part *PartComponentDefinition, ref feature.WorkRef) W
 // SourceID returns the datum reference (its stable cross-recompute identity).
 func (s WorkPointRefSource) SourceID() string { return string(s.ref) }
 
+// SourceKind tags this as a work-point reference for projection persistence/rebind (#1268).
+func (s WorkPointRefSource) SourceKind() string { return "workPoint" }
+
 // Position re-resolves the datum point by reference; ok=false when it no longer resolves.
 func (s WorkPointRefSource) Position() (math.Point3, bool) {
 	w, ok := s.work().WorkPointByRef(s.ref)
@@ -68,6 +71,9 @@ func NewWorkAxisRefSource(part *PartComponentDefinition, ref feature.WorkRef) Wo
 
 // SourceID returns the datum axis reference.
 func (s WorkAxisRefSource) SourceID() string { return string(s.ref) }
+
+// SourceKind tags this as a work-axis reference for projection persistence/rebind (#1268).
+func (s WorkAxisRefSource) SourceKind() string { return "workAxis" }
 
 // SamplePoints re-resolves the axis and returns its two endpoints at ±span from the origin;
 // ok=false when the axis no longer resolves.
@@ -105,6 +111,9 @@ func NewWorkPlaneRefSource(part *PartComponentDefinition, ref feature.WorkRef, t
 
 // SourceID returns the datum plane reference.
 func (s WorkPlaneRefSource) SourceID() string { return string(s.ref) }
+
+// SourceKind tags this as a work-plane reference for projection persistence/rebind (#1268).
+func (s WorkPlaneRefSource) SourceKind() string { return "workPlane" }
 
 // SamplePoints re-resolves the work plane and returns the two endpoints of its intersection
 // line with the target sketch plane, at ±span from the line's anchor point; ok=false when

--- a/model/sketch/projection.go
+++ b/model/sketch/projection.go
@@ -37,6 +37,10 @@ type ProjectedPoint struct {
 	plane  Plane
 	anchor *Point
 	linked bool
+	// srcKind/srcID persist the source's identity (its kind tag + SourceID) so a saved sketch
+	// round-trips: serialization writes them, restore keeps them, and compdef rebinds a live
+	// self-resolving source from them after a reload (#1268).
+	srcKind, srcID string
 }
 
 // EntityID is the anchor's id — constraining to this id binds to the fixed anchor.
@@ -88,6 +92,8 @@ type ProjectedCurve struct {
 	plane  Plane
 	points []math.Point2
 	linked bool
+	// srcKind/srcID persist the source's identity for save/reload + rebind (see ProjectedPoint).
+	srcKind, srcID string
 }
 
 // EntityID implements [Entity].
@@ -138,7 +144,10 @@ func (c *ProjectedCurve) BreakLink() { c.linked = false }
 // point and returns the associative projected point.
 func (s *Sketch) ProjectPoint(src PointSource) *ProjectedPoint {
 	pos, _ := src.Position() // resolved now; a later lost reference freezes via Update
-	p := &ProjectedPoint{source: src, plane: s.plane, anchor: s.newRefPoint(s.plane.ToSketch(pos)), linked: true}
+	p := &ProjectedPoint{
+		source: src, plane: s.plane, anchor: s.newRefPoint(s.plane.ToSketch(pos)), linked: true,
+		srcKind: pointSourceKind(src), srcID: src.SourceID(),
+	}
 	p.Update()
 	s.add(p)
 	return p
@@ -146,7 +155,10 @@ func (s *Sketch) ProjectPoint(src PointSource) *ProjectedPoint {
 
 // ProjectCurve projects a model edge into the sketch as reference geometry.
 func (s *Sketch) ProjectCurve(src CurveSource) *ProjectedCurve {
-	c := &ProjectedCurve{id: nextID(), source: src, plane: s.plane, linked: true}
+	c := &ProjectedCurve{
+		id: nextID(), source: src, plane: s.plane, linked: true,
+		srcKind: curveSourceKind(src), srcID: src.SourceID(),
+	}
 	c.Update()
 	s.add(c)
 	return c
@@ -177,4 +189,55 @@ func (s *Sketch) UpdateProjections() {
 		}
 	}
 	s.updateCloudAnchors() // re-project scan-anchored points so they follow their clouds (#645)
+}
+
+// sourceKinded is the optional interface a projection source implements to declare its kind
+// ("vertex"/"edge"/"workPoint"/"workAxis"/"workPlane"), so the sketch can persist enough to let
+// compdef rebuild a live source on restore (#1268). The model-side reference sources implement
+// it; a source that does not is persisted with an empty kind and stays frozen after a reload.
+type sourceKinded interface{ SourceKind() string }
+
+func pointSourceKind(src PointSource) string {
+	if k, ok := src.(sourceKinded); ok {
+		return k.SourceKind()
+	}
+	return ""
+}
+
+func curveSourceKind(src CurveSource) string {
+	if k, ok := src.(sourceKinded); ok {
+		return k.SourceKind()
+	}
+	return ""
+}
+
+// SourceDescriptor returns the (kind, id) a host uses to rebuild this projection's live source
+// after a reload; an empty kind means there is nothing to rebind (the projection stays frozen).
+func (p *ProjectedPoint) SourceDescriptor() (kind, id string) { return p.srcKind, p.srcID }
+
+// Rebind attaches a freshly built live source to a projection restored frozen, making it
+// associative again; the next UpdateProjections re-projects from it.
+func (p *ProjectedPoint) Rebind(src PointSource) { p.source, p.linked = src, true }
+
+// SourceDescriptor / Rebind for a projected curve mirror ProjectedPoint's.
+func (c *ProjectedCurve) SourceDescriptor() (kind, id string) { return c.srcKind, c.srcID }
+func (c *ProjectedCurve) Rebind(src CurveSource)              { c.source, c.linked = src, true }
+
+// RestoreProjectedPoint rebuilds a projected point frozen at pos, pinning the anchor's id so
+// constraints that reference it survive, and keeping the source descriptor for a later Rebind.
+// The host re-attaches the live source after load (compdef.rebindSketchProjections, #1268).
+func (s *Sketch) RestoreProjectedPoint(anchorID ID, pos math.Point2, srcKind, srcID string) *ProjectedPoint {
+	anchor := &Point{id: anchorID, X: pos.X, Y: pos.Y}
+	s.refPts = append(s.refPts, anchor)
+	p := &ProjectedPoint{plane: s.plane, anchor: anchor, linked: false, srcKind: srcKind, srcID: srcID}
+	s.add(p)
+	return p
+}
+
+// RestoreProjectedCurve rebuilds a projected curve frozen at the given polyline, pinning its id
+// and keeping the source descriptor for a later Rebind.
+func (s *Sketch) RestoreProjectedCurve(id ID, pts []math.Point2, srcKind, srcID string) *ProjectedCurve {
+	c := &ProjectedCurve{id: id, plane: s.plane, points: pts, linked: false, srcKind: srcKind, srcID: srcID}
+	s.add(c)
+	return c
 }

--- a/model/sketch/projection_test.go
+++ b/model/sketch/projection_test.go
@@ -65,6 +65,79 @@ func TestProjectedPointIsConstrainableAnchor(t *testing.T) {
 	}
 }
 
+// kindedVertex/kindedEdge are kinded fake sources, so the projection records a source kind for
+// persistence (the unkinded movableVertex/Edge record "").
+type kindedVertex struct{ movableVertex }
+
+func (kindedVertex) SourceKind() string { return "vertex" }
+
+type kindedEdge struct{ movableEdge }
+
+func (kindedEdge) SourceKind() string { return "edge" }
+
+// TestProjectedSourceDescriptorAndRebind covers the persistence seam: a projection records its
+// source (kind, id); a restored-frozen projection keeps the descriptor and re-links + re-projects
+// once a live source is rebound (#1268).
+func TestProjectedSourceDescriptorAndRebind(t *testing.T) {
+	live := NewSketches().Add(XYPlane())
+	pp := live.ProjectPoint(&kindedVertex{movableVertex{id: "v1", pos: math.P3(1, 2, 0)}})
+	if k, id := pp.SourceDescriptor(); k != "vertex" || id != "v1" {
+		t.Errorf("point descriptor = (%q,%q), want (vertex,v1)", k, id)
+	}
+	pc := live.ProjectCurve(&kindedEdge{movableEdge{id: "e1", samples: []math.Point3{{X: 0}, {X: 1}}}})
+	if k, id := pc.SourceDescriptor(); k != "edge" || id != "e1" {
+		t.Errorf("curve descriptor = (%q,%q), want (edge,e1)", k, id)
+	}
+
+	s := NewSketches().Add(XYPlane())
+	rp := s.RestoreProjectedPoint(ID(7), math.P2(1, 2), "vertex", "v1")
+	if rp.Linked() {
+		t.Error("a restored projection starts frozen (no live source yet)")
+	}
+	rp.Rebind(&movableVertex{id: "v1", pos: math.P3(5, 6, 0)})
+	rp.Update()
+	if !rp.Linked() || !rp.Position().IsEqualTo(math.P2(5, 6), tol) {
+		t.Errorf("after rebind+update the point should track its source, got %v linked=%v", rp.Position(), rp.Linked())
+	}
+
+	rc := s.RestoreProjectedCurve(ID(8), []math.Point2{{X: 0}, {X: 1}}, "edge", "e1")
+	if k, id := rc.SourceDescriptor(); k != "edge" || id != "e1" {
+		t.Errorf("restored curve descriptor = (%q,%q), want (edge,e1)", k, id)
+	}
+	rc.Rebind(&movableEdge{id: "e1", samples: []math.Point3{{X: 0}, {X: 2}, {X: 4}}})
+	rc.Update()
+	if !rc.Linked() || len(rc.Points()) != 3 {
+		t.Errorf("after rebind the curve should re-project, got %d points linked=%v", len(rc.Points()), rc.Linked())
+	}
+}
+
+// TestProjectedAnchorIsPickable proves the projected anchor appears in AllPoints — the
+// pick/snap/selection candidate set — so a coincident constraint can actually be picked to it
+// (#1268; the anchor was previously omitted, so the user's click found nothing and no
+// constraint was ever created).
+func TestProjectedAnchorIsPickable(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	pp := s.ProjectPoint(&movableVertex{id: "v1", pos: math.P3(4, 2, 0)})
+	free := s.Points().Add(math.P2(0, 0))
+
+	pts := s.AllPoints()
+	if !containsPoint(pts, pp.Anchor()) {
+		t.Error("AllPoints must include the projected anchor so it can be picked/snapped")
+	}
+	if !containsPoint(pts, free) {
+		t.Error("AllPoints must still include free points")
+	}
+}
+
+func containsPoint(pts []*Point, p *Point) bool {
+	for _, q := range pts {
+		if q == p {
+			return true
+		}
+	}
+	return false
+}
+
 // TestProjectedLostReferenceFreezes checks UpdateProjections breaks the link and freezes
 // geometry when a projected source's reference is lost.
 func TestProjectedLostReferenceFreezes(t *testing.T) {

--- a/model/sketch/projection_test.go
+++ b/model/sketch/projection_test.go
@@ -226,3 +226,48 @@ func TestProjectCutEdgesProjectsEachSource(t *testing.T) {
 		t.Error("broken curve link still reports linked/source")
 	}
 }
+
+// TestProjectedGeometrySerializeRoundTrip exercises the model-side serialize/restore of projected
+// geometry (the codec that used to be missing, #1268): a projected point and curve survive a
+// MarshalRecipe→ApplyRecipe, restoring frozen with their anchor id, geometry and source
+// descriptor preserved (the host rebinds the live source separately).
+func TestProjectedGeometrySerializeRoundTrip(t *testing.T) {
+	sc := NewSketches()
+	s := sc.Add(XYPlane())
+	pp := s.ProjectPoint(&kindedVertex{movableVertex{id: "v9", pos: math.P3(2, 3, 0)}})
+	anchorID := pp.EntityID()
+	s.ProjectCurve(&kindedEdge{movableEdge{id: "e9", samples: []math.Point3{{X: 0}, {X: 1, Y: 1}}}})
+
+	out := roundTrip(t, sc)
+	var rp *ProjectedPoint
+	var rc *ProjectedCurve
+	for _, e := range out.Entities() {
+		switch v := e.(type) {
+		case *ProjectedPoint:
+			rp = v
+		case *ProjectedCurve:
+			rc = v
+		}
+	}
+	if rp == nil || rc == nil {
+		t.Fatalf("projected geometry lost on round trip: point=%v curve=%v", rp, rc)
+	}
+	if rp.EntityID() != anchorID {
+		t.Errorf("restored anchor id = %d, want %d (constraints reference it)", rp.EntityID(), anchorID)
+	}
+	if !rp.Position().IsEqualTo(math.P2(2, 3), tol) {
+		t.Errorf("restored projected point at %v, want frozen (2,3)", rp.Position())
+	}
+	if k, id := rp.SourceDescriptor(); k != "vertex" || id != "v9" {
+		t.Errorf("restored point descriptor = (%q,%q), want (vertex,v9)", k, id)
+	}
+	if rp.Linked() {
+		t.Error("restored projection should be frozen until the host rebinds it")
+	}
+	if k, id := rc.SourceDescriptor(); k != "edge" || id != "e9" {
+		t.Errorf("restored curve descriptor = (%q,%q), want (edge,e9)", k, id)
+	}
+	if len(rc.Points()) != 2 {
+		t.Errorf("restored curve has %d points, want 2", len(rc.Points()))
+	}
+}

--- a/model/sketch/serialize.go
+++ b/model/sketch/serialize.go
@@ -87,6 +87,8 @@ type EntityData struct {
 	Fit          bool      `yaml:"fit,omitempty"`
 	Construction bool      `yaml:"construction,omitempty"`
 	Centerline   bool      `yaml:"centerline,omitempty"`   // line only: an axis
+	Source       string    `yaml:"source,omitempty"`       // projected*: the source's SourceID
+	SourceKind   string    `yaml:"sourceKind,omitempty"`   // projected*: vertex|edge|workPoint|workAxis|workPlane
 	ImageRef     string    `yaml:"imageRef,omitempty"`     // image only
 	Anchor       []float64 `yaml:"anchor,omitempty"`       // image/text: [x, y]
 	Size         []float64 `yaml:"size,omitempty"`         // image only: [w, h]
@@ -290,6 +292,15 @@ func serializeEntity(e Entity) (EntityData, error) {
 			Size:     []float64{float64(v.Width), float64(v.Height)},
 			Rotation: float64(v.Rotation), Opacity: v.Opacity,
 		}, nil
+	case *ProjectedPoint:
+		kind, id := v.SourceDescriptor()
+		return EntityData{
+			ID: int(v.anchor.id), Kind: "projectedPoint", Points: []int{int(v.anchor.id)},
+			Anchor: []float64{float64(v.anchor.X), float64(v.anchor.Y)}, Source: id, SourceKind: kind,
+		}, nil
+	case *ProjectedCurve:
+		kind, id := v.SourceDescriptor()
+		return EntityData{ID: int(v.id), Kind: "projectedCurve", Coords: flattenPoints(v.points), Source: id, SourceKind: kind}, nil
 	case *FillRegion:
 		return EntityData{ID: int(v.id), Kind: "fillRegion", Seed: []float64{float64(v.Seed.X), float64(v.Seed.Y)}, Style: v.Style}, nil
 	case *TextBox:

--- a/model/sketch/serialize_restore.go
+++ b/model/sketch/serialize_restore.go
@@ -183,13 +183,19 @@ func (r *sketchRestorer) restoreEntities(entities []EntityData) error {
 		if err != nil {
 			return err
 		}
-		e.(interface{ SetConstruction(bool) }).SetConstruction(ed.Construction)
+		// Projected reference entities (#1268) carry no construction flag and pin their own ids,
+		// so each post-step is optional rather than a hard type-assert.
+		if sc, ok := e.(interface{ SetConstruction(bool) }); ok {
+			sc.SetConstruction(ed.Construction)
+		}
 		if ed.Centerline {
 			if cl, ok := e.(interface{ SetCenterline(bool) }); ok {
 				cl.SetCenterline(true)
 			}
 		}
-		r.pin(e.(idCarrier), ed.ID)
+		if ic, ok := e.(idCarrier); ok {
+			r.pin(ic, ed.ID)
+		}
 		r.entityMap[ed.ID] = e
 	}
 	return nil
@@ -265,8 +271,36 @@ func (r *sketchRestorer) restoreEntity(ed EntityData) (Entity, error) {
 			TextHJustify(ed.Justify), TextVJustify(ed.VJustify), ed.FontFamily, math.Scalar(ed.FontSize))
 		tb.FontResource = ed.FontResource
 		return tb, nil
+	case "projectedPoint":
+		return r.restoreProjectedPoint(ed)
+	case "projectedCurve":
+		c := r.s.RestoreProjectedCurve(ID(ed.ID), unflattenPoints(ed.Coords), ed.SourceKind, ed.Source)
+		r.note(ed.ID)
+		return c, nil
 	default:
 		return r.restoreDerivedCurve(ed)
+	}
+}
+
+// restoreProjectedPoint rebuilds a frozen projected point and registers its anchor in the point
+// map so constraints referencing the anchor restore, pinning the anchor id (#1268).
+func (r *sketchRestorer) restoreProjectedPoint(ed EntityData) (Entity, error) {
+	if len(ed.Points) < 1 || len(ed.Anchor) < 2 {
+		return nil, fmt.Errorf("projectedPoint needs an anchor id and a 2-component anchor")
+	}
+	pos := math.P2(math.Scalar(ed.Anchor[0]), math.Scalar(ed.Anchor[1]))
+	pp := r.s.RestoreProjectedPoint(ID(ed.Points[0]), pos, ed.SourceKind, ed.Source)
+	r.pointMap[ed.Points[0]] = pp.Anchor()
+	r.note(ed.Points[0])
+	r.note(ed.ID)
+	return pp, nil
+}
+
+// note raises the restorer's max-id watermark for an id pinned outside pin() (the
+// self-id'd projected entities), so later minted ids never collide with restored ones.
+func (r *sketchRestorer) note(id int) {
+	if uint64(id) > r.maxID {
+		r.maxID = uint64(id)
 	}
 }
 

--- a/model/sketch/sketch.go
+++ b/model/sketch/sketch.go
@@ -246,11 +246,16 @@ func (s *Sketch) PointByID(id ID) (*Point, bool) {
 	return nil, false
 }
 
-// AllPoints returns every constrainable point in the sketch — endpoints, centers,
-// and standalone points — which are the solver's position variables.
+// AllPoints returns every constrainable point in the sketch — free points (endpoints,
+// centers, standalone) AND the fixed projected/reference anchors (refPts). It is the
+// pick/snap/inference candidate set, so projected geometry (e.g. the origin centre point) can
+// be selected and constrained to; the solver's free-variable universe is variables(), which
+// deliberately excludes the fixed anchors. Before #1268 the anchors were omitted here, so a
+// coincident constraint to a projected point could never be picked.
 func (s *Sketch) AllPoints() []*Point {
-	out := make([]*Point, len(s.pts))
-	copy(out, s.pts)
+	out := make([]*Point, 0, len(s.pts)+len(s.refPts))
+	out = append(out, s.pts...)
+	out = append(out, s.refPts...)
 	return out
 }
 


### PR DESCRIPTION
Fixes #1268.

## What

The report surfaced **two** projection bugs:

1. **Reported:** a coincident constraint between a rectangle vertex and a *projected* point (the origin centre) did nothing — the rectangle never moved.
2. **Critical, also in the report's document dump:** saving failed entirely — `cannot serialize entity of type *sketch.ProjectedPoint (no codec)`. Because new sketches auto-project the origin centre (#1262), **every part with a sketch was unsaveable**.

## Root causes & fixes

**1. Projected anchor wasn't pickable.** A projected point's anchor lives in the sketch's `refPts`, but `Sketch.AllPoints()` — the pick/snap/selection candidate set — returned only `pts`. So clicking the projected centre selected nothing and no constraint could form. `AllPoints` now includes the fixed anchors. The solver's free-variable universe (`variables()`) still excludes them, so the anchor stays put while the picked geometry is pulled to it (the solver already handled this — it builds a numerical Jacobian over the free vars only).

**2. Projected geometry didn't persist.** `ProjectedPoint`/`ProjectedCurve` (and `refPts`) had no serialization codec, so save crashed. Now:
- They serialize their geometry (anchor / polyline) plus a **source descriptor** — a `kind` tag (`vertex`/`edge`/`workPoint`/`workAxis`/`workPlane`) + the `SourceID` (reference sources gained `SourceKind()`).
- They restore **frozen**, preserving the anchor id so constraints referencing it survive.
- `compdef.rebindSketchProjections` (run before recompute on restore) rebuilds a live self-resolving source from the descriptor and re-attaches it, so projections are **associative again** after reload.

## Tests

- `model/sketch`: projected anchor is in `AllPoints`; source descriptor + restore + rebind re-projects.
- `model/compdef`: full save→restore round-trip (no crash; projected point/curve re-linked at correct geometry; coincident constraint survives); source-kind tags; rebind builders for every kind.
- `app`: end-to-end — with the origin auto-projected, picking the anchor + a free point and applying coincident pulls the geometry to the origin.

## Verification

`go build ./...`, full `model/sketch` / `model/compdef` / `app` / `addin` suites pass; `gofmt` + `golangci-lint` clean.

**Live-confirmed** offscreen: a rectangle corner constrained coincident to the projected origin snaps to the origin (where the X/Y axes cross).

🤖 Generated with [Claude Code](https://claude.com/claude-code)