### PR TITLE
fix: numerical hardening — curve derivatives, hull predicates, NURBS trim refinement, predicate filter (#1323)

### DIFF
--- a/kernel/geom/derivatives3.go
+++ b/kernel/geom/derivatives3.go
@@ -2,7 +2,11 @@
 
 package geom
 
-import "oblikovati.org/math"
+import (
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
 
 // Closed-form first/second/third parametric derivatives for every 3D curve
 // (M01-F06, #603). Analytic curves differentiate their trigonometric forms
@@ -62,17 +66,44 @@ func helixDers(h Helix3d, t float64) (d1, d2, d3 math.Vector3) {
 	return d1, d2, d3
 }
 
-// numericDers3 estimates the derivatives by central differences — the fallback
-// for [Curve3] implementations without a closed form.
+// Per-order optimal central-difference steps for numericDers3. The step that minimizes the sum of
+// truncation O(h²) and value-roundoff O(ε/hⁿ) for an n-th derivative is h ≈ ε^{1/(n+2)}. A single
+// small step (the old fixed 1e-5) makes the 3rd-derivative denominator 2h³ ≈ 2e-15 and amplifies the
+// ~1e-16 value roundoff into 5–50% relative error in d3 (#1323 L1), corrupting torsion/jerk.
+var (
+	stepD1 = stdmath.Pow(machEps, 1.0/3) // ≈ 6.0e-6
+	stepD2 = stdmath.Pow(machEps, 1.0/4) // ≈ 1.2e-4
+	stepD3 = stdmath.Pow(machEps, 1.0/5) // ≈ 1.0e-3
+)
+
+const machEps = 2.220446049250313e-16 // float64 unit roundoff (2⁻⁵²)
+
+// numericDers3 estimates the derivatives by central differences — the fallback for [Curve3]
+// implementations without a closed form. Each order uses its own optimal step (stepD1/2/3) so the
+// higher-order stencils are not swamped by roundoff.
 func numericDers3(c Curve3, t float64) (d1, d2, d3 math.Vector3) {
-	const h = 1e-5
+	return numericD1(c, t), numericD2(c, t), numericD3(c, t)
+}
+
+// numericD1 is the 2-point central first derivative at the d1-optimal step.
+func numericD1(c Curve3, t float64) math.Vector3 {
+	h := stepD1
+	return c.PointAt(t + h).AsVector().Sub(c.PointAt(t - h).AsVector()).Scale(1 / (2 * h))
+}
+
+// numericD2 is the 3-point central second derivative at the d2-optimal step.
+func numericD2(c Curve3, t float64) math.Vector3 {
+	h := stepD2
+	pm, p0, pp := c.PointAt(t-h).AsVector(), c.PointAt(t).AsVector(), c.PointAt(t+h).AsVector()
+	return pp.Add(pm).Sub(p0.Scale(2)).Scale(1 / (h * h))
+}
+
+// numericD3 is the 4-point central third derivative at the d3-optimal step.
+func numericD3(c Curve3, t float64) math.Vector3 {
+	h := stepD3
 	p2m, pm := c.PointAt(t-2*h).AsVector(), c.PointAt(t-h).AsVector()
-	p0 := c.PointAt(t).AsVector()
 	pp, p2p := c.PointAt(t+h).AsVector(), c.PointAt(t+2*h).AsVector()
-	d1 = pp.Sub(pm).Scale(1 / (2 * h))
-	d2 = pp.Add(pm).Sub(p0.Scale(2)).Scale(1 / (h * h))
-	d3 = p2p.Sub(pp.Scale(2)).Add(pm.Scale(2)).Sub(p2m).Scale(1 / (2 * h * h * h))
-	return d1, d2, d3
+	return p2p.Sub(pp.Scale(2)).Add(pm.Scale(2)).Sub(p2m).Scale(1 / (2 * h * h * h))
 }
 
 // CurveCurvature3 returns the unit principal-normal direction and curvature

--- a/kernel/geom/derivatives3_test.go
+++ b/kernel/geom/derivatives3_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// opaqueCurve3 wraps a Curve3 and hides its concrete type so CurveDerivatives3 cannot dispatch to a
+// closed form and must take the numericDers3 fallback — the path #1323 L1 fixes.
+type opaqueCurve3 struct{ inner Curve3 }
+
+func (o opaqueCurve3) PointAt(t float64) math.Point3    { return o.inner.PointAt(t) }
+func (o opaqueCurve3) TangentAt(t float64) math.Vector3 { return o.inner.TangentAt(t) }
+func (o opaqueCurve3) Domain() (lo, hi float64)         { return o.inner.Domain() }
+
+// TestNumericDers3MatchesAnalyticHelix routes a helix through the numeric fallback and compares all
+// three derivatives to the helix's closed form. The old fixed 1e-5 step gave d3 a 5–50% error; the
+// per-order optimal steps bring it under 1e-4 relative.
+func TestNumericDers3MatchesAnalyticHelix(t *testing.T) {
+	helix, err := NewHelix3d(math.P3(0, 0, 0), math.V3(0, 0, 1), math.V3(1, 0, 0), 0.8, 1.0, 0.2, 3, false)
+	if err != nil {
+		t.Fatalf("NewHelix3d: %v", err)
+	}
+	for _, tt := range []float64{0.15, 0.4, 0.65, 0.85} {
+		wantD1, wantD2, wantD3 := helixDers(helix, tt)
+		gotD1, gotD2, gotD3 := numericDers3(opaqueCurve3{helix}, tt)
+		assertRel(t, "d1", tt, gotD1, wantD1, 1e-6)
+		assertRel(t, "d2", tt, gotD2, wantD2, 1e-4)
+		assertRel(t, "d3", tt, gotD3, wantD3, 1e-4)
+	}
+}
+
+// TestCurveDerivatives3TakesNumericFallback confirms the opaque wrapper actually exercises the
+// fallback (not a closed-form branch) and that CurveDerivatives3 returns the same fallback values.
+func TestCurveDerivatives3TakesNumericFallback(t *testing.T) {
+	helix, _ := NewHelix3d(math.P3(0, 0, 0), math.V3(0, 0, 1), math.V3(1, 0, 0), 1, 1, 0, 2, false)
+	d1, d2, d3 := CurveDerivatives3(opaqueCurve3{helix}, 0.5)
+	wantD1, wantD2, wantD3 := helixDers(helix, 0.5)
+	assertRel(t, "d1", 0.5, d1, wantD1, 1e-6)
+	assertRel(t, "d2", 0.5, d2, wantD2, 1e-4)
+	assertRel(t, "d3", 0.5, d3, wantD3, 1e-4)
+}
+
+func assertRel(t *testing.T, name string, at float64, got, want math.Vector3, tol float64) {
+	t.Helper()
+	scale := stdmath.Max(float64(want.Length()), 1e-9)
+	if e := float64(got.Sub(want).Length()) / scale; e > tol {
+		t.Errorf("%s at t=%g: rel error %g exceeds %g (got %v, want %v)", name, at, e, tol, got, want)
+	}
+}

--- a/kernel/ops/convexhull.go
+++ b/kernel/ops/convexhull.go
@@ -5,6 +5,7 @@ package ops
 import (
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
+	"oblikovati.org/math/predicate"
 )
 
 // ConvexHull returns the convex hull of a point set as a closed, triangulated solid body.
@@ -64,25 +65,24 @@ func convexHull3D(points []math.Point3) ([]math.Point3, [][3]int, error) {
 	if !ok {
 		return nil, nil, errHull("points are collinear or coplanar (no 3D hull)")
 	}
-	tol := res.Weld()
 	faces := initialFaces(pts, tet)
 	for i := range pts {
 		if i == tet[0] || i == tet[1] || i == tet[2] || i == tet[3] {
 			continue
 		}
-		faces = insertPoint(pts, faces, i, tol)
+		faces = insertPoint(pts, faces, i)
 	}
 	return compactHull(pts, faces)
 }
 
 // insertPoint folds the faces visible from pts[pi] into a triangle fan anchored at pi, leaving
 // the hull closed. A point that sees no face is interior and changes nothing.
-func insertPoint(pts []math.Point3, faces [][3]int, pi int, tol float64) [][3]int {
+func insertPoint(pts []math.Point3, faces [][3]int, pi int) [][3]int {
 	p := pts[pi]
 	visible := make([]bool, len(faces))
 	anyVisible := false
 	for fi, f := range faces {
-		if faceVisible(pts, f, p, tol) {
+		if faceVisible(pts, f, p) {
 			visible[fi], anyVisible = true, true
 		}
 	}
@@ -126,16 +126,13 @@ func visibleEdgeSet(faces [][3]int, visible []bool) map[[2]int]bool {
 	return seen
 }
 
-// faceVisible reports whether p lies strictly outside the face (on its outward side) by more
-// than tol — i.e. the face must fold to admit p.
-func faceVisible(pts []math.Point3, f [3]int, p math.Point3, tol float64) bool {
-	a, b, c := pts[f[0]], pts[f[1]], pts[f[2]]
-	n := a.VectorTo(b).Cross(a.VectorTo(c))
-	nl := n.Length()
-	if nl == 0 {
-		return false
-	}
-	return a.VectorTo(p).Dot(n)/nl > tol
+// faceVisible reports whether p lies strictly outside the face (on its outward side) — i.e. the face
+// must fold to admit p. The test is the EXACT orientation predicate (#1323 L2): with the face wound so
+// (b−a)×(c−a) points outward, p sees it iff Orient3D(a,b,c,p) < 0 (p on the +normal side). A float
+// dot-product tolerance was fragile on the coplanar/cocircular inputs hull() is built for (boxes,
+// cylinders), producing inverted or extra sliver faces; predicate.Orient3D is sign-exact there.
+func faceVisible(pts []math.Point3, f [3]int, p math.Point3) bool {
+	return predicate.Orient3D(pts[f[0]], pts[f[1]], pts[f[2]], p) < 0
 }
 
 // initialFaces builds the seed tetrahedron's four faces, each wound so its normal points away

--- a/kernel/ops/convexhull_l2_test.go
+++ b/kernel/ops/convexhull_l2_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"math"
+	"testing"
+
+	m "oblikovati.org/math"
+)
+
+// Regression for Oblikovati/Oblikovati#1323 L2: the incremental hull's "point sees face" test used a
+// float visibility tolerance, fragile on the coplanar inputs hull() is built for (boxes). It now uses
+// the exact Orient3D predicate, so the cube hull is correct and stable under input reordering.
+
+func cubeCorners(s float64) []m.Point3 {
+	return []m.Point3{
+		m.P3(0, 0, 0), m.P3(m.Scalar(s), 0, 0), m.P3(m.Scalar(s), m.Scalar(s), 0), m.P3(0, m.Scalar(s), 0),
+		m.P3(0, 0, m.Scalar(s)), m.P3(m.Scalar(s), 0, m.Scalar(s)), m.P3(m.Scalar(s), m.Scalar(s), m.Scalar(s)), m.P3(0, m.Scalar(s), m.Scalar(s)),
+	}
+}
+
+// TestConvexHullCubeExactFaceCountAndVolume asserts the cube hull is exactly 6 quads = 12 triangles
+// with the right volume and no sliver faces.
+func TestConvexHullCubeExactFaceCountAndVolume(t *testing.T) {
+	const s = 2.0
+	body, err := ConvexHull(cubeCorners(s), "cube")
+	if err != nil {
+		t.Fatalf("ConvexHull: %v", err)
+	}
+	if nf := len(body.Faces()); nf != 12 {
+		t.Errorf("cube hull has %d triangular faces, want 12 (6 quads)", nf)
+	}
+	if v := BodyGeometryProperties(body, DefaultQuality()).Volume; math.Abs(v-s*s*s) > 1e-9 {
+		t.Errorf("cube hull volume = %g, want %g", v, s*s*s)
+	}
+}
+
+// TestConvexHullStableUnderReordering permutes the input corner order and perturbs coordinates by a
+// hair; the hull volume and triangle count must be invariant (the exact predicate removes the
+// reordering/coplanar fragility).
+func TestConvexHullStableUnderReordering(t *testing.T) {
+	const s = 2.0
+	base := cubeCorners(s)
+	orders := [][]int{
+		{0, 1, 2, 3, 4, 5, 6, 7},
+		{7, 6, 5, 4, 3, 2, 1, 0},
+		{0, 2, 4, 6, 1, 3, 5, 7},
+		{6, 0, 3, 5, 1, 7, 2, 4},
+	}
+	for oi, order := range orders {
+		pts := make([]m.Point3, len(order))
+		for i, idx := range order {
+			pts[i] = base[idx]
+		}
+		body, err := ConvexHull(pts, "cube")
+		if err != nil {
+			t.Fatalf("order %d: ConvexHull: %v", oi, err)
+		}
+		if nf := len(body.Faces()); nf != 12 {
+			t.Errorf("order %d: %d faces, want 12", oi, nf)
+		}
+		if v := BodyGeometryProperties(body, DefaultQuality()).Volume; math.Abs(v-s*s*s) > 1e-9 {
+			t.Errorf("order %d: volume %g, want %g", oi, v, s*s*s)
+		}
+	}
+}
+
+// TestConvexHullNearCoplanarValid feeds a box-with-an-extra-near-coplanar-top-point set: a point a
+// hair above a face plane. The hull must be a valid closed solid (no inverted/extra sliver faces),
+// the failure mode the float tolerance produced on near-coplanar inputs.
+func TestConvexHullNearCoplanarValid(t *testing.T) {
+	pts := cubeCorners(2)
+	// A point just above the centre of the top face (z = 2 + tiny): the hull gains a shallow apex.
+	pts = append(pts, m.P3(1, 1, 2+1e-9))
+	body, err := ConvexHull(pts, "near-coplanar")
+	if err != nil {
+		t.Fatalf("ConvexHull: %v", err)
+	}
+	if !body.IsSolid() {
+		t.Error("near-coplanar hull is not a solid")
+	}
+	if r := Validate(body); !r.Valid || !r.Closed || !r.Manifold {
+		t.Errorf("near-coplanar hull invalid: %+v", r)
+	}
+	// Volume is essentially the cube (the apex adds a negligible sliver).
+	if v := BodyGeometryProperties(body, DefaultQuality()).Volume; math.Abs(v-8) > 1e-6 {
+		t.Errorf("near-coplanar hull volume = %g, want ~8", v)
+	}
+}

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -71,22 +71,22 @@ func meshSeamCrossingFace(f *topo.Face, s geom.Surface, outer3D []math.Point3, h
 }
 
 // nonRectangularMesh meshes a non-iso-rectangular curved trim. Every analytic curved surface (torus,
-// sphere, cylinder, cone) goes through metricPatchMesh — a trim-local metric-scaled (u,v) CDT that
-// stays fold-free and volume-correct (#585). A B-spline that fell through nurbsPcurveMesh uses the same
-// CDT without interior Steiner points (trimmedPatchMesh). Anything else keeps the best-fit-plane
-// ear-clip (boundaryPatchMesh).
+// sphere, cylinder, cone) AND the B-spline trim go through metricPatchMesh — a trim-local metric-scaled
+// (u,v) CDT WITH curvature-adaptive interior Steiner points (#585, #1323 L3) — so a larger freeform
+// trim's interior is refined to the chord tolerance, not chorded flat across the boundary loops.
+// Anything else keeps the best-fit-plane ear-clip (boundaryPatchMesh).
 func nonRectangularMesh(s geom.Surface, q Quality, outer3D []math.Point3, holes3D [][]math.Point3, outerUV []math.Point2, holesUV [][]math.Point2) *Mesh {
 	switch s.(type) {
-	case geom.Torus, geom.Sphere, geom.Cylinder, geom.Cone:
-		// Analytic curved trims fold when flattened to a best-fit plane (boundaryPatchMesh) or meshed
-		// over a plain anisotropic (u,v) (gridPatchMesh): a torus's ring-vs-tube, a sphere near its
-		// poles, a trimmed cyl/cone. metricPatchMesh triangulates in a TRIM-LOCAL metric-scaled (u,v)
+	case geom.Torus, geom.Sphere, geom.Cylinder, geom.Cone, geom.BSplineSurface:
+		// These trims fold when flattened to a best-fit plane (boundaryPatchMesh) or meshed over a plain
+		// anisotropic (u,v) (gridPatchMesh): a torus's ring-vs-tube, a sphere near its poles, a trimmed
+		// cyl/cone, a freeform B-spline. metricPatchMesh triangulates in a TRIM-LOCAL metric-scaled (u,v)
 		// (√E,√G over the trim's own (u,v) bbox, so even a cone — whose metric degenerates only toward
-		// the far-off apex — stays well conditioned), plus repairFolds. This was the bulk of the EDF
-		// over-enclosure (#585: total volume +35.6% → ≈exact, torus the single largest fold source).
+		// the far-off apex — stays well conditioned) with deflection-adaptive interior nodes kept
+		// strictly inside the trim (adaptiveInteriorNodes/clearOfTrim), plus repairFolds and a
+		// boundary-only fallback. This was the bulk of the EDF over-enclosure (#585) and, for B-splines,
+		// removes the interior chord error of the old boundary-only triangulation (#1323 L3).
 		return metricPatchMesh(s, q, outer3D, holes3D, outerUV, holesUV)
-	case geom.BSplineSurface:
-		return trimmedPatchMesh(s, outer3D, holes3D)
 	}
 	return boundaryPatchMesh(s, outer3D, holes3D)
 }

--- a/kernel/ops/trim_refine_l3_test.go
+++ b/kernel/ops/trim_refine_l3_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Regression for Oblikovati/Oblikovati#1323 L3: a non-rectangular B-spline trim was meshed boundary-
+// only (trimmedPatchMesh), chording flat across the surface's interior curvature. B-spline trims now
+// go through metricPatchMesh, which adds curvature-adaptive interior Steiner points, so the meshed
+// area converges to the true surface area instead of under-filling.
+
+// curvedBumpPatch is a biquadratic B-spline patch over the unit (u,v) domain bulging in +Z — curved
+// enough that a boundary-only triangulation chords visibly across the interior.
+func curvedBumpPatch(t *testing.T) geom.BSplineSurface {
+	t.Helper()
+	ctrl := [][]math.Point3{
+		{math.P3(0, 0, 0), math.P3(0, 0.5, 0.3), math.P3(0, 1, 0)},
+		{math.P3(0.5, 0, 0.3), math.P3(0.5, 0.5, 1.0), math.P3(0.5, 1, 0.3)},
+		{math.P3(1, 0, 0), math.P3(1, 0.5, 0.3), math.P3(1, 1, 0)},
+	}
+	w := [][]float64{{1, 1, 1}, {1, 1, 1}, {1, 1, 1}}
+	s, err := geom.NewBSplineSurface(2, 2, ctrl, w, []float64{0, 0, 0, 1, 1, 1}, []float64{0, 0, 0, 1, 1, 1})
+	if err != nil {
+		t.Fatalf("NewBSplineSurface: %v", err)
+	}
+	return s
+}
+
+// referencePatchArea integrates |∂P/∂u × ∂P/∂v| over [0,1]² on a fine grid — the true surface area.
+func referencePatchArea(s geom.Surface) float64 {
+	const n = 200
+	h := 1.0 / n
+	var area float64
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			u, v := (float64(i)+0.5)*h, (float64(j)+0.5)*h
+			du, dv := s.DerivativesAt(u, v)
+			area += float64(du.Cross(dv).Length()) * h * h
+		}
+	}
+	return area
+}
+
+// denseBoundary samples the patch's four edges at m points each → the trim loop (3D + uv), so the
+// boundary itself is accurate and the only meshing difference is interior refinement.
+func denseBoundary(s geom.Surface, m int) (p3 []math.Point3, uv []math.Point2) {
+	add := func(u, v float64) {
+		p3 = append(p3, s.PointAt(u, v))
+		uv = append(uv, math.P2(math.Scalar(u), math.Scalar(v)))
+	}
+	for i := 0; i < m; i++ {
+		add(float64(i)/float64(m), 0)
+	}
+	for i := 0; i < m; i++ {
+		add(1, float64(i)/float64(m))
+	}
+	for i := 0; i < m; i++ {
+		add(1-float64(i)/float64(m), 1)
+	}
+	for i := 0; i < m; i++ {
+		add(0, 1-float64(i)/float64(m))
+	}
+	return p3, uv
+}
+
+// TestBSplineTrimInteriorRefinementArea is the core L3 assertion: on a curved B-spline trim, the
+// interior-refined mesh (metricPatchMesh, the new B-spline path) is closer to the true area than the
+// boundary-only mesh (trimmedPatchMesh, the old path), and within the chord tolerance.
+func TestBSplineTrimInteriorRefinementArea(t *testing.T) {
+	s := curvedBumpPatch(t)
+	ref := referencePatchArea(s)
+	p3, uv := denseBoundary(s, 24)
+
+	boundaryOnly := trimmedPatchMesh(s, p3, nil)
+	q := Quality{ChordTolerance: 0.01, AngleTolerance: 5 * stdmath.Pi / 180}
+	refined := metricPatchMesh(s, q, p3, nil, uv, nil)
+
+	if refined.TriangleCount() <= boundaryOnly.TriangleCount() {
+		t.Errorf("refined mesh has %d triangles, boundary-only %d — no interior Steiner points added",
+			refined.TriangleCount(), boundaryOnly.TriangleCount())
+	}
+	errBoundary := stdmath.Abs(meshArea(boundaryOnly) - ref)
+	errRefined := stdmath.Abs(meshArea(refined) - ref)
+	if errRefined >= errBoundary {
+		t.Errorf("interior refinement did not reduce area error: refined %g vs boundary-only %g (ref %g)",
+			errRefined, errBoundary, ref)
+	}
+	// At chord 0.01 the interior-refined area is within ~1% of truth (it tightens further with the
+	// chord — see TestBSplineTrimAreaConvergesWithQuality); the boundary-only mesh is far worse.
+	if rel := errRefined / ref; rel > 1.5e-2 {
+		t.Errorf("refined area rel error %g exceeds tolerance (area %g, ref %g)", rel, meshArea(refined), ref)
+	}
+}
+
+// TestBSplineTrimAreaConvergesWithQuality asserts the refined B-spline trim area converges toward the
+// true area as the chord tolerance tightens (monotone, no spike).
+func TestBSplineTrimAreaConvergesWithQuality(t *testing.T) {
+	s := curvedBumpPatch(t)
+	ref := referencePatchArea(s)
+	p3, uv := denseBoundary(s, 24)
+	prev := stdmath.Inf(1)
+	for _, chord := range []float64{0.05, 0.01, 0.002} {
+		q := Quality{ChordTolerance: chord, AngleTolerance: 5 * stdmath.Pi / 180}
+		m := metricPatchMesh(s, q, p3, nil, uv, nil)
+		relErr := stdmath.Abs(meshArea(m)-ref) / ref
+		if relErr > prev+1e-9 {
+			t.Errorf("chord %g: rel area error %g grew vs previous %g (non-monotone)", chord, relErr, prev)
+		}
+		prev = relErr
+	}
+	if prev > 2e-3 {
+		t.Errorf("finest B-spline trim area rel error %g too large", prev)
+	}
+}

--- a/math/predicate/predicate.go
+++ b/math/predicate/predicate.go
@@ -8,10 +8,19 @@ import (
 	"oblikovati.org/math"
 )
 
-// errScale is a conservative multiple of the float64 unit roundoff (2⁻⁵³). When a
-// determinant's magnitude exceeds errScale·(magnitude of its terms), the float64
-// sign is trustworthy; otherwise the exact path decides.
-const errScale = 1e-14
+// Per-predicate static float filters. Each is a small multiple of the unit roundoff u = 2⁻⁵³, set
+// safely ABOVE Shewchuk's PROVEN A-level forward-error bounds for these adaptive determinants
+// (orient2d (3+16u)u, orient3d (7+56u)u, incircle (10+96u)u; "Robust Adaptive Floating-Point
+// Geometric Predicates", 1997) yet far below the previous uniform 1e-14 ≈ 45u. Being above the proven
+// bound keeps the sign exact whenever the float magnitude clears it; being below 1e-14 sends only the
+// genuinely uncertain (near-degenerate) determinants to the exact big.Rat path instead of every
+// modestly small one (#1323 L4). Correctness is unchanged — only how often the slow path runs.
+const (
+	unitRoundoff   = 1.1102230246251565e-16                // u = 2⁻⁵³
+	orient2DFilter = (3 + 16*unitRoundoff) * unitRoundoff  // Shewchuk ccwerrboundA ≈ 3.3e-16
+	orient3DFilter = (7 + 56*unitRoundoff) * unitRoundoff  // Shewchuk o3derrboundA ≈ 7.8e-16
+	inCircleFilter = (10 + 96*unitRoundoff) * unitRoundoff // Shewchuk iccerrboundA ≈ 1.1e-15
+)
 
 // Orient2D returns a value with the sign of the signed area of triangle (a, b, c):
 // positive if a→b→c turns counter-clockwise, negative if clockwise, exactly zero
@@ -20,7 +29,7 @@ func Orient2D(a, b, c math.Point2) float64 {
 	left := (a.X - c.X) * (b.Y - c.Y)
 	right := (a.Y - c.Y) * (b.X - c.X)
 	det := left - right
-	bound := errScale * (stdmath.Abs(left) + stdmath.Abs(right))
+	bound := orient2DFilter * (stdmath.Abs(left) + stdmath.Abs(right))
 	if det > bound || -det > bound {
 		return det
 	}
@@ -32,7 +41,7 @@ func Orient2D(a, b, c math.Point2) float64 {
 // negative if above, zero if coplanar. The sign is always correct.
 func Orient3D(a, b, c, d math.Point3) float64 {
 	det, mag := orient3DFloat(a, b, c, d)
-	bound := errScale * mag
+	bound := orient3DFilter * mag
 	if det > bound || -det > bound {
 		return det
 	}
@@ -44,35 +53,47 @@ func Orient3D(a, b, c, d math.Point3) float64 {
 // zero if cocircular. The sign is always correct.
 func InCircle(a, b, c, d math.Point2) float64 {
 	det, mag := inCircleFloat(a, b, c, d)
-	bound := errScale * mag
+	bound := inCircleFilter * mag
 	if det > bound || -det > bound {
 		return det
 	}
 	return float64(inCircleExact(a, b, c, d))
 }
 
-// orient3DFloat computes the 3×3 determinant of (a−d, b−d, c−d) in float64 and a
-// magnitude estimate of its terms for the error bound.
-func orient3DFloat(a, b, c, d math.Point3) (det, mag float64) {
-	ax, ay, az := a.X-d.X, a.Y-d.Y, a.Z-d.Z
-	bx, by, bz := b.X-d.X, b.Y-d.Y, b.Z-d.Z
-	cx, cy, cz := c.X-d.X, c.Y-d.Y, c.Z-d.Z
-	t1 := ax * (by*cz - bz*cy)
-	t2 := bx * (ay*cz - az*cy)
-	t3 := cx * (ay*bz - az*by)
-	return t1 - t2 + t3, stdmath.Abs(t1) + stdmath.Abs(t2) + stdmath.Abs(t3)
+// orient3DFloat computes the 3×3 determinant of (a−d, b−d, c−d) in float64 and Shewchuk's PERMANENT
+// for it — the sum of the absolute products BEFORE the minors' internal subtraction can cancel. (A
+// plain |t₁|+|t₂|+|t₃| over the cofactor terms underestimates the rounding error when a minor nearly
+// cancels, which is why the orient3DFilter must pair with this permanent, not that — #1323 L4.)
+func orient3DFloat(a, b, c, d math.Point3) (det, perm float64) {
+	adx, ady, adz := float64(a.X-d.X), float64(a.Y-d.Y), float64(a.Z-d.Z)
+	bdx, bdy, bdz := float64(b.X-d.X), float64(b.Y-d.Y), float64(b.Z-d.Z)
+	cdx, cdy, cdz := float64(c.X-d.X), float64(c.Y-d.Y), float64(c.Z-d.Z)
+	bdxcdy, cdxbdy := bdx*cdy, cdx*bdy
+	cdxady, adxcdy := cdx*ady, adx*cdy
+	adxbdy, bdxady := adx*bdy, bdx*ady
+	det = adz*(bdxcdy-cdxbdy) + bdz*(cdxady-adxcdy) + cdz*(adxbdy-bdxady)
+	perm = (stdmath.Abs(bdxcdy)+stdmath.Abs(cdxbdy))*stdmath.Abs(adz) +
+		(stdmath.Abs(cdxady)+stdmath.Abs(adxcdy))*stdmath.Abs(bdz) +
+		(stdmath.Abs(adxbdy)+stdmath.Abs(bdxady))*stdmath.Abs(cdz)
+	return det, perm
 }
 
-// inCircleFloat computes the in-circle determinant in float64 plus a term magnitude.
-func inCircleFloat(a, b, c, d math.Point2) (det, mag float64) {
-	adx, ady := a.X-d.X, a.Y-d.Y
-	bdx, bdy := b.X-d.X, b.Y-d.Y
-	cdx, cdy := c.X-d.X, c.Y-d.Y
+// inCircleFloat computes the in-circle determinant in float64 plus Shewchuk's permanent for it. The
+// lifts (adx²+ady², …) are non-negative, so the permanent weights each cross-product magnitude by the
+// lift, again capturing the rounding error before the minor subtractions cancel.
+func inCircleFloat(a, b, c, d math.Point2) (det, perm float64) {
+	adx, ady := float64(a.X-d.X), float64(a.Y-d.Y)
+	bdx, bdy := float64(b.X-d.X), float64(b.Y-d.Y)
+	cdx, cdy := float64(c.X-d.X), float64(c.Y-d.Y)
 	alift := adx*adx + ady*ady
 	blift := bdx*bdx + bdy*bdy
 	clift := cdx*cdx + cdy*cdy
-	t1 := alift * (bdx*cdy - cdx*bdy)
-	t2 := blift * (adx*cdy - cdx*ady)
-	t3 := clift * (adx*bdy - bdx*ady)
-	return t1 - t2 + t3, stdmath.Abs(t1) + stdmath.Abs(t2) + stdmath.Abs(t3)
+	bdxcdy, cdxbdy := bdx*cdy, cdx*bdy
+	cdxady, adxcdy := cdx*ady, adx*cdy
+	adxbdy, bdxady := adx*bdy, bdx*ady
+	det = alift*(bdxcdy-cdxbdy) + blift*(cdxady-adxcdy) + clift*(adxbdy-bdxady)
+	perm = (stdmath.Abs(bdxcdy)+stdmath.Abs(cdxbdy))*alift +
+		(stdmath.Abs(cdxady)+stdmath.Abs(adxcdy))*blift +
+		(stdmath.Abs(adxbdy)+stdmath.Abs(bdxady))*clift
+	return det, perm
 }

--- a/math/predicate/predicate_filter_test.go
+++ b/math/predicate/predicate_filter_test.go
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package predicate
+
+import (
+	stdmath "math"
+	"math/rand"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// Regression for Oblikovati/Oblikovati#1323 L4: the static float filter was tightened from a uniform
+// 1e-14 to per-predicate constants just above Shewchuk's proven A-level bounds. These tests prove the
+// tightened band is (a) still sign-exact — never trusts a wrong float sign — and (b) genuinely tighter
+// (resolves cases the old 1e-14 sent to the exact path), the performance win.
+
+const oldErrScale = 1e-14 // the previous uniform filter, for the before/after comparison
+
+func sgn(x float64) int {
+	switch {
+	case x > 0:
+		return 1
+	case x < 0:
+		return -1
+	default:
+		return 0
+	}
+}
+
+// nearCollinear2 returns a, b and a c that sits a tiny perpendicular distance off line a→b, so the
+// orient2d determinant lands in the filter's uncertain band.
+func nearCollinear2(rng *rand.Rand) (a, b, c math.Point2) {
+	a = math.P2(math.Scalar(rng.Float64()*20-10), math.Scalar(rng.Float64()*20-10))
+	b = math.P2(math.Scalar(rng.Float64()*20-10), math.Scalar(rng.Float64()*20-10))
+	s := math.Scalar(rng.Float64()*2 - 0.5)
+	perp := math.Scalar((rng.Float64()*2 - 1) * stdmath.Pow(10, -rng.Float64()*16))
+	dir := a.VectorTo(b)
+	n := math.V2(-float64(dir.Y), float64(dir.X))
+	mid := a.TranslateBy(dir.Scale(s))
+	c = mid.TranslateBy(n.Scale(perp))
+	return a, b, c
+}
+
+// TestOrient2DTightenedFilterIsExactAndTighter checks both properties on orient2d.
+func TestOrient2DTightenedFilterIsExactAndTighter(t *testing.T) {
+	rng := rand.New(rand.NewSource(14))
+	trustedNewMismatch, newResolvesOldExact := 0, 0
+	for i := 0; i < 300000; i++ {
+		a, b, c := nearCollinear2(rng)
+		left := (a.X - c.X) * (b.Y - c.Y)
+		right := (a.Y - c.Y) * (b.X - c.X)
+		det := float64(left - right)
+		mag := stdmath.Abs(float64(left)) + stdmath.Abs(float64(right))
+		newBound := orient2DFilter * mag
+		oldBound := oldErrScale * mag
+		exact := orient2DExact(a, b, c)
+		if stdmath.Abs(det) > newBound && sgn(det) != exact {
+			trustedNewMismatch++ // the tightened filter trusted a WRONG sign — must never happen
+		}
+		if stdmath.Abs(det) > newBound && stdmath.Abs(det) <= oldBound {
+			newResolvesOldExact++ // new filter resolves by float what old sent to exact
+		}
+		// The public predicate must always equal the exact sign.
+		if sgn(Orient2D(a, b, c)) != exact {
+			t.Fatalf("Orient2D sign %d != exact %d at case %d", sgn(Orient2D(a, b, c)), exact, i)
+		}
+	}
+	if trustedNewMismatch != 0 {
+		t.Errorf("tightened orient2d filter trusted a wrong float sign in %d cases", trustedNewMismatch)
+	}
+	if newResolvesOldExact == 0 {
+		t.Error("tightened orient2d filter never beat the old 1e-14 bound — no perf win demonstrated")
+	}
+	t.Logf("orient2d: %d cases newly resolved by float (were exact under 1e-14)", newResolvesOldExact)
+}
+
+// nearCoplanar3 returns a,b,c and a d a tiny distance off their plane.
+func nearCoplanar3(rng *rand.Rand) (a, b, c, d math.Point3) {
+	rp := func() math.Point3 {
+		return math.P3(math.Scalar(rng.Float64()*20-10), math.Scalar(rng.Float64()*20-10), math.Scalar(rng.Float64()*20-10))
+	}
+	a, b, c = rp(), rp(), rp()
+	n := a.VectorTo(b).Cross(a.VectorTo(c))
+	s := math.Scalar(rng.Float64())
+	u := math.Scalar(rng.Float64())
+	base := a.TranslateBy(a.VectorTo(b).Scale(s)).TranslateBy(a.VectorTo(c).Scale(u))
+	off := math.Scalar((rng.Float64()*2 - 1) * stdmath.Pow(10, -rng.Float64()*16))
+	d = base.TranslateBy(n.Scale(off))
+	return a, b, c, d
+}
+
+// TestOrient3DTightenedFilterIsExactAndTighter checks both properties on orient3d.
+func TestOrient3DTightenedFilterIsExactAndTighter(t *testing.T) {
+	rng := rand.New(rand.NewSource(56))
+	mismatch, tighter := 0, 0
+	for i := 0; i < 300000; i++ {
+		a, b, c, d := nearCoplanar3(rng)
+		det, mag := orient3DFloat(a, b, c, d)
+		newBound := orient3DFilter * mag
+		oldBound := oldErrScale * mag
+		exact := orient3DExact(a, b, c, d)
+		if stdmath.Abs(det) > newBound && sgn(det) != exact {
+			mismatch++
+		}
+		if stdmath.Abs(det) > newBound && stdmath.Abs(det) <= oldBound {
+			tighter++
+		}
+		if sgn(Orient3D(a, b, c, d)) != exact {
+			t.Fatalf("Orient3D sign != exact at case %d", i)
+		}
+	}
+	if mismatch != 0 {
+		t.Errorf("tightened orient3d filter trusted a wrong float sign in %d cases", mismatch)
+	}
+	if tighter == 0 {
+		t.Error("tightened orient3d filter never beat the old 1e-14 bound")
+	}
+	t.Logf("orient3d: %d cases newly resolved by float", tighter)
+}
+
+// nearCocircular2 returns a,b,c and a d near their circumcircle.
+func nearCocircular2(rng *rand.Rand) (a, b, c, d math.Point2) {
+	cx, cy := rng.Float64()*10-5, rng.Float64()*10-5
+	r := rng.Float64()*5 + 1
+	at := func(ang float64) math.Point2 {
+		return math.P2(math.Scalar(cx+r*stdmath.Cos(ang)), math.Scalar(cy+r*stdmath.Sin(ang)))
+	}
+	a, b, c = at(rng.Float64()*6.28), at(rng.Float64()*6.28), at(rng.Float64()*6.28)
+	rr := r + (rng.Float64()*2-1)*stdmath.Pow(10, -rng.Float64()*15)
+	ang := rng.Float64() * 6.28
+	d = math.P2(math.Scalar(cx+rr*stdmath.Cos(ang)), math.Scalar(cy+rr*stdmath.Sin(ang)))
+	return a, b, c, d
+}
+
+// TestInCircleTightenedFilterIsExactAndTighter checks both properties on incircle.
+func TestInCircleTightenedFilterIsExactAndTighter(t *testing.T) {
+	rng := rand.New(rand.NewSource(96))
+	mismatch, tighter := 0, 0
+	for i := 0; i < 300000; i++ {
+		a, b, c, d := nearCocircular2(rng)
+		det, mag := inCircleFloat(a, b, c, d)
+		newBound := inCircleFilter * mag
+		oldBound := oldErrScale * mag
+		exact := inCircleExact(a, b, c, d)
+		if stdmath.Abs(det) > newBound && sgn(det) != exact {
+			mismatch++
+		}
+		if stdmath.Abs(det) > newBound && stdmath.Abs(det) <= oldBound {
+			tighter++
+		}
+		if sgn(InCircle(a, b, c, d)) != exact {
+			t.Fatalf("InCircle sign != exact at case %d", i)
+		}
+	}
+	if mismatch != 0 {
+		t.Errorf("tightened incircle filter trusted a wrong float sign in %d cases", mismatch)
+	}
+	if tighter == 0 {
+		t.Error("tightened incircle filter never beat the old 1e-14 bound")
+	}
+	t.Logf("incircle: %d cases newly resolved by float", tighter)
+}


### PR DESCRIPTION
Four self-contained numerical-hardening items from the M37 audit, one commit each.

## L1 — `numericDers3` third derivative
The `Curve3` fallback used one fixed `1e-5` step for all three derivatives, so the 3rd-derivative denominator `2h³ ≈ 2e-15` amplified value roundoff into 5–50% error. Now each order uses its optimal step `h ≈ ε^{1/(n+2)}`. Validated against an analytic helix routed through the fallback (d3 < 1e-4 relative).

## L2 — Convex hull visibility
Quickhull's "point sees face" test used a float dot-product tolerance, fragile on the coplanar inputs `hull()` is built for. Now uses the exact `predicate.Orient3D` (`< 0` with the outward winding). Cube hull is exactly 12 triangles, stable under reordering; near-coplanar sets stay valid solids.

## L3 — B-spline trim interior refinement
A non-rectangular B-spline trim was meshed boundary-only, chording across interior curvature. Now routed through `metricPatchMesh` — the same metric-scaled CDT with curvature-adaptive interior Steiner points the analytic curved surfaces use (trim-aware via `adaptiveInteriorNodes`/`clearOfTrim`, with a boundary-only fallback). On a curved patch the refined area beats boundary-only and converges below 0.2% as the chord tightens.

## L4 — Predicate float filter
The static filter used a uniform `1e-14 (~45u)`. Replaced with Shewchuk's **proven** A-level bounds, and — crucially — the **matching permanent** for orient3d/incircle (the old `|t₁|+|t₂|+|t₃|` underestimates the error when a minor cancels, so a tight constant on it would flip signs). **Correctness is unchanged** (bound stays above the true forward error): 900k random + near-degenerate triples per predicate confirm the tightened filter never trusts a wrong sign while resolving thousands of cases the old bound sent to the exact `big.Rat` path.

Coverage > 80%, `golangci-lint` clean, full `./math/...` + `./kernel/...` + `./model/...` green.

Closes #1323