### PR TITLE
feat: surface fairing (M36-F04)

### DIFF
--- a/addin/opregistry/apply_test.go
+++ b/addin/opregistry/apply_test.go
@@ -372,6 +372,7 @@ func TestEveryOperationHandlesArgsCleanly(t *testing.T) {
 		"fillSurface":             `{"continuity":"g2"}`,
 		"bridgeSurface":           `{"continuityA":"g2","continuityB":"g2"}`,
 		"networkSurface":          `{"uCurves":[[[0,0,0],[2,0,0]],[[0,2,0],[2,2,0]]],"vCurves":[[[0,0,0],[0,2,0]],[[2,0,0],[2,2,0]]]}`,
+		"fairSurface":             `{"continuity":"g2","strength":0.5,"iterations":10}`,
 		"freeformBox":             `{"length":"10 mm","width":"10 mm","height":"10 mm"}`,
 		"freeformPlane":           `{"length":"10 mm","width":"10 mm"}`,
 		"freeformQuadBall":        `{"radius":"5 mm"}`,

--- a/addin/opregistry/feature_surface.go
+++ b/addin/opregistry/feature_surface.go
@@ -293,6 +293,50 @@ func applyNetworkSurface(s *app.Session, raw json.RawMessage) (json.RawMessage, 
 	return recomputeResult(part, pf)
 }
 
+// fairSurfaceArgs is the M36-F04 fairing op: held boundary continuity + relaxation strength/iters.
+type fairSurfaceArgs struct {
+	Continuity string  `json:"continuity,omitempty"`
+	Strength   float64 `json:"strength,omitempty"`
+	Iterations int     `json:"iterations,omitempty"`
+}
+
+const fairSurfaceSchema = `{
+  "type": "object",
+  "properties": {
+    "continuity": {"type": "string", "enum": ["g0", "g1", "g2"], "default": "g2", "description": "Boundary continuity to hold while fairing the running surface (api/types SurfaceContinuity)."},
+    "strength": {"type": "number", "default": 0.5, "description": "Per-iteration relaxation (0<s<=1)."},
+    "iterations": {"type": "integer", "default": 20, "description": "Number of fairing iterations."}
+  }
+}`
+
+func fairSurfaceDescriptor() *OperationDescriptor {
+	return &OperationDescriptor{Name: "fairSurface", Summary: "Smooth curvature wrinkles out of the running surface, holding its boundary continuity (G0/G1/G2).", Schema: json.RawMessage(fairSurfaceSchema), Apply: applyFairSurface}
+}
+
+func applyFairSurface(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		return nil, err
+	}
+	var in fairSurfaceArgs
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, err
+	}
+	cont, ok := types.ParseSurfaceContinuity(in.Continuity, types.ContinuityG2)
+	if !ok {
+		return nil, fmt.Errorf("fairSurface: unknown continuity %q (want g0, g1, or g2)", in.Continuity)
+	}
+	strength, iters := in.Strength, in.Iterations
+	if strength <= 0 {
+		strength = 0.5
+	}
+	if iters <= 0 {
+		iters = 20
+	}
+	pf := feature.NewFairFeatures(part.Features()).Add(cont.Order(), strength, iters)
+	return recomputeResult(part, pf)
+}
+
 // networkPolylines converts wire [x,y,z] curve point lists to model points (skipping malformed points).
 func networkPolylines(curves [][][]float64) [][]math.Point3 {
 	out := make([][]math.Point3, len(curves))

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -171,6 +171,7 @@ func Default() *Registry {
 		fillSurfaceDescriptor(),
 		bridgeSurfaceDescriptor(),
 		networkSurfaceDescriptor(),
+		fairSurfaceDescriptor(),
 		// Freeform primitives.
 		freeformBoxDescriptor(),
 		freeformPlaneDescriptor(),

--- a/addin/opregistry/registry_test.go
+++ b/addin/opregistry/registry_test.go
@@ -20,7 +20,7 @@ func TestDefaultDescriptors(t *testing.T) {
 		"combine", "thicken", "trim", "directEdit", "moveFace", "faceOffset", "deleteFace", "split",
 		"replaceFace", "simplify", "unwrap", "modelTolerance", "moveBody", "bendPart", "sheetMetalFace", "sheetMetalFlange", "sheetMetalHem", "sheetMetalBend", "sheetMetalFold", "sheetMetalCorner", "sheetMetalContourFlange", "sheetMetalLoftedFlange", "sheetMetalContourRoll", "sheetMetalCornerSeam", "sheetMetalCut", "sheetMetalRip", "sheetMetalPunch", "sheetMetalLip", "sheetMetalCosmeticBend", "sheetMetalUnfold", "sheetMetalRefold", "splitSolid", "coreCavity", "hull",
 		"sweep", "patternRectangular", "patternCircular", "mirror", "patternSketchDriven",
-		"boundaryPatch", "ruledSurface", "surfaceOffset", "extend", "midSurface", "stitch", "sculpt", "fillSurface", "bridgeSurface", "networkSurface",
+		"boundaryPatch", "ruledSurface", "surfaceOffset", "extend", "midSurface", "stitch", "sculpt", "fillSurface", "bridgeSurface", "networkSurface", "fairSurface",
 		"freeformBox", "freeformPlane", "freeformQuadBall", "mesh",
 	}
 	if got := len(r.All()); got != len(all) {

--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -412,6 +412,12 @@ func surfaceFeatureCommands() []*CommandDefinition {
 		}).WithTab(tabSurfacesMesh).WithEnable(hasActivePart).
 			WithIcon("network-surface").WithButtonStyle(LargeIconButton).
 			WithTooltip("Network Surface — interpolate a grid of intersecting U and V curves with a single NURBS (Gordon surface)."),
+		NewCommand("Surface.Fair", "Fair Surface", "Surface", func(s *Session) error {
+			s.StartTool(NewFairSurfaceTool())
+			return nil
+		}).WithTab(tabSurfacesMesh).WithEnable(hasActivePart).
+			WithIcon("fair-surface").WithButtonStyle(LargeIconButton).
+			WithTooltip("Fair Surface — smooth curvature wrinkles out of a surface while holding its boundary continuity (G0/G1/G2)."),
 	}
 }
 

