### PR TITLE
Cone–cone intersection (M2 Phase 2)

### DIFF
--- a/kernel/brep/curved_cone_cone_intersect.go
+++ b/kernel/brep/curved_cone_cone_intersect.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+)
+
+// Cone–cone intersection (M2 Phase 2, Oblikovati/Oblikovati#1335). The split/classify/stitch stage after the
+// cone–cone imprint: a cone (or frustum) crossing a fatter cone, like a tapered rod through a tapered tube.
+// The result is the same three-face shape as the crossing-cylinder and cone–cylinder intersections — the
+// rod-wall BAND inside the fat (between the two loops) plus the two fat-wall LENS caps — only here BOTH the
+// rod and the fat are CONES. Because the loop classification works off each operand's axis (crossAxis) and
+// the stitch takes the rod and fat as geom.Surface, the cones reuse the whole pipeline: the rod cone band
+// lofts through the saddle-band path (a cone is ruled along its slant), and each lens cap is a trimmed patch
+// of the fat cone (a cone is developable, like a cylinder, so the metric-patch mesher handles it).
+
+// ConeConeIntersect builds the exact intersection of a cone crossing a fatter cone (the rod-cone band inside
+// the fat plus the two fat-cone lens caps), or ok=false when the configuration is outside the wired
+// cone-through-cone case (not exactly two imprint loops, neither cone is the rod both loops encircle, or a
+// loop lies beyond the rod cone's caps) so kernel/ops keeps its fallback.
+//
+// Example — a radius-0.8→1.5 frustum on x crossing a radius-2→4 frustum on z gives a three-face solid:
+//
+//	thin, _ := brep.SolidCylinderCone(math.P3(-6,0,0), math.P3(6,0,0), 0.8, 1.5, "thin")
+//	fat, _  := brep.SolidCylinderCone(math.P3(0,0,-6), math.P3(0,0,6), 2, 4, "fat")
+//	res, ok := brep.ConeConeIntersect(thin, fat) // rod-cone band capped by two fat-cone lenses
+func ConeConeIntersect(a, b *topo.Body) (*topo.Body, bool) {
+	loops, ok := coneConeImprint(a, b)
+	if !ok || len(loops) != 2 {
+		return nil, false
+	}
+	rod, fat, rodVMin, rodVMax, ok := rodAndFatCones(a, b, loops)
+	if !ok || !loopsSpanCone(rod, rodVMin, rodVMax, loops) {
+		return nil, false // a loop beyond a rod-cone cap is a partial penetration, not a full crossing
+	}
+	lo, hi, ok := assignRimLoops(coneAxis(rod), coneAxis(fat), loops)
+	if !ok {
+		return nil, false
+	}
+	return stitchRodWithSaddleCaps(rod, fat, lo, hi), true
+}
+
+// rodAndFatCones picks which cone is the rod (the band-bearing one both imprint loops fully encircle) and
+// which is the fat cone (the lens-capped one), carrying the rod cone's apex-distance band [vMin, vMax]
+// through. ok=false unless both bodies are bare cones and exactly one is the rod the loops encircle.
+func rodAndFatCones(a, b *topo.Body, loops []geom.Polyline) (rod, fat geom.Cone, rodVMin, rodVMax float64, ok bool) {
+	ca, aMin, aMax, okA := coneSolidParams(facesOfAny(a))
+	cb, bMin, bMax, okB := coneSolidParams(facesOfAny(b))
+	if !okA || !okB {
+		return geom.Cone{}, geom.Cone{}, 0, 0, false
+	}
+	aWraps, bWraps := allLoopsEncircle(loops, coneAxis(ca)), allLoopsEncircle(loops, coneAxis(cb))
+	if aWraps && !bWraps {
+		return ca, cb, aMin, aMax, true
+	}
+	if bWraps && !aWraps {
+		return cb, ca, bMin, bMax, true
+	}
+	return geom.Cone{}, geom.Cone{}, 0, 0, false
+}

