### PR TITLE
feat: partial-penetration blind hole and one-sided join (M2 Phase 2)

### DIFF
--- a/kernel/brep/curved_crossing_cut.go
+++ b/kernel/brep/curved_crossing_cut.go
@@ -126,21 +126,22 @@ func drillFatWithRod(p *crossingParts) *topo.Body {
 	// The tunnel wall is the rod band flipped inward (kept material is outside the rod).
 	bld.AddReversedFace(p.rod, crossLin("tunnel"),
 		topo.OuterLoop(topo.Fwd(rSeam), topo.Rev(eHi), topo.Rev(rSeam), topo.Fwd(eLo)))
-	addFatCapsAndHoledWall(bld, p, eLo, eHi)
+	addFatCapsAndHoledWall(bld, p.fat, p.fatBase, p.fatHeight, clearSeamParam(p.fat, p.lo, p.hi),
+		topo.Rev(eLo), topo.Fwd(eHi))
 	return bld.Build()
 }
 
-// addFatCapsAndHoledWall adds the fat cylinder's two planar caps and its holed side wall, sharing the two
-// imprint-loop edges (as wall holes, opposite to the tunnel band's use of them). The wall's seam is placed
-// clear of the lens holes so the unroll-and-CDT mesher can mesh it.
-func addFatCapsAndHoledWall(bld *topo.Builder, p *crossingParts, eLo, eHi *topo.Edge) {
-	axis := p.fat.AxisDir.AsVector()
-	vBot := float64(p.fat.Origin.VectorTo(p.fatBase).Dot(axis))
-	topCenter := p.fatBase.TranslateBy(axis.Scale(math.Scalar(p.fatHeight)))
-	seam := clearSeamParam(p.fat, p.lo, p.hi)
-	seamBot, seamTop := p.fat.PointAt(seam, vBot), p.fat.PointAt(seam, vBot+p.fatHeight)
-	botC := seamedCircle(p.fatBase, p.fat.AxisDir, seamBot, p.fat.Radius)
-	topC := seamedCircle(topCenter, p.fat.AxisDir, seamTop, p.fat.Radius)
+// addFatCapsAndHoledWall adds the fat cylinder's two planar caps and its side wall carrying the given hole
+// loops (one per wall breach). seam is an angular parameter placed clear of every hole (the unroll-and-CDT
+// mesher needs a hole-free seam); each hole use is the lens-loop edge in the orientation OPPOSITE the band
+// that fills it from the other side, so every edge stays used exactly twice.
+func addFatCapsAndHoledWall(bld *topo.Builder, fat geom.Cylinder, fatBase math.Point3, fatHeight, seam float64, holes ...topo.Use) {
+	axis := fat.AxisDir.AsVector()
+	vBot := float64(fat.Origin.VectorTo(fatBase).Dot(axis))
+	topCenter := fatBase.TranslateBy(axis.Scale(math.Scalar(fatHeight)))
+	seamBot, seamTop := fat.PointAt(seam, vBot), fat.PointAt(seam, vBot+fatHeight)
+	botC := seamedCircle(fatBase, fat.AxisDir, seamBot, fat.Radius)
+	topC := seamedCircle(topCenter, fat.AxisDir, seamTop, fat.Radius)
 
 	vb := bld.AddVertex(seamBot, crossLin("fvb"))
 	vt := bld.AddVertex(seamTop, crossLin("fvt"))
@@ -148,13 +149,15 @@ func addFatCapsAndHoledWall(bld *topo.Builder, p *crossingParts, eLo, eHi *topo.
 	eTop := bld.AddEdge(topC, vt, vt, crossLin("fetop"))
 	eSeam := bld.AddEdge(geom.NewLineSegment(seamBot, seamTop), vb, vt, crossLin("fseam"))
 
-	capBot, _ := geom.NewPlane(p.fatBase, axis.Scale(-1))
+	capBot, _ := geom.NewPlane(fatBase, axis.Scale(-1))
 	capTop, _ := geom.NewPlane(topCenter, axis)
 	bld.AddFace(capBot, crossLin("fcapbot"), topo.OuterLoop(topo.Rev(eBot)))
 	bld.AddFace(capTop, crossLin("fcaptop"), topo.OuterLoop(topo.Fwd(eTop)))
-	bld.AddFace(p.fat, crossLin("fwall"),
-		topo.OuterLoop(topo.Fwd(eSeam), topo.Rev(eTop), topo.Rev(eSeam), topo.Fwd(eBot)),
-		topo.InnerLoop(topo.Rev(eLo)), topo.InnerLoop(topo.Fwd(eHi)))
+	wallLoops := []topo.LoopSpec{topo.OuterLoop(topo.Fwd(eSeam), topo.Rev(eTop), topo.Rev(eSeam), topo.Fwd(eBot))}
+	for _, h := range holes {
+		wallLoops = append(wallLoops, topo.InnerLoop(h))
+	}
+	bld.AddFace(fat, crossLin("fwall"), wallLoops...)
 }
 
 // clearSeamParam returns an angular parameter on the fat cylinder midway through the larger gap between the
@@ -168,6 +171,13 @@ func clearSeamParam(fat geom.Cylinder, lo, hi geom.Polyline) float64 {
 		return (a + b) / 2 // the gap from a to b is the larger one
 	}
 	return (a+b)/2 + stdmath.Pi // the gap wrapping past 0 is larger
+}
+
+// clearSeamForLens returns an angular parameter on the fat cylinder diametrically opposite a single lens
+// hole, so a seam placed there crosses the hole-free side of the wall (the holed-wall mesher needs a
+// hole-free seam).
+func clearSeamForLens(fat geom.Cylinder, lens geom.Polyline) float64 {
+	return axisAngleOf(loopCentroid(lens), fat) + stdmath.Pi
 }
 
 // seamedCircle builds a cap circle whose angle-zero seam vertex is at seamPt (radius and centre on the

--- a/kernel/brep/curved_crossing_join.go
+++ b/kernel/brep/curved_crossing_join.go
@@ -49,23 +49,26 @@ func joinFatAndRod(p *crossingParts) *topo.Body {
 	vHi := bld.AddVertex(p.hi.Vertices[0], crossLin("vhi"))
 	eLo := bld.AddEdge(p.lo, vLo, vLo, crossLin("elo"))
 	eHi := bld.AddEdge(p.hi, vHi, vHi, crossLin("ehi"))
-	addFatCapsAndHoledWall(bld, p, eLo, eHi)
+	addFatCapsAndHoledWall(bld, p.fat, p.fatBase, p.fatHeight, clearSeamParam(p.fat, p.lo, p.hi),
+		topo.Rev(eLo), topo.Fwd(eHi))
 	axis := p.rod.AxisDir.AsVector()
 	rodFar := p.rodBase.TranslateBy(axis.Scale(math.Scalar(p.rodHeight)))
 	// The lo lens (fat-outward along −rodaxis) connects to the rod's base end; the hi lens to the far end.
 	// The wall holes are InnerLoop(Rev(eLo)) and InnerLoop(Fwd(eHi)), so the stubs take the opposite half.
-	addRodStub(bld, p.rod, p.rodBase, axis.Scale(-1), eLo, vLo, p.lo.Vertices[0], true, "slo")
-	addRodStub(bld, p.rod, rodFar, axis, eHi, vHi, p.hi.Vertices[0], false, "shi")
+	addRodStub(bld, p.rod, p.rodBase, axis.Scale(-1), eLo, vLo, p.lo.Vertices[0], true, false, "slo")
+	addRodStub(bld, p.rod, rodFar, axis, eHi, vHi, p.hi.Vertices[0], false, false, "shi")
 	return bld.Build()
 }
 
 // addRodStub adds one rod stub to a join/cut body: the rod-wall band from the lens loop out to the rod's
 // end cap, plus that planar end cap. The shared lens edge eLens is used in the orientation lensFwd so the
 // stub welds opposite to the face that owns the other side of it (the holed wall, or the fat lens cap). The
-// band keeps the rod's natural outward normal (the kept material is inside the rod); the end cap faces along
-// capNormal (the outward ±rod-axis). The end circle is re-seamed to the lens loop's start angle so the band
+// band keeps the rod's natural outward normal (the kept material is inside the rod) when reversed is false;
+// when reversed is true it is flipped inward as a tunnel wall (the kept material is outside the rod, e.g. a
+// blind hole) and the end cap faces back into the void. The end cap faces along capNormal (the outward
+// ±rod-axis), negated when reversed. The end circle is re-seamed to the lens loop's start angle so the band
 // loft stitches a near-constant-angle seam.
-func addRodStub(bld *topo.Builder, rod geom.Cylinder, endCenter math.Point3, capNormal math.Vector3, eLens *topo.Edge, vLens *topo.Vertex, lensStart math.Point3, lensFwd bool, tag string) {
+func addRodStub(bld *topo.Builder, rod geom.Cylinder, endCenter math.Point3, capNormal math.Vector3, eLens *topo.Edge, vLens *topo.Vertex, lensStart math.Point3, lensFwd, reversed bool, tag string) {
 	seamPt := stubSeamPoint(rod, endCenter, lensStart)
 	endC := seamedCircle(endCenter, rod.AxisDir, seamPt, rod.Radius)
 	vEnd := bld.AddVertex(seamPt, crossLin(tag+"ve"))
@@ -75,9 +78,15 @@ func addRodStub(bld *topo.Builder, rod geom.Cylinder, endCenter math.Point3, cap
 	if !lensFwd {
 		lensHalf = topo.Rev(eLens)
 	}
-	bld.AddFace(rod, crossLin(tag+"band"),
-		topo.OuterLoop(lensHalf, topo.Rev(eSeam), topo.Fwd(eEnd), topo.Fwd(eSeam)))
-	cap, _ := geom.NewPlane(endCenter, capNormal)
+	band := topo.OuterLoop(lensHalf, topo.Rev(eSeam), topo.Fwd(eEnd), topo.Fwd(eSeam))
+	capNorm := capNormal
+	if reversed {
+		bld.AddReversedFace(rod, crossLin(tag+"band"), band)
+		capNorm = capNormal.Scale(-1)
+	} else {
+		bld.AddFace(rod, crossLin(tag+"band"), band)
+	}
+	cap, _ := geom.NewPlane(endCenter, capNorm)
 	bld.AddFace(cap, crossLin(tag+"cap"), topo.OuterLoop(topo.Rev(eEnd)))
 }
 
@@ -106,6 +115,6 @@ func rodStubLump(rod, fat geom.Cylinder, endCenter math.Point3, capNormal math.V
 	vLens := bld.AddVertex(lens.Vertices[0], crossLin(tag+"vl"))
 	eLens := bld.AddEdge(lens, vLens, vLens, crossLin(tag+"el"))
 	bld.AddReversedFace(fat, crossLin(tag+"lenscap"), topo.OuterLoop(topo.Rev(eLens)))
-	addRodStub(bld, rod, endCenter, capNormal, eLens, vLens, lens.Vertices[0], true, tag)
+	addRodStub(bld, rod, endCenter, capNormal, eLens, vLens, lens.Vertices[0], true, false, tag)
 	return bld.Build()
 }

--- a/kernel/brep/curved_partial_penetration.go
+++ b/kernel/brep/curved_partial_penetration.go
@@ -45,13 +45,16 @@ func PartialPenetrationIntersect(a, b *topo.Body) (*topo.Body, bool) {
 }
 
 // partialPlugParts holds the resolved geometry of a partial penetration: the rod (the single imprint loop
-// encircles it) and the fat cylinder, the rod's blind end cap (centre and outward normal, sitting inside
-// the fat), and the single entry imprint loop oriented CCW about the rod axis.
+// encircles it) and the fat cylinder; the rod's blind end cap (inside the fat) and its entry end cap
+// (outside the fat), each as a centre and outward axial normal; the single entry imprint loop oriented CCW
+// about the rod axis; and the fat cylinder's cap base and height (for the wall the Cut and Join carry).
 type partialPlugParts struct {
-	rod, fat     geom.Cylinder
-	rodEndCenter math.Point3
-	rodEndNormal math.Vector3
-	lens         geom.Polyline
+	rod, fat                 geom.Cylinder
+	blindCenter, entryCenter math.Point3
+	blindNormal, entryNormal math.Vector3
+	lens                     geom.Polyline
+	fatBase                  math.Point3
+	fatHeight                float64
 }
 
 // partialPlugPartsOf resolves two bodies into a partial penetration, or ok=false when they are not a thin
@@ -81,30 +84,36 @@ func tryPartialPlug(rodBody, fatBody *topo.Body) (*partialPlugParts, bool) {
 	if !okR || !okF || !allLoopsEncircle(loops, rod) {
 		return nil, false
 	}
-	center, normal, ok := blindRodEnd(rod, rodBase, rodH, fat, fatBase, fatH)
+	blindC, blindN, entryC, entryN, ok := rodEnds(rod, rodBase, rodH, fat, fatBase, fatH)
 	if !ok {
 		return nil, false
 	}
-	return &partialPlugParts{rod, fat, center, normal, orientLoopCCW(loops[0], rod)}, true
+	return &partialPlugParts{
+		rod: rod, fat: fat,
+		blindCenter: blindC, blindNormal: blindN,
+		entryCenter: entryC, entryNormal: entryN,
+		lens:    orientLoopCCW(loops[0], rod),
+		fatBase: fatBase, fatHeight: fatH,
+	}, true
 }
 
-// blindRodEnd returns the rod end cap that lies inside the fat solid (the blind tip of a partial
-// penetration) — its centre and the outward axial normal (pointing away from the rod material). ok=false
-// unless exactly one of the rod's two ends is inside the fat (both inside is a rod fully contained, neither
-// is a full crossing — both handled elsewhere).
-func blindRodEnd(rod geom.Cylinder, rodBase math.Point3, rodH float64, fat geom.Cylinder, fatBase math.Point3, fatH float64) (center math.Point3, normal math.Vector3, ok bool) {
+// rodEnds returns the rod's blind end cap (inside the fat — the tip of a partial penetration) and its entry
+// end cap (outside the fat — where the rod sticks out), each as a centre and the outward axial normal
+// (pointing away from the rod material). ok=false unless exactly one of the rod's two ends is inside the fat
+// (both inside is a rod fully contained, neither is a full crossing — both handled elsewhere).
+func rodEnds(rod geom.Cylinder, rodBase math.Point3, rodH float64, fat geom.Cylinder, fatBase math.Point3, fatH float64) (blindCenter math.Point3, blindNormal math.Vector3, entryCenter math.Point3, entryNormal math.Vector3, ok bool) {
 	axis := rod.AxisDir.AsVector()
 	e0 := rodBase
 	e1 := rodBase.TranslateBy(axis.Scale(math.Scalar(rodH)))
 	in0 := rodEndInsideFat(rod, e0, fat, fatBase, fatH)
 	in1 := rodEndInsideFat(rod, e1, fat, fatBase, fatH)
 	switch {
-	case in1 && !in0:
-		return e1, axis, true // blind end at the +axis extreme: material lies below it, normal points +axis
-	case in0 && !in1:
-		return e0, axis.Scale(-1), true // blind end at the base: material lies above it, normal points −axis
+	case in1 && !in0: // blind end at the +axis extreme (e1), entry end at the base (e0)
+		return e1, axis, e0, axis.Scale(-1), true
+	case in0 && !in1: // blind end at the base (e0), entry end at the +axis extreme (e1)
+		return e0, axis.Scale(-1), e1, axis, true
 	default:
-		return math.Point3{}, math.Vector3{}, false
+		return math.Point3{}, math.Vector3{}, math.Point3{}, math.Vector3{}, false
 	}
 }
 
@@ -146,6 +155,71 @@ func partialPlug(p *partialPlugParts) *topo.Body {
 	vLens := bld.AddVertex(lensStart, partLin("vlens"))
 	eLens := bld.AddEdge(p.lens, vLens, vLens, partLin("elens"))
 	bld.AddFace(p.fat, partLin("lenscap"), topo.OuterLoop(topo.Rev(eLens)))
-	addRodStub(bld, p.rod, p.rodEndCenter, p.rodEndNormal, eLens, vLens, lensStart, true, "plug")
+	addRodStub(bld, p.rod, p.blindCenter, p.blindNormal, eLens, vLens, lensStart, true, false, "plug")
+	return bld.Build()
+}
+
+// PartialPenetrationCut builds target − tool when tool is a thin rod that ends inside the fatter target (a
+// BLIND HOLE), or ok=false to defer. The result is the fat with a blind cylindrical pocket: its two caps,
+// its side wall carrying the single lens hole, the rod-wall tunnel flipped inward, and the rod's blind end
+// cap as the pocket bottom.
+//
+// Example — a radius-3 cylinder blind-drilled by a radius-1.5 rod ending at its centre:
+//
+//	fat, _  := brep.SolidCylinder(math.P3(0,0,-6), math.V3(0,0,1), 3, 12)
+//	stub, _ := brep.SolidCylinder(math.P3(-6,0,0), math.V3(1,0,0), 1.5, 6)
+//	res, ok := brep.PartialPenetrationCut(fat, stub) // fat with a blind pocket
+func PartialPenetrationCut(target, tool *topo.Body) (*topo.Body, bool) {
+	p, ok := partialPlugPartsOf(target, tool)
+	if !ok || !targetIsFat(target, p) {
+		return nil, false // only fat − rod is the blind hole; rod − fat (a stub lump) defers for now
+	}
+	return blindHole(p), true
+}
+
+// PartialPenetrationJoin builds target ∪ tool for a thin rod ending inside the fatter cylinder, or ok=false
+// to defer. The result is the fat with a single rod STUB sticking out the entry side: the fat's two caps,
+// its holed side wall, the rod-wall stub band from the lens out to the rod's entry end, and the rod's entry
+// end cap.
+func PartialPenetrationJoin(a, b *topo.Body) (*topo.Body, bool) {
+	p, ok := partialPlugPartsOf(a, b)
+	if !ok {
+		return nil, false
+	}
+	return partialJoinStub(p), true
+}
+
+// targetIsFat reports whether the Cut target is the fat cylinder of the resolved partial penetration (so the
+// subtraction is the blind hole), rather than the rod.
+func targetIsFat(target *topo.Body, p *partialPlugParts) bool {
+	tc, _, _, ok := cylinderSolidParams(facesOfAny(target))
+	return ok && nearEqual(tc.Radius, p.fat.Radius)
+}
+
+// blindHole welds the fat with a blind pocket: the fat caps and holed side wall (one lens hole), the rod
+// tunnel flipped inward (kept material is outside the rod), and the rod's blind end cap as the pocket
+// bottom. The lens edge is shared by the wall hole and the tunnel band in opposite orientation, so the
+// result is a closed manifold solid.
+func blindHole(p *partialPlugParts) *topo.Body {
+	bld := topo.NewBuilder(true, partLin("body"))
+	lensStart := p.lens.Vertices[0]
+	vLens := bld.AddVertex(lensStart, partLin("vlens"))
+	eLens := bld.AddEdge(p.lens, vLens, vLens, partLin("elens"))
+	addFatCapsAndHoledWall(bld, p.fat, p.fatBase, p.fatHeight, clearSeamForLens(p.fat, p.lens), topo.Rev(eLens))
+	addRodStub(bld, p.rod, p.blindCenter, p.blindNormal, eLens, vLens, lensStart, true, true, "blind")
+	return bld.Build()
+}
+
+// partialJoinStub welds the union of the fat and a partially-penetrating rod: the fat caps and holed side
+// wall (one lens hole), the rod stub band from the lens out to the rod's entry end, and the rod's entry end
+// cap. The lens edge is shared by the wall hole and the stub band in opposite orientation, so the result is
+// a closed manifold solid.
+func partialJoinStub(p *partialPlugParts) *topo.Body {
+	bld := topo.NewBuilder(true, partLin("body"))
+	lensStart := p.lens.Vertices[0]
+	vLens := bld.AddVertex(lensStart, partLin("vlens"))
+	eLens := bld.AddEdge(p.lens, vLens, vLens, partLin("elens"))
+	addFatCapsAndHoledWall(bld, p.fat, p.fatBase, p.fatHeight, clearSeamForLens(p.fat, p.lens), topo.Rev(eLens))
+	addRodStub(bld, p.rod, p.entryCenter, p.entryNormal, eLens, vLens, lensStart, true, false, "jstub")
 	return bld.Build()
 }

--- a/kernel/brep/curved_partial_penetration_test.go
+++ b/kernel/brep/curved_partial_penetration_test.go
@@ -49,6 +49,82 @@ func TestPartialPenetrationPlugIsWatertight(t *testing.T) {
 	}
 }
 
+// TestPartialPenetrationBlindHoleIsWatertight cuts a radius-1.5 rod (ending at the fat centre) from a
+// radius-3 cylinder and checks the blind pocket is a watertight solid: two fat caps, the holed fat wall
+// (one hole), the rod tunnel, and the blind end cap.
+func TestPartialPenetrationBlindHoleIsWatertight(t *testing.T) {
+	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	stub, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 6)
+
+	res, ok := PartialPenetrationCut(fat, stub)
+	if !ok {
+		t.Fatal("blind-hole cut declined; want a five-face pocketed solid")
+	}
+	if !res.IsSolid() {
+		t.Fatalf("blind hole result is not a solid: %+v", res)
+	}
+	for _, e := range res.Edges() {
+		if uses := len(e.Uses()); uses != 2 {
+			t.Errorf("edge %v has %d uses, want 2 (a closed manifold)", e.Lineage(), uses)
+		}
+	}
+	cyls, planes, holed := 0, 0, 0
+	for _, f := range res.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cylinder:
+			cyls++
+		case geom.Plane:
+			planes++
+		default:
+			t.Errorf("face surface %T is not analytic", f.Geometry())
+		}
+		if countInnerLoops(f) == 1 {
+			holed++ // the fat side wall with its one lens hole
+		}
+	}
+	if cyls != 2 || planes != 3 {
+		t.Errorf("got %d cylinder + %d planar faces, want 2 (holed wall + tunnel) + 3 (two fat caps + blind bottom)", cyls, planes)
+	}
+	if holed != 1 {
+		t.Errorf("got %d faces with one hole, want 1 (the pocketed wall)", holed)
+	}
+}
+
+// TestPartialPenetrationJoinIsWatertight joins a radius-1.5 rod (ending at the fat centre) with a radius-3
+// cylinder and checks the result is a watertight solid: two fat caps, the holed fat wall (one hole), the rod
+// stub band, and the rod's entry end cap.
+func TestPartialPenetrationJoinIsWatertight(t *testing.T) {
+	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	stub, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 6)
+
+	res, ok := PartialPenetrationJoin(fat, stub)
+	if !ok {
+		t.Fatal("partial-penetration join declined; want a five-face stubbed solid")
+	}
+	if !res.IsSolid() {
+		t.Fatalf("join result is not a solid: %+v", res)
+	}
+	for _, e := range res.Edges() {
+		if uses := len(e.Uses()); uses != 2 {
+			t.Errorf("edge %v has %d uses, want 2 (a closed manifold)", e.Lineage(), uses)
+		}
+	}
+	cyls, planes := 0, 0
+	for _, f := range res.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cylinder:
+			cyls++
+		case geom.Plane:
+			planes++
+		default:
+			t.Errorf("face surface %T is not analytic", f.Geometry())
+		}
+	}
+	if cyls != 2 || planes != 3 {
+		t.Errorf("got %d cylinder + %d planar faces, want 2 (holed wall + stub band) + 3 (two fat caps + entry cap)", cyls, planes)
+	}
+}
+
 // TestPartialPenetrationFullCrossingDefers: a rod that crosses all the way through gives two imprint loops,
 // not the single loop of a partial penetration, so the plug assembler declines.
 func TestPartialPenetrationFullCrossingDefers(t *testing.T) {

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -123,7 +123,7 @@ func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.L
 //   - a curved solid − a convex prism tunnelling through it (cylinder − box) (#1334);
 //   - two crossing cylinders ∩ (rod band + fat-wall lens caps) (#1335);
 //   - two EQUAL-radius perpendicular cylinders ∩ (the Steinmetz bicylinder, fitted as crossing ellipses) (#1335);
-//   - a thin rod ending inside a fatter cylinder ∩ (the rod plug: a partial penetration) (#1335);
+//   - a thin rod ending inside a fatter cylinder ∩/−/∪ (a partial penetration: the plug, a blind hole, a one-sided stub) (#1335);
 //   - drilling a fat cylinder with a crossing rod (fat − rod), and the two rod stubs of rod − fat (#1335);
 //   - joining two crossing cylinders (fat ∪ rod: the fat with a rod stub each side) (#1335).
 func curvedExactBoolean(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
@@ -140,6 +140,12 @@ func curvedExactBoolean(op PartFeatureOperation, target, tool *topo.Body) (*topo
 		return body, true
 	}
 	if body, ok := curvedPartialIntersect(op, target, tool); ok {
+		return body, true
+	}
+	if body, ok := curvedPartialCut(op, target, tool); ok {
+		return body, true
+	}
+	if body, ok := curvedPartialJoin(op, target, tool); ok {
 		return body, true
 	}
 	if body, ok := curvedCrossingCut(op, target, tool); ok {

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -57,6 +57,33 @@ func curvedPartialIntersect(op PartFeatureOperation, target, tool *topo.Body) (*
 	return res, true
 }
 
+// curvedPartialCut returns target − tool when tool is a thin rod ending inside the fatter target (a blind
+// hole), or ok=false to defer. Only Cut maps here, and only a valid closed manifold result is adopted.
+func curvedPartialCut(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+	if op != Cut {
+		return nil, false
+	}
+	res, ok := brep.PartialPenetrationCut(target, tool)
+	if !ok || !validBooleanSolid(res) {
+		return nil, false
+	}
+	return res, true
+}
+
+// curvedPartialJoin returns target ∪ tool for a thin rod ending inside the fatter cylinder (the fat with a
+// single rod stub sticking out the entry side), or ok=false to defer. Only Join maps here, and only a valid
+// closed manifold result is adopted.
+func curvedPartialJoin(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+	if op != Join {
+		return nil, false
+	}
+	res, ok := brep.PartialPenetrationJoin(target, tool)
+	if !ok || !validBooleanSolid(res) {
+		return nil, false
+	}
+	return res, true
+}
+
 // curvedCrossingCut returns target − tool for two crossing cylinders (drilling a fat cylinder with a
 // crossing rod, or the two rod stubs of rod − fat), or ok=false to defer. Only Cut maps here, and only a
 // valid closed manifold result is adopted.

--- a/kernel/ops/boolean_crossing_cylinder_test.go
+++ b/kernel/ops/boolean_crossing_cylinder_test.go
@@ -188,6 +188,75 @@ func TestBooleanIntersectPartialPenetration(t *testing.T) {
 	}
 }
 
+// TestBooleanCutPartialPenetrationBlindHole cuts a thin rod (r=1.5, axis x) that ENDS at the fat centre out
+// of a fat cylinder (R=3, axis z): Cut must give the exact blind pocket (two caps, the holed wall, the rod
+// tunnel, the blind bottom) whose volume is the fat minus the plug (half the full crossing intersection).
+func TestBooleanCutPartialPenetrationBlindHole(t *testing.T) {
+	const rRod, rFat, hFat = 1.5, 3.0, 12.0
+	fat, _ := brep.SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), rFat, hFat)
+	stub, _ := brep.SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), rRod, 6) // ends at x=0, inside the fat
+
+	res, err := ops.Boolean(ops.Cut, fat, stub)
+	if err != nil {
+		t.Fatalf("Boolean(Cut blind hole): %v", err)
+	}
+	if v := ops.Validate(res); !v.Valid || !v.Closed || !v.Manifold || !res.IsSolid() {
+		t.Fatalf("blind hole is not a valid closed manifold solid: %+v", v)
+	}
+	for _, f := range res.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cylinder, geom.Plane:
+		default:
+			t.Errorf("face surface %T is not analytic (the exact path must run, not CSG)", f.Geometry())
+		}
+	}
+	if n := len(res.Faces()); n != 5 {
+		t.Errorf("blind hole has %d faces, want 5 (two caps, holed wall, tunnel, blind bottom)", n)
+	}
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	want := stdmath.Pi*rFat*rFat*hFat - crossingIntersectVolume(rRod, rFat)/2 // fat − the plug
+	// 4%: the curved tunnel and holed wall inscribe their curvature, so the meshed volume runs a little
+	// under the analytic fat − plug (the B-rep is exact; this bounds the property-mesh error, as for the
+	// full drill).
+	if rel := stdmath.Abs(got-want) / want; rel > 0.04 {
+		t.Errorf("blind hole volume %.4f, want %.4f (fat − plug) — rel %.4f > 4%%", got, want, rel)
+	}
+}
+
+// TestBooleanJoinPartialPenetration joins a thin rod (r=1.5, axis x) ending at the fat centre with a fat
+// cylinder (R=3, axis z): Join must give the fat with one rod stub out the entry side, its volume the fat
+// plus the rod minus the plug (the doubly-counted overlap).
+func TestBooleanJoinPartialPenetration(t *testing.T) {
+	const rRod, hRod, rFat, hFat = 1.5, 6.0, 3.0, 12.0
+	fat, _ := brep.SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), rFat, hFat)
+	stub, _ := brep.SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), rRod, hRod) // ends at x=0, inside the fat
+
+	res, err := ops.Boolean(ops.Join, fat, stub)
+	if err != nil {
+		t.Fatalf("Boolean(Join partial): %v", err)
+	}
+	if v := ops.Validate(res); !v.Valid || !v.Closed || !v.Manifold || !res.IsSolid() {
+		t.Fatalf("partial join is not a valid closed manifold solid: %+v", v)
+	}
+	for _, f := range res.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cylinder, geom.Plane:
+		default:
+			t.Errorf("face surface %T is not analytic (the exact path must run, not CSG)", f.Geometry())
+		}
+	}
+	if n := len(res.Faces()); n != 5 {
+		t.Errorf("partial join has %d faces, want 5 (two caps, holed wall, stub band, entry cap)", n)
+	}
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	want := stdmath.Pi*rFat*rFat*hFat + stdmath.Pi*rRod*rRod*hRod - crossingIntersectVolume(rRod, rFat)/2
+	// 4%: the curved holed wall and stub inscribe their curvature, so the meshed volume runs a little under
+	// the analytic fat + rod − plug (the B-rep is exact; this bounds the property-mesh error).
+	if rel := stdmath.Abs(got-want) / want; rel > 0.04 {
+		t.Errorf("partial join volume %.4f, want %.4f (fat + rod − plug) — rel %.4f > 4%%", got, want, rel)
+	}
+}
+
 // TestBooleanIntersectEqualRadiusSteinmetz intersects two EQUAL-radius perpendicular cylinders (axes x and
 // z, R=3): Intersect must give the exact Steinmetz bicylinder — four analytic cylinder faces — whose volume
 // is the closed form 16/3·R³, not triangle-soup CSG (the SSI tracer pinches on this case, so it is fitted


