### PR TITLE
[ops] Local curvature-adaptive tessellation + cap-saturation diagnostic

### DIFF
--- a/kernel/ops/adaptive_tessellation_test.go
+++ b/kernel/ops/adaptive_tessellation_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// offsetBumpSurface is a 4×4 biquadratic patch that is flat except for one raised control point near a
+// corner — a curvature feature OFF the centre, the case a single mid-line / diagonal sagitta sample
+// misses and a uniform global step over/under-tessellates (#1412).
+func offsetBumpSurface(t *testing.T) geom.BSplineSurface {
+	t.Helper()
+	ctrl := make([][]math.Point3, 4)
+	w := make([][]float64, 4)
+	for i := 0; i < 4; i++ {
+		ctrl[i] = make([]math.Point3, 4)
+		w[i] = []float64{1, 1, 1, 1}
+		for j := 0; j < 4; j++ {
+			z := math.Scalar(0)
+			if i == 1 && j == 1 { // raise one control point toward the (≈0.25,0.25) corner region
+				z = 4
+			}
+			ctrl[i][j] = math.Point3{X: math.Scalar(i), Y: math.Scalar(j), Z: z}
+		}
+	}
+	knots := []float64{0, 0, 0, 0.5, 1, 1, 1}
+	s, err := geom.NewBSplineSurface(2, 2, ctrl, w, knots, knots)
+	if err != nil {
+		t.Fatalf("offset bump surface: %v", err)
+	}
+	return s
+}
+
+// tightDomeSurface is a centred dome raised so extremely steeply (z far beyond any real model) that even the finest grid (the maxInteriorCells
+// floor) cannot meet the chord tolerance — the saturation case #1412 must report.
+func tightDomeSurface(t *testing.T) geom.BSplineSurface {
+	t.Helper()
+	ctrl := [][]math.Point3{
+		{math.P3(0, 0, 0), math.P3(0, 1, 0), math.P3(0, 2, 0)},
+		{math.P3(1, 0, 0), math.P3(1, 1, 3000), math.P3(1, 2, 0)},
+		{math.P3(2, 0, 0), math.P3(2, 1, 0), math.P3(2, 2, 0)},
+	}
+	w := [][]float64{{1, 1, 1}, {1, 1, 1}, {1, 1, 1}}
+	s, err := geom.NewBSplineSurface(2, 2, ctrl, w, []float64{0, 0, 0, 1, 1, 1}, []float64{0, 0, 0, 1, 1, 1})
+	if err != nil {
+		t.Fatalf("tight dome: %v", err)
+	}
+	return s
+}
+
+// TestLocalRefinementConcentratesAtBump is #1412's core criterion: interior refinement adds nodes WHERE
+// the curvature is (the off-centre bump), not uniformly — the bump quadrant ends up denser than the far
+// flat quadrant, and the refinement adds nodes the base grid alone did not.
+func TestLocalRefinementConcentratesAtBump(t *testing.T) {
+	s := offsetBumpSurface(t)
+	outer := uvSquare(0.02, 0.98, 12)
+	base, _ := adaptiveInteriorNodes(s, outer, nil, DefaultQuality(), 1, false)
+	refined, _ := adaptiveInteriorNodes(s, outer, nil, DefaultQuality(), 1, true)
+
+	if len(refined) <= len(base) {
+		t.Fatalf("local refinement added no nodes: base %d, refined %d", len(base), len(refined))
+	}
+	bump, far := 0, 0
+	for _, n := range refined {
+		switch {
+		case n[0] < 0.5 && n[1] < 0.5:
+			bump++
+		case n[0] > 0.5 && n[1] > 0.5:
+			far++
+		}
+	}
+	if bump <= far {
+		t.Errorf("refinement did not concentrate at the bump: bump quadrant %d nodes, far flat quadrant %d", bump, far)
+	}
+}
+
+// TestLocalRefinementLeavesFlatFaceUnchanged is #1412 criterion 3 (no flat regression) at its sharpest:
+// a flat face has zero curvature everywhere, so local refinement adds exactly nothing on top of the
+// base grid — the broader no-regression guarantee is the unchanged golden suite.
+func TestLocalRefinementLeavesFlatFaceUnchanged(t *testing.T) {
+	flat := unitPatch(t)
+	outer := uvSquare(0.05, 0.95, 8)
+	base, _ := adaptiveInteriorNodes(flat, outer, nil, DefaultQuality(), 1, false)
+	refined, satur := adaptiveInteriorNodes(flat, outer, nil, DefaultQuality(), 1, true)
+	if len(refined) != len(base) {
+		t.Errorf("flat face densified by local refinement: base %d → refined %d nodes", len(base), len(refined))
+	}
+	if satur {
+		t.Error("a flat face cannot saturate the cap")
+	}
+}
+
+// TestInteriorRefinementReportsSaturation is #1412's saturation criterion: a face curved too steeply for
+// the cell-size floor to meet the chord tolerance reports saturated, and recordCapSaturation surfaces it
+// as a searchable diagnostic on the mesh — instead of silently exceeding tolerance.
+func TestInteriorRefinementReportsSaturation(t *testing.T) {
+	s := tightDomeSurface(t)
+	outer := uvSquare(0.02, 0.98, 12)
+	_, saturated := adaptiveInteriorNodes(s, outer, nil, DefaultQuality(), 1, true)
+	if !saturated {
+		t.Fatal("a face too curved for the cell floor should report saturation")
+	}
+
+	m := &Mesh{}
+	recordCapSaturation(m, saturated, DefaultQuality())
+	if !hasDiag(m.Diagnostics, CodeTessellateCapSaturated) {
+		t.Errorf("saturation was not recorded as a %q diagnostic: %v", CodeTessellateCapSaturated, m.Diagnostics)
+	}
+}
+
+// hasDiag reports whether the diagnostics carry the given code.
+func hasDiag(ds []diag.Diagnostic, code diag.Code) bool {
+	for _, d := range ds {
+		if d.Code == code {
+			return true
+		}
+	}
+	return false
+}

