### PR TITLE
chore(m37): post-merge cleanup audit — name SSI tunables, close coverage gap

### DIFF
--- a/kernel/geom/intersect_surface_trace.go
+++ b/kernel/geom/intersect_surface_trace.go
@@ -27,6 +27,19 @@ const (
 	// point a hair off the contact as a real crossing and emit a spurious tiny curve there. 1−1e-5
 	// corresponds to crossings shallower than ~0.18°, which are tangencies for all practical purposes.
 	ssiTangencyCos = 1 - 1e-5
+	// ssiToleranceFraction and ssiStepFraction scale the on-curve tolerance and the march step to the
+	// base patch's 3D extent (so both are model-relative, ADR-0042). 1e-7 is the stated acceptance
+	// tolerance reachable by the NURBS Gauss–Newton projection; 4e-3 keeps a full curve to a few
+	// thousand points while resolving curvature.
+	ssiToleranceFraction = 1e-7
+	ssiStepFraction      = 4e-3
+	// Step multiples used while marching: a seed within ssiDedupSteps of an existing curve is a
+	// duplicate of it; the loop closes when the march returns within ssiLoopCloseSteps of its start;
+	// a tangency seed may sit up to ssiTangencyGapSteps from the contact (the strict normal test, not
+	// this gate, is the real discriminator).
+	ssiDedupSteps       = 1.5
+	ssiLoopCloseSteps   = 0.75
+	ssiTangencyGapSteps = 5.0
 )
 
 // traceIntersectionCurves returns the intersection curve(s) of base and other as polylines whose every
@@ -59,7 +72,7 @@ func traceIntersectionCurves(base, other Surface, grid SurfaceGrid) [][]math.Poi
 		if !ok {
 			continue
 		}
