### PR TITLE
[kernel] Diagnostic-collection channel (diag) — infrastructure for #1407/#1412

### DIFF
--- a/kernel/diag/diag.go
+++ b/kernel/diag/diag.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package diag is the kernel's diagnostic-collection channel: the way a geometry operation reports,
+// instead of silently swallowing, that it could not do the ideal thing — a cap it saturated, an exact
+// path it declined, a fallback it took. A [Recorder] threaded into an operation collects the typed
+// [Diagnostic]s it emits, so callers and tests can SEE what degraded and WHY rather than discovering it
+// later when a downstream feature or export breaks (Oblikovati/Oblikovati#1407, #1412).
+//
+// The channel is deliberately tiny: pass a *Recorder into an operation (or nil to discard), and emit
+// with rec.Record(...). Record is safe on a nil receiver, so an emission site never branches on whether
+// anyone is listening, and the Recorder is safe for the concurrent face tessellation the mesher runs.
+package diag
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Code is a stable, greppable diagnostic identifier — e.g. "boolean.csg-fallback",
+// "tessellate.cap-saturated". Use a dotted "domain.what" form so a category greps as a prefix.
+type Code string
+
+// Severity ranks a diagnostic. Defect is the load-bearing one: a tracked degradation (a CSG fallback, a
+// saturated cap) that produced a possibly-wrong result and should ultimately be eliminated, not an
+// expected outcome — the discipline that turns "exact or silent soup" into a visible, countable signal.
+type Severity int
+
+const (
+	// Info is a benign note (a path was taken, nothing degraded).
+	Info Severity = iota
+	// Warning is a result that is probably fine but worth surfacing (a sampled tolerance near its limit).
+	Warning
+	// Defect is a degraded/fallback result that is a tracked defect: it should not happen and is counted.
+	Defect
+)
+
+// String renders the severity for messages and logs.
+func (s Severity) String() string {
+	switch s {
+	case Info:
+		return "info"
+	case Warning:
+		return "warning"
+	case Defect:
+		return "defect"
+	default:
+		return fmt.Sprintf("severity(%d)", int(s))
+	}
+}
+
+// Diagnostic is one structured report: a typed [Code] for searching/counting, a [Severity], and a human
+// Detail that — per the CLAUDE.md exception-message rule — names the offending value or configuration
+// (which operands, which face, which cap value), so the reader can reproduce it without guessing.
+type Diagnostic struct {
+	Code     Code
+	Severity Severity
+	Detail   string
+}
+
+// String renders the diagnostic as "severity code: detail", the form used in logs and test failures.
+func (d Diagnostic) String() string {
+	return fmt.Sprintf("%s %s: %s", d.Severity, d.Code, d.Detail)
+}
+
+// Recorder collects the diagnostics emitted during one operation. The zero value is ready to use, and a
+// nil *Recorder is a valid sink that discards — so a caller that does not care passes nil and every
+// emission site stays branch-free. It is safe for concurrent use (the mesher records from parallel face
+// goroutines into one shared recorder).
+type Recorder struct {
+	mu      sync.Mutex
+	records []Diagnostic
+}
+
+// Record appends d. It is a no-op on a nil receiver, so emission sites call rec.Record(...) whether or
+// not the caller supplied a recorder.
+func (r *Recorder) Record(d Diagnostic) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.records = append(r.records, d)
+}
+
+// Recordf is Record with a formatted Detail, the common emission shape.
+func (r *Recorder) Recordf(code Code, sev Severity, format string, args ...any) {
+	if r == nil {
+		return
+	}
+	r.Record(Diagnostic{Code: code, Severity: sev, Detail: fmt.Sprintf(format, args...)})
+}
+
+// Records returns a copy of the collected diagnostics in emission order (a copy, so the caller cannot
+// mutate the recorder's slice). nil receiver returns nil.
+func (r *Recorder) Records() []Diagnostic {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]Diagnostic(nil), r.records...)
+}
+
+// Count returns how many recorded diagnostics have the given severity — e.g. Count(diag.Defect) is the
+// tracked-defect count a test asserts is zero on a clean run.
+func (r *Recorder) Count(sev Severity) int {
+	if r == nil {
+		return 0
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	n := 0
+	for _, d := range r.records {
+		if d.Severity == sev {
+			n++
+		}
+	}
+	return n
+}
+
+// Has reports whether any recorded diagnostic carries code — the searchable assertion a handler test
+// uses to confirm its decline emitted a diagnostic rather than a silent result.
+func (r *Recorder) Has(code Code) bool {
+	if r == nil {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, d := range r.records {
+		if d.Code == code {
+			return true
+		}
+	}
+	return false
+}

--- a/kernel/diag/diag_test.go
+++ b/kernel/diag/diag_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package diag
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestRecorderCollectsInOrder(t *testing.T) {
+	var r Recorder
+	r.Recordf("a.one", Warning, "first %d", 1)
+	r.Record(Diagnostic{Code: "a.two", Severity: Defect, Detail: "second"})
+
+	got := r.Records()
+	if len(got) != 2 {
+		t.Fatalf("recorded %d, want 2", len(got))
+	}
+	if got[0].Code != "a.one" || got[0].Detail != "first 1" || got[0].Severity != Warning {
+		t.Errorf("first diagnostic = %+v, want a.one/warning/\"first 1\"", got[0])
+	}
+	if got[1].Code != "a.two" || got[1].Severity != Defect {
+		t.Errorf("second diagnostic = %+v, want a.two/defect", got[1])
+	}
+}
+
+func TestRecorderCountAndHas(t *testing.T) {
+	var r Recorder
+	r.Recordf("x.warn", Warning, "w")
+	r.Recordf("x.defect", Defect, "d")
+	r.Recordf("x.defect2", Defect, "d2")
+
+	if n := r.Count(Defect); n != 2 {
+		t.Errorf("defect count = %d, want 2", n)
+	}
+	if n := r.Count(Warning); n != 1 {
+		t.Errorf("warning count = %d, want 1", n)
+	}
+	if !r.Has("x.defect") {
+		t.Error("Has(x.defect) = false, want true")
+	}
+	if r.Has("x.absent") {
+		t.Error("Has(x.absent) = true, want false")
+	}
+}
+
+// TestNilRecorderDiscards is the contract that lets an emission site stay branch-free: every method is
+// safe on a nil *Recorder and reports empty.
+func TestNilRecorderDiscards(t *testing.T) {
+	var r *Recorder // nil
+	r.Record(Diagnostic{Code: "ignored"})
+	r.Recordf("ignored", Defect, "x")
+	if got := r.Records(); got != nil {
+		t.Errorf("nil recorder Records() = %v, want nil", got)
+	}
+	if r.Count(Defect) != 0 || r.Has("ignored") {
+		t.Error("nil recorder reported a diagnostic it discarded")
+	}
+}
+
+// TestRecorderIsConcurrencySafe records from many goroutines at once — the mesher tessellates faces in
+// parallel into one shared recorder — and asserts none are lost or race.
+func TestRecorderIsConcurrencySafe(t *testing.T) {
+	var r Recorder
+	const goroutines, each = 16, 64
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < each; i++ {
+				r.Recordf("c.parallel", Defect, "from a goroutine")
+			}
+		}()
+	}
+	wg.Wait()
+	if n := r.Count(Defect); n != goroutines*each {
+		t.Errorf("concurrent records = %d, want %d (lost under the race)", n, goroutines*each)
+	}
+}
+
+func TestDiagnosticString(t *testing.T) {
+	d := Diagnostic{Code: "boolean.csg-fallback", Severity: Defect, Detail: "Cut on a cylinder operand"}
+	if got, want := d.String(), "defect boolean.csg-fallback: Cut on a cylinder operand"; got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -4,6 +4,7 @@ package ops
 
 import (
 	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 )
@@ -44,6 +45,19 @@ func (op PartFeatureOperation) String() string {
 // planar-faceted operands, falling back to triangle-soup CSG when an operand has a curved
 // face. Result-face lineage flows from the operands, so reference keys stay rebindable.
 func Boolean(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, error) {
+	return BooleanWithDiagnostics(op, target, tool, nil)
+}
+
+// CodeBooleanCSGFallback marks a boolean that abandoned the exact analytic/planar B-rep path for
+// triangle-soup CSG — a tracked defect: the result keeps no analytic surfaces and can hide a
+// volume-preserving topology error the volume guard misses (Oblikovati#1407).
+const CodeBooleanCSGFallback diag.Code = "boolean.csg-fallback"
+
+// BooleanWithDiagnostics is [Boolean] with a diagnostic [diag.Recorder] (pass nil to discard). Whenever
+// the operation falls back from the exact analytic/planar path to triangle-soup CSG it records a Defect
+// diagnostic naming the operation and operands, so callers and tests can SEE and count the fallback
+// instead of silently shipping a faceted mesh (Oblikovati#1407).
+func BooleanWithDiagnostics(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, error) {
 	lin := topo.NewLineage(topo.Tok("boolean", op.String(), 0))
 	if op == NewBody {
 		return tool, nil
@@ -51,11 +65,11 @@ func Boolean(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, erro
 	rel := classify(target, tool)
 	switch op {
 	case Join:
-		return join(lin, target, tool, rel)
+		return join(lin, target, tool, rel, rec)
 	case Cut:
-		return cut(lin, target, tool, rel)
+		return cut(lin, target, tool, rel, rec)
 	default: // Intersect
-		return intersect(lin, target, tool, rel)
+		return intersect(lin, target, tool, rel, rec)
 	}
 }
 
@@ -64,14 +78,14 @@ func Boolean(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, erro
 // inner shell is discarded rather than kept as a floating interior wall — the old MergeBodies path
 // concatenated both shells and double-counted the volume (#1316). Disjoint bodies merge into one
 // multi-lump body (each a separate valid shell); intersecting bodies go to the face-splitting boolean.
-func join(lin topo.Lineage, target, tool *topo.Body, rel relation) (*topo.Body, error) {
+func join(lin topo.Lineage, target, tool *topo.Body, rel relation, rec *diag.Recorder) (*topo.Body, error) {
 	switch rel {
 	case targetContainsTool:
 		return target, nil // tool lies inside target → union is target alone
 	case toolContainsTarget:
 		return tool, nil
 	case intersecting:
-		return booleanGeneral(Join, target, tool, lin)
+		return booleanGeneral(Join, target, tool, lin, rec)
 	default: // disjoint: two separate lumps form a valid multi-shell body
 		return topo.MergeBodies(lin, true, target, tool), nil
 	}
@@ -81,17 +95,17 @@ func join(lin topo.Lineage, target, tool *topo.Body, rel relation) (*topo.Body, 
 // — it is sound under chaining and yields a low-face-count solid — falling back to the
 // triangle-soup BSP CSG only when an operand has a non-planar face the B-rep path can't take
 // (a cylinder, cone, etc.). A nil B-rep result is a (valid) empty body.
-func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.Lineage) (*topo.Body, error) {
+func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.Lineage, rec *diag.Recorder) (*topo.Body, error) {
 	if body, ok := curvedExactBoolean(op, target, tool); ok {
 		return body, nil // an exact analytic curved result (M2 #1334/#1335) — keeps surfaces, no CSG soup
 	}
 	bop, ok := toBrepOp(op)
 	if !ok {
-		return booleanCSG(op, target, tool, lin)
+		return booleanCSG(op, target, tool, lin, rec)
 	}
 	body, err := brep.Boolean(bop, target, tool)
 	if err != nil {
-		return booleanCSG(op, target, tool, lin) // non-planar operand → triangle CSG
+		return booleanCSG(op, target, tool, lin, rec) // non-planar operand → triangle CSG
 	}
 	if body == nil {
 		return topo.MergeBodies(lin, true), nil
@@ -109,7 +123,7 @@ func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.L
 		// Validate().Valid, which does not require Closed. T-junction removal now always closes
 		// the cage (#1336), so this is belt-and-braces: never replace a sound planar result with
 		// an open one.
-		if csg, cerr := booleanCSG(op, target, tool, lin); cerr == nil && csg != nil && validBooleanSolid(csg) {
+		if csg, cerr := booleanCSG(op, target, tool, lin, rec); cerr == nil && csg != nil && validBooleanSolid(csg) {
 			return csg, nil
 		}
 	}
@@ -234,7 +248,10 @@ func toBrepOp(op PartFeatureOperation) (brep.Op, bool) {
 // declined. The supported curved booleans keep their analytic surfaces and never land here — the
 // TestCurvedBooleansStayExact guard pins that. CSG remains for the unsupported long tail (arbitrary
 // freeform/NURBS overlaps), where a faceted-but-watertight result still beats failing.
-func booleanCSG(op PartFeatureOperation, target, tool *topo.Body, lin topo.Lineage) (*topo.Body, error) {
+func booleanCSG(op PartFeatureOperation, target, tool *topo.Body, lin topo.Lineage, rec *diag.Recorder) (*topo.Body, error) {
+	rec.Recordf(CodeBooleanCSGFallback, diag.Defect,
+		"%s fell back to triangle-soup CSG (target %d faces, tool %d faces): no exact analytic/planar path",
+		op, len(target.Faces()), len(tool.Faces()))
 	a, b := bodyTriangles(target), bodyTriangles(tool)
 	// One model-relative on-plane tolerance for the BSP, scaled to the larger operand
 	// (ADR-0042) so a sub-µm boolean classifies coplanarity correctly.
@@ -254,18 +271,18 @@ func booleanCSG(op PartFeatureOperation, target, tool *topo.Body, lin topo.Linea
 	return topo.MergeBodies(lin, true), nil
 }
 
-func cut(lin topo.Lineage, target, tool *topo.Body, rel relation) (*topo.Body, error) {
+func cut(lin topo.Lineage, target, tool *topo.Body, rel relation, rec *diag.Recorder) (*topo.Body, error) {
 	switch rel {
 	case disjoint:
 		return target, nil // tool removes nothing
 	case toolContainsTarget:
 		return topo.MergeBodies(lin, true), nil // target fully removed → empty
 	default: // targetContainsTool (a void/cavity) and intersecting need face splitting
-		return booleanGeneral(Cut, target, tool, lin)
+		return booleanGeneral(Cut, target, tool, lin, rec)
 	}
 }
 
-func intersect(lin topo.Lineage, target, tool *topo.Body, rel relation) (*topo.Body, error) {
+func intersect(lin topo.Lineage, target, tool *topo.Body, rel relation, rec *diag.Recorder) (*topo.Body, error) {
 	switch rel {
 	case disjoint:
 		return topo.MergeBodies(lin, true), nil // nothing in common → empty
@@ -274,7 +291,7 @@ func intersect(lin topo.Lineage, target, tool *topo.Body, rel relation) (*topo.B
 	case toolContainsTarget:
 		return target, nil
 	default:
-		return booleanGeneral(Intersect, target, tool, lin)
+		return booleanGeneral(Intersect, target, tool, lin, rec)
 	}
 }
 

--- a/kernel/ops/diag_integration_test.go
+++ b/kernel/ops/diag_integration_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/math"
+)
+
+// TestBooleanRecordsCSGFallbackDiagnostic proves the diag channel end to end on the boolean side: a
+// curved configuration with no exact analytic/planar path (two overlapping spheres) falls back to
+// triangle-soup CSG, and that fallback is now RECORDED as a searchable Defect instead of silently
+// shipping a faceted mesh (the #1407 guardrail this infrastructure enables).
+func TestBooleanRecordsCSGFallbackDiagnostic(t *testing.T) {
+	a, err := brep.SolidSphere(math.P3(0, 0, 0), 2, "a")
+	if err != nil {
+		t.Fatalf("sphere a: %v", err)
+	}
+	b, err := brep.SolidSphere(math.P3(2, 0, 0), 2, "b") // overlaps a; sphere∩sphere has no exact handler
+	if err != nil {
+		t.Fatalf("sphere b: %v", err)
+	}
+
+	var rec diag.Recorder
+	res, err := BooleanWithDiagnostics(Intersect, a, b, &rec)
+	if err != nil {
+		t.Fatalf("BooleanWithDiagnostics: %v", err)
+	}
+	if res == nil {
+		t.Fatal("nil result")
+	}
+	if !rec.Has(CodeBooleanCSGFallback) {
+		t.Errorf("curved boolean fell back to CSG but recorded no %q diagnostic; got %v", CodeBooleanCSGFallback, rec.Records())
+	}
+	if rec.Count(diag.Defect) == 0 {
+		t.Error("a CSG fallback must record a Defect-severity diagnostic")
+	}
+}
+
+// TestBooleanExactPathRecordsNoDiagnostic confirms the channel is quiet on success: an exact analytic
+// crossing-cylinder boolean (unequal radii — handled by the curved exact path) records no defect, so a
+// recorded defect always means a real degradation, never noise.
+func TestBooleanExactPathRecordsNoDiagnostic(t *testing.T) {
+	fat, _ := brep.SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	thin, _ := brep.SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
+
+	var rec diag.Recorder
+	if _, err := BooleanWithDiagnostics(Intersect, fat, thin, &rec); err != nil {
+		t.Fatalf("BooleanWithDiagnostics: %v", err)
+	}
+	if n := rec.Count(diag.Defect); n != 0 {
+		t.Errorf("an exact crossing-cylinder boolean recorded %d defect(s), want 0: %v", n, rec.Records())
+	}
+}
+
+// TestBooleanNilRecorderStillWorks confirms the legacy Boolean entry point (which passes a nil recorder)
+// is unaffected: the same fallback runs, just unobserved.
+func TestBooleanNilRecorderStillWorks(t *testing.T) {
+	a, _ := brep.SolidSphere(math.P3(0, 0, 0), 2, "a")
+	b, _ := brep.SolidSphere(math.P3(2, 0, 0), 2, "b")
+	if res, err := Boolean(Intersect, a, b); err != nil || res == nil {
+		t.Fatalf("Boolean (nil recorder) = %v, %v; want a result and no error", res, err)
+	}
+}
+
+// TestMeshCarriesDiagnostics covers the tessellation carrier: a diagnostic recorded on a component mesh
+// surfaces on the composed mesh through mergeMesh — the path a deep tessellation degradation takes to
+// the final face/body mesh (#1412).
+func TestMeshCarriesDiagnostics(t *testing.T) {
+	child := &Mesh{}
+	child.Diagnose(diag.Diagnostic{Code: "tessellate.cap-saturated", Severity: diag.Defect, Detail: "face X below tol"})
+	parent := &Mesh{}
+	mergeMesh(parent, child)
+	if len(parent.Diagnostics) != 1 || parent.Diagnostics[0].Code != "tessellate.cap-saturated" {
+		t.Errorf("mergeMesh did not carry the child mesh's diagnostics up: %v", parent.Diagnostics)
+	}
+}

--- a/kernel/ops/tessellate.go
+++ b/kernel/ops/tessellate.go
@@ -5,6 +5,7 @@ package ops
 import (
 	stdmath "math"
 
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -17,6 +18,23 @@ type Mesh struct {
 	Positions []math.Point3
 	Normals   []math.Vector3
 	Indices   []int
+	// Diagnostics carries any degradation the tessellator recorded while building this mesh — a cap it
+	// saturated, an exact path it declined — the diag channel's tessellation carrier, so a consumer sees
+	// the mesh may not meet tolerance instead of discovering it downstream (Oblikovati#1412). Empty means
+	// a clean tessellation.
+	Diagnostics []diag.Diagnostic
+}
+
+// Diagnose records a diagnostic onto the mesh — the emission site for a tessellator that degraded while
+// building it (e.g. saturated the interior-cell cap below the chord tolerance, #1412).
+func (m *Mesh) Diagnose(d diag.Diagnostic) { m.Diagnostics = append(m.Diagnostics, d) }
+
+// carryDiagnostics lifts a sub-mesh's diagnostics into m when the tessellator composes meshes, so a
+// degradation recorded deep in a component surfaces on the final face mesh.
+func (m *Mesh) carryDiagnostics(child *Mesh) {
+	if child != nil && len(child.Diagnostics) > 0 {
+		m.Diagnostics = append(m.Diagnostics, child.Diagnostics...)
+	}
 }
 
 // TriangleCount returns the number of triangles.
@@ -189,6 +207,7 @@ func mergeMesh(dst, src *Mesh) {
 	for _, idx := range src.Indices {
 		dst.Indices = append(dst.Indices, base+idx)
 	}
+	dst.carryDiagnostics(src) // a face's tessellation diagnostics surface on the whole-body mesh
 }
 
 // adaptiveParams returns the parameter breakpoints (lo…hi inclusive) at which eval's chord


### PR DESCRIPTION
Foundation requested before #1407 and #1412: the kernel had **no channel** to report — rather than silently swallow — that a geometry operation could not do the ideal thing (a cap it saturated, an exact path it declined, a fallback it took). The only nets were a gross-volume guard and ad-hoc warning strings, so a degraded result (triangle-soup CSG, an under-tessellated face) shipped looking fine until something downstream broke. That failure-visibility gap is what makes "exact analytic or silent soup" a binary with no middle.

## `kernel/diag` — the facility
- `Diagnostic{Code, Severity, Detail}` — a typed, **searchable** `Code` (`"boolean.csg-fallback"`), a `Severity` (`Info`/`Warning`/**`Defect`** — the tracked-degradation rank), and a `Detail` that names the offending value/configuration per the CLAUDE.md exception-message rule.
- `Recorder` — collects diagnostics during one operation. **Nil-safe** (`Record` on a nil `*Recorder` is a no-op, so an emission site never branches on whether anyone is listening) and **concurrency-safe** (the mesher records from parallel face goroutines — verified under `-race`). `Count(Defect)` / `Has(code)` give tests a precise "this degradation was surfaced" assertion.

## Two consumer channels wired (proving it end-to-end)
- **Boolean** — `BooleanWithDiagnostics(op, target, tool, rec)`: when it falls back from the exact analytic/planar path to triangle-soup CSG it records a `boolean.csg-fallback` Defect naming the op and operand face counts. The public `Boolean` delegates with `nil`, so its **27 callers are untouched**. This is the central CSG-fallback emission #1407 asks for; #1407 can additionally thread the same `Recorder` into the ~45 brep per-site declines for finer granularity.
- **Tessellation** — a `Mesh.Diagnostics` carrier (`Diagnose` to record; `mergeMesh` carries a component's diagnostics up to the body mesh), the surface on which a deep tessellation degradation (a saturated interior-cell cap, #1412) reaches the caller.

## Tests
`kernel/diag` unit tests (order, count/has, nil-discard, `-race` concurrency, String); integration: a sphere∩sphere with no exact handler records the CSG fallback, an exact crossing-cylinder boolean records nothing, the nil-recorder `Boolean` is unaffected, and a component mesh's diagnostic surfaces on the merged mesh.

This unblocks **#1412** (record the cap saturation onto `Mesh.Diagnostics`) and **#1407** (count CSG fallbacks; add the Euler check to the existing manifold/free-edge `ValidationReport`).

Local: `go test ./...` green; golangci-lint clean; `diag` coverage 91.7%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)