### PR TITLE
M36-F06: real G1/G2 (curvature) loft end conditions from adjacent faces

### DIFF
--- a/model/feature/loft_faces_test.go
+++ b/model/feature/loft_faces_test.go
@@ -79,13 +79,16 @@ func TestLoftFaceTangentFlares(t *testing.T) {
 	}
 }
 
-// TestLoftFaceSmoothApproximatesTangent: Smooth (G2) reuses the G1 tangent in the faceted kernel,
-// so it produces the same flare as Tangent (documented approximation).
-func TestLoftFaceSmoothApproximatesTangent(t *testing.T) {
+// TestLoftFaceSmoothIsRealCurvature (M36-F06): Smooth (G2) now imposes the adjacent face's real
+// curvature via the quintic end blend — it is no longer an alias of Tangent (G1), so it produces a
+// genuinely different, valid solid (against the planar cap it leaves with zero curvature, so the
+// takeoff stays in-plane longer than G1's cubic). The numeric curvature-continuity proof against a
+// CURVED face is TestLoftG2MatchesFaceCurvature.
+func TestLoftFaceSmoothIsRealCurvature(t *testing.T) {
 	tan := ops.BodyGeometryProperties(loftFromCylinderTop(t, LoftEnd{Condition: LoftTangent}), ops.DefaultQuality()).Volume
 	smooth := ops.BodyGeometryProperties(loftFromCylinderTop(t, LoftEnd{Condition: LoftSmooth}), ops.DefaultQuality()).Volume
-	if relErr(tan, smooth) > 1e-9 {
-		t.Errorf("Smooth (%.4f) differs from Tangent (%.4f); it approximates G1 in the faceted kernel", smooth, tan)
+	if relErr(tan, smooth) < 1e-3 {
+		t.Errorf("Smooth (%.4f) should differ from Tangent (%.4f) now that G2 imposes real curvature, not an alias", smooth, tan)
 	}
 }
 

--- a/model/feature/loft_skin.go
+++ b/model/feature/loft_skin.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/math"
 
 	stdmath "math"
@@ -132,7 +133,102 @@ func splineSections(sections [][]math.Point3, closed bool, ends loftEnds, wrapSh
 	if m < 2 || loftSegmentSamples < 2 {
 		return sections
 	}
-	return hermiteBlend(sections, sectionTangents(sections, closed, ends, wrapShift), closed, wrapShift)
+	tan := sectionTangents(sections, closed, ends, wrapShift)
+	// Real face continuity (M36-F06): when an end section is a body face and its condition is
+	// Tangent/Smooth, override the end tangent with the adjacent surface's actual derivative (G1) and,
+	// for Smooth, supply its second derivative so the end segment blends with a quintic that matches
+	// the face's curvature (G2). Closed lofts have no end sections, so this is open-only.
+	var firstA, lastA []math.Vector3
+	if !closed {
+		firstA = faceContinuity(tan[0], sections[0], sections[1], ends.firstSurf, ends.first)
+		lastA = faceContinuity(tan[m-1], sections[m-1], sections[m-2], ends.lastSurf, ends.last)
+	}
+	return hermiteBlend(sections, tan, closed, wrapShift, firstA, lastA)
+}
+
+// continuityOrder maps a face-continuity condition to the derivative order it matches across the
+// section edge: Tangent = 1 (G1, tangent), Smooth = 2 (G2, curvature). (G3 is a follow-up — it needs
+// a new public condition value.) Non-face conditions return 0.
+func continuityOrder(c LoftCondition) int {
+	switch c {
+	case LoftTangent:
+		return 1
+	case LoftSmooth:
+		return 2
+	default:
+		return 0
+	}
+}
+
+// faceContinuity overrides an end section's tangents with the adjacent face's real longitudinal
+// derivative (true G1, replacing the normal-only approximation) and, for a Smooth (G2) end, returns
+// the per-point second derivative the quintic end-segment blend uses to match the face's curvature.
+// It returns nil (leaving the existing tangents) when there is no adjacent surface or the condition
+// is not face continuity. neighbor is the adjacent section; the takeoff speed follows the existing
+// impact·chord convention so G1 magnitudes are unchanged.
+func faceContinuity(tangents []math.Vector3, sec, neighbor []math.Point3, surf geom.Surface, end LoftEnd) []math.Vector3 {
+	order := continuityOrder(end.Condition)
+	if surf == nil || order == 0 {
+		return nil
+	}
+	impact := end.Impact
+	if impact <= 0 {
+		impact = 1
+	}
+	var second []math.Vector3
+	if order >= 2 {
+		second = make([]math.Vector3, len(sec))
+	}
+	c := centroidOf(sec)
+	for j := range sec {
+		outward := c.VectorTo(sec[j]) // away from the section centroid (the flare side)
+		edge := edgeDirAt(sec, j)     // boundary tangent at this point
+		t1, g2, ok := faceEndDeriv(surf, sec[j], edge, outward)
+		if !ok {
+			continue // degenerate surface here — keep the approximate tangent
+		}
+		speed := impact * float64(sec[j].DistanceTo(neighbor[j])) // c: matches applyFaceTangent's scale
+		tangents[j] = t1.Scale(math.Scalar(speed))                // m0 = c · unit cross-boundary tangent
+		if second != nil {
+			// P(t)=γ(s(t)) with s=c·t and |t1|=1 ⇒ P'(0)=c·t1, P''(0)=c²·γ'' — matching geometric
+			// curvature at the seam (G2), reparam-invariant.
+			second[j] = g2.Scale(math.Scalar(speed * speed))
+		}
+	}
+	return second
+}
+
+// faceEndDeriv returns, at the boundary point nearest p, the adjacent face surface's unit
+// cross-boundary tangent direction (perpendicular to the boundary edge, in the surface tangent
+// plane, pointing outward) and the surface's SECOND derivative along that same direction. The loft
+// leaves the face along this tangent (true G1) and, for a Smooth end, with this curvature (true G2),
+// so it continues the real surface — exact for planar and analytic faces and correct for NURBS faces
+// (the directional 2nd derivative includes the mixed term). ok is false at a degenerate point.
+func faceEndDeriv(surf geom.Surface, p math.Point3, edge, outwardRef math.Vector3) (t1, g2 math.Vector3, ok bool) {
+	u, v := surf.ParamAt(p)
+	su, sv := surf.DerivativesAt(u, v)
+	n := surf.NormalAt(u, v)
+	cross := n.Cross(edge) // in-surface direction perpendicular to the boundary edge
+	if cross.Dot(outwardRef) < 0 {
+		cross = cross.Scale(-1) // orient outward (away from the face interior)
+	}
+	if cross.Length() < 1e-9 {
+		return math.Vector3{}, math.Vector3{}, false
+	}
+	t1 = cross.Scale(1 / cross.Length())
+	// Solve du·Su + dv·Sv = t1 (t1 lies in the tangent plane) via the first fundamental form, so the
+	// directional 2nd derivative γ'' = du²·Suu + 2·du·dv·Suv + dv²·Svv is exact for this direction.
+	puu, puv, pvv := geom.SurfaceSecondPartials(surf, u, v)
+	e, f, g := su.Dot(su), su.Dot(sv), sv.Dot(sv)
+	det := e*g - f*f
+	if stdmath.Abs(float64(det)) < 1e-18 {
+		return t1, math.Vector3{}, true // degenerate metric ⇒ treat as zero curvature (G2 → straight)
+	}
+	b1, b2 := t1.Dot(su), t1.Dot(sv)
+	du := (g*b1 - f*b2) / det
+	dv := (e*b2 - f*b1) / det
+	g2 = puu.Scale(du * du).Add(puv.Scale(2 * du * dv)).Add(pvv.Scale(dv * dv))
+	return t1, g2, true
 }
 
 // railGuide deforms the densified sections so the loft follows guide rails (the kLoftWithRails
@@ -558,7 +654,12 @@ func unitOrFallback(v, fallback math.Vector3) math.Vector3 {
 // Möbius), the closing segment blends toward the start section REINDEXED by wrapShift, so the wrap
 // is a small twist (one step) instead of cramming the whole accumulated twist into one segment.
 // sweptSolid's mesh wrap applies the same shift, so the two stay consistent.
-func hermiteBlend(sections [][]math.Point3, tan [][]math.Vector3, closed bool, wrapShift int) [][]math.Point3 {
+// firstA/lastA are the per-point second derivatives at the first/last section for a curvature (G2)
+// face-continuity end (nil otherwise): the first segment then blends with a QUINTIC Hermite that
+// matches firstA at its start, the last segment one that matches lastA at its end, so the loft
+// continues the adjacent face's curvature across the seam. The interior side of each such segment
+// keeps a natural (zero) second derivative.
+func hermiteBlend(sections [][]math.Point3, tan [][]math.Vector3, closed bool, wrapShift int, firstA, lastA []math.Vector3) [][]math.Point3 {
 	m := len(sections)
 	segs := m - 1
 	if closed {
@@ -571,15 +672,67 @@ func hermiteBlend(sections [][]math.Point3, tan [][]math.Vector3, closed bool, w
 		if closed && i == segs-1 && wrapShift != 0 { // the wrap: aim at the start reindexed by the monodromy
 			p1, t1 = rotateLoop(sections[0], wrapShift), rotateVecLoop(tan[0], wrapShift)
 		}
-		n := segmentSamples(sections[i], p1, tan[i], t1)
+		var startA, endA []math.Vector3
+		if i == 0 {
+			startA = firstA
+		}
+		if i == segs-1 && !closed {
+			endA = lastA
+		}
+		n := segmentSamplesG2(sections[i], p1, tan[i], t1, startA, endA)
 		for s := 1; s <= n; s++ {
-			out = append(out, hermiteSection(sections[i], p1, tan[i], t1, float64(s)/float64(n)))
+			out = append(out, blendSection(sections[i], p1, tan[i], t1, startA, endA, float64(s)/float64(n)))
 		}
 	}
 	if closed {
 		out = out[:len(out)-1] // the final sample equals the (reindexed) start; drop it (sweptSolid closes the loop)
 	}
 	return out
+}
+
+// blendSection blends one sub-section with a cubic Hermite, or — when a curvature (G2) second
+// derivative is supplied at either end (startA/endA) — a quintic Hermite that additionally matches
+// that second derivative. A nil second-derivative end matches a natural (zero) second derivative.
+func blendSection(p0, p1 []math.Point3, m0, m1, startA, endA []math.Vector3, t float64) []math.Point3 {
+	if startA == nil && endA == nil {
+		return hermiteSection(p0, p1, m0, m1, t)
+	}
+	out := make([]math.Point3, len(p0))
+	for j := range p0 {
+		out[j] = hermite5(p0[j], p1[j], m0[j], m1[j], vecAt(startA, j), vecAt(endA, j), t)
+	}
+	return out
+}
+
+// vecAt returns a[j], or the zero vector when a is nil (a natural, unconstrained second derivative).
+func vecAt(a []math.Vector3, j int) math.Vector3 {
+	if a == nil {
+		return math.Vector3{}
+	}
+	return a[j]
+}
+
+// segmentSamplesG2 is segmentSamples, but probes the actual blend (quintic when a G2 second
+// derivative is present) so a curvature-matched end segment that bends more than its chord gets
+// enough sub-sections to read smooth.
+func segmentSamplesG2(p0, p1 []math.Point3, m0, m1, startA, endA []math.Vector3) int {
+	if startA == nil && endA == nil {
+		return segmentSamples(p0, p1, m0, m1)
+	}
+	const probes = 12
+	sec := make([][]math.Point3, probes+1)
+	for s := 0; s <= probes; s++ {
+		sec[s] = blendSection(p0, p1, m0, m1, startA, endA, float64(s)/float64(probes))
+	}
+	turn := stdmath.Max(segmentTwist(p0, p1), maxTrackTurn(sec))
+	n := int(stdmath.Ceil(turn / (loftMaxStepDeg * stdmath.Pi / 180)))
+	if n < loftSegmentSamples {
+		n = loftSegmentSamples
+	}
+	if n > loftMaxSegmentSamples {
+		n = loftMaxSegmentSamples
+	}
+	return n
 }
 
 // segmentSamples is how many sub-sections to blend a section pair into: at least
@@ -688,8 +841,15 @@ func segmentTrackTurn(p0, p1 []math.Point3, m0, m1 []math.Vector3) float64 {
 	for s := 0; s <= probes; s++ {
 		sec[s] = hermiteSection(p0, p1, m0, m1, float64(s)/float64(probes))
 	}
+	return maxTrackTurn(sec)
+}
+
+// maxTrackTurn is the most any corresponding-point track bends across a sequence of probed
+// sub-sections — the shared turning measure for cubic and quintic segment sampling.
+func maxTrackTurn(sec [][]math.Point3) float64 {
+	probes := len(sec) - 1
 	var maxTurn float64
-	for j := range p0 {
+	for j := range sec[0] {
 		var turn float64
 		for s := 1; s < probes; s++ {
 			turn += turnAngle(sec[s-1][j], sec[s][j], sec[s+1][j])
@@ -782,6 +942,34 @@ func hermite3(p0, p1 math.Point3, m0, m1 math.Vector3, t float64) math.Point3 {
 		axis(p0.X, m0.X, p1.X, m1.X),
 		axis(p0.Y, m0.Y, p1.Y, m1.Y),
 		axis(p0.Z, m0.Z, p1.Z, m1.Z),
+	)
+}
+
+// hermite5 is the quintic Hermite interpolant matching position, first AND second derivatives at
+// both ends: p0,m0,a0 at t=0 and p1,m1,a1 at t=1. With a0=a1=0 it does NOT reduce to the cubic
+// (the extra basis is nonzero), so it is only used where a curvature (G2) end condition supplies a
+// real second derivative; the other end passes a natural a=0. Basis (the standard quintic Hermite):
+//
+//	H0=1−10t³+15t⁴−6t⁵  H1=t−6t³+8t⁴−3t⁵  H2=½t²−1.5t³+1.5t⁴−0.5t⁵
+//	H3=10t³−15t⁴+6t⁵    H4=−4t³+7t⁴−3t⁵   H5=½t³−t⁴+½t⁵
+func hermite5(p0, p1 math.Point3, m0, m1, a0, a1 math.Vector3, t float64) math.Point3 {
+	t2 := t * t
+	t3 := t2 * t
+	t4 := t3 * t
+	t5 := t4 * t
+	h0 := 1 - 10*t3 + 15*t4 - 6*t5
+	h1 := t - 6*t3 + 8*t4 - 3*t5
+	h2 := 0.5*t2 - 1.5*t3 + 1.5*t4 - 0.5*t5
+	h3 := 10*t3 - 15*t4 + 6*t5
+	h4 := -4*t3 + 7*t4 - 3*t5
+	h5 := 0.5*t3 - t4 + 0.5*t5
+	axis := func(p0c, m0c, a0c, p1c, m1c, a1c float64) float64 {
+		return h0*p0c + h1*m0c + h2*a0c + h3*p1c + h4*m1c + h5*a1c
+	}
+	return math.P3(
+		axis(p0.X, m0.X, a0.X, p1.X, m1.X, a1.X),
+		axis(p0.Y, m0.Y, a0.Y, p1.Y, m1.Y, a1.Y),
+		axis(p0.Z, m0.Z, a0.Z, p1.Z, m1.Z, a1.Z),
 	)
 }
 

--- a/model/feature/loft_skin_test.go
+++ b/model/feature/loft_skin_test.go
@@ -6,6 +6,7 @@ import (
 	stdmath "math"
 	"testing"
 
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/math"
 )
 
@@ -73,6 +74,136 @@ func TestSplineThreeSectionsBulges(t *testing.T) {
 	}
 	if maxX > 1.2 {
 		t.Errorf("3-section loft overshoots the middle: max x = %.3f, want ≈1", maxX)
+	}
+}
+
+// mengerCurv is the discrete (Menger) curvature of three points — the geometric curvature at the
+// middle point: 4·triangleArea / (|ab|·|bc|·|ca|). Scale/parameterization independent.
+func mengerCurv(a, b, c math.Point3) float64 {
+	ab := float64(a.DistanceTo(b))
+	bc := float64(b.DistanceTo(c))
+	ca := float64(c.DistanceTo(a))
+	area := 0.5 * float64(a.VectorTo(b).Cross(a.VectorTo(c)).Length())
+	if ab*bc*ca < 1e-18 {
+		return 0
+	}
+	return 4 * area / (ab * bc * ca)
+}
+
+// TestHermite5MatchesQuinticPolynomial: hermite5 is the exact quintic interpolant of its Hermite data
+// (position, 1st and 2nd derivatives at both ends), so it reproduces any degree-5 polynomial curve
+// from that curve's endpoint data.
+func TestHermite5MatchesQuinticPolynomial(t *testing.T) {
+	// Q(t) = c0 + c1 t + c2 t² + c3 t³ + c4 t⁴ + c5 t⁵ (a distinct cubic-ish per axis).
+	q := func(t float64) math.Point3 {
+		return math.P3(
+			math.Scalar(1+2*t-t*t+0.5*t*t*t+t*t*t*t-0.3*t*t*t*t*t),
+			math.Scalar(-2+t+3*t*t-t*t*t+0.2*t*t*t*t*t),
+			math.Scalar(t*t-2*t*t*t+t*t*t*t*t),
+		)
+	}
+	qd := func(t float64) math.Vector3 {
+		return math.V3(2-2*t+1.5*t*t+4*t*t*t-1.5*t*t*t*t, 1+6*t-3*t*t+t*t*t*t, 2*t-6*t*t+5*t*t*t*t)
+	}
+	qdd := func(t float64) math.Vector3 {
+		return math.V3(-2+3*t+12*t*t-6*t*t*t, 6-6*t+4*t*t*t, 2-12*t+20*t*t*t)
+	}
+	p0, p1 := q(0), q(1)
+	m0, m1 := qd(0), qd(1)
+	a0, a1 := qdd(0), qdd(1)
+	for _, tt := range []float64{0, 0.2, 0.5, 0.75, 1} {
+		got := hermite5(p0, p1, m0, m1, a0, a1, tt)
+		if !got.IsEqualTo(q(tt), 1e-9) {
+			t.Errorf("hermite5 at t=%g = %v, want %v", tt, got, q(tt))
+		}
+	}
+}
+
+// TestFaceEndDerivSphereCurvature: faceEndDeriv reports the adjacent surface's true cross-boundary
+// curvature. On a sphere of radius R the directional 2nd derivative along the meridian has magnitude
+// 1/R and points toward the centre (the sphere's normal curvature), and the takeoff tangent is unit
+// and perpendicular to the boundary (hoop) edge.
+func TestFaceEndDerivSphereCurvature(t *testing.T) {
+	const R = 2.0
+	sph, _ := geom.NewSphere(math.P3(0, 0, 0), R)
+	u0, v0 := 0.7, 0.3
+	p := sph.PointAt(u0, v0)
+	edge, _ := sph.DerivativesAt(u0, v0) // ∂/∂u = the latitude (hoop) tangent = boundary edge
+	ringC := math.P3(0, 0, math.Scalar(R*stdmath.Sin(v0)))
+	t1, g2, ok := faceEndDeriv(sph, p, edge, ringC.VectorTo(p))
+	if !ok {
+		t.Fatal("faceEndDeriv reported degenerate on a sphere")
+	}
+	if d := stdmath.Abs(float64(g2.Length()) - 1/R); d > 1e-6 {
+		t.Errorf("cross-boundary curvature |g2| = %g, want 1/R = %g", g2.Length(), 1/R)
+	}
+	if g2.Dot(p.VectorTo(math.P3(0, 0, 0))) <= 0 {
+		t.Error("sphere curvature vector should point toward the centre")
+	}
+	if d := stdmath.Abs(float64(t1.Length()) - 1); d > 1e-9 {
+		t.Errorf("takeoff tangent |t1| = %g, want unit", t1.Length())
+	}
+	if d := float64(t1.Dot(edge)); stdmath.Abs(d) > 1e-9 {
+		t.Errorf("takeoff tangent should be perpendicular to the boundary edge, dot = %g", d)
+	}
+}
+
+// TestLoftG2MatchesFaceCurvature is the F06 acceptance: a loft leaving a sphere face with a Smooth
+// (G2) end has its longitudinal seam curvature equal to the sphere's (1/R) — curvature continuity —
+// whereas a Tangent (G1) end leaves with a different seam curvature. This is the numeric F13-style
+// gate (the body is a faceted skin, so continuity is measured on the longitudinal track).
+func TestLoftG2MatchesFaceCurvature(t *testing.T) {
+	const R = 2.0
+	sph, _ := geom.NewSphere(math.P3(0, 0, 0), R)
+	v0 := 0.3
+	const n = 24
+	ring := func(radius, z float64) []math.Point3 {
+		out := make([]math.Point3, n)
+		for k := 0; k < n; k++ {
+			a := 2 * stdmath.Pi * float64(k) / float64(n)
+			out[k] = math.P3(math.Scalar(radius*stdmath.Cos(a)), math.Scalar(radius*stdmath.Sin(a)), math.Scalar(z))
+		}
+		return out
+	}
+	sphereRing := func() []math.Point3 { // the loft's start section, lying on the sphere at latitude v0
+		out := make([]math.Point3, n)
+		for k := 0; k < n; k++ {
+			out[k] = sph.PointAt(2*stdmath.Pi*float64(k)/float64(n), v0)
+		}
+		return out
+	}
+	sec0 := sphereRing()
+	sec1 := ring(R*stdmath.Cos(v0)+1, R*stdmath.Sin(v0)+1) // a flaring target circle above
+	ends := func(c LoftCondition) loftEnds {
+		return loftEnds{
+			first:  LoftEnd{Condition: c, Impact: 1},
+			firstN: math.V3(0, 0, 1).AsUnit(), lastN: math.V3(0, 0, 1).AsUnit(),
+			firstSurf: sph,
+		}
+	}
+	// Exact seam curvature of the G2 takeoff: faceContinuity sets the tangent m0 and returns the
+	// second derivative a0, so the longitudinal track's geometric curvature at the seam is
+	// |m0×a0|/|m0|³ — this must equal the sphere's 1/R (true curvature continuity), per point.
+	tan := sectionTangents([][]math.Point3{sec0, sec1}, false, ends(LoftSmooth), 0)
+	a0 := faceContinuity(tan[0], sec0, sec1, sph, LoftEnd{Condition: LoftSmooth, Impact: 1})
+	if a0 == nil {
+		t.Fatal("G2 face continuity produced no second-derivative data")
+	}
+	for j := 0; j < n; j++ {
+		m := tan[0][j]
+		k := float64(m.Cross(a0[j]).Length()) / stdmath.Pow(float64(m.Length()), 3)
+		if d := stdmath.Abs(k - 1/R); d > 1e-6 {
+			t.Fatalf("track %d seam curvature = %.6f, want 1/R = %.6f (G2 curvature continuity)", j, k, 1/R)
+		}
+	}
+	// End to end on the actual densified skin: the G2 track curves differently near the seam than the
+	// G1 (tangent-only) track — so the curvature condition really reshapes the built geometry.
+	g2 := splineSections([][]math.Point3{sec0, sec1}, false, ends(LoftSmooth), 0)
+	g1 := splineSections([][]math.Point3{sec0, sec1}, false, ends(LoftTangent), 0)
+	ck2 := mengerCurv(g2[0][0], g2[1][0], g2[2][0])
+	ck1 := mengerCurv(g1[0][0], g1[1][0], g1[2][0])
+	if stdmath.Abs(ck2-ck1) < 0.05 {
+		t.Errorf("G2 (%.4f) and G1 (%.4f) seam track curvatures should differ — G2 must reshape the skin", ck2, ck1)
 	}
 }
 

--- a/model/feature/sweep_loft.go
+++ b/model/feature/sweep_loft.go
@@ -44,10 +44,14 @@ type LoftEnd struct {
 }
 
 // loftEnds carries the resolved start/end conditions plus the section-plane normals the skinner
-// needs to build the angled takeoff tangents.
+// needs to build the angled takeoff tangents. firstSurf/lastSurf are the adjacent face surfaces for
+// a face-continuity end (Tangent/Smooth on a face section): the skinner reads their real 1st/2nd
+// derivatives so the loft continues that face's tangent (G1) and curvature (G2) across the section
+// edge, instead of the normal-only approximation. They are nil for sketch/point sections.
 type loftEnds struct {
-	first, last   LoftEnd
-	firstN, lastN math.UnitVector3
+	first, last         LoftEnd
+	firstN, lastN       math.UnitVector3
+	firstSurf, lastSurf geom.Surface
 }
 
 // loftGuides carries everything that shapes the OUTER skin beyond the plain blend: an explicit
@@ -281,11 +285,11 @@ func (l *LoftFeature) ToolBody() *topo.Body                { return l.tool }
 // inner loop per section (the common pipe) is meshed directly into a hollow tube, so a loft of
 // annulus sections is a watertight pipe rather than a filled cone.
 func (l *LoftFeature) Recompute(in Input) (Output, error) {
-	outers, inners, normals, err := l.resolveSections(in.Bodies)
+	outers, inners, normals, surfs, err := l.resolveSections(in.Bodies)
 	if err != nil {
 		return Output{}, err
 	}
-	tool, err := l.skinTool(outers, inners, l.endsWith(normals), l.resolveGuides())
+	tool, err := l.skinTool(outers, inners, l.endsWith(normals, surfs), l.resolveGuides())
 	if err != nil {
 		return Output{}, err
 	}
@@ -298,13 +302,22 @@ func (l *LoftFeature) Recompute(in Input) (Output, error) {
 }
 
 // endsWith pairs the definition's end conditions with the first/last section normals (a sketch
-// plane, an apex tangent plane, or a source-face normal) the skinner needs to aim the takeoff.
-func (l *LoftFeature) endsWith(normals []math.UnitVector3) loftEnds {
+// plane, an apex tangent plane, or a source-face normal) the skinner needs to aim the takeoff, plus
+// the adjacent face surfaces for a face-continuity (Tangent/Smooth) end so the skinner can read real
+// tangent/curvature derivatives.
+func (l *LoftFeature) endsWith(normals []math.UnitVector3, surfs []geom.Surface) loftEnds {
 	first, last := l.def.First, l.def.Last
 	if l.def.LiveEnds != nil {
 		first, last = l.def.LiveEnds()
 	}
-	return loftEnds{first: first, last: last, firstN: normals[0], lastN: normals[len(normals)-1]}
+	e := loftEnds{first: first, last: last, firstN: normals[0], lastN: normals[len(normals)-1]}
+	if first.Condition.IsFaceContinuity() {
+		e.firstSurf = surfs[0]
+	}
+	if last.Condition.IsFaceContinuity() {
+		e.lastSurf = surfs[len(surfs)-1]
+	}
+	return e
 }
 
 // resolveGuides evaluates the definition's rail + centerline providers into model-space polylines
@@ -392,54 +405,55 @@ func holeRing(inners [][][]math.Point3, h int) [][]math.Point3 {
 // holes, valid only at an end), or an existing body face (resolved against bodies — its boundary
 // is the loop, its surface gives the normal for Tangent/Smooth). At least one section must be a
 // real profile/face, and all sections must share their inner-loop count.
-func (l *LoftFeature) resolveSections(bodies []*topo.Body) (outers [][]math.Point3, inners [][][]math.Point3, normals []math.UnitVector3, err error) {
+func (l *LoftFeature) resolveSections(bodies []*topo.Body) (outers [][]math.Point3, inners [][][]math.Point3, normals []math.UnitVector3, surfs []geom.Surface, err error) {
 	if len(l.def.Sections) < 2 {
-		return nil, nil, nil, fmt.Errorf("loft: %d sections, need at least 2", len(l.def.Sections))
+		return nil, nil, nil, nil, fmt.Errorf("loft: %d sections, need at least 2", len(l.def.Sections))
 	}
 	if err := l.validatePointSections(); err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	for i, s := range l.def.Sections {
-		outer, holes, n, e := resolveSection(s, bodies)
+		outer, holes, n, surf, e := resolveSection(s, bodies)
 		if e != nil {
-			return nil, nil, nil, fmt.Errorf("loft section %d: %w", i, e)
+			return nil, nil, nil, nil, fmt.Errorf("loft section %d: %w", i, e)
 		}
-		outers, inners, normals = append(outers, outer), append(inners, holes), append(normals, n)
+		outers, inners, normals, surfs = append(outers, outer), append(inners, holes), append(normals, n), append(surfs, surf)
 	}
 	for i, h := range inners {
 		if len(h) != len(inners[0]) {
-			return nil, nil, nil, fmt.Errorf("loft: section %d has %d holes, want %d (hole counts must match across sections; a point section cannot pair with a hollow one)", i, len(h), len(inners[0]))
+			return nil, nil, nil, nil, fmt.Errorf("loft: section %d has %d holes, want %d (hole counts must match across sections; a point section cannot pair with a hollow one)", i, len(h), len(inners[0]))
 		}
 	}
-	return outers, inners, normals, nil
+	return outers, inners, normals, surfs, nil
 }
 
-// resolveSection resolves one section's outer loop, inner (hole) loops, and normal.
-func resolveSection(s LoftSection, bodies []*topo.Body) ([]math.Point3, [][]math.Point3, math.UnitVector3, error) {
+// resolveSection resolves one section's outer loop, inner (hole) loops, normal, and — for a face
+// section — the face's surface (nil otherwise; the skinner reads it for real face continuity).
+func resolveSection(s LoftSection, bodies []*topo.Body) ([]math.Point3, [][]math.Point3, math.UnitVector3, geom.Surface, error) {
 	switch {
 	case s.IsPoint():
-		return []math.Point3{*s.Point}, nil, sectionNormal(s), nil
+		return []math.Point3{*s.Point}, nil, sectionNormal(s), nil, nil
 	case s.IsFace():
 		f, ok := findFace(bodies, s.FaceKey)
 		if !ok {
-			return nil, nil, math.UnitVector3{}, fmt.Errorf("face reference is lost (no running body has it)")
+			return nil, nil, math.UnitVector3{}, nil, fmt.Errorf("face reference is lost (no running body has it)")
 		}
 		outer, holes := faceLoopsModel(f)
 		if len(outer) < 3 {
-			return nil, nil, math.UnitVector3{}, fmt.Errorf("face has a degenerate boundary (%d points)", len(outer))
+			return nil, nil, math.UnitVector3{}, nil, fmt.Errorf("face has a degenerate boundary (%d points)", len(outer))
 		}
-		return outer, holes, faceNormal(f, outer), nil
+		return outer, holes, faceNormal(f, outer), f.Geometry(), nil
 	default:
 		prof, e := resolveSingleProfile(s.Sketch, s.ProfileIndex, "loft")
 		if e != nil {
-			return nil, nil, math.UnitVector3{}, e
+			return nil, nil, math.UnitVector3{}, nil, e
 		}
 		outer := loopToModel(prof.OuterLoop(), s.Sketch.Plane())
 		var holes [][]math.Point3
 		for _, il := range prof.InnerLoops() {
 			holes = append(holes, loopToModel(il, s.Sketch.Plane()))
 		}
-		return outer, holes, s.Sketch.Plane().Normal(), nil
+		return outer, holes, s.Sketch.Plane().Normal(), nil, nil
 	}
 }
 


### PR DESCRIPTION
## What

Makes the loft's **Tangent (G1)** and **Smooth (G2)** end conditions *real*, driven by the
adjacent face's actual derivatives across the section edge — closing the gap where the skinner
only had the section-plane normal and **aliased Smooth to G1** ("Smooth reuses this as a faceted-
kernel approximation").

- **Carry the surface**: a face-section end now resolves the adjacent face's `geom.Surface` (not just
  its normal) and threads it to the skinner (`loftEnds.firstSurf/lastSurf`).
- **Real G1**: the end takeoff leaves along the face's true cross-boundary tangent
  (`surfaceNormal × edgeTangent`, oriented outward), replacing the normal-only approximation.
- **Real G2**: `Smooth` matches the face's curvature via a **quintic Hermite** end segment whose
  second derivative is the surface's directional 2nd derivative at the seam (first-fundamental-form
  solve + mixed term — exact for analytic and NURBS faces). `faceEndDeriv` computes it; `hermite5` is
  the quintic interpolant; the end-segment sample count probes the quintic so a curvature-matched
  takeoff stays smooth.

Closed lofts (no end sections) and Free/Angle/Direction/point conditions are unchanged. The
app/dialog/serialization already exposed these conditions — no UI or API change here.

## Why

Class-A lofts must blend into existing geometry without a curvature break. Before this, a "Smooth"
loft was just G1; now it continues the neighbour's curvature.

## Acceptance (F13-style numeric gate)

`TestLoftG2MatchesFaceCurvature`: a loft leaving a **sphere** face at Smooth has its longitudinal
seam curvature equal to the sphere's **1/R** (true G2), while a Tangent end leaves with a different
seam curvature. Plus unit tests for `hermite5` (reproduces a quintic exactly) and `faceEndDeriv`
(sphere directional curvature = 1/R toward centre). The old "Smooth approximates Tangent" face test
is updated to assert Smooth now imposes real curvature (no longer a G1 alias); the G1 flare tests
still pass with the real tangent.

## Live verification

Confirmed offscreen (lavapipe) through the real loft pipeline — a cylinder lofted to a small top
circle: **Free** has a sharp crease at the seam, **G1** flares smoothly tangent to the cap, **G2**
gives a fuller, rounder bell (zero-curvature continuation of the planar cap). All three render
distinctly; G1/G2 flow without a crease.

## Scope note

**G3** (curvature-rate) needs a new public `LoftCondition` value (a cross-repo API MINOR bump) and a
septic end segment; deferred to **#1301** to keep this PR API-free. The directional 2nd derivative is
exact for boundaries following a parameter iso-line (planar/analytic faces, NURBS iso-edges — the
common case); a fully oblique NURBS boundary drops the small mixed term.

Closes #1282

🤖 Generated with [Claude Code](https://claude.com/claude-code)