### PR TITLE
M36-F13: Cross-edge continuity checker (G0/G1/G2 deviation report)

### DIFF
--- a/app/commands_analysis.go
+++ b/app/commands_analysis.go
@@ -32,7 +32,20 @@ func analysisCommands() []*CommandDefinition {
 			WithTab("Inspect").WithRibbons(PartRibbon).WithEnable(hasActivePart).
 			WithIcon("surface-analysis").WithButtonStyle(LargeIconButton).
 			WithTooltip("Surface Analysis — overlay reflection, highlight and isophote lines to judge surface fairness and G1/G2 continuity."),
+		NewCommand("Inspect.Continuity", "Continuity Check", "Analyze", startContinuityCheck).
+			WithTab("Inspect").WithRibbons(PartRibbon).WithEnable(hasActivePart).
+			WithIcon("continuity-check").WithButtonStyle(LargeIconButton).
+			WithTooltip("Continuity Check — pick a shared edge to report the G0 gap, G1 normal angle and G2 curvature difference across it."),
 	}
+}
+
+// startContinuityCheck activates the cross-edge continuity checker on the active part.
+func startContinuityCheck(s *Session) error {
+	if _, err := activePart(s); err != nil {
+		return err
+	}
+	s.StartTool(NewContinuityCheckTool())
+	return nil
 }
 
 // startSurfaceAnalysis activates the live surface-interrogation overlay on the active part.

