### PR TITLE
[geom] Numerical hardening of surface evaluators: scale-invariant degeneracy + optimal FD steps

### DIFF
--- a/kernel/geom/derivatives2.go
+++ b/kernel/geom/derivatives2.go
@@ -37,15 +37,19 @@ func circularDers2(major, minor math.Vector2, a, b, angle, rate float64) (d1, d2
 	return d1, d2, d3
 }
 
-// numericDers2 estimates the derivatives by central differences.
+// numericDers2 estimates the derivatives by central differences — the 2D twin of
+// numericDers3. Each order uses its OWN optimal step (stepD1/2/3 = ε^{1/(n+2)}) so
+// the higher-order stencils are not swamped by roundoff; a single fixed 1e-5 step
+// drove the 3rd-derivative denominator to ~2e-15 and amplified value roundoff into
+// 5–50% error (#1323, #1402).
 func numericDers2(c Curve2, t float64) (d1, d2, d3 math.Vector2) {
-	const h = 1e-5
-	p2m, pm := c.PointAt(t-2*h).AsVector(), c.PointAt(t-h).AsVector()
-	p0 := c.PointAt(t).AsVector()
-	pp, p2p := c.PointAt(t+h).AsVector(), c.PointAt(t+2*h).AsVector()
-	d1 = pp.Sub(pm).Scale(1 / (2 * h))
-	d2 = pp.Add(pm).Sub(p0.Scale(2)).Scale(1 / (h * h))
-	d3 = p2p.Sub(pp.Scale(2)).Add(pm.Scale(2)).Sub(p2m).Scale(1 / (2 * h * h * h))
+	h1, h2, h3 := stepD1, stepD2, stepD3
+	d1 = c.PointAt(t + h1).AsVector().Sub(c.PointAt(t - h1).AsVector()).Scale(1 / (2 * h1))
+	pm, p0, pp := c.PointAt(t-h2).AsVector(), c.PointAt(t).AsVector(), c.PointAt(t+h2).AsVector()
+	d2 = pp.Add(pm).Sub(p0.Scale(2)).Scale(1 / (h2 * h2))
+	q2m, qm := c.PointAt(t-2*h3).AsVector(), c.PointAt(t-h3).AsVector()
+	qp, q2p := c.PointAt(t+h3).AsVector(), c.PointAt(t+2*h3).AsVector()
+	d3 = q2p.Sub(qp.Scale(2)).Add(qm.Scale(2)).Sub(q2m).Scale(1 / (2 * h3 * h3 * h3))
 	return d1, d2, d3
 }
 

--- a/kernel/geom/evaluator_surface.go
+++ b/kernel/geom/evaluator_surface.go
@@ -85,15 +85,20 @@ func ellipticalConeSecondPartials(g EllipticalCone, u, v float64) (puu, puv, pvv
 	return puu, puv, math.Vector3{}
 }
 
-// numericSecondPartials estimates the second partials by central differences —
-// the fallback for unknown [Surface] implementations.
+// numericSecondPartials estimates the second partials by central-differencing the
+// first partials — the fallback for unknown [Surface] implementations (e.g. the
+// offset and threaded surfaces). Each direction uses the first-difference-optimal
+// step stepD1 = ε^{1/3} scaled by its OWN domain span, so the truncation/roundoff
+// balance holds whether the direction runs over [0,1] or [0,2π] and at any model
+// scale, rather than a fixed 1e-5 that was both non-optimal and scale-blind (#1402).
 func numericSecondPartials(s Surface, u, v float64) (puu, puv, pvv math.Vector3) {
-	const h = 1e-5
+	hu := stepD1 * spanOr1(s.UDomain())
+	hv := stepD1 * spanOr1(s.VDomain())
 	pu := func(uu, vv float64) math.Vector3 { du, _ := s.DerivativesAt(uu, vv); return du }
 	pv := func(uu, vv float64) math.Vector3 { _, dv := s.DerivativesAt(uu, vv); return dv }
-	puu = pu(u+h, v).Sub(pu(u-h, v)).Scale(1 / (2 * h))
-	puv = pu(u, v+h).Sub(pu(u, v-h)).Scale(1 / (2 * h))
-	pvv = pv(u, v+h).Sub(pv(u, v-h)).Scale(1 / (2 * h))
+	puu = pu(u+hu, v).Sub(pu(u-hu, v)).Scale(1 / (2 * hu))
+	puv = pu(u, v+hv).Sub(pu(u, v-hv)).Scale(1 / (2 * hv))
+	pvv = pv(u, v+hv).Sub(pv(u, v-hv)).Scale(1 / (2 * hv))
 	return puu, puv, pvv
 }
 
