### PR TITLE
Targeted parameter-edit invalidation: rebuild only the affected tail (#1414)

### DIFF
--- a/model/compdef/param_incremental_recompute_test.go
+++ b/model/compdef/param_incremental_recompute_test.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef_test
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/param"
+	"oblikovati.org/model/sketch"
+)
+
+// Incremental parameter recompute (Oblikovati#1414): a parameter edit must rebuild only the
+// features it actually affects (the dependent tail), not the whole program. Before this, every
+// parameter edit called MarkAllDirty, so editing one dimension on an N-feature part recomputed
+// all N features from index 0. These tests pin the new behaviour: the earliest feature whose
+// consumed-sketch dimension (or direct read) the edit touched, and its tail, recompute; the
+// clean prefix is reused; and an edit that reaches no feature recomputes nothing — while the
+// resulting geometry still equals a full rebuild.
+
+// buildExtrudeStack builds n independent extruded blocks, each on its own sketch offset along x.
+// The block at driveIndex is sized by a dimension referencing the user parameter driveParam, so
+// editing that parameter moves only that block (and the tail the engine rebuilds after it).
+func buildExtrudeStack(t *testing.T, def *compdef.PartComponentDefinition, n, driveIndex int, driveParam string) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		sk := def.Sketches().Add(sketch.XYPlane())
+		ox := float64(i) * 10
+		c0 := sk.Points().Add(math.P2(ox, 0))
+		c1 := sk.Points().Add(math.P2(ox+4, 0)) // 4 cm == 40 mm, the driveParam's initial value
+		c2 := sk.Points().Add(math.P2(ox+4, 3))
+		c3 := sk.Points().Add(math.P2(ox, 3))
+		sk.Lines().Add(c0, c1)
+		sk.Lines().Add(c1, c2)
+		sk.Lines().Add(c2, c3)
+		sk.Lines().Add(c3, c0)
+		if i == driveIndex {
+			if _, err := sk.DimensionConstraints().AddDistance(c0, c1, driveParam); err != nil {
+				t.Fatalf("AddDistance(%q): %v", driveParam, err)
+			}
+		}
+		feature.NewExtrudeFeatures(def.Features()).
+			AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 5 })
+	}
+}
+
+// recomputeCounts snapshots the per-feature recompute counters.
+func recomputeCounts(def *compdef.PartComponentDefinition) []int {
+	fs := def.Features()
+	counts := make([]int, fs.Count())
+	for i := range counts {
+		counts[i] = fs.Item(i).RecomputeCount()
+	}
+	return counts
+}
+
+// userParamID resolves a user parameter's id by name.
+func userParamID(t *testing.T, def *compdef.PartComponentDefinition, name string) param.ID {
+	t.Helper()
+	p, ok := def.Parameters().ByName(name)
+	if !ok {
+		t.Fatalf("parameter %q not found", name)
+	}
+	return p.ID()
+}
+
+func TestParameterEditRebuildsOnlyDependentTail(t *testing.T) {
+	def := compdef.NewPartComponentDefinition()
+	if _, err := def.Parameters().AddUserParameter("drive", "40 mm"); err != nil {
+		t.Fatalf("AddUserParameter: %v", err)
+	}
+	const n, driveIndex = 8, 5
+	buildExtrudeStack(t, def, n, driveIndex, "drive")
+	def.Recompute()
+	before := recomputeCounts(def)
+
+	if err := def.Parameters().SetExpression(userParamID(t, def, "drive"), "60 mm"); err != nil {
+		t.Fatalf("SetExpression: %v", err)
+	}
+	def.RecomputeAfterParameterEdit()
+	after := recomputeCounts(def)
+
+	for i := 0; i < n; i++ {
+		switch {
+		case i < driveIndex && after[i] != before[i]:
+			t.Errorf("feature %d (before the edited one) recomputed: %d→%d, want reused", i, before[i], after[i])
+		case i >= driveIndex && after[i] != before[i]+1:
+			t.Errorf("feature %d (the edited one or its tail) count %d→%d, want exactly +1", i, before[i], after[i])
+		}
+	}
+}
+
+func TestIndependentParameterEditRebuildsNothing(t *testing.T) {
+	def := compdef.NewPartComponentDefinition()
+	if _, err := def.Parameters().AddUserParameter("drive", "40 mm"); err != nil {
+		t.Fatalf("AddUserParameter(drive): %v", err)
+	}
+	if _, err := def.Parameters().AddUserParameter("unused", "10 mm"); err != nil {
+		t.Fatalf("AddUserParameter(unused): %v", err)
+	}
+	buildExtrudeStack(t, def, 6, 3, "drive")
+	def.Recompute()
+	before := recomputeCounts(def)
+
+	// "unused" drives no dimension and is read by nothing, so editing it must recompute no feature.
+	if err := def.Parameters().SetExpression(userParamID(t, def, "unused"), "20 mm"); err != nil {
+		t.Fatalf("SetExpression: %v", err)
+	}
+	def.RecomputeAfterParameterEdit()
+	after := recomputeCounts(def)
+
+	for i := range before {
+		if after[i] != before[i] {
+			t.Errorf("feature %d recomputed on an unrelated parameter edit: %d→%d", i, before[i], after[i])
+		}
+	}
+}
+
+func TestTargetedParameterEditMatchesFullRebuildGeometry(t *testing.T) {
+	// A part whose driven block is edited from 40 mm to 60 mm via the targeted seam...
+	edited := compdef.NewPartComponentDefinition()
+	if _, err := edited.Parameters().AddUserParameter("drive", "40 mm"); err != nil {
+		t.Fatalf("AddUserParameter: %v", err)
+	}
+	buildExtrudeStack(t, edited, 6, 3, "drive")
+	edited.Recompute()
+	if err := edited.Parameters().SetExpression(userParamID(t, edited, "drive"), "60 mm"); err != nil {
+		t.Fatalf("SetExpression: %v", err)
+	}
+	edited.RecomputeAfterParameterEdit()
+
+	// ...must match a part built from scratch at 60 mm (a full evaluation).
+	fresh := compdef.NewPartComponentDefinition()
+	if _, err := fresh.Parameters().AddUserParameter("drive", "60 mm"); err != nil {
+		t.Fatalf("AddUserParameter: %v", err)
+	}
+	buildExtrudeStack(t, fresh, 6, 3, "drive")
+	fresh.Recompute()
+
+	a, b := edited.RangeBox(), fresh.RangeBox()
+	if !a.Min.IsEqualTo(b.Min, 1e-9) || !a.Max.IsEqualTo(b.Max, 1e-9) {
+		t.Errorf("targeted-edit geometry [%v..%v] != full-rebuild geometry [%v..%v]", a.Min, a.Max, b.Min, b.Max)
+	}
+}

