### PR TITLE
feat: cone–cylinder SSI imprint (M2 Phase 2)

### DIFF
--- a/kernel/brep/curved_cone_cylinder_imprint.go
+++ b/kernel/brep/curved_cone_cylinder_imprint.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+)
+
+// Cone–cylinder imprint (M2 Phase 2, Oblikovati/Oblikovati#1335). The first slice of the cone∩cylinder
+// boolean: a cone (or frustum) crossing a cylinder meet in a curve that is generally NOT analytic — a
+// quartic the predictor–corrector SSI tracer (geom.IntersectSurfaceSurface) marches as a closed polyline,
+// exactly as for two crossing cylinders (curved_crossing_imprint.go), but with one operand a cone. It
+// returns the loops where the two surfaces cross, each a closed polyline lying on BOTH surfaces to
+// tolerance — the foundation the later split/classify/stitch slices build the watertight result on.
+//
+// Scope note: a tapered rod (a narrow cone/frustum) crossing a fatter cylinder gives clean, well-separated
+// closed loops (the rod's entry and exit). The trace is windowed to the cone's apex-distance band so the
+// cone's finite extent clips any continuation beyond its caps.
+
+// coneCylinderImprint returns the intersection loops of a cone body and a cylinder body as closed polylines,
+// or ok=false when the two bodies are not one bare cone and one bare cylinder, or no closed loop is traced.
+// The cone is the trace base, windowed to its apex-distance band [vMin, vMax]; the periodic angular
+// direction is left to the tracer.
+func coneCylinderImprint(a, b *topo.Body) ([]geom.Polyline, bool) {
+	cone, cyl, vMin, vMax, ok := coneAndCylinder(a, b)
+	if !ok {
+		return nil, false
+	}
+	window := geom.SurfaceGrid{VMin: vMin, VMax: vMax}
+	loops := closedTraceLoops(geom.IntersectSurfaceSurface(cone, cyl, window))
+	if len(loops) == 0 {
+		return nil, false
+	}
+	return loops, true
+}
+
+// coneAndCylinder resolves two bodies into one bare cone (with its apex-distance band) and one bare
+// cylinder, in either order. ok=false unless exactly one is a cone solid and the other a cylinder solid.
+func coneAndCylinder(a, b *topo.Body) (cone geom.Cone, cyl geom.Cylinder, vMin, vMax float64, ok bool) {
+	if cn, lo, hi, okCone := coneSolidParams(facesOfAny(a)); okCone {
+		if cy, _, _, okCyl := cylinderSolidParams(facesOfAny(b)); okCyl {
+			return cn, cy, lo, hi, true
+		}
+	}
+	if cn, lo, hi, okCone := coneSolidParams(facesOfAny(b)); okCone {
+		if cy, _, _, okCyl := cylinderSolidParams(facesOfAny(a)); okCyl {
+			return cn, cy, lo, hi, true
+		}
+	}
+	return geom.Cone{}, geom.Cylinder{}, 0, 0, false
+}

