### PR TITLE
[ops][CDT] Guard the silent constraint-recovery boundary leak (#1410)

### DIFF
--- a/kernel/ops/cdt.go
+++ b/kernel/ops/cdt.go
@@ -36,6 +36,12 @@ type cdt struct {
 	con  map[[2]int]bool // constrained undirected edges (sorted vertex pair)
 	nsup int             // index of the first super-triangle vertex (points >= nsup are super)
 	last int             // a recently-live triangle, the seed hint for the next point-location walk (#1408)
+	// unrecovered collects the constraint endpoint pairs whose edge the flip recovery never realized
+	// (the flip cap hit, or a non-convex crossing stalled). Such a constraint is NOT recorded in con —
+	// a phantom con entry has no mesh edge for floodInside to toggle at, so the domain boundary leaks
+	// across the gap silently (#1410). A non-empty list means extractDomain is untrustworthy and the
+	// caller must take the deterministic earcut fallback instead.
+	unrecovered [][2]int
 	// walkSteps counts triangles visited by the adjacency walk over this triangulation's life — a
 	// per-instance counter (each cdt runs on one goroutine, so no data race), read by tests to assert
 	// point location is near-linear, not the old O(N²) full scan.

--- a/kernel/ops/cdt_build.go
+++ b/kernel/ops/cdt_build.go
@@ -257,7 +257,15 @@ func (m *cdt) insertConstraint(a, b int) {
 			break
 		}
 	}
-	m.con[conKey(a, b)] = true
+	// Record the constraint ONLY when its edge actually survives in the mesh. Marking con
+	// unconditionally (the old behaviour) registered a phantom boundary the flood could not toggle at,
+	// leaking the domain across the unrecovered gap — a silent watertightness defect (#1410). A genuine
+	// non-recovery (cap hit / non-convex stall) is collected so the caller falls back deterministically.
+	if m.hasEdge(a, b) {
+		m.con[conKey(a, b)] = true
+		return
+	}
+	m.unrecovered = append(m.unrecovered, [2]int{a, b})
 }
 
 // representatives maps each input point index to the inserted vertex that carries its coordinates:
@@ -370,16 +378,21 @@ func (m *cdt) hasSuper(t int) bool {
 	return m.tris[t].v[0] >= m.nsup || m.tris[t].v[1] >= m.nsup || m.tris[t].v[2] >= m.nsup
 }
 
