### PR TITLE
Cylinder ∩ box exact curved boolean (M2 Phase 1, #1334)

### DIFF
--- a/kernel/brep/curved_halfspace.go
+++ b/kernel/brep/curved_halfspace.go
@@ -35,8 +35,8 @@ var ErrUnsupportedHalfSpace = errors.New("brep: half-space cut handles only the 
 func HalfSpaceCut(body *topo.Body, plane geom.Plane) (*topo.Body, error) {
 	n := unit(plane.Normal())
 	faces := facesOfAny(body)
-	if cyl, base, height, ok := cylinderSolidParams(faces); ok {
-		return cylinderHalfSpace(body, cyl, base, height, plane)
+	if cyl, base, height, ok := cylinderSolidParams(faces); ok && perpendicularToAxis(n, cyl) {
+		return cylinderHalfSpace(body, cyl, base, height, plane) // ⟂ cut → shorter cylinder, fast path
 	}
 	return generalHalfSpace(body, plane, n, faces)
 }

--- a/kernel/brep/curved_halfspace_cylinder.go
+++ b/kernel/brep/curved_halfspace_cylinder.go
@@ -20,6 +20,14 @@ import (
 // the cylinder axis (a constant-axial-coordinate cut). Looser than that is an oblique section.
 const cylinderAxisTol = 1e-7
 
+// perpendicularToAxis reports whether the cut plane normal is parallel to the cylinder axis (a
+// constant-axial-coordinate cut), the only orientation the fast SolidCylinder path handles; an
+// axis-parallel or oblique cut routes to the general arrangement instead.
+func perpendicularToAxis(n math.Vector3, cyl geom.Cylinder) bool {
+	along := float64(n.Dot(cyl.AxisDir.AsVector()))
+	return stdmath.Abs(along) >= 1-cylinderAxisTol
+}
+
 // cylinderSolidParams recovers a closed cylinder's geometry from its flattened faces: the side's
 // geom.Cylinder, the base centre (axially lowest cap), and the height. ok=false unless the body is
 // exactly one cylindrical side plus two planar caps (a bare SolidCylinder), the only shape this

--- a/kernel/brep/curved_halfspace_cylinder_side.go
+++ b/kernel/brep/curved_halfspace_cylinder_side.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Cylinder-side split (M2 Phase 1, Oblikovati/Oblikovati#1334). The general looped split tangles on a
+// FULL periodic cylinder side: its seam edge runs up one constant angle, and when that seam lands in the
+// kept region the two boundary circles' kept arcs join across it into runs the imprint lines cannot
+// bridge. So the full side cut by a plane PARALLEL to the axis (imprint = two axis-parallel lines) gets a
+// dedicated closed-form split here: the kept band is the single arc the plane leaves, rebuilt as a clean
+// seam-free arc face (bottom arc, up one cut line, top arc back, down the other). After this first cut the
+// side is a seam-free arc band, so every later cut composes through the general loopedSplit.
+
+// cylinderSideSplit splits a full periodic cylinder side f by a plane parallel to the axis, given the two
+// axis-parallel imprint lines. It returns the kept arc-band face and the two section lines (reversed for
+// the lid). The two lines bound the chord the plane cuts across the circular cross-section.
+func cylinderSideSplit(f curvedFace, lines []geom.Curve3, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
+	cyl, ok := f.surface.(geom.Cylinder)
+	if !ok || len(lines) != 2 {
+		return nil, nil, ErrUnsupportedHalfSpace
+	}
+	bottom, top, ok := cylinderSideBand(f)
+	if !ok {
+		return nil, nil, ErrUnsupportedHalfSpace
+	}
+	u1 := cylinderAngleOf(cyl, lines[0].PointAt(0))
+	u2 := cylinderAngleOf(cyl, lines[1].PointAt(0))
+	start, sweep := keptCylinderArc(cyl, bottom, top, u1, u2, plane, n)
+	loop, section := cylinderArcBand(cyl, bottom, top, start, sweep)
+	kept := curvedFace{surface: cyl, reversed: f.reversed, lineage: f.lineage, loops: []curvedLoop{{edges: loop}}}
+	return []curvedFace{kept}, section, nil
+}
+
+// cylinderSideBand returns the bottom and top cross-section circle centres of a cylinder side face (the
+// two full-circle boundary edges), ordered low→high along the axis. ok=false if the face is not the
+// expected two-circle periodic side.
+func cylinderSideBand(f curvedFace) (bottom, top math.Point3, ok bool) {
+	cyl := f.surface.(geom.Cylinder)
+	axis := cyl.AxisDir.AsVector()
+	var centers []math.Point3
+	for _, le := range f.loops[0].edges {
+		if c, isCircle := le.curve.(geom.Circle); isCircle && isFullDomain(le.t0, le.t1) {
+			centers = append(centers, c.Center)
+		}
+	}
+	if len(centers) != 2 {
+		return math.Point3{}, math.Point3{}, false
+	}
+	if float64(centers[0].VectorTo(centers[1]).Dot(axis)) < 0 {
+		centers[0], centers[1] = centers[1], centers[0]
+	}
+	return centers[0], centers[1], true
+}
+
+// cylinderAngleOf returns the angle (about the axis, in the cylinder's Ref/binormal frame) of a point on
+// the cylinder surface — the angular position of an imprint line.
+func cylinderAngleOf(cyl geom.Cylinder, p math.Point3) float64 {
+	axis := cyl.AxisDir.AsVector()
+	r := cyl.Origin.VectorTo(p)
+	r = r.Sub(axis.Scale(r.Dot(axis))) // drop the axial component → radial vector
+	binormal := axis.Cross(cyl.Ref.AsVector())
+	return stdmath.Atan2(float64(r.Dot(binormal)), float64(r.Dot(cyl.Ref.AsVector())))
+}
+
+// keptCylinderArc returns the start angle and signed sweep of the arc the plane leaves on the kept
+// (negative) side. Of the two arcs between the crossing angles u1 and u2, it keeps the one whose midpoint
+// lies on the negative side; the sweep is positive (increasing angle) from the returned start.
+func keptCylinderArc(cyl geom.Cylinder, bottom, top math.Point3, u1, u2 float64, plane geom.Plane, n math.Vector3) (start, sweep float64) {
+	const twoPi = 2 * stdmath.Pi
+	midV := float64(bottom.VectorTo(top).Dot(cyl.AxisDir.AsVector())) / 2
+	forward := stdmath.Mod(u2-u1, twoPi) // u1 → u2 increasing
+	if forward < 0 {
+		forward += twoPi
+	}
+	if cylinderArcKept(cyl, bottom, u1+forward/2, midV, plane, n) {
+		return u1, forward
+	}
+	return u2, twoPi - forward
+}
+
+// cylinderArcKept reports whether the cylinder point at angle u and mid-height midV lies on the plane's
+// negative (kept) side.
+func cylinderArcKept(cyl geom.Cylinder, bottom math.Point3, u, midV float64, plane geom.Plane, n math.Vector3) bool {
+	cos, sin := stdmath.Cos(u), stdmath.Sin(u)
+	binormal := cyl.AxisDir.AsVector().Cross(cyl.Ref.AsVector())
+	radial := cyl.Ref.AsVector().Scale(math.Scalar(cos)).Add(binormal.Scale(math.Scalar(sin)))
+	p := bottom.TranslateBy(cyl.AxisDir.AsVector().Scale(math.Scalar(midV))).TranslateBy(radial.Scale(math.Scalar(cyl.Radius)))
+	return signedDistance(p, plane, n) < 0
+}
+
+// cylinderArcBand builds the kept arc-band loop (bottom arc, up the far cut line, top arc back, down the
+// near cut line) and the two section lines (the cut lines, reversed, for the lid). The bottom arc runs
+// forward (the cylinder's outward orientation) and the top arc back, mirroring the periodic side's
+// bottom-forward / top-reversed circle uses so the kept face keeps an outward radial normal.
+func cylinderArcBand(cyl geom.Cylinder, bottom, top math.Point3, start, sweep float64) (loop, section []loopEdge) {
+	axis := cyl.AxisDir.AsVector()
+	ref := cyl.Ref.AsVector()
+	bottomArc, _ := geom.NewArc3d(bottom, axis, ref, cyl.Radius, start, sweep)
+	topArc, _ := geom.NewArc3d(top, axis, ref, cyl.Radius, start+sweep, -sweep)
+	bEnd, bStart := bottomArc.PointAt(1), bottomArc.PointAt(0)
+	tStart, tEnd := topArc.PointAt(0), topArc.PointAt(1) // tStart at β (= bEnd angle), tEnd at α
+	up := loopEdge{curve: geom.NewLineSegment(bEnd, tStart), t0: 0, t1: 1}
+	down := loopEdge{curve: geom.NewLineSegment(tEnd, bStart), t0: 0, t1: 1}
+	loop = []loopEdge{
+		{curve: bottomArc, t0: 0, t1: 1},
+		up,
+		{curve: topArc, t0: 0, t1: 1},
+		down,
+	}
+	return loop, []loopEdge{reverseEdge(up), reverseEdge(down)}
+}

--- a/kernel/brep/curved_halfspace_cylinder_side_test.go
+++ b/kernel/brep/curved_halfspace_cylinder_side_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Cylinder-side split topology (M2 Phase 1, Oblikovati/Oblikovati#1334). HalfSpaceCut by a plane parallel
+// to the cylinder axis must rebuild a clean, seam-free manifold: the arc band, the box-wall lid and the
+// trimmed caps, every edge shared by exactly two faces. Volume is checked through ops_test (brep cannot
+// import ops); here the concern is watertight topology and analytic surfaces preserved.
+
+// assertClosedManifold checks every edge of a solid is used exactly twice and the surfaces stayed
+// analytic (cylinder bands + planar caps/lids), the watertight invariant the split must keep.
+func assertClosedManifold(t *testing.T, body *topo.Body, wantFaces int) {
+	t.Helper()
+	if body == nil || !body.IsSolid() {
+		t.Fatalf("result is not a solid: %+v", body)
+	}
+	if n := len(body.Faces()); n != wantFaces {
+		t.Errorf("result has %d faces, want %d", n, wantFaces)
+	}
+	for _, e := range body.Edges() {
+		if uses := len(e.Uses()); uses != 2 {
+			t.Errorf("edge %v has %d uses, want 2 (a closed manifold)", e.Lineage(), uses)
+		}
+	}
+	for _, f := range body.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cylinder, geom.Plane:
+		default:
+			t.Errorf("face surface %T is not analytic", f.Geometry())
+		}
+	}
+}
+
+// TestHalfSpaceCutCylinderSegmentTopology: an off-centre axis-parallel cut leaves an arc-band side, two
+// half-disk caps and the wall lid — four faces, watertight.
+func TestHalfSpaceCutCylinderSegmentTopology(t *testing.T) {
+	cyl, _ := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 10)
+	plane, _ := geom.NewPlane(math.P3(1.5, 0, 0), math.V3(1, 0, 0)) // keep x ≤ 1.5
+	res, err := HalfSpaceCut(cyl, plane)
+	if err != nil {
+		t.Fatalf("HalfSpaceCut: %v", err)
+	}
+	assertClosedManifold(t, res, 4)
+}
+
+// TestHalfSpaceCutCylinderSeamOnCutTopology is a regression for the closed-edge seam split: when the
+// cut keeps the circle's seam vertex (here the symmetric x ≤ 0 plane), the kept arc wraps the seam and
+// must stay ONE edge that welds with the side band, not fragment into two open edges.
+func TestHalfSpaceCutCylinderSeamOnCutTopology(t *testing.T) {
+	cyl, _ := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 10)
+	plane, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(1, 0, 0)) // keep x ≤ 0
+	res, err := HalfSpaceCut(cyl, plane)
+	if err != nil {
+		t.Fatalf("HalfSpaceCut: %v", err)
+	}
+	assertClosedManifold(t, res, 4)
+}
+
+// TestHalfSpaceCutCylinderSlabTopology composes two opposite walls into a |x| ≤ 1.5 slab. The kept
+// cylinder surface is two disconnected strips, so the looped split must emit TWO arc-band faces (six
+// faces total), each watertight.
+func TestHalfSpaceCutCylinderSlabTopology(t *testing.T) {
+	cyl, _ := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 10)
+	pHi, _ := geom.NewPlane(math.P3(1.5, 0, 0), math.V3(1, 0, 0))
+	pLo, _ := geom.NewPlane(math.P3(-1.5, 0, 0), math.V3(-1, 0, 0))
+	band, err := HalfSpaceCut(cyl, pHi)
+	if err != nil {
+		t.Fatalf("first wall: %v", err)
+	}
+	slab, err := HalfSpaceCut(band, pLo)
+	if err != nil {
+		t.Fatalf("second wall: %v", err)
+	}
+	cylFaces := 0
+	for _, f := range slab.Faces() {
+		if _, ok := f.Geometry().(geom.Cylinder); ok {
+			cylFaces++
+		}
+	}
+	if cylFaces != 2 {
+		t.Errorf("slab has %d cylinder faces, want 2 (two disconnected strips)", cylFaces)
+	}
+	assertClosedManifold(t, slab, 6)
+}
+
+// TestHalfSpaceCutCylinderClearsKeepsWhole: an axis-parallel plane clear of the cylinder keeps it whole.
+func TestHalfSpaceCutCylinderClearsKeepsWhole(t *testing.T) {
+	cyl, _ := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 10)
+	plane, _ := geom.NewPlane(math.P3(5, 0, 0), math.V3(1, 0, 0)) // x ≤ 5: the whole cylinder
+	res, err := HalfSpaceCut(cyl, plane)
+	if err != nil {
+		t.Fatalf("HalfSpaceCut: %v", err)
+	}
+	assertClosedManifold(t, res, 3) // untouched: side + two caps
+}

