### PR TITLE
Cone/frustum half-space cut (M2 Phase 1, #1334)

### DIFF
--- a/kernel/brep/curved_halfspace.go
+++ b/kernel/brep/curved_halfspace.go
@@ -38,5 +38,8 @@ func HalfSpaceCut(body *topo.Body, plane geom.Plane) (*topo.Body, error) {
 	if cyl, base, height, ok := cylinderSolidParams(faces); ok && perpendicularToAxis(n, cyl) {
 		return cylinderHalfSpace(body, cyl, base, height, plane) // ⟂ cut → shorter cylinder, fast path
 	}
+	if cone, vMin, vMax, ok := coneSolidParams(faces); ok && perpendicularToConeAxis(n, cone) {
+		return coneHalfSpace(body, cone, vMin, vMax, plane) // ⟂ cut → cone/frustum, fast path
+	}
 	return generalHalfSpace(body, plane, n, faces)
 }

--- a/kernel/brep/curved_halfspace_cone.go
+++ b/kernel/brep/curved_halfspace_cone.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Cone half-space cut (M2 Phase 1, Oblikovati/Oblikovati#1334). Trims an analytic cone or frustum (one
+// geom.Cone side + one or two planar caps) by a plane PERPENDICULAR to its axis: the kept axial band is
+// itself a cone or frustum, rebuilt exactly via SolidCylinderCone (the apex side keeps a smaller cone, the
+// base side a frustum). An oblique plane (an ellipse/parabola/hyperbola section) or a plane through the
+// side defers to the general arrangement — planeConeCurve only solves the perpendicular circle — so it
+// returns ErrUnsupportedHalfSpace and the caller keeps the CSG fallback. Mirrors cylinderHalfSpace.
+
+// coneSolidParams recovers a cone/frustum's geom.Cone and its axial extent (distances from the apex along
+// the axis to the lowest and highest caps) from a body's faces. ok=false unless the body is exactly one
+// cone side plus one cap (a full cone, apex at v=0) or two caps (a frustum) — the bare shapes this path
+// rebuilds.
+func coneSolidParams(faces []curvedFace) (cone geom.Cone, vMin, vMax float64, ok bool) {
+	var caps []geom.Plane
+	found := false
+	for _, f := range faces {
+		switch s := f.surface.(type) {
+		case geom.Cone:
+			cone, found = s, true
+		case geom.Plane:
+			caps = append(caps, s)
+		default:
+			return geom.Cone{}, 0, 0, false
+		}
+	}
+	if !found || len(caps) == 0 || len(caps) > 2 {
+		return geom.Cone{}, 0, 0, false
+	}
+	vMin, vMax = coneCapExtent(cone, caps)
+	return cone, vMin, vMax, true
+}
+
+// coneCapExtent returns the apex-distance band [vMin, vMax] the solid spans: a full cone runs from the
+// apex (v=0) to its one cap; a frustum between its two caps.
+func coneCapExtent(cone geom.Cone, caps []geom.Plane) (vMin, vMax float64) {
+	axis := cone.AxisDir.AsVector()
+	v0 := float64(cone.Apex.VectorTo(caps[0].Origin).Dot(axis))
+	if len(caps) == 1 {
+		return 0, v0 // full cone: apex at v=0 up to the base cap
+	}
+	v1 := float64(cone.Apex.VectorTo(caps[1].Origin).Dot(axis))
+	return stdmath.Min(v0, v1), stdmath.Max(v0, v1)
+}
+
+// coneHalfSpace keeps the axial band of the cone on the plane's negative side, rebuilt as a fresh cone or
+// frustum (exact geom.Cone side + planar caps). The plane must be perpendicular to the axis. A plane clear
+// of the kept band keeps the solid whole or empties it.
+func coneHalfSpace(body *topo.Body, cone geom.Cone, vMin, vMax float64, plane geom.Plane) (*topo.Body, error) {
+	n := unit(plane.Normal())
+	axis := cone.AxisDir.AsVector()
+	along := float64(n.Dot(axis))
+	vCut := float64(cone.Apex.VectorTo(plane.Origin).Dot(axis))
+	vLo, vHi := keptConeBand(vCut, vMin, vMax, along > 0)
+	if vHi-vLo <= cylinderAxisTol {
+		return topo.MergeBodies(topo.NewLineage(topo.Tok("halfspace", "empty", 0)), true), nil
+	}
+	if vLo <= vMin+cylinderAxisTol && vHi >= vMax-cylinderAxisTol {
+		return body, nil // plane clears the cone on the kept side
+	}
+	t := stdmath.Tan(cone.HalfAngle)
+	bottom := cone.Apex.TranslateBy(axis.Scale(math.Scalar(vLo)))
+	top := cone.Apex.TranslateBy(axis.Scale(math.Scalar(vHi)))
+	return SolidCylinderCone(bottom, top, vLo*t, vHi*t, "halfspace")
+}
+
+// keptConeBand returns the [vLo, vHi] apex-distance interval (within [vMin, vMax]) kept on the plane's
+// negative side. With n along +axis the negative side is toward the apex (v ≤ cut); with n along −axis it
+// is toward the base (v ≥ cut).
+func keptConeBand(vCut, vMin, vMax float64, nAlongAxis bool) (vLo, vHi float64) {
+	vCut = stdmath.Max(vMin, stdmath.Min(vMax, vCut))
+	if nAlongAxis {
+		return vMin, vCut
+	}
+	return vCut, vMax
+}
+
+// perpendicularToConeAxis reports whether the cut plane normal is parallel to the cone axis (a
+// constant-apex-distance cut), the only orientation the fast cone path handles.
+func perpendicularToConeAxis(n math.Vector3, cone geom.Cone) bool {
+	return stdmath.Abs(float64(n.Dot(cone.AxisDir.AsVector()))) >= 1-cylinderAxisTol
+}

--- a/kernel/brep/curved_halfspace_cone_test.go
+++ b/kernel/brep/curved_halfspace_cone_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"errors"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Cone half-space topology (M2 Phase 1, Oblikovati/Oblikovati#1334). A perpendicular cut rebuilds an
+// exact cone (apex side) or frustum (base side), watertight; an oblique cut defers. Volume is checked in
+// ops_test.
+
+// assertConeManifold checks a solid is watertight (every edge used twice) with only cone/planar faces.
+func assertConeManifold(t *testing.T, body *topo.Body, wantFaces int) {
+	t.Helper()
+	if body == nil || !body.IsSolid() {
+		t.Fatalf("result is not a solid: %+v", body)
+	}
+	if n := len(body.Faces()); n != wantFaces {
+		t.Errorf("result has %d faces, want %d", n, wantFaces)
+	}
+	for _, e := range body.Edges() {
+		if uses := len(e.Uses()); uses != 2 {
+			t.Errorf("edge %v has %d uses, want 2 (a closed manifold)", e.Lineage(), uses)
+		}
+	}
+	for _, f := range body.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cone, geom.Plane:
+		default:
+			t.Errorf("face surface %T is not analytic", f.Geometry())
+		}
+	}
+}
+
+// TestHalfSpaceCutConeBaseFrustumTopology: keeping the base side leaves a frustum (cone + two caps).
+func TestHalfSpaceCutConeBaseFrustumTopology(t *testing.T) {
+	cone, _ := SolidCylinderCone(math.P3(0, 0, 0), math.P3(0, 0, 10), 3, 0, "cone")
+	plane, _ := geom.NewPlane(math.P3(0, 0, 5), math.V3(0, 0, 1)) // keep z ≤ 5
+	res, err := HalfSpaceCut(cone, plane)
+	if err != nil {
+		t.Fatalf("cone ⟂ cut: %v", err)
+	}
+	assertConeManifold(t, res, 3)
+}
+
+// TestHalfSpaceCutConeApexConeTopology: keeping the apex side leaves a smaller cone (cone + one cap).
+func TestHalfSpaceCutConeApexConeTopology(t *testing.T) {
+	cone, _ := SolidCylinderCone(math.P3(0, 0, 0), math.P3(0, 0, 10), 3, 0, "cone")
+	plane, _ := geom.NewPlane(math.P3(0, 0, 5), math.V3(0, 0, -1)) // keep z ≥ 5 (the tip)
+	res, err := HalfSpaceCut(cone, plane)
+	if err != nil {
+		t.Fatalf("cone ⟂ cut: %v", err)
+	}
+	assertConeManifold(t, res, 2)
+}
+
+// TestHalfSpaceCutFrustumReCut: a frustum (both radii non-zero) is recognized and re-cut to a shorter
+// frustum, so perpendicular cuts compose.
+func TestHalfSpaceCutFrustumReCut(t *testing.T) {
+	frustum, _ := SolidCylinderCone(math.P3(0, 0, 0), math.P3(0, 0, 10), 4, 2, "frustum")
+	plane, _ := geom.NewPlane(math.P3(0, 0, 6), math.V3(0, 0, 1)) // keep z ≤ 6
+	res, err := HalfSpaceCut(frustum, plane)
+	if err != nil {
+		t.Fatalf("frustum ⟂ cut: %v", err)
+	}
+	assertConeManifold(t, res, 3)
+}
+
+// TestHalfSpaceCutConeObliqueDefers: an oblique plane cuts an ellipse/hyperbola section that the analytic
+// imprint does not solve, so the cut defers and the caller keeps the CSG fallback.
+func TestHalfSpaceCutConeObliqueDefers(t *testing.T) {
+	cone, _ := SolidCylinderCone(math.P3(0, 0, 0), math.P3(0, 0, 10), 3, 0, "cone")
+	plane, _ := geom.NewPlane(math.P3(0, 0, 5), math.V3(1, 0, 1)) // tilted: not perpendicular to the axis
+	if _, err := HalfSpaceCut(cone, plane); !errors.Is(err, ErrUnsupportedHalfSpace) {
+		t.Errorf("oblique cone cut should defer, got err=%v", err)
+	}
+}

--- a/kernel/ops/halfspace_cone_test.go
+++ b/kernel/ops/halfspace_cone_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Cone half-space cut (M2 Phase 1, Oblikovati/Oblikovati#1334). A plane perpendicular to the axis trims a
+// cone to an exact cone or frustum (geom.Cone preserved). The oracle is the analytic frustum volume
+// (πh/3)(R²+Rr+r²); the tessellated cone runs ~0.6% under from chord inscription, so 2% tolerance.
+
+// frustumVolume is the analytic volume of a frustum of height h with end radii r0 and r1.
+func frustumVolume(h, r0, r1 float64) float64 {
+	return stdmath.Pi * h / 3 * (r0*r0 + r0*r1 + r1*r1)
+}
+
+// coneAndPlaneFaces checks the exact path kept analytic surfaces (a cone side + planar caps), not soup.
+func coneAndPlaneFaces(t *testing.T, body *topo.Body) {
+	t.Helper()
+	for _, f := range body.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cone, geom.Plane:
+		default:
+			t.Errorf("result face surface %T is not analytic (cone cut must keep exact surfaces)", f.Geometry())
+		}
+	}
+}
+
+// TestHalfSpaceCutConeBaseSideIsFrustum keeps the base side of a cone (apex at z=10, base radius 3 at
+// z=0) below z=5: an exact frustum of end radii 3 and 1.5.
+func TestHalfSpaceCutConeBaseSideIsFrustum(t *testing.T) {
+	cone, _ := brep.SolidCylinderCone(math.P3(0, 0, 0), math.P3(0, 0, 10), 3, 0, "cone")
+	plane, _ := geom.NewPlane(math.P3(0, 0, 5), math.V3(0, 0, 1)) // keep z ≤ 5 (the wide base side)
+	res, err := brep.HalfSpaceCut(cone, plane)
+	if err != nil {
+		t.Fatalf("cone ⟂ cut: %v", err)
+	}
+	if v := ops.Validate(res); !v.Valid || !v.Closed || !v.Manifold || !res.IsSolid() {
+		t.Fatalf("frustum is not a valid closed manifold solid: %+v", v)
+	}
+	coneAndPlaneFaces(t, res)
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	want := frustumVolume(5, 3, 1.5)
+	if rel := stdmath.Abs(got-want) / want; rel > 0.02 {
+		t.Errorf("frustum volume %.4f, want %.4f (analytic) — rel %.4f > 2%%", got, want, rel)
+	}
+}
+
+// TestHalfSpaceCutConeApexSideIsCone keeps the apex side above z=5: a smaller exact cone (radius 1.5).
+func TestHalfSpaceCutConeApexSideIsCone(t *testing.T) {
+	cone, _ := brep.SolidCylinderCone(math.P3(0, 0, 0), math.P3(0, 0, 10), 3, 0, "cone")
+	plane, _ := geom.NewPlane(math.P3(0, 0, 5), math.V3(0, 0, -1)) // keep z ≥ 5 (the apex tip)
+	res, err := brep.HalfSpaceCut(cone, plane)
+	if err != nil {
+		t.Fatalf("cone ⟂ cut: %v", err)
+	}
+	if v := ops.Validate(res); !v.Valid || !v.Closed || !v.Manifold || !res.IsSolid() {
+		t.Fatalf("tip cone is not a valid closed manifold solid: %+v", v)
+	}
+	coneAndPlaneFaces(t, res)
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	want := frustumVolume(5, 1.5, 0) // a cone is a frustum with one radius zero
+	if rel := stdmath.Abs(got-want) / want; rel > 0.02 {
+		t.Errorf("tip cone volume %.4f, want %.4f (analytic) — rel %.4f > 2%%", got, want, rel)
+	}
+}
+
+// TestHalfSpaceCutConeClearsKeepsWhole: a perpendicular plane beyond the base keeps the cone whole.
+func TestHalfSpaceCutConeClearsKeepsWhole(t *testing.T) {
+	cone, _ := brep.SolidCylinderCone(math.P3(0, 0, 0), math.P3(0, 0, 10), 3, 0, "cone")
+	full := ops.BodyGeometryProperties(cone, ops.DefaultQuality()).Volume
+	plane, _ := geom.NewPlane(math.P3(0, 0, 12), math.V3(0, 0, 1)) // z ≤ 12 ⊇ the whole z∈[0,10] cone
+	res, err := brep.HalfSpaceCut(cone, plane)
+	if err != nil {
+		t.Fatalf("cone ⟂ cut: %v", err)
+	}
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	if stdmath.Abs(got-full) > 1e-6 {
+		t.Errorf("cleared cone volume %.6f, want %.6f (whole)", got, full)
+	}
+}


