### PR TITLE
head(viewport): eliminate per-frame heap allocations on the instanced draw path (#1423)

### DIFF
--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -375,6 +375,40 @@ func updateViewportCamera(s *app.Session, pw, ph int, overCube bool) (scene.Came
 	return cam, hoveredPlane(s)
 }
 
+// Per-frame scratch buffers reused across frames so a static orbit allocates nothing here (#1423).
+// Safe because the render loop is single-threaded and each is consumed within the frame that fills it
+// (the overlay is flattened into the atlas; sources only feeds the highlight decorator; eye is copied
+// into the push constant by RenderViewport before it returns).
+var (
+	frameOverlayScratch []renderer.DrawItem
+	frameSourcesScratch []*topo.Body
+	frameEyeScratch     [3]float32
+)
+
+// frameOverlayList builds the overlay DrawList (body-tail items + ground) into the reused scratch
+// slice, so an orbit doesn't reallocate it each frame (#1423).
+func frameOverlayList(items, ground []renderer.DrawItem) renderer.DrawList {
+	frameOverlayScratch = append(frameOverlayScratch[:0], items...)
+	frameOverlayScratch = append(frameOverlayScratch, ground...)
+	return renderer.DrawList{Items: frameOverlayScratch}
+}
+
+// frameSources collects the group source bodies into the reused scratch slice (#1423).
+func frameSources(groups []app.InstanceGroup) []*topo.Body {
+	frameSourcesScratch = frameSourcesScratch[:0]
+	for _, g := range groups {
+		frameSourcesScratch = append(frameSourcesScratch, g.Source)
+	}
+	return frameSourcesScratch
+}
+
+// frameEye packs the camera eye into the reused scratch array; RenderViewport copies it into the push
+// constant synchronously, so handing back the shared slice is safe (#1423).
+func frameEye(cam scene.Camera) []float32 {
+	frameEyeScratch = [3]float32{float32(cam.Eye.X), float32(cam.Eye.Y), float32(cam.Eye.Z)}
+	return frameEyeScratch[:]
+}
+
 // frameMeshAndInstances builds the geometry the viewport draws: the instanced path (ADR-0038)
 // rebuilds the bodies from per-component LOCAL meshes (deduped, one per unique component) plus the
 // overlay/ground tail as one identity instance, returning the merged mesh + per-instance matrices +
@@ -389,14 +423,12 @@ func frameMeshAndInstances(s *app.Session, cam scene.Camera, list renderer.DrawL
 	// source-mesh cache (instancedSourceKey) and the body cache (bodyGeometryKey).
 	renderer.SetEdgeColor(displayEdgeColor(s))
 	if on, _ := s.MeshColors(); !on {
-		overlay := renderer.DrawList{Items: append(append([]renderer.DrawItem(nil), list.Items[bodyCount:]...), ground...)}
-		// Highlight against the group SOURCE bodies (already in hand), NOT activeBodies(s) — the
-		// latter is VisibleBodies → worldAssemblyBodies, which re-derives (TransformBody) every
-		// occurrence each frame, an O(occurrences) cost that defeats instancing on a big assembly.
-		sources := make([]*topo.Body, len(groups))
-		for i, g := range groups {
-			sources[i] = g.Source
-		}
+		// frameOverlayList/frameSources reuse scratch buffers (consumed within this frame), so a static
+		// orbit rebuilds neither's backing array (#1423). Sources highlight against the group SOURCE
+		// bodies (already in hand), NOT activeBodies(s) — the latter re-derives every occurrence each
+		// frame (TransformBody), an O(occurrences) cost that defeats instancing on a big assembly.
+		overlay := frameOverlayList(list.Items[bodyCount:], ground)
+		sources := frameSources(groups)
 		decorate := func(l renderer.DrawList) renderer.DrawList {
 			return highlightSelection(l, s.Selection().First(), sources)
 		}
@@ -465,7 +497,7 @@ func renderViewportImage(win *native.Window, s *app.Session, slot int, cam scene
 	m, mats, recs, geomKey := frameMeshAndInstances(s, cam, list, bodyCount, ground, groups, s.CulledInstances(cam))
 	frameStats.buildNs = time.Since(tb).Nanoseconds()
 	mvp := renderer.ViewProjection(cam, viewportNear, viewportFarPlane(s, cam, mn, mx, hasGeom))
-	eye := []float32{float32(cam.Eye.X), float32(cam.Eye.Y), float32(cam.Eye.Z)}
+	eye := frameEye(cam) // reused scratch; RenderViewport copies it into the push constant synchronously (#1423)
 	win.SetViewportLighting(viewport.PackLighting(s.SceneLighting()))
 	applyEnvironment(win, s.Environment())
 	applySkybox(win, s.Environment(), mvp)

--- a/head/ui/viewport_assemble_alloc_test.go
+++ b/head/ui/viewport_assemble_alloc_test.go
@@ -1,0 +1,67 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// TestAssembleAllocFree is the #1423 guard: assembling the per-frame instance matrices + draw records
+// for a STATIC scene (unchanged geometry + culled set, only the camera orbiting) must allocate
+// nothing — the buffers are reused across frames. Before #1423 this allocated a 16-float slice per
+// instance plus three fresh slices per frame; a 10k-instance assembly did ~10k heap slices/frame.
+func TestAssembleAllocFree(t *testing.T) {
+	const sources, perSource = 4, 2500 // 10k instances total
+	atlas := frameAtlas{}
+	visible := map[*topo.Body][]math.Matrix4{}
+	tfs := make([]math.Matrix4, perSource)
+	for i := range tfs {
+		tfs[i] = math.Translation4(math.V3(float64(i), 0, 0))
+	}
+	for s := 0; s < sources; s++ {
+		b := new(topo.Body)
+		atlas.recs = append(atlas.recs, [5]int32{1, 0, 36, 0, 0}) // one tri-stream template per source
+		atlas.regions = append(atlas.regions, atlasRegion{source: b, start: s, end: s + 1})
+		visible[b] = tfs // every source visible with perSource instances
+	}
+
+	mats, recs := atlas.assemble(visible) // warm the scratch buffers
+	if got := len(mats) / 16; got != sources*perSource {
+		t.Fatalf("assemble produced %d instances, want %d", got, sources*perSource)
+	}
+	if len(recs) != sources*7 {
+		t.Fatalf("assemble produced %d record ints, want %d", len(recs), sources*7)
+	}
+
+	allocs := testing.AllocsPerRun(50, func() { _, _ = atlas.assemble(visible) })
+	if allocs > 0 {
+		t.Errorf("assemble allocates %.1f times/op on a static frame, want 0 (#1423)", allocs)
+	}
+}
+
+// TestSelectionSeqStableThenBumps pins the reflection-free selection key: the sequence holds while the
+// first selected item is unchanged (so an orbit doesn't invalidate the highlighted-source cache) and
+// bumps when it changes — replacing the per-frame fmt.Sprintf("%v", …) reflection (#1423).
+func TestSelectionSeqStableThenBumps(t *testing.T) {
+	lastSelFirst, lastSelSeq = nil, 0 // reset package state for a deterministic check
+	s := assemblyWithPlacedBox(t)
+	a := selectionSeq(s)
+	if b := selectionSeq(s); b != a {
+		t.Errorf("selectionSeq changed on an unchanged selection: %d→%d (orbit would re-tessellate)", a, b)
+	}
+	// Select a body → First() changes identity → the sequence must advance.
+	groups := s.VisibleInstances()
+	if len(groups) == 0 {
+		t.Skip("no instance to select")
+	}
+	s.Selection().Add(app.BodyHandle{Body: groups[0].Source})
+	if c := selectionSeq(s); c == a {
+		t.Errorf("selectionSeq did not advance after a selection change (stale highlight key)")
+	}
+}

--- a/head/ui/viewport_instancing.go
+++ b/head/ui/viewport_instancing.go
@@ -6,7 +6,6 @@ package ui
 
 import (
 	"encoding/binary"
-	"fmt"
 	"hash"
 	"hash/fnv"
 	stdmath "math"
@@ -142,22 +141,37 @@ type frameAtlas struct {
 // (nil source) always draws as one identity instance. Records are stream-sorted so native binds
 // each pipeline once. This is all the per-frame work now — the heavy streams come from the cache.
 func (a *frameAtlas) assemble(visible map[*topo.Body][]math.Matrix4) ([]float32, []int32) {
-	var mats []float32
-	var recs [][7]int32
+	// Reuse the per-frame instance buffers across frames (the render loop is single-threaded, like
+	// frameAtlasCache): a static orbit then allocates nothing — only the buffer contents change. The
+	// native side memcpy's mats/recs synchronously during the RenderViewport cgo call, so handing back
+	// a buffer that the next frame overwrites is safe (#1423).
+	sc := &assembleScratch
+	sc.mats = sc.mats[:0]
+	sc.recs = sc.recs[:0]
 	for _, region := range a.regions {
 		tfs := regionTransforms(region, visible)
 		if len(tfs) == 0 {
 			continue
 		}
-		first := int32(len(mats) / 16)
+		first := int32(len(sc.mats) / 16)
 		for _, t := range tfs {
-			mats = append(mats, matrixFloats(t)...)
+			sc.mats = appendMatrixFloats(sc.mats, t) // write the 16 floats in place, no per-instance heap slice
 		}
 		for _, tmpl := range a.recs[region.start:region.end] {
-			recs = append(recs, [7]int32{tmpl[0], tmpl[1], tmpl[2], tmpl[3], first, int32(len(tfs)), tmpl[4]})
+			sc.recs = append(sc.recs, [7]int32{tmpl[0], tmpl[1], tmpl[2], tmpl[3], first, int32(len(tfs)), tmpl[4]})
 		}
 	}
-	return mats, flattenRecs(sortRecsByStream(recs))
+	return sc.mats, flattenRecsInto(&sc.flat, sortRecsInto(&sc.sorted, sc.recs))
+}
+
+// assembleScratch holds the per-frame instance matrices + draw records, reused every frame so the
+// steady-state orbit path is allocation-free (#1423). Package-level is safe because the render loop
+// is single-threaded (the same invariant frameAtlasCache relies on).
+var assembleScratch struct {
+	mats   []float32
+	recs   [][7]int32
+	sorted [][7]int32
+	flat   []int32
 }
 
 // regionTransforms returns the world matrices to draw a region this frame: the overlay (nil source)
@@ -173,13 +187,15 @@ func regionTransforms(region atlasRegion, visible map[*topo.Body][]math.Matrix4)
 // world space and are placed by the view-projection, not a model matrix).
 var identityInstance = []math.Matrix4{math.Identity4()}
 
-// flattenRecs packs the stream-sorted [7]int32 records into the flat []int32 native expects.
-func flattenRecs(recs [][7]int32) []int32 {
-	out := make([]int32, 0, len(recs)*7)
+// flattenRecsInto packs the stream-sorted [7]int32 records into the flat []int32 native expects,
+// reusing *out's backing array across frames (#1423).
+func flattenRecsInto(out *[]int32, recs [][7]int32) []int32 {
+	o := (*out)[:0]
 	for _, r := range recs {
-		out = append(out, r[:]...)
+		o = append(o, r[:]...)
 	}
-	return out
+	*out = o
+	return o
 }
 
 // mergedMesh assembles the six accumulated streams into one viewport.Mesh (the per-stream order
@@ -195,18 +211,19 @@ func (b *instanceBuilder) mergedMesh() viewport.Mesh {
 	return m
 }
 
-// sortRecsByStream returns the records grouped by stream id (stable), so the native binds each
-// stream's pipeline once. A simple bucket sort over the six fixed streams.
-func sortRecsByStream(recs [][7]int32) [][7]int32 {
-	out := make([][7]int32, 0, len(recs))
+// sortRecsInto returns the records grouped by stream id (stable), so the native binds each stream's
+// pipeline once. A simple bucket sort over the six fixed streams, reusing *out across frames (#1423).
+func sortRecsInto(out *[][7]int32, recs [][7]int32) [][7]int32 {
+	o := (*out)[:0]
 	for s := int32(0); s <= 5; s++ {
 		for _, r := range recs {
 			if r[0] == s {
-				out = append(out, r)
+				o = append(o, r)
 			}
 		}
 	}
-	return out
+	*out = o
+	return o
 }
 
 // buildInstancedFrame returns the merged mesh + per-frame instance matrices + draw records for
@@ -223,7 +240,10 @@ func buildInstancedFrame(allGroups, culledGroups []app.InstanceGroup, overlay re
 		return viewport.Mesh{}, nil, nil, "", false
 	}
 	atlas := cachedFrameAtlas(allGroups, overlay, cam, lookup, style, decorate, sourceKey)
-	visible := make(map[*topo.Body][]math.Matrix4, len(culledGroups))
+	// Reuse the visible-instances map across frames (single-threaded render loop) — clear keeps the
+	// buckets, so a static orbit re-maps the culled set without allocating a fresh map (#1423).
+	visible := visibleScratch
+	clear(visible)
 	for _, g := range culledGroups {
 		visible[g.Source] = g.Transforms
 	}
@@ -253,6 +273,10 @@ func geomUploadKey(key string) uint64 {
 // rebuilds (degrading to the pre-F1b cost, never incorrectly).
 var frameAtlasCache frameAtlas
 
+// visibleScratch is the reused source→transforms map assemble reads each frame (#1423); cleared and
+// refilled per frame from the culled set, so a static orbit allocates no fresh map.
+var visibleScratch = map[*topo.Body][]math.Matrix4{}
+
 // cachedFrameAtlas returns the atlas for the given sources + overlay, rebuilding it only when the
 // source signature (sourceKey, which bumps on any geometry/style/selection/placement change) or the
 // overlay content changes. The overlay is flattened every frame (it is small) so its hash can key
@@ -279,11 +303,16 @@ func cachedFrameAtlas(allGroups []app.InstanceGroup, overlay renderer.DrawList, 
 	return frameAtlasCache
 }
 
+// overlayHasher is reused across frames so keying the atlas cache on the overlay doesn't allocate a
+// fresh hasher every frame (#1423). Single-threaded render loop, so package-level state is safe.
+var overlayHasher = fnv.New64a()
+
 // overlayHash is an order-sensitive FNV-1a digest of the overlay mesh's streams, so the atlas cache
 // rebuilds when an overlay (work plane, sketch, gizmo, ground) appears, moves or disappears, but
 // holds while it is unchanged during an orbit.
 func overlayHash(m viewport.Mesh) uint64 {
-	h := fnv.New64a()
+	h := overlayHasher
+	h.Reset()
 	for _, s := range [][]float32{m.TriVerts, m.OccVerts, m.LineVerts, m.HidVerts, m.TopTriVerts, m.TopLineVerts} {
 		hashFloat32s(h, s)
 	}
@@ -334,9 +363,30 @@ func instancedSourceKey(s *app.Session) string {
 		return ""
 	}
 	ec := displayEdgeColor(s) // M16-F07: edge-color override is baked into the source mesh
-	return ver + "|" + strconv.Itoa(int(s.VisualStyle())) + "|" + fmt.Sprintf("%v", s.Selection().First()) +
-		"|" + fmt.Sprintf("%.3f", ec[0]+ec[1]*2+ec[2]*3)
+	// Key the highlighted-source cache on a selection SEQUENCE (bumped when the highlighted item
+	// changes) and a strconv'd edge-color digest — never fmt.Sprintf/%v, whose reflection ran on every
+	// frame even while orbiting a fixed selection (#1423).
+	return ver + "|" + strconv.Itoa(int(s.VisualStyle())) + "|" + strconv.Itoa(selectionSeq(s)) +
+		"|" + strconv.FormatFloat(float64(ec[0]+ec[1]*2+ec[2]*3), 'f', 3, 32)
 }
+
+// selectionSeq returns a counter that increments whenever the FIRST selected item (the one the source
+// mesh bakes its highlight from) changes identity. Selectable handles are comparable value structs, so
+// this is a plain == check — reflection-free and allocation-free, stable while orbiting a fixed
+// selection. Single-threaded render loop, so the package-level state is safe (#1423).
+func selectionSeq(s *app.Session) int {
+	f := s.Selection().First()
+	if f != lastSelFirst {
+		lastSelFirst = f
+		lastSelSeq++
+	}
+	return lastSelSeq
+}
+
+var (
+	lastSelFirst app.Selectable
+	lastSelSeq   int
+)
 
 // cachedSourceMesh returns g's flattened source mesh, rebuilding only when sourceKey changed.
 func cachedSourceMesh(src *topo.Body, cam scene.Camera, lookup renderer.SurfaceLookup,
@@ -394,14 +444,14 @@ func widenBounds(min, max *[3]float32, x, y, z float32) {
 	}
 }
 
-// matrixFloats returns t as 16 column-major float32 — the per-instance model matrix layout the
-// mesh.vert binding-1 mat4 expects.
-func matrixFloats(t math.Matrix4) []float32 {
-	var out [16]float32
+// appendMatrixFloats appends t as 16 column-major float32 — the per-instance model matrix layout the
+// mesh.vert binding-1 mat4 expects — directly onto dst, so a frame's matrices land in one reused
+// buffer instead of a heap slice per instance (#1423).
+func appendMatrixFloats(dst []float32, t math.Matrix4) []float32 {
 	for col := 0; col < 4; col++ {
 		for row := 0; row < 4; row++ {
-			out[col*4+row] = float32(t.At(row, col))
+			dst = append(dst, float32(t.At(row, col)))
 		}
 	}
-	return out[:]
+	return dst
 }


### PR DESCRIPTION
## What & why

Closes #1423.

A 10k-instance assembly did **~10k heap slices per frame with a still camera** — pure GC pressure on the
steady-state orbit path (the realtime-arch "near-zero steady-state allocation" rule). The per-frame instance
assembly allocated a fresh 16-float slice **per instance** (`matrixFloats`), three fresh slices per frame
(`mats`, the stream-sorted records, the flattened records), a fresh visible-instances map, the
overlay-items/source-body/eye slices, plus `fmt.Sprintf("%v", selection)` reflection in the source-mesh
cache key and a fresh FNV hasher in the overlay cache key — none of which changed on a static orbit.

## How

Reuse single-threaded scratch buffers across frames (the same invariant `frameAtlasCache` already relies on):
- **`assemble`** writes the 16 matrix floats in place (`appendMatrixFloats`) and reuses the `mats` / sorted /
  flattened record buffers (`sortRecsInto` / `flattenRecsInto`) — no per-instance heap slice.
- the **visible map** is `clear`ed and refilled; the **overlay / sources / eye** slices and the **FNV hasher**
  are reused.
- the source-mesh cache key drops `fmt.Sprintf("%v", selection)` for a **selection sequence counter** (bumped
  only when the highlighted item changes — comparable handles, plain `==`) and `strconv` for the edge-color digest.

Every reused buffer is consumed within the frame that fills it — the native side memcpy's `mats`/`recs` and the
eye push-constant **synchronously** during the `RenderViewport` cgo call — so handing back a buffer the next
frame overwrites is safe. **The emitted matrices/records are unchanged.**

## Acceptance criteria

- [x] No `fmt.Sprintf`/reflection in per-frame key construction (selection-sequence counter + `strconv`); the
  overlay cache key no longer allocates per frame (reused FNV hasher — see note).
- [x] Per-instance and per-frame slices/maps pooled/reused; `AllocsPerOp` on a static-orbit `assemble` = **0**.
- [x] No rendering regression.

## Verification

- **`TestAssembleAllocFree`**: `assemble` allocates **0 times/op** on a static 10k-instance frame
  (`testing.AllocsPerRun`) — was a 16-float slice per instance + three slices per frame before.
- **`TestSelectionSeqStableThenBumps`**: the reflection-free key holds while orbiting a fixed selection and
  bumps on a selection change (no stale highlight).
- **Live** (driven over the Oblikovati.AddIns.MCPBridge add-in): the running app renders a filleted box
  correctly through the instanced path — output unchanged.
- Full `head` suite green; `gofmt`/`vet`/`golangci-lint` clean on the touched files.

## Note / follow-up

The overlay cache key keeps a **byte-hash made allocation-free** (reused hasher) rather than a model/tool
version counter — the version-counter approach needs an upstream overlay-version signal (a broader change).
For a scene with overlays *shown* (a sketch/work-plane), the overlay items are still rebuilt upstream each
frame (`modelOverlays`), so that generation cost is independent of this PR; the instanced assembly itself —
the part that scaled with instance count — is now allocation-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)