--- a/app/fair_surface_tool.go
+++ b/app/fair_surface_tool.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"oblikovati.org/model/feature"
+)
+
+// The Fair Surface tool (M36-F04) smooths curvature wrinkles out of the running surface while holding
+// its boundary continuity (G0/G1/G2) — the Class-A "take the wrinkles out" move. Parameter-only (the
+// running surface is the input): the hold-continuity, relaxation strength and iteration count.
+
+// fairHoldLabels label the boundary continuity to hold (index = order).
+var fairHoldLabels = []string{"Position (G0)", "Tangent (G1)", "Curvature (G2)"}
+
+// FairSurfaceTool fairs the running surface body.
+type FairSurfaceTool struct {
+	dialogTool
+	hold       int // index into fairHoldLabels (order = index)
+	strength   float64
+	iterations int
+	added      *feature.PartFeature
+}
+
+// NewFairSurfaceTool returns a fair tool holding G2, strength 0.5, 20 iterations.
+func NewFairSurfaceTool() *FairSurfaceTool {
+	return &FairSurfaceTool{hold: 2, strength: 0.5, iterations: 20}
+}
+
+// Name implements [Tool].
+func (t *FairSurfaceTool) Name() string { return "Fair Surface" }
+
+// Prompt guides the input.
+func (t *FairSurfaceTool) Prompt(*Session) string {
+	return "Fair the running surface: set the held continuity, strength and iterations, then OK."
+}
+
+// Params exposes the hold-continuity, strength and iterations.
+func (t *FairSurfaceTool) Params() ToolParams {
+	return ToolParams{
+		Floats: []FloatParam{{Label: "Strength", Get: func() float64 { return t.strength }, Set: func(v float64) { t.strength = v }}},
+		Ints:   []IntParam{{Label: "Iterations", Get: func() int { return t.iterations }, Set: func(v int) { t.iterations = v }}},
+		Choices: []ChoiceParam{
+			{Label: "Hold", Options: fairHoldLabels, Get: func() int { return t.hold }, Set: func(v int) { t.hold = v }},
+		},
+	}
+}
+
+// CanCommit reports whether the strength and iterations are positive.
+func (t *FairSurfaceTool) CanCommit() bool { return t.strength > 0 && t.iterations > 0 }
+
+// Commit fairs the running surface and recomputes.
+func (t *FairSurfaceTool) Commit(s *Session) error {
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	t.added = feature.NewFairFeatures(part.Features()).Add(t.hold, t.strength, t.iterations)
+	part.Recompute()
+	s.recordEdit(part, "Fair Surface")
+	if !t.added.Health().OK() {
+		return errors.New("fair surface: " + t.added.Health().Reason)
+	}
+	return nil
+}
+
+// AddedFeature returns the feature created on commit (for inspection/tests).
+func (t *FairSurfaceTool) AddedFeature() *feature.PartFeature { return t.added }

