### PR TITLE
brep: fix loopedSplit missing a crossing on a closed edge's seam vertex

### DIFF
--- a/kernel/brep/curved_halfspace_looped.go
+++ b/kernel/brep/curved_halfspace_looped.go
@@ -4,6 +4,7 @@ package brep
 
 import (
 	stdmath "math"
+	"sort"
 
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/math"
@@ -169,12 +170,16 @@ func taggedSeg(c geom.Curve3, a, b float64, plane geom.Plane, n math.Vector3) ke
 }
 
 // edgeCrossings returns the parameters within an edge's [t0, t1] where g crosses zero (the plane cuts
-// the edge), found by sampling for sign changes then bisecting each.
+// the edge), found by sampling for sign changes then bisecting each. A CLOSED (seam) edge is sampled
+// cyclically — see closedEdgeCrossings — so a crossing that lands on its seam vertex is not missed.
 func edgeCrossings(le loopEdge, plane geom.Plane, n math.Vector3) []float64 {
-	const samples = 32
+	if samePoint(le.start(), le.end()) {
+		return closedEdgeCrossings(le, plane, n)
+	}
 	var out []float64
 	prevT := le.t0
 	prevG := signedDistance(le.curve.PointAt(le.t0), plane, n)
+	const samples = 32
 	for i := 1; i <= samples; i++ {
 		t := le.t0 + (le.t1-le.t0)*float64(i)/samples
 		g := signedDistance(le.curve.PointAt(t), plane, n)
@@ -184,6 +189,55 @@ func edgeCrossings(le loopEdge, plane geom.Plane, n math.Vector3) []float64 {
 		prevT, prevG = t, g
 	}
 	return out
+}
+
+// closedEdgeCrossings returns the plane crossings of a closed (seam) edge — a full circle/ellipse whose
+// start and end vertex coincide. The open sampler starts and ends AT the seam vertex, so a crossing that
+// lands exactly there (the cap centre on the plane) sits at g≈0 at both ends and is missed, yielding an
+// odd count that defers the split. Sampling at phase-shifted MIDPOINTS keeps every sample off the seam,
+// and comparing the samples CYCLICALLY (the last wraps across the seam to the first) catches a crossing
+// at the seam like any other. The wrap interval's bisection runs past the period; the result is folded
+// back into [t0, t1).
+func closedEdgeCrossings(le loopEdge, plane geom.Plane, n math.Vector3) []float64 {
+	const samples = 64
+	span := le.t1 - le.t0 // signed: negative when the closed edge is traversed reversed (t0 > t1)
+	ts := make([]float64, samples)
+	gs := make([]float64, samples)
+	for i := 0; i < samples; i++ {
+		ts[i] = le.t0 + span*(float64(i)+0.5)/samples
+		gs[i] = signedDistance(le.curve.PointAt(ts[i]), plane, n)
+	}
+	var out []float64
+	for i := 0; i < samples; i++ {
+		j := (i + 1) % samples
+		if (gs[i] < 0) == (gs[j] < 0) {
+			continue
+		}
+		hi := ts[j]
+		if j == 0 {
+			hi += span // the last→first pair straddles the seam: extend past t1 (the curve is periodic)
+		}
+		out = append(out, foldParam(bisectCrossing(le, plane, n, ts[i], hi), le.t0, span))
+	}
+	sortByTraversal(out, le.t0, span) // closedEdgeSegs needs the crossings in traversal (t0→t1) order
+	return out
+}
+
+// foldParam folds a parameter (possibly advanced past t1 by the seam-wrap bisection) back into the
+// half-open traversal interval [t0, t0+span) — handling either sign of span (a reversed closed edge has
+// span < 0).
+func foldParam(t, t0, span float64) float64 {
+	prog := (t - t0) / span // fraction of the way through the traversal
+	prog -= stdmath.Floor(prog)
+	return t0 + prog*span
+}
+
+// sortByTraversal orders crossings by how far along the edge's traversal (t0→t1) they sit, so they tile
+// the closed curve in order regardless of whether span is positive (forward) or negative (reversed).
+func sortByTraversal(out []float64, t0, span float64) {
+	sort.Slice(out, func(i, j int) bool {
+		return (out[i]-t0)/span < (out[j]-t0)/span
+	})
 }
 
 // bisectCrossing refines a sign-change bracket [ta, tb] to the parameter where g = 0.

--- a/kernel/brep/curved_halfspace_seam_crossing_test.go
+++ b/kernel/brep/curved_halfspace_seam_crossing_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// A cylinder cut by a plane PARALLEL to the axis and passing through a cap's seam vertex must split
+// watertight, not defer: the cap-boundary circle's seam lands on the cut plane, the closed-edge crossing
+// degeneracy that closedEdgeCrossings fixes. The seam of a SolidCylinder cap circle is at angle 0 (the
+// +RefDir point); a plane through that point parallel to the axis makes the seam a crossing.
+func TestHalfSpaceThroughCapSeam(t *testing.T) {
+	cyl, err := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 10)
+	if err != nil {
+		t.Fatalf("SolidCylinder: %v", err)
+	}
+	// The cap circle's seam point is at radius along +RefDir. A plane through the axis whose normal is
+	// perpendicular to that ref makes the seam point lie on the plane (a chord through the seam).
+	plane, err := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 1, 0)) // y=0 through the axis: seam (5,0,*) on it
+	if err != nil {
+		t.Fatalf("NewPlane: %v", err)
+	}
+	res, err := HalfSpaceCut(cyl, plane)
+	if err != nil {
+		t.Fatalf("HalfSpaceCut through a cap seam should not defer: %v", err)
+	}
+	assertWatertight(t, res)
+	// A genuine half-cylinder, not the whole solid kept: half side + two half-cap segments + the planar
+	// lid — more faces than the original three. Before the fix the seam-coincident crossing was missed, so
+	// the cap split deferred and the whole cut fell to CSG.
+	if got := len(res.Faces()); got <= len(cyl.Faces()) {
+		t.Errorf("result has %d faces, want > %d (the half-cut must add a lid, not keep the solid whole)", got, len(cyl.Faces()))
+	}
+	if !hasPlanarLid(res, plane) {
+		t.Error("result has no planar lid on the cut plane — the body was not actually split")
+	}
+}
+
+// hasPlanarLid reports whether the body has a planar face coincident with the cut plane (the lid the
+// split adds).
+func hasPlanarLid(b *topo.Body, plane geom.Plane) bool {
+	for _, f := range b.Faces() {
+		pl, ok := f.Geometry().(geom.Plane)
+		if ok && samePoint(pl.Origin, plane.Origin) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
A general `loopedSplit` robustness fix, and the prerequisite for the steep-oblique-hyperbola slice of #1375.

## The bug
A planar face cut by a plane that passes through a boundary **circle's seam vertex** — e.g. a cap whose centre lies on the cut plane — reported an **odd** crossing count and deferred the whole `HalfSpaceCut` to faceted CSG.

`edgeCrossings` sampled the closed boundary circle from `t0` to `t1` (the same seam point), where the signed distance is ≈0 at both ends. A crossing landing exactly on the seam was therefore invisible (it starts at g≈0 treated as one side), and the wrap from `t1` back to `t0` was never checked — so one of the two chord crossings was missed.

This is what blocked the oblique-hyperbola box composition: a near-axial cutting plane slices the cone lengthwise through a cap centre, hitting this degeneracy on the bite side.

## The fix
Closed (seam) edges route to a new `closedEdgeCrossings`, which:
- samples at **phase-shifted midpoints** so no sample ever lands on the seam;
- compares the samples **cyclically** — the last sample wraps across the seam to the first — so a crossing on the seam is caught like any other;
- `foldParam` folds the wrap interval's bisection back into the traversal interval for **either sign of span** (a reversed closed edge has `t0 > t1`, `span < 0` — getting this wrong was an infinite loop caught by the suite);
- orders the crossings by traversal progress so `closedEdgeSegs` tiles the curve correctly.

Open edges keep the original sampler unchanged.

## Validation
- New regression test: a cylinder halved by a plane through a cap seam now splits **watertight with a planar lid** (more faces than the original solid) instead of deferring.
- **Full kernel suite green** — `edgeCrossings` is shared by every `loopedSplit` boolean (sphere/cylinder/cone ∩ box, drilled plates, the `closedEdgeSegs` cylinder/cone side splits of #1345/#1372), so this was the non-negotiable gate. No regression; no hang.
- Lint clean; 100% coverage on the new functions.

## Follow-up
With this in, the steep-oblique-hyperbola slice of #1375 (the brep cone-side split is already proven at the `HalfSpaceCut` level) can compose the box cut end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)