### PR TITLE
Cone–cylinder cut and join (M2 Phase 2)

### DIFF
--- a/kernel/brep/curved_cone_cylinder_cut.go
+++ b/kernel/brep/curved_cone_cylinder_cut.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Cone–cylinder cut (M2 Phase 2, Oblikovati/Oblikovati#1335). The two subtraction outcomes when a cone (a
+// tapered rod) crosses a fatter cylinder, assembled from the cone–cylinder imprint loops exactly like the
+// crossing-cylinder drill (curved_crossing_cut.go) and sharing its builders — the rod is just a cone now (a
+// crossRod), so the cone band lofts through the same ruled saddle-band path:
+//
+//   - Cut(fat, cone): the fat cylinder drilled by the cone — its two caps, its side wall carrying the two
+//     lens holes, and the cone-wall band flipped inward as the tapered tunnel (drillFatWithRod).
+//   - Cut(cone, fat): the cone − the fat — the two disconnected tapered stubs sticking out either side of the
+//     fat, each a closed lump (a cone-wall band, the cone's end cap, and the fat-wall lens), merged into one
+//     multi-shell body (cutRodMinusFat).
+
+// ConeCylinderCut returns target − tool for a cone crossing a cylinder, or ok=false to defer (a non-cone/non-
+// cylinder operand, equal-axis cylinders, a breach reaching a fat cap, or a cone that does not fully cross)
+// so kernel/ops keeps its CSG fallback. The direction is read from which body is the cone: drilling the fat
+// when the target is the cylinder, the two cone stubs when the target is the cone.
+//
+// Example — a radius-1→2.5 frustum on x crossing (and drilling) a radius-3 cylinder on z:
+//
+//	cone, _ := brep.SolidCylinderCone(math.P3(-6,0,0), math.P3(6,0,0), 1, 2.5, "cone")
+//	cyl, _  := brep.SolidCylinder(math.P3(0,0,-6), math.V3(0,0,1), 3, 12)
+//	res, ok := brep.ConeCylinderCut(cyl, cone) // fat with a tapered tunnel
+//	res, ok = brep.ConeCylinderCut(cone, cyl)  // the two cone stubs
+func ConeCylinderCut(target, tool *topo.Body) (*topo.Body, bool) {
+	p, ok := coneCrossingPartsOf(target, tool)
+	if !ok {
+		return nil, false
+	}
+	if !loopsBetweenCaps(p.fat, p.fatBase, p.fatHeight, p.lo, p.hi) {
+		return nil, false // the breach reaches a fat cap (not a clean side breach): out of scope
+	}
+	if _, _, _, okCone := coneSolidParams(facesOfAny(target)); okCone {
+		return cutRodMinusFat(p), true // target is the cone rod: two disconnected tapered stubs
+	}
+	return drillFatWithRod(p), true // target is the fat cylinder: drill a tapered tunnel
+}
+
+// coneCrossingPartsOf resolves a cone body and a cylinder body into crossingParts (with the cone as the rod),
+// or ok=false when they are not one bare cone crossing one fatter cylinder in the full-crossing configuration
+// (exactly two imprint loops, the cone the rod both loops encircle, both loops between the cone's caps).
+func coneCrossingPartsOf(a, b *topo.Body) (*crossingParts, bool) {
+	loops, ok := coneCylinderImprint(a, b)
+	if !ok || len(loops) != 2 {
+		return nil, false
+	}
+	cone, vMin, vMax, cyl, fatBase, fatH, ok := coneCrossingGeom(a, b)
+	if !ok || !allLoopsEncircle(loops, coneAxis(cone)) || allLoopsEncircle(loops, cylAxis(cyl)) {
+		return nil, false // the cone must be the rod both loops encircle, the cylinder the lens-capped fat
+	}
+	if !loopsSpanCone(cone, vMin, vMax, loops) {
+		return nil, false // a loop beyond a cone cap is a partial penetration, not a full crossing
+	}
+	lo, hi, ok := assignRimLoops(coneAxis(cone), cylAxis(cyl), loops)
+	if !ok {
+		return nil, false
+	}
+	rodBase := cone.Apex.TranslateBy(cone.AxisDir.AsVector().Scale(vMin))
+	return &crossingParts{coneRod{cone}, cyl, rodBase, fatBase, vMax - vMin, fatH, lo, hi}, true
+}
+
+// coneCrossingGeom resolves the cone (with its apex-distance band [vMin, vMax]) and the fat cylinder (with its
+// cap base and height) from two bodies, in either order. ok=false unless one is a bare cone and the other a
+// bare cylinder.
+func coneCrossingGeom(a, b *topo.Body) (cone geom.Cone, vMin, vMax float64, cyl geom.Cylinder, fatBase math.Point3, fatHeight float64, ok bool) {
+	coneBody, cylBody := a, b
+	if _, _, _, okCone := coneSolidParams(facesOfAny(a)); !okCone {
+		coneBody, cylBody = b, a
+	}
+	cn, lo, hi, okCone := coneSolidParams(facesOfAny(coneBody))
+	cy, base, h, okCyl := cylinderSolidParams(facesOfAny(cylBody))
+	if !okCone || !okCyl {
+		return geom.Cone{}, 0, 0, geom.Cylinder{}, math.Point3{}, 0, false
+	}
+	return cn, lo, hi, cy, base, h, true
+}

--- a/kernel/brep/curved_cone_cylinder_cut_test.go
+++ b/kernel/brep/curved_cone_cylinder_cut_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Cone–cylinder cut assembly (M2 Phase 2, Oblikovati/Oblikovati#1335). Drilling a fat cylinder with a
+// crossing cone, and the two cone stubs of cone − fat, must weld into watertight analytic solids — the same
+// shapes as the crossing-cylinder drill/stubs, only the rod is a cone. Volumes are checked through ops_test;
+// here the concern is the watertight topology and that the surfaces stay analytic.
+
+// TestConeCylinderCutDrillsFat drills a radius-3 cylinder with a crossing frustum and checks the result is a
+// watertight four-face solid: two fat caps (planes), the holed fat wall (cylinder), and the cone tunnel band.
+func TestConeCylinderCutDrillsFat(t *testing.T) {
+	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	cone, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
+
+	res, ok := ConeCylinderCut(cyl, cone)
+	if !ok {
+		t.Fatal("cone drill of cylinder declined; want a four-face solid")
+	}
+	assertWatertight(t, res)
+	cones, cyls, planes := faceTypeCounts(t, res)
+	if cones != 1 || cyls != 1 || planes != 2 {
+		t.Errorf("drilled fat got %d cone + %d cyl + %d plane faces, want 1 (tunnel) + 1 (holed wall) + 2 (caps)",
+			cones, cyls, planes)
+	}
+}
+
+// TestConeCylinderCutConeMinusFatStubs subtracts the fat cylinder from the crossing cone and checks the
+// result is the two disconnected tapered stubs (a two-shell solid).
+func TestConeCylinderCutConeMinusFatStubs(t *testing.T) {
+	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	cone, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
+
+	res, ok := ConeCylinderCut(cone, cyl)
+	if !ok {
+		t.Fatal("cone − fat declined; want two tapered stubs")
+	}
+	assertWatertight(t, res)
+	if n := len(res.Shells()); n != 2 {
+		t.Errorf("cone − fat has %d shells, want 2 (a disconnected stub each side)", n)
+	}
+	cones, cyls, planes := faceTypeCounts(t, res)
+	if cones != 2 || cyls != 2 || planes != 2 {
+		t.Errorf("cone − fat got %d cone + %d cyl + %d plane faces, want 2 (stub bands) + 2 (lens caps) + 2 (cone end caps)",
+			cones, cyls, planes)
+	}
+}
+
+// TestConeCylinderCutTwoCylindersDefer: two cylinders are the crossing-cylinder drill, not this one.
+func TestConeCylinderCutTwoCylindersDefer(t *testing.T) {
+	a, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
+	b, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	if _, ok := ConeCylinderCut(a, b); ok {
+		t.Error("two cylinders should defer from the cone–cylinder cut (ok=false)")
+	}
+}
+
+// assertWatertight fails the test unless the body is a solid whose every edge is shared by exactly two faces.
+func assertWatertight(t *testing.T, b *topo.Body) {
+	t.Helper()
+	if !b.IsSolid() {
+		t.Fatalf("body is not a solid: %+v", b)
+	}
+	for _, e := range b.Edges() {
+		if uses := len(e.Uses()); uses != 2 {
+			t.Errorf("edge %v has %d uses, want 2 (a closed manifold)", e.Lineage(), uses)
+		}
+	}
+}
+
+// faceTypeCounts tallies a body's faces by analytic surface type, failing the test on any non-analytic face.
+func faceTypeCounts(t *testing.T, b *topo.Body) (cones, cyls, planes int) {
+	t.Helper()
+	for _, f := range b.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cone:
+			cones++
+		case geom.Cylinder:
+			cyls++
+		case geom.Plane:
+			planes++
+		default:
+			t.Errorf("face surface %T is not analytic", f.Geometry())
+		}
+	}
+	return
+}