--- a/model/compdef/param_wholesale_recompute_test.go
+++ b/model/compdef/param_wholesale_recompute_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef_test
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// A parameter that reaches geometry through a path the engine cannot attribute to a single
+// feature — here a work-plane offset, which moves a hosted sketch and everything built on it —
+// must conservatively rebuild the whole program (Oblikovati#1414). Missing it would leave the
+// dependent feature on stale geometry, the exact silent-stale failure the targeted path must
+// never introduce. This test pins both halves: the rebuild happens (every feature recomputes)
+// AND the geometry follows the moved plane.
+func TestWorkPlaneOffsetParameterEditRebuildsWholeProgram(t *testing.T) {
+	def := compdef.NewPartComponentDefinition()
+	lift, err := def.Parameters().AddUserParameter("lift", "20 mm") // 2 cm
+	if err != nil {
+		t.Fatalf("AddUserParameter: %v", err)
+	}
+
+	// Feature 0: a plain block on XY (independent of lift).
+	base := def.Sketches().Add(sketch.XYPlane())
+	rectangle(base, 4, 3)
+	feature.NewExtrudeFeatures(def.Features()).
+		AddByDistanceExtent(base, 0, ops.NewBody, func() float64 { return 5 })
+
+	// Feature 1: a block on a work plane offset from XY by the "lift" parameter.
+	wp := def.WorkPlanes().AddByPlaneAndOffset(feature.OriginXYPlane, lift.ModelValue)
+	lifted := def.Sketches().Add(wp.Plane())
+	lifted.SetPlaneHost(func() sketch.Plane { return wp.Plane() })
+	rectangle(lifted, 4, 3)
+	feature.NewExtrudeFeatures(def.Features()).
+		AddByDistanceExtent(lifted, 0, ops.NewBody, func() float64 { return 5 })
+
+	def.Recompute()
+	before := recomputeCounts(def)
+	if z := def.RangeBox().Min.Z; z < -1e-6 || z > 1e-6 {
+		t.Fatalf("base block min.z = %v, want 0 before the lift edit", z)
+	}
+
+	if err := def.Parameters().SetExpression(userParamID(t, def, "lift"), "50 mm"); err != nil { // 5 cm
+		t.Fatalf("SetExpression: %v", err)
+	}
+	def.RecomputeAfterParameterEdit()
+
+	// The whole program rebuilds: even feature 0, independent of lift, recomputes (the
+	// conservative fallback for an unmodelled parameter path).
+	after := recomputeCounts(def)
+	for i := range before {
+		if after[i] != before[i]+1 {
+			t.Errorf("feature %d count %d→%d, want a full rebuild (+1)", i, before[i], after[i])
+		}
+	}
+	// The lifted block followed its work plane: the model now spans z ∈ [0, 5+5] (base 0..5,
+	// lifted 5..10), so the top moved from 7 cm to 10 cm.
+	if z := def.RangeBox().Max.Z; z < 9.999 || z > 10.001 {
+		t.Errorf("after lift→50 mm, model max.z = %v, want ~10 (lifted block at 5..10 cm)", z)
+	}
+}

