### PR TITLE
fix(ops): resolve nested-body Join/Intersect, no interior wall (#1316)

### DIFF
--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -51,14 +51,29 @@ func Boolean(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, erro
 	rel := classify(target, tool)
 	switch op {
 	case Join:
-		if rel == intersecting {
-			return booleanGeneral(op, target, tool, lin)
-		}
-		return topo.MergeBodies(lin, true, target, tool), nil
+		return join(lin, target, tool, rel)
 	case Cut:
 		return cut(lin, target, tool, rel)
 	default: // Intersect
 		return intersect(lin, target, tool, rel)
+	}
+}
+
+// join combines target and tool under A ∪ B. When one body strictly contains the other (classify
+// guarantees no boundary crossing — see strictlyContains, #1315), the union IS the outer body, so the
+// inner shell is discarded rather than kept as a floating interior wall — the old MergeBodies path
+// concatenated both shells and double-counted the volume (#1316). Disjoint bodies merge into one
+// multi-lump body (each a separate valid shell); intersecting bodies go to the face-splitting boolean.
+func join(lin topo.Lineage, target, tool *topo.Body, rel relation) (*topo.Body, error) {
+	switch rel {
+	case targetContainsTool:
+		return target, nil // tool lies inside target → union is target alone
+	case toolContainsTarget:
+		return tool, nil
+	case intersecting:
+		return booleanGeneral(Join, target, tool, lin)
+	default: // disjoint: two separate lumps form a valid multi-shell body
+		return topo.MergeBodies(lin, true, target, tool), nil
 	}
 }
 

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -220,20 +220,29 @@ const (
 	intersecting
 )
 
-// classify determines the spatial relationship from bounding boxes and vertex
-// containment. It recognizes the cases that combine without face splitting (disjoint,
-// or one body containing the other); anything else is reported as intersecting.
+// classify determines the spatial relationship from bounding boxes and containment. It recognizes
+// the cases that combine without face splitting (disjoint, or one body strictly containing the
+// other); anything else is reported as intersecting and routed to the general face-splitting boolean.
 func classify(target, tool *topo.Body) relation {
 	if !target.RangeBox().Intersects(tool.RangeBox()) {
 		return disjoint
 	}
-	if allVerticesInside(tool, target) {
+	if strictlyContains(target, tool) {
 		return targetContainsTool
 	}
-	if allVerticesInside(target, tool) {
+	if strictlyContains(tool, target) {
 		return toolContainsTarget
 	}
 	return intersecting
+}
+
+// strictlyContains reports whether outer fully contains inner: every vertex of inner lies inside
+// outer AND the two boundaries do not cross. The boundary-crossing condition is essential — vertex
+// containment alone is unsound for non-convex bodies, where inner's surface can pass back out through
+// outer between inner's vertices (#1315). Without it such a pair skips face splitting and returns a
+// silently wrong solid. The crossing test runs only after the (cheap) vertex test passes.
+func strictlyContains(outer, inner *topo.Body) bool {
+	return allVerticesInside(inner, outer) && !boundariesCross(outer, inner)
 }
 
 // allVerticesInside reports whether every vertex of inner lies strictly within outer. It

--- a/kernel/ops/boolean_nested_test.go
+++ b/kernel/ops/boolean_nested_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/topo"
+	m "oblikovati.org/math"
+)
+
+// Regression for Oblikovati/Oblikovati#1316: Join/Intersect of nested bodies used to concatenate
+// shells (MergeBodies), leaving the inner shell as a floating interior wall — an invalid solid whose
+// reported volume double-counted the inner body. The union of nested solids is just the outer body.
+
+// nestedCubes returns a large outer cube and a small inner cube strictly inside it, both offset by
+// `shift` so the divergence-sum origin sensitivity is exercised (translation invariance).
+func nestedCubes(t *testing.T, shift float64) (outer, inner *topo.Body) {
+	t.Helper()
+	s := m.Scalar(shift)
+	var err error
+	outer, err = brep.SolidBlock(m.P3(s, s, s), m.P3(s+10, s+10, s+10), "outer")
+	if err != nil {
+		t.Fatalf("outer: %v", err)
+	}
+	inner, err = brep.SolidBlock(m.P3(s+3, s+3, s+3), m.P3(s+6, s+6, s+6), "inner")
+	if err != nil {
+		t.Fatalf("inner: %v", err)
+	}
+	return outer, inner
+}
+
+// TestJoinNestedReturnsOuterOnly asserts Join(outer, inner) with inner ⊂ outer is exactly the outer
+// body: outer's volume (1000, not 1027), outer's six faces (no interior wall), and a valid solid.
+func TestJoinNestedReturnsOuterOnly(t *testing.T) {
+	outer, inner := nestedCubes(t, 0)
+	joined, err := Boolean(Join, outer, inner)
+	if err != nil {
+		t.Fatalf("Boolean(Join): %v", err)
+	}
+	if got := BodyGeometryProperties(joined, DefaultQuality()).Volume; math.Abs(got-1000) > 1e-6 {
+		t.Errorf("union volume = %g, want 1000 (no double-counted inner shell)", got)
+	}
+	if nf := len(joined.Faces()); nf != 6 {
+		t.Errorf("union face count = %d, want 6 (no interior wall)", nf)
+	}
+	if !validBooleanSolid(joined) {
+		t.Errorf("union is not a valid closed manifold solid")
+	}
+	if r := Validate(joined); !r.Closed || !r.Manifold {
+		t.Errorf("union not closed/manifold: %+v", r)
+	}
+}
+
+// TestJoinNestedToolContainsTargetReturnsTool covers the mirror branch: when the TOOL contains the
+// target, the union is the tool. Volume is the outer cube's (1000), with no interior wall.
+func TestJoinNestedToolContainsTargetReturnsTool(t *testing.T) {
+	outer, inner := nestedCubes(t, 0)
+	joined, err := Boolean(Join, inner, outer) // target=inner (small), tool=outer (large)
+	if err != nil {
+		t.Fatalf("Boolean(Join): %v", err)
+	}
+	if got := BodyGeometryProperties(joined, DefaultQuality()).Volume; math.Abs(got-1000) > 1e-6 {
+		t.Errorf("union volume = %g, want 1000", got)
+	}
+	if nf := len(joined.Faces()); nf != 6 {
+		t.Errorf("union face count = %d, want 6", nf)
+	}
+}
+
+// TestIntersectNestedReturnsInner asserts Intersect(outer, inner) with inner ⊂ outer is the inner
+// body's geometry (volume 27).
+func TestIntersectNestedReturnsInner(t *testing.T) {
+	outer, inner := nestedCubes(t, 0)
+	got, err := Boolean(Intersect, outer, inner)
+	if err != nil {
+		t.Fatalf("Boolean(Intersect): %v", err)
+	}
+	if v := BodyGeometryProperties(got, DefaultQuality()).Volume; math.Abs(v-27) > 1e-6 {
+		t.Errorf("intersection volume = %g, want 27", v)
+	}
+	if !validBooleanSolid(got) {
+		t.Errorf("intersection is not a valid closed manifold solid")
+	}
+}
+
+// TestJoinNestedTranslationInvariant repeats the nested Join far from the origin: the result volume
+// must be unchanged, guarding both the shell-discard fix and the divergence-sum origin handling.
+func TestJoinNestedTranslationInvariant(t *testing.T) {
+	for _, shift := range []float64{0, 500, -250} {
+		outer, inner := nestedCubes(t, shift)
+		joined, err := Boolean(Join, outer, inner)
+		if err != nil {
+			t.Fatalf("shift %g: Boolean(Join): %v", shift, err)
+		}
+		if got := BodyGeometryProperties(joined, DefaultQuality()).Volume; math.Abs(got-1000) > 1e-6 {
+			t.Errorf("shift %g: union volume = %g, want 1000", shift, got)
+		}
+	}
+}
+
+// TestCutNestedToolInsideRemovesCavity confirms Cut still routes correctly: cutting an interior tool
+// from the target produces a body with a cavity (volume 1000-27 = 973) and remains valid.
+func TestCutNestedToolInsideRemovesCavity(t *testing.T) {
+	outer, inner := nestedCubes(t, 0)
+	got, err := Boolean(Cut, outer, inner)
+	if err != nil {
+		t.Fatalf("Boolean(Cut): %v", err)
+	}
+	if v := BodyGeometryProperties(got, DefaultQuality()).Volume; math.Abs(v-973) > 1e-6 {
+		t.Errorf("cut volume = %g, want 973 (outer minus interior cavity)", v)
+	}
+}

--- a/kernel/ops/boolean_nonconvex_test.go
+++ b/kernel/ops/boolean_nonconvex_test.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/subd"
+	"oblikovati.org/kernel/topo"
+	m "oblikovati.org/math"
+)
+
+// Regression for Oblikovati/Oblikovati#1315: classify decided containment from vertex-in-solid only,
+// which is unsound for non-convex bodies. The fixture below is the canonical counterexample — every
+// vertex of the inner body lies inside the outer body's MATERIAL, yet the inner body crosses the
+// outer's boundary, so the pair must be classified `intersecting`, not contained.
+
+// zPrism extrudes a closed XY polygon between z0 and z1 into a solid prism (winding per the proven
+// brep prismBody helper: bottom reversed, top forward, quad sides).
+func zPrism(poly []m.Point2, z0, z1 float64, feat string) *topo.Body {
+	n := len(poly)
+	verts := make([]m.Point3, 0, n*2)
+	for _, p := range poly {
+		verts = append(verts, m.P3(p.X, p.Y, m.Scalar(z0)))
+	}
+	for _, p := range poly {
+		verts = append(verts, m.P3(p.X, p.Y, m.Scalar(z1)))
+	}
+	bottom, top := make([]int, n), make([]int, n)
+	for i := range poly {
+		bottom[i] = n - 1 - i
+		top[i] = n + i
+	}
+	faces := [][]int{bottom, top}
+	for i := range poly {
+		next := (i + 1) % n
+		faces = append(faces, []int{i, next, next + n, i + n})
+	}
+	return subd.ToBody(subd.Mesh{Verts: verts, Faces: faces}, feat)
+}
+
+// uSlotPrism builds the U-shaped outer body: the block [0,10]x[0,10] with the top-centre slot
+// [3,7]x[4,10] removed, extruded z in [0,4]. Material volume = (100-24)*4 = 304.
+func uSlotPrism() *topo.Body {
+	poly := []m.Point2{
+		m.P2(0, 0), m.P2(10, 0), m.P2(10, 10),
+		m.P2(7, 10), m.P2(7, 4), m.P2(3, 4), m.P2(3, 10), m.P2(0, 10),
+	}
+	return zPrism(poly, 0, 4, "u-slot")
+}
+
+// TestClassifyNonConvexVertexInsideButBoundaryCrosses is the core #1315 assertion: the bar's eight
+// corners all lie in the U's two arms (inside its material), but the bar spans the empty slot and so
+// crosses the slot walls. classify must report `intersecting`, not targetContainsTool.
+func TestClassifyNonConvexVertexInsideButBoundaryCrosses(t *testing.T) {
+	outer := uSlotPrism()
+	bar, err := brep.SolidBlock(m.P3(2, 5.5, 1), m.P3(8, 6.5, 3), "bar")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	// Precondition: every vertex of the bar is inside the U's material (the unsound test passes).
+	if !allVerticesInside(bar, outer) {
+		t.Fatal("test premise broken: not all bar vertices are inside the U material")
+	}
+	// Precondition: the boundaries genuinely cross (the bar pierces the slot walls).
+	if !boundariesCross(outer, bar) {
+		t.Fatal("test premise broken: boundaries do not cross")
+	}
+	if rel := classify(outer, bar); rel != intersecting {
+		t.Errorf("classify = %v, want intersecting (vertex-only containment is unsound here)", rel)
+	}
+	if rel := classify(bar, outer); rel != intersecting {
+		t.Errorf("classify(bar,outer) = %v, want intersecting", rel)
+	}
+}
+
+// TestNonConvexJoinVolumeMatchesAnalytic checks the boolean now routed through booleanGeneral yields
+// the correct union volume: V(A) + V(B) - V(A∩B) = 304 + 12 - 4 = 312.
+func TestNonConvexJoinVolumeMatchesAnalytic(t *testing.T) {
+	outer := uSlotPrism()
+	bar, err := brep.SolidBlock(m.P3(2, 5.5, 1), m.P3(8, 6.5, 3), "bar")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	joined, err := Boolean(Join, outer, bar)
+	if err != nil {
+		t.Fatalf("Boolean(Join): %v", err)
+	}
+	got := BodyGeometryProperties(joined, DefaultQuality()).Volume
+	const want = 312.0
+	if math.Abs(got-want) > 1e-6*want {
+		t.Errorf("union volume = %g, want %g", got, want)
+	}
+	if !validBooleanSolid(joined) {
+		t.Errorf("union is not a valid closed manifold solid")
+	}
+}
+
+// TestGenuineContainmentStillFastPaths guards against a perf/behaviour regression: a strictly interior
+// tool (no boundary crossing) must still be recognized as contained, taking the fast path.
+func TestGenuineContainmentStillFastPaths(t *testing.T) {
+	outer, err := brep.SolidBlock(m.P3(0, 0, 0), m.P3(10, 10, 10), "outer")
+	if err != nil {
+		t.Fatalf("outer: %v", err)
+	}
+	inner, err := brep.SolidBlock(m.P3(3, 3, 3), m.P3(6, 6, 6), "inner")
+	if err != nil {
+		t.Fatalf("inner: %v", err)
+	}
+	if rel := classify(outer, inner); rel != targetContainsTool {
+		t.Errorf("classify = %v, want targetContainsTool (strict interior)", rel)
+	}
+	if boundariesCross(outer, inner) {
+		t.Error("strictly interior tool should not cross the outer boundary")
+	}
+}

--- a/kernel/ops/boundary_cross.go
+++ b/kernel/ops/boundary_cross.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// boundariesCross reports whether the boundary (tessellated surface) of body a crosses the boundary
+// of body b. It is the missing half of containment classification (#1315): all-vertices-inside does
+// NOT imply containment for non-convex operands — an edge or face of the inner body can pass back out
+// through the outer body BETWEEN the inner's vertices — so a boundary crossing must demote the pair to
+// the general face-splitting boolean instead of the (wrong) contains-fast-path.
+//
+// Each body is tessellated once; the O(Ta·Tb) triangle-pair scan is AABB-culled per triangle, and the
+// whole test runs only after allVerticesInside already passed (the candidate-containment case), so it
+// never burdens the common intersecting path, which exits classify earlier.
+func boundariesCross(a, b *topo.Body) bool {
+	ma, _ := TessellateBody(a, DefaultQuality())
+	mb, _ := TessellateBody(b, DefaultQuality())
+	return meshesCrossBounded(ma, mb)
+}
+
+// meshesCrossBounded reports whether any triangle of a crosses any triangle of b, culling triangle
+// pairs by their axis-aligned bounding boxes before the exact Möller test (trianglesIntersect).
+func meshesCrossBounded(a, b *Mesh) bool {
+	boxesB := triangleBoxes(b)
+	for i := 0; i+2 < len(a.Indices); i += 3 {
+		ta := meshTriangle(a, i)
+		boxA := math.BoxFromPoints(ta[0], ta[1], ta[2])
+		for j := 0; j+2 < len(b.Indices); j += 3 {
+			if !boxA.Intersects(boxesB[j/3]) {
+				continue
+			}
+			if _, hit := trianglesIntersect(ta, meshTriangle(b, j)); hit {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// triangleBoxes precomputes the AABB of every triangle of m for the cull above.
+func triangleBoxes(m *Mesh) []math.Box {
+	boxes := make([]math.Box, 0, m.TriangleCount())
+	for i := 0; i+2 < len(m.Indices); i += 3 {
+		t := meshTriangle(m, i)
+		boxes = append(boxes, math.BoxFromPoints(t[0], t[1], t[2]))
+	}
+	return boxes
+}


### PR DESCRIPTION
> Stacked on #1326 (H1) → #1325 (H3). Base retargets to `develop` as the stack merges.

## What
`Join` of nested bodies routed through `MergeBodies`, which **concatenates both operands' shells**. When one body strictly contains the other, the inner shell was kept as a **floating interior wall** — an invalid solid whose divergence-sum volume double-counted the inner body.

## Why
The union of nested solids is just the outer body. Keeping the inner shell gives `volume ≈ target_vol + tool_vol` (should be `target_vol`), the same double-count in inertia, and a spurious internal cavity wall that corrupts downstream booleans/sectioning/export.

## How
New `join()`: when `classify` reports containment (H1/#1315 guarantees no boundary crossing), discard the inner shell and return the outer body with its lineage intact. Disjoint bodies still merge into one valid multi-lump body; intersecting bodies still go to the face-splitting boolean. `Intersect`'s containment branches were already sound once `classify` became boundary-aware, so they are unchanged.

## Validation (small cube inside large cube)
- `Join` → volume **1000** (not 1027), **6** faces (no interior wall), valid closed manifold solid; mirror branch (tool contains target) covered.
- `Intersect` → **27**.
- `Cut` → **973** (interior cavity).
- All **translation-invariant** (shifts of ±hundreds of units).
- 100% coverage on `join`; full `./kernel/...` + `./model/...` green.

Closes #1316