### PR TITLE
M2 Phase 3: exact coaxial cylinder union (coplanar/tangent overlap)

### DIFF
--- a/kernel/brep/curved_coaxial_cylinder.go
+++ b/kernel/brep/curved_coaxial_cylinder.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Coaxial cylinder union (M2 Phase 3, Oblikovati/Oblikovati#1336 — the coplanar/tangent curved-overlap
+// case). Two coaxial same-radius cylinders that overlap or abut along their shared axis have COINCIDENT
+// side surfaces (both lie on the very same geom.Cylinder) and their inner caps fall inside the other body
+// — the curved analogue of a coplanar overlap. The general boolean sends this to triangle-soup CSG, which
+// faceted it (a coaxial-cylinder union came back ~2.5% under volume with zero analytic faces). The union
+// is exactly one taller cylinder spanning the merged axial interval, so build that directly and keep the
+// analytic surface. Anything off the coaxial-same-radius-overlapping case (different radius, skew axis, an
+// axial gap) returns ok=false so the caller keeps its fallback.
+
+// CoaxialCylinderUnion returns a ∪ b when a and b are coaxial, equal-radius cylinders overlapping or
+// abutting along the axis — one cylinder spanning their merged extent — or ok=false to defer.
+//
+// Example:
+//
+//	a, _ := brep.SolidCylinder(math.P3(0,0,0), math.V3(0,0,1), 2, 4) // z 0..4
+//	b, _ := brep.SolidCylinder(math.P3(0,0,3), math.V3(0,0,1), 2, 4) // z 3..7
+//	u, ok := brep.CoaxialCylinderUnion(a, b)                          // ok: one cylinder z 0..7
+func CoaxialCylinderUnion(a, b *topo.Body) (*topo.Body, bool) {
+	ca, baseA, hA, okA := cylinderSolidParams(facesOfAny(a))
+	cb, baseB, hB, okB := cylinderSolidParams(facesOfAny(b))
+	if !okA || !okB || !coaxialEqualRadius(ca, baseA, cb, baseB) {
+		return nil, false
+	}
+	axis := ca.AxisDir.AsVector()
+	loA, loB := axialOffset(baseA, baseA, axis), axialOffset(baseA, baseB, axis)
+	lo, hi := stdmath.Min(loA, loB), stdmath.Max(loA+hA, loB+hB)
+	if hi-lo > hA+hB+axialTouchTol {
+		return nil, false // an axial gap between the two — not a single solid, leave it to MergeBodies
+	}
+	union, err := SolidCylinder(baseA.TranslateBy(axis.Scale(math.Scalar(lo))), axis, ca.Radius, hi-lo)
+	if err != nil {
+		return nil, false
+	}
+	return union, true
+}
+
+// coaxialEqualRadius reports whether two cylinders share the same axis line (parallel directions, each
+// base on the other's axis) and the same radius — the precondition for their side faces to be coincident.
+func coaxialEqualRadius(ca geom.Cylinder, baseA math.Point3, cb geom.Cylinder, baseB math.Point3) bool {
+	ua, ub := ca.AxisDir.AsVector(), cb.AxisDir.AsVector()
+	if stdmath.Abs(float64(ua.Dot(ub))) < 1-1e-7 {
+		return false // axes not parallel
+	}
+	if !nearEqual(ca.Radius, cb.Radius) {
+		return false
+	}
+	return offAxisDistance(baseA, ua, baseB) <= axialTouchTol // baseB lies on a's axis line
+}
+
+// offAxisDistance returns the perpendicular distance of point p from the line through origin along the unit
+// axis ua.
+func offAxisDistance(origin math.Point3, ua math.Vector3, p math.Point3) float64 {
+	d := origin.VectorTo(p)
+	along := ua.Scale(d.Dot(ua))
+	return float64(d.Sub(along).Length())
+}
+
+// axialOffset returns the signed projection of p onto the axis through origin (the axial coordinate used
+// to merge the two extents).
+func axialOffset(origin, p math.Point3, ua math.Vector3) float64 {
+	return float64(origin.VectorTo(p).Dot(ua))
+}
+
+// axialTouchTol is the coincidence tolerance for the off-axis distance and the abut/gap test. Two
+// cylinders closer than this along the axis are treated as touching (no gap), matching nearEqual's scale.
+const axialTouchTol = 1e-7

--- a/kernel/brep/curved_coaxial_cylinder_test.go
+++ b/kernel/brep/curved_coaxial_cylinder_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Coaxial cylinder union (M2 Phase 3, Oblikovati/Oblikovati#1336). Two coaxial equal-radius cylinders that
+// overlap or abut along the axis union to ONE taller cylinder — an exact analytic solid, not the faceted
+// CSG the general path produced for this coincident-side-surface (coplanar/tangent) case.
+
+// TestCoaxialCylinderUnionOverlap unions z∈[0,4] with z∈[3,7] (overlapping) and checks the result is one
+// watertight cylinder spanning z∈[0,7]: three faces (one cylinder side + two caps).
+func TestCoaxialCylinderUnionOverlap(t *testing.T) {
+	a, _ := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2, 4)
+	b, _ := SolidCylinder(math.P3(0, 0, 3), math.V3(0, 0, 1), 2, 4)
+	res, ok := CoaxialCylinderUnion(a, b)
+	if !ok {
+		t.Fatal("coaxial overlap union declined; want one taller cylinder")
+	}
+	assertWatertight(t, res)
+	_, cyls, planes := faceTypeCounts(t, res)
+	if cyls != 1 || planes != 2 {
+		t.Errorf("coaxial union got %d cyl + %d plane faces, want 1 + 2 (one cylinder)", cyls, planes)
+	}
+}
+
+// TestCoaxialCylinderUnionAbut unions z∈[0,4] with z∈[4,8] (touching end to end) into one z∈[0,8] cylinder.
+func TestCoaxialCylinderUnionAbut(t *testing.T) {
+	a, _ := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2, 4)
+	b, _ := SolidCylinder(math.P3(0, 0, 4), math.V3(0, 0, 1), 2, 4)
+	res, ok := CoaxialCylinderUnion(a, b)
+	if !ok {
+		t.Fatal("coaxial abutting union declined; want one cylinder")
+	}
+	assertWatertight(t, res)
+	if _, cyls, _ := faceTypeCounts(t, res); cyls != 1 {
+		t.Errorf("abutting union got %d cylinder faces, want 1", cyls)
+	}
+}
+
+// TestCoaxialCylinderUnionOrderIndependent: union resolves whichever cylinder is passed first.
+func TestCoaxialCylinderUnionOrderIndependent(t *testing.T) {
+	a, _ := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2, 4)
+	b, _ := SolidCylinder(math.P3(0, 0, 3), math.V3(0, 0, 1), 2, 4)
+	if _, ok := CoaxialCylinderUnion(b, a); !ok {
+		t.Error("coaxial union should resolve with the upper cylinder passed first too")
+	}
+}
+
+// TestCoaxialCylinderUnionRejectsOffCase: different radius, parallel-but-offset axis, and an axial gap each
+// defer (ok=false) so the general boolean keeps the case.
+func TestCoaxialCylinderUnionRejectsOffCase(t *testing.T) {
+	base, _ := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2, 4)
+	cases := map[string]*topo.Body{
+		"different radius": mustCyl(math.P3(0, 0, 3), 3, 4),
+		"offset axis":      mustCyl(math.P3(5, 0, 3), 2, 4),
+		"axial gap":        mustCyl(math.P3(0, 0, 6), 2, 4), // base z6, gap (0..4) vs (6..10)
+	}
+	for name, tool := range cases {
+		if _, ok := CoaxialCylinderUnion(base, tool); ok {
+			t.Errorf("%s: expected the coaxial union to defer (ok=false)", name)
+		}
+	}
+}
+
+// mustCyl builds a validated solid cylinder of radius r, height h, with its base at base, along +Z.
+func mustCyl(base math.Point3, r, h float64) *topo.Body {
+	c, _ := SolidCylinder(base, math.V3(0, 0, 1), r, h)
+	return c
+}

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -129,7 +129,8 @@ func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.L
 //   - drilling a fat cylinder with a crossing rod (fat − rod), and the two rod stubs of rod − fat (#1335);
 //   - joining two crossing cylinders (fat ∪ rod: the fat with a rod stub each side) (#1335);
 //   - drilling/joining a fat cylinder with a crossing CONE (the tapered tunnel/stubs of cone − fat / fat ∪ cone) (#1335);
