### PR TITLE
fix: keep the analytic cylinder wall when drilling a circular hole into a box (#1472)

### DIFF
--- a/model/feature/circular_cut_analytic_test.go
+++ b/model/feature/circular_cut_analytic_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// circleSketchAt builds a sketch with one full circle at (cx,cy) of the given radius.
+func circleSketchAt(cx, cy, r float64) *sketch.Sketch {
+	s := sketch.NewSketches().Add(sketch.XYPlane())
+	s.Circles().AddByCenterRadius(math.P2(cx, cy), r)
+	return s
+}
+
+// closedCircleEdgeCount tallies edges whose curve is a full geom.Circle (a single circular rim — the
+// edge a user clicks to fillet), as opposed to many short line segments.
+func closedCircleEdgeCount(b *topo.Body) int {
+	n := 0
+	for _, e := range b.Edges() {
+		if _, ok := e.Geometry().(geom.Circle); ok {
+			n++
+		}
+	}
+	return n
+}
+
+// TestCircularCutKeepsCircleEdge is the #1472 regression: cutting a cylindrical hole through a box must
+// leave a TRUE cylindrical hole wall bounded by single circular edges (the rim a user fillets), not a
+// 24-gon faceted prism. The bug was that combine() pre-faceted the analytic cylinder TOOL before the
+// boolean because its curved-boolean gate only routed the mirror case (a curved solid cut by a planar
+// box). The box−cylinder cut now reaches the exact M2 path (curvedCylindricalHoleCut), which the kernel
+// already supported but the model layer never fed an analytic cylinder.
+func TestCircularCutKeepsCircleEdge(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	ex := NewExtrudeFeatures(fs)
+
+	// Box: 4×4 rectangle extruded 5 deep (the report's Extrusion1, squared off for a clean volume check).
+	ex.AddExtrude(squareSketch(4), []int{0}, ops.NewBody,
+		Extent{Type: DistanceExtent, Direction: PositiveDir, Distance: func() float64 { return 5 }}, 0)
+
+	// Circular cut: a r=1 circle centred in the box, drilled through.
+	ex.AddExtrude(circleSketchAt(2, 2, 1), []int{0}, ops.Cut,
+		Extent{Type: ThroughAllExtent, Direction: SymmetricDir}, 0)
+
+	fs.Recompute()
+	bodies := fs.Result()
+	if len(bodies) != 1 {
+		t.Fatalf("box+cut = %d bodies, want 1", len(bodies))
+	}
+	body := bodies[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("box+cut is not a valid solid: %+v", r.Issues)
+	}
+
+	// 6 box faces + 1 cylindrical hole wall = 7; the wall is bounded by 2 full circular edges (top & bottom).
+	if got := cylinderFaceCount(body); got != 1 {
+		t.Errorf("hole wall = %d cylinder faces, want 1 (the rim was faceted into a prism — #1472)", got)
+	}
+	if got := closedCircleEdgeCount(body); got != 2 {
+		t.Errorf("hole has %d full-circle edges, want 2 (the circular rim shattered into segments — #1472)", got)
+	}
+	if got := len(body.Faces()); got != 7 {
+		t.Errorf("drilled box has %d faces, want 7 (6 box + 1 cylinder wall)", got)
+	}
+
+	// Volume: 4·4·5 box − π·1²·5 cylinder = 80 − 5π.
+	want := 4.0*4.0*5.0 - stdmath.Pi*1.0*1.0*5.0
+	if got := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; relErr(got, want) > 0.01 {
+		t.Errorf("drilled box volume = %g, want ≈%g (80 − 5π)", got, want)
+	}
+}

--- a/model/feature/extrude.go
+++ b/model/feature/extrude.go
@@ -172,13 +172,14 @@ func combine(running []*topo.Body, body *topo.Body, op ops.PartFeatureOperation)
 		return append(append([]*topo.Body(nil), running...), body), nil
 	}
 	target := running[len(running)-1]
