### PR TITLE
M36-F01: kernel NURBS rebuild primitives (knot insert/remove, degree elevate/reduce)

### DIFF
--- a/kernel/geom/bspline_compatible.go
+++ b/kernel/geom/bspline_compatible.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+// Making two curves compatible — a common degree and a common knot vector — so they can
+// skin a tensor-product surface (loft between two sections, or one row/column of a curve
+// network). Both curves are first reparametrized to [0, 1], then raised to the higher of
+// the two degrees and refined to the union of their interior knots. The results are
+// geometrically unchanged (reparametrization, degree elevation and knot insertion are all
+// shape-preserving), differing only in representation (M36-F01).
+
+// MakeCompatible returns a and b raised to a common degree and knot vector. The inputs are
+// reparametrized to the domain [0, 1] first, so curves with different parameter ranges still
+// align. The outputs trace the same geometry as the inputs and share Degree and Knots, the
+// precondition for [NewBSplineSurface] over a pair (or a grid) of section curves.
+func MakeCompatible(a, b BSplineCurve) (BSplineCurve, BSplineCurve, error) {
+	a = a.reparametrizedUnit()
+	b = b.reparametrizedUnit()
+	a, b, err := matchDegree(a, b)
+	if err != nil {
+		return BSplineCurve{}, BSplineCurve{}, err
+	}
+	return matchKnots(a, b)
+}
+
+// matchDegree elevates whichever curve has the lower degree up to the other's.
+func matchDegree(a, b BSplineCurve) (BSplineCurve, BSplineCurve, error) {
+	switch {
+	case a.Degree < b.Degree:
+		ea, err := a.ElevateDegree(b.Degree - a.Degree)
+		return ea, b, err
+	case b.Degree < a.Degree:
+		eb, err := b.ElevateDegree(a.Degree - b.Degree)
+		return a, eb, err
+	default:
+		return a, b, nil
+	}
+}
+
+// matchKnots refines each curve with the interior knots it is missing relative to the
+// other, so both end on the union knot vector (both already share degree and domain).
+func matchKnots(a, b BSplineCurve) (BSplineCurve, BSplineCurve, error) {
+	va, ea := mergedInteriorKnots(a.Degree, a.Knots, b.Knots)
+	vb, eb := mergedInteriorKnots(b.Degree, b.Knots, a.Knots)
+	ra, err := a.RefineKnots(expandKnots(va, ea))
+	if err != nil {
+		return BSplineCurve{}, BSplineCurve{}, err
+	}
+	rb, err := b.RefineKnots(expandKnots(vb, eb))
+	if err != nil {
+		return BSplineCurve{}, BSplineCurve{}, err
+	}
+	return ra, rb, nil
+}
+
+// reparametrizedUnit returns c with its knot vector rescaled to [0, 1]; the geometry is
+// unchanged (a reparametrization), only the knot values move.
+func (c BSplineCurve) reparametrizedUnit() BSplineCurve {
+	return BSplineCurve{Degree: c.Degree, Ctrl: c.Ctrl, Weights: c.Weights, Knots: normalizeKnots(c.Knots)}
+}
+
+// expandKnots flattens a (values, extra) difference list into a flat slice with each value
+// repeated extra[i] times, the form [BSplineCurve.RefineKnots] consumes.
+func expandKnots(values []float64, extra []int) []float64 {
+	var out []float64
+	for i, v := range values {
+		for k := 0; k < extra[i]; k++ {
+			out = append(out, v)
+		}
+	}
+	return out
+}

--- a/kernel/geom/bspline_compatible_test.go
+++ b/kernel/geom/bspline_compatible_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+func TestMakeCompatibleEqualizesDegreeAndKnots(t *testing.T) {
+	// a: quadratic with an interior knot at 0.5; b: cubic with an interior knot at 0.25,
+	// over a different parameter range. After MakeCompatible both must share degree and knots.
+	a, err := NewBSplineCurveUniformWeights(
+		2,
+		[]math.Point3{math.P3(0, 0, 0), math.P3(1, 1, 0), math.P3(2, 0, 0), math.P3(3, 1, 0)},
+		[]float64{0, 0, 0, 0.5, 1, 1, 1},
+	)
+	if err != nil {
+		t.Fatalf("curve a: %v", err)
+	}
+	b, err := NewBSplineCurveUniformWeights(
+		3,
+		[]math.Point3{math.P3(0, 2, 0), math.P3(1, 3, 0), math.P3(2, 2, 0), math.P3(3, 3, 0), math.P3(4, 2, 0)},
+		[]float64{2, 2, 2, 2, 3, 4, 4, 4, 4},
+	)
+	if err != nil {
+		t.Fatalf("curve b: %v", err)
+	}
+
+	ca, cb, err := MakeCompatible(a, b)
+	if err != nil {
+		t.Fatalf("MakeCompatible: %v", err)
+	}
+	if ca.Degree != cb.Degree || ca.Degree != 3 {
+		t.Errorf("degrees = %d,%d, want both 3", ca.Degree, cb.Degree)
+	}
+	if len(ca.Knots) != len(cb.Knots) {
+		t.Fatalf("knot counts differ: %d vs %d", len(ca.Knots), len(cb.Knots))
+	}
+	for i := range ca.Knots {
+		if ca.Knots[i] != cb.Knots[i] {
+			t.Fatalf("knot %d differs: %g vs %g", i, ca.Knots[i], cb.Knots[i])
+		}
+	}
+	if len(ca.Ctrl) != len(cb.Ctrl) {
+		t.Errorf("control counts differ: %d vs %d", len(ca.Ctrl), len(cb.Ctrl))
+	}
+}
+
+func TestMakeCompatiblePreservesGeometry(t *testing.T) {
+	a, err := NewBSplineCurveUniformWeights(
+		2,
+		[]math.Point3{math.P3(0, 0, 0), math.P3(1, 2, 0), math.P3(3, 0, 0)},
+		[]float64{0, 0, 0, 1, 1, 1},
+	)
+	if err != nil {
+		t.Fatalf("curve a: %v", err)
+	}
+	b, err := NewBSplineCurveUniformWeights(
+		3,
+		[]math.Point3{math.P3(0, 1, 0), math.P3(1, 2, 0), math.P3(2, 0, 0), math.P3(3, 1, 0)},
+		[]float64{0, 0, 0, 0, 1, 1, 1, 1},
+	)
+	if err != nil {
+		t.Fatalf("curve b: %v", err)
+	}
+	ca, cb, err := MakeCompatible(a, b)
+	if err != nil {
+		t.Fatalf("MakeCompatible: %v", err)
+	}
+	// a and b share the domain [0,1] already, so the compatible curves must trace the
+	// same points as the originals (reparametrization is the identity here).
+	for i := 0; i <= 20; i++ {
+		u := float64(i) / 20
+		if !a.PointAt(u).IsEqualTo(ca.PointAt(u), 1e-9) {
+			t.Fatalf("curve a diverges at u=%g after MakeCompatible", u)
+		}
+		if !b.PointAt(u).IsEqualTo(cb.PointAt(u), 1e-9) {
+			t.Fatalf("curve b diverges at u=%g after MakeCompatible", u)
+		}
+	}
+}
+
+func TestMakeCompatibleElevatesEitherSide(t *testing.T) {
+	// a is the higher-degree curve here, exercising the b<a branch of matchDegree.
+	a, err := NewBSplineCurveUniformWeights(
+		3,
+		[]math.Point3{math.P3(0, 0, 0), math.P3(1, 1, 0), math.P3(2, 0, 0), math.P3(3, 1, 0)},
+		[]float64{0, 0, 0, 0, 1, 1, 1, 1},
+	)
+	if err != nil {
+		t.Fatalf("curve a: %v", err)
+	}
+	b, err := NewBSplineCurveUniformWeights(
+		2,
+		[]math.Point3{math.P3(0, 2, 0), math.P3(1, 3, 0), math.P3(2, 2, 0)},
+		[]float64{0, 0, 0, 1, 1, 1},
+	)
+	if err != nil {
+		t.Fatalf("curve b: %v", err)
+	}
+	ca, cb, err := MakeCompatible(a, b)
+	if err != nil {
+		t.Fatalf("MakeCompatible: %v", err)
+	}
+	if ca.Degree != 3 || cb.Degree != 3 {
+		t.Errorf("degrees = %d,%d, want both 3", ca.Degree, cb.Degree)
+	}
+}
+
+func TestExpandKnots(t *testing.T) {
+	got := expandKnots([]float64{0.25, 0.5}, []int{1, 2})
+	want := []float64{0.25, 0.5, 0.5}
+	if len(got) != len(want) {
+		t.Fatalf("expandKnots = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expandKnots = %v, want %v", got, want)
+		}
+	}
+}

--- a/kernel/geom/bspline_curve_refine.go
+++ b/kernel/geom/bspline_curve_refine.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+// Public knot-refinement on the rational B-spline curve types. Each method returns
+// a NEW geometrically-identical curve with a refined knot vector; the receiver is
+// unchanged (the BSpline types are value-immutable). Refinement underpins the
+// higher-level Class-A operations — rebuild, CV editing, match, extend (M36-F01).
+
+// InsertKnot returns a curve geometrically identical to c with the knot u inserted r
+// times (Boehm, A5.1). It is exact: the curve is unchanged, only its control polygon
+// is subdivided. It errors when r < 1, u lies outside the open domain, or r would
+// raise u's multiplicity past the degree.
+//
+// Example: refined, _ := c.InsertKnot(0.5, 1) // add a control point at the midspan.
+func (c BSplineCurve) InsertKnot(u float64, r int) (BSplineCurve, error) {
+	if err := validateInsert(c.Degree, c.Knots, u, r); err != nil {
+		return BSplineCurve{}, err
+	}
+	newU, newPw := insertKnotHomog(c.Degree, c.Knots, curveToHomog(c.Ctrl, c.Weights), u, r)
+	ctrl, weights := curveFromHomog(newPw)
+	return NewBSplineCurve(c.Degree, ctrl, weights, newU)
+}
+
+// RefineKnots inserts every value in us into the curve (a value repeated in us is
+// inserted with that multiplicity), returning the exactly-equal refined curve. It is
+// the bulk form of [BSplineCurve.InsertKnot] used to make two curves knot-compatible.
+func (c BSplineCurve) RefineKnots(us []float64) (BSplineCurve, error) {
+	U, pw := append([]float64(nil), c.Knots...), curveToHomog(c.Ctrl, c.Weights)
+	for _, u := range us {
+		if err := validateInsert(c.Degree, U, u, 1); err != nil {
+			return BSplineCurve{}, err
+		}
+		U, pw = insertKnotHomog(c.Degree, U, pw, u, 1)
+	}
+	ctrl, weights := curveFromHomog(pw)
+	return NewBSplineCurve(c.Degree, ctrl, weights, U)
+}
+
+// InsertKnot is the 2D analogue of [BSplineCurve.InsertKnot].
+func (c BSplineCurve2d) InsertKnot(u float64, r int) (BSplineCurve2d, error) {
+	if err := validateInsert(c.Degree, c.Knots, u, r); err != nil {
+		return BSplineCurve2d{}, err
+	}
+	newU, newPw := insertKnotHomog(c.Degree, c.Knots, curve2dToHomog(c.Ctrl, c.Weights), u, r)
+	ctrl, weights := curve2dFromHomog(newPw)
+	return NewBSplineCurve2d(c.Degree, ctrl, weights, newU)
+}
+
+// RefineKnots is the 2D analogue of [BSplineCurve.RefineKnots].
+func (c BSplineCurve2d) RefineKnots(us []float64) (BSplineCurve2d, error) {
+	U, pw := append([]float64(nil), c.Knots...), curve2dToHomog(c.Ctrl, c.Weights)
+	for _, u := range us {
+		if err := validateInsert(c.Degree, U, u, 1); err != nil {
+			return BSplineCurve2d{}, err
+		}
+		U, pw = insertKnotHomog(c.Degree, U, pw, u, 1)
+	}
+	ctrl, weights := curve2dFromHomog(pw)
+	return NewBSplineCurve2d(c.Degree, ctrl, weights, U)
+}

--- a/kernel/geom/bspline_elevate.go
+++ b/kernel/geom/bspline_elevate.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	"fmt"
+
+	"oblikovati.org/math"
+)
+
+// Public degree elevation on the rational B-spline types. Elevation is exact: it raises
+// the degree by t and adds control points while preserving the geometry. It is how two
+// curves are brought to a common degree before a tensor-product surface op, and how a
+// surface reaches the degree a G2/G3 blend needs (M36-F01).
+
+// ElevateDegree returns a curve of degree+t geometrically identical to c (A5.9).
+// It errors when t < 1.
+//
+// Example: cubic, _ := quad.ElevateDegree(1) // degree 2 → 3, same curve.
+func (c BSplineCurve) ElevateDegree(t int) (BSplineCurve, error) {
+	if t < 1 {
+		return BSplineCurve{}, fmt.Errorf("geom: degree elevation amount %d must be >= 1", t)
+	}
+	newU, newPw := elevateDegreeHomog(c.Degree, t, c.Knots, curveToHomog(c.Ctrl, c.Weights))
+	ctrl, weights := curveFromHomog(newPw)
+	return NewBSplineCurve(c.Degree+t, ctrl, weights, newU)
+}
+
+// ElevateDegree is the 2D analogue of [BSplineCurve.ElevateDegree].
+func (c BSplineCurve2d) ElevateDegree(t int) (BSplineCurve2d, error) {
+	if t < 1 {
+		return BSplineCurve2d{}, fmt.Errorf("geom: degree elevation amount %d must be >= 1", t)
+	}
+	newU, newPw := elevateDegreeHomog(c.Degree, t, c.Knots, curve2dToHomog(c.Ctrl, c.Weights))
+	ctrl, weights := curve2dFromHomog(newPw)
+	return NewBSplineCurve2d(c.Degree+t, ctrl, weights, newU)
+}
+
+// ElevateDegreeU returns the surface with its U degree raised by t, geometry preserved
+// (each v-column is elevated as a U-direction curve, all sharing the new U knot vector).
+func (s BSplineSurface) ElevateDegreeU(t int) (BSplineSurface, error) {
+	if t < 1 {
+		return BSplineSurface{}, fmt.Errorf("geom: degree elevation amount %d must be >= 1", t)
+	}
+	vCount := len(s.Ctrl[0])
+	cols := make([][]hpoint4, vCount)
+	var newU []float64
+	for j := 0; j < vCount; j++ {
+		newU, cols[j] = elevateDegreeHomog(s.UDegree, t, s.UKnots, columnToHomog(s, j))
+	}
+	ctrl, weights := netFromColumns(cols)
+	return NewBSplineSurface(s.UDegree+t, s.VDegree, ctrl, weights, newU, s.VKnots)
+}
+
+// ElevateDegreeV is the V-direction analogue of [BSplineSurface.ElevateDegreeU] (row-wise).
+func (s BSplineSurface) ElevateDegreeV(t int) (BSplineSurface, error) {
+	if t < 1 {
+		return BSplineSurface{}, fmt.Errorf("geom: degree elevation amount %d must be >= 1", t)
+	}
+	uCount := len(s.Ctrl)
+	ctrl := make([][]math.Point3, uCount)
+	weights := make([][]float64, uCount)
+	var newV []float64
+	for i := 0; i < uCount; i++ {
+		var elevated []hpoint4
+		newV, elevated = elevateDegreeHomog(s.VDegree, t, s.VKnots, rowToHomog(s, i))
+		ctrl[i], weights[i] = curveFromHomog(elevated)
+	}
+	return NewBSplineSurface(s.UDegree, s.VDegree+t, ctrl, weights, s.UKnots, newV)
+}

