### PR TITLE
brep,ops: exact two-oblique-oval torus cut (#1375)

### DIFF
--- a/kernel/brep/curved_halfspace.go
+++ b/kernel/brep/curved_halfspace.go
@@ -71,6 +71,9 @@ func torusHalfSpaceCut(body *topo.Body, torus geom.Torus, plane geom.Plane, n ma
 	case torusObliqueOval(torus, plane):
 		res, err := torusObliqueOvalHalfSpace(torus, plane) // tilted single-oval bite → cap or complement
 		return res, true, err
+	case torusTwoObliqueOval(torus, plane):
+		res, err := torusTwoOvalHalfSpace(torus, plane) // tilted cut through the hole → v-wrapping band + 2 lids
+		return res, true, err
 	}
 	return nil, false, nil
 }

--- a/kernel/brep/curved_halfspace_torus_oblique_general.go
+++ b/kernel/brep/curved_halfspace_torus_oblique_general.go
@@ -15,8 +15,9 @@ import (
 // extra C·r·sin v term, so it is asymmetric in v — but it is still single-valued, u(v) = Phi ± arccos w(v).
 // This handles the common single-OVAL tilt (one bite off the tube): the section is one closed oval and the
 // kept solid is the small contractible CAP or its genus-1 COMPLEMENT, reusing the axis-parallel builders and
-// meshers with the oval's v-range found from the closed-form w(v) = ±1 crossings. Two oblique ovals, the
-// figure-eight pinch, and a tilt enclosing more than half the torus still demote to CSG.
+// meshers with the oval's v-range found from the closed-form w(v) = ±1 crossings. A tilted cut through the
+// hole makes TWO oblique ovals — [torusTwoObliqueOval] routes those through the two-oval band path. A tilt
+// enclosing more than half the torus (the disk-larger-than-half case) still demotes to CSG.
 
 // torusW evaluates the section function w(v) = (K − C·r·sin v) / (M·(R + r·cos v)).
 func torusW(t geom.Torus, m, k, c, v float64) float64 {
@@ -98,6 +99,18 @@ func ovalDiskArea(t geom.Torus, m, k, c, v0, v1, pinch float64) float64 {
 		area += 2 * stdmath.Acos(clampUnitF(pinch*torusW(t, m, k, c, v))) * (v1 - v0) / n
 	}
 	return area
+}
+
+// torusTwoObliqueOval reports whether a TILTED plane (cylinderAxisTol < |C| < 1) cuts TWO ovals: the section
+// is valid at every tube angle (no w=±1 crossing, so each branch is a full closed oval) and not cleared
+// (|w(0)| < 1). The two-oval band builder and the spiric band mesher are general in C, so the tilted
+// two-oval reuses them exactly — only the detection differs from the axis-parallel [torusTwoOvalBand].
+func torusTwoObliqueOval(t geom.Torus, plane geom.Plane) bool {
+	_, m, k, c := geom.TorusSectionCoeffs(t, plane)
+	if stdmath.Abs(c) <= cylinderAxisTol || stdmath.Abs(c) >= 1-cylinderAxisTol || m <= cylinderAxisTol {
+		return false
+	}
+	return len(wUnitCrossings(t, m, k, c)) == 0 && stdmath.Abs(torusW(t, m, k, c, 0)) < 1
 }
 
 // torusObliqueOvalHalfSpace keeps the cap or the genus-1 complement of the single oval a tilted plane bites

--- a/kernel/brep/curved_halfspace_torus_oblique_general_test.go
+++ b/kernel/brep/curved_halfspace_torus_oblique_general_test.go
@@ -66,6 +66,59 @@ func TestTorusObliqueOvalRange(t *testing.T) {
 	}
 }
 
