### PR TITLE
Cone–cone cut and join (M2 Phase 2)

### DIFF
--- a/kernel/brep/curved_cone_cone_cut.go
+++ b/kernel/brep/curved_cone_cone_cut.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Cone–cone cut (M2 Phase 2, Oblikovati/Oblikovati#1335). The two subtraction outcomes when a cone (a
+// tapered rod) crosses a fatter cone, assembled from the cone–cone imprint loops exactly like the
+// crossing-cylinder and cone–cylinder drills (curved_crossing_cut.go) — both the rod AND the fat are now
+// cones (crossRods), so the fat's caps take the cone's radius at each end and its holed side wall is a holed
+// CONE wall (a cone is developable, so the unroll-and-CDT mesher meshes it):
+//
+//   - Cut(fat, cone): the fat cone drilled by the rod cone — its two caps, its side wall carrying the two
+//     lens holes, and the rod-cone band flipped inward as the tapered tunnel (drillFatWithRod).
+//   - Cut(cone, fat): the rod cone − the fat cone — the two disconnected tapered stubs, each a closed lump
+//     (a rod-cone band, the rod's end cap, and the fat-cone lens), merged into one multi-shell body
+//     (cutRodMinusFat).
+
+// ConeConeCut returns target − tool for a cone crossing a fatter cone, or ok=false to defer (a non-cone
+// operand, the cone–cylinder case, a breach reaching a fat cap, or a rod cone that does not fully cross) so
+// kernel/ops keeps its CSG fallback. The direction is read from which cone is the rod the loops encircle:
+// drilling the fat when the target is the fat cone, the two rod stubs when the target is the rod cone.
+//
+// Example — a radius-0.8→1.5 frustum on x crossing (and drilling) a radius-2→4 frustum on z:
+//
+//	thin, _ := brep.SolidCylinderCone(math.P3(-6,0,0), math.P3(6,0,0), 0.8, 1.5, "thin")
+//	fat, _  := brep.SolidCylinderCone(math.P3(0,0,-6), math.P3(0,0,6), 2, 4, "fat")
+//	res, ok := brep.ConeConeCut(fat, thin) // fat cone with a tapered tunnel
+//	res, ok = brep.ConeConeCut(thin, fat)  // the two rod-cone stubs
+func ConeConeCut(target, tool *topo.Body) (*topo.Body, bool) {
+	p, targetIsRod, ok := coneConeCrossingPartsOf(target, tool)
+	if !ok {
+		return nil, false
+	}
+	if !loopsBetweenCaps(p.fat, p.fatBase, p.fatHeight, p.lo, p.hi) {
+		return nil, false // the breach reaches a fat cap (not a clean side breach): out of scope
+	}
+	if targetIsRod {
+		return cutRodMinusFat(p), true // target is the rod cone: two disconnected tapered stubs
+	}
+	return drillFatWithRod(p), true // target is the fat cone: drill a tapered tunnel
+}
+
+// coneConeCrossingPartsOf resolves two cone bodies into crossingParts (both rod and fat as coneRods), also
+// reporting whether the FIRST body (the Cut target) is the rod cone. ok=false when they are not one cone
+// crossing one fatter cone in the full-crossing configuration (exactly two imprint loops, one cone the rod
+// both loops encircle, both loops between the rod cone's caps).
+func coneConeCrossingPartsOf(a, b *topo.Body) (parts *crossingParts, aIsRod, ok bool) {
+	loops, imOK := coneConeImprint(a, b)
+	if !imOK || len(loops) != 2 {
+		return nil, false, false
+	}
+	rod, fat, rodVMin, rodVMax, fatVMin, fatVMax, firstIsRod, rfOK := rodAndFatCones(a, b, loops)
+	if !rfOK || !loopsSpanCone(rod, rodVMin, rodVMax, loops) {
+		return nil, false, false // a loop beyond a rod-cone cap is a partial penetration, not a crossing
+	}
+	lo, hi, asOK := assignRimLoops(coneAxis(rod), coneAxis(fat), loops)
+	if !asOK {
+		return nil, false, false
+	}
+	rodBase := rod.Apex.TranslateBy(rod.AxisDir.AsVector().Scale(math.Scalar(rodVMin)))
+	fatBase := fat.Apex.TranslateBy(fat.AxisDir.AsVector().Scale(math.Scalar(fatVMin)))
+	parts = &crossingParts{coneRod{rod}, coneRod{fat}, rodBase, fatBase, rodVMax - rodVMin, fatVMax - fatVMin, lo, hi}
+	return parts, firstIsRod, true
+}

--- a/kernel/brep/curved_cone_cone_cut_test.go
+++ b/kernel/brep/curved_cone_cone_cut_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// Cone–cone cut assembly (M2 Phase 2, Oblikovati/Oblikovati#1335). Drilling a fat cone with a crossing rod
+// cone, and the two rod-cone stubs of cone − fat, must weld into watertight analytic solids — the same shapes
+// as the cone–cylinder drill/stubs, only the fat is a cone too (its holed wall is a holed CONE wall). Volumes
+// are checked through ops_test; here the concern is the watertight topology and that the surfaces stay
+// analytic.
+
+// TestConeConeCutDrillsFat drills a radius-2→4 fat cone with a crossing radius-0.8→1.5 rod cone and checks the
+// result is a watertight four-face solid: two fat-cone caps (planes), the holed fat-cone wall, and the rod
+// cone tunnel band.
+func TestConeConeCutDrillsFat(t *testing.T) {
+	fat, _ := SolidCylinderCone(math.P3(0, 0, -6), math.P3(0, 0, 6), 2, 4, "fat")
+	thin, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 0.8, 1.5, "thin")
+
+	res, ok := ConeConeCut(fat, thin)
+	if !ok {
+		t.Fatal("cone drill of cone declined; want a four-face solid")
+	}
+	assertWatertight(t, res)
+	cones, cyls, planes := faceTypeCounts(t, res)
+	if cones != 2 || cyls != 0 || planes != 2 {
+		t.Errorf("drilled fat cone got %d cone + %d cyl + %d plane faces, want 2 (tunnel + holed wall) + 2 (caps)",
+			cones, cyls, planes)
+	}
+}
+
+// TestConeConeCutRodMinusFatStubs subtracts the fat cone from the crossing rod cone and checks the result is
+// the two disconnected tapered stubs (a two-shell solid).
+func TestConeConeCutRodMinusFatStubs(t *testing.T) {
+	fat, _ := SolidCylinderCone(math.P3(0, 0, -6), math.P3(0, 0, 6), 2, 4, "fat")
+	thin, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 0.8, 1.5, "thin")
+
+	res, ok := ConeConeCut(thin, fat)
+	if !ok {
+		t.Fatal("rod cone − fat cone declined; want two tapered stubs")
+	}
+	assertWatertight(t, res)
+	if n := len(res.Shells()); n != 2 {
+		t.Errorf("rod − fat has %d shells, want 2 (a disconnected stub each side)", n)
+	}
+	cones, cyls, planes := faceTypeCounts(t, res)
+	if cones != 4 || cyls != 0 || planes != 2 {
+		t.Errorf("rod − fat got %d cone + %d cyl + %d plane faces, want 4 (2 stub bands + 2 lens caps) + 2 (rod end caps)",
+			cones, cyls, planes)
+	}
+}
+
+// TestConeConeCutConeCylinderDefer: a cone and a cylinder are the cone–cylinder case, not this one.
+func TestConeConeCutConeCylinderDefer(t *testing.T) {
+	cone, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
+	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	if _, ok := ConeConeCut(cyl, cone); ok {
+		t.Error("a cone and a cylinder should defer from the cone–cone cut (ok=false)")
+	}
+}

