### PR TITLE
feat(ops): wire exact curved ∩ box into ops.Boolean (M2 Phase 1, closes acceptance #1)

### DIFF
--- a/kernel/brep/curved_halfspace_looped.go
+++ b/kernel/brep/curved_halfspace_looped.go
@@ -32,8 +32,16 @@ func loopedSplit(f curvedFace, c geom.Curve3, plane geom.Plane, n math.Vector3) 
 		return nil, nil, ErrUnsupportedHalfSpace // holes/multi-loop: a later increment
 	}
 	segs, crossings := splitLoopByPlane(f.loops[0], plane, n)
-	if crossings == 0 || crossings%2 != 0 {
-		return nil, nil, ErrUnsupportedHalfSpace // island cut or a tangency we don't resolve yet
+	if crossings == 0 {
+		// The imprint exists as a curve but does not cross this face's boundary — the face lies wholly
+		// on one side (e.g. a planar lid whose plane meets the cut plane in a line far outside it).
+		if signedDistance(faceSample(f), plane, n) <= 0 {
+			return []curvedFace{f}, nil, nil
+		}
+		return nil, nil, nil
+	}
+	if crossings%2 != 0 {
+		return nil, nil, ErrUnsupportedHalfSpace // a tangency / island we don't resolve yet
 	}
 	runs := keptRuns(segs)
 	if len(runs) == 0 {

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -82,6 +82,11 @@ func join(lin topo.Lineage, target, tool *topo.Body, rel relation) (*topo.Body, 
 // triangle-soup BSP CSG only when an operand has a non-planar face the B-rep path can't take
 // (a cylinder, cone, etc.). A nil B-rep result is a (valid) empty body.
 func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.Lineage) (*topo.Body, error) {
+	// Exact curved path first: a curved solid intersected with a convex planar tool composes
+	// brep.HalfSpaceCut over the tool's planes (M2 #1334), keeping analytic surfaces instead of CSG soup.
+	if body, ok := curvedConvexIntersect(op, target, tool); ok {
+		return body, nil
+	}
 	bop, ok := toBrepOp(op)
 	if !ok {
 		return booleanCSG(op, target, tool, lin)

--- a/kernel/ops/boolean_curved_convex.go
+++ b/kernel/ops/boolean_curved_convex.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Exact curved ∩ convex-planar boolean (M2 Phase 1, Oblikovati/Oblikovati#1334). A convex planar solid
+// (a box) is the intersection of its faces' inner half-spaces, so intersecting a curved analytic solid
+// with it is just composing brep.HalfSpaceCut over those planes — an EXACT curved B-rep (cylinder/sphere
+// surfaces preserved), not the triangle-soup CSG. booleanGeneral tries this before falling back to CSG;
+// any operand or cut it cannot handle (a non-convex tool, an unhandled face) returns ok=false, so there
+// is no regression — the CSG path still runs.
+
+// curvedConvexIntersect returns the exact intersection of a curved solid with a convex planar tool, or
+// ok=false to defer to CSG. Only the Intersect operation maps to a half-space composition; Join and Cut
+// (a box is not a half-space complement) stay on the existing path.
+func curvedConvexIntersect(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+	if op != Intersect {
+		return nil, false
+	}
+	curved, planar := orderCurvedPlanar(target, tool)
+	if curved == nil {
+		return nil, false
+	}
+	planes, ok := convexFacePlanes(planar)
+	if !ok {
+		return nil, false
+	}
+	body := curved
+	for _, pl := range planes {
+		res, err := brep.HalfSpaceCut(body, pl)
+		if err != nil {
+			return nil, false // an unhandled cut: defer the whole boolean to CSG
+		}
+		if len(res.Faces()) == 0 {
+			return res, true // a plane removed everything: the intersection is empty
+		}
+		body = res
+	}
+	if !validBooleanSolid(body) {
+		return nil, false
+	}
+	return body, true
+}
+
+// orderCurvedPlanar returns the operand that carries a curved (non-planar) face and the all-planar one,
+// or (nil, nil) when they are not one of each (both planar, or both curved).
+func orderCurvedPlanar(a, b *topo.Body) (curved, planar *topo.Body) {
+	switch {
+	case hasCurvedFace(a) && !hasCurvedFace(b):
+		return a, b
+	case hasCurvedFace(b) && !hasCurvedFace(a):
+		return b, a
+	default:
+		return nil, nil
+	}
+}
+
+// hasCurvedFace reports whether a body has any non-planar face.
+func hasCurvedFace(b *topo.Body) bool {
+	for _, f := range b.Faces() {
+		if _, planar := f.Geometry().(geom.Plane); !planar {
+			return true
+		}
+	}
+	return false
+}
+
+// convexFacePlanes returns each face's plane oriented along its OUTWARD normal, provided the body is an
+// all-planar CONVEX solid (every vertex on the inner side of every face plane). HalfSpaceCut keeps each
+// plane's negative side, which is the convex solid's interior, so composing them carves the tool.
+func convexFacePlanes(b *topo.Body) ([]geom.Plane, bool) {
+	planes, normals, origins, ok := outwardFacePlanes(b)
+	if !ok {
+		return nil, false
+	}
+	tol := ResolutionForBodies(b).Plane()
+	for _, v := range b.Vertices() {
+		for i := range normals {
+			if float64(origins[i].VectorTo(v.Point()).Dot(normals[i])) > tol {
+				return nil, false // a vertex lies outside a face plane → the solid is not convex
+			}
+		}
+	}
+	return planes, true
+}
+
+// outwardFacePlanes collects each planar face's outward-oriented plane (and its normal/origin for the
+// convexity test). ok=false if any face is non-planar or degenerate.
+func outwardFacePlanes(b *topo.Body) (planes []geom.Plane, normals []math.Vector3, origins []math.Point3, ok bool) {
+	for _, f := range b.Faces() {
+		pl, planar := f.Geometry().(geom.Plane)
+		if !planar {
+			return nil, nil, nil, false
+		}
+		n := pl.NormalAt(0, 0)
+		if f.Reversed() {
+			n = n.Scale(-1)
+		}
+		out, err := geom.NewPlane(pl.Origin, n)
+		if err != nil {
+			return nil, nil, nil, false
+		}
+		planes = append(planes, out)
+		normals = append(normals, n)
+		origins = append(origins, pl.Origin)
+	}
+	return planes, normals, origins, true
+}

--- a/kernel/ops/boolean_curved_convex_test.go
+++ b/kernel/ops/boolean_curved_convex_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+)
+
+// The user-facing ops.Boolean(Intersect, curvedSolid, box) must now take the EXACT curved path (compose
+// HalfSpaceCut over the box planes), not the triangle-soup CSG — analytic faces preserved, analytic
+// volume (M2 Phase 1, Oblikovati/Oblikovati#1334, acceptance #1).
+
+// TestBooleanIntersectSphereBoxExact intersects a sphere with a box that trims its +x and lower-z sides.
+// The box's other four planes clear the sphere (kept whole); only x=2 and z=0 cut.
+func TestBooleanIntersectSphereBoxExact(t *testing.T) {
+	const R = 5.0
+	sphere, _ := brep.SolidSphere(math.P3(0, 0, 0), R, "s")
+	box, _ := brep.SolidBlock(math.P3(-10, -10, -10), math.P3(2, 10, 0), "box") // keeps x ≤ 2, z ≤ 0
+
+	res, err := ops.Boolean(ops.Intersect, sphere, box)
+	if err != nil {
+		t.Fatalf("Boolean(Intersect): %v", err)
+	}
+	if r := ops.Validate(res); !r.Valid || !r.Closed || !r.Manifold || !res.IsSolid() {
+		t.Fatalf("sphere∩box is not a valid closed manifold solid: %+v", r)
+	}
+	// EXACT path keeps analytic surfaces — a CSG result would be all tessellated planar triangles.
+	spheres := 0
+	for _, f := range res.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Sphere:
+			spheres++
+		case geom.Plane:
+		default:
+			t.Errorf("face surface %T is not analytic (the exact path must be taken, not CSG)", f.Geometry())
+		}
+	}
+	if spheres != 1 {
+		t.Errorf("result has %d sphere faces, want 1 (the curved cap survived as exact geometry)", spheres)
+	}
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	capV := stdmath.Pi * 9 * (3*R - 3) / 3 // x>2 spherical cap (height 3); its z<0 half is removed
+	want := (2.0/3.0)*stdmath.Pi*R*R*R - capV/2
+	if rel := stdmath.Abs(got-want) / want; rel > 0.02 {
+		t.Errorf("sphere∩box volume %.4f, want %.4f (analytic) — rel %.4f > 2%%", got, want, rel)
+	}
+}
+
+// TestBooleanIntersectSphereContainedBoxUnaffected: a box fully inside the sphere intersects to the box
+// (handled by classify before the curved path) — a sanity check that the wiring did not disturb it.
+func TestBooleanIntersectSphereContainedBoxUnaffected(t *testing.T) {
+	sphere, _ := brep.SolidSphere(math.P3(0, 0, 0), 5, "s")
+	box, _ := brep.SolidBlock(math.P3(-1, -1, -1), math.P3(1, 1, 1), "box") // corner dist √3 < 5: inside
+	res, err := ops.Boolean(ops.Intersect, sphere, box)
+	if err != nil {
+		t.Fatalf("Boolean(Intersect): %v", err)
+	}
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	if stdmath.Abs(got-8) > 1e-6 { // the 2×2×2 box
+		t.Errorf("sphere ∩ contained box volume %.6f, want 8", got)
+	}
+}

--- a/kernel/topo/body.go
+++ b/kernel/topo/body.go
@@ -127,7 +127,8 @@ func (b *Body) RangeBox() math.Box {
 	for _, v := range b.Vertices() {
 		box = box.ExtendPoint(v.point)
 	}
-	return extendBoxByEdges(box, b.Edges())
+	box = extendBoxByEdges(box, b.Edges())
+	return extendBoxByBoundarylessFaces(box, b.Faces())
 }
 
 // FindFaceByKey re-binds a face reference key to the matching face by lineage,

--- a/kernel/topo/rangebox_boundaryless_test.go
+++ b/kernel/topo/rangebox_boundaryless_test.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package topo
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// A boundary-less body (a whole sphere: one face, no vertices or edges) must report its true range box
+// from the surface, not an empty box — else boolean classification judges it disjoint from any tool
+// (Oblikovati/Oblikovati#1334).
+func TestRangeBoxBoundarylessSphere(t *testing.T) {
+	sphere, _ := geom.NewSphere(math.P3(1, 2, 3), 5)
+	bld := NewBuilder(true, NewLineage(Tok("s", "body", 0)))
+	bld.AddFace(sphere, NewLineage(Tok("s", "face", 0)))
+	box := bld.Build().RangeBox()
+	min, max := box.Min, box.Max
+	for _, c := range []struct {
+		got, want float64
+	}{
+		{float64(min.X), -4}, {float64(max.X), 6},
+		{float64(min.Y), -3}, {float64(max.Y), 7},
+		{float64(min.Z), -2}, {float64(max.Z), 8},
+	} {
+		if stdmath.Abs(c.got-c.want) > 1e-9 {
+			t.Errorf("range box bound %.4f, want %.4f (sphere centre (1,2,3) r=5)", c.got, c.want)
+		}
+	}
+}

--- a/kernel/topo/topology.go
+++ b/kernel/topo/topology.go
@@ -37,6 +37,34 @@ func extendBoxByEdges(box math.Box, edges []*Edge) math.Box {
 	return box
 }
 
+// faceSamplesPerAxis grids a boundary-less face's UV domain for its range-box contribution.
+const faceSamplesPerAxis = 8
+
+// extendBoxByBoundarylessFaces extends box by the surface of every face with NO boundary loops — a whole
+// sphere or torus, whose extent comes from neither vertices nor edges (it has none). Without this a bare
+// analytic primitive (SolidSphere) reports an empty range box, so boolean classification wrongly judges
+// it disjoint from any tool. Only bounded closed surfaces reach here; an unbounded domain is skipped.
+func extendBoxByBoundarylessFaces(box math.Box, faces []*Face) math.Box {
+	for _, f := range faces {
+		if len(f.loops) > 0 {
+			continue
+		}
+		uLo, uHi := f.surface.UDomain()
+		vLo, vHi := f.surface.VDomain()
+		if stdmath.IsInf(uLo, 0) || stdmath.IsInf(uHi, 0) || stdmath.IsInf(vLo, 0) || stdmath.IsInf(vHi, 0) {
+			continue
+		}
+		for i := 0; i <= faceSamplesPerAxis; i++ {
+			for j := 0; j <= faceSamplesPerAxis; j++ {
+				u := uLo + (uHi-uLo)*float64(i)/faceSamplesPerAxis
+				v := vLo + (vHi-vLo)*float64(j)/faceSamplesPerAxis
+				box = box.ExtendPoint(f.surface.PointAt(u, v))
+			}
+		}
+	}
+	return box
+}
+
 // Vertex is a 0-dimensional topological entity: a point with identity.
 type Vertex struct {
 	id      uint64


### PR DESCRIPTION
Makes the **user-facing** `ops.Boolean(Intersect, curvedSolid, box)` take the exact curved path instead of triangle-soup CSG — the payoff of the M2 arrangement stack.

## What
A convex planar tool is the intersection of its faces' inner half-spaces, so intersecting a curved analytic solid with it composes `brep.HalfSpaceCut` over those planes (analytic surfaces preserved). `booleanGeneral` tries `curvedConvexIntersect` first; a non-convex tool or an unhandled cut returns ok=false, so the CSG fallback still runs — **no regression**.

## Two enabling fixes (found by wiring)
- **fix(topo): range box for boundary-less bodies.** A whole sphere/torus (one face, no vertices/edges) reported an *empty* range box, so classification judged it disjoint from any tool and returned nothing. Now the surface is sampled over its bounded UV domain. (Regression test: sphere at (1,2,3) r=5 → [-4,6]×[-3,7]×[-2,8].)
- **fix(brep): looped split keeps a non-crossing face whole.** A face whose imprint curve exists but does not cross its boundary (a lid plane meeting the cut plane in a far-off line) wrongly errored; now it is classified whole/dropped — needed so composing over a box's planes survives the planes that clear part of the body.

## Validation
`ops.Boolean(Intersect, sphere, box)` is a valid closed manifold solid with an **exact `geom.Sphere` cap face** and the analytic volume (was the broken CSG returning 0); a box contained in the sphere still intersects to the box. Full `./kernel/...` + `./model/...` green; lint clean.

Closes acceptance #1 (sphere ∩ box exact). Refs #1334 #1320
🤖 Generated with [Claude Code](https://claude.com/claude-code)