### PR TITLE
brep,ops: exact general oblique single-oval torus cut (#1375)

### DIFF
--- a/kernel/brep/curved_halfspace.go
+++ b/kernel/brep/curved_halfspace.go
@@ -68,6 +68,9 @@ func torusHalfSpaceCut(body *topo.Body, torus geom.Torus, plane geom.Plane, n ma
 	case torusTwoOvalBand(torus, plane):
 		res, err := torusTwoOvalHalfSpace(torus, plane) // axis-∥ through the hole → v-wrapping band + 2 lids
 		return res, true, err
+	case torusObliqueOval(torus, plane):
+		res, err := torusObliqueOvalHalfSpace(torus, plane) // tilted single-oval bite → cap or complement
+		return res, true, err
 	}
 	return nil, false, nil
 }

--- a/kernel/brep/curved_halfspace_torus_oblique_general.go
+++ b/kernel/brep/curved_halfspace_torus_oblique_general.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"sort"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+)
+
+// General oblique torus half-space cut (M2 Phase-1 follow-up, Oblikovati/Oblikovati#1375). A plane TILTED
+// relative to the torus axis (C = m·axis neither 0 nor ±1) cuts a spiric section whose w(v) carries the
+// extra C·r·sin v term, so it is asymmetric in v — but it is still single-valued, u(v) = Phi ± arccos w(v).
+// This handles the common single-OVAL tilt (one bite off the tube): the section is one closed oval and the
+// kept solid is the small contractible CAP or its genus-1 COMPLEMENT, reusing the axis-parallel builders and
+// meshers with the oval's v-range found from the closed-form w(v) = ±1 crossings. Two oblique ovals, the
+// figure-eight pinch, and a tilt enclosing more than half the torus still demote to CSG.
+
+// torusW evaluates the section function w(v) = (K − C·r·sin v) / (M·(R + r·cos v)).
+func torusW(t geom.Torus, m, k, c, v float64) float64 {
+	return (k - c*t.MinorRadius*stdmath.Sin(v)) / (m * (t.MajorRadius + t.MinorRadius*stdmath.Cos(v)))
+}
+
+// wUnitCrossings returns the tube angles v∈[0,2π) where |w(v)| = 1 (the section's branch pinches), from
+// the closed forms K ∓ M·R = r·√(C²+M²)·sin(v ± δ), δ = atan2(M, C). Up to four (two per ±1 level).
+func wUnitCrossings(t geom.Torus, m, k, c float64) []float64 {
+	a := stdmath.Hypot(c, m)
+	delta := stdmath.Atan2(m, c)
+	var out []float64
+	addLevel := func(s, phase float64) {
+		if stdmath.Abs(s) > 1 {
+			return
+		}
+		base := stdmath.Asin(s)
+		for _, x := range []float64{base + phase, stdmath.Pi - base + phase} {
+			out = append(out, normalizeAngle(x))
+		}
+	}
+	addLevel((k-m*t.MajorRadius)/(t.MinorRadius*a), -delta) // w = +1
+	addLevel((k+m*t.MajorRadius)/(t.MinorRadius*a), +delta) // w = −1
+	return out
+}
+
+// normalizeAngle folds an angle into [0, 2π).
+func normalizeAngle(x float64) float64 {
+	x = stdmath.Mod(x, 2*stdmath.Pi)
+	if x < 0 {
+		x += 2 * stdmath.Pi
+	}
+	return x
+}
+
+// torusObliqueOvalRange returns the single-oval tube-angle interval [v0,v1] (v0 may be negative so the
+// sweep is continuous across the seam) and the pinch sign — +1 when the branches meet at u=Phi (the
+// crossings are at w=+1) or −1 when they meet at u=Phi+π (w=−1), which is where the bounded disk is centred.
+// ok=false unless the section is exactly one oval — two pinch crossings bounding one valid (|w|≤1) interval
+// (zero or four crossings are a clearing/two-oval/figure-eight topology handled elsewhere or deferred).
+func torusObliqueOvalRange(t geom.Torus, m, k, c float64) (v0, v1, pinch float64, ok bool) {
+	cross := wUnitCrossings(t, m, k, c)
+	if len(cross) != 2 {
+		return 0, 0, 0, false
+	}
+	sort.Float64s(cross)
+	a, b := cross[0], cross[1]
+	v0, v1 = a, b
+	if stdmath.Abs(torusW(t, m, k, c, (a+b)/2)) > 1 {
+		v0, v1 = b, a+2*stdmath.Pi // the valid stretch wraps the seam
+	}
+	pinch = 1
+	if torusW(t, m, k, c, v0) < 0 {
+		pinch = -1 // the branches meet at Phi+π, so the disk is centred there
+	}
+	return v0, v1, pinch, true
+}
+
+// torusObliqueOval reports whether plane makes a single small oval bite we can build exactly: genuinely
+// tilted (cylinderAxisTol < |C| so it is not the axis-parallel case, |C| < 1 so it is not perpendicular),
+// one oval, and the BOUNDED disk under half the torus (so it is the small cap and its complement the large
+// genus-1 region — keeping the meshers well-conditioned). A tilt enclosing a larger disk defers to CSG.
+func torusObliqueOval(t geom.Torus, plane geom.Plane) bool {
+	_, m, k, c := geom.TorusSectionCoeffs(t, plane)
+	if stdmath.Abs(c) <= cylinderAxisTol || stdmath.Abs(c) >= 1-cylinderAxisTol || m <= cylinderAxisTol {
+		return false
+	}
+	v0, v1, pinch, ok := torusObliqueOvalRange(t, m, k, c)
+	return ok && ovalDiskArea(t, m, k, c, v0, v1, pinch) < 2*stdmath.Pi*stdmath.Pi
+}
+
+// ovalDiskArea returns the (u,v) area of the disk the oval bounds — the lens around the pinch, whose
+// half-width is arccos(pinch·w(v)) (arccos w around Phi, or π−arccos w around Phi+π). ∫ 2·that over [v0,v1].
+func ovalDiskArea(t geom.Torus, m, k, c, v0, v1, pinch float64) float64 {
+	const n = 200
+	var area float64
+	for i := 0; i < n; i++ {
+		v := v0 + (v1-v0)*(float64(i)+0.5)/n
+		area += 2 * stdmath.Acos(clampUnitF(pinch*torusW(t, m, k, c, v))) * (v1 - v0) / n
+	}
+	return area
+}
+
+// torusObliqueOvalHalfSpace keeps the cap or the genus-1 complement of the single oval a tilted plane bites
+// from the torus. The kept side is decided by the sign of g at the disk's interior (u = the pinch, mid-v):
+// g≤0 there keeps the contractible cap (oval as the torus face's outer loop), g>0 keeps the complement.
+func torusObliqueOvalHalfSpace(t geom.Torus, plane geom.Plane) (*topo.Body, error) {
+	phi, m, k, c := geom.TorusSectionCoeffs(t, plane)
+	v0, v1, pinch, _ := torusObliqueOvalRange(t, m, k, c)
+	vMid := (v0 + v1) / 2
+	gDisk := (t.MajorRadius+t.MinorRadius*stdmath.Cos(vMid))*m*pinch + c*t.MinorRadius*stdmath.Sin(vMid) - k
+	return buildTorusOvalSolid(t, phi, m, k, c, v0, v1, unit(plane.Normal()), plane, gDisk > 0)
+}