--- a/kernel/brep/curved_cone_cone_intersect_test.go
+++ b/kernel/brep/curved_cone_cone_intersect_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// Cone–cone intersection assembly (M2 Phase 2, Oblikovati/Oblikovati#1335). A cone crossing a fatter cone
+// must weld into the same three-face shape as the crossing-cylinder and cone–cylinder intersections — a
+// rod-cone band plus two fat-cone lens caps — watertight, with every face an analytic cone. Volume is checked
+// through ops_test; here the concern is the watertight topology and that the surfaces stay analytic.
+
+// TestConeConeIntersectThreeFaces crosses a narrow frustum through a fatter frustum and checks the result is a
+// watertight three-face solid whose every face is a cone (the rod band and the two fat-cone lens caps).
+func TestConeConeIntersectThreeFaces(t *testing.T) {
+	thin, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 0.8, 1.5, "thin")
+	fat, _ := SolidCylinderCone(math.P3(0, 0, -6), math.P3(0, 0, 6), 2, 4, "fat")
+
+	res, ok := ConeConeIntersect(thin, fat)
+	if !ok {
+		t.Fatal("cone–cone intersection declined; want a three-face solid")
+	}
+	assertWatertight(t, res)
+	cones, cyls, planes := faceTypeCounts(t, res)
+	if cones != 3 || cyls != 0 || planes != 0 {
+		t.Errorf("got %d cone + %d cyl + %d plane faces, want 3 cones (rod band + 2 fat-cone lens caps)",
+			cones, cyls, planes)
+	}
+}
+
+// TestConeConeIntersectOrderIndependent: resolving works whichever cone is passed first.
+func TestConeConeIntersectOrderIndependent(t *testing.T) {
+	thin, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 0.8, 1.5, "thin")
+	fat, _ := SolidCylinderCone(math.P3(0, 0, -6), math.P3(0, 0, 6), 2, 4, "fat")
+	if _, ok := ConeConeIntersect(fat, thin); !ok {
+		t.Error("cone–cone intersection should resolve with the fat cone passed first too")
+	}
+}
+
+// TestConeConeIntersectConeCylinderDefer: a cone and a cylinder are the cone–cylinder case, not this one.
+func TestConeConeIntersectConeCylinderDefer(t *testing.T) {
+	cone, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
+	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	if _, ok := ConeConeIntersect(cone, cyl); ok {
+		t.Error("a cone and a cylinder should defer from the cone–cone intersection (ok=false)")
+	}
+}

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -123,6 +123,7 @@ func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.L
 //   - a curved solid − a convex prism tunnelling through it (cylinder − box) (#1334);
 //   - two crossing cylinders ∩ (rod band + fat-wall lens caps) (#1335);
 //   - a cone crossing a cylinder ∩ (cone band + cylinder-wall lens caps) (#1335);
+//   - a cone crossing a fatter cone ∩ (rod-cone band + fat-cone lens caps) (#1335);
 //   - two EQUAL-radius perpendicular cylinders ∩/−/∪ (the Steinmetz bicylinder and its cut/union, fitted as crossing ellipses) (#1335);
 //   - a thin rod ending inside a fatter cylinder ∩/−/∪ (a partial penetration: the plug, a blind hole, a one-sided stub) (#1335);
 //   - drilling a fat cylinder with a crossing rod (fat − rod), and the two rod stubs of rod − fat (#1335);
@@ -141,7 +142,8 @@ func curvedExactBoolean(op PartFeatureOperation, target, tool *topo.Body) (*topo
 // returns ok=false when it does not apply to (op, target, tool).
 var curvedExactPaths = []func(PartFeatureOperation, *topo.Body, *topo.Body) (*topo.Body, bool){
 	curvedConvexIntersect, curvedConvexSubtract,
-	curvedCrossingIntersect, curvedSteinmetzIntersect, curvedConeCylinderIntersect, curvedPartialIntersect,
+	curvedCrossingIntersect, curvedSteinmetzIntersect, curvedConeCylinderIntersect, curvedConeConeIntersect,
+	curvedPartialIntersect,
 	curvedPartialCut, curvedSteinmetzCut, curvedConeCylinderCut, curvedCrossingCut,
 	curvedPartialJoin, curvedConeCylinderJoin, curvedCrossingJoin, curvedSteinmetzJoin,
 }

--- a/kernel/ops/boolean_cone_cone_test.go
+++ b/kernel/ops/boolean_cone_cone_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+)
+
+// Cone–cone intersection through Boolean (M2 Phase 2, Oblikovati/Oblikovati#1335). A cone (a tapered rod)
+// crossing a fatter cone must Intersect to the exact analytic solid — the rod-cone band plus two fat-cone
+// lens caps — its volume matching the analytic cone∩cone, not triangle-soup CSG.
+
+// coneConeIntersectVolume is the volume of the thin frustum (axis x, apex x=−19.714, half-angle atan
+// 0.7/12, radius 0.8→1.5 over x∈[−6,6]) ∩ the fat frustum (axis z, apex z=−18, half-angle atan 2/12, radius
+// 2→4 over z∈[−6,6]). The two cone constraints couple all three coordinates (unlike a cone∩cylinder slab
+// clip), so the oracle is a deterministic midpoint sum over a world-space grid bounding the thin rod.
+func coneConeIntersectVolume() float64 {
+	const thinTan, fatTan = 0.7 / 12.0, 2.0 / 12.0
+	thinApexX, fatApexZ := -6.0-0.8/thinTan, -6.0-2.0/fatTan
+	const nx, nyz = 360, 150
+	lo, hi, yz := -6.0, 6.0, 1.6
+	dx, dyz := (hi-lo)/nx, 2*yz/nyz
+	cnt := 0
+	for i := 0; i < nx; i++ {
+		x := lo + (float64(i)+0.5)*dx
+		rThin := (x - thinApexX) * thinTan
+		for j := 0; j < nyz; j++ {
+			y := -yz + (float64(j)+0.5)*dyz
+			for k := 0; k < nyz; k++ {
+				z := -yz + (float64(k)+0.5)*dyz
+				rFat := (z - fatApexZ) * fatTan
+				if y*y+z*z <= rThin*rThin && x*x+y*y <= rFat*rFat {
+					cnt++
+				}
+			}
+		}
+	}
+	return float64(cnt) * dx * dyz * dyz
+}
+
+// TestBooleanIntersectConeCone crosses a narrow frustum through a fatter frustum and checks the result is the
+// exact three-face analytic solid (all cone faces) with the analytic cone∩cone volume.
+func TestBooleanIntersectConeCone(t *testing.T) {
+	thin, _ := brep.SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 0.8, 1.5, "thin")
+	fat, _ := brep.SolidCylinderCone(math.P3(0, 0, -6), math.P3(0, 0, 6), 2, 4, "fat")
+
+	res, err := ops.Boolean(ops.Intersect, thin, fat)
+	if err != nil {
+		t.Fatalf("Boolean(Intersect cone∩cone): %v", err)
+	}
+	if v := ops.Validate(res); !v.Valid || !v.Closed || !v.Manifold || !res.IsSolid() {
+		t.Fatalf("cone∩cone is not a valid closed manifold solid: %+v", v)
+	}
+	for _, f := range res.Faces() {
+		if _, ok := f.Geometry().(geom.Cone); !ok {
+			t.Errorf("face surface %T is not a cone (the exact path must run, not CSG)", f.Geometry())
+		}
+	}
+	if n := len(res.Faces()); n != 3 {
+		t.Errorf("cone∩cone has %d faces, want 3 (rod band + 2 fat-cone lens caps)", n)
+	}
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	want := coneConeIntersectVolume()
+	if rel := stdmath.Abs(got-want) / want; rel > 0.03 {
+		t.Errorf("cone∩cone volume %.4f, want %.4f (analytic) — rel %.4f > 3%%", got, want, rel)
+	}
+}

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -42,6 +42,20 @@ func curvedConeCylinderIntersect(op PartFeatureOperation, target, tool *topo.Bod
 	return res, true
 }
 
