### PR TITLE
refactor(m36): clean-code audit of the M36 surfacing PRs

### DIFF
--- a/addin/opregistry/feature_surface.go
+++ b/addin/opregistry/feature_surface.go
@@ -222,7 +222,7 @@ func applyFillSurface(s *app.Session, raw json.RawMessage) (json.RawMessage, err
 	}
 	sides := in.Sides
 	if sides <= 0 {
-		sides = 4
+		sides = feature.DefaultFillSides
 	}
 	pf := feature.NewFillFeatures(part.Features()).AddSides(cont.Order(), sides)
 	return recomputeResult(part, pf)
@@ -389,13 +389,13 @@ func applyFitSurface(s *app.Session, raw json.RawMessage) (json.RawMessage, erro
 func fitSurfaceDefaults(in fitSurfaceArgs) (degree, nu, nv int) {
 	degree, nu, nv = in.Degree, in.NU, in.NV
 	if degree <= 0 {
-		degree = 3
+		degree = feature.DefaultFitDegree
 	}
 	if nu <= 0 {
-		nu = 6
+		nu = feature.DefaultFitSpans
 	}
 	if nv <= 0 {
-		nv = 6
+		nv = feature.DefaultFitSpans
 	}
 	return degree, nu, nv
 }

--- a/addin/opregistry/fit_surface_defaults_test.go
+++ b/addin/opregistry/fit_surface_defaults_test.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import "testing"
+
+// TestFitSurfaceDefaults: omitted (zero) degree/spans fall back to the bicubic 6×6 defaults, while
+// explicit values pass through unchanged.
+func TestFitSurfaceDefaults(t *testing.T) {
+	d, nu, nv := fitSurfaceDefaults(fitSurfaceArgs{})
+	if d != 3 || nu != 6 || nv != 6 {
+		t.Errorf("zero args = (%d,%d,%d), want the (3,6,6) defaults", d, nu, nv)
+	}
+	d, nu, nv = fitSurfaceDefaults(fitSurfaceArgs{Degree: 5, NU: 8, NV: 7})
+	if d != 5 || nu != 8 || nv != 7 {
+		t.Errorf("explicit args = (%d,%d,%d), want (5,8,7) passed through", d, nu, nv)
+	}
+}

--- a/app/fill_surface_tool.go
+++ b/app/fill_surface_tool.go
@@ -24,7 +24,9 @@ type FillSurfaceTool struct {
 }
 
 // NewFillSurfaceTool returns a fill tool defaulting to a four-sided curvature (G2) fill.
-func NewFillSurfaceTool() *FillSurfaceTool { return &FillSurfaceTool{continuity: 2, sides: 4} }
+func NewFillSurfaceTool() *FillSurfaceTool {
+	return &FillSurfaceTool{continuity: 2, sides: feature.DefaultFillSides}
+}
 
 // SetContinuity sets the continuity order (0=G0, 1=G1, 2=G2).
 func (t *FillSurfaceTool) SetContinuity(order int) { t.continuity = order }

--- a/app/fit_surface_tool.go
+++ b/app/fit_surface_tool.go
@@ -29,7 +29,9 @@ type FitSurfaceTool struct {
 }
 
 // NewFitSurfaceTool returns a fit tool defaulting to a bicubic 6×6 patch.
-func NewFitSurfaceTool() *FitSurfaceTool { return &FitSurfaceTool{degree: 3, nu: 6, nv: 6} }
+func NewFitSurfaceTool() *FitSurfaceTool {
+	return &FitSurfaceTool{degree: feature.DefaultFitDegree, nu: feature.DefaultFitSpans, nv: feature.DefaultFitSpans}
+}
 
 // Name implements [Tool].
 func (t *FitSurfaceTool) Name() string { return "Fit Surface" }

--- a/kernel/fit/surface.go
+++ b/kernel/fit/surface.go
@@ -50,7 +50,7 @@ func planeParameters(points []math.Point3, plane geom.Plane) (us, vs []float64) 
 func normalizeUnit(vals []float64) {
 	lo, hi := vals[0], vals[0]
 	for _, v := range vals {
-		lo, hi = minF(lo, v), maxF(hi, v)
+		lo, hi = min(lo, v), max(hi, v)
 	}
 	span := hi - lo
 	for i, v := range vals {
@@ -60,18 +60,4 @@ func normalizeUnit(vals []float64) {
 		}
 		vals[i] = (v - lo) / span
 	}
-}
-
-func minF(a, b float64) float64 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func maxF(a, b float64) float64 {
-	if a > b {
-		return a
-	}
-	return b
 }

--- a/kernel/geom/curve_split_join.go
+++ b/kernel/geom/curve_split_join.go
@@ -60,7 +60,7 @@ func JoinCurves(curves []BSplineCurve) (BSplineCurve, error) {
 	}
 	deg := 0
 	for _, c := range curves {
-		deg = maxInt(deg, c.Degree)
+		deg = max(deg, c.Degree)
 	}
 	acc, err := elevateTo(curves[0], deg)
 	if err != nil {
@@ -143,11 +143,4 @@ func repeatKnot(u float64, n int) []float64 {
 		out[i] = u
 	}
 	return out
-}
-
-func maxInt(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
 }

--- a/kernel/ops/fair_face_test.go
+++ b/kernel/ops/fair_face_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+)
+
+// TestFairFaceSurfaceFairsBody fairs a multi-span NURBS surface body (5×5 net) at G1 and checks it
+// returns a valid single-face NURBS body with the same control dimensions (fairing moves interior
+// points, it does not change degree/knots).
+func TestFairFaceSurfaceFairsBody(t *testing.T) {
+	body := surfaceFaceBody(t, multiSpanPatch(t))
+	out, err := ops.FairFaceSurface(body, 1, 0.5, 10)
+	if err != nil {
+		t.Fatalf("FairFaceSurface: %v", err)
+	}
+	s, ok := out.Faces()[0].Geometry().(geom.BSplineSurface)
+	if !ok {
+		t.Fatalf("faired face is %T, want geom.BSplineSurface", out.Faces()[0].Geometry())
+	}
+	if len(s.Ctrl) != 5 || len(s.Ctrl[0]) != 5 {
+		t.Errorf("faired net = %dx%d, want 5x5 (fairing keeps the control structure)", len(s.Ctrl), len(s.Ctrl[0]))
+	}
+}
+
+func TestFairFaceSurfaceRejectsNonNurbs(t *testing.T) {
+	box := csgBox(math.P3(0, 0, 0), 1, 1, 1)
+	if _, err := ops.FairFaceSurface(box, 1, 0.5, 10); err == nil {
+		t.Error("fairing a body with no NURBS face should error")
+	}
+}

