### PR TITLE
fix(ops): point-in-solid via generalized winding number (#1317)

### DIFF
--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -236,41 +236,29 @@ func classify(target, tool *topo.Body) relation {
 	return intersecting
 }
 
-// allVerticesInside reports whether every vertex of inner lies strictly within outer.
+// allVerticesInside reports whether every vertex of inner lies strictly within outer. It
+// tessellates outer ONCE and reuses that mesh for every vertex query (#1317) — previously each
+// vertex re-tessellated the whole body, making boolean classification O(V·T).
 func allVerticesInside(inner, outer *topo.Body) bool {
 	verts := inner.Vertices()
 	if len(verts) == 0 {
 		return false
 	}
+	mesh, _ := TessellateBody(outer, DefaultQuality())
 	for _, v := range verts {
-		if !PointInsideBody(outer, v.Point()) {
+		if !pointInMesh(mesh, v.Point()) {
 			return false
 		}
 	}
 	return true
 }
 
-// PointInsideBody reports whether p is inside a solid body, by casting a ray from p
-// and counting crossings of the body's tessellated faces (odd ⇒ inside). The ray
-// direction is skewed off the axes to avoid degenerate grazing hits.
+// PointInsideBody reports whether p is inside a solid body, via the generalized winding number of
+// the body's tessellation (see pointInMesh/windingNumber). This replaces the old single fixed-ray
+// parity test (#1317), which miscounted whenever the ray grazed a shared edge or vertex of the mesh
+// — ubiquitous on a closed surface — flipping the inside/outside result. The winding number
+// integrates the entire boundary, so it has no such degeneracy and tolerates small mesh cracks.
 func PointInsideBody(b *topo.Body, p math.Point3) bool {
 	mesh, _ := TessellateBody(b, DefaultQuality())
-	dir := math.V3(0.5773, 0.5774, 0.5775) // near-diagonal, non-axis-aligned
-	crossings := 0
-	for t := 0; t+2 < len(mesh.Indices); t += 3 {
-		a := mesh.Positions[mesh.Indices[t]]
-		q := mesh.Positions[mesh.Indices[t+1]]
-		r := mesh.Positions[mesh.Indices[t+2]]
-		if rayHitsTriangle(p, dir, a, q, r) {
-			crossings++
-		}
-	}
-	return crossings%2 == 1
-}
-
-// rayHitsTriangle reports whether the ray from orig along dir hits triangle abc at a
-// positive distance (Möller–Trumbore; shares rayTriangleDist with picking).
-func rayHitsTriangle(orig math.Point3, dir math.Vector3, a, b, c math.Point3) bool {
-	_, ok := rayTriangleDist(orig, dir, a, b, c)
-	return ok
+	return pointInMesh(mesh, p)
 }

--- a/kernel/ops/point_in_solid.go
+++ b/kernel/ops/point_in_solid.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// pointInsideWindingThreshold is the generalized-winding-number cutoff for "inside". For a closed,
+// outward-oriented mesh the winding number is ~1 strictly inside and ~0 strictly outside, crossing
+// 0.5 on the surface; the 0.5 cutoff is the maximally robust split and tolerates small mesh cracks
+// (a hairline gap perturbs the number by ≪0.5 rather than flipping a ray's parity).
+const pointInsideWindingThreshold = 0.5
+
+// windingNumber returns the generalized winding number of mesh around p (Jacobson, Kavan &
+// Sorkine, "Robust Inside-Outside Segmentation using Generalized Winding Numbers", SIGGRAPH 2013):
+// w(p) = (1/4π)·Σ signed_solid_angle(p; a,b,c). Unlike a single parity ray it has no grazing-edge or
+// grazing-vertex degeneracy (it integrates the whole boundary, it does not sample one direction) and
+// degrades gracefully on a cracked mesh. The mesh is expected outward-oriented — TessellateBody
+// already runs orientFacesOutward — so w≈+1 inside the solid material and ≈0 outside.
+func windingNumber(mesh *Mesh, p math.Point3) float64 {
+	sum := 0.0
+	for t := 0; t+2 < len(mesh.Indices); t += 3 {
+		a := mesh.Positions[mesh.Indices[t]]
+		b := mesh.Positions[mesh.Indices[t+1]]
+		c := mesh.Positions[mesh.Indices[t+2]]
+		sum += signedSolidAngle(p, a, b, c)
+	}
+	return sum / (4 * stdmath.Pi)
+}
+
+// signedSolidAngle returns the signed solid angle (steradians) that triangle (a,b,c) subtends at p,
+// via the Van Oosterom–Strackee atan2 formula (IEEE Trans. Biomed. Eng. 1983) — numerically stable
+// across the full sphere, including the back hemisphere where a naive arccos loses sign/precision.
+// The sign follows the triangle's winding (right-hand rule), so the sum over an outward mesh is +4π
+// inside and 0 outside. A degenerate triangle, or p coincident with a corner, contributes 0.
+func signedSolidAngle(p, a, b, c math.Point3) float64 {
+	va, vb, vc := p.VectorTo(a), p.VectorTo(b), p.VectorTo(c)
+	la, lb, lc := va.Length(), vb.Length(), vc.Length()
+	if la == 0 || lb == 0 || lc == 0 {
+		return 0
+	}
+	num := float64(va.Dot(vb.Cross(vc)))
+	den := float64(la*lb*lc) + float64(va.Dot(vb))*float64(lc) +
+		float64(vb.Dot(vc))*float64(la) + float64(vc.Dot(va))*float64(lb)
+	return 2 * stdmath.Atan2(num, den)
+}
+
+// pointInMesh reports whether p lies inside the solid bounded by an outward-oriented mesh, by
+// thresholding the generalized winding number. Hoisting the (already-tessellated) mesh in keeps a
+// multi-point query — e.g. classifying every vertex of one operand against another — at O(points·tris)
+// without re-tessellating per point (the cost that made allVerticesInside O(V·T) before #1317).
+func pointInMesh(mesh *Mesh, p math.Point3) bool {
+	return windingNumber(mesh, p) > pointInsideWindingThreshold
+}

--- a/kernel/ops/point_in_solid_test.go
+++ b/kernel/ops/point_in_solid_test.go
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	m "oblikovati.org/math"
+)
+
+// Regression suite for Oblikovati/Oblikovati#1317: point-in-solid was a single fixed-ray parity test
+// that miscounted on grazing edges/vertices (ubiquitous on a closed mesh) and re-tessellated per call.
+// It is now the generalized winding number (pointInMesh/windingNumber).
+
+// TestSignedSolidAngleClosedMeshIsQuantized verifies the core identity the winding number rests on:
+// the signed solid angle summed over a closed outward mesh is 4π at an interior point and 0 at an
+// exterior point (winding 1 vs 0).
+func TestSignedSolidAngleClosedMeshIsQuantized(t *testing.T) {
+	cube, err := brep.SolidBlock(m.P3(0, 0, 0), m.P3(2, 2, 2), "cube")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	mesh, _ := TessellateBody(cube, DefaultQuality())
+	if w := windingNumber(mesh, m.P3(1, 1, 1)); math.Abs(w-1) > 1e-6 {
+		t.Errorf("interior winding = %g, want 1", w)
+	}
+	if w := windingNumber(mesh, m.P3(5, 5, 5)); math.Abs(w) > 1e-6 {
+		t.Errorf("exterior winding = %g, want 0", w)
+	}
+}
+
+// TestPointInsideRayThroughCornerIsRobust is the direct degeneracy regression: a cube centred so the
+// OLD skewed ray (0.5773,0.5774,0.5775) from the interior point passes essentially through the cube's
+// far CORNER (a vertex shared by three faces), the exact case that made the single ray miscount.
+func TestPointInsideRayThroughCornerIsRobust(t *testing.T) {
+	// Cube [0,2]^3: centre (1,1,1); (1,1,1)+t·(0.5773,0.5774,0.5775) reaches the corner (2,2,2).
+	cube, err := brep.SolidBlock(m.P3(0, 0, 0), m.P3(2, 2, 2), "cube")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	if !PointInsideBody(cube, m.P3(1, 1, 1)) {
+		t.Error("centre of cube classified outside — the corner-grazing ray degeneracy is not handled")
+	}
+	if PointInsideBody(cube, m.P3(3, 3, 3)) {
+		t.Error("far point classified inside")
+	}
+}
+
+// TestPointInsideCubeFacePlanes checks classification just inside and just outside the plane of each
+// cube face — points the surface-grazing ray handled poorly.
+func TestPointInsideCubeFacePlanes(t *testing.T) {
+	cube, err := brep.SolidBlock(m.P3(0, 0, 0), m.P3(2, 2, 2), "cube")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	const eps = 1e-4
+	cases := []struct {
+		p    m.Point3
+		want bool
+	}{
+		{m.P3(eps, 1, 1), true}, {m.P3(-eps, 1, 1), false},
+		{m.P3(2-eps, 1, 1), true}, {m.P3(2+eps, 1, 1), false},
+		{m.P3(1, eps, 1), true}, {m.P3(1, -eps, 1), false},
+		{m.P3(1, 1, 2-eps), true}, {m.P3(1, 1, 2+eps), false},
+	}
+	for _, c := range cases {
+		if got := PointInsideBody(cube, c.p); got != c.want {
+			t.Errorf("PointInsideBody(%v) = %v, want %v", c.p, got, c.want)
+		}
+	}
+}
+
+// TestSphereContainmentMatchesAnalytic stress-tests the winding number against the analytic sphere
+// membership |p-c| < r over many random points, requiring 100% agreement outside a thin surface shell.
+func TestSphereContainmentMatchesAnalytic(t *testing.T) {
+	const r = 3.0
+	center := m.P3(0, 0, 0)
+	sphere, err := brep.SolidSphere(center, r, "sphere")
+	if err != nil {
+		t.Fatalf("SolidSphere: %v", err)
+	}
+	mesh, _ := TessellateBody(sphere, Quality{ChordTolerance: 0.02, AngleTolerance: 5 * math.Pi / 180})
+	shell := 0.1 // exclude points within this band of the surface (chord/sagitta ambiguity)
+	rng := rand.New(rand.NewSource(1317))
+	tested, mism := 0, 0
+	for i := 0; i < 4000; i++ {
+		p := m.P3(m.Scalar(rng.Float64()*8-4), m.Scalar(rng.Float64()*8-4), m.Scalar(rng.Float64()*8-4))
+		d := float64(p.DistanceTo(center))
+		if math.Abs(d-r) < shell {
+			continue
+		}
+		tested++
+		if pointInMesh(mesh, p) != (d < r) {
+			mism++
+		}
+	}
+	if tested < 1000 {
+		t.Fatalf("too few points tested: %d", tested)
+	}
+	if mism != 0 {
+		t.Errorf("%d/%d sphere classifications disagree with analytic membership", mism, tested)
+	}
+}
+
+// insideTorus is the analytic membership for a torus about +Z at the origin: the point is inside the
+// tube when its distance from the central circle of radius major is below the tube radius minor.
+func insideTorus(p m.Point3, major, minor float64) bool {
+	rho := math.Hypot(float64(p.X), float64(p.Y))
+	return (rho-major)*(rho-major)+float64(p.Z)*float64(p.Z) < minor*minor
+}
+
+// TestTorusContainmentMatchesAnalytic validates the winding number on a genuinely NON-CONVEX solid
+// (a torus — its hole means many exterior points sit "between" surface patches, defeating any
+// vertex-only or single-ray test). Compared against the analytic torus membership over random points.
+func TestTorusContainmentMatchesAnalytic(t *testing.T) {
+	const major, minor = 5.0, 1.5
+	torus, err := brep.SolidTorus(m.P3(0, 0, 0), m.V3(0, 0, 1), major, minor, "torus")
+	if err != nil {
+		t.Fatalf("SolidTorus: %v", err)
+	}
+	mesh, _ := TessellateBody(torus, Quality{ChordTolerance: 0.02, AngleTolerance: 4 * math.Pi / 180})
+	// Sanity: the axis centre and the hole are OUTSIDE the solid; the tube core is INSIDE.
+	if pointInMesh(mesh, m.P3(0, 0, 0)) {
+		t.Error("torus axis centre classified inside (it is in the hole)")
+	}
+	if !pointInMesh(mesh, m.P3(major, 0, 0)) {
+		t.Error("torus tube core classified outside")
+	}
+	rng := rand.New(rand.NewSource(424242))
+	tested, mism := 0, 0
+	for i := 0; i < 6000; i++ {
+		p := m.P3(m.Scalar(rng.Float64()*16-8), m.Scalar(rng.Float64()*16-8), m.Scalar(rng.Float64()*4-2))
+		// Exclude a shell band where faceting vs analytic legitimately disagree.
+		rho := math.Hypot(float64(p.X), float64(p.Y))
+		band := (rho-major)*(rho-major) + float64(p.Z)*float64(p.Z)
+		if math.Abs(math.Sqrt(band)-minor) < 0.12 {
+			continue
+		}
+		tested++
+		if pointInMesh(mesh, p) != insideTorus(p, major, minor) {
+			mism++
+		}
+	}
+	if tested < 1500 {
+		t.Fatalf("too few points tested: %d", tested)
+	}
+	if mism != 0 {
+		t.Errorf("%d/%d torus classifications disagree with analytic membership", mism, tested)
+	}
+}
+
+// TestSignedSolidAngleDegenerate locks the degenerate guards: a query point coincident with a
+// triangle corner, and a zero-area triangle, both contribute 0 (no NaN/Inf from a 0-length vector).
+func TestSignedSolidAngleDegenerate(t *testing.T) {
+	a, b, c := m.P3(0, 0, 0), m.P3(1, 0, 0), m.P3(0, 1, 0)
+	if w := signedSolidAngle(a, a, b, c); w != 0 {
+		t.Errorf("solid angle at coincident corner = %g, want 0", w)
+	}
+	if w := signedSolidAngle(m.P3(0, 0, 1), a, a, a); math.Abs(w) > 1e-12 {
+		t.Errorf("solid angle of degenerate triangle = %g, want 0", w)
+	}
+}
+
+// TestAllVerticesInsideCubeInCube confirms allVerticesInside (the boolean classifier helper) is
+// correct for nested and non-nested convex bodies — and, with the tessellation hoisted, returns the
+// same verdicts as before for the cases the boolean relies on.
+func TestAllVerticesInsideCubeInCube(t *testing.T) {
+	outer, err := brep.SolidBlock(m.P3(0, 0, 0), m.P3(10, 10, 10), "outer")
+	if err != nil {
+		t.Fatalf("outer: %v", err)
+	}
+	inner, err := brep.SolidBlock(m.P3(3, 3, 3), m.P3(6, 6, 6), "inner")
+	if err != nil {
+		t.Fatalf("inner: %v", err)
+	}
+	if !allVerticesInside(inner, outer) {
+		t.Error("inner cube vertices should all be inside outer cube")
+	}
+	if allVerticesInside(outer, inner) {
+		t.Error("outer cube vertices should not be inside inner cube")
+	}
+	apart, err := brep.SolidBlock(m.P3(20, 20, 20), m.P3(22, 22, 22), "apart")
+	if err != nil {
+		t.Fatalf("apart: %v", err)
+	}
+	if allVerticesInside(apart, outer) {
+		t.Error("disjoint cube vertices should not be inside outer cube")
+	}
+}

--- a/kernel/ops/shell_query.go
+++ b/kernel/ops/shell_query.go
@@ -82,10 +82,12 @@ func BodyContainment(b *topo.Body, p math.Point3, q Quality, onTol float64) Poin
 	return meshContainment(mesh, p, onTol)
 }
 