--- a/kernel/brep/curved_cone_cone_intersect.go
+++ b/kernel/brep/curved_cone_cone_intersect.go
@@ -31,7 +31,7 @@ func ConeConeIntersect(a, b *topo.Body) (*topo.Body, bool) {
 	if !ok || len(loops) != 2 {
 		return nil, false
 	}
-	rod, fat, rodVMin, rodVMax, ok := rodAndFatCones(a, b, loops)
+	rod, fat, rodVMin, rodVMax, _, _, _, ok := rodAndFatCones(a, b, loops)
 	if !ok || !loopsSpanCone(rod, rodVMin, rodVMax, loops) {
 		return nil, false // a loop beyond a rod-cone cap is a partial penetration, not a full crossing
 	}
@@ -43,20 +43,21 @@ func ConeConeIntersect(a, b *topo.Body) (*topo.Body, bool) {
 }
 
 // rodAndFatCones picks which cone is the rod (the band-bearing one both imprint loops fully encircle) and
-// which is the fat cone (the lens-capped one), carrying the rod cone's apex-distance band [vMin, vMax]
-// through. ok=false unless both bodies are bare cones and exactly one is the rod the loops encircle.
-func rodAndFatCones(a, b *topo.Body, loops []geom.Polyline) (rod, fat geom.Cone, rodVMin, rodVMax float64, ok bool) {
+// which is the fat cone (the lens-capped one), carrying BOTH cones' apex-distance bands [vMin, vMax] through
+// (the rod's for the span check, the fat's for its cap centres). ok=false unless both bodies are bare cones
+// and exactly one is the rod the loops encircle.
+func rodAndFatCones(a, b *topo.Body, loops []geom.Polyline) (rod, fat geom.Cone, rodVMin, rodVMax, fatVMin, fatVMax float64, aIsRod, ok bool) {
 	ca, aMin, aMax, okA := coneSolidParams(facesOfAny(a))
 	cb, bMin, bMax, okB := coneSolidParams(facesOfAny(b))
 	if !okA || !okB {
-		return geom.Cone{}, geom.Cone{}, 0, 0, false
+		return geom.Cone{}, geom.Cone{}, 0, 0, 0, 0, false, false
 	}
 	aWraps, bWraps := allLoopsEncircle(loops, coneAxis(ca)), allLoopsEncircle(loops, coneAxis(cb))
 	if aWraps && !bWraps {
-		return ca, cb, aMin, aMax, true
+		return ca, cb, aMin, aMax, bMin, bMax, true, true
 	}
 	if bWraps && !aWraps {
-		return cb, ca, bMin, bMax, true
+		return cb, ca, bMin, bMax, aMin, aMax, false, true
 	}
-	return geom.Cone{}, geom.Cone{}, 0, 0, false
+	return geom.Cone{}, geom.Cone{}, 0, 0, 0, 0, false, false
 }

--- a/kernel/brep/curved_cone_cone_join.go
+++ b/kernel/brep/curved_cone_cone_join.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import "oblikovati.org/kernel/topo"
+
+// Cone–cone join (M2 Phase 2, Oblikovati/Oblikovati#1335). The union of a cone (a tapered rod) passing right
+// through a fatter cone: one connected solid — the fat cone's two caps and its holed side wall (the two lens
+// holes), plus a rod-cone STUB protruding from each lens hole out to the rod cone's own end cap. It reuses
+// the crossing/cone–cylinder join builder (joinFatAndRod) unchanged now that both the rod and the fat are
+// crossRods: each stub band lofts through the ruled saddle-band path, the fat-cone wall meshes through the
+// holed-cone-wall unroll, and the frustum ends carry their own radii.
+
+// ConeConeJoin builds fat ∪ cone for a cone crossing a fatter cone (the fat cone with a tapered stub each
+// side), or ok=false to defer (a non-cone operand, the cone–cylinder case, a rod cone that does not fully
+// cross, or a breach that reaches a fat cap) so kernel/ops keeps its CSG fallback.
+//
+// Example — a radius-0.8→1.5 frustum on x joined with a crossing radius-2→4 frustum on z gives the fat cone
+// with two tapered stubs:
+//
+//	thin, _ := brep.SolidCylinderCone(math.P3(-6,0,0), math.P3(6,0,0), 0.8, 1.5, "thin")
+//	fat, _  := brep.SolidCylinderCone(math.P3(0,0,-6), math.P3(0,0,6), 2, 4, "fat")
+//	res, ok := brep.ConeConeJoin(fat, thin)
+func ConeConeJoin(a, b *topo.Body) (*topo.Body, bool) {
+	p, _, ok := coneConeCrossingPartsOf(a, b)
+	if !ok {
+		return nil, false
+	}
+	if !loopsBetweenCaps(p.fat, p.fatBase, p.fatHeight, p.lo, p.hi) {
+		return nil, false // a stub would breach a fat cap, not the side wall: out of scope
+	}
+	return joinFatAndRod(p), true
+}

--- a/kernel/brep/curved_cone_cone_join_test.go
+++ b/kernel/brep/curved_cone_cone_join_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// Cone–cone join assembly (M2 Phase 2, Oblikovati/Oblikovati#1335). A rod cone passing through a fatter cone
+// must weld into one watertight solid — the fat cone with a tapered stub each side — the same shape as the
+// cone–cylinder join, only the fat is a cone too. Volume is checked through ops_test; here the concern is the
+// watertight topology and that the surfaces stay analytic.
+
+// TestConeConeJoinFatWithStubs joins a radius-2→4 fat cone with a crossing radius-0.8→1.5 rod cone and checks
+// the result is a watertight seven-face solid: two fat-cone caps, the holed fat-cone wall, and two rod-cone
+// stubs each capped by a disc.
+func TestConeConeJoinFatWithStubs(t *testing.T) {
+	fat, _ := SolidCylinderCone(math.P3(0, 0, -6), math.P3(0, 0, 6), 2, 4, "fat")
+	thin, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 0.8, 1.5, "thin")
+
+	res, ok := ConeConeJoin(fat, thin)
+	if !ok {
+		t.Fatal("cone ∪ cone declined; want the fat cone with two tapered stubs")
+	}
+	assertWatertight(t, res)
+	if n := len(res.Shells()); n != 1 {
+		t.Errorf("cone ∪ fat has %d shells, want 1 (one connected solid)", n)
+	}
+	cones, cyls, planes := faceTypeCounts(t, res)
+	if cones != 3 || cyls != 0 || planes != 4 {
+		t.Errorf("cone ∪ fat got %d cone + %d cyl + %d plane faces, want 3 (2 stub bands + holed wall) + 4 (2 fat caps + 2 stub end caps)",
+			cones, cyls, planes)
+	}
+}
+
+// TestConeConeJoinOrderIndependent: joining works whichever cone is passed first.
+func TestConeConeJoinOrderIndependent(t *testing.T) {
+	fat, _ := SolidCylinderCone(math.P3(0, 0, -6), math.P3(0, 0, 6), 2, 4, "fat")
+	thin, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 0.8, 1.5, "thin")
+	if _, ok := ConeConeJoin(thin, fat); !ok {
+		t.Error("cone ∪ cone should resolve with the rod cone passed first too")
+	}
+}

