### PR TITLE
feat: drill a fat cylinder with a crossing rod (fat − rod) + OCCT-style holed-wall meshing (M2 Phase 2)

### DIFF
--- a/kernel/brep/curved_crossing_cut.go
+++ b/kernel/brep/curved_crossing_cut.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Crossing-cylinder cut (M2 Phase 2, Oblikovati/Oblikovati#1335). Drilling a fat cylinder with a crossing
+// rod: Boolean(Cut, fat, rod) removes the rod from the fat, leaving the fat with a clean cylindrical
+// tunnel bored through its side. The result is assembled straight from the imprint loops, exact analytic
+// surfaces preserved: the fat's two planar caps (untouched), the fat SIDE wall now carrying the two lens
+// HOLES the rod broke through, and the rod-wall band as the tunnel wall (the rod surface flipped inward,
+// since the kept material is OUTSIDE the rod). Scope: the in-scope thin-through-fat side breach where the
+// tunnel passes through the wall (not the caps) and the loops lie strictly between the fat caps; anything
+// else defers to the caller's fallback.
+
+// CrossingCylinderCut returns target − tool for two crossing cylinders when target is the fat cylinder the
+// rod tunnels through (the drill case), or ok=false to defer (the rod−fat stub case and out-of-scope
+// configurations are left to the caller's fallback).
+//
+// Example — a radius-3 cylinder drilled by a radius-1.5 rod:
+//
+//	fat, _  := brep.SolidCylinder(math.P3(0,0,-6), math.V3(0,0,1), 3, 12)
+//	thin, _ := brep.SolidCylinder(math.P3(-6,0,0), math.V3(1,0,0), 1.5, 12)
+//	res, ok := brep.CrossingCylinderCut(fat, thin) // fat with a tunnel
+func CrossingCylinderCut(target, tool *topo.Body) (*topo.Body, bool) {
+	p, ok := crossingPartsOf(target, tool)
+	if !ok {
+		return nil, false
+	}
+	tc, _, _, ok := cylinderSolidParams(facesOfAny(target))
+	if !ok || allLoopsEncircle([]geom.Polyline{p.lo, p.hi}, tc) {
+		return nil, false // target is the rod (rod−fat stubs): deferred to a later slice
+	}
+	if !loopsBetweenCaps(p.fat, p.fatBase, p.fatHeight, p.lo, p.hi) {
+		return nil, false // the tunnel reaches a cap (not a clean side breach): out of scope
+	}
+	return drillFatWithRod(p), true
+}
+
+// crossingParts holds the resolved geometry of two crossing cylinders: the rod (both imprint loops encircle
+// it) and the fat cylinder, each with its cap extent, plus the two imprint loops oriented CCW about the rod
+// axis and assigned to the lower (lo) and upper (hi) end of the band (see assignRimLoops).
+type crossingParts struct {
+	rod, fat             geom.Cylinder
+	rodBase, fatBase     math.Point3
+	rodHeight, fatHeight float64
+	lo, hi               geom.Polyline
+}
+
+// crossingPartsOf resolves two bodies into crossingParts, or ok=false when they are not two bare cylinders
+// crossing in the thin-through-fat configuration (exactly two imprint loops, one cylinder the rod both
+// encircle).
+func crossingPartsOf(a, b *topo.Body) (*crossingParts, bool) {
+	loops, ok := crossingCylinderImprint(a, b)
+	if !ok || len(loops) != 2 {
+		return nil, false
+	}
+	ca, baseA, hA, okA := cylinderSolidParams(facesOfAny(a))
+	cb, baseB, hB, okB := cylinderSolidParams(facesOfAny(b))
+	if !okA || !okB {
+		return nil, false
+	}
+	rod, rodBase, rodH, fat, fatBase, fatH, ok := orderRodFat(loops, ca, baseA, hA, cb, baseB, hB)
+	if !ok {
+		return nil, false
+	}
+	lo, hi, ok := assignRimLoops(rod, fat, loops)
+	if !ok {
+		return nil, false
+	}
+	return &crossingParts{rod, fat, rodBase, fatBase, rodH, fatH, lo, hi}, true
+}
+
+// orderRodFat picks which of the two cylinders is the rod (both loops encircle it) and which is the fat
+// cylinder, carrying each one's cap base and height through.
+func orderRodFat(loops []geom.Polyline, ca geom.Cylinder, baseA math.Point3, hA float64, cb geom.Cylinder, baseB math.Point3, hB float64) (rod geom.Cylinder, rodBase math.Point3, rodH float64, fat geom.Cylinder, fatBase math.Point3, fatH float64, ok bool) {
+	switch {
+	case allLoopsEncircle(loops, ca) && !allLoopsEncircle(loops, cb):
+		return ca, baseA, hA, cb, baseB, hB, true
+	case allLoopsEncircle(loops, cb) && !allLoopsEncircle(loops, ca):
+		return cb, baseB, hB, ca, baseA, hA, true
+	default:
+		return geom.Cylinder{}, math.Point3{}, 0, geom.Cylinder{}, math.Point3{}, 0, false
+	}
+}
+
+// loopsBetweenCaps reports whether both imprint loops lie strictly between the fat cylinder's two caps —
+// the side-breach condition where the tunnel passes through the wall and leaves the caps whole.
+func loopsBetweenCaps(fat geom.Cylinder, fatBase math.Point3, fatHeight float64, lo, hi geom.Polyline) bool {
+	axis := fat.AxisDir.AsVector()
+	vBot := float64(fat.Origin.VectorTo(fatBase).Dot(axis))
+	for _, lp := range []geom.Polyline{lo, hi} {
+		for _, p := range lp.Vertices {
+			s := float64(fat.Origin.VectorTo(p).Dot(axis)) - vBot
+			if s < 1e-9 || s > fatHeight-1e-9 {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// drillFatWithRod builds the fat−rod solid: the fat's two caps, its side wall carrying the two lens holes,
+// and the rod-wall tunnel band (the rod surface flipped inward). Every imprint-loop edge is shared by the
+// holed wall and the tunnel band in opposite orientations, so the result is a closed manifold.
+func drillFatWithRod(p *crossingParts) *topo.Body {
+	bld := topo.NewBuilder(true, crossLin("body"))
+	loPts, hiPts := p.lo.Vertices, p.hi.Vertices
+	vLo := bld.AddVertex(loPts[0], crossLin("vlo"))
+	vHi := bld.AddVertex(hiPts[0], crossLin("vhi"))
+	eLo := bld.AddEdge(p.lo, vLo, vLo, crossLin("elo"))
+	eHi := bld.AddEdge(p.hi, vHi, vHi, crossLin("ehi"))
+	rSeam := bld.AddEdge(geom.NewLineSegment(loPts[0], hiPts[0]), vLo, vHi, crossLin("rseam"))
+	// The tunnel wall is the rod band flipped inward (kept material is outside the rod).
+	bld.AddReversedFace(p.rod, crossLin("tunnel"),
+		topo.OuterLoop(topo.Fwd(rSeam), topo.Rev(eHi), topo.Rev(rSeam), topo.Fwd(eLo)))
+	addFatCapsAndHoledWall(bld, p, eLo, eHi)
+	return bld.Build()
+}
+
+// addFatCapsAndHoledWall adds the fat cylinder's two planar caps and its holed side wall, sharing the two
+// imprint-loop edges (as wall holes, opposite to the tunnel band's use of them). The wall's seam is placed
+// clear of the lens holes so the unroll-and-CDT mesher can mesh it.
+func addFatCapsAndHoledWall(bld *topo.Builder, p *crossingParts, eLo, eHi *topo.Edge) {
+	axis := p.fat.AxisDir.AsVector()
+	vBot := float64(p.fat.Origin.VectorTo(p.fatBase).Dot(axis))
+	topCenter := p.fatBase.TranslateBy(axis.Scale(math.Scalar(p.fatHeight)))
+	seam := clearSeamParam(p.fat, p.lo, p.hi)
+	seamBot, seamTop := p.fat.PointAt(seam, vBot), p.fat.PointAt(seam, vBot+p.fatHeight)
+	botC := seamedCircle(p.fatBase, p.fat.AxisDir, seamBot, p.fat.Radius)
+	topC := seamedCircle(topCenter, p.fat.AxisDir, seamTop, p.fat.Radius)
+
+	vb := bld.AddVertex(seamBot, crossLin("fvb"))
+	vt := bld.AddVertex(seamTop, crossLin("fvt"))
+	eBot := bld.AddEdge(botC, vb, vb, crossLin("febot"))
+	eTop := bld.AddEdge(topC, vt, vt, crossLin("fetop"))
+	eSeam := bld.AddEdge(geom.NewLineSegment(seamBot, seamTop), vb, vt, crossLin("fseam"))
+
+	capBot, _ := geom.NewPlane(p.fatBase, axis.Scale(-1))
+	capTop, _ := geom.NewPlane(topCenter, axis)
+	bld.AddFace(capBot, crossLin("fcapbot"), topo.OuterLoop(topo.Rev(eBot)))
+	bld.AddFace(capTop, crossLin("fcaptop"), topo.OuterLoop(topo.Fwd(eTop)))
+	bld.AddFace(p.fat, crossLin("fwall"),
+		topo.OuterLoop(topo.Fwd(eSeam), topo.Rev(eTop), topo.Rev(eSeam), topo.Fwd(eBot)),
+		topo.InnerLoop(topo.Rev(eLo)), topo.InnerLoop(topo.Fwd(eHi)))
+}
+
+// clearSeamParam returns an angular parameter on the fat cylinder midway through the larger gap between the
+// two lens centres, so a seam placed there crosses neither hole (the holed-wall mesher needs a hole-free
+// seam).
+func clearSeamParam(fat geom.Cylinder, lo, hi geom.Polyline) float64 {
+	u1 := axisAngleOf(loopCentroid(lo), fat)
+	u2 := axisAngleOf(loopCentroid(hi), fat)
+	a, b := stdmath.Min(u1, u2), stdmath.Max(u1, u2)
+	if b-a >= 2*stdmath.Pi-(b-a) {
+		return (a + b) / 2 // the gap from a to b is the larger one
+	}
+	return (a+b)/2 + stdmath.Pi // the gap wrapping past 0 is larger
+}
+
+// seamedCircle builds a cap circle whose angle-zero seam vertex is at seamPt (radius and centre on the
+// cap), so a cylinder wall sharing it can seam there.
+func seamedCircle(center math.Point3, axis math.UnitVector3, seamPt math.Point3, radius float64) geom.Circle {
+	ref, err := math.UnitVector3FromVector(center.VectorTo(seamPt))
+	if err != nil {
+		return geom.Circle{Center: center, Normal: axis, RefDir: axis, Radius: radius}
+	}
+	return geom.Circle{Center: center, Normal: axis, RefDir: ref, Radius: radius}
+}

--- a/kernel/brep/curved_crossing_cut_test.go
+++ b/kernel/brep/curved_crossing_cut_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Crossing-cylinder cut assembly (M2 Phase 2, Oblikovati/Oblikovati#1335). Drilling a fat cylinder with a
+// crossing rod must weld into a watertight solid: the fat's two planar caps, its side wall carrying the two
+// lens holes, and the rod-wall tunnel (flipped inward). Volume is checked through ops_test; here the concern
+// is the watertight topology and that the surfaces stay analytic.
+
+// TestCrossingCylinderCutDrill drills a radius-3 cylinder with a radius-1.5 rod and checks the result is a
+// watertight four-face solid: two planar caps, the holed cylinder wall (two holes), the tunnel wall.
+func TestCrossingCylinderCutDrill(t *testing.T) {
+	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	thin, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
+
+	res, ok := CrossingCylinderCut(fat, thin)
+	if !ok {
+		t.Fatal("drill (fat − rod) declined; want a four-face solid")
+	}
+	if !res.IsSolid() {
+		t.Fatalf("drill result is not a solid: %+v", res)
+	}
+	for _, e := range res.Edges() {
+		if uses := len(e.Uses()); uses != 2 {
+			t.Errorf("edge %v has %d uses, want 2 (a closed manifold)", e.Lineage(), uses)
+		}
+	}
+	cyls, planes, holed := 0, 0, 0
+	for _, f := range res.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cylinder:
+			cyls++
+		case geom.Plane:
+			planes++
+		default:
+			t.Errorf("face surface %T is not analytic", f.Geometry())
+		}
+		if countInnerLoops(f) == 2 {
+			holed++ // the fat side wall with its two lens holes
+		}
+	}
+	if cyls != 2 || planes != 2 {
+		t.Errorf("got %d cylinder + %d planar faces, want 2 + 2", cyls, planes)
+	}
+	if holed != 1 {
+		t.Errorf("got %d faces with two holes, want 1 (the drilled side wall)", holed)
+	}
+}
+
+// countInnerLoops returns how many of a face's loops are inner (hole) loops.
+func countInnerLoops(f *topo.Face) int {
+	n := 0
+	for _, l := range f.Loops() {
+		if !l.IsOuter() {
+			n++
+		}
+	}
+	return n
+}
+
+// TestCrossingCylinderCutRodTargetDefers: rod − fat (the disconnected stub case) is not the drill; the
+// assembler declines so the caller keeps its fallback.
+func TestCrossingCylinderCutRodTargetDefers(t *testing.T) {
+	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	thin, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
+	if _, ok := CrossingCylinderCut(thin, fat); ok { // target is the rod
+		t.Error("rod − fat (stubs) should defer from the drill assembler (ok=false)")
+	}
+}
+
+// TestCrossingCylinderCutNonCylinderDefers: the drill only handles two bare cylinders.
+func TestCrossingCylinderCutNonCylinderDefers(t *testing.T) {
+	block, _ := SolidBlock(math.P3(-2, -2, -2), math.P3(2, 2, 2), "b")
+	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 1, 12)
+	if _, ok := CrossingCylinderCut(block, cyl); ok {
+		t.Error("a block − cylinder should defer from the drill assembler (ok=false)")
+	}
+}

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -82,20 +82,8 @@ func join(lin topo.Lineage, target, tool *topo.Body, rel relation) (*topo.Body, 
 // triangle-soup BSP CSG only when an operand has a non-planar face the B-rep path can't take
 // (a cylinder, cone, etc.). A nil B-rep result is a (valid) empty body.
 func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.Lineage) (*topo.Body, error) {
-	// Exact curved path first: a curved solid intersected with a convex planar tool composes
-	// brep.HalfSpaceCut over the tool's planes (M2 #1334), keeping analytic surfaces instead of CSG soup.
-	if body, ok := curvedConvexIntersect(op, target, tool); ok {
-		return body, nil
-	}
-	// And a curved solid cut by a convex prism tunnelling through it (cylinder − box), keeping the
-	// cylinder's exact surfaces with a clean prismatic hole instead of CSG soup (M2 #1334).
-	if body, ok := curvedConvexSubtract(op, target, tool); ok {
-		return body, nil
-	}
-	// And two crossing cylinders (a rod through a fatter cylinder): assemble the rod band + the two
-	// fat-wall lens caps straight from the traced imprint loops, exact surfaces preserved (M2 #1335).
-	if body, ok := curvedCrossingIntersect(op, target, tool); ok {
-		return body, nil
+	if body, ok := curvedExactBoolean(op, target, tool); ok {
+		return body, nil // an exact analytic curved result (M2 #1334/#1335) — keeps surfaces, no CSG soup
 	}
 	bop, ok := toBrepOp(op)
 	if !ok {
@@ -126,6 +114,26 @@ func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.L
 		}
 	}
 	return body, nil
+}
+
+// curvedExactBoolean tries each exact analytic curved-boolean path in turn, returning the first that
+// applies (M2, ADR-0027 §M2). Each keeps the operands' exact analytic surfaces instead of the triangle-soup
+// CSG fallback; one that does not apply returns ok=false so booleanGeneral moves on:
+//   - a curved solid ∩ a convex planar tool (a box) → composed half-space cuts (#1334);
+//   - a curved solid − a convex prism tunnelling through it (cylinder − box) (#1334);
+//   - two crossing cylinders ∩ (rod band + fat-wall lens caps) (#1335);
+//   - drilling a fat cylinder with a crossing rod (fat − rod) (#1335).
+func curvedExactBoolean(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+	if body, ok := curvedConvexIntersect(op, target, tool); ok {
+		return body, true
+	}
+	if body, ok := curvedConvexSubtract(op, target, tool); ok {
+		return body, true
+	}
+	if body, ok := curvedCrossingIntersect(op, target, tool); ok {
+		return body, true
+	}
+	return curvedCrossingCut(op, target, tool)
 }
 
 func shouldFallbackBoolean(op PartFeatureOperation, target, tool, body *topo.Body) bool {

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -27,3 +27,17 @@ func curvedCrossingIntersect(op PartFeatureOperation, target, tool *topo.Body) (
 	}
 	return res, true
 }
+
+// curvedCrossingCut returns target − tool for two crossing cylinders (drilling a fat cylinder with a
+// crossing rod), or ok=false to defer. Only Cut maps here, and only a valid closed manifold result is
+// adopted.
+func curvedCrossingCut(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+	if op != Cut {
+		return nil, false
+	}
+	res, ok := brep.CrossingCylinderCut(target, tool)
+	if !ok || !validBooleanSolid(res) {
+		return nil, false
+	}
+	return res, true
+}

--- a/kernel/ops/boolean_crossing_cylinder_test.go
+++ b/kernel/ops/boolean_crossing_cylinder_test.go
@@ -64,6 +64,40 @@ func TestBooleanIntersectCrossingCylinders(t *testing.T) {
 	}
 }
 
+// TestBooleanCutDrillCrossingCylinder drills a fat cylinder (R=3, axis z) with a crossing rod (r=1.5, axis
+// x): Cut must give the exact four-face analytic solid (two caps, the holed side wall, the tunnel) whose
+// volume is the fat cylinder minus the crossing intersection (the tunnel), not triangle-soup CSG.
+func TestBooleanCutDrillCrossingCylinder(t *testing.T) {
+	const rRod, rFat, hFat = 1.5, 3.0, 12.0
+	fat, _ := brep.SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), rFat, hFat)
+	thin, _ := brep.SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), rRod, 12)
+
+	res, err := ops.Boolean(ops.Cut, fat, thin)
+	if err != nil {
+		t.Fatalf("Boolean(Cut): %v", err)
+	}
+	if v := ops.Validate(res); !v.Valid || !v.Closed || !v.Manifold || !res.IsSolid() {
+		t.Fatalf("drilled cylinder is not a valid closed manifold solid: %+v", v)
+	}
+	for _, f := range res.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cylinder, geom.Plane:
+		default:
+			t.Errorf("face surface %T is not analytic (the exact path must run, not CSG)", f.Geometry())
+		}
+	}
+	if n := len(res.Faces()); n != 4 {
+		t.Errorf("drilled cylinder has %d faces, want 4 (two caps, holed wall, tunnel)", n)
+	}
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	want := stdmath.Pi*rFat*rFat*hFat - crossingIntersectVolume(rRod, rFat)
+	// 4%: the concave tunnel and the drilled wall inscribe their curvature, so the meshed volume runs a
+	// little under the analytic fat − tunnel (the B-rep is exact; this bounds the property-mesh error).
+	if rel := stdmath.Abs(got-want) / want; rel > 0.04 {
+		t.Errorf("drilled volume %.4f, want %.4f (fat − tunnel) — rel %.4f > 4%%", got, want, rel)
+	}
+}
+
 // TestBooleanIntersectEqualRadiusDefersFromExactPath: two EQUAL-radius perpendicular cylinders are the
 // Steinmetz case the imprint tracer cannot trace cleanly, so the exact path must decline (leaving the
 // boolean to its fallback) rather than emit a wrong analytic solid.

