### PR TITLE
Incremental undo/redo: rebuild only the changed feature tail (closes #1424)

### DIFF
--- a/model/compdef/snapshot.go
+++ b/model/compdef/snapshot.go
@@ -38,6 +38,13 @@ func (d *PartComponentDefinition) RestoreSnapshot(snapshot []byte) error {
 	if err := json.Unmarshal(snapshot, &r); err != nil {
 		return fmt.Errorf("compdef: parse part snapshot: %w", err)
 	}
+	// Incremental path: when the snapshot changed only a feature tail (Oblikovati#1424), reuse the
+	// live engine's cached prefix instead of rebuilding the whole program from an empty engine. The
+	// full reset+rebuild below stays the fallback for any other change (a parameter, a sketch, a
+	// reorder before the tail), so a missed fast path only costs speed, never correctness.
+	if prefix, ok := d.fastRestorePrefix(r); ok {
+		return d.restoreFeatureTail(r, prefix)
+	}
 	d.resetRecipe()
 	return d.applyRecipeStruct(r)
 }

--- a/model/compdef/snapshot_incremental.go
+++ b/model/compdef/snapshot_incremental.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/param"
+)
+
+// restoreFeatureTail applies a snapshot that changed only a feature tail — every parameter,
+// sketch, work feature, and other non-feature section is identical to the live model, and the
+// feature program agrees up to prefix. It keeps the live engine and its cached prefix bodies and
+// rebuilds only features[prefix:], then recomputes from the dirty index (Oblikovati#1424). This
+// is the incremental undo/redo path: where a full RestoreSnapshot re-evaluates every feature
+// from an empty engine, this re-evaluates just the tail the edit actually touched.
+//
+// Correctness rests on the precondition fastRestorePrefix verifies: identical non-feature
+// sections and an identical feature prefix mean the kept prefix bodies are exactly what the
+// snapshot implies, so reusing them is sound. The prior wholesale-parameter set is merged back
+// (never shrunk) because the partial recompute does not re-read the prefix's parameters, and a
+// shrunk wholesale set could let a later parameter edit silently skip a feature (#1414).
+func (d *PartComponentDefinition) restoreFeatureTail(r partRecipe, prefix int) error {
+	if err := d.features.ReplaceFrom(prefix, r.Features[prefix:], sketchIndex{d.sketches}, d.work); err != nil {
+		return fmt.Errorf("compdef: restore feature tail: %w", err)
+	}
+	d.rebindSketchProjections()
+	prior := d.wholesaleParams
+	d.Recompute()
+	d.mergeWholesaleParams(prior)
+	return nil
+}
+
+// fastRestorePrefix reports whether a snapshot restore can reuse the live engine's cached prefix
+// (and the length of that reusable feature prefix). It is the eligibility check for the
+// incremental path: every non-feature recipe section must be byte-identical to the live model and
+// the feature programs must share a prefix. ok=false forces the full reset+rebuild — the always-
+// correct fallback, so a missed fast path only costs speed, never correctness.
+//
+// Sections are compared as marshalled JSON rather than by reflect.DeepEqual so that a live recipe
+// (nil slices) and a snapshot-decoded recipe (empty slices) normalise identically — the
+// comparison reflects semantic equality, not in-memory representation.
+func (d *PartComponentDefinition) fastRestorePrefix(target partRecipe) (int, bool) {
+	cur, err := d.buildRecipe()
+	if err != nil {
+		return 0, false
+	}
+	if !sameNonFeatureSections(cur, target) {
+		return 0, false
+	}
+	return commonFeaturePrefix(cur.Features, target.Features), true
+}
+
+// sameNonFeatureSections reports whether two recipes agree on everything except their feature
+// programs, comparing the marshalled JSON of each with its Features field blanked.
+func sameNonFeatureSections(a, b partRecipe) bool {
+	a.Features, b.Features = nil, nil
+	aj, err1 := json.Marshal(a)
+	bj, err2 := json.Marshal(b)
+	return err1 == nil && err2 == nil && bytes.Equal(aj, bj)
+}
+
+// commonFeaturePrefix returns the number of leading features two programs share (compared as
+// marshalled JSON), so the restore knows the first feature index that actually changed.
+func commonFeaturePrefix(a, b []feature.FeatureData) int {
+	n := min(len(a), len(b))
+	for i := 0; i < n; i++ {
+		if !sameFeatureData(a[i], b[i]) {
+			return i
+		}
+	}
+	return n
+}
+
+// sameFeatureData reports whether two serialized features are identical, comparing marshalled
+// JSON (robust to nil-vs-empty differences between a live and a decoded feature).
+func sameFeatureData(a, b feature.FeatureData) bool {
+	aj, err1 := json.Marshal(a)
+	bj, err2 := json.Marshal(b)
+	return err1 == nil && err2 == nil && bytes.Equal(aj, bj)
+}
+
+// mergeWholesaleParams unions prior into the current wholesale set, so an incremental restore
+// never shrinks it (the partial recompute did not re-read the kept prefix's parameters, so its
+// freshly-derived set is incomplete; a superset is conservative and safe — it can only force an
+// unnecessary full rebuild on a later parameter edit, never permit a stale one — #1414).
+func (d *PartComponentDefinition) mergeWholesaleParams(prior map[param.ID]bool) {
+	if len(prior) == 0 {
+		return
+	}
+	if d.wholesaleParams == nil {
+		d.wholesaleParams = map[param.ID]bool{}
+	}
+	for id := range prior {
+		d.wholesaleParams[id] = true
+	}
+}