--- a/kernel/geom/bspline_reduce.go
+++ b/kernel/geom/bspline_reduce.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	"fmt"
+
+	"oblikovati.org/math"
+)
+
+// Public degree reduction on the rational B-spline types. Reduction is approximate and
+// reports ok=false (leaving the input unchanged) when the shape cannot be represented one
+// degree lower within tol. It is the inverse of degree elevation: a curve produced by
+// [BSplineCurve.ElevateDegree] reduces back exactly. After dropping to the C^0 form the
+// redundant join knots are removed within tol to restore the natural knot structure (M36-F01).
+
+// ReduceDegree returns a curve of degree−1 approximating c within tol, with ok=false (and
+// c unchanged) when c is not reducible at that tolerance. It errors when c is already
+// degree 1 (degree 0 is not a meaningful curve).
+//
+// Example: quad, ok, _ := cubic.ReduceDegree(1e-6) // back to degree 2 if the shape allows.
+func (c BSplineCurve) ReduceDegree(tol float64) (BSplineCurve, bool, error) {
+	if c.Degree < 2 {
+		return c, false, fmt.Errorf("geom: cannot reduce a degree-%d curve below degree 1", c.Degree)
+	}
+	newU, newPw, ok := degreeReduceHomog(c.Degree, c.Knots, curveToHomog(c.Ctrl, c.Weights), tol)
+	if !ok {
+		return c, false, nil
+	}
+	ctrl, weights := curveFromHomog(newPw)
+	reduced, err := NewBSplineCurve(c.Degree-1, ctrl, weights, newU)
+	if err != nil {
+		return c, false, err
+	}
+	return cleanCurveKnots(reduced, tol), true, nil
+}
+
+// ReduceDegree is the 2D analogue of [BSplineCurve.ReduceDegree].
+func (c BSplineCurve2d) ReduceDegree(tol float64) (BSplineCurve2d, bool, error) {
+	if c.Degree < 2 {
+		return c, false, fmt.Errorf("geom: cannot reduce a degree-%d curve below degree 1", c.Degree)
+	}
+	newU, newPw, ok := degreeReduceHomog(c.Degree, c.Knots, curve2dToHomog(c.Ctrl, c.Weights), tol)
+	if !ok {
+		return c, false, nil
+	}
+	ctrl, weights := curve2dFromHomog(newPw)
+	reduced, err := NewBSplineCurve2d(c.Degree-1, ctrl, weights, newU)
+	if err != nil {
+		return c, false, err
+	}
+	return clean2dCurveKnots(reduced, tol), true, nil
+}
+
+// ReduceDegreeU returns the surface with its U degree lowered by one within tol, ok=false
+// when any v-column is not reducible. Every column reduces to the same C^0 knot vector, so
+// the redundant knots are then removed across all columns together (RemoveKnotU).
+func (s BSplineSurface) ReduceDegreeU(tol float64) (BSplineSurface, bool, error) {
+	if s.UDegree < 2 {
+		return s, false, fmt.Errorf("geom: cannot reduce a U-degree-%d surface below degree 1", s.UDegree)
+	}
+	vCount := len(s.Ctrl[0])
+	cols := make([][]hpoint4, vCount)
+	var newU []float64
+	for j := 0; j < vCount; j++ {
+		var ok bool
+		newU, cols[j], ok = degreeReduceHomog(s.UDegree, s.UKnots, columnToHomog(s, j), tol)
+		if !ok {
+			return s, false, nil
+		}
+	}
+	ctrl, weights := netFromColumns(cols)
+	reduced, err := NewBSplineSurface(s.UDegree-1, s.VDegree, ctrl, weights, newU, s.VKnots)
+	if err != nil {
+		return s, false, err
+	}
+	return cleanSurfaceU(reduced, tol), true, nil
+}
+
+// ReduceDegreeV is the V-direction analogue of [BSplineSurface.ReduceDegreeU].
+func (s BSplineSurface) ReduceDegreeV(tol float64) (BSplineSurface, bool, error) {
+	if s.VDegree < 2 {
+		return s, false, fmt.Errorf("geom: cannot reduce a V-degree-%d surface below degree 1", s.VDegree)
+	}
+	uCount := len(s.Ctrl)
+	ctrl := make([][]math.Point3, uCount)
+	weights := make([][]float64, uCount)
+	var newV []float64
+	for i := 0; i < uCount; i++ {
+		var rowPw []hpoint4
+		var ok bool
+		newV, rowPw, ok = degreeReduceHomog(s.VDegree, s.VKnots, rowToHomog(s, i), tol)
+		if !ok {
+			return s, false, nil
+		}
+		ctrl[i], weights[i] = curveFromHomog(rowPw)
+	}
+	reduced, err := NewBSplineSurface(s.UDegree, s.VDegree-1, ctrl, weights, s.UKnots, newV)
+	if err != nil {
+		return s, false, err
+	}
+	return cleanSurfaceV(reduced, tol), true, nil
+}
+
+// cleanCurveKnots removes every redundant interior knot left by the C^0 reduction, within
+// tol — restoring the highest continuity the reduced shape supports.
+func cleanCurveKnots(c BSplineCurve, tol float64) BSplineCurve {
+	for _, v := range distinctInterior(c.Degree, c.Knots, c.Knots) {
+		if next, n, err := c.RemoveKnot(v, c.Degree, tol); err == nil && n > 0 {
+			c = next
+		}
+	}
+	return c
+}
+
+// clean2dCurveKnots is the 2D analogue of [cleanCurveKnots].
+func clean2dCurveKnots(c BSplineCurve2d, tol float64) BSplineCurve2d {
+	for _, v := range distinctInterior(c.Degree, c.Knots, c.Knots) {
+		if next, n, err := c.RemoveKnot(v, c.Degree, tol); err == nil && n > 0 {
+			c = next
+		}
+	}
+	return c
+}
+
+// cleanSurfaceU removes the redundant interior U-knots across all columns together.
+func cleanSurfaceU(s BSplineSurface, tol float64) BSplineSurface {
+	for _, v := range distinctInterior(s.UDegree, s.UKnots, s.UKnots) {
+		if next, n, err := s.RemoveKnotU(v, s.UDegree, tol); err == nil && n > 0 {
+			s = next
+		}
+	}
+	return s
+}
+
+// cleanSurfaceV is the V-direction analogue of [cleanSurfaceU].
+func cleanSurfaceV(s BSplineSurface, tol float64) BSplineSurface {
+	for _, v := range distinctInterior(s.VDegree, s.VKnots, s.VKnots) {
+		if next, n, err := s.RemoveKnotV(v, s.VDegree, tol); err == nil && n > 0 {
+			s = next
+		}
+	}
+	return s
+}

--- a/kernel/geom/bspline_remove.go
+++ b/kernel/geom/bspline_remove.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import "oblikovati.org/math"
+
+// Public knot removal on the rational B-spline types. Removal is approximate and so
+// reports how many of the requested removals were actually applied within tol; it is
+// the simplification half of a rebuild (insert-dense → remove-redundant). tol is the
+// allowed deviation of the homogeneous control points (equal to model space for a
+// non-rational curve/surface). See [removeKnotHomog] (M36-F01).
+
+// RemoveKnot returns the curve with the interior knot u removed up to num times,
+// stopping as soon as a removal would move the curve more than tol; the second result
+// is how many removals were applied (0 when none was within tol). It errors when num<1
+// or u is not an interior knot.
+//
+// Example: simplified, n, _ := c.RemoveKnot(0.5, 1, 1e-6) // drop a redundant knot.
+func (c BSplineCurve) RemoveKnot(u float64, num int, tol float64) (BSplineCurve, int, error) {
+	r, s, eff, err := interiorKnot(c.Degree, c.Knots, u, num)
+	if err != nil {
+		return BSplineCurve{}, 0, err
+	}
+	newU, newPw, removed := removeKnotHomog(c.Degree, c.Knots, curveToHomog(c.Ctrl, c.Weights), u, r, s, eff, tol)
+	if removed == 0 {
+		return c, 0, nil
+	}
+	ctrl, weights := curveFromHomog(newPw)
+	out, err := NewBSplineCurve(c.Degree, ctrl, weights, newU)
+	return out, removed, err
+}
+
+// RemoveKnot is the 2D analogue of [BSplineCurve.RemoveKnot].
+func (c BSplineCurve2d) RemoveKnot(u float64, num int, tol float64) (BSplineCurve2d, int, error) {
+	r, s, eff, err := interiorKnot(c.Degree, c.Knots, u, num)
+	if err != nil {
+		return BSplineCurve2d{}, 0, err
+	}
+	newU, newPw, removed := removeKnotHomog(c.Degree, c.Knots, curve2dToHomog(c.Ctrl, c.Weights), u, r, s, eff, tol)
+	if removed == 0 {
+		return c, 0, nil
+	}
+	ctrl, weights := curve2dFromHomog(newPw)
+	out, err := NewBSplineCurve2d(c.Degree, ctrl, weights, newU)
+	return out, removed, err
+}
+
+// RemoveKnotU removes the interior U-knot u from the surface up to num times, but only
+// while every refined v-column stays within tol; the removal count is the minimum
+// achievable across all columns (a knot is only droppable when removable from all).
+func (s BSplineSurface) RemoveKnotU(u float64, num int, tol float64) (BSplineSurface, int, error) {
+	r, sm, eff, err := interiorKnot(s.UDegree, s.UKnots, u, num)
+	if err != nil {
+		return BSplineSurface{}, 0, err
+	}
+	newU, ctrl, weights, removed := removeSurfaceU(s, u, r, sm, eff, tol)
+	if removed == 0 {
+		return s, 0, nil
+	}
+	out, err := NewBSplineSurface(s.UDegree, s.VDegree, ctrl, weights, newU, s.VKnots)
+	return out, removed, err
+}
+
+// RemoveKnotV is the V-direction analogue of [BSplineSurface.RemoveKnotU].
+func (s BSplineSurface) RemoveKnotV(v float64, num int, tol float64) (BSplineSurface, int, error) {
+	r, sm, eff, err := interiorKnot(s.VDegree, s.VKnots, v, num)
+	if err != nil {
+		return BSplineSurface{}, 0, err
+	}
+	newV, ctrl, weights, removed := removeSurfaceV(s, v, r, sm, eff, tol)
+	if removed == 0 {
+		return s, 0, nil
+	}
+	out, err := NewBSplineSurface(s.UDegree, s.VDegree, ctrl, weights, s.UKnots, newV)
+	return out, removed, err
+}
+
+// removeSurfaceU removes the U-knot from each v-column and keeps the largest count
+// common to every column, so all columns share one consistent U knot vector. A column
+// is re-refined to that common count when it could individually remove more.
+func removeSurfaceU(s BSplineSurface, u float64, r, sm, eff int, tol float64) (newU []float64, ctrl [][]math.Point3, weights [][]float64, removed int) {
+	uCount, vCount := len(s.Ctrl), len(s.Ctrl[0])
+	removed = eff
+	cols := make([][]hpoint4, vCount)
+	for j := 0; j < vCount; j++ {
+		col := make([]hpoint4, uCount)
+		for i := 0; i < uCount; i++ {
+			col[i] = hpoint4FromCurve(s.Ctrl[i][j], s.Weights[i][j])
+		}
+		_, _, got := removeKnotHomog(s.UDegree, s.UKnots, col, u, r, sm, eff, tol)
+		removed = min(removed, got)
+	}
+	if removed == 0 {
+		return nil, nil, nil, 0
+	}
+	for j := 0; j < vCount; j++ {
+		col := make([]hpoint4, uCount)
+		for i := 0; i < uCount; i++ {
+			col[i] = hpoint4FromCurve(s.Ctrl[i][j], s.Weights[i][j])
+		}
+		newU, cols[j], _ = removeKnotHomog(s.UDegree, s.UKnots, col, u, r, sm, removed, tol)
+	}
+	ctrl, weights = netFromColumns(cols)
+	return newU, ctrl, weights, removed
+}
+
+// removeSurfaceV is the V-direction analogue of [removeSurfaceU] (row-wise).
+func removeSurfaceV(s BSplineSurface, v float64, r, sm, eff int, tol float64) (newV []float64, ctrl [][]math.Point3, weights [][]float64, removed int) {
+	uCount := len(s.Ctrl)
+	removed = eff
+	for i := 0; i < uCount; i++ {
+		row := rowToHomog(s, i)
+		_, _, got := removeKnotHomog(s.VDegree, s.VKnots, row, v, r, sm, eff, tol)
+		removed = min(removed, got)
+	}
+	if removed == 0 {
+		return nil, nil, nil, 0
+	}
+	ctrl = make([][]math.Point3, uCount)
+	weights = make([][]float64, uCount)
+	for i := 0; i < uCount; i++ {
+		var refined []hpoint4
+		newV, refined, _ = removeKnotHomog(s.VDegree, s.VKnots, rowToHomog(s, i), v, r, sm, removed, tol)
+		ctrl[i], weights[i] = curveFromHomog(refined)
+	}
+	return newV, ctrl, weights, removed
+}
+
+// rowToHomog converts the u-row i of the surface to homogeneous control points.
+func rowToHomog(s BSplineSurface, i int) []hpoint4 {
+	row := make([]hpoint4, len(s.Ctrl[i]))
+	for j := range s.Ctrl[i] {
+		row[j] = hpoint4FromCurve(s.Ctrl[i][j], s.Weights[i][j])
+	}
+	return row
+}

