### PR TITLE
fix(ops): self-intersection check no longer skips vertex-sharing faces (#1321)

### DIFF
--- a/kernel/ops/self_intersect.go
+++ b/kernel/ops/self_intersect.go
@@ -37,10 +37,14 @@ func SelfIntersections(b *topo.Body, q Quality) []SelfIntersection {
 	var out []SelfIntersection
 	for i := range faces {
 		for j := i + 1; j < len(faces); j++ {
-			if !boxes[i].Intersects(boxes[j]) || facesAdjacent(faces[i], faces[j]) {
+			if !boxes[i].Intersects(boxes[j]) {
 				continue
 			}
-			if p, hit := meshesCross(meshes[i], meshes[j]); hit {
+			// Don't skip the whole pair when the faces merely touch (#1321): test every triangle
+			// pair and discard only crossings that land ON the shared boundary (the legitimate edge/
+			// vertex contact). A crossing AWAY from the shared topology is a real interpenetration.
+			shared := sharedFaceBoundary(faces[i], faces[j])
+			if p, hit := meshesCrossOffBoundary(meshes[i], meshes[j], shared, q.tol()); hit {
 				out = append(out, SelfIntersection{FaceA: faces[i], FaceB: faces[j], Witness: p})
 			}
 		}
@@ -48,33 +52,56 @@ func SelfIntersections(b *topo.Body, q Quality) []SelfIntersection {
 	return out
 }
 
-// facesAdjacent reports whether two faces share any vertex (which covers
-// sharing an edge) — contact along shared topology is legitimate.
-func facesAdjacent(a, b *topo.Face) bool {
-	verts := map[*topo.Vertex]bool{}
-	for _, e := range a.Edges() {
-		verts[e.StartVertex()] = true
-		verts[e.EndVertex()] = true
-	}
+// sharedFaceBoundary returns the geometry two faces legitimately share: their common edges as
+// segments and any common vertex as a degenerate (point) segment. Contact within tol of any of these
+// is the faces meeting along their shared topology, not an interpenetration.
+func sharedFaceBoundary(a, b *topo.Face) [][2]math.Point3 {
+	edgesB := map[*topo.Edge]bool{}
+	vertsB := map[*topo.Vertex]bool{}
 	for _, e := range b.Edges() {
-		if verts[e.StartVertex()] || verts[e.EndVertex()] {
-			return true
+		edgesB[e] = true
+		vertsB[e.StartVertex()], vertsB[e.EndVertex()] = true, true
+	}
+	var shared [][2]math.Point3
+	seenV := map[*topo.Vertex]bool{}
+	for _, e := range a.Edges() {
+		if edgesB[e] {
+			shared = append(shared, [2]math.Point3{e.StartVertex().Point(), e.EndVertex().Point()})
+		}
+		for _, v := range [2]*topo.Vertex{e.StartVertex(), e.EndVertex()} {
+			if vertsB[v] && !seenV[v] {
+				seenV[v] = true
+				shared = append(shared, [2]math.Point3{v.Point(), v.Point()})
+			}
 		}
 	}
-	return false
+	return shared
 }
 
-// meshesCross tests every triangle pair of the two face meshes.
-func meshesCross(a, b *Mesh) (math.Point3, bool) {
+// meshesCrossOffBoundary tests every triangle pair of the two face meshes and returns the first
+// crossing whose witness lies farther than tol from the shared boundary — the first real
+// interpenetration. Crossings on the shared boundary are the faces' legitimate contact and ignored.
+func meshesCrossOffBoundary(a, b *Mesh, shared [][2]math.Point3, tol float64) (math.Point3, bool) {
 	for i := 0; i+2 < len(a.Indices); i += 3 {
 		t1 := meshTriangle(a, i)
 		for j := 0; j+2 < len(b.Indices); j += 3 {
-			if p, hit := trianglesIntersect(t1, meshTriangle(b, j)); hit {
+			p, hit := trianglesIntersect(t1, meshTriangle(b, j))
+			if hit && !onSharedBoundary(p, shared, tol) {
 				return p, true
 			}
 		}
 	}
 	return math.Point3{}, false
+}
+
+// onSharedBoundary reports whether p lies within tol of any shared boundary segment/point.
+func onSharedBoundary(p math.Point3, shared [][2]math.Point3, tol float64) bool {
+	for _, s := range shared {
+		if pointToSegment(p, s[0], s[1]) <= tol {
+			return true
+		}
+	}
+	return false
 }
 
 func meshTriangle(m *Mesh, i int) [3]math.Point3 {

--- a/kernel/ops/self_intersect_shared_test.go
+++ b/kernel/ops/self_intersect_shared_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	gmath "oblikovati.org/math"
+)
+
+// Regression for Oblikovati/Oblikovati#1321: SelfIntersections skipped any face pair sharing a single
+// vertex, hiding interpenetrations away from that vertex. The two fixtures below share exactly one
+// vertex (bowtie) or exactly one edge (tent) so the shared-topology pointers are real.
+
+// triFace adds one triangular face through the three given (already-added) vertices to bld, in a plane
+// fit to the triangle's winding.
+func triFace(bld *topo.Builder, feat string, v0, v1, v2 *topo.Vertex) {
+	p0, p1, p2 := v0.Point(), v1.Point(), v2.Point()
+	surf, _ := geom.NewPlane(p0, p0.VectorTo(p1).Cross(p0.VectorTo(p2)))
+	e0 := bld.AddEdge(geom.NewLineSegment(p0, p1), v0, v1, topo.NewLineage(topo.Tok(feat, "e", 0)))
+	e1 := bld.AddEdge(geom.NewLineSegment(p1, p2), v1, v2, topo.NewLineage(topo.Tok(feat, "e", 1)))
+	e2 := bld.AddEdge(geom.NewLineSegment(p2, p0), v2, v0, topo.NewLineage(topo.Tok(feat, "e", 2)))
+	bld.AddFace(surf, topo.NewLineage(topo.Tok(feat, "f", 0)),
+		topo.OuterLoop(topo.Fwd(e0), topo.Fwd(e1), topo.Fwd(e2)))
+}
+
+// bowtieBody builds two triangles sharing ONLY the apex vertex at the origin. Face A lies in z=0;
+// face B is tilted so its far edge pierces z=0 at (3,1.5,0) — inside face A's interior and far from
+// the shared apex. This is a real interpenetration the old vertex-skip rule hid.
+func bowtieBody() *topo.Body {
+	bld := topo.NewBuilder(false, topo.NewLineage(topo.Tok("bowtie", "body", 0)))
+	p := gmath.P3
+	apex := bld.AddVertex(p(0, 0, 0), topo.NewLineage(topo.Tok("bowtie", "v", 0)))
+	a1 := bld.AddVertex(p(4, 0, 0), topo.NewLineage(topo.Tok("bowtie", "v", 1)))
+	a2 := bld.AddVertex(p(4, 4, 0), topo.NewLineage(topo.Tok("bowtie", "v", 2)))
+	b1 := bld.AddVertex(p(3, 1.5, -1), topo.NewLineage(topo.Tok("bowtie", "v", 3)))
+	b2 := bld.AddVertex(p(3, 1.5, 1), topo.NewLineage(topo.Tok("bowtie", "v", 4)))
+	triFace(bld, "A", apex, a1, a2)
+	triFace(bld, "B", apex, b1, b2)
+	return bld.Build()
+}
+
+// tentBody builds two triangles sharing ONE edge (the ridge from (0,0,0) to (4,0,0)), folded like a
+// roof so they meet only along that edge — a legitimate manifold contact that must NOT be flagged.
+func tentBody() *topo.Body {
+	bld := topo.NewBuilder(false, topo.NewLineage(topo.Tok("tent", "body", 0)))
+	p := gmath.P3
+	r0 := bld.AddVertex(p(0, 0, 0), topo.NewLineage(topo.Tok("tent", "v", 0)))
+	r1 := bld.AddVertex(p(4, 0, 0), topo.NewLineage(topo.Tok("tent", "v", 1)))
+	left := bld.AddVertex(p(2, 2, 1), topo.NewLineage(topo.Tok("tent", "v", 2)))
+	right := bld.AddVertex(p(2, -2, 1), topo.NewLineage(topo.Tok("tent", "v", 3)))
+	ridge := bld.AddEdge(geom.NewLineSegment(p(0, 0, 0), p(4, 0, 0)), r0, r1, topo.NewLineage(topo.Tok("tent", "ridge", 0)))
+	addTriWithRidge(bld, "L", ridge, r0, r1, left)
+	addTriWithRidge(bld, "R", ridge, r1, r0, right)
+	return bld.Build()
+}
+
+// addTriWithRidge adds a triangle ( va, vb, apex) whose first edge IS the shared ridge edge, so both
+// tent faces reference the same *topo.Edge.
+func addTriWithRidge(bld *topo.Builder, feat string, ridge *topo.Edge, va, vb, apex *topo.Vertex) {
+	pa, pb, pc := va.Point(), vb.Point(), apex.Point()
+	surf, _ := geom.NewPlane(pa, pa.VectorTo(pb).Cross(pa.VectorTo(pc)))
+	e1 := bld.AddEdge(geom.NewLineSegment(pb, pc), vb, apex, topo.NewLineage(topo.Tok(feat, "e", 1)))
+	e2 := bld.AddEdge(geom.NewLineSegment(pc, pa), apex, va, topo.NewLineage(topo.Tok(feat, "e", 2)))
+	ridgeUse := topo.Use{Edge: ridge, Reversed: ridge.StartVertex() != va}
+	bld.AddFace(surf, topo.NewLineage(topo.Tok(feat, "f", 0)),
+		topo.OuterLoop(ridgeUse, topo.Fwd(e1), topo.Fwd(e2)))
+}
+
+// TestSelfIntersectionSharedVertexPokeThrough is the core #1321 regression: two faces share one
+// apex vertex but one pierces the other far from it. Exactly one self-intersection, witness off apex.
+func TestSelfIntersectionSharedVertexPokeThrough(t *testing.T) {
+	hits := SelfIntersections(bowtieBody(), DefaultQuality())
+	if len(hits) == 0 {
+		t.Fatal("shared-vertex poke-through must be reported (was hidden by the vertex-skip rule)")
+	}
+	for _, h := range hits {
+		if d := float64(h.Witness.DistanceTo(gmath.P3(0, 0, 0))); d < 0.5 {
+			t.Errorf("witness %v is at the shared apex (dist %g); a real crossing should be off it", h.Witness, d)
+		}
+	}
+}
+
+// TestSelfIntersectionSharedEdgeClean is the negative control: two faces meeting only along their
+// shared edge (a roof ridge) are legitimate and must report nothing.
+func TestSelfIntersectionSharedEdgeClean(t *testing.T) {
+	if hits := SelfIntersections(tentBody(), DefaultQuality()); len(hits) != 0 {
+		t.Errorf("tent (clean shared edge) reports %d self-intersections, want 0: %+v", len(hits), hits)
+	}
+}
+
+// TestSharedFaceBoundaryFindsEdgeAndVertex checks the helper directly: the tent's two faces share an
+// edge (a non-degenerate segment); the bowtie's share a point (a degenerate segment).
+func TestSharedFaceBoundaryFindsEdgeAndVertex(t *testing.T) {
+	tent := tentBody()
+	shared := sharedFaceBoundary(tent.Faces()[0], tent.Faces()[1])
+	hasSegment := false
+	for _, s := range shared {
+		if s[0].DistanceTo(s[1]) > 1e-9 {
+			hasSegment = true
+		}
+	}
+	if !hasSegment {
+		t.Errorf("tent faces should share a non-degenerate edge segment, got %+v", shared)
+	}
+	bow := bowtieBody()
+	bshared := sharedFaceBoundary(bow.Faces()[0], bow.Faces()[1])
+	if len(bshared) == 0 {
+		t.Error("bowtie faces should share the apex vertex point")
+	}
+	for _, s := range bshared {
+		if math.Abs(float64(s[0].DistanceTo(s[1]))) > 1e-9 {
+			t.Errorf("bowtie shared boundary should be a point, got segment %+v", s)
+		}
+	}
+}


### PR DESCRIPTION
## What
`facesAdjacent` excluded a whole face pair from the self-intersection test whenever the faces shared **any** vertex. This PR tests every triangle pair and filters only crossings on the **shared boundary**.

## Why
Two faces can share exactly one vertex (a bowtie/pinch, a cone apex, an hourglass throat) and still pass through each other **far from** that vertex. Skipping the entire pair hid that crossing — a **false negative** in a routine that gates body validity (booleans, mass-props, export reject on `len(hits) > 0`), the dangerous direction for a validity test.

## How
`sharedFaceBoundary(a, b)` collects the faces' common edges (as segments) and common vertices (as points). `meshesCrossOffBoundary` runs the Möller triangle/triangle test over all pairs and reports the first crossing whose witness lies farther than the chord tolerance from that shared boundary. Legitimate contact along the shared edge/vertex is ignored; interpenetration elsewhere is reported.

## Validation
- **Bowtie** (two faces sharing one apex vertex; one pierces the other at (3,1.5,0)): now reports a self-intersection with a **witness off the apex**.
- **Tent** (two faces meeting cleanly along a shared ridge edge): reports **none** (negative control for the relaxed rule).
- Clean cube and all existing fixtures still report **zero** (no regression).
- `sharedFaceBoundary` verified to return a non-degenerate segment for the shared edge and a point for the shared vertex.
- Package coverage 89.6%; `golangci-lint` clean; full `./kernel/...` + `./model/...` green.

Closes #1321