### PR TITLE
brep,ops: robustly mesh near-full-wrap torus complement cuts (#1375)

### DIFF
--- a/kernel/brep/curved_halfspace_torus_oblique_general.go
+++ b/kernel/brep/curved_halfspace_torus_oblique_general.go
@@ -76,41 +76,60 @@ func torusObliqueOvalRange(t geom.Torus, m, k, c float64) (v0, v1, pinch float64
 	return v0, v1, pinch, true
 }
 
-// torusObliqueOval reports whether plane makes a single small oval bite we can build exactly: genuinely
-// tilted (cylinderAxisTol < |C| so it is not the axis-parallel case, |C| < 1 so it is not perpendicular),
-// one oval, and the BOUNDED disk under half the torus (so it is the small cap and its complement the large
-// genus-1 region — keeping the meshers well-conditioned). A tilt enclosing a larger disk defers to CSG.
+// figureEightWrapTol is the tube-angle arc over which a single oval's section may be ABSENT before it counts
+// as a near-full-wrap figure-eight (the oblique analogue of the axis-parallel tangent cut) and routes to the
+// two-oval band path instead. A single oval whose section exists over all but this sliver of the tube has
+// wrapped nearly the whole tube; its genus-1 complement is then a thin strip the chart can't mesh, so the
+// band loft (which meshes the sliver as the band's zero-width pinch) handles it robustly instead.
+//
+// The near-full-wrap test SAMPLES where the section exists (|w(v)|≤1) rather than reading the analytic
+// w(v)=±1 crossings: at the exact transition the two crossings collide into a double root whose asin is
+// platform-sensitive, so the analytic span flickers either side of the threshold across platforms.
+const figureEightWrapTol = 0.15
+
+// torusSectionAbsentArc returns the tube-angle arc length over which the spiric section does NOT exist
+// (|w(v)| > 1), sampled around the tube. Zero means the section wraps the whole tube (two ovals); a small
+// value means a near-full-wrap single oval; a large value a clear single-oval bite.
+func torusSectionAbsentArc(t geom.Torus, m, k, c float64) float64 {
+	const n = 720
+	absent := 0
+	for i := 0; i < n; i++ {
+		if stdmath.Abs(torusW(t, m, k, c, 2*stdmath.Pi*float64(i)/n)) > 1 {
+			absent++
+		}
+	}
+	return 2 * stdmath.Pi * float64(absent) / n
+}
+
+// torusObliqueOval reports whether plane makes a single CLEAR oval bite we build via the cap/complement
+// path: genuinely tilted (cylinderAxisTol < |C| < 1), one oval, and NOT near-full-wrap (the section is
+// absent over more than figureEightWrapTol of the tube, so the complement is a fat genus-1 region the chart
+// meshes well). A near-full-wrap oval is the oblique figure-eight, routed to [torusTwoObliqueOval] instead.
 func torusObliqueOval(t geom.Torus, plane geom.Plane) bool {
 	_, m, k, c := geom.TorusSectionCoeffs(t, plane)
 	if stdmath.Abs(c) <= cylinderAxisTol || stdmath.Abs(c) >= 1-cylinderAxisTol || m <= cylinderAxisTol {
 		return false
 	}
-	v0, v1, pinch, ok := torusObliqueOvalRange(t, m, k, c)
-	return ok && ovalDiskArea(t, m, k, c, v0, v1, pinch) < 2*stdmath.Pi*stdmath.Pi
-}
-
-// ovalDiskArea returns the (u,v) area of the disk the oval bounds — the lens around the pinch, whose
-// half-width is arccos(pinch·w(v)) (arccos w around Phi, or π−arccos w around Phi+π). ∫ 2·that over [v0,v1].
-func ovalDiskArea(t geom.Torus, m, k, c, v0, v1, pinch float64) float64 {
-	const n = 200
-	var area float64
-	for i := 0; i < n; i++ {
-		v := v0 + (v1-v0)*(float64(i)+0.5)/n
-		area += 2 * stdmath.Acos(clampUnitF(pinch*torusW(t, m, k, c, v))) * (v1 - v0) / n
+	if torusSectionAbsentArc(t, m, k, c) <= figureEightWrapTol {
+		return false // near-full-wrap (or two-oval): the band path handles it
 	}
-	return area
+	_, _, _, ok := torusObliqueOvalRange(t, m, k, c)
+	return ok // a clear single oval (the substantial absent arc keeps the crossings well separated)
 }
 
-// torusTwoObliqueOval reports whether a TILTED plane (cylinderAxisTol < |C| < 1) cuts TWO ovals: the section
-// is valid at every tube angle (no w=±1 crossing, so each branch is a full closed oval) and not cleared
-// (|w(0)| < 1). The two-oval band builder and the spiric band mesher are general in C, so the tilted
-// two-oval reuses them exactly — only the detection differs from the axis-parallel [torusTwoOvalBand].
+// torusTwoObliqueOval reports whether a TILTED plane (cylinderAxisTol < |C| < 1) cuts a band the band loft
+// meshes: either TWO ovals (the section is valid at every tube angle — no w=±1 crossing — so each branch is
+// a full closed oval) or the near-full-wrap FIGURE-EIGHT (a single oval whose two pinches are within
+// figureEightWrapTol, valid over all but a sliver of the tube). Both are the tilted analogue of the
+// axis-parallel [torusTwoOvalBand]; the band builder and spiric mesher are general in C, so they reuse it.
 func torusTwoObliqueOval(t geom.Torus, plane geom.Plane) bool {
 	_, m, k, c := geom.TorusSectionCoeffs(t, plane)
 	if stdmath.Abs(c) <= cylinderAxisTol || stdmath.Abs(c) >= 1-cylinderAxisTol || m <= cylinderAxisTol {
 		return false
 	}
-	return len(wUnitCrossings(t, m, k, c)) == 0 && stdmath.Abs(torusW(t, m, k, c, 0)) < 1
+	// The section exists over (nearly) all of the tube — two full ovals, or the near-full-wrap figure-eight.
+	// A plane that clears the tube has the section absent everywhere (a 2π absent arc), so it fails this too.
+	return torusSectionAbsentArc(t, m, k, c) <= figureEightWrapTol
 }
 
 // torusObliqueOvalHalfSpace keeps the cap or the genus-1 complement of the single oval a tilted plane bites

--- a/kernel/brep/curved_halfspace_torus_oblique_general_test.go
+++ b/kernel/brep/curved_halfspace_torus_oblique_general_test.go
@@ -104,11 +104,16 @@ func TestTorusTwoObliqueOvalGuards(t *testing.T) {
 		want   bool
 	}{
 		{"tilted through hole (two ovals)", math.P3(0, 0, 0.5), true},
+		{"tilted figure-eight (z=1.0, near-full-wrap)", math.P3(0, 0, 1.0), true},
 		{"tilted single-oval bite (z=3.6)", math.P3(0, 0, 3.6), false},
 	} {
 		plane, _ := geom.NewPlane(tc.origin, math.V3(0, 0, 1))
 		if got := torusTwoObliqueOval(torS, plane); got != tc.want {
 			t.Errorf("%s: torusTwoObliqueOval = %v, want %v", tc.name, got, tc.want)
+		}
+		// The figure-eight and two-oval cases must NOT also be claimed by the single-oval (cap/complement) path.
+		if got := torusObliqueOval(torS, plane); got == tc.want && tc.want {
+			t.Errorf("%s: torusObliqueOval also claimed it (overlap with the band path)", tc.name)
 		}
 	}
 	// An upright (axis-aligned) torus cut is never the oblique two-oval case.

--- a/kernel/ops/boolean_csg_demotion_test.go
+++ b/kernel/ops/boolean_csg_demotion_test.go
@@ -148,6 +148,9 @@ func curvedExactCases() []curvedExactCase {
 		{"torus − box (figure-eight pinch)", ops.Cut, torusFigureEightBox},
 		{"torus ∩ box (two oblique ovals)", ops.Intersect, torusTwoObliqueOvalBox},
 		{"torus − box (two oblique ovals)", ops.Cut, torusTwoObliqueOvalBox},
+		{"torus ∩ box (oblique figure-eight)", ops.Intersect, torusObliqueFigureEightBox},
+		{"torus − box (oblique figure-eight)", ops.Cut, torusObliqueFigureEightBox},
+		{"torus − box (axis-∥ near-pinch large oval)", ops.Cut, torusNearPinchOvalBox},
 	}
 }
 
@@ -205,6 +208,23 @@ func torusFigureEightBox(t *testing.T) (*topo.Body, *topo.Body) {
 // the section's C≠0 term; the general band builder/mesher serve it directly (Oblikovati#1375).
 func torusTwoObliqueOvalBox(t *testing.T) (*topo.Body, *topo.Body) {
 	return demoTorus(t, math.P3(0, 0, 0), math.V3(0, 0.6, 0.8), 5, 2), demoBlock(t, math.P3(-20, -20, 0.5), math.P3(20, 20, 20))
+}
+
+// torusObliqueFigureEightBox cuts a TILTED torus (axis (0,0.6,0.8)) by z=1.0 — the offset where the tilted
+// section is EXACTLY at the single/two-oval transition: a single oval that wraps the whole tube but for a
+// measure-zero sliver (the oblique FIGURE-EIGHT). Its genus-1 complement is a thin strip the chart can't
+// mesh, so it routes to the v-wrapping band loft (which meshes the sliver as the band's pinch) like the
+// axis-parallel figure-eight (Oblikovati#1375).
+func torusObliqueFigureEightBox(t *testing.T) (*topo.Body, *topo.Body) {
+	return demoTorus(t, math.P3(0, 0, 0), math.V3(0, 0.6, 0.8), 5, 2), demoBlock(t, math.P3(-20, -20, 1), math.P3(20, 20, 20))
+}
+
+// torusNearPinchOvalBox cuts by y=3.01 — axis-parallel, JUST outside the inner equator (offset barely above
+// R−r=3): a single oval that wraps almost the whole tube, so its genus-1 complement is large and nearly
+// fills the chart. It exercises the complement chart's window reaching the chart seam (Oblikovati#1375); the
+// − keeps that near-full complement.
+func torusNearPinchOvalBox(t *testing.T) (*topo.Body, *topo.Body) {
+	return demoTorus(t, math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2), demoBlock(t, math.P3(-20, 3.01, -20), math.P3(20, 20, 20))
 }
 
 func demoTorus(t *testing.T, center math.Point3, axis math.Vector3, major, minor float64) *topo.Body {

--- a/kernel/ops/testdata/occ_boolean_oracle.json
+++ b/kernel/ops/testdata/occ_boolean_oracle.json
@@ -43,5 +43,8 @@
   "torus ∩ box (figure-eight pinch)": 114.8863256,
   "torus − box (figure-eight pinch)": 279.8978536,
   "torus ∩ box (two oblique ovals)": 175.3359946,
-  "torus − box (two oblique ovals)": 219.4483228
+  "torus − box (two oblique ovals)": 219.4483228,
+  "torus ∩ box (oblique figure-eight)": 151.898735,
+  "torus − box (oblique figure-eight)": 242.8854496,
+  "torus − box (axis-∥ near-pinch large oval)": 280.2555295
 }

--- a/kernel/ops/torus_complement_mesh.go
+++ b/kernel/ops/torus_complement_mesh.go
@@ -50,13 +50,16 @@ func centroidUV(loop []math.Point2) (uc, vc float64) {
 }
 
 // ovalWindow returns the grid-index rectangle [i0,i1]×[j0,j1] that brackets the oval's (u,v) bounding box
-// with a one-cell margin, clamped to stay strictly interior to the chart (so the window is meshed by the
-// local patch and never touches the chart seam).
+// with a one-cell margin. It must always CONTAIN the oval: a near-full-wrap oval (one whose section barely
+// clears the seam, at the single/two-oval transition) extends to the chart edges, so the window is allowed
+// to reach them — otherwise the clamp would push the window inside the oval, the seam grid cells would tile
+// over the oval region, and the complement would double-count (Oblikovati/Oblikovati#1375). The local patch
+// then meshes the whole window (up to the full chart minus the oval), which stays well-conditioned.
 func ovalWindow(us, vs []float64, ovalUV []math.Point2) (i0, i1, j0, j1 int) {
 	uMin, uMax, vMin, vMax := loopUVBounds(ovalUV)
-	i0 = clampIndex(lastBelow(us, uMin)-1, 1, len(us)-2)
+	i0 = clampIndex(lastBelow(us, uMin)-1, 0, len(us)-2)
 	i1 = clampIndex(firstAbove(us, uMax)+1, i0+1, len(us)-1)
-	j0 = clampIndex(lastBelow(vs, vMin)-1, 1, len(vs)-2)
+	j0 = clampIndex(lastBelow(vs, vMin)-1, 0, len(vs)-2)
 	j1 = clampIndex(firstAbove(vs, vMax)+1, j0+1, len(vs)-1)
 	return i0, i1, j0, j1
 }

--- a/kernel/ops/torus_complement_mesh_test.go
+++ b/kernel/ops/torus_complement_mesh_test.go
@@ -39,7 +39,12 @@ func TestComplementCentroidAndWindow(t *testing.T) {
 	us := []float64{0, 1, 2, 3, 4, 5, 6}
 	vs := []float64{0, 1, 2, 3, 4, 5, 6}
 	i0, i1, j0, j1 := ovalWindow(us, vs, loop) // oval u∈[1,3], v∈[2,4]
-	if i0 < 1 || i1 > len(us)-1 || i0 >= i1 || j0 < 1 || j1 > len(vs)-1 || j0 >= j1 {
-		t.Errorf("ovalWindow = [%d,%d]x[%d,%d], want a non-empty interior bracket", i0, i1, j0, j1)
+	// The window must contain the oval (so the grid never tiles over it) and be a non-empty bracket; it may
+	// reach the chart edge (0 / len-1) for a near-full-wrap oval, but here it brackets the interior oval.
+	if i0 < 0 || i1 > len(us)-1 || i0 >= i1 || j0 < 0 || j1 > len(vs)-1 || j0 >= j1 {
+		t.Errorf("ovalWindow = [%d,%d]x[%d,%d], want a non-empty bracket within the chart", i0, i1, j0, j1)
+	}
+	if us[i0] > 1 || us[i1] < 3 || vs[j0] > 2 || vs[j1] < 4 {
+		t.Errorf("ovalWindow [%d,%d]x[%d,%d] does not contain the oval bbox u∈[1,3] v∈[2,4]", i0, i1, j0, j1)
 	}
 }


### PR DESCRIPTION
## What

Fixes two latent tearing cases in the torus single-oval **complement** mesh, discovered while stress-testing the torus half-space cut near its degenerate transitions. Both are now meshed **exactly** rather than torn or deferred — taking the user's direction to make the mesher robust (learning from OCCT, whose BRepMesh handles these because it never relies on a single global metric scale).

The complement chart tore when the oval wraps **nearly the whole tube** (section valid over all but a sliver) — the genus-1 complement is then a thin strip and the oval fills the chart. Two distinct failures:

### 1. Window/grid overlap (the volume came out *larger than the whole torus*)
`ovalWindow` clamped the window strictly interior to the chart, so a large oval pushed the window inside itself; the seam grid cells then tiled over the oval region and the complement **double-counted**. Fix: let the window reach the chart edge when the oval needs it — the local patch then meshes up to the full-chart-minus-oval, which stays well-conditioned. This makes **axis-parallel near-pinch** cuts (offset just above `R−r`) exact.

### 2. Oblique figure-eight (the exact single/two-oval transition)
At the exact transition a tilted cut's oval wraps the whole tube but for a measure-zero sliver; the complement is a thin strip the chart can't mesh. The axis-parallel figure-eight already routes to the two-oval **band loft** (which meshes the sliver as the band's zero-width pinch). This extends the same routing to the oblique case: `torusObliqueOval` yields a near-full-wrap oval (its two pinches within `figureEightWrapTol`) to `torusTwoObliqueOval`'s band path.

## How I found it

Mapped the failure precisely: `∩+−` consistency around the transition showed h=0.99 (band) ✓, h=1.01 (single-oval+window-fix) ✓ — **only the exact transition h=1.0 tore**. The cap (`metricPatchMesh` on the contractible disk) always works; only the complement chart was fragile. The `disk>half` case I'd guarded against turns out not to occur (a single-oval bite is always the smaller side), so that guard is replaced by the near-full-wrap routing.

## Validation

Against OpenCASCADE `getMass`: oblique figure-eight `∩` 151.90 / `−` 242.89, axis-parallel near-pinch large oval `−` 280.26; all sum-consistent to `40π²`. Both take the exact analytic path. Lint clean (golangci-lint v2.1.0); coverage 100% on the changed detectors.

With this, the torus half-space cut meshes **every single-plane section topology exactly** — perpendicular, and axis-parallel and oblique single-oval (cap and complement), two-oval, and figure-eight — with CSG only as a defensive fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)