### PR TITLE
feat: cone–cylinder intersection (M2 Phase 2)

### DIFF
--- a/kernel/brep/curved_cone_cylinder_imprint_test.go
+++ b/kernel/brep/curved_cone_cylinder_imprint_test.go
@@ -64,7 +64,7 @@ func worstLoopOffset(loops []geom.Polyline, cone geom.Cone, cyl geom.Cylinder) f
 }
 
 func distToCylinderSurface(c geom.Cylinder, p math.Point3) float64 {
-	return stdmath.Abs(float64(radialOf(p, c).Length()) - c.Radius)
+	return stdmath.Abs(float64(radialOf(p, cylAxis(c)).Length()) - c.Radius)
 }
 
 func distToConeSurface(c geom.Cone, p math.Point3) float64 {

--- a/kernel/brep/curved_cone_cylinder_intersect.go
+++ b/kernel/brep/curved_cone_cylinder_intersect.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+)
+
+// Cone–cylinder intersection (M2 Phase 2, Oblikovati/Oblikovati#1335). The split/classify/stitch stage
+// after the cone–cylinder imprint: a cone (or frustum) crossing a fatter cylinder, like a tapered rod
+// through a fat tube. The result is the same three-face shape as the crossing-cylinder intersection — the
+// rod-wall BAND inside the fat (between the two loops) plus the two fat-wall LENS caps — only here the rod
+// is a CONE. Because the band loft and the loop classification work off the rod's AXIS (not its surface
+// type, see crossAxis), the cone reuses the whole crossing-cylinder pipeline: the cone is the rod (both
+// loops encircle its axis), the cylinder the fat, and the cone band lofts through the same saddle-band path
+// (a cone is ruled along its slant, exactly like a cylinder).
+
+// ConeCylinderIntersect builds the exact intersection of a cone crossing a cylinder (the cone band inside
+// the cylinder plus the two cylinder-wall lens caps), or ok=false when the configuration is outside the
+// wired cone-through-cylinder case (not exactly two imprint loops, the cone is not the rod both loops
+// encircle, or a loop lies beyond the cone's caps) so kernel/ops keeps its fallback.
+//
+// Example — a radius-1→2.5 frustum on x crossing a radius-3 cylinder on z gives a three-face solid:
+//
+//	cone, _ := brep.SolidCylinderCone(math.P3(-6,0,0), math.P3(6,0,0), 1, 2.5, "cone")
+//	cyl, _  := brep.SolidCylinder(math.P3(0,0,-6), math.V3(0,0,1), 3, 12)
+//	res, ok := brep.ConeCylinderIntersect(cone, cyl) // cone band capped by two lenses
+func ConeCylinderIntersect(a, b *topo.Body) (*topo.Body, bool) {
+	cone, cyl, vMin, vMax, ok := coneAndCylinder(a, b)
+	if !ok {
+		return nil, false
+	}
+	loops, ok := coneCylinderImprint(a, b)
+	if !ok || len(loops) != 2 {
+		return nil, false
+	}
+	if !allLoopsEncircle(loops, coneAxis(cone)) || allLoopsEncircle(loops, cylAxis(cyl)) {
+		return nil, false // the cone must be the rod the loops encircle, the cylinder the lens-capped fat
+	}
+	if !loopsSpanCone(cone, vMin, vMax, loops) {
+		return nil, false // a loop beyond a cone cap: the cone does not fully cross (a partial penetration)
+	}
+	lo, hi, ok := assignRimLoops(coneAxis(cone), cylAxis(cyl), loops)
+	if !ok {
+		return nil, false
+	}
+	return stitchRodWithSaddleCaps(cone, cyl, lo, hi), true
+}
+
+// loopsSpanCone reports whether every imprint loop lies within the cone's finite apex-distance band
+// [vMin, vMax] (between its caps). A loop beyond a cap means the cone ends inside the cylinder (a partial
+// penetration), so the full-crossing assembler must defer.
+func loopsSpanCone(cone geom.Cone, vMin, vMax float64, loops []geom.Polyline) bool {
+	axis := cone.AxisDir.AsVector()
+	for _, lp := range loops {
+		for _, p := range lp.Vertices {
+			v := float64(cone.Apex.VectorTo(p).Dot(axis))
+			if v < vMin-1e-7 || v > vMax+1e-7 {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/kernel/brep/curved_cone_cylinder_intersect_test.go
+++ b/kernel/brep/curved_cone_cylinder_intersect_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Cone–cylinder intersection assembly (M2 Phase 2, Oblikovati/Oblikovati#1335). A cone crossing a cylinder
+// must weld into the same three-face shape as the crossing-cylinder intersection — a cone band plus two
+// cylinder-wall lens caps — watertight. Volume is checked through ops_test; here the concern is the
+// watertight topology and that the surfaces stay analytic (one cone band, two cylinder lens caps).
+
+// TestConeCylinderIntersectThreeFaces crosses a frustum through a radius-3 cylinder and checks the result is
+// a watertight three-face solid: one cone band and two cylinder lens caps.
+func TestConeCylinderIntersectThreeFaces(t *testing.T) {
+	cone, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
+	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+
+	res, ok := ConeCylinderIntersect(cone, cyl)
+	if !ok {
+		t.Fatal("cone–cylinder intersection declined; want a three-face solid")
+	}
+	if !res.IsSolid() {
+		t.Fatalf("cone–cylinder intersection is not a solid: %+v", res)
+	}
+	for _, e := range res.Edges() {
+		if uses := len(e.Uses()); uses != 2 {
+			t.Errorf("edge %v has %d uses, want 2 (a closed manifold)", e.Lineage(), uses)
+		}
+	}
+	cones, cyls := 0, 0
+	for _, f := range res.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cone:
+			cones++
+		case geom.Cylinder:
+			cyls++
+		default:
+			t.Errorf("face surface %T is not analytic", f.Geometry())
+		}
+	}
+	if cones != 1 || cyls != 2 {
+		t.Errorf("got %d cone + %d cylinder faces, want 1 (band) + 2 (lens caps)", cones, cyls)
+	}
+}
+
+// TestConeCylinderIntersectOrderIndependent: resolving works whichever body is passed first.
+func TestConeCylinderIntersectOrderIndependent(t *testing.T) {
+	cone, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
+	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	if _, ok := ConeCylinderIntersect(cyl, cone); !ok {
+		t.Error("cone–cylinder intersection should resolve with the cylinder passed first too")
+	}
+}
+
+// TestConeCylinderIntersectTwoCylindersDefer: two cylinders are the crossing-cylinder case, not this one.
+func TestConeCylinderIntersectTwoCylindersDefer(t *testing.T) {
+	a, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
+	b, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	if _, ok := ConeCylinderIntersect(a, b); ok {
+		t.Error("two cylinders should defer from the cone–cylinder assembler (ok=false)")
+	}
+}

--- a/kernel/brep/curved_crossing_cut.go
+++ b/kernel/brep/curved_crossing_cut.go
@@ -43,7 +43,7 @@ func CrossingCylinderCut(target, tool *topo.Body) (*topo.Body, bool) {
 	if !ok {
 		return nil, false
 	}
-	if allLoopsEncircle([]geom.Polyline{p.lo, p.hi}, tc) {
+	if allLoopsEncircle([]geom.Polyline{p.lo, p.hi}, cylAxis(tc)) {
 		return cutRodMinusFat(p), true // target is the rod: two disconnected stubs
 	}
 	return drillFatWithRod(p), true // target is the fat: drill a tunnel
@@ -76,7 +76,7 @@ func crossingPartsOf(a, b *topo.Body) (*crossingParts, bool) {
 	if !ok || !loopsSpanRod(rod, rodBase, rodH, loops) {
 		return nil, false // a loop beyond a rod end is a partial penetration, not a full crossing
 	}
-	lo, hi, ok := assignRimLoops(rod, fat, loops)
+	lo, hi, ok := assignRimLoops(cylAxis(rod), cylAxis(fat), loops)
 	if !ok {
 		return nil, false
 	}
@@ -87,9 +87,9 @@ func crossingPartsOf(a, b *topo.Body) (*crossingParts, bool) {
 // cylinder, carrying each one's cap base and height through.
 func orderRodFat(loops []geom.Polyline, ca geom.Cylinder, baseA math.Point3, hA float64, cb geom.Cylinder, baseB math.Point3, hB float64) (rod geom.Cylinder, rodBase math.Point3, rodH float64, fat geom.Cylinder, fatBase math.Point3, fatH float64, ok bool) {
 	switch {
-	case allLoopsEncircle(loops, ca) && !allLoopsEncircle(loops, cb):
+	case allLoopsEncircle(loops, cylAxis(ca)) && !allLoopsEncircle(loops, cylAxis(cb)):
 		return ca, baseA, hA, cb, baseB, hB, true
-	case allLoopsEncircle(loops, cb) && !allLoopsEncircle(loops, ca):
+	case allLoopsEncircle(loops, cylAxis(cb)) && !allLoopsEncircle(loops, cylAxis(ca)):
 		return cb, baseB, hB, ca, baseA, hA, true
 	default:
 		return geom.Cylinder{}, math.Point3{}, 0, geom.Cylinder{}, math.Point3{}, 0, false
@@ -164,8 +164,8 @@ func addFatCapsAndHoledWall(bld *topo.Builder, fat geom.Cylinder, fatBase math.P
 // two lens centres, so a seam placed there crosses neither hole (the holed-wall mesher needs a hole-free
 // seam).
 func clearSeamParam(fat geom.Cylinder, lo, hi geom.Polyline) float64 {
-	u1 := axisAngleOf(loopCentroid(lo), fat)
-	u2 := axisAngleOf(loopCentroid(hi), fat)
+	u1 := axisAngleOf(loopCentroid(lo), cylAxis(fat))
+	u2 := axisAngleOf(loopCentroid(hi), cylAxis(fat))
 	a, b := stdmath.Min(u1, u2), stdmath.Max(u1, u2)
 	if b-a >= 2*stdmath.Pi-(b-a) {
 		return (a + b) / 2 // the gap from a to b is the larger one
@@ -177,7 +177,7 @@ func clearSeamParam(fat geom.Cylinder, lo, hi geom.Polyline) float64 {
 // hole, so a seam placed there crosses the hole-free side of the wall (the holed-wall mesher needs a
 // hole-free seam).
 func clearSeamForLens(fat geom.Cylinder, lens geom.Polyline) float64 {
-	return axisAngleOf(loopCentroid(lens), fat) + stdmath.Pi
+	return axisAngleOf(loopCentroid(lens), cylAxis(fat)) + stdmath.Pi
 }
 
 // seamedCircle builds a cap circle whose angle-zero seam vertex is at seamPt (radius and centre on the

--- a/kernel/brep/curved_crossing_intersect.go
+++ b/kernel/brep/curved_crossing_intersect.go
@@ -41,7 +41,7 @@ func CrossingCylinderIntersect(a, b *topo.Body) (*topo.Body, bool) {
 	if !ok || !loopsSpanRod(rod, rodBase, rodHeight, loops) {
 		return nil, false // a loop beyond a rod end is a partial penetration, not a full crossing
 	}
-	lo, hi, ok := assignRimLoops(rod, fat, loops)
+	lo, hi, ok := assignRimLoops(cylAxis(rod), cylAxis(fat), loops)
 	if !ok {
 		return nil, false
 	}
@@ -57,7 +57,7 @@ func rodAndFatCylinders(a, b *topo.Body, loops []geom.Polyline) (rod, fat geom.C
 	if !okA || !okB {
 		return geom.Cylinder{}, geom.Cylinder{}, math.Point3{}, 0, false
 	}
-	aWraps, bWraps := allLoopsEncircle(loops, ca), allLoopsEncircle(loops, cb)
+	aWraps, bWraps := allLoopsEncircle(loops, cylAxis(ca)), allLoopsEncircle(loops, cylAxis(cb))
 	if aWraps && !bWraps {
 		return ca, cb, baseA, hA, true
 	}
@@ -86,36 +86,52 @@ func loopsSpanRod(rod geom.Cylinder, rodBase math.Point3, rodHeight float64, loo
 	return true
 }
 
-// allLoopsEncircle reports whether every loop winds a full turn about the cylinder's axis — the test that
-// distinguishes the rod (each loop rings right around it, ≈ ±2π) from the fat cylinder (each loop is a
-// local lens off to one side that barely turns, ≈ 0).
-func allLoopsEncircle(loops []geom.Polyline, cyl geom.Cylinder) bool {
+// crossAxis is the axis of a crossing operand (a cylinder or a cone) — a point on it, the unit direction,
+// and the angle-zero reference — enough to measure how an imprint loop turns and where it sits about that
+// axis, without knowing the surface type. This lets the rod be a cone, not just a cylinder.
+type crossAxis struct {
+	point math.Point3
+	dir   math.Vector3
+	ref   math.Vector3
+}
+
+// cylAxis and coneAxis read the crossing axis of a cylinder (origin) or a cone (apex).
+func cylAxis(c geom.Cylinder) crossAxis {
+	return crossAxis{c.Origin, c.AxisDir.AsVector(), c.Ref.AsVector()}
+}
+
+func coneAxis(c geom.Cone) crossAxis {
+	return crossAxis{c.Apex, c.AxisDir.AsVector(), c.Ref.AsVector()}
+}
+
+// allLoopsEncircle reports whether every loop winds a full turn about the axis — the test that distinguishes
+// the rod (each loop rings right around it, ≈ ±2π) from the fat cylinder (each loop is a local lens off to
+// one side that barely turns, ≈ 0).
+func allLoopsEncircle(loops []geom.Polyline, ax crossAxis) bool {
 	for _, lp := range loops {
-		if stdmath.Abs(loopTurnAboutAxis(lp, cyl)) < stdmath.Pi {
+		if stdmath.Abs(loopTurnAboutAxis(lp, ax)) < stdmath.Pi {
 			return false
 		}
 	}
 	return true
 }
 
-// loopTurnAboutAxis sums the signed angle a loop's spokes sweep about the cylinder axis (≈ ±2π for a loop
-// encircling the axis, ≈ 0 for a local lens).
-func loopTurnAboutAxis(lp geom.Polyline, cyl geom.Cylinder) float64 {
-	axis := cyl.AxisDir.AsVector()
+// loopTurnAboutAxis sums the signed angle a loop's spokes sweep about the axis (≈ ±2π for a loop encircling
+// the axis, ≈ 0 for a local lens).
+func loopTurnAboutAxis(lp geom.Polyline, ax crossAxis) float64 {
 	vs := lp.Vertices
 	total := 0.0
 	for i := 0; i+1 < len(vs); i++ {
-		total += signedAngleAround(radialOf(vs[i], cyl), radialOf(vs[i+1], cyl), axis)
+		total += signedAngleAround(radialOf(vs[i], ax), radialOf(vs[i+1], ax), ax.dir)
 	}
 	return total
 }
 
-// radialOf returns the spoke from the cylinder axis out to p — the component of (axis origin → p)
-// perpendicular to the axis, whose turning measures the angle about the axis.
-func radialOf(p math.Point3, cyl geom.Cylinder) math.Vector3 {
-	axis := cyl.AxisDir.AsVector()
-	v := cyl.Origin.VectorTo(p)
-	return v.Sub(axis.Scale(v.Dot(axis)))
+// radialOf returns the spoke from the axis out to p — the component of (axis point → p) perpendicular to the
+// axis, whose turning measures the angle about the axis.
+func radialOf(p math.Point3, ax crossAxis) math.Vector3 {
+	v := ax.point.VectorTo(p)
+	return v.Sub(ax.dir.Scale(v.Dot(ax.dir)))
 }
 
 // assignRimLoops orients both imprint loops CCW about the rod axis and assigns them to the lower (lo) and
@@ -123,12 +139,11 @@ func radialOf(p math.Point3, cyl geom.Cylinder) math.Vector3 {
 // points along +rodaxis is the upper rim (the band traverses it reversed, its cap forward), the other the
 // lower. The hi loop is rotated to start at the lo loop's seam angle so their joining seam is a clean
 // constant-angle ruling of the rod. ok=false unless there is exactly one loop of each end.
-func assignRimLoops(rod, fat geom.Cylinder, loops []geom.Polyline) (lo, hi geom.Polyline, ok bool) {
-	rodAxis := rod.AxisDir.AsVector()
+func assignRimLoops(rodAx, fatAx crossAxis, loops []geom.Polyline) (lo, hi geom.Polyline, ok bool) {
 	var los, his []geom.Polyline
 	for _, lp := range loops {
-		ccw := orientLoopCCW(lp, rod)
-		if fatOutwardAlongAxis(ccw, fat, rodAxis) >= 0 {
+		ccw := orientLoopCCW(lp, rodAx)
+		if fatOutwardAlongAxis(ccw, fatAx, rodAx.dir) >= 0 {
 			his = append(his, ccw)
 		} else {
 			los = append(los, ccw)
@@ -137,13 +152,13 @@ func assignRimLoops(rod, fat geom.Cylinder, loops []geom.Polyline) (lo, hi geom.
 	if len(los) != 1 || len(his) != 1 {
 		return geom.Polyline{}, geom.Polyline{}, false
 	}
-	return los[0], alignLoopStart(his[0], los[0], rod), true
+	return los[0], alignLoopStart(his[0], los[0], rodAx), true
 }
 
 // orientLoopCCW returns the loop oriented so it winds CCW about the rod axis (positive turn), reversing
 // its vertex order when the traced loop runs the other way.
-func orientLoopCCW(lp geom.Polyline, rod geom.Cylinder) geom.Polyline {
-	if loopTurnAboutAxis(lp, rod) >= 0 {
+func orientLoopCCW(lp geom.Polyline, rodAx crossAxis) geom.Polyline {
+	if loopTurnAboutAxis(lp, rodAx) >= 0 {
 		return lp
 	}
 	return reverseLoop(lp)
@@ -163,9 +178,9 @@ func reverseLoop(lp geom.Polyline) geom.Polyline {
 
 // fatOutwardAlongAxis returns the component along the rod axis of the fat cylinder's outward normal at the
 // loop's centroid — its sign places the loop's lens on the +rodaxis (≥0) or −rodaxis (<0) end of the band.
-func fatOutwardAlongAxis(lp geom.Polyline, fat geom.Cylinder, rodAxis math.Vector3) float64 {
-	outward := unit(radialOf(loopCentroid(lp), fat))
-	return float64(outward.Dot(rodAxis))
+func fatOutwardAlongAxis(lp geom.Polyline, fatAx crossAxis, rodDir math.Vector3) float64 {
+	outward := unit(radialOf(loopCentroid(lp), fatAx))
+	return float64(outward.Dot(rodDir))
 }
 
 // loopCentroid averages a loop's distinct vertices (skipping the repeated closing vertex).
@@ -182,21 +197,21 @@ func loopCentroid(lp geom.Polyline) math.Point3 {
 // alignLoopStart rotates the hi loop so it begins at the vertex nearest, in rod-axis angle, to the lo
 // loop's start — so the seam joining the two starts is a near-constant-angle ruling of the rod (lying on
 // the surface), the clean seam the band's periodic face needs.
-func alignLoopStart(hi, lo geom.Polyline, rod geom.Cylinder) geom.Polyline {
-	target := axisAngleOf(lo.Vertices[0], rod)
+func alignLoopStart(hi, lo geom.Polyline, rodAx crossAxis) geom.Polyline {
+	target := axisAngleOf(lo.Vertices[0], rodAx)
 	core := hi.Vertices[:len(hi.Vertices)-1]
 	best, bestErr := 0, stdmath.Inf(1)
 	for i, p := range core {
-		if d := angleDelta(axisAngleOf(p, rod), target); d < bestErr {
+		if d := angleDelta(axisAngleOf(p, rodAx), target); d < bestErr {
 			best, bestErr = i, d
 		}
 	}
 	return rotateClosedLoop(core, best)
 }
 
-// axisAngleOf returns p's angle about the cylinder axis, measured from the cylinder's reference direction.
-func axisAngleOf(p math.Point3, cyl geom.Cylinder) float64 {
-	return signedAngleAround(cyl.Ref.AsVector(), radialOf(p, cyl), cyl.AxisDir.AsVector())
+// axisAngleOf returns p's angle about the axis, measured from the axis's reference direction.
+func axisAngleOf(p math.Point3, ax crossAxis) float64 {
+	return signedAngleAround(ax.ref, radialOf(p, ax), ax.dir)
 }
 
 // angleDelta is the absolute difference between two angles, wrapped into [0, π].
@@ -225,7 +240,7 @@ func rotateClosedLoop(core []math.Point3, start int) geom.Polyline {
 // two fat-wall lens caps, each sharing one rim edge with the band in the OPPOSITE orientation, so every
 // edge is used exactly twice (a closed manifold). The rims stay closed saddle-polyline edges so the band
 // tessellates via the saddle-band loft and each lens via the metric-patch mesher.
-func stitchRodWithSaddleCaps(rod, fat geom.Cylinder, lo, hi geom.Polyline) *topo.Body {
+func stitchRodWithSaddleCaps(rodSurface, fat geom.Surface, lo, hi geom.Polyline) *topo.Body {
 	loPts, hiPts := lo.Vertices, hi.Vertices
 	bld := topo.NewBuilder(true, crossLin("body"))
 	vLo := bld.AddVertex(loPts[0], crossLin("vlo"))
@@ -233,7 +248,7 @@ func stitchRodWithSaddleCaps(rod, fat geom.Cylinder, lo, hi geom.Polyline) *topo
 	eLo := bld.AddEdge(lo, vLo, vLo, crossLin("elo"))
 	eHi := bld.AddEdge(hi, vHi, vHi, crossLin("ehi"))
 	eSeam := bld.AddEdge(geom.NewLineSegment(loPts[0], hiPts[0]), vLo, vHi, crossLin("seam"))
-	bld.AddFace(rod, crossLin("band"),
+	bld.AddFace(rodSurface, crossLin("band"),
 		topo.OuterLoop(topo.Fwd(eSeam), topo.Rev(eHi), topo.Rev(eSeam), topo.Fwd(eLo)))
 	bld.AddFace(fat, crossLin("caplo"), topo.OuterLoop(topo.Rev(eLo)))
 	bld.AddFace(fat, crossLin("caphi"), topo.OuterLoop(topo.Fwd(eHi)))

--- a/kernel/brep/curved_crossing_join.go
+++ b/kernel/brep/curved_crossing_join.go
@@ -94,7 +94,7 @@ func addRodStub(bld *topo.Builder, rod geom.Cylinder, endCenter math.Point3, cap
 // so the seam connecting them is a near-constant-angle ruling of the rod (lying on the surface).
 func stubSeamPoint(rod geom.Cylinder, endCenter, lensStart math.Point3) math.Point3 {
 	v := float64(rod.Origin.VectorTo(endCenter).Dot(rod.AxisDir.AsVector()))
-	return rod.PointAt(axisAngleOf(lensStart, rod), v)
+	return rod.PointAt(axisAngleOf(lensStart, cylAxis(rod)), v)
 }
 
 // cutRodMinusFat builds rod − fat: the two rod stubs sticking out either side of the fat, each a separate

--- a/kernel/brep/curved_partial_penetration.go
+++ b/kernel/brep/curved_partial_penetration.go
@@ -81,7 +81,7 @@ func tryPartialPlug(rodBody, fatBody *topo.Body) (*partialPlugParts, bool) {
 	}
 	rod, rodBase, rodH, okR := cylinderSolidParams(facesOfAny(rodBody))
 	fat, fatBase, fatH, okF := cylinderSolidParams(facesOfAny(fatBody))
-	if !okR || !okF || !allLoopsEncircle(loops, rod) {
+	if !okR || !okF || !allLoopsEncircle(loops, cylAxis(rod)) {
 		return nil, false
 	}
 	blindC, blindN, entryC, entryN, ok := rodEnds(rod, rodBase, rodH, fat, fatBase, fatH)
@@ -92,7 +92,7 @@ func tryPartialPlug(rodBody, fatBody *topo.Body) (*partialPlugParts, bool) {
 		rod: rod, fat: fat,
 		blindCenter: blindC, blindNormal: blindN,
 		entryCenter: entryC, entryNormal: entryN,
-		lens:    orientLoopCCW(loops[0], rod),
+		lens:    orientLoopCCW(loops[0], cylAxis(rod)),
 		fatBase: fatBase, fatHeight: fatH,
 	}, true
 }
@@ -136,7 +136,7 @@ func rodEndInsideFat(rod geom.Cylinder, center math.Point3, fat geom.Cylinder, f
 // radius and between the caps, by a small margin so a point on the surface counts as outside.
 func pointInsideCylinderSolid(c geom.Cylinder, base math.Point3, height float64, p math.Point3) bool {
 	const margin = 1e-7
-	if float64(radialOf(p, c).Length()) > c.Radius-margin {
+	if float64(radialOf(p, cylAxis(c)).Length()) > c.Radius-margin {
 		return false
 	}
 	axis := c.AxisDir.AsVector()

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -122,6 +122,7 @@ func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.L
 //   - a curved solid ∩ a convex planar tool (a box) → composed half-space cuts (#1334);
 //   - a curved solid − a convex prism tunnelling through it (cylinder − box) (#1334);
 //   - two crossing cylinders ∩ (rod band + fat-wall lens caps) (#1335);
+//   - a cone crossing a cylinder ∩ (cone band + cylinder-wall lens caps) (#1335);
 //   - two EQUAL-radius perpendicular cylinders ∩/−/∪ (the Steinmetz bicylinder and its cut/union, fitted as crossing ellipses) (#1335);
 //   - a thin rod ending inside a fatter cylinder ∩/−/∪ (a partial penetration: the plug, a blind hole, a one-sided stub) (#1335);
 //   - drilling a fat cylinder with a crossing rod (fat − rod), and the two rod stubs of rod − fat (#1335);
@@ -139,7 +140,7 @@ func curvedExactBoolean(op PartFeatureOperation, target, tool *topo.Body) (*topo
 // returns ok=false when it does not apply to (op, target, tool).
 var curvedExactPaths = []func(PartFeatureOperation, *topo.Body, *topo.Body) (*topo.Body, bool){
 	curvedConvexIntersect, curvedConvexSubtract,
-	curvedCrossingIntersect, curvedSteinmetzIntersect, curvedPartialIntersect,
+	curvedCrossingIntersect, curvedSteinmetzIntersect, curvedConeCylinderIntersect, curvedPartialIntersect,
 	curvedPartialCut, curvedSteinmetzCut, curvedCrossingCut,
 	curvedPartialJoin, curvedCrossingJoin, curvedSteinmetzJoin,
 }

--- a/kernel/ops/boolean_cone_cylinder_test.go
+++ b/kernel/ops/boolean_cone_cylinder_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+)
+
+// Cone–cylinder intersection through Boolean (M2 Phase 2, Oblikovati/Oblikovati#1335). A cone (a tapered
+// rod) crossing a fatter cylinder must Intersect to the exact analytic solid — the cone band plus two
+// cylinder-wall lens caps — its volume matching the analytic cone∩cylinder, not triangle-soup CSG.
+
+// coneCylinderIntersectVolume is the volume of the frustum (apex at x=−14, half-angle atan 0.125, so radius
+// 1→2.5 over x∈[−6,6]) ∩ the cylinder x²+y²≤R² (axis z). At each x the cone is a disk of radius r(x) clipped
+// by the cylinder slab |y|≤√(R²−x²); only |x|≤R lies inside the cylinder. Integrating the clipped-disk area.
+func coneCylinderIntersectVolume(rFat float64) float64 {
+	const n = 200000
+	const apexX, tanHalf = -14.0, 0.125
+	sum, lo, hi := 0.0, -rFat, rFat
+	for i := 0; i < n; i++ {
+		x := lo + (hi-lo)*(float64(i)+0.5)/n
+		r := (x - apexX) * tanHalf
+		h := stdmath.Sqrt(rFat*rFat - x*x)
+		sum += clippedDiskArea(r, h)
+	}
+	return sum * (hi - lo) / n
+}
+
+// clippedDiskArea is the area of {y²+z²≤r²} ∩ {|y|≤h} — a disk of radius r clipped to a slab of half-width h.
+func clippedDiskArea(r, h float64) float64 {
+	if h >= r {
+		return stdmath.Pi * r * r
+	}
+	if h <= 0 {
+		return 0
+	}
+	seg := r*r*stdmath.Acos(h/r) - h*stdmath.Sqrt(r*r-h*h) // one circular segment beyond |y|=h
+	return stdmath.Pi*r*r - 2*seg
+}
+
+// TestBooleanIntersectConeCylinder crosses a frustum (radius 1→2.5, axis x) through a radius-3 cylinder
+// (axis z) and checks the result is the exact three-face analytic solid (cone band + two lens caps) with the
+// analytic cone∩cylinder volume.
+func TestBooleanIntersectConeCylinder(t *testing.T) {
+	const rFat = 3.0
+	cone, _ := brep.SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
+	cyl, _ := brep.SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), rFat, 12)
+
+	res, err := ops.Boolean(ops.Intersect, cone, cyl)
+	if err != nil {
+		t.Fatalf("Boolean(Intersect cone∩cyl): %v", err)
+	}
+	if v := ops.Validate(res); !v.Valid || !v.Closed || !v.Manifold || !res.IsSolid() {
+		t.Fatalf("cone∩cylinder is not a valid closed manifold solid: %+v", v)
+	}
+	cones, cyls := 0, 0
+	for _, f := range res.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cone:
+			cones++
+		case geom.Cylinder:
+			cyls++
+		default:
+			t.Errorf("face surface %T is not analytic (the exact path must run, not CSG)", f.Geometry())
+		}
+	}
+	if cones != 1 || cyls != 2 {
+		t.Errorf("got %d cone + %d cylinder faces, want 1 (band) + 2 (lens caps)", cones, cyls)
+	}
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	want := coneCylinderIntersectVolume(rFat)
+	if rel := stdmath.Abs(got-want) / want; rel > 0.03 {
+		t.Errorf("cone∩cylinder volume %.4f, want %.4f (analytic) — rel %.4f > 3%%", got, want, rel)
+	}
+}

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -28,6 +28,20 @@ func curvedCrossingIntersect(op PartFeatureOperation, target, tool *topo.Body) (
 	return res, true
 }
 
+// curvedConeCylinderIntersect returns the exact intersection of a cone crossing a cylinder (the cone band
+// plus two cylinder-wall lens caps), or ok=false to defer. Only Intersect maps here, and only a valid closed
+// manifold result is adopted.
+func curvedConeCylinderIntersect(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+	if op != Intersect {
+		return nil, false
+	}
+	res, ok := brep.ConeCylinderIntersect(target, tool)
+	if !ok || !validBooleanSolid(res) {
+		return nil, false
+	}
+	return res, true
+}
+
 // curvedSteinmetzIntersect returns the exact intersection of two equal-radius perpendicular cylinders (the
 // Steinmetz bicylinder), or ok=false to defer. Only Intersect maps here, and only a valid closed manifold
 // result is adopted. This is the equal-radius case the SSI imprint tracer cannot trace (it pinches), fitted


### PR DESCRIPTION
## What

Adds the **Intersect** of a cone (or frustum) crossing a cylinder (#1335) — a tapered rod through a fat tube. `Boolean(Intersect, cone, cyl)` now produces the exact analytic solid instead of CSG: the same three-face shape as the crossing-cylinder intersection — the rod-wall **band** inside the fat plus the two fat-wall **lens caps** — only the rod is a **cone**.

## How (the generalization)

The crossing-cylinder pipeline classified loops and lofted the band off `geom.Cylinder`. This PR refactors those primitives to a small **`crossAxis`** abstraction — a point on the axis, the unit direction, and the angle-zero reference — so the rod a loop encircles can be a cone (read from its apex) or a cylinder (its origin):

- `radialOf`, `loopTurnAboutAxis`, `allLoopsEncircle`, `axisAngleOf`, `orientLoopCCW`, `assignRimLoops`, `alignLoopStart`, `fatOutwardAlongAxis` now take a `crossAxis`;
- `stitchRodWithSaddleCaps` takes the rod and fat as `geom.Surface`, so the band face can be a cone.

The refactor is **behaviour-preserving** — every existing crossing, partial-penetration and Steinmetz test still passes (the cylinder call sites just wrap their cylinder in `cylAxis`).

Then `ConeCylinderIntersect` reuses the whole pipeline: the cone is the rod (both imprint loops encircle its axis), the cylinder the fat. The cone band lofts through the **same saddle-band path** (a cone is ruled along its slant, exactly like a cylinder — no new mesher), the lens caps through the cylinder trimmed-patch mesher. `loopsSpanCone` defers a cone that ends inside the cylinder (a partial penetration) to a later slice.

## Tests

- `kernel/brep`: `TestConeCylinderIntersectThreeFaces` (one cone band + two cylinder lens caps, every edge used twice, solid), order-independence, and a two-cylinder defer guard.
- `kernel/ops`: `TestBooleanIntersectConeCylinder` through `ops.Boolean` — validated closed + manifold + analytic-surface, volume against a **numerical oracle** (the clipped-disk integral of frustum ∩ cylinder; measured 1.3% under at DefaultQuality, 3% tolerance).

Full `kernel/...` suite green; `golangci-lint` clean; `gofmt`/`go vet` clean.

Remaining Phase 2: cone-through-cylinder Cut/Join (now within reach — the rod is surface-typed), cone partial penetration, and cone∩cone SSI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)