--- a/kernel/brep/curved_cone_cylinder_imprint_test.go
+++ b/kernel/brep/curved_cone_cylinder_imprint_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Cone–cylinder imprint (M2 Phase 2, Oblikovati/Oblikovati#1335). A tapered rod (a narrow frustum) crossing
+// a fatter cylinder must trace as two clean closed loops (the rod's entry and exit), each lying on BOTH the
+// cone and the cylinder surface to tolerance — the SSI foundation the later boolean slices build on.
+
+// TestConeCylinderImprintTwoCleanLoops crosses a frustum (axis x, radius 1→2.5 over x∈[-6,6]) through a
+// radius-3 cylinder (axis z) and checks the trace is two closed loops, each on both surfaces.
+func TestConeCylinderImprintTwoCleanLoops(t *testing.T) {
+	cone, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
+	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+
+	loops, ok := coneCylinderImprint(cone, cyl)
+	if !ok {
+		t.Fatal("cone–cylinder imprint declined; want two crossing loops")
+	}
+	if n := len(loops); n != 2 {
+		t.Fatalf("imprint traced %d loops, want 2 (the rod's entry and exit)", n)
+	}
+	cn, _, _, _ := coneSolidParams(facesOfAny(cone))
+	cy, _, _, _ := cylinderSolidParams(facesOfAny(cyl))
+	if d := worstLoopOffset(loops, cn, cy); d > 1e-4 {
+		t.Errorf("imprint loops stray %.2e from the surfaces, want ≤ 1e-4 (must lie on both)", d)
+	}
+}
+
+// TestConeCylinderImprintOrderIndependent: resolving works whichever body is passed first.
+func TestConeCylinderImprintOrderIndependent(t *testing.T) {
+	cone, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
+	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	if _, ok := coneCylinderImprint(cyl, cone); !ok {
+		t.Error("cone–cylinder imprint should resolve with the cylinder passed first too")
+	}
+}
+
+// TestConeCylinderImprintTwoCylindersDefer: two cylinders are not the cone–cylinder case.
+func TestConeCylinderImprintTwoCylindersDefer(t *testing.T) {
+	a, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
+	b, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	if _, ok := coneCylinderImprint(a, b); ok {
+		t.Error("two cylinders should defer from the cone–cylinder imprint (ok=false)")
+	}
+}
+
+// worstLoopOffset is the largest distance of any loop vertex from either surface.
+func worstLoopOffset(loops []geom.Polyline, cone geom.Cone, cyl geom.Cylinder) float64 {
+	worst := 0.0
+	for _, lp := range loops {
+		for _, p := range lp.Vertices {
+			worst = stdmath.Max(worst, stdmath.Max(distToCylinderSurface(cyl, p), distToConeSurface(cone, p)))
+		}
+	}
+	return worst
+}
+
+func distToCylinderSurface(c geom.Cylinder, p math.Point3) float64 {
+	return stdmath.Abs(float64(radialOf(p, c).Length()) - c.Radius)
+}
+
+func distToConeSurface(c geom.Cone, p math.Point3) float64 {
+	axis := c.AxisDir.AsVector()
+	v := float64(c.Apex.VectorTo(p).Dot(axis))
+	radial := c.Apex.VectorTo(p).Sub(axis.Scale(math.Scalar(v)))
+	return stdmath.Abs((float64(radial.Length()) - v*stdmath.Tan(c.HalfAngle)) * stdmath.Cos(c.HalfAngle))
+}


### PR DESCRIPTION
## What

Begins the **cone∩cylinder** boolean (#1335) — the last remaining surface pair of Phase 2 — with the **SSI imprint** slice, exactly mirroring how the crossing-cylinder work started (#1348).

A cone (or frustum) crossing a cylinder meet in a generally **non-analytic quartic** curve, which the predictor–corrector SSI tracer (`geom.IntersectSurfaceSurface`) marches as closed polylines — the same tracer used for two crossing cylinders, here with one operand a cone.

`coneCylinderImprint`:
- resolves the two bodies into a bare cone and a bare cylinder (either order),
- traces with the **cone as the base, windowed to its apex-distance band** `[vMin, vMax]`, so the cone's finite extent clips any continuation past its caps (the rod-first windowing lesson from #1355),
- keeps the closed loops.

A tapered rod (a narrow frustum) crossing a fatter cylinder gives **two clean loops** (its entry and exit), each lying on **both** surfaces to tolerance.

## Tests

- `TestConeCylinderImprintTwoCleanLoops` — a radius 1→2.5 frustum crossing a radius-3 cylinder traces exactly two closed loops, each within `1e-4` of both the cone and the cylinder surface (an explicit on-surface check).
- `TestConeCylinderImprintOrderIndependent` — resolves whichever body is passed first.
- `TestConeCylinderImprintTwoCylindersDefer` — two cylinders defer (`ok=false`).

Full `kernel/...` suite green; `golangci-lint` clean; `gofmt`/`go vet` clean.

This is the foundation; the cone-rod-through-cylinder **Intersect** (cone band + two cylinder-wall lens caps — the saddle-band loft already handles cone bands) is the next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)