+// curvedConeConeIntersect returns the exact intersection of a cone crossing a fatter cone (the rod-cone band
+// plus two fat-cone lens caps), or ok=false to defer. Only Intersect maps here, and only a valid closed
+// manifold result is adopted.
+func curvedConeConeIntersect(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+	if op != Intersect {
+		return nil, false
+	}
+	res, ok := brep.ConeConeIntersect(target, tool)
+	if !ok || !validBooleanSolid(res) {
+		return nil, false
+	}
+	return res, true
+}
+
 // curvedSteinmetzIntersect returns the exact intersection of two equal-radius perpendicular cylinders (the
 // Steinmetz bicylinder), or ok=false to defer. Only Intersect maps here, and only a valid closed manifold
 // result is adopted. This is the equal-radius case the SSI imprint tracer cannot trace (it pinches), fitted


### PR DESCRIPTION
## What

A **cone (a tapered rod) crossing a fatter cone** now Intersects to the exact analytic solid — the same three-face shape as the crossing-cylinder (#1350) and cone–cylinder (#1360) intersections: the rod-cone wall **band** inside the fat plus the two fat-wall **lens caps** — only here **both** operands are cones.

`ConeConeIntersect` reuses the whole crossing pipeline unchanged:
- the imprint loops (#1363) are classified off each cone's axis (`crossAxis`/`coneAxis`); the rod is the cone both loops encircle (`rodAndFatCones`);
- `stitchRodWithSaddleCaps` — which already takes the rod and fat as `geom.Surface` — welds the three faces;
- the rod-cone band lofts through the saddle-band path (a cone is ruled along its slant), and **each lens cap is a trimmed patch of the fat cone** — a cone is developable like a cylinder, so the metric-patch mesher handles it (the key thing this slice de-risked);
- `loopsSpanCone` defers a rod cone ending inside (a partial penetration).

Wired into `Boolean` as `curvedConeConeIntersect`; a cone + a cylinder defers to the cone–cylinder path.

## Validation

A radius-0.8→1.5 frustum (axis x) crossing a radius-2→4 frustum (axis z) gives a **watertight three-face all-cone solid**. Volume through `ops.Boolean` against a deterministic world-space grid integral of the two coupled cone constraints: **1.2% under** the converged oracle (24.30 vs 24.60), within the 3% tolerance. The fat-cone lens caps tessellate cleanly (valid closed manifold).

## Phase 2 status (#1335)

With this, **cone∩cone intersect** joins the complete set. Remaining cone–cone slices (cut/join) would follow the cone–cylinder cut/join pattern; the trimmed cone-patch tessellation they need is now proven here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)