### PR TITLE
brep,ops: exact non-wrapping tongue cone ∩/− box via the (u,v) split (#1375)

### DIFF
--- a/kernel/brep/curved_halfspace_cone_ellipse_test.go
+++ b/kernel/brep/curved_halfspace_cone_ellipse_test.go
@@ -54,6 +54,27 @@ func TestConeSideHalfSpaceEllipseClipsRim(t *testing.T) {
 	}
 }
 
+// The same rim-straddling ellipse kept from the OTHER side is the non-wrapping TONGUE: the kept region
+// survives only over the single azimuth span where the section sits inside the band, pinching to a point
+// at each end (where the section meets the top rim). The (u,v) split's coneSideUVTongue builds it as one
+// loop — the surviving top-rim arc plus the section arc — watertight, one analytic cone face, no CSG
+// (Oblikovati/Oblikovati#1375).
+func TestConeSideHalfSpaceEllipseTongue(t *testing.T) {
+	frustum := mustFrustum(t, math.P3(0, 0, 0), math.P3(0, 0, 10), 3, 6)
+	plane, _ := geom.NewPlane(math.P3(0, 0, 9.5), math.V3(-0.5, 0, -0.866)) // keep the wedge the ellipse cuts off
+	res, err := HalfSpaceCut(frustum, plane)
+	if err != nil {
+		t.Fatalf("tongue cut should be handled exactly, got %v", err)
+	}
+	assertWatertight(t, res)
+	if cones, _, _ := faceTypeCounts(t, res); cones != 1 {
+		t.Errorf("result has %d cone faces, want exactly 1 (the tongue stays analytic)", cones)
+	}
+	if !anyFaceHasEllipse(res) {
+		t.Error("no face carries an elliptical edge — the rim-clipping ellipse was not imprinted")
+	}
+}
+
 // wrapToPi folds an angle into (−π, π] from either direction.
 func TestWrapToPi(t *testing.T) {
 	cases := []struct{ in, want float64 }{
@@ -62,6 +83,22 @@ func TestWrapToPi(t *testing.T) {
 	for _, c := range cases {
 		if got := wrapToPi(c.in); got-c.want > 1e-9 || c.want-got > 1e-9 {
 			t.Errorf("wrapToPi(%g) = %g, want %g", c.in, got, c.want)
+		}
+	}
+}
+
+// unwrapParamNear shifts a wrapped [0,1) parameter by whole turns to within ±0.5 of the reference, so a
+// section sub-arc straddling the ellipse param seam sweeps through the tongue interior, not the major arc.
+func TestUnwrapParamNear(t *testing.T) {
+	cases := []struct{ ref, x, want float64 }{
+		{0.9, 0.1, 1.1},  // forward across the seam: 0.1 lifts a turn so 0.9→1.1 is the short arc
+		{0.1, 0.9, -0.1}, // backward across the seam: 0.9 drops a turn
+		{0.4, 0.6, 0.6},  // within half a turn: unchanged
+		{0.0, 0.5, 0.5},  // exactly half a turn: unchanged (boundary)
+	}
+	for _, c := range cases {
+		if got := unwrapParamNear(c.ref, c.x); got-c.want > 1e-9 || c.want-got > 1e-9 {
+			t.Errorf("unwrapParamNear(%g, %g) = %g, want %g", c.ref, c.x, got, c.want)
 		}
 	}
 }

--- a/kernel/brep/curved_halfspace_cone_uv.go
+++ b/kernel/brep/curved_halfspace_cone_uv.go
@@ -102,12 +102,13 @@ func (c coneUV) point3(u, v float64) math.Point3 {
 // WRAPPING case (kept v-interval non-empty for every azimuth) is a band represented as a face with two
 // boundary loops (no seam, like the vertex-inside annulus #1374): the upper loop is the kept hi(u) curve
 // and the lower loop the kept lo(u) curve, each a closed chain of WHOLE rim arcs and section arcs split
-// only at the rim crossings — so each rim arc welds with the cap that shares it. A non-wrapping (tongue)
-// arrangement defers to the caller for now.
+// only at the rim crossings — so each rim arc welds with the cap that shares it. A NON-WRAPPING (tongue)
+// arrangement — the kept interval empties at some azimuths because the section straddles a rim on its
+// kept side — is built by coneSideUVTongue as one loop over the single surviving azimuth span.
 func coneSideUVSplit(f curvedFace, cone geom.Cone, conic geom.Curve3, band coneSideBand_, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
 	uv := newConeUV(cone, band, plane, n)
 	if !uv.wrapsAllU() {
-		return nil, nil, ErrUnsupportedHalfSpace // a tongue (kept interval empties somewhere): not yet built here
+		return uv.coneSideUVTongue(f, cone, conic) // a non-wrapping arrangement: one kept azimuth span
 	}
 	hiEdges, hiSec, ok1 := uv.boundaryLoop(conic, band, true)
 	loEdges, loSec, ok2 := uv.boundaryLoop(conic, band, false)
@@ -126,6 +127,109 @@ func coneSideUVSplit(f curvedFace, cone geom.Cone, conic geom.Curve3, band coneS
 		loops: []curvedLoop{{edges: hiLoop}, {edges: loEdges}}}
 	lidSection := append(append([]loopEdge{}, lidHiSec...), reverseEdgeChain(loSec)...)
 	return []curvedFace{kept}, lidSection, nil
+}
+
+// coneSideUVTongue builds the kept face of a NON-WRAPPING arrangement: the section straddles the rim on
+// its kept side (the section ellipse dips below vMin, or rises above vMax), so the kept v-interval is
+// non-empty only over a single azimuth span [u1, u2] and pinches to a point at each end (where the
+// section meets the clamp rim). The kept region is one loop — the LOWER bound forward over [u1, u2] then
+// the UPPER bound reversed — closing at the two pinch vertices; the section sub-arcs cap the planar lid
+// together with the cap chords the same plane carves on the frustum's end caps (Oblikovati#1375).
+func (c coneUV) coneSideUVTongue(f curvedFace, cone geom.Cone, conic geom.Curve3) ([]curvedFace, []loopEdge, error) {
+	u1, u2, ok := c.keptUSpan()
+	if !ok {
+		return nil, nil, ErrUnsupportedHalfSpace // not a single span (only an ellipse-section tongue is built)
+	}
+	loEdges, loSec, ok1 := c.boundarySubChain(conic, u1, u2, false)
+	hiEdges, hiSec, ok2 := c.boundarySubChain(conic, u1, u2, true)
+	if !ok1 || !ok2 {
+		return nil, nil, ErrUnsupportedHalfSpace
+	}
+	loop := append(append([]loopEdge{}, loEdges...), reverseEdgeChain(hiEdges)...)
+	kept := curvedFace{surface: cone, reversed: f.reversed, lineage: f.lineage, loops: []curvedLoop{{edges: loop}}}
+	// The lid uses each section sub-arc OPPOSITE to the band's final use: the lo section runs forward in the
+	// band so the lid reverses it; the hi section runs reversed in the band so the lid uses it forward.
+	section := append(reverseEdgeChain(loSec), hiSec...)
+	return []curvedFace{kept}, section, nil
+}
+
+// keptUSpan returns the single azimuth interval [u1, u2] (u2 may exceed 2π when the span wraps the seam)
+// where the kept v-interval is non-empty — the tongue's u-extent, pinching at u1 and u2 where the section
+// reaches the clamp rim. ok=false unless the kept region is EXACTLY one such span (an ellipse section
+// straddling a rim makes exactly one; anything else is left to the caller's fallback).
+func (c coneUV) keptUSpan() (u1, u2 float64, ok bool) {
+	const twoPi, N = 2 * stdmath.Pi, 1440
+	var starts, ends []float64
+	prev := c.keptNonEmpty(0)
+	for i := 1; i <= N; i++ {
+		u := twoPi * float64(i) / N
+		cur := c.keptNonEmpty(u)
+		switch {
+		case cur && !prev:
+			starts = append(starts, c.bisectKeptEdge(twoPi*float64(i-1)/N, u, true))
+		case !cur && prev:
+			ends = append(ends, c.bisectKeptEdge(twoPi*float64(i-1)/N, u, false))
+		}
+		prev = cur
+	}
+	if len(starts) != 1 || len(ends) != 1 {
+		return 0, 0, false
+	}
+	u1, u2 = starts[0], ends[0]
+	if u2 < u1 {
+		u2 += twoPi // the kept span straddles the seam (it was already open at u=0)
+	}
+	return u1, u2, true
+}
+
+// keptNonEmpty reports whether the kept v-interval is non-empty at azimuth u.
+func (c coneUV) keptNonEmpty(u float64) bool { _, _, ok := c.keptV(u); return ok }
+
+// bisectKeptEdge refines the azimuth where the kept interval pinches to empty — the tongue endpoint where
+// the section curve meets the clamp rim. rising=true brackets an empty→non-empty edge, else non-empty→empty.
+func (c coneUV) bisectKeptEdge(lo, hi float64, rising bool) float64 {
+	for i := 0; i < 60; i++ {
+		mid := (lo + hi) / 2
+		if c.keptNonEmpty(mid) == rising {
+			hi = mid
+		} else {
+			lo = mid
+		}
+	}
+	return (lo + hi) / 2
+}
+
+// boundarySubChain builds the boundary chain (rim and section edges) of the upper or lower bound over the
+// non-wrapping azimuth span [ua, ub], split at the interior rim crossings, with the section sub-arcs
+// returned separately (u-increasing) for the lid.
+func (c coneUV) boundarySubChain(conic geom.Curve3, ua, ub float64, upper bool) (edges, section []loopEdge, ok bool) {
+	breaks := append([]float64{ua}, c.interiorRimCrossings(ua, ub, upper)...)
+	breaks = append(breaks, ub)
+	for i := 0; i+1 < len(breaks); i++ {
+		e, sec, good := c.boundaryEdge(conic, breaks[i], breaks[i+1], upper)
+		if !good {
+			return nil, nil, false
+		}
+		edges = append(edges, e)
+		section = append(section, sec...)
+	}
+	return edges, section, true
+}
+
+// interiorRimCrossings returns the azimuths strictly inside (ua, ub) where the bound switches between a
+// rim and the section curve, bisected to the exact crossing (where the section reaches the clamp rim).
+func (c coneUV) interiorRimCrossings(ua, ub float64, upper bool) []float64 {
+	const N = 1440
+	var out []float64
+	prev := c.onRim(ua, upper)
+	for i := 1; i < N; i++ {
+		u := ua + (ub-ua)*float64(i)/N
+		if cur := c.onRim(u, upper); cur != prev {
+			out = append(out, c.bisectRimBreak(ua+(ub-ua)*float64(i-1)/N, u, upper))
+			prev = cur
+		}
+	}
+	return out
 }
 
 // loAt and hiAt give the kept interval's lower / upper bound at azimuth u.
@@ -245,10 +349,42 @@ func (c coneUV) boundaryEdge(conic geom.Curve3, ua, ub float64, upper bool) (loo
 		}
 		return loopEdge{curve: arc, t0: 0, t1: 1}, nil, true
 	}
-	va := c.sectionV(ua)
-	vb := c.sectionV(ub)
-	e := conicArm(conic, c.point3(ua, va), c.point3(ub, vb)) // a partial section arc
+	e := c.sectionArm(conic, ua, ub) // a partial section arc, seam-wrap-safe for a full ellipse
 	return e, []loopEdge{e}, true
+}
+
+// sectionArm builds the section conic sub-arc spanning azimuth [ua, ub]. For a full ellipse the endpoint
+// parameters alone are ambiguous (the param seam may fall inside the span, so a plain start→end sweep can
+// trace the COMPLEMENTARY major arc instead of the tongue side); the midpoint azimuth's parameter
+// disambiguates by unwrapping start→mid→end onto one monotone run. Other conics (hyperbola/parabola arms)
+// are open and need no unwrapping, so conicArm's endpoint parameters suffice.
+func (c coneUV) sectionArm(conic geom.Curve3, ua, ub float64) loopEdge {
+	el, ok := conic.(geom.EllipseFull)
+	if !ok {
+		return conicArm(conic, c.point3(ua, c.sectionV(ua)), c.point3(ub, c.sectionV(ub)))
+	}
+	t0 := c.ellipseParamAt(el, ua)
+	tm := unwrapParamNear(t0, c.ellipseParamAt(el, (ua+ub)/2))
+	t1 := unwrapParamNear(tm, c.ellipseParamAt(el, ub))
+	return loopEdge{curve: el, t0: t0, t1: t1}
+}
+
+// ellipseParamAt returns the full ellipse's parameter (in [0,1)) at the section point of azimuth u.
+func (c coneUV) ellipseParamAt(el geom.EllipseFull, u float64) float64 {
+	t, _ := geom.CurveParamAtPoint3(el, c.point3(u, c.sectionV(u)))
+	return t
+}
+
+// unwrapParamNear shifts x by whole turns so it lands within ±0.5 of ref — turning a wrapped [0,1)
+// parameter sequence into a monotone run, so the swept ellipse arc passes through the interior point.
+func unwrapParamNear(ref, x float64) float64 {
+	for x-ref > 0.5 {
+		x--
+	}
+	for x-ref < -0.5 {
+		x++
+	}
+	return x
 }
 
 // fullSectionEdge builds the closed re-anchored ellipse edge when a boundary is the whole within-band

--- a/kernel/ops/boolean_csg_demotion_test.go
+++ b/kernel/ops/boolean_csg_demotion_test.go
@@ -128,6 +128,7 @@ func curvedExactCases() []curvedExactCase {
 		{"cone ∩ box (oblique vertex-inside)", ops.Intersect, coneObliqueVertexInsideBox},
 		{"cone − box (oblique vertex-inside)", ops.Cut, coneObliqueVertexInsideBox},
 		{"cone − box (clips rim annulus)", ops.Cut, coneClipsRimBox},
+		{"cone ∩ box (clips rim tongue)", ops.Intersect, coneClipsRimBox},
 	}
 }
 
