### PR TITLE
brep,geom,ops: exact two-oval torus band cut through the hole (#1375)

### DIFF
--- a/kernel/brep/curved_halfspace.go
+++ b/kernel/brep/curved_halfspace.go
@@ -7,6 +7,7 @@ import (
 
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
 )
 
 // Curved half-space cut (M2 Phase 1, Oblikovati/Oblikovati#1334). The first operation of the
@@ -41,14 +42,32 @@ func HalfSpaceCut(body *topo.Body, plane geom.Plane) (*topo.Body, error) {
 	if cone, vMin, vMax, ok := coneSolidParams(faces); ok && perpendicularToConeAxis(n, cone) {
 		return coneHalfSpace(body, cone, vMin, vMax, plane) // ⟂ cut → cone/frustum, fast path
 	}
-	if torus, ok := torusSolidParams(faces); ok && perpendicularToTorusAxis(n, torus) {
-		return torusHalfSpace(body, torus, plane) // ⟂ cut → trimmed torus band + annular lid
-	}
-	if torus, ok := torusSolidParams(faces); ok && torusSingleOvalCap(torus, plane) {
-		return torusObliqueHalfSpace(torus, plane) // axis-∥ cut → single-oval cap + planar lid
-	}
-	if torus, ok := torusSolidParams(faces); ok && torusSingleOvalComplement(torus, plane) {
-		return torusComplementHalfSpace(torus, plane) // axis-∥ cut → genus-1 complement + planar lid
+	if torus, ok := torusSolidParams(faces); ok {
+		if res, handled, err := torusHalfSpaceCut(body, torus, plane, n); handled {
+			return res, err
+		}
 	}
 	return generalHalfSpace(body, plane, n, faces)
+}
+
+// torusHalfSpaceCut dispatches a bare torus's analytic half-space cuts by the section the plane carves:
+// a perpendicular cut (two concentric circles → a band + annular lid), and the axis-parallel spiric cuts
+// (a single oval cap, its genus-1 complement, or a two-oval band through the hole — Oblikovati#1375).
+// handled=false leaves an oblique/spiric topology not yet wired to the general CSG fallback.
+func torusHalfSpaceCut(body *topo.Body, torus geom.Torus, plane geom.Plane, n math.Vector3) (*topo.Body, bool, error) {
+	switch {
+	case perpendicularToTorusAxis(n, torus):
+		res, err := torusHalfSpace(body, torus, plane) // ⟂ cut → trimmed torus band + annular lid
+		return res, true, err
+	case torusSingleOvalCap(torus, plane):
+		res, err := torusObliqueHalfSpace(torus, plane) // axis-∥ → single-oval cap + planar lid
+		return res, true, err
+	case torusSingleOvalComplement(torus, plane):
+		res, err := torusComplementHalfSpace(torus, plane) // axis-∥ → genus-1 complement + planar lid
+		return res, true, err
+	case torusTwoOvalBand(torus, plane):
+		res, err := torusTwoOvalHalfSpace(torus, plane) // axis-∥ through the hole → v-wrapping band + 2 lids
+		return res, true, err
+	}
+	return nil, false, nil
 }

--- a/kernel/brep/curved_halfspace_torus_twooval.go
+++ b/kernel/brep/curved_halfspace_torus_twooval.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+)
+
+// Two-oval torus half-space cut (M2 Phase-1 follow-up, Oblikovati/Oblikovati#1375). A plane PARALLEL to a
+// torus axis whose offset is LESS than the inner tube radius (|K|/M < R−r) passes through the central hole
+// and cuts BOTH tube walls — the spiric section is TWO ovals, each wrapping the whole tube (the v-period).
+// The two ovals split the torus into two v-wrapping BANDS; the kept half-space keeps one of them. The kept
+// band (one torus face wrapping the tube between the two ovals) is closed by TWO planar oval-disk lids (the
+// two tube cross-sections the plane carves), unlike the single-oval cut's one lid.
+
+// torusTwoOvalBand reports whether plane cuts two ovals from torus: PARALLEL to the axis (m·axis ≈ 0) with
+// the offset strictly inside the inner tube radius (0 < |K|/M < R−r). At |K|/M = 0 the plane passes through
+// the axis (the ovals degenerate to two meridian circles) and at ≥ R−r it cuts a single oval — both handled
+// elsewhere — so this is the strict two-oval interior.
+func torusTwoOvalBand(t geom.Torus, plane geom.Plane) bool {
+	_, m, k, c := geom.TorusSectionCoeffs(t, plane)
+	if stdmath.Abs(c) > cylinderAxisTol || m <= cylinderAxisTol {
+		return false
+	}
+	ratio := stdmath.Abs(k) / m
+	return ratio > cylinderAxisTol && ratio < t.MajorRadius-t.MinorRadius-cylinderAxisTol
+}
+
+// torusTwoOvalHalfSpace keeps the v-wrapping band a plane parallel to the torus axis leaves on its negative
+// side: the band {g ≤ 0} swept around the tube between the two section ovals (through u = Phi+π, the side the
+// half-space keeps), closed by the two planar oval-disk lids. The caller must have checked [torusTwoOvalBand].
+func torusTwoOvalHalfSpace(t geom.Torus, plane geom.Plane) (*topo.Body, error) {
+	phi, m, k, c := geom.TorusSectionCoeffs(t, plane)
+	n := unit(plane.Normal())
+	lidPlane, err := geom.NewPlane(plane.Origin, n)
+	if err != nil {
+		return nil, err
+	}
+	plus := geom.SpiricArc{Torus: t, Phi: phi, M: m, K: k, C: c, Branch: +1, V0: 0, V1: 2 * stdmath.Pi}
+	minus := geom.SpiricArc{Torus: t, Phi: phi, M: m, K: k, C: c, Branch: -1, V0: 0, V1: 2 * stdmath.Pi}
+	// The seam bridges the two ovals at v=0 the long way, through u=Phi+π — the side the kept band wraps.
+	seam, err := geom.Arc3dByThreePoints(plus.PointAt(0), t.PointAt(phi+stdmath.Pi, 0), minus.PointAt(0))
+	if err != nil {
+		return nil, err
+	}
+	return buildTorusTwoOvalSolid(t, lidPlane, plus, minus, seam), nil
+}
+
+// buildTorusTwoOvalSolid assembles the kept band: one torus BAND face (the two closed-oval edges bridged by
+// a v=0 seam, mirroring the perpendicular band) and TWO planar oval-disk lids, one bounded by each oval. The
+// lids share each oval edge with the band in the opposite sense, so every edge has two uses (watertight).
+func buildTorusTwoOvalSolid(t geom.Torus, lidPlane geom.Plane, plus, minus geom.SpiricArc, seam geom.Arc3d) *topo.Body {
+	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok("halfspace", "torustwooval", 0)))
+	vPlus := bld.AddVertex(plus.PointAt(0), torusLin("twoovalvp"))
+	vMinus := bld.AddVertex(minus.PointAt(0), torusLin("twoovalvm"))
+	ePlus := bld.AddEdge(plus, vPlus, vPlus, torusLin("twoovalplus"))    // closed oval (one seam vertex)
+	eMinus := bld.AddEdge(minus, vMinus, vMinus, torusLin("twoovalmin")) // closed oval
+	seamE := bld.AddEdge(seam, vPlus, vMinus, torusLin("twoovalseam"))
+	bld.AddFace(t, torusLin("twoovalband"),
+		topo.OuterLoop(topo.Fwd(seamE), topo.Rev(eMinus), topo.Rev(seamE), topo.Fwd(ePlus)))
+	bld.AddFace(lidPlane, torusLin("twoovallidp"), topo.OuterLoop(topo.Rev(ePlus)))
+	bld.AddFace(lidPlane, torusLin("twoovallidm"), topo.OuterLoop(topo.Fwd(eMinus)))
+	return bld.Build()
+}

