### PR TITLE
[router] Wire body + attribute editing into central undo + replication (#1426)

### DIFF
--- a/addin/router/attributes.go
+++ b/addin/router/attributes.go
@@ -22,11 +22,11 @@ import (
 
 // registerAttributeHandlers wires the attributes.* methods.
 func (r *Router) registerAttributeHandlers() {
-	r.readOnly(wire.MethodAttributesSet, setAttribute)
+	r.mutating(wire.MethodAttributesSet, "Set Attribute", setAttribute)
 	r.readOnly(wire.MethodAttributesGet, getAttribute)
 	r.readOnly(wire.MethodAttributesList, listAttributes)
 	r.readOnly(wire.MethodAttributesListSets, listAttributeSets)
-	r.readOnly(wire.MethodAttributesDelete, deleteAttribute)
+	r.mutating(wire.MethodAttributesDelete, "Delete Attribute", deleteAttribute)
 	r.readOnly(wire.MethodAttributesFind, findByAttribute)
 }
 

--- a/addin/router/central_undo_test.go
+++ b/addin/router/central_undo_test.go
@@ -63,6 +63,27 @@ func TestCentralSeamRecordsFeatureUndo(t *testing.T) {
 	}
 }
 
+// TestCentralSeamRecordsBodyDeleteUndo proves deleting a body over the wire (body.delete, which records
+// a DeleteBody feature) is one undo step that restores the body — body editing was read-only before #1426.
+func TestCentralSeamRecordsBodyDeleteUndo(t *testing.T) {
+	r, s, def := twoBodyPartSession(t)
+
+	call(t, r, s, "body.delete", `{"bodyIndex":0}`, &wire.BodyListResult{})
+	if n := len(def.SurfaceBodies().All()); n != 1 {
+		t.Fatalf("after body.delete: %d bodies, want 1", n)
+	}
+
+	st := undoState(t, r, s)
+	if !st.CanUndo || st.NextUndo != "Delete Body" {
+		t.Fatalf("after body.delete state = %+v, want canUndo with nextUndo=Delete Body", st)
+	}
+
+	call(t, r, s, "transaction.undo", "{}", nil)
+	if n := len(def.SurfaceBodies().All()); n != 2 {
+		t.Errorf("after undo: %d bodies, want 2 (the delete reverted)", n)
+	}
+}
+
 // TestCentralSeamRecordsAssemblyPlacementUndo proves placing a component over the wire
 // (assembly.placeByDefinition) is one undo step that reverts the occurrence — the assembly authoring
 // family was registered read-only before #1426, so wire-driven placements were silently non-undoable and

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -448,9 +448,9 @@ func (r *Router) registerMaterialHandlers() {
 
 	// Body topology, queries and facet sets (M07 #293/#629/#630).
 	r.readOnly(wire.MethodBodyList, bodyList)
-	r.readOnly(wire.MethodBodySetVisible, bodySetVisible)
-	r.readOnly(wire.MethodBodyRename, bodyRename)
-	r.readOnly(wire.MethodBodyDelete, bodyDelete)
+	r.mutating(wire.MethodBodySetVisible, "", bodySetVisible)
+	r.mutating(wire.MethodBodyRename, "Rename Body", bodyRename)
+	r.mutating(wire.MethodBodyDelete, "Delete Body", bodyDelete)
 	r.readOnly(wire.MethodBodyPhysicalProps, bodyPhysicalProperties)
 	r.readOnly(wire.MethodBodyShells, bodyShells)
 	r.readOnly(wire.MethodBodyWires, bodyWires)


### PR DESCRIPTION
## What & why

Part of the central-undo wiring (#1426). `body.delete`/`body.rename` edit the part recipe and `attributes.set`/`attributes.delete` edit a document's attribute sets, but all were registered `readOnly` — silently non-undoable and not replicated over the wire.

## Change

| method | classification |
|---|---|
| body.delete | mutating — *Delete Body* (records a DeleteBody feature) |
| body.rename | mutating — *Rename Body* |
| body.setVisible | mutating — broadcast-only (`""`, doc-scoped visibility, matches workSurfaces.setVisible) |
| attributes.set | mutating — *Set Attribute* |
| attributes.delete | mutating — *Delete Attribute* |

## Deliberately left read-only (with rationale)

- **`brep.*`** (boolean/createPrimitive/imprint/offsetFaces/transform/…): operates on session **transient bodies** (`s.TransientBodies()`), not the document recipe — neither undoable nor a replicated document edit.
- **`appearances`/`materials` create/update**: manage the **session asset library** (`DuplicateAppearance`/`DuplicateMaterial`), not the document. The document edit is `model.assignMaterial`/`assignAppearance`, already mutating.
- body/face query methods (facets/strokes/evaluate/distance/inside/list/validate/properties).

## Tests

`TestCentralSeamRecordsBodyDeleteUndo`: `body.delete` is one undo step that restores the body on undo. Full suite green; lint clean.

Part of #1426

🤖 Generated with [Claude Code](https://claude.com/claude-code)