--- a/model/compdef/snapshot_incremental_test.go
+++ b/model/compdef/snapshot_incremental_test.go
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef_test
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// Incremental undo/redo recompute (Oblikovati#1424 PR2): restoring a snapshot that changed only a
+// feature tail must reuse the live engine's cached prefix and recompute just the tail — not reset
+// the whole program and re-evaluate every feature. These tests pin that the kept prefix features
+// keep their identity and recompute counters across the restore (so they were genuinely reused),
+// that the rebuilt tail re-evaluates, that a non-feature change still falls back to the full
+// reset, and that every path lands the same geometry.
+
+// addExtrudeOn appends one more extruded block reusing an existing sketch, so the recipe change is
+// purely a feature-tail change (no new sketch or parameter) — the case the incremental path covers.
+func addExtrudeOn(def *compdef.PartComponentDefinition, sketchIndex int) {
+	sk := def.Sketches().Item(sketchIndex)
+	feature.NewExtrudeFeatures(def.Features()).
+		AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 5 })
+}
+
+func TestIncrementalUndoReusesFeaturePrefix(t *testing.T) {
+	def := compdef.NewPartComponentDefinition()
+	const n = 6
+	buildExtrudeStack(t, def, n, -1, "") // n independent blocks, no driven dimension
+	def.Recompute()
+	base, err := def.MarshalSnapshot() // the n-feature state to undo back to
+	if err != nil {
+		t.Fatalf("MarshalSnapshot: %v", err)
+	}
+
+	addExtrudeOn(def, 0) // pure feature-tail change: +1 feature, sketches/params untouched
+	def.Recompute()
+	if def.Features().Count() != n+1 {
+		t.Fatalf("after adding a feature: %d features, want %d", def.Features().Count(), n+1)
+	}
+	before := recomputeCounts(def)
+	prefixObjs := make([]*feature.PartFeature, n)
+	for i := 0; i < n; i++ {
+		prefixObjs[i] = def.Features().Item(i)
+	}
+
+	if err := def.RestoreSnapshot(base); err != nil { // undo the feature add
+		t.Fatalf("RestoreSnapshot: %v", err)
+	}
+	if def.Features().Count() != n {
+		t.Fatalf("after incremental undo: %d features, want %d", def.Features().Count(), n)
+	}
+	after := recomputeCounts(def)
+	for i := 0; i < n; i++ {
+		if def.Features().Item(i) != prefixObjs[i] {
+			t.Errorf("feature %d was rebuilt (different object); the incremental path should reuse it", i)
+		}
+		if after[i] != before[i] {
+			t.Errorf("feature %d recomputed on incremental undo: %d→%d, want reused (cached prefix)", i, before[i], after[i])
+		}
+	}
+}
+
+func TestIncrementalRedoRebuildsOnlyTailFeature(t *testing.T) {
+	def := compdef.NewPartComponentDefinition()
+	const n = 5
+	buildExtrudeStack(t, def, n, -1, "")
+	def.Recompute()
+	base, err := def.MarshalSnapshot() // n features
+	if err != nil {
+		t.Fatalf("MarshalSnapshot: %v", err)
+	}
+	addExtrudeOn(def, 0)
+	def.Recompute()
+	withExtra, err := def.MarshalSnapshot() // n+1 features
+	if err != nil {
+		t.Fatalf("MarshalSnapshot: %v", err)
+	}
+
+	if err := def.RestoreSnapshot(base); err != nil { // undo
+		t.Fatalf("undo: %v", err)
+	}
+	before := recomputeCounts(def)
+	if err := def.RestoreSnapshot(withExtra); err != nil { // redo: rebuild only the tail feature
+		t.Fatalf("redo: %v", err)
+	}
+	if def.Features().Count() != n+1 {
+		t.Fatalf("after redo: %d features, want %d", def.Features().Count(), n+1)
+	}
+	after := recomputeCounts(def)
+	for i := 0; i < n; i++ {
+		if after[i] != before[i] {
+			t.Errorf("prefix feature %d recomputed on redo: %d→%d, want reused", i, before[i], after[i])
+		}
+	}
+	if got := def.Features().Item(n).RecomputeCount(); got != 1 {
+		t.Errorf("the redone tail feature evaluated %d times, want exactly 1", got)
+	}
+}
+
+func TestIncrementalRestoreGeometryMatchesFreshBuild(t *testing.T) {
+	def := compdef.NewPartComponentDefinition()
+	const n = 6
+	buildExtrudeStack(t, def, n, -1, "")
+	def.Recompute()
+	base, err := def.MarshalSnapshot()
+	if err != nil {
+		t.Fatalf("MarshalSnapshot: %v", err)
+	}
+	addExtrudeOn(def, 0)
+	def.Recompute()
+	if err := def.RestoreSnapshot(base); err != nil {
+		t.Fatalf("RestoreSnapshot: %v", err)
+	}
+
+	fresh := compdef.NewPartComponentDefinition()
+	buildExtrudeStack(t, fresh, n, -1, "")
+	fresh.Recompute()
+
+	a, b := def.RangeBox(), fresh.RangeBox()
+	if !a.Min.IsEqualTo(b.Min, 1e-9) || !a.Max.IsEqualTo(b.Max, 1e-9) {
+		t.Errorf("incremental-restore geometry [%v..%v] != fresh-build geometry [%v..%v]", a.Min, a.Max, b.Min, b.Max)
+	}
+	if def.SurfaceBodies().Count() != fresh.SurfaceBodies().Count() {
+		t.Errorf("incremental-restore body count %d != fresh %d", def.SurfaceBodies().Count(), fresh.SurfaceBodies().Count())
+	}
+}
+
+// TestParameterSnapshotRestoreFallsBackToFullRebuild: a snapshot differing in a non-feature
+// section (here a parameter expression) is NOT eligible for the incremental path, so the restore
+// resets the engine — observable as the prefix features being rebuilt (new objects) — and still
+// lands the snapshot's geometry.
+func TestParameterSnapshotRestoreFallsBackToFullRebuild(t *testing.T) {
+	def := compdef.NewPartComponentDefinition()
+	if _, err := def.Parameters().AddUserParameter("drive", "40 mm"); err != nil {
+		t.Fatalf("AddUserParameter: %v", err)
+	}
+	buildExtrudeStack(t, def, 4, 2, "drive")
+	def.Recompute()
+	at40, err := def.MarshalSnapshot()
+	if err != nil {
+		t.Fatalf("MarshalSnapshot: %v", err)
+	}
+
+	if err := def.Parameters().SetExpression(userParamID(t, def, "drive"), "60 mm"); err != nil {
+		t.Fatalf("SetExpression: %v", err)
+	}
+	def.RecomputeAfterParameterEdit()
+	firstFeatureAt60 := def.Features().Item(0)
+
+	if err := def.RestoreSnapshot(at40); err != nil { // a parameter differs → full reset path
+		t.Fatalf("RestoreSnapshot: %v", err)
+	}
+	if def.Features().Item(0) == firstFeatureAt60 {
+		t.Error("a parameter-differing restore reused the engine; it must fall back to a full reset")
+	}
+	if _, ok := def.Parameters().ByName("drive"); !ok {
+		t.Fatal("restore lost the drive parameter")
+	}
+}
+
+// TestIncrementalRestoreThenWholesaleParamEditStillFullRebuilds guards the wholesale-set
+// invariant (#1424 PR2): an incremental restore must not shrink the set of parameters that force a
+// full rebuild, or a later edit to such a parameter could leave a feature on stale geometry. Here
+// a work-plane offset parameter ("lift") reaches geometry through an unmodelled path; after an
+// incremental feature-tail restore, editing it must still rebuild the whole program and move the
+// geometry — never silently skip it.
+func TestIncrementalRestoreThenWholesaleParamEditStillFullRebuilds(t *testing.T) {
+	def := compdef.NewPartComponentDefinition()
+	lift, err := def.Parameters().AddUserParameter("lift", "20 mm")
+	if err != nil {
+		t.Fatalf("AddUserParameter: %v", err)
+	}
+	base := def.Sketches().Add(sketch.XYPlane())
+	rectangle(base, 4, 3)
+	feature.NewExtrudeFeatures(def.Features()).
+		AddByDistanceExtent(base, 0, ops.NewBody, func() float64 { return 5 })
+	wp := def.WorkPlanes().AddByPlaneAndOffset(feature.OriginXYPlane, lift.ModelValue)
+	lifted := def.Sketches().Add(wp.Plane())
+	lifted.SetPlaneHost(func() sketch.Plane { return wp.Plane() })
+	rectangle(lifted, 4, 3)
+	feature.NewExtrudeFeatures(def.Features()).
+		AddByDistanceExtent(lifted, 0, ops.NewBody, func() float64 { return 5 })
+	def.Recompute()
+
+	twoFeatures, err := def.MarshalSnapshot()
+	if err != nil {
+		t.Fatalf("MarshalSnapshot: %v", err)
+	}
+	addExtrudeOn(def, 0) // pure feature-tail change → eligible for the incremental path
+	def.Recompute()
+	if err := def.RestoreSnapshot(twoFeatures); err != nil { // incremental undo
+		t.Fatalf("RestoreSnapshot: %v", err)
+	}
+
+	before := recomputeCounts(def)
+	if err := def.Parameters().SetExpression(userParamID(t, def, "lift"), "50 mm"); err != nil {
+		t.Fatalf("SetExpression: %v", err)
+	}
+	def.RecomputeAfterParameterEdit()
+
+	after := recomputeCounts(def)
+	for i := range before {
+		if after[i] != before[i]+1 {
+			t.Errorf("feature %d count %d→%d after the lift edit, want a full rebuild (+1) — the wholesale set was shrunk by the incremental restore", i, before[i], after[i])
+		}
+	}
+	if z := def.RangeBox().Max.Z; z < 9.999 || z > 10.001 {
+		t.Errorf("after lift→50 mm, model max.z = %v, want ~10 (lifted block followed its plane)", z)
+	}
+}