--- a/kernel/brep/curved_halfspace_general.go
+++ b/kernel/brep/curved_halfspace_general.go
@@ -58,10 +58,39 @@ func splitFaceByPlane(f curvedFace, plane geom.Plane, n math.Vector3) ([]curvedF
 	if len(f.loops) == 0 {
 		return capSplit(f, curves[0])
 	}
-	if len(curves) != 1 {
-		return nil, nil, ErrUnsupportedHalfSpace // multiple imprints on one looped face: a later increment
+	if isFullCylinderSide(f) {
+		if !allLines(curves) {
+			return nil, nil, ErrUnsupportedHalfSpace // an oblique cut of a full periodic side: deferred
+		}
+		return cylinderSideSplit(f, curves, plane, n)
 	}
-	return loopedSplit(f, curves[0], plane, n)
+	return loopedSplit(f, curves, plane, n)
+}
+
+// isFullCylinderSide reports whether f is the full periodic cylinder side (a geom.Cylinder bounded by two
+// closed-circle edges and the seam) — the case the general looped split tangles on, routed to the
+// dedicated cylinderSideSplit instead.
+func isFullCylinderSide(f curvedFace) bool {
+	if _, ok := f.surface.(geom.Cylinder); !ok || len(f.loops) == 0 {
+		return false
+	}
+	for _, le := range f.loops[0].edges {
+		if _, isCircle := le.curve.(geom.Circle); isCircle && isFullDomain(le.t0, le.t1) {
+			return true
+		}
+	}
+	return false
+}
+
+// allLines reports whether every imprint curve is an infinite line (the axis-parallel cut of a cylinder),
+// distinguishing it from a conic (an oblique ellipse) the dedicated cylinder split cannot consume.
+func allLines(curves []geom.Curve3) bool {
+	for _, c := range curves {
+		if _, ok := c.(geom.Line); !ok {
+			return false
+		}
+	}
+	return len(curves) > 0
 }
 
 // capSplit splits a boundary-less face (a bare sphere) by its imprint circle into the kept negative cap

--- a/kernel/brep/curved_halfspace_looped.go
+++ b/kernel/brep/curved_halfspace_looped.go
@@ -10,12 +10,14 @@ import (
 )
 
 // Looped split (M2 Phase 1, Oblikovati/Oblikovati#1334). Splits a face the cutting plane CROSSES — the
-// step that, composed over a tool's planes, cuts a curved solid by a box. For each boundary loop it
-// finds where the loop crosses g=0 (the imprint curve on the surface), keeps the runs on the negative
-// side, and bridges each run's exit back to its entry along the part of the imprint that lies inside the
-// face (pointInCurvedFace picks which arc). The bridge arcs, reversed, are the section edges that chain
-// into the lid. Scope: a single imprint conic and loops with an even number of simple crossings (the box
-// case); an imprint that closes inside the face (an island cut) defers to ErrUnsupportedHalfSpace.
+// step that, composed over a tool's planes, cuts a curved solid by a box. It finds where the boundary
+// crosses g=0 (the imprint on the surface), keeps the runs on the negative side, and threads them into
+// closed loops by bridging each run's exit along whichever imprint curve reaches the next run's entry.
+// The imprint may be one conic (a sphere cap, a disk lid) or several lines (a cylinder arc band a box
+// re-cuts), and a single plane may leave the face in SEVERAL kept pieces (a slab leaves a cylinder band
+// in two strips) — so it yields one sub-face per traced loop. The bridges, reversed, are the section
+// edges that chain into the lid. Scope: an even number of simple crossings and a single outer loop; a
+// hole, an odd crossing (a tangency/island), or an unbridgeable run defers to ErrUnsupportedHalfSpace.
 
 // keptSeg is one sub-edge of a boundary loop after splitting at the plane crossings, tagged by whether
 // its interior lies on the kept (negative) side.
@@ -24,17 +26,19 @@ type keptSeg struct {
 	keep bool
 }
 
-// loopedSplit splits a looped face f by the plane along imprint conic c, returning the kept sub-faces
+// loopedSplit splits a looped face f by the plane along its imprint curves, returning the kept sub-faces
 // and the section arcs (oriented for the lid). It handles f's outer loop crossed at an even number of
-// points with no holes; anything else defers.
-func loopedSplit(f curvedFace, c geom.Curve3, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
+// points with no holes; the imprint may be one conic (a sphere cap, a disk lid) or several lines (a
+// cylinder arc band a box re-cuts), each kept run bridged along whichever imprint curve joins it. A face
+// with holes, an odd crossing count (a tangency/island), or an unbridgeable run defers.
+func loopedSplit(f curvedFace, curves []geom.Curve3, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
 	if len(f.loops) != 1 {
 		return nil, nil, ErrUnsupportedHalfSpace // holes/multi-loop: a later increment
 	}
 	segs, crossings := splitLoopByPlane(f.loops[0], plane, n)
 	if crossings == 0 {
-		// The imprint exists as a curve but does not cross this face's boundary — the face lies wholly
-		// on one side (e.g. a planar lid whose plane meets the cut plane in a line far outside it).
+		// An imprint curve exists but does not cross this face's boundary — the face lies wholly on one
+		// side (e.g. a planar lid whose plane meets the cut plane in a line far outside it).
 		if signedDistance(faceSample(f), plane, n) <= 0 {
 			return []curvedFace{f}, nil, nil
 		}
@@ -47,50 +51,121 @@ func loopedSplit(f curvedFace, c geom.Curve3, plane geom.Plane, n math.Vector3) 
 	if len(runs) == 0 {
 		return nil, nil, nil // every crossing-free piece was on the positive side: dropped
 	}
-	loop, section, err := closeRuns(f, c, runs)
-	if err != nil {
-		return nil, nil, err
-	}
-	kept := curvedFace{surface: f.surface, reversed: f.reversed, lineage: f.lineage, loops: []curvedLoop{{edges: loop}}}
-	return []curvedFace{kept}, section, nil
+	return traceKeptFaces(f, curves, runs)
 }
 
-// closeRuns bridges each kept run's exit back to the next run's entry along the imprint arc inside f,
-// producing one closed kept loop and the matching (reversed) section arcs. It assumes the runs, taken in
-// order, alternate with the imprint bridges (the even-crossing convex case).
-func closeRuns(f curvedFace, c geom.Curve3, runs [][]loopEdge) ([]loopEdge, []loopEdge, error) {
+// traceKeptFaces threads the kept boundary runs into closed loops, each bridged along the imprint, and
+// returns one kept sub-face per loop plus all section edges (the reversed bridges, for the lid). A plane
+// can split one face into SEVERAL kept pieces — a slab leaves a cylinder band in two strips — so the runs
+// are grouped into as many loops as the bridging forms, not assumed to chain into one.
+func traceKeptFaces(f curvedFace, curves []geom.Curve3, runs [][]loopEdge) ([]curvedFace, []loopEdge, error) {
+	used := make([]bool, len(runs))
+	var faces []curvedFace
+	var section []loopEdge
+	for s := range runs {
+		if used[s] {
+			continue
+		}
+		loop, sec, err := traceKeptLoop(f, curves, runs, used, s)
+		if err != nil {
+			return nil, nil, err
+		}
+		faces = append(faces, curvedFace{surface: f.surface, reversed: f.reversed, lineage: f.lineage, loops: []curvedLoop{{edges: loop}}})
+		section = append(section, sec...)
+	}
+	return faces, section, nil
+}
+
+// traceKeptLoop walks from the start run, alternating boundary runs with imprint bridges, until it
+// returns to the start — one closed kept loop. Each run's exit bridges along the imprint curve to the
+// crossing where the next (or the same) run begins.
+func traceKeptLoop(f curvedFace, curves []geom.Curve3, runs [][]loopEdge, used []bool, start int) ([]loopEdge, []loopEdge, error) {
 	var loop, section []loopEdge
-	for i, run := range runs {
-		loop = append(loop, run...)
-		exit := run[len(run)-1].end()
-		entry := runs[(i+1)%len(runs)][0].start()
-		bridge, ok := bridgeArc(f, c, exit, entry)
+	for j := start; ; {
+		used[j] = true
+		loop = append(loop, runs[j]...)
+		exit := runs[j][len(runs[j])-1].end()
+		bridge, k, ok := bridgeToEntry(f, curves, runs, exit)
 		if !ok {
 			return nil, nil, ErrUnsupportedHalfSpace
 		}
 		loop = append(loop, bridge)
 		section = append(section, reverseEdge(bridge)) // the lid traverses the cut the opposite way
+		if k == start {
+			return loop, section, nil
+		}
+		if used[k] {
+			return nil, nil, ErrUnsupportedHalfSpace // a bridge re-entered a consumed run: an arrangement we defer
+		}
+		j = k
 	}
-	return loop, section, nil
+}
+
+// bridgeToEntry finds the run whose start the exit point bridges to along an imprint curve, returning the
+// bridge edge and that run's index. The imprint curve must pass through BOTH the exit and the candidate
+// entry, so the matching line of an axis-parallel pair selects the run that continues the same strip.
+func bridgeToEntry(f curvedFace, curves []geom.Curve3, runs [][]loopEdge, exit math.Point3) (loopEdge, int, bool) {
+	for k, run := range runs {
+		entry := run[0].start()
+		if bridge, ok := bridgeArc(f, curves, exit, entry); ok {
+			return bridge, k, true
+		}
+	}
+	return loopEdge{}, -1, false
 }
 
 // splitLoopByPlane cuts every loop edge at its g=0 crossings, returning the resulting sub-edges tagged
-// kept/dropped (by their midpoint side) and the total crossing count.
+// kept/dropped (by their midpoint side) and the total crossing count. A closed edge (a full seam circle)
+// is cut at its crossings ONLY, the arcs running between consecutive crossings across the seam — never
+// split at the arbitrary seam vertex, which would fragment a kept arc that wraps it into two edges that
+// then fail to weld with the matching single arc on the adjoining face.
 func splitLoopByPlane(loop curvedLoop, plane geom.Plane, n math.Vector3) ([]keptSeg, int) {
 	var segs []keptSeg
 	crossings := 0
 	for _, le := range loop.edges {
 		cs := edgeCrossings(le, plane, n)
 		crossings += len(cs)
-		bounds := append([]float64{le.t0}, cs...)
-		bounds = append(bounds, le.t1)
-		for i := 0; i+1 < len(bounds); i++ {
-			sub := loopEdge{curve: le.curve, t0: bounds[i], t1: bounds[i+1]}
-			mid := le.curve.PointAt((bounds[i] + bounds[i+1]) / 2)
-			segs = append(segs, keptSeg{edge: sub, keep: signedDistance(mid, plane, n) < 0})
+		if samePoint(le.start(), le.end()) && len(cs) > 0 {
+			segs = append(segs, closedEdgeSegs(le, cs, plane, n)...)
+		} else {
+			segs = append(segs, openEdgeSegs(le, cs, plane, n)...)
 		}
 	}
 	return segs, crossings
+}
+
+// openEdgeSegs splits an open edge at its crossings into [t0, c…, t1] sub-edges, tagged by midpoint side.
+func openEdgeSegs(le loopEdge, cs []float64, plane geom.Plane, n math.Vector3) []keptSeg {
+	bounds := append([]float64{le.t0}, cs...)
+	bounds = append(bounds, le.t1)
+	out := make([]keptSeg, 0, len(bounds)-1)
+	for i := 0; i+1 < len(bounds); i++ {
+		out = append(out, taggedSeg(le.curve, bounds[i], bounds[i+1], plane, n))
+	}
+	return out
+}
+
+// closedEdgeSegs splits a closed (seam) edge into the arcs between consecutive crossings, the last
+// wrapping across the seam (its end parameter carries +period so the arc spans the seam rather than
+// stopping at it). period is the signed full-domain span le walks (±1 by traversal direction).
+func closedEdgeSegs(le loopEdge, cs []float64, plane geom.Plane, n math.Vector3) []keptSeg {
+	period := le.t1 - le.t0
+	out := make([]keptSeg, 0, len(cs))
+	for i := range cs {
+		a, b := cs[i], cs[(i+1)%len(cs)]
+		if i == len(cs)-1 {
+			b += period // the final arc runs from the last crossing across the seam to the first
+		}
+		out = append(out, taggedSeg(le.curve, a, b, plane, n))
+	}
+	return out
+}
+
+// taggedSeg builds a sub-edge over [a, b] of curve c and tags it kept when its midpoint is on the plane's
+// negative side.
+func taggedSeg(c geom.Curve3, a, b float64, plane geom.Plane, n math.Vector3) keptSeg {
+	mid := c.PointAt((a + b) / 2)
+	return keptSeg{edge: loopEdge{curve: c, t0: a, t1: b}, keep: signedDistance(mid, plane, n) < 0}
 }
 
 // edgeCrossings returns the parameters within an edge's [t0, t1] where g crosses zero (the plane cuts
@@ -174,12 +249,27 @@ func allEdges(segs []keptSeg) []loopEdge {
 	return out
 }
 
-// bridgeArc returns the portion of the imprint curve c from exit to entry that lies inside face f. For a
-// line it is the segment between them; for a closed conic it is whichever of the two arcs has its
-// midpoint inside f.
-func bridgeArc(f curvedFace, c geom.Curve3, exit, entry math.Point3) (loopEdge, bool) {
+// bridgeArc returns the portion of one imprint curve from exit to entry that lies inside face f, trying
+// each curve until one passes through both points (the right line of an axis-parallel pair, or the
+// imprint conic). A line gives the segment between them; a closed conic gives whichever of its two arcs
+// has its midpoint inside f.
+func bridgeArc(f curvedFace, curves []geom.Curve3, exit, entry math.Point3) (loopEdge, bool) {
+	for _, c := range curves {
+		if e, ok := bridgeAlong(f, c, exit, entry); ok {
+			return e, true
+		}
+	}
+	return loopEdge{}, false
+}
+
+// bridgeAlong returns the exit→entry portion of a single imprint curve c, or ok=false if c does not pass
+// through both endpoints (so the wrong line of a pair is rejected) or no arc of it lies inside f.
+func bridgeAlong(f curvedFace, c geom.Curve3, exit, entry math.Point3) (loopEdge, bool) {
 	tExit, _ := geom.CurveParamAtPoint3(c, exit)
 	tEntry, _ := geom.CurveParamAtPoint3(c, entry)
+	if !onCurve(c, tExit, exit) || !onCurve(c, tEntry, entry) {
+		return loopEdge{}, false
+	}
 	if _, isLine := c.(geom.Line); isLine {
 		return loopEdge{curve: c, t0: tExit, t1: tEntry}, true
 	}
@@ -190,6 +280,12 @@ func bridgeArc(f curvedFace, c geom.Curve3, exit, entry math.Point3) (loopEdge, 
 		}
 	}
 	return loopEdge{}, false
+}
+
+// onCurve reports whether c.PointAt(t) coincides with p — used to confirm a candidate imprint curve
+// actually passes through a crossing point before bridging along it.
+func onCurve(c geom.Curve3, t float64, p math.Point3) bool {
+	return samePoint(c.PointAt(t), p)
 }
 
 // arcCandidates returns the two end parameters that, paired with tExit, sweep the two arcs (positive and

--- a/kernel/geom/intersect_analytic.go
+++ b/kernel/geom/intersect_analytic.go
@@ -64,15 +64,17 @@ func planePlaneCurve(a, b Plane) ([]Curve3, bool) {
 }
 
 // planeCylinderCurve returns the conic a plane cuts from a cylinder: a circle when the
-// plane is perpendicular to the axis, an ellipse when oblique. A plane parallel to the axis
-// (a line pair) is left to the numeric tracer.
+// plane is perpendicular to the axis, an ellipse when oblique, and — when the plane is
+// parallel to the axis — the pair of axis-parallel lines it grazes the cylinder along (none
+// when it clears or is tangent to the cylinder). The axis-parallel pair is what lets a box
+// wall be subtracted from a cylinder exactly (M2 Phase 1, Oblikovati/Oblikovati#1334).
 func planeCylinderCurve(pl Plane, cyl Cylinder) ([]Curve3, bool) {
 	n := unitVec3(pl.Normal())
 	axis := cyl.AxisDir.AsVector()
 	cosA := float64(axis.Dot(n)) // both unit; |cosA| = cos∠(axis, plane normal)
 	abs := stdmath.Abs(cosA)
-	if abs < 1e-6 { // axis ∥ plane → 0/1/2 lines, not a conic
-		return nil, false
+	if abs < 1e-6 { // axis ∥ plane → 0/1/2 lines along the axis
+		return cylinderAxisParallelLines(pl, cyl, n, axis)
 	}
 	t := n.Dot(cyl.Origin.VectorTo(pl.Origin)) / axis.Dot(n)
 	center := cyl.Origin.TranslateBy(axis.Scale(t))
@@ -91,6 +93,29 @@ func planeCylinderCurve(pl Plane, cyl Cylinder) ([]Curve3, bool) {
 		return nil, true
 	}
 	return []Curve3{e}, true
+}
+
+// cylinderAxisParallelLines returns the lines where a plane parallel to the cylinder axis grazes
+// the cylinder: two when the plane cuts inside the radius, none when it clears or is tangent to it
+// (a single tangent line carries no enclosed region, so the half-space cut keeps the cylinder
+// whole). Both lines run along the axis; they are the section edges of a box-wall subtraction.
+func cylinderAxisParallelLines(pl Plane, cyl Cylinder, n, axis math.Vector3) ([]Curve3, bool) {
+	d := float64(n.Dot(pl.Origin.VectorTo(cyl.Origin))) // signed distance of the axis from the plane
+	if stdmath.Abs(d) >= cyl.Radius-1e-9 {
+		return nil, true // plane clears or merely touches the cylinder: no line pair
+	}
+	half := stdmath.Sqrt(cyl.Radius*cyl.Radius - d*d) // half-chord of the cross-section
+	tangent := unitVec3(n.Cross(axis))                // in-plane, perpendicular to the axis
+	foot := cyl.Origin.TranslateBy(n.Scale(math.Scalar(-d)))
+	var out []Curve3
+	for _, s := range []float64{half, -half} {
+		ln, err := NewLine(foot.TranslateBy(tangent.Scale(math.Scalar(s))), axis)
+		if err != nil {
+			return nil, true
+		}
+		out = append(out, ln)
+	}
+	return out, true
 }
 
 // planeConeCurve returns the circle where a plane perpendicular to a cone's axis cuts it

--- a/kernel/geom/intersect_analytic_test.go
+++ b/kernel/geom/intersect_analytic_test.go
@@ -87,11 +87,32 @@ func TestAnalyticObliquePlaneCylinderIsEllipse(t *testing.T) {
 	}
 }
 
-// A plane parallel to the cylinder axis (a line pair) is left to the numeric tracer.
-func TestAnalyticPlaneParallelToCylinderDefers(t *testing.T) {
+// A plane parallel to the cylinder axis, cutting inside the radius, grazes the cylinder along a
+// pair of axis-parallel lines (the section edges of a box-wall subtraction).
+func TestAnalyticPlaneParallelToCylinderIsLinePair(t *testing.T) {
 	cyl, _ := NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2)
-	if _, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 0, 1, 0, 0), cyl); ok {
-		t.Error("a plane parallel to the cylinder axis should defer (handled=false)")
+	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 0, 1, 0, 0), cyl) // x = 0
+	if !ok || len(curves) != 2 {
+		t.Fatalf("plane∥axis through center = %v ok=%v, want two lines", curves, ok)
+	}
+	for _, c := range curves {
+		ln, isLine := c.(Line)
+		if !isLine || !near(stdmath.Abs(float64(ln.Origin.Y)), 2) || !near(float64(ln.Origin.X), 0) {
+			t.Errorf("line %+v, want axis-parallel through y=±2 on x=0", c)
+		}
+		if !near(stdmath.Abs(float64(ln.Dir.AsVector().Z)), 1) {
+			t.Errorf("line direction %v, want along the cylinder axis", ln.Dir)
+		}
+	}
+}
+
+// A plane parallel to the axis but clear of (or tangent to) the cylinder grazes no enclosed
+// region: handled, with no curves, so the half-space cut keeps the cylinder whole.
+func TestAnalyticPlaneParallelClearsCylinder(t *testing.T) {
+	cyl, _ := NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2)
+	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 3, 0, 0, 1, 0, 0), cyl) // x = 3, radius 2
+	if !ok || len(curves) != 0 {
+		t.Errorf("plane clear of the cylinder = %v ok=%v, want handled with no curves", curves, ok)
 	}
 }
 

