### PR TITLE
feat: report each body's assigned material in body.list

### DIFF
--- a/addin/router/bodies.go
+++ b/addin/router/bodies.go
@@ -53,7 +53,8 @@ func bodyListResult(s *app.Session, part *compdef.PartComponentDefinition) (json
 }
 
 // bodyInfo builds a body's wire summary: its display name, visibility (#158), persistent
-// reference key and assigned color-style name (#1078).
+// reference key, assigned color-style name (#1078) and effective material id (the read-back
+// of the write-only assignMaterial, for analysis add-ins).
 func bodyInfo(s *app.Session, index int, b *topo.Body) wire.BodyInfo {
 	key := string(b.ReferenceKey())
 	style, _ := s.BodyColorStyle(key)
@@ -61,7 +62,7 @@ func bodyInfo(s *app.Session, index int, b *topo.Body) wire.BodyInfo {
 		Index: index, Name: bodyDisplayName(s, index, key), Solid: b.IsSolid(), Visible: s.BodyVisible(b),
 		Faces: len(b.Faces()), Edges: len(b.Edges()), Vertices: len(b.Vertices()),
 		Shells: len(b.Shells()), Wires: len(b.Wires()),
-		Key: key, Style: style,
+		Key: key, Style: style, MaterialID: s.BodyMaterialID(key),
 	}
 }
 

--- a/addin/router/body_m07_test.go
+++ b/addin/router/body_m07_test.go
@@ -49,6 +49,38 @@ func TestBodyListAndShells(t *testing.T) {
 	}
 }
 
+// TestBodyListReportsMaterial: body.list reports each body's effective material id — the
+// part default, then a body-level override winning over it — the read-back of the write-only
+// assignMaterial that an analysis add-in uses for per-body material models.
+func TestBodyListReportsMaterial(t *testing.T) {
+	r, s := boxPartSession(t)
+
+	var before wire.BodyListResult
+	call(t, r, s, "body.list", `{}`, &before)
+	if before.Bodies[0].MaterialID != "" {
+		t.Fatalf("unassigned body materialID = %q, want empty", before.Bodies[0].MaterialID)
+	}
+	key := before.Bodies[0].Key
+
+	// Part-level default reaches the body.
+	call(t, r, s, "model.assignMaterial", `{"materialId":"steel"}`, nil)
+	var afterPart wire.BodyListResult
+	call(t, r, s, "body.list", `{}`, &afterPart)
+	if afterPart.Bodies[0].MaterialID != "steel" {
+		t.Fatalf("materialID after part assign = %q, want steel", afterPart.Bodies[0].MaterialID)
+	}
+
+	// A body-level override wins over the part default. The reference key is raw bytes, so
+	// JSON-encode the args rather than string-formatting them.
+	assignArgs := mustJSON(t, wire.AssignMaterialArgs{BodyKey: key, MaterialID: "aluminum-6061"})
+	call(t, r, s, "model.assignMaterial", assignArgs, nil)
+	var afterBody wire.BodyListResult
+	call(t, r, s, "body.list", `{}`, &afterBody)
+	if afterBody.Bodies[0].MaterialID != "aluminum-6061" {
+		t.Fatalf("materialID after body override = %q, want aluminum-6061", afterBody.Bodies[0].MaterialID)
+	}
+}
+
 // TestBodyMinimumDistance: a transient travel polyline measured against the box — clearance above
 // the top face, tool-radius widening, and a piercing move clamped to 0; plus the malformed-input
 // guard. Distances are database units (cm); the box top is at z=5.

--- a/app/material_ops.go
+++ b/app/material_ops.go
@@ -29,6 +29,18 @@ func (s *Session) ActivePartMaterialID() string {
 	return part.Assignments().PartMaterial()
 }
 
+// BodyMaterialID returns the effective material id assigned to a body (its own override, else
+// the part default), or "" when none is assigned and there is no active part. The body.list
+// router reports it so an analysis add-in can resolve each body's material (#1078 read-back of
+// the write-only AssignMaterial).
+func (s *Session) BodyMaterialID(bodyKey string) string {
+	part, err := activePart(s)
+	if err != nil {
+		return ""
+	}
+	return part.Assignments().EffectiveMaterialID(bodyKey)
+}
+
 // ActivePartAppearanceID returns the active part's assigned part-level appearance id, or "".
 func (s *Session) ActivePartAppearanceID() string {
 	part, err := activePart(s)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.91.0
+	oblikovati.org/api v0.92.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.91.0
+	oblikovati.org/api v0.92.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/material/assignment.go
+++ b/model/material/assignment.go
@@ -65,13 +65,21 @@ type AssetLookup interface {
 	DefaultAppearance() *Appearance
 }
 
+// EffectiveMaterialID returns the id of the material governing a body — its own override if
+// set, else the part default — or "" when none is assigned. It is the id-only form of
+// EffectiveMaterial, for callers (e.g. the body.list router) that report the assignment
+// without resolving the material's properties.
+func (s *AssignmentStore) EffectiveMaterialID(bodyKey string) string {
+	if id := s.bodyMaterial[bodyKey]; id != "" {
+		return id
+	}
+	return s.partMaterial
+}
+
 // EffectiveMaterial returns the material governing a body (its override, else the part
 // default), or false when none is assigned.
 func (s *AssignmentStore) EffectiveMaterial(look AssetLookup, bodyKey string) (*Material, bool) {
-	id := s.bodyMaterial[bodyKey]
-	if id == "" {
-		id = s.partMaterial
-	}
+	id := s.EffectiveMaterialID(bodyKey)
 	if id == "" {
 		return nil, false
 	}

--- a/model/material/assignment_test.go
+++ b/model/material/assignment_test.go
@@ -57,6 +57,21 @@ func TestEffectiveMaterialOverride(t *testing.T) {
 	}
 }
 
+func TestEffectiveMaterialID(t *testing.T) {
+	st := NewAssignmentStore()
+	if got := st.EffectiveMaterialID("b1"); got != "" {
+		t.Errorf("unassigned body material id = %q, want empty", got)
+	}
+	st.SetPartMaterial("steel")
+	st.SetBodyMaterial("b1", "aluminum-6061")
+	if got := st.EffectiveMaterialID("b1"); got != "aluminum-6061" {
+		t.Errorf("b1 material id = %q, want aluminum-6061 (override)", got)
+	}
+	if got := st.EffectiveMaterialID("b2"); got != "steel" {
+		t.Errorf("b2 material id = %q, want steel (part default)", got)
+	}
+}
+
 func TestSetEmptyClearsAssignment(t *testing.T) {
 	st := NewAssignmentStore()
 	st.SetBodyMaterial("b1", "steel")


### PR DESCRIPTION
## What

Populates the new `BodyInfo.MaterialID` (api v0.92.0) in `body.list` from the per-body material assignment, so an add-in can read which material is on each body.

## Why

`model.assignMaterial` was write-only — no read-back. The CalculiX FEA add-in needs each body's material to build a **per-body material model** for multi-material ELSETs.

## How

- `AssignmentStore.EffectiveMaterialID` — id-only form of `EffectiveMaterial` (body override → part default → "").
- `Session.BodyMaterialID` exposes it; the `body.list` router fills `MaterialID` per body.
- Bumps the api pin to v0.92.0.

Tests: `EffectiveMaterialID` unit test; router test asserting `body.list` reports the part default then a body-level override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)