### PR TITLE
Saddle-band loft tessellation for crossing cylinders (M2 Phase 2, #1335)

### DIFF
--- a/kernel/ops/saddle_band_loft.go
+++ b/kernel/ops/saddle_band_loft.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Saddle-band loft (M2 Phase 2, Oblikovati/Oblikovati#1335). A cylinder's wall inside a crossing
+// cylinder is a full-period band whose two rims are NOT circles but the traced saddle curves where the
+// surfaces meet — so each rim's axial parameter v varies with the angle u. periodicBandGrid meshes only
+// bands with two constant-v (circular) rims, and closedDomainMesh grids a single v-resolution; neither
+// fits a saddle rim. But a cylinder and a cone are RULED along v (the straight line between the two rims
+// at a fixed angle lies exactly on the surface), so the band needs no interior rows at all: stitching the
+// two rim rows — each the exact tessellation of its own saddle edge, so the band welds to the caps that
+// share those edges — is itself an exact loft of the band.
+
+// saddleBandLoftMesh meshes a singly-periodic ruled band (a trimmed cylinder/cone side) bounded by two
+// full-wrap rim loops, stitching the rims directly. ok=false unless the surface is singly periodic (a
+// cylinder/cone, not a torus/plane) and the face has exactly two closed rim edges.
+func saddleBandLoftMesh(f *topo.Face, s geom.Surface, q Quality) (*Mesh, bool) {
+	if isPeriodic(s.UDomain()) == isPeriodic(s.VDomain()) {
+		return nil, false // need exactly one periodic direction (a cylinder/cone side, not a torus/plane)
+	}
+	rings := bandWrapRings(f, q)
+	if len(rings) != 2 {
+		return nil, false
+	}
+	lo, hi := orderedRing(s, rings[0]), orderedRing(s, rings[1])
+	if len(lo) < 3 || len(hi) < 3 {
+		return nil, false
+	}
+	m := &Mesh{}
+	stitchBandRows(m, addRow(m, s, lo, ringAngles(s, lo)), addRow(m, s, hi, ringAngles(s, hi)))
+	return m, true
+}
+
+// bandWrapRings reads the band's rim rings by topology rather than curve type (the rims are saddle
+// polylines, not circles): every closed boundary edge (its start and end vertex coincide) is a rim.
+func bandWrapRings(f *topo.Face, q Quality) [][]math.Point3 {
+	var rings [][]math.Point3
+	for _, e := range f.Edges() {
+		if e.StartVertex() == e.EndVertex() {
+			rings = append(rings, dropClosingDup(TessellateEdge(e, q)))
+		}
+	}
+	return rings
+}

--- a/kernel/ops/saddle_band_loft_test.go
+++ b/kernel/ops/saddle_band_loft_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Saddle-band loft tessellation (M2 Phase 2, Oblikovati/Oblikovati#1335). A cylinder's wall inside a
+// crossing cylinder is a full-period band with non-circular (saddle) rims. These tests build that band as
+// a real face and check the lofted mesh against the analytic lateral area — the rod-of-radius-r wall
+// inside the fat-cylinder-of-radius-R, whose width at angle α is 2√(R²−r²cos²α).
+
+const bandR, bandr = 3.0, 1.5
+
+// analyticBandArea numerically integrates the rod-wall lateral area ∫ r·2√(R²−r²cos²α) dα over [0,2π].
+func analyticBandArea(rRod, rFat float64) float64 {
+	const n = 20000
+	sum := 0.0
+	for i := 0; i < n; i++ {
+		a := 2 * stdmath.Pi * (float64(i) + 0.5) / n
+		sum += rRod * 2 * stdmath.Sqrt(rFat*rFat-rRod*rRod*stdmath.Cos(a)*stdmath.Cos(a))
+	}
+	return sum * 2 * stdmath.Pi / n
+}
+
+// rodInsideFatBand builds the periodic cylinder-side face of a rod (radius r, axis x) trimmed to the band
+// inside a fat cylinder (radius R, axis z): its two rims are the saddle curves x = ±√(R²−r²cos²α).
+func rodInsideFatBand(t *testing.T, samples int) *topo.Face {
+	t.Helper()
+	rod, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(1, 0, 0), bandr)
+	loPts, hiPts := saddleRimPoints(samples)
+	loPoly, _ := geom.NewPolyline(loPts)
+	hiPoly, _ := geom.NewPolyline(hiPts)
+	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok("band", "body", 0)))
+	vLo := bld.AddVertex(loPts[0], topo.NewLineage(topo.Tok("band", "vlo", 0)))
+	vHi := bld.AddVertex(hiPts[0], topo.NewLineage(topo.Tok("band", "vhi", 0)))
+	eLo := bld.AddEdge(loPoly, vLo, vLo, topo.NewLineage(topo.Tok("band", "elo", 0)))
+	eHi := bld.AddEdge(hiPoly, vHi, vHi, topo.NewLineage(topo.Tok("band", "ehi", 0)))
+	eSeam := bld.AddEdge(geom.NewLineSegment(loPts[0], hiPts[0]), vLo, vHi, topo.NewLineage(topo.Tok("band", "seam", 0)))
+	bld.AddFace(rod, topo.NewLineage(topo.Tok("band", "face", 0)),
+		topo.OuterLoop(topo.Fwd(eSeam), topo.Rev(eHi), topo.Rev(eSeam), topo.Fwd(eLo)))
+	return bld.Build().Faces()[0]
+}
+
+// saddleRimPoints returns the lo (x<0) and hi (x>0) rim polylines, closed (last point repeats the first).
+func saddleRimPoints(samples int) (lo, hi []math.Point3) {
+	for i := 0; i <= samples; i++ {
+		a := 2 * stdmath.Pi * float64(i%samples) / float64(samples)
+		x := stdmath.Sqrt(bandR*bandR - bandr*bandr*stdmath.Cos(a)*stdmath.Cos(a))
+		y, z := bandr*stdmath.Cos(a), bandr*stdmath.Sin(a)
+		lo = append(lo, math.P3(math.Scalar(-x), math.Scalar(y), math.Scalar(z)))
+		hi = append(hi, math.P3(math.Scalar(x), math.Scalar(y), math.Scalar(z)))
+	}
+	return lo, hi
+}
+
+// TestSaddleBandLoftAreaMatchesAnalytic builds the rod-inside-fat band face and checks the lofted mesh's
+// area against the analytic lateral area — confirming the loft follows the saddle rims, not a flat or
+// full-domain fallback.
+func TestSaddleBandLoftAreaMatchesAnalytic(t *testing.T) {
+	face := rodInsideFatBand(t, 64)
+	mesh := tessellateCurvedFace(face, DefaultQuality())
+	if mesh == nil || len(mesh.Indices) == 0 {
+		t.Fatal("saddle band produced no mesh")
+	}
+	got := meshArea(mesh)
+	want := analyticBandArea(bandr, bandR)
+	if rel := stdmath.Abs(got-want) / want; rel > 0.02 {
+		t.Errorf("saddle band area %.4f, want %.4f (analytic) — rel %.4f > 2%%", got, want, rel)
+	}
+}
+
+// TestSaddleBandLoftMeshIsRouted confirms the dispatch reaches saddleBandLoftMesh for this band (a
+// non-circular-rim periodic face) rather than a fallback: the helper returns ok.
+func TestSaddleBandLoftMeshIsRouted(t *testing.T) {
+	face := rodInsideFatBand(t, 48)
+	if _, ok := saddleBandLoftMesh(face, face.Geometry(), DefaultQuality()); !ok {
+		t.Error("saddleBandLoftMesh declined the rod-inside-fat band; the dispatch would fall back")
+	}
+}
+
+// TestSaddleBandLoftDeclinesNonBand: a planar face is not a singly-periodic ruled band, so the loft must
+// decline (ok=false) and leave the dispatch to its other meshers.
+func TestSaddleBandLoftDeclinesNonBand(t *testing.T) {
+	block, _ := brep.SolidBlock(math.P3(0, 0, 0), math.P3(1, 1, 1), "b")
+	face := block.Faces()[0] // a planar face: both parameter directions are non-periodic
+	if _, ok := saddleBandLoftMesh(face, face.Geometry(), DefaultQuality()); ok {
+		t.Error("a planar face is not a periodic band; saddleBandLoftMesh should decline")
+	}
+}

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -62,7 +62,10 @@ func tessellateCurvedFace(f *topo.Face, q Quality) *Mesh {
 // (the full-domain grid tears there); a doubly-periodic torus we can't reduce keeps the full-domain grid.
 func meshSeamCrossingFace(f *topo.Face, s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, q Quality) *Mesh {
 	if us, vs, isBand := periodicBandGrid(s, outer3D, holes3D); isBand {
-		return closedDomainMesh(s, us, vs) // full cylinder/cone side: wraps the seam watertight
+		return closedDomainMesh(s, us, vs) // full cylinder/cone side with circular rims: grid the period
+	}
+	if m, ok := saddleBandLoftMesh(f, s, q); ok {
+		return m // a cylinder/cone band with non-circular (saddle) rims — a crossing cylinder: loft v(u)
 	}
 	if _, _, isBand := doublyPeriodicBandGrid(s, outer3D, holes3D); isBand {
 		if m, ok := closedBandLoftMesh(f, s, q); ok {


### PR DESCRIPTION
## What

Tessellates a curved band whose two rims are **non-circular saddle curves** — the cylinder-wall band that appears inside a crossing cylinder. This is the tessellation prerequisite for any visible crossing-cylinder boolean result (Phase 2, #1335).

## Why

A cylinder's wall inside another cylinder is a full-period band, but its rims are the traced saddle curves (each rim's axial parameter `v` varies with the angle `u`), not circles. The existing band meshers can't handle that:
- `periodicBandGrid` requires two **constant-v (circular)** rims (exactly two distinct values in the non-periodic direction);
- `closedDomainMesh` grids the wrap at one `v`-resolution.

So a saddle band fell through to the best-fit-plane CDT, which **tears** a face that wraps the seam. Per the repo's tessellation-first rule, this had to be fixed before building the boolean result on top of it.

## How

Key insight: a cylinder and a cone are **ruled along `v`** — the straight line between the two rims at a fixed angle lies exactly on the surface. So the band needs **no interior rows at all**: stitching the two rim rows directly is already an exact loft. Each rim row is the exact tessellation of its own saddle edge (`TessellateEdge`), so the band welds to the caps that share those edges.

Wired into `meshSeamCrossingFace` right after `periodicBandGrid`, gated to a singly-periodic surface (cylinder/cone, not torus/plane) with exactly two closed rim edges — so circular-rim cylinder/cone sides keep their existing grid mesh and there's no regression (full kernel suite green).

No `/api` change.

## Tests

- Builds the rod-inside-fat-cylinder band as a real face (rims `x = ±√(R²−r²cos²α)`) and checks the lofted mesh area against the **analytic lateral area** `∫ r·2√(R²−r²cos²α) dα` — confirming the loft follows the saddle rims, not a flat or full-domain fallback.
- Confirms the dispatch routes a non-circular-rim band to the loft, and that a planar face declines it.

## Next slice

With the imprint (#1348) and now the saddle-band mesh in place, the remaining Phase 2 slice is the **split + classify + stitch** that assembles the rod-with-saddle-caps result (point-in-cylinder is analytic, no H3 needed) and a volume oracle through `ops.Boolean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)