### PR TITLE
fix(head): make the viewport Navigation Bar buttons clickable (#1468)

### DIFF
--- a/app/ui_wiring_guard_test.go
+++ b/app/ui_wiring_guard_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app_test
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+)
+
+// TestRibbonDropdownEntriesAreExecutable is the structural "exposed-but-unwired UI" guard for the
+// id-dispatched parts of the ribbon (#1468 investigation). A split-button head exposes VARIANTS in
+// its dropdown; clicking one routes through Session.Execute(variantID) → CommandManager.ByID. But
+// WithVariants only FLAGS its entries (isVariant=true) — it does not register them — so a variant
+// that was attached but never added to the registry is a visible dropdown row whose click silently
+// fails ByID. Likewise a PopupControl lists other commands by string id and silently drops any that
+// do not resolve. This asserts every dropdown entry resolves to a registered, executable command, so
+// an unwired entry fails CI instead of being a dead control the user discovers.
+//
+// (Plain ribbon buttons and selector options are built FROM the registry — their command is a live
+// *CommandDefinition — so they cannot dangle. Menu-bar items call session verbs directly and are
+// compile-checked. On-canvas overlay buttons hold direct func pointers, so their gap is input
+// plumbing, not a missing id — covered by the Navigation Bar click test in head/ui.)
+func TestRibbonDropdownEntriesAreExecutable(t *testing.T) {
+	s := app.NewSession()
+	if err := app.RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	cmds := s.Commands()
+	variants := 0
+	for _, c := range cmds.All() {
+		for _, v := range c.Variants() {
+			variants++
+			if _, ok := cmds.ByID(v.ID()); !ok {
+				t.Errorf("command %q exposes variant %q in its dropdown, but it is not registered — a "+
+					"click routes through Execute→ByID and silently fails (exposed-but-unwired UI)", c.ID(), v.ID())
+			}
+		}
+		if c.Kind() == app.PopupControl {
+			for _, id := range c.PopupItems() {
+				if _, ok := cmds.ByID(id); !ok {
+					t.Errorf("popup command %q lists item id %q that resolves to no registered command — "+
+						"the flyout entry is silently dropped (exposed-but-unwired UI)", c.ID(), id)
+				}
+			}
+		}
+	}
+	if variants == 0 {
+		t.Fatal("no command variants found — the guard is checking nothing; has the registry changed?")
+	}
+}

