### PR TITLE
brep,geom,ops: exact perpendicular torus half-space cut (#1375)

### DIFF
--- a/kernel/brep/curved_halfspace.go
+++ b/kernel/brep/curved_halfspace.go
@@ -41,5 +41,8 @@ func HalfSpaceCut(body *topo.Body, plane geom.Plane) (*topo.Body, error) {
 	if cone, vMin, vMax, ok := coneSolidParams(faces); ok && perpendicularToConeAxis(n, cone) {
 		return coneHalfSpace(body, cone, vMin, vMax, plane) // ⟂ cut → cone/frustum, fast path
 	}
+	if torus, ok := torusSolidParams(faces); ok && perpendicularToTorusAxis(n, torus) {
+		return torusHalfSpace(body, torus, plane) // ⟂ cut → trimmed torus band + annular lid
+	}
 	return generalHalfSpace(body, plane, n, faces)
 }

--- a/kernel/brep/curved_halfspace_looped.go
+++ b/kernel/brep/curved_halfspace_looped.go
@@ -33,13 +33,20 @@ type keptSeg struct {
 // cylinder arc band a box re-cuts), each kept run bridged along whichever imprint curve joins it. A face
 // with holes, an odd crossing count (a tangency/island), or an unbridgeable run defers.
 func loopedSplit(f curvedFace, curves []geom.Curve3, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
+	if !faceBoundaryCrosses(f, plane, n) {
+		// The imprint curve exists but does not cross ANY of the face's boundary loops — the face lies
+		// wholly on one side (e.g. a far clearing plane on a multi-loop annular lid). Keep or drop it whole;
+		// this precedes the single-loop requirement so a clearing plane composes over a holed planar face.
+		if signedDistance(faceSample(f), plane, n) <= 0 {
+			return []curvedFace{f}, nil, nil
+		}
+		return nil, nil, nil
+	}
 	if len(f.loops) != 1 {
-		return nil, nil, ErrUnsupportedHalfSpace // holes/multi-loop: a later increment
+		return nil, nil, ErrUnsupportedHalfSpace // a CROSSED holes/multi-loop face: a later increment
 	}
 	segs, crossings := splitLoopByPlane(f.loops[0], plane, n)
 	if crossings == 0 {
-		// An imprint curve exists but does not cross this face's boundary — the face lies wholly on one
-		// side (e.g. a planar lid whose plane meets the cut plane in a line far outside it).
 		if signedDistance(faceSample(f), plane, n) <= 0 {
 			return []curvedFace{f}, nil, nil
 		}
@@ -53,6 +60,19 @@ func loopedSplit(f curvedFace, curves []geom.Curve3, plane geom.Plane, n math.Ve
 		return nil, nil, nil // every crossing-free piece was on the positive side: dropped
 	}
 	return traceKeptFaces(f, curves, runs)
+}
+
+// faceBoundaryCrosses reports whether any of the face's boundary loops crosses the cutting plane (an edge
+// runs from one side to the other). A face whose whole boundary lies on one side does not genuinely meet
+// the plane — the imprint curve passes outside it — so the caller keeps or drops it whole regardless of
+// how many loops it has (the multi-loop split is only needed when the plane actually cuts the boundary).
+func faceBoundaryCrosses(f curvedFace, plane geom.Plane, n math.Vector3) bool {
+	for i := range f.loops {
+		if _, crossings := splitLoopByPlane(f.loops[i], plane, n); crossings > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // traceKeptFaces threads the kept boundary runs into closed loops, each bridged along the imprint, and

--- a/kernel/brep/curved_halfspace_torus.go
+++ b/kernel/brep/curved_halfspace_torus.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Torus half-space cut (M2 Phase-1 follow-up, Oblikovati/Oblikovati#1375). Trims a bare torus by a plane
+// PERPENDICULAR to its axis — the only torus cut with an analytic section (two concentric circles; an
+// oblique or axis-parallel plane cuts a quartic SPIRIC curve, deferred to CSG). The kept solid is the tube
+// arc on the plane's negative side (a singly-trimmed torus BAND) capped by the planar ANNULUS between the
+// two section circles. It is the torus analogue of cylinderHalfSpace/coneHalfSpace, built directly here
+// because the section is a nested circle pair the general arrangement's lid chainer does not assemble.
+
+// torusSolidParams recovers a bare torus body's geom.Torus. ok=false unless the body is exactly one torus
+// face (a boundary-less analytic torus, as SolidTorus builds it) — the shape this fast path trims.
+func torusSolidParams(faces []curvedFace) (geom.Torus, bool) {
+	if len(faces) != 1 {
+		return geom.Torus{}, false
+	}
+	t, ok := faces[0].surface.(geom.Torus)
+	return t, ok
+}
+
+// perpendicularToTorusAxis reports whether the cut plane normal is parallel to the torus axis — the
+// constant-axial-level cut whose section is the two concentric circles this path handles.
+func perpendicularToTorusAxis(n math.Vector3, t geom.Torus) bool {
+	return stdmath.Abs(float64(n.Dot(t.AxisDir.AsVector()))) >= 1-cylinderAxisTol
+}
+
+// torusHalfSpace keeps the tube arc of a torus on the plane's negative side, rebuilt as a trimmed torus
+// band plus a planar annular lid. The plane must be perpendicular to the axis. A plane clear of the tube
+// (|d| ≥ minor radius) keeps the whole torus or empties it, by which side the kept half-space faces.
+func torusHalfSpace(body *topo.Body, t geom.Torus, plane geom.Plane) (*topo.Body, error) {
+	n := unit(plane.Normal())
+	axis := t.AxisDir.AsVector()
+	nAxis := float64(n.Dot(axis))
+	d := float64(t.Center.VectorTo(plane.Origin).Dot(axis)) // section level along the axis
+	r := t.MinorRadius
+	if d >= r-cylinderAxisTol {
+		return keepWholeOrEmpty(body, nAxis > 0) // the whole tube lies below d: kept iff the low side is kept
+	}
+	if d <= -r+cylinderAxisTol {
+		return keepWholeOrEmpty(body, nAxis < 0)
+	}
+	half := stdmath.Sqrt(r*r - d*d)
+	level := t.Center.TranslateBy(axis.Scale(math.Scalar(d)))
+	outer := geom.Circle{Center: level, Normal: t.AxisDir, RefDir: t.Ref, Radius: t.MajorRadius + half}
+	inner := geom.Circle{Center: level, Normal: t.AxisDir, RefDir: t.Ref, Radius: t.MajorRadius - half}
+	vMid := 1.5 * stdmath.Pi // the kept seam runs through the tube bottom when the LOW side is kept (nAxis>0)
+	if nAxis < 0 {
+		vMid = 0.5 * stdmath.Pi // through the tube top when the high side is kept
+	}
+	return buildTorusBandSolid(t, level, n, outer, inner, vMid)
+}
+
+// keepWholeOrEmpty returns the whole body when keep is true, else an empty body — the plane-clears case.
+func keepWholeOrEmpty(body *topo.Body, keep bool) (*topo.Body, error) {
+	if keep {
+		return body, nil
+	}
+	return topo.MergeBodies(topo.NewLineage(topo.Tok("halfspace", "empty", 0)), true), nil
+}
+
+// buildTorusBandSolid assembles the kept solid: the trimmed torus BAND (a seam-bridged loop between the
+// two section circles, mirroring the rim-fillet band so each circle is shared with the lid in the opposite
+// sense) and the planar ANNULUS lid (outer circle, inner-circle hole) on the cut plane with outward normal
+// +n. The seam is the tube-circle arc at u=0 over the kept v-range (through vMid).
+func buildTorusBandSolid(t geom.Torus, level math.Point3, n math.Vector3, outer, inner geom.Circle, vMid float64) (*topo.Body, error) {
+	lidPlane, err := geom.NewPlane(level, n)
+	if err != nil {
+		return nil, err
+	}
+	seam, err := geom.Arc3dByThreePoints(outer.PointAt(0), t.PointAt(0, vMid), inner.PointAt(0))
+	if err != nil {
+		return nil, err
+	}
+	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok("halfspace", "torusbody", 0)))
+	vo := bld.AddVertex(outer.PointAt(0), torusLin("vo"))
+	vi := bld.AddVertex(inner.PointAt(0), torusLin("vi"))
+	outerE := bld.AddEdge(outer, vo, vo, torusLin("outer"))
+	innerE := bld.AddEdge(inner, vi, vi, torusLin("inner"))
+	seamE := bld.AddEdge(seam, vo, vi, torusLin("seam"))
+	bld.AddFace(t, torusLin("band"),
+		topo.OuterLoop(topo.Fwd(seamE), topo.Rev(innerE), topo.Rev(seamE), topo.Fwd(outerE)))
+	bld.AddFace(lidPlane, torusLin("lid"),
+		topo.OuterLoop(topo.Rev(outerE)), topo.InnerLoop(topo.Fwd(innerE)))
+	return bld.Build(), nil
+}
+
+// torusLin builds a torus-halfspace lineage token.
+func torusLin(role string) topo.Lineage { return topo.NewLineage(topo.Tok("halfspace", role, 0)) }

--- a/kernel/brep/curved_halfspace_torus_test.go
+++ b/kernel/brep/curved_halfspace_torus_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// A plane perpendicular to a torus axis trims it to a tube arc: a single analytic torus band capped by a
+// planar annulus, watertight, no CSG (the only torus cut with an analytic section, Oblikovati/Oblikovati#1375).
+func TestHalfSpaceCutTorusPerpendicularBand(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		origin math.Point3
+		normal math.Vector3
+	}{
+		{"keep below mid-plane", math.P3(0, 0, 0), math.V3(0, 0, 1)},
+		{"keep above mid-plane", math.P3(0, 0, 0), math.V3(0, 0, -1)},
+		{"keep below off-centre", math.P3(0, 0, 1), math.V3(0, 0, 1)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tor, err := SolidTorus(math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2, "torus")
+			if err != nil {
+				t.Fatalf("SolidTorus: %v", err)
+			}
+			plane, _ := geom.NewPlane(tc.origin, tc.normal)
+			res, err := HalfSpaceCut(tor, plane)
+			if err != nil {
+				t.Fatalf("HalfSpaceCut: %v", err)
+			}
+			assertWatertight(t, res)
+			tori := 0
+			for _, f := range res.Faces() {
+				if _, ok := f.Geometry().(geom.Torus); ok {
+					tori++
+				}
+			}
+			if tori != 1 {
+				t.Errorf("result has %d torus faces, want exactly 1 (the band stays analytic)", tori)
+			}
+		})
+	}
+}
+
+// A plane clear of the tube keeps the whole torus or empties it, by which side faces the kept half-space.
+func TestHalfSpaceCutTorusClears(t *testing.T) {
+	tor, _ := SolidTorus(math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2, "torus")
+	whole, _ := geom.NewPlane(math.P3(0, 0, 3), math.V3(0, 0, 1)) // z<3 holds the whole torus (tube to z=2)
+	res, err := HalfSpaceCut(tor, whole)
+	if err != nil {
+		t.Fatalf("HalfSpaceCut (clears): %v", err)
+	}
+	if len(res.Faces()) != 1 {
+		t.Errorf("a plane clearing the torus should keep it whole (1 face), got %d", len(res.Faces()))
+	}
+}

--- a/kernel/geom/intersect_analytic.go
+++ b/kernel/geom/intersect_analytic.go
@@ -38,9 +38,42 @@ func intersectPlaneSurface(pl Plane, other Surface) ([]Curve3, bool) {
 		return planeSphereCurve(pl, o)
 	case Cone:
 		return planeConeCurve(pl, o)
+	case Torus:
+		return planeTorusCurve(pl, o)
 	default:
 		return nil, false
 	}
+}
+
+// planeTorusCurve returns the section a plane PERPENDICULAR to the torus axis cuts: two concentric circles
+// (the outer R+√(r²−d²) and inner R−√(r²−d²), at the section level d along the axis), or none when the
+// plane clears or grazes the tube (|d|≥r). An OBLIQUE or axis-parallel plane cuts a quartic SPIRIC curve
+// (no analytic conic), so it is not solved here — handled=false defers it to the CSG fallback. Returned
+// outer first, then inner — both anchored to the torus Ref so their seam lines up with the band.
+func planeTorusCurve(pl Plane, t Torus) ([]Curve3, bool) {
+	n := unitVec3(pl.Normal())
+	axis := t.AxisDir.AsVector()
+	cosA := float64(axis.Dot(n))
+	if stdmath.Abs(cosA) < 1-1e-6 {
+		// Oblique / axis-parallel: a spiric quartic when it cuts the tube. But a plane that CLEARS the whole
+		// torus (its distance exceeds the torus's reach along n) carries no section — report that (handled,
+		// empty) so a box's far clearing faces compose; only a genuine spiric cut defers to CSG.
+		reach := (t.MajorRadius+t.MinorRadius)*float64(n.Sub(axis.Scale(math.Scalar(cosA))).Length()) + t.MinorRadius*stdmath.Abs(cosA)
+		if stdmath.Abs(float64(t.Center.VectorTo(pl.Origin).Dot(n))) >= reach-1e-9 {
+			return nil, true // the plane clears the torus
+		}
+		return nil, false // a spiric quartic cut, not an analytic conic
+	}
+	d := float64(t.Center.VectorTo(pl.Origin).Dot(axis)) // section level along the axis
+	r := t.MinorRadius
+	if stdmath.Abs(d) >= r-1e-9 {
+		return nil, true // the plane clears or grazes the tube: no crossing section
+	}
+	half := stdmath.Sqrt(r*r - d*d)
+	level := t.Center.TranslateBy(axis.Scale(math.Scalar(d)))
+	outer := Circle{Center: level, Normal: t.AxisDir, RefDir: t.Ref, Radius: t.MajorRadius + half}
+	inner := Circle{Center: level, Normal: t.AxisDir, RefDir: t.Ref, Radius: t.MajorRadius - half}
+	return []Curve3{outer, inner}, true
 }
 
 // planePlaneCurve returns the intersection line of two planes (empty when parallel).

--- a/kernel/geom/intersect_analytic_test.go
+++ b/kernel/geom/intersect_analytic_test.go
@@ -137,3 +137,38 @@ func TestAnalyticOrderIndependent(t *testing.T) {
 		t.Errorf("cylinder∩plane (swapped) = %v ok=%v, want one circle", curves, ok)
 	}
 }
