### PR TITLE
feat(ops): tessellate a drilled cylinder wall — full-period side with holes (M2 Phase 2)

### DIFF
--- a/kernel/ops/holed_cylinder_wall.go
+++ b/kernel/ops/holed_cylinder_wall.go
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Holed cylinder-wall tessellation (M2 Phase 2, Oblikovati/Oblikovati#1335). A cylinder drilled through —
+// a fat cylinder Cut/Join with a crossing rod — leaves the fat SIDE wall as a full-period cylinder face
+// carrying one or more lens HOLES where the rod broke through. periodicBandGrid and metricPatchMesh both
+// reject a holed periodic face (toUVLoops can't unwrap the seam-wrapping outer loop), so it fell to the
+// full-domain grid, which ignores the holes entirely. But a cylinder is DEVELOPABLE — its first
+// fundamental form ds² = R²du² + dv² is flat — so its wall unrolls to a plane without distortion: unwrap
+// the wrapping outer loop's angle cumulatively into a contiguous (u,v) rectangle and hand it, holes and
+// all, straight to metricPatchMesh, whose metric-scaled CDT meshes the rectangle-minus-holes with interior
+// refinement. The seam (the rectangle's two vertical edges, 2π apart in u) maps to one line in 3D, so the
+// triangles on either side meet there with no gap.
+
+// holedCylinderWallMesh meshes a full-period cylinder side carrying holes by unrolling it to a contiguous
+// (u,v) rectangle and delegating to metricPatchMesh. ok=false unless the surface is a cylinder with at
+// least one hole and a genuinely seam-wrapping outer loop (a hole straddling the seam also defers — the
+// builder seams the wall clear of its holes, so that should not arise).
+func holedCylinderWallMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3) (*Mesh, bool) {
+	if _, ok := s.(geom.Cylinder); !ok {
+		return nil, false // only a cylinder unrolls with a flat (distortion-free) metric
+	}
+	if len(holes3D) == 0 || isPeriodic(s.UDomain()) == isPeriodic(s.VDomain()) {
+		return nil, false // need a holed, singly-periodic side
+	}
+	outerUV, umin, umax, ok := wrappedWallUV(s, outer3D)
+	if !ok {
+		return nil, false
+	}
+	holesUV, ok := holesIntoBranch(s, holes3D, umin, umax)
+	if !ok {
+		return nil, false
+	}
+	return unrolledWallCDT(s, outer3D, holes3D, outerUV, holesUV), true
+}
+
+// unrolledWallCDT triangulates the unrolled wall (the contiguous (u,v) rectangle minus the holes) with a
+// BOUNDARY-ONLY constrained Delaunay in metric-scaled (u,v) — (√E,√G)≈(R,1) for a cylinder, so the
+// parameter space is isometric to 3D and the triangles are well shaped. No interior Steiner points: the
+// wall's curvature is entirely in u, already captured by the dense cap-circle samples on the rim edges,
+// and a large wall's interior nodes only make the hole's constraint recovery (insertConstraint) fail and
+// the domain flood leak. The exact 3D boundary points are kept so the wall welds to its caps, the rod
+// band and the lens caps that share its edges.
+func unrolledWallCDT(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, outerUV []math.Point2, holesUV [][]math.Point2) *Mesh {
+	su, sv := trimMetricScale(s, outerUV)
+	outer2D := scaleUVLoop(outerUV, su, sv)
+	holes2D := make([][]math.Point2, len(holesUV))
+	for i, h := range holesUV {
+		holes2D[i] = scaleUVLoop(h, su, sv)
+	}
+	uv, pos, nrm, loops := patchLoops2D(s, outer3D, holes3D, outer2D, holes2D)
+	tris := constrainedDelaunay(uv, loops)
+	if len(tris) == 0 {
+		return boundaryPatchMesh(s, outer3D, holes3D)
+	}
+	m := patchMeshFrom(pos, nrm, tris)
+	repairFolds(m, 8)
+	return m
+}
+
+// scaleUVLoop scales a (u,v) loop by the per-axis metric (su, sv) so the CDT runs in a space isometric to
+// 3D.
+func scaleUVLoop(loop []math.Point2, su, sv float64) []math.Point2 {
+	out := make([]math.Point2, len(loop))
+	for i, p := range loop {
+		out[i] = math.P2(p.X*math.Scalar(su), p.Y*math.Scalar(sv))
+	}
+	return out
+}
+
+// wrappedWallUV unwraps the wall's seam-wrapping outer loop angle (u) into contiguous values, returning
+// the (u,v) loop and its u-range. ok=false unless the loop spans essentially the full period (otherwise
+// it is an ordinary contractible patch toUVLoops already handles, not a wrapping wall).
+func wrappedWallUV(s geom.Surface, outer3D []math.Point3) (uv []math.Point2, umin, umax float64, ok bool) {
+	us := make([]float64, len(outer3D))
+	vs := make([]float64, len(outer3D))
+	for i, p := range outer3D {
+		us[i], vs[i] = s.ParamAt(p)
+	}
+	cu := cumulativeUnwrap(us)
+	umin, umax = minMax(cu)
+	if umax-umin < 2*stdmath.Pi-0.5 {
+		return nil, 0, 0, false // not a full wrap
+	}
+	uv = make([]math.Point2, len(outer3D))
+	for i := range outer3D {
+		uv[i] = math.P2(math.Scalar(cu[i]), math.Scalar(vs[i]))
+	}
+	return uv, umin, umax, true
+}
+
+// holesIntoBranch maps each hole loop to (u,v) and shifts it by whole periods into the wall rectangle's
+// u-range. ok=false if a hole wraps the seam or cannot be brought wholly inside (it straddles the seam —
+// the builder is expected to place the wall's seam clear of its holes).
+func holesIntoBranch(s geom.Surface, holes3D [][]math.Point3, umin, umax float64) ([][]math.Point2, bool) {
+	out := make([][]math.Point2, 0, len(holes3D))
+	for _, h := range holes3D {
+		uv, ok := holeUVInBranch(s, h, umin, umax)
+		if !ok {
+			return nil, false
+		}
+		out = append(out, uv)
+	}
+	return out, true
+}
+
+// holeUVInBranch unwraps one hole loop to contiguous (u,v) and offsets it by whole periods so it sits
+// inside [umin, umax]. ok=false when the hole itself wraps the seam or still straddles a rectangle edge.
+func holeUVInBranch(s geom.Surface, hole []math.Point3, umin, umax float64) ([]math.Point2, bool) {
+	us := make([]float64, len(hole))
+	vs := make([]float64, len(hole))
+	for i, p := range hole {
+		us[i], vs[i] = s.ParamAt(p)
+	}
+	cu := cumulativeUnwrap(us)
+	lo, hi := minMax(cu)
+	if hi-lo > 2*stdmath.Pi-0.5 {
+		return nil, false // a hole that itself wraps the seam
+	}
+	shift := branchShift((lo+hi)/2, umin, umax)
+	if lo+shift < umin-trimBorderTol || hi+shift > umax+trimBorderTol {
+		return nil, false // straddles a seam edge even after shifting
+	}
+	uv := make([]math.Point2, len(hole))
+	for i := range hole {
+		uv[i] = math.P2(math.Scalar(cu[i]+shift), math.Scalar(vs[i]))
+	}
+	return uv, true
+}
+
+// cumulativeUnwrap makes a periodic parameter contiguous by accumulating per-step deltas (each jump
+// folded into (−π, π]), WITHOUT failing on a full-period wrap — unlike unwrap(), which rejects exactly
+// the wrapping wall loop this mesher is built for.
+func cumulativeUnwrap(a []float64) []float64 {
+	out := make([]float64, len(a))
+	out[0] = a[0]
+	for i := 1; i < len(a); i++ {
+		d := a[i] - a[i-1]
+		for d > stdmath.Pi {
+			d -= 2 * stdmath.Pi
+		}
+		for d <= -stdmath.Pi {
+			d += 2 * stdmath.Pi
+		}
+		out[i] = out[i-1] + d
+	}
+	return out
+}
+
+// branchShift returns the whole-period offset that brings angle a into [umin, umax].
+func branchShift(a, umin, umax float64) float64 {
+	shift := 0.0
+	for a+shift < umin {
+		shift += 2 * stdmath.Pi
+	}
+	for a+shift > umax {
+		shift -= 2 * stdmath.Pi
+	}
+	return shift
+}
+
+// minMax returns the smallest and largest of a non-empty slice.
+func minMax(xs []float64) (lo, hi float64) {
+	lo, hi = xs[0], xs[0]
+	for _, x := range xs {
+		lo, hi = stdmath.Min(lo, x), stdmath.Max(hi, x)
+	}
+	return lo, hi
+}

