### PR TITLE
fix(head): darwin go.sum + validate the macOS/Windows head build on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,76 @@ jobs:
           name: coverage-head
           path: head/coverage.out
 
+  # cgo GUI head — macOS compile check on EVERY PR (Apple Silicon + Intel). build.yml
+  # only builds the macOS head in the release/nightly pipeline, and there it is gated on
+  # the signing secrets, so darwin-only cgo / go.sum breakage used to reach develop
+  # completely unvalidated (it surfaced only post-merge in nightly). Compiling the whole
+  # head module on both Mac arches here makes a green PR guarantee the macOS build won't
+  # break. Build-only: headless CI Macs have no window server for GLFW and no Metal
+  # device for MoltenVK, so the in-window e2e tests stay on the ubuntu `head` job (xvfb +
+  # lavapipe). The dep list mirrors build.yml's head-macos-build.
+  head-macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [macos-14, macos-15-intel]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+          cache: false
+      - uses: ./.github/actions/api-contract
+        with:
+          modules: head
+      - name: Install cgo + Vulkan deps
+        run: brew install glfw vulkan-loader vulkan-headers molten-vk pkg-config
+      - name: Build head
+        working-directory: head
+        run: CGO_ENABLED=1 go build ./...
+
+  # cgo GUI head — Windows compile check on EVERY PR (mingw toolchain). Mirrors
+  # build.yml's head-windows minus packaging, so mingw/cgo breakage is caught pre-merge
+  # rather than in nightly. msys2 provides the Go + gcc + glfw/vulkan toolchain; the api
+  # contract is resolved/checked out in bash then pinned in the msys2 shell (the same
+  # split build.yml uses, because that job's Go lives inside msys2).
+  head-windows:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v5
+      - id: api
+        shell: bash
+        run: echo "version=$(scripts/latest-api-version.sh)" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@v5
+        with:
+          repository: Oblikovati/Oblikovati.API
+          ref: ${{ steps.api.outputs.version }}
+          path: _api
+      - uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            mingw-w64-x86_64-go
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-pkgconf
+            mingw-w64-x86_64-glfw
+            mingw-w64-x86_64-vulkan-loader
+            mingw-w64-x86_64-vulkan-headers
+      - name: Pin + replace api to the release
+        env:
+          VERSION: ${{ steps.api.outputs.version }}
+        run: |
+          go -C head mod edit -require="oblikovati.org/api@$VERSION"
+          go -C head mod edit -replace "oblikovati.org/api=$GITHUB_WORKSPACE/_api"
+      - name: Build head
+        working-directory: head
+        run: CGO_ENABLED=1 go build ./...
+
   # Confirm the cgo-free core cross-compiles for every shipping target.
   build:
     runs-on: ubuntu-latest

--- a/head/go.mod
+++ b/head/go.mod
@@ -19,6 +19,7 @@ require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph norm
 require (
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4 // indirect
+	golang.org/x/sys v0.20.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/head/go.sum
+++ b/head/go.sum
@@ -8,9 +8,11 @@ golang.org/x/image v0.0.0-20211028202545-6944b10bf410 h1:hTftEOvwiOq2+O8k2D5/Q7C
 golang.org/x/image v0.0.0-20211028202545-6944b10bf410/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
 golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4 h1:DZshvxDdVoeKIbudAdFEKi+f70l51luSy/7b76ibTY0=
 golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
+golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.22.0 h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM=
 golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=
-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## What
1. `go mod tidy` on the head module → add `golang.org/x/sys v0.20.0` (indirect) + `go.sum` hashes, fixing the darwin head build.
2. Harden the PR pipeline: build the cgo head on **macOS (arm64 + Intel)** and **Windows** on every PR (`head-macos`, `head-windows`), mirroring build.yml's toolchains.

## Why
The macOS head build had **never run on a PR** — build.yml only builds it in the release/nightly pipeline, gated behind the Developer ID signing secrets. So darwin-only cgo/`go.sum` breakage reached `develop` unvalidated and only showed up post-merge in nightly. That is exactly how this `x/sys` gap escaped: `usagestats` reaches `golang.org/x/sys/unix` only on darwin (its probe uses `sysctl`; the linux probe uses bare `syscall`), and the head module never recorded `x/sys`.

A green PR must guarantee every platform's head compiles, so we can't risk a merge breaking `develop`. The new compile jobs close that gap — and this PR's own `head-macos` job is the first real CI proof that the darwin head builds.

Build-only on macOS/Windows: headless CI runners have no window server for GLFW and no GPU/Vulkan device for MoltenVK, so the in-window e2e tests remain on the ubuntu `head` job (xvfb + lavapipe), which already runs them for real.

## Verification
- Local: `go build oblikovati.org/usagestats` for darwin/linux/windows under `-mod=readonly` (darwin was the failing path).
- CI: the new `head-macos` / `head-windows` jobs on this PR.

## Follow-up
Consider marking `head-macos` and `head-windows` as **required status checks** in branch protection so they truly gate merges into `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)