@@ -135,7 +136,8 @@ func curvedExactCases() []curvedExactCase {
 // THROUGH the tilted top rim (the rim z-range is [4.4, 11.6]): the section ellipse clips the top rim, so
 // the kept annulus's upper boundary is the ellipse arc PLUS the surviving top-rim arc — the clips-rim
 // arrangement built exactly by the (u,v) split (Oblikovati/Oblikovati#1375). The complementary ∩ keeps
-// the non-wrapping tongue above z=6, which still demotes to CSG, so only the Cut is an exact case.
+// the non-wrapping TONGUE above z=6 (the surviving top-rim arc plus the section arc, pinching where the
+// section meets the rim) — also built exactly by the (u,v) split's coneSideUVTongue.
 func coneClipsRimBox(t *testing.T) (*topo.Body, *topo.Body) {
 	return demoCone(t, math.P3(0, 0, 0), math.P3(0, 6, 8), 3, 6), demoBlock(t, math.P3(-30, -30, 6), math.P3(30, 30, 40))
 }

--- a/kernel/ops/testdata/occ_boolean_oracle.json
+++ b/kernel/ops/testdata/occ_boolean_oracle.json
@@ -23,5 +23,6 @@
   "cone − box (parabola)": 366.1903846,
   "cone ∩ box (oblique vertex-inside)": 48.83120765,
   "cone − box (oblique vertex-inside)": 610.9032496,
-  "cone − box (clips rim annulus)": 431.6646687
+  "cone − box (clips rim annulus)": 431.6646687,
+  "cone ∩ box (clips rim tongue)": 228.0697885
 }


