### PR TITLE
fix(geom): correct OffsetSurface ParamAt/derivatives, detect self-intersection (#1322)

### DIFF
--- a/kernel/geom/offset_surface.go
+++ b/kernel/geom/offset_surface.go
@@ -2,26 +2,43 @@
 
 package geom
 
-import "oblikovati.org/math"
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
 
 // OffsetSurface is the parallel surface a fixed signed Distance from a base surface along its
-// normal: S_d(u,v) = S(u,v) + Distance·N(u,v). It shares the base's (u,v) parameterization, so its
-// normal at (u,v) equals the base normal there and its ParamAt is the base's — which is exactly what
-// lets a face be offset by swapping its surface and KEEPING its loops: the trimmed-face tessellator
-// projects the loop to (u,v) through ParamAt and evaluates through PointAt, so the same UV region is
-// re-evaluated on the offset surface (no edge/loop surgery). CAM uses it to offset a part face by the
-// tool radius and then sample the offset for drop-cutter projection.
+// normal: S_d(u,v) = S(u,v) + Distance·N(u,v). It shares the base's (u,v) parameterization and normal
+// field, which is what lets a face be offset by swapping its surface and KEEPING its loops: the
+// trimmed-face tessellator projects the loop to (u,v) through ParamAt and evaluates through PointAt,
+// so the same UV region is re-evaluated on the offset surface (no edge/loop surgery). CAM uses it to
+// offset a part face by the tool radius and then sample the offset for drop-cutter projection.
 //
-// The offset is exact for the analytic surfaces (plane/cylinder/sphere/cone/torus, whose normal is
-// closed-form); a large inward Distance on a tightly curved surface can self-intersect (the offset
-// of a cylinder by more than its radius inverts), which the caller must avoid — there is no
-// self-intersection trimming here.
+// A large inward Distance on a tightly curved surface self-intersects (the offset of a cylinder by
+// more than its radius inverts). Construct through NewOffsetSurface to reject that regime; the bare
+// struct literal is still valid for callers that have already guaranteed the offset is non-folding.
 type OffsetSurface struct {
 	Base     Surface
 	Distance float64
 }
 
 var _ Surface = OffsetSurface{}
+
+// NewOffsetSurface builds the offset and rejects a self-intersecting (folded) result: an inward offset
+// larger than the base's local concave radius of curvature inverts the surface into invalid geometry.
+//
+//	off, err := geom.NewOffsetSurface(cyl, 2) // err != nil if 2 exceeds the cylinder radius
+func NewOffsetSurface(base Surface, distance float64) (OffsetSurface, error) {
+	o := OffsetSurface{Base: base, Distance: distance}
+	if u, v, folds := o.foldPoint(); folds {
+		return OffsetSurface{}, fmt.Errorf(
+			"geom.NewOffsetSurface: distance %g self-intersects the base near (u,v)=(%g,%g): it exceeds the local concave radius of curvature",
+			distance, u, v)
+	}
+	return o, nil
+}
 
 // PointAt evaluates the base point displaced along the base normal by Distance.
 func (o OffsetSurface) PointAt(u, v float64) math.Point3 {
@@ -31,31 +48,153 @@ func (o OffsetSurface) PointAt(u, v float64) math.Point3 {
 // NormalAt returns the base normal: a parallel surface has the same normal field as its base.
 func (o OffsetSurface) NormalAt(u, v float64) math.Vector3 { return o.Base.NormalAt(u, v) }
 
-// offsetParamStep is the half-width of the central difference used to take the normal field's rate
-// of change; small enough to be accurate on the analytic surfaces' [0,2π] angular domains.
-const offsetParamStep = 1e-6
+// offsetStepFraction is the central-difference half-step for ∂N/∂param, as a FRACTION of the domain
+// span — so the step adapts to the base's parameter scale (a NURBS [0,1] domain and an analytic
+// [0,2π] domain need different absolute steps for the same truncation/roundoff balance). #1322.
+const offsetStepFraction = 1e-6
 
 // DerivativesAt returns the offset surface's partials, ∂S_d/∂u = ∂S/∂u + Distance·∂N/∂u (and v): the
-// base's exact partials plus the Distance-scaled rate of change of the normal (by central
-// difference, since the Surface interface exposes no second derivative).
+// base's exact partials plus the Distance-scaled rate of change of the normal. ∂N/∂param is a central
+// difference (the Surface interface exposes no second derivative) with a domain-scaled step.
 func (o OffsetSurface) DerivativesAt(u, v float64) (du, dv math.Vector3) {
 	bdu, bdv := o.Base.DerivativesAt(u, v)
-	dNdu := centralDiff(o.Base.NormalAt(u+offsetParamStep, v), o.Base.NormalAt(u-offsetParamStep, v))
-	dNdv := centralDiff(o.Base.NormalAt(u, v+offsetParamStep), o.Base.NormalAt(u, v-offsetParamStep))
+	hu := offsetStepFraction * spanOr1(o.Base.UDomain())
+	hv := offsetStepFraction * spanOr1(o.Base.VDomain())
+	dNdu := centralDiff(o.Base.NormalAt(u+hu, v), o.Base.NormalAt(u-hu, v), hu)
+	dNdv := centralDiff(o.Base.NormalAt(u, v+hv), o.Base.NormalAt(u, v-hv), hv)
 	d := math.Scalar(o.Distance)
 	return bdu.Add(dNdu.Scale(d)), bdv.Add(dNdv.Scale(d))
 }
 
-// centralDiff returns (hi − lo) / (2·offsetParamStep).
-func centralDiff(hi, lo math.Vector3) math.Vector3 {
-	return hi.Add(lo.Scale(-1)).Scale(math.Scalar(1.0 / (2 * offsetParamStep)))
+// centralDiff returns (hi − lo) / (2·h).
+func centralDiff(hi, lo math.Vector3, h float64) math.Vector3 {
+	return hi.Add(lo.Scale(-1)).Scale(math.Scalar(1.0 / (2 * h)))
 }
 
 // UDomain / VDomain are the base's: offsetting along the normal does not change the parameter range.
 func (o OffsetSurface) UDomain() (lo, hi float64) { return o.Base.UDomain() }
 func (o OffsetSurface) VDomain() (lo, hi float64) { return o.Base.VDomain() }
 
-// ParamAt returns the base parameters of p. For a point on the offset surface this reproduces its
-// (u,v) (the analytic surfaces' radial/perpendicular projection is offset-invariant), which is what
-// the tessellator needs when the offset face reuses the base loops.
-func (o OffsetSurface) ParamAt(p math.Point3) (u, v float64) { return o.Base.ParamAt(p) }
+const (
+	// offsetInvertIters bounds the Gauss–Newton iterations inverting a point onto the offset surface.
+	offsetInvertIters = 40
+	// offsetInvertTol is the converged step size, as a fraction of the domain span.
+	offsetInvertTol = 1e-12
+)
+
+// ParamAt inverts PointAt by projecting p onto the OFFSET surface (not the base): seed from the base
+// inversion — exact for the radial/perpendicular analytic projections (plane/cylinder/sphere), a good
+// guess otherwise — then refine with projected Gauss–Newton on the offset's own partials. This fixes
+// the silent error of returning o.Base.ParamAt(p) directly (#1322): for a NURBS base (and even the
+// cone/torus, whose offset is not radially offset-invariant) that returned the wrong (u,v).
+func (o OffsetSurface) ParamAt(p math.Point3) (u, v float64) {
+	uLo, uHi := o.UDomain()
+	vLo, vHi := o.VDomain()
+	u, v = o.Base.ParamAt(p)
+	u, v = clampTo(u, uLo, uHi), clampTo(v, vLo, vHi)
+	uTol := offsetInvertTol * spanOr1(uLo, uHi)
+	vTol := offsetInvertTol * spanOr1(vLo, vHi)
+	for i := 0; i < offsetInvertIters; i++ {
+		nu, nv := surfaceProjectStep(o, p, u, v, uLo, uHi, vLo, vHi)
+		if stdmath.Abs(nu-u) <= uTol && stdmath.Abs(nv-v) <= vTol {
+			return nu, nv
+		}
+		u, v = nu, nv
+	}
+	return u, v
+}
+
+// SelfIntersects reports whether the offset folds onto itself anywhere in the domain. It samples the
+// signed area element of the offset's partials against the base normal: an inward offset past the
+// local concave radius of curvature inverts the surface, flipping that sign (or collapsing it).
+func (o OffsetSurface) SelfIntersects() bool {
+	_, _, folds := o.foldPoint()
+	return folds
+}
+
+// foldTol is the tangent-scaling eigenvalue below which the offset is treated as folded — slightly
+// above 0 so the razor-edge collapse (eigenvalue exactly 0, the offset pinched to a line/point) is
+// rejected along with the inverted regime, with margin against finite-difference noise.
+const foldTol = 1e-7
+
+// foldPoint scans a grid for the first (u,v) where the offset has folded — where the smaller tangent-
+// scaling eigenvalue 1 + Distance·κ has gone non-positive (the offset passed the local centre of
+// curvature). Degenerate base points (a sphere pole, a degenerate tangent frame) are skipped.
+func (o OffsetSurface) foldPoint() (u, v float64, folds bool) {
+	uLo, uHi := finiteRange(o.UDomain())
+	vLo, vHi := finiteRange(o.VDomain())
+	const n = 24
+	for i := 0; i <= n; i++ {
+		uu := uLo + (uHi-uLo)*float64(i)/n
+		for j := 0; j <= n; j++ {
+			vv := vLo + (vHi-vLo)*float64(j)/n
+			if s, ok := o.minTangentScale(uu, vv); ok && s < foldTol {
+				return uu, vv, true
+			}
+		}
+	}
+	return 0, 0, false
+}
+
+// minTangentScale returns the smaller eigenvalue of the offset's tangent-scaling map I + Distance·W,
+// where W is the base's shape operator (Weingarten map) recovered from ∂N/∂param in the tangent
+// basis. The eigenvalues are 1 + Distance·κ₁,₂ (the principal curvatures); the offset self-intersects
+// where the smaller one reaches 0 — i.e. |Distance| exceeds the local concave radius of curvature.
+// This catches the ISOTROPIC fold (a sphere offset past its centre flips BOTH partials, so a mere
+// area-element sign — the product of the two scalings — would stay positive and miss it). ok is false
+// at a degenerate base point (zero normal or degenerate tangent frame).
+func (o OffsetSurface) minTangentScale(u, v float64) (float64, bool) {
+	if o.Base.NormalAt(u, v).LengthSquared() < math.DefaultTolerance {
+		return 0, false
+	}
+	su, sv := o.Base.DerivativesAt(u, v)
+	e, f, g := dot(su, su), dot(su, sv), dot(sv, sv)
+	det := e*g - f*f
+	if det < math.DefaultTolerance {
+		return 0, false
+	}
+	hu := offsetStepFraction * spanOr1(o.Base.UDomain())
+	hv := offsetStepFraction * spanOr1(o.Base.VDomain())
+	nu := centralDiff(o.Base.NormalAt(u+hu, v), o.Base.NormalAt(u-hu, v), hu)
+	nv := centralDiff(o.Base.NormalAt(u, v+hv), o.Base.NormalAt(u, v-hv), hv)
+	// Express ∂N/∂u, ∂N/∂v in the {Su,Sv} basis (solve the metric system) → the 2×2 map W.
+	w11, w21 := solveMetric(e, f, g, det, dot(nu, su), dot(nu, sv))
+	w12, w22 := solveMetric(e, f, g, det, dot(nv, su), dot(nv, sv))
+	d := o.Distance
+	a, b, c, dd := 1+d*w11, d*w12, d*w21, 1+d*w22
+	disc := (a-dd)*(a-dd) + 4*b*c
+	if disc < 0 {
+		disc = 0 // numerically tiny negative from FD noise on a (real-spectrum) shape operator
+	}
+	return ((a + dd) - stdmath.Sqrt(disc)) / 2, true
+}
+
+// solveMetric solves [[e,f],[f,g]]·x = [r1;r2] (det = e·g−f², precomputed nonzero).
+func solveMetric(e, f, g, det, r1, r2 float64) (float64, float64) {
+	return (g*r1 - f*r2) / det, (-f*r1 + e*r2) / det
+}
+
+// dot is float64(a·b), for the metric arithmetic above.
+func dot(a, b math.Vector3) float64 { return float64(a.Dot(b)) }
+
+// spanOr1 returns the domain span, or 1 for an unbounded/degenerate domain (so a relative step or
+// tolerance built from it stays finite and nonzero).
+func spanOr1(lo, hi float64) float64 {
+	s := hi - lo
+	if stdmath.IsInf(s, 0) || s <= 0 {
+		return 1
+	}
+	return s
+}
+
+// finiteRange replaces ±Inf domain bounds with a finite sampling window for the fold scan.
+func finiteRange(lo, hi float64) (float64, float64) {
+	const window = 10
+	if stdmath.IsInf(lo, 0) {
+		lo = -window
+	}
+	if stdmath.IsInf(hi, 0) {
+		hi = window
+	}
+	return lo, hi
+}

--- a/kernel/geom/offset_surface_m4_test.go
+++ b/kernel/geom/offset_surface_m4_test.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// Regression suite for Oblikovati/Oblikovati#1322: OffsetSurface returned the BASE ParamAt (wrong
+// (u,v) off the radial/perpendicular analytic projections), used a fixed domain-unaware FD step, and
+// never detected self-intersection. ParamAt now inverts onto the offset by Gauss–Newton, the FD step
+// scales to the domain span, and NewOffsetSurface/SelfIntersects reject a folded offset.
+
+// nurbsBump builds a non-trivial rational biquadratic NURBS patch on the unit domain (a saddle-ish
+// bump), the non-analytic base the old ParamAt could not invert.
+func nurbsBump(t *testing.T) BSplineSurface {
+	t.Helper()
+	ctrl := [][]math.Point3{
+		{{X: 0, Y: 0, Z: 0}, {X: 0, Y: 1, Z: 1}, {X: 0, Y: 2, Z: 0}},
+		{{X: 1, Y: 0, Z: 1}, {X: 1, Y: 1, Z: 2}, {X: 1, Y: 2, Z: 1}},
+		{{X: 2, Y: 0, Z: 0}, {X: 2, Y: 1, Z: 1}, {X: 2, Y: 2, Z: 0}},
+		{{X: 3, Y: 0, Z: -1}, {X: 3, Y: 1, Z: 0}, {X: 3, Y: 2, Z: -1}},
+	}
+	weights := [][]float64{{1, 2, 1}, {1, 1, 1}, {2, 1, 2}, {1, 1, 1}}
+	s, err := NewBSplineSurface(2, 2, ctrl, weights,
+		[]float64{0, 0, 0, 0.5, 1, 1, 1}, []float64{0, 0, 0, 1, 1, 1})
+	if err != nil {
+		t.Fatalf("NewBSplineSurface: %v", err)
+	}
+	return s
+}
+
+// TestOffsetParamAtInvertsNurbs is the core #1322 fix: for a NURBS base, ParamAt(PointAt(u,v)) must
+// round-trip to (u,v) — the old o.Base.ParamAt returned the base projection (wrong) here.
+func TestOffsetParamAtInvertsNurbs(t *testing.T) {
+	off := OffsetSurface{Base: nurbsBump(t), Distance: 0.25}
+	for _, u := range []float64{0.2, 0.5, 0.8} {
+		for _, v := range []float64{0.2, 0.5, 0.8} {
+			p := off.PointAt(u, v)
+			gu, gv := off.ParamAt(p)
+			if stdmath.Abs(gu-u) > 1e-6 || stdmath.Abs(gv-v) > 1e-6 {
+				t.Errorf("ParamAt(PointAt(%g,%g)) = (%g,%g), want (%g,%g)", u, v, gu, gv, u, v)
+			}
+			// And the recovered params must land back on the offset point.
+			if back := off.PointAt(gu, gv); back.DistanceTo(p) > 1e-7 {
+				t.Errorf("recovered (u,v) maps to a point %g away from p", back.DistanceTo(p))
+			}
+		}
+	}
+}
+
+// fdPartialU is a 4th-order central finite-difference reference for ∂(s.PointAt)/∂u — the accurate
+// derivative of the offset surface to validate DerivativesAt against.
+func fdPartialU(s Surface, u, v, h float64) math.Vector3 {
+	p2 := s.PointAt(u+2*h, v).AsVector()
+	p1 := s.PointAt(u+h, v).AsVector()
+	m1 := s.PointAt(u-h, v).AsVector()
+	m2 := s.PointAt(u-2*h, v).AsVector()
+	return p2.Scale(-1).Add(p1.Scale(8)).Add(m1.Scale(-8)).Add(m2).Scale(math.Scalar(1.0 / (12 * h)))
+}
+
+func fdPartialV(s Surface, u, v, h float64) math.Vector3 {
+	p2 := s.PointAt(u, v+2*h).AsVector()
+	p1 := s.PointAt(u, v+h).AsVector()
+	m1 := s.PointAt(u, v-h).AsVector()
+	m2 := s.PointAt(u, v-2*h).AsVector()
+	return p2.Scale(-1).Add(p1.Scale(8)).Add(m1.Scale(-8)).Add(m2).Scale(math.Scalar(1.0 / (12 * h)))
+}
+
+func relDiff(a, b math.Vector3) float64 {
+	scale := stdmath.Max(float64(a.Length()), 1e-9)
+	return float64(a.Add(b.Scale(-1)).Length()) / scale
+}
+
+// TestOffsetDerivativesMatchReference checks DerivativesAt against the 4th-order FD reference on an
+// analytic base ([0,2π] domain) and a NURBS base ([0,1] domain) — two parameter scales, both within
+// tolerance now that the FD step scales to the domain span.
+func TestOffsetDerivativesMatchReference(t *testing.T) {
+	sphere, err := NewSphere(math.P3(0, 0, 0), 4)
+	if err != nil {
+		t.Fatalf("NewSphere: %v", err)
+	}
+	cases := []struct {
+		name string
+		base Surface
+		us   []float64
+		vs   []float64
+		h    float64
+	}{
+		{"sphere", sphere, []float64{0.8, 1.6, 2.4}, []float64{-0.6, 0.3, 0.9}, 1e-4},
+		{"nurbs", nurbsBump(t), []float64{0.3, 0.6}, []float64{0.3, 0.6}, 1e-4},
+	}
+	for _, c := range cases {
+		off := OffsetSurface{Base: c.base, Distance: 0.3}
+		for _, u := range c.us {
+			for _, v := range c.vs {
+				du, dv := off.DerivativesAt(u, v)
+				if e := relDiff(du, fdPartialU(off, u, v, c.h)); e > 1e-5 {
+					t.Errorf("%s ∂u(%g,%g) rel error %g exceeds 1e-5", c.name, u, v, e)
+				}
+				if e := relDiff(dv, fdPartialV(off, u, v, c.h)); e > 1e-5 {
+					t.Errorf("%s ∂v(%g,%g) rel error %g exceeds 1e-5", c.name, u, v, e)
+				}
+			}
+		}
+	}
+}
+
+// TestOffsetSelfIntersectionRejected checks the fold detector and validating constructor: a cylinder
+// offset inward by MORE than its radius inverts (self-intersects) and must be rejected; a safe inward
+// offset is accepted.
+func TestOffsetSelfIntersectionRejected(t *testing.T) {
+	cyl, err := NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 5)
+	if err != nil {
+		t.Fatalf("NewCylinder: %v", err)
+	}
+	folded := OffsetSurface{Base: cyl, Distance: -6} // inward past the radius → inverted
+	if !folded.SelfIntersects() {
+		t.Error("inward offset beyond the cylinder radius must report SelfIntersects")
+	}
+	if _, err := NewOffsetSurface(cyl, -6); err == nil {
+		t.Error("NewOffsetSurface must reject a self-intersecting offset")
+	}
+	safe := OffsetSurface{Base: cyl, Distance: -2}
+	if safe.SelfIntersects() {
+		t.Error("inward offset within the radius must not report SelfIntersects")
+	}
+	if _, err := NewOffsetSurface(cyl, -2); err != nil {
+		t.Errorf("NewOffsetSurface rejected a valid offset: %v", err)
+	}
+	// Outward offset never folds.
+	if (OffsetSurface{Base: cyl, Distance: 10}).SelfIntersects() {
+		t.Error("outward offset must never self-intersect")
+	}
+}
+
+// TestOffsetSphereDoesNotFalseFoldAtPole guards the degenerate-point skip: a sphere's poles have a
+// zero normal, which must not be misread as a fold for a safe offset.
+func TestOffsetSphereDoesNotFalseFoldAtPole(t *testing.T) {
+	sphere, err := NewSphere(math.P3(0, 0, 0), 4)
+	if err != nil {
+		t.Fatalf("NewSphere: %v", err)
+	}
+	if (OffsetSurface{Base: sphere, Distance: -1}).SelfIntersects() {
+		t.Error("a sphere offset well within its radius must not false-fold at the poles")
+	}
+	if !(OffsetSurface{Base: sphere, Distance: -5}).SelfIntersects() {
+		t.Error("a sphere offset inward beyond its radius must self-intersect")
+	}
+}

--- a/kernel/ops/offset_faces.go
+++ b/kernel/ops/offset_faces.go
@@ -30,8 +30,10 @@ func OffsetFaceSurfaces(b *topo.Body, faceKeys [][]byte, distance float64, rever
 		if !ok {
 			return nil, fmt.Errorf("ops.OffsetFaceSurfaces: no face with key %x", key)
 		}
-		off := geom.OffsetSurface{Base: f.Geometry(), Distance: signedOffset(distance, reverse, f.Reversed())}
-		var err error
+		off, err := geom.NewOffsetSurface(f.Geometry(), signedOffset(distance, reverse, f.Reversed()))
+		if err != nil {
+			return nil, fmt.Errorf("ops.OffsetFaceSurfaces: offset face %x: %w", key, err)
+		}
 		if out, err = ReplaceFaceSurface(out, key, off); err != nil {
 			return nil, fmt.Errorf("ops.OffsetFaceSurfaces: offset face %x: %w", key, err)
 		}


### PR DESCRIPTION
## What
`OffsetSurface` accepted any base but was only correct for the radial/perpendicular analytic surfaces. This PR fixes its `ParamAt`, scales its finite-difference step, and adds self-intersection detection.

## Why
- **`ParamAt`** returned `o.Base.ParamAt(p)` — the base projection — which is wrong off the offset for a NURBS base (and even the cone/torus, whose offset is not radially offset-invariant). This corrupts any caller that reuses base loops on the offset (CAM tool-radius offset, trimmed-face tessellation).
- **`DerivativesAt`** used a fixed `1e-6` step regardless of the base's parameter scale.
- An over-large inward offset that **self-intersects** was never detected — invalid geometry passed silently.

## How
- `ParamAt` seeds from the base inversion and refines onto the **offset** surface by projected Gauss–Newton (`surfaceProjectStep`), so it round-trips for any base. The analytic seed is already exact, so the refinement is a no-op there.
- `DerivativesAt` scales the central-difference half-step to each domain span.
- `NewOffsetSurface` / `SelfIntersects` detect a fold via the **shape-operator eigenvalues** `1 + Distance·κ` (the Weingarten map recovered from `∂N` in the tangent basis): the offset self-intersects where the smaller eigenvalue reaches 0 — i.e. `|Distance|` exceeds the local concave radius of curvature. This catches the **isotropic** fold (a sphere past its centre flips *both* partials, so a plain area-element sign would stay positive and miss it). `OffsetFaceSurfaces` constructs through `NewOffsetSurface` and surfaces the rejection.

## Validation
- NURBS `ParamAt(PointAt(u,v))` round-trips to `(u,v)` (was wrong before).
- `DerivativesAt` matches a 4th-order FD reference (<1e-5) on a sphere (`[0,2π]`) and a NURBS patch (`[0,1]`) — two parameter scales.
- Cylinder & sphere inward offsets beyond the radius are rejected; safe ones accepted; sphere poles do not false-fold.
- Package coverage 90.7%; `golangci-lint` clean; full `./kernel/...` + `./model/...` green.

Closes #1322