### PR TITLE
feat: join two crossing cylinders + rod−fat stubs (M2 Phase 2)

### DIFF
--- a/kernel/brep/curved_crossing_cut.go
+++ b/kernel/brep/curved_crossing_cut.go
@@ -19,28 +19,34 @@ import (
 // tunnel passes through the wall (not the caps) and the loops lie strictly between the fat caps; anything
 // else defers to the caller's fallback.
 
-// CrossingCylinderCut returns target − tool for two crossing cylinders when target is the fat cylinder the
-// rod tunnels through (the drill case), or ok=false to defer (the rod−fat stub case and out-of-scope
-// configurations are left to the caller's fallback).
+// CrossingCylinderCut returns target − tool for two crossing cylinders, or ok=false to defer (out-of-scope
+// configurations are left to the caller's fallback). Both subtraction directions are built from the same
+// imprint loops: when target is the fat cylinder the rod bores through, the result is the fat with a clean
+// tunnel (drillFatWithRod); when target is the rod, the result is the two disconnected rod stubs sticking
+// out either side of the fat (cutRodMinusFat).
 //
 // Example — a radius-3 cylinder drilled by a radius-1.5 rod:
 //
 //	fat, _  := brep.SolidCylinder(math.P3(0,0,-6), math.V3(0,0,1), 3, 12)
 //	thin, _ := brep.SolidCylinder(math.P3(-6,0,0), math.V3(1,0,0), 1.5, 12)
 //	res, ok := brep.CrossingCylinderCut(fat, thin) // fat with a tunnel
+//	res, ok = brep.CrossingCylinderCut(thin, fat)  // the two rod stubs
 func CrossingCylinderCut(target, tool *topo.Body) (*topo.Body, bool) {
 	p, ok := crossingPartsOf(target, tool)
 	if !ok {
 		return nil, false
 	}
-	tc, _, _, ok := cylinderSolidParams(facesOfAny(target))
-	if !ok || allLoopsEncircle([]geom.Polyline{p.lo, p.hi}, tc) {
-		return nil, false // target is the rod (rod−fat stubs): deferred to a later slice
-	}
 	if !loopsBetweenCaps(p.fat, p.fatBase, p.fatHeight, p.lo, p.hi) {
-		return nil, false // the tunnel reaches a cap (not a clean side breach): out of scope
+		return nil, false // the breach reaches a fat cap (not a clean side breach): out of scope
 	}
-	return drillFatWithRod(p), true
+	tc, _, _, ok := cylinderSolidParams(facesOfAny(target))
+	if !ok {
+		return nil, false
+	}
+	if allLoopsEncircle([]geom.Polyline{p.lo, p.hi}, tc) {
+		return cutRodMinusFat(p), true // target is the rod: two disconnected stubs
+	}
+	return drillFatWithRod(p), true // target is the fat: drill a tunnel
 }
 
 // crossingParts holds the resolved geometry of two crossing cylinders: the rod (both imprint loops encircle

--- a/kernel/brep/curved_crossing_cut_test.go
+++ b/kernel/brep/curved_crossing_cut_test.go
@@ -66,13 +66,30 @@ func countInnerLoops(f *topo.Face) int {
 	return n
 }
 
-// TestCrossingCylinderCutRodTargetDefers: rod − fat (the disconnected stub case) is not the drill; the
-// assembler declines so the caller keeps its fallback.
-func TestCrossingCylinderCutRodTargetDefers(t *testing.T) {
+// TestCrossingCylinderCutRodMinusFatStubs: rod − fat is the two disconnected rod stubs (the rod sticking
+// out either side of the fat). Each stub is a closed lump of three faces (the rod stub band, the rod end
+// cap, and the fat-wall lens), merged into one two-shell solid.
+func TestCrossingCylinderCutRodMinusFatStubs(t *testing.T) {
 	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
 	thin, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
-	if _, ok := CrossingCylinderCut(thin, fat); ok { // target is the rod
-		t.Error("rod − fat (stubs) should defer from the drill assembler (ok=false)")
+
+	res, ok := CrossingCylinderCut(thin, fat) // target is the rod
+	if !ok {
+		t.Fatal("rod − fat declined; want two disconnected rod stubs")
+	}
+	if !res.IsSolid() {
+		t.Fatalf("rod − fat result is not a solid: %+v", res)
+	}
+	if n := len(res.Shells()); n != 2 {
+		t.Errorf("rod − fat has %d shells, want 2 (a disconnected stub each side)", n)
+	}
+	for _, e := range res.Edges() {
+		if uses := len(e.Uses()); uses != 2 {
+			t.Errorf("edge %v has %d uses, want 2 (a closed manifold)", e.Lineage(), uses)
+		}
+	}
+	if n := len(res.Faces()); n != 6 {
+		t.Errorf("rod − fat has %d faces, want 6 (band + rod cap + lens, twice)", n)
 	}
 }
 

--- a/kernel/brep/curved_crossing_join.go
+++ b/kernel/brep/curved_crossing_join.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Crossing-cylinder join and rod−fat cut (M2 Phase 2, Oblikovati/Oblikovati#1335). The two boolean
+// outcomes that keep the rod material OUTSIDE the fat cylinder, assembled from the same imprint loops as the
+// drill (curved_crossing_cut.go) and sharing its rod stub builder:
+//
+//   - Join (fat ∪ rod): one connected solid — the fat's two caps and its holed side wall (reused from the
+//     drill), plus a rod-wall STUB protruding from each lens hole out to the rod's own end cap. Each lens
+//     edge is shared by the wall (as a hole) and its stub in opposite orientation, so the union is watertight.
+//   - Cut (rod − fat): two DISCONNECTED rod stubs (the rod sticking out either side of the fat), each a
+//     closed lump — a stub band, the rod end cap, and the fat-wall lens closing its inner end (the fat
+//     surface reversed, since the kept material is outside the fat). The two lumps are merged into one
+//     multi-shell body.
+
+// CrossingCylinderJoin builds fat ∪ rod for two crossing cylinders (a fat cylinder side-breached by a rod
+// passing right through it), or ok=false to defer (a non-cylinder operand, equal radii, or a breach that
+// reaches a fat cap) so kernel/ops keeps its fallback.
+//
+// Example — a radius-3 cylinder joined with a crossing radius-1.5 rod gives the fat with two rod stubs:
+//
+//	fat, _  := brep.SolidCylinder(math.P3(0,0,-6), math.V3(0,0,1), 3, 12)
+//	thin, _ := brep.SolidCylinder(math.P3(-6,0,0), math.V3(1,0,0), 1.5, 12)
+//	res, ok := brep.CrossingCylinderJoin(fat, thin)
+func CrossingCylinderJoin(a, b *topo.Body) (*topo.Body, bool) {
+	p, ok := crossingPartsOf(a, b)
+	if !ok {
+		return nil, false
+	}
+	if !loopsBetweenCaps(p.fat, p.fatBase, p.fatHeight, p.lo, p.hi) {
+		return nil, false // a stub would breach a fat cap, not the side wall: out of scope
+	}
+	return joinFatAndRod(p), true
+}
+
+// joinFatAndRod welds the union: the fat's two caps and its holed side wall (the two lens holes), plus a rod
+// stub out of each hole to the rod's end cap. Each lens edge is used by the wall (as a hole) and its stub in
+// opposite orientation, so every edge is used exactly twice — a closed manifold solid.
+func joinFatAndRod(p *crossingParts) *topo.Body {
+	bld := topo.NewBuilder(true, crossLin("body"))
+	vLo := bld.AddVertex(p.lo.Vertices[0], crossLin("vlo"))
+	vHi := bld.AddVertex(p.hi.Vertices[0], crossLin("vhi"))
+	eLo := bld.AddEdge(p.lo, vLo, vLo, crossLin("elo"))
+	eHi := bld.AddEdge(p.hi, vHi, vHi, crossLin("ehi"))
+	addFatCapsAndHoledWall(bld, p, eLo, eHi)
+	axis := p.rod.AxisDir.AsVector()
+	rodFar := p.rodBase.TranslateBy(axis.Scale(math.Scalar(p.rodHeight)))
+	// The lo lens (fat-outward along −rodaxis) connects to the rod's base end; the hi lens to the far end.
+	// The wall holes are InnerLoop(Rev(eLo)) and InnerLoop(Fwd(eHi)), so the stubs take the opposite half.
+	addRodStub(bld, p.rod, p.rodBase, axis.Scale(-1), eLo, vLo, p.lo.Vertices[0], true, "slo")
+	addRodStub(bld, p.rod, rodFar, axis, eHi, vHi, p.hi.Vertices[0], false, "shi")
+	return bld.Build()
+}
+
+// addRodStub adds one rod stub to a join/cut body: the rod-wall band from the lens loop out to the rod's
+// end cap, plus that planar end cap. The shared lens edge eLens is used in the orientation lensFwd so the
+// stub welds opposite to the face that owns the other side of it (the holed wall, or the fat lens cap). The
+// band keeps the rod's natural outward normal (the kept material is inside the rod); the end cap faces along
+// capNormal (the outward ±rod-axis). The end circle is re-seamed to the lens loop's start angle so the band
+// loft stitches a near-constant-angle seam.
+func addRodStub(bld *topo.Builder, rod geom.Cylinder, endCenter math.Point3, capNormal math.Vector3, eLens *topo.Edge, vLens *topo.Vertex, lensStart math.Point3, lensFwd bool, tag string) {
+	seamPt := stubSeamPoint(rod, endCenter, lensStart)
+	endC := seamedCircle(endCenter, rod.AxisDir, seamPt, rod.Radius)
+	vEnd := bld.AddVertex(seamPt, crossLin(tag+"ve"))
+	eEnd := bld.AddEdge(endC, vEnd, vEnd, crossLin(tag+"ee"))
+	eSeam := bld.AddEdge(geom.NewLineSegment(seamPt, lensStart), vEnd, vLens, crossLin(tag+"es"))
+	lensHalf := topo.Fwd(eLens)
+	if !lensFwd {
+		lensHalf = topo.Rev(eLens)
+	}
+	bld.AddFace(rod, crossLin(tag+"band"),
+		topo.OuterLoop(lensHalf, topo.Rev(eSeam), topo.Fwd(eEnd), topo.Fwd(eSeam)))
+	cap, _ := geom.NewPlane(endCenter, capNormal)
+	bld.AddFace(cap, crossLin(tag+"cap"), topo.OuterLoop(topo.Rev(eEnd)))
+}
+
+// stubSeamPoint returns the point on the rod's end circle at the same axial angle as the lens loop's start,
+// so the seam connecting them is a near-constant-angle ruling of the rod (lying on the surface).
+func stubSeamPoint(rod geom.Cylinder, endCenter, lensStart math.Point3) math.Point3 {
+	v := float64(rod.Origin.VectorTo(endCenter).Dot(rod.AxisDir.AsVector()))
+	return rod.PointAt(axisAngleOf(lensStart, rod), v)
+}
+
+// cutRodMinusFat builds rod − fat: the two rod stubs sticking out either side of the fat, each a separate
+// closed lump, merged into one multi-shell body (the boolean result is two disconnected pieces).
+func cutRodMinusFat(p *crossingParts) *topo.Body {
+	axis := p.rod.AxisDir.AsVector()
+	rodFar := p.rodBase.TranslateBy(axis.Scale(math.Scalar(p.rodHeight)))
+	lo := rodStubLump(p.rod, p.fat, p.rodBase, axis.Scale(-1), p.lo, "rlo")
+	hi := rodStubLump(p.rod, p.fat, rodFar, axis, p.hi, "rhi")
+	return topo.MergeBodies(crossLin("body"), true, lo, hi)
+}
+
+// rodStubLump builds one closed rod stub: its wall band, the rod end cap, and the fat-wall lens closing the
+// inner end. The lens cap is the fat surface REVERSED — the kept material is outside the fat, so the lens
+// normal points back into the fat (away from the stub). Its edge is shared with the stub band opposite.
+func rodStubLump(rod, fat geom.Cylinder, endCenter math.Point3, capNormal math.Vector3, lens geom.Polyline, tag string) *topo.Body {
+	bld := topo.NewBuilder(true, crossLin(tag))
+	vLens := bld.AddVertex(lens.Vertices[0], crossLin(tag+"vl"))
+	eLens := bld.AddEdge(lens, vLens, vLens, crossLin(tag+"el"))
+	bld.AddReversedFace(fat, crossLin(tag+"lenscap"), topo.OuterLoop(topo.Rev(eLens)))
+	addRodStub(bld, rod, endCenter, capNormal, eLens, vLens, lens.Vertices[0], true, tag)
+	return bld.Build()
+}

--- a/kernel/brep/curved_crossing_join_test.go
+++ b/kernel/brep/curved_crossing_join_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Crossing-cylinder join assembly (M2 Phase 2, Oblikovati/Oblikovati#1335). Joining a fat cylinder with a
+// crossing rod must weld into one watertight solid: the fat's two planar caps, its side wall carrying the
+// two lens holes, and a rod-wall stub out of each hole capped by the rod's own end disc. Volume is checked
+// through ops_test; here the concern is the watertight topology and that the surfaces stay analytic.
+
+// TestCrossingCylinderJoinStubs joins a radius-3 cylinder with a radius-1.5 rod and checks the result is a
+// watertight single-shell solid of seven analytic faces: two fat caps, the holed fat wall (two holes), two
+// rod stub bands, and two rod end caps.
+func TestCrossingCylinderJoinStubs(t *testing.T) {
+	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	thin, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
+
+	res, ok := CrossingCylinderJoin(fat, thin)
+	if !ok {
+		t.Fatal("join (fat ∪ rod) declined; want a single-shell stub solid")
+	}
+	if !res.IsSolid() {
+		t.Fatalf("join result is not a solid: %+v", res)
+	}
+	if n := len(res.Shells()); n != 1 {
+		t.Errorf("join has %d shells, want 1 (one connected body)", n)
+	}
+	for _, e := range res.Edges() {
+		if uses := len(e.Uses()); uses != 2 {
+			t.Errorf("edge %v has %d uses, want 2 (a closed manifold)", e.Lineage(), uses)
+		}
+	}
+	cyls, planes, holed := 0, 0, 0
+	for _, f := range res.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cylinder:
+			cyls++
+		case geom.Plane:
+			planes++
+		default:
+			t.Errorf("face surface %T is not analytic", f.Geometry())
+		}
+		if countInnerLoops(f) == 2 {
+			holed++ // the fat side wall with its two lens holes
+		}
+	}
+	if cyls != 3 || planes != 4 {
+		t.Errorf("got %d cylinder + %d planar faces, want 3 (fat wall + two stub bands) + 4 (two fat caps + two rod caps)", cyls, planes)
+	}
+	if holed != 1 {
+		t.Errorf("got %d faces with two holes, want 1 (the fat side wall)", holed)
+	}
+}
+
+// TestCrossingCylinderJoinNonCylinderDefers: the join only handles two bare cylinders.
+func TestCrossingCylinderJoinNonCylinderDefers(t *testing.T) {
+	block, _ := SolidBlock(math.P3(-2, -2, -2), math.P3(2, 2, 2), "b")
+	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 1, 12)
+	if _, ok := CrossingCylinderJoin(block, cyl); ok {
+		t.Error("a block ∪ cylinder should defer from the join assembler (ok=false)")
+	}
+}

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -122,7 +122,8 @@ func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.L
 //   - a curved solid ∩ a convex planar tool (a box) → composed half-space cuts (#1334);
 //   - a curved solid − a convex prism tunnelling through it (cylinder − box) (#1334);
 //   - two crossing cylinders ∩ (rod band + fat-wall lens caps) (#1335);
-//   - drilling a fat cylinder with a crossing rod (fat − rod) (#1335).
+//   - drilling a fat cylinder with a crossing rod (fat − rod), and the two rod stubs of rod − fat (#1335);
+//   - joining two crossing cylinders (fat ∪ rod: the fat with a rod stub each side) (#1335).
 func curvedExactBoolean(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
 	if body, ok := curvedConvexIntersect(op, target, tool); ok {
 		return body, true
@@ -133,7 +134,10 @@ func curvedExactBoolean(op PartFeatureOperation, target, tool *topo.Body) (*topo
 	if body, ok := curvedCrossingIntersect(op, target, tool); ok {
 		return body, true
 	}
-	return curvedCrossingCut(op, target, tool)
+	if body, ok := curvedCrossingCut(op, target, tool); ok {
+		return body, true
+	}
+	return curvedCrossingJoin(op, target, tool)
 }
 
 func shouldFallbackBoolean(op PartFeatureOperation, target, tool, body *topo.Body) bool {

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -29,13 +29,27 @@ func curvedCrossingIntersect(op PartFeatureOperation, target, tool *topo.Body) (
 }
 
 // curvedCrossingCut returns target − tool for two crossing cylinders (drilling a fat cylinder with a
-// crossing rod), or ok=false to defer. Only Cut maps here, and only a valid closed manifold result is
-// adopted.
+// crossing rod, or the two rod stubs of rod − fat), or ok=false to defer. Only Cut maps here, and only a
+// valid closed manifold result is adopted.
 func curvedCrossingCut(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
 	if op != Cut {
 		return nil, false
 	}
 	res, ok := brep.CrossingCylinderCut(target, tool)
+	if !ok || !validBooleanSolid(res) {
+		return nil, false
+	}
+	return res, true
+}
+
+// curvedCrossingJoin returns target ∪ tool for two crossing cylinders (a fat cylinder side-breached by a
+// rod passing through it, leaving a stub each side), or ok=false to defer. Only Join maps here, and only a
+// valid closed manifold result is adopted.
+func curvedCrossingJoin(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+	if op != Join {
+		return nil, false
+	}
+	res, ok := brep.CrossingCylinderJoin(target, tool)
 	if !ok || !validBooleanSolid(res) {
 		return nil, false
 	}

--- a/kernel/ops/boolean_crossing_cylinder_test.go
+++ b/kernel/ops/boolean_crossing_cylinder_test.go
@@ -98,6 +98,63 @@ func TestBooleanCutDrillCrossingCylinder(t *testing.T) {
 	}
 }
 
+// TestBooleanJoinCrossingCylinders joins a fat cylinder (R=3, axis z) with a crossing rod (r=1.5, axis x):
+// Join must give the connected analytic solid (fat caps, holed fat wall, a rod stub each side capped by the
+// rod's end disc) whose volume is fat + rod − the crossing intersection, not triangle-soup CSG.
+func TestBooleanJoinCrossingCylinders(t *testing.T) {
+	const rRod, hRod, rFat, hFat = 1.5, 12.0, 3.0, 12.0
+	fat, _ := brep.SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), rFat, hFat)
+	thin, _ := brep.SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), rRod, hRod)
+
+	res, err := ops.Boolean(ops.Join, fat, thin)
+	if err != nil {
+		t.Fatalf("Boolean(Join): %v", err)
+	}
+	if v := ops.Validate(res); !v.Valid || !v.Closed || !v.Manifold || !res.IsSolid() {
+		t.Fatalf("joined cylinders are not a valid closed manifold solid: %+v", v)
+	}
+	for _, f := range res.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cylinder, geom.Plane:
+		default:
+			t.Errorf("face surface %T is not analytic (the exact path must run, not CSG)", f.Geometry())
+		}
+	}
+	if n := len(res.Faces()); n != 7 {
+		t.Errorf("joined cylinders have %d faces, want 7 (two fat caps, holed wall, two stubs, two rod caps)", n)
+	}
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	want := stdmath.Pi*rFat*rFat*hFat + stdmath.Pi*rRod*rRod*hRod - crossingIntersectVolume(rRod, rFat)
+	if rel := stdmath.Abs(got-want) / want; rel > 0.04 {
+		t.Errorf("joined volume %.4f, want %.4f (fat + rod − intersection) — rel %.4f > 4%%", got, want, rel)
+	}
+}
+
+// TestBooleanCutRodMinusFatStubs subtracts a fat cylinder (R=3, axis z) from a crossing rod (r=1.5, axis x):
+// Cut must give the two disconnected rod stubs (a two-shell solid) whose total volume is the rod minus the
+// crossing intersection, not triangle-soup CSG.
+func TestBooleanCutRodMinusFatStubs(t *testing.T) {
+	const rRod, hRod, rFat = 1.5, 12.0, 3.0
+	fat, _ := brep.SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), rFat, 12)
+	thin, _ := brep.SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), rRod, hRod)
+
+	res, err := ops.Boolean(ops.Cut, thin, fat) // rod − fat
+	if err != nil {
+		t.Fatalf("Boolean(Cut rod−fat): %v", err)
+	}
+	if v := ops.Validate(res); !v.Valid || !v.Closed || !v.Manifold || !res.IsSolid() {
+		t.Fatalf("rod − fat is not a valid closed manifold solid: %+v", v)
+	}
+	if n := len(res.Shells()); n != 2 {
+		t.Errorf("rod − fat has %d shells, want 2 (a disconnected stub each side)", n)
+	}
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	want := stdmath.Pi*rRod*rRod*hRod - crossingIntersectVolume(rRod, rFat)
+	if rel := stdmath.Abs(got-want) / want; rel > 0.04 {
+		t.Errorf("rod − fat volume %.4f, want %.4f (rod − intersection) — rel %.4f > 4%%", got, want, rel)
+	}
+}
+
 // TestBooleanIntersectEqualRadiusDefersFromExactPath: two EQUAL-radius perpendicular cylinders are the
 // Steinmetz case the imprint tracer cannot trace cleanly, so the exact path must decline (leaving the
 // boolean to its fallback) rather than emit a wrong analytic solid.