-// constrainedDelaunayRefined triangulates the domain bounded by loops with interior refinement, inserting
-// the boundary in the OCCT BRepMesh order: the loop (frontier) points FIRST, then the constraints are
-// recovered on that small point set (robust — no interior nodes fighting the flip recovery), then the
-// interior Steiner points are inserted into the already-constrained mesh, where collectCavity protects the
-// frontier edges. pts[:nFrontier] are the loop points (indexed by loops); pts[nFrontier:] are interior.
-// This is the accurate path for a large face with several concave holes, where inserting everything at
-// once (constrainedDelaunay) makes the constraint recovery leak and tear.
-func constrainedDelaunayRefined(pts [][2]float64, loops [][]int, nFrontier int) [][3]int {
+// constrainedDelaunayRefinedChecked triangulates the domain bounded by loops with interior refinement,
+// inserting the boundary in the OCCT BRepMesh order: the loop (frontier) points FIRST, then the
+// constraints are recovered on that small point set (robust — no interior nodes fighting the flip
+// recovery), then the interior Steiner points are inserted into the already-constrained mesh, where
+// collectCavity protects the frontier edges. pts[:nFrontier] are the loop points (indexed by loops);
+// pts[nFrontier:] are interior. This is the accurate path for a large face with several concave holes,
+// where inserting everything at once (constrainedDelaunay) makes the constraint recovery leak and tear.
+// It also reports the recovery status: the constraint endpoint pairs whose edge never recovered, and
+// whether the deterministic earcut fallback was taken because the domain actually leaked across a missing
+// boundary (#1410). See finalizeDomain for how a benign non-recovery (an outer seam bordering the excluded
+// super region) keeps the higher-quality refined mesh while a genuine leak (a filled hole/notch) is
+// replaced.
+func constrainedDelaunayRefinedChecked(pts [][2]float64, loops [][]int, nFrontier int) ([][3]int, [][2]int, bool) {
 	if len(pts) < 3 || nFrontier < 3 {
-		return nil
+		return nil, nil, false
 	}
 	m := newCDT(pts)
 	for i := 0; i < nFrontier; i++ {
@@ -389,7 +402,24 @@ func constrainedDelaunayRefined(pts [][2]float64, loops [][]int, nFrontier int) 
 	for i := nFrontier; i < m.nsup; i++ {
 		m.insert(i) // interior nodes, now respecting the frontier edges (see collectCavity)
 	}
-	return m.extractDomain()
+	return m.finalizeDomain(pts, loops)
+}
+
+// finalizeDomain extracts the inside domain and, when constraint recovery left a boundary edge
+// unrealized, decides between the refined extraction and the deterministic earcut fallback by whether the
+// domain ACTUALLY leaked (domainLeaked) — a missing boundary that filled a hole or concave notch — rather
+// than assuming every non-recovery is harmful. A non-recovery that does not leak (the common holed-wall
+// seam, whose far side is the excluded super region) keeps the higher-quality refined mesh. Returns the
+// triangles, the unrecovered constraints (for the caller's diagnostic), and whether the fallback was used.
+func (m *cdt) finalizeDomain(pts [][2]float64, loops [][]int) ([][3]int, [][2]int, bool) {
+	ed := m.extractDomain()
+	if len(m.unrecovered) == 0 {
+		return ed, nil, false
+	}
+	if m.domainLeaked(ed, loops) {
+		return earcutFromLoops(pts, loops), m.unrecovered, true
+	}
+	return ed, m.unrecovered, false
 }
 
 // constrain recovers every loop edge as a hard constraint between the inserted representatives (see
@@ -408,8 +438,16 @@ func (m *cdt) constrain(loops [][]int) {
 // each loop), returning CCW triangles inside the domain as index triples into pts. Every loop edge
 // is a hard constraint; points not on a loop are interior Steiner points refining the mesh.
 func constrainedDelaunay(pts [][2]float64, loops [][]int) [][3]int {
+	tris, _, _ := constrainedDelaunayChecked(pts, loops)
+	return tris
+}
+
+// constrainedDelaunayChecked is constrainedDelaunay plus the recovery status: it also returns the
+// constraint endpoint pairs whose edge never recovered and whether the deterministic earcut fallback was
+// taken because the domain leaked across a missing boundary (#1410, see finalizeDomain).
+func constrainedDelaunayChecked(pts [][2]float64, loops [][]int) ([][3]int, [][2]int, bool) {
 	if len(pts) < 3 {
-		return nil
+		return nil, nil, false
 	}
 	m := newCDT(pts)
 	for i := 0; i < m.nsup; i++ {
@@ -420,5 +458,5 @@ func constrainedDelaunay(pts [][2]float64, loops [][]int) [][3]int {
 	// neither the corridor walk (no incident triangle) nor the flips (which then spin to exhaustion —
 	// the real O(T²) freeze on imported faces, #1073). constrain works between the inserted REPRESENTATIVES.
 	m.constrain(loops)
-	return m.extractDomain()
+	return m.finalizeDomain(pts, loops)
 }

--- a/kernel/ops/cdt_recovery.go
+++ b/kernel/ops/cdt_recovery.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/math"
+)
+
+// CodeCDTConstraintLeak marks a constrained triangulation where a boundary constraint edge could not be
+// recovered (the flip cap hit, or a non-convex crossing stalled). Left unhandled the domain boundary
+// leaks across the gap and floodInside mislabels inside/outside — a silent watertightness defect, the
+// highest-priority bug class. The tessellator instead falls back to a deterministic boundary-only ear
+// clip and records this Defect so the degradation is counted, never silent (#1410).
+const CodeCDTConstraintLeak diag.Code = "tessellate.cdt-constraint-leak"
+
+// earcutFromLoops triangulates the index-based loops (loops[0] is the outer boundary, the rest are
+// holes) by deterministic ear clipping, returning triangles indexed back into the original pts space.
+// It is the watertight fallback taken when constraint recovery failed and extractDomain would leak the
+// domain (#1410): ear clipping respects every boundary edge by construction, so it cannot leak. It uses
+// only the loop (boundary) points — any interior Steiner refinement is dropped on this rare failure
+// path, trading curved-area accuracy for a guaranteed watertight result.
+func earcutFromLoops(pts [][2]float64, loops [][]int) [][3]int {
+	if len(loops) == 0 || len(loops[0]) < 3 {
+		return nil
+	}
+	outer := loopPoints(pts, loops[0])
+	holes := make([][]math.Point2, 0, len(loops)-1)
+	for _, h := range loops[1:] {
+		holes = append(holes, loopPoints(pts, h))
+	}
+	// earcut indexes its output into outer++holes in input order (it normalizes winding without
+	// reordering vertices), so the loops flattened in the same order remap straight back into pts.
+	remap := make([]int, 0, len(pts))
+	for _, lp := range loops {
+		remap = append(remap, lp...)
+	}
+	local := earcut(outer, holes)
+	out := make([][3]int, len(local))
+	for i, t := range local {
+		out[i] = [3]int{remap[t[0]], remap[t[1]], remap[t[2]]}
+	}
+	return out
+}
+
+// loopPoints gathers a loop's points from pts by its index list, as the math.Point2 type earcut takes.
+func loopPoints(pts [][2]float64, idx []int) []math.Point2 {
+	out := make([]math.Point2, len(idx))
+	for i, j := range idx {
+		out[i] = math.P2(math.Scalar(pts[j][0]), math.Scalar(pts[j][1]))
+	}
+	return out
+}
+
+// domainLeaked reports whether the extracted domain bled across a constraint LOOP — a hole or concave
+// notch that did not get cut because its boundary was not recovered, so the flood filled it. A loop edge
+// kept on exactly one side is a clean domain boundary (use==1); shared by TWO kept triangles it is
+// interior (use≥2), meaning that segment dissolved into the domain. A properly cut loop is (almost) all
+// boundary; a FILLED loop is (almost) all interior. We flag a leak only when a loop is PREDOMINANTLY
+// dissolved (interior edges outnumber boundary edges) — an isolated use≥2 edge is a local fold repairFolds
+// later removes, not a missing cut, so a single fold must not discard the higher-quality refined mesh
+// (#1410). use==0 (bordering the excluded super region, e.g. an unrecovered outer seam) is benign.
+func (m *cdt) domainLeaked(tris [][3]int, loops [][]int) bool {
+	use := make(map[[2]int]int, len(tris)*3)
+	for _, t := range tris {
+		for i := 0; i < 3; i++ {
+			use[conKey(t[i], t[(i+1)%3])]++
+		}
+	}
+	rep := m.representatives()
+	for _, lp := range loops {
+		boundary, interior := 0, 0
+		for k := 0; k < len(lp); k++ {
+			switch e := conKey(rep[lp[k]], rep[lp[(k+1)%len(lp)]]); {
+			case use[e] == 1:
+				boundary++
+			case use[e] >= 2:
+				interior++
+			}
+		}
+		if interior > boundary {
+			return true
+		}
+	}
+	return false
+}
+
+// recordConstraintLeak surfaces the recovery status on the mesh when a boundary constraint did not
+// recover (#1410). A genuine leak — the domain bled across the gap and the deterministic earcut fallback
+// replaced it — is a counted Defect; a non-recovery that stayed watertight (an outer seam into the
+// excluded super region) is a benign Info, so the degradation is never silent yet the common harmless
+// case does not raise a false alarm.
+func recordConstraintLeak(m *Mesh, unrecovered [][2]int, leaked bool) {
+	if m == nil || len(unrecovered) == 0 {
+		return
+	}
+	if leaked {
+		m.Diagnose(diag.Diagnostic{
+			Code:     CodeCDTConstraintLeak,
+			Severity: diag.Defect,
+			Detail:   fmt.Sprintf("%d boundary constraint(s) unrecovered and the domain leaked; used deterministic ear-clip fallback to stay watertight", len(unrecovered)),
+		})
+		return
+	}
+	m.Diagnose(diag.Diagnostic{
+		Code:     CodeCDTConstraintLeak,
+		Severity: diag.Info,
+		Detail:   fmt.Sprintf("%d boundary constraint(s) unrecovered but the cut stayed watertight; corridor-walk recovery (#1409) would realize them", len(unrecovered)),
+	})
+}

--- a/kernel/ops/cdt_recovery_test.go
+++ b/kernel/ops/cdt_recovery_test.go
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/diag"
+)
+
+// #1410: a non-recovered boundary constraint must never be recorded as recovered (a phantom con entry the
+// flood cannot toggle at leaks the domain), and a genuine leak must fall back deterministically and be
+// surfaced — while a benign non-recovery keeps the higher-quality refined mesh.
+
+// edgeUseCount tallies how many of the given triangles use each undirected edge — the watertightness probe
+// the recovery tests share (boundary edges are used once, interior edges twice, >2 is non-manifold).
+func edgeUseCount(tris [][3]int) map[[2]int]int {
+	use := map[[2]int]int{}
+	for _, t := range tris {
+		for i := 0; i < 3; i++ {
+			use[conKey(t[i], t[(i+1)%3])]++
+		}
+	}
+	return use
+}
+
+// TestConstrainRecordsOnlyRecoveredEdges is #1410 criterion 1: every edge recorded in con must actually
+// exist in the mesh. The old code set con unconditionally, registering phantom boundaries with no edge;
+// the invariant con ⟹ hasEdge guarantees floodInside has a real edge to toggle at for each constraint.
+func TestConstrainRecordsOnlyRecoveredEdges(t *testing.T) {
+	pts := [][2]float64{{0, 0}, {4, 0}, {4, 3}, {0, 3}} // a simple convex quad, every loop edge recoverable
+	m := newCDT(pts)
+	for i := 0; i < m.nsup; i++ {
+		m.insert(i)
+	}
+	m.constrain([][]int{{0, 1, 2, 3}})
+	if len(m.unrecovered) != 0 {
+		t.Fatalf("a convex quad loop should fully recover, got %d unrecovered", len(m.unrecovered))
+	}
+	for e := range m.con {
+		if !m.hasEdge(e[0], e[1]) {
+			t.Errorf("con holds edge %v with no surviving mesh edge — a phantom constraint (#1410)", e)
+		}
+	}
+}
+
+// TestDomainLeakedFlagsFilledLoopNotFold checks the detector that gates the fallback: a loop dissolved
+// into the domain interior (a hole the flood filled) is a leak, while an isolated interior edge (a local
+// fold repairFolds later removes) and a cleanly cut loop are not — so a single fold never discards the
+// refined mesh (#1410).
+func TestDomainLeakedFlagsFilledLoopNotFold(t *testing.T) {
+	// Distinct coordinates → representatives() is the identity, so loop indices address pts directly.
+	pts := [][2]float64{{0, 0}, {10, 0}, {10, 10}, {0, 10}, {3, 3}, {6, 3}, {6, 6}}
+	m := newCDT(pts)
+	loops := [][]int{{0, 1, 2, 3}, {4, 5, 6}} // outer quad + triangular hole (edges 4-5, 5-6, 6-4)
+
+	cut := [][3]int{{0, 1, 4}, {1, 5, 4}, {1, 2, 5}, {2, 6, 5}} // each hole edge appears once → boundary
+	if m.domainLeaked(cut, loops) {
+		t.Error("a cleanly cut hole (every loop edge on the boundary) must not be flagged as leaked")
+	}
+
+	// One hole edge (4-5) shared by two kept triangles, the other two still boundary: a local fold, where
+	// dissolved edges (1) do NOT outnumber boundary edges (2), so it must NOT be flagged as a leak.
+	fold := [][3]int{{4, 5, 6}, {4, 5, 0}}
+	if m.domainLeaked(fold, loops) {
+		t.Error("a single dissolved hole edge is a local fold, not a leak — must keep the refined mesh")
+	}
+
+	// Every hole edge shared by two kept triangles → the hole boundary fully dissolved (filled).
+	filled := [][3]int{{4, 5, 6}, {4, 5, 0}, {5, 6, 1}, {6, 4, 2}}
+	if !m.domainLeaked(filled, loops) {
+		t.Error("a filled hole (every loop edge interior) must be flagged as a leak (#1410)")
+	}
+}
+
+// TestEarcutFromLoopsProducesWatertightIndexedMesh checks the deterministic fallback: ear clipping the
+// loops yields a manifold triangulation, indexed back into the original pts, whose area is the outer minus
+// the hole — i.e. the hole is genuinely cut, never filled (#1410).
+func TestEarcutFromLoopsProducesWatertightIndexedMesh(t *testing.T) {
+	pts := [][2]float64{{0, 0}, {10, 0}, {10, 10}, {0, 10}, {3, 3}, {6, 3}, {6, 6}, {3, 6}}
+	loops := [][]int{{0, 1, 2, 3}, {4, 5, 6, 7}} // a 10×10 square with a 3×3 square hole
+	tris := earcutFromLoops(pts, loops)
+	if len(tris) == 0 {
+		t.Fatal("earcut fallback produced no triangles")
+	}
+	for _, tri := range tris {
+		for _, v := range tri {
+			if v < 0 || v >= len(pts) {
+				t.Fatalf("triangle index %d out of range for %d pts (remap broke)", v, len(pts))
+			}
+		}
+	}
+	for e, c := range edgeUseCount(tris) {
+		if c > 2 {
+			t.Errorf("edge %v used by %d triangles — non-manifold fallback", e, c)
+		}
+	}
+	if area := loopTriArea(pts, tris); stdmath.Abs(area-(100-9)) > 1e-9 {
+		t.Errorf("fallback area %.4f, want 91 (square 100 − hole 9); the hole was not cut", area)
+	}
+}
+
+// loopTriArea sums the unsigned area of pts-indexed triangles (the fallback's domain area).
+func loopTriArea(pts [][2]float64, tris [][3]int) float64 {
+	total := 0.0
+	for _, t := range tris {
+		a, b, c := pts[t[0]], pts[t[1]], pts[t[2]]
+		total += stdmath.Abs((b[0]-a[0])*(c[1]-a[1])-(c[0]-a[0])*(b[1]-a[1])) / 2
+	}
+	return total
+}
+
+// TestRecordConstraintLeakSeverity checks the two-tier diagnostic: a genuine leak (fallback taken) is a
+// counted Defect, a benign non-recovery is an Info, and a fully recovered triangulation records nothing —
+// so non-recovery is never silent yet the common harmless case raises no false alarm (#1410).
+func TestRecordConstraintLeakSeverity(t *testing.T) {
+	none := &Mesh{}
+	recordConstraintLeak(none, nil, false)
+	if len(none.Diagnostics) != 0 {
+		t.Errorf("full recovery should record nothing, got %d diagnostics", len(none.Diagnostics))
+	}
+
+	benign := &Mesh{}
+	recordConstraintLeak(benign, [][2]int{{1, 2}}, false)
+	if len(benign.Diagnostics) != 1 || benign.Diagnostics[0].Severity != diag.Info ||
+		benign.Diagnostics[0].Code != CodeCDTConstraintLeak {
+		t.Errorf("benign non-recovery should record one Info %s, got %+v", CodeCDTConstraintLeak, benign.Diagnostics)
+	}
+
+	leaked := &Mesh{}
+	recordConstraintLeak(leaked, [][2]int{{1, 2}}, true)
+	if len(leaked.Diagnostics) != 1 || leaked.Diagnostics[0].Severity != diag.Defect {
+		t.Errorf("a genuine leak should record one Defect, got %+v", leaked.Diagnostics)
+	}
+}
+
+// TestHoledCylinderWallNonRecoverySurfacedAndWatertight is the #1410 watertightness test for the real
+// cap-hit / non-recovery path: the holed cylinder wall's long seam constraint does not recover, but the
+// cut stays watertight (the seam borders the excluded super region), so the mesher keeps the refined mesh,
+// reports a non-manifold-free result, AND surfaces the non-recovery as an Info diagnostic — never silent.
+func TestHoledCylinderWallNonRecoverySurfacedAndWatertight(t *testing.T) {
+	const uLo, uHi, vLo, vHi = stdmath.Pi / 4, stdmath.Pi / 2, 4.0, 8.0
+	face := windowedCylinderWall(t, uLo, uHi, vLo, vHi)
+	mesh := tessellateCurvedFace(face, DefaultQuality())
+	if mesh == nil || mesh.TriangleCount() == 0 {
+		t.Fatal("holed cylinder wall produced no mesh")
+	}
+
+	tris := make([][3]int, 0, mesh.TriangleCount())
+	for i := 0; i+2 < len(mesh.Indices); i += 3 {
+		tris = append(tris, [3]int{mesh.Indices[i], mesh.Indices[i+1], mesh.Indices[i+2]})
+	}
+	for e, c := range edgeUseCount(tris) {
+		if c > 2 {
+			t.Errorf("mesh edge %v used by %d triangles — the non-recovery tore the mesh non-manifold", e, c)
+		}
+	}
+
+	var info, defect int
+	for _, d := range mesh.Diagnostics {
+		if d.Code != CodeCDTConstraintLeak {
+			continue
+		}
+		switch d.Severity {
+		case diag.Info:
+			info++
+		case diag.Defect:
+			defect++
+		}
+	}
+	if info != 1 {
+		t.Errorf("seam non-recovery must surface exactly one Info %s, got %d", CodeCDTConstraintLeak, info)
+	}
+	if defect != 0 {
+		t.Errorf("the watertight holed wall must not raise a leak Defect, got %d", defect)
+	}
+}

--- a/kernel/ops/holed_cylinder_wall.go
+++ b/kernel/ops/holed_cylinder_wall.go
@@ -79,13 +79,14 @@ func unrolledWallCDT(s geom.Surface, q Quality, outer3D []math.Point3, holes3D [
 		pos = append(pos, s.PointAt(g[0], g[1]))
 		nrm = append(nrm, s.NormalAt(g[0], g[1]))
 	}
-	tris := constrainedDelaunayRefined(uv, loops, nFrontier)
+	tris, unrecovered, leaked := constrainedDelaunayRefinedChecked(uv, loops, nFrontier)
 	if len(tris) == 0 {
 		return boundaryPatchMesh(s, outer3D, holes3D)
 	}
 	m := patchMeshFrom(pos, nrm, tris)
 	repairFolds(m, 8)
 	recordCapSaturation(m, saturated, q)
+	recordConstraintLeak(m, unrecovered, leaked) // #1410: surface non-recovery; never a silent boundary leak
 	return m
 }
 


### PR DESCRIPTION
## What & why

`insertConstraint` recorded `con[a,b] = true` **unconditionally** after the capped flip loop — even when the edge was never recovered (the flip cap hit, or a non-convex crossing stalled). A phantom `con` entry has no mesh edge for `floodInside` to toggle at, so when a boundary genuinely fails to recover the domain can leak across the gap and label a hole as filled — a **silent watertightness defect** the volume guard cannot catch (the highest-priority bug class per CLAUDE.md).

## The fix

- **Record only recovered constraints** (`con ⟹ hasEdge`). Genuine non-recovery is collected on the `cdt` instead of falsely marked recovered.
- **Decide on an actual leak, not a recovery miss.** `finalizeDomain` checks, per loop, whether the extraction *actually* leaked (`domainLeaked`): a loop whose edges dissolved into the domain interior (interior uses outnumber boundary uses) was filled. This was the load-bearing subtlety — the common holed-cylinder-wall **seam** constraint does not recover, yet the cut stays watertight (its far side is the excluded super-triangle region), and a single dissolved edge is a local fold `repairFolds` removes. Neither should discard the higher-quality refined mesh.
- **Deterministic fallback on a genuine leak.** A filled hole/notch falls back to an ear clip over the loops, which respects every boundary by construction and so cannot leak.
- **Never silent.** Non-recovery is surfaced on the mesh: a counted `Defect` when the earcut fallback was taken, a benign `Info` otherwise — so the common harmless case raises no false alarm. Built on the `kernel/diag` channel.

## Acceptance criteria (#1410)

- [x] `con` is set only on actual edge recovery.
- [x] Non-recovery raises a diagnostic and uses a deterministic fallback; no silent boundary leak.
- [x] Watertightness test added covering the cap-hit / non-recovery path.

## Tests

`kernel/ops/cdt_recovery_test.go`: con⟹hasEdge invariant; `domainLeaked` separating a filled hole (leak) from a fold and a clean cut; the ear-clip fallback producing a watertight pts-indexed mesh (area = outer − hole); the two-tier diagnostic severity; and an integration test driving the real holed cylinder wall (seam non-recovery) asserting it stays manifold and surfaces exactly one `Info`. Full suite green; ops coverage 90.8%; lint clean.

Closes #1410

🤖 Generated with [Claude Code](https://claude.com/claude-code)