### PR TITLE
fix(head): center the close-time save prompt over the main window (#1474)

### DIFF
--- a/head/internal/native/center_window_test.go
+++ b/head/internal/native/center_window_test.go
@@ -1,0 +1,48 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package native
+
+import (
+	"testing"
+)
+
+// TestCenterNextWindowCentersOnViewport pins the #1474 fix: CenterNextWindow must place
+// the following window so its MIDPOINT sits on the main-viewport centre — i.e. top-left =
+// centre − size/2 — rather than ImGui's default top-left cascade that left the save prompt
+// lost in a corner. It drives a real offscreen ImGui frame (lavapipe+xvfb in CI) and reads
+// the window's resulting position back through WindowPos.
+func TestCenterNextWindowCentersOnViewport(t *testing.T) {
+	w, err := CreateWindow(800, 600, "Oblikovati (#1474 center test)")
+	if err != nil {
+		t.Skipf("no window/GPU available: %v", err)
+	}
+	defer w.Destroy()
+
+	const ww, wh float32 = 240, 140
+	var px, py, cx, cy float32
+	w.BeginFrame()
+	cx, cy = MainViewportCenter()
+	CenterNextWindow()
+	SetNextWindowSize(ww, wh)
+	if Begin("center-probe") {
+		px, py = WindowPos()
+	}
+	End()
+	w.EndFrame(0.10, 0.10, 0.12)
+
+	wantX, wantY := cx-ww/2, cy-wh/2
+	const tol = 1.0 // sub-pixel rounding in ImGui's pivot placement
+	if abs32(px-wantX) > tol || abs32(py-wantY) > tol {
+		t.Errorf("centered window at (%.1f,%.1f), want (%.1f,%.1f) — pivot centring broken (#1474)",
+			px, py, wantX, wantY)
+	}
+}
+
+func abs32(v float32) float32 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -55,6 +55,8 @@ void obk_ig_indent(float w);
 void obk_ig_unindent(float w);
 void obk_ig_progress_bar(float fraction, float w, const char* overlay);
 void obk_ig_main_viewport_size(float* w, float* h);
+void obk_ig_main_viewport_center(float* x, float* y);
+void obk_ig_window_pos(float* x, float* y);
 float obk_ig_hover_seconds(void);
 int  obk_ig_begin_popup_context_item(const char* id);
 void obk_ig_open_popup(const char* id);
@@ -110,6 +112,7 @@ float obk_ig_frame_height(void);
 float obk_ig_text_line_height(void);
 void obk_ig_style_metrics(float* fpx, float* fpy, float* isx, float* isy, float* wpx, float* wpy);
 void obk_ig_set_next_window_pos(float x, float y);
+void obk_ig_center_next_window(void);
 void obk_ig_set_next_window_size(float w, float h);
 void obk_ig_set_next_window_size_first_use(float w, float h);
 
@@ -790,6 +793,22 @@ func MainViewportSize() (w, h float32) {
 	return float32(cw), float32(ch)
 }
 
+// MainViewportCenter is the point CenterNextWindow pivots the next window onto. Exposed
+// so the #1474 centering can be asserted; mirrors GetMainViewport()->GetCenter().
+func MainViewportCenter() (x, y float32) {
+	var cx, cy C.float
+	C.obk_ig_main_viewport_center(&cx, &cy)
+	return float32(cx), float32(cy)
+}
+
+// WindowPos reports the current window's top-left in screen pixels (valid between
+// Begin/End). Used to confirm a centred window landed where the pivot placed it.
+func WindowPos() (x, y float32) {
+	var cx, cy C.float
+	C.obk_ig_window_pos(&cx, &cy)
+	return float32(cx), float32(cy)
+}
+
 // HoverSeconds reports how long the last item has been hovered — drives the
 // progressive tooltip's expanded text (M05-F09).
 func HoverSeconds() float32 { return float32(C.obk_ig_hover_seconds()) }
@@ -973,6 +992,12 @@ func SetCursorPos(x, y float32) { C.obk_ig_set_cursor_pos(C.float(x), C.float(y)
 // in-window tests to put the viewport panel at a known rect so injected input lands on it.
 func SetNextWindowPos(x, y float32)  { C.obk_ig_set_next_window_pos(C.float(x), C.float(y)) }
 func SetNextWindowSize(w, h float32) { C.obk_ig_set_next_window_size(C.float(w), C.float(h)) }
+
+// CenterNextWindow anchors the next Begin's window to the centre of the main viewport
+// (a 0.5,0.5 pivot), so a prompt opens over the drawing rather than off in a corner.
+// Used for the graceful-close save prompt so it is not lost against the dark canvas
+// (Oblikovati#1474).
+func CenterNextWindow() { C.obk_ig_center_next_window() }
 
 // SetNextWindowSizeOnce sets the next window's size only the first time it is shown
 // (ImGuiCond_FirstUseEver), so it gives a sensible default the user can still resize.

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -23,6 +23,15 @@ int  obk_ig_menu_item_ex(const char* label, const char* shortcut, int enabled) {
 }
 
 void obk_ig_set_next_window_pos(float x, float y)  { ImGui::SetNextWindowPos(ImVec2(x, y)); }
+// Center the next window on the main viewport. A (0.5,0.5) pivot anchors the window's
+// midpoint to the viewport midpoint, so auto-sized content centers without us knowing
+// the window's size, and GetCenter() (not ImVec2(w/2,h/2)) keeps it correct off a
+// non-zero viewport origin under multi-monitor. Re-applied each frame (ImGuiCond_Always)
+// so a resized main window keeps the prompt centred (Oblikovati#1474).
+void obk_ig_center_next_window(void) {
+    ImVec2 center = ImGui::GetMainViewport()->GetCenter();
+    ImGui::SetNextWindowPos(center, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+}
 void obk_ig_set_next_window_size(float w, float h) { ImGui::SetNextWindowSize(ImVec2(w, h)); }
 void obk_ig_set_next_window_size_first_use(float w, float h) {
     ImGui::SetNextWindowSize(ImVec2(w, h), ImGuiCond_FirstUseEver);
@@ -165,6 +174,18 @@ void obk_ig_progress_bar(float fraction, float w, const char* overlay) {
 void obk_ig_main_viewport_size(float* w, float* h) {
     ImVec2 sz = ImGui::GetMainViewport()->Size;
     *w = sz.x; *h = sz.y;
+}
+// main_viewport_center is the anchor obk_ig_center_next_window pivots to; exposed so the
+// centering math is regression-testable (Oblikovati#1474).
+void obk_ig_main_viewport_center(float* x, float* y) {
+    ImVec2 c = ImGui::GetMainViewport()->GetCenter();
+    *x = c.x; *y = c.y;
+}
+// window_pos reads the current window's top-left (valid between Begin/End) — lets a test
+// confirm a centred window landed where the pivot put it.
+void obk_ig_window_pos(float* x, float* y) {
+    ImVec2 p = ImGui::GetWindowPos();
+    *x = p.x; *y = p.y;
 }
 // hover_seconds reports how long the last item has been hovered (the progressive
 // tooltip's expand timer).

--- a/head/ui/close_guard_draw.go
+++ b/head/ui/close_guard_draw.go
@@ -43,6 +43,7 @@ func drawCloseModal(s *app.Session) bool {
 		return true
 	}
 	exit := false
+	native.CenterNextWindow() // over the drawing, not lost in a corner (#1474)
 	if native.Begin("Save changes?") {
 		drawDirtyDocumentList(dirty)
 		exit = drawCloseModalButtons(s)

--- a/head/ui/close_prompt_center_test.go
+++ b/head/ui/close_prompt_center_test.go
@@ -1,0 +1,68 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+)
+
+// dirtyPromptSession returns a session holding one unsaved (dirty) part, so the graceful-close
+// and per-tab close prompts both have something to warn about.
+func dirtyPromptSession(t *testing.T) *app.Session {
+	t.Helper()
+	s := app.NewSession()
+	pd, err := compdef.AddPart(s.Workspace(), "close-prompt-test.opd", true)
+	if err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	_ = s.Workspace().SetActiveDocument(pd)
+	pd.MarkDirty()
+	return s
+}
+
+// TestCloseSavePromptDrawsWhileDirty is the #1474 regression guard for the window-close
+// "Save changes?" prompt: it drives a real frame through drawCloseModal (which now centres the
+// window via native.CenterNextWindow) with a dirty document open, and asserts the close does not
+// proceed while work is unsaved. A panic in the centring/Begin path would fail here.
+func TestCloseSavePromptDrawsWhileDirty(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	icons = nil // rebind the icon cache to this fresh window
+	s := dirtyPromptSession(t)
+	if len(dirtyDocuments(s)) == 0 {
+		t.Fatal("expected the part to be dirty so the prompt has something to show")
+	}
+
+	closeModal.prompting = true
+	defer func() { closeModal.prompting = false }()
+	win.BeginFrame()
+	exit := drawCloseModal(s)
+	win.EndFrame(0.1, 0.1, 0.1)
+	if exit {
+		t.Error("drawCloseModal proceeded with the close while a document was still dirty")
+	}
+}
+
+// TestDocumentClosePromptDrawsWhileDirty is the same guard for the per-tab "Save document
+// changes?" prompt (drawDocumentClosePrompt), which is also centred now (#1474). With a dirty
+// pending document it must keep the prompt up rather than dismiss itself.
+func TestDocumentClosePromptDrawsWhileDirty(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	icons = nil
+	s := dirtyPromptSession(t)
+
+	closeDocumentModal.pending = s.ActiveDocument()
+	defer func() { closeDocumentModal.pending = nil }()
+	win.BeginFrame()
+	drawDocumentClosePrompt(s)
+	win.EndFrame(0.1, 0.1, 0.1)
+	if closeDocumentModal.pending == nil {
+		t.Error("drawDocumentClosePrompt dismissed itself while the document was still dirty")
+	}
+}

--- a/head/ui/document_close_draw.go
+++ b/head/ui/document_close_draw.go
@@ -19,6 +19,7 @@ func drawDocumentClosePrompt(s *app.Session) {
 		return
 	}
 	d := closeDocumentModal.pending
+	native.CenterNextWindow() // over the drawing, not lost in a corner (#1474)
 	if native.Begin("Save document changes?##document-close") {
 		native.Text("Save changes to " + d.FullDocumentName() + " before closing?")
 		if native.Button("Save") {


### PR DESCRIPTION
## What
The close-time **"Save changes?"** prompt (and the per-tab "Save document changes?" prompt) now open **centred on the main window** instead of ImGui's default top-left cascade.

## Why
A user reported (#1474) that closing the window with unsaved work pops the save prompt in the top-left corner, against the dark canvas, where it is easy to miss. Centring it over the drawing puts it where the user is looking.

## How (briefly)
- New `native.CenterNextWindow()` — pivots the next window's midpoint onto the main-viewport centre (`GetMainViewport()->GetCenter()` + `(0.5,0.5)` pivot, re-applied each frame so it tracks a window resize, and `GetCenter()` keeps it correct off a non-zero viewport origin under multi-monitor).
- Applied to both close prompts in `close_guard_draw.go` and `document_close_draw.go`.
- Exposed `MainViewportCenter()` / `WindowPos()` readbacks and added a live offscreen regression test (`TestCenterNextWindowCentersOnViewport`) asserting the centred window lands at `centre − size/2`.

## Verification
- `go test ./internal/native/ ./ui/` green; the new test passes against a real offscreen ImGui frame.
- Linter clean on touched files; gofmt clean.
- **Live capture** (throwaway driver rebuilding the reporter's "demo" part, then driving the graceful-close flow + `SaveWindowPNG`) confirms the prompt now renders centred over the extruded box rather than in the corner.

Fixes #1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)