### PR TITLE
feat(brep): curved boolean foundations + sphere half-space cut (M2 Phase 1)

### DIFF
--- a/architecture/decisions/ADR-0027-curved-face-boolean.md
+++ b/architecture/decisions/ADR-0027-curved-face-boolean.md
@@ -87,6 +87,40 @@ stay (imprint → split → classify → stitch); each is lifted from "plane + 3
 Until a slice lands, the affected case keeps using the BSP-CSG fallback (correct, just
 faceted) — no regression.
 
+## M2 — the general arrangement boolean (#1320)
+
+Slices 1–3 and the slice-5 hole cutters are **specialized**: each is a hand-built assembly
+for one feature (through-hole, blind hole, counterbore, …). They do not generalize — an
+arbitrary `Boolean(Cut, curvedBody, planarTool)` still falls to BSP-CSG. M2 (#1320) finishes
+ADR-0027 by building the **general arrangement-based curved boolean** the four-stage pipeline
+above always intended, so *any* curved operand goes through the exact path, not a per-feature
+specialization. It is phased so each phase is shippable, oracle-tested, and leaves the CSG
+fallback intact for the unhandled cases.
+
+- **Phase 1 — curved solid ∩ planar half-spaces (analytic imprints, #1334).** A generalized
+  `curvedFace{surface, loops []curvedLoop, lineage}` (loops are `geom.Curve3` edges, not just
+  3D point rings) and `facesOfAny(body)` that flattens planar *and* analytic-curved bodies.
+  Imprint a curved face against a plane with `geom.IntersectSurfacesAnalytic` (the exact conic),
+  split the curved face in its (u,v) domain along that conic, classify each sub-face by the
+  **H3 generalized winding number** (`ops.PointInsideBody`), and stitch curved edges. Scope is
+  the case where every imprint is an analytic conic: a cylinder/sphere/cone solid cut/intersected
+  by planar half-spaces (a box). Hits acceptance #1 (cylinder−box, sphere∩box: exact curved
+  result faces, analytic volume). First slice: a single half-space cut (sphere→cap, cylinder→
+  frustum); then compose half-spaces for the box.
+- **Phase 2 — curved ∩ curved imprints via the M1 SSI tracer (#1335).** Two crossing cylinders
+  (cross/tee): imprint from `geom.IntersectSurfaceSurface` (the predictor–corrector tracer),
+  split both curved faces along the traced curve, exact watertight manifold result (acceptance
+  #2). Fit a traced loop to an analytic curve where one exists; otherwise carry it as a spline
+  edge.
+- **Phase 3 — robustness, chaining, oracle, fallback retirement (#1336).** Coplanar/tangent
+  curved overlaps; chained-boolean drift guard (acceptance #4); remove the dependence on
+  `tjunctionFaceBudget` for watertightness (acceptance #3); OCCT `getMass` regression oracle;
+  retire BSP-CSG as the *primary* curved path (keep only as last-resort fallback).
+
+Prerequisites now in place (M37): **H3** robust point membership (winding number), **M1** SSI
+tracer, the analytic conic intersect (slice 1), and curved-face tessellation. #1320 stays the
+open umbrella until Phase 3 lands.
+
 ## Consequences
 
 - Hole/Boss/Fillet become clean, low-face-count, chain-exact, with stable face keys.

--- a/kernel/brep/curved_boolean_imprint.go
+++ b/kernel/brep/curved_boolean_imprint.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import "oblikovati.org/kernel/geom"
+
+// Curved boolean imprint (M2 Phase 1, Oblikovati/Oblikovati#1334). The imprint stage of the
+// curved boolean asks, for a pair of faces, "where do their surfaces meet?". For the planar
+// boolean that is plane∩plane → a line segment (imprint, boolean.go). Lifted to curved faces
+// it is surface∩surface → analytic conic(s): plane∩cylinder ⟂ axis → a circle, plane∩sphere →
+// a circle, plane∩cone ⟂ axis → a circle, oblique plane∩cylinder → an ellipse, plane∩plane → a
+// line. Phase 1 covers exactly the pairs geom.IntersectSurfacesAnalytic solves in closed form;
+// curved∩curved (cylinder∩cylinder) is Phase 2's SSI tracer. Clipping the returned curve to the
+// two faces' trimmed regions is the split stage (next slice) — these are the full surface
+// intersection curves.
+
+// curvedImprint returns the analytic intersection curve(s) of two faces' surfaces and whether
+// the pair was handled in closed form. handled == false means no analytic solver applies (a
+// curved∩curved pair, or a NURBS face) — the caller defers that pair to the numeric tracer in
+// Phase 2. handled == true with an empty slice means the surfaces provably do not cross
+// (parallel planes, a sphere clear of the plane, a tangent touch).
+//
+// Example — a cylinder side cut by a plane perpendicular to its axis yields one circle:
+//
+//	cyl, _ := brep.SolidCylinder(math.P3(0,0,0), math.V3(0,0,1), 3, 4)
+//	box, _ := brep.SolidBlock(math.P3(-5,-5,2), math.P3(5,5,3), "box")
+//	curves, ok := curvedImprint(facesOfAny(cyl)[2], facesOfAny(box)[0]) // ok, one geom.Circle
+func curvedImprint(a, b curvedFace) (curves []geom.Curve3, handled bool) {
+	return geom.IntersectSurfacesAnalytic(a.surface, b.surface)
+}

--- a/kernel/brep/curved_boolean_model.go
+++ b/kernel/brep/curved_boolean_model.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Curved boolean face model (M2 Phase 1, Oblikovati/Oblikovati#1334). The planar boolean
+// flattens a body to planarFace{plane, 3D point rings}; the general curved boolean needs the
+// same four-stage pipeline (imprint → split → classify → stitch) lifted to ANY analytic
+// surface with curved (line/circle/ellipse) boundary edges. curvedFace is that lifted model —
+// planarFace is the special case surface == geom.Plane. This file is the model + flatten only;
+// imprint/split/classify/stitch land in the following slices of #1334.
+
+// loopEdge is one boundary edge as a loop traverses it: the underlying analytic curve plus the
+// parameter interval walked, t0→t1, already oriented to the loop's direction (so PointAt(t0) is
+// where the edge begins in this loop). A closed edge — a full seam circle whose start and end
+// vertex coincide — spans the curve's whole domain.
+type loopEdge struct {
+	curve  geom.Curve3
+	t0, t1 float64
+}
+
+// start and end return the loop-oriented endpoints of the edge.
+func (e loopEdge) start() math.Point3 { return e.curve.PointAt(e.t0) }
+func (e loopEdge) end() math.Point3   { return e.curve.PointAt(e.t1) }
+
+// curvedLoop is one boundary loop of a curved face: an ordered ring of loopEdges where each
+// edge's end meets the next edge's start (the last meets the first).
+type curvedLoop struct {
+	edges []loopEdge
+}
+
+// curvedFace is a face flattened for the curved boolean (the curved generalization of
+// planarFace, ADR-0027 §M2): its analytic surface, ordered boundary loops (loops[0] is the
+// outer loop, the rest holes), the face sense (reversed when the surface normal points into
+// the material — a cut wall, AddReversedFace), and the source face's lineage so a result face
+// keeps its reference key (K1a). A boundary-less closed face (full sphere/torus) has no loops.
+type curvedFace struct {
+	surface  geom.Surface
+	reversed bool
+	loops    []curvedLoop
+	lineage  topo.Lineage
+}
+
+// facesOfAny flattens EVERY face of a body into a curvedFace, unlike facesOf which rejects any
+// curved face. The model holds any geom.Surface; whether a given face pair can be imprinted in
+// closed form is decided later (curvedImprint), not here. Used by the general curved boolean.
+//
+// Example:
+//
+//	cyl, _ := brep.SolidCylinder(math.P3(0,0,0), math.V3(0,0,1), 3, 4)
+//	faces := brep.facesOfAny(cyl) // 3 faces: two planar caps + one cylindrical side
+func facesOfAny(b *topo.Body) []curvedFace {
+	out := make([]curvedFace, 0, len(b.Faces()))
+	for _, f := range b.Faces() {
+		out = append(out, curvedFace{
+			surface:  f.Geometry(),
+			reversed: f.Reversed(),
+			loops:    loopsOf(f),
+			lineage:  f.Lineage(),
+		})
+	}
+	return out
+}
+
+// loopsOf extracts a face's boundary loops as curvedLoops (outer loop first, matching
+// topo.Loop.IsOuter), each edge carried as its analytic curve over the parameter interval the
+// loop walks.
+func loopsOf(f *topo.Face) []curvedLoop {
+	var outer, holes []curvedLoop
+	for _, l := range f.Loops() {
+		cl := curvedLoop{edges: loopEdgesOf(l)}
+		if l.IsOuter() {
+			outer = append(outer, cl)
+		} else {
+			holes = append(holes, cl)
+		}
+	}
+	return append(outer, holes...)
+}
+
+// loopEdgesOf turns a loop's edge uses into oriented loopEdges.
+func loopEdgesOf(l *topo.Loop) []loopEdge {
+	uses := l.EdgeUses()
+	out := make([]loopEdge, 0, len(uses))
+	for _, u := range uses {
+		out = append(out, orientedLoopEdge(u))
+	}
+	return out
+}
+
+// orientedLoopEdge resolves one edge use to a loop-oriented loopEdge. A closed edge (start and
+// end vertex coincide — a full circle seam) walks the curve's whole domain; an open edge walks
+// from its start vertex's parameter to its end vertex's, swapped when the use is reversed.
+func orientedLoopEdge(u *topo.EdgeUse) loopEdge {
+	e := u.Edge()
+	c := e.Geometry()
+	lo, hi := c.Domain()
+	if e.StartVertex() == e.EndVertex() {
+		if u.Reversed() {
+			return loopEdge{curve: c, t0: hi, t1: lo}
+		}
+		return loopEdge{curve: c, t0: lo, t1: hi}
+	}
+	t0, _ := geom.CurveParamAtPoint3(c, e.StartVertex().Point())
+	t1, _ := geom.CurveParamAtPoint3(c, e.EndVertex().Point())
+	if u.Reversed() {
+		return loopEdge{curve: c, t0: t1, t1: t0}
+	}
+	return loopEdge{curve: c, t0: t0, t1: t1}
+}

--- a/kernel/brep/curved_boolean_model_test.go
+++ b/kernel/brep/curved_boolean_model_test.go
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Acceptance for the curved boolean face model + analytic imprint (M2 Phase 1,
+// Oblikovati/Oblikovati#1334): facesOfAny flattens curved bodies the planar facesOf rejects,
+// loop edges come out oriented along the loop, and curvedImprint returns the exact conic for
+// the analytic surface pairs (deferring curved∩curved to Phase 2).
+
+// cylSide returns the curvedFace whose surface is the cylindrical side of a SolidCylinder.
+func cylSide(t *testing.T, faces []curvedFace) curvedFace {
+	t.Helper()
+	for _, f := range faces {
+		if _, ok := f.surface.(geom.Cylinder); ok {
+			return f
+		}
+	}
+	t.Fatal("no cylindrical face found")
+	return curvedFace{}
+}
+
+// TestFacesOfAnyFlattensCylinder: a SolidCylinder the planar facesOf rejects flattens here into
+// three curvedFaces — two planar caps and one true cylindrical side — each carrying its surface,
+// loops, and lineage.
+func TestFacesOfAnyFlattensCylinder(t *testing.T) {
+	cyl, err := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 4)
+	if err != nil {
+		t.Fatalf("SolidCylinder: %v", err)
+	}
+	if _, ok := facesOf(cyl); ok {
+		t.Fatal("planar facesOf should reject a cylinder (precondition for needing facesOfAny)")
+	}
+	faces := facesOfAny(cyl)
+	if len(faces) != 3 {
+		t.Fatalf("facesOfAny gave %d faces, want 3", len(faces))
+	}
+	planes, cylinders := 0, 0
+	for _, f := range faces {
+		switch f.surface.(type) {
+		case geom.Plane:
+			planes++
+		case geom.Cylinder:
+			cylinders++
+		}
+		if len(f.loops) == 0 {
+			t.Errorf("face on %T has no boundary loops", f.surface)
+		}
+		if len(f.lineage.Tokens()) == 0 {
+			t.Errorf("face on %T carries no lineage (reference key would not survive)", f.surface)
+		}
+	}
+	if planes != 2 || cylinders != 1 {
+		t.Errorf("got %d planar + %d cylindrical faces, want 2 + 1", planes, cylinders)
+	}
+}
+
+// TestLoopEdgesWalkContiguously: a planar block face's loop edges must chain — each edge's
+// oriented end meets the next edge's oriented start — so the loop is a closed contiguous ring.
+func TestLoopEdgesWalkContiguously(t *testing.T) {
+	box, err := SolidBlock(math.P3(0, 0, 0), math.P3(2, 3, 4), "box")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	faces := facesOfAny(box)
+	loop := faces[0].loops[0]
+	n := len(loop.edges)
+	if n < 3 {
+		t.Fatalf("block face loop has %d edges, want ≥3", n)
+	}
+	for i := 0; i < n; i++ {
+		end := loop.edges[i].end()
+		start := loop.edges[(i+1)%n].start()
+		if d := float64(end.DistanceTo(start)); d > 1e-9 {
+			t.Errorf("edge %d end %v does not meet edge %d start %v (gap %g)", i, end, (i+1)%n, start, d)
+		}
+	}
+}
+
+// TestClosedCircleEdgeSpansDomain: a cylinder cap's boundary is a single closed-circle edge
+// (start vertex == end vertex); its loopEdge must span the curve's whole [0,1] domain so the
+// ring closes on itself rather than collapsing to a point.
+func TestClosedCircleEdgeSpansDomain(t *testing.T) {
+	cyl, err := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 4)
+	if err != nil {
+		t.Fatalf("SolidCylinder: %v", err)
+	}
+	for _, f := range facesOfAny(cyl) {
+		pl, ok := f.surface.(geom.Plane)
+		if !ok {
+			continue
+		}
+		_ = pl
+		loop := f.loops[0]
+		if len(loop.edges) != 1 {
+			t.Fatalf("cap loop has %d edges, want 1 closed circle", len(loop.edges))
+		}
+		e := loop.edges[0]
+		if _, isCircle := e.curve.(geom.Circle); !isCircle {
+			t.Fatalf("cap boundary edge is %T, want geom.Circle", e.curve)
+		}
+		if stdmath.Abs(e.t1-e.t0) < 0.99 { // a full circle domain is [0,1]
+			t.Errorf("closed circle edge spans only [%g,%g], want the full domain", e.t0, e.t1)
+		}
+	}
+}
+
+// TestCurvedImprintCylinderPlaneIsCircle: a cylinder side imprinted against a plane ⟂ its axis
+// is the exact section circle — at the plane's height, with the cylinder's radius.
+func TestCurvedImprintCylinderPlaneIsCircle(t *testing.T) {
+	cyl, _ := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 4)
+	side := cylSide(t, facesOfAny(cyl))
+	plane, _ := geom.NewPlane(math.P3(0, 0, 2.5), math.V3(0, 0, 1))
+	curves, ok := curvedImprint(side, curvedFace{surface: plane})
+	if !ok || len(curves) != 1 {
+		t.Fatalf("cylinder∩plane: handled=%v, %d curves; want handled, 1 circle", ok, len(curves))
+	}
+	c, isCircle := curves[0].(geom.Circle)
+	if !isCircle {
+		t.Fatalf("imprint is %T, want geom.Circle", curves[0])
+	}
+	if stdmath.Abs(c.Radius-3) > 1e-9 {
+		t.Errorf("imprint radius %g, want 3", c.Radius)
+	}
+	if z := float64(c.Center.Z); stdmath.Abs(z-2.5) > 1e-9 {
+		t.Errorf("imprint center z %g, want 2.5", z)
+	}
+}
+
+// TestCurvedImprintSpherePlaneIsCircle: a sphere imprinted against an offset plane is the circle
+// of radius sqrt(r²−d²) at the plane.
+func TestCurvedImprintSpherePlaneIsCircle(t *testing.T) {
+	sphere, _ := geom.NewSphere(math.P3(0, 0, 0), 5)
+	plane, _ := geom.NewPlane(math.P3(0, 0, 3), math.V3(0, 0, 1))
+	curves, ok := curvedImprint(curvedFace{surface: sphere}, curvedFace{surface: plane})
+	if !ok || len(curves) != 1 {
+		t.Fatalf("sphere∩plane: handled=%v, %d curves; want handled, 1 circle", ok, len(curves))
+	}
+	c := curves[0].(geom.Circle)
+	if want := stdmath.Sqrt(25 - 9); stdmath.Abs(c.Radius-want) > 1e-9 {
+		t.Errorf("imprint radius %g, want %g", c.Radius, want)
+	}
+}
+
+// TestCurvedImprintPlanePlaneIsLine: two non-parallel planar faces imprint to a line (the planar
+// case still flows through the curved model).
+func TestCurvedImprintPlanePlaneIsLine(t *testing.T) {
+	box, _ := SolidBlock(math.P3(0, 0, 0), math.P3(2, 2, 2), "box")
+	faces := facesOfAny(box)
+	a, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	b, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(1, 0, 0))
+	_ = faces
+	curves, ok := curvedImprint(curvedFace{surface: a}, curvedFace{surface: b})
+	if !ok || len(curves) != 1 {
+		t.Fatalf("plane∩plane: handled=%v, %d curves; want handled, 1 line", ok, len(curves))
+	}
+	if _, isLine := curves[0].(geom.Line); !isLine {
+		t.Errorf("imprint is %T, want geom.Line", curves[0])
+	}
+}
+
+// TestCurvedImprintCurvedCurvedDefers: a cylinder∩cylinder pair has no closed-form analytic
+// solver in Phase 1, so curvedImprint reports handled=false (the caller routes it to the Phase 2
+// SSI tracer), NOT an empty "they don't cross" result.
+func TestCurvedImprintCurvedCurvedDefers(t *testing.T) {
+	a, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3)
+	b, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(1, 0, 0), 2)
+	if _, ok := curvedImprint(curvedFace{surface: a}, curvedFace{surface: b}); ok {
+		t.Error("cylinder∩cylinder should defer (handled=false) to Phase 2, not be handled analytically")
+	}
+}

--- a/kernel/brep/curved_halfspace.go
+++ b/kernel/brep/curved_halfspace.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"errors"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Curved half-space cut (M2 Phase 1, Oblikovati/Oblikovati#1334). The first operation of the
+// general curved boolean: trim an analytic curved solid by ONE plane, keeping the part on the
+// plane's negative side and closing it with a planar lid — an EXACT curved B-rep (the kept curved
+// faces preserve their analytic surface, not a tessellated soup). It is the building block the box
+// boolean composes (a convex planar tool is an intersection of half-spaces) and the natural place
+// the imprint→split→classify→stitch pipeline starts, restricted to a single planar cutter so
+// classification is just "which side of the plane" (no point-in-solid needed yet).
+
+// ErrUnsupportedHalfSpace reports a body the half-space cut does not yet handle (a surface type or
+// trim configuration beyond the analytic primitives wired so far) — the caller keeps the BSP-CSG
+// fallback, so there is no regression.
+var ErrUnsupportedHalfSpace = errors.New("brep: half-space cut handles only the wired analytic curved solids")
+
+// HalfSpaceCut returns the part of body on the NEGATIVE side of plane — the half-space
+// {x : normal·(x − origin) ≤ 0} — capped by a planar lid whose outward normal is +plane.Normal.
+// The result is an exact curved B-rep. A plane that misses the body returns the whole body (all
+// negative) or an empty body (all positive). ErrUnsupportedHalfSpace for an as-yet-unwired solid.
+//
+// Example — a sphere cut by z=0 keeps the lower hemisphere (a true spherical cap + a disk lid):
+//
+//	sphere, _ := brep.SolidSphere(math.P3(0,0,0), 5, "s")
+//	plane, _ := geom.NewPlane(math.P3(0,0,0), math.V3(0,0,1))
+//	cap, _ := brep.HalfSpaceCut(sphere, plane) // lower hemisphere
+func HalfSpaceCut(body *topo.Body, plane geom.Plane) (*topo.Body, error) {
+	faces := facesOfAny(body)
+	if len(faces) == 1 {
+		if sph, ok := faces[0].surface.(geom.Sphere); ok && len(faces[0].loops) == 0 {
+			return sphereHalfSpace(body, sph, plane, faces[0].lineage)
+		}
+	}
+	return nil, ErrUnsupportedHalfSpace
+}
+
+// sphereHalfSpace cuts a bare sphere by a plane: the part on the plane's negative side is a
+// spherical cap closed by a circular lid. The cut circle is the analytic imprint (curvedImprint);
+// when the plane clears the sphere the cap is the whole sphere (centre below) or empty (above).
+func sphereHalfSpace(body *topo.Body, sph geom.Sphere, plane geom.Plane, lineage topo.Lineage) (*topo.Body, error) {
+	n := unit(plane.Normal())
+	curves, _ := curvedImprint(curvedFace{surface: sph}, curvedFace{surface: plane})
+	if len(curves) == 0 {
+		if float64(plane.Origin.VectorTo(sph.Center).Dot(n)) <= 0 {
+			return body, nil // centre on the negative side → the whole sphere is kept
+		}
+		return topo.MergeBodies(topo.NewLineage(topo.Tok("halfspace", "empty", 0)), true), nil
+	}
+	circle, ok := curves[0].(geom.Circle)
+	if !ok {
+		return nil, ErrUnsupportedHalfSpace
+	}
+	return assembleSphereCap(sph, circle, n, lineage)
+}
+
+// assembleSphereCap builds the spherical cap (kept side) and its planar disk lid, sharing the cut
+// circle as one edge. The cap face carries the sphere's lineage (its reference key survives); the
+// sphere face's loop is the circle reversed so the kept −n cap is enclosed, and the lid's outward
+// normal is +n (it faces away from the kept material on the −n side).
+func assembleSphereCap(sph geom.Sphere, circle geom.Circle, n math.Vector3, lineage topo.Lineage) (*topo.Body, error) {
+	lid, err := geom.NewPlane(circle.Center, n)
+	if err != nil {
+		return nil, err
+	}
+	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok("halfspace", "body", 0)))
+	v := bld.AddVertex(circle.PointAt(0), topo.NewLineage(topo.Tok("halfspace", "seam", 0)))
+	edge := bld.AddEdge(circle, v, v, topo.NewLineage(topo.Tok("halfspace", "cut", 0)))
+	bld.AddFace(lid, topo.NewLineage(topo.Tok("halfspace", "lid", 0)), topo.OuterLoop(topo.Fwd(edge)))
+	bld.AddFace(sph, lineage, topo.OuterLoop(topo.Rev(edge))) // cap keeps the sphere's key (K1a/K1b)
+	return bld.Build(), nil
+}

--- a/kernel/ops/halfspace_cut_test.go
+++ b/kernel/ops/halfspace_cut_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Acceptance for the curved half-space cut (M2 Phase 1, Oblikovati/Oblikovati#1334): cutting an
+// analytic curved solid by ONE plane yields an EXACT curved B-rep — the kept faces preserve their
+// analytic surface (a geom.Sphere, not tessellated soup) and the body's volume matches the analytic
+// formula. brep.HalfSpaceCut keeps the part on the plane's negative side, capped by a planar lid.
+
+// capVolume is the analytic spherical-cap volume π·h²(3R−h)/3, the oracle for the kept −n cap.
+func capVolume(radius, height float64) float64 {
+	return stdmath.Pi * height * height * (3*radius - height) / 3
+}
+
+// TestHalfSpaceCutSphereIsExactCap cuts a sphere by several planes and checks the result is a valid
+// closed solid whose two faces are an exact sphere + plane, with the analytic spherical-cap volume.
+func TestHalfSpaceCutSphereIsExactCap(t *testing.T) {
+	const R = 5.0
+	cases := []struct {
+		name        string
+		planePoint  math.Point3
+		planeNormal math.Vector3
+		height      float64 // kept (−normal) cap height h = R + d, d = (planePoint − centre)·normal
+	}{
+		{"hemisphere", math.P3(0, 0, 0), math.V3(0, 0, 1), R},
+		{"shallow cap", math.P3(0, 0, 3), math.V3(0, 0, 1), R + 3},     // keep −z side, h = 8
+		{"deep keep", math.P3(0, 0, -3), math.V3(0, 0, 1), R - 3},      // keep −z side, h = 2
+		{"oblique", math.P3(0, 0, 0), math.V3(1, 1, 1), R},             // hemisphere, tilted cut
+		{"oblique offset", math.P3(-2, 0, 0), math.V3(1, 0, 0), R - 2}, // keep −x side, h = 3
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sphere, err := brep.SolidSphere(math.P3(0, 0, 0), R, "s")
+			if err != nil {
+				t.Fatalf("SolidSphere: %v", err)
+			}
+			plane, err := geom.NewPlane(tc.planePoint, tc.planeNormal)
+			if err != nil {
+				t.Fatalf("NewPlane: %v", err)
+			}
+			cap, err := brep.HalfSpaceCut(sphere, plane)
+			if err != nil {
+				t.Fatalf("HalfSpaceCut: %v", err)
+			}
+			if r := ops.Validate(cap); !r.Valid || !r.Closed || !r.Manifold || !cap.IsSolid() {
+				t.Fatalf("cap not a valid closed manifold solid: %+v", r)
+			}
+			assertSphereAndPlaneFaces(t, cap)
+			got := ops.BodyGeometryProperties(cap, ops.DefaultQuality()).Volume
+			want := capVolume(R, tc.height)
+			if rel := stdmath.Abs(got-want) / want; rel > 0.02 {
+				t.Errorf("cap volume %.4f, want %.4f (rel err %.4f > 2%%)", got, want, rel)
+			}
+		})
+	}
+}
+
+// assertSphereAndPlaneFaces verifies the result preserves the EXACT analytic surfaces: one
+// geom.Sphere face (the cap) and one geom.Plane face (the lid) — not a tessellated approximation.
+func assertSphereAndPlaneFaces(t *testing.T, body *topo.Body) {
+	t.Helper()
+	spheres, planes := 0, 0
+	for _, f := range body.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Sphere:
+			spheres++
+		case geom.Plane:
+			planes++
+		default:
+			t.Errorf("unexpected result face surface %T (curved boolean must keep exact surfaces)", f.Geometry())
+		}
+	}
+	if spheres != 1 || planes != 1 {
+		t.Errorf("cap has %d sphere + %d plane faces, want 1 + 1", spheres, planes)
+	}
+}
+
+// TestHalfSpaceCutSpherePlaneMissKeepsOrEmpties: a plane clear of the sphere keeps the whole sphere
+// (centre on the negative side) or empties it (centre on the positive side).
+func TestHalfSpaceCutSpherePlaneMissKeepsOrEmpties(t *testing.T) {
+	sphere, _ := brep.SolidSphere(math.P3(0, 0, 0), 5, "s")
+	full := ops.BodyGeometryProperties(sphere, ops.DefaultQuality()).Volume
+
+	below, _ := geom.NewPlane(math.P3(0, 0, 8), math.V3(0, 0, 1)) // sphere entirely on −z (kept) side
+	kept, err := brep.HalfSpaceCut(sphere, below)
+	if err != nil {
+		t.Fatalf("HalfSpaceCut (miss, keep): %v", err)
+	}
+	if got := ops.BodyGeometryProperties(kept, ops.DefaultQuality()).Volume; stdmath.Abs(got-full) > 1e-6 {
+		t.Errorf("plane clear above sphere should keep it whole: volume %.4f, want %.4f", got, full)
+	}
+
+	above, _ := geom.NewPlane(math.P3(0, 0, -8), math.V3(0, 0, 1)) // sphere entirely on +z (dropped) side
+	empty, err := brep.HalfSpaceCut(sphere, above)
+	if err != nil {
+		t.Fatalf("HalfSpaceCut (miss, empty): %v", err)
+	}
+	if empty.IsSolid() && len(empty.Faces()) > 0 {
+		t.Errorf("plane clear below sphere should empty it, got %d faces", len(empty.Faces()))
+	}
+}


