### PR TITLE
[M2] cone ∩/− box: vertex-inside flat → exact hyperbolic imprint (#1374)

### DIFF
--- a/kernel/brep/curved_halfspace_cone_side.go
+++ b/kernel/brep/curved_halfspace_cone_side.go
@@ -13,11 +13,13 @@ import (
 // cylinderSideSplit: a FULL periodic frustum side cut by a plane PARALLEL to the axis. Like the
 // cylinder, the seam tangles the general looped split, so this gives a dedicated closed-form split —
 // but the imprint is one hyperbola branch (the conic a plane ∥ axis cuts from a cone), not two lines,
-// and the kept band's two cross-section arcs have different radii. This slice handles the ARC-BAND
+// and the kept band's two cross-section arcs have different radii. coneArcBand handles the ARC-BAND
 // arrangement where the plane cuts EVERY cross-section in the band (the vertex sits at or below the
-// bottom rim, |D| < bottom radius) — a flat milled the full length of a frustum's side. The vertex-
-// inside-band arrangement (the flat fades out before the bottom rim) and a full cone reaching its
-// apex defer to ErrUnsupportedHalfSpace, so the CSG fallback still covers them with no regression.
+// bottom rim, |D| < bottom radius) — a flat milled the full length of a frustum's side. coneSideVertex-
+// Inside handles the VERTEX-INSIDE-BAND arrangement where the flat fades out before the small rim
+// (bottom radius ≤ |D| < top radius), the hyperbola turning through its vertex inside the side
+// (Oblikovati/Oblikovati#1374). A full cone reaching its apex still defers to ErrUnsupportedHalfSpace,
+// so the CSG fallback covers it with no regression.
 
 // coneSideSplit splits a full periodic frustum side f by a plane parallel to the axis, given the
 // hyperbola branch the plane cuts. It returns the kept arc-band sub-face and the two hyperbola arms
@@ -40,18 +42,20 @@ func coneSideSplit(f curvedFace, curves []geom.Curve3, plane geom.Plane, n math.
 	if absD >= band.rTop-cylinderAxisTol { // plane clears every cross-section: whole side, or none
 		return coneSideWholeOrEmpty(f, d), nil, nil
 	}
-	if absD >= band.rBot-cylinderAxisTol { // vertex sits inside the band: deferred to CSG for now
-		return nil, nil, ErrUnsupportedHalfSpace
+	if absD >= band.rBot-cylinderAxisTol { // vertex sits inside the band: the flat fades before the small rim
+		return coneSideVertexInside(f, cone, hyper, band, n, d)
 	}
 	return coneArcBand(f, cone, hyper, band, n, d)
 }
 
 // coneSideBand carries a frustum side's two cross-section circles (centres on the axis, ordered
-// low→high in apex distance) and their radii.
+// low→high in apex distance), the source rim circles themselves (so a kept face can reuse a rim edge
+// and weld with its cap), and their radii.
 type coneSideBand_ struct {
-	bottom, top math.Point3
-	vMin, vMax  float64
-	rBot, rTop  float64
+	bottom, top         math.Point3
+	bottomCirc, topCirc geom.Circle
+	vMin, vMax          float64
+	rBot, rTop          float64
 }
 
 // coneSideBand recovers the frustum side's two full-circle rims, ordered by apex distance. ok=false
@@ -60,21 +64,25 @@ type coneSideBand_ struct {
 func coneSideBand(f curvedFace, cone geom.Cone) (coneSideBand_, bool) {
 	axis := cone.AxisDir.AsVector()
 	tanA := stdmath.Tan(cone.HalfAngle)
-	var centers []math.Point3
+	var circles []geom.Circle
 	for _, le := range f.loops[0].edges {
 		if c, isCircle := le.curve.(geom.Circle); isCircle && isFullDomain(le.t0, le.t1) {
-			centers = append(centers, c.Center)
+			circles = append(circles, c)
 		}
 	}
-	if len(centers) != 2 {
+	if len(circles) != 2 {
 		return coneSideBand_{}, false
 	}
-	if float64(cone.Apex.VectorTo(centers[0]).Dot(axis)) > float64(cone.Apex.VectorTo(centers[1]).Dot(axis)) {
-		centers[0], centers[1] = centers[1], centers[0]
+	if float64(cone.Apex.VectorTo(circles[0].Center).Dot(axis)) > float64(cone.Apex.VectorTo(circles[1].Center).Dot(axis)) {
+		circles[0], circles[1] = circles[1], circles[0]
 	}
-	vMin := float64(cone.Apex.VectorTo(centers[0]).Dot(axis))
-	vMax := float64(cone.Apex.VectorTo(centers[1]).Dot(axis))
-	return coneSideBand_{bottom: centers[0], top: centers[1], vMin: vMin, vMax: vMax, rBot: vMin * tanA, rTop: vMax * tanA}, true
+	vMin := float64(cone.Apex.VectorTo(circles[0].Center).Dot(axis))
+	vMax := float64(cone.Apex.VectorTo(circles[1].Center).Dot(axis))
+	return coneSideBand_{
+		bottom: circles[0].Center, top: circles[1].Center,
+		bottomCirc: circles[0], topCirc: circles[1],
+		vMin: vMin, vMax: vMax, rBot: vMin * tanA, rTop: vMax * tanA,
+	}, true
 }
 
 // coneSideWholeOrEmpty handles a plane that clears the whole band: the cone's axis sits at signed
@@ -110,6 +118,46 @@ func coneArcBand(f curvedFace, cone geom.Cone, hyper geom.Hyperbola, band coneSi
 	kept := curvedFace{surface: cone, reversed: f.reversed, lineage: f.lineage, loops: []curvedLoop{{edges: loop}}}
 	section := []loopEdge{reverseEdge(armA), reverseEdge(armB)}
 	return []curvedFace{kept}, section, nil
+}
+
+// coneSideVertexInside builds the kept sub-face(s) when the hyperbola vertex (apex distance |d|/tanα)
+// lies strictly inside the band — the flat fades out before reaching the small rim
+// (band.rBot ≤ |d| < band.rTop, Oblikovati/Oblikovati#1374). The imprint is one continuous hyperbola
+// branch through its vertex (an interior cone point), so the kept top boundary is NOTCHED down to that
+// vertex. Two arrangements by which side the apex is on:
+//   - d > 0 (apex on the dropped side): the small rim is wholly dropped and the kept region is a single
+//     tongue around u_n+π narrowing to the vertex — one loop.
+//   - d < 0 (apex on the kept side): the kept region is the whole side MINUS that tongue — an annulus
+//     whose outer loop is the notched top and whose inner loop is the full small-rim circle.
+//
+// Both arrangements share the same notched-top loop and the same through-vertex hyperbola section
+// (reversed for the lid).
+func coneSideVertexInside(f curvedFace, cone geom.Cone, hyper geom.Hyperbola, band coneSideBand_, n math.Vector3, d float64) ([]curvedFace, []loopEdge, error) {
+	axis := cone.AxisDir.AsVector()
+	ref := cone.Ref.AsVector()
+	uN := coneAngleOf(cone, n)
+	phiT := stdmath.Acos(clampUnit(-d / band.rTop))
+	topArc, err := geom.NewArc3d(band.top, axis, ref, band.rTop, uN-phiT, -(2*stdmath.Pi - 2*phiT))
+	if err != nil {
+		return nil, nil, ErrUnsupportedHalfSpace
+	}
+	vertex := hyper.PointAt(0)                                // the branch vertex sits on the cone at apex distance |d|/tanα
+	armDown := hyperbolaArm(hyper, topArc.PointAt(1), vertex) // top rim → vertex
+	armUp := hyperbolaArm(hyper, vertex, topArc.PointAt(0))   // vertex → top rim
+	notched := []loopEdge{{curve: topArc, t0: 0, t1: 1}, armDown, armUp}
+	section := []loopEdge{reverseEdge(armDown), reverseEdge(armUp)}
+	return coneVertexInsideFaces(f, cone, band, d, notched), section, nil
+}
+
+// coneVertexInsideFaces wraps the notched-top loop into the kept face: a lone tongue when the apex is
+// dropped (d>0), or an annulus closed by the intact small-rim circle as an inner loop when the apex is
+// kept (d<0). The small-rim circle is the source side's own edge so it welds with the small cap.
+func coneVertexInsideFaces(f curvedFace, cone geom.Cone, band coneSideBand_, d float64, notched []loopEdge) []curvedFace {
+	loops := []curvedLoop{{edges: notched}}
+	if d < 0 { // apex kept: close the annulus with the intact small rim
+		loops = append(loops, curvedLoop{edges: []loopEdge{{curve: band.bottomCirc, t0: 0, t1: 1}}})
+	}
+	return []curvedFace{{surface: cone, reversed: f.reversed, lineage: f.lineage, loops: loops}}
 }
 
 // hyperbolaArm builds the loop edge along the hyperbola branch from start to end, its parameters the

--- a/kernel/brep/curved_halfspace_cone_side_test.go
+++ b/kernel/brep/curved_halfspace_cone_side_test.go
@@ -3,7 +3,6 @@
 package brep
 
 import (
-	"errors"
 	"testing"
 
 	"oblikovati.org/kernel/geom"
@@ -60,14 +59,56 @@ func TestConeSideHalfSpaceClears(t *testing.T) {
 	}
 }
 
-// The vertex-inside-band arrangement (the flat fades before the bottom rim, bottom r ≤ |D| < top r)
-// is not yet built and must defer cleanly so the CSG fallback still covers it.
-func TestConeSideHalfSpaceVertexInsideDefers(t *testing.T) {
+// The vertex-inside-band arrangement (the flat fades before the bottom rim, bottom r ≤ |D| < top r),
+// keeping the axis side, leaves an ANNULUS cone face: the intact small rim plus a notched top loop
+// whose tongue is bitten out down to the hyperbola vertex (Oblikovati/Oblikovati#1374).
+func TestConeSideHalfSpaceVertexInsideAnnulus(t *testing.T) {
 	frustum := mustFrustum(t, math.P3(0, 0, 0), math.P3(0, 0, 10), 3, 6)
 	plane, _ := geom.NewPlane(math.P3(4, 0, 0), math.V3(1, 0, 0)) // |D|=4: cuts the top (r=6) but not the bottom (r=3)
-	if _, err := HalfSpaceCut(frustum, plane); !errors.Is(err, ErrUnsupportedHalfSpace) {
-		t.Errorf("vertex-inside cut should defer with ErrUnsupportedHalfSpace, got %v", err)
+	res, err := HalfSpaceCut(frustum, plane)                      // keeps x<4, the axis side: apex kept → annulus
+	if err != nil {
+		t.Fatalf("HalfSpaceCut: %v", err)
 	}
+	assertWatertight(t, res)
+	cones, _, _ := faceTypeCounts(t, res)
+	if cones != 1 {
+		t.Errorf("result has %d cone faces, want exactly 1 (the notched annulus stays analytic)", cones)
+	}
+	if !anyFaceHasHyperbola(res) {
+		t.Error("no face carries a hyperbolic edge — the notch was not imprinted as a hyperbola")
+	}
+}
+
+// The same arrangement keeping the FAR side drops the small rim entirely and leaves a single TONGUE
+// cone face narrowing to the hyperbola vertex (Oblikovati/Oblikovati#1374).
+func TestConeSideHalfSpaceVertexInsideTongue(t *testing.T) {
+	frustum := mustFrustum(t, math.P3(0, 0, 0), math.P3(0, 0, 10), 3, 6)
+	plane, _ := geom.NewPlane(math.P3(4, 0, 0), math.V3(-1, 0, 0)) // keeps x>4, the far side: apex dropped → tongue
+	res, err := HalfSpaceCut(frustum, plane)
+	if err != nil {
+		t.Fatalf("HalfSpaceCut: %v", err)
+	}
+	assertWatertight(t, res)
+	cones, _, planes := faceTypeCounts(t, res)
+	if cones != 1 {
+		t.Errorf("result has %d cone faces, want exactly 1 (the tongue stays analytic)", cones)
+	}
+	if planes != 2 { // top-cap minor segment + lid only; the small cap is dropped
+		t.Errorf("result has %d planar faces, want 2 (top-cap segment + lid, no small cap)", planes)
+	}
+	if !anyFaceHasHyperbola(res) {
+		t.Error("no face carries a hyperbolic edge — the tongue was not imprinted as a hyperbola")
+	}
+}
+
+// anyFaceHasHyperbola reports whether any face of the body carries a hyperbolic edge.
+func anyFaceHasHyperbola(b *topo.Body) bool {
+	for _, f := range b.Faces() {
+		if hasHyperbolaEdge(f) {
+			return true
+		}
+	}
+	return false
 }
 
 // mustFrustum builds a frustum solid (bottom radius < top radius) or fails the test.

--- a/kernel/ops/boolean_cone_box_test.go
+++ b/kernel/ops/boolean_cone_box_test.go
@@ -98,6 +98,70 @@ func TestConeIntersectBoxVolume(t *testing.T) {
 	}
 }
 
+// Vertex-inside-band cone ∩/− box (Oblikovati/Oblikovati#1374): the box face x=4 has |D|=4 between the
+// bottom radius (3) and top radius (6), so the flat fades out before the small rim. Intersect keeps a
+// single tongue narrowing to the hyperbola vertex; Cut keeps an annulus notched down to that vertex.
+// Both must stay exact (an analytic cone face, no faceted soup), not fall back to CSG.
+
+func coneVertexInsideBox(t *testing.T) *topo.Body {
+	t.Helper()
+	b, err := brep.SolidBlock(math.P3(4, -20, -5), math.P3(20, 20, 15), "box")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	return b
+}
+
+// TestConeIntersectBoxVertexInsideExact keeps the +x tongue (x ≥ 4) — an exact cone face narrowing to
+// the hyperbola vertex, with the small rim wholly dropped.
+func TestConeIntersectBoxVertexInsideExact(t *testing.T) {
+	res, err := ops.Boolean(ops.Intersect, coneBoxFrustum(t), coneVertexInsideBox(t))
+	if err != nil {
+		t.Fatalf("Boolean(Intersect): %v", err)
+	}
+	assertConeBoxExact(t, res)
+}
+
+// TestConeCutBoxVertexInsideExact removes the +x tongue, leaving the cone minus a flat that fades out
+// before the small rim — an exact notched-annulus cone face.
+func TestConeCutBoxVertexInsideExact(t *testing.T) {
+	res, err := ops.Boolean(ops.Cut, coneBoxFrustum(t), coneVertexInsideBox(t))
+	if err != nil {
+		t.Fatalf("Boolean(Cut): %v", err)
+	}
+	assertConeBoxExact(t, res)
+}
+
+// TestConeVertexInsideVolumes cross-checks both pieces against the independent numeric integral: the
+// kept tongue equals the cross-section area beyond x=4, and the notched complement equals the full
+// frustum (210π) minus that tongue. The tongue pinches to the hyperbola vertex, a sharply-curved cusp
+// whose chord error at display density is ~3%; it converges to the analytic value as the mesh refines
+// (proving the B-rep is exact, not just close), so this verifies the cut SHAPE at a fine quality where
+// chord error is negligible — the geometry is right, independent of display tessellation density.
+func TestConeVertexInsideVolumes(t *testing.T) {
+	tongue := frustumCapBeyondPlaneVolume(0.3, 0, 10, 4)
+	full := 210 * stdmath.Pi
+	fine := ops.Quality{ChordTolerance: 0.005, AngleTolerance: 5 * stdmath.Pi / 180}
+	cases := []struct {
+		name string
+		op   ops.PartFeatureOperation
+		want float64
+	}{
+		{"intersect tongue", ops.Intersect, tongue},
+		{"cut notched annulus", ops.Cut, full - tongue},
+	}
+	for _, c := range cases {
+		res, err := ops.Boolean(c.op, coneBoxFrustum(t), coneVertexInsideBox(t))
+		if err != nil {
+			t.Fatalf("%s: Boolean: %v", c.name, err)
+		}
+		got := ops.BodyGeometryProperties(res, fine).Volume
+		if rel := stdmath.Abs(got-c.want) / c.want; rel > 0.01 {
+			t.Errorf("%s volume %.4f vs numeric %.4f (rel %.4f > 0.01)", c.name, got, c.want, rel)
+		}
+	}
+}
+
 // frustumCapBeyondPlaneVolume integrates the area of each circular cross-section lying at x ≥ xCut for
 // a cone of slope tanα over z∈[z0,z1] (apex at z=z0−r0/tanα). A circle of radius r centred on the axis
 // has area r²·(θ − sinθ·cosθ) beyond a chord at distance xCut, θ = arccos(xCut/r) (0 when xCut ≥ r).

--- a/kernel/ops/boolean_csg_demotion_test.go
+++ b/kernel/ops/boolean_csg_demotion_test.go
@@ -116,7 +116,16 @@ func curvedExactCases() []curvedExactCase {
 		}},
 		{"cone ∩ box (axis-∥ flat)", ops.Intersect, coneFlatBox},
 		{"cone − box (axis-∥ flat)", ops.Cut, coneFlatBox},
+		{"cone ∩ box (vertex-inside flat)", ops.Intersect, coneVertexInsideFlatBox},
+		{"cone − box (vertex-inside flat)", ops.Cut, coneVertexInsideFlatBox},
 	}
+}
+
+// coneVertexInsideFlatBox is the same frustum with a box whose face x=4 has |D|=4 BETWEEN the bottom
+// radius (3) and the top radius (6): the flat fades out before the small rim, so the imprint turns
+// through the hyperbola vertex inside the side — the vertex-inside-band case (Oblikovati/Oblikovati#1374).
+func coneVertexInsideFlatBox(t *testing.T) (*topo.Body, *topo.Body) {
+	return demoCone(t, math.P3(0, 0, 0), math.P3(0, 0, 10), 3, 6), demoBlock(t, math.P3(4, -20, -5), math.P3(20, 20, 15))
 }
 
 // coneFlatBox is the frustum (tanα=0.3, bottom r=3, top r=6) and an oversized box whose face x=2 is

--- a/kernel/ops/saddle_band_loft.go
+++ b/kernel/ops/saddle_band_loft.go
@@ -17,6 +17,43 @@ import (
 // two rim rows — each the exact tessellation of its own saddle edge, so the band welds to the caps that
 // share those edges — is itself an exact loft of the band.
 
+// notchedRimBandMesh meshes a singly-periodic ruled side whose two rims are ONE full-period circle and
+// ONE notched rim — a frustum flat that fades out before the small rim, leaving the kept cone side as a
+// band with a complete circular rim plus a rim notched down to the hyperbola vertex
+// (Oblikovati/Oblikovati#1374). toUVLoops "succeeds" on such a face (the notched outer loop unwraps) and
+// would route it to metricPatchMesh, which treats the full circle as an interior hole and meshes a
+// boundary that does not weld to the cap sharing that rim. But it is a genuine two-rim band, so the
+// saddle-band loft meshes it exactly (ruled rows) AND tessellates each rim by its own shared edge, so it
+// welds. ok=false unless the face is a developable side carrying both a full-circle rim and an open
+// (notched) rim edge — so a plain two-circle band (which already bypasses toUVLoops) is untouched.
+func notchedRimBandMesh(f *topo.Face, s geom.Surface, q Quality) (*Mesh, bool) {
+	if !isDevelopableSide(s) || !hasFullCircleAndNotchedRim(f) {
+		return nil, false
+	}
+	return saddleBandLoftMesh(f, s, q)
+}
+
+// hasFullCircleAndNotchedRim reports whether the face has BOTH a full-period closed-circle rim edge and
+// at least one open (non-closed) rim edge — the notched-band signature. Seam edges (used twice within
+// the face) are excluded, as they bridge the rims and belong to neither.
+func hasFullCircleAndNotchedRim(f *topo.Face) bool {
+	seam := seamEdgesOf(f)
+	fullCircle, notched := false, false
+	for _, e := range f.Edges() {
+		if seam[e] {
+			continue
+		}
+		if e.StartVertex() == e.EndVertex() {
+			if _, isCircle := e.Geometry().(geom.Circle); isCircle {
+				fullCircle = true
+			}
+		} else {
+			notched = true
+		}
+	}
+	return fullCircle && notched
+}
+
 // saddleBandLoftMesh meshes a singly-periodic ruled band (a trimmed cylinder/cone side) bounded by two
 // full-wrap rim loops, stitching the rims directly. ok=false unless the surface is singly periodic (a
 // cylinder/cone, not a torus/plane) and the face has exactly two closed rim edges.

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -27,24 +27,16 @@ const trimBorderTol = 1e-6
 // tessellateCurvedFace meshes a curved face's trimmed region (see file doc).
 func tessellateCurvedFace(f *topo.Face, q Quality) *Mesh {
 	s := f.Geometry()
-	if _, isSpline := s.(geom.BSplineSurface); isSpline {
-		if m := nurbsPcurveMesh(f, q); m != nil { // M25: metric-aware (u,v) triangulation
-			return m
-		}
+	if m := splineFaceMesh(f, s, q); m != nil {
+		return m // M25: a B-spline face via the metric-aware (u,v) triangulation
 	}
 	outer3D := faceOuterBoundary(f, q)
 	holes3D := faceHoleBoundaries(f, q)
 	if len(outer3D) < 3 {
 		return fullDomainGridMesh(s, q)
 	}
-	if m, isFan := coneApexFan(s, outer3D); isFan {
-		return m // a cone closing to its apex (a drill point): a fan from the apex to the rim
-	}
-	if m, isCap := sphereCapFan(s, outer3D, q); isCap {
-		return m // a sphere cut by one plane (a cap): rings from the rim to the enclosed pole
-	}
-	if m, isPatch := spherePatchMesh(s, outer3D, holes3D, q); isPatch {
-		return m // a sphere bounded by several arcs (a box cut): gnomonic CDT, pole/seam-safe
+	if m, special := specialCurvedMesh(f, s, outer3D, holes3D, q); special {
+		return m // a cone-apex/sphere fan or cap, sphere box-cut patch, or notched-rim band
 	}
 	outerUV, holesUV, ok := toUVLoops(s, outer3D, holes3D)
 	if !ok {
@@ -54,6 +46,35 @@ func tessellateCurvedFace(f *topo.Face, q Quality) *Mesh {
 		return structuredGridMesh(s, us, vs) // cylinder/cone wall, fillet face: exact area
 	}
 	return nonRectangularMesh(s, q, outer3D, holes3D, outerUV, holesUV)
+}
+
+// specialCurvedMesh tries the surface-specific meshers that precede the generic (u,v) trim path: a cone
+// closing to its apex (a fan), a sphere cut by one plane (a cap fan) or by several (a gnomonic patch),
+// and a periodic developable side with one full-circle rim plus a notched rim (a band loft). It returns
+// (mesh, true) on the first that applies, or (nil, false) so the caller falls through to toUVLoops.
+func specialCurvedMesh(f *topo.Face, s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, q Quality) (*Mesh, bool) {
+	if m, isFan := coneApexFan(s, outer3D); isFan {
+		return m, true // a cone closing to its apex (a drill point): a fan from the apex to the rim
+	}
+	if m, isCap := sphereCapFan(s, outer3D, q); isCap {
+		return m, true // a sphere cut by one plane (a cap): rings from the rim to the enclosed pole
+	}
+	if m, isPatch := spherePatchMesh(s, outer3D, holes3D, q); isPatch {
+		return m, true // a sphere bounded by several arcs (a box cut): gnomonic CDT, pole/seam-safe
+	}
+	if m, isBand := notchedRimBandMesh(f, s, q); isBand {
+		return m, true // a periodic side with one full-circle rim and one notched rim (a frustum flat that fades): loft
+	}
+	return nil, false
+}
+
+// splineFaceMesh meshes a B-spline face through the metric-aware (u,v) triangulation (M25), or nil when
+// the face is not a B-spline (so the caller falls through to the analytic-surface paths).
+func splineFaceMesh(f *topo.Face, s geom.Surface, q Quality) *Mesh {
+	if _, isSpline := s.(geom.BSplineSurface); !isSpline {
+		return nil
+	}
+	return nurbsPcurveMesh(f, q)
 }
 
 // meshSeamCrossingFace meshes a curved face whose boundary loop wraps the periodic seam (so toUVLoops

--- a/kernel/ops/testdata/occ_boolean_oracle.json
+++ b/kernel/ops/testdata/occ_boolean_oracle.json
@@ -12,5 +12,7 @@
   "coaxial cylinders ∪": 87.9645943,
   "cylinder boss ∪": 221.2057504,
   "cone ∩ box (axis-∥ flat)": 156.27698,
-  "cone − box (axis-∥ flat)": 503.4574773
+  "cone − box (axis-∥ flat)": 503.4574773,
+  "cone ∩ box (vertex-inside flat)": 31.78157847,
+  "cone − box (vertex-inside flat)": 627.9528788
 }


### PR DESCRIPTION
Closes #1374.

## What & why

Phase 1 (#1372) made `cone ∩ box` / `cone − box` exact when a box face parallel to the cone axis cuts **every** cross-section (`|D| <` small rim radius — the arc-band case). It deferred to faceted CSG the case where the flat **fades out before the small rim**: `|D|` between the small and large rim radii, so the hyperbola turns through its **vertex inside the band**. This PR makes that case exact too.

Now exact for all four directions (∩ and − on either side of the flat):
- **Intersect (apex dropped)** keeps a single cone tongue narrowing to the hyperbola vertex.
- **Cut (apex kept)** keeps the cone band minus that tongue — an annulus whose top rim is notched down to the vertex, closed by the intact small-rim circle.

The kept cone region stays an analytic `geom.Cone`; the cut edge is the analytic `geom.HyperbolicArc`. No dependence on the CSG `tjunctionFaceBudget`.

## How

1. **brep** — `coneSideSplit` routes the `rBot ≤ |D| < rTop` range to a new `coneSideVertexInside`: builds the notched-top loop (long top arc + two hyperbola arms meeting at the vertex) and, for the apex-kept side, closes the annulus with the small-rim circle as an inner loop so it welds to the small cap.
2. **ops (tessellation)** — the kept annulus is a developable band with one full-circle rim and one notched rim. `toUVLoops` mis-routes it to `metricPatchMesh` (treats the full circle as an interior hole → unwelded boundary, wrong volume despite correct area). Added `notchedRimBandMesh` to route exactly that signature (a developable side with both a full-circle rim and an open rim edge) to the saddle-band loft, which meshes ruled rows and tessellates each rim by its own shared edge so it welds. A plain two-circle band already bypasses `toUVLoops`, so it is untouched.

## Validation

- `TestCurvedBooleansStayExact` and `TestCurvedBooleanVolumesMatchOCC` both gain the vertex-inside case: result carries an analytic cone face, no faceted soup, watertight & manifold.
- **OCC getMass oracle** (BRepGProp::VolumeProperties) and an independent numeric cross-section integral both give **31.78** (∩) and **627.95** (−); our result converges to those as the mesh refines — proving the B-rep is exact and the display-quality deficit is only chord error at the vertex cusp.
- Full kernel suite green; coverage on the new functions 92–100% (package total 90.2%); lint clean.

## Still deferred
- A box face whose flat reaches the **apex** of a full cone (not a frustum) — still `ErrUnsupportedHalfSpace` → CSG.
- An **oblique** box face (ellipse / parabola / steep hyperbola) — tracked in #1375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)