### PR TITLE
head(viewport): skip the geometry re-upload when the mesh is unchanged (#1422)

### DIFF
--- a/head/internal/native/smoke.go
+++ b/head/internal/native/smoke.go
@@ -63,7 +63,7 @@ func RunViewportSmoke(maxFrames int) int {
 	for i := 0; i < maxFrames && !w.ShouldClose(); i++ {
 		w.BeginFrame()
 		w.RenderViewport(0, 1280, 720, mvp[:], eye, verts, len(verts)/16, idx,
-			nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil, len(idx), nil, nil, nil)
+			nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil, len(idx), nil, nil, nil, 0)
 		w.EndFrame(0.10, 0.10, 0.12)
 	}
 	if path := os.Getenv("OBK_SMOKE_PNG"); path != "" {

--- a/head/internal/native/viewport.cpp
+++ b/head/internal/native/viewport.cpp
@@ -51,6 +51,7 @@ struct GpuBuffer {
     VkBuffer       buffer = VK_NULL_HANDLE;
     VkDeviceMemory memory = VK_NULL_HANDLE;
     VkDeviceSize   size = 0;
+    void*          mapped = nullptr; // persistent mapping for HOST_VISIBLE geometry (#1422)
 };
 } // namespace
 
@@ -131,8 +132,17 @@ struct Viewport {
     // single-view target; the quad layout uses up to kMaxTiles.
     Target          targets[kMaxTiles];
 
-    GpuBuffer       vbuf, ibuf; // concatenated vertex + index geometry (HOST_VISIBLE, uploaded per frame)
+    GpuBuffer       vbuf, ibuf; // concatenated vertex + index geometry (HOST_VISIBLE, persistently mapped)
     GpuBuffer       instbuf;    // per-instance model matrices (binding 1, ADR-0038)
+
+    // The merged-mesh identity (FNV-64 from the Go atlas key) currently resident in vbuf/ibuf. When
+    // the next render carries the same key the concatenation + re-upload is skipped entirely, so a
+    // static scene being orbited touches only the MVP push-constant (#1422). It tracks what is in the
+    // SHARED buffer (last uploaded by ANY tile), which is what makes the skip correct across tiles —
+    // a different tile's upload changes the key and forces this tile to re-upload. 0 = unknown (the
+    // legacy flatten path, or a freshly recreated target), which always re-uploads (the #1218 guard).
+    uint64_t        geomKey = 0;
+    uint64_t        geomUploads = 0; // count of actual vbuf/ibuf re-uploads, for the #1422 test instrument
 
     // Background the 3D pass clears to (themed; ADR-0021). Defaults reproduce the
     // pre-theming look so an un-themed build is unchanged.
@@ -422,6 +432,9 @@ VkPipeline create_skybox_pipeline(HeadContext* c, Viewport* v) {
 bool ensure_buffer(HeadContext* c, GpuBuffer* b, VkBufferUsageFlags usage,
                    VkMemoryPropertyFlags props, VkDeviceSize bytes) {
     if (b->buffer && b->size >= bytes) return false;
+    // A grow frees the old allocation; unmap its persistent mapping first so the handle does not
+    // dangle (the new, larger allocation is remapped lazily by upload_geom — #1422).
+    if (b->mapped) { vkUnmapMemory(c->device, b->memory); b->mapped = nullptr; }
     if (b->buffer) vkDestroyBuffer(c->device, b->buffer, nullptr);
     if (b->memory) vkFreeMemory(c->device, b->memory, nullptr);
     VkBufferCreateInfo bi{};
@@ -452,6 +465,20 @@ void upload(HeadContext* c, GpuBuffer* b, VkBufferUsageFlags usage, const void* 
     vkMapMemory(c->device, b->memory, 0, bytes, 0, &mapped);
     std::memcpy(mapped, data, (size_t)bytes);
     vkUnmapMemory(c->device, b->memory);
+}
+
+// upload_geom (re)sizes a HOST_VISIBLE|COHERENT geometry buffer and memcpys data into its
+// PERSISTENT mapping — mapped once at (re)allocation, never unmapped per frame. Coherent memory
+// makes the write visible to the GPU without an explicit flush, so the steady-state orbit path
+// does zero map/unmap syscalls (#1422), unlike the generic per-call upload() above (which the
+// rare readback-staging path still uses).
+void upload_geom(HeadContext* c, GpuBuffer* b, VkBufferUsageFlags usage, const void* data,
+                 VkDeviceSize bytes) {
+    if (bytes == 0) return;
+    ensure_buffer(c, b, usage,
+                  VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, bytes);
+    if (!b->mapped) vkMapMemory(c->device, b->memory, 0, VK_WHOLE_SIZE, 0, &b->mapped);
+    if (data) std::memcpy(b->mapped, data, (size_t)bytes);
 }
 
 VkImageView make_image(HeadContext* c, VkFormat fmt, VkImageUsageFlags usage,
@@ -509,6 +536,10 @@ void destroy_target(HeadContext* c, Target* t) {
 void ensure_target(HeadContext* c, Viewport* v, Target* t, int w, int h) {
     if (w == t->width && h == t->height && t->framebuffer != VK_NULL_HANDLE) return;
     vkDeviceWaitIdle(c->device);
+    // Recreating a target invalidates the geometry-resident assumption: M34-F4's geometry-skip
+    // rendered blank across target-recreation / dock-layout transitions (#1218). Clearing the key
+    // forces the next render to re-upload, so the recreated target is never sampled stale.
+    v->geomKey = 0;
     destroy_target(c, t);
     t->width = w;
     t->height = h;
@@ -985,8 +1016,9 @@ void obk_viewport_init(void* h, const uint32_t* vert, int vlen, const uint32_t* 
     init_default_env(c, v);
 }
 
-// obk_viewport_render uploads the flattened geometry, records the offscreen pass, and
-// submits it (waiting on a fence so the color image is ready to sample this frame).
+// obk_viewport_render uploads the geometry (only when geomKey marks it changed — #1422), records
+// the offscreen pass, and submits it (waiting on a fence so the color image is ready to sample
+// this frame). geomKey is the merged-mesh identity from the Go atlas cache; 0 means always upload.
 void obk_viewport_render(void* h, int slot, int w, int hh, const float* mvp, const float* camPos,
                          const float* triV, int triVC, const uint32_t* triIdx, int triIC,
                          const float* occV, int occVC, const uint32_t* occIdx, int occIC,
@@ -995,12 +1027,13 @@ void obk_viewport_render(void* h, int slot, int w, int hh, const float* mvp, con
                          const float* topTriV, int topTriVC, const uint32_t* topTriIdx, int topTriIC,
                          const float* topLineV, int topLineVC, const uint32_t* topLineIdx, int topLineIC,
                          int triBiasFirst, const float* clip,
-                         const float* mats, int matCount, const int32_t* recs, int recCount) {
+                         const float* mats, int matCount, const int32_t* recs, int recCount,
+                         uint64_t geomKey) {
     HeadContext* c = (HeadContext*)h;
     Viewport* v = c->viewport;
     if (!v || w <= 0 || hh <= 0) return;
     Target* t = &v->targets[slotIndex(slot)];
-    ensure_target(c, v, t, w, hh);
+    ensure_target(c, v, t, w, hh); // may clear v->geomKey (target recreated → re-upload, #1218)
 
     // One interleaved vertex buffer and one index buffer hold the streams back to back, in
     // draw order: occluder faces, shaded tris, solid lines, hidden lines, on-top tris, on-top
@@ -1010,40 +1043,53 @@ void obk_viewport_render(void* h, int slot, int w, int hh, const float* mvp, con
     const int topTriBase = hidBase + hidVC, topLineBase = topTriBase + topTriVC;
     const int occFirst = 0, triFirst = occIC, lineFirst = occIC + triIC, hidFirst = occIC + triIC + lineIC;
     const int topTriFirst = hidFirst + hidIC, topLineFirst = topTriFirst + topTriIC;
+    // Whether there is any geometry to draw this frame, independent of whether it was (re)uploaded —
+    // a skipped upload (#1422) still draws the resident buffer, so the draw gate must use the counts.
+    const bool haveGeometry = (occVC + triVC + lineVC + hidVC + topTriVC + topLineVC) > 0;
 
-    // Concatenate the six streams into one vertex + one index buffer and upload them every frame.
-    // (M34-F4 tried to skip this on unchanged geometry: it holds in steady state but renders blank
-    // across viewport-target recreation/dock-layout transitions — a fragile offscreen-buffer-reuse
-    // interaction — so geometry is uploaded unconditionally for correctness; see #1218 for the
-    // careful re-attempt.)
-    std::vector<float> verts;
-    verts.reserve((size_t)(occVC + triVC + lineVC + hidVC + topTriVC + topLineVC) * kVertexFloats);
-    verts.insert(verts.end(), occV, occV + (size_t)occVC * kVertexFloats);
-    verts.insert(verts.end(), triV, triV + (size_t)triVC * kVertexFloats);
-    verts.insert(verts.end(), lineV, lineV + (size_t)lineVC * kVertexFloats);
-    verts.insert(verts.end(), hidV, hidV + (size_t)hidVC * kVertexFloats);
-    verts.insert(verts.end(), topTriV, topTriV + (size_t)topTriVC * kVertexFloats);
-    verts.insert(verts.end(), topLineV, topLineV + (size_t)topLineVC * kVertexFloats);
-    std::vector<uint32_t> idx;
-    idx.reserve((size_t)(occIC + triIC + lineIC + hidIC + topTriIC + topLineIC));
-    idx.insert(idx.end(), occIdx, occIdx + occIC);
-    idx.insert(idx.end(), triIdx, triIdx + triIC);
-    idx.insert(idx.end(), lineIdx, lineIdx + lineIC);
-    idx.insert(idx.end(), hidIdx, hidIdx + hidIC);
-    idx.insert(idx.end(), topTriIdx, topTriIdx + topTriIC);
-    idx.insert(idx.end(), topLineIdx, topLineIdx + topLineIC);
-    upload(c, &v->vbuf, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, verts.data(), verts.size() * sizeof(float));
-    upload(c, &v->ibuf, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, idx.data(), idx.size() * sizeof(uint32_t));
+    // Concatenate the six streams into one vertex + one index buffer and upload them — but ONLY when
+    // the geometry actually changed. geomKey identifies the merged mesh (from the Go atlas cache); when
+    // it matches what is already resident in vbuf/ibuf (last uploaded by any tile), the concatenation
+    // and the whole-model PCIe transfer are skipped, so orbiting a static scene touches only the MVP
+    // push-constant (#1422). geomKey == 0 (the legacy flatten path, or a freshly recreated target)
+    // always re-uploads — that, plus ensure_target clearing the key, is the #1218 blank-after-recreation
+    // guard. The draw offsets below are recomputed from the per-stream counts every frame regardless,
+    // so a skip stays consistent with the resident buffer (identical geometry ⇒ identical counts).
+    const bool geomResident = geomKey != 0 && geomKey == v->geomKey &&
+                              v->vbuf.buffer != VK_NULL_HANDLE && v->ibuf.buffer != VK_NULL_HANDLE;
+    if (!geomResident) {
+        std::vector<float> verts;
+        verts.reserve((size_t)(occVC + triVC + lineVC + hidVC + topTriVC + topLineVC) * kVertexFloats);
+        verts.insert(verts.end(), occV, occV + (size_t)occVC * kVertexFloats);
+        verts.insert(verts.end(), triV, triV + (size_t)triVC * kVertexFloats);
+        verts.insert(verts.end(), lineV, lineV + (size_t)lineVC * kVertexFloats);
+        verts.insert(verts.end(), hidV, hidV + (size_t)hidVC * kVertexFloats);
+        verts.insert(verts.end(), topTriV, topTriV + (size_t)topTriVC * kVertexFloats);
+        verts.insert(verts.end(), topLineV, topLineV + (size_t)topLineVC * kVertexFloats);
+        std::vector<uint32_t> idx;
+        idx.reserve((size_t)(occIC + triIC + lineIC + hidIC + topTriIC + topLineIC));
+        idx.insert(idx.end(), occIdx, occIdx + occIC);
+        idx.insert(idx.end(), triIdx, triIdx + triIC);
+        idx.insert(idx.end(), lineIdx, lineIdx + lineIC);
+        idx.insert(idx.end(), hidIdx, hidIdx + hidIC);
+        idx.insert(idx.end(), topTriIdx, topTriIdx + topTriIC);
+        idx.insert(idx.end(), topLineIdx, topLineIdx + topLineIC);
+        upload_geom(c, &v->vbuf, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, verts.data(), verts.size() * sizeof(float));
+        upload_geom(c, &v->ibuf, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, idx.data(), idx.size() * sizeof(uint32_t));
+        v->geomKey = geomKey; // what is now resident (0 stays 0 ⇒ legacy path never skips)
+        v->geomUploads++;
+    }
 
     // Per-instance model matrices (binding 1, ADR-0038) are small and change every frame (the
-    // frustum-culled set), so they stay HOST_VISIBLE and upload each frame. With matrices supplied,
-    // recs drive instanced per-(source,stream) draws; otherwise every stream draws as one identity
-    // instance (geometry in its own world space — unchanged output).
+    // frustum-culled set), so they upload each frame — but into the same persistent mapping as the
+    // geometry (upload_geom), so no per-frame map/unmap. With matrices supplied, recs drive instanced
+    // per-(source,stream) draws; otherwise every stream draws as one identity instance (geometry in
+    // its own world space — unchanged output).
     static const float kIdentity[16] = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
     if (matCount > 0 && mats) {
-        upload(c, &v->instbuf, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, mats, (size_t)matCount * 16 * sizeof(float));
+        upload_geom(c, &v->instbuf, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, mats, (size_t)matCount * 16 * sizeof(float));
     } else {
-        upload(c, &v->instbuf, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, kIdentity, sizeof(kIdentity));
+        upload_geom(c, &v->instbuf, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, kIdentity, sizeof(kIdentity));
     }
 
     // Refresh the scene-lighting UBO from the CPU copy (coherent mapped memory, so the copy is
@@ -1135,7 +1181,7 @@ void obk_viewport_render(void* h, int slot, int w, int hh, const float* mvp, con
         vkCmdDraw(v->cmd, 3, 1, 0, 0);
     }
 
-    if (!verts.empty()) {
+    if (haveGeometry) {
         VkDeviceSize zero = 0;
         VkBuffer vbufs[2] = {v->vbuf.buffer, v->instbuf.buffer};
         VkDeviceSize voffs[2] = {0, 0};
@@ -1480,6 +1526,15 @@ uint64_t obk_viewport_texture(void* h, int slot) {
     return (uint64_t)c->viewport->targets[slotIndex(slot)].texture;
 }
 
+// obk_viewport_geom_uploads returns the running count of actual geometry (vbuf/ibuf) re-uploads.
+// A static scene being orbited holds this constant — the dirty-skip means only the MVP changes.
+// Exposed for the #1422 regression test to assert "zero re-upload across frames"; 0 before init.
+uint64_t obk_viewport_geom_uploads(void* h) {
+    HeadContext* c = (HeadContext*)h;
+    if (!c || !c->viewport) return 0;
+    return c->viewport->geomUploads;
+}
+
 void obk_viewport_destroy(HeadContext* c) {
     Viewport* v = c->viewport;
     if (!v) return;
@@ -1489,6 +1544,7 @@ void obk_viewport_destroy(HeadContext* c) {
     // GPU — lavapipe did not flag it).
     GpuBuffer* geom[] = {&v->vbuf, &v->ibuf, &v->instbuf};
     for (GpuBuffer* b : geom) {
+        if (b->mapped) vkUnmapMemory(c->device, b->memory); // persistent map (#1422)
         if (b->buffer) vkDestroyBuffer(c->device, b->buffer, nullptr);
         if (b->memory) vkFreeMemory(c->device, b->memory, nullptr);
     }

--- a/head/internal/native/viewport.go
+++ b/head/internal/native/viewport.go
@@ -20,7 +20,9 @@ void     obk_viewport_render(void* h, int slot, int w, int hh, const float* mvp,
                              const float* topTriV, int topTriVC, const uint32_t* topTriIdx, int topTriIC,
                              const float* topLineV, int topLineVC, const uint32_t* topLineIdx, int topLineIC,
                              int triBiasFirst, const float* clip,
-                             const float* mats, int matCount, const int32_t* recs, int recCount);
+                             const float* mats, int matCount, const int32_t* recs, int recCount,
+                             uint64_t geomKey);
+uint64_t obk_viewport_geom_uploads(void* h);
 void     obk_viewport_set_clear(void* h, float r, float g, float b);
 void     obk_viewport_set_normal_debug(void* h, int on);
 void     obk_viewport_set_lighting(void* h, const float* data, int n);
@@ -78,7 +80,7 @@ func (win *Window) RenderViewport(slot, w, h int, mvp []float32, camPos []float3
 	topTriVerts []float32, topTriVCount int, topTriIdx []uint32,
 	topLineVerts []float32, topLineVCount int, topLineIdx []uint32,
 	triBiasFirst int, clip []float32,
-	mats []float32, recs []int32,
+	mats []float32, recs []int32, geomKey uint64,
 ) {
 	C.obk_viewport_render(win.handle, C.int(slot), C.int(w), C.int(h),
 		(*C.float)(unsafe.Pointer(&mvp[0])), floatPtr(camPos),
@@ -89,7 +91,15 @@ func (win *Window) RenderViewport(slot, w, h int, mvp []float32, camPos []float3
 		floatPtr(topTriVerts), C.int(topTriVCount), uint32Ptr(topTriIdx), C.int(len(topTriIdx)),
 		floatPtr(topLineVerts), C.int(topLineVCount), uint32Ptr(topLineIdx), C.int(len(topLineIdx)),
 		C.int(triBiasFirst), floatPtr(clip),
-		floatPtr(mats), C.int(len(mats)/16), int32Ptr(recs), C.int(len(recs)/recDrawInts))
+		floatPtr(mats), C.int(len(mats)/16), int32Ptr(recs), C.int(len(recs)/recDrawInts),
+		C.uint64_t(geomKey))
+}
+
+// ViewportGeomUploads returns how many times the geometry buffers have actually been re-uploaded.
+// A static scene being orbited holds this constant (the #1422 dirty-skip); the regression test
+// asserts it does not climb frame-to-frame on unchanged geometry.
+func (w *Window) ViewportGeomUploads() uint64 {
+	return uint64(C.obk_viewport_geom_uploads(w.handle))
 }
 
 // recDrawInts is the int32 stride of one instanced draw record (ADR-0038): stream, firstIndex,

--- a/head/internal/native/viewport_geom_upload_test.go
+++ b/head/internal/native/viewport_geom_upload_test.go
@@ -1,0 +1,91 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package native
+
+import (
+	"testing"
+
+	"oblikovati.org/renderer"
+)
+
+// TestViewportGeomUploadDirtySkip is the live #1422 stress test: it drives the real offscreen
+// viewport (under lavapipe + xvfb in CI) and asserts the geometry buffer is re-uploaded ONLY when
+// the geometry actually changes — a static scene being orbited touches only the MVP push-constant,
+// not the whole-model PCIe transfer. It also pins the #1218 regression: recreating the target
+// (a resize / dock-layout transition) must force a re-upload so the new target is never sampled
+// stale-or-blank. Skips when no window can be created (a truly headless dev box).
+func TestViewportGeomUploadDirtySkip(t *testing.T) {
+	w, err := CreateWindow(640, 480, "Oblikovati (#1422 upload test)")
+	if err != nil {
+		t.Skipf("no window/GPU available: %v", err)
+	}
+	defer w.Destroy()
+	w.InitViewport()
+	verts, idx, min, max := smokeScene()
+	configureViewportSmokeLighting(w, min, max)
+	cam := smokeCamera()
+	eye := []float32{float32(cam.Eye.X), float32(cam.Eye.Y), float32(cam.Eye.Z)}
+
+	// render submits one frame for geomKey at w×h. Orbiting is simulated by nudging the camera each
+	// call (a new MVP) WITHOUT changing the geometry — exactly the static-orbit path the skip targets.
+	render := func(geomKey uint64, pw, ph int) {
+		cam.Eye.X += 0.05 // nudge the camera only (simulated orbit); geometry stays unchanged
+		mvp := renderer.ViewProjection(cam, 0.1, 100)
+		w.BeginFrame()
+		w.RenderViewport(0, pw, ph, mvp[:], eye, verts, len(verts)/16, idx,
+			nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil, len(idx), nil, nil, nil, geomKey)
+		w.EndFrame(0.10, 0.10, 0.12)
+	}
+
+	const keyA, keyB uint64 = 0xA11CE, 0xB0B
+	render(keyA, 640, 480)
+	if got := w.ViewportGeomUploads(); got != 1 {
+		t.Fatalf("first render: geom uploads = %d, want 1", got)
+	}
+	// Static orbit: same geometry (keyA), moving camera, several frames — ZERO further uploads.
+	for i := 0; i < 5; i++ {
+		render(keyA, 640, 480)
+	}
+	if got := w.ViewportGeomUploads(); got != 1 {
+		t.Errorf("static orbit re-uploaded geometry: uploads = %d, want 1 (only the MVP should change) — #1422", got)
+	}
+	// A genuine geometry change (new key) must upload exactly once, then hold.
+	render(keyB, 640, 480)
+	render(keyB, 640, 480)
+	if got := w.ViewportGeomUploads(); got != 2 {
+		t.Errorf("geometry change: uploads = %d, want 2 (one re-upload on the changed frame, then skip)", got)
+	}
+	// #1218 guard: a resize recreates the target; even with UNCHANGED geometry the next render must
+	// re-upload, or the recreated target samples stale/blank geometry.
+	render(keyB, 400, 300)
+	if got := w.ViewportGeomUploads(); got != 3 {
+		t.Errorf("after target recreation: uploads = %d, want 3 (recreation must force a re-upload) — #1218", got)
+	}
+	// The legacy/unknown path (geomKey 0) never skips, so it is always safe.
+	render(0, 400, 300)
+	render(0, 400, 300)
+	if got := w.ViewportGeomUploads(); got != 5 {
+		t.Errorf("legacy geomKey 0: uploads = %d, want 5 (geomKey 0 always uploads)", got)
+	}
+
+	// Image-parity sanity: after all that, the offscreen image is still a real render, not blank.
+	pixels, pw, ph, ok := w.ReadbackViewport(0)
+	if !ok || pw <= 0 || ph <= 0 {
+		t.Fatalf("ReadbackViewport failed: ok=%v %dx%d", ok, pw, ph)
+	}
+	if allZero(pixels) {
+		t.Error("offscreen image is fully blank after the skip path — geometry was lost (regression vs the always-upload path)")
+	}
+}
+
+// allZero reports whether every byte is 0 (a fully-black/transparent readback — i.e. nothing drew).
+func allZero(b []byte) bool {
+	for _, x := range b {
+		if x != 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -380,7 +380,7 @@ func updateViewportCamera(s *app.Session, pw, ph int, overCube bool) (scene.Came
 // overlay/ground tail as one identity instance, returning the merged mesh + per-instance matrices +
 // draw records. It falls back to a single legacy flatten of the whole list (nil mats/recs) when
 // instancing does not apply — mesh-color debug mode (its own builder) or no keyable geometry.
-func frameMeshAndInstances(s *app.Session, cam scene.Camera, list renderer.DrawList, bodyCount int, ground []renderer.DrawItem, groups, culled []app.InstanceGroup) (viewport.Mesh, []float32, []int32) {
+func frameMeshAndInstances(s *app.Session, cam scene.Camera, list renderer.DrawList, bodyCount int, ground []renderer.DrawItem, groups, culled []app.InstanceGroup) (viewport.Mesh, []float32, []int32, uint64) {
 	if bodyCount < 0 || bodyCount > len(list.Items) {
 		bodyCount = len(list.Items)
 	}
@@ -400,12 +400,14 @@ func frameMeshAndInstances(s *app.Session, cam scene.Camera, list renderer.DrawL
 		decorate := func(l renderer.DrawList) renderer.DrawList {
 			return highlightSelection(l, s.Selection().First(), sources)
 		}
-		if m, mats, recs, ok := buildInstancedFrame(groups, culled, overlay, cam, s.SurfaceLookup(), s.VisualStyle(), decorate, instancedSourceKey(s)); ok {
-			return m, mats, recs
+		if m, mats, recs, key, ok := buildInstancedFrame(groups, culled, overlay, cam, s.SurfaceLookup(), s.VisualStyle(), decorate, instancedSourceKey(s)); ok {
+			return m, mats, recs, geomUploadKey(key)
 		}
 	}
-	list.Items = append(list.Items, ground...) // legacy: one flatten of the whole (world-space) list
-	return viewport.Flatten(list), nil, nil
+	// Legacy flatten: a fresh world-space mesh with no stable atlas key, so geomKey 0 ⇒ the native
+	// renderer always re-uploads it (correct, just unoptimised — the instanced path is the hot one).
+	list.Items = append(list.Items, ground...)
+	return viewport.Flatten(list), nil, nil, 0
 }
 
 // frameBounds is the model bounds for shadow + ground framing: the instance groups' transformed
@@ -460,7 +462,7 @@ func renderViewportImage(win *native.Window, s *app.Session, slot int, cam scene
 	// Draw only the instances inside the view frustum (M34-F1) — off-screen placements never reach
 	// the GPU upload. The bounds above still use the full set so shadows/framing don't shift on orbit.
 	// allGroups builds the retained vertex atlas (stable on orbit); culled drives the per-frame draws.
-	m, mats, recs := frameMeshAndInstances(s, cam, list, bodyCount, ground, groups, s.CulledInstances(cam))
+	m, mats, recs, geomKey := frameMeshAndInstances(s, cam, list, bodyCount, ground, groups, s.CulledInstances(cam))
 	frameStats.buildNs = time.Since(tb).Nanoseconds()
 	mvp := renderer.ViewProjection(cam, viewportNear, viewportFarPlane(s, cam, mn, mx, hasGeom))
 	eye := []float32{float32(cam.Eye.X), float32(cam.Eye.Y), float32(cam.Eye.Z)}
@@ -477,7 +479,7 @@ func renderViewportImage(win *native.Window, s *app.Session, slot int, cam scene
 		m.TopTriVerts, m.TopTriVCount, m.TopTriIndices,
 		m.TopLineVerts, m.TopLineVCount, m.TopLineIndices,
 		m.TriBiasFirst, s.ActiveSectionClip(), // section-plane clip (M12-F04)
-		mats, recs) // instanced draw (ADR-0038); nil mats/recs ⇒ legacy one-identity-instance path
+		mats, recs, geomKey) // instanced draw (ADR-0038); geomKey gates the geometry re-upload (#1422)
 	frameStats.gpuNs = time.Since(tg).Nanoseconds()
 	if tex := win.ViewportTexture(slot); tex != 0 {
 		native.SetCursorPos(cx, cy) // draw the image back over the invisible button
@@ -557,7 +559,7 @@ func modelOverlays(s *app.Session, cam scene.Camera, hovered *feature.WorkPlane,
 	list.Items = append(list.Items, activeToolPreviewItems(s)...)
 	list.Items = append(list.Items, pointCloudOverlay(s, cam)...)     // attached scans (M17-F06, #645)
 	list.Items = append(list.Items, s.SurfaceInterrogationItems()...) // reflection/highlight/isophote (M36-F12)
-	list.Items = append(list.Items, s.DeviationItems()...)             // deviation heatmap (M36-F14)
+	list.Items = append(list.Items, s.DeviationItems()...)            // deviation heatmap (M36-F14)
 	return list
 }
 

--- a/head/ui/instancing_cache_test.go
+++ b/head/ui/instancing_cache_test.go
@@ -109,7 +109,7 @@ func TestBuildInstancedFrameDedupes(t *testing.T) {
 		t.Fatalf("VisibleInstances = %d groups, want 1 (copies share one mesh)", len(groups))
 	}
 	n := len(groups[0].Transforms)
-	m, mats, recs, ok := buildInstancedFrame(groups, groups, renderer.DrawList{}, instCamera(), nullSurface, renderer.Shaded, nil, "k")
+	m, mats, recs, _, ok := buildInstancedFrame(groups, groups, renderer.DrawList{}, instCamera(), nullSurface, renderer.Shaded, nil, "k")
 	if !ok {
 		t.Fatal("buildInstancedFrame returned ok=false")
 	}

--- a/head/ui/viewport_instancing.go
+++ b/head/ui/viewport_instancing.go
@@ -218,9 +218,9 @@ func sortRecsByStream(recs [][7]int32) [][7]int32 {
 func buildInstancedFrame(allGroups, culledGroups []app.InstanceGroup, overlay renderer.DrawList, cam scene.Camera,
 	lookup renderer.SurfaceLookup, style renderer.VisualStyle,
 	decorate func(renderer.DrawList) renderer.DrawList, sourceKey string,
-) (viewport.Mesh, []float32, []int32, bool) {
+) (viewport.Mesh, []float32, []int32, string, bool) {
 	if len(allGroups) == 0 && len(overlay.Items) == 0 {
-		return viewport.Mesh{}, nil, nil, false
+		return viewport.Mesh{}, nil, nil, "", false
 	}
 	atlas := cachedFrameAtlas(allGroups, overlay, cam, lookup, style, decorate, sourceKey)
 	visible := make(map[*topo.Body][]math.Matrix4, len(culledGroups))
@@ -228,7 +228,24 @@ func buildInstancedFrame(allGroups, culledGroups []app.InstanceGroup, overlay re
 		visible[g.Source] = g.Transforms
 	}
 	mats, recs := atlas.assemble(visible)
-	return atlas.mesh, mats, recs, len(recs) > 0
+	// atlas.key identifies the merged mesh resident in the atlas; it is stable across an orbit (only
+	// the per-frame matrices/records change), so it drives the native geometry-upload dirty-skip (#1422).
+	return atlas.mesh, mats, recs, atlas.key, len(recs) > 0
+}
+
+// geomUploadKey hashes the atlas key (or any merged-mesh identity string) into the uint64 the native
+// renderer compares against its resident-geometry key to decide whether to re-upload (#1422). An empty
+// key returns 0, which the native side reads as "unknown" and always re-uploads (the legacy path).
+func geomUploadKey(key string) uint64 {
+	if key == "" {
+		return 0
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(key))
+	if k := h.Sum64(); k != 0 {
+		return k
+	}
+	return 1 // never collide with the 0 "always upload" sentinel
 }
 
 // frameAtlasCache retains the last built atlas. The render loop is single-threaded, so a single

--- a/head/ui/viewport_upload_key_test.go
+++ b/head/ui/viewport_upload_key_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import "testing"
+
+// geomUploadKey turns the atlas key string into the uint64 the native renderer compares against its
+// resident-geometry key to skip a re-upload (#1422). The contract the native side relies on: an empty
+// key is the 0 "always upload" sentinel; a non-empty key is stable across calls (same key in, same
+// uint64 out) and never 0 (so it can actually match and skip); distinct keys map to distinct values.
+func TestGeomUploadKey(t *testing.T) {
+	if got := geomUploadKey(""); got != 0 {
+		t.Errorf("geomUploadKey(\"\") = %d, want 0 (the always-upload sentinel)", got)
+	}
+	const k = "part:42|sel:none|ov:1a2b"
+	first, second := geomUploadKey(k), geomUploadKey(k)
+	if first != second {
+		t.Errorf("geomUploadKey not stable: %d != %d for the same key — a static orbit would re-upload every frame", first, second)
+	}
+	if first == 0 {
+		t.Error("geomUploadKey(non-empty) = 0 — would alias the always-upload sentinel and never skip")
+	}
+	if other := geomUploadKey(k + "|changed"); other == first {
+		t.Errorf("geomUploadKey collided distinct keys onto %d — a real geometry change would be skipped (stale)", other)
+	}
+}


### PR DESCRIPTION
## What & why

Closes #1422.

The offscreen viewport (`obk_viewport_render`) re-concatenated the six geometry
streams into two `std::vector`s and re-uploaded the **whole model** (`map`→`memcpy`→`unmap`)
**every frame** — even a static scene merely being orbited, where only the MVP
push-constant changes. That is wasted CPU memcpy + PCIe bandwidth on the steady-state
orbit path (the realtime-arch "near-zero steady-state work" discipline). M34-F4 tried to
skip it before and was reverted because the skip rendered **blank** across target
recreation / dock-layout transitions (#1218).

## How

- **Dirty-skip keyed on resident geometry.** The Go atlas cache already has a key
  (`frameAtlasCache.key`) that uniquely identifies the merged mesh and is stable across an
  orbit. Hash it to a `uint64` (`geomUploadKey`) and pass it into `obk_viewport_render`. The
  native side tracks which key is currently in the **shared** `vbuf`/`ibuf` (last uploaded by
  *any* tile) and skips the concatenation + upload when it matches. Tracking what is *resident*
  (not a per-slot flag) is what makes the skip correct across tiles — and is the real fix for
  the #1218 reuse bug.
- **#1218 guard.** `ensure_target` clears the resident key on recreation, so a resize forces
  exactly one re-upload — the recreated target is never sampled stale/blank. `geomKey == 0`
  (the legacy flatten path) always uploads.
- **Persistent mapping.** The three geometry buffers (`vbuf`/`ibuf`/`instbuf`) are now mapped
  once at allocation (like the scene UBO), so even the per-frame instance-matrix upload does
  zero `map`/`unmap` syscalls. `ensure_buffer` unmaps a stale mapping before a grow.

## Acceptance criteria

- [x] Geometry buffer uploads only when the atlas key/generation changes; static orbit = zero uploads.
- [x] Buffers persistently mapped; per-frame map/unmap removed.
- [x] #1218 target-recreation correctness covered by a test; no stale geometry.

## Verification

Live on a **real GPU (radeon)** and **lavapipe**:

- `TestViewportGeomUploadDirtySkip` (new, cgo, runs under the CI `head` job's `xvfb + lavapipe`):
  drives the offscreen viewport and asserts a static orbit re-uploads **zero** times, a genuine
  geometry change uploads **exactly once**, a resize (target recreation) **forces** a re-upload
  (#1218), the legacy `geomKey 0` path always uploads, and the image is **non-blank** after the
  skip path (no regression vs the always-upload path).
- `TestGeomUploadKey` (pure Go): the key is `0` only for the empty/legacy case, stable, never
  aliases the sentinel, and distinct keys don't collide.
- Visual: captured the offscreen render — a correctly lit PBR cube with ground, shadow and skybox,
  confirming the persistent-mapping upload path renders identically.
- `go vet`, `gofmt`, `golangci-lint` clean on the touched files; full `head` `ui`/`native`/`viewport`
  suites green.

## Scope note

This is the natural prerequisite for #1421 (frames-in-flight): with geometry no longer churned
every frame, ringing/pipelining the offscreen draw becomes clean. Per-instance matrices still
upload each frame (the frustum-culled set legitimately changes), now into the persistent mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)