--- a/app/fair_surface_tool_test.go
+++ b/app/fair_surface_tool_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+)
+
+// partWithOneSurface seeds a session's active part with one curved NURBS surface body.
+func partWithOneSurface(t *testing.T) (*Session, *compdef.PartComponentDefinition) {
+	t.Helper()
+	s := NewSession()
+	def := compdef.NewPartComponentDefinition()
+	pd, err := s.Workspace().Add(doc.Part, "fair.obk", true)
+	if err != nil {
+		t.Fatalf("Add part: %v", err)
+	}
+	pd.SetContent(def)
+	def.Features().Add(&seedSurfaceFeature{body: matchPatchBody(t, 0, func(i, j int) float64 { return 0.2 * float64(i) })})
+	def.Recompute()
+	return s, def
+}
+
+func TestFairSurfaceToolParams(t *testing.T) {
+	tool := NewFairSurfaceTool()
+	if tool.Name() != "Fair Surface" || !tool.CanCommit() {
+		t.Error("fair tool should name and be committable by default")
+	}
+	p := tool.Params()
+	p.Floats[0].Set(0.8)
+	p.Ints[0].Set(30)
+	p.Choices[0].Set(1)
+	if p.Floats[0].Get() != 0.8 || p.Ints[0].Get() != 30 || p.Choices[0].Get() != 1 {
+		t.Error("fair param get/set round-trip mismatch")
+	}
+	tool.strength = 0
+	if tool.CanCommit() {
+		t.Error("zero strength should block commit")
+	}
+}
+
+func TestFairSurfaceToolCommits(t *testing.T) {
+	s, _ := partWithOneSurface(t)
+	tool := NewFairSurfaceTool()
+	tool.hold = 1
+	s.StartTool(tool)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if tool.AddedFeature() == nil {
+		t.Error("fair commit should add a feature")
+	}
+}
+
+func TestFairViaRibbonCommand(t *testing.T) {
+	s, _ := partWithOneSurface(t)
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("register commands: %v", err)
+	}
+	if err := s.Execute("Surface.Fair"); err != nil {
+		t.Fatalf("execute Surface.Fair: %v", err)
+	}
+	if got := s.ActiveTool().Name(); got != "Fair Surface" {
+		t.Errorf("Surface.Fair started tool %q, want Fair Surface", got)
+	}
+}

--- a/head/icon/assets/fair-surface.svg
+++ b/head/icon/assets/fair-surface.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><path d="M3 13 L5 9 L7 15 L9 8 L11 14 L13 10" stroke="#ff0000"/><path d="M11 14 C14 9, 17 9, 21 11" stroke="#000"/></svg>

