### PR TITLE
[M2] exact cone ∩/− box with a parabolic (boundary-tilt) face (#1375 slice 4)

### DIFF
--- a/kernel/brep/curved_halfspace_cone_oblique_conic.go
+++ b/kernel/brep/curved_halfspace_cone_oblique_conic.go
@@ -9,35 +9,40 @@ import (
 	"oblikovati.org/math"
 )
 
-// Cone-side oblique-hyperbolic split (M2 Phase-1 follow-up, Oblikovati/Oblikovati#1375). An OBLIQUE box
-// face tilted SHALLOWER than the cone's generators (but not parallel to the axis) cuts the frustum side
-// in a HYPERBOLA — like the axis-parallel case (#1372) but tilted, so the section is symmetric about the
-// {axis, normal} meridian rather than a constant-distance chord. Its two arms still climb from one rim to
-// the other, so the kept band is an ARC-BAND bounded by the two arms plus the kept arcs of the rims.
+// Cone-side oblique-conic split (M2 Phase-1 follow-up, Oblikovati/Oblikovati#1375). An OBLIQUE box face
+// that is NOT axis-parallel cuts the frustum side in an open conic ARM — a HYPERBOLA (tilt shallower than
+// the cone's generators) or a PARABOLA (tilt parallel to a generator, the boundary between the elliptic
+// and hyperbolic regimes). Both are like the axis-parallel hyperbola (#1372) but tilted, symmetric about
+// the {axis, normal} meridian rather than a constant-distance chord; their two arms still climb from one
+// rim to the other, so the kept band is an ARC-BAND bounded by the two arms plus the kept arcs of the rims.
 //
 // coneArcBand (#1372) builds that band from a CONSTANT chord half-angle φ=arccos(−d/r); here the chord
 // distance varies with apex distance, so this finds the rim crossings by ROOT-FINDING (the apex distance
-// along a hyperbola arm is monotonic, so each arm crosses each rim once) and reuses coneArcBand's winding
-// with the per-rim φ taken from the ACTUAL crossing azimuths. The vertex-below-band arrangement (the arms
-// cross BOTH rims) is handled; a vertex inside the band, or arms that miss a rim, defer to CSG.
+// along a +nappe arm is monotonic in the conic's parameter, so each arm crosses each rim once) and reuses
+// coneArcBand's winding with the per-rim φ taken from the ACTUAL crossing azimuths. The vertex-below-band
+// arrangement (the arms cross BOTH rims) is handled; a vertex inside the band, or arms that miss a rim,
+// defer to CSG.
 
-// coneSideObliqueHyperbolaSplit splits a full periodic frustum side by an oblique plane whose section is
-// one hyperbola branch whose vertex sits below the band (both arms cross both rims). It returns the kept
-// arc-band sub-face and the two hyperbola arms (reversed, for the lid). A plane that clears the band
-// keeps the side whole or drops it; a vertex inside the band or arms missing a rim defer.
-func coneSideObliqueHyperbolaSplit(f curvedFace, cone geom.Cone, hyper geom.Hyperbola, band coneSideBand_, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
+// coneSideObliqueConicSplit splits a full periodic frustum side by an oblique plane whose section is one
+// open conic ARM — a hyperbola branch (tilt shallower than the generators) or a parabola (tilt parallel
+// to a generator) — whose vertex sits below the band, so both arms cross both rims. It returns the kept
+// arc-band sub-face and the two conic arms (reversed, for the lid). A plane that clears the band keeps
+// the side whole or drops it; a vertex inside the band or arms missing a rim defer. conic must have its
+// vertex at parameter 0 with apex distance even & monotonic in the parameter (true of both sections,
+// each symmetric about the {axis, normal} meridian).
+func coneSideObliqueConicSplit(f curvedFace, cone geom.Cone, conic geom.Curve3, band coneSideBand_, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
 	if side := bandSideOfPlane(cone, band, plane, n); side != 0 {
 		return coneSideWholeOrEmpty(f, float64(side)), nil, nil // the plane clears the side: whole or empty
 	}
-	if apexDistOf(cone, hyper.PointAt(0)) >= band.vMin-cylinderAxisTol {
+	if apexDistOf(cone, conic.PointAt(0)) >= band.vMin-cylinderAxisTol {
 		return nil, nil, ErrUnsupportedHalfSpace // vertex inside the band (oblique #1374 analogue): deferred
 	}
-	thetaBot, okB := hyperThetaAtApexDist(hyper, cone, band.vMin)
-	thetaTop, okT := hyperThetaAtApexDist(hyper, cone, band.vMax)
+	paramBot, okB := conicParamAtApexDist(conic, cone, band.vMin)
+	paramTop, okT := conicParamAtApexDist(conic, cone, band.vMax)
 	if !okB || !okT {
 		return nil, nil, ErrUnsupportedHalfSpace // an arm does not reach a rim: an unhandled arrangement
 	}
-	loop, section := obliqueHyperbolaBand(cone, hyper, band, thetaBot, thetaTop, n)
+	loop, section := obliqueConicBand(cone, conic, band, paramBot, paramTop, n)
 	if loop == nil {
 		return nil, nil, ErrUnsupportedHalfSpace
 	}
@@ -45,24 +50,25 @@ func coneSideObliqueHyperbolaSplit(f curvedFace, cone geom.Cone, hyper geom.Hype
 	return []curvedFace{kept}, section, nil
 }
 
-// obliqueHyperbolaBand builds the kept band the SAME way coneArcBand (#1372) does — bottom arc CCW from
-// u_n+φ_B over the major arc, top arc CW, the two hyperbola arms between them — but the per-rim half-angle
-// φ comes from the ACTUAL rim crossing (root-found) instead of the constant-chord arccos(−d/r), because
-// an oblique plane's chord distance varies with apex distance. u_n is the meridian azimuth toward the
-// plane; the crossings sit symmetrically at u_n±φ, so the kept (negative-side) band is the major arc away
-// from u_n, identical in winding to the axis-parallel band so it composes with the cap chords.
-func obliqueHyperbolaBand(cone geom.Cone, hyper geom.Hyperbola, band coneSideBand_, thetaBot, thetaTop float64, n math.Vector3) ([]loopEdge, []loopEdge) {
+// obliqueConicBand builds the kept band the SAME way coneArcBand (#1372) does — bottom arc CCW from
+// u_n+φ_B over the major arc, top arc CW, the two conic arms between them — but the per-rim half-angle φ
+// comes from the ACTUAL rim crossing (root-found) instead of the constant-chord arccos(−d/r), because an
+// oblique plane's chord distance varies with apex distance. u_n is the meridian azimuth toward the
+// plane; the crossings sit symmetrically at u_n±φ, so the kept (negative-side) band is the major arc
+// away from u_n, identical in winding to the axis-parallel band so it composes with the cap chords. The
+// conic parameter ±param gives the two symmetric arms (the section is even about the meridian).
+func obliqueConicBand(cone geom.Cone, conic geom.Curve3, band coneSideBand_, paramBot, paramTop float64, n math.Vector3) ([]loopEdge, []loopEdge) {
 	axis, ref := cone.AxisDir.AsVector(), cone.Ref.AsVector()
 	uN := coneAngleOf(cone, n)
-	phiB := crossingHalfAngle(cone, hyper.PointAt(thetaBot), uN)
-	phiT := crossingHalfAngle(cone, hyper.PointAt(thetaTop), uN)
+	phiB := crossingHalfAngle(cone, conic.PointAt(paramBot), uN)
+	phiT := crossingHalfAngle(cone, conic.PointAt(paramTop), uN)
 	bottomArc, errB := geom.NewArc3d(band.bottom, axis, ref, band.rBot, uN+phiB, 2*stdmath.Pi-2*phiB)
 	topArc, errT := geom.NewArc3d(band.top, axis, ref, band.rTop, uN-phiT, -(2*stdmath.Pi - 2*phiT))
 	if errB != nil || errT != nil {
 		return nil, nil
 	}
-	armA := hyperbolaArm(hyper, bottomArc.PointAt(1), topArc.PointAt(0)) // −φ side, bottom→top
-	armB := hyperbolaArm(hyper, topArc.PointAt(1), bottomArc.PointAt(0)) // +φ side, top→bottom
+	armA := conicArm(conic, bottomArc.PointAt(1), topArc.PointAt(0)) // −φ side, bottom→top
+	armB := conicArm(conic, topArc.PointAt(1), bottomArc.PointAt(0)) // +φ side, top→bottom
 	loop := []loopEdge{{curve: bottomArc, t0: 0, t1: 1}, armA, {curve: topArc, t0: 0, t1: 1}, armB}
 	return loop, []loopEdge{reverseEdge(armA), reverseEdge(armB)}
 }
@@ -119,12 +125,13 @@ func apexDistOf(cone geom.Cone, p math.Point3) float64 {
 	return float64(cone.Apex.VectorTo(p).Dot(cone.AxisDir.AsVector()))
 }
 
-// hyperThetaAtApexDist returns the positive hyperbola parameter θ where the arm reaches apex distance
-// target. Apex distance grows monotonically with θ along a +nappe arm, so it brackets then bisects.
-// ok=false if no θ up to a large bound reaches the target (the arm never gets that far up the cone).
-func hyperThetaAtApexDist(hyper geom.Hyperbola, cone geom.Cone, target float64) (float64, bool) {
+// conicParamAtApexDist returns the positive conic parameter where the arm reaches apex distance target.
+// Apex distance grows monotonically with the parameter along a +nappe arm (v=A·coshθ for a hyperbola,
+// v∝t² for a parabola), so it brackets then bisects. ok=false if no parameter up to a large bound
+// reaches the target (the arm never gets that far up the cone).
+func conicParamAtApexDist(conic geom.Curve3, cone geom.Cone, target float64) (float64, bool) {
 	lo, hi := 0.0, 0.5
-	for apexDistOf(cone, hyper.PointAt(hi)) < target {
+	for apexDistOf(cone, conic.PointAt(hi)) < target {
 		hi *= 2
 		if hi > 1e4 {
 			return 0, false
@@ -132,7 +139,7 @@ func hyperThetaAtApexDist(hyper geom.Hyperbola, cone geom.Cone, target float64) 
 	}
 	for i := 0; i < 80; i++ {
 		mid := (lo + hi) / 2
-		if apexDistOf(cone, hyper.PointAt(mid)) < target {
+		if apexDistOf(cone, conic.PointAt(mid)) < target {
 			lo = mid
 		} else {
 			hi = mid

--- a/kernel/brep/curved_halfspace_cone_parabola_test.go
+++ b/kernel/brep/curved_halfspace_cone_parabola_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// The boundary tilt — a plane PARALLEL to a generator — cuts the frustum side in a parabola (the limit
+// between the elliptic and hyperbolic sections). The kept side is an exact cone arc-band bounded by the
+// two parabola arms, watertight (Oblikovati/Oblikovati#1375). A frustum whose axis is tilted by its own
+// half-angle has one generator vertical, so an axis-aligned x-plane is parallel to it.
+func TestConeSideHalfSpaceParabola(t *testing.T) {
+	a := stdmath.Atan(0.3)
+	top := math.P3(math.Scalar(stdmath.Sin(a)*10), 0, math.Scalar(stdmath.Cos(a)*10))
+	frustum := mustFrustum(t, math.P3(0, 0, 0), top, 3, 6)
+	plane, err := geom.NewPlane(math.P3(2, 0, 0), math.V3(1, 0, 0)) // x=2, parallel to the vertical generator
+	if err != nil {
+		t.Fatalf("NewPlane: %v", err)
+	}
+	res, err := HalfSpaceCut(frustum, plane)
+	if err != nil {
+		t.Fatalf("HalfSpaceCut: %v", err)
+	}
+	assertWatertight(t, res)
+	if cones, _, _ := faceTypeCounts(t, res); cones != 1 {
+		t.Errorf("got %d cone faces, want 1", cones)
+	}
+	if !anyFaceHasParabola(res) {
+		t.Error("no parabolic edge — the boundary-tilt cut was not imprinted as a parabola")
+	}
+}
+
+func anyFaceHasParabola(b *topo.Body) bool {
+	for _, f := range b.Faces() {
+		for _, l := range f.Loops() {
+			for _, u := range l.EdgeUses() {
+				if _, ok := u.Edge().Geometry().(geom.ParabolicArc); ok {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/kernel/brep/curved_halfspace_cone_side.go
+++ b/kernel/brep/curved_halfspace_cone_side.go
@@ -112,8 +112,8 @@ func coneArcBand(f curvedFace, cone geom.Cone, hyper geom.Hyperbola, band coneSi
 	if err != nil {
 		return nil, nil, ErrUnsupportedHalfSpace
 	}
-	armA := hyperbolaArm(hyper, bottomArc.PointAt(1), topArc.PointAt(0)) // −φ side, bottom→top
-	armB := hyperbolaArm(hyper, topArc.PointAt(1), bottomArc.PointAt(0)) // +φ side, top→bottom
+	armA := conicArm(hyper, bottomArc.PointAt(1), topArc.PointAt(0)) // −φ side, bottom→top
+	armB := conicArm(hyper, topArc.PointAt(1), bottomArc.PointAt(0)) // +φ side, top→bottom
 	loop := []loopEdge{{curve: bottomArc, t0: 0, t1: 1}, armA, {curve: topArc, t0: 0, t1: 1}, armB}
 	kept := curvedFace{surface: cone, reversed: f.reversed, lineage: f.lineage, loops: []curvedLoop{{edges: loop}}}
 	section := []loopEdge{reverseEdge(armA), reverseEdge(armB)}
@@ -141,9 +141,9 @@ func coneSideVertexInside(f curvedFace, cone geom.Cone, hyper geom.Hyperbola, ba
 	if err != nil {
 		return nil, nil, ErrUnsupportedHalfSpace
 	}
-	vertex := hyper.PointAt(0)                                // the branch vertex sits on the cone at apex distance |d|/tanα
-	armDown := hyperbolaArm(hyper, topArc.PointAt(1), vertex) // top rim → vertex
-	armUp := hyperbolaArm(hyper, vertex, topArc.PointAt(0))   // vertex → top rim
+	vertex := hyper.PointAt(0)                            // the branch vertex sits on the cone at apex distance |d|/tanα
+	armDown := conicArm(hyper, topArc.PointAt(1), vertex) // top rim → vertex
+	armUp := conicArm(hyper, vertex, topArc.PointAt(0))   // vertex → top rim
 	notched := []loopEdge{{curve: topArc, t0: 0, t1: 1}, armDown, armUp}
 	section := []loopEdge{reverseEdge(armDown), reverseEdge(armUp)}
 	return coneVertexInsideFaces(f, cone, band, d, notched), section, nil
@@ -160,12 +160,13 @@ func coneVertexInsideFaces(f curvedFace, cone geom.Cone, band coneSideBand_, d f
 	return []curvedFace{{surface: cone, reversed: f.reversed, lineage: f.lineage, loops: loops}}
 }
 
-// hyperbolaArm builds the loop edge along the hyperbola branch from start to end, its parameters the
-// θ values the branch inverse gives at the two rim feet (a hyperbola loop edge's t0/t1 are θ).
-func hyperbolaArm(hyper geom.Hyperbola, start, end math.Point3) loopEdge {
-	t0, _ := geom.CurveParamAtPoint3(hyper, start)
-	t1, _ := geom.CurveParamAtPoint3(hyper, end)
-	return loopEdge{curve: hyper, t0: t0, t1: t1}
+// conicArm builds the loop edge along an open conic section (a hyperbola branch or a parabola) from
+// start to end, its parameters the conic's own parameter values at the two rim feet (the loop edge's
+// t0/t1 are the curve parameter — θ for a hyperbola, the cross coordinate t for a parabola).
+func conicArm(conic geom.Curve3, start, end math.Point3) loopEdge {
+	t0, _ := geom.CurveParamAtPoint3(conic, start)
+	t1, _ := geom.CurveParamAtPoint3(conic, end)
+	return loopEdge{curve: conic, t0: t0, t1: t1}
 }
 
 // coneAngleOf returns the angle of a direction (here the cut-plane normal, which lies in the cone's
@@ -194,24 +195,36 @@ func fullConeSideBand(f curvedFace) (geom.Cone, coneSideBand_, bool) {
 	return cone, band, true
 }
 
-// coneSideBandSplit routes a genuine full cone side by the section type the cut plane produces: a
-// closed ellipse (oblique tilt steeper than the generators) to coneSideEllipseSplit, a hyperbola
-// branch (axis-parallel or shallow tilt) to coneSideSplit. A perpendicular circle is handled by the
-// fast cone path before the arrangement, so anything else here defers.
+// coneSideBandSplit routes a genuine full cone side by the section type the cut plane produces: a closed
+// ellipse (oblique tilt steeper than the generators) to coneSideEllipseSplit; an AXIS-PARALLEL hyperbola
+// to the constant-chord coneSideSplit (#1372/#1374); an OBLIQUE open conic — a tilted hyperbola or a
+// parabola (the boundary tilt) — to the root-finding coneSideObliqueConicSplit. A perpendicular circle
+// is handled by the fast cone path before the arrangement, so anything else defers.
 func coneSideBandSplit(f curvedFace, curves []geom.Curve3, cone geom.Cone, band coneSideBand_, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
 	if allEllipses(curves) {
 		return coneSideEllipseSplit(f, curves, cone, plane, n)
 	}
-	if !allHyperbolas(curves) {
-		return nil, nil, ErrUnsupportedHalfSpace
-	}
-	if isAxisParallel(n, cone) {
+	if allHyperbolas(curves) && isAxisParallel(n, cone) {
 		return coneSideSplit(f, curves, plane, n) // the symmetric constant-chord hyperbola (#1372/#1374)
 	}
-	if hyper, ok := curves[0].(geom.Hyperbola); ok && len(curves) == 1 {
-		return coneSideObliqueHyperbolaSplit(f, cone, hyper, band, plane, n) // an oblique (tilted) hyperbola
+	if conic, ok := obliqueConicArm(curves); ok {
+		return coneSideObliqueConicSplit(f, cone, conic, band, plane, n) // an oblique hyperbola or parabola
 	}
 	return nil, nil, ErrUnsupportedHalfSpace
+}
+
+// obliqueConicArm returns the single open conic section (hyperbola branch or parabola) an oblique plane
+// cuts from the cone side, ok=false otherwise. Both are routed to the same root-finding arc-band split.
+func obliqueConicArm(curves []geom.Curve3) (geom.Curve3, bool) {
+	if len(curves) != 1 {
+		return nil, false
+	}
+	switch curves[0].(type) {
+	case geom.Hyperbola, geom.Parabola:
+		return curves[0], true
+	default:
+		return nil, false
+	}
 }
 
 // allHyperbolas reports whether every imprint curve is a hyperbola branch (the axis-parallel cut of a

--- a/kernel/brep/curved_halfspace_looped.go
+++ b/kernel/brep/curved_halfspace_looped.go
@@ -327,8 +327,9 @@ func bridgeAlong(f curvedFace, c geom.Curve3, exit, entry math.Point3) (loopEdge
 	if _, isLine := c.(geom.Line); isLine {
 		return loopEdge{curve: c, t0: tExit, t1: tEntry}, true
 	}
-	if _, isHyp := c.(geom.Hyperbola); isHyp {
-		return loopEdge{curve: c, t0: tExit, t1: tEntry}, true // a hyperbola branch is simple: bridge by θ range
+	switch c.(type) {
+	case geom.Hyperbola, geom.Parabola:
+		return loopEdge{curve: c, t0: tExit, t1: tEntry}, true // an open conic arm is simple: bridge by its param range
 	}
 	for _, t1 := range arcCandidates(tExit, tEntry) {
 		cand := loopEdge{curve: c, t0: tExit, t1: t1}

--- a/kernel/brep/curved_stitch.go
+++ b/kernel/brep/curved_stitch.go
@@ -131,6 +131,8 @@ func edgeCurveFor(le loopEdge) geom.Curve3 {
 		return geom.NewLineSegment(le.start(), le.end())
 	case geom.Hyperbola:
 		return c.Arc(le.t0, le.t1) // a hyperbola loop edge's params are θ; the bounded arc is what the edge stores
+	case geom.Parabola:
+		return c.Arc(le.t0, le.t1) // a parabola loop edge's params are the cross coordinate t; store the bounded arc
 	case geom.EllipticalArc:
 		return c // the re-anchored elliptical rim/lid of an oblique cone cut tessellates over its sweep
 	default:

--- a/kernel/geom/evaluator_point3.go
+++ b/kernel/geom/evaluator_point3.go
@@ -27,14 +27,36 @@ func CurveParamAtPoint3(c Curve3, p math.Point3) (float64, SolutionNature) {
 		return arcParamAtPoint3(g, p)
 	case Polyline:
 		return polylineParamAtPoint3(g, p)
+	case Hyperbola, HyperbolicArc, Parabola, ParabolicArc:
+		return openConicParamAtPoint3(c, p)
+	default:
+		return genericParamAtPoint3(c, p)
+	}
+}
+
+// openConicParamAtPoint3 inverts an open conic section (hyperbola branch or parabola) at a point on it:
+// the unbounded curve maps to its native parameter, the bounded arc rescales that onto [0, 1].
+func openConicParamAtPoint3(c Curve3, p math.Point3) (float64, SolutionNature) {
+	switch g := c.(type) {
 	case Hyperbola:
 		return hyperbolaThetaAtPoint3(g.Center, g.ConjugateAxis.AsVector(), g.B, p), UniqueSolution
 	case HyperbolicArc:
 		theta := hyperbolaThetaAtPoint3(g.Center, g.ConjugateAxis.AsVector(), g.B, p)
 		return (theta - g.Theta0) / (g.Theta1 - g.Theta0), UniqueSolution
+	case Parabola:
+		return parabolaTAtPoint3(g.Vertex, g.CrossDir.AsVector(), p), UniqueSolution
+	case ParabolicArc:
+		t := parabolaTAtPoint3(g.Vertex, g.CrossDir.AsVector(), p)
+		return (t - g.T0) / (g.T1 - g.T0), UniqueSolution
 	default:
-		return genericParamAtPoint3(c, p)
+		return 0, UniqueSolution
 	}
+}
+
+// parabolaTAtPoint3 inverts a parabola: the parameter t is the cross coordinate directly (x along
+// CrossDir), so a point on the curve maps back by projecting onto CrossDir.
+func parabolaTAtPoint3(vertex math.Point3, cross math.Vector3, p math.Point3) float64 {
+	return float64(vertex.VectorTo(p).Dot(cross))
 }
 
 // hyperbolaThetaAtPoint3 inverts a hyperbola branch: with the conjugate coordinate y = B·sinh(θ),
@@ -240,7 +262,7 @@ func refineClosest3(c Curve3, p math.Point3, t, lo, hi float64) float64 {
 // (enclosing but not minimal), ±Inf faces for an unbounded line.
 func CurveRangeBox3(c Curve3) math.Box {
 	switch g := c.(type) {
-	case Line, Hyperbola:
+	case Line, Hyperbola, Parabola:
 		inf := stdmath.Inf(1)
 		return math.Box{Min: math.P3(-inf, -inf, -inf), Max: math.P3(inf, inf, inf)}
 	case LineSegment:

--- a/kernel/geom/intersect_cone_oblique.go
+++ b/kernel/geom/intersect_cone_oblique.go
@@ -43,13 +43,22 @@ type conic2D struct {
 }
 
 // curve3 classifies the conic by its quadratic-form eigenvalues and lifts it to the analytic 3D curve:
-// a same-sign pair is an ellipse, an opposite-sign pair a hyperbola (the branch on the cone's nappe),
-// a (near-)zero eigenvalue a parabola — deferred. handled=false on the parabolic boundary or a
-// degenerate/empty section so the caller keeps the numeric-tracer fallback.
+// a same-sign pair is an ellipse, an opposite-sign pair a hyperbola (the branch on the cone's nappe), a
+// single (near-)zero eigenvalue a parabola. handled=false only on a fully degenerate section (both
+// eigenvalues zero, or the parabola collapses to parallel lines), where the caller keeps the fallback.
 func (q conic2D) curve3(o math.Point3, e1, e2, n, axis math.Vector3, apex math.Point3) ([]Curve3, bool) {
 	l1, l2, u1, u2 := symmetricEig2(q.a, q.b/2, q.c)
-	if stdmath.Abs(l1) < 1e-9 || stdmath.Abs(l2) < 1e-9 {
-		return nil, false // a (near-)zero eigenvalue: the parabolic tilt, deferred to the tracer
+	dir1 := e1.Scale(math.Scalar(u1[0])).Add(e2.Scale(math.Scalar(u1[1])))
+	dir2 := e1.Scale(math.Scalar(u2[0])).Add(e2.Scale(math.Scalar(u2[1])))
+	z1, z2 := stdmath.Abs(l1) < 1e-9, stdmath.Abs(l2) < 1e-9
+	if z1 && z2 {
+		return nil, false // both eigenvalues zero: a fully degenerate section
+	}
+	if z2 { // λ1 is the nonzero (cross) eigenvalue, dir2 the parabola's opening (zero) direction
+		return obliqueParabola(o, l1, u1, u2, dir1, dir2, q)
+	}
+	if z1 {
+		return obliqueParabola(o, l2, u2, u1, dir2, dir1, q)
 	}
 	s0, t0, ok := q.center()
 	if !ok {
@@ -57,12 +66,36 @@ func (q conic2D) curve3(o math.Point3, e1, e2, n, axis math.Vector3, apex math.P
 	}
 	center := o.TranslateBy(e1.Scale(math.Scalar(s0))).TranslateBy(e2.Scale(math.Scalar(t0)))
 	f0 := q.f + 0.5*(q.d*s0+q.e*t0) // the conic value at its centre: λ1·u²+λ2·v²=−f0 in principal axes
-	dir1 := e1.Scale(math.Scalar(u1[0])).Add(e2.Scale(math.Scalar(u1[1])))
-	dir2 := e1.Scale(math.Scalar(u2[0])).Add(e2.Scale(math.Scalar(u2[1])))
 	if l1*l2 > 0 {
 		return obliqueEllipse(center, n, l1, l2, f0, dir1, dir2)
 	}
 	return obliqueHyperbola(center, l1, l2, f0, dir1, dir2, axis, apex)
+}
+
+// obliqueParabola builds the parabolic section (plane parallel to a generator, the boundary tilt). In
+// principal coords with the zero-eigenvalue direction w the conic is λ·u²+d_u·u+d_w·w+f=0 (no w²
+// term), so w = quadratic(u): a parabola with cross axis u (crossDir), opening along w (zeroDir). Its
+// vertex is at u*=−d_u/(2λ), w*=(d_u²/(4λ)−f)/d_w; the shape coefficient k=−λ/d_w gives the focal
+// length f=1/(4|k|) and orients the opening. d_w≈0 means the section is two parallel lines — deferred.
+func obliqueParabola(o math.Point3, lam float64, crossEig, zeroEig [2]float64, crossDir, zeroDir math.Vector3, q conic2D) ([]Curve3, bool) {
+	duP := q.d*crossEig[0] + q.e*crossEig[1]
+	dwP := q.d*zeroEig[0] + q.e*zeroEig[1]
+	if stdmath.Abs(dwP) < 1e-12 {
+		return nil, false // the quadratic in u has no linear w term: parallel lines, not a parabola
+	}
+	uStar := -duP / (2 * lam)
+	wStar := (duP*duP/(4*lam) - q.f) / dwP
+	vertex := o.TranslateBy(crossDir.Scale(math.Scalar(uStar))).TranslateBy(zeroDir.Scale(math.Scalar(wStar)))
+	k := -lam / dwP
+	axisDir := zeroDir
+	if k < 0 {
+		axisDir = zeroDir.Scale(-1) // open toward +w when k>0, −w when k<0
+	}
+	par, err := NewParabola(vertex, axisDir, crossDir, 1/(4*stdmath.Abs(k)))
+	if err != nil {
+		return nil, false
+	}
+	return []Curve3{par}, true
 }
 
 // center solves the 2×2 system [[a, b/2],[b/2, c]]·[s0,t0] = −[d/2, e/2] for the conic's centre in

--- a/kernel/geom/intersect_cone_oblique_test.go
+++ b/kernel/geom/intersect_cone_oblique_test.go
@@ -52,13 +52,23 @@ func TestPlaneConeObliqueHyperbola(t *testing.T) {
 	}
 }
 
-// The parabolic boundary tilt (plane parallel to a generator, φ = α) is the measure-zero degenerate
-// case and is deferred to the numeric tracer (handled=false), as #1375 allows.
-func TestPlaneConeParabolaDeferred(t *testing.T) {
-	cone, _ := NewCone(math.P3(0, 0, 0), math.V3(0, 0, 1), stdmath.Pi/4) // α = 45°
-	pl, _ := NewPlane(math.P3(0, 0, 3), math.V3(1, 0, 1))                // normal at 45° → plane ∥ a generator
-	if _, handled := IntersectSurfacesAnalytic(pl, cone); handled {
-		t.Error("parabolic tilt should defer (handled=false)")
+// The parabolic boundary tilt (plane parallel to a generator, φ = α) cuts an exact PARABOLA; every
+// sampled point lies on both the cone and the plane (Oblikovati/Oblikovati#1375). A cone whose axis is
+// tilted by its own half-angle has one generator vertical, so an axis-aligned x-plane is parallel to it.
+func TestPlaneConeParabola(t *testing.T) {
+	a := stdmath.Atan(0.3)
+	cone, _ := NewCone(math.P3(0, 0, 0), math.V3(stdmath.Sin(a), 0, stdmath.Cos(a)), a)
+	pl, _ := NewPlane(math.P3(2, 0, 0), math.V3(1, 0, 0)) // x=2, parallel to the vertical generator
+	curves, handled := IntersectSurfacesAnalytic(pl, cone)
+	if !handled || len(curves) != 1 {
+		t.Fatalf("imprint handled=%v curves=%d, want one curve", handled, len(curves))
+	}
+	par, ok := curves[0].(Parabola)
+	if !ok {
+		t.Fatalf("imprint curve is %T, want Parabola", curves[0])
+	}
+	for _, tt := range []float64{-3, -1, 0, 1, 3} {
+		assertOnConeAndPlane(t, cone, pl, par.PointAt(tt))
 	}
 }
 

--- a/kernel/geom/parabola.go
+++ b/kernel/geom/parabola.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// Parabola is an infinite 3D parabola (the conic a plane PARALLEL to a cone generator cuts from it —
+// the boundary tilt between the elliptic and hyperbolic sections, M2 Phase-1 follow-up,
+// Oblikovati/Oblikovati#1375). It lies in the plane through Vertex spanned by the orthonormal AxisDir
+// (the axis of symmetry, toward which the curve opens) and CrossDir. Parameterized by the cross
+// coordinate t (the standard y = x²/4f form, x along CrossDir, y along AxisDir):
+//
+//	P(t) = Vertex + t·CrossDir + (t²/(4·Focal))·AxisDir
+//
+// so t=0 is the vertex and |t|→∞ runs out the two arms. Like [Hyperbola] it is unbounded (Domain
+// ±Inf, parameter t directly); the bounded edge a face stores is a [ParabolicArc]. Focal is the focal
+// length (the distance from vertex to focus).
+type Parabola struct {
+	Vertex   math.Point3
+	AxisDir  math.UnitVector3
+	CrossDir math.UnitVector3
+	Focal    float64
+}
+
+// NewParabola builds a parabola. axis and cross are normalized, and cross is re-orthogonalized against
+// axis (its component along axis is dropped). Errors on a zero axis, a non-positive focal length, or
+// axes that are parallel.
+func NewParabola(vertex math.Point3, axis, cross math.Vector3, focal float64) (Parabola, error) {
+	if focal <= 0 {
+		return Parabola{}, fmt.Errorf("geom: parabola focal length %g must be positive", focal)
+	}
+	au, err := math.UnitVector3FromVector(axis)
+	if err != nil {
+		return Parabola{}, fmt.Errorf("geom: parabola axis %v is zero", axis)
+	}
+	cv := cross.Sub(au.AsVector().Scale(cross.Dot(au.AsVector())))
+	cu, err := math.UnitVector3FromVector(cv)
+	if err != nil {
+		return Parabola{}, fmt.Errorf("geom: parabola cross axis %v is parallel to axis %v", cross, axis)
+	}
+	return Parabola{Vertex: vertex, AxisDir: au, CrossDir: cu, Focal: focal}, nil
+}
+
+// PointAt returns the parabola point at cross coordinate t (the parameter t is t).
+func (p Parabola) PointAt(t float64) math.Point3 {
+	return parabolaPoint(p.Vertex, p.AxisDir.AsVector(), p.CrossDir.AsVector(), p.Focal, t)
+}
+
+// TangentAt returns dP/dt = CrossDir + (t/(2·Focal))·AxisDir.
+func (p Parabola) TangentAt(t float64) math.Vector3 {
+	return parabolaTangent(p.AxisDir.AsVector(), p.CrossDir.AsVector(), p.Focal, t)
+}
+
+// Domain returns the full real line, as a Parabola is unbounded.
+func (p Parabola) Domain() (lo, hi float64) { return stdmath.Inf(-1), stdmath.Inf(1) }
+
+// Arc restricts the parabola to [t0, t1], the bounded curve stored on a trimmed face edge.
+func (p Parabola) Arc(t0, t1 float64) ParabolicArc {
+	return ParabolicArc{Vertex: p.Vertex, AxisDir: p.AxisDir, CrossDir: p.CrossDir, Focal: p.Focal, T0: t0, T1: t1}
+}
+
+// ParabolicArc is a bounded segment of a [Parabola], parameterized s∈[0,1] mapping to t = T0 +
+// s·(T1−T0) — the edge curve a trimmed cone face stores (as LineSegment is to Line). T0 may exceed T1
+// to run the arc in the opposite direction.
+type ParabolicArc struct {
+	Vertex   math.Point3
+	AxisDir  math.UnitVector3
+	CrossDir math.UnitVector3
+	Focal    float64
+	T0, T1   float64
+}
+
+// PointAt returns the point at parameter s∈[0,1].
+func (p ParabolicArc) PointAt(s float64) math.Point3 {
+	t := p.T0 + s*(p.T1-p.T0)
+	return parabolaPoint(p.Vertex, p.AxisDir.AsVector(), p.CrossDir.AsVector(), p.Focal, t)
+}
+
+// TangentAt returns dP/ds (chain rule: dP/dt scaled by the t-span).
+func (p ParabolicArc) TangentAt(s float64) math.Vector3 {
+	t := p.T0 + s*(p.T1-p.T0)
+	return parabolaTangent(p.AxisDir.AsVector(), p.CrossDir.AsVector(), p.Focal, t).Scale(math.Scalar(p.T1 - p.T0))
+}
+
+// Domain returns [0, 1].
+func (p ParabolicArc) Domain() (lo, hi float64) { return 0, 1 }
+
+// parabolaPoint evaluates Vertex + t·ĉ + (t²/(4f))·â.
+func parabolaPoint(vertex math.Point3, axis, cross math.Vector3, focal, t float64) math.Point3 {
+	return vertex.TranslateBy(cross.Scale(math.Scalar(t)).
+		Add(axis.Scale(math.Scalar(t * t / (4 * focal)))))
+}
+
+// parabolaTangent returns dP/dt = ĉ + (t/(2f))·â.
+func parabolaTangent(axis, cross math.Vector3, focal, t float64) math.Vector3 {
+	return cross.Add(axis.Scale(math.Scalar(t / (2 * focal))))
+}

--- a/kernel/geom/parabola_test.go
+++ b/kernel/geom/parabola_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// A parabola point at t=0 is the vertex; the two arms climb symmetrically along the axis.
+func TestParabolaVertexAndArms(t *testing.T) {
+	p, err := NewParabola(math.P3(1, 0, 0), math.V3(0, 0, 1), math.V3(0, 1, 0), 2)
+	if err != nil {
+		t.Fatalf("NewParabola: %v", err)
+	}
+	if v := p.PointAt(0); ptFar(v, math.P3(1, 0, 0)) {
+		t.Errorf("vertex = %v, want (1,0,0)", v)
+	}
+	up, down := p.PointAt(0.8), p.PointAt(-0.8)
+	if stdmath.Abs(float64(up.Z-down.Z)) > 1e-9 {
+		t.Errorf("arms not symmetric along the axis: %v vs %v", up, down)
+	}
+	if stdmath.Abs(float64(up.Y+down.Y)) > 1e-9 {
+		t.Errorf("arms not antisymmetric across the axis: %v vs %v", up, down)
+	}
+	// y = x²/(4f): at t (cross) = 0.8, the axial offset is 0.8²/(4·2) = 0.08.
+	if got := float64(up.Z); stdmath.Abs(got-0.08) > 1e-9 {
+		t.Errorf("axial offset = %g, want 0.08", got)
+	}
+}
+
+// NewParabola re-orthogonalizes the cross axis against the axis and rejects degenerate input.
+func TestNewParabolaValidation(t *testing.T) {
+	if _, err := NewParabola(math.P3(0, 0, 0), math.V3(0, 0, 1), math.V3(0, 0, 1), 1); err == nil {
+		t.Error("parallel axes should error")
+	}
+	if _, err := NewParabola(math.P3(0, 0, 0), math.V3(0, 0, 1), math.V3(0, 1, 0), -1); err == nil {
+		t.Error("non-positive focal length should error")
+	}
+	p, err := NewParabola(math.P3(0, 0, 0), math.V3(0, 0, 2), math.V3(0.5, 1, 0), 1)
+	if err != nil {
+		t.Fatalf("NewParabola: %v", err)
+	}
+	if d := p.CrossDir.AsVector().Dot(p.AxisDir.AsVector()); stdmath.Abs(float64(d)) > 1e-12 {
+		t.Errorf("cross not orthogonal to axis: dot=%g", d)
+	}
+}
+
+// TangentAt matches a central finite difference of PointAt.
+func TestParabolaTangentFiniteDifference(t *testing.T) {
+	p, _ := NewParabola(math.P3(0, 1, 0), math.V3(1, 0, 0), math.V3(0, 1, 0), 1.5)
+	const eps = 1e-6
+	for _, t0 := range []float64{-1.2, 0, 0.8} {
+		fd := p.PointAt(t0 - eps).VectorTo(p.PointAt(t0 + eps)).Scale(math.Scalar(1 / (2 * eps)))
+		an := p.TangentAt(t0)
+		if d := an.Sub(fd).Length(); float64(d) > 1e-4 {
+			t.Errorf("t=%g tangent %v vs finite-diff %v (|Δ|=%g)", t0, an, fd, d)
+		}
+	}
+}
+
+// ParabolicArc reparameterizes the same parabola onto s∈[0,1] over [T0,T1].
+func TestParabolicArcReparam(t *testing.T) {
+	p, _ := NewParabola(math.P3(0, 0, 0), math.V3(0, 0, 1), math.V3(0, 1, 0), 2)
+	arc := p.Arc(-0.5, 1.5)
+	if ptFar(arc.PointAt(0), p.PointAt(-0.5)) || ptFar(arc.PointAt(1), p.PointAt(1.5)) {
+		t.Error("arc endpoints must match the parabola at T0/T1")
+	}
+	if ptFar(arc.PointAt(0.5), p.PointAt(0.5)) {
+		t.Error("arc midpoint must match the parabola at the mid t")
+	}
+	if lo, hi := arc.Domain(); lo != 0 || hi != 1 {
+		t.Errorf("arc domain = [%g,%g], want [0,1]", lo, hi)
+	}
+	const eps = 1e-6
+	fd := arc.PointAt(0.5 - eps).VectorTo(arc.PointAt(0.5 + eps)).Scale(math.Scalar(1 / (2 * eps)))
+	if d := arc.TangentAt(0.5).Sub(fd).Length(); float64(d) > 1e-4 {
+		t.Errorf("arc tangent %v vs finite-diff %v", arc.TangentAt(0.5), fd)
+	}
+}
+
+// CurveParamAtPoint3 inverts a parabola in closed form: the cross coordinate of a point on the curve
+// round-trips to the t (or arc s) that produced it.
+func TestParabolaParamRoundTrip(t *testing.T) {
+	p, _ := NewParabola(math.P3(1, -2, 3), math.V3(0, 0, 1), math.V3(0, 1, 0), 1.5)
+	if lo, hi := p.Domain(); !stdmath.IsInf(lo, -1) || !stdmath.IsInf(hi, 1) {
+		t.Errorf("Parabola.Domain = [%g,%g], want unbounded", lo, hi)
+	}
+	for _, t0 := range []float64{-1.3, 0, 0.9} {
+		got, nature := CurveParamAtPoint3(p, p.PointAt(t0))
+		if nature != UniqueSolution || stdmath.Abs(got-t0) > 1e-9 {
+			t.Errorf("Parabola param at t=%g: got %g (%v)", t0, got, nature)
+		}
+	}
+	arc := p.Arc(-1, 2)
+	for _, s := range []float64{0.1, 0.5, 0.95} {
+		got, _ := CurveParamAtPoint3(arc, arc.PointAt(s))
+		if stdmath.Abs(got-s) > 1e-9 {
+			t.Errorf("ParabolicArc param at s=%g: got %g", s, got)
+		}
+	}
+}

--- a/kernel/ops/boolean_cone_box_test.go
+++ b/kernel/ops/boolean_cone_box_test.go
@@ -280,6 +280,66 @@ func resultHasHyperbolicEdge(b *topo.Body) bool {
 	return false
 }
 
+// Parabolic boundary-tilt cone ∩/− box (Oblikovati/Oblikovati#1375): a frustum whose axis is tilted by
+// its own half-angle has one vertical generator, so the box's x=2 face is PARALLEL to it — the section is
+// a parabola (the limit between the elliptic and hyperbolic tilts). Both directions must stay exact (an
+// analytic cone face, the parabolic cut edge) and match OCC getMass.
+
+func parabolaFrustum(t *testing.T) *topo.Body {
+	t.Helper()
+	a := stdmath.Atan(0.3)
+	top := math.P3(math.Scalar(stdmath.Sin(a)*10), 0, math.Scalar(stdmath.Cos(a)*10)) // axis tilted by α
+	b, err := brep.SolidCylinderCone(math.P3(0, 0, 0), top, 3, 6, "frustum")
+	if err != nil {
+		t.Fatalf("SolidCylinderCone: %v", err)
+	}
+	return b
+}
+
+func parabolaBox(t *testing.T) *topo.Body {
+	t.Helper()
+	b, err := brep.SolidBlock(math.P3(2, -20, -20), math.P3(40, 20, 40), "box") // only the x=2 face cuts
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	return b
+}
+
+// TestConeIntersectBoxParabolaExact keeps the +x wedge of the tilted frustum — an exact cone arc-band
+// bounded by the parabola arms.
+func TestConeIntersectBoxParabolaExact(t *testing.T) {
+	res, err := ops.Boolean(ops.Intersect, parabolaFrustum(t), parabolaBox(t))
+	if err != nil {
+		t.Fatalf("Boolean(Intersect): %v", err)
+	}
+	assertConeBoxExact(t, res)
+	if !resultHasParabolicEdge(res) {
+		t.Error("result carries no parabolic edge — the boundary-tilt cut was not imprinted as a parabola")
+	}
+}
+
+// TestConeCutBoxParabolaExact removes the +x wedge — also exact.
+func TestConeCutBoxParabolaExact(t *testing.T) {
+	res, err := ops.Boolean(ops.Cut, parabolaFrustum(t), parabolaBox(t))
+	if err != nil {
+		t.Fatalf("Boolean(Cut): %v", err)
+	}
+	assertConeBoxExact(t, res)
+	if !resultHasParabolicEdge(res) {
+		t.Error("result carries no parabolic edge — the boundary-tilt cut was not imprinted as a parabola")
+	}
+}
+
+// resultHasParabolicEdge reports whether any edge of the body stores an analytic parabolic arc.
+func resultHasParabolicEdge(b *topo.Body) bool {
+	for _, e := range b.Edges() {
+		if _, ok := e.Geometry().(geom.ParabolicArc); ok {
+			return true
+		}
+	}
+	return false
+}
+
 // frustumCapBeyondPlaneVolume integrates the area of each circular cross-section lying at x ≥ xCut for
 // a cone of slope tanα over z∈[z0,z1] (apex at z=z0−r0/tanα). A circle of radius r centred on the axis
 // has area r²·(θ − sinθ·cosθ) beyond a chord at distance xCut, θ = arccos(xCut/r) (0 when xCut ≥ r).

--- a/kernel/ops/boolean_csg_demotion_test.go
+++ b/kernel/ops/boolean_csg_demotion_test.go
@@ -3,6 +3,7 @@
 package ops_test
 
 import (
+	stdmath "math"
 	"testing"
 
 	"oblikovati.org/kernel/brep"
@@ -122,7 +123,17 @@ func curvedExactCases() []curvedExactCase {
 		{"cone − box (oblique ellipse)", ops.Cut, coneObliqueEllipseBox},
 		{"cone ∩ box (oblique hyperbola)", ops.Intersect, coneObliqueHyperbolaBox},
 		{"cone − box (oblique hyperbola)", ops.Cut, coneObliqueHyperbolaBox},
+		{"cone ∩ box (parabola)", ops.Intersect, coneParabolaBox},
+		{"cone − box (parabola)", ops.Cut, coneParabolaBox},
 	}
+}
+
+// coneParabolaBox is a frustum tilted by its own half-angle (one vertical generator) so the box's x=2
+// face is parallel to that generator — the PARABOLIC boundary tilt (Oblikovati/Oblikovati#1375).
+func coneParabolaBox(t *testing.T) (*topo.Body, *topo.Body) {
+	a := stdmath.Atan(0.3)
+	top := math.P3(math.Scalar(stdmath.Sin(a)*10), 0, math.Scalar(stdmath.Cos(a)*10))
+	return demoCone(t, math.P3(0, 0, 0), top, 3, 6), demoBlock(t, math.P3(2, -20, -20), math.P3(40, 20, 40))
 }
 
 // coneObliqueHyperbolaBox is a frustum tilted so its axis (0.2,0,0.98) is shallower than the box's x=2

--- a/kernel/ops/testdata/occ_boolean_oracle.json
+++ b/kernel/ops/testdata/occ_boolean_oracle.json
@@ -18,5 +18,7 @@
   "cone ∩ box (oblique ellipse)": 410.117045,
   "cone − box (oblique ellipse)": 249.6174126,
   "cone ∩ box (oblique hyperbola)": 250.308012,
-  "cone − box (oblique hyperbola)": 409.4264453
+  "cone − box (oblique hyperbola)": 409.4264453,
+  "cone ∩ box (parabola)": 293.5440727,
+  "cone − box (parabola)": 366.1903846
 }


### PR DESCRIPTION
Part of #1375 (fourth slice — the parabolic boundary tilt, the **last conic type**). Builds on slices 1–3 (#1377, #1378, #1380) and the cap-seam fix (#1379).

## What & why
A box face **parallel to a cone generator** — the boundary tilt between the elliptic (steeper) and hyperbolic (shallower) sections — cuts the frustum side in a **parabola**. This slice handles it analytically, so `cone ∩/− box` is now exact across the whole conic family.

## How
- **geom**: a new `geom.Parabola` / `geom.ParabolicArc` curve type (the open-conic analogue of `Hyperbola`/`HyperbolicArc`; the `y = x²/4f` form, parameter the cross coordinate), with `CurveParamAtPoint3` and `CurveRangeBox3` support. `coneObliqueConic` now detects the parabola (one **zero eigenvalue** of the section's quadratic form) and builds it: in principal axes the conic is `λ·u² + d_u·u + d_w·w + f = 0` with no `w²` term — a parabola opening along the zero-eigenvalue direction. Verified points lie on both the cone and the plane.
- **brep**: the parabola section is structurally the oblique hyperbola (open arm, vertex below band, symmetric about the meridian), so the oblique split is **generalized from `geom.Hyperbola` to any `geom.Curve3` arm** (`coneSideObliqueConicSplit` / `obliqueConicBand` / `conicParamAtApexDist` / `conicArm`) and routed for both via `obliqueConicArm`. `edgeCurveFor` and `bridgeAlong` gain `Parabola` cases. The oblique-conic file is renamed accordingly.

## Validation
- **OCC `getMass` oracle**: `cone ∩ box (parabola)` and `cone − box (parabola)` match **293.54** and **366.19** within ~1.4% (chord deficit); both added to `TestCurvedBooleansStayExact` and `TestCurvedBooleanVolumesMatchOCC`.
- Watertight & manifold both directions; brep test for the single-plane parabolic cut; geom tests for the curve type (vertex/arms, validation, tangent finite-diff, arc reparam, param round-trip) and the parabolic section (points on cone & plane).
- Full kernel suite green; lint clean; package coverage 90.5%.

## `cone ∩/− box` conic matrix — now complete
| Tilt | Section | Status |
|---|---|---|
| ⟂ axis | circle | ✅ #1334 |
| ∥ axis | hyperbola (arc-band / vertex-inside) | ✅ #1372 / #1374 |
| oblique steep | ellipse | ✅ #1378 |
| oblique shallow | hyperbola | ✅ #1380 |
| **oblique boundary** | **parabola** | ✅ **this PR** |

## Still deferred (clean CSG fallback)
- Oblique-conic **vertex-inside-band** (oblique analogue of #1374).
- An oblique face that **clips a rim**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)