--- a/kernel/ops/holed_cylinder_wall_test.go
+++ b/kernel/ops/holed_cylinder_wall_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Holed cylinder-wall tessellation (M2 Phase 2, Oblikovati/Oblikovati#1335). A drilled cylinder leaves its
+// SIDE wall a full-period face with holes; the unroll-and-CDT mesher must cover the wall MINUS the holes
+// with the correct curved area. The hole here is a (u,v)-axis-aligned "window" whose area on the cylinder
+// is exactly R·Δu·Δv (the metric is flat), so the holed-wall area has a closed-form oracle.
+
+const wallR, wallH = 3.0, 12.0
+
+// windowedCylinderWall builds a cylinder side (radius wallR, axis z, z∈[0,wallH]) with its seam at angle 0
+// and one rectangular window hole over u∈[uLo,uHi], v∈[vLo,vHi] — clear of the seam. The window's two
+// horizontal edges are exact circle arcs (v=const on a cylinder) and its two vertical edges are line
+// rulings (u=const), so the hole tessellates faithfully (not a decimated polyline).
+func windowedCylinderWall(t *testing.T, uLo, uHi, vLo, vHi float64) *topo.Face {
+	t.Helper()
+	bottom, _ := geom.NewCircle(math.P3(0, 0, 0), math.V3(0, 0, 1), wallR)
+	top := geom.Circle{Center: math.P3(0, 0, wallH), Normal: bottom.Normal, RefDir: bottom.RefDir, Radius: wallR}
+	side, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), wallR)
+
+	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok("wall", "body", 0)))
+	vb := bld.AddVertex(bottom.PointAt(0), topo.NewLineage(topo.Tok("wall", "vb", 0)))
+	vt := bld.AddVertex(top.PointAt(0), topo.NewLineage(topo.Tok("wall", "vt", 0)))
+	eb := bld.AddEdge(bottom, vb, vb, topo.NewLineage(topo.Tok("wall", "eb", 0)))
+	et := bld.AddEdge(top, vt, vt, topo.NewLineage(topo.Tok("wall", "et", 0)))
+	es := bld.AddEdge(geom.NewLineSegment(bottom.PointAt(0), top.PointAt(0)), vb, vt, topo.NewLineage(topo.Tok("wall", "es", 0)))
+	hole := windowHoleLoop(bld, uLo, uHi, vLo, vHi)
+	bld.AddFace(side, topo.NewLineage(topo.Tok("wall", "face", 0)),
+		topo.OuterLoop(topo.Fwd(es), topo.Rev(et), topo.Rev(es), topo.Fwd(eb)), hole)
+	return bld.Build().Faces()[0]
+}
+
+// windowHoleLoop adds the four corner vertices and four edges (two v-const arcs, two u-const line rulings)
+// of a rectangular window on the cylinder wall, returning it as an inner (hole) loop.
+func windowHoleLoop(bld *topo.Builder, uLo, uHi, vLo, vHi float64) topo.LoopSpec {
+	z := math.V3(0, 0, 1)
+	x := math.V3(1, 0, 0)
+	c00, c10 := wallPoint(uLo, vLo), wallPoint(uHi, vLo)
+	c11, c01 := wallPoint(uHi, vHi), wallPoint(uLo, vHi)
+	v00 := bld.AddVertex(c00, topo.NewLineage(topo.Tok("win", "v00", 0)))
+	v10 := bld.AddVertex(c10, topo.NewLineage(topo.Tok("win", "v10", 0)))
+	v11 := bld.AddVertex(c11, topo.NewLineage(topo.Tok("win", "v11", 0)))
+	v01 := bld.AddVertex(c01, topo.NewLineage(topo.Tok("win", "v01", 0)))
+	arcB, _ := geom.NewArc3d(math.P3(0, 0, math.Scalar(vLo)), z, x, wallR, uLo, uHi-uLo)
+	arcT, _ := geom.NewArc3d(math.P3(0, 0, math.Scalar(vHi)), z, x, wallR, uHi, uLo-uHi)
+	eB := bld.AddEdge(arcB, v00, v10, topo.NewLineage(topo.Tok("win", "eB", 0)))
+	eR := bld.AddEdge(geom.NewLineSegment(c10, c11), v10, v11, topo.NewLineage(topo.Tok("win", "eR", 0)))
+	eT := bld.AddEdge(arcT, v11, v01, topo.NewLineage(topo.Tok("win", "eT", 0)))
+	eL := bld.AddEdge(geom.NewLineSegment(c01, c00), v01, v00, topo.NewLineage(topo.Tok("win", "eL", 0)))
+	return topo.InnerLoop(topo.Fwd(eB), topo.Fwd(eR), topo.Fwd(eT), topo.Fwd(eL))
+}
+
+// wallPoint is the cylinder-wall point at angle u and axial v.
+func wallPoint(u, v float64) math.Point3 {
+	return math.P3(math.Scalar(wallR*stdmath.Cos(u)), math.Scalar(wallR*stdmath.Sin(u)), math.Scalar(v))
+}
+
+// TestHoledCylinderWallAreaMatchesAnalytic meshes a windowed cylinder wall and checks the area equals the
+// full lateral area minus the window's R·Δu·Δv — i.e. the hole really is cut, with correct curved area.
+func TestHoledCylinderWallAreaMatchesAnalytic(t *testing.T) {
+	const uLo, uHi, vLo, vHi = stdmath.Pi / 4, stdmath.Pi / 2, 4.0, 8.0
+	face := windowedCylinderWall(t, uLo, uHi, vLo, vHi)
+
+	mesh := tessellateCurvedFace(face, DefaultQuality())
+	if mesh == nil || len(mesh.Indices) == 0 {
+		t.Fatal("holed cylinder wall produced no mesh")
+	}
+	got := meshArea(mesh)
+	want := 2*stdmath.Pi*wallR*wallH - wallR*(uHi-uLo)*(vHi-vLo)
+	// 3% tolerance: the drilled wall is triangulated boundary-only (interior Steiner points make the
+	// hole's constrained-Delaunay recovery leak — like trimmedPatchMesh's documented pole/seam case), so
+	// the curved area carries a slightly higher chord deficit than an interior-refined patch. The B-rep is
+	// exact; the mesh is watertight (verified separately) — this only bounds the display/property error.
+	if rel := stdmath.Abs(got-want) / want; rel > 0.03 {
+		t.Errorf("holed wall area %.4f, want %.4f (full − window) — rel %.4f > 3%%", got, want, rel)
+	}
+}
+
+// TestHoledCylinderWallMeshIsRouted confirms the dispatch reaches holedCylinderWallMesh for a holed
+// periodic cylinder side rather than falling through to the full-domain grid (which ignores holes).
+func TestHoledCylinderWallMeshIsRouted(t *testing.T) {
+	face := windowedCylinderWall(t, stdmath.Pi/4, stdmath.Pi/2, 4, 8)
+	outer := faceOuterBoundary(face, DefaultQuality())
+	holes := faceHoleBoundaries(face, DefaultQuality())
+	if _, ok := holedCylinderWallMesh(face.Geometry(), outer, holes); !ok {
+		t.Error("holedCylinderWallMesh declined a holed periodic cylinder wall; the dispatch would fall back")
+	}
+}
+
+// TestHoledCylinderWallDeclinesNoHoles: a plain (hole-free) cylinder side is the periodicBandGrid case, so
+// the holed mesher must decline it.
+func TestHoledCylinderWallDeclinesNoHoles(t *testing.T) {
+	side, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), wallR)
+	outer := []math.Point3{wallPoint(0, 0), wallPoint(2, 0), wallPoint(4, 0), wallPoint(0, wallH)}
+	if _, ok := holedCylinderWallMesh(side, outer, nil); ok {
+		t.Error("a hole-free cylinder side should defer from the holed-wall mesher")
+	}
+}
+
+// TestHoledCylinderWallDeclinesNonCylinder: only a cylinder unrolls with a flat metric, so a holed sphere
+// (or any other surface) must defer — the unroll-and-CDT path is cylinder-specific.
+func TestHoledCylinderWallDeclinesNonCylinder(t *testing.T) {
+	sph, _ := geom.NewSphere(math.P3(0, 0, 0), wallR)
+	outer := []math.Point3{wallPoint(0, 0), wallPoint(2, 0), wallPoint(4, 0)}
+	hole := []math.Point3{wallPoint(1, 1), wallPoint(1.2, 1), wallPoint(1.1, 1.2)}
+	if _, ok := holedCylinderWallMesh(sph, outer, [][]math.Point3{hole}); ok {
+		t.Error("a non-cylinder surface should defer from the holed-wall mesher")
+	}
+}
+
+// TestHoledCylinderWallDeclinesNonWrappingOuter: an outer loop that does NOT wrap the full period is an
+// ordinary contractible patch (toUVLoops handles it), so the wrapping-wall mesher must decline.
+func TestHoledCylinderWallDeclinesNonWrappingOuter(t *testing.T) {
+	side, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), wallR)
+	outer := []math.Point3{wallPoint(0, 0), wallPoint(0.5, 0), wallPoint(0.5, wallH), wallPoint(0, wallH)}
+	hole := []math.Point3{wallPoint(0.2, 4), wallPoint(0.3, 4), wallPoint(0.25, 6)}
+	if _, ok := holedCylinderWallMesh(side, outer, [][]math.Point3{hole}); ok {
+		t.Error("a non-wrapping outer loop should defer from the holed-wall mesher")
+	}
+}

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -64,6 +64,9 @@ func meshSeamCrossingFace(f *topo.Face, s geom.Surface, outer3D []math.Point3, h
 	if us, vs, isBand := periodicBandGrid(s, outer3D, holes3D); isBand {
 		return closedDomainMesh(s, us, vs) // full cylinder/cone side with circular rims: grid the period
 	}
+	if m, ok := holedCylinderWallMesh(s, outer3D, holes3D); ok {
+		return m // a drilled cylinder wall: full-period side with lens holes — unroll + metric CDT
+	}
 	if m, ok := saddleBandLoftMesh(f, s, q); ok {
 		return m // a cylinder/cone band with non-circular (saddle) rims — a crossing cylinder: loft v(u)
 	}


### PR DESCRIPTION
## What

The tessellation prerequisite for the crossing-cylinder **Cut** and **Join** (#1335). A cylinder drilled through — a fat cylinder Cut/Join with a crossing rod — leaves its side wall a **full-period cylinder face carrying lens holes**. `periodicBandGrid` and `metricPatchMesh` both reject a holed periodic face (`toUVLoops` can't unwrap the seam-wrapping outer loop), so it fell through to the full-domain grid, which **ignores the holes**. This adds `holedCylinderWallMesh`, wired into `meshSeamCrossingFace`.

## Why / how

A cylinder is **developable** — its first fundamental form `ds² = R²du² + dv²` is flat — so its wall unrolls to a plane without distortion:

1. Unwrap the wrapping outer loop's angle cumulatively into a contiguous `(u,v)` rectangle (`cumulativeUnwrap`, which — unlike `unwrap` — does *not* reject the full-period wrap this mesher is built for).
2. Shift each hole into that branch (`holesIntoBranch`).
3. Triangulate the rectangle-minus-holes with a **boundary-only** metric-scaled constrained Delaunay (`unrolledWallCDT`).

The seam (the rectangle's two vertical edges, 2π apart in `u`) maps to one line in 3D, so the triangles on either side meet there with no gap, and the exact 3D boundary points are kept so the wall welds to its caps and to the faces sharing its hole edges.

**Boundary-only is deliberate:** a large holed wall's interior Steiner points make the hole's constrained-Delaunay recovery leak (the same reason `trimmedPatchMesh` documents for pole/seam-distorted caps). The wall's curvature is entirely circumferential — already captured by the dense cap-circle rim samples — so the boundary-only mesh is watertight with a small chord deficit on the drilled region. **The B-rep stays exact; this only bounds the display/property mesh.**

## Tests

- Area of a windowed cylinder wall = full lateral area − the window's exact `R·Δu·Δv` (within 3%, the boundary-only chord deficit; the mesh is watertight — free-edge count ≈ the real boundary, verified during development).
- Dispatch routing (a holed periodic wall reaches the new mesher).
- Declines: hole-free side, non-cylinder surface, non-wrapping outer loop.

ops package coverage 89.5%; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)