### PR DESCRIPTION
## What

Completes the **partial-penetration** set of the crossing-cylinder boolean (#1335) — a thin rod that ends *inside* the fatter cylinder — by adding the **Cut** and **Join** directions on top of the plug intersection (#1355):

- **Cut (fat − rod) = a blind hole.** The fat with a blind cylindrical pocket: its two caps, its side wall carrying the **single** lens hole, the rod-wall tunnel flipped inward, and the rod's blind end cap as the pocket bottom.
- **Join (fat ∪ rod).** The fat with a single rod **stub** sticking out the entry side: the holed wall plus the rod stub band out to the rod's entry end cap.

`Boolean(Cut, fat, rod)` and `Boolean(Join, fat, rod)` now produce these exact analytic solids instead of CSG.

## How (mostly reuse)

Both are built from the same blocks as the full-crossing drill (#1352) and join (#1353):

- `addFatCapsAndHoledWall` is **generalised to a variable hole count** — one hole here, two for the through drill — so the fat caps + holed side wall are shared.
- `addRodStub` gains a **reversed mode**: the inward-flipped tunnel wall + back-facing end cap for the blind hole (the outward stub + end cap is the join, unchanged).
- The single-loop resolver now carries **both** rod ends (blind and entry) and the fat extent, so all three partial operations (∩, −, ∪) share it.

No new mesher: the holed wall meshes through `holedCylinderWallMesh` (already supports ≥1 hole), the stub/tunnel band through `saddleBandLoftMesh`, the caps and lens through the trimmed-patch path.

## Tests

- `kernel/brep`: `TestPartialPenetrationBlindHoleIsWatertight` and `TestPartialPenetrationJoinIsWatertight` (five analytic faces, every edge used twice, solid; the blind hole has exactly one holed wall).
- `kernel/ops`: `TestBooleanCutPartialPenetrationBlindHole` and `TestBooleanJoinPartialPenetration` through `ops.Boolean` — validated closed + manifold + analytic-surface, with volume oracles `fat − plug` (hole) and `fat + rod − plug` (join), the plug being half the full crossing intersection (4% tolerance, as for the full drill's curved tunnel).
- All existing crossing-cylinder Intersect/Cut/Join/plug tests still pass (the `addFatCapsAndHoledWall` / `addRodStub` refactor is behaviour-preserving).

Full `kernel/...` suite green; `golangci-lint` clean; `gofmt`/`go vet` clean.

Remaining Phase 2 (separate slices): partial **rod − fat** (a single stub lump); equal-radius Cut/Join; cyl∩cone / cone∩cone SSI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)