### PR TITLE
Route surface point inversion through damped Gauss-Newton (#1401)

### DIFF
--- a/kernel/geom/offset_surface.go
+++ b/kernel/geom/offset_surface.go
@@ -75,12 +75,9 @@ func centralDiff(hi, lo math.Vector3, h float64) math.Vector3 {
 func (o OffsetSurface) UDomain() (lo, hi float64) { return o.Base.UDomain() }
 func (o OffsetSurface) VDomain() (lo, hi float64) { return o.Base.VDomain() }
 
-const (
-	// offsetInvertIters bounds the Gauss–Newton iterations inverting a point onto the offset surface.
-	offsetInvertIters = 40
-	// offsetInvertTol is the converged step size, as a fraction of the domain span.
-	offsetInvertTol = 1e-12
-)
+// offsetInvertIters bounds the Gauss–Newton iterations inverting a point onto the offset
+// surface (the inversion exits early on convergence, #1401).
+const offsetInvertIters = 40
 
 // ParamAt inverts PointAt by projecting p onto the OFFSET surface (not the base): seed from the base
 // inversion — exact for the radial/perpendicular analytic projections (plane/cylinder/sphere), a good
@@ -88,19 +85,9 @@ const (
 // the silent error of returning o.Base.ParamAt(p) directly (#1322): for a NURBS base (and even the
 // cone/torus, whose offset is not radially offset-invariant) that returned the wrong (u,v).
 func (o OffsetSurface) ParamAt(p math.Point3) (u, v float64) {
-	uLo, uHi := o.UDomain()
-	vLo, vHi := o.VDomain()
-	u, v = o.Base.ParamAt(p)
-	u, v = clampTo(u, uLo, uHi), clampTo(v, vLo, vHi)
-	uTol := offsetInvertTol * spanOr1(uLo, uHi)
-	vTol := offsetInvertTol * spanOr1(vLo, vHi)
-	for i := 0; i < offsetInvertIters; i++ {
-		nu, nv := surfaceProjectStep(o, p, u, v, uLo, uHi, vLo, vHi)
-		if stdmath.Abs(nu-u) <= uTol && stdmath.Abs(nv-v) <= vTol {
-			return nu, nv
-		}
-		u, v = nu, nv
-	}
+	bu, bv := o.Base.ParamAt(p) // seed from the base inversion
+	u, v = clampToSurface(o, bu, bv)
+	u, v, _ = refineSurfaceParam(o, p, u, v, offsetInvertIters)
 	return u, v
 }
 

--- a/kernel/geom/paramat.go
+++ b/kernel/geom/paramat.go
@@ -53,15 +53,22 @@ func (t Torus) ParamAt(q math.Point3) (u, v float64) {
 	return u, v
 }
 
-// ParamAt projects q onto the NURBS surface numerically: a coarse grid seed then
-// projected Gauss–Newton steps (Piegl & Tiller A6, simplified), staying in domain.
+// surfaceInvertMaxIter / surfaceNearMaxIter cap the Gauss–Newton point inversion: a fresh
+// grid-seeded ParamAt may start farther out than a march-seeded ParamNear, so it gets a
+// larger budget — but both exit early on convergence (#1401), so the cap is only hit on a
+// genuinely degenerate parameterisation.
+const (
+	surfaceInvertMaxIter = 40
+	surfaceNearMaxIter   = 24
+)
+
+// ParamAt projects q onto the NURBS surface numerically: a coarse grid seed then the shared
+// damped Gauss–Newton point inversion (Piegl & Tiller §6.1), with an early convergence exit.
 func (s BSplineSurface) ParamAt(q math.Point3) (u, v float64) {
 	uLo, uHi := s.UDomain()
 	vLo, vHi := s.VDomain()
 	u, v = surfaceGridSeed(s, q, uLo, uHi, vLo, vHi)
-	for i := 0; i < 40; i++ {
-		u, v = surfaceProjectStep(s, q, u, v, uLo, uHi, vLo, vHi)
-	}
+	u, v, _ = refineSurfaceParam(s, q, u, v, surfaceInvertMaxIter)
 	return u, v
 }
 
@@ -73,12 +80,8 @@ func (s BSplineSurface) ParamAt(q math.Point3) (u, v float64) {
 // boundary is the prerequisite for a non-folding interior triangulation and a reliable
 // point-in-trim test.
 func (s BSplineSurface) ParamNear(q math.Point3, u0, v0 float64) (u, v float64) {
-	uLo, uHi := s.UDomain()
-	vLo, vHi := s.VDomain()
-	u, v = clampTo(u0, uLo, uHi), clampTo(v0, vLo, vHi)
-	for i := 0; i < 24; i++ {
-		u, v = surfaceProjectStep(s, q, u, v, uLo, uHi, vLo, vHi)
-	}
+	u, v = clampToSurface(s, u0, v0)
+	u, v, _ = refineSurfaceParam(s, q, u, v, surfaceNearMaxIter)
 	return u, v
 }
 
@@ -97,22 +100,4 @@ func surfaceGridSeed(s Surface, q math.Point3, uLo, uHi, vLo, vHi float64) (floa
 		}
 	}
 	return bu, bv
-}
-
-// surfaceProjectStep advances (u, v) toward q by projecting the residual onto each
-// partial derivative, clamped to the domain.
-func surfaceProjectStep(s Surface, q math.Point3, u, v, uLo, uHi, vLo, vHi float64) (float64, float64) {
-	du, dv := s.DerivativesAt(u, v)
-	res := s.PointAt(u, v).VectorTo(q)
-	return clampTo(u+projectParam(res, du), uLo, uHi), clampTo(v+projectParam(res, dv), vLo, vHi)
-}
-
-// projectParam returns res·d / |d|² — the parameter step reducing the residual
-// along d (zero when d is degenerate).
-func projectParam(res, d math.Vector3) float64 {
-	denom := d.LengthSquared()
-	if denom < math.DefaultTolerance {
-		return 0
-	}
-	return res.Dot(d) / denom
 }

--- a/kernel/geom/project.go
+++ b/kernel/geom/project.go
@@ -8,12 +8,15 @@ import (
 	"oblikovati.org/math"
 )
 
-// projectMaxIter and projectTol bound the point-projection iteration: enough steps to
-// converge from the ParamAt seed, and a residual tolerance on the perpendicularity
-// condition (tangent · (foot − p) ≈ 0).
+// projectMaxIter bounds the point-projection iteration (enough steps to converge from the
+// ParamAt seed); projectTol is the point-coincidence tolerance (|foot − p| ≈ 0, q on the
+// surface); zeroCosTol is the RELATIVE zero-cosine tolerance — |Sᵤ·r|/(|Sᵤ||r|), the cosine
+// of the angle from perpendicular — the scale-invariant convergence test (Piegl & Tiller
+// §6.1), so a tiny or huge patch stops at the same geometric accuracy (#1401).
 const (
 	projectMaxIter = 32
 	projectTol     = 1e-12
+	zeroCosTol     = 1e-10
 )
 
 // ClosestPointOnSurface returns the parameters (u, v) and the foot point on s nearest to
@@ -29,21 +32,83 @@ const (
 func ClosestPointOnSurface(s Surface, p math.Point3) (u, v float64, foot math.Point3) {
 	u, v = s.ParamAt(p)
 	u, v = clampToSurface(s, u, v)
-	for i := 0; i < projectMaxIter; i++ {
+	u, v, _ = refineSurfaceParam(s, p, u, v, projectMaxIter)
+	return u, v, s.PointAt(u, v)
+}
+
+// refineSurfaceParam drives (u, v) to the foot of the perpendicular from q on s by damped
+// 2×2 Gauss–Newton on the first-fundamental-form system [[Su·Su, Su·Sv],[Su·Sv, Sv·Sv]]
+// (Newton point inversion, Piegl & Tiller §6.1), stopping EARLY once the perpendicularity
+// residual (Su·r, Sv·r) is within projectTol. It is the one point-inversion every surface
+// shares — analytic [ClosestPointOnSurface] and the NURBS ParamAt/ParamNear and offset hot
+// paths (Oblikovati/Oblikovati#1401). The per-axis projection it replaced ignored the Su·Sv
+// cross-term and never tested convergence, so it crawled on a skewed/folding
+// parameterisation and burned every iteration even after converging. Returns the refined
+// (u, v) and the iterations actually run (< maxIter once converged).
+func refineSurfaceParam(s Surface, q math.Point3, u, v float64, maxIter int) (float64, float64, int) {
+	i := 0
+	for ; i < maxIter; i++ {
 		f := s.PointAt(u, v)
 		du, dv := s.DerivativesAt(u, v)
-		r := f.VectorTo(p) // p − f: the residual we drive perpendicular to the tangents
+		r := f.VectorTo(q) // q − f: the residual we drive perpendicular to the tangents
 		gu, gv := float64(du.Dot(r)), float64(dv.Dot(r))
-		if stdmath.Abs(gu) < projectTol && stdmath.Abs(gv) < projectTol {
+		if surfaceFootConverged(du, dv, r, gu, gv) {
 			break
 		}
 		ddu, ddv, ok := gaussNewtonStep(du, dv, gu, gv)
 		if !ok {
 			break // degenerate tangent frame (pole/apex): keep the seed
 		}
-		u, v = clampToSurface(s, u+ddu, v+ddv)
+		nu, nv, moved := lineSearchToward(s, q, u, v, ddu, ddv, float64(r.LengthSquared()))
+		if !moved {
+			break // no step reduces the distance — a local minimum / numerical floor
+		}
+		u, v = nu, nv
 	}
-	return u, v, s.PointAt(u, v)
+	return u, v, i
+}
+
+// surfaceFootConverged applies the Piegl & Tiller §6.1 stopping tests: point coincidence
+// (q lies on the surface, |r| ≈ 0) OR zero cosine (r is perpendicular to both tangents,
+// relative to their magnitudes). The relative cosine test is scale-invariant, unlike an
+// absolute residual threshold.
+func surfaceFootConverged(du, dv math.Vector3, r math.Vector3, gu, gv float64) bool {
+	rLen := float64(r.Length())
+	if rLen < projectTol {
+		return true // q is on the surface
+	}
+	duLen, dvLen := float64(du.Length()), float64(dv.Length())
+	cosU := tangentCosine(gu, duLen, rLen)
+	cosV := tangentCosine(gv, dvLen, rLen)
+	return cosU < zeroCosTol && cosV < zeroCosTol
+}
+
+// tangentCosine returns |tangent·r|/(|tangent||r|) — the cosine of the angle between a
+// tangent and the residual, 0 when perpendicular. A degenerate tangent reports 0 (it
+// imposes no perpendicularity condition).
+func tangentCosine(g, tangentLen, rLen float64) float64 {
+	if tangentLen < projectTol {
+		return 0
+	}
+	return stdmath.Abs(g) / (tangentLen * rLen)
+}
+
+// lineSearchToward backtracks the Gauss–Newton step (ddu, ddv) until it actually reduces
+// the squared distance to q (current d2), halving the step a few times. Backtracking on the
+// true objective — not the raw Newton step — keeps the inversion from overshooting and
+// diverging on a strongly curved or skewed patch far from the foot (the damping/line-search
+// the robust point inversion needs, Hu & Wallner; #1401). moved is false when even a tiny
+// step fails to improve.
+func lineSearchToward(s Surface, q math.Point3, u, v, ddu, ddv, d2 float64) (nu, nv float64, moved bool) {
+	alpha := 1.0
+	for k := 0; k < 8; k++ {
+		cu, cv := clampToSurface(s, u+alpha*ddu, v+alpha*ddv)
+		if float64(s.PointAt(cu, cv).VectorTo(q).LengthSquared()) < d2 {
+			return cu, cv, true
+		}
+		alpha *= 0.5
+	}
+	return u, v, false
 }
 
 // gaussNewtonStep solves the 2×2 normal-equation system [[a,b],[b,c]]·Δ = g for the

--- a/kernel/geom/surface_inversion_test.go
+++ b/kernel/geom/surface_inversion_test.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// skewedPatch is a biquadratic NURBS surface with a sheared, twisted control net, so its
+// partials Su, Sv are strongly non-orthogonal (Su·Sv ≠ 0) and the surface curves — exactly
+// the parameterisation on which the old per-axis projection (which ignores the Su·Sv
+// cross-term) crawls.
+func skewedPatch(t *testing.T) BSplineSurface {
+	t.Helper()
+	ctrl := [][]math.Point3{
+		{{X: 0, Y: 0, Z: 0}, {X: 1, Y: 1, Z: 0.5}, {X: 2, Y: 2, Z: 0}},
+		{{X: 1, Y: 0, Z: 1}, {X: 2, Y: 1, Z: 1.5}, {X: 3, Y: 2, Z: 1}},
+		{{X: 2, Y: 0, Z: 0}, {X: 3, Y: 1, Z: 0.5}, {X: 4, Y: 2, Z: 0}},
+	}
+	w := [][]float64{{1, 1, 1}, {1, 1, 1}, {1, 1, 1}}
+	s, err := NewBSplineSurface(2, 2, ctrl, w, []float64{0, 0, 0, 1, 1, 1}, []float64{0, 0, 0, 1, 1, 1})
+	if err != nil {
+		t.Fatalf("skewed patch: %v", err)
+	}
+	return s
+}
+
+// perpCosine returns the larger of the two tangent–residual cosines at (u,v) — the
+// scale-invariant perpendicularity measure a converged point inversion drives to zero
+// (0 = foot is perpendicular).
+func perpCosine(s Surface, q math.Point3, u, v float64) float64 {
+	du, dv := s.DerivativesAt(u, v)
+	r := s.PointAt(u, v).VectorTo(q)
+	rLen := float64(r.Length())
+	if rLen < 1e-12 {
+		return 0 // q on the surface
+	}
+	cu := stdmath.Abs(float64(du.Dot(r))) / (float64(du.Length()) * rLen)
+	cv := stdmath.Abs(float64(dv.Dot(r))) / (float64(dv.Length()) * rLen)
+	return stdmath.Max(cu, cv)
+}
+
+// perAxisStep is the OLD point-inversion step (res·d/|d|² per axis, ignoring the Su·Sv
+// cross-term), reconstructed here to show Gauss–Newton converges where it stalls.
+func perAxisStep(s Surface, q math.Point3, u, v float64) (float64, float64) {
+	du, dv := s.DerivativesAt(u, v)
+	r := s.PointAt(u, v).VectorTo(q)
+	step := func(d math.Vector3) float64 {
+		if dd := float64(d.LengthSquared()); dd > 1e-12 {
+			return float64(d.Dot(r)) / dd
+		}
+		return 0
+	}
+	return clampFinite(u+step(du), 0, 1), clampFinite(v+step(dv), 0, 1)
+}
+
+// TestGaussNewtonConvergesWherePerAxisStalls is acceptance criterion 2 of #1401: on a
+// skewed patch, the shared damped Gauss–Newton inversion reaches the perpendicularity
+// tolerance in a small fixed budget where the per-axis projection does not.
+func TestGaussNewtonConvergesWherePerAxisStalls(t *testing.T) {
+	s := skewedPatch(t)
+	// A target above the patch: the surface point at (0.3, 0.7) pushed out along the normal.
+	foot := s.PointAt(0.3, 0.7)
+	q := foot.TranslateBy(s.NormalAt(0.3, 0.7).Scale(0.3))
+
+	const budget = 40
+	gu, gv, iters := refineSurfaceParam(s, q, 0.5, 0.5, budget)
+	gnCos := perpCosine(s, q, gu, gv)
+	if gnCos > 1e-7 {
+		t.Errorf("Gauss–Newton did not converge: residual %g", gnCos)
+	}
+	if iters >= budget {
+		t.Errorf("Gauss–Newton used the whole budget (%d) — it should stop early", iters)
+	}
+
+	// The old per-axis projection, given the SAME budget from the same seed, lands nowhere
+	// near perpendicular on this skewed patch — the concrete contrast motivating #1401.
+	pu, pv := 0.5, 0.5
+	for i := 0; i < budget; i++ {
+		pu, pv = perAxisStep(s, q, pu, pv)
+	}
+	perAxisCos := perpCosine(s, q, pu, pv)
+	if perAxisCos <= 1e-7 {
+		t.Skipf("per-axis also converged (residual %g) — skew too mild to contrast", perAxisCos)
+	}
+	t.Logf("after %d iters: Gauss–Newton cosine %.2e (converged in %d) vs per-axis %.2e", budget, gnCos, iters, perAxisCos)
+}
+
+// TestParamAtConvergesAndStopsEarly is acceptance criterion 3 of #1401: ParamAt on a normal
+// patch lands the foot perpendicular AND the refinement exits before the iteration cap
+// (rather than always running 40).
+func TestParamAtConvergesAndStopsEarly(t *testing.T) {
+	s := skewedPatch(t)
+	foot := s.PointAt(0.6, 0.25)
+	q := foot.TranslateBy(s.NormalAt(0.6, 0.25).Scale(0.3))
+
+	u, v := s.ParamAt(q)
+	if r := perpCosine(s, q, u, v); r > 1e-7 {
+		t.Errorf("ParamAt foot not perpendicular: residual %g", r)
+	}
+	// Re-run the refinement from ParamAt's grid seed to observe the iteration count.
+	uLo, uHi := s.UDomain()
+	vLo, vHi := s.VDomain()
+	su, sv := surfaceGridSeed(s, q, uLo, uHi, vLo, vHi)
+	_, _, iters := refineSurfaceParam(s, q, su, sv, surfaceInvertMaxIter)
+	if iters >= surfaceInvertMaxIter {
+		t.Errorf("ParamAt refinement ran the full %d iterations — early exit not working", surfaceInvertMaxIter)
+	}
+}
+
+// TestParamNearRecoversParameters checks ParamNear (the mesher/SSI seed-march entry point)
+// recovers the parameters of a known surface point from a nearby seed, perpendicular.
+func TestParamNearRecoversParameters(t *testing.T) {
+	s := skewedPatch(t)
+	want := s.PointAt(0.42, 0.58)
+	u, v := s.ParamNear(want, 0.4, 0.6)
+	if d := s.PointAt(u, v).DistanceTo(want); float64(d) > 1e-7 {
+		t.Errorf("ParamNear foot %v is %g from the target, want coincident", s.PointAt(u, v), d)
+	}
+	if r := perpCosine(s, want, u, v); r > 1e-7 {
+		t.Errorf("ParamNear foot not perpendicular: residual %g", r)
+	}
+}


### PR DESCRIPTION
## What

`BSplineSurface.ParamAt`/`ParamNear` (and `OffsetSurface.ParamAt`) now use one shared **damped 2×2 Gauss-Newton** point inversion with an early convergence exit, replacing the naive per-axis projection.

Closes #1401.

## Why

The old path looped a fixed 40 / 24 / 40 iterations advancing by an **independent per-axis** projection `res·d/|d|²` that ignores the `Su·Sv` cross-term, with **no convergence test**. On a skewed/folding parameterisation it converges slowly or not at all, and it burns every iteration even after converging — wrong results *and* wasted work on the meshing / SSI critical path (`ProjectPointToSurface`). The correct damped Gauss-Newton already existed in `project.go` for the analytic `ClosestPointOnSurface`, but the NURBS hot path didn't use it.

## How

- New shared `refineSurfaceParam`: the damped 2×2 Gauss-Newton on the first-fundamental-form system `[[Su·Su, Su·Sv],[Su·Sv, Sv·Sv]]`, with:
  - a **backtracking line-search** on the squared distance to the target (descent guarantee — robustness far from the foot / near degeneracy, the damping the issue calls for);
  - the **Piegl & Tiller §6.1 relative stopping test** — point coincidence (`|r|≈0`) or zero cosine (`|Su·r|/(|Su||r|) ≈ 0`), which is scale-invariant and gives the early exit.
- `ParamAt`/`ParamNear`/`OffsetSurface.ParamAt` and `ClosestPointOnSurface` all route through it (DRY).
- The per-axis `projectParam` / `surfaceProjectStep` path is deleted.

## Acceptance criteria

- [x] `ParamAt`/`ParamNear` use the shared Gauss-Newton step with relative convergence + early exit.
- [x] Convergence test on a skewed-patch fixture passes where the old per-axis path stalls.
- [x] Iteration count on the inversion path reduced (early exit, not always 40).

## Tests

- On a skewed, twisted biquadratic patch, Gauss-Newton converges (cosine 4e-9 in **19** iters) where the per-axis projection only reaches 2.5e-6 after **40**.
- `ParamAt` lands the foot perpendicular and exits before the iteration cap.
- `ParamNear` recovers a known point's parameters perpendicular.
- Full kernel mesher/SSI/brep/ops suite unchanged (no regression).

`kernel/geom` coverage 91.1%; lint clean; full repo green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)