### PR DESCRIPTION
## What

Completes the third analytic primitive of the curved half-space cut: `brep.HalfSpaceCut` now trims a **cone or frustum** by a plane perpendicular to its axis, keeping the kept axial band as an **exact** `geom.Cone` (apex side → a smaller cone, base side → a frustum) instead of triangle-soup CSG.

## Why

`HalfSpaceCut` already handled spheres and cylinders exactly; cones fell through to the general arrangement, which has no analytic imprint for them and so degraded to CSG. The perpendicular cut has a clean closed form (the section is a circle of radius `v·tan(halfAngle)`), so the kept part can be rebuilt directly — mirroring the cylinder fast path.

## How

- `coneSolidParams` recovers the `geom.Cone` and its apex-distance extent from the body's faces (one cap = a full cone with apex at v=0; two caps = a frustum), so perpendicular cuts also **compose** (a re-cut frustum is still recognized).
- `coneHalfSpace` computes the kept `[vLo, vHi]` band on the plane's negative side and rebuilds it with `SolidCylinderCone` (a zero radius at `vLo` gives a full cone, else a frustum). A clearing plane keeps the solid whole or empties it.
- The fast path is gated on the plane being ⟂ the axis. An oblique cut (ellipse/parabola/hyperbola) or an axis-parallel cut defers with `ErrUnsupportedHalfSpace`, so the CSG fallback still runs — no regression.

No `/api` change (kernel-internal).

## Tests

- brep: watertight-manifold topology for the base-side frustum (3 faces), the apex-side cone (2 faces), a re-cut frustum (composition), and an oblique-cut defer.
- ops: analytic frustum-volume oracle `(πh/3)(R²+Rr+r²)` for the frustum and tip-cone cuts, plus a clearing plane keeping the cone whole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)