### PR TITLE
Enforce arc circularity so the End stays on the circle (#1419)

### DIFF
--- a/model/sketch/arc_circularity.go
+++ b/model/sketch/arc_circularity.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"oblikovati.org/math"
+	"oblikovati.org/solve/ad"
+)
+
+// arcCircularityConstraint is the internal, system-owned constraint that keeps an arc's End
+// point on its circle: |Center−End| = |Center−Start| (the radius). An arc stores its End as
+// an independent free point, so without this constraint driving the arc's radius or a
+// tangent (which move Center+Start) would leave End behind — the solved "arc" would no
+// longer pass through its own endpoint at constant radius, a silent geometry-correctness bug
+// that propagates into the profiles extrude/revolve consume (Oblikovati/Oblikovati#1419).
+//
+// It is created with the arc (see [Arcs.Add]), lives and dies with it, and is never
+// user-visible or deletable — circularity is a property of the arc, not a user relation.
+type arcCircularityConstraint struct {
+	constraintBase
+	arc *Arc
+}
+
+// newArcCircularity builds the circularity constraint for an arc.
+func newArcCircularity(a *Arc) *arcCircularityConstraint {
+	return &arcCircularityConstraint{constraintBase: newConstraint(), arc: a}
+}
+
+// residualAD: v = [Center.X, Center.Y, Start.X, Start.Y, End.X, End.Y]. The end and start
+// must be equidistant from the center — a distance residual (|End−Center| − |Start−Center|),
+// already scale-invariant, so no extra normalisation is needed (#1418).
+func (c *arcCircularityConstraint) residualAD(v []ad.Number) []ad.Number {
+	center := ad.V2(v[0], v[1])
+	start := ad.V2(v[2], v[3])
+	end := ad.V2(v[4], v[5])
+	return []ad.Number{end.Sub(center).Length().Sub(start.Sub(center).Length())}
+}
+
+func (c *arcCircularityConstraint) Residuals() []float64 {
+	return adResiduals(c.Variables(), c.residualAD)
+}
+func (c *arcCircularityConstraint) Partials() [][]float64 {
+	return adPartials(c.Variables(), c.residualAD)
+}
+
+func (c *arcCircularityConstraint) Variables() []*math.Scalar {
+	return []*math.Scalar{
+		&c.arc.Center.X, &c.arc.Center.Y,
+		&c.arc.Start.X, &c.arc.Start.Y,
+		&c.arc.End.X, &c.arc.End.Y,
+	}
+}
+
+// Deletable implements [NonDeletable]: the circularity record is structural and cannot be
+// removed on its own — it is dropped when its arc is.
+func (c *arcCircularityConstraint) Deletable() bool { return false }

