### PR TITLE
[M2] exact oblique cone ∩/− box when the conic vertex is inside the band (#1375)

### DIFF
--- a/kernel/brep/curved_halfspace_cone_oblique_conic.go
+++ b/kernel/brep/curved_halfspace_cone_oblique_conic.go
@@ -34,8 +34,12 @@ func coneSideObliqueConicSplit(f curvedFace, cone geom.Cone, conic geom.Curve3, 
 	if side := bandSideOfPlane(cone, band, plane, n); side != 0 {
 		return coneSideWholeOrEmpty(f, float64(side)), nil, nil // the plane clears the side: whole or empty
 	}
-	if apexDistOf(cone, conic.PointAt(0)) >= band.vMin-cylinderAxisTol {
-		return nil, nil, ErrUnsupportedHalfSpace // vertex inside the band (oblique #1374 analogue): deferred
+	vertexDist := apexDistOf(cone, conic.PointAt(0))
+	if vertexDist >= band.vMax-cylinderAxisTol {
+		return nil, nil, ErrUnsupportedHalfSpace // vertex at/above the top rim: not a band-crossing cut
+	}
+	if vertexDist > band.vMin+cylinderAxisTol {
+		return coneSideObliqueVertexInside(f, cone, conic, band, plane, n) // vertex inside the band (oblique #1374)
 	}
 	paramBot, okB := conicParamAtApexDist(conic, cone, band.vMin)
 	paramTop, okT := conicParamAtApexDist(conic, cone, band.vMax)
@@ -48,6 +52,33 @@ func coneSideObliqueConicSplit(f curvedFace, cone geom.Cone, conic geom.Curve3, 
 	}
 	kept := curvedFace{surface: cone, reversed: f.reversed, lineage: f.lineage, loops: []curvedLoop{{edges: loop}}}
 	return []curvedFace{kept}, section, nil
+}
+
+// coneSideObliqueVertexInside builds the kept sub-face when the oblique conic's vertex lies INSIDE the
+// band — the cut fades out before reaching the small rim (the oblique analogue of #1374). The two arms
+// climb only from the TOP rim down to the vertex; below the vertex no cross-section is cut, so the small
+// rim is intact on one side. It mirrors coneSideVertexInside (the notched-top loop, the through-vertex
+// section) but the top-rim half-angle comes from the ACTUAL crossing (root-found) rather than the
+// constant-chord formula, and the tongue-vs-annulus choice from which side the small rim sits on.
+func coneSideObliqueVertexInside(f curvedFace, cone geom.Cone, conic geom.Curve3, band coneSideBand_, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
+	axis, ref := cone.AxisDir.AsVector(), cone.Ref.AsVector()
+	uN := coneAngleOf(cone, n)
+	paramTop, ok := conicParamAtApexDist(conic, cone, band.vMax)
+	if !ok {
+		return nil, nil, ErrUnsupportedHalfSpace // the arms do not reach the top rim
+	}
+	phiT := crossingHalfAngle(cone, conic.PointAt(paramTop), uN)
+	topArc, err := geom.NewArc3d(band.top, axis, ref, band.rTop, uN-phiT, -(2*stdmath.Pi - 2*phiT))
+	if err != nil {
+		return nil, nil, ErrUnsupportedHalfSpace
+	}
+	vertex := conic.PointAt(0)
+	armDown := conicArm(conic, topArc.PointAt(1), vertex) // top rim → vertex
+	armUp := conicArm(conic, vertex, topArc.PointAt(0))   // vertex → top rim
+	notched := []loopEdge{{curve: topArc, t0: 0, t1: 1}, armDown, armUp}
+	section := []loopEdge{reverseEdge(armDown), reverseEdge(armUp)}
+	annulus := signedDistance(rimPoint(band.bottomCirc), plane, n) < 0 // the small rim is on the kept side
+	return coneVertexInsideFaces(f, cone, band, annulus, notched), section, nil
 }
 
 // obliqueConicBand builds the kept band the SAME way coneArcBand (#1372) does — bottom arc CCW from

--- a/kernel/brep/curved_halfspace_cone_oblique_hyperbola_test.go
+++ b/kernel/brep/curved_halfspace_cone_oblique_hyperbola_test.go
@@ -33,13 +33,34 @@ func TestConeSideHalfSpaceObliqueHyperbola(t *testing.T) {
 }
 
 // An oblique hyperbola whose vertex falls INSIDE the band (the arms turn before reaching the small rim,
-// the oblique analogue of #1374) is not yet built and must defer cleanly so the CSG fallback covers it.
-func TestConeSideHalfSpaceObliqueHyperbolaVertexInsideDefers(t *testing.T) {
+// the oblique analogue of #1374) splits exactly: keeping the apex side leaves a notched ANNULUS (the
+// intact small rim plus a top notched down to the vertex), keeping the far side a lone TONGUE.
+func TestConeSideHalfSpaceObliqueHyperbolaVertexInside(t *testing.T) {
 	frustum := mustFrustum(t, math.P3(0, 0, 0), math.P3(0, 0, 10), 3, 6)
-	plane, _ := geom.NewPlane(math.P3(4, 0, 0), math.V3(stdmath.Sqrt(1-0.2*0.2), 0, 0.2)) // vertex apex-dist ≈ 12, in band
-	if _, err := HalfSpaceCut(frustum, plane); err == nil {
-		t.Error("vertex-inside oblique hyperbola should defer, got nil error")
+	for _, c := range []struct {
+		name string
+		nx   float64
+	}{{"annulus (keep apex side)", stdmath.Sqrt(1 - 0.2*0.2)}, {"tongue (keep far side)", -stdmath.Sqrt(1 - 0.2*0.2)}} {
+		plane, _ := geom.NewPlane(math.P3(4, 0, 0), math.V3(c.nx, 0, 0.2*signOf(c.nx))) // vertex apex-dist ≈ 12, in band
+		res, err := HalfSpaceCut(frustum, plane)
+		if err != nil {
+			t.Fatalf("%s: HalfSpaceCut: %v", c.name, err)
+		}
+		assertWatertight(t, res)
+		if cones, _, _ := faceTypeCounts(t, res); cones != 1 {
+			t.Errorf("%s: got %d cone faces, want 1", c.name, cones)
+		}
+		if !anyFaceHasHyperbola(res) {
+			t.Errorf("%s: no hyperbolic edge", c.name)
+		}
 	}
+}
+
+func signOf(x float64) float64 {
+	if x < 0 {
+		return -1
+	}
+	return 1
 }
 
 // A plane shallower than the generators but clear of the frustum band (its section lies on the infinite

--- a/kernel/brep/curved_halfspace_cone_side.go
+++ b/kernel/brep/curved_halfspace_cone_side.go
@@ -146,15 +146,16 @@ func coneSideVertexInside(f curvedFace, cone geom.Cone, hyper geom.Hyperbola, ba
 	armUp := conicArm(hyper, vertex, topArc.PointAt(0))   // vertex → top rim
 	notched := []loopEdge{{curve: topArc, t0: 0, t1: 1}, armDown, armUp}
 	section := []loopEdge{reverseEdge(armDown), reverseEdge(armUp)}
-	return coneVertexInsideFaces(f, cone, band, d, notched), section, nil
+	return coneVertexInsideFaces(f, cone, band, d < 0, notched), section, nil // d<0: apex (small rim) kept → annulus
 }
 
-// coneVertexInsideFaces wraps the notched-top loop into the kept face: a lone tongue when the apex is
-// dropped (d>0), or an annulus closed by the intact small-rim circle as an inner loop when the apex is
-// kept (d<0). The small-rim circle is the source side's own edge so it welds with the small cap.
-func coneVertexInsideFaces(f curvedFace, cone geom.Cone, band coneSideBand_, d float64, notched []loopEdge) []curvedFace {
+// coneVertexInsideFaces wraps the notched-top loop into the kept face: a lone tongue narrowing to the
+// vertex (the small rim dropped), or — when annulus is true (the small rim is on the kept side) — the
+// whole side minus that tongue, closed by the intact small-rim circle as an inner loop. The small-rim
+// circle is the source side's own edge so it welds with the small cap.
+func coneVertexInsideFaces(f curvedFace, cone geom.Cone, band coneSideBand_, annulus bool, notched []loopEdge) []curvedFace {
 	loops := []curvedLoop{{edges: notched}}
-	if d < 0 { // apex kept: close the annulus with the intact small rim
+	if annulus {
 		loops = append(loops, curvedLoop{edges: []loopEdge{{curve: band.bottomCirc, t0: 0, t1: 1}}})
 	}
 	return []curvedFace{{surface: cone, reversed: f.reversed, lineage: f.lineage, loops: loops}}

--- a/kernel/ops/boolean_cone_box_test.go
+++ b/kernel/ops/boolean_cone_box_test.go
@@ -280,6 +280,42 @@ func resultHasHyperbolicEdge(b *topo.Body) bool {
 	return false
 }
 
+// Oblique vertex-inside cone ∩/− box (Oblikovati/Oblikovati#1375): the tilted frustum cut by the box face
+// x=5 — far enough out that the oblique hyperbola's vertex falls INSIDE the band (apex distance ≈ 14, the
+// oblique analogue of #1374). Intersect keeps a lone tongue narrowing to the vertex; Cut keeps the notched
+// annulus (the intact small rim plus a top notched down to the vertex). Both must stay exact.
+
+func obliqueVertexInsideBox(t *testing.T) *topo.Body {
+	t.Helper()
+	b, err := brep.SolidBlock(math.P3(5, -20, -20), math.P3(40, 20, 40), "box") // x=5 face cuts, vertex inside band
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	return b
+}
+
+func TestConeIntersectBoxObliqueVertexInsideExact(t *testing.T) {
+	res, err := ops.Boolean(ops.Intersect, obliqueHyperbolaFrustum(t), obliqueVertexInsideBox(t))
+	if err != nil {
+		t.Fatalf("Boolean(Intersect): %v", err)
+	}
+	assertConeBoxExact(t, res)
+	if !resultHasHyperbolicEdge(res) {
+		t.Error("result carries no hyperbolic edge")
+	}
+}
+
+func TestConeCutBoxObliqueVertexInsideExact(t *testing.T) {
+	res, err := ops.Boolean(ops.Cut, obliqueHyperbolaFrustum(t), obliqueVertexInsideBox(t))
+	if err != nil {
+		t.Fatalf("Boolean(Cut): %v", err)
+	}
+	assertConeBoxExact(t, res)
+	if !resultHasHyperbolicEdge(res) {
+		t.Error("result carries no hyperbolic edge")
+	}
+}
+
 // Parabolic boundary-tilt cone ∩/− box (Oblikovati/Oblikovati#1375): a frustum whose axis is tilted by
 // its own half-angle has one vertical generator, so the box's x=2 face is PARALLEL to it — the section is
 // a parabola (the limit between the elliptic and hyperbolic tilts). Both directions must stay exact (an

--- a/kernel/ops/boolean_csg_demotion_test.go
+++ b/kernel/ops/boolean_csg_demotion_test.go
@@ -125,7 +125,15 @@ func curvedExactCases() []curvedExactCase {
 		{"cone − box (oblique hyperbola)", ops.Cut, coneObliqueHyperbolaBox},
 		{"cone ∩ box (parabola)", ops.Intersect, coneParabolaBox},
 		{"cone − box (parabola)", ops.Cut, coneParabolaBox},
+		{"cone ∩ box (oblique vertex-inside)", ops.Intersect, coneObliqueVertexInsideBox},
+		{"cone − box (oblique vertex-inside)", ops.Cut, coneObliqueVertexInsideBox},
 	}
+}
+
+// coneObliqueVertexInsideBox is the tilted frustum (axis (0.2,0,0.98)) cut by the box face x=5 — far
+// enough out that the oblique hyperbola's vertex falls inside the band (the oblique analogue of #1374).
+func coneObliqueVertexInsideBox(t *testing.T) (*topo.Body, *topo.Body) {
+	return demoCone(t, math.P3(0, 0, 0), math.P3(2, 0, 9.797958971), 3, 6), demoBlock(t, math.P3(5, -20, -20), math.P3(40, 20, 40))
 }
 
 // coneParabolaBox is a frustum tilted by its own half-angle (one vertical generator) so the box's x=2

--- a/kernel/ops/testdata/occ_boolean_oracle.json
+++ b/kernel/ops/testdata/occ_boolean_oracle.json
@@ -20,5 +20,7 @@
   "cone ∩ box (oblique hyperbola)": 250.308012,
   "cone − box (oblique hyperbola)": 409.4264453,
   "cone ∩ box (parabola)": 293.5440727,
-  "cone − box (parabola)": 366.1903846
+  "cone − box (parabola)": 366.1903846,
+  "cone ∩ box (oblique vertex-inside)": 48.83120765,
+  "cone − box (oblique vertex-inside)": 610.9032496
 }


### PR DESCRIPTION
Part of #1375 — the oblique analogue of #1374 (vertex-inside-band), generalized to any oblique conic. Builds on the oblique slices (#1378/#1380/#1381).

## What & why
When an oblique box face cuts the frustum **far enough out**, the section conic's **vertex falls inside the band** — the cut fades out before reaching the small rim, so the two arms climb only from the top rim down to the vertex. This is the oblique counterpart of the axis-parallel #1374. `cone ∩/− box` is now exact there instead of faceted CSG.

## How
`coneSideObliqueConicSplit` routes a vertex-inside section to the new `coneSideObliqueVertexInside`, which mirrors `coneSideVertexInside` (#1374) — the notched-top loop, the through-vertex section — but:
- takes the top-rim half-angle from the **actual crossing** (root-found via `conicParamAtApexDist`) rather than the constant-chord `arccos(−d/r)` formula;
- chooses **tongue vs annulus** from which side the intact small rim sits on (instead of the sign of `d`).

`coneVertexInsideFaces` now takes that choice as a bool (the #1374 caller passes `d < 0`). The annulus reuses the notched-rim band tessellation from #1374 (`notchedRimBandMesh`).

## Validation
- **OCC `getMass` oracle**: `cone ∩/− box (oblique vertex-inside)` match **48.83** and **610.90** within ~2% (the Intersect tongue pinches to the vertex — a sharper cusp, so a slightly larger chord deficit); both added to `TestCurvedBooleansStayExact` and `TestCurvedBooleanVolumesMatchOCC`.
- Watertight & manifold both directions (annulus keeps the apex side, tongue the far side); brep test covering both.
- Full kernel suite green; lint clean; package coverage 90.3%.

## `cone ∩/− box` — now essentially complete
Every conic tilt (circle / axis-parallel hyperbola incl. vertex-inside / oblique ellipse / oblique hyperbola incl. **vertex-inside** / parabola) is exact through `ops.Boolean`. The only remaining arrangement is an oblique face that **clips a rim** (section becomes a conic arc + rim arc), which still defers cleanly to CSG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)