### PR TITLE
feat(model): combine keeps analytic primitives via the curved boolean (#129)

### DIFF
--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -141,6 +141,15 @@ func curvedExactBoolean(op PartFeatureOperation, target, tool *topo.Body) (*topo
 	return nil, false
 }
 
+// CurvedBoolean attempts the exact analytic curved boolean and reports whether it applied. It is SAFE to
+// call on any operands — each path declines (ok=false) when it does not handle (op, target, tool), and none
+// hangs (unlike the planar B-rep boolean, which loops on a full periodic curved face). The model layer uses
+// it to combine a still-analytic primitive (a revolved torus, an extruded cylinder) by its curved faces
+// before falling back to faceting the operands for the planar path (#129).
+func CurvedBoolean(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+	return curvedExactBoolean(op, target, tool)
+}
+
 // curvedExactPaths is the ordered list of exact analytic curved-boolean paths curvedExactBoolean tries; each
 // returns ok=false when it does not apply to (op, target, tool).
 var curvedExactPaths = []func(PartFeatureOperation, *topo.Body, *topo.Body) (*topo.Body, bool){

--- a/model/feature/extrude.go
+++ b/model/feature/extrude.go
@@ -171,20 +171,37 @@ func combine(running []*topo.Body, body *topo.Body, op ops.PartFeatureOperation)
 	if len(running) == 0 || op == ops.NewBody {
 		return append(append([]*topo.Body(nil), running...), body), nil
 	}
-	// The planar B-rep boolean cannot consume a curved face (it hangs on one), so re-facet any
-	// analytic cylinder/cone into a planar B-rep before combining (#129). A standalone cylinder that
-	// is never combined keeps its analytic face for thread/chamfer/fillet.
-	target := planarized(running[len(running)-1], "combine-target")
+	target := running[len(running)-1]
+	// First try the EXACT curved boolean on the still-analytic operands when the target is a BARE analytic
+	// primitive (exactly one curved face — a revolved torus, an extruded cylinder/cone, a sphere) and the
+	// tool is all-planar (a prism): those keep their curved faces through the M2 curved boolean
+	// (#1334/#1335). The single-curved-face gate is deliberately tight — a composite curved body (a washer's
+	// two cylinder walls, a filleted edge) is NOT a primitive the half-space cut handles, so it stays on the
+	// faceted planar path; CurvedBoolean can over-match such a body and cut it wrongly.
+	if curvedFaceCount(target) == 1 && curvedFaceCount(body) == 0 {
+		if res, ok := ops.CurvedBoolean(op, target, body); ok {
+			return appendCombined(running, res), nil
+		}
+	}
+	// Otherwise re-facet any analytic curved face into a planar B-rep before the planar boolean — it hangs
+	// on a full periodic curved face it cannot consume (#129). A standalone primitive that is never
+	// combined keeps its analytic face for thread/chamfer/fillet.
+	target = planarized(target, "combine-target")
 	body = planarized(body, "combine-tool")
 	res, err := ops.Boolean(op, target, body)
 	if err != nil {
 		return nil, err
 	}
+	return appendCombined(running, res), nil
+}
+
+// appendCombined replaces the running target with the boolean result, dropping an empty result.
+func appendCombined(running []*topo.Body, res *topo.Body) []*topo.Body {
 	out := append([]*topo.Body(nil), running[:len(running)-1]...)
 	if res != nil && len(res.Faces()) > 0 {
 		out = append(out, res)
 	}
-	return out, nil
+	return out
 }
 
 // buildPrism extrudes a closed polygon over the span (near→far offsets along the plane

--- a/model/feature/planarize.go
+++ b/model/feature/planarize.go
@@ -27,6 +27,19 @@ func hasCurvedFace(b *topo.Body) bool {
 	return false
 }
 
+// curvedFaceCount counts a body's non-planar faces. A BARE analytic primitive (cylinder/cone/sphere/torus
+// solid) has exactly one — its single curved wall; a composite (a washer's two cylinders, a filleted edge)
+// has more, which the curved boolean does not cut as a primitive.
+func curvedFaceCount(b *topo.Body) int {
+	n := 0
+	for _, f := range b.Faces() {
+		if _, planar := f.Geometry().(geom.Plane); !planar {
+			n++
+		}
+	}
+	return n
+}
+
 // planarized converts a body with analytic curved faces into a planar B-rep the exact boolean can
 // consume (it hangs on a full periodic curved face, #129). A SIMPLE extrude-circle cylinder becomes
 // a clean, key-stable N-gon prism (the fast path that keeps downstream edge identity); any OTHER

--- a/model/feature/revolve_analytic_test.go
+++ b/model/feature/revolve_analytic_test.go
@@ -255,3 +255,35 @@ func TestNativeObliqueRevolveTorusCutsAreExact(t *testing.T) {
 		}
 	}
 }
