### PR TITLE
brep(uv-trim): general (u,v)-arrangement ruled-side trimmer (full replacement)

### DIFF
--- a/kernel/brep/curved_halfspace_cone_side.go
+++ b/kernel/brep/curved_halfspace_cone_side.go
@@ -114,15 +114,6 @@ func fullConeApexSideBand(f curvedFace, res geom.Resolution) (geom.Cone, coneSid
 	return cone, band, true
 }
 
-// conicArm builds the loop edge along an open conic section (a hyperbola branch or a parabola) from
-// start to end, its parameters the conic's own parameter values at the two rim feet (the loop edge's
-// t0/t1 are the curve parameter — θ for a hyperbola, the cross coordinate t for a parabola).
-func conicArm(conic geom.Curve3, start, end math.Point3) loopEdge {
-	t0, _ := geom.CurveParamAtPoint3(conic, start)
-	t1, _ := geom.CurveParamAtPoint3(conic, end)
-	return loopEdge{curve: conic, t0: t0, t1: t1}
-}
-
 // fullConeSideBand reports whether f is the GENUINE full periodic cone side — a geom.Cone bounded by
 // TWO closed-circle rims and the seam, the untrimmed frustum side the general looped split tangles on
 // — and returns its band. An already-trimmed band (one circle plus an ellipse/hyperbola rim, after a

