### PR TITLE
M2 Phase 3: multi-hole exact drilling — chained drilled plate (acceptance #4)

### DIFF
--- a/kernel/brep/drill.go
+++ b/kernel/brep/drill.go
@@ -53,9 +53,15 @@ func DrillThroughHole(slab, cylinderTool *topo.Body) (*topo.Body, bool) {
 	if !ok {
 		return nil, false // tool is not a single bare cylinder
 	}
-	res, err := CutCylindricalHole(slab, base, cyl.AxisDir.AsVector(), cyl.Radius)
+	ua := cyl.AxisDir.AsVector()
+	// All-planar slab → the proven planar assembly; a slab that already has curved faces (a prior bore's
+	// wall) → the curvedFace path, so a drilled plate chains exactly instead of falling to CSG (#1336).
+	if res, err := CutCylindricalHole(slab, base, ua, cyl.Radius); err == nil {
+		return res, true
+	}
+	res, err := drillThroughCurved(slab, base, ua, cyl.Radius)
 	if err != nil {
-		return nil, false // partial / clipped / off-axis hole → defer to the general fallback
+		return nil, false // partial / clipped / overlapping / off-axis hole → defer to the general fallback
 	}
 	return res, true
 }

--- a/kernel/brep/drill_multi.go
+++ b/kernel/brep/drill_multi.go
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Multi-hole exact drilling (M2 Phase 3, Oblikovati/Oblikovati#1336). CutCylindricalHole drills an exact
+// round hole only into an ALL-planar slab (facesOf rejects any curved face), so the second bore — whose
+// target already carries the first hole's cylinder wall — fell back to triangle-soup CSG, and a chain of
+// bores accumulated CSG noise into a non-manifold mesh (the chained-drift defect). drillThroughCurved
+// lifts the drill to the curvedFace model: it copies EVERY existing face unchanged (planar walls and the
+// prior bores' cylinder walls alike), adds the new hole circle to the two pierced caps, adds one new
+// cylinder wall, and re-welds through curvedStitch (which welds line AND circle edges, sharing the new
+// circle between each cap and the wall). So every bore stays an exact curved B-rep and a drilled plate
+// chains without drift — no bore touches CSG.
+
+// curvedDrillCap is a planar cap face the new hole axis pierces, with its pierce centre, its axial
+// parameter (to order entry before exit), and its index in the face list (so the other faces copy through).
+type curvedDrillCap struct {
+	face   curvedFace
+	idx    int
+	center math.Point3
+	param  float64
+}
+
+// drillThroughCurved cuts target − (cylinder of axis base→ua, radius) as an exact through-hole, accepting a
+// target that already has curved faces (unlike CutCylindricalHole). It returns an error — so the caller
+// keeps its fallback — when the cylinder does not pierce exactly two perpendicular planar caps whose
+// interiors clear the circle and its existing holes (a partial / clipped / overlapping hole).
+func drillThroughCurved(target *topo.Body, base math.Point3, ua math.Vector3, radius float64) (*topo.Body, error) {
+	faces := facesOfAny(target)
+	caps, err := findDrillCaps(faces, base, ua, radius)
+	if err != nil {
+		return nil, err
+	}
+	circLo, err := geom.NewCircle(caps[0].center, ua, radius)
+	if err != nil {
+		return nil, err
+	}
+	circHi := geom.Circle{Center: caps[1].center, Normal: circLo.Normal, RefDir: circLo.RefDir, Radius: radius}
+
+	out := copyFacesExcept(faces, caps[0].idx, caps[1].idx)
+	out = append(out, capWithHole(caps[0].face, circLo), capWithHole(caps[1].face, circHi))
+	out = append(out, drillWallFace(caps[0].center, ua, radius, circLo, circHi))
+	body := curvedStitch(out)
+	if body == nil {
+		return nil, fmt.Errorf("brep: multi-hole drill produced an empty body (r=%g at %+v)", radius, base)
+	}
+	return body, nil
+}
+
+// findDrillCaps returns the exactly-two planar faces the axis pierces cleanly (perpendicular, the circle
+// strictly inside and clear of existing holes), ordered entry (lower param) before exit. A perpendicular
+// face the axis misses is left for copying; a circle that straddles a face boundary or an existing hole is
+// an error (a partial/overlapping hole the general boolean must handle).
+func findDrillCaps(faces []curvedFace, base math.Point3, ua math.Vector3, radius float64) ([2]curvedDrillCap, error) {
+	var caps []curvedDrillCap
+	for i, f := range faces {
+		pl, ok := f.surface.(geom.Plane)
+		if !ok || stdmath.Abs(float64(unit(pl.Normal()).Dot(ua))) < 1-1e-7 {
+			continue // a wall (planar or curved) the hole runs alongside — copied unchanged
+		}
+		c := base.TranslateBy(ua.Scale(math.Scalar(pierceParam(base, ua, pl))))
+		pierced, clean := circleVsCap(c, radius, f, pl)
+		if !pierced {
+			continue // a perpendicular face the axis misses — copied unchanged
+		}
+		if !clean {
+			return [2]curvedDrillCap{}, fmt.Errorf("brep: hole circle (r=%g at %+v) straddles a pierced face boundary or an existing hole; partial holes need the general boolean", radius, c)
+		}
+		caps = append(caps, curvedDrillCap{face: f, idx: i, center: c, param: pierceParam(base, ua, pl)})
+	}
+	if len(caps) != 2 {
+		return [2]curvedDrillCap{}, fmt.Errorf("brep: a through-hole needs exactly 2 perpendicular pierced faces, found %d", len(caps))
+	}
+	if caps[0].param > caps[1].param {
+		caps[0], caps[1] = caps[1], caps[0]
+	}
+	return [2]curvedDrillCap{caps[0], caps[1]}, nil
+}
+
+// circleVsCap classifies the hole circle against a perpendicular planar face: pierced when its centre is
+// inside the face (existing holes excluded), clean when the whole circle is strictly inside and clear of
+// every existing hole. It samples the curved loops into a planarFace so it can reuse the planar
+// containment tests (pointInFace2D / circleInsideFace), which run even-odd over outer loop plus holes.
+func circleVsCap(c math.Point3, radius float64, f curvedFace, pl geom.Plane) (pierced, clean bool) {
+	pf := curvedCapAsPlanar(f, pl)
+	pierced = pointInFace2D(to2D(pl, c), pf)
+	clean = pierced && circleInsideFace(c, pf, radius)
+	return pierced, clean
+}
+
+// curvedCapAsPlanar samples a planar face's curved loops into 3D point rings (outer first) so the planar
+// containment helpers can run on it — a circle hole becomes a 32-gon, a straight edge its corner.
+func curvedCapAsPlanar(f curvedFace, pl geom.Plane) planarFace {
+	rings := make([][]math.Point3, len(f.loops))
+	for i, lp := range f.loops {
+		rings[i] = sampleCurvedLoop(lp)
+	}
+	return planarFace{plane: pl, normal: unit(pl.Normal()), loops: rings, lineage: f.lineage}
+}
+
+// sampleCurvedLoop flattens a loop into an ordered 3D point ring.
+func sampleCurvedLoop(lp curvedLoop) []math.Point3 {
+	var ring []math.Point3
+	for _, e := range lp.edges {
+		ring = append(ring, sampleLoopEdge(e)...)
+	}
+	return ring
+}
+
+// sampleLoopEdge samples one edge from t0 to t1 (exclusive of t1, the next edge's start): a circle/arc
+// into 32 points, a straight edge into its start corner.
+func sampleLoopEdge(e loopEdge) []math.Point3 {
+	n := 1
+	switch e.curve.(type) {
+	case geom.Circle, geom.Arc3d:
+		n = 32
+	}
+	pts := make([]math.Point3, 0, n)
+	for j := 0; j < n; j++ {
+		t := e.t0 + (e.t1-e.t0)*float64(j)/float64(n)
+		pts = append(pts, e.curve.PointAt(t))
+	}
+	return pts
+}
+
+// capWithHole returns the cap face with the new hole circle appended as an inner loop (a single closed
+// circle edge). The loops slice is copied so the source face is untouched.
+func capWithHole(f curvedFace, circ geom.Circle) curvedFace {
+	hole := curvedLoop{edges: []loopEdge{{curve: circ, t0: 0, t1: 1}}}
+	f.loops = append(append([]curvedLoop{}, f.loops...), hole)
+	return f
+}
+
+// drillWallFace builds the hole wall as a reversed cylinder face (material faces the axis) whose loop runs
+// the bottom circle reversed, up the seam, the top circle reversed, down the seam — the same seamed loop
+// SolidCylinder uses, so the wall welds to both caps along the shared circle edges.
+func drillWallFace(baseCenter math.Point3, ua math.Vector3, radius float64, circLo, circHi geom.Circle) curvedFace {
+	cyl, _ := geom.NewCylinder(baseCenter, ua, radius)
+	seam := geom.NewLineSegment(circLo.PointAt(0), circHi.PointAt(0))
+	loop := curvedLoop{edges: []loopEdge{
+		{curve: circLo, t0: 1, t1: 0},
+		{curve: seam, t0: 0, t1: 1},
+		{curve: circHi, t0: 1, t1: 0},
+		{curve: seam, t0: 1, t1: 0},
+	}}
+	return curvedFace{surface: cyl, reversed: true, loops: []curvedLoop{loop}, lineage: topo.NewLineage(topo.Tok("brep", "drillwall", 0))}
+}
+
+// copyFacesExcept returns every face except the two cap indices, unchanged (the prior bores' walls and the
+// slab's side walls pass straight through).
+func copyFacesExcept(faces []curvedFace, a, b int) []curvedFace {
+	out := make([]curvedFace, 0, len(faces))
+	for i, f := range faces {
+		if i == a || i == b {
+			continue
+		}
+		out = append(out, f)
+	}
+	return out
+}

--- a/kernel/brep/drill_multi_test.go
+++ b/kernel/brep/drill_multi_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// Multi-hole exact drilling (M2 Phase 3, Oblikovati/Oblikovati#1336). drillThroughCurved must drill a
+// second (and later) hole into a body that already carries a cylinder wall, where CutCylindricalHole's
+// all-planar precondition fails. Each bore stays an exact watertight curved B-rep — one analytic cylinder
+// wall per hole — so a drilled plate chains without ever touching CSG.
+
+// TestDrillThroughCurvedSecondHole drills a hole into a slab that already has one, exercising the curved
+// path (the target is no longer all-planar). The result is watertight with two cylinder walls and the
+// slab's six planar faces.
+func TestDrillThroughCurvedSecondHole(t *testing.T) {
+	slab, _ := SolidBlock(math.P3(-16, -10, 0), math.P3(16, 10, 6), "slab")
+	first, err := CutCylindricalHole(slab, math.P3(-6, 0, -1), math.V3(0, 0, 1), 1.5)
+	if err != nil {
+		t.Fatalf("first (planar) hole: %v", err)
+	}
+	second, err := drillThroughCurved(first, math.P3(6, 0, -1), math.V3(0, 0, 1), 1.5)
+	if err != nil {
+		t.Fatalf("second (curved) hole: %v", err)
+	}
+	assertWatertight(t, second)
+	if n := len(second.Shells()); n != 1 {
+		t.Errorf("twice-drilled slab has %d shells, want 1", n)
+	}
+	_, cyls, planes := faceTypeCounts(t, second)
+	if cyls != 2 || planes != 6 {
+		t.Errorf("twice-drilled slab got %d cyl + %d plane faces, want 2 + 6", cyls, planes)
+	}
+}
+
+// TestDrillThroughCurvedFiveHoles drills five holes in sequence and checks each adds exactly one cylinder
+// wall while the body stays a single watertight shell — the topology behind the chained-drift guard.
+func TestDrillThroughCurvedFiveHoles(t *testing.T) {
+	res, _ := SolidBlock(math.P3(-16, -10, 0), math.P3(16, 10, 6), "slab")
+	for i, cx := range []float64{-8, -4, 0, 4, 8} {
+		out, err := drillThroughCurved(res, math.P3(cx, 0, -1), math.V3(0, 0, 1), 1.5)
+		if err != nil {
+			t.Fatalf("bore %d: %v", i, err)
+		}
+		assertWatertight(t, out)
+		if _, cyls, _ := faceTypeCounts(t, out); cyls != i+1 {
+			t.Errorf("bore %d: %d cylinder walls, want %d", i, cyls, i+1)
+		}
+		res = out
+	}
+}
+
+// TestDrillThroughCurvedRejectsClipped: a hole whose circle spills past the slab edge is partial, so the
+// curved drill returns an error and the caller keeps its fallback.
+func TestDrillThroughCurvedRejectsClipped(t *testing.T) {
+	slab, _ := SolidBlock(math.P3(-16, -10, 0), math.P3(16, 10, 6), "slab")
+	if _, err := drillThroughCurved(slab, math.P3(15.5, 0, -1), math.V3(0, 0, 1), 1.5); err == nil {
+		t.Error("a hole clipping the slab edge should error (partial hole), got nil")
+	}
+}
+
+// TestDrillThroughCurvedRejectsOverlap: a second hole overlapping the first is not a clean through-hole,
+// so the curved drill rejects it.
+func TestDrillThroughCurvedRejectsOverlap(t *testing.T) {
+	slab, _ := SolidBlock(math.P3(-16, -10, 0), math.P3(16, 10, 6), "slab")
+	first, _ := CutCylindricalHole(slab, math.P3(0, 0, -1), math.V3(0, 0, 1), 1.5)
+	if _, err := drillThroughCurved(first, math.P3(1.5, 0, -1), math.V3(0, 0, 1), 1.5); err == nil {
+		t.Error("a hole overlapping an existing hole should error, got nil")
+	}
+}

--- a/kernel/ops/boolean_chain_drift_test.go
+++ b/kernel/ops/boolean_chain_drift_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	"fmt"
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Chained-boolean drift guard (M2 Phase 3, Oblikovati/Oblikovati#1336, acceptance #4 of #1320). Five
+// sequential curved booleans must leave the cumulative volume within tolerance and every intermediate
+// body a watertight manifold solid. The umbrella's worry is csg.js fragility — chained triangle-soup CSG
+// accumulates noise and loses watertightness. The exact drilled-plate path (slice A) plus multi-hole
+// drilling (this slice) keep every bore an EXACT curved B-rep, so the chain neither drifts nor opens: the
+// test asserts the result stays exact (one analytic cylinder wall PER bore, never faceted CSG) and the
+// final volume equals the slab minus five single-bore removals.
+
+// chainRod builds a validated cylinder long enough to pierce the slab's two z-faces, centred at (cx, cy).
+func chainRod(t *testing.T, cx, cy float64) *topo.Body {
+	t.Helper()
+	rod, err := brep.SolidCylinder(math.P3(cx, cy, -1), math.V3(0, 0, 1), 1.5, 8)
+	if err != nil {
+		t.Fatalf("SolidCylinder at (%g,%g): %v", cx, cy, err)
+	}
+	return rod
+}
+
+// chainSlab is the 32×20×6 plate every chain test bores; a fresh body each call so no test mutates
+// another's operand. It is wide enough that all five bores sit clear of the edges and each other.
+func chainSlab(t *testing.T) *topo.Body {
+	t.Helper()
+	b, err := brep.SolidBlock(math.P3(-16, -10, 0), math.P3(16, 10, 6), "slab")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	return b
+}
+
+// cylinderFaceCount reports how many of a body's faces are analytic cylinders — the exactness witness: a
+// drilled plate that fell back to CSG would have a faceted (planar-triangle) wall and report zero.
+func cylinderFaceCount(b *topo.Body) int {
+	n := 0
+	for _, f := range b.Faces() {
+		if _, ok := f.Geometry().(geom.Cylinder); ok {
+			n++
+		}
+	}
+	return n
+}
+
+// assertChainSolid fails unless b is a watertight manifold solid; a chain step that opens is the
+// tjunctionFaceBudget watertightness regression acceptance #3 forbids.
+func assertChainSolid(t *testing.T, b *topo.Body, step string) {
+	t.Helper()
+	r := ops.Validate(b)
+	if !r.Valid || !r.Closed || !r.Manifold || !b.IsSolid() {
+		t.Fatalf("%s: result not a watertight solid (valid=%v closed=%v manifold=%v solid=%v)",
+			step, r.Valid, r.Closed, r.Manifold, b.IsSolid())
+	}
+}
+
+// TestCurvedBooleanChainDriftBores bores five identical, non-overlapping holes through the plate in
+// sequence. Each stays EXACT (the running body gains exactly one analytic cylinder wall per bore), so the
+// cumulative volume is the plate minus five single-bore removals with no drift, and no body ever opens.
+func TestCurvedBooleanChainDriftBores(t *testing.T) {
+	v0 := ops.BodyGeometryProperties(chainSlab(t), ops.DefaultQuality()).Volume
+	centers := []float64{-8, -4, 0, 4, 8} // spacing 4 > 2r=3: the bores never touch
+
+	ref, err := ops.Boolean(ops.Cut, chainSlab(t), chainRod(t, centers[0], 0))
+	if err != nil {
+		t.Fatalf("reference bore: %v", err)
+	}
+	assertChainSolid(t, ref, "reference bore")
+	removed := v0 - ops.BodyGeometryProperties(ref, ops.DefaultQuality()).Volume
+
+	res := chainSlab(t)
+	for i, cx := range centers {
+		out, err := ops.Boolean(ops.Cut, res, chainRod(t, cx, 0))
+		if err != nil {
+			t.Fatalf("bore %d at x=%g: %v", i, cx, err)
+		}
+		assertChainSolid(t, out, fmt.Sprintf("bore %d", i))
+		if got := cylinderFaceCount(out); got != i+1 {
+			t.Fatalf("bore %d: %d cylinder faces, want %d — a bore fell back to faceted CSG instead of an exact hole", i, got, i+1)
+		}
+		res = out
+	}
+
+	got, want := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume, v0-5*removed
+	if drift := stdmath.Abs(got - want); drift > 0.005*v0 {
+		t.Errorf("five chained bores: volume %.4f, want %.4f (drift %.4f > %.4f = 0.5%% of slab)",
+			got, want, drift, 0.005*v0)
+	}
+}
+
+// TestCurvedBooleanChainDriftOrderIndependent: the same five holes drilled in a shuffled order reach the
+// same exact volume — chaining is path-independent, not just stable for one ordering.
+func TestCurvedBooleanChainDriftOrderIndependent(t *testing.T) {
+	want := ops.BodyGeometryProperties(chainSlab(t), ops.DefaultQuality()).Volume
+	ref, _ := ops.Boolean(ops.Cut, chainSlab(t), chainRod(t, 0, 0))
+	want -= 5 * (ops.BodyGeometryProperties(chainSlab(t), ops.DefaultQuality()).Volume - ops.BodyGeometryProperties(ref, ops.DefaultQuality()).Volume)
+
+	res := chainSlab(t)
+	for _, cx := range []float64{0, 8, -4, 4, -8} { // shuffled
+		out, err := ops.Boolean(ops.Cut, res, chainRod(t, cx, 0))
+		if err != nil {
+			t.Fatalf("bore at x=%g: %v", cx, err)
+		}
+		res = out
+	}
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	if stdmath.Abs(got-want) > 0.005*want {
+		t.Errorf("shuffled-order chain volume %.4f, want %.4f (drift > 0.5%%)", got, want)
+	}
+}


### PR DESCRIPTION
## What

Second slice of **M2 Phase 3** (Oblikovati/Oblikovati#1336), building on the exact drilled-plate path from #1366. It closes **acceptance #4** of the #1320 umbrella — *booleans stable under chaining without volume drift*.

`brep.drillThroughCurved` lifts the round-hole drill to the `curvedFace` model so it works on a target that **already has curved faces** (a prior bore's cylinder wall), where `CutCylindricalHole`'s all-planar precondition fails:

- `facesOfAny(target)` → copy every existing face unchanged (planar walls *and* prior bores' cylinder walls);
- add the new hole circle as an inner loop on the two pierced caps;
- add one reversed-cylinder wall face (the seamed loop `SolidCylinder` uses);
- re-weld via `curvedStitch`, which welds line *and* circle edges and shares the new circle between each cap and the wall.

So **every bore stays an exact watertight curved B-rep** and a drilled plate chains without drift — no bore touches CSG. `DrillThroughHole` now tries the planar assembly first and falls through to the curved path; it rejects a partial / clipped / overlapping hole so the general fallback still runs.

## Why

Slice A made the *first* bore exact, but the second — drilling into the now-curved body — fell back to CSG, and a chain of bores accumulated CSG noise into a non-manifold mesh. With multi-hole drilling, the whole chain is exact.

## Tests

- `kernel/ops/boolean_chain_drift_test.go` — **acceptance #4**: five sequential bores through `ops.Boolean`, each adding exactly one analytic cylinder face (witness it stayed exact, not CSG), watertight at every step, **order-independent**, cumulative volume within 0.5%.
- `kernel/brep/drill_multi_test.go` — second/fifth hole topology (one cylinder wall per bore, one shell), and the clipped / overlapping rejection paths.
- Full `kernel` + `model` + `app` suites green.

## Phase 3 status

After this, the #1320 umbrella's four acceptance criteria are all met (exact cyl±box, crossing cylinders, no `tjunctionFaceBudget` dependence, chaining stability). Remaining #1336 items before closing #1320: coplanar/tangent curved overlap (in progress — coaxial cylinder union), the OCCT `getMass` oracle, and demoting CSG to last-resort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)