### PR TITLE
fix(ops): tessellate multi-arc sphere patches via a gnomonic chart (M2 Phase 1)

### DIFF
--- a/kernel/ops/sphere_patch_mesh.go
+++ b/kernel/ops/sphere_patch_mesh.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Multi-arc sphere-patch tessellation (M2 Phase 1, Oblikovati/Oblikovati#1334). A sphere face bounded
+// by SEVERAL arcs — the curved face a box (or any multi-plane) cut leaves on a sphere — meshed wrong
+// through the lat/long (u,v) path: near a pole every column collapses, so the constrained-Delaunay in
+// (u,v) folds and over/under-fills (a hand-built octant came out ~38% over its analytic πR³/6). The
+// fix is to triangulate in a GNOMONIC chart instead: central projection from the sphere centre onto
+// the tangent plane at the patch's mean direction. There great circles map to straight lines and there
+// is no pole/seam degeneracy within a hemisphere, so interior Steiner points lift back to the sphere
+// cleanly and the patch carries its true curvature. Like sphereCapFan/coneApexFan it self-gates — a
+// patch that exceeds a hemisphere (where the gnomonic projection blows up) defers to the existing path.
+
+// minPatchAxisDot requires every boundary point to lie within ~81° of the chart axis (dir·axis ≥ this),
+// i.e. inside a hemisphere, so the gnomonic projection stays well-conditioned (the projection diverges
+// as a point approaches 90°). A larger patch defers to the caller.
+const minPatchAxisDot = 0.15
+
+// spherePatchMesh meshes a multi-arc sphere patch in a gnomonic chart. ok=false unless the surface is a
+// sphere whose boundary lies within a hemisphere — then the caller keeps its existing path.
+func spherePatchMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, q Quality) (*Mesh, bool) {
+	sph, ok := s.(geom.Sphere)
+	if !ok || len(outer3D) < 3 {
+		return nil, false
+	}
+	axis, ok := patchAxis(sph, outer3D, holes3D)
+	if !ok {
+		return nil, false
+	}
+	e1, e2 := planeBasis(axis)
+	c := gnomonicChart{sph: sph, axis: axis, e1: e1, e2: e2}
+	uv, pos, nrm, loops, loops2D := c.projectBoundary(outer3D, holes3D)
+	c.addInteriorNodes(&uv, &pos, &nrm, loops2D, q)
+	tris := constrainedDelaunay(uv, loops)
+	if len(tris) == 0 {
+		return nil, false
+	}
+	m := patchMeshFrom(pos, nrm, tris)
+	repairFolds(m, 8)
+	return m, true
+}
+
+// gnomonicChart is the central projection of a sphere onto the tangent plane at axis: a point of unit
+// direction u maps to ((R/(u·axis))·u − R·axis) resolved in the orthonormal in-plane basis (e1, e2).
+type gnomonicChart struct {
+	sph    geom.Sphere
+	axis   math.Vector3
+	e1, e2 math.Vector3
+}
+
+// patchAxis returns the chart axis (the boundary's mean direction from the sphere centre) and whether
+// every boundary point lies within a hemisphere of it (so the gnomonic projection is well-conditioned).
+func patchAxis(sph geom.Sphere, outer3D []math.Point3, holes3D [][]math.Point3) (math.Vector3, bool) {
+	var sum math.Vector3
+	pts := append(append([]math.Point3{}, outer3D...), flattenLoops(holes3D)...)
+	for _, p := range pts {
+		sum = sum.Add(sphereDir(sph, p))
+	}
+	axis, err := math.UnitVector3FromVector(sum)
+	if err != nil {
+		return math.Vector3{}, false
+	}
+	a := axis.AsVector()
+	for _, p := range pts {
+		if float64(sphereDir(sph, p).Dot(a)) < minPatchAxisDot {
+			return math.Vector3{}, false
+		}
+	}
+	return a, true
+}
+
+// projectBoundary maps every boundary loop to the gnomonic plane, keeping the EXACT 3D points and radial
+// normals (so the patch welds to its neighbour faces at the shared edge samples). It returns the parallel
+// 2D/3D/normal arrays, the loop index sequences for the CDT, and the loops as math.Point2 for clearOfTrim.
+func (c gnomonicChart) projectBoundary(outer3D []math.Point3, holes3D [][]math.Point3) (uv [][2]float64, pos []math.Point3, nrm []math.Vector3, loops [][]int, loops2D [][]math.Point2) {
+	for _, loop := range append([][]math.Point3{outer3D}, holes3D...) {
+		idx := make([]int, len(loop))
+		ring2D := make([]math.Point2, len(loop))
+		for i, p := range loop {
+			g := c.project(p)
+			idx[i] = len(uv)
+			uv = append(uv, g)
+			pos = append(pos, p)
+			nrm = append(nrm, sphereDir(c.sph, p))
+			ring2D[i] = math.P2(math.Scalar(g[0]), math.Scalar(g[1]))
+		}
+		loops = append(loops, idx)
+		loops2D = append(loops2D, ring2D)
+	}
+	return uv, pos, nrm, loops, loops2D
+}
+
+// project maps a 3D sphere point to its gnomonic (e1, e2) coordinates.
+func (c gnomonicChart) project(p math.Point3) [2]float64 {
+	u := sphereDir(c.sph, p)
+	s := float64(u.Dot(c.axis))
+	local := u.Scale(math.Scalar(c.sph.Radius / s)).Add(c.axis.Scale(math.Scalar(-c.sph.Radius)))
+	return [2]float64{float64(local.Dot(c.e1)), float64(local.Dot(c.e2))}
+}
+
+// lift inverts project: a gnomonic point becomes the sphere point along the direction axis·R + a·e1 + b·e2,
+// returning that point and its outward radial normal.
+func (c gnomonicChart) lift(a, b float64) (math.Point3, math.Vector3) {
+	planeDir := c.axis.Scale(math.Scalar(c.sph.Radius)).Add(c.e1.Scale(math.Scalar(a))).Add(c.e2.Scale(math.Scalar(b)))
+	dir := planeDir.Scale(math.Scalar(1 / float64(planeDir.Length())))
+	return c.sph.Center.TranslateBy(dir.Scale(math.Scalar(c.sph.Radius))), dir
+}
+
+// patchGridCap bounds the interior Steiner grid per axis so a large/fine patch cannot explode the node
+// count; beyond it the chord tolerance is met by the cap density rather than the exact spacing.
+const patchGridCap = 60
+
+// addInteriorNodes lays a grid of Steiner points across the gnomonic bbox at a spacing whose lifted
+// chord error meets the tolerance, keeping only points strictly inside the trim, and lifts each to the
+// sphere. Interior points carry the patch's curvature (a boundary-only triangulation would chord flat).
+func (c gnomonicChart) addInteriorNodes(uv *[][2]float64, pos *[]math.Point3, nrm *[]math.Vector3, loops2D [][]math.Point2, q Quality) {
+	umin, umax, vmin, vmax := bounds2D(loops2D[0])
+	h := stdmath.Sqrt(2 * c.sph.Radius * q.tol()) // chord error R(1−cos(h/R)) ≈ h²/2R ≤ tol
+	if h <= 0 {
+		return
+	}
+	nu, nv := gridSteps(umax-umin, h), gridSteps(vmax-vmin, h)
+	holes2D := loops2D[1:]
+	for i := 1; i < nu; i++ {
+		for j := 1; j < nv; j++ {
+			p := [2]float64{umin + (umax-umin)*float64(i)/float64(nu), vmin + (vmax-vmin)*float64(j)/float64(nv)}
+			if !clearOfTrim(loops2D[0], holes2D, p, h*0.25) {
+				continue
+			}
+			pt, n := c.lift(p[0], p[1])
+			*uv = append(*uv, p)
+			*pos = append(*pos, pt)
+			*nrm = append(*nrm, n)
+		}
+	}
+}
+
+// gridSteps returns the number of grid intervals to span extent at spacing h, clamped to patchGridCap.
+func gridSteps(extent, h float64) int {
+	n := int(extent / h)
+	if n > patchGridCap {
+		return patchGridCap
+	}
+	return n
+}
+
+// sphereDir returns the outward unit direction from the sphere centre to a point on it.
+func sphereDir(sph geom.Sphere, p math.Point3) math.Vector3 {
+	return sph.Center.VectorTo(p).Scale(math.Scalar(1 / sph.Radius))
+}
+
+// flattenLoops concatenates loop point rings.
+func flattenLoops(loops [][]math.Point3) []math.Point3 {
+	var out []math.Point3
+	for _, l := range loops {
+		out = append(out, l...)
+	}
+	return out
+}

