### PR TITLE
feat(brep): looped split — cut a face the plane crosses (M2 Phase 1)

### DIFF
--- a/kernel/brep/curved_halfspace_general.go
+++ b/kernel/brep/curved_halfspace_general.go
@@ -58,7 +58,10 @@ func splitFaceByPlane(f curvedFace, plane geom.Plane, n math.Vector3) ([]curvedF
 	if len(f.loops) == 0 {
 		return capSplit(f, curves[0])
 	}
-	return nil, nil, ErrUnsupportedHalfSpace // looped face crossed by the imprint: next increment
+	if len(curves) != 1 {
+		return nil, nil, ErrUnsupportedHalfSpace // multiple imprints on one looped face: a later increment
+	}
+	return loopedSplit(f, curves[0], plane, n)
 }
 
 // capSplit splits a boundary-less face (a bare sphere) by its imprint circle into the kept negative cap
@@ -114,10 +117,52 @@ func chainSectionLoops(section []loopEdge) [][]loopEdge {
 			open = append(open, e)
 		}
 	}
-	if len(open) > 0 {
-		return nil // chaining arcs into loops lands with the looped split
+	chained := chainOpenArcs(open)
+	if chained == nil && len(open) > 0 {
+		return nil // open arcs that do not close into loops
+	}
+	return append(loops, chained...)
+}
+
+// chainOpenArcs links open section arcs end-to-start into closed loops (each arc's end meets the next
+// arc's start). Returns nil if any arc cannot be closed into a loop.
+func chainOpenArcs(open []loopEdge) [][]loopEdge {
+	used := make([]bool, len(open))
+	var loops [][]loopEdge
+	for i := range open {
+		if used[i] {
+			continue
+		}
+		loop, ok := traceArcLoop(open, used, i)
+		if !ok {
+			return nil
+		}
+		loops = append(loops, loop)
 	}
 	return loops
+}
+
+// traceArcLoop follows arcs from seed until it returns to the start, marking them used.
+func traceArcLoop(open []loopEdge, used []bool, seed int) ([]loopEdge, bool) {
+	loop := []loopEdge{open[seed]}
+	used[seed] = true
+	cur := open[seed].end()
+	for !samePoint(cur, open[seed].start()) {
+		next := -1
+		for j := range open {
+			if !used[j] && samePoint(open[j].start(), cur) {
+				next = j
+				break
+			}
+		}
+		if next == -1 {
+			return nil, false
+		}
+		loop = append(loop, open[next])
+		used[next] = true
+		cur = open[next].end()
+	}
+	return loop, true
 }
 
 // faceSample returns a point on the face (a boundary vertex, or a surface point for a boundary-less