--- a/kernel/brep/curved_halfspace_torus_oblique_general_test.go
+++ b/kernel/brep/curved_halfspace_torus_oblique_general_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// A plane oblique to the torus axis (tilted torus, axis-aligned cut) bites a single asymmetric spiric oval:
+// the kept solid is the small contractible CAP or its genus-1 COMPLEMENT, watertight, no CSG (Oblikovati#1375).
+func TestHalfSpaceCutTorusObliqueOval(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		normal math.Vector3
+	}{
+		{"keep cap (small)", math.V3(0, 0, -1)}, // z≥3.6 keeps the small cap
+		{"keep complement", math.V3(0, 0, 1)},   // z≤3.6 keeps the genus-1 complement
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tor, _ := SolidTorus(math.P3(0, 0, 0), math.V3(0, 0.6, 0.8), 5, 2, "torus")
+			plane, _ := geom.NewPlane(math.P3(0, 0, 3.6), tc.normal)
+			res, err := HalfSpaceCut(tor, plane)
+			if err != nil {
+				t.Fatalf("HalfSpaceCut: %v", err)
+			}
+			assertWatertight(t, res)
+			tori, planes := 0, 0
+			for _, f := range res.Faces() {
+				switch f.Geometry().(type) {
+				case geom.Torus:
+					tori++
+				case geom.Plane:
+					planes++
+				}
+			}
+			if tori != 1 || planes != 1 {
+				t.Errorf("oblique oval cut has %d torus + %d plane faces, want 1 + 1", tori, planes)
+			}
+		})
+	}
+}
+
+// torusObliqueOvalRange finds the oval's tube-angle interval and pinch sign from the closed-form w=±1
+// crossings, exactly where the sampled section starts/ends.
+func TestTorusObliqueOvalRange(t *testing.T) {
+	tor, _ := geom.NewTorus(math.P3(0, 0, 0), math.V3(0, 0.6, 0.8), 5, 2)
+	plane, _ := geom.NewPlane(math.P3(0, 0, 3.6), math.V3(0, 0, 1))
+	_, m, k, c := geom.TorusSectionCoeffs(tor, plane)
+	v0, v1, pinch, ok := torusObliqueOvalRange(tor, m, k, c)
+	if !ok {
+		t.Fatal("expected a single oval")
+	}
+	// |w|=1 at both ends, |w|<1 strictly inside.
+	if w := stdmath.Abs(torusW(tor, m, k, c, v0)); stdmath.Abs(w-1) > 1e-9 {
+		t.Errorf("|w(v0)|=%g, want 1", w)
+	}
+	if w := stdmath.Abs(torusW(tor, m, k, c, (v0+v1)/2)); w > 1 {
+		t.Errorf("|w(mid)|=%g, want <1 (inside the oval)", w)
+	}
+	if pinch != 1 && pinch != -1 {
+		t.Errorf("pinch=%g, want ±1", pinch)
+	}
+}
+
+// A perpendicular or axis-parallel plane is not the oblique case; a non-tilted cut must defer.
+func TestTorusObliqueOvalGuards(t *testing.T) {
+	tor, _ := geom.NewTorus(math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2)
+	for _, tc := range []struct {
+		name   string
+		normal math.Vector3
+	}{
+		{"perpendicular", math.V3(0, 0, 1)},
+		{"axis-parallel", math.V3(0, 1, 0)},
+	} {
+		plane, _ := geom.NewPlane(math.P3(0, 0, 1), tc.normal)
+		if torusObliqueOval(tor, plane) {
+			t.Errorf("%s plane wrongly classified as an oblique oval", tc.name)
+		}
+	}
+}

