### PR TITLE
[M2] geom: analytic ellipse/hyperbola from an oblique cone-plane cut (#1375 slice 1)

### DIFF
--- a/kernel/geom/intersect_analytic.go
+++ b/kernel/geom/intersect_analytic.go
@@ -131,8 +131,8 @@ func planeConeCurve(pl Plane, cone Cone) ([]Curve3, bool) {
 	if along < 1e-6 { // plane ∥ axis → hyperbola
 		return coneAxisParallelHyperbola(pl, cone, n, axis)
 	}
-	if along < 1-1e-6 { // oblique (ellipse/parabola/steep hyperbola) → defer to the tracer
-		return nil, false
+	if along < 1-1e-6 { // oblique → ellipse / hyperbola (parabolic boundary deferred inside)
+		return coneObliqueConic(pl, cone, n, axis)
 	}
 	t := n.Dot(cone.Apex.VectorTo(pl.Origin)) / axis.Dot(n)
 	r := stdmath.Abs(float64(t)) * stdmath.Tan(cone.HalfAngle)

--- a/kernel/geom/intersect_cone_hyperbola_test.go
+++ b/kernel/geom/intersect_cone_hyperbola_test.go
@@ -44,15 +44,6 @@ func TestPlaneConeAxisParallelHyperbola(t *testing.T) {
 	}
 }
 
-// An oblique-but-not-parallel plane is still deferred to the numeric tracer (handled=false).
-func TestPlaneConeObliqueStillDeferred(t *testing.T) {
-	cone, _ := NewCone(math.P3(0, 0, 0), math.V3(0, 0, 1), stdmath.Pi/6)
-	pl, _ := NewPlane(math.P3(0, 0, 5), math.V3(1, 0, 1)) // 45° to the axis: an ellipse/hyperbola, deferred
-	if _, handled := IntersectSurfacesAnalytic(pl, cone); handled {
-		t.Error("oblique cone cut should defer (handled=false)")
-	}
-}
-
 // A plane through the apex (D≈0) is the degenerate two-generator case and is deferred.
 func TestPlaneConeThroughApexDeferred(t *testing.T) {
 	cone, _ := NewCone(math.P3(0, 0, 0), math.V3(0, 0, 1), stdmath.Pi/6)

--- a/kernel/geom/intersect_cone_oblique.go
+++ b/kernel/geom/intersect_cone_oblique.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// Oblique cone–plane section (M2 Phase-1 follow-up, Oblikovati/Oblikovati#1375). A plane that is
+// neither perpendicular to the cone axis (a circle, #1334) nor parallel to it (an axis-parallel
+// hyperbola, #1372) cuts the cone in an ELLIPSE (tilt steeper than the generators wrt the axis), a
+// HYPERBOLA (tilt shallower) or — at the boundary tilt, parallel to one generator — a PARABOLA.
+//
+// All three come from ONE derivation: parameterize the plane by its own orthonormal in-plane basis
+// (UAxis ê1, VAxis ê2), P(s,t)=O+s·ê1+t·ê2, and substitute into the cone identity
+// ((P−V)·â)² = cos²α·|P−V|². The result is a general 2D conic A·s²+B·st+C·t²+D·s+E·t+F=0 whose
+// quadratic-form eigenvalues classify it (same-sign→ellipse, opposite→hyperbola, one zero→parabola)
+// and whose principal axes and centre give the analytic conic in 3D. This unifies the section types
+// the cone can produce without per-case trigonometry — the conic falls out of the algebra.
+
+// coneObliqueConic returns the conic an oblique plane cuts from a cone (n the unit plane normal, axis
+// the unit cone axis), as a geom.EllipseFull (elliptic tilt) or geom.Hyperbola branch on the cone's
+// nappe (hyperbolic tilt). The parabolic boundary tilt is deferred (handled=false) — a measure-zero
+// case left to the numeric tracer for now (Oblikovati/Oblikovati#1375 notes it may be its own slice).
+func coneObliqueConic(pl Plane, cone Cone, n, axis math.Vector3) ([]Curve3, bool) {
+	e1, e2 := pl.UAxis.AsVector(), pl.VAxis.AsVector()
+	w := cone.Apex.VectorTo(pl.Origin) // O − V, the apex-to-plane-origin vector
+	c2 := cosSquared(cone.HalfAngle)
+	a1, a2, aw := float64(axis.Dot(e1)), float64(axis.Dot(e2)), float64(axis.Dot(w))
+	w1, w2, ww := float64(w.Dot(e1)), float64(w.Dot(e2)), float64(w.Dot(w))
+	q := conic2D{
+		a: a1*a1 - c2, b: 2 * a1 * a2, c: a2*a2 - c2,
+		d: 2*a1*aw - 2*c2*w1, e: 2*a2*aw - 2*c2*w2, f: aw*aw - c2*ww,
+	}
+	return q.curve3(pl.Origin, e1, e2, n, axis, cone.Apex)
+}
+
+// conic2D is a general planar conic a·s²+b·st+c·t²+d·s+e·t+f=0 in a plane's (s,t)=(ê1,ê2) coordinates.
+type conic2D struct {
+	a, b, c, d, e, f float64
+}
+
+// curve3 classifies the conic by its quadratic-form eigenvalues and lifts it to the analytic 3D curve:
+// a same-sign pair is an ellipse, an opposite-sign pair a hyperbola (the branch on the cone's nappe),
+// a (near-)zero eigenvalue a parabola — deferred. handled=false on the parabolic boundary or a
+// degenerate/empty section so the caller keeps the numeric-tracer fallback.
+func (q conic2D) curve3(o math.Point3, e1, e2, n, axis math.Vector3, apex math.Point3) ([]Curve3, bool) {
+	l1, l2, u1, u2 := symmetricEig2(q.a, q.b/2, q.c)
+	if stdmath.Abs(l1) < 1e-9 || stdmath.Abs(l2) < 1e-9 {
+		return nil, false // a (near-)zero eigenvalue: the parabolic tilt, deferred to the tracer
+	}
+	s0, t0, ok := q.center()
+	if !ok {
+		return nil, false
+	}
+	center := o.TranslateBy(e1.Scale(math.Scalar(s0))).TranslateBy(e2.Scale(math.Scalar(t0)))
+	f0 := q.f + 0.5*(q.d*s0+q.e*t0) // the conic value at its centre: λ1·u²+λ2·v²=−f0 in principal axes
+	dir1 := e1.Scale(math.Scalar(u1[0])).Add(e2.Scale(math.Scalar(u1[1])))
+	dir2 := e1.Scale(math.Scalar(u2[0])).Add(e2.Scale(math.Scalar(u2[1])))
+	if l1*l2 > 0 {
+		return obliqueEllipse(center, n, l1, l2, f0, dir1, dir2)
+	}
+	return obliqueHyperbola(center, l1, l2, f0, dir1, dir2, axis, apex)
+}
+
+// center solves the 2×2 system [[a, b/2],[b/2, c]]·[s0,t0] = −[d/2, e/2] for the conic's centre in
+// (s,t). ok=false when the form is singular (no unique centre — the parabolic/degenerate case).
+func (q conic2D) center() (s0, t0 float64, ok bool) {
+	h := q.b / 2
+	det := q.a*q.c - h*h
+	if stdmath.Abs(det) < 1e-12 {
+		return 0, 0, false
+	}
+	s0 = (-q.d/2*q.c - h*(-q.e/2)) / det
+	t0 = (q.a*(-q.e/2) - (-q.d/2)*h) / det
+	return s0, t0, true
+}
+
+// obliqueEllipse builds the elliptic section: in principal axes λ1·u²+λ2·v²=−f0, so the semi-axis
+// along eigenvector i is √(−f0/λi) (both positive for a real ellipse). The larger is the major axis.
+func obliqueEllipse(center math.Point3, n math.Vector3, l1, l2, f0 float64, dir1, dir2 math.Vector3) ([]Curve3, bool) {
+	r1, r2 := -f0/l1, -f0/l2
+	if r1 <= 0 || r2 <= 0 {
+		return nil, false // no real ellipse (the plane misses the nappe)
+	}
+	semi1, semi2 := stdmath.Sqrt(r1), stdmath.Sqrt(r2)
+	majorDir, majorR, minorR := dir1, semi1, semi2
+	if semi2 > semi1 {
+		majorDir, majorR, minorR = dir2, semi2, semi1
+	}
+	el, err := NewEllipseFull(center, n, majorDir, majorR, minorR)
+	if err != nil {
+		return nil, false
+	}
+	return []Curve3{el}, true
+}
+
+// obliqueHyperbola builds the hyperbolic section's branch ON the cone's nappe. In principal axes
+// λ1·u²+λ2·v²=−f0 with λ1,λ2 opposite signs: the transverse axis is the eigenvector whose −f0/λ is
+// positive (real semi A=√(−f0/λ)), the other gives the conjugate semi B=√(|−f0/λ|). The branch opens
+// toward whichever nappe-side vertex lies on the actual cone (apex+t·axis, t>0), so the transverse
+// direction is signed to point from the centre to that vertex.
+func obliqueHyperbola(center math.Point3, l1, l2, f0 float64, dir1, dir2, axis math.Vector3, apex math.Point3) ([]Curve3, bool) {
+	transDir, transL, conjL := dir1, l1, l2
+	if -f0/l1 <= 0 { // dir1 is the imaginary axis; swap so transDir is the real (transverse) one
+		transDir, transL, conjL = dir2, l2, l1
+	}
+	a := stdmath.Sqrt(-f0 / transL)
+	b := stdmath.Sqrt(f0 / conjL)
+	if stdmath.IsNaN(a) || stdmath.IsNaN(b) || a <= 0 || b <= 0 {
+		return nil, false
+	}
+	if float64(apex.VectorTo(center.TranslateBy(transDir.Scale(math.Scalar(a)))).Dot(axis)) < 0 {
+		transDir = transDir.Scale(-1) // point the branch toward the vertex on the cone's real nappe
+	}
+	conjDir := axis.Cross(transDir)
+	h, err := NewHyperbola(center, transDir, conjDir, a, b)
+	if err != nil {
+		return nil, false
+	}
+	return []Curve3{h}, true
+}
+
+// symmetricEig2 returns the eigenvalues and unit eigenvectors of the symmetric 2×2 [[a, h],[h, c]]
+// (l1 with u1, l2 with u2). Used to reduce a planar conic to its principal axes.
+func symmetricEig2(a, h, c float64) (l1, l2 float64, u1, u2 [2]float64) {
+	tr, disc := a+c, stdmath.Hypot(a-c, 2*h)
+	l1, l2 = (tr+disc)/2, (tr-disc)/2
+	u1 = eigenvector2(a, h, c, l1)
+	u2 = [2]float64{-u1[1], u1[0]} // the other eigenvector is orthogonal (symmetric matrix)
+	return l1, l2, u1, u2
+}
+
+// eigenvector2 returns a unit eigenvector of [[a, h],[h, c]] for eigenvalue l. For h≈0 the matrix is
+// already diagonal, so the axis is e1 or e2 by which diagonal entry l matches.
+func eigenvector2(a, h, c, l float64) [2]float64 {
+	if stdmath.Abs(h) < 1e-12 {
+		if stdmath.Abs(l-a) <= stdmath.Abs(l-c) {
+			return [2]float64{1, 0}
+		}
+		return [2]float64{0, 1}
+	}
+	vx, vy := l-c, h // (l−c, h) solves (a−l)vx+h·vy=0 ↔ h·vx+(c−l)vy=0
+	norm := stdmath.Hypot(vx, vy)
+	return [2]float64{vx / norm, vy / norm}
+}
+
+// cosSquared returns cos²(angle), the coefficient the cone identity ((P−V)·â)²=cos²α·|P−V|² uses.
+func cosSquared(angle float64) float64 {
+	c := stdmath.Cos(angle)
+	return c * c
+}

--- a/kernel/geom/intersect_cone_oblique_test.go
+++ b/kernel/geom/intersect_cone_oblique_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// An oblique plane tilted STEEPER than the cone's generators (relative to the axis) cuts a closed
+// ELLIPSE on one nappe (Oblikovati/Oblikovati#1375). Every sampled point must lie on BOTH the cone
+// surface and the plane, and the curve must be a geom.EllipseFull.
+func TestPlaneConeObliqueEllipse(t *testing.T) {
+	cone, _ := NewCone(math.P3(0, 0, 0), math.V3(0, 0, 1), stdmath.Pi/6) // α = 30°
+	pl, _ := NewPlane(math.P3(0, 0, 5), math.V3(1, 0, 1))                // tilt 45° > 30° → ellipse on the +z nappe
+	curves, handled := IntersectSurfacesAnalytic(pl, cone)
+	if !handled || len(curves) != 1 {
+		t.Fatalf("imprint handled=%v curves=%d, want one curve", handled, len(curves))
+	}
+	el, ok := curves[0].(EllipseFull)
+	if !ok {
+		t.Fatalf("imprint curve is %T, want EllipseFull", curves[0])
+	}
+	if el.MajorRadius < el.MinorRadius {
+		t.Errorf("major radius %g < minor %g", el.MajorRadius, el.MinorRadius)
+	}
+	for i := 0; i < 12; i++ {
+		assertOnConeAndPlane(t, cone, pl, el.PointAt(float64(i)/12))
+	}
+}
+
+// An oblique plane tilted SHALLOWER than the generators cuts a HYPERBOLA; the returned branch lies on
+// the cone's real (+axis) nappe, every point on both surfaces.
+func TestPlaneConeObliqueHyperbola(t *testing.T) {
+	cone, _ := NewCone(math.P3(0, 0, 0), math.V3(0, 0, 1), stdmath.Pi/3) // α = 60°, steep cone
+	pl, _ := NewPlane(math.P3(3, 0, 0), math.V3(1, 0, 0.6))              // tilt ~31° < 60° → hyperbola
+	curves, handled := IntersectSurfacesAnalytic(pl, cone)
+	if !handled || len(curves) != 1 {
+		t.Fatalf("imprint handled=%v curves=%d, want one curve", handled, len(curves))
+	}
+	h, ok := curves[0].(Hyperbola)
+	if !ok {
+		t.Fatalf("imprint curve is %T, want Hyperbola", curves[0])
+	}
+	if v := float64(cone.Apex.VectorTo(h.PointAt(0)).Dot(cone.AxisDir.AsVector())); v <= 0 {
+		t.Errorf("hyperbola vertex on the wrong nappe (apex-distance %g ≤ 0)", v)
+	}
+	for _, theta := range []float64{-1.2, -0.4, 0, 0.4, 1.2} {
+		assertOnConeAndPlane(t, cone, pl, h.PointAt(theta))
+	}
+}
+
+// The parabolic boundary tilt (plane parallel to a generator, φ = α) is the measure-zero degenerate
+// case and is deferred to the numeric tracer (handled=false), as #1375 allows.
+func TestPlaneConeParabolaDeferred(t *testing.T) {
+	cone, _ := NewCone(math.P3(0, 0, 0), math.V3(0, 0, 1), stdmath.Pi/4) // α = 45°
+	pl, _ := NewPlane(math.P3(0, 0, 3), math.V3(1, 0, 1))                // normal at 45° → plane ∥ a generator
+	if _, handled := IntersectSurfacesAnalytic(pl, cone); handled {
+		t.Error("parabolic tilt should defer (handled=false)")
+	}
+}
+
+// A plane through the apex is degenerate (the section collapses through the centre) and defers.
+func TestPlaneConeObliqueThroughApexDeferred(t *testing.T) {
+	cone, _ := NewCone(math.P3(0, 0, 0), math.V3(0, 0, 1), stdmath.Pi/6)
+	pl, _ := NewPlane(math.P3(0, 0, 0), math.V3(1, 0, 1)) // oblique AND through the apex
+	if _, handled := IntersectSurfacesAnalytic(pl, cone); handled {
+		t.Error("oblique plane through the apex should defer (handled=false)")
+	}
+}
+
+// A hyperbolic oblique cut on the OPPOSITE side of the axis (x = −3) exercises the branch-direction
+// flip: the transverse axis must still point to the vertex on the cone's real nappe.
+func TestPlaneConeObliqueHyperbolaOtherSide(t *testing.T) {
+	cone, _ := NewCone(math.P3(0, 0, 0), math.V3(0, 0, 1), stdmath.Pi/3)
+	pl, _ := NewPlane(math.P3(-3, 0, 0), math.V3(1, 0, -0.6)) // mirror of the +x hyperbola case
+	curves, handled := IntersectSurfacesAnalytic(pl, cone)
+	if !handled || len(curves) != 1 {
+		t.Fatalf("imprint handled=%v curves=%d, want one curve", handled, len(curves))
+	}
+	h := curves[0].(Hyperbola)
+	if v := float64(cone.Apex.VectorTo(h.PointAt(0)).Dot(cone.AxisDir.AsVector())); v <= 0 {
+		t.Errorf("hyperbola vertex on the wrong nappe (apex-distance %g ≤ 0)", v)
+	}
+	for _, theta := range []float64{-1, 0, 1} {
+		assertOnConeAndPlane(t, cone, pl, h.PointAt(theta))
+	}
+}
+
+// symmetricEig2 on an already-diagonal form (h=0) returns axis-aligned eigenvectors — the branch
+// eigenvector2 takes when the quadratic form has no cross term.
+func TestSymmetricEig2Diagonal(t *testing.T) {
+	l1, l2, u1, u2 := symmetricEig2(4, 0, 1)
+	if stdmath.Abs(l1-4) > 1e-12 || stdmath.Abs(l2-1) > 1e-12 {
+		t.Errorf("eigenvalues (%g,%g), want (4,1)", l1, l2)
+	}
+	if stdmath.Abs(u1[0]-1) > 1e-12 || stdmath.Abs(u1[1]) > 1e-12 {
+		t.Errorf("u1 = %v, want (1,0)", u1)
+	}
+	if stdmath.Abs(u2[0]) > 1e-12 || stdmath.Abs(stdmath.Abs(u2[1])-1) > 1e-12 {
+		t.Errorf("u2 = %v, want ±(0,1)", u2)
+	}
+	// a < c: the larger eigenvalue now matches the SECOND diagonal entry, so the eigenvector is (0,1).
+	_, _, v1, _ := symmetricEig2(1, 0, 4)
+	if stdmath.Abs(v1[0]) > 1e-12 || stdmath.Abs(v1[1]-1) > 1e-12 {
+		t.Errorf("v1 = %v, want (0,1)", v1)
+	}
+}
+
+// assertOnConeAndPlane fails unless p lies on both the cone surface (radial residual ≈ 0 on the
+// +nappe) and the cutting plane (signed distance ≈ 0).
+func assertOnConeAndPlane(t *testing.T, cone Cone, pl Plane, p math.Point3) {
+	t.Helper()
+	if off := coneRadialResidual(cone, p); off > 1e-7 {
+		t.Errorf("point %v not on cone (residual=%g)", p, off)
+	}
+	if d := float64(pl.Origin.VectorTo(p).Dot(pl.Normal())); stdmath.Abs(d) > 1e-7 {
+		t.Errorf("point %v not on plane (signed distance=%g)", p, d)
+	}
+}


### PR DESCRIPTION
Part of #1375 (first slice — the geometry foundation).

## What & why
A cone–plane section is a conic whose type depends on the plane's tilt vs the cone's half-angle:
- **⟂ to the axis** → circle (#1334)
- **∥ to the axis** → hyperbola (#1372 / #1374)
- **oblique** → an **ellipse** (tilt steeper than the generators wrt the axis), a **hyperbola** (shallower), or a **parabola** at the boundary tilt.

`geom.planeConeCurve` deferred every oblique case to the numeric tracer. This slice makes it return the exact analytic conic, so the later brep/ops slices can imprint and split the cone side by it (keeping `cone ∩/− box` with an oblique face exact instead of faceted CSG).

## How
All three regimes fall out of **one derivation**: parameterize the plane by its own in-plane orthonormal basis (`UAxis`, `VAxis`), substitute `P(s,t)` into the cone identity `((P−V)·â)² = cos²α·|P−V|²`, and read off a general 2D conic `A·s²+B·st+C·t²+D·s+E·t+F`. The quadratic form's eigenvalues classify it (same-sign → ellipse, opposite → hyperbola, one zero → parabola) and its principal axes + centre give the 3D curve — a `geom.EllipseFull` or the `geom.Hyperbola` branch on the cone's real nappe. No per-case trigonometry; the conic falls out of the algebra (`kernel/geom/intersect_cone_oblique.go`).

## Scope of this slice
- The **parabolic** boundary (a zero eigenvalue) is the measure-zero degenerate case and stays deferred for now (#1375 allows it as its own slice).
- brep still gates the full-cone-side box cut on hyperbola-only imprints (`allHyperbolas`), so this slice is **purely additive**: oblique box cuts keep the CSG fallback until the split slice lands. Full kernel suite green (no behaviour change).

## Validation
Sampled conic points lie on **both** the cone surface and the cutting plane, for the elliptic tilt, the hyperbolic tilt, and both sides of the axis; the parabolic and through-apex tilts defer cleanly. The symmetric-2×2 eigensolver is unit-tested on diagonal and general forms. Lint clean; package coverage 91%.

## Next slices (tracked on #1375)
- brep: split the full cone side by the ellipse (a seam-wrapping band, circle rim + elliptical rim) and by the oblique hyperbola; planar elliptical lid; OCC-oracle the `cone ∩/− box` volumes.
- the parabola representation (a new curve type) if/when its tilt is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)