--- a/app/view.go
+++ b/app/view.go
@@ -29,33 +29,39 @@ func (s *Session) HomeView() { s.SetCamera(s.Camera().Home(s.modelBounds())) }
 // view with the standard tween, recording view history so Previous View returns. A selected work
 // plane wins over a selected face. Reports whether a planar reference was selected (false ⇒ no-op).
 func (s *Session) LookAtSelection() bool {
-	if wp := s.SelectedWorkPlane(); wp != nil {
-		p := wp.Plane()
-		s.lookAtPlane(p.Origin(), p.Normal().AsVector(), p.YAxis().AsVector())
-		return true
-	}
-	if f, ok := s.SelectedFace(); ok {
-		if pl, planar := f.Geometry().(geom.Plane); planar {
-			_, up := pl.DerivativesAt(0, 0) // the plane's in-plane v-axis is a stable screen-up
-			s.lookAtPlane(f.RangeBox().Center(), pl.Normal(), up)
-			return true
-		}
-	}
-	return false
-}
-
-// CanLookAt reports whether the current selection has a planar reference LookAtSelection can face —
-// the enable predicate for the Look At command.
-func (s *Session) CanLookAt() bool {
-	if s.SelectedWorkPlane() != nil {
-		return true
-	}
-	f, ok := s.SelectedFace()
+	target, normal, up, ok := s.lookAtTarget()
 	if !ok {
 		return false
 	}
-	_, planar := f.Geometry().(geom.Plane)
-	return planar
+	s.lookAtPlane(target, normal, up)
+	return true
+}
+
+// lookAtTarget resolves the current selection to a plane the camera can face — a selected work plane
+// or a planar face — returning its centre, normal and a stable screen-up. ok=false when the selection
+// has no such target. Shared by LookAtSelection and CanLookAtSelection so the action and its
+// enablement can never disagree (#1468 follow-up).
+func (s *Session) lookAtTarget() (target math.Point3, normal, up math.Vector3, ok bool) {
+	if wp := s.SelectedWorkPlane(); wp != nil {
+		p := wp.Plane()
+		return p.Origin(), p.Normal().AsVector(), p.YAxis().AsVector(), true
+	}
+	if f, sel := s.SelectedFace(); sel {
+		if pl, planar := f.Geometry().(geom.Plane); planar {
+			_, v := pl.DerivativesAt(0, 0) // the plane's in-plane v-axis is a stable screen-up
+			return f.RangeBox().Center(), pl.Normal(), v, true
+		}
+	}
+	return math.Point3{}, math.Vector3{}, math.Vector3{}, false
+}
+
+// CanLookAt reports whether the current selection has a planar reference LookAtSelection can face (a
+// work plane or planar face) — the enable predicate for the Look At command, used to disable the
+// Navigation Bar's Look At button when a click would be a no-op (#1468 follow-up). It shares
+// lookAtTarget with the action, so the two can never disagree.
+func (s *Session) CanLookAt() bool {
+	_, _, _, ok := s.lookAtTarget()
+	return ok
 }
 
 // ToggleSteeringWheel shows or hides the SteeringWheels radial navigation menu (#913 N26) — a

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -82,6 +82,7 @@ void obk_ig_begin_disabled(int disabled);
 void obk_ig_end_disabled(void);
 int  obk_ig_want_capture_mouse(void);
 int  obk_ig_invisible_button(const char* id, float w, float h);
+int  obk_ig_begin_overlay_window(const char* name);
 int  obk_ig_is_item_active(void);
 int  obk_ig_is_item_hovered(void);
 int  obk_ig_mouse_down(int button);
@@ -893,6 +894,16 @@ func InvisibleButton(id string, w, h float32) {
 	c, free := cstr(id)
 	defer free()
 	C.obk_ig_invisible_button(c, C.float(w), C.float(h))
+}
+
+// BeginOverlayWindow opens a borderless, transparent, auto-sized floating window for on-canvas
+// controls (the Navigation Bar). As its own window it receives clicks on its buttons while the
+// viewport keeps drag-to-orbit everywhere else — ImGui routes the cursor to the topmost window under
+// it (#1468). Position it first with SetNextWindowPos; pair with End regardless of the return value.
+func BeginOverlayWindow(name string) bool {
+	c, free := cstr(name)
+	defer free()
+	return C.obk_ig_begin_overlay_window(c) != 0
 }
 
 // IsItemActive / IsItemHovered report the state of the most recent item (the viewport

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -542,6 +542,17 @@ int  obk_ig_invisible_button(const char* id, float w, float h) {
         ImGuiButtonFlags_MouseButtonLeft | ImGuiButtonFlags_MouseButtonRight |
         ImGuiButtonFlags_MouseButtonMiddle) ? 1 : 0;
 }