### PR DESCRIPTION
## What

Completes the crossing-cylinder boolean (#1335) with the **two remaining outcomes** that keep the rod material *outside* the fat cylinder — `Boolean(Join, fat, rod)` and `Boolean(Cut, rod, fat)` — closing out the Cut **and** Join directive. Both are assembled straight from the same imprint loops as the drill (PR #1352) and preserve the exact analytic cylinder/plane surfaces instead of falling back to triangle-soup CSG.

- **Join (fat ∪ rod)** — one connected solid: the fat's two caps and its holed side wall (reused unchanged from the drill), plus a rod-wall **stub** protruding from each lens hole out to the rod's own end cap. Each lens edge is shared by the wall (as a hole) and its stub in opposite orientation → watertight.
- **Cut (rod − fat)** — the two **disconnected** rod stubs sticking out either side of the fat, each a closed lump (stub band + rod end cap + the fat-wall lens *reversed* to face back into the fat, since the kept material is outside it), merged into one two-shell body via `MergeBodies`.

## Why

The drill (fat − rod) shipped in #1352; these are the other three subtraction/union directions of the same crossing configuration, finishing the Phase 2 crossing-cylinder slice end-to-end through `ops.Boolean`.

## How it stays robust

- The rod **stub band** (a cap circle rim + a saddle lens rim) tessellates through the existing saddle-band loft — no new mesher needed.
- `CrossingCylinderCut` now routes the rod-target case to the stubs instead of deferring.
- Orientation is pinned by manifold edge-sharing (each shared edge used twice, opposite) and by volume oracles measured against the **analytic** crossing-cylinder intersection:
  - Join volume = fat + rod − intersection (rel < 4%)
  - rod − fat volume = rod − intersection (rel < 4%)
- Each result is validated closed + manifold + solid; anything out of scope returns `ok=false` so the CSG fallback is untouched.

## Tests

- `kernel/brep`: `TestCrossingCylinderJoinStubs` (7 analytic faces, single shell, every edge used twice), `TestCrossingCylinderCutRodMinusFatStubs` (two shells, 6 faces), non-cylinder defer guards.
- `kernel/ops`: `TestBooleanJoinCrossingCylinders` + `TestBooleanCutRodMinusFatStubs` (manifold + analytic-surface + volume-oracle through `ops.Boolean`).

Full `kernel/...` suite green; `golangci-lint` clean; `gofmt`/`go vet` clean.

Remaining Phase 2 (separate slices): equal-radius Steinmetz, partial penetration, cyl∩cone / cone∩cone SSI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)