--- a/model/feature/restore_tail.go
+++ b/model/feature/restore_tail.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// ReplaceFrom rebuilds the feature program from index prefix onward from the given recipe data,
+// keeping features [0,prefix) — and the cached bodies they already computed — untouched. It is
+// the engine half of incremental undo/redo (Oblikovati#1424): when a snapshot restore changed
+// only a feature tail (every earlier feature and every non-feature recipe section is identical),
+// reusing the clean prefix means the next Recompute re-evaluates just the rebuilt tail instead
+// of the whole program — undoing one fillet on a long part costs one fillet, not N features.
+//
+// The kept prefix seeds pattern/mirror source resolution (sources are recorded as program
+// indices), so a rebuilt tail feature that replicates an earlier one still binds correctly. The
+// rebuilt tail features are added dirty, so Recompute's earliest-dirty scan starts at prefix.
+//
+// Callers must establish the precondition (identical prefix + non-feature sections) themselves;
+// ReplaceFrom does not verify it. data is the tail only — the features at [prefix:].
+func (fs *PartFeatures) ReplaceFrom(prefix int, data []FeatureData, sk SketchIndexer, work *WorkGeometry) error {
+	if prefix < 0 || prefix > len(fs.items) {
+		return fmt.Errorf("feature: ReplaceFrom prefix %d out of range [0,%d]", prefix, len(fs.items))
+	}
+	for _, pf := range fs.items[prefix:] {
+		delete(fs.byID, pf.id) // drop the old tail's id bindings before rebuilding
+	}
+	// Cap the kept slice so the first rebuilt feature's append allocates a fresh backing array
+	// rather than overwriting the old tail in place (the old tail may still be referenced).
+	fs.items = fs.items[:prefix:prefix]
+	restored := append([]*PartFeature(nil), fs.items...) // source resolution sees the kept prefix
+	for i, fd := range data {
+		pf, err := buildFeature(fs, fd, sk, restored, work) // Add-appends to fs.items
+		if err != nil {
+			return fmt.Errorf("feature %d (%s): %w", prefix+i, fd.Kind, err)
+		}
+		applyFeatureState(pf, fd)
+		restored = append(restored, pf)
+	}
+	return nil
+}