+// begin_overlay_window opens a borderless, transparent, auto-sized floating window for on-canvas
+// controls (the Navigation Bar). Being its OWN window — not items inside the viewport window — its
+// buttons receive clicks while the viewport's full-region InvisibleButton keeps the drag-to-orbit
+// everywhere else, because ImGui routes the cursor to the topmost window under it (#1468). Pair with
+// obk_ig_end regardless of the return value.
+int obk_ig_begin_overlay_window(const char* name) {
+    ImGuiWindowFlags f = ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove |
+        ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoBackground |
+        ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoDocking;
+    return ImGui::Begin(name, nullptr, f) ? 1 : 0;
+}
 int  obk_ig_is_item_active(void)             { return ImGui::IsItemActive() ? 1 : 0; }
 int  obk_ig_is_item_hovered(void)            { return ImGui::IsItemHovered() ? 1 : 0; }
 int  obk_ig_mouse_down(int button)           { return ImGui::IsMouseDown((ImGuiMouseButton)button) ? 1 : 0; }

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -99,7 +99,7 @@ func drawViewportRubberBands(s *app.Session, bx, by, cx, cy float32, pw, ph int,
 	drawBoxSelectRect(s, bx, by)                // the rubber-band selection rectangle, on top of the image
 	drawZoomWindowRect(s, bx, by)               // the Zoom Window rubber band (#913 N16), if armed
 	drawOrbitRing(bx, by, pw, ph)               // the Free-Orbit ring while F4 is held (#913 N5–N8)
-	drawNavigationBar(s, cx, cy, pw, ph)        // the floating nav-tool strip at the right edge (#913 N25)
+	drawNavigationBar(s, bx, by, pw, ph)        // the floating nav-tool strip at the right edge (#913 N25)
 	drawSteeringWheel(s, cx, cy)                // the on-cursor radial nav menu (#913 N26), if active
 	handleSketchHUD(s, bx, by, viewportHovered) // the 2D-sketch dynamic-input HUD (#790)
 }

--- a/head/ui/navigation_bar.go
+++ b/head/ui/navigation_bar.go
@@ -38,32 +38,45 @@ const (
 )
 
 // drawNavigationBar draws the floating Navigation Bar as a vertical strip of icon buttons at the
