### PR TITLE
brep(boolean): route crossing-cylinder subtract through the general pipeline (#1403)

### DIFF
--- a/kernel/brep/curved_general_boolean.go
+++ b/kernel/brep/curved_general_boolean.go
@@ -171,6 +171,87 @@ func polylineCurves(loops []geom.Polyline) []geom.Curve3 {
 	return out
 }
 
+// planarCapFaces returns a body's planar (cap) faces as curvedFaces, kept WHOLE — for a clean side-breach
+// cut the breach never reaches a cap, so the target's caps survive untouched in the result (#1403).
+func planarCapFaces(b *topo.Body) []curvedFace {
+	var caps []curvedFace
+	for _, f := range facesOfAny(b) {
+		if _, isPlane := f.surface.(geom.Plane); isPlane {
+			caps = append(caps, f)
+		}
+	}
+	return caps
+}
+
+// reverseCurvedFaces flips each face's sense so it bounds the CAVITY a Difference carves: the tool's surface
+// inside the target, re-faced inward (AddReversedFace). curvedStitch then welds it to the target side along
+// the shared imprint, the cut wall opposite the surviving material (#1403).
+func reverseCurvedFaces(faces []curvedFace) []curvedFace {
+	out := make([]curvedFace, len(faces))
+	for i, f := range faces {
+		f.reversed = !f.reversed
+		out[i] = f
+	}
+	return out
+}
+
+// loopsClearOfCaps reports whether every imprint point sits STRICTLY between the side band's two cap levels
+// (vMin, vMax) — a clean side-breach where the cut leaves both caps whole. A breach reaching a cap needs the
+// planar cap itself trimmed, which this first cut migration defers to the bespoke handler (#1403).
+func loopsClearOfCaps(side ruledUV, loops []geom.Polyline) bool {
+	margin := geom.ResolutionForSize(side.band.vMax - side.band.vMin).Plane()
+	for _, lp := range loops {
+		for _, p := range lp.Vertices {
+			v := float64(side.base.VectorTo(p).Dot(side.axis))
+			if v < side.band.vMin+margin || v > side.band.vMax-margin {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// CrossingCylinderCutGeneral is the exported entry kernel/ops routes crossing-cylinder subtract through: the
+// GENERAL curved∩curved pipeline (#1403). target − tool drills a tunnel through the target: the target side
+// kept OUTSIDE the tool (the breached wall), the target's caps whole, and the tool side kept INSIDE the
+// target and reversed (the tunnel wall). ok=false outside the wired clean-side-breach crossing.
+func CrossingCylinderCutGeneral(target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	loops, ok := crossingCylinderImprint(target, tool, rec)
+	if !ok || len(loops) != 2 {
+		return nil, false
+	}
+	fA, cylA, bandA, okA := cylinderSideFace(target)
+	fB, cylB, bandB, okB := cylinderSideFace(tool)
+	insideA, okMA := curvedSolidMembership(target)
+	insideB, okMB := curvedSolidMembership(tool)
+	if !okA || !okB || !okMA || !okMB {
+		return nil, false
+	}
+	// Clean side-breach only: the tool must breach the target's SIDE between its caps (so the caps stay
+	// whole) and not reach the tool's own caps inside the target (a full crossing, both loops on the side).
+	if !loopsClearOfCaps(newCylinderUVSolid(cylA, bandA, Difference, false, insideB), loops) {
+		return nil, false
+	}
+	imprint := polylineCurves(loops)
+	keptA, okKA := keptOrNone(cylinderSideSolidSplit(fA, cylA, bandA, imprint, Difference, false, insideB))
+	keptB, okKB := keptOrNone(cylinderSideSolidSplit(fB, cylB, bandB, imprint, Difference, true, insideA))
+	if !okKA || !okKB {
+		return nil, false
+	}
+	return curvedStitch(cutFaces(keptA, target, keptB)), true
+}
+
+// cutFaces assembles a Difference result's boundary: the target's breached wall (kept outside the tool), the
+// target's whole caps (clean side-breach), and the tool's wall inside the target reversed into the cavity
+// (the tunnel/cut wall) — #1403.
+func cutFaces(targetWall []curvedFace, target *topo.Body, toolWall []curvedFace) []curvedFace {
+	faces := make([]curvedFace, 0, len(targetWall)+len(toolWall)+2)
+	faces = append(faces, targetWall...)
+	faces = append(faces, planarCapFaces(target)...)
+	faces = append(faces, reverseCurvedFaces(toolWall)...)
+	return faces
+}
+
 // CrossingCylinderIntersectGeneral is the exported entry kernel/ops routes crossing-cylinder intersect
 // through: the GENERAL curved∩curved pipeline (#1403), no bespoke loop→body constructor. ok=false outside
 // the wired cylinder-through-cylinder crossing so the caller keeps its fallback.

--- a/kernel/brep/curved_general_boolean_test.go
+++ b/kernel/brep/curved_general_boolean_test.go
@@ -208,3 +208,39 @@ func TestCrossingCylinderIntersectGeneralDeclines(t *testing.T) {
 		t.Error("cone+cylinder should decline from the crossing-cylinder general path")
 	}
 }
+
+// TestCrossingCylinderCutGeneral: target − tool (fat drilled by a crossing rod) through the general pipeline
+// yields a watertight solid — the breached fat side, its two whole caps, and the reversed rod tunnel wall.
+// This is the first CUT migration (#1403): it adds surviving planar caps + cut-wall face reversal.
+func TestCrossingCylinderCutGeneral(t *testing.T) {
+	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	rod, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
+	res, ok := CrossingCylinderCutGeneral(fat, rod, nil)
+	if !ok {
+		t.Fatal("general crossing-cylinder cut declined; want the drilled solid")
+	}
+	assertWatertight(t, res)
+	cones, cyls, planes := faceTypeCounts(t, res)
+	if cones != 0 || cyls != 2 || planes != 2 {
+		t.Errorf("got %d cone + %d cyl + %d plane faces, want 2 cyl (breached fat + rod tunnel) + 2 plane (fat caps)", cones, cyls, planes)
+	}
+}
+
+// TestReverseCurvedFaces: reversing flips the face sense (the cut wall faces into the cavity).
+func TestReverseCurvedFaces(t *testing.T) {
+	in := []curvedFace{{reversed: false}, {reversed: true}}
+	out := reverseCurvedFaces(in)
+	if !out[0].reversed || out[1].reversed {
+		t.Errorf("reverseCurvedFaces sense = {%v,%v}, want {true,false}", out[0].reversed, out[1].reversed)
+	}
+}
+
+// TestCrossingCylinderCutGeneralDeclines: a non-crossing pair (parallel, no imprint) declines so kernel/ops
+// keeps its fallback.
+func TestCrossingCylinderCutGeneralDeclines(t *testing.T) {
+	a, _ := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 12)
+	b, _ := SolidCylinder(math.P3(20, 0, 0), math.V3(0, 0, 1), 1.5, 12) // far apart, no intersection
+	if _, ok := CrossingCylinderCutGeneral(a, b, nil); ok {
+		t.Error("non-intersecting cylinders should decline from the cut general path")
+	}
+}

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -258,6 +258,12 @@ func curvedCrossingCut(op PartFeatureOperation, target, tool *topo.Body, rec *di
 	if op != Cut {
 		return nil, false
 	}
+	// EPIC #1403: route crossing-cylinder subtract through the GENERAL pipeline first (no bespoke
+	// loop→body constructor); the hand-built CrossingCylinderCut stays as a fallback for the cases the
+	// general path declines (a breach reaching a cap, a partial penetration), so no OCC case regresses.
+	if res, ok := brep.CrossingCylinderCutGeneral(target, tool, rec); ok && validBooleanSolid(res) {
+		return res, true
+	}
 	res, ok := brep.CrossingCylinderCut(target, tool, rec)
 	if !ok || !validBooleanSolid(res) {
 		return nil, false


### PR DESCRIPTION
## What & why

**Advances EPIC #1403** (first CUT migration; does not close it). The three intersect migrations were
special — the operands' caps were entirely excluded from the result. The cut/join families are not: this PR
establishes the **cut template** they need — **surviving planar caps** + **cut-wall face reversal**.

## How

`target − tool` (a fat cylinder drilled by a crossing rod) now runs the general pipeline:
- the **target side** trimmed keep-**outside** the tool (the breached wall);
- the target's **end caps** kept **whole** — a clean side-breach never reaches them;
- the **tool side** trimmed keep-**inside** the target and **reversed** so it bounds the cavity (the tunnel
  wall, opposite the surviving material);
- welded by `curvedStitch`.

New helpers, reusable for the rest of the cut/join family: `planarCapFaces`, `reverseCurvedFaces`,
`loopsClearOfCaps` (the clean-side-breach guard), `cutFaces` (assemble a Difference boundary).

`kernel/ops` routes crossing-cylinder cut through `CrossingCylinderCutGeneral` first; the bespoke
`CrossingCylinderCut` stays as a fallback (a breach reaching a cap, a partial penetration), so no OCC case
regresses.

## Verification

- **OCC volume oracle**: crossing cylinders − (drill) `ours=289.39` vs `occ=298.25`, **rel=0.030 < 0.05**.
- **Structural**: watertight drilled solid — 2 cylinder faces (breached fat + rod tunnel) + 2 planar caps
  (`TestCrossingCylinderCutGeneral`).
- **No regression**: no-CSG exactness suite + full kernel suite green; new code >80% covered; lint/gofmt clean.

## Scope

Four pairs/ops now on the general pipeline (three intersect crossings + crossing-cylinder cut). The cut
template (caps + reversal) now generalizes to the cone∩cone / cone∩cylinder cuts and, with the union
keep-table, the join family — follow-up PRs under the EPIC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)