--- a/kernel/ops/boolean_curved_convex_test.go
+++ b/kernel/ops/boolean_curved_convex_test.go
@@ -52,6 +52,43 @@ func TestBooleanIntersectSphereBoxExact(t *testing.T) {
 	}
 }
 
+// TestBooleanIntersectCylinderBoxExact intersects an axis-aligned cylinder with a box narrower than its
+// diameter: all four box walls clip chords off the cross-section, leaving four exact cylinder arc faces
+// at the corners (a "squircle" prism). The box top/bottom clear the cylinder height. The exact path must
+// preserve the cylinder surfaces and match the analytic cross-section (disk minus four segments) × height.
+func TestBooleanIntersectCylinderBoxExact(t *testing.T) {
+	const r, h, a = 3.0, 10.0, 2.5
+	cyl, _ := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), r, h)
+	box, _ := brep.SolidBlock(math.P3(-a, -a, -5), math.P3(a, a, 15), "box")
+
+	res, err := ops.Boolean(ops.Intersect, cyl, box)
+	if err != nil {
+		t.Fatalf("Boolean(Intersect): %v", err)
+	}
+	if v := ops.Validate(res); !v.Valid || !v.Closed || !v.Manifold || !res.IsSolid() {
+		t.Fatalf("cylinder∩box is not a valid closed manifold solid: %+v", v)
+	}
+	cylFaces := 0
+	for _, f := range res.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cylinder:
+			cylFaces++
+		case geom.Plane:
+		default:
+			t.Errorf("face surface %T is not analytic (the exact path must be taken, not CSG)", f.Geometry())
+		}
+	}
+	if cylFaces != 4 {
+		t.Errorf("result has %d cylinder faces, want 4 (one exact arc per clipped corner)", cylFaces)
+	}
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	segs := r*r*stdmath.Acos(a/r) - a*stdmath.Sqrt(r*r-a*a) // one minor segment beyond a wall
+	want := (stdmath.Pi*r*r - 4*segs) * h
+	if rel := stdmath.Abs(got-want) / want; rel > 0.02 {
+		t.Errorf("cylinder∩box volume %.4f, want %.4f (analytic) — rel %.4f > 2%%", got, want, rel)
+	}
+}
+
 // TestBooleanIntersectSphereContainedBoxUnaffected: a box fully inside the sphere intersects to the box
 // (handled by classify before the curved path) — a sanity check that the wiring did not disturb it.
 func TestBooleanIntersectSphereContainedBoxUnaffected(t *testing.T) {

--- a/kernel/ops/halfspace_cylinder_side_test.go
+++ b/kernel/ops/halfspace_cylinder_side_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Cylinder ∩ box acceptance (M2 Phase 1, Oblikovati/Oblikovati#1334). A box wall parallel to the
+// cylinder axis cuts a chord off the circular cross-section: the kept band is an exact arc-band cylinder
+// face capped by the box wall (a planar lid) and the trimmed circular caps. These tests drive that
+// through HalfSpaceCut — one wall (symmetry + analytic segment) and two opposite walls (a slab, which
+// re-cuts the seam-free arc band through the general looped split).
+
+const cylR, cylH = 3.0, 10.0
+
+// segmentArea returns the area of the smaller circular segment cut off a disk of radius r by a chord at
+// distance m from the centre (m ≤ r): r²·acos(m/r) − m·√(r²−m²).
+func segmentArea(r, m float64) float64 {
+	return r*r*stdmath.Acos(m/r) - m*stdmath.Sqrt(r*r-m*m)
+}
+
+// TestHalfSpaceCutCylinderHalvesBySymmetry cuts an axis-aligned cylinder by a plane of symmetry through
+// the axis (x ≤ 0): the kept band must be a valid analytic solid of exactly half the cylinder's volume.
+func TestHalfSpaceCutCylinderHalvesBySymmetry(t *testing.T) {
+	cyl, _ := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), cylR, cylH)
+	full := ops.BodyGeometryProperties(cyl, ops.DefaultQuality()).Volume
+
+	plane, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(1, 0, 0)) // keep x ≤ 0
+	half, err := brep.HalfSpaceCut(cyl, plane)
+	if err != nil {
+		t.Fatalf("axis-parallel cut: %v", err)
+	}
+	if r := ops.Validate(half); !r.Valid || !r.Closed || !r.Manifold || !half.IsSolid() {
+		t.Fatalf("half cylinder is not a valid closed manifold solid: %+v", r)
+	}
+	assertOnlyCylinderAndPlaneFaces(t, half)
+	got := ops.BodyGeometryProperties(half, ops.DefaultQuality()).Volume
+	if rel := stdmath.Abs(got-full/2) / (full / 2); rel > 0.02 {
+		t.Errorf("symmetric half volume %.4f, want %.4f (full/2) — rel %.4f > 2%%", got, full/2, rel)
+	}
+}
+
+// TestHalfSpaceCutCylinderSegmentVsAnalytic clips the cylinder by an off-centre axis-parallel plane
+// (keep x ≤ 1.5): the kept cross-section is the disk minus the minor segment beyond the chord, so the
+// volume is that area times the height — an analytic oracle the exact arc-band face must match.
+func TestHalfSpaceCutCylinderSegmentVsAnalytic(t *testing.T) {
+	cyl, _ := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), cylR, cylH)
+	plane, _ := geom.NewPlane(math.P3(1.5, 0, 0), math.V3(1, 0, 0)) // keep x ≤ 1.5
+	clipped, err := brep.HalfSpaceCut(cyl, plane)
+	if err != nil {
+		t.Fatalf("axis-parallel cut: %v", err)
+	}
+	if r := ops.Validate(clipped); !r.Valid || !r.Closed || !r.Manifold || !clipped.IsSolid() {
+		t.Fatalf("clipped cylinder is not a valid closed manifold solid: %+v", r)
+	}
+	assertOnlyCylinderAndPlaneFaces(t, clipped)
+	got := ops.BodyGeometryProperties(clipped, ops.DefaultQuality()).Volume
+	want := (stdmath.Pi*cylR*cylR - segmentArea(cylR, 1.5)) * cylH // major part of the disk × height
+	if rel := stdmath.Abs(got-want) / want; rel > 0.02 {
+		t.Errorf("clipped cylinder volume %.4f, want %.4f (analytic) — rel %.4f > 2%%", got, want, rel)
+	}
+}
+
+// TestHalfSpaceCutCylinderSlab keeps the |x| ≤ 1.5 slab by composing two opposite axis-parallel walls.
+// The second wall re-cuts the seam-free arc band the first produced, exercising the general looped split
+// bridging across an axis-parallel line pair. The kept area is the disk minus two minor segments.
+func TestHalfSpaceCutCylinderSlab(t *testing.T) {
+	cyl, _ := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), cylR, cylH)
+	pHi, _ := geom.NewPlane(math.P3(1.5, 0, 0), math.V3(1, 0, 0))   // keep x ≤ 1.5
+	pLo, _ := geom.NewPlane(math.P3(-1.5, 0, 0), math.V3(-1, 0, 0)) // keep x ≥ −1.5
+
+	band, err := brep.HalfSpaceCut(cyl, pHi)
+	if err != nil {
+		t.Fatalf("first wall: %v", err)
+	}
+	slab, err := brep.HalfSpaceCut(band, pLo)
+	if err != nil {
+		t.Fatalf("second wall: %v", err)
+	}
+	if r := ops.Validate(slab); !r.Valid || !r.Closed || !r.Manifold || !slab.IsSolid() {
+		t.Fatalf("slab is not a valid closed manifold solid: %+v", r)
+	}
+	assertOnlyCylinderAndPlaneFaces(t, slab)
+	got := ops.BodyGeometryProperties(slab, ops.DefaultQuality()).Volume
+	want := (stdmath.Pi*cylR*cylR - 2*segmentArea(cylR, 1.5)) * cylH
+	if rel := stdmath.Abs(got-want) / want; rel > 0.02 {
+		t.Errorf("slab volume %.4f, want %.4f (analytic) — rel %.4f > 2%%", got, want, rel)
+	}
+}
+
+// assertOnlyCylinderAndPlaneFaces checks the exact path kept analytic surfaces (cylinder arc bands +
+// planar caps/lids), not tessellated soup.
+func assertOnlyCylinderAndPlaneFaces(t *testing.T, body *topo.Body) {
+	t.Helper()
+	for _, f := range body.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cylinder, geom.Plane:
+		default:
+			t.Errorf("result face surface %T is not analytic (curved boolean must keep exact surfaces)", f.Geometry())
+		}
+	}
+}


