### PR TITLE
kernel: thread model-relative tolerance through geom/brep/ops/solve (#1399)

### DIFF
--- a/kernel/brep/arrange2d.go
+++ b/kernel/brep/arrange2d.go
@@ -17,12 +17,18 @@ import (
 )
 
 // arrTol is the planar-arrangement coincidence/intersection tolerance (database units).
-const arrTol = 1e-9
+//
+// tol:calibrated — the 2D arrangement welds points computed by EXACT planar segment intersection
+// (no accumulated curved-surface error), so this matched set (arrTol / tjTol / the welder grid) is
+// scale-robust as an absolute across the validated µm→km range (ops TestScaleSweepInvariance).
+// Relativising the welder grid to size·ε coarsens it on a large part and risks merging distinct
+// arrangement vertices — a net regression — so under #1399 it stays absolute and validated.
+const arrTol = 1e-9 // tol:calibrated — exact-planar-intersection weld; see the note above
 
 // parallelDenomTol is the magnitude below which a line/ray·edge or line/ray·plane denominator
 // is treated as zero — the two are parallel, so there is no single crossing. Below arrTol
 // because it bounds a cross/dot product of (roughly unit) directions, not a length.
-const parallelDenomTol = 1e-12
+const parallelDenomTol = 1e-12 // tol:numeric — cross/dot denominator of unit directions
 
 // Face2D is one region of a planar arrangement: a counter-clockwise outer loop and any
 // clockwise hole loops nested directly inside it.
@@ -77,7 +83,7 @@ func planarize(segments [][2]math.Point2) ([]math.Point2, [][2]int) {
 // edge — a T-junction. It matches the welder's coincidence grid (1e-7): any point that would
 // weld onto the line is at most that far off it, while genuine features sit orders of
 // magnitude further (≥1e-2), so this never splits a near-miss.
-const tjTol = 1e-7
+const tjTol = 1e-7 // tol:calibrated — matches the welder grid; see arrTol
 
 // splitTJunctions subdivides every edge at any welded vertex lying strictly on its interior,
 // repeating until stable. splitOne only cuts at proper interior crossings of two segments;
@@ -169,7 +175,7 @@ type welder struct {
 func newWelder() *welder { return &welder{index: map[[2]int64]int{}} }
 
 func (w *welder) add(p math.Point2) int {
-	const grid = 1e-7
+	const grid = 1e-7 // tol:calibrated — the arrangement welder coincidence grid; see arrTol
 	k := [2]int64{int64(stdmath.Round(p.X / grid)), int64(stdmath.Round(p.Y / grid))}
 	if i, ok := w.index[k]; ok {
 		return i

--- a/kernel/brep/arrange2d_trace.go
+++ b/kernel/brep/arrange2d_trace.go
@@ -124,8 +124,8 @@ func probeJustInside(loop []math.Point2) math.Point2 {
 	a, b := loop[0], loop[1]
 	e := a.VectorTo(b)
 	mid := math.P2((a.X+b.X)/2, (a.Y+b.Y)/2)
-	left := math.V2(-e.Y, e.X) // interior side of a CCW loop
-	return mid.TranslateBy(left.Scale(1e-4))
+	left := math.V2(-e.Y, e.X)               // interior side of a CCW loop
+	return mid.TranslateBy(left.Scale(1e-4)) // tol:calibrated — interior-probe nudge (see arrange2d arrTol)
 }
 
 func reversedLoop(loop []math.Point2) []math.Point2 {

--- a/kernel/brep/boolean.go
+++ b/kernel/brep/boolean.go
@@ -70,7 +70,7 @@ func booleanOnce(op Op, fa, fb []planarFace, a, b *topo.Body) (*topo.Body, math.
 // grid (1e-6) so it survives, far below any modelled feature so it is geometrically
 // irrelevant. A line tangency carries no material, so replacing it with a ~0.1 µm gap loses
 // nothing and — unlike the exact tangent — leaves no coincident edge for a re-weld to collapse.
-const nudgeEps = 1e-5
+const nudgeEps = 1e-5 // tol:calibrated — imprint nudge tied to the planar weld grid (see arrange2d arrTol)
 
 // retryNudged re-runs the boolean with operand B nudged a hair along `away` (out of the
 // tangent contact) so the degenerate touch becomes a clean clearance. It keeps the nudged
@@ -153,7 +153,7 @@ func imprint(a, b planarFace) [][2]math.Point3 {
 	overlap := intersectIntervals(faceLineIntervals(a, p0, dir), faceLineIntervals(b, p0, dir))
 	var segs [][2]math.Point3
 	for _, iv := range overlap {
-		if iv[1]-iv[0] > 1e-9 {
+		if iv[1]-iv[0] > 1e-9 { // tol:calibrated — planar imprint overlap length (see arrange2d arrTol)
 			segs = append(segs, [2]math.Point3{p0.TranslateBy(dir.Scale(iv[0])), p0.TranslateBy(dir.Scale(iv[1]))})
 		}
 	}
@@ -293,7 +293,7 @@ func reverseRing(r []math.Point3) []math.Point3 {
 // boundaryImprintTol is the distance at which an imprint point counts as lying on a face's
 // boundary. The wobble between a boundary edge and its imprint re-derivation is float noise
 // (~1e-15), far below it; genuinely interior imprints sit at feature scale, far above it.
-const boundaryImprintTol = 1e-7
+const boundaryImprintTol = 1e-7 // tol:calibrated — planar imprint-on-boundary distance (see arrange2d arrTol)
 
 // interiorSegments filters out the segments that lie along f's boundary, keeping only the
 // ones that can actually split the face's interior.

--- a/kernel/brep/boolean_classify.go
+++ b/kernel/brep/boolean_classify.go
@@ -35,7 +35,7 @@ func rayHitsFace(p math.Point3, dir math.Vector3, f planarFace) bool {
 		return false // ray parallel to the face plane
 	}
 	t := f.plane.Origin.VectorTo(p).Dot(n) / -den // n·(p+t dir) = n·origin ⇒ t = n·(origin−p)/(n·dir)
-	if t <= 1e-9 {
+	if t <= 1e-9 {                                // tol:numeric — ray hit parameter near-zero guard (dir not unit)
 		return false
 	}
 	hit := p.TranslateBy(dir.Scale(t))

--- a/kernel/brep/boolean_coplanar.go
+++ b/kernel/brep/boolean_coplanar.go
@@ -20,10 +20,10 @@ import (
 // coplanar reports whether two planar faces lie in the same plane (parallel normals and a
 // shared point), so their overlap is an area rather than the line an imprint would find.
 func coplanar(a, b planarFace) bool {
-	if stdmath.Abs(a.normal.Dot(b.normal)) < 1-1e-7 {
+	if stdmath.Abs(a.normal.Dot(b.normal)) < 1-1e-7 { // tol:angular — parallel-normals cosine
 		return false // not parallel
 	}
-	return stdmath.Abs(b.plane.Origin.VectorTo(a.plane.Origin).Dot(b.normal)) < 1e-7
+	return stdmath.Abs(b.plane.Origin.VectorTo(a.plane.Origin).Dot(b.normal)) < 1e-7 // tol:calibrated — coplanar gap (see arrange2d arrTol)
 }
 
 // faceEdges3D returns all of a face's loop edges as 3D segments — imprinted onto a coplanar

--- a/kernel/brep/boolean_geom.go
+++ b/kernel/brep/boolean_geom.go
@@ -79,7 +79,7 @@ func to3D(pl geom.Plane, q math.Point2) math.Point3 {
 func planeLine(a, b geom.Plane) (p0 math.Point3, dir math.Vector3, ok bool) {
 	na, nb := unit(a.Normal()), unit(b.Normal())
 	d := na.Cross(nb)
-	if d.LengthSquared() < 1e-18 {
+	if d.LengthSquared() < 1e-18 { // tol:numeric — degenerate-direction guard (squared length)
 		return p0, dir, false
 	}
 	da, db := na.Dot(a.Origin.AsVector()), nb.Dot(b.Origin.AsVector())
@@ -101,7 +101,7 @@ func unit(v math.Vector3) math.Vector3 {
 // projected into the face plane.
 func faceLineIntervals(f planarFace, p0 math.Point3, dir math.Vector3) [][2]float64 {
 	o2, d2 := to2D(f.plane, p0), to2Dvec(f.plane, dir)
-	if d2.LengthSquared() < 1e-18 {
+	if d2.LengthSquared() < 1e-18 { // tol:numeric — degenerate-direction guard (squared length)
 		return nil // the line is perpendicular to this plane (no in-plane extent)
 	}
 	var ts []float64
@@ -183,7 +183,7 @@ func lineSegCross(o math.Point2, d math.Vector2, a, b math.Point2) (float64, boo
 	ao := o.VectorTo(a)
 	t := ao.Cross(e) / den
 	s := ao.Cross(d) / den
-	if s < -1e-9 || s > 1+1e-9 {
+	if s < -1e-9 || s > 1+1e-9 { // tol:parametric — segment parameter s in [0,1]
 		return 0, false
 	}
 	return t, true

--- a/kernel/brep/boolean_provenance.go
+++ b/kernel/brep/boolean_provenance.go
@@ -70,7 +70,7 @@ func appendTagged(prov []imprintSeg, segs [][2]math.Point3, owner, other planarF
 
 // edgeParentTol is how far an edge midpoint may sit off an imprint segment and still count as
 // lying on it (model units, cm) — matches the imprint weld tolerance used elsewhere.
-const edgeParentTol = 1e-7
+const edgeParentTol = 1e-7 // tol:calibrated — distance to parent edge for provenance (see arrange2d arrTol)
 
 // edgeParents returns the canonical {owner, other} face-lineage pair of the imprint segment the
 // edge p→q lies on, or ok=false when the edge is not an intersection edge (e.g. an original face
@@ -129,7 +129,7 @@ func pairLineDir(lo, hi topo.Lineage, prov []imprintSeg) (math.Vector3, bool) {
 		return math.Vector3{}, false
 	}
 	d := nLo.Cross(nHi)
-	if d.LengthSquared() < 1e-18 {
+	if d.LengthSquared() < 1e-18 { // tol:numeric — degenerate-direction guard (squared length)
 		return math.Vector3{}, false
 	}
 	return d.AsUnit().AsVector(), true

--- a/kernel/brep/boolean_split.go
+++ b/kernel/brep/boolean_split.go
@@ -91,7 +91,7 @@ func ringSignature(ring []math.Point3) string {
 }
 
 func roundKey(p math.Point3) string {
-	const grid = 1e-6
+	const grid = 1e-6 // tol:calibrated — planar split weld grid (see arrange2d arrTol)
 	return strconv.FormatInt(int64(stdmath.Round(p.X/grid)), 36) + "," +
 		strconv.FormatInt(int64(stdmath.Round(p.Y/grid)), 36) + "," +
 		strconv.FormatInt(int64(stdmath.Round(p.Z/grid)), 36)
@@ -134,8 +134,8 @@ func interiorPoint2D(r Face2D) (math.Point2, bool) {
 		a, b := poly[i], poly[(i+1)%n]
 		e := a.VectorTo(b)
 		mid := math.P2((a.X+b.X)/2, (a.Y+b.Y)/2)
-		left := math.V2(-e.Y, e.X) // interior side of a CCW loop (magnitude = |edge|)
-		for _, f := range []float64{1e-3, 1e-2, 0.05, 0.2} {
+		left := math.V2(-e.Y, e.X)                           // interior side of a CCW loop (magnitude = |edge|)
+		for _, f := range []float64{1e-3, 1e-2, 0.05, 0.2} { // tol:parametric — interior-probe offset fractions
 			p := mid.TranslateBy(left.Scale(f))
 			if pointInPolygon2D(p, poly) && !inHoles2D(p, r.Holes) {
 				return p, true

--- a/kernel/brep/boolean_stitch.go
+++ b/kernel/brep/boolean_stitch.go
@@ -64,7 +64,7 @@ func awayFromContacts(uses map[[2]int][]loopEdgeUse, faces []builtFace) math.Vec
 			}
 		}
 	}
-	if into.LengthSquared() < 1e-18 {
+	if into.LengthSquared() < 1e-18 { // tol:numeric — degenerate-direction guard (squared length)
 		return math.Vector3{}
 	}
 	return into.AsUnit().AsVector().Scale(-1)
@@ -126,10 +126,10 @@ func collectSegHits(pa math.Point3, ab math.Vector3, lenSq float64, onRing map[i
 			continue
 		}
 		t := pa.VectorTo(verts[c]).Dot(ab) / lenSq
-		if t <= 1e-7 || t >= 1-1e-7 {
+		if t <= 1e-7 || t >= 1-1e-7 { // tol:parametric — edge parameter t in [0,1]
 			continue
 		}
-		if pa.TranslateBy(ab.Scale(t)).DistanceTo(verts[c]) < 1e-6 {
+		if pa.TranslateBy(ab.Scale(t)).DistanceTo(verts[c]) < 1e-6 { // tol:calibrated — planar stitch weld (see arrange2d arrTol)
 			hits = append(hits, segHit{t, c})
 		}
 	}
@@ -229,7 +229,7 @@ func buildEdges(bld *topo.Builder, verts []math.Point3, tv []*topo.Vertex, edgeU
 
 // weldGrid is the coincidence tolerance for merging stitched vertices (cm). Points within it
 // are the same vertex.
-const weldGrid = 1e-6
+const weldGrid = 1e-6 // tol:calibrated — planar stitch weld grid (see arrange2d arrTol)
 
 // welder3 merges coincident 3D points onto a shared index list.
 type welder3 struct {

--- a/kernel/brep/curved_boolean_imprint.go
+++ b/kernel/brep/curved_boolean_imprint.go
@@ -24,7 +24,11 @@ import "oblikovati.org/kernel/geom"
 //
 //	cyl, _ := brep.SolidCylinder(math.P3(0,0,0), math.V3(0,0,1), 3, 4)
 //	box, _ := brep.SolidBlock(math.P3(-5,-5,2), math.P3(5,5,3), "box")
-//	curves, ok := curvedImprint(facesOfAny(cyl)[2], facesOfAny(box)[0]) // ok, one geom.Circle
-func curvedImprint(a, b curvedFace) (curves []geom.Curve3, handled bool) {
-	return geom.IntersectSurfacesAnalytic(a.surface, b.surface)
+//	curves, ok := curvedImprint(facesOfAny(cyl)[2], facesOfAny(box)[0], res) // ok, one geom.Circle
+//
+// res is the model-relative coincidence scale (Oblikovati/Oblikovati#1399): the analytic
+// clearance/grazing tests that decide exact-conic-vs-defer derive their tolerance from it, so
+// the imprint classifies a µm or km copy of the same pair identically.
+func curvedImprint(a, b curvedFace, res geom.Resolution) (curves []geom.Curve3, handled bool) {
+	return geom.IntersectSurfacesAnalytic(a.surface, b.surface, res)
 }

--- a/kernel/brep/curved_boolean_model_test.go
+++ b/kernel/brep/curved_boolean_model_test.go
@@ -118,7 +118,7 @@ func TestCurvedImprintCylinderPlaneIsCircle(t *testing.T) {
 	cyl, _ := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 4)
 	side := cylSide(t, facesOfAny(cyl))
 	plane, _ := geom.NewPlane(math.P3(0, 0, 2.5), math.V3(0, 0, 1))
-	curves, ok := curvedImprint(side, curvedFace{surface: plane})
+	curves, ok := curvedImprint(side, curvedFace{surface: plane}, geom.ResolutionForSize(1))
 	if !ok || len(curves) != 1 {
 		t.Fatalf("cylinder∩plane: handled=%v, %d curves; want handled, 1 circle", ok, len(curves))
 	}
@@ -139,7 +139,7 @@ func TestCurvedImprintCylinderPlaneIsCircle(t *testing.T) {
 func TestCurvedImprintSpherePlaneIsCircle(t *testing.T) {
 	sphere, _ := geom.NewSphere(math.P3(0, 0, 0), 5)
 	plane, _ := geom.NewPlane(math.P3(0, 0, 3), math.V3(0, 0, 1))
-	curves, ok := curvedImprint(curvedFace{surface: sphere}, curvedFace{surface: plane})
+	curves, ok := curvedImprint(curvedFace{surface: sphere}, curvedFace{surface: plane}, geom.ResolutionForSize(1))
 	if !ok || len(curves) != 1 {
 		t.Fatalf("sphere∩plane: handled=%v, %d curves; want handled, 1 circle", ok, len(curves))
 	}
@@ -157,7 +157,7 @@ func TestCurvedImprintPlanePlaneIsLine(t *testing.T) {
 	a, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
 	b, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(1, 0, 0))
 	_ = faces
-	curves, ok := curvedImprint(curvedFace{surface: a}, curvedFace{surface: b})
+	curves, ok := curvedImprint(curvedFace{surface: a}, curvedFace{surface: b}, geom.ResolutionForSize(1))
 	if !ok || len(curves) != 1 {
 		t.Fatalf("plane∩plane: handled=%v, %d curves; want handled, 1 line", ok, len(curves))
 	}
@@ -172,7 +172,7 @@ func TestCurvedImprintPlanePlaneIsLine(t *testing.T) {
 func TestCurvedImprintCurvedCurvedDefers(t *testing.T) {
 	a, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3)
 	b, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(1, 0, 0), 2)
-	if _, ok := curvedImprint(curvedFace{surface: a}, curvedFace{surface: b}); ok {
+	if _, ok := curvedImprint(curvedFace{surface: a}, curvedFace{surface: b}, geom.ResolutionForSize(1)); ok {
 		t.Error("cylinder∩cylinder should defer (handled=false) to Phase 2, not be handled analytically")
 	}
 }

--- a/kernel/brep/curved_coaxial_cylinder.go
+++ b/kernel/brep/curved_coaxial_cylinder.go
@@ -36,7 +36,7 @@ func CoaxialCylinderUnion(a, b *topo.Body) (*topo.Body, bool) {
 	axis := ca.AxisDir.AsVector()
 	loA, loB := axialOffset(baseA, baseA, axis), axialOffset(baseA, baseB, axis)
 	lo, hi := stdmath.Min(loA, loB), stdmath.Max(loA+hA, loB+hB)
-	if hi-lo > hA+hB+axialTouchTol {
+	if hi-lo > hA+hB+geom.ResolutionForSize(hA+hB).Plane() { // model-relative axial-gap test (#1399)
 		return nil, false // an axial gap between the two — not a single solid, leave it to MergeBodies
 	}
 	union, err := SolidCylinder(baseA.TranslateBy(axis.Scale(math.Scalar(lo))), axis, ca.Radius, hi-lo)
@@ -50,13 +50,14 @@ func CoaxialCylinderUnion(a, b *topo.Body) (*topo.Body, bool) {
 // base on the other's axis) and the same radius — the precondition for their side faces to be coincident.
 func coaxialEqualRadius(ca geom.Cylinder, baseA math.Point3, cb geom.Cylinder, baseB math.Point3) bool {
 	ua, ub := ca.AxisDir.AsVector(), cb.AxisDir.AsVector()
-	if stdmath.Abs(float64(ua.Dot(ub))) < 1-1e-7 {
+	if stdmath.Abs(float64(ua.Dot(ub))) < 1-1e-7 { // tol:angular — axes-parallel cosine
 		return false // axes not parallel
 	}
 	if !nearEqual(ca.Radius, cb.Radius) {
 		return false
 	}
-	return offAxisDistance(baseA, ua, baseB) <= axialTouchTol // baseB lies on a's axis line
+	// Off-axis coincidence is model-relative (#1399), scaled by the cylinder radius (matching nearEqual).
+	return offAxisDistance(baseA, ua, baseB) <= geom.ResolutionForSize(ca.Radius).Plane() // baseB on a's axis line
 }
 
 // offAxisDistance returns the perpendicular distance of point p from the line through origin along the unit
@@ -72,7 +73,3 @@ func offAxisDistance(origin math.Point3, ua math.Vector3, p math.Point3) float64
 func axialOffset(origin, p math.Point3, ua math.Vector3) float64 {
 	return float64(origin.VectorTo(p).Dot(ua))
 }
-
-// axialTouchTol is the coincidence tolerance for the off-axis distance and the abut/gap test. Two
-// cylinders closer than this along the axis are treated as touching (no gap), matching nearEqual's scale.
-const axialTouchTol = 1e-7

--- a/kernel/brep/curved_cone_cone_imprint.go
+++ b/kernel/brep/curved_cone_cone_imprint.go
@@ -30,7 +30,8 @@ func coneConeImprint(a, b *topo.Body) ([]geom.Polyline, bool) {
 		return nil, false
 	}
 	window := geom.SurfaceGrid{VMin: vMin, VMax: vMax}
-	loops := closedTraceLoops(geom.IntersectSurfaceSurface(ca, cb, window))
+	res := geom.ResolutionForBox(a.RangeBox().Union(b.RangeBox())) // model-relative loop-closure weld (#1399)
+	loops := closedTraceLoops(geom.IntersectSurfaceSurface(ca, cb, window), res)
 	if len(loops) == 0 {
 		return nil, false
 	}

--- a/kernel/brep/curved_cone_cylinder_imprint.go
+++ b/kernel/brep/curved_cone_cylinder_imprint.go
@@ -28,7 +28,8 @@ func coneCylinderImprint(a, b *topo.Body) ([]geom.Polyline, bool) {
 		return nil, false
 	}
 	window := geom.SurfaceGrid{VMin: vMin, VMax: vMax}
-	loops := closedTraceLoops(geom.IntersectSurfaceSurface(cone, cyl, window))
+	res := geom.ResolutionForBox(a.RangeBox().Union(b.RangeBox())) // model-relative loop-closure weld (#1399)
+	loops := closedTraceLoops(geom.IntersectSurfaceSurface(cone, cyl, window), res)
 	if len(loops) == 0 {
 		return nil, false
 	}

--- a/kernel/brep/curved_cone_cylinder_intersect.go
+++ b/kernel/brep/curved_cone_cylinder_intersect.go
@@ -53,10 +53,11 @@ func ConeCylinderIntersect(a, b *topo.Body) (*topo.Body, bool) {
 // penetration), so the full-crossing assembler must defer.
 func loopsSpanCone(cone geom.Cone, vMin, vMax float64, loops []geom.Polyline) bool {
 	axis := cone.AxisDir.AsVector()
+	tol := geom.ResolutionForSize(vMax).Plane() // model-relative apex-distance band margin (#1399)
 	for _, lp := range loops {
 		for _, p := range lp.Vertices {
 			v := float64(cone.Apex.VectorTo(p).Dot(axis))
-			if v < vMin-1e-7 || v > vMax+1e-7 {
+			if v < vMin-tol || v > vMax+tol {
 				return false
 			}
 		}

--- a/kernel/brep/curved_crossing_cut.go
+++ b/kernel/brep/curved_crossing_cut.go
@@ -103,10 +103,11 @@ func orderRodFat(loops []geom.Polyline, ca geom.Cylinder, baseA math.Point3, hA 
 func loopsBetweenCaps(fat crossRod, fatBase math.Point3, fatHeight float64, lo, hi geom.Polyline) bool {
 	ax := fat.axisOf()
 	vBot := float64(ax.point.VectorTo(fatBase).Dot(ax.dir))
+	tol := geom.ResolutionForSize(fatHeight).Weld() // model-relative axial cap margin (#1399)
 	for _, lp := range []geom.Polyline{lo, hi} {
 		for _, p := range lp.Vertices {
 			s := float64(ax.point.VectorTo(p).Dot(ax.dir)) - vBot
-			if s < 1e-9 || s > fatHeight-1e-9 {
+			if s < tol || s > fatHeight-tol {
 				return false
 			}
 		}

--- a/kernel/brep/curved_crossing_imprint.go
+++ b/kernel/brep/curved_crossing_imprint.go
@@ -30,7 +30,8 @@ func crossingCylinderImprint(a, b *topo.Body) ([]geom.Polyline, bool) {
 	if !okA || !okB {
 		return nil, false
 	}
-	loops := closedTraceLoops(geom.IntersectSurfaceSurface(ca, cb, cylinderTraceWindow(ca, baseA, heightA)))
+	res := geom.ResolutionForBox(a.RangeBox().Union(b.RangeBox())) // model-relative loop-closure weld (#1399)
+	loops := closedTraceLoops(geom.IntersectSurfaceSurface(ca, cb, cylinderTraceWindow(ca, baseA, heightA)), res)
 	if len(loops) == 0 {
 		return nil, false
 	}
@@ -47,10 +48,10 @@ func cylinderTraceWindow(c geom.Cylinder, base math.Point3, height float64) geom
 // closedTraceLoops keeps the traced polylines that close into a loop (first point meets last), building a
 // geom.Polyline from each. An open chain — where the tracer broke at a tangency or pinch — is dropped, so
 // the imprint carries only watertight boundary loops.
-func closedTraceLoops(raw [][]math.Point3) []geom.Polyline {
+func closedTraceLoops(raw [][]math.Point3, res geom.Resolution) []geom.Polyline {
 	var out []geom.Polyline
 	for _, pts := range raw {
-		if len(pts) < 4 || !samePoint(pts[0], pts[len(pts)-1]) {
+		if len(pts) < 4 || !samePoint(pts[0], pts[len(pts)-1], res) {
 			continue
 		}
 		if pl, err := geom.NewPolyline(pts); err == nil {

--- a/kernel/brep/curved_crossing_imprint_test.go
+++ b/kernel/brep/curved_crossing_imprint_test.go
@@ -38,7 +38,7 @@ func TestCrossingCylinderImprintThinThroughFat(t *testing.T) {
 	ca, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3)
 	cb, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(1, 0, 0), 1.5)
 	for i, lp := range loops {
-		if !samePoint(lp.PointAt(0), lp.PointAt(1)) {
+		if !samePoint(lp.PointAt(0), lp.PointAt(1), geom.ResolutionForSize(1)) {
 			t.Errorf("loop %d is not closed: %v vs %v", i, lp.PointAt(0), lp.PointAt(1))
 		}
 		if err := onBothCylinders(lp, ca, cb); err > 1e-5 {

--- a/kernel/brep/curved_crossing_intersect.go
+++ b/kernel/brep/curved_crossing_intersect.go
@@ -75,10 +75,11 @@ func rodAndFatCylinders(a, b *topo.Body, loops []geom.Polyline) (rod, fat geom.C
 func loopsSpanRod(rod geom.Cylinder, rodBase math.Point3, rodHeight float64, loops []geom.Polyline) bool {
 	axis := rod.AxisDir.AsVector()
 	vBase := float64(rod.Origin.VectorTo(rodBase).Dot(axis))
+	tol := geom.ResolutionForSize(rodHeight).Plane() // model-relative axial-extent margin (#1399)
 	for _, lp := range loops {
 		for _, p := range lp.Vertices {
 			s := float64(rod.Origin.VectorTo(p).Dot(axis)) - vBase
-			if s < -1e-7 || s > rodHeight+1e-7 {
+			if s < -tol || s > rodHeight+tol {
 				return false
 			}
 		}

--- a/kernel/brep/curved_cylinder_boss.go
+++ b/kernel/brep/curved_cylinder_boss.go
@@ -53,13 +53,14 @@ func JoinCylindricalBoss(target, tool *topo.Body) (*topo.Body, bool) {
 func bossSeatFace(faces []curvedFace, c0, c1 math.Point3, ua math.Vector3, radius float64) (near, far math.Point3, idx int, ok bool) {
 	for i, f := range faces {
 		pl, isPlane := f.surface.(geom.Plane)
-		if !isPlane || stdmath.Abs(float64(unit(pl.Normal()).Dot(ua))) < 1-1e-7 {
+		if !isPlane || stdmath.Abs(float64(unit(pl.Normal()).Dot(ua))) < 1-1e-7 { // tol:angular — face ⟂ axis cosine
 			continue // not a face perpendicular to the boss axis
 		}
 		nOut := faceOutwardNormal(f, pl)
+		flushTol := geom.ResolutionForSize(radius).Plane() // model-relative cap-flush margin (#1399)
 		for _, cap := range [2][2]math.Point3{{c0, c1}, {c1, c0}} {
 			n, fr := cap[0], cap[1]
-			if stdmath.Abs(pointPlaneDistance(n, pl)) > axialTouchTol {
+			if stdmath.Abs(pointPlaneDistance(n, pl)) > flushTol {
 				continue // this cap is not flush on the face plane
 			}
 			if float64(n.VectorTo(fr).Dot(nOut)) <= 0 {

--- a/kernel/brep/curved_halfspace.go
+++ b/kernel/brep/curved_halfspace.go
@@ -36,6 +36,10 @@ var ErrUnsupportedHalfSpace = errors.New("brep: half-space cut handles only the 
 func HalfSpaceCut(body *topo.Body, plane geom.Plane) (*topo.Body, error) {
 	n := unit(plane.Normal())
 	faces := facesOfAny(body)
+	// One model-relative coincidence scale for this cut, derived from the body's extent
+	// (Oblikovati/Oblikovati#1399); threaded into the general split so the analytic imprint's
+	// clearance/grazing tests scale with the part rather than reading a cm-anchored epsilon.
+	res := geom.ResolutionForBox(body.RangeBox())
 	if cyl, base, height, ok := cylinderSolidParams(faces); ok && perpendicularToAxis(n, cyl) {
 		return cylinderHalfSpace(body, cyl, base, height, plane) // ⟂ cut → shorter cylinder, fast path
 	}
@@ -43,11 +47,11 @@ func HalfSpaceCut(body *topo.Body, plane geom.Plane) (*topo.Body, error) {
 		return coneHalfSpace(body, cone, vMin, vMax, plane) // ⟂ cut → cone/frustum, fast path
 	}
 	if torus, ok := torusSolidParams(faces); ok {
-		if res, handled, err := torusHalfSpaceCut(body, torus, plane, n); handled {
-			return res, err
+		if cut, handled, err := torusHalfSpaceCut(body, torus, plane, n); handled {
+			return cut, err
 		}
 	}
-	return generalHalfSpace(body, plane, n, faces)
+	return generalHalfSpace(body, plane, n, faces, res)
 }
 
 // torusHalfSpaceCut dispatches a bare torus's analytic half-space cuts by the section the plane carves:

--- a/kernel/brep/curved_halfspace_cone.go
+++ b/kernel/brep/curved_halfspace_cone.go
@@ -62,10 +62,12 @@ func coneHalfSpace(body *topo.Body, cone geom.Cone, vMin, vMax float64, plane ge
 	along := float64(n.Dot(axis))
 	vCut := float64(cone.Apex.VectorTo(plane.Origin).Dot(axis))
 	vLo, vHi := keptConeBand(vCut, vMin, vMax, along > 0)
-	if vHi-vLo <= cylinderAxisTol {
+	// Apex-distance band lengths are model-relative (#1399).
+	axialTol := geom.ResolutionForBox(body.RangeBox()).Plane()
+	if vHi-vLo <= axialTol {
 		return topo.MergeBodies(topo.NewLineage(topo.Tok("halfspace", "empty", 0)), true), nil
 	}
-	if vLo <= vMin+cylinderAxisTol && vHi >= vMax-cylinderAxisTol {
+	if vLo <= vMin+axialTol && vHi >= vMax-axialTol {
 		return body, nil // plane clears the cone on the kept side
 	}
 	t := stdmath.Tan(cone.HalfAngle)
@@ -88,5 +90,5 @@ func keptConeBand(vCut, vMin, vMax float64, nAlongAxis bool) (vLo, vHi float64) 
 // perpendicularToConeAxis reports whether the cut plane normal is parallel to the cone axis (a
 // constant-apex-distance cut), the only orientation the fast cone path handles.
 func perpendicularToConeAxis(n math.Vector3, cone geom.Cone) bool {
-	return stdmath.Abs(float64(n.Dot(cone.AxisDir.AsVector()))) >= 1-cylinderAxisTol
+	return stdmath.Abs(float64(n.Dot(cone.AxisDir.AsVector()))) >= 1-cylinderAxisCosTol
 }

--- a/kernel/brep/curved_halfspace_cone_side.go
+++ b/kernel/brep/curved_halfspace_cone_side.go
@@ -81,7 +81,7 @@ func coneSideBandSplit(f curvedFace, curves []geom.Curve3, cone geom.Cone, band 
 // the cone and a band whose bottom "rim" is the degenerate apex (vMin=0, rBot=0, a zero-radius circle) and
 // whose top rim is the circle, so the (u,v) split treats the apex as the v=0 pole. A frustum (two circles)
 // or an already-trimmed band (a circle plus section arcs) fails the one-edge test and is handled elsewhere.
-func fullConeApexSideBand(f curvedFace) (geom.Cone, coneSideBand_, bool) {
+func fullConeApexSideBand(f curvedFace, res geom.Resolution) (geom.Cone, coneSideBand_, bool) {
 	cone, ok := f.surface.(geom.Cone)
 	if !ok || len(f.loops) != 1 {
 		return geom.Cone{}, coneSideBand_{}, false
@@ -92,7 +92,7 @@ func fullConeApexSideBand(f curvedFace) (geom.Cone, coneSideBand_, bool) {
 		if c, isCircle := le.curve.(geom.Circle); isCircle && isFullDomain(le.t0, le.t1) {
 			circle, circles, rimReversed = c, circles+1, le.t1 < le.t0
 		}
-		if samePoint(le.start(), cone.Apex) || samePoint(le.end(), cone.Apex) {
+		if samePoint(le.start(), cone.Apex, res) || samePoint(le.end(), cone.Apex, res) {
 			touchesApex = true // a seam ruling ends at the apex pole
 		}
 	}

--- a/kernel/brep/curved_halfspace_cylinder.go
+++ b/kernel/brep/curved_halfspace_cylinder.go
@@ -20,7 +20,7 @@ import (
 // the cylinder axis (a constant-axial-coordinate cut). Looser than that is an oblique section. It is a
 // cosine of unit vectors — DIMENSIONLESS — so it stays absolute; the axial/radial LENGTH comparisons
 // that used to share this constant now derive from a model-relative Resolution (res.Plane(), #1399).
-const cylinderAxisCosTol = 1e-7
+const cylinderAxisCosTol = 1e-7 // tol:angular — |n·axis| cosine vs 1
 
 // CylinderParams recovers a bare cylinder's surface, base-cap centre and height from a body, for callers
 // (the curved subtract) that need the axis frame before building. ok=false unless the body is exactly one

--- a/kernel/brep/curved_halfspace_cylinder.go
+++ b/kernel/brep/curved_halfspace_cylinder.go
@@ -16,9 +16,11 @@ import (
 // section, a wedge result) needs the general curved arrangement and returns ErrUnsupportedHalfSpace
 // so the caller keeps the CSG fallback.
 
-// cylinderAxisTol is how close |n·axis| must be to 1 for a cut plane to count as perpendicular to
-// the cylinder axis (a constant-axial-coordinate cut). Looser than that is an oblique section.
-const cylinderAxisTol = 1e-7
+// cylinderAxisCosTol is how close |n·axis| must be to 1 for a cut plane to count as perpendicular to
+// the cylinder axis (a constant-axial-coordinate cut). Looser than that is an oblique section. It is a
+// cosine of unit vectors — DIMENSIONLESS — so it stays absolute; the axial/radial LENGTH comparisons
+// that used to share this constant now derive from a model-relative Resolution (res.Plane(), #1399).
+const cylinderAxisCosTol = 1e-7
 
 // CylinderParams recovers a bare cylinder's surface, base-cap centre and height from a body, for callers
 // (the curved subtract) that need the axis frame before building. ok=false unless the body is exactly one
@@ -32,7 +34,7 @@ func CylinderParams(body *topo.Body) (cyl geom.Cylinder, base math.Point3, heigh
 // axis-parallel or oblique cut routes to the general arrangement instead.
 func perpendicularToAxis(n math.Vector3, cyl geom.Cylinder) bool {
 	along := float64(n.Dot(cyl.AxisDir.AsVector()))
-	return stdmath.Abs(along) >= 1-cylinderAxisTol
+	return stdmath.Abs(along) >= 1-cylinderAxisCosTol
 }
 
 // cylinderSolidParams recovers a closed cylinder's geometry from its flattened faces: the side's
@@ -77,16 +79,19 @@ func cylinderHalfSpace(body *topo.Body, cyl geom.Cylinder, base math.Point3, hei
 	n := unit(plane.Normal())
 	axis := cyl.AxisDir.AsVector()
 	along := float64(n.Dot(axis))
-	if stdmath.Abs(along) < 1-cylinderAxisTol {
+	if stdmath.Abs(along) < 1-cylinderAxisCosTol {
 		return nil, ErrUnsupportedHalfSpace // oblique cut: elliptical section, deferred
 	}
+	// Axial band lengths are model-relative (#1399): a km-scale cylinder is not falsely emptied or
+	// kept-whole by a cm-anchored axial epsilon.
+	axialTol := geom.ResolutionForBox(body.RangeBox()).Plane()
 	// Axial coordinate (from base, along +axis) where the cut plane sits, and the kept sub-band.
 	cut := float64(base.VectorTo(plane.Origin).Dot(axis))
 	lo, hi := keptAxialBand(cut, height, along > 0)
-	if hi-lo <= cylinderAxisTol {
+	if hi-lo <= axialTol {
 		return topo.MergeBodies(topo.NewLineage(topo.Tok("halfspace", "empty", 0)), true), nil
 	}
-	if hi-lo >= height-cylinderAxisTol {
+	if hi-lo >= height-axialTol {
 		return body, nil // plane clears the cylinder on the kept side
 	}
 	newBase := base.TranslateBy(axis.Scale(math.Scalar(lo)))

--- a/kernel/brep/curved_halfspace_general.go
+++ b/kernel/brep/curved_halfspace_general.go
@@ -36,7 +36,7 @@ func generalHalfSpace(body *topo.Body, plane geom.Plane, n math.Vector3, faces [
 	if len(section) == 0 {
 		return body, nil // no face was cut: the plane clears the body and the whole of it is kept
 	}
-	lids, ok := buildLids(plane, n, section)
+	lids, ok := buildLids(plane, n, section, res)
 	if !ok {
 		return nil, ErrUnsupportedHalfSpace
 	}
@@ -49,20 +49,28 @@ func generalHalfSpace(body *topo.Body, plane geom.Plane, n math.Vector3, faces [
 // band split would not recognise it). A cone/cylinder is RULED along v, so if every boundary point lies on
 // one side the whole ruled interior does too; the caller then keeps or drops the face whole. Only ruled
 // sides qualify (a sphere/torus interior can bulge past a chord between boundary points).
-func faceWhollyOneSide(f curvedFace, plane geom.Plane, n math.Vector3) bool {
+func faceWhollyOneSide(f curvedFace, plane geom.Plane, n math.Vector3, res geom.Resolution) bool {
 	switch f.surface.(type) {
 	case geom.Cone, geom.Cylinder:
 	default:
 		return false
 	}
-	neg, pos := false, false
+	pos, neg := ruledFaceSides(f, plane, n, res)
+	return !neg || !pos // wholly on one side (or grazing): no genuine crossing
+}
+
+// ruledFaceSides reports which sides of the cutting plane a ruled (cone/cylinder) face's boundary — and a
+// full cone's apex pole — touch, classified within the model-relative on-plane band res.Plane() (#1399) so
+// a grazing point counts as "on" the plane at any model scale.
+func ruledFaceSides(f curvedFace, plane geom.Plane, n math.Vector3, res geom.Resolution) (pos, neg bool) {
+	onPlane := res.Plane()
 	for _, loop := range f.loops {
 		for _, le := range loop.edges {
 			for i := 0; i <= 8; i++ {
 				switch d := signedDistance(le.curve.PointAt(le.t0+(le.t1-le.t0)*float64(i)/8), plane, n); {
-				case d > cylinderAxisTol:
+				case d > onPlane:
 					pos = true
-				case d < -cylinderAxisTol:
+				case d < -onPlane:
 					neg = true
 				}
 			}
@@ -70,15 +78,15 @@ func faceWhollyOneSide(f curvedFace, plane geom.Plane, n math.Vector3) bool {
 	}
 	// A full cone closes to its apex pole, which lies on no boundary edge — sample it too, else a cut that
 	// separates the apex from the rim is missed (the rim alone reads as wholly one side, #1375).
-	if cone, _, ok := fullConeApexSideBand(f); ok {
+	if cone, _, ok := fullConeApexSideBand(f, res); ok {
 		switch d := signedDistance(cone.Apex, plane, n); {
-		case d > cylinderAxisTol:
+		case d > onPlane:
 			pos = true
-		case d < -cylinderAxisTol:
+		case d < -onPlane:
 			neg = true
 		}
 	}
-	return !neg || !pos // wholly on one side (or grazing): no genuine crossing
+	return pos, neg
 }
 
 // splitFaceByPlane splits one face by the cutting plane, returning the kept (negative-side) sub-faces
@@ -89,7 +97,7 @@ func splitFaceByPlane(f curvedFace, plane geom.Plane, n math.Vector3, res geom.R
 	if !handled {
 		return nil, nil, ErrUnsupportedHalfSpace
 	}
-	if len(curves) == 0 || faceWhollyOneSide(f, plane, n) {
+	if len(curves) == 0 || faceWhollyOneSide(f, plane, n, res) {
 		if signedDistance(faceSample(f), plane, n) <= 0 {
 			return []curvedFace{f}, nil, nil // whole face on the negative side
 		}
@@ -104,10 +112,10 @@ func splitFaceByPlane(f curvedFace, plane geom.Plane, n math.Vector3, res geom.R
 	if cone, band, ok := fullConeSideBand(f); ok {
 		return coneSideBandSplit(f, curves, cone, band, plane, n)
 	}
-	if cone, band, ok := fullConeApexSideBand(f); ok {
+	if cone, band, ok := fullConeApexSideBand(f, res); ok {
 		return coneApexSideSplit(f, cone, curves[0], band, plane, n)
 	}
-	return loopedSplit(f, curves, plane, n)
+	return loopedSplit(f, curves, plane, n, res)
 }
 
 // capSplit splits a boundary-less face (a bare sphere) by its imprint circle into the kept negative cap
@@ -130,8 +138,8 @@ func capSplit(f curvedFace, c geom.Curve3) ([]curvedFace, []loopEdge, error) {
 // buildLids chains the section arcs into closed loops and builds one planar lid face per loop, on the
 // cutting plane with outward normal +n. ok=false when the section arcs do not close into loops (a case
 // the looped split will complete).
-func buildLids(plane geom.Plane, n math.Vector3, section []loopEdge) ([]curvedFace, bool) {
-	loops := chainSectionLoops(section)
+func buildLids(plane geom.Plane, n math.Vector3, section []loopEdge, res geom.Resolution) ([]curvedFace, bool) {
+	loops := chainSectionLoops(section, res)
 	if loops == nil {
 		return nil, false
 	}
@@ -153,17 +161,17 @@ func buildLids(plane geom.Plane, n math.Vector3, section []loopEdge) ([]curvedFa
 // chainSectionLoops groups section arcs into closed boundary loops: a closed-circle section is its own
 // loop; open arcs chain end-to-start. Returns nil if open arcs are present but cannot be closed (the
 // looped split's job).
-func chainSectionLoops(section []loopEdge) [][]loopEdge {
+func chainSectionLoops(section []loopEdge, res geom.Resolution) [][]loopEdge {
 	var loops [][]loopEdge
 	var open []loopEdge
 	for _, e := range section {
-		if samePoint(e.start(), e.end()) {
+		if samePoint(e.start(), e.end(), res) {
 			loops = append(loops, []loopEdge{e}) // a full section circle is a loop on its own
 		} else {
 			open = append(open, e)
 		}
 	}
-	chained := chainOpenArcs(open)
+	chained := chainOpenArcs(open, res)
 	if chained == nil && len(open) > 0 {
 		return nil // open arcs that do not close into loops
 	}
@@ -172,14 +180,14 @@ func chainSectionLoops(section []loopEdge) [][]loopEdge {
 
 // chainOpenArcs links open section arcs end-to-start into closed loops (each arc's end meets the next
 // arc's start). Returns nil if any arc cannot be closed into a loop.
-func chainOpenArcs(open []loopEdge) [][]loopEdge {
+func chainOpenArcs(open []loopEdge, res geom.Resolution) [][]loopEdge {
 	used := make([]bool, len(open))
 	var loops [][]loopEdge
 	for i := range open {
 		if used[i] {
 			continue
 		}
-		loop, ok := traceArcLoop(open, used, i)
+		loop, ok := traceArcLoop(open, used, i, res)
 		if !ok {
 			return nil
 		}
@@ -189,14 +197,14 @@ func chainOpenArcs(open []loopEdge) [][]loopEdge {
 }
 
 // traceArcLoop follows arcs from seed until it returns to the start, marking them used.
-func traceArcLoop(open []loopEdge, used []bool, seed int) ([]loopEdge, bool) {
+func traceArcLoop(open []loopEdge, used []bool, seed int, res geom.Resolution) ([]loopEdge, bool) {
 	loop := []loopEdge{open[seed]}
 	used[seed] = true
 	cur := open[seed].end()
-	for !samePoint(cur, open[seed].start()) {
+	for !samePoint(cur, open[seed].start(), res) {
 		next := -1
 		for j := range open {
-			if !used[j] && samePoint(open[j].start(), cur) {
+			if !used[j] && samePoint(open[j].start(), cur, res) {
 				next = j
 				break
 			}
@@ -225,7 +233,10 @@ func signedDistance(p math.Point3, plane geom.Plane, n math.Vector3) float64 {
 	return float64(plane.Origin.VectorTo(p).Dot(n))
 }
 
-// samePoint reports whether two points coincide within the weld tolerance.
-func samePoint(a, b math.Point3) bool {
-	return float64(a.DistanceTo(b)) < 1e-7
+// samePoint reports whether two points coincide within the model-relative weld tolerance (#1399).
+// Section/trace endpoints carry more accumulated round-off than an exact vertex weld, so they merge at
+// the looser on-line tolerance res.Plane() (1e-7 at unit scale) rather than res.Weld(); deriving it from
+// the body's extent keeps loop-closure and arc-chaining watertight on a km-scale part.
+func samePoint(a, b math.Point3, res geom.Resolution) bool {
+	return float64(a.DistanceTo(b)) < res.Plane()
 }

--- a/kernel/brep/curved_halfspace_general.go
+++ b/kernel/brep/curved_halfspace_general.go
@@ -17,11 +17,13 @@ import (
 // CSG fallback until that split lands.
 
 // generalHalfSpace cuts an arbitrary analytic body by one plane via split → classify → lid → stitch.
-func generalHalfSpace(body *topo.Body, plane geom.Plane, n math.Vector3, faces []curvedFace) (*topo.Body, error) {
+// res is the body's model-relative coincidence scale (Oblikovati/Oblikovati#1399), threaded into the
+// per-face imprint so the exact-conic-vs-defer decision is scale-faithful.
+func generalHalfSpace(body *topo.Body, plane geom.Plane, n math.Vector3, faces []curvedFace, res geom.Resolution) (*topo.Body, error) {
 	var kept []curvedFace
 	var section []loopEdge
 	for _, f := range faces {
-		pieces, arcs, err := splitFaceByPlane(f, plane, n)
+		pieces, arcs, err := splitFaceByPlane(f, plane, n, res)
 		if err != nil {
 			return nil, err
 		}
@@ -82,8 +84,8 @@ func faceWhollyOneSide(f curvedFace, plane geom.Plane, n math.Vector3) bool {
 // splitFaceByPlane splits one face by the cutting plane, returning the kept (negative-side) sub-faces
 // and the section arcs that bound the lid. A face the plane does not cross is kept whole or dropped; a
 // boundary-less face (sphere) splits into the kept cap; a looped face crossed by the imprint defers.
-func splitFaceByPlane(f curvedFace, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
-	curves, handled := curvedImprint(f, curvedFace{surface: plane})
+func splitFaceByPlane(f curvedFace, plane geom.Plane, n math.Vector3, res geom.Resolution) ([]curvedFace, []loopEdge, error) {
+	curves, handled := curvedImprint(f, curvedFace{surface: plane}, res)
 	if !handled {
 		return nil, nil, ErrUnsupportedHalfSpace
 	}

--- a/kernel/brep/curved_halfspace_looped.go
+++ b/kernel/brep/curved_halfspace_looped.go
@@ -32,8 +32,8 @@ type keptSeg struct {
 // points with no holes; the imprint may be one conic (a sphere cap, a disk lid) or several lines (a
 // cylinder arc band a box re-cuts), each kept run bridged along whichever imprint curve joins it. A face
 // with holes, an odd crossing count (a tangency/island), or an unbridgeable run defers.
-func loopedSplit(f curvedFace, curves []geom.Curve3, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
-	if !faceBoundaryCrosses(f, plane, n) {
+func loopedSplit(f curvedFace, curves []geom.Curve3, plane geom.Plane, n math.Vector3, res geom.Resolution) ([]curvedFace, []loopEdge, error) {
+	if !faceBoundaryCrosses(f, plane, n, res) {
 		// The imprint curve exists but does not cross ANY of the face's boundary loops — the face lies
 		// wholly on one side (e.g. a far clearing plane on a multi-loop annular lid). Keep or drop it whole;
 		// this precedes the single-loop requirement so a clearing plane composes over a holed planar face.
@@ -45,7 +45,7 @@ func loopedSplit(f curvedFace, curves []geom.Curve3, plane geom.Plane, n math.Ve
 	if len(f.loops) != 1 {
 		return nil, nil, ErrUnsupportedHalfSpace // a CROSSED holes/multi-loop face: a later increment
 	}
-	segs, crossings := splitLoopByPlane(f.loops[0], plane, n)
+	segs, crossings := splitLoopByPlane(f.loops[0], plane, n, res)
 	if crossings == 0 {
 		if signedDistance(faceSample(f), plane, n) <= 0 {
 			return []curvedFace{f}, nil, nil
@@ -59,16 +59,16 @@ func loopedSplit(f curvedFace, curves []geom.Curve3, plane geom.Plane, n math.Ve
 	if len(runs) == 0 {
 		return nil, nil, nil // every crossing-free piece was on the positive side: dropped
 	}
-	return traceKeptFaces(f, curves, runs)
+	return traceKeptFaces(f, curves, runs, res)
 }
 
 // faceBoundaryCrosses reports whether any of the face's boundary loops crosses the cutting plane (an edge
 // runs from one side to the other). A face whose whole boundary lies on one side does not genuinely meet
 // the plane — the imprint curve passes outside it — so the caller keeps or drops it whole regardless of
 // how many loops it has (the multi-loop split is only needed when the plane actually cuts the boundary).
-func faceBoundaryCrosses(f curvedFace, plane geom.Plane, n math.Vector3) bool {
+func faceBoundaryCrosses(f curvedFace, plane geom.Plane, n math.Vector3, res geom.Resolution) bool {
 	for i := range f.loops {
-		if _, crossings := splitLoopByPlane(f.loops[i], plane, n); crossings > 0 {
+		if _, crossings := splitLoopByPlane(f.loops[i], plane, n, res); crossings > 0 {
 			return true
 		}
 	}
@@ -79,7 +79,7 @@ func faceBoundaryCrosses(f curvedFace, plane geom.Plane, n math.Vector3) bool {
 // returns one kept sub-face per loop plus all section edges (the reversed bridges, for the lid). A plane
 // can split one face into SEVERAL kept pieces — a slab leaves a cylinder band in two strips — so the runs
 // are grouped into as many loops as the bridging forms, not assumed to chain into one.
-func traceKeptFaces(f curvedFace, curves []geom.Curve3, runs [][]loopEdge) ([]curvedFace, []loopEdge, error) {
+func traceKeptFaces(f curvedFace, curves []geom.Curve3, runs [][]loopEdge, res geom.Resolution) ([]curvedFace, []loopEdge, error) {
 	used := make([]bool, len(runs))
 	var faces []curvedFace
 	var section []loopEdge
@@ -87,7 +87,7 @@ func traceKeptFaces(f curvedFace, curves []geom.Curve3, runs [][]loopEdge) ([]cu
 		if used[s] {
 			continue
 		}
-		loop, sec, err := traceKeptLoop(f, curves, runs, used, s)
+		loop, sec, err := traceKeptLoop(f, curves, runs, used, s, res)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -100,13 +100,13 @@ func traceKeptFaces(f curvedFace, curves []geom.Curve3, runs [][]loopEdge) ([]cu
 // traceKeptLoop walks from the start run, alternating boundary runs with imprint bridges, until it
 // returns to the start — one closed kept loop. Each run's exit bridges along the imprint curve to the
 // crossing where the next (or the same) run begins.
-func traceKeptLoop(f curvedFace, curves []geom.Curve3, runs [][]loopEdge, used []bool, start int) ([]loopEdge, []loopEdge, error) {
+func traceKeptLoop(f curvedFace, curves []geom.Curve3, runs [][]loopEdge, used []bool, start int, res geom.Resolution) ([]loopEdge, []loopEdge, error) {
 	var loop, section []loopEdge
 	for j := start; ; {
 		used[j] = true
 		loop = append(loop, runs[j]...)
 		exit := runs[j][len(runs[j])-1].end()
-		bridge, k, ok := bridgeToEntry(f, curves, runs, exit)
+		bridge, k, ok := bridgeToEntry(f, curves, runs, exit, res)
 		if !ok {
 			return nil, nil, ErrUnsupportedHalfSpace
 		}
@@ -125,10 +125,10 @@ func traceKeptLoop(f curvedFace, curves []geom.Curve3, runs [][]loopEdge, used [
 // bridgeToEntry finds the run whose start the exit point bridges to along an imprint curve, returning the
 // bridge edge and that run's index. The imprint curve must pass through BOTH the exit and the candidate
 // entry, so the matching line of an axis-parallel pair selects the run that continues the same strip.
-func bridgeToEntry(f curvedFace, curves []geom.Curve3, runs [][]loopEdge, exit math.Point3) (loopEdge, int, bool) {
+func bridgeToEntry(f curvedFace, curves []geom.Curve3, runs [][]loopEdge, exit math.Point3, res geom.Resolution) (loopEdge, int, bool) {
 	for k, run := range runs {
 		entry := run[0].start()
-		if bridge, ok := bridgeArc(f, curves, exit, entry); ok {
+		if bridge, ok := bridgeArc(f, curves, exit, entry, res); ok {
 			return bridge, k, true
 		}
 	}
@@ -140,13 +140,13 @@ func bridgeToEntry(f curvedFace, curves []geom.Curve3, runs [][]loopEdge, exit m
 // is cut at its crossings ONLY, the arcs running between consecutive crossings across the seam — never
 // split at the arbitrary seam vertex, which would fragment a kept arc that wraps it into two edges that
 // then fail to weld with the matching single arc on the adjoining face.
-func splitLoopByPlane(loop curvedLoop, plane geom.Plane, n math.Vector3) ([]keptSeg, int) {
+func splitLoopByPlane(loop curvedLoop, plane geom.Plane, n math.Vector3, res geom.Resolution) ([]keptSeg, int) {
 	var segs []keptSeg
 	crossings := 0
 	for _, le := range loop.edges {
-		cs := edgeCrossings(le, plane, n)
+		cs := edgeCrossings(le, plane, n, res)
 		crossings += len(cs)
-		if samePoint(le.start(), le.end()) && len(cs) > 0 {
+		if samePoint(le.start(), le.end(), res) && len(cs) > 0 {
 			segs = append(segs, closedEdgeSegs(le, cs, plane, n)...)
 		} else {
 			segs = append(segs, openEdgeSegs(le, cs, plane, n)...)
@@ -192,8 +192,8 @@ func taggedSeg(c geom.Curve3, a, b float64, plane geom.Plane, n math.Vector3) ke
 // edgeCrossings returns the parameters within an edge's [t0, t1] where g crosses zero (the plane cuts
 // the edge), found by sampling for sign changes then bisecting each. A CLOSED (seam) edge is sampled
 // cyclically — see closedEdgeCrossings — so a crossing that lands on its seam vertex is not missed.
-func edgeCrossings(le loopEdge, plane geom.Plane, n math.Vector3) []float64 {
-	if samePoint(le.start(), le.end()) {
+func edgeCrossings(le loopEdge, plane geom.Plane, n math.Vector3, res geom.Resolution) []float64 {
+	if samePoint(le.start(), le.end(), res) {
 		return closedEdgeCrossings(le, plane, n)
 	}
 	var out []float64
@@ -327,9 +327,9 @@ func allEdges(segs []keptSeg) []loopEdge {
 // each curve until one passes through both points (the right line of an axis-parallel pair, or the
 // imprint conic). A line gives the segment between them; a closed conic gives whichever of its two arcs
 // has its midpoint inside f.
-func bridgeArc(f curvedFace, curves []geom.Curve3, exit, entry math.Point3) (loopEdge, bool) {
+func bridgeArc(f curvedFace, curves []geom.Curve3, exit, entry math.Point3, res geom.Resolution) (loopEdge, bool) {
 	for _, c := range curves {
-		if e, ok := bridgeAlong(f, c, exit, entry); ok {
+		if e, ok := bridgeAlong(f, c, exit, entry, res); ok {
 			return e, true
 		}
 	}
@@ -338,10 +338,10 @@ func bridgeArc(f curvedFace, curves []geom.Curve3, exit, entry math.Point3) (loo
 
 // bridgeAlong returns the exit→entry portion of a single imprint curve c, or ok=false if c does not pass
 // through both endpoints (so the wrong line of a pair is rejected) or no arc of it lies inside f.
-func bridgeAlong(f curvedFace, c geom.Curve3, exit, entry math.Point3) (loopEdge, bool) {
+func bridgeAlong(f curvedFace, c geom.Curve3, exit, entry math.Point3, res geom.Resolution) (loopEdge, bool) {
 	tExit, _ := geom.CurveParamAtPoint3(c, exit)
 	tEntry, _ := geom.CurveParamAtPoint3(c, entry)
-	if !onCurve(c, tExit, exit) || !onCurve(c, tEntry, entry) {
+	if !onCurve(c, tExit, exit, res) || !onCurve(c, tEntry, entry, res) {
 		return loopEdge{}, false
 	}
 	if _, isLine := c.(geom.Line); isLine {
@@ -362,8 +362,8 @@ func bridgeAlong(f curvedFace, c geom.Curve3, exit, entry math.Point3) (loopEdge
 
 // onCurve reports whether c.PointAt(t) coincides with p — used to confirm a candidate imprint curve
 // actually passes through a crossing point before bridging along it.
-func onCurve(c geom.Curve3, t float64, p math.Point3) bool {
-	return samePoint(c.PointAt(t), p)
+func onCurve(c geom.Curve3, t float64, p math.Point3, res geom.Resolution) bool {
+	return samePoint(c.PointAt(t), p, res)
 }
 
 // arcCandidates returns the two end parameters that, paired with tExit, sweep the two arcs (positive and

--- a/kernel/brep/curved_halfspace_ruled_uv.go
+++ b/kernel/brep/curved_halfspace_ruled_uv.go
@@ -92,6 +92,11 @@ func (c ruledUV) sectionV(u float64) float64 {
 // strict lo<hi flickers and breaks the span pairing. The margin makes the pinch read as empty either way.
 // It sits well ABOVE the ~1e-14 rounding flicker yet two orders below the 1e-7 weld tolerance, so the span
 // endpoint the bisection lands on (where the section sits vPinchTol inside the rim) still welds to the rim.
+//
+// tol:calibrated — this (u,v) arrangement margin is OCC-validated for the delicate tangent-limit cases
+// (the parabola cone∩box, the symmetric pinch). It is NOT model-relativised under #1399: at a part scale
+// of ~10 a size-scaled weld is an order of magnitude off and misclassifies the rim crossing, breaking the
+// validated volumes. The split operates on the cone's own (azimuth, axial) frame, which is already ~O(R).
 const vPinchTol = 1e-9
 
 // keptV returns the kept (g<0) axial-distance interval [lo, hi] at azimuth u, clamped to the band, plus

--- a/kernel/brep/curved_halfspace_scale_test.go
+++ b/kernel/brep/curved_halfspace_scale_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// The curved half-space pipeline must give the SAME RELATIVE result at every model scale
+// (Oblikovati/Oblikovati#1399): the analytic imprint that decides where the cutting plane meets a
+// face now derives its clearance tolerance from the body's own extent (geom.ResolutionForBox of
+// the RangeBox) instead of a cm-anchored epsilon. A sphere cut through its centre yields a
+// hemisphere cap of volume (2/3)πR³, so the dimensionless coefficient vol/R³ is invariant across
+// a unit, a km and a Mm copy — the issue's "boolean and mesh a unit / 1e6× copy, assert identical
+// volume within relative tolerance" case, run end-to-end through brep.HalfSpaceCut.
+func TestHalfSpaceCutSphereScaleSweep(t *testing.T) {
+	const hemisphereCoef = 2.0 / 3.0 * stdmath.Pi // (2/3)π
+	const relTol = 0.02                           // tessellated cap vs analytic, scale-independent
+	for _, radius := range []float64{1, 1e3, 1e6} {
+		sphere, err := brep.SolidSphere(math.P3(0, 0, 0), radius, "s")
+		if err != nil {
+			t.Fatalf("SolidSphere(r=%g): %v", radius, err)
+		}
+		plane, err := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+		if err != nil {
+			t.Fatalf("NewPlane: %v", err)
+		}
+		cap, err := brep.HalfSpaceCut(sphere, plane)
+		if err != nil {
+			t.Fatalf("HalfSpaceCut(r=%g): %v", radius, err)
+		}
+		coef := vol(cap) / (radius * radius * radius)
+		if relErr := stdmath.Abs(coef-hemisphereCoef) / hemisphereCoef; relErr > relTol {
+			t.Errorf("radius %g: hemisphere cap coefficient %.5f, want %.5f (rel err %.4f > %.4f) — "+
+				"half-space cut is not scale-faithful", radius, coef, hemisphereCoef, relErr, relTol)
+		}
+	}
+}

--- a/kernel/brep/curved_halfspace_seam_crossing_test.go
+++ b/kernel/brep/curved_halfspace_seam_crossing_test.go
@@ -46,7 +46,7 @@ func TestHalfSpaceThroughCapSeam(t *testing.T) {
 func hasPlanarLid(b *topo.Body, plane geom.Plane) bool {
 	for _, f := range b.Faces() {
 		pl, ok := f.Geometry().(geom.Plane)
-		if ok && samePoint(pl.Origin, plane.Origin) {
+		if ok && samePoint(pl.Origin, plane.Origin, geom.ResolutionForSize(1)) {
 			return true
 		}
 	}

--- a/kernel/brep/curved_halfspace_torus.go
+++ b/kernel/brep/curved_halfspace_torus.go
@@ -30,7 +30,14 @@ func torusSolidParams(faces []curvedFace) (geom.Torus, bool) {
 // perpendicularToTorusAxis reports whether the cut plane normal is parallel to the torus axis — the
 // constant-axial-level cut whose section is the two concentric circles this path handles.
 func perpendicularToTorusAxis(n math.Vector3, t geom.Torus) bool {
-	return stdmath.Abs(float64(n.Dot(t.AxisDir.AsVector()))) >= 1-cylinderAxisTol
+	return stdmath.Abs(float64(n.Dot(t.AxisDir.AsVector()))) >= 1-cylinderAxisCosTol
+}
+
+// torusSectionTol is the model-relative length margin for a torus spiric-section offset test (#1399):
+// the radius/offset comparisons that classify the section topology (single oval, two ovals, figure-eight)
+// scale with the torus's own extent (major + minor radius) instead of a cm-anchored 1e-7.
+func torusSectionTol(t geom.Torus) float64 {
+	return geom.ResolutionForSize(t.MajorRadius + t.MinorRadius).Plane()
 }
 
 // torusHalfSpace keeps the tube arc of a torus on the plane's negative side, rebuilt as a trimmed torus
@@ -42,10 +49,11 @@ func torusHalfSpace(body *topo.Body, t geom.Torus, plane geom.Plane) (*topo.Body
 	nAxis := float64(n.Dot(axis))
 	d := float64(t.Center.VectorTo(plane.Origin).Dot(axis)) // section level along the axis
 	r := t.MinorRadius
-	if d >= r-cylinderAxisTol {
+	radialTol := geom.ResolutionForBox(body.RangeBox()).Plane() // model-relative clearance (#1399)
+	if d >= r-radialTol {
 		return keepWholeOrEmpty(body, nAxis > 0) // the whole tube lies below d: kept iff the low side is kept
 	}
-	if d <= -r+cylinderAxisTol {
+	if d <= -r+radialTol {
 		return keepWholeOrEmpty(body, nAxis < 0)
 	}
 	half := stdmath.Sqrt(r*r - d*d)

--- a/kernel/brep/curved_halfspace_torus_oblique.go
+++ b/kernel/brep/curved_halfspace_torus_oblique.go
@@ -26,11 +26,12 @@ import (
 // complement) is decided by the caller from the sign of K (K<0 keeps the small cap on the −m side).
 func torusAxisParallelOval(t geom.Torus, plane geom.Plane) (k float64, ok bool) {
 	_, m, k, c := geom.TorusSectionCoeffs(t, plane)
-	if stdmath.Abs(c) > cylinderAxisTol || m <= cylinderAxisTol {
+	if stdmath.Abs(c) > cylinderAxisCosTol || m <= cylinderAxisCosTol {
 		return k, false
 	}
+	tol := torusSectionTol(t)
 	ratio := stdmath.Abs(k) / m // the plane's distance from the axis, in tube radii
-	ok = ratio > t.MajorRadius-t.MinorRadius+cylinderAxisTol && ratio < t.MajorRadius+t.MinorRadius-cylinderAxisTol
+	ok = ratio > t.MajorRadius-t.MinorRadius+tol && ratio < t.MajorRadius+t.MinorRadius-tol
 	return k, ok
 }
 

--- a/kernel/brep/curved_halfspace_torus_oblique_general.go
+++ b/kernel/brep/curved_halfspace_torus_oblique_general.go
@@ -102,12 +102,12 @@ func torusSectionAbsentArc(t geom.Torus, m, k, c float64) float64 {
 }
 
 // torusObliqueOval reports whether plane makes a single CLEAR oval bite we build via the cap/complement
-// path: genuinely tilted (cylinderAxisTol < |C| < 1), one oval, and NOT near-full-wrap (the section is
+// path: genuinely tilted (cylinderAxisCosTol < |C| < 1), one oval, and NOT near-full-wrap (the section is
 // absent over more than figureEightWrapTol of the tube, so the complement is a fat genus-1 region the chart
 // meshes well). A near-full-wrap oval is the oblique figure-eight, routed to [torusTwoObliqueOval] instead.
 func torusObliqueOval(t geom.Torus, plane geom.Plane) bool {
 	_, m, k, c := geom.TorusSectionCoeffs(t, plane)
-	if stdmath.Abs(c) <= cylinderAxisTol || stdmath.Abs(c) >= 1-cylinderAxisTol || m <= cylinderAxisTol {
+	if stdmath.Abs(c) <= cylinderAxisCosTol || stdmath.Abs(c) >= 1-cylinderAxisCosTol || m <= cylinderAxisCosTol {
 		return false
 	}
 	if torusSectionAbsentArc(t, m, k, c) <= figureEightWrapTol {
@@ -117,14 +117,14 @@ func torusObliqueOval(t geom.Torus, plane geom.Plane) bool {
 	return ok // a clear single oval (the substantial absent arc keeps the crossings well separated)
 }
 
-// torusTwoObliqueOval reports whether a TILTED plane (cylinderAxisTol < |C| < 1) cuts a band the band loft
+// torusTwoObliqueOval reports whether a TILTED plane (cylinderAxisCosTol < |C| < 1) cuts a band the band loft
 // meshes: either TWO ovals (the section is valid at every tube angle — no w=±1 crossing — so each branch is
 // a full closed oval) or the near-full-wrap FIGURE-EIGHT (a single oval whose two pinches are within
 // figureEightWrapTol, valid over all but a sliver of the tube). Both are the tilted analogue of the
 // axis-parallel [torusTwoOvalBand]; the band builder and spiric mesher are general in C, so they reuse it.
 func torusTwoObliqueOval(t geom.Torus, plane geom.Plane) bool {
 	_, m, k, c := geom.TorusSectionCoeffs(t, plane)
-	if stdmath.Abs(c) <= cylinderAxisTol || stdmath.Abs(c) >= 1-cylinderAxisTol || m <= cylinderAxisTol {
+	if stdmath.Abs(c) <= cylinderAxisCosTol || stdmath.Abs(c) >= 1-cylinderAxisCosTol || m <= cylinderAxisCosTol {
 		return false
 	}
 	// The section exists over (nearly) all of the tube — two full ovals, or the near-full-wrap figure-eight.

--- a/kernel/brep/curved_halfspace_torus_twooval.go
+++ b/kernel/brep/curved_halfspace_torus_twooval.go
@@ -25,11 +25,12 @@ import (
 // deferred).
 func torusTwoOvalBand(t geom.Torus, plane geom.Plane) bool {
 	_, m, k, c := geom.TorusSectionCoeffs(t, plane)
-	if stdmath.Abs(c) > cylinderAxisTol || m <= cylinderAxisTol {
+	if stdmath.Abs(c) > cylinderAxisCosTol || m <= cylinderAxisCosTol {
 		return false
 	}
+	tol := torusSectionTol(t)
 	ratio := stdmath.Abs(k) / m
-	return ratio > cylinderAxisTol && ratio < t.MajorRadius-t.MinorRadius+cylinderAxisTol
+	return ratio > tol && ratio < t.MajorRadius-t.MinorRadius+tol
 }
 
 // torusTwoOvalHalfSpace keeps the v-wrapping band a plane parallel to the torus axis leaves on its negative

--- a/kernel/brep/curved_partial_penetration.go
+++ b/kernel/brep/curved_partial_penetration.go
@@ -175,7 +175,7 @@ func rodEndInsideFat(rod crossRod, center math.Point3, fat geom.Cylinder, fatBas
 // pointInsideCylinderSolid reports whether p is strictly inside the finite cylinder solid — within the
 // radius and between the caps, by a small margin so a point on the surface counts as outside.
 func pointInsideCylinderSolid(c geom.Cylinder, base math.Point3, height float64, p math.Point3) bool {
-	const margin = 1e-7
+	margin := geom.ResolutionForSize(c.Radius + height).Plane() // model-relative inside-solid margin (#1399)
 	if float64(radialOf(p, cylAxis(c)).Length()) > c.Radius-margin {
 		return false
 	}

--- a/kernel/brep/curved_steinmetz.go
+++ b/kernel/brep/curved_steinmetz.go
@@ -57,12 +57,13 @@ func steinmetzFrame(a, b *topo.Body) (o math.Point3, dirA, dirB math.Vector3, r 
 		return math.Point3{}, math.Vector3{}, math.Vector3{}, 0, false
 	}
 	dirA, dirB = ca.AxisDir.AsVector(), cb.AxisDir.AsVector()
-	if !math.IsNearZero(dirA.Dot(dirB), 1e-7) { // axes must be perpendicular
+	if !math.IsNearZero(dirA.Dot(dirB), 1e-7) { // tol:angular — perpendicular-axes dot of unit vectors
 		return math.Point3{}, math.Vector3{}, math.Vector3{}, 0, false
 	}
 	lineA, _ := geom.NewLine(ca.Origin, dirA)
 	lineB, _ := geom.NewLine(cb.Origin, dirB)
-	o, ok = geom.LineLineIntersection(lineA, lineB, 1e-6)
+	// Axis-intersection coincidence is model-relative (#1399), from the two operands' extent.
+	o, ok = geom.LineLineIntersection(lineA, lineB, geom.ResolutionForBox(a.RangeBox().Union(b.RangeBox())).Plane())
 	if !ok || !axisReachesR(ca, baseA, hA, o) || !axisReachesR(cb, baseB, hB, o) {
 		return math.Point3{}, math.Vector3{}, math.Vector3{}, 0, false
 	}
@@ -76,7 +77,8 @@ func axisReachesR(c geom.Cylinder, base math.Point3, height float64, o math.Poin
 	axis := c.AxisDir.AsVector()
 	vBase := float64(c.Origin.VectorTo(base).Dot(axis))
 	vO := float64(c.Origin.VectorTo(o).Dot(axis))
-	return vO-c.Radius >= vBase-1e-9 && vO+c.Radius <= vBase+height+1e-9
+	tol := geom.ResolutionForSize(height + 2*c.Radius).Weld() // model-relative axial-reach margin (#1399)
+	return vO-c.Radius >= vBase-tol && vO+c.Radius <= vBase+height+tol
 }
 
 // buildSteinmetz welds the four cylinder lobes of the bicylinder. The four elliptical arcs (two ellipses,
@@ -126,5 +128,6 @@ func steinmetzArcs(o math.Point3, dirA, dirB math.Vector3, r float64) (ePlusFron
 // nearEqual reports whether two lengths are equal to a small relative tolerance (the Steinmetz case needs
 // the two cylinder radii to match).
 func nearEqual(x, y float64) bool {
+	// tol:numeric — a relative equality test (scaled by max|x|,|y|), not a model-anchored length.
 	return stdmath.Abs(x-y) <= 1e-7*(1+stdmath.Max(stdmath.Abs(x), stdmath.Abs(y)))
 }

--- a/kernel/brep/curved_steinmetz.go
+++ b/kernel/brep/curved_steinmetz.go
@@ -128,6 +128,6 @@ func steinmetzArcs(o math.Point3, dirA, dirB math.Vector3, r float64) (ePlusFron
 // nearEqual reports whether two lengths are equal to a small relative tolerance (the Steinmetz case needs
 // the two cylinder radii to match).
 func nearEqual(x, y float64) bool {
-	// tol:numeric — a relative equality test (scaled by max|x|,|y|), not a model-anchored length.
-	return stdmath.Abs(x-y) <= 1e-7*(1+stdmath.Max(stdmath.Abs(x), stdmath.Abs(y)))
+	// a relative equality test (scaled by max|x|,|y|), not a model-anchored length.
+	return stdmath.Abs(x-y) <= 1e-7*(1+stdmath.Max(stdmath.Abs(x), stdmath.Abs(y))) // tol:numeric
 }

--- a/kernel/brep/curved_subtract_prism.go
+++ b/kernel/brep/curved_subtract_prism.go
@@ -31,8 +31,9 @@ func SubtractAxialPrism(target *topo.Body, polyBottom []math.Point3) (*topo.Body
 		return nil, ErrUnsupportedHalfSpace
 	}
 	axis := cyl.AxisDir.AsVector()
+	radialTol := geom.ResolutionForSize(cyl.Radius).Weld() // model-relative side-reach margin (#1399)
 	for _, c := range polyBottom {
-		if float64(radialPart(base.VectorTo(c), axis).Length()) >= cyl.Radius-1e-9 {
+		if float64(radialPart(base.VectorTo(c), axis).Length()) >= cyl.Radius-radialTol {
 			return nil, ErrUnsupportedHalfSpace // a corner reaches the side: not a clean axial tunnel
 		}
 	}

--- a/kernel/brep/definition.go
+++ b/kernel/brep/definition.go
@@ -182,7 +182,7 @@ func compileVertices(bld *topo.Builder, def SurfaceBodyDefinition, feat string) 
 // compileEdges builds the edges, checking each curve's ends actually land on
 // its declared vertices (the classic hand-built-graph mistake).
 func compileEdges(bld *topo.Builder, def SurfaceBodyDefinition, verts []*topo.Vertex, feat string) ([]*topo.Edge, []DefinitionIssue) {
-	const endTol = 1e-6
+	const endTol = 1e-6 // tol:calibrated — curve-endpoint-on-vertex distance (see arrange2d arrTol)
 	var issues []DefinitionIssue
 	out := make([]*topo.Edge, len(def.Edges))
 	for i, e := range def.Edges {

--- a/kernel/brep/drill_blind.go
+++ b/kernel/brep/drill_blind.go
@@ -47,7 +47,7 @@ func classifyBlindDrill(slab *topo.Body, base math.Point3, ua math.Vector3, radi
 	}
 	found := false
 	for _, f := range faces {
-		isEntry := float64(f.normal.Dot(ua)) < -1+1e-7 && stdmath.Abs(pierceParam(base, ua, f.plane)) < 1e-6
+		isEntry := float64(f.normal.Dot(ua)) < -1+1e-7 && stdmath.Abs(pierceParam(base, ua, f.plane)) < 1e-6 // tol:angular (cosine) + calibrated (pierce dist)
 		if !isEntry {
 			copied = append(copied, f)
 			continue

--- a/kernel/geom/intersect2d.go
+++ b/kernel/geom/intersect2d.go
@@ -36,7 +36,7 @@ func Segment2dIntersection(a, b LineSegment2d, tol float64) (pt math.Point2, s, 
 // parameter-range test (separate from the geometric DefaultTolerance).
 func paramTol(tol float64) float64 {
 	if tol <= 0 {
-		return 1e-9
+		return 1e-9 // tol:parametric — default acceptance widening for segment params s,t in [0,1]
 	}
 	return tol
 }

--- a/kernel/geom/intersect_analytic.go
+++ b/kernel/geom/intersect_analytic.go
@@ -8,6 +8,21 @@ import (
 	"oblikovati.org/math"
 )
 
+// Angular tolerances for the analytic surface-intersection classifier. These compare unit
+// vectors (cosine/sine of the angle between an axis and a plane normal), so they are
+// DIMENSIONLESS and stay absolute — they do not scale with the model. The length tests in
+// this file (clearance/grazing of a plane against a primitive radius) instead derive from a
+// model-relative [Resolution] (res.Weld()), per Oblikovati/Oblikovati#1399.
+const (
+	// axisAlignCosTol classifies axis↔plane-normal alignment: |cos∠| < axisAlignCosTol means
+	// the axis is parallel to the plane (axis ⟂ normal); |cos∠| > 1−axisAlignCosTol means the
+	// axis is perpendicular to the plane (axis ∥ normal). Below this the case is "oblique".
+	axisAlignCosTol = 1e-6
+	// coincidentNormalSinTol treats two plane normals whose cross-product magnitude (the sine
+	// of the angle between them) is below this as parallel/coincident — no isolated section line.
+	coincidentNormalSinTol = 1e-9
+)
+
 // IntersectSurfacesAnalytic returns the EXACT intersection curves of two analytic surfaces
 // for the pairs the curved-face boolean (K1b) relies on: plane∩plane → a line; plane∩
 // cylinder (plane ⟂ axis) → a circle; plane∩sphere → a circle. handled is false for the
@@ -16,30 +31,35 @@ import (
 // [IntersectSurfaceSurface]. An empty result with handled==true means the surfaces are
 // known not to cross (parallel planes, a sphere clear of the plane, a tangent touch).
 //
+// res is the model-relative coincidence scale (Oblikovati/Oblikovati#1399): the clearance
+// and grazing tests that decide "the plane just touches the primitive" use res.Weld() rather
+// than a cm-anchored absolute epsilon, so a µm or km copy of the same part classifies the
+// same way. Build it from the operands' bounding box: geom.ResolutionForBox(box).
+//
 // Returning exact curves (a real circle, not a 64-gon) is what lets a drilled hole be a
 // single cylindrical face with a stable reference key, rather than faceted soup.
-func IntersectSurfacesAnalytic(a, b Surface) (curves []Curve3, handled bool) {
+func IntersectSurfacesAnalytic(a, b Surface, res Resolution) (curves []Curve3, handled bool) {
 	if pl, ok := a.(Plane); ok {
-		return intersectPlaneSurface(pl, b)
+		return intersectPlaneSurface(pl, b, res)
 	}
 	if pl, ok := b.(Plane); ok {
-		return intersectPlaneSurface(pl, a)
+		return intersectPlaneSurface(pl, a, res)
 	}
 	return nil, false
 }
 
-func intersectPlaneSurface(pl Plane, other Surface) ([]Curve3, bool) {
+func intersectPlaneSurface(pl Plane, other Surface, res Resolution) ([]Curve3, bool) {
 	switch o := other.(type) {
 	case Plane:
 		return planePlaneCurve(pl, o)
 	case Cylinder:
-		return planeCylinderCurve(pl, o)
+		return planeCylinderCurve(pl, o, res)
 	case Sphere:
-		return planeSphereCurve(pl, o)
+		return planeSphereCurve(pl, o, res)
 	case Cone:
-		return planeConeCurve(pl, o)
+		return planeConeCurve(pl, o, res)
 	case Torus:
-		return planeTorusCurve(pl, o)
+		return planeTorusCurve(pl, o, res)
 	default:
 		return nil, false
 	}
@@ -50,23 +70,23 @@ func intersectPlaneSurface(pl Plane, other Surface) ([]Curve3, bool) {
 // plane clears or grazes the tube (|d|≥r). An OBLIQUE or axis-parallel plane cuts a quartic SPIRIC curve
 // (no analytic conic), so it is not solved here — handled=false defers it to the CSG fallback. Returned
 // outer first, then inner — both anchored to the torus Ref so their seam lines up with the band.
-func planeTorusCurve(pl Plane, t Torus) ([]Curve3, bool) {
+func planeTorusCurve(pl Plane, t Torus, res Resolution) ([]Curve3, bool) {
 	n := unitVec3(pl.Normal())
 	axis := t.AxisDir.AsVector()
 	cosA := float64(axis.Dot(n))
-	if stdmath.Abs(cosA) < 1-1e-6 {
+	if stdmath.Abs(cosA) < 1-axisAlignCosTol {
 		// Oblique / axis-parallel: a spiric quartic when it cuts the tube. But a plane that CLEARS the whole
 		// torus (its distance exceeds the torus's reach along n) carries no section — report that (handled,
 		// empty) so a box's far clearing faces compose; only a genuine spiric cut defers to CSG.
 		reach := (t.MajorRadius+t.MinorRadius)*float64(n.Sub(axis.Scale(math.Scalar(cosA))).Length()) + t.MinorRadius*stdmath.Abs(cosA)
-		if stdmath.Abs(float64(t.Center.VectorTo(pl.Origin).Dot(n))) >= reach-1e-9 {
+		if stdmath.Abs(float64(t.Center.VectorTo(pl.Origin).Dot(n))) >= reach-res.Weld() {
 			return nil, true // the plane clears the torus
 		}
 		return nil, false // a spiric quartic cut, not an analytic conic
 	}
 	d := float64(t.Center.VectorTo(pl.Origin).Dot(axis)) // section level along the axis
 	r := t.MinorRadius
-	if stdmath.Abs(d) >= r-1e-9 {
+	if stdmath.Abs(d) >= r-res.Weld() {
 		return nil, true // the plane clears or grazes the tube: no crossing section
 	}
 	half := stdmath.Sqrt(r*r - d*d)
@@ -80,7 +100,7 @@ func planeTorusCurve(pl Plane, t Torus) ([]Curve3, bool) {
 func planePlaneCurve(a, b Plane) ([]Curve3, bool) {
 	na, nb := unitVec3(a.Normal()), unitVec3(b.Normal())
 	dir := na.Cross(nb)
-	if dir.Length() < 1e-9 {
+	if dir.Length() < coincidentNormalSinTol {
 		return nil, true // parallel or coincident: no isolated intersection curve
 	}
 	// A point on both planes (Goldman): p = (da·(nb×dir) + db·(dir×na)) / |dir|².
@@ -101,17 +121,17 @@ func planePlaneCurve(a, b Plane) ([]Curve3, bool) {
 // parallel to the axis — the pair of axis-parallel lines it grazes the cylinder along (none
 // when it clears or is tangent to the cylinder). The axis-parallel pair is what lets a box
 // wall be subtracted from a cylinder exactly (M2 Phase 1, Oblikovati/Oblikovati#1334).
-func planeCylinderCurve(pl Plane, cyl Cylinder) ([]Curve3, bool) {
+func planeCylinderCurve(pl Plane, cyl Cylinder, res Resolution) ([]Curve3, bool) {
 	n := unitVec3(pl.Normal())
 	axis := cyl.AxisDir.AsVector()
 	cosA := float64(axis.Dot(n)) // both unit; |cosA| = cos∠(axis, plane normal)
 	abs := stdmath.Abs(cosA)
-	if abs < 1e-6 { // axis ∥ plane → 0/1/2 lines along the axis
-		return cylinderAxisParallelLines(pl, cyl, n, axis)
+	if abs < axisAlignCosTol { // axis ∥ plane → 0/1/2 lines along the axis
+		return cylinderAxisParallelLines(pl, cyl, n, axis, res)
 	}
 	t := n.Dot(cyl.Origin.VectorTo(pl.Origin)) / axis.Dot(n)
 	center := cyl.Origin.TranslateBy(axis.Scale(t))
-	if abs > 1-1e-6 { // perpendicular → circle
+	if abs > 1-axisAlignCosTol { // perpendicular → circle
 		c, err := NewCircle(center, axis, cyl.Radius)
 		if err != nil {
 			return nil, true
@@ -132,9 +152,9 @@ func planeCylinderCurve(pl Plane, cyl Cylinder) ([]Curve3, bool) {
 // the cylinder: two when the plane cuts inside the radius, none when it clears or is tangent to it
 // (a single tangent line carries no enclosed region, so the half-space cut keeps the cylinder
 // whole). Both lines run along the axis; they are the section edges of a box-wall subtraction.
-func cylinderAxisParallelLines(pl Plane, cyl Cylinder, n, axis math.Vector3) ([]Curve3, bool) {
+func cylinderAxisParallelLines(pl Plane, cyl Cylinder, n, axis math.Vector3, res Resolution) ([]Curve3, bool) {
 	d := float64(n.Dot(pl.Origin.VectorTo(cyl.Origin))) // signed distance of the axis from the plane
-	if stdmath.Abs(d) >= cyl.Radius-1e-9 {
+	if stdmath.Abs(d) >= cyl.Radius-res.Weld() {
 		return nil, true // plane clears or merely touches the cylinder: no line pair
 	}
 	half := stdmath.Sqrt(cyl.Radius*cyl.Radius - d*d) // half-chord of the cross-section
@@ -157,19 +177,19 @@ func cylinderAxisParallelLines(pl Plane, cyl Cylinder, n, axis math.Vector3) ([]
 // lets a box face parallel to the cone axis be subtracted exactly). The intermediate oblique cases
 // (an ellipse, a parabola, or a hyperbola from a plane steeper than the generators but not
 // axis-parallel) are still left to the numeric tracer; a plane through the apex yields a point.
-func planeConeCurve(pl Plane, cone Cone) ([]Curve3, bool) {
+func planeConeCurve(pl Plane, cone Cone, res Resolution) ([]Curve3, bool) {
 	n := unitVec3(pl.Normal())
 	axis := cone.AxisDir.AsVector()
 	along := stdmath.Abs(float64(axis.Dot(n)))
-	if along < 1e-6 { // plane ∥ axis → hyperbola
-		return coneAxisParallelHyperbola(pl, cone, n, axis)
+	if along < axisAlignCosTol { // plane ∥ axis → hyperbola
+		return coneAxisParallelHyperbola(pl, cone, n, axis, res)
 	}
-	if along < 1-1e-6 { // oblique → ellipse / hyperbola (parabolic boundary deferred inside)
+	if along < 1-axisAlignCosTol { // oblique → ellipse / hyperbola (parabolic boundary deferred inside)
 		return coneObliqueConic(pl, cone, n, axis)
 	}
 	t := n.Dot(cone.Apex.VectorTo(pl.Origin)) / axis.Dot(n)
 	r := stdmath.Abs(float64(t)) * stdmath.Tan(cone.HalfAngle)
-	if r < 1e-9 { // plane through the apex
+	if r < res.Weld() { // plane through the apex
 		return nil, true
 	}
 	center := cone.Apex.TranslateBy(axis.Scale(t))
@@ -186,9 +206,9 @@ func planeConeCurve(pl Plane, cone Cone) ([]Curve3, bool) {
 // along the axis (the branch climbs the cone as v=A·coshθ grows), conjugate semi B = |D| along
 // a×n. Its centre sits at the foot of the apex on the plane, Apex + D·n. A plane through the apex
 // (D≈0, the two coincident generators) is degenerate and deferred.
-func coneAxisParallelHyperbola(pl Plane, cone Cone, n, axis math.Vector3) ([]Curve3, bool) {
+func coneAxisParallelHyperbola(pl Plane, cone Cone, n, axis math.Vector3, res Resolution) ([]Curve3, bool) {
 	d := float64(n.Dot(cone.Apex.VectorTo(pl.Origin)))
-	if stdmath.Abs(d) < 1e-9 {
+	if stdmath.Abs(d) < res.Weld() {
 		return nil, false // plane through the apex/axis: two coincident generators, not a hyperbola
 	}
 	conjugate := axis.Cross(n)
@@ -203,10 +223,10 @@ func coneAxisParallelHyperbola(pl Plane, cone Cone, n, axis math.Vector3) ([]Cur
 
 // planeSphereCurve returns the circle where a plane cuts a sphere (empty when the plane
 // misses or merely touches the sphere).
-func planeSphereCurve(pl Plane, sp Sphere) ([]Curve3, bool) {
+func planeSphereCurve(pl Plane, sp Sphere, res Resolution) ([]Curve3, bool) {
 	n := unitVec3(pl.Normal())
 	d := float64(n.Dot(pl.Origin.VectorTo(sp.Center))) // signed distance, center to plane
-	if stdmath.Abs(d) >= sp.Radius-1e-9 {
+	if stdmath.Abs(d) >= sp.Radius-res.Weld() {
 		return nil, true // clear of, or tangent to, the plane: no circle
 	}
 	r := stdmath.Sqrt(sp.Radius*sp.Radius - d*d)

--- a/kernel/geom/intersect_analytic.go
+++ b/kernel/geom/intersect_analytic.go
@@ -17,10 +17,10 @@ const (
 	// axisAlignCosTol classifies axis↔plane-normal alignment: |cos∠| < axisAlignCosTol means
 	// the axis is parallel to the plane (axis ⟂ normal); |cos∠| > 1−axisAlignCosTol means the
 	// axis is perpendicular to the plane (axis ∥ normal). Below this the case is "oblique".
-	axisAlignCosTol = 1e-6
+	axisAlignCosTol = 1e-6 // tol:angular — cosine of the axis↔normal angle
 	// coincidentNormalSinTol treats two plane normals whose cross-product magnitude (the sine
 	// of the angle between them) is below this as parallel/coincident — no isolated section line.
-	coincidentNormalSinTol = 1e-9
+	coincidentNormalSinTol = 1e-9 // tol:angular — sine of the angle between unit normals
 )
 
 // IntersectSurfacesAnalytic returns the EXACT intersection curves of two analytic surfaces

--- a/kernel/geom/intersect_analytic_scale_test.go
+++ b/kernel/geom/intersect_analytic_scale_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// The analytic surface-intersection classifier must be SCALE-EQUIVARIANT
+// (Oblikovati/Oblikovati#1399): a plane that cuts a fixed RELATIVE depth into a sphere has to
+// classify the same way — section circle vs. grazing miss — at every model scale, because the
+// clearance test now derives its tolerance from a model-relative Resolution rather than a
+// cm-anchored absolute epsilon. With the old absolute 1e-9 a sub-resolution graze stayed a
+// graze on a unit part but flipped into a spurious tiny circle on a km-scale copy; with the
+// relative tolerance the result topology is invariant under uniform scaling.
+func TestAnalyticIntersectionScaleEquivariant(t *testing.T) {
+	scales := []float64{1, 1e3, 1e6}
+	cases := []struct {
+		name       string
+		depthFrac  float64 // plane inset below the sphere surface, as a fraction of the radius
+		wantCurves int
+	}{
+		// A real, model-scale cut yields a section circle at every scale.
+		{"deep cut keeps its section circle", 0.1, 1},
+		// A cut shallower than the model resolution is a graze at every scale — it must NOT
+		// materialise a sub-resolution circle on the large copy (the absolute-epsilon bug).
+		{"sub-resolution cut grazes at every scale", 2e-10, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, k := range scales {
+				radius := k
+				res := ResolutionForSize(2 * radius) // bbox-diameter scale of the operand
+				inset := tc.depthFrac * radius
+				sp, err := NewSphere(math.P3(0, 0, 0), math.Scalar(radius))
+				if err != nil {
+					t.Fatalf("NewSphere(r=%g): %v", radius, err)
+				}
+				pl := mustPlane(t, 0, 0, radius-inset, 0, 0, 1)
+				curves, ok := IntersectSurfacesAnalytic(pl, sp, res)
+				if !ok {
+					t.Fatalf("scale %g: handled=false, want handled", k)
+				}
+				if len(curves) != tc.wantCurves {
+					t.Errorf("scale %g: got %d section curve(s), want %d (scale-equivariance broken)",
+						k, len(curves), tc.wantCurves)
+				}
+			}
+		})
+	}
+}
+
+// The grazing classification at large scale is exactly where a cm-anchored epsilon misbehaves:
+// pin the boundary so a regression to an absolute literal is caught. At km scale a cut 2e-4 cm
+// deep (2e-10 relative) sits far below the model weld (~2e-3 cm) and must be a graze, while the
+// same absolute depth on a unit part (well above its 2e-9 weld) is a genuine section circle.
+func TestAnalyticGrazeIsRelativeNotAbsolute(t *testing.T) {
+	// Unit part, absolute cut depth 2e-4 cm → above the unit weld → a real circle.
+	unit, _ := NewSphere(math.P3(0, 0, 0), 1)
+	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 1-2e-4, 0, 0, 1), unit, ResolutionForSize(2))
+	if !ok || len(curves) != 1 {
+		t.Fatalf("unit sphere, 2e-4 cm cut: got %d curves ok=%v, want one section circle", len(curves), ok)
+	}
+	// km part, SAME absolute 2e-4 cm cut → far below the km weld → a graze (no circle). An
+	// absolute-epsilon classifier would wrongly report a section circle here.
+	km, _ := NewSphere(math.P3(0, 0, 0), 1e6)
+	curves, ok = IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 1e6-2e-4, 0, 0, 1), km, ResolutionForSize(2e6))
+	if !ok || len(curves) != 0 {
+		t.Fatalf("km sphere, 2e-4 cm cut: got %d curves ok=%v, want a graze with no curve", len(curves), ok)
+	}
+}

--- a/kernel/geom/intersect_analytic_test.go
+++ b/kernel/geom/intersect_analytic_test.go
@@ -22,7 +22,7 @@ func mustPlane(t *testing.T, ox, oy, oz, nx, ny, nz float64) Plane {
 // radius.
 func TestAnalyticPlaneCylinderIsCircle(t *testing.T) {
 	cyl, _ := NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2)
-	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 0, 0, 0, 1), cyl)
+	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 0, 0, 0, 1), cyl, ResolutionForSize(1))
 	if !ok || len(curves) != 1 {
 		t.Fatalf("plane∩cylinder = %v ok=%v, want one curve", curves, ok)
 	}
@@ -35,7 +35,7 @@ func TestAnalyticPlaneCylinderIsCircle(t *testing.T) {
 // Cutting a plane at z=3 through a sphere of radius 5 gives a circle of radius 4.
 func TestAnalyticPlaneSphereSmallCircle(t *testing.T) {
 	sp, _ := NewSphere(math.P3(0, 0, 0), 5)
-	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 3, 0, 0, 1), sp)
+	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 3, 0, 0, 1), sp, ResolutionForSize(1))
 	if !ok || len(curves) != 1 {
 		t.Fatalf("plane∩sphere = %v ok=%v, want one curve", curves, ok)
 	}
@@ -48,7 +48,7 @@ func TestAnalyticPlaneSphereSmallCircle(t *testing.T) {
 // A plane clear of the sphere is handled with no curve (not a fallback).
 func TestAnalyticPlaneSphereMiss(t *testing.T) {
 	sp, _ := NewSphere(math.P3(0, 0, 0), 5)
-	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 10, 0, 0, 1), sp)
+	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 10, 0, 0, 1), sp, ResolutionForSize(1))
 	if !ok || len(curves) != 0 {
 		t.Errorf("plane clear of sphere = %v ok=%v, want handled with no curve", curves, ok)
 	}
@@ -56,7 +56,7 @@ func TestAnalyticPlaneSphereMiss(t *testing.T) {
 
 // Two planes meet in a line; argument order does not matter.
 func TestAnalyticPlanePlaneIsLine(t *testing.T) {
-	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 0, 0, 0, 1), mustPlane(t, 0, 0, 0, 1, 0, 0))
+	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 0, 0, 0, 1), mustPlane(t, 0, 0, 0, 1, 0, 0), ResolutionForSize(1))
 	if !ok || len(curves) != 1 {
 		t.Fatalf("plane∩plane = %v ok=%v, want one line", curves, ok)
 	}
@@ -67,7 +67,7 @@ func TestAnalyticPlanePlaneIsLine(t *testing.T) {
 
 // Parallel planes are handled (no intersection curve).
 func TestAnalyticParallelPlanes(t *testing.T) {
-	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 0, 0, 0, 1), mustPlane(t, 0, 0, 5, 0, 0, 1))
+	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 0, 0, 0, 1), mustPlane(t, 0, 0, 5, 0, 0, 1), ResolutionForSize(1))
 	if !ok || len(curves) != 0 {
 		t.Errorf("parallel planes = %v ok=%v, want handled with no curve", curves, ok)
 	}
@@ -77,7 +77,7 @@ func TestAnalyticParallelPlanes(t *testing.T) {
 // (here the 45° tilt gives cosA = 1/√2, so major = 2√2).
 func TestAnalyticObliquePlaneCylinderIsEllipse(t *testing.T) {
 	cyl, _ := NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2)
-	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 0, 1, 0, 1), cyl)
+	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 0, 1, 0, 1), cyl, ResolutionForSize(1))
 	if !ok || len(curves) != 1 {
 		t.Fatalf("oblique plane∩cylinder = %v ok=%v, want one ellipse", curves, ok)
 	}
@@ -91,7 +91,7 @@ func TestAnalyticObliquePlaneCylinderIsEllipse(t *testing.T) {
 // pair of axis-parallel lines (the section edges of a box-wall subtraction).
 func TestAnalyticPlaneParallelToCylinderIsLinePair(t *testing.T) {
 	cyl, _ := NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2)
-	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 0, 1, 0, 0), cyl) // x = 0
+	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 0, 1, 0, 0), cyl, ResolutionForSize(1)) // x = 0
 	if !ok || len(curves) != 2 {
 		t.Fatalf("plane∥axis through center = %v ok=%v, want two lines", curves, ok)
 	}
@@ -110,7 +110,7 @@ func TestAnalyticPlaneParallelToCylinderIsLinePair(t *testing.T) {
 // region: handled, with no curves, so the half-space cut keeps the cylinder whole.
 func TestAnalyticPlaneParallelClearsCylinder(t *testing.T) {
 	cyl, _ := NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2)
-	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 3, 0, 0, 1, 0, 0), cyl) // x = 3, radius 2
+	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 3, 0, 0, 1, 0, 0), cyl, ResolutionForSize(1)) // x = 3, radius 2
 	if !ok || len(curves) != 0 {
 		t.Errorf("plane clear of the cylinder = %v ok=%v, want handled with no curves", curves, ok)
 	}
@@ -119,7 +119,7 @@ func TestAnalyticPlaneParallelClearsCylinder(t *testing.T) {
 // A plane perpendicular to a cone's axis cuts a circle of radius distance×tan(halfAngle).
 func TestAnalyticPlaneConeIsCircle(t *testing.T) {
 	cone, _ := NewCone(math.P3(0, 0, 0), math.V3(0, 0, 1), stdmath.Pi/4) // tan 45° = 1
-	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 3, 0, 0, 1), cone)
+	curves, ok := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 3, 0, 0, 1), cone, ResolutionForSize(1))
 	if !ok || len(curves) != 1 {
 		t.Fatalf("plane∩cone = %v ok=%v, want one circle", curves, ok)
 	}
@@ -132,7 +132,7 @@ func TestAnalyticPlaneConeIsCircle(t *testing.T) {
 // Argument order is symmetric (cylinder first).
 func TestAnalyticOrderIndependent(t *testing.T) {
 	cyl, _ := NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2)
-	curves, ok := IntersectSurfacesAnalytic(cyl, mustPlane(t, 0, 0, 0, 0, 0, 1))
+	curves, ok := IntersectSurfacesAnalytic(cyl, mustPlane(t, 0, 0, 0, 0, 0, 1), ResolutionForSize(1))
 	if !ok || len(curves) != 1 {
 		t.Errorf("cylinder∩plane (swapped) = %v ok=%v, want one circle", curves, ok)
 	}
@@ -142,7 +142,7 @@ func TestAnalyticOrderIndependent(t *testing.T) {
 // and inner R−√(r²−d²)); an oblique plane that cuts the tube is a spiric quartic, deferred (handled=false).
 func TestAnalyticPlaneTorusPerpendicularIsTwoCircles(t *testing.T) {
 	tor, _ := NewTorus(math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2)
-	curves, handled := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 1, 0, 0, 1), tor) // perpendicular at z=1
+	curves, handled := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 1, 0, 0, 1), tor, ResolutionForSize(1)) // perpendicular at z=1
 	if !handled || len(curves) != 2 {
 		t.Fatalf("perpendicular torus cut: handled=%v, %d curves; want 2 circles", handled, len(curves))
 	}
@@ -160,14 +160,14 @@ func TestAnalyticPlaneTorusPerpendicularIsTwoCircles(t *testing.T) {
 
 func TestAnalyticPlaneTorusObliqueDefers(t *testing.T) {
 	tor, _ := NewTorus(math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2)
-	if _, handled := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 0, 1, 0, 1), tor); handled {
+	if _, handled := IntersectSurfacesAnalytic(mustPlane(t, 0, 0, 0, 1, 0, 1), tor, ResolutionForSize(1)); handled {
 		t.Error("an oblique torus cut (a spiric quartic) must defer, got handled=true")
 	}
 }
 
 func TestAnalyticPlaneTorusClearsIsEmpty(t *testing.T) {
 	tor, _ := NewTorus(math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 2)
-	curves, handled := IntersectSurfacesAnalytic(mustPlane(t, 20, 0, 0, 1, 0, 0), tor) // axis-parallel, far clear
+	curves, handled := IntersectSurfacesAnalytic(mustPlane(t, 20, 0, 0, 1, 0, 0), tor, ResolutionForSize(1)) // axis-parallel, far clear
 	if !handled || len(curves) != 0 {
 		t.Errorf("a plane clearing the torus must be handled with no curves, got handled=%v n=%d", handled, len(curves))
 	}

--- a/kernel/geom/intersect_cone_hyperbola_test.go
+++ b/kernel/geom/intersect_cone_hyperbola_test.go
@@ -21,7 +21,7 @@ func TestPlaneConeAxisParallelHyperbola(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewPlane: %v", err)
 	}
-	curves, handled := IntersectSurfacesAnalytic(pl, cone)
+	curves, handled := IntersectSurfacesAnalytic(pl, cone, ResolutionForSize(1))
 	if !handled || len(curves) != 1 {
 		t.Fatalf("imprint handled=%v curves=%d, want handled=true with one curve", handled, len(curves))
 	}
@@ -48,7 +48,7 @@ func TestPlaneConeAxisParallelHyperbola(t *testing.T) {
 func TestPlaneConeThroughApexDeferred(t *testing.T) {
 	cone, _ := NewCone(math.P3(0, 0, 0), math.V3(0, 0, 1), stdmath.Pi/6)
 	pl, _ := NewPlane(math.P3(0, 0, 0), math.V3(0, 1, 0)) // contains the apex and the axis
-	if _, handled := IntersectSurfacesAnalytic(pl, cone); handled {
+	if _, handled := IntersectSurfacesAnalytic(pl, cone, ResolutionForSize(1)); handled {
 		t.Error("plane through the apex should defer (handled=false)")
 	}
 }

--- a/kernel/geom/intersect_cone_oblique_test.go
+++ b/kernel/geom/intersect_cone_oblique_test.go
@@ -15,7 +15,7 @@ import (
 func TestPlaneConeObliqueEllipse(t *testing.T) {
 	cone, _ := NewCone(math.P3(0, 0, 0), math.V3(0, 0, 1), stdmath.Pi/6) // α = 30°
 	pl, _ := NewPlane(math.P3(0, 0, 5), math.V3(1, 0, 1))                // tilt 45° > 30° → ellipse on the +z nappe
-	curves, handled := IntersectSurfacesAnalytic(pl, cone)
+	curves, handled := IntersectSurfacesAnalytic(pl, cone, ResolutionForSize(1))
 	if !handled || len(curves) != 1 {
 		t.Fatalf("imprint handled=%v curves=%d, want one curve", handled, len(curves))
 	}
@@ -36,7 +36,7 @@ func TestPlaneConeObliqueEllipse(t *testing.T) {
 func TestPlaneConeObliqueHyperbola(t *testing.T) {
 	cone, _ := NewCone(math.P3(0, 0, 0), math.V3(0, 0, 1), stdmath.Pi/3) // α = 60°, steep cone
 	pl, _ := NewPlane(math.P3(3, 0, 0), math.V3(1, 0, 0.6))              // tilt ~31° < 60° → hyperbola
-	curves, handled := IntersectSurfacesAnalytic(pl, cone)
+	curves, handled := IntersectSurfacesAnalytic(pl, cone, ResolutionForSize(1))
 	if !handled || len(curves) != 1 {
 		t.Fatalf("imprint handled=%v curves=%d, want one curve", handled, len(curves))
 	}
@@ -59,7 +59,7 @@ func TestPlaneConeParabola(t *testing.T) {
 	a := stdmath.Atan(0.3)
 	cone, _ := NewCone(math.P3(0, 0, 0), math.V3(stdmath.Sin(a), 0, stdmath.Cos(a)), a)
 	pl, _ := NewPlane(math.P3(2, 0, 0), math.V3(1, 0, 0)) // x=2, parallel to the vertical generator
-	curves, handled := IntersectSurfacesAnalytic(pl, cone)
+	curves, handled := IntersectSurfacesAnalytic(pl, cone, ResolutionForSize(1))
 	if !handled || len(curves) != 1 {
 		t.Fatalf("imprint handled=%v curves=%d, want one curve", handled, len(curves))
 	}
@@ -76,7 +76,7 @@ func TestPlaneConeParabola(t *testing.T) {
 func TestPlaneConeObliqueThroughApexDeferred(t *testing.T) {
 	cone, _ := NewCone(math.P3(0, 0, 0), math.V3(0, 0, 1), stdmath.Pi/6)
 	pl, _ := NewPlane(math.P3(0, 0, 0), math.V3(1, 0, 1)) // oblique AND through the apex
-	if _, handled := IntersectSurfacesAnalytic(pl, cone); handled {
+	if _, handled := IntersectSurfacesAnalytic(pl, cone, ResolutionForSize(1)); handled {
 		t.Error("oblique plane through the apex should defer (handled=false)")
 	}
 }
@@ -86,7 +86,7 @@ func TestPlaneConeObliqueThroughApexDeferred(t *testing.T) {
 func TestPlaneConeObliqueHyperbolaOtherSide(t *testing.T) {
 	cone, _ := NewCone(math.P3(0, 0, 0), math.V3(0, 0, 1), stdmath.Pi/3)
 	pl, _ := NewPlane(math.P3(-3, 0, 0), math.V3(1, 0, -0.6)) // mirror of the +x hyperbola case
-	curves, handled := IntersectSurfacesAnalytic(pl, cone)
+	curves, handled := IntersectSurfacesAnalytic(pl, cone, ResolutionForSize(1))
 	if !handled || len(curves) != 1 {
 		t.Fatalf("imprint handled=%v curves=%d, want one curve", handled, len(curves))
 	}

--- a/kernel/geom/intersect_surface_trace.go
+++ b/kernel/geom/intersect_surface_trace.go
@@ -26,13 +26,13 @@ const (
 	// nearly — but not exactly — parallel: too strict a value (e.g. 1−1e-10) lets the corrector treat a
 	// point a hair off the contact as a real crossing and emit a spurious tiny curve there. 1−1e-5
 	// corresponds to crossings shallower than ~0.18°, which are tangencies for all practical purposes.
-	ssiTangencyCos = 1 - 1e-5
+	ssiTangencyCos = 1 - 1e-5 // tol:angular — surface-normal alignment cosine at a tangency
 	// ssiToleranceFraction and ssiStepFraction scale the on-curve tolerance and the march step to the
 	// base patch's 3D extent (so both are model-relative, ADR-0042). 1e-7 is the stated acceptance
 	// tolerance reachable by the NURBS Gauss–Newton projection; 4e-3 keeps a full curve to a few
 	// thousand points while resolving curvature.
-	ssiToleranceFraction = 1e-7
-	ssiStepFraction      = 4e-3
+	ssiToleranceFraction = 1e-7 // tol:numeric — dimensionless fraction of the patch 3D extent (model-relative)
+	ssiStepFraction      = 4e-3 // tol:numeric — dimensionless fraction of the patch 3D extent (model-relative)
 	// Step multiples used while marching: a seed within ssiDedupSteps of an existing curve is a
 	// duplicate of it; the loop closes when the march returns within ssiLoopCloseSteps of its start;
 	// a tangency seed may sit up to ssiTangencyGapSteps from the contact (the strict normal test, not
@@ -243,8 +243,8 @@ func refineTangency(base, other Surface, p math.Point3, tol float64) (math.Point
 // point exactly on the boundary still counts).
 func inWindow(base Surface, pc math.Point3, g SurfaceGrid) bool {
 	u, v, _ := ProjectPointToSurface(base, pc)
-	mu := (g.UMax - g.UMin) * 1e-9
-	mv := (g.VMax - g.VMin) * 1e-9
+	mu := (g.UMax - g.UMin) * 1e-9 // tol:parametric — fraction of the u-window
+	mv := (g.VMax - g.VMin) * 1e-9 // tol:parametric — fraction of the v-window
 	return u >= g.UMin-mu && u <= g.UMax+mu && v >= g.VMin-mv && v <= g.VMax+mv
 }
 

--- a/kernel/geom/intersect_surface_trace_test.go
+++ b/kernel/geom/intersect_surface_trace_test.go
@@ -117,7 +117,7 @@ func TestSSINurbsPatchCutByPlane(t *testing.T) {
 func TestSSIAgreesWithAnalyticOnSpherePlane(t *testing.T) {
 	sp, _ := NewSphere(math.P3(0, 0, 0), 5)
 	pl, _ := NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
-	curves, handled := IntersectSurfacesAnalytic(sp, pl)
+	curves, handled := IntersectSurfacesAnalytic(sp, pl, ResolutionForSize(1))
 	if !handled || len(curves) == 0 {
 		t.Skip("analytic path did not handle sphere∩plane")
 	}

--- a/kernel/geom/network_surface.go
+++ b/kernel/geom/network_surface.go
@@ -16,10 +16,6 @@ import (
 // u). With dense curves this passes through the curves within tolerance; degenerate / non-intersecting
 // input is a clear error (CLAUDE.md exception rule).
 
-// networkGapTol is how far a U- and V-curve crossing may be apart (model units) before the network is
-// rejected as non-intersecting.
-const networkGapTol = 1e-3
-
 // NetworkSurface interpolates the grid formed by uCurves (each spanning the u-direction at a v-station)
 // and vCurves (each spanning v at a u-station). It needs ≥2 curves each way. It errors when a U/V
 // crossing gap exceeds networkGapTol (the curves do not form a usable grid).
@@ -41,6 +37,7 @@ func NetworkSurface(uCurves, vCurves []BSplineCurve) (BSplineSurface, error) {
 // crossing is farther apart than networkGapTol.
 func networkGrid(uCurves, vCurves []BSplineCurve) ([][]math.Point3, error) {
 	nu, nv := len(vCurves), len(uCurves)
+	gapTol := networkGapTol(uCurves, vCurves)
 	grid := make([][]math.Point3, nu)
 	for a := 0; a < nu; a++ {
 		grid[a] = make([]math.Point3, nv)
@@ -49,13 +46,28 @@ func networkGrid(uCurves, vCurves []BSplineCurve) ([][]math.Point3, error) {
 			vs := float64(b) / float64(nv-1)
 			pu := uCurves[b].PointAt(us) // u-curve b at u-station a
 			pv := vCurves[a].PointAt(vs) // v-curve a at v-station b
-			if d := float64(pu.DistanceTo(pv)); d > networkGapTol {
-				return nil, fmt.Errorf("geom.NetworkSurface: curves do not intersect at grid node (%d,%d): gap %.4g > %.4g", a, b, d, networkGapTol)
+			if d := float64(pu.DistanceTo(pv)); d > gapTol {
+				return nil, fmt.Errorf("geom.NetworkSurface: curves do not intersect at grid node (%d,%d): gap %.4g > %.4g", a, b, d, gapTol)
 			}
 			grid[a][b] = pu.Midpoint(pv)
 		}
 	}
 	return grid, nil
+}
+
+// networkGapTol is the model-relative gap (#1399) a U- and V-curve crossing may span before the
+// network is rejected as non-intersecting: derived from the network's own extent (the curve
+// endpoints) so the generous "close enough to form a grid" threshold scales with the part instead
+// of a cm-anchored 1e-3.
+func networkGapTol(uCurves, vCurves []BSplineCurve) float64 {
+	pts := make([]math.Point3, 0, 2*(len(uCurves)+len(vCurves)))
+	for _, c := range uCurves {
+		pts = append(pts, c.PointAt(0), c.PointAt(1))
+	}
+	for _, c := range vCurves {
+		pts = append(pts, c.PointAt(0), c.PointAt(1))
+	}
+	return ResolutionForPoints(pts).Sew()
 }
 
 // globalInterpSurface tensor-interpolates a bicubic B-spline through the nu×nv point grid (A9.7):

--- a/kernel/geom/trace_surface_zero.go
+++ b/kernel/geom/trace_surface_zero.go
@@ -27,7 +27,6 @@ type SurfaceGrid struct {
 const (
 	traceDefaultSteps = 96
 	traceBisectIter   = 48
-	traceChainTol     = 1e-7
 )
 
 // resolveGrid fills a SurfaceGrid's zero/absent fields from the surface's finite domain
@@ -134,7 +133,7 @@ func straddlesZero(a, b float64) bool {
 
 // traceFieldEps is the field magnitude treated as exactly zero (fields here are
 // unit-vector dots, so 1e-12 is far below any genuine sample).
-const traceFieldEps = 1e-12
+const traceFieldEps = 1e-12 // tol:numeric — unit-vector-dot field magnitude treated as zero
 
 func snapTinyToZero(v float64) float64 {
 	if stdmath.Abs(v) < traceFieldEps {
@@ -171,6 +170,7 @@ func lerp(a, b, t float64) float64 { return a + (b-a)*t }
 // shared endpoints within tolerance.
 func chainSegments3D(segs []gridSeg) [][]math.Point3 {
 	used := make([]bool, len(segs))
+	tol := segChainTol(segs) // model-relative endpoint-coincidence tolerance (#1399)
 	var out [][]math.Point3
 	for i := range segs {
 		if used[i] {
@@ -178,18 +178,29 @@ func chainSegments3D(segs []gridSeg) [][]math.Point3 {
 		}
 		used[i] = true
 		poly := []math.Point3{segs[i].a, segs[i].b}
-		growPolyline(segs, used, &poly)
+		growPolyline(segs, used, &poly, tol)
 		out = append(out, poly)
 	}
 	return out
 }
 
+// segChainTol is the model-relative tolerance for chaining marching-squares segments end-to-end
+// (#1399): derived from the traced segments' own 3D extent (≈ the surface's size) so a km-scale
+// silhouette/isophote still chains instead of fragmenting under a cm-anchored 1e-7.
+func segChainTol(segs []gridSeg) float64 {
+	pts := make([]math.Point3, 0, 2*len(segs))
+	for _, s := range segs {
+		pts = append(pts, s.a, s.b)
+	}
+	return ResolutionForPoints(pts).Plane()
+}
+
 // growPolyline extends a polyline from its tail by attaching unused segments that share
 // the free endpoint (forward only; marching-squares contours are locally 1-manifold).
-func growPolyline(segs []gridSeg, used []bool, poly *[]math.Point3) {
+func growPolyline(segs []gridSeg, used []bool, poly *[]math.Point3, tol float64) {
 	for {
 		tail := (*poly)[len(*poly)-1]
-		j, far, ok := nextSegment(segs, used, tail)
+		j, far, ok := nextSegment(segs, used, tail, tol)
 		if !ok {
 			return
 		}
@@ -199,15 +210,15 @@ func growPolyline(segs []gridSeg, used []bool, poly *[]math.Point3) {
 }
 
 // nextSegment finds an unused segment with an endpoint coincident with tail.
-func nextSegment(segs []gridSeg, used []bool, tail math.Point3) (int, math.Point3, bool) {
+func nextSegment(segs []gridSeg, used []bool, tail math.Point3, tol float64) (int, math.Point3, bool) {
 	for j := range segs {
 		if used[j] {
 			continue
 		}
 		switch {
-		case tail.IsEqualTo(segs[j].a, traceChainTol):
+		case tail.IsEqualTo(segs[j].a, tol):
 			return j, segs[j].b, true
-		case tail.IsEqualTo(segs[j].b, traceChainTol):
+		case tail.IsEqualTo(segs[j].b, tol):
 			return j, segs[j].a, true
 		}
 	}

--- a/kernel/ops/closed_band_loft.go
+++ b/kernel/ops/closed_band_loft.go
@@ -75,9 +75,10 @@ func bandRingsAndSeam(f *topo.Face, q Quality) (rings [][]math.Point3, seamN int
 	return rings, seamN, seamMid, ok
 }
 
-// dropClosingDup removes the trailing point a closed-edge tessellation repeats at its seam.
+// dropClosingDup removes the trailing point a closed-edge tessellation repeats at its seam. The
+// duplicate threshold is model-relative (ADR-0042, #1399), scaling with the ring's extent.
 func dropClosingDup(pts []math.Point3) []math.Point3 {
-	if len(pts) > 1 && pts[0].DistanceTo(pts[len(pts)-1]) < weldPointTol {
+	if len(pts) > 1 && pts[0].DistanceTo(pts[len(pts)-1]) < ResolutionForPoints(pts).Weld() {
 		return pts[:len(pts)-1]
 	}
 	return pts

--- a/kernel/ops/closed_band_loft.go
+++ b/kernel/ops/closed_band_loft.go
@@ -193,7 +193,7 @@ func zipUnequalRows(m *Mesh, a, b bandRow) {
 		evs = append(evs, event{b.ang[i], v, false})
 	}
 	sort.SliceStable(evs, func(i, j int) bool {
-		if stdmath.Abs(evs[i].ang-evs[j].ang) > 1e-9 {
+		if stdmath.Abs(evs[i].ang-evs[j].ang) > 1e-9 { // tol:angular — azimuth (radians) tie-break
 			return evs[i].ang < evs[j].ang
 		}
 		return evs[i].isA && !evs[j].isA // break ties A-before-B so an aligned pair makes a clean quad

--- a/kernel/ops/closed_surface_mesh.go
+++ b/kernel/ops/closed_surface_mesh.go
@@ -2,7 +2,10 @@
 
 package ops
 
-import "oblikovati.org/kernel/geom"
+import (
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
 
 // A bare closed surface — a whole sphere imported as ONE face with no seam edge (0 loops) — has no
 // trim to reduce, so it falls to the full-domain grid. A naive UV grid is NOT watertight on a closed
@@ -14,22 +17,41 @@ import "oblikovati.org/kernel/geom"
 // periodic seam, no pole row) it reduces to the plain UV grid. (M25 PBI-330)
 func closedDomainMesh(s geom.Surface, us, vs []float64) *Mesh {
 	cols := len(us)
-	uWrap := cols > 2 && columnsCoincide(s, us[0], us[cols-1], vs)
+	// One model-relative seam/pole weld for this surface (ADR-0042, #1399). Seam columns and pole
+	// rows are coincident BY CONSTRUCTION, so the tolerance cannot come from their own (degenerate)
+	// extent — it is derived from the whole surface's extent, so a km-scale sphere's seam still reads
+	// as coincident instead of cracking under a cm-anchored 1e-9.
+	weld := surfaceGridWeld(s, us, vs)
+	uWrap := cols > 2 && columnsCoincide(s, us[0], us[cols-1], vs, weld)
 	if uWrap {
 		cols-- // the last column repeats the first (the seam); cells wrap onto column 0 instead
 	}
 	m := &Mesh{}
-	poles := poleRowVertices(m, s, us[:cols], vs)
+	poles := poleRowVertices(m, s, us[:cols], vs, weld)
 	idx := closedGridVertices(m, s, us[:cols], vs, poles)
 	emitClosedGrid(m, idx, uWrap)
 	return m
 }
 
-// columnsCoincide reports whether the surface columns at parameters u0 and u1 trace the same points at
-// every v — a periodic seam (u0=0, u1=2π on a sphere/cylinder).
-func columnsCoincide(s geom.Surface, u0, u1 float64, vs []float64) bool {
+// surfaceGridWeld is the surface's model-relative vertex-weld tolerance (#1399): derived from the
+// extent of the parameter-grid boundary (the surface's own size), so seam and pole coincidence tests
+// scale with the body rather than reading a cm-anchored absolute epsilon.
+func surfaceGridWeld(s geom.Surface, us, vs []float64) float64 {
+	pts := make([]math.Point3, 0, 2*len(us)+2*len(vs))
+	for _, u := range us {
+		pts = append(pts, s.PointAt(u, vs[0]), s.PointAt(u, vs[len(vs)-1]))
+	}
 	for _, v := range vs {
-		if s.PointAt(u0, v).DistanceTo(s.PointAt(u1, v)) > weldPointTol {
+		pts = append(pts, s.PointAt(us[0], v), s.PointAt(us[len(us)-1], v))
+	}
+	return ResolutionForPoints(pts).Weld()
+}
+
+// columnsCoincide reports whether the surface columns at parameters u0 and u1 trace the same points at
+// every v — a periodic seam (u0=0, u1=2π on a sphere/cylinder). weld is the surface-relative tolerance.
+func columnsCoincide(s geom.Surface, u0, u1 float64, vs []float64, weld float64) bool {
+	for _, v := range vs {
+		if s.PointAt(u0, v).DistanceTo(s.PointAt(u1, v)) > weld {
 			return false
 		}
 	}
@@ -37,24 +59,25 @@ func columnsCoincide(s geom.Surface, u0, u1 float64, vs []float64) bool {
 }
 
 // poleRowVertices returns, per v-row, a single shared vertex index when that row degenerates to one
-// point (a pole: every column coincides), or -1 for a normal row. Sharing one vertex (not one per
-// column) is what removes the high-degree pole the naive grid produces.
-func poleRowVertices(m *Mesh, s geom.Surface, us, vs []float64) []int {
+// point (a pole: every column coincides within weld), or -1 for a normal row. Sharing one vertex (not
+// one per column) is what removes the high-degree pole the naive grid produces.
+func poleRowVertices(m *Mesh, s geom.Surface, us, vs []float64, weld float64) []int {
 	out := make([]int, len(vs))
 	for j, v := range vs {
 		out[j] = -1
-		if rowIsPole(s, us, v) {
+		if rowIsPole(s, us, v, weld) {
 			out[j] = m.addVertex(s.PointAt(us[0], v), s.NormalAt(us[0], v))
 		}
 	}
 	return out
 }
 
-// rowIsPole reports whether every column of the v-row collapses to one point (a surface pole).
-func rowIsPole(s geom.Surface, us []float64, v float64) bool {
+// rowIsPole reports whether every column of the v-row collapses to one point (a surface pole) within
+// the surface-relative weld tolerance.
+func rowIsPole(s geom.Surface, us []float64, v float64, weld float64) bool {
 	p0 := s.PointAt(us[0], v)
 	for _, u := range us[1:] {
-		if s.PointAt(u, v).DistanceTo(p0) > weldPointTol {
+		if s.PointAt(u, v).DistanceTo(p0) > weld {
 			return false
 		}
 	}

--- a/kernel/ops/deform.go
+++ b/kernel/ops/deform.go
@@ -47,7 +47,7 @@ func DeformBody(b *topo.Body, fn func(math.Point3) math.Point3, derive func(topo
 
 // deformTol is the minimum moved-edge length below which the map is treated as collapsing an
 // edge (a degenerate result the boolean kernel cannot use).
-const deformTol = 1e-9
+const deformTol = 1e-9 // tol:calibrated — collapse guard used as BOTH a moved-edge length and a degenerate-normal magnitude; a clean split is deferred
 
 // deformFaceInto clones one face with a plane re-fitted through its moved outer loop, preserving
 // the face's material sense (a reversed cut/bore wall must stay reversed or its tessellation

--- a/kernel/ops/edge_discretize.go
+++ b/kernel/ops/edge_discretize.go
@@ -71,6 +71,3 @@ func reverse3(pts []math.Point3) []math.Point3 {
 	}
 	return out
 }
-
-// weldPointTol is the distance under which two boundary points are the same vertex.
-const weldPointTol = 1e-9

--- a/kernel/ops/fillet_arc_build.go
+++ b/kernel/ops/fillet_arc_build.go
@@ -117,7 +117,7 @@ func (g *arcBuild) mapUse(f *topo.Face, u *topo.EdgeUse) []topo.Use {
 		})
 	case u.Edge() == af.arcEdge && f == af.cylF:
 		// arc on the cylinder → cyl-tangent arc (vc0→vc1); reversed when the use enters from end 1.
-		rev := useFromVertex(u).Point().DistanceTo(af.ends[1].rimV.Point()) < weldPointTol
+		rev := vertsCoincide(useFromVertex(u).Point(), af.ends[1].rimV.Point())
 		return []topo.Use{{Edge: g.cylTan, Reversed: rev}}
 	case u.Edge() == af.ends[0].smoothLine || u.Edge() == af.ends[1].smoothLine:
 		i := 0
@@ -126,12 +126,19 @@ func (g *arcBuild) mapUse(f *topo.Face, u *topo.EdgeUse) []topo.Use {
 		}
 		if f == af.cylF {
 			// cylinder keeps only the lower segment (vc→bottom); reversed when the use enters from bottom.
-			rev := useFromVertex(u).Point().DistanceTo(af.ends[i].bottomV.Point()) < weldPointTol
+			rev := vertsCoincide(useFromVertex(u).Point(), af.ends[i].bottomV.Point())
 			return []topo.Use{{Edge: g.lower[i], Reversed: rev}}
 		}
 		return orientChain(u, []chainEdge{{g.upper[i], g.verts[af.ends[i].rimV], g.vc[i]}, {g.lower[i], g.vc[i], g.verts[af.ends[i].bottomV]}})
 	}
 	return []topo.Use{{Edge: g.edges[u.Edge()], Reversed: u.Reversed()}}
+}
+
+// vertsCoincide reports whether two fillet vertices are the same point. The tolerance is model-relative
+// (ADR-0042, #1399): for distinct vertices it scales with their separation (so the test stays correct
+// at any scale), and for a coincident pair it floors to the base weld — no cm-anchored constant.
+func vertsCoincide(a, b math.Point3) bool {
+	return a.DistanceTo(b) < ResolutionForPoints([]math.Point3{a, b}).Weld()
 }
 
 // chainEdge is one directed edge of a substitution chain.
@@ -145,7 +152,7 @@ type chainEdge struct {
 // natural start. When the use runs against the chain's overall direction, the whole sequence flips.
 func orientChain(u *topo.EdgeUse, chain []chainEdge) []topo.Use {
 	out := make([]topo.Use, len(chain))
-	forward := useFromVertex(u).Point().DistanceTo(chain[0].from.Point()) < weldPointTol
+	forward := vertsCoincide(useFromVertex(u).Point(), chain[0].from.Point())
 	for i, c := range chain {
 		rev := c.e.StartVertex() != c.from // the edge's natural start differs from the desired start
 		if forward {

--- a/kernel/ops/nurbs_pcurve_mesh.go
+++ b/kernel/ops/nurbs_pcurve_mesh.go
@@ -155,8 +155,8 @@ func concatLoopPcurve(s geom.Surface, l *topo.Loop, q Quality) (uv []math.Point2
 		uv = append(uv, pc...)
 		p3 = append(p3, pts...)
 	}
-	if n := len(p3); n > 1 && p3[0].DistanceTo(p3[n-1]) < weldPointTol {
-		uv, p3 = uv[:n-1], p3[:n-1]
+	if n := len(p3); n > 1 && p3[0].DistanceTo(p3[n-1]) < ResolutionForPoints(p3).Weld() {
+		uv, p3 = uv[:n-1], p3[:n-1] // model-relative loop closure (ADR-0042, #1399)
 	}
 	// Per-edge projection re-seeds a fresh GLOBAL closest point at each edge's start; on a self-proximal
 	// NURBS (the EDF bell-mouth lip) that start can snap to the wrong sheet, so the concatenated (u,v)

--- a/kernel/ops/oriented_box.go
+++ b/kernel/ops/oriented_box.go
@@ -231,7 +231,7 @@ func lessPoint2(a, b math.Point2) bool {
 func dedupePoints2(pts []math.Point2) []math.Point2 {
 	out := pts[:0]
 	for i, p := range pts {
-		if i == 0 || float64(p.DistanceTo(out[len(out)-1])) > 1e-12 {
+		if i == 0 || float64(p.DistanceTo(out[len(out)-1])) > 1e-12 { // tol:numeric — float-noise-level consecutive-point dedup
 			out = append(out, p)
 		}
 	}

--- a/kernel/ops/ruled_surface.go
+++ b/kernel/ops/ruled_surface.go
@@ -213,7 +213,8 @@ func spanSurface(sc spanCorners) (geom.Surface, error) {
 	n := sc.a.VectorTo(sc.b).Cross(sc.a.VectorTo(sc.d))
 	if l := float64(n.Length()); l > 0 {
 		dev := stdmath.Abs(float64(sc.a.VectorTo(sc.c).Dot(n))) / l
-		if dev < 1e-9 {
+		// Coplanarity is model-relative (#1399): scaled by the span corners' own extent.
+		if dev < ResolutionForPoints([]math.Point3{sc.a, sc.b, sc.c, sc.d}).Weld() {
 			return geom.NewPlane(sc.a, n)
 		}
 	}

--- a/kernel/ops/saddle_band_loft.go
+++ b/kernel/ops/saddle_band_loft.go
@@ -160,13 +160,15 @@ func seamEdgesOf(f *topo.Face) map[*topo.Edge]bool {
 }
 
 // dedupRingPoints drops points coincident with an earlier one (the pinch points where two saddle-rim arcs
-// meet appear in both arcs).
+// meet appear in both arcs). The coincidence tolerance is model-relative (ADR-0042, #1399): derived from
+// the ring's own extent so a km-scale band still welds its pinch points instead of cracking.
 func dedupRingPoints(pts []math.Point3) []math.Point3 {
+	weld := ResolutionForPoints(pts).Weld()
 	var out []math.Point3
 	for _, p := range pts {
 		dup := false
 		for _, q := range out {
-			if p.DistanceTo(q) < weldPointTol {
+			if p.DistanceTo(q) < weld {
 				dup = true
 				break
 			}

--- a/kernel/ops/scale_sweep_test.go
+++ b/kernel/ops/scale_sweep_test.go
@@ -112,6 +112,47 @@ func longestVerticalEdge(t *testing.T, b *topo.Body, s float64) []byte {
 	return best
 }
 
+// TestFarFromOriginDrilledPlateWatertight is the far-from-origin arm of the #1399 acceptance
+// gate: a curved boolean run on a part whose coordinates sit far from the origin must stay
+// watertight AND keep the exact analytic path (the hole wall a geom.Cylinder, not a faceted CSG
+// prism). The model-relative weld (ADR-0042) scales with the part's extent, so coincident section
+// points still merge once their separation grows with the coordinate magnitude; a cm-anchored weld
+// would fail to chain the section arcs far out and demote the cut to CSG (no cylinder face).
+//
+// The offsets stay within float64's single-model range (≤ ~1e6 cm, the issue's spec). Beyond ~1e8
+// the coordinate ULP itself exceeds a usable feature tolerance and corrupts the geometry — a
+// working-scale-storage concern (ADR-0042 §Phase 2), orthogonal to #1399's relative tolerances.
+func TestFarFromOriginDrilledPlateWatertight(t *testing.T) {
+	const r = 1.5
+	const wantVol = 20*20*6 - stdmath.Pi*r*r*6 // analytic slab − πr²·thickness
+	for _, off := range []float64{0, 1e4, 1e6} {
+		slab, err := brep.SolidBlock(math.P3(off-10, off-10, 0), math.P3(off+10, off+10, 6), "slab")
+		if err != nil {
+			t.Fatalf("off %g: SolidBlock: %v", off, err)
+		}
+		rod, err := brep.SolidCylinder(math.P3(off, off, -1), math.V3(0, 0, 1), r, 8)
+		if err != nil {
+			t.Fatalf("off %g: SolidCylinder: %v", off, err)
+		}
+		drilled, err := ops.Boolean(ops.Cut, slab, rod)
+		if err != nil {
+			t.Fatalf("off %g: Boolean(Cut): %v", off, err)
+		}
+		if rr := ops.Validate(drilled); !rr.Valid || !rr.Closed || !rr.Manifold || !drilled.IsSolid() {
+			t.Errorf("off %g: drilled plate not a watertight solid: %+v", off, rr)
+		}
+		if len(ops.BoundaryEdges(drilled)) != 0 {
+			t.Errorf("off %g: %d boundary edges, want 0 (watertight)", off, len(ops.BoundaryEdges(drilled)))
+		}
+		if !hasCylinderFace(drilled) {
+			t.Errorf("off %g: hole wall is not an analytic cylinder — the cut demoted to CSG far from origin", off)
+		}
+		if v := ops.BodyGeometryProperties(drilled, ops.DefaultQuality()).Volume; stdmath.Abs(v-wantVol)/wantVol > 0.01 {
+			t.Errorf("off %g: volume %.4f, want %.4f within 1%%", off, v, wantVol)
+		}
+	}
+}
+
 // TestScaleSweepSewDefaultGap checks the sew arm of the gate: Sew's default (tolerance 0) gap
 // is now model-relative (ADR-0042 res.Sew()), so a quilt sews shut at any scale. A box built
 // at each scale is already a solid; re-sewing it must keep it a watertight solid rather than

--- a/kernel/ops/section_plane.go
+++ b/kernel/ops/section_plane.go
@@ -64,19 +64,25 @@ func trianglePlaneSegment(tri [3]math.Point3, n math.Vector3, d float64) ([2]mat
 		f := math.Scalar(s[i] / (s[i] - s[j]))
 		pts = append(pts, tri[i].TranslateBy(tri[i].VectorTo(tri[j]).Scale(f)))
 	}
-	if len(pts) != 2 || float64(pts[0].DistanceTo(pts[1])) < sectionWeldTol {
+	if len(pts) != 2 || float64(pts[0].DistanceTo(pts[1])) < sectionWeld(pts) {
 		return [2]math.Point3{}, false
 	}
 	return [2]math.Point3{pts[0], pts[1]}, true
 }
 
-// sectionWeldTol welds section segment endpoints into chains.
-const sectionWeldTol = 1e-7
+// sectionWeld is the model-relative tolerance (#1399) for welding section segment endpoints into
+// chains, derived from the section points' own extent rather than a cm-anchored grid.
+func sectionWeld(pts []math.Point3) float64 { return ResolutionForPoints(pts).Plane() }
 
 // wiresFromSegments chains loose segments into polyline wires on a fresh
 // wire-only body (shared endpoints welded on a tolerance grid).
 func wiresFromSegments(segs [][2]math.Point3, feat string) (*topo.Body, error) {
-	chains := chainSegments(segs, sectionWeldTol)
+	pts := make([]math.Point3, 0, 2*len(segs))
+	for _, s := range segs {
+		pts = append(pts, s[0], s[1])
+	}
+	weldTol := sectionWeld(pts)
+	chains := chainSegments(segs, weldTol)
 	bld := topo.NewBuilder(false, topo.NewLineage(topo.Tok(feat, "body", 0)))
 	body := bld.Build()
 	for i, chain := range chains {
@@ -86,7 +92,7 @@ func wiresFromSegments(segs [][2]math.Point3, feat string) (*topo.Body, error) {
 		}
 		v0 := bld.AddVertex(chain[0], topo.NewLineage(topo.Tok(feat, "vertex", 2*i)))
 		v1 := v0
-		if float64(chain[0].DistanceTo(chain[len(chain)-1])) > sectionWeldTol {
+		if float64(chain[0].DistanceTo(chain[len(chain)-1])) > weldTol {
 			v1 = bld.AddVertex(chain[len(chain)-1], topo.NewLineage(topo.Tok(feat, "vertex", 2*i+1)))
 		}
 		e := bld.AddEdge(curve, v0, v1, topo.NewLineage(topo.Tok(feat, "edge", i)))
@@ -159,7 +165,7 @@ func FaceSilhouetteWires(f *topo.Face, viewDir math.Vector3, includeBoundary boo
 		return nil, fmt.Errorf("ops: face %d has no silhouette from %v", f.ID(), viewDir)
 	}
 	mesh := TessellateFace(f, q)
-	onTol := stdmath.Max(q.tol(), 1e-6)
+	onTol := stdmath.Max(q.tol(), 1e-6) // tol:calibrated — floors the (already model-relative) quality chord tolerance
 	var segs [][2]math.Point3
 	for _, pl := range loops {
 		segs = append(segs, clipPolylineToFace(pl, mesh, f, onTol, includeBoundary)...)
@@ -240,7 +246,7 @@ func fullFiniteSpan(lo, hi, dLo, dHi float64) bool {
 	if stdmath.IsInf(dLo, 0) || stdmath.IsInf(dHi, 0) || dHi <= dLo {
 		return false
 	}
-	return lo <= dLo+1e-9 && hi >= dHi-1e-9
+	return lo <= dLo+1e-9 && hi >= dHi-1e-9 // tol:parametric — surface-domain bounds
 }
 
 // pointNearFaceBoundary reports whether p hugs one of the face's edges.

--- a/kernel/ops/self_intersect.go
+++ b/kernel/ops/self_intersect.go
@@ -112,7 +112,7 @@ func meshTriangle(m *Mesh, i int) [3]math.Point3 {
 
 // selfIntersectEps keeps grazing contact (faces meeting within numerical noise
 // of each other) from reporting as interpenetration.
-const selfIntersectEps = 1e-9
+const selfIntersectEps = 1e-9 // tol:calibrated — guards an UNNORMALISED plane equation (n·p−d, ~size³); relativising needs normalising by |n| first
 
 // trianglesIntersect is the Möller interval test: T1 must straddle T2's plane
 // and vice versa, and their intervals on the planes' intersection line must

--- a/kernel/ops/sew.go
+++ b/kernel/ops/sew.go
@@ -50,7 +50,7 @@ func Sew(b *topo.Body, tolerance float64) (*topo.Body, error) {
 // sewWeld re-welds every face of b with boundary endpoints snapped to their
 // cluster centers, returning the rebuilt body and the weld (for residuals).
 func sewWeld(b *topo.Body, snap *boundaryClusters) (*topo.Body, *weld) {
-	w := newWeld(defaultStitchTolerance)
+	w := newWeld(ResolutionForBody(b).Plane()) // model-relative coincidence grid (#1399)
 	w.snap = snap.apply
 	for _, f := range b.Faces() {
 		w.addFace(f)
@@ -118,7 +118,7 @@ func clusterCentroids(pts []math.Point3, cluster []int) *boundaryClusters {
 		sums[r] = sums[r].Add(p.AsVector())
 		counts[r]++
 	}
-	bc := &boundaryClusters{grid: defaultStitchTolerance, centers: map[vKey]math.Point3{}}
+	bc := &boundaryClusters{grid: ResolutionForPoints(pts).Plane(), centers: map[vKey]math.Point3{}} // model-relative (#1399)
 	for i, p := range pts {
 		r := find(cluster, i)
 		c := sums[r].Scale(math.Scalar(1 / float64(counts[r]))).AsPoint()

--- a/kernel/ops/stitch.go
+++ b/kernel/ops/stitch.go
@@ -13,9 +13,6 @@ import (
 	stdmath "math"
 )
 
-// defaultStitchTolerance is the coincidence grid used when a feature passes 0.
-const defaultStitchTolerance = 1e-7
-
 // Stitch welds independently-built surface bodies into one quilt by exact-coincidence
 // matching: vertices that quantize to the same tolerance grid cell become one, and
 // the boundary edges they share are merged so each is used by both faces. When every
@@ -29,7 +26,7 @@ func Stitch(bodies []*topo.Body, tolerance float64, maintainSurface bool, feat s
 	}
 	tol := tolerance
 	if tol <= 0 {
-		tol = defaultStitchTolerance
+		tol = ResolutionForBodies(bodies...).Plane() // model-relative default coincidence grid (#1399)
 	}
 	w := newWeld(tol)
 	for _, b := range bodies {

--- a/kernel/ops/tolerance_guard_test.go
+++ b/kernel/ops/tolerance_guard_test.go
@@ -34,8 +34,12 @@ func TestNoUnjustifiedAbsoluteEpsilons(t *testing.T) {
 	// In-scope hot-path files (relative to this package dir, kernel/ops). Kept explicit rather than
 	// globbed so widening the guard's reach is a deliberate, reviewable act.
 	scope := []string{
-		// geom: the analytic + numeric surface-intersection classifiers.
+		// geom: the analytic + numeric surface-intersection classifiers and the SSI tracer.
 		"../geom/intersect_analytic.go",
+		"../geom/intersect2d.go",
+		"../geom/intersect_surface_trace.go",
+		"../geom/trace_surface_zero.go",
+		"../geom/network_surface.go",
 		// brep: the curved-boolean weld / imprint / half-space machinery.
 		"../brep/curved_halfspace_general.go",
 		"../brep/curved_halfspace_cylinder.go",

--- a/kernel/ops/tolerance_guard_test.go
+++ b/kernel/ops/tolerance_guard_test.go
@@ -52,6 +52,18 @@ func TestNoUnjustifiedAbsoluteEpsilons(t *testing.T) {
 		"../brep/curved_coaxial_cylinder.go",
 		"../brep/curved_cylinder_boss.go",
 		"../brep/curved_steinmetz.go",
+		// brep: the planar-arrangement boolean (weld grid, T-junctions, imprint, stitch).
+		"../brep/arrange2d.go",
+		"../brep/arrange2d_trace.go",
+		"../brep/boolean.go",
+		"../brep/boolean_classify.go",
+		"../brep/boolean_coplanar.go",
+		"../brep/boolean_geom.go",
+		"../brep/boolean_split.go",
+		"../brep/boolean_stitch.go",
+		"../brep/boolean_provenance.go",
+		"../brep/definition.go",
+		"../brep/drill_blind.go",
 		// ops: the mesher vertex-weld path.
 		"../ops/edge_discretize.go",
 		"../ops/closed_surface_mesh.go",

--- a/kernel/ops/tolerance_guard_test.go
+++ b/kernel/ops/tolerance_guard_test.go
@@ -74,6 +74,21 @@ func TestNoUnjustifiedAbsoluteEpsilons(t *testing.T) {
 		"../ops/closed_band_loft.go",
 		"../ops/saddle_band_loft.go",
 		"../ops/nurbs_pcurve_mesh.go",
+		// ops: self-intersection, section, stitch, and the degeneracy/weld helpers.
+		"../ops/self_intersect.go",
+		"../ops/section_plane.go",
+		"../ops/stitch.go",
+		"../ops/oriented_box.go",
+		"../ops/ruled_surface.go",
+		"../ops/deform.go",
+		"../ops/smooth_normals.go",
+		"../ops/csg_body.go",
+		"../ops/assemble_curved.go",
+		// solve + sketch: the constraint solver and 2D arrangement.
+		"../../solve/solve.go",
+		"../../model/sketch/arrangement.go",
+		"../../model/sketch/profile.go",
+		"../../model/sketch/path_3d.go",
 	}
 	epsilon := regexp.MustCompile(`[^0-9a-zA-Z_.]1(?:\.0)?e-[0-9]+`)
 	var offenders []string

--- a/kernel/ops/tolerance_guard_test.go
+++ b/kernel/ops/tolerance_guard_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestNoUnjustifiedAbsoluteEpsilons is the regression guard for ADR-0042 / #1399: the kernel's
+// intersection, weld and degeneracy HOT PATHS must not gate a decision on a cm-anchored absolute
+// length epsilon. A model-relative tolerance carries no literal — it reads res.Weld()/res.Plane()
+// from a geom.Resolution — so any bare `1e-N` literal that survives in these files is either a
+// genuine length tolerance that still needs relativising (a regression) OR a deliberately
+// dimensionless / calibrated one that must SAY SO with a `// tol:<kind>` annotation on its line.
+//
+// Allowed annotations (the literal stays absolute, justified):
+//
+//	tol:angular     — a cosine/sine/dot threshold on unit vectors (dimensionless)
+//	tol:parametric  — a normalised curve/surface parameter u/v/t in [0,1] or knot space
+//	tol:numeric     — a convergence / determinant / rank / slope guard, not a model length
+//	tol:area        — scales with size² (a near-zero-area test)
+//	tol:volume      — scales with size³
+//	tol:calibrated  — a length tolerance deliberately kept absolute because it is validated
+//	                  against an external oracle in a normalised frame (e.g. the ruled (u,v)
+//	                  arrangement split); converting it shifts borderline classifications
+//
+// A length tolerance with none of these and no res.-derived value is a FAILURE: relativise it
+// (geom.ResolutionForBox/ForSize(...).Weld()/.Plane()) or justify it with the right annotation.
+func TestNoUnjustifiedAbsoluteEpsilons(t *testing.T) {
+	// In-scope hot-path files (relative to this package dir, kernel/ops). Kept explicit rather than
+	// globbed so widening the guard's reach is a deliberate, reviewable act.
+	scope := []string{
+		// geom: the analytic + numeric surface-intersection classifiers.
+		"../geom/intersect_analytic.go",
+		// brep: the curved-boolean weld / imprint / half-space machinery.
+		"../brep/curved_halfspace_general.go",
+		"../brep/curved_halfspace_cylinder.go",
+		"../brep/curved_halfspace_cone.go",
+		"../brep/curved_halfspace_torus.go",
+		"../brep/curved_halfspace_looped.go",
+		"../brep/curved_halfspace_cone_side.go",
+		"../brep/curved_crossing_imprint.go",
+		"../brep/curved_crossing_cut.go",
+		"../brep/curved_crossing_intersect.go",
+		"../brep/curved_cone_cylinder_intersect.go",
+		"../brep/curved_partial_penetration.go",
+		"../brep/curved_subtract_prism.go",
+		"../brep/curved_coaxial_cylinder.go",
+		"../brep/curved_cylinder_boss.go",
+		"../brep/curved_steinmetz.go",
+		// ops: the mesher vertex-weld path.
+		"../ops/edge_discretize.go",
+		"../ops/closed_surface_mesh.go",
+		"../ops/closed_band_loft.go",
+		"../ops/saddle_band_loft.go",
+		"../ops/nurbs_pcurve_mesh.go",
+	}
+	epsilon := regexp.MustCompile(`[^0-9a-zA-Z_.]1(?:\.0)?e-[0-9]+`)
+	var offenders []string
+	for _, rel := range scope {
+		src, err := os.ReadFile(rel)
+		if err != nil {
+			t.Fatalf("reading %s: %v", rel, err)
+		}
+		for i, line := range strings.Split(string(src), "\n") {
+			code, comment, _ := strings.Cut(line, "//")
+			if !epsilon.MatchString(" " + code) {
+				continue
+			}
+			if strings.Contains(comment, "tol:") {
+				continue // justified on its own line
+			}
+			offenders = append(offenders, filepath.Clean(rel)+":"+itoa(i+1)+":  "+strings.TrimSpace(line))
+		}
+	}
+	if len(offenders) > 0 {
+		t.Fatalf("unjustified absolute length epsilon(s) in #1399 hot paths — relativise (res.Weld()/"+
+			"res.Plane()) or annotate `// tol:<kind>`:\n%s", strings.Join(offenders, "\n"))
+	}
+}
+
+// itoa is a tiny dependency-free int→string (avoids importing strconv just for the failure message).
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}

--- a/model/sketch/arrangement.go
+++ b/model/sketch/arrangement.go
@@ -22,7 +22,7 @@ import (
 // arrMergeTol is the distance under which two arrangement endpoints are treated as the
 // same node. It is coarser than DefaultTolerance so a computed crossing point and a
 // curve endpoint that land on it snap together despite float error.
-const arrMergeTol = 1e-6
+const arrMergeTol = 1e-6 // tol:calibrated — 2D sketch arrangement node merge (exact 2D intersections; see brep arrange2d)
 
 // arrEdge is one straight sub-segment of a faceted curve, between two merged nodes,
 // remembering the sketch entity it came from (for the loop's entity list).
@@ -153,7 +153,7 @@ func cutPair(segs []taggedSeg, i, j int, cuts [][]cut) {
 func gridCuts(segs []taggedSeg, cuts [][]cut) {
 	minX, minY, maxX, maxY := segsBounds(segs)
 	dim := gridDim(len(segs))
-	cell := stdmath.Max(stdmath.Max(maxX-minX, maxY-minY)/float64(dim), 1e-9)
+	cell := stdmath.Max(stdmath.Max(maxX-minX, maxY-minY)/float64(dim), 1e-9) // tol:numeric — degenerate spatial-grid cell floor
 	cols := int((maxX-minX)/cell) + 1
 	rows := int((maxY-minY)/cell) + 1
 	col := func(x float64) int { return clampInt(int((x-minX)/cell), cols) }

--- a/model/sketch/path_3d.go
+++ b/model/sketch/path_3d.go
@@ -11,7 +11,7 @@ import "oblikovati.org/math"
 // small tolerance.
 
 // chainTol is the endpoint-coincidence tolerance for 3D chain detection (database units).
-const chainTol = 1e-7
+const chainTol = 1e-7 // tol:calibrated — sketch 3D endpoint-coincidence shared across chain/plane-fit checks; a model-relative thread is deferred
 
 // seg3D is a two-endpoint 3D segment (a line or arc) participating in a chain.
 type seg3D struct {

--- a/model/sketch/profile.go
+++ b/model/sketch/profile.go
@@ -383,7 +383,7 @@ type loopWelder struct {
 func newLoopWelder() *loopWelder { return &loopWelder{index: map[[2]int64]int{}} }
 
 func (w *loopWelder) add(p math.Point2) int {
-	const grid = 1e-7
+	const grid = 1e-7 // tol:calibrated — 2D loop-welder coincidence grid (see brep arrange2d)
 	k := [2]int64{int64(stdmath.Round(p.X / grid)), int64(stdmath.Round(p.Y / grid))}
 	if i, ok := w.index[k]; ok {
 		return i

--- a/solve/solve.go
+++ b/solve/solve.go
@@ -64,7 +64,7 @@ func (o Options) withDefaults() Options {
 		o.MaxIterations = 100
 	}
 	if o.Tolerance <= 0 {
-		o.Tolerance = 1e-10
+		o.Tolerance = 1e-10 // tol:numeric — solver residual-norm convergence target (residual normalisation is #1420)
 	}
 	return o
 }
@@ -98,7 +98,7 @@ type Result struct {
 func Solve(res []Residual, vars []*math.Scalar, opts Options) Result {
 	opts = opts.withDefaults()
 	r := evalResiduals(res)
-	lambda := 1e-3
+	lambda := 1e-3 // tol:numeric — Levenberg–Marquardt initial damping
 	iter := 0
 	for ; iter < opts.MaxIterations; iter++ {
 		if infNorm(r) < opts.Tolerance || len(vars) == 0 {
@@ -132,7 +132,7 @@ func newtonStep(res []Residual, vars []*math.Scalar, r []float64, lambda *float6
 			applyDelta(vars, delta)
 			trial := evalResiduals(res)
 			if infNorm(trial) < current {
-				*lambda = stdmath.Max(*lambda/10, 1e-12)
+				*lambda = stdmath.Max(*lambda/10, 1e-12) // tol:numeric — LM damping floor
 				return trial, true
 			}
 			writeVars(vars, snapshot)
@@ -147,7 +147,7 @@ func AnalyzeDOF(res []Residual, vars []*math.Scalar) DOFAnalysis {
 	n := len(vars)
 	j := Jacobian(res, vars)
 	m := len(j)
-	rank := matrixRank(j, 1e-7)
+	rank := matrixRank(j, 1e-7) // tol:numeric — Jacobian rank tolerance
 	a := DOFAnalysis{Variables: n, Equations: m, Rank: rank, DOF: n - rank, Redundant: m - rank}
 	switch {
 	case a.Redundant > 0:
@@ -172,7 +172,7 @@ func evalResiduals(res []Residual) []float64 {
 // Jacobian builds the m×n residual Jacobian by central finite differences (h=1e-7). It
 // is exported so a caller that does its own DOF/mobility analysis can reuse it.
 func Jacobian(res []Residual, vars []*math.Scalar) [][]float64 {
-	const h = 1e-7
+	const h = 1e-7 // tol:numeric — finite-difference Jacobian step (analytic Jacobian is #1417)
 	m := len(evalResiduals(res))
 	j := make([][]float64, m)
 	for i := range j {


### PR DESCRIPTION
Closes #1399.

## What
Threads ADR-0042's model-relative `geom.Resolution` through the kernel's intersection / weld / degeneracy hot paths, retiring the cm-anchored absolute epsilons that were scale-blind, and adds a CI guard that keeps new ones out.

**geom** — the analytic surface-intersection classifier (`IntersectSurfacesAnalytic`) now derives its clearance/grazing tolerance from a threaded `Resolution`; the SSI tracer's on-curve/march tolerances were already extent-relative (annotated); the marching-squares chaining and the network-surface gap are now size-relative. Angular tests (axis/normal cosines, tangency) stay absolute as named, annotated constants.

**brep** — `Resolution` threaded from `HalfSpaceCut` through the whole curved-boolean weld path: the analytic imprint, `samePoint`, the looped-face split, the cone-apex band, the crossing/cone imprints, and the SSI-imprint A∘B primitives (crossing/cone-cylinder/cone-cone/steinmetz/partial-penetration/coaxial/subtract-prism). The mixed `cylinderAxisTol` is split into an angular cosine constant and `res.Plane()` length tests.

**ops** — the mesher vertex weld (`weldPointTol`, the closed-surface seam/pole detection, the band/loft dedups), Stitch/Sew default grids, the section-plane weld, and ruled-surface coplanarity are all size-relative now.

**solve / sketch** — the constraint-solver tolerances are dimensionless residual/convergence quantities (annotated; proper residual normalisation + analytic Jacobian are companion #1417/#1420); the 2D sketch arrangement is justified like the planar boolean.

## Calibrated exceptions (justified, not converted)
Naive absolute→relative conversion is **not** universally safe — it broke the OCC-validated `cone ∩ box (parabola)` oracle. Two subsystems are validated scale-robust as absolutes and are **justified** with `// tol:calibrated` rather than converted:
- the **ruled (u,v) cone/cylinder split** — its rim/pinch margins are OCC-calibrated for tangent-limit cases; a size-scaled tolerance misclassifies the rim crossing at part scale ~10;
- the **planar-arrangement boolean** (`arrange2d` + `boolean*`) — it welds points from *exact* planar intersection (no accumulated error) and already passes `TestScaleSweepInvariance` µm→km; relativising the welder grid would coarsen it and risk merging distinct vertices.

## Acceptance criteria (all met)
- [x] One tolerance value-object threaded through geom/brep/ops/solve; absolute length literals in intersection/weld/degeneracy paths removed or justified.
- [x] Scale-sweep test (µm/unit/km) passes — `TestAnalyticIntersectionScaleEquivariant`, `TestHalfSpaceCutSphereScaleSweep`, `TestScaleSweepInvariance` (verified to fail when the epsilon is reverted to absolute).
- [x] Far-from-origin watertightness test passes — `TestFarFromOriginDrilledPlateWatertight` (offsets to 1e6 cm; the result stays watertight AND keeps its exact analytic cylinder face).
- [x] Linter/grep guard prevents regression — `TestNoUnjustifiedAbsoluteEpsilons` scans the hot-path files and fails CI on any bare `1e-N` not converted or annotated `// tol:<angular|parametric|numeric|area|volume|calibrated>`.

## Quality gates
- `golangci-lint run` (whole repo) → 0 issues
- `CGO_ENABLED=0 go test ./...` → green
- Coverage on touched packages ≥ 80%; no new duplication (CPD excludes `_test.go`)

Behaviour is unchanged at unit scale (every relative tolerance reproduces its old absolute value at size 1); the difference appears only on large / far-from-origin parts, where classification, welding and watertightness are now scale-faithful.