### PR TITLE
feat: equal-radius Steinmetz cylinder intersection (M2 Phase 2)

### DIFF
--- a/kernel/brep/curved_steinmetz.go
+++ b/kernel/brep/curved_steinmetz.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Equal-radius Steinmetz intersection (M2 Phase 2, Oblikovati/Oblikovati#1335). Two EQUAL-radius
+// perpendicular cylinders crossing through a common axis point intersect in the Steinmetz bicylinder. This
+// is the degenerate case the SSI imprint tracer cannot trace: the intersection curve is NOT a quartic
+// saddle but two planar ELLIPSES that cross at two pinch points (where the tracer's continuation stalls),
+// so it is fitted analytically here instead.
+//
+// Geometry in the frame (a = axis A, b = axis B, n = a×b) through the axis crossing O, with equal radius R:
+// a surface point O + α·a + β·b + γ·n is on cyl A when β²+γ²=R² and on cyl B when α²+γ²=R², so on both when
+// β=±α. The two intersection ellipses therefore lie in the planes β=α and β=−α; they meet only where
+// α=β=0, i.e. at the PINCH points O±R·n. The bicylinder boundary is four cylinder patches (two lobes of
+// each cylinder, split at the pinch points), each bounded by one arc of each ellipse, all four meeting at
+// the two pinch vertices. Every lobe carries its cylinder's natural outward normal (the solid is inside
+// both cylinders), and every elliptical arc is shared by one A-lobe and one B-lobe in opposite orientation,
+// so the result is a closed manifold solid of exactly four analytic faces.
+
+// steinLin tags the assembled Steinmetz body's topology (one entity per role, so the index is always 0).
+func steinLin(role string) topo.Lineage { return topo.NewLineage(topo.Tok("steinmetz", role, 0)) }
+
+// EqualRadiusSteinmetzIntersect builds the exact intersection of two equal-radius perpendicular cylinders
+// (the Steinmetz bicylinder), or ok=false when the configuration is outside that case (unequal radii,
+// non-perpendicular or non-intersecting axes, or a cylinder too short to contain the bicylinder) so
+// kernel/ops keeps its CSG fallback.
+//
+// Example — two radius-3 cylinders on x and z crossing at the origin gives the four-face bicylinder:
+//
+//	cx, _ := brep.SolidCylinder(math.P3(-6,0,0), math.V3(1,0,0), 3, 12)
+//	cz, _ := brep.SolidCylinder(math.P3(0,0,-6), math.V3(0,0,1), 3, 12)
+//	res, ok := brep.EqualRadiusSteinmetzIntersect(cx, cz)
+func EqualRadiusSteinmetzIntersect(a, b *topo.Body) (*topo.Body, bool) {
+	o, dirA, dirB, r, ok := steinmetzFrame(a, b)
+	if !ok {
+		return nil, false
+	}
+	return buildSteinmetz(o, dirA, dirB, r), true
+}
+
+// steinmetzFrame resolves two bodies into the Steinmetz frame: the axis crossing point O, the two unit axis
+// directions, and the shared radius R. ok=false unless both are bare cylinders of equal radius whose axes
+// are perpendicular, cross, and whose finite extents each reach at least R either side of O (so the
+// bicylinder is not clipped by a cap).
+func steinmetzFrame(a, b *topo.Body) (o math.Point3, dirA, dirB math.Vector3, r float64, ok bool) {
+	ca, baseA, hA, okA := cylinderSolidParams(facesOfAny(a))
+	cb, baseB, hB, okB := cylinderSolidParams(facesOfAny(b))
+	if !okA || !okB || !nearEqual(ca.Radius, cb.Radius) {
+		return math.Point3{}, math.Vector3{}, math.Vector3{}, 0, false
+	}
+	dirA, dirB = ca.AxisDir.AsVector(), cb.AxisDir.AsVector()
+	if !math.IsNearZero(dirA.Dot(dirB), 1e-7) { // axes must be perpendicular
+		return math.Point3{}, math.Vector3{}, math.Vector3{}, 0, false
+	}
+	lineA, _ := geom.NewLine(ca.Origin, dirA)
+	lineB, _ := geom.NewLine(cb.Origin, dirB)
+	o, ok = geom.LineLineIntersection(lineA, lineB, 1e-6)
+	if !ok || !axisReachesR(ca, baseA, hA, o) || !axisReachesR(cb, baseB, hB, o) {
+		return math.Point3{}, math.Vector3{}, math.Vector3{}, 0, false
+	}
+	return o, dirA, dirB, ca.Radius, true
+}
+
+// axisReachesR reports whether the cylinder's finite extent reaches at least its radius either side of O
+// along the axis — the condition for the bicylinder (which spans ±R about O on each axis) to lie strictly
+// between the caps rather than be clipped by one.
+func axisReachesR(c geom.Cylinder, base math.Point3, height float64, o math.Point3) bool {
+	axis := c.AxisDir.AsVector()
+	vBase := float64(c.Origin.VectorTo(base).Dot(axis))
+	vO := float64(c.Origin.VectorTo(o).Dot(axis))
+	return vO-c.Radius >= vBase-1e-9 && vO+c.Radius <= vBase+height+1e-9
+}
+
+// buildSteinmetz welds the four cylinder lobes of the bicylinder. The four elliptical arcs (two ellipses,
+// each split at the pinch vertices into a front and a back arc) are created once and shared: every arc is
+// used by one A-lobe and one B-lobe in opposite orientation, so every edge is used exactly twice. Each lobe
+// cylinder is framed with its reference pointing at the lobe centre, so the lobe is a contractible patch
+// (it never wraps the seam) that the trimmed-patch mesher handles directly.
+func buildSteinmetz(o math.Point3, dirA, dirB math.Vector3, r float64) *topo.Body {
+	n := dirA.Cross(dirB)
+	bld := topo.NewBuilder(true, steinLin("body"))
+	vMinus := bld.AddVertex(o.TranslateBy(n.Scale(math.Scalar(-r))), steinLin("pinchlo"))
+	vPlus := bld.AddVertex(o.TranslateBy(n.Scale(math.Scalar(r))), steinLin("pinchhi"))
+	ePF, ePB, eMF, eMB := steinmetzArcs(o, dirA, dirB, r)
+	e1 := bld.AddEdge(ePF, vMinus, vPlus, steinLin("e+front"))    // E+ front: P− → P+
+	e2 := bld.AddEdge(ePB, vPlus, vMinus, steinLin("e+back"))     // E+ back:  P+ → P−
+	e3 := bld.AddEdge(eMF, vMinus, vPlus, steinLin("e-front"))    // E− front: P− → P+
+	e4 := bld.AddEdge(eMB, vPlus, vMinus, steinLin("e-back"))     // E− back:  P+ → P−
+	cA1, _ := geom.NewCylinderWithRef(o, dirA, dirB, r)           // A lobe on +b
+	cA2, _ := geom.NewCylinderWithRef(o, dirA, dirB.Scale(-1), r) // A lobe on −b
+	cB1, _ := geom.NewCylinderWithRef(o, dirB, dirA, r)           // B lobe on +a
+	cB2, _ := geom.NewCylinderWithRef(o, dirB, dirA.Scale(-1), r) // B lobe on −a
+	bld.AddFace(cA1, steinLin("a1"), topo.OuterLoop(topo.Fwd(e1), topo.Fwd(e4)))
+	bld.AddFace(cA2, steinLin("a2"), topo.OuterLoop(topo.Rev(e2), topo.Rev(e3)))
+	bld.AddFace(cB1, steinLin("b1"), topo.OuterLoop(topo.Rev(e1), topo.Fwd(e3)))
+	bld.AddFace(cB2, steinLin("b2"), topo.OuterLoop(topo.Rev(e4), topo.Fwd(e2)))
+	return bld.Build()
+}
+
+// steinmetzArcs builds the four elliptical-arc edges of the bicylinder. The E+ ellipse lies in the plane
+// spanned by (a+b) and n (its major axis is a+b, length R√2; its minor axis is n, length R); the E−
+// ellipse lies in the plane spanned by (a−b) and n. Each ellipse passes through both pinch points O±R·n at
+// angles ±π/2, so the front arc (sweep starting at −π/2) runs P− → P+ and the back arc (starting at +π/2)
+// runs P+ → P−.
+func steinmetzArcs(o math.Point3, dirA, dirB math.Vector3, r float64) (ePlusFront, ePlusBack, eMinusFront, eMinusBack geom.EllipticalArc) {
+	majorR := stdmath.Sqrt2 * r
+	sum, diff := dirA.Add(dirB), dirA.Sub(dirB)
+	const start, sweep = -stdmath.Pi / 2, stdmath.Pi
+	// E+ (β=α): Normal = a−b, MajorAxis = a+b, so the minor direction Normal×MajorAxis = n.
+	ePlusFront, _ = geom.NewEllipticalArc(o, diff, sum, majorR, r, start, sweep)
+	ePlusBack, _ = geom.NewEllipticalArc(o, diff, sum, majorR, r, start+sweep, sweep)
+	// E− (β=−α): Normal = −(a+b), MajorAxis = a−b, so again the minor direction is n.
+	eMinusFront, _ = geom.NewEllipticalArc(o, sum.Scale(-1), diff, majorR, r, start, sweep)
+	eMinusBack, _ = geom.NewEllipticalArc(o, sum.Scale(-1), diff, majorR, r, start+sweep, sweep)
+	return ePlusFront, ePlusBack, eMinusFront, eMinusBack
+}
+
+// nearEqual reports whether two lengths are equal to a small relative tolerance (the Steinmetz case needs
+// the two cylinder radii to match).
+func nearEqual(x, y float64) bool {
+	return stdmath.Abs(x-y) <= 1e-7*(1+stdmath.Max(stdmath.Abs(x), stdmath.Abs(y)))
+}

--- a/kernel/brep/curved_steinmetz_test.go
+++ b/kernel/brep/curved_steinmetz_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Equal-radius Steinmetz intersection (M2 Phase 2, Oblikovati/Oblikovati#1335). Two equal-radius
+// perpendicular cylinders intersect in the bicylinder: four cylindrical lobe faces sharing four elliptical
+// arcs and two pinch vertices. Volume is checked through ops_test; here the concern is the watertight
+// topology and that the surfaces and edges stay analytic (cylinder faces, elliptical-arc edges).
+
+// TestSteinmetzIsWatertightFourFaces intersects two radius-3 cylinders (axes x and z) and checks the result
+// is a watertight four-face solid: every face a cylinder, every edge an elliptical arc used exactly twice,
+// two pinch vertices.
+func TestSteinmetzIsWatertightFourFaces(t *testing.T) {
+	cx, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 3, 12)
+	cz, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+
+	res, ok := EqualRadiusSteinmetzIntersect(cx, cz)
+	if !ok {
+		t.Fatal("Steinmetz intersection declined; want a four-face bicylinder")
+	}
+	if !res.IsSolid() {
+		t.Fatalf("Steinmetz result is not a solid: %+v", res)
+	}
+	if n := len(res.Faces()); n != 4 {
+		t.Errorf("Steinmetz has %d faces, want 4 (two lobes per cylinder)", n)
+	}
+	for _, f := range res.Faces() {
+		if _, isCyl := f.Geometry().(geom.Cylinder); !isCyl {
+			t.Errorf("face surface %T is not a cylinder", f.Geometry())
+		}
+	}
+	for _, e := range res.Edges() {
+		if uses := len(e.Uses()); uses != 2 {
+			t.Errorf("edge %v has %d uses, want 2 (a closed manifold)", e.Lineage(), uses)
+		}
+		if _, isArc := e.Geometry().(geom.EllipticalArc); !isArc {
+			t.Errorf("edge %v geometry %T is not an elliptical arc", e.Lineage(), e.Geometry())
+		}
+	}
+	if n := len(res.Edges()); n != 4 {
+		t.Errorf("Steinmetz has %d edges, want 4 (two ellipses, each split at the pinch points)", n)
+	}
+	if n := len(res.Vertices()); n != 2 {
+		t.Errorf("Steinmetz has %d vertices, want 2 (the pinch points)", n)
+	}
+}
+
+// TestSteinmetzUnequalRadiusDefers: unequal radii are the clean thin-through-fat case (handled by the SSI
+// imprint path), not Steinmetz, so this assembler declines.
+func TestSteinmetzUnequalRadiusDefers(t *testing.T) {
+	cx, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
+	cz, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	if _, ok := EqualRadiusSteinmetzIntersect(cx, cz); ok {
+		t.Error("unequal-radius crossing should defer from the Steinmetz assembler (ok=false)")
+	}
+}
+
+// TestSteinmetzNonCrossingDefers: equal-radius cylinders whose axes do not intersect (skew/offset) are not
+// the Steinmetz case.
+func TestSteinmetzNonCrossingDefers(t *testing.T) {
+	cx, _ := SolidCylinder(math.P3(-6, 0, 5), math.V3(1, 0, 0), 3, 12) // offset in z, axes do not meet
+	cz, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	if _, ok := EqualRadiusSteinmetzIntersect(cx, cz); ok {
+		t.Error("non-crossing equal-radius cylinders should defer (ok=false)")
+	}
+}

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -122,6 +122,7 @@ func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.L
 //   - a curved solid ∩ a convex planar tool (a box) → composed half-space cuts (#1334);
 //   - a curved solid − a convex prism tunnelling through it (cylinder − box) (#1334);
 //   - two crossing cylinders ∩ (rod band + fat-wall lens caps) (#1335);
+//   - two EQUAL-radius perpendicular cylinders ∩ (the Steinmetz bicylinder, fitted as crossing ellipses) (#1335);
 //   - drilling a fat cylinder with a crossing rod (fat − rod), and the two rod stubs of rod − fat (#1335);
 //   - joining two crossing cylinders (fat ∪ rod: the fat with a rod stub each side) (#1335).
 func curvedExactBoolean(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
@@ -132,6 +133,9 @@ func curvedExactBoolean(op PartFeatureOperation, target, tool *topo.Body) (*topo
 		return body, true
 	}
 	if body, ok := curvedCrossingIntersect(op, target, tool); ok {
+		return body, true
+	}
+	if body, ok := curvedSteinmetzIntersect(op, target, tool); ok {
 		return body, true
 	}
 	if body, ok := curvedCrossingCut(op, target, tool); ok {

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -28,6 +28,21 @@ func curvedCrossingIntersect(op PartFeatureOperation, target, tool *topo.Body) (
 	return res, true
 }
 
+// curvedSteinmetzIntersect returns the exact intersection of two equal-radius perpendicular cylinders (the
+// Steinmetz bicylinder), or ok=false to defer. Only Intersect maps here, and only a valid closed manifold
+// result is adopted. This is the equal-radius case the SSI imprint tracer cannot trace (it pinches), fitted
+// analytically as two crossing ellipses instead.
+func curvedSteinmetzIntersect(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+	if op != Intersect {
+		return nil, false
+	}
+	res, ok := brep.EqualRadiusSteinmetzIntersect(target, tool)
+	if !ok || !validBooleanSolid(res) {
+		return nil, false
+	}
+	return res, true
+}
+
 // curvedCrossingCut returns target − tool for two crossing cylinders (drilling a fat cylinder with a
 // crossing rod, or the two rod stubs of rod − fat), or ok=false to defer. Only Cut maps here, and only a
 // valid closed manifold result is adopted.

--- a/kernel/ops/boolean_crossing_cylinder_test.go
+++ b/kernel/ops/boolean_crossing_cylinder_test.go
@@ -155,6 +155,40 @@ func TestBooleanCutRodMinusFatStubs(t *testing.T) {
 	}
 }
 
+// TestBooleanIntersectEqualRadiusSteinmetz intersects two EQUAL-radius perpendicular cylinders (axes x and
+// z, R=3): Intersect must give the exact Steinmetz bicylinder — four analytic cylinder faces — whose volume
+// is the closed form 16/3·R³, not triangle-soup CSG (the SSI tracer pinches on this case, so it is fitted
+// analytically as two crossing ellipses).
+func TestBooleanIntersectEqualRadiusSteinmetz(t *testing.T) {
+	const r = 3.0
+	cx, _ := brep.SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), r, 12)
+	cz, _ := brep.SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), r, 12)
+
+	res, err := ops.Boolean(ops.Intersect, cx, cz)
+	if err != nil {
+		t.Fatalf("Boolean(Intersect equal-radius): %v", err)
+	}
+	if v := ops.Validate(res); !v.Valid || !v.Closed || !v.Manifold || !res.IsSolid() {
+		t.Fatalf("Steinmetz bicylinder is not a valid closed manifold solid: %+v", v)
+	}
+	for _, f := range res.Faces() {
+		if _, ok := f.Geometry().(geom.Cylinder); !ok {
+			t.Errorf("face surface %T is not analytic (the exact path must run, not CSG)", f.Geometry())
+		}
+	}
+	if n := len(res.Faces()); n != 4 {
+		t.Errorf("Steinmetz has %d faces, want 4 (two lobes per cylinder)", n)
+	}
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	want := 16.0 / 3.0 * r * r * r // the Steinmetz bicylinder volume
+	// 4%: the four lobes inscribe their curvature and pinch to a sharp corner at each pinch vertex, so the
+	// meshed volume runs a little under the analytic 16/3·R³ (the B-rep is exact; this bounds the
+	// property-mesh error, ~2.5% at DefaultQuality).
+	if rel := stdmath.Abs(got-want) / want; rel > 0.04 {
+		t.Errorf("Steinmetz volume %.4f, want %.4f (16/3·R³) — rel %.4f > 4%%", got, want, rel)
+	}
+}
+
 // TestBooleanIntersectEqualRadiusDefersFromExactPath: two EQUAL-radius perpendicular cylinders are the
 // Steinmetz case the imprint tracer cannot trace cleanly, so the exact path must decline (leaving the
 // boolean to its fallback) rather than emit a wrong analytic solid.


