### PR TITLE
feat: partial-penetration crossing-cylinder intersection (M2 Phase 2)

### DIFF
--- a/kernel/brep/curved_crossing_cut.go
+++ b/kernel/brep/curved_crossing_cut.go
@@ -73,8 +73,8 @@ func crossingPartsOf(a, b *topo.Body) (*crossingParts, bool) {
 		return nil, false
 	}
 	rod, rodBase, rodH, fat, fatBase, fatH, ok := orderRodFat(loops, ca, baseA, hA, cb, baseB, hB)
-	if !ok {
-		return nil, false
+	if !ok || !loopsSpanRod(rod, rodBase, rodH, loops) {
+		return nil, false // a loop beyond a rod end is a partial penetration, not a full crossing
 	}
 	lo, hi, ok := assignRimLoops(rod, fat, loops)
 	if !ok {

--- a/kernel/brep/curved_crossing_intersect.go
+++ b/kernel/brep/curved_crossing_intersect.go
@@ -37,9 +37,9 @@ func CrossingCylinderIntersect(a, b *topo.Body) (*topo.Body, bool) {
 	if !ok || len(loops) != 2 {
 		return nil, false
 	}
-	rod, fat, ok := rodAndFatCylinders(a, b, loops)
-	if !ok {
-		return nil, false
+	rod, fat, rodBase, rodHeight, ok := rodAndFatCylinders(a, b, loops)
+	if !ok || !loopsSpanRod(rod, rodBase, rodHeight, loops) {
+		return nil, false // a loop beyond a rod end is a partial penetration, not a full crossing
 	}
 	lo, hi, ok := assignRimLoops(rod, fat, loops)
 	if !ok {
@@ -49,21 +49,41 @@ func CrossingCylinderIntersect(a, b *topo.Body) (*topo.Body, bool) {
 }
 
 // rodAndFatCylinders picks which cylinder is the rod (the band-bearing one both imprint loops fully
-// encircle) and which is the fat cylinder (the lens-capped one). ok=false when neither or both qualify.
-func rodAndFatCylinders(a, b *topo.Body, loops []geom.Polyline) (rod, fat geom.Cylinder, ok bool) {
-	ca, _, _, okA := cylinderSolidParams(facesOfAny(a))
-	cb, _, _, okB := cylinderSolidParams(facesOfAny(b))
+// encircle) and which is the fat cylinder (the lens-capped one), carrying the rod's cap base and height
+// through. ok=false when neither or both qualify.
+func rodAndFatCylinders(a, b *topo.Body, loops []geom.Polyline) (rod, fat geom.Cylinder, rodBase math.Point3, rodHeight float64, ok bool) {
+	ca, baseA, hA, okA := cylinderSolidParams(facesOfAny(a))
+	cb, baseB, hB, okB := cylinderSolidParams(facesOfAny(b))
 	if !okA || !okB {
-		return geom.Cylinder{}, geom.Cylinder{}, false
+		return geom.Cylinder{}, geom.Cylinder{}, math.Point3{}, 0, false
 	}
 	aWraps, bWraps := allLoopsEncircle(loops, ca), allLoopsEncircle(loops, cb)
 	if aWraps && !bWraps {
-		return ca, cb, true
+		return ca, cb, baseA, hA, true
 	}
 	if bWraps && !aWraps {
-		return cb, ca, true
+		return cb, ca, baseB, hB, true
 	}
-	return geom.Cylinder{}, geom.Cylinder{}, false
+	return geom.Cylinder{}, geom.Cylinder{}, math.Point3{}, 0, false
+}
+
+// loopsSpanRod reports whether every imprint loop lies within the rod's finite axial extent (between its end
+// caps). The imprint is traced on the two infinite cylinder surfaces, so a thin rod that ENDS inside the fat
+// still yields two loops when traced fat-first — but the second (the would-be exit) sits beyond the rod's
+// end. When that happens the rod does not actually cross, so the full-crossing assemblers must defer and let
+// the partial-penetration path (curved_partial_penetration.go) handle it.
+func loopsSpanRod(rod geom.Cylinder, rodBase math.Point3, rodHeight float64, loops []geom.Polyline) bool {
+	axis := rod.AxisDir.AsVector()
+	vBase := float64(rod.Origin.VectorTo(rodBase).Dot(axis))
+	for _, lp := range loops {
+		for _, p := range lp.Vertices {
+			s := float64(rod.Origin.VectorTo(p).Dot(axis)) - vBase
+			if s < -1e-7 || s > rodHeight+1e-7 {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // allLoopsEncircle reports whether every loop winds a full turn about the cylinder's axis — the test that

--- a/kernel/brep/curved_partial_penetration.go
+++ b/kernel/brep/curved_partial_penetration.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Partial-penetration crossing-cylinder intersection (M2 Phase 2, Oblikovati/Oblikovati#1335). A thin rod
+// that does NOT fully cross the fatter cylinder — it breaches one wall and ENDS inside, its blind end cap
+// sitting within the fat solid. The rod surface then meets the fat surface in just ONE imprint loop (the
+// single entry breach), not the two of a full crossing, so this case falls outside CrossingCylinderIntersect
+// (which needs two loops) and is assembled here instead.
+//
+// The intersection (rod ∩ fat) is the rod "plug" inside the fat: three analytic faces — the fat-wall LENS
+// cap (the one breach), the rod-wall stub BAND from that lens out to the rod's blind end, and the rod's
+// blind END cap (the flat disc, wholly inside the fat). The lens edge is shared by the lens cap and the
+// stub band, and the end circle by the stub band and the end cap, both in opposite orientation, so the plug
+// is a closed manifold solid. The stub band and end cap reuse the rod stub builder shared with the join and
+// drill (curved_crossing_join.go).
+
+// partLin tags the assembled plug body's topology (one entity per role, so the index is always 0).
+func partLin(role string) topo.Lineage { return topo.NewLineage(topo.Tok("partpen", role, 0)) }
+
+// PartialPenetrationIntersect builds the exact intersection of a thin rod that ends inside a fatter
+// cylinder (the rod plug), or ok=false when the configuration is outside that case (not exactly one imprint
+// loop, neither cylinder is the rod the loop encircles, or no rod end lies cleanly inside the other) so
+// kernel/ops keeps its CSG fallback.
+//
+// Example — a radius-1.5 rod on x ending at the centre of a radius-3 cylinder on z gives a three-face plug:
+//
+//	fat, _  := brep.SolidCylinder(math.P3(0,0,-6), math.V3(0,0,1), 3, 12)
+//	stub, _ := brep.SolidCylinder(math.P3(-6,0,0), math.V3(1,0,0), 1.5, 6) // ends at x=0, inside the fat
+//	res, ok := brep.PartialPenetrationIntersect(fat, stub)
+func PartialPenetrationIntersect(a, b *topo.Body) (*topo.Body, bool) {
+	p, ok := partialPlugPartsOf(a, b)
+	if !ok {
+		return nil, false
+	}
+	return partialPlug(p), true
+}
+
+// partialPlugParts holds the resolved geometry of a partial penetration: the rod (the single imprint loop
+// encircles it) and the fat cylinder, the rod's blind end cap (centre and outward normal, sitting inside
+// the fat), and the single entry imprint loop oriented CCW about the rod axis.
+type partialPlugParts struct {
+	rod, fat     geom.Cylinder
+	rodEndCenter math.Point3
+	rodEndNormal math.Vector3
+	lens         geom.Polyline
+}
+
+// partialPlugPartsOf resolves two bodies into a partial penetration, or ok=false when they are not a thin
+// rod ending inside a fatter cylinder. The imprint is traced on the FIRST body's surface within that body's
+// axial window, so it must be traced with the ROD first: the rod's short extent then clips the would-be
+// exit loop of the two infinite surfaces, leaving the single entry loop (tracing fat-first would window the
+// full crossing and return both loops). Which body is the rod is unknown up front, so both orderings are
+// tried; the rod-first ordering is the one that yields exactly one loop encircling that body and exactly one
+// of that body's ends inside the other.
+func partialPlugPartsOf(a, b *topo.Body) (*partialPlugParts, bool) {
+	if p, ok := tryPartialPlug(a, b); ok {
+		return p, true
+	}
+	return tryPartialPlug(b, a)
+}
+
+// tryPartialPlug resolves a partial plug treating rodBody as the penetrating rod (traced first), or
+// ok=false when that does not hold: not exactly one imprint loop, the loop does not encircle rodBody, or
+// not exactly one of rodBody's ends lies inside fatBody.
+func tryPartialPlug(rodBody, fatBody *topo.Body) (*partialPlugParts, bool) {
+	loops, ok := crossingCylinderImprint(rodBody, fatBody)
+	if !ok || len(loops) != 1 {
+		return nil, false
+	}
+	rod, rodBase, rodH, okR := cylinderSolidParams(facesOfAny(rodBody))
+	fat, fatBase, fatH, okF := cylinderSolidParams(facesOfAny(fatBody))
+	if !okR || !okF || !allLoopsEncircle(loops, rod) {
+		return nil, false
+	}
+	center, normal, ok := blindRodEnd(rod, rodBase, rodH, fat, fatBase, fatH)
+	if !ok {
+		return nil, false
+	}
+	return &partialPlugParts{rod, fat, center, normal, orientLoopCCW(loops[0], rod)}, true
+}
+
+// blindRodEnd returns the rod end cap that lies inside the fat solid (the blind tip of a partial
+// penetration) — its centre and the outward axial normal (pointing away from the rod material). ok=false
+// unless exactly one of the rod's two ends is inside the fat (both inside is a rod fully contained, neither
+// is a full crossing — both handled elsewhere).
+func blindRodEnd(rod geom.Cylinder, rodBase math.Point3, rodH float64, fat geom.Cylinder, fatBase math.Point3, fatH float64) (center math.Point3, normal math.Vector3, ok bool) {
+	axis := rod.AxisDir.AsVector()
+	e0 := rodBase
+	e1 := rodBase.TranslateBy(axis.Scale(math.Scalar(rodH)))
+	in0 := rodEndInsideFat(rod, e0, fat, fatBase, fatH)
+	in1 := rodEndInsideFat(rod, e1, fat, fatBase, fatH)
+	switch {
+	case in1 && !in0:
+		return e1, axis, true // blind end at the +axis extreme: material lies below it, normal points +axis
+	case in0 && !in1:
+		return e0, axis.Scale(-1), true // blind end at the base: material lies above it, normal points −axis
+	default:
+		return math.Point3{}, math.Vector3{}, false
+	}
+}
+
+// rodEndInsideFat reports whether the whole rod end circle (radius = rod radius, centre = end) lies strictly
+// inside the fat solid — sampled around the circle so a tilted disc is judged by its actual extent, not just
+// its centre. This is the condition for the blind end cap to be a clean disc wholly within the fat.
+func rodEndInsideFat(rod geom.Cylinder, center math.Point3, fat geom.Cylinder, fatBase math.Point3, fatH float64) bool {
+	const samples = 24
+	for k := 0; k < samples; k++ {
+		ang := 2 * stdmath.Pi * float64(k) / samples
+		p := center.TranslateBy(rod.NormalAt(ang, 0).Scale(math.Scalar(rod.Radius)))
+		if !pointInsideCylinderSolid(fat, fatBase, fatH, p) {
+			return false
+		}
+	}
+	return true
+}
+
+// pointInsideCylinderSolid reports whether p is strictly inside the finite cylinder solid — within the
+// radius and between the caps, by a small margin so a point on the surface counts as outside.
+func pointInsideCylinderSolid(c geom.Cylinder, base math.Point3, height float64, p math.Point3) bool {
+	const margin = 1e-7
+	if float64(radialOf(p, c).Length()) > c.Radius-margin {
+		return false
+	}
+	axis := c.AxisDir.AsVector()
+	vBase := float64(c.Origin.VectorTo(base).Dot(axis))
+	v := float64(c.Origin.VectorTo(p).Dot(axis))
+	return v >= vBase+margin && v <= vBase+height-margin
+}
+
+// partialPlug welds the three faces of the rod plug: the fat-wall lens cap (the fat surface, natural
+// outward normal — the plug is inside the fat), the rod stub band out to the blind end, and the rod's blind
+// end cap. The lens edge is shared by the lens cap (reversed) and the stub band (forward), so the plug is a
+// closed manifold solid.
+func partialPlug(p *partialPlugParts) *topo.Body {
+	bld := topo.NewBuilder(true, partLin("body"))
+	lensStart := p.lens.Vertices[0]
+	vLens := bld.AddVertex(lensStart, partLin("vlens"))
+	eLens := bld.AddEdge(p.lens, vLens, vLens, partLin("elens"))
+	bld.AddFace(p.fat, partLin("lenscap"), topo.OuterLoop(topo.Rev(eLens)))
+	addRodStub(bld, p.rod, p.rodEndCenter, p.rodEndNormal, eLens, vLens, lensStart, true, "plug")
+	return bld.Build()
+}

--- a/kernel/brep/curved_partial_penetration_test.go
+++ b/kernel/brep/curved_partial_penetration_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Partial-penetration intersection (M2 Phase 2, Oblikovati/Oblikovati#1335). A thin rod ending inside a
+// fatter cylinder intersects it in the rod plug: a lens cap on the fat wall, a rod stub band, and the rod's
+// blind end cap. Volume is checked through ops_test; here the concern is the watertight topology and that
+// the surfaces stay analytic (two cylinder faces and one planar end cap).
+
+// TestPartialPenetrationPlugIsWatertight intersects a radius-3 cylinder with a radius-1.5 rod that ends at
+// the fat centre and checks the result is a watertight three-face solid: the fat-wall lens, the rod stub
+// band, and the planar blind end cap.
+func TestPartialPenetrationPlugIsWatertight(t *testing.T) {
+	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	stub, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 6) // ends at x=0, inside the fat
+
+	res, ok := PartialPenetrationIntersect(fat, stub)
+	if !ok {
+		t.Fatal("partial-penetration intersection declined; want a three-face plug")
+	}
+	if !res.IsSolid() {
+		t.Fatalf("plug result is not a solid: %+v", res)
+	}
+	for _, e := range res.Edges() {
+		if uses := len(e.Uses()); uses != 2 {
+			t.Errorf("edge %v has %d uses, want 2 (a closed manifold)", e.Lineage(), uses)
+		}
+	}
+	cyls, planes := 0, 0
+	for _, f := range res.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cylinder:
+			cyls++
+		case geom.Plane:
+			planes++
+		default:
+			t.Errorf("face surface %T is not analytic", f.Geometry())
+		}
+	}
+	if cyls != 2 || planes != 1 {
+		t.Errorf("got %d cylinder + %d planar faces, want 2 (lens + stub band) + 1 (blind end cap)", cyls, planes)
+	}
+}
+
+// TestPartialPenetrationFullCrossingDefers: a rod that crosses all the way through gives two imprint loops,
+// not the single loop of a partial penetration, so the plug assembler declines.
+func TestPartialPenetrationFullCrossingDefers(t *testing.T) {
+	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	thru, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12) // spans both walls
+	if _, ok := PartialPenetrationIntersect(fat, thru); ok {
+		t.Error("a full crossing (two loops) should defer from the plug assembler (ok=false)")
+	}
+}
+
+// TestPartialPenetrationContainedRodDefers: a rod wholly inside the fat never breaches a wall (no imprint
+// loop), so the plug assembler declines (the intersection is the whole rod, handled elsewhere).
+func TestPartialPenetrationContainedRodDefers(t *testing.T) {
+	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	inside, _ := SolidCylinder(math.P3(-1, 0, 0), math.V3(1, 0, 0), 0.5, 2) // x∈[-1,1], wholly inside
+	if _, ok := PartialPenetrationIntersect(fat, inside); ok {
+		t.Error("a fully-contained rod should defer from the plug assembler (ok=false)")
+	}
+}

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -123,6 +123,7 @@ func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.L
 //   - a curved solid − a convex prism tunnelling through it (cylinder − box) (#1334);
 //   - two crossing cylinders ∩ (rod band + fat-wall lens caps) (#1335);
 //   - two EQUAL-radius perpendicular cylinders ∩ (the Steinmetz bicylinder, fitted as crossing ellipses) (#1335);
+//   - a thin rod ending inside a fatter cylinder ∩ (the rod plug: a partial penetration) (#1335);
 //   - drilling a fat cylinder with a crossing rod (fat − rod), and the two rod stubs of rod − fat (#1335);
 //   - joining two crossing cylinders (fat ∪ rod: the fat with a rod stub each side) (#1335).
 func curvedExactBoolean(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
@@ -136,6 +137,9 @@ func curvedExactBoolean(op PartFeatureOperation, target, tool *topo.Body) (*topo
 		return body, true
 	}
 	if body, ok := curvedSteinmetzIntersect(op, target, tool); ok {
+		return body, true
+	}
+	if body, ok := curvedPartialIntersect(op, target, tool); ok {
 		return body, true
 	}
 	if body, ok := curvedCrossingCut(op, target, tool); ok {

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -43,6 +43,20 @@ func curvedSteinmetzIntersect(op PartFeatureOperation, target, tool *topo.Body) 
 	return res, true
 }
 
+// curvedPartialIntersect returns the exact intersection of a thin rod ending inside a fatter cylinder (the
+// rod plug), or ok=false to defer. Only Intersect maps here, and only a valid closed manifold result is
+// adopted. This is the partial-penetration case the imprint traces as a single loop (one wall breach).
+func curvedPartialIntersect(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+	if op != Intersect {
+		return nil, false
+	}
+	res, ok := brep.PartialPenetrationIntersect(target, tool)
+	if !ok || !validBooleanSolid(res) {
+		return nil, false
+	}
+	return res, true
+}
+
 // curvedCrossingCut returns target − tool for two crossing cylinders (drilling a fat cylinder with a
 // crossing rod, or the two rod stubs of rod − fat), or ok=false to defer. Only Cut maps here, and only a
 // valid closed manifold result is adopted.

--- a/kernel/ops/boolean_crossing_cylinder_test.go
+++ b/kernel/ops/boolean_crossing_cylinder_test.go
@@ -155,6 +155,39 @@ func TestBooleanCutRodMinusFatStubs(t *testing.T) {
 	}
 }
 
+// TestBooleanIntersectPartialPenetration intersects a fat cylinder (R=3, axis z) with a thin rod (r=1.5,
+// axis x) that ENDS at the fat centre: Intersect must give the exact three-face plug (fat-wall lens, rod
+// stub band, blind end cap). Because the rod stops at the centre, the plug is exactly half the full-crossing
+// intersection, so its volume is crossingIntersectVolume(r,R)/2, not triangle-soup CSG.
+func TestBooleanIntersectPartialPenetration(t *testing.T) {
+	const rRod, rFat = 1.5, 3.0
+	fat, _ := brep.SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), rFat, 12)
+	stub, _ := brep.SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), rRod, 6) // ends at x=0, inside the fat
+
+	res, err := ops.Boolean(ops.Intersect, fat, stub)
+	if err != nil {
+		t.Fatalf("Boolean(Intersect partial): %v", err)
+	}
+	if v := ops.Validate(res); !v.Valid || !v.Closed || !v.Manifold || !res.IsSolid() {
+		t.Fatalf("rod plug is not a valid closed manifold solid: %+v", v)
+	}
+	for _, f := range res.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cylinder, geom.Plane:
+		default:
+			t.Errorf("face surface %T is not analytic (the exact path must run, not CSG)", f.Geometry())
+		}
+	}
+	if n := len(res.Faces()); n != 3 {
+		t.Errorf("rod plug has %d faces, want 3 (lens, stub band, blind end cap)", n)
+	}
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	want := crossingIntersectVolume(rRod, rFat) / 2 // the plug is half the full crossing intersection
+	if rel := stdmath.Abs(got-want) / want; rel > 0.02 {
+		t.Errorf("plug volume %.4f, want %.4f (half the crossing intersection) — rel %.4f > 2%%", got, want, rel)
+	}
+}
+
 // TestBooleanIntersectEqualRadiusSteinmetz intersects two EQUAL-radius perpendicular cylinders (axes x and
 // z, R=3): Intersect must give the exact Steinmetz bicylinder — four analytic cylinder faces — whose volume
 // is the closed form 16/3·R³, not triangle-soup CSG (the SSI tracer pinches on this case, so it is fitted


### PR DESCRIPTION
## What

Handles **partial penetration** of the crossing-cylinder boolean (#1335): a thin rod that does **not** fully cross the fatter cylinder but **ends inside it** (its blind end cap sits within the fat solid). `Boolean(Intersect, fat, rod)` now produces the exact analytic **rod plug** instead of falling back to CSG.

## The case

A full crossing breaches both walls (two imprint loops). A partial penetration breaches **one** wall and stops: the rod surface meets the fat surface in a **single** loop, and the rod's flat end cap lies wholly inside the fat. The intersection (rod ∩ fat) is the rod plug — three analytic faces:

- the **fat-wall lens** cap (the one breach, on the fat surface),
- the **rod-wall stub band** from that lens out to the blind end (reuses the stub builder from #1353),
- the rod's **blind end cap** (the flat disc, inside the fat).

The lens edge is shared by the lens cap and stub band, and the end circle by the stub band and end cap, both opposite-oriented → a closed manifold solid.

## Two fixes that made it correct

1. **Trace rod-first.** The imprint is traced on the *first* body's surface within that body's axial window. Tracing fat-first windows the full crossing and returns *both* loops (the infinite surfaces always cross twice); tracing **rod-first** lets the rod's short extent clip the would-be exit loop, leaving the single entry loop. Which body is the rod is unknown up front, so both orderings are tried.

2. **Defer the full-crossing path on a phantom.** The full-crossing assemblers (`CrossingCylinderIntersect`, and the Cut/Join resolver `crossingPartsOf`) traced the two *infinite* surfaces and built a result even when the rod ended inside the fat — producing a solid that extends past the rod's real end (a phantom that measured ≈ the *full* crossing volume). They now defer (`loopsSpanRod`) when an imprint loop sits beyond a rod end, leaving the partial case to the new path. This is a latent correctness fix in #1350/#1352/#1353, with no change for genuine full crossings.

## Tests

- `kernel/brep`: `TestPartialPenetrationPlugIsWatertight` (three analytic faces, every edge used twice, solid), plus full-crossing and fully-contained defer guards.
- `kernel/ops`: `TestBooleanIntersectPartialPenetration` — through `ops.Boolean`, validated closed + manifold + analytic-surface; a rod stopping at the fat centre makes the plug exactly half the full crossing, so volume is checked against `crossingIntersectVolume(r,R)/2` (within 2%).
- All existing crossing-cylinder Intersect/Cut/Join tests still pass (the `loopsSpanRod` guard is a no-op for full crossings).

Full `kernel/...` suite green; `golangci-lint` clean; `gofmt`/`go vet` clean.

Remaining Phase 2 (separate slices): partial-penetration **Cut** (blind hole) and **Join** (one-sided stub) — same building blocks, opposite orientations; equal-radius Cut/Join; cyl∩cone / cone∩cone SSI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)