--- a/kernel/geom/fair_surface.go
+++ b/kernel/geom/fair_surface.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import "oblikovati.org/math"
+
+// Surface fairing (M36-F04): smooth curvature wrinkles out of a surface by relaxing its INTERIOR
+// control points toward a minimal-strain-energy configuration (discrete Laplacian / membrane
+// smoothing), while HOLDING a band of boundary control rows fixed so the surface keeps its boundary
+// position/tangent/curvature — hence its continuity to neighbours (G0/G1/G2). The held band depth is
+// holdOrder+1 rows from each edge (G2 holds 3 rows, so the boundary's 2nd derivative is preserved).
+
+// FairSurface returns s faired: holdOrder selects the boundary continuity to preserve (0=G0/position,
+// 1=G1/tangent, 2=G2/curvature), strength∈(0,1] is the per-iteration relaxation, iterations the count.
+// Control points within holdOrder+1 of any edge are fixed; interior points relax (Jacobi) toward the
+// average of their 4 grid neighbours. Knots, degree and weights are unchanged. A surface with no
+// interior points (too small for the held band) is returned unchanged.
+func FairSurface(s BSplineSurface, holdOrder int, strength float64, iterations int) BSplineSurface {
+	nu, nv := len(s.Ctrl), len(s.Ctrl[0])
+	band := holdOrder + 1
+	if strength <= 0 || iterations <= 0 || nu <= 2*band || nv <= 2*band {
+		return s
+	}
+	if strength > 1 {
+		strength = 1
+	}
+	cur := cloneNet(s.Ctrl)
+	for it := 0; it < iterations; it++ {
+		next := cloneNet(cur)
+		for i := band; i < nu-band; i++ {
+			for j := band; j < nv-band; j++ {
+				avg := neighbourAverage(cur, i, j)
+				next[i][j] = lerpP(cur[i][j], avg, strength)
+			}
+		}
+		cur = next
+	}
+	out, err := NewBSplineSurface(s.UDegree, s.VDegree, cur, cloneWeights(s.Weights), s.UKnots, s.VKnots)
+	if err != nil {
+		return s
+	}
+	return out
+}
+
+// neighbourAverage is the mean of control point (i,j)'s four grid neighbours — the discrete Laplacian
+// target that minimizes membrane strain energy.
+func neighbourAverage(net [][]math.Point3, i, j int) math.Point3 {
+	n := net[i-1][j].AsVector().Add(net[i+1][j].AsVector()).Add(net[i][j-1].AsVector()).Add(net[i][j+1].AsVector())
+	return n.Scale(0.25).AsPoint()
+}
+
+// cloneNet deep-copies a control net.
+func cloneNet(net [][]math.Point3) [][]math.Point3 {
+	out := make([][]math.Point3, len(net))
+	for i := range net {
+		out[i] = append([]math.Point3(nil), net[i]...)
+	}
+	return out
+}
+
+// cloneWeights deep-copies a weight net.
+func cloneWeights(w [][]float64) [][]float64 {
+	out := make([][]float64, len(w))
+	for i := range w {
+		out[i] = append([]float64(nil), w[i]...)
+	}
+	return out
+}

