### PR TITLE
feat: partial-penetration rod − fat stub lump (M2 Phase 2)

### DIFF
--- a/kernel/brep/curved_partial_penetration.go
+++ b/kernel/brep/curved_partial_penetration.go
@@ -159,22 +159,34 @@ func partialPlug(p *partialPlugParts) *topo.Body {
 	return bld.Build()
 }
 
-// PartialPenetrationCut builds target − tool when tool is a thin rod that ends inside the fatter target (a
-// BLIND HOLE), or ok=false to defer. The result is the fat with a blind cylindrical pocket: its two caps,
-// its side wall carrying the single lens hole, the rod-wall tunnel flipped inward, and the rod's blind end
-// cap as the pocket bottom.
+// PartialPenetrationCut builds target − tool for a thin rod that ends inside the fatter cylinder, or
+// ok=false to defer. Both subtraction directions are handled: when the target is the fat the result is a
+// BLIND HOLE (the fat with a blind cylindrical pocket — two caps, the holed side wall, the rod-wall tunnel
+// flipped inward, and the rod's blind end cap as the pocket bottom); when the target is the rod the result
+// is the single rod STUB sticking out the entry side (rod − fat: the rod material outside the fat).
 //
 // Example — a radius-3 cylinder blind-drilled by a radius-1.5 rod ending at its centre:
 //
 //	fat, _  := brep.SolidCylinder(math.P3(0,0,-6), math.V3(0,0,1), 3, 12)
 //	stub, _ := brep.SolidCylinder(math.P3(-6,0,0), math.V3(1,0,0), 1.5, 6)
 //	res, ok := brep.PartialPenetrationCut(fat, stub) // fat with a blind pocket
+//	res, ok = brep.PartialPenetrationCut(stub, fat)  // the rod stub outside the fat
 func PartialPenetrationCut(target, tool *topo.Body) (*topo.Body, bool) {
 	p, ok := partialPlugPartsOf(target, tool)
-	if !ok || !targetIsFat(target, p) {
-		return nil, false // only fat − rod is the blind hole; rod − fat (a stub lump) defers for now
+	if !ok {
+		return nil, false
 	}
-	return blindHole(p), true
+	if targetIsFat(target, p) {
+		return blindHole(p), true // fat − rod: a blind hole
+	}
+	return partialRodMinusFat(p), true // rod − fat: a single stub lump
+}
+
+// partialRodMinusFat builds rod − fat for a partial penetration: the single rod stub sticking out the entry
+// side (the rod material outside the fat), a closed lump of the rod stub band, the rod's entry end cap, and
+// the fat-wall lens reversed to face back into the fat (the kept material is outside it).
+func partialRodMinusFat(p *partialPlugParts) *topo.Body {
+	return rodStubLump(p.rod, p.fat, p.entryCenter, p.entryNormal, p.lens, "prmf")
 }
 
 // PartialPenetrationJoin builds target ∪ tool for a thin rod ending inside the fatter cylinder, or ok=false

--- a/kernel/brep/curved_partial_penetration_test.go
+++ b/kernel/brep/curved_partial_penetration_test.go
@@ -125,6 +125,33 @@ func TestPartialPenetrationJoinIsWatertight(t *testing.T) {
 	}
 }
 
+// TestPartialPenetrationRodMinusFatStub cuts the fat cylinder out of the rod (rod − fat) and checks the
+// result is the single rod stub outside the fat: a watertight one-shell lump of three analytic faces — the
+// fat-wall lens, the rod stub band, and the rod's entry end cap.
+func TestPartialPenetrationRodMinusFatStub(t *testing.T) {
+	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	stub, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 6)
+
+	res, ok := PartialPenetrationCut(stub, fat) // target is the rod
+	if !ok {
+		t.Fatal("rod − fat declined; want a single rod stub lump")
+	}
+	if !res.IsSolid() {
+		t.Fatalf("rod − fat result is not a solid: %+v", res)
+	}
+	if n := len(res.Shells()); n != 1 {
+		t.Errorf("rod − fat has %d shells, want 1 (the rod only breaches one wall)", n)
+	}
+	for _, e := range res.Edges() {
+		if uses := len(e.Uses()); uses != 2 {
+			t.Errorf("edge %v has %d uses, want 2 (a closed manifold)", e.Lineage(), uses)
+		}
+	}
+	if n := len(res.Faces()); n != 3 {
+		t.Errorf("rod − fat has %d faces, want 3 (lens, stub band, entry cap)", n)
+	}
+}
+
 // TestPartialPenetrationFullCrossingDefers: a rod that crosses all the way through gives two imprint loops,
 // not the single loop of a partial penetration, so the plug assembler declines.
 func TestPartialPenetrationFullCrossingDefers(t *testing.T) {

--- a/kernel/ops/boolean_crossing_cylinder_test.go
+++ b/kernel/ops/boolean_crossing_cylinder_test.go
@@ -223,6 +223,31 @@ func TestBooleanCutPartialPenetrationBlindHole(t *testing.T) {
 	}
 }
 