--- a/kernel/brep/curved_cone_cylinder_cut.go
+++ b/kernel/brep/curved_cone_cylinder_cut.go
@@ -64,7 +64,7 @@ func coneCrossingPartsOf(a, b *topo.Body) (*crossingParts, bool) {
 		return nil, false
 	}
 	rodBase := cone.Apex.TranslateBy(cone.AxisDir.AsVector().Scale(vMin))
-	return &crossingParts{coneRod{cone}, cyl, rodBase, fatBase, vMax - vMin, fatH, lo, hi}, true
+	return &crossingParts{coneRod{cone}, cylinderRod{cyl}, rodBase, fatBase, vMax - vMin, fatH, lo, hi}, true
 }
 
 // coneCrossingGeom resolves the cone (with its apex-distance band [vMin, vMax]) and the fat cylinder (with its

--- a/kernel/brep/curved_crossing_cut.go
+++ b/kernel/brep/curved_crossing_cut.go
@@ -54,8 +54,7 @@ func CrossingCylinderCut(target, tool *topo.Body) (*topo.Body, bool) {
 // oriented CCW about the rod axis and assigned to the lower (lo) and upper (hi) end of the band (see
 // assignRimLoops). rodBase is the rod's lower-axis cap centre and rodHeight its axial length.
 type crossingParts struct {
-	rod                  crossRod
-	fat                  geom.Cylinder
+	rod, fat             crossRod
 	rodBase, fatBase     math.Point3
 	rodHeight, fatHeight float64
 	lo, hi               geom.Polyline
@@ -82,7 +81,7 @@ func crossingPartsOf(a, b *topo.Body) (*crossingParts, bool) {
 	if !ok {
 		return nil, false
 	}
-	return &crossingParts{cylinderRod{rod}, fat, rodBase, fatBase, rodH, fatH, lo, hi}, true
+	return &crossingParts{cylinderRod{rod}, cylinderRod{fat}, rodBase, fatBase, rodH, fatH, lo, hi}, true
 }
 
 // orderRodFat picks which of the two cylinders is the rod (both loops encircle it) and which is the fat
@@ -98,14 +97,15 @@ func orderRodFat(loops []geom.Polyline, ca geom.Cylinder, baseA math.Point3, hA 
 	}
 }
 
-// loopsBetweenCaps reports whether both imprint loops lie strictly between the fat cylinder's two caps —
-// the side-breach condition where the tunnel passes through the wall and leaves the caps whole.
-func loopsBetweenCaps(fat geom.Cylinder, fatBase math.Point3, fatHeight float64, lo, hi geom.Polyline) bool {
-	axis := fat.AxisDir.AsVector()
-	vBot := float64(fat.Origin.VectorTo(fatBase).Dot(axis))
+// loopsBetweenCaps reports whether both imprint loops lie strictly between the fat's two caps — the
+// side-breach condition where the tunnel passes through the wall and leaves the caps whole. Works for a
+// cylinder or a cone fat (the test is purely axial).
+func loopsBetweenCaps(fat crossRod, fatBase math.Point3, fatHeight float64, lo, hi geom.Polyline) bool {
+	ax := fat.axisOf()
+	vBot := float64(ax.point.VectorTo(fatBase).Dot(ax.dir))
 	for _, lp := range []geom.Polyline{lo, hi} {
 		for _, p := range lp.Vertices {
-			s := float64(fat.Origin.VectorTo(p).Dot(axis)) - vBot
+			s := float64(ax.point.VectorTo(p).Dot(ax.dir)) - vBot
 			if s < 1e-9 || s > fatHeight-1e-9 {
 				return false
 			}
@@ -133,17 +133,18 @@ func drillFatWithRod(p *crossingParts) *topo.Body {
 	return bld.Build()
 }
 
-// addFatCapsAndHoledWall adds the fat cylinder's two planar caps and its side wall carrying the given hole
-// loops (one per wall breach). seam is an angular parameter placed clear of every hole (the unroll-and-CDT
-// mesher needs a hole-free seam); each hole use is the lens-loop edge in the orientation OPPOSITE the band
-// that fills it from the other side, so every edge stays used exactly twice.
-func addFatCapsAndHoledWall(bld *topo.Builder, fat geom.Cylinder, fatBase math.Point3, fatHeight, seam float64, holes ...topo.Use) {
-	axis := fat.AxisDir.AsVector()
-	vBot := float64(fat.Origin.VectorTo(fatBase).Dot(axis))
+// addFatCapsAndHoledWall adds the fat's two planar caps and its side wall carrying the given hole loops (one
+// per wall breach). The fat is a cylinder or a cone (a crossRod): the two cap circles take the fat's radius
+// at each cap centre (constant for a cylinder, growing with apex distance for a cone), and the wall is the
+// fat's analytic surface. seam is an angular parameter placed clear of every hole (the unroll-and-CDT mesher
+// needs a hole-free seam); each hole use is the lens-loop edge in the orientation OPPOSITE the band that
+// fills it from the other side, so every edge stays used exactly twice.
+func addFatCapsAndHoledWall(bld *topo.Builder, fat crossRod, fatBase math.Point3, fatHeight, seam float64, holes ...topo.Use) {
+	axis := fat.axisVec()
 	topCenter := fatBase.TranslateBy(axis.Scale(math.Scalar(fatHeight)))
-	seamBot, seamTop := fat.PointAt(seam, vBot), fat.PointAt(seam, vBot+fatHeight)
-	botC := seamedCircle(fatBase, fat.AxisDir, seamBot, fat.Radius)
-	topC := seamedCircle(topCenter, fat.AxisDir, seamTop, fat.Radius)
+	seamBot, seamTop := rodCirclePoint(fat, fatBase, seam), rodCirclePoint(fat, topCenter, seam)
+	botC := seamedCircle(fatBase, fat.axisUnit(), seamBot, fat.endRadius(fatBase))
+	topC := seamedCircle(topCenter, fat.axisUnit(), seamTop, fat.endRadius(topCenter))
 
 	vb := bld.AddVertex(seamBot, crossLin("fvb"))
 	vt := bld.AddVertex(seamTop, crossLin("fvt"))
@@ -159,15 +160,14 @@ func addFatCapsAndHoledWall(bld *topo.Builder, fat geom.Cylinder, fatBase math.P
 	for _, h := range holes {
 		wallLoops = append(wallLoops, topo.InnerLoop(h))
 	}
-	bld.AddFace(fat, crossLin("fwall"), wallLoops...)
+	bld.AddFace(fat.surface(), crossLin("fwall"), wallLoops...)
 }
 
-// clearSeamParam returns an angular parameter on the fat cylinder midway through the larger gap between the
-// two lens centres, so a seam placed there crosses neither hole (the holed-wall mesher needs a hole-free
-// seam).
-func clearSeamParam(fat geom.Cylinder, lo, hi geom.Polyline) float64 {
-	u1 := axisAngleOf(loopCentroid(lo), cylAxis(fat))
-	u2 := axisAngleOf(loopCentroid(hi), cylAxis(fat))
+// clearSeamParam returns an angular parameter on the fat midway through the larger gap between the two lens
+// centres, so a seam placed there crosses neither hole (the holed-wall mesher needs a hole-free seam).
+func clearSeamParam(fat crossRod, lo, hi geom.Polyline) float64 {
+	u1 := axisAngleOf(loopCentroid(lo), fat.axisOf())
+	u2 := axisAngleOf(loopCentroid(hi), fat.axisOf())
 	a, b := stdmath.Min(u1, u2), stdmath.Max(u1, u2)
 	if b-a >= 2*stdmath.Pi-(b-a) {
 		return (a + b) / 2 // the gap from a to b is the larger one
@@ -175,11 +175,10 @@ func clearSeamParam(fat geom.Cylinder, lo, hi geom.Polyline) float64 {
 	return (a+b)/2 + stdmath.Pi // the gap wrapping past 0 is larger
 }
 
-// clearSeamForLens returns an angular parameter on the fat cylinder diametrically opposite a single lens
-// hole, so a seam placed there crosses the hole-free side of the wall (the holed-wall mesher needs a
-// hole-free seam).
-func clearSeamForLens(fat geom.Cylinder, lens geom.Polyline) float64 {
-	return axisAngleOf(loopCentroid(lens), cylAxis(fat)) + stdmath.Pi
+// clearSeamForLens returns an angular parameter on the fat diametrically opposite a single lens hole, so a
+// seam placed there crosses the hole-free side of the wall (the holed-wall mesher needs a hole-free seam).
+func clearSeamForLens(fat crossRod, lens geom.Polyline) float64 {
+	return axisAngleOf(loopCentroid(lens), fat.axisOf()) + stdmath.Pi
 }
 
 // seamedCircle builds a cap circle whose angle-zero seam vertex is at seamPt (radius and centre on the

--- a/kernel/brep/curved_crossing_join.go
+++ b/kernel/brep/curved_crossing_join.go
@@ -110,11 +110,11 @@ func cutRodMinusFat(p *crossingParts) *topo.Body {
 // rodStubLump builds one closed rod stub: its wall band, the rod end cap, and the fat-wall lens closing the
 // inner end. The lens cap is the fat surface REVERSED — the kept material is outside the fat, so the lens
 // normal points back into the fat (away from the stub). Its edge is shared with the stub band opposite.
-func rodStubLump(rod crossRod, fat geom.Cylinder, endCenter math.Point3, capNormal math.Vector3, lens geom.Polyline, tag string) *topo.Body {
+func rodStubLump(rod, fat crossRod, endCenter math.Point3, capNormal math.Vector3, lens geom.Polyline, tag string) *topo.Body {
 	bld := topo.NewBuilder(true, crossLin(tag))
 	vLens := bld.AddVertex(lens.Vertices[0], crossLin(tag+"vl"))
 	eLens := bld.AddEdge(lens, vLens, vLens, crossLin(tag+"el"))
-	bld.AddReversedFace(fat, crossLin(tag+"lenscap"), topo.OuterLoop(topo.Rev(eLens)))
+	bld.AddReversedFace(fat.surface(), crossLin(tag+"lenscap"), topo.OuterLoop(topo.Rev(eLens)))
 	addRodStub(bld, rod, endCenter, capNormal, eLens, vLens, lens.Vertices[0], true, false, tag)
 	return bld.Build()
 }

--- a/kernel/brep/curved_partial_penetration.go
+++ b/kernel/brep/curved_partial_penetration.go
@@ -226,7 +226,7 @@ func PartialPenetrationCut(target, tool *topo.Body) (*topo.Body, bool) {
 // side (the rod material outside the fat), a closed lump of the rod stub band, the rod's entry end cap, and
 // the fat-wall lens reversed to face back into the fat (the kept material is outside it).
 func partialRodMinusFat(p *partialPlugParts) *topo.Body {
-	return rodStubLump(p.rod, p.fat, p.entryCenter, p.entryNormal, p.lens, "prmf")
+	return rodStubLump(p.rod, cylinderRod{p.fat}, p.entryCenter, p.entryNormal, p.lens, "prmf")
 }
 
 // PartialPenetrationJoin builds target ∪ tool for a thin rod ending inside the fatter cylinder, or ok=false
@@ -257,7 +257,7 @@ func blindHole(p *partialPlugParts) *topo.Body {
 	lensStart := p.lens.Vertices[0]
 	vLens := bld.AddVertex(lensStart, partLin("vlens"))
 	eLens := bld.AddEdge(p.lens, vLens, vLens, partLin("elens"))
-	addFatCapsAndHoledWall(bld, p.fat, p.fatBase, p.fatHeight, clearSeamForLens(p.fat, p.lens), topo.Rev(eLens))
+	addFatCapsAndHoledWall(bld, cylinderRod{p.fat}, p.fatBase, p.fatHeight, clearSeamForLens(cylinderRod{p.fat}, p.lens), topo.Rev(eLens))
 	addRodStub(bld, p.rod, p.blindCenter, p.blindNormal, eLens, vLens, lensStart, true, true, "blind")
 	return bld.Build()
 }
@@ -271,7 +271,7 @@ func partialJoinStub(p *partialPlugParts) *topo.Body {
 	lensStart := p.lens.Vertices[0]
 	vLens := bld.AddVertex(lensStart, partLin("vlens"))
 	eLens := bld.AddEdge(p.lens, vLens, vLens, partLin("elens"))
-	addFatCapsAndHoledWall(bld, p.fat, p.fatBase, p.fatHeight, clearSeamForLens(p.fat, p.lens), topo.Rev(eLens))
+	addFatCapsAndHoledWall(bld, cylinderRod{p.fat}, p.fatBase, p.fatHeight, clearSeamForLens(cylinderRod{p.fat}, p.lens), topo.Rev(eLens))
 	addRodStub(bld, p.rod, p.entryCenter, p.entryNormal, eLens, vLens, lensStart, true, false, "jstub")
 	return bld.Build()
 }

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -123,7 +123,7 @@ func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.L
 //   - a curved solid − a convex prism tunnelling through it (cylinder − box) (#1334);
 //   - two crossing cylinders ∩ (rod band + fat-wall lens caps) (#1335);
 //   - a cone crossing a cylinder ∩ (cone band + cylinder-wall lens caps) (#1335);
-//   - a cone crossing a fatter cone ∩ (rod-cone band + fat-cone lens caps) (#1335);
+//   - a cone crossing a fatter cone ∩/−/∪ (rod-cone band + fat-cone lens caps; drill/stubs/join) (#1335);
 //   - two EQUAL-radius perpendicular cylinders ∩/−/∪ (the Steinmetz bicylinder and its cut/union, fitted as crossing ellipses) (#1335);
 //   - a thin rod ending inside a fatter cylinder ∩/−/∪ (a partial penetration: the plug, a blind hole, a one-sided stub) (#1335);
 //   - drilling a fat cylinder with a crossing rod (fat − rod), and the two rod stubs of rod − fat (#1335);
@@ -144,8 +144,8 @@ var curvedExactPaths = []func(PartFeatureOperation, *topo.Body, *topo.Body) (*to
 	curvedConvexIntersect, curvedConvexSubtract,
 	curvedCrossingIntersect, curvedSteinmetzIntersect, curvedConeCylinderIntersect, curvedConeConeIntersect,
 	curvedPartialIntersect,
-	curvedPartialCut, curvedSteinmetzCut, curvedConeCylinderCut, curvedCrossingCut,
-	curvedPartialJoin, curvedConeCylinderJoin, curvedCrossingJoin, curvedSteinmetzJoin,
+	curvedPartialCut, curvedSteinmetzCut, curvedConeCylinderCut, curvedConeConeCut, curvedCrossingCut,
+	curvedPartialJoin, curvedConeCylinderJoin, curvedConeConeJoin, curvedCrossingJoin, curvedSteinmetzJoin,
 }
 
 func shouldFallbackBoolean(op PartFeatureOperation, target, tool, body *topo.Body) bool {

--- a/kernel/ops/boolean_cone_cone_test.go
+++ b/kernel/ops/boolean_cone_cone_test.go
@@ -9,6 +9,7 @@ import (
 	"oblikovati.org/kernel/brep"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 )
 
@@ -69,5 +70,74 @@ func TestBooleanIntersectConeCone(t *testing.T) {
 	want := coneConeIntersectVolume()
 	if rel := stdmath.Abs(got-want) / want; rel > 0.03 {
 		t.Errorf("cone∩cone volume %.4f, want %.4f (analytic) — rel %.4f > 3%%", got, want, rel)
+	}
+}
+
+// coneConeBodies builds the test pair: the radius-0.8→1.5 rod cone (axis x) and the radius-2→4 fat cone
+// (axis z) it crosses.
+func coneConeBodies() (thin, fat *topo.Body) {
+	thin, _ = brep.SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 0.8, 1.5, "thin")
+	fat, _ = brep.SolidCylinderCone(math.P3(0, 0, -6), math.P3(0, 0, 6), 2, 4, "fat")
+	return thin, fat
+}
+
+// TestBooleanCutConeConeDrillsFat drills the fat cone with the crossing rod cone (fat − cone): the exact
+// analytic solid (two fat-cone caps, the holed fat-cone wall, the rod-cone tunnel) whose volume is the fat
+// cone minus the cone∩cone.
+func TestBooleanCutConeConeDrillsFat(t *testing.T) {
+	thin, fat := coneConeBodies()
+	res, err := ops.Boolean(ops.Cut, fat, thin)
+	if err != nil {
+		t.Fatalf("Boolean(Cut fatCone−rodCone): %v", err)
+	}
+	if v := ops.Validate(res); !v.Valid || !v.Closed || !v.Manifold || !res.IsSolid() {
+		t.Fatalf("drilled fat cone is not a valid closed manifold solid: %+v", v)
+	}
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	want := coneFrustumVolume(2, 4, 12) - coneConeIntersectVolume()
+	// 4%: the faceted fat-cone wall/caps and the tapered tunnel inscribe their curvature, so the meshed
+	// volume runs under the analytic fat − tunnel (the B-rep is exact; this bounds the property-mesh error).
+	if rel := stdmath.Abs(got-want) / want; rel > 0.04 {
+		t.Errorf("drilled fat-cone volume %.4f, want %.4f (fat − cone∩cone) — rel %.4f > 4%%", got, want, rel)
+	}
+}
+
+// TestBooleanCutConeConeStubs subtracts the fat cone from the rod cone (cone − fat): the two disconnected
+// tapered stubs (a two-shell solid) whose total volume is the rod cone minus the cone∩cone.
+func TestBooleanCutConeConeStubs(t *testing.T) {
+	thin, fat := coneConeBodies()
+	res, err := ops.Boolean(ops.Cut, thin, fat)
+	if err != nil {
+		t.Fatalf("Boolean(Cut rodCone−fatCone): %v", err)
+	}
+	if v := ops.Validate(res); !v.Valid || !v.Closed || !v.Manifold || !res.IsSolid() {
+		t.Fatalf("rod − fat (cones) is not a valid closed manifold solid: %+v", v)
+	}
+	if n := len(res.Shells()); n != 2 {
+		t.Errorf("rod − fat (cones) has %d shells, want 2 (a disconnected stub each side)", n)
+	}
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	want := coneFrustumVolume(0.8, 1.5, 12) - coneConeIntersectVolume()
+	if rel := stdmath.Abs(got-want) / want; rel > 0.02 {
+		t.Errorf("rod − fat (cones) volume %.4f, want %.4f (rod − cone∩cone) — rel %.4f > 2%%", got, want, rel)
+	}
+}
+
+// TestBooleanJoinConeCone joins the fat cone and the crossing rod cone (fat ∪ cone): the connected analytic
+// solid (fat-cone caps, holed fat-cone wall, a tapered stub each side) whose volume is fat + rod − the
+// cone∩cone.
+func TestBooleanJoinConeCone(t *testing.T) {
+	thin, fat := coneConeBodies()
+	res, err := ops.Boolean(ops.Join, fat, thin)
+	if err != nil {
+		t.Fatalf("Boolean(Join fatCone∪rodCone): %v", err)
+	}
+	if v := ops.Validate(res); !v.Valid || !v.Closed || !v.Manifold || !res.IsSolid() {
+		t.Fatalf("joined cone∪cone is not a valid closed manifold solid: %+v", v)
+	}
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	want := coneFrustumVolume(2, 4, 12) + coneFrustumVolume(0.8, 1.5, 12) - coneConeIntersectVolume()
+	if rel := stdmath.Abs(got-want) / want; rel > 0.04 {
+		t.Errorf("joined cone∪cone volume %.4f, want %.4f (fat + rod − cone∩cone) — rel %.4f > 4%%", got, want, rel)
 	}
 }

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -140,6 +140,34 @@ func curvedConeCylinderJoin(op PartFeatureOperation, target, tool *topo.Body) (*
 	return res, true
 }
 
+// curvedConeConeCut returns target − tool for a cone crossing a fatter cone (drilling the fat cone with the
+// rod cone, or the two rod-cone stubs of cone − fat), or ok=false to defer. Only Cut maps here, and only a
+// valid closed manifold result is adopted.
+func curvedConeConeCut(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+	if op != Cut {
+		return nil, false
+	}
+	res, ok := brep.ConeConeCut(target, tool)
+	if !ok || !validBooleanSolid(res) {
+		return nil, false
+	}
+	return res, true
+}
+
+// curvedConeConeJoin returns target ∪ tool for a cone crossing a fatter cone (the fat cone side-breached by a
+// rod cone passing through it, leaving a tapered stub each side), or ok=false to defer. Only Join maps here,
+// and only a valid closed manifold result is adopted.
+func curvedConeConeJoin(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+	if op != Join {
+		return nil, false
+	}
+	res, ok := brep.ConeConeJoin(target, tool)
+	if !ok || !validBooleanSolid(res) {
+		return nil, false
+	}
+	return res, true
+}
+
 // curvedSteinmetzCut returns target − tool for two equal-radius perpendicular cylinders (the target with
 // the tool's saddle bite removed), or ok=false to defer. Only Cut maps here, and only a valid closed
 // manifold result is adopted.

--- a/kernel/ops/holed_cylinder_wall.go
+++ b/kernel/ops/holed_cylinder_wall.go
@@ -9,24 +9,27 @@ import (
 	"oblikovati.org/math"
 )
 
-// Holed cylinder-wall tessellation (M2 Phase 2, Oblikovati/Oblikovati#1335). A cylinder drilled through —
-// a fat cylinder Cut/Join with a crossing rod — leaves the fat SIDE wall as a full-period cylinder face
-// carrying one or more lens HOLES where the rod broke through. periodicBandGrid and metricPatchMesh both
-// reject a holed periodic face (toUVLoops can't unwrap the seam-wrapping outer loop), so it fell to the
-// full-domain grid, which ignores the holes entirely. But a cylinder is DEVELOPABLE — its first
-// fundamental form ds² = R²du² + dv² is flat — so its wall unrolls to a plane without distortion: unwrap
-// the wrapping outer loop's angle cumulatively into a contiguous (u,v) rectangle and hand it, holes and
-// all, straight to metricPatchMesh, whose metric-scaled CDT meshes the rectangle-minus-holes with interior
-// refinement. The seam (the rectangle's two vertical edges, 2π apart in u) maps to one line in 3D, so the
-// triangles on either side meet there with no gap.
+// Holed developable-wall tessellation (M2 Phase 2, Oblikovati/Oblikovati#1335). A cylinder OR cone drilled
+// through — a fat cylinder/cone Cut/Join with a crossing rod — leaves the fat SIDE wall as a full-period
+// cylinder/cone face carrying one or more lens HOLES where the rod broke through. periodicBandGrid and
+// metricPatchMesh both reject a holed periodic face (toUVLoops can't unwrap the seam-wrapping outer loop),
+// so it fell to the full-domain grid, which ignores the holes entirely. But both a cylinder and a cone are
+// DEVELOPABLE (zero Gaussian curvature), so the wall unrolls and meshes through the trim-local metric-scaled
+// CDT: unwrap the wrapping outer loop's angle cumulatively into a contiguous (u,v) rectangle and hand it,
+// holes and all, to that CDT. The boundary and hole loops map to their exact (u,v) and the interior nodes
+// lift to the exact surface, so the area is accurate regardless of the parameter metric; the metric scaling
+// (√E,√G over the trim's (u,v) bbox) only keeps the triangulation well shaped — exact (R,1) for a cylinder,
+// the local (v·tanα, secα) average for a cone, whose metric varies slowly over a wall away from the apex.
+// The seam (the rectangle's two vertical edges, 2π apart in u) maps to one line in 3D, so the triangles on
+// either side meet there with no gap.
 
-// holedCylinderWallMesh meshes a full-period cylinder side carrying holes by unrolling it to a contiguous
-// (u,v) rectangle and delegating to metricPatchMesh. ok=false unless the surface is a cylinder with at
-// least one hole and a genuinely seam-wrapping outer loop (a hole straddling the seam also defers — the
-// builder seams the wall clear of its holes, so that should not arise).
-func holedCylinderWallMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, q Quality) (*Mesh, bool) {
-	if _, ok := s.(geom.Cylinder); !ok {
-		return nil, false // only a cylinder unrolls with a flat (distortion-free) metric
+// holedConicWallMesh meshes a full-period cylinder or cone side carrying holes by unrolling it to a
+// contiguous (u,v) rectangle and delegating to the metric-scaled CDT. ok=false unless the surface is a
+// developable side (cylinder/cone) with at least one hole and a genuinely seam-wrapping outer loop (a hole
+// straddling the seam also defers — the builder seams the wall clear of its holes, so that should not arise).
+func holedConicWallMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, q Quality) (*Mesh, bool) {
+	if !isDevelopableSide(s) {
+		return nil, false // only a cylinder/cone unrolls (developable: zero Gaussian curvature)
 	}
 	if len(holes3D) == 0 || isPeriodic(s.UDomain()) == isPeriodic(s.VDomain()) {
 		return nil, false // need a holed, singly-periodic side
@@ -40,6 +43,17 @@ func holedCylinderWallMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]ma
 		return nil, false
 	}
 	return unrolledWallCDT(s, q, outer3D, holes3D, outerUV, holesUV), true
+}
+
+// isDevelopableSide reports whether the surface is a cylinder or a cone — the developable (zero
+// Gaussian-curvature) sides whose walls unroll, so a holed wall on them meshes through the unrolled CDT.
+func isDevelopableSide(s geom.Surface) bool {
+	switch s.(type) {
+	case geom.Cylinder, geom.Cone:
+		return true
+	default:
+		return false
+	}
 }
 
 // unrolledWallCDT triangulates the unrolled wall (the contiguous (u,v) rectangle minus the holes) with a

--- a/kernel/ops/holed_cylinder_wall_test.go
+++ b/kernel/ops/holed_cylinder_wall_test.go
@@ -86,14 +86,14 @@ func TestHoledCylinderWallAreaMatchesAnalytic(t *testing.T) {
 	}
 }
 
-// TestHoledCylinderWallMeshIsRouted confirms the dispatch reaches holedCylinderWallMesh for a holed
+// TestHoledCylinderWallMeshIsRouted confirms the dispatch reaches holedConicWallMesh for a holed
 // periodic cylinder side rather than falling through to the full-domain grid (which ignores holes).
 func TestHoledCylinderWallMeshIsRouted(t *testing.T) {
 	face := windowedCylinderWall(t, stdmath.Pi/4, stdmath.Pi/2, 4, 8)
 	outer := faceOuterBoundary(face, DefaultQuality())
 	holes := faceHoleBoundaries(face, DefaultQuality())
-	if _, ok := holedCylinderWallMesh(face.Geometry(), outer, holes, DefaultQuality()); !ok {
-		t.Error("holedCylinderWallMesh declined a holed periodic cylinder wall; the dispatch would fall back")
+	if _, ok := holedConicWallMesh(face.Geometry(), outer, holes, DefaultQuality()); !ok {
+		t.Error("holedConicWallMesh declined a holed periodic cylinder wall; the dispatch would fall back")
 	}
 }
 
@@ -102,7 +102,7 @@ func TestHoledCylinderWallMeshIsRouted(t *testing.T) {
 func TestHoledCylinderWallDeclinesNoHoles(t *testing.T) {
 	side, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), wallR)
 	outer := []math.Point3{wallPoint(0, 0), wallPoint(2, 0), wallPoint(4, 0), wallPoint(0, wallH)}
-	if _, ok := holedCylinderWallMesh(side, outer, nil, DefaultQuality()); ok {
+	if _, ok := holedConicWallMesh(side, outer, nil, DefaultQuality()); ok {
 		t.Error("a hole-free cylinder side should defer from the holed-wall mesher")
 	}
 }
@@ -113,7 +113,7 @@ func TestHoledCylinderWallDeclinesNonCylinder(t *testing.T) {
 	sph, _ := geom.NewSphere(math.P3(0, 0, 0), wallR)
 	outer := []math.Point3{wallPoint(0, 0), wallPoint(2, 0), wallPoint(4, 0)}
 	hole := []math.Point3{wallPoint(1, 1), wallPoint(1.2, 1), wallPoint(1.1, 1.2)}
-	if _, ok := holedCylinderWallMesh(sph, outer, [][]math.Point3{hole}, DefaultQuality()); ok {
+	if _, ok := holedConicWallMesh(sph, outer, [][]math.Point3{hole}, DefaultQuality()); ok {
 		t.Error("a non-cylinder surface should defer from the holed-wall mesher")
 	}
 }
@@ -124,7 +124,7 @@ func TestHoledCylinderWallDeclinesNonWrappingOuter(t *testing.T) {
 	side, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), wallR)
 	outer := []math.Point3{wallPoint(0, 0), wallPoint(0.5, 0), wallPoint(0.5, wallH), wallPoint(0, wallH)}
 	hole := []math.Point3{wallPoint(0.2, 4), wallPoint(0.3, 4), wallPoint(0.25, 6)}
-	if _, ok := holedCylinderWallMesh(side, outer, [][]math.Point3{hole}, DefaultQuality()); ok {
+	if _, ok := holedConicWallMesh(side, outer, [][]math.Point3{hole}, DefaultQuality()); ok {
 		t.Error("a non-wrapping outer loop should defer from the holed-wall mesher")
 	}
 }

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -64,8 +64,8 @@ func meshSeamCrossingFace(f *topo.Face, s geom.Surface, outer3D []math.Point3, h
 	if us, vs, isBand := periodicBandGrid(s, outer3D, holes3D); isBand {
 		return closedDomainMesh(s, us, vs) // full cylinder/cone side with circular rims: grid the period
 	}
-	if m, ok := holedCylinderWallMesh(s, outer3D, holes3D, q); ok {
-		return m // a drilled cylinder wall: full-period side with lens holes — unroll + metric CDT
+	if m, ok := holedConicWallMesh(s, outer3D, holes3D, q); ok {
+		return m // a drilled cylinder/cone wall: full-period side with lens holes — unroll + metric CDT
 	}
 	if m, ok := saddleBandLoftMesh(f, s, q); ok {
 		return m // a cylinder/cone band with non-circular (saddle) rims — a crossing cylinder: loft v(u)


### PR DESCRIPTION
## What

The **last cone–cone slice** (#1335): the two subtraction outcomes and the union of a cone (a tapered rod) crossing a fatter cone, all exact analytic B-rep:

- **`Cut(fat, cone)`** — the fat cone drilled by the rod cone: two fat-cone caps, the **holed fat-cone wall**, and the rod-cone band flipped inward as a tapered tunnel.
- **`Cut(cone, fat)`** — `cone − fat`: the **two disconnected tapered stubs** (two-shell solid).
- **`Join(fat, cone)`** — one connected solid: fat-cone caps, holed fat-cone wall, and a rod-cone stub out each lens hole to the rod cone's end cap.

## How — three layers

1. **Holed cone wall mesher** (`holedConicWallMesh`). The drilled-wall tessellation was gated to cylinders; a cone is also developable, so its wall unrolls and meshes through the same trim-local metric-scaled CDT (boundary/holes map to exact `(u,v)`, interior nodes lift to the exact surface, so area accuracy is independent of the parameter metric). Now gated to cylinder **or** cone.
2. **Fat unified as a `crossRod`** (cylinder or cone). The drill/join builders hard-typed the fat as `geom.Cylinder`; a cone fat has the same needs (surface, axis, cap radius at each end), which `crossRod` already exposes. `crossingParts.fat`, `addFatCapsAndHoledWall`, `loopsBetweenCaps`, `clearSeam*`, `rodStubLump` now work off a `crossRod` fat. **Behaviour-preserving** — every crossing / cone–cylinder / partial-penetration cut/join test still passes.
3. **Cone–cone cut/join** reuse those builders verbatim; `coneConeCrossingPartsOf` shares the imprint (#1363) and `rodAndFatCones` classifier with the intersection (#1364), reporting which operand is the rod so the Cut picks stubs vs a drilled tunnel.

## Validation

Watertight all-analytic topology (correct face/shell counts; faces only cone/plane). Volumes through `ops.Boolean` against the analytic `fat ∓ (cone∩cone)` and the two-shell `rod − (cone∩cone)`: drill **3.1%** / join **2.8%** under (the faceted fat-cone curvature, same bound as the cylinder drill), stubs **0.1%**. The holed cone wall meshes correctly — if its holes were ignored the drill would read ~352 instead of ~317.

Three commits: the holed-cone-wall mesher, the fat `crossRod` unification, then the cone–cone cut/join + wiring + tests.

## Phase 2 (#1335)

This **completes the cone–cone pair** (imprint #1363, intersect #1364, cut/join here) — and with it every crossing/partial curved∩curved combination of cylinders and cones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)