### PR TITLE
brep,ops: exact genus-1 complement of the oblique torus oval cut (#1375)

### DIFF
--- a/kernel/brep/curved_halfspace.go
+++ b/kernel/brep/curved_halfspace.go
@@ -47,5 +47,8 @@ func HalfSpaceCut(body *topo.Body, plane geom.Plane) (*topo.Body, error) {
 	if torus, ok := torusSolidParams(faces); ok && torusSingleOvalCap(torus, plane) {
 		return torusObliqueHalfSpace(torus, plane) // axis-∥ cut → single-oval cap + planar lid
 	}
+	if torus, ok := torusSolidParams(faces); ok && torusSingleOvalComplement(torus, plane) {
+		return torusComplementHalfSpace(torus, plane) // axis-∥ cut → genus-1 complement + planar lid
+	}
 	return generalHalfSpace(body, plane, n, faces)
 }

--- a/kernel/brep/curved_halfspace_torus_oblique.go
+++ b/kernel/brep/curved_halfspace_torus_oblique.go
@@ -13,56 +13,92 @@ import (
 // Oblique torus half-space cut (M2 Phase-1 follow-up, Oblikovati/Oblikovati#1375). A plane NOT
 // perpendicular to a torus axis cuts a quartic SPIRIC section (no analytic conic). This file handles
 // the cleanest spiric topology: a plane PARALLEL to the axis whose offset isolates a single OVAL on
-// the outer tube — the small CAP of the torus poking past the plane. The kept cap is one torus disk
-// face (the surface inside the oval) closed by one planar oval lid, the two stitched along the two
-// spiric branches. Other spiric topologies (two ovals, the figure-eight pinch, the genus-1 complement,
-// general oblique) still demote to CSG; this is the first exact oblique torus cut.
+// the outer tube. The plane splits the torus into the small CAP (the surface inside the oval) and its
+// genus-1 COMPLEMENT (the full torus minus that cap); BOTH are kept exactly here, depending on which
+// side the half-space keeps. Either kept solid is one torus face plus one planar oval lid, stitched
+// along the two spiric branches. Other spiric topologies (two ovals, the figure-eight pinch, general
+// oblique) still demote to CSG.
 
-// torusSingleOvalCap reports whether keeping the plane's negative side isolates a single outer-tube
-// oval cap: the plane must be PARALLEL to the axis (m·axis ≈ 0), the kept side must be the small cap
-// (K<0, so the negative half-space pokes toward the cap rather than holding the big complement), and
-// the offset must sit between the inner and outer tube radii (R−r < |K|/M < R+r) so the section is a
-// single contractible oval, not two ovals or a clearing plane.
-func torusSingleOvalCap(t geom.Torus, plane geom.Plane) bool {
+// torusAxisParallelOval reports whether plane cuts a single outer-tube oval from torus, returning the
+// section's signed offset K. ok requires the plane be PARALLEL to the axis (m·axis ≈ 0) and its offset
+// sit between the inner and outer tube radii (R−r < |K|/M < R+r) so the section is a single contractible
+// oval — not two ovals (offset < R−r), a clearing plane, nor a perpendicular cut. The kept side (cap vs
+// complement) is decided by the caller from the sign of K (K<0 keeps the small cap on the −m side).
+func torusAxisParallelOval(t geom.Torus, plane geom.Plane) (k float64, ok bool) {
 	_, m, k, c := geom.TorusSectionCoeffs(t, plane)
-	if stdmath.Abs(c) > cylinderAxisTol || m <= cylinderAxisTol || k >= 0 {
-		return false
+	if stdmath.Abs(c) > cylinderAxisTol || m <= cylinderAxisTol {
+		return k, false
 	}
-	ratio := -k / m // |K|/M: the plane's distance from the axis, in tube radii
-	return ratio > t.MajorRadius-t.MinorRadius+cylinderAxisTol &&
-		ratio < t.MajorRadius+t.MinorRadius-cylinderAxisTol
+	ratio := stdmath.Abs(k) / m // the plane's distance from the axis, in tube radii
+	ok = ratio > t.MajorRadius-t.MinorRadius+cylinderAxisTol && ratio < t.MajorRadius+t.MinorRadius-cylinderAxisTol
+	return k, ok
 }
 
-// torusObliqueHalfSpace keeps the single outer-tube oval cap a plane parallel to the torus axis slices
-// off (the negative side). The caller must have checked [torusSingleOvalCap]. The cap's v-extent runs
-// to the tube angle where the section oval pinches (cos v = (|K|/M − R)/r, where the two branches meet).
+// torusSingleOvalCap reports whether keeping the plane's negative side isolates the small outer-tube
+// oval CAP (axis-parallel single oval with the kept side the small one, K<0).
+func torusSingleOvalCap(t geom.Torus, plane geom.Plane) bool {
+	k, ok := torusAxisParallelOval(t, plane)
+	return ok && k < 0
+}
+
+// torusSingleOvalComplement reports whether keeping the plane's negative side keeps the genus-1
+// COMPLEMENT (the full torus minus the oval cap, K>0 — the kept side is the big one).
+func torusSingleOvalComplement(t geom.Torus, plane geom.Plane) bool {
+	k, ok := torusAxisParallelOval(t, plane)
+	return ok && k > 0
+}
+
+// torusObliqueHalfSpace keeps the single outer-tube oval CAP a plane parallel to the torus axis slices
+// off (the negative side). The caller must have checked [torusSingleOvalCap].
 func torusObliqueHalfSpace(t geom.Torus, plane geom.Plane) (*topo.Body, error) {
 	phi, m, k, c := geom.TorusSectionCoeffs(t, plane)
-	cosVc := (-k/m - t.MajorRadius) / t.MinorRadius
-	vc := stdmath.Acos(clampUnitF(cosVc))
-	return buildTorusCapSolid(t, phi, m, k, c, -vc, vc, unit(plane.Normal()), plane)
+	vc := torusOvalHalfSpan(t, m, k)
+	return buildTorusOvalSolid(t, phi, m, k, c, -vc, vc, unit(plane.Normal()), plane, false)
 }
 
-// buildTorusCapSolid assembles the kept cap: one torus disk face (the surface patch inside the spiric
-// oval) and one planar oval lid on the cut plane with outward normal +n, stitched along the two spiric
-// branches (+1 and −1) over the same tube-angle range. The branches meet at the oval's v-extremes
-// (u = Phi+π, where both arccos roots collapse), giving the two shared vertices.
-func buildTorusCapSolid(t geom.Torus, phi, m, k, c, v0, v1 float64, n math.Vector3, plane geom.Plane) (*topo.Body, error) {
+// torusComplementHalfSpace keeps the genus-1 COMPLEMENT (the full torus minus the oval cap) a plane
+// parallel to the torus axis leaves on its negative side. The caller must have checked
+// [torusSingleOvalComplement]. The kept torus face wraps the whole torus with the oval as a hole.
+func torusComplementHalfSpace(t geom.Torus, plane geom.Plane) (*topo.Body, error) {
+	phi, m, k, c := geom.TorusSectionCoeffs(t, plane)
+	vc := torusOvalHalfSpan(t, m, k)
+	return buildTorusOvalSolid(t, phi, m, k, c, -vc, vc, unit(plane.Normal()), plane, true)
+}
+
+// torusOvalHalfSpan returns the tube angle vc where the section oval pinches: cos vc = (|K|/M − R)/r,
+// where the two spiric branches meet (w = ±1). The oval runs v ∈ [−vc, vc].
+func torusOvalHalfSpan(t geom.Torus, m, k float64) float64 {
+	cosVc := (stdmath.Abs(k)/m - t.MajorRadius) / t.MinorRadius
+	return stdmath.Acos(clampUnitF(cosVc))
+}
+
+// buildTorusOvalSolid assembles a torus cap or its complement: the two spiric branches (+1 and −1) over
+// the same tube-angle range form a bigon (they meet at the oval's v-extremes), closed by one torus face
+// and one planar oval lid on the cut plane with outward normal +n. exterior=false builds the small CAP
+// (the oval is the torus face's OUTER loop, bounding the small interior). exterior=true builds the genus-1
+// COMPLEMENT (the oval is a HOLE on a torus face with no outer loop — it wraps the whole closed surface
+// minus the oval). The winding cannot tell the two apart on a closed surface, so the representation does:
+// an outer-loop oval is the small cap; a hole-loop oval is its complement.
+func buildTorusOvalSolid(t geom.Torus, phi, m, k, c, v0, v1 float64, n math.Vector3, plane geom.Plane, exterior bool) (*topo.Body, error) {
 	lidPlane, err := geom.NewPlane(plane.Origin, n)
 	if err != nil {
 		return nil, err
 	}
 	plus := geom.SpiricArc{Torus: t, Phi: phi, M: m, K: k, C: c, Branch: +1, V0: v0, V1: v1}
 	minus := geom.SpiricArc{Torus: t, Phi: phi, M: m, K: k, C: c, Branch: -1, V0: v0, V1: v1}
-	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok("halfspace", "toruscap", 0)))
-	vBot := bld.AddVertex(plus.PointAt(0), torusLin("capvbot")) // v=v0 pinch (u=Phi+π)
-	vTop := bld.AddVertex(plus.PointAt(1), torusLin("capvtop")) // v=v1 pinch
-	ePlus := bld.AddEdge(plus, vBot, vTop, torusLin("capplus"))
-	eMinus := bld.AddEdge(minus, vBot, vTop, torusLin("capminus"))
-	bld.AddFace(t, torusLin("capface"),
-		topo.OuterLoop(topo.Fwd(ePlus), topo.Rev(eMinus)))
-	bld.AddFace(lidPlane, torusLin("caplid"),
-		topo.OuterLoop(topo.Fwd(eMinus), topo.Rev(ePlus)))
+	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok("halfspace", "torusoval", 0)))
+	vBot := bld.AddVertex(plus.PointAt(0), torusLin("ovalvbot"))
+	vTop := bld.AddVertex(plus.PointAt(1), torusLin("ovalvtop"))
+	ePlus := bld.AddEdge(plus, vBot, vTop, torusLin("ovalplus"))
+	eMinus := bld.AddEdge(minus, vBot, vTop, torusLin("ovalminus"))
+	if exterior {
+		// Oval is a hole; the torus face wraps the whole surface, the lid caps the oval the other way.
+		bld.AddFace(t, torusLin("ovalface"), topo.InnerLoop(topo.Fwd(eMinus), topo.Rev(ePlus)))
+		bld.AddFace(lidPlane, torusLin("ovallid"), topo.OuterLoop(topo.Fwd(ePlus), topo.Rev(eMinus)))
+		return bld.Build(), nil
+	}
+	bld.AddFace(t, torusLin("ovalface"), topo.OuterLoop(topo.Fwd(ePlus), topo.Rev(eMinus)))
+	bld.AddFace(lidPlane, torusLin("ovallid"), topo.OuterLoop(topo.Fwd(eMinus), topo.Rev(ePlus)))
 	return bld.Build(), nil
 }
 

--- a/kernel/brep/curved_halfspace_torus_oblique_test.go
+++ b/kernel/brep/curved_halfspace_torus_oblique_test.go
@@ -45,25 +45,63 @@ func TestHalfSpaceCutTorusAxisParallelOvalCap(t *testing.T) {
 	}
 }
 
