### PR TITLE
Crossing-cylinder imprint via SSI tracer (M2 Phase 2 slice 1, #1335)

### DIFF
--- a/kernel/brep/curved_crossing_imprint.go
+++ b/kernel/brep/curved_crossing_imprint.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Crossing-cylinder imprint (M2 Phase 2, Oblikovati/Oblikovati#1335). Phase 1 imprints are analytic
+// conics on a cutting plane (a half-space). Two crossing cylinders meet in a curve that is generally NOT
+// analytic — a quartic "saddle" the predictor–corrector SSI tracer (geom.IntersectSurfaceSurface) marches
+// as a closed polyline. This is the imprint stage of the curved∩curved boolean: it returns the loops
+// where the two cylinder surfaces cross, each a closed polyline lying on BOTH surfaces to tolerance — the
+// foundation the split/classify/stitch slices build the watertight result on.
+//
+// Scope note: a thinner cylinder crossing a fatter one (radii unequal) gives clean, well-separated closed
+// loops (a rod's entry/exit through the fat wall). Two EQUAL-radius perpendicular cylinders intersect in
+// two ellipses that cross at pinch points where the tracer's continuation struggles; that degenerate
+// (Steinmetz) case is left to a later slice, which can fit those planar loops to exact ellipses.
+
+// crossingCylinderImprint returns the intersection loops of two bare cylinder bodies as closed polylines,
+// or ok=false when either body is not a bare cylinder or no closed loop is traced. The trace window spans
+// the first body's axial extent (the cylinders cross within it), and the periodic angular direction is
+// resolved by the tracer automatically.
+func crossingCylinderImprint(a, b *topo.Body) ([]geom.Polyline, bool) {
+	ca, baseA, heightA, okA := cylinderSolidParams(facesOfAny(a))
+	cb, _, _, okB := cylinderSolidParams(facesOfAny(b))
+	if !okA || !okB {
+		return nil, false
+	}
+	loops := closedTraceLoops(geom.IntersectSurfaceSurface(ca, cb, cylinderTraceWindow(ca, baseA, heightA)))
+	if len(loops) == 0 {
+		return nil, false
+	}
+	return loops, true
+}
+
+// cylinderTraceWindow is the (u, v) window for tracing on a cylinder base: the full periodic angle (left
+// to the tracer) and the body's own axial span, from the base cap up by its height.
+func cylinderTraceWindow(c geom.Cylinder, base math.Point3, height float64) geom.SurfaceGrid {
+	vLo := float64(c.Origin.VectorTo(base).Dot(c.AxisDir.AsVector()))
+	return geom.SurfaceGrid{VMin: vLo, VMax: vLo + height}
+}
+
+// closedTraceLoops keeps the traced polylines that close into a loop (first point meets last), building a
+// geom.Polyline from each. An open chain — where the tracer broke at a tangency or pinch — is dropped, so
+// the imprint carries only watertight boundary loops.
+func closedTraceLoops(raw [][]math.Point3) []geom.Polyline {
+	var out []geom.Polyline
+	for _, pts := range raw {
+		if len(pts) < 4 || !samePoint(pts[0], pts[len(pts)-1]) {
+			continue
+		}
+		if pl, err := geom.NewPolyline(pts); err == nil {
+			out = append(out, pl)
+		}
+	}
+	return out
+}

--- a/kernel/brep/curved_crossing_imprint_test.go
+++ b/kernel/brep/curved_crossing_imprint_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Crossing-cylinder imprint (M2 Phase 2, Oblikovati/Oblikovati#1335). The imprint stage must trace the
+// surface-surface intersection of two crossing cylinders as closed loops lying on BOTH surfaces — the
+// boundary the split/stitch slices will build the watertight result on.
+
+// onBothCylinders returns the largest distance any loop vertex sits off either cylinder surface.
+func onBothCylinders(loop geom.Polyline, a, b geom.Cylinder) float64 {
+	worst := 0.0
+	for _, p := range loop.Vertices {
+		ea := stdmath.Abs(float64(geom.SignedDistanceToSurface(a, p)))
+		eb := stdmath.Abs(float64(geom.SignedDistanceToSurface(b, p)))
+		worst = stdmath.Max(worst, stdmath.Max(ea, eb))
+	}
+	return worst
+}
+
+// TestCrossingCylinderImprintThinThroughFat traces a thin cylinder crossing a fat one perpendicularly:
+// the rod's entry and exit through the fat wall give two clean closed loops, each on both surfaces.
+func TestCrossingCylinderImprintThinThroughFat(t *testing.T) {
+	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)    // axis z, R=3
+	thin, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12) // axis x, r=1.5, through the centre
+
+	loops, ok := crossingCylinderImprint(fat, thin)
+	if !ok || len(loops) != 2 {
+		t.Fatalf("thin-through-fat imprint: ok=%v loops=%d, want 2 closed loops", ok, len(loops))
+	}
+	ca, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3)
+	cb, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(1, 0, 0), 1.5)
+	for i, lp := range loops {
+		if !samePoint(lp.PointAt(0), lp.PointAt(1)) {
+			t.Errorf("loop %d is not closed: %v vs %v", i, lp.PointAt(0), lp.PointAt(1))
+		}
+		if err := onBothCylinders(lp, ca, cb); err > 1e-5 {
+			t.Errorf("loop %d sits %.2e off a cylinder surface, want it on both", i, err)
+		}
+	}
+}
+
+// TestCrossingCylinderImprintNonCylinderDefers: the imprint only handles bare cylinders.
+func TestCrossingCylinderImprintNonCylinderDefers(t *testing.T) {
+	block, _ := SolidBlock(math.P3(0, 0, 0), math.P3(2, 2, 2), "b")
+	cyl, _ := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 1, 4)
+	if _, ok := crossingCylinderImprint(block, cyl); ok {
+		t.Error("imprint of a block and a cylinder should defer (ok=false)")
+	}
+}
+
+// TestCrossingCylinderImprintDisjointHasNoLoops: cylinders that do not meet trace no loop.
+func TestCrossingCylinderImprintDisjointHasNoLoops(t *testing.T) {
+	a, _ := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 1, 4)
+	b, _ := SolidCylinder(math.P3(20, 0, 0), math.V3(1, 0, 0), 1, 4) // far away
+	if _, ok := crossingCylinderImprint(a, b); ok {
+		t.Error("disjoint cylinders should trace no imprint loop (ok=false)")
+	}
+}