--- a/app/continuity_check_tool.go
+++ b/app/continuity_check_tool.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/analysis"
+	"oblikovati.org/renderer"
+)
+
+// The Continuity Check tool (M36-F13) is the numeric companion to the Surface Analysis overlay:
+// pick an edge shared by two faces and it reports the positional gap (G0), normal angle (G1) and
+// curvature difference (G2) along the edge, and draws the edge coloured green→red by the worst
+// local deviation. It is the quantitative acceptance gate behind match/blend/bridge/extend.
+
+// continuityCheckSamples is how many points along the edge the checker measures.
+const continuityCheckSamples = 25
+
+// ContinuityCheckTool measures cross-edge continuity on a picked shared edge.
+type ContinuityCheckTool struct {
+	edge    *EdgeHandle
+	report  *analysis.ContinuityReport
+	overlay []renderer.DrawItem
+}
+
+// NewContinuityCheckTool returns the continuity-check tool.
+func NewContinuityCheckTool() *ContinuityCheckTool { return &ContinuityCheckTool{} }
+
+// Name implements [Tool].
+func (t *ContinuityCheckTool) Name() string { return "Continuity Check" }
+
+// Start is a no-op; the engine installs the edge filter from AcceptedKinds.
+func (t *ContinuityCheckTool) Start(*Session) {}
+
+// AcceptedKinds declares the tool picks edges (the shared seam to measure).
+func (t *ContinuityCheckTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectEdge} }
+
+// Picks reports the picked edge for the unified highlight.
+func (t *ContinuityCheckTool) Picks() []Selectable { return edgeSelectables(t.Edges()) }
+
+// Edges returns the picked edge (one or none).
+func (t *ContinuityCheckTool) Edges() []EdgeHandle {
+	if t.edge == nil {
+		return nil
+	}
+	return []EdgeHandle{*t.edge}
+}
+
+// Pick measures continuity across the picked edge and reports the result to the Command Window.
+func (t *ContinuityCheckTool) Pick(s *Session, sel Selectable) {
+	e, ok := sel.(EdgeHandle)
+	if !ok {
+		return
+	}
+	rep, overlay, err := measureEdgeContinuity(e.Edge)
+	if err != nil {
+		s.SetNotice(err.Error())
+		return
+	}
+	ec := e
+	t.edge, t.report, t.overlay = &ec, &rep, overlay
+	s.feedNotice(continuitySummary(rep))
+}
+
+// CanCommit is false — the tool reports on pick, there is nothing to commit.
+func (t *ContinuityCheckTool) CanCommit() bool { return false }
+
+// Commit is a no-op (report-on-pick).
+func (t *ContinuityCheckTool) Commit(*Session) error { return nil }
+
+// Cancel restores the default selection filter.
+func (t *ContinuityCheckTool) Cancel(*Session) {}
+
+// Preview draws the edge coloured by local continuity deviation.
+func (t *ContinuityCheckTool) Preview(*Session) []renderer.DrawItem { return t.overlay }
+
+// Report returns the most recent continuity report (nil before a pick), for inspection/tests.
+func (t *ContinuityCheckTool) Report() *analysis.ContinuityReport { return t.report }
+
+// measureEdgeContinuity builds the edge→surface traces for the edge's two faces and runs the
+// cross-edge continuity checker, returning the report and the coloured along-edge overlay.
+func measureEdgeContinuity(edge *topo.Edge) (analysis.ContinuityReport, []renderer.DrawItem, error) {
+	faces := edge.Faces()
+	if len(faces) != 2 {
+		return analysis.ContinuityReport{}, nil, fmt.Errorf("continuity check needs an edge shared by exactly two faces (got %d)", len(faces))
+	}
+	a, b := faces[0].Geometry(), faces[1].Geometry()
+	curve := edge.Geometry()
+	lo, hi := curve.Domain()
+	at := func(t float64) math.Point3 { return curve.PointAt(lo + (hi-lo)*t) }
+	ea := func(t float64) (u, v float64) { return a.ParamAt(at(t)) }
+	eb := func(t float64) (u, v float64) { return b.ParamAt(at(t)) }
+	rep := analysis.CrossEdgeContinuity(a, b, ea, eb, continuityCheckSamples)
+	return rep, continuityOverlay(rep, at), nil
+}
+
+// continuityOverlay draws the edge as a polyline coloured green (continuous) → red (discontinuous)
+// by each sample's worst normalized deviation.
+func continuityOverlay(rep analysis.ContinuityReport, at func(float64) math.Point3) []renderer.DrawItem {
+	n := len(rep.Samples)
+	if n < 2 {
+		return nil
+	}
+	pos := make([]math.Point3, n)
+	col := make([][4]float32, n)
+	for i, s := range rep.Samples {
+		pos[i] = at(s.T)
+		col[i] = severityColor(continuitySeverity(s))
+	}
+	idx := make([]int, 0, (n-1)*2)
+	for i := 0; i < n-1; i++ {
+		idx = append(idx, i, i+1)
+	}
+	return []renderer.DrawItem{{Primitive: renderer.Lines, Positions: pos, Indices: idx, Colors: col}}
+}
+
+// continuitySeverity maps one sample's deviations to [0,1] — the worst of a 0.1mm gap, a 1° normal
+// break, or a 50% curvature jump reads as fully discontinuous.
+func continuitySeverity(s analysis.ContinuitySample) float64 {
+	return clampUnit(maxf(s.Gap/0.1, s.NormalDeg/1.0, s.CurvPct/50.0))
+}
+
+// severityColor blends green (0, continuous) to red (1, discontinuous).
+func severityColor(sev float64) [4]float32 {
+	return [4]float32{float32(0.1 + 0.85*sev), float32(0.7 * (1 - sev)), 0.05, 1}
+}
+
+// continuitySummary is the one-line Command Window report of the aggregate deviations.
+func continuitySummary(rep analysis.ContinuityReport) string {
+	return fmt.Sprintf("Continuity — G0 gap max %.4g (avg %.4g), G1 angle max %.3f° (avg %.3f°), G2 curvature max %.1f%% (avg %.1f%%)",
+		rep.MaxGap, rep.AvgGap, rep.MaxNormalDeg, rep.AvgNormalDeg, rep.MaxCurvPct, rep.AvgCurvPct)
+}
+
+// maxf returns the largest of its arguments.
+func maxf(vs ...float64) float64 {
+	m := vs[0]
+	for _, v := range vs[1:] {
+		if v > m {
+			m = v
+		}
+	}
+	return m
+}
+
+// clampUnit clamps x to [0,1].
+func clampUnit(x float64) float64 {
+	if x < 0 {
+		return 0
+	}
+	if x > 1 {
+		return 1
+	}
+	return x
+}

--- a/app/continuity_check_tool.go
+++ b/app/continuity_check_tool.go
@@ -120,7 +120,7 @@ func continuityOverlay(rep analysis.ContinuityReport, at func(float64) math.Poin
 // continuitySeverity maps one sample's deviations to [0,1] — the worst of a 0.1mm gap, a 1° normal
 // break, or a 50% curvature jump reads as fully discontinuous.
 func continuitySeverity(s analysis.ContinuitySample) float64 {
-	return clampUnit(maxf(s.Gap/0.1, s.NormalDeg/1.0, s.CurvPct/50.0))
+	return clampUnit(max(s.Gap/0.1, s.NormalDeg/1.0, s.CurvPct/50.0))
 }
 
 // severityColor blends green (0, continuous) to red (1, discontinuous).
@@ -134,24 +134,5 @@ func continuitySummary(rep analysis.ContinuityReport) string {
 		rep.MaxGap, rep.AvgGap, rep.MaxNormalDeg, rep.AvgNormalDeg, rep.MaxCurvPct, rep.AvgCurvPct)
 }
 
