### PR TITLE
brep,ops: exact oblique cut of a FULL cone to its apex (#1375)

### DIFF
--- a/kernel/brep/curved_halfspace_cone_side.go
+++ b/kernel/brep/curved_halfspace_cone_side.go
@@ -23,12 +23,16 @@ import (
 
 // coneSideBand carries a frustum side's two cross-section circles (centres on the axis, ordered
 // low→high in apex distance), the source rim circles themselves (so a kept face can reuse a rim edge
-// and weld with its cap), and their radii.
+// and weld with its cap), and their radii. topRimReversed records how the SOURCE side face traverses the
+// top (vMax) rim — opposite to the cap that shares it; the kept band reuses that sense so its rim stays
+// opposite that cap. A frustum/cylinder side (apex below, axis "up") traverses the top rim REVERSED; an
+// apex-at-top full cone (axis "down") traverses its sole rim FORWARD, so this is not a fixed convention.
 type coneSideBand_ struct {
 	bottom, top         math.Point3
 	bottomCirc, topCirc geom.Circle
 	vMin, vMax          float64
 	rBot, rTop          float64
+	topRimReversed      bool
 }
 
 // coneSideBand recovers the frustum side's two full-circle rims, ordered by apex distance. ok=false
@@ -38,9 +42,10 @@ func coneSideBand(f curvedFace, cone geom.Cone) (coneSideBand_, bool) {
 	axis := cone.AxisDir.AsVector()
 	tanA := stdmath.Tan(cone.HalfAngle)
 	var circles []geom.Circle
+	var revs []bool
 	for _, le := range f.loops[0].edges {
 		if c, isCircle := le.curve.(geom.Circle); isCircle && isFullDomain(le.t0, le.t1) {
-			circles = append(circles, c)
+			circles, revs = append(circles, c), append(revs, le.t1 < le.t0)
 		}
 	}
 	if len(circles) != 2 {
@@ -48,6 +53,7 @@ func coneSideBand(f curvedFace, cone geom.Cone) (coneSideBand_, bool) {
 	}
 	if float64(cone.Apex.VectorTo(circles[0].Center).Dot(axis)) > float64(cone.Apex.VectorTo(circles[1].Center).Dot(axis)) {
 		circles[0], circles[1] = circles[1], circles[0]
+		revs[0], revs[1] = revs[1], revs[0]
 	}
 	vMin := float64(cone.Apex.VectorTo(circles[0].Center).Dot(axis))
 	vMax := float64(cone.Apex.VectorTo(circles[1].Center).Dot(axis))
@@ -55,6 +61,7 @@ func coneSideBand(f curvedFace, cone geom.Cone) (coneSideBand_, bool) {
 		bottom: circles[0].Center, top: circles[1].Center,
 		bottomCirc: circles[0], topCirc: circles[1],
 		vMin: vMin, vMax: vMax, rBot: vMin * tanA, rTop: vMax * tanA,
+		topRimReversed: revs[1],
 	}, true
 }
 
@@ -67,6 +74,44 @@ func coneSideBandSplit(f curvedFace, curves []geom.Curve3, cone geom.Cone, band 
 		return nil, nil, ErrUnsupportedHalfSpace
 	}
 	return coneSideUVSplit(f, cone, curves[0], band, plane, n)
+}
+
+// fullConeApexSideBand reports whether f is a FULL cone side closing to its APEX — a geom.Cone whose
+// single boundary loop is exactly one full rim circle, the apex its v=0 pole (no second rim). It returns
+// the cone and a band whose bottom "rim" is the degenerate apex (vMin=0, rBot=0, a zero-radius circle) and
+// whose top rim is the circle, so the (u,v) split treats the apex as the v=0 pole. A frustum (two circles)
+// or an already-trimmed band (a circle plus section arcs) fails the one-edge test and is handled elsewhere.
+func fullConeApexSideBand(f curvedFace) (geom.Cone, coneSideBand_, bool) {
+	cone, ok := f.surface.(geom.Cone)
+	if !ok || len(f.loops) != 1 {
+		return geom.Cone{}, coneSideBand_{}, false
+	}
+	var circle geom.Circle
+	circles, rimReversed, touchesApex := 0, false, false
+	for _, le := range f.loops[0].edges {
+		if c, isCircle := le.curve.(geom.Circle); isCircle && isFullDomain(le.t0, le.t1) {
+			circle, circles, rimReversed = c, circles+1, le.t1 < le.t0
+		}
+		if samePoint(le.start(), cone.Apex) || samePoint(le.end(), cone.Apex) {
+			touchesApex = true // a seam ruling ends at the apex pole
+		}
+	}
+	if circles != 1 || !touchesApex { // a frustum has two circles; a trimmed band reaches no apex vertex
+		return geom.Cone{}, coneSideBand_{}, false
+	}
+	axis := cone.AxisDir.AsVector()
+	vRim := float64(cone.Apex.VectorTo(circle.Center).Dot(axis))
+	apexCirc, err := geom.NewCircle(cone.Apex, axis, 0) // the degenerate zero-radius rim at the apex pole
+	if err != nil {
+		return geom.Cone{}, coneSideBand_{}, false
+	}
+	band := coneSideBand_{
+		bottom: cone.Apex, top: circle.Center,
+		bottomCirc: apexCirc, topCirc: circle,
+		vMin: 0, vMax: vRim, rBot: 0, rTop: vRim * stdmath.Tan(cone.HalfAngle),
+		topRimReversed: rimReversed,
+	}
+	return cone, band, true
 }
 
 // conicArm builds the loop edge along an open conic section (a hyperbola branch or a parabola) from

--- a/kernel/brep/curved_halfspace_cone_test.go
+++ b/kernel/brep/curved_halfspace_cone_test.go
@@ -3,7 +3,6 @@
 package brep
 
 import (
-	"errors"
 	"testing"
 
 	"oblikovati.org/kernel/geom"
@@ -72,12 +71,35 @@ func TestHalfSpaceCutFrustumReCut(t *testing.T) {
 	assertConeManifold(t, res, 3)
 }
 
-// TestHalfSpaceCutConeObliqueDefers: an oblique plane cuts an ellipse/hyperbola section that the analytic
-// imprint does not solve, so the cut defers and the caller keeps the CSG fallback.
-func TestHalfSpaceCutConeObliqueDefers(t *testing.T) {
+// TestHalfSpaceCutConeObliqueApexExact: an oblique plane cuts a FULL cone (apex at z=10) in a conic
+// section the (u,v) ruled split now builds exactly — the full-cone-to-apex case (Oblikovati#1375). The
+// plane drops the apex, so the kept part is a frustum-like band (the base cap, the cone band, and the
+// section lid), watertight, no CSG fallback.
+func TestHalfSpaceCutConeObliqueApexExact(t *testing.T) {
 	cone, _ := SolidCylinderCone(math.P3(0, 0, 0), math.P3(0, 0, 10), 3, 0, "cone")
-	plane, _ := geom.NewPlane(math.P3(0, 0, 5), math.V3(1, 0, 1)) // tilted: not perpendicular to the axis
-	if _, err := HalfSpaceCut(cone, plane); !errors.Is(err, ErrUnsupportedHalfSpace) {
-		t.Errorf("oblique cone cut should defer, got err=%v", err)
+	plane, _ := geom.NewPlane(math.P3(0, 0, 4), math.V3(0.5, 0, 0.866)) // steep oblique → ellipse, apex dropped
+	res, err := HalfSpaceCut(cone, plane)
+	if err != nil {
+		t.Fatalf("oblique full-cone cut should now be exact, got %v", err)
+	}
+	assertWatertight(t, res)
+	if cones, _, _ := faceTypeCounts(t, res); cones != 1 {
+		t.Errorf("result has %d cone faces, want exactly 1 (the band stays analytic)", cones)
+	}
+}
+
+// TestHalfSpaceCutConeObliqueApexKept keeps the apex side of an oblique full-cone cut: the kept solid is
+// the cone TIP closing to its apex pole, a single-loop cone face capped by the elliptical lid — watertight,
+// one analytic cone face, no CSG (the apex-kept branch of the full-cone-to-apex split, Oblikovati#1375).
+func TestHalfSpaceCutConeObliqueApexKept(t *testing.T) {
+	cone, _ := SolidCylinderCone(math.P3(0, 0, 0), math.P3(0, 0, 10), 3, 0, "cone")
+	plane, _ := geom.NewPlane(math.P3(0, 0, 4), math.V3(-0.5, 0, -0.866)) // keep the apex tip above the ellipse
+	res, err := HalfSpaceCut(cone, plane)
+	if err != nil {
+		t.Fatalf("apex-kept oblique cut should be exact, got %v", err)
+	}
+	assertWatertight(t, res)
+	if cones, _, _ := faceTypeCounts(t, res); cones != 1 {
+		t.Errorf("result has %d cone faces, want exactly 1 (the cone tip stays analytic)", cones)
 	}
 }

--- a/kernel/brep/curved_halfspace_cylinder_side.go
+++ b/kernel/brep/curved_halfspace_cylinder_side.go
@@ -27,9 +27,10 @@ func fullCylinderSideBand(f curvedFace) (geom.Cylinder, coneSideBand_, bool) {
 		return geom.Cylinder{}, coneSideBand_{}, false
 	}
 	var circles []geom.Circle
+	var revs []bool
 	for _, le := range f.loops[0].edges {
 		if c, isCircle := le.curve.(geom.Circle); isCircle && isFullDomain(le.t0, le.t1) {
-			circles = append(circles, c)
+			circles, revs = append(circles, c), append(revs, le.t1 < le.t0)
 		}
 	}
 	if len(circles) != 2 {
@@ -38,12 +39,14 @@ func fullCylinderSideBand(f curvedFace) (geom.Cylinder, coneSideBand_, bool) {
 	axis := cyl.AxisDir.AsVector()
 	if float64(circles[0].Center.VectorTo(circles[1].Center).Dot(axis)) < 0 {
 		circles[0], circles[1] = circles[1], circles[0] // order low→high along the axis
+		revs[0], revs[1] = revs[1], revs[0]
 	}
 	height := float64(circles[0].Center.VectorTo(circles[1].Center).Dot(axis))
 	band := coneSideBand_{
 		bottom: circles[0].Center, top: circles[1].Center,
 		bottomCirc: circles[0], topCirc: circles[1],
 		vMin: 0, vMax: height, rBot: cyl.Radius, rTop: cyl.Radius,
+		topRimReversed: revs[1],
 	}
 	return cyl, band, true
 }

--- a/kernel/brep/curved_halfspace_general.go
+++ b/kernel/brep/curved_halfspace_general.go
@@ -66,6 +66,16 @@ func faceWhollyOneSide(f curvedFace, plane geom.Plane, n math.Vector3) bool {
 			}
 		}
 	}
+	// A full cone closes to its apex pole, which lies on no boundary edge — sample it too, else a cut that
+	// separates the apex from the rim is missed (the rim alone reads as wholly one side, #1375).
+	if cone, _, ok := fullConeApexSideBand(f); ok {
+		switch d := signedDistance(cone.Apex, plane, n); {
+		case d > cylinderAxisTol:
+			pos = true
+		case d < -cylinderAxisTol:
+			neg = true
+		}
+	}
 	return !neg || !pos // wholly on one side (or grazing): no genuine crossing
 }
 
@@ -91,6 +101,9 @@ func splitFaceByPlane(f curvedFace, plane geom.Plane, n math.Vector3) ([]curvedF
 	}
 	if cone, band, ok := fullConeSideBand(f); ok {
 		return coneSideBandSplit(f, curves, cone, band, plane, n)
+	}
+	if cone, band, ok := fullConeApexSideBand(f); ok {
+		return coneApexSideSplit(f, cone, curves[0], band, plane, n)
 	}
 	return loopedSplit(f, curves, plane, n)
 }

--- a/kernel/brep/curved_halfspace_ruled_uv.go
+++ b/kernel/brep/curved_halfspace_ruled_uv.go
@@ -129,6 +129,40 @@ func coneSideUVSplit(f curvedFace, cone geom.Cone, conic geom.Curve3, band coneS
 	return newConeUV(cone, band, plane, n).splitSide(f, cone, conic)
 }
 
+// coneApexSideSplit splits a FULL cone side (apex + one rim) by the (u,v) arrangement. The apex is the
+// v=0 pole; because a cone has q=0, the apex's signed distance is the constant p, so it is kept exactly
+// when p<0. Apex DROPPED → the kept region is a frustum-like band (section + rim) the standard splitSide
+// builds (it never references the degenerate apex rim). Apex KEPT → the kept face closes to the apex as a
+// single loop (the cut ellipse, or the notched rim), the apex an interior pole (apexCapSide).
+func coneApexSideSplit(f curvedFace, cone geom.Cone, conic geom.Curve3, band coneSideBand_, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
+	uv := newConeUV(cone, band, plane, n)
+	if !uv.apexKept() {
+		return uv.splitSide(f, cone, conic) // apex on the dropped side: a frustum-like band, no apex pole
+	}
+	return uv.apexCapSide(f, cone, conic)
+}
+
+// apexKept reports whether the cone apex (the v=0 pole) is on the kept (negative) side. A cone has q=0, so
+// a(0)=p is constant in u and the apex's signed distance g(0)=p; the apex is kept exactly when p<0.
+func (c ruledUV) apexKept() bool { return c.p < 0 }
+
+// apexCapSide builds the kept face when the apex is KEPT: the cone closes to its apex pole capped by the
+// cut, so the face is a SINGLE loop — the hi boundary (the full cut ellipse, or the rim notched by the
+// section) — with the apex an interior pole and no lower loop. The hi boundary is oriented like splitSide's
+// upper loop (reversed when it carries a rim shared with the base cap); the section caps the lid.
+func (c ruledUV) apexCapSide(f curvedFace, surface geom.Surface, conic geom.Curve3) ([]curvedFace, []loopEdge, error) {
+	hiEdges, hiSec, ok := c.boundaryLoop(conic, true)
+	if !ok {
+		return nil, nil, ErrUnsupportedHalfSpace
+	}
+	hiLoop, lidSec := hiEdges, reverseEdgeChain(hiSec)
+	if loopHasRim(hiEdges) && c.band.topRimReversed {
+		hiLoop, lidSec = reverseEdgeChain(hiEdges), hiSec
+	}
+	kept := curvedFace{surface: surface, reversed: f.reversed, lineage: f.lineage, loops: []curvedLoop{{edges: hiLoop}}}
+	return []curvedFace{kept}, lidSec, nil
+}
+
 // cylinderSideUVSplit splits a full periodic cylinder side by the (u,v) arrangement (newCylinderUV +
 // splitSide). It handles both the axis-parallel flat (b≡0 → a vertical-edged span) and an oblique ellipse
 // cut (within-band / clips-rim / tongue), the latter the case the line-only cylinder split deferred to CSG.
@@ -151,12 +185,13 @@ func (c ruledUV) splitSide(f curvedFace, surface geom.Surface, conic geom.Curve3
 	if !ok1 || !ok2 {
 		return nil, nil, ErrUnsupportedHalfSpace
 	}
-	// A ruled side's two rims run oppositely (lower CCW, upper CW) so the side stays consistent with both
-	// caps. The lo boundary is built CCW (forward); the UPPER boundary is reversed to CW whenever it carries
-	// a rim shared with a kept cap, so that rim welds to the cap with opposite sense. The lid then uses each
-	// section sub-arc OPPOSITE to the band's (final) use of it, so the shared section edge is consistent too.
+	// A ruled side's two rims run oppositely so the side stays consistent with both caps. The lo boundary is
+	// built CCW (forward); the UPPER boundary is reversed whenever it carries a rim that the source face
+	// traversed reversed (band.topRimReversed) — so the rebuilt rim keeps the sense opposite its kept cap.
+	// A frustum/cylinder traverses the top rim reversed; an apex-at-top full cone traverses its rim forward,
+	// so this is NOT a fixed flip. The lid uses each section sub-arc OPPOSITE to the band's final use of it.
 	hiLoop, lidHiSec := hiEdges, reverseEdgeChain(hiSec)
-	if loopHasRim(hiEdges) {
+	if loopHasRim(hiEdges) && c.band.topRimReversed {
 		hiLoop, lidHiSec = reverseEdgeChain(hiEdges), hiSec
 	}
 	kept := curvedFace{surface: surface, reversed: f.reversed, lineage: f.lineage,

--- a/kernel/ops/boolean_csg_demotion_test.go
+++ b/kernel/ops/boolean_csg_demotion_test.go
@@ -133,7 +133,17 @@ func curvedExactCases() []curvedExactCase {
 		{"cylinder − box (oblique ellipse)", ops.Cut, cylinderObliqueEllipseBox},
 		{"cylinder − box (clips rim annulus)", ops.Cut, cylinderClipsRimBox},
 		{"cylinder ∩ box (clips rim tongue)", ops.Intersect, cylinderClipsRimBox},
+		{"cone apex − box (oblique, apex dropped)", ops.Cut, coneApexObliqueBox},
+		{"cone apex ∩ box (oblique, apex kept)", ops.Intersect, coneApexObliqueBox},
 	}
+}
+
+// coneApexObliqueBox is a FULL cone (apex at the top, base radius 3) tilted (axis (0,0.6,0.8)) cut by the
+// box face z=4. The section is an oblique ELLIPSE wholly between the base rim and the apex: the Cut keeps
+// the base side (apex DROPPED → a frustum-like band) and the ∩ keeps the tip (apex KEPT → a one-loop cone
+// closing to its apex pole, capped by the elliptical cut). The full-cone-to-apex case (Oblikovati#1375).
+func coneApexObliqueBox(t *testing.T) (*topo.Body, *topo.Body) {
+	return demoCone(t, math.P3(0, 0, 0), math.P3(0, 6, 8), 3, 0), demoBlock(t, math.P3(-20, -20, 4), math.P3(20, 20, 30))
 }
 
 // cylinderObliqueEllipseBox is a tilted cylinder (axis (0,0.6,0.8)) cut by the axis-aligned box face z=4 —

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -53,10 +53,12 @@ func tessellateCurvedFace(f *topo.Face, q Quality) *Mesh {
 // and a periodic developable side with one full-circle rim plus a notched rim (a band loft). It returns
 // (mesh, true) on the first that applies, or (nil, false) so the caller falls through to toUVLoops.
 func specialCurvedMesh(f *topo.Face, s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, q Quality) (*Mesh, bool) {
-	if m, isFan := coneApexFan(s, outer3D); isFan && len(holes3D) == 0 {
-		return m, true // a cone closing to its apex (a drill point): a fan from the apex to the rim. A
-		// holed face is never an apex cap — it is a band whose inner rim is the hole (e.g. a (u,v) cone
-		// split whose outer rim is a circle and inner rim an oblique-cut ellipse), handled below.
+	if len(holes3D) == 0 && faceIsConeApexCap(f, s) {
+		if m, isFan := coneApexFan(s, outer3D); isFan {
+			return m, true // a cone closing to its apex (a drill point or an oblique apex cap): a fan from
+			// the apex to the rim. A holed face is never an apex cap — it is a band whose inner rim is the
+			// hole; a stub (saddle-bounded) is rejected by faceIsConeApexCap, not fanned to a far-off apex.
+		}
 	}
 	if m, isCap := sphereCapFan(s, outer3D, q); isCap {
 		return m, true // a sphere cut by one plane (a cap): rings from the rim to the enclosed pole
@@ -409,14 +411,6 @@ func coneApexFan(s geom.Surface, outer3D []math.Point3) (*Mesh, bool) {
 	if !ok || len(outer3D) < 3 {
 		return nil, false
 	}
-	vMin, vMax := stdmath.Inf(1), stdmath.Inf(-1)
-	for _, p := range outer3D {
-		_, v := cone.ParamAt(p)
-		vMin, vMax = stdmath.Min(vMin, v), stdmath.Max(vMax, v)
-	}
-	if vMax-vMin > trimBorderTol {
-		return nil, false // a frustum (two rim circles), not an apex cap
-	}
 	m := &Mesh{}
 	apex := m.addVertex(cone.Apex, cone.AxisDir.AsVector().Scale(-1)) // axial normal at the pole
 	rim := make([]int, len(outer3D))
@@ -432,6 +426,28 @@ func coneApexFan(s geom.Surface, outer3D []math.Point3) (*Mesh, bool) {
 		m.addTriangle(apex, b, c)
 	}
 	return m, true
+}
+
+// faceIsConeApexCap reports whether a cone face is a SEAM-FREE apex cap — a single loop that is one closed
+// conic rim (a circle or an oblique-cut ellipse) encircling the axis, so an apex fan tiles it cleanly. This
+// is the brep drill point and the oblique apex cut (Oblikovati#1375). A SEAMED apex face (an imported cone
+// whose loop carries seam rulings down to the apex) is excluded: its boundary already spans the apex, so it
+// is meshed by the seamed closed-domain mesher, not the fan. A frustum band or a crossing-cone stub
+// (bounded by saddle curves) also fails the single-closed-conic test and is not fanned to a far-off apex.
+func faceIsConeApexCap(f *topo.Face, s geom.Surface) bool {
+	if _, ok := s.(geom.Cone); !ok || len(f.Loops()) != 1 {
+		return false
+	}
+	uses := f.Loops()[0].EdgeUses()
+	if len(uses) != 1 {
+		return false
+	}
+	e := uses[0].Edge()
+	switch e.Geometry().(type) {
+	case geom.Circle, geom.EllipseFull, geom.EllipticalArc:
+		return e.StartVertex() == e.EndVertex() // a single closed conic rim around the axis
+	}
+	return false
 }
 
 // bracketPeriod normalises a periodic direction's samples to span a CLOSED [0, 2π]: a seam sample whose

--- a/kernel/ops/testdata/occ_boolean_oracle.json
+++ b/kernel/ops/testdata/occ_boolean_oracle.json
@@ -28,5 +28,7 @@
   "cylinder ∩ box (oblique ellipse)": 141.3716694,
   "cylinder − box (oblique ellipse)": 141.3716694,
   "cylinder − box (clips rim annulus)": 245.4880608,
-  "cylinder ∩ box (clips rim tongue)": 37.25527803
+  "cylinder ∩ box (clips rim tongue)": 37.25527803,
+  "cone apex − box (oblique, apex dropped)": 81.51203176,
+  "cone apex ∩ box (oblique, apex kept)": 12.73574788
 }


### PR DESCRIPTION
## What

The last deferred ruled-side arrangement: an oblique plane cutting a **full cone** (apex + one rim, the apex its v=0 pole) carved a conic the analytic split couldn't build, so it fell to CSG. A full cone is just the `(u,v)` ruled side with `vMin=0` and a degenerate (radius-0) apex rim, so the same model handles it — split by which side the apex falls on. Because a cone has `q=0`, the apex's signed distance is the constant `p`, so the apex is kept exactly when `p<0`:

- **apex dropped** → a frustum-like band (section ellipse + base rim), built by the standard `splitSide` (it never references the apex rim);
- **apex kept** → the kept face closes to the apex as **one loop** (the cut ellipse, or the notched rim) with the apex an interior pole (`apexCapSide`).

`fullConeApexSideBand` recognises the full-cone side (one rim circle + seam rulings meeting at the apex) and synthesises the apex band; `coneApexSideSplit` routes by `apexKept`.

## Three supporting fixes

1. **`faceWhollyOneSide` samples the apex pole** — a full cone whose rim is wholly one side but whose apex is on the other was wrongly kept whole (the rim alone read as uncrossed), so the cut was missed.
2. **`topRimReversed`** — the kept band's top rim must stay opposite its cap, but an apex-at-top cone's axis runs *opposite* a frustum's, so the source rim is traversed forward, not reversed. The band records the source direction and `splitSide` reverses the hi rim only when set (a fixed flip left the base rim inconsistent — a flipped edge → CSG).
3. **`coneApexFan` via `faceIsConeApexCap`** — fires for a *seam-free single closed-conic rim* (circle or oblique-cut ellipse). This admits the new tilted-ellipse apex cap (the old constant-v guard rejected its varying-v rim) while still excluding a *seamed* imported cone (meshed by the seamed mesher, keeps `cone_sharp` watertight) and a crossing-cone *stub* (saddle-bounded — must not fan to a far-off apex).

## Validation (OpenCASCADE `getMass`)

`cone apex − box (apex dropped)` 80.81 vs 81.51, `cone apex ∩ box (apex kept)` 12.53 vs 12.74 — and `81.51 + 12.74 = 94.25 = 30π`, the whole cone, so the pair partitions it. Both join `curvedExactCases` + the OCC oracle; the former `TestHalfSpaceCutConeObliqueDefers` becomes `…ApexExact`/`…ApexKept`. Full kernel+model suites green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)