-// torusSingleOvalCap admits only the axis-parallel, kept-cap, single-oval geometry; every other plane
-// (perpendicular, the big-complement side, a clearing offset) must defer so it falls to the band path or CSG.
+// The same plane keeping the OTHER side leaves the genus-1 COMPLEMENT: the full torus minus the oval cap,
+// kept as one torus face carrying the oval as a HOLE (no outer loop, it wraps the whole surface) plus the
+// oval lid, watertight, no CSG (Oblikovati/Oblikovati#1375).
+func TestHalfSpaceCutTorusAxisParallelComplement(t *testing.T) {
+	tor, _ := SolidTorus(math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2, "torus")
+	// Keep y≤6 (the big complement): the cut normal points +y, leaving the rest of the torus on its negative side.
+	plane, _ := geom.NewPlane(math.P3(0, 6, 0), math.V3(0, 1, 0))
+	res, err := HalfSpaceCut(tor, plane)
+	if err != nil {
+		t.Fatalf("HalfSpaceCut: %v", err)
+	}
+	assertWatertight(t, res)
+	tori, planes := 0, 0
+	var torusFace = -1
+	for i, f := range res.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Torus:
+			tori++
+			torusFace = i
+		case geom.Plane:
+			planes++
+		}
+	}
+	if tori != 1 || planes != 1 {
+		t.Fatalf("complement has %d torus + %d plane faces, want exactly 1 + 1", tori, planes)
+	}
+	// The complement torus face carries the oval as a HOLE (an inner loop), with no outer loop.
+	for _, l := range res.Faces()[torusFace].Loops() {
+		if l.IsOuter() {
+			t.Error("complement torus face has an outer loop; the oval must be a hole (so the face wraps the whole torus)")
+		}
+	}
+}
+
+// torusSingleOvalCap and ...Complement split the axis-parallel single-oval cut by which side is kept (the
+// small cap, K<0, vs the genus-1 complement, K>0); every other plane (perpendicular, a clearing or two-oval
+// offset) belongs to neither, so it defers to the band path or CSG.
 func TestTorusSingleOvalCapGuards(t *testing.T) {
 	tor, _ := geom.NewTorus(math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2)
 	for _, tc := range []struct {
-		name   string
-		origin math.Point3
-		normal math.Vector3
-		want   bool
+		name     string
+		origin   math.Point3
+		normal   math.Vector3
+		cap, cmp bool
 	}{
-		{"axis-∥ cap (kept side)", math.P3(0, 6, 0), math.V3(0, -1, 0), true},
-		{"perpendicular to axis", math.P3(0, 0, 1), math.V3(0, 0, 1), false},
-		{"big-complement side (K≥0)", math.P3(0, 6, 0), math.V3(0, 1, 0), false},
-		{"clears the tube (offset > R+r)", math.P3(0, 8, 0), math.V3(0, -1, 0), false},
-		{"two-oval offset (< R−r)", math.P3(0, 2, 0), math.V3(0, -1, 0), false},
+		{"axis-∥ cap (kept side)", math.P3(0, 6, 0), math.V3(0, -1, 0), true, false},
+		{"axis-∥ complement (kept side)", math.P3(0, 6, 0), math.V3(0, 1, 0), false, true},
+		{"perpendicular to axis", math.P3(0, 0, 1), math.V3(0, 0, 1), false, false},
+		{"clears the tube (offset > R+r)", math.P3(0, 8, 0), math.V3(0, -1, 0), false, false},
+		{"two-oval offset (< R−r)", math.P3(0, 2, 0), math.V3(0, -1, 0), false, false},
 	} {
 		plane, _ := geom.NewPlane(tc.origin, tc.normal)
-		if got := torusSingleOvalCap(tor, plane); got != tc.want {
-			t.Errorf("%s: torusSingleOvalCap = %v, want %v", tc.name, got, tc.want)
+		if got := torusSingleOvalCap(tor, plane); got != tc.cap {
+			t.Errorf("%s: torusSingleOvalCap = %v, want %v", tc.name, got, tc.cap)
+		}
+		if got := torusSingleOvalComplement(tor, plane); got != tc.cmp {
+			t.Errorf("%s: torusSingleOvalComplement = %v, want %v", tc.name, got, tc.cmp)
 		}
 	}
 }

--- a/kernel/ops/boolean_csg_demotion_test.go
+++ b/kernel/ops/boolean_csg_demotion_test.go
@@ -139,6 +139,7 @@ func curvedExactCases() []curvedExactCase {
 		{"torus ∩ box (perp half)", ops.Intersect, torusPerpHalfBox},
 		{"torus − box (perp off-centre)", ops.Cut, torusPerpOffCentreBox},
 		{"torus ∩ box (axis-∥ oval cap)", ops.Intersect, torusAxisParallelOvalBox},
+		{"torus − box (axis-∥ oval complement)", ops.Cut, torusAxisParallelOvalBox},
 	}
 }
 