### PR DESCRIPTION
## What

Extends the exact curved B-rep boolean to **cylinder ∩ box**, the second half of acceptance #1 (sphere ∩ box landed earlier this milestone). `ops.Boolean(Intersect, cylinder, box)` now takes the exact curved path — the cylinder's curved surfaces survive as analytic `geom.Cylinder` arc faces — instead of degrading to triangle-soup CSG.

A box narrower than the cylinder's diameter now intersects to a clean "squircle" prism: four exact cylinder arc faces at the clipped corners, the box walls as planar lids, and the trimmed caps, with the analytic disk-minus-four-segments cross-section volume.

## Why

`HalfSpaceCut` only handled a cylinder cut perpendicular to its axis (a shorter cylinder). The box walls that clip a cylinder run **parallel** to its axis, and that case was unwired, so every cylinder ∩ box fell back to CSG. Closing it is the next increment of M2 Phase 1 (#1334).

## How (three composing pieces)

- **geom** — a plane parallel to the cylinder axis now returns its true analytic intersection: the **pair of axis-parallel lines** it grazes the cylinder along (the section edges of the wall subtraction), instead of deferring.
- **brep** — the general looped split tangles on a full periodic cylinder side, because its seam, when kept, joins the two rim arcs into runs the imprint lines cannot bridge. The full side cut by an axis-parallel plane gets a **dedicated closed-form split** into a clean seam-free arc band; after that first cut every later cut is seam-free and composes through the general path. The looped split was also generalised to **bridge several imprint curves and trace as many kept loops as the arrangement forms** (a slab leaves a cylinder band in two disconnected strips → two sub-faces). And a **closed seam edge is now cut at its plane crossings only**, never at its arbitrary seam vertex — splitting there fragmented a kept arc into two edges that failed to weld with the adjoining face.

No `/api` change (kernel-internal).

## Tests

Analytic / symmetry oracles (CSG is not a usable oracle here):
- geom: the line-pair imprint and the clears/tangent case.
- brep: watertight-manifold topology for the segment cut, the seam-on-cut regression, the two-strip slab, and a clear-keeps-whole.
- ops: symmetric half, off-centre circular-segment clip, |x|≤a slab, and the full box ∩ cylinder squircle through `ops.Boolean` — four exact cylinder faces, analytic volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)