### PR DESCRIPTION
## What

Handles the **equal-radius Steinmetz** case of the crossing-cylinder boolean (#1335) — the one the SSI imprint tracer cannot trace. `Boolean(Intersect, cylA, cylB)` for two **equal-radius perpendicular cylinders** crossing through a common axis point now produces the exact **Steinmetz bicylinder** (four analytic cylinder faces) instead of falling back to triangle-soup CSG.

## Why the tracer couldn't do it

For unequal radii the intersection is a clean pair of quartic saddle loops (the rod entry/exit), which the predictor–corrector tracer marches fine. For **equal** radii the intersection degenerates: in the frame `(a, b, n=a×b)` through the axis crossing `O`, a surface point is on both cylinders exactly when `β=±α`, so the intersection is **two planar ellipses** (in the planes `β=±α`) that **cross at two pinch points** `O±R·n`. The tracer's continuation stalls at those pinches — so the curves are **fitted analytically** here as exact `geom.EllipticalArc`s rather than traced.

## How the solid is assembled

The bicylinder boundary is **four cylinder lobes** (two of each cylinder, split at the pinch points), each bounded by one arc of each ellipse, all four meeting at the two pinch vertices:

- 2 pinch vertices `O±R·n`, 4 elliptical-arc edges (each ellipse split front/back at the pinches).
- Each arc is shared by one A-lobe and one B-lobe in **opposite orientation** → every edge used exactly twice (closed manifold).
- Every lobe carries its cylinder's **natural outward normal** (the solid is inside both cylinders).
- Each lobe cylinder is framed with its reference pointing at the lobe centre, so the lobe is a **contractible** patch (never wraps the seam) and meshes through the existing trimmed-patch (`metricPatchMesh`) path — no new mesher.

Detection (`steinmetzFrame`) gates strictly: two bare cylinders, equal radii, perpendicular axes that actually cross (`geom.LineLineIntersection`), and each finite extent reaching at least `R` either side of `O` (so the bicylinder isn't clipped by a cap). Anything else returns `ok=false` → CSG fallback untouched.

## Tests

- `kernel/brep`: `TestSteinmetzIsWatertightFourFaces` (4 cylinder faces, 4 elliptical-arc edges each used twice, 2 pinch vertices, solid), plus unequal-radius and non-crossing defer guards.
- `kernel/ops`: `TestBooleanIntersectEqualRadiusSteinmetz` — through `ops.Boolean`, validated closed + manifold + analytic-surface, volume against the closed form **16/3·R³** (measured 2.5% under at DefaultQuality from the lobes' chord inscription + pinch corners; 4% tolerance).

Full `kernel/...` suite green; `golangci-lint` clean; `gofmt`/`go vet` clean.

Remaining Phase 2 (separate slices): partial penetration (rod not fully crossing → open band / blind lens), and cyl∩cone / cone∩cone SSI. (Equal-radius Cut/Join are a possible follow-up; this slice ships the canonical Steinmetz intersection.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)