### PR TITLE
fix(head): show a horizontal scrollbar when the ribbon overflows (#1471)

### DIFF
--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -104,6 +104,8 @@ void obk_ig_mouse_delta(float* dx, float* dy);
 void obk_ig_get_cursor_pos(float* x, float* y);
 void obk_ig_set_cursor_pos(float x, float y);
 int  obk_ig_begin_ribbon_band(const char* name, float height);
+float obk_ig_scroll_max_x(void);
+float obk_ig_scrollbar_size(void);
 void obk_ig_get_cursor_screen_pos(float* x, float* y);
 void obk_ig_set_cursor_screen_pos(float x, float y);
 void obk_ig_item_rect_max(float* x, float* y);
@@ -1054,6 +1056,14 @@ func BeginRibbonBand(name string, height float32) bool {
 	defer free()
 	return C.obk_ig_begin_ribbon_band(c, C.float(height)) != 0
 }
+
+// ScrollMaxX is the current window's maximum horizontal scroll offset; >0 means its content
+// overflows the window width (the ribbon band's horizontal scrollbar is showing, #1471).
+func ScrollMaxX() float32 { return float32(C.obk_ig_scroll_max_x()) }
+
+// ScrollbarSize is the style thickness of a scrollbar — the ribbon reserves this much extra band
+// height when the horizontal scrollbar is showing so it never covers the panel-name strip (#1471).
+func ScrollbarSize() float32 { return float32(C.obk_ig_scrollbar_size()) }
 
 // GetCursorScreenPos / SetCursorScreenPos read and write the layout cursor in screen
 // space — for pinning the ribbon's panel-name strip at a fixed band Y.

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -62,10 +62,19 @@ void obk_ig_separator_vertical(void)         { ImGui::SeparatorEx(ImGuiSeparator
 // it. The band cannot be moved, resized, collapsed, or docked: the ribbon is window
 // chrome, not a palette. Pair with obk_ig_end regardless of the return value.
 int  obk_ig_begin_ribbon_band(const char* name, float height) {
-    ImGuiWindowFlags flags = ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoSavedSettings;
+    // HorizontalScrollbar (not NoScrollbar) so a too-narrow window shows a scrollbar at the band
+    // bottom and the mouse wheel scrolls the overflowing buttons into view (Oblikovati#1471). The
+    // caller reserves the scrollbar's height so the panel-name strip is never hidden behind it.
+    ImGuiWindowFlags flags = ImGuiWindowFlags_HorizontalScrollbar | ImGuiWindowFlags_NoSavedSettings;
     return ImGui::BeginViewportSideBar(name, ImGui::GetMainViewport(), ImGuiDir_Up,
         height, flags) ? 1 : 0;
 }
+// scroll_max_x reports the current window's maximum horizontal scroll — >0 exactly when its content
+// overflows the window width, i.e. the ribbon's horizontal scrollbar is showing (#1471).
+float obk_ig_scroll_max_x(void) { return ImGui::GetScrollMaxX(); }
+// scrollbar_size is the style thickness of a scrollbar, so the ribbon can grow its band height by
+// exactly that to seat the horizontal scrollbar without covering content (#1471).
+float obk_ig_scrollbar_size(void) { return ImGui::GetStyle().ScrollbarSize; }
 
 // Cursor/layout probes for the ribbon's manual placement (screen space): the panel
 // name strip is pinned at a fixed band Y and centered under its button block, which

--- a/head/ui/chrome_ribbon.go
+++ b/head/ui/chrome_ribbon.go
@@ -23,7 +23,8 @@ var prevEnv app.Environment
 func drawRibbon(s *app.Session) string {
 	force := contextualTab(s)
 	var activated string
-	if native.BeginRibbonBand("##ribbon", ribbonBandHeight()) && native.BeginTabBar("##ribbon-tabs") {
+	bandOpen := native.BeginRibbonBand("##ribbon", ribbonBandHeight())
+	if bandOpen && native.BeginTabBar("##ribbon-tabs") {
 		for _, tab := range app.BuildRibbon(s).Tabs {
 			if native.BeginTabItemSelected(tab.Name, tab.Name == force) {
 				if id := drawTabPanels(tab.Panels); id != "" {
@@ -34,9 +35,18 @@ func drawRibbon(s *app.Session) string {
 		}
 		native.EndTabBar()
 	}
+	if bandOpen {
+		// Remember (for next frame's height) whether the buttons overflow a too-narrow window, so
+		// the band grows to seat the horizontal scrollbar without covering the panel names (#1471).
+		ribbonScrollbarShown = native.ScrollMaxX() > 0
+	}
 	native.End()
 	return activated
 }
+
+// ribbonScrollbarShown is last frame's overflow state: true when the ribbon's content was wider than
+// the window, so a horizontal scrollbar is on screen and ribbonBandHeight reserves room for it.
+var ribbonScrollbarShown bool
 
 // ribbonMaxRows is how many small buttons stack in one panel column before the next
 // column starts (the classic ribbon stacks its small buttons three deep).
@@ -55,7 +65,11 @@ func ribbonGridHeight(m native.StyleMetrics) float32 {
 func ribbonBandHeight() float32 {
 	m := native.Metrics()
 	content := ribbonGridHeight(m) + m.ItemSpacingY + native.TextLineHeight()
-	return 2*m.WindowPadY + native.FrameHeight() + m.ItemSpacingY + content
+	h := 2*m.WindowPadY + native.FrameHeight() + m.ItemSpacingY + content
+	if ribbonScrollbarShown {
+		h += native.ScrollbarSize() // seat the horizontal scrollbar below the panel names (#1471)
+	}
+	return h
 }
 
 // drawTabPanels lays the tab's panels out horizontally — each panel is a layout group

--- a/head/ui/ribbon_scrollbar_test.go
+++ b/head/ui/ribbon_scrollbar_test.go
@@ -1,0 +1,88 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+	"oblikovati.org/model/compdef"
+)
+
+// ribbonSession is a session with one part open, so the ribbon builds its full tab/panel set.
+func ribbonSession(t *testing.T) *app.Session {
+	t.Helper()
+	s := app.NewSession()
+	if err := app.RegisterStandardCommands(s); err != nil { // populate the ribbon's tabs/panels
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	pd, err := compdef.AddPart(s.Workspace(), "ribbon.opd", true)
+	if err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	_ = s.Workspace().SetActiveDocument(pd)
+	return s
+}
+
+// driveRibbon opens a window of the given size, runs a few real chrome frames, and reports whether
+// the ribbon ended up overflowing (its horizontal scrollbar showing). Skips when no GPU/display.
+func driveRibbon(t *testing.T, w, h int) bool {
+	t.Helper()
+	win, err := native.CreateWindow(w, h, "ribbon-scroll-test")
+	if err != nil {
+		t.Skipf("no window/Vulkan available: %v", err)
+	}
+	defer win.Destroy()
+	win.InitViewport()
+	dockLaidOut = false
+	icons = nil
+	ribbonScrollbarShown = false
+	defer func() { ribbonScrollbarShown = false }()
+	s := ribbonSession(t)
+	for i := 0; i < 5; i++ { // settle the dock layout + let the overflow flag stabilise
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.1)
+	}
+	return ribbonScrollbarShown
+}
+
+// TestRibbonShowsScrollbarWhenNarrow is the #1471 guard: a window too narrow to fit the active tab's
+// buttons must overflow, so the band reports its horizontal scrollbar is showing.
+func TestRibbonShowsScrollbarWhenNarrow(t *testing.T) {
+	if !driveRibbon(t, 360, 600) {
+		t.Error("a 360px-wide window should overflow the ribbon and show a horizontal scrollbar (#1471)")
+	}
+}
+
+// TestRibbonNoScrollbarWhenWide is the converse: a wide window fits the active tab, so no scrollbar
+// is shown and the band keeps its compact height.
+func TestRibbonNoScrollbarWhenWide(t *testing.T) {
+	if driveRibbon(t, 3200, 600) {
+		t.Error("a 3200px-wide window should fit the default tab without a ribbon scrollbar (#1471)")
+	}
+}
+
+// TestRibbonBandHeightReservesScrollbar checks the height arithmetic directly: when the scrollbar is
+// showing the band grows by exactly the scrollbar thickness, so the panel-name strip is never hidden
+// behind it.
+func TestRibbonBandHeightReservesScrollbar(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	defer func() { ribbonScrollbarShown = false }()
+
+	win.BeginFrame()
+	ribbonScrollbarShown = false
+	without := ribbonBandHeight()
+	ribbonScrollbarShown = true
+	with := ribbonBandHeight()
+	bar := native.ScrollbarSize()
+	win.EndFrame(0.1, 0.1, 0.1)
+
+	if got := with - without; got != bar {
+		t.Errorf("band height grew by %.2f reserving the scrollbar, want exactly ScrollbarSize=%.2f", got, bar)
+	}
+}

--- a/head/ui/scrollbar_contrast_test.go
+++ b/head/ui/scrollbar_contrast_test.go
@@ -1,0 +1,62 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/app"
+)
+
+// slotToken reverses chromeBinding to report which theme token drives a given Dear ImGui color slot.
+func slotToken(slot string) (types.ThemeToken, bool) {
+	for tok, slots := range chromeBinding {
+		for _, s := range slots {
+			if s == slot {
+				return tok, true
+			}
+		}
+	}
+	var none types.ThemeToken
+	return none, false
+}
+
+// TestScrollbarGrabContrastsWithTrack is the regression guard for the #1471 follow-up: the scrollbar
+// GRAB (draggable slider) and its TRACK background must be driven by different theme tokens, and
+// resolve to visibly different colors — otherwise the grab is invisible against its track until you
+// drag it (ScrollbarGrabActive, the bright accent, is the only state that shows). That was the bug:
+// ScrollbarBg and ScrollbarGrab shared one token, so both painted the same color.
+func TestScrollbarGrabContrastsWithTrack(t *testing.T) {
+	bgTok, okBg := slotToken("ScrollbarBg")
+	grabTok, okGrab := slotToken("ScrollbarGrab")
+	if !okBg || !okGrab {
+		t.Fatal("ScrollbarBg and ScrollbarGrab must both be bound in chromeBinding")
+	}
+	if bgTok == grabTok {
+		t.Fatalf("ScrollbarBg and ScrollbarGrab share token %v — the grab is invisible against its "+
+			"track until dragged (#1471 follow-up)", bgTok)
+	}
+	th := app.NewSession().Theme()
+	bg := th.Color(bgTok).Array()
+	grab := th.Color(grabTok).Array()
+	if rgbDistance(bg, grab) < 0.12 { // perceptible at rest, not just while dragging
+		t.Errorf("scrollbar track %v and grab %v are nearly identical (Δ=%.3f) — grab not visible at rest",
+			bg, grab, rgbDistance(bg, grab))
+	}
+}
+
+// rgbDistance is the summed absolute RGB difference of two RGBA colors (alpha ignored).
+func rgbDistance(a, b [4]float32) float32 {
+	var d float32
+	for i := 0; i < 3; i++ {
+		if a[i] > b[i] {
+			d += a[i] - b[i]
+		} else {
+			d += b[i] - a[i]
+		}
+	}
+	return d
+}

--- a/head/ui/theme_apply.go
+++ b/head/ui/theme_apply.go
@@ -134,15 +134,18 @@ func WindowClearColor() (r, g, b float32) {
 // accent paints the active tab, checkmark, slider grab, and selection. Each ImGui slot
 // appears under exactly one token, so apply order does not matter.
 var chromeBinding = map[types.ThemeToken][]string{
-	types.TokenChromeWindowBg:      {"WindowBg"},
-	types.TokenChromePanelBg:       {"ChildBg"},
-	types.TokenChromePopupBg:       {"PopupBg"},
-	types.TokenChromeMenuBarBg:     {"MenuBarBg"},
-	types.TokenChromeHeaderBg:      {"TitleBg", "TitleBgCollapsed", "Header"},
-	types.TokenChromeText:          {"Text", "InputTextCursor"},
-	types.TokenChromeTextDisabled:  {"TextDisabled"},
-	types.TokenChromeBorder:        {"Border", "Separator"},
-	types.TokenChromeControlBg:     {"FrameBg"},
+	types.TokenChromeWindowBg:     {"WindowBg"},
+	types.TokenChromePanelBg:      {"ChildBg"},
+	types.TokenChromePopupBg:      {"PopupBg"},
+	types.TokenChromeMenuBarBg:    {"MenuBarBg"},
+	types.TokenChromeHeaderBg:     {"TitleBg", "TitleBgCollapsed", "Header"},
+	types.TokenChromeText:         {"Text", "InputTextCursor"},
+	types.TokenChromeTextDisabled: {"TextDisabled"},
+	types.TokenChromeBorder:       {"Border", "Separator"},
+	// ScrollbarBg (the track groove) shares the recessed control background so the grab — painted
+	// by TokenChromeScrollbar below — actually contrasts against it. Binding both the track and the
+	// grab to one token left the grab invisible until dragged (Oblikovati#1471 follow-up).
+	types.TokenChromeControlBg:     {"FrameBg", "ScrollbarBg"},
 	types.TokenChromeControlHover:  {"FrameBgHovered", "SeparatorHovered"},
 	types.TokenChromeControlActive: {"FrameBgActive"},
 	types.TokenChromeButton:        {"Button", "Tab", "TabDimmed"},
@@ -153,7 +156,10 @@ var chromeBinding = map[types.ThemeToken][]string{
 		"SliderGrab", "SliderGrabActive", "HeaderHovered", "HeaderActive",
 		"SeparatorActive", "ScrollbarGrabActive", "TextSelectedBg",
 	},
-	types.TokenChromeScrollbar: {"ScrollbarBg", "ScrollbarGrab", "ScrollbarGrabHovered"},
+	// The scrollbar GRAB (the draggable slider) — the track is TokenChromeControlBg above and the
+	// dragged state is ScrollbarGrabActive under the accent, so the grab is visible at rest, not
+	// only while dragging (Oblikovati#1471 follow-up).
+	types.TokenChromeScrollbar: {"ScrollbarGrab", "ScrollbarGrabHovered"},
 }
 
 // applyChromeStyle pushes every chrome token's color into the ImGui slots it binds to.


### PR DESCRIPTION
## What
When the window is too narrow to fit the active ribbon tab's buttons, the ribbon band now shows a **horizontal scrollbar** and the mouse wheel scrolls the clipped buttons into view.

## Why
A user reported (#1471) that on a small screen the top toolbar buttons get cut off with no obvious way to scroll. The band was created with `ImGuiWindowFlags_NoScrollbar`, so overflow was simply clipped at the right edge — unreachable.

## How
- **`obk_ig_begin_ribbon_band`** now passes `ImGuiWindowFlags_HorizontalScrollbar` (instead of `NoScrollbar`). ImGui then draws the scrollbar at the band bottom when the content overflows, and routes the mouse wheel to horizontal scroll (the band has no vertical scroll).
- **Reserve the scrollbar's height**: `ribbonBandHeight` adds exactly one `ScrollbarSize` while the scrollbar is showing, so the panel-name strip ("Work Features", "Sketch", …) is never hidden behind it. Whether it's showing is read each frame from `GetScrollMaxX` (>0 ⇒ overflowing) and applied to the next frame's height — a standard one-frame ImGui sizing pattern, with no feedback loop (height is vertical, overflow is horizontal).
- New native probes `ScrollMaxX()` / `ScrollbarSize()` (in the coverage-excluded cgo binding layer).

## Verification
- New tests: a 360px window overflows → scrollbar shown; a 3200px window fits the default tab → no scrollbar; and the band height grows by exactly `ScrollbarSize` when the scrollbar is showing. (100% coverage on the new `chrome_ribbon.go` lines.)
- `go test ./head/ui/ ./head/internal/native/` green; gofmt + linter clean.
- **Live capture** on a 620px window confirms the horizontal scrollbar renders below the ribbon panels with the panel-name strip intact above it.

Fixes #1471

🤖 Generated with [Claude Code](https://claude.com/claude-code)