+
+// A plane perpendicular to a torus axis cuts the tube in two concentric circles (the outer R+√(r²−d²)
+// and inner R−√(r²−d²)); an oblique plane that cuts the tube is a spiric quartic, deferred (handled=false).
+func TestAnalyticPlaneTorusPerpendicularIsTwoCircles(t *testing.T) {
+	tor, _ := NewTorus(math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2)
+	curves, handled := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 1, 0, 0, 1), tor) // perpendicular at z=1
+	if !handled || len(curves) != 2 {
+		t.Fatalf("perpendicular torus cut: handled=%v, %d curves; want 2 circles", handled, len(curves))
+	}
+	want := []float64{5 + stdmath.Sqrt(4-1), 5 - stdmath.Sqrt(4-1)} // R ± √(r²−d²), d=1
+	for i, c := range curves {
+		circ, ok := c.(Circle)
+		if !ok {
+			t.Fatalf("curve %d is %T, want Circle", i, c)
+		}
+		if stdmath.Abs(circ.Radius-want[i]) > 1e-9 {
+			t.Errorf("circle %d radius %.6f, want %.6f", i, circ.Radius, want[i])
+		}
+	}
+}
+
+func TestAnalyticPlaneTorusObliqueDefers(t *testing.T) {
+	tor, _ := NewTorus(math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2)
+	if _, handled := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 0, 1, 0, 1), tor); handled {
+		t.Error("an oblique torus cut (a spiric quartic) must defer, got handled=true")
+	}
+}
+
+func TestAnalyticPlaneTorusClearsIsEmpty(t *testing.T) {
+	tor, _ := NewTorus(math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2)
+	curves, handled := IntersectSurfacesAnalytic(mustPlane(t, 20, 0, 0, 1, 0, 0), tor) // axis-parallel, far clear
+	if !handled || len(curves) != 0 {
+		t.Errorf("a plane clearing the torus must be handled with no curves, got handled=%v n=%d", handled, len(curves))
+	}
+}