-// meshContainment is the shared mesh-level classifier.
+// meshContainment is the shared mesh-level classifier: ON when p is within onTol of any facet, else
+// INSIDE/OUTSIDE by the generalized winding number (pointInMesh). The winding number replaces the
+// former skewed parity ray (#1317) — robust to grazing edges/vertices — and still gives the right
+// cavity verdict: an outer shell contributes +1 and a void shell −1, so a point in a cavity sums to
+// 0 (outside the material), exactly as the old crossing-cancellation intended.
 func meshContainment(mesh *Mesh, p math.Point3, onTol float64) PointContainment {
-	dir := math.V3(0.5773, 0.5774, 0.5775) // same skewed ray as PointInsideBody
-	crossings := 0
 	for t := 0; t+2 < len(mesh.Indices); t += 3 {
 		a := mesh.Positions[mesh.Indices[t]]
 		b := mesh.Positions[mesh.Indices[t+1]]
@@ -93,11 +95,8 @@ func meshContainment(mesh *Mesh, p math.Point3, onTol float64) PointContainment 
 		if pointTriangleDistance(p, a, b, c) <= onTol {
 			return ContainOn
 		}
-		if rayHitsTriangle(p, dir, a, b, c) {
-			crossings++
-		}
 	}
-	if crossings%2 == 1 {
+	if pointInMesh(mesh, p) {
 		return ContainInside
 	}
 	return ContainOutside


### PR DESCRIPTION
## What
Replaces the single fixed-ray parity test in `PointInsideBody` (and the same ray in `meshContainment`) with the **generalized winding number**, and hoists the tessellation out of the per-vertex loop in `allVerticesInside`.

## Why
1. **Robustness:** a single skewed ray miscounts whenever it grazes a shared edge or vertex of the mesh — these are everywhere on a closed surface — flipping inside/outside, with no degeneracy retry.
2. **Complexity:** `TessellateBody` was called *inside* `PointInsideBody`, so classifying one operand re-tessellated the target once per vertex (O(V·T)).

## How
`w(p) = (1/4π)·Σ signed_solid_angle(p; a,b,c)` (Jacobson, Kavan & Sorkine, SIGGRAPH 2013), the signed solid angle via the Van Oosterom–Strackee `atan2` formula (stable across the full sphere). It integrates the entire boundary, so there is no grazing degeneracy and it tolerates small mesh cracks; inside ⇔ `w > 0.5`. `allVerticesInside` tessellates the outer body once and reuses the mesh. `meshContainment` is routed through the same number — preserving the cavity verdict (outer shell +1, void shell −1 ⇒ 0 inside a cavity) and deleting the duplicated skewed ray.

## Validation
- Cube: interior winding == 1, exterior == 0; the **corner-grazing-ray** degeneracy that broke the old test now classifies correctly; just-inside/just-outside each face plane.
- Stress: 4000 random points vs analytic sphere membership, and 6000 random points vs analytic **non-convex torus** membership — 100% agreement outside a thin shell band.
- Degenerate guards (point on a corner, zero-area triangle) contribute 0, no NaN.
- Full `./kernel/...` and `./model/...` suites green (fillet, boolean, shell consumers unaffected).

Closes #1317