### PR TITLE
fix(massprops): orient triangles topologically, not from shading normals (#1318)

### DIFF
--- a/kernel/ops/inertia.go
+++ b/kernel/ops/inertia.go
@@ -47,12 +47,14 @@ func meshInertia(mesh *Mesh) InertiaTensor {
 }
 
 // accumulateCovariance sums each outward-wound triangle's tetra covariance (∫ p pᵀ dV about the
-// origin) and signed volume / centroid numerator over the mesh.
+// origin) and signed volume / centroid numerator over the mesh. Triangles are oriented consistently
+// outward TOPOLOGICALLY (consistentOutwardFlips), not from shading normals, so a saddle/silhouette
+// facet can no longer flip its covariance sign at random (Oblikovati/Oblikovati#1318).
 func accumulateCovariance(mesh *Mesh) (cov mat3, vol, cx, cy, cz float64) {
-	for t := 0; t+2 < len(mesh.Indices); t += 3 {
-		ia, ib, ic := mesh.Indices[t], mesh.Indices[t+1], mesh.Indices[t+2]
-		a, b, c := mesh.Positions[ia], mesh.Positions[ib], mesh.Positions[ic]
-		if outwardRef(mesh, ia, ib, ic).Dot(a.VectorTo(b).Cross(a.VectorTo(c))) < 0 {
+	flips := consistentOutwardFlips(mesh)
+	for ti, n := 0, mesh.TriangleCount(); ti < n; ti++ {
+		a, b, c := triVerts(mesh, ti)
+		if flips[ti] {
 			b, c = c, b
 		}
 		// A = [a b c] as columns; det A = a · (b × c) = 6 × signed tetra volume.

--- a/kernel/ops/massprops.go
+++ b/kernel/ops/massprops.go
@@ -31,19 +31,18 @@ func BodyGeometryProperties(b *topo.Body, q Quality) GeometryProperties {
 // is testable without a body. Each triangle (a,b,c) forms a tetrahedron with the origin;
 // the signed tetra volumes sum to the enclosed volume regardless of where the origin sits
 // (the parts outside the body cancel), and the volume-weighted tetra centroids give the
-// body centroid. Each triangle is first oriented outward using the mesh's per-vertex
-// normals, so the sum is correct even when a tessellator does not guarantee globally
-// consistent winding across faces (without this the divergence sum is not
-// translation-invariant — see TestVolumeIsTranslationInvariant).
+// body centroid. The triangles are first oriented consistently outward TOPOLOGICALLY (shared-
+// edge 2-colouring, see consistentOutwardFlips), so the sum is correct even when a tessellator
+// does not guarantee globally consistent winding across faces, and — unlike the old shading-
+// normal test — without spurious per-triangle flips at saddles/silhouette slivers
+// (Oblikovati/Oblikovati#1318). It stays translation-invariant (see TestVolumeIsTranslationInvariant).
 func meshGeometryProperties(mesh *Mesh) GeometryProperties {
+	flips := consistentOutwardFlips(mesh)
 	origin := math.P3(0, 0, 0)
 	var vol, area, cx, cy, cz float64
-	for t := 0; t+2 < len(mesh.Indices); t += 3 {
-		ia, ib, ic := mesh.Indices[t], mesh.Indices[t+1], mesh.Indices[t+2]
-		a, b, c := mesh.Positions[ia], mesh.Positions[ib], mesh.Positions[ic]
-		// Force outward winding: if the geometric normal opposes the (outward) shading
-		// normal, swap two vertices.
-		if outwardRef(mesh, ia, ib, ic).Dot(a.VectorTo(b).Cross(a.VectorTo(c))) < 0 {
+	for ti, n := 0, mesh.TriangleCount(); ti < n; ti++ {
+		a, b, c := triVerts(mesh, ti)
+		if flips[ti] {
 			b, c = c, b
 		}
 		sv := float64(origin.VectorTo(a).Dot(origin.VectorTo(b).Cross(origin.VectorTo(c)))) / 6

--- a/kernel/ops/massprops_orientation_test.go
+++ b/kernel/ops/massprops_orientation_test.go
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	m "oblikovati.org/math"
+)
+
+// Regression for Oblikovati/Oblikovati#1318: mass properties used to orient triangles from summed
+// per-vertex shading normals, which flip at random on coarse high-curvature meshes (saddles,
+// silhouette slivers) and corrupt the divergence-theorem sum. The orientation is now topological
+// (consistentOutwardFlips), so volume/centroid/inertia converge cleanly with no sign-flip spikes.
+
+// sphereVolume returns the analytic volume of a sphere of the given radius.
+func sphereVolume(r float64) float64 { return 4.0 / 3.0 * math.Pi * r * r * r }
+
+// TestCoarseSphereVolumeConvergesMonotonically tessellates a sphere at successively finer qualities
+// and asserts the volume rises monotonically toward the analytic value from below (an inscribed
+// polyhedron under-fills), with no spike. A random saddle flip would break monotonicity or sign.
+func TestCoarseSphereVolumeConvergesMonotonically(t *testing.T) {
+	const r = 3.0
+	want := sphereVolume(r)
+	sphere, err := brep.SolidSphere(m.P3(0, 0, 0), r, "sphere")
+	if err != nil {
+		t.Fatalf("SolidSphere: %v", err)
+	}
+	qualities := []Quality{
+		{ChordTolerance: 0.5, AngleTolerance: 40 * math.Pi / 180},  // coarse
+		{ChordTolerance: 0.1, AngleTolerance: 20 * math.Pi / 180},  // medium
+		{ChordTolerance: 0.02, AngleTolerance: 8 * math.Pi / 180},  // fine
+		{ChordTolerance: 0.005, AngleTolerance: 3 * math.Pi / 180}, // finer
+	}
+	var coarseErr, prevErr = 0.0, math.Inf(1)
+	for i, q := range qualities {
+		v := BodyGeometryProperties(sphere, q).Volume
+		if v <= 0 {
+			t.Fatalf("q[%d]: non-positive volume %g (sign flip)", i, v)
+		}
+		if v > want*(1+1e-9) {
+			t.Errorf("q[%d]: volume %g exceeds analytic %g (inscribed mesh must under-fill)", i, v, want)
+		}
+		relErr := (want - v) / want
+		if relErr > prevErr+1e-12 {
+			t.Errorf("q[%d]: rel error %g grew vs previous %g (non-monotone — orientation spike)", i, relErr, prevErr)
+		}
+		if i == 0 {
+			coarseErr = relErr
+		}
+		prevErr = relErr
+	}
+	// Genuine convergence: refining the mesh ~100× (chord 0.5→0.005) must shrink the error by at
+	// least 5×. A constant orientation-injected bias would not converge like this.
+	if prevErr > coarseErr/5 {
+		t.Errorf("finest rel error %g did not converge below coarse/5 = %g", prevErr, coarseErr/5)
+	}
+	if prevErr > 1e-2 {
+		t.Errorf("finest rel error %g too large for a converged sphere mesh", prevErr)
+	}
+}
+
+// TestCoarseSphereVolumeWithinChordBound asserts that even at the COARSEST quality the volume error
+// is bounded by O(chord²)/R² — the geometric chord-deviation bound — not an O(1) spike. Pre-fix, a
+// flipped saddle facet on a coarse sphere produced errors far beyond this bound.
+func TestCoarseSphereVolumeWithinChordBound(t *testing.T) {
+	const r = 3.0
+	want := sphereVolume(r)
+	sphere, err := brep.SolidSphere(m.P3(0, 0, 0), r, "sphere")
+	if err != nil {
+		t.Fatalf("SolidSphere: %v", err)
+	}
+	const chord = 0.5
+	v := BodyGeometryProperties(sphere, Quality{ChordTolerance: chord, AngleTolerance: 40 * math.Pi / 180}).Volume
+	// Shell bound: an inscribed polyhedron's volume deficit is at most the surface area times the
+	// chord deviation (a shell of that thickness). A flipped saddle facet blows past this bound.
+	area := 4 * math.Pi * r * r
+	bound := area * chord
+	if math.Abs(v-want) > bound {
+		t.Errorf("coarse sphere volume %g, analytic %g, |err| %g exceeds shell bound area*chord = %g", v, want, math.Abs(v-want), bound)
+	}
+}
+
+// TestSaddleRichTorusVolumeStable uses a torus — the canonical surface carrying both positive and
+// NEGATIVE Gaussian curvature (its inner half is a saddle band) — as the saddle-rich oracle. Volume
+// must track the analytic 2π²·R·r² across qualities with no spike. The summed-normal test was most
+// fragile exactly on this saddle band.
+func TestSaddleRichTorusVolumeStable(t *testing.T) {
+	const major, minor = 5.0, 1.5
+	want := 2 * math.Pi * math.Pi * major * minor * minor
+	torus, err := brep.SolidTorus(m.P3(0, 0, 0), m.V3(0, 0, 1), major, minor, "torus")
+	if err != nil {
+		t.Fatalf("SolidTorus: %v", err)
+	}
+	qualities := []Quality{
+		{ChordTolerance: 0.2, AngleTolerance: 20 * math.Pi / 180},
+		{ChordTolerance: 0.05, AngleTolerance: 8 * math.Pi / 180},
+		{ChordTolerance: 0.01, AngleTolerance: 3 * math.Pi / 180},
+	}
+	var prevErr = math.Inf(1)
+	for i, q := range qualities {
+		v := BodyGeometryProperties(torus, q).Volume
+		if v <= 0 {
+			t.Fatalf("q[%d]: non-positive torus volume %g (saddle sign flip)", i, v)
+		}
+		relErr := math.Abs(v-want) / want
+		if relErr > prevErr+1e-3 {
+			t.Errorf("q[%d]: torus rel error %g jumped above previous %g (saddle spike)", i, relErr, prevErr)
+		}
+		prevErr = relErr
+	}
+	if prevErr > 5e-3 {
+		t.Errorf("finest torus rel error %g too large", prevErr)
+	}
+}
+
+// TestSolidSphereInertiaIsotropic checks the inertia tensor of a uniform solid sphere: Ixx=Iyy=Izz=
+// (2/5)·V·R² and the products of inertia vanish. A saddle-flipped covariance contribution would
+// break the isotropy or the diagonal value.
+func TestSolidSphereInertiaIsotropic(t *testing.T) {
+	const r = 3.0
+	sphere, err := brep.SolidSphere(m.P3(0, 0, 0), r, "sphere")
+	if err != nil {
+		t.Fatalf("SolidSphere: %v", err)
+	}
+	q := Quality{ChordTolerance: 0.01, AngleTolerance: 3 * math.Pi / 180}
+	it := BodyInertia(sphere, q)
+	v := BodyGeometryProperties(sphere, q).Volume
+	want := 0.4 * v * r * r
+	tol := want * 5e-3
+	for _, c := range []struct {
+		name string
+		got  float64
+	}{{"Ixx", it.Ixx}, {"Iyy", it.Iyy}, {"Izz", it.Izz}} {
+		if math.Abs(c.got-want) > tol {
+			t.Errorf("%s = %g, want %g (tol %g)", c.name, c.got, want, tol)
+		}
+	}
+	offTol := want * 5e-3
+	for _, c := range []struct {
+		name string
+		got  float64
+	}{{"Ixy", it.Ixy}, {"Iyz", it.Iyz}, {"Izx", it.Izx}} {
+		if math.Abs(c.got) > offTol {
+			t.Errorf("%s = %g, want ~0 (tol %g)", c.name, c.got, offTol)
+		}
+	}
+}
+
+// inconsistentCubeMesh builds a unit-cube surface mesh of side s at the origin, then deliberately
+// reverses the winding of a subset of its triangles and zeroes the per-vertex normals — a worst-case
+// input for the OLD shading-normal orientation (which would then mis-sum the volume). The topological
+// orientation must still recover |V| = s³.
+func inconsistentCubeMesh(s float64) *Mesh {
+	mesh := &Mesh{}
+	c := [8]m.Point3{
+		m.P3(0, 0, 0), m.P3(s, 0, 0), m.P3(s, s, 0), m.P3(0, s, 0),
+		m.P3(0, 0, s), m.P3(s, 0, s), m.P3(s, s, s), m.P3(0, s, s),
+	}
+	for _, p := range c {
+		mesh.addVertex(p, m.Vector3{}) // zeroed normals: prove they are unused
+	}
+	// Outward-wound quads (CCW seen from outside), each split into two triangles.
+	quads := [6][4]int{
+		{0, 3, 2, 1}, // bottom (z=0), normal -Z
+		{4, 5, 6, 7}, // top (z=s),    normal +Z
+		{0, 1, 5, 4}, // front (y=0),  normal -Y
+		{2, 3, 7, 6}, // back (y=s),   normal +Y
+		{1, 2, 6, 5}, // right (x=s),  normal +X
+		{0, 4, 7, 3}, // left (x=0),   normal -X
+	}
+	for qi, q := range quads {
+		t0 := [3]int{q[0], q[1], q[2]}
+		t1 := [3]int{q[0], q[2], q[3]}
+		if qi%2 == 0 { // corrupt every other quad's winding to make the input inconsistent
+			t0[1], t0[2] = t0[2], t0[1]
+			t1[1], t1[2] = t1[2], t1[1]
+		}
+		mesh.addTriangle(t0[0], t0[1], t0[2])
+		mesh.addTriangle(t1[0], t1[1], t1[2])
+	}
+	return mesh
+}
+
+// TestInconsistentlyWoundMeshVolumeMagnitude proves the topological orientation path recovers the
+// correct volume magnitude from a mesh whose triangles are inconsistently wound and whose shading
+// normals are useless — the case the old summed-normal test got wrong (Oblikovati/Oblikovati#1318).
+func TestInconsistentlyWoundMeshVolumeMagnitude(t *testing.T) {
+	const s = 2.0
+	mesh := inconsistentCubeMesh(s)
+	gp := meshGeometryProperties(mesh)
+	want := s * s * s
+	if math.Abs(gp.Volume-want) > 1e-9 {
+		t.Errorf("volume = %g, want %g (topological orientation failed on inconsistent input)", gp.Volume, want)
+	}
+	// Centroid of a cube [0,s]³ is its centre.
+	for _, c := range []struct {
+		name string
+		got  float64
+	}{{"X", float64(gp.Centroid.X)}, {"Y", float64(gp.Centroid.Y)}, {"Z", float64(gp.Centroid.Z)}} {
+		if math.Abs(c.got-s/2) > 1e-9 {
+			t.Errorf("centroid.%s = %g, want %g", c.name, c.got, s/2)
+		}
+	}
+}

--- a/kernel/ops/mesh_orient.go
+++ b/kernel/ops/mesh_orient.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import "oblikovati.org/math"
+
+// consistentOutwardFlips returns, per triangle of m, whether that triangle's winding must be
+// reversed for the whole mesh to wind consistently OUTWARD (a positive enclosed volume) — the
+// divergence-theorem prerequisite for mass properties (Oblikovati/Oblikovati#1318).
+//
+// It recovers the orientation TOPOLOGICALLY: weld the shared vertices, 2-colour the triangles
+// across their shared edges (neighbours that traverse a shared edge in OPPOSITE directions agree,
+// the SAME direction disagree), then fix the one global sign by signed volume. It deliberately does
+// NOT consult per-vertex shading normals: those diverge at a saddle or on a coarse-mesh silhouette
+// sliver until their sum is nearly perpendicular to the facet, so the old `outwardRef·geomNormal < 0`
+// test flipped facets at random there and corrupted the signed sum. A triangle on a non-orientable
+// defect (its links disagree — a frustrated component) is left exactly as wound rather than flipped
+// on a guess, mirroring orientFacesOutward's frustrated-face rule, so a correct facet is never
+// mis-oriented.
+//
+//	flips := consistentOutwardFlips(mesh) // flips[i]==true ⇒ swap two corners of triangle i
+func consistentOutwardFlips(m *Mesh) []bool {
+	adj := triangleAdjacency(m)
+	parity := twoColorFaces(adj)
+	frustrated := frustratedFaces(adj, parity)
+	globalFlip := triangleParityVolume(m, parity) < 0
+	flips := make([]bool, len(parity))
+	for ti := range flips {
+		flips[ti] = !frustrated[ti] && (parity[ti] == 1) != globalFlip
+	}
+	return flips
+}
+
+// triangleAdjacency builds, per triangle of m, its orientation links over the welded shared edges —
+// the per-triangle analogue of faceAdjacency, so the same 2-colouring drives orientation on a single
+// merged mesh (mass properties) and on per-face meshes (orientFacesOutward).
+func triangleAdjacency(m *Mesh) [][]orientLink {
+	type use struct {
+		tri int
+		dir bool
+	}
+	uses := map[segKey][]use{}
+	nt := m.TriangleCount()
+	for ti := 0; ti < nt; ti++ {
+		for k := 0; k < 3; k++ {
+			a, b := triEdge(m, ti, k)
+			key := weldSeg(a, b)
+			if len(uses[key]) < 2 {
+				uses[key] = append(uses[key], use{ti, quantLess(a, b)})
+			} else {
+				uses[key] = append(uses[key], use{-1, false}) // mark non-manifold (>2 uses)
+			}
+		}
+	}
+	adj := make([][]orientLink, nt)
+	for _, us := range uses {
+		if len(us) != 2 || us[0].tri < 0 || us[1].tri < 0 || us[0].tri == us[1].tri {
+			continue // boundary / non-manifold / self edge
+		}
+		flip := us[0].dir == us[1].dir
+		adj[us[0].tri] = append(adj[us[0].tri], orientLink{us[1].tri, flip})
+		adj[us[1].tri] = append(adj[us[1].tri], orientLink{us[0].tri, flip})
+	}
+	return adj
+}
+
+// triEdge returns the k-th directed edge (corner k → corner k+1) of triangle ti.
+func triEdge(m *Mesh, ti, k int) (math.Point3, math.Point3) {
+	return m.Positions[m.Indices[3*ti+k]], m.Positions[m.Indices[3*ti+(k+1)%3]]
+}
+
+// triVerts returns triangle ti's three corner points.
+func triVerts(m *Mesh, ti int) (math.Point3, math.Point3, math.Point3) {
+	return m.Positions[m.Indices[3*ti]], m.Positions[m.Indices[3*ti+1]], m.Positions[m.Indices[3*ti+2]]
+}
+
+// triangleParityVolume is the divergence-theorem signed volume of m with every parity-1 triangle's
+// winding flipped — the sign tells consistentOutwardFlips whether the whole component is inside-out.
+func triangleParityVolume(m *Mesh, parity []int) float64 {
+	vol := 0.0
+	for ti := 0; ti < m.TriangleCount(); ti++ {
+		a := math.Point3{}.VectorTo(m.Positions[m.Indices[3*ti]])
+		b := math.Point3{}.VectorTo(m.Positions[m.Indices[3*ti+1]])
+		c := math.Point3{}.VectorTo(m.Positions[m.Indices[3*ti+2]])
+		s := float64(a.Dot(b.Cross(c)))
+		if parity[ti] == 1 {
+			s = -s
+		}
+		vol += s / 6.0
+	}
+	return vol
+}

--- a/kernel/ops/tessellate.go
+++ b/kernel/ops/tessellate.go
@@ -170,8 +170,8 @@ func tessellateThreadedFace(f *topo.Face, s geom.ThreadedCylinder, q Quality) *M
 
 // reverseMesh flips a reversed face's sense (see topo.Face.Reversed): every outward normal
 // negates and every triangle's winding reverses, so the face presents its true material side
-// to shading and to the divergence-theorem volume (mass-properties orient triangles by these
-// per-vertex normals — see meshGeometryProperties).
+// to shading and to the divergence-theorem volume (mass-properties orient triangles by the
+// resulting shared-edge winding — see consistentOutwardFlips/meshGeometryProperties).
 func reverseMesh(m *Mesh) {
 	for i := range m.Normals {
 		m.Normals[i] = m.Normals[i].Scale(-1)


### PR DESCRIPTION
## What
Mass-properties (`meshGeometryProperties`) and inertia (`accumulateCovariance`) recovered each triangle's outward sense from the **sum of its three per-vertex shading normals**. This PR replaces that with the **topological 2-coloring orientation** the import-heal path already uses, applied at triangle granularity.

## Why
On coarse, high-curvature meshes (saddle bands, silhouette slivers) the three vertex normals diverge until their sum is nearly perpendicular to the facet. The sign of `outwardRef·geomNormal` is then dominated by floating-point noise → **random facet flips** → wrong signed volume/centroid/inertia. This was masking the divergence sum's real requirement (consistent topological winding).

## How
`consistentOutwardFlips(mesh)` welds shared vertices, 2-colours triangles across shared edges (neighbours traversing a shared edge in opposite directions agree), and fixes the single global sign by signed volume. Frustrated (non-orientable) facets are left as wound rather than guessed — mirroring `orientFacesOutward`'s rule. No dependence on shading normals.

## Validation
- Sphere volume `4/3·π·r³`, torus `2·π²·R·r²` — converge monotonically from below across qualities, no sign-flip spike; coarse error bounded by the shell bound `Area·chord`.
- Solid-sphere inertia `2/5·V·R²`, isotropic, products of inertia ≈ 0.
- Deliberately **inconsistently-wound** cube mesh with zeroed normals recovers exact `|V|=s³` and centroid — proving the orientation is connectivity-driven, not normal-driven.
- Full `./kernel/...` suite green; `TestVolumeIsTranslationInvariant` still passes.

Closes #1318