-// viewport's right edge, vertically centred (#913 N25). ox,oy is the viewport panel's window-local
-// origin (the cursor position captured before the viewport's InvisibleButton); pw,ph its pixel size.
-// Each button runs its session action; a toggle/armed tool renders accented. No-op when hidden.
-func drawNavigationBar(s *app.Session, ox, oy float32, pw, ph int) {
+// viewport's right edge, vertically centred (#913 N25). bx,by is the viewport's SCREEN origin; pw,ph
+// its pixel size. The strip is its OWN borderless overlay window so its buttons receive clicks while
+// the viewport keeps drag-to-orbit everywhere else — ImGui routes the cursor to the topmost window
+// under it, which a same-window InvisibleButton used to swallow (#1468). Each button runs its session
+// action; a toggle/armed tool renders accented. No-op when hidden.
+func drawNavigationBar(s *app.Session, bx, by float32, pw, ph int) {
 	if !s.ShowNavBar() {
 		return
 	}
 	iconPx := scaledIconPx(navBarIconPx)
-	cell := float32(iconPx + 2*navBarPad)
-	x := ox + float32(pw) - cell - navBarMargin
-	y := oy + (float32(ph)-cell*float32(len(navBarButtons)))/2
-	for _, b := range navBarButtons {
-		if drawNavBarButton(s, b, x, y, iconPx) {
-			y += cell // a button with no icon asset consumes no slot (keeps the strip gapless)
+	x, y := navBarStripRect(bx, by, pw, ph)
+	native.SetNextWindowPos(x, y)
+	if native.BeginOverlayWindow("##navbar") {
+		for _, b := range navBarButtons {
+			drawNavBarButton(s, b, iconPx)
 		}
 	}
+	native.End()
 }
 
-// drawNavBarButton draws one Navigation Bar button at (x,y): its icon at iconPx, accented while
-// its tool is armed/toggled. Returns false (drawing nothing) when the icon asset is missing.
-func drawNavBarButton(s *app.Session, b navBarButton, x, y float32, iconPx int) bool {
+// navBarStripRect is the strip's top-left corner in the given coordinate frame whose origin (ox,oy)
+// is the viewport's top-left: a right-edge vertical strip of len(navBarButtons) cells, vertically
+// centred. The overlay window is positioned here.
+func navBarStripRect(ox, oy float32, pw, ph int) (x, y float32) {
+	cell := float32(scaledIconPx(navBarIconPx) + 2*navBarPad)
+	x = ox + float32(pw) - cell - navBarMargin
+	y = oy + (float32(ph)-cell*float32(len(navBarButtons)))/2
+	return x, y
+}
+
+// drawNavBarButton draws one Navigation Bar button at the overlay window's current cursor: its icon
+// at iconPx, accented while its tool is armed/toggled. Returns false (drawing nothing) when the icon
+// asset is missing. Clicking it runs the tool — which now reaches it, since the strip is its own
+// window rather than items under the viewport's input-capturing button (#1468).
+func drawNavBarButton(s *app.Session, b navBarButton, iconPx int) bool {
 	tex, ok := icons.texture(b.icon, "", iconPx)
 	if !ok {
 		return false
 	}
-	native.SetCursorPos(x, y)
 	on := b.active != nil && b.active(s)
 	if on {
 		native.PushStyleColor("Button", accentColor)
@@ -71,8 +84,17 @@ func drawNavBarButton(s *app.Session, b navBarButton, x, y float32, iconPx int) 
 		native.PushStyleColor("ButtonActive", accentColor)
 		defer native.PopStyleColor(3)
 	}
-	if native.ImageButton(b.id, tex, float32(iconPx), float32(iconPx), identityTint) {
+	clicked := native.ImageButton(b.id, tex, float32(iconPx), float32(iconPx), identityTint)
+	x0, y0 := native.ItemRectMin()
+	x1, y1 := native.ItemRectMax()
+	navBarButtonRect[b.id] = [4]float32{x0, y0, x1, y1} // screen rect, so a click test can target it
+	if clicked {
 		b.run(s)
 	}
 	return true
 }
+
+// navBarButtonRect holds each nav-bar button's screen rect (minX,minY,maxX,maxY) from the last
+// frame it drew, keyed by id. It lets an interaction test click a button by id without recomputing
+// the layout; production code does not read it (#1468 regression guard).
+var navBarButtonRect = map[string][4]float32{}

--- a/head/ui/navigation_bar.go
+++ b/head/ui/navigation_bar.go
@@ -14,21 +14,25 @@ import (
 // (HomeView/FitView/ArmZoomWindow/ToggleConstrainedOrbit/LookAtSelection); this only draws the
 // buttons and routes clicks, so it stays thin.
 
-// navBarButton is one Navigation Bar tool: an icon key, the session action it runs, and an optional
-// active-state predicate (a toggle/armed tool renders accented while on).
+// navBarButton is one Navigation Bar tool: an icon key, the session action it runs, an optional
+// active-state predicate (a toggle/armed tool renders accented while on), and an optional enabled
+// predicate (a nil enabled means always enabled; false greys the button out and blocks the click).
 type navBarButton struct {
 	id, icon string
 	run      func(*app.Session)
 	active   func(*app.Session) bool
+	enabled  func(*app.Session) bool
 }
 
 // navBarButtons are the bar's tools, top to bottom.
 var navBarButtons = []navBarButton{
-	{"navbar.home", "home", func(s *app.Session) { s.HomeView() }, nil},
-	{"navbar.fit", "zoom-all", func(s *app.Session) { s.FitView() }, nil},
-	{"navbar.zoomWindow", "zoom-window", func(s *app.Session) { s.ArmZoomWindow() }, (*app.Session).ZoomWindowArmed},
-	{"navbar.constrainedOrbit", "orbit-constrained", func(s *app.Session) { s.ToggleConstrainedOrbit() }, (*app.Session).ConstrainedOrbitActive},
-	{"navbar.lookAt", "look-at", func(s *app.Session) { s.LookAtSelection() }, nil},
+	{"navbar.home", "home", func(s *app.Session) { s.HomeView() }, nil, nil},
+	{"navbar.fit", "zoom-all", func(s *app.Session) { s.FitView() }, nil, nil},
+	{"navbar.zoomWindow", "zoom-window", func(s *app.Session) { s.ArmZoomWindow() }, (*app.Session).ZoomWindowArmed, nil},
+	{"navbar.constrainedOrbit", "orbit-constrained", func(s *app.Session) { s.ToggleConstrainedOrbit() }, (*app.Session).ConstrainedOrbitActive, nil},
+	// Look At only orients to a selected work plane / planar face, so it disables with nothing
+	// suitable selected — a click would otherwise be a silent no-op (#1468 follow-up).
+	{"navbar.lookAt", "look-at", func(s *app.Session) { s.LookAtSelection() }, nil, (*app.Session).CanLookAt},
 }
 
 const (
@@ -83,6 +87,10 @@ func drawNavBarButton(s *app.Session, b navBarButton, iconPx int) bool {
 		native.PushStyleColor("ButtonHovered", accentColor)
 		native.PushStyleColor("ButtonActive", accentColor)
 		defer native.PopStyleColor(3)
+	}
+	if b.enabled != nil && !b.enabled(s) {
+		native.BeginDisabled(true) // greys the icon and blocks the click when the tool can't run
+		defer native.EndDisabled()
 	}
 	clicked := native.ImageButton(b.id, tex, float32(iconPx), float32(iconPx), identityTint)
 	x0, y0 := native.ItemRectMin()

--- a/head/ui/navigation_bar_click_test.go
+++ b/head/ui/navigation_bar_click_test.go
@@ -1,0 +1,68 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// clickNavBarButton renders the viewport, locates the named nav-bar button's screen rect, and
+// injects a full left click at its centre (hover one frame first so the allow-overlap button can
+// take the press), then settles. Reports false if the button was not drawn.
+func clickNavBarButton(win *native.Window, s *app.Session, id string) bool {
+	viewportFrame(win, s) // draw once to record the button rects
+	r, ok := navBarButtonRect[id]
+	if !ok {
+		return false
+	}
+	cx, cy := (r[0]+r[2])/2, (r[1]+r[3])/2
+	native.InjectMousePos(cx, cy)
+	viewportFrame(win, s) // establish hover before the press (allow-overlap settles over one frame)
+	native.InjectMouseButton(native.MouseLeft, true)
+	viewportFrame(win, s)
+	native.InjectMouseButton(native.MouseLeft, false)
+	viewportFrame(win, s)
+	return true
+}
+
+// TestNavBarButtonClicksReachActions is the #1468 regression guard: clicking a Navigation Bar button
+// must fire its action. The bug was that the full-viewport InvisibleButton (submitted first) swallowed
+// the click via ImGui's overlap rule, so the overlay buttons never fired. We click two buttons whose
+// effect is a deterministic session flag and assert the flag flipped — which only happens if the
+// click actually reached the button.
+func TestNavBarButtonClicksReachActions(t *testing.T) {
+	cases := []struct {
+		id    string
+		state func(*app.Session) bool // the flag the button's action sets, false until clicked
+	}{
+		{"navbar.zoomWindow", (*app.Session).ZoomWindowArmed},
+		{"navbar.constrainedOrbit", (*app.Session).ConstrainedOrbitActive},
+	}
+	for _, c := range cases {
+		t.Run(c.id, func(t *testing.T) {
+			win := newViewportWindow(t)
+			defer win.Destroy()
+			dockLaidOut = false // fresh layout for this window/context
+			icons = nil
+			s := framedSession()
+			if !s.ShowNavBar() {
+				t.Skip("nav bar hidden")
+			}
+			if c.state(s) {
+				t.Fatalf("%s state should start false", c.id)
+			}
+			if !clickNavBarButton(win, s, c.id) {
+				t.Fatalf("%s button was not drawn", c.id)
+			}
+			if !c.state(s) {
+				t.Errorf("clicking %s did not fire its action — the viewport swallowed the click (#1468)", c.id)
+			}
+			native.InjectMouseButton(native.MouseLeft, false)
+		})
+	}
+}

--- a/head/ui/navigation_bar_click_test.go
+++ b/head/ui/navigation_bar_click_test.go
@@ -9,6 +9,7 @@ import (
 
 	"oblikovati.org/app"
 	"oblikovati.org/head/internal/native"
+	"oblikovati.org/model/compdef"
 )
 
 // clickNavBarButton renders the viewport, locates the named nav-bar button's screen rect, and
@@ -65,4 +66,46 @@ func TestNavBarButtonClicksReachActions(t *testing.T) {
 			native.InjectMouseButton(native.MouseLeft, false)
 		})
 	}
+}
+
+// TestNavBarLookAtEnablement covers the Look At button's enable state (#1468 follow-up): it is
+// disabled — a click is a no-op — when nothing it can orient to is selected, and enabled (the click
+// swings the camera) once a work plane is selected.
+func TestNavBarLookAtEnablement(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+	s := app.NewSession()
+	pd, err := compdef.AddPart(s.Workspace(), "lookat.opd", true)
+	if err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	_ = s.Workspace().SetActiveDocument(pd)
+	def := pd.Content().(*compdef.PartComponentDefinition)
+	if !s.ShowNavBar() {
+		t.Skip("nav bar hidden")
+	}
+
+	// Nothing selected: the button is disabled and a click moves nothing.
+	if s.CanLookAt() {
+		t.Fatal("precondition: nothing selected, CanLookAt should be false")
+	}
+	if !clickNavBarButton(win, s, "navbar.lookAt") {
+		t.Fatal("look-at button was not drawn")
+	}
+	if s.CameraAnimating() {
+		t.Error("Look At should be disabled (no-op) with nothing selected")
+	}
+
+	// Select a work plane: now enabled, the click swings the view to face it.
+	s.Selection().Add(app.WorkPlaneHandle{Plane: def.OriginPlanes()[0]})
+	if !s.CanLookAt() {
+		t.Fatal("CanLookAt should be true with a work plane selected")
+	}
+	clickNavBarButton(win, s, "navbar.lookAt")
+	if !s.CameraAnimating() {
+		t.Error("clicking the enabled Look At button did not start the look-at swing")
+	}
+	native.InjectMouseButton(native.MouseLeft, false)
 }


### PR DESCRIPTION
## What
The 5 viewport **Navigation Bar** buttons on the center-right (Home, Fit, Zoom Window, Constrained Orbit, Look At) now work when clicked.

## Why
A user reported (#1468) that these buttons do nothing. They were ImGui `ImageButton`s drawn in the *same window as*, and on top of, the full-viewport `InvisibleButton` submitted first. ImGui's overlap rule gives the earlier background button the hover/active id, so the nav buttons never received a click — and the press was consumed as an orbit drag.

## How
- New native `BeginOverlayWindow` — a borderless, transparent, auto-sized floating window. The nav strip is drawn in **its own window** positioned at the viewport's right edge. As a separate window its buttons get clicks, while the viewport keeps drag-to-orbit everywhere else (ImGui routes the cursor to the topmost window under it). This is the same pattern the working minitoolbars use; the camera path is untouched.
- (Tried `SetNextItemAllowOverlap` on the background button first — it broke drag-to-orbit, so the separate-window approach is the right one.)

## Guard tests (the "exposed but unwired UI" investigation)
The codebase has two UI→handler wiring models, needing different guards:
1. **Overlay buttons** (nav bar, steering wheel) hold direct func pointers — the handler is never nil, so the gap is *input plumbing*, only catchable by interaction tests. Added `TestNavBarButtonClicksReachActions`: injects a real click at each toggle button's screen rect and asserts the session flag flipped (it **fails on the pre-fix bug**, confirmed).
2. **Id-dispatched dropdowns** (ribbon split-button variants, popup items) carry string ids resolved via `Execute→ByID`, and silently drop/ no-op if unregistered. Added `TestRibbonDropdownEntriesAreExecutable` (app): every variant/popup id must resolve to a registered command. (Plain ribbon buttons & selector options are built *from* the registry and can't dangle; menu items call verbs directly and are compile-checked.)

## Verification
- New click test passes with the fix, fails without it; the docked-viewport orbit test still passes (orbit untouched).
- `go test ./head/ui/ ./head/internal/native/ ./app/` green; 100% coverage on the new head/ui lines; gofmt/lint clean.
- **Live capture**: the strip renders at the viewport's right edge with the Constrained Orbit button accented after toggling — buttons present, stateful, and (per the click test) clickable.

Fixes #1468

🤖 Generated with [Claude Code](https://claude.com/claude-code)