### PR TITLE
brep(boolean): mesh the OUTSIDE-keep wrapping band, adopting general crossing cut/join (#1476)

### DIFF
--- a/kernel/brep/curved_general_boolean.go
+++ b/kernel/brep/curved_general_boolean.go
@@ -262,13 +262,10 @@ func crossingCylinderSides(a, b *topo.Body, rec *diag.Recorder) ([]geom.Polyline
 }
 
 // CrossingCylinderCutGeneral builds target − tool through the GENERAL curved∩curved pipeline (#1403): the
-// target side kept OUTSIDE the tool (the breached wall), the target's caps whole, and the tool side kept
-// INSIDE the target and reversed (the tunnel wall).
-//
-// NOT WIRED — known broken (Oblikovati#1476): the OUTSIDE-keep wall meshes the WRONG region, so the result is
-// orientation-inconsistent or wrong-volume and validBooleanSolid rejects it. kernel/ops keeps crossing-cylinder
-// subtract on the bespoke CrossingCylinderCut until #1476 fixes the arrangement winding. Retained as the
-// scaffolding that fix builds on; the brep test only checks its edge-count/face structure, not correctness.
+// target side kept OUTSIDE the tool (the breached wall, a keyhole-bridged holed tube), the target's caps whole,
+// and the tool side kept INSIDE the target and reversed (the tunnel wall). The OUTSIDE-keep wrapping-band
+// emission (Oblikovati#1476) makes it mesh the right region, so kernel/ops adopts it (validBooleanSolid passes,
+// OCC drill rel 0.030); the bespoke CrossingCylinderCut stays as the fallback for the cases this declines.
 func CrossingCylinderCutGeneral(target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	loops, tgt, tl, ok := crossingCylinderSides(target, tool, rec)
 	if !ok {
@@ -300,13 +297,10 @@ func cutFaces(targetWall []curvedFace, target *topo.Body, toolWall []curvedFace)
 }
 
 // CrossingCylinderJoinGeneral builds target ∪ tool through the GENERAL curved∩curved pipeline (#1403): each
-// side keeps the part OUTSIDE the other (the Union keep-table — the fat's holed wall plus the two rod stubs),
-// and BOTH bodies keep their caps whole. The cut's sibling with NO face reversal.
-//
-// NOT WIRED — known broken (Oblikovati#1476): with the imprint weld fixed this now passes validBooleanSolid
-// but meshes the WRONG region (∪ volume 194 vs 383), so adopting it would be worse than the bespoke result.
-// kernel/ops keeps crossing-cylinder JOIN on the bespoke CrossingCylinderJoin until #1476 fixes the OUTSIDE-keep
-// arrangement winding. Retained as scaffolding; the brep test only checks its edge-count/face structure.
+// side keeps the part OUTSIDE the other (the Union keep-table — the fat's keyhole-bridged holed wall plus the
+// two split rod stubs), and BOTH bodies keep their caps whole. The cut's sibling with NO face reversal. The
+// OUTSIDE-keep wrapping-band emission (Oblikovati#1476) makes it mesh the right region, so kernel/ops adopts it
+// (validBooleanSolid passes, OCC ∪ rel 0.026); the bespoke CrossingCylinderJoin stays as the fallback.
 func CrossingCylinderJoinGeneral(a, b *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	loops, sa, sb, ok := crossingCylinderSides(a, b, rec)
 	if !ok {

--- a/kernel/brep/curved_general_boolean.go
+++ b/kernel/brep/curved_general_boolean.go
@@ -183,16 +183,37 @@ func planarCapFaces(b *topo.Body) []curvedFace {
 	return caps
 }
 
-// reverseCurvedFaces flips each face's sense so it bounds the CAVITY a Difference carves: the tool's surface
-// inside the target, re-faced inward (AddReversedFace). curvedStitch then welds it to the target side along
-// the shared imprint, the cut wall opposite the surviving material (#1403).
+// reverseCurvedFaces flips each tool wall into the CAVITY a Difference carves: the sense flag (so the normal
+// points into the void) AND every loop's winding (so the boundary is walked the OTHER way). The tool keeps the
+// part INSIDE the target — a tunnel band whose imprint loop is walked the SAME way as the target's own hole —
+// so reversing the loop opposes them, the manifold-orientation a watertight cut needs (curvedStitch orients
+// each shared edge by its loop traversal, not the face sense). The tunnel is a ruled LOFT band
+// (twoClosedRimBandMesh), which lofts rim-to-rim regardless of winding, so the reversal does not change its
+// meshed region — only its orientation (#1403/#1476).
 func reverseCurvedFaces(faces []curvedFace) []curvedFace {
 	out := make([]curvedFace, len(faces))
 	for i, f := range faces {
 		f.reversed = !f.reversed
+		loops := make([]curvedLoop, len(f.loops))
+		for j, lp := range f.loops {
+			loops[j] = reverseCurvedLoop(lp)
+		}
+		f.loops = loops
 		out[i] = f
 	}
 	return out
+}
+
+// reverseCurvedLoop reverses a loop's traversal: each edge's direction (t0↔t1) and the edge order both flip,
+// so the loop walks the opposite way around the same boundary (#1476).
+func reverseCurvedLoop(lp curvedLoop) curvedLoop {
+	n := len(lp.edges)
+	rev := make([]loopEdge, n)
+	for i, e := range lp.edges {
+		e.t0, e.t1 = e.t1, e.t0
+		rev[n-1-i] = e
+	}
+	return curvedLoop{edges: rev}
 }
 
 // loopsClearOfCaps reports whether every imprint point sits STRICTLY between the side band's two cap levels

--- a/kernel/brep/curved_general_boolean_test.go
+++ b/kernel/brep/curved_general_boolean_test.go
@@ -229,11 +229,11 @@ func TestCrossingCylinderCutGeneral(t *testing.T) {
 	}
 }
 
-// TestCrossingCylinderJoinGeneral checks the STRUCTURE the general join builder emits (face composition +
-// edge-use counts), NOT orientation/region correctness: this builder is known broken (Oblikovati#1476 — it
-// meshes the wrong region, ∪ volume 194 vs 383) and is NOT wired into kernel/ops; crossing-cylinder JOIN stays
-// on the bespoke handler. Scoped to structure on purpose — edge-count watertightness is what masked the silent
-// fallback, so correctness is asserted in ops once #1476 lands (#1403).
+// TestCrossingCylinderJoinGeneral: target ∪ tool (fat side-breached by a crossing rod) through the general
+// pipeline yields the correct welded solid — the fat's holed wall (a keyhole-bridged tube), the two disjoint
+// rod stubs (split by connected band), and BOTH bodies' whole caps. The OUTSIDE-keep wrapping-band emission
+// (Oblikovati#1476) is what makes this mesh the right region; its volume is checked against OCC in ops
+// (TestCurvedBooleanVolumesMatchOCC, crossing ∪). Here we assert the watertight face structure (#1403/#1476).
 func TestCrossingCylinderJoinGeneral(t *testing.T) {
 	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
 	rod, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
@@ -243,14 +243,10 @@ func TestCrossingCylinderJoinGeneral(t *testing.T) {
 	}
 	assertWatertight(t, res)
 	cones, cyls, planes := faceTypeCounts(t, res)
-	// 2 cyl: the fat's holed wall (one connected band, 2 lens holes), and the rod's wall — which the general
-	// path keeps as ONE face carrying BOTH stubs (bottom-rim + two lens loops + top-rim), the disjoint stubs
-	// separated by the dropped middle band via trim winding (kept between rim↔lens, dropped between the two
-	// lenses). The volume sits UNDER OCC (chord deficit only), confirming the middle is correctly excluded.
-	// The bespoke handler splits this into two stub faces; the general path's compact 1-face form is an
-	// equally valid watertight manifold (#1403). 4 plane: 2 fat caps + 2 rod caps, all whole.
-	if cones != 0 || cyls != 2 || planes != 4 {
-		t.Errorf("got %d cone + %d cyl + %d plane faces, want 2 cyl (holed fat + rod both-stubs) + 4 plane (2 fat + 2 rod caps)", cones, cyls, planes)
+	// 3 cyl: the fat's holed wall (one keyhole-bridged tube with 2 lens holes) + the two rod stubs (the
+	// connected-band split separates them, unlike a single 4-loop face). 4 plane: 2 fat caps + 2 rod caps.
+	if cones != 0 || cyls != 3 || planes != 4 {
+		t.Errorf("got %d cone + %d cyl + %d plane faces, want 3 cyl (holed fat tube + 2 rod stubs) + 4 plane (2 fat + 2 rod caps)", cones, cyls, planes)
 	}
 }
 

--- a/kernel/brep/curved_general_wrapping_band.go
+++ b/kernel/brep/curved_general_wrapping_band.go
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// OUTSIDE-keep wrapping-band emission for the general curved∩curved cut/join (Oblikovati#1476). A boolean
+// that keeps the part of a ruled side OUTSIDE the other solid produces a band that WRAPS the whole azimuth —
+// a tube with no contractible outer loop. The half-space (u,v) emission assumes a contractible outer
+// (loops[0]) with the rest as holes, so it mis-files one of the tube's two ends (a rim) as a "hole" and the
+// mesher carves the wrong region. The two correct shapes the bespoke handlers build are reproduced here:
+//
+//   - a HOLED tube (the fat wall punched by the rod): two constant-v rims plus contractible imprint holes.
+//     Bridged by a seam ruling into one keyhole outer loop (rim→seam→rim→seam), holes inside — the
+//     seam-cut form periodicBandGrid meshes (the bespoke addFatCapsAndHoledWall shape).
+//   - a TWO-RIM band (a rod stub poking out): one cap rim + one imprint rim, both full-wrap, no holes —
+//     emitted as a two-closed-loop face the ruled saddle loft (twoClosedRimBandMesh) lofts rim-to-rim.
+//
+// Disjoint bands (the two stubs a rod leaves either side of the fat) are split first by connected component,
+// so each emits its own face. Gated to ruledUV solidMode+wrapping, so every half-space/torus/intersect path
+// is untouched.
+
+// wrappingSolidFaces emits the kept region of a ruled solid-membership side as one curvedFace per connected
+// band (#1476). ok=false unless this is the solid-membership wrapping case (the cut/join OUTSIDE/tunnel wall),
+// so the half-space and the non-wrapping intersect paths fall through to the ordinary (u,v) emission.
+func (c ruledUV) wrappingSolidFaces(kept []Face2D, segs []uvSeg, surface geom.Surface, f curvedFace) ([]curvedFace, bool) {
+	if !c.solidMode || !c.wrapsAllU() {
+		return nil, false
+	}
+	var faces []curvedFace
+	for _, comp := range keptComponents(kept, c.vPeriodic()) {
+		face, ok := c.bandFace(comp, segs, surface, f)
+		if !ok {
+			return nil, false
+		}
+		faces = append(faces, face)
+	}
+	return faces, len(faces) > 0
+}
+
+// bandFace builds one curvedFace for a single connected wrapping band: the loops are classified into the
+// band's two full-wrap ends and its contractible holes, then assembled as a keyhole (holed tube) or a
+// two-closed-loop band (a clean stub) — the two shapes the curved mesher renders correctly (#1476).
+func (c ruledUV) bandFace(comp []Face2D, segs []uvSeg, surface geom.Surface, f curvedFace) (curvedFace, bool) {
+	loops := dropArtificialLoops(&c, chainLoops(keptBoundaryEdges(comp, c.vPeriodic())), segs)
+	emitted, ok := emitKeptLoops(&c, loops, segs)
+	if !ok {
+		return curvedFace{}, false
+	}
+	var ends, holes []emittedLoop
+	for _, e := range emitted {
+		if c.loopWrapsU(e) {
+			ends = append(ends, e)
+		} else {
+			holes = append(holes, e)
+		}
+	}
+	if len(ends) != 2 {
+		return curvedFace{}, false // a wrapping band has exactly two full-wrap ends; anything else defers
+	}
+	if len(holes) > 0 && allRimEdges(ends[0].face) && allRimEdges(ends[1].face) {
+		return c.keyholeTubeFace(holes, surface, f), true // a holed tube (the fat wall): bridge the rims
+	}
+	return curvedFace{
+		surface: surface, reversed: f.reversed, lineage: f.lineage,
+		loops: c.orientWrappingBand(emitted),
+	}, true
+}
+
+// keyholeTubeFace assembles a holed tube (the fat wall punched by the rod) as a single contractible face: its
+// two constant-v rims are bridged by a seam ruling into one outer loop (rim→seam→rim→seam), with the imprint
+// holes inside. This is the seam-cut form holedConicWallMesh unrolls — the natural two-rim tube has no
+// contractible outer, so the unroller (which needs the outer to span the v-extent) cannot chart it. The rims
+// are the ORIGINAL band circles, so the outer's rim edges weld to the planar caps that share them (#1476).
+func (c ruledUV) keyholeTubeFace(holes []emittedLoop, surface geom.Surface, f curvedFace) curvedFace {
+	loops := make([]curvedLoop, 0, len(holes)+1)
+	loops = append(loops, curvedLoop{edges: c.keyholeOuter()})
+	for _, h := range holes {
+		loops = append(loops, curvedLoop{edges: h.face})
+	}
+	return curvedFace{surface: surface, reversed: f.reversed, lineage: f.lineage, loops: loops}
+}
+
+// keyholeOuter bridges the band's two rims into one outer loop at their NATIVE seam (the rim circles' own
+// angle-zero ruling, where both rims are anchored to the same azimuth, so the bridge is a v-ruling on the
+// surface). The loop runs up the bridge, around the top rim (reversed when the source side traverses its top
+// rim opposite its cap), back down the bridge, around the bottom rim — the bespoke addFatCapsAndHoledWall
+// keyhole, but reusing the original rim circles so the outer's rims weld to the caps without re-seaming (#1476).
+func (c ruledUV) keyholeOuter() []loopEdge {
+	seamBot := c.band.bottomCirc.PointAt(0)
+	seamTop := c.band.topCirc.PointAt(0)
+	ruling := geom.NewLineSegment(seamBot, seamTop)
+	top := loopEdge{curve: c.band.topCirc, t0: 0, t1: 1}
+	bot := loopEdge{curve: c.band.bottomCirc, t0: 0, t1: 1}
+	if c.band.topRimReversed {
+		top.t0, top.t1 = 1, 0 // top rim opposite its cap; bottom forward (the band convention)
+	} else {
+		bot.t0, bot.t1 = 1, 0
+	}
+	return []loopEdge{{curve: ruling, t0: 0, t1: 1}, top, {curve: ruling, t0: 1, t1: 0}, bot}
+}
+
+// orientWrappingBand applies the ruled band's rim convention to a wrapping band's loops: the rim at the TOP
+// (vMax) end is reversed when the source side traverses its top rim reversed, so it keeps the sense opposite
+// the cap that shares it; the bottom (vMin) rim and the imprint loops keep their arrangement winding (the
+// imprint sense is already set by emitImprintRun, #1477). Unlike orientLoops this keys the reversal on each
+// rim's v-LEVEL, not its position in the loop list — a stub's single cap rim can be the vMin OR vMax end (the
+// rod's two ends), and a tube carries both — so the position-0 rule of the half-space path does not fit (#1476).
+func (c ruledUV) orientWrappingBand(emitted []emittedLoop) []curvedLoop {
+	out := make([]curvedLoop, 0, len(emitted))
+	for _, e := range emitted {
+		edges := e.face
+		if allRimEdges(e.face) && c.isTopRim(e.mv) && c.band.topRimReversed {
+			edges = reverseEdgeChain(e.face)
+		}
+		out = append(out, curvedLoop{edges: edges})
+	}
+	return out
+}
+
+// isTopRim reports whether a loop's mean axial level is nearer the band's vMax (top) rim than its vMin
+// (bottom) rim — the rim the topRimReversed convention flips (#1476).
+func (c ruledUV) isTopRim(mv float64) bool {
+	return stdmath.Abs(mv-c.band.vMax) < stdmath.Abs(mv-c.band.vMin)
+}
+
+// loopWrapsU reports whether an emitted boundary loop spans the WHOLE azimuth — a band end (a rim or a
+// full-wrap imprint loop) rather than a contractible hole. A pure rim run is always full-wrap; an imprint
+// loop is sampled and its (seam-relative) u-extent measured, so the lens that wraps the rod (a stub's inner
+// rim) is told apart from the small lens that punches the fat wall (a hole) (#1476).
+func (c ruledUV) loopWrapsU(e emittedLoop) bool {
+	if allRimEdges(e.face) {
+		return true
+	}
+	uMin, uMax := stdmath.Inf(1), stdmath.Inf(-1)
+	for _, le := range e.face {
+		for k := 0; k <= 16; k++ {
+			u := float64(c.paramOf(le.curve.PointAt(le.t0 + (le.t1-le.t0)*float64(k)/16)).X)
+			uMin, uMax = stdmath.Min(uMin, u), stdmath.Max(uMax, u)
+		}
+	}
+	return uMax-uMin >= 2*stdmath.Pi-0.5
+}
+
+// keptComponents groups the kept arrangement cells into connected bands by shared (seam-folded) edges, so the
+// two disjoint stubs a rod leaves either side of the fat become separate faces (#1476). Two cells are in the
+// same band iff they share an edge; the seam fold makes cells on either side of the azimuth seam adjacent, so
+// a band wrapping the seam stays one component.
+func keptComponents(kept []Face2D, vPeriodic bool) [][]Face2D {
+	w := newSeamWelder(vPeriodic)
+	uf := newBandUF(len(kept))
+	edgeCell := map[[2]int]int{}
+	for ci, cell := range kept {
+		eachCellEdge(cell, func(a, b math.Point2) {
+			key := canonEdgeKey(w.add(a), w.add(b))
+			if prev, ok := edgeCell[key]; ok {
+				uf.union(prev, ci)
+			} else {
+				edgeCell[key] = ci
+			}
+		})
+	}
+	groups := map[int][]Face2D{}
+	order := []int{}
+	for ci := range kept {
+		r := uf.find(ci)
+		if _, seen := groups[r]; !seen {
+			order = append(order, r)
+		}
+		groups[r] = append(groups[r], kept[ci])
+	}
+	out := make([][]Face2D, 0, len(order))
+	for _, r := range order {
+		out = append(out, groups[r])
+	}
+	return out
+}
+
+// eachCellEdge calls fn for every boundary edge of a cell (its outer ring and each hole ring).
+func eachCellEdge(cell Face2D, fn func(a, b math.Point2)) {
+	ring := func(poly []math.Point2) {
+		for i, n := 0, len(poly); i < n; i++ {
+			a, b := poly[i], poly[(i+1)%n]
+			if a.DistanceTo(b) > arrTol {
+				fn(a, b)
+			}
+		}
+	}
+	ring(cell.Outer)
+	for _, h := range cell.Holes {
+		ring(h)
+	}
+}
+
+// canonEdgeKey returns an undirected edge key (endpoints sorted) so the two cells sharing an edge map it to
+// the same key regardless of traversal direction.
+func canonEdgeKey(u, v int) [2]int {
+	if u > v {
+		return [2]int{v, u}
+	}
+	return [2]int{u, v}
+}
+
+// bandUF is a tiny union-find over kept-cell indices for the connected-band grouping.
+type bandUF struct{ parent []int }
+
+func newBandUF(n int) *bandUF {
+	p := make([]int, n)
+	for i := range p {
+		p[i] = i
+	}
+	return &bandUF{parent: p}
+}
+
+func (u *bandUF) find(i int) int {
+	for u.parent[i] != i {
+		u.parent[i] = u.parent[u.parent[i]]
+		i = u.parent[i]
+	}
+	return i
+}
+
+func (u *bandUF) union(a, b int) { u.parent[u.find(a)] = u.find(b) }

--- a/kernel/brep/curved_general_wrapping_band_test.go
+++ b/kernel/brep/curved_general_wrapping_band_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestKeptComponentsSplitsDisjointBands: two cells sharing an edge are one band; a disjoint cell is its own
+// band — the split that separates a rod's two stubs (Oblikovati#1476).
+func TestKeptComponentsSplitsDisjointBands(t *testing.T) {
+	cellAt := func(x float64) Face2D {
+		return Face2D{Outer: []math.Point2{math.P2(x, 0), math.P2(x+1, 0), math.P2(x+1, 1), math.P2(x, 1)}}
+	}
+	left, mid, far := cellAt(0), cellAt(1), cellAt(10) // left & mid share the edge x=1; far is disjoint
+	comps := keptComponents([]Face2D{left, mid, far}, false)
+	if len(comps) != 2 {
+		t.Fatalf("keptComponents = %d bands, want 2 (left+mid joined, far separate)", len(comps))
+	}
+	sizes := map[int]int{}
+	for _, c := range comps {
+		sizes[len(c)]++
+	}
+	if sizes[2] != 1 || sizes[1] != 1 {
+		t.Errorf("band sizes = %v, want one band of 2 cells and one of 1", sizes)
+	}
+}
+
+// TestIsTopRim: a level nearer vMax is the top rim (reversed by the convention), nearer vMin the bottom.
+func TestIsTopRim(t *testing.T) {
+	c := ruledUV{band: coneSideBand_{vMin: 0, vMax: 12}}
+	if !c.isTopRim(11) {
+		t.Error("mv=11 should be the top rim (nearer vMax=12)")
+	}
+	if c.isTopRim(1) {
+		t.Error("mv=1 should be the bottom rim (nearer vMin=0)")
+	}
+}
+
+// TestReverseCurvedLoop: reversing a loop flips each edge's direction and the edge order, so it walks the
+// opposite way around the same boundary (Oblikovati#1476).
+func TestReverseCurvedLoop(t *testing.T) {
+	in := curvedLoop{edges: []loopEdge{{t0: 0, t1: 1}, {t0: 2, t1: 3}}}
+	out := reverseCurvedLoop(in)
+	if len(out.edges) != 2 || out.edges[0].t0 != 3 || out.edges[0].t1 != 2 || out.edges[1].t0 != 1 || out.edges[1].t1 != 0 {
+		t.Errorf("reverseCurvedLoop = %+v, want order+direction flipped", out.edges)
+	}
+}

--- a/kernel/brep/curved_halfspace_torus_uv.go
+++ b/kernel/brep/curved_halfspace_torus_uv.go
@@ -66,6 +66,12 @@ func (c torusUV) wrapsAllU() bool { return false }
 // multiFace: a torus half-space cut leaves one connected face; it is not on the general curved∩curved path (uvSide, #1403).
 func (c torusUV) multiFace() bool { return false }
 
+// wrappingSolidFaces: a torus is not on the general ruled solid-membership wrapping path, so it always defers
+// to the ordinary (u,v) emission (Oblikovati#1476).
+func (c torusUV) wrappingSolidFaces(_ []Face2D, _ []uvSeg, _ geom.Surface, _ curvedFace) ([]curvedFace, bool) {
+	return nil, false
+}
+
 // assembleSegments samples the spiric section, seam-splits it in u, and adds the four artificial seam edges
 // that close the (u,v) rectangle (uvSide). There is no v-band clip (v is periodic) and no rim — the torus is
 // closed, so the section is the only real boundary; the frame seams fold and dissolve.

--- a/kernel/brep/curved_halfspace_uv_side.go
+++ b/kernel/brep/curved_halfspace_uv_side.go
@@ -42,6 +42,11 @@ type uvSide interface {
 	// (a fat cone's wall punched by a rod yields two disjoint lens caps); a plane half-space always leaves
 	// one connected region, so the ruled/torus half-space paths return false and emit a single face (#1403).
 	multiFace() bool
+	// wrappingSolidFaces emits the kept region directly as one curvedFace per connected band when it WRAPS
+	// the whole azimuth (the cut/join OUTSIDE/tunnel wall) — a tube the ordinary contractible-outer emission
+	// mis-files. ok=false for every other case (half-space, torus, the non-wrapping intersect), so they fall
+	// through to the standard (u,v) emission below (Oblikovati#1476).
+	wrappingSolidFaces(kept []Face2D, segs []uvSeg, surface geom.Surface, f curvedFace) ([]curvedFace, bool)
 	// orientLoops applies the surface's winding convention to the ordered boundary loops, returning the face
 	// loops, the section (cut) arcs that bound the planar lid (reversed into it), and whether the kept face is
 	// outerless — a closed-surface face whose loops are all holes (the genus-1 torus complement).
@@ -65,6 +70,11 @@ func trimByImprint(c uvSide, f curvedFace, surface geom.Surface, imprint []geom.
 	kept := keptCells(arrangeBand(segs), materialOf())
 	if len(kept) == 0 {
 		return nil, nil, nil // the whole side is on the dropped side
+	}
+	// A solid-membership side that WRAPS the whole azimuth (the cut/join OUTSIDE/tunnel wall) is a tube the
+	// contractible-outer emission below mis-files; emit it directly as one face per connected band (#1476).
+	if faces, ok := c.wrappingSolidFaces(kept, segs, surface, f); ok {
+		return faces, nil, nil
 	}
 	loops := dropArtificialLoops(c, chainLoops(keptBoundaryEdges(kept, c.vPeriodic())), segs)
 	var faces []curvedFace

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -258,10 +258,13 @@ func curvedCrossingCut(op PartFeatureOperation, target, tool *topo.Body, rec *di
 	if op != Cut {
 		return nil, false
 	}
-	// EPIC #1403: the general ruled CUT (brep.CrossingCylinderCutGeneral) is NOT wired here yet — it produces
-	// an orientation-inconsistent or wrong-region solid that validBooleanSolid rejects (the OUTSIDE-keep region
-	// bug, Oblikovati#1476), so it would only ever fall back. Kept on the bespoke handler until that lands; the
-	// intersect general path IS adopted now that the imprint weld is fixed.
+	// EPIC #1403: route crossing-cylinder subtract through the GENERAL pipeline first (the OUTSIDE-keep
+	// wrapping-band emission, Oblikovati#1476, makes it mesh the right region; the tool tunnel reverses into the
+	// cavity); the bespoke CrossingCylinderCut stays as a fallback for the cases the general path declines (a
+	// breach reaching a cap, a partial penetration), so no OCC case regresses.
+	if res, ok := brep.CrossingCylinderCutGeneral(target, tool, rec); ok && validBooleanSolid(res) {
+		return res, true
+	}
 	res, ok := brep.CrossingCylinderCut(target, tool, rec)
 	if !ok || !validBooleanSolid(res) {
 		return nil, false
@@ -290,10 +293,13 @@ func curvedCrossingJoin(op PartFeatureOperation, target, tool *topo.Body, rec *d
 	if op != Join {
 		return nil, false
 	}
-	// EPIC #1403: the general ruled JOIN (brep.CrossingCylinderJoinGeneral) is NOT wired here yet — with the
-	// imprint weld fixed it now passes validBooleanSolid but meshes the WRONG region (OUTSIDE-keep holed-wall
-	// bug, Oblikovati#1476: ∪ volume 194 vs 383), so adopting it would be worse than the bespoke result. Kept
-	// on the bespoke handler until #1476 lands.
+	// EPIC #1403: route crossing-cylinder JOIN through the GENERAL pipeline first (the OUTSIDE-keep
+	// wrapping-band emission, Oblikovati#1476, makes it mesh the right region — the fat's keyhole-bridged holed
+	// wall plus the two split rod stubs); the bespoke CrossingCylinderJoin stays as a fallback for the cases the
+	// general path declines (a breach reaching a cap, equal radii), so no OCC case regresses.
+	if res, ok := brep.CrossingCylinderJoinGeneral(target, tool, rec); ok && validBooleanSolid(res) {
+		return res, true
+	}
 	res, ok := brep.CrossingCylinderJoin(target, tool, rec)
 	if !ok || !validBooleanSolid(res) {
 		return nil, false

--- a/kernel/ops/boolean_general_adoption_test.go
+++ b/kernel/ops/boolean_general_adoption_test.go
@@ -10,14 +10,13 @@ import (
 	"oblikovati.org/math"
 )
 
-// EPIC #1403 adoption guard. The general curved∩curved INTERSECT drivers must produce a solid that
-// validBooleanSolid ACCEPTS — i.e. one ops.Boolean actually adopts instead of silently discarding for the
-// bespoke fallback. This guard exists because every general migration shipped while the result was
-// orientation-inconsistent: validBooleanSolid rejected it and the bespoke handler did all the work, yet the
-// brep tests (edge-USE-COUNT "watertight" only) and the OCC oracle (run through the adopted = bespoke result)
-// all passed. The imprint weld fix (emitImprintRun keeps the closed-loop traversal sense) is what makes these
-// adopt; this test would have caught the silent fallback, and fails if it ever returns. The general CUT/JOIN
-// are NOT here: they still mesh the wrong region and stay on the bespoke handlers until Oblikovati#1476.
+// EPIC #1403 adoption guard. The general curved∩curved drivers must produce a solid that validBooleanSolid
+// ACCEPTS — i.e. one ops.Boolean actually adopts instead of silently discarding for the bespoke fallback. This
+// guard exists because every general migration shipped while the result was orientation-inconsistent:
+// validBooleanSolid rejected it and the bespoke handler did all the work, yet the brep tests (edge-USE-COUNT
+// "watertight" only) and the OCC oracle (run through the adopted = bespoke result) all passed. The imprint weld
+// fix (emitImprintRun, #1403) is what makes the INTERSECT adopt; the OUTSIDE-keep wrapping-band emission
+// (Oblikovati#1476) makes the crossing-cylinder CUT/JOIN adopt. This test fails if any silently falls back.
 func TestGeneralIntersectIsAdopted(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -51,6 +50,32 @@ func TestGeneralIntersectIsAdopted(t *testing.T) {
 			res, ok := c.general(c.a(), c.b())
 			if !ok {
 				t.Fatalf("%s: general intersect declined; want the general path taken", c.name)
+			}
+			if r := Validate(res); !r.Valid {
+				t.Fatalf("%s: general result NOT adopted by validBooleanSolid (silent fallback): %+v", c.name, r)
+			}
+		})
+	}
+}
+
+// TestGeneralCrossingCutJoinIsAdopted guards the crossing-cylinder CUT and JOIN general drivers (the
+// OUTSIDE-keep wrapping-band emission, Oblikovati#1476): each must produce a validBooleanSolid result so
+// ops.Boolean adopts it rather than falling back to the bespoke handler.
+func TestGeneralCrossingCutJoinIsAdopted(t *testing.T) {
+	fat := func() *topo.Body { b, _ := brep.SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12); return b }
+	rod := func() *topo.Body { b, _ := brep.SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12); return b }
+	cases := []struct {
+		name    string
+		general func() (*topo.Body, bool)
+	}{
+		{"crossing cylinders − (drill)", func() (*topo.Body, bool) { return brep.CrossingCylinderCutGeneral(fat(), rod(), nil) }},
+		{"crossing cylinders ∪", func() (*topo.Body, bool) { return brep.CrossingCylinderJoinGeneral(fat(), rod(), nil) }},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			res, ok := c.general()
+			if !ok {
+				t.Fatalf("%s: general driver declined; want the general path taken", c.name)
 			}
 			if r := Validate(res); !r.Valid {
 				t.Fatalf("%s: general result NOT adopted by validBooleanSolid (silent fallback): %+v", c.name, r)


### PR DESCRIPTION
## TL;DR

Fixes the OUTSIDE-keep region bug (#1476) that kept the general curved∩curved **CUT** and **JOIN** silently falling back to bespoke. The crossing-cylinder cut and join now go through the general pipeline, OCC-validated and adopted.

## The bug

A cut/join that keeps the part of a ruled side **outside** the other solid produces a band that **wraps the whole azimuth** — a tube with no contractible outer loop. The half-space (u,v) emission assumes a contractible outer (`loops[0]`) with the rest as holes, so it mis-filed one of the tube's two rims as a "hole" and the mesher carved the wrong region. Result: `validBooleanSolid` rejected the general output (or it meshed at ~half volume), so `ops.Boolean` fell back to bespoke. A live render of the broken join showed the fat wall with huge conical bites.

Diagnosis confirmed the kept-**cell classification** was correct (OUTSIDE keeps area 75.40/80.27 = the full band minus 2 lens); the defect was purely in **boundary emission** for the wrapping band.

## The fix (gated to `ruledUV` solidMode — half-space / torus / intersect untouched)

- **Connected-component split** of the kept cells (`keptComponents`, union-find over shared seam-folded edges), so a rod's two disjoint stubs become separate faces instead of one 4-loop face the trim winding mis-meshes.
- **Per band**:
  - a **holed tube** (the fat wall) → a **keyhole**: its two rims bridged by a v-ruling at their native seam into one outer loop, holes inside — the seam-cut form `holedConicWallMesh` unrolls. The rims reuse the original band circles so they weld to the planar caps.
  - a clean **two-rim band** (a stub) → two closed loops the ruled saddle loft (`twoClosedRimBandMesh`) lofts rim-to-rim.
  - rim orientation keys on each rim's **v-level** (a stub's cap rim can be the vMin or vMax end), not loop position.
- The cut's **tool tunnel** (a loft band, region-invariant under loop reversal) now has `reverseCurvedFaces` flip its loop winding too, so it opposes the target's hole — the manifold orientation a watertight cut needs.

## Validation

| op | ours | OCC | rel | adopted |
|---|---|---|---|---|
| crossing − (drill) | 289.40 | 298.25 | 0.0297 | ✅ |
| crossing ∪ | 373.17 | 383.07 | 0.0258 | ✅ |

- `TestGeneralCrossingCutJoinIsAdopted` asserts both produce a `validBooleanSolid` result (no silent fallback).
- Live offscreen render via the real `ops.Boolean` path — shaded clean (T-junction join; drilled tunnel cut), Normal-Debug all front-facing.
- Full kernel suite green; lint/vet/gofmt clean; new code >85% covered.

Closes #1476. Advances #1403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)