### PR TITLE
brep,ops: exact figure-eight (tangent) torus cut (#1375)

### DIFF
--- a/kernel/brep/curved_halfspace_torus_twooval.go
+++ b/kernel/brep/curved_halfspace_torus_twooval.go
@@ -17,16 +17,19 @@ import (
 // two tube cross-sections the plane carves), unlike the single-oval cut's one lid.
 
 // torusTwoOvalBand reports whether plane cuts two ovals from torus: PARALLEL to the axis (m·axis ≈ 0) with
-// the offset strictly inside the inner tube radius (0 < |K|/M < R−r). At |K|/M = 0 the plane passes through
-// the axis (the ovals degenerate to two meridian circles) and at ≥ R−r it cuts a single oval — both handled
-// elsewhere — so this is the strict two-oval interior.
+// the offset up to the inner tube radius (0 < |K|/M ≤ R−r). Below R−r the plane passes through the hole and
+// cuts both walls as two separate ovals; AT R−r exactly it is tangent to the inner equator and the two ovals
+// touch in a FIGURE-EIGHT pinch (Oblikovati/Oblikovati#1375). The band loft handles the pinch as the band's
+// zero-width limit there, so the same path serves both; above R−r the section is a single oval, handled
+// elsewhere. At |K|/M = 0 the plane passes through the axis (the ovals degenerate to meridian circles, still
+// deferred).
 func torusTwoOvalBand(t geom.Torus, plane geom.Plane) bool {
 	_, m, k, c := geom.TorusSectionCoeffs(t, plane)
 	if stdmath.Abs(c) > cylinderAxisTol || m <= cylinderAxisTol {
 		return false
 	}
 	ratio := stdmath.Abs(k) / m
-	return ratio > cylinderAxisTol && ratio < t.MajorRadius-t.MinorRadius-cylinderAxisTol
+	return ratio > cylinderAxisTol && ratio < t.MajorRadius-t.MinorRadius+cylinderAxisTol
 }
 
 // torusTwoOvalHalfSpace keeps the v-wrapping band a plane parallel to the torus axis leaves on its negative

--- a/kernel/brep/curved_halfspace_torus_twooval_test.go
+++ b/kernel/brep/curved_halfspace_torus_twooval_test.go
@@ -48,8 +48,34 @@ func TestHalfSpaceCutTorusTwoOvalBand(t *testing.T) {
 	}
 }
 
-// torusTwoOvalBand admits only the axis-parallel offset strictly inside the inner tube radius; a single-oval
-// offset (≥ R−r) or a perpendicular cut belongs elsewhere.
+// At offset EXACTLY R−r the plane is tangent to the inner equator: the two ovals merge into a figure-eight
+// pinched at the tangent point. The two-oval band path meshes it (the band's zero-width limit), watertight.
+func TestHalfSpaceCutTorusFigureEight(t *testing.T) {
+	for _, n := range []math.Vector3{math.V3(0, -1, 0), math.V3(0, 1, 0)} {
+		tor, _ := SolidTorus(math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2, "torus")
+		plane, _ := geom.NewPlane(math.P3(0, 3, 0), n) // |offset| = R−r = 3
+		res, err := HalfSpaceCut(tor, plane)
+		if err != nil {
+			t.Fatalf("HalfSpaceCut: %v", err)
+		}
+		assertWatertight(t, res)
+		tori, planes := 0, 0
+		for _, f := range res.Faces() {
+			switch f.Geometry().(type) {
+			case geom.Torus:
+				tori++
+			case geom.Plane:
+				planes++
+			}
+		}
+		if tori != 1 || planes != 2 {
+			t.Errorf("figure-eight cut has %d torus + %d plane faces, want 1 + 2 (band + two touching lids)", tori, planes)
+		}
+	}
+}
+
+// torusTwoOvalBand admits the axis-parallel offset up to (and including) the inner tube radius; a single-oval
+// offset (> R−r) or a perpendicular cut belongs elsewhere.
 func TestTorusTwoOvalBandGuards(t *testing.T) {
 	tor, _ := geom.NewTorus(math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2)
 	for _, tc := range []struct {
@@ -59,6 +85,7 @@ func TestTorusTwoOvalBandGuards(t *testing.T) {
 		want   bool
 	}{
 		{"two-oval (offset 2 < R−r)", math.P3(0, 2, 0), math.V3(0, 1, 0), true},
+		{"figure-eight (offset 3 = R−r, tangent)", math.P3(0, 3, 0), math.V3(0, 1, 0), true},
 		{"single-oval (offset 6 in (R−r,R+r))", math.P3(0, 6, 0), math.V3(0, 1, 0), false},
 		{"perpendicular to axis", math.P3(0, 0, 1), math.V3(0, 0, 1), false},
 		{"through the axis (offset 0)", math.P3(0, 0, 0), math.V3(0, 1, 0), false},

--- a/kernel/ops/boolean_csg_demotion_test.go
+++ b/kernel/ops/boolean_csg_demotion_test.go
@@ -144,6 +144,8 @@ func curvedExactCases() []curvedExactCase {
 		{"torus − box (axis-∥ two-oval band)", ops.Cut, torusTwoOvalBox},
 		{"torus ∩ box (oblique single oval)", ops.Intersect, torusObliqueOvalBox},
 		{"torus − box (oblique single oval)", ops.Cut, torusObliqueOvalBox},
+		{"torus ∩ box (figure-eight pinch)", ops.Intersect, torusFigureEightBox},
+		{"torus − box (figure-eight pinch)", ops.Cut, torusFigureEightBox},
 	}
 }
 
@@ -185,6 +187,14 @@ func torusTwoOvalBox(t *testing.T) (*topo.Body, *topo.Body) {
 // a box can't make an oblique cut of an upright torus, so the torus is tilted instead (as the cone cases do).
 func torusObliqueOvalBox(t *testing.T) (*topo.Body, *topo.Body) {
 	return demoTorus(t, math.P3(0, 0, 0), math.V3(0, 0.6, 0.8), 5, 2), demoBlock(t, math.P3(-20, -20, 3.6), math.P3(20, 20, 20))
+}
+
+// torusFigureEightBox cuts the same torus by the box face y=3 — axis-parallel and EXACTLY tangent to the
+// inner equator (offset = R−r = 3): the two ovals of the two-oval cut have merged into a single FIGURE-EIGHT
+// pinched at the tangent point (0,3,0). The band loft meshes the pinch as its zero-width limit, so the same
+// path (a v-wrapping band + two oval lids that touch at the pinch) serves it exactly (Oblikovati#1375).
+func torusFigureEightBox(t *testing.T) (*topo.Body, *topo.Body) {
+	return demoTorus(t, math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2), demoBlock(t, math.P3(-20, 3, -20), math.P3(20, 20, 20))
 }
 
 func demoTorus(t *testing.T, center math.Point3, axis math.Vector3, major, minor float64) *topo.Body {

--- a/kernel/ops/testdata/occ_boolean_oracle.json
+++ b/kernel/ops/testdata/occ_boolean_oracle.json
@@ -39,5 +39,7 @@
   "torus ∩ box (axis-∥ two-oval band)": 145.422929,
   "torus − box (axis-∥ two-oval band)": 249.3613324,
   "torus ∩ box (oblique single oval)": 24.93812164,
-  "torus − box (oblique single oval)": 369.8453969
+  "torus − box (oblique single oval)": 369.8453969,
+  "torus ∩ box (figure-eight pinch)": 114.8863256,
+  "torus − box (figure-eight pinch)": 279.8978536
 }


### PR DESCRIPTION
## What

At an axis-parallel offset **exactly** equal to the inner tube radius (`|K|/M = R−r`) the plane is **tangent to the torus's inner equator**: the two ovals of the two-oval cut merge into a single **figure-eight**, pinched at the tangent point. This was the boundary between the two-oval band (`offset < R−r`) and the single-oval cut (`offset > R−r`), and fell into the gap to CSG.

## Why

It completes the axis-parallel family with no gap at the transition between two-oval and single-oval.

## How

No new machinery needed: the v-wrapping band loft already meshes the pinch as the band's **zero-width limit** — at the tangent tube angle the two oval branches meet, so the band closes to a point and the two oval lids touch there. The fix is just to route the offset *up to and including* `R−r` to the two-oval path; the band + two-oval-lid builder and the spiric band mesher handle the merged section as-is. (I confirmed this empirically before changing anything — the two-oval mesh at exactly `R−r` already produced the right volume.)

- **`brep.torusTwoOvalBand`** — extend the offset bound from `< R−r` to `≤ R−r` (the tangent boundary).

## Validation

Against OpenCASCADE `getMass` (torus cut by `y=3`, tangent to the inner equator of an `R=5 r=2` torus): `∩` = **114.89** (rel 0.021), `−` = **279.90** (rel 0.017); the two sum to `40π²` exactly. Both take the exact analytic path. Lint clean (golangci-lint v2.1.0).

The only torus half-space topologies still on CSG are now the two-**oblique**-oval cut and a tilt whose enclosed disk exceeds half the torus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)