### PR TITLE
fix(ops): require no boundary crossing for boolean containment (#1315)

### DIFF
--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -220,20 +220,29 @@ const (
 	intersecting
 )
 
-// classify determines the spatial relationship from bounding boxes and vertex
-// containment. It recognizes the cases that combine without face splitting (disjoint,
-// or one body containing the other); anything else is reported as intersecting.
+// classify determines the spatial relationship from bounding boxes and containment. It recognizes
+// the cases that combine without face splitting (disjoint, or one body strictly containing the
+// other); anything else is reported as intersecting and routed to the general face-splitting boolean.
 func classify(target, tool *topo.Body) relation {
 	if !target.RangeBox().Intersects(tool.RangeBox()) {
 		return disjoint
 	}
-	if allVerticesInside(tool, target) {
+	if strictlyContains(target, tool) {
 		return targetContainsTool
 	}
-	if allVerticesInside(target, tool) {
+	if strictlyContains(tool, target) {
 		return toolContainsTarget
 	}
 	return intersecting
+}
+
+// strictlyContains reports whether outer fully contains inner: every vertex of inner lies inside
+// outer AND the two boundaries do not cross. The boundary-crossing condition is essential — vertex
+// containment alone is unsound for non-convex bodies, where inner's surface can pass back out through
+// outer between inner's vertices (#1315). Without it such a pair skips face splitting and returns a
+// silently wrong solid. The crossing test runs only after the (cheap) vertex test passes.
+func strictlyContains(outer, inner *topo.Body) bool {
+	return allVerticesInside(inner, outer) && !boundariesCross(outer, inner)
 }
 
 // allVerticesInside reports whether every vertex of inner lies strictly within outer. It

--- a/kernel/ops/boolean_nonconvex_test.go
+++ b/kernel/ops/boolean_nonconvex_test.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/subd"
+	"oblikovati.org/kernel/topo"
+	m "oblikovati.org/math"
+)
+
+// Regression for Oblikovati/Oblikovati#1315: classify decided containment from vertex-in-solid only,
+// which is unsound for non-convex bodies. The fixture below is the canonical counterexample — every
+// vertex of the inner body lies inside the outer body's MATERIAL, yet the inner body crosses the
+// outer's boundary, so the pair must be classified `intersecting`, not contained.
+
+// zPrism extrudes a closed XY polygon between z0 and z1 into a solid prism (winding per the proven
+// brep prismBody helper: bottom reversed, top forward, quad sides).
+func zPrism(poly []m.Point2, z0, z1 float64, feat string) *topo.Body {
+	n := len(poly)
+	verts := make([]m.Point3, 0, n*2)
+	for _, p := range poly {
+		verts = append(verts, m.P3(p.X, p.Y, m.Scalar(z0)))
+	}
+	for _, p := range poly {
+		verts = append(verts, m.P3(p.X, p.Y, m.Scalar(z1)))
+	}
+	bottom, top := make([]int, n), make([]int, n)
+	for i := range poly {
+		bottom[i] = n - 1 - i
+		top[i] = n + i
+	}
+	faces := [][]int{bottom, top}
+	for i := range poly {
+		next := (i + 1) % n
+		faces = append(faces, []int{i, next, next + n, i + n})
+	}
+	return subd.ToBody(subd.Mesh{Verts: verts, Faces: faces}, feat)
+}
+
+// uSlotPrism builds the U-shaped outer body: the block [0,10]x[0,10] with the top-centre slot
+// [3,7]x[4,10] removed, extruded z in [0,4]. Material volume = (100-24)*4 = 304.
+func uSlotPrism() *topo.Body {
+	poly := []m.Point2{
+		m.P2(0, 0), m.P2(10, 0), m.P2(10, 10),
+		m.P2(7, 10), m.P2(7, 4), m.P2(3, 4), m.P2(3, 10), m.P2(0, 10),
+	}
+	return zPrism(poly, 0, 4, "u-slot")
+}
+
+// TestClassifyNonConvexVertexInsideButBoundaryCrosses is the core #1315 assertion: the bar's eight
+// corners all lie in the U's two arms (inside its material), but the bar spans the empty slot and so
+// crosses the slot walls. classify must report `intersecting`, not targetContainsTool.
+func TestClassifyNonConvexVertexInsideButBoundaryCrosses(t *testing.T) {
+	outer := uSlotPrism()
+	bar, err := brep.SolidBlock(m.P3(2, 5.5, 1), m.P3(8, 6.5, 3), "bar")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	// Precondition: every vertex of the bar is inside the U's material (the unsound test passes).
+	if !allVerticesInside(bar, outer) {
+		t.Fatal("test premise broken: not all bar vertices are inside the U material")
+	}
+	// Precondition: the boundaries genuinely cross (the bar pierces the slot walls).
+	if !boundariesCross(outer, bar) {
+		t.Fatal("test premise broken: boundaries do not cross")
+	}
+	if rel := classify(outer, bar); rel != intersecting {
+		t.Errorf("classify = %v, want intersecting (vertex-only containment is unsound here)", rel)
+	}
+	if rel := classify(bar, outer); rel != intersecting {
+		t.Errorf("classify(bar,outer) = %v, want intersecting", rel)
+	}
+}
+
+// TestNonConvexJoinVolumeMatchesAnalytic checks the boolean now routed through booleanGeneral yields
+// the correct union volume: V(A) + V(B) - V(A∩B) = 304 + 12 - 4 = 312.
+func TestNonConvexJoinVolumeMatchesAnalytic(t *testing.T) {
+	outer := uSlotPrism()
+	bar, err := brep.SolidBlock(m.P3(2, 5.5, 1), m.P3(8, 6.5, 3), "bar")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	joined, err := Boolean(Join, outer, bar)
+	if err != nil {
+		t.Fatalf("Boolean(Join): %v", err)
+	}
+	got := BodyGeometryProperties(joined, DefaultQuality()).Volume
+	const want = 312.0
+	if math.Abs(got-want) > 1e-6*want {
+		t.Errorf("union volume = %g, want %g", got, want)
+	}
+	if !validBooleanSolid(joined) {
+		t.Errorf("union is not a valid closed manifold solid")
+	}
+}
+
+// TestGenuineContainmentStillFastPaths guards against a perf/behaviour regression: a strictly interior
+// tool (no boundary crossing) must still be recognized as contained, taking the fast path.
+func TestGenuineContainmentStillFastPaths(t *testing.T) {
+	outer, err := brep.SolidBlock(m.P3(0, 0, 0), m.P3(10, 10, 10), "outer")
+	if err != nil {
+		t.Fatalf("outer: %v", err)
+	}
+	inner, err := brep.SolidBlock(m.P3(3, 3, 3), m.P3(6, 6, 6), "inner")
+	if err != nil {
+		t.Fatalf("inner: %v", err)
+	}
+	if rel := classify(outer, inner); rel != targetContainsTool {
+		t.Errorf("classify = %v, want targetContainsTool (strict interior)", rel)
+	}
+	if boundariesCross(outer, inner) {
+		t.Error("strictly interior tool should not cross the outer boundary")
+	}
+}

--- a/kernel/ops/boundary_cross.go
+++ b/kernel/ops/boundary_cross.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// boundariesCross reports whether the boundary (tessellated surface) of body a crosses the boundary
+// of body b. It is the missing half of containment classification (#1315): all-vertices-inside does
+// NOT imply containment for non-convex operands — an edge or face of the inner body can pass back out
+// through the outer body BETWEEN the inner's vertices — so a boundary crossing must demote the pair to
+// the general face-splitting boolean instead of the (wrong) contains-fast-path.
+//
+// Each body is tessellated once; the O(Ta·Tb) triangle-pair scan is AABB-culled per triangle, and the
+// whole test runs only after allVerticesInside already passed (the candidate-containment case), so it
+// never burdens the common intersecting path, which exits classify earlier.
+func boundariesCross(a, b *topo.Body) bool {
+	ma, _ := TessellateBody(a, DefaultQuality())
+	mb, _ := TessellateBody(b, DefaultQuality())
+	return meshesCrossBounded(ma, mb)
+}
+
+// meshesCrossBounded reports whether any triangle of a crosses any triangle of b, culling triangle
+// pairs by their axis-aligned bounding boxes before the exact Möller test (trianglesIntersect).
+func meshesCrossBounded(a, b *Mesh) bool {
+	boxesB := triangleBoxes(b)
+	for i := 0; i+2 < len(a.Indices); i += 3 {
+		ta := meshTriangle(a, i)
+		boxA := math.BoxFromPoints(ta[0], ta[1], ta[2])
+		for j := 0; j+2 < len(b.Indices); j += 3 {
+			if !boxA.Intersects(boxesB[j/3]) {
+				continue
+			}
+			if _, hit := trianglesIntersect(ta, meshTriangle(b, j)); hit {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// triangleBoxes precomputes the AABB of every triangle of m for the cull above.
+func triangleBoxes(m *Mesh) []math.Box {
+	boxes := make([]math.Box, 0, m.TriangleCount())
+	for i := 0; i+2 < len(m.Indices); i += 3 {
+		t := meshTriangle(m, i)
+		boxes = append(boxes, math.BoxFromPoints(t[0], t[1], t[2]))
+	}
+	return boxes
+}


### PR DESCRIPTION
> Stacked on #1325 (H3). Base will retarget to `develop` once #1325 merges.

## What
`classify` decided "one body contains the other" from **vertex-in-solid alone**. This PR additionally requires that the two boundaries do **not** cross before claiming containment.

## Why
All-vertices-inside ⇏ containment for non-convex bodies: an edge or face of the inner body can pass back out through the outer body **between** the inner's vertices. Such pairs were classified as contained, skipped the general face-splitting boolean, and returned a **silently wrong** solid.

## How
`boundariesCross(a, b)` tessellates both bodies once and tests their triangles for intersection (Möller, reusing `trianglesIntersect`), AABB-culled per triangle. `strictlyContains` = `allVerticesInside && !boundariesCross`. The crossing test runs only after the cheap vertex test passes, so the common intersecting path is unaffected.

## Validation
- **Canonical counterexample:** a U-slot prism whose slot is spanned by a bar — all eight bar vertices lie in the U's arms (material), yet the bar crosses the slot walls. `classify` now returns `intersecting` (was `targetContainsTool`).
- **Volume oracle:** the same pair's `Join` yields the exact analytic union volume `304 + 12 − 4 = 312`, and validates as a closed manifold solid — confirming the boolean engine was always correct; the bug was purely classification.
- Genuine strict-interior containment still fast-paths (no perf regression).
- 100% coverage on the new functions; full `./kernel/...` + `./model/...` green.

Closes #1315