### PR TITLE
[brep] CSG-fallback guardrails: Euler validator + adaptive membership

### DIFF
--- a/kernel/brep/curved_membership.go
+++ b/kernel/brep/curved_membership.go
@@ -41,36 +41,51 @@ func pointInCurvedFace(f curvedFace, p math.Point3) bool {
 }
 
 // loopWindingAngle returns the signed turning angle of a loop's boundary seen from p, summed around the
-// surface normal — ≈ +2π if the loop winds CCW around p (p inside it), ≈ 0 if p is outside.
+// surface normal — ≈ +2π if the loop winds CCW around p (p inside it), ≈ 0 if p is outside. Each edge is
+// walked in loopSampleCount base steps, and any step that subtends a large angle from p — the signature
+// of the boundary passing CLOSE to p, where the turning is rapid — is refined ADAPTIVELY until it does
+// not. So a thin feature can no longer slip BETWEEN samples and be mis-counted (the misclassification a
+// bare fixed count risks, #1407), while a boundary far from p is summed exactly as before (its base steps
+// already subtend little), keeping the established classification on every non-pathological case.
 func loopWindingAngle(loop curvedLoop, p math.Point3, normal math.Vector3) float64 {
-	pts := sampleLoopPoints(loop)
-	if len(pts) < 3 {
-		return 0
-	}
 	sum := 0.0
-	for i := range pts {
-		a := tangentComponent(p.VectorTo(pts[i]), normal)
-		b := tangentComponent(p.VectorTo(pts[(i+1)%len(pts)]), normal)
-		sum += signedAngleAround(a, b, normal)
+	for _, le := range loop.edges {
+		for k := 0; k < loopSampleCount; k++ {
+			ta := le.t0 + (le.t1-le.t0)*float64(k)/loopSampleCount
+			tb := le.t0 + (le.t1-le.t0)*float64(k+1)/loopSampleCount
+			sum += edgeWindingAngle(le, p, normal, ta, tb, le.curve.PointAt(ta), le.curve.PointAt(tb), 0)
+		}
 	}
 	return sum
 }
 
-// loopSampleCount is how many points to sample per loop edge for the winding sum — enough that a curved
-// edge's turning is captured, cheap enough for the inner loop of the split.
+// loopSampleCount is the BASE number of steps per loop edge for the winding sum — enough that a curved
+// edge's turning is captured; edgeWindingAngle refines below it wherever a step subtends a large angle.
 const loopSampleCount = 8
 
-// sampleLoopPoints samples a loop's boundary into ordered 3D points (each edge sampled across its
-// parameter range, the shared endpoints deduplicated by skipping each edge's last sample).
-func sampleLoopPoints(loop curvedLoop) []math.Point3 {
-	var pts []math.Point3
-	for _, le := range loop.edges {
-		for k := 0; k < loopSampleCount; k++ {
-			t := le.t0 + (le.t1-le.t0)*float64(k)/loopSampleCount
-			pts = append(pts, le.curve.PointAt(t))
-		}
+// maxWindingSubtend bounds the angle one step may subtend from p before it is split: keeping every
+// contribution small means a near-pass to p cannot be under-counted, so the winding sum is accurate to
+// that bound regardless of how close the boundary runs to p (#1407).
+const maxWindingSubtend = stdmath.Pi / 6 // 30°
+
+// maxWindingDepth caps the adaptive recursion: a boundary passing exactly through p makes the angle
+// ill-defined, so the split bottoms out there rather than spinning.
+const maxWindingDepth = 24
+
+// edgeWindingAngle returns the signed turning angle the edge arc from (t0,p0) to (t1,p1) subtends about
+// the normal as seen from p, refining the arc by recursive bisection until each piece subtends at most
+// maxWindingSubtend (or the depth cap) — exact angle integration in place of fixed-N sampling.
+func edgeWindingAngle(le loopEdge, p math.Point3, normal math.Vector3, t0, t1 float64, p0, p1 math.Point3, depth int) float64 {
+	a := tangentComponent(p.VectorTo(p0), normal)
+	b := tangentComponent(p.VectorTo(p1), normal)
+	ang := signedAngleAround(a, b, normal)
+	if stdmath.Abs(ang) <= maxWindingSubtend || depth >= maxWindingDepth {
+		return ang
 	}
-	return pts
+	tm := (t0 + t1) / 2
+	pm := le.curve.PointAt(tm)
+	return edgeWindingAngle(le, p, normal, t0, tm, p0, pm, depth+1) +
+		edgeWindingAngle(le, p, normal, tm, t1, pm, p1, depth+1)
 }
 
 // tangentComponent projects v onto the plane perpendicular to the unit normal (the surface tangent

--- a/kernel/brep/curved_membership_test.go
+++ b/kernel/brep/curved_membership_test.go
@@ -5,6 +5,8 @@ package brep
 import (
 	"testing"
 
+	stdmath "math"
+
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/math"
 )
@@ -44,5 +46,41 @@ func TestPointInCurvedFaceBoundaryless(t *testing.T) {
 	f := curvedFace{surface: sphere}
 	if !pointInCurvedFace(f, sphere.PointAt(0.7, 0.3)) {
 		t.Error("a boundary-less face must contain every point on its surface")
+	}
+}
+
+// TestPointInCurvedFaceHuggingBoundary is #1407 criterion 3: a point pressed right up against the loop
+// boundary — where the boundary passes close to it and the geodesic turning is rapid — is still
+// classified correctly, because the winding sum refines adaptively there instead of trusting a fixed
+// number of samples that a thin feature could slip between.
+func TestPointInCurvedFaceHuggingBoundary(t *testing.T) {
+	const r = 5
+	cap := lowerHemisphereCap(t, r)
+	sphere := cap.surface.(geom.Sphere)
+	for _, c := range []struct {
+		name string
+		v    float64
+		want bool
+	}{
+		{"just inside the equator (lower)", -0.001, true},
+		{"just outside the equator (upper)", 0.001, false},
+	} {
+		p := sphere.PointAt(2.0, c.v) // latitude a hair from the equator, hugging the boundary loop
+		if got := pointInCurvedFace(cap, p); got != c.want {
+			t.Errorf("%s: point %v classified inside=%v, want %v", c.name, p, got, c.want)
+		}
+	}
+}
+
+// TestEdgeWindingAngleRefinesLargeSubtend covers the adaptive split: an arc that subtends a large angle
+// from a nearby point is integrated to the true turning, not under-counted as one coarse step. A
+// half-circle seen from its own centre subtends exactly π; one bisected chord step would read far less.
+func TestEdgeWindingAngleRefinesLargeSubtend(t *testing.T) {
+	circle, _ := geom.NewCircle(math.P3(0, 0, 0), math.V3(0, 0, 1), 4)
+	le := loopEdge{curve: circle, t0: 0, t1: 0.5} // the upper half-circle (t ∈ [0, 0.5] of a full turn)
+	normal := math.V3(0, 0, 1)
+	got := edgeWindingAngle(le, math.P3(0, 0, 0), normal, le.t0, le.t1, le.curve.PointAt(le.t0), le.curve.PointAt(le.t1), 0)
+	if d := got - stdmath.Pi; d < -1e-6 || d > 1e-6 {
+		t.Errorf("half-circle winding from the centre = %v, want pi (adaptive refinement under-integrated)", got)
 	}
 }

--- a/kernel/ops/validate.go
+++ b/kernel/ops/validate.go
@@ -15,15 +15,24 @@ type ValidationReport struct {
 	Manifold      bool
 	Closed        bool
 	OrientationOK bool
-	Issues        []string
+	// EulerCharacteristic is the body surface's χ from the Euler–Poincaré relation V−E+2F−L (L = total
+	// face loops; the +2F−L corrects the naive V−E+F for B-rep seam edges and holed faces). For a closed
+	// orientable solid χ = Σ over shells of 2−2·genusₛ, so EulerConsistent reports whether χ is admissible
+	// (even, and ≤ 2 per shell). A body can pass the per-edge manifold/closed/orientation checks yet still
+	// be a topological impossibility — a dropped or doubled face that keeps every edge used twice — which
+	// an odd or too-large χ catches where the volume guard cannot (Oblikovati#1407).
+	EulerCharacteristic int
+	EulerConsistent     bool
+	Issues              []string
 }
 
 // Validate checks a body's topology: every edge of a manifold solid must be used by
-// exactly two faces with opposite orientation, and a solid must be closed (no
-// boundary edges). It reports each offending edge precisely (PBI-084) — a surface
-// body is allowed to be open.
+// exactly two faces with opposite orientation, a solid must be closed (no boundary
+// edges), and its Euler characteristic must be admissible for a closed orientable
+// solid. It reports each offending edge precisely (PBI-084) — a surface body is
+// allowed to be open.
 func Validate(b *topo.Body) ValidationReport {
-	r := ValidationReport{Manifold: true, Closed: true, OrientationOK: true}
+	r := ValidationReport{Manifold: true, Closed: true, OrientationOK: true, EulerConsistent: true}
 	for _, e := range b.Edges() {
 		switch uses := e.Uses(); {
 		case len(uses) < 2:
@@ -41,8 +50,38 @@ func Validate(b *topo.Body) ValidationReport {
 			}
 		}
 	}
-	r.Valid = r.Manifold && r.OrientationOK && (!b.IsSolid() || r.Closed)
+	r.checkEuler(b)
+	r.Valid = r.Manifold && r.OrientationOK && (!b.IsSolid() || (r.Closed && r.EulerConsistent))
 	return r
+}
+
+// checkEuler computes the surface χ = V−E+2F−L (the Euler–Poincaré form, correct across B-rep seams and
+// holed faces) and, for a CLOSED solid, verifies it is admissible: even (an odd χ cannot be a closed
+// orientable 2-manifold) and at most 2 per shell (χ = Σ over shells of 2−2·genus, so each contributes
+// ≤ 2). A violation is a topology defect the per-edge tests can miss, recorded as an issue.
+func (r *ValidationReport) checkEuler(b *topo.Body) {
+	loops := 0
+	for _, f := range b.Faces() {
+		loops += len(f.Loops())
+	}
+	r.EulerCharacteristic = len(b.Vertices()) - len(b.Edges()) + 2*len(b.Faces()) - loops
+	if !b.IsSolid() || !r.Closed {
+		return // χ = 2−2g only constrains a closed orientable solid; an open sheet is unconstrained
+	}
+	shells := len(b.Shells())
+	if !eulerAdmissible(r.EulerCharacteristic, shells) {
+		r.EulerConsistent = false
+		r.Issues = append(r.Issues, fmt.Sprintf(
+			"Euler characteristic V−E+2F−L = %d is inadmissible for a closed solid of %d shell(s) (must be even and ≤ %d)",
+			r.EulerCharacteristic, shells, 2*shells))
+	}
+}
+
+// eulerAdmissible reports whether χ is possible for a CLOSED orientable solid of the given shell count:
+// χ = Σ over shells of (2 − 2·genusₛ), so it must be EVEN and at most 2 per shell (genus ≥ 0). An odd or
+// too-large χ is a topological impossibility — a defect the per-edge manifold checks can miss (#1407).
+func eulerAdmissible(chi, shells int) bool {
+	return chi%2 == 0 && chi <= 2*shells
 }
 
 // BoundaryEdges returns the open (boundary) edges of a body — those used by fewer

--- a/kernel/ops/validate_euler_test.go
+++ b/kernel/ops/validate_euler_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// TestEulerAdmissible is the admissibility gate at the heart of the Euler check: χ for a closed
+// orientable solid must be EVEN and ≤ 2 per shell (χ = Σ 2−2g, genus ≥ 0). It catches the odd or
+// too-large χ a dropped/doubled face would produce while every edge stays used twice (#1407).
+func TestEulerAdmissible(t *testing.T) {
+	for _, c := range []struct {
+		chi, shells int
+		want        bool
+	}{
+		{2, 1, true},   // a sphere/box (genus 0)
+		{0, 1, true},   // a torus shell (genus 1)
+		{-2, 1, true},  // genus 2
+		{4, 2, true},   // two genus-0 shells
+		{3, 1, false},  // odd χ — impossible for an orientable closed manifold
+		{4, 1, false},  // χ > 2 on one shell — implies negative genus
+		{-1, 1, false}, // odd (negative)
+	} {
+		if got := eulerAdmissible(c.chi, c.shells); got != c.want {
+			t.Errorf("eulerAdmissible(χ=%d, shells=%d) = %v, want %v", c.chi, c.shells, got, c.want)
+		}
+	}
+}
+
+// TestValidateEulerCharacteristic is #1407 criterion 2: the validator computes the Euler–Poincaré
+// characteristic χ = V−E+2F−L and admits it for a closed orientable solid. A simple solid has χ = 2;
+// an oblique cylinder cut — whose result has a HOLED face, so the naive V−E+F would be 3 (odd) and
+// falsely flagged — still computes χ = 2 through the loop-corrected form. Both are EulerConsistent and
+// Valid, confirming the check admits real B-reps (including holed and periodic faces) rather than
+// false-positiving on them.
+func TestValidateEulerCharacteristic(t *testing.T) {
+	cyl, _ := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2, 4)
+	cutTarget, _ := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 4)
+	plane, _ := geom.NewPlane(math.P3(0, 0, 2), math.V3(1, 0, 2))
+	oblique, err := brep.HalfSpaceCut(cutTarget, plane)
+	if err != nil {
+		t.Fatalf("oblique cut: %v", err)
+	}
+
+	for _, c := range []struct {
+		name string
+		body *topo.Body
+		chi  int
+	}{
+		{"genus-0 cylinder", cyl, 2},
+		{"oblique cut (holed face)", oblique, 2},
+	} {
+		r := Validate(c.body)
+		if r.EulerCharacteristic != c.chi {
+			t.Errorf("%s: Euler χ = %d, want %d", c.name, r.EulerCharacteristic, c.chi)
+		}
+		if !r.EulerConsistent {
+			t.Errorf("%s: EulerConsistent = false, want true (χ=%d should be admissible)", c.name, r.EulerCharacteristic)
+		}
+		if !r.Valid {
+			t.Errorf("%s: a valid closed solid was reported invalid: %+v", c.name, r)
+		}
+	}
+}


### PR DESCRIPTION
Closes #1407. Builds on the `diag` channel (#1439).

The silent CSG-fallback gap had three parts; this closes the two not already delivered by the diag infrastructure.

## Criterion 1 — typed, counted CSG-fallback diagnostic — *delivered by #1439*
`BooleanWithDiagnostics` records a `boolean.csg-fallback` Defect whenever the exact analytic/planar path is abandoned for triangle-soup CSG, counted in `TestBooleanRecordsCSGFallbackDiagnostic` (merged). The ~45 brep declines all funnel through that single `booleanCSG` site, so the central diagnostic captures every fallback.

## Criterion 2 — Euler-Poincaré validator (`ops/validate.go`)
The validator checked per-edge manifoldness / free-edges / orientation plus a gross **volume** guard — but a *volume-preserving* topology error (a dropped or doubled face that keeps every edge used twice) slips through all of them. Add **χ = V − E + 2F − L** (the `+2F − L` corrects the naive `V − E + F` for B-rep seam edges and holed faces) and require it **admissible** for a closed orientable solid: **even**, and **≤ 2 per shell** (χ = Σ 2 − 2·genusₛ). Folded into `Valid` for a closed solid.

Verified it admits real B-reps, not false-positives: a cylinder is χ = 2; an oblique cylinder cut whose result has a **holed face** — where naive `V − E + F = 3` (odd) would wrongly flag it — computes χ = 2 through the loop term. The admissibility gate is unit-tested directly (even/≤2-per-shell, catching odd and too-large χ).

## Criterion 3 — adaptive membership (`brep/curved_membership.go`)
Point-in-curved-face classification summed the geodesic winding over a **fixed** sample count per edge, so a boundary passing close to the query point — where the turning is rapid — could be under-counted *between* samples and the point misclassified (the wrong imprint arc). Keep the base sample count but **refine adaptively** any step that subtends a large angle from the point (`edgeWindingAngle`, recursive bisection), so a near-pass integrates accurately while a boundary far from the point is summed exactly as before. The established classification is unchanged on every non-pathological case — the full brep+ops boolean golden suite passes — only the thin-feature gap is closed.

Tests: a point hugging the equator boundary from each side is classified correctly; the adaptive split integrates a half-circle's π turning a coarse chord would under-read.

Local: `go test ./...` green; golangci-lint clean; ops 90.7% / brep 91.6% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)