### PR TITLE
Exact cone ∩/− box with a box face parallel to the cone axis (#1372)

### DIFF
--- a/kernel/brep/curved_halfspace_cone_side.go
+++ b/kernel/brep/curved_halfspace_cone_side.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Cone-side split (M2 Phase-1 follow-up, Oblikovati/Oblikovati#1372). The cone analogue of
+// cylinderSideSplit: a FULL periodic frustum side cut by a plane PARALLEL to the axis. Like the
+// cylinder, the seam tangles the general looped split, so this gives a dedicated closed-form split —
+// but the imprint is one hyperbola branch (the conic a plane ∥ axis cuts from a cone), not two lines,
+// and the kept band's two cross-section arcs have different radii. This slice handles the ARC-BAND
+// arrangement where the plane cuts EVERY cross-section in the band (the vertex sits at or below the
+// bottom rim, |D| < bottom radius) — a flat milled the full length of a frustum's side. The vertex-
+// inside-band arrangement (the flat fades out before the bottom rim) and a full cone reaching its
+// apex defer to ErrUnsupportedHalfSpace, so the CSG fallback still covers them with no regression.
+
+// coneSideSplit splits a full periodic frustum side f by a plane parallel to the axis, given the
+// hyperbola branch the plane cuts. It returns the kept arc-band sub-face and the two hyperbola arms
+// (reversed, for the lid). Defers the vertex-inside and through-apex arrangements.
+func coneSideSplit(f curvedFace, curves []geom.Curve3, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
+	cone, ok := f.surface.(geom.Cone)
+	if !ok || len(curves) != 1 {
+		return nil, nil, ErrUnsupportedHalfSpace
+	}
+	hyper, ok := curves[0].(geom.Hyperbola)
+	if !ok {
+		return nil, nil, ErrUnsupportedHalfSpace
+	}
+	band, ok := coneSideBand(f, cone)
+	if !ok {
+		return nil, nil, ErrUnsupportedHalfSpace
+	}
+	d := float64(plane.Origin.VectorTo(cone.Apex).Dot(n)) // signed: every cross-section centre sits at distance d
+	absD := stdmath.Abs(d)
+	if absD >= band.rTop-cylinderAxisTol { // plane clears every cross-section: whole side, or none
+		return coneSideWholeOrEmpty(f, d), nil, nil
+	}
+	if absD >= band.rBot-cylinderAxisTol { // vertex sits inside the band: deferred to CSG for now
+		return nil, nil, ErrUnsupportedHalfSpace
+	}
+	return coneArcBand(f, cone, hyper, band, n, d)
+}
+
+// coneSideBand carries a frustum side's two cross-section circles (centres on the axis, ordered
+// low→high in apex distance) and their radii.
+type coneSideBand_ struct {
+	bottom, top math.Point3
+	vMin, vMax  float64
+	rBot, rTop  float64
+}
+
+// coneSideBand recovers the frustum side's two full-circle rims, ordered by apex distance. ok=false
+// unless the face is the expected two-circle periodic side (a full cone, with one rim and an apex,
+// is not the arc-band case and defers).
+func coneSideBand(f curvedFace, cone geom.Cone) (coneSideBand_, bool) {
+	axis := cone.AxisDir.AsVector()
+	tanA := stdmath.Tan(cone.HalfAngle)
+	var centers []math.Point3
+	for _, le := range f.loops[0].edges {
+		if c, isCircle := le.curve.(geom.Circle); isCircle && isFullDomain(le.t0, le.t1) {
+			centers = append(centers, c.Center)
+		}
+	}
+	if len(centers) != 2 {
+		return coneSideBand_{}, false
+	}
+	if float64(cone.Apex.VectorTo(centers[0]).Dot(axis)) > float64(cone.Apex.VectorTo(centers[1]).Dot(axis)) {
+		centers[0], centers[1] = centers[1], centers[0]
+	}
+	vMin := float64(cone.Apex.VectorTo(centers[0]).Dot(axis))
+	vMax := float64(cone.Apex.VectorTo(centers[1]).Dot(axis))
+	return coneSideBand_{bottom: centers[0], top: centers[1], vMin: vMin, vMax: vMax, rBot: vMin * tanA, rTop: vMax * tanA}, true
+}
+
+// coneSideWholeOrEmpty handles a plane that clears the whole band: the cone's axis sits at signed
+// distance d from the plane, so d<0 keeps the entire side (negative side) and d≥0 drops it.
+func coneSideWholeOrEmpty(f curvedFace, d float64) []curvedFace {
+	if d < 0 {
+		return []curvedFace{f}
+	}
+	return nil
+}
+
+// coneArcBand builds the kept arc-band sub-face and the two hyperbola section arms. The kept arc of
+// each cross-section is centred on u_c = u_n+π (the rim point farthest from the plane) and spans the
+// angle the plane leaves; the two arms are the hyperbola feet climbing from the bottom rim to the top.
+func coneArcBand(f curvedFace, cone geom.Cone, hyper geom.Hyperbola, band coneSideBand_, n math.Vector3, d float64) ([]curvedFace, []loopEdge, error) {
+	axis := cone.AxisDir.AsVector()
+	ref := cone.Ref.AsVector()
+	uN := coneAngleOf(cone, n)
+	// Kept where cos(u−u_n) < c*(v) = −d/(v·tanα): the arc centred on u_n+π spanning 2π−2φ, φ=arccos(c*).
+	phiB := stdmath.Acos(clampUnit(-d / band.rBot))
+	phiT := stdmath.Acos(clampUnit(-d / band.rTop))
+	bottomArc, err := geom.NewArc3d(band.bottom, axis, ref, band.rBot, uN+phiB, 2*stdmath.Pi-2*phiB)
+	if err != nil {
+		return nil, nil, ErrUnsupportedHalfSpace
+	}
+	topArc, err := geom.NewArc3d(band.top, axis, ref, band.rTop, uN-phiT, -(2*stdmath.Pi - 2*phiT))
+	if err != nil {
+		return nil, nil, ErrUnsupportedHalfSpace
+	}
+	armA := hyperbolaArm(hyper, bottomArc.PointAt(1), topArc.PointAt(0)) // −φ side, bottom→top
+	armB := hyperbolaArm(hyper, topArc.PointAt(1), bottomArc.PointAt(0)) // +φ side, top→bottom
+	loop := []loopEdge{{curve: bottomArc, t0: 0, t1: 1}, armA, {curve: topArc, t0: 0, t1: 1}, armB}
+	kept := curvedFace{surface: cone, reversed: f.reversed, lineage: f.lineage, loops: []curvedLoop{{edges: loop}}}
+	section := []loopEdge{reverseEdge(armA), reverseEdge(armB)}
+	return []curvedFace{kept}, section, nil
+}
+
+// hyperbolaArm builds the loop edge along the hyperbola branch from start to end, its parameters the
+// θ values the branch inverse gives at the two rim feet (a hyperbola loop edge's t0/t1 are θ).
+func hyperbolaArm(hyper geom.Hyperbola, start, end math.Point3) loopEdge {
+	t0, _ := geom.CurveParamAtPoint3(hyper, start)
+	t1, _ := geom.CurveParamAtPoint3(hyper, end)
+	return loopEdge{curve: hyper, t0: t0, t1: t1}
+}
+
+// coneAngleOf returns the angle of a direction (here the cut-plane normal, which lies in the cone's
+// cross-section plane since the plane is parallel to the axis) in the cone's Ref/binormal frame.
+func coneAngleOf(cone geom.Cone, dir math.Vector3) float64 {
+	axis := cone.AxisDir.AsVector()
+	r := dir.Sub(axis.Scale(dir.Dot(axis))) // drop the axial component
+	binormal := axis.Cross(cone.Ref.AsVector())
+	return stdmath.Atan2(float64(r.Dot(binormal)), float64(r.Dot(cone.Ref.AsVector())))
+}
+
+// isFullConeSide reports whether f is a full periodic cone side (a geom.Cone bounded by a closed-
+// circle rim and the seam) — the case the general looped split tangles on, routed to coneSideSplit.
+func isFullConeSide(f curvedFace) bool {
+	if _, ok := f.surface.(geom.Cone); !ok || len(f.loops) == 0 {
+		return false
+	}
+	for _, le := range f.loops[0].edges {
+		if _, isCircle := le.curve.(geom.Circle); isCircle && isFullDomain(le.t0, le.t1) {
+			return true
+		}
+	}
+	return false
+}
+
+// allHyperbolas reports whether every imprint curve is a hyperbola branch (the axis-parallel cut of a
+// cone), distinguishing it from a perpendicular circle the dedicated cone split cannot consume.
+func allHyperbolas(curves []geom.Curve3) bool {
+	for _, c := range curves {
+		if _, ok := c.(geom.Hyperbola); !ok {
+			return false
+		}
+	}
+	return len(curves) > 0
+}
+
+// clampUnit clamps x into [-1, 1] so arccos stays defined against rounding at the band rims.
+func clampUnit(x float64) float64 {
+	return stdmath.Max(-1, stdmath.Min(1, x))
+}

--- a/kernel/brep/curved_halfspace_cone_side_test.go
+++ b/kernel/brep/curved_halfspace_cone_side_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"errors"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// A frustum cut by a plane PARALLEL to its axis, shallow enough to clip every cross-section
+// (|D| < bottom radius), keeps an exact arc-band cone face — a flat milled the full side of a
+// frustum (Oblikovati/Oblikovati#1372). The result must be a watertight solid whose curved face is
+// still a geom.Cone (not faceted), with the hyperbola arms welded into the lid.
+func TestConeSideHalfSpaceArcBand(t *testing.T) {
+	frustum := mustFrustum(t, math.P3(0, 0, 0), math.P3(0, 0, 10), 3, 6) // tanα = 0.3, bottom r=3, top r=6
+	plane, err := geom.NewPlane(math.P3(2, 0, 0), math.V3(1, 0, 0))      // x=2 ∥ z axis, |D|=2 < bottom r=3
+	if err != nil {
+		t.Fatalf("NewPlane: %v", err)
+	}
+	res, err := HalfSpaceCut(frustum, plane)
+	if err != nil {
+		t.Fatalf("HalfSpaceCut: %v", err)
+	}
+	assertWatertight(t, res)
+	cones, _, _ := faceTypeCounts(t, res)
+	if cones != 1 {
+		t.Errorf("result has %d cone faces, want exactly 1 (the arc-band side stays analytic)", cones)
+	}
+	for _, f := range res.Faces() {
+		if hasHyperbolaEdge(f) {
+			return
+		}
+	}
+	t.Error("no face carries a hyperbolic edge — the cut was not imprinted as a hyperbola")
+}
+
+// A plane parallel to the axis but clear of the whole frustum (|D| ≥ top radius) keeps the solid
+// whole on the axis side and empty on the far side.
+func TestConeSideHalfSpaceClears(t *testing.T) {
+	frustum := mustFrustum(t, math.P3(0, 0, 0), math.P3(0, 0, 10), 3, 6)
+	keep, _ := geom.NewPlane(math.P3(7, 0, 0), math.V3(1, 0, 0)) // axis at -7 (negative side): whole kept
+	res, err := HalfSpaceCut(frustum, keep)
+	if err != nil {
+		t.Fatalf("HalfSpaceCut(keep): %v", err)
+	}
+	if len(res.Faces()) != len(frustum.Faces()) {
+		t.Errorf("clearing plane changed the face count: %d vs %d", len(res.Faces()), len(frustum.Faces()))
+	}
+	drop, _ := geom.NewPlane(math.P3(-7, 0, 0), math.V3(1, 0, 0)) // axis at +7 (positive side): emptied
+	empty, err := HalfSpaceCut(frustum, drop)
+	if err != nil {
+		t.Fatalf("HalfSpaceCut(drop): %v", err)
+	}
+	if len(empty.Faces()) != 0 {
+		t.Errorf("plane on the far side should empty the solid, got %d faces", len(empty.Faces()))
+	}
+}
+
+// The vertex-inside-band arrangement (the flat fades before the bottom rim, bottom r ≤ |D| < top r)
+// is not yet built and must defer cleanly so the CSG fallback still covers it.
+func TestConeSideHalfSpaceVertexInsideDefers(t *testing.T) {
+	frustum := mustFrustum(t, math.P3(0, 0, 0), math.P3(0, 0, 10), 3, 6)
+	plane, _ := geom.NewPlane(math.P3(4, 0, 0), math.V3(1, 0, 0)) // |D|=4: cuts the top (r=6) but not the bottom (r=3)
+	if _, err := HalfSpaceCut(frustum, plane); !errors.Is(err, ErrUnsupportedHalfSpace) {
+		t.Errorf("vertex-inside cut should defer with ErrUnsupportedHalfSpace, got %v", err)
+	}
+}
+
+// mustFrustum builds a frustum solid (bottom radius < top radius) or fails the test.
+func mustFrustum(t *testing.T, bottom, top math.Point3, rBot, rTop float64) *topo.Body {
+	t.Helper()
+	b, err := SolidCylinderCone(bottom, top, rBot, rTop, "frustum")
+	if err != nil {
+		t.Fatalf("SolidCylinderCone: %v", err)
+	}
+	return b
+}
+
+// hasHyperbolaEdge reports whether any edge of a face stores a hyperbolic arc.
+func hasHyperbolaEdge(f *topo.Face) bool {
+	for _, l := range f.Loops() {
+		for _, u := range l.EdgeUses() {
+			if _, ok := u.Edge().Geometry().(geom.HyperbolicArc); ok {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/kernel/brep/curved_halfspace_general.go
+++ b/kernel/brep/curved_halfspace_general.go
@@ -64,6 +64,12 @@ func splitFaceByPlane(f curvedFace, plane geom.Plane, n math.Vector3) ([]curvedF
 		}
 		return cylinderSideSplit(f, curves, plane, n)
 	}
+	if isFullConeSide(f) {
+		if !allHyperbolas(curves) {
+			return nil, nil, ErrUnsupportedHalfSpace // a perpendicular (circle) cut reaches the fast cone path
+		}
+		return coneSideSplit(f, curves, plane, n)
+	}
 	return loopedSplit(f, curves, plane, n)
 }
 

--- a/kernel/brep/curved_halfspace_looped.go
+++ b/kernel/brep/curved_halfspace_looped.go
@@ -273,6 +273,9 @@ func bridgeAlong(f curvedFace, c geom.Curve3, exit, entry math.Point3) (loopEdge
 	if _, isLine := c.(geom.Line); isLine {
 		return loopEdge{curve: c, t0: tExit, t1: tEntry}, true
 	}
+	if _, isHyp := c.(geom.Hyperbola); isHyp {
+		return loopEdge{curve: c, t0: tExit, t1: tEntry}, true // a hyperbola branch is simple: bridge by θ range
+	}
 	for _, t1 := range arcCandidates(tExit, tEntry) {
 		cand := loopEdge{curve: c, t0: tExit, t1: t1}
 		if pointInCurvedFace(f, c.PointAt((tExit+t1)/2)) {

--- a/kernel/brep/curved_stitch.go
+++ b/kernel/brep/curved_stitch.go
@@ -129,6 +129,8 @@ func edgeCurveFor(le loopEdge) geom.Curve3 {
 		return geom.NewLineSegment(le.start(), le.end())
 	case geom.Line:
 		return geom.NewLineSegment(le.start(), le.end())
+	case geom.Hyperbola:
+		return c.Arc(le.t0, le.t1) // a hyperbola loop edge's params are θ; the bounded arc is what the edge stores
 	default:
 		return c
 	}

--- a/kernel/geom/evaluator_point3.go
+++ b/kernel/geom/evaluator_point3.go
@@ -27,9 +27,22 @@ func CurveParamAtPoint3(c Curve3, p math.Point3) (float64, SolutionNature) {
 		return arcParamAtPoint3(g, p)
 	case Polyline:
 		return polylineParamAtPoint3(g, p)
+	case Hyperbola:
+		return hyperbolaThetaAtPoint3(g.Center, g.ConjugateAxis.AsVector(), g.B, p), UniqueSolution
+	case HyperbolicArc:
+		theta := hyperbolaThetaAtPoint3(g.Center, g.ConjugateAxis.AsVector(), g.B, p)
+		return (theta - g.Theta0) / (g.Theta1 - g.Theta0), UniqueSolution
 	default:
 		return genericParamAtPoint3(c, p)
 	}
+}
+
+// hyperbolaThetaAtPoint3 inverts a hyperbola branch: with the conjugate coordinate y = B·sinh(θ),
+// θ = asinh(y/B). A point on the branch maps back to its exact parameter (the branch is simple, so
+// the conjugate component alone fixes θ — no sign ambiguity).
+func hyperbolaThetaAtPoint3(center math.Point3, conjugate math.Vector3, b float64, p math.Point3) float64 {
+	y := float64(center.VectorTo(p).Dot(conjugate))
+	return stdmath.Asinh(y / b)
 }
 
 // segmentParamAtPoint3 projects p onto the segment's chord and clamps.
@@ -227,7 +240,7 @@ func refineClosest3(c Curve3, p math.Point3, t, lo, hi float64) float64 {
 // (enclosing but not minimal), ±Inf faces for an unbounded line.
 func CurveRangeBox3(c Curve3) math.Box {
 	switch g := c.(type) {
-	case Line:
+	case Line, Hyperbola:
 		inf := stdmath.Inf(1)
 		return math.Box{Min: math.P3(-inf, -inf, -inf), Max: math.P3(inf, inf, inf)}
 	case LineSegment:

--- a/kernel/geom/hyperbola.go
+++ b/kernel/geom/hyperbola.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// Hyperbola is one branch of an infinite 3D hyperbola (the conic a plane parallel to a cone's
+// axis cuts from it — M2 Phase-1 follow-up, Oblikovati/Oblikovati#1372). It lies in the plane
+// through Center spanned by the orthonormal TransverseAxis (toward the branch's opening, the
+// real axis) and ConjugateAxis (the imaginary axis). Parameterized by the hyperbolic angle θ:
+//
+//	P(θ) = Center + A·cosh(θ)·TransverseAxis + B·sinh(θ)·ConjugateAxis
+//
+// so θ=0 is the branch vertex (Center + A·TransverseAxis) and |θ|→∞ runs out the two arms. Like
+// [Line] it is unbounded (Domain ±Inf, parameter t = θ directly); the bounded edge a face stores
+// is a [HyperbolicArc]. A and B are the transverse and conjugate semi-axes.
+type Hyperbola struct {
+	Center         math.Point3
+	TransverseAxis math.UnitVector3
+	ConjugateAxis  math.UnitVector3
+	A, B           float64
+}
+
+// NewHyperbola builds a hyperbola branch. transverse and conjugate are normalized, and conjugate
+// is re-orthogonalized against transverse (its component along transverse is dropped). Errors on a
+// zero axis, a non-positive semi-axis, or axes that are parallel.
+func NewHyperbola(center math.Point3, transverse, conjugate math.Vector3, a, b float64) (Hyperbola, error) {
+	if a <= 0 || b <= 0 {
+		return Hyperbola{}, fmt.Errorf("geom: hyperbola semi-axes (%g, %g) must be positive", a, b)
+	}
+	tu, err := math.UnitVector3FromVector(transverse)
+	if err != nil {
+		return Hyperbola{}, fmt.Errorf("geom: hyperbola transverse axis %v is zero", transverse)
+	}
+	cv := conjugate.Sub(tu.AsVector().Scale(conjugate.Dot(tu.AsVector())))
+	cu, err := math.UnitVector3FromVector(cv)
+	if err != nil {
+		return Hyperbola{}, fmt.Errorf("geom: hyperbola conjugate axis %v is parallel to transverse %v", conjugate, transverse)
+	}
+	return Hyperbola{Center: center, TransverseAxis: tu, ConjugateAxis: cu, A: a, B: b}, nil
+}
+
+// PointAt returns the branch point at hyperbolic angle θ (the parameter t is θ).
+func (h Hyperbola) PointAt(theta float64) math.Point3 {
+	return hyperbolaPoint(h.Center, h.TransverseAxis.AsVector(), h.ConjugateAxis.AsVector(), h.A, h.B, theta)
+}
+
+// TangentAt returns dP/dθ = A·sinh(θ)·TransverseAxis + B·cosh(θ)·ConjugateAxis.
+func (h Hyperbola) TangentAt(theta float64) math.Vector3 {
+	return hyperbolaTangent(h.TransverseAxis.AsVector(), h.ConjugateAxis.AsVector(), h.A, h.B, theta)
+}
+
+// Domain returns the full real line, as a Hyperbola branch is unbounded.
+func (h Hyperbola) Domain() (lo, hi float64) { return stdmath.Inf(-1), stdmath.Inf(1) }
+
+// Arc restricts the branch to [theta0, theta1], the bounded curve stored on a trimmed face edge.
+func (h Hyperbola) Arc(theta0, theta1 float64) HyperbolicArc {
+	return HyperbolicArc{Center: h.Center, TransverseAxis: h.TransverseAxis, ConjugateAxis: h.ConjugateAxis,
+		A: h.A, B: h.B, Theta0: theta0, Theta1: theta1}
+}
+
+// HyperbolicArc is a bounded segment of a [Hyperbola] branch, parameterized t∈[0,1] mapping to
+// θ = Theta0 + t·(Theta1−Theta0) — the edge curve a trimmed cone face stores (as LineSegment is to
+// Line). Theta0 may exceed Theta1 to run the arc in the opposite direction.
+type HyperbolicArc struct {
+	Center         math.Point3
+	TransverseAxis math.UnitVector3
+	ConjugateAxis  math.UnitVector3
+	A, B           float64
+	Theta0, Theta1 float64
+}
+
+// PointAt returns the point at parameter t∈[0,1].
+func (h HyperbolicArc) PointAt(t float64) math.Point3 {
+	theta := h.Theta0 + t*(h.Theta1-h.Theta0)
+	return hyperbolaPoint(h.Center, h.TransverseAxis.AsVector(), h.ConjugateAxis.AsVector(), h.A, h.B, theta)
+}
+
+// TangentAt returns dP/dt (chain rule: dP/dθ scaled by the θ-span).
+func (h HyperbolicArc) TangentAt(t float64) math.Vector3 {
+	theta := h.Theta0 + t*(h.Theta1-h.Theta0)
+	return hyperbolaTangent(h.TransverseAxis.AsVector(), h.ConjugateAxis.AsVector(), h.A, h.B, theta).Scale(math.Scalar(h.Theta1 - h.Theta0))
+}
+
+// Domain returns [0, 1].
+func (h HyperbolicArc) Domain() (lo, hi float64) { return 0, 1 }
+
+// hyperbolaPoint evaluates Center + A·cosh(θ)·û + B·sinh(θ)·v̂.
+func hyperbolaPoint(center math.Point3, transverse, conjugate math.Vector3, a, b, theta float64) math.Point3 {
+	return center.TranslateBy(transverse.Scale(math.Scalar(a * stdmath.Cosh(theta))).
+		Add(conjugate.Scale(math.Scalar(b * stdmath.Sinh(theta)))))
+}
+
+// hyperbolaTangent returns dP/dθ = A·sinh(θ)·û + B·cosh(θ)·v̂.
+func hyperbolaTangent(transverse, conjugate math.Vector3, a, b, theta float64) math.Vector3 {
+	return transverse.Scale(math.Scalar(a * stdmath.Sinh(theta))).
+		Add(conjugate.Scale(math.Scalar(b * stdmath.Cosh(theta))))
+}

--- a/kernel/geom/hyperbola_test.go
+++ b/kernel/geom/hyperbola_test.go
@@ -79,4 +79,27 @@ func TestHyperbolicArcReparam(t *testing.T) {
 	}
 }
 
+// CurveParamAtPoint3 inverts a hyperbola branch in closed form: the parameter of a point on the
+// branch round-trips to the θ (or arc t) that produced it.
+func TestHyperbolaParamRoundTrip(t *testing.T) {
+	h, _ := NewHyperbola(math.P3(1, -2, 3), math.V3(0, 0, 1), math.V3(0, 1, 0), 2, 1.5)
+	lo, hi := h.Domain()
+	if !stdmath.IsInf(lo, -1) || !stdmath.IsInf(hi, 1) {
+		t.Errorf("Hyperbola.Domain = [%g,%g], want unbounded", lo, hi)
+	}
+	for _, theta := range []float64{-1.3, 0, 0.9} {
+		got, nature := CurveParamAtPoint3(h, h.PointAt(theta))
+		if nature != UniqueSolution || stdmath.Abs(got-theta) > 1e-9 {
+			t.Errorf("Hyperbola param at θ=%g: got %g (%v)", theta, got, nature)
+		}
+	}
+	arc := h.Arc(-1, 2)
+	for _, ts := range []float64{0.1, 0.5, 0.95} {
+		got, _ := CurveParamAtPoint3(arc, arc.PointAt(ts))
+		if stdmath.Abs(got-ts) > 1e-9 {
+			t.Errorf("HyperbolicArc param at t=%g: got %g", ts, got)
+		}
+	}
+}
+
 func ptFar(a, b math.Point3) bool { return float64(a.DistanceTo(b)) > 1e-9 }

--- a/kernel/geom/hyperbola_test.go
+++ b/kernel/geom/hyperbola_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// A hyperbola point at θ=0 is the vertex Center + A·TransverseAxis; the arms climb symmetrically.
+func TestHyperbolaVertexAndArms(t *testing.T) {
+	h, err := NewHyperbola(math.P3(1, 0, 0), math.V3(0, 0, 1), math.V3(0, 1, 0), 2, 3)
+	if err != nil {
+		t.Fatalf("NewHyperbola: %v", err)
+	}
+	vertex := h.PointAt(0)
+	if got := vertex; ptFar(got, math.P3(1, 0, 2)) {
+		t.Errorf("vertex = %v, want (1,0,2)", got)
+	}
+	up, down := h.PointAt(0.7), h.PointAt(-0.7)
+	if stdmath.Abs(float64(up.Z-down.Z)) > 1e-9 {
+		t.Errorf("arms not symmetric in transverse: %v vs %v", up, down)
+	}
+	if stdmath.Abs(float64(up.Y+down.Y)) > 1e-9 {
+		t.Errorf("arms not antisymmetric in conjugate: %v vs %v", up, down)
+	}
+}
+
+// NewHyperbola re-orthogonalizes the conjugate axis against the transverse and rejects degenerate input.
+func TestNewHyperbolaValidation(t *testing.T) {
+	if _, err := NewHyperbola(math.P3(0, 0, 0), math.V3(0, 0, 1), math.V3(0, 0, 1), 1, 1); err == nil {
+		t.Error("parallel axes should error")
+	}
+	if _, err := NewHyperbola(math.P3(0, 0, 0), math.V3(0, 0, 1), math.V3(0, 1, 0), -1, 1); err == nil {
+		t.Error("non-positive semi-axis should error")
+	}
+	h, err := NewHyperbola(math.P3(0, 0, 0), math.V3(0, 0, 2), math.V3(0.5, 1, 0), 1, 1)
+	if err != nil {
+		t.Fatalf("NewHyperbola: %v", err)
+	}
+	if d := h.ConjugateAxis.AsVector().Dot(h.TransverseAxis.AsVector()); stdmath.Abs(float64(d)) > 1e-12 {
+		t.Errorf("conjugate not orthogonal to transverse: dot=%g", d)
+	}
+}
+
+// TangentAt matches a central finite difference of PointAt.
+func TestHyperbolaTangentFiniteDifference(t *testing.T) {
+	h, _ := NewHyperbola(math.P3(0, 1, 0), math.V3(1, 0, 0), math.V3(0, 1, 0), 1.5, 2.5)
+	const eps = 1e-6
+	for _, theta := range []float64{-1.2, 0, 0.8} {
+		fd := h.PointAt(theta - eps).VectorTo(h.PointAt(theta + eps)).Scale(math.Scalar(1 / (2 * eps)))
+		an := h.TangentAt(theta)
+		if d := an.Sub(fd).Length(); float64(d) > 1e-4 {
+			t.Errorf("θ=%g tangent %v vs finite-diff %v (|Δ|=%g)", theta, an, fd, d)
+		}
+	}
+}
+
+// HyperbolicArc reparameterizes the same branch onto t∈[0,1] over [Theta0,Theta1].
+func TestHyperbolicArcReparam(t *testing.T) {
+	h, _ := NewHyperbola(math.P3(0, 0, 0), math.V3(0, 0, 1), math.V3(0, 1, 0), 2, 1)
+	arc := h.Arc(-0.5, 1.5)
+	if ptFar(arc.PointAt(0), h.PointAt(-0.5)) || ptFar(arc.PointAt(1), h.PointAt(1.5)) {
+		t.Error("arc endpoints must match the branch at Theta0/Theta1")
+	}
+	if ptFar(arc.PointAt(0.5), h.PointAt(0.5)) {
+		t.Error("arc midpoint must match the branch at the mid θ")
+	}
+	lo, hi := arc.Domain()
+	if lo != 0 || hi != 1 {
+		t.Errorf("arc domain = [%g,%g], want [0,1]", lo, hi)
+	}
+	const eps = 1e-6
+	fd := arc.PointAt(0.5 - eps).VectorTo(arc.PointAt(0.5 + eps)).Scale(math.Scalar(1 / (2 * eps)))
+	if d := arc.TangentAt(0.5).Sub(fd).Length(); float64(d) > 1e-4 {
+		t.Errorf("arc tangent %v vs finite-diff %v (|Δ|=%g)", arc.TangentAt(0.5), fd, d)
+	}
+}
+
+func ptFar(a, b math.Point3) bool { return float64(a.DistanceTo(b)) > 1e-9 }

--- a/kernel/geom/intersect_analytic.go
+++ b/kernel/geom/intersect_analytic.go
@@ -118,17 +118,23 @@ func cylinderAxisParallelLines(pl Plane, cyl Cylinder, n, axis math.Vector3) ([]
 	return out, true
 }
 
-// planeConeCurve returns the circle where a plane perpendicular to a cone's axis cuts it
-// (radius grows with distance from the apex); an oblique plane (ellipse/parabola/hyperbola)
-// is left to the numeric tracer, and a plane through the apex yields a point (no curve).
+// planeConeCurve returns the conic a plane cuts from a cone: a circle when the plane is
+// perpendicular to the axis (radius grows with distance from the apex), and — when the plane is
+// PARALLEL to the axis — the hyperbola branch it cuts (Oblikovati/Oblikovati#1372, the section that
+// lets a box face parallel to the cone axis be subtracted exactly). The intermediate oblique cases
+// (an ellipse, a parabola, or a hyperbola from a plane steeper than the generators but not
+// axis-parallel) are still left to the numeric tracer; a plane through the apex yields a point.
 func planeConeCurve(pl Plane, cone Cone) ([]Curve3, bool) {
 	n := unitVec3(pl.Normal())
 	axis := cone.AxisDir.AsVector()
-	denom := axis.Dot(n)
-	if stdmath.Abs(float64(denom)) < 1-1e-6 { // not perpendicular → conic section, defer
+	along := stdmath.Abs(float64(axis.Dot(n)))
+	if along < 1e-6 { // plane ∥ axis → hyperbola
+		return coneAxisParallelHyperbola(pl, cone, n, axis)
+	}
+	if along < 1-1e-6 { // oblique (ellipse/parabola/steep hyperbola) → defer to the tracer
 		return nil, false
 	}
-	t := n.Dot(cone.Apex.VectorTo(pl.Origin)) / denom
+	t := n.Dot(cone.Apex.VectorTo(pl.Origin)) / axis.Dot(n)
 	r := stdmath.Abs(float64(t)) * stdmath.Tan(cone.HalfAngle)
 	if r < 1e-9 { // plane through the apex
 		return nil, true
@@ -139,6 +145,27 @@ func planeConeCurve(pl Plane, cone Cone) ([]Curve3, bool) {
 		return nil, true
 	}
 	return []Curve3{c}, true
+}
+
+// coneAxisParallelHyperbola returns the hyperbola branch where a plane parallel to the cone axis
+// cuts the cone. With the apex-to-plane signed distance D = n·(Origin − Apex) (n ⟂ axis here), the
+// section is z²/A² − y²/B² = 1 in the plane: vertex on the axis side, transverse semi A = |D|/tanα
+// along the axis (the branch climbs the cone as v=A·coshθ grows), conjugate semi B = |D| along
+// a×n. Its centre sits at the foot of the apex on the plane, Apex + D·n. A plane through the apex
+// (D≈0, the two coincident generators) is degenerate and deferred.
+func coneAxisParallelHyperbola(pl Plane, cone Cone, n, axis math.Vector3) ([]Curve3, bool) {
+	d := float64(n.Dot(cone.Apex.VectorTo(pl.Origin)))
+	if stdmath.Abs(d) < 1e-9 {
+		return nil, false // plane through the apex/axis: two coincident generators, not a hyperbola
+	}
+	conjugate := axis.Cross(n)
+	tanA := stdmath.Tan(cone.HalfAngle)
+	center := cone.Apex.TranslateBy(n.Scale(math.Scalar(d)))
+	h, err := NewHyperbola(center, axis, conjugate, stdmath.Abs(d)/tanA, stdmath.Abs(d))
+	if err != nil {
+		return nil, true
+	}
+	return []Curve3{h}, true
 }
 
 // planeSphereCurve returns the circle where a plane cuts a sphere (empty when the plane

--- a/kernel/geom/intersect_cone_hyperbola_test.go
+++ b/kernel/geom/intersect_cone_hyperbola_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// A plane parallel to a cone's axis cuts an exact hyperbola; every sampled point must lie on BOTH
+// the cone surface and the plane (Oblikovati/Oblikovati#1372). The vertex distance from the apex
+// along the axis is |D|/tanα, where D is the apex-to-plane offset.
+func TestPlaneConeAxisParallelHyperbola(t *testing.T) {
+	cone, err := NewCone(math.P3(0, 0, 0), math.V3(0, 0, 1), stdmath.Pi/6) // tanα = 1/√3
+	if err != nil {
+		t.Fatalf("NewCone: %v", err)
+	}
+	pl, err := NewPlane(math.P3(2, 0, 0), math.V3(1, 0, 0)) // x=2, parallel to the z axis
+	if err != nil {
+		t.Fatalf("NewPlane: %v", err)
+	}
+	curves, handled := IntersectSurfacesAnalytic(pl, cone)
+	if !handled || len(curves) != 1 {
+		t.Fatalf("imprint handled=%v curves=%d, want handled=true with one curve", handled, len(curves))
+	}
+	h, ok := curves[0].(Hyperbola)
+	if !ok {
+		t.Fatalf("imprint curve is %T, want Hyperbola", curves[0])
+	}
+	wantA := 2 / stdmath.Tan(stdmath.Pi/6)
+	if stdmath.Abs(h.A-wantA) > 1e-9 || stdmath.Abs(h.B-2) > 1e-9 {
+		t.Errorf("semi-axes (A=%g,B=%g), want (A=%g,B=2)", h.A, h.B, wantA)
+	}
+	for _, theta := range []float64{-1.5, -0.4, 0, 0.4, 1.5} {
+		p := h.PointAt(theta)
+		if dx := float64(p.X) - 2; stdmath.Abs(dx) > 1e-9 {
+			t.Errorf("θ=%g: point %v not on plane x=2 (Δ=%g)", theta, p, dx)
+		}
+		if off := coneRadialResidual(cone, p); off > 1e-9 {
+			t.Errorf("θ=%g: point %v not on cone (residual=%g)", theta, p, off)
+		}
+	}
+}
+
+// An oblique-but-not-parallel plane is still deferred to the numeric tracer (handled=false).
+func TestPlaneConeObliqueStillDeferred(t *testing.T) {
+	cone, _ := NewCone(math.P3(0, 0, 0), math.V3(0, 0, 1), stdmath.Pi/6)
+	pl, _ := NewPlane(math.P3(0, 0, 5), math.V3(1, 0, 1)) // 45° to the axis: an ellipse/hyperbola, deferred
+	if _, handled := IntersectSurfacesAnalytic(pl, cone); handled {
+		t.Error("oblique cone cut should defer (handled=false)")
+	}
+}
+
+// A plane through the apex (D≈0) is the degenerate two-generator case and is deferred.
+func TestPlaneConeThroughApexDeferred(t *testing.T) {
+	cone, _ := NewCone(math.P3(0, 0, 0), math.V3(0, 0, 1), stdmath.Pi/6)
+	pl, _ := NewPlane(math.P3(0, 0, 0), math.V3(0, 1, 0)) // contains the apex and the axis
+	if _, handled := IntersectSurfacesAnalytic(pl, cone); handled {
+		t.Error("plane through the apex should defer (handled=false)")
+	}
+}
+
+// coneRadialResidual is |radial distance from axis − v·tanα| at a point: zero on the cone surface.
+func coneRadialResidual(c Cone, p math.Point3) float64 {
+	axis := c.AxisDir.AsVector()
+	ap := c.Apex.VectorTo(p)
+	v := float64(ap.Dot(axis))
+	radial := ap.Sub(axis.Scale(ap.Dot(axis)))
+	return stdmath.Abs(float64(radial.Length()) - v*stdmath.Tan(c.HalfAngle))
+}

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -147,7 +147,7 @@ var curvedExactPaths = []func(PartFeatureOperation, *topo.Body, *topo.Body) (*to
 	curvedConvexIntersect, curvedConvexSubtract,
 	curvedCrossingIntersect, curvedSteinmetzIntersect, curvedConeCylinderIntersect, curvedConeConeIntersect,
 	curvedPartialIntersect,
-	curvedCylindricalHoleCut, curvedPartialCut, curvedSteinmetzCut, curvedConeCylinderCut, curvedConeConeCut, curvedCrossingCut,
+	curvedCylindricalHoleCut, curvedFlatSubtract, curvedPartialCut, curvedSteinmetzCut, curvedConeCylinderCut, curvedConeConeCut, curvedCrossingCut,
 	curvedCoaxialJoin, curvedCylinderBossJoin, curvedPartialJoin, curvedConeCylinderJoin, curvedConeConeJoin, curvedCrossingJoin, curvedSteinmetzJoin,
 }
 

--- a/kernel/ops/boolean_cone_box_test.go
+++ b/kernel/ops/boolean_cone_box_test.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// cone ∩ box / cone − box with a box face PARALLEL to the cone axis now stay exact: the cut is the
+// analytic hyperbola the plane carves from the cone, not faceted CSG (Oblikovati/Oblikovati#1372).
+// The frustum has tanα=0.3 (bottom r=3 at z=0, top r=6 at z=10); the box face x=2 (|D|=2 < bottom r)
+// cuts every cross-section, the arc-band case.
+
+func coneBoxFrustum(t *testing.T) *topo.Body {
+	t.Helper()
+	b, err := brep.SolidCylinderCone(math.P3(0, 0, 0), math.P3(0, 0, 10), 3, 6, "frustum")
+	if err != nil {
+		t.Fatalf("SolidCylinderCone: %v", err)
+	}
+	return b
+}
+
+// TestConeIntersectBoxExact keeps the +x wedge of the frustum (x ≥ 2): an exact cone arc-band face,
+// two cap segments and the planar lid, watertight, with no faceted soup.
+func TestConeIntersectBoxExact(t *testing.T) {
+	frustum := coneBoxFrustum(t)
+	box, err := brep.SolidBlock(math.P3(2, -20, -5), math.P3(20, 20, 15), "box")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	res, err := ops.Boolean(ops.Intersect, frustum, box)
+	if err != nil {
+		t.Fatalf("Boolean(Intersect): %v", err)
+	}
+	assertConeBoxExact(t, res)
+}
+
+// TestConeCutBoxExact removes the +x wedge (the box spans the frustum on every side but x), leaving
+// the cone minus a flat — still an exact cone arc-band face.
+func TestConeCutBoxExact(t *testing.T) {
+	frustum := coneBoxFrustum(t)
+	box, err := brep.SolidBlock(math.P3(2, -20, -5), math.P3(20, 20, 15), "box")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	res, err := ops.Boolean(ops.Cut, frustum, box)
+	if err != nil {
+		t.Fatalf("Boolean(Cut): %v", err)
+	}
+	assertConeBoxExact(t, res)
+}
+
+// assertConeBoxExact pins the result on the exact analytic path: a watertight solid carrying at least
+// one analytic cone face and no non-analytic (tessellated) face.
+func assertConeBoxExact(t *testing.T, res *topo.Body) {
+	t.Helper()
+	if v := ops.Validate(res); !v.Valid || !v.Closed || !v.Manifold || !res.IsSolid() {
+		t.Fatalf("result is not a watertight solid: %+v", v)
+	}
+	cones, nonAnalytic := 0, 0
+	for _, f := range res.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Cone:
+			cones++
+		case geom.Plane, geom.Cylinder, geom.Sphere, geom.Torus:
+		default:
+			nonAnalytic++
+		}
+	}
+	if cones == 0 {
+		t.Errorf("result has no analytic cone face across %d faces — it fell back to CSG", len(res.Faces()))
+	}
+	if nonAnalytic > 0 {
+		t.Errorf("result has %d non-analytic faces — not the exact path", nonAnalytic)
+	}
+}
+
+// TestConeIntersectBoxVolume cross-checks the kept +x wedge volume against a dense numeric integral of
+// the frustum cross-section area beyond x=2 (independent of the B-rep), so a wrong cut shape is caught.
+func TestConeIntersectBoxVolume(t *testing.T) {
+	frustum := coneBoxFrustum(t)
+	box, _ := brep.SolidBlock(math.P3(2, -20, -5), math.P3(20, 20, 15), "box")
+	res, err := ops.Boolean(ops.Intersect, frustum, box)
+	if err != nil {
+		t.Fatalf("Boolean: %v", err)
+	}
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	want := frustumCapBeyondPlaneVolume(0.3, 0, 10, 2)
+	if rel := stdmath.Abs(got-want) / want; rel > 0.03 {
+		t.Errorf("kept wedge volume %.4f vs numeric %.4f (rel %.4f > 0.03)", got, want, rel)
+	}
+}
+
+// frustumCapBeyondPlaneVolume integrates the area of each circular cross-section lying at x ≥ xCut for
+// a cone of slope tanα over z∈[z0,z1] (apex at z=z0−r0/tanα). A circle of radius r centred on the axis
+// has area r²·(θ − sinθ·cosθ) beyond a chord at distance xCut, θ = arccos(xCut/r) (0 when xCut ≥ r).
+func frustumCapBeyondPlaneVolume(tanA, z0, z1, xCut float64) float64 {
+	const steps = 20000
+	sum := 0.0
+	for i := 0; i < steps; i++ {
+		z := z0 + (z1-z0)*(float64(i)+0.5)/steps
+		r := (z - (z0 - 3/tanA)) * tanA // radius grows linearly; bottom r=3 at z0
+		sum += circleAreaBeyondChord(r, xCut)
+	}
+	return sum * (z1 - z0) / steps
+}
+
+func circleAreaBeyondChord(r, x float64) float64 {
+	if x >= r {
+		return 0
+	}
+	theta := stdmath.Acos(x / r)
+	return r * r * (theta - stdmath.Sin(theta)*stdmath.Cos(theta))
+}

--- a/kernel/ops/boolean_csg_demotion_test.go
+++ b/kernel/ops/boolean_csg_demotion_test.go
@@ -114,7 +114,15 @@ func curvedExactCases() []curvedExactCase {
 		{"cylinder boss ∪", ops.Join, func(t *testing.T) (*topo.Body, *topo.Body) {
 			return demoBlock(t, math.P3(-5, -5, 0), math.P3(5, 5, 2)), demoCyl(t, math.P3(0, 0, 2), math.V3(0, 0, 1), 1.5, 3)
 		}},
+		{"cone ∩ box (axis-∥ flat)", ops.Intersect, coneFlatBox},
+		{"cone − box (axis-∥ flat)", ops.Cut, coneFlatBox},
 	}
+}
+
+// coneFlatBox is the frustum (tanα=0.3, bottom r=3, top r=6) and an oversized box whose face x=2 is
+// parallel to the cone axis and cuts every cross-section — the hyperbolic-imprint case (#1372).
+func coneFlatBox(t *testing.T) (*topo.Body, *topo.Body) {
+	return demoCone(t, math.P3(0, 0, 0), math.P3(0, 0, 10), 3, 6), demoBlock(t, math.P3(2, -20, -5), math.P3(20, 20, 15))
 }
 
 // crossingCylinders is the shared thin-through-fat pair used by the three crossing-cylinder cases.

--- a/kernel/ops/boolean_curved_flat_subtract.go
+++ b/kernel/ops/boolean_curved_flat_subtract.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+)
+
+// Exact curved − convex-planar subtract bounded by a single plane (M2 Phase-1 follow-up,
+// Oblikovati/Oblikovati#1372). Cut is not a half-space composition, but De Morgan gives
+// target − box = target ∩ ¬box = ∪ᵢ (target ∩ Hᵢ⁺) over the box faces' OUTER half-spaces. When the
+// box's removal from the curved target is bounded by exactly one of its faces (a flat milled on a
+// cone or cylinder side: the other faces clear the target), all but one of those pieces are empty, so
+// the subtract is a single brep.HalfSpaceCut keeping the target outside that face — an exact curved
+// B-rep, the cone/cylinder surface preserved. A removal bounded by several box planes (a corner
+// notch) leaves more than one non-empty piece and would need a curved union, so it defers to CSG.
+
+// curvedFlatSubtract returns target − box when the removal is bounded by a single box face, or
+// ok=false to defer. Only Cut, a curved target, and a convex all-planar tool map here.
+func curvedFlatSubtract(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+	if op != Cut || !hasCurvedFace(target) || hasCurvedFace(tool) {
+		return nil, false
+	}
+	planes, ok := convexFacePlanes(tool) // each oriented along its OUTWARD normal
+	if !ok {
+		return nil, false
+	}
+	var pieces []*topo.Body
+	for _, pl := range planes {
+		inward, err := geom.NewPlane(pl.Origin, pl.NormalAt(0, 0).Scale(-1)) // flip outward → inward
+		if err != nil {
+			return nil, false
+		}
+		piece, err := brep.HalfSpaceCut(target, inward) // keeps Hᵢ⁺ = the target outside this face
+		if err != nil {
+			return nil, false // an unhandled cut: defer the whole subtract to CSG
+		}
+		if len(piece.Faces()) > 0 {
+			pieces = append(pieces, piece)
+		}
+	}
+	if len(pieces) != 1 || !validBooleanSolid(pieces[0]) {
+		return nil, false // 0 pieces (box ⊇ target) or several (a multi-plane notch needing a union): defer
+	}
+	return pieces[0], true
+}

--- a/kernel/ops/testdata/occ_boolean_oracle.json
+++ b/kernel/ops/testdata/occ_boolean_oracle.json
@@ -10,5 +10,7 @@
   "cone ∩ cone": 24.59680642,
   "partial penetration ∩": 20.52055473,
   "coaxial cylinders ∪": 87.9645943,
-  "cylinder boss ∪": 221.2057504
+  "cylinder boss ∪": 221.2057504,
+  "cone ∩ box (axis-∥ flat)": 156.27698,
+  "cone − box (axis-∥ flat)": 503.4574773
 }


### PR DESCRIPTION
Closes #1372.

## What

A plane parallel to a cone's axis cuts the cone in a **hyperbola** — the one conic section Phase 1 (#1334) left unhandled. So `cone ∩ box` / `cone − box` with a box face parallel to the cone axis fell back to faceted BSP-CSG. This makes that arrangement **exact**: the result keeps its `geom.Cone` surface and the cut edge is the analytic hyperbolic arc.

## Why

It was the only documented gap left from Phase 1 of the general curved boolean (ADR-0027 §M2). The CSG fallback was watertight and volume-correct but faceted — not exact, and dependent on `tjunctionFaceBudget`.

## How (three slices)

1. **geom** — `Hyperbola` / `HyperbolicArc` curve types and `planeConeCurve` returning the exact branch for an axis-parallel plane (centre at the apex's foot on the plane, transverse semi `|D|/tanα` along the axis, conjugate semi `|D|`). The intermediate oblique cases (ellipse / parabola / steep hyperbola) and the through-apex degeneracy stay deferred to the tracer.
2. **brep** — `coneSideSplit`, the cone analogue of `cylinderSideSplit`: a full periodic frustum side cut by a plane ∥ axis is imprinted as one hyperbola branch and rebuilt seam-free as an arc-band sub-face (two cross-section arcs + two hyperbola arms). Scope: the arc-band case (`|D| < bottom radius`, the flat runs the full side); vertex-inside-band and full-cone-to-apex defer to `ErrUnsupportedHalfSpace` (CSG fallback, no regression). The hyperbola is plumbed through `CurveParamAtPoint3` (closed-form θ inverse), `edgeCurveFor`, and the looped split's bridge.
3. **ops** — `cone ∩ box` already composes through `curvedConvexIntersect`. For Cut, `curvedFlatSubtract` uses De Morgan (`target − box = ∪ᵢ target ∩ outer-half-spaceᵢ`): when the removal is bounded by a single box face, exactly one piece is non-empty — one `HalfSpaceCut`. A multi-plane notch defers to CSG.

## Validation

- New cases added to `TestCurvedBooleansStayExact` (both stay on the analytic path — a `geom.Cone` face, no faceted soup) and to the **OCC `getMass` oracle** (`experiments/occ-boolean-oracle`, regenerated): ours is **1.6% / 1.2% under** OCC, consistent with inscribed faceting. The two volumes sum to the full frustum (156.28 + 503.46 = 659.73).
- Watertight + manifold; independent numeric cross-section integral for the wedge volume.
- Full `kernel/...` suite green; lint clean; no API changes.

## Deferred (noted, not regressions)

- Vertex-inside-band (a flat that fades before the bottom rim) and a full cone reaching its apex — both still take the clean CSG fallback. Tracked in #1374.
- The intermediate oblique cone cuts (ellipse / parabola / steep hyperbola from a non-axis-parallel plane). Tracked in #1375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
