### PR TITLE
[undo] DrawingContent recipe-snapshot support for central undo (#1448)

### DIFF
--- a/addin/router/central_undo_test.go
+++ b/addin/router/central_undo_test.go
@@ -11,7 +11,20 @@ import (
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/drawing"
 )
+
+// activeDrawingViews returns the number of views on the active drawing's active sheet — the
+// observable the drawing central-seam test checks across an undo to prove the view actually
+// rolled back, not just that the cursor reports it can.
+func activeDrawingViews(t *testing.T, s *app.Session) int {
+	t.Helper()
+	c, ok := s.ActiveDocument().Content().(*drawing.Content)
+	if !ok {
+		t.Fatalf("active document content is %T, want *drawing.Content", s.ActiveDocument().Content())
+	}
+	return c.Sheets().Active().Views().Count()
+}
 
 // activePartBodies returns the number of solid bodies on the session's active part — the
 // observable the central-seam tests check before and after an undo to prove the model
@@ -99,6 +112,38 @@ func TestCentralSeamRecordsBodyDeleteUndo(t *testing.T) {
 	call(t, r, s, "transaction.undo", "{}", nil)
 	if n := len(def.SurfaceBodies().All()); n != 2 {
 		t.Errorf("after undo: %d bodies, want 2 (the delete reverted)", n)
+	}
+}
+
+// TestCentralSeamRecordsDrawingViewUndo proves a drawing edit over the wire (drawingViews.addBase)
+// is now one undo step that reverts the view. The whole drawing authoring surface was classified
+// mutating in #1447 for replication, but its undo labels were dead until DrawingContent gained
+// recipe-snapshot support (#1448): with no MarshalSnapshot the central seam recorded nothing. This
+// is the activation test for that support — addBase adds a view, undo removes it, redo restores it.
+func TestCentralSeamRecordsDrawingViewUndo(t *testing.T) {
+	r, s := drawingViewSession(t) // a part with geometry + an active drawing referencing it
+	if got := activeDrawingViews(t, s); got != 0 {
+		t.Fatalf("fresh drawing already has %d views, want 0", got)
+	}
+
+	call(t, r, s, "drawingViews.addBase", `{"name":"FRONT","orientation":"front","scale":2,"centerXmm":120,"centerYmm":100}`, &wire.ViewResult{})
+	if got := activeDrawingViews(t, s); got != 1 {
+		t.Fatalf("after drawingViews.addBase: %d views, want 1", got)
+	}
+
+	st := undoState(t, r, s)
+	if !st.CanUndo || st.NextUndo != "Add View" {
+		t.Fatalf("after drawingViews.addBase state = %+v, want canUndo with nextUndo=Add View", st)
+	}
+
+	call(t, r, s, "transaction.undo", "{}", nil)
+	if got := activeDrawingViews(t, s); got != 0 {
+		t.Errorf("after undo: %d views, want 0 (the view reverted)", got)
+	}
+
+	call(t, r, s, "transaction.redo", "{}", nil)
+	if got := activeDrawingViews(t, s); got != 1 {
+		t.Errorf("after redo: %d views, want 1 (the view restored)", got)
 	}
 }
 

--- a/addin/router/drawing_replication_test.go
+++ b/addin/router/drawing_replication_test.go
@@ -10,14 +10,14 @@ import (
 	"oblikovati.org/event"
 )
 
-// TestDrawingEditsReplicate proves a drawing edit over the wire now emits edit.committed for
+// TestDrawingEditsReplicate proves a drawing edit over the wire emits edit.committed for
 // collaboration replication (ADR-0004). The whole drawing authoring surface (views/annotations/
 // dimensions/sketches/sheets) was registered read-only before #1426, so wire-driven drawing edits were
 // silently not replicated to collaborators. A read-only drawing query still emits nothing.
 //
-// Drawing UNDO additionally requires DrawingContent to support recipe snapshots (MarshalSnapshot); the
-// central seam records no undo step for content that is not a recipe store, so wiring these mutating
-// delivers replication today and undo once that support lands. See the package's drawing-undo follow-up.
+// Drawing UNDO is covered separately by TestCentralSeamRecordsDrawingViewUndo: since #1448 gave
+// DrawingContent recipe-snapshot support, the same mutating classification now also records an undo
+// step, so a wire drawing edit both replicates and is undoable.
 func TestDrawingEditsReplicate(t *testing.T) {
 	r, s := drawingViewSession(t) // a part with geometry + a drawing whose model reference is set
 

--- a/app/undo.go
+++ b/app/undo.go
@@ -13,6 +13,7 @@ import (
 	"oblikovati.org/event"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/doc"
+	"oblikovati.org/model/drawing"
 )
 
 // maxSessionTxEvents bounds the append-only transaction log so a very long session cannot
@@ -70,10 +71,14 @@ type recipeStore interface {
 	MarshalSnapshot() ([]byte, error)
 }
 
-// Part and assembly definitions are the concrete recipe stores a snapshot event navigates.
+// Part and assembly definitions and drawing content are the concrete recipe stores a snapshot event
+// navigates. Drawing content joined them in #1448 so a wire drawing edit (views/annotations/
+// dimensions/sketches/sheets), classified mutating in #1426/#1447 for replication, also records an
+// undo step — its undo labels were dead until DrawingContent gained snapshot support.
 var (
 	_ recipeStore = (*compdef.PartComponentDefinition)(nil)
 	_ recipeStore = (*compdef.AssemblyComponentDefinition)(nil)
+	_ recipeStore = (*drawing.Content)(nil)
 )
 
 // docHistory is one document's transaction-event stream: the [command.History] (the

--- a/model/drawing/recipe.go
+++ b/model/drawing/recipe.go
@@ -149,24 +149,41 @@ type viewRecipe struct {
 	CenterY      float64    `yaml:"centerYmm,omitempty"`
 }
 
-// MarshalRecipe renders the drawing's sheets and referenced model as YAML
-// (doc.RecipeContent).
-func (c *Content) MarshalRecipe() ([]byte, error) {
+// buildRecipe captures the drawing's full persisted state as a [drawingRecipe] value — the shared
+// step behind both the YAML save ([MarshalRecipe]) and the fast undo snapshot ([Content.MarshalSnapshot],
+// snapshot.go), so a snapshot reuses a faster codec without re-deriving the recipe.
+func (c *Content) buildRecipe() drawingRecipe {
 	r := drawingRecipe{ModelReference: c.modelRef, Standard: c.styles.active.String(), ActiveSheet: c.sheets.active}
 	for _, sh := range c.sheets.items {
 		r.Sheets = append(r.Sheets, sheetRecipeOf(sh))
 	}
-	return yamlcodec.Marshal(r)
+	return r
 }
 
-// ApplyRecipe restores the drawing from recipe YAML. It replaces the content's sheets
-// outright (so applying onto the factory's default sheet yields exactly the saved set),
-// re-wiring the title-block resolution hook so fields resolve against the model again.
+// MarshalRecipe renders the drawing's sheets and referenced model as YAML
+// (doc.RecipeContent).
+func (c *Content) MarshalRecipe() ([]byte, error) {
+	return yamlcodec.Marshal(c.buildRecipe())
+}
+
+// ApplyRecipe restores the drawing from recipe YAML (doc.RecipeContent).
 func (c *Content) ApplyRecipe(model []byte) error {
 	var r drawingRecipe
 	if err := yamlcodec.Unmarshal(model, &r); err != nil {
 		return fmt.Errorf("drawing: parse recipe: %w", err)
 	}
+	return c.applyRecipeStruct(r)
+}
+
+// applyRecipeStruct restores the drawing from an already-decoded [drawingRecipe] — the shared tail
+// of [ApplyRecipe] (YAML) and [Content.RestoreSnapshot] (the fast undo codec, snapshot.go), so both
+// decode formats converge on one apply path. It replaces the content's sheets outright (so applying
+// onto the factory's default sheet yields exactly the saved set), re-wiring the sheet resolution
+// hooks so title-block, body-projection, BOM and dimension-precision lookups target the model again.
+// The BOM hook is re-wired here too (NewContent sets it, ApplyRecipe previously did not): an undo
+// restore does not re-run the host's SetBOMResolver, so without this a parts list would lose its rows
+// after undo.
+func (c *Content) applyRecipeStruct(r drawingRecipe) error {
 	c.modelRef = r.ModelReference
 	if std, ok := types.ParseDraftingStandard(r.Standard); ok {
 		c.styles.SetActiveStandard(std)
@@ -174,6 +191,7 @@ func (c *Content) ApplyRecipe(model []byte) error {
 	c.sheets = newSheets()
 	c.sheets.lookup = c.resolveProperty
 	c.sheets.bodyResolve = c.resolveBody
+	c.sheets.bomResolve = c.resolveBOM
 	c.sheets.dimPrecision = c.dimDecimals
 	for _, sr := range r.Sheets {
 		if err := c.sheets.restore(sr); err != nil {

--- a/model/drawing/snapshot.go
+++ b/model/drawing/snapshot.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package drawing
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Undo/redo snapshots use a fast internal JSON codec, distinct from the human-readable YAML on-disk
+// format (MarshalRecipe / ApplyRecipe, recipe.go). A snapshot is transient and never written to a
+// file, so it trades readability for speed — exactly the part/assembly snapshot codec rationale
+// (#1147). The drawing recipe types carry no custom MarshalYAML and no interface-typed fields, so
+// the plain JSON struct codec round-trips faithfully and deterministically (the no-op-delta byte
+// check in the undo stream relies on that determinism). Landing DrawingContent on this codec puts it
+// on the central undo seam, so a wire drawing edit records an undo step rather than only replicating
+// (#1448, found while wiring #1426): its undo labels (PR #1447) were dead until this.
+
+// MarshalSnapshot encodes the drawing's full state for the undo/redo stream. It shares the recipe
+// build with the YAML save (recipe.go) but encodes JSON for speed; see the package note in this file.
+func (c *Content) MarshalSnapshot() ([]byte, error) {
+	return json.Marshal(c.buildRecipe())
+}
+
+// RestoreSnapshot replaces the drawing's entire state with a snapshot produced by
+// [Content.MarshalSnapshot] — the undo/redo restore direction. It is a full REPLACE (the sheets are
+// rebuilt from the recipe in place, preserving the Content pointer and its injected resolvers), so
+// navigating to any snapshot yields exactly that state regardless of what the drawing now holds. The
+// snapshot is decoded before the rebuild, so a malformed snapshot leaves the drawing untouched.
+//
+// The rebuilt sheets carry no projected view curves yet, so the view-projection cache is cleared and
+// re-projected immediately when the referenced model resolves; otherwise the head's next SyncViews
+// re-projects (the unchanged-body fast path would wrongly skip a rebuild without the cache reset).
+func (c *Content) RestoreSnapshot(snapshot []byte) error {
+	var r drawingRecipe
+	if err := json.Unmarshal(snapshot, &r); err != nil {
+		return fmt.Errorf("drawing: parse snapshot: %w", err)
+	}
+	if err := c.applyRecipeStruct(r); err != nil {
+		return err
+	}
+	c.lastViewBody = nil // the rebuilt views hold no projected curves; force re-projection
+	c.SyncViews()        // re-project now if the model resolves; else the head's next frame does
+	return nil
+}

--- a/model/drawing/snapshot_test.go
+++ b/model/drawing/snapshot_test.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package drawing
+
+import (
+	"bytes"
+	"testing"
+
+	"oblikovati.org/api/types"
+)
+
+// richDrawing builds a drawing exercising the recipe sections a snapshot must round-trip without a
+// body resolver: an extra custom sheet, a drawing sketch with an entity + a hatch, and a couple of
+// self-contained annotations (a revision cloud and a feature-control frame, whose glyphs are pure
+// functions of their persisted fields, so they survive a round-trip with no model attached).
+func richDrawing(t *testing.T) *Content {
+	t.Helper()
+	c := NewContent()
+	c.SetModelReference("widget.opd")
+	if _, err := c.Sheets().Add(SheetSpec{Name: "Detail", Size: types.SheetSizeCustom, WidthMM: 500, HeightMM: 350}); err != nil {
+		t.Fatalf("Add sheet: %v", err)
+	}
+	sh := c.Sheets().Active()
+	sh.Sketches().Add("Sketch1")
+	if _, err := sh.Sketches().AddEntity("Sketch1", types.SketchLineEntity, [][2]float64{{0, 0}, {50, 25}}, 0); err != nil {
+		t.Fatalf("AddEntity: %v", err)
+	}
+	if _, err := sh.Sketches().AddHatchRegion("Sketch1", 10, 10, 40, 20, types.HatchANSI31, 2); err != nil {
+		t.Fatalf("AddHatchRegion: %v", err)
+	}
+	if _, err := sh.Annotations().AddRevisionCloud("Cloud1", 100, 100, 60, 40, "A"); err != nil {
+		t.Fatalf("AddRevisionCloud: %v", err)
+	}
+	if _, err := sh.Annotations().AddFeatureControlFrame("FCF1", 200, 150, types.CharacteristicFlatness, "0.05", nil); err != nil {
+		t.Fatalf("AddFeatureControlFrame: %v", err)
+	}
+	return c
+}
+
+// drawingMetrics is the structural fingerprint a snapshot round-trip must preserve: which sheet is
+// active, the sheet count, and the active sheet's view/sketch/annotation/dimension counts plus the
+// model reference.
+type drawingMetrics struct {
+	modelRef                              string
+	active, sheets, views, sketches, anns int
+}
+
+func metricsOf(c *Content) drawingMetrics {
+	sh := c.Sheets().Active()
+	return drawingMetrics{
+		modelRef: c.ModelReference(),
+		active:   c.Sheets().active,
+		sheets:   c.Sheets().Count(),
+		views:    sh.Views().Count(),
+		sketches: sh.Sketches().Count(),
+		anns:     sh.Annotations().Count(),
+	}
+}
+
+// TestDrawingSnapshotDeterministic: marshalling a fixed drawing twice yields identical bytes. The
+// undo stream's no-op-delta check (bytes.Equal) depends on this, or recomputes that change nothing
+// would record phantom undo steps.
+func TestDrawingSnapshotDeterministic(t *testing.T) {
+	c := richDrawing(t)
+	a, err := c.MarshalSnapshot()
+	if err != nil {
+		t.Fatalf("MarshalSnapshot: %v", err)
+	}
+	b, err := c.MarshalSnapshot()
+	if err != nil {
+		t.Fatalf("MarshalSnapshot 2: %v", err)
+	}
+	if !bytes.Equal(a, b) {
+		t.Error("MarshalSnapshot is not deterministic for a fixed drawing (breaks no-op detection)")
+	}
+}
+
+// TestDrawingSnapshotRoundTripPreservesState: a snapshot restored onto the SAME drawing reproduces
+// its structure exactly (the redo direction), byte-stable since there is no body to re-project.
+func TestDrawingSnapshotRoundTripPreservesState(t *testing.T) {
+	c := richDrawing(t)
+	want := metricsOf(c)
+	snap, err := c.MarshalSnapshot()
+	if err != nil {
+		t.Fatalf("MarshalSnapshot: %v", err)
+	}
+	if err := c.RestoreSnapshot(snap); err != nil {
+		t.Fatalf("RestoreSnapshot: %v", err)
+	}
+	if got := metricsOf(c); got != want {
+		t.Errorf("round-trip changed structure:\n got %+v\nwant %+v", got, want)
+	}
+	again, err := c.MarshalSnapshot()
+	if err != nil {
+		t.Fatalf("MarshalSnapshot after restore: %v", err)
+	}
+	if !bytes.Equal(snap, again) {
+		t.Errorf("drawing snapshot not byte-stable across round-trip (len %d vs %d)", len(snap), len(again))
+	}
+}
+
+// TestDrawingSnapshotRestoreReplacesOtherDrawing: restoring a snapshot onto a DIFFERENT, populated
+// drawing yields exactly the snapshot's state — proving RestoreSnapshot is a full replace (the
+// property undo relies on to navigate between arbitrary states), not a merge onto the default sheet.
+func TestDrawingSnapshotRestoreReplacesOtherDrawing(t *testing.T) {
+	src := richDrawing(t)
+	want := metricsOf(src)
+	snap, err := src.MarshalSnapshot()
+	if err != nil {
+		t.Fatalf("MarshalSnapshot: %v", err)
+	}
+
+	dst := NewContent()
+	dst.SetModelReference("other.opd")
+	dst.Sheets().Active().Sketches().Add("Foreign")
+	if _, err := dst.Sheets().Active().Sketches().AddEntity("Foreign", types.SketchCircleEntity, [][2]float64{{0, 0}}, 5); err != nil {
+		t.Fatalf("seed foreign sketch: %v", err)
+	}
+
+	if err := dst.RestoreSnapshot(snap); err != nil {
+		t.Fatalf("RestoreSnapshot onto other drawing: %v", err)
+	}
+	if got := metricsOf(dst); got != want {
+		t.Errorf("restore onto populated drawing did not fully replace:\n got %+v\nwant %+v", got, want)
+	}
+	if _, ok := dst.Sheets().Active().Sketches().ByName("Foreign"); ok {
+		t.Error("foreign drawing sketch survived the restore (merge, not replace)")
+	}
+}
+
+// TestEmptyDrawingSnapshotRoundTrips: a freshly created drawing snapshots and restores without
+// error, staying at its one default sheet — the baseline a document's undo stream captures on open.
+func TestEmptyDrawingSnapshotRoundTrips(t *testing.T) {
+	c := NewContent()
+	snap, err := c.MarshalSnapshot()
+	if err != nil {
+		t.Fatalf("MarshalSnapshot empty: %v", err)
+	}
+	if err := c.RestoreSnapshot(snap); err != nil {
+		t.Fatalf("RestoreSnapshot empty: %v", err)
+	}
+	if c.Sheets().Count() != 1 {
+		t.Errorf("empty drawing has %d sheets after round-trip, want 1 default", c.Sheets().Count())
+	}
+}
+
+// TestDrawingRestoreSnapshotRejectsBadJSON: the undo restore must reject a corrupt event payload
+// rather than apply a half-state. Malformed JSON is decoded before the sheet rebuild, so the drawing
+// is left untouched.
+func TestDrawingRestoreSnapshotRejectsBadJSON(t *testing.T) {
+	c := richDrawing(t)
+	before := metricsOf(c)
+	if err := c.RestoreSnapshot([]byte("{not valid json")); err == nil {
+		t.Error("RestoreSnapshot accepted invalid JSON")
+	}
+	if got := metricsOf(c); got != before {
+		t.Errorf("drawing mutated by a failed parse-restore:\n got %+v\nwant %+v", got, before)
+	}
+}


### PR DESCRIPTION
## What & why

Only `PartComponentDefinition` and `AssemblyComponentDefinition` implemented the `recipeStore` interface (`MarshalSnapshot` + `RestoreSnapshot`) the central undo seam records through. `DrawingContent` did not, so a drawing edit routed through the mutating-handler seam (#1426) **replicated** (`edit.committed`) but recorded **no undo step** — the drawing undo labels added in #1447 were dead.

This lands `DrawingContent` on the recipe-snapshot codec so wire drawing edits (views/annotations/dimensions/sketches/sheets) are now one undo step each, exactly like part/assembly edits — no router change needed (the labels were already in place).

## How

- **`model/drawing/recipe.go`** — extract a shared `buildRecipe` / `applyRecipeStruct` so the YAML save and the fast undo codec converge on one build/apply path. The apply path now also re-wires the BOM resolver: an undo restore does not re-run the host's `SetBOMResolver`, so a parts list would otherwise lose its rows after undo.
- **`model/drawing/snapshot.go`** (new) — `MarshalSnapshot`/`RestoreSnapshot` over JSON (the same transient-snapshot rationale as part/assembly, #1147). `RestoreSnapshot` clears the view-projection cache so the rebuilt views re-project against the referenced model.
- **`app/undo.go`** — add the `_ recipeStore = (*drawing.Content)(nil)` compile-time assertion, so a drawing document opens an undo stream and records each wire edit.

## Tests

- `model/drawing/snapshot_test.go` — determinism, round-trip-preserves-state (byte-stable), full-replace onto a different drawing, empty-drawing baseline, bad-JSON rejection leaves the drawing untouched.
- `addin/router` — `TestCentralSeamRecordsDrawingViewUndo`: `drawingViews.addBase` adds a view, undo removes it, redo restores it (the activation test); replication test note refreshed.

Full suite green, lint clean, `gofmt`/`vet` clean.

Closes #1448

🤖 Generated with [Claude Code](https://claude.com/claude-code)