--- a/kernel/brep/curved_halfspace_torus_twooval_test.go
+++ b/kernel/brep/curved_halfspace_torus_twooval_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// A plane PARALLEL to the torus axis but offset INSIDE the inner tube radius passes through the central
+// hole and cuts BOTH tube walls: the section is two ovals, and the kept solid is one tube-wrapping torus
+// band closed by two planar oval-disk lids, watertight, no CSG (Oblikovati/Oblikovati#1375).
+func TestHalfSpaceCutTorusTwoOvalBand(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		normal math.Vector3
+	}{
+		{"keep +y band", math.V3(0, -1, 0)}, // keep y≥2
+		{"keep −y band", math.V3(0, 1, 0)},  // keep y≤2 (the wider band)
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tor, _ := SolidTorus(math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2, "torus")
+			plane, _ := geom.NewPlane(math.P3(0, 2, 0), tc.normal) // |offset|=2 < R−r=3 → two ovals
+			res, err := HalfSpaceCut(tor, plane)
+			if err != nil {
+				t.Fatalf("HalfSpaceCut: %v", err)
+			}
+			assertWatertight(t, res)
+			tori, planes := 0, 0
+			for _, f := range res.Faces() {
+				switch f.Geometry().(type) {
+				case geom.Torus:
+					tori++
+				case geom.Plane:
+					planes++
+				}
+			}
+			if tori != 1 || planes != 2 {
+				t.Errorf("two-oval band has %d torus + %d plane faces, want 1 + 2 (the band + two oval-disk lids)", tori, planes)
+			}
+			// Two ovals (each a closed spiric edge) + one bridging seam.
+			if e := len(res.Edges()); e != 3 {
+				t.Errorf("two-oval band has %d edges, want 3 (two ovals + a seam)", e)
+			}
+		})
+	}
+}
+
+// torusTwoOvalBand admits only the axis-parallel offset strictly inside the inner tube radius; a single-oval
+// offset (≥ R−r) or a perpendicular cut belongs elsewhere.
+func TestTorusTwoOvalBandGuards(t *testing.T) {
+	tor, _ := geom.NewTorus(math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2)
+	for _, tc := range []struct {
+		name   string
+		origin math.Point3
+		normal math.Vector3
+		want   bool
+	}{
+		{"two-oval (offset 2 < R−r)", math.P3(0, 2, 0), math.V3(0, 1, 0), true},
+		{"single-oval (offset 6 in (R−r,R+r))", math.P3(0, 6, 0), math.V3(0, 1, 0), false},
+		{"perpendicular to axis", math.P3(0, 0, 1), math.V3(0, 0, 1), false},
+		{"through the axis (offset 0)", math.P3(0, 0, 0), math.V3(0, 1, 0), false},
+	} {
+		plane, _ := geom.NewPlane(tc.origin, tc.normal)
+		if got := torusTwoOvalBand(tor, plane); got != tc.want {
+			t.Errorf("%s: torusTwoOvalBand = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/kernel/geom/spiric.go
+++ b/kernel/geom/spiric.go
@@ -65,6 +65,11 @@ func (s SpiricArc) uOfV(v float64) float64 {
 	return s.Phi + s.Branch*stdmath.Acos(clampUnit(w))
 }
 
+// UAt returns the azimuth u on this branch at tube angle v — the spiric section's single-valued u(v).
+// A two-oval band (a plane that cuts both tube walls) is meshed by sweeping v over the full tube period
+// and filling u between the two branches' UAt, so the tessellator needs this without inverting PointAt.
+func (s SpiricArc) UAt(v float64) float64 { return s.uOfV(v) }
+
 // PointAt returns the point at parameter t∈[0,1], evaluated on the torus at (u(v), v).
 func (s SpiricArc) PointAt(t float64) math.Point3 {
 	v := s.V0 + t*(s.V1-s.V0)

--- a/kernel/ops/boolean_csg_demotion_test.go
+++ b/kernel/ops/boolean_csg_demotion_test.go
@@ -140,6 +140,8 @@ func curvedExactCases() []curvedExactCase {
 		{"torus − box (perp off-centre)", ops.Cut, torusPerpOffCentreBox},
 		{"torus ∩ box (axis-∥ oval cap)", ops.Intersect, torusAxisParallelOvalBox},
 		{"torus − box (axis-∥ oval complement)", ops.Cut, torusAxisParallelOvalBox},
+		{"torus ∩ box (axis-∥ two-oval band)", ops.Intersect, torusTwoOvalBox},
+		{"torus − box (axis-∥ two-oval band)", ops.Cut, torusTwoOvalBox},
 	}
 }
 
@@ -165,6 +167,14 @@ func torusPerpOffCentreBox(t *testing.T) (*topo.Body, *topo.Body) {
 // faces clear and compose.
 func torusAxisParallelOvalBox(t *testing.T) (*topo.Body, *topo.Body) {
 	return demoTorus(t, math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2), demoBlock(t, math.P3(-20, 6, -20), math.P3(20, 20, 20))
+}
+
+// torusTwoOvalBox cuts the same torus by the box face y=2 — PARALLEL to the axis but offset INSIDE the inner
+// tube radius (R−r=3), so the plane passes through the central hole and cuts BOTH tube walls: the section is
+// TWO ovals, each wrapping the tube. The ∩ keeps the +y band between them; the − keeps the wider −y band.
+// Each kept solid is one tube-wrapping torus band + TWO planar oval-disk lids (Oblikovati#1375).
+func torusTwoOvalBox(t *testing.T) (*topo.Body, *topo.Body) {
+	return demoTorus(t, math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2), demoBlock(t, math.P3(-20, 2, -20), math.P3(20, 20, 20))
 }
 
 func demoTorus(t *testing.T, center math.Point3, axis math.Vector3, major, minor float64) *topo.Body {

--- a/kernel/ops/spiric_band_mesh.go
+++ b/kernel/ops/spiric_band_mesh.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// spiricBandMesh meshes the v-wrapping torus BAND a plane parallel to the axis cuts through the central
+// hole (Oblikovati/Oblikovati#1375): the band swept around the tube between the two spiric ovals, the kept
+// side {g ≤ 0} (through u = Phi+π). The band wraps the tube seam, so toUVLoops can't chart it; instead it
+// lofts in u between the two oval edges — each boundary row is the EXACT discretization of its oval edge
+// (so it welds to that oval's planar lid), interior rows fill u between the two branches at the finer oval's
+// tube stations, and consecutive rows are stitched watertight by the shared band zipper. ok=false unless the
+// face is a torus carrying exactly the two oval (spiric) edges.
+func spiricBandMesh(f *topo.Face, s geom.Surface, q Quality) (*Mesh, bool) {
+	t, isTorus := s.(geom.Torus)
+	if !isTorus {
+		return nil, false
+	}
+	plus, minus, ok := twoOvalEdges(f)
+	if !ok {
+		return nil, false
+	}
+	m := &Mesh{}
+	lo := spiricRow(m, t, dropClosingDup(discretizeEdge(plus.edge, q)))
+	hi := spiricRow(m, t, dropClosingDup(discretizeEdge(minus.edge, q)))
+	if len(lo.idx) < 3 || len(hi.idx) < 3 {
+		return nil, false
+	}
+	rows := []bandRow{lo}
+	rows = append(rows, spiricInteriorRows(m, t, plus.arc, minus.arc, finerRowVs(lo, hi), q)...)
+	rows = append(rows, hi)
+	for i := 0; i+1 < len(rows); i++ {
+		stitchBandRows(m, rows[i], rows[i+1])
+	}
+	return m, true
+}
+
+// spiricEdge pairs an oval edge with its analytic SpiricArc (the +1 / −1 branch the band lofts between).
+type spiricEdge struct {
+	edge *topo.Edge
+	arc  geom.SpiricArc
+}
+
+// twoOvalEdges returns the face's two spiric oval edges, the +1 branch as plus and the −1 as minus. ok=false
+// unless exactly two spiric edges are present (the two-oval band's boundary).
+func twoOvalEdges(f *topo.Face) (plus, minus spiricEdge, ok bool) {
+	var arcs []spiricEdge
+	for _, e := range f.Edges() {
+		if a, isSpiric := e.Geometry().(geom.SpiricArc); isSpiric {
+			arcs = append(arcs, spiricEdge{edge: e, arc: a})
+		}
+	}
+	if len(arcs) != 2 {
+		return plus, minus, false
+	}
+	plus, minus = arcs[0], arcs[1]
+	if plus.arc.Branch < 0 {
+		plus, minus = minus, plus
+	}
+	return plus, minus, true
+}
+
+// spiricRow adds a band row from exact 3D boundary points, keyed by each point's tube parameter v (so the
+// zipper merges rows of differing counts in tube order).
+func spiricRow(m *Mesh, t geom.Torus, pts []math.Point3) bandRow {
+	ang := make([]float64, len(pts))
+	for i, p := range pts {
+		ang[i] = vParam(t, p)
+	}
+	return addRow(m, t, pts, ang)
+}
+
+// spiricInteriorRows builds the interior loft rows: at each u-fraction between the branches, fill u from the
+// +1 branch to the −1 branch (the long way, +2π, through u = Phi+π) at the given tube stations vs.
+func spiricInteriorRows(m *Mesh, t geom.Torus, plus, minus geom.SpiricArc, vs []float64, q Quality) []bandRow {
+	nCols := spiricBandColumns(plus, minus, q)
+	rows := make([]bandRow, 0, nCols-1)
+	for k := 1; k < nCols; k++ {
+		frac := float64(k) / float64(nCols)
+		pts := make([]math.Point3, len(vs))
+		for i, v := range vs {
+			uLo := plus.UAt(v)
+			uHi := minus.UAt(v) + 2*stdmath.Pi
+			pts[i] = t.PointAt(uLo+frac*(uHi-uLo), v)
+		}
+		rows = append(rows, addRow(m, t, pts, vs))
+	}
+	return rows
+}
+
+// spiricBandColumns picks the loft column count from the band's widest u-span and the angular tolerance, so
+// even the wide ( |K|/M small ) band is faceted to the chord deflection.
+func spiricBandColumns(plus, minus geom.SpiricArc, q Quality) int {
+	var maxSpan float64
+	for k := 0; k < 8; k++ {
+		v := 2 * stdmath.Pi * float64(k) / 8
+		if span := minus.UAt(v) + 2*stdmath.Pi - plus.UAt(v); span > maxSpan {
+			maxSpan = span
+		}
+	}
+	if n := int(stdmath.Ceil(maxSpan / q.angleTol())); n > 2 {
+		return n
+	}
+	return 2
+}
+
+// finerRowVs returns the tube parameters of whichever boundary row has more samples — the interior loft
+// rows reuse them so a clean quad strip forms against the finer oval (the other zips).
+func finerRowVs(a, b bandRow) []float64 {
+	if len(a.ang) >= len(b.ang) {
+		return a.ang
+	}
+	return b.ang
+}

--- a/kernel/ops/spiric_band_mesh_test.go
+++ b/kernel/ops/spiric_band_mesh_test.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// finerRowVs returns whichever row's tube stations are denser (the interior loft reuses them).
+func TestFinerRowVs(t *testing.T) {
+	a := bandRow{ang: []float64{0, 1, 2}}
+	b := bandRow{ang: []float64{0, 1}}
+	if got := finerRowVs(a, b); len(got) != 3 {
+		t.Errorf("finerRowVs picked the coarser row: len %d, want 3", len(got))
+	}
+	if got := finerRowVs(b, a); len(got) != 3 {
+		t.Errorf("finerRowVs(b,a) picked the coarser row: len %d, want 3", len(got))
+	}
+}
+
+// spiricBandColumns scales the loft column count with the band's widest u-span and the angle tolerance.
+func TestSpiricBandColumns(t *testing.T) {
+	tor, _ := geom.NewTorus(math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2)
+	pl, _ := geom.NewPlane(math.P3(0, 2, 0), math.V3(0, 1, 0))
+	phi, m, k, c := geom.TorusSectionCoeffs(tor, pl)
+	plus := geom.SpiricArc{Torus: tor, Phi: phi, M: m, K: k, C: c, Branch: +1, V0: 0, V1: 2 * stdmath.Pi}
+	minus := geom.SpiricArc{Torus: tor, Phi: phi, M: m, K: k, C: c, Branch: -1, V0: 0, V1: 2 * stdmath.Pi}
+	if n := spiricBandColumns(plus, minus, DefaultQuality()); n < 3 {
+		t.Errorf("spiricBandColumns = %d, want ≥3 for a wide band at default angle tolerance", n)
+	}
+	// A coarse angle tolerance needs fewer columns than a fine one.
+	coarse := spiricBandColumns(plus, minus, Quality{AngleTolerance: 1})
+	fine := spiricBandColumns(plus, minus, Quality{AngleTolerance: 0.05})
+	if coarse >= fine {
+		t.Errorf("spiricBandColumns coarse=%d should be < fine=%d", coarse, fine)
+	}
+}

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -78,6 +78,9 @@ func specialCurvedMesh(f *topo.Face, s geom.Surface, outer3D []math.Point3, hole
 	if m, isBand := twoClosedRimBandMesh(f, s, q); isBand {
 		return m, true // a developable side with two CLOSED full-wrap rims (e.g. a circle + an oblique-cut ellipse): loft
 	}
+	if m, isBand := spiricBandMesh(f, s, q); isBand {
+		return m, true // a torus cut through the hole: a tube-wrapping band between two spiric ovals (#1375)
+	}
 	return nil, false
 }
 

--- a/kernel/ops/testdata/occ_boolean_oracle.json
+++ b/kernel/ops/testdata/occ_boolean_oracle.json
@@ -35,5 +35,7 @@
   "torus ∩ box (perp half)": 197.392088,
   "torus − box (perp off-centre)": 317.6034316,
   "torus ∩ box (axis-∥ oval cap)": 10.66402825,
-  "torus − box (axis-∥ oval complement)": 384.1202201
+  "torus − box (axis-∥ oval complement)": 384.1202201,
+  "torus ∩ box (axis-∥ two-oval band)": 145.422929,
+  "torus − box (axis-∥ two-oval band)": 249.3613324
 }


### PR DESCRIPTION
## What

The last single-plane axis-parallel spiric topology. A plane **parallel to a torus axis** but offset **inside** the inner tube radius (`|K|/M < R−r`) passes through the central hole and cuts **both** tube walls — the spiric section is **two ovals**, each wrapping the whole tube. The two ovals split the torus into two v-wrapping **bands**; the half-space keeps one. Previously this demoted to faceted CSG.

## Why

Completes the axis-parallel oblique torus cut across all its section topologies: single-oval cap (#1389), genus-1 complement (#1390), and now the two-oval band. Together they partition a torus by any axis-parallel plane exactly.

## How

The kept band is always `{g ≤ 0}`, swept around the tube from the `+1` branch to the `−1` branch **the long way** (through `u = Phi+π`) — so the **same** builder and mesher serve both `∩` and `−` (the plane normal sets `Phi`). The kept solid is one tube-wrapping torus band closed by **two** planar oval-disk lids (the two tube cross-sections), unlike the single-oval cut's one lid.

- **`geom.SpiricArc.UAt`** — exposes the section's single-valued `u(v)` so the tessellator can sweep the band without inverting `PointAt`.
- **`brep.torusTwoOvalBand` / `torusTwoOvalHalfSpace`** — detect (axis-parallel, offset in `(0, R−r)`) and build the band: two closed-oval edges bridged by a `v=0` seam (mirroring the perpendicular band) plus the two oval lids. The torus dispatch is factored into `torusHalfSpaceCut` to keep `HalfSpaceCut` within the complexity limit.
- **`ops.spiricBandMesh`** — lofts the band in `u` between the two oval edges: each boundary row is the **exact** oval-edge discretization (so it welds to that oval's planar lid), interior rows fill `u` between the branches at the finer oval's tube stations, stitched watertight by the shared band zipper.

## Validation

Against OpenCASCADE `getMass`: `∩` band = **145.42** (rel 0.014), `−` band = **249.36** (rel 0.011), and `∩ + − = 40π²` exactly (the two bands partition the torus). Both take the exact analytic path. Lint clean under golangci-lint v2.1.0; new-code coverage 87–100%.

Remaining oblique-torus cases (the figure-eight pinch at `|K|/M = R−r`, and a general oblique `C≠0` cut) still demote to CSG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)