@@ -145,10 +150,10 @@ func SurfaceCurvatures(s Surface, u, v float64) (maxDir math.Vector3, kMax, kMin
 	puu, puv, pvv := SurfaceSecondPartials(s, u, v)
 	e, f, g := float64(du.Dot(du)), float64(du.Dot(dv)), float64(dv.Dot(dv))
 	l, m, nn := float64(puu.Dot(n)), float64(puv.Dot(n)), float64(pvv.Dot(n))
-	den := e*g - f*f
-	if den <= 0 {
-		return math.Vector3{}, 0, 0 // degenerate tangent frame
+	if degenerateFirstForm(e, f, g) {
+		return math.Vector3{}, 0, 0 // parallel/collapsed tangents (scale-invariant test, #1402)
 	}
+	den := e*g - f*f
 	mean := (e*nn - 2*f*m + g*l) / (2 * den)
 	gauss := (l*nn - m*m) / den
 	disc := stdmath.Sqrt(stdmath.Max(0, mean*mean-gauss))

--- a/kernel/geom/first_form.go
+++ b/kernel/geom/first_form.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+// The first fundamental form of a surface at (u, v) is the 2×2 metric
+// [[a, b], [b, c]] with a = Sᵤ·Sᵤ, b = Sᵤ·Sᵥ, c = Sᵥ·Sᵥ. Its determinant
+// det = a·c − b² carries units of length⁴, so a FIXED cutoff on det is
+// scale-blind: the same patch is judged "degenerate" at mm scale and well-formed
+// at km scale (#1402). The scale-invariant conditioning measure is the squared
+// sine of the angle θ between the two tangents — purely geometric, unit-free.
+
+// firstFormRelTol is the relative floor on sin²θ below which the tangent frame is
+// treated as degenerate (tangents collapsed or parallel). It is a pure ratio, so
+// it means the same thing at every model scale, unlike an absolute length⁴ cutoff.
+const firstFormRelTol = 1e-12
+
+// firstFormParallelity returns sin²θ = 1 − (Sᵤ·Sᵥ)²/((Sᵤ·Sᵤ)(Sᵥ·Sᵥ)) — the
+// dimensionless squared sine of the angle between the surface tangents (1 when
+// orthogonal, 0 when parallel or collapsed). By Cauchy–Schwarz b² ≤ a·c, so the
+// value lies in [0, 1]; a tiny negative from roundoff near parallel is clamped to
+// 0. Returns 0 when either tangent has zero length (a·c ≤ 0).
+//
+//	firstFormParallelity(1, 0, 1) // 1.0 — orthogonal unit tangents
+//	firstFormParallelity(1, 1, 1) // 0.0 — identical tangents, degenerate
+func firstFormParallelity(a, b, c float64) float64 {
+	ac := a * c
+	if ac <= 0 {
+		return 0
+	}
+	s := 1 - b*b/ac
+	if s < 0 {
+		return 0
+	}
+	return s
+}
+
+// degenerateFirstForm reports whether the first fundamental form [[a,b],[b,c]] is
+// degenerate — its tangents parallel or collapsed — by the scale-invariant
+// parallelity falling below firstFormRelTol. Replaces the legacy absolute cutoffs
+// on the length⁴ determinant (#1402), which misjudged tiny or huge patches.
+func degenerateFirstForm(a, b, c float64) bool {
+	return firstFormParallelity(a, b, c) < firstFormRelTol
+}

--- a/kernel/geom/nurbs_eval.go
+++ b/kernel/geom/nurbs_eval.go
@@ -4,6 +4,7 @@ package geom
 
 import (
 	"fmt"
+	stdmath "math"
 
 	"oblikovati.org/math"
 )
@@ -22,17 +23,42 @@ func (h *homog) add(p math.Point3, weight float64) {
 	h.w += weight
 }
 
-// point returns the rational position A/w.
+// point returns the rational position A/w, or the origin when the basis weight w
+// has collapsed. The B-spline basis is a partition of unity in-span and the control
+// weights are positive ([requirePositiveWeights]), so a valid w is at least the
+// smallest control weight; only an out-of-span evaluation or malformed knots drive
+// it toward zero. Returning a finite zero instead of A/0 stops a NaN/Inf from
+// propagating into tessellation, mass properties and continuity analysis (#1402).
 func (h homog) point() math.Point3 {
+	if !weightUsable(h.w) {
+		return math.Point3{}
+	}
 	return h.a.Scale(1 / h.w).AsPoint()
 }
 
 // deriv applies the rational quotient rule: given the value accumulator (this)
 // and a derivative accumulator d (built from basis-function derivatives), it
-// returns d(A/w) = (d.a − point·d.w)/w.
+// returns d(A/w) = (d.a − point·d.w)/w, or the zero vector when w has collapsed
+// (#1402, see [homog.point]).
 func (h homog) deriv(d homog) math.Vector3 {
+	if !weightUsable(h.w) {
+		return math.Vector3{}
+	}
 	point := h.point()
 	return d.a.Sub(point.AsVector().Scale(d.w)).Scale(1 / h.w)
+}
+
+// weightFloor is the smallest accumulated basis weight treated as usable. It is far
+// below any realistic positive control weight, so it rejects only a genuinely
+// collapsed denominator (an exactly-zero or denormal w from an out-of-span /
+// malformed evaluation), never a valid rational point (#1402).
+const weightFloor = 1e-300
+
+// weightUsable reports whether the rational denominator w is a normal, strictly
+// positive number — division by it yields a finite point. A non-finite or
+// at-/below-floor w is unusable.
+func weightUsable(w float64) bool {
+	return w > weightFloor && !stdmath.IsInf(w, 0)
 }
 
 // validateBSpline checks the size relationships every B-spline (curve direction)

--- a/kernel/geom/offset_surface.go
+++ b/kernel/geom/offset_surface.go
@@ -48,22 +48,26 @@ func (o OffsetSurface) PointAt(u, v float64) math.Point3 {
 // NormalAt returns the base normal: a parallel surface has the same normal field as its base.
 func (o OffsetSurface) NormalAt(u, v float64) math.Vector3 { return o.Base.NormalAt(u, v) }
 
-// offsetStepFraction is the central-difference half-step for ∂N/∂param, as a FRACTION of the domain
-// span — so the step adapts to the base's parameter scale (a NURBS [0,1] domain and an analytic
-// [0,2π] domain need different absolute steps for the same truncation/roundoff balance). #1322.
-const offsetStepFraction = 1e-6
-
 // DerivativesAt returns the offset surface's partials, ∂S_d/∂u = ∂S/∂u + Distance·∂N/∂u (and v): the
-// base's exact partials plus the Distance-scaled rate of change of the normal. ∂N/∂param is a central
-// difference (the Surface interface exposes no second derivative) with a domain-scaled step.
+// base's exact partials plus the Distance-scaled rate of change of the normal.
 func (o OffsetSurface) DerivativesAt(u, v float64) (du, dv math.Vector3) {
 	bdu, bdv := o.Base.DerivativesAt(u, v)
-	hu := offsetStepFraction * spanOr1(o.Base.UDomain())
-	hv := offsetStepFraction * spanOr1(o.Base.VDomain())
-	dNdu := centralDiff(o.Base.NormalAt(u+hu, v), o.Base.NormalAt(u-hu, v), hu)
-	dNdv := centralDiff(o.Base.NormalAt(u, v+hv), o.Base.NormalAt(u, v-hv), hv)
+	dNdu, dNdv := o.normalDerivs(u, v)
 	d := math.Scalar(o.Distance)
 	return bdu.Add(dNdu.Scale(d)), bdv.Add(dNdv.Scale(d))
+}
+
+// normalDerivs returns ∂N/∂u, ∂N/∂v of the base normal field by central differences — the Surface
+// interface exposes no analytic ∂N, so this is the one place the offset's curvature-dependent partials
+// come from. Each direction uses the first-difference-optimal step stepD1 = ε^{1/3} scaled by its own
+// domain span, so the step adapts to the base's parameter scale (a NURBS [0,1] vs an analytic [0,2π]
+// domain) and the truncation/roundoff balance holds at any model scale (#1322, #1402).
+func (o OffsetSurface) normalDerivs(u, v float64) (dNdu, dNdv math.Vector3) {
+	hu := stepD1 * spanOr1(o.Base.UDomain())
+	hv := stepD1 * spanOr1(o.Base.VDomain())
+	dNdu = centralDiff(o.Base.NormalAt(u+hu, v), o.Base.NormalAt(u-hu, v), hu)
+	dNdv = centralDiff(o.Base.NormalAt(u, v+hv), o.Base.NormalAt(u, v-hv), hv)
+	return dNdu, dNdv
 }
 
 // centralDiff returns (hi − lo) / (2·h).
@@ -136,14 +140,11 @@ func (o OffsetSurface) minTangentScale(u, v float64) (float64, bool) {
 	}
 	su, sv := o.Base.DerivativesAt(u, v)
 	e, f, g := dot(su, su), dot(su, sv), dot(sv, sv)
-	det := e*g - f*f
-	if det < math.DefaultTolerance {
+	if degenerateFirstForm(e, f, g) { // scale-invariant (parallel/collapsed tangents), #1402
 		return 0, false
 	}
-	hu := offsetStepFraction * spanOr1(o.Base.UDomain())
-	hv := offsetStepFraction * spanOr1(o.Base.VDomain())
-	nu := centralDiff(o.Base.NormalAt(u+hu, v), o.Base.NormalAt(u-hu, v), hu)
-	nv := centralDiff(o.Base.NormalAt(u, v+hv), o.Base.NormalAt(u, v-hv), hv)
+	det := e*g - f*f
+	nu, nv := o.normalDerivs(u, v)
 	// Express ∂N/∂u, ∂N/∂v in the {Su,Sv} basis (solve the metric system) → the 2×2 map W.
 	w11, w21 := solveMetric(e, f, g, det, dot(nu, su), dot(nu, sv))
 	w12, w22 := solveMetric(e, f, g, det, dot(nv, su), dot(nv, sv))

--- a/kernel/geom/project.go
+++ b/kernel/geom/project.go
@@ -112,13 +112,16 @@ func lineSearchToward(s Surface, q math.Point3, u, v, ddu, ddv, d2 float64) (nu,
 }
 
 // gaussNewtonStep solves the 2×2 normal-equation system [[a,b],[b,c]]·Δ = g for the
-// projection step, where a=du·du, b=du·dv, c=dv·dv. ok is false at a degenerate frame.
+// projection step, where a=du·du, b=du·dv, c=dv·dv. ok is false at a degenerate
+// frame, judged by the SCALE-INVARIANT [degenerateFirstForm] (parallel/collapsed
+// tangents) rather than an absolute cutoff on the length⁴ determinant, which would
+// reject a valid small-scale patch and accept a singular huge-scale one (#1402).
 func gaussNewtonStep(du, dv math.Vector3, gu, gv float64) (ddu, ddv float64, ok bool) {
 	a, b, c := float64(du.Dot(du)), float64(du.Dot(dv)), float64(dv.Dot(dv))
-	det := a*c - b*b
-	if stdmath.Abs(det) < 1e-18 {
+	if degenerateFirstForm(a, b, c) {
 		return 0, 0, false
 	}
+	det := a*c - b*b
 	return (c*gu - b*gv) / det, (a*gv - b*gu) / det, true
 }
 

--- a/kernel/geom/surface_hardening_test.go
+++ b/kernel/geom/surface_hardening_test.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// scaledSkewedPatch is skewedPatch's control net uniformly scaled, so the surface
+// is geometrically self-similar at every scale: the tangent angles (and thus the
+// dimensionless first-form conditioning) are identical, only the lengths change.
+// It is the fixture that separates a scale-invariant degeneracy test from the old
+// absolute determinant cutoff.
+func scaledSkewedPatch(t *testing.T, scale float64) BSplineSurface {
+	t.Helper()
+	base := [][]math.Point3{
+		{{X: 0, Y: 0, Z: 0}, {X: 1, Y: 1, Z: 0.5}, {X: 2, Y: 2, Z: 0}},
+		{{X: 1, Y: 0, Z: 1}, {X: 2, Y: 1, Z: 1.5}, {X: 3, Y: 2, Z: 1}},
+		{{X: 2, Y: 0, Z: 0}, {X: 3, Y: 1, Z: 0.5}, {X: 4, Y: 2, Z: 0}},
+	}
+	ctrl := make([][]math.Point3, len(base))
+	for i, row := range base {
+		ctrl[i] = make([]math.Point3, len(row))
+		for j, p := range row {
+			ctrl[i][j] = math.P3(p.X*scale, p.Y*scale, p.Z*scale)
+		}
+	}
+	w := [][]float64{{1, 1, 1}, {1, 1, 1}, {1, 1, 1}}
+	s, err := NewBSplineSurface(2, 2, ctrl, w, []float64{0, 0, 0, 1, 1, 1}, []float64{0, 0, 0, 1, 1, 1})
+	if err != nil {
+		t.Fatalf("scaled skewed patch (scale %g): %v", scale, err)
+	}
+	return s
+}
+
+// opaqueSurface wraps a Surface so the SurfaceSecondPartials type switch misses it
+// and falls through to the numeric path — the way to exercise numericSecondPartials
+// against a fixture whose curvature has a known closed form (the embedded sphere).
+type opaqueSurface struct{ Surface }
+
+// TestFirstFormDegeneracyIsScaleInvariant is acceptance criterion 1 of #1402: the
+// degeneracy verdict on the first fundamental form depends only on the tangent
+// ANGLE, not the model scale — where the retired absolute determinant cutoff flips.
+func TestFirstFormDegeneracyIsScaleInvariant(t *testing.T) {
+	for _, k := range []float64{1e-8, 1e-4, 1, 1e4, 1e8} {
+		a := k * k // tangents scale by k, so a = c = |Su|² scale by k²
+		if degenerateFirstForm(a, 0, a) {
+			t.Errorf("scale k=%g: orthogonal frame wrongly flagged degenerate", k)
+		}
+		if !degenerateFirstForm(a, a, a) {
+			t.Errorf("scale k=%g: parallel frame not flagged degenerate", k)
+		}
+	}
+	// Contrast with the retired absolute cutoff (det = a·c − b² < 1e-18): at k=1e-5 a
+	// perfectly orthogonal frame has det = 1e-20 and would have been rejected, while
+	// the scale-invariant test correctly accepts it.
+	const a = 1e-5 * 1e-5
+	if det := a * a; det >= 1e-18 {
+		t.Fatalf("fixture invalid: det=%g is not below the legacy cutoff", det)
+	}
+	if degenerateFirstForm(a, 0, a) {
+		t.Error("scale-invariant test must accept the orthogonal frame the legacy cutoff rejected")
+	}
+	// A collapsed tangent (a·c ≤ 0, e.g. a sphere pole) is degenerate regardless of b.
+	if !degenerateFirstForm(0, 0, 1) {
+		t.Error("a collapsed tangent (a=0) must be flagged degenerate")
+	}
+}
+
+// TestParamAtConvergesAtExtremeScale is acceptance criterion 1 of #1402 end to end:
+// the NURBS point inversion (whose Gauss–Newton step guards the frame with the new
+// scale-invariant test) recovers a perpendicular foot on a patch shrunk to µm and
+// grown to km, where the old absolute determinant cutoff aborts the small-scale step.
+func TestParamAtConvergesAtExtremeScale(t *testing.T) {
+	for _, scale := range []float64{1e-5, 1, 1e5} {
+		s := scaledSkewedPatch(t, scale)
+		foot := s.PointAt(0.35, 0.65)
+		q := foot.TranslateBy(s.NormalAt(0.35, 0.65).Scale(math.Scalar(0.3 * scale)))
+		u, v := s.ParamAt(q)
+		if r := perpCosine(s, q, u, v); r > 1e-7 {
+			t.Errorf("scale %g: ParamAt foot not perpendicular, residual %g", scale, r)
+		}
+	}
+}
+
+// TestNumericSecondPartialsCurvature is acceptance criterion 2 of #1402: the numeric
+// second-partial fallback (now an optimal, domain-scaled central difference) matches
+// the analytic closed form on a known surface — a sphere, whose principal curvatures
+// are ±1/R — within a tight tolerance, instead of the 5–50% error a fixed step admits.
+// The genuine Sphere uses the closed-form second partials; the opaque wrapper forces
+// the numeric path, so the two results must agree.
+func TestNumericSecondPartialsCurvature(t *testing.T) {
+	for _, r := range []float64{0.5, 2, 50} {
+		sphere, err := NewSphere(math.P3(0, 0, 0), r)
+		if err != nil {
+			t.Fatalf("sphere r=%g: %v", r, err)
+		}
+		_, wantMax, wantMin := SurfaceCurvatures(sphere, 0.6, 0.3)              // analytic
+		_, gotMax, gotMin := SurfaceCurvatures(opaqueSurface{sphere}, 0.6, 0.3) // numeric
+		if relErr(gotMax, wantMax) > 1e-5 || relErr(gotMin, wantMin) > 1e-5 {
+			t.Errorf("sphere r=%g: numeric curvatures (%g, %g), analytic (%g, %g)", r, gotMax, gotMin, wantMax, wantMin)
+		}
+	}
+}
+
+// relErr is the relative error |got − want|/|want| (want assumed nonzero here).
+func relErr(got, want float64) float64 {
+	return stdmath.Abs(got-want) / stdmath.Abs(want)
+}
+
+// opaqueCurve2 wraps a Curve2 so CurveDerivatives2's type switch misses it and falls
+// through to numericDers2 — the 2D analogue of opaqueSurface, used to exercise the
+// per-order finite-difference fallback against a known closed form.
+type opaqueCurve2 struct{ Curve2 }
+
+// TestNumericDers2Curvature exercises the per-order optimal steps in numericDers2 (the
+// 2D twin of numericDers3, #1402): the curvature of a circle of radius R is 1/R, so the
+// numeric fallback must recover it within a tight tolerance where a single fixed step
+// would not. A circle is the simplest fixture with a nonzero, constant analytic curvature.
+func TestNumericDers2Curvature(t *testing.T) {
+	for _, r := range []float64{0.25, 3, 40} {
+		circle := NewCircle2d(math.P2(0, 0), r)
+		got := CurveCurvature2(opaqueCurve2{circle}, 0.3) // numeric path
+		want := CurveCurvature2(circle, 0.3)              // analytic path (signed 1/R)
+		if relErr(got, want) > 1e-4 {
+			t.Errorf("circle r=%g: numeric curvature %g, analytic %g", r, got, want)
+		}
+	}
+}
+
+// TestRationalWeightCollapseReturnsFiniteZero is acceptance criterion 3 of #1402: a
+// collapsed rational denominator (out-of-span / malformed evaluation) yields a finite
+// zero from point and deriv instead of leaking NaN/Inf into downstream consumers.
+func TestRationalWeightCollapseReturnsFiniteZero(t *testing.T) {
+	collapsed := homog{a: math.V3(1, 2, 3), w: 0}
+	p := collapsed.point()
+	if stdmath.IsNaN(float64(p.X)) || stdmath.IsInf(float64(p.X), 0) || p != (math.Point3{}) {
+		t.Errorf("point() on a collapsed weight = %v, want the finite origin", p)
+	}
+	d := collapsed.deriv(homog{a: math.V3(4, 5, 6), w: 1})
+	if stdmath.IsNaN(float64(d.X)) || stdmath.IsInf(float64(d.X), 0) || d != (math.Vector3{}) {
+		t.Errorf("deriv() on a collapsed weight = %v, want the finite zero vector", d)
+	}
+	// A usable weight still evaluates the rational point: A/w = (2,4,6)/2 = (1,2,3).
+	if got := (homog{a: math.V3(2, 4, 6), w: 2}).point(); got != math.P3(1, 2, 3) {
+		t.Errorf("point() with a valid weight = %v, want (1,2,3)", got)
+	}
+}

--- a/kernel/geom/threaded_cylinder.go
+++ b/kernel/geom/threaded_cylinder.go
@@ -62,11 +62,15 @@ func (t ThreadedCylinder) PointAt(u, v float64) math.Point3 {
 }
 
 // DerivativesAt returns the partials by central differences (the thread modulation has no tidy
-// closed form; finite differences are exact enough for shading/normals).
+// closed form; finite differences are exact enough for shading/normals). Each direction uses the
+// first-difference-optimal step stepD1 = ε^{1/3} scaled by its domain span — the periodic angular
+// span in u and the threaded run in v — so the step stays scale-invariant rather than a fixed 1e-5
+// that ignored both the [0,2π] angular scale and the part size (#1402).
 func (t ThreadedCylinder) DerivativesAt(u, v float64) (du, dv math.Vector3) {
-	const e = 1e-5
-	du = t.PointAt(u-e, v).VectorTo(t.PointAt(u+e, v)).Scale(1 / (2 * e))
-	dv = t.PointAt(u, v-e).VectorTo(t.PointAt(u, v+e)).Scale(1 / (2 * e))
+	eu := stepD1 * spanOr1(t.UDomain())
+	ev := stepD1 * spanOr1(t.VDomain())
+	du = t.PointAt(u-eu, v).VectorTo(t.PointAt(u+eu, v)).Scale(1 / (2 * eu))
+	dv = t.PointAt(u, v-ev).VectorTo(t.PointAt(u, v+ev)).Scale(1 / (2 * ev))
 	return du, dv
 }
 


### PR DESCRIPTION
Closes #1402.

Closes three numerical-hygiene gaps in the geom evaluators, all of which silently degraded results depending on model scale.

## 1. Scale-invariant degeneracy tests (`first_form.go`)
The first-fundamental-form determinant `det = a·c − b²` (a=Sᵤ·Sᵤ, b=Sᵤ·Sᵥ, c=Sᵥ·Sᵥ) has units **length⁴**, so the fixed cutoffs that guarded it were scale-blind — false "degenerate" at mm scale, masked singularity at km scale:
- `project.go` `gaussNewtonStep`: `abs(det) < 1e-18`
- `offset_surface.go` `minTangentScale`: `det < DefaultTolerance`
- `evaluator_surface.go` `SurfaceCurvatures`: `den <= 0`

All three now use `degenerateFirstForm`, the dimensionless `sin²θ = 1 − b²/(a·c)` between the tangents (a pure ratio, identical at every scale) against a relative floor.

## 2. Optimal, domain-scaled second-derivative FD steps
The fixed `1e-5` step (whose pitfall #1323 documented for curves but never propagated) was both non-optimal and not domain-scaled. `numericSecondPartials`, `numericDers2`, `ThreadedCylinder.DerivativesAt` and the `OffsetSurface` normal derivatives now use the per-order optimal step `ε^{1/(n+2)}` scaled by each direction's own domain span, so the truncation/roundoff balance holds over `[0,1]` and `[0,2π]` alike and at any model size. Extracted `OffsetSurface.normalDerivs` to drop the duplicated central-difference block.

## 3. Rational weight-denominator guard (`nurbs_eval.go`)
`homog.point`/`deriv` divided by the accumulated basis weight with no near-zero guard, so an out-of-span / malformed-knot evaluation (w→0) leaked `Inf/NaN` into tessellation, mass properties and continuity analysis. Both now return a finite zero when `w` has collapsed.

## Tests (`surface_hardening_test.go`)
- degeneracy verdict invariant across `1e-8 … 1e8`; `ParamAt` converging on a patch shrunk to µm / grown to km (where the old absolute cutoff aborted the step);
- numeric 2nd-partial and 2D-derivative fallbacks matching the analytic curvature of a sphere / circle to tight tolerance (the genuine analytic surface vs an opaque wrapper forced down the numeric path);
- a collapsed rational weight yielding a finite zero, not `NaN/Inf`.

Local: `go test ./kernel/... ./model/...` green; geom coverage 91.3%; golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)