### PR TITLE
[router] Wire sketch3D authoring into central undo + replication (#1426)

### DIFF
--- a/addin/router/central_undo_test.go
+++ b/addin/router/central_undo_test.go
@@ -62,6 +62,26 @@ func TestCentralSeamRecordsFeatureUndo(t *testing.T) {
 	}
 }
 
+// TestCentralSeamRecordsSketch3DEntityUndo proves 3D-sketch geometry added over the wire
+// (sketch3d.addEntity) is undoable and replicated, exactly like its 2D parallel. Before #1426 the whole
+// sketch3d authoring family was absent from the mutating table — silently non-undoable; wiring it through
+// the MutatingMethod interface fixes the drift.
+func TestCentralSeamRecordsSketch3DEntityUndo(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch3d.create", `{}`, &wire.CreateSketch3DResult{})
+	call(t, r, s, "sketch3d.addEntity", `{"sketchIndex":0,"kind":"line","points":[[0,0,0],[3,0,4]]}`, &wire.AddSketch3DEntityResult{})
+
+	st := undoState(t, r, s)
+	if !st.CanUndo || st.NextUndo != "Add Sketch Geometry" {
+		t.Fatalf("after sketch3d.addEntity state = %+v, want canUndo with nextUndo=Add Sketch Geometry", st)
+	}
+
+	call(t, r, s, "transaction.undo", "{}", nil)
+	if st := undoState(t, r, s); st.NextUndo != "Create Sketch" {
+		t.Fatalf("after one undo nextUndo = %q, want \"Create Sketch\" (only the entity reverted)", st.NextUndo)
+	}
+}
+
 // TestCentralSeamRecordsSketchEntityUndo proves sketch geometry added over the wire
 // (sketch.addEntity) is undoable — another path that previously recorded nothing.
 func TestCentralSeamRecordsSketchEntityUndo(t *testing.T) {

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -365,14 +365,14 @@ func (r *Router) registerSketchHandlers() {
 // and property edits (M22-F01). The 3D authoring methods (addEntity/addConstraint/
 // addDimension) are wired by their features (M22 F02+).
 func (r *Router) registerSketch3DHandlers() {
-	r.readOnly(wire.MethodSketch3DCreate, createSketch3D)
+	r.mutating(wire.MethodSketch3DCreate, "Create Sketch", createSketch3D)
 	r.readOnly(wire.MethodSketch3DList, listSketches3D)
 	r.readOnly(wire.MethodSketch3DGet, getSketch3D)
-	r.readOnly(wire.MethodSketch3DEdit, editSketch3D)
-	r.readOnly(wire.MethodSketch3DExitEdit, exitEditSketch3D)
-	r.readOnly(wire.MethodSketch3DSolve, solveSketch3D)
-	r.readOnly(wire.MethodSketch3DDelete, deleteSketch3D)
-	r.readOnly(wire.MethodSketch3DSetProperty, setSketch3DProperty)
+	r.mutating(wire.MethodSketch3DEdit, "", editSketch3D)
+	r.mutating(wire.MethodSketch3DExitEdit, "", exitEditSketch3D)
+	r.mutating(wire.MethodSketch3DSolve, "", solveSketch3D)
+	r.mutating(wire.MethodSketch3DDelete, "Delete Sketch", deleteSketch3D)
+	r.mutating(wire.MethodSketch3DSetProperty, "Edit Sketch", setSketch3DProperty)
 	r.readOnly(wire.MethodSketch3DEntities, enumerateEntities3D)
 	r.readOnly(wire.MethodSketch3DConstraints, enumerateConstraints3D)
 	r.readOnly(wire.MethodSketch3DDimensions, enumerateDimensions3D)
@@ -383,17 +383,17 @@ func (r *Router) registerSketch3DHandlers() {
 // registerSketch3DAuthoringHandlers wires the 3D-sketch mutation/query methods: entity/
 // constraint/dimension creation, profiles/paths, edit transform, and include.
 func (r *Router) registerSketch3DAuthoringHandlers() {
-	r.readOnly(wire.MethodSketch3DAddEntity, addSketch3DEntity)
-	r.readOnly(wire.MethodSketch3DAddConstraint, addSketch3DConstraint)
-	r.readOnly(wire.MethodSketch3DDeleteConstraint, deleteSketch3DConstraint)
-	r.readOnly(wire.MethodSketch3DAddDimension, addSketch3DDimension)
-	r.readOnly(wire.MethodSketch3DDriveDimension, driveSketch3DDimension)
+	r.mutating(wire.MethodSketch3DAddEntity, "Add Sketch Geometry", addSketch3DEntity)
+	r.mutating(wire.MethodSketch3DAddConstraint, "Add Constraint", addSketch3DConstraint)
+	r.mutating(wire.MethodSketch3DDeleteConstraint, "Delete Constraint", deleteSketch3DConstraint)
+	r.mutating(wire.MethodSketch3DAddDimension, "Add Dimension", addSketch3DDimension)
+	r.mutating(wire.MethodSketch3DDriveDimension, "Edit Dimension", driveSketch3DDimension)
 	r.readOnly(wire.MethodSketch3DProfiles, sketch3DProfiles)
 	r.readOnly(wire.MethodSketch3DPaths, sketch3DPaths)
-	r.readOnly(wire.MethodSketch3DTransform, transformSketch3D)
-	r.readOnly(wire.MethodSketch3DInclude, includeSketch3D)
-	r.readOnly(wire.MethodSketch3DIncludeSketch, includeSketch2DInto3D)
-	r.readOnly(wire.MethodSketch3DAddSurfaceCurve, addSketch3DSurfaceCurve)
+	r.mutating(wire.MethodSketch3DTransform, "Transform Sketch", transformSketch3D)
+	r.mutating(wire.MethodSketch3DInclude, "Project Geometry", includeSketch3D)
+	r.mutating(wire.MethodSketch3DIncludeSketch, "Project Geometry", includeSketch2DInto3D)
+	r.mutating(wire.MethodSketch3DAddSurfaceCurve, "Add Sketch Geometry", addSketch3DSurfaceCurve)
 }
 
 // registerSketchAuthoringHandlers wires the sketch mutation methods: property edits,


### PR DESCRIPTION
## What & why

Part of the central-undo wiring (#1426). The whole `sketch3d.*` authoring/lifecycle family was registered `readOnly`, so **3D sketch edits over the wire (API / MCP / Lua) were silently non-undoable and not replicated** to collaborators — the exact drift the new `MutatingMethod` interface exists to prevent. Each method is the direct 3D parallel of an already-mutating 2D method.

## Change

Reclassify as `mutating`, reusing the 2D parallels' undo labels:

| sketch3d method | label |
|---|---|
| create | Create Sketch |
| delete | Delete Sketch |
| edit / exitEdit / solve | (broadcast-only) |
| setProperty | Edit Sketch |
| addEntity / addSurfaceCurve | Add Sketch Geometry |
| addConstraint | Add Constraint |
| deleteConstraint | Delete Constraint |
| addDimension | Add Dimension |
| driveDimension | Edit Dimension |
| transform | Transform Sketch |
| include / includeSketch | Project Geometry |

Query methods (list/get/entities/constraints/dimensions/constraintStatus/profiles/paths/regionProperties) stay read-only.

## Tests

`TestCentralSeamRecordsSketch3DEntityUndo`: a `sketch3d.addEntity` is now one undo step that reverts on undo (and leaves the create step). Full suite green; lint clean; the `MutatingMethod` interface enforcement test covers the new classifications.

Part of #1426

🤖 Generated with [Claude Code](https://claude.com/claude-code)