--- a/kernel/geom/fair_surface_test.go
+++ b/kernel/geom/fair_surface_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// noisyPatch builds an 8×8 bicubic patch over [0,1]² with z jittered by a deterministic pseudo-random
+// wrinkle on the interior — a surface with curvature noise to fair out.
+func noisyPatch(t *testing.T) BSplineSurface {
+	t.Helper()
+	const n = 8
+	ctrl := make([][]math.Point3, n)
+	w := make([][]float64, n)
+	for i := 0; i < n; i++ {
+		ctrl[i] = make([]math.Point3, n)
+		w[i] = make([]float64, n)
+		for j := 0; j < n; j++ {
+			z := 0.0
+			if i > 0 && i < n-1 && j > 0 && j < n-1 { // jitter interior only (boundary stays flat)
+				z = 0.2 * float64((i*7+j*13)%5-2) // deterministic ±wrinkle
+			}
+			ctrl[i][j] = math.P3(math.Scalar(float64(i)/7), math.Scalar(float64(j)/7), math.Scalar(z))
+			w[i][j] = 1
+		}
+	}
+	k := clampedUniformKnots(n-1, 3)
+	s, err := NewBSplineSurface(3, 3, ctrl, w, k, k)
+	if err != nil {
+		t.Fatalf("noisy patch: %v", err)
+	}
+	return s
+}
+
+// meanCurvVariance is the variance of the mean curvature (kMax+kMin)/2 over an interior sample grid.
+func meanCurvVariance(s BSplineSurface) float64 {
+	var vals []float64
+	for i := 1; i < 8; i++ {
+		for j := 1; j < 8; j++ {
+			_, kMax, kMin := SurfaceCurvatures(s, float64(i)/8, float64(j)/8)
+			vals = append(vals, (kMax+kMin)/2)
+		}
+	}
+	mean := 0.0
+	for _, v := range vals {
+		mean += v
+	}
+	mean /= float64(len(vals))
+	varc := 0.0
+	for _, v := range vals {
+		varc += (v - mean) * (v - mean)
+	}
+	return varc / float64(len(vals))
+}
+
+// TestFairSurfaceReducesCurvatureVariance: fairing smooths the wrinkle, cutting the mean-curvature
+// variance, while the held boundary band (G2: 3 rows each edge) is preserved exactly.
+func TestFairSurfaceReducesCurvatureVariance(t *testing.T) {
+	s := noisyPatch(t)
+	before := meanCurvVariance(s)
+	faired := FairSurface(s, 2, 0.5, 40)
+	after := meanCurvVariance(faired)
+	if after >= before {
+		t.Errorf("fairing did not reduce curvature variance: before %g, after %g", before, after)
+	}
+	// The G2 held band (rows/cols 0–2 and 5–7) is unchanged, so boundary continuity is preserved.
+	for i := 0; i < 8; i++ {
+		for j := 0; j < 8; j++ {
+			held := i < 3 || i >= 5 || j < 3 || j >= 5
+			if held && !faired.Ctrl[i][j].IsEqualTo(s.Ctrl[i][j], 1e-12) {
+				t.Errorf("held band CV (%d,%d) moved: %v vs %v", i, j, faired.Ctrl[i][j], s.Ctrl[i][j])
+			}
+		}
+	}
+}
+
+// TestFairSurfaceHoldsBoundaryDerivatives: a G1 fairing leaves the surface's boundary position and
+// tangent (cross-derivative) unchanged at the edges.
+func TestFairSurfaceHoldsBoundaryDerivatives(t *testing.T) {
+	s := noisyPatch(t)
+	faired := FairSurface(s, 1, 0.5, 20)
+	for _, v := range []float64{0, 0.5, 1} {
+		for k := 0; k <= 1; k++ {
+			if !faired.SurfaceDersAt(0, v, k, 0)[k][0].IsEqualTo(s.SurfaceDersAt(0, v, k, 0)[k][0], 1e-9) {
+				t.Errorf("G1 fairing changed u=0 boundary derivative order %d at v=%g", k, v)
+			}
+		}
+	}
+}
+
+// TestFairSurfaceNoInteriorIsNoop: a patch too small for the held band is returned unchanged.
+func TestFairSurfaceNoInteriorIsNoop(t *testing.T) {
+	s := uPatch(t, 0, func(i, j int) float64 { return 0.1 * float64(i) }) // 5×5
+	if faired := FairSurface(s, 2, 0.5, 10); !faired.Ctrl[2][2].IsEqualTo(s.Ctrl[2][2], 1e-12) {
+		t.Error("a 5×5 patch has no interior past a G2 band; fairing should be a no-op")
+	}
+}

--- a/kernel/ops/fair_face.go
+++ b/kernel/ops/fair_face.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+)
+
+// Fairing a surface body's NURBS face (M36-F04): relax the interior control points to smooth
+// curvature wrinkles while holding the boundary band (geom.FairSurface), and rebuild the face on the
+// unchanged domain. holdOrder preserves the boundary continuity (0=G0,1=G1,2=G2).
+
+// FairFaceSurface returns a surface body whose NURBS face is faired (interior smoothed, boundary held
+// to holdOrder) by strength over iterations. It errors when the body has no NURBS face.
+func FairFaceSurface(b *topo.Body, holdOrder int, strength float64, iterations int) (*topo.Body, error) {
+	_, s, ok := firstNurbsFace(b)
+	if !ok {
+		return nil, fmt.Errorf("ops.FairFaceSurface: body has no NURBS surface face")
+	}
+	faired := geom.FairSurface(s, holdOrder, strength, iterations)
+	return fullDomainBody(faired, "fair"), nil
+}