-//   - drilling a clean through-hole in an all-planar slab with a straight cylinder (a drilled plate: box − cylinder) (#1336).
+//   - drilling a clean through-hole in an all-planar slab with a straight cylinder (a drilled plate: box − cylinder) (#1336);
+//   - the union of two coaxial equal-radius cylinders that overlap/abut → one taller cylinder (a coplanar/tangent overlap) (#1336).
 func curvedExactBoolean(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
 	for _, exact := range curvedExactPaths {
 		if body, ok := exact(op, target, tool); ok {
@@ -146,7 +147,7 @@ var curvedExactPaths = []func(PartFeatureOperation, *topo.Body, *topo.Body) (*to
 	curvedCrossingIntersect, curvedSteinmetzIntersect, curvedConeCylinderIntersect, curvedConeConeIntersect,
 	curvedPartialIntersect,
 	curvedCylindricalHoleCut, curvedPartialCut, curvedSteinmetzCut, curvedConeCylinderCut, curvedConeConeCut, curvedCrossingCut,
-	curvedPartialJoin, curvedConeCylinderJoin, curvedConeConeJoin, curvedCrossingJoin, curvedSteinmetzJoin,
+	curvedCoaxialJoin, curvedPartialJoin, curvedConeCylinderJoin, curvedConeConeJoin, curvedCrossingJoin, curvedSteinmetzJoin,
 }
 
 func shouldFallbackBoolean(op PartFeatureOperation, target, tool, body *topo.Body) bool {

--- a/kernel/ops/boolean_coaxial_test.go
+++ b/kernel/ops/boolean_coaxial_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+)
+
+// Coaxial cylinder union exactness (M2 Phase 3, Oblikovati/Oblikovati#1336, the coplanar/tangent overlap
+// case). Two coaxial equal-radius cylinders that overlap union to ONE taller cylinder. Through ops.Boolean
+// the result must be exact — an analytic cylinder face survives and the volume is πr²·(merged height),
+// not the faceted CSG value (the case used to come back ~2.5% under with zero analytic faces).
+
+// TestCoaxialCylinderUnionIsExact unions z∈[0,4] with z∈[3,7] (radius 2) and checks the result keeps a
+// cylinder face and has the exact merged volume πr²·7.
+func TestCoaxialCylinderUnionIsExact(t *testing.T) {
+	a, err := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2, 4)
+	if err != nil {
+		t.Fatalf("SolidCylinder a: %v", err)
+	}
+	b, err := brep.SolidCylinder(math.P3(0, 0, 3), math.V3(0, 0, 1), 2, 4)
+	if err != nil {
+		t.Fatalf("SolidCylinder b: %v", err)
+	}
+
+	res, err := ops.Boolean(ops.Join, a, b)
+	if err != nil {
+		t.Fatalf("Boolean(Join): %v", err)
+	}
+	if r := ops.Validate(res); !r.Valid || !r.Closed || !r.Manifold || !res.IsSolid() {
+		t.Fatalf("coaxial union not a watertight solid: %+v", r)
+	}
+	if !hasCylinderFace(res) {
+		t.Error("coaxial union has no geom.Cylinder face — it fell back to faceted CSG")
+	}
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	want := stdmath.Pi * 2 * 2 * 7 // one cylinder r=2, merged height 7
+	if rel := stdmath.Abs(got-want) / want; rel > 0.01 {
+		t.Errorf("coaxial union volume %.4f, want %.4f (rel %.4f > 0.01); union is not exact", got, want, rel)
+	}
+}

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -130,6 +130,22 @@ func curvedCylindricalHoleCut(op PartFeatureOperation, target, tool *topo.Body) 
 	return res, true
 }
 
+// curvedCoaxialJoin returns target ∪ tool when both are coaxial equal-radius cylinders overlapping or
+// abutting along the axis — one cylinder spanning their merged extent — or ok=false to defer. Their side
+// faces are coincident (the curved analogue of a coplanar overlap), which the CSG fallback faceted; the
+// exact union keeps the analytic cylinder. Only Join maps here, and only a valid closed manifold result is
+// adopted.
+func curvedCoaxialJoin(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+	if op != Join {
+		return nil, false
+	}
+	res, ok := brep.CoaxialCylinderUnion(target, tool)
+	if !ok || !validBooleanSolid(res) {
+		return nil, false
+	}
+	return res, true
+}
+
 // curvedConeCylinderCut returns target − tool for a cone crossing a cylinder (drilling the fat cylinder with
 // the cone, or the two cone stubs of cone − fat), or ok=false to defer. Only Cut maps here, and only a valid
 // closed manifold result is adopted.


### PR DESCRIPTION
## What

Third slice of **M2 Phase 3** (Oblikovati/Oblikovati#1336) — the **coplanar/tangent curved-overlap** case. Two coaxial equal-radius cylinders that overlap or abut along their shared axis have **coincident side surfaces** (both lie on the very same `geom.Cylinder`) and their inner caps fall inside the other body — the curved analogue of a coplanar overlap. The general boolean faceted this through CSG: a coaxial union came back **~2.5% under volume with zero analytic faces**.

`brep.CoaxialCylinderUnion` builds the exact result — one taller cylinder spanning the merged axial interval — keeping the analytic surface. It detects coaxial (parallel axes, each base on the other's axis line), equal-radius, overlapping/abutting cylinders, and declines (`ok=false` → CSG fallback) for a different radius, a skew/offset axis, or an axial gap. Wired as `curvedCoaxialJoin` in `curvedExactPaths`.

## Why

Extending a shaft or stacking a boss of the same radius is a common modeling op, and it's the cleanest concrete instance of the coplanar/tangent curved overlap #1336 calls out. Making it exact removes faceting error and keeps the cylinder surface for downstream consumers.

## Tests

- `kernel/brep/curved_coaxial_cylinder_test.go` — overlap and abutting unions yield one watertight cylinder (1 cylinder + 2 cap faces), order-independent; different-radius / offset-axis / axial-gap all defer.
- `kernel/ops/boolean_coaxial_test.go` — through `ops.Boolean(Join)` the result keeps a `geom.Cylinder` face and has the exact merged volume πr²·h (a CSG fallback would miss by the facet deficit).
- Full `kernel` + `model` suites green.

## Phase 3 status

The #1320 umbrella's four acceptance criteria are already met (after #1366/#1367). Remaining #1336 items before closing #1320: more coplanar/tangent cases, the OCCT `getMass` oracle, and demoting CSG to last-resort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)