### PR TITLE
brep(boolean): route crossing-cylinder JOIN through the general pipeline (#1403)

### DIFF
--- a/kernel/brep/curved_general_boolean.go
+++ b/kernel/brep/curved_general_boolean.go
@@ -211,30 +211,52 @@ func loopsClearOfCaps(side ruledUV, loops []geom.Polyline) bool {
 	return true
 }
 
+// crossingSide bundles everything a crossing-cylinder general boolean needs about ONE operand: its cylinder
+// side face, the rim band, the geom.Cylinder, and a 3D solid-membership oracle for it. Both the cut and the
+// join trim one side against the OTHER side's `inside` oracle (#1403).
+type crossingSide struct {
+	face   curvedFace
+	cyl    geom.Cylinder
+	band   coneSideBand_
+	inside func(math.Point3) bool
+}
+
+// crossingCylinderSides resolves the shared inputs every crossing-cylinder general boolean (cut, join)
+// starts from: the SSI imprint (exactly two closed loops for a clean rod-through-fat crossing) and, for each
+// operand, its cylinder side face + rim band + solid-membership oracle. ok=false when the pair is not two
+// bare cylinders meeting in two closed loops, so each caller keeps its bespoke fallback (#1403).
+func crossingCylinderSides(a, b *topo.Body, rec *diag.Recorder) ([]geom.Polyline, crossingSide, crossingSide, bool) {
+	loops, ok := crossingCylinderImprint(a, b, rec)
+	if !ok || len(loops) != 2 {
+		return nil, crossingSide{}, crossingSide{}, false
+	}
+	fA, cylA, bandA, okA := cylinderSideFace(a)
+	fB, cylB, bandB, okB := cylinderSideFace(b)
+	insideA, okMA := curvedSolidMembership(a)
+	insideB, okMB := curvedSolidMembership(b)
+	if !okA || !okB || !okMA || !okMB {
+		return nil, crossingSide{}, crossingSide{}, false
+	}
+	return loops, crossingSide{fA, cylA, bandA, insideA}, crossingSide{fB, cylB, bandB, insideB}, true
+}
+
 // CrossingCylinderCutGeneral is the exported entry kernel/ops routes crossing-cylinder subtract through: the
 // GENERAL curved∩curved pipeline (#1403). target − tool drills a tunnel through the target: the target side
 // kept OUTSIDE the tool (the breached wall), the target's caps whole, and the tool side kept INSIDE the
 // target and reversed (the tunnel wall). ok=false outside the wired clean-side-breach crossing.
 func CrossingCylinderCutGeneral(target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	loops, ok := crossingCylinderImprint(target, tool, rec)
-	if !ok || len(loops) != 2 {
-		return nil, false
-	}
-	fA, cylA, bandA, okA := cylinderSideFace(target)
-	fB, cylB, bandB, okB := cylinderSideFace(tool)
-	insideA, okMA := curvedSolidMembership(target)
-	insideB, okMB := curvedSolidMembership(tool)
-	if !okA || !okB || !okMA || !okMB {
+	loops, tgt, tl, ok := crossingCylinderSides(target, tool, rec)
+	if !ok {
 		return nil, false
 	}
 	// Clean side-breach only: the tool must breach the target's SIDE between its caps (so the caps stay
 	// whole) and not reach the tool's own caps inside the target (a full crossing, both loops on the side).
-	if !loopsClearOfCaps(newCylinderUVSolid(cylA, bandA, Difference, false, insideB), loops) {
+	if !loopsClearOfCaps(newCylinderUVSolid(tgt.cyl, tgt.band, Difference, false, tl.inside), loops) {
 		return nil, false
 	}
 	imprint := polylineCurves(loops)
-	keptA, okKA := keptOrNone(cylinderSideSolidSplit(fA, cylA, bandA, imprint, Difference, false, insideB))
-	keptB, okKB := keptOrNone(cylinderSideSolidSplit(fB, cylB, bandB, imprint, Difference, true, insideA))
+	keptA, okKA := keptOrNone(cylinderSideSolidSplit(tgt.face, tgt.cyl, tgt.band, imprint, Difference, false, tl.inside))
+	keptB, okKB := keptOrNone(cylinderSideSolidSplit(tl.face, tl.cyl, tl.band, imprint, Difference, true, tgt.inside))
 	if !okKA || !okKB {
 		return nil, false
 	}
@@ -249,6 +271,45 @@ func cutFaces(targetWall []curvedFace, target *topo.Body, toolWall []curvedFace)
 	faces = append(faces, targetWall...)
 	faces = append(faces, planarCapFaces(target)...)
 	faces = append(faces, reverseCurvedFaces(toolWall)...)
+	return faces
+}
+
+// CrossingCylinderJoinGeneral is the exported entry kernel/ops routes crossing-cylinder JOIN through: the
+// GENERAL curved∩curved pipeline (#1403). target ∪ tool is the union of two crossing cylinders (a fat
+// cylinder side-breached by a rod passing right through it): each side keeps the part OUTSIDE the other
+// (the Union keep-table — the fat's holed wall plus the two rod stubs sticking out), and BOTH bodies keep
+// their caps whole. It is the cut's sibling with NO face reversal (a union's walls keep their outward sense)
+// and the tool's caps surviving too. ok=false outside the wired clean-side-breach crossing.
+func CrossingCylinderJoinGeneral(a, b *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	loops, sa, sb, ok := crossingCylinderSides(a, b, rec)
+	if !ok {
+		return nil, false
+	}
+	// Both bodies keep their caps whole, so the breach must lie strictly between EACH body's caps — a rod
+	// passing fully through a fat cylinder and sticking out each side (a breach that reaches a cap would need
+	// that planar cap trimmed, which this migration defers to the bespoke handler).
+	if !loopsClearOfCaps(newCylinderUVSolid(sa.cyl, sa.band, Union, false, sb.inside), loops) ||
+		!loopsClearOfCaps(newCylinderUVSolid(sb.cyl, sb.band, Union, true, sa.inside), loops) {
+		return nil, false
+	}
+	imprint := polylineCurves(loops)
+	keptA, okKA := keptOrNone(cylinderSideSolidSplit(sa.face, sa.cyl, sa.band, imprint, Union, false, sb.inside))
+	keptB, okKB := keptOrNone(cylinderSideSolidSplit(sb.face, sb.cyl, sb.band, imprint, Union, true, sa.inside))
+	if !okKA || !okKB {
+		return nil, false
+	}
+	return curvedStitch(joinFaces(keptA, a, keptB, b)), true
+}
+
+// joinFaces assembles a Union result's boundary: each operand's wall kept outside the other (the fat's holed
+// wall + the rod's two protruding stubs) plus BOTH operands' whole caps. Unlike the cut neither wall is
+// reversed — a union keeps every kept wall facing outward — and both bodies contribute their caps (#1403).
+func joinFaces(wallA []curvedFace, a *topo.Body, wallB []curvedFace, b *topo.Body) []curvedFace {
+	faces := make([]curvedFace, 0, len(wallA)+len(wallB)+4)
+	faces = append(faces, wallA...)
+	faces = append(faces, planarCapFaces(a)...)
+	faces = append(faces, wallB...)
+	faces = append(faces, planarCapFaces(b)...)
 	return faces
 }
 

--- a/kernel/brep/curved_general_boolean_test.go
+++ b/kernel/brep/curved_general_boolean_test.go
@@ -226,6 +226,59 @@ func TestCrossingCylinderCutGeneral(t *testing.T) {
 	}
 }
 
+// TestCrossingCylinderJoinGeneral: target ∪ tool (fat side-breached by a crossing rod) through the general
+// pipeline yields a watertight solid — the fat's holed wall, the two rod stubs, and BOTH bodies' whole caps.
+// This is the first JOIN migration (#1403): it reuses the cut's caps machinery but keeps both walls outward
+// (no reversal) and contributes the tool's caps too.
+func TestCrossingCylinderJoinGeneral(t *testing.T) {
+	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	rod, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
+	res, ok := CrossingCylinderJoinGeneral(fat, rod, nil)
+	if !ok {
+		t.Fatal("general crossing-cylinder join declined; want the welded solid")
+	}
+	assertWatertight(t, res)
+	cones, cyls, planes := faceTypeCounts(t, res)
+	// 2 cyl: the fat's holed wall (one connected band, 2 lens holes), and the rod's wall — which the general
+	// path keeps as ONE face carrying BOTH stubs (bottom-rim + two lens loops + top-rim), the disjoint stubs
+	// separated by the dropped middle band via trim winding (kept between rim↔lens, dropped between the two
+	// lenses). The volume sits UNDER OCC (chord deficit only), confirming the middle is correctly excluded.
+	// The bespoke handler splits this into two stub faces; the general path's compact 1-face form is an
+	// equally valid watertight manifold (#1403). 4 plane: 2 fat caps + 2 rod caps, all whole.
+	if cones != 0 || cyls != 2 || planes != 4 {
+		t.Errorf("got %d cone + %d cyl + %d plane faces, want 2 cyl (holed fat + rod both-stubs) + 4 plane (2 fat + 2 rod caps)", cones, cyls, planes)
+	}
+}
+
+// TestCrossingCylinderJoinGeneralDeclines: a non-crossing pair (far apart, no imprint) declines so kernel/ops
+// keeps its fallback.
+func TestCrossingCylinderJoinGeneralDeclines(t *testing.T) {
+	a, _ := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 12)
+	b, _ := SolidCylinder(math.P3(20, 0, 0), math.V3(0, 0, 1), 1.5, 12) // far apart, no intersection
+	if _, ok := CrossingCylinderJoinGeneral(a, b, nil); ok {
+		t.Error("non-intersecting cylinders should decline from the join general path")
+	}
+}
+
+// TestJoinFacesAssembly: the union assembly keeps both walls outward (no reversal) and contributes both
+// bodies' caps — distinct from the cut, which reverses the tool wall and drops the tool's caps.
+func TestJoinFacesAssembly(t *testing.T) {
+	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	rod, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
+	wallA := []curvedFace{{reversed: false}}
+	wallB := []curvedFace{{reversed: false}}
+	faces := joinFaces(wallA, fat, wallB, rod)
+	for i, f := range faces {
+		if f.reversed {
+			t.Errorf("joinFaces[%d] reversed=true, want all walls/caps outward (union keeps outward sense)", i)
+		}
+	}
+	// 1 wallA + 2 fat caps + 1 wallB + 2 rod caps = 6 faces.
+	if len(faces) != 6 {
+		t.Errorf("joinFaces produced %d faces, want 6 (1 wallA + 2 fat caps + 1 wallB + 2 rod caps)", len(faces))
+	}
+}
+
 // TestReverseCurvedFaces: reversing flips the face sense (the cut wall faces into the cavity).
 func TestReverseCurvedFaces(t *testing.T) {
 	in := []curvedFace{{reversed: false}, {reversed: true}}

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -292,6 +292,12 @@ func curvedCrossingJoin(op PartFeatureOperation, target, tool *topo.Body, rec *d
 	if op != Join {
 		return nil, false
 	}
+	// EPIC #1403: route crossing-cylinder JOIN through the GENERAL pipeline first (no bespoke loop→body
+	// constructor); the hand-built CrossingCylinderJoin stays as a fallback for the cases the general path
+	// declines (a breach reaching a cap, equal radii), so no OCC case regresses.
+	if res, ok := brep.CrossingCylinderJoinGeneral(target, tool, rec); ok && validBooleanSolid(res) {
+		return res, true
+	}
 	res, ok := brep.CrossingCylinderJoin(target, tool, rec)
 	if !ok || !validBooleanSolid(res) {
 		return nil, false


### PR DESCRIPTION
## What

Routes the **crossing-cylinder JOIN** (`fat ∪ rod`) through the GENERAL curved∩curved pipeline (SSI → `trimByImprint` → solid-membership → `curvedStitch`), instead of the bespoke `CrossingCylinderJoin` loop→body constructor. This is the **first JOIN migration** of EPIC #1403 (after the intersect family and the first cut).

## Why

The EPIC replaces ~21 bespoke per-pair curved handlers with one general pipeline. The join completes the boolean *operation* trio for crossing cylinders (∩ #1466, − #1467, ∪ here) on the same machinery, proving the pipeline handles the Union keep-table.

## How it works

- **Union keep-table** (`keep(Union, …) = !inside`): each operand's wall keeps the part **outside** the other — the fat's holed wall + the rod's two protruding stubs — and **both** bodies keep their caps whole.
- The cut's sibling: **no face reversal** (a union keeps every wall facing outward) and the tool's caps survive too, assembled by a new `joinFaces` (vs the cut's `cutFaces`, which reverses the tool wall and drops its caps).
- The shared crossing-cylinder preamble (imprint + both side faces + membership oracles) is extracted into **`crossingCylinderSides`**, now used by both the cut and the join — removes the duplicated setup (CLAUDE.md: extract shared logic).
- The rod's two stubs come out as one cylindrical face carrying both (4 loops: 2 rod-cap rims + 2 lens loops); the trim winding meshes them as two stubs with the middle correctly excluded. A valid watertight manifold; the bespoke splits into two faces but the compact form is equally correct.

The bespoke `CrossingCylinderJoin` stays as a **fallback** for the cases the general path declines (a breach reaching a cap, equal-radius Steinmetz), so no OCC case regresses.

## Validation

- **OCC `getMass` oracle**: `crossing cylinders ∪` ours=372.89 vs OCC=383.07, **rel 0.0266 < 0.05** ✅
- **Watertight** (every edge used exactly twice) ✅
- **StayExact** (no CSG demotion) ✅
- Full `kernel/brep` + `kernel/ops` suites green; lint/gofmt/vet clean; new code >80% coverage.
- **Live offscreen render** of the real `ops.Boolean(Join)` path — shaded + Normal-Debug both clean (all faces front-facing, fold-free union).

Advances #1403 (the EPIC stays open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)