### PR TITLE
feat(brep): crossing-cylinder intersection — split/classify/stitch (M2 Phase 2)

### DIFF
--- a/kernel/brep/curved_crossing_intersect.go
+++ b/kernel/brep/curved_crossing_intersect.go
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Crossing-cylinder intersection (M2 Phase 2, Oblikovati/Oblikovati#1335). The split/classify/stitch
+// stage following the imprint: it assembles the exact A∩B of two crossing cylinders — a rod through a
+// fatter cylinder — straight from the traced imprint loops, with no general face splitting. The
+// intersection's boundary is just three analytic faces: the rod's wall BAND inside the fat cylinder
+// (between the two loops) plus the two LENS caps of the fat wall the rod pokes through (one per loop).
+// Classification is analytic — the rod is the cylinder both loops fully encircle — so no tessellation
+// winding number (the H3 oracle) is needed. Scope: the clean thin-through-fat case the imprint traces as
+// two clean loops; equal-radius (Steinmetz) and partial penetrations defer to the caller's fallback.
+
+// crossLin tags the assembled body's topology (one entity per role, so the index is always 0).
+func crossLin(role string) topo.Lineage { return topo.NewLineage(topo.Tok("crosscyl", role, 0)) }
+
+// CrossingCylinderIntersect builds the exact intersection of two bare crossing cylinders as a watertight
+// analytic B-rep (rod band + two fat-wall lens caps), or ok=false when the configuration is outside the
+// wired thin-through-fat case (not exactly two imprint loops, or neither cylinder is the rod both loops
+// encircle) so kernel/ops keeps its fallback.
+//
+// Example — a radius-1.5 rod on x crossing a radius-3 cylinder on z gives a three-face solid:
+//
+//	fat, _  := brep.SolidCylinder(math.P3(0,0,-6), math.V3(0,0,1), 3, 12)
+//	thin, _ := brep.SolidCylinder(math.P3(-6,0,0), math.V3(1,0,0), 1.5, 12)
+//	res, ok := brep.CrossingCylinderIntersect(fat, thin) // rod band capped by two lenses
+func CrossingCylinderIntersect(a, b *topo.Body) (*topo.Body, bool) {
+	loops, ok := crossingCylinderImprint(a, b)
+	if !ok || len(loops) != 2 {
+		return nil, false
+	}
+	rod, fat, ok := rodAndFatCylinders(a, b, loops)
+	if !ok {
+		return nil, false
+	}
+	lo, hi, ok := assignRimLoops(rod, fat, loops)
+	if !ok {
+		return nil, false
+	}
+	return stitchRodWithSaddleCaps(rod, fat, lo, hi), true
+}
+
+// rodAndFatCylinders picks which cylinder is the rod (the band-bearing one both imprint loops fully
+// encircle) and which is the fat cylinder (the lens-capped one). ok=false when neither or both qualify.
+func rodAndFatCylinders(a, b *topo.Body, loops []geom.Polyline) (rod, fat geom.Cylinder, ok bool) {
+	ca, _, _, okA := cylinderSolidParams(facesOfAny(a))
+	cb, _, _, okB := cylinderSolidParams(facesOfAny(b))
+	if !okA || !okB {
+		return geom.Cylinder{}, geom.Cylinder{}, false
+	}
+	aWraps, bWraps := allLoopsEncircle(loops, ca), allLoopsEncircle(loops, cb)
+	if aWraps && !bWraps {
+		return ca, cb, true
+	}
+	if bWraps && !aWraps {
+		return cb, ca, true
+	}
+	return geom.Cylinder{}, geom.Cylinder{}, false
+}
+
+// allLoopsEncircle reports whether every loop winds a full turn about the cylinder's axis — the test that
+// distinguishes the rod (each loop rings right around it, ≈ ±2π) from the fat cylinder (each loop is a
+// local lens off to one side that barely turns, ≈ 0).
+func allLoopsEncircle(loops []geom.Polyline, cyl geom.Cylinder) bool {
+	for _, lp := range loops {
+		if stdmath.Abs(loopTurnAboutAxis(lp, cyl)) < stdmath.Pi {
+			return false
+		}
+	}
+	return true
+}
+
+// loopTurnAboutAxis sums the signed angle a loop's spokes sweep about the cylinder axis (≈ ±2π for a loop
+// encircling the axis, ≈ 0 for a local lens).
+func loopTurnAboutAxis(lp geom.Polyline, cyl geom.Cylinder) float64 {
+	axis := cyl.AxisDir.AsVector()
+	vs := lp.Vertices
+	total := 0.0
+	for i := 0; i+1 < len(vs); i++ {
+		total += signedAngleAround(radialOf(vs[i], cyl), radialOf(vs[i+1], cyl), axis)
+	}
+	return total
+}
+
+// radialOf returns the spoke from the cylinder axis out to p — the component of (axis origin → p)
+// perpendicular to the axis, whose turning measures the angle about the axis.
+func radialOf(p math.Point3, cyl geom.Cylinder) math.Vector3 {
+	axis := cyl.AxisDir.AsVector()
+	v := cyl.Origin.VectorTo(p)
+	return v.Sub(axis.Scale(v.Dot(axis)))
+}
+
+// assignRimLoops orients both imprint loops CCW about the rod axis and assigns them to the lower (lo) and
+// upper (hi) rim of the band by which way the fat wall faces there: the loop whose fat-outward normal
+// points along +rodaxis is the upper rim (the band traverses it reversed, its cap forward), the other the
+// lower. The hi loop is rotated to start at the lo loop's seam angle so their joining seam is a clean
+// constant-angle ruling of the rod. ok=false unless there is exactly one loop of each end.
+func assignRimLoops(rod, fat geom.Cylinder, loops []geom.Polyline) (lo, hi geom.Polyline, ok bool) {
+	rodAxis := rod.AxisDir.AsVector()
+	var los, his []geom.Polyline
+	for _, lp := range loops {
+		ccw := orientLoopCCW(lp, rod)
+		if fatOutwardAlongAxis(ccw, fat, rodAxis) >= 0 {
+			his = append(his, ccw)
+		} else {
+			los = append(los, ccw)
+		}
+	}
+	if len(los) != 1 || len(his) != 1 {
+		return geom.Polyline{}, geom.Polyline{}, false
+	}
+	return los[0], alignLoopStart(his[0], los[0], rod), true
+}
+
+// orientLoopCCW returns the loop oriented so it winds CCW about the rod axis (positive turn), reversing
+// its vertex order when the traced loop runs the other way.
+func orientLoopCCW(lp geom.Polyline, rod geom.Cylinder) geom.Polyline {
+	if loopTurnAboutAxis(lp, rod) >= 0 {
+		return lp
+	}
+	return reverseLoop(lp)
+}
+
+// reverseLoop returns the loop with its vertex order reversed (still closed: the first vertex still
+// repeats as the last).
+func reverseLoop(lp geom.Polyline) geom.Polyline {
+	vs := lp.Vertices
+	out := make([]math.Point3, len(vs))
+	for i, p := range vs {
+		out[len(vs)-1-i] = p
+	}
+	rev, _ := geom.NewPolyline(out)
+	return rev
+}
+
+// fatOutwardAlongAxis returns the component along the rod axis of the fat cylinder's outward normal at the
+// loop's centroid — its sign places the loop's lens on the +rodaxis (≥0) or −rodaxis (<0) end of the band.
+func fatOutwardAlongAxis(lp geom.Polyline, fat geom.Cylinder, rodAxis math.Vector3) float64 {
+	outward := unit(radialOf(loopCentroid(lp), fat))
+	return float64(outward.Dot(rodAxis))
+}
+
+// loopCentroid averages a loop's distinct vertices (skipping the repeated closing vertex).
+func loopCentroid(lp geom.Polyline) math.Point3 {
+	core := lp.Vertices[:len(lp.Vertices)-1]
+	var sx, sy, sz math.Scalar
+	for _, p := range core {
+		sx, sy, sz = sx+p.X, sy+p.Y, sz+p.Z
+	}
+	n := math.Scalar(len(core))
+	return math.P3(sx/n, sy/n, sz/n)
+}
+
+// alignLoopStart rotates the hi loop so it begins at the vertex nearest, in rod-axis angle, to the lo
+// loop's start — so the seam joining the two starts is a near-constant-angle ruling of the rod (lying on
+// the surface), the clean seam the band's periodic face needs.
+func alignLoopStart(hi, lo geom.Polyline, rod geom.Cylinder) geom.Polyline {
+	target := axisAngleOf(lo.Vertices[0], rod)
+	core := hi.Vertices[:len(hi.Vertices)-1]
+	best, bestErr := 0, stdmath.Inf(1)
+	for i, p := range core {
+		if d := angleDelta(axisAngleOf(p, rod), target); d < bestErr {
+			best, bestErr = i, d
+		}
+	}
+	return rotateClosedLoop(core, best)
+}
+
+// axisAngleOf returns p's angle about the cylinder axis, measured from the cylinder's reference direction.
+func axisAngleOf(p math.Point3, cyl geom.Cylinder) float64 {
+	return signedAngleAround(cyl.Ref.AsVector(), radialOf(p, cyl), cyl.AxisDir.AsVector())
+}
+
+// angleDelta is the absolute difference between two angles, wrapped into [0, π].
+func angleDelta(a, b float64) float64 {
+	d := stdmath.Abs(a - b)
+	if d > stdmath.Pi {
+		d = 2*stdmath.Pi - d
+	}
+	return d
+}
+
+// rotateClosedLoop returns a closed polyline starting at index start of the distinct (de-duplicated)
+// vertices, wrapping around and repeating the new start vertex at the end to keep the loop closed.
+func rotateClosedLoop(core []math.Point3, start int) geom.Polyline {
+	out := make([]math.Point3, 0, len(core)+1)
+	for i := 0; i < len(core); i++ {
+		out = append(out, core[(start+i)%len(core)])
+	}
+	out = append(out, core[start]) // repeat the start vertex so the loop closes
+	rot, _ := geom.NewPolyline(out)
+	return rot
+}
+
+// stitchRodWithSaddleCaps welds the three analytic faces of the intersection into one solid: the rod-wall
+// band (a periodic cylinder side — seam up, hi rim, seam down, lo rim, the SolidCylinder pattern) plus the
+// two fat-wall lens caps, each sharing one rim edge with the band in the OPPOSITE orientation, so every
+// edge is used exactly twice (a closed manifold). The rims stay closed saddle-polyline edges so the band
+// tessellates via the saddle-band loft and each lens via the metric-patch mesher.
+func stitchRodWithSaddleCaps(rod, fat geom.Cylinder, lo, hi geom.Polyline) *topo.Body {
+	loPts, hiPts := lo.Vertices, hi.Vertices
+	bld := topo.NewBuilder(true, crossLin("body"))
+	vLo := bld.AddVertex(loPts[0], crossLin("vlo"))
+	vHi := bld.AddVertex(hiPts[0], crossLin("vhi"))
+	eLo := bld.AddEdge(lo, vLo, vLo, crossLin("elo"))
+	eHi := bld.AddEdge(hi, vHi, vHi, crossLin("ehi"))
+	eSeam := bld.AddEdge(geom.NewLineSegment(loPts[0], hiPts[0]), vLo, vHi, crossLin("seam"))
+	bld.AddFace(rod, crossLin("band"),
+		topo.OuterLoop(topo.Fwd(eSeam), topo.Rev(eHi), topo.Rev(eSeam), topo.Fwd(eLo)))
+	bld.AddFace(fat, crossLin("caplo"), topo.OuterLoop(topo.Rev(eLo)))
+	bld.AddFace(fat, crossLin("caphi"), topo.OuterLoop(topo.Fwd(eHi)))
+	return bld.Build()
+}

--- a/kernel/brep/curved_crossing_intersect_test.go
+++ b/kernel/brep/curved_crossing_intersect_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Crossing-cylinder intersection assembly (M2 Phase 2, Oblikovati/Oblikovati#1335). The split/classify/
+// stitch slice must weld the traced imprint loops into a watertight analytic solid: the rod's wall band
+// inside the fat cylinder plus the two fat-wall lens caps, three analytic faces, every edge shared by
+// exactly two faces. Volume is checked through ops_test (brep cannot import ops); here the concern is the
+// watertight topology and that the cylinder surfaces are preserved (no triangle soup).
+
+// assertCrossingManifold checks the assembled body is a solid of the expected analytic faces with every
+// edge used exactly twice — the closed-manifold invariant the stitch must keep.
+func assertCrossingManifold(t *testing.T, body *topo.Body, wantFaces int) {
+	t.Helper()
+	if body == nil || !body.IsSolid() {
+		t.Fatalf("crossing intersection is not a solid: %+v", body)
+	}
+	if n := len(body.Faces()); n != wantFaces {
+		t.Errorf("result has %d faces, want %d (rod band + two lens caps)", n, wantFaces)
+	}
+	for _, e := range body.Edges() {
+		if uses := len(e.Uses()); uses != 2 {
+			t.Errorf("edge %v has %d uses, want 2 (a closed manifold)", e.Lineage(), uses)
+		}
+	}
+	for _, f := range body.Faces() {
+		if _, ok := f.Geometry().(geom.Cylinder); !ok {
+			t.Errorf("face surface %T is not a cylinder (the exact surfaces must be preserved)", f.Geometry())
+		}
+	}
+}
+
+// TestCrossingCylinderIntersectThinThroughFat assembles a radius-1.5 rod (axis x) crossing a radius-3
+// cylinder (axis z) through its centre into the watertight three-face intersection solid.
+func TestCrossingCylinderIntersectThinThroughFat(t *testing.T) {
+	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	thin, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
+
+	res, ok := CrossingCylinderIntersect(fat, thin)
+	if !ok {
+		t.Fatal("thin-through-fat intersection declined; want a three-face solid")
+	}
+	assertCrossingManifold(t, res, 3)
+}
+
+// TestCrossingCylinderIntersectOrderIndependent: A ∩ B = B ∩ A — the rod is detected from the imprint, not
+// the argument order, so passing the rod first gives the same watertight solid.
+func TestCrossingCylinderIntersectOrderIndependent(t *testing.T) {
+	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	thin, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
+
+	res, ok := CrossingCylinderIntersect(thin, fat) // rod first
+	if !ok {
+		t.Fatal("rod-first intersection declined; the assembly must be order-independent")
+	}
+	assertCrossingManifold(t, res, 3)
+}
+
+// TestCrossingCylinderIntersectNonCylinderDefers: the assembly only handles two bare cylinders.
+func TestCrossingCylinderIntersectNonCylinderDefers(t *testing.T) {
+	block, _ := SolidBlock(math.P3(-2, -2, -2), math.P3(2, 2, 2), "b")
+	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 1, 12)
+	if _, ok := CrossingCylinderIntersect(block, cyl); ok {
+		t.Error("intersection of a block and a cylinder should defer (ok=false)")
+	}
+}

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -92,6 +92,11 @@ func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.L
 	if body, ok := curvedConvexSubtract(op, target, tool); ok {
 		return body, nil
 	}
+	// And two crossing cylinders (a rod through a fatter cylinder): assemble the rod band + the two
+	// fat-wall lens caps straight from the traced imprint loops, exact surfaces preserved (M2 #1335).
+	if body, ok := curvedCrossingIntersect(op, target, tool); ok {
+		return body, nil
+	}
 	bop, ok := toBrepOp(op)
 	if !ok {
 		return booleanCSG(op, target, tool, lin)

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/topo"
+)
+
+// Exact crossing-cylinder intersection (M2 Phase 2, Oblikovati/Oblikovati#1335). Wires
+// brep.CrossingCylinderIntersect into the boolean: a rod ∩ a fatter cylinder builds straight from the
+// traced imprint loops into a watertight analytic solid (rod band + two fat-wall lens caps), keeping the
+// exact cylinder surfaces instead of triangle-soup CSG. Anything outside the thin-through-fat case (a
+// non-cylinder operand, equal radii, a partial penetration) returns ok=false so booleanGeneral keeps its
+// CSG fallback — no regression.
+
+// curvedCrossingIntersect returns the exact intersection of two crossing cylinders, or ok=false to defer.
+// Only Intersect maps here, and only a valid closed manifold result is adopted (an inside-out or open
+// assembly is rejected so the fallback runs instead).
+func curvedCrossingIntersect(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+	if op != Intersect {
+		return nil, false
+	}
+	res, ok := brep.CrossingCylinderIntersect(target, tool)
+	if !ok || !validBooleanSolid(res) {
+		return nil, false
+	}
+	return res, true
+}

--- a/kernel/ops/boolean_crossing_cylinder_test.go
+++ b/kernel/ops/boolean_crossing_cylinder_test.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+)
+
+// Crossing-cylinder intersection through Boolean (M2 Phase 2, Oblikovati/Oblikovati#1335). A rod ∩ a
+// fatter cylinder must Intersect to the exact analytic solid (rod band + two fat-wall lens caps), its
+// volume matching the analytic intersection of two perpendicular cylinders, not triangle-soup CSG.
+
+// crossingIntersectVolume is the exact volume of {y²+z² ≤ rRod²} ∩ {x²+y² ≤ rFat²} — a rod of radius rRod
+// (axis x) crossing a cylinder of radius rFat (axis z) through the centre. Integrating x out first leaves
+// ∫₀^{2π}∫₀^{rRod} 2√(rFat²−ρ²cos²φ)·ρ dρ dφ; the inner ρ-integral has the closed form below (its φ→π/2
+// limit, where cos²φ→0, is rFat·rRod²).
+func crossingIntersectVolume(rRod, rFat float64) float64 {
+	const n = 20000
+	sum := 0.0
+	for i := 0; i < n; i++ {
+		phi := 2 * stdmath.Pi * (float64(i) + 0.5) / n
+		c := stdmath.Cos(phi) * stdmath.Cos(phi)
+		if c < 1e-9 {
+			sum += rFat * rRod * rRod
+			continue
+		}
+		sum += (2.0 / (3 * c)) * (rFat*rFat*rFat - stdmath.Pow(rFat*rFat-rRod*rRod*c, 1.5))
+	}
+	return sum * 2 * stdmath.Pi / n
+}
+
+// TestBooleanIntersectCrossingCylinders intersects a rod (r=1.5, axis x) with a fat cylinder (R=3, axis z)
+// and checks the result is the exact three-face analytic solid with the analytic intersection volume.
+func TestBooleanIntersectCrossingCylinders(t *testing.T) {
+	const rRod, rFat = 1.5, 3.0
+	fat, _ := brep.SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), rFat, 12)
+	thin, _ := brep.SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), rRod, 12)
+
+	res, err := ops.Boolean(ops.Intersect, fat, thin)
+	if err != nil {
+		t.Fatalf("Boolean(Intersect): %v", err)
+	}
+	if v := ops.Validate(res); !v.Valid || !v.Closed || !v.Manifold || !res.IsSolid() {
+		t.Fatalf("crossing-cylinder intersection is not a valid closed manifold solid: %+v", v)
+	}
+	for _, f := range res.Faces() {
+		if _, ok := f.Geometry().(geom.Cylinder); !ok {
+			t.Errorf("face surface %T is not analytic (the exact path must run, not CSG)", f.Geometry())
+		}
+	}
+	if n := len(res.Faces()); n != 3 {
+		t.Errorf("result has %d faces, want 3 (rod band + two lens caps)", n)
+	}
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	want := crossingIntersectVolume(rRod, rFat)
+	if rel := stdmath.Abs(got-want) / want; rel > 0.02 {
+		t.Errorf("intersection volume %.4f, want %.4f (analytic) — rel %.4f > 2%%", got, want, rel)
+	}
+}
+
+// TestBooleanIntersectEqualRadiusDefersFromExactPath: two EQUAL-radius perpendicular cylinders are the
+// Steinmetz case the imprint tracer cannot trace cleanly, so the exact path must decline (leaving the
+// boolean to its fallback) rather than emit a wrong analytic solid.
+func TestBooleanIntersectEqualRadiusDefersFromExactPath(t *testing.T) {
+	a, _ := brep.SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	b, _ := brep.SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 3, 12) // equal radius
+
+	if _, ok := brep.CrossingCylinderIntersect(a, b); ok {
+		t.Error("equal-radius (Steinmetz) crossing should defer from the exact path (ok=false)")
+	}
+}


