### PR TITLE
[router] Wire reps, model states, contacts & sheet metal into central seam (#1426)

### DIFF
--- a/addin/router/contact.go
+++ b/addin/router/contact.go
@@ -18,11 +18,11 @@ import (
 
 // registerContactHandlers wires the contactSets.*/contactSolver.*/interference.* methods.
 func (r *Router) registerContactHandlers() {
-	r.readOnly(wire.MethodContactSetsCreate, contactSetsCreate)
+	r.mutating(wire.MethodContactSetsCreate, "Create Contact Set", contactSetsCreate)
 	r.readOnly(wire.MethodContactSetsList, contactSetsList)
-	r.readOnly(wire.MethodContactSetsDelete, contactSetsDelete)
-	r.readOnly(wire.MethodContactSetsAddMember, contactSetsAddMember)
-	r.readOnly(wire.MethodContactSetsRemoveMember, contactSetsRemoveMember)
+	r.mutating(wire.MethodContactSetsDelete, "Delete Contact Set", contactSetsDelete)
+	r.mutating(wire.MethodContactSetsAddMember, "Edit Contact Set", contactSetsAddMember)
+	r.mutating(wire.MethodContactSetsRemoveMember, "Edit Contact Set", contactSetsRemoveMember)
 	r.readOnly(wire.MethodContactSolverSetEnabled, contactSolverSetEnabled)
 	r.readOnly(wire.MethodContactSolverStatus, contactSolverStatus)
 	r.readOnly(wire.MethodInterferenceAnalyze, interferenceAnalyze)

--- a/addin/router/flat_pattern.go
+++ b/addin/router/flat_pattern.go
@@ -26,20 +26,20 @@ import (
 // registerFlatPatternHandlers wires the flatPattern.* methods.
 func (r *Router) registerFlatPatternHandlers() {
 	r.readOnly(wire.MethodFlatPatternListOrientations, flatPatternListOrientations)
-	r.readOnly(wire.MethodFlatPatternAddOrientation, flatPatternAddOrientation)
+	r.mutating(wire.MethodFlatPatternAddOrientation, "Edit Flat Pattern", flatPatternAddOrientation)
 	r.readOnly(wire.MethodFlatPatternActivateOrientation, flatPatternActivateOrientation)
-	r.readOnly(wire.MethodFlatPatternDeleteOrientation, flatPatternDeleteOrientation)
+	r.mutating(wire.MethodFlatPatternDeleteOrientation, "Edit Flat Pattern", flatPatternDeleteOrientation)
 	r.readOnly(wire.MethodFlatPatternEdgesOfType, flatPatternEdgesOfType)
 	r.readOnly(wire.MethodFlatPatternFaces, flatPatternFaces)
 	r.readOnly(wire.MethodFlatPatternMapEntity, flatPatternMapEntity)
 	r.readOnly(wire.MethodFlatPatternListPlates, flatPatternListPlates)
 	r.readOnly(wire.MethodFlatPatternGetSettings, flatPatternGetSettings)
-	r.readOnly(wire.MethodFlatPatternSetSettings, flatPatternSetSettings)
+	r.mutating(wire.MethodFlatPatternSetSettings, "Edit Flat Pattern Settings", flatPatternSetSettings)
 	r.readOnly(wire.MethodFlatPatternListBendOrder, flatPatternListBendOrder)
-	r.readOnly(wire.MethodFlatPatternSetBendOrder, flatPatternSetBendOrder)
-	r.readOnly(wire.MethodFlatPatternAddCenterline, flatPatternAddCenterline)
+	r.mutating(wire.MethodFlatPatternSetBendOrder, "Edit Flat Pattern", flatPatternSetBendOrder)
+	r.mutating(wire.MethodFlatPatternAddCenterline, "Edit Flat Pattern", flatPatternAddCenterline)
 	r.readOnly(wire.MethodFlatPatternListCenterlines, flatPatternListCenterlines)
-	r.readOnly(wire.MethodFlatPatternDeleteCenterline, flatPatternDeleteCenterline)
+	r.mutating(wire.MethodFlatPatternDeleteCenterline, "Edit Flat Pattern", flatPatternDeleteCenterline)
 }
 
 func flatPatternAddCenterline(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {

--- a/addin/router/representations.go
+++ b/addin/router/representations.go
@@ -29,37 +29,37 @@ func (r *Router) registerRepresentationHandlers() {
 }
 
 func (r *Router) registerDesignRepHandlers() {
-	r.readOnly(wire.MethodDesignRepsCapture, designRepsCapture)
+	r.mutating(wire.MethodDesignRepsCapture, "Capture Design View", designRepsCapture)
 	r.readOnly(wire.MethodDesignRepsActivate, designRepsActivate)
 	r.readOnly(wire.MethodDesignRepsList, designRepsList)
-	r.readOnly(wire.MethodDesignRepsDelete, designRepsDelete)
-	r.readOnly(wire.MethodDesignRepsSetVisibility, designRepsSetVisibility)
-	r.readOnly(wire.MethodDesignRepsSetAppearance, designRepsSetAppearance)
-	r.readOnly(wire.MethodDesignRepsAddSection, designRepsAddSection)
+	r.mutating(wire.MethodDesignRepsDelete, "Delete Design View", designRepsDelete)
+	r.mutating(wire.MethodDesignRepsSetVisibility, "Edit Design View", designRepsSetVisibility)
+	r.mutating(wire.MethodDesignRepsSetAppearance, "Edit Design View", designRepsSetAppearance)
+	r.mutating(wire.MethodDesignRepsAddSection, "Add Section View", designRepsAddSection)
 }
 
 func (r *Router) registerPositionalRepHandlers() {
-	r.readOnly(wire.MethodPositionalRepsCapture, positionalRepsCapture)
+	r.mutating(wire.MethodPositionalRepsCapture, "Capture Positional Rep", positionalRepsCapture)
 	r.readOnly(wire.MethodPositionalRepsActivate, positionalRepsActivate)
 	r.readOnly(wire.MethodPositionalRepsList, positionalRepsList)
-	r.readOnly(wire.MethodPositionalRepsDelete, positionalRepsDelete)
-	r.readOnly(wire.MethodPositionalRepsSetOverride, positionalRepsSetOverride)
-	r.readOnly(wire.MethodPositionalRepsSetFlexible, positionalRepsSetFlexible)
+	r.mutating(wire.MethodPositionalRepsDelete, "Delete Positional Rep", positionalRepsDelete)
+	r.mutating(wire.MethodPositionalRepsSetOverride, "Edit Positional Rep", positionalRepsSetOverride)
+	r.mutating(wire.MethodPositionalRepsSetFlexible, "Edit Positional Rep", positionalRepsSetFlexible)
 }
 
 func (r *Router) registerLODRepHandlers() {
-	r.readOnly(wire.MethodLODRepsCapture, lodRepsCapture)
+	r.mutating(wire.MethodLODRepsCapture, "Capture LOD Rep", lodRepsCapture)
 	r.readOnly(wire.MethodLODRepsActivate, lodRepsActivate)
 	r.readOnly(wire.MethodLODRepsList, lodRepsList)
-	r.readOnly(wire.MethodLODRepsDelete, lodRepsDelete)
-	r.readOnly(wire.MethodLODRepsSetSuppressed, lodRepsSetSuppressed)
+	r.mutating(wire.MethodLODRepsDelete, "Delete LOD Rep", lodRepsDelete)
+	r.mutating(wire.MethodLODRepsSetSuppressed, "Edit LOD Rep", lodRepsSetSuppressed)
 }
 
 func (r *Router) registerModelStateHandlers() {
-	r.readOnly(wire.MethodModelStatesCreate, modelStatesCreate)
+	r.mutating(wire.MethodModelStatesCreate, "Create Model State", modelStatesCreate)
 	r.readOnly(wire.MethodModelStatesActivate, modelStatesActivate)
 	r.readOnly(wire.MethodModelStatesList, modelStatesList)
-	r.readOnly(wire.MethodModelStatesDelete, modelStatesDelete)
+	r.mutating(wire.MethodModelStatesDelete, "Delete Model State", modelStatesDelete)
 }
 
 // --- design-view ---

--- a/addin/router/representations_replication_test.go
+++ b/addin/router/representations_replication_test.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/event"
+)
+
+// TestRepresentationEditsReplicate proves an assembly-representation edit over the wire now emits
+// edit.committed for collaboration replication (ADR-0004). Capturing an LOD rep and creating a model
+// state were registered read-only before #1426, so these document edits were silently not replicated;
+// a read-only rep query still emits nothing.
+func TestRepresentationEditsReplicate(t *testing.T) {
+	r, s, _, _ := assemblySessionWithBoxes(t, 0, 5)
+
+	var got []app.EditCommitted
+	sub := event.Subscribe(s.Events(), event.After, func(_ event.Context, e app.EditCommitted) event.Outcome {
+		got = append(got, e)
+		return event.Continue()
+	})
+	defer sub.Cancel()
+
+	call(t, r, s, "lodReps.list", `{}`, nil)
+	if len(got) != 0 {
+		t.Fatalf("read-only lodReps.list emitted edit.committed: %+v", got)
+	}
+
+	call(t, r, s, "lodReps.capture", mustJSON(t, wire.CaptureRepArgs{Name: "simplified"}), &wire.LODResult{})
+	if len(got) != 1 || got[0].Method != wire.MethodLODRepsCapture {
+		t.Fatalf("lodReps.capture replication = %+v, want one edit.committed for that method", got)
+	}
+
+	call(t, r, s, "modelStates.create", mustJSON(t, wire.CreateModelStateArgs{Name: "state"}), &wire.ModelStateResult{})
+	if len(got) != 2 || got[1].Method != wire.MethodModelStatesCreate {
+		t.Fatalf("modelStates.create replication = %+v, want a second edit.committed for that method", got)
+	}
+}

--- a/addin/router/sheet_metal.go
+++ b/addin/router/sheet_metal.go
@@ -26,10 +26,10 @@ import (
 // registerSheetMetalHandlers wires the sheetMetal.* methods.
 func (r *Router) registerSheetMetalHandlers() {
 	r.readOnly(wire.MethodSheetMetalGetStyle, sheetMetalGetStyle)
-	r.readOnly(wire.MethodSheetMetalSetStyle, sheetMetalSetStyle)
+	r.mutating(wire.MethodSheetMetalSetStyle, "Edit Sheet Metal Style", sheetMetalSetStyle)
 	r.readOnly(wire.MethodSheetMetalBendAllowance, sheetMetalBendAllowance)
 	r.readOnly(wire.MethodSheetMetalBends, sheetMetalBends)
-	r.readOnly(wire.MethodSheetMetalUnfold, sheetMetalUnfold)
+	r.mutating(wire.MethodSheetMetalUnfold, "Create Flat Pattern", sheetMetalUnfold)
 }
 
 // activeSheetMetal returns the active part and its rule, or an error if the active document


### PR DESCRIPTION
## What & why

Part of the central-undo/replication wiring (#1426). These document edits were registered `readOnly` — silently non-undoable and not replicated over the wire (API/MCP/Lua).

## Change (26 methods reclassified `mutating`)

- **sheetMetal**: setStyle → *Edit Sheet Metal Style*; unfold → *Create Flat Pattern*
- **flatPattern**: add/deleteOrientation, add/deleteCenterline, setBendOrder → *Edit Flat Pattern*; setSettings → *Edit Flat Pattern Settings*
- **modelStates**: create → *Create Model State*; delete → *Delete Model State*
- **designReps**: capture/delete/addSection/setAppearance/setVisibility
- **positionalReps**: capture/delete/setFlexible/setOverride
- **lodReps**: capture/delete/setSuppressed
- **contactSets**: create/delete/addMember/removeMember

## Deliberately left read-only

- **`*.activate`** (designReps/positionalReps/lodReps/modelStates): switching the active configuration is view/state navigation, not a recipe edit (consistent with `drawing.setActiveSheet`).
- **`graphicsNode.*`**: add-in client-graphics overlays (`s.Graphics()`), not the document.
- **`environment.*`**: renderer/IBL state (`s.SetEnvironment`), not the document.
- **`contactSolver.*`**: solver mode toggle/status.

## Tests

`TestRepresentationEditsReplicate`: `lodReps.capture` and `modelStates.create` each emit one `edit.committed` for replication; a `lodReps.list` query emits none. Full suite green; lint clean; the `MutatingMethod` interface enforcement test covers the new classifications.

Part of #1426

🤖 Generated with [Claude Code](https://claude.com/claude-code)