--- a/model/sketch/arc_circularity_test.go
+++ b/model/sketch/arc_circularity_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// arcRadii returns an arc's center-to-start and center-to-end distances.
+func arcRadii(a *Arc) (start, end float64) {
+	c := a.Center.Position()
+	return float64(c.DistanceTo(a.Start.Position())), float64(c.DistanceTo(a.End.Position()))
+}
+
+// assertCircular fails unless the arc's two endpoints are equidistant from its center.
+func assertCircular(t *testing.T, name string, a *Arc) {
+	t.Helper()
+	s, e := arcRadii(a)
+	if stdmath.Abs(s-e) > 1e-6 {
+		t.Errorf("%s: arc not circular — |center−start| = %g, |center−end| = %g", name, s, e)
+	}
+}
+
+// TestArcCarriesCircularityConstraint is acceptance criterion 1 of #1419: an arc's End is no
+// longer a free-floating point — it is tied to the arc radius by an internal constraint that
+// the solver consumes.
+func TestArcCarriesCircularityConstraint(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	arc := s.Arcs().AddByCenterStartEnd(math.P2(0, 0), math.P2(2, 0), math.P2(0, 2), true)
+	found := false
+	for _, c := range s.Constraints() {
+		if cc, ok := c.(*arcCircularityConstraint); ok && cc.arc == arc {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("arc has no circularity constraint among the sketch's solver constraints")
+	}
+}
+
+// TestSolveRestoresArcCircularity is the core regression for #1419: nudging End off the
+// radius and solving pulls it back onto the circle — without the internal constraint nothing
+// would, leaving a non-circular "arc".
+func TestSolveRestoresArcCircularity(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	arc := s.Arcs().AddByCenterStartEnd(math.P2(0, 0), math.P2(2, 0), math.P2(0, 2), true)
+	g := s.GeometricConstraints()
+	g.AddFix(arc.Center)
+	g.AddFix(arc.Start)
+	arc.End.SetPosition(math.P2(0, 3.5)) // pushed off the radius-2 circle
+
+	if r := s.Solve(); !r.Converged {
+		t.Fatalf("solve did not converge: residual %v", r.Residual)
+	}
+	assertCircular(t, "after solve", arc)
+	if _, e := arcRadii(arc); stdmath.Abs(e-2) > 1e-6 {
+		t.Errorf("end radius %g, want 2 (the fixed start radius)", e)
+	}
+}
+
+// TestDriveArcRadiusKeepsEndOnCircle is the issue's first test case: driving the arc radius
+// moves Center+Start, and End must follow to the new radius rather than being left behind.
+func TestDriveArcRadiusKeepsEndOnCircle(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	arc := s.Arcs().AddByCenterStartEnd(math.P2(0, 0), math.P2(2, 0), math.P2(0, 2), true)
+	g := s.GeometricConstraints()
+	g.AddFix(arc.Center)
+	if _, err := s.DimensionConstraints().AddRadius(arc, "3 cm"); err != nil {
+		t.Fatalf("AddRadius: %v", err)
+	}
+	if r := s.Solve(); !r.Converged {
+		t.Fatalf("solve did not converge: residual %v", r.Residual)
+	}
+	assertCircular(t, "driven radius", arc)
+	start, end := arcRadii(arc)
+	if stdmath.Abs(start-3) > 1e-6 || stdmath.Abs(end-3) > 1e-6 {
+		t.Errorf("radii after driving to 3: start %g, end %g, want both 3", start, end)
+	}
+}
+
+// TestTangentOnArcKeepsEndOnCircle is the issue's second test case: a tangent constraint
+// drives the arc (via its center/start), and its End stays on the circle.
+func TestTangentOnArcKeepsEndOnCircle(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	arc := s.Arcs().AddByCenterStartEnd(math.P2(0, 0), math.P2(1.5, 0), math.P2(0, 1.5), true)
+	g := s.GeometricConstraints()
+	g.AddFix(arc.Center)
+	// A fixed horizontal line at y = 2; tangency drives the arc radius to 2.
+	line := s.Lines().AddByTwoPoints(math.P2(-3, 2), math.P2(3, 2))
+	g.AddFix(line.A)
+	g.AddFix(line.B)
+	g.AddTangent(line, arc)
+
+	if r := s.Solve(); !r.Converged {
+		t.Fatalf("solve did not converge: residual %v", r.Residual)
+	}
+	assertCircular(t, "tangent-driven", arc)
+}
+
+// TestValidArcRoundTripsThroughSolve is the issue's third test case: a well-formed arc that
+// already satisfies its circularity survives an unconstrained solve unchanged (the internal
+// constraint adds no spurious motion).
+func TestValidArcRoundTripsThroughSolve(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	arc := s.Arcs().AddByCenterStartEnd(math.P2(1, 1), math.P2(4, 1), math.P2(1, 4), true) // radius 3 both ends
+	before := arc.End.Position()
+	if r := s.Solve(); !r.Converged {
+		t.Fatalf("solve did not converge: residual %v", r.Residual)
+	}
+	assertCircular(t, "round-trip", arc)
+	if d := before.DistanceTo(arc.End.Position()); float64(d) > 1e-9 {
+		t.Errorf("a valid arc's End moved by %g during an unconstrained solve, want 0", d)
+	}
+}

--- a/model/sketch/entities.go
+++ b/model/sketch/entities.go
@@ -96,14 +96,16 @@ type Circle struct {
 }
 
 // Arc is a circular arc defined by a center and two endpoints; the radius is
-// derived from the center-to-start distance (a tangency/radius constraint keeps the
-// end at the same radius). Sweep direction is CounterClockwise.
+// derived from the center-to-start distance. An internal circularity constraint
+// (#1419) keeps End on the same circle as Start, so the arc stays circular under
+// radius/tangent edits. Sweep direction is CounterClockwise.
 type Arc struct {
 	entityBase
 	Center           *Point
 	Start            *Point
 	End              *Point
 	CounterClockwise bool
+	circularity      *arcCircularityConstraint // system-owned; keeps End at the arc radius
 }
 
 // Radius returns the current center-to-start distance.

--- a/model/sketch/entity_collections.go
+++ b/model/sketch/entity_collections.go
@@ -101,6 +101,7 @@ func (c *Arcs) Add(center, start, end *Point, ccw bool) *Arc {
 		End:              end,
 		CounterClockwise: ccw,
 	}
+	a.circularity = newArcCircularity(a) // keep End on the circle (#1419)
 	c.s.add(a)
 	c.items = append(c.items, a)
 	return a

--- a/model/sketch/sketch.go
+++ b/model/sketch/sketch.go
@@ -310,6 +310,11 @@ func (s *Sketch) SetParameters(ps *param.Parameters) {
 // dimensions are excluded (they report, they do not constrain).
 func (s *Sketch) Constraints() []Constraint {
 	out := s.geomCons.All()
+	// Every arc carries an internal circularity constraint keeping its End on the circle
+	// (#1419); the solver consumes it like any other, but it is not a user-facing relation.
+	for _, a := range s.arcs.items {
+		out = append(out, a.circularity)
+	}
 	for _, d := range s.dimCons.items {
 		if !d.driven {
 			out = append(out, d)


### PR DESCRIPTION
## What

Every sketch arc now carries an internal circularity constraint that keeps its `End` on the same circle as `Start` (`|Center−End| = |Center−Start|`), so an arc stays circular under radius/tangent edits.

Closes #1419.

## Why

An `Arc` stored `End` as an **independent free point**: `Radius()` is `|Center−Start|` and nothing tied `|Center−End|` to it. Driving the arc's radius or a tangent moves `Center`+`Start` (the arc's `circularVars`) but leaves `End` behind — the solved "arc" no longer passes through its own endpoint at constant radius. That is a silent geometry-correctness bug that propagates into the profiles `extrude`/`revolve` consume.

## How

- A new system-owned `arcCircularityConstraint` with residual `|End−Center| − |Start−Center|` — a scale-invariant distance residual reusing the dual-residual (`residualAD`) machinery from #1417, so it contributes an exact Jacobian row like any constraint.
- Created with the arc in `Arcs.Add` — the single arc-construction seam, so originals, clones (`cloneEntity`), composite-slot caps and restored arcs all get one (no separate lifecycle bookkeeping; it lives and dies with the arc).
- Included in `Sketch.Constraints()` (the solver's view) but kept out of the user-facing `GeometricConstraints` collection and marked non-deletable — circularity is a property of the arc, not a user relation, and is derived (not serialized).

## Acceptance criteria

- [x] Arc endpoints are constrained to the arc radius; no free-floating `End`.
- [x] Radius/tangent edits keep the arc circular.
- [x] No regression in existing arc fixtures (full suite green).

## Tests

- Nudging `End` off the radius and solving pulls it back onto the circle.
- Driving the arc radius keeps `End` on the **new** circle (the exact bug — verified to regress, `End` left behind, when the constraint is withheld).
- A tangent constraint on the arc keeps it circular.
- A valid arc round-trips an unconstrained solve unchanged (no spurious motion).

`model/sketch` coverage 86.2%; lint clean; full repo green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)