### PR TITLE
Cylinder − box subtract: exact axial prism tunnel (M2 Phase 1, #1334)

### DIFF
--- a/kernel/brep/curved_halfspace_cylinder.go
+++ b/kernel/brep/curved_halfspace_cylinder.go
@@ -20,6 +20,13 @@ import (
 // the cylinder axis (a constant-axial-coordinate cut). Looser than that is an oblique section.
 const cylinderAxisTol = 1e-7
 
+// CylinderParams recovers a bare cylinder's surface, base-cap centre and height from a body, for callers
+// (the curved subtract) that need the axis frame before building. ok=false unless the body is exactly one
+// cylindrical side plus two planar caps. It mirrors cylinderSolidParams, exported for kernel/ops.
+func CylinderParams(body *topo.Body) (cyl geom.Cylinder, base math.Point3, height float64, ok bool) {
+	return cylinderSolidParams(facesOfAny(body))
+}
+
 // perpendicularToAxis reports whether the cut plane normal is parallel to the cylinder axis (a
 // constant-axial-coordinate cut), the only orientation the fast SolidCylinder path handles; an
 // axis-parallel or oblique cut routes to the general arrangement instead.

--- a/kernel/brep/curved_subtract_prism.go
+++ b/kernel/brep/curved_subtract_prism.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Curved convex subtract — axial prism tunnel (M2 Phase 1, Oblikovati/Oblikovati#1334). A Cut is not a
+// half-space composition: cylinder − box keeps the cylinder OUTSIDE the box plus the box walls INSIDE the
+// cylinder, flipped to bound the cavity. This file handles the clean through-tunnel along the axis: a
+// convex prism (the box) that passes through both caps and stays inside the cylinder radius. The side is
+// untouched, each cap gains a polygonal hole (a planar face with an inner loop), and the prism's walls
+// become the tube — no curved face gets a hole, so it stays within what tessellation already supports.
+
+// SubtractAxialPrism returns the cylinder target with the convex prism through-hole whose cross-section,
+// at the base cap, is polyBottom (ordered CCW about the axis, inside the disk). The caller guarantees the
+// prism spans both caps and clears the side; ErrUnsupportedHalfSpace if target is not a bare cylinder or
+// a corner falls outside the disk (a side-breaching tunnel — a later increment).
+//
+// Example — a 2×2 square hole down the axis of a radius-3 cylinder:
+//
+//	cyl, _ := brep.SolidCylinder(math.P3(0,0,0), math.V3(0,0,1), 3, 10)
+//	sq := []math.Point3{ {1,1,0},{-1,1,0},{-1,-1,0},{1,-1,0} } // CCW about +z, at the base
+//	holed, _ := brep.SubtractAxialPrism(cyl, sq)
+func SubtractAxialPrism(target *topo.Body, polyBottom []math.Point3) (*topo.Body, error) {
+	cyl, base, height, ok := cylinderSolidParams(facesOfAny(target))
+	if !ok || len(polyBottom) < 3 {
+		return nil, ErrUnsupportedHalfSpace
+	}
+	axis := cyl.AxisDir.AsVector()
+	for _, c := range polyBottom {
+		if float64(radialPart(base.VectorTo(c), axis).Length()) >= cyl.Radius-1e-9 {
+			return nil, ErrUnsupportedHalfSpace // a corner reaches the side: not a clean axial tunnel
+		}
+	}
+	polyTop := translateAll(polyBottom, axis.Scale(math.Scalar(height)))
+	faces := prismHoledCaps(facesOfAny(target), base, polyBottom, polyTop)
+	faces = append(faces, prismTubeWalls(polyBottom, polyTop)...)
+	return curvedStitch(faces), nil
+}
+
+// prismHoledCaps keeps the cylinder side whole and gives each planar cap a polygonal hole loop (the prism
+// cross-section at that cap's level), so the cap becomes an annulus-like face the hole tunnels through.
+func prismHoledCaps(faces []curvedFace, base math.Point3, polyBottom, polyTop []math.Point3) []curvedFace {
+	out := make([]curvedFace, 0, len(faces))
+	for _, f := range faces {
+		if _, isCyl := f.surface.(geom.Cylinder); isCyl {
+			out = append(out, f) // the side never meets the axial tunnel: untouched
+			continue
+		}
+		normal := capOutwardNormal(f)
+		poly := polyBottom
+		if float64(base.VectorTo(capOrigin(f)).Dot(normal)) > 0 {
+			poly = polyTop // this cap's outward normal points away from the base → it is the top cap
+		}
+		f.loops = append(f.loops, holeLoop(poly, normal))
+		out = append(out, f)
+	}
+	return out
+}
+
+// prismTubeWalls builds the cavity walls: one planar rectangle per cross-section edge, spanning base to
+// top, with its outward normal pointing into the cylinder material (away from the prism interior) so it
+// bounds the removed tunnel.
+func prismTubeWalls(polyBottom, polyTop []math.Point3) []curvedFace {
+	n := len(polyBottom)
+	centroid := polygonCentroid(polyBottom)
+	walls := make([]curvedFace, 0, n)
+	for i := range polyBottom {
+		j := (i + 1) % n
+		bi, bj, tj, ti := polyBottom[i], polyBottom[j], polyTop[j], polyTop[i]
+		outward := wallOutwardNormal(bi, bj, ti, centroid)
+		plane, err := geom.NewPlane(bi, outward)
+		if err != nil {
+			continue
+		}
+		walls = append(walls, curvedFace{
+			surface: plane,
+			loops:   []curvedLoop{orientLoop([]math.Point3{bi, bj, tj, ti}, outward, +1)},
+			lineage: topo.NewLineage(topo.Tok("subtract", "wall", i)),
+		})
+	}
+	return walls
+}
+
+// capOutwardNormal returns a planar cap's outward normal (its plane normal, flipped when the face is a
+// reversed use of that plane).
+func capOutwardNormal(f curvedFace) math.Vector3 {
+	n := f.surface.(geom.Plane).NormalAt(0, 0)
+	if f.reversed {
+		return n.Scale(-1)
+	}
+	return n
+}
+
+// capOrigin returns a planar cap's plane origin.
+func capOrigin(f curvedFace) math.Point3 {
+	return f.surface.(geom.Plane).Origin
+}
+
+// holeLoop builds the polygon as an inner (hole) loop of a cap: wound CW about the cap's outward normal,
+// the opposite sense to the outer circle, so it removes material.
+func holeLoop(poly []math.Point3, normal math.Vector3) curvedLoop {
+	return orientLoop(poly, normal, -1)
+}
+
+// orientLoop builds a closed polygon loop (line segments between consecutive corners) wound so its signed
+// area about normal has the requested sign (+1 CCW for an outer/wall loop, −1 CW for a hole).
+func orientLoop(poly []math.Point3, normal math.Vector3, want float64) curvedLoop {
+	pts := append([]math.Point3(nil), poly...)
+	if signedLoopArea(pts, normal)*want < 0 {
+		reverse3(pts)
+	}
+	edges := make([]loopEdge, len(pts))
+	for i := range pts {
+		j := (i + 1) % len(pts)
+		edges[i] = loopEdge{curve: geom.NewLineSegment(pts[i], pts[j]), t0: 0, t1: 1}
+	}
+	return curvedLoop{edges: edges}
+}
+
+// wallOutwardNormal returns the unit normal of a tube wall (the plane through edge bi→bj and the axial
+// direction ti−bi) pointing INTO the prism interior (toward the centroid). The solid is the cylinder
+// material OUTSIDE the prism, so the wall's outward face normal points away from that material — into the
+// removed tunnel — which is toward the cross-section centroid.
+func wallOutwardNormal(bi, bj, ti, centroid math.Point3) math.Vector3 {
+	n := bi.VectorTo(bj).Cross(bi.VectorTo(ti))
+	if float64(centroid.VectorTo(bi).Dot(n)) > 0 {
+		n = n.Scale(-1) // pointing away from the centroid → flip to point into the prism
+	}
+	return n
+}
+
+// signedLoopArea is twice the polygon area projected on normal, signed +CCW about it (Newell's method).
+func signedLoopArea(pts []math.Point3, normal math.Vector3) float64 {
+	var sum math.Vector3
+	for i := range pts {
+		j := (i + 1) % len(pts)
+		sum = sum.Add(pts[i].AsVector().Cross(pts[j].AsVector()))
+	}
+	return float64(sum.Dot(normal))
+}
+
+// polygonCentroid returns the average of the polygon corners.
+func polygonCentroid(pts []math.Point3) math.Point3 {
+	var v math.Vector3
+	for _, p := range pts {
+		v = v.Add(p.AsVector())
+	}
+	return math.P3(0, 0, 0).TranslateBy(v.Scale(math.Scalar(1 / float64(len(pts)))))
+}
+
+// radialPart returns the component of v perpendicular to axis (its distance from the axis line).
+func radialPart(v, axis math.Vector3) math.Vector3 {
+	return v.Sub(axis.Scale(v.Dot(axis)))
+}
+
+// translateAll offsets every point by delta.
+func translateAll(pts []math.Point3, delta math.Vector3) []math.Point3 {
+	out := make([]math.Point3, len(pts))
+	for i, p := range pts {
+		out[i] = p.TranslateBy(delta)
+	}
+	return out
+}
+
+// reverse3 reverses a point slice in place.
+func reverse3(pts []math.Point3) {
+	for i, j := 0, len(pts)-1; i < j; i, j = i+1, j-1 {
+		pts[i], pts[j] = pts[j], pts[i]
+	}
+}

--- a/kernel/brep/curved_subtract_prism_test.go
+++ b/kernel/brep/curved_subtract_prism_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"errors"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// Axial prism subtract topology (M2 Phase 1, Oblikovati/Oblikovati#1334). SubtractAxialPrism must rebuild
+// a watertight cylinder-with-tunnel: the side untouched, two holed caps, one wall per cross-section edge,
+// every edge shared by exactly two faces. Volume is checked through ops_test.
+
+// TestSubtractAxialPrismSquareHole: a 2×2 square tunnel → side + 2 caps + 4 walls = 7 faces, watertight.
+func TestSubtractAxialPrismSquareHole(t *testing.T) {
+	cyl, _ := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 10)
+	sq := []math.Point3{math.P3(1, 1, 0), math.P3(-1, 1, 0), math.P3(-1, -1, 0), math.P3(1, -1, 0)}
+	res, err := SubtractAxialPrism(cyl, sq)
+	if err != nil {
+		t.Fatalf("SubtractAxialPrism: %v", err)
+	}
+	assertClosedManifold(t, res, 7)
+}
+
+// TestSubtractAxialPrismTriangleHole proves the polygon path is not rectangle-only: a triangular tunnel
+// gives side + 2 caps + 3 walls = 6 faces, watertight.
+func TestSubtractAxialPrismTriangleHole(t *testing.T) {
+	cyl, _ := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 10)
+	tri := []math.Point3{math.P3(1.5, 0, 0), math.P3(-1, 1.2, 0), math.P3(-1, -1.2, 0)}
+	res, err := SubtractAxialPrism(cyl, tri)
+	if err != nil {
+		t.Fatalf("SubtractAxialPrism: %v", err)
+	}
+	assertClosedManifold(t, res, 6)
+}
+
+// TestSubtractAxialPrismCornerOutsideDefers: a cross-section corner beyond the radius would breach the
+// side — defer (ErrUnsupportedHalfSpace) so the caller keeps the CSG fallback.
+func TestSubtractAxialPrismCornerOutsideDefers(t *testing.T) {
+	cyl, _ := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 10)
+	wide := []math.Point3{math.P3(4, 1, 0), math.P3(-1, 1, 0), math.P3(-1, -1, 0), math.P3(4, -1, 0)}
+	if _, err := SubtractAxialPrism(cyl, wide); !errors.Is(err, ErrUnsupportedHalfSpace) {
+		t.Errorf("corner at radius 4 (> 3) should defer, got err=%v", err)
+	}
+}
+
+// TestSubtractAxialPrismNotACylinderDefers: only a bare cylinder is handled.
+func TestSubtractAxialPrismNotACylinderDefers(t *testing.T) {
+	block, _ := SolidBlock(math.P3(0, 0, 0), math.P3(5, 5, 5), "b")
+	sq := []math.Point3{math.P3(1, 1, 0), math.P3(2, 1, 0), math.P3(2, 2, 0), math.P3(1, 2, 0)}
+	if _, err := SubtractAxialPrism(block, sq); !errors.Is(err, ErrUnsupportedHalfSpace) {
+		t.Errorf("a non-cylinder target should defer, got err=%v", err)
+	}
+}

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -87,6 +87,11 @@ func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.L
 	if body, ok := curvedConvexIntersect(op, target, tool); ok {
 		return body, nil
 	}