--- a/kernel/brep/curved_cone_cylinder_join.go
+++ b/kernel/brep/curved_cone_cylinder_join.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import "oblikovati.org/kernel/topo"
+
+// Cone–cylinder join (M2 Phase 2, Oblikovati/Oblikovati#1335). The union of a cone (a tapered rod) passing
+// right through a fatter cylinder: one connected solid — the fat's two caps and its holed side wall (the two
+// lens holes), plus a cone-wall STUB protruding from each lens hole out to the cone's own end cap. It reuses
+// the crossing-cylinder join builder (joinFatAndRod) unchanged: the rod is just a cone (a crossRod), so each
+// stub band lofts through the same ruled saddle-band path and the frustum's two ends carry their own radii.
+
+// ConeCylinderJoin builds fat ∪ cone for a cone crossing a cylinder (the fat with a tapered stub each side),
+// or ok=false to defer (a non-cone/non-cylinder operand, a cone that does not fully cross, or a breach that
+// reaches a fat cap) so kernel/ops keeps its CSG fallback.
+//
+// Example — a radius-1→2.5 frustum on x joined with a crossing radius-3 cylinder on z gives the fat with two
+// tapered stubs:
+//
+//	cone, _ := brep.SolidCylinderCone(math.P3(-6,0,0), math.P3(6,0,0), 1, 2.5, "cone")
+//	cyl, _  := brep.SolidCylinder(math.P3(0,0,-6), math.V3(0,0,1), 3, 12)
+//	res, ok := brep.ConeCylinderJoin(cyl, cone)
+func ConeCylinderJoin(a, b *topo.Body) (*topo.Body, bool) {
+	p, ok := coneCrossingPartsOf(a, b)
+	if !ok {
+		return nil, false
+	}
+	if !loopsBetweenCaps(p.fat, p.fatBase, p.fatHeight, p.lo, p.hi) {
+		return nil, false // a stub would breach a fat cap, not the side wall: out of scope
+	}
+	return joinFatAndRod(p), true
+}

