### PR TITLE
Analytic per-constraint Jacobian for the sketch solver (#1417)

### DIFF
--- a/model/sketch/autodiff.go
+++ b/model/sketch/autodiff.go
@@ -91,6 +91,28 @@ func adConstResiduals(n int, val float64) []ad.Number {
 	return out
 }
 
+// adV3 reads a 3D point from three consecutive seeded variables starting at i.
+func adV3(v []ad.Number, i int) ad.Vec3 { return ad.V3(v[i], v[i+1], v[i+2]) }
+
+// adConstVec3 lifts a fixed (non-DOF) vector — a world axis or plane normal — into a
+// constant dual vector.
+func adConstVec3(n math.Vector3) ad.Vec3 {
+	return ad.V3(ad.Const(float64(n.X)), ad.Const(float64(n.Y)), ad.Const(float64(n.Z)))
+}
+
+// adZeroVec3 is the dual zero vector (a constant, no gradient).
+func adZeroVec3() ad.Vec3 { return ad.V3(ad.Const(0), ad.Const(0), ad.Const(0)) }
+
+// adUnit3 returns v scaled to unit length, or the zero vector when v is (near) zero — the
+// dual twin of unit3.
+func adUnit3(v ad.Vec3) ad.Vec3 {
+	l := v.Length()
+	if l.Val() < math.DefaultTolerance {
+		return adZeroVec3()
+	}
+	return v.MulN(ad.Const(1).Div(l))
+}
+
 // circularFrameAD returns a circular curve's center and radius as duals, read from the
 // segment of the seeded variable row that holds the curve's circularVars (starting at
 // off), plus the number of variables it consumed — so a constraint over two curves can

--- a/model/sketch/autodiff.go
+++ b/model/sketch/autodiff.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"oblikovati.org/math"
+	"oblikovati.org/solve/ad"
+)
+
+// This file is the bridge between a constraint's residual formula and the solver's
+// exact Jacobian (Oblikovati/Oblikovati#1417). Each constraint writes its residual ONCE
+// as a function over dual numbers (residualAD); adResiduals derives the float residual
+// values from it (the value-only path), and adPartials derives the exact per-variable
+// derivatives — neither perturbs the live geometry, replacing the solver's old
+// finite-difference Jacobian on the sketch path.
+
+// adFunc is a constraint's residual written over dual numbers: it receives one seeded
+// [ad.Number] per variable, in the constraint's Variables() order, and returns one dual
+// per residual, in Residuals() order.
+type adFunc func(v []ad.Number) []ad.Number
+
+// adFunc1 is a single-valued dual function — a dimension's measured quantity written over
+// dual numbers (one seeded number per variable). Its derivative is the dimension's row of
+// the Jacobian.
+type adFunc1 func(v []ad.Number) ad.Number
+
+// adMeasureValue evaluates a single-valued dual measure at the current variable values —
+// the float quantity a dimension reports, derived from its dual measure so the value and
+// its derivative never diverge.
+func adMeasureValue(vars []*math.Scalar, f adFunc1) float64 {
+	return f(ad.Consts(scalarValues(vars))).Val()
+}
+
+// adResiduals evaluates f at the current variable values as constants — the value-only
+// path, which allocates no gradients.
+func adResiduals(vars []*math.Scalar, f adFunc) []float64 {
+	out := f(ad.Consts(scalarValues(vars)))
+	res := make([]float64, len(out))
+	for i, n := range out {
+		res[i] = n.Val()
+	}
+	return res
+}
+
+// adPartials evaluates f with the variables seeded, returning ∂residualᵢ/∂varⱼ. A
+// residual that does not depend on any variable yields a nil gradient, reported as a
+// zero row of the right width.
+func adPartials(vars []*math.Scalar, f adFunc) [][]float64 {
+	out := f(ad.Seed(scalarValues(vars)))
+	jac := make([][]float64, len(out))
+	for i, n := range out {
+		if g := n.Grad(); g != nil {
+			jac[i] = g
+		} else {
+			jac[i] = make([]float64, len(vars))
+		}
+	}
+	return jac
+}
+
+// scalarValues snapshots the current values behind a variable-pointer slice (a read; the
+// live scalars are never written).
+func scalarValues(vars []*math.Scalar) []float64 {
+	vals := make([]float64, len(vars))
+	for i, v := range vars {
+		vals[i] = float64(*v)
+	}
+	return vals
+}
+
+// adZeroVec2 is the dual zero vector (a constant, no gradient).
+func adZeroVec2() ad.Vec2 { return ad.V2(ad.Const(0), ad.Const(0)) }
+
+// adUnit2 returns v scaled to unit length, or the zero vector when v is (near) zero —
+// the dual twin of unit2, keeping a degenerate direction from producing NaNs.
+func adUnit2(v ad.Vec2) ad.Vec2 {
+	l := v.Length()
+	if l.Val() < math.DefaultTolerance {
+		return adZeroVec2()
+	}
+	return v.MulN(ad.Const(1).Div(l))
+}
+
+// adConstResiduals returns n constant-valued residuals — the dual form of a constraint's
+// "cannot be satisfied" fallback (e.g. a smooth join whose endpoints are not curve ends).
+func adConstResiduals(n int, val float64) []ad.Number {
+	out := make([]ad.Number, n)
+	for i := range out {
+		out[i] = ad.Const(val)
+	}
+	return out
+}
+
+// circularFrameAD returns a circular curve's center and radius as duals, read from the
+// segment of the seeded variable row that holds the curve's circularVars (starting at
+// off), plus the number of variables it consumed — so a constraint over two curves can
+// place the second curve's frame after the first. It mirrors circularVars/CenterPoint/
+// CurveRadius in dual arithmetic.
+type circularAD interface {
+	circularFrameAD(v []ad.Number, off int) (center ad.Vec2, radius ad.Number, consumed int)
+}
+
+// A circle's frame is its center and its stored radius DOF (three variables).
+func (c *Circle) circularFrameAD(v []ad.Number, off int) (ad.Vec2, ad.Number, int) {
+	return ad.V2(v[off], v[off+1]), v[off+2], 3
+}
+
+// An arc has no radius DOF: its radius is |center − start|, so the frame is computed from
+// the center and start points (four variables).
+func (a *Arc) circularFrameAD(v []ad.Number, off int) (ad.Vec2, ad.Number, int) {
+	center := ad.V2(v[off], v[off+1])
+	start := ad.V2(v[off+2], v[off+3])
+	return center, start.Sub(center).Length(), 4
+}

--- a/model/sketch/autodiff_3d_test.go
+++ b/model/sketch/autodiff_3d_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestConstraint3DPartialsMatchFiniteDifference exercises every analytic 3D constraint at
+// a generic off-axis configuration and checks its Jacobian block against central
+// differences (#1417). Bend3D and the join constraints are covered separately because
+// their residual shape depends on shared-endpoint identity.
+func TestConstraint3DPartialsMatchFiniteDifference(t *testing.T) {
+	s := NewSketches3D().Add()
+
+	a := s.AddPoint3D(math.P3(1.3, 2.1, -0.6))
+	b := s.AddPoint3D(math.P3(-0.7, 3.4, 1.2))
+	c := s.AddPoint3D(math.P3(2.2, -1.1, 0.8))
+	l1 := s.AddLine3D(math.P3(0.2, 0.5, 0.1), math.P3(2.6, 1.9, -0.4))
+	l2 := s.AddLine3D(math.P3(-1.1, 0.3, 0.7), math.P3(1.7, 2.8, 1.3))
+	r1, r2 := math.Scalar(2.5), math.Scalar(3.1)
+
+	cases := []struct {
+		name string
+		c    differentiableConstraint
+	}{
+		{"coincident3d", NewCoincident3D(a, b)},
+		{"collinear3d", NewCollinear3D(a, b, c)},
+		{"concentric3d", NewConcentric3D(a, b)},
+		{"equal3d", NewEqual3D(&r1, &r2)},
+		{"parallel3d", NewParallel3D(l1, l2)},
+		{"perpendicular3d", NewPerpendicular3D(l1, l2)},
+		{"midpoint3d", NewMidpoint3D(a, l1)},
+		{"ground3d", NewGround3D(a)},
+		{"parallel-to-axis3d", NewParallelToYAxis3D(l1)},
+		{"parallel-to-plane3d", NewParallelToXZPlane3D(l1)},
+	}
+	for _, tc := range cases {
+		assertAnalyticMatchesFD(t, tc.name, tc.c)
+	}
+}
+
+// TestSmoothConstraint3DPartialsMatchFiniteDifference covers the 3D tangent/smooth joins
+// over line/arc/spline dual frames (including the spline circumcircle curvature in 3D).
+func TestSmoothConstraint3DPartialsMatchFiniteDifference(t *testing.T) {
+	s := NewSketches3D().Add()
+	line := s.AddLine3D(math.P3(0, 0, 0), math.P3(1.4, 0.3, 0.2))
+	arc := s.AddArc3D(math.P3(2, 1, 0.5), math.P3(3.1, 1.2, 0.4), math.P3(2.2, 2.3, 1.1), true)
+	sp := s.AddSpline3D([]math.Point3{
+		{X: 0.2, Y: 0.1, Z: 0}, {X: 1.1, Y: 0.9, Z: 0.3}, {X: 2.3, Y: 0.7, Z: -0.2}, {X: 3.0, Y: 1.8, Z: 0.5},
+	}, false, false)
+
+	cases := []struct {
+		name string
+		c    differentiableConstraint
+	}{
+		{"tangent3d-line-arc", NewTangent3D(line, arc, line.B, arc.Start)},
+		{"smooth3d-line-arc", NewSmooth3D(line, arc, line.B, arc.Start)},
+		{"smooth3d-arc-spline", NewSmooth3D(arc, sp, arc.End, sp.Points[0])},
+		{"smooth3d-spline-line", NewSmooth3D(sp, line, sp.Points[len(sp.Points)-1], line.A)},
+	}
+	for _, tc := range cases {
+		assertAnalyticMatchesFD(t, tc.name, tc.c)
+	}
+}
+
+// TestBend3DGlobalJacobian checks the bend constraint's assembled (global) Jacobian. The
+// bend shares its arc endpoints with the trimmed lines, so the shared points appear twice
+// in its Variables() — only the assembled column (scatterRow accumulation) is well
+// defined, so it is compared against a global finite-difference Jacobian (#1417).
+func TestBend3DGlobalJacobian(t *testing.T) {
+	s := NewSketches3D().Add()
+	l1 := s.AddLine3D(math.P3(0, 0, 0), math.P3(4, 0, 0))
+	l2 := s.AddLine3D(math.P3(4, 0, 0), math.P3(4, 4, 0))
+	arc, err := s.AddBend3D(l1, l2, 1.0)
+	if err != nil {
+		t.Fatalf("AddBend3D: %v", err)
+	}
+	// Nudge the arc center off its solved spot so the tangency/radius residuals are
+	// nonzero and every variable genuinely participates.
+	arc.Center.SetPosition(math.P3(3.2, 0.9, 0.1))
+
+	cons, universe := s.Constraints(), s.variables()
+	got := jacobian(cons, universe)
+	want := globalFDJacobian(cons, universe)
+	for i := range want {
+		for j := range want[i] {
+			if stdmath.Abs(got[i][j]-want[i][j]) > 1e-5 {
+				t.Errorf("bend3d global J[%d][%d] = %.9f, FD says %.9f", i, j, got[i][j], want[i][j])
+			}
+		}
+	}
+}
+
+// TestDimension3DPartialsMatchFiniteDifference checks the analytic 3D dimensions. The
+// spline-length dimension is excluded: its measure is a black-box NURBS sampler with no
+// closed-form derivative, so it finite-differences by design (#1417).
+func TestDimension3DPartialsMatchFiniteDifference(t *testing.T) {
+	s := NewSketches3D().Add()
+	d := s.DimensionConstraints3D()
+
+	a := s.AddPoint3D(math.P3(1.3, 2.1, -0.6))
+	b := s.AddPoint3D(math.P3(-0.7, 3.4, 1.2))
+	l1 := s.AddLine3D(math.P3(0.2, 0.5, 0.1), math.P3(2.6, 1.9, -0.4))
+	l2 := s.AddLine3D(math.P3(-1.1, 0.3, 0.7), math.P3(1.7, 2.8, 1.3))
+	zAxis, _ := math.NewUnitVector3(0, 0, 1)
+	circ := s.AddCircle3D(math.P3(0, 0, 0), zAxis, 2.0)
+
+	mk := func(c *DimensionConstraint3D, err error) differentiableConstraint {
+		if err != nil {
+			t.Fatalf("3D dimension factory: %v", err)
+		}
+		return c
+	}
+	cases := []struct {
+		name string
+		c    differentiableConstraint
+	}{
+		{"distance3d", mk(d.AddDistance(a, b, "5 cm"))},
+		{"line-length3d", mk(d.AddLineLength(l1, "3 cm"))},
+		{"radius3d", mk(d.AddRadius(circ, "2 cm"))},
+		{"point-plane3d", mk(d.AddPointPlaneDistance(a, math.V3(0, 0, 1), "1 cm"))},
+		{"two-line-angle3d", mk(d.AddTwoLineAngle(l1, l2, "30 deg"))},
+	}
+	for _, tc := range cases {
+		assertAnalyticMatchesFD(t, tc.name, tc.c)
+	}
+}

--- a/model/sketch/autodiff_convergence_test.go
+++ b/model/sketch/autodiff_convergence_test.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/solve"
+)
+
+// residualOnly wraps a constraint as a plain (non-Differentiable) residual source, so
+// solve.Solve falls back to finite differencing — the "before #1417" behaviour, used to
+// contrast against the analytic path on the same fixture.
+type residualOnly struct{ c Constraint }
+
+func (r residualOnly) Residuals() []float64 { return r.c.Residuals() }
+
+func snapshotVars(vars []*math.Scalar) []float64 {
+	out := make([]float64, len(vars))
+	for i, v := range vars {
+		out[i] = float64(*v)
+	}
+	return out
+}
+
+// maxResidual returns the largest |residual| across all constraints — the inf-norm the
+// solver drives to zero, used to measure starting-configuration error.
+func maxResidual(cons []Constraint) float64 {
+	m := 0.0
+	for _, c := range cons {
+		for _, r := range c.Residuals() {
+			if a := stdmath.Abs(r); a > m {
+				m = a
+			}
+		}
+	}
+	return m
+}
+
+// constraintResiduals views constraints as the solver's residual sources (each is
+// Differentiable, so the solver assembles the Jacobian analytically).
+func constraintResiduals(cons []Constraint) []solve.Residual {
+	out := make([]solve.Residual, len(cons))
+	for i, c := range cons {
+		out[i] = c
+	}
+	return out
+}
+
+// fdResiduals wraps every constraint as a non-Differentiable source, forcing the solver's
+// finite-difference Jacobian fallback.
+func fdResiduals(cons []Constraint) []solve.Residual {
+	out := make([]solve.Residual, len(cons))
+	for i, c := range cons {
+		out[i] = residualOnly{c}
+	}
+	return out
+}
+
+// TestNearTangentSketchConvergesAnalytically is acceptance criterion 3 of #1417: a point
+// pulled onto BOTH a circle and a line that are nearly tangent near it — the near-singular
+// Jacobian where Gauss–Newton is most sensitive to derivative error — converges cleanly
+// with the exact analytic Jacobian.
+func TestNearTangentSketchConvergesAnalytically(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	g := s.GeometricConstraints()
+
+	center := s.Points().Add(math.P2(0, 0))
+	g.AddFix(center)
+	circle := s.Circles().AddByCenterRadius(math.P2(0, 0), 1)
+	circle.Radius = 1
+	// A near-horizontal line just below the circle's apex, almost tangent at (0,1).
+	la := s.Points().Add(math.P2(-3, 0.999))
+	lb := s.Points().Add(math.P2(3, 1.0006))
+	line := s.Lines().AddByTwoPoints(la.Position(), lb.Position())
+	line.A, line.B = la, lb
+	g.AddFix(la)
+	g.AddFix(lb)
+	p := s.Points().Add(math.P2(0.05, 0.97)) // start near, but off, the contact
+	g.AddPointOnCircle(p, circle)
+	g.AddPointOnLine(p, line)
+
+	r := solve.Solve(constraintResiduals(s.Constraints()), s.variables(), solve.Options{MaxIterations: 200})
+	if !r.Converged || r.Residual > 1e-9 {
+		t.Fatalf("near-tangent analytic solve: converged=%v residual=%g, want converged with residual < 1e-9", r.Converged, r.Residual)
+	}
+}
+
+// TestFarFromOriginAnalyticBeatsFiniteDifference is the deterministic "where FD stalled"
+// evidence: far from the origin the solver's fixed absolute finite-difference step
+// (h=1e-7) underflows the coordinate ULP, so the FD Jacobian collapses to noise and FD
+// makes NO progress — while the exact analytic Jacobian still drives the residual down by
+// orders of magnitude (the absolute floor it reaches is the coordinate-precision limit of
+// #1399, orthogonal to the Jacobian quality demonstrated here).
+func TestFarFromOriginAnalyticBeatsFiniteDifference(t *testing.T) {
+	const off = 1e10
+	build := func() ([]Constraint, []*math.Scalar) {
+		s := NewSketches().Add(XYPlane())
+		g := s.GeometricConstraints()
+		a := s.Points().Add(math.P2(off, off))
+		b := s.Points().Add(math.P2(off, off))
+		b.SetPosition(math.P2(off+0.3, off+0.1)) // start ~0.32 apart; target 5
+		g.AddFix(a)
+		if _, err := s.DimensionConstraints().AddDistance(a, b, "5 cm"); err != nil {
+			t.Fatalf("AddDistance: %v", err)
+		}
+		return s.Constraints(), s.variables()
+	}
+
+	cons, _ := build()
+	initial := maxResidual(cons) // residual at the starting configuration, before any solve
+
+	cons, vars := build()
+	analytic := solve.Solve(constraintResiduals(cons), vars, solve.Options{MaxIterations: 200})
+
+	cons, vars = build()
+	fd := solve.Solve(fdResiduals(cons), vars, solve.Options{MaxIterations: 200})
+
+	// FD's step underflows: it barely moves off the initial residual.
+	if fd.Residual < initial*0.5 {
+		t.Errorf("finite-difference residual %g made unexpected progress from initial %g (FD was expected to stall at this scale)", fd.Residual, initial)
+	}
+	// Analytic drives the residual down by orders of magnitude despite the scale.
+	if analytic.Residual > initial*1e-4 {
+		t.Errorf("analytic residual %g did not improve enough from initial %g", analytic.Residual, initial)
+	}
+	if analytic.Residual >= fd.Residual {
+		t.Errorf("analytic residual %g not better than stalled FD %g", analytic.Residual, fd.Residual)
+	}
+	t.Logf("initial %.3e → analytic %.3e (it=%d) vs FD %.3e (it=%d)",
+		initial, analytic.Residual, analytic.Iterations, fd.Residual, fd.Iterations)
+}
+
+// TestWellConditionedAnalyticIsCorrect is the control: on a well-conditioned fixture the
+// analytic solve converges to the right geometry, confirming the near-tangent and
+// far-origin gaps are conditioning/scale effects, not a wrong analytic derivative.
+func TestWellConditionedAnalyticIsCorrect(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	g := s.GeometricConstraints()
+	a := s.Points().Add(math.P2(0, 0))
+	b := s.Points().Add(math.P2(3, 0.2))
+	g.AddFix(a)
+	if _, err := s.DimensionConstraints().AddDistance(a, b, "5 cm"); err != nil {
+		t.Fatalf("AddDistance: %v", err)
+	}
+	r := solve.Solve(constraintResiduals(s.Constraints()), s.variables(), solve.Options{})
+	if !r.Converged || r.Residual > 1e-9 {
+		t.Fatalf("well-conditioned analytic solve: converged=%v residual=%g", r.Converged, r.Residual)
+	}
+	if d := float64(a.Position().DistanceTo(b.Position())); stdmath.Abs(d-5) > 1e-6 {
+		t.Errorf("distance %v after solve, want 5", d)
+	}
+}