+	// And a curved solid cut by a convex prism tunnelling through it (cylinder − box), keeping the
+	// cylinder's exact surfaces with a clean prismatic hole instead of CSG soup (M2 #1334).
+	if body, ok := curvedConvexSubtract(op, target, tool); ok {
+		return body, nil
+	}
 	bop, ok := toBrepOp(op)
 	if !ok {
 		return booleanCSG(op, target, tool, lin)

--- a/kernel/ops/boolean_curved_subtract.go
+++ b/kernel/ops/boolean_curved_subtract.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Exact curved − convex-planar subtract (M2 Phase 1, Oblikovati/Oblikovati#1334). Cut is not a half-space
+// composition (a box is not a half-space complement); cylinder − box keeps the cylinder outside the box
+// and the box walls inside the cylinder, flipped. This wires the clean case: a box that tunnels straight
+// through the cylinder along its axis, inside the radius — an exact prismatic hole (brep.SubtractAxialPrism),
+// the cylinder surfaces preserved. Anything else (a side-breaching or partial tunnel, a tilted box, a
+// non-cylinder target) returns ok=false so booleanGeneral keeps the CSG fallback — no regression.
+
+// axisAlignTol bounds how nearly a box face must be parallel or perpendicular to the cylinder axis for the
+// axial-prism subtract to apply; a more tilted box tunnels along no clean axis and defers to CSG.
+const axisAlignTol = 1e-7
+
+// curvedConvexSubtract returns cylinder − box when the box is an axial through-tunnel inside the cylinder,
+// or ok=false to defer. Only Cut maps here, and only with a curved target (the body being cut) and a
+// convex all-planar tool whose faces are each parallel or perpendicular to the cylinder axis.
+func curvedConvexSubtract(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+	if op != Cut || !hasCurvedFace(target) || hasCurvedFace(tool) {
+		return nil, false
+	}
+	if _, convex := convexFacePlanes(tool); !convex {
+		return nil, false // a non-convex tool: its hull cross-section would over-remove material
+	}
+	cyl, base, height, ok := brep.CylinderParams(target)
+	if !ok {
+		return nil, false
+	}
+	axis := cyl.AxisDir.AsVector()
+	if !boxAxisAligned(tool, axis) || !boxSpansAxially(tool, base, axis, height) {
+		return nil, false
+	}
+	poly := boxAxialCrossSection(tool, cyl, base)
+	if len(poly) < 3 {
+		return nil, false
+	}
+	res, err := brep.SubtractAxialPrism(target, poly)
+	if err != nil || !validBooleanSolid(res) {
+		return nil, false
+	}
+	return res, true
+}
+
+// boxAxisAligned reports whether every tool face is parallel or perpendicular to the axis (so the tool is
+// a prism whose tube walls run straight along the axis), the shape the axial-prism subtract can build.
+func boxAxisAligned(tool *topo.Body, axis math.Vector3) bool {
+	for _, f := range tool.Faces() {
+		pl, planar := f.Geometry().(geom.Plane)
+		if !planar {
+			return false
+		}
+		along := stdmath.Abs(float64(unit(pl.NormalAt(0, 0)).Dot(axis)))
+		if along > axisAlignTol && along < 1-axisAlignTol {
+			return false // an oblique wall: no clean axial tube
+		}
+	}
+	return true
+}
+
+// boxSpansAxially reports whether the tool fully spans the cylinder along the axis (a through-tunnel, not
+// a blind pocket): every cylinder cap level lies between the tool's lowest and highest vertices.
+func boxSpansAxially(tool *topo.Body, base math.Point3, axis math.Vector3, height float64) bool {
+	lo, hi := stdmath.Inf(1), stdmath.Inf(-1)
+	for _, v := range tool.Vertices() {
+		s := float64(base.VectorTo(v.Point()).Dot(axis))
+		lo, hi = stdmath.Min(lo, s), stdmath.Max(hi, s)
+	}
+	return lo <= axisAlignTol && hi >= height-axisAlignTol
+}
+
+// boxAxialCrossSection projects the tool's vertices onto the base cap plane and convex-hulls them into the
+// tunnel's cross-section polygon (ordered CCW about the axis, lifted back to 3D at the base).
+func boxAxialCrossSection(tool *topo.Body, cyl geom.Cylinder, base math.Point3) []math.Point3 {
+	e1 := cyl.Ref.AsVector()
+	e2 := cyl.AxisDir.AsVector().Cross(e1)
+	pts := make([]math.Point2, 0, len(tool.Vertices()))
+	for _, v := range tool.Vertices() {
+		r := base.VectorTo(v.Point())
+		pts = append(pts, math.P2(r.Dot(e1), r.Dot(e2)))
+	}
+	hull := convexHull2D(pts)
+	out := make([]math.Point3, len(hull))
+	for i, p := range hull {
+		out[i] = base.TranslateBy(e1.Scale(p.X)).TranslateBy(e2.Scale(p.Y))
+	}
+	return out
+}

--- a/kernel/ops/boolean_curved_subtract_test.go
+++ b/kernel/ops/boolean_curved_subtract_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+)
+
+// Cylinder − box subtract (M2 Phase 1, Oblikovati/Oblikovati#1334). A box tunnelling along the cylinder
+// axis, inside the radius, must Cut to an exact cylinder with a prismatic hole — the side preserved, each
+// cap an annulus-like planar face the tunnel passes through — not triangle-soup CSG.
+
+// TestBooleanCutCylinderAxialSquareHole drills a 2×2 square hole down the axis of a radius-3 cylinder.
+// Volume = cylinder − the square prism; the cylinder side survives as one exact face.
+func TestBooleanCutCylinderAxialSquareHole(t *testing.T) {
+	const r, h, a = 3.0, 10.0, 1.0
+	cyl, _ := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), r, h)
+	box, _ := brep.SolidBlock(math.P3(-a, -a, -5), math.P3(a, a, 15), "box") // spans beyond both caps
+
+	res, err := ops.Boolean(ops.Cut, cyl, box)
+	if err != nil {
+		t.Fatalf("Boolean(Cut): %v", err)
+	}
+	if v := ops.Validate(res); !v.Valid || !v.Closed || !v.Manifold || !res.IsSolid() {
+		t.Fatalf("cylinder−box is not a valid closed manifold solid: %+v", v)
+	}
+	cylFaces := 0
+	for _, f := range res.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cylinder:
+			cylFaces++
+		case geom.Plane:
+		default:
+			t.Errorf("face surface %T is not analytic (the exact path must be taken, not CSG)", f.Geometry())
+		}
+	}
+	if cylFaces != 1 {
+		t.Errorf("result has %d cylinder faces, want 1 (the side survived the axial tunnel)", cylFaces)
+	}
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	want := stdmath.Pi*r*r*h - (2*a)*(2*a)*h
+	if rel := stdmath.Abs(got-want) / want; rel > 0.02 {
+		t.Errorf("cylinder−box volume %.4f, want %.4f (analytic) — rel %.4f > 2%%", got, want, rel)
+	}
+}
+
+// TestBooleanCutCylinderBlindPocketDefers: a box that does NOT pass through both caps is a blind pocket,
+// not an axial tunnel; the exact path declines it so the CSG fallback still runs (no wrong result).
+func TestBooleanCutCylinderBlindPocketDefers(t *testing.T) {
+	cyl, _ := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 10)
+	box, _ := brep.SolidBlock(math.P3(-1, -1, 4), math.P3(1, 1, 6), "box") // wholly inside, spans nothing
+	res, err := ops.Boolean(ops.Cut, cyl, box)
+	if err != nil {
+		t.Fatalf("Boolean(Cut): %v", err)
+	}
+	if v := ops.Validate(res); !v.Valid || !res.IsSolid() {
+		t.Fatalf("blind-pocket cut is not a valid solid: %+v", v)
+	}
+}


