### PR TITLE
geom(ssi): trace surface intersections through tangencies/pinches; diagnose dropped imprint chains

### DIFF
--- a/kernel/brep/curved_cone_cone_cut.go
+++ b/kernel/brep/curved_cone_cone_cut.go
@@ -3,6 +3,7 @@
 package brep
 
 import (
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 )
@@ -29,9 +30,9 @@ import (
 //	thin, _ := brep.SolidCylinderCone(math.P3(-6,0,0), math.P3(6,0,0), 0.8, 1.5, "thin")
 //	fat, _  := brep.SolidCylinderCone(math.P3(0,0,-6), math.P3(0,0,6), 2, 4, "fat")
 //	res, ok := brep.ConeConeCut(fat, thin) // fat cone with a tapered tunnel
-//	res, ok = brep.ConeConeCut(thin, fat)  // the two rod-cone stubs
-func ConeConeCut(target, tool *topo.Body) (*topo.Body, bool) {
-	p, targetIsRod, ok := coneConeCrossingPartsOf(target, tool)
+//	res, ok = brep.ConeConeCut(thin, fat, nil)  // the two rod-cone stubs
+func ConeConeCut(target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	p, targetIsRod, ok := coneConeCrossingPartsOf(target, tool, rec)
 	if !ok {
 		return nil, false
 	}
@@ -48,8 +49,8 @@ func ConeConeCut(target, tool *topo.Body) (*topo.Body, bool) {
 // reporting whether the FIRST body (the Cut target) is the rod cone. ok=false when they are not one cone
 // crossing one fatter cone in the full-crossing configuration (exactly two imprint loops, one cone the rod
 // both loops encircle, both loops between the rod cone's caps).
-func coneConeCrossingPartsOf(a, b *topo.Body) (parts *crossingParts, aIsRod, ok bool) {
-	loops, imOK := coneConeImprint(a, b)
+func coneConeCrossingPartsOf(a, b *topo.Body, rec *diag.Recorder) (parts *crossingParts, aIsRod, ok bool) {
+	loops, imOK := coneConeImprint(a, b, rec)
 	if !imOK || len(loops) != 2 {
 		return nil, false, false
 	}

--- a/kernel/brep/curved_cone_cone_cut_test.go
+++ b/kernel/brep/curved_cone_cone_cut_test.go
@@ -21,7 +21,7 @@ func TestConeConeCutDrillsFat(t *testing.T) {
 	fat, _ := SolidCylinderCone(math.P3(0, 0, -6), math.P3(0, 0, 6), 2, 4, "fat")
 	thin, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 0.8, 1.5, "thin")
 
-	res, ok := ConeConeCut(fat, thin)
+	res, ok := ConeConeCut(fat, thin, nil)
 	if !ok {
 		t.Fatal("cone drill of cone declined; want a four-face solid")
 	}
@@ -39,7 +39,7 @@ func TestConeConeCutRodMinusFatStubs(t *testing.T) {
 	fat, _ := SolidCylinderCone(math.P3(0, 0, -6), math.P3(0, 0, 6), 2, 4, "fat")
 	thin, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 0.8, 1.5, "thin")
 
-	res, ok := ConeConeCut(thin, fat)
+	res, ok := ConeConeCut(thin, fat, nil)
 	if !ok {
 		t.Fatal("rod cone − fat cone declined; want two tapered stubs")
 	}
@@ -58,7 +58,7 @@ func TestConeConeCutRodMinusFatStubs(t *testing.T) {
 func TestConeConeCutConeCylinderDefer(t *testing.T) {
 	cone, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
 	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
-	if _, ok := ConeConeCut(cyl, cone); ok {
+	if _, ok := ConeConeCut(cyl, cone, nil); ok {
 		t.Error("a cone and a cylinder should defer from the cone–cone cut (ok=false)")
 	}
 }

--- a/kernel/brep/curved_cone_cone_imprint.go
+++ b/kernel/brep/curved_cone_cone_imprint.go
@@ -3,6 +3,7 @@
 package brep
 
 import (
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 )
@@ -23,7 +24,7 @@ import (
 // when either body is not a bare cone (a cone + a cylinder is the cone–cylinder case, handled elsewhere), or
 // no closed loop is traced. The first body's cone is the trace base, windowed to its apex-distance band
 // [vMin, vMax]; the periodic angular direction is left to the tracer.
-func coneConeImprint(a, b *topo.Body) ([]geom.Polyline, bool) {
+func coneConeImprint(a, b *topo.Body, rec *diag.Recorder) ([]geom.Polyline, bool) {
 	ca, vMin, vMax, okA := coneSolidParams(facesOfAny(a))
 	cb, _, _, okB := coneSolidParams(facesOfAny(b))
 	if !okA || !okB {
@@ -31,7 +32,7 @@ func coneConeImprint(a, b *topo.Body) ([]geom.Polyline, bool) {
 	}
 	window := geom.SurfaceGrid{VMin: vMin, VMax: vMax}
 	res := geom.ResolutionForBox(a.RangeBox().Union(b.RangeBox())) // model-relative loop-closure weld (#1399)
-	loops := closedTraceLoops(geom.IntersectSurfaceSurface(ca, cb, window), res)
+	loops := closedTraceLoops(geom.IntersectSurfaceSurface(ca, cb, window), res, rec)
 	if len(loops) == 0 {
 		return nil, false
 	}

--- a/kernel/brep/curved_cone_cone_imprint_test.go
+++ b/kernel/brep/curved_cone_cone_imprint_test.go
@@ -20,7 +20,7 @@ func TestConeConeImprintTwoCleanLoops(t *testing.T) {
 	fat, _ := SolidCylinderCone(math.P3(0, 0, -6), math.P3(0, 0, 6), 2, 4, "fat")
 	thin, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 0.8, 1.5, "thin")
 
-	loops, ok := coneConeImprint(thin, fat)
+	loops, ok := coneConeImprint(thin, fat, nil)
 	if !ok {
 		t.Fatal("cone–cone imprint declined; want two crossing loops")
 	}
@@ -38,7 +38,7 @@ func TestConeConeImprintTwoCleanLoops(t *testing.T) {
 func TestConeConeImprintOrderIndependent(t *testing.T) {
 	fat, _ := SolidCylinderCone(math.P3(0, 0, -6), math.P3(0, 0, 6), 2, 4, "fat")
 	thin, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 0.8, 1.5, "thin")
-	if _, ok := coneConeImprint(fat, thin); !ok {
+	if _, ok := coneConeImprint(fat, thin, nil); !ok {
 		t.Error("cone–cone imprint should resolve with the fat cone traced first too")
 	}
 }
@@ -47,7 +47,7 @@ func TestConeConeImprintOrderIndependent(t *testing.T) {
 func TestConeConeImprintConeCylinderDefer(t *testing.T) {
 	cone, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
 	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
-	if _, ok := coneConeImprint(cone, cyl); ok {
+	if _, ok := coneConeImprint(cone, cyl, nil); ok {
 		t.Error("a cone and a cylinder should defer from the cone–cone imprint (ok=false)")
 	}
 }

--- a/kernel/brep/curved_cone_cone_intersect.go
+++ b/kernel/brep/curved_cone_cone_intersect.go
@@ -3,6 +3,7 @@
 package brep
 
 import (
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 )
@@ -25,9 +26,9 @@ import (
 //
 //	thin, _ := brep.SolidCylinderCone(math.P3(-6,0,0), math.P3(6,0,0), 0.8, 1.5, "thin")
 //	fat, _  := brep.SolidCylinderCone(math.P3(0,0,-6), math.P3(0,0,6), 2, 4, "fat")
-//	res, ok := brep.ConeConeIntersect(thin, fat) // rod-cone band capped by two fat-cone lenses
-func ConeConeIntersect(a, b *topo.Body) (*topo.Body, bool) {
-	loops, ok := coneConeImprint(a, b)
+//	res, ok := brep.ConeConeIntersect(thin, fat, nil) // rod-cone band capped by two fat-cone lenses
+func ConeConeIntersect(a, b *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	loops, ok := coneConeImprint(a, b, rec)
 	if !ok || len(loops) != 2 {
 		return nil, false
 	}

--- a/kernel/brep/curved_cone_cone_intersect_test.go
+++ b/kernel/brep/curved_cone_cone_intersect_test.go
@@ -19,7 +19,7 @@ func TestConeConeIntersectThreeFaces(t *testing.T) {
 	thin, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 0.8, 1.5, "thin")
 	fat, _ := SolidCylinderCone(math.P3(0, 0, -6), math.P3(0, 0, 6), 2, 4, "fat")
 
-	res, ok := ConeConeIntersect(thin, fat)
+	res, ok := ConeConeIntersect(thin, fat, nil)
 	if !ok {
 		t.Fatal("cone–cone intersection declined; want a three-face solid")
 	}
@@ -35,7 +35,7 @@ func TestConeConeIntersectThreeFaces(t *testing.T) {
 func TestConeConeIntersectOrderIndependent(t *testing.T) {
 	thin, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 0.8, 1.5, "thin")
 	fat, _ := SolidCylinderCone(math.P3(0, 0, -6), math.P3(0, 0, 6), 2, 4, "fat")
-	if _, ok := ConeConeIntersect(fat, thin); !ok {
+	if _, ok := ConeConeIntersect(fat, thin, nil); !ok {
 		t.Error("cone–cone intersection should resolve with the fat cone passed first too")
 	}
 }
@@ -44,7 +44,7 @@ func TestConeConeIntersectOrderIndependent(t *testing.T) {
 func TestConeConeIntersectConeCylinderDefer(t *testing.T) {
 	cone, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
 	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
-	if _, ok := ConeConeIntersect(cone, cyl); ok {
+	if _, ok := ConeConeIntersect(cone, cyl, nil); ok {
 		t.Error("a cone and a cylinder should defer from the cone–cone intersection (ok=false)")
 	}
 }

--- a/kernel/brep/curved_cone_cone_join.go
+++ b/kernel/brep/curved_cone_cone_join.go
@@ -2,7 +2,10 @@
 
 package brep
 
-import "oblikovati.org/kernel/topo"
+import (
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/topo"
+)
 
 // Cone–cone join (M2 Phase 2, Oblikovati/Oblikovati#1335). The union of a cone (a tapered rod) passing right
 // through a fatter cone: one connected solid — the fat cone's two caps and its holed side wall (the two lens
@@ -20,9 +23,9 @@ import "oblikovati.org/kernel/topo"
 //
 //	thin, _ := brep.SolidCylinderCone(math.P3(-6,0,0), math.P3(6,0,0), 0.8, 1.5, "thin")
 //	fat, _  := brep.SolidCylinderCone(math.P3(0,0,-6), math.P3(0,0,6), 2, 4, "fat")
-//	res, ok := brep.ConeConeJoin(fat, thin)
-func ConeConeJoin(a, b *topo.Body) (*topo.Body, bool) {
-	p, _, ok := coneConeCrossingPartsOf(a, b)
+//	res, ok := brep.ConeConeJoin(fat, thin, nil)
+func ConeConeJoin(a, b *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	p, _, ok := coneConeCrossingPartsOf(a, b, rec)
 	if !ok {
 		return nil, false
 	}

--- a/kernel/brep/curved_cone_cone_join_test.go
+++ b/kernel/brep/curved_cone_cone_join_test.go
@@ -20,7 +20,7 @@ func TestConeConeJoinFatWithStubs(t *testing.T) {
 	fat, _ := SolidCylinderCone(math.P3(0, 0, -6), math.P3(0, 0, 6), 2, 4, "fat")
 	thin, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 0.8, 1.5, "thin")
 
-	res, ok := ConeConeJoin(fat, thin)
+	res, ok := ConeConeJoin(fat, thin, nil)
 	if !ok {
 		t.Fatal("cone ∪ cone declined; want the fat cone with two tapered stubs")
 	}
@@ -39,7 +39,7 @@ func TestConeConeJoinFatWithStubs(t *testing.T) {
 func TestConeConeJoinOrderIndependent(t *testing.T) {
 	fat, _ := SolidCylinderCone(math.P3(0, 0, -6), math.P3(0, 0, 6), 2, 4, "fat")
 	thin, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 0.8, 1.5, "thin")
-	if _, ok := ConeConeJoin(thin, fat); !ok {
+	if _, ok := ConeConeJoin(thin, fat, nil); !ok {
 		t.Error("cone ∪ cone should resolve with the rod cone passed first too")
 	}
 }

--- a/kernel/brep/curved_cone_cylinder_cut.go
+++ b/kernel/brep/curved_cone_cylinder_cut.go
@@ -3,6 +3,7 @@
 package brep
 
 import (
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -29,9 +30,9 @@ import (
 //	cone, _ := brep.SolidCylinderCone(math.P3(-6,0,0), math.P3(6,0,0), 1, 2.5, "cone")
 //	cyl, _  := brep.SolidCylinder(math.P3(0,0,-6), math.V3(0,0,1), 3, 12)
 //	res, ok := brep.ConeCylinderCut(cyl, cone) // fat with a tapered tunnel
-//	res, ok = brep.ConeCylinderCut(cone, cyl)  // the two cone stubs
-func ConeCylinderCut(target, tool *topo.Body) (*topo.Body, bool) {
-	p, ok := coneCrossingPartsOf(target, tool)
+//	res, ok = brep.ConeCylinderCut(cone, cyl, nil)  // the two cone stubs
+func ConeCylinderCut(target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	p, ok := coneCrossingPartsOf(target, tool, rec)
 	if !ok {
 		return nil, false
 	}
@@ -47,8 +48,8 @@ func ConeCylinderCut(target, tool *topo.Body) (*topo.Body, bool) {
 // coneCrossingPartsOf resolves a cone body and a cylinder body into crossingParts (with the cone as the rod),
 // or ok=false when they are not one bare cone crossing one fatter cylinder in the full-crossing configuration
 // (exactly two imprint loops, the cone the rod both loops encircle, both loops between the cone's caps).
-func coneCrossingPartsOf(a, b *topo.Body) (*crossingParts, bool) {
-	loops, ok := coneCylinderImprint(a, b)
+func coneCrossingPartsOf(a, b *topo.Body, rec *diag.Recorder) (*crossingParts, bool) {
+	loops, ok := coneCylinderImprint(a, b, rec)
 	if !ok || len(loops) != 2 {
 		return nil, false
 	}

--- a/kernel/brep/curved_cone_cylinder_cut_test.go
+++ b/kernel/brep/curved_cone_cylinder_cut_test.go
@@ -21,7 +21,7 @@ func TestConeCylinderCutDrillsFat(t *testing.T) {
 	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
 	cone, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
 
-	res, ok := ConeCylinderCut(cyl, cone)
+	res, ok := ConeCylinderCut(cyl, cone, nil)
 	if !ok {
 		t.Fatal("cone drill of cylinder declined; want a four-face solid")
 	}
@@ -39,7 +39,7 @@ func TestConeCylinderCutConeMinusFatStubs(t *testing.T) {
 	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
 	cone, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
 
-	res, ok := ConeCylinderCut(cone, cyl)
+	res, ok := ConeCylinderCut(cone, cyl, nil)
 	if !ok {
 		t.Fatal("cone − fat declined; want two tapered stubs")
 	}
@@ -58,7 +58,7 @@ func TestConeCylinderCutConeMinusFatStubs(t *testing.T) {
 func TestConeCylinderCutTwoCylindersDefer(t *testing.T) {
 	a, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
 	b, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
-	if _, ok := ConeCylinderCut(a, b); ok {
+	if _, ok := ConeCylinderCut(a, b, nil); ok {
 		t.Error("two cylinders should defer from the cone–cylinder cut (ok=false)")
 	}
 }

--- a/kernel/brep/curved_cone_cylinder_imprint.go
+++ b/kernel/brep/curved_cone_cylinder_imprint.go
@@ -3,6 +3,7 @@
 package brep
 
 import (
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 )
@@ -22,14 +23,14 @@ import (
 // or ok=false when the two bodies are not one bare cone and one bare cylinder, or no closed loop is traced.
 // The cone is the trace base, windowed to its apex-distance band [vMin, vMax]; the periodic angular
 // direction is left to the tracer.
-func coneCylinderImprint(a, b *topo.Body) ([]geom.Polyline, bool) {
+func coneCylinderImprint(a, b *topo.Body, rec *diag.Recorder) ([]geom.Polyline, bool) {
 	cone, cyl, vMin, vMax, ok := coneAndCylinder(a, b)
 	if !ok {
 		return nil, false
 	}
 	window := geom.SurfaceGrid{VMin: vMin, VMax: vMax}
 	res := geom.ResolutionForBox(a.RangeBox().Union(b.RangeBox())) // model-relative loop-closure weld (#1399)
-	loops := closedTraceLoops(geom.IntersectSurfaceSurface(cone, cyl, window), res)
+	loops := closedTraceLoops(geom.IntersectSurfaceSurface(cone, cyl, window), res, rec)
 	if len(loops) == 0 {
 		return nil, false
 	}

--- a/kernel/brep/curved_cone_cylinder_imprint_test.go
+++ b/kernel/brep/curved_cone_cylinder_imprint_test.go
@@ -20,7 +20,7 @@ func TestConeCylinderImprintTwoCleanLoops(t *testing.T) {
 	cone, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
 	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
 
-	loops, ok := coneCylinderImprint(cone, cyl)
+	loops, ok := coneCylinderImprint(cone, cyl, nil)
 	if !ok {
 		t.Fatal("cone–cylinder imprint declined; want two crossing loops")
 	}
@@ -38,7 +38,7 @@ func TestConeCylinderImprintTwoCleanLoops(t *testing.T) {
 func TestConeCylinderImprintOrderIndependent(t *testing.T) {
 	cone, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
 	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
-	if _, ok := coneCylinderImprint(cyl, cone); !ok {
+	if _, ok := coneCylinderImprint(cyl, cone, nil); !ok {
 		t.Error("cone–cylinder imprint should resolve with the cylinder passed first too")
 	}
 }
@@ -47,7 +47,7 @@ func TestConeCylinderImprintOrderIndependent(t *testing.T) {
 func TestConeCylinderImprintTwoCylindersDefer(t *testing.T) {
 	a, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
 	b, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
-	if _, ok := coneCylinderImprint(a, b); ok {
+	if _, ok := coneCylinderImprint(a, b, nil); ok {
 		t.Error("two cylinders should defer from the cone–cylinder imprint (ok=false)")
 	}
 }

--- a/kernel/brep/curved_cone_cylinder_intersect.go
+++ b/kernel/brep/curved_cone_cylinder_intersect.go
@@ -3,6 +3,7 @@
 package brep
 
 import (
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 )
@@ -25,13 +26,13 @@ import (
 //
 //	cone, _ := brep.SolidCylinderCone(math.P3(-6,0,0), math.P3(6,0,0), 1, 2.5, "cone")
 //	cyl, _  := brep.SolidCylinder(math.P3(0,0,-6), math.V3(0,0,1), 3, 12)
-//	res, ok := brep.ConeCylinderIntersect(cone, cyl) // cone band capped by two lenses
-func ConeCylinderIntersect(a, b *topo.Body) (*topo.Body, bool) {
+//	res, ok := brep.ConeCylinderIntersect(cone, cyl, nil) // cone band capped by two lenses
+func ConeCylinderIntersect(a, b *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	cone, cyl, vMin, vMax, ok := coneAndCylinder(a, b)
 	if !ok {
 		return nil, false
 	}
-	loops, ok := coneCylinderImprint(a, b)
+	loops, ok := coneCylinderImprint(a, b, rec)
 	if !ok || len(loops) != 2 {
 		return nil, false
 	}

--- a/kernel/brep/curved_cone_cylinder_intersect_test.go
+++ b/kernel/brep/curved_cone_cylinder_intersect_test.go
@@ -20,7 +20,7 @@ func TestConeCylinderIntersectThreeFaces(t *testing.T) {
 	cone, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
 	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
 
-	res, ok := ConeCylinderIntersect(cone, cyl)
+	res, ok := ConeCylinderIntersect(cone, cyl, nil)
 	if !ok {
 		t.Fatal("cone–cylinder intersection declined; want a three-face solid")
 	}
@@ -52,7 +52,7 @@ func TestConeCylinderIntersectThreeFaces(t *testing.T) {
 func TestConeCylinderIntersectOrderIndependent(t *testing.T) {
 	cone, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
 	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
-	if _, ok := ConeCylinderIntersect(cyl, cone); !ok {
+	if _, ok := ConeCylinderIntersect(cyl, cone, nil); !ok {
 		t.Error("cone–cylinder intersection should resolve with the cylinder passed first too")
 	}
 }
@@ -61,7 +61,7 @@ func TestConeCylinderIntersectOrderIndependent(t *testing.T) {
 func TestConeCylinderIntersectTwoCylindersDefer(t *testing.T) {
 	a, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
 	b, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
-	if _, ok := ConeCylinderIntersect(a, b); ok {
+	if _, ok := ConeCylinderIntersect(a, b, nil); ok {
 		t.Error("two cylinders should defer from the cone–cylinder assembler (ok=false)")
 	}
 }

--- a/kernel/brep/curved_cone_cylinder_join.go
+++ b/kernel/brep/curved_cone_cylinder_join.go
@@ -2,7 +2,10 @@
 
 package brep
 
-import "oblikovati.org/kernel/topo"
+import (
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/topo"
+)
 
 // Cone–cylinder join (M2 Phase 2, Oblikovati/Oblikovati#1335). The union of a cone (a tapered rod) passing
 // right through a fatter cylinder: one connected solid — the fat's two caps and its holed side wall (the two
@@ -19,9 +22,9 @@ import "oblikovati.org/kernel/topo"
 //
 //	cone, _ := brep.SolidCylinderCone(math.P3(-6,0,0), math.P3(6,0,0), 1, 2.5, "cone")
 //	cyl, _  := brep.SolidCylinder(math.P3(0,0,-6), math.V3(0,0,1), 3, 12)
-//	res, ok := brep.ConeCylinderJoin(cyl, cone)
-func ConeCylinderJoin(a, b *topo.Body) (*topo.Body, bool) {
-	p, ok := coneCrossingPartsOf(a, b)
+//	res, ok := brep.ConeCylinderJoin(cyl, cone, nil)
+func ConeCylinderJoin(a, b *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	p, ok := coneCrossingPartsOf(a, b, rec)
 	if !ok {
 		return nil, false
 	}

--- a/kernel/brep/curved_cone_cylinder_join_test.go
+++ b/kernel/brep/curved_cone_cylinder_join_test.go
@@ -19,7 +19,7 @@ func TestConeCylinderJoinFatWithStubs(t *testing.T) {
 	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
 	cone, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
 
-	res, ok := ConeCylinderJoin(cyl, cone)
+	res, ok := ConeCylinderJoin(cyl, cone, nil)
 	if !ok {
 		t.Fatal("cone ∪ cylinder declined; want the fat with two tapered stubs")
 	}
@@ -38,7 +38,7 @@ func TestConeCylinderJoinFatWithStubs(t *testing.T) {
 func TestConeCylinderJoinOrderIndependent(t *testing.T) {
 	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
 	cone, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
-	if _, ok := ConeCylinderJoin(cone, cyl); !ok {
+	if _, ok := ConeCylinderJoin(cone, cyl, nil); !ok {
 		t.Error("cone ∪ cylinder should resolve with the cone passed first too")
 	}
 }

--- a/kernel/brep/curved_cone_partial_penetration_test.go
+++ b/kernel/brep/curved_cone_partial_penetration_test.go
@@ -29,7 +29,7 @@ func conePartialFat() *topo.Body {
 // TestConePartialPlugThreeFaces: the cone ∩ fat plug is a watertight three-face solid — the fat-wall lens
 // cap (cylinder), the cone stub band, and the cone's blind end cap (plane).
 func TestConePartialPlugThreeFaces(t *testing.T) {
-	res, ok := PartialPenetrationIntersect(conePartialFat(), conePartialFrustum())
+	res, ok := PartialPenetrationIntersect(conePartialFat(), conePartialFrustum(), nil)
 	if !ok {
 		t.Fatal("cone partial plug declined; want a three-face plug")
 	}
@@ -44,7 +44,7 @@ func TestConePartialPlugThreeFaces(t *testing.T) {
 // TestConePartialBlindHole: fat − cone is a watertight blind pocket — two fat caps, the holed wall, the cone
 // tunnel band, and the cone's blind end cap as the pocket bottom (5 faces).
 func TestConePartialBlindHole(t *testing.T) {
-	res, ok := PartialPenetrationCut(conePartialFat(), conePartialFrustum())
+	res, ok := PartialPenetrationCut(conePartialFat(), conePartialFrustum(), nil)
 	if !ok {
 		t.Fatal("cone blind hole declined; want a five-face pocketed solid")
 	}
@@ -59,7 +59,7 @@ func TestConePartialBlindHole(t *testing.T) {
 // TestConePartialConeMinusFatStub: cone − fat is the single tapered stub sticking out the entry side (one
 // shell — a partial penetration sticks out one side only, unlike a full crossing's two stubs).
 func TestConePartialConeMinusFatStub(t *testing.T) {
-	res, ok := PartialPenetrationCut(conePartialFrustum(), conePartialFat())
+	res, ok := PartialPenetrationCut(conePartialFrustum(), conePartialFat(), nil)
 	if !ok {
 		t.Fatal("cone − fat (partial) declined; want a single stub")
 	}
@@ -72,7 +72,7 @@ func TestConePartialConeMinusFatStub(t *testing.T) {
 // TestConePartialJoin: fat ∪ cone is one connected solid — the fat with a single tapered stub sticking out
 // the entry side (5 faces, one shell).
 func TestConePartialJoin(t *testing.T) {
-	res, ok := PartialPenetrationJoin(conePartialFat(), conePartialFrustum())
+	res, ok := PartialPenetrationJoin(conePartialFat(), conePartialFrustum(), nil)
 	if !ok {
 		t.Fatal("fat ∪ cone (partial) declined; want the fat with one tapered stub")
 	}
@@ -89,7 +89,7 @@ func TestConePartialJoin(t *testing.T) {
 
 // TestConePartialOrderIndependent: the plug resolves whichever body is passed first.
 func TestConePartialOrderIndependent(t *testing.T) {
-	if _, ok := PartialPenetrationIntersect(conePartialFrustum(), conePartialFat()); !ok {
+	if _, ok := PartialPenetrationIntersect(conePartialFrustum(), conePartialFat(), nil); !ok {
 		t.Error("cone partial plug should resolve with the cone passed first too")
 	}
 }

--- a/kernel/brep/curved_crossing_cut.go
+++ b/kernel/brep/curved_crossing_cut.go
@@ -5,6 +5,7 @@ package brep
 import (
 	stdmath "math"
 
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -30,9 +31,9 @@ import (
 //	fat, _  := brep.SolidCylinder(math.P3(0,0,-6), math.V3(0,0,1), 3, 12)
 //	thin, _ := brep.SolidCylinder(math.P3(-6,0,0), math.V3(1,0,0), 1.5, 12)
 //	res, ok := brep.CrossingCylinderCut(fat, thin) // fat with a tunnel
-//	res, ok = brep.CrossingCylinderCut(thin, fat)  // the two rod stubs
-func CrossingCylinderCut(target, tool *topo.Body) (*topo.Body, bool) {
-	p, ok := crossingPartsOf(target, tool)
+//	res, ok = brep.CrossingCylinderCut(thin, fat, nil)  // the two rod stubs
+func CrossingCylinderCut(target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	p, ok := crossingPartsOf(target, tool, rec)
 	if !ok {
 		return nil, false
 	}
@@ -63,8 +64,8 @@ type crossingParts struct {
 // crossingPartsOf resolves two bodies into crossingParts, or ok=false when they are not two bare cylinders
 // crossing in the thin-through-fat configuration (exactly two imprint loops, one cylinder the rod both
 // encircle).
-func crossingPartsOf(a, b *topo.Body) (*crossingParts, bool) {
-	loops, ok := crossingCylinderImprint(a, b)
+func crossingPartsOf(a, b *topo.Body, rec *diag.Recorder) (*crossingParts, bool) {
+	loops, ok := crossingCylinderImprint(a, b, rec)
 	if !ok || len(loops) != 2 {
 		return nil, false
 	}

--- a/kernel/brep/curved_crossing_cut_test.go
+++ b/kernel/brep/curved_crossing_cut_test.go
@@ -21,7 +21,7 @@ func TestCrossingCylinderCutDrill(t *testing.T) {
 	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
 	thin, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
 
-	res, ok := CrossingCylinderCut(fat, thin)
+	res, ok := CrossingCylinderCut(fat, thin, nil)
 	if !ok {
 		t.Fatal("drill (fat − rod) declined; want a four-face solid")
 	}
@@ -73,7 +73,7 @@ func TestCrossingCylinderCutRodMinusFatStubs(t *testing.T) {
 	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
 	thin, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
 
-	res, ok := CrossingCylinderCut(thin, fat) // target is the rod
+	res, ok := CrossingCylinderCut(thin, fat, nil) // target is the rod
 	if !ok {
 		t.Fatal("rod − fat declined; want two disconnected rod stubs")
 	}
@@ -97,7 +97,7 @@ func TestCrossingCylinderCutRodMinusFatStubs(t *testing.T) {
 func TestCrossingCylinderCutNonCylinderDefers(t *testing.T) {
 	block, _ := SolidBlock(math.P3(-2, -2, -2), math.P3(2, 2, 2), "b")
 	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 1, 12)
-	if _, ok := CrossingCylinderCut(block, cyl); ok {
+	if _, ok := CrossingCylinderCut(block, cyl, nil); ok {
 		t.Error("a block − cylinder should defer from the drill assembler (ok=false)")
 	}
 }

--- a/kernel/brep/curved_crossing_imprint.go
+++ b/kernel/brep/curved_crossing_imprint.go
@@ -3,6 +3,7 @@
 package brep
 
 import (
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -17,21 +18,30 @@ import (
 //
 // Scope note: a thinner cylinder crossing a fatter one (radii unequal) gives clean, well-separated closed
 // loops (a rod's entry/exit through the fat wall). Two EQUAL-radius perpendicular cylinders intersect in
-// two ellipses that cross at pinch points where the tracer's continuation struggles; that degenerate
-// (Steinmetz) case is left to a later slice, which can fit those planar loops to exact ellipses.
+// two ellipses that cross at pinch points; the SSI tracer now follows each ellipse straight through those
+// pinches (Oblikovati#1404), so this returns the two closed loops there too. The bicylinder SOLID is still
+// assembled by the exact analytic constructor (curved_steinmetz.go) because its four-lobe topology differs
+// from the rod-band result this file builds — full unification onto the traced loops is tracked under the
+// general curved∩curved pipeline (Oblikovati#1403).
+
+// CodeImprintUnclosedChain marks an SSI imprint that dropped a traced chain because it did not close into
+// a loop — the typed signal (#1404) that replaces silently discarding it, so a caller/test can SEE the
+// imprint degraded (and the boolean will fall back) rather than discover it later downstream.
+const CodeImprintUnclosedChain diag.Code = "imprint.unclosed-chain"
 
 // crossingCylinderImprint returns the intersection loops of two bare cylinder bodies as closed polylines,
 // or ok=false when either body is not a bare cylinder or no closed loop is traced. The trace window spans
 // the first body's axial extent (the cylinders cross within it), and the periodic angular direction is
-// resolved by the tracer automatically.
-func crossingCylinderImprint(a, b *topo.Body) ([]geom.Polyline, bool) {
+// resolved by the tracer automatically. A non-nil rec receives a diagnostic for any traced chain that
+// failed to close (#1404).
+func crossingCylinderImprint(a, b *topo.Body, rec *diag.Recorder) ([]geom.Polyline, bool) {
 	ca, baseA, heightA, okA := cylinderSolidParams(facesOfAny(a))
 	cb, _, _, okB := cylinderSolidParams(facesOfAny(b))
 	if !okA || !okB {
 		return nil, false
 	}
 	res := geom.ResolutionForBox(a.RangeBox().Union(b.RangeBox())) // model-relative loop-closure weld (#1399)
-	loops := closedTraceLoops(geom.IntersectSurfaceSurface(ca, cb, cylinderTraceWindow(ca, baseA, heightA)), res)
+	loops := closedTraceLoops(geom.IntersectSurfaceSurface(ca, cb, cylinderTraceWindow(ca, baseA, heightA)), res, rec)
 	if len(loops) == 0 {
 		return nil, false
 	}
@@ -46,11 +56,19 @@ func cylinderTraceWindow(c geom.Cylinder, base math.Point3, height float64) geom
 }
 
 // closedTraceLoops keeps the traced polylines that close into a loop (first point meets last), building a
-// geom.Polyline from each. An open chain — where the tracer broke at a tangency or pinch — is dropped, so
-// the imprint carries only watertight boundary loops.
-func closedTraceLoops(raw [][]math.Point3, res geom.Resolution) []geom.Polyline {
+// geom.Polyline from each. An open chain that is more than a single tangency marker but never closed — the
+// tracer broke at a pinch it could not cross — is dropped from the watertight boundary, but no longer
+// silently: it raises a CodeImprintUnclosedChain diagnostic on rec so the degradation is visible (#1404).
+// Single/short point markers (an isolated tangential contact) are not chains and are skipped quietly.
+func closedTraceLoops(raw [][]math.Point3, res geom.Resolution, rec *diag.Recorder) []geom.Polyline {
 	var out []geom.Polyline
 	for _, pts := range raw {
+		if len(pts) >= 4 && !samePoint(pts[0], pts[len(pts)-1], res) {
+			rec.Recordf(CodeImprintUnclosedChain, diag.Defect,
+				"SSI traced a %d-point chain that did not close (endpoint gap %g > weld %g): dropped from the imprint",
+				len(pts), float64(pts[0].DistanceTo(pts[len(pts)-1])), res.Weld())
+			continue
+		}
 		if len(pts) < 4 || !samePoint(pts[0], pts[len(pts)-1], res) {
 			continue
 		}

--- a/kernel/brep/curved_crossing_imprint_test.go
+++ b/kernel/brep/curved_crossing_imprint_test.go
@@ -6,6 +6,7 @@ import (
 	stdmath "math"
 	"testing"
 
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/math"
 )
@@ -31,7 +32,7 @@ func TestCrossingCylinderImprintThinThroughFat(t *testing.T) {
 	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)    // axis z, R=3
 	thin, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12) // axis x, r=1.5, through the centre
 
-	loops, ok := crossingCylinderImprint(fat, thin)
+	loops, ok := crossingCylinderImprint(fat, thin, nil)
 	if !ok || len(loops) != 2 {
 		t.Fatalf("thin-through-fat imprint: ok=%v loops=%d, want 2 closed loops", ok, len(loops))
 	}
@@ -47,11 +48,87 @@ func TestCrossingCylinderImprintThinThroughFat(t *testing.T) {
 	}
 }
 
+// TestClosedTraceLoopsRecordsUnclosedChain: a traced chain that does not close (more than a single
+// tangency marker, endpoints apart) must be DROPPED from the watertight imprint but NOT silently — it
+// raises a CodeImprintUnclosedChain diagnostic so the degradation is visible (Oblikovati#1404).
+func TestClosedTraceLoopsRecordsUnclosedChain(t *testing.T) {
+	res := geom.ResolutionForSize(10)
+	open := []math.Point3{math.P3(0, 0, 0), math.P3(1, 0, 0), math.P3(2, 0, 0), math.P3(5, 0, 0)} // ends 5 apart
+	rec := &diag.Recorder{}
+	loops := closedTraceLoops([][]math.Point3{open}, res, rec)
+	if len(loops) != 0 {
+		t.Fatalf("an unclosed chain yielded %d loops, want 0 (it must be dropped)", len(loops))
+	}
+	if !rec.Has(CodeImprintUnclosedChain) {
+		t.Errorf("dropping an unclosed chain recorded no %q diagnostic; got %v", CodeImprintUnclosedChain, rec.Records())
+	}
+	if rec.Count(diag.Defect) != 1 {
+		t.Errorf("recorded %d defects, want exactly 1 for the one dropped chain", rec.Count(diag.Defect))
+	}
+}
+
+// TestClosedTraceLoopsQuietOnCleanTrace: a closed loop is kept and a single-point tangency marker is
+// skipped, neither raising a diagnostic — only a genuine unclosed chain is a tracked defect (#1404).
+func TestClosedTraceLoopsQuietOnCleanTrace(t *testing.T) {
+	res := geom.ResolutionForSize(10)
+	square := []math.Point3{math.P3(0, 0, 0), math.P3(1, 0, 0), math.P3(1, 1, 0), math.P3(0, 1, 0), math.P3(0, 0, 0)}
+	marker := []math.Point3{math.P3(9, 9, 9)} // an isolated tangential contact, not a chain
+	rec := &diag.Recorder{}
+	loops := closedTraceLoops([][]math.Point3{square, marker}, res, rec)
+	if len(loops) != 1 {
+		t.Fatalf("got %d loops, want 1 (the closed square; the marker is not a loop)", len(loops))
+	}
+	if rec.Count(diag.Defect) != 0 {
+		t.Errorf("a clean trace recorded %d defects, want 0; got %v", rec.Count(diag.Defect), rec.Records())
+	}
+}
+
+// TestCrossingCylinderImprintEqualRadiusPinch: the equal-radius Steinmetz case — two ellipses crossing at
+// two pinch points — used to break the tracer (it stopped at the first pinch), which is why an analytic
+// Steinmetz constructor exists. The through-pinch tracer (Oblikovati#1404) now returns both closed ellipse
+// loops here too: this pins the prerequisite the general curved∩curved pipeline (#1403) needs to one day
+// fold curved_steinmetz.go onto the traced path. Each loop must be a planar ellipse of minor radius R and
+// major radius R√2 (the Steinmetz ellipse), lying on both cylinders.
+func TestCrossingCylinderImprintEqualRadiusPinch(t *testing.T) {
+	const r = 3.0
+	a, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), r, 12) // axis x
+	b, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), r, 12) // axis z
+	loops, ok := crossingCylinderImprint(a, b, nil)
+	if !ok || len(loops) != 2 {
+		t.Fatalf("equal-radius imprint: ok=%v loops=%d, want 2 closed Steinmetz ellipses", ok, len(loops))
+	}
+	ca, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(1, 0, 0), r)
+	cb, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), r)
+	for i, lp := range loops {
+		if !samePoint(lp.PointAt(0), lp.PointAt(1), geom.ResolutionForSize(1)) {
+			t.Errorf("loop %d is not closed: %v vs %v", i, lp.PointAt(0), lp.PointAt(1))
+		}
+		if err := onBothCylinders(lp, ca, cb); err > 1e-4 {
+			t.Errorf("loop %d sits %.2e off a cylinder surface", i, err)
+		}
+		near, far := loopRadialExtent(lp)
+		if stdmath.Abs(near-r) > 1e-3 || stdmath.Abs(far-stdmath.Sqrt2*r) > 1e-3 {
+			t.Errorf("loop %d radial extent [%.4f,%.4f], want [R=%.4f, R√2=%.4f] (a Steinmetz ellipse)", i, near, far, r, stdmath.Sqrt2*r)
+		}
+	}
+}
+
+// loopRadialExtent returns the min and max distance of a loop's vertices from the origin — for a Steinmetz
+// ellipse (centred at the axis crossing) this is its minor (R) and major (R√2) semi-axis length.
+func loopRadialExtent(lp geom.Polyline) (near, far float64) {
+	near, far = stdmath.Inf(1), 0
+	for _, p := range lp.Vertices {
+		d := float64(p.AsVector().Length())
+		near, far = stdmath.Min(near, d), stdmath.Max(far, d)
+	}
+	return near, far
+}
+
 // TestCrossingCylinderImprintNonCylinderDefers: the imprint only handles bare cylinders.
 func TestCrossingCylinderImprintNonCylinderDefers(t *testing.T) {
 	block, _ := SolidBlock(math.P3(0, 0, 0), math.P3(2, 2, 2), "b")
 	cyl, _ := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 1, 4)
-	if _, ok := crossingCylinderImprint(block, cyl); ok {
+	if _, ok := crossingCylinderImprint(block, cyl, nil); ok {
 		t.Error("imprint of a block and a cylinder should defer (ok=false)")
 	}
 }
@@ -60,7 +137,7 @@ func TestCrossingCylinderImprintNonCylinderDefers(t *testing.T) {
 func TestCrossingCylinderImprintDisjointHasNoLoops(t *testing.T) {
 	a, _ := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 1, 4)
 	b, _ := SolidCylinder(math.P3(20, 0, 0), math.V3(1, 0, 0), 1, 4) // far away
-	if _, ok := crossingCylinderImprint(a, b); ok {
+	if _, ok := crossingCylinderImprint(a, b, nil); ok {
 		t.Error("disjoint cylinders should trace no imprint loop (ok=false)")
 	}
 }

--- a/kernel/brep/curved_crossing_intersect.go
+++ b/kernel/brep/curved_crossing_intersect.go
@@ -5,6 +5,7 @@ package brep
 import (
 	stdmath "math"
 
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -31,9 +32,9 @@ func crossLin(role string) topo.Lineage { return topo.NewLineage(topo.Tok("cross
 //
 //	fat, _  := brep.SolidCylinder(math.P3(0,0,-6), math.V3(0,0,1), 3, 12)
 //	thin, _ := brep.SolidCylinder(math.P3(-6,0,0), math.V3(1,0,0), 1.5, 12)
-//	res, ok := brep.CrossingCylinderIntersect(fat, thin) // rod band capped by two lenses
-func CrossingCylinderIntersect(a, b *topo.Body) (*topo.Body, bool) {
-	loops, ok := crossingCylinderImprint(a, b)
+//	res, ok := brep.CrossingCylinderIntersect(fat, thin, nil) // rod band capped by two lenses
+func CrossingCylinderIntersect(a, b *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	loops, ok := crossingCylinderImprint(a, b, rec)
 	if !ok || len(loops) != 2 {
 		return nil, false
 	}

--- a/kernel/brep/curved_crossing_intersect_test.go
+++ b/kernel/brep/curved_crossing_intersect_test.go
@@ -44,7 +44,7 @@ func TestCrossingCylinderIntersectThinThroughFat(t *testing.T) {
 	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
 	thin, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
 
-	res, ok := CrossingCylinderIntersect(fat, thin)
+	res, ok := CrossingCylinderIntersect(fat, thin, nil)
 	if !ok {
 		t.Fatal("thin-through-fat intersection declined; want a three-face solid")
 	}
@@ -57,7 +57,7 @@ func TestCrossingCylinderIntersectOrderIndependent(t *testing.T) {
 	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
 	thin, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
 
-	res, ok := CrossingCylinderIntersect(thin, fat) // rod first
+	res, ok := CrossingCylinderIntersect(thin, fat, nil) // rod first
 	if !ok {
 		t.Fatal("rod-first intersection declined; the assembly must be order-independent")
 	}
@@ -68,7 +68,7 @@ func TestCrossingCylinderIntersectOrderIndependent(t *testing.T) {
 func TestCrossingCylinderIntersectNonCylinderDefers(t *testing.T) {
 	block, _ := SolidBlock(math.P3(-2, -2, -2), math.P3(2, 2, 2), "b")
 	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 1, 12)
-	if _, ok := CrossingCylinderIntersect(block, cyl); ok {
+	if _, ok := CrossingCylinderIntersect(block, cyl, nil); ok {
 		t.Error("intersection of a block and a cylinder should defer (ok=false)")
 	}
 }

--- a/kernel/brep/curved_crossing_join.go
+++ b/kernel/brep/curved_crossing_join.go
@@ -3,6 +3,7 @@
 package brep
 
 import (
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -28,9 +29,9 @@ import (
 //
 //	fat, _  := brep.SolidCylinder(math.P3(0,0,-6), math.V3(0,0,1), 3, 12)
 //	thin, _ := brep.SolidCylinder(math.P3(-6,0,0), math.V3(1,0,0), 1.5, 12)
-//	res, ok := brep.CrossingCylinderJoin(fat, thin)
-func CrossingCylinderJoin(a, b *topo.Body) (*topo.Body, bool) {
-	p, ok := crossingPartsOf(a, b)
+//	res, ok := brep.CrossingCylinderJoin(fat, thin, nil)
+func CrossingCylinderJoin(a, b *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	p, ok := crossingPartsOf(a, b, rec)
 	if !ok {
 		return nil, false
 	}

--- a/kernel/brep/curved_crossing_join_test.go
+++ b/kernel/brep/curved_crossing_join_test.go
@@ -21,7 +21,7 @@ func TestCrossingCylinderJoinStubs(t *testing.T) {
 	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
 	thin, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
 
-	res, ok := CrossingCylinderJoin(fat, thin)
+	res, ok := CrossingCylinderJoin(fat, thin, nil)
 	if !ok {
 		t.Fatal("join (fat ∪ rod) declined; want a single-shell stub solid")
 	}
@@ -62,7 +62,7 @@ func TestCrossingCylinderJoinStubs(t *testing.T) {
 func TestCrossingCylinderJoinNonCylinderDefers(t *testing.T) {
 	block, _ := SolidBlock(math.P3(-2, -2, -2), math.P3(2, 2, 2), "b")
 	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 1, 12)
-	if _, ok := CrossingCylinderJoin(block, cyl); ok {
+	if _, ok := CrossingCylinderJoin(block, cyl, nil); ok {
 		t.Error("a block ∪ cylinder should defer from the join assembler (ok=false)")
 	}
 }

--- a/kernel/brep/curved_partial_penetration.go
+++ b/kernel/brep/curved_partial_penetration.go
@@ -5,6 +5,7 @@ package brep
 import (
 	stdmath "math"
 
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -36,9 +37,9 @@ func partLin(role string) topo.Lineage { return topo.NewLineage(topo.Tok("partpe
 //
 //	fat, _  := brep.SolidCylinder(math.P3(0,0,-6), math.V3(0,0,1), 3, 12)
 //	stub, _ := brep.SolidCylinder(math.P3(-6,0,0), math.V3(1,0,0), 1.5, 6) // ends at x=0, inside the fat
-//	res, ok := brep.PartialPenetrationIntersect(fat, stub)
-func PartialPenetrationIntersect(a, b *topo.Body) (*topo.Body, bool) {
-	p, ok := partialPlugPartsOf(a, b)
+//	res, ok := brep.PartialPenetrationIntersect(fat, stub, nil)
+func PartialPenetrationIntersect(a, b *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	p, ok := partialPlugPartsOf(a, b, rec)
 	if !ok {
 		return nil, false
 	}
@@ -67,24 +68,24 @@ type partialPlugParts struct {
 // full crossing and return both loops). Which body is the rod is unknown up front, so both orderings are
 // tried; the rod-first ordering is the one that yields exactly one loop encircling that body and exactly one
 // of that body's ends inside the other.
-func partialPlugPartsOf(a, b *topo.Body) (*partialPlugParts, bool) {
-	if p, ok := tryPartialPlug(a, b); ok {
+func partialPlugPartsOf(a, b *topo.Body, rec *diag.Recorder) (*partialPlugParts, bool) {
+	if p, ok := tryPartialPlug(a, b, rec); ok {
 		return p, true
 	}
-	if p, ok := tryPartialPlug(b, a); ok {
+	if p, ok := tryPartialPlug(b, a, rec); ok {
 		return p, true
 	}
-	if p, ok := tryConePartialPlug(a, b); ok {
+	if p, ok := tryConePartialPlug(a, b, rec); ok {
 		return p, true
 	}
-	return tryConePartialPlug(b, a)
+	return tryConePartialPlug(b, a, rec)
 }
 
 // tryPartialPlug resolves a cylinder-rod partial plug treating rodBody as the penetrating rod (traced first),
 // or ok=false when that does not hold: not exactly one imprint loop, the loop does not encircle rodBody, or
 // not exactly one of rodBody's ends lies inside fatBody.
-func tryPartialPlug(rodBody, fatBody *topo.Body) (*partialPlugParts, bool) {
-	loops, ok := crossingCylinderImprint(rodBody, fatBody)
+func tryPartialPlug(rodBody, fatBody *topo.Body, rec *diag.Recorder) (*partialPlugParts, bool) {
+	loops, ok := crossingCylinderImprint(rodBody, fatBody, rec)
 	if !ok {
 		return nil, false
 	}
@@ -102,8 +103,8 @@ func tryPartialPlug(rodBody, fatBody *topo.Body) (*partialPlugParts, bool) {
 // coneCylinderImprint always traces the cone within its own apex-distance band, so a cone ending inside the
 // fat yields the single entry loop (the blind end is interior, no exit loop). ok=false unless coneBody is a
 // bare cone, fatBody a bare cylinder, and the partial-plug conditions hold (see partialPlugFrom).
-func tryConePartialPlug(coneBody, fatBody *topo.Body) (*partialPlugParts, bool) {
-	loops, ok := coneCylinderImprint(coneBody, fatBody)
+func tryConePartialPlug(coneBody, fatBody *topo.Body, rec *diag.Recorder) (*partialPlugParts, bool) {
+	loops, ok := coneCylinderImprint(coneBody, fatBody, rec)
 	if !ok {
 		return nil, false
 	}
@@ -210,9 +211,9 @@ func partialPlug(p *partialPlugParts) *topo.Body {
 //	fat, _  := brep.SolidCylinder(math.P3(0,0,-6), math.V3(0,0,1), 3, 12)
 //	stub, _ := brep.SolidCylinder(math.P3(-6,0,0), math.V3(1,0,0), 1.5, 6)
 //	res, ok := brep.PartialPenetrationCut(fat, stub) // fat with a blind pocket
-//	res, ok = brep.PartialPenetrationCut(stub, fat)  // the rod stub outside the fat
-func PartialPenetrationCut(target, tool *topo.Body) (*topo.Body, bool) {
-	p, ok := partialPlugPartsOf(target, tool)
+//	res, ok = brep.PartialPenetrationCut(stub, fat, nil)  // the rod stub outside the fat
+func PartialPenetrationCut(target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	p, ok := partialPlugPartsOf(target, tool, rec)
 	if !ok {
 		return nil, false
 	}
@@ -233,8 +234,8 @@ func partialRodMinusFat(p *partialPlugParts) *topo.Body {
 // to defer. The result is the fat with a single rod STUB sticking out the entry side: the fat's two caps,
 // its holed side wall, the rod-wall stub band from the lens out to the rod's entry end, and the rod's entry
 // end cap.
-func PartialPenetrationJoin(a, b *topo.Body) (*topo.Body, bool) {
-	p, ok := partialPlugPartsOf(a, b)
+func PartialPenetrationJoin(a, b *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	p, ok := partialPlugPartsOf(a, b, rec)
 	if !ok {
 		return nil, false
 	}

--- a/kernel/brep/curved_partial_penetration_test.go
+++ b/kernel/brep/curved_partial_penetration_test.go
@@ -21,7 +21,7 @@ func TestPartialPenetrationPlugIsWatertight(t *testing.T) {
 	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
 	stub, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 6) // ends at x=0, inside the fat
 
-	res, ok := PartialPenetrationIntersect(fat, stub)
+	res, ok := PartialPenetrationIntersect(fat, stub, nil)
 	if !ok {
 		t.Fatal("partial-penetration intersection declined; want a three-face plug")
 	}
@@ -56,7 +56,7 @@ func TestPartialPenetrationBlindHoleIsWatertight(t *testing.T) {
 	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
 	stub, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 6)
 
-	res, ok := PartialPenetrationCut(fat, stub)
+	res, ok := PartialPenetrationCut(fat, stub, nil)
 	if !ok {
 		t.Fatal("blind-hole cut declined; want a five-face pocketed solid")
 	}
@@ -97,7 +97,7 @@ func TestPartialPenetrationJoinIsWatertight(t *testing.T) {
 	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
 	stub, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 6)
 
-	res, ok := PartialPenetrationJoin(fat, stub)
+	res, ok := PartialPenetrationJoin(fat, stub, nil)
 	if !ok {
 		t.Fatal("partial-penetration join declined; want a five-face stubbed solid")
 	}
@@ -132,7 +132,7 @@ func TestPartialPenetrationRodMinusFatStub(t *testing.T) {
 	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
 	stub, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 6)
 
-	res, ok := PartialPenetrationCut(stub, fat) // target is the rod
+	res, ok := PartialPenetrationCut(stub, fat, nil) // target is the rod
 	if !ok {
 		t.Fatal("rod − fat declined; want a single rod stub lump")
 	}
@@ -157,7 +157,7 @@ func TestPartialPenetrationRodMinusFatStub(t *testing.T) {
 func TestPartialPenetrationFullCrossingDefers(t *testing.T) {
 	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
 	thru, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12) // spans both walls
-	if _, ok := PartialPenetrationIntersect(fat, thru); ok {
+	if _, ok := PartialPenetrationIntersect(fat, thru, nil); ok {
 		t.Error("a full crossing (two loops) should defer from the plug assembler (ok=false)")
 	}
 }
@@ -167,7 +167,7 @@ func TestPartialPenetrationFullCrossingDefers(t *testing.T) {
 func TestPartialPenetrationContainedRodDefers(t *testing.T) {
 	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
 	inside, _ := SolidCylinder(math.P3(-1, 0, 0), math.V3(1, 0, 0), 0.5, 2) // x∈[-1,1], wholly inside
-	if _, ok := PartialPenetrationIntersect(fat, inside); ok {
+	if _, ok := PartialPenetrationIntersect(fat, inside, nil); ok {
 		t.Error("a fully-contained rod should defer from the plug assembler (ok=false)")
 	}
 }

--- a/kernel/brep/curved_steinmetz.go
+++ b/kernel/brep/curved_steinmetz.go
@@ -11,10 +11,13 @@ import (
 )
 
 // Equal-radius Steinmetz intersection (M2 Phase 2, Oblikovati/Oblikovati#1335). Two EQUAL-radius
-// perpendicular cylinders crossing through a common axis point intersect in the Steinmetz bicylinder. This
-// is the degenerate case the SSI imprint tracer cannot trace: the intersection curve is NOT a quartic
-// saddle but two planar ELLIPSES that cross at two pinch points (where the tracer's continuation stalls),
-// so it is fitted analytically here instead.
+// perpendicular cylinders crossing through a common axis point intersect in the Steinmetz bicylinder: the
+// intersection curve is NOT a quartic saddle but two planar ELLIPSES that cross at two pinch points. The
+// SSI imprint tracer now follows each ellipse straight through those pinches (Oblikovati#1404), so the
+// crossing imprint returns the two loops here too; but the bicylinder's four-lobe SOLID is still assembled
+// from EXACT analytic ellipse edges below (sharper than traced polylines, and a different topology from the
+// rod-band crossing result). Folding this constructor into a general loop→solid stitch is tracked under the
+// curved∩curved pipeline (Oblikovati#1403), for which the through-pinch tracer is the prerequisite.
 //
 // Geometry in the frame (a = axis A, b = axis B, n = a×b) through the axis crossing O, with equal radius R:
 // a surface point O + α·a + β·b + γ·n is on cyl A when β²+γ²=R² and on cyl B when α²+γ²=R², so on both when

--- a/kernel/geom/intersect_surface_trace.go
+++ b/kernel/geom/intersect_surface_trace.go
@@ -14,7 +14,13 @@ import (
 // saddle branches arbitrarily. This tracer instead marches the joint zero of the two surfaces: from
 // each seed it corrects onto the curve (project onto the intersection of the two tangent planes) and
 // steps along nb×no, the curve tangent, with adaptive direction — so loops close, branches stay
-// connected, and a tangency (parallel normals) is reported as a point rather than dropped.
+// connected, and an isolated tangency (parallel normals) is reported as a point rather than dropped.
+//
+// A curve that PASSES THROUGH a tangency or pinch — where two intersection branches cross and the
+// surface normals momentarily align, e.g. the two ellipses of an equal-radius Steinmetz crossing — is
+// traced straight through the singularity rather than stopping at it (Oblikovati#1404): the corrector
+// damps to a steepest-descent step where the tangent-plane intersection is ill-conditioned, so the
+// march re-acquires the curve on the far side and the loop closes instead of being dropped open.
 
 const (
 	ssiCorrectIters     = 40   // max corrector iterations per point
@@ -39,6 +45,12 @@ const (
 	ssiDedupSteps       = 1.5
 	ssiLoopCloseSteps   = 0.75
 	ssiTangencyGapSteps = 5.0
+	// ssiDescentGain damps the steepest-descent corrector step taken where the two surface normals are
+	// near-parallel (a tangency/pinch), so the corrector converges onto the curve through that singular
+	// neighbourhood instead of diverging — see correctorStep (#1404). A full (gain 1) Newton-on-the-gaps
+	// step overshoots when the normals coincide; half-stepping is unconditionally stable and still
+	// monotone, costing only a few extra iterations through the (rare, localised) near-parallel band.
+	ssiDescentGain = 0.5 // tol:numeric — under-relaxation of the near-tangency descent step
 )
 
 // ssiTracer holds the immutable context for one surface↔surface trace: the two surfaces, the base's
@@ -161,10 +173,13 @@ func orient(t, h math.Vector3) math.Vector3 {
 	return d
 }
 
-// correctToBothSurfaces pulls p onto the intersection of base and other by repeatedly projecting it
-// onto the intersection LINE of the two surfaces' tangent planes (the standard SSI corrector). Returns
-// the corrected point, the unit normals there, and whether it converged below tol. ok is false when
-// the normals are (near) parallel — the tangent-plane intersection is undefined, signalling a tangency.
+// correctToBothSurfaces pulls p onto the intersection of base and other by repeatedly stepping it toward
+// both surfaces (the standard SSI corrector). Returns the corrected point, the unit normals there, and
+// whether it converged below tol. Where the normals are well separated each step is the tangent-plane
+// intersection; through a tangency/pinch neighbourhood — where that step is ill-conditioned — it falls
+// back to a damped descent step so the curve is traced THROUGH the singularity rather than dropped at it
+// (correctorStep, #1404). ok is false only when no zero is reached within ssiCorrectIters (a genuine
+// mid-air stall: the predicted point has no nearby crossing, e.g. a march walking off a NURBS patch).
 func correctToBothSurfaces(base, other Surface, p math.Point3, tol float64) (math.Point3, math.Vector3, math.Vector3, bool) {
 	var nb, no math.Vector3
 	for i := 0; i < ssiCorrectIters; i++ {
@@ -180,13 +195,24 @@ func correctToBothSurfaces(base, other Surface, p math.Point3, tol float64) (mat
 		if db < tol && do < tol {
 			return p, nb, no, true
 		}
-		a, b, ok := tangentPlaneSolve(nb, no, sb, so)
-		if !ok {
-			return p, nb, no, false
-		}
-		p = p.TranslateBy(nb.Scale(math.Scalar(a)).Add(no.Scale(math.Scalar(b))))
+		p = p.TranslateBy(correctorStep(nb, no, sb, so))
 	}
 	return p, nb, no, false
+}
+
+// correctorStep returns one corrector displacement that drives the two signed tangent-plane gaps (sb, so)
+// toward zero. Where the normals are well separated it is the exact tangent-plane intersection step (lands
+// p on BOTH tangent planes). Where they are near-parallel — a tangency or pinch, the configuration #1404
+// must survive — that 2×2 system is ill-conditioned and blows up, so it falls back to a damped
+// steepest-descent step on ½(sb²+so²), whose gradient is sb·nb+so·no: unconditionally stable, still
+// monotone, and so converges onto a shallow transversal crossing (a near-pinch) and onto a true contact
+// (a pinch) instead of giving up and dropping the curve there.
+func correctorStep(nb, no math.Vector3, sb, so float64) math.Vector3 {
+	if a, b, ok := tangentPlaneSolve(nb, no, sb, so); ok {
+		return nb.Scale(math.Scalar(a)).Add(no.Scale(math.Scalar(b)))
+	}
+	gradient := nb.Scale(math.Scalar(sb)).Add(no.Scale(math.Scalar(so)))
+	return gradient.Scale(-ssiDescentGain)
 }
 
 // tangentPlaneSolve finds the step δ = a·nb + b·no that lands p on BOTH tangent planes:

--- a/kernel/geom/intersect_surface_trace_test.go
+++ b/kernel/geom/intersect_surface_trace_test.go
@@ -112,6 +112,95 @@ func TestSSINurbsPatchCutByPlane(t *testing.T) {
 	}
 }
 
+// closedOnly keeps the loops that close (first≈last) and have enough points to be a real curve, dropping
+// the single-point tangency markers, so a #1404 test asserts on the boundary loops the imprint consumes.
+func closedOnly(loops [][]math.Point3) [][]math.Point3 {
+	var out [][]math.Point3
+	for _, c := range loops {
+		if len(c) >= 4 && float64(c[0].DistanceTo(c[len(c)-1])) < 0.05 {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// passesNear reports whether some point of the loop comes within tol of p.
+func passesNear(loop []math.Point3, p math.Point3, tol float64) bool {
+	for _, q := range loop {
+		if float64(q.DistanceTo(p)) < tol {
+			return true
+		}
+	}
+	return false
+}
+
+// planarDiagonal reports whether the whole loop lies in the plane x=z OR the whole loop lies in x=−z — the
+// two Steinmetz ellipse planes for an x-axis and a z-axis cylinder of equal radius.
+func planarDiagonal(loop []math.Point3) bool {
+	inPlus, inMinus := true, true
+	for _, p := range loop {
+		if stdmath.Abs(float64(p.X)-float64(p.Z)) > 1e-4 {
+			inPlus = false
+		}
+		if stdmath.Abs(float64(p.X)+float64(p.Z)) > 1e-4 {
+			inMinus = false
+		}
+	}
+	return inPlus || inMinus
+}
+
+// TestSSITracesThroughSteinmetzPinch is the headline acceptance for Oblikovati#1404: two equal-radius
+// perpendicular cylinders intersect in two ellipses that CROSS at two pinch points (the Steinmetz
+// configuration). The tracer must follow each ellipse straight through both pinches and return two
+// topologically-complete closed loops — not stop at the first pinch and silently drop the open arcs, the
+// old behaviour that forced the bespoke curved_steinmetz analytic family.
+func TestSSITracesThroughSteinmetzPinch(t *testing.T) {
+	const r = 3.0
+	a, _ := NewCylinder(math.P3(0, 0, 0), math.V3(1, 0, 0), r) // axis x
+	b, _ := NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), r) // axis z
+	loops := closedOnly(IntersectSurfaceSurface(a, b, SurfaceGrid{VMin: -r - 1, VMax: r + 1}))
+	if len(loops) != 2 {
+		t.Fatalf("got %d closed loops, want 2 (the two Steinmetz ellipses through the pinches)", len(loops))
+	}
+	onBothSurfaces(t, a, b, loops, 1e-4)
+	pinchLo, pinchHi := math.P3(0, -r, 0), math.P3(0, r, 0)
+	for i, loop := range loops {
+		if !passesNear(loop, pinchLo, 0.05) || !passesNear(loop, pinchHi, 0.05) {
+			t.Errorf("loop %d does not pass through both pinch points (0,±%g,0)", i, r)
+		}
+		if !planarDiagonal(loop) {
+			t.Errorf("loop %d is not planar in x=z or x=-z (a Steinmetz ellipse plane)", i)
+		}
+	}
+}
+
+// TestSSINearPinchKeepsBothLoops: two perpendicular cylinders whose radii differ by only 1e-6 meet in two
+// SEPARATE closed loops that approach within a few microns at a tight high-curvature near-pinch U-turn. The
+// corrector's near-tangency descent must follow that turn so BOTH loops come back closed — no silently
+// dropped chain (Oblikovati#1404).
+func TestSSINearPinchKeepsBothLoops(t *testing.T) {
+	a, _ := NewCylinder(math.P3(0, 0, 0), math.V3(1, 0, 0), 3.0)
+	b, _ := NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3.0-1e-6)
+	loops := closedOnly(IntersectSurfaceSurface(a, b, SurfaceGrid{VMin: -4, VMax: 4}))
+	if len(loops) != 2 {
+		t.Fatalf("got %d closed loops, want 2 (a near-pinch must not drop a chain)", len(loops))
+	}
+	onBothSurfaces(t, a, b, loops, 1e-4)
+}
+
+// TestSSINearTangentSphereCylinderClosesLoops: a sphere just larger than the cylinder it surrounds cuts it
+// in two near-tangent circles; the descent corrector traces both as closed loops through the shallow
+// (near-parallel-normal) crossing rather than dropping them (Oblikovati#1404).
+func TestSSINearTangentSphereCylinderClosesLoops(t *testing.T) {
+	sp, _ := NewSphere(math.P3(0, 0, 0), 3.0001)
+	cy, _ := NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3.0)
+	loops := closedOnly(IntersectSurfaceSurface(sp, cy, SurfaceGrid{}))
+	if len(loops) != 2 {
+		t.Fatalf("got %d closed loops, want 2 near-tangent circles", len(loops))
+	}
+	onBothSurfaces(t, sp, cy, loops, 1e-4)
+}
+
 // TestSSIAgreesWithAnalyticOnSpherePlane: the tracer's sphere∩plane circle must match the analytic
 // equator (radius and planarity), the acceptance cross-check against the analytic path.
 func TestSSIAgreesWithAnalyticOnSpherePlane(t *testing.T) {

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -96,7 +96,7 @@ func join(lin topo.Lineage, target, tool *topo.Body, rel relation, rec *diag.Rec
 // triangle-soup BSP CSG only when an operand has a non-planar face the B-rep path can't take
 // (a cylinder, cone, etc.). A nil B-rep result is a (valid) empty body.
 func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.Lineage, rec *diag.Recorder) (*topo.Body, error) {
-	if body, ok := curvedExactBoolean(op, target, tool); ok {
+	if body, ok := curvedExactBoolean(op, target, tool, rec); ok {
 		return body, nil // an exact analytic curved result (M2 #1334/#1335) — keeps surfaces, no CSG soup
 	}
 	bop, ok := toBrepOp(op)
@@ -146,9 +146,9 @@ func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.L
 //   - drilling a clean through-hole in an all-planar slab with a straight cylinder (a drilled plate: box − cylinder) (#1336);
 //   - the union of two coaxial equal-radius cylinders that overlap/abut → one taller cylinder (a coplanar/tangent overlap) (#1336);
 //   - the union of a cylinder seated flush on a planar face (a boss/spigot) → seat-face hole + outward wall + cap (a coplanar overlap) (#1336).
-func curvedExactBoolean(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+func curvedExactBoolean(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	for _, exact := range curvedExactPaths {
-		if body, ok := exact(op, target, tool); ok {
+		if body, ok := exact(op, target, tool, rec); ok {
 			return body, true
 		}
 	}
@@ -161,12 +161,13 @@ func curvedExactBoolean(op PartFeatureOperation, target, tool *topo.Body) (*topo
 // it to combine a still-analytic primitive (a revolved torus, an extruded cylinder) by its curved faces
 // before falling back to faceting the operands for the planar path (#129).
 func CurvedBoolean(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
-	return curvedExactBoolean(op, target, tool)
+	return curvedExactBoolean(op, target, tool, nil)
 }
 
 // curvedExactPaths is the ordered list of exact analytic curved-boolean paths curvedExactBoolean tries; each
-// returns ok=false when it does not apply to (op, target, tool).
-var curvedExactPaths = []func(PartFeatureOperation, *topo.Body, *topo.Body) (*topo.Body, bool){
+// returns ok=false when it does not apply to (op, target, tool). The recorder carries the SSI imprint's
+// closure diagnostics (#1404) up to the boolean's caller; a path that takes no imprint ignores it.
+var curvedExactPaths = []func(PartFeatureOperation, *topo.Body, *topo.Body, *diag.Recorder) (*topo.Body, bool){
 	curvedConvexIntersect, curvedConvexSubtract,
 	curvedCrossingIntersect, curvedSteinmetzIntersect, curvedConeCylinderIntersect, curvedConeConeIntersect,
 	curvedPartialIntersect,

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -4,6 +4,7 @@ package ops
 
 import (
 	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/topo"
 )
 
@@ -17,11 +18,11 @@ import (
 // curvedCrossingIntersect returns the exact intersection of two crossing cylinders, or ok=false to defer.
 // Only Intersect maps here, and only a valid closed manifold result is adopted (an inside-out or open
 // assembly is rejected so the fallback runs instead).
-func curvedCrossingIntersect(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+func curvedCrossingIntersect(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	if op != Intersect {
 		return nil, false
 	}
-	res, ok := brep.CrossingCylinderIntersect(target, tool)
+	res, ok := brep.CrossingCylinderIntersect(target, tool, rec)
 	if !ok || !validBooleanSolid(res) {
 		return nil, false
 	}
@@ -31,11 +32,11 @@ func curvedCrossingIntersect(op PartFeatureOperation, target, tool *topo.Body) (
 // curvedConeCylinderIntersect returns the exact intersection of a cone crossing a cylinder (the cone band
 // plus two cylinder-wall lens caps), or ok=false to defer. Only Intersect maps here, and only a valid closed
 // manifold result is adopted.
-func curvedConeCylinderIntersect(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+func curvedConeCylinderIntersect(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	if op != Intersect {
 		return nil, false
 	}
-	res, ok := brep.ConeCylinderIntersect(target, tool)
+	res, ok := brep.ConeCylinderIntersect(target, tool, rec)
 	if !ok || !validBooleanSolid(res) {
 		return nil, false
 	}
@@ -45,11 +46,11 @@ func curvedConeCylinderIntersect(op PartFeatureOperation, target, tool *topo.Bod
 // curvedConeConeIntersect returns the exact intersection of a cone crossing a fatter cone (the rod-cone band
 // plus two fat-cone lens caps), or ok=false to defer. Only Intersect maps here, and only a valid closed
 // manifold result is adopted.
-func curvedConeConeIntersect(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+func curvedConeConeIntersect(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	if op != Intersect {
 		return nil, false
 	}
-	res, ok := brep.ConeConeIntersect(target, tool)
+	res, ok := brep.ConeConeIntersect(target, tool, rec)
 	if !ok || !validBooleanSolid(res) {
 		return nil, false
 	}
@@ -58,9 +59,9 @@ func curvedConeConeIntersect(op PartFeatureOperation, target, tool *topo.Body) (
 
 // curvedSteinmetzIntersect returns the exact intersection of two equal-radius perpendicular cylinders (the
 // Steinmetz bicylinder), or ok=false to defer. Only Intersect maps here, and only a valid closed manifold
-// result is adopted. This is the equal-radius case the SSI imprint tracer cannot trace (it pinches), fitted
-// analytically as two crossing ellipses instead.
-func curvedSteinmetzIntersect(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+// result is adopted. The SSI tracer now traces this equal-radius pinch (#1404), but the four-lobe bicylinder
+// solid is still built from exact analytic ellipse edges here; unifying it onto the traced loops is #1403.
+func curvedSteinmetzIntersect(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	if op != Intersect {
 		return nil, false
 	}
@@ -74,11 +75,11 @@ func curvedSteinmetzIntersect(op PartFeatureOperation, target, tool *topo.Body) 
 // curvedPartialIntersect returns the exact intersection of a thin rod ending inside a fatter cylinder (the
 // rod plug), or ok=false to defer. Only Intersect maps here, and only a valid closed manifold result is
 // adopted. This is the partial-penetration case the imprint traces as a single loop (one wall breach).
-func curvedPartialIntersect(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+func curvedPartialIntersect(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	if op != Intersect {
 		return nil, false
 	}
-	res, ok := brep.PartialPenetrationIntersect(target, tool)
+	res, ok := brep.PartialPenetrationIntersect(target, tool, rec)
 	if !ok || !validBooleanSolid(res) {
 		return nil, false
 	}
@@ -87,11 +88,11 @@ func curvedPartialIntersect(op PartFeatureOperation, target, tool *topo.Body) (*
 
 // curvedPartialCut returns target − tool when tool is a thin rod ending inside the fatter target (a blind
 // hole), or ok=false to defer. Only Cut maps here, and only a valid closed manifold result is adopted.
-func curvedPartialCut(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+func curvedPartialCut(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	if op != Cut {
 		return nil, false
 	}
-	res, ok := brep.PartialPenetrationCut(target, tool)
+	res, ok := brep.PartialPenetrationCut(target, tool, rec)
 	if !ok || !validBooleanSolid(res) {
 		return nil, false
 	}
@@ -101,11 +102,11 @@ func curvedPartialCut(op PartFeatureOperation, target, tool *topo.Body) (*topo.B
 // curvedPartialJoin returns target ∪ tool for a thin rod ending inside the fatter cylinder (the fat with a
 // single rod stub sticking out the entry side), or ok=false to defer. Only Join maps here, and only a valid
 // closed manifold result is adopted.
-func curvedPartialJoin(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+func curvedPartialJoin(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	if op != Join {
 		return nil, false
 	}
-	res, ok := brep.PartialPenetrationJoin(target, tool)
+	res, ok := brep.PartialPenetrationJoin(target, tool, rec)
 	if !ok || !validBooleanSolid(res) {
 		return nil, false
 	}
@@ -119,7 +120,7 @@ func curvedPartialJoin(op PartFeatureOperation, target, tool *topo.Body) (*topo.
 // Oblikovati/Oblikovati#1336, reverse of the #1334 cylinder − box case). Only Cut maps here; a tool that
 // is not a single full cylinder, or a hole that clips a face or does not pass clean through, returns
 // ok=false so the CSG fallback still runs.
-func curvedCylindricalHoleCut(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+func curvedCylindricalHoleCut(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	if op != Cut {
 		return nil, false
 	}
@@ -135,7 +136,7 @@ func curvedCylindricalHoleCut(op PartFeatureOperation, target, tool *topo.Body) 
 // faces are coincident (the curved analogue of a coplanar overlap), which the CSG fallback faceted; the
 // exact union keeps the analytic cylinder. Only Join maps here, and only a valid closed manifold result is
 // adopted.
-func curvedCoaxialJoin(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+func curvedCoaxialJoin(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	if op != Join {
 		return nil, false
 	}
@@ -151,7 +152,7 @@ func curvedCoaxialJoin(op PartFeatureOperation, target, tool *topo.Body) (*topo.
 // disk is coplanar with the seat face — the canonical coplanar overlap the CSG fallback faceted; the exact
 // union keeps the analytic cylinder wall. Only Join maps here, and only a valid closed manifold result is
 // adopted.
-func curvedCylinderBossJoin(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+func curvedCylinderBossJoin(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	if op != Join {
 		return nil, false
 	}
@@ -165,11 +166,11 @@ func curvedCylinderBossJoin(op PartFeatureOperation, target, tool *topo.Body) (*
 // curvedConeCylinderCut returns target − tool for a cone crossing a cylinder (drilling the fat cylinder with
 // the cone, or the two cone stubs of cone − fat), or ok=false to defer. Only Cut maps here, and only a valid
 // closed manifold result is adopted.
-func curvedConeCylinderCut(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+func curvedConeCylinderCut(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	if op != Cut {
 		return nil, false
 	}
-	res, ok := brep.ConeCylinderCut(target, tool)
+	res, ok := brep.ConeCylinderCut(target, tool, rec)
 	if !ok || !validBooleanSolid(res) {
 		return nil, false
 	}
@@ -179,11 +180,11 @@ func curvedConeCylinderCut(op PartFeatureOperation, target, tool *topo.Body) (*t
 // curvedConeCylinderJoin returns target ∪ tool for a cone crossing a cylinder (a fat cylinder side-breached
 // by a cone passing through it, leaving a tapered stub each side), or ok=false to defer. Only Join maps here,
 // and only a valid closed manifold result is adopted.
-func curvedConeCylinderJoin(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+func curvedConeCylinderJoin(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	if op != Join {
 		return nil, false
 	}
-	res, ok := brep.ConeCylinderJoin(target, tool)
+	res, ok := brep.ConeCylinderJoin(target, tool, rec)
 	if !ok || !validBooleanSolid(res) {
 		return nil, false
 	}
@@ -193,11 +194,11 @@ func curvedConeCylinderJoin(op PartFeatureOperation, target, tool *topo.Body) (*
 // curvedConeConeCut returns target − tool for a cone crossing a fatter cone (drilling the fat cone with the
 // rod cone, or the two rod-cone stubs of cone − fat), or ok=false to defer. Only Cut maps here, and only a
 // valid closed manifold result is adopted.
-func curvedConeConeCut(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+func curvedConeConeCut(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	if op != Cut {
 		return nil, false
 	}
-	res, ok := brep.ConeConeCut(target, tool)
+	res, ok := brep.ConeConeCut(target, tool, rec)
 	if !ok || !validBooleanSolid(res) {
 		return nil, false
 	}
@@ -207,11 +208,11 @@ func curvedConeConeCut(op PartFeatureOperation, target, tool *topo.Body) (*topo.
 // curvedConeConeJoin returns target ∪ tool for a cone crossing a fatter cone (the fat cone side-breached by a
 // rod cone passing through it, leaving a tapered stub each side), or ok=false to defer. Only Join maps here,
 // and only a valid closed manifold result is adopted.
-func curvedConeConeJoin(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+func curvedConeConeJoin(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	if op != Join {
 		return nil, false
 	}
-	res, ok := brep.ConeConeJoin(target, tool)
+	res, ok := brep.ConeConeJoin(target, tool, rec)
 	if !ok || !validBooleanSolid(res) {
 		return nil, false
 	}
@@ -221,7 +222,7 @@ func curvedConeConeJoin(op PartFeatureOperation, target, tool *topo.Body) (*topo
 // curvedSteinmetzCut returns target − tool for two equal-radius perpendicular cylinders (the target with
 // the tool's saddle bite removed), or ok=false to defer. Only Cut maps here, and only a valid closed
 // manifold result is adopted.
-func curvedSteinmetzCut(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+func curvedSteinmetzCut(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	if op != Cut {
 		return nil, false
 	}
@@ -235,11 +236,11 @@ func curvedSteinmetzCut(op PartFeatureOperation, target, tool *topo.Body) (*topo
 // curvedCrossingCut returns target − tool for two crossing cylinders (drilling a fat cylinder with a
 // crossing rod, or the two rod stubs of rod − fat), or ok=false to defer. Only Cut maps here, and only a
 // valid closed manifold result is adopted.
-func curvedCrossingCut(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+func curvedCrossingCut(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	if op != Cut {
 		return nil, false
 	}
-	res, ok := brep.CrossingCylinderCut(target, tool)
+	res, ok := brep.CrossingCylinderCut(target, tool, rec)
 	if !ok || !validBooleanSolid(res) {
 		return nil, false
 	}
@@ -249,7 +250,7 @@ func curvedCrossingCut(op PartFeatureOperation, target, tool *topo.Body) (*topo.
 // curvedSteinmetzJoin returns target ∪ tool for two equal-radius perpendicular cylinders (the union of two
 // crossing cylinders of the same radius), or ok=false to defer. Only Join maps here, and only a valid closed
 // manifold result is adopted.
-func curvedSteinmetzJoin(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+func curvedSteinmetzJoin(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	if op != Join {
 		return nil, false
 	}
@@ -263,11 +264,11 @@ func curvedSteinmetzJoin(op PartFeatureOperation, target, tool *topo.Body) (*top
 // curvedCrossingJoin returns target ∪ tool for two crossing cylinders (a fat cylinder side-breached by a
 // rod passing through it, leaving a stub each side), or ok=false to defer. Only Join maps here, and only a
 // valid closed manifold result is adopted.
-func curvedCrossingJoin(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+func curvedCrossingJoin(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	if op != Join {
 		return nil, false
 	}
-	res, ok := brep.CrossingCylinderJoin(target, tool)
+	res, ok := brep.CrossingCylinderJoin(target, tool, rec)
 	if !ok || !validBooleanSolid(res) {
 		return nil, false
 	}

--- a/kernel/ops/boolean_crossing_cylinder_test.go
+++ b/kernel/ops/boolean_crossing_cylinder_test.go
@@ -392,7 +392,7 @@ func TestBooleanIntersectEqualRadiusDefersFromExactPath(t *testing.T) {
 	a, _ := brep.SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
 	b, _ := brep.SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 3, 12) // equal radius
 
-	if _, ok := brep.CrossingCylinderIntersect(a, b); ok {
+	if _, ok := brep.CrossingCylinderIntersect(a, b, nil); ok {
 		t.Error("equal-radius (Steinmetz) crossing should defer from the exact path (ok=false)")
 	}
 }

--- a/kernel/ops/boolean_curved_convex.go
+++ b/kernel/ops/boolean_curved_convex.go
@@ -4,6 +4,7 @@ package ops
 
 import (
 	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -19,7 +20,7 @@ import (
 // curvedConvexIntersect returns the exact intersection of a curved solid with a convex planar tool, or
 // ok=false to defer to CSG. Only the Intersect operation maps to a half-space composition; Join and Cut
 // (a box is not a half-space complement) stay on the existing path.
-func curvedConvexIntersect(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+func curvedConvexIntersect(op PartFeatureOperation, target, tool *topo.Body, _ *diag.Recorder) (*topo.Body, bool) {
 	if op != Intersect {
 		return nil, false
 	}

--- a/kernel/ops/boolean_curved_flat_subtract.go
+++ b/kernel/ops/boolean_curved_flat_subtract.go
@@ -4,6 +4,7 @@ package ops
 
 import (
 	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 )
@@ -19,7 +20,7 @@ import (
 
 // curvedFlatSubtract returns target − box when the removal is bounded by a single box face, or
 // ok=false to defer. Only Cut, a curved target, and a convex all-planar tool map here.
-func curvedFlatSubtract(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+func curvedFlatSubtract(op PartFeatureOperation, target, tool *topo.Body, _ *diag.Recorder) (*topo.Body, bool) {
 	if op != Cut || !hasCurvedFace(target) || hasCurvedFace(tool) {
 		return nil, false
 	}

--- a/kernel/ops/boolean_curved_subtract.go
+++ b/kernel/ops/boolean_curved_subtract.go
@@ -6,6 +6,7 @@ import (
 	stdmath "math"
 
 	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -25,7 +26,7 @@ const axisAlignTol = 1e-7
 // curvedConvexSubtract returns cylinder − box when the box is an axial through-tunnel inside the cylinder,
 // or ok=false to defer. Only Cut maps here, and only with a curved target (the body being cut) and a
 // convex all-planar tool whose faces are each parallel or perpendicular to the cylinder axis.
-func curvedConvexSubtract(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, bool) {
+func curvedConvexSubtract(op PartFeatureOperation, target, tool *topo.Body, _ *diag.Recorder) (*topo.Body, bool) {
 	if op != Cut || !hasCurvedFace(target) || hasCurvedFace(tool) {
 		return nil, false
 	}


### PR DESCRIPTION
## What & why

Closes #1404.

The surface–surface intersection (SSI) continuation tracer stopped at any **pinch or tangency**. Its corrector projects onto the intersection *line* of the two surfaces' tangent planes — a 2×2 system that is singular where the surface normals align. At a pinch (two intersection branches crossing, e.g. the two ellipses of an equal-radius Steinmetz) the corrector bailed, the march returned an **open** chain, and `closedTraceLoops` **silently dropped** it. That tracer weakness is the upstream root cause of bespoke-handler proliferation: the equal-radius case needed a whole separate analytic family (`curved_steinmetz.go`) precisely because the tracer couldn't follow it.

## How

**1. Trace through the singularity (criterion 1).** The marching corrector now damps to a **steepest-descent step on the squared tangent-plane gaps** wherever that linear solve is ill-conditioned (the near-parallel-normal neighbourhood of a tangency/pinch). Descent is unconditionally stable and still monotone, so the march re-acquires the curve on the far side and the loop closes. The change is confined to that neighbourhood — transversal crossings keep the exact tangent-plane step untouched, so **no existing boolean result changes** (whole kernel + model suites green).

Now:
- equal-radius perpendicular cylinders trace as the **two complete closed Steinmetz ellipses** (minor R, major R√2),
- a **1e-6 near-pinch** keeps both loops (a tight high-curvature U-turn that previously dropped a chain),
- a **near-tangent sphere/cylinder** closes both circles.

**2. No silent chain drop (criterion 3).** `closedTraceLoops` takes a `diag.Recorder` and raises a typed `CodeImprintUnclosedChain` (Defect) for each dropped chain. The recorder is threaded from `BooleanWithDiagnostics` down through the curved-exact-boolean dispatch and every SSI imprint helper (crossing / cone-cylinder / cone-cone / partial). A path that takes no imprint ignores it; a closed loop or single-point tangency marker stays quiet.

**3. Steinmetz family (criterion 2 — prerequisite delivered).** The equal-radius case now traces as two closed loops through the **general** SSI imprint (pinned by a regression test) — the prerequisite the general curved∩curved pipeline (#1403) needs to fold `curved_steinmetz.go` onto the traced path. Its analytic four-lobe constructor is **retained** for now: it builds *exact* ellipse edges, and a different topology (four lobes meeting at two pinch verts) from the rod-band crossing result. The stale "the tracer cannot trace this pinch" comments are corrected. Full removal of the bespoke family is tracked under #1403, for which this PR is the unblocker.

## Tests
- `geom`: traces-through-Steinmetz-pinch (2 closed ellipses through both pinches, planar in x=±z, on both surfaces), 1e-6 near-pinch keeps both loops, near-tangent sphere/cylinder closes both circles.
- `brep`: `closedTraceLoops` records `CodeImprintUnclosedChain` on an unclosed chain and stays quiet on a clean trace; the equal-radius crossing imprint returns two closed Steinmetz ellipses.
- Full kernel + model suites pass; lint clean; no behavioural change to any existing curved boolean (the Steinmetz solid is still the exact analytic constructor).

Non-visual change (SSI tracer + diagnostics; no geometry/render change to supported booleans), so the kernel/integration suites serve as the e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)