--- a/kernel/ops/boolean_csg_demotion_test.go
+++ b/kernel/ops/boolean_csg_demotion_test.go
@@ -142,6 +142,8 @@ func curvedExactCases() []curvedExactCase {
 		{"torus − box (axis-∥ oval complement)", ops.Cut, torusAxisParallelOvalBox},
 		{"torus ∩ box (axis-∥ two-oval band)", ops.Intersect, torusTwoOvalBox},
 		{"torus − box (axis-∥ two-oval band)", ops.Cut, torusTwoOvalBox},
+		{"torus ∩ box (oblique single oval)", ops.Intersect, torusObliqueOvalBox},
+		{"torus − box (oblique single oval)", ops.Cut, torusObliqueOvalBox},
 	}
 }
 
@@ -175,6 +177,14 @@ func torusAxisParallelOvalBox(t *testing.T) (*topo.Body, *topo.Body) {
 // Each kept solid is one tube-wrapping torus band + TWO planar oval-disk lids (Oblikovati#1375).
 func torusTwoOvalBox(t *testing.T) (*topo.Body, *topo.Body) {
 	return demoTorus(t, math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2), demoBlock(t, math.P3(-20, 2, -20), math.P3(20, 20, 20))
+}
+
+// torusObliqueOvalBox cuts a TILTED torus (axis (0,0.6,0.8)) by the box face z=3.6 — a plane oblique to the
+// axis (C = m·axis ≈ 0.8). The asymmetric spiric section is a single oval bitten off one side of the tube:
+// the ∩ keeps the small contractible CAP, the − the genus-1 COMPLEMENT. The general oblique cut (#1375);
+// a box can't make an oblique cut of an upright torus, so the torus is tilted instead (as the cone cases do).
+func torusObliqueOvalBox(t *testing.T) (*topo.Body, *topo.Body) {
+	return demoTorus(t, math.P3(0, 0, 0), math.V3(0, 0.6, 0.8), 5, 2), demoBlock(t, math.P3(-20, -20, 3.6), math.P3(20, 20, 20))
 }
 
 func demoTorus(t *testing.T, center math.Point3, axis math.Vector3, major, minor float64) *topo.Body {

--- a/kernel/ops/testdata/occ_boolean_oracle.json
+++ b/kernel/ops/testdata/occ_boolean_oracle.json
@@ -37,5 +37,7 @@
   "torus ∩ box (axis-∥ oval cap)": 10.66402825,
   "torus − box (axis-∥ oval complement)": 384.1202201,
   "torus ∩ box (axis-∥ two-oval band)": 145.422929,
-  "torus − box (axis-∥ two-oval band)": 249.3613324
+  "torus − box (axis-∥ two-oval band)": 249.3613324,
+  "torus ∩ box (oblique single oval)": 24.93812164,
+  "torus − box (oblique single oval)": 369.8453969
 }


### PR DESCRIPTION
## What

A plane **tilted** relative to the torus axis (`C = m·axis` neither 0 nor ±1) cuts a spiric section whose `w(v) = (K − C·r·sin v)/(M·(R + r·cos v))` carries the extra `C·r·sin v` term — so it is **asymmetric** in `v`, unlike all the axis-parallel cases. This lands the common single-**oval** tilt (one bite off the tube) exactly, reusing the oval cap/complement builders and meshers. Previously any tilted cut demoted to faceted CSG.

## Why

This is the general oblique frontier of the torus half-space cut — the last broadly-applicable family. The section's v-range comes from the **closed-form** `w(v) = ±1` crossings: `K ∓ M·R = r·√(C²+M²)·sin(v ± atan2(M,C))` (no iterative root-finding needed).

## How — the subtlety

The bounded disk the oval encloses is centred on the **pinch** `u` (where the two branches meet), which is `Phi` when the crossings are at `w=+1` but `Phi+π` when at `w=−1`. Reading cap-vs-complement off `u=Phi` (as the axis-parallel cases can) picks the *wrong region* here — I debugged a case where both `∩` and `−` resolved to the same (complement) side because of this. So `torusObliqueOvalRange` returns the **pinch sign**, and both the kept-side decision and the half-torus size guard evaluate at the pinch.

- **`brep.torusObliqueOval` / `torusObliqueOvalHalfSpace`** — detect a genuinely tilted single-oval bite whose disk is under half the torus, and build the small **cap** (oval as outer loop) or the genus-1 **complement** (oval as a hole) via the shared `buildTorusOvalSolid` and the existing cap/complement meshers (no new tessellation code).

## Validation

Against OpenCASCADE `getMass` on a tilted torus (axis `(0,0.6,0.8)`) cut by `z=3.6`: `∩` cap = **24.94** (rel 0.027), `−` complement = **369.85** (rel 0.031); the two sum to `40π²` exactly. Both take the exact analytic path. Lint clean (golangci-lint v2.1.0); new-code coverage 91–100%.

Remaining oblique-torus topologies — two oblique ovals, the figure-eight pinch, and a tilt whose disk exceeds half the torus — still demote to CSG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)