--- a/kernel/ops/fold_585_test.go
+++ b/kernel/ops/fold_585_test.go
@@ -17,8 +17,8 @@ import (
 func TestAdaptiveInteriorNodesRefineDensifies(t *testing.T) {
 	s := domeSurface(t)
 	outer := []math.Point2{math.P2(0, 0), math.P2(1, 0), math.P2(1, 1), math.P2(0, 1)}
-	base := adaptiveInteriorNodes(s, outer, nil, DefaultQuality(), 1)
-	fine := adaptiveInteriorNodes(s, outer, nil, DefaultQuality(), 0.5)
+	base := interiorNodesOnly(s, outer, nil, DefaultQuality(), 1)
+	fine := interiorNodesOnly(s, outer, nil, DefaultQuality(), 0.5)
 	if len(fine) <= len(base) {
 		t.Errorf("refine 0.5 gave %d interior nodes, want more than the %d at refine 1", len(fine), len(base))
 	}

--- a/kernel/ops/holed_cylinder_wall.go
+++ b/kernel/ops/holed_cylinder_wall.go
@@ -73,7 +73,8 @@ func unrolledWallCDT(s geom.Surface, q Quality, outer3D []math.Point3, holes3D [
 	}
 	uv, pos, nrm, loops := patchLoops2D(s, outer3D, holes3D, outer2D, holes2D)
 	nFrontier := len(uv)
-	for _, g := range adaptiveInteriorNodes(s, outerUV, holesUV, q, 1) {
+	nodes, saturated := adaptiveInteriorNodes(s, outerUV, holesUV, q, 1, false)
+	for _, g := range nodes {
 		uv = append(uv, [2]float64{g[0] * su, g[1] * sv})
 		pos = append(pos, s.PointAt(g[0], g[1]))
 		nrm = append(nrm, s.NormalAt(g[0], g[1]))
@@ -84,6 +85,7 @@ func unrolledWallCDT(s geom.Surface, q Quality, outer3D []math.Point3, holes3D [
 	}
 	m := patchMeshFrom(pos, nrm, tris)
 	repairFolds(m, 8)
+	recordCapSaturation(m, saturated, q)
 	return m
 }
 

--- a/kernel/ops/nurbs_interior.go
+++ b/kernel/ops/nurbs_interior.go
@@ -3,8 +3,10 @@
 package ops
 
 import (
+	"fmt"
 	stdmath "math"
 
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/math"
 )
@@ -16,13 +18,31 @@ const (
 	minInteriorCells = 2
 )
 
-// adaptiveInteriorNodes returns interior (u,v) nodes for a trimmed NURBS face: a staggered grid
-// whose spacing follows the surface's curvature (a flat face gets none, a curved face gets dense
-// nodes at the same Quality), kept STRICTLY inside the trim — inside the outer pcurve, outside every
-// hole, and at least a margin off the boundary so no node spills past the trim or sits on it (the
-// over-enclosure that inflated the volume in every naive attempt — ADR-0030 / M24 F02). The pcurves
-// are the smooth march-projected boundary (F01); their point-in-polygon test is therefore reliable.
-func adaptiveInteriorNodes(s geom.Surface, outer []math.Point2, holes [][]math.Point2, q Quality, refine float64) [][2]float64 {
+// CodeTessellateCapSaturated marks a face whose interior refinement hit the cell-size floor with the
+// surface still bulging past the chord tolerance — the mesh may not meet tolerance there, recorded
+// instead of silently exceeding it (Oblikovati#1412).
+const CodeTessellateCapSaturated diag.Code = "tessellate.cap-saturated"
+
+// localRefineThreshold is how far above the global step's per-cell deviation budget a base cell must
+// bulge before it is LOCALLY subdivided. It is > 1 so a uniformly-curved face — whose cells already sit
+// ≈ at the budget by the global step's construction — is left exactly as before (no regression, #1412);
+// only a cell markedly more curved than the face's average (an off-centre bump, a torus tube against
+// its flatter ring) crosses it and gets concentrated refinement.
+const localRefineThreshold = 1.5
+
+// adaptiveInteriorNodes returns interior (u,v) nodes for a trimmed NURBS face, and whether the local
+// refinement SATURATED (hit the cell-size floor with the surface still over tolerance). The base is the
+// curvature-scaled staggered grid as before — a flat face gets none, a uniformly-curved one a uniform
+// grid — kept STRICTLY inside the trim (inside the outer pcurve, outside every hole, a margin off the
+// boundary, so no node spills past the trim, ADR-0030 / M24 F02). ON TOP of it, any base cell that
+// bulges well past the global step's average is recursively subdivided, so the refinement CONCENTRATES
+// where curvature varies (a bump, a torus tube) without densifying the rest — fixing the under/over-
+// tessellation of the single global step from one diagonal sagitta sample (#1412).
+// localRefine asks adaptiveInteriorNodes to ADD concentrated curvature nodes on top of the base grid.
+// Only the robust all-points constrainedDelaunay path (metricCDTPatch) passes it: the holed-wall path
+// uses constrainedDelaunayRefined, whose post-constraint insertion can fold, and extra interior nodes
+// there tear the mesh — so it takes the base grid only and relies on the saturation diagnostic instead.
+func adaptiveInteriorNodes(s geom.Surface, outer []math.Point2, holes [][]math.Point2, q Quality, refine float64, localRefine bool) ([][2]float64, bool) {
 	umin, umax, vmin, vmax := uvBBox(outer)
 	stepU, stepV := adaptiveStep(s, umin, umax, vmin, vmax, q)
 	if refine > 0 && refine < 1 {
@@ -32,15 +52,46 @@ func adaptiveInteriorNodes(s geom.Surface, outer []math.Point2, holes [][]math.P
 		stepV = stdmath.Max(stepV*refine, (vmax-vmin)/maxInteriorCells)
 	}
 	if stepU <= 0 || stepV <= 0 {
-		return nil
+		return nil, false
 	}
 	margin := 0.3 * stdmath.Min(stepU, stepV)
+	pts := baseStaggeredGrid(umin, umax, vmin, vmax, stepU, stepV, outer, holes, margin)
+	saturated := stepSaturates(s, umin, umax, vmin, vmax, stepU, stepV, q.tol())
+	if localRefine && refineLocalCurvature(s, umin, umax, vmin, vmax, stepU, stepV, q, outer, holes, margin, &pts) {
+		saturated = true
+	}
+	return pts, saturated
+}
+
+// stepSaturates reports whether the base step is clamped to the cell-size floor with a floor-sized cell
+// STILL bulging past the chord tolerance — a genuinely large high-curvature face the cap cannot resolve,
+// the case #1412 surfaces as a diagnostic instead of silently under-tessellating. It samples cells at
+// the centre and quarter positions (not just a corner, which on a centred dome is flat) and reports true
+// if the most-curved of them exceeds tol.
+func stepSaturates(s geom.Surface, umin, umax, vmin, vmax, stepU, stepV, tol float64) bool {
+	floorU, floorV := (umax-umin)/maxInteriorCells, (vmax-vmin)/maxInteriorCells
+	if stepU > floorU*1.001 && stepV > floorV*1.001 {
+		return false // step is not at the floor → the grid already meets the tolerance
+	}
+	for _, c := range [][2]float64{{0.5, 0.5}, {0.25, 0.25}, {0.75, 0.75}, {0.25, 0.75}, {0.75, 0.25}} {
+		u0 := umin + c[0]*(umax-umin-stepU)
+		v0 := vmin + c[1]*(vmax-vmin-stepV)
+		if regionSagitta(s, u0, u0+stepU, v0, v0+stepV) > tol {
+			return true
+		}
+	}
+	return false
+}
+
+// baseStaggeredGrid is the curvature-scaled staggered interior grid (alternate rows offset by half a
+// step for better-shaped triangles), every node clear of the trim by margin.
+func baseStaggeredGrid(umin, umax, vmin, vmax, stepU, stepV float64, outer []math.Point2, holes [][]math.Point2, margin float64) [][2]float64 {
 	var pts [][2]float64
 	row := 0
 	for v := vmin + stepV/2; v < vmax; v += stepV {
 		off := 0.0
 		if row%2 == 1 {
-			off = stepU / 2 // stagger alternate rows for better-shaped triangles
+			off = stepU / 2
 		}
 		row++
 		for u := umin + stepU/2 + off; u < umax; u += stepU {
@@ -50,6 +101,59 @@ func adaptiveInteriorNodes(s geom.Surface, outer []math.Point2, holes [][]math.P
 		}
 	}
 	return pts
+}
+
+// refineLocalCurvature walks the base cells and recursively subdivides any whose surface sagitta exceeds
+// localRefineThreshold·tol, appending the new finer nodes to pts. It returns whether any cell saturated
+// the cell-size floor while still over tolerance.
+func refineLocalCurvature(s geom.Surface, umin, umax, vmin, vmax, stepU, stepV float64, q Quality, outer []math.Point2, holes [][]math.Point2, margin float64, pts *[][2]float64) bool {
+	tol := q.tol() * localRefineThreshold
+	minU, minV := (umax-umin)/maxInteriorCells, (vmax-vmin)/maxInteriorCells
+	saturated := false
+	for u0 := umin; u0 < umax-1e-12; u0 += stepU {
+		u1 := stdmath.Min(u0+stepU, umax)
+		for v0 := vmin; v0 < vmax-1e-12; v0 += stepV {
+			refineCell(s, u0, u1, v0, stdmath.Min(v0+stepV, vmax), tol, minU, minV, outer, holes, margin, pts, &saturated)
+		}
+	}
+	return saturated
+}
+
+// refineCell subdivides a (u,v) cell while its surface bulges past tol, emitting the four sub-cell
+// centres (the new finer nodes that are clear of the trim) at each split, down to the cell-size floor —
+// where, if still over tol, it flags saturation for the caller to record.
+func refineCell(s geom.Surface, u0, u1, v0, v1, tol, minU, minV float64, outer []math.Point2, holes [][]math.Point2, margin float64, pts *[][2]float64, saturated *bool) {
+	if regionSagitta(s, u0, u1, v0, v1) <= tol {
+		return
+	}
+	if u1-u0 <= minU && v1-v0 <= minV {
+		*saturated = true
+		return
+	}
+	um, vm := (u0+u1)/2, (v0+v1)/2
+	for _, c := range [4][2]float64{{(u0 + um) / 2, (v0 + vm) / 2}, {(um + u1) / 2, (v0 + vm) / 2}, {(u0 + um) / 2, (vm + v1) / 2}, {(um + u1) / 2, (vm + v1) / 2}} {
+		if clearOfTrim(outer, holes, c, margin) {
+			*pts = append(*pts, c)
+		}
+	}
+	refineCell(s, u0, um, v0, vm, tol, minU, minV, outer, holes, margin, pts, saturated)
+	refineCell(s, um, u1, v0, vm, tol, minU, minV, outer, holes, margin, pts, saturated)
+	refineCell(s, u0, um, vm, v1, tol, minU, minV, outer, holes, margin, pts, saturated)
+	refineCell(s, um, u1, vm, v1, tol, minU, minV, outer, holes, margin, pts, saturated)
+}
+
+// recordCapSaturation records a cap-saturation diagnostic on the mesh when the interior refinement
+// could not meet the chord tolerance within the cell-size floor — so a face that under-tessellates is
+// visible to the caller, not silently shipped (#1412).
+func recordCapSaturation(m *Mesh, saturated bool, q Quality) {
+	if m == nil || !saturated {
+		return
+	}
+	m.Diagnose(diag.Diagnostic{
+		Code:     CodeTessellateCapSaturated,
+		Severity: diag.Warning,
+		Detail:   fmt.Sprintf("interior refinement saturated the %d-cell floor still above chord tol %g", maxInteriorCells, q.tol()),
+	})
 }
 
 // adaptiveStep picks the (u,v) grid spacing so the surface's chord deviation over a cell stays

--- a/kernel/ops/nurbs_interior_test.go
+++ b/kernel/ops/nurbs_interior_test.go
@@ -49,7 +49,7 @@ func TestAdaptiveInteriorNoSpill(t *testing.T) {
 	s := domeSurface(t)
 	outer := uvSquare(0.1, 0.9, 8)
 	holes := [][]math.Point2{uvSquare(0.4, 0.6, 6)}
-	nodes := adaptiveInteriorNodes(s, outer, holes, DefaultQuality(), 1)
+	nodes := interiorNodesOnly(s, outer, holes, DefaultQuality(), 1)
 	if len(nodes) == 0 {
 		t.Fatal("a curved patch should get interior nodes")
 	}
@@ -67,8 +67,8 @@ func TestAdaptiveInteriorDensityFollowsCurvature(t *testing.T) {
 	flat := unitPatch(t) // z=0 bilinear (from refined_patch_test.go)
 	dome := domeSurface(t)
 	outer := uvSquare(0.05, 0.95, 8)
-	nFlat := len(adaptiveInteriorNodes(flat, outer, nil, DefaultQuality(), 1))
-	nDome := len(adaptiveInteriorNodes(dome, outer, nil, DefaultQuality(), 1))
+	nFlat := len(interiorNodesOnly(flat, outer, nil, DefaultQuality(), 1))
+	nDome := len(interiorNodesOnly(dome, outer, nil, DefaultQuality(), 1))
 	if nDome <= nFlat {
 		t.Errorf("curved patch should get more interior nodes than flat: dome=%d flat=%d", nDome, nFlat)
 	}
@@ -77,8 +77,8 @@ func TestAdaptiveInteriorDensityFollowsCurvature(t *testing.T) {
 func TestAdaptiveInteriorDeterministic(t *testing.T) {
 	s := domeSurface(t)
 	outer := uvSquare(0.1, 0.9, 8)
-	a := adaptiveInteriorNodes(s, outer, nil, DefaultQuality(), 1)
-	b := adaptiveInteriorNodes(s, outer, nil, DefaultQuality(), 1)
+	a := interiorNodesOnly(s, outer, nil, DefaultQuality(), 1)
+	b := interiorNodesOnly(s, outer, nil, DefaultQuality(), 1)
 	if len(a) != len(b) {
 		t.Fatalf("non-deterministic node count: %d vs %d", len(a), len(b))
 	}
@@ -87,4 +87,11 @@ func TestAdaptiveInteriorDeterministic(t *testing.T) {
 			t.Errorf("non-deterministic node %d: %v vs %v", i, a[i], b[i])
 		}
 	}
+}
+
+// interiorNodesOnly adapts adaptiveInteriorNodes' (nodes, saturated) result to the node slice the
+// pre-#1412 tests expect.
+func interiorNodesOnly(s geom.Surface, outer []math.Point2, holes [][]math.Point2, q Quality, refine float64) [][2]float64 {
+	nodes, _ := adaptiveInteriorNodes(s, outer, holes, q, refine, true)
+	return nodes
 }

--- a/kernel/ops/refined_patch.go
+++ b/kernel/ops/refined_patch.go
@@ -208,7 +208,8 @@ func metricCDTPatch(s geom.Surface, su, sv float64, q Quality, outer3D []math.Po
 	for i := range holes3D {
 		loops = append(loops, b.addLoop(holes3D[i], holesUV[i]))
 	}
-	for _, g := range adaptiveInteriorNodes(s, outerUV, holesUV, q, refine) {
+	nodes, saturated := adaptiveInteriorNodes(s, outerUV, holesUV, q, refine, true)
+	for _, g := range nodes {
 		b.addInterior(g)
 	}
 	tris := constrainedDelaunay(b.scaled, loops)
@@ -217,6 +218,7 @@ func metricCDTPatch(s geom.Surface, su, sv float64, q Quality, outer3D []math.Po
 	}
 	m := patchMeshFrom(b.pos, b.nrm, tris)
 	repairFolds(m, 8)
+	recordCapSaturation(m, saturated, q)
 	return m, loops
 }
 

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -615,7 +615,57 @@ func sameGrid(a, b []float64) bool {
 func fullDomainGridMesh(s geom.Surface, q Quality) *Mesh {
 	uLo, uHi := clampSpan(s.UDomain())
 	vLo, vHi := clampSpan(s.VDomain())
-	us := adaptiveParams(func(u float64) math.Point3 { return s.PointAt(u, (vLo+vHi)/2) }, uLo, uHi, q.tol(), q.angleTol())
-	vs := adaptiveParams(func(v float64) math.Point3 { return s.PointAt((uLo+uHi)/2, v) }, vLo, vHi, q.tol(), q.angleTol())
+	us := unionIsoparmParams(s, uLo, uHi, vLo, vHi, true, q)
+	vs := unionIsoparmParams(s, uLo, uHi, vLo, vHi, false, q)
 	return closedDomainMesh(s, us, vs) // watertight on a closed surface (periodic seam + poles); else == gridMesh
+}
+
+// isoparmSampleFractions are the fixed-direction positions at which unionIsoparmParams samples the
+// varying direction — the ends, quarters and middle, enough to catch a curvature feature anywhere
+// across the domain that a single mid-line would miss.
+var isoparmSampleFractions = []float64{0, 0.25, 0.5, 0.75, 1}
+
+// unionIsoparmParams returns the adaptive parameter breakpoints of the VARYING direction, unioned over
+// SEVERAL isoparms of the fixed direction instead of a single mid-line — so the grid resolves curvature
+// wherever it occurs in the domain (a torus tube, an off-centre bump), not only where the mid-line
+// happens to look (#1412). A uniformly-curved surface yields the same breakpoints on every isoparm, so
+// the union equals the old single-line result and nothing is densified (no flat-face regression).
+func unionIsoparmParams(s geom.Surface, uLo, uHi, vLo, vHi float64, alongU bool, q Quality) []float64 {
+	lo, hi, fixedLo, fixedHi := uLo, uHi, vLo, vHi
+	if !alongU {
+		lo, hi, fixedLo, fixedHi = vLo, vHi, uLo, uHi
+	}
+	var merged []float64
+	for _, frac := range isoparmSampleFractions {
+		fixed := fixedLo + frac*(fixedHi-fixedLo)
+		eval := func(t float64) math.Point3 {
+			if alongU {
+				return s.PointAt(t, fixed)
+			}
+			return s.PointAt(fixed, t)
+		}
+		merged = mergeSortedParams(merged, adaptiveParams(eval, lo, hi, q.tol(), q.angleTol()))
+	}
+	return merged
+}
+
+// mergeSortedParams merges two ascending parameter slices into one, dropping a value within a tiny
+// fraction of the span of one already kept (so unioning many isoparms does not pile near-coincident
+// grid lines that would make sliver cells).
+func mergeSortedParams(a, b []float64) []float64 {
+	if len(a) == 0 {
+		return b
+	}
+	out := append([]float64(nil), a...)
+	out = append(out, b...)
+	sort.Float64s(out)
+	span := out[len(out)-1] - out[0]
+	eps := span * 1e-9
+	deduped := out[:1]
+	for _, v := range out[1:] {
+		if v-deduped[len(deduped)-1] > eps {
+			deduped = append(deduped, v)
+		}
+	}
+	return deduped
 }


### PR DESCRIPTION
Closes #1412. Builds on the `diag` channel (#1439).

## Problem
Interior tessellation density came from **one** global `stepU/stepV` derived from a single 5-point **diagonal** sagitta, and `fullDomainGridMesh` adapted each direction on a single **mid-line isoparm**. A surface whose curvature **varies across the domain** (a torus tube vs its ring, an off-centre B-spline bump) was over-tessellated where the single sample over-estimated curvature and **under-tessellated** where it under-estimated — and the `maxInteriorCells` cap could silently miss the chord tolerance on a genuinely large high-curvature face.

## Fix
- **Local refinement** (`adaptiveInteriorNodes`): keep the curvature-scaled base grid and, where a base cell bulges markedly past the global average (`localRefineThreshold·tol`), recursively subdivide it — so refinement **concentrates** where curvature varies. A uniformly-curved face (cells already at the budget) is left exactly as before. The node-adding refinement runs only on the robust all-points `constrainedDelaunay` path; the fold-prone `constrainedDelaunayRefined` holed-wall path (#1408) takes the base grid + diagnostic only, since extra interior nodes tear its post-constraint mesh.
- **Cap-saturation diagnostic**: when even the cell-size floor cannot meet tolerance, a `tessellate.cap-saturated` diagnostic is recorded on the `Mesh` (via the diag channel), instead of silently exceeding it.
- **Multi-isoparm sampling** (`fullDomainGridMesh`): union the adaptive breakpoints over several isoparms (ends/quarters/middle); a uniformly-curved surface yields identical breakpoints on each, so the union equals the old result (no densification).

## Tests
Local refinement concentrates nodes at an off-centre bump (bump quadrant denser than the far flat quadrant); a flat face is left exactly unchanged; a face too curved for the floor reports saturation surfaced as the diagnostic. The full tessellation **golden suite passes unchanged** (criterion 3, no flat-dominant regression).

> Note on criterion 1 (deviation ≤ tol): the refinement brings concentrated curvature regions to within `localRefineThreshold·tol` (1.5×), which is the deliberate resolution of the tension with criterion 3 — refining every cell strictly to 1.0×tol would re-tessellate uniformly-curved faces whose estimate sits just above tol, the regression criterion 3 forbids. This fixes the *gross* under-tessellation the issue targets.

Local: `go test ./...` green; golangci-lint clean; ops coverage 90.8%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)