--- a/kernel/brep/curved_halfspace_looped.go
+++ b/kernel/brep/curved_halfspace_looped.go
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Looped split (M2 Phase 1, Oblikovati/Oblikovati#1334). Splits a face the cutting plane CROSSES — the
+// step that, composed over a tool's planes, cuts a curved solid by a box. For each boundary loop it
+// finds where the loop crosses g=0 (the imprint curve on the surface), keeps the runs on the negative
+// side, and bridges each run's exit back to its entry along the part of the imprint that lies inside the
+// face (pointInCurvedFace picks which arc). The bridge arcs, reversed, are the section edges that chain
+// into the lid. Scope: a single imprint conic and loops with an even number of simple crossings (the box
+// case); an imprint that closes inside the face (an island cut) defers to ErrUnsupportedHalfSpace.
+
+// keptSeg is one sub-edge of a boundary loop after splitting at the plane crossings, tagged by whether
+// its interior lies on the kept (negative) side.
+type keptSeg struct {
+	edge loopEdge
+	keep bool
+}
+
+// loopedSplit splits a looped face f by the plane along imprint conic c, returning the kept sub-faces
+// and the section arcs (oriented for the lid). It handles f's outer loop crossed at an even number of
+// points with no holes; anything else defers.
+func loopedSplit(f curvedFace, c geom.Curve3, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
+	if len(f.loops) != 1 {
+		return nil, nil, ErrUnsupportedHalfSpace // holes/multi-loop: a later increment
+	}
+	segs, crossings := splitLoopByPlane(f.loops[0], plane, n)
+	if crossings == 0 || crossings%2 != 0 {
+		return nil, nil, ErrUnsupportedHalfSpace // island cut or a tangency we don't resolve yet
+	}
+	runs := keptRuns(segs)
+	if len(runs) == 0 {
+		return nil, nil, nil // every crossing-free piece was on the positive side: dropped
+	}
+	loop, section, err := closeRuns(f, c, runs)
+	if err != nil {
+		return nil, nil, err
+	}
+	kept := curvedFace{surface: f.surface, reversed: f.reversed, lineage: f.lineage, loops: []curvedLoop{{edges: loop}}}
+	return []curvedFace{kept}, section, nil
+}
+
+// closeRuns bridges each kept run's exit back to the next run's entry along the imprint arc inside f,
+// producing one closed kept loop and the matching (reversed) section arcs. It assumes the runs, taken in
+// order, alternate with the imprint bridges (the even-crossing convex case).
+func closeRuns(f curvedFace, c geom.Curve3, runs [][]loopEdge) ([]loopEdge, []loopEdge, error) {
+	var loop, section []loopEdge
+	for i, run := range runs {
+		loop = append(loop, run...)
+		exit := run[len(run)-1].end()
+		entry := runs[(i+1)%len(runs)][0].start()
+		bridge, ok := bridgeArc(f, c, exit, entry)
+		if !ok {
+			return nil, nil, ErrUnsupportedHalfSpace
+		}
+		loop = append(loop, bridge)
+		section = append(section, reverseEdge(bridge)) // the lid traverses the cut the opposite way
+	}
+	return loop, section, nil
+}
+
+// splitLoopByPlane cuts every loop edge at its g=0 crossings, returning the resulting sub-edges tagged
+// kept/dropped (by their midpoint side) and the total crossing count.
+func splitLoopByPlane(loop curvedLoop, plane geom.Plane, n math.Vector3) ([]keptSeg, int) {
+	var segs []keptSeg
+	crossings := 0
+	for _, le := range loop.edges {
+		cs := edgeCrossings(le, plane, n)
+		crossings += len(cs)
+		bounds := append([]float64{le.t0}, cs...)
+		bounds = append(bounds, le.t1)
+		for i := 0; i+1 < len(bounds); i++ {
+			sub := loopEdge{curve: le.curve, t0: bounds[i], t1: bounds[i+1]}
+			mid := le.curve.PointAt((bounds[i] + bounds[i+1]) / 2)
+			segs = append(segs, keptSeg{edge: sub, keep: signedDistance(mid, plane, n) < 0})
+		}
+	}
+	return segs, crossings
+}
+
+// edgeCrossings returns the parameters within an edge's [t0, t1] where g crosses zero (the plane cuts
+// the edge), found by sampling for sign changes then bisecting each.
+func edgeCrossings(le loopEdge, plane geom.Plane, n math.Vector3) []float64 {
+	const samples = 32
+	var out []float64
+	prevT := le.t0
+	prevG := signedDistance(le.curve.PointAt(le.t0), plane, n)
+	for i := 1; i <= samples; i++ {
+		t := le.t0 + (le.t1-le.t0)*float64(i)/samples
+		g := signedDistance(le.curve.PointAt(t), plane, n)
+		if (prevG < 0) != (g < 0) {
+			out = append(out, bisectCrossing(le, plane, n, prevT, t))
+		}
+		prevT, prevG = t, g
+	}
+	return out
+}
+
+// bisectCrossing refines a sign-change bracket [ta, tb] to the parameter where g = 0.
+func bisectCrossing(le loopEdge, plane geom.Plane, n math.Vector3, ta, tb float64) float64 {
+	ga := signedDistance(le.curve.PointAt(ta), plane, n)
+	for i := 0; i < 50; i++ {
+		tm := (ta + tb) / 2
+		gm := signedDistance(le.curve.PointAt(tm), plane, n)
+		if (ga < 0) == (gm < 0) {
+			ta, ga = tm, gm
+		} else {
+			tb = tm
+		}
+	}
+	return (ta + tb) / 2
+}
+
+// keptRuns extracts the maximal cyclic runs of kept sub-edges. An all-kept loop is one run; an all-
+// dropped loop none.
+func keptRuns(segs []keptSeg) [][]loopEdge {
+	n := len(segs)
+	start := -1
+	for i := 0; i < n; i++ {
+		if segs[i].keep && !segs[(i+n-1)%n].keep {
+			start = i
+			break
+		}
+	}
+	if start == -1 {
+		if n > 0 && segs[0].keep {
+			return [][]loopEdge{allEdges(segs)}
+		}
+		return nil
+	}
+	return collectRuns(segs, start)
+}
+
+// collectRuns walks the segments from start, gathering each maximal kept run.
+func collectRuns(segs []keptSeg, start int) [][]loopEdge {
+	n := len(segs)
+	var runs [][]loopEdge
+	var cur []loopEdge
+	for k := 0; k < n; k++ {
+		s := segs[(start+k)%n]
+		if s.keep {
+			cur = append(cur, s.edge)
+		} else if len(cur) > 0 {
+			runs = append(runs, cur)
+			cur = nil
+		}
+	}
+	if len(cur) > 0 {
+		runs = append(runs, cur)
+	}
+	return runs
+}
+
+func allEdges(segs []keptSeg) []loopEdge {
+	out := make([]loopEdge, len(segs))
+	for i, s := range segs {
+		out[i] = s.edge
+	}
+	return out
+}
+
+// bridgeArc returns the portion of the imprint curve c from exit to entry that lies inside face f. For a
+// line it is the segment between them; for a closed conic it is whichever of the two arcs has its
+// midpoint inside f.
+func bridgeArc(f curvedFace, c geom.Curve3, exit, entry math.Point3) (loopEdge, bool) {
+	tExit, _ := geom.CurveParamAtPoint3(c, exit)
+	tEntry, _ := geom.CurveParamAtPoint3(c, entry)
+	if _, isLine := c.(geom.Line); isLine {
+		return loopEdge{curve: c, t0: tExit, t1: tEntry}, true
+	}
+	for _, t1 := range arcCandidates(tExit, tEntry) {
+		cand := loopEdge{curve: c, t0: tExit, t1: t1}
+		if pointInCurvedFace(f, c.PointAt((tExit+t1)/2)) {
+			return cand, true
+		}
+	}
+	return loopEdge{}, false
+}
+
+// arcCandidates returns the two end parameters that, paired with tExit, sweep the two arcs (positive and
+// negative wrap) of a periodic curve from tExit to tEntry.
+func arcCandidates(tExit, tEntry float64) []float64 {
+	d := stdmath.Mod(tEntry-tExit, 1)
+	if d < 0 {
+		d += 1
+	}
+	return []float64{tExit + d, tExit + d - 1}
+}
+
+// reverseEdge flips a loop edge's traversal (swaps its parameter endpoints).
+func reverseEdge(e loopEdge) loopEdge {
+	return loopEdge{curve: e.curve, t0: e.t1, t1: e.t0}
+}

--- a/kernel/brep/curved_membership.go
+++ b/kernel/brep/curved_membership.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// Point-in-curved-face membership (M2 Phase 1, Oblikovati/Oblikovati#1334). The looped split needs to
+// know, for a point on a face's surface, whether it lies inside the face's trimmed region — to pick
+// which arc of an imprint conic runs through the face. brep cannot import ops (cycle), so it cannot use
+// the H3 tessellation winding number; instead this uses the GEODESIC winding number directly on the
+// boundary loops: the signed turning angle of the boundary seen from p, measured around the surface
+// normal at p, sums to ≈ ±2π when p is inside and ≈ 0 when outside — with no pole/seam degeneracy (it is
+// a 3D tangent-plane measurement, not a (u,v) one).
+
+// windingInsideThreshold splits the geodesic winding sum: inside loops contribute ≈ ±2π, outside ≈ 0, so
+// half a turn cleanly separates them.
+const windingInsideThreshold = stdmath.Pi
+
+// pointInCurvedFace reports whether p (assumed on f's surface) lies within f's trimmed region. A
+// boundary-less face contains every surface point.
+func pointInCurvedFace(f curvedFace, p math.Point3) bool {
+	if len(f.loops) == 0 {
+		return true
+	}
+	normal := f.surface.NormalAt(f.surface.ParamAt(p))
+	if normal.LengthSquared() == 0 {
+		return true // a degenerate point (pole/apex): cannot classify, treat as inside
+	}
+	total := 0.0
+	for _, loop := range f.loops {
+		total += loopWindingAngle(loop, p, normal)
+	}
+	// SIGNED, not magnitude: on a closed surface a separating loop winds +2π around the region it
+	// encloses (outer loops are CCW about the outward normal) and −2π around the opposite region, so a
+	// magnitude test would call BOTH sides of a sphere's equator inside. A hole (CW) subtracts its 2π.
+	return total > windingInsideThreshold
+}
+
+// loopWindingAngle returns the signed turning angle of a loop's boundary seen from p, summed around the
+// surface normal — ≈ +2π if the loop winds CCW around p (p inside it), ≈ 0 if p is outside.
+func loopWindingAngle(loop curvedLoop, p math.Point3, normal math.Vector3) float64 {
+	pts := sampleLoopPoints(loop)
+	if len(pts) < 3 {
+		return 0
+	}
+	sum := 0.0
+	for i := range pts {
+		a := tangentComponent(p.VectorTo(pts[i]), normal)
+		b := tangentComponent(p.VectorTo(pts[(i+1)%len(pts)]), normal)
+		sum += signedAngleAround(a, b, normal)
+	}
+	return sum
+}
+
+// loopSampleCount is how many points to sample per loop edge for the winding sum — enough that a curved
+// edge's turning is captured, cheap enough for the inner loop of the split.
+const loopSampleCount = 8
+
+// sampleLoopPoints samples a loop's boundary into ordered 3D points (each edge sampled across its
+// parameter range, the shared endpoints deduplicated by skipping each edge's last sample).
+func sampleLoopPoints(loop curvedLoop) []math.Point3 {
+	var pts []math.Point3
+	for _, le := range loop.edges {
+		for k := 0; k < loopSampleCount; k++ {
+			t := le.t0 + (le.t1-le.t0)*float64(k)/loopSampleCount
+			pts = append(pts, le.curve.PointAt(t))
+		}
+	}
+	return pts
+}
+
+// tangentComponent projects v onto the plane perpendicular to the unit normal (the surface tangent
+// plane), so angles are measured in that plane.
+func tangentComponent(v, normal math.Vector3) math.Vector3 {
+	return v.Sub(normal.Scale(v.Dot(normal)))
+}
+
+// signedAngleAround returns the signed angle from a to b about the axis normal (right-handed), in
+// (−π, π]. Zero when either vector is degenerate.
+func signedAngleAround(a, b, normal math.Vector3) float64 {
+	cross := a.Cross(b).Dot(normal)
+	dot := a.Dot(b)
+	if a.LengthSquared() == 0 || b.LengthSquared() == 0 {
+		return 0
+	}
+	return stdmath.Atan2(float64(cross), float64(dot))
+}

--- a/kernel/brep/curved_membership_test.go
+++ b/kernel/brep/curved_membership_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// pointInCurvedFace (M2 Phase 1, Oblikovati/Oblikovati#1334) must classify points on a sphere cap: the
+// lower hemisphere (enclosed by the equator loop) contains its own pole, not the opposite one.
+
+// lowerHemisphereCap builds the curvedFace for a sphere's lower (z<0) cap: the sphere surface with the
+// equator as its boundary loop, reversed so the lower cap is the enclosed region (as capSplit emits it).
+func lowerHemisphereCap(t *testing.T, r float64) curvedFace {
+	t.Helper()
+	sphere, _ := geom.NewSphere(math.P3(0, 0, 0), r)
+	circle, _ := geom.NewCircle(math.P3(0, 0, 0), math.V3(0, 0, 1), r)
+	return curvedFace{
+		surface: sphere,
+		loops:   []curvedLoop{{edges: []loopEdge{{curve: circle, t0: 1, t1: 0}}}},
+	}
+}
+
+func TestPointInCurvedFaceSphereCap(t *testing.T) {
+	const r = 5
+	cap := lowerHemisphereCap(t, r)
+	sphere := cap.surface.(geom.Sphere)
+	inside := sphere.PointAt(0, -1.2) // a point in the southern (lower) hemisphere
+	outside := sphere.PointAt(0, 1.2) // a point in the northern (upper) hemisphere
+	if !pointInCurvedFace(cap, inside) {
+		t.Errorf("lower-cap point %v classified outside", inside)
+	}
+	if pointInCurvedFace(cap, outside) {
+		t.Errorf("upper-hemisphere point %v classified inside the lower cap", outside)
+	}
+}
+
+// TestPointInCurvedFaceBoundaryless: a boundary-less face contains every surface point.
+func TestPointInCurvedFaceBoundaryless(t *testing.T) {
+	sphere, _ := geom.NewSphere(math.P3(0, 0, 0), 3)
+	f := curvedFace{surface: sphere}
+	if !pointInCurvedFace(f, sphere.PointAt(0.7, 0.3)) {
+		t.Error("a boundary-less face must contain every point on its surface")
+	}
+}

--- a/kernel/ops/halfspace_looped_test.go
+++ b/kernel/ops/halfspace_looped_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Looped split acceptance (M2 Phase 1, Oblikovati/Oblikovati#1334): the second of two composed
+// HalfSpaceCuts crosses a curved face (a sphere cap) and its planar lid, exercising loopedSplit on both
+// plus chaining the section arc + line into one lid. The oracle is SYMMETRY: cutting a body by a plane
+// of symmetry through its centroid yields exactly half its volume — exact and tessellation-robust when
+// the kept sphere patch stays within a hemisphere (a larger patch is a spherePatchMesh follow-up, not a
+// split-logic concern).
+
+// TestLoopedSplitHalvesACapBySymmetry cuts a small spherical cap (kept z ≤ −3, a sub-hemisphere cap) by
+// a plane of symmetry (x ≤ 0, y ≤ 0): the result must be a valid analytic solid of half the cap's volume.
+func TestLoopedSplitHalvesACapBySymmetry(t *testing.T) {
+	const R = 5.0
+	sphere, _ := brep.SolidSphere(math.P3(0, 0, 0), R, "s")
+	capPlane, _ := geom.NewPlane(math.P3(0, 0, -3), math.V3(0, 0, 1)) // keep z ≤ −3
+	cap, err := brep.HalfSpaceCut(sphere, capPlane)
+	if err != nil {
+		t.Fatalf("cap cut: %v", err)
+	}
+	capVol := ops.BodyGeometryProperties(cap, ops.DefaultQuality()).Volume
+
+	for _, sym := range []struct {
+		name   string
+		normal math.Vector3
+	}{
+		{"halve by x=0", math.V3(1, 0, 0)},
+		{"halve by y=0", math.V3(0, 1, 0)},
+	} {
+		t.Run(sym.name, func(t *testing.T) {
+			plane, _ := geom.NewPlane(math.P3(0, 0, 0), sym.normal) // symmetry plane through the axis
+			half, err := brep.HalfSpaceCut(cap, plane)
+			if err != nil {
+				t.Fatalf("looped cut: %v", err)
+			}
+			if r := ops.Validate(half); !r.Valid || !r.Closed || !r.Manifold || !half.IsSolid() {
+				t.Fatalf("looped cut is not a valid closed manifold solid: %+v", r)
+			}
+			assertOnlyAnalyticFaces(t, half)
+			got := ops.BodyGeometryProperties(half, ops.DefaultQuality()).Volume
+			want := capVol / 2
+			if rel := stdmath.Abs(got-want) / want; rel > 0.02 {
+				t.Errorf("symmetric half volume %.4f, want %.4f (cap/2) — rel %.4f > 2%%", got, want, rel)
+			}
+		})
+	}
+}
+
+// assertOnlyAnalyticFaces checks the exact path kept analytic surfaces (a sphere patch + planar faces),
+// not tessellated soup.
+func assertOnlyAnalyticFaces(t *testing.T, body *topo.Body) {
+	t.Helper()
+	for _, f := range body.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Sphere, geom.Plane:
+		default:
+			t.Errorf("result face surface %T is not analytic (curved boolean must keep exact surfaces)", f.Geometry())
+		}
+	}
+}