### PR DESCRIPTION
## What

The cone-side **(u,v) arrangement split** already built every *wrapping* cone–plane arrangement exactly (within-band ellipse, clips-rim annulus). This closes the last deferred arrangement — the **non-wrapping tongue** — so it too takes the exact analytic path instead of demoting to triangle-soup CSG.

When the section ellipse straddles the rim on its *kept* side, the kept `v`-interval empties at some azimuths: the kept region is a single **tongue** surviving only over one azimuth span, pinching to a point at each end where the section meets the clamp rim.

## How

- `coneSideUVTongue` reuses the same `(u,v)` model: `keptUSpan` finds the one surviving azimuth span (endpoints bisected to where the section reaches the clamp rim); the kept face is one loop — lower bound forward over the span, then upper bound reversed — each a chain of rim arcs and section sub-arcs via `boundarySubChain`/`interiorRimCrossings`.
- The section sub-arcs cap the planar lid together with the chords the same plane carves on the frustum's end caps (the general half-space pipeline chains them).
- `boundaryEdge`'s section arc is now seam-wrap-safe (`sectionArm`/`unwrapParamNear`): a full-ellipse sub-arc straddling the param seam sweeps the *tongue interior*, not the complementary major arc.

## Validation (OpenCASCADE `getMass`)

`cone ∩ box (clips rim tongue)` ours **226.93** vs occ **228.07** — rel **0.005** (the faceting deficit, well under the 0.05 budget). And `228.07 + 431.66` (the clips-rim annulus) `= 659.73`, the whole frustum, so the ∩/− pair partitions it exactly.

Both the **exactness guard** (`TestCurvedBooleansStayExact`) and the **OCC oracle** (`TestCurvedBooleanVolumesMatchOCC`) now cover the tongue, plus a brep-level watertight test (`TestConeSideHalfSpaceEllipseTongue`) and a `unwrapParamNear` unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)