+// A tilted plane through the central hole cuts TWO oblique ovals (the section is valid at every tube angle):
+// the kept solid is a v-wrapping band + two oval lids, watertight, no CSG (Oblikovati#1375).
+func TestHalfSpaceCutTorusTwoObliqueOval(t *testing.T) {
+	tor, _ := SolidTorus(math.P3(0, 0, 0), math.V3(0, 0.6, 0.8), 5, 2, "torus")
+	torS, _ := geom.NewTorus(math.P3(0, 0, 0), math.V3(0, 0.6, 0.8), 5, 2)
+	plane, _ := geom.NewPlane(math.P3(0, 0, 0.5), math.V3(0, 0, 1)) // tilted, through the hole
+	if !torusTwoObliqueOval(torS, plane) {
+		t.Fatal("expected a tilted two-oval section")
+	}
+	res, err := HalfSpaceCut(tor, plane)
+	if err != nil {
+		t.Fatalf("HalfSpaceCut: %v", err)
+	}
+	assertWatertight(t, res)
+	tori, planes := 0, 0
+	for _, f := range res.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Torus:
+			tori++
+		case geom.Plane:
+			planes++
+		}
+	}
+	if tori != 1 || planes != 2 {
+		t.Errorf("tilted two-oval cut has %d torus + %d plane faces, want 1 + 2 (band + two oval lids)", tori, planes)
+	}
+}
+
+// torusTwoObliqueOval admits only a tilted cut through the hole (two ovals); a tilted single-oval bite (with
+// w=±1 crossings) or an upright cut is not it.
+func TestTorusTwoObliqueOvalGuards(t *testing.T) {
+	torS, _ := geom.NewTorus(math.P3(0, 0, 0), math.V3(0, 0.6, 0.8), 5, 2)
+	for _, tc := range []struct {
+		name   string
+		origin math.Point3
+		want   bool
+	}{
+		{"tilted through hole (two ovals)", math.P3(0, 0, 0.5), true},
+		{"tilted single-oval bite (z=3.6)", math.P3(0, 0, 3.6), false},
+	} {
+		plane, _ := geom.NewPlane(tc.origin, math.V3(0, 0, 1))
+		if got := torusTwoObliqueOval(torS, plane); got != tc.want {
+			t.Errorf("%s: torusTwoObliqueOval = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+	// An upright (axis-aligned) torus cut is never the oblique two-oval case.
+	upright, _ := geom.NewTorus(math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2)
+	plane, _ := geom.NewPlane(math.P3(0, 2, 0), math.V3(0, 1, 0))
+	if torusTwoObliqueOval(upright, plane) {
+		t.Error("axis-parallel two-oval wrongly classified as oblique")
+	}
+}
+
 // A perpendicular or axis-parallel plane is not the oblique case; a non-tilted cut must defer.
 func TestTorusObliqueOvalGuards(t *testing.T) {
 	tor, _ := geom.NewTorus(math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2)

--- a/kernel/ops/boolean_csg_demotion_test.go
+++ b/kernel/ops/boolean_csg_demotion_test.go
@@ -146,6 +146,8 @@ func curvedExactCases() []curvedExactCase {
 		{"torus − box (oblique single oval)", ops.Cut, torusObliqueOvalBox},
 		{"torus ∩ box (figure-eight pinch)", ops.Intersect, torusFigureEightBox},
 		{"torus − box (figure-eight pinch)", ops.Cut, torusFigureEightBox},
+		{"torus ∩ box (two oblique ovals)", ops.Intersect, torusTwoObliqueOvalBox},
+		{"torus − box (two oblique ovals)", ops.Cut, torusTwoObliqueOvalBox},
 	}
 }
 
@@ -195,6 +197,14 @@ func torusObliqueOvalBox(t *testing.T) (*topo.Body, *topo.Body) {
 // path (a v-wrapping band + two oval lids that touch at the pinch) serves it exactly (Oblikovati#1375).
 func torusFigureEightBox(t *testing.T) (*topo.Body, *topo.Body) {
 	return demoTorus(t, math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2), demoBlock(t, math.P3(-20, 3, -20), math.P3(20, 20, 20))
+}
+
+// torusTwoObliqueOvalBox cuts a TILTED torus (axis (0,0.6,0.8)) by the box face z=0.5 — a plane oblique to
+// the axis AND through the central hole, so it cuts both tube walls into TWO asymmetric (tilted) ovals. The
+// kept solid is the v-wrapping band between them + two oval lids, same as the axis-parallel two-oval but with
+// the section's C≠0 term; the general band builder/mesher serve it directly (Oblikovati#1375).
+func torusTwoObliqueOvalBox(t *testing.T) (*topo.Body, *topo.Body) {
+	return demoTorus(t, math.P3(0, 0, 0), math.V3(0, 0.6, 0.8), 5, 2), demoBlock(t, math.P3(-20, -20, 0.5), math.P3(20, 20, 20))
 }
 
 func demoTorus(t *testing.T, center math.Point3, axis math.Vector3, major, minor float64) *topo.Body {

--- a/kernel/ops/testdata/occ_boolean_oracle.json
+++ b/kernel/ops/testdata/occ_boolean_oracle.json
@@ -41,5 +41,7 @@
   "torus ∩ box (oblique single oval)": 24.93812164,
   "torus − box (oblique single oval)": 369.8453969,
   "torus ∩ box (figure-eight pinch)": 114.8863256,
-  "torus − box (figure-eight pinch)": 279.8978536
+  "torus − box (figure-eight pinch)": 279.8978536,
+  "torus ∩ box (two oblique ovals)": 175.3359946,
+  "torus − box (two oblique ovals)": 219.4483228
 }


### PR DESCRIPTION
## What

A plane that is **both** tilted relative to the torus axis (`C = m·axis ≠ 0`) **and** offset through the central hole cuts both tube walls into **two asymmetric ovals** — the oblique analogue of the axis-parallel two-oval band. It was the last *common* torus half-space topology still demoting to CSG.

## Why / How

No new builder or mesher needed: the two-oval band builder and the spiric band loft are already **general in C** (the section's `u(v) = Phi ± arccos w(v)` carries the `C·r·sin v` term through `SpiricArc`), so the tilted two-oval reuses them directly. Only the detection differs — the section is two ovals exactly when it's valid at every tube angle: **no `w(v) = ±1` crossing** (each branch is a full closed oval) and **not cleared** (`|w(0)| < 1`), which `torusTwoObliqueOval` reads off the closed-form crossings.

- **`brep.torusTwoObliqueOval`** — detect a tilted cut through the hole and route it to `torusTwoOvalHalfSpace` via the torus dispatch.

## Validation

Against OpenCASCADE `getMass` on a tilted torus (axis `(0,0.6,0.8)`) cut by `z=0.5`: `∩` = **175.34** (rel 0.019), `−` = **219.45** (rel 0.020); the two sum to `40π²`. Both take the exact analytic path. Lint clean (golangci-lint v2.1.0); new-code coverage 100%.

## What's left

The only torus half-space topology still on CSG is a tilt whose **enclosed disk exceeds half the torus** — a large contractible disk the local patch mesher can't chart without tearing (and the complement chart tears symmetrically on the large oval window). That one is genuinely hard with no clean reuse, so it's left to the correct (faceted) CSG fallback. This brings the torus half-space cut to exact analytic coverage for every section topology except that single large-disk corner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)