--- a/kernel/ops/boolean_csg_demotion_test.go
+++ b/kernel/ops/boolean_csg_demotion_test.go
@@ -135,7 +135,33 @@ func curvedExactCases() []curvedExactCase {
 		{"cylinder ∩ box (clips rim tongue)", ops.Intersect, cylinderClipsRimBox},
 		{"cone apex − box (oblique, apex dropped)", ops.Cut, coneApexObliqueBox},
 		{"cone apex ∩ box (oblique, apex kept)", ops.Intersect, coneApexObliqueBox},
+		{"torus − box (perp half)", ops.Cut, torusPerpHalfBox},
+		{"torus ∩ box (perp half)", ops.Intersect, torusPerpHalfBox},
+		{"torus − box (perp off-centre)", ops.Cut, torusPerpOffCentreBox},
 	}
+}
+
+// torusPerpHalfBox is a torus (R=5, r=2, axis +z) cut by the box face z=0 — PERPENDICULAR to the axis at
+// the mid-plane: the section is two concentric circles, and the kept half is a trimmed torus band capped
+// by a planar annulus. The only torus cut with an analytic section (an oblique plane cuts a quartic spiric
+// curve, still CSG); the box's far parallel faces clear the torus and compose (Oblikovati#1375).
+func torusPerpHalfBox(t *testing.T) (*topo.Body, *topo.Body) {
+	return demoTorus(t, math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2), demoBlock(t, math.P3(-20, -20, 0), math.P3(20, 20, 20))
+}
+
+// torusPerpOffCentreBox cuts the same torus by z=1 (off the mid-plane): the kept band's two section
+// circles have unequal tube parameters, exercising the seam-direction loft over the wrapping tube arc.
+func torusPerpOffCentreBox(t *testing.T) (*topo.Body, *topo.Body) {
+	return demoTorus(t, math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2), demoBlock(t, math.P3(-20, -20, 1), math.P3(20, 20, 20))
+}
+
+func demoTorus(t *testing.T, center math.Point3, axis math.Vector3, major, minor float64) *topo.Body {
+	t.Helper()
+	b, err := brep.SolidTorus(center, axis, major, minor, "torus")
+	if err != nil {
+		t.Fatalf("SolidTorus: %v", err)
+	}
+	return b
 }
 
 // coneApexObliqueBox is a FULL cone (apex at the top, base radius 3) tilted (axis (0,0.6,0.8)) cut by the