--- a/kernel/brep/curved_cone_cylinder_join_test.go
+++ b/kernel/brep/curved_cone_cylinder_join_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// Cone–cylinder join assembly (M2 Phase 2, Oblikovati/Oblikovati#1335). A cone passing through a fatter
+// cylinder must weld into one watertight solid — the fat with a tapered stub each side — the same shape as
+// the crossing-cylinder join, only the rod is a cone. Volume is checked through ops_test; here the concern is
+// the watertight topology and that the surfaces stay analytic.
+
+// TestConeCylinderJoinFatWithStubs joins a radius-3 cylinder with a crossing frustum and checks the result is
+// a watertight seven-face solid: two fat caps, the holed fat wall, and two cone stubs each capped by a disc.
+func TestConeCylinderJoinFatWithStubs(t *testing.T) {
+	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	cone, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
+
+	res, ok := ConeCylinderJoin(cyl, cone)
+	if !ok {
+		t.Fatal("cone ∪ cylinder declined; want the fat with two tapered stubs")
+	}
+	assertWatertight(t, res)
+	if n := len(res.Shells()); n != 1 {
+		t.Errorf("cone ∪ fat has %d shells, want 1 (one connected solid)", n)
+	}
+	cones, cyls, planes := faceTypeCounts(t, res)
+	if cones != 2 || cyls != 1 || planes != 4 {
+		t.Errorf("cone ∪ fat got %d cone + %d cyl + %d plane faces, want 2 (stub bands) + 1 (holed wall) + 4 (2 fat caps + 2 cone end caps)",
+			cones, cyls, planes)
+	}
+}
+
+// TestConeCylinderJoinOrderIndependent: joining works whichever body is passed first.
+func TestConeCylinderJoinOrderIndependent(t *testing.T) {
+	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	cone, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
+	if _, ok := ConeCylinderJoin(cone, cyl); !ok {
+		t.Error("cone ∪ cylinder should resolve with the cone passed first too")
+	}
+}