--- a/model/compdef/part.go
+++ b/model/compdef/part.go
@@ -75,6 +75,13 @@ type PartComponentDefinition struct {
 	// centerlines are the flat pattern's cosmetic centerlines (M13-F06) — annotation lines that
 	// persist with the part.
 	centerlines []sheetmetal.CosmeticCenterline
+	// wholesaleParams are the parameters whose change must rebuild the whole feature program
+	// because they reach geometry through a path the engine does not model per-feature — a
+	// work-plane offset, a 3D-sketch dimension, a sketch's host plane. Captured each Recompute
+	// as (all parameters read during recompute) − (those precisely attributable to a 2D sketch
+	// or a feature's direct reads), so any unmodelled path is conservatively wholesale and a
+	// parameter edit never silently leaves stale geometry (Oblikovati#1414).
+	wholesaleParams map[param.ID]bool
 }
 
 // NewPartComponentDefinition returns an empty part content object with its feature
@@ -140,6 +147,21 @@ func (d *PartComponentDefinition) Features() *feature.PartFeatures { return d.fe
 // SurfaceBodies, advancing the geometry version. This is the part-level
 // orchestration that turns the feature history into the evaluated result.
 func (d *PartComponentDefinition) Recompute() {
+	// Capture every parameter read during the recompute (total footprint); the difference
+	// against what is precisely attributable to a 2D sketch or a feature's direct reads is
+	// the wholesale set a future parameter edit must rebuild the whole program for (#1414).
+	total := d.params.Track(d.recomputeGeometry)
+	d.recordWholesaleParams(total)
+	// Drop any change records produced before now (parameters added while building
+	// sketches/features, an earlier untargeted recompute) so the NEXT parameter edit sees
+	// only its own changes and can target precisely (Oblikovati#1414).
+	d.params.DrainChanged()
+	d.MarkChanged()
+}
+
+// recomputeGeometry runs the feature program and syncs the resulting bodies; Recompute wraps
+// it in a parameter-read capture (see Recompute).
+func (d *PartComponentDefinition) recomputeGeometry() {
 	// Re-solve sketches first so dimension expressions that reference parameters
 	// (e.g. "od/2") propagate into the geometry: a parameter edit updates the
 	// dimension's target value, and only a solve moves the profile to match.
@@ -163,21 +185,70 @@ func (d *PartComponentDefinition) Recompute() {
 	}
 	d.surfaces.Sync(d.features.Result()) // gather the result's sheet bodies as work surfaces (M20-F16)
 	d.refreshSketchReferences()
-	d.MarkChanged()
+}
+
+// recordWholesaleParams stores (total parameter reads − precisely-targetable reads) as the
+// set a parameter edit must rebuild the whole program for. The precise set is every 2D
+// sketch's dimension footprint plus every feature's direct reads — exactly what
+// MarkDirtyForParams can attribute to a feature. Anything else a recompute read (a
+// work-plane offset, a 3D-sketch dimension, a host-plane closure) is conservatively
+// wholesale, so no parameter path is ever silently skipped (Oblikovati#1414).
+func (d *PartComponentDefinition) recordWholesaleParams(total []param.ID) {
+	precise := map[param.ID]bool{}
+	for i := 0; i < d.sketches.Count(); i++ {
+		for _, id := range d.sketches.Item(i).ParameterFootprint() {
+			precise[id] = true
+		}
+	}
+	for _, id := range d.features.ParameterReads() {
+		precise[id] = true
+	}
+	d.wholesaleParams = map[param.ID]bool{}
+	for _, id := range total {
+		if !precise[id] {
+			d.wholesaleParams[id] = true
+		}
+	}
 }
 
 // RecomputeAfterParameterEdit rebuilds the part after a parameter value/equation/bool edit. A
-// parameter edit can change any feature's LIVE inputs — sketch dimensions, extrude-distance and
-// work-plane-offset closures — which the feature engine does NOT track as dependencies, so a plain
-// Recompute would find nothing dirty and hand back the cached, pre-edit bodies (silent stale
-// geometry). It marks the whole program dirty first, so the rebuild actually re-evaluates. This is
-// the single invalidation seam every parameter-edit path shares — the UI verb, XML import, and the
-// wire router — so they cannot diverge (Oblikovati#1413; before this, the app verb omitted the
-// MarkAllDirty the router did, leaving UI dimension edits stale). Until per-parameter feature edges
-// exist (targeted invalidation, #16) this is a full rebuild.
+// parameter edit can change a feature's LIVE inputs — sketch dimensions, sheet-metal thicknesses,
+// work-plane-offset closures — which the feature engine does not see as ordinary feature
+// dependencies, so a plain Recompute would find nothing dirty and hand back the cached, pre-edit
+// bodies (silent stale geometry). This is the single invalidation seam every parameter-edit path
+// shares — the UI verb, XML import, and the wire router — so they cannot diverge (Oblikovati#1413).
+//
+// It invalidates only the affected tail (Oblikovati#1414): the edit's changed parameters (and their
+// transitive dependents) come from the parameter graph; if any reaches geometry through a path the
+// engine cannot attribute to a feature (a work-plane offset, a 3D-sketch dimension — the wholesale
+// set captured last recompute) it falls back to a full rebuild, otherwise it dirties only the
+// features whose consumed-sketch dimensions or direct reads the edit touched. Editing one fillet's
+// driving parameter on a 1000-feature part then rebuilds that fillet's tail, not all 1000.
 func (d *PartComponentDefinition) RecomputeAfterParameterEdit() {
-	d.features.MarkAllDirty()
+	changed := d.params.DrainChanged()
+	if d.paramEditNeedsFullRebuild(changed) {
+		d.features.MarkAllDirty()
+	} else {
+		d.features.MarkDirtyForParams(changed)
+	}
 	d.Recompute()
+}
+
+// paramEditNeedsFullRebuild reports whether a parameter edit must rebuild the whole program
+// rather than a targeted tail: when nothing recorded as changed (an edit path that bypassed the
+// graph, or the first edit after load — rebuild conservatively), or when a changed parameter is in
+// the wholesale set (reaches geometry through an unmodelled path). Otherwise the changed
+// parameters are precisely attributable to features and MarkDirtyForParams handles them.
+func (d *PartComponentDefinition) paramEditNeedsFullRebuild(changed []param.ID) bool {
+	if len(changed) == 0 {
+		return true
+	}
+	for _, id := range changed {
+		if d.wholesaleParams[id] {
+			return true
+		}
+	}
+	return false
 }
 
 // refreshSketchPlanes re-reads each sketch's host work plane (if any), so sketches on
@@ -190,10 +261,14 @@ func (d *PartComponentDefinition) refreshSketchPlanes() {
 
 // solveSketches re-solves every 2D sketch so parameter-driven dimensions move the
 // geometry on recompute. Solving a fully-constrained sketch is idempotent; an
-// under-constrained one keeps its free DOFs.
+// under-constrained one keeps its free DOFs. Each solve is wrapped in a parameter-read
+// capture so the sketch records the dimension parameters that drive it (its footprint),
+// letting a parameter edit rebuild only the features that consume an affected sketch
+// (Oblikovati#1414).
 func (d *PartComponentDefinition) solveSketches() {
 	for i := 0; i < d.sketches.Count(); i++ {
-		d.sketches.Item(i).Solve()
+		sk := d.sketches.Item(i)
+		sk.SetParameterFootprint(d.params.Track(func() { sk.Solve() }))
 	}
 }
 

--- a/model/feature/engine.go
+++ b/model/feature/engine.go
@@ -212,8 +212,21 @@ func (fs *PartFeatures) PreviewResult(candidate Feature) ([]*topo.Body, error) {
 }
 
 // evaluate runs one feature, updating its health/cache and returning the running
-// body state after it.
+// body state after it. It captures the model parameters the feature read directly
+// (its suppression condition and its own recompute, e.g. a sheet-metal thickness)
+// into pf.paramReads, so a later parameter edit can skip the feature when it touches
+// none of them (Oblikovati#1414).
 func (fs *PartFeatures) evaluate(pf *PartFeature, bodies []*topo.Body, sick map[ID]bool) []*topo.Body {
+	if fs.params == nil {
+		return fs.evaluateBody(pf, bodies, sick)
+	}
+	var out []*topo.Body
+	pf.paramReads = fs.params.Track(func() { out = fs.evaluateBody(pf, bodies, sick) })
+	return out
+}
+
+// evaluateBody is evaluate without the parameter-read capture (see evaluate).
+func (fs *PartFeatures) evaluateBody(pf *PartFeature, bodies []*topo.Body, sick map[ID]bool) []*topo.Body {
 	pf.dirty = false
 	if pf.suppress || (pf.condition != nil && pf.condition.holds(fs.params)) {
 		pf.health = health.Health{Status: health.Suppressed}

--- a/model/feature/engine_param_invalidate.go
+++ b/model/feature/engine_param_invalidate.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"oblikovati.org/model/health"
+	"oblikovati.org/model/param"
+)
+
+// This file is the feature side of incremental parameter recompute (Oblikovati#1414):
+// after a parameter edit, dirty only the features the edit can change instead of the
+// whole program. The engine already rebuilds a CONTIGUOUS tail from the earliest dirty
+// feature (see Recompute), so the only decision is the earliest feature an edit affects;
+// everything before it is reused, everything from it rebuilds.
+
+// MarkDirtyForParams marks dirty the earliest feature that depends on any of the changed
+// parameters, and every feature after it. A feature depends on a changed parameter when it
+// read the parameter directly (paramReads — a sheet-metal thickness, a suppression
+// condition) or through a sketch it consumes (the sketch's captured dimension footprint). A
+// sick feature is always re-evaluated, so fixing the offending parameter can recover it.
+// Features before the earliest affected one are provably independent of the edit and keep
+// their cached bodies.
+//
+// The caller must already have excluded parameters that reach geometry through paths the
+// engine does not model per-feature (work-plane offsets, 3D-sketch dimensions); those force
+// a full rebuild upstream (see compdef RecomputeAfterParameterEdit). With an empty change
+// set this is a no-op — nothing dirties.
+func (fs *PartFeatures) MarkDirtyForParams(changed []param.ID) {
+	if len(changed) == 0 {
+		return
+	}
+	set := idSetOf(changed)
+	for i, pf := range fs.items {
+		if fs.featureAffectedByParams(pf, set) {
+			for _, tail := range fs.items[i:] {
+				tail.dirty = true
+			}
+			return
+		}
+	}
+}
+
+// featureAffectedByParams reports whether a parameter in changed reaches pf — directly
+// (its own reads) or through a sketch it consumes. A sick feature counts as affected so a
+// parameter fix retries it.
+func (fs *PartFeatures) featureAffectedByParams(pf *PartFeature, changed map[param.ID]bool) bool {
+	if pf.health.Status == health.Sick {
+		return true
+	}
+	if intersectsParams(pf.paramReads, changed) {
+		return true
+	}
+	for _, sk := range pf.ConsumedSketches() {
+		if intersectsParams(sk.ParameterFootprint(), changed) {
+			return true
+		}
+	}
+	return false
+}
+
+// ParameterReads returns every model parameter any feature read directly during the last
+// recompute (the union of per-feature paramReads). The part recompute unions it with the
+// consumed-sketch footprints to form the set it can target precisely; any parameter read
+// elsewhere during recompute (a work-plane offset, a 3D-sketch dimension) falls outside it
+// and forces a full rebuild — so an unmodelled path is never silently skipped.
+func (fs *PartFeatures) ParameterReads() []param.ID {
+	seen := map[param.ID]bool{}
+	var out []param.ID
+	for _, pf := range fs.items {
+		for _, id := range pf.paramReads {
+			if !seen[id] {
+				seen[id] = true
+				out = append(out, id)
+			}
+		}
+	}
+	return out
+}
+
+// idSetOf builds a lookup set from a parameter id slice.
+func idSetOf(ids []param.ID) map[param.ID]bool {
+	set := make(map[param.ID]bool, len(ids))
+	for _, id := range ids {
+		set[id] = true
+	}
+	return set
+}
+
+// intersectsParams reports whether any id in ids is in set.
+func intersectsParams(ids []param.ID, set map[param.ID]bool) bool {
+	for _, id := range ids {
+		if set[id] {
+			return true
+		}
+	}
+	return false
+}

--- a/model/feature/engine_param_invalidate_test.go
+++ b/model/feature/engine_param_invalidate_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/model/health"
+	"oblikovati.org/model/param"
+)
+
+// paramReader is a fake feature that reads one parameter directly during recompute (modelling a
+// sheet-metal thickness): the engine's read capture records it in paramReads, so MarkDirtyForParams
+// can target the feature.
+type paramReader struct {
+	p *param.Parameter
+}
+
+func (paramReader) Kind() string { return "paramReader" }
+func (f paramReader) Recompute(in Input) (Output, error) {
+	_ = f.p.ModelValue() // the captured direct read
+	return Output{Bodies: in.Bodies}, nil
+}
+
+// mustUserParam adds a user parameter to ps, failing the test on error.
+func mustUserParam(t *testing.T, ps *param.Parameters, name, expr string) *param.Parameter {
+	t.Helper()
+	p, err := ps.AddUserParameter(name, expr)
+	if err != nil {
+		t.Fatalf("AddUserParameter(%q): %v", name, err)
+	}
+	return p
+}
+
+func TestMarkDirtyForParamsTargetsDirectReaderAndTail(t *testing.T) {
+	ps := param.NewParameters()
+	a := mustUserParam(t, ps, "a", "10 mm")
+	b := mustUserParam(t, ps, "b", "20 mm")
+	fs := NewPartFeatures(ps, nil)
+	fs.Add(body())            // 0: independent of any parameter
+	fs.Add(paramReader{p: a}) // 1: reads a
+	fs.Add(body())            // 2: tail of feature 1
+	fs.Recompute()
+
+	// Editing a dirties the reader and its tail, not the clean prefix.
+	fs.MarkDirtyForParams([]param.ID{a.ID()})
+	fs.Recompute()
+	if c := fs.Item(0).RecomputeCount(); c != 1 {
+		t.Errorf("feature 0 (independent) recomputed again: count=%d, want 1", c)
+	}
+	if c1, c2 := fs.Item(1).RecomputeCount(), fs.Item(2).RecomputeCount(); c1 != 2 || c2 != 2 {
+		t.Errorf("reader/tail not rebuilt: counts=%d/%d, want 2/2", c1, c2)
+	}
+
+	// Editing b (read by no feature) dirties nothing.
+	fs.MarkDirtyForParams([]param.ID{b.ID()})
+	fs.Recompute()
+	for i := 0; i < fs.Count(); i++ {
+		if c := fs.Item(i).RecomputeCount(); (i == 0 && c != 1) || (i > 0 && c != 2) {
+			t.Errorf("feature %d recomputed on unrelated edit: count=%d", i, c)
+		}
+	}
+}
+
+func TestMarkDirtyForParamsAlwaysRetriesSickFeature(t *testing.T) {
+	ps := param.NewParameters()
+	unrelated := mustUserParam(t, ps, "x", "1 mm")
+	fs := NewPartFeatures(ps, nil)
+	fs.Add(body())   // 0
+	fs.Add(failer{}) // 1: goes sick
+	fs.Recompute()
+	if fs.Item(1).Health().Status != health.Sick {
+		t.Fatalf("failer health = %v, want sick", fs.Item(1).Health().Status)
+	}
+	before := fs.Item(1).RecomputeCount()
+
+	// An unrelated parameter edit must still retry the sick feature (fixing a parameter can
+	// recover it), even though it read no parameter.
+	fs.MarkDirtyForParams([]param.ID{unrelated.ID()})
+	fs.Recompute()
+	if after := fs.Item(1).RecomputeCount(); after != before+1 {
+		t.Errorf("sick feature not retried on parameter edit: count %d→%d", before, after)
+	}
+}
+
+func TestMarkDirtyForParamsEmptyChangeIsNoOp(t *testing.T) {
+	fs := NewPartFeatures(param.NewParameters(), nil)
+	fs.Add(body())
+	fs.Recompute()
+	fs.MarkDirtyForParams(nil)
+	fs.Recompute()
+	if c := fs.Item(0).RecomputeCount(); c != 1 {
+		t.Errorf("empty change set rebuilt a feature: count=%d, want 1", c)
+	}
+}

--- a/model/feature/part_feature.go
+++ b/model/feature/part_feature.go
@@ -5,6 +5,7 @@ package feature
 import (
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/model/health"
+	"oblikovati.org/model/param"
 )
 
 // PartFeature wraps a [Feature] with the engine's per-feature state: identity,
@@ -22,6 +23,13 @@ type PartFeature struct {
 	recomputes int
 	cached     []*topo.Body
 	seq        uint64 // global creation stamp; see model/seq
+
+	// paramReads is the model parameters this feature read DIRECTLY during its last
+	// evaluation — a sheet-metal thickness, a suppression condition (NOT the
+	// dimensions of a consumed sketch, which are reported via ConsumedSketches). The
+	// engine uses it, with the consumed sketches' footprints, to skip the feature on a
+	// parameter edit that touches none of them (Oblikovati#1414).
+	paramReads []param.ID
 }
 
 // ID returns the feature's stable handle (unchanged by rename).

--- a/model/param/graph.go
+++ b/model/param/graph.go
@@ -158,11 +158,14 @@ func (ps *Parameters) attachEdges(id ID, drivers []ID) {
 }
 
 // recomputeFrom re-evaluates id and its transitive dependents in dependency
-// order — and nothing else.
+// order — and nothing else. The reflowed set is exactly the parameters this edit
+// can change, so it is recorded for the feature engine's targeted invalidation
+// (Oblikovati#1414): a later DrainChanged hands it to the edit seam.
 func (ps *Parameters) recomputeFrom(id ID) {
 	dirty := ps.dependentsClosure(id)
 	dirty[id] = true
 	for _, n := range ps.topoOrder(dirty) {
+		ps.markChanged(n)
 		ps.evaluate(ps.byID[n])
 	}
 }

--- a/model/param/parameter.go
+++ b/model/param/parameter.go
@@ -51,6 +51,7 @@ func (h Health) OK() bool { return h.Status == Healthy }
 // parameters through a [Parameters] collection, never directly.
 type Parameter struct {
 	id     ID
+	owner  *Parameters // the collection that minted this parameter; nil for a bare test parameter
 	name   string
 	expr   Expr
 	value  Quantity
@@ -106,7 +107,17 @@ func (p *Parameter) Value() Quantity { return p.value }
 
 // ModelValue returns the value the model consumes after the tolerance band and
 // the parameter's model-value selection are applied (database units).
+//
+// This is the single accessor every geometry-driving consumer reads through — a
+// sketch dimension's residual, a work-plane offset closure, a sheet-metal
+// thickness, a suppression condition. So it is also the seam that records a read
+// during a footprint capture ([Parameters.Track]): the engine learns which
+// parameters a feature/sketch actually consumed, and a later edit re-evaluates
+// only those (Oblikovati#1414) instead of the whole program.
 func (p *Parameter) ModelValue() float64 {
+	if p.owner != nil {
+		p.owner.recordRead(p.id)
+	}
 	switch p.ModelValueType() {
 	case Upper:
 		return p.value.Value + p.tol.Upper

--- a/model/param/parameters.go
+++ b/model/param/parameters.go
@@ -31,6 +31,10 @@ type Parameters struct {
 	// order, with their persistent id counter. See derived_table.go.
 	derivedTables []*DerivedParameterTable
 	nextTableID   int
+
+	// Incremental-recompute support (Oblikovati#1414); see tracking.go.
+	readSink idSet // when non-nil, every ModelValue read records its id here (a footprint capture)
+	changed  idSet // parameters whose value an edit re-evaluated since the last DrainChanged
 }
 
 // idSet is a set of parameter ids.
@@ -194,7 +198,7 @@ func (ps *Parameters) add(name string, kind ParameterKind) (*Parameter, error) {
 		return nil, fmt.Errorf("param: a parameter named %q already exists", name)
 	}
 	p := &Parameter{
-		id: ps.nextID, name: name, kind: kind, Visible: true,
+		id: ps.nextID, owner: ps, name: name, kind: kind, Visible: true,
 		DisplayFormat: DisplayFormatDecimal, modelValueType: Nominal,
 		CustomProperty: DefaultCustomPropertyFormat(),
 	}

--- a/model/param/tracking.go
+++ b/model/param/tracking.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package param
+
+// This file is the parameter side of incremental recompute (Oblikovati#1414): two
+// small mechanisms that let the feature engine dirty only the features a parameter
+// edit can change, instead of marking the whole program dirty and rebuilding every
+// feature from index 0.
+//
+//   - Read tracking ([Track]) records which parameters a piece of work read through
+//     [Parameter.ModelValue]. Capturing it around a sketch solve yields the dimension
+//     parameters that position that sketch; around a feature recompute, the parameters
+//     that feature consumes directly (a sheet-metal thickness, a suppression condition).
+//   - Change tracking ([DrainChanged]) records which parameters an edit actually
+//     re-evaluated (the edited parameter and its transitive dependents — recorded in
+//     graph.recomputeFrom). The edit seam intersects the two: a feature is dirty only
+//     when a parameter it reads is among the parameters the edit changed.
+//
+// Both are single-threaded by construction — the model recomputes on one goroutine —
+// so neither needs synchronization.
+
+// recordRead notes that parameter id was read, when a footprint capture is active.
+// It is a no-op (one nil check) outside a [Track], so normal solves and renders pay
+// nothing.
+func (ps *Parameters) recordRead(id ID) {
+	if ps.readSink != nil {
+		ps.readSink[id] = true
+	}
+}
+
+// Track runs fn while recording every parameter read through [Parameter.ModelValue],
+// returning the ids read. Tracks compose: reads captured by an inner Track also bubble
+// up to an enclosing one, so wrapping a whole recompute captures the union while each
+// nested sketch/feature still gets its own footprint.
+//
+// Example: deps := params.Track(func() { sketch.Solve() }) // the dimensions that drive sketch
+func (ps *Parameters) Track(fn func()) []ID {
+	prev := ps.readSink
+	sink := idSet{}
+	ps.readSink = sink
+	fn()
+	ps.readSink = prev
+	if prev != nil {
+		for id := range sink {
+			prev[id] = true
+		}
+	}
+	return keysOf(sink)
+}
+
+// markChanged records that an edit re-evaluated parameter id (called from the graph
+// reflow). The set accumulates until [DrainChanged] reads and clears it.
+func (ps *Parameters) markChanged(id ID) {
+	if ps.changed == nil {
+		ps.changed = idSet{}
+	}
+	ps.changed[id] = true
+}
+
+// DrainChanged returns the parameters re-evaluated since the previous call and clears
+// the record. The edit seam ([compdef] RecomputeAfterParameterEdit) uses it to learn
+// exactly which parameters an edit changed, so it can dirty only their dependent
+// features. An empty result means no parameter value changed (or the changes predate
+// tracking) — the caller then rebuilds conservatively.
+func (ps *Parameters) DrainChanged() []ID {
+	out := keysOf(ps.changed)
+	ps.changed = nil
+	return out
+}

--- a/model/param/tracking_test.go
+++ b/model/param/tracking_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package param
+
+import (
+	"sort"
+	"testing"
+)
+
+// sortedIDs returns ids sorted, for order-independent comparison.
+func sortedIDs(ids []ID) []ID {
+	out := append([]ID(nil), ids...)
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+func TestTrackRecordsModelValueReads(t *testing.T) {
+	ps := NewParameters()
+	a := mustAdd(t, ps, "a", "10 mm")
+	b := mustAdd(t, ps, "b", "20 mm")
+	mustAdd(t, ps, "c", "30 mm") // never read
+
+	got := ps.Track(func() {
+		_ = a.ModelValue()
+		_ = b.ModelValue()
+		_ = a.ModelValue() // a re-read must not duplicate
+	})
+
+	want := sortedIDs([]ID{a.ID(), b.ID()})
+	if g := sortedIDs(got); len(g) != 2 || g[0] != want[0] || g[1] != want[1] {
+		t.Errorf("Track captured %v, want %v (only the parameters actually read)", g, want)
+	}
+}
+
+func TestTrackOutsideCaptureRecordsNothing(t *testing.T) {
+	ps := NewParameters()
+	a := mustAdd(t, ps, "a", "10 mm")
+	// A read with no active capture must be a no-op (no panic, nothing leaked into a later Track).
+	_ = a.ModelValue()
+	if got := ps.Track(func() {}); len(got) != 0 {
+		t.Errorf("Track with no reads captured %v, want empty", got)
+	}
+}
+
+func TestNestedTrackBubblesReadsToOuter(t *testing.T) {
+	ps := NewParameters()
+	a := mustAdd(t, ps, "a", "10 mm")
+	b := mustAdd(t, ps, "b", "20 mm")
+
+	var inner []ID
+	outer := ps.Track(func() {
+		_ = a.ModelValue()
+		inner = ps.Track(func() { _ = b.ModelValue() })
+	})
+
+	if len(inner) != 1 || inner[0] != b.ID() {
+		t.Errorf("inner Track captured %v, want [b]", inner)
+	}
+	// The outer capture must see BOTH its own read and the inner one (composition).
+	want := sortedIDs([]ID{a.ID(), b.ID()})
+	if g := sortedIDs(outer); len(g) != 2 || g[0] != want[0] || g[1] != want[1] {
+		t.Errorf("outer Track captured %v, want %v", g, want)
+	}
+}
+
+func TestDrainChangedReturnsEditedAndDependents(t *testing.T) {
+	ps := NewParameters()
+	w := mustAdd(t, ps, "width", "10 cm")
+	h := mustAdd(t, ps, "height", "2 * width") // depends on width
+	mustAdd(t, ps, "other", "3 cm")
+
+	ps.DrainChanged() // clear the records from construction
+
+	if err := ps.SetExpression(w.ID(), "15 cm"); err != nil {
+		t.Fatalf("SetExpression: %v", err)
+	}
+	got := sortedIDs(ps.DrainChanged())
+	want := sortedIDs([]ID{w.ID(), h.ID()}) // the edited parameter and its transitive dependent
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("DrainChanged = %v, want %v (edited + dependents, not the independent parameter)", got, want)
+	}
+	// Draining is destructive: a second drain is empty.
+	if again := ps.DrainChanged(); len(again) != 0 {
+		t.Errorf("second DrainChanged = %v, want empty", again)
+	}
+}

--- a/model/sketch/sketch.go
+++ b/model/sketch/sketch.go
@@ -185,7 +185,19 @@ type Sketch struct {
 	// was built for (counts + point coordinates), so any edit invalidates it.
 	profilesCache *Profiles
 	profilesSig   uint64
+
+	// paramFootprint is the model parameters this sketch's last solve read (its
+	// dimension targets), captured by the part recompute (Oblikovati#1414). A
+	// parameter edit re-solves and rebuilds only the features whose consumed sketch
+	// footprint it touches, instead of the whole program.
+	paramFootprint []param.ID
 }
+
+// SetParameterFootprint records the parameters the sketch's solve read; ParameterFootprint
+// returns them. The part recompute captures the footprint around each solve (param.Track)
+// so the feature engine can dirty only the features a parameter edit actually affects.
+func (s *Sketch) SetParameterFootprint(ids []param.ID) { s.paramFootprint = ids }
+func (s *Sketch) ParameterFootprint() []param.ID       { return s.paramFootprint }
 
 // Plane returns the sketch's host plane.
 func (s *Sketch) Plane() Plane { return s.plane }


### PR DESCRIPTION
## What & why

A parameter edit went through `MarkAllDirty`, so editing **one** dimension on an N-feature part rebuilt **all N** features from index 0 — defeating the engine's canonical clean-prefix reuse. On a 1000-feature part, changing one fillet radius recomputed 1000 features. This wires param→feature dependency so an edit dirties only the features it can actually change.

Closes #1414.

## How it stays correct (no silent stale geometry)

The hard part isn't speed — it's never reusing a feature that should rebuild. The design guarantees completeness by construction:

- **param** — `ModelValue()` records reads into an active sink (`Parameters.Track`); the graph reflow records which parameters an edit changed (`DrainChanged`). Two small primitives, both no-ops outside an edit.
- **compdef.Recompute** captures the **total** parameters read during a rebuild and subtracts those precisely attributable to a 2D sketch's dimensions or a feature's direct reads. The remainder — work-plane offsets, 3D-sketch dimensions, host-plane closures (paths the engine can't map to a single feature) — becomes the **wholesale** set.
- **RecomputeAfterParameterEdit** rebuilds the whole program when a changed parameter is wholesale (or nothing recorded — e.g. first edit after load); otherwise it dirties from the earliest feature whose consumed-sketch footprint (`SketchConsumer.ConsumedSketches`) or direct reads the edit touched. The engine already rebuilds a contiguous tail, so the earliest affected feature is the only decision; everything before it is reused. A **sick** feature is always retried so a parameter fix can recover it.

Net: any parameter path the engine doesn't model per-feature falls back to the proven full rebuild — an unmodelled path is never silently skipped.

## Acceptance criteria (issue)

- [x] Parameter edits dirty only dependent features; the `MarkAllDirty` on the edit seam is replaced by targeted invalidation (the remaining `MarkAllDirty` sites — document update, sheet-metal style — are legitimately wholesale).
- [x] Recompute-count test confirms only the affected tail rebuilds.
- [x] No geometry regression vs full rebuild.

## Tests

- `TestParameterEditRebuildsOnlyDependentTail` — 8 extrudes, edit the parameter feeding #5: features 0–4 reused, 5–7 rebuilt (exactly +1).
- `TestIndependentParameterEditRebuildsNothing` — editing a parameter read by nothing recomputes no feature.
- `TestTargetedParameterEditMatchesFullRebuildGeometry` — targeted edit ≡ a from-scratch build at the target value.
- `TestWorkPlaneOffsetParameterEditRebuildsWholeProgram` — the wholesale safety valve: a work-plane-offset parameter edit rebuilds the whole program **and** the geometry follows the moved plane.
- param: `Track` (capture / nesting / no-op), `DrainChanged`. feature: `MarkDirtyForParams` direct-read, sick-retry, empty-noop.

Lint clean (`golangci-lint`), `go vet` clean, `-race` clean, coverage >80% on all touched packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)