### PR TITLE
brep(boolean): route crossing-cylinder intersect through the general pipeline (#1403)

### DIFF
--- a/kernel/brep/curved_general_boolean.go
+++ b/kernel/brep/curved_general_boolean.go
@@ -171,6 +171,39 @@ func polylineCurves(loops []geom.Polyline) []geom.Curve3 {
 	return out
 }
 
+// CrossingCylinderIntersectGeneral is the exported entry kernel/ops routes crossing-cylinder intersect
+// through: the GENERAL curved∩curved pipeline (#1403), no bespoke loop→body constructor. ok=false outside
+// the wired cylinder-through-cylinder crossing so the caller keeps its fallback.
+func CrossingCylinderIntersectGeneral(a, b *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	return crossingCylinderIntersectGeneral(a, b, rec)
+}
+
+// crossingCylinderIntersectGeneral builds cylinder ∩ cylinder (two crossing cylinders) through the GENERAL
+// pipeline (#1403): the SSI imprint, then trimByImprint on each cylinder side keeping the part inside the
+// other, then curvedStitch. The simplest pair — both sides are cylinders, so the recipe is fully symmetric
+// (no rod/fat split): the rod-wall band inside the fat plus the two fat-wall lens caps fall out of the same
+// two-sided trim. ok=false when the pair is not a cylinder-through-cylinder crossing.
+func crossingCylinderIntersectGeneral(a, b *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	loops, ok := crossingCylinderImprint(a, b, rec)
+	if !ok || len(loops) == 0 {
+		return nil, false
+	}
+	fA, cylA, bandA, okA := cylinderSideFace(a)
+	fB, cylB, bandB, okB := cylinderSideFace(b)
+	insideA, okMA := curvedSolidMembership(a)
+	insideB, okMB := curvedSolidMembership(b)
+	if !okA || !okB || !okMA || !okMB {
+		return nil, false
+	}
+	imprint := polylineCurves(loops)
+	keptA, okKA := keptOrNone(cylinderSideSolidSplit(fA, cylA, bandA, imprint, Intersection, false, insideB))
+	keptB, okKB := keptOrNone(cylinderSideSolidSplit(fB, cylB, bandB, imprint, Intersection, true, insideA))
+	if !okKA || !okKB {
+		return nil, false
+	}
+	return curvedStitch(append(keptA, keptB...)), true
+}
+
 // ConeCylinderIntersectGeneral is the exported entry kernel/ops routes cone∩cylinder intersect through: the
 // GENERAL curved∩curved pipeline (#1403), no bespoke loop→body constructor. ok=false outside the wired
 // frustum-through-cylinder case so the caller keeps its fallback.

--- a/kernel/brep/curved_general_boolean_test.go
+++ b/kernel/brep/curved_general_boolean_test.go
@@ -179,3 +179,32 @@ func TestConeCylinderIntersectGeneralDeclines(t *testing.T) {
 		t.Error("two cylinders should decline from the cone∩cylinder general path")
 	}
 }
+
+// TestCrossingCylinderIntersectGeneral: two crossing cylinders through the general pipeline yield a
+// watertight three-cylinder solid (rod band + two fat lens caps) — the simplest, fully symmetric pair
+// (both sides cylinders), the third EPIC #1403 migration and the largest bespoke handler replaced.
+func TestCrossingCylinderIntersectGeneral(t *testing.T) {
+	rod, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
+	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	res, ok := crossingCylinderIntersectGeneral(rod, fat, nil)
+	if !ok {
+		t.Fatal("general crossing-cylinder declined; want the three-face intersection")
+	}
+	assertWatertight(t, res)
+	cones, cyls, planes := faceTypeCounts(t, res)
+	if cones != 0 || cyls != 3 || planes != 0 {
+		t.Errorf("got %d cone + %d cyl + %d plane faces, want 3 cylinders (rod band + 2 lens caps)", cones, cyls, planes)
+	}
+	if _, ok := CrossingCylinderIntersectGeneral(fat, rod, nil); !ok {
+		t.Error("crossing cylinders should resolve with the fat passed first too")
+	}
+}
+
+// TestCrossingCylinderIntersectGeneralDeclines: a cone and a cylinder are not the crossing-cylinder case.
+func TestCrossingCylinderIntersectGeneralDeclines(t *testing.T) {
+	cone, _ := SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
+	cyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	if _, ok := CrossingCylinderIntersectGeneral(cone, cyl, nil); ok {
+		t.Error("cone+cylinder should decline from the crossing-cylinder general path")
+	}
+}

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -22,6 +22,12 @@ func curvedCrossingIntersect(op PartFeatureOperation, target, tool *topo.Body, r
 	if op != Intersect {
 		return nil, false
 	}
+	// EPIC #1403: route crossing-cylinder intersect through the GENERAL pipeline first (no bespoke
+	// loop→body constructor); the hand-built CrossingCylinderIntersect stays as a fallback so no OCC case
+	// regresses.
+	if res, ok := brep.CrossingCylinderIntersectGeneral(target, tool, rec); ok && validBooleanSolid(res) {
+		return res, true
+	}
 	res, ok := brep.CrossingCylinderIntersect(target, tool, rec)
 	if !ok || !validBooleanSolid(res) {
 		return nil, false


### PR DESCRIPTION
## What & why

**Advances EPIC #1403** (third migration; does not close it). Replaces the **largest** bespoke handler
(`curved_crossing_intersect.go`'s `stitchRodWithSaddleCaps`) on the intersect side.

Two crossing cylinders is the simplest, fully symmetric pair — both operands are cylinders, so both sides
use the same cylinder solid-membership trim with **no rod/fat identification**. The rod-wall band inside the
fat plus the two fat-wall lens caps fall out of the same two-sided `trimByImprint` + `curvedStitch`. No new
machinery beyond the driver itself (membership + cylinder-side split already landed in the cone∩cylinder PR).

`kernel/ops` routes crossing-cylinder intersect through `CrossingCylinderIntersectGeneral` first; the bespoke
`CrossingCylinderIntersect` stays as a fallback, so no OCC matrix case regresses.

## Verification

- **OCC volume oracle**: crossing cylinders ∩ `ours=40.02` vs `occ=41.04`, **rel=0.025 < 0.05**.
- **Structural**: watertight three-cylinder solid (rod band + 2 lens caps), order-independent
  (`TestCrossingCylinderIntersectGeneral`).
- **No regression**: no-CSG exactness suite + full kernel suite green; new code >80% covered; lint/gofmt clean.

## Scope

Three intersect pairs now on the general pipeline (cone∩cone, cone∩cylinder, crossing-cylinder). The
remaining special-topology intersects (Steinmetz, partial penetration) and the cut/join operations are
follow-up PRs under the EPIC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)