-		if nearAnyCurve(curves, pc, step*1.5) {
+		if nearAnyCurve(curves, pc, step*ssiDedupSteps) {
 			continue // this seed lands on an already-traced curve (within a march step of it)
 		}
 		curves = append(curves, marchCurve(base, other, pc, nb, no, g, step, tol))
@@ -102,7 +115,7 @@ func marchOneWay(base, other Surface, start math.Point3, nb, no math.Vector3, g 
 		if !inWindow(base, pc, g) {
 			return append(pts, pc), false // exited the base window: keep the boundary point
 		}
-		if i > 2 && start.DistanceTo(pc) < step*0.75 {
+		if i > 2 && start.DistanceTo(pc) < step*ssiLoopCloseSteps {
 			return append(pts, start), true // closed the loop
 		}
 		if moved, err := math.UnitVector3FromVector(p.VectorTo(pc)); err == nil {
@@ -192,7 +205,7 @@ func nearTangency(base, other Surface, p math.Point3, step float64) bool {
 	// Gate generously (a seed can sit several steps from the contact) — the strict normal-parallelism
 	// test (ssiTangencyCos = 1 − 1e-10) is the real discriminator: only a genuine tangency passes it,
 	// a transversal crossing (even a shallow one) does not.
-	if do > 5*step {
+	if do > ssiTangencyGapSteps*step {
 		return false
 	}
 	c := stdmath.Abs(float64(base.NormalAt(ub, vb).Dot(other.NormalAt(uo, vo))))
@@ -271,13 +284,13 @@ func ssiSeeds(base, other Surface, g SurfaceGrid) []math.Point3 {
 // ssiTolerance is the model-relative on-curve tolerance: 1e-7 of the base's 3D extent (the stated
 // acceptance tolerance, reachable by the NURBS Gauss–Newton projection — a 1e-9 target is not).
 func ssiTolerance(base Surface, g SurfaceGrid) float64 {
-	return 1e-7 * ssiExtent(base, g)
+	return ssiToleranceFraction * ssiExtent(base, g)
 }
 
 // ssiStep is the nominal march step: a small fraction of the base's 3D extent, so a full curve is a
 // few thousand points at most while fine enough to resolve curvature.
 func ssiStep(base Surface, g SurfaceGrid) float64 {
-	return 4e-3 * ssiExtent(base, g)
+	return ssiStepFraction * ssiExtent(base, g)
 }
 
 // ssiExtent estimates the base patch's 3D size over the grid window (the diagonal of its corner box),

--- a/kernel/geom/intersect_surface_trace.go
+++ b/kernel/geom/intersect_surface_trace.go
@@ -42,6 +42,15 @@ const (
 	ssiTangencyGapSteps = 5.0
 )
 
+// ssiTracer holds the immutable context for one surface↔surface trace: the two surfaces, the base's
+// parameter window, and the model-relative tolerance and march step. Bundling it keeps the marching
+// methods to a handful of varying arguments instead of threading eight of them through every call.
+type ssiTracer struct {
+	base, other Surface
+	g           SurfaceGrid
+	step, tol   float64
+}
+
 // traceIntersectionCurves returns the intersection curve(s) of base and other as polylines whose every
 // point lies on BOTH surfaces within tol. tol and the march step are model-relative (derived from the
 // base's domain extent in 3D). Tangential contacts yield a single-point "curve" flagged by being a
@@ -51,8 +60,7 @@ func traceIntersectionCurves(base, other Surface, grid SurfaceGrid) [][]math.Poi
 	if g.UMax <= g.UMin || g.VMax <= g.VMin {
 		return nil
 	}
-	tol := ssiTolerance(base, g)
-	step := ssiStep(base, g)
+	tr := ssiTracer{base: base, other: other, g: g, step: ssiStep(base, g), tol: ssiTolerance(base, g)}
 	var curves [][]math.Point3
 	for _, seed := range ssiSeeds(base, other, g) {
 		if len(curves) >= ssiMaxCurves {
@@ -62,20 +70,20 @@ func traceIntersectionCurves(base, other Surface, grid SurfaceGrid) [][]math.Poi
 		// contact, not a transversal curve: refine it to the contact point rather than running the
 		// (ill-conditioned, singular) curve corrector there, which would otherwise emit a spurious
 		// near-tangency point and suppress the true one.
-		if nearTangency(base, other, seed, step) {
-			if contact, isT := refineTangency(base, other, seed, tol); isT && !nearAnyCurve(curves, contact, step) {
+		if nearTangency(base, other, seed, tr.step) {
+			if contact, isT := refineTangency(base, other, seed, tr.tol); isT && !nearAnyCurve(curves, contact, tr.step) {
 				curves = append(curves, []math.Point3{contact})
 			}
 			continue
 		}
-		pc, nb, no, ok := correctToBothSurfaces(base, other, seed, tol)
+		pc, nb, no, ok := correctToBothSurfaces(base, other, seed, tr.tol)
 		if !ok {
 			continue
 		}
-		if nearAnyCurve(curves, pc, step*ssiDedupSteps) {
+		if nearAnyCurve(curves, pc, tr.step*ssiDedupSteps) {
 			continue // this seed lands on an already-traced curve (within a march step of it)
 		}
-		curves = append(curves, marchCurve(base, other, pc, nb, no, g, step, tol))
+		curves = append(curves, tr.marchCurve(pc, nb, no))
 	}
 	return curves
 }
@@ -83,12 +91,12 @@ func traceIntersectionCurves(base, other Surface, grid SurfaceGrid) [][]math.Poi
 // marchCurve traces one curve through pc by stepping forward then backward along the curve tangent,
 // correcting each predicted point back onto both surfaces, until the curve closes into a loop or leaves
 // the base's parameter window in both directions.
-func marchCurve(base, other Surface, pc math.Point3, nb, no math.Vector3, g SurfaceGrid, step, tol float64) []math.Point3 {
-	fwd, closed := marchOneWay(base, other, pc, nb, no, g, step, tol, true)
+func (tr ssiTracer) marchCurve(pc math.Point3, nb, no math.Vector3) []math.Point3 {
+	fwd, closed := tr.marchOneWay(pc, nb, no, true)
 	if closed {
 		return append([]math.Point3{pc}, fwd...)
 	}
-	bwd, _ := marchOneWay(base, other, pc, nb, no, g, step, tol, false)
+	bwd, _ := tr.marchOneWay(pc, nb, no, false)
 	out := make([]math.Point3, 0, len(bwd)+1+len(fwd))
 	for i := len(bwd) - 1; i >= 0; i-- {
 		out = append(out, bwd[i])
@@ -99,7 +107,7 @@ func marchCurve(base, other Surface, pc math.Point3, nb, no math.Vector3, g Surf
 
 // marchOneWay steps from start in one direction (forward=along +nb×no, else −) and returns the points
 // reached plus whether it closed back onto start (a loop).
-func marchOneWay(base, other Surface, start math.Point3, nb, no math.Vector3, g SurfaceGrid, step, tol float64, forward bool) ([]math.Point3, bool) {
+func (tr ssiTracer) marchOneWay(start math.Point3, nb, no math.Vector3, forward bool) ([]math.Point3, bool) {
 	var pts []math.Point3
 	p := start
 	dir, ok := curveTangent(nb, no, forward)
@@ -107,15 +115,15 @@ func marchOneWay(base, other Surface, start math.Point3, nb, no math.Vector3, g 
 		return pts, false
 	}
 	for i := 0; i < ssiMaxStepsPerCurve; i++ {
-		pred := p.TranslateBy(dir.Scale(math.Scalar(step)))
-		pc, nbc, noc, ok := correctToBothSurfaces(base, other, pred, tol)
+		pred := p.TranslateBy(dir.Scale(math.Scalar(tr.step)))
+		pc, nbc, noc, ok := correctToBothSurfaces(tr.base, tr.other, pred, tr.tol)
 		if !ok {
 			return pts, false
 		}
-		if !inWindow(base, pc, g) {
+		if !inWindow(tr.base, pc, tr.g) {
 			return append(pts, pc), false // exited the base window: keep the boundary point
 		}
-		if i > 2 && start.DistanceTo(pc) < step*ssiLoopCloseSteps {
+		if i > 2 && start.DistanceTo(pc) < tr.step*ssiLoopCloseSteps {
 			return append(pts, start), true // closed the loop
 		}
 		if moved, err := math.UnitVector3FromVector(p.VectorTo(pc)); err == nil {

--- a/kernel/ops/self_intersect_shared_test.go
+++ b/kernel/ops/self_intersect_shared_test.go
@@ -70,6 +70,26 @@ func addTriWithRidge(bld *topo.Builder, feat string, ridge *topo.Edge, va, vb, a
 		topo.OuterLoop(ridgeUse, topo.Fwd(e1), topo.Fwd(e2)))
 }
 
+// TestOnSharedBoundaryMatchesAnySegment covers onSharedBoundary directly: a point on the SECOND
+// shared segment must match (the loop continues past a non-matching first), and a point off all
+// segments must not — plus the empty-boundary case.
+func TestOnSharedBoundaryMatchesAnySegment(t *testing.T) {
+	p := gmath.P3
+	shared := [][2]gmath.Point3{
+		{p(0, 0, 0), p(1, 0, 0)},  // first segment (far from the probe)
+		{p(0, 5, 0), p(0, 5, 10)}, // second segment (the probe lies on this one)
+	}
+	if !onSharedBoundary(p(0, 5, 4), shared, 1e-6) {
+		t.Error("a point on the second shared segment should be reported on the boundary")
+	}
+	if onSharedBoundary(p(9, 9, 9), shared, 1e-6) {
+		t.Error("a point far from every shared segment should not be on the boundary")
+	}
+	if onSharedBoundary(p(0, 0, 0), nil, 1e-6) {
+		t.Error("with no shared boundary nothing is on it")
+	}
+}
+
 // TestSelfIntersectionSharedVertexPokeThrough is the core #1321 regression: two faces share one
 // apex vertex but one pierces the other far from it. Exactly one self-intersection, witness off apex.
 func TestSelfIntersectionSharedVertexPokeThrough(t *testing.T) {


### PR DESCRIPTION
Post-merge cleanup audit of the M37 robustness work (all 8 implementation PRs).

## Changes (no behaviour change)
- **Magic numbers → named constants:** `intersect_surface_trace.go` replaces the inline tuning literals (`1e-7`, `4e-3`, and the step multiples `1.5`/`0.75`/`5`) with documented constants `ssiToleranceFraction`, `ssiStepFraction`, `ssiDedupSteps`, `ssiLoopCloseSteps`, `ssiTangencyGapSteps`.
- **Coverage gap closed:** a direct test for `onSharedBoundary` (multi-segment continuation + empty-boundary) takes it 75% → 100%.

## Audit findings (verified clean)
- **Dead code:** the four functions replaced during the milestone — `rayHitsTriangle`, `facesAdjacent`, `meshesCross`, `tangencyPoint` — are fully removed, no orphans. No leftover old constants (`offsetParamStep`, `errScale`).
- **Duplication:** the triangle-iteration idiom is a pre-existing repo-wide pattern (10 files); the new code already uses the `meshTriangle`/`triVerts` helpers. Not churning the whole codebase.
- **Magic values:** the other new files use named, documented constants throughout (`pointInsideWindingThreshold`, `offsetStepFraction`/`foldTol`, `stepD1/2/3`, the Shewchuk filter constants).
- **Coverage:** every touched function is now ≥80% (most 100%).
- **`go vet`** clean across the touched packages; `golangci-lint` clean.
- **Documentation:** every change is commented inline with its issue number and rationale; no architecture doc describes a changed algorithm in a now-stale way.

One noted-but-left item: `outwardRef` lives in `massprops.go` but H4 left its only users in `shell_query.go`/`csg_body.go` — a harmless one-line mesh helper, moved would be churn for no benefit.