### PR TITLE
Undo storage: delta log + sparse checkpoints (memory architecture for #1424)

### DIFF
--- a/app/bug_report_diag.go
+++ b/app/bug_report_diag.go
@@ -43,10 +43,29 @@ func (s *Session) TransactionLog() []report.TransactionEvent {
 			Time:     e.when.Format("15:04:05"),
 			Document: e.doc,
 			Label:    e.label,
-			Recipe:   string(e.recipe),
+			Recipe:   s.auditRecipe(e),
 		})
 	}
 	return out
+}
+
+// auditRecipe reconstructs one audit event's after-step recipe from its document's delta log
+// (#1424), or "" when the step recorded no recipe (non-recipe content, a marshal failure, or a
+// position since trimmed by the audit bound). The bug report renders the reconstructed recipe
+// exactly as the old full-copy form did, so a triager still sees the replayable command payload.
+func (s *Session) auditRecipe(e sessionTxEvent) string {
+	if e.pos < 0 {
+		return ""
+	}
+	log, ok := s.txAudit[e.docID]
+	if !ok {
+		return ""
+	}
+	r, err := log.At(e.pos)
+	if err != nil {
+		return ""
+	}
+	return string(r)
 }
 
 // documentMarshaler is the optional capability of the session's store that renders a

--- a/app/session.go
+++ b/app/session.go
@@ -10,6 +10,7 @@ import (
 
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app/options"
+	"oblikovati.org/command"
 	"oblikovati.org/event"
 	"oblikovati.org/model/bodyapi"
 	"oblikovati.org/model/bom"
@@ -124,50 +125,51 @@ type Session struct {
 	themeStore                *theme.Store
 	materials                 *material.Library
 	materialStore             *material.Store
-	recentDocuments           []string                       // recently opened/saved paths, most recent first (M04-F05)
-	fileMetadata              map[doc.ID][]FileMetadataValue // last save's PopulateFileMetadata harvest (M04-F05)
-	notice                    string                         // last user-facing notice (e.g. a failed-commit reason)
-	visualStyle               renderer.VisualStyle           // how the scene is drawn (View tab's Visual Style)
-	lightingStyle             renderer.LightingStyleID       // active lighting preset (View tab's Lighting Style)
-	lighting                  renderer.SceneLighting         // the live lighting rig (resolved from the style, then edited)
-	colorSchemes              *colorscheme.Registry          // application color schemes — viewport bg + highlight/select palette (M16-F06 #642)
-	colorSchemeRev            uint64                         // bumped on scheme/background change; the head re-applies the viewport colors (live preview)
-	styles                    *style.Manager                 // document color styles + style-library cascade (M16-F02 #403/#408)
-	bodyColorStyles           map[string]string              // body reference key → assigned color-style name (M16-F02 #403/#408)
-	displayOptions            display.Options                // app-level display options that parameterize the display modes (M16-F07 #643)
-	chamferFlatCorners        bool                           // default three-edge-corner treatment for new chamfers
-	chamferConcaveOut         bool                           // default concave-edge strategy for new chamfers (true ⇒ outward fill)
-	paramsDialogOpen          bool                           // the Manage ▸ Parameters dialog is open
-	keymapEditorOpen          bool                           // the Tools ▸ Customize Keyboard panel is open (M05-F17)
-	lightingPanelOpen         bool                           // the View ▸ Lighting settings panel is open
-	namedViewsPanelOpen       bool                           // the View ▸ Named Views panel is open (M16-F03 #404)
-	colorStylesPanelOpen      bool                           // the Color Styles panel is open (M16-F02 #403/#408)
-	displaySettingsOpen       bool                           // the Display Settings dialog is open (M16-F07 #643)
-	unitsSettingsOpen         bool                           // the Document Settings ▸ Units dialog is open (#146)
-	historyBrowserOpen        bool                           // the Edit ▸ History Browser window is open
-	loadEnvRequested          bool                           // a "Load HDR…" was requested; the head opens the file dialog
-	meshImportRequested       bool                           // a "Place Mesh…" was requested; the head opens the file dialog (#700)
-	pointCloudRequested       bool                           // an "Import Point Cloud…" was requested; the head opens the file dialog (#645)
-	scriptConsoleOpen         bool                           // the Manage ▸ Scripts ▸ Script Console panel is open
-	addInCatalogueRequested   bool                           // a Get Started ▸ AddIn Catalogue was requested; the head opens the catalogue window
-	preferencesRequested      bool                           // a Get Started ▸ Preferences was requested; the head opens the Preferences window
-	capturePath               string                         // a requested viewport PNG capture path; the head writes it after render
-	captureWindowPath         string                         // a requested whole-window PNG capture path; the head writes it after the frame composites
-	normalDebug               bool                           // viewport normal-debug render (front green / back red); head reads each frame
-	meshColors                bool                           // viewport mesh-debug-colors render (each face/triangle a distinct color)
-	meshColorsPerTri          bool                           // when meshColors: color per TRIANGLE (else per B-rep face)
-	editScope                 editScope                      // while editing a node, hide everything created after it (issue #132)
-	asmBodies                 assemblyBodyCache              // memoized world-space assembly bodies + their occurrences (#769)
-	pickIndex                 *assemblyPickIndex             // BVH over placement AABBs for sub-linear ray picking (M34-F5)
-	bomPanelOpen              bool                           // the Assemble ▸ Bill of Materials panel is open (#768)
-	bomViewKind               bom.ViewKind                   // the BOM panel's selected view (structured / parts-only)
-	updateCheckRequested      bool                           // Help ▸ Check for Updates was clicked; the head runs the (network) check
-	pendingUpdate             *update.Result                 // last update-check outcome to show in the update window; nil = closed
-	txEvents                  []sessionTxEvent               // append-only transaction log since app open (for bug reports)
-	bugReport                 bugReportState                 // in-progress Help ▸ Report Bug capture+submit, if any
-	bugOutcome                atomic.Pointer[bugResult]      // submit goroutine → frame loop handoff (session never touched off-thread)
-	bugSubmitter              bugSubmitter                   // injectable reporting endpoint (DI; lazily defaults to real HTTP)
-	addInCat                  addInCatalogue                 // Add-In Catalogue browse/install state (#1164)
+	recentDocuments           []string                        // recently opened/saved paths, most recent first (M04-F05)
+	fileMetadata              map[doc.ID][]FileMetadataValue  // last save's PopulateFileMetadata harvest (M04-F05)
+	notice                    string                          // last user-facing notice (e.g. a failed-commit reason)
+	visualStyle               renderer.VisualStyle            // how the scene is drawn (View tab's Visual Style)
+	lightingStyle             renderer.LightingStyleID        // active lighting preset (View tab's Lighting Style)
+	lighting                  renderer.SceneLighting          // the live lighting rig (resolved from the style, then edited)
+	colorSchemes              *colorscheme.Registry           // application color schemes — viewport bg + highlight/select palette (M16-F06 #642)
+	colorSchemeRev            uint64                          // bumped on scheme/background change; the head re-applies the viewport colors (live preview)
+	styles                    *style.Manager                  // document color styles + style-library cascade (M16-F02 #403/#408)
+	bodyColorStyles           map[string]string               // body reference key → assigned color-style name (M16-F02 #403/#408)
+	displayOptions            display.Options                 // app-level display options that parameterize the display modes (M16-F07 #643)
+	chamferFlatCorners        bool                            // default three-edge-corner treatment for new chamfers
+	chamferConcaveOut         bool                            // default concave-edge strategy for new chamfers (true ⇒ outward fill)
+	paramsDialogOpen          bool                            // the Manage ▸ Parameters dialog is open
+	keymapEditorOpen          bool                            // the Tools ▸ Customize Keyboard panel is open (M05-F17)
+	lightingPanelOpen         bool                            // the View ▸ Lighting settings panel is open
+	namedViewsPanelOpen       bool                            // the View ▸ Named Views panel is open (M16-F03 #404)
+	colorStylesPanelOpen      bool                            // the Color Styles panel is open (M16-F02 #403/#408)
+	displaySettingsOpen       bool                            // the Display Settings dialog is open (M16-F07 #643)
+	unitsSettingsOpen         bool                            // the Document Settings ▸ Units dialog is open (#146)
+	historyBrowserOpen        bool                            // the Edit ▸ History Browser window is open
+	loadEnvRequested          bool                            // a "Load HDR…" was requested; the head opens the file dialog
+	meshImportRequested       bool                            // a "Place Mesh…" was requested; the head opens the file dialog (#700)
+	pointCloudRequested       bool                            // an "Import Point Cloud…" was requested; the head opens the file dialog (#645)
+	scriptConsoleOpen         bool                            // the Manage ▸ Scripts ▸ Script Console panel is open
+	addInCatalogueRequested   bool                            // a Get Started ▸ AddIn Catalogue was requested; the head opens the catalogue window
+	preferencesRequested      bool                            // a Get Started ▸ Preferences was requested; the head opens the Preferences window
+	capturePath               string                          // a requested viewport PNG capture path; the head writes it after render
+	captureWindowPath         string                          // a requested whole-window PNG capture path; the head writes it after the frame composites
+	normalDebug               bool                            // viewport normal-debug render (front green / back red); head reads each frame
+	meshColors                bool                            // viewport mesh-debug-colors render (each face/triangle a distinct color)
+	meshColorsPerTri          bool                            // when meshColors: color per TRIANGLE (else per B-rep face)
+	editScope                 editScope                       // while editing a node, hide everything created after it (issue #132)
+	asmBodies                 assemblyBodyCache               // memoized world-space assembly bodies + their occurrences (#769)
+	pickIndex                 *assemblyPickIndex              // BVH over placement AABBs for sub-linear ray picking (M34-F5)
+	bomPanelOpen              bool                            // the Assemble ▸ Bill of Materials panel is open (#768)
+	bomViewKind               bom.ViewKind                    // the BOM panel's selected view (structured / parts-only)
+	updateCheckRequested      bool                            // Help ▸ Check for Updates was clicked; the head runs the (network) check
+	pendingUpdate             *update.Result                  // last update-check outcome to show in the update window; nil = closed
+	txEvents                  []sessionTxEvent                // append-only transaction log since app open (for bug reports)
+	txAudit                   map[doc.ID]*command.SnapshotLog // per-document delta log the audit's recipes are reconstructed from (#1424)
+	bugReport                 bugReportState                  // in-progress Help ▸ Report Bug capture+submit, if any
+	bugOutcome                atomic.Pointer[bugResult]       // submit goroutine → frame loop handoff (session never touched off-thread)
+	bugSubmitter              bugSubmitter                    // injectable reporting endpoint (DI; lazily defaults to real HTTP)
+	addInCat                  addInCatalogue                  // Add-In Catalogue browse/install state (#1164)
 }
 
 // Notice returns the last user-facing notice (a failed commit's reason), or "" — shown in
@@ -205,7 +207,7 @@ func newSession(store doc.Store) *Session {
 		store:     store,
 		workspace: doc.NewWorkspace(store),
 		commands:  NewCommandManager(),
-		histories: map[doc.ID]*docHistory{},
+		histories: map[doc.ID]*docHistory{}, txAudit: map[doc.ID]*command.SnapshotLog{},
 		bus:       event.NewBus(),
 		selection: NewSelection(), selectionFilterState: NewSelectionFilterState(),
 		camera:         scene.NewCamera(800, 600),

--- a/app/undo.go
+++ b/app/undo.go
@@ -23,13 +23,16 @@ const maxSessionTxEvents = 2000
 
 // sessionTxEvent is one committed transaction recorded for the life of the session — an
 // append-only audit of what the user did since the app opened, independent of the
-// per-document undo stacks (which shrink on undo). recipe is the document's full parametric
-// recipe after the step (the complete command payload), so the sequence replays precisely.
+// per-document undo stacks (which shrink on undo). The document's after-step recipe (the
+// replayable command payload) is delta-encoded in the per-document audit log (#1424); the
+// event keeps only the document id and the position there, so the audit no longer retains a
+// full recipe copy per step (the old form was ~2 GB at the 2000-event bound on a large model).
 type sessionTxEvent struct {
-	when   time.Time
-	doc    string
-	label  string
-	recipe []byte
+	when  time.Time
+	doc   string
+	docID doc.ID
+	label string
+	pos   int // position in s.txAudit[docID] the after-step recipe reconstructs from
 }
 
 // watchTransactions appends every committed transaction (on any document) to the session's
@@ -39,23 +42,76 @@ type sessionTxEvent struct {
 // commitRecipeDelta advances the snapshot, so the content's recipe is the after-state.
 func (s *Session) watchTransactions() {
 	event.Subscribe(s.bus, event.After, func(_ event.Context, e TransactionCommitted) event.Outcome {
-		name, recipe := "untitled", []byte(nil)
-		if d, ok := s.workspace.ByID(e.Document); ok {
-			name = d.DisplayName()
-			if rc, ok := d.Content().(recipeStore); ok {
-				if r, err := rc.MarshalSnapshot(); err != nil {
-					s.reportSnapshotFailure("capturing the session-log recipe", d, err) // #1425: not silent
-				} else {
-					recipe = r
-				}
-			}
-		}
-		s.txEvents = append(s.txEvents, sessionTxEvent{when: time.Now().UTC(), doc: name, label: e.Label, recipe: recipe})
-		if len(s.txEvents) > maxSessionTxEvents {
-			s.txEvents = s.txEvents[len(s.txEvents)-maxSessionTxEvents:]
-		}
+		s.appendAuditEvent(e.Document, e.Label)
 		return event.Continue()
 	})
+}
+
+// appendAuditEvent records one committed step in the session audit, delta-encoding the
+// document's after-step recipe into its per-document log and keeping only the position there
+// (#1424). pos is -1 when the step has no recipe to replay (non-recipe content, or a marshal
+// failure already surfaced), which the report renders as an empty recipe — the old behaviour.
+func (s *Session) appendAuditEvent(id doc.ID, label string) {
+	name, pos := "untitled", -1
+	if d, ok := s.workspace.ByID(id); ok {
+		name = d.DisplayName()
+		if rc, ok := d.Content().(recipeStore); ok {
+			if r, err := rc.MarshalSnapshot(); err != nil {
+				s.reportSnapshotFailure("capturing the session-log recipe", d, err) // #1425: not silent
+			} else {
+				pos = s.auditLog(id).Append(r)
+			}
+		}
+	}
+	s.txEvents = append(s.txEvents, sessionTxEvent{when: time.Now().UTC(), doc: name, docID: id, label: label, pos: pos})
+	s.boundAuditLog()
+}
+
+// auditLog returns the per-document delta log the session audit appends recipes to, creating it
+// on first use.
+func (s *Session) auditLog(id doc.ID) *command.SnapshotLog {
+	log, ok := s.txAudit[id]
+	if !ok {
+		log = command.NewSnapshotLog()
+		s.txAudit[id] = log
+	}
+	return log
+}
+
+// boundAuditLog caps the audit at maxSessionTxEvents, dropping the oldest events and reclaiming
+// the audit-log positions no surviving event still references — per document, trimming everything
+// before its earliest live position, and discarding a document's log once nothing references it.
+// This keeps the audit's memory bounded without ever holding a full recipe copy per step (#1424).
+func (s *Session) boundAuditLog() {
+	if len(s.txEvents) <= maxSessionTxEvents {
+		return
+	}
+	s.txEvents = s.txEvents[len(s.txEvents)-maxSessionTxEvents:]
+	reclaimAuditLogs(s.txEvents, s.txAudit)
+}
+
+// reclaimAuditLogs frees the audit-log positions no surviving event references: per document it
+// trims everything before that document's earliest live position, and discards a document's log
+// entirely once nothing references it. Pure over its arguments so the bound's bookkeeping is
+// unit-testable without driving thousands of events (#1424).
+func reclaimAuditLogs(live []sessionTxEvent, audit map[doc.ID]*command.SnapshotLog) {
+	earliest := map[doc.ID]int{}
+	for _, e := range live {
+		if e.pos < 0 {
+			continue
+		}
+		if p, ok := earliest[e.docID]; !ok || e.pos < p {
+			earliest[e.docID] = e.pos
+		}
+	}
+	for id, log := range audit {
+		keep, ok := earliest[id]
+		if !ok {
+			delete(audit, id)
+			continue
+		}
+		_ = log.TruncateFront(keep)
+	}
 }
 
 // recipeStore is the document content the app's undo stream records: content whose entire
@@ -89,7 +145,15 @@ var (
 // stream begins when the document is opened (snapshot captures the open state), per
 // the event-sourcing model: current state is the fold of all events since open.
 type docHistory struct {
-	hist     *command.History
+	hist *command.History
+	// log delta-encodes every cursor position of this document's stream (Oblikovati#1424):
+	// position 0 is the open-state baseline, each recorded edit appends its after-snapshot, and
+	// a RecipeEvent stores only its before/after positions. It replaces the two full-recipe
+	// copies the old per-edit storage held, so a long session's undo stream is O(N) not O(N²).
+	log *command.SnapshotLog
+	// snapshot is the recipe the model holds at the current cursor position, kept verbatim for
+	// the no-op-delta check and the empty-baseline guard (#1425); the navigable stream lives in
+	// log.
 	snapshot []byte
 
 	// groupDepth > 0 means a bounded transaction is open: per-edit recording is
@@ -165,9 +229,12 @@ func (s *Session) documentHistory(d *doc.Document) *docHistory {
 	if dh, ok := s.histories[d.ID()]; ok {
 		return dh
 	}
-	dh := &docHistory{hist: command.NewHistory()}
+	dh := &docHistory{hist: command.NewHistory(), log: command.NewSnapshotLog()}
 	if err := dh.resync(d); err != nil {
 		s.reportSnapshotFailure("capturing the open-state baseline", d, err) // #1425: empty baseline guarded at commit
+	}
+	if len(dh.snapshot) > 0 {
+		dh.log.Append(dh.snapshot) // seed position 0 with the open-state baseline
 	}
 	dh.hist.OnChange(func() {
 		d.MarkDirty()
@@ -224,7 +291,13 @@ func (s *Session) commitRecipeDelta(d *doc.Document, dh *docHistory, content rec
 		s.revertVetoedCommit(d, dh, content, label, out.Reason)
 		return
 	}
-	dh.hist.Record(command.NewRecipeEvent(label, dh.snapshot, after, content))
+	// Append the after-snapshot as a new stream position and record the event by position, not
+	// by value (Oblikovati#1424). beforePos is the current cursor (hist.Len()); truncating the
+	// log to it drops any redo-branch positions in lockstep with Record clearing the redo stack.
+	beforePos := dh.hist.Len()
+	dh.log.TruncateTo(beforePos + 1)
+	afterPos := dh.log.Append(after)
+	dh.hist.Record(command.NewRecipeEvent(label, beforePos, afterPos, dh.log, content))
 	dh.snapshot = after
 	s.resyncDerivedTables(d, map[string]bool{})
 	event.Emit(s.bus, event.After, TransactionCommitted{Document: d.ID(), Label: label})

--- a/app/undo_delta_log_test.go
+++ b/app/undo_delta_log_test.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+	"testing"
+
+	"oblikovati.org/command"
+	"oblikovati.org/model/doc"
+)
+
+// activeLog returns the active document's undo snapshot log — the delta stream #1424 records
+// edits into, the observable the memory tests read.
+func activeLog(t *testing.T, s *Session) *command.SnapshotLog {
+	t.Helper()
+	dh, ok := s.histories[s.ActiveDocument().ID()]
+	if !ok {
+		t.Fatal("active document has no transaction stream")
+	}
+	return dh.log
+}
+
+// TestUndoStreamStoresDeltasNotFullSnapshots is the issue's headline memory guarantee: recording
+// many edits costs far less than the two-full-snapshots-per-edit storage it replaces. Each added
+// parameter changes a localised region of the recipe, so the stream must retain deltas — well
+// under the naive O(edits × recipeSize) the old RecipeEvent before+after held.
+func TestUndoStreamStoresDeltasNotFullSnapshots(t *testing.T) {
+	s, _ := newPartWithSquare(t, 2)
+	trackFromHere(s)
+	def := partOf(t, s)
+
+	const edits = 96
+	for i := 0; i < edits; i++ {
+		if err := s.AddNumericUserParameter(fmt.Sprintf("d%d", i), "10 mm"); err != nil {
+			t.Fatalf("add param %d: %v", i, err)
+		}
+	}
+
+	final, err := def.MarshalSnapshot()
+	if err != nil {
+		t.Fatalf("MarshalSnapshot: %v", err)
+	}
+	naive := edits * len(final) // the old stream held ~one full snapshot per edit (before==prev after)
+	retained := activeLog(t, s).RetainedBytes()
+	if retained >= naive/4 {
+		t.Errorf("undo stream retained %d bytes for %d edits of ~%d-byte recipes; not sub-linear vs the %d-byte naive store",
+			retained, edits, len(final), naive)
+	}
+}
+
+// TestUndoRedoParityThroughDeltaLog: undoing every edit back to the baseline then redoing every
+// edit restores the identical model state, proving the delta-log reconstruction is lossless at
+// every cursor position (the parity acceptance criterion).
+func TestUndoRedoParityThroughDeltaLog(t *testing.T) {
+	s, _ := newPartWithSquare(t, 2)
+	trackFromHere(s)
+	def := partOf(t, s)
+	base := def.Parameters().Count()
+
+	const edits = 40 // spans multiple checkpoint intervals so reconstruction replays real deltas
+	for i := 0; i < edits; i++ {
+		if err := s.AddNumericUserParameter(fmt.Sprintf("p%d", i), fmt.Sprintf("%d mm", i+1)); err != nil {
+			t.Fatalf("add param %d: %v", i, err)
+		}
+	}
+	if def.Parameters().Count() != base+edits {
+		t.Fatalf("after edits: %d params, want %d", def.Parameters().Count(), base+edits)
+	}
+
+	for i := 0; i < edits; i++ {
+		if err := s.Undo(); err != nil {
+			t.Fatalf("undo %d: %v", i, err)
+		}
+	}
+	if def.Parameters().Count() != base {
+		t.Errorf("after undoing all edits: %d params, want the baseline %d", def.Parameters().Count(), base)
+	}
+
+	for i := 0; i < edits; i++ {
+		if err := s.Redo(); err != nil {
+			t.Fatalf("redo %d: %v", i, err)
+		}
+	}
+	if def.Parameters().Count() != base+edits {
+		t.Errorf("after redoing all edits: %d params, want %d", def.Parameters().Count(), base+edits)
+	}
+	for i := 0; i < edits; i++ {
+		if _, ok := def.Parameters().ByName(fmt.Sprintf("p%d", i)); !ok {
+			t.Errorf("redo lost parameter p%d", i)
+		}
+	}
+}
+
+// TestReclaimAuditLogsTrimsAndDiscards pins the session-audit bound's bookkeeping (#1424): a
+// document with surviving events keeps its log trimmed to the earliest live position; a document
+// whose events all aged out has its log discarded. Tested directly so it needs no 2000-event run.
+func TestReclaimAuditLogsTrimsAndDiscards(t *testing.T) {
+	keptDoc, goneDoc := doc.ID(1), doc.ID(2)
+	audit := map[doc.ID]*command.SnapshotLog{
+		keptDoc: command.NewSnapshotLogEvery(2),
+		goneDoc: command.NewSnapshotLogEvery(2),
+	}
+	for n := 0; n < 8; n++ {
+		audit[keptDoc].Append([]byte(fmt.Sprintf("kept-%d", n)))
+	}
+	for n := 0; n < 4; n++ {
+		audit[goneDoc].Append([]byte(fmt.Sprintf("gone-%d", n)))
+	}
+	// Surviving events reference only keptDoc, earliest position 5; goneDoc has no live event.
+	live := []sessionTxEvent{
+		{docID: keptDoc, pos: 5},
+		{docID: keptDoc, pos: 7},
+		{docID: keptDoc, pos: -1}, // a no-recipe step must not affect trimming
+	}
+
+	reclaimAuditLogs(live, audit)
+
+	if _, ok := audit[goneDoc]; ok {
+		t.Error("a document with no surviving events kept its audit log")
+	}
+	kept, ok := audit[keptDoc]
+	if !ok {
+		t.Fatal("a referenced document lost its audit log")
+	}
+	if _, err := kept.At(5); err != nil {
+		t.Errorf("earliest live position 5 no longer reconstructs after trim: %v", err)
+	}
+	got, err := kept.At(7)
+	if err != nil || string(got) != "kept-7" {
+		t.Errorf("At(7) after trim = %q, %v; want kept-7", got, err)
+	}
+	if _, err := kept.At(4); err == nil {
+		t.Error("position 4 should have been reclaimed (before the earliest live position)")
+	}
+}

--- a/app/undo_marshal_error_test.go
+++ b/app/undo_marshal_error_test.go
@@ -174,8 +174,8 @@ func TestBaselineAndSessionLogSurfaceContentMarshalFailure(t *testing.T) {
 	if len(s.txEvents) != beforeEvents+1 {
 		t.Errorf("the audit event was dropped on a marshal failure: %d → %d", beforeEvents, len(s.txEvents))
 	}
-	if r := s.txEvents[len(s.txEvents)-1].recipe; r != nil {
-		t.Errorf("a failed-marshal audit recipe should be nil, got %d bytes", len(r))
+	if pos := s.txEvents[len(s.txEvents)-1].pos; pos != -1 {
+		t.Errorf("a failed-marshal audit event should record no recipe position, got pos = %d", pos)
 	}
 	if !s.messageCenter.hasErrors {
 		t.Error("session-log marshal failure was not surfaced (silent discard, #1425)")

--- a/command/recipe_event.go
+++ b/command/recipe_event.go
@@ -5,7 +5,7 @@ package command
 // RecipeStore is the seam a [RecipeEvent] navigates: something that can replace its
 // entire recipe with a previously-captured snapshot and recompute the geometry that
 // snapshot implies. A part's component definition satisfies it (MarshalSnapshot captures
-// the snapshot the event stores; RestoreSnapshot replaces+recomputes from it). Declared
+// the snapshot the log stores; RestoreSnapshot replaces+recomputes from it). Declared
 // here — and injected — so the command engine stays decoupled from the model packages
 // (no import of model/compdef; the dependency flows the other way).
 type RecipeStore interface {
@@ -17,35 +17,44 @@ type RecipeStore interface {
 	RestoreSnapshot(snapshot []byte) error
 }
 
-// RecipeEvent is one transaction event in a document's edit stream: it remembers
-// the recipe snapshot before and after a single interaction. Navigating the stream
-// (undo/redo) restores the corresponding snapshot and recomputes — so the current
-// model state is always the fold of the events up to the cursor, and moving the
-// cursor is O(1) restore rather than an O(n) replay from the document's open state.
+// SnapshotSource reconstructs the recipe snapshot recorded at a stream position. A
+// [SnapshotLog] is the production implementation; a test can supply its own. Keeping it an
+// interface lets [RecipeEvent] hold positions rather than bytes (Oblikovati#1424) without
+// coupling the event to the log's delta encoding.
+type SnapshotSource interface {
+	At(position int) ([]byte, error)
+}
+
+// RecipeEvent is one transaction event in a document's edit stream. Rather than carry the
+// recipe snapshot before and after the interaction (two full copies per edit, the O(N²)
+// storage #1424 replaces), it records the BEFORE and AFTER positions in a shared
+// [SnapshotLog] and reconstructs the bytes on demand. Navigating the stream (undo/redo)
+// reconstructs the corresponding snapshot and recomputes — so the current model state is
+// always the fold of the events up to the cursor, and moving the cursor is one restore.
 //
-// The mutation has already happened in the model when the event is built (the app
-// edits, then captures before/after), so the event is recorded via [History.Record]
-// (not Do): Apply re-establishes the after-snapshot for redo, Revert re-establishes
-// the before-snapshot for undo.
+// The mutation has already happened in the model when the event is built (the app edits,
+// then appends the after-snapshot to the log), so the event is recorded via [History.Record]
+// (not Do): Apply re-establishes the after-snapshot for redo, Revert re-establishes the
+// before-snapshot for undo.
 type RecipeEvent struct {
 	label  string
-	before []byte
-	after  []byte
+	before int
+	after  int
+	snaps  SnapshotSource
 	store  RecipeStore
 }
 
-// NewRecipeEvent builds a snapshot event from the before/after recipe bytes captured
-// around an interaction. before is the recipe as it was when the document reached
-// this point; after is the recipe the interaction produced.
+// NewRecipeEvent builds a snapshot event from the before/after positions of an interaction
+// in the shared snapshot log. before is the position the document held when it reached this
+// point; after is the position the interaction produced.
 //
 // Example:
 //
-//	before, _ := def.MarshalSnapshot()
-//	mutate()                          // the interaction
-//	after, _ := def.MarshalSnapshot()
-//	history.Record(command.NewRecipeEvent("Extrude", before, after, def))
-func NewRecipeEvent(label string, before, after []byte, store RecipeStore) *RecipeEvent {
-	return &RecipeEvent{label: label, before: before, after: after, store: store}
+//	before := log.Next() - 1              // the current position
+//	after := log.Append(afterSnapshot)    // record the new state
+//	history.Record(command.NewRecipeEvent("Extrude", before, after, log, def))
+func NewRecipeEvent(label string, before, after int, snaps SnapshotSource, store RecipeStore) *RecipeEvent {
+	return &RecipeEvent{label: label, before: before, after: after, snaps: snaps, store: store}
 }
 
 // Label returns the event's undo-menu text.
@@ -57,8 +66,13 @@ func (e *RecipeEvent) Apply() error { return e.restore(e.after) }
 // Revert restores the before-snapshot and recomputes — the undo direction.
 func (e *RecipeEvent) Revert() error { return e.restore(e.before) }
 
-// restore replaces the store's recipe with one snapshot (which recomputes the geometry
-// it implies).
-func (e *RecipeEvent) restore(snapshot []byte) error {
+// restore reconstructs the snapshot at one stream position and replaces the store's recipe
+// with it (which recomputes the geometry it implies). A reconstruction failure surfaces
+// rather than restoring a wrong recipe.
+func (e *RecipeEvent) restore(position int) error {
+	snapshot, err := e.snaps.At(position)
+	if err != nil {
+		return err
+	}
 	return e.store.RestoreSnapshot(snapshot)
 }

--- a/command/recipe_event_test.go
+++ b/command/recipe_event_test.go
@@ -18,9 +18,20 @@ func (f *fakeRecipeStore) RestoreSnapshot(snapshot []byte) error {
 	return nil
 }
 
+// logWith seeds a snapshot log with the given position snapshots and returns it, the helper
+// every event-stream test records its before/after positions against.
+func logWith(snaps ...string) *SnapshotLog {
+	l := NewSnapshotLog()
+	for _, s := range snaps {
+		l.Append([]byte(s))
+	}
+	return l
+}
+
 func TestRecipeEventApplyRevertRestoreSnapshots(t *testing.T) {
 	store := &fakeRecipeStore{current: "v1"}
-	e := NewRecipeEvent("Edit", []byte("v1"), []byte("v2"), store)
+	log := logWith("v1", "v2") // positions 0 and 1
+	e := NewRecipeEvent("Edit", 0, 1, log, store)
 	if e.Label() != "Edit" {
 		t.Fatalf("Label = %q", e.Label())
 	}
@@ -47,13 +58,14 @@ func TestRecipeEventApplyRevertRestoreSnapshots(t *testing.T) {
 func TestRecordNavigatesStreamWithoutReapplying(t *testing.T) {
 	store := &fakeRecipeStore{current: "base"}
 	h := NewHistory()
+	log := logWith("base") // position 0 = open-state baseline
 
 	// Two interactions: base→a, then a→b. The model already holds the result when
-	// each event is recorded.
+	// each event is recorded; each appends its after-snapshot to the shared log.
 	store.current = "a"
-	h.Record(NewRecipeEvent("first", []byte("base"), []byte("a"), store))
+	h.Record(NewRecipeEvent("first", 0, log.Append([]byte("a")), log, store))
 	store.current = "b"
-	h.Record(NewRecipeEvent("second", []byte("a"), []byte("b"), store))
+	h.Record(NewRecipeEvent("second", 1, log.Append([]byte("b")), log, store))
 
 	if got := store.restores; got != 0 {
 		t.Fatalf("Record must not restore; restores = %d", got)
@@ -91,13 +103,15 @@ func TestRecordNavigatesStreamWithoutReapplying(t *testing.T) {
 func TestRecordTruncatesRedoTail(t *testing.T) {
 	store := &fakeRecipeStore{}
 	h := NewHistory()
-	h.Record(NewRecipeEvent("a", []byte("0"), []byte("1"), store))
-	h.Record(NewRecipeEvent("b", []byte("1"), []byte("2"), store))
+	log := logWith("0") // baseline
+	h.Record(NewRecipeEvent("a", 0, log.Append([]byte("1")), log, store))
+	h.Record(NewRecipeEvent("b", 1, log.Append([]byte("2")), log, store))
 	_ = h.Undo() // cursor before "b"
 	if !h.CanRedo() {
 		t.Fatal("expected a redo branch after undo")
 	}
-	h.Record(NewRecipeEvent("c", []byte("1"), []byte("3"), store)) // new edit
+	log.TruncateTo(2)                                                     // a new edit discards the redo branch position
+	h.Record(NewRecipeEvent("c", 1, log.Append([]byte("3")), log, store)) // new edit
 	if h.CanRedo() {
 		t.Error("new edit did not truncate the redo branch")
 	}

--- a/command/snapshot_delta.go
+++ b/command/snapshot_delta.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package command
+
+import "fmt"
+
+// snapshotDelta is a forward byte patch from one recipe snapshot to the next, encoded as the
+// length of the common prefix, the length of the common suffix, and the differing middle that
+// replaces everything between them. Consecutive undo snapshots differ only where the model
+// actually changed — and the recipe codec is deterministic (snapshot.go), so a single edit
+// produces a localised change in the serialized bytes. The middle is therefore O(edit size),
+// not O(model size), which is what turns the per-edit whole-recipe storage into an O(N) stream
+// (Oblikovati#1424). A non-localised edit (e.g. a parameter rename touching many references)
+// stores a larger middle but is still correct — prefix/suffix is a lossless framing.
+type snapshotDelta struct {
+	prefix int    // bytes shared with the source snapshot at the start
+	suffix int    // bytes shared with the source snapshot at the end (non-overlapping with prefix)
+	middle []byte // the bytes that replace source[prefix : len(source)-suffix]
+}
+
+// makeSnapshotDelta computes the forward patch that turns from into to.
+//
+// Example:
+//
+//	d := makeSnapshotDelta([]byte(`{"d":10}`), []byte(`{"d":25}`)) // middle == "25"
+//	got, _ := d.apply([]byte(`{"d":10}`))                          // got == {"d":25}
+func makeSnapshotDelta(from, to []byte) snapshotDelta {
+	p := commonPrefixLen(from, to)
+	// Measure the suffix only within the bytes that follow the shared prefix, so prefix and
+	// suffix can never overlap and double-count a shared byte (which would corrupt apply).
+	s := commonSuffixLen(from[p:], to[p:])
+	middle := append([]byte(nil), to[p:len(to)-s]...)
+	return snapshotDelta{prefix: p, suffix: s, middle: middle}
+}
+
+// apply reconstructs the target snapshot by splicing the stored middle between from's shared
+// prefix and suffix. It errors if from is not the snapshot this delta was built against (its
+// length cannot accommodate the prefix+suffix), so a corrupt stream surfaces instead of
+// silently producing a malformed recipe.
+func (d snapshotDelta) apply(from []byte) ([]byte, error) {
+	if d.prefix+d.suffix > len(from) {
+		return nil, fmt.Errorf("command: snapshot delta prefix %d + suffix %d exceeds source length %d", d.prefix, d.suffix, len(from))
+	}
+	out := make([]byte, 0, d.prefix+len(d.middle)+d.suffix)
+	out = append(out, from[:d.prefix]...)
+	out = append(out, d.middle...)
+	out = append(out, from[len(from)-d.suffix:]...)
+	return out, nil
+}
+
+// size is the delta's retained byte cost — the differing middle plus the two length fields —
+// used by the stream's memory accounting (and its O(N)-growth regression test).
+func (d snapshotDelta) size() int { return len(d.middle) + 2*8 }
+
+// commonPrefixLen returns the number of leading bytes a and b share.
+func commonPrefixLen(a, b []byte) int {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	return n
+}
+
+// commonSuffixLen returns the number of trailing bytes a and b share.
+func commonSuffixLen(a, b []byte) int {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		if a[len(a)-1-i] != b[len(b)-1-i] {
+			return i
+		}
+	}
+	return n
+}

--- a/command/snapshot_delta_test.go
+++ b/command/snapshot_delta_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package command
+
+import (
+	"bytes"
+	"testing"
+)
+
+// roundTrip is the codec's defining property: apply(makeDelta(from,to), from) == to, for any
+// pair. Every case below asserts it, so a regression in either half is caught.
+func roundTrip(t *testing.T, from, to []byte) {
+	t.Helper()
+	d := makeSnapshotDelta(from, to)
+	got, err := d.apply(from)
+	if err != nil {
+		t.Fatalf("apply(makeDelta(%q,%q)): %v", from, to, err)
+	}
+	if !bytes.Equal(got, to) {
+		t.Fatalf("apply(makeDelta(%q,%q)) = %q, want %q", from, to, got, to)
+	}
+}
+
+func TestSnapshotDeltaRoundTrips(t *testing.T) {
+	cases := []struct{ from, to string }{
+		{"", ""},                           // empty → empty
+		{"abc", "abc"},                     // identical
+		{"", "abc"},                        // grow from nothing
+		{"abc", ""},                        // shrink to nothing
+		{`{"d":10}`, `{"d":25}`},           // localised middle edit (equal length)
+		{`{"d":10}`, `{"d":250}`},          // localised middle edit (grows)
+		{`[1,2,3]`, `[1,2,3,4]`},           // append (prefix is everything but the close)
+		{`[1,2,3,4]`, `[1,2,3]`},           // delete tail element
+		{`{"a":1,"b":2}`, `{"a":9,"b":2}`}, // change at the front
+		{`{"a":1,"b":2}`, `{"a":1,"b":9}`}, // change at the back
+		{"aXa", "aYa"},                     // prefix and suffix both one byte, no overlap
+		{"aaaa", "aa"},                     // overlap-prone: shared bytes must not double-count
+		{"aa", "aaaa"},                     // its inverse
+	}
+	for _, c := range cases {
+		roundTrip(t, []byte(c.from), []byte(c.to))
+	}
+}
+
+// TestSnapshotDeltaLocalisedEditIsSmall pins the whole point: a one-field change in a large
+// snapshot stores a middle proportional to the edit, not to the snapshot.
+func TestSnapshotDeltaLocalisedEditIsSmall(t *testing.T) {
+	big := bytes.Repeat([]byte("feature,"), 1000) // ~8 KB
+	from := append(append([]byte(`{"head":"`), big...), []byte(`,"d":10}`)...)
+	to := append(append([]byte(`{"head":"`), big...), []byte(`,"d":25}`)...)
+	d := makeSnapshotDelta(from, to)
+	if len(d.middle) > 8 {
+		t.Errorf("middle = %d bytes for a 2-byte edit in an %d-byte snapshot; delta is not localised", len(d.middle), len(from))
+	}
+	roundTrip(t, from, to)
+}
+
+// TestSnapshotDeltaApplyRejectsWrongSource: applying a delta to bytes it was not built against
+// must error rather than fabricate a corrupt snapshot.
+func TestSnapshotDeltaApplyRejectsWrongSource(t *testing.T) {
+	d := makeSnapshotDelta([]byte("a-long-source-string"), []byte("a-long-target-string"))
+	if _, err := d.apply([]byte("xy")); err == nil {
+		t.Error("apply against a too-short source returned no error; a corrupt stream would go undetected")
+	}
+}

--- a/command/snapshot_log.go
+++ b/command/snapshot_log.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package command
+
+import "fmt"
+
+// defaultCheckpointInterval is how often the snapshot log stores a full checkpoint instead of a
+// delta. Reconstructing a position replays at most this many deltas from the nearest checkpoint,
+// and the retained checkpoints cost ~totalPositions/interval full snapshots — so the constant
+// trades reconstruction time against memory. 32 keeps the undo stream's memory ~32× smaller than
+// the old whole-recipe-per-edit storage (Oblikovati#1424) while bounding a restore to ≤32 delta
+// applies; PR2's incremental recompute removes the per-restore cost that dominates either way.
+const defaultCheckpointInterval = 32
+
+// SnapshotLog is an append-only, sparsely-checkpointed delta stream of recipe snapshots indexed
+// by position (Oblikovati#1424). Position 0 is the document's open-state baseline; each later
+// position is one cursor state of the undo stream. A position is stored either as a full
+// checkpoint (every checkpointEvery positions) or as a forward [snapshotDelta] from the previous
+// position, so a stream of N edits costs O(N·editSize + N/interval·recipeSize) instead of the
+// O(N·recipeSize) two-full-snapshots-per-edit it replaces.
+//
+// It is the storage behind [RecipeEvent]: the event holds only its before/after positions and
+// reconstructs the bytes through [SnapshotLog.At] on undo/redo. The log is content-agnostic
+// (part, assembly, drawing recipes are all just bytes), so every recipe store gets the saving.
+type SnapshotLog struct {
+	checkpointEvery int
+	// entries holds the live positions in order; entries[0] is logical position baseOffset.
+	// baseOffset advances when the front is trimmed (the session audit's bound), so positions
+	// recorded in events stay stable even as old history is reclaimed.
+	entries    []logEntry
+	baseOffset int
+}
+
+// logEntry is one stored position: a full checkpoint, or a forward delta from the previous
+// position (exactly one of the two is set).
+type logEntry struct {
+	checkpoint []byte         // the full snapshot; nil unless this position is a checkpoint
+	delta      *snapshotDelta // forward patch from the previous position; nil at a checkpoint
+}
+
+// NewSnapshotLog returns an empty log with the default checkpoint spacing.
+func NewSnapshotLog() *SnapshotLog { return NewSnapshotLogEvery(defaultCheckpointInterval) }
+
+// NewSnapshotLogEvery returns an empty log that checkpoints every interval positions. An interval
+// below 1 is clamped to 1 (every position a checkpoint — the safe, memory-heavy extreme), so a
+// caller can never configure a log that fails to reconstruct.
+func NewSnapshotLogEvery(interval int) *SnapshotLog {
+	if interval < 1 {
+		interval = 1
+	}
+	return &SnapshotLog{checkpointEvery: interval}
+}
+
+// IsEmpty reports whether no position has been appended yet (so the caller knows to seed the
+// open-state baseline at position 0 before recording its first edit).
+func (l *SnapshotLog) IsEmpty() bool { return len(l.entries) == 0 }
+
+// Next returns the position the next [SnapshotLog.Append] will assign.
+func (l *SnapshotLog) Next() int { return l.baseOffset + len(l.entries) }
+
+// Append stores snap at the next position and returns that position. It is a checkpoint when the
+// position is the log's first live entry or falls on the checkpoint interval; otherwise it is a
+// forward delta from the previous position. snap is copied defensively so a caller reusing its
+// buffer cannot corrupt the stream.
+func (l *SnapshotLog) Append(snap []byte) int {
+	pos := l.Next()
+	if len(l.entries) == 0 || pos%l.checkpointEvery == 0 {
+		l.entries = append(l.entries, logEntry{checkpoint: append([]byte(nil), snap...)})
+		return pos
+	}
+	prev, _ := l.reconstruct(len(l.entries) - 1) // the just-stored previous entry always reconstructs
+	d := makeSnapshotDelta(prev, snap)
+	l.entries = append(l.entries, logEntry{delta: &d})
+	return pos
+}
+
+// At reconstructs the snapshot at the given position by copying the nearest checkpoint at or
+// before it and replaying the intervening deltas. It errors if the position is outside the live
+// range (a stale event reference, or a position trimmed away), surfacing a stream bug instead of
+// returning a wrong recipe.
+func (l *SnapshotLog) At(pos int) ([]byte, error) {
+	i := pos - l.baseOffset
+	if i < 0 || i >= len(l.entries) {
+		return nil, fmt.Errorf("command: snapshot position %d out of range [%d,%d)", pos, l.baseOffset, l.Next())
+	}
+	return l.reconstruct(i)
+}
+
+// reconstruct rebuilds the snapshot at the given slice index (not logical position).
+func (l *SnapshotLog) reconstruct(i int) ([]byte, error) {
+	start := i
+	for start > 0 && l.entries[start].checkpoint == nil {
+		start--
+	}
+	if l.entries[start].checkpoint == nil {
+		return nil, fmt.Errorf("command: snapshot log has no checkpoint at or before index %d (corrupt stream)", i)
+	}
+	out := append([]byte(nil), l.entries[start].checkpoint...)
+	for k := start + 1; k <= i; k++ {
+		next, err := l.entries[k].delta.apply(out)
+		if err != nil {
+			return nil, err
+		}
+		out = next
+	}
+	return out, nil
+}
+
+// TruncateTo drops every position at or beyond highWater — the redo branch a new edit discards
+// (the undo stream truncates in lockstep with the command history's done/undone stacks). A
+// highWater at or above the current high-water mark is a no-op.
+func (l *SnapshotLog) TruncateTo(highWater int) {
+	keep := highWater - l.baseOffset
+	if keep < 0 {
+		keep = 0
+	}
+	if keep < len(l.entries) {
+		l.entries = l.entries[:keep]
+	}
+}
+
+// TruncateFront reclaims positions before keepFrom, re-baselining keepFrom as a fresh checkpoint
+// so what remains still reconstructs. It is how the session audit honours its memory bound
+// without copying whole recipes: positions recorded in surviving events keep their stable index
+// (baseOffset advances), only the dropped prefix is freed. A keepFrom at or before the current
+// front is a no-op; one beyond the live range is clamped to keep the newest position.
+func (l *SnapshotLog) TruncateFront(keepFrom int) error {
+	if keepFrom <= l.baseOffset || len(l.entries) == 0 {
+		return nil
+	}
+	if keepFrom >= l.Next() {
+		keepFrom = l.Next() - 1
+	}
+	rebased, err := l.At(keepFrom)
+	if err != nil {
+		return err
+	}
+	drop := keepFrom - l.baseOffset
+	l.entries = l.entries[drop:]
+	l.entries[0] = logEntry{checkpoint: rebased} // the new front must stand alone
+	l.baseOffset = keepFrom
+	return nil
+}
+
+// RetainedBytes is the total snapshot bytes the log holds (checkpoints in full, deltas as their
+// differing middles) — the figure the O(N)-growth regression test and the memory benchmark read.
+func (l *SnapshotLog) RetainedBytes() int {
+	total := 0
+	for _, e := range l.entries {
+		if e.checkpoint != nil {
+			total += len(e.checkpoint)
+			continue
+		}
+		total += e.delta.size()
+	}
+	return total
+}

--- a/command/snapshot_log_test.go
+++ b/command/snapshot_log_test.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package command
+
+import (
+	"fmt"
+	"testing"
+)
+
+// snap builds a deterministic, mostly-shared snapshot for position n: a large constant body with
+// a small varying tail, mimicking how a real edit changes a localised region of the recipe.
+func snap(n int) []byte {
+	body := make([]byte, 0, 4096)
+	for i := 0; i < 256; i++ {
+		body = append(body, []byte(fmt.Sprintf("feature%d;", i))...)
+	}
+	return append(body, []byte(fmt.Sprintf("|edit=%d", n))...)
+}
+
+func TestSnapshotLogReconstructsEveryPositionAcrossCheckpoints(t *testing.T) {
+	l := NewSnapshotLogEvery(4) // force frequent checkpoints + deltas to exercise both paths
+	const positions = 21
+	for n := 0; n < positions; n++ {
+		if got := l.Append(snap(n)); got != n {
+			t.Fatalf("Append returned position %d, want %d", got, n)
+		}
+	}
+	// Every position must reconstruct byte-for-byte — checkpoints and the deltas between them.
+	for n := 0; n < positions; n++ {
+		got, err := l.At(n)
+		if err != nil {
+			t.Fatalf("At(%d): %v", n, err)
+		}
+		if want := snap(n); string(got) != string(want) {
+			t.Fatalf("At(%d) reconstructed the wrong snapshot", n)
+		}
+	}
+}
+
+func TestSnapshotLogAtRejectsOutOfRange(t *testing.T) {
+	l := NewSnapshotLog()
+	l.Append(snap(0))
+	if _, err := l.At(1); err == nil {
+		t.Error("At past the high-water mark returned no error")
+	}
+	if _, err := l.At(-1); err == nil {
+		t.Error("At a negative position returned no error")
+	}
+}
+
+// TestSnapshotLogTruncateToDropsRedoBranch mirrors the undo stream: undo moves the cursor back,
+// a new edit truncates the forward positions, and the reused position reconstructs the new state.
+func TestSnapshotLogTruncateToDropsRedoBranch(t *testing.T) {
+	l := NewSnapshotLogEvery(4)
+	for n := 0; n < 6; n++ {
+		l.Append(snap(n))
+	}
+	l.TruncateTo(3) // keep positions 0,1,2 (the cursor undid back to position 2)
+	if l.Next() != 3 {
+		t.Fatalf("after TruncateTo(3) Next = %d, want 3", l.Next())
+	}
+	if got := l.Append([]byte("new-branch")); got != 3 {
+		t.Fatalf("re-appended position = %d, want 3 (reused slot)", got)
+	}
+	got, err := l.At(3)
+	if err != nil || string(got) != "new-branch" {
+		t.Fatalf("At(3) = %q, %v; want new-branch", got, err)
+	}
+	// The discarded position 4 must be gone.
+	if _, err := l.At(4); err == nil {
+		t.Error("position 4 survived truncation")
+	}
+}
+
+// TestSnapshotLogTruncateFrontReclaimsAndKeepsPositionsStable is the session-audit bound: old
+// positions are freed but surviving event references (by absolute position) still resolve.
+func TestSnapshotLogTruncateFrontReclaimsAndKeepsPositionsStable(t *testing.T) {
+	l := NewSnapshotLogEvery(4)
+	for n := 0; n < 10; n++ {
+		l.Append(snap(n))
+	}
+	before := l.RetainedBytes()
+	if err := l.TruncateFront(6); err != nil {
+		t.Fatalf("TruncateFront(6): %v", err)
+	}
+	if l.RetainedBytes() >= before {
+		t.Errorf("TruncateFront did not reclaim memory: before=%d after=%d", before, l.RetainedBytes())
+	}
+	// Position 6 onward keep their absolute index and reconstruct unchanged.
+	for n := 6; n < 10; n++ {
+		got, err := l.At(n)
+		if err != nil {
+			t.Fatalf("At(%d) after front-trim: %v", n, err)
+		}
+		if string(got) != string(snap(n)) {
+			t.Fatalf("At(%d) wrong after front-trim", n)
+		}
+	}
+	if _, err := l.At(5); err == nil {
+		t.Error("position 5 survived front truncation")
+	}
+}
+
+// TestSnapshotLogMemoryGrowsLinearly is the issue's headline guarantee: storing M localised edits
+// of an O(R)-byte recipe costs O(M·editSize + M/interval·R), NOT O(M·R). With localised edits the
+// retained bytes must stay far below the M-full-copies the old stream held.
+func TestSnapshotLogMemoryGrowsLinearly(t *testing.T) {
+	l := NewSnapshotLogEvery(32)
+	const edits = 200
+	recipeSize := len(snap(0))
+	for n := 0; n < edits; n++ {
+		l.Append(snap(n))
+	}
+	naive := edits * recipeSize // what two-full-snapshots-per-edit storage approximated
+	if l.RetainedBytes() >= naive/4 {
+		t.Errorf("retained %d bytes for %d edits of %d-byte recipes; not sub-linear vs the %d-byte naive store",
+			l.RetainedBytes(), edits, recipeSize, naive)
+	}
+}
+
+// BenchmarkSnapshotLogMemory documents the #1424 memory win: it records `edits` localised edits
+// of an ~R-byte recipe and reports the bytes the delta log retains against the naive
+// one-full-snapshot-per-edit storage it replaces. Run: go test ./command/ -run=^$ -bench=Memory.
+// Measured (edits=1000, R≈2.7 KB): naive_bytes ≈ 2.71 MB, delta_bytes ≈ 0.10 MB — the stream
+// holds ~26× less, and the ratio improves as the recipe grows (the per-edit O(N²) blow-up is
+// gone; reconstruction stays bounded to one checkpoint interval).
+func BenchmarkSnapshotLogMemory(b *testing.B) {
+	const edits = 1000
+	for i := 0; i < b.N; i++ {
+		l := NewSnapshotLog()
+		for n := 0; n < edits; n++ {
+			l.Append(snap(n))
+		}
+		if i == 0 {
+			b.ReportMetric(float64(edits*len(snap(0))), "naive_bytes")
+			b.ReportMetric(float64(l.RetainedBytes()), "delta_bytes")
+		}
+	}
+}


### PR DESCRIPTION
## What & why

Undo stored the **entire document recipe twice per edit** (`RecipeEvent`'s `before []byte` + `after []byte`), and the session audit retained up to **2000 full-recipe copies** — an O(N²) memory blow-up over a session (~2 GB on a large recipe; #1147 territory). This replaces that with a **sparsely-checkpointed delta stream**.

A single edit changes only a localised region of the deterministic recipe JSON, and adjacent events duplicate (`event[k].after == event[k+1].before`), so two full snapshots per edit is almost all duplication. Delta-encoding collapses the stream to **O(edit size)** per position.

This is **PR 1 of 2** for #1424 — the *memory architecture* (acceptance criteria 1, 3, 4). The remaining criterion, **incremental recompute-from-dirty-index on undo** (the time cost), is the follow-up PR; it reuses the #1414 dirty-tail machinery and is deliberately kept separate to limit risk in a subsystem everything depends on.

## How

- **`command.SnapshotLog`** — append-only, position-indexed stream. Full checkpoint every 32 positions, forward byte-delta (shared prefix/suffix + differing middle) otherwise. `At()` reconstructs any position from the nearest checkpoint; `TruncateTo` drops the redo branch in lockstep with the history's done/undone stacks; `TruncateFront` reclaims the audit's aged-out prefix while keeping surviving positions stable.
- **`RecipeEvent`** now holds before/after **positions** into a shared log (via a `SnapshotSource` seam) instead of two `[]byte` snapshots; undo/redo reconstruct bytes on demand. The command engine stays decoupled from the model.
- **App undo stream** — `docHistory` owns the per-document log, seeded with the open-state baseline at position 0; `commitRecipeDelta` appends the after-snapshot and records by position. Veto, the empty-baseline guard (#1425), bounded transactions, and cursor navigation are unchanged.
- **Session audit (bug report)** — per-document delta log; events keep only the document id + position. The 2000-event bound front-trims each log and drops logs nothing references, so the audit never holds a full recipe copy per step. `TransactionLog` reconstructs on demand.

## Results

`BenchmarkSnapshotLogMemory` (1000 edits of a ~2.7 KB recipe): retained bytes **2.71 MB → 0.10 MB (~26× less)**, improving as the recipe grows.

## Verification

- Parity preserved: existing undo/redo/veto + assembly/drawing/sketch undo + router central-seam tests pass unchanged.
- New coverage: delta codec round-trip/localisation/corruption; log reconstruction across checkpoints, both truncations, linear memory growth; app stream sub-linear storage + full undo→redo round-trip parity + audit-log reclaiming.
- `go test ./...` green; `go vet` + `golangci-lint` clean (0 issues); `-race` clean on command + app undo paths.
- This is a non-visual storage refactor with **zero geometry/render behaviour change** — the app+router integration tests drive the exact `Session.Undo/Redo/recordEdit` seams the live head uses, so they are the e2e for this change.

Part of #1424

🤖 Generated with [Claude Code](https://claude.com/claude-code)