### PR DESCRIPTION
First slice of the **general curved B-rep boolean** (#1334, M2 / ADR-0027 §M2). Delivers the lifted face model, the analytic imprint, and the first exact curved-boolean operation — a sphere cut by a plane. The BSP-CSG fallback is untouched, so there is no regression for unhandled cases.

## What
1. **Curved boolean face model** (`curved_boolean_model.go`) — `curvedFace{surface, curved loops, lineage}` and `facesOfAny()`, which flattens curved bodies the planar `facesOf` rejects (the curved generalization of `planarFace`). Loop edges come out oriented along the loop, closed seam circles spanning their whole domain.
2. **Analytic imprint** (`curved_boolean_imprint.go`) — `curvedImprint` returns the exact conic where two faces' surfaces meet (plane∩cylinder/sphere/cone → circle, plane∩plane → line), deferring curved∩curved to the Phase 2 SSI tracer.
3. **`brep.HalfSpaceCut(body, plane)`** (`curved_halfspace.go`) — trims a curved solid by one plane, keeping the negative-side part capped by a planar lid, as an **exact curved B-rep**. With a single planar cutter, classification is just 'which side of the plane' (no point-in-solid yet). The **sphere** path is wired end-to-end: the cut circle is the analytic imprint, the kept side is a true spherical cap (`geom.Sphere` preserved) closed by a disk lid (`geom.Plane`) sharing the cut circle; a plane that clears the sphere keeps it whole or empties it.

## Why
This is the foundational operation the box boolean composes (a convex planar tool is an intersection of half-spaces) and the place the imprint→split→classify→stitch pipeline starts. It depends on the sphere-cap tessellation fix (#1337, merged): the kept cap reuses `sphereCapFan`.

## Validation
- Model/imprint unit tests (face flatten, loop orientation, exact conic per analytic pair, curved∩curved defers).
- `TestHalfSpaceCutSphereIsExactCap` (package `ops_test`): hemispheres, offset caps, **oblique** cuts, clear-miss keep/empty → a valid closed manifold solid with exactly one sphere + one plane face and volume within 2% of the analytic π·h²(3R−h)/3.
- Full `./kernel/...` suite green; lint clean.

## Follow-ups (same phase, #1334)
Cylinder/cone half-space paths; multi-arc trimmed-patch tessellation (the blocker for a box cut, where a sphere/cylinder face is bounded by several arcs); compose half-spaces → curved solid ∩ box (acceptance #1); wire into `ops.booleanGeneral` ahead of CSG.

Refs #1334 #1320
🤖 Generated with [Claude Code](https://claude.com/claude-code)