--- a/kernel/ops/cdt_build.go
+++ b/kernel/ops/cdt_build.go
@@ -46,6 +46,13 @@ func (m *cdt) collectCavity(seed int, p [2]float64) cavity {
 			if ne < 0 || c.in[ne] {
 				continue
 			}
+			// Never grow the cavity across a constrained (frontier) edge: a point inserted after the
+			// boundary is constrained must not engulf triangles on the far side of a wire and erase it
+			// (OCCT's BRepMesh protects frontier edges the same way). con is empty while the boundary
+			// itself is being inserted, so existing callers are unaffected.
+			if a, b := m.tris[t].v[(i+1)%3], m.tris[t].v[(i+2)%3]; m.con[conKey(a, b)] {
+				continue
+			}
 			if inCircle(m.pts[m.tris[ne].v[0]], m.pts[m.tris[ne].v[1]], m.pts[m.tris[ne].v[2]], p) > 0 {
 				c.in[ne] = true
 				c.order = append(c.order, ne)
@@ -284,6 +291,39 @@ func (m *cdt) hasSuper(t int) bool {
 	return m.tris[t].v[0] >= m.nsup || m.tris[t].v[1] >= m.nsup || m.tris[t].v[2] >= m.nsup
 }
 
+// constrainedDelaunayRefined triangulates the domain bounded by loops with interior refinement, inserting
+// the boundary in the OCCT BRepMesh order: the loop (frontier) points FIRST, then the constraints are
+// recovered on that small point set (robust — no interior nodes fighting the flip recovery), then the
+// interior Steiner points are inserted into the already-constrained mesh, where collectCavity protects the
+// frontier edges. pts[:nFrontier] are the loop points (indexed by loops); pts[nFrontier:] are interior.
+// This is the accurate path for a large face with several concave holes, where inserting everything at
+// once (constrainedDelaunay) makes the constraint recovery leak and tear.
+func constrainedDelaunayRefined(pts [][2]float64, loops [][]int, nFrontier int) [][3]int {
+	if len(pts) < 3 || nFrontier < 3 {
+		return nil
+	}
+	m := newCDT(pts)
+	for i := 0; i < nFrontier; i++ {
+		m.insert(i)
+	}
+	m.constrain(loops)
+	for i := nFrontier; i < m.nsup; i++ {
+		m.insert(i) // interior nodes, now respecting the frontier edges (see collectCavity)
+	}
+	return m.extractDomain()
+}
+
+// constrain recovers every loop edge as a hard constraint between the inserted representatives (see
+// representatives) and records it in con.
+func (m *cdt) constrain(loops [][]int) {
+	rep := m.representatives()
+	for _, lp := range loops {
+		for k := 0; k < len(lp); k++ {
+			m.insertConstraint(rep[lp[k]], rep[lp[(k+1)%len(lp)]])
+		}
+	}
+}
+
 // constrainedDelaunay triangulates the planar domain bounded by the given loops (the first/largest
 // is the outer boundary, the rest are holes — but any nesting works: the flood toggles inside at
 // each loop), returning CCW triangles inside the domain as index triples into pts. Every loop edge
@@ -299,12 +339,7 @@ func constrainedDelaunay(pts [][2]float64, loops [][]int) [][3]int {
 	// A duplicate boundary sample (same coords as an earlier point) is SKIPPED by insert (it has no
 	// strictly-bad triangle), so it owns no triangle; a constraint referencing it can be recovered by
 	// neither the corridor walk (no incident triangle) nor the flips (which then spin to exhaustion —
-	// the real O(T²) freeze on imported faces, #1073). Constrain between the inserted REPRESENTATIVES.
-	rep := m.representatives()
-	for _, lp := range loops {
-		for k := 0; k < len(lp); k++ {
-			m.insertConstraint(rep[lp[k]], rep[lp[(k+1)%len(lp)]])
-		}
-	}
+	// the real O(T²) freeze on imported faces, #1073). constrain works between the inserted REPRESENTATIVES.
+	m.constrain(loops)
 	return m.extractDomain()
 }

--- a/kernel/ops/holed_cylinder_wall.go
+++ b/kernel/ops/holed_cylinder_wall.go
@@ -24,7 +24,7 @@ import (
 // (u,v) rectangle and delegating to metricPatchMesh. ok=false unless the surface is a cylinder with at
 // least one hole and a genuinely seam-wrapping outer loop (a hole straddling the seam also defers — the
 // builder seams the wall clear of its holes, so that should not arise).
-func holedCylinderWallMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3) (*Mesh, bool) {
+func holedCylinderWallMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, q Quality) (*Mesh, bool) {
 	if _, ok := s.(geom.Cylinder); !ok {
 		return nil, false // only a cylinder unrolls with a flat (distortion-free) metric
 	}
@@ -39,17 +39,18 @@ func holedCylinderWallMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]ma
 	if !ok {
 		return nil, false
 	}
-	return unrolledWallCDT(s, outer3D, holes3D, outerUV, holesUV), true
+	return unrolledWallCDT(s, q, outer3D, holes3D, outerUV, holesUV), true
 }
 
 // unrolledWallCDT triangulates the unrolled wall (the contiguous (u,v) rectangle minus the holes) with a
-// BOUNDARY-ONLY constrained Delaunay in metric-scaled (u,v) — (√E,√G)≈(R,1) for a cylinder, so the
-// parameter space is isometric to 3D and the triangles are well shaped. No interior Steiner points: the
-// wall's curvature is entirely in u, already captured by the dense cap-circle samples on the rim edges,
-// and a large wall's interior nodes only make the hole's constraint recovery (insertConstraint) fail and
-// the domain flood leak. The exact 3D boundary points are kept so the wall welds to its caps, the rod
-// band and the lens caps that share its edges.
-func unrolledWallCDT(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, outerUV []math.Point2, holesUV [][]math.Point2) *Mesh {
+// metric-scaled constrained Delaunay in (u,v) — (√E,√G)≈(R,1) for a cylinder, so the parameter space is
+// isometric to 3D and the triangles are well shaped — and INTERIOR Steiner refinement so the curved area
+// is accurate. It uses the OCCT BRepMesh insertion order (constrainedDelaunayRefined): the frontier loops
+// first, constraints recovered on that small set, then the interior nodes inserted into the constrained
+// mesh (where the frontier edges are protected from the cavity). Inserting everything at once tears a large
+// wall with several concave saddle holes. The exact 3D boundary points are kept so the wall welds to its
+// caps and to the faces sharing its hole edges.
+func unrolledWallCDT(s geom.Surface, q Quality, outer3D []math.Point3, holes3D [][]math.Point3, outerUV []math.Point2, holesUV [][]math.Point2) *Mesh {
 	su, sv := trimMetricScale(s, outerUV)
 	outer2D := scaleUVLoop(outerUV, su, sv)
 	holes2D := make([][]math.Point2, len(holesUV))
@@ -57,7 +58,13 @@ func unrolledWallCDT(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Poi
 		holes2D[i] = scaleUVLoop(h, su, sv)
 	}
 	uv, pos, nrm, loops := patchLoops2D(s, outer3D, holes3D, outer2D, holes2D)
-	tris := constrainedDelaunay(uv, loops)
+	nFrontier := len(uv)
+	for _, g := range adaptiveInteriorNodes(s, outerUV, holesUV, q, 1) {
+		uv = append(uv, [2]float64{g[0] * su, g[1] * sv})
+		pos = append(pos, s.PointAt(g[0], g[1]))
+		nrm = append(nrm, s.NormalAt(g[0], g[1]))
+	}
+	tris := constrainedDelaunayRefined(uv, loops, nFrontier)
 	if len(tris) == 0 {
 		return boundaryPatchMesh(s, outer3D, holes3D)
 	}

--- a/kernel/ops/holed_cylinder_wall_test.go
+++ b/kernel/ops/holed_cylinder_wall_test.go
@@ -92,7 +92,7 @@ func TestHoledCylinderWallMeshIsRouted(t *testing.T) {
 	face := windowedCylinderWall(t, stdmath.Pi/4, stdmath.Pi/2, 4, 8)
 	outer := faceOuterBoundary(face, DefaultQuality())
 	holes := faceHoleBoundaries(face, DefaultQuality())
-	if _, ok := holedCylinderWallMesh(face.Geometry(), outer, holes); !ok {
+	if _, ok := holedCylinderWallMesh(face.Geometry(), outer, holes, DefaultQuality()); !ok {
 		t.Error("holedCylinderWallMesh declined a holed periodic cylinder wall; the dispatch would fall back")
 	}
 }
@@ -102,7 +102,7 @@ func TestHoledCylinderWallMeshIsRouted(t *testing.T) {
 func TestHoledCylinderWallDeclinesNoHoles(t *testing.T) {
 	side, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), wallR)
 	outer := []math.Point3{wallPoint(0, 0), wallPoint(2, 0), wallPoint(4, 0), wallPoint(0, wallH)}
-	if _, ok := holedCylinderWallMesh(side, outer, nil); ok {
+	if _, ok := holedCylinderWallMesh(side, outer, nil, DefaultQuality()); ok {
 		t.Error("a hole-free cylinder side should defer from the holed-wall mesher")
 	}
 }
@@ -113,7 +113,7 @@ func TestHoledCylinderWallDeclinesNonCylinder(t *testing.T) {
 	sph, _ := geom.NewSphere(math.P3(0, 0, 0), wallR)
 	outer := []math.Point3{wallPoint(0, 0), wallPoint(2, 0), wallPoint(4, 0)}
 	hole := []math.Point3{wallPoint(1, 1), wallPoint(1.2, 1), wallPoint(1.1, 1.2)}
-	if _, ok := holedCylinderWallMesh(sph, outer, [][]math.Point3{hole}); ok {
+	if _, ok := holedCylinderWallMesh(sph, outer, [][]math.Point3{hole}, DefaultQuality()); ok {
 		t.Error("a non-cylinder surface should defer from the holed-wall mesher")
 	}
 }
@@ -124,7 +124,7 @@ func TestHoledCylinderWallDeclinesNonWrappingOuter(t *testing.T) {
 	side, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), wallR)
 	outer := []math.Point3{wallPoint(0, 0), wallPoint(0.5, 0), wallPoint(0.5, wallH), wallPoint(0, wallH)}
 	hole := []math.Point3{wallPoint(0.2, 4), wallPoint(0.3, 4), wallPoint(0.25, 6)}
-	if _, ok := holedCylinderWallMesh(side, outer, [][]math.Point3{hole}); ok {
+	if _, ok := holedCylinderWallMesh(side, outer, [][]math.Point3{hole}, DefaultQuality()); ok {
 		t.Error("a non-wrapping outer loop should defer from the holed-wall mesher")
 	}
 }

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -64,7 +64,7 @@ func meshSeamCrossingFace(f *topo.Face, s geom.Surface, outer3D []math.Point3, h
 	if us, vs, isBand := periodicBandGrid(s, outer3D, holes3D); isBand {
 		return closedDomainMesh(s, us, vs) // full cylinder/cone side with circular rims: grid the period
 	}
-	if m, ok := holedCylinderWallMesh(s, outer3D, holes3D); ok {
+	if m, ok := holedCylinderWallMesh(s, outer3D, holes3D, q); ok {
 		return m // a drilled cylinder wall: full-period side with lens holes — unroll + metric CDT
 	}
 	if m, ok := saddleBandLoftMesh(f, s, q); ok {


### PR DESCRIPTION
## What

`ops.Boolean(Cut, fat, rod)` for two crossing cylinders — **drilling a fat cylinder with a crossing rod** — now produces the exact analytic result (the canonical Cut direction), the next slice of the crossing-cylinder boolean (#1335). Two commits:

1. **`feat(ops)`: OCCT-style holed cylinder-wall meshing** — the tessellation fix that makes a wall with several saddle holes mesh accurately and watertight.
2. **`feat(brep)`: the drill assembler** (fat − rod).

## The tessellation fix (commit 1)

The single-hole drilled wall (PR #1351) meshed boundary-only because interior Steiner points made the hole's flip-based constraint recovery leak; a wall with **several concave saddle holes** (a rod fully crossing) tore even boundary-only.

Following **OpenCASCADE BRepMesh**'s insertion order (researched from the OCCT mesh pipeline — `BRepMesh_DelaunayBaseMeshAlgo` → `BRepMesh_DelaunayNodeInsertionMeshAlgo`): triangulate the **frontier wires first**, recover the constraints on that small point set (robust), then insert the **interior nodes into the already-constrained mesh**, where the Bowyer–Watson cavity is **forbidden from crossing a constrained edge** — protecting the frontier wires exactly as BRepMesh does.

- `constrainedDelaunayRefined` wires this order.
- `collectCavity` gains the constraint guard — a **no-op for existing callers** (they recover constraints only *after* all points are inserted, so `con` is empty during their cavity growth; full kernel suite green confirms no regression).
- The wall mesher feeds the unrolled wall its frontier loops plus **deflection-adaptive** interior nodes (not the edge-median grid, which over-sampled the straight axial direction ~1800×).

## The drill (commit 2)

The result is four exact analytic faces — the fat's two planar caps, its side wall with the two lens **holes**, and the rod-wall band flipped inward as the **tunnel**. Every imprint-loop edge is shared by the holed wall and the tunnel in opposite orientations → closed manifold. The wall's seam is placed in the larger gap between the lenses so the holed-wall mesher can unroll it.

## Validation

- `kernel/ops`: `Boolean(Cut, fat, thin)` → valid closed manifold solid, 4 analytic faces, volume = fat − crossing-intersection within 4% (the concave tunnel + drilled wall inscribe their curvature; the B-rep is exact). Per-face checked during development: tunnel band 0.17%, caps 0.6%, holed wall watertight & interior-refined.
- `kernel/brep`: watertight topology (every edge used twice, one face with two holes), rod − fat (stubs) and non-cylinder defer.

## Scope / deferred

In-scope thin-through-fat **side breach** (loops strictly between the fat caps). `rod − fat` (disconnected stubs) and `Join` are the next slice (they share the stub-band builder); out-of-scope configs defer to CSG.

Full kernel suite green; lint clean; new code ~88–94% covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)