--- a/model/feature/fill_surface.go
+++ b/model/feature/fill_surface.go
@@ -15,6 +15,10 @@ import (
 // fill math is kernel/geom.FillSurface via ops.FillFourSided; the F13 cross-edge checker is the
 // numeric acceptance gate.
 
+// DefaultFillSides is the classic four-sided boundary fill — the side count assumed when none is
+// given (Sides ≤ 0), shared by the fill feature, tool and MCP op.
+const DefaultFillSides = 4
+
 // FillDefinition is the recipe for a boundary fill: the continuity order to impose on every side
 // (0=G0/position … 2=G2/curvature) and the number of bounding sides (0 or 4 = the classic four-sided
 // fill; 3, 5, 6… = an N-sided fill of the last Sides surface bodies).
@@ -40,7 +44,7 @@ func (f *FillFeature) Kind() string { return "fill-surface" }
 func (f *FillFeature) Recompute(in Input) (Output, error) {
 	sides := f.def.Sides
 	if sides <= 0 {
-		sides = 4
+		sides = DefaultFillSides
 	}
 	if len(in.Bodies) < sides {
 		return Output{}, fmt.Errorf("fill surface: needs %d bounding surface bodies, have %d", sides, len(in.Bodies))

--- a/model/feature/fit_surface.go
+++ b/model/feature/fit_surface.go
@@ -15,6 +15,13 @@ import (
 // model-space points); the feature least-squares fits a degree×degree B-spline with the requested
 // nu×nv control net via ops.FitSurfaceToPoints and appends it as a surface body.
 
+// Class-A fit defaults shared by the Fit Surface tool and the fitSurface MCP op: a bicubic patch
+// (degree 3) with a 6×6 control net — few even spans for clean reflection lines.
+const (
+	DefaultFitDegree = 3
+	DefaultFitSpans  = 6
+)
+
 // FitDefinition is the recipe for a fitted surface: the region points and the degree/span targets.
 type FitDefinition struct {
 	Points []math.Point3


### PR DESCRIPTION
## What

Post-merge clean-code audit of the M36 Class-A surfacing PRs (#1307–#1312). No behaviour change.

- **Dead/redundant code:** dropped the custom `minF`/`maxF` (kernel/fit) and `maxInt` (kernel/geom) helpers added during M36 — the Go 1.21+ builtins `min`/`max` cover them.
- **Missing coverage:** `ops.FairFaceSurface` had no *direct* test (only exercised cross-package via the feature). Added one covering the fair path and the no-NURBS-face error branch, matching the `fit_face`/`network_face`/`bridge_face` wrappers.
- **Magic numbers → named constants:** the fit defaults (degree 3, 6×6 spans) and the fill default (4 sides) were repeated across the tool, the feature normalization and the MCP op. Centralized as `feature.DefaultFitDegree` / `DefaultFitSpans` / `DefaultFillSides`.

## Audit findings that needed no change

- **Tolerances** are already named constants (`networkGapTol`, `surfaceFitRidge`, `deviationGrid`); no stray magic tolerances.
- **No dead code / TODO / FIXME** in the new source; the one `panic` is the pre-existing registry-seeding init guard.
- **Docs are current:** the api `CHANGELOG` lists `SurfaceContinuity` (0.91.0) and `FilletCrossSection`/`LoftG3` (0.90.0); the M36 GitHub milestone + epic #1276 are closed; the deviation tolerance comment is accurate (0.01 cm = 0.1 mm); no third-party CAD names leak into the public api types (gen-api-docs gate).
- **Accepted (not churned):** the spherical-cap test samplers and `lerp3` repeat across four *packages* (cpd-excluded; sharing would need an exported test-util) — Go cross-package test convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)