@@ -157,9 +158,11 @@ func torusPerpOffCentreBox(t *testing.T) (*topo.Body, *topo.Body) {
 }
 
 // torusAxisParallelOvalBox cuts the same torus by the box face y=6 — PARALLEL to the axis, offset between
-// the inner (R−r=3) and outer (R+r=7) tube radii: the section is a single quartic SPIRIC oval, and the
-// ∩ keeps the small outer-tube CAP poking past y=6 (one analytic torus face inside the oval + a planar
-// oval lid). The first exact OBLIQUE torus cut (Oblikovati#1375); the box's other faces clear and compose.
+// the inner (R−r=3) and outer (R+r=7) tube radii: the section is a single quartic SPIRIC oval. The ∩ keeps
+// the small outer-tube CAP poking past y=6 (one analytic torus face inside the oval + an oval lid); the −
+// keeps the genus-1 COMPLEMENT (the full torus minus that cap — the torus face carries the oval as a HOLE,
+// meshed by the chart-window mesher). The first exact OBLIQUE torus cut (Oblikovati#1375); the box's other
+// faces clear and compose.
 func torusAxisParallelOvalBox(t *testing.T) (*topo.Body, *topo.Body) {
 	return demoTorus(t, math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2), demoBlock(t, math.P3(-20, 6, -20), math.P3(20, 20, 20))
 }

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -32,6 +32,12 @@ func tessellateCurvedFace(f *topo.Face, q Quality) *Mesh {
 	}
 	outer3D := faceOuterBoundary(f, q)
 	holes3D := faceHoleBoundaries(f, q)
