### PR TITLE
brep(boolean): fix imprint weld so the general INTERSECT path is actually adopted (#1403)

### DIFF
--- a/kernel/brep/curved_general_boolean.go
+++ b/kernel/brep/curved_general_boolean.go
@@ -240,10 +240,14 @@ func crossingCylinderSides(a, b *topo.Body, rec *diag.Recorder) ([]geom.Polyline
 	return loops, crossingSide{fA, cylA, bandA, insideA}, crossingSide{fB, cylB, bandB, insideB}, true
 }
 
-// CrossingCylinderCutGeneral is the exported entry kernel/ops routes crossing-cylinder subtract through: the
-// GENERAL curved∩curved pipeline (#1403). target − tool drills a tunnel through the target: the target side
-// kept OUTSIDE the tool (the breached wall), the target's caps whole, and the tool side kept INSIDE the
-// target and reversed (the tunnel wall). ok=false outside the wired clean-side-breach crossing.
+// CrossingCylinderCutGeneral builds target − tool through the GENERAL curved∩curved pipeline (#1403): the
+// target side kept OUTSIDE the tool (the breached wall), the target's caps whole, and the tool side kept
+// INSIDE the target and reversed (the tunnel wall).
+//
+// NOT WIRED — known broken (Oblikovati#1476): the OUTSIDE-keep wall meshes the WRONG region, so the result is
+// orientation-inconsistent or wrong-volume and validBooleanSolid rejects it. kernel/ops keeps crossing-cylinder
+// subtract on the bespoke CrossingCylinderCut until #1476 fixes the arrangement winding. Retained as the
+// scaffolding that fix builds on; the brep test only checks its edge-count/face structure, not correctness.
 func CrossingCylinderCutGeneral(target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	loops, tgt, tl, ok := crossingCylinderSides(target, tool, rec)
 	if !ok {
@@ -274,12 +278,14 @@ func cutFaces(targetWall []curvedFace, target *topo.Body, toolWall []curvedFace)
 	return faces
 }
 
-// CrossingCylinderJoinGeneral is the exported entry kernel/ops routes crossing-cylinder JOIN through: the
-// GENERAL curved∩curved pipeline (#1403). target ∪ tool is the union of two crossing cylinders (a fat
-// cylinder side-breached by a rod passing right through it): each side keeps the part OUTSIDE the other
-// (the Union keep-table — the fat's holed wall plus the two rod stubs sticking out), and BOTH bodies keep
-// their caps whole. It is the cut's sibling with NO face reversal (a union's walls keep their outward sense)
-// and the tool's caps surviving too. ok=false outside the wired clean-side-breach crossing.
+// CrossingCylinderJoinGeneral builds target ∪ tool through the GENERAL curved∩curved pipeline (#1403): each
+// side keeps the part OUTSIDE the other (the Union keep-table — the fat's holed wall plus the two rod stubs),
+// and BOTH bodies keep their caps whole. The cut's sibling with NO face reversal.
+//
+// NOT WIRED — known broken (Oblikovati#1476): with the imprint weld fixed this now passes validBooleanSolid
+// but meshes the WRONG region (∪ volume 194 vs 383), so adopting it would be worse than the bespoke result.
+// kernel/ops keeps crossing-cylinder JOIN on the bespoke CrossingCylinderJoin until #1476 fixes the OUTSIDE-keep
+// arrangement winding. Retained as scaffolding; the brep test only checks its edge-count/face structure.
 func CrossingCylinderJoinGeneral(a, b *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	loops, sa, sb, ok := crossingCylinderSides(a, b, rec)
 	if !ok {

--- a/kernel/brep/curved_general_boolean_test.go
+++ b/kernel/brep/curved_general_boolean_test.go
@@ -209,9 +209,12 @@ func TestCrossingCylinderIntersectGeneralDeclines(t *testing.T) {
 	}
 }
 
-// TestCrossingCylinderCutGeneral: target − tool (fat drilled by a crossing rod) through the general pipeline
-// yields a watertight solid — the breached fat side, its two whole caps, and the reversed rod tunnel wall.
-// This is the first CUT migration (#1403): it adds surviving planar caps + cut-wall face reversal.
+// TestCrossingCylinderCutGeneral checks the STRUCTURE the general cut builder emits — its face composition and
+// edge-USE-COUNT (every edge used twice). It does NOT assert orientation/region correctness: this builder is
+// known broken (Oblikovati#1476, the OUTSIDE-keep region bug) and is NOT wired into kernel/ops — crossing-
+// cylinder subtract stays on the bespoke handler. Orientation/volume are validated in ops (TestGeneral...
+// IsAdopted covers the intersect path; cut/join join that guard once #1476 lands). Edge-count watertightness
+// alone is exactly what masked the silent fallback, so this is intentionally scoped to structure (#1403).
 func TestCrossingCylinderCutGeneral(t *testing.T) {
 	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
 	rod, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
@@ -226,10 +229,11 @@ func TestCrossingCylinderCutGeneral(t *testing.T) {
 	}
 }
 
-// TestCrossingCylinderJoinGeneral: target ∪ tool (fat side-breached by a crossing rod) through the general
-// pipeline yields a watertight solid — the fat's holed wall, the two rod stubs, and BOTH bodies' whole caps.
-// This is the first JOIN migration (#1403): it reuses the cut's caps machinery but keeps both walls outward
-// (no reversal) and contributes the tool's caps too.
+// TestCrossingCylinderJoinGeneral checks the STRUCTURE the general join builder emits (face composition +
+// edge-use counts), NOT orientation/region correctness: this builder is known broken (Oblikovati#1476 — it
+// meshes the wrong region, ∪ volume 194 vs 383) and is NOT wired into kernel/ops; crossing-cylinder JOIN stays
+// on the bespoke handler. Scoped to structure on purpose — edge-count watertightness is what masked the silent
+// fallback, so correctness is asserted in ops once #1476 lands (#1403).
 func TestCrossingCylinderJoinGeneral(t *testing.T) {
 	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
 	rod, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)

--- a/kernel/brep/curved_halfspace_uv_arrangement.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement.go
@@ -952,7 +952,18 @@ func emitImprintRun(run []recoveredEdge) (loopEdge, bool) {
 		}
 		tEnd = prev
 		if lo, hi := curve.Domain(); stdmath.Abs(tEnd-t0) >= (hi-lo)-1e-6 {
-			return loopEdge{curve: curve, t0: lo, t1: hi}, true // the whole closed curve
+			// The whole closed curve, but KEEP the run's traversal sense: a boundary walked in the curve's
+			// DECREASING-parameter direction re-emits as [hi, lo], not [lo, hi]. Discarding the sign made the
+			// two walls of a general curved∩curved boolean emit a SHARED imprint loop identically, so the weld
+			// saw the same orientation on both faces (curvedStitch orients a closed edge by t1<t0) and the
+			// solid failed the orientation check — silently rejected by validBooleanSolid, falling back to the
+			// bespoke handler. The two walls walk the shared loop in OPPOSITE senses, so preserving the sign
+			// welds them consistently. A half-space cut keeps the forward sense it always had (its single kept
+			// region walks the closed section forward), so those paths are unchanged (#1403).
+			if tEnd < t0 {
+				return loopEdge{curve: curve, t0: hi, t1: lo}, true
+			}
+			return loopEdge{curve: curve, t0: lo, t1: hi}, true
 		}
 	}
 	return loopEdge{curve: curve, t0: t0, t1: tEnd}, true

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -258,12 +258,10 @@ func curvedCrossingCut(op PartFeatureOperation, target, tool *topo.Body, rec *di
 	if op != Cut {
 		return nil, false
 	}
-	// EPIC #1403: route crossing-cylinder subtract through the GENERAL pipeline first (no bespoke
-	// loop→body constructor); the hand-built CrossingCylinderCut stays as a fallback for the cases the
-	// general path declines (a breach reaching a cap, a partial penetration), so no OCC case regresses.
-	if res, ok := brep.CrossingCylinderCutGeneral(target, tool, rec); ok && validBooleanSolid(res) {
-		return res, true
-	}
+	// EPIC #1403: the general ruled CUT (brep.CrossingCylinderCutGeneral) is NOT wired here yet — it produces
+	// an orientation-inconsistent or wrong-region solid that validBooleanSolid rejects (the OUTSIDE-keep region
+	// bug, Oblikovati#1476), so it would only ever fall back. Kept on the bespoke handler until that lands; the
+	// intersect general path IS adopted now that the imprint weld is fixed.
 	res, ok := brep.CrossingCylinderCut(target, tool, rec)
 	if !ok || !validBooleanSolid(res) {
 		return nil, false
@@ -292,12 +290,10 @@ func curvedCrossingJoin(op PartFeatureOperation, target, tool *topo.Body, rec *d
 	if op != Join {
 		return nil, false
 	}
-	// EPIC #1403: route crossing-cylinder JOIN through the GENERAL pipeline first (no bespoke loop→body
-	// constructor); the hand-built CrossingCylinderJoin stays as a fallback for the cases the general path
-	// declines (a breach reaching a cap, equal radii), so no OCC case regresses.
-	if res, ok := brep.CrossingCylinderJoinGeneral(target, tool, rec); ok && validBooleanSolid(res) {
-		return res, true
-	}
+	// EPIC #1403: the general ruled JOIN (brep.CrossingCylinderJoinGeneral) is NOT wired here yet — with the
+	// imprint weld fixed it now passes validBooleanSolid but meshes the WRONG region (OUTSIDE-keep holed-wall
+	// bug, Oblikovati#1476: ∪ volume 194 vs 383), so adopting it would be worse than the bespoke result. Kept
+	// on the bespoke handler until #1476 lands.
 	res, ok := brep.CrossingCylinderJoin(target, tool, rec)
 	if !ok || !validBooleanSolid(res) {
 		return nil, false

--- a/kernel/ops/boolean_general_adoption_test.go
+++ b/kernel/ops/boolean_general_adoption_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// EPIC #1403 adoption guard. The general curved∩curved INTERSECT drivers must produce a solid that
+// validBooleanSolid ACCEPTS — i.e. one ops.Boolean actually adopts instead of silently discarding for the
+// bespoke fallback. This guard exists because every general migration shipped while the result was
+// orientation-inconsistent: validBooleanSolid rejected it and the bespoke handler did all the work, yet the
+// brep tests (edge-USE-COUNT "watertight" only) and the OCC oracle (run through the adopted = bespoke result)
+// all passed. The imprint weld fix (emitImprintRun keeps the closed-loop traversal sense) is what makes these
+// adopt; this test would have caught the silent fallback, and fails if it ever returns. The general CUT/JOIN
+// are NOT here: they still mesh the wrong region and stay on the bespoke handlers until Oblikovati#1476.
+func TestGeneralIntersectIsAdopted(t *testing.T) {
+	cases := []struct {
+		name    string
+		general func(a, b *topo.Body) (*topo.Body, bool)
+		a, b    func() *topo.Body
+	}{
+		{"crossing cylinders ∩",
+			func(a, b *topo.Body) (*topo.Body, bool) { return brep.CrossingCylinderIntersectGeneral(a, b, nil) },
+			func() *topo.Body { b, _ := brep.SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12); return b },
+			func() *topo.Body { b, _ := brep.SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12); return b }},
+		{"cone ∩ cone",
+			func(a, b *topo.Body) (*topo.Body, bool) { return brep.ConeConeIntersectGeneral(a, b, nil) },
+			func() *topo.Body {
+				b, _ := brep.SolidCylinderCone(math.P3(0, 0, -6), math.P3(0, 0, 6), 2, 4, "fat")
+				return b
+			},
+			func() *topo.Body {
+				b, _ := brep.SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 0.8, 1.5, "thin")
+				return b
+			}},
+		{"cone ∩ cylinder",
+			func(a, b *topo.Body) (*topo.Body, bool) { return brep.ConeCylinderIntersectGeneral(a, b, nil) },
+			func() *topo.Body { b, _ := brep.SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12); return b },
+			func() *topo.Body {
+				b, _ := brep.SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
+				return b
+			}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			res, ok := c.general(c.a(), c.b())
+			if !ok {
+				t.Fatalf("%s: general intersect declined; want the general path taken", c.name)
+			}
+			if r := Validate(res); !r.Valid {
+				t.Fatalf("%s: general result NOT adopted by validBooleanSolid (silent fallback): %+v", c.name, r)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## TL;DR

The EPIC #1403 general curved∩curved migrations were **silent no-ops** — every one was rejected by `validBooleanSolid` and fell back to the bespoke handler. This fixes the root-cause weld bug so the **general INTERSECT path is genuinely adopted** for the first time, and adds a guard so a silent fallback can't recur. The general CUT/JOIN remain broken (#1476) and are kept on bespoke.

## What was wrong

Every `kernel/ops` handler does `if ok && validBooleanSolid(general) { return general }` then falls back to bespoke. On clean develop, **every** general driver returned `ok=true` but `OrientationOK=false` → always rejected → the bespoke handler did 100% of the work. The OCC oracle and "live renders" all passed/looked-right because they were the *bespoke* result.

**Why it slipped through:** the brep tests assert `assertWatertight` = every edge used exactly twice (edge-*count* only); they never checked orientation consistency (`uses[0].Reversed()==uses[1].Reversed()`). A solid can be edge-count-watertight yet orientation-inconsistent.

## Root cause + fix

`emitImprintRun` re-emitted a **closed** imprint loop (the shared lens) always forward `[lo,hi]`, discarding the boundary run's traversal sense. Both welded walls then emitted the shared edge identically, so `curvedStitch` (which orients a closed edge by `t1<t0`) gave both faces the same sense → inconsistent. **Fix:** keep the run's sense — emit `[hi,lo]` when it walks the curve backward. The two walls walk the shared loop in opposite senses, so the weld is now consistent. Open imprint arcs already preserved direction; a half-space cut is unchanged (its single kept region walks the section forward).

## Result

The general **INTERSECT** is now adopted AND OCC-correct:

| case | ours | OCC | rel |
|---|---|---|---|
| crossing cylinders ∩ | 40.02 | 41.04 | 0.025 |
| cone ∩ cone | 24.29 | 24.60 | 0.012 |
| cone ∩ cylinder | 54.72 | 55.44 | 0.013 |

So #1464 / #1465 / #1466 genuinely take effect for the first time. A live offscreen render of the real `ops.Boolean(Intersect)` path confirms it — shaded clean, Normal-Debug all front-facing.

## What this does NOT do

The general **CUT/JOIN** are not made real here. The weld fix makes JOIN *valid but wrong-region* (∪ = 194 vs 383), and CUT stays invalid — the OUTSIDE-keep arrangement-winding bug, tracked in **#1476**. `curvedCrossingCut` / `curvedCrossingJoin` are reverted to bespoke-only so the broken general result is never adopted; their builders are retained (marked NOT WIRED) as scaffolding for #1476.

## Guard against recurrence

`TestGeneralIntersectIsAdopted` asserts the intersect general drivers produce a `validBooleanSolid` result — the check whose absence let the silent fallback ship. The cut/join brep tests are re-scoped to STRUCTURE only, with a note that correctness is validated in ops once #1476 lands.

Advances #1403. Relates to #1476.

🤖 Generated with [Claude Code](https://claude.com/claude-code)