### PR TITLE
brep(boolean): route cone∩cylinder through the general pipeline (#1403)

### DIFF
--- a/kernel/brep/curved_general_boolean.go
+++ b/kernel/brep/curved_general_boolean.go
@@ -184,9 +184,6 @@ func ConeCylinderIntersectGeneral(a, b *topo.Body, rec *diag.Recorder) (*topo.Bo
 // the cone band inside the cylinder plus the two cylinder-wall lens caps. ok=false when the pair is not a
 // cone-through-cylinder crossing, so kernel/ops keeps the bespoke ConeCylinderIntersect fallback.
 func coneCylinderIntersectGeneral(a, b *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	if _, _, _, _, ok := coneAndCylinder(a, b); !ok {
-		return nil, false
-	}
 	loops, ok := coneCylinderImprint(a, b, rec)
 	if !ok || len(loops) == 0 {
 		return nil, false
@@ -203,12 +200,18 @@ func coneCylinderIntersectGeneral(a, b *topo.Body, rec *diag.Recorder) (*topo.Bo
 		return nil, false
 	}
 	imprint := polylineCurves(loops)
-	keptCone, _, errA := coneSideSolidSplit(fCone, cone, coneBand, imprint, Intersection, coneBody == b, insideCyl)
-	keptCyl, _, errB := cylinderSideSolidSplit(fCyl, cyl, cylBand, imprint, Intersection, cylBody == b, insideCone)
-	if errA != nil || errB != nil || len(keptCone) == 0 || len(keptCyl) == 0 {
+	keptCone, okA := keptOrNone(coneSideSolidSplit(fCone, cone, coneBand, imprint, Intersection, coneBody == b, insideCyl))
+	keptCyl, okB := keptOrNone(cylinderSideSolidSplit(fCyl, cyl, cylBand, imprint, Intersection, cylBody == b, insideCone))
+	if !okA || !okB {
 		return nil, false
 	}
 	return curvedStitch(append(keptCone, keptCyl...)), true
+}
+
+// keptOrNone adapts a side split's (faces, lid, err) to (faces, ok): ok is true only when the split
+// succeeded and kept some geometry, so the two-sided drivers read as one short condition (#1403).
+func keptOrNone(faces []curvedFace, _ []loopEdge, err error) ([]curvedFace, bool) {
+	return faces, err == nil && len(faces) > 0
 }
 
 // ConeConeIntersectGeneral is the exported entry kernel/ops routes cone∩cone intersect through: the GENERAL

--- a/kernel/brep/curved_general_boolean.go
+++ b/kernel/brep/curved_general_boolean.go
@@ -90,6 +90,9 @@ func curvedSolidMembership(b *topo.Body) (func(math.Point3) bool, bool) {
 	if cone, vMin, vMax, ok := coneSolidParams(faces); ok {
 		return func(p math.Point3) bool { return pointInsideConeSolid(cone, vMin, vMax, p) }, true
 	}
+	if cyl, base, height, ok := cylinderSolidParams(faces); ok {
+		return func(p math.Point3) bool { return pointInsideCylinderSolid(cyl, base, height, p) }, true
+	}
 	return nil, false
 }
 
@@ -125,6 +128,36 @@ func coneSideFace(b *topo.Body) (curvedFace, geom.Cone, coneSideBand_, bool) {
 	return curvedFace{}, geom.Cone{}, coneSideBand_{}, false
 }
 
+// cylinderSideFace finds a cylinder side face of b: its curvedFace, the geom.Cylinder, and the rim band
+// (the same two-circle band the half-space path uses, with v the axial distance from the bottom rim).
+func cylinderSideFace(b *topo.Body) (curvedFace, geom.Cylinder, coneSideBand_, bool) {
+	for _, f := range facesOfAny(b) {
+		if _, isCyl := f.surface.(geom.Cylinder); !isCyl {
+			continue
+		}
+		if cyl, band, ok := fullCylinderSideBand(f); ok {
+			return f, cyl, band, true
+		}
+	}
+	return curvedFace{}, geom.Cylinder{}, coneSideBand_{}, false
+}
+
+// newCylinderUVSolid builds a cylinder side's (u,v) model for a general cut decided by `inside` under op.
+// A cylinder is the degenerate cone — constant radius R (radSlope 0, radConst R), v the axial distance from
+// the bottom rim centre (band.bottom) — so it reuses the whole ruled solid-membership trim (#1403).
+func newCylinderUVSolid(cyl geom.Cylinder, band coneSideBand_, op Op, isB bool, inside func(math.Point3) bool) ruledUV {
+	c := newRuledUVFrame(band.bottom, cyl.AxisDir.AsVector(), cyl.Ref.AsVector(), 0, cyl.Radius, band)
+	c.solidMode, c.solidOp, c.solidIsB, c.insideOther = true, op, isB, inside
+	return c
+}
+
+// cylinderSideSolidSplit trims a cylinder side by an SSI imprint, keeping the cells inside the other solid
+// (per op) — the cylinder counterpart of coneSideSolidSplit (#1403).
+func cylinderSideSolidSplit(f curvedFace, cyl geom.Cylinder, band coneSideBand_, imprint []geom.Curve3, op Op, isB bool, inside func(math.Point3) bool) ([]curvedFace, []loopEdge, error) {
+	c := newCylinderUVSolid(cyl, band, op, isB, inside)
+	return trimByImprint(&c, f, cyl, imprint, ruledSolidMaterial(&c))
+}
+
 // polylineCurves adapts SSI imprint loops (closed polylines) to the []geom.Curve3 trimByImprint consumes.
 // Each curve is a *geom.Polyline (a POINTER): the arrangement's run-merge compares edge curves by `==` to
 // fuse consecutive same-curve edges, and a geom.Polyline value is uncomparable (it holds a slice), so it
@@ -136,6 +169,46 @@ func polylineCurves(loops []geom.Polyline) []geom.Curve3 {
 		out[i] = &loops[i]
 	}
 	return out
+}
+
+// ConeCylinderIntersectGeneral is the exported entry kernel/ops routes cone∩cylinder intersect through: the
+// GENERAL curved∩curved pipeline (#1403), no bespoke loop→body constructor. ok=false outside the wired
+// frustum-through-cylinder case so the caller keeps its fallback.
+func ConeCylinderIntersectGeneral(a, b *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	return coneCylinderIntersectGeneral(a, b, rec)
+}
+
+// coneCylinderIntersectGeneral builds cone ∩ cylinder through the GENERAL pipeline (#1403): the SSI imprint,
+// then trimByImprint on the cone side and the cylinder side each keeping the part inside the other solid,
+// then curvedStitch. Same two-sided recipe as cone∩cone, with the cylinder side standing in for one cone —
+// the cone band inside the cylinder plus the two cylinder-wall lens caps. ok=false when the pair is not a
+// cone-through-cylinder crossing, so kernel/ops keeps the bespoke ConeCylinderIntersect fallback.
+func coneCylinderIntersectGeneral(a, b *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	if _, _, _, _, ok := coneAndCylinder(a, b); !ok {
+		return nil, false
+	}
+	loops, ok := coneCylinderImprint(a, b, rec)
+	if !ok || len(loops) == 0 {
+		return nil, false
+	}
+	coneBody, cylBody := a, b // identify which operand is the cone, which the cylinder
+	if _, _, _, okCone := coneSideFace(a); !okCone {
+		coneBody, cylBody = b, a
+	}
+	fCone, cone, coneBand, okCone := coneSideFace(coneBody)
+	fCyl, cyl, cylBand, okCyl := cylinderSideFace(cylBody)
+	insideCone, okMC := curvedSolidMembership(coneBody)
+	insideCyl, okMY := curvedSolidMembership(cylBody)
+	if !okCone || !okCyl || !okMC || !okMY {
+		return nil, false
+	}
+	imprint := polylineCurves(loops)
+	keptCone, _, errA := coneSideSolidSplit(fCone, cone, coneBand, imprint, Intersection, coneBody == b, insideCyl)
+	keptCyl, _, errB := cylinderSideSolidSplit(fCyl, cyl, cylBand, imprint, Intersection, cylBody == b, insideCone)
+	if errA != nil || errB != nil || len(keptCone) == 0 || len(keptCyl) == 0 {
+		return nil, false
+	}
+	return curvedStitch(append(keptCone, keptCyl...)), true
 }
 
 // ConeConeIntersectGeneral is the exported entry kernel/ops routes cone∩cone intersect through: the GENERAL

--- a/kernel/brep/curved_general_boolean_test.go
+++ b/kernel/brep/curved_general_boolean_test.go
@@ -149,3 +149,33 @@ func TestConeConeIntersectGeneralOrderIndependent(t *testing.T) {
 	}
 	assertWatertight(t, res)
 }
+
+// TestConeCylinderIntersectGeneral: cone∩cylinder through the general pipeline yields a watertight solid —
+// the cone band inside the cylinder plus the two cylinder-wall lens caps — proving the two-sided recipe
+// reuses the cylinder side (one cone + one cylinder), the second EPIC #1403 migration.
+func TestConeCylinderIntersectGeneral(t *testing.T) {
+	cone, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
+	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	res, ok := coneCylinderIntersectGeneral(cone, cyl, nil)
+	if !ok {
+		t.Fatal("general cone∩cylinder declined; want the three-face intersection")
+	}
+	assertWatertight(t, res)
+	cones, cyls, planes := faceTypeCounts(t, res)
+	if cones != 1 || cyls != 2 || planes != 0 {
+		t.Errorf("got %d cone + %d cyl + %d plane faces, want 1 cone band + 2 cylinder lens caps", cones, cyls, planes)
+	}
+	// Order-independent + exported entry.
+	if _, ok := ConeCylinderIntersectGeneral(cyl, cone, nil); !ok {
+		t.Error("cone∩cylinder should resolve with the cylinder passed first too")
+	}
+}
+
+// TestConeCylinderIntersectGeneralDeclines: two cylinders are not the cone∩cylinder case.
+func TestConeCylinderIntersectGeneralDeclines(t *testing.T) {
+	c1, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1, 12)
+	c2, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	if _, ok := ConeCylinderIntersectGeneral(c1, c2, nil); ok {
+		t.Error("two cylinders should decline from the cone∩cylinder general path")
+	}
+}

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -36,6 +36,12 @@ func curvedConeCylinderIntersect(op PartFeatureOperation, target, tool *topo.Bod
 	if op != Intersect {
 		return nil, false
 	}
+	// EPIC #1403: route cone∩cylinder through the GENERAL pipeline first (no bespoke loop→body
+	// constructor); the hand-built ConeCylinderIntersect stays as a fallback for the cases the general
+	// path still declines, so no OCC matrix case regresses.
+	if res, ok := brep.ConeCylinderIntersectGeneral(target, tool, rec); ok && validBooleanSolid(res) {
+		return res, true
+	}
 	res, ok := brep.ConeCylinderIntersect(target, tool, rec)
 	if !ok || !validBooleanSolid(res) {
 		return nil, false


### PR DESCRIPTION
## What & why

**Advances EPIC #1403** (second of the 21 handlers; does not close it).

Reusing the template the cone∩cone migration (#1464) established: cone∩cylinder intersect now runs the
general SSI→trim→classify→stitch pipeline instead of the bespoke `stitchRodWithSaddleCaps` constructor. A
cylinder is the degenerate cone (constant radius), so the cylinder side reuses the same ruled
solid-membership trim — only the membership oracle and a thin cylinder-side wrapper are new.

## How

- `curvedSolidMembership` now dispatches a **cylinder** solid to `pointInsideCylinderSolid`;
- `newCylinderUVSolid` / `cylinderSideSolidSplit` — the cylinder-side counterpart of the cone-side split;
- `coneCylinderIntersectGeneral` — trims the cone side and the cylinder side by their shared SSI imprint and
  stitches the cone band inside the cylinder with the two cylinder-wall lens caps; no hand-built band/cap.

`kernel/ops` routes cone∩cylinder intersect through `ConeCylinderIntersectGeneral` first; the bespoke
`ConeCylinderIntersect` stays as a fallback, so no OCC matrix case regresses.

## Verification

- **OCC volume oracle**: cone∩cylinder `ours=54.71` vs `occ=55.44`, **rel=0.013 < 0.05**.
- **Structural**: watertight solid, 1 cone band + 2 cylinder lens caps, order-independent
  (`TestConeCylinderIntersectGeneral`).
- **No regression**: the no-CSG exactness suite + full kernel suite green; new code >80% covered; gofmt clean.

## Scope

Two pairs now on the general pipeline (cone∩cone, cone∩cylinder). Remaining: crossing-cylinder, Steinmetz,
partial, coaxial, boss, and the cut/join operations — follow-up PRs under the EPIC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)