--- a/model/feature/fair_surface.go
+++ b/model/feature/fair_surface.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "oblikovati.org/kernel/ops"
+
+// The Fair feature (M36-F04) smooths curvature wrinkles out of the running surface body's NURBS face
+// while holding its boundary continuity (G0/G1/G2) to neighbours — the Class-A "take the wrinkles
+// out" move. It replaces the running surface. The fairing math is kernel/geom.FairSurface via
+// ops.FairFaceSurface; F13 is the boundary-continuity gate.
+
+// FairDefinition is the recipe for a fairing: the boundary continuity to hold (0=G0,1=G1,2=G2), the
+// per-iteration relaxation strength (0<s≤1), and the iteration count.
+type FairDefinition struct {
+	HoldOrder  int
+	Strength   float64
+	Iterations int
+}
+
+// FairFeature fairs the running surface body's NURBS face.
+type FairFeature struct {
+	def      *FairDefinition
+	featName string
+}
+
+// Definition returns the fairing recipe.
+func (f *FairFeature) Definition() *FairDefinition { return f.def }
+
+// Kind implements [Feature].
+func (f *FairFeature) Kind() string { return "fair-surface" }
+
+// Recompute fairs the running surface body's NURBS face and replaces it.
+func (f *FairFeature) Recompute(in Input) (Output, error) {
+	target, err := lastBody(in, "fair surface")
+	if err != nil {
+		return Output{}, err
+	}
+	out, err := ops.FairFaceSurface(target, f.def.HoldOrder, f.def.Strength, f.def.Iterations)
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: replaceLast(in.Bodies, out)}, nil
+}
+
+// FairFeatures adds fairing features into the engine.
+type FairFeatures struct{ engine *PartFeatures }
+
+// NewFairFeatures binds the collection to a feature engine.
+func NewFairFeatures(engine *PartFeatures) *FairFeatures { return &FairFeatures{engine: engine} }
+
+// Add fairs the running surface, holding holdOrder continuity, by strength over iterations.
+func (c *FairFeatures) Add(holdOrder int, strength float64, iterations int) *PartFeature {
+	def := &FairDefinition{HoldOrder: holdOrder, Strength: strength, Iterations: iterations}
+	ff := &FairFeature{def: def, featName: "Fair"}
+	pf := c.engine.Add(ff)
+	ff.featName = pf.name
+	return pf
+}

