### PR TITLE
M2 Phase 3: OCC getMass boolean oracle (independent ground-truth)

### DIFF
--- a/kernel/ops/boolean_occ_oracle_test.go
+++ b/kernel/ops/boolean_occ_oracle_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	"encoding/json"
+	stdmath "math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+)
+
+// OCC getMass boolean oracle (M2 Phase 3, Oblikovati/Oblikovati#1336 — the independent ground-truth
+// validation #1320 asks for). The exact analytic curved booleans are checked against OpenCASCADE's exact
+// volume (BRepGProp::VolumeProperties, "getMass") on the SAME inputs. testdata/occ_boolean_oracle.json
+// holds {case: volume} produced offline by experiments/occ-boolean-oracle (a tiny OCCT C++ driver), so the
+// test needs no OCCT at run time. The cases ARE curvedExactCases — the same matrix the exactness guard
+// runs — so each documented curved boolean is validated both for staying exact AND for matching OCC mass.
+//
+// Our volume is the tessellated B-rep's (inscribed facets at DefaultQuality), so it sits slightly UNDER
+// OCC's exact analytic value by the chord deficit — never far over. The per-case budget reflects how much
+// curved area each result carries (a doubly-curved or many-arc result faceted more than a singly-curved
+// one); it is one-sided in spirit but written as |rel| for simplicity.
+
+func loadOCCBooleanOracle(t *testing.T) map[string]float64 {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("testdata", "occ_boolean_oracle.json"))
+	if err != nil {
+		t.Fatalf("read occ_boolean_oracle.json: %v", err)
+	}
+	oracle := map[string]float64{}
+	if err := json.Unmarshal(raw, &oracle); err != nil {
+		t.Fatalf("parse occ_boolean_oracle.json: %v", err)
+	}
+	return oracle
+}
+
+// occBooleanTolerance is the allowed relative volume error vs OCC getMass. Our value is the TESSELLATED
+// B-rep's volume (inscribed facets at DefaultQuality), so it sits below OCC's exact analytic value by the
+// chord deficit — the more curved area a result carries, the larger the (one-sided) deficit. The B-rep
+// itself is exact; this budget is the meshing error, matching the per-shape budgets the STEP OCC oracle
+// already uses (singly-curved solids ~5%). A result that exceeds it has a geometry error, not mere faceting.
+func occBooleanTolerance(name string) float64 {
+	switch name {
+	case "box − cylinder (drilled plate)", "cylinder boss ∪", "cylinder − box tunnel":
+		return 0.015 // planar-dominant: only one cylinder wall to facet
+	default:
+		return 0.05 // a singly-curved result (cylinder/cone bands, saddle lobes) at DefaultQuality
+	}
+}
+
+func TestCurvedBooleanVolumesMatchOCC(t *testing.T) {
+	oracle := loadOCCBooleanOracle(t)
+	for _, c := range curvedExactCases() {
+		t.Run(c.name, func(t *testing.T) {
+			want, ok := oracle[c.name]
+			if !ok {
+				t.Fatalf("no OCC oracle entry for %q (regenerate testdata/occ_boolean_oracle.json)", c.name)
+			}
+			target, tool := c.build(t)
+			res, err := ops.Boolean(c.op, target, tool)
+			if err != nil {
+				t.Fatalf("%s: Boolean(%s): %v", c.name, c.op, err)
+			}
+			got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+			rel := stdmath.Abs(got-want) / want
+			t.Logf("%-32s ours=%.4f  occ=%.4f  rel=%.4f (budget %.3f)", c.name, got, want, rel, occBooleanTolerance(c.name))
+			if rel > occBooleanTolerance(c.name) {
+				t.Errorf("%s: volume %.4f vs OCC getMass %.4f (rel %.4f > %.4f)", c.name, got, want, rel, occBooleanTolerance(c.name))
+			}
+		})
+	}
+}

--- a/kernel/ops/testdata/occ_boolean_oracle.json
+++ b/kernel/ops/testdata/occ_boolean_oracle.json
@@ -1,0 +1,14 @@
+{
+  "cylinder ∩ box": 237.7277827,
+  "cylinder − box tunnel": 137.93804,
+  "box − cylinder (drilled plate)": 2357.588499,
+  "crossing cylinders ∩": 41.04118851,
+  "crossing cylinders − (drill)": 298.2504735,
+  "crossing cylinders ∪": 383.0734752,
+  "equal-radius Steinmetz ∩": 144,
+  "cone ∩ cylinder": 55.44125747,
+  "cone ∩ cone": 24.59680642,
+  "partial penetration ∩": 20.52055473,
+  "coaxial cylinders ∪": 87.9645943,
+  "cylinder boss ∪": 221.2057504
+}


### PR DESCRIPTION
## What

Final slice of **M2 Phase 3** (Oblikovati/Oblikovati#1336) — the independent-oracle acceptance of #1320. Every exact analytic curved boolean is now validated against **OpenCASCADE's exact volume** (`BRepGProp::VolumeProperties` — *getMass*) on the same inputs.

`TestCurvedBooleanVolumesMatchOCC` iterates the same matrix as the exactness guard (`curvedExactCases`) and compares each `ops.Boolean` result's volume to the OCC value in `testdata/occ_boolean_oracle.json`. Agreement is within the DefaultQuality chord-faceting budget — our tessellated volume sits just **under** OCC's exact analytic value (the B-rep itself is exact; the gap is inscribed-facet meshing error), matching the per-shape budgets the existing STEP OCC oracle uses.

OCC's numbers also confirm the geometry independently: the equal-radius **Steinmetz reads exactly 144** (= 16/3·R³), the coaxial union π·4·7 = 87.96, the boss 200 + π·2.25·3 = 221.21.

## How the oracle is produced

`experiments/occ-boolean-oracle/` (git-ignored, like the STEP oracle's generator) holds a small OCCT C++ driver (`occ_boolean_oracle.cpp` + `gen-oracle.sh` + `README.md`) that builds the same primitives/booleans and prints `{case: volume}`. I built the **vendored OCCT source** (`../OCCT`, v8.0) as a minimal subset (FoundationClasses + ModelingData + ModelingAlgorithms) and ran the driver to produce the committed JSON, so the test needs no OCCT at run time.

## Tests

- `kernel/ops/boolean_occ_oracle_test.go` — 12 families vs OCC `getMass`, all green.
- Full `kernel/ops` + `kernel/brep` suites green.

## Phase 3 / #1320 status

This completes every #1336 item: coplanar/tangent overlaps (#1368/#1369), chaining drift guard (#1367), no `tjunctionFaceBudget` dependence (#1366), CSG demoted to last-resort (#1370), and now the OCC `getMass` oracle. With this merged, the **#1320 umbrella's acceptance criteria are all satisfied** and it can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)