### PR TITLE
brep,ops: exact clips-rim cone ∩/− box via a (u,v) arrangement split (#1375)

### DIFF
--- a/kernel/brep/curved_halfspace_cone_ellipse_test.go
+++ b/kernel/brep/curved_halfspace_cone_ellipse_test.go
@@ -3,7 +3,6 @@
 package brep
 
 import (
-	"errors"
 	"testing"
 
 	"oblikovati.org/kernel/geom"
@@ -35,12 +34,23 @@ func TestConeSideHalfSpaceEllipse(t *testing.T) {
 }
 
 // An oblique plane positioned so its ellipse straddles the top rim (some of the section above z=10) is
-// the clips-rim arrangement, not yet built: it must defer cleanly so the CSG fallback covers it.
-func TestConeSideHalfSpaceEllipseClipsRimDefers(t *testing.T) {
+// the clips-rim arrangement: the kept band's UPPER boundary is the cut ellipse arc PLUS the surviving
+// top-rim arc, and the planar lid is bounded by that ellipse arc and the top cap's chord. The (u,v)
+// arrangement split builds it exactly — one analytic cone band, watertight, no CSG fallback
+// (Oblikovati/Oblikovati#1375).
+func TestConeSideHalfSpaceEllipseClipsRim(t *testing.T) {
 	frustum := mustFrustum(t, math.P3(0, 0, 0), math.P3(0, 0, 10), 3, 6)
 	plane, _ := geom.NewPlane(math.P3(0, 0, 9.5), math.V3(0.5, 0, 0.866)) // ellipse crosses the top rim
-	if _, err := HalfSpaceCut(frustum, plane); !errors.Is(err, ErrUnsupportedHalfSpace) {
-		t.Errorf("clips-rim cut should defer with ErrUnsupportedHalfSpace, got %v", err)
+	res, err := HalfSpaceCut(frustum, plane)
+	if err != nil {
+		t.Fatalf("clips-rim cut should now be handled exactly, got %v", err)
+	}
+	assertWatertight(t, res)
+	if cones, _, _ := faceTypeCounts(t, res); cones != 1 {
+		t.Errorf("result has %d cone faces, want exactly 1 (the clipped band stays analytic)", cones)
+	}
+	if !anyFaceHasEllipse(res) {
+		t.Error("no face carries an elliptical edge — the rim-clipping ellipse was not imprinted")
 	}
 }
 

--- a/kernel/brep/curved_halfspace_cone_side.go
+++ b/kernel/brep/curved_halfspace_cone_side.go
@@ -203,7 +203,10 @@ func fullConeSideBand(f curvedFace) (geom.Cone, coneSideBand_, bool) {
 // is handled by the fast cone path before the arrangement, so anything else defers.
 func coneSideBandSplit(f curvedFace, curves []geom.Curve3, cone geom.Cone, band coneSideBand_, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
 	if allEllipses(curves) {
-		return coneSideEllipseSplit(f, curves, cone, plane, n)
+		if pieces, sec, err := coneSideUVSplit(f, cone, curves[0], band, plane, n); err == nil {
+			return pieces, sec, nil // the (u,v) arrangement: handles within-band AND a rim clip uniformly
+		}
+		return coneSideEllipseSplit(f, curves, cone, plane, n) // the non-wrapping (tongue) arrangement, for now
 	}
 	if allHyperbolas(curves) && isAxisParallel(n, cone) {
 		return coneSideSplit(f, curves, plane, n) // the symmetric constant-chord hyperbola (#1372/#1374)

--- a/kernel/brep/curved_halfspace_cone_uv.go
+++ b/kernel/brep/curved_halfspace_cone_uv.go
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Cone-side split in PARAMETER SPACE (M2 Phase-1 follow-up, Oblikovati/Oblikovati#1375). The OCCT-style
+// arrangement approach: instead of hand-building the kept loop and deriving its winding per topological
+// case (the arc-band / annulus / tongue / clip families), split the full periodic cone side in its own
+// (u, v) = (azimuth, apex-distance) space, where the section a plane carves is a SINGLE-VALUED function
+//
+//	v(u) = −A / C(u),   C(u) = n·â + tanα·|n_r|·cos(u − u_n),   A = n·(apex − O)
+//
+// because a cone point is P(u,v) = apex + v·â + v·tanα·r̂(u), so the signed distance is g(u,v)=A+v·C(u),
+// linear in v. The kept region {g<0} is then just a v-INTERVAL [lo(u), hi(u)] per u, bounded below/above
+// by the rims (v=vMin / vMax) and the section curve — tongue, annulus and rim-clip all fall out of that
+// interval, with the cone's own orientation inherited, no per-case winding. This file builds the (u,v)
+// model and the kept-interval structure; the boundary trace and edge build follow.
+
+// coneUV is the cone side expressed in (u, v): the apex frame plus the cut plane reduced to A and the
+// cosine coefficient C(u) of the signed distance g(u,v) = A + v·C(u).
+type coneUV struct {
+	apex             math.Point3
+	axis, ref, binor math.Vector3
+	tanA             float64
+	vMin, vMax       float64
+	rBot, rTop       float64
+	a                float64 // A = n·(apex − O)
+	nAxis            float64 // n·â
+	nRad             float64 // |radial component of n|
+	uN               float64 // azimuth of n's radial component
+}
+
+// newConeUV builds the (u, v) model of a frustum side cut by a plane (n the unit plane normal).
+func newConeUV(cone geom.Cone, band coneSideBand_, plane geom.Plane, n math.Vector3) coneUV {
+	axis := cone.AxisDir.AsVector()
+	ref := cone.Ref.AsVector()
+	binor := axis.Cross(ref)
+	nAxis := float64(n.Dot(axis))
+	nr := n.Sub(axis.Scale(math.Scalar(nAxis))) // radial part of n
+	nRad := float64(nr.Length())
+	uN := stdmath.Atan2(float64(nr.Dot(binor)), float64(nr.Dot(ref)))
+	return coneUV{
+		apex: cone.Apex, axis: axis, ref: ref, binor: binor, tanA: stdmath.Tan(cone.HalfAngle),
+		vMin: band.vMin, vMax: band.vMax, rBot: band.rBot, rTop: band.rTop,
+		a:     float64(plane.Origin.VectorTo(cone.Apex).Dot(n)),
+		nAxis: nAxis, nRad: nRad, uN: uN,
+	}
+}
+
+// coeffC returns C(u) = n·â + tanα·|n_r|·cos(u − u_n); the signed distance is g(u,v) = A + v·C(u).
+func (c coneUV) coeffC(u float64) float64 {
+	return c.nAxis + c.tanA*c.nRad*stdmath.Cos(u-c.uN)
+}
+
+// sectionV returns the apex distance v where the cut plane meets the cone at azimuth u — the section
+// curve v(u) = −A/C(u). It returns 0 where C(u)≈0 (the plane is parallel to the generator at u, the
+// section's asymptote); the wrapping-band caller never samples there, so the degenerate value is unused.
+func (c coneUV) sectionV(u float64) float64 {
+	cu := c.coeffC(u)
+	if stdmath.Abs(cu) < 1e-12 {
+		return 0
+	}
+	return -c.a / cu
+}
+
+// keptV returns the kept (g<0) apex-distance interval [lo, hi] at azimuth u, clamped to the band, plus
+// whether it is non-empty. g=A+v·C(u) is linear in v: when C>0 the kept side is v<v(u), when C<0 it is
+// v>v(u), and when C≈0 the whole column is kept (A<0) or dropped (A≥0).
+func (c coneUV) keptV(u float64) (lo, hi float64, ok bool) {
+	cu := c.coeffC(u)
+	switch {
+	case cu > 1e-12:
+		hi = c.vMax
+		if v := -c.a / cu; v < hi {
+			hi = v
+		}
+		return c.vMin, hi, hi > c.vMin
+	case cu < -1e-12:
+		lo = c.vMin
+		if v := -c.a / cu; v > lo {
+			lo = v
+		}
+		return lo, c.vMax, lo < c.vMax
+	default:
+		return c.vMin, c.vMax, c.a < 0 // the plane is parallel to the generator: whole column kept or dropped
+	}
+}
+
+// point3 returns the cone point at (u, v): apex + v·â + v·tanα·r̂(u).
+func (c coneUV) point3(u, v float64) math.Point3 {
+	radial := c.ref.Scale(math.Scalar(stdmath.Cos(u))).Add(c.binor.Scale(math.Scalar(stdmath.Sin(u))))
+	return c.apex.TranslateBy(c.axis.Scale(math.Scalar(v))).TranslateBy(radial.Scale(math.Scalar(v * c.tanA)))
+}
+
+// coneSideUVSplit splits a full periodic frustum side by building the kept region {g<0} in (u,v). The
+// WRAPPING case (kept v-interval non-empty for every azimuth) is a band represented as a face with two
+// boundary loops (no seam, like the vertex-inside annulus #1374): the upper loop is the kept hi(u) curve
+// and the lower loop the kept lo(u) curve, each a closed chain of WHOLE rim arcs and section arcs split
+// only at the rim crossings — so each rim arc welds with the cap that shares it. A non-wrapping (tongue)
+// arrangement defers to the caller for now.
+func coneSideUVSplit(f curvedFace, cone geom.Cone, conic geom.Curve3, band coneSideBand_, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
+	uv := newConeUV(cone, band, plane, n)
+	if !uv.wrapsAllU() {
+		return nil, nil, ErrUnsupportedHalfSpace // a tongue (kept interval empties somewhere): not yet built here
+	}
+	hiEdges, hiSec, ok1 := uv.boundaryLoop(conic, band, true)
+	loEdges, loSec, ok2 := uv.boundaryLoop(conic, band, false)
+	if !ok1 || !ok2 {
+		return nil, nil, ErrUnsupportedHalfSpace
+	}
+	// A frustum side's two rims run oppositely (lower CCW, upper CW) so the side stays consistent with both
+	// caps. The lo boundary is built CCW (forward); the UPPER boundary is reversed to CW whenever it carries
+	// a rim shared with a kept cap, so that rim welds to the cap with opposite sense. The lid then uses each
+	// section sub-arc OPPOSITE to the band's (final) use of it, so the shared section edge is consistent too.
+	hiLoop, lidHiSec := hiEdges, reverseEdgeChain(hiSec)
+	if loopHasRim(hiEdges) {
+		hiLoop, lidHiSec = reverseEdgeChain(hiEdges), hiSec
+	}
+	kept := curvedFace{surface: cone, reversed: f.reversed, lineage: f.lineage,
+		loops: []curvedLoop{{edges: hiLoop}, {edges: loEdges}}}
+	lidSection := append(append([]loopEdge{}, lidHiSec...), reverseEdgeChain(loSec)...)
+	return []curvedFace{kept}, lidSection, nil
+}
+
+// loAt and hiAt give the kept interval's lower / upper bound at azimuth u.
+func (c coneUV) loAt(u float64) float64 { lo, _, _ := c.keptV(u); return lo }
+func (c coneUV) hiAt(u float64) float64 { _, hi, _ := c.keptV(u); return hi }
+
+// wrapsAllU reports whether the kept v-interval is non-empty at every azimuth (the band wraps the seam).
+func (c coneUV) wrapsAllU() bool {
+	for i := 0; i < 720; i++ {
+		if _, _, ok := c.keptV(2 * stdmath.Pi * float64(i) / 720); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// boundAt gives the boundary value (lo or hi) at u.
+func (c coneUV) boundAt(u float64, upper bool) float64 {
+	if upper {
+		return c.hiAt(u)
+	}
+	return c.loAt(u)
+}
+
+// onRim reports whether the boundary at u sits on a rim (constant v) rather than on the section curve.
+func (c coneUV) onRim(u float64, upper bool) bool {
+	v := c.boundAt(u, upper)
+	if upper {
+		return v >= c.vMax-1e-7
+	}
+	return v <= c.vMin+1e-7
+}
+
+// boundaryLoop builds the upper (upper=true) or lower boundary of the kept band as a closed loop of whole
+// rim arcs and section arcs, and the section (conic) sub-edges alone for the lid. A boundary with no rim
+// crossing is either the full source rim circle (all rim) or the full re-anchored ellipse (all section).
+func (c coneUV) boundaryLoop(conic geom.Curve3, band coneSideBand_, upper bool) (edges, section []loopEdge, ok bool) {
+	breaks := c.rimCrossings(upper)
+	if len(breaks) == 0 {
+		if c.onRim(0, upper) {
+			// A full source rim circle reused whole (built forward here), so it welds to the cap that shares
+			// it; coneSideUVSplit reverses the whole upper loop to give that rim the cap-opposite sense.
+			circle := band.bottomCirc
+			if upper {
+				circle = band.topCirc
+			}
+			return []loopEdge{{curve: circle, t0: 0, t1: 1}}, nil, true
+		}
+		e, sec, good := c.fullSectionEdge(conic) // the within-band ellipse: a closed re-anchored edge
+		return []loopEdge{e}, sec, good
+	}
+	for i := range breaks { // one edge per gap between consecutive crossings, wrapping the last to the first
+		ua, ub := breaks[i], breaks[(i+1)%len(breaks)]
+		if i == len(breaks)-1 {
+			ub += 2 * stdmath.Pi
+		}
+		e, sec, good := c.boundaryEdge(conic, ua, ub, upper)
+		if !good {
+			return nil, nil, false
+		}
+		edges = append(edges, e)
+		section = append(section, sec...)
+	}
+	return edges, section, true
+}
+
+// rimCrossings returns the azimuths in [0, 2π) where the boundary switches between a rim and the section
+// curve (the section reaches the clamp rim), sorted. Empty when the boundary is wholly rim or wholly
+// section.
+func (c coneUV) rimCrossings(upper bool) []float64 {
+	const twoPi, N = 2 * stdmath.Pi, 1440
+	var out []float64
+	prev := c.onRim(0, upper)
+	for i := 1; i <= N; i++ {
+		u := twoPi * float64(i) / N
+		if cur := c.onRim(u, upper); cur != prev {
+			out = append(out, c.bisectRimBreak(twoPi*float64(i-1)/N, u, upper))
+			prev = cur
+		}
+	}
+	return out
+}
+
+// bisectRimBreak refines the azimuth where the section curve EXACTLY reaches the clamp rim (vMax for the
+// upper boundary, vMin for the lower) — the crossing shared with the cap, so the section arc welds to the
+// cap chord there.
+func (c coneUV) bisectRimBreak(lo, hi float64, upper bool) float64 {
+	clamp := c.vMin
+	if upper {
+		clamp = c.vMax
+	}
+	f := func(u float64) float64 { return c.sectionV(u) - clamp }
+	flo := f(lo)
+	for i := 0; i < 60; i++ {
+		mid := (lo + hi) / 2
+		if (flo < 0) == (f(mid) < 0) {
+			lo, flo = mid, f(mid)
+		} else {
+			hi = mid
+		}
+	}
+	return (lo + hi) / 2
+}
+
+// boundaryEdge builds one boundary edge over [ua, ub]: a rim arc when the boundary is on a rim there, else
+// a sub-arc of the section conic (also returned, u-increasing, as the lid's cut edge).
+func (c coneUV) boundaryEdge(conic geom.Curve3, ua, ub float64, upper bool) (loopEdge, []loopEdge, bool) {
+	um := (ua + ub) / 2
+	if c.onRim(um, upper) {
+		center, radius := c.apex.TranslateBy(c.axis.Scale(math.Scalar(c.vMin))), c.rBot
+		if upper {
+			center, radius = c.apex.TranslateBy(c.axis.Scale(math.Scalar(c.vMax))), c.rTop
+		}
+		arc, err := geom.NewArc3d(center, c.axis, c.ref, radius, ua, ub-ua)
+		if err != nil {
+			return loopEdge{}, nil, false
+		}
+		return loopEdge{curve: arc, t0: 0, t1: 1}, nil, true
+	}
+	va := c.sectionV(ua)
+	vb := c.sectionV(ub)
+	e := conicArm(conic, c.point3(ua, va), c.point3(ub, vb)) // a partial section arc
+	return e, []loopEdge{e}, true
+}
+
+// fullSectionEdge builds the closed re-anchored ellipse edge when a boundary is the whole within-band
+// section (the section never reaches a rim). Only an ellipse encircles the axis, so anything else defers.
+func (c coneUV) fullSectionEdge(conic geom.Curve3) (loopEdge, []loopEdge, bool) {
+	el, ok := conic.(geom.EllipseFull)
+	if !ok {
+		return loopEdge{}, nil, false
+	}
+	v0 := c.sectionV(0)
+	tStart, _ := geom.CurveParamAtPoint3(el, c.point3(0, v0))
+	arc := geom.EllipticalArc{Center: el.Center, Normal: el.Normal, MajorAxis: el.MajorAxis,
+		MajorRadius: el.MajorRadius, MinorRadius: el.MinorRadius,
+		StartAngle: 2 * stdmath.Pi * tStart, SweepAngle: 2 * stdmath.Pi}
+	e := loopEdge{curve: arc, t0: 0, t1: 1}
+	return e, []loopEdge{e}, true
+}
+
+// loopHasRim reports whether a boundary chain carries a rim edge (a full circle or a rim arc, shared with
+// a cap) rather than only section conic arcs — the upper boundary is then reversed to the cap-opposite
+// sense. A rim edge's curve is a geom.Circle (full rim) or geom.Arc3d (a partial rim between crossings).
+func loopHasRim(edges []loopEdge) bool {
+	for _, e := range edges {
+		switch e.curve.(type) {
+		case geom.Circle, geom.Arc3d:
+			return true
+		}
+	}
+	return false
+}
+
+// reverseEdgeChain reverses a chain of loop edges (order reversed, each reversed).
+func reverseEdgeChain(chain []loopEdge) []loopEdge {
+	out := make([]loopEdge, len(chain))
+	for i, e := range chain {
+		out[len(chain)-1-i] = reverseEdge(e)
+	}
+	return out
+}

--- a/kernel/brep/curved_halfspace_general.go
+++ b/kernel/brep/curved_halfspace_general.go
@@ -41,6 +41,34 @@ func generalHalfSpace(body *topo.Body, plane geom.Plane, n math.Vector3, faces [
 	return curvedStitch(append(kept, lids...)), nil
 }
 
+// faceWhollyOneSide reports whether a developable (cone/cylinder) face lies entirely on one side of the
+// plane even though the infinite surface's imprint conic exists — the case a clearing plane makes on a
+// band the earlier cut already trimmed (its rims are no longer the original circles, so the dedicated
+// band split would not recognise it). A cone/cylinder is RULED along v, so if every boundary point lies on
+// one side the whole ruled interior does too; the caller then keeps or drops the face whole. Only ruled
+// sides qualify (a sphere/torus interior can bulge past a chord between boundary points).
+func faceWhollyOneSide(f curvedFace, plane geom.Plane, n math.Vector3) bool {
+	switch f.surface.(type) {
+	case geom.Cone, geom.Cylinder:
+	default:
+		return false
+	}
+	neg, pos := false, false
+	for _, loop := range f.loops {
+		for _, le := range loop.edges {
+			for i := 0; i <= 8; i++ {
+				switch d := signedDistance(le.curve.PointAt(le.t0+(le.t1-le.t0)*float64(i)/8), plane, n); {
+				case d > cylinderAxisTol:
+					pos = true
+				case d < -cylinderAxisTol:
+					neg = true
+				}
+			}
+		}
+	}
+	return !neg || !pos // wholly on one side (or grazing): no genuine crossing
+}
+
 // splitFaceByPlane splits one face by the cutting plane, returning the kept (negative-side) sub-faces
 // and the section arcs that bound the lid. A face the plane does not cross is kept whole or dropped; a
 // boundary-less face (sphere) splits into the kept cap; a looped face crossed by the imprint defers.
@@ -49,7 +77,7 @@ func splitFaceByPlane(f curvedFace, plane geom.Plane, n math.Vector3) ([]curvedF
 	if !handled {
 		return nil, nil, ErrUnsupportedHalfSpace
 	}
-	if len(curves) == 0 {
+	if len(curves) == 0 || faceWhollyOneSide(f, plane, n) {
 		if signedDistance(faceSample(f), plane, n) <= 0 {
 			return []curvedFace{f}, nil, nil // whole face on the negative side
 		}

--- a/kernel/brep/curved_stitch.go
+++ b/kernel/brep/curved_stitch.go
@@ -129,15 +129,35 @@ func edgeCurveFor(le loopEdge) geom.Curve3 {
 		return geom.NewLineSegment(le.start(), le.end())
 	case geom.Line:
 		return geom.NewLineSegment(le.start(), le.end())
+	default:
+		return conicEdgeCurveFor(le)
+	}
+}
+
+// conicEdgeCurveFor restricts the analytic conic edges (the oblique cone-cut sections) to their loop
+// sub-range: a hyperbola/parabola to its bounded arc, an elliptical arc as-is, a full ellipse to the
+// elliptical arc over [t0, t1]. Any other curve is stored whole.
+func conicEdgeCurveFor(le loopEdge) geom.Curve3 {
+	switch c := le.curve.(type) {
 	case geom.Hyperbola:
 		return c.Arc(le.t0, le.t1) // a hyperbola loop edge's params are θ; the bounded arc is what the edge stores
 	case geom.Parabola:
 		return c.Arc(le.t0, le.t1) // a parabola loop edge's params are the cross coordinate t; store the bounded arc
 	case geom.EllipticalArc:
 		return c // the re-anchored elliptical rim/lid of an oblique cone cut tessellates over its sweep
+	case geom.EllipseFull:
+		return ellipseArcOf(c, le.t0, le.t1) // a section sub-arc of a full ellipse (the (u,v) cone split)
 	default:
 		return c
 	}
+}
+
+// ellipseArcOf builds the EllipticalArc covering a full ellipse's parameter sub-range [t0, t1]
+// (EllipseFull.PointAt(t) is the point at angle 2πt), so the edge tessellates over that arc alone.
+func ellipseArcOf(e geom.EllipseFull, t0, t1 float64) geom.Curve3 {
+	const twoPi = 2 * stdmath.Pi
+	a, _ := geom.NewEllipticalArc(e.Center, e.Normal.AsVector(), e.MajorAxis.AsVector(), e.MajorRadius, e.MinorRadius, twoPi*t0, twoPi*(t1-t0))
+	return a
 }
 
 // isFullDomain reports whether [t0, t1] spans a curve's whole [0, 1] domain (a closed seam circle),

--- a/kernel/ops/boolean_csg_demotion_test.go
+++ b/kernel/ops/boolean_csg_demotion_test.go
@@ -127,7 +127,17 @@ func curvedExactCases() []curvedExactCase {
 		{"cone − box (parabola)", ops.Cut, coneParabolaBox},
 		{"cone ∩ box (oblique vertex-inside)", ops.Intersect, coneObliqueVertexInsideBox},
 		{"cone − box (oblique vertex-inside)", ops.Cut, coneObliqueVertexInsideBox},
+		{"cone − box (clips rim annulus)", ops.Cut, coneClipsRimBox},
 	}
+}
+
+// coneClipsRimBox is the oblique-ellipse frustum (axis (0,0.6,0.8)) cut by a box whose face z=6 slices
+// THROUGH the tilted top rim (the rim z-range is [4.4, 11.6]): the section ellipse clips the top rim, so
+// the kept annulus's upper boundary is the ellipse arc PLUS the surviving top-rim arc — the clips-rim
+// arrangement built exactly by the (u,v) split (Oblikovati/Oblikovati#1375). The complementary ∩ keeps
+// the non-wrapping tongue above z=6, which still demotes to CSG, so only the Cut is an exact case.
+func coneClipsRimBox(t *testing.T) (*topo.Body, *topo.Body) {
+	return demoCone(t, math.P3(0, 0, 0), math.P3(0, 6, 8), 3, 6), demoBlock(t, math.P3(-30, -30, 6), math.P3(30, 30, 40))
 }
 
 // coneObliqueVertexInsideBox is the tilted frustum (axis (0.2,0,0.98)) cut by the box face x=5 — far

--- a/kernel/ops/conformance_repair.go
+++ b/kernel/ops/conformance_repair.go
@@ -37,6 +37,10 @@ func conformCylConeFaces(faces []*topo.Face, idx map[*topo.Face]int, fm []*Mesh,
 func conformingMesh(f *topo.Face, q Quality) *Mesh {
 	switch f.Geometry().(type) {
 	case geom.Cylinder, geom.Cone:
+		if isPeriodicTwoRimBand(f) {
+			return nil // a periodic two-rim band: the saddle loft already meshed it exactly, and its
+			// full-wrap outer loop degenerates the (u,v) CDT (constrainedDelaunay can spin) — keep the loft
+		}
 		return conformingCylConeMesh(f, q)
 	case geom.Plane:
 		return conformingPlaneMesh(f, q)

--- a/kernel/ops/saddle_band_loft.go
+++ b/kernel/ops/saddle_band_loft.go
@@ -33,6 +33,46 @@ func notchedRimBandMesh(f *topo.Face, s geom.Surface, q Quality) (*Mesh, bool) {
 	return saddleBandLoftMesh(f, s, q)
 }
 
+// twoClosedRimBandMesh meshes a developable side (cylinder/cone) bounded by exactly TWO closed full-wrap
+// rim edges and no open rim edge — the shape produced by the (u,v) cone-side split, whose band has one
+// circular rim and one oblique-cut ellipse rim, both closed loops with no seam (Oblikovati#1375). Such a
+// face's two loops each "unwrap" through toUVLoops, which would mis-route it to metricPatchMesh — a flat
+// best-fit-plane annulus that neither follows the cone nor welds to the caps sharing those rims. But it
+// is a genuine two-rim ruled band, so the saddle-band loft meshes it exactly (ruled rim-to-rim rows) and
+// tessellates each rim by its own shared edge, so it welds. ok=false unless the face is a developable
+// side with exactly two closed rim edges and no open (non-seam) edge.
+func twoClosedRimBandMesh(f *topo.Face, s geom.Surface, q Quality) (*Mesh, bool) {
+	if !isDevelopableSide(s) || !hasTwoClosedRimsNoOpen(f) {
+		return nil, false
+	}
+	return saddleBandLoftMesh(f, s, q)
+}
+
+// isPeriodicTwoRimBand reports whether the face is a no-seam two-rim ruled band — either two closed rims
+// (a (u,v) cone split) or a full circle plus a notched rim (#1374) — which the saddle loft meshes exactly
+// and whose full-wrap outer loop must NOT be re-meshed through the (u,v) CDT (it can spin / tear there).
+func isPeriodicTwoRimBand(f *topo.Face) bool {
+	return hasTwoClosedRimsNoOpen(f) || hasFullCircleAndNotchedRim(f)
+}
+
+// hasTwoClosedRimsNoOpen reports whether the face is the no-seam two-loop ruled band: exactly two closed
+// rim edges, no open edge, and NO seam edge. The absence of a seam is what distinguishes it from an
+// ordinary full periodic side (two closed circles bridged by a seam, used twice) — those are already
+// meshed by periodicBandGrid/cylinderSide and must keep that path (e.g. the off-surface-rim snap repair).
+func hasTwoClosedRimsNoOpen(f *topo.Face) bool {
+	if len(seamEdgesOf(f)) != 0 {
+		return false // a seam-bridged full side: handled by the grid path, not the two-loop band loft
+	}
+	closed := 0
+	for _, e := range f.Edges() {
+		if e.StartVertex() != e.EndVertex() {
+			return false // an open rim: handled by notchedRimBandMesh, not here
+		}
+		closed++
+	}
+	return closed == 2
+}
+
 // hasFullCircleAndNotchedRim reports whether the face has BOTH a full-period closed-circle rim edge and
 // at least one open (non-closed) rim edge — the notched-band signature. Seam edges (used twice within
 // the face) are excluded, as they bridge the rims and belong to neither.

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -53,8 +53,10 @@ func tessellateCurvedFace(f *topo.Face, q Quality) *Mesh {
 // and a periodic developable side with one full-circle rim plus a notched rim (a band loft). It returns
 // (mesh, true) on the first that applies, or (nil, false) so the caller falls through to toUVLoops.
 func specialCurvedMesh(f *topo.Face, s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, q Quality) (*Mesh, bool) {
-	if m, isFan := coneApexFan(s, outer3D); isFan {
-		return m, true // a cone closing to its apex (a drill point): a fan from the apex to the rim
+	if m, isFan := coneApexFan(s, outer3D); isFan && len(holes3D) == 0 {
+		return m, true // a cone closing to its apex (a drill point): a fan from the apex to the rim. A
+		// holed face is never an apex cap — it is a band whose inner rim is the hole (e.g. a (u,v) cone
+		// split whose outer rim is a circle and inner rim an oblique-cut ellipse), handled below.
 	}
 	if m, isCap := sphereCapFan(s, outer3D, q); isCap {
 		return m, true // a sphere cut by one plane (a cap): rings from the rim to the enclosed pole
@@ -64,6 +66,9 @@ func specialCurvedMesh(f *topo.Face, s geom.Surface, outer3D []math.Point3, hole
 	}
 	if m, isBand := notchedRimBandMesh(f, s, q); isBand {
 		return m, true // a periodic side with one full-circle rim and one notched rim (a frustum flat that fades): loft
+	}
+	if m, isBand := twoClosedRimBandMesh(f, s, q); isBand {
+		return m, true // a developable side with two CLOSED full-wrap rims (e.g. a circle + an oblique-cut ellipse): loft
 	}
 	return nil, false
 }

--- a/kernel/ops/testdata/occ_boolean_oracle.json
+++ b/kernel/ops/testdata/occ_boolean_oracle.json
@@ -22,5 +22,6 @@
   "cone ∩ box (parabola)": 293.5440727,
   "cone − box (parabola)": 366.1903846,
   "cone ∩ box (oblique vertex-inside)": 48.83120765,
-  "cone − box (oblique vertex-inside)": 610.9032496
+  "cone − box (oblique vertex-inside)": 610.9032496,
+  "cone − box (clips rim annulus)": 431.6646687
 }


### PR DESCRIPTION
## What

The last `cone ∩/− box` arrangement still falling back to triangle-soup CSG was the **clips-rim** case: an oblique plane whose section ellipse straddles a frustum rim, so the kept band's upper boundary is a cut-ellipse arc **plus** a surviving rim arc. This PR makes it exact with a unified **(u,v) arrangement split** and validates it against the OpenCASCADE `getMass` oracle.

- New `kernel/brep/curved_halfspace_cone_uv.go`: on a cone `g(u,v)=A+v·C(u)` is linear in v, so the section is single-valued `v(u)=−A/C(u)` and the kept region `{g<0}` is a per-azimuth v-interval. A wrapping band is emitted as a **two-loop, seam-free face** (like the #1374 annulus) whose rim and section arcs are whole, split only at the exact `v(u)=clamp` rim crossings so each welds to the cap/lid that shares it.
- **Winding follows the frustum convention** (lower rim CCW, upper loop reversed to CW when it shares a cap rim) instead of being derived per arrangement — this is what dissolved the clips-rim orientation paradox. The lid uses each section arc opposite to the band's final use.
- `faceWhollyOneSide` keeps a later clearing plane from demoting the trimmed band, so the box composition stays on the exact path.

**Results (OCC-validated):** within-band ellipse (both keep directions) and the **clips-rim annulus** are now exact; `cone − box (clips rim annulus)` = `431.6647` joins `curvedExactCases` + the oracle JSON. The non-wrapping *tongue* (`clip ∩`) still defers to CSG — next slice.

## Why

Closes another arrangement on the path to the M2 §M2 acceptance (#1375 / #1320): every cone-plane conic section should stay an exact analytic B-rep, not a faceted approximation.

## Tessellation fixes (top priority)

The two-loop band exposed three latent tessellation defects, fixed so the mesh is watertight and never hangs:
- `twoClosedRimBandMesh` routes a no-seam two-closed-rim developable band to the saddle-band loft (`toUVLoops` otherwise meshes it as a flat annulus → wrong volume); gated on having no seam edge so ordinary full sides keep `periodicBandGrid`.
- `coneApexFan` is skipped when the face has holes (a holed face is a band, not an apex cap).
- `conformingCylConeMesh` is skipped for periodic two-rim bands, whose full-wrap outer loop made the (u,v) constrained Delaunay **spin** (a tessellation hang).

## Tests

- `TestConeSideHalfSpaceEllipseClipsRim` (was the deferral test) now asserts the exact watertight result.
- `cone − box (clips rim annulus)` added to `curvedExactCases` (stays exact) and `TestCurvedBooleanVolumesMatchOCC` (matches OCC `getMass`).
- Full `kernel/...` + `model/...` suites green; lint clean; coverage 89.3% (brep) / 90.0% (ops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)