### PR DESCRIPTION
## What

Starts **Phase 2** of the curved boolean (#1335) — curved ∩ curved — with its first stage: the **imprint** of two crossing cylinders, computed by the numeric SSI tracer.

`crossingCylinderImprint(a, b)` returns the loops where two bare cylinders cross, each a **closed polyline lying on both surfaces** to tolerance. This is the boundary the split/classify/stitch slices will build the watertight result on.

## Why

Phase 1 imprints are analytic conics on a cutting plane (a half-space). Two crossing cylinders meet in a quartic **saddle** curve that is generally *not* analytic — it can't be a circle/ellipse/line — so it's traced as a polyline by the predictor–corrector tracer (`geom.IntersectSurfaceSurface`, the M1 SSI prerequisite). Validating this imprint is the foundation the rest of Phase 2 stands on, and it surfaced the key scoping fact below.

## How / scope

- The trace window spans the base cylinder's axial extent; the periodic angular direction is resolved by the tracer.
- Open chains (where the trace broke at a tangency/pinch) are dropped, so only watertight closed loops are carried.
- **Scope:** a *thinner* cylinder crossing a *fatter* one (unequal radii) traces two clean, well-separated loops — a rod's entry/exit through the fat wall. The **equal-radius perpendicular (Steinmetz)** case, whose two ellipses cross at pinch points the continuation struggles with, is deferred to a later slice that can fit those planar loops to exact ellipses.

## Next slices (flagged, not in this PR)

The visible boolean result needs two more pieces, both substantial:
1. **Saddle-band tessellation** — the rod's wall inside the fat cylinder is a *periodic band with non-circular (saddle) rims*; `periodicBandGrid` only meshes circular rims, so this needs a loft mesh like the torus rim-fillet (`closedBandLoftMesh`). Per the repo's tessellation-first rule, this is the right next step.
2. **Split + classify + stitch** along the traced loops (point-in-cylinder is analytic, no H3 needed for cylinders).

No `/api` change (kernel-internal).

## Tests

- A thin cylinder through a fat one: two closed loops, every vertex on **both** cylinder surfaces (< 1e-5).
- A block/cylinder pair and disjoint cylinders both defer (ok=false).

🤖 Generated with [Claude Code](https://claude.com/claude-code)