--- a/kernel/ops/sphere_patch_mesh_test.go
+++ b/kernel/ops/sphere_patch_mesh_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Regression for the multi-arc sphere-patch bug (M2 Phase 1, Oblikovati/Oblikovati#1334): a sphere
+// face bounded by several arcs (a box cut) meshed wrong through the lat/long (u,v) path — a hand-built
+// octant came out ~38% over its analytic πR³/6. spherePatchMesh meshes it in a gnomonic chart, so the
+// patch carries true curvature and the body's volume matches the analytic octant.
+
+// octantBody builds the +,+,+ sphere octant: one spherical face bounded by three quarter ARCS (Arc3d,
+// not full circles — TessellateEdge walks the whole curve domain, so a full Circle edge would mesh the
+// whole circle) plus three planar quarter-disks meeting at the centre. Exactly 1/8 of the sphere.
+func octantBody(t *testing.T, radius float64) *topo.Body {
+	t.Helper()
+	O := math.P3(0, 0, 0)
+	A, B, C := math.P3(radius, 0, 0), math.P3(0, radius, 0), math.P3(0, 0, radius)
+	sphere, _ := geom.NewSphere(O, radius)
+	q := stdmath.Pi / 2
+	circZ, _ := geom.NewArc3d(O, math.V3(0, 0, 1), math.V3(1, 0, 0), radius, 0, q) // A→B (equator)
+	circX, _ := geom.NewArc3d(O, math.V3(1, 0, 0), math.V3(0, 1, 0), radius, 0, q) // B→C (x=0 plane)
+	circY, _ := geom.NewArc3d(O, math.V3(0, 1, 0), math.V3(0, 0, 1), radius, 0, q) // C→A (y=0 plane)
+	planeZ, _ := geom.NewPlane(O, math.V3(0, 0, -1))
+	planeX, _ := geom.NewPlane(O, math.V3(-1, 0, 0))
+	planeY, _ := geom.NewPlane(O, math.V3(0, -1, 0))
+	lin := func(s string, i int) topo.Lineage { return topo.NewLineage(topo.Tok(s, "x", i)) }
+
+	bld := topo.NewBuilder(true, lin("body", 0))
+	vO := bld.AddVertex(O, lin("v", 0))
+	vA := bld.AddVertex(A, lin("v", 1))
+	vB := bld.AddVertex(B, lin("v", 2))
+	vC := bld.AddVertex(C, lin("v", 3))
+	ab := bld.AddEdge(circZ, vA, vB, lin("arc", 0))
+	bc := bld.AddEdge(circX, vB, vC, lin("arc", 1))
+	ca := bld.AddEdge(circY, vC, vA, lin("arc", 2))
+	oa := bld.AddEdge(geom.NewLineSegment(O, A), vO, vA, lin("r", 0))
+	ob := bld.AddEdge(geom.NewLineSegment(O, B), vO, vB, lin("r", 1))
+	oc := bld.AddEdge(geom.NewLineSegment(O, C), vO, vC, lin("r", 2))
+
+	bld.AddFace(sphere, lin("sph", 0), topo.OuterLoop(topo.Fwd(ab), topo.Fwd(bc), topo.Fwd(ca)))
+	bld.AddFace(planeZ, lin("pz", 0), topo.OuterLoop(topo.Fwd(ob), topo.Rev(ab), topo.Rev(oa)))
+	bld.AddFace(planeX, lin("px", 0), topo.OuterLoop(topo.Fwd(oc), topo.Rev(bc), topo.Rev(ob)))
+	bld.AddFace(planeY, lin("py", 0), topo.OuterLoop(topo.Fwd(oa), topo.Rev(ca), topo.Rev(oc)))
+	return bld.Build()
+}
+
+// TestSpherePatchOctantVolume is the headline regression: the spherical triangle (3 arcs, a corner at
+// the +z pole) must mesh to its true curvature so the octant volume is πR³/6, not the ~38%-over the old
+// (u,v) path produced.
+func TestSpherePatchOctantVolume(t *testing.T) {
+	const R = 5.0
+	body := octantBody(t, R)
+	if r := Validate(body); !r.Valid || !r.Closed || !r.Manifold || !body.IsSolid() {
+		t.Fatalf("octant not a valid closed manifold solid: %+v", r)
+	}
+	got := BodyGeometryProperties(body, DefaultQuality()).Volume
+	want := stdmath.Pi * R * R * R / 6
+	if rel := stdmath.Abs(got-want) / want; rel > 0.02 {
+		t.Errorf("octant volume %.4f, want %.4f (rel %.4f > 2%%) — multi-arc sphere patch mis-meshed", got, want, rel)
+	}
+}
+
+// TestSpherePatchDirectMeshIsCurved exercises spherePatchMesh directly on a sphere patch near the +z cap
+// (corners off the pole): it must claim the patch, add interior Steiner points (else the patch is flat),
+// and keep EVERY vertex exactly on the sphere (the gnomonic lift is exact).
+func TestSpherePatchDirectMeshIsCurved(t *testing.T) {
+	const R = 4.0
+	sphere, _ := geom.NewSphere(math.P3(0, 0, 0), R)
+	// A spherical patch sampled ON the sphere along its four bounding iso-curves (so the boundary
+	// points are exact sphere points, as a real arc tessellation would supply).
+	outer := sphereQuadBoundary(sphere, 0.2, 1.0, 0.6, 1.1, 6)
+	m, ok := spherePatchMesh(sphere, outer, nil, DefaultQuality())
+	if !ok {
+		t.Fatal("spherePatchMesh declined a hemisphere patch it should handle")
+	}
+	if len(m.Positions) <= len(outer) {
+		t.Errorf("no interior Steiner points added (%d verts for %d boundary) — patch would be flat", len(m.Positions), len(outer))
+	}
+	for _, p := range m.Positions {
+		if d := float64(p.DistanceTo(sphere.Center)); stdmath.Abs(d-R) > 1e-6 {
+			t.Errorf("mesh vertex %v is off the sphere (radius %.6f, want %.1f)", p, d, R)
+		}
+	}
+}
+
+// sphereQuadBoundary samples the closed boundary of the (u,v)-rectangle [u0,u1]×[v0,v1] on the sphere,
+// n points per side, every point exact on the surface.
+func sphereQuadBoundary(s geom.Sphere, u0, u1, v0, v1 float64, n int) []math.Point3 {
+	var out []math.Point3
+	add := func(uf func(t float64) (u, v float64)) {
+		for k := 0; k < n; k++ {
+			u, v := uf(float64(k) / float64(n))
+			out = append(out, s.PointAt(u, v))
+		}
+	}
+	add(func(t float64) (float64, float64) { return u0 + (u1-u0)*t, v0 })
+	add(func(t float64) (float64, float64) { return u1, v0 + (v1-v0)*t })
+	add(func(t float64) (float64, float64) { return u1 - (u1-u0)*t, v1 })
+	add(func(t float64) (float64, float64) { return u0, v1 - (v1-v0)*t })
+	return out
+}

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -43,6 +43,9 @@ func tessellateCurvedFace(f *topo.Face, q Quality) *Mesh {
 	if m, isCap := sphereCapFan(s, outer3D, q); isCap {
 		return m // a sphere cut by one plane (a cap): rings from the rim to the enclosed pole
 	}
+	if m, isPatch := spherePatchMesh(s, outer3D, holes3D, q); isPatch {
+		return m // a sphere bounded by several arcs (a box cut): gnomonic CDT, pole/seam-safe
+	}
 	outerUV, holesUV, ok := toUVLoops(s, outer3D, holes3D)
 	if !ok {
 		return meshSeamCrossingFace(f, s, outer3D, holes3D, q) // a loop wrapping the seam: band/cap fallbacks


### PR DESCRIPTION
## What
A sphere face bounded by **several arcs** — the curved face a box (or any multi-plane) cut leaves on a sphere — meshed wrong through the lat/long (u,v) path: near a pole every column collapses, so the constrained-Delaunay folds and mis-fills (a hand-built octant came out **~38% over** its analytic πR³/6).

`spherePatchMesh` triangulates in a **gnomonic chart** instead — central projection from the sphere centre onto the tangent plane at the patch's mean direction. There great circles map to straight lines and there's no pole/seam degeneracy within a hemisphere, so interior Steiner points lift back to the sphere cleanly and the patch carries its true curvature. Like `sphereCapFan`/`coneApexFan` it self-gates: a patch exceeding a hemisphere defers to the existing path. It reuses the existing `constrainedDelaunay` / `patchMeshFrom` / `clearOfTrim` / `repairFolds` infrastructure.

## Why
Tessellation correctness is the kernel's top priority, and this is the prerequisite for the **curved-solid ∩ box** boolean (#1334 / M2): composing half-spaces leaves exactly these multi-arc curved faces.

## Validation
- `TestSpherePatchOctantVolume` — a sphere octant (spherical triangle with a corner **at the pole**) now tessellates to the analytic πR³/6 within 2% (was ~38% over). Its arcs use `Arc3d` (a full `Circle` edge would mesh the whole circle — `TessellateEdge` walks the curve's whole domain).
- `TestSpherePatchDirectMeshIsCurved` — a direct patch keeps every vertex exactly on the sphere with interior refinement (not flat).
- Full `./kernel/...` + `./model/...` green; lint clean.

Refs #1334 #1320
🤖 Generated with [Claude Code](https://claude.com/claude-code)