--- a/model/sketch/autodiff_guard_test.go
+++ b/model/sketch/autodiff_guard_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/solve"
+)
+
+// representativeSketch builds a sketch exercising a broad spread of geometric and
+// dimensional constraint types — the fixture the guard tests run against.
+func representativeSketch(t *testing.T) *Sketch {
+	t.Helper()
+	s := NewSketches().Add(XYPlane())
+	g := s.GeometricConstraints()
+	a := s.Points().Add(math.P2(0, 0))
+	b := s.Points().Add(math.P2(2, 0))
+	l1 := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(2, 0.1))
+	l2 := s.Lines().AddByTwoPoints(math.P2(0, 1), math.P2(2, 1.2))
+	c1 := s.Circles().AddByCenterRadius(math.P2(1, 1), 0.5)
+	g.AddCoincident(a, b)
+	g.AddHorizontal(a, b)
+	g.AddParallel(l1, l2)
+	g.AddTangent(l1, c1)
+	g.AddPointOnCircle(a, c1)
+	g.AddFix(a)
+	if _, err := s.DimensionConstraints().AddDistance(a, b, "2 cm"); err != nil {
+		t.Fatalf("AddDistance: %v", err)
+	}
+	if _, err := s.DimensionConstraints().AddRadius(c1, "0.5 cm"); err != nil {
+		t.Fatalf("AddRadius: %v", err)
+	}
+	return s
+}
+
+// TestSketchSolvePathIsFiniteDifferenceFree is acceptance criterion 1 of #1417: every
+// constraint a 2D sketch hands the solver supplies its own analytic partials, so the
+// solver's Jacobian assembly takes the analytic path and never finite-differences.
+func TestSketchSolvePathIsFiniteDifferenceFree(t *testing.T) {
+	s := representativeSketch(t)
+	for _, c := range s.Constraints() {
+		if _, ok := interface{}(c).(solve.Differentiable); !ok {
+			t.Errorf("constraint %T is not solve.Differentiable — it would force the finite-difference fallback", c)
+		}
+	}
+}
+
+// TestMobilityAndDOFDoNotPerturbLiveGeometry is acceptance criterion 3 of #1417: the
+// hover-time DOF and mobility analyses build the Jacobian from exact analytic partials
+// that READ the live variables, so no coordinate is transiently written (as the old
+// finite-difference Jacobian did with orig±h).
+func TestMobilityAndDOFDoNotPerturbLiveGeometry(t *testing.T) {
+	s := representativeSketch(t)
+	s.Solve()
+
+	before := snapshotVars(s.variables())
+	_ = s.DegreesOfFreedom()
+	_ = s.AnalyzeConstraints()
+	mc := s.MoveableClassifier()
+	for _, e := range []Entity{s.Points().Item(0), s.Lines().Item(0), s.Circles().Item(0)} {
+		_ = mc.Of(e)
+	}
+	after := snapshotVars(s.variables())
+
+	for i := range before {
+		if before[i] != after[i] {
+			t.Errorf("variable %d changed during DOF/mobility analysis: %v → %v (the analysis path must not perturb live geometry)",
+				i, before[i], after[i])
+		}
+	}
+}

--- a/model/sketch/autodiff_test.go
+++ b/model/sketch/autodiff_test.go
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// differentiableConstraint is a constraint that supplies its own analytic partials —
+// every geometric and dimensional constraint, post-#1417.
+type differentiableConstraint interface {
+	Constraint
+	Partials() [][]float64
+}
+
+// fdPartials approximates a constraint's Jacobian block by central differences over its
+// own variables — the trusted oracle the analytic Partials are checked against. Finite
+// differencing is fine HERE (a test); the point of #1417 is that it is gone from the
+// solve path.
+func fdPartials(c differentiableConstraint) [][]float64 {
+	const h = 1e-6
+	vars := c.Variables()
+	m := len(c.Residuals())
+	jac := make([][]float64, m)
+	for i := range jac {
+		jac[i] = make([]float64, len(vars))
+	}
+	for j, v := range vars {
+		orig := *v
+		*v = orig + h
+		rp := append([]float64(nil), c.Residuals()...)
+		*v = orig - h
+		rm := append([]float64(nil), c.Residuals()...)
+		*v = orig
+		for i := 0; i < m; i++ {
+			jac[i][j] = (rp[i] - rm[i]) / (2 * h)
+		}
+	}
+	return jac
+}
+
+// assertAnalyticMatchesFD checks every entry of the analytic block against the
+// finite-difference oracle, and that the block is shaped to the residuals × variables.
+func assertAnalyticMatchesFD(t *testing.T, name string, c differentiableConstraint) {
+	t.Helper()
+	got := c.Partials()
+	want := fdPartials(c)
+	if len(got) != len(c.Residuals()) {
+		t.Fatalf("%s: %d partial rows, want %d residuals", name, len(got), len(c.Residuals()))
+	}
+	for i := range want {
+		if len(got[i]) != len(c.Variables()) {
+			t.Fatalf("%s: row %d width %d, want %d variables", name, i, len(got[i]), len(c.Variables()))
+		}
+		for j := range want[i] {
+			if stdmath.Abs(got[i][j]-want[i][j]) > 1e-5 {
+				t.Errorf("%s: ∂r%d/∂v%d = %.9f, FD says %.9f", name, i, j, got[i][j], want[i][j])
+			}
+		}
+	}
+}
+
+// TestGeometricConstraintPartialsMatchFiniteDifference exercises every 2D geometric
+// constraint at a generic (non-degenerate, off-axis) configuration, where the residual
+// genuinely depends on every variable, and checks its analytic Jacobian against central
+// differences (#1417: "agreement within tol on each constraint type").
+func TestGeometricConstraintPartialsMatchFiniteDifference(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	g := s.GeometricConstraints()
+
+	p := s.Points().Add(math.P2(1.3, 2.1))
+	q := s.Points().Add(math.P2(-0.7, 3.4))
+	l1 := s.Lines().AddByTwoPoints(math.P2(0.2, 0.5), math.P2(2.6, 1.9))
+	l2 := s.Lines().AddByTwoPoints(math.P2(-1.1, 0.3), math.P2(1.7, 2.8))
+	c1 := s.Circles().AddByCenterRadius(math.P2(0.9, 1.4), 2.3)
+	c2 := s.Circles().AddByCenterRadius(math.P2(3.2, -0.6), 1.1)
+	arc := s.Arcs().AddByCenterStartEnd(math.P2(0.4, 0.7), math.P2(2.1, 0.7), math.P2(0.4, 2.4), true)
+
+	cases := []struct {
+		name string
+		c    differentiableConstraint
+	}{
+		{"coincident", g.AddCoincident(p, q)},
+		{"point-on-line", g.AddPointOnLine(p, l1)},
+		{"midpoint", g.AddMidpoint(p, l1)},
+		{"point-on-circle", g.AddPointOnCircle(p, c1)},
+		{"point-on-arc", g.AddPointOnCircle(q, arc)},
+		{"horizontal", g.AddHorizontal(p, q)},
+		{"vertical", g.AddVertical(p, q)},
+		{"parallel", g.AddParallel(l1, l2)},
+		{"perpendicular", g.AddPerpendicular(l1, l2)},
+		{"collinear", g.AddCollinear(l1, l2)},
+		{"concentric", g.AddConcentric(c1, c2)},
+		{"equal-length", g.AddEqualLength(l1, l2)},
+		{"equal-radius-circle", g.AddEqualRadius(c1, c2)},
+		{"equal-radius-arc", g.AddEqualRadius(c1, arc)},
+		{"tangent-line-circle", g.AddTangent(l1, c1)},
+		{"tangent-line-arc", g.AddTangent(l2, arc)},
+		{"circular-tangent", g.AddCircularTangent(c1, c2)},
+		{"symmetry", g.AddSymmetry(p, q, l1)},
+		{"fix", g.AddFix(p)},
+	}
+	for _, tc := range cases {
+		assertAnalyticMatchesFD(t, tc.name, tc.c)
+	}
+}
+
+// globalFDJacobian builds the sketch's Jacobian by central differences over the whole
+// variable universe — the oracle for the assembled (global) analytic Jacobian, the only
+// level at which a shared variable's column is well defined.
+func globalFDJacobian(cons []Constraint, universe []*math.Scalar) [][]float64 {
+	const h = 1e-6
+	resAt := func() []float64 {
+		var out []float64
+		for _, c := range cons {
+			out = append(out, c.Residuals()...)
+		}
+		return out
+	}
+	m := len(resAt())
+	jac := make([][]float64, m)
+	for i := range jac {
+		jac[i] = make([]float64, len(universe))
+	}
+	for j, v := range universe {
+		orig := *v
+		*v = orig + h
+		rp := resAt()
+		*v = orig - h
+		rm := resAt()
+		*v = orig
+		for i := 0; i < m; i++ {
+			jac[i][j] = (rp[i] - rm[i]) / (2 * h)
+		}
+	}
+	return jac
+}
+
+// TestEqualLengthSharedVertexGlobalJacobian covers what the per-constraint table misses:
+// two lines sharing a vertex, so the shared point appears TWICE in one constraint's
+// Variables(). Its two occurrences' partials must SUM into the shared global column
+// (#1417 scatterRow accumulation). This is only well defined after assembly, so it is
+// checked against a global finite-difference Jacobian.
+func TestEqualLengthSharedVertexGlobalJacobian(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	shared := s.Points().Add(math.P2(1.0, 1.0))
+	l1 := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(0, 0))
+	l2 := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(0, 0))
+	l1.B, l2.A = shared, shared // l1 ends and l2 starts at the same point
+	l1.A.SetPosition(math.P2(-1.3, 0.4))
+	l2.B.SetPosition(math.P2(2.1, -0.7))
+	s.GeometricConstraints().AddEqualLength(l1, l2)
+
+	cons, universe := s.Constraints(), s.variables()
+	got := jacobian(cons, universe)
+	want := globalFDJacobian(cons, universe)
+	for i := range want {
+		for j := range want[i] {
+			if stdmath.Abs(got[i][j]-want[i][j]) > 1e-5 {
+				t.Errorf("global J[%d][%d] = %.9f, FD says %.9f", i, j, got[i][j], want[i][j])
+			}
+		}
+	}
+}
+
+// TestSmoothConstraintPartialsMatchFiniteDifference exercises the G2 smooth constraint's
+// per-curve dual frames (line/arc/spline) at a generic configuration, where the spline
+// curvature (circumcircle of three control points) genuinely depends on every variable.
+func TestSmoothConstraintPartialsMatchFiniteDifference(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	g := s.GeometricConstraints()
+
+	line := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(1.4, 0.3))
+	arc := s.Arcs().AddByCenterStartEnd(math.P2(2, 1), math.P2(3.1, 1.2), math.P2(2.2, 2.3), true)
+	sp := s.Splines().AddByControlPoints([]math.Point2{{X: 0.2, Y: 0.1}, {X: 1.1, Y: 0.9}, {X: 2.3, Y: 0.7}, {X: 3.0, Y: 1.8}}, false)
+
+	cases := []struct {
+		name string
+		c    differentiableConstraint
+	}{
+		{"smooth-line-arc", g.AddSmooth(line, arc, line.B, arc.Start)},
+		{"smooth-arc-spline", g.AddSmooth(arc, sp, arc.End, sp.Points[0])},
+		{"smooth-spline-line", g.AddSmooth(sp, line, sp.Points[len(sp.Points)-1], line.A)},
+	}
+	for _, tc := range cases {
+		assertAnalyticMatchesFD(t, tc.name, tc.c)
+	}
+}
+
+// TestDimensionPartialsMatchFiniteDifference checks each 2D dimension kind's analytic
+// Jacobian row against central differences at a generic configuration.
+func TestDimensionPartialsMatchFiniteDifference(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	d := s.DimensionConstraints()
+
+	p := s.Points().Add(math.P2(1.3, 2.1))
+	q := s.Points().Add(math.P2(-0.7, 3.4))
+	vtx := s.Points().Add(math.P2(0.5, 0.5))
+	l1 := s.Lines().AddByTwoPoints(math.P2(0.2, 0.5), math.P2(2.6, 1.9))
+	l2 := s.Lines().AddByTwoPoints(math.P2(-1.1, 0.3), math.P2(1.7, 2.8))
+	c1 := s.Circles().AddByCenterRadius(math.P2(0.9, 1.4), 2.3)
+	arc := s.Arcs().AddByCenterStartEnd(math.P2(0.4, 0.7), math.P2(2.1, 0.7), math.P2(0.4, 2.4), true)
+	ell := s.Ellipses().Add(math.P2(1, 1), math.V2(1, 0), 3, 1.5)
+
+	mk := func(c *DimensionConstraint, err error) *DimensionConstraint {
+		if err != nil {
+			t.Fatalf("dimension factory: %v", err)
+		}
+		return c
+	}
+	cases := []struct {
+		name string
+		c    differentiableConstraint
+	}{
+		{"distance", mk(d.AddDistance(p, q, "5 cm"))},
+		{"radius-circle", mk(d.AddRadius(c1, "2 cm"))},
+		{"radius-arc", mk(d.AddRadius(arc, "2 cm"))},
+		{"diameter", mk(d.AddDiameter(c1, "4 cm"))},
+		{"angle", mk(d.AddAngle(l1, l2, "30 deg"))},
+		{"tangent-distance-near", mk(d.AddTangentDistance(l1, c1, false, "1 cm"))},
+		{"tangent-distance-far", mk(d.AddTangentDistance(l2, c1, true, "1 cm"))},
+		{"arc-length", mk(d.AddArcLength(arc, "3 cm"))},
+		{"offset", mk(d.AddOffsetDim(p, l1, "1 cm"))},
+		{"three-point-angle", mk(d.AddThreePointAngle(vtx, p, q, "45 deg"))},
+		{"ellipse-radius", mk(d.AddEllipseRadius(ell, "3 cm"))},
+	}
+	for _, tc := range cases {
+		assertAnalyticMatchesFD(t, tc.name, tc.c)
+	}
+}

--- a/model/sketch/bend_3d.go
+++ b/model/sketch/bend_3d.go
@@ -7,6 +7,7 @@ import (
 	stdmath "math"
 
 	"oblikovati.org/math"
+	"oblikovati.org/solve/ad"
 )
 
 // The 3D-sketch bend (issue #143, M22-F05/PBI-237): Inventor's
@@ -156,31 +157,44 @@ func nearerEnd(l *Line3D, to math.Point3) *Point3D {
 	return l.B
 }
 
-func (c *Bend3D) Residuals() []float64 {
-	center := c.Arc.Center.Position()
-	rs := c.Arc.Start.Position().VectorTo(center) // start → center radius vectors
-	re := c.Arc.End.Position().VectorTo(center)
-	d1 := c.L1.A.Position().VectorTo(c.L1.B.Position())
-	d2 := c.L2.A.Position().VectorTo(c.L2.B.Position())
-	out := appendBendJoin3D(nil, c.P1, c.Arc.Start) // G0 line1↔start
-	out = appendBendJoin3D(out, c.P2, c.Arc.End)    // G0 line2↔end
+// residualAD mirrors the float residual over duals. v = [L1.A.xyz, L1.B.xyz, L2.A.xyz,
+// L2.B.xyz, Arc.Center.xyz, Arc.Start.xyz, Arc.End.xyz]. Rows: optional G0 joins (each
+// skipped when the line endpoint IS the arc endpoint), tangency at each join, the
+// end-on-same-circle relation, and the bend radius.
+func (c *Bend3D) residualAD(v []ad.Number) []ad.Number {
+	center, start, end := adV3(v, 12), adV3(v, 15), adV3(v, 18)
+	rs, re := center.Sub(start), center.Sub(end) // start → centre, end → centre
+	d1, d2 := adLine3DDir(v, 0), adLine3DDir(v, 6)
+	out := appendBendJoin3DAD(nil, c.P1, c.Arc.Start, adBendEndpoint(v, c.L1, c.P1, 0), start)
+	out = appendBendJoin3DAD(out, c.P2, c.Arc.End, adBendEndpoint(v, c.L2, c.P2, 6), end)
 	return append(out,
-		float64(d1.Dot(rs)), float64(d2.Dot(re)), // tangency at each join
-		float64(re.LengthSquared()-rs.LengthSquared()), // end on the same circle as start
-		float64(rs.Length())-c.Radius,                  // hold the bend radius
+		d1.Dot(rs), d2.Dot(re), // tangency at each join
+		re.Dot(re).Sub(rs.Dot(rs)),      // end on the same circle as start
+		rs.Length().AddConst(-c.Radius), // hold the bend radius
 	)
 }
+func (c *Bend3D) Residuals() []float64  { return adResiduals(c.Variables(), c.residualAD) }
+func (c *Bend3D) Partials() [][]float64 { return adPartials(c.Variables(), c.residualAD) }
 
-// appendBendJoin3D appends the G0 rows pulling a split join endpoint onto its arc
-// endpoint, skipping them when both are the same point object (the AddBend3D
-// sharing): identically-zero rows carry no Jacobian rank, so they only inflated
-// the redundancy count and flagged a fresh bend over-constrained (#145 audit
-// finding on the #143 bend).
-func appendBendJoin3D(out []float64, p, arcEnd *Point3D) []float64 {
+// adBendEndpoint returns the dual for a line's join endpoint p — its A end (v[off]) or B
+// end (v[off+3]).
+func adBendEndpoint(v []ad.Number, l *Line3D, p *Point3D, off int) ad.Vec3 {
+	if p == l.B {
+		return adV3(v, off+3)
+	}
+	return adV3(v, off)
+}
+
+// appendBendJoin3DAD appends the G0 rows pulling a split join endpoint onto its arc
+// endpoint, skipping them when both are the same point object (the AddBend3D sharing):
+// identically-zero rows carry no Jacobian rank, so they only inflated the redundancy
+// count and flagged a fresh bend over-constrained (#145 audit finding on the #143 bend).
+func appendBendJoin3DAD(out []ad.Number, p, arcEnd *Point3D, pd, arcd ad.Vec3) []ad.Number {
 	if p == arcEnd {
 		return out
 	}
-	return append(out, float64(p.X-arcEnd.X), float64(p.Y-arcEnd.Y), float64(p.Z-arcEnd.Z))
+	d := pd.Sub(arcd)
+	return append(out, d.X, d.Y, d.Z)
 }
 
 func (c *Bend3D) Variables() []*math.Scalar {

--- a/model/sketch/constraints_2d.go
+++ b/model/sketch/constraints_2d.go
@@ -6,6 +6,7 @@ import (
 	stdmath "math"
 
 	"oblikovati.org/math"
+	"oblikovati.org/solve/ad"
 )
 
 // This file defines the 2D geometric constraints and their factory methods on
@@ -25,9 +26,12 @@ func (g *GeometricConstraints) AddCoincident(a, b *Point) *CoincidentConstraint 
 	return c
 }
 
-func (c *CoincidentConstraint) Residuals() []float64 {
-	return []float64{c.A.X - c.B.X, c.A.Y - c.B.Y}
+// residualAD: v = [A.X, A.Y, B.X, B.Y]; the two points must coincide.
+func (c *CoincidentConstraint) residualAD(v []ad.Number) []ad.Number {
+	return []ad.Number{v[0].Sub(v[2]), v[1].Sub(v[3])}
 }
+func (c *CoincidentConstraint) Residuals() []float64  { return adResiduals(c.Variables(), c.residualAD) }
+func (c *CoincidentConstraint) Partials() [][]float64 { return adPartials(c.Variables(), c.residualAD) }
 
 func (c *CoincidentConstraint) Variables() []*math.Scalar {
 	return []*math.Scalar{&c.A.X, &c.A.Y, &c.B.X, &c.B.Y}
@@ -48,11 +52,17 @@ func (g *GeometricConstraints) AddPointOnLine(p *Point, l *Line) *PointOnLineCon
 	return c
 }
 
+// residualAD: v = [P.X, P.Y, A.X, A.Y, B.X, B.Y]. The cross product of (P−A) with the
+// line direction (B−A) is zero iff P lies on the line.
+func (c *PointOnLineConstraint) residualAD(v []ad.Number) []ad.Number {
+	p, a, b := ad.V2(v[0], v[1]), ad.V2(v[2], v[3]), ad.V2(v[4], v[5])
+	return []ad.Number{b.Sub(a).Cross(p.Sub(a))}
+}
 func (c *PointOnLineConstraint) Residuals() []float64 {
-	dx, dy := lineDir(c.L)
-	// Cross product of (P−A) with the line direction is zero iff P is on the line.
-	ox, oy := c.P.X-c.L.A.X, c.P.Y-c.L.A.Y
-	return []float64{dx*oy - dy*ox}
+	return adResiduals(c.Variables(), c.residualAD)
+}
+func (c *PointOnLineConstraint) Partials() [][]float64 {
+	return adPartials(c.Variables(), c.residualAD)
 }
 
 func (c *PointOnLineConstraint) Variables() []*math.Scalar {
@@ -73,12 +83,15 @@ func (g *GeometricConstraints) AddMidpoint(p *Point, l *Line) *MidpointConstrain
 	return c
 }
 
-func (c *MidpointConstraint) Residuals() []float64 {
-	return []float64{
-		c.P.X - (c.L.A.X+c.L.B.X)/2,
-		c.P.Y - (c.L.A.Y+c.L.B.Y)/2,
+// residualAD: v = [P.X, P.Y, A.X, A.Y, B.X, B.Y]; P must equal (A+B)/2.
+func (c *MidpointConstraint) residualAD(v []ad.Number) []ad.Number {
+	return []ad.Number{
+		v[0].Sub(v[2].Add(v[4]).Scale(0.5)),
+		v[1].Sub(v[3].Add(v[5]).Scale(0.5)),
 	}
 }
+func (c *MidpointConstraint) Residuals() []float64  { return adResiduals(c.Variables(), c.residualAD) }
+func (c *MidpointConstraint) Partials() [][]float64 { return adPartials(c.Variables(), c.residualAD) }
 
 func (c *MidpointConstraint) Variables() []*math.Scalar {
 	return []*math.Scalar{&c.P.X, &c.P.Y, &c.L.A.X, &c.L.A.Y, &c.L.B.X, &c.L.B.Y}
@@ -99,9 +112,17 @@ func (g *GeometricConstraints) AddPointOnCircle(p *Point, c CircularCurve) *Poin
 	return con
 }
 
+// residualAD: v = [P.X, P.Y, <curve circularVars>]; |P − center| must equal the radius.
+func (c *PointOnCircleConstraint) residualAD(v []ad.Number) []ad.Number {
+	p := ad.V2(v[0], v[1])
+	center, radius, _ := c.C.circularFrameAD(v, 2)
+	return []ad.Number{p.Sub(center).Length().Sub(radius)}
+}
 func (c *PointOnCircleConstraint) Residuals() []float64 {
-	ctr := c.C.CenterPoint()
-	return []float64{stdmath.Hypot(c.P.X-ctr.X, c.P.Y-ctr.Y) - c.C.CurveRadius()}
+	return adResiduals(c.Variables(), c.residualAD)
+}
+func (c *PointOnCircleConstraint) Partials() [][]float64 {
+	return adPartials(c.Variables(), c.residualAD)
 }
 
 func (c *PointOnCircleConstraint) Variables() []*math.Scalar {
@@ -120,7 +141,13 @@ func (g *GeometricConstraints) AddHorizontal(a, b *Point) *HorizontalConstraint 
 	g.add(c)
 	return c
 }
-func (c *HorizontalConstraint) Residuals() []float64      { return []float64{c.A.Y - c.B.Y} }
+
+// residualAD: v = [A.Y, B.Y]; the two endpoints must share a Y.
+func (c *HorizontalConstraint) residualAD(v []ad.Number) []ad.Number {
+	return []ad.Number{v[0].Sub(v[1])}
+}
+func (c *HorizontalConstraint) Residuals() []float64      { return adResiduals(c.Variables(), c.residualAD) }
+func (c *HorizontalConstraint) Partials() [][]float64     { return adPartials(c.Variables(), c.residualAD) }
 func (c *HorizontalConstraint) Variables() []*math.Scalar { return []*math.Scalar{&c.A.Y, &c.B.Y} }
 
 // VerticalConstraint forces two points to the same X (a vertical segment).
@@ -135,7 +162,13 @@ func (g *GeometricConstraints) AddVertical(a, b *Point) *VerticalConstraint {
 	g.add(c)
 	return c
 }
-func (c *VerticalConstraint) Residuals() []float64      { return []float64{c.A.X - c.B.X} }
+
+// residualAD: v = [A.X, B.X]; the two endpoints must share an X.
+func (c *VerticalConstraint) residualAD(v []ad.Number) []ad.Number {
+	return []ad.Number{v[0].Sub(v[1])}
+}
+func (c *VerticalConstraint) Residuals() []float64      { return adResiduals(c.Variables(), c.residualAD) }
+func (c *VerticalConstraint) Partials() [][]float64     { return adPartials(c.Variables(), c.residualAD) }
 func (c *VerticalConstraint) Variables() []*math.Scalar { return []*math.Scalar{&c.A.X, &c.B.X} }
 
 // ParallelConstraint forces two lines to be parallel (zero direction cross product).
@@ -151,11 +184,13 @@ func (g *GeometricConstraints) AddParallel(l1, l2 *Line) *ParallelConstraint {
 	return c
 }
 
-func (c *ParallelConstraint) Residuals() []float64 {
-	d1x, d1y := lineDir(c.L1)
-	d2x, d2y := lineDir(c.L2)
-	return []float64{d1x*d2y - d1y*d2x}
+// residualAD: the two line directions are parallel iff their cross product is zero.
+func (c *ParallelConstraint) residualAD(v []ad.Number) []ad.Number {
+	d1, d2 := adLineDirs(v)
+	return []ad.Number{d1.Cross(d2)}
 }
+func (c *ParallelConstraint) Residuals() []float64      { return adResiduals(c.Variables(), c.residualAD) }
+func (c *ParallelConstraint) Partials() [][]float64     { return adPartials(c.Variables(), c.residualAD) }
 func (c *ParallelConstraint) Variables() []*math.Scalar { return lineVars(c.L1, c.L2) }
 
 // PerpendicularConstraint forces two lines to meet at a right angle (zero dot product).
@@ -171,10 +206,16 @@ func (g *GeometricConstraints) AddPerpendicular(l1, l2 *Line) *PerpendicularCons
 	return c
 }
 
+// residualAD: the two line directions are perpendicular iff their dot product is zero.
+func (c *PerpendicularConstraint) residualAD(v []ad.Number) []ad.Number {
+	d1, d2 := adLineDirs(v)
+	return []ad.Number{d1.Dot(d2)}
+}
 func (c *PerpendicularConstraint) Residuals() []float64 {
-	d1x, d1y := lineDir(c.L1)
-	d2x, d2y := lineDir(c.L2)
-	return []float64{d1x*d2x + d1y*d2y}
+	return adResiduals(c.Variables(), c.residualAD)
+}
+func (c *PerpendicularConstraint) Partials() [][]float64 {
+	return adPartials(c.Variables(), c.residualAD)
 }
 func (c *PerpendicularConstraint) Variables() []*math.Scalar { return lineVars(c.L1, c.L2) }
 
@@ -191,13 +232,15 @@ func (g *GeometricConstraints) AddCollinear(l1, l2 *Line) *CollinearConstraint {
 	return c
 }
 
-func (c *CollinearConstraint) Residuals() []float64 {
-	d1x, d1y := lineDir(c.L1)
-	d2x, d2y := lineDir(c.L2)
-	// parallel, and L2.A lies on L1's line.
-	ox, oy := c.L2.A.X-c.L1.A.X, c.L2.A.Y-c.L1.A.Y
-	return []float64{d1x*d2y - d1y*d2x, d1x*oy - d1y*ox}
+// residualAD: the lines are collinear iff they are parallel (cross of directions zero)
+// AND L2.A lies on L1's line (cross of d1 with L2.A−L1.A zero).
+func (c *CollinearConstraint) residualAD(v []ad.Number) []ad.Number {
+	a1, b1, a2, b2 := adTwoLines(v)
+	d1, d2 := b1.Sub(a1), b2.Sub(a2)
+	return []ad.Number{d1.Cross(d2), d1.Cross(a2.Sub(a1))}
 }
+func (c *CollinearConstraint) Residuals() []float64      { return adResiduals(c.Variables(), c.residualAD) }
+func (c *CollinearConstraint) Partials() [][]float64     { return adPartials(c.Variables(), c.residualAD) }
 func (c *CollinearConstraint) Variables() []*math.Scalar { return lineVars(c.L1, c.L2) }
 
 // ConcentricConstraint forces two circular curves (circles or arcs) to share a center.
@@ -213,10 +256,12 @@ func (g *GeometricConstraints) AddConcentric(c1, c2 CircularCurve) *ConcentricCo
 	return c
 }
 
-func (c *ConcentricConstraint) Residuals() []float64 {
-	a, b := c.C1.CenterPoint(), c.C2.CenterPoint()
-	return []float64{a.X - b.X, a.Y - b.Y}
+// residualAD: v = [C1.X, C1.Y, C2.X, C2.Y]; the two centers must coincide.
+func (c *ConcentricConstraint) residualAD(v []ad.Number) []ad.Number {
+	return []ad.Number{v[0].Sub(v[2]), v[1].Sub(v[3])}
 }
+func (c *ConcentricConstraint) Residuals() []float64  { return adResiduals(c.Variables(), c.residualAD) }
+func (c *ConcentricConstraint) Partials() [][]float64 { return adPartials(c.Variables(), c.residualAD) }
 
 func (c *ConcentricConstraint) Variables() []*math.Scalar {
 	a, b := c.C1.CenterPoint(), c.C2.CenterPoint()
@@ -236,8 +281,16 @@ func (g *GeometricConstraints) AddEqualLength(l1, l2 *Line) *EqualLengthConstrai
 	return c
 }
 
+// residualAD: the two segment lengths must be equal.
+func (c *EqualLengthConstraint) residualAD(v []ad.Number) []ad.Number {
+	a1, b1, a2, b2 := adTwoLines(v)
+	return []ad.Number{b1.Sub(a1).Length().Sub(b2.Sub(a2).Length())}
+}
 func (c *EqualLengthConstraint) Residuals() []float64 {
-	return []float64{c.L1.Length() - c.L2.Length()}
+	return adResiduals(c.Variables(), c.residualAD)
+}
+func (c *EqualLengthConstraint) Partials() [][]float64 {
+	return adPartials(c.Variables(), c.residualAD)
 }
 func (c *EqualLengthConstraint) Variables() []*math.Scalar { return lineVars(c.L1, c.L2) }
 
@@ -254,8 +307,17 @@ func (g *GeometricConstraints) AddEqualRadius(c1, c2 CircularCurve) *EqualRadius
 	return c
 }
 
+// residualAD: v = [<C1 circularVars>, <C2 circularVars>]; the two radii must be equal.
+func (c *EqualRadiusConstraint) residualAD(v []ad.Number) []ad.Number {
+	_, r1, n := c.C1.circularFrameAD(v, 0)
+	_, r2, _ := c.C2.circularFrameAD(v, n)
+	return []ad.Number{r1.Sub(r2)}
+}
 func (c *EqualRadiusConstraint) Residuals() []float64 {
-	return []float64{c.C1.CurveRadius() - c.C2.CurveRadius()}
+	return adResiduals(c.Variables(), c.residualAD)
+}
+func (c *EqualRadiusConstraint) Partials() [][]float64 {
+	return adPartials(c.Variables(), c.residualAD)
 }
 
 func (c *EqualRadiusConstraint) Variables() []*math.Scalar {
@@ -278,28 +340,22 @@ func (g *GeometricConstraints) AddTangent(l *Line, c CircularCurve) *TangentCons
 	return t
 }
 
-func (t *TangentConstraint) Residuals() []float64 {
-	signed, ok := signedCenterToLine(t.L, t.C)
-	if !ok {
-		return []float64{t.C.CurveRadius()} // degenerate line: cannot be tangent
+// residualAD: v = [L.A.X, L.A.Y, L.B.X, L.B.Y, <C circularVars>]. The unsigned
+// perpendicular distance from the center to the infinite line equals the radius at
+// tangency (the center may lie on either side, hence Abs).
+func (t *TangentConstraint) residualAD(v []ad.Number) []ad.Number {
+	a, b := ad.V2(v[0], v[1]), ad.V2(v[2], v[3])
+	center, radius, _ := t.C.circularFrameAD(v, 4)
+	dir := b.Sub(a)
+	length := dir.Length()
+	if length.Val() == 0 {
+		return []ad.Number{radius} // degenerate line: cannot be tangent
 	}
-	// Unsigned perpendicular distance from the center to the line equals the
-	// radius at tangency. (The center may lie on either side of the line.)
-	return []float64{stdmath.Abs(signed) - t.C.CurveRadius()}
+	signed := dir.Cross(center.Sub(a)).Div(length)
+	return []ad.Number{signed.Abs().Sub(radius)}
 }
-
-// signedCenterToLine returns the signed perpendicular distance from a circular curve's center
-// to the infinite line through l, and false for a degenerate (zero-length) line. Shared by the
-// tangent constraint and the tangent-distance dimension (#152).
-func signedCenterToLine(l *Line, c CircularCurve) (float64, bool) {
-	dx, dy := lineDir(l)
-	length := stdmath.Hypot(dx, dy)
-	if length == 0 {
-		return 0, false
-	}
-	ctr := c.CenterPoint()
-	return (dx*(ctr.Y-l.A.Y) - dy*(ctr.X-l.A.X)) / length, true
-}
+func (t *TangentConstraint) Residuals() []float64  { return adResiduals(t.Variables(), t.residualAD) }
+func (t *TangentConstraint) Partials() [][]float64 { return adPartials(t.Variables(), t.residualAD) }
 
 func (t *TangentConstraint) Variables() []*math.Scalar {
 	return append([]*math.Scalar{&t.L.A.X, &t.L.A.Y, &t.L.B.X, &t.L.B.Y}, t.C.circularVars()...)
@@ -338,13 +394,22 @@ func (t *CircularTangentConstraint) centerDistance() float64 {
 	return stdmath.Hypot(a.X-b.X, a.Y-b.Y)
 }
 
-func (t *CircularTangentConstraint) Residuals() []float64 {
-	r1, r2 := t.C1.CurveRadius(), t.C2.CurveRadius()
-	target := r1 + r2
+// residualAD: the center distance equals r1+r2 (external tangency) or |r1−r2| (internal).
+// The mode was fixed at creation, so only the target form differs.
+func (t *CircularTangentConstraint) residualAD(v []ad.Number) []ad.Number {
+	c1, r1, n := t.C1.circularFrameAD(v, 0)
+	c2, r2, _ := t.C2.circularFrameAD(v, n)
+	target := r1.Add(r2)
 	if t.internal {
-		target = stdmath.Abs(r1 - r2)
+		target = r1.Sub(r2).Abs()
 	}
-	return []float64{t.centerDistance() - target}
+	return []ad.Number{c1.Sub(c2).Length().Sub(target)}
+}
+func (t *CircularTangentConstraint) Residuals() []float64 {
+	return adResiduals(t.Variables(), t.residualAD)
+}
+func (t *CircularTangentConstraint) Partials() [][]float64 {
+	return adPartials(t.Variables(), t.residualAD)
 }
 
 func (t *CircularTangentConstraint) Variables() []*math.Scalar {
@@ -366,13 +431,18 @@ func (g *GeometricConstraints) AddSymmetry(a, b *Point, about *Line) *SymmetryCo
 	return c
 }
 
-func (c *SymmetryConstraint) Residuals() []float64 {
-	dx, dy := lineDir(c.About)
-	mx, my := (c.A.X+c.B.X)/2, (c.A.Y+c.B.Y)/2
-	onLine := dx*(my-c.About.A.Y) - dy*(mx-c.About.A.X)
-	perp := (c.B.X-c.A.X)*dx + (c.B.Y-c.A.Y)*dy
-	return []float64{onLine, perp}
+// residualAD: v = [A.X, A.Y, B.X, B.Y, About.A.X, About.A.Y, About.B.X, About.B.Y]. The
+// midpoint of A,B lies on the mirror line (onLine) and the A→B segment is perpendicular
+// to it (perp).
+func (c *SymmetryConstraint) residualAD(v []ad.Number) []ad.Number {
+	a, b := ad.V2(v[0], v[1]), ad.V2(v[2], v[3])
+	la, lb := ad.V2(v[4], v[5]), ad.V2(v[6], v[7])
+	dir := lb.Sub(la)
+	mid := a.Add(b).Scale(0.5)
+	return []ad.Number{dir.Cross(mid.Sub(la)), b.Sub(a).Dot(dir)}
 }
+func (c *SymmetryConstraint) Residuals() []float64  { return adResiduals(c.Variables(), c.residualAD) }
+func (c *SymmetryConstraint) Partials() [][]float64 { return adPartials(c.Variables(), c.residualAD) }
 
 func (c *SymmetryConstraint) Variables() []*math.Scalar {
 	return []*math.Scalar{&c.A.X, &c.A.Y, &c.B.X, &c.B.Y, &c.About.A.X, &c.About.A.Y, &c.About.B.X, &c.About.B.Y}
@@ -391,15 +461,27 @@ func (g *GeometricConstraints) AddFix(p *Point) *FixConstraint {
 	g.add(c)
 	return c
 }
-func (c *FixConstraint) Residuals() []float64      { return []float64{c.P.X - c.x0, c.P.Y - c.y0} }
-func (c *FixConstraint) Variables() []*math.Scalar { return []*math.Scalar{&c.P.X, &c.P.Y} }
 
-// lineDir returns a line's direction components (B-A).
-func lineDir(l *Line) (dx, dy math.Scalar) {
-	return l.B.X - l.A.X, l.B.Y - l.A.Y
+// residualAD: each coordinate must hold its captured value.
+func (c *FixConstraint) residualAD(v []ad.Number) []ad.Number {
+	return []ad.Number{v[0].AddConst(-float64(c.x0)), v[1].AddConst(-float64(c.y0))}
 }
+func (c *FixConstraint) Residuals() []float64      { return adResiduals(c.Variables(), c.residualAD) }
+func (c *FixConstraint) Partials() [][]float64     { return adPartials(c.Variables(), c.residualAD) }
+func (c *FixConstraint) Variables() []*math.Scalar { return []*math.Scalar{&c.P.X, &c.P.Y} }
 
 // lineVars returns the eight endpoint coordinates of two lines.
 func lineVars(l1, l2 *Line) []*math.Scalar {
 	return []*math.Scalar{&l1.A.X, &l1.A.Y, &l1.B.X, &l1.B.Y, &l2.A.X, &l2.A.Y, &l2.B.X, &l2.B.Y}
+}
+
+// adLineDirs returns the two line directions (B−A) from a seeded lineVars row.
+func adLineDirs(v []ad.Number) (d1, d2 ad.Vec2) {
+	a1, b1, a2, b2 := adTwoLines(v)
+	return b1.Sub(a1), b2.Sub(a2)
+}
+
+// adTwoLines returns the four endpoints (L1.A, L1.B, L2.A, L2.B) from a seeded lineVars row.
+func adTwoLines(v []ad.Number) (a1, b1, a2, b2 ad.Vec2) {
+	return ad.V2(v[0], v[1]), ad.V2(v[2], v[3]), ad.V2(v[4], v[5]), ad.V2(v[6], v[7])
 }

--- a/model/sketch/constraints_3d.go
+++ b/model/sketch/constraints_3d.go
@@ -2,7 +2,10 @@
 
 package sketch
 
-import "oblikovati.org/math"
+import (
+	"oblikovati.org/math"
+	"oblikovati.org/solve/ad"
+)
 
 // Point3D is a constrainable point in a 3D sketch: three solver variables. The
 // solver is dimension-agnostic — it sees [Constraint.Variables] as []*math.Scalar
@@ -42,9 +45,13 @@ func NewCoincident3D(a, b *Point3D) *Coincident3D {
 	return &Coincident3D{constraintBase: newConstraint(), A: a, B: b}
 }
 
-func (c *Coincident3D) Residuals() []float64 {
-	return []float64{c.A.X - c.B.X, c.A.Y - c.B.Y, c.A.Z - c.B.Z}
+// residualAD: v = [A.xyz, B.xyz]; the two points must coincide.
+func (c *Coincident3D) residualAD(v []ad.Number) []ad.Number {
+	d := adV3(v, 0).Sub(adV3(v, 3))
+	return []ad.Number{d.X, d.Y, d.Z}
 }
+func (c *Coincident3D) Residuals() []float64  { return adResiduals(c.Variables(), c.residualAD) }
+func (c *Coincident3D) Partials() [][]float64 { return adPartials(c.Variables(), c.residualAD) }
 
 func (c *Coincident3D) Variables() []*math.Scalar {
 	return []*math.Scalar{&c.A.X, &c.A.Y, &c.A.Z, &c.B.X, &c.B.Y, &c.B.Z}
@@ -62,12 +69,14 @@ func NewCollinear3D(a, b, c *Point3D) *Collinear3D {
 	return &Collinear3D{constraintBase: newConstraint(), A: a, B: b, C: c}
 }
 
-func (c *Collinear3D) Residuals() []float64 {
-	u := c.A.Position().VectorTo(c.B.Position())
-	v := c.A.Position().VectorTo(c.C.Position())
-	cr := u.Cross(v)
-	return []float64{cr.X, cr.Y, cr.Z}
+// residualAD: v = [A.xyz, B.xyz, C.xyz]; (B−A)×(C−A) vanishes iff the three are collinear.
+func (c *Collinear3D) residualAD(v []ad.Number) []ad.Number {
+	a := adV3(v, 0)
+	cr := adV3(v, 3).Sub(a).Cross(adV3(v, 6).Sub(a))
+	return []ad.Number{cr.X, cr.Y, cr.Z}
 }
+func (c *Collinear3D) Residuals() []float64  { return adResiduals(c.Variables(), c.residualAD) }
+func (c *Collinear3D) Partials() [][]float64 { return adPartials(c.Variables(), c.residualAD) }
 
 func (c *Collinear3D) Variables() []*math.Scalar {
 	return []*math.Scalar{&c.A.X, &c.A.Y, &c.A.Z, &c.B.X, &c.B.Y, &c.B.Z, &c.C.X, &c.C.Y, &c.C.Z}
@@ -85,9 +94,13 @@ func NewConcentric3D(c1, c2 *Point3D) *Concentric3D {
 	return &Concentric3D{constraintBase: newConstraint(), Center1: c1, Center2: c2}
 }
 
-func (c *Concentric3D) Residuals() []float64 {
-	return []float64{c.Center1.X - c.Center2.X, c.Center1.Y - c.Center2.Y, c.Center1.Z - c.Center2.Z}
+// residualAD: v = [C1.xyz, C2.xyz]; the two centers must coincide.
+func (c *Concentric3D) residualAD(v []ad.Number) []ad.Number {
+	d := adV3(v, 0).Sub(adV3(v, 3))
+	return []ad.Number{d.X, d.Y, d.Z}
 }
+func (c *Concentric3D) Residuals() []float64  { return adResiduals(c.Variables(), c.residualAD) }
+func (c *Concentric3D) Partials() [][]float64 { return adPartials(c.Variables(), c.residualAD) }
 
 func (c *Concentric3D) Variables() []*math.Scalar {
 	return []*math.Scalar{&c.Center1.X, &c.Center1.Y, &c.Center1.Z, &c.Center2.X, &c.Center2.Y, &c.Center2.Z}
@@ -103,8 +116,12 @@ type Equal3D struct {
 func NewEqual3D(a, b *math.Scalar) *Equal3D {
 	return &Equal3D{constraintBase: newConstraint(), A: a, B: b}
 }
-func (c *Equal3D) Residuals() []float64      { return []float64{*c.A - *c.B} }
-func (c *Equal3D) Variables() []*math.Scalar { return []*math.Scalar{c.A, c.B} }
+
+// residualAD: v = [A, B]; the two scalar DOFs must be equal.
+func (c *Equal3D) residualAD(v []ad.Number) []ad.Number { return []ad.Number{v[0].Sub(v[1])} }
+func (c *Equal3D) Residuals() []float64                 { return adResiduals(c.Variables(), c.residualAD) }
+func (c *Equal3D) Partials() [][]float64                { return adPartials(c.Variables(), c.residualAD) }
+func (c *Equal3D) Variables() []*math.Scalar            { return []*math.Scalar{c.A, c.B} }
 
 // CustomConstraint3D adapts an arbitrary residual function over given variables
 // into a [Constraint], for relations not covered by the built-ins.

--- a/model/sketch/constraints_3d_curves.go
+++ b/model/sketch/constraints_3d_curves.go
@@ -7,6 +7,7 @@ import (
 	stdmath "math"
 
 	"oblikovati.org/math"
+	"oblikovati.org/solve/ad"
 )
 
 // The curve-attachment 3D constraints of issue #142 (M22 F04/F05): SplineFitPoints3D
@@ -62,10 +63,13 @@ func nearestFitIndex(sp *Spline3D, p *Point3D) int {
 	return best
 }
 
-func (c *SplineFitPoints3D) Residuals() []float64 {
-	fp := c.Spline.Points[c.FitIndex]
-	return []float64{float64(fp.X - c.P.X), float64(fp.Y - c.P.Y), float64(fp.Z - c.P.Z)}
+// residualAD: v = [fitPoint.xyz, P.xyz]; the fit point and the attached point coincide.
+func (c *SplineFitPoints3D) residualAD(v []ad.Number) []ad.Number {
+	d := adV3(v, 0).Sub(adV3(v, 3))
+	return []ad.Number{d.X, d.Y, d.Z}
 }
+func (c *SplineFitPoints3D) Residuals() []float64  { return adResiduals(c.Variables(), c.residualAD) }
+func (c *SplineFitPoints3D) Partials() [][]float64 { return adPartials(c.Variables(), c.residualAD) }
 
 func (c *SplineFitPoints3D) Variables() []*math.Scalar {
 	fp := c.Spline.Points[c.FitIndex]
@@ -93,14 +97,14 @@ func NewHelical3D(h *HelicalCurve3D, c *Circle3D) (*Helical3D, error) {
 	return &Helical3D{constraintBase: newConstraint(), H: h, C: c}, nil
 }
 
-func (c *Helical3D) Residuals() []float64 {
-	return []float64{
-		float64(c.H.Origin.X - c.C.Center.X),
-		float64(c.H.Origin.Y - c.C.Center.Y),
-		float64(c.H.Origin.Z - c.C.Center.Z),
-		float64(c.H.StartRadius - c.C.Radius),
-	}
+// residualAD: v = [H.Origin.xyz, H.StartRadius, C.Center.xyz, C.Radius]. The helix origin
+// coincides with the circle center and the start radius equals the circle radius.
+func (c *Helical3D) residualAD(v []ad.Number) []ad.Number {
+	d := adV3(v, 0).Sub(adV3(v, 4))
+	return []ad.Number{d.X, d.Y, d.Z, v[3].Sub(v[7])}
 }
+func (c *Helical3D) Residuals() []float64  { return adResiduals(c.Variables(), c.residualAD) }
+func (c *Helical3D) Partials() [][]float64 { return adPartials(c.Variables(), c.residualAD) }
 
 func (c *Helical3D) Variables() []*math.Scalar {
 	return []*math.Scalar{

--- a/model/sketch/constraints_3d_geom.go
+++ b/model/sketch/constraints_3d_geom.go
@@ -2,18 +2,16 @@
 
 package sketch
 
-import "oblikovati.org/math"
+import (
+	"oblikovati.org/math"
+	"oblikovati.org/solve/ad"
+)
 
 // This file holds the line/point-based 3D geometric constraints (M22-F05) that extend the
 // point-only set in constraints_3d.go: parallel, perpendicular, midpoint, ground, and the
 // orientation-to-origin-frame constraints (parallel-to-X/Y/Z-axis, parallel-to-XY/XZ/YZ-
 // plane). Each implements [Constraint] over the dimension-agnostic solver — a line's
 // direction residual reads its two endpoints' nine coordinates by pointer.
-
-// line3DDir returns the current A→B direction components of a 3D line.
-func line3DDir(l *Line3D) (dx, dy, dz float64) {
-	return float64(l.B.X - l.A.X), float64(l.B.Y - l.A.Y), float64(l.B.Z - l.A.Z)
-}
 
 // line3DVars returns the six endpoint coordinate DOFs of a 3D line.
 func line3DVars(l *Line3D) []*math.Scalar {
@@ -32,11 +30,13 @@ func NewParallel3D(l1, l2 *Line3D) *Parallel3D {
 	return &Parallel3D{constraintBase: newConstraint(), L1: l1, L2: l2}
 }
 
-func (c *Parallel3D) Residuals() []float64 {
-	ax, ay, az := line3DDir(c.L1)
-	bx, by, bz := line3DDir(c.L2)
-	return cross3(ax, ay, az, bx, by, bz)
+// residualAD: v = [L1.A.xyz, L1.B.xyz, L2.A.xyz, L2.B.xyz]; the directions' cross vanishes.
+func (c *Parallel3D) residualAD(v []ad.Number) []ad.Number {
+	cr := adLine3DDir(v, 0).Cross(adLine3DDir(v, 6))
+	return []ad.Number{cr.X, cr.Y, cr.Z}
 }
+func (c *Parallel3D) Residuals() []float64  { return adResiduals(c.Variables(), c.residualAD) }
+func (c *Parallel3D) Partials() [][]float64 { return adPartials(c.Variables(), c.residualAD) }
 
 func (c *Parallel3D) Variables() []*math.Scalar {
 	return append(line3DVars(c.L1), line3DVars(c.L2)...)
@@ -54,11 +54,12 @@ func NewPerpendicular3D(l1, l2 *Line3D) *Perpendicular3D {
 	return &Perpendicular3D{constraintBase: newConstraint(), L1: l1, L2: l2}
 }
 
-func (c *Perpendicular3D) Residuals() []float64 {
-	ax, ay, az := line3DDir(c.L1)
-	bx, by, bz := line3DDir(c.L2)
-	return []float64{ax*bx + ay*by + az*bz}
+// residualAD: the two line directions are perpendicular iff their dot product is zero.
+func (c *Perpendicular3D) residualAD(v []ad.Number) []ad.Number {
+	return []ad.Number{adLine3DDir(v, 0).Dot(adLine3DDir(v, 6))}
 }
+func (c *Perpendicular3D) Residuals() []float64  { return adResiduals(c.Variables(), c.residualAD) }
+func (c *Perpendicular3D) Partials() [][]float64 { return adPartials(c.Variables(), c.residualAD) }
 
 func (c *Perpendicular3D) Variables() []*math.Scalar {
 	return append(line3DVars(c.L1), line3DVars(c.L2)...)
@@ -76,13 +77,13 @@ func NewMidpoint3D(p *Point3D, l *Line3D) *Midpoint3D {
 	return &Midpoint3D{constraintBase: newConstraint(), P: p, L: l}
 }
 
-func (c *Midpoint3D) Residuals() []float64 {
-	return []float64{
-		float64(c.P.X - (c.L.A.X+c.L.B.X)/2),
-		float64(c.P.Y - (c.L.A.Y+c.L.B.Y)/2),
-		float64(c.P.Z - (c.L.A.Z+c.L.B.Z)/2),
-	}
+// residualAD: v = [P.xyz, A.xyz, B.xyz]; P must equal (A+B)/2.
+func (c *Midpoint3D) residualAD(v []ad.Number) []ad.Number {
+	d := adV3(v, 0).Sub(adV3(v, 3).Add(adV3(v, 6)).Scale(0.5))
+	return []ad.Number{d.X, d.Y, d.Z}
 }
+func (c *Midpoint3D) Residuals() []float64  { return adResiduals(c.Variables(), c.residualAD) }
+func (c *Midpoint3D) Partials() [][]float64 { return adPartials(c.Variables(), c.residualAD) }
 
 func (c *Midpoint3D) Variables() []*math.Scalar {
 	return []*math.Scalar{&c.P.X, &c.P.Y, &c.P.Z, &c.L.A.X, &c.L.A.Y, &c.L.A.Z, &c.L.B.X, &c.L.B.Y, &c.L.B.Z}
@@ -101,14 +102,16 @@ func NewGround3D(p *Point3D) *Ground3D {
 	return &Ground3D{constraintBase: newConstraint(), P: p, Target: p.Position()}
 }
 
-func (c *Ground3D) Residuals() []float64 {
-	return []float64{
-		float64(c.P.X - c.Target.X),
-		float64(c.P.Y - c.Target.Y),
-		float64(c.P.Z - c.Target.Z),
+// residualAD: v = [P.xyz]; the point must hold its captured target position.
+func (c *Ground3D) residualAD(v []ad.Number) []ad.Number {
+	return []ad.Number{
+		v[0].AddConst(-float64(c.Target.X)),
+		v[1].AddConst(-float64(c.Target.Y)),
+		v[2].AddConst(-float64(c.Target.Z)),
 	}
 }
-
+func (c *Ground3D) Residuals() []float64      { return adResiduals(c.Variables(), c.residualAD) }
+func (c *Ground3D) Partials() [][]float64     { return adPartials(c.Variables(), c.residualAD) }
 func (c *Ground3D) Variables() []*math.Scalar { return []*math.Scalar{&c.P.X, &c.P.Y, &c.P.Z} }
 
 // ParallelToAxis3D forces a 3D line to be parallel to a fixed world axis (its direction
@@ -138,11 +141,14 @@ func NewParallelToZAxis3D(l *Line3D) *ParallelToAxis3D {
 	return NewParallelToAxis3D(l, math.V3(0, 0, 1))
 }
 
-func (c *ParallelToAxis3D) Residuals() []float64 {
-	dx, dy, dz := line3DDir(c.L)
-	return cross3(dx, dy, dz, float64(c.Axis.X), float64(c.Axis.Y), float64(c.Axis.Z))
+// residualAD: v = [L.A.xyz, L.B.xyz]; the line direction crossed with the fixed axis
+// vanishes when they are parallel.
+func (c *ParallelToAxis3D) residualAD(v []ad.Number) []ad.Number {
+	cr := adLine3DDir(v, 0).Cross(adConstVec3(c.Axis))
+	return []ad.Number{cr.X, cr.Y, cr.Z}
 }
-
+func (c *ParallelToAxis3D) Residuals() []float64      { return adResiduals(c.Variables(), c.residualAD) }
+func (c *ParallelToAxis3D) Partials() [][]float64     { return adPartials(c.Variables(), c.residualAD) }
 func (c *ParallelToAxis3D) Variables() []*math.Scalar { return line3DVars(c.L) }
 
 // ParallelToPlane3D forces a 3D line to be parallel to a fixed origin-frame plane (its
@@ -173,14 +179,17 @@ func NewParallelToYZPlane3D(l *Line3D) *ParallelToPlane3D {
 	return NewParallelToPlane3D(l, math.V3(1, 0, 0))
 }
 
-func (c *ParallelToPlane3D) Residuals() []float64 {
-	dx, dy, dz := line3DDir(c.L)
-	return []float64{dx*float64(c.Normal.X) + dy*float64(c.Normal.Y) + dz*float64(c.Normal.Z)}
+// residualAD: the line direction is perpendicular to the plane normal (dot product zero)
+// iff the line is parallel to the plane.
+func (c *ParallelToPlane3D) residualAD(v []ad.Number) []ad.Number {
+	return []ad.Number{adLine3DDir(v, 0).Dot(adConstVec3(c.Normal))}
 }
-
+func (c *ParallelToPlane3D) Residuals() []float64      { return adResiduals(c.Variables(), c.residualAD) }
+func (c *ParallelToPlane3D) Partials() [][]float64     { return adPartials(c.Variables(), c.residualAD) }
 func (c *ParallelToPlane3D) Variables() []*math.Scalar { return line3DVars(c.L) }
 
-// cross3 returns the three components of the cross product of two free vectors.
-func cross3(ax, ay, az, bx, by, bz float64) []float64 {
-	return []float64{ay*bz - az*by, az*bx - ax*bz, ax*by - ay*bx}
+// adLine3DDir returns a 3D line's A→B direction (B−A) from a seeded line3DVars segment at
+// off (the line occupies v[off..off+5]).
+func adLine3DDir(v []ad.Number, off int) ad.Vec3 {
+	return adV3(v, off+3).Sub(adV3(v, off))
 }

--- a/model/sketch/constraints_3d_smooth.go
+++ b/model/sketch/constraints_3d_smooth.go
@@ -6,6 +6,7 @@ import (
 	stdmath "math"
 
 	"oblikovati.org/math"
+	"oblikovati.org/solve/ad"
 )
 
 // Tangent (G1) and Smooth (G2) constraints for 3D curves — the 3D counterparts of
@@ -30,6 +31,10 @@ type SmoothCurve3D interface {
 	smoothVars3D() []*math.Scalar
 	// smoothEnds3D returns the curve's free endpoints (empty for a closed curve).
 	smoothEnds3D() []*Point3D
+	// smoothFrame3DAD is the dual twin of smoothFrame3D: it also returns the endpoint p as
+	// a dual (for the G0 coincidence residual), reading the curve's smoothVars3D from v
+	// starting at off (off advances by len(smoothVars3D) between the two curves).
+	smoothFrame3DAD(v []ad.Number, off int, p *Point3D) (point, tangent, curvature ad.Vec3, ok bool)
 }
 
 // Tangent3D joins curves C1 and C2 with collinear tangents (G1) at endpoints P1 and
@@ -48,18 +53,18 @@ func NewTangent3D(c1, c2 SmoothCurve3D, p1, p2 *Point3D) *Tangent3D {
 	return &Tangent3D{constraintBase: newConstraint(), C1: c1, C2: c2, P1: p1, P2: p2}
 }
 
-func (c *Tangent3D) Residuals() []float64 {
-	t1, _, ok1 := c.C1.smoothFrame3D(c.P1)
-	t2, _, ok2 := c.C2.smoothFrame3D(c.P2)
+// residualAD: G0 join coincidence (3) and G1 tangent collinearity (cross, 3).
+func (c *Tangent3D) residualAD(v []ad.Number) []ad.Number {
+	p1, t1, _, ok1 := c.C1.smoothFrame3DAD(v, 0, c.P1)
+	p2, t2, _, ok2 := c.C2.smoothFrame3DAD(v, len(c.C1.smoothVars3D()), c.P2)
 	if !ok1 || !ok2 {
-		return []float64{1, 1, 1, 1, 1, 1} // p1/p2 not endpoints: cannot be satisfied
+		return adConstResiduals(6, 1)
 	}
-	cr := t1.Cross(t2)
-	return []float64{
-		float64(c.P1.X - c.P2.X), float64(c.P1.Y - c.P2.Y), float64(c.P1.Z - c.P2.Z), // G0
-		float64(cr.X), float64(cr.Y), float64(cr.Z), // G1
-	}
+	d, cr := p1.Sub(p2), t1.Cross(t2)
+	return []ad.Number{d.X, d.Y, d.Z, cr.X, cr.Y, cr.Z}
 }
+func (c *Tangent3D) Residuals() []float64  { return adResiduals(c.Variables(), c.residualAD) }
+func (c *Tangent3D) Partials() [][]float64 { return adPartials(c.Variables(), c.residualAD) }
 
 func (c *Tangent3D) Variables() []*math.Scalar {
 	return append(c.C1.smoothVars3D(), c.C2.smoothVars3D()...)
@@ -79,19 +84,18 @@ func NewSmooth3D(c1, c2 SmoothCurve3D, p1, p2 *Point3D) *Smooth3D {
 	return &Smooth3D{constraintBase: newConstraint(), C1: c1, C2: c2, P1: p1, P2: p2}
 }
 
-func (c *Smooth3D) Residuals() []float64 {
-	t1, k1, ok1 := c.C1.smoothFrame3D(c.P1)
-	t2, k2, ok2 := c.C2.smoothFrame3D(c.P2)
+// residualAD: the Tangent3D residuals (G0+G1) plus the G2 curvature-vector match (3).
+func (c *Smooth3D) residualAD(v []ad.Number) []ad.Number {
+	p1, t1, k1, ok1 := c.C1.smoothFrame3DAD(v, 0, c.P1)
+	p2, t2, k2, ok2 := c.C2.smoothFrame3DAD(v, len(c.C1.smoothVars3D()), c.P2)
 	if !ok1 || !ok2 {
-		return []float64{1, 1, 1, 1, 1, 1, 1, 1, 1}
+		return adConstResiduals(9, 1)
 	}
-	cr := t1.Cross(t2)
-	return []float64{
-		float64(c.P1.X - c.P2.X), float64(c.P1.Y - c.P2.Y), float64(c.P1.Z - c.P2.Z), // G0
-		float64(cr.X), float64(cr.Y), float64(cr.Z), // G1
-		float64(k1.X - k2.X), float64(k1.Y - k2.Y), float64(k1.Z - k2.Z), // G2
-	}
+	d, cr, dk := p1.Sub(p2), t1.Cross(t2), k1.Sub(k2)
+	return []ad.Number{d.X, d.Y, d.Z, cr.X, cr.Y, cr.Z, dk.X, dk.Y, dk.Z}
 }
+func (c *Smooth3D) Residuals() []float64  { return adResiduals(c.Variables(), c.residualAD) }
+func (c *Smooth3D) Partials() [][]float64 { return adPartials(c.Variables(), c.residualAD) }
 
 func (c *Smooth3D) Variables() []*math.Scalar {
 	return append(c.C1.smoothVars3D(), c.C2.smoothVars3D()...)
@@ -249,4 +253,112 @@ func circumcenter3(a, b, c math.Point3) (math.Point3, bool) {
 	}
 	offset := v.Cross(n).Scale(u.LengthSquared()).Add(n.Cross(u).Scale(v.LengthSquared())).Scale(1 / (2 * n2))
 	return a.TranslateBy(offset), true
+}
+
+// --- dual 3D smooth frames (#1417) --------------------------------------------------
+
+// smoothFrame3DAD for a line: tangent from p toward the other endpoint, zero curvature.
+func (l *Line3D) smoothFrame3DAD(v []ad.Number, off int, p *Point3D) (ad.Vec3, ad.Vec3, ad.Vec3, bool) {
+	a, b := adV3(v, off), adV3(v, off+3)
+	switch p {
+	case l.A:
+		return a, adUnit3(b.Sub(a)), adZeroVec3(), true
+	case l.B:
+		return b, adUnit3(a.Sub(b)), adZeroVec3(), true
+	}
+	return ad.Vec3{}, ad.Vec3{}, ad.Vec3{}, false
+}
+
+// smoothFrame3DAD for an arc: tangent ⟂ the radius within the arc plane, curvature p→centre
+// with magnitude 1/r.
+func (a *Arc3D) smoothFrame3DAD(v []ad.Number, off int, p *Point3D) (ad.Vec3, ad.Vec3, ad.Vec3, bool) {
+	center, start, end := adV3(v, off), adV3(v, off+3), adV3(v, off+6)
+	var pt ad.Vec3
+	switch p {
+	case a.Start:
+		pt = start
+	case a.End:
+		pt = end
+	default:
+		return ad.Vec3{}, ad.Vec3{}, ad.Vec3{}, false
+	}
+	normal := start.Sub(center).Cross(end.Sub(center))
+	radial := pt.Sub(center) // centre → p
+	rsq, nsq := radial.Dot(radial), normal.Dot(normal)
+	tol := math.DefaultTolerance * math.DefaultTolerance
+	if rsq.Val() < tol || nsq.Val() < tol {
+		return ad.Vec3{}, ad.Vec3{}, ad.Vec3{}, false // degenerate arc
+	}
+	tangent := adUnit3(normal.Cross(radial))
+	curvature := center.Sub(pt).MulN(ad.Const(1).Div(rsq))
+	return pt, tangent, curvature, true
+}
+
+// smoothFrame3DAD for a spline: tangent from the endpoint toward its adjacent point;
+// curvature the circle through the three terminal points.
+func (s *Spline3D) smoothFrame3DAD(v []ad.Number, off int, p *Point3D) (ad.Vec3, ad.Vec3, ad.Vec3, bool) {
+	pi, ai, si, ok := splineTerminalIndices3D(s, p)
+	if !ok {
+		return ad.Vec3{}, ad.Vec3{}, ad.Vec3{}, false
+	}
+	pt, adj := adV3(v, off+3*pi), adV3(v, off+3*ai)
+	tangent := adUnit3(adj.Sub(pt))
+	if si < 0 {
+		return pt, tangent, adZeroVec3(), true
+	}
+	return pt, tangent, adCurvatureVector3(adV3(v, off+3*si), adj, pt), true
+}
+
+// splineTerminalIndices3D returns the indices of the endpoint p, its adjacent point, and
+// its second-adjacent point (si<0 with fewer than three points), or ok=false when p is not
+// a free endpoint (closed or too short).
+func splineTerminalIndices3D(s *Spline3D, p *Point3D) (pi, ai, si int, ok bool) {
+	n := len(s.Points)
+	if n < 2 || s.Closed {
+		return 0, 0, -1, false
+	}
+	switch p {
+	case s.Points[0]:
+		si = -1
+		if n >= 3 {
+			si = 2
+		}
+		return 0, 1, si, true
+	case s.Points[n-1]:
+		si = -1
+		if n >= 3 {
+			si = n - 3
+		}
+		return n - 1, n - 2, si, true
+	}
+	return 0, 0, -1, false
+}
+
+// adCurvatureVector3 is the dual twin of curvatureVector3: the curvature vector at p of the
+// circle through a, b, p (zero when collinear or degenerate).
+func adCurvatureVector3(a, b, p ad.Vec3) ad.Vec3 {
+	center, ok := adCircumcenter3(a, b, p)
+	if !ok {
+		return adZeroVec3()
+	}
+	toCenter := center.Sub(p)
+	rsq := toCenter.Dot(toCenter)
+	if rsq.Val() < math.DefaultTolerance*math.DefaultTolerance {
+		return adZeroVec3()
+	}
+	return toCenter.MulN(ad.Const(1).Div(rsq))
+}
+
+// adCircumcenter3 is the dual twin of circumcenter3: with u = b−a, w = c−a and n = u×w,
+// the centre is a + (|u|²(w×n) + |w|²(n×u)) / (2|n|²).
+func adCircumcenter3(a, b, c ad.Vec3) (ad.Vec3, bool) {
+	u, w := b.Sub(a), c.Sub(a)
+	n := u.Cross(w)
+	n2 := n.Dot(n)
+	if n2.Val() < math.DefaultTolerance*math.DefaultTolerance {
+		return ad.Vec3{}, false
+	}
+	inv := ad.Const(1).Div(n2.Scale(2))
+	offset := w.Cross(n).MulN(u.Dot(u)).Add(n.Cross(u).MulN(w.Dot(w))).MulN(inv)
+	return a.Add(offset), true
 }

--- a/model/sketch/constraints_new.go
+++ b/model/sketch/constraints_new.go
@@ -3,9 +3,8 @@
 package sketch
 
 import (
-	stdmath "math"
-
 	"oblikovati.org/math"
+	"oblikovati.org/solve/ad"
 )
 
 // GroundConstraint freezes every point of an entity at its current position — the
@@ -36,14 +35,19 @@ func (g *GeometricConstraints) AddGroundPoints(pts ...*Point) *GroundConstraint 
 // Points returns the grounded points (for serialization).
 func (c *GroundConstraint) Points() []*Point { return c.pts }
 
-// Residuals reports each point's drift from its frozen position.
-func (c *GroundConstraint) Residuals() []float64 {
-	out := make([]float64, 0, len(c.pts)*2)
-	for i, p := range c.pts {
-		out = append(out, float64(p.X)-c.x0[i], float64(p.Y)-c.y0[i])
+// residualAD: each grounded coordinate must hold its frozen value (v ordered X,Y per
+// point, matching Variables()).
+func (c *GroundConstraint) residualAD(v []ad.Number) []ad.Number {
+	out := make([]ad.Number, 0, len(c.pts)*2)
+	for i := range c.pts {
+		out = append(out, v[2*i].AddConst(-c.x0[i]), v[2*i+1].AddConst(-c.y0[i]))
 	}
 	return out
 }
+
+// Residuals reports each point's drift from its frozen position.
+func (c *GroundConstraint) Residuals() []float64  { return adResiduals(c.Variables(), c.residualAD) }
+func (c *GroundConstraint) Partials() [][]float64 { return adPartials(c.Variables(), c.residualAD) }
 
 // Variables returns the grounded points' coordinates.
 func (c *GroundConstraint) Variables() []*math.Scalar {
@@ -69,20 +73,24 @@ func (g *GeometricConstraints) AddOffset(l1, l2 *Line, dist float64) *OffsetCons
 	return c
 }
 
-// Residuals reports the parallel error and the perpendicular-distance error.
-func (c *OffsetConstraint) Residuals() []float64 {
-	d1x, d1y := lineDir(c.L1)
-	d2x, d2y := lineDir(c.L2)
-	parallel := float64(d1x*d2y - d1y*d2x)
-	length := stdmath.Hypot(float64(d1x), float64(d1y))
-	if length == 0 {
-		return []float64{parallel, 0}
+// residualAD: L2 stays parallel to L1 (cross of directions zero) and L2.A holds a fixed
+// signed perpendicular distance from L1's line. The signed distance is d1×(L2.A−L1.A) /
+// |d1|, the projection of L2.A−L1.A onto L1's left normal.
+func (c *OffsetConstraint) residualAD(v []ad.Number) []ad.Number {
+	a1, b1, a2, b2 := adTwoLines(v)
+	d1, d2 := b1.Sub(a1), b2.Sub(a2)
+	parallel := d1.Cross(d2)
+	length := d1.Length()
+	if length.Val() == 0 {
+		return []ad.Number{parallel, ad.Const(0)}
 	}
-	nx, ny := -float64(d1y)/length, float64(d1x)/length
-	wx := float64(c.L2.A.X - c.L1.A.X)
-	wy := float64(c.L2.A.Y - c.L1.A.Y)
-	return []float64{parallel, wx*nx + wy*ny - c.Dist}
+	dist := d1.Cross(a2.Sub(a1)).Div(length)
+	return []ad.Number{parallel, dist.AddConst(-c.Dist)}
 }
+
+// Residuals reports the parallel error and the perpendicular-distance error.
+func (c *OffsetConstraint) Residuals() []float64  { return adResiduals(c.Variables(), c.residualAD) }
+func (c *OffsetConstraint) Partials() [][]float64 { return adPartials(c.Variables(), c.residualAD) }
 
 // Variables returns the two lines' endpoint coordinates.
 func (c *OffsetConstraint) Variables() []*math.Scalar { return lineVars(c.L1, c.L2) }
@@ -114,17 +122,20 @@ func (g *GeometricConstraints) AddPatternLinkLive(seed, member *Point, offset fu
 	return c
 }
 
-// Residuals reports the member's drift from seed + the (frozen or live) offset.
-func (c *PatternConstraint) Residuals() []float64 {
+// residualAD: v = [Seed.X, Seed.Y, Member.X, Member.Y]. The member tracks the seed at a
+// fixed offset; the offset (frozen or spacing-driven) is constant w.r.t. the solver
+// variables, so it enters as an additive constant.
+func (c *PatternConstraint) residualAD(v []ad.Number) []ad.Number {
 	dx, dy := c.dx, c.dy
 	if c.live != nil {
 		dx, dy = c.live()
 	}
-	return []float64{
-		float64(c.Member.X-c.Seed.X) - dx,
-		float64(c.Member.Y-c.Seed.Y) - dy,
-	}
+	return []ad.Number{v[2].Sub(v[0]).AddConst(-dx), v[3].Sub(v[1]).AddConst(-dy)}
 }
+
+// Residuals reports the member's drift from seed + the (frozen or live) offset.
+func (c *PatternConstraint) Residuals() []float64  { return adResiduals(c.Variables(), c.residualAD) }
+func (c *PatternConstraint) Partials() [][]float64 { return adPartials(c.Variables(), c.residualAD) }
 
 // Variables returns the seed and member coordinates.
 func (c *PatternConstraint) Variables() []*math.Scalar {

--- a/model/sketch/constraints_smooth.go
+++ b/model/sketch/constraints_smooth.go
@@ -6,6 +6,7 @@ import (
 	stdmath "math"
 
 	"oblikovati.org/math"
+	"oblikovati.org/solve/ad"
 )
 
 // The Smooth (G2) constraint makes two curves curvature-continuous where they join.
@@ -29,6 +30,10 @@ type SmoothCurve interface {
 	smoothFrame(p *Point) (tangent, curvature math.Vector2, ok bool)
 	// smoothVars returns the scalar DOFs of the curve's defining points.
 	smoothVars() []*math.Scalar
+	// smoothFrameAD is the dual twin of smoothFrame: it also returns the endpoint p as a
+	// dual (for the G0 coincidence residual), reading the curve's smoothVars from v
+	// starting at off (off advances by len(smoothVars) between the two curves).
+	smoothFrameAD(v []ad.Number, off int, p *Point) (point, tangent, curvature ad.Vec2, ok bool)
 }
 
 // SmoothConstraint makes curves C1 and C2 curvature-continuous at endpoints P1 and P2,
@@ -47,18 +52,23 @@ func (g *GeometricConstraints) AddSmooth(c1, c2 SmoothCurve, p1, p2 *Point) *Smo
 	return c
 }
 
-func (c *SmoothConstraint) Residuals() []float64 {
-	t1, k1, ok1 := c.C1.smoothFrame(c.P1)
-	t2, k2, ok2 := c.C2.smoothFrame(c.P2)
+// residualAD mirrors the float residual over duals: G0 join coincidence (2), G1 tangent
+// collinearity (1), G2 curvature-vector match (2). The frames carry their own exact
+// derivatives, so the spline circumcircle curvature differentiates by construction.
+func (c *SmoothConstraint) residualAD(v []ad.Number) []ad.Number {
+	p1, t1, k1, ok1 := c.C1.smoothFrameAD(v, 0, c.P1)
+	p2, t2, k2, ok2 := c.C2.smoothFrameAD(v, len(c.C1.smoothVars()), c.P2)
 	if !ok1 || !ok2 {
-		return []float64{1, 1, 1, 1, 1} // p1/p2 not endpoints: cannot be satisfied
+		return adConstResiduals(5, 1) // p1/p2 not endpoints: cannot be satisfied
 	}
-	return []float64{
-		c.P1.X - c.P2.X, c.P1.Y - c.P2.Y, // G0: join coincident
-		t1.Cross(t2),             // G1: tangents collinear
-		k1.X - k2.X, k1.Y - k2.Y, // G2: equal curvature vector
+	return []ad.Number{
+		p1.X.Sub(p2.X), p1.Y.Sub(p2.Y), // G0: join coincident
+		t1.Cross(t2),                   // G1: tangents collinear
+		k1.X.Sub(k2.X), k1.Y.Sub(k2.Y), // G2: equal curvature vector
 	}
 }
+func (c *SmoothConstraint) Residuals() []float64  { return adResiduals(c.Variables(), c.residualAD) }
+func (c *SmoothConstraint) Partials() [][]float64 { return adPartials(c.Variables(), c.residualAD) }
 
 func (c *SmoothConstraint) Variables() []*math.Scalar {
 	return append(c.C1.smoothVars(), c.C2.smoothVars()...)
@@ -185,3 +195,113 @@ func circumcenter(a, b, c math.Point2) (math.Point2, bool) {
 
 // originSq is the squared distance of p from the origin (a circumcenter sub-term).
 func originSq(p math.Point2) float64 { return p.X*p.X + p.Y*p.Y }
+
+// --- dual smooth frames (#1417) -----------------------------------------------------
+
+// smoothFrameAD for a line: tangent from p toward the other endpoint, zero curvature.
+func (l *Line) smoothFrameAD(v []ad.Number, off int, p *Point) (ad.Vec2, ad.Vec2, ad.Vec2, bool) {
+	a, b := ad.V2(v[off], v[off+1]), ad.V2(v[off+2], v[off+3])
+	switch p {
+	case l.A:
+		return a, adUnit2(b.Sub(a)), adZeroVec2(), true
+	case l.B:
+		return b, adUnit2(a.Sub(b)), adZeroVec2(), true
+	}
+	return ad.Vec2{}, ad.Vec2{}, ad.Vec2{}, false
+}
+
+// smoothFrameAD for an arc: tangent ⟂ the radius at p, curvature vector p→centre with
+// magnitude 1/r (computed as (centre−p)/r²).
+func (a *Arc) smoothFrameAD(v []ad.Number, off int, p *Point) (ad.Vec2, ad.Vec2, ad.Vec2, bool) {
+	center := ad.V2(v[off], v[off+1])
+	var pt ad.Vec2
+	switch p {
+	case a.Start:
+		pt = ad.V2(v[off+2], v[off+3])
+	case a.End:
+		pt = ad.V2(v[off+4], v[off+5])
+	default:
+		return ad.Vec2{}, ad.Vec2{}, ad.Vec2{}, false
+	}
+	radial := pt.Sub(center) // centre → p
+	rsq := radial.Dot(radial)
+	if rsq.Val() < math.DefaultTolerance*math.DefaultTolerance {
+		return ad.Vec2{}, ad.Vec2{}, ad.Vec2{}, false
+	}
+	tangent := adUnit2(ad.V2(radial.Y.Neg(), radial.X))
+	curvature := center.Sub(pt).MulN(ad.Const(1).Div(rsq))
+	return pt, tangent, curvature, true
+}
+
+// smoothFrameAD for a spline: tangent from the endpoint toward its adjacent control
+// point; curvature the circle through the three terminal control points.
+func (s *Spline) smoothFrameAD(v []ad.Number, off int, p *Point) (ad.Vec2, ad.Vec2, ad.Vec2, bool) {
+	pi, ai, si, ok := splineTerminalIndices(s, p)
+	if !ok {
+		return ad.Vec2{}, ad.Vec2{}, ad.Vec2{}, false
+	}
+	pt, adj := adSplinePoint(v, off, pi), adSplinePoint(v, off, ai)
+	tangent := adUnit2(adj.Sub(pt))
+	if si < 0 {
+		return pt, tangent, adZeroVec2(), true
+	}
+	return pt, tangent, adCurvatureVector(adSplinePoint(v, off, si), adj, pt), true
+}
+
+// splineTerminalIndices returns the indices (in Points order) of the endpoint p, its
+// adjacent point, and the second-adjacent point (si<0 when the spline has fewer than
+// three points, i.e. no curvature), or ok=false when p is not a spline endpoint.
+func splineTerminalIndices(s *Spline, p *Point) (pi, ai, si int, ok bool) {
+	n := len(s.Points)
+	if n < 2 {
+		return 0, 0, -1, false
+	}
+	switch p {
+	case s.Points[0]:
+		si = -1
+		if n >= 3 {
+			si = 2
+		}
+		return 0, 1, si, true
+	case s.Points[n-1]:
+		si = -1
+		if n >= 3 {
+			si = n - 3
+		}
+		return n - 1, n - 2, si, true
+	}
+	return 0, 0, -1, false
+}
+
+// adSplinePoint returns control point k of a spline as a dual, from its seeded segment.
+func adSplinePoint(v []ad.Number, off, k int) ad.Vec2 {
+	return ad.V2(v[off+2*k], v[off+2*k+1])
+}
+
+// adCurvatureVector is the dual twin of curvatureVector: the curvature vector at p of the
+// circle through a, b, p (zero when collinear or degenerate).
+func adCurvatureVector(a, b, p ad.Vec2) ad.Vec2 {
+	center, ok := adCircumcenter(a, b, p)
+	if !ok {
+		return adZeroVec2()
+	}
+	toCenter := center.Sub(p)
+	rsq := toCenter.Dot(toCenter)
+	if rsq.Val() < math.DefaultTolerance*math.DefaultTolerance {
+		return adZeroVec2()
+	}
+	return toCenter.MulN(ad.Const(1).Div(rsq))
+}
+
+// adCircumcenter is the dual twin of circumcenter: the centre of the circle through a, b,
+// c, and false when they are collinear (the determinant vanishes).
+func adCircumcenter(a, b, c ad.Vec2) (ad.Vec2, bool) {
+	d := a.X.Mul(b.Y.Sub(c.Y)).Add(b.X.Mul(c.Y.Sub(a.Y))).Add(c.X.Mul(a.Y.Sub(b.Y))).Scale(2)
+	if stdmath.Abs(d.Val()) < math.DefaultTolerance {
+		return ad.Vec2{}, false
+	}
+	a2, b2, c2 := a.Dot(a), b.Dot(b), c.Dot(c)
+	ux := a2.Mul(b.Y.Sub(c.Y)).Add(b2.Mul(c.Y.Sub(a.Y))).Add(c2.Mul(a.Y.Sub(b.Y))).Div(d)
+	uy := a2.Mul(c.X.Sub(b.X)).Add(b2.Mul(a.X.Sub(c.X))).Add(c2.Mul(b.X.Sub(a.X))).Div(d)
+	return ad.V2(ux, uy), true
+}

--- a/model/sketch/constraints_tagged.go
+++ b/model/sketch/constraints_tagged.go
@@ -36,6 +36,10 @@ type TextBoxAnchorConstraint struct {
 func (c *TextBoxAnchorConstraint) Residuals() []float64      { return nil }
 func (c *TextBoxAnchorConstraint) Variables() []*math.Scalar { return nil }
 
+// Partials implements the solver's Differentiable interface: an anchoring record has no
+// residuals, so its Jacobian block is empty (#1417).
+func (c *TextBoxAnchorConstraint) Partials() [][]float64 { return nil }
+
 // Deletable implements [NonDeletable]: the anchor lives and dies with its
 // text box.
 func (c *TextBoxAnchorConstraint) Deletable() bool { return false }
@@ -53,6 +57,10 @@ type CustomConstraint struct {
 // Residuals and Variables implement [Constraint]: a tag constrains nothing.
 func (c *CustomConstraint) Residuals() []float64      { return nil }
 func (c *CustomConstraint) Variables() []*math.Scalar { return nil }
+
+// Partials implements the solver's Differentiable interface: a tag constrains nothing,
+// so its Jacobian block is empty (#1417).
+func (c *CustomConstraint) Partials() [][]float64 { return nil }
 
 // AddCustom tags the given entities for the owning client. ClientID is
 // required — an anonymous tag could never be cleaned up by its owner.

--- a/model/sketch/dimension.go
+++ b/model/sketch/dimension.go
@@ -4,10 +4,10 @@ package sketch
 
 import (
 	"fmt"
-	stdmath "math"
 
 	"oblikovati.org/math"
 	"oblikovati.org/model/param"
+	"oblikovati.org/solve/ad"
 )
 
 // DimKind classifies a dimensional constraint.
@@ -62,14 +62,14 @@ func (l ConstraintLimits) clamp(v float64) float64 {
 // the parameter's value (modeling/00).
 type DimensionConstraint struct {
 	constraintBase
-	kind    DimKind
-	driven  bool
-	param   *param.Parameter
-	limits  ConstraintLimits
-	measure func() float64
-	vars    []*math.Scalar
-	refs    []Entity // the dimensioned geometry (points/lines/arcs), for editing + serialization
-	farSide bool     // tangentDistance only: dimension to the far tangent point (#152)
+	kind      DimKind
+	driven    bool
+	param     *param.Parameter
+	limits    ConstraintLimits
+	measureAD adFunc1 // the measured quantity over duals; the float measure derives from it
+	vars      []*math.Scalar
+	refs      []Entity // the dimensioned geometry (points/lines/arcs), for editing + serialization
+	farSide   bool     // tangentDistance only: dimension to the far tangent point (#152)
 }
 
 // FarSide reports whether a tangent-distance dimension measures to the far tangent point
@@ -88,7 +88,7 @@ func (d *DimensionConstraint) Kind() DimKind { return d.kind }
 func (d *DimensionConstraint) Parameter() *param.Parameter { return d.param }
 
 // Measured returns the current geometric value of the dimensioned quantity.
-func (d *DimensionConstraint) Measured() float64 { return d.measure() }
+func (d *DimensionConstraint) Measured() float64 { return adMeasureValue(d.vars, d.measureAD) }
 
 // Driven reports whether the dimension only reports (true) or constrains (false).
 func (d *DimensionConstraint) Driven() bool { return d.driven }
@@ -109,12 +109,26 @@ func (d *DimensionConstraint) Drive(value float64) error {
 	return d.param.SetValue(param.Q(d.limits.clamp(value), d.param.Unit()))
 }
 
+// residualAD: measured-minus-target, the target being a constant from the parameter DAG.
+func (d *DimensionConstraint) residualAD(v []ad.Number) []ad.Number {
+	return []ad.Number{d.measureAD(v).AddConst(-d.param.ModelValue())}
+}
+
 // Residuals returns measured-minus-target when driving, or nil when driven.
 func (d *DimensionConstraint) Residuals() []float64 {
 	if d.driven {
 		return nil
 	}
-	return []float64{d.measure() - d.param.ModelValue()}
+	return adResiduals(d.vars, d.residualAD)
+}
+
+// Partials returns the dimension's exact Jacobian row, or nil when driven (it contributes
+// no equation). It reuses the dual measure, so the derivative cannot drift from the value.
+func (d *DimensionConstraint) Partials() [][]float64 {
+	if d.driven {
+		return nil
+	}
+	return adPartials(d.vars, d.residualAD)
 }
 
 // Variables returns the geometry DOFs this dimension constrains (none when driven).
@@ -160,7 +174,7 @@ func (dc *DimensionConstraints) Delete(d *DimensionConstraint) bool {
 
 // AddDistance dimensions the distance between two points to expression (e.g. "25 mm").
 func (dc *DimensionConstraints) AddDistance(a, b *Point, expression string) (*DimensionConstraint, error) {
-	measure := func() float64 { return a.Position().DistanceTo(b.Position()) }
+	measure := func(v []ad.Number) ad.Number { return ad.V2(v[0], v[1]).Sub(ad.V2(v[2], v[3])).Length() }
 	vars := []*math.Scalar{&a.X, &a.Y, &b.X, &b.Y}
 	return dc.create(DistanceDim, expression, []Entity{a, b}, measure, vars)
 }
@@ -169,20 +183,21 @@ func (dc *DimensionConstraints) AddDistance(a, b *Point, expression string) (*Di
 // a circle the radius is a stored DOF; for an arc it is the center-to-start distance,
 // so the solver drives the center/start points (circularVars) to satisfy the target.
 func (dc *DimensionConstraints) AddRadius(c CircularCurve, expression string) (*DimensionConstraint, error) {
-	return dc.create(RadiusDim, expression, []Entity{c}, func() float64 { return float64(c.CurveRadius()) }, c.circularVars())
+	measure := func(v []ad.Number) ad.Number { _, r, _ := c.circularFrameAD(v, 0); return r }
+	return dc.create(RadiusDim, expression, []Entity{c}, measure, c.circularVars())
 }
 
 // AddDiameter dimensions the diameter of a circle or an arc.
 func (dc *DimensionConstraints) AddDiameter(c CircularCurve, expression string) (*DimensionConstraint, error) {
-	return dc.create(DiameterDim, expression, []Entity{c}, func() float64 { return 2 * float64(c.CurveRadius()) }, c.circularVars())
+	measure := func(v []ad.Number) ad.Number { _, r, _ := c.circularFrameAD(v, 0); return r.Scale(2) }
+	return dc.create(DiameterDim, expression, []Entity{c}, measure, c.circularVars())
 }
 
 // AddAngle dimensions the angle (radians, in [0,π]) between two lines.
 func (dc *DimensionConstraints) AddAngle(l1, l2 *Line, expression string) (*DimensionConstraint, error) {
-	measure := func() float64 {
-		d1x, d1y := lineDir(l1)
-		d2x, d2y := lineDir(l2)
-		return stdmath.Atan2(stdmath.Abs(d1x*d2y-d1y*d2x), d1x*d2x+d1y*d2y)
+	measure := func(v []ad.Number) ad.Number {
+		d1, d2 := adLineDirs(v)
+		return d1.Cross(d2).Abs().Atan2(d1.Dot(d2))
 	}
 	return dc.create(AngleDim, expression, []Entity{l1, l2}, measure, lineVars(l1, l2))
 }
@@ -192,16 +207,19 @@ func (dc *DimensionConstraints) AddAngle(l1, l2 *Line, expression string) (*Dime
 // side (default) subtracts the radius, the far side adds it (#152). The solver drives the
 // line's endpoints and the curve's center/radius (circularVars) to satisfy the target.
 func (dc *DimensionConstraints) AddTangentDistance(l *Line, c CircularCurve, farSide bool, expression string) (*DimensionConstraint, error) {
-	measure := func() float64 {
-		signed, ok := signedCenterToLine(l, c)
-		if !ok {
-			return 0
+	measure := func(v []ad.Number) ad.Number {
+		a, b := ad.V2(v[0], v[1]), ad.V2(v[2], v[3])
+		center, radius, _ := c.circularFrameAD(v, 4)
+		dir := b.Sub(a)
+		length := dir.Length()
+		if length.Val() == 0 {
+			return ad.Const(0)
 		}
-		d := stdmath.Abs(signed)
+		d := dir.Cross(center.Sub(a)).Div(length).Abs() // |perpendicular distance|
 		if farSide {
-			return d + c.CurveRadius()
+			return d.Add(radius)
 		}
-		return d - c.CurveRadius()
+		return d.Sub(radius)
 	}
 	vars := append([]*math.Scalar{&l.A.X, &l.A.Y, &l.B.X, &l.B.Y}, c.circularVars()...)
 	d, err := dc.create(TangentDistanceDim, expression, []Entity{l, c}, measure, vars)
@@ -214,19 +232,26 @@ func (dc *DimensionConstraints) AddTangentDistance(l *Line, c CircularCurve, far
 
 // AddArcLength dimensions an arc's length (radius × swept angle).
 func (dc *DimensionConstraints) AddArcLength(a *Arc, expression string) (*DimensionConstraint, error) {
-	measure := func() float64 { return a.Radius() * arcSweep(a) }
+	measure := func(v []ad.Number) ad.Number {
+		center, start, end := ad.V2(v[0], v[1]), ad.V2(v[2], v[3]), ad.V2(v[4], v[5])
+		radius := start.Sub(center).Length()
+		s, e := start.Sub(center), end.Sub(center)
+		sweep := s.Cross(e).Atan2(s.Dot(e)).Abs() // unsigned swept angle
+		return radius.Mul(sweep)
+	}
 	vars := []*math.Scalar{&a.Center.X, &a.Center.Y, &a.Start.X, &a.Start.Y, &a.End.X, &a.End.Y}
 	return dc.create(ArcLengthDim, expression, []Entity{a}, measure, vars)
 }
 
-// create builds a driving dimension backed by a fresh model parameter. refs records
-// the dimensioned geometry for editing and serialization.
-func (dc *DimensionConstraints) create(kind DimKind, expression string, refs []Entity, measure func() float64, vars []*math.Scalar) (*DimensionConstraint, error) {
+// create builds a driving dimension backed by a fresh model parameter. measure is the
+// dimensioned quantity over duals (the single source of both its value and its exact
+// Jacobian row, #1417); refs records the dimensioned geometry for editing/serialization.
+func (dc *DimensionConstraints) create(kind DimKind, expression string, refs []Entity, measure adFunc1, vars []*math.Scalar) (*DimensionConstraint, error) {
 	p, err := dc.params.AddModelParameter(dc.nextName(), expression)
 	if err != nil {
 		return nil, fmt.Errorf("sketch: dimension parameter: %w", err)
 	}
-	d := &DimensionConstraint{constraintBase: newConstraint(), kind: kind, param: p, measure: measure, vars: vars, refs: refs}
+	d := &DimensionConstraint{constraintBase: newConstraint(), kind: kind, param: p, measureAD: measure, vars: vars, refs: refs}
 	dc.items = append(dc.items, d)
 	return d, nil
 }
@@ -240,13 +265,4 @@ func (dc *DimensionConstraints) nextName() string {
 			return name
 		}
 	}
-}
-
-// arcSweep returns the unsigned swept angle of an arc about its center.
-func arcSweep(a *Arc) float64 {
-	c := a.Center.Position()
-	s := c.VectorTo(a.Start.Position())
-	e := c.VectorTo(a.End.Position())
-	sweep := stdmath.Atan2(s.Cross(e), s.Dot(e))
-	return stdmath.Abs(sweep)
 }

--- a/model/sketch/dimension_3d.go
+++ b/model/sketch/dimension_3d.go
@@ -8,6 +8,7 @@ import (
 
 	"oblikovati.org/math"
 	"oblikovati.org/model/param"
+	"oblikovati.org/solve/ad"
 )
 
 // DimensionConstraint3D sizes a 3D sketch, backed by a model parameter like its 2D
@@ -15,10 +16,15 @@ import (
 // (F05) solves 3D sketches unchanged.
 type DimensionConstraint3D struct {
 	constraintBase
-	kind        DimKind
-	driven      bool
-	param       *param.Parameter
+	kind   DimKind
+	driven bool
+	param  *param.Parameter
+	// measure is the float quantity (for reporting and the residual value); measureAD is
+	// its dual twin for exact partials. measureAD is nil ONLY for the spline-length
+	// dimension, whose value comes from the kernel NURBS sampler — a black box with no
+	// closed-form derivative (see Partials) — and which therefore finite-differences.
 	measure     func() float64
+	measureAD   adFunc1
 	vars        []*math.Scalar
 	refs        []Entity     // dimensioned operands, for serialization
 	planeNormal math.Vector3 // point-plane dimension only
@@ -71,12 +77,47 @@ func (d *DimensionConstraint3D) Residuals() []float64 {
 	return []float64{d.measure() - d.param.ModelValue()}
 }
 
+// Partials returns the dimension's exact Jacobian row from its dual measure, or nil when
+// driven. The lone exception is the spline-length dimension (measureAD nil): its value is
+// produced by the kernel NURBS sampler, a black box with no closed-form derivative, so it
+// alone finite-differences over its own variables (restoring each) — every other 3D
+// dimension is exact and perturbs nothing (#1417).
+func (d *DimensionConstraint3D) Partials() [][]float64 {
+	if d.driven {
+		return nil
+	}
+	if d.measureAD == nil {
+		return sampledMeasurePartials(d.vars, d.measure)
+	}
+	return adPartials(d.vars, func(v []ad.Number) []ad.Number {
+		return []ad.Number{d.measureAD(v).AddConst(-d.param.ModelValue())}
+	})
+}
+
 // Variables returns the 3D DOFs this dimension constrains.
 func (d *DimensionConstraint3D) Variables() []*math.Scalar {
 	if d.driven {
 		return nil
 	}
 	return d.vars
+}
+
+// sampledMeasurePartials central-differences a single black-box measure (the NURBS-sampled
+// spline length) over its own variables, restoring each — the one residual whose
+// derivative is not closed-form (#1417). The target is constant, so ∂residual/∂v = ∂measure/∂v.
+func sampledMeasurePartials(vars []*math.Scalar, measure func() float64) [][]float64 {
+	const h = 1e-7 // tol:numeric — black-box (NURBS spline length) finite-difference step
+	row := make([]float64, len(vars))
+	for i, v := range vars {
+		orig := *v
+		*v = orig + h
+		plus := measure()
+		*v = orig - h
+		minus := measure()
+		*v = orig
+		row[i] = (plus - minus) / (2 * h)
+	}
+	return [][]float64{row}
 }
 
 // DimensionConstraints3D owns a 3D sketch's dimensions and their parameters.
@@ -101,9 +142,26 @@ func (dc *DimensionConstraints3D) Count() int                        { return le
 func (dc *DimensionConstraints3D) Item(i int) *DimensionConstraint3D { return dc.items[i] }
 
 // create builds a 3D dimension of the given kind, backed by a fresh model parameter, over
-// a measure closure and the scalar DOFs it constrains. It is the shared seam every
-// AddXxx factory uses.
-func (dc *DimensionConstraints3D) create(kind DimKind, expression string, refs []Entity, measure func() float64, vars []*math.Scalar) (*DimensionConstraint3D, error) {
+// a dual measure (the source of both its value and its exact Jacobian row, #1417) and the
+// scalar DOFs it constrains. It is the shared seam every closed-form AddXxx factory uses.
+func (dc *DimensionConstraints3D) create(kind DimKind, expression string, refs []Entity, measure adFunc1, vars []*math.Scalar) (*DimensionConstraint3D, error) {
+	d, err := dc.newDimension(kind, expression, refs, func() float64 { return adMeasureValue(vars, measure) }, vars)
+	if err != nil {
+		return nil, err
+	}
+	d.measureAD = measure
+	return d, nil
+}
+
+// createSampled builds a 3D dimension whose measure is a black-box float closure (the
+// NURBS-sampled spline length) with no closed-form derivative — its measureAD stays nil
+// and Partials finite-differences it.
+func (dc *DimensionConstraints3D) createSampled(kind DimKind, expression string, refs []Entity, measure func() float64, vars []*math.Scalar) (*DimensionConstraint3D, error) {
+	return dc.newDimension(kind, expression, refs, measure, vars)
+}
+
+// newDimension is the common construction step shared by create and createSampled.
+func (dc *DimensionConstraints3D) newDimension(kind DimKind, expression string, refs []Entity, measure func() float64, vars []*math.Scalar) (*DimensionConstraint3D, error) {
 	p, err := dc.params.AddModelParameter(dc.nextName(), expression)
 	if err != nil {
 		return nil, fmt.Errorf("sketch: 3D dimension parameter: %w", err)
@@ -115,31 +173,30 @@ func (dc *DimensionConstraints3D) create(kind DimKind, expression string, refs [
 
 // AddDistance dimensions the distance between two 3D points.
 func (dc *DimensionConstraints3D) AddDistance(a, b *Point3D, expression string) (*DimensionConstraint3D, error) {
-	return dc.create(DistanceDim, expression, []Entity{a, b},
-		func() float64 { return float64(a.Position().DistanceTo(b.Position())) },
+	measure := func(v []ad.Number) ad.Number { return adV3(v, 0).Sub(adV3(v, 3)).Length() }
+	return dc.create(DistanceDim, expression, []Entity{a, b}, measure,
 		[]*math.Scalar{&a.X, &a.Y, &a.Z, &b.X, &b.Y, &b.Z})
 }
 
 // AddLineLength dimensions a 3D line's length (the distance between its endpoints).
 func (dc *DimensionConstraints3D) AddLineLength(l *Line3D, expression string) (*DimensionConstraint3D, error) {
-	return dc.create(LengthDimKind3D, expression, []Entity{l},
-		func() float64 { return float64(l.Length()) },
+	measure := func(v []ad.Number) ad.Number { return adLine3DDir(v, 0).Length() }
+	return dc.create(LengthDimKind3D, expression, []Entity{l}, measure,
 		[]*math.Scalar{&l.A.X, &l.A.Y, &l.A.Z, &l.B.X, &l.B.Y, &l.B.Z})
 }
 
 // AddRadius dimensions a 3D circle's radius.
 func (dc *DimensionConstraints3D) AddRadius(c *Circle3D, expression string) (*DimensionConstraint3D, error) {
-	return dc.create(RadiusDim, expression, []Entity{c},
-		func() float64 { return float64(c.Radius) }, []*math.Scalar{&c.Radius})
+	measure := func(v []ad.Number) ad.Number { return v[0] }
+	return dc.create(RadiusDim, expression, []Entity{c}, measure, []*math.Scalar{&c.Radius})
 }
 
 // AddPointPlaneDistance dimensions the signed distance from a 3D point to the origin
 // plane with the given unit normal (XY ⇒ +Z, XZ ⇒ +Y, YZ ⇒ +X): the point's coordinate
 // along that normal.
 func (dc *DimensionConstraints3D) AddPointPlaneDistance(p *Point3D, normal math.Vector3, expression string) (*DimensionConstraint3D, error) {
-	d, err := dc.create(PointPlaneDimKind3D, expression, []Entity{p},
-		func() float64 { return float64(p.X*normal.X + p.Y*normal.Y + p.Z*normal.Z) },
-		[]*math.Scalar{&p.X, &p.Y, &p.Z})
+	measure := func(v []ad.Number) ad.Number { return adV3(v, 0).Dot(adConstVec3(normal)) }
+	d, err := dc.create(PointPlaneDimKind3D, expression, []Entity{p}, measure, []*math.Scalar{&p.X, &p.Y, &p.Z})
 	if err != nil {
 		return nil, err
 	}
@@ -147,11 +204,14 @@ func (dc *DimensionConstraints3D) AddPointPlaneDistance(p *Point3D, normal math.
 	return d, nil
 }
 
-// AddTwoLineAngle dimensions the angle between two 3D lines (radians).
+// AddTwoLineAngle dimensions the angle between two 3D lines (radians). The unsigned angle
+// atan2(|d1×d2|, d1·d2) equals acos(cos θ) on [0,π] but differentiates cleanly.
 func (dc *DimensionConstraints3D) AddTwoLineAngle(l1, l2 *Line3D, expression string) (*DimensionConstraint3D, error) {
-	return dc.create(AngleDim, expression, []Entity{l1, l2},
-		func() float64 { return angleBetweenLines3D(l1, l2) },
-		append(line3DVars(l1), line3DVars(l2)...))
+	measure := func(v []ad.Number) ad.Number {
+		d1, d2 := adLine3DDir(v, 0), adLine3DDir(v, 6)
+		return d1.Cross(d2).Length().Atan2(d1.Dot(d2))
+	}
+	return dc.create(AngleDim, expression, []Entity{l1, l2}, measure, append(line3DVars(l1), line3DVars(l2)...))
 }
 
 // AddSplineLength dimensions a 3D spline's arc length, measured over the same
@@ -161,7 +221,7 @@ func (dc *DimensionConstraints3D) AddSplineLength(sp *Spline3D, expression strin
 	if len(sp.Points) < 2 {
 		return nil, fmt.Errorf("sketch: splineLength: spline %d has %d points, need at least 2", sp.EntityID(), len(sp.Points))
 	}
-	return dc.create(SplineLengthDimKind3D, expression, []Entity{sp},
+	return dc.createSampled(SplineLengthDimKind3D, expression, []Entity{sp},
 		func() float64 { return splineLength3D(sp) }, sp.smoothVars3D())
 }
 

--- a/model/sketch/dimension_advanced.go
+++ b/model/sketch/dimension_advanced.go
@@ -3,24 +3,31 @@
 package sketch
 
 import (
-	stdmath "math"
-
 	"oblikovati.org/math"
+	"oblikovati.org/solve/ad"
 )
 
 // AddOffsetDim dimensions the perpendicular distance from point p to line l.
 func (dc *DimensionConstraints) AddOffsetDim(p *Point, l *Line, expression string) (*DimensionConstraint, error) {
-	measure := func() float64 { return perpDistance(p, l) }
+	measure := func(v []ad.Number) ad.Number {
+		pt, a, b := ad.V2(v[0], v[1]), ad.V2(v[2], v[3]), ad.V2(v[4], v[5])
+		dir := b.Sub(a)
+		length := dir.Length()
+		if length.Val() == 0 {
+			return pt.Sub(a).Length() // degenerate line: distance to its point
+		}
+		return dir.Cross(pt.Sub(a)).Div(length).Abs()
+	}
 	vars := []*math.Scalar{&p.X, &p.Y, &l.A.X, &l.A.Y, &l.B.X, &l.B.Y}
 	return dc.create(OffsetDim, expression, []Entity{p, l}, measure, vars)
 }
 
 // AddThreePointAngle dimensions the angle a–vertex–b (the included angle at vertex).
 func (dc *DimensionConstraints) AddThreePointAngle(vertex, a, b *Point, expression string) (*DimensionConstraint, error) {
-	measure := func() float64 {
-		ax, ay := float64(a.X-vertex.X), float64(a.Y-vertex.Y)
-		bx, by := float64(b.X-vertex.X), float64(b.Y-vertex.Y)
-		return stdmath.Atan2(stdmath.Abs(ax*by-ay*bx), ax*bx+ay*by)
+	measure := func(v []ad.Number) ad.Number {
+		va := ad.V2(v[2], v[3]).Sub(ad.V2(v[0], v[1])) // a − vertex
+		vb := ad.V2(v[4], v[5]).Sub(ad.V2(v[0], v[1])) // b − vertex
+		return va.Cross(vb).Abs().Atan2(va.Dot(vb))
 	}
 	vars := []*math.Scalar{&vertex.X, &vertex.Y, &a.X, &a.Y, &b.X, &b.Y}
 	return dc.create(ThreePointAngleDim, expression, []Entity{vertex, a, b}, measure, vars)
@@ -28,18 +35,6 @@ func (dc *DimensionConstraints) AddThreePointAngle(vertex, a, b *Point, expressi
 
 // AddEllipseRadius dimensions an ellipse's major radius.
 func (dc *DimensionConstraints) AddEllipseRadius(e *Ellipse, expression string) (*DimensionConstraint, error) {
-	measure := func() float64 { return float64(e.MajorRadius) }
+	measure := func(v []ad.Number) ad.Number { return v[0] }
 	return dc.create(EllipseRadiusDim, expression, []Entity{e}, measure, []*math.Scalar{&e.MajorRadius})
-}
-
-// perpDistance is the absolute perpendicular distance from point p to the line through l.
-func perpDistance(p *Point, l *Line) float64 {
-	a, b := l.A.Position(), l.B.Position()
-	dx, dy := float64(b.X-a.X), float64(b.Y-a.Y)
-	length := stdmath.Hypot(dx, dy)
-	if length == 0 {
-		return float64(p.Position().DistanceTo(a))
-	}
-	cross := float64(p.X-a.X)*dy - float64(p.Y-a.Y)*dx
-	return stdmath.Abs(cross) / length
 }

--- a/model/sketch/entities.go
+++ b/model/sketch/entities.go
@@ -125,6 +125,7 @@ type CircularCurve interface {
 	// For a circle that is its center and radius; for an arc the radius has no DOF of
 	// its own, so it is the center and start point that define it.
 	circularVars() []*math.Scalar
+	circularAD
 }
 
 // CenterPoint, CurveRadius and circularVars make Circle a [CircularCurve].

--- a/model/sketch/moveable_status.go
+++ b/model/sketch/moveable_status.go
@@ -109,9 +109,10 @@ func freeVariableSet(cons []Constraint, universe []*math.Scalar) map[*math.Scala
 	return free
 }
 
-// freeVarTol is the residual-norm² threshold below which a coordinate
-// direction counts as captured by the constraints. It is generous because the
-// Jacobian rows are finite-difference approximations.
+// freeVarTol is the residual-norm² threshold below which a coordinate direction
+// counts as captured by the constraints. The Jacobian rows are now exact analytic
+// derivatives (#1417), so the slack absorbs Gram–Schmidt round-off rather than
+// finite-difference noise; it is left unchanged to keep classifications stable.
 const freeVarTol = 1e-6
 
 // orthonormalRows builds an orthonormal basis of the row space (modified

--- a/solve/ad/errors.go
+++ b/solve/ad/errors.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ad
+
+import "fmt"
+
+// indexError reports a seed index outside the variable system's range — a wiring
+// bug in a constraint (its Partials referenced a variable it did not declare).
+type indexError struct {
+	index, count int
+}
+
+func (e indexError) Error() string {
+	return fmt.Sprintf("ad: variable index %d out of range for a %d-variable system", e.index, e.count)
+}
+
+func adIndexError(i, n int) error { return indexError{index: i, count: n} }

--- a/solve/ad/number.go
+++ b/solve/ad/number.go
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package ad is a small forward-mode automatic-differentiation layer (vector
+// duals) the constraint solver uses to obtain EXACT residual partial derivatives
+// without finite differencing and without perturbing live geometry (Oblikovati/
+// Oblikovati#1417). A [Number] carries a value and its gradient with respect to a
+// fixed set of seeded variables; arithmetic propagates both, so evaluating a
+// residual formula once over seeded numbers yields the residual AND the row of the
+// Jacobian for free, to machine precision.
+//
+// It is the project-owned alternative to hand-coding (and re-deriving) a Jacobian
+// per constraint — the approach SolveSpace/planegcs take by hand, done here by
+// construction so a constraint's derivative can never drift from its residual.
+//
+//	v := ad.Seed([]float64{3, 4})        // two variables, seeded e0,e1
+//	r := v[0].Hypot(v[1])                // r.Val()==5, r.Grad()=={0.6, 0.8}
+package ad
+
+import stdmath "math"
+
+// Number is a forward-mode dual: a value and its gradient w.r.t. the seeded
+// variables. A nil grad means a constant (all-zero gradient) — kept nil so the
+// value-only path allocates nothing.
+type Number struct {
+	val  float64
+	grad []float64
+}
+
+// Const returns a constant (zero-gradient) number.
+func Const(v float64) Number { return Number{val: v} }
+
+// Var returns variable i of an n-variable system seeded at value v: its gradient
+// is the unit vector eᵢ. Panics on an out-of-range index so a mis-wired constraint
+// fails loudly rather than silently producing a wrong derivative.
+func Var(v float64, i, n int) Number {
+	if i < 0 || i >= n {
+		panic(adIndexError(i, n))
+	}
+	g := make([]float64, n)
+	g[i] = 1
+	return Number{val: v, grad: g}
+}
+
+// Seed returns the values as the variables of an len(vals)-variable system, each
+// seeded with its own unit gradient — the input row a residual formula consumes.
+func Seed(vals []float64) []Number {
+	out := make([]Number, len(vals))
+	for i, v := range vals {
+		out[i] = Var(v, i, len(vals))
+	}
+	return out
+}
+
+// Consts returns the values as constants (no gradient) — the input row for a
+// value-only (no-derivative) evaluation.
+func Consts(vals []float64) []Number {
+	out := make([]Number, len(vals))
+	for i, v := range vals {
+		out[i] = Number{val: v}
+	}
+	return out
+}
+
+// Val returns the number's value.
+func (a Number) Val() float64 { return a.val }
+
+// Grad returns the number's gradient (length = the seeded variable count), or nil
+// for a constant.
+func (a Number) Grad() []float64 { return a.grad }
+
+// Add returns a+b.
+func (a Number) Add(b Number) Number {
+	return Number{val: a.val + b.val, grad: combine(a.grad, b.grad, 1, 1)}
+}
+
+// Sub returns a−b.
+func (a Number) Sub(b Number) Number {
+	return Number{val: a.val - b.val, grad: combine(a.grad, b.grad, 1, -1)}
+}
+
+// Mul returns a·b (product rule: d(ab)=b·da+a·db).
+func (a Number) Mul(b Number) Number {
+	return Number{val: a.val * b.val, grad: combine(a.grad, b.grad, b.val, a.val)}
+}
+
+// Div returns a/b (quotient rule). It does not guard b==0; a residual that can
+// divide by zero must check its denominator before calling (as the float formulas
+// already do for degenerate geometry).
+func (a Number) Div(b Number) Number {
+	inv := 1 / b.val
+	return Number{val: a.val * inv, grad: combine(a.grad, b.grad, inv, -a.val*inv*inv)}
+}
+
+// Neg returns −a.
+func (a Number) Neg() Number { return Number{val: -a.val, grad: combine(a.grad, nil, -1, 0)} }
+
+// AddConst returns a+c (c constant); Scale returns a·c.
+func (a Number) AddConst(c float64) Number { return Number{val: a.val + c, grad: a.grad} }
+func (a Number) Scale(c float64) Number {
+	return Number{val: a.val * c, grad: combine(a.grad, nil, c, 0)}
+}
+
+// Sqrt returns √a (derivative 1/(2√a)); the gradient is zero at a==0 where √ is not
+// differentiable, which keeps a degenerate (coincident) term from producing NaNs.
+func (a Number) Sqrt() Number {
+	s := stdmath.Sqrt(a.val)
+	d := 0.0
+	if s != 0 {
+		d = 0.5 / s
+	}
+	return Number{val: s, grad: combine(a.grad, nil, d, 0)}
+}
+
+// Hypot returns √(a²+b²) — the Euclidean length used by distances and radii. Its
+// gradient is (a·da+b·db)/hypot, zero at the origin (the non-differentiable point).
+func (a Number) Hypot(b Number) Number {
+	h := stdmath.Hypot(a.val, b.val)
+	if h == 0 {
+		return Number{val: 0, grad: combine(a.grad, b.grad, 0, 0)}
+	}
+	return Number{val: h, grad: combine(a.grad, b.grad, a.val/h, b.val/h)}
+}
+
+// Abs returns |a|; its derivative is sign(a) (and zero at a==0, the kink). The
+// tangent constraint and tangent-distance dimension take an absolute distance.
+func (a Number) Abs() Number {
+	switch {
+	case a.val > 0:
+		return a
+	case a.val < 0:
+		return a.Neg()
+	default:
+		return Number{val: 0, grad: combine(a.grad, nil, 0, 0)}
+	}
+}
+
+// Atan2 returns atan2(a, b) treating a as y and b as x — the angle measure. Its
+// gradient is (x·dy − y·dx)/(x²+y²); zero at the origin where the angle is
+// undefined.
+func (a Number) Atan2(b Number) Number {
+	y, x := a.val, b.val
+	den := x*x + y*y
+	t := stdmath.Atan2(y, x)
+	if den == 0 {
+		return Number{val: t, grad: combine(a.grad, b.grad, 0, 0)}
+	}
+	return Number{val: t, grad: combine(a.grad, b.grad, x/den, -y/den)}
+}
+
+// Sin and Cos are the trigonometric primitives (used by 3D angle relations).
+func (a Number) Sin() Number {
+	return Number{val: stdmath.Sin(a.val), grad: combine(a.grad, nil, stdmath.Cos(a.val), 0)}
+}
+func (a Number) Cos() Number {
+	return Number{val: stdmath.Cos(a.val), grad: combine(a.grad, nil, -stdmath.Sin(a.val), 0)}
+}
+
+// combine returns ca·ga + cb·gb, the chain-rule accumulation of two operands'
+// gradients scaled by their partials. It is the single place gradient vectors are
+// allocated, so a constant (nil) operand contributes nothing and the value-only
+// path stays allocation-free.
+func combine(ga, gb []float64, ca, cb float64) []float64 {
+	n := len(ga)
+	if len(gb) > n {
+		n = len(gb)
+	}
+	if n == 0 {
+		return nil
+	}
+	out := make([]float64, n)
+	for i := range ga {
+		out[i] += ca * ga[i]
+	}
+	for i := range gb {
+		out[i] += cb * gb[i]
+	}
+	return out
+}

--- a/solve/ad/number_test.go
+++ b/solve/ad/number_test.go
@@ -106,6 +106,43 @@ func TestVarSeedsUnitGradient(t *testing.T) {
 	}
 }
 
+func TestVectorOpValues(t *testing.T) {
+	// Spot-check the value (not gradient) of each vector helper at constants.
+	a2, b2 := V2(Const(1), Const(2)), V2(Const(3), Const(5))
+	if v := a2.Add(b2); v.X.Val() != 4 || v.Y.Val() != 7 {
+		t.Errorf("Vec2.Add = (%v,%v), want (4,7)", v.X.Val(), v.Y.Val())
+	}
+	if v := b2.Sub(a2); v.X.Val() != 2 || v.Y.Val() != 3 {
+		t.Errorf("Vec2.Sub = (%v,%v), want (2,3)", v.X.Val(), v.Y.Val())
+	}
+	if v := a2.Scale(2); v.X.Val() != 2 || v.Y.Val() != 4 {
+		t.Errorf("Vec2.Scale = (%v,%v), want (2,4)", v.X.Val(), v.Y.Val())
+	}
+	if v := a2.MulN(Const(3)); v.X.Val() != 3 || v.Y.Val() != 6 {
+		t.Errorf("Vec2.MulN = (%v,%v), want (3,6)", v.X.Val(), v.Y.Val())
+	}
+	if d := a2.Dot(b2).Val(); d != 13 {
+		t.Errorf("Vec2.Dot = %v, want 13", d)
+	}
+
+	a3, b3 := V3(Const(1), Const(2), Const(3)), V3(Const(4), Const(5), Const(6))
+	if v := a3.Add(b3); v.X.Val() != 5 || v.Z.Val() != 9 {
+		t.Errorf("Vec3.Add = %v, want X=5,Z=9", v)
+	}
+	if v := b3.Scale(0.5); v.Y.Val() != 2.5 {
+		t.Errorf("Vec3.Scale Y = %v, want 2.5", v.Y.Val())
+	}
+	if v := a3.MulN(Const(2)); v.Z.Val() != 6 {
+		t.Errorf("Vec3.MulN Z = %v, want 6", v.Z.Val())
+	}
+}
+
+func TestIndexErrorMessage(t *testing.T) {
+	if got := adIndexError(5, 3).Error(); got != "ad: variable index 5 out of range for a 3-variable system" {
+		t.Errorf("error message = %q", got)
+	}
+}
+
 func TestVarPanicsOnBadIndex(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {

--- a/solve/ad/number_test.go
+++ b/solve/ad/number_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ad
+
+import (
+	stdmath "math"
+	"testing"
+)
+
+// fdGrad approximates ∇f at x by central differences — the trusted oracle the
+// analytic gradients are checked against (finite differencing is fine in a test;
+// the point of #1417 is to keep it out of the solve path).
+func fdGrad(f func([]float64) float64, x []float64) []float64 {
+	const h = 1e-6
+	g := make([]float64, len(x))
+	for i := range x {
+		xp := append([]float64(nil), x...)
+		xm := append([]float64(nil), x...)
+		xp[i] += h
+		xm[i] -= h
+		g[i] = (f(xp) - f(xm)) / (2 * h)
+	}
+	return g
+}
+
+func assertGradMatchesFD(t *testing.T, name string, f func([]Number) Number, x []float64) {
+	t.Helper()
+	got := f(Seed(x)).Grad()
+	want := fdGrad(func(v []float64) float64 { return f(Consts(v)).Val() }, x)
+	if len(got) != len(want) {
+		t.Fatalf("%s: gradient length %d, want %d", name, len(got), len(want))
+	}
+	for i := range want {
+		if stdmath.Abs(got[i]-want[i]) > 1e-5 {
+			t.Errorf("%s: ∂/∂x%d = %.9f, FD says %.9f", name, i, got[i], want[i])
+		}
+	}
+}
+
+func TestArithmeticGradientsMatchFiniteDifference(t *testing.T) {
+	cases := []struct {
+		name string
+		f    func([]Number) Number
+	}{
+		{"add", func(v []Number) Number { return v[0].Add(v[1]) }},
+		{"sub", func(v []Number) Number { return v[0].Sub(v[1]) }},
+		{"mul", func(v []Number) Number { return v[0].Mul(v[1]) }},
+		{"div", func(v []Number) Number { return v[0].Div(v[1]) }},
+		{"neg", func(v []Number) Number { return v[0].Neg() }},
+		{"scale", func(v []Number) Number { return v[0].Scale(2.5) }},
+		{"addconst", func(v []Number) Number { return v[0].AddConst(3) }},
+		{"sqrt", func(v []Number) Number { return v[0].Mul(v[0]).Add(v[1]).Sqrt() }},
+		{"hypot", func(v []Number) Number { return v[0].Hypot(v[1]) }},
+		{"abs+", func(v []Number) Number { return v[0].Abs() }},
+		{"abs-", func(v []Number) Number { return v[0].Neg().Abs() }},
+		{"atan2", func(v []Number) Number { return v[0].Atan2(v[1]) }},
+		{"sin", func(v []Number) Number { return v[0].Sin() }},
+		{"cos", func(v []Number) Number { return v[0].Cos() }},
+		{"composite", func(v []Number) Number {
+			return v[0].Mul(v[1]).Sub(v[0].Hypot(v[1])).Div(v[1].AddConst(2))
+		}},
+	}
+	x := []float64{1.3, 2.7}
+	for _, c := range cases {
+		assertGradMatchesFD(t, c.name, c.f, x)
+	}
+}
+
+func TestVectorOpsGradientsMatchFiniteDifference(t *testing.T) {
+	// v = [ax, ay, az, bx, by, bz]
+	a := func(v []Number) Vec3 { return V3(v[0], v[1], v[2]) }
+	b := func(v []Number) Vec3 { return V3(v[3], v[4], v[5]) }
+	cases := []struct {
+		name string
+		f    func([]Number) Number
+	}{
+		{"dot3", func(v []Number) Number { return a(v).Dot(b(v)) }},
+		{"cross3.x", func(v []Number) Number { return a(v).Cross(b(v)).X }},
+		{"len3", func(v []Number) Number { return a(v).Length() }},
+		{"sub.dot", func(v []Number) Number { return a(v).Sub(b(v)).Dot(a(v)) }},
+		{"cross2", func(v []Number) Number { return V2(v[0], v[1]).Cross(V2(v[3], v[4])) }},
+		{"len2", func(v []Number) Number { return V2(v[0], v[1]).Length() }},
+	}
+	x := []float64{1.1, -2.2, 3.3, 0.7, 1.9, -0.4}
+	for _, c := range cases {
+		assertGradMatchesFD(t, c.name, c.f, x)
+	}
+}
+
+func TestConstHasNoGradient(t *testing.T) {
+	if g := Const(5).Add(Const(2)).Grad(); g != nil {
+		t.Errorf("constant arithmetic produced a gradient %v, want nil", g)
+	}
+}
+
+func TestVarSeedsUnitGradient(t *testing.T) {
+	v := Var(7, 1, 3)
+	if v.Val() != 7 {
+		t.Errorf("value = %v, want 7", v.Val())
+	}
+	want := []float64{0, 1, 0}
+	for i, g := range v.Grad() {
+		if g != want[i] {
+			t.Fatalf("grad = %v, want %v", v.Grad(), want)
+		}
+	}
+}
+
+func TestVarPanicsOnBadIndex(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("Var with out-of-range index did not panic")
+		}
+	}()
+	Var(1, 5, 3)
+}

--- a/solve/ad/vector.go
+++ b/solve/ad/vector.go
@@ -31,6 +31,10 @@ func (a Vec3) Add(b Vec3) Vec3 { return Vec3{X: a.X.Add(b.X), Y: a.Y.Add(b.Y), Z
 func (a Vec2) Scale(c float64) Vec2 { return Vec2{X: a.X.Scale(c), Y: a.Y.Scale(c)} }
 func (a Vec3) Scale(c float64) Vec3 { return Vec3{X: a.X.Scale(c), Y: a.Y.Scale(c), Z: a.Z.Scale(c)} }
 
+// MulN multiplies every component by the dual scalar n (a varying scale, e.g. 1/length).
+func (a Vec2) MulN(n Number) Vec2 { return Vec2{X: a.X.Mul(n), Y: a.Y.Mul(n)} }
+func (a Vec3) MulN(n Number) Vec3 { return Vec3{X: a.X.Mul(n), Y: a.Y.Mul(n), Z: a.Z.Mul(n)} }
+
 // Dot returns a·b.
 func (a Vec2) Dot(b Vec2) Number { return a.X.Mul(b.X).Add(a.Y.Mul(b.Y)) }
 func (a Vec3) Dot(b Vec3) Number {

--- a/solve/ad/vector.go
+++ b/solve/ad/vector.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ad
+
+// Vec2 and Vec3 are dual-number vectors — the planar and spatial points/directions
+// constraint residuals are written in terms of, so a residual reads like its
+// geometric definition (cross, dot, length) while carrying exact derivatives. They
+// hold [Number] components, not raw floats, so every operation differentiates.
+
+// Vec2 is a 2D dual vector.
+type Vec2 struct{ X, Y Number }
+
+// Vec3 is a 3D dual vector.
+type Vec3 struct{ X, Y, Z Number }
+
+// V2 builds a 2D dual vector from two components.
+func V2(x, y Number) Vec2 { return Vec2{X: x, Y: y} }
+
+// V3 builds a 3D dual vector from three components.
+func V3(x, y, z Number) Vec3 { return Vec3{X: x, Y: y, Z: z} }
+
+// Sub returns a−b componentwise.
+func (a Vec2) Sub(b Vec2) Vec2 { return Vec2{X: a.X.Sub(b.X), Y: a.Y.Sub(b.Y)} }
+func (a Vec3) Sub(b Vec3) Vec3 { return Vec3{X: a.X.Sub(b.X), Y: a.Y.Sub(b.Y), Z: a.Z.Sub(b.Z)} }
+
+// Add returns a+b componentwise.
+func (a Vec2) Add(b Vec2) Vec2 { return Vec2{X: a.X.Add(b.X), Y: a.Y.Add(b.Y)} }
+func (a Vec3) Add(b Vec3) Vec3 { return Vec3{X: a.X.Add(b.X), Y: a.Y.Add(b.Y), Z: a.Z.Add(b.Z)} }
+
+// Scale multiplies every component by the constant c.
+func (a Vec2) Scale(c float64) Vec2 { return Vec2{X: a.X.Scale(c), Y: a.Y.Scale(c)} }
+func (a Vec3) Scale(c float64) Vec3 { return Vec3{X: a.X.Scale(c), Y: a.Y.Scale(c), Z: a.Z.Scale(c)} }
+
+// Dot returns a·b.
+func (a Vec2) Dot(b Vec2) Number { return a.X.Mul(b.X).Add(a.Y.Mul(b.Y)) }
+func (a Vec3) Dot(b Vec3) Number {
+	return a.X.Mul(b.X).Add(a.Y.Mul(b.Y)).Add(a.Z.Mul(b.Z))
+}
+
+// Cross returns the 2D scalar cross product aₓbᵧ − aᵧbₓ (the signed parallelogram
+// area), zero iff a and b are parallel.
+func (a Vec2) Cross(b Vec2) Number { return a.X.Mul(b.Y).Sub(a.Y.Mul(b.X)) }
+
+// Cross returns the 3D cross product a×b.
+func (a Vec3) Cross(b Vec3) Vec3 {
+	return Vec3{
+		X: a.Y.Mul(b.Z).Sub(a.Z.Mul(b.Y)),
+		Y: a.Z.Mul(b.X).Sub(a.X.Mul(b.Z)),
+		Z: a.X.Mul(b.Y).Sub(a.Y.Mul(b.X)),
+	}
+}
+
+// Length returns the Euclidean length √(x²+y²[+z²]).
+func (a Vec2) Length() Number { return a.X.Hypot(a.Y) }
+func (a Vec3) Length() Number { return a.Dot(a).Sqrt() }

--- a/solve/jacobian_test.go
+++ b/solve/jacobian_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package solve
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// diffGap is a Differentiable version of gap: residual = (b−a)−dist, with exact
+// partials ∂r/∂a = −1, ∂r/∂b = +1. It also records whether its variables were ever
+// read at a perturbed value, to prove the analytic path never moves them.
+type diffGap struct {
+	a, b *math.Scalar
+	dist float64
+}
+
+func (g diffGap) Residuals() []float64      { return []float64{(*g.b - *g.a) - g.dist} }
+func (g diffGap) Variables() []*math.Scalar { return []*math.Scalar{g.a, g.b} }
+func (g diffGap) Partials() [][]float64     { return [][]float64{{-1, 1}} }
+
+// nonDiff is a plain residual (no Partials) — it forces the finite-difference fallback.
+type nonDiff struct{ v *math.Scalar }
+
+func (n nonDiff) Residuals() []float64 { return []float64{*n.v * *n.v} }
+
+func TestAnalyticJacobianMatchesFiniteDifference(t *testing.T) {
+	a, b := math.Scalar(1.5), math.Scalar(4.0)
+	vars := []*math.Scalar{&a, &b}
+	src := []Residual{diffGap{&a, &b, 2}}
+
+	analytic, ok := analyticJacobian(src, vars)
+	if !ok {
+		t.Fatal("analyticJacobian rejected an all-differentiable system")
+	}
+	fd := finiteDiffJacobian(src, vars)
+	for i := range analytic {
+		for j := range analytic[i] {
+			if stdmath.Abs(analytic[i][j]-fd[i][j]) > 1e-6 {
+				t.Errorf("J[%d][%d]: analytic %v vs FD %v", i, j, analytic[i][j], fd[i][j])
+			}
+		}
+	}
+}
+
+func TestAnalyticJacobianDoesNotPerturbLiveVariables(t *testing.T) {
+	a, b := math.Scalar(1.5), math.Scalar(4.0)
+	// A NaN guard: if the analytic path mutated a live variable mid-evaluation, a
+	// concurrent reader could observe the perturbed value. We assert the exact values
+	// are untouched after the call (the FD path would restore them, but only after
+	// transiently writing orig±h).
+	_, ok := analyticJacobian([]Residual{diffGap{&a, &b, 2}}, []*math.Scalar{&a, &b})
+	if !ok {
+		t.Fatal("expected analytic path")
+	}
+	if a != 1.5 || b != 4.0 {
+		t.Errorf("live variables changed to (%v, %v), want (1.5, 4.0)", a, b)
+	}
+}
+
+func TestJacobianFallsBackToFiniteDifference(t *testing.T) {
+	v := math.Scalar(3)
+	// A non-differentiable source forces FD; the derivative of v² at 3 is 6.
+	j := Jacobian([]Residual{nonDiff{&v}}, []*math.Scalar{&v})
+	if len(j) != 1 || stdmath.Abs(j[0][0]-6) > 1e-4 {
+		t.Errorf("FD fallback Jacobian = %v, want ≈[[6]]", j)
+	}
+}
+
+func TestMixedDifferentiabilityFallsBack(t *testing.T) {
+	a, b := math.Scalar(1), math.Scalar(2)
+	// One differentiable, one not → the whole system must finite-difference.
+	if _, ok := analyticJacobian([]Residual{diffGap{&a, &b, 1}, nonDiff{&a}}, []*math.Scalar{&a, &b}); ok {
+		t.Error("analyticJacobian accepted a system with a non-differentiable source")
+	}
+}
+
+// sharedVar is a Differentiable whose Variables list the SAME pointer twice — the shape
+// EqualLength takes on two lines sharing a vertex. residual = 3·x, with the dependence
+// split across the two occurrences (partials 1 and 2), so the true column derivative is
+// their sum, 3.
+type sharedVar struct{ x *math.Scalar }
+
+func (s sharedVar) Residuals() []float64      { return []float64{3 * *s.x} }
+func (s sharedVar) Variables() []*math.Scalar { return []*math.Scalar{s.x, s.x} }
+func (s sharedVar) Partials() [][]float64     { return [][]float64{{1, 2}} }
+
+func TestAnalyticJacobianAccumulatesRepeatedVariable(t *testing.T) {
+	x := math.Scalar(1)
+	vars := []*math.Scalar{&x}
+	j, ok := analyticJacobian([]Residual{sharedVar{&x}}, vars)
+	if !ok {
+		t.Fatal("expected analytic path")
+	}
+	// The repeated-variable partials (1 and 2) must SUM into the single column (3), the
+	// same total the finite-difference path sees by perturbing x once.
+	fd := finiteDiffJacobian([]Residual{sharedVar{&x}}, vars)
+	if stdmath.Abs(j[0][0]-3) > 1e-9 || stdmath.Abs(j[0][0]-fd[0][0]) > 1e-6 {
+		t.Errorf("repeated-variable column = %v, want 3 (FD says %v)", j[0][0], fd[0][0])
+	}
+}
+
+func TestSolveReusesConvergedJacobian(t *testing.T) {
+	a, b := math.Scalar(0), math.Scalar(0)
+	r := Solve([]Residual{diffGap{&a, &b, 2}}, []*math.Scalar{&a, &b}, Options{})
+	if r.Jacobian == nil {
+		t.Fatal("Result.Jacobian not populated for reuse")
+	}
+	// The carried Jacobian must reproduce the reported DOF analysis.
+	if got := analyzeJacobian(r.Jacobian, 2); got != r.DOFAnalysis {
+		t.Errorf("DOF from carried Jacobian = %+v, want %+v", got, r.DOFAnalysis)
+	}
+}

--- a/solve/solve.go
+++ b/solve/solve.go
@@ -29,6 +29,23 @@ type Residual interface {
 	Residuals() []float64
 }
 
+// Differentiable is a residual source that supplies its OWN exact partial derivatives,
+// letting the solver assemble the Jacobian analytically — no finite differencing and,
+// crucially, no perturbation of the live variables (Oblikovati/Oblikovati#1417). When
+// every source is Differentiable the solver never finite-differences; a source that is
+// not (an opaque residual closure, e.g. the assembly positioner) makes the whole solve
+// fall back to central differences.
+type Differentiable interface {
+	Residual
+	// Variables returns the scalar DOFs the partials are ordered by — the columns of
+	// the Partials block, by pointer, so the solver can map them to global columns.
+	Variables() []*math.Scalar
+	// Partials returns ∂residualᵢ/∂varⱼ at the current point: one row per value of
+	// Residuals() (same order), each row holding a partial for every variable of
+	// Variables() (same order). It reads, never mutates, the live variables.
+	Partials() [][]float64
+}
+
 // Status summarizes a constraint system's state.
 type Status uint8
 
@@ -86,6 +103,10 @@ type Result struct {
 	Iterations int
 	Residual   float64 // final max |residual|
 	DOFAnalysis
+	// Jacobian is the residual Jacobian at the converged point, computed once at the
+	// end of the solve and reused for the rank/DOF analysis here (#1417). Callers can
+	// reuse it for mobility analysis instead of rebuilding it.
+	Jacobian [][]float64
 }
 
 // Solve drives the residuals to zero over the given variables, mutating them in place
@@ -110,11 +131,16 @@ func Solve(res []Residual, vars []*math.Scalar, opts Options) Result {
 		}
 		r = next
 	}
+	// Compute the Jacobian ONCE at the converged point and derive the DOF analysis from
+	// it, rather than rebuilding it inside AnalyzeDOF (#1417). The Result carries it so a
+	// caller can reuse it for mobility analysis too.
+	j := Jacobian(res, vars)
 	return Result{
 		Converged:   infNorm(r) < opts.Tolerance,
 		Iterations:  iter,
 		Residual:    infNorm(r),
-		DOFAnalysis: AnalyzeDOF(res, vars),
+		DOFAnalysis: analyzeJacobian(j, len(vars)),
+		Jacobian:    j,
 	}
 }
 
@@ -142,10 +168,16 @@ func newtonStep(res []Residual, vars []*math.Scalar, r []float64, lambda *float6
 	return r, false
 }
 
-// AnalyzeDOF computes the DOF/redundancy structure from the Jacobian rank.
+// AnalyzeDOF computes the DOF/redundancy structure from the Jacobian rank. It is the
+// entry point for analysis WITHOUT a solve (e.g. a hover-time DOF query); within a
+// solve the Jacobian is computed once and [analyzeJacobian] is reused directly.
 func AnalyzeDOF(res []Residual, vars []*math.Scalar) DOFAnalysis {
-	n := len(vars)
-	j := Jacobian(res, vars)
+	return analyzeJacobian(Jacobian(res, vars), len(vars))
+}
+
+// analyzeJacobian derives the DOF/redundancy structure from an already-built Jacobian,
+// so the matrix is computed once per solve and reused (#1417).
+func analyzeJacobian(j [][]float64, n int) DOFAnalysis {
 	m := len(j)
 	rank := matrixRank(j, 1e-7) // tol:numeric — Jacobian rank tolerance
 	a := DOFAnalysis{Variables: n, Equations: m, Rank: rank, DOF: n - rank, Redundant: m - rank}
@@ -169,10 +201,63 @@ func evalResiduals(res []Residual) []float64 {
 	return out
 }
 
-// Jacobian builds the m×n residual Jacobian by central finite differences (h=1e-7). It
-// is exported so a caller that does its own DOF/mobility analysis can reuse it.
+// Jacobian builds the m×n residual Jacobian over vars. When every residual source
+// supplies its own exact partials it is assembled analytically — no finite differencing
+// and no perturbation of the live variables (#1417). Otherwise it falls back to central
+// differences (the legacy path for opaque residual closures, e.g. the assembly
+// positioner). It is exported so a caller doing its own DOF/mobility analysis can reuse
+// it.
 func Jacobian(res []Residual, vars []*math.Scalar) [][]float64 {
-	const h = 1e-7 // tol:numeric — finite-difference Jacobian step (analytic Jacobian is #1417)
+	if j, ok := analyticJacobian(res, vars); ok {
+		return j
+	}
+	return finiteDiffJacobian(res, vars)
+}
+
+// analyticJacobian assembles the Jacobian from each source's exact partials, mapping the
+// source's own variables to global columns by pointer identity. It reports ok=false (so
+// the caller finite-differences instead) the moment any source is not [Differentiable].
+func analyticJacobian(res []Residual, vars []*math.Scalar) ([][]float64, bool) {
+	col := make(map[*math.Scalar]int, len(vars))
+	for i, v := range vars {
+		col[v] = i
+	}
+	var rows [][]float64
+	for _, src := range res {
+		d, ok := src.(Differentiable)
+		if !ok {
+			return nil, false
+		}
+		dvars := d.Variables()
+		for _, partials := range d.Partials() {
+			rows = append(rows, scatterRow(partials, dvars, col, len(vars)))
+		}
+	}
+	return rows, true
+}
+
+// scatterRow places a source's local partials into a full-width Jacobian row, keyed by
+// each local variable's global column. Contributions ACCUMULATE: when a constraint lists
+// the same variable twice (e.g. EqualLength on two lines sharing a vertex, where the
+// shared point is both lines' endpoint), the column's true derivative is the sum of the
+// partials w.r.t. each occurrence — matching the finite-difference path, which perturbs
+// the shared column once and sees both. Variables outside the universe (not in col) are
+// dropped, again matching finite differencing, which only perturbs universe columns.
+func scatterRow(partials []float64, dvars []*math.Scalar, col map[*math.Scalar]int, width int) []float64 {
+	row := make([]float64, width)
+	for li, p := range partials {
+		if c, in := col[dvars[li]]; in {
+			row[c] += p
+		}
+	}
+	return row
+}
+
+// finiteDiffJacobian builds the Jacobian by central differences (h=1e-7) — the fallback
+// for residual sources that cannot supply analytic partials. It perturbs the live
+// variables and restores them, so it must not be used on the interactive analysis path.
+func finiteDiffJacobian(res []Residual, vars []*math.Scalar) [][]float64 {
+	const h = 1e-7 // tol:numeric — finite-difference Jacobian step (analytic path is #1417)
 	m := len(evalResiduals(res))
 	j := make([][]float64, m)
 	for i := range j {


### PR DESCRIPTION
## What

Replaces the sketch solver's finite-difference Jacobian with **exact analytic derivatives**, obtained by forward-mode dual-number autodiff. Every 2D and 3D sketch constraint and dimension now writes its residual **once** over dual numbers; both the float residual and its exact Jacobian block derive from that one formula, so a derivative can never drift from its residual.

Closes #1417.

## Why

`solve/solve.go` built the m×n Jacobian by central differences (`h=1e-7`) and rebuilt it every Newton iteration and again in each post-solve analysis. Finite differencing:
- caps derivative accuracy at the roundoff floor exactly where Gauss–Newton already struggles (near tangency/singularity) and where rank/DOF analysis is most sensitive;
- **fails outright far from the origin**, where the fixed absolute step underflows the coordinate ULP (ties into the model-relative-tolerance work of #1399);
- perturbs live geometry pointers (`orig±h`) during differencing — a hazard on the interactive hover/DOF path.

## How

- **`solve/ad`** — a small project-owned forward-mode autodiff layer (vector duals). A `Number` carries a value and its gradient w.r.t. seeded variables; `Vec2`/`Vec3` let a residual read like its geometric definition (cross, dot, length) while differentiating by construction.
- **`solve`** — a `Differentiable` residual interface; the solver assembles the Jacobian by scattering each source's exact block into global columns (accumulating where a constraint lists a shared variable twice, e.g. two lines sharing a vertex). It computes the Jacobian **once at the converged point** and derives the DOF analysis from it. A source that can't supply analytic partials (opaque assembly closures) still falls back to finite differences, so existing behaviour is preserved.
- **`model/sketch`** — every 2D and 3D geometric constraint, the G2 smooth joins (incl. spline circumcircle curvature), the 3D bend, and all dimensions converted to dual residuals.

## Scope notes

- The **2D sketch path is fully finite-difference-free** (guard test asserts every constraint is `Differentiable`).
- Two honest exceptions, both isolated and documented: the **3D spline-length** dimension (its value comes from the kernel NURBS sampler — a black box with no closed-form derivative — so it alone finite-differences over its own variables), and the unused `CustomConstraint3D` adapter (an arbitrary residual closure). The shared **assembly positioner** is out of this issue's scope and keeps the FD fallback.

## Acceptance criteria

- [x] Analytic Jacobian per constraint; FD removed from the (2D) solve/analysis path, with the analytic path the default everywhere a closed-form residual exists.
- [x] Jacobian computed once per solve and reused for the rank/DOF analysis (no post-solve rebuild); carried on `Result` for mobility reuse.
- [x] Near-tangent fixture converges; far-from-origin fixture shows FD stalling (zero progress) where the analytic Jacobian still drives the residual down by orders of magnitude; DOF/mobility analysis perturbs no live coordinate.

## Tests

- Per-constraint and per-dimension analytic-vs-finite-difference agreement (2D and 3D), incl. the shared-vertex accumulation case verified at the assembled (global) Jacobian level.
- Solver-level analytic assembly, repeated-variable accumulation, and converged-Jacobian reuse.
- Convergence: near-tangent solve, far-from-origin FD-stall contrast, well-conditioned control.
- Guards: sketch solve path is `Differentiable`-only; DOF/mobility leave live geometry untouched.

Coverage: `solve` 92.6%, `solve/ad` 94.6%, `model/sketch` 86.2%. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)