+
+// TestRevolvedTorusExtrudeCutStaysAnalytic proves the combine fix: cutting a revolved (analytic) torus with
+// an extruded box keeps the analytic torus surface — the feature boolean uses the M2 curved path rather than
+// faceting the torus first. Complements TestAnalyticRevolveTubeBooleanCutsHalf, where a COMPOSITE washer
+// (two cylinder walls) correctly stays on the faceted planar path.
+func TestRevolvedTorusExtrudeCutStaysAnalytic(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	sk.Circles().AddByCenterRadius(math.P2(5, 0), 2)
+	cl := sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(0, 1))
+	cl.SetCenterline(true)
+	NewRevolveFeatures(fs).AddAboutCenterline(sk, 0, nil, ops.NewBody)
+
+	// keep x>=6 (an axis-parallel single-oval cap) via a box on the x=6 plane intersected with the torus
+	pl, err := sketch.NewPlane(math.P3(6, 0, 0), math.V3(0, 1, 0).AsUnit(), math.V3(0, 0, 1).AsUnit())
+	if err != nil {
+		t.Fatal(err)
+	}
+	clip := sketch.NewSketches().Add(pl)
+	clip.AddRectangleByCorners(math.P2(-20, -20), math.P2(20, 20))
+	NewExtrudeFeatures(fs).AddByDistanceExtent(clip, 0, ops.Intersect, func() float64 { return 14 })
+	fs.Recompute()
+
+	body := fs.Result()[0]
+	if torusFaceCount(body) != 1 {
+		t.Fatalf("torus extrude-cut has %d torus faces, want 1 (analytic kept, not planarized) — %d total faces",
+			torusFaceCount(body), len(body.Faces()))
+	}
+	if n := len(body.Faces()); n > 40 {
+		t.Errorf("torus extrude-cut has %d faces — fell to faceted CSG", n)
+	}
+}


### PR DESCRIPTION
## What

The extrude **combine** planarized (faceted) both operands before the boolean — a workaround from before the curved boolean existed (the planar B-rep boolean hangs on a full periodic curved face). So cutting a natively-revolved torus (or an extruded cylinder) with a box produced a **faceted CSG soup**: the M2 curved boolean never ran on a feature-modelled primitive.

## How it was found

Regenerating the M2 demo as a true native recipe (sketch circle → revolve → extrude-cut) — the third gap the native stress test surfaced. The revolved torus is analytic (#1396), but the combine faceted it (61 faces) before the cut.

## How

`combine` now tries the exact curved boolean **first** when the target is a **bare** analytic primitive (exactly one curved face) and the tool is all-planar — the torus/cylinder/cone/sphere keeps its analytic surface through the M2 half-space cut.

The single-curved-face gate is deliberately tight: a **composite** curved body (a washer's two cylinder walls, a filleted edge) is *not* a primitive the half-space cut handles, and `CurvedBoolean` can over-match such a body and cut it wrongly (I hit exactly this — a washer cut came out 12.49 vs 37.70). Those stay on the faceted planar path, so `TestAnalyticRevolveTubeBooleanCutsHalf` still cuts the washer correctly.

- `ops.CurvedBoolean` exposes the exact curved boolean — safe to call (it declines rather than hanging, unlike the planar B-rep path).

## Validation

- A revolved torus cut by an extruded box now keeps its one `geom.Torus` face and the exact analytic result (cap **10.30, 2 faces**), not 61 facets (`TestRevolvedTorusExtrudeCutStaysAnalytic`).
- The washer composite still planarizes correctly (no regression).
- Full `model/feature` + `kernel/ops` + `kernel/brep` suites green; lint clean.

This makes the whole M2 torus half-space family reachable **analytically through native modelling** — sketch → revolve → extrude-cut — closing the loop the revolve fix (#1396) opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)