### PR TITLE
[recompute] Recover per-feature recompute panics into health.Sick

### DIFF
--- a/model/feature/engine.go
+++ b/model/feature/engine.go
@@ -227,8 +227,25 @@ func (fs *PartFeatures) evaluate(pf *PartFeature, bodies []*topo.Body, sick map[
 		return bodies
 	}
 	pf.recomputes++
-	out, err := pf.feature.Recompute(Input{Bodies: bodies, Params: fs.params, Keys: fs.keys, SourceTool: fs.sourceTool})
+	out, err := safeRecompute(pf, Input{Bodies: bodies, Params: fs.params, Keys: fs.keys, SourceTool: fs.sourceTool})
 	return fs.classify(pf, bodies, out, err, sick)
+}
+
+// safeRecompute runs one feature's Recompute, converting a PANIC (a nil-deref or
+// index-out-of-range the alpha kernel can hit on an unhandled boolean/tessellation case) into
+// an ordinary error. That error flows through classify like any other failure, so the feature
+// goes Sick and the rebuild continues its tail instead of the panic unwinding the whole
+// Recompute and crashing the app — the canonical "a sick feature never aborts the rebuild"
+// rule (Oblikovati#1415). The recover is scoped to this single call so a programmer error
+// anywhere else still surfaces. The error names the offending feature (via classify's Kind
+// prefix) and the recovered panic value.
+func safeRecompute(pf *PartFeature, in Input) (out Output, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			out, err = Output{}, fmt.Errorf("panicked during recompute: %v", r)
+		}
+	}()
+	return pf.feature.Recompute(in)
 }
 
 // sourceTool resolves a source feature's geometric contribution for a pattern/mirror: the

--- a/model/feature/engine_test.go
+++ b/model/feature/engine_test.go
@@ -4,6 +4,7 @@ package feature
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"oblikovati.org/kernel/geom"
@@ -28,6 +29,13 @@ type failer struct{}
 
 func (failer) Kind() string                    { return "failer" }
 func (failer) Recompute(Input) (Output, error) { return Output{}, errors.New("boom") }
+
+// panicker is a fake feature whose Recompute panics — the alpha-kernel crash (a nil-deref /
+// out-of-range mid-boolean) that #1415 must convert into a sick feature, not an app crash.
+type panicker struct{}
+
+func (panicker) Kind() string                    { return "panicker" }
+func (panicker) Recompute(Input) (Output, error) { panic("kernel nil-deref") }
 
 func makeBody() *topo.Body {
 	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok("f", "body", 0)))
@@ -164,6 +172,56 @@ func TestSickFeaturePoisonsDependents(t *testing.T) {
 	}
 	if dependent.RecomputeCount() != 0 {
 		t.Error("poisoned feature should not run its recompute")
+	}
+}
+
+// TestPanickingFeatureGoesSickWithoutAbortingRebuild is acceptance criterion 1/2 of #1415: a
+// feature whose Recompute panics is marked Sick and the rebuild carries on — Recompute itself
+// must return normally (no panic escaping to crash the app), and an independent later feature
+// still evaluates healthy.
+func TestPanickingFeatureGoesSickWithoutAbortingRebuild(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	good := fs.Add(body())
+	bad := fs.Add(panicker{})
+	after := fs.Add(body()) // independent of bad → must still evaluate
+	fs.Recompute()          // must return, not unwind the panic
+
+	if !good.Health().OK() {
+		t.Error("healthy feature before the panic went sick")
+	}
+	if bad.Health().Status != health.Sick {
+		t.Errorf("panicking feature health = %v, want sick", bad.Health().Status)
+	}
+	if !after.Health().OK() {
+		t.Error("independent feature after the panic should still be healthy (rebuild not aborted)")
+	}
+}
+
+// TestPanicSickMessageNamesFeatureAndValue is acceptance criterion 3 of #1415: the sick reason
+// carries the offending feature's identity and the recovered panic value (per the CLAUDE.md
+// exception-message rule), so the user can see WHAT failed and WHY.
+func TestPanicSickMessageNamesFeatureAndValue(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	bad := fs.Add(panicker{})
+	fs.Recompute()
+	reason := bad.Health().Reason
+	if !strings.Contains(reason, "panicker") || !strings.Contains(reason, "kernel nil-deref") {
+		t.Errorf("sick reason %q must name the feature (panicker) and the panic value (kernel nil-deref)", reason)
+	}
+}
+
+// TestPanickingFeaturePoisonsDependents confirms a panic is treated like any other failure
+// downstream: a feature depending on the panicking one is poisoned sick, not evaluated.
+func TestPanickingFeaturePoisonsDependents(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	bad := fs.Add(panicker{})
+	dependent := fs.Add(body(), bad.ID())
+	fs.Recompute()
+	if bad.Health().Status != health.Sick {
+		t.Errorf("panicking feature = %v, want sick", bad.Health().Status)
+	}
+	if dependent.Health().Status != health.Sick {
+		t.Errorf("dependent of a panicking feature = %v, want sick (poisoned)", dependent.Health().Status)
 	}
 }
 


### PR DESCRIPTION
Closes #1415.

## Problem
`PartFeatures.evaluate` called `pf.feature.Recompute(...)` with **no `recover()`** anywhere in `model/feature`. Returned `error`s were correctly classified into `health.Sick`, but a runtime **panic** in the alpha kernel (a nil-deref / index-out-of-range during a boolean or tessellation) unwound the whole `Recompute()` and crashed the app — violating the canonical rule that a failing feature goes sick and never aborts the rebuild, and preventing the user from opening and repairing a broken model.

## Fix
Wrap the single `evaluate` Recompute call in `safeRecompute`, which `recover()`s a panic into an ordinary error. That error flows through the existing `classify` path like any other failure:
- the feature goes **Sick**, its reason naming the offending feature (via `classify`'s `Kind` prefix) and the recovered **panic value**;
- its dependents **poison**;
- the rebuild **continues its tail**.

The recover is scoped to this one call, so a programmer error anywhere else still surfaces in tests.

## Tests
- `TestPanickingFeatureGoesSickWithoutAbortingRebuild` — injected panicking feature is marked Sick, `Recompute()` returns (no crash), and an independent later feature stays healthy.
- `TestPanicSickMessageNamesFeatureAndValue` — the sick reason contains the feature identity and the panic value.
- `TestPanickingFeaturePoisonsDependents` — a dependent of the panicking feature is poisoned sick.

Local: `go test ./model/...` green; `safeRecompute` 100% covered; golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)