### PR TITLE
fix(ops): tessellate sphere caps with true curvature (M2 Phase 1)

### DIFF
--- a/kernel/ops/sphere_cap_mesh.go
+++ b/kernel/ops/sphere_cap_mesh.go
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Sphere-cap tessellation (M2 Phase 1, Oblikovati/Oblikovati#1334). A sphere face trimmed by ONE
+// planar circle — the cap a single plane cuts off (a hemisphere, a drilled spherical seat, the
+// curved face of sphere∩half-space) — used to mesh FLAT: meshSeamCrossingFace routed it to the
+// best-fit-plane CDT, whose only vertices are the coplanar rim circle, so with no interior points
+// the "cap" was a flat disk in the cut plane (zero bulge → zero cap volume, wrong mass/render/
+// export for every spherical cap, boolean or not). sphereCapFan instead sweeps latitude rings
+// about the cut axis from the rim to the enclosed pole, so the cap carries its true spherical
+// curvature. Like coneApexFan it claims only the single-circle-boundary case; an arc-bounded
+// sphere patch (a box cut) keeps the existing path.
+
+// sphereCapFan meshes a sphere face whose outer boundary is a single planar circle by fanning
+// latitude rings from that rim to the enclosed pole. ok=false unless the surface is a sphere and
+// the boundary is one circle (every rim point coplanar) — any other trim defers to the caller.
+//
+// Example: a unit sphere cut by z=0, the lower face's rim is the equator → a watertight, true
+// hemisphere cap (tessellated volume → 2/3 πr³).
+func sphereCapFan(s geom.Surface, outer3D []math.Point3, q Quality) (*Mesh, bool) {
+	sph, ok := s.(geom.Sphere)
+	if !ok || len(outer3D) < 3 {
+		return nil, false
+	}
+	axis, ok := capAxis(sph, outer3D)
+	if !ok {
+		return nil, false
+	}
+	return buildSphereCap(sph, outer3D, axis, q), true
+}
+
+// capAxis returns the unit direction from the sphere centre toward the pole the cap encloses (the
+// rim circle's plane normal, flipped to the face's material side). ok=false when the rim is not a
+// single planar circle on the sphere (an arc-bounded patch), which sphereCapFan does not handle.
+func capAxis(sph geom.Sphere, outer3D []math.Point3) (math.Vector3, bool) {
+	a := newellUnit(outer3D) // rim plane normal (unit)
+	if !rimIsCircle(sph, outer3D, a) {
+		return math.Vector3{}, false
+	}
+	// Interior surface direction at the first rim point: outward radial × loop tangent. The cap
+	// pole lies on whichever side of the rim plane that interior direction points to.
+	outward := sph.Center.VectorTo(outer3D[0])
+	tangent := outer3D[0].VectorTo(outer3D[1])
+	if outward.Cross(tangent).Dot(a) < 0 {
+		a = a.Scale(-1)
+	}
+	return a, true
+}
+
+// rimCoplanarTol is the distance a rim sample may deviate from the rim's best-fit plane and still
+// count as one circle. A genuine plane-cut circle's samples are coplanar to edge-tessellation
+// noise (~chord error); an arc-bounded patch's far arcs leave the plane by feature scale.
+const rimCoplanarTol = 1e-6
+
+// rimIsCircle reports whether every boundary sample lies in the single plane (normal a through the
+// rim centroid) — i.e. the boundary is one circle, not a chain of arcs from several cutting planes.
+func rimIsCircle(sph geom.Sphere, outer3D []math.Point3, a math.Vector3) bool {
+	if a.LengthSquared() == 0 {
+		return false
+	}
+	c0 := centroidOf(outer3D)
+	for _, p := range outer3D {
+		if stdmath.Abs(float64(c0.VectorTo(p).Dot(a))) > rimCoplanarTol*sph.Radius {
+			return false
+		}
+	}
+	return true
+}
+
+// buildSphereCap sweeps the rim ring (outer3D, kept exactly so it welds to the cap's planar lid)
+// up to the pole at centre+R·axis, emitting one latitude ring per angular step.
+func buildSphereCap(sph geom.Sphere, outer3D []math.Point3, axis math.Vector3, q Quality) *Mesh {
+	r := sph.Radius
+	alpha := rimPolarAngle(sph, outer3D, axis) // rim's angle from the cap axis
+	rows := capRingCount(alpha, q)
+	m := &Mesh{}
+	grid := capRingVertices(m, sph, outer3D, axis, alpha, rows)
+	pole := m.addVertex(sph.Center.TranslateBy(axis.Scale(math.Scalar(r))), axis)
+	emitCapGrid(m, grid, pole)
+	return m
+}
+
+// rimPolarAngle returns the rim's mean polar angle from the cap axis (acos of the rim direction's
+// axial component), the angle the rings sweep down from to reach the pole (angle 0).
+func rimPolarAngle(sph geom.Sphere, outer3D []math.Point3, axis math.Vector3) float64 {
+	sum := 0.0
+	for _, p := range outer3D {
+		dir := sph.Center.VectorTo(p).Scale(math.Scalar(1 / sph.Radius))
+		sum += stdmath.Acos(clampUnit(float64(dir.Dot(axis))))
+	}
+	return sum / float64(len(outer3D))
+}
+
+// capRingCount picks the number of latitude rings so each ring's angular step stays within the
+// angle tolerance (so the meridian chord error matches the rim's own faceting), at least one ring.
+func capRingCount(alpha float64, q Quality) int {
+	n := int(stdmath.Ceil(alpha / q.angleTol()))
+	if n < 1 {
+		return 1
+	}
+	return n
+}
+
+// capRingVertices builds the cols×rows vertex grid: row 0 is the exact rim (outer3D), rows step the
+// polar angle linearly from the rim angle down toward 0 (the pole, added separately). Each column
+// keeps its own azimuth, so a column is a meridian from rim to pole.
+func capRingVertices(m *Mesh, sph geom.Sphere, outer3D []math.Point3, axis math.Vector3, alpha float64, rows int) [][]int {
+	grid := make([][]int, len(outer3D))
+	for i, p := range outer3D {
+		perp := meridianPerp(sph, p, axis)
+		grid[i] = make([]int, rows)
+		grid[i][0] = m.addVertex(p, sph.Center.VectorTo(p).Scale(math.Scalar(1/sph.Radius)))
+		for k := 1; k < rows; k++ {
+			ang := alpha * float64(rows-k) / float64(rows) // rows→pole as k grows; k=0 is the rim
+			grid[i][k] = m.addVertex(capPoint(sph, axis, perp, ang), capNormal(axis, perp, ang))
+		}
+	}
+	return grid
+}
+
+// meridianPerp returns the unit in-plane direction (perpendicular to the cap axis) of rim point p's
+// meridian, so capPoint can place that column's rings at the rim's own azimuth.
+func meridianPerp(sph geom.Sphere, p math.Point3, axis math.Vector3) math.Vector3 {
+	dir := sph.Center.VectorTo(p)
+	perp := dir.Add(axis.Scale(math.Scalar(-dir.Dot(axis))))
+	if u, err := math.UnitVector3FromVector(perp); err == nil {
+		return u.AsVector()
+	}
+	return perp
+}
+
+// capPoint is the sphere point at polar angle ang from the cap axis along the meridian (axis, perp).
+func capPoint(sph geom.Sphere, axis, perp math.Vector3, ang float64) math.Point3 {
+	cos, sin := stdmath.Cos(ang), stdmath.Sin(ang)
+	dir := axis.Scale(math.Scalar(cos)).Add(perp.Scale(math.Scalar(sin)))
+	return sph.Center.TranslateBy(dir.Scale(math.Scalar(sph.Radius)))
+}
+
+// capNormal is the outward unit normal at the cap point — the radial direction equals (axis, perp)
+// at angle ang.
+func capNormal(axis, perp math.Vector3, ang float64) math.Vector3 {
+	cos, sin := stdmath.Cos(ang), stdmath.Sin(ang)
+	return axis.Scale(math.Scalar(cos)).Add(perp.Scale(math.Scalar(sin)))
+}
+
+// emitCapGrid triangulates the rim→pole grid (columns wrap, since the rim is a closed loop) and
+// fans the last ring to the shared pole vertex, each triangle wound to agree with its normals.
+func emitCapGrid(m *Mesh, grid [][]int, pole int) {
+	cols, rows := len(grid), len(grid[0])
+	for i := 0; i < cols; i++ {
+		ni := (i + 1) % cols
+		for k := 0; k+1 < rows; k++ {
+			emitClosedTri(m, grid[i][k], grid[ni][k], grid[ni][k+1])
+			emitClosedTri(m, grid[i][k], grid[ni][k+1], grid[i][k+1])
+		}
+		emitClosedTri(m, grid[i][rows-1], grid[ni][rows-1], pole)
+	}
+}
+
+// centroidOf returns the average of the points.
+func centroidOf(pts []math.Point3) math.Point3 {
+	var x, y, z float64
+	for _, p := range pts {
+		x, y, z = x+float64(p.X), y+float64(p.Y), z+float64(p.Z)
+	}
+	n := float64(len(pts))
+	return math.P3(math.Scalar(x/n), math.Scalar(y/n), math.Scalar(z/n))
+}
+
+// clampUnit clamps x to [−1, 1] so acos of a dot product that floated just past ±1 is finite.
+func clampUnit(x float64) float64 {
+	if x > 1 {
+		return 1
+	}
+	if x < -1 {
+		return -1
+	}
+	return x
+}

--- a/kernel/ops/sphere_cap_mesh_test.go
+++ b/kernel/ops/sphere_cap_mesh_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Regression for the flat-cap tessellation bug (M2 Phase 1, Oblikovati/Oblikovati#1334): a sphere
+// trimmed by one plane used to mesh as a flat disk (its coplanar rim lifted to no bulge → zero cap
+// volume). sphereCapFan must mesh the true spherical cap, so the body's volume matches the analytic
+// spherical-cap formula V = π·h²·(3R − h)/3 for the kept (−normal) side, height h = R + d where
+// d = (planePoint − centre)·normal (signed centre→plane distance along the normal). Accuracy is
+// held to 2%: the kernel's own DefaultQuality full sphere is ~1.6% under analytic (inscribed
+// chords), so a cap meshed at the same density can be no better; the regression that matters is
+// that the cap is no longer flat (volume ≈ 0).
+
+// capBody builds the cap of a sphere kept on the side OPPOSITE planeNormal: the spherical cap face
+// (rim = the cut circle) closed by a planar disk lid whose outward normal is +planeNormal.
+func capBody(t *testing.T, center math.Point3, radius float64, planePoint math.Point3, planeNormal math.Vector3) *topo.Body {
+	t.Helper()
+	n, err := math.UnitVector3FromVector(planeNormal)
+	if err != nil {
+		t.Fatalf("degenerate plane normal %v", planeNormal)
+	}
+	sphere, err := geom.NewSphere(center, radius)
+	if err != nil {
+		t.Fatalf("NewSphere: %v", err)
+	}
+	d := float64(center.VectorTo(planePoint).Dot(n.AsVector())) // signed center→plane distance along n
+	r0 := stdmath.Sqrt(radius*radius - d*d)
+	circleCenter := center.TranslateBy(n.AsVector().Scale(math.Scalar(d)))
+	circle, err := geom.NewCircle(circleCenter, n.AsVector(), r0)
+	if err != nil {
+		t.Fatalf("NewCircle: %v", err)
+	}
+	disk, _ := geom.NewPlane(planePoint, n.AsVector()) // outward = +n (material on −n side)
+	lin := func(s string) topo.Lineage { return topo.NewLineage(topo.Tok("cap", s, 0)) }
+	bld := topo.NewBuilder(true, lin("body"))
+	v := bld.AddVertex(circle.PointAt(0), lin("v"))
+	e := bld.AddEdge(circle, v, v, lin("e"))
+	bld.AddFace(disk, lin("disk"), topo.OuterLoop(topo.Fwd(e)))
+	bld.AddFace(sphere, lin("sph"), topo.OuterLoop(topo.Rev(e)))
+	return bld.Build()
+}
+
+func TestSphereCapTessellatesToAnalyticVolume(t *testing.T) {
+	const R = 5.0
+	cases := []struct {
+		name        string
+		planePoint  math.Point3
+		planeNormal math.Vector3
+		d           float64 // signed center→plane distance along the (unit) normal
+	}{
+		{"hemisphere", math.P3(0, 0, 0), math.V3(0, 0, 1), 0},      // h = 5
+		{"small cap", math.P3(0, 0, 3.5), math.V3(0, 0, 1), 3.5},   // kept −z side, h = 8.5
+		{"large cap", math.P3(0, 0, -2.5), math.V3(0, 0, 1), -2.5}, // kept −z side, h = 2.5
+		{"oblique axis", math.P3(0, 0, 0), math.V3(1, 1, 1), 0},    // hemisphere, tilted cut
+		{"oblique offset", math.P3(2, 0, 0), math.V3(1, 0, 0), 2},  // h = 7 along +x
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := capBody(t, math.P3(0, 0, 0), R, tc.planePoint, tc.planeNormal)
+			if r := Validate(body); !r.Valid || !r.Closed || !r.Manifold || !body.IsSolid() {
+				t.Fatalf("cap body not a valid closed manifold solid: %+v", r)
+			}
+			got := BodyGeometryProperties(body, DefaultQuality()).Volume
+			h := R + tc.d
+			want := stdmath.Pi * h * h * (3*R - h) / 3
+			if got < 0.5*want {
+				t.Fatalf("cap meshed flat: volume %.4f is far below analytic %.4f (the #1334 bug)", got, want)
+			}
+			if rel := stdmath.Abs(got-want) / want; rel > 0.02 {
+				t.Errorf("cap volume %.4f, want %.4f (rel err %.4f > 2%%)", got, want, rel)
+			}
+		})
+	}
+}

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -40,6 +40,9 @@ func tessellateCurvedFace(f *topo.Face, q Quality) *Mesh {
 	if m, isFan := coneApexFan(s, outer3D); isFan {
 		return m // a cone closing to its apex (a drill point): a fan from the apex to the rim
 	}
+	if m, isCap := sphereCapFan(s, outer3D, q); isCap {
+		return m // a sphere cut by one plane (a cap): rings from the rim to the enclosed pole
+	}
 	outerUV, holesUV, ok := toUVLoops(s, outer3D, holes3D)
 	if !ok {
 		return meshSeamCrossingFace(f, s, outer3D, holes3D, q) // a loop wrapping the seam: band/cap fallbacks


### PR DESCRIPTION
## What
A sphere face trimmed by a **single planar circle** — a hemisphere, a drilled spherical seat, the curved face of a sphere∩half-space — tessellated as a **flat disk**: the dispatch routed it to the best-fit-plane CDT, whose only vertices are the coplanar rim circle, so with no interior points the cap collapsed flat (zero bulge → near-zero cap volume), corrupting mass properties, render, and export for **every** spherical cap.

`sphereCapFan` (the sphere analogue of the existing `coneApexFan`) sweeps latitude rings about the cut axis from the rim to the enclosed pole, recovering the cap's true spherical curvature. It claims only the single-circle-boundary case; arc-bounded sphere patches keep the existing path.

## Why
Tessellation correctness is the kernel's top priority (a wrong mesh corrupts mass props, render, export, and boolean input). This is also the first foundational step of the **general curved boolean** (#1334 / M2 §ADR-0027): the half-space cut of a sphere produces exactly this cap face.

## Validation
New `TestSphereCapTessellatesToAnalyticVolume` checks the tessellated volume against the analytic spherical-cap formula π·h²(3R−h)/3 across:
- hemisphere, offset small/large caps, and **oblique** (non-axis-aligned) cuts

within 2% — the kernel's own `DefaultQuality` full sphere is ~1.6% under analytic (inscribed chords), so a cap meshed at the same density can be no better; the regression that matters is that the cap is no longer flat. Full `./kernel/...` suite green; lint clean.

Refs #1334
🤖 Generated with [Claude Code](https://claude.com/claude-code)