### PR DESCRIPTION
## What

Slice 3 of the curved∩curved boolean (#1335): **split + classify + stitch**. With the imprint loops traced (#1348) and the saddle band lofting (#1349) already in, this welds the **exact A∩B of two crossing cylinders** — a rod through a fatter cylinder — straight from those loops, with no general face splitting.

`ops.Boolean(ops.Intersect, fat, rod)` now returns the exact three-face analytic solid instead of triangle-soup CSG.

## Why

A rod through a fatter cylinder meets the intersection boundary in just **three analytic faces**:

- the rod's wall **BAND** inside the fat cylinder (between the two imprint loops), and
- the two fat-wall **LENS caps** the rod pokes through (one per loop).

Classification is **analytic** — the rod is the cylinder both loops fully encircle (≈ ±2π of turn about its axis) while the fat cylinder each loop only laps locally (≈ 0) — so **no tessellation winding number (the H3 oracle) is needed**.

## How

- `brep.CrossingCylinderIntersect(a, b)` traces the imprint (#1348), picks rod vs fat by the encircle test, orients both loops CCW about the rod axis, assigns each to the band's lower/upper rim by which way the fat wall faces there, and stitches.
- The band is the **proven periodic cylinder-side topology** (seam + two closed saddle-polyline rims); each rim is shared with one lens cap in the **opposite** orientation, so every edge is used exactly twice → a closed manifold. The rims stay closed saddle edges so the band tessellates via the saddle-band loft (#1349) and each lens via the metric-patch mesher.
- Wired into `booleanGeneral` after the existing curved paths, gated to `Intersect` and validated (`validBooleanSolid`) before adoption — anything outside scope returns `ok=false` and the CSG fallback runs.

## Scope / deferred

Equal-radius (Steinmetz) and partial penetrations stay outside scope and **defer to the CSG fallback — no regression** (the exact path declines them).

## Tests

- `kernel/brep`: watertight topology (3 cylinder faces, every edge used twice), order-independence (A∩B = B∩A), non-cylinder defer.
- `kernel/ops`: full `Boolean(Intersect)` produces the three-face analytic solid with volume within 2% (chord deficit) of the analytic two-cylinder intersection `∫₀^{2π}∫₀^r 2√(R²−ρ²cos²φ)·ρ dρ dφ`; equal-radius defers from the exact path.

Full kernel suite green; lint 0 issues; new code ~93% covered (brep 90.1%, ops 89.4% package totals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)