### PR DESCRIPTION
## What

Adds the **subtract** half of acceptance #1: `ops.Boolean(Cut, cylinder, box)` now produces an **exact cylinder with a prismatic through-hole** when the box tunnels along the cylinder axis (inside the radius, spanning both caps), instead of degrading to triangle-soup CSG. The cylinder side survives as one exact `geom.Cylinder` face; each cap becomes an annulus-like planar face the tunnel passes through.

## Why

`Cut` is **not** a half-space composition — a box is not a half-space complement. `A − B` keeps `A` *outside* `B` plus `B`'s walls *inside* `A`, flipped to bound the cavity. So it needs its own construction; until now every `cylinder − box` fell back to CSG.

This is the clean, hole-free-on-curved-faces slice: a tunnel straight down the axis leaves the curved side untouched and puts the holes only on the **planar caps**, which planar multi-hole tessellation already supports. Other configurations (side-breaching or blind tunnels, tilted or non-convex tools) return `ok=false` and keep the CSG fallback — no regression.

## How

- **brep `SubtractAxialPrism`** — given the cylinder and the prism cross-section polygon (CCW about the axis, inside the disk): keep the side whole; give each cap a polygonal **hole** loop (wound opposite the outer circle); build one cavity **wall** per cross-section edge, its outward normal pointing *into* the removed tunnel. Stitched with the existing curved welder. Defers (`ErrUnsupportedHalfSpace`) for a non-cylinder target or a corner beyond the radius.
- **ops `curvedConvexSubtract`** — detects the case (Cut, curved target, convex axis-aligned tool spanning both caps), derives the cross-section by projecting the tool's vertices onto the cap plane and convex-hulling them, and builds via brep; validates the result or defers.

No `/api` change (kernel-internal).

## Tests

- ops: square axial hole through `ops.Boolean(Cut, …)` — one exact cylinder face, analytic `πr²h − prism` volume; a blind pocket correctly defers to CSG.
- brep: watertight-manifold topology for the square hole (7 faces) and a **triangular** prism (6 faces, proving the polygon path isn't rectangle-only); side-breach and non-cylinder defers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)