--- a/model/feature/restore_tail_test.go
+++ b/model/feature/restore_tail_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/model/sketch"
+)
+
+// TestReplaceFromKeepsPrefixRebuildsTail is the engine half of incremental undo (#1424): replacing
+// the program from an index keeps the earlier features (same objects, same cached recompute
+// counts) and rebuilds only the tail, so the next Recompute re-evaluates just the tail.
+func TestReplaceFromKeepsPrefixRebuildsTail(t *testing.T) {
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	fs := NewPartFeatures(nil, nil)
+	for i := 0; i < 3; i++ {
+		NewExtrudeFeatures(fs).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 5 })
+	}
+	fs.Recompute()
+	data, err := fs.MarshalRecipe(oneSketch{sk})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	keep0, keep1 := fs.Item(0), fs.Item(1)
+	count0, count1 := keep0.RecomputeCount(), keep1.RecomputeCount()
+	oldTail := fs.Item(2)
+
+	if err := fs.ReplaceFrom(2, data[2:], oneSketch{sk}, nil); err != nil {
+		t.Fatalf("ReplaceFrom: %v", err)
+	}
+
+	if fs.Count() != 3 {
+		t.Fatalf("after ReplaceFrom: %d features, want 3", fs.Count())
+	}
+	if fs.Item(0) != keep0 || fs.Item(1) != keep1 {
+		t.Error("ReplaceFrom rebuilt the kept prefix; it must reuse those features")
+	}
+	if fs.Item(0).RecomputeCount() != count0 || fs.Item(1).RecomputeCount() != count1 {
+		t.Error("kept prefix recompute counters changed; the prefix was not reused")
+	}
+	if fs.Item(2) == oldTail {
+		t.Error("the tail feature was not rebuilt")
+	}
+	// The rebuilt tail is dirty, so the next recompute re-evaluates only it.
+	if !fs.RequiresUpdate() {
+		t.Error("rebuilt tail is not marked for recompute")
+	}
+}
+
+func TestReplaceFromRejectsOutOfRangePrefix(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	NewExtrudeFeatures(fs).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 5 })
+	if err := fs.ReplaceFrom(2, nil, oneSketch{sk}, nil); err == nil {
+		t.Error("ReplaceFrom past the program length returned no error")
+	}
+	if err := fs.ReplaceFrom(-1, nil, oneSketch{sk}, nil); err == nil {
+		t.Error("ReplaceFrom with a negative prefix returned no error")
+	}
+}
+
+// TestReplaceFromTruncatesTail: replacing from a prefix with no tail data drops the old tail and
+// removes its id bindings (a restore that undid feature additions).
+func TestReplaceFromTruncatesTail(t *testing.T) {
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	fs := NewPartFeatures(nil, nil)
+	for i := 0; i < 3; i++ {
+		NewExtrudeFeatures(fs).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 5 })
+	}
+	removedID := fs.Item(2).ID()
+
+	if err := fs.ReplaceFrom(2, nil, oneSketch{sk}, nil); err != nil {
+		t.Fatalf("ReplaceFrom: %v", err)
+	}
+	if fs.Count() != 2 {
+		t.Fatalf("after truncation: %d features, want 2", fs.Count())
+	}
+	if _, ok := fs.ByID(removedID); ok {
+		t.Error("the dropped tail feature's id binding survived")
+	}
+}


