### PR TITLE
fix(release): exclude macOS staging artifacts from published releases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -82,7 +82,17 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p dist
-          find artifacts -type f -exec cp {} dist/ \;
+          # Collect ONLY shippable artifacts. The macOS universal build also uploads
+          # per-arch staging artifacts (head-macos-stage-*: the bare unsigned
+          # oblikovati-head binary + bundled *.dylib) for the lipo step; those must
+          # never land on the public release, so select by release filename shape
+          # rather than copying every downloaded file.
+          find artifacts -type f \( \
+            -name '*.AppImage' -o \
+            -name '*-macos-universal.zip' -o \
+            -name '*-windows-amd64.zip' -o \
+            -name 'oblikovati-cli-*' \
+          \) -exec cp {} dist/ \;
           ( cd dist && files=$(ls) && sha256sum $files > checksums.txt )
           ls -la dist
       - name: Publish rolling nightly prerelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,17 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p dist
-          find artifacts -type f -exec cp {} dist/ \;
+          # Collect ONLY shippable artifacts. The macOS universal build also uploads
+          # per-arch staging artifacts (head-macos-stage-*: the bare unsigned
+          # oblikovati-head binary + bundled *.dylib) for the lipo step; those must
+          # never land on the public release, so select by release filename shape
+          # rather than copying every downloaded file.
+          find artifacts -type f \( \
+            -name '*.AppImage' -o \
+            -name '*-macos-universal.zip' -o \
+            -name '*-windows-amd64.zip' -o \
+            -name 'oblikovati-cli-*' \
+          \) -exec cp {} dist/ \;
           ( cd dist && files=$(ls) && sha256sum $files > checksums.txt )
           ls -la dist
       - name: Publish stable release


### PR DESCRIPTION
## What
The `publish` job in both `release.yml` and `nightly.yml` now collects only shippable artifacts by filename shape instead of `find artifacts -type f` (copy-everything).

## Why
With the macOS universal build now running, `head-macos-build` uploads per-arch **staging** artifacts (`head-macos-stage-*`) — the bare unsigned `oblikovati-head` binary plus the bundled `libMoltenVK.dylib` / `libvulkan.1.dylib` / `libglfw.3.dylib` — purely so the `head-macos` job can `lipo` them into the universal bundle. The blanket copy published those intermediates onto the release, so the nightly release showed loose `.dylib` files and an unsigned bare binary next to the real signed download.

Allowlist: `*.AppImage`, `*-macos-universal.zip`, `*-windows-amd64.zip`, `oblikovati-cli-*`.

## Verification
Simulated the artifacts tree (real leaked names) and ran the new `find` allowlist: `dist/` contains exactly the 5 shippable files and none of the staging `.dylib`s or bare binary. (The publish step only runs in nightly/release, not on PRs, so this is verified locally; the next nightly will confirm clean release assets.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)