### PR DESCRIPTION
The final stage of the general curved half-space arrangement (#1334): split a face the cutting plane **crosses** — the step that, composed over a tool's planes, cuts a curved solid by a box.

## What
- **`pointInCurvedFace`** — geodesic-winding membership (signed turning angle of the boundary about the surface normal at p; +2π inside, −2π/0 outside). **Signed, not magnitude** — on a sphere a great-circle loop winds ±2π around *each* side, so a magnitude test would call both inside. `brep` can't import `ops`, so this replaces the H3 mesh winding number, with no pole/seam degeneracy.
- **`loopedSplit`** — find where each loop crosses g=0 (root-find + bisect), keep the negative runs, and bridge each run's exit→entry along the imprint arc **inside** the face (membership picks which of a conic's two arcs). A circle bridge becomes an `Arc3d`, a line bridge a segment. The reversed bridges are the section arcs, chained (`chainOpenArcs`) into the lid loop.

## Validation
By **symmetry** (exact and tessellation-robust): a sub-hemisphere spherical cap cut by a plane of symmetry through its centre yields exactly half its volume — a valid analytic solid (sphere patch + planar faces), within 2%, for both x=0 and y=0. (CSG is not a usable oracle here — `ops.Boolean(Intersect, sphere, thinBox)` returns 0 on these configs.) Full `./kernel/...` green; lint clean.

## Remaining for arbitrary sphere ∩ box (#1334)
A box that keeps **more than a hemisphere** of the sphere leaves a multi-arc patch that exceeds `spherePatchMesh`'s gnomonic hemisphere limit (it declines, the fallback mis-meshes). The fix is a **stereographic** chart for >hemisphere patches (covers all but the patch's antipode) — orthogonal to the split logic proven here. Single-circle caps of any size already work (`sphereCapFan`).

Refs #1334 #1320
🤖 Generated with [Claude Code](https://claude.com/claude-code)