### PR TITLE
feat(brep): cylinder half-space cut (perpendicular) — M2 Phase 1

### DIFF
--- a/kernel/brep/curved_halfspace.go
+++ b/kernel/brep/curved_halfspace.go
@@ -40,6 +40,9 @@ func HalfSpaceCut(body *topo.Body, plane geom.Plane) (*topo.Body, error) {
 			return sphereHalfSpace(body, sph, plane, faces[0].lineage)
 		}
 	}
+	if cyl, base, height, ok := cylinderSolidParams(faces); ok {
+		return cylinderHalfSpace(body, cyl, base, height, plane)
+	}
 	return nil, ErrUnsupportedHalfSpace
 }
 

--- a/kernel/brep/curved_halfspace_cylinder.go
+++ b/kernel/brep/curved_halfspace_cylinder.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Cylinder half-space cut (M2 Phase 1, Oblikovati/Oblikovati#1334). Trims a closed analytic
+// cylinder (one cylindrical side + two planar caps) by a plane PERPENDICULAR to its axis: the kept
+// axial band is itself a shorter cylinder, exact and watertight. An oblique plane (an elliptical
+// section, a wedge result) needs the general curved arrangement and returns ErrUnsupportedHalfSpace
+// so the caller keeps the CSG fallback.
+
+// cylinderAxisTol is how close |n·axis| must be to 1 for a cut plane to count as perpendicular to
+// the cylinder axis (a constant-axial-coordinate cut). Looser than that is an oblique section.
+const cylinderAxisTol = 1e-7
+
+// cylinderSolidParams recovers a closed cylinder's geometry from its flattened faces: the side's
+// geom.Cylinder, the base centre (axially lowest cap), and the height. ok=false unless the body is
+// exactly one cylindrical side plus two planar caps (a bare SolidCylinder), the only shape this
+// perpendicular-cut path handles.
+func cylinderSolidParams(faces []curvedFace) (cyl geom.Cylinder, base math.Point3, height float64, ok bool) {
+	var caps []geom.Plane
+	found := false
+	for _, f := range faces {
+		switch s := f.surface.(type) {
+		case geom.Cylinder:
+			cyl, found = s, true
+		case geom.Plane:
+			caps = append(caps, s)
+		default:
+			return geom.Cylinder{}, math.Point3{}, 0, false
+		}
+	}
+	if !found || len(caps) != 2 {
+		return geom.Cylinder{}, math.Point3{}, 0, false
+	}
+	base, height = cylinderExtent(cyl, caps)
+	return cyl, base, height, true
+}
+
+// cylinderExtent returns the axially-lowest cap centre and the cylinder height, projecting both cap
+// origins onto the axis from the side's origin (so it is robust to which cap geom.Cylinder.Origin
+// sits on).
+func cylinderExtent(cyl geom.Cylinder, caps []geom.Plane) (base math.Point3, height float64) {
+	axis := cyl.AxisDir.AsVector()
+	s0 := float64(cyl.Origin.VectorTo(caps[0].Origin).Dot(axis))
+	s1 := float64(cyl.Origin.VectorTo(caps[1].Origin).Dot(axis))
+	lo, hi := stdmath.Min(s0, s1), stdmath.Max(s0, s1)
+	return cyl.Origin.TranslateBy(axis.Scale(math.Scalar(lo))), hi - lo
+}
+
+// cylinderHalfSpace keeps the axial band of the cylinder on the plane's negative side. The plane
+// must be perpendicular to the axis; the kept band is rebuilt as a shorter SolidCylinder (exact
+// cylinder side + planar caps). A plane clear of the cylinder keeps it whole or empties it.
+func cylinderHalfSpace(body *topo.Body, cyl geom.Cylinder, base math.Point3, height float64, plane geom.Plane) (*topo.Body, error) {
+	n := unit(plane.Normal())
+	axis := cyl.AxisDir.AsVector()
+	along := float64(n.Dot(axis))
+	if stdmath.Abs(along) < 1-cylinderAxisTol {
+		return nil, ErrUnsupportedHalfSpace // oblique cut: elliptical section, deferred
+	}
+	// Axial coordinate (from base, along +axis) where the cut plane sits, and the kept sub-band.
+	cut := float64(base.VectorTo(plane.Origin).Dot(axis))
+	lo, hi := keptAxialBand(cut, height, along > 0)
+	if hi-lo <= cylinderAxisTol {
+		return topo.MergeBodies(topo.NewLineage(topo.Tok("halfspace", "empty", 0)), true), nil
+	}
+	if hi-lo >= height-cylinderAxisTol {
+		return body, nil // plane clears the cylinder on the kept side
+	}
+	newBase := base.TranslateBy(axis.Scale(math.Scalar(lo)))
+	return SolidCylinder(newBase, axis, cyl.Radius, hi-lo)
+}
+
+// keptAxialBand returns the [lo, hi] axial interval (within [0, height]) kept on the plane's
+// negative side. With n along +axis the negative side is below the cut (toward the base); with n
+// along −axis it is above (toward the top).
+func keptAxialBand(cut, height float64, nAlongAxis bool) (lo, hi float64) {
+	cut = stdmath.Max(0, stdmath.Min(height, cut))
+	if nAlongAxis {
+		return 0, cut // g = s − cut ≤ 0 ⇒ s ≤ cut
+	}
+	return cut, height // g = cut − s ≤ 0 ⇒ s ≥ cut
+}

--- a/kernel/ops/halfspace_cut_test.go
+++ b/kernel/ops/halfspace_cut_test.go
@@ -86,6 +86,88 @@ func assertSphereAndPlaneFaces(t *testing.T, body *topo.Body) {
 	}
 }
 
