### PR TITLE
docs(boolean): document why Steinmetz stays on its bespoke analytic handler (#1403)

### DIFF
--- a/kernel/brep/curved_general_ruled_cutjoin.go
+++ b/kernel/brep/curved_general_ruled_cutjoin.go
@@ -15,6 +15,12 @@ import (
 // cone∩cone, cone∩cyl) runs the SAME two recipes here — only the per-operand side-face / membership / UV-frame
 // builders differ, captured behind one ruledOperand so the cut and the join are written once. The OUTSIDE-keep
 // walls mesh through the wrapping-band emission (curved_general_wrapping_band.go, Oblikovati#1476).
+//
+// SCOPE: a CLEAN crossing whose imprint is a set of NON-self-intersecting loops (a thin rod or cone through a
+// fatter solid, fully or partially). The one ruled crossing this pipeline does NOT cover is the equal-radius
+// Steinmetz bicylinder, whose two ellipses pinch into a self-intersecting imprint the (u,v) arrangement cannot
+// split into lobes — it keeps its bespoke analytic constructor (see curved_steinmetz.go). An out-of-scope pair
+// declines from these drivers (validBooleanSolid rejects the result), so kernel/ops uses the bespoke handler.
 
 // ruledOperand bundles everything a general cut/join needs about ONE crossing ruled solid: its body, the
 // curved side face being trimmed, that face's analytic surface, a 3D solid-membership oracle, and a builder

--- a/kernel/brep/curved_steinmetz.go
+++ b/kernel/brep/curved_steinmetz.go
@@ -14,10 +14,25 @@ import (
 // perpendicular cylinders crossing through a common axis point intersect in the Steinmetz bicylinder: the
 // intersection curve is NOT a quartic saddle but two planar ELLIPSES that cross at two pinch points. The
 // SSI imprint tracer now follows each ellipse straight through those pinches (Oblikovati#1404), so the
-// crossing imprint returns the two loops here too; but the bicylinder's four-lobe SOLID is still assembled
-// from EXACT analytic ellipse edges below (sharper than traced polylines, and a different topology from the
-// rod-band crossing result). Folding this constructor into a general loop→solid stitch is tracked under the
-// curved∩curved pipeline (Oblikovati#1403), for which the through-pinch tracer is the prerequisite.
+// crossing imprint returns the two loops here too; but the bicylinder's four-lobe SOLID is assembled from
+// EXACT analytic ellipse edges below.
+//
+// WHY THIS STAYS ANALYTIC and is NOT folded into the general curved∩curved pipeline (Oblikovati#1403, which
+// now builds every CLEAN ruled boolean — crossing-cylinder, cone∩cone, cone∩cylinder, partial penetration):
+// the equal-radius pinch makes the imprint SELF-INTERSECT, which violates the (u,v)-arrangement's clean-band
+// assumptions in four places at once, deep-diagnosed under #1403:
+//   1. wrapsAllU reads the pinch (the lobes meet at a single v) as kept at every azimuth, so the region looks
+//      like a wrapping band and the two lobes collapse into one face;
+//   2. the two lobes TOUCH at the two pinch vertices, so groupLoopFaces' containment cannot separate them;
+//   3. chainLoops walks each ellipse STRAIGHT THROUGH the degree-4 pinch vertex instead of turning into a
+//      lobe (an angular next-edge walk is necessary but, alone, not sufficient);
+//   4. the elliptical arcs do not weld at the shared pinch vertices.
+// Handling it generally needs a pinch-AWARE arrangement (split the region at the self-intersection into the
+// four lobes, then weld arcs at the shared pinch vertices) — a dedicated change touching wrapsAllU,
+// groupLoopFaces, chainLoops, emission and welding, with real regression risk to every working torus/cone/
+// cylinder cut. A general pipeline plus this small analytic special case is the deliberate, correct design;
+// kernel/ops routes equal-radius crossings here, and the general crossing path declines them (its result
+// fails validBooleanSolid, see boolean_crossing_cylinder_test.go).
 //
 // Geometry in the frame (a = axis A, b = axis B, n = a×b) through the axis crossing O, with equal radius R:
 // a surface point O + α·a + β·b + γ·n is on cyl A when β²+γ²=R² and on cyl B when α²+γ²=R², so on both when

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -62,8 +62,11 @@ func curvedConeConeIntersect(op PartFeatureOperation, target, tool *topo.Body, r
 
 // curvedSteinmetzIntersect returns the exact intersection of two equal-radius perpendicular cylinders (the
 // Steinmetz bicylinder), or ok=false to defer. Only Intersect maps here, and only a valid closed manifold
-// result is adopted. The SSI tracer now traces this equal-radius pinch (#1404), but the four-lobe bicylinder
-// solid is still built from exact analytic ellipse edges here; unifying it onto the traced loops is #1403.
+// result is adopted. This is the ONE crossing case kept on its bespoke analytic constructor (the general
+// curved∩curved pipeline, #1403, handles every other ruled pair): the equal-radius pinch makes the imprint
+// self-intersect into four lobes, which the general (u,v) arrangement cannot yet split or weld — see the
+// detailed rationale on brep.EqualRadiusSteinmetzIntersect. The general crossing path declines equal radii
+// (its result fails validBooleanSolid), so it does not race this handler.
 func curvedSteinmetzIntersect(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	if op != Intersect {
 		return nil, false
@@ -238,7 +241,9 @@ func curvedConeConeJoin(op PartFeatureOperation, target, tool *topo.Body, rec *d
 
 // curvedSteinmetzCut returns target − tool for two equal-radius perpendicular cylinders (the target with
 // the tool's saddle bite removed), or ok=false to defer. Only Cut maps here, and only a valid closed
-// manifold result is adopted.
+// manifold result is adopted. Like curvedSteinmetzIntersect, this stays on the bespoke analytic constructor:
+// the equal-radius pinch is the one case the general pipeline (#1403) does not handle — see the rationale on
+// brep.EqualRadiusSteinmetzIntersect.
 func curvedSteinmetzCut(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	if op != Cut {
 		return nil, false
@@ -270,7 +275,9 @@ func curvedCrossingCut(op PartFeatureOperation, target, tool *topo.Body, rec *di
 
 // curvedSteinmetzJoin returns target ∪ tool for two equal-radius perpendicular cylinders (the union of two
 // crossing cylinders of the same radius), or ok=false to defer. Only Join maps here, and only a valid closed
-// manifold result is adopted.
+// manifold result is adopted. Like curvedSteinmetzIntersect, this stays on the bespoke analytic constructor:
+// the equal-radius pinch is the one case the general pipeline (#1403) does not handle — see the rationale on
+// brep.EqualRadiusSteinmetzIntersect.
 func curvedSteinmetzJoin(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	if op != Join {
 		return nil, false


### PR DESCRIPTION
## What

Documents — in the code — why the equal-radius **Steinmetz** bicylinder deliberately stays on its bespoke analytic constructor while the general curved∩curved pipeline (#1403) now builds every other clean ruled boolean. Docs only; no behaviour change.

## Why

Following the decision to keep Steinmetz analytic, this makes the rationale explicit so a future reader knows it's a designed choice, not an oversight. The equal-radius pinch makes the imprint **self-intersect**, which breaks the (u,v)-arrangement's clean-band assumptions in four places at once (deep-diagnosed under #1403):

1. `wrapsAllU` reads the pinch (lobes meet at a single v) as kept at every azimuth → the two lobes collapse into one face;
2. the lobes **touch** at the two pinch vertices → `groupLoopFaces` containment can't separate them;
3. `chainLoops` walks each ellipse **straight through** the degree-4 pinch instead of turning into a lobe;
4. the elliptical arcs **don't weld** at the shared pinch vertices.

Folding it in needs a pinch-aware arrangement (split at the self-intersection into four lobes, weld arcs at shared pinch vertices) — a dedicated change touching `wrapsAllU` + `groupLoopFaces` + `chainLoops` + emission + welding, with real regression risk to every working torus/cone/cylinder cut. A general pipeline plus this one analytic special case is the correct design.

## Changes

- `curved_steinmetz.go` — the four concrete blockers + what a general fold-in would require.
- the three `curvedSteinmetz{Intersect,Cut,Join}` ops handlers — point to that rationale; note the general crossing path declines equal radii (so it never races them).
- the general ruled cut/join header — states its scope (non-self-intersecting imprints) and that the Steinmetz pinch is out of scope.

Full kernel suite green; lint/vet/gofmt clean.

Advances #1403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)