--- a/kernel/geom/bspline_remove.go
+++ b/kernel/geom/bspline_remove.go
@@ -79,26 +79,18 @@ func (s BSplineSurface) RemoveKnotV(v float64, num int, tol float64) (BSplineSur
 // common to every column, so all columns share one consistent U knot vector. A column
 // is re-refined to that common count when it could individually remove more.
 func removeSurfaceU(s BSplineSurface, u float64, r, sm, eff int, tol float64) (newU []float64, ctrl [][]math.Point3, weights [][]float64, removed int) {
-	uCount, vCount := len(s.Ctrl), len(s.Ctrl[0])
+	vCount := len(s.Ctrl[0])
 	removed = eff
-	cols := make([][]hpoint4, vCount)
 	for j := 0; j < vCount; j++ {
-		col := make([]hpoint4, uCount)
-		for i := 0; i < uCount; i++ {
-			col[i] = hpoint4FromCurve(s.Ctrl[i][j], s.Weights[i][j])
-		}
-		_, _, got := removeKnotHomog(s.UDegree, s.UKnots, col, u, r, sm, eff, tol)
+		_, _, got := removeKnotHomog(s.UDegree, s.UKnots, columnToHomog(s, j), u, r, sm, eff, tol)
 		removed = min(removed, got)
 	}
 	if removed == 0 {
 		return nil, nil, nil, 0
 	}
+	cols := make([][]hpoint4, vCount)
 	for j := 0; j < vCount; j++ {
-		col := make([]hpoint4, uCount)
-		for i := 0; i < uCount; i++ {
-			col[i] = hpoint4FromCurve(s.Ctrl[i][j], s.Weights[i][j])
-		}
-		newU, cols[j], _ = removeKnotHomog(s.UDegree, s.UKnots, col, u, r, sm, removed, tol)
+		newU, cols[j], _ = removeKnotHomog(s.UDegree, s.UKnots, columnToHomog(s, j), u, r, sm, removed, tol)
 	}
 	ctrl, weights = netFromColumns(cols)
 	return newU, ctrl, weights, removed

--- a/kernel/geom/bspline_surface_refine.go
+++ b/kernel/geom/bspline_surface_refine.go
@@ -59,17 +59,23 @@ func (s BSplineSurface) RefineKnotsV(vs []float64) (BSplineSurface, error) {
 // insertSurfaceU refines each v-column as a U-direction curve; all columns share the
 // resulting U knot vector.
 func insertSurfaceU(s BSplineSurface, u float64, r int) (newU []float64, ctrl [][]math.Point3, weights [][]float64) {
-	uCount, vCount := len(s.Ctrl), len(s.Ctrl[0])
+	vCount := len(s.Ctrl[0])
 	cols := make([][]hpoint4, vCount)
 	for j := 0; j < vCount; j++ {
-		col := make([]hpoint4, uCount)
-		for i := 0; i < uCount; i++ {
-			col[i] = hpoint4FromCurve(s.Ctrl[i][j], s.Weights[i][j])
-		}
-		newU, cols[j] = insertKnotHomog(s.UDegree, s.UKnots, col, u, r)
+		newU, cols[j] = insertKnotHomog(s.UDegree, s.UKnots, columnToHomog(s, j), u, r)
 	}
 	ctrl, weights = netFromColumns(cols)
 	return newU, ctrl, weights
+}
+
+// columnToHomog converts the v-column j of the surface to homogeneous control points
+// (the U-direction curve at constant v).
+func columnToHomog(s BSplineSurface, j int) []hpoint4 {
+	col := make([]hpoint4, len(s.Ctrl))
+	for i := range s.Ctrl {
+		col[i] = hpoint4FromCurve(s.Ctrl[i][j], s.Weights[i][j])
+	}
+	return col
 }
 
 // insertSurfaceV refines each u-row as a V-direction curve.

--- a/kernel/geom/bspline_surface_refine.go
+++ b/kernel/geom/bspline_surface_refine.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import "oblikovati.org/math"
+
+// Public knot-refinement on the rational B-spline surface, per parametric direction.
+// A surface refines as a tensor product: inserting a U-knot refines every v-column as
+// a U-direction curve (all columns share the new U knot vector); inserting a V-knot
+// refines every u-row as a V-direction curve. Each method returns a NEW, geometrically
+// identical surface (M36-F01).
+
+// InsertKnotU returns a surface identical to s with the knot u inserted r times in the
+// U direction (exact; A5.3 column-wise). It errors as [BSplineCurve.InsertKnot] does.
+func (s BSplineSurface) InsertKnotU(u float64, r int) (BSplineSurface, error) {
+	if err := validateInsert(s.UDegree, s.UKnots, u, r); err != nil {
+		return BSplineSurface{}, err
+	}
+	newU, ctrl, weights := insertSurfaceU(s, u, r)
+	return NewBSplineSurface(s.UDegree, s.VDegree, ctrl, weights, newU, s.VKnots)
+}
+
+// InsertKnotV is the V-direction analogue of [BSplineSurface.InsertKnotU] (row-wise).
+func (s BSplineSurface) InsertKnotV(v float64, r int) (BSplineSurface, error) {
+	if err := validateInsert(s.VDegree, s.VKnots, v, r); err != nil {
+		return BSplineSurface{}, err
+	}
+	newV, ctrl, weights := insertSurfaceV(s, v, r)
+	return NewBSplineSurface(s.UDegree, s.VDegree, ctrl, weights, s.UKnots, newV)
+}
+
+// RefineKnotsU inserts every value in us into the U direction (repeats raise
+// multiplicity), returning the exactly-equal refined surface.
+func (s BSplineSurface) RefineKnotsU(us []float64) (BSplineSurface, error) {
+	out := s
+	for _, u := range us {
+		next, err := out.InsertKnotU(u, 1)
+		if err != nil {
+			return BSplineSurface{}, err
+		}
+		out = next
+	}
+	return out, nil
+}
+
+// RefineKnotsV is the V-direction analogue of [BSplineSurface.RefineKnotsU].
+func (s BSplineSurface) RefineKnotsV(vs []float64) (BSplineSurface, error) {
+	out := s
+	for _, v := range vs {
+		next, err := out.InsertKnotV(v, 1)
+		if err != nil {
+			return BSplineSurface{}, err
+		}
+		out = next
+	}
+	return out, nil
+}
+
+// insertSurfaceU refines each v-column as a U-direction curve; all columns share the
+// resulting U knot vector.
+func insertSurfaceU(s BSplineSurface, u float64, r int) (newU []float64, ctrl [][]math.Point3, weights [][]float64) {
+	uCount, vCount := len(s.Ctrl), len(s.Ctrl[0])
+	cols := make([][]hpoint4, vCount)
+	for j := 0; j < vCount; j++ {
+		col := make([]hpoint4, uCount)
+		for i := 0; i < uCount; i++ {
+			col[i] = hpoint4FromCurve(s.Ctrl[i][j], s.Weights[i][j])
+		}
+		newU, cols[j] = insertKnotHomog(s.UDegree, s.UKnots, col, u, r)
+	}
+	ctrl, weights = netFromColumns(cols)
+	return newU, ctrl, weights
+}
+
+// insertSurfaceV refines each u-row as a V-direction curve.
+func insertSurfaceV(s BSplineSurface, v float64, r int) (newV []float64, ctrl [][]math.Point3, weights [][]float64) {
+	uCount := len(s.Ctrl)
+	ctrl = make([][]math.Point3, uCount)
+	weights = make([][]float64, uCount)
+	for i := 0; i < uCount; i++ {
+		row := make([]hpoint4, len(s.Ctrl[i]))
+		for j := range s.Ctrl[i] {
+			row[j] = hpoint4FromCurve(s.Ctrl[i][j], s.Weights[i][j])
+		}
+		var refined []hpoint4
+		newV, refined = insertKnotHomog(s.VDegree, s.VKnots, row, v, r)
+		ctrl[i], weights[i] = curveFromHomog(refined)
+	}
+	return newV, ctrl, weights
+}
+
+// netFromColumns assembles a control net from per-v refined U-columns: ctrl[i][j] is
+// row i of column j (the transpose back from column-major refinement).
+func netFromColumns(cols [][]hpoint4) (ctrl [][]math.Point3, weights [][]float64) {
+	rows := len(cols[0])
+	ctrl = make([][]math.Point3, rows)
+	weights = make([][]float64, rows)
+	for i := 0; i < rows; i++ {
+		ctrl[i] = make([]math.Point3, len(cols))
+		weights[i] = make([]float64, len(cols))
+		for j := range cols {
+			ctrl[i][j], weights[i][j] = cols[j][i].point3()
+		}
+	}
+	return ctrl, weights
+}

--- a/kernel/geom/errors.go
+++ b/kernel/geom/errors.go
@@ -37,3 +37,10 @@ type CollinearPoints3dError struct {
 func (e *CollinearPoints3dError) Error() string {
 	return fmt.Sprintf("geom: points %v, %v, %v are collinear; a circle/arc through three points needs them non-collinear", e.A, e.B, e.C)
 }
+
+// insertOverflow formats the panic message for a knot insertion that would push a
+// knot's multiplicity past the degree (r+s > p), which is a caller invariant the
+// public InsertKnot methods guard before reaching the homogeneous core (M36-F01).
+func insertOverflow(u float64, r, s, p int) string {
+	return fmt.Sprintf("geom: cannot insert knot %g %d time(s): existing multiplicity %d + %d exceeds degree %d", u, r, r, s, p)
+}

--- a/kernel/geom/nurbs_elevate.go
+++ b/kernel/geom/nurbs_elevate.go
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+// Degree elevation on homogeneous control points (Piegl & Tiller A5.9). Elevation is
+// *exact*: it raises the polynomial degree by t and adds control points while leaving
+// the curve/surface geometry unchanged. It is the precursor to matching the degrees of
+// two curves before a tensor-product surface op, and to reaching a higher-continuity
+// (G2/G3) representation (M36-F01). The algorithm's many phases share mutable working
+// state, so they are gathered on [degElevator] to keep each routine small.
+
+// elevateDegreeHomog raises the degree of the homogeneous B-spline by t, returning the
+// new knot vector and control points. t <= 0 is a no-op copy.
+func elevateDegreeHomog(p, t int, U []float64, pw []hpoint4) (newU []float64, newPw []hpoint4) {
+	if t <= 0 {
+		return append([]float64(nil), U...), append([]hpoint4(nil), pw...)
+	}
+	return newDegElevator(p, t, U, pw).run()
+}
+
+// degElevator holds the working state of A5.9: the precomputed Bézier elevation
+// coefficients, the per-segment scratch polygons, and the output cursors.
+type degElevator struct {
+	p, t, ph, ph2, m int
+	U                []float64
+	pw               []hpoint4
+	bezalfs          [][]float64
+	bpts, ebpts      []hpoint4
+	nextbpts         []hpoint4
+	alfs             []float64
+	Uh               []float64
+	Qw               []hpoint4
+	kind, cind, mh   int
+	r, a, b          int
+	ua, ub           float64
+}
+
+// newDegElevator sizes the output and scratch arrays exactly (every distinct knot ends
+// up with its multiplicity raised by t) and precomputes the Bézier elevation table.
+func newDegElevator(p, t int, U []float64, pw []hpoint4) *degElevator {
+	n := len(pw) - 1
+	e := &degElevator{p: p, t: t, ph: p + t, ph2: (p + t) / 2, m: n + p + 1, U: U, pw: pw}
+	knotLen := len(U) + t*distinctCount(U)
+	e.Uh = make([]float64, knotLen)
+	e.Qw = make([]hpoint4, knotLen-e.ph-1)
+	e.bpts = make([]hpoint4, p+1)
+	e.ebpts = make([]hpoint4, e.ph+1)
+	e.nextbpts = make([]hpoint4, max(p-1, 0))
+	e.alfs = make([]float64, max(p-1, 0))
+	e.initBezalfs()
+	return e
+}
+
+// initBezalfs fills the bezalfs[i][j] coefficients that elevate a degree-p Bézier
+// segment to degree ph (A5.9, eqs. via binomials, with the symmetric upper half mirrored).
+func (e *degElevator) initBezalfs() {
+	e.bezalfs = make([][]float64, e.ph+1)
+	for i := range e.bezalfs {
+		e.bezalfs[i] = make([]float64, e.p+1)
+	}
+	e.bezalfs[0][0] = 1
+	e.bezalfs[e.ph][e.p] = 1
+	e.fillBezalfsLow()
+	e.fillBezalfsHigh()
+}
+
+// fillBezalfsLow computes the lower-index half of the coefficient table directly.
+func (e *degElevator) fillBezalfsLow() {
+	for i := 1; i <= e.ph2; i++ {
+		inv := 1 / binomial(e.ph, i)
+		mpi := min(e.p, i)
+		for j := max(0, i-e.t); j <= mpi; j++ {
+			e.bezalfs[i][j] = inv * binomial(e.p, j) * binomial(e.t, i-j)
+		}
+	}
+}
+
+// fillBezalfsHigh mirrors the upper-index half from the (already computed) lower half.
+func (e *degElevator) fillBezalfsHigh() {
+	for i := e.ph2 + 1; i <= e.ph-1; i++ {
+		mpi := min(e.p, i)
+		for j := max(0, i-e.t); j <= mpi; j++ {
+			e.bezalfs[i][j] = e.bezalfs[e.ph-i][e.p-j]
+		}
+	}
+}
+
+// run executes the main A5.9 loop, returning the elevated knot vector and control points.
+func (e *degElevator) run() ([]float64, []hpoint4) {
+	e.mh, e.kind, e.r, e.a, e.b, e.cind = e.ph, e.ph+1, -1, e.p, e.p+1, 1
+	e.ua = e.U[0]
+	e.Qw[0] = e.pw[0]
+	for i := 0; i <= e.ph; i++ {
+		e.Uh[i] = e.ua
+	}
+	copy(e.bpts, e.pw[:e.p+1])
+	for e.b < e.m {
+		e.elevateSegment()
+	}
+	nh := e.mh - e.ph - 1
+	return e.Uh[:e.mh+1], e.Qw[:nh+1]
+}
+
+// elevateSegment processes one distinct-knot span: isolate its Bézier segment, elevate
+// it, remove the surplus knots elevation introduced, and emit the new knots and points.
+func (e *degElevator) elevateSegment() {
+	mul := e.advanceToNextDistinct()
+	oldr := e.r
+	e.r = e.p - mul
+	lbz, rbz := e.bezierBounds(oldr)
+	if e.r > 0 {
+		e.insertToBezier(mul)
+	}
+	e.elevateBezier(lbz)
+	if oldr > 1 {
+		e.removeAfterElevation(oldr, lbz)
+	}
+	e.loadKnot(oldr)
+	e.loadCtrl(lbz, rbz)
+	e.setupNext()
+}
+
+// advanceToNextDistinct scans b to the end of the current repeated-knot run, folding the
+// knot's multiplicity into mh and recording the run's end value in ub.
+func (e *degElevator) advanceToNextDistinct() (mul int) {
+	i := e.b
+	for e.b < e.m && e.U[e.b] == e.U[e.b+1] {
+		e.b++
+	}
+	mul = e.b - i + 1
+	e.mh += mul + e.t
+	e.ub = e.U[e.b]
+	return mul
+}
+
+// bezierBounds returns the Bézier index range [lbz, rbz] that the elevated segment's
+// control points occupy, accounting for the knots shared with the neighbouring segments.
+func (e *degElevator) bezierBounds(oldr int) (lbz, rbz int) {
+	lbz, rbz = 1, e.ph
+	if oldr > 0 {
+		lbz = (oldr + 2) / 2
+	}
+	if e.r > 0 {
+		rbz = e.ph - (e.r+1)/2
+	}
+	return lbz, rbz
+}
+
+// insertToBezier inserts the span-end knot r times so bpts becomes a pure Bézier segment,
+// stashing the spill-over points for the next span in nextbpts.
+func (e *degElevator) insertToBezier(mul int) {
+	numer := e.ub - e.ua
+	for k := e.p; k > mul; k-- {
+		e.alfs[k-mul-1] = numer / (e.U[e.a+k] - e.ua)
+	}
+	for j := 1; j <= e.r; j++ {
+		save := e.r - j
+		s := mul + j
+		for k := e.p; k >= s; k-- {
+			e.bpts[k] = e.bpts[k].lerp(e.bpts[k-1], 1-e.alfs[k-s])
+		}
+		e.nextbpts[save] = e.bpts[e.p]
+	}
+}
+
+// elevateBezier raises the current Bézier segment bpts to degree ph in ebpts via bezalfs.
+func (e *degElevator) elevateBezier(lbz int) {
+	for i := lbz; i <= e.ph; i++ {
+		e.ebpts[i] = hpoint4{}
+		mpi := min(e.p, i)
+		for j := max(0, i-e.t); j <= mpi; j++ {
+			e.ebpts[i] = e.ebpts[i].add(e.bpts[j].scale(e.bezalfs[i][j]))
+		}
+	}
+}
+
+// removeAfterElevation removes the knot at the span start oldr times — elevation
+// over-inserts it, and these passes restore the correct multiplicity (A5.9 inner block).
+func (e *degElevator) removeAfterElevation(oldr, lbz int) {
+	first, last := e.kind-2, e.kind
+	den := e.ub - e.ua
+	bet := (e.ub - e.Uh[e.kind-1]) / den
+	for tr := 1; tr < oldr; tr++ {
+		e.removalPass(tr, oldr, lbz, first, last, den, bet)
+		first--
+		last++
+	}
+}
+
+// removalPass runs one knot-removal sweep over the already-emitted Qw and the elevated
+// ebpts for the converging index window.
+func (e *degElevator) removalPass(tr, oldr, lbz, first, last int, den, bet float64) {
+	i, j := first, last
+	kj := j - e.kind + 1
+	for j-i > tr {
+		if i < e.cind {
+			alf := (e.ub - e.Uh[i]) / (e.ua - e.Uh[i])
+			e.Qw[i] = e.Qw[i].lerp(e.Qw[i-1], 1-alf)
+		}
+		if j >= lbz {
+			e.ebpts[kj] = e.removalBlend(j, tr, kj, oldr, den, bet)
+		}
+		i, j, kj = i+1, j-1, kj-1
+	}
+}
+
+// removalBlend chooses A5.9's interior (gamma) or boundary (beta) blend for one ebpts entry.
+func (e *degElevator) removalBlend(j, tr, kj, oldr int, den, bet float64) hpoint4 {
+	if j-tr <= e.kind-e.ph+oldr {
+		gam := (e.ub - e.Uh[j-tr]) / den
+		return e.ebpts[kj].lerp(e.ebpts[kj+1], 1-gam)
+	}
+	return e.ebpts[kj].lerp(e.ebpts[kj+1], 1-bet)
+}
+
+// loadKnot writes the span-start knot ua into Uh with its elevated multiplicity (ph−oldr),
+// except for the very first span whose start knots are loaded before the loop.
+func (e *degElevator) loadKnot(oldr int) {
+	if e.a == e.p {
+		return
+	}
+	for i := 0; i < e.ph-oldr; i++ {
+		e.Uh[e.kind] = e.ua
+		e.kind++
+	}
+}
+
+// loadCtrl emits the elevated segment's control points [lbz, rbz] into the output Qw.
+func (e *degElevator) loadCtrl(lbz, rbz int) {
+	for j := lbz; j <= rbz; j++ {
+		e.Qw[e.cind] = e.ebpts[j]
+		e.cind++
+	}
+}
+
+// setupNext primes bpts for the following span (or loads the clamped end knots when done).
+func (e *degElevator) setupNext() {
+	if e.b >= e.m {
+		for i := 0; i <= e.ph; i++ {
+			e.Uh[e.kind+i] = e.ub
+		}
+		return
+	}
+	for j := 0; j < e.r; j++ {
+		e.bpts[j] = e.nextbpts[j]
+	}
+	for j := e.r; j <= e.p; j++ {
+		e.bpts[j] = e.pw[e.b-e.p+j]
+	}
+	e.a, e.b, e.ua = e.b, e.b+1, e.ub
+}
+
+// distinctCount returns the number of distinct knot values in U (consecutive equal
+// entries count once), the multiplier behind the elevated array sizing.
+func distinctCount(U []float64) int {
+	count := 0
+	for i := range U {
+		if i == 0 || U[i] != U[i-1] {
+			count++
+		}
+	}
+	return count
+}
+
+// binomial returns the binomial coefficient C(n, k) as a float64 (0 outside 0..n).
+func binomial(n, k int) float64 {
+	if k < 0 || k > n {
+		return 0
+	}
+	if k > n-k {
+		k = n - k
+	}
+	c := 1.0
+	for i := 0; i < k; i++ {
+		c = c * float64(n-i) / float64(i+1)
+	}
+	return c
+}

--- a/kernel/geom/nurbs_elevate.go
+++ b/kernel/geom/nurbs_elevate.go
@@ -11,11 +11,11 @@ package geom
 
 // elevateDegreeHomog raises the degree of the homogeneous B-spline by t, returning the
 // new knot vector and control points. t <= 0 is a no-op copy.
-func elevateDegreeHomog(p, t int, U []float64, pw []hpoint4) (newU []float64, newPw []hpoint4) {
+func elevateDegreeHomog(p, t int, knots []float64, pw []hpoint4) (newU []float64, newPw []hpoint4) {
 	if t <= 0 {
-		return append([]float64(nil), U...), append([]hpoint4(nil), pw...)
+		return append([]float64(nil), knots...), append([]hpoint4(nil), pw...)
 	}
-	return newDegElevator(p, t, U, pw).run()
+	return newDegElevator(p, t, knots, pw).run()
 }
 
 // degElevator holds the working state of A5.9: the precomputed Bézier elevation
@@ -37,10 +37,10 @@ type degElevator struct {
 
 // newDegElevator sizes the output and scratch arrays exactly (every distinct knot ends
 // up with its multiplicity raised by t) and precomputes the Bézier elevation table.
-func newDegElevator(p, t int, U []float64, pw []hpoint4) *degElevator {
+func newDegElevator(p, t int, knots []float64, pw []hpoint4) *degElevator {
 	n := len(pw) - 1
-	e := &degElevator{p: p, t: t, ph: p + t, ph2: (p + t) / 2, m: n + p + 1, U: U, pw: pw}
-	knotLen := len(U) + t*distinctCount(U)
+	e := &degElevator{p: p, t: t, ph: p + t, ph2: (p + t) / 2, m: n + p + 1, U: knots, pw: pw}
+	knotLen := len(knots) + t*distinctCount(knots)
 	e.Uh = make([]float64, knotLen)
 	e.Qw = make([]hpoint4, knotLen-e.ph-1)
 	e.bpts = make([]hpoint4, p+1)
@@ -252,10 +252,10 @@ func (e *degElevator) setupNext() {
 
 // distinctCount returns the number of distinct knot values in U (consecutive equal
 // entries count once), the multiplier behind the elevated array sizing.
-func distinctCount(U []float64) int {
+func distinctCount(knots []float64) int {
 	count := 0
-	for i := range U {
-		if i == 0 || U[i] != U[i-1] {
+	for i := range knots {
+		if i == 0 || knots[i] != knots[i-1] {
 			count++
 		}
 	}

--- a/kernel/geom/nurbs_elevate_test.go
+++ b/kernel/geom/nurbs_elevate_test.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+func TestElevateDegreePreservesCurve(t *testing.T) {
+	c := sampleCubicCurve(t)
+	got, err := c.ElevateDegree(1)
+	if err != nil {
+		t.Fatalf("ElevateDegree: %v", err)
+	}
+	if got.Degree != c.Degree+1 {
+		t.Errorf("degree = %d, want %d", got.Degree, c.Degree+1)
+	}
+	if len(got.Knots) != len(got.Ctrl)+got.Degree+1 {
+		t.Errorf("knot/ctrl mismatch: %d knots, %d ctrl, degree %d", len(got.Knots), len(got.Ctrl), got.Degree)
+	}
+	curvesAgree(t, c, got, 1e-12)
+}
+
+func TestElevateDegreeByTwo(t *testing.T) {
+	c := sampleCubicCurve(t)
+	got, err := c.ElevateDegree(2)
+	if err != nil {
+		t.Fatalf("ElevateDegree x2: %v", err)
+	}
+	if got.Degree != c.Degree+2 {
+		t.Errorf("degree = %d, want %d", got.Degree, c.Degree+2)
+	}
+	curvesAgree(t, c, got, 1e-12)
+}
+
+func TestElevateDegreeBezier(t *testing.T) {
+	// A single-span (Bézier) quadratic: elevating to cubic must keep it on the curve.
+	c := quarterCircleNURBS(t)
+	got, err := c.ElevateDegree(1)
+	if err != nil {
+		t.Fatalf("ElevateDegree: %v", err)
+	}
+	if got.Degree != 3 || len(got.Ctrl) != 4 {
+		t.Errorf("elevated Bézier: degree %d, %d ctrl; want 3 and 4", got.Degree, len(got.Ctrl))
+	}
+	for i := 0; i <= 20; i++ {
+		u := float64(i) / 20
+		if !c.PointAt(u).IsEqualTo(got.PointAt(u), 1e-12) {
+			t.Fatalf("elevated quarter circle diverges at u=%g", u)
+		}
+	}
+}
+
+func TestElevateDegreeRejectsZero(t *testing.T) {
+	c := sampleCubicCurve(t)
+	if _, err := c.ElevateDegree(0); err == nil {
+		t.Error("elevating by 0 should error")
+	}
+}
+
+func TestElevateDegree2d(t *testing.T) {
+	c, err := NewBSplineCurve2dUniformWeights(
+		2,
+		[]math.Point2{math.P2(0, 0), math.P2(1, 2), math.P2(3, 0), math.P2(4, 1)},
+		[]float64{0, 0, 0, 0.5, 1, 1, 1},
+	)
+	if err != nil {
+		t.Fatalf("2d curve: %v", err)
+	}
+	got, err := c.ElevateDegree(1)
+	if err != nil {
+		t.Fatalf("ElevateDegree: %v", err)
+	}
+	lo, hi := c.Domain()
+	for i := 0; i <= 20; i++ {
+		u := lo + (hi-lo)*float64(i)/20
+		if !c.PointAt(u).IsEqualTo(got.PointAt(u), 1e-12) {
+			t.Fatalf("2d curve diverges at u=%g after elevation", u)
+		}
+	}
+}
+
+func TestElevateDegreeSurface(t *testing.T) {
+	s := sampleQuadraticSurface(t)
+	gu, err := s.ElevateDegreeU(1)
+	if err != nil {
+		t.Fatalf("ElevateDegreeU: %v", err)
+	}
+	gv, err := gu.ElevateDegreeV(1)
+	if err != nil {
+		t.Fatalf("ElevateDegreeV: %v", err)
+	}
+	if gv.UDegree != 3 || gv.VDegree != 3 {
+		t.Errorf("degrees = %dx%d, want 3x3", gv.UDegree, gv.VDegree)
+	}
+	for i := 0; i <= 10; i++ {
+		for j := 0; j <= 10; j++ {
+			u, v := float64(i)/10, float64(j)/10
+			if !s.PointAt(u, v).IsEqualTo(gv.PointAt(u, v), 1e-12) {
+				t.Fatalf("surface diverges at (%g,%g) after elevation: %v vs %v", u, v, s.PointAt(u, v), gv.PointAt(u, v))
+			}
+		}
+	}
+}
+
+func TestBinomial(t *testing.T) {
+	cases := []struct {
+		n, k int
+		want float64
+	}{{5, 0, 1}, {5, 5, 1}, {5, 2, 10}, {6, 3, 20}, {4, 5, 0}, {4, -1, 0}}
+	for _, c := range cases {
+		if got := binomial(c.n, c.k); got != c.want {
+			t.Errorf("binomial(%d,%d) = %g, want %g", c.n, c.k, got, c.want)
+		}
+	}
+}

--- a/kernel/geom/nurbs_homog.go
+++ b/kernel/geom/nurbs_homog.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// hpoint4 is a control point in homogeneous (projective) form: the weight-scaled
+// coordinates (w·X, w·Y, w·Z) together with the weight w. The NURBS refinement and
+// degree-change algorithms (Piegl & Tiller, "The NURBS Book", ch. 5) are affine
+// combinations of these homogeneous points, so they run identically for rational
+// and non-rational data; the rational position is recovered by the perspective
+// divide A/w in [hpoint4.point3] / [hpoint4.point2]. Working in homogeneous space
+// is why a single core implements curve, 2D-curve and surface refinement (M36-F01).
+type hpoint4 struct {
+	x, y, z, w float64
+}
+
+// hpoint4FromCurve maps a 3D control point and its weight to homogeneous form.
+func hpoint4FromCurve(p math.Point3, w float64) hpoint4 {
+	return hpoint4{p.X * w, p.Y * w, p.Z * w, w}
+}
+
+// hpoint4FromCurve2d maps a 2D control point and its weight to homogeneous form (z = 0).
+func hpoint4FromCurve2d(p math.Point2, w float64) hpoint4 {
+	return hpoint4{p.X * w, p.Y * w, 0, w}
+}
+
+// point3 recovers the rational 3D position (A/w) and the weight w.
+func (h hpoint4) point3() (math.Point3, float64) {
+	return math.P3(h.x/h.w, h.y/h.w, h.z/h.w), h.w
+}
+
+// point2 recovers the rational 2D position (A/w) and the weight w.
+func (h hpoint4) point2() (math.Point2, float64) {
+	return math.P2(h.x/h.w, h.y/h.w), h.w
+}
+
+// lerp returns (1−a)·h + a·o, the affine blend used by knot insertion (A5.1):
+// lerp(Rw[i], Rw[i+1], α) = α·Rw[i+1] + (1−α)·Rw[i].
+func (h hpoint4) lerp(o hpoint4, a float64) hpoint4 {
+	return hpoint4{
+		h.x + a*(o.x-h.x),
+		h.y + a*(o.y-h.y),
+		h.z + a*(o.z-h.z),
+		h.w + a*(o.w-h.w),
+	}
+}
+
+// add returns the component-wise sum, for the weighted blends of degree elevation.
+func (h hpoint4) add(o hpoint4) hpoint4 {
+	return hpoint4{h.x + o.x, h.y + o.y, h.z + o.z, h.w + o.w}
+}
+
+// scale returns h scaled by s.
+func (h hpoint4) scale(s float64) hpoint4 {
+	return hpoint4{h.x * s, h.y * s, h.z * s, h.w * s}
+}
+
+// dist returns the Euclidean distance in homogeneous 4-space, the deviation
+// measure knot removal and degree reduction compare against a tolerance (A5.8/A5.11).
+func (h hpoint4) dist(o hpoint4) float64 {
+	dx, dy, dz, dw := h.x-o.x, h.y-o.y, h.z-o.z, h.w-o.w
+	return stdmath.Sqrt(dx*dx + dy*dy + dz*dz + dw*dw)
+}
+
+// curveToHomog converts a rational curve's (ctrl, weights) to homogeneous points.
+func curveToHomog(ctrl []math.Point3, weights []float64) []hpoint4 {
+	pw := make([]hpoint4, len(ctrl))
+	for i := range ctrl {
+		pw[i] = hpoint4FromCurve(ctrl[i], weights[i])
+	}
+	return pw
+}
+
+// curveFromHomog recovers the (ctrl, weights) of a rational curve from homogeneous points.
+func curveFromHomog(pw []hpoint4) (ctrl []math.Point3, weights []float64) {
+	ctrl = make([]math.Point3, len(pw))
+	weights = make([]float64, len(pw))
+	for i := range pw {
+		ctrl[i], weights[i] = pw[i].point3()
+	}
+	return ctrl, weights
+}
+
+// curve2dToHomog converts a 2D rational curve's (ctrl, weights) to homogeneous points.
+func curve2dToHomog(ctrl []math.Point2, weights []float64) []hpoint4 {
+	pw := make([]hpoint4, len(ctrl))
+	for i := range ctrl {
+		pw[i] = hpoint4FromCurve2d(ctrl[i], weights[i])
+	}
+	return pw
+}
+
+// curve2dFromHomog recovers the (ctrl, weights) of a 2D rational curve from homogeneous points.
+func curve2dFromHomog(pw []hpoint4) (ctrl []math.Point2, weights []float64) {
+	ctrl = make([]math.Point2, len(pw))
+	weights = make([]float64, len(pw))
+	for i := range pw {
+		ctrl[i], weights[i] = pw[i].point2()
+	}
+	return ctrl, weights
+}

--- a/kernel/geom/nurbs_homog.go
+++ b/kernel/geom/nurbs_homog.go
@@ -55,6 +55,11 @@ func (h hpoint4) add(o hpoint4) hpoint4 {
 	return hpoint4{h.x + o.x, h.y + o.y, h.z + o.z, h.w + o.w}
 }
 
+// sub returns the component-wise difference, used by knot removal's back-substitution.
+func (h hpoint4) sub(o hpoint4) hpoint4 {
+	return hpoint4{h.x - o.x, h.y - o.y, h.z - o.z, h.w - o.w}
+}
+
 // scale returns h scaled by s.
 func (h hpoint4) scale(s float64) hpoint4 {
 	return hpoint4{h.x * s, h.y * s, h.z * s, h.w * s}

--- a/kernel/geom/nurbs_insert.go
+++ b/kernel/geom/nurbs_insert.go
@@ -10,36 +10,36 @@ import "fmt"
 // block of refine, make-compatible, Bézier extraction and (with removal) rebuild.
 
 // insertKnotHomog inserts the knot u into the homogeneous B-spline (degree p, knots
-// U, control points pw) r times, returning the refined knot vector and control
+// knots, control points pw) r times, returning the refined knot vector and control
 // points. It is Boehm's A5.1 generalized over the seeded span/multiplicity (k, s).
 // It panics on r+s > p (more insertions than the degree allows, a caller bug).
-func insertKnotHomog(p int, U []float64, pw []hpoint4, u float64, r int) (newU []float64, newPw []hpoint4) {
+func insertKnotHomog(p int, knots []float64, pw []hpoint4, u float64, r int) (newU []float64, newPw []hpoint4) {
 	n := len(pw) - 1
-	k, s := findSpanMult(n, p, u, U)
+	k, s := findSpanMult(n, p, u, knots)
 	if r+s > p {
 		panic(insertOverflow(u, r, s, p))
 	}
-	newU = insertedKnots(U, u, k, r)
-	newPw = insertedCtrl(p, U, pw, u, k, s, r)
+	newU = insertedKnots(knots, u, k, r)
+	newPw = insertedCtrl(p, knots, pw, u, k, s, r)
 	return newU, newPw
 }
 
 // insertedKnots builds the knot vector after inserting u (r times) at span k.
-func insertedKnots(U []float64, u float64, k, r int) []float64 {
-	out := make([]float64, len(U)+r)
-	copy(out[:k+1], U[:k+1])
+func insertedKnots(knots []float64, u float64, k, r int) []float64 {
+	out := make([]float64, len(knots)+r)
+	copy(out[:k+1], knots[:k+1])
 	for i := 1; i <= r; i++ {
 		out[k+i] = u
 	}
-	for i := k + 1; i < len(U); i++ {
-		out[i+r] = U[i]
+	for i := k + 1; i < len(knots); i++ {
+		out[i+r] = knots[i]
 	}
 	return out
 }
 
 // insertedCtrl builds the control points after inserting u (r times) at span k with
 // pre-existing multiplicity s, via the affine corner-cutting blend of A5.1.
-func insertedCtrl(p int, U []float64, pw []hpoint4, u float64, k, s, r int) []hpoint4 {
+func insertedCtrl(p int, knots []float64, pw []hpoint4, u float64, k, s, r int) []hpoint4 {
 	n := len(pw) - 1
 	out := make([]hpoint4, len(pw)+r)
 	for i := 0; i <= k-p; i++ {
@@ -50,18 +50,18 @@ func insertedCtrl(p int, U []float64, pw []hpoint4, u float64, k, s, r int) []hp
 	}
 	tmp := make([]hpoint4, p-s+1)
 	copy(tmp, pw[k-p:k-s+1])
-	insertBlend(p, U, tmp, out, u, k, s, r)
+	insertBlend(p, knots, tmp, out, u, k, s, r)
 	return out
 }
 
 // insertBlend runs the r corner-cutting passes of A5.1, writing the new control
 // points into out and threading the working row tmp between passes.
-func insertBlend(p int, U []float64, tmp, out []hpoint4, u float64, k, s, r int) {
+func insertBlend(p int, knots []float64, tmp, out []hpoint4, u float64, k, s, r int) {
 	var L int
 	for j := 1; j <= r; j++ {
 		L = k - p + j
 		for i := 0; i <= p-j-s; i++ {
-			alpha := (u - U[L+i]) / (U[i+k+1] - U[L+i])
+			alpha := (u - knots[L+i]) / (knots[i+k+1] - knots[L+i])
 			tmp[i] = tmp[i].lerp(tmp[i+1], alpha)
 		}
 		out[L] = tmp[0]
@@ -87,18 +87,4 @@ func validateInsert(p int, knots []float64, u float64, r int) error {
 		return fmt.Errorf("geom: inserting knot %g %d time(s) would exceed degree %d (current multiplicity %d)", u, r, p, s)
 	}
 	return nil
-}
-
-// refineKnotsHomog inserts each requested extra knot multiplicity into the
-// homogeneous curve, returning the fully refined knots and control points. values
-// and extra are parallel (extra[i] additional insertions of values[i]); it is the
-// repeated-insertion convenience over [insertKnotHomog] used by make-compatible.
-func refineKnotsHomog(p int, U []float64, pw []hpoint4, values []float64, extra []int) (newU []float64, newPw []hpoint4) {
-	newU, newPw = U, pw
-	for i, v := range values {
-		if extra[i] > 0 {
-			newU, newPw = insertKnotHomog(p, newU, newPw, v, extra[i])
-		}
-	}
-	return newU, newPw
 }

--- a/kernel/geom/nurbs_insert.go
+++ b/kernel/geom/nurbs_insert.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import "fmt"
+
+// Knot insertion and refinement on homogeneous control points (Boehm's algorithm,
+// Piegl & Tiller A5.1 / A5.4). Inserting a knot is an *exact* operation: it adds a
+// control point without changing the curve or surface geometry, and is the building
+// block of refine, make-compatible, Bézier extraction and (with removal) rebuild.
+
+// insertKnotHomog inserts the knot u into the homogeneous B-spline (degree p, knots
+// U, control points pw) r times, returning the refined knot vector and control
+// points. It is Boehm's A5.1 generalized over the seeded span/multiplicity (k, s).
+// It panics on r+s > p (more insertions than the degree allows, a caller bug).
+func insertKnotHomog(p int, U []float64, pw []hpoint4, u float64, r int) (newU []float64, newPw []hpoint4) {
+	n := len(pw) - 1
+	k, s := findSpanMult(n, p, u, U)
+	if r+s > p {
+		panic(insertOverflow(u, r, s, p))
+	}
+	newU = insertedKnots(U, u, k, r)
+	newPw = insertedCtrl(p, U, pw, u, k, s, r)
+	return newU, newPw
+}
+
+// insertedKnots builds the knot vector after inserting u (r times) at span k.
+func insertedKnots(U []float64, u float64, k, r int) []float64 {
+	out := make([]float64, len(U)+r)
+	copy(out[:k+1], U[:k+1])
+	for i := 1; i <= r; i++ {
+		out[k+i] = u
+	}
+	for i := k + 1; i < len(U); i++ {
+		out[i+r] = U[i]
+	}
+	return out
+}
+
+// insertedCtrl builds the control points after inserting u (r times) at span k with
+// pre-existing multiplicity s, via the affine corner-cutting blend of A5.1.
+func insertedCtrl(p int, U []float64, pw []hpoint4, u float64, k, s, r int) []hpoint4 {
+	n := len(pw) - 1
+	out := make([]hpoint4, len(pw)+r)
+	for i := 0; i <= k-p; i++ {
+		out[i] = pw[i]
+	}
+	for i := k - s; i <= n; i++ {
+		out[i+r] = pw[i]
+	}
+	tmp := make([]hpoint4, p-s+1)
+	copy(tmp, pw[k-p:k-s+1])
+	insertBlend(p, U, tmp, out, u, k, s, r)
+	return out
+}
+
+// insertBlend runs the r corner-cutting passes of A5.1, writing the new control
+// points into out and threading the working row tmp between passes.
+func insertBlend(p int, U []float64, tmp, out []hpoint4, u float64, k, s, r int) {
+	var L int
+	for j := 1; j <= r; j++ {
+		L = k - p + j
+		for i := 0; i <= p-j-s; i++ {
+			alpha := (u - U[L+i]) / (U[i+k+1] - U[L+i])
+			tmp[i] = tmp[i].lerp(tmp[i+1], alpha)
+		}
+		out[L] = tmp[0]
+		out[k+r-j-s] = tmp[p-j-s]
+	}
+	for i := L + 1; i < k-s; i++ {
+		out[i] = tmp[i-L]
+	}
+}
+
+// validateInsert checks an insertion request against the curve-direction invariants:
+// r ≥ 1, u strictly inside the clamped domain, and r + u's existing multiplicity ≤ p.
+// Both curve and surface (per direction) public refiners share it.
+func validateInsert(p int, knots []float64, u float64, r int) error {
+	if r < 1 {
+		return fmt.Errorf("geom: knot insertion count %d must be >= 1", r)
+	}
+	lo, hi := knots[p], knots[len(knots)-1-p]
+	if u <= lo || u >= hi {
+		return fmt.Errorf("geom: knot %g must lie strictly inside the domain (%g, %g)", u, lo, hi)
+	}
+	if s := knotMultiplicity(knots, u); r+s > p {
+		return fmt.Errorf("geom: inserting knot %g %d time(s) would exceed degree %d (current multiplicity %d)", u, r, p, s)
+	}
+	return nil
+}
+
+// refineKnotsHomog inserts each requested extra knot multiplicity into the
+// homogeneous curve, returning the fully refined knots and control points. values
+// and extra are parallel (extra[i] additional insertions of values[i]); it is the
+// repeated-insertion convenience over [insertKnotHomog] used by make-compatible.
+func refineKnotsHomog(p int, U []float64, pw []hpoint4, values []float64, extra []int) (newU []float64, newPw []hpoint4) {
+	newU, newPw = U, pw
+	for i, v := range values {
+		if extra[i] > 0 {
+			newU, newPw = insertKnotHomog(p, newU, newPw, v, extra[i])
+		}
+	}
+	return newU, newPw
+}

--- a/kernel/geom/nurbs_insert_test.go
+++ b/kernel/geom/nurbs_insert_test.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// sampleCubicCurve is a non-rational cubic B-spline with one interior knot, a
+// general-position control polygon the refinement tests subdivide.
+func sampleCubicCurve(t *testing.T) BSplineCurve {
+	t.Helper()
+	c, err := NewBSplineCurveUniformWeights(
+		3,
+		[]math.Point3{
+			math.P3(0, 0, 0), math.P3(1, 2, 0), math.P3(3, 2, 1),
+			math.P3(4, 0, 1), math.P3(6, 1, 0),
+		},
+		[]float64{0, 0, 0, 0, 0.5, 1, 1, 1, 1},
+	)
+	if err != nil {
+		t.Fatalf("sample cubic curve: %v", err)
+	}
+	return c
+}
+
+// sampleQuadraticSurface is a 2×2-interior NURBS surface (degree 2×2) with varied
+// weights, for surface-direction refinement round-trips.
+func sampleQuadraticSurface(t *testing.T) BSplineSurface {
+	t.Helper()
+	ctrl := [][]math.Point3{
+		{math.P3(0, 0, 0), math.P3(0, 1, 1), math.P3(0, 2, 0)},
+		{math.P3(1, 0, 1), math.P3(1, 1, 2), math.P3(1, 2, 1)},
+		{math.P3(2, 0, 0), math.P3(2, 1, 1), math.P3(2, 2, 0)},
+	}
+	weights := [][]float64{{1, 2, 1}, {2, 4, 2}, {1, 2, 1}}
+	s, err := NewBSplineSurface(2, 2, ctrl, weights,
+		[]float64{0, 0, 0, 1, 1, 1}, []float64{0, 0, 0, 1, 1, 1})
+	if err != nil {
+		t.Fatalf("sample quadratic surface: %v", err)
+	}
+	return s
+}
+
+// curvesAgree samples both curves over the (shared) domain and fails if any sample
+// deviates beyond tol — the geometric-identity check refinement must satisfy.
+func curvesAgree(t *testing.T, a, b BSplineCurve, tol float64) {
+	t.Helper()
+	lo, hi := a.Domain()
+	for i := 0; i <= 20; i++ {
+		u := lo + (hi-lo)*float64(i)/20
+		if !a.PointAt(u).IsEqualTo(b.PointAt(u), tol) {
+			t.Fatalf("curves diverge at u=%g: %v vs %v", u, a.PointAt(u), b.PointAt(u))
+		}
+	}
+}
+
+func TestInsertKnotPreservesCurve(t *testing.T) {
+	c := sampleCubicCurve(t)
+	got, err := c.InsertKnot(0.25, 1)
+	if err != nil {
+		t.Fatalf("InsertKnot: %v", err)
+	}
+	if len(got.Ctrl) != len(c.Ctrl)+1 {
+		t.Errorf("control count = %d, want %d", len(got.Ctrl), len(c.Ctrl)+1)
+	}
+	if knotMultiplicity(got.Knots, 0.25) != 1 {
+		t.Errorf("inserted knot multiplicity = %d, want 1", knotMultiplicity(got.Knots, 0.25))
+	}
+	curvesAgree(t, c, got, 1e-12)
+}
+
+func TestInsertKnotRepeatedRaisesMultiplicity(t *testing.T) {
+	c := sampleCubicCurve(t)
+	got, err := c.InsertKnot(0.25, 3) // degree 3, fresh knot → up to 3 allowed
+	if err != nil {
+		t.Fatalf("InsertKnot x3: %v", err)
+	}
+	if m := knotMultiplicity(got.Knots, 0.25); m != 3 {
+		t.Errorf("multiplicity = %d, want 3", m)
+	}
+	curvesAgree(t, c, got, 1e-12)
+}
+
+func TestInsertKnotRejectsOverflow(t *testing.T) {
+	c := sampleCubicCurve(t)
+	if _, err := c.InsertKnot(0.5, 3); err == nil {
+		t.Error("inserting an interior knot (already multiplicity 1) 3 times at degree 3 should error")
+	}
+	if _, err := c.InsertKnot(0.0, 1); err == nil {
+		t.Error("inserting the domain-boundary knot should error (outside the open domain)")
+	}
+	if _, err := c.InsertKnot(0.5, 0); err == nil {
+		t.Error("a zero insertion count should error")
+	}
+}
+
+func TestRefineKnotsPreservesCurve(t *testing.T) {
+	c := sampleCubicCurve(t)
+	got, err := c.RefineKnots([]float64{0.25, 0.25, 0.75})
+	if err != nil {
+		t.Fatalf("RefineKnots: %v", err)
+	}
+	if len(got.Ctrl) != len(c.Ctrl)+3 {
+		t.Errorf("control count = %d, want %d", len(got.Ctrl), len(c.Ctrl)+3)
+	}
+	curvesAgree(t, c, got, 1e-12)
+}
+
+func TestInsertKnot2dPreservesCurve(t *testing.T) {
+	c, err := NewBSplineCurve2dUniformWeights(
+		2,
+		[]math.Point2{math.P2(0, 0), math.P2(1, 2), math.P2(3, 0), math.P2(4, 1)},
+		[]float64{0, 0, 0, 0.5, 1, 1, 1},
+	)
+	if err != nil {
+		t.Fatalf("2d curve: %v", err)
+	}
+	got, err := c.InsertKnot(0.25, 1)
+	if err != nil {
+		t.Fatalf("InsertKnot: %v", err)
+	}
+	lo, hi := c.Domain()
+	for i := 0; i <= 20; i++ {
+		u := lo + (hi-lo)*float64(i)/20
+		if !c.PointAt(u).IsEqualTo(got.PointAt(u), 1e-12) {
+			t.Fatalf("2d curves diverge at u=%g: %v vs %v", u, c.PointAt(u), got.PointAt(u))
+		}
+	}
+}
+
+func TestInsertKnotSurfacePreservesGeometry(t *testing.T) {
+	s := sampleQuadraticSurface(t)
+	gu, err := s.InsertKnotU(0.5, 1)
+	if err != nil {
+		t.Fatalf("InsertKnotU: %v", err)
+	}
+	gv, err := gu.InsertKnotV(0.5, 1)
+	if err != nil {
+		t.Fatalf("InsertKnotV: %v", err)
+	}
+	if len(gv.Ctrl) != len(s.Ctrl)+1 || len(gv.Ctrl[0]) != len(s.Ctrl[0])+1 {
+		t.Errorf("net dims = %dx%d, want %dx%d", len(gv.Ctrl), len(gv.Ctrl[0]), len(s.Ctrl)+1, len(s.Ctrl[0])+1)
+	}
+	for i := 0; i <= 10; i++ {
+		for j := 0; j <= 10; j++ {
+			u, v := float64(i)/10, float64(j)/10
+			if !s.PointAt(u, v).IsEqualTo(gv.PointAt(u, v), 1e-12) {
+				t.Fatalf("surface diverges at (%g,%g): %v vs %v", u, v, s.PointAt(u, v), gv.PointAt(u, v))
+			}
+		}
+	}
+}

--- a/kernel/geom/nurbs_insert_test.go
+++ b/kernel/geom/nurbs_insert_test.go
@@ -131,6 +131,64 @@ func TestInsertKnot2dPreservesCurve(t *testing.T) {
 	}
 }
 
+func TestRefineKnots2dPreservesCurve(t *testing.T) {
+	c, err := NewBSplineCurve2dUniformWeights(
+		2,
+		[]math.Point2{math.P2(0, 0), math.P2(1, 2), math.P2(3, 0), math.P2(4, 1)},
+		[]float64{0, 0, 0, 0.5, 1, 1, 1},
+	)
+	if err != nil {
+		t.Fatalf("2d curve: %v", err)
+	}
+	got, err := c.RefineKnots([]float64{0.25, 0.75})
+	if err != nil {
+		t.Fatalf("RefineKnots: %v", err)
+	}
+	if len(got.Ctrl) != len(c.Ctrl)+2 {
+		t.Errorf("control count = %d, want %d", len(got.Ctrl), len(c.Ctrl)+2)
+	}
+	lo, hi := c.Domain()
+	for i := 0; i <= 20; i++ {
+		u := lo + (hi-lo)*float64(i)/20
+		if !c.PointAt(u).IsEqualTo(got.PointAt(u), 1e-12) {
+			t.Fatalf("2d curve diverges at u=%g after refine", u)
+		}
+	}
+}
+
+func TestRefineKnotsSurfacePreservesGeometry(t *testing.T) {
+	s := sampleQuadraticSurface(t)
+	gu, err := s.RefineKnotsU([]float64{0.25, 0.5})
+	if err != nil {
+		t.Fatalf("RefineKnotsU: %v", err)
+	}
+	gv, err := gu.RefineKnotsV([]float64{0.5, 0.75})
+	if err != nil {
+		t.Fatalf("RefineKnotsV: %v", err)
+	}
+	if len(gv.Ctrl) != len(s.Ctrl)+2 || len(gv.Ctrl[0]) != len(s.Ctrl[0])+2 {
+		t.Errorf("net dims = %dx%d, want %dx%d", len(gv.Ctrl), len(gv.Ctrl[0]), len(s.Ctrl)+2, len(s.Ctrl[0])+2)
+	}
+	for i := 0; i <= 10; i++ {
+		for j := 0; j <= 10; j++ {
+			u, v := float64(i)/10, float64(j)/10
+			if !s.PointAt(u, v).IsEqualTo(gv.PointAt(u, v), 1e-12) {
+				t.Fatalf("surface diverges at (%g,%g) after refine", u, v)
+			}
+		}
+	}
+}
+
+func TestRefineKnotsSurfaceRejectsBadKnot(t *testing.T) {
+	s := sampleQuadraticSurface(t)
+	if _, err := s.RefineKnotsU([]float64{1.5}); err == nil {
+		t.Error("refining with an out-of-domain U knot should error")
+	}
+	if _, err := s.RefineKnotsV([]float64{-0.2}); err == nil {
+		t.Error("refining with an out-of-domain V knot should error")
+	}
+}
+
 func TestInsertKnotSurfacePreservesGeometry(t *testing.T) {
 	s := sampleQuadraticSurface(t)
 	gu, err := s.InsertKnotU(0.5, 1)

--- a/kernel/geom/nurbs_knots.go
+++ b/kernel/geom/nurbs_knots.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import stdmath "math"
+
+// Knot-vector helpers shared by the NURBS refinement and degree-change primitives
+// (M36-F01). A knot is treated as a repeat of an existing value when it lies within
+// knotEps of it, so floating-point round-off in inserted knots does not spuriously
+// raise or hide multiplicity.
+const knotEps = 1e-9
+
+// knotMultiplicity returns how many entries of knots equal value (within knotEps).
+func knotMultiplicity(knots []float64, value float64) int {
+	mult := 0
+	for _, k := range knots {
+		if stdmath.Abs(k-value) <= knotEps {
+			mult++
+		}
+	}
+	return mult
+}
+
+// findSpanMult returns the knot span k containing u (as [findSpan]) together with
+// the multiplicity s of u in the knot vector. Knot insertion seeds its blend with
+// the pair (k, s): a knot may be inserted at most degree−s more times (P&T §5.2).
+func findSpanMult(n, p int, u float64, knots []float64) (span, mult int) {
+	return findSpan(n, p, u, knots), knotMultiplicity(knots, u)
+}
+
+// normalizeKnots returns a copy of knots affinely rescaled so the vector spans
+// [0, 1]; it leaves a degenerate (zero-width) vector unchanged. Reparametrizing to
+// a common domain is the precondition for making two knot vectors compatible.
+func normalizeKnots(knots []float64) []float64 {
+	lo, hi := knots[0], knots[len(knots)-1]
+	span := hi - lo
+	out := make([]float64, len(knots))
+	if span <= knotEps {
+		copy(out, knots)
+		return out
+	}
+	for i, k := range knots {
+		out[i] = (k - lo) / span
+	}
+	return out
+}
+
+// mergedInteriorKnots returns the per-knot extra multiplicity needed to raise a in
+// each of its distinct interior knots up to the maximum multiplicity that value has
+// across a and b — the difference list that makes a's knots a superset of b's. Both
+// vectors must already share a degree and domain. It is the heart of making two
+// curves knot-compatible before a tensor-product surface op (network/loft).
+func mergedInteriorKnots(p int, a, b []float64) (values []float64, extra []int) {
+	for _, v := range distinctInterior(p, a, b) {
+		need := max(knotMultiplicity(a, v), knotMultiplicity(b, v)) - knotMultiplicity(a, v)
+		if need > 0 {
+			values = append(values, v)
+			extra = append(extra, need)
+		}
+	}
+	return values, extra
+}
+
+// distinctInterior returns the sorted distinct interior knot values appearing in
+// either a or b (the clamped end knots are excluded — they are shared by construction).
+func distinctInterior(p int, a, b []float64) []float64 {
+	lo, hi := a[p], a[len(a)-1-p]
+	var seen []float64
+	for _, src := range [][]float64{a, b} {
+		for _, v := range src {
+			if v <= lo+knotEps || v >= hi-knotEps {
+				continue
+			}
+			if !containsKnot(seen, v) {
+				seen = append(seen, v)
+			}
+		}
+	}
+	sortFloats(seen)
+	return seen
+}
+
+// containsKnot reports whether value already appears in vs (within knotEps).
+func containsKnot(vs []float64, value float64) bool {
+	for _, v := range vs {
+		if stdmath.Abs(v-value) <= knotEps {
+			return true
+		}
+	}
+	return false
+}
+
+// sortFloats sorts a small knot-value slice ascending (insertion sort: these
+// slices hold at most a handful of distinct interior knots).
+func sortFloats(vs []float64) {
+	for i := 1; i < len(vs); i++ {
+		for j := i; j > 0 && vs[j] < vs[j-1]; j-- {
+			vs[j], vs[j-1] = vs[j-1], vs[j]
+		}
+	}
+}

--- a/kernel/geom/nurbs_knots_test.go
+++ b/kernel/geom/nurbs_knots_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+	"testing"
+)
+
+func TestKnotMultiplicity(t *testing.T) {
+	knots := []float64{0, 0, 0, 0.5, 0.5, 1, 1, 1}
+	cases := []struct {
+		value float64
+		want  int
+	}{{0, 3}, {0.5, 2}, {1, 3}, {0.25, 0}}
+	for _, c := range cases {
+		if got := knotMultiplicity(knots, c.value); got != c.want {
+			t.Errorf("knotMultiplicity(%g) = %d, want %d", c.value, got, c.want)
+		}
+	}
+}
+
+func TestFindSpanMult(t *testing.T) {
+	knots := []float64{0, 0, 0, 0.5, 1, 1, 1} // degree 2, n=3
+	span, mult := findSpanMult(3, 2, 0.5, knots)
+	if span != 3 || mult != 1 {
+		t.Errorf("findSpanMult(0.5) = (%d,%d), want (3,1)", span, mult)
+	}
+	_, mult = findSpanMult(3, 2, 0.25, knots)
+	if mult != 0 {
+		t.Errorf("findSpanMult(0.25) multiplicity = %d, want 0", mult)
+	}
+}
+
+func TestNormalizeKnots(t *testing.T) {
+	got := normalizeKnots([]float64{2, 2, 2, 4, 6, 6, 6})
+	want := []float64{0, 0, 0, 0.5, 1, 1, 1}
+	for i := range want {
+		if stdmath.Abs(got[i]-want[i]) > 1e-12 {
+			t.Fatalf("normalizeKnots = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestNormalizeKnotsDegenerate(t *testing.T) {
+	in := []float64{3, 3, 3, 3}
+	got := normalizeKnots(in)
+	for i := range in {
+		if got[i] != in[i] {
+			t.Fatalf("degenerate normalizeKnots = %v, want unchanged %v", got, in)
+		}
+	}
+}
+
+func TestMergedInteriorKnots(t *testing.T) {
+	// a has a single interior knot at 0.5; b has interior knots at 0.5 (double) and
+	// 0.25. To match the maximum multiplicity per value, a must gain one more 0.5 and
+	// one fresh 0.25.
+	p := 3
+	a := []float64{0, 0, 0, 0, 0.5, 1, 1, 1, 1}
+	b := []float64{0, 0, 0, 0, 0.25, 0.5, 0.5, 1, 1, 1, 1}
+	values, extra := mergedInteriorKnots(p, a, b)
+	if len(values) != 2 {
+		t.Fatalf("merged values = %v (extra %v), want 2 entries", values, extra)
+	}
+	got := map[float64]int{values[0]: extra[0], values[1]: extra[1]}
+	if got[0.25] != 1 || got[0.5] != 1 {
+		t.Errorf("merged extras = %v, want {0.25:1, 0.5:1}", got)
+	}
+}

--- a/kernel/geom/nurbs_reduce.go
+++ b/kernel/geom/nurbs_reduce.go
@@ -20,12 +20,12 @@ package geom
 // degreeReduceHomog reduces the homogeneous B-spline (degree p) by one degree to its C^0
 // Bézier-joined form within tol, returning ok=false when any segment is not reducible.
 // The result still carries the redundant join knots; the caller cleans them up.
-func degreeReduceHomog(p int, U []float64, pw []hpoint4, tol float64) (newU []float64, newPw []hpoint4, ok bool) {
+func degreeReduceHomog(p int, knots []float64, pw []hpoint4, tol float64) (newU []float64, newPw []hpoint4, ok bool) {
 	if p < 2 {
 		return nil, nil, false
 	}
-	breaks := distinctValues(U)
-	segs := decomposeBezier(p, U, pw, breaks)
+	breaks := distinctValues(knots)
+	segs := decomposeBezier(p, knots, pw, breaks)
 	reduced := make([][]hpoint4, len(segs))
 	for i, seg := range segs {
 		r, segOK := reduceBezierSegment(seg, tol)
@@ -38,12 +38,12 @@ func degreeReduceHomog(p int, U []float64, pw []hpoint4, tol float64) (newU []fl
 	return newU, newPw, true
 }
 
-// distinctValues returns the distinct knot values of U in order (consecutive equal
+// distinctValues returns the distinct knot values of knots in order (consecutive equal
 // entries collapse to one), i.e. the Bézier break points including the two clamped ends.
-func distinctValues(U []float64) []float64 {
+func distinctValues(knots []float64) []float64 {
 	var out []float64
-	for i, k := range U {
-		if i == 0 || k != U[i-1] {
+	for i, k := range knots {
+		if i == 0 || k != knots[i-1] {
 			out = append(out, k)
 		}
 	}
@@ -53,8 +53,8 @@ func distinctValues(U []float64) []float64 {
 // decomposeBezier inserts every interior break up to multiplicity p so the curve becomes
 // a chain of Bézier segments, then slices out each segment's p+1 control points (segments
 // overlap by one shared endpoint).
-func decomposeBezier(p int, U []float64, pw []hpoint4, breaks []float64) [][]hpoint4 {
-	knots, work := U, pw
+func decomposeBezier(p int, knots []float64, pw []hpoint4, breaks []float64) [][]hpoint4 {
+	work := pw
 	for _, v := range breaks[1 : len(breaks)-1] {
 		if m := knotMultiplicity(knots, v); m < p {
 			knots, work = insertKnotHomog(p, knots, work, v, p-m)
@@ -150,7 +150,7 @@ func elevateBezier1(q []hpoint4, d int) []hpoint4 {
 
 // recomposeBezier joins the reduced (degree pr) Bézier segments into one C^0 B-spline:
 // segments share endpoints and every interior break carries multiplicity pr.
-func recomposeBezier(pr int, breaks []float64, reduced [][]hpoint4) (U []float64, pw []hpoint4) {
+func recomposeBezier(pr int, breaks []float64, reduced [][]hpoint4) (knots []float64, pw []hpoint4) {
 	pw = append([]hpoint4(nil), reduced[0]...)
 	for s := 1; s < len(reduced); s++ {
 		pw = append(pw, reduced[s][1:]...)
@@ -162,17 +162,17 @@ func recomposeBezier(pr int, breaks []float64, reduced [][]hpoint4) (U []float64
 // the given break points (interior breaks at multiplicity pr, ends at pr+1).
 func bezierJoinKnots(pr int, breaks []float64) []float64 {
 	nseg := len(breaks) - 1
-	U := make([]float64, 0, 2*(pr+1)+(nseg-1)*pr)
+	knots := make([]float64, 0, 2*(pr+1)+(nseg-1)*pr)
 	for k := 0; k <= pr; k++ {
-		U = append(U, breaks[0])
+		knots = append(knots, breaks[0])
 	}
 	for s := 1; s < nseg; s++ {
 		for k := 0; k < pr; k++ {
-			U = append(U, breaks[s])
+			knots = append(knots, breaks[s])
 		}
 	}
 	for k := 0; k <= pr; k++ {
-		U = append(U, breaks[nseg])
+		knots = append(knots, breaks[nseg])
 	}
-	return U
+	return knots
 }

--- a/kernel/geom/nurbs_reduce.go
+++ b/kernel/geom/nurbs_reduce.go
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+// Degree reduction on homogeneous control points — the inverse of degree elevation and,
+// like knot removal, *approximate*: a curve can drop a degree only if its shape admits a
+// lower-degree representation within a tolerance (M36-F01). Rather than A5.11's in-place
+// error bookkeeping, this uses the equivalent decompose→reduce→recompose route, which
+// reuses the already-tested knot insertion (Bézier extraction) and knot removal (cleanup):
+//
+//  1. insert knots until the curve is a sequence of Bézier segments;
+//  2. lower each segment to degree p−1 (Piegl & Tiller eq. 5.40), rejecting the whole
+//     curve if any segment's deviation — measured by RE-ELEVATING the reduced segment and
+//     comparing to the original, an exact error rather than an estimate — exceeds tol;
+//  3. re-join the reduced segments into a C^0 degree-(p−1) B-spline.
+//
+// The caller then removes the now-redundant interior knots (curves directly, surfaces via
+// the all-columns-agree RemoveKnot), so a surface keeps one consistent knot vector.
+
+// degreeReduceHomog reduces the homogeneous B-spline (degree p) by one degree to its C^0
+// Bézier-joined form within tol, returning ok=false when any segment is not reducible.
+// The result still carries the redundant join knots; the caller cleans them up.
+func degreeReduceHomog(p int, U []float64, pw []hpoint4, tol float64) (newU []float64, newPw []hpoint4, ok bool) {
+	if p < 2 {
+		return nil, nil, false
+	}
+	breaks := distinctValues(U)
+	segs := decomposeBezier(p, U, pw, breaks)
+	reduced := make([][]hpoint4, len(segs))
+	for i, seg := range segs {
+		r, segOK := reduceBezierSegment(seg, tol)
+		if !segOK {
+			return nil, nil, false
+		}
+		reduced[i] = r
+	}
+	newU, newPw = recomposeBezier(p-1, breaks, reduced)
+	return newU, newPw, true
+}
+
+// distinctValues returns the distinct knot values of U in order (consecutive equal
+// entries collapse to one), i.e. the Bézier break points including the two clamped ends.
+func distinctValues(U []float64) []float64 {
+	var out []float64
+	for i, k := range U {
+		if i == 0 || k != U[i-1] {
+			out = append(out, k)
+		}
+	}
+	return out
+}
+
+// decomposeBezier inserts every interior break up to multiplicity p so the curve becomes
+// a chain of Bézier segments, then slices out each segment's p+1 control points (segments
+// overlap by one shared endpoint).
+func decomposeBezier(p int, U []float64, pw []hpoint4, breaks []float64) [][]hpoint4 {
+	knots, work := U, pw
+	for _, v := range breaks[1 : len(breaks)-1] {
+		if m := knotMultiplicity(knots, v); m < p {
+			knots, work = insertKnotHomog(p, knots, work, v, p-m)
+		}
+	}
+	nseg := len(breaks) - 1
+	segs := make([][]hpoint4, nseg)
+	for s := 0; s < nseg; s++ {
+		segs[s] = append([]hpoint4(nil), work[s*p:s*p+p+1]...)
+	}
+	return segs
+}
+
+// reduceBezierSegment lowers one Bézier segment from degree p to p−1 and accepts it only
+// when re-elevating the result stays within tol of the original at every control point.
+func reduceBezierSegment(seg []hpoint4, tol float64) (reduced []hpoint4, ok bool) {
+	p := len(seg) - 1
+	q := bezierReduceCtrl(seg, p)
+	if bezierReduceError(seg, q, p) > tol {
+		return nil, false
+	}
+	return q, true
+}
+
+// bezierReduceCtrl computes the degree-(p−1) control points by meeting the left-to-right
+// and right-to-left reduction recurrences (eq. 5.40) in the middle, which is exact for a
+// genuinely reducible segment and well-conditioned otherwise.
+func bezierReduceCtrl(seg []hpoint4, p int) []hpoint4 {
+	qf := reduceForward(seg, p)
+	qb := reduceBackward(seg, p)
+	r := (p - 1) / 2
+	q := make([]hpoint4, p)
+	for i := 0; i < p; i++ {
+		if i <= r {
+			q[i] = qf[i]
+		} else {
+			q[i] = qb[i]
+		}
+	}
+	return q
+}
+
+// reduceForward solves the elevation relation P_i = (i/p)·Q_{i−1} + (1−i/p)·Q_i for Q from
+// the left (Q_0 = P_0); accurate for the left half of the segment.
+func reduceForward(seg []hpoint4, p int) []hpoint4 {
+	q := make([]hpoint4, p)
+	q[0] = seg[0]
+	for i := 1; i < p; i++ {
+		a := float64(i) / float64(p)
+		q[i] = seg[i].sub(q[i-1].scale(a)).scale(1 / (1 - a))
+	}
+	return q
+}
+
+// reduceBackward solves the same relation from the right (Q_{p−1} = P_p); accurate for the
+// right half of the segment.
+func reduceBackward(seg []hpoint4, p int) []hpoint4 {
+	q := make([]hpoint4, p)
+	q[p-1] = seg[p]
+	for i := p - 2; i >= 0; i-- {
+		a := float64(i+1) / float64(p)
+		q[i] = seg[i+1].sub(q[i+1].scale(1 - a)).scale(1 / a)
+	}
+	return q
+}
+
+// bezierReduceError returns the largest control-point deviation between the original
+// segment and the degree-(p−1) candidate re-elevated to degree p — an exact reducibility
+// measure (zero exactly when the segment is one degree reducible).
+func bezierReduceError(seg, q []hpoint4, p int) float64 {
+	elevated := elevateBezier1(q, p-1)
+	maxErr := 0.0
+	for i := 0; i <= p; i++ {
+		if d := seg[i].dist(elevated[i]); d > maxErr {
+			maxErr = d
+		}
+	}
+	return maxErr
+}
+
+// elevateBezier1 raises a single Bézier polygon from degree d to d+1 in closed form:
+// P̃_i = (i/(d+1))·Q_{i−1} + (1 − i/(d+1))·Q_i, preserving the end points.
+func elevateBezier1(q []hpoint4, d int) []hpoint4 {
+	out := make([]hpoint4, d+2)
+	out[0] = q[0]
+	out[d+1] = q[d]
+	for i := 1; i <= d; i++ {
+		a := float64(i) / float64(d+1)
+		out[i] = q[i-1].scale(a).add(q[i].scale(1 - a))
+	}
+	return out
+}
+
+// recomposeBezier joins the reduced (degree pr) Bézier segments into one C^0 B-spline:
+// segments share endpoints and every interior break carries multiplicity pr.
+func recomposeBezier(pr int, breaks []float64, reduced [][]hpoint4) (U []float64, pw []hpoint4) {
+	pw = append([]hpoint4(nil), reduced[0]...)
+	for s := 1; s < len(reduced); s++ {
+		pw = append(pw, reduced[s][1:]...)
+	}
+	return bezierJoinKnots(pr, breaks), pw
+}
+
+// bezierJoinKnots builds the clamped knot vector of a C^0 chain of degree-pr Béziers over
+// the given break points (interior breaks at multiplicity pr, ends at pr+1).
+func bezierJoinKnots(pr int, breaks []float64) []float64 {
+	nseg := len(breaks) - 1
+	U := make([]float64, 0, 2*(pr+1)+(nseg-1)*pr)
+	for k := 0; k <= pr; k++ {
+		U = append(U, breaks[0])
+	}
+	for s := 1; s < nseg; s++ {
+		for k := 0; k < pr; k++ {
+			U = append(U, breaks[s])
+		}
+	}
+	for k := 0; k <= pr; k++ {
+		U = append(U, breaks[nseg])
+	}
+	return U
+}

--- a/kernel/geom/nurbs_reduce_test.go
+++ b/kernel/geom/nurbs_reduce_test.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+func TestElevateThenReduceRoundTrip(t *testing.T) {
+	c := sampleCubicCurve(t)
+	elevated, err := c.ElevateDegree(1)
+	if err != nil {
+		t.Fatalf("ElevateDegree: %v", err)
+	}
+	got, ok, err := elevated.ReduceDegree(1e-9)
+	if err != nil {
+		t.Fatalf("ReduceDegree: %v", err)
+	}
+	if !ok {
+		t.Fatal("an elevated curve must reduce back to its original degree")
+	}
+	if got.Degree != c.Degree {
+		t.Errorf("degree = %d, want %d", got.Degree, c.Degree)
+	}
+	if len(got.Ctrl) != len(c.Ctrl) {
+		t.Errorf("control count = %d, want %d (back to the original)", len(got.Ctrl), len(c.Ctrl))
+	}
+	curvesAgree(t, c, got, 1e-7)
+}
+
+func TestReduceDegreeBezierRoundTrip(t *testing.T) {
+	c := quarterCircleNURBS(t) // degree 2 Bézier
+	elevated, err := c.ElevateDegree(1)
+	if err != nil {
+		t.Fatalf("ElevateDegree: %v", err)
+	}
+	got, ok, err := elevated.ReduceDegree(1e-9)
+	if err != nil {
+		t.Fatalf("ReduceDegree: %v", err)
+	}
+	if !ok || got.Degree != 2 || len(got.Ctrl) != 3 {
+		t.Fatalf("reduced Bézier: ok=%v degree=%d ctrl=%d; want true/2/3", ok, got.Degree, len(got.Ctrl))
+	}
+	for i := 0; i <= 20; i++ {
+		u := float64(i) / 20
+		if !c.PointAt(u).IsEqualTo(got.PointAt(u), 1e-7) {
+			t.Fatalf("reduced quarter circle diverges at u=%g", u)
+		}
+	}
+}
+
+func TestReduceDegreeRejectsIrreducible(t *testing.T) {
+	// A genuine cubic (its degree-3 term is essential) cannot drop to a quadratic at a
+	// tight tolerance.
+	c := sampleCubicCurve(t)
+	if _, ok, err := c.ReduceDegree(1e-9); err != nil {
+		t.Fatalf("ReduceDegree: %v", err)
+	} else if ok {
+		t.Error("a genuine cubic must not reduce to a quadratic within a tight tolerance")
+	}
+}
+
+func TestReduceDegreeRejectsDegreeOne(t *testing.T) {
+	c, err := NewBSplineCurveUniformWeights(
+		1,
+		[]math.Point3{math.P3(0, 0, 0), math.P3(1, 0, 0)},
+		[]float64{0, 0, 1, 1},
+	)
+	if err != nil {
+		t.Fatalf("linear curve: %v", err)
+	}
+	if _, _, err := c.ReduceDegree(1e-6); err == nil {
+		t.Error("reducing a degree-1 curve should error")
+	}
+}
+
+func TestReduceDegree2dRoundTrip(t *testing.T) {
+	c, err := NewBSplineCurve2dUniformWeights(
+		2,
+		[]math.Point2{math.P2(0, 0), math.P2(1, 2), math.P2(3, 0), math.P2(4, 1)},
+		[]float64{0, 0, 0, 0.5, 1, 1, 1},
+	)
+	if err != nil {
+		t.Fatalf("2d curve: %v", err)
+	}
+	elevated, err := c.ElevateDegree(1)
+	if err != nil {
+		t.Fatalf("ElevateDegree: %v", err)
+	}
+	got, ok, err := elevated.ReduceDegree(1e-9)
+	if err != nil || !ok {
+		t.Fatalf("ReduceDegree: ok=%v err=%v", ok, err)
+	}
+	if got.Degree != 2 {
+		t.Errorf("degree = %d, want 2", got.Degree)
+	}
+	lo, hi := c.Domain()
+	for i := 0; i <= 20; i++ {
+		u := lo + (hi-lo)*float64(i)/20
+		if !c.PointAt(u).IsEqualTo(got.PointAt(u), 1e-7) {
+			t.Fatalf("2d curve diverges at u=%g after round-trip", u)
+		}
+	}
+}
+
+func TestElevateThenReduceSurfaceRoundTrip(t *testing.T) {
+	s := sampleQuadraticSurface(t)
+	elevated, err := s.ElevateDegreeU(1)
+	if err != nil {
+		t.Fatalf("ElevateDegreeU: %v", err)
+	}
+	gotU, ok, err := elevated.ReduceDegreeU(1e-9)
+	if err != nil || !ok {
+		t.Fatalf("ReduceDegreeU: ok=%v err=%v", ok, err)
+	}
+	if gotU.UDegree != s.UDegree {
+		t.Errorf("U degree = %d, want %d", gotU.UDegree, s.UDegree)
+	}
+	elevatedV, err := s.ElevateDegreeV(1)
+	if err != nil {
+		t.Fatalf("ElevateDegreeV: %v", err)
+	}
+	gotV, okV, err := elevatedV.ReduceDegreeV(1e-9)
+	if err != nil || !okV {
+		t.Fatalf("ReduceDegreeV: ok=%v err=%v", okV, err)
+	}
+	if gotV.VDegree != s.VDegree {
+		t.Errorf("V degree = %d, want %d", gotV.VDegree, s.VDegree)
+	}
+	for i := 0; i <= 10; i++ {
+		for j := 0; j <= 10; j++ {
+			u, v := float64(i)/10, float64(j)/10
+			if !s.PointAt(u, v).IsEqualTo(gotV.PointAt(u, v), 1e-7) {
+				t.Fatalf("surface diverges at (%g,%g) after V round-trip", u, v)
+			}
+		}
+	}
+}

--- a/kernel/geom/nurbs_remove.go
+++ b/kernel/geom/nurbs_remove.go
@@ -17,7 +17,7 @@ import (
 // removeKnotHomog tries to remove the knot u (last index r, multiplicity s) up to num
 // times from the homogeneous curve, succeeding only while each candidate control point
 // stays within tol. It returns the new knots, control points and the removal count.
-func removeKnotHomog(p int, U []float64, pw []hpoint4, u float64, r, s, num int, tol float64) (newU []float64, newPw []hpoint4, removed int) {
+func removeKnotHomog(p int, knots []float64, pw []hpoint4, u float64, r, s, num int, tol float64) (newU []float64, newPw []hpoint4, removed int) {
 	work := append([]hpoint4(nil), pw...)
 	n := len(pw) - 1
 	ord := p + 1
@@ -25,35 +25,35 @@ func removeKnotHomog(p int, U []float64, pw []hpoint4, u float64, r, s, num int,
 	temp := make([]hpoint4, 2*p+2)
 	t := 0
 	for ; t < num; t++ {
-		if !removeOnce(ord, U, work, temp, u, first, last, t, tol) {
+		if !removeOnce(ord, knots, work, temp, u, first, last, t, tol) {
 			break
 		}
 		first--
 		last++
 	}
 	if t == 0 {
-		return append([]float64(nil), U...), work, 0
+		return append([]float64(nil), knots...), work, 0
 	}
-	return shiftRemovedKnots(U, r, t), shiftRemovedCtrl(work, p, r, s, t, n), t
+	return shiftRemovedKnots(knots, r, t), shiftRemovedCtrl(work, p, r, s, t, n), t
 }
 
 // removeOnce computes the candidate control points for removal pass t in temp, tests
 // removability against tol, and on success writes them back into work. It returns
 // whether this pass removed the knot.
-func removeOnce(ord int, U []float64, work, temp []hpoint4, u float64, first, last, t int, tol float64) bool {
+func removeOnce(ord int, knots []float64, work, temp []hpoint4, u float64, first, last, t int, tol float64) bool {
 	off := first - 1
 	temp[0] = work[off]
 	temp[last+1-off] = work[last+1]
 	i, j := first, last
 	ii, jj := 1, last-off
 	for j-i > t {
-		alfi := (u - U[i]) / (U[i+ord+t] - U[i])
-		alfj := (u - U[j-t]) / (U[j+ord] - U[j-t])
+		alfi := (u - knots[i]) / (knots[i+ord+t] - knots[i])
+		alfj := (u - knots[j-t]) / (knots[j+ord] - knots[j-t])
 		temp[ii] = work[i].sub(temp[ii-1].scale(1 - alfi)).scale(1 / alfi)
 		temp[jj] = work[j].sub(temp[jj+1].scale(alfj)).scale(1 / (1 - alfj))
 		i, ii, j, jj = i+1, ii+1, j-1, jj-1
 	}
-	if !removable(ord, U, work, temp, u, i, j, ii, jj, t, tol) {
+	if !removable(ord, knots, work, temp, u, i, j, ii, jj, t, tol) {
 		return false
 	}
 	writeBackRemoval(work, temp, off, first, last, t)
@@ -62,11 +62,11 @@ func removeOnce(ord int, U []float64, work, temp []hpoint4, u float64, first, la
 
 // removable applies A5.8's two-case deviation test: the symmetric (j−i<t) case compares
 // the two converging temps, the asymmetric case reconstructs the original control point.
-func removable(ord int, U []float64, work, temp []hpoint4, u float64, i, j, ii, jj, t int, tol float64) bool {
+func removable(ord int, knots []float64, work, temp []hpoint4, u float64, i, j, ii, jj, t int, tol float64) bool {
 	if j-i < t {
 		return temp[ii-1].dist(temp[jj+1]) <= tol
 	}
-	alfi := (u - U[i]) / (U[i+ord+t] - U[i])
+	alfi := (u - knots[i]) / (knots[i+ord+t] - knots[i])
 	candidate := temp[ii+t+1].scale(alfi).add(temp[ii-1].scale(1 - alfi))
 	return work[i].dist(candidate) <= tol
 }
@@ -81,15 +81,15 @@ func writeBackRemoval(work, temp []hpoint4, off, first, last, t int) {
 	}
 }
 
-// shiftRemovedKnots drops t copies of the removed knot from U (the knots above index r
+// shiftRemovedKnots drops t copies of the removed knot from knots (the knots above index r
 // slide down by t), returning the shortened knot vector.
-func shiftRemovedKnots(U []float64, r, t int) []float64 {
-	m := len(U) - 1
-	out := append([]float64(nil), U...)
+func shiftRemovedKnots(knots []float64, r, t int) []float64 {
+	m := len(knots) - 1
+	out := append([]float64(nil), knots...)
 	for k := r + 1; k <= m; k++ {
 		out[k-t] = out[k]
 	}
-	return out[:len(U)-t]
+	return out[:len(knots)-t]
 }
 
 // shiftRemovedCtrl closes the t-wide gap A5.8 opens around the removed knot, returning
@@ -114,25 +114,25 @@ func shiftRemovedCtrl(work []hpoint4, p, r, s, t, n int) []hpoint4 {
 // interiorKnot validates a removal request and resolves u's last index r, multiplicity
 // s, and the effective removal count (capped at s — a knot cannot be removed more times
 // than it is present). It errors when num < 1 or u is not an interior knot.
-func interiorKnot(p int, U []float64, u float64, num int) (r, s, effNum int, err error) {
+func interiorKnot(p int, knots []float64, u float64, num int) (r, s, effNum int, err error) {
 	if num < 1 {
 		return 0, 0, 0, fmt.Errorf("geom: knot removal count %d must be >= 1", num)
 	}
-	lo, hi := U[p], U[len(U)-1-p]
+	lo, hi := knots[p], knots[len(knots)-1-p]
 	if u <= lo+knotEps || u >= hi-knotEps {
 		return 0, 0, 0, fmt.Errorf("geom: knot %g is not interior to (%g, %g); only interior knots are removable", u, lo, hi)
 	}
-	r, s = lastKnotIndex(U, u)
+	r, s = lastKnotIndex(knots, u)
 	if s == 0 {
 		return 0, 0, 0, fmt.Errorf("geom: knot %g does not appear in the knot vector", u)
 	}
 	return r, s, min(num, s), nil
 }
 
-// lastKnotIndex returns the highest index at which u appears in U (within knotEps) and
+// lastKnotIndex returns the highest index at which u appears in knots (within knotEps) and
 // u's multiplicity; mult is 0 when u is absent.
-func lastKnotIndex(U []float64, u float64) (idx, mult int) {
-	for i, k := range U {
+func lastKnotIndex(knots []float64, u float64) (idx, mult int) {
+	for i, k := range knots {
 		if stdmath.Abs(k-u) <= knotEps {
 			idx = i
 			mult++

--- a/kernel/geom/nurbs_remove.go
+++ b/kernel/geom/nurbs_remove.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	"fmt"
+	stdmath "math"
+)
+
+// Knot removal on homogeneous control points (Tiller's algorithm, Piegl & Tiller
+// A5.8). Unlike insertion, removal is *approximate*: a knot can be removed only if
+// doing so keeps the curve within a tolerance of the original. Removal is half of a
+// rebuild — insert a dense knot set, then remove what the shape does not need to
+// reach a clean, minimal control polygon (M36-F01). The tolerance is measured on the
+// homogeneous control points (equal to model space for a non-rational curve).
+
+// removeKnotHomog tries to remove the knot u (last index r, multiplicity s) up to num
+// times from the homogeneous curve, succeeding only while each candidate control point
+// stays within tol. It returns the new knots, control points and the removal count.
+func removeKnotHomog(p int, U []float64, pw []hpoint4, u float64, r, s, num int, tol float64) (newU []float64, newPw []hpoint4, removed int) {
+	work := append([]hpoint4(nil), pw...)
+	n := len(pw) - 1
+	ord := p + 1
+	first, last := r-p, r-s
+	temp := make([]hpoint4, 2*p+2)
+	t := 0
+	for ; t < num; t++ {
+		if !removeOnce(ord, U, work, temp, u, first, last, t, tol) {
+			break
+		}
+		first--
+		last++
+	}
+	if t == 0 {
+		return append([]float64(nil), U...), work, 0
+	}
+	return shiftRemovedKnots(U, r, t), shiftRemovedCtrl(work, p, r, s, t, n), t
+}
+
+// removeOnce computes the candidate control points for removal pass t in temp, tests
+// removability against tol, and on success writes them back into work. It returns
+// whether this pass removed the knot.
+func removeOnce(ord int, U []float64, work, temp []hpoint4, u float64, first, last, t int, tol float64) bool {
+	off := first - 1
+	temp[0] = work[off]
+	temp[last+1-off] = work[last+1]
+	i, j := first, last
+	ii, jj := 1, last-off
+	for j-i > t {
+		alfi := (u - U[i]) / (U[i+ord+t] - U[i])
+		alfj := (u - U[j-t]) / (U[j+ord] - U[j-t])
+		temp[ii] = work[i].sub(temp[ii-1].scale(1 - alfi)).scale(1 / alfi)
+		temp[jj] = work[j].sub(temp[jj+1].scale(alfj)).scale(1 / (1 - alfj))
+		i, ii, j, jj = i+1, ii+1, j-1, jj-1
+	}
+	if !removable(ord, U, work, temp, u, i, j, ii, jj, t, tol) {
+		return false
+	}
+	writeBackRemoval(work, temp, off, first, last, t)
+	return true
+}
+
+// removable applies A5.8's two-case deviation test: the symmetric (j−i<t) case compares
+// the two converging temps, the asymmetric case reconstructs the original control point.
+func removable(ord int, U []float64, work, temp []hpoint4, u float64, i, j, ii, jj, t int, tol float64) bool {
+	if j-i < t {
+		return temp[ii-1].dist(temp[jj+1]) <= tol
+	}
+	alfi := (u - U[i]) / (U[i+ord+t] - U[i])
+	candidate := temp[ii+t+1].scale(alfi).add(temp[ii-1].scale(1 - alfi))
+	return work[i].dist(candidate) <= tol
+}
+
+// writeBackRemoval copies the accepted candidate control points from temp into work.
+func writeBackRemoval(work, temp []hpoint4, off, first, last, t int) {
+	i, j := first, last
+	for j-i > t {
+		work[i] = temp[i-off]
+		work[j] = temp[j-off]
+		i, j = i+1, j-1
+	}
+}
+
+// shiftRemovedKnots drops t copies of the removed knot from U (the knots above index r
+// slide down by t), returning the shortened knot vector.
+func shiftRemovedKnots(U []float64, r, t int) []float64 {
+	m := len(U) - 1
+	out := append([]float64(nil), U...)
+	for k := r + 1; k <= m; k++ {
+		out[k-t] = out[k]
+	}
+	return out[:len(U)-t]
+}
+
+// shiftRemovedCtrl closes the t-wide gap A5.8 opens around the removed knot, returning
+// the shortened control-point slice.
+func shiftRemovedCtrl(work []hpoint4, p, r, s, t, n int) []hpoint4 {
+	fout := (2*r - s - p) / 2
+	i, j := fout, fout
+	for k := 1; k < t; k++ {
+		if k%2 == 1 {
+			i++
+		} else {
+			j--
+		}
+	}
+	for k := i + 1; k <= n; k++ {
+		work[j] = work[k]
+		j++
+	}
+	return work[:len(work)-t]
+}
+
+// interiorKnot validates a removal request and resolves u's last index r, multiplicity
+// s, and the effective removal count (capped at s — a knot cannot be removed more times
+// than it is present). It errors when num < 1 or u is not an interior knot.
+func interiorKnot(p int, U []float64, u float64, num int) (r, s, effNum int, err error) {
+	if num < 1 {
+		return 0, 0, 0, fmt.Errorf("geom: knot removal count %d must be >= 1", num)
+	}
+	lo, hi := U[p], U[len(U)-1-p]
+	if u <= lo+knotEps || u >= hi-knotEps {
+		return 0, 0, 0, fmt.Errorf("geom: knot %g is not interior to (%g, %g); only interior knots are removable", u, lo, hi)
+	}
+	r, s = lastKnotIndex(U, u)
+	if s == 0 {
+		return 0, 0, 0, fmt.Errorf("geom: knot %g does not appear in the knot vector", u)
+	}
+	return r, s, min(num, s), nil
+}
+
+// lastKnotIndex returns the highest index at which u appears in U (within knotEps) and
+// u's multiplicity; mult is 0 when u is absent.
+func lastKnotIndex(U []float64, u float64) (idx, mult int) {
+	for i, k := range U {
+		if stdmath.Abs(k-u) <= knotEps {
+			idx = i
+			mult++
+		}
+	}
+	return idx, mult
+}

--- a/kernel/geom/nurbs_remove_test.go
+++ b/kernel/geom/nurbs_remove_test.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// sqrtHalf is √2/2, the middle weight of a rational quadratic quarter circle.
+var sqrtHalf = stdmath.Sqrt2 / 2
+
+func TestInsertThenRemoveRoundTrip(t *testing.T) {
+	c := sampleCubicCurve(t)
+	refined, err := c.InsertKnot(0.25, 1)
+	if err != nil {
+		t.Fatalf("InsertKnot: %v", err)
+	}
+	got, removed, err := refined.RemoveKnot(0.25, 1, 1e-9)
+	if err != nil {
+		t.Fatalf("RemoveKnot: %v", err)
+	}
+	if removed != 1 {
+		t.Fatalf("removed = %d, want 1 (the just-inserted knot is redundant)", removed)
+	}
+	if len(got.Ctrl) != len(c.Ctrl) {
+		t.Errorf("control count = %d, want %d (back to the original)", len(got.Ctrl), len(c.Ctrl))
+	}
+	curvesAgree(t, c, got, 1e-9)
+}
+
+func TestRemoveKnotRepeatedRoundTrip(t *testing.T) {
+	c := sampleCubicCurve(t)
+	refined, err := c.InsertKnot(0.25, 3) // multiplicity 3 of a fresh knot
+	if err != nil {
+		t.Fatalf("InsertKnot x3: %v", err)
+	}
+	got, removed, err := refined.RemoveKnot(0.25, 3, 1e-9)
+	if err != nil {
+		t.Fatalf("RemoveKnot x3: %v", err)
+	}
+	if removed != 3 {
+		t.Fatalf("removed = %d, want 3", removed)
+	}
+	curvesAgree(t, c, got, 1e-9)
+}
+
+func TestRemoveKnotKeepsNeededKnot(t *testing.T) {
+	// 0.5 is an intrinsic knot of the sample curve; removing it at a tight tolerance
+	// must fail (the shape genuinely needs it) and leave the curve untouched.
+	c := sampleCubicCurve(t)
+	got, removed, err := c.RemoveKnot(0.5, 1, 1e-12)
+	if err != nil {
+		t.Fatalf("RemoveKnot: %v", err)
+	}
+	if removed != 0 {
+		t.Errorf("removed = %d, want 0 (knot is geometrically required at tight tol)", removed)
+	}
+	if len(got.Ctrl) != len(c.Ctrl) {
+		t.Errorf("control count changed to %d; a failed removal must leave the curve intact", len(got.Ctrl))
+	}
+}
+
+func TestRemoveKnotRejectsNonInterior(t *testing.T) {
+	c := sampleCubicCurve(t)
+	if _, _, err := c.RemoveKnot(0.0, 1, 1e-6); err == nil {
+		t.Error("removing a boundary knot should error")
+	}
+	if _, _, err := c.RemoveKnot(0.3, 1, 1e-6); err == nil {
+		t.Error("removing a knot that does not appear should error")
+	}
+	if _, _, err := c.RemoveKnot(0.5, 0, 1e-6); err == nil {
+		t.Error("a zero removal count should error")
+	}
+}
+
+func TestRemoveKnot2dRoundTrip(t *testing.T) {
+	c := quarterCircleCurve2d(t)
+	refined, err := c.InsertKnot(0.5, 1)
+	if err != nil {
+		t.Fatalf("InsertKnot: %v", err)
+	}
+	got, removed, err := refined.RemoveKnot(0.5, 1, 1e-9)
+	if err != nil {
+		t.Fatalf("RemoveKnot: %v", err)
+	}
+	if removed != 1 {
+		t.Fatalf("removed = %d, want 1", removed)
+	}
+	lo, hi := c.Domain()
+	for i := 0; i <= 20; i++ {
+		u := lo + (hi-lo)*float64(i)/20
+		if !c.PointAt(u).IsEqualTo(got.PointAt(u), 1e-9) {
+			t.Fatalf("2d curve diverges at u=%g after round-trip", u)
+		}
+	}
+}
+
+func TestInsertThenRemoveSurfaceRoundTrip(t *testing.T) {
+	s := sampleQuadraticSurface(t)
+	refined, err := s.InsertKnotU(0.5, 1)
+	if err != nil {
+		t.Fatalf("InsertKnotU: %v", err)
+	}
+	gotU, removed, err := refined.RemoveKnotU(0.5, 1, 1e-9)
+	if err != nil {
+		t.Fatalf("RemoveKnotU: %v", err)
+	}
+	if removed != 1 || len(gotU.Ctrl) != len(s.Ctrl) {
+		t.Fatalf("U removal: removed=%d net rows=%d, want 1 and %d", removed, len(gotU.Ctrl), len(s.Ctrl))
+	}
+	refinedV, err := s.InsertKnotV(0.5, 1)
+	if err != nil {
+		t.Fatalf("InsertKnotV: %v", err)
+	}
+	gotV, removedV, err := refinedV.RemoveKnotV(0.5, 1, 1e-9)
+	if err != nil {
+		t.Fatalf("RemoveKnotV: %v", err)
+	}
+	if removedV != 1 || len(gotV.Ctrl[0]) != len(s.Ctrl[0]) {
+		t.Fatalf("V removal: removed=%d net cols=%d, want 1 and %d", removedV, len(gotV.Ctrl[0]), len(s.Ctrl[0]))
+	}
+	for i := 0; i <= 10; i++ {
+		for j := 0; j <= 10; j++ {
+			u, v := float64(i)/10, float64(j)/10
+			if !s.PointAt(u, v).IsEqualTo(gotV.PointAt(u, v), 1e-9) {
+				t.Fatalf("surface diverges at (%g,%g) after V round-trip", u, v)
+			}
+		}
+	}
+}
+
+// quarterCircleCurve2d is the rational quadratic quarter circle as a 2D curve, the
+// rational case for the 2D removal round-trip.
+func quarterCircleCurve2d(t *testing.T) BSplineCurve2d {
+	t.Helper()
+	c, err := NewBSplineCurve2d(
+		2,
+		[]math.Point2{math.P2(1, 0), math.P2(1, 1), math.P2(0, 1)},
+		[]float64{1, sqrtHalf, 1},
+		[]float64{0, 0, 0, 1, 1, 1},
+	)
+	if err != nil {
+		t.Fatalf("quarter-circle 2d: %v", err)
+	}
+	// A fresh interior knot must be insertable, so widen the domain by inserting first.
+	refined, err := c.InsertKnot(0.5, 1)
+	if err != nil {
+		t.Fatalf("seed insert: %v", err)
+	}
+	return refined
+}


### PR DESCRIPTION
## What

The foundational NURBS refinement and degree-change primitives for Class-A surface modeling (milestone **M36**), added to `kernel/geom` with no public-API change (kernel-internal, per the issue):

- **Knot insertion + refinement** (Boehm, A5.1) — exact; subdivides the control polygon/net without moving geometry.
- **Knot removal** (Tiller, A5.8) — tolerance-bounded; reports how many removals it applied.
- **Degree elevation** (Piegl & Tiller A5.9) — exact; raises degree preserving geometry.
- **Degree reduction** — tolerance-bounded inverse of elevation, via a decompose→reduce→recompose route that reuses the tested insert (Bézier extraction) and remove (join cleanup) primitives and measures reducibility by *re-elevating* each reduced Bézier (an exact error, not an estimate).
- **Knot-vector helpers** — span/multiplicity, normalize, and `MakeCompatible` (raise two curves to a common degree + union knot vector — the precondition for skinning a tensor-product surface).

All operate on a shared homogeneous control-point core (`hpoint4`), so one implementation serves curves, 2D curves and both surface directions (rational and non-rational alike).

## Why

Every higher-level Class-A operation — rebuild to clean single-span NURBS (F02), CV editing (F03), match-to-continuity (F05), extend/untrim (F11), and the G2/G3 construction features — needs these. `kernel/geom` had NURBS evaluation and fitting but no refinement primitives; this is that missing layer.

## Verification

- **Round-trip invariants** (the issue's acceptance criteria): insert→remove returns the original within tolerance; elevate→reduce returns the original exactly; elevation/insertion preserve the curve/surface to 1e-12 across dense samples — for curves, 2D curves and both surface directions.
- A genuine cubic is correctly **refused** reduction to a quadratic at tight tolerance; a geometrically-required knot is **kept** by removal.
- `go test ./kernel/geom/…` green, **89.7%** package coverage; `golangci-lint` clean; `gofmt` clean; whole module builds and kernel+model suites pass.

Commits are split by primitive for granular review.

Part of #1276. Closes #1277.