--- a/model/feature/fair_surface_test.go
+++ b/model/feature/fair_surface_test.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+)
+
+func TestFairFeatureReplacesSurface(t *testing.T) {
+	body := surfaceBodyFrom(t, matchPatch(t, 0, func(i, j int) float64 { return 0.3 * float64((i*3+j)%2) }))
+	f := &FairFeature{def: &FairDefinition{HoldOrder: 1, Strength: 0.5, Iterations: 10}, featName: "Fair"}
+	out, err := f.Recompute(Input{Bodies: []*topo.Body{body}})
+	if err != nil {
+		t.Fatalf("Recompute: %v", err)
+	}
+	if len(out.Bodies) != 1 {
+		t.Fatalf("fair should replace the body, got %d", len(out.Bodies))
+	}
+	if _, ok := out.Bodies[0].Faces()[0].Geometry().(geom.BSplineSurface); !ok {
+		t.Fatalf("faired face is %T, want BSplineSurface", out.Bodies[0].Faces()[0].Geometry())
+	}
+}
+
+func TestFairFeatureErrorsWithoutBody(t *testing.T) {
+	f := &FairFeature{def: &FairDefinition{HoldOrder: 1, Strength: 0.5, Iterations: 5}}
+	if _, err := f.Recompute(Input{}); err == nil {
+		t.Error("fair with no body should error")
+	}
+}
+
+func TestFairKind(t *testing.T) {
+	if (&FairFeature{def: &FairDefinition{}}).Kind() != "fair-surface" {
+		t.Error("fair kind")
+	}
+}
+
+func TestFairSurfaceRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	NewFairFeatures(fs).Add(2, 0.4, 25)
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	d := fresh.Item(0).Definition().(*FairFeature).Definition()
+	if d.HoldOrder != 2 || d.Strength != 0.4 || d.Iterations != 25 {
+		t.Errorf("restored fair = %+v, want {2 0.4 25}", d)
+	}
+}
+
+func TestRestoreFairRejectsMissingPayload(t *testing.T) {
+	if _, err := restoreFairSurface(NewPartFeatures(nil, nil), nil); err == nil {
+		t.Error("restoreFairSurface(nil) should error")
+	}
+}

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -67,6 +67,7 @@ type FeatureData struct {
 	FillSurface      *FillSurfaceData      `yaml:"fillSurface,omitempty"`
 	BridgeSurface    *BridgeSurfaceData    `yaml:"bridgeSurface,omitempty"`
 	NetworkSurface   *NetworkSurfaceData   `yaml:"networkSurface,omitempty"`
+	FairSurface      *FairSurfaceData      `yaml:"fairSurface,omitempty"`
 	FaceEdit         *FaceEditData         `yaml:"faceEdit,omitempty"`
 	Thicken          *ThickenData          `yaml:"thicken,omitempty"`
 	Revolve          *RevolveData          `yaml:"revolve,omitempty"`
@@ -300,6 +301,8 @@ func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (Featur
 		fd.BridgeSurface = serializeBridgeSurface(f.def)
 	case *NetworkFeature:
 		fd.NetworkSurface = serializeNetworkSurface(f.def)
+	case *FairFeature:
+		fd.FairSurface = serializeFairSurface(f.def)
 	case *RevolveFeature:
 		rv, err := serializeRevolve(f.def, sk)
 		if err != nil {
@@ -638,6 +641,8 @@ func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored [
 		return restoreBridgeSurface(fs, fd.BridgeSurface)
 	case "network-surface":
 		return restoreNetworkSurface(fs, fd.NetworkSurface)
+	case "fair-surface":
+		return restoreFairSurface(fs, fd.FairSurface)
 	case "split", "move-face", "face-offset", "delete-face", "replace-face":
 		return restoreFaceEdit(fs, fd.Kind, fd.FaceEdit)
 	case "thicken":

--- a/model/feature/serialize_fair_surface.go
+++ b/model/feature/serialize_fair_surface.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// Serialized form of the fairing feature (M36-F04).
+
+// FairSurfaceData is a fairing's recipe.
+type FairSurfaceData struct {
+	HoldOrder  int     `yaml:"holdOrder"`
+	Strength   float64 `yaml:"strength"`
+	Iterations int     `yaml:"iterations"`
+}
+
+func serializeFairSurface(def *FairDefinition) *FairSurfaceData {
+	return &FairSurfaceData{HoldOrder: def.HoldOrder, Strength: def.Strength, Iterations: def.Iterations}
+}
+
+func restoreFairSurface(fs *PartFeatures, d *FairSurfaceData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("fair-surface feature is missing its payload")
+	}
+	return NewFairFeatures(fs).Add(d.HoldOrder, d.Strength, d.Iterations), nil
+}


### PR DESCRIPTION
## What

Adds **surface fairing** — the M36 Class-A tool that smooths curvature wrinkles out of a NURBS surface while preserving its boundary continuity to neighbours.

- `geom.FairSurface(s, holdOrder, strength, iterations)` — Jacobi-relax interior control points toward the discrete-Laplacian (membrane) target; a band of `holdOrder+1` rows from each edge is held fixed so boundary position/tangent/curvature (G0/G1/G2) — and thus continuity to adjacent surfaces — is preserved. Knots, degree and weights are untouched; a patch too small for the held band is returned unchanged.
- `ops.FairFaceSurface` wraps it as a body op; `FairFeature` (kind `fair-surface`) replaces the last surface body and round-trips through `.obk`.
- `Surface.Fair` ribbon tool with **Hold (G0/G1/G2)**, **Strength** and **Iterations** parameters + `fair-surface` icon.
- Self-describing `fairSurface` MCP op over `features.add`.

Follows ADR-0018 — the continuity enum already shipped in `api/types` (PR #212); this is the `/source` implementation only (no new wire surface needed for the op, which rides the generic `features.add` method).

## Why

Closes #1280. Completes another M36 Class-A surfacing feature. Fairing is the standard finishing step on Class-A panels — Alias exposes the same hold-boundary-continuity smoothing in its Surface Edit palette.

## Tests

- `kernel/geom/fair_surface_test.go` — fairing reduces mean-curvature variance on a noisy patch; the G2 held band is preserved exactly; G1 fairing holds boundary derivatives; no-interior patch is a no-op.
- `model/feature/fair_surface_test.go` — Recompute replaces the body with a NURBS face; errors without a body; `.obk` round-trip.
- `app/fair_surface_tool_test.go` — params round-trip, zero-strength blocks commit, commit adds a feature, `Surface.Fair` starts the tool.
- opregistry registry/apply tests updated for the new op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)