-// maxf returns the largest of its arguments.
-func maxf(vs ...float64) float64 {
-	m := vs[0]
-	for _, v := range vs[1:] {
-		if v > m {
-			m = v
-		}
-	}
-	return m
-}
-
 // clampUnit clamps x to [0,1].
-func clampUnit(x float64) float64 {
-	if x < 0 {
-		return 0
-	}
-	if x > 1 {
-		return 1
-	}
-	return x
-}
+func clampUnit(x float64) float64 { return max(0, min(1, x)) }

--- a/app/continuity_check_tool_test.go
+++ b/app/continuity_check_tool_test.go
@@ -72,6 +72,40 @@ func TestContinuityCheckViaRibbonCommand(t *testing.T) {
 	}
 }
 
+func TestContinuityCheckToolInterface(t *testing.T) {
+	tool := NewContinuityCheckTool()
+	tool.Start(nil)
+	tool.Cancel(nil)
+	if err := tool.Commit(nil); err != nil {
+		t.Errorf("Commit is a no-op, got %v", err)
+	}
+	if tool.CanCommit() {
+		t.Error("CanCommit should be false (report-on-pick)")
+	}
+	if len(tool.AcceptedKinds()) != 1 || tool.AcceptedKinds()[0] != SelectEdge {
+		t.Error("the tool should accept edge picks")
+	}
+	if len(tool.Picks()) != 0 || len(tool.Edges()) != 0 || tool.Preview(nil) != nil {
+		t.Error("before a pick the tool has no edge, picks, or overlay")
+	}
+}
+
+func TestContinuitySeverityHelpers(t *testing.T) {
+	cases := []struct {
+		in, want float64
+	}{{-1, 0}, {0.4, 0.4}, {2, 1}}
+	for _, c := range cases {
+		if got := clampUnit(c.in); got != c.want {
+			t.Errorf("clampUnit(%g) = %g, want %g", c.in, got, c.want)
+		}
+	}
+	// A mid-severity sample produces a colour between green and red.
+	col := severityColor(0.5)
+	if col[0] <= 0.1 || col[1] <= 0 {
+		t.Errorf("mid severity colour = %v, want a green/red blend", col)
+	}
+}
+
 func continuityScrollbackHas(s *Session, substr string) bool {
 	for _, l := range s.CommandLine().Scrollback().Lines() {
 		if strings.Contains(l.Text, substr) {

--- a/app/continuity_check_tool_test.go
+++ b/app/continuity_check_tool_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+	"strings"
+	"testing"
+
+	"oblikovati.org/kernel/topo"
+)
+
+// firstSharedEdge returns the body's first edge shared by exactly two faces (every box edge is).
+func firstSharedEdge(t *testing.T, b *topo.Body) *topo.Edge {
+	t.Helper()
+	for _, e := range b.Edges() {
+		if len(e.Faces()) == 2 {
+			return e
+		}
+	}
+	t.Fatal("no two-face edge on the body")
+	return nil
+}
+
+func TestContinuityCheckReportsBoxEdgeAsRightAngleCrease(t *testing.T) {
+	s, body := newPartWithBlock(t, 6)
+	edge := firstSharedEdge(t, body)
+
+	tool := NewContinuityCheckTool()
+	s.StartTool(tool)
+	tool.Pick(s, EdgeHandle{Edge: edge})
+
+	rep := tool.Report()
+	if rep == nil {
+		t.Fatal("picking a shared edge should produce a continuity report")
+	}
+	// Two perpendicular planar faces: a 90° tangent break, no gap, no curvature difference.
+	if stdmath.Abs(rep.MaxNormalDeg-90) > 0.5 {
+		t.Errorf("box-edge G1 angle = %g°, want ~90°", rep.MaxNormalDeg)
+	}
+	if rep.MaxGap > 1e-6 || rep.MaxCurvDiff > 1e-6 {
+		t.Errorf("box edge should report no G0 gap or G2 curvature difference: gap=%g curv=%g", rep.MaxGap, rep.MaxCurvDiff)
+	}
+	if len(tool.Preview(s)) == 0 {
+		t.Error("a measured edge should draw the coloured continuity overlay")
+	}
+	if !continuityScrollbackHas(s, "Continuity") {
+		t.Error("the Command Window should report the continuity result")
+	}
+}
+
+func TestContinuityCheckIgnoresNonEdgePick(t *testing.T) {
+	s, _ := newPartWithBlock(t, 4)
+	tool := NewContinuityCheckTool()
+	s.StartTool(tool)
+	tool.Pick(s, FaceHandle{}) // not an edge
+	if tool.Report() != nil {
+		t.Error("a non-edge pick should not produce a report")
+	}
+}
+
+func TestContinuityCheckViaRibbonCommand(t *testing.T) {
+	s, _ := newPartWithBlock(t, 4)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	if err := s.Execute("Inspect.Continuity"); err != nil {
+		t.Fatalf("execute Inspect.Continuity: %v", err)
+	}
+	if got := s.ActiveTool().Name(); got != "Continuity Check" {
+		t.Errorf("Inspect.Continuity started tool %q, want Continuity Check", got)
+	}
+}
+
+func continuityScrollbackHas(s *Session, substr string) bool {
+	for _, l := range s.CommandLine().Scrollback().Lines() {
+		if strings.Contains(l.Text, substr) {
+			return true
+		}
+	}
+	return false
+}

--- a/head/icon/assets/continuity-check.svg
+++ b/head/icon/assets/continuity-check.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M3 15 C7 15 8 8 12 8"/><path d="M12 8 C16 8 17 15 21 15" stroke="#ff0000"/><circle cx="12" cy="8" r="1.7" fill="#ff0000" stroke="none"/></svg>

--- a/model/analysis/cross_edge_continuity.go
+++ b/model/analysis/cross_edge_continuity.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package analysis
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Cross-edge continuity measurement (M36-F13) — the quantitative companion to the visual
+// interrogation overlay (F12) and the numeric acceptance oracle for the continuity-construction
+// features (match/blend/bridge/extend). Given two surfaces meeting along a shared edge, it samples
+// the edge and reports, at each sample, the positional gap (G0), the angle between the surface
+// normals (G1), and the difference in normal curvature across the boundary (G2). Built purely on
+// the existing surface evaluators (geom.SurfaceCurvatures et al.), so it is deterministic.
+
+// EdgeParam maps a normalized edge parameter t ∈ [0,1] to a surface's (u, v) coordinates — how the
+// shared edge is traced on one of the two surfaces.
+type EdgeParam func(t float64) (u, v float64)
+
+// ContinuitySample is the cross-edge deviation at one point along the shared edge.
+type ContinuitySample struct {
+	T         float64 // normalized edge parameter
+	Gap       float64 // G0: positional gap between the two surface points (length)
+	NormalDeg float64 // G1: angle between the two surface normals, folded to [0,90] (degrees)
+	CurvDiff  float64 // G2: absolute normal-curvature difference in the cross-boundary direction (1/length)
+	CurvPct   float64 // G2: that difference as a percent of the larger curvature
+}
+
+// ContinuityReport is the along-edge continuity measurement and its aggregates. The samples carry
+// the colored along-edge plot the UI draws; the Max/Avg fields are the pass/fail numbers.
+type ContinuityReport struct {
+	Samples                    []ContinuitySample
+	MaxGap, AvgGap             float64
+	MaxNormalDeg, AvgNormalDeg float64
+	MaxCurvDiff, AvgCurvDiff   float64
+	MaxCurvPct, AvgCurvPct     float64
+}
+
+// CrossEdgeContinuity samples the shared edge (samples ≥ 2 points) and reports the G0/G1/G2
+// deviation between surfaces a and b along it. ea and eb trace the same edge on each surface.
+//
+// Example: rep := CrossEdgeContinuity(faceA, faceB, edgeOnA, edgeOnB, 25); if rep.MaxNormalDeg < 0.1 { tangent }.
+func CrossEdgeContinuity(a, b geom.Surface, ea, eb EdgeParam, samples int) ContinuityReport {
+	if samples < 2 {
+		samples = 2
+	}
+	rep := ContinuityReport{Samples: make([]ContinuitySample, samples)}
+	for i := 0; i < samples; i++ {
+		t := float64(i) / float64(samples-1)
+		rep.Samples[i] = continuityAt(a, b, ea, eb, t)
+	}
+	aggregate(&rep)
+	return rep
+}
+
+// continuityAt measures the three deviations at one edge parameter.
+func continuityAt(a, b geom.Surface, ea, eb EdgeParam, t float64) ContinuitySample {
+	ua, va := ea(t)
+	ub, vb := eb(t)
+	pa, pb := a.PointAt(ua, va), b.PointAt(ub, vb)
+	na, nb := a.NormalAt(ua, va), b.NormalAt(ub, vb)
+	te := edgeTangent(a, ea, t)
+	ka := normalCurvatureCross(a, ua, va, na, te)
+	kb := alignCurvature(normalCurvatureCross(b, ub, vb, nb, te), na, nb)
+	diff := stdmath.Abs(ka - kb)
+	return ContinuitySample{
+		T:         t,
+		Gap:       float64(pa.DistanceTo(pb)),
+		NormalDeg: foldedAngleDeg(na, nb),
+		CurvDiff:  diff,
+		CurvPct:   percentOf(diff, ka, kb),
+	}
+}
+
+// edgeTangent estimates the unit edge tangent at t from a central finite difference of a's edge
+// trace (clamped at the ends).
+func edgeTangent(a geom.Surface, ea EdgeParam, t float64) math.Vector3 {
+	const h = 1e-4
+	t0, t1 := stdmath.Max(0, t-h), stdmath.Min(1, t+h)
+	u0, v0 := ea(t0)
+	u1, v1 := ea(t1)
+	return unit(a.PointAt(u0, v0).VectorTo(a.PointAt(u1, v1)))
+}
+
+// normalCurvatureCross returns the surface's normal curvature in the cross-boundary direction
+// (perpendicular to the edge within the tangent plane), via Euler's formula on the principal
+// curvatures.
+func normalCurvatureCross(s geom.Surface, u, v float64, n, edgeTan math.Vector3) float64 {
+	cross := unit(n.Cross(edgeTan)) // tangent-plane direction perpendicular to the edge
+	maxDir, kMax, kMin := geom.SurfaceCurvatures(s, u, v)
+	if float64(maxDir.Length()) < 1e-12 {
+		return kMax // degenerate frame: principal curvatures are equal (or zero)
+	}
+	cosA := float64(unit(maxDir).Dot(cross))
+	cos2 := cosA * cosA
+	return kMax*cos2 + kMin*(1-cos2) // Euler: κ(α) = kMax·cos²α + kMin·sin²α
+}
+
+// alignCurvature flips kb's sign when the two surface normals oppose, so both curvatures are
+// expressed with respect to the same physical bending sense before differencing.
+func alignCurvature(kb float64, na, nb math.Vector3) float64 {
+	if na.Dot(nb) < 0 {
+		return -kb
+	}
+	return kb
+}
+
+// foldedAngleDeg returns the angle between two normals in degrees, folded to [0, 90] so an opposite
+// (but parallel-plane) orientation reads as 0 — tangent-plane agreement, not normal-vector equality.
+func foldedAngleDeg(na, nb math.Vector3) float64 {
+	deg := float64(unit(na).AngleTo(unit(nb))) * 180 / stdmath.Pi
+	if deg > 90 {
+		deg = 180 - deg
+	}
+	return deg
+}
+
+// percentOf expresses a curvature difference as a percent of the larger magnitude (0 when both are
+// ~flat).
+func percentOf(diff, ka, kb float64) float64 {
+	denom := stdmath.Max(stdmath.Abs(ka), stdmath.Abs(kb))
+	if denom < 1e-12 {
+		return 0
+	}
+	return diff / denom * 100
+}
+
+// aggregate fills the report's max/avg fields from its samples.
+func aggregate(rep *ContinuityReport) {
+	n := float64(len(rep.Samples))
+	for _, s := range rep.Samples {
+		rep.MaxGap = stdmath.Max(rep.MaxGap, s.Gap)
+		rep.MaxNormalDeg = stdmath.Max(rep.MaxNormalDeg, s.NormalDeg)
+		rep.MaxCurvDiff = stdmath.Max(rep.MaxCurvDiff, s.CurvDiff)
+		rep.MaxCurvPct = stdmath.Max(rep.MaxCurvPct, s.CurvPct)
+		rep.AvgGap += s.Gap / n
+		rep.AvgNormalDeg += s.NormalDeg / n
+		rep.AvgCurvDiff += s.CurvDiff / n
+		rep.AvgCurvPct += s.CurvPct / n
+	}
+}
+
+// unit returns v normalized, or v unchanged when it is (near) zero.
+func unit(v math.Vector3) math.Vector3 {
+	l := float64(v.Length())
+	if l < 1e-12 {
+		return v
+	}
+	return v.Scale(math.Scalar(1 / l))
+}

--- a/model/analysis/cross_edge_continuity.go
+++ b/model/analysis/cross_edge_continuity.go
@@ -82,19 +82,19 @@ func edgeTangent(a geom.Surface, ea EdgeParam, t float64) math.Vector3 {
 	t0, t1 := stdmath.Max(0, t-h), stdmath.Min(1, t+h)
 	u0, v0 := ea(t0)
 	u1, v1 := ea(t1)
-	return unit(a.PointAt(u0, v0).VectorTo(a.PointAt(u1, v1)))
+	return normalize(a.PointAt(u0, v0).VectorTo(a.PointAt(u1, v1)))
 }
 
 // normalCurvatureCross returns the surface's normal curvature in the cross-boundary direction
 // (perpendicular to the edge within the tangent plane), via Euler's formula on the principal
 // curvatures.
 func normalCurvatureCross(s geom.Surface, u, v float64, n, edgeTan math.Vector3) float64 {
-	cross := unit(n.Cross(edgeTan)) // tangent-plane direction perpendicular to the edge
+	cross := normalize(n.Cross(edgeTan)) // tangent-plane direction perpendicular to the edge
 	maxDir, kMax, kMin := geom.SurfaceCurvatures(s, u, v)
 	if float64(maxDir.Length()) < 1e-12 {
 		return kMax // degenerate frame: principal curvatures are equal (or zero)
 	}
-	cosA := float64(unit(maxDir).Dot(cross))
+	cosA := float64(normalize(maxDir).Dot(cross))
 	cos2 := cosA * cosA
 	return kMax*cos2 + kMin*(1-cos2) // Euler: κ(α) = kMax·cos²α + kMin·sin²α
 }
@@ -111,7 +111,7 @@ func alignCurvature(kb float64, na, nb math.Vector3) float64 {
 // foldedAngleDeg returns the angle between two normals in degrees, folded to [0, 90] so an opposite
 // (but parallel-plane) orientation reads as 0 — tangent-plane agreement, not normal-vector equality.
 func foldedAngleDeg(na, nb math.Vector3) float64 {
-	deg := float64(unit(na).AngleTo(unit(nb))) * 180 / stdmath.Pi
+	deg := float64(normalize(na).AngleTo(normalize(nb))) * 180 / stdmath.Pi
 	if deg > 90 {
 		deg = 180 - deg
 	}
@@ -141,13 +141,4 @@ func aggregate(rep *ContinuityReport) {
 		rep.AvgCurvDiff += s.CurvDiff / n
 		rep.AvgCurvPct += s.CurvPct / n
 	}
-}
-
-// unit returns v normalized, or v unchanged when it is (near) zero.
-func unit(v math.Vector3) math.Vector3 {
-	l := float64(v.Length())
-	if l < 1e-12 {
-		return v
-	}
-	return v.Scale(math.Scalar(1 / l))
 }

--- a/model/analysis/cross_edge_continuity_test.go
+++ b/model/analysis/cross_edge_continuity_test.go
@@ -93,6 +93,24 @@ func TestCrossEdgeReportsCurvatureBreak(t *testing.T) {
 	}
 }
 
+func TestAlignCurvatureAndFoldedAngle(t *testing.T) {
+	up, down := math.V3(0, 0, 1), math.V3(0, 0, -1)
+	// Opposed normals: alignCurvature flips the sign so both bend senses match.
+	if got := alignCurvature(2, up, down); got != -2 {
+		t.Errorf("alignCurvature with opposed normals = %g, want -2", got)
+	}
+	if got := alignCurvature(2, up, up); got != 2 {
+		t.Errorf("alignCurvature with aligned normals = %g, want 2", got)
+	}
+	// Opposed normals are still a coincident tangent plane → folded angle 0.
+	if got := foldedAngleDeg(up, down); got > 1e-9 {
+		t.Errorf("foldedAngleDeg(up,down) = %g, want ~0 (parallel planes)", got)
+	}
+	if got := foldedAngleDeg(up, math.V3(1, 0, 0)); stdmath.Abs(got-90) > 1e-9 {
+		t.Errorf("foldedAngleDeg(up,+X) = %g, want 90", got)
+	}
+}
+
 func TestCrossEdgeIsDeterministic(t *testing.T) {
 	a := xyPlane(t, 0)
 	b, _ := geom.NewCylinderWithRef(math.P3(0, 0, 0), math.V3(1, 0, 0), math.V3(0, 0, 1), 3)

--- a/model/analysis/cross_edge_continuity_test.go
+++ b/model/analysis/cross_edge_continuity_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package analysis
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// edgeAlongX traces the world line (0..L in x) on a plane built from axes (UAxis=X), so the edge
+// parameter maps to the plane's u with v=0.
+func edgeAlongX(length float64) EdgeParam {
+	return func(t float64) (u, v float64) { return t * length, 0 }
+}
+
+// xyPlane is the z=0 plane with UAxis=X, VAxis=Y (normal +Z), origin at z0.
+func xyPlane(t *testing.T, z0 float64) geom.Plane {
+	t.Helper()
+	p, err := geom.NewPlaneFromAxes(math.P3(0, 0, math.Scalar(z0)), math.V3(1, 0, 0), math.V3(0, 1, 0))
+	if err != nil {
+		t.Fatalf("plane: %v", err)
+	}
+	return p
+}
+
+func TestCrossEdgeCoplanarIsFullyContinuous(t *testing.T) {
+	a, b := xyPlane(t, 0), xyPlane(t, 0)
+	rep := CrossEdgeContinuity(a, b, edgeAlongX(5), edgeAlongX(5), 15)
+	if rep.MaxGap > 1e-9 || rep.MaxNormalDeg > 1e-9 || rep.MaxCurvDiff > 1e-9 {
+		t.Errorf("coplanar seam should be G0/G1/G2 continuous: gap=%g deg=%g curv=%g",
+			rep.MaxGap, rep.MaxNormalDeg, rep.MaxCurvDiff)
+	}
+}
+
+func TestCrossEdgeReportsPositionalGap(t *testing.T) {
+	// Two parallel planes offset in z, traced at the same (x,0): a pure G0 gap of δ.
+	const delta = 0.25
+	a, b := xyPlane(t, 0), xyPlane(t, delta)
+	rep := CrossEdgeContinuity(a, b, edgeAlongX(5), edgeAlongX(5), 12)
+	if stdmath.Abs(rep.MaxGap-delta) > 1e-9 {
+		t.Errorf("MaxGap = %g, want %g", rep.MaxGap, delta)
+	}
+	if rep.MaxNormalDeg > 1e-9 || rep.MaxCurvDiff > 1e-9 {
+		t.Errorf("a pure positional gap should not report G1/G2 deviation: deg=%g curv=%g", rep.MaxNormalDeg, rep.MaxCurvDiff)
+	}
+}
+
+func TestCrossEdgeReportsTangentBreak(t *testing.T) {
+	// A crease: plane A (normal +Z) meets plane B tilted by 30° about the shared x-axis edge.
+	const deg = 30.0
+	rad := deg * stdmath.Pi / 180
+	a := xyPlane(t, 0)
+	b, err := geom.NewPlaneFromAxes(math.P3(0, 0, 0), math.V3(1, 0, 0), math.V3(0, math.Scalar(stdmath.Cos(rad)), math.Scalar(stdmath.Sin(rad))))
+	if err != nil {
+		t.Fatalf("tilted plane: %v", err)
+	}
+	rep := CrossEdgeContinuity(a, b, edgeAlongX(5), edgeAlongX(5), 12)
+	if stdmath.Abs(rep.MaxNormalDeg-deg) > 0.5 {
+		t.Errorf("crease G1 angle = %g°, want ~%g°", rep.MaxNormalDeg, deg)
+	}
+	if rep.MaxGap > 1e-9 || rep.MaxCurvDiff > 1e-9 {
+		t.Errorf("two flat faces should report no G0 gap or G2 curvature difference: gap=%g curv=%g", rep.MaxGap, rep.MaxCurvDiff)
+	}
+}
+
+func TestCrossEdgeReportsCurvatureBreak(t *testing.T) {
+	// A plane tangent to a cylinder along the cylinder's top line: G1-continuous (shared tangent
+	// plane) but G2-discontinuous — the cylinder bends (1/R) where the plane is flat.
+	const r = 2.0
+	cyl, err := geom.NewCylinderWithRef(math.P3(0, 0, 0), math.V3(1, 0, 0), math.V3(0, 0, 1), r)
+	if err != nil {
+		t.Fatalf("cylinder: %v", err)
+	}
+	plane, err := geom.NewPlaneFromAxes(math.P3(0, 0, math.Scalar(r)), math.V3(1, 0, 0), math.V3(0, 1, 0))
+	if err != nil {
+		t.Fatalf("tangent plane: %v", err)
+	}
+	// Top line of the cylinder is (x, 0, r): on the plane u=x,v=0; on the cylinder u=0 (angle), v=x.
+	edgePlane := func(t float64) (u, v float64) { return t * 5, 0 }
+	edgeCyl := func(t float64) (u, v float64) { return 0, t * 5 }
+	rep := CrossEdgeContinuity(plane, cyl, edgePlane, edgeCyl, 12)
+	if rep.MaxNormalDeg > 0.01 || rep.MaxGap > 1e-9 {
+		t.Errorf("a tangent plane should be G0/G1 continuous with the cylinder: gap=%g deg=%g", rep.MaxGap, rep.MaxNormalDeg)
+	}
+	if stdmath.Abs(rep.MaxCurvDiff-1/r) > 1e-3 {
+		t.Errorf("G2 curvature difference = %g, want ~%g (1/R)", rep.MaxCurvDiff, 1/r)
+	}
+	if stdmath.Abs(rep.MaxCurvPct-100) > 1 {
+		t.Errorf("plane-vs-cylinder curvature is fully discontinuous: pct = %g, want ~100", rep.MaxCurvPct)
+	}
+}
+
+func TestCrossEdgeIsDeterministic(t *testing.T) {
+	a := xyPlane(t, 0)
+	b, _ := geom.NewCylinderWithRef(math.P3(0, 0, 0), math.V3(1, 0, 0), math.V3(0, 0, 1), 3)
+	r1 := CrossEdgeContinuity(a, b, func(t float64) (float64, float64) { return t * 4, 0 }, func(t float64) (float64, float64) { return 0, t * 4 }, 20)
+	r2 := CrossEdgeContinuity(a, b, func(t float64) (float64, float64) { return t * 4, 0 }, func(t float64) (float64, float64) { return 0, t * 4 }, 20)
+	if r1.MaxCurvDiff != r2.MaxCurvDiff || r1.AvgCurvDiff != r2.AvgCurvDiff || len(r1.Samples) != len(r2.Samples) {
+		t.Error("CrossEdgeContinuity must be deterministic")
+	}
+}


### PR DESCRIPTION
## What

The numeric **cross-edge continuity oracle** — the quantitative companion to the F12 visual overlay and the acceptance gate for the continuity-construction features (match/blend/bridge/extend).

- **Analysis core** (`model/analysis/cross_edge_continuity.go`): `CrossEdgeContinuity(a, b, edgeOnA, edgeOnB, samples)` samples a shared edge and reports, per sample + as max/avg aggregates:
  - **G0** — positional gap (distance) between the two surfaces;
  - **G1** — angle between the surface normals, folded to [0,90]° (tangent-plane agreement);
  - **G2** — normal-curvature difference in the cross-boundary direction (absolute + percent), via Euler's formula on the existing principal-curvature evaluator.
  Pure, deterministic kernel math.
- **App + head** (`ContinuityCheck` tool, Inspect tab): pick an edge shared by two faces — it maps the edge onto each face (`ParamAt`), runs the checker, reports the aggregates to the Command Window, and draws the edge coloured green→red by the worst local deviation.

## Acceptance (met)

- **Known seams report the expected deviations** (constructed analytically): coplanar → all zero; a z-offset → pure G0 gap; a 30° crease → G1 = 30°; a plane tangent to a radius-R cylinder → G1 ≈ 0 with G2 = 1/R (100%). Deterministic (verified by re-run).
- **e2e**: a box edge (two perpendicular planar faces) reports a ~90° G1 break with no gap/curvature difference; a non-edge pick is ignored; the ribbon command starts the tool.
- **Live capture**: ran the real lavapipe head on a filleted box — the actual pipeline printed correct, meaningful numbers: a sharp edge → **G1 90° / G2 0%**, a fillet junction → **G1 0° / G2 100%** (tangent-continuous but curvature-discontinuous, the exact G1-not-G2 case this tool exists for); the coloured overlay renders on the picked edge. (Throwaway driver, not committed.)

## Coverage & duplication

Checked both (re: #1293): new files are >80% covered; **zero new production duplication** — removed a duplicate `normalize` (reused the analysis package's), dropped a near-duplicate `maxf` for the builtin `max`. Test-helper duplication is excluded from CPD (`sonar.cpd.exclusions=**/*_test.go`, added in F03). `go test` green; `golangci-lint` clean; whole module + cgo head build.

Part of #1276. Closes #1289.