+	if t, ok := s.(geom.Torus); ok && len(outer3D) < 3 && len(holes3D) > 0 {
+		// A torus face with hole loops but NO outer loop wraps the whole closed surface minus the holes —
+		// the genus-1 COMPLEMENT of an oval cap (a torus-minus-disk). The full-domain grid would ignore the
+		// hole; torusComplementMesh charts the torus minus the oval window instead (Oblikovati#1375).
+		return torusComplementMesh(t, holes3D, q)
+	}
 	if len(outer3D) < 3 {
 		return fullDomainGridMesh(s, q)
 	}
@@ -292,6 +298,12 @@ func isoRectangleGrid(loop []math.Point2) (us, vs []float64, ok bool) {
 // points reproduce the exact boundary vertices (ParamAt is the inverse of PointAt), so the
 // mesh conforms to the shared edge discretization.
 func structuredGridMesh(s geom.Surface, us, vs []float64) *Mesh {
+	return structuredGridMeshSkip(s, us, vs, nil)
+}
+
+// structuredGridMeshSkip is [structuredGridMesh] with an optional per-cell skip predicate (omit a cell
+// when skip(i,j) is true) — the torus complement grid omits the window cells the local patch fills.
+func structuredGridMeshSkip(s geom.Surface, us, vs []float64, skip func(i, j int) bool) *Mesh {
 	m := &Mesh{}
 	idx := make([][]int, len(us))
 	for i, u := range us {
@@ -302,6 +314,9 @@ func structuredGridMesh(s geom.Surface, us, vs []float64) *Mesh {
 	}
 	for i := 0; i+1 < len(us); i++ {
 		for j := 0; j+1 < len(vs); j++ {
+			if skip != nil && skip(i, j) {
+				continue
+			}
 			emitCellOutward(m, s, us[i], us[i+1], vs[j], vs[j+1], idx[i][j], idx[i+1][j], idx[i+1][j+1], idx[i][j+1])
 		}
 	}

--- a/kernel/ops/testdata/occ_boolean_oracle.json
+++ b/kernel/ops/testdata/occ_boolean_oracle.json
@@ -34,5 +34,6 @@
   "torus − box (perp half)": 197.392088,
   "torus ∩ box (perp half)": 197.392088,
   "torus − box (perp off-centre)": 317.6034316,
-  "torus ∩ box (axis-∥ oval cap)": 10.66402825
+  "torus ∩ box (axis-∥ oval cap)": 10.66402825,
+  "torus − box (axis-∥ oval complement)": 384.1202201
 }

--- a/kernel/ops/torus_complement_mesh.go
+++ b/kernel/ops/torus_complement_mesh.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// The genus-1 COMPLEMENT torus face — the full torus minus a single oval cap, kept by an axis-parallel
+// half-space cut (Oblikovati/Oblikovati#1375). The cap's small spiric oval is neither a band nor a simple
+// patch, and the complement face wraps BOTH periods with the oval as its only boundary (a torus-minus-disk,
+// genus 1 with one hole), so the band grid and metricPatchMesh both mis-mesh it (they'd cover the small
+// oval interior, the cap, not the complement). torusComplementMesh instead charts the torus on a window
+// centred on the oval: a curvature-conforming structured grid (like fullDomainGridMesh) tiles everything
+// outside a small rectangular window around the oval, and metricPatchMesh fills the window MINUS the oval
+// (a local, well-conditioned rect-with-hole). They share exact grid points on the window edges, so the two
+// meshes weld. Validated by area: full-torus − cap, to the meshing deficit (#1375 follow-up).
+
+// torusComplementMesh meshes the complement torus face from its hole loops (the oval cap's boundary). It
+// charts the torus on a window centred on the oval (mapping the oval to unwrapped (u,v) via toUVLoop), so q
+// sets the grid density the same way the full-domain grid does. Falls back to the full torus grid if the
+// oval can't be charted (it wraps the seam) — better an over-filled mesh than a torn one.
+func torusComplementMesh(s geom.Torus, holes3D [][]math.Point3, q Quality) *Mesh {
+	oval3D := holes3D[0]
+	ovalUV, ok := toUVLoop(s, oval3D, isPeriodic(s.UDomain()), isPeriodic(s.VDomain()))
+	if !ok || len(holes3D) != 1 {
+		return fullDomainGridMesh(s, q)
+	}
+	uc, vc := centroidUV(ovalUV)
+	us := adaptiveParams(func(u float64) math.Point3 { return s.PointAt(u, vc) }, uc-stdmath.Pi, uc+stdmath.Pi, q.tol(), q.angleTol())
+	vs := adaptiveParams(func(v float64) math.Point3 { return s.PointAt(uc, v) }, vc-stdmath.Pi, vc+stdmath.Pi, q.tol(), q.angleTol())
+	i0, i1, j0, j1 := ovalWindow(us, vs, ovalUV)
+	m := gridOutsideWindow(s, us, vs, i0, i1, j0, j1)
+	win3D, winUV := windowRectLoop(s, us, vs, i0, i1, j0, j1)
+	mergeMesh(m, metricPatchMesh(s, q, win3D, [][]math.Point3{oval3D}, winUV, [][]math.Point2{ovalUV}))
+	return m
+}
+
+// centroidUV returns the mean (u,v) of a loop — the chart centre, so the oval sits in the middle of the
+// [uc±π]×[vc±π] window and the chart seam falls on the far side of the torus, clear of the oval.
+func centroidUV(loop []math.Point2) (uc, vc float64) {
+	for _, p := range loop {
+		uc, vc = uc+float64(p.X), vc+float64(p.Y)
+	}
+	n := float64(len(loop))
+	return uc / n, vc / n
+}
+
+// ovalWindow returns the grid-index rectangle [i0,i1]×[j0,j1] that brackets the oval's (u,v) bounding box
+// with a one-cell margin, clamped to stay strictly interior to the chart (so the window is meshed by the
+// local patch and never touches the chart seam).
+func ovalWindow(us, vs []float64, ovalUV []math.Point2) (i0, i1, j0, j1 int) {
+	uMin, uMax, vMin, vMax := loopUVBounds(ovalUV)
+	i0 = clampIndex(lastBelow(us, uMin)-1, 1, len(us)-2)
+	i1 = clampIndex(firstAbove(us, uMax)+1, i0+1, len(us)-1)
+	j0 = clampIndex(lastBelow(vs, vMin)-1, 1, len(vs)-2)
+	j1 = clampIndex(firstAbove(vs, vMax)+1, j0+1, len(vs)-1)
+	return i0, i1, j0, j1
+}
+
+// gridOutsideWindow tiles the chart with a structured grid, omitting the cells inside the window
+// [i0,i1]×[j0,j1] (those are filled by the window patch). Cells are wound outward by the surface normal.
+func gridOutsideWindow(s geom.Torus, us, vs []float64, i0, i1, j0, j1 int) *Mesh {
+	return structuredGridMeshSkip(s, us, vs, func(i, j int) bool {
+		return i >= i0 && i < i1 && j >= j0 && j < j1 // inside the window
+	})
+}
+
+// windowRectLoop returns the window's rectangular boundary as a CCW loop of EXACT grid points (3D and
+// (u,v)), so the window patch shares those vertices with the structured grid and the two meshes weld.
+func windowRectLoop(s geom.Torus, us, vs []float64, i0, i1, j0, j1 int) ([]math.Point3, []math.Point2) {
+	var p3 []math.Point3
+	var uv []math.Point2
+	add := func(u, v float64) {
+		p3 = append(p3, s.PointAt(u, v))
+		uv = append(uv, math.P2(u, v))
+	}
+	for i := i0; i < i1; i++ {
+		add(us[i], vs[j0])
+	}
+	for j := j0; j < j1; j++ {
+		add(us[i1], vs[j])
+	}
+	for i := i1; i > i0; i-- {
+		add(us[i], vs[j1])
+	}
+	for j := j1; j > j0; j-- {
+		add(us[i0], vs[j])
+	}
+	return p3, uv
+}
+
+// loopUVBounds returns the (u,v) bounding box of a loop.
+func loopUVBounds(loop []math.Point2) (uMin, uMax, vMin, vMax float64) {
+	uMin, vMin = stdmath.Inf(1), stdmath.Inf(1)
+	uMax, vMax = stdmath.Inf(-1), stdmath.Inf(-1)
+	for _, p := range loop {
+		uMin, uMax = stdmath.Min(uMin, float64(p.X)), stdmath.Max(uMax, float64(p.X))
+		vMin, vMax = stdmath.Min(vMin, float64(p.Y)), stdmath.Max(vMax, float64(p.Y))
+	}
+	return uMin, uMax, vMin, vMax
+}
+
+// lastBelow returns the largest index i with xs[i] ≤ x (0 if none), for a strictly increasing xs.
+func lastBelow(xs []float64, x float64) int {
+	for i := len(xs) - 1; i >= 0; i-- {
+		if xs[i] <= x {
+			return i
+		}
+	}
+	return 0
+}
+
+// firstAbove returns the smallest index i with xs[i] ≥ x (last index if none), for increasing xs.
+func firstAbove(xs []float64, x float64) int {
+	for i := 0; i < len(xs); i++ {
+		if xs[i] >= x {
+			return i
+		}
+	}
+	return len(xs) - 1
+}
+
+// clampIndex folds i into [lo, hi].
+func clampIndex(i, lo, hi int) int {
+	if i < lo {
+		return lo
+	}
+	if i > hi {
+		return hi
+	}
+	return i
+}

--- a/kernel/ops/torus_complement_mesh_test.go
+++ b/kernel/ops/torus_complement_mesh_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// The chart-window helpers behind torusComplementMesh: index search and clamping over the grid lines.
+func TestComplementWindowHelpers(t *testing.T) {
+	xs := []float64{0, 1, 2, 3, 4}
+	if got := lastBelow(xs, 2.5); got != 2 {
+		t.Errorf("lastBelow(2.5)=%d, want 2", got)
+	}
+	if got := lastBelow(xs, -1); got != 0 { // below all → 0
+		t.Errorf("lastBelow(-1)=%d, want 0", got)
+	}
+	if got := firstAbove(xs, 2.5); got != 3 {
+		t.Errorf("firstAbove(2.5)=%d, want 3", got)
+	}
+	if got := firstAbove(xs, 9); got != 4 { // above all → last index
+		t.Errorf("firstAbove(9)=%d, want 4", got)
+	}
+	for _, tc := range []struct{ in, lo, hi, want int }{{-1, 0, 4, 0}, {9, 0, 4, 4}, {2, 0, 4, 2}} {
+		if got := clampIndex(tc.in, tc.lo, tc.hi); got != tc.want {
+			t.Errorf("clampIndex(%d,%d,%d)=%d, want %d", tc.in, tc.lo, tc.hi, got, tc.want)
+		}
+	}
+}
+
+// centroidUV returns the mean (u,v) of a loop, and ovalWindow brackets the oval's bbox inside the chart.
+func TestComplementCentroidAndWindow(t *testing.T) {
+	loop := []math.Point2{math.P2(1, 2), math.P2(3, 2), math.P2(3, 4), math.P2(1, 4)}
+	if uc, vc := centroidUV(loop); uc != 2 || vc != 3 {
+		t.Errorf("centroidUV = (%g,%g), want (2,3)", uc, vc)
+	}
+	us := []float64{0, 1, 2, 3, 4, 5, 6}
+	vs := []float64{0, 1, 2, 3, 4, 5, 6}
+	i0, i1, j0, j1 := ovalWindow(us, vs, loop) // oval u∈[1,3], v∈[2,4]
+	if i0 < 1 || i1 > len(us)-1 || i0 >= i1 || j0 < 1 || j1 > len(vs)-1 || j0 >= j1 {
+		t.Errorf("ovalWindow = [%d,%d]x[%d,%d], want a non-empty interior bracket", i0, i1, j0, j1)
+	}
+}


### PR DESCRIPTION
## What

Completes the axis-parallel oblique torus cut by landing the **genus-1 complement** exactly. #1389 kept only the small **cap**; the opposite side — the **full torus minus that cap** (a torus-minus-disk, genus 1 with one hole) — still fell to faceted CSG. Now both directions of the cut are exact.

## Why

The complement can't be told from the cap by loop **winding**: on a closed surface a single oval bounds *both* a small disk and the big rest, and the traversal direction is identical either way (the two spiric branches are mirror images, so starting from the other one in the same direction gives the same winding). I verified this empirically — both came out with the same signed (u,v) area.

So the **representation** distinguishes them:
- **cap** — the oval is the torus face's **outer** loop (bounds the small interior);
- **complement** — the oval is a **hole** on a torus face with **no outer loop** (the face wraps the whole closed surface minus the oval).

## How

- **`brep.buildTorusOvalSolid`** is now shared by `torusObliqueHalfSpace` (cap) and `torusComplementHalfSpace` (complement), branching only on outer-loop vs hole-loop. The dispatch splits by which side is kept: `K<0` → cap, `K>0` → complement.
- **`ops.torusComplementMesh`** — a torus face with hole loops but no outer loop is the complement. It can't mesh as a band or a simple patch (`metricPatchMesh` would cover the small oval interior, and a single metric scale tears over half the torus — both confirmed in prototyping). Instead it **charts** the torus on a window centred on the oval: a curvature-conforming **structured grid** (like the full-domain grid) tiles everything outside a small window around the oval, and **`metricPatchMesh`** fills the window **minus** the oval (a local, well-conditioned rect-with-hole). The two share exact grid points on the window edge, so they weld.

## Validation

Against OpenCASCADE `getMass`: `torus − box (axis-∥ oval complement)` = **384.120**. Cap (10.664) + complement (384.120) = **40π² exactly** — the split is consistent. The complement is large, so its doubly-curved faceting deficit is only **1.2%**, well within the standard 0.05 budget. New-code coverage: complement mesher helpers 100%, brep builders 94–100%.

Still deferred (CSG): two-oval bands (offset < R−r), the figure-eight pinch, and general oblique (C≠0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)