+// TestBooleanCutPartialPenetrationRodMinusFat subtracts a fat cylinder (R=3, axis z) from a thin rod
+// (r=1.5, axis x) that ends at the fat centre: Cut must give the single rod stub outside the fat (a
+// one-shell solid) whose volume is the rod minus the plug (half the full crossing intersection).
+func TestBooleanCutPartialPenetrationRodMinusFat(t *testing.T) {
+	const rRod, hRod, rFat = 1.5, 6.0, 3.0
+	fat, _ := brep.SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), rFat, 12)
+	stub, _ := brep.SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), rRod, hRod) // ends at x=0, inside the fat
+
+	res, err := ops.Boolean(ops.Cut, stub, fat) // rod − fat
+	if err != nil {
+		t.Fatalf("Boolean(Cut rod−fat partial): %v", err)
+	}
+	if v := ops.Validate(res); !v.Valid || !v.Closed || !v.Manifold || !res.IsSolid() {
+		t.Fatalf("rod − fat is not a valid closed manifold solid: %+v", v)
+	}
+	if n := len(res.Shells()); n != 1 {
+		t.Errorf("rod − fat has %d shells, want 1 (the rod breaches only one wall)", n)
+	}
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	want := stdmath.Pi*rRod*rRod*hRod - crossingIntersectVolume(rRod, rFat)/2 // rod − the plug
+	if rel := stdmath.Abs(got-want) / want; rel > 0.02 {
+		t.Errorf("rod − fat volume %.4f, want %.4f (rod − plug) — rel %.4f > 2%%", got, want, rel)
+	}
+}
+
 // TestBooleanJoinPartialPenetration joins a thin rod (r=1.5, axis x) ending at the fat centre with a fat
 // cylinder (R=3, axis z): Join must give the fat with one rod stub out the entry side, its volume the fat
 // plus the rod minus the plug (the doubly-counted overlap).


### PR DESCRIPTION
## What

Adds the **last** partial-penetration direction of the crossing-cylinder boolean (#1335): `Boolean(Cut, rod, fat)` when the thin rod **ends inside** the fatter cylinder. The result is the single rod **stub** sticking out the entry side — the rod material *outside* the fat — a closed lump of the rod stub band, the rod's entry end cap, and the fat-wall lens reversed to face back into the fat.

Because the rod only breaches one wall, it's a **single shell**, not the two-lump body of a full-crossing rod − fat.

## How (pure reuse)

It's exactly **one** `rodStubLump` — the same builder shared with the full-crossing rod − fat (#1353). `PartialPenetrationCut` already resolves both rod ends (blind and entry); it now routes the rod-target case to a one-lump `partialRodMinusFat` instead of deferring. No ops change (it already runs through `curvedPartialCut`), no new mesher.

## Tests

- `kernel/brep`: `TestPartialPenetrationRodMinusFatStub` — one shell, three analytic faces (lens, stub band, entry cap), every edge used twice.
- `kernel/ops`: `TestBooleanCutPartialPenetrationRodMinusFat` through `ops.Boolean` — validated closed + manifold + one shell, volume `rod − plug` (the plug being half the full crossing intersection), within 2%.
- All existing crossing-cylinder tests still pass.

Full `kernel/...` suite green; `golangci-lint` clean; `gofmt`/`go vet` clean.

This completes the partial-penetration set: plug intersection (#1355), blind hole + one-sided join (#1356), and now rod − fat (#1356 follow-up). Remaining Phase 2: equal-radius Cut/Join; cyl∩cone / cone∩cone SSI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)