+// TestHalfSpaceCutCylinderPerpendicularIsFrustum cuts a cylinder by a plane ⟂ its axis: the kept
+// band is a shorter cylinder (exact side + caps). The oracle is the tessellated volume of an
+// independently-built SolidCylinder of the kept height — identical faceting, so they must agree
+// exactly (comparing to the analytic π·r²·h' would only confirm the cylinder's own ~0.6% chord
+// inscription, not the cut).
+func TestHalfSpaceCutCylinderPerpendicularIsFrustum(t *testing.T) {
+	const r, h = 3.0, 4.0
+	facetedVol := func(height float64) float64 {
+		c, _ := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), r, height)
+		return ops.BodyGeometryProperties(c, ops.DefaultQuality()).Volume
+	}
+	cases := []struct {
+		name        string
+		planePoint  math.Point3
+		planeNormal math.Vector3
+		keptHeight  float64 // 0 ⇒ empty, h ⇒ whole
+	}{
+		{"keep lower band", math.P3(0, 0, 2.5), math.V3(0, 0, 1), 2.5},
+		{"keep upper band", math.P3(0, 0, 1.5), math.V3(0, 0, -1), 2.5},
+		{"plane clears (whole)", math.P3(0, 0, 10), math.V3(0, 0, 1), h},
+		{"plane clears (empty)", math.P3(0, 0, -1), math.V3(0, 0, 1), 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cyl, err := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), r, h)
+			if err != nil {
+				t.Fatalf("SolidCylinder: %v", err)
+			}
+			plane, _ := geom.NewPlane(tc.planePoint, tc.planeNormal)
+			res, err := brep.HalfSpaceCut(cyl, plane)
+			if err != nil {
+				t.Fatalf("HalfSpaceCut: %v", err)
+			}
+			if tc.keptHeight == 0 {
+				if res.IsSolid() && len(res.Faces()) > 0 {
+					t.Fatalf("expected empty result, got %d faces", len(res.Faces()))
+				}
+				return
+			}
+			if r := ops.Validate(res); !r.Valid || !r.Closed || !r.Manifold || !res.IsSolid() {
+				t.Fatalf("frustum not a valid closed manifold solid: %+v", r)
+			}
+			assertCylinderAndPlaneFaces(t, res)
+			got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+			want := facetedVol(tc.keptHeight)
+			if rel := stdmath.Abs(got-want) / want; rel > 1e-6 {
+				t.Errorf("kept volume %.6f, want %.6f (rel %.2e)", got, want, rel)
+			}
+		})
+	}
+}
+
+// TestHalfSpaceCutCylinderObliqueDefers: an oblique cut (elliptical section) is not yet handled and
+// must report ErrUnsupportedHalfSpace so the caller keeps the CSG fallback.
+func TestHalfSpaceCutCylinderObliqueDefers(t *testing.T) {
+	cyl, _ := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 4)
+	plane, _ := geom.NewPlane(math.P3(0, 0, 2), math.V3(1, 0, 2)) // tilted off the axis
+	if _, err := brep.HalfSpaceCut(cyl, plane); err == nil {
+		t.Error("oblique cylinder cut should defer (ErrUnsupportedHalfSpace), not return a result")
+	}
+}
+
+// assertCylinderAndPlaneFaces verifies an exact truncated cylinder: one geom.Cylinder side + two
+// geom.Plane caps.
+func assertCylinderAndPlaneFaces(t *testing.T, body *topo.Body) {
+	t.Helper()
+	cyls, planes := 0, 0
+	for _, f := range body.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cylinder:
+			cyls++
+		case geom.Plane:
+			planes++
+		default:
+			t.Errorf("unexpected result face surface %T", f.Geometry())
+		}
+	}
+	if cyls != 1 || planes != 2 {
+		t.Errorf("frustum has %d cylinder + %d plane faces, want 1 + 2", cyls, planes)
+	}
+}
+
 // TestHalfSpaceCutSpherePlaneMissKeepsOrEmpties: a plane clear of the sphere keeps the whole sphere
 // (centre on the negative side) or empties it (centre on the positive side).
 func TestHalfSpaceCutSpherePlaneMissKeepsOrEmpties(t *testing.T) {


### PR DESCRIPTION
Extends `brep.HalfSpaceCut` (M2 Phase 1, #1334) to a closed analytic **cylinder** cut by a plane **perpendicular to its axis**: the kept axial band is a shorter cylinder (exact cylindrical side + planar caps), rebuilt via `SolidCylinder` so it stays watertight and tessellates exactly. A plane clear of the cylinder keeps it whole or empties it; an **oblique** cut (elliptical section) returns `ErrUnsupportedHalfSpace` so the caller keeps the CSG fallback.

## Validation
`TestHalfSpaceCutCylinderPerpendicularIsFrustum` (package `ops_test`): keep-lower/upper band, plane-clears whole/empty. Oracle is the tessellated volume of an independently-built `SolidCylinder` of the kept height — identical faceting, so they agree to 1e-6 (comparing to analytic π·r²·h' would only confirm the cylinder's own ~0.6% chord inscription, not the cut). Plus exact face-type (1 cylinder + 2 planes) and oblique-defer checks. Full `./kernel/...` green; lint clean.

## Box-cut status (transparency)
The general **box** cut is blocked on robust **multi-arc curved-patch tessellation**: a sphere/cylinder face bounded by several arcs (composing >1 half-space) currently mis-meshes — a hand-built sphere octant (patch touching the pole) tessellates ~38% over its analytic πR³/6. That is the next prerequisite (a pole/seam-safe curved-patch mesher), tracked on #1334; this PR does not attempt it, so there is no fragile partial box path.

Refs #1334 #1320
🤖 Generated with [Claude Code](https://claude.com/claude-code)