-	// First try the EXACT curved boolean on the still-analytic operands when the target is a BARE analytic
-	// primitive (exactly one curved face — a revolved torus, an extruded cylinder/cone, a sphere) and the
-	// tool is all-planar (a prism): those keep their curved faces through the M2 curved boolean
-	// (#1334/#1335). The single-curved-face gate is deliberately tight — a composite curved body (a washer's
-	// two cylinder walls, a filleted edge) is NOT a primitive the half-space cut handles, so it stays on the
-	// faceted planar path; CurvedBoolean can over-match such a body and cut it wrongly.
-	if curvedFaceCount(target) == 1 && curvedFaceCount(body) == 0 {
+	// First try the EXACT curved boolean on the still-analytic operands when exactly one of them is a BARE
+	// analytic primitive and the other is all-planar (see exactlyOneCurvedPrimitive): the result keeps the
+	// curved surface through the M2 curved boolean instead of being re-faceted into a prism. This routes BOTH
+	// directions — a curved solid cut by a planar box (#1334/#1335) AND a planar box drilled/joined by a
+	// cylinder/cone tool, which previously fell through to faceting and shattered the hole rim into 24 straight
+	// segments (#1472). CurvedBoolean takes (target, tool) in feature order; each kernel path checks its own
+	// operand roles, so the same call serves both directions.
+	if exactlyOneCurvedPrimitive(target, body) {
 		if res, ok := ops.CurvedBoolean(op, target, body); ok {
 			return appendCombined(running, res), nil
 		}

--- a/model/feature/planarize.go
+++ b/model/feature/planarize.go
@@ -40,6 +40,18 @@ func curvedFaceCount(b *topo.Body) int {
 	return n
 }
 
+// exactlyOneCurvedPrimitive reports whether exactly one of target/tool is a BARE analytic primitive
+// (a single curved face — an extruded cylinder/cone, a revolved torus, a sphere) and the other is
+// all-planar. Only then can the exact M2 curved boolean keep the curved surface: a box drilled by a
+// cylinder tool keeps its cylindrical hole wall (#1472), the mirror of a curved solid cut by a planar
+// box (#1334/#1335). The single-curved-face gate is deliberately tight — a composite curved body (a
+// washer's two cylinder walls, a filleted edge) is NOT a primitive the half-space cut handles, so it
+// stays on the faceted planar path; CurvedBoolean can over-match such a body and cut it wrongly.
+func exactlyOneCurvedPrimitive(target, tool *topo.Body) bool {
+	tc, oc := curvedFaceCount(target), curvedFaceCount(tool)
+	return (tc == 1 && oc == 0) || (tc == 0 && oc == 1)
+}
+
 // planarized converts a body with analytic curved faces into a planar B-rep the exact boolean can
 // consume (it hangs on a full periodic curved face, #129). A SIMPLE extrude-circle cylinder becomes
 // a clean, key-stable N-gon prism (the fast path that keeps downstream edge identity); any OTHER


### PR DESCRIPTION
## What

A circular extrude-**cut** into a box now keeps a **true cylindrical hole wall bounded by a single circular edge**, instead of shattering the rim into 24 straight segments. The hole is selectable and filletable, and renders as a smooth circle.

## Why

Reported in #1472: cutting a cylindrical hole into a box divided the cut edge into many tiny line segments, making it impossible to fillet the circular rim.

Root cause was in the **model layer**, not the kernel boolean:
- The extrude tool for a circle was already built as a true analytic `geom.Cylinder` (`buildAnalyticCylinder`).
- The kernel boolean already had an **exact** box−cylinder path (`curvedCylindricalHoleCut`, the "drilled plate" #1336) — `TestDrilledPlateIsExact` proves it.
- But `combine()`'s curved-boolean gate only routed the **mirror** direction (a curved *target* cut by a planar box tool — #1334/#1335). For a cut the cylinder is the **tool**, so the gate fell through and `planarized()` re-faceted the analytic cylinder into a `regularPolygon(r, 24)` prism **before** the boolean ran. The exact path never received an analytic cylinder.

## How

Broaden the gate (`exactlyOneCurvedPrimitive`) to fire whenever **exactly one** operand is a bare curved primitive (a single curved face) and the other is all-planar — routing **both** directions through the exact M2 curved boolean. Each kernel path checks its own operand roles, so the same `CurvedBoolean(op, target, tool)` call serves both directions; a non-matching case still declines (`ok=false`) and safely falls through to the faceted planar path.

Result for the reported scenario: **7 faces (6 box + 1 cylinder wall), 2 full-circle edges** — was 30 faces / 0 circle edges.

## Verification

- New regression test `TestCircularCutKeepsCircleEdge` (asserts 1 cylinder wall, 2 circle edges, 7 faces, and volume = 80 − 5π). Fails on `develop`, passes here.
- Live render of the drilled box from the real `DrawChrome` viewport shows a smooth circular hole with a curved cylindrical interior (no facets).
- Full `model/...` and `kernel/ops` suites green; lint/vet/gofmt clean.

Fixes #1472

🤖 Generated with [Claude Code](https://claude.com/claude-code)