### PR TITLE
[M2] exact cone ∩/− box with an oblique (hyperbolic) face (#1375 slice 3)

### DIFF
--- a/kernel/brep/curved_halfspace_cone_oblique_hyperbola.go
+++ b/kernel/brep/curved_halfspace_cone_oblique_hyperbola.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Cone-side oblique-hyperbolic split (M2 Phase-1 follow-up, Oblikovati/Oblikovati#1375). An OBLIQUE box
+// face tilted SHALLOWER than the cone's generators (but not parallel to the axis) cuts the frustum side
+// in a HYPERBOLA — like the axis-parallel case (#1372) but tilted, so the section is symmetric about the
+// {axis, normal} meridian rather than a constant-distance chord. Its two arms still climb from one rim to
+// the other, so the kept band is an ARC-BAND bounded by the two arms plus the kept arcs of the rims.
+//
+// coneArcBand (#1372) builds that band from a CONSTANT chord half-angle φ=arccos(−d/r); here the chord
+// distance varies with apex distance, so this finds the rim crossings by ROOT-FINDING (the apex distance
+// along a hyperbola arm is monotonic, so each arm crosses each rim once) and reuses coneArcBand's winding
+// with the per-rim φ taken from the ACTUAL crossing azimuths. The vertex-below-band arrangement (the arms
+// cross BOTH rims) is handled; a vertex inside the band, or arms that miss a rim, defer to CSG.
+
+// coneSideObliqueHyperbolaSplit splits a full periodic frustum side by an oblique plane whose section is
+// one hyperbola branch whose vertex sits below the band (both arms cross both rims). It returns the kept
+// arc-band sub-face and the two hyperbola arms (reversed, for the lid). A plane that clears the band
+// keeps the side whole or drops it; a vertex inside the band or arms missing a rim defer.
+func coneSideObliqueHyperbolaSplit(f curvedFace, cone geom.Cone, hyper geom.Hyperbola, band coneSideBand_, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
+	if side := bandSideOfPlane(cone, band, plane, n); side != 0 {
+		return coneSideWholeOrEmpty(f, float64(side)), nil, nil // the plane clears the side: whole or empty
+	}
+	if apexDistOf(cone, hyper.PointAt(0)) >= band.vMin-cylinderAxisTol {
+		return nil, nil, ErrUnsupportedHalfSpace // vertex inside the band (oblique #1374 analogue): deferred
+	}
+	thetaBot, okB := hyperThetaAtApexDist(hyper, cone, band.vMin)
+	thetaTop, okT := hyperThetaAtApexDist(hyper, cone, band.vMax)
+	if !okB || !okT {
+		return nil, nil, ErrUnsupportedHalfSpace // an arm does not reach a rim: an unhandled arrangement
+	}
+	loop, section := obliqueHyperbolaBand(cone, hyper, band, thetaBot, thetaTop, n)
+	if loop == nil {
+		return nil, nil, ErrUnsupportedHalfSpace
+	}
+	kept := curvedFace{surface: cone, reversed: f.reversed, lineage: f.lineage, loops: []curvedLoop{{edges: loop}}}
+	return []curvedFace{kept}, section, nil
+}
+
+// obliqueHyperbolaBand builds the kept band the SAME way coneArcBand (#1372) does — bottom arc CCW from
+// u_n+φ_B over the major arc, top arc CW, the two hyperbola arms between them — but the per-rim half-angle
+// φ comes from the ACTUAL rim crossing (root-found) instead of the constant-chord arccos(−d/r), because
+// an oblique plane's chord distance varies with apex distance. u_n is the meridian azimuth toward the
+// plane; the crossings sit symmetrically at u_n±φ, so the kept (negative-side) band is the major arc away
+// from u_n, identical in winding to the axis-parallel band so it composes with the cap chords.
+func obliqueHyperbolaBand(cone geom.Cone, hyper geom.Hyperbola, band coneSideBand_, thetaBot, thetaTop float64, n math.Vector3) ([]loopEdge, []loopEdge) {
+	axis, ref := cone.AxisDir.AsVector(), cone.Ref.AsVector()
+	uN := coneAngleOf(cone, n)
+	phiB := crossingHalfAngle(cone, hyper.PointAt(thetaBot), uN)
+	phiT := crossingHalfAngle(cone, hyper.PointAt(thetaTop), uN)
+	bottomArc, errB := geom.NewArc3d(band.bottom, axis, ref, band.rBot, uN+phiB, 2*stdmath.Pi-2*phiB)
+	topArc, errT := geom.NewArc3d(band.top, axis, ref, band.rTop, uN-phiT, -(2*stdmath.Pi - 2*phiT))
+	if errB != nil || errT != nil {
+		return nil, nil
+	}
+	armA := hyperbolaArm(hyper, bottomArc.PointAt(1), topArc.PointAt(0)) // −φ side, bottom→top
+	armB := hyperbolaArm(hyper, topArc.PointAt(1), bottomArc.PointAt(0)) // +φ side, top→bottom
+	loop := []loopEdge{{curve: bottomArc, t0: 0, t1: 1}, armA, {curve: topArc, t0: 0, t1: 1}, armB}
+	return loop, []loopEdge{reverseEdge(armA), reverseEdge(armB)}
+}
+
+// crossingHalfAngle returns the unsigned azimuthal angle between a rim crossing point and the meridian
+// u_n — the φ the kept major arc (u_n+φ … u_n−φ the long way) leaves on that rim.
+func crossingHalfAngle(cone geom.Cone, crossing math.Point3, uN float64) float64 {
+	u := coneAngleOf(cone, cone.Apex.VectorTo(crossing))
+	return stdmath.Abs(wrapToPi(u - uN))
+}
+
+// bandSideOfPlane samples the frustum side over a (u, v) grid and reports −1 if every sample is on the
+// plane's negative (kept) side (the plane clears the band → keep whole), +1 if every sample is positive
+// (→ empty), or 0 if the plane crosses the band (→ split). It guards the split against a plane whose
+// section hyperbola lies on the infinite cone OUTSIDE the frustum (a far box face), which must clear the
+// side, not defer.
+func bandSideOfPlane(cone geom.Cone, band coneSideBand_, plane geom.Plane, n math.Vector3) int {
+	axis := cone.AxisDir.AsVector()
+	tanA := stdmath.Tan(cone.HalfAngle)
+	pos, neg := false, false
+	for vi := 0; vi <= 4; vi++ {
+		v := band.vMin + (band.vMax-band.vMin)*float64(vi)/4
+		center := cone.Apex.TranslateBy(axis.Scale(math.Scalar(v)))
+		for ui := 0; ui < 16; ui++ {
+			p := coneRimPoint(cone, center, v*tanA, 2*stdmath.Pi*float64(ui)/16)
+			if signedDistance(p, plane, n) < 0 {
+				neg = true
+			} else {
+				pos = true
+			}
+		}
+	}
+	switch {
+	case neg && !pos:
+		return -1
+	case pos && !neg:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// coneRimPoint returns the point at azimuth u on a cross-section circle (centre on the axis, given
+// radius) in the cone's Ref/binormal frame.
+func coneRimPoint(cone geom.Cone, center math.Point3, radius, u float64) math.Point3 {
+	ref := cone.Ref.AsVector()
+	binormal := cone.AxisDir.AsVector().Cross(ref)
+	radial := ref.Scale(math.Scalar(stdmath.Cos(u))).Add(binormal.Scale(math.Scalar(stdmath.Sin(u))))
+	return center.TranslateBy(radial.Scale(math.Scalar(radius)))
+}
+
+// apexDistOf returns a point's distance from the apex measured along the cone axis.
+func apexDistOf(cone geom.Cone, p math.Point3) float64 {
+	return float64(cone.Apex.VectorTo(p).Dot(cone.AxisDir.AsVector()))
+}
+
+// hyperThetaAtApexDist returns the positive hyperbola parameter θ where the arm reaches apex distance
+// target. Apex distance grows monotonically with θ along a +nappe arm, so it brackets then bisects.
+// ok=false if no θ up to a large bound reaches the target (the arm never gets that far up the cone).
+func hyperThetaAtApexDist(hyper geom.Hyperbola, cone geom.Cone, target float64) (float64, bool) {
+	lo, hi := 0.0, 0.5
+	for apexDistOf(cone, hyper.PointAt(hi)) < target {
+		hi *= 2
+		if hi > 1e4 {
+			return 0, false
+		}
+	}
+	for i := 0; i < 80; i++ {
+		mid := (lo + hi) / 2
+		if apexDistOf(cone, hyper.PointAt(mid)) < target {
+			lo = mid
+		} else {
+			hi = mid
+		}
+	}
+	return (lo + hi) / 2, true
+}
+
+// isAxisParallel reports whether the cut plane is (essentially) parallel to the cone axis — the
+// symmetric constant-chord hyperbola of #1372/#1374, routed to coneSideSplit rather than the oblique
+// root-finding split here.
+func isAxisParallel(n math.Vector3, cone geom.Cone) bool {
+	return stdmath.Abs(float64(n.Dot(cone.AxisDir.AsVector()))) < 1e-6
+}

--- a/kernel/brep/curved_halfspace_cone_oblique_hyperbola_test.go
+++ b/kernel/brep/curved_halfspace_cone_oblique_hyperbola_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// An oblique plane tilted SHALLOWER than the cone's generators (but not axis-parallel) cuts the frustum
+// side in a hyperbola whose vertex is below the band; the kept side is an exact arc-band cone face
+// bounded by the two hyperbola arms and the kept rim arcs, watertight (Oblikovati/Oblikovati#1375).
+func TestConeSideHalfSpaceObliqueHyperbola(t *testing.T) {
+	frustum := mustFrustum(t, math.P3(0, 0, 0), math.P3(0, 0, 10), 3, 6)                    // α≈16.7°
+	plane, err := geom.NewPlane(math.P3(2, 0, 0), math.V3(stdmath.Sqrt(1-0.2*0.2), 0, 0.2)) // φ≈11.5° < α
+	if err != nil {
+		t.Fatalf("NewPlane: %v", err)
+	}
+	res, err := HalfSpaceCut(frustum, plane)
+	if err != nil {
+		t.Fatalf("HalfSpaceCut: %v", err)
+	}
+	assertWatertight(t, res)
+	if cones, _, _ := faceTypeCounts(t, res); cones != 1 {
+		t.Errorf("got %d cone faces, want 1", cones)
+	}
+	if !anyFaceHasHyperbola(res) {
+		t.Error("no hyperbolic edge — the oblique cut was not imprinted as a hyperbola")
+	}
+}
+
+// An oblique hyperbola whose vertex falls INSIDE the band (the arms turn before reaching the small rim,
+// the oblique analogue of #1374) is not yet built and must defer cleanly so the CSG fallback covers it.
+func TestConeSideHalfSpaceObliqueHyperbolaVertexInsideDefers(t *testing.T) {
+	frustum := mustFrustum(t, math.P3(0, 0, 0), math.P3(0, 0, 10), 3, 6)
+	plane, _ := geom.NewPlane(math.P3(4, 0, 0), math.V3(stdmath.Sqrt(1-0.2*0.2), 0, 0.2)) // vertex apex-dist ≈ 12, in band
+	if _, err := HalfSpaceCut(frustum, plane); err == nil {
+		t.Error("vertex-inside oblique hyperbola should defer, got nil error")
+	}
+}
+
+// A plane shallower than the generators but clear of the frustum band (its section lies on the infinite
+// cone beyond the rims) keeps the side whole / empties it rather than deferring.
+func TestConeSideHalfSpaceObliqueHyperbolaClears(t *testing.T) {
+	frustum := mustFrustum(t, math.P3(0, 0, 0), math.P3(0, 0, 10), 3, 6)
+	keep, _ := geom.NewPlane(math.P3(40, 0, 0), math.V3(stdmath.Sqrt(1-0.2*0.2), 0, 0.2)) // far +x: whole kept
+	res, err := HalfSpaceCut(frustum, keep)
+	if err != nil {
+		t.Fatalf("HalfSpaceCut(keep): %v", err)
+	}
+	if len(res.Faces()) != len(frustum.Faces()) {
+		t.Errorf("clearing plane changed the face count: %d vs %d", len(res.Faces()), len(frustum.Faces()))
+	}
+}

--- a/kernel/brep/curved_halfspace_cone_side.go
+++ b/kernel/brep/curved_halfspace_cone_side.go
@@ -198,12 +198,18 @@ func fullConeSideBand(f curvedFace) (geom.Cone, coneSideBand_, bool) {
 // closed ellipse (oblique tilt steeper than the generators) to coneSideEllipseSplit, a hyperbola
 // branch (axis-parallel or shallow tilt) to coneSideSplit. A perpendicular circle is handled by the
 // fast cone path before the arrangement, so anything else here defers.
-func coneSideBandSplit(f curvedFace, curves []geom.Curve3, cone geom.Cone, _ coneSideBand_, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
+func coneSideBandSplit(f curvedFace, curves []geom.Curve3, cone geom.Cone, band coneSideBand_, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
 	if allEllipses(curves) {
 		return coneSideEllipseSplit(f, curves, cone, plane, n)
 	}
-	if allHyperbolas(curves) {
-		return coneSideSplit(f, curves, plane, n)
+	if !allHyperbolas(curves) {
+		return nil, nil, ErrUnsupportedHalfSpace
+	}
+	if isAxisParallel(n, cone) {
+		return coneSideSplit(f, curves, plane, n) // the symmetric constant-chord hyperbola (#1372/#1374)
+	}
+	if hyper, ok := curves[0].(geom.Hyperbola); ok && len(curves) == 1 {
+		return coneSideObliqueHyperbolaSplit(f, cone, hyper, band, plane, n) // an oblique (tilted) hyperbola
 	}
 	return nil, nil, ErrUnsupportedHalfSpace
 }

--- a/kernel/ops/boolean_cone_box_test.go
+++ b/kernel/ops/boolean_cone_box_test.go
@@ -221,6 +221,65 @@ func resultHasEllipticalEdge(b *topo.Body) bool {
 	return false
 }
 
+// Oblique cone ∩/− box, HYPERBOLIC tilt (Oblikovati/Oblikovati#1375): a frustum tilted so its axis is
+// (0.2,0,0.98) — shallower than the box's x=2 face relative to that axis — so the section is a HYPERBOLA
+// (vertex below the band, arms crossing both rims). Both directions must stay exact (an analytic cone
+// face, the hyperbolic cut edge), not fall back to CSG, and match OCC getMass. This is also the case that
+// composes only because the cap-seam crossing fix (the near-axial plane slices both caps through centre).
+
+func obliqueHyperbolaFrustum(t *testing.T) *topo.Body {
+	t.Helper()
+	b, err := brep.SolidCylinderCone(math.P3(0, 0, 0), math.P3(2, 0, 9.797958971), 3, 6, "frustum") // axis (0.2,0,0.98), h=10
+	if err != nil {
+		t.Fatalf("SolidCylinderCone: %v", err)
+	}
+	return b
+}
+
+func obliqueHyperbolaBox(t *testing.T) *topo.Body {
+	t.Helper()
+	b, err := brep.SolidBlock(math.P3(2, -20, -20), math.P3(40, 20, 40), "box") // only the x=2 face cuts
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	return b
+}
+
+// TestConeIntersectBoxObliqueHyperbolaExact keeps the +x wedge (x ≥ 2) of the tilted frustum — an exact
+// cone arc-band bounded by the hyperbola arms, no faceted soup.
+func TestConeIntersectBoxObliqueHyperbolaExact(t *testing.T) {
+	res, err := ops.Boolean(ops.Intersect, obliqueHyperbolaFrustum(t), obliqueHyperbolaBox(t))
+	if err != nil {
+		t.Fatalf("Boolean(Intersect): %v", err)
+	}
+	assertConeBoxExact(t, res)
+	if !resultHasHyperbolicEdge(res) {
+		t.Error("result carries no hyperbolic edge — the oblique cut was not imprinted as a hyperbola")
+	}
+}
+
+// TestConeCutBoxObliqueHyperbolaExact removes the +x wedge, leaving the rest — also exact.
+func TestConeCutBoxObliqueHyperbolaExact(t *testing.T) {
+	res, err := ops.Boolean(ops.Cut, obliqueHyperbolaFrustum(t), obliqueHyperbolaBox(t))
+	if err != nil {
+		t.Fatalf("Boolean(Cut): %v", err)
+	}
+	assertConeBoxExact(t, res)
+	if !resultHasHyperbolicEdge(res) {
+		t.Error("result carries no hyperbolic edge — the oblique cut was not imprinted as a hyperbola")
+	}
+}
+
+// resultHasHyperbolicEdge reports whether any edge of the body stores an analytic hyperbolic arc.
+func resultHasHyperbolicEdge(b *topo.Body) bool {
+	for _, e := range b.Edges() {
+		if _, ok := e.Geometry().(geom.HyperbolicArc); ok {
+			return true
+		}
+	}
+	return false
+}
+
 // frustumCapBeyondPlaneVolume integrates the area of each circular cross-section lying at x ≥ xCut for
 // a cone of slope tanα over z∈[z0,z1] (apex at z=z0−r0/tanα). A circle of radius r centred on the axis
 // has area r²·(θ − sinθ·cosθ) beyond a chord at distance xCut, θ = arccos(xCut/r) (0 when xCut ≥ r).

--- a/kernel/ops/boolean_csg_demotion_test.go
+++ b/kernel/ops/boolean_csg_demotion_test.go
@@ -120,7 +120,16 @@ func curvedExactCases() []curvedExactCase {
 		{"cone − box (vertex-inside flat)", ops.Cut, coneVertexInsideFlatBox},
 		{"cone ∩ box (oblique ellipse)", ops.Intersect, coneObliqueEllipseBox},
 		{"cone − box (oblique ellipse)", ops.Cut, coneObliqueEllipseBox},
+		{"cone ∩ box (oblique hyperbola)", ops.Intersect, coneObliqueHyperbolaBox},
+		{"cone − box (oblique hyperbola)", ops.Cut, coneObliqueHyperbolaBox},
 	}
+}
+
+// coneObliqueHyperbolaBox is a frustum tilted so its axis (0.2,0,0.98) is shallower than the box's x=2
+// face relative to that axis — the oblique HYPERBOLA section (vertex below the band, arms crossing both
+// rims), the case that also exercises the cap-seam crossing fix (Oblikovati/Oblikovati#1375).
+func coneObliqueHyperbolaBox(t *testing.T) (*topo.Body, *topo.Body) {
+	return demoCone(t, math.P3(0, 0, 0), math.P3(2, 0, 9.797958971), 3, 6), demoBlock(t, math.P3(2, -20, -20), math.P3(40, 20, 40))
 }
 
 // coneObliqueEllipseBox is a frustum tilted so its axis is (0,0.6,0.8) and an axis-aligned box whose

--- a/kernel/ops/testdata/occ_boolean_oracle.json
+++ b/kernel/ops/testdata/occ_boolean_oracle.json
@@ -16,5 +16,7 @@
   "cone ∩ box (vertex-inside flat)": 31.78157847,
   "cone − box (vertex-inside flat)": 627.9528788,
   "cone ∩ box (oblique ellipse)": 410.117045,
-  "cone − box (oblique ellipse)": 249.6174126
+  "cone − box (oblique ellipse)": 249.6174126,
+  "cone ∩ box (oblique hyperbola)": 250.308012,
+  "cone − box (oblique hyperbola)": 409.4264453
 }


### PR DESCRIPTION
Part of #1375 (third slice — the hyperbolic oblique tilt). Builds on slice 1 (#1377, analytic conic), slice 2 (#1378, elliptic tilt), and the `loopedSplit` cap-seam fix (#1379).

## What & why
A box face tilted **shallower** than the cone's generators (but not axis-parallel) cuts the frustum side in a **hyperbola** — like the axis-parallel case (#1372) but tilted, symmetric about the `{axis, normal}` meridian. This slice imprints and splits the cone side by it, so `cone ∩/− box` with an oblique hyperbolic face is **exact** (analytic cone face + hyperbolic cut edge) instead of faceted CSG.

## How
- `coneSideObliqueHyperbolaSplit` (`kernel/brep/curved_halfspace_cone_oblique_hyperbola.go`) reuses `coneArcBand`'s proven winding (bottom arc CCW from `u_n+φ`, top CW, two hyperbola arms between), but because an oblique plane's chord distance **varies with apex distance**, it takes the per-rim half-angle `φ` from the **actual rim crossings**: apex distance along a +nappe arm is monotonic in `θ`, so `hyperThetaAtApexDist` root-finds where each arm meets each rim.
- `bandSideOfPlane` keeps the side **whole / drops it** when the section lies on the infinite cone beyond the frustum (a far box face) — what lets the other box faces compose in `Intersect`.
- `coneSideBandSplit` now routes an **axis-parallel** hyperbola to `coneSideSplit` (#1372/#1374) and a **tilted** one to the new split.
- Composing the box `Intersect` needs the near-axial plane to slice **both caps through their centres** — which only works because of the cap-seam crossing fix (#1379, `closedEdgeCrossings`). This slice is the consumer that motivated that fix.

## Validation
- **OCC `getMass` oracle**: `cone ∩ box (oblique hyperbola)` and `cone − box (oblique hyperbola)` match **250.31** and **409.43** within ~1.4% (chord deficit); both added to `TestCurvedBooleansStayExact` and `TestCurvedBooleanVolumesMatchOCC`.
- Watertight & manifold both directions; brep tests for the single-plane cut, a clearing plane (whole/empty), and a **vertex-inside-band defer**.
- Full kernel suite green; lint clean; package coverage 90.3%.

## Still deferred (tracked on #1375)
- A **vertex inside the band** (the oblique analogue of #1374) — defers cleanly to CSG.
- The **parabolic** boundary tilt (needs a new `geom.Parabola` curve type).
- An oblique face that **clips a rim** — defers cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)