### PR TITLE
M2 Phase 3: exact cylindrical boss union (coplanar overlap)

### DIFF
--- a/kernel/brep/curved_cylinder_boss.go
+++ b/kernel/brep/curved_cylinder_boss.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Cylindrical boss union (M2 Phase 3, Oblikovati/Oblikovati#1336 — the coplanar curved+planar overlap
+// case). A cylinder sitting flush on a planar face of a solid (a boss: think a spigot on a plate) shares
+// that face's plane: its base disk is COINCIDENT and counter-oriented with the disk it covers, the
+// canonical coplanar overlap. The general boolean faceted this through CSG. The union is exact — the seat
+// face loses the boss-footprint disk (gains a circular hole), the boss adds one cylinder wall and a top
+// cap — so build it directly through the curvedFace model and keep the analytic surface. The boss is the
+// join analogue of CutCylindricalHole: a hole in the seat face plus an OUTWARD-facing wall (a solid boss,
+// material toward the axis) rather than a reversed one. Anything else (the cylinder not seated flush and
+// perpendicular on a single face, the circle clipping the face) returns ok=false so the caller keeps CSG.
+
+// JoinCylindricalBoss returns target ∪ tool when tool is a cylinder seated flush and perpendicular on one
+// planar face of target, protruding outward (a boss), or ok=false to defer.
+//
+// Example:
+//
+//	plate, _ := brep.SolidBlock(math.P3(-5,-5,0), math.P3(5,5,2), "plate")
+//	boss, _ := brep.SolidCylinder(math.P3(0,0,2), math.V3(0,0,1), 1.5, 3) // sits on the z=2 face
+//	u, ok := brep.JoinCylindricalBoss(plate, boss)                        // ok: plate + boss
+func JoinCylindricalBoss(target, tool *topo.Body) (*topo.Body, bool) {
+	cyl, base, height, ok := cylinderSolidParams(facesOfAny(tool))
+	if !ok {
+		return nil, false
+	}
+	ua := cyl.AxisDir.AsVector()
+	c0, c1 := base, base.TranslateBy(ua.Scale(math.Scalar(height)))
+	faces := facesOfAny(target)
+	near, far, seat, ok := bossSeatFace(faces, c0, c1, ua, cyl.Radius)
+	if !ok {
+		return nil, false
+	}
+	body := assembleBoss(faces, seat, near, far, cyl.Radius)
+	if body == nil {
+		return nil, false
+	}
+	return body, true
+}
+
+// bossSeatFace finds the planar face one cap sits flush on (perpendicular to the axis, the circle clear
+// inside it) with the boss protruding to that face's OUTWARD side. It returns the seated (near) and
+// protruding (far) cap centres and the face index, or ok=false when no face seats the boss.
+func bossSeatFace(faces []curvedFace, c0, c1 math.Point3, ua math.Vector3, radius float64) (near, far math.Point3, idx int, ok bool) {
+	for i, f := range faces {
+		pl, isPlane := f.surface.(geom.Plane)
+		if !isPlane || stdmath.Abs(float64(unit(pl.Normal()).Dot(ua))) < 1-1e-7 {
+			continue // not a face perpendicular to the boss axis
+		}
+		nOut := faceOutwardNormal(f, pl)
+		for _, cap := range [2][2]math.Point3{{c0, c1}, {c1, c0}} {
+			n, fr := cap[0], cap[1]
+			if stdmath.Abs(pointPlaneDistance(n, pl)) > axialTouchTol {
+				continue // this cap is not flush on the face plane
+			}
+			if float64(n.VectorTo(fr).Dot(nOut)) <= 0 {
+				continue // boss would protrude into the solid, not out of the seat face
+			}
+			if _, clean := circleVsCap(n, radius, f, pl); clean {
+				return n, fr, i, true
+			}
+		}
+	}
+	return math.Point3{}, math.Point3{}, 0, false
+}
+
+// assembleBoss rebuilds the union: every target face unchanged except the seat face, which gains the
+// boss-footprint hole, plus the outward boss wall and its top cap, re-welded through curvedStitch.
+func assembleBoss(faces []curvedFace, seat int, near, far math.Point3, radius float64) *topo.Body {
+	axis := unit(near.VectorTo(far)) // near → far, the boss's outward direction
+	nearCirc, err := geom.NewCircle(near, axis, radius)
+	if err != nil {
+		return nil
+	}
+	farCirc := geom.Circle{Center: far, Normal: nearCirc.Normal, RefDir: nearCirc.RefDir, Radius: radius}
+
+	out := make([]curvedFace, 0, len(faces)+2)
+	for i, f := range faces {
+		if i == seat {
+			out = append(out, capWithHoleReversed(f, nearCirc)) // the disk the boss covers becomes a hole
+			continue
+		}
+		out = append(out, f)
+	}
+	out = append(out, bossWallFace(near, axis, radius, nearCirc, farCirc), bossTopCapFace(far, axis, farCirc))
+	return curvedStitch(out)
+}
+
+// capWithHoleReversed appends the circle to a face as an inner loop wound REVERSED — opposite to
+// capWithHole — so its single use is counter to the boss wall's forward use of the same circle (the wall
+// reuses the bottom circle the way SolidCylinder's side does, Fwd(eb)).
+func capWithHoleReversed(f curvedFace, circ geom.Circle) curvedFace {
+	hole := curvedLoop{edges: []loopEdge{{curve: circ, t0: 1, t1: 0}}}
+	f.loops = append(append([]curvedLoop{}, f.loops...), hole)
+	return f
+}
+
+// bossWallFace builds the boss side as an OUTWARD cylinder face (material toward the axis, a solid boss —
+// AddFace, not the reversed hole wall) with the same seamed loop SolidCylinder's side uses (seam up, far
+// circle reversed, seam down, near circle forward), so it welds to the seat-face hole and the top cap
+// along the shared circle edges.
+func bossWallFace(baseCenter math.Point3, axis math.Vector3, radius float64, nearCirc, farCirc geom.Circle) curvedFace {
+	cyl, _ := geom.NewCylinder(baseCenter, axis, radius)
+	seam := geom.NewLineSegment(nearCirc.PointAt(0), farCirc.PointAt(0))
+	loop := curvedLoop{edges: []loopEdge{
+		{curve: seam, t0: 0, t1: 1},
+		{curve: farCirc, t0: 1, t1: 0},
+		{curve: seam, t0: 1, t1: 0},
+		{curve: nearCirc, t0: 0, t1: 1},
+	}}
+	return curvedFace{surface: cyl, reversed: false, loops: []curvedLoop{loop}, lineage: topo.NewLineage(topo.Tok("brep", "bosswall", 0))}
+}
+
+// bossTopCapFace builds the boss's outer cap disk (outward normal along the axis, away from the seat).
+func bossTopCapFace(center math.Point3, axis math.Vector3, farCirc geom.Circle) curvedFace {
+	pl, _ := geom.NewPlane(center, axis)
+	loop := curvedLoop{edges: []loopEdge{{curve: farCirc, t0: 0, t1: 1}}}
+	return curvedFace{surface: pl, reversed: false, loops: []curvedLoop{loop}, lineage: topo.NewLineage(topo.Tok("brep", "bosscap", 0))}
+}
+
+// faceOutwardNormal returns a face's true outward normal: the plane normal, flipped when the face was
+// added reversed (its material side is the plane's positive side).
+func faceOutwardNormal(f curvedFace, pl geom.Plane) math.Vector3 {
+	n := unit(pl.Normal())
+	if f.reversed {
+		return n.Scale(-1)
+	}
+	return n
+}
+
+// pointPlaneDistance returns the signed distance of p from the plane (positive on the normal side).
+func pointPlaneDistance(p math.Point3, pl geom.Plane) float64 {
+	return float64(pl.Origin.VectorTo(p).Dot(unit(pl.Normal())))
+}

--- a/kernel/brep/curved_cylinder_boss_test.go
+++ b/kernel/brep/curved_cylinder_boss_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Cylindrical boss union (M2 Phase 3, Oblikovati/Oblikovati#1336). A cylinder seated flush on a planar
+// face (a boss) unions exactly: the seat face gains the boss-footprint hole, the boss adds one analytic
+// cylinder wall and a top cap. The shared base disk is the canonical coplanar overlap the CSG fallback
+// faceted.
+
+// TestJoinCylindricalBossOnPlate seats a boss on a plate's top face and checks the result is one watertight
+// solid with the boss's single analytic cylinder wall and the plate's faces (the seat face kept, holed).
+func TestJoinCylindricalBossOnPlate(t *testing.T) {
+	plate, _ := SolidBlock(math.P3(-5, -5, 0), math.P3(5, 5, 2), "plate")
+	boss, _ := SolidCylinder(math.P3(0, 0, 2), math.V3(0, 0, 1), 1.5, 3)
+	res, ok := JoinCylindricalBoss(plate, boss)
+	if !ok {
+		t.Fatal("boss union declined; want plate + boss")
+	}
+	assertWatertight(t, res)
+	if n := len(res.Shells()); n != 1 {
+		t.Errorf("boss union has %d shells, want 1", n)
+	}
+	_, cyls, planes := faceTypeCounts(t, res)
+	if cyls != 1 || planes != 7 {
+		t.Errorf("boss union got %d cyl + %d plane faces, want 1 (wall) + 7 (6 box + boss cap)", cyls, planes)
+	}
+}
+
+// TestJoinCylindricalBossOnBottomFace seats a boss on the plate's BOTTOM face (outward normal −Z), so the
+// boss protrudes downward — the seat detection must handle either face orientation.
+func TestJoinCylindricalBossOnBottomFace(t *testing.T) {
+	plate, _ := SolidBlock(math.P3(-5, -5, 0), math.P3(5, 5, 2), "plate")
+	boss, _ := SolidCylinder(math.P3(0, 0, -3), math.V3(0, 0, 1), 1.5, 3) // z −3..0, seated on z=0
+	res, ok := JoinCylindricalBoss(plate, boss)
+	if !ok {
+		t.Fatal("boss on bottom face declined")
+	}
+	assertWatertight(t, res)
+	if _, cyls, _ := faceTypeCounts(t, res); cyls != 1 {
+		t.Errorf("downward boss got %d cylinder faces, want 1", cyls)
+	}
+}
+
+// TestJoinCylindricalBossRejectsOffCase: a boss that would protrude INTO the solid, one clipping the seat
+// face edge, and a tool not touching any face each defer (ok=false).
+func TestJoinCylindricalBossRejectsOffCase(t *testing.T) {
+	plate, _ := SolidBlock(math.P3(-5, -5, 0), math.P3(5, 5, 2), "plate")
+	cases := map[string]*topo.Body{
+		"into the solid":  mustCyl(math.P3(0, 0, -1), 1.5, 3),  // z −1..2: far cap inside the plate, not a boss
+		"clips seat edge": mustCyl(math.P3(4.5, 0, 2), 1.5, 3), // circle spills past x=5
+		"not on any face": mustCyl(math.P3(0, 0, 3), 1.5, 3),   // floats above the plate, base at z=3
+	}
+	for name, tool := range cases {
+		if _, ok := JoinCylindricalBoss(plate, tool); ok {
+			t.Errorf("%s: expected the boss union to defer (ok=false)", name)
+		}
+	}
+}

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -130,7 +130,8 @@ func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.L
 //   - joining two crossing cylinders (fat ∪ rod: the fat with a rod stub each side) (#1335);
 //   - drilling/joining a fat cylinder with a crossing CONE (the tapered tunnel/stubs of cone − fat / fat ∪ cone) (#1335);
 //   - drilling a clean through-hole in an all-planar slab with a straight cylinder (a drilled plate: box − cylinder) (#1336);
-//   - the union of two coaxial equal-radius cylinders that overlap/abut → one taller cylinder (a coplanar/tangent overlap) (#1336).
+//   - the union of two coaxial equal-radius cylinders that overlap/abut → one taller cylinder (a coplanar/tangent overlap) (#1336);
+//   - the union of a cylinder seated flush on a planar face (a boss/spigot) → seat-face hole + outward wall + cap (a coplanar overlap) (#1336).
 func curvedExactBoolean(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
 	for _, exact := range curvedExactPaths {
 		if body, ok := exact(op, target, tool); ok {
@@ -147,7 +148,7 @@ var curvedExactPaths = []func(PartFeatureOperation, *topo.Body, *topo.Body) (*to
 	curvedCrossingIntersect, curvedSteinmetzIntersect, curvedConeCylinderIntersect, curvedConeConeIntersect,
 	curvedPartialIntersect,
 	curvedCylindricalHoleCut, curvedPartialCut, curvedSteinmetzCut, curvedConeCylinderCut, curvedConeConeCut, curvedCrossingCut,
-	curvedCoaxialJoin, curvedPartialJoin, curvedConeCylinderJoin, curvedConeConeJoin, curvedCrossingJoin, curvedSteinmetzJoin,
+	curvedCoaxialJoin, curvedCylinderBossJoin, curvedPartialJoin, curvedConeCylinderJoin, curvedConeConeJoin, curvedCrossingJoin, curvedSteinmetzJoin,
 }
 
 func shouldFallbackBoolean(op PartFeatureOperation, target, tool, body *topo.Body) bool {

--- a/kernel/ops/boolean_boss_test.go
+++ b/kernel/ops/boolean_boss_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+)
+
+// Cylindrical boss union exactness (M2 Phase 3, Oblikovati/Oblikovati#1336 — the coplanar curved+planar
+// overlap case). A cylinder seated flush on a plate face (a boss/spigot) unions to an exact solid: the
+// seat face's base disk is coplanar with the boss base — the coplanar overlap the general boolean faceted
+// through CSG. Through ops.Boolean the result must keep an analytic cylinder face and have the exact
+// volume plate + πr²h.
+
+// TestCylindricalBossUnionIsExact seats a radius-1.5, height-3 boss on a 10×10×2 plate and checks the
+// union keeps a cylinder face and has volume 200 + π·1.5²·3.
+func TestCylindricalBossUnionIsExact(t *testing.T) {
+	plate, err := brep.SolidBlock(math.P3(-5, -5, 0), math.P3(5, 5, 2), "plate")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	boss, err := brep.SolidCylinder(math.P3(0, 0, 2), math.V3(0, 0, 1), 1.5, 3)
+	if err != nil {
+		t.Fatalf("SolidCylinder: %v", err)
+	}
+
+	res, err := ops.Boolean(ops.Join, plate, boss)
+	if err != nil {
+		t.Fatalf("Boolean(Join): %v", err)
+	}
+	if r := ops.Validate(res); !r.Valid || !r.Closed || !r.Manifold || !res.IsSolid() {
+		t.Fatalf("boss union not a watertight solid: %+v", r)
+	}
+	if !hasCylinderFace(res) {
+		t.Error("boss union has no geom.Cylinder face — it fell back to faceted CSG")
+	}
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	want := 200.0 + stdmath.Pi*1.5*1.5*3 // plate 10×10×2 + boss πr²h
+	if rel := stdmath.Abs(got-want) / want; rel > 0.01 {
+		t.Errorf("boss union volume %.4f, want %.4f (rel %.4f > 0.01); union is not exact", got, want, rel)
+	}
+}

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -146,6 +146,22 @@ func curvedCoaxialJoin(op PartFeatureOperation, target, tool *topo.Body) (*topo.
 	return res, true
 }
 
+// curvedCylinderBossJoin returns target ∪ tool when tool is a cylinder seated flush and perpendicular on
+// one planar face of target, protruding outward (a boss / spigot), or ok=false to defer. The boss base
+// disk is coplanar with the seat face — the canonical coplanar overlap the CSG fallback faceted; the exact
+// union keeps the analytic cylinder wall. Only Join maps here, and only a valid closed manifold result is
+// adopted.
+func curvedCylinderBossJoin(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+	if op != Join {
+		return nil, false
+	}
+	res, ok := brep.JoinCylindricalBoss(target, tool)
+	if !ok || !validBooleanSolid(res) {
+		return nil, false
+	}
+	return res, true
+}
+
 // curvedConeCylinderCut returns target − tool for a cone crossing a cylinder (drilling the fat cylinder with
 // the cone, or the two cone stubs of cone − fat), or ok=false to defer. Only Cut maps here, and only a valid
 // closed manifold result is adopted.


### PR DESCRIPTION
## What

Fourth slice of **M2 Phase 3** (Oblikovati/Oblikovati#1336) — another **coplanar curved+planar overlap** case. A cylinder seated flush on a planar face of a solid (a boss / spigot — a spindle on a plate) shares that face's plane: its base disk is coincident and counter-oriented with the disk it covers. The general boolean faceted this through CSG.

`brep.JoinCylindricalBoss` is the **join analogue of `CutCylindricalHole`**: the seat face loses the boss-footprint disk (gains a circular hole), and the boss adds one analytic cylinder wall (OUTWARD-facing — a solid boss, material toward the axis, vs. the reversed hole wall) and a top cap. The new circle is shared between the seat-face hole and the wall through `curvedStitch`. It seats either face orientation and declines (`ok=false` → CSG fallback) when the cylinder isn't flush-and-perpendicular on a single face, protrudes into the solid, or clips the face. Wired as `curvedCylinderBossJoin`.

## Why

Adding a boss/spigot to a face is one of the most common modeling joins, and it's the canonical coplanar curved+planar overlap #1336 calls out (alongside the coaxial-cylinder case from #1368). Making it exact removes faceting error and keeps the cylinder surface for downstream consumers.

## Tests

- `kernel/brep/curved_cylinder_boss_test.go` — boss on a plate's top *and* bottom face → one watertight solid (1 cylinder wall + 7 planar faces); plus rejections (protrudes into the solid / clips the seat edge / not touching any face).
- `kernel/ops/boolean_boss_test.go` — through `ops.Boolean(Join)` the result keeps a `geom.Cylinder` face and has the exact volume plate + πr²h.
- Full `kernel` + `model` + `app` suites green.

## Phase 3 status

The #1320 umbrella's four acceptance criteria are met (after #1366/#1367). This and #1368 cover the two principal coplanar/tangent curved overlaps (coaxial cylinders, boss on a face). Remaining #1336 items before closing #1320: the OCCT `getMass` oracle and formally demoting CSG to last-resort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)