--- a/kernel/brep/curved_cross_rod.go
+++ b/kernel/brep/curved_cross_rod.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Crossing-rod abstraction (M2 Phase 2, Oblikovati/Oblikovati#1335). The cut/join stub builders
+// (curved_crossing_cut.go, curved_crossing_join.go) assemble a fat cylinder breached by a "rod" crossing it.
+// The rod is a cylinder when two cylinders cross, but a CONE when a tapered rod crosses a cylinder — and the
+// only places the surface type matters are the band/stub faces (the rod's analytic surface), its axis (for
+// angle math and the two end-cap centres), and the radius of its end circle at a given cap. crossRod exposes
+// exactly those, so the same drill/join/stub assembly serves a cone rod without duplication. This mirrors the
+// crossAxis split that let the imprint/classify stage classify a cone rod (curved_crossing_intersect.go).
+
+// crossRod is the rod operand of a crossing boolean — a cylinder or a cone — exposed through just what the
+// stub builders need: its analytic surface (for the band faces), its axis (direction + the crossAxis for
+// angle math), and the radius of its end circle at a given cap centre.
+type crossRod interface {
+	surface() geom.Surface
+	axisUnit() math.UnitVector3
+	axisVec() math.Vector3
+	axisOf() crossAxis
+	endRadius(center math.Point3) float64
+}
+
+// cylinderRod adapts a geom.Cylinder as a crossRod: its end circle has the cylinder's constant radius.
+type cylinderRod struct{ c geom.Cylinder }
+
+func (r cylinderRod) surface() geom.Surface         { return r.c }
+func (r cylinderRod) axisUnit() math.UnitVector3    { return r.c.AxisDir }
+func (r cylinderRod) axisVec() math.Vector3         { return r.c.AxisDir.AsVector() }
+func (r cylinderRod) axisOf() crossAxis             { return cylAxis(r.c) }
+func (r cylinderRod) endRadius(math.Point3) float64 { return r.c.Radius }
+
+// coneRod adapts a geom.Cone as a crossRod: its end circle radius is v·tan(HalfAngle), where v is the cap
+// centre's distance from the apex along the axis — so a frustum's two ends carry different radii.
+type coneRod struct{ c geom.Cone }
+
+func (r coneRod) surface() geom.Surface      { return r.c }
+func (r coneRod) axisUnit() math.UnitVector3 { return r.c.AxisDir }
+func (r coneRod) axisVec() math.Vector3      { return r.c.AxisDir.AsVector() }
+func (r coneRod) axisOf() crossAxis          { return coneAxis(r.c) }
+
+func (r coneRod) endRadius(center math.Point3) float64 {
+	v := float64(r.c.Apex.VectorTo(center).Dot(r.c.AxisDir.AsVector()))
+	return v * stdmath.Tan(r.c.HalfAngle)
+}

--- a/kernel/brep/curved_crossing_cut.go
+++ b/kernel/brep/curved_crossing_cut.go
@@ -49,11 +49,13 @@ func CrossingCylinderCut(target, tool *topo.Body) (*topo.Body, bool) {
 	return drillFatWithRod(p), true // target is the fat: drill a tunnel
 }
 
-// crossingParts holds the resolved geometry of two crossing cylinders: the rod (both imprint loops encircle
-// it) and the fat cylinder, each with its cap extent, plus the two imprint loops oriented CCW about the rod
-// axis and assigned to the lower (lo) and upper (hi) end of the band (see assignRimLoops).
+// crossingParts holds the resolved geometry of a crossing boolean: the rod (a cylinder or a cone, both
+// imprint loops encircle it) and the fat cylinder, each with its cap extent, plus the two imprint loops
+// oriented CCW about the rod axis and assigned to the lower (lo) and upper (hi) end of the band (see
+// assignRimLoops). rodBase is the rod's lower-axis cap centre and rodHeight its axial length.
 type crossingParts struct {
-	rod, fat             geom.Cylinder
+	rod                  crossRod
+	fat                  geom.Cylinder
 	rodBase, fatBase     math.Point3
 	rodHeight, fatHeight float64
 	lo, hi               geom.Polyline
@@ -80,7 +82,7 @@ func crossingPartsOf(a, b *topo.Body) (*crossingParts, bool) {
 	if !ok {
 		return nil, false
 	}
-	return &crossingParts{rod, fat, rodBase, fatBase, rodH, fatH, lo, hi}, true
+	return &crossingParts{cylinderRod{rod}, fat, rodBase, fatBase, rodH, fatH, lo, hi}, true
 }
 
 // orderRodFat picks which of the two cylinders is the rod (both loops encircle it) and which is the fat
@@ -124,7 +126,7 @@ func drillFatWithRod(p *crossingParts) *topo.Body {
 	eHi := bld.AddEdge(p.hi, vHi, vHi, crossLin("ehi"))
 	rSeam := bld.AddEdge(geom.NewLineSegment(loPts[0], hiPts[0]), vLo, vHi, crossLin("rseam"))
 	// The tunnel wall is the rod band flipped inward (kept material is outside the rod).
-	bld.AddReversedFace(p.rod, crossLin("tunnel"),
+	bld.AddReversedFace(p.rod.surface(), crossLin("tunnel"),
 		topo.OuterLoop(topo.Fwd(rSeam), topo.Rev(eHi), topo.Rev(rSeam), topo.Fwd(eLo)))
 	addFatCapsAndHoledWall(bld, p.fat, p.fatBase, p.fatHeight, clearSeamParam(p.fat, p.lo, p.hi),
 		topo.Rev(eLo), topo.Fwd(eHi))

--- a/kernel/brep/curved_crossing_join.go
+++ b/kernel/brep/curved_crossing_join.go
@@ -3,6 +3,8 @@
 package brep
 
 import (
+	stdmath "math"
+
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -51,7 +53,7 @@ func joinFatAndRod(p *crossingParts) *topo.Body {
 	eHi := bld.AddEdge(p.hi, vHi, vHi, crossLin("ehi"))
 	addFatCapsAndHoledWall(bld, p.fat, p.fatBase, p.fatHeight, clearSeamParam(p.fat, p.lo, p.hi),
 		topo.Rev(eLo), topo.Fwd(eHi))
-	axis := p.rod.AxisDir.AsVector()
+	axis := p.rod.axisVec()
 	rodFar := p.rodBase.TranslateBy(axis.Scale(math.Scalar(p.rodHeight)))
 	// The lo lens (fat-outward along −rodaxis) connects to the rod's base end; the hi lens to the far end.
 	// The wall holes are InnerLoop(Rev(eLo)) and InnerLoop(Fwd(eHi)), so the stubs take the opposite half.
@@ -68,9 +70,9 @@ func joinFatAndRod(p *crossingParts) *topo.Body {
 // blind hole) and the end cap faces back into the void. The end cap faces along capNormal (the outward
 // ±rod-axis), negated when reversed. The end circle is re-seamed to the lens loop's start angle so the band
 // loft stitches a near-constant-angle seam.
-func addRodStub(bld *topo.Builder, rod geom.Cylinder, endCenter math.Point3, capNormal math.Vector3, eLens *topo.Edge, vLens *topo.Vertex, lensStart math.Point3, lensFwd, reversed bool, tag string) {
+func addRodStub(bld *topo.Builder, rod crossRod, endCenter math.Point3, capNormal math.Vector3, eLens *topo.Edge, vLens *topo.Vertex, lensStart math.Point3, lensFwd, reversed bool, tag string) {
 	seamPt := stubSeamPoint(rod, endCenter, lensStart)
-	endC := seamedCircle(endCenter, rod.AxisDir, seamPt, rod.Radius)
+	endC := seamedCircle(endCenter, rod.axisUnit(), seamPt, rod.endRadius(endCenter))
 	vEnd := bld.AddVertex(seamPt, crossLin(tag+"ve"))
 	eEnd := bld.AddEdge(endC, vEnd, vEnd, crossLin(tag+"ee"))
 	eSeam := bld.AddEdge(geom.NewLineSegment(seamPt, lensStart), vEnd, vLens, crossLin(tag+"es"))
@@ -81,26 +83,30 @@ func addRodStub(bld *topo.Builder, rod geom.Cylinder, endCenter math.Point3, cap
 	band := topo.OuterLoop(lensHalf, topo.Rev(eSeam), topo.Fwd(eEnd), topo.Fwd(eSeam))
 	capNorm := capNormal
 	if reversed {
-		bld.AddReversedFace(rod, crossLin(tag+"band"), band)
+		bld.AddReversedFace(rod.surface(), crossLin(tag+"band"), band)
 		capNorm = capNormal.Scale(-1)
 	} else {
-		bld.AddFace(rod, crossLin(tag+"band"), band)
+		bld.AddFace(rod.surface(), crossLin(tag+"band"), band)
 	}
 	cap, _ := geom.NewPlane(endCenter, capNorm)
 	bld.AddFace(cap, crossLin(tag+"cap"), topo.OuterLoop(topo.Rev(eEnd)))
 }
 
 // stubSeamPoint returns the point on the rod's end circle at the same axial angle as the lens loop's start,
-// so the seam connecting them is a near-constant-angle ruling of the rod (lying on the surface).
-func stubSeamPoint(rod geom.Cylinder, endCenter, lensStart math.Point3) math.Point3 {
-	v := float64(rod.Origin.VectorTo(endCenter).Dot(rod.AxisDir.AsVector()))
-	return rod.PointAt(axisAngleOf(lensStart, cylAxis(rod)), v)
+// so the seam connecting them is a near-constant-angle ruling of the rod (lying on the surface). It rebuilds
+// the point from the rod's axis frame (ref·cos u + binormal·sin u, the convention both geom.Cylinder and
+// geom.Cone use) at the end's radius, so it works for a cone end too.
+func stubSeamPoint(rod crossRod, endCenter, lensStart math.Point3) math.Point3 {
+	ax := rod.axisOf()
+	u := axisAngleOf(lensStart, ax)
+	radial := ax.ref.Scale(stdmath.Cos(u)).Add(ax.dir.Cross(ax.ref).Scale(stdmath.Sin(u)))
+	return endCenter.TranslateBy(radial.Scale(rod.endRadius(endCenter)))
 }
 
 // cutRodMinusFat builds rod − fat: the two rod stubs sticking out either side of the fat, each a separate
 // closed lump, merged into one multi-shell body (the boolean result is two disconnected pieces).
 func cutRodMinusFat(p *crossingParts) *topo.Body {
-	axis := p.rod.AxisDir.AsVector()
+	axis := p.rod.axisVec()
 	rodFar := p.rodBase.TranslateBy(axis.Scale(math.Scalar(p.rodHeight)))
 	lo := rodStubLump(p.rod, p.fat, p.rodBase, axis.Scale(-1), p.lo, "rlo")
 	hi := rodStubLump(p.rod, p.fat, rodFar, axis, p.hi, "rhi")
@@ -110,7 +116,7 @@ func cutRodMinusFat(p *crossingParts) *topo.Body {
 // rodStubLump builds one closed rod stub: its wall band, the rod end cap, and the fat-wall lens closing the
 // inner end. The lens cap is the fat surface REVERSED — the kept material is outside the fat, so the lens
 // normal points back into the fat (away from the stub). Its edge is shared with the stub band opposite.
-func rodStubLump(rod, fat geom.Cylinder, endCenter math.Point3, capNormal math.Vector3, lens geom.Polyline, tag string) *topo.Body {
+func rodStubLump(rod crossRod, fat geom.Cylinder, endCenter math.Point3, capNormal math.Vector3, lens geom.Polyline, tag string) *topo.Body {
 	bld := topo.NewBuilder(true, crossLin(tag))
 	vLens := bld.AddVertex(lens.Vertices[0], crossLin(tag+"vl"))
 	eLens := bld.AddEdge(lens, vLens, vLens, crossLin(tag+"el"))

--- a/kernel/brep/curved_partial_penetration.go
+++ b/kernel/brep/curved_partial_penetration.go
@@ -155,7 +155,7 @@ func partialPlug(p *partialPlugParts) *topo.Body {
 	vLens := bld.AddVertex(lensStart, partLin("vlens"))
 	eLens := bld.AddEdge(p.lens, vLens, vLens, partLin("elens"))
 	bld.AddFace(p.fat, partLin("lenscap"), topo.OuterLoop(topo.Rev(eLens)))
-	addRodStub(bld, p.rod, p.blindCenter, p.blindNormal, eLens, vLens, lensStart, true, false, "plug")
+	addRodStub(bld, cylinderRod{p.rod}, p.blindCenter, p.blindNormal, eLens, vLens, lensStart, true, false, "plug")
 	return bld.Build()
 }
 
@@ -186,7 +186,7 @@ func PartialPenetrationCut(target, tool *topo.Body) (*topo.Body, bool) {
 // side (the rod material outside the fat), a closed lump of the rod stub band, the rod's entry end cap, and
 // the fat-wall lens reversed to face back into the fat (the kept material is outside it).
 func partialRodMinusFat(p *partialPlugParts) *topo.Body {
-	return rodStubLump(p.rod, p.fat, p.entryCenter, p.entryNormal, p.lens, "prmf")
+	return rodStubLump(cylinderRod{p.rod}, p.fat, p.entryCenter, p.entryNormal, p.lens, "prmf")
 }
 
 // PartialPenetrationJoin builds target ∪ tool for a thin rod ending inside the fatter cylinder, or ok=false
@@ -218,7 +218,7 @@ func blindHole(p *partialPlugParts) *topo.Body {
 	vLens := bld.AddVertex(lensStart, partLin("vlens"))
 	eLens := bld.AddEdge(p.lens, vLens, vLens, partLin("elens"))
 	addFatCapsAndHoledWall(bld, p.fat, p.fatBase, p.fatHeight, clearSeamForLens(p.fat, p.lens), topo.Rev(eLens))
-	addRodStub(bld, p.rod, p.blindCenter, p.blindNormal, eLens, vLens, lensStart, true, true, "blind")
+	addRodStub(bld, cylinderRod{p.rod}, p.blindCenter, p.blindNormal, eLens, vLens, lensStart, true, true, "blind")
 	return bld.Build()
 }
 
@@ -232,6 +232,6 @@ func partialJoinStub(p *partialPlugParts) *topo.Body {
 	vLens := bld.AddVertex(lensStart, partLin("vlens"))
 	eLens := bld.AddEdge(p.lens, vLens, vLens, partLin("elens"))
 	addFatCapsAndHoledWall(bld, p.fat, p.fatBase, p.fatHeight, clearSeamForLens(p.fat, p.lens), topo.Rev(eLens))
-	addRodStub(bld, p.rod, p.entryCenter, p.entryNormal, eLens, vLens, lensStart, true, false, "jstub")
+	addRodStub(bld, cylinderRod{p.rod}, p.entryCenter, p.entryNormal, eLens, vLens, lensStart, true, false, "jstub")
 	return bld.Build()
 }

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -126,7 +126,8 @@ func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.L
 //   - two EQUAL-radius perpendicular cylinders ∩/−/∪ (the Steinmetz bicylinder and its cut/union, fitted as crossing ellipses) (#1335);
 //   - a thin rod ending inside a fatter cylinder ∩/−/∪ (a partial penetration: the plug, a blind hole, a one-sided stub) (#1335);
 //   - drilling a fat cylinder with a crossing rod (fat − rod), and the two rod stubs of rod − fat (#1335);
-//   - joining two crossing cylinders (fat ∪ rod: the fat with a rod stub each side) (#1335).
+//   - joining two crossing cylinders (fat ∪ rod: the fat with a rod stub each side) (#1335);
+//   - drilling/joining a fat cylinder with a crossing CONE (the tapered tunnel/stubs of cone − fat / fat ∪ cone) (#1335).
 func curvedExactBoolean(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
 	for _, exact := range curvedExactPaths {
 		if body, ok := exact(op, target, tool); ok {
@@ -141,8 +142,8 @@ func curvedExactBoolean(op PartFeatureOperation, target, tool *topo.Body) (*topo
 var curvedExactPaths = []func(PartFeatureOperation, *topo.Body, *topo.Body) (*topo.Body, bool){
 	curvedConvexIntersect, curvedConvexSubtract,
 	curvedCrossingIntersect, curvedSteinmetzIntersect, curvedConeCylinderIntersect, curvedPartialIntersect,
-	curvedPartialCut, curvedSteinmetzCut, curvedCrossingCut,
-	curvedPartialJoin, curvedCrossingJoin, curvedSteinmetzJoin,
+	curvedPartialCut, curvedSteinmetzCut, curvedConeCylinderCut, curvedCrossingCut,
+	curvedPartialJoin, curvedConeCylinderJoin, curvedCrossingJoin, curvedSteinmetzJoin,
 }
 
 func shouldFallbackBoolean(op PartFeatureOperation, target, tool, body *topo.Body) bool {

--- a/kernel/ops/boolean_cone_cylinder_test.go
+++ b/kernel/ops/boolean_cone_cylinder_test.go
@@ -9,6 +9,7 @@ import (
 	"oblikovati.org/kernel/brep"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 )
 
@@ -77,5 +78,96 @@ func TestBooleanIntersectConeCylinder(t *testing.T) {
 	want := coneCylinderIntersectVolume(rFat)
 	if rel := stdmath.Abs(got-want) / want; rel > 0.03 {
 		t.Errorf("cone∩cylinder volume %.4f, want %.4f (analytic) — rel %.4f > 3%%", got, want, rel)
+	}
+}
+
+// coneFrustumVolume is the volume of a frustum of axial length h between end radii r0 and r1:
+// π·h/3·(r0² + r0·r1 + r1²).
+func coneFrustumVolume(r0, r1, h float64) float64 {
+	return stdmath.Pi * h / 3 * (r0*r0 + r0*r1 + r1*r1)
+}
+
+// TestBooleanCutConeCylinderDrillsFat drills a radius-3 cylinder (axis z) with a crossing frustum (radius
+// 1→2.5, axis x): Cut must give the exact analytic solid (two fat caps, the holed fat wall, the cone tunnel)
+// whose volume is the fat minus the cone∩cylinder, not triangle-soup CSG.
+func TestBooleanCutConeCylinderDrillsFat(t *testing.T) {
+	const rFat, hFat = 3.0, 12.0
+	cyl, _ := brep.SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), rFat, hFat)
+	cone, _ := brep.SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
+
+	res, err := ops.Boolean(ops.Cut, cyl, cone)
+	if err != nil {
+		t.Fatalf("Boolean(Cut fat−cone): %v", err)
+	}
+	if v := ops.Validate(res); !v.Valid || !v.Closed || !v.Manifold || !res.IsSolid() {
+		t.Fatalf("drilled cylinder is not a valid closed manifold solid: %+v", v)
+	}
+	assertConeCylinderAnalytic(t, res)
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	want := stdmath.Pi*rFat*rFat*hFat - coneCylinderIntersectVolume(rFat)
+	// 4%: the tapered tunnel and the drilled wall inscribe their curvature, so the meshed volume runs a
+	// little under the analytic fat − tunnel (the B-rep is exact; this bounds the property-mesh error).
+	if rel := stdmath.Abs(got-want) / want; rel > 0.04 {
+		t.Errorf("drilled volume %.4f, want %.4f (fat − cone∩cyl) — rel %.4f > 4%%", got, want, rel)
+	}
+}
+
+// TestBooleanCutConeMinusCylinderStubs subtracts a fat cylinder from a crossing frustum: Cut must give the
+// two disconnected tapered stubs (a two-shell solid) whose total volume is the cone minus the cone∩cylinder.
+func TestBooleanCutConeMinusCylinderStubs(t *testing.T) {
+	const rFat = 3.0
+	cyl, _ := brep.SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), rFat, 12)
+	cone, _ := brep.SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
+
+	res, err := ops.Boolean(ops.Cut, cone, cyl) // cone − fat
+	if err != nil {
+		t.Fatalf("Boolean(Cut cone−fat): %v", err)
+	}
+	if v := ops.Validate(res); !v.Valid || !v.Closed || !v.Manifold || !res.IsSolid() {
+		t.Fatalf("cone − fat is not a valid closed manifold solid: %+v", v)
+	}
+	if n := len(res.Shells()); n != 2 {
+		t.Errorf("cone − fat has %d shells, want 2 (a disconnected stub each side)", n)
+	}
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	want := coneFrustumVolume(1, 2.5, 12) - coneCylinderIntersectVolume(rFat)
+	if rel := stdmath.Abs(got-want) / want; rel > 0.04 {
+		t.Errorf("cone − fat volume %.4f, want %.4f (cone − cone∩cyl) — rel %.4f > 4%%", got, want, rel)
+	}
+}
+
+// TestBooleanJoinConeCylinder joins a radius-3 cylinder (axis z) with a crossing frustum (radius 1→2.5, axis
+// x): Join must give the connected analytic solid (fat caps, holed fat wall, a tapered stub each side) whose
+// volume is fat + cone − the cone∩cylinder, not triangle-soup CSG.
+func TestBooleanJoinConeCylinder(t *testing.T) {
+	const rFat, hFat = 3.0, 12.0
+	cyl, _ := brep.SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), rFat, hFat)
+	cone, _ := brep.SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
+
+	res, err := ops.Boolean(ops.Join, cyl, cone)
+	if err != nil {
+		t.Fatalf("Boolean(Join cyl∪cone): %v", err)
+	}
+	if v := ops.Validate(res); !v.Valid || !v.Closed || !v.Manifold || !res.IsSolid() {
+		t.Fatalf("joined cone∪cylinder is not a valid closed manifold solid: %+v", v)
+	}
+	assertConeCylinderAnalytic(t, res)
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	want := stdmath.Pi*rFat*rFat*hFat + coneFrustumVolume(1, 2.5, 12) - coneCylinderIntersectVolume(rFat)
+	if rel := stdmath.Abs(got-want) / want; rel > 0.04 {
+		t.Errorf("joined volume %.4f, want %.4f (fat + cone − cone∩cyl) — rel %.4f > 4%%", got, want, rel)
+	}
+}
+
+// assertConeCylinderAnalytic fails the test on any face whose surface is not a cone, cylinder, or plane (the
+// exact analytic path must run, not the triangle-soup CSG fallback).
+func assertConeCylinderAnalytic(t *testing.T, res *topo.Body) {
+	t.Helper()
+	for _, f := range res.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cone, geom.Cylinder, geom.Plane:
+		default:
+			t.Errorf("face surface %T is not analytic (the exact path must run, not CSG)", f.Geometry())
+		}
 	}
 }

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -98,6 +98,34 @@ func curvedPartialJoin(op PartFeatureOperation, target, tool *topo.Body) (*topo.
 	return res, true
 }
 
+// curvedConeCylinderCut returns target − tool for a cone crossing a cylinder (drilling the fat cylinder with
+// the cone, or the two cone stubs of cone − fat), or ok=false to defer. Only Cut maps here, and only a valid
+// closed manifold result is adopted.
+func curvedConeCylinderCut(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+	if op != Cut {
+		return nil, false
+	}
+	res, ok := brep.ConeCylinderCut(target, tool)
+	if !ok || !validBooleanSolid(res) {
+		return nil, false
+	}
+	return res, true
+}
+
+// curvedConeCylinderJoin returns target ∪ tool for a cone crossing a cylinder (a fat cylinder side-breached
+// by a cone passing through it, leaving a tapered stub each side), or ok=false to defer. Only Join maps here,
+// and only a valid closed manifold result is adopted.
+func curvedConeCylinderJoin(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+	if op != Join {
+		return nil, false
+	}
+	res, ok := brep.ConeCylinderJoin(target, tool)
+	if !ok || !validBooleanSolid(res) {
+		return nil, false
+	}
+	return res, true
+}
+
 // curvedSteinmetzCut returns target − tool for two equal-radius perpendicular cylinders (the target with
 // the tool's saddle bite removed), or ok=false to defer. Only Cut maps here, and only a valid closed
 // manifold result is adopted.


### PR DESCRIPTION
## What

Completes the cut and join outcomes for a **cone (a tapered rod) crossing a fatter cylinder**, the next slice of M2 Phase 2 (#1335). The intersection already shipped (#1360); this wires the other three boolean results into `ops.Boolean`, exact analytic surfaces preserved:

- **`Cut(fat, cone)`** — the fat cylinder drilled by the cone: its two caps, the side wall carrying the two lens holes, and the cone band flipped inward as a **tapered tunnel**.
- **`Cut(cone, fat)`** — `cone − fat`: the **two disconnected tapered stubs** sticking out either side of the fat, a two-shell solid.
- **`Join(fat, cone)`** — one connected solid: the fat caps and holed wall, plus a cone **stub** out of each lens hole to the cone's own end cap.

## Why this was small

The drill/join/stub assembly was already built for two crossing cylinders. The only thing that differed for a cone rod was the band/stub **surface** and its **end-circle radius** (constant for a cylinder, growing with apex distance for a cone). So the rod is abstracted behind a new `crossRod` interface (`cylinderRod` / `coneRod`) — mirroring the `crossAxis` split that already let the imprint/classify stage handle a cone rod. The cone band lofts through the **same ruled saddle-band path** (a cone is ruled along its slant, like a cylinder), so no new mesher.

The refactor is **behaviour-preserving**: cylinder callers wrap their rod in `cylinderRod{...}`; every crossing/partial/Steinmetz test still passes.

## Validation

- Watertight analytic topology (every edge shared by exactly two faces; faces are only cone/cylinder/plane).
- Volumes through `ops.Boolean` against the analytic `fat ∓ (cone∩cyl)` and `cone − (cone∩cyl)`, within the 4% mesh-inscription bound (the B-rep is exact; the bound is on the property mesh).
- Out-of-scope configurations (a cap-reaching breach, a cone ending inside the fat) defer to the CSG fallback.

Two commits: the `crossRod` refactor, then the cone cut/join + ops wiring + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)