--- a/kernel/brep/curved_halfspace_general.go
+++ b/kernel/brep/curved_halfspace_general.go
@@ -107,7 +107,7 @@ func splitFaceByPlane(f curvedFace, plane geom.Plane, n math.Vector3, res geom.R
 		return capSplit(f, curves[0])
 	}
 	if cyl, band, ok := fullCylinderSideBand(f); ok {
-		return cylinderSideUVSplit(f, cyl, curves[0], band, plane, n)
+		return cylinderSideUVSplit(f, cyl, curves, band, plane, n)
 	}
 	if cone, band, ok := fullConeSideBand(f); ok {
 		return coneSideBandSplit(f, curves, cone, band, plane, n)

--- a/kernel/brep/curved_halfspace_ruled_boundary.go
+++ b/kernel/brep/curved_halfspace_ruled_boundary.go
@@ -4,100 +4,17 @@ package brep
 
 import (
 	stdmath "math"
-
-	"oblikovati.org/kernel/geom"
 )
 
-// Ruled-side boundary trace (M2 Phase-1, Oblikovati/Oblikovati#1375). The kept-region boundary walk for
-// the (u,v) ruled-side split (curved_halfspace_ruled_uv.go): finding the kept azimuth span, tracing each
-// of the lo/hi bounds as a chain of whole rim arcs and section sub-arcs split at the exact rim crossings,
-// and building those edges (rim arcs, seam-wrap-safe ellipse arcs, open conic arms). Shared by both the
-// cone and cylinder sides — it only reads the surface through keptV / sectionV / onRim / point3.
-
-// keptUSpan returns the single azimuth interval [u1, u2] (u2 may exceed 2π when the span wraps the seam)
-// where the kept v-interval is non-empty — the span's u-extent. ok=false unless the kept region is EXACTLY
-// one such span (the case the non-wrapping arrangements produce; anything else is left to the fallback).
-func (c ruledUV) keptUSpan() (u1, u2 float64, ok bool) {
-	const twoPi, N = 2 * stdmath.Pi, 1440
-	var starts, ends []float64
-	prev := c.keptNonEmpty(0)
-	for i := 1; i <= N; i++ {
-		u := twoPi * float64(i) / N
-		cur := c.keptNonEmpty(u)
-		switch {
-		case cur && !prev:
-			starts = append(starts, c.bisectKeptEdge(twoPi*float64(i-1)/N, u, true))
-		case !cur && prev:
-			ends = append(ends, c.bisectKeptEdge(twoPi*float64(i-1)/N, u, false))
-		}
-		prev = cur
-	}
-	if len(starts) != 1 || len(ends) != 1 {
-		return 0, 0, false
-	}
-	u1, u2 = starts[0], ends[0]
-	if u2 < u1 {
-		u2 += twoPi // the kept span straddles the seam (it was already open at u=0)
-	}
-	return u1, u2, true
-}
-
-// keptNonEmpty reports whether the kept v-interval is non-empty at azimuth u.
-func (c ruledUV) keptNonEmpty(u float64) bool { _, _, ok := c.keptV(u); return ok }
-
-// bisectKeptEdge refines the azimuth where the kept interval pinches to empty — the span endpoint where the
-// section meets the clamp rim (or the cut line of an axis-parallel flat). rising=true brackets an
-// empty→non-empty edge, else non-empty→empty.
-func (c ruledUV) bisectKeptEdge(lo, hi float64, rising bool) float64 {
-	for i := 0; i < 60; i++ {
-		mid := (lo + hi) / 2
-		if c.keptNonEmpty(mid) == rising {
-			hi = mid
-		} else {
-			lo = mid
-		}
-	}
-	return (lo + hi) / 2
-}
-
-// boundarySubChain builds the boundary chain (rim and section edges) of the upper or lower bound over the
-// non-wrapping azimuth span [ua, ub], split at the interior rim crossings, with the section sub-arcs
-// returned separately (u-increasing) for the lid.
-func (c ruledUV) boundarySubChain(conic geom.Curve3, ua, ub float64, upper bool) (edges, section []loopEdge, ok bool) {
-	breaks := append([]float64{ua}, c.interiorRimCrossings(ua, ub, upper)...)
-	breaks = append(breaks, ub)
-	for i := 0; i+1 < len(breaks); i++ {
-		e, sec, good := c.boundaryEdge(conic, breaks[i], breaks[i+1], upper)
-		if !good {
-			return nil, nil, false
-		}
-		edges = append(edges, e)
-		section = append(section, sec...)
-	}
-	return edges, section, true
-}
-
-// interiorRimCrossings returns the azimuths strictly inside (ua, ub) where the bound switches between a
-// rim and the section curve, bisected to the exact crossing (where the section reaches the clamp rim).
-func (c ruledUV) interiorRimCrossings(ua, ub float64, upper bool) []float64 {
-	const N = 1440
-	var out []float64
-	prev := c.onRim(ua, upper)
-	for i := 1; i < N; i++ {
-		u := ua + (ub-ua)*float64(i)/N
-		if cur := c.onRim(u, upper); cur != prev {
-			out = append(out, c.bisectRimBreak(ua+(ub-ua)*float64(i-1)/N, u, upper))
-			prev = cur
-		}
-	}
-	return out
-}
-
-// loAt and hiAt give the kept interval's lower / upper bound at azimuth u.
-func (c ruledUV) loAt(u float64) float64 { lo, _, _ := c.keptV(u); return lo }
-func (c ruledUV) hiAt(u float64) float64 { _, hi, _ := c.keptV(u); return hi }
+// Ruled-side arrangement support (M2 Phase-1, Oblikovati/Oblikovati#1375, generalised #1405). What remains
+// of the original single-valued boundary walk after the general (u,v)-arrangement trimmer
+// (curved_halfspace_uv_arrangement.go) replaced it: the few helpers the arrangement still leans on — the
+// wrapping test that picks the band orientation convention, the parameter unwrap that keeps a re-emitted
+// conic arc on one monotone run, and the edge-chain reversal.
 
 // wrapsAllU reports whether the kept v-interval is non-empty at every azimuth (the band wraps the seam).
+// orientLoops uses it to gate the top-rim reversal: a wrapping band's pure top-rim hi loop is reversed,
+// a non-wrapping tongue's mixed loop is not.
 func (c ruledUV) wrapsAllU() bool {
 	for i := 0; i < 720; i++ {
 		if _, _, ok := c.keptV(2 * stdmath.Pi * float64(i) / 720); !ok {
@@ -107,137 +24,9 @@ func (c ruledUV) wrapsAllU() bool {
 	return true
 }
 
-// boundAt gives the boundary value (lo or hi) at u.
-func (c ruledUV) boundAt(u float64, upper bool) float64 {
-	if upper {
-		return c.hiAt(u)
-	}
-	return c.loAt(u)
-}
-
-// onRim reports whether the boundary at u sits on a rim (constant v) rather than on the section curve.
-func (c ruledUV) onRim(u float64, upper bool) bool {
-	v := c.boundAt(u, upper)
-	if upper {
-		return v >= c.band.vMax-1e-7
-	}
-	return v <= c.band.vMin+1e-7
-}
-
-// boundaryLoop builds the upper (upper=true) or lower boundary of the kept band as a closed loop of whole
-// rim arcs and section arcs, and the section (conic) sub-edges alone for the lid. A boundary with no rim
-// crossing is either the full source rim circle (all rim) or the full re-anchored ellipse (all section).
-func (c ruledUV) boundaryLoop(conic geom.Curve3, upper bool) (edges, section []loopEdge, ok bool) {
-	breaks := c.rimCrossings(upper)
-	if len(breaks) == 0 {
-		if c.onRim(0, upper) {
-			// A full source rim circle reused whole (built forward here), so it welds to the cap that shares
-			// it; splitSide reverses the whole upper loop to give that rim the cap-opposite sense.
-			circle := c.band.bottomCirc
-			if upper {
-				circle = c.band.topCirc
-			}
-			return []loopEdge{{curve: circle, t0: 0, t1: 1}}, nil, true
-		}
-		e, sec, good := c.fullSectionEdge(conic) // the within-band ellipse: a closed re-anchored edge
-		return []loopEdge{e}, sec, good
-	}
-	for i := range breaks { // one edge per gap between consecutive crossings, wrapping the last to the first
-		ua, ub := breaks[i], breaks[(i+1)%len(breaks)]
-		if i == len(breaks)-1 {
-			ub += 2 * stdmath.Pi
-		}
-		e, sec, good := c.boundaryEdge(conic, ua, ub, upper)
-		if !good {
-			return nil, nil, false
-		}
-		edges = append(edges, e)
-		section = append(section, sec...)
-	}
-	return edges, section, true
-}
-
-// rimCrossings returns the azimuths in [0, 2π) where the boundary switches between a rim and the section
-// curve (the section reaches the clamp rim), sorted. Empty when the boundary is wholly rim or wholly
-// section.
-func (c ruledUV) rimCrossings(upper bool) []float64 {
-	const twoPi, N = 2 * stdmath.Pi, 1440
-	var out []float64
-	prev := c.onRim(0, upper)
-	for i := 1; i <= N; i++ {
-		u := twoPi * float64(i) / N
-		if cur := c.onRim(u, upper); cur != prev {
-			out = append(out, c.bisectRimBreak(twoPi*float64(i-1)/N, u, upper))
-			prev = cur
-		}
-	}
-	return out
-}
-
-// bisectRimBreak refines the azimuth where the section curve EXACTLY reaches the clamp rim (vMax for the
-// upper boundary, vMin for the lower) — the crossing shared with the cap, so the section arc welds to the
-// cap chord there.
-func (c ruledUV) bisectRimBreak(lo, hi float64, upper bool) float64 {
-	clamp := c.band.vMin
-	if upper {
-		clamp = c.band.vMax
-	}
-	f := func(u float64) float64 { return c.sectionV(u) - clamp }
-	flo := f(lo)
-	for i := 0; i < 60; i++ {
-		mid := (lo + hi) / 2
-		if (flo < 0) == (f(mid) < 0) {
-			lo, flo = mid, f(mid)
-		} else {
-			hi = mid
-		}
-	}
-	return (lo + hi) / 2
-}
-
-// boundaryEdge builds one boundary edge over [ua, ub]: a rim arc when the boundary is on a rim there, else
-// a sub-arc of the section conic (also returned, u-increasing, as the lid's cut edge).
-func (c ruledUV) boundaryEdge(conic geom.Curve3, ua, ub float64, upper bool) (loopEdge, []loopEdge, bool) {
-	um := (ua + ub) / 2
-	if c.onRim(um, upper) {
-		center, radius := c.band.bottom, c.band.rBot
-		if upper {
-			center, radius = c.band.top, c.band.rTop
-		}
-		arc, err := geom.NewArc3d(center, c.axis, c.ref, radius, ua, ub-ua)
-		if err != nil {
-			return loopEdge{}, nil, false
-		}
-		return loopEdge{curve: arc, t0: 0, t1: 1}, nil, true
-	}
-	e := c.sectionArm(conic, ua, ub) // a partial section arc, seam-wrap-safe for a full ellipse
-	return e, []loopEdge{e}, true
-}
-
-// sectionArm builds the section conic sub-arc spanning azimuth [ua, ub]. For a full ellipse the endpoint
-// parameters alone are ambiguous (the param seam may fall inside the span, so a plain start→end sweep can
-// trace the COMPLEMENTARY major arc instead of the kept side); the midpoint azimuth's parameter
-// disambiguates by unwrapping start→mid→end onto one monotone run. Other conics (hyperbola/parabola arms)
-// are open and need no unwrapping, so conicArm's endpoint parameters suffice.
-func (c ruledUV) sectionArm(conic geom.Curve3, ua, ub float64) loopEdge {
-	el, ok := conic.(geom.EllipseFull)
-	if !ok {
-		return conicArm(conic, c.point3(ua, c.sectionV(ua)), c.point3(ub, c.sectionV(ub)))
-	}
-	t0 := c.ellipseParamAt(el, ua)
-	tm := unwrapParamNear(t0, c.ellipseParamAt(el, (ua+ub)/2))
-	t1 := unwrapParamNear(tm, c.ellipseParamAt(el, ub))
-	return loopEdge{curve: el, t0: t0, t1: t1}
-}
-
-// ellipseParamAt returns the full ellipse's parameter (in [0,1)) at the section point of azimuth u.
-func (c ruledUV) ellipseParamAt(el geom.EllipseFull, u float64) float64 {
-	t, _ := geom.CurveParamAtPoint3(el, c.point3(u, c.sectionV(u)))
-	return t
-}
-
 // unwrapParamNear shifts x by whole turns so it lands within ±0.5 of ref — turning a wrapped [0,1)
-// parameter sequence into a monotone run, so the swept ellipse arc passes through the interior point.
+// parameter sequence into a monotone run, so a re-emitted full-ellipse section arc passes through the
+// interior point rather than the complementary arc.
 func unwrapParamNear(ref, x float64) float64 {
 	for x-ref > 0.5 {
 		x--
@@ -246,35 +35,6 @@ func unwrapParamNear(ref, x float64) float64 {
 		x++
 	}
 	return x
-}
-
-// fullSectionEdge builds the closed re-anchored ellipse edge when a boundary is the whole within-band
-// section (the section never reaches a rim). Only an ellipse encircles the axis, so anything else defers.
-func (c ruledUV) fullSectionEdge(conic geom.Curve3) (loopEdge, []loopEdge, bool) {
-	el, ok := conic.(geom.EllipseFull)
-	if !ok {
-		return loopEdge{}, nil, false
-	}
-	v0 := c.sectionV(0)
-	tStart, _ := geom.CurveParamAtPoint3(el, c.point3(0, v0))
-	arc := geom.EllipticalArc{Center: el.Center, Normal: el.Normal, MajorAxis: el.MajorAxis,
-		MajorRadius: el.MajorRadius, MinorRadius: el.MinorRadius,
-		StartAngle: 2 * stdmath.Pi * tStart, SweepAngle: 2 * stdmath.Pi}
-	e := loopEdge{curve: arc, t0: 0, t1: 1}
-	return e, []loopEdge{e}, true
-}
-
-// loopHasRim reports whether a boundary chain carries a rim edge (a full circle or a rim arc, shared with
-// a cap) rather than only section conic arcs — the upper boundary is then reversed to the cap-opposite
-// sense. A rim edge's curve is a geom.Circle (full rim) or geom.Arc3d (a partial rim between crossings).
-func loopHasRim(edges []loopEdge) bool {
-	for _, e := range edges {
-		switch e.curve.(type) {
-		case geom.Circle, geom.Arc3d:
-			return true
-		}
-	}
-	return false
 }
 
 // reverseEdgeChain reverses a chain of loop edges (order reversed, each reversed).

--- a/kernel/brep/curved_halfspace_ruled_uv.go
+++ b/kernel/brep/curved_halfspace_ruled_uv.go
@@ -35,6 +35,11 @@ type ruledUV struct {
 	radSlope, radConst float64 // rad(v) = radSlope·v + radConst (cone: tanα, 0; cylinder: 0, R)
 	band               coneSideBand_
 	p, q, s, t, uN     float64
+	// seamU rotates the (u,v) parameter origin for the arrangement trim only: the artificial azimuth seam
+	// (u=0≡2π) is moved to absolute azimuth seamU so it falls clear of the imprint's rim crossings (a
+	// section arm grazing the seam otherwise breaks the arrangement, #1405). paramOf reports u relative to
+	// seamU; point3/aU/bU add it back. The analytic walk leaves it 0, so its parameterisation is unchanged.
+	seamU float64
 }
 
 // newConeUV builds the (u, v) model of a frustum side cut by a plane (n the unit plane normal).
@@ -69,11 +74,12 @@ func newRuledUV(base math.Point3, axis, ref math.Vector3, radSlope, radConst flo
 	}
 }
 
-// aU returns a(u) = p + q·cos(u−uN), the v-independent part of the signed distance g(u,v)=a(u)+v·b(u).
-func (c ruledUV) aU(u float64) float64 { return c.p + c.q*stdmath.Cos(u-c.uN) }
+// aU returns a(u) = p + q·cos(u−uN), the v-independent part of the signed distance g(u,v)=a(u)+v·b(u). u is
+// relative to the seam origin (seamU), so the absolute azimuth used against uN is u+seamU.
+func (c ruledUV) aU(u float64) float64 { return c.p + c.q*stdmath.Cos(u+c.seamU-c.uN) }
 
 // bU returns b(u) = s + t·cos(u−uN), the coefficient of v in the signed distance g(u,v)=a(u)+v·b(u).
-func (c ruledUV) bU(u float64) float64 { return c.s + c.t*stdmath.Cos(u-c.uN) }
+func (c ruledUV) bU(u float64) float64 { return c.s + c.t*stdmath.Cos(u+c.seamU-c.uN) }
 
 // sectionV returns the axial distance v where the cut plane meets the side at azimuth u — the section
 // curve v(u) = −a(u)/b(u). It returns 0 where b(u)≈0 (the plane is parallel to the ruling at u, no finite
@@ -122,19 +128,22 @@ func (c ruledUV) keptV(u float64) (lo, hi float64, ok bool) {
 	}
 }
 
-// point3 returns the surface point at (u, v): base + v·â + (radSlope·v+radConst)·r̂(u).
+// point3 returns the surface point at (u, v): base + v·â + (radSlope·v+radConst)·r̂(u). u is relative to the
+// seam origin (seamU), so the absolute azimuth on the surface frame is u+seamU.
 func (c ruledUV) point3(u, v float64) math.Point3 {
-	radial := c.ref.Scale(math.Scalar(stdmath.Cos(u))).Add(c.binor.Scale(math.Scalar(stdmath.Sin(u))))
+	a := u + c.seamU
+	radial := c.ref.Scale(math.Scalar(stdmath.Cos(a))).Add(c.binor.Scale(math.Scalar(stdmath.Sin(a))))
 	rad := c.radSlope*v + c.radConst
 	return c.base.TranslateBy(c.axis.Scale(math.Scalar(v))).TranslateBy(radial.Scale(math.Scalar(rad)))
 }
 
-// coneSideUVSplit splits a full periodic frustum side. The general (u,v)-arrangement trimmer (trimByImprint,
-// with the multi-arm clipParams) now handles most cone cuts (axis-∥ flat, parabola, vertex-inside, ellipse),
-// but the OBLIQUE hyperbola still arranges wrong — its two arms leave the band's interior cell misclassified
-// — so the analytic splitSide stands here until that arrangement case is reconciled (Oblikovati#1405).
+// coneSideUVSplit splits a full periodic frustum side by the general (u,v)-arrangement trimmer (newConeUV +
+// trimByImprint), the same path the cylinder side uses — the cone's a(u)+v·b(u) signed distance and its
+// conic section (ellipse, hyperbola branch or parabola, windowed to the band by clipParams, the seam moved
+// clear of the section by chooseSeamU) flow through it uniformly (Oblikovati#1405).
 func coneSideUVSplit(f curvedFace, cone geom.Cone, conic geom.Curve3, band coneSideBand_, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
-	return newConeUV(cone, band, plane, n).splitSide(f, cone, conic)
+	c := newConeUV(cone, band, plane, n)
+	return c.trimByImprint(f, cone, []geom.Curve3{conic}, ruledUV.halfSpaceMaterial)
 }
 
 // coneApexSideSplit splits a FULL cone side (apex + one rim) by the (u,v) arrangement. The apex is the
@@ -176,7 +185,7 @@ func (c ruledUV) apexCapSide(f curvedFace, surface geom.Surface, conic geom.Curv
 // cut (within-band / clips-rim / tongue), the latter the case the line-only cylinder split deferred to CSG.
 func cylinderSideUVSplit(f curvedFace, cyl geom.Cylinder, curves []geom.Curve3, band coneSideBand_, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
 	c := newCylinderUV(cyl, band, plane, n)
-	return c.trimByImprint(f, cyl, curves, c.halfSpaceMaterial())
+	return c.trimByImprint(f, cyl, curves, ruledUV.halfSpaceMaterial)
 }
 
 // splitSide builds the kept region {g<0} of a ruled side in (u,v). The WRAPPING case (kept v-interval

--- a/kernel/brep/curved_halfspace_ruled_uv.go
+++ b/kernel/brep/curved_halfspace_ruled_uv.go
@@ -129,7 +129,10 @@ func (c ruledUV) point3(u, v float64) math.Point3 {
 	return c.base.TranslateBy(c.axis.Scale(math.Scalar(v))).TranslateBy(radial.Scale(math.Scalar(rad)))
 }
 
-// coneSideUVSplit splits a full periodic frustum side by the (u,v) arrangement (newConeUV + splitSide).
+// coneSideUVSplit splits a full periodic frustum side. The general (u,v)-arrangement trimmer (trimByImprint)
+// now drives the whole cylinder side; the cone reuses the same path but its hyperbola/parabola arm sections
+// and span-end rulings still need their weld reconciled (a valid face emits, but the assembled solid is not
+// yet manifold), so the analytic splitSide stands here until that lands (Oblikovati#1405).
 func coneSideUVSplit(f curvedFace, cone geom.Cone, conic geom.Curve3, band coneSideBand_, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
 	return newConeUV(cone, band, plane, n).splitSide(f, cone, conic)
 }

--- a/kernel/brep/curved_halfspace_ruled_uv.go
+++ b/kernel/brep/curved_halfspace_ruled_uv.go
@@ -172,11 +172,8 @@ func (c ruledUV) apexCapSide(f curvedFace, surface geom.Surface, conic geom.Curv
 // splitSide). It handles both the axis-parallel flat (b≡0 → a vertical-edged span) and an oblique ellipse
 // cut (within-band / clips-rim / tongue), the latter the case the line-only cylinder split deferred to CSG.
 func cylinderSideUVSplit(f curvedFace, cyl geom.Cylinder, curves []geom.Curve3, band coneSideBand_, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
-	// trimByImprint (the general arrangement trimmer) now reproduces the analytic result for the wrapping
-	// band, oblique-ellipse and axis-parallel cuts via the hi/lo orientation convention (orientLoops); the
-	// clips-rim case still needs the multi-face weld at the rim crossings reconciled before this can switch
-	// (Oblikovati#1405). Until then the analytic single-valued walk stands.
-	return newCylinderUV(cyl, band, plane, n).splitSide(f, cyl, curves[0])
+	c := newCylinderUV(cyl, band, plane, n)
+	return c.trimByImprint(f, cyl, curves, c.halfSpaceMaterial())
 }
 
 // splitSide builds the kept region {g<0} of a ruled side in (u,v). The WRAPPING case (kept v-interval

--- a/kernel/brep/curved_halfspace_ruled_uv.go
+++ b/kernel/brep/curved_halfspace_ruled_uv.go
@@ -171,8 +171,11 @@ func (c ruledUV) apexCapSide(f curvedFace, surface geom.Surface, conic geom.Curv
 // cylinderSideUVSplit splits a full periodic cylinder side by the (u,v) arrangement (newCylinderUV +
 // splitSide). It handles both the axis-parallel flat (b≡0 → a vertical-edged span) and an oblique ellipse
 // cut (within-band / clips-rim / tongue), the latter the case the line-only cylinder split deferred to CSG.
-func cylinderSideUVSplit(f curvedFace, cyl geom.Cylinder, conic geom.Curve3, band coneSideBand_, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
-	return newCylinderUV(cyl, band, plane, n).splitSide(f, cyl, conic)
+func cylinderSideUVSplit(f curvedFace, cyl geom.Cylinder, curves []geom.Curve3, band coneSideBand_, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
+	// The general (u,v)-arrangement trimmer (trimByImprint) is built and unit-tested but not yet wired here:
+	// reconciling its connected-loop orientation with the stitcher's hi/lo-bound convention (topRimReversed,
+	// lid sense) is the remaining step of Oblikovati#1405. Until then the analytic single-valued walk stands.
+	return newCylinderUV(cyl, band, plane, n).splitSide(f, cyl, curves[0])
 }
 
 // splitSide builds the kept region {g<0} of a ruled side in (u,v). The WRAPPING case (kept v-interval

--- a/kernel/brep/curved_halfspace_ruled_uv.go
+++ b/kernel/brep/curved_halfspace_ruled_uv.go
@@ -81,17 +81,6 @@ func (c ruledUV) aU(u float64) float64 { return c.p + c.q*stdmath.Cos(u+c.seamU-
 // bU returns b(u) = s + t·cos(u−uN), the coefficient of v in the signed distance g(u,v)=a(u)+v·b(u).
 func (c ruledUV) bU(u float64) float64 { return c.s + c.t*stdmath.Cos(u+c.seamU-c.uN) }
 
-// sectionV returns the axial distance v where the cut plane meets the side at azimuth u — the section
-// curve v(u) = −a(u)/b(u). It returns 0 where b(u)≈0 (the plane is parallel to the ruling at u, no finite
-// section there); that azimuth's section is a vertical ruling handled by the span-end edge, not sampled here.
-func (c ruledUV) sectionV(u float64) float64 {
-	b := c.bU(u)
-	if stdmath.Abs(b) < 1e-12 {
-		return 0
-	}
-	return -c.aU(u) / b
-}
-
 // vPinchTol is the axial-distance margin below which a kept interval counts as PINCHED (empty). A tongue
 // pinches where the section meets a clamp rim (lo≈hi); when that azimuth lands exactly on a sample (a
 // symmetric cut puts the pinch on u=0/π/2π) the section value equals the rim to within rounding, so a
@@ -152,133 +141,16 @@ func coneSideUVSplit(f curvedFace, cone geom.Cone, conic geom.Curve3, band coneS
 // builds (it never references the degenerate apex rim). Apex KEPT → the kept face closes to the apex as a
 // single loop (the cut ellipse, or the notched rim), the apex an interior pole (apexCapSide).
 func coneApexSideSplit(f curvedFace, cone geom.Cone, conic geom.Curve3, band coneSideBand_, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
-	uv := newConeUV(cone, band, plane, n)
-	if !uv.apexKept() {
-		return uv.splitSide(f, cone, conic) // apex on the dropped side: a frustum-like band, no apex pole
-	}
-	return uv.apexCapSide(f, cone, conic)
+	// Both apex sides go through the general arrangement trim. Apex dropped → a frustum-like band; apex kept
+	// → the kept face closes to the apex as a single loop, the apex an interior pole (the degenerate v=0
+	// rim loop is dropped inside trimByImprint, dropApexLoop).
+	return newConeUV(cone, band, plane, n).trimByImprint(f, cone, []geom.Curve3{conic}, ruledUV.halfSpaceMaterial)
 }
 
-// apexKept reports whether the cone apex (the v=0 pole) is on the kept (negative) side. A cone has q=0, so
-// a(0)=p is constant in u and the apex's signed distance g(0)=p; the apex is kept exactly when p<0.
-func (c ruledUV) apexKept() bool { return c.p < 0 }
-
-// apexCapSide builds the kept face when the apex is KEPT: the cone closes to its apex pole capped by the
-// cut, so the face is a SINGLE loop — the hi boundary (the full cut ellipse, or the rim notched by the
-// section) — with the apex an interior pole and no lower loop. The hi boundary is oriented like splitSide's
-// upper loop (reversed when it carries a rim shared with the base cap); the section caps the lid.
-func (c ruledUV) apexCapSide(f curvedFace, surface geom.Surface, conic geom.Curve3) ([]curvedFace, []loopEdge, error) {
-	hiEdges, hiSec, ok := c.boundaryLoop(conic, true)
-	if !ok {
-		return nil, nil, ErrUnsupportedHalfSpace
-	}
-	hiLoop, lidSec := hiEdges, reverseEdgeChain(hiSec)
-	if loopHasRim(hiEdges) && c.band.topRimReversed {
-		hiLoop, lidSec = reverseEdgeChain(hiEdges), hiSec
-	}
-	kept := curvedFace{surface: surface, reversed: f.reversed, lineage: f.lineage, loops: []curvedLoop{{edges: hiLoop}}}
-	return []curvedFace{kept}, lidSec, nil
-}
-
-// cylinderSideUVSplit splits a full periodic cylinder side by the (u,v) arrangement (newCylinderUV +
-// splitSide). It handles both the axis-parallel flat (b≡0 → a vertical-edged span) and an oblique ellipse
-// cut (within-band / clips-rim / tongue), the latter the case the line-only cylinder split deferred to CSG.
+// cylinderSideUVSplit splits a full periodic cylinder side by the general (u,v)-arrangement trimmer
+// (newCylinderUV + trimByImprint): the axis-parallel flat (a ruling-pair section), the oblique ellipse
+// (within-band / clips-rim / tongue), all flow through it uniformly (Oblikovati#1405).
 func cylinderSideUVSplit(f curvedFace, cyl geom.Cylinder, curves []geom.Curve3, band coneSideBand_, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
 	c := newCylinderUV(cyl, band, plane, n)
 	return c.trimByImprint(f, cyl, curves, ruledUV.halfSpaceMaterial)
-}
-
-// splitSide builds the kept region {g<0} of a ruled side in (u,v). The WRAPPING case (kept v-interval
-// non-empty for every azimuth) is a band represented as a face with two boundary loops (no seam, like the
-// vertex-inside annulus #1374): the upper loop is the kept hi(u) curve and the lower loop the kept lo(u)
-// curve, each a closed chain of WHOLE rim arcs and section arcs split only at the rim crossings — so each
-// rim arc welds with the cap that shares it. A NON-WRAPPING arrangement — the interval empties at some
-// azimuths — is built by tongueSide as one span. surface is the kept face's analytic surface (cone/cylinder).
-func (c ruledUV) splitSide(f curvedFace, surface geom.Surface, conic geom.Curve3) ([]curvedFace, []loopEdge, error) {
-	if !c.wrapsAllU() {
-		return c.tongueSide(f, surface, conic) // a non-wrapping arrangement: one kept azimuth span
-	}
-	hiEdges, hiSec, ok1 := c.boundaryLoop(conic, true)
-	loEdges, loSec, ok2 := c.boundaryLoop(conic, false)
-	if !ok1 || !ok2 {
-		return nil, nil, ErrUnsupportedHalfSpace
-	}
-	// A ruled side's two rims run oppositely so the side stays consistent with both caps. The lo boundary is
-	// built CCW (forward); the UPPER boundary is reversed whenever it carries a rim that the source face
-	// traversed reversed (band.topRimReversed) — so the rebuilt rim keeps the sense opposite its kept cap.
-	// A frustum/cylinder traverses the top rim reversed; an apex-at-top full cone traverses its rim forward,
-	// so this is NOT a fixed flip. The lid uses each section sub-arc OPPOSITE to the band's final use of it.
-	hiLoop, lidHiSec := hiEdges, reverseEdgeChain(hiSec)
-	if loopHasRim(hiEdges) && c.band.topRimReversed {
-		hiLoop, lidHiSec = reverseEdgeChain(hiEdges), hiSec
-	}
-	kept := curvedFace{surface: surface, reversed: f.reversed, lineage: f.lineage,
-		loops: []curvedLoop{{edges: hiLoop}, {edges: loEdges}}}
-	lidSection := append(append([]loopEdge{}, lidHiSec...), reverseEdgeChain(loSec)...)
-	return []curvedFace{kept}, lidSection, nil
-}
-
-// tongueSide builds the kept face of a NON-WRAPPING arrangement: the kept v-interval is non-empty only
-// over a single azimuth span [u1, u2]. The kept region is one loop — the LOWER bound forward over [u1, u2],
-// the span-end ruling UP (lo→hi at u2), the UPPER bound reversed, the start ruling DOWN (hi→lo at u1).
-// At a PINCH end (cone tongue: section meets the clamp rim, lo≈hi) the ruling is degenerate and dropped;
-// at a FULL end (cylinder axis-parallel flat: the plane parallels the ruling, lo=vMin hi=vMax) the ruling
-// is the vertical cut line that bounds the lid. The section sub-arcs and the cut-line rulings cap the
-// planar lid together with the cap chords the same plane carves on the end caps (Oblikovati#1375).
-func (c ruledUV) tongueSide(f curvedFace, surface geom.Surface, conic geom.Curve3) ([]curvedFace, []loopEdge, error) {
-	u1, u2, ok := c.keptUSpan()
-	if !ok {
-		return nil, nil, ErrUnsupportedHalfSpace // not a single span
-	}
-	loEdges, loSec, ok1 := c.boundarySubChain(conic, u1, u2, false)
-	hiEdges, hiSec, ok2 := c.boundarySubChain(conic, u1, u2, true)
-	if !ok1 || !ok2 {
-		return nil, nil, ErrUnsupportedHalfSpace
-	}
-	endHi, hasHi := c.spanEndEdge(u2) // the ruling at u2, oriented lo→hi
-	endLo, hasLo := c.spanEndEdge(u1) // the ruling at u1, oriented lo→hi
-	loop := tongueLoop(loEdges, hiEdges, endHi, hasHi, endLo, hasLo)
-	section := tongueSection(loSec, hiSec, endHi, hasHi, endLo, hasLo)
-	kept := curvedFace{surface: surface, reversed: f.reversed, lineage: f.lineage, loops: []curvedLoop{{edges: loop}}}
-	return []curvedFace{kept}, section, nil
-}
-
-// tongueLoop assembles the single kept loop of a non-wrapping span: the lower bound forward, the u2 ruling
-// up (lo→hi), the upper bound reversed, the u1 ruling down (hi→lo). A degenerate (pinch) ruling is dropped.
-func tongueLoop(loEdges, hiEdges []loopEdge, endHi loopEdge, hasHi bool, endLo loopEdge, hasLo bool) []loopEdge {
-	loop := append([]loopEdge{}, loEdges...)
-	if hasHi {
-		loop = append(loop, endHi)
-	}
-	loop = append(loop, reverseEdgeChain(hiEdges)...)
-	if hasLo {
-		loop = append(loop, reverseEdge(endLo))
-	}
-	return loop
-}
-
-// tongueSection assembles the span's lid section edges, each OPPOSITE to the band's final use of it: the
-// lo section runs forward in the band so the lid reverses it, the hi section runs reversed so the lid uses
-// it forward, and each cut-line ruling likewise (the u2 ruling reversed, the u1 ruling forward).
-func tongueSection(loSec, hiSec []loopEdge, endHi loopEdge, hasHi bool, endLo loopEdge, hasLo bool) []loopEdge {
-	section := append(reverseEdgeChain(loSec), hiSec...)
-	if hasHi {
-		section = append(section, reverseEdge(endHi))
-	}
-	if hasLo {
-		section = append(section, endLo)
-	}
-	return section
-}
-
-// spanEndEdge returns the vertical ruling at azimuth u from the kept lo to hi, oriented lo→hi, and whether
-// it is non-degenerate. At a pinch end (lo≈hi) it returns false (the loop closes at the pinch vertex with
-// no edge); at a full end (the cut line of an axis-parallel flat) it returns the straight cut ruling.
-func (c ruledUV) spanEndEdge(u float64) (loopEdge, bool) {
-	lo, hi, _ := c.keptV(u)
-	if hi-lo < 1e-6 {
-		return loopEdge{}, false // pinched: no span-end ruling
-	}
-	seg := geom.NewLineSegment(c.point3(u, lo), c.point3(u, hi))
-	return loopEdge{curve: seg, t0: 0, t1: 1}, true
 }

--- a/kernel/brep/curved_halfspace_ruled_uv.go
+++ b/kernel/brep/curved_halfspace_ruled_uv.go
@@ -172,9 +172,10 @@ func (c ruledUV) apexCapSide(f curvedFace, surface geom.Surface, conic geom.Curv
 // splitSide). It handles both the axis-parallel flat (b≡0 → a vertical-edged span) and an oblique ellipse
 // cut (within-band / clips-rim / tongue), the latter the case the line-only cylinder split deferred to CSG.
 func cylinderSideUVSplit(f curvedFace, cyl geom.Cylinder, curves []geom.Curve3, band coneSideBand_, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
-	// The general (u,v)-arrangement trimmer (trimByImprint) is built and unit-tested but not yet wired here:
-	// reconciling its connected-loop orientation with the stitcher's hi/lo-bound convention (topRimReversed,
-	// lid sense) is the remaining step of Oblikovati#1405. Until then the analytic single-valued walk stands.
+	// trimByImprint (the general arrangement trimmer) now reproduces the analytic result for the wrapping
+	// band, oblique-ellipse and axis-parallel cuts via the hi/lo orientation convention (orientLoops); the
+	// clips-rim case still needs the multi-face weld at the rim crossings reconciled before this can switch
+	// (Oblikovati#1405). Until then the analytic single-valued walk stands.
 	return newCylinderUV(cyl, band, plane, n).splitSide(f, cyl, curves[0])
 }
 

--- a/kernel/brep/curved_halfspace_ruled_uv.go
+++ b/kernel/brep/curved_halfspace_ruled_uv.go
@@ -129,10 +129,10 @@ func (c ruledUV) point3(u, v float64) math.Point3 {
 	return c.base.TranslateBy(c.axis.Scale(math.Scalar(v))).TranslateBy(radial.Scale(math.Scalar(rad)))
 }
 
-// coneSideUVSplit splits a full periodic frustum side. The general (u,v)-arrangement trimmer (trimByImprint)
-// now drives the whole cylinder side; the cone reuses the same path but its hyperbola/parabola arm sections
-// and span-end rulings still need their weld reconciled (a valid face emits, but the assembled solid is not
-// yet manifold), so the analytic splitSide stands here until that lands (Oblikovati#1405).
+// coneSideUVSplit splits a full periodic frustum side. The general (u,v)-arrangement trimmer (trimByImprint,
+// with the multi-arm clipParams) now handles most cone cuts (axis-∥ flat, parabola, vertex-inside, ellipse),
+// but the OBLIQUE hyperbola still arranges wrong — its two arms leave the band's interior cell misclassified
+// — so the analytic splitSide stands here until that arrangement case is reconciled (Oblikovati#1405).
 func coneSideUVSplit(f curvedFace, cone geom.Cone, conic geom.Curve3, band coneSideBand_, plane geom.Plane, n math.Vector3) ([]curvedFace, []loopEdge, error) {
 	return newConeUV(cone, band, plane, n).splitSide(f, cone, conic)
 }

--- a/kernel/brep/curved_halfspace_uv_arrangement.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement.go
@@ -146,3 +146,76 @@ func (c ruledUV) assembleBandSegments(imprint []uvSeg) []uvSeg {
 	}
 	return append(out, c.bandFrameSegments()...)
 }
+
+// materialPredicate reports whether a (u,v) point of the band is on the KEPT side of the imprint. For a
+// plane cut it is the half-space membership g(u,v) = a(u)+v·b(u) < 0 (the same {g<0} the analytic walk
+// keeps); a general curved∩curved imprint supplies its own inside/outside test. The arrangement is built
+// once and classified through this predicate, so the two cases share the whole pipeline (#1405).
+type materialPredicate func(uv math.Point2) bool
+
+// halfSpaceMaterial is the plane-cut predicate: a band point is kept where the signed distance g(u,v) is
+// negative, exactly the {g<0} region the single-valued walk traced as a v-interval.
+func (c ruledUV) halfSpaceMaterial() materialPredicate {
+	return func(uv math.Point2) bool { return c.aU(uv.X)+uv.Y*c.bU(uv.X) < 0 }
+}
+
+// arrangeBand runs the planar subdivision on the assembled band, returning the cells as (u,v) polygons
+// (outer loop + nested holes). It is the periodic band flattened to a rectangle; cross-seam adjacency is
+// reconciled later when the kept region's boundary is walked.
+func (c ruledUV) arrangeBand(segs []uvSeg) []Face2D {
+	in := make([][2]math.Point2, 0, len(segs))
+	for _, s := range segs {
+		in = append(in, [2]math.Point2{s.a, s.b})
+	}
+	return Arrange(in)
+}
+
+// keptCells returns the arrangement cells whose interior is on the material side of the imprint, each cell
+// classified by evaluating the predicate at a point strictly inside its outer loop. A cell straddling the
+// imprint cannot occur (the imprint is an arrangement edge), so any interior sample decides the whole cell.
+func keptCells(cells []Face2D, material materialPredicate) []Face2D {
+	var kept []Face2D
+	for _, cell := range cells {
+		if p, ok := interiorPointOf(cell.Outer); ok && material(p) {
+			kept = append(kept, cell)
+		}
+	}
+	return kept
+}
+
+// interiorPointOf returns a point strictly inside the simple polygon (and ok). The centroid serves for a
+// convex cell; for a concave one it may fall outside, so the fallback steps a short way from each edge
+// midpoint toward the centroid until a point lands inside — robust for the arrangement's simple cells.
+func interiorPointOf(poly []math.Point2) (math.Point2, bool) {
+	if len(poly) < 3 {
+		return math.Point2{}, false
+	}
+	c := centroidOf(poly)
+	if pointInPolygon2D(c, poly) {
+		return c, true
+	}
+	for i := range poly {
+		a, b := poly[i], poly[(i+1)%len(poly)]
+		mid := math.P2((float64(a.X)+float64(b.X))/2, (float64(a.Y)+float64(b.Y))/2)
+		for _, f := range []float64{1e-3, 1e-2, 0.1, 0.5} {
+			p := math.P2(lerp(float64(mid.X), float64(c.X), f), lerp(float64(mid.Y), float64(c.Y), f))
+			if pointInPolygon2D(p, poly) {
+				return p, true
+			}
+		}
+	}
+	return c, false
+}
+
+// centroidOf returns the vertex average of a polygon (a cheap interior estimate, exact for the convex case).
+func centroidOf(poly []math.Point2) math.Point2 {
+	var sx, sy float64
+	for _, p := range poly {
+		sx, sy = sx+float64(p.X), sy+float64(p.Y)
+	}
+	n := float64(len(poly))
+	return math.P2(sx/n, sy/n)
+}
+
+// lerp linearly interpolates from a to b by fraction f.
+func lerp(a, b, f float64) float64 { return a + f*(b-a) }

--- a/kernel/brep/curved_halfspace_uv_arrangement.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement.go
@@ -71,8 +71,16 @@ const imprintSampleCount = 256
 // The azimuth seam (u wrapping 2π↔0) is left for the arrangement to resolve — sampleImprintUV reports the
 // raw branch [0,2π); seam unwrapping is applied when segments are assembled into the band.
 func (c ruledUV) sampleImprintUV(curve geom.Curve3) []uvSeg {
-	t0, t1, ok := c.clipParams(curve)
-	if !ok || t0 == t1 {
+	var segs []uvSeg
+	for _, r := range c.clipParams(curve) {
+		segs = append(segs, c.sampleRange(curve, r[0], r[1])...)
+	}
+	return segs
+}
+
+// sampleRange samples one curve parameter interval [t0,t1] into tagged (u,v) segments.
+func (c ruledUV) sampleRange(curve geom.Curve3, t0, t1 float64) []uvSeg {
+	if t0 == t1 {
 		return nil
 	}
 	segs := make([]uvSeg, 0, imprintSampleCount)
@@ -87,65 +95,55 @@ func (c ruledUV) sampleImprintUV(curve geom.Curve3) []uvSeg {
 	return segs
 }
 
-// clipParams returns the parameter window over which an imprint curve should be sampled: its whole domain
-// when finite (an ellipse, a clipped arc), but for an UNBOUNDED curve (a ruling line, or an open
-// hyperbola/parabola arm of a cone cut) the sub-range where it lies within the band's axial extent — so
-// sampling stays finite and on the side. A ruling is linear in v, solved directly; a general unbounded
-// curve is windowed by numerically finding its band-edge crossings.
-func (c ruledUV) clipParams(curve geom.Curve3) (t0, t1 float64, ok bool) {
+// clipParams returns the parameter sub-ranges over which an imprint curve should be sampled: its whole
+// domain when finite (an ellipse / clipped arc — clipSegToVBand then trims any out-of-band part), but for an
+// UNBOUNDED curve (a ruling line, or an open hyperbola/parabola of a cone cut) only the sub-ranges where it
+// lies within the band's axial extent. A cone cut's hyperbola has TWO arms in the band (the joining vertex
+// is outside it), so this can return more than one range — each a separate boundary arc.
+func (c ruledUV) clipParams(curve geom.Curve3) [][2]float64 {
 	lo, hi := curve.Domain()
 	if !stdmath.IsInf(lo, 0) && !stdmath.IsInf(hi, 0) {
-		return lo, hi, true
+		return [][2]float64{{lo, hi}}
 	}
 	if line, isLine := curve.(geom.Line); isLine {
 		d := float64(line.Dir.AsVector().Dot(c.axis))
 		if stdmath.Abs(d) < 1e-12 {
-			return 0, 0, false // a ruling perpendicular to the axis cannot bound a v-band
+			return nil // a ruling perpendicular to the axis cannot bound a v-band
 		}
 		v0 := float64(c.base.VectorTo(line.Origin).Dot(c.axis))
-		return (c.band.vMin - v0) / d, (c.band.vMax - v0) / d, true
+		return [][2]float64{{(c.band.vMin - v0) / d, (c.band.vMax - v0) / d}}
 	}
-	return c.clipParamsNumeric(curve)
+	return c.inBandRanges(curve)
 }
 
-// clipParamsNumeric windows an unbounded curve to the band by scanning a finite bracket (proportional to
-// the band's 3D size) for where its axial coordinate v crosses vMin and vMax, then bisecting each crossing.
-// It assumes v is monotone through the band — true for the open conic arms a half-space cut produces.
-func (c ruledUV) clipParamsNumeric(curve geom.Curve3) (t0, t1 float64, ok bool) {
+// inBandRanges scans an unbounded curve over a finite bracket (proportional to the band's 3D size) and
+// returns every maximal sub-range whose axial coordinate v lies within the band. Each range straddles its
+// band crossings by one sample so clipSegToVBand can refine the exact crossing; multiple ranges arise when
+// the curve enters the band more than once (the two arms of a cone-cut hyperbola).
+func (c ruledUV) inBandRanges(curve geom.Curve3) [][2]float64 {
 	b := 4 * (c.band.vMax - c.band.vMin + 2*stdmath.Max(c.band.rBot, c.band.rTop) + 1)
-	vAt := func(t float64) float64 { return float64(c.paramOf(curve.PointAt(t)).Y) }
-	a, okA := bisectVCrossing(vAt, c.band.vMin, -b, b)
-	d, okD := bisectVCrossing(vAt, c.band.vMax, -b, b)
-	if !okA || !okD {
-		return 0, 0, false
+	const scan = 2048
+	inBand := func(t float64) bool {
+		v := c.curveV(curve, t)
+		return v >= c.band.vMin && v <= c.band.vMax
 	}
-	return a, d, true
-}
-
-// bisectVCrossing scans [lo,hi] for an interval where vAt crosses target, then bisects it to the crossing
-// parameter. Returns ok=false when no crossing is bracketed.
-func bisectVCrossing(vAt func(float64) float64, target, lo, hi float64) (float64, bool) {
-	const scan = 256
-	prevT := lo
-	prevV := vAt(lo) - target
-	for i := 1; i <= scan; i++ {
-		t := lo + (hi-lo)*float64(i)/scan
-		v := vAt(t) - target
-		if (prevV <= 0) != (v <= 0) {
-			a, b := prevT, t
-			for j := 0; j < 50; j++ {
-				m := (a + b) / 2
-				if (vAt(a)-target <= 0) == (vAt(m)-target <= 0) {
-					a = m
-				} else {
-					b = m
-				}
-			}
-			return (a + b) / 2, true
+	var ranges [][2]float64
+	open, start, prev := false, 0.0, -b
+	for i := 0; i <= scan; i++ {
+		t := -b + 2*b*float64(i)/scan
+		switch in := inBand(t); {
+		case in && !open:
+			start, open = prev, true
+		case !in && open:
+			ranges = append(ranges, [2]float64{start, t})
+			open = false
 		}
-		prevT, prevV = t, v
+		prev = t
 	}
-	return 0, false
+	if open {
+		ranges = append(ranges, [2]float64{start, b})
+	}
+	return ranges
 }
 
 // unwrapAzimuthNear shifts x by whole turns (2π) so it lands within ±π of ref, turning a wrapped azimuth

--- a/kernel/brep/curved_halfspace_uv_arrangement.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement.go
@@ -208,7 +208,7 @@ func (c ruledUV) assembleBandSegments(imprint []uvSeg) []uvSeg {
 			// Clip each imprint segment to the band's axial range: a section can leave [vMin,vMax] (a tilted
 			// cut's ellipse rises past the rim), and sampling that out-of-band part would inject a spurious
 			// arc; clipping lands the imprint exactly on the rim where it crosses, the real rim split.
-			for _, clipped := range clipSegToVBand(split, c.band.vMin, c.band.vMax) {
+			for _, clipped := range c.clipSegToVBand(split) {
 				if clipped.a.DistanceTo(clipped.b) > arrTol {
 					out = append(out, clipped)
 				}
@@ -218,37 +218,62 @@ func (c ruledUV) assembleBandSegments(imprint []uvSeg) []uvSeg {
 	return append(out, c.bandFrameSegments()...)
 }
 
-// clipSegToVBand clips a (u,v) imprint segment to the axial band [vMin,vMax], returning the in-band part
-// (with u and the curve parameter interpolated to the rim crossing) or nothing when the segment lies wholly
-// outside. The band rims then bound the imprint exactly where it would otherwise overshoot.
-func clipSegToVBand(s uvSeg, vMin, vMax float64) []uvSeg {
+// clipSegToVBand clips a (u,v) imprint segment to the axial band [vMin,vMax], returning the in-band part or
+// nothing when the segment lies wholly outside on one side. Crucially, an endpoint that leaves the band is
+// snapped to the EXACT curve parameter where the imprint crosses the rim (not a linear interpolation of the
+// sampled segment), so the rim-crossing 3D point equals plane∩rim and welds with the cap's matching arc —
+// the section ellipse is plane∩cylinder, so its v=rim crossing is exactly plane∩rim (#1405).
+func (c ruledUV) clipSegToVBand(s uvSeg) []uvSeg {
+	vMin, vMax := c.band.vMin, c.band.vMax
 	a, b := float64(s.a.Y), float64(s.b.Y)
 	if (a < vMin && b < vMin) || (a > vMax && b > vMax) {
 		return nil
 	}
-	if a >= vMin && a <= vMax && b >= vMin && b <= vMax {
-		return []uvSeg{s}
-	}
-	t0, t1 := 0.0, 1.0
-	if dv := b - a; dv != 0 {
-		lo, hi := (vMin-a)/dv, (vMax-a)/dv
-		if lo > hi {
-			lo, hi = hi, lo
-		}
-		t0, t1 = stdmath.Max(t0, lo), stdmath.Min(t1, hi)
-	}
-	if t0 >= t1 {
+	sa, ta := c.clipEndToBand(s, true)
+	sb, tb := c.clipEndToBand(s, false)
+	if sa.DistanceTo(sb) <= arrTol {
 		return nil
 	}
-	return []uvSeg{{
-		a: lerpUV(s.a, s.b, t0), b: lerpUV(s.a, s.b, t1),
-		curve: s.curve, tA: lerp(s.tA, s.tB, t0), tB: lerp(s.tA, s.tB, t1), kind: s.kind,
-	}}
+	return []uvSeg{{a: sa, b: sb, curve: s.curve, tA: ta, tB: tb, kind: s.kind}}
 }
 
-// lerpUV linearly interpolates a (u,v) point between a and b by fraction t.
-func lerpUV(a, b math.Point2, t float64) math.Point2 {
-	return math.P2(lerp(float64(a.X), float64(b.X), t), lerp(float64(a.Y), float64(b.Y), t))
+// clipEndToBand returns one endpoint of a segment clipped to the band: the endpoint unchanged when already
+// in [vMin,vMax], else the (u,v) and curve parameter where the imprint curve exactly reaches the nearer rim
+// (refined on the curve, between this end's parameter and the other's).
+func (c ruledUV) clipEndToBand(s uvSeg, isA bool) (math.Point2, float64) {
+	p, v, t, tOther := s.a, float64(s.a.Y), s.tA, s.tB
+	if !isA {
+		p, v, t, tOther = s.b, float64(s.b.Y), s.tB, s.tA
+	}
+	if v >= c.band.vMin && v <= c.band.vMax {
+		return p, t
+	}
+	vLim := c.band.vMin
+	if v > c.band.vMax {
+		vLim = c.band.vMax
+	}
+	tc := c.refineCurveV(s.curve, t, tOther, vLim)
+	return c.paramOf(s.curve.PointAt(tc)), tc
+}
+
+// refineCurveV bisects the imprint curve parameter between tOut (outside the band) and tIn (inside) to the
+// point where the curve's axial coordinate v equals vLim — the exact rim crossing.
+func (c ruledUV) refineCurveV(curve geom.Curve3, tOut, tIn, vLim float64) float64 {
+	out := tOut
+	for i := 0; i < 50; i++ {
+		tm := (tOut + tIn) / 2
+		if (c.curveV(curve, out)-vLim <= 0) == (c.curveV(curve, tm)-vLim <= 0) {
+			tOut = tm
+		} else {
+			tIn = tm
+		}
+	}
+	return (tOut + tIn) / 2
+}
+
+// curveV is the axial coordinate v of a 3D imprint curve at parameter t.
+func (c ruledUV) curveV(curve geom.Curve3, t float64) float64 {
+	return float64(c.paramOf(curve.PointAt(t)).Y)
 }
 
 // materialPredicate reports whether a (u,v) point of the band is on the KEPT side of the imprint. For a

--- a/kernel/brep/curved_halfspace_uv_arrangement.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// General (u,v) arrangement trim of a ruled side (Oblikovati#1405). The analytic walk in
+// curved_halfspace_ruled_boundary.go reduces the kept region to a single-valued v-interval [lo(u),hi(u)]
+// per azimuth — it reads the surface only through keptV/sectionV, so it cannot trim by a MULTI-valued or
+// CLOSED-island imprint (the general curved∩curved case). This file replaces that walk with a parameter-
+// space arrangement: project the imprint into the side's (u,v) band, subdivide the band into cells along
+// the imprint, classify each cell kept/dropped by a material predicate, and re-emit the kept region's
+// boundary as exact analytic edges. A plane cut becomes the special case where the imprint is one conic.
+//
+// The arrangement reuses the planar subdivision engine (Arrange, arrange2d.go) on the (u,v) point cloud;
+// curve identity is carried on the sampled segments so the re-emitted boundary keeps exact arcs/conics
+// rather than the sampled polyline. This file builds the (u,v) projection and the tagged imprint sampling;
+// the cell classification and boundary re-emission follow in the same arrangement pipeline.
+
+// paramOf returns the (u, v) = (azimuth, axial distance) of a 3D point on the ruled side — the inverse of
+// point3. v is the signed distance along the axis from the v=0 base; the radial remainder gives the azimuth
+// in [0, 2π) measured from the ref direction. A point off the surface projects to its nearest (u,v) (the
+// axial/azimuth components are still well defined), which is what sampling an imprint that lies ON the
+// surface to tolerance needs.
+func (c ruledUV) paramOf(p math.Point3) math.Point2 {
+	d := c.base.VectorTo(p)
+	v := float64(d.Dot(c.axis))
+	radial := d.Sub(c.axis.Scale(math.Scalar(v)))
+	u := stdmath.Atan2(float64(radial.Dot(c.binor)), float64(radial.Dot(c.ref)))
+	if u < 0 {
+		u += 2 * stdmath.Pi
+	}
+	return math.P2(u, v)
+}
+
+// uvSeg is one sampled segment of an imprint curve in the side's (u,v) band, tagged with the analytic
+// curve it came from and the curve parameters at its endpoints, so the arrangement can re-emit the exact
+// curve sub-arc (an ellipse/hyperbola/parabola arm) for a boundary chain rather than the sampled polyline.
+type uvSeg struct {
+	a, b   math.Point2 // (u,v) endpoints
+	curve  geom.Curve3 // the source analytic imprint curve
+	tA, tB float64     // its parameters at a and b
+}
+
+// imprintSampleCount is the number of segments one analytic imprint curve is sampled into across its
+// parameter domain. It is dense enough to resolve the curve's crossings with the rims and with other
+// imprint arcs to the arrangement weld (1e-7) at part scale, while keeping the planar arrangement small.
+const imprintSampleCount = 256
+
+// sampleImprintUV samples an analytic imprint curve over [t0, t1] into tagged (u,v) segments on the side.
+// Each sample inverts the 3D curve point to (u,v) via paramOf; consecutive samples become one uvSeg
+// carrying the curve and its endpoint parameters, so a later boundary walk re-emits exact sub-arcs. The
+// azimuth seam (u wrapping 2π↔0) is left for the arrangement to resolve — sampleImprintUV reports the raw
+// branch [0,2π); seam unwrapping is applied when segments are assembled into the band.
+func (c ruledUV) sampleImprintUV(curve geom.Curve3, t0, t1 float64) []uvSeg {
+	segs := make([]uvSeg, 0, imprintSampleCount)
+	prevT := t0
+	prevP := c.paramOf(curve.PointAt(t0))
+	for i := 1; i <= imprintSampleCount; i++ {
+		t := t0 + (t1-t0)*float64(i)/imprintSampleCount
+		p := c.paramOf(curve.PointAt(t))
+		segs = append(segs, uvSeg{a: prevP, b: p, curve: curve, tA: prevT, tB: t})
+		prevT, prevP = t, p
+	}
+	return segs
+}

--- a/kernel/brep/curved_halfspace_uv_arrangement.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement.go
@@ -32,8 +32,11 @@ func (c ruledUV) paramOf(p math.Point3) math.Point2 {
 	d := c.base.VectorTo(p)
 	v := float64(d.Dot(c.axis))
 	radial := d.Sub(c.axis.Scale(math.Scalar(v)))
-	u := stdmath.Atan2(float64(radial.Dot(c.binor)), float64(radial.Dot(c.ref)))
-	if u < 0 {
+	// atan2 ∈ [−π, π] and seamU ∈ [0, 2π), so u ∈ [−3π, π]: only a lower wrap is needed. (An upper clamp
+	// would map a point at azimuth ≈2π−ε, which rounds to 2π after the wrap, down to 0 — a false seam
+	// discontinuity that leaves an un-split wrap segment.)
+	u := stdmath.Atan2(float64(radial.Dot(c.binor)), float64(radial.Dot(c.ref))) - c.seamU
+	for u < 0 {
 		u += 2 * stdmath.Pi
 	}
 	return math.P2(u, v)
@@ -281,9 +284,38 @@ func (c ruledUV) curveV(curve geom.Curve3, t float64) float64 {
 type materialPredicate func(uv math.Point2) bool
 
 // halfSpaceMaterial is the plane-cut predicate: a band point is kept where the signed distance g(u,v) is
-// negative, exactly the {g<0} region the single-valued walk traced as a v-interval.
+// negative, exactly the {g<0} region the single-valued walk traced as a v-interval. It is passed to
+// trimByImprint as a builder (ruledUV.halfSpaceMaterial) so it is bound to the seam-shifted frame.
 func (c ruledUV) halfSpaceMaterial() materialPredicate {
 	return func(uv math.Point2) bool { return c.aU(uv.X)+uv.Y*c.bU(uv.X) < 0 }
+}
+
+// chooseSeamU returns an azimuth for the arrangement's artificial seam that is clear of the imprint: the
+// midpoint of the widest gap between the imprint's azimuths (the wrap gap included). Placing the seam there
+// keeps a section arm from grazing it, which would otherwise collapse the (u,v) arrangement (#1405). With
+// no imprint, or one that covers every azimuth, it returns 0 (the default seam).
+func (c ruledUV) chooseSeamU(imprint []geom.Curve3) float64 {
+	var us []float64
+	for _, cv := range imprint {
+		for _, s := range c.sampleImprintUV(cv) { // c.seamU is still 0 here, so these are absolute azimuths
+			us = append(us, float64(s.a.X))
+		}
+	}
+	if len(us) == 0 {
+		return 0
+	}
+	sort.Float64s(us)
+	twoPi := 2 * stdmath.Pi
+	bestGap, bestMid := us[0]+twoPi-us[len(us)-1], (us[len(us)-1]+us[0]+twoPi)/2
+	for i := 1; i < len(us); i++ {
+		if g := us[i] - us[i-1]; g > bestGap {
+			bestGap, bestMid = g, (us[i]+us[i-1])/2
+		}
+	}
+	for bestMid >= twoPi {
+		bestMid -= twoPi
+	}
+	return bestMid
 }
 
 // arrangeBand runs the planar subdivision on the assembled band, returning the cells as (u,v) polygons
@@ -572,13 +604,14 @@ func (c ruledUV) emitLoopEdges(loop []dedge, segs []uvSeg) (face, section []loop
 // and the section (cut) arcs that bound the planar lid. It is the arrangement replacement for the analytic
 // splitSide — a plane cut passes its section conic and the half-space predicate, while a general
 // curved∩curved cut passes its projected imprint and membership test (#1405).
-func (c ruledUV) trimByImprint(f curvedFace, surface geom.Surface, imprint []geom.Curve3, material materialPredicate) ([]curvedFace, []loopEdge, error) {
+func (c ruledUV) trimByImprint(f curvedFace, surface geom.Surface, imprint []geom.Curve3, materialOf func(ruledUV) materialPredicate) ([]curvedFace, []loopEdge, error) {
+	c.seamU = c.chooseSeamU(imprint) // move the artificial seam clear of the imprint before arranging
 	var imp []uvSeg
 	for _, cv := range imprint {
 		imp = append(imp, c.sampleImprintUV(cv)...)
 	}
 	segs := c.assembleBandSegments(imp)
-	kept := keptCells(c.arrangeBand(segs), material)
+	kept := keptCells(c.arrangeBand(segs), materialOf(c))
 	if len(kept) == 0 {
 		return nil, nil, nil // the whole side is on the dropped side
 	}
@@ -719,7 +752,9 @@ func (c ruledUV) emitRimRun(run []recoveredEdge) (loopEdge, bool) {
 	if stdmath.Abs(span) >= 2*stdmath.Pi-1e-6 {
 		return loopEdge{curve: circle, t0: 0, t1: 1}, true // a full rim circle, reused whole
 	}
-	arc, err := geom.NewArc3d(center, c.axis, c.ref, radius, float64(run[0].a.X), span)
+	// NewArc3d's start angle is measured on the surface's own ref frame, so add seamU back to the
+	// seam-relative u of the run's start.
+	arc, err := geom.NewArc3d(center, c.axis, c.ref, radius, float64(run[0].a.X)+c.seamU, span)
 	if err != nil {
 		return loopEdge{}, false
 	}

--- a/kernel/brep/curved_halfspace_uv_arrangement.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement.go
@@ -38,13 +38,25 @@ func (c ruledUV) paramOf(p math.Point3) math.Point2 {
 	return math.P2(u, v)
 }
 
+// segKind tags what a (u,v) segment re-emits to when it bounds a kept cell: an imprint sub-arc (the cut),
+// a band rim (constant v, a circle arc), or the azimuth SEAM ruling (u=0≡2π — an ARTIFICIAL edge that
+// closes the parameter rectangle for the arrangement and dissolves wherever the kept region wraps it).
+type segKind int
+
+const (
+	segImprint segKind = iota
+	segRim
+	segSeam
+)
+
 // uvSeg is one sampled segment of an imprint curve in the side's (u,v) band, tagged with the analytic
 // curve it came from and the curve parameters at its endpoints, so the arrangement can re-emit the exact
 // curve sub-arc (an ellipse/hyperbola/parabola arm) for a boundary chain rather than the sampled polyline.
 type uvSeg struct {
 	a, b   math.Point2 // (u,v) endpoints
-	curve  geom.Curve3 // the source analytic imprint curve
+	curve  geom.Curve3 // the source analytic curve this segment re-emits to
 	tA, tB float64     // its parameters at a and b
+	kind   segKind
 }
 
 // imprintSampleCount is the number of segments one analytic imprint curve is sampled into across its
@@ -64,8 +76,73 @@ func (c ruledUV) sampleImprintUV(curve geom.Curve3, t0, t1 float64) []uvSeg {
 	for i := 1; i <= imprintSampleCount; i++ {
 		t := t0 + (t1-t0)*float64(i)/imprintSampleCount
 		p := c.paramOf(curve.PointAt(t))
-		segs = append(segs, uvSeg{a: prevP, b: p, curve: curve, tA: prevT, tB: t})
+		segs = append(segs, uvSeg{a: prevP, b: p, curve: curve, tA: prevT, tB: t, kind: segImprint})
 		prevT, prevP = t, p
 	}
 	return segs
+}
+
+// unwrapAzimuthNear shifts x by whole turns (2π) so it lands within ±π of ref, turning a wrapped azimuth
+// pair into a monotone run — so a segment's true u-extent (and whether it crosses the seam) is unambiguous.
+func unwrapAzimuthNear(ref, x float64) float64 {
+	for x-ref > stdmath.Pi {
+		x -= 2 * stdmath.Pi
+	}
+	for x-ref < -stdmath.Pi {
+		x += 2 * stdmath.Pi
+	}
+	return x
+}
+
+// splitSeamCrossing splits an imprint segment whose endpoints straddle the azimuth seam (the shorter arc
+// between them crosses u=0≡2π) into two segments meeting AT the seam, so no segment spans the discontinuity
+// — the arrangement sees a clean parameter rectangle. v and the curve parameter are interpolated to the
+// seam crossing. A segment that does not straddle the seam is returned unchanged.
+func splitSeamCrossing(s uvSeg) []uvSeg {
+	ub := unwrapAzimuthNear(s.a.X, s.b.X)
+	if ub >= 0 && ub <= 2*stdmath.Pi {
+		return []uvSeg{s} // wholly inside the band, no seam crossing
+	}
+	seamU, otherU := 0.0, 2*stdmath.Pi
+	if ub > 2*stdmath.Pi { // the run climbs past 2π: a → 2π, then 0 → b
+		seamU, otherU = 2*stdmath.Pi, 0
+	}
+	f := (seamU - s.a.X) / (ub - s.a.X)
+	vSeam := s.a.Y + f*(s.b.Y-s.a.Y)
+	tSeam := s.tA + f*(s.tB-s.tA)
+	return []uvSeg{
+		{a: s.a, b: math.P2(seamU, vSeam), curve: s.curve, tA: s.tA, tB: tSeam, kind: s.kind},
+		{a: math.P2(otherU, vSeam), b: s.b, curve: s.curve, tA: tSeam, tB: s.tB, kind: s.kind},
+	}
+}
+
+// bandFrameSegments returns the four straight (u,v) edges that bound the parameter rectangle for the
+// arrangement: the bottom rim (v=vMin) and top rim (v=vMax) — each a single horizontal segment in (u,v),
+// tagged to its rim circle — and the two seam verticals (u=0 and u=2π), tagged to the shared seam ruling.
+// The rims are genuine surface boundaries; the seam verticals are artificial and dissolve where the kept
+// region wraps them (resolved when cells are merged across the seam).
+func (c ruledUV) bandFrameSegments() []uvSeg {
+	twoPi := 2 * stdmath.Pi
+	seam := geom.NewLineSegment(c.point3(0, c.band.vMin), c.point3(0, c.band.vMax))
+	return []uvSeg{
+		{a: math.P2(0, c.band.vMin), b: math.P2(twoPi, c.band.vMin), curve: c.band.bottomCirc, tA: 0, tB: 1, kind: segRim},
+		{a: math.P2(0, c.band.vMax), b: math.P2(twoPi, c.band.vMax), curve: c.band.topCirc, tA: 0, tB: 1, kind: segRim},
+		{a: math.P2(0, c.band.vMin), b: math.P2(0, c.band.vMax), curve: seam, tA: 0, tB: 1, kind: segSeam},
+		{a: math.P2(twoPi, c.band.vMin), b: math.P2(twoPi, c.band.vMax), curve: seam, tA: 0, tB: 1, kind: segSeam},
+	}
+}
+
+// assembleBandSegments builds the full tagged (u,v) segment set the arrangement subdivides: every imprint
+// segment (seam-split so none spans the azimuth discontinuity) plus the rim+seam frame that closes the
+// parameter rectangle. Degenerate segments (both endpoints welded by the seam split) are dropped.
+func (c ruledUV) assembleBandSegments(imprint []uvSeg) []uvSeg {
+	out := make([]uvSeg, 0, len(imprint)+4)
+	for _, s := range imprint {
+		for _, split := range splitSeamCrossing(s) {
+			if split.a.DistanceTo(split.b) > arrTol {
+				out = append(out, split)
+			}
+		}
+	}
+	return append(out, c.bandFrameSegments()...)
 }

--- a/kernel/brep/curved_halfspace_uv_arrangement.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement.go
@@ -4,6 +4,7 @@ package brep
 
 import (
 	stdmath "math"
+	"sort"
 
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/math"
@@ -70,7 +71,10 @@ const imprintSampleCount = 256
 // The azimuth seam (u wrapping 2π↔0) is left for the arrangement to resolve — sampleImprintUV reports the
 // raw branch [0,2π); seam unwrapping is applied when segments are assembled into the band.
 func (c ruledUV) sampleImprintUV(curve geom.Curve3) []uvSeg {
-	t0, t1 := curve.Domain()
+	t0, t1, ok := c.clipParams(curve)
+	if !ok || t0 == t1 {
+		return nil
+	}
 	segs := make([]uvSeg, 0, imprintSampleCount)
 	prevT := t0
 	prevP := c.paramOf(curve.PointAt(t0))
@@ -81,6 +85,67 @@ func (c ruledUV) sampleImprintUV(curve geom.Curve3) []uvSeg {
 		prevT, prevP = t, p
 	}
 	return segs
+}
+
+// clipParams returns the parameter window over which an imprint curve should be sampled: its whole domain
+// when finite (an ellipse, a clipped arc), but for an UNBOUNDED curve (a ruling line, or an open
+// hyperbola/parabola arm of a cone cut) the sub-range where it lies within the band's axial extent — so
+// sampling stays finite and on the side. A ruling is linear in v, solved directly; a general unbounded
+// curve is windowed by numerically finding its band-edge crossings.
+func (c ruledUV) clipParams(curve geom.Curve3) (t0, t1 float64, ok bool) {
+	lo, hi := curve.Domain()
+	if !stdmath.IsInf(lo, 0) && !stdmath.IsInf(hi, 0) {
+		return lo, hi, true
+	}
+	if line, isLine := curve.(geom.Line); isLine {
+		d := float64(line.Dir.AsVector().Dot(c.axis))
+		if stdmath.Abs(d) < 1e-12 {
+			return 0, 0, false // a ruling perpendicular to the axis cannot bound a v-band
+		}
+		v0 := float64(c.base.VectorTo(line.Origin).Dot(c.axis))
+		return (c.band.vMin - v0) / d, (c.band.vMax - v0) / d, true
+	}
+	return c.clipParamsNumeric(curve)
+}
+
+// clipParamsNumeric windows an unbounded curve to the band by scanning a finite bracket (proportional to
+// the band's 3D size) for where its axial coordinate v crosses vMin and vMax, then bisecting each crossing.
+// It assumes v is monotone through the band — true for the open conic arms a half-space cut produces.
+func (c ruledUV) clipParamsNumeric(curve geom.Curve3) (t0, t1 float64, ok bool) {
+	b := 4 * (c.band.vMax - c.band.vMin + 2*stdmath.Max(c.band.rBot, c.band.rTop) + 1)
+	vAt := func(t float64) float64 { return float64(c.paramOf(curve.PointAt(t)).Y) }
+	a, okA := bisectVCrossing(vAt, c.band.vMin, -b, b)
+	d, okD := bisectVCrossing(vAt, c.band.vMax, -b, b)
+	if !okA || !okD {
+		return 0, 0, false
+	}
+	return a, d, true
+}
+
+// bisectVCrossing scans [lo,hi] for an interval where vAt crosses target, then bisects it to the crossing
+// parameter. Returns ok=false when no crossing is bracketed.
+func bisectVCrossing(vAt func(float64) float64, target, lo, hi float64) (float64, bool) {
+	const scan = 256
+	prevT := lo
+	prevV := vAt(lo) - target
+	for i := 1; i <= scan; i++ {
+		t := lo + (hi-lo)*float64(i)/scan
+		v := vAt(t) - target
+		if (prevV <= 0) != (v <= 0) {
+			a, b := prevT, t
+			for j := 0; j < 50; j++ {
+				m := (a + b) / 2
+				if (vAt(a)-target <= 0) == (vAt(m)-target <= 0) {
+					a = m
+				} else {
+					b = m
+				}
+			}
+			return (a + b) / 2, true
+		}
+		prevT, prevV = t, v
+	}
+	return 0, false
 }
 
 // unwrapAzimuthNear shifts x by whole turns (2π) so it lands within ±π of ref, turning a wrapped azimuth
@@ -417,25 +482,81 @@ func clamp01(t float64) float64 {
 
 // emitLoopEdges re-emits a (u,v) boundary loop as a chain of exact analytic loopEdges: recover each dedge's
 // analytic source, merge consecutive edges that share a curve into one run, and emit each run as a single
-// loopEdge (a rim arc, an imprint sub-arc, or a seam ruling). This is the bridge back to the B-rep face.
-func (c ruledUV) emitLoopEdges(loop []dedge, segs []uvSeg) ([]loopEdge, bool) {
+// loopEdge (a rim arc, an imprint sub-arc, or a seam ruling). It returns the full boundary chain and,
+// separately, the imprint (section) sub-arcs alone — the cut edges the planar lid re-uses (reversed).
+func (c ruledUV) emitLoopEdges(loop []dedge, segs []uvSeg) (face, section []loopEdge, ok bool) {
 	rec := make([]recoveredEdge, 0, len(loop))
 	for _, d := range loop {
-		re, ok := c.recoverEdge(d, segs)
-		if !ok {
-			return nil, false
+		re, good := c.recoverEdge(d, segs)
+		if !good {
+			return nil, nil, false
 		}
 		rec = append(rec, re)
 	}
-	var edges []loopEdge
 	for _, run := range mergeRuns(rec) {
-		e, ok := c.emitRun(run)
-		if !ok {
-			return nil, false
+		e, good := c.emitRun(run)
+		if !good {
+			return nil, nil, false
 		}
-		edges = append(edges, e)
+		face = append(face, e)
+		if run[0].kind == segImprint {
+			section = append(section, e)
+		}
 	}
-	return edges, true
+	return face, section, true
+}
+
+// trimByImprint is the general ruled-side split: it trims the side by the (u,v) imprint of the given
+// analytic curves, keeping the cells the material predicate selects, and returns the kept curvedFace(s)
+// and the section (cut) arcs that bound the planar lid. It is the arrangement replacement for the analytic
+// splitSide — a plane cut passes its section conic and the half-space predicate, while a general
+// curved∩curved cut passes its projected imprint and membership test (#1405).
+func (c ruledUV) trimByImprint(f curvedFace, surface geom.Surface, imprint []geom.Curve3, material materialPredicate) ([]curvedFace, []loopEdge, error) {
+	var imp []uvSeg
+	for _, cv := range imprint {
+		imp = append(imp, c.sampleImprintUV(cv)...)
+	}
+	segs := c.assembleBandSegments(imp)
+	kept := keptCells(c.arrangeBand(segs), material)
+	if len(kept) == 0 {
+		return nil, nil, nil // the whole side is on the dropped side
+	}
+	loops := chainLoops(keptBoundaryEdges(kept))
+	faceLoops := make([]curvedLoop, 0, len(loops))
+	var lid []loopEdge
+	for _, lp := range loops {
+		edges, section, ok := c.emitLoopEdges(lp, segs)
+		if !ok {
+			return nil, nil, ErrUnsupportedHalfSpace
+		}
+		faceLoops = append(faceLoops, curvedLoop{edges: edges})
+		lid = append(lid, reverseEdgeChain(section)...) // the lid uses each section arc opposite the side
+	}
+	kf := curvedFace{surface: surface, reversed: f.reversed, lineage: f.lineage, loops: c.orderLoops(faceLoops)}
+	return []curvedFace{kf}, lid, nil
+}
+
+// orderLoops orders a kept face's boundary loops by descending axial level (the higher-v boundary first),
+// matching the analytic splitSide convention where loops[0] is the upper (hi) boundary and the stitcher
+// treats it as the outer loop. A single-loop face is unchanged.
+func (c ruledUV) orderLoops(loops []curvedLoop) []curvedLoop {
+	if len(loops) < 2 {
+		return loops
+	}
+	sort.SliceStable(loops, func(i, j int) bool { return c.meanV(loops[i]) > c.meanV(loops[j]) })
+	return loops
+}
+
+// meanV is a loop's mean axial level (the average v of its edge endpoints), used only to order loops.
+func (c ruledUV) meanV(l curvedLoop) float64 {
+	sum := 0.0
+	for _, e := range l.edges {
+		sum += float64(c.paramOf(e.start()).Y) + float64(c.paramOf(e.end()).Y)
+	}
+	if len(l.edges) == 0 {
+		return 0
+	}
+	return sum / float64(2*len(l.edges))
 }
 
 // mergeRuns groups consecutive recovered edges that lie on the same analytic curve into runs, so a chain of

--- a/kernel/brep/curved_halfspace_uv_arrangement.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement.go
@@ -620,8 +620,36 @@ func (c ruledUV) trimByImprint(f curvedFace, surface geom.Surface, imprint []geo
 		return nil, nil, ErrUnsupportedHalfSpace
 	}
 	faceLoops, lid := c.orientLoops(emitted, c.wrapsAllU())
+	faceLoops = c.dropApexLoop(faceLoops)
 	kf := curvedFace{surface: surface, reversed: f.reversed, lineage: f.lineage, loops: faceLoops}
 	return []curvedFace{kf}, lid, nil
+}
+
+// dropApexLoop removes a degenerate apex-rim loop from a kept cone face. When the band's bottom rim is the
+// cone apex (rBot=0), an apex-kept cut emits that rim as a zero-radius circle at the apex point; the apex is
+// an interior POLE of the closed face, not a boundary, so the loop (carrying no section arcs, so no lid) is
+// dropped — leaving the single cut loop the analytic apexCapSide produced (#1405).
+func (c ruledUV) dropApexLoop(loops []curvedLoop) []curvedLoop {
+	if c.band.rBot > 1e-9 {
+		return loops
+	}
+	out := make([]curvedLoop, 0, len(loops))
+	for _, lp := range loops {
+		if !c.loopAtApex(lp) {
+			out = append(out, lp)
+		}
+	}
+	return out
+}
+
+// loopAtApex reports whether every edge of a loop sits at the cone apex (the degenerate v=0 rim point).
+func (c ruledUV) loopAtApex(lp curvedLoop) bool {
+	for _, e := range lp.edges {
+		if float64(e.start().DistanceTo(c.band.bottom)) > 1e-6 {
+			return false
+		}
+	}
+	return len(lp.edges) > 0
 }
 
 // emittedLoop is one re-emitted boundary loop awaiting orientation: its full edge chain, the imprint

--- a/kernel/brep/curved_halfspace_uv_arrangement.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement.go
@@ -64,12 +64,13 @@ type uvSeg struct {
 // imprint arcs to the arrangement weld (1e-7) at part scale, while keeping the planar arrangement small.
 const imprintSampleCount = 256
 
-// sampleImprintUV samples an analytic imprint curve over [t0, t1] into tagged (u,v) segments on the side.
-// Each sample inverts the 3D curve point to (u,v) via paramOf; consecutive samples become one uvSeg
-// carrying the curve and its endpoint parameters, so a later boundary walk re-emits exact sub-arcs. The
-// azimuth seam (u wrapping 2π↔0) is left for the arrangement to resolve — sampleImprintUV reports the raw
-// branch [0,2π); seam unwrapping is applied when segments are assembled into the band.
-func (c ruledUV) sampleImprintUV(curve geom.Curve3, t0, t1 float64) []uvSeg {
+// sampleImprintUV samples an analytic imprint curve over its whole domain into tagged (u,v) segments on
+// the side. Each sample inverts the 3D curve point to (u,v) via paramOf; consecutive samples become one
+// uvSeg carrying the curve and its endpoint parameters, so a later boundary walk re-emits exact sub-arcs.
+// The azimuth seam (u wrapping 2π↔0) is left for the arrangement to resolve — sampleImprintUV reports the
+// raw branch [0,2π); seam unwrapping is applied when segments are assembled into the band.
+func (c ruledUV) sampleImprintUV(curve geom.Curve3) []uvSeg {
+	t0, t1 := curve.Domain()
 	segs := make([]uvSeg, 0, imprintSampleCount)
 	prevT := t0
 	prevP := c.paramOf(curve.PointAt(t0))
@@ -219,3 +220,130 @@ func centroidOf(poly []math.Point2) math.Point2 {
 
 // lerp linearly interpolates from a to b by fraction f.
 func lerp(a, b, f float64) float64 { return a + f*(b-a) }
+
+// seamWeld grid (matches the arrangement welder, arrTol/tjTol family) used to identify (u,v) boundary
+// vertices, with the azimuth seam folded: u=2π is the SAME ruling as u=0, so both weld to one vertex.
+const seamWeldGrid = 1e-7
+
+// seamWelder welds (u,v) points onto shared indices with the azimuth seam identified (u=2π≡u=0). Folding
+// the seam is what turns the artificial seam edges of a wrapping kept region into reverse twins that cancel.
+type seamWelder struct {
+	index  map[[2]int64]int
+	points []math.Point2
+}
+
+func newSeamWelder() *seamWelder { return &seamWelder{index: map[[2]int64]int{}} }
+
+// add returns the welded index of p, normalising u=2π to u=0 first so a seam vertex on either side of the
+// parameter rectangle maps to one ruling vertex.
+func (w *seamWelder) add(p math.Point2) int {
+	u := float64(p.X)
+	if stdmath.Abs(u-2*stdmath.Pi) < seamWeldGrid {
+		u = 0
+	}
+	k := [2]int64{int64(stdmath.Round(u / seamWeldGrid)), int64(stdmath.Round(float64(p.Y) / seamWeldGrid))}
+	if i, ok := w.index[k]; ok {
+		return i
+	}
+	w.index[k] = len(w.points)
+	w.points = append(w.points, p)
+	return len(w.points) - 1
+}
+
+// dedge is one directed (u,v) boundary edge of the kept region: the seam-welded endpoint indices for
+// cancellation/chaining, and the original (u,v) endpoints (a may sit at u=2π even when welded to u=0) for
+// re-emitting the exact analytic curve.
+type dedge struct {
+	from, to int
+	a, b     math.Point2
+}
+
+// keptBoundaryEdges returns the directed boundary edges of the kept region. It collects every kept cell's
+// oriented boundary (outer CCW, holes CW), welds endpoints with the seam folded, then keeps only edges
+// whose reverse is absent: an edge interior to the kept region (bordering two kept cells, or a seam edge a
+// wrapping region traverses on both sides) appears as a reverse-twin pair and cancels, leaving exactly the
+// edges between kept material and dropped material (or the band rims). This is the cross-seam merge and the
+// shared-edge dissolve in one pass (#1405).
+func keptBoundaryEdges(kept []Face2D) []dedge {
+	w := newSeamWelder()
+	var all []dedge
+	add := func(poly []math.Point2) {
+		for i, n := 0, len(poly); i < n; i++ {
+			a, b := poly[i], poly[(i+1)%n]
+			if a.DistanceTo(b) <= arrTol {
+				continue // a degenerate edge
+			}
+			all = append(all, dedge{from: w.add(a), to: w.add(b), a: a, b: b})
+		}
+	}
+	for _, cell := range kept {
+		add(cell.Outer)
+		for _, h := range cell.Holes {
+			add(h)
+		}
+	}
+	present := make(map[[2]int]bool, len(all))
+	for _, e := range all {
+		present[[2]int{e.from, e.to}] = true
+	}
+	survivors := make([]dedge, 0, len(all))
+	for _, e := range all {
+		// A full-wrap edge (an uncut rim/section circle: both ends weld to the seam vertex) is its own
+		// closed loop and has no distinct reverse, so it is never canceled. Any other edge survives only if
+		// its reverse is absent — the shared-edge dissolve and the cross-seam merge.
+		if e.from == e.to || !present[[2]int{e.to, e.from}] {
+			survivors = append(survivors, e)
+		}
+	}
+	return survivors
+}
+
+// chainLoops links the surviving directed boundary edges into closed loops by following each edge's `to`
+// vertex to the next edge that starts there. A valid kept-region boundary has matched in/out degree at
+// every vertex, so following any unused outgoing edge closes each loop; the result is one loop per
+// connected boundary component (a wrapping band yields two — a rim loop and a section loop). A full-wrap
+// edge (from==to) is its own one-edge loop.
+func chainLoops(edges []dedge) [][]dedge {
+	out := make(map[int][]int) // vertex -> indices of edges starting there
+	for i, e := range edges {
+		out[e.from] = append(out[e.from], i)
+	}
+	used := make([]bool, len(edges))
+	var loops [][]dedge
+	for i := range edges {
+		if !used[i] {
+			loops = append(loops, walkLoop(i, edges, out, used))
+		}
+	}
+	return loops
+}
+
+// walkLoop follows the boundary from edge i, marking edges used, until it returns to the start vertex (or a
+// full-wrap singleton, or a dead end). out maps each vertex to the edges leaving it.
+func walkLoop(i int, edges []dedge, out map[int][]int, used []bool) []dedge {
+	start := edges[i].from
+	var loop []dedge
+	for cur := i; ; {
+		used[cur] = true
+		loop = append(loop, edges[cur])
+		if edges[cur].from == edges[cur].to || edges[cur].to == start {
+			break // a full-wrap singleton, or the loop closed back to its start
+		}
+		next := nextUnused(out[edges[cur].to], used)
+		if next < 0 {
+			break
+		}
+		cur = next
+	}
+	return loop
+}
+
+// nextUnused returns the first not-yet-used edge index from a vertex's outgoing list, or -1.
+func nextUnused(candidates []int, used []bool) int {
+	for _, i := range candidates {
+		if !used[i] {
+			return i
+		}
+	}
+	return -1
+}

--- a/kernel/brep/curved_halfspace_uv_arrangement.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement.go
@@ -347,3 +347,199 @@ func nextUnused(candidates []int, used []bool) int {
 	}
 	return -1
 }
+
+// recoveredEdge is one boundary dedge resolved back to the analytic curve it lies on: its kind, the source
+// curve, its (u,v) endpoints (giving the azimuth span for a rim/seam edge) and the curve parameters at
+// those endpoints (for an imprint sub-arc). It is the bridge from the (u,v) arrangement back to exact
+// 3D geometry (#1405).
+type recoveredEdge struct {
+	kind   segKind
+	curve  geom.Curve3
+	a, b   math.Point2
+	tA, tB float64
+}
+
+// recoverEdge resolves a boundary dedge to the assembled segment it lies on, recovering the segment's kind
+// and source curve, and (for an imprint edge) interpolating the curve parameter at each endpoint from the
+// matched segment's tagged endpoints. The dedge is a sub-piece of exactly one assembled segment, found by
+// its midpoint's perpendicular distance.
+func (c ruledUV) recoverEdge(d dedge, segs []uvSeg) (recoveredEdge, bool) {
+	mid := math.P2((float64(d.a.X)+float64(d.b.X))/2, (float64(d.a.Y)+float64(d.b.Y))/2)
+	best, bestDist := -1, tjTol
+	for i, s := range segs {
+		if dist := perpDistToSeg(mid, s.a, s.b); dist < bestDist {
+			best, bestDist = i, dist
+		}
+	}
+	if best < 0 {
+		return recoveredEdge{}, false
+	}
+	s := segs[best]
+	re := recoveredEdge{kind: s.kind, curve: s.curve, a: d.a, b: d.b}
+	if s.kind == segImprint {
+		re.tA = lerp(s.tA, s.tB, projFraction(d.a, s.a, s.b))
+		re.tB = lerp(s.tA, s.tB, projFraction(d.b, s.a, s.b))
+	}
+	return re, true
+}
+
+// perpDistToSeg returns the distance from p to the segment a→b (clamped to the segment).
+func perpDistToSeg(p, a, b math.Point2) float64 {
+	ab := a.VectorTo(b)
+	l2 := float64(ab.LengthSquared())
+	if l2 < arrTol*arrTol {
+		return float64(p.DistanceTo(a))
+	}
+	t := clamp01(float64(a.VectorTo(p).Dot(ab)) / l2)
+	return float64(p.DistanceTo(a.TranslateBy(ab.Scale(math.Scalar(t)))))
+}
+
+// projFraction returns p's projection parameter along a→b, clamped to [0,1].
+func projFraction(p, a, b math.Point2) float64 {
+	ab := a.VectorTo(b)
+	l2 := float64(ab.LengthSquared())
+	if l2 < arrTol*arrTol {
+		return 0
+	}
+	return clamp01(float64(a.VectorTo(p).Dot(ab)) / l2)
+}
+
+// clamp01 clamps t to [0,1].
+func clamp01(t float64) float64 {
+	if t < 0 {
+		return 0
+	}
+	if t > 1 {
+		return 1
+	}
+	return t
+}
+
+// emitLoopEdges re-emits a (u,v) boundary loop as a chain of exact analytic loopEdges: recover each dedge's
+// analytic source, merge consecutive edges that share a curve into one run, and emit each run as a single
+// loopEdge (a rim arc, an imprint sub-arc, or a seam ruling). This is the bridge back to the B-rep face.
+func (c ruledUV) emitLoopEdges(loop []dedge, segs []uvSeg) ([]loopEdge, bool) {
+	rec := make([]recoveredEdge, 0, len(loop))
+	for _, d := range loop {
+		re, ok := c.recoverEdge(d, segs)
+		if !ok {
+			return nil, false
+		}
+		rec = append(rec, re)
+	}
+	var edges []loopEdge
+	for _, run := range mergeRuns(rec) {
+		e, ok := c.emitRun(run)
+		if !ok {
+			return nil, false
+		}
+		edges = append(edges, e)
+	}
+	return edges, true
+}
+
+// mergeRuns groups consecutive recovered edges that lie on the same analytic curve into runs, so a chain of
+// many sampled sub-edges along one conic (or many sub-arcs of one rim) re-emits as a single loopEdge.
+func mergeRuns(rec []recoveredEdge) [][]recoveredEdge {
+	var runs [][]recoveredEdge
+	for _, e := range rec {
+		if n := len(runs); n > 0 && sameRun(runs[n-1][0], e) {
+			runs[n-1] = append(runs[n-1], e)
+		} else {
+			runs = append(runs, []recoveredEdge{e})
+		}
+	}
+	return runs
+}
+
+// emitRun re-emits one run of recovered edges (all on the same curve) as a single exact loopEdge.
+func (c ruledUV) emitRun(run []recoveredEdge) (loopEdge, bool) {
+	switch run[0].kind {
+	case segRim:
+		return c.emitRimRun(run)
+	case segImprint:
+		return c.emitImprintRun(run)
+	default:
+		return c.emitSeamRun(run)
+	}
+}
+
+// emitRimRun re-emits a run along a band rim as one circular edge: the full rim circle when the run wraps
+// the whole azimuth, else a geom.Arc3d over the run's azimuth span in the surface's own frame (so it lands
+// exactly on the rim). The span sums per-edge azimuth deltas, which stays correct across the seam and for
+// a single full-wrap edge (where the raw endpoints alone would read as a zero span).
+func (c ruledUV) emitRimRun(run []recoveredEdge) (loopEdge, bool) {
+	bottom := stdmath.Abs(float64(run[0].a.Y)-c.band.vMin) <= stdmath.Abs(float64(run[0].a.Y)-c.band.vMax)
+	center, radius, circle := c.band.top, c.band.rTop, c.band.topCirc
+	if bottom {
+		center, radius, circle = c.band.bottom, c.band.rBot, c.band.bottomCirc
+	}
+	span := 0.0
+	for _, e := range run {
+		span += float64(e.b.X) - float64(e.a.X)
+	}
+	if stdmath.Abs(span) >= 2*stdmath.Pi-1e-6 {
+		return loopEdge{curve: circle, t0: 0, t1: 1}, true // a full rim circle, reused whole
+	}
+	arc, err := geom.NewArc3d(center, c.axis, c.ref, radius, float64(run[0].a.X), span)
+	if err != nil {
+		return loopEdge{}, false
+	}
+	return loopEdge{curve: arc, t0: 0, t1: 1}, true
+}
+
+// emitImprintRun re-emits a run along one imprint curve as a single loopEdge over the recovered parameter
+// span. For a CLOSED conic (ellipse/circle) the parameters wrap, so the run's parameter sequence is
+// unwrapped to a monotone span (handling the param seam, like the analytic sectionArm); a run that covers
+// the whole closed curve re-emits it over its full domain. Open conic arms (hyperbola/parabola/line) carry
+// monotone parameters already.
+func (c ruledUV) emitImprintRun(run []recoveredEdge) (loopEdge, bool) {
+	curve := run[0].curve
+	t0 := run[0].tA
+	tEnd := run[len(run)-1].tB
+	if isClosedCurve(curve) {
+		prev := t0
+		for _, e := range run {
+			prev = unwrapParamNear(prev, e.tB)
+		}
+		tEnd = prev
+		if lo, hi := curve.Domain(); stdmath.Abs(tEnd-t0) >= (hi-lo)-1e-6 {
+			return loopEdge{curve: curve, t0: lo, t1: hi}, true // the whole closed curve
+		}
+	}
+	return loopEdge{curve: curve, t0: t0, t1: tEnd}, true
+}
+
+// emitSeamRun re-emits a (rare, surviving) seam-ruling run as a straight edge between its 3D endpoints — a
+// ruling of the side from the run's first to last (u,v) vertex.
+func (c ruledUV) emitSeamRun(run []recoveredEdge) (loopEdge, bool) {
+	p0 := c.point3(float64(run[0].a.X), float64(run[0].a.Y))
+	p1 := c.point3(float64(run[len(run)-1].b.X), float64(run[len(run)-1].b.Y))
+	return loopEdge{curve: geom.NewLineSegment(p0, p1), t0: 0, t1: 1}, true
+}
+
+// isClosedCurve reports whether a conic closes on itself (an ellipse or circle), so its parameter wraps and
+// a boundary run along it must be unwrapped to a monotone span before re-emission.
+func isClosedCurve(curve geom.Curve3) bool {
+	switch curve.(type) {
+	case geom.EllipseFull, geom.Circle:
+		return true
+	}
+	return false
+}
+
+// sameRun reports whether two recovered edges belong to one re-emittable run: the same kind, and for an
+// imprint the same source curve, for a rim the same rim level (a rim sits at constant v, so equal v).
+func sameRun(a, b recoveredEdge) bool {
+	if a.kind != b.kind {
+		return false
+	}
+	switch a.kind {
+	case segImprint:
+		return a.curve == b.curve
+	case segRim:
+		return stdmath.Abs(float64(a.a.Y)-float64(b.a.Y)) < 1e-6
+	default:
+		return true
+	}
+}

--- a/kernel/brep/curved_halfspace_uv_arrangement.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement.go
@@ -335,11 +335,46 @@ func (c ruledUV) arrangeBand(segs []uvSeg) []Face2D {
 func keptCells(cells []Face2D, material materialPredicate) []Face2D {
 	var kept []Face2D
 	for _, cell := range cells {
-		if p, ok := interiorPointOf(cell.Outer); ok && material(p) {
+		if p, ok := interiorOfCell(cell); ok && material(p) {
 			kept = append(kept, cell)
 		}
 	}
 	return kept
+}
+
+// interiorOfCell returns a point inside the cell's outer loop but OUTSIDE every hole, so a cell that
+// contains an island (a dropped region) is classified by its own material, not the island's. The centroid
+// serves when it misses the holes; else a short step from an outer-edge midpoint toward the centroid lands
+// near the boundary, clear of any central hole.
+func interiorOfCell(cell Face2D) (math.Point2, bool) {
+	if c := centroidOf(cell.Outer); insideCell(c, cell) {
+		return c, true
+	}
+	c := centroidOf(cell.Outer)
+	for i := range cell.Outer {
+		a, b := cell.Outer[i], cell.Outer[(i+1)%len(cell.Outer)]
+		mid := math.P2((float64(a.X)+float64(b.X))/2, (float64(a.Y)+float64(b.Y))/2)
+		for _, f := range []float64{1e-3, 1e-2, 0.1, 0.5} {
+			p := math.P2(lerp(float64(mid.X), float64(c.X), f), lerp(float64(mid.Y), float64(c.Y), f))
+			if insideCell(p, cell) {
+				return p, true
+			}
+		}
+	}
+	return c, false
+}
+
+// insideCell reports whether p is inside the cell's outer loop and outside all its holes.
+func insideCell(p math.Point2, cell Face2D) bool {
+	if !pointInPolygon2D(p, cell.Outer) {
+		return false
+	}
+	for _, h := range cell.Holes {
+		if pointInPolygon2D(p, h) {
+			return false
+		}
+	}
+	return true
 }
 
 // interiorPointOf returns a point strictly inside the simple polygon (and ok). The centroid serves for a

--- a/kernel/brep/curved_halfspace_uv_arrangement.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement.go
@@ -205,12 +205,50 @@ func (c ruledUV) assembleBandSegments(imprint []uvSeg) []uvSeg {
 	out := make([]uvSeg, 0, len(imprint)+4)
 	for _, s := range imprint {
 		for _, split := range splitSeamCrossing(s) {
-			if split.a.DistanceTo(split.b) > arrTol {
-				out = append(out, split)
+			// Clip each imprint segment to the band's axial range: a section can leave [vMin,vMax] (a tilted
+			// cut's ellipse rises past the rim), and sampling that out-of-band part would inject a spurious
+			// arc; clipping lands the imprint exactly on the rim where it crosses, the real rim split.
+			for _, clipped := range clipSegToVBand(split, c.band.vMin, c.band.vMax) {
+				if clipped.a.DistanceTo(clipped.b) > arrTol {
+					out = append(out, clipped)
+				}
 			}
 		}
 	}
 	return append(out, c.bandFrameSegments()...)
+}
+
+// clipSegToVBand clips a (u,v) imprint segment to the axial band [vMin,vMax], returning the in-band part
+// (with u and the curve parameter interpolated to the rim crossing) or nothing when the segment lies wholly
+// outside. The band rims then bound the imprint exactly where it would otherwise overshoot.
+func clipSegToVBand(s uvSeg, vMin, vMax float64) []uvSeg {
+	a, b := float64(s.a.Y), float64(s.b.Y)
+	if (a < vMin && b < vMin) || (a > vMax && b > vMax) {
+		return nil
+	}
+	if a >= vMin && a <= vMax && b >= vMin && b <= vMax {
+		return []uvSeg{s}
+	}
+	t0, t1 := 0.0, 1.0
+	if dv := b - a; dv != 0 {
+		lo, hi := (vMin-a)/dv, (vMax-a)/dv
+		if lo > hi {
+			lo, hi = hi, lo
+		}
+		t0, t1 = stdmath.Max(t0, lo), stdmath.Min(t1, hi)
+	}
+	if t0 >= t1 {
+		return nil
+	}
+	return []uvSeg{{
+		a: lerpUV(s.a, s.b, t0), b: lerpUV(s.a, s.b, t1),
+		curve: s.curve, tA: lerp(s.tA, s.tB, t0), tB: lerp(s.tA, s.tB, t1), kind: s.kind,
+	}}
+}
+
+// lerpUV linearly interpolates a (u,v) point between a and b by fraction t.
+func lerpUV(a, b math.Point2, t float64) math.Point2 {
+	return math.P2(lerp(float64(a.X), float64(b.X), t), lerp(float64(a.Y), float64(b.Y), t))
 }
 
 // materialPredicate reports whether a (u,v) point of the band is on the KEPT side of the imprint. For a
@@ -493,7 +531,7 @@ func (c ruledUV) emitLoopEdges(loop []dedge, segs []uvSeg) (face, section []loop
 		}
 		rec = append(rec, re)
 	}
-	for _, run := range mergeRuns(rec) {
+	for _, run := range mergeRuns(rotateToTransition(rec)) {
 		e, good := c.emitRun(run)
 		if !good {
 			return nil, nil, false
@@ -521,42 +559,98 @@ func (c ruledUV) trimByImprint(f curvedFace, surface geom.Surface, imprint []geo
 	if len(kept) == 0 {
 		return nil, nil, nil // the whole side is on the dropped side
 	}
-	loops := chainLoops(keptBoundaryEdges(kept))
-	faceLoops := make([]curvedLoop, 0, len(loops))
-	var lid []loopEdge
-	for _, lp := range loops {
-		edges, section, ok := c.emitLoopEdges(lp, segs)
-		if !ok {
-			return nil, nil, ErrUnsupportedHalfSpace
-		}
-		faceLoops = append(faceLoops, curvedLoop{edges: edges})
-		lid = append(lid, reverseEdgeChain(section)...) // the lid uses each section arc opposite the side
+	emitted, ok := c.emitKeptLoops(chainLoops(keptBoundaryEdges(kept)), segs)
+	if !ok {
+		return nil, nil, ErrUnsupportedHalfSpace
 	}
-	kf := curvedFace{surface: surface, reversed: f.reversed, lineage: f.lineage, loops: c.orderLoops(faceLoops)}
+	faceLoops, lid := c.orientLoops(emitted, c.wrapsAllU())
+	kf := curvedFace{surface: surface, reversed: f.reversed, lineage: f.lineage, loops: faceLoops}
 	return []curvedFace{kf}, lid, nil
 }
 
-// orderLoops orders a kept face's boundary loops by descending axial level (the higher-v boundary first),
-// matching the analytic splitSide convention where loops[0] is the upper (hi) boundary and the stitcher
-// treats it as the outer loop. A single-loop face is unchanged.
-func (c ruledUV) orderLoops(loops []curvedLoop) []curvedLoop {
-	if len(loops) < 2 {
-		return loops
-	}
-	sort.SliceStable(loops, func(i, j int) bool { return c.meanV(loops[i]) > c.meanV(loops[j]) })
-	return loops
+// emittedLoop is one re-emitted boundary loop awaiting orientation: its full edge chain, the imprint
+// (section) sub-arcs alone (for the lid), and its mean axial level (to order hi boundary first).
+type emittedLoop struct {
+	face    []loopEdge
+	section []loopEdge
+	mv      float64
 }
 
-// meanV is a loop's mean axial level (the average v of its edge endpoints), used only to order loops.
-func (c ruledUV) meanV(l curvedLoop) float64 {
-	sum := 0.0
-	for _, e := range l.edges {
-		sum += float64(c.paramOf(e.start()).Y) + float64(c.paramOf(e.end()).Y)
+// emitKeptLoops re-emits every (u,v) boundary loop to analytic edges, sorted with the higher (hi) boundary
+// first to match the analytic split convention (loops[0] is the hi boundary / outer loop).
+func (c ruledUV) emitKeptLoops(loops [][]dedge, segs []uvSeg) ([]emittedLoop, bool) {
+	out := make([]emittedLoop, 0, len(loops))
+	for _, lp := range loops {
+		face, section, ok := c.emitLoopEdges(lp, segs)
+		if !ok {
+			return nil, false
+		}
+		out = append(out, emittedLoop{face: face, section: section, mv: meanEdgeV(c, face)})
 	}
-	if len(l.edges) == 0 {
+	sort.SliceStable(out, func(i, j int) bool { return out[i].mv > out[j].mv })
+	return out, true
+}
+
+// orientLoops applies the analytic splitSide orientation convention to the ordered loops: the lo boundaries
+// and the default hi boundary are forward with their section arcs reversed into the lid; but in a WRAPPING
+// band the hi loop is REVERSED when it carries a rim and the source side traversed its top rim reversed
+// (band.topRimReversed), the lid then taking that loop's section arcs forward — so the rebuilt rim keeps the
+// sense opposite its cap and the band, lid and caps stay a consistent manifold. The reversal is gated on
+// wrapping because a non-wrapping tongue is one mixed loop the analytic tongueSide leaves un-reversed
+// (#1405, mirroring curved_halfspace_ruled_uv.go's splitSide vs tongueSide).
+func (c ruledUV) orientLoops(loops []emittedLoop, wrapping bool) ([]curvedLoop, []loopEdge) {
+	faceLoops := make([]curvedLoop, 0, len(loops))
+	var lid []loopEdge
+	for i, e := range loops {
+		face, lidSec := e.face, reverseEdgeChain(e.section)
+		if i == 0 && wrapping && c.band.topRimReversed && allRimEdges(e.face) {
+			face, lidSec = reverseEdgeChain(e.face), e.section
+		}
+		faceLoops = append(faceLoops, curvedLoop{edges: face})
+		lid = append(lid, lidSec...)
+	}
+	return faceLoops, lid
+}
+
+// allRimEdges reports whether every edge of a loop is a rim (circle/arc) — a PURE top-rim hi boundary, the
+// only wrapping hi loop the topRimReversed whole-loop reversal applies to; a mixed section+rim hi boundary
+// (a clips-rim annulus) keeps its arrangement orientation instead.
+func allRimEdges(edges []loopEdge) bool {
+	for _, e := range edges {
+		switch e.curve.(type) {
+		case geom.Circle, geom.Arc3d:
+		default:
+			return false
+		}
+	}
+	return len(edges) > 0
+}
+
+// meanEdgeV is the mean axial level of an edge chain (the average v of its endpoints), used to order the
+// hi boundary loop first.
+func meanEdgeV(c ruledUV, edges []loopEdge) float64 {
+	if len(edges) == 0 {
 		return 0
 	}
-	return sum / float64(2*len(l.edges))
+	sum := 0.0
+	for _, e := range edges {
+		sum += float64(c.paramOf(e.start()).Y) + float64(c.paramOf(e.end()).Y)
+	}
+	return sum / float64(2*len(edges))
+}
+
+// rotateToTransition rotates the recovered loop so it begins at a curve boundary (where the kind/curve
+// changes), so every run mergeRuns forms is ONE contiguous arc. Without it a loop that happens to start in
+// the middle of a curve splits that curve into two runs around the loop seam — and a closed conic run that
+// wraps re-emits as a spurious full curve. A loop on a single curve (no transition) is returned unchanged.
+func rotateToTransition(rec []recoveredEdge) []recoveredEdge {
+	n := len(rec)
+	for i := 0; i < n; i++ {
+		if !sameRun(rec[(i-1+n)%n], rec[i]) {
+			return append(append([]recoveredEdge{}, rec[i:]...), rec[:i]...)
+		}
+	}
+	return rec
 }
 
 // mergeRuns groups consecutive recovered edges that lie on the same analytic curve into runs, so a chain of

--- a/kernel/brep/curved_halfspace_uv_arrangement_test.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement_test.go
@@ -65,3 +65,63 @@ func TestSampleImprintUVOnRimCircle(t *testing.T) {
 		}
 	}
 }
+
+// TestSplitSeamCrossingSplitsAtSeam: an imprint segment whose endpoints straddle the seam (its short arc
+// crosses u=0≡2π) is split into two segments meeting exactly at the seam, with v and the curve parameter
+// interpolated; a non-straddling segment passes through unchanged (Oblikovati#1405).
+func TestSplitSeamCrossingSplitsAtSeam(t *testing.T) {
+	twoPi := 2 * stdmath.Pi
+	// climbs past 2π: a=(6.0, 1) -> b=(0.2, 3); the short arc crosses the seam at u=2π.
+	up := uvSeg{a: math.P2(6.0, 1), b: math.P2(0.2, 3), curve: nil, tA: 0, tB: 1, kind: segImprint}
+	got := splitSeamCrossing(up)
+	if len(got) != 2 {
+		t.Fatalf("seam-straddling segment split into %d, want 2", len(got))
+	}
+	if stdmath.Abs(got[0].b.X-twoPi) > 1e-12 || got[1].a.X != 0 {
+		t.Errorf("split not anchored at the seam: end of first=%.4f, start of second=%.4f (want 2π, 0)", got[0].b.X, got[1].a.X)
+	}
+	if stdmath.Abs(got[0].b.Y-got[1].a.Y) > 1e-12 {
+		t.Errorf("v discontinuous across the seam: %.6f vs %.6f", got[0].b.Y, got[1].a.Y)
+	}
+	// continuity of the curve parameter: first runs tA->tSeam, second tSeam->tB
+	if got[0].tB != got[1].tA {
+		t.Errorf("curve parameter discontinuous across the seam: %.6f vs %.6f", got[0].tB, got[1].tA)
+	}
+	// a non-straddling segment is unchanged
+	inside := uvSeg{a: math.P2(1.0, 0), b: math.P2(2.0, 1), kind: segImprint}
+	if s := splitSeamCrossing(inside); len(s) != 1 || s[0] != inside {
+		t.Errorf("a non-straddling segment was altered: %+v", s)
+	}
+}
+
+// TestAssembleBandSegmentsClosesRectangle: assembling an imprint with the rim+seam frame yields a closed
+// parameter rectangle — the four frame edges span [0,2π]×[vMin,vMax] and share the rectangle corners — and
+// no assembled segment spans the seam discontinuity (Oblikovati#1405).
+func TestAssembleBandSegmentsClosesRectangle(t *testing.T) {
+	const vMin, vMax = -5.0, 5.0
+	c := cylinderRuledUV(3, vMin, vMax)
+	rim, _ := geom.NewCircle(math.P3(0, 0, 0), math.V3(0, 0, 1), 3) // a v=0 horizontal cut imprint
+	segs := c.assembleBandSegments(c.sampleImprintUV(rim, 0, 1))
+
+	rims, seams := 0, 0
+	for _, s := range segs {
+		if du := stdmath.Abs(s.b.X - s.a.X); du > stdmath.Pi && s.kind == segImprint {
+			t.Errorf("an imprint segment spans the seam: a=%v b=%v", s.a, s.b)
+		}
+		switch s.kind {
+		case segRim:
+			rims++
+			if s.a.X != 0 || stdmath.Abs(s.b.X-2*stdmath.Pi) > 1e-12 {
+				t.Errorf("rim segment does not span [0,2π]: a=%v b=%v", s.a, s.b)
+			}
+		case segSeam:
+			seams++
+			if stdmath.Abs(s.a.Y-vMin) > 1e-12 || stdmath.Abs(s.b.Y-vMax) > 1e-12 {
+				t.Errorf("seam segment does not span [vMin,vMax]: a=%v b=%v", s.a, s.b)
+			}
+		}
+	}
+	if rims != 2 || seams != 2 {
+		t.Errorf("frame has %d rims and %d seams, want 2 and 2", rims, seams)
+	}
+}

--- a/kernel/brep/curved_halfspace_uv_arrangement_test.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement_test.go
@@ -315,6 +315,54 @@ func TestClipParamsMultiArmHyperbola(t *testing.T) {
 	}
 }
 
+// TestTrimByImprintIslandHole: a CLOSED imprint loop inside a ruled face (not reaching a rim) with the
+// material kept OUTSIDE it produces a trimmed face carrying that loop as an inner HOLE — the island case
+// the general arrangement handles that the single-valued analytic walk never could (Oblikovati#1405, the
+// curved∩curved generality). The material is given as a seam-aware 3D test (point3 handles the shifted
+// frame), the form a curved∩curved membership predicate takes.
+func TestTrimByImprintIslandHole(t *testing.T) {
+	c := cylinderRuledUV(3, -5, 5)
+	corners := []math.Point2{math.P2(2, -1), math.P2(3, -1), math.P2(3, 1), math.P2(2, 1)}
+	var curves []geom.Curve3
+	for i := 0; i < 4; i++ {
+		a := c.point3(float64(corners[i].X), float64(corners[i].Y))
+		b := c.point3(float64(corners[(i+1)%4].X), float64(corners[(i+1)%4].Y))
+		curves = append(curves, geom.NewLineSegment(a, b))
+	}
+	center := c.point3(2.5, 0) // 3D centre of the island (absolute frame)
+	keepOutside := func(cc ruledUV) materialPredicate {
+		return func(uv math.Point2) bool {
+			// near the island centre on the cylinder ≈ inside the island; keep everything else.
+			return float64(cc.point3(uv.X, uv.Y).DistanceTo(center)) > 1.6
+		}
+	}
+	surf, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3)
+	faces, _, err := c.trimByImprint(curvedFace{surface: surf}, surf, curves, keepOutside)
+	if err != nil || len(faces) != 1 {
+		t.Fatalf("trimByImprint: err=%v faces=%d, want 1", err, len(faces))
+	}
+	// the kept band has its two rim loops PLUS the island as an inner loop.
+	if got := len(faces[0].loops); got != 3 {
+		t.Fatalf("kept face has %d loops, want 3 (two rims + the island hole)", got)
+	}
+	// exactly one loop is the island (none of its edges touch a rim level vMin/vMax).
+	islands := 0
+	for _, lp := range faces[0].loops {
+		interior := true
+		for _, e := range lp.edges {
+			if v := float64(c.paramOf(e.start()).Y); stdmath.Abs(v-5) < 0.1 || stdmath.Abs(v+5) < 0.1 {
+				interior = false
+			}
+		}
+		if interior {
+			islands++
+		}
+	}
+	if islands != 1 {
+		t.Errorf("found %d interior (island) loops, want 1", islands)
+	}
+}
+
 // distFromAxis returns p's perpendicular distance from the side's axis (its cylinder radius).
 func distFromAxis(p math.Point3, c ruledUV) float64 {
 	d := c.base.VectorTo(p)

--- a/kernel/brep/curved_halfspace_uv_arrangement_test.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement_test.go
@@ -14,10 +14,16 @@ import (
 // (u,v)-arrangement unit tests: point3(u,v) = (R·cos u, R·sin u, v), so paramOf must invert it exactly.
 func cylinderRuledUV(r, vMin, vMax float64) ruledUV {
 	axis, ref := math.V3(0, 0, 1), math.V3(1, 0, 0)
+	bottom, top := math.P3(0, 0, vMin), math.P3(0, 0, vMax)
+	botCirc, _ := geom.NewCircle(bottom, axis, r)
+	topCirc, _ := geom.NewCircle(top, axis, r)
 	return ruledUV{
 		base: math.P3(0, 0, 0), axis: axis, ref: ref, binor: axis.Cross(ref),
 		radSlope: 0, radConst: r,
-		band: coneSideBand_{vMin: vMin, vMax: vMax},
+		band: coneSideBand_{
+			bottom: bottom, top: top, bottomCirc: botCirc, topCirc: topCirc,
+			vMin: vMin, vMax: vMax, rBot: r, rTop: r,
+		},
 	}
 }
 
@@ -225,5 +231,40 @@ func TestKeptBoundaryTongueSingleLoop(t *testing.T) {
 	}
 	if loops := chainLoops(keptBoundaryEdges(kept)); len(loops) != 1 {
 		t.Fatalf("tongue: %d boundary loops, want 1", len(loops))
+	}
+}
+
+// distFromAxis returns p's perpendicular distance from the side's axis (its cylinder radius).
+func distFromAxis(p math.Point3, c ruledUV) float64 {
+	d := c.base.VectorTo(p)
+	radial := d.Sub(c.axis.Scale(d.Dot(c.axis)))
+	return float64(radial.Length())
+}
+
+// TestEmitLoopEdgesStructurallyValid: re-emitting a wrapping-band boundary yields analytic loopEdges whose
+// 3D endpoints lie exactly on the cylinder, whose consecutive edges connect, and that close — the bridge
+// from the (u,v) arrangement back to a valid B-rep boundary (Oblikovati#1405).
+func TestEmitLoopEdgesStructurallyValid(t *testing.T) {
+	c := cylinderRuledUV(3, -5, 5)
+	c.s = 1 // g(u,v)=v -> keep v<0
+	segs := c.assembleBandSegments(c.horizontalCutImprint(t, 0))
+	loops := chainLoops(keptBoundaryEdges(keptCells(c.arrangeBand(segs), c.halfSpaceMaterial())))
+	if len(loops) != 2 {
+		t.Fatalf("want 2 boundary loops, got %d", len(loops))
+	}
+	for li, lp := range loops {
+		edges, ok := c.emitLoopEdges(lp, segs)
+		if !ok || len(edges) == 0 {
+			t.Fatalf("loop %d: emit failed (ok=%v, %d edges)", li, ok, len(edges))
+		}
+		for ei, e := range edges {
+			if r := distFromAxis(e.start(), c); stdmath.Abs(r-3) > 1e-6 {
+				t.Errorf("loop %d edge %d start off the cylinder: radius %.6f, want 3", li, ei, r)
+			}
+			next := edges[(ei+1)%len(edges)]
+			if gap := float64(e.end().DistanceTo(next.start())); gap > 1e-6 {
+				t.Errorf("loop %d edge %d end does not meet the next edge's start: gap %.2e", li, ei, gap)
+			}
+		}
 	}
 }

--- a/kernel/brep/curved_halfspace_uv_arrangement_test.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement_test.go
@@ -48,7 +48,7 @@ func TestSampleImprintUVOnRimCircle(t *testing.T) {
 	const r, vMin = 3.0, -5.0
 	c := cylinderRuledUV(r, vMin, 5)
 	rim, _ := geom.NewCircle(math.P3(0, 0, vMin), math.V3(0, 0, 1), r) // the bottom rim, z=vMin
-	segs := c.sampleImprintUV(rim, 0, 1)
+	segs := c.sampleImprintUV(rim)
 	if len(segs) != imprintSampleCount {
 		t.Fatalf("sampled %d segments, want %d", len(segs), imprintSampleCount)
 	}
@@ -101,7 +101,7 @@ func TestAssembleBandSegmentsClosesRectangle(t *testing.T) {
 	const vMin, vMax = -5.0, 5.0
 	c := cylinderRuledUV(3, vMin, vMax)
 	rim, _ := geom.NewCircle(math.P3(0, 0, 0), math.V3(0, 0, 1), 3) // a v=0 horizontal cut imprint
-	segs := c.assembleBandSegments(c.sampleImprintUV(rim, 0, 1))
+	segs := c.assembleBandSegments(c.sampleImprintUV(rim))
 
 	rims, seams := 0, 0
 	for _, s := range segs {
@@ -133,7 +133,7 @@ func (c ruledUV) horizontalCutImprint(t *testing.T, v float64) []uvSeg {
 	if err != nil {
 		t.Fatalf("NewCircle: %v", err)
 	}
-	return c.sampleImprintUV(circ, 0, 1)
+	return c.sampleImprintUV(circ)
 }
 
 // TestKeptCellsClassifiesByMaterial: two horizontal imprint cuts split the band into three v-bands; the
@@ -179,5 +179,51 @@ func TestInteriorPointOfConcave(t *testing.T) {
 	p, ok := interiorPointOf(lShape)
 	if !ok || !pointInPolygon2D(p, lShape) {
 		t.Errorf("interiorPointOf returned %v (ok=%v), not inside the L-shape", p, ok)
+	}
+}
+
+// TestKeptBoundaryWrappingBandTwoLoops: a v=0 cut keeping the v<0 half is a band that WRAPS the seam — its
+// boundary must be two closed loops (the bottom rim and the section), with the artificial seam edges
+// dissolved by the cross-seam cancellation (Oblikovati#1405).
+func TestKeptBoundaryWrappingBandTwoLoops(t *testing.T) {
+	c := cylinderRuledUV(3, -5, 5)
+	c.s = 1 // g(u,v)=v -> keep v<0
+	cells := c.arrangeBand(c.assembleBandSegments(c.horizontalCutImprint(t, 0)))
+	loops := chainLoops(keptBoundaryEdges(keptCells(cells, c.halfSpaceMaterial())))
+	if len(loops) != 2 {
+		t.Fatalf("wrapping band: %d boundary loops, want 2 (rim + section)", len(loops))
+	}
+	atRim, atSection := false, false
+	for _, lp := range loops {
+		allRim, allSec := true, true
+		for _, e := range lp {
+			if stdmath.Abs(float64(e.a.Y)+5) > 1e-6 {
+				allRim = false
+			}
+			if stdmath.Abs(float64(e.a.Y)) > 1e-6 {
+				allSec = false
+			}
+		}
+		atRim, atSection = atRim || allRim, atSection || allSec
+	}
+	if !atRim || !atSection {
+		t.Errorf("loops are not {bottom rim, section}: atRim=%v atSection=%v", atRim, atSection)
+	}
+}
+
+// TestKeptBoundaryTongueSingleLoop: two vertical-ruling imprints carve a u-span that does NOT touch the
+// seam; keeping the middle span is a non-wrapping tongue whose boundary is a single loop (two rulings + two
+// rim arcs), with no seam edge involved (Oblikovati#1405).
+func TestKeptBoundaryTongueSingleLoop(t *testing.T) {
+	c := cylinderRuledUV(3, -5, 5)
+	left := c.sampleImprintUV(geom.NewLineSegment(c.point3(stdmath.Pi/2, -5), c.point3(stdmath.Pi/2, 5)))
+	right := c.sampleImprintUV(geom.NewLineSegment(c.point3(3*stdmath.Pi/2, -5), c.point3(3*stdmath.Pi/2, 5)))
+	cells := c.arrangeBand(c.assembleBandSegments(append(left, right...)))
+	kept := keptCells(cells, func(uv math.Point2) bool { return uv.X > stdmath.Pi/2 && uv.X < 3*stdmath.Pi/2 })
+	if len(kept) != 1 {
+		t.Fatalf("tongue: %d kept cells, want 1", len(kept))
+	}
+	if loops := chainLoops(keptBoundaryEdges(kept)); len(loops) != 1 {
+		t.Fatalf("tongue: %d boundary loops, want 1", len(loops))
 	}
 }

--- a/kernel/brep/curved_halfspace_uv_arrangement_test.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 )
 
@@ -279,6 +280,38 @@ func TestTrimByImprintReversesTopRim(t *testing.T) {
 	hi := faces[0].loops[0].edges
 	if !allRimEdges(hi) {
 		t.Errorf("hi loop is not the pure top rim (edges: %d)", len(hi))
+	}
+}
+
+// TestClipParamsMultiArmHyperbola: a plane parallel to a cone's axis cuts it in a hyperbola whose two arms
+// both lie in the band (the joining vertex falls below it), so clipParams must return TWO parameter ranges,
+// each spanning the band height — the multi-arm windowing a cone cut needs (Oblikovati#1405).
+func TestClipParamsMultiArmHyperbola(t *testing.T) {
+	cone, _ := SolidCylinderCone(math.P3(0, 0, 0), math.P3(0, 0, 10), 3, 6, "c")
+	plane, _ := geom.NewPlane(math.P3(2, 0, 0), math.V3(1, 0, 0)) // axis-parallel → hyperbola, two arms
+	var sf *topo.Face
+	for _, f := range cone.Faces() {
+		if _, ok := f.Geometry().(geom.Cone); ok {
+			sf = f
+		}
+	}
+	cf := curvedFace{surface: sf.Geometry(), reversed: sf.Reversed(), loops: loopsOf(sf), lineage: sf.Lineage()}
+	curves, _ := curvedImprint(cf, curvedFace{surface: plane}, geom.ResolutionForBox(cone.RangeBox()))
+	if len(curves) != 1 {
+		t.Fatalf("want one conic section, got %d", len(curves))
+	}
+	_, band, _ := fullConeSideBand(cf)
+	c := newConeUV(sf.Geometry().(geom.Cone), band, plane, math.V3(1, 0, 0))
+	ranges := c.clipParams(curves[0])
+	if len(ranges) != 2 {
+		t.Fatalf("hyperbola has two arms in the band, clipParams returned %d ranges", len(ranges))
+	}
+	for i, r := range ranges {
+		v0, v1 := c.curveV(curves[0], r[0]), c.curveV(curves[0], r[1])
+		lo, hi := stdmath.Min(v0, v1), stdmath.Max(v0, v1)
+		if lo > band.vMin+0.5 || hi < band.vMax-0.5 {
+			t.Errorf("arm %d spans v[%.2f,%.2f], should cover the band [%.2f,%.2f]", i, lo, hi, band.vMin, band.vMax)
+		}
 	}
 }
 

--- a/kernel/brep/curved_halfspace_uv_arrangement_test.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement_test.go
@@ -262,6 +262,26 @@ func TestTrimByImprintProducesValidFace(t *testing.T) {
 	}
 }
 
+// TestTrimByImprintReversesTopRim: when the source side traverses its top rim reversed (topRimReversed) and
+// the kept wrapping band's hi boundary is the PURE top rim, orientLoops reverses that loop so the rebuilt
+// rim stays opposite its cap — the analytic splitSide convention reproduced through the arrangement (#1405).
+func TestTrimByImprintReversesTopRim(t *testing.T) {
+	c := cylinderRuledUV(3, -5, 5)
+	c.s = -1                     // g(u,v) = -v -> keep v>0, so the hi boundary is the top rim
+	c.band.topRimReversed = true // the source side traverses the top rim reversed
+	surf, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3)
+	circ, _ := geom.NewCircle(math.P3(0, 0, 0), math.V3(0, 0, 1), 3)
+	faces, _, err := c.trimByImprint(curvedFace{surface: surf}, surf, []geom.Curve3{circ}, c.halfSpaceMaterial())
+	if err != nil || len(faces) != 1 || len(faces[0].loops) != 2 {
+		t.Fatalf("trimByImprint: err=%v faces=%d", err, len(faces))
+	}
+	// loops[0] is the hi boundary = the top rim (a full circle); it must be present and on the cylinder.
+	hi := faces[0].loops[0].edges
+	if !allRimEdges(hi) {
+		t.Errorf("hi loop is not the pure top rim (edges: %d)", len(hi))
+	}
+}
+
 // distFromAxis returns p's perpendicular distance from the side's axis (its cylinder radius).
 func distFromAxis(p math.Point3, c ruledUV) float64 {
 	d := c.base.VectorTo(p)

--- a/kernel/brep/curved_halfspace_uv_arrangement_test.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement_test.go
@@ -234,6 +234,34 @@ func TestKeptBoundaryTongueSingleLoop(t *testing.T) {
 	}
 }
 
+// TestTrimByImprintProducesValidFace: the end-to-end arrangement trim of a wrapping cut yields one kept
+// curvedFace with two boundary loops whose edges lie on the cylinder, plus a non-empty lid section — the
+// whole project→assemble→subdivide→classify→boundary→re-emit pipeline (Oblikovati#1405).
+func TestTrimByImprintProducesValidFace(t *testing.T) {
+	c := cylinderRuledUV(3, -5, 5)
+	c.s = 1 // g(u,v)=v -> keep v<0
+	surf, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3)
+	cf := curvedFace{surface: surf}
+	circ, _ := geom.NewCircle(math.P3(0, 0, 0), math.V3(0, 0, 1), 3)
+	faces, lid, err := c.trimByImprint(cf, surf, []geom.Curve3{circ}, c.halfSpaceMaterial())
+	if err != nil || len(faces) != 1 {
+		t.Fatalf("trimByImprint: err=%v faces=%d, want 1 face", err, len(faces))
+	}
+	if len(faces[0].loops) != 2 {
+		t.Fatalf("kept face has %d loops, want 2 (the wrapping band)", len(faces[0].loops))
+	}
+	for li, lp := range faces[0].loops {
+		for ei, e := range lp.edges {
+			if r := distFromAxis(e.start(), c); stdmath.Abs(r-3) > 1e-6 {
+				t.Errorf("loop %d edge %d start off the cylinder: radius %.6f", li, ei, r)
+			}
+		}
+	}
+	if len(lid) == 0 {
+		t.Error("trimByImprint returned no lid section arcs")
+	}
+}
+
 // distFromAxis returns p's perpendicular distance from the side's axis (its cylinder radius).
 func distFromAxis(p math.Point3, c ruledUV) float64 {
 	d := c.base.VectorTo(p)
@@ -253,7 +281,7 @@ func TestEmitLoopEdgesStructurallyValid(t *testing.T) {
 		t.Fatalf("want 2 boundary loops, got %d", len(loops))
 	}
 	for li, lp := range loops {
-		edges, ok := c.emitLoopEdges(lp, segs)
+		edges, _, ok := c.emitLoopEdges(lp, segs)
 		if !ok || len(edges) == 0 {
 			t.Fatalf("loop %d: emit failed (ok=%v, %d edges)", li, ok, len(edges))
 		}

--- a/kernel/brep/curved_halfspace_uv_arrangement_test.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// cylinderRuledUV builds a minimal radius-R cylinder ruledUV about the z-axis (base at the origin) for the
+// (u,v)-arrangement unit tests: point3(u,v) = (R·cos u, R·sin u, v), so paramOf must invert it exactly.
+func cylinderRuledUV(r, vMin, vMax float64) ruledUV {
+	axis, ref := math.V3(0, 0, 1), math.V3(1, 0, 0)
+	return ruledUV{
+		base: math.P3(0, 0, 0), axis: axis, ref: ref, binor: axis.Cross(ref),
+		radSlope: 0, radConst: r,
+		band: coneSideBand_{vMin: vMin, vMax: vMax},
+	}
+}
+
+// TestRuledParamOfInvertsPoint3: paramOf is the exact inverse of point3 over the band — a sampled (u,v)
+// round-trips through the surface point and back to itself (Oblikovati#1405).
+func TestRuledParamOfInvertsPoint3(t *testing.T) {
+	c := cylinderRuledUV(3, -5, 5)
+	for i := 0; i < 16; i++ {
+		u := 2 * stdmath.Pi * float64(i) / 16
+		for _, v := range []float64{-4, -1, 0, 2.5, 4} {
+			uv := c.paramOf(c.point3(u, v))
+			du := stdmath.Abs(uv.X - u)
+			if du > stdmath.Pi { // both near the seam (0 vs 2π) — compare wrapped
+				du = 2*stdmath.Pi - du
+			}
+			if du > 1e-9 || stdmath.Abs(uv.Y-v) > 1e-9 {
+				t.Errorf("paramOf(point3(%.4f,%.4f)) = (%.6f,%.6f), want (%.4f,%.4f)", u, v, uv.X, uv.Y, u, v)
+			}
+		}
+	}
+}
+
+// TestSampleImprintUVOnRimCircle: sampling the bottom-rim circle (v=vMin) as an imprint yields tagged
+// (u,v) segments that all sit at v=vMin, carry the circle as their source curve, and whose endpoint
+// parameters map back (via the circle) to the segment's (u,v) — the round-trip the boundary re-emission
+// relies on (Oblikovati#1405).
+func TestSampleImprintUVOnRimCircle(t *testing.T) {
+	const r, vMin = 3.0, -5.0
+	c := cylinderRuledUV(r, vMin, 5)
+	rim, _ := geom.NewCircle(math.P3(0, 0, vMin), math.V3(0, 0, 1), r) // the bottom rim, z=vMin
+	segs := c.sampleImprintUV(rim, 0, 1)
+	if len(segs) != imprintSampleCount {
+		t.Fatalf("sampled %d segments, want %d", len(segs), imprintSampleCount)
+	}
+	for i, s := range segs {
+		if stdmath.Abs(s.a.Y-vMin) > 1e-9 || stdmath.Abs(s.b.Y-vMin) > 1e-9 {
+			t.Errorf("segment %d not on the rim v=%.1f: a.v=%.6f b.v=%.6f", i, vMin, s.a.Y, s.b.Y)
+		}
+		if s.curve != rim {
+			t.Errorf("segment %d lost its source curve tag", i)
+		}
+		// The tagged parameter at b must reproduce the segment's (u,v) endpoint through the surface.
+		if got := c.paramOf(s.curve.PointAt(s.tB)); stdmath.Abs(got.Y-s.b.Y) > 1e-9 {
+			t.Errorf("segment %d param tB=%.4f maps to v=%.6f, want %.6f", i, s.tB, got.Y, s.b.Y)
+		}
+	}
+}

--- a/kernel/brep/curved_halfspace_uv_arrangement_test.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement_test.go
@@ -244,7 +244,7 @@ func TestTrimByImprintProducesValidFace(t *testing.T) {
 	surf, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3)
 	cf := curvedFace{surface: surf}
 	circ, _ := geom.NewCircle(math.P3(0, 0, 0), math.V3(0, 0, 1), 3)
-	faces, lid, err := c.trimByImprint(cf, surf, []geom.Curve3{circ}, c.halfSpaceMaterial())
+	faces, lid, err := c.trimByImprint(cf, surf, []geom.Curve3{circ}, ruledUV.halfSpaceMaterial)
 	if err != nil || len(faces) != 1 {
 		t.Fatalf("trimByImprint: err=%v faces=%d, want 1 face", err, len(faces))
 	}
@@ -272,7 +272,7 @@ func TestTrimByImprintReversesTopRim(t *testing.T) {
 	c.band.topRimReversed = true // the source side traverses the top rim reversed
 	surf, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3)
 	circ, _ := geom.NewCircle(math.P3(0, 0, 0), math.V3(0, 0, 1), 3)
-	faces, _, err := c.trimByImprint(curvedFace{surface: surf}, surf, []geom.Curve3{circ}, c.halfSpaceMaterial())
+	faces, _, err := c.trimByImprint(curvedFace{surface: surf}, surf, []geom.Curve3{circ}, ruledUV.halfSpaceMaterial)
 	if err != nil || len(faces) != 1 || len(faces[0].loops) != 2 {
 		t.Fatalf("trimByImprint: err=%v faces=%d", err, len(faces))
 	}

--- a/kernel/brep/curved_halfspace_uv_arrangement_test.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement_test.go
@@ -125,3 +125,59 @@ func TestAssembleBandSegmentsClosesRectangle(t *testing.T) {
 		t.Errorf("frame has %d rims and %d seams, want 2 and 2", rims, seams)
 	}
 }
+
+// horizontalCutImprint samples the circle at axial height v as a (u,v) imprint (a horizontal line v=const).
+func (c ruledUV) horizontalCutImprint(t *testing.T, v float64) []uvSeg {
+	t.Helper()
+	circ, err := geom.NewCircle(math.P3(0, 0, v), math.V3(0, 0, 1), c.radConst)
+	if err != nil {
+		t.Fatalf("NewCircle: %v", err)
+	}
+	return c.sampleImprintUV(circ, 0, 1)
+}
+
+// TestKeptCellsClassifiesByMaterial: two horizontal imprint cuts split the band into three v-bands; the
+// material predicate selects which are kept — the middle band (one cell) or the two outer bands (#1405).
+func TestKeptCellsClassifiesByMaterial(t *testing.T) {
+	c := cylinderRuledUV(3, -5, 5)
+	imprint := append(c.horizontalCutImprint(t, -2), c.horizontalCutImprint(t, 2)...)
+	cells := c.arrangeBand(c.assembleBandSegments(imprint))
+	if len(cells) != 3 {
+		t.Fatalf("got %d cells, want 3 (v<-2, -2<v<2, v>2)", len(cells))
+	}
+	mid := keptCells(cells, func(uv math.Point2) bool { return uv.Y > -2 && uv.Y < 2 })
+	if len(mid) != 1 {
+		t.Errorf("middle-band material kept %d cells, want 1", len(mid))
+	}
+	outer := keptCells(cells, func(uv math.Point2) bool { return uv.Y < -2 || uv.Y > 2 })
+	if len(outer) != 2 {
+		t.Errorf("outer material kept %d cells, want 2", len(outer))
+	}
+}
+
+// TestHalfSpaceMaterialKeepsNegativeSide: with g(u,v)=v the half-space predicate keeps exactly the v<0
+// cell of a v=0 cut — the plane-cut classification the analytic walk produced, now via the arrangement.
+func TestHalfSpaceMaterialKeepsNegativeSide(t *testing.T) {
+	c := cylinderRuledUV(3, -5, 5)
+	c.s = 1 // g(u,v) = p + v·s = v  -> kept where v < 0
+	cells := c.arrangeBand(c.assembleBandSegments(c.horizontalCutImprint(t, 0)))
+	kept := keptCells(cells, c.halfSpaceMaterial())
+	if len(kept) != 1 {
+		t.Fatalf("kept %d cells, want 1 (the v<0 half)", len(kept))
+	}
+	if p, _ := interiorPointOf(kept[0].Outer); p.Y >= 0 {
+		t.Errorf("kept cell interior v=%.3f, want <0", p.Y)
+	}
+}
+
+// TestInteriorPointOfConcave: interiorPointOf returns a point genuinely inside even for a concave (L-shaped)
+// polygon whose centroid lies outside it — the robustness keptCells relies on for non-convex cells.
+func TestInteriorPointOfConcave(t *testing.T) {
+	lShape := []math.Point2{
+		math.P2(0, 0), math.P2(4, 0), math.P2(4, 1), math.P2(1, 1), math.P2(1, 4), math.P2(0, 4),
+	}
+	p, ok := interiorPointOf(lShape)
+	if !ok || !pointInPolygon2D(p, lShape) {
+		t.Errorf("interiorPointOf returned %v (ok=%v), not inside the L-shape", p, ok)
+	}
+}


### PR DESCRIPTION
## What & why

Closes #1405.

Generalises the ruled-side face trimmer from a plane's analytic single-valued section `v(u)=−a(u)/b(u)` to an **arbitrary (u,v) imprint** via a parameter-space arrangement — the centerpiece prerequisite for the general curved∩curved boolean (EPIC #1403). Per the scoping decision this is the **full replacement**: every cone *and* cylinder plane-cut case (the whole OCC-validated regression matrix) now routes through one general trimmer, and the bespoke analytic walk is removed.

## The pipeline (`curved_halfspace_uv_arrangement.go`)

project → assemble → subdivide → classify → boundary → re-emit:

1. **Project** the imprint into the side's (u,v) (`paramOf`, the inverse of `point3`); sample analytic curves into tagged segments that carry the source curve + params, so the boundary re-emits **exact** arcs/conics, not the sampled polyline. Unbounded curves (rulings, hyperbola/parabola arms) are windowed to the band; a cone section's **two arms** yield two ranges (`clipParams`/`inBandRanges`).
2. **Assemble** the periodic band into a parameter rectangle: seam-split wrapping imprints, add the rim+seam frame, and **clip each imprint segment to the band — snapping out-of-band ends to the exact curve crossing** (so a rim crossing equals `plane∩rim` and welds with the cap).
3. **Subdivide** (`brep.Arrange`) and **classify** each cell by a material predicate at a hole-aware interior point (`interiorOfCell`).
4. **Boundary**: collect kept cells' oriented edges and cancel reverse twins, with the azimuth seam *folded* (`u=2π≡0`) so the cross-seam merge falls out of the same pass; chain survivors into loops.
5. **Re-emit** each boundary run as one exact `loopEdge` (rim arc / conic sub-arc / ruling), restoring the analytic orientation convention (`orientLoops`: a wrapping band's pure top-rim hi loop reversed when `topRimReversed`).
6. **Adaptive seam** (`chooseSeamU`): move the artificial seam to the widest gap in the imprint's azimuths, so a section arm never grazes it (the oblique-hyperbola failure).

## Scope covered

- **Cylinder side** — axis-∥ flat, oblique ellipse, within-band/clips-rim/tongue, seam-on-cut, slab.
- **Cone side** — ellipse, hyperbola (incl. oblique, two-arm), parabola, vertex-inside, axis-∥ flat.
- **Cone apex** — apex-dropped (frustum band) and apex-kept (single loop, the degenerate v=0 apex-rim loop dropped so the apex is an interior pole).
- **Islands/holes** — a closed imprint loop inside a face → a trimmed face with an inner hole (the curved∩curved generality the analytic walk could never express).

The single-valued analytic boundary walk (`splitSide`, `tongueSide`, the `boundaryLoop` family, `apexCapSide`, `sectionV`, …, ~390 lines) is **removed** — only `wrapsAllU`, `unwrapParamNear`, `reverseEdgeChain` survive as arrangement support.

## Acceptance criteria

- [x] `splitSide` trims by an arbitrary (multi-valued, island) imprint, not only a plane's analytic section.
- [x] Island/hole and multi-valued imprints produce correct trimmed faces (`TestTrimByImprintIslandHole`, cone hyperbola).
- [x] All existing ruledUV planar-cutter regression cases still pass (every cone & cylinder curved-exact + half-space-cut case, through the new trimmer).

## Tests

Unit tests for every stage (projection round-trip, seam-split, multi-arm windowing, classification, boundary extraction with seam-merge, re-emission, end-to-end trim incl. the `topRimReversed` and island cases), plus the full OCC-validated curved-boolean volume/manifold regression suite. Whole kernel + model suites green; lint clean.

This is an internal kernel refactor — the curved booleans produce the *same* exact B-reps (validated by the volume/manifold regressions), now via the general arrangement, so the kernel regression suite is the e2e.

**Follow-ups** the EPIC #1403 can drive when consuming the trimmer: a raw `geom.Polyline` SSI-imprint front-end (line-segment `geom.Curve3` imprints serve today), and disconnected kept regions → multiple faces (plane cuts are always connected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)