--- a/kernel/ops/closed_band_loft.go
+++ b/kernel/ops/closed_band_loft.go
@@ -26,18 +26,19 @@ import (
 // points all share angle 0 and pollute the v-partition. ok=false unless the band is exactly two
 // circle edges + one arc seam.
 func closedBandLoftMesh(f *topo.Face, s geom.Surface, q Quality) (*Mesh, bool) {
-	rings, seamN := bandRingsAndSeam(f, q)
-	if len(rings) != 2 || seamN < 2 {
+	rings, seamN, seamMid, ok := bandRingsAndSeam(f, q)
+	if !ok || len(rings) != 2 || seamN < 2 {
 		return nil, false
 	}
 	lo, hi := orderedRing(s, rings[0]), orderedRing(s, rings[1])
 	if len(lo) < 3 || len(hi) < 3 {
 		return nil, false
 	}
-	vLo, vHi := vParam(s, lo[0]), vParam(s, hi[0])
-	if vLo > vHi {
-		lo, hi, vLo, vHi = hi, lo, vHi, vLo // lo is the smaller tube-parameter ring
-	}
+	// Loft from the lo ring to the hi ring ALONG THE SEAM — the seam's midpoint tube parameter says which
+	// of the two arcs between the rings the band spans. A torus cut keeps the long (seam-wrapping) arc;
+	// using min→max would loft the short complement instead (the dropped tube arc, Oblikovati#1375).
+	vLo, vHiRaw, vMid := vParam(s, lo[0]), vParam(s, hi[0]), vParam(s, seamMid)
+	vHi := vLo + wrapPi(vMid-vLo) + wrapPi(vHiRaw-vMid) // unwrapped so vLo→vMid→vHi is monotone
 	mid := make([]float64, 0, seamN-2)
 	for k := 1; k < seamN-1; k++ {
 		mid = append(mid, vLo+(vHi-vLo)*float64(k)/float64(seamN-1))
@@ -45,20 +46,33 @@ func closedBandLoftMesh(f *topo.Face, s geom.Surface, q Quality) (*Mesh, bool) {
 	return loftRows(s, lo, hi, mid), true
 }
 
+// wrapPi folds an angle into (−π, π] — the signed shortest step between two tube parameters.
+func wrapPi(a float64) float64 {
+	const twoPi = 2 * stdmath.Pi
+	for a > stdmath.Pi {
+		a -= twoPi
+	}
+	for a <= -stdmath.Pi {
+		a += twoPi
+	}
+	return a
+}
+
 // bandRingsAndSeam reads the band face's boundary edges: each closed circle (with its closing
-// duplicate dropped) is a ring; seamN is the largest arc-edge sample count (the tube subdivision).
-func bandRingsAndSeam(f *topo.Face, q Quality) (rings [][]math.Point3, seamN int) {
+// duplicate dropped) is a ring; seamN is the largest arc-edge sample count (the tube subdivision) and
+// seamMid that arc's midpoint (whose tube parameter picks which arc the band spans). ok=false with no seam.
+func bandRingsAndSeam(f *topo.Face, q Quality) (rings [][]math.Point3, seamN int, seamMid math.Point3, ok bool) {
 	for _, e := range f.Edges() {
 		switch e.Geometry().(type) {
 		case geom.Circle:
 			rings = append(rings, dropClosingDup(TessellateEdge(e, q)))
 		case geom.Arc3d:
-			if n := len(TessellateEdge(e, q)); n > seamN {
-				seamN = n
+			if pts := TessellateEdge(e, q); len(pts) > seamN {
+				seamN, seamMid, ok = len(pts), pts[len(pts)/2], true
 			}
 		}
 	}
-	return rings, seamN
+	return rings, seamN, seamMid, ok
 }
 
 // dropClosingDup removes the trailing point a closed-edge tessellation repeats at its seam.

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -393,10 +393,22 @@ func doublyPeriodicBandGrid(s geom.Surface, outer3D []math.Point3, holes3D [][]m
 }
 
 // spansFullPeriod reports whether a periodic parameter's samples cover essentially its whole [0,2π]
-// period (a band that wraps the seam), versus a bounded sub-range (the tube of a rim-fillet torus).
+// period (a band that wraps the seam), versus a bounded sub-range (the tube of a rim-fillet torus, or a
+// perpendicular torus cut's kept arc). It measures the OCCUPIED span as 2π minus the single largest gap —
+// so a sub-arc that merely STRADDLES the 0/2π seam (min near 0, max near 2π, but a wide gap in between) is
+// correctly seen as bounded, not full (Oblikovati#1375).
 func spansFullPeriod(g []float64) bool {
-	u := sortUnique(g)
-	return len(u) > 1 && u[len(u)-1]-u[0] > 2*stdmath.Pi-0.5
+	s := sortUnique(g)
+	if len(s) < 2 {
+		return false
+	}
+	maxGap := s[0] + 2*stdmath.Pi - s[len(s)-1] // the wrap gap (last sample → first, across the seam)
+	for i := 0; i+1 < len(s); i++ {
+		if gap := s[i+1] - s[i]; gap > maxGap {
+			maxGap = gap
+		}
+	}
+	return 2*stdmath.Pi-maxGap > 2*stdmath.Pi-0.5 // occupied span (all but the largest gap) is nearly full
 }
 
 // coneApexFan tessellates a cone face that closes to its apex (a drill point): its single rim

--- a/kernel/ops/testdata/occ_boolean_oracle.json
+++ b/kernel/ops/testdata/occ_boolean_oracle.json
@@ -30,5 +30,8 @@
   "cylinder − box (clips rim annulus)": 245.4880608,
   "cylinder ∩ box (clips rim tongue)": 37.25527803,
   "cone apex − box (oblique, apex dropped)": 81.51203176,
-  "cone apex ∩ box (oblique, apex kept)": 12.73574788
+  "cone apex ∩ box (oblique, apex kept)": 12.73574788,
+  "torus − box (perp half)": 197.392088,
+  "torus ∩ box (perp half)": 197.392088,
+  "torus − box (perp off-centre)": 317.6034316
 }


### PR DESCRIPTION
## What

A torus cut by a plane was the last curved primitive that always demoted to CSG. The general torus–plane section is a quartic **spiric** curve (no analytic conic), but the plane **perpendicular to the axis** is the tractable analytic case — its section is two concentric circles (`R±√(r²−d²)`), the torus analogue of the cylinder/cone perpendicular fast path.

- `geom.planeTorusCurve`: perpendicular → the two section circles; a plane that **clears** the torus → handled/empty (so a box's far parallel faces compose); a genuine oblique spiric cut → `handled=false`, still deferred.
- `brep.torusHalfSpace`: a dedicated fast path (like `cone`/`cylinderHalfSpace`) rebuilding the kept tube arc as a trimmed torus **band** (a seam-bridged loop between the two section circles, mirroring the rim-fillet band) + a planar **annulus** lid — built directly because the nested circle pair isn't a section the general lid chainer assembles.

## Three supporting fixes the cut surfaced

1. **`closedBandLoftMesh`** now lofts the tube arc **along the seam** (the seam midpoint's tube parameter picks which of the two arcs the band spans). A torus cut keeps the long, seam-wrapping arc; the old `min→max` range lofted the dropped complement.
2. **`spansFullPeriod`** measures the *occupied* span (`2π − largest gap`), so a kept arc that merely **straddles** the `0/2π` seam reads as bounded, not a full wrap — without this the band was mis-classified and meshed as the whole torus.
3. **`loopedSplit`** keeps/drops a face wholly on one side **before** the single-loop check, so a far clearing plane composes over the multi-loop **annular lid** (a holes-bearing planar face it otherwise deferred).

## Validation (OpenCASCADE `getMass`)

`torus − box (perp half)` 194.87 vs 197.39, the `∩` complement 194.87, off-centre 312.59 vs 317.60 — all within budget, watertight, exact analytic path (one torus face + a planar annulus). Both the exactness guard and the OCC oracle cover them, plus geom-level `planeTorusCurve` tests and brep watertight tests. An **oblique** torus cut still defers (a follow-up needs a spiric curve type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)