### PR DESCRIPTION
## What & why

`RestoreSnapshot` rebuilt the **whole part from an empty engine** on every undo/redo (`resetRecipe` → `applyRecipeStruct` → full `Recompute`), re-evaluating every feature even when an edit touched only one — undoing one fillet on a 10k-feature model rebuilt all 10k. This adds an **incremental path** that reuses the live engine's cached prefix.

This is **PR 2 of 2** for #1424 and **closes** it. [PR #1456](https://github.com/Oblikovati/Oblikovati/pull/1456) landed the delta-log *storage* (memory); this lands the incremental *recompute* (time). The undo stream is now O(N) in memory **and** incremental in recompute.

The feature engine already replays only a dirty **contiguous tail**, reusing cached prefix bodies (#1414). The only thing forcing a full rebuild on restore was `resetRecipe` destroying the engine and its caches. When a snapshot changed only a feature tail — every parameter/sketch/work-feature/non-feature section identical, and the feature program agreeing up to some index — the kept prefix's cached bodies are exactly what the snapshot implies, so they're reused verbatim.

## How

- **`feature.PartFeatures.ReplaceFrom(prefix, tailData, …)`** — keeps features `[0,prefix)` (same objects, same caches), rebuilds only `[prefix:]`, seeds pattern/mirror source resolution with the kept prefix, and marks the rebuilt tail dirty so `Recompute` starts there.
- **`compdef.RestoreSnapshot` fast path** — `fastRestorePrefix` compares the live recipe against the target (non-feature sections as marshalled JSON — robust to nil-vs-empty between a live and a decoded recipe — and the feature programs feature-by-feature) and returns the reusable prefix length; `restoreFeatureTail` applies just the tail and recomputes from the dirty index. **Any other change** (a parameter, a sketch, a reorder before the tail) **falls back to the existing full reset+rebuild** — a missed fast path costs speed, never correctness.
- **Wholesale-set invariant (#1414)** — the prior wholesale-parameter set is merged back after an incremental restore (never shrunk): the partial recompute doesn't re-read the kept prefix's parameters, and a shrunk set could let a later parameter edit silently skip a feature. A superset is conservative — at worst an unnecessary full rebuild, never a stale one.

## Verification

- **Recompute-count** tests prove the kept prefix is reused (same feature objects, unchanged counters) on undo, and that redo rebuilds only the tail feature (`count == 1`) — the issue's "instrument recompute count" spec.
- **Geometry-parity** test proves the incremental result equals a fresh build (range box + body count).
- **Fallback** test proves a parameter-differing restore still does a full reset (prefix feature objects replaced).
- **Wholesale-invariant** test proves a work-plane-offset edit *after* an incremental restore still rebuilds the whole program and moves the geometry (no silent stale).
- Direct `ReplaceFrom` unit tests (prefix reuse, tail rebuild, truncation, range errors).
- Full existing undo/redo/veto + assembly/drawing/sketch + router central-seam suites pass unchanged; `go test ./...` green; `go vet` + `golangci-lint` 0 issues; `-race` clean.
- Non-visual change: geometry results are identical (parity-tested); only *which* features re-evaluate differs. The app+router integration tests drive the exact `Session.Undo/Redo` → `RestoreSnapshot` seam the live head uses.

Closes #1424

🤖 Generated with [Claude Code](https://claude.com/claude-code)