### PR TITLE
Normalise orientation residuals so DOF classification is scale-invariant (#1418)

### DIFF
--- a/model/sketch/autodiff.go
+++ b/model/sketch/autodiff.go
@@ -71,6 +71,59 @@ func scalarValues(vars []*math.Scalar) []float64 {
 // adZeroVec2 is the dual zero vector (a constant, no gradient).
 func adZeroVec2() ad.Vec2 { return ad.V2(ad.Const(0), ad.Const(0)) }
 
+// The orientation residuals below are normalised so their magnitude is in LENGTH units
+// (perpendicular distance / projection) or DIMENSIONLESS (sine / cosine of an angle),
+// never area (|line|·|offset|). An un-normalised cross/dot residual shrinks with the
+// line's length, so a short segment yields a tiny Jacobian row that matrixRank drops —
+// mis-reporting the constraint as redundant and falsifying the DOF / over-constrained
+// signal (Oblikovati/Oblikovati#1418). Normalising keeps the Jacobian rows O(1)
+// regardless of segment length, so classification matches the geometric truth and a long
+// vs short geometrically-identical sketch classify the same.
+
+// adSignedPerpDistance returns the signed perpendicular distance of offset w from a line
+// of direction dir: (dir × w)/|dir|. A degenerate (zero-length) direction falls back to
+// |w| (distance to the line's anchor), keeping the residual finite and in length units.
+func adSignedPerpDistance(dir, w ad.Vec2) ad.Number {
+	length := dir.Length()
+	if length.Val() < math.DefaultTolerance {
+		return w.Length()
+	}
+	return dir.Cross(w).Div(length)
+}
+
+// adSineAngle returns the sine of the angle between two directions, (d1 × d2)/(|d1||d2|) —
+// the scale-invariant parallelism residual. A degenerate direction (no orientation to be
+// parallel to) falls back to the raw cross product (which is itself ≈ 0).
+func adSineAngle(d1, d2 ad.Vec2) ad.Number {
+	denom := d1.Length().Mul(d2.Length())
+	if denom.Val() < math.DefaultTolerance {
+		return d1.Cross(d2)
+	}
+	return d1.Cross(d2).Div(denom)
+}
+
+// adCosAngle returns the cosine of the angle between two directions, (d1 · d2)/(|d1||d2|) —
+// the scale-invariant perpendicularity residual (zero at a right angle). Degenerate
+// directions fall back to the raw dot product.
+func adCosAngle(d1, d2 ad.Vec2) ad.Number {
+	denom := d1.Length().Mul(d2.Length())
+	if denom.Val() < math.DefaultTolerance {
+		return d1.Dot(d2)
+	}
+	return d1.Dot(d2).Div(denom)
+}
+
+// adProjectionAlong returns the component of w along dir, (w · dir)/|dir| — a length
+// independent of dir's arbitrary representation length. A degenerate dir falls back to the
+// raw dot product.
+func adProjectionAlong(w, dir ad.Vec2) ad.Number {
+	length := dir.Length()
+	if length.Val() < math.DefaultTolerance {
+		return w.Dot(dir)
+	}
+	return w.Dot(dir).Div(length)
+}
+
 // adUnit2 returns v scaled to unit length, or the zero vector when v is (near) zero —
 // the dual twin of unit2, keeping a degenerate direction from producing NaNs.
 func adUnit2(v ad.Vec2) ad.Vec2 {

--- a/model/sketch/constraints_2d.go
+++ b/model/sketch/constraints_2d.go
@@ -52,11 +52,12 @@ func (g *GeometricConstraints) AddPointOnLine(p *Point, l *Line) *PointOnLineCon
 	return c
 }
 
-// residualAD: v = [P.X, P.Y, A.X, A.Y, B.X, B.Y]. The cross product of (P−A) with the
-// line direction (B−A) is zero iff P lies on the line.
+// residualAD: v = [P.X, P.Y, A.X, A.Y, B.X, B.Y]. The signed perpendicular distance of P
+// from the line is zero iff P lies on it — a true distance residual, not the area
+// |line|·|offset| (#1418).
 func (c *PointOnLineConstraint) residualAD(v []ad.Number) []ad.Number {
 	p, a, b := ad.V2(v[0], v[1]), ad.V2(v[2], v[3]), ad.V2(v[4], v[5])
-	return []ad.Number{b.Sub(a).Cross(p.Sub(a))}
+	return []ad.Number{adSignedPerpDistance(b.Sub(a), p.Sub(a))}
 }
 func (c *PointOnLineConstraint) Residuals() []float64 {
 	return adResiduals(c.Variables(), c.residualAD)
@@ -184,10 +185,11 @@ func (g *GeometricConstraints) AddParallel(l1, l2 *Line) *ParallelConstraint {
 	return c
 }
 
-// residualAD: the two line directions are parallel iff their cross product is zero.
+// residualAD: the two line directions are parallel iff the sine of their angle is zero —
+// the length-normalised cross product, scale-invariant (#1418).
 func (c *ParallelConstraint) residualAD(v []ad.Number) []ad.Number {
 	d1, d2 := adLineDirs(v)
-	return []ad.Number{d1.Cross(d2)}
+	return []ad.Number{adSineAngle(d1, d2)}
 }
 func (c *ParallelConstraint) Residuals() []float64      { return adResiduals(c.Variables(), c.residualAD) }
 func (c *ParallelConstraint) Partials() [][]float64     { return adPartials(c.Variables(), c.residualAD) }
@@ -206,10 +208,11 @@ func (g *GeometricConstraints) AddPerpendicular(l1, l2 *Line) *PerpendicularCons
 	return c
 }
 
-// residualAD: the two line directions are perpendicular iff their dot product is zero.
+// residualAD: the two line directions are perpendicular iff the cosine of their angle is
+// zero — the length-normalised dot product, scale-invariant (#1418).
 func (c *PerpendicularConstraint) residualAD(v []ad.Number) []ad.Number {
 	d1, d2 := adLineDirs(v)
-	return []ad.Number{d1.Dot(d2)}
+	return []ad.Number{adCosAngle(d1, d2)}
 }
 func (c *PerpendicularConstraint) Residuals() []float64 {
 	return adResiduals(c.Variables(), c.residualAD)
@@ -237,7 +240,9 @@ func (g *GeometricConstraints) AddCollinear(l1, l2 *Line) *CollinearConstraint {
 func (c *CollinearConstraint) residualAD(v []ad.Number) []ad.Number {
 	a1, b1, a2, b2 := adTwoLines(v)
 	d1, d2 := b1.Sub(a1), b2.Sub(a2)
-	return []ad.Number{d1.Cross(d2), d1.Cross(a2.Sub(a1))}
+	// Parallel (sine of the angle) AND L2.A on L1's line (perpendicular distance) — both
+	// scale-invariant rather than area-scaled (#1418).
+	return []ad.Number{adSineAngle(d1, d2), adSignedPerpDistance(d1, a2.Sub(a1))}
 }
 func (c *CollinearConstraint) Residuals() []float64      { return adResiduals(c.Variables(), c.residualAD) }
 func (c *CollinearConstraint) Partials() [][]float64     { return adPartials(c.Variables(), c.residualAD) }
@@ -439,7 +444,10 @@ func (c *SymmetryConstraint) residualAD(v []ad.Number) []ad.Number {
 	la, lb := ad.V2(v[4], v[5]), ad.V2(v[6], v[7])
 	dir := lb.Sub(la)
 	mid := a.Add(b).Scale(0.5)
-	return []ad.Number{dir.Cross(mid.Sub(la)), b.Sub(a).Dot(dir)}
+	// Midpoint's perpendicular distance to the mirror line, and the A→B segment's
+	// component along it (zero when perpendicular) — both normalised by the mirror line's
+	// length so they are independent of its arbitrary representation (#1418).
+	return []ad.Number{adSignedPerpDistance(dir, mid.Sub(la)), adProjectionAlong(b.Sub(a), dir)}
 }
 func (c *SymmetryConstraint) Residuals() []float64  { return adResiduals(c.Variables(), c.residualAD) }
 func (c *SymmetryConstraint) Partials() [][]float64 { return adPartials(c.Variables(), c.residualAD) }

--- a/model/sketch/constraints_new.go
+++ b/model/sketch/constraints_new.go
@@ -79,12 +79,10 @@ func (g *GeometricConstraints) AddOffset(l1, l2 *Line, dist float64) *OffsetCons
 func (c *OffsetConstraint) residualAD(v []ad.Number) []ad.Number {
 	a1, b1, a2, b2 := adTwoLines(v)
 	d1, d2 := b1.Sub(a1), b2.Sub(a2)
-	parallel := d1.Cross(d2)
-	length := d1.Length()
-	if length.Val() == 0 {
-		return []ad.Number{parallel, ad.Const(0)}
-	}
-	dist := d1.Cross(a2.Sub(a1)).Div(length)
+	// Parallelism as the sine of the angle (scale-invariant, #1418); the perpendicular
+	// distance of L2.A from L1 was already a true distance.
+	parallel := adSineAngle(d1, d2)
+	dist := adSignedPerpDistance(d1, a2.Sub(a1))
 	return []ad.Number{parallel, dist.AddConst(-c.Dist)}
 }
 

--- a/model/sketch/normalized_residuals_test.go
+++ b/model/sketch/normalized_residuals_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// pointOnLineFixture builds a rigid line of the given length on the X axis (both endpoints
+// fixed) plus a free point constrained onto it, then returns the sketch. The point starts
+// off the line. With the line fixed, a correctly-counted PointOnLine leaves exactly one DOF
+// (the point slides along the line); a dropped row would leave two.
+func pointOnLineFixture(length, perpOffset float64) *Sketch {
+	s := NewSketches().Add(XYPlane())
+	g := s.GeometricConstraints()
+	a := s.Points().Add(math.P2(0, 0))
+	b := s.Points().Add(math.P2(math.Scalar(length), 0))
+	line := s.Lines().Add(a, b)
+	g.AddFix(a)
+	g.AddFix(b)
+	p := s.Points().Add(math.P2(math.Scalar(length/2), math.Scalar(perpOffset)))
+	g.AddPointOnLine(p, line)
+	return s
+}
+
+// TestPointOnLineResidualIsADistanceNotArea is acceptance criterion 1 of #1418: the
+// PointOnLine residual is the perpendicular distance (length units), independent of the
+// line's length — not the area |line|·|offset| it used to be.
+func TestPointOnLineResidualIsADistanceNotArea(t *testing.T) {
+	const perp = 0.1
+	for _, length := range []float64{1, 1e-3, 100} {
+		s := pointOnLineFixture(length, perp)
+		c := s.GeometricConstraints().All()[2] // the PointOnLine constraint
+		r := c.Residuals()[0]
+		if stdmath.Abs(stdmath.Abs(r)-perp) > 1e-9 {
+			t.Errorf("length %g: |residual| = %g, want the perpendicular distance %g (area-scaling not removed)",
+				length, stdmath.Abs(r), perp)
+		}
+	}
+}
+
+// TestShortSegmentConstraintIsCounted is acceptance criterion 2 of #1418: a PointOnLine on
+// a very short segment is still counted in the rank, so the DOF is correct. An area-scaled
+// residual would give a Jacobian row below the rank tolerance and be dropped, inflating the
+// reported DOF.
+func TestShortSegmentConstraintIsCounted(t *testing.T) {
+	s := pointOnLineFixture(1e-8, 0.05)
+	if dof := s.DegreesOfFreedom(); dof != 1 {
+		t.Errorf("short-segment PointOnLine: DOF = %d, want 1 (the constraint must be counted, not dropped)", dof)
+	}
+}
+
+// TestLongShortParityClassification is acceptance criterion 3 of #1418: a geometrically
+// identical sketch classifies the same whether its segments are long or short.
+func TestLongShortParityClassification(t *testing.T) {
+	long := pointOnLineFixture(10, 0.2)
+	short := pointOnLineFixture(1e-7, 0.2)
+	if l, s := long.DegreesOfFreedom(), short.DegreesOfFreedom(); l != s {
+		t.Errorf("DOF parity broken: long sketch %d vs short sketch %d", l, s)
+	}
+	if l, s := long.AnalyzeConstraints().Status, short.AnalyzeConstraints().Status; l != s {
+		t.Errorf("status parity broken: long %v vs short %v", l, s)
+	}
+}
+
+// TestParallelCollinearShortSegmentOverConstrained covers the issue's over-constrained
+// fixture: parallel AND collinear on short segments is redundant (collinear implies
+// parallel), and must be reported over-constrained — which only holds if the short-segment
+// rows are counted at their true (normalised) magnitude.
+func TestParallelCollinearShortSegmentOverConstrained(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	g := s.GeometricConstraints()
+	const e = 1e-7 // short segments
+	l1 := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(e, 0))
+	l2 := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(e, 0))
+	l2.A.SetPosition(math.P2(2*e, 0))
+	l2.B.SetPosition(math.P2(3*e, 0))
+	g.AddParallel(l1, l2)
+	g.AddCollinear(l1, l2) // collinear ⊇ parallel: the parallel row is redundant
+	if st := s.AnalyzeConstraints(); st.Redundant < 1 || st.Status != OverConstrained {
+		t.Errorf("short parallel+collinear: %+v, want over-constrained with ≥1 redundant", st)
+	}
+}


### PR DESCRIPTION
## What

Normalises the cross-/dot-product orientation residuals of the 2D sketch constraints so their magnitude is a **scale-invariant** quantity — a perpendicular distance or projection (length units), or the sine/cosine of an angle (dimensionless) — instead of an **area** that shrinks with segment length.

Closes #1418.

## Why

`PointOnLine`, `Parallel`, `Perpendicular`, `Collinear`, `Symmetry` and `Offset` returned residuals like `dx·oy − dy·ox`, whose magnitude scales as `|line|·|offset|`. A short segment therefore produced a tiny residual **and** a tiny Jacobian row, which `matrixRank` (`solve/solve.go`) drops — so the constraint is mis-reported redundant/under-counted. That **falsifies the DOF / over-/under-/well-constrained signal** — the primary CAD UI indicator, surfaced to add-ins via `DegreesOfFreedom()` — and under-weights the constraint in the solve. `TangentConstraint` already normalised, so the codebase was internally inconsistent; this makes the rest match.

## How

Because #1417 made every constraint residual dual (`residualAD`), normalising that single formula fixes **both** the residual value and the exact Jacobian. Four small dual helpers in `model/sketch/autodiff.go` express the normalisation with degenerate-direction guards:
- `adSignedPerpDistance` — `(dir × w)/|dir|` (length)
- `adProjectionAlong` — `(w · dir)/|dir|` (length)
- `adSineAngle` — `(d1 × d2)/(|d1||d2|)` (dimensionless)
- `adCosAngle` — `(d1 · d2)/(|d1||d2|)` (dimensionless)

The Jacobian rows now stay O(1) regardless of segment length, so the rank/DOF analysis counts the constraint at its true weight.

## Scope

This issue is filed against the 2D sketch constraints (and its test cases are 2D); the fix covers all of them, including the dot-product orientation siblings (`Perpendicular`, `Symmetry`'s perpendicularity row) for true parity. The 3D constraints (`Parallel3D`, `Collinear3D`, …) share the same pattern and would be a natural follow-up.

## Acceptance criteria

- [x] All 2D cross-/dot orientation residuals normalised (distance / dimensionless).
- [x] DOF / over-constrained classification correct on short-segment fixtures.
- [x] Parity: long vs short geometrically-identical sketches classify the same.

## Tests

- `PointOnLine` residual equals the perpendicular distance, independent of line length (dimensional check).
- A short-segment `PointOnLine` is counted (DOF correct) — **verified to regress to the wrong DOF when the normalisation is reverted**, so the test exercises the bug.
- Long vs short geometrically-identical sketches classify identically (DOF + status).
- Short-segment `Parallel`+`Collinear` reports over-constrained (the redundancy is detected only when the short rows are counted at their true magnitude).

Coverage `model/sketch` 86.2%; lint clean; full test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)