### PR TITLE
attributes: resolve the target selector (per-body/face anchors)

### DIFF
--- a/addin/router/attributes.go
+++ b/addin/router/attributes.go
@@ -30,14 +30,33 @@ func (r *Router) registerAttributeHandlers() {
 	r.readOnly(wire.MethodAttributesFind, findByAttribute)
 }
 
-// documentAttributeSets resolves the open document's document-level attribute sets, anchored under
-// the well-known [identity.DocumentKey].
-func documentAttributeSets(s *app.Session, id uint64, method string) (*attr.AttributeSets, error) {
+// targetKey resolves a wire target string to the reference key that anchors its attributes: the
+// document itself when empty, otherwise the entity addressed by its (opaque, external) reference
+// key — the body/face/edge key an add-in received from body.list / model.referenceKeys.
+func targetKey(target string) identity.RefKey {
+	if target == "" {
+		return identity.DocumentKey()
+	}
+	return identity.ExternalKey([]byte(target))
+}
+
+// targetString renders an anchor key back to the wire target an add-in addressed it by: empty for
+// the document, the external reference key for an entity anchor.
+func targetString(key identity.RefKey) string {
+	if ref, ok := key.ExternalRef(); ok {
+		return string(ref)
+	}
+	return ""
+}
+
+// targetAttributeSets resolves the attribute sets anchored to target (empty = the document) on the
+// open document.
+func targetAttributeSets(s *app.Session, id uint64, target, method string) (*attr.AttributeSets, error) {
 	d, err := documentByID(s, id)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", method, err)
 	}
-	return d.Attributes().AttributeSets(identity.DocumentKey()), nil
+	return d.Attributes().AttributeSets(targetKey(target)), nil
 }
 
 // setAttribute creates or replaces the named attribute in the set with the typed value.
@@ -49,12 +68,12 @@ func setAttribute(s *app.Session, raw json.RawMessage) (json.RawMessage, error) 
 	if in.Set == "" || in.Name == "" {
 		return nil, fmt.Errorf("%s: a set and a name are required", wire.MethodAttributesSet)
 	}
-	ss, err := documentAttributeSets(s, in.Document, wire.MethodAttributesSet)
+	ss, err := targetAttributeSets(s, in.Document, in.Target, wire.MethodAttributesSet)
 	if err != nil {
 		return nil, err
 	}
 	a := ss.Set(in.Set).Put(in.Name, valueFromVariant(in.Value))
-	return json.Marshal(wire.AttributeResult{Attribute: attributeInfo(in.Set, a), Found: true})
+	return json.Marshal(wire.AttributeResult{Attribute: attributeInfo(in.Set, in.Target, a), Found: true})
 }
 
 // getAttribute reads one attribute by set and name; Found is false when it is absent.
@@ -63,19 +82,19 @@ func getAttribute(s *app.Session, raw json.RawMessage) (json.RawMessage, error) 
 	if err := decode(raw, &in); err != nil {
 		return nil, err
 	}
-	ss, err := documentAttributeSets(s, in.Document, wire.MethodAttributesGet)
+	ss, err := targetAttributeSets(s, in.Document, in.Target, wire.MethodAttributesGet)
 	if err != nil {
 		return nil, err
 	}
 	set, ok := ss.Lookup(in.Set)
 	if !ok {
-		return json.Marshal(notFoundAttribute(in.Set, in.Name))
+		return json.Marshal(notFoundAttribute(in.Set, in.Name, in.Target))
 	}
 	a, ok := set.Attribute(in.Name)
 	if !ok {
-		return json.Marshal(notFoundAttribute(in.Set, in.Name))
+		return json.Marshal(notFoundAttribute(in.Set, in.Name, in.Target))
 	}
-	return json.Marshal(wire.AttributeResult{Attribute: attributeInfo(in.Set, a), Found: true})
+	return json.Marshal(wire.AttributeResult{Attribute: attributeInfo(in.Set, in.Target, a), Found: true})
 }
 
 // listAttributes returns every attribute on the document, or only those in Set when it is set.
@@ -84,20 +103,22 @@ func listAttributes(s *app.Session, raw json.RawMessage) (json.RawMessage, error
 	if err := decode(raw, &in); err != nil {
 		return nil, err
 	}
-	ss, err := documentAttributeSets(s, in.Document, wire.MethodAttributesList)
+	if in.AllTargets {
+		d, err := documentByID(s, in.Document)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", wire.MethodAttributesList, err)
+		}
+		var infos []wire.AttributeInfo
+		for _, anchor := range d.Attributes().Anchors() {
+			infos = appendSetInfos(infos, anchor.Sets, in.Set, targetString(anchor.Key))
+		}
+		return json.Marshal(wire.ListAttributesResult{Attributes: infos})
+	}
+	ss, err := targetAttributeSets(s, in.Document, in.Target, wire.MethodAttributesList)
 	if err != nil {
 		return nil, err
 	}
-	var infos []wire.AttributeInfo
-	for _, set := range ss.Sets() {
-		if in.Set != "" && set.Name() != in.Set {
-			continue
-		}
-		for _, a := range set.Attributes() {
-			infos = append(infos, attributeInfo(set.Name(), a))
-		}
-	}
-	return json.Marshal(wire.ListAttributesResult{Attributes: infos})
+	return json.Marshal(wire.ListAttributesResult{Attributes: appendSetInfos(nil, ss, in.Set, in.Target)})
 }
 
 // listAttributeSets returns the document's attribute set names, sorted.
@@ -106,7 +127,7 @@ func listAttributeSets(s *app.Session, raw json.RawMessage) (json.RawMessage, er
 	if err := decode(raw, &in); err != nil {
 		return nil, err
 	}
-	ss, err := documentAttributeSets(s, in.Document, wire.MethodAttributesListSets)
+	ss, err := targetAttributeSets(s, in.Document, "", wire.MethodAttributesListSets)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +143,7 @@ func deleteAttribute(s *app.Session, raw json.RawMessage) (json.RawMessage, erro
 	if err := decode(raw, &in); err != nil {
 		return nil, err
 	}
-	ss, err := documentAttributeSets(s, in.Document, wire.MethodAttributesDelete)
+	ss, err := targetAttributeSets(s, in.Document, in.Target, wire.MethodAttributesDelete)
 	if err != nil {
 		return nil, err
 	}
@@ -156,20 +177,34 @@ func findByAttribute(s *app.Session, raw json.RawMessage) (json.RawMessage, erro
 		for _, h := range d.Attributes().FindAttributes(in.Set, in.Name) {
 			matches = append(matches, wire.AttributeMatch{
 				Document:  uint64(d.ID()),
-				Attribute: attributeInfo(h.Set.Name(), h.Attribute),
+				Attribute: attributeInfo(h.Set.Name(), targetString(h.Key), h.Attribute),
 			})
 		}
 	}
 	return json.Marshal(wire.FindByAttributeResult{Matches: matches})
 }
 
-// attributeInfo renders a model attribute in set as a wire DTO.
-func attributeInfo(set string, a *attr.Attribute) wire.AttributeInfo {
-	return wire.AttributeInfo{Set: set, Name: a.Name(), Value: variantFromValue(a.Value())}
+// appendSetInfos appends one anchor's attributes (filtered to setFilter when non-empty), each
+// stamped with target, to infos.
+func appendSetInfos(infos []wire.AttributeInfo, ss *attr.AttributeSets, setFilter, target string) []wire.AttributeInfo {
+	for _, set := range ss.Sets() {
+		if setFilter != "" && set.Name() != setFilter {
+			continue
+		}
+		for _, a := range set.Attributes() {
+			infos = append(infos, attributeInfo(set.Name(), target, a))
+		}
+	}
+	return infos
+}
+
+// attributeInfo renders a model attribute in set, anchored to target, as a wire DTO.
+func attributeInfo(set, target string, a *attr.Attribute) wire.AttributeInfo {
+	return wire.AttributeInfo{Set: set, Name: a.Name(), Value: variantFromValue(a.Value()), Target: target}
 }
 
 // notFoundAttribute is the get reply for an absent attribute: Found=false echoing the requested
-// set/name with an empty (but well-typed, so it serializes) value the caller ignores.
-func notFoundAttribute(set, name string) wire.AttributeResult {
-	return wire.AttributeResult{Attribute: wire.AttributeInfo{Set: set, Name: name, Value: types.StringVariant("")}, Found: false}
+// set/name/target with an empty (but well-typed, so it serializes) value the caller ignores.
+func notFoundAttribute(set, name, target string) wire.AttributeResult {
+	return wire.AttributeResult{Attribute: wire.AttributeInfo{Set: set, Name: name, Value: types.StringVariant(""), Target: target}, Found: false}
 }

--- a/addin/router/attributes_test.go
+++ b/addin/router/attributes_test.go
@@ -104,3 +104,60 @@ func TestAttributeHandlersRejectBadInput(t *testing.T) {
 		t.Error("find with a blank set should fail")
 	}
 }
+
+// TestAttributesPerTarget drives the per-entity (target) attribute round trip: tags anchored to
+// two different reference keys are independent of each other and of the document, each get/list
+// echoes its target, allTargets enumerates them, and the same target re-resolves the same anchor.
+func TestAttributesPerTarget(t *testing.T) {
+	r, s := emptyPartSession(t)
+	id := uint64(s.ActiveDocument().ID())
+	const set = "com.oblikovati.traceon"
+	const bodyA, bodyB = "body-ref-A", "body-ref-B"
+
+	// Two electrodes get different voltages; the document-scoped attribute is independent.
+	var res wire.AttributeResult
+	call(t, r, s, "attributes.set", mustJSON(t, wire.SetAttributeArgs{Document: id, Set: set, Name: "voltage", Value: types.DoubleVariant(1000), Target: bodyA}), &res)
+	if res.Attribute.Target != bodyA {
+		t.Errorf("set echoed target %q, want %q", res.Attribute.Target, bodyA)
+	}
+	call(t, r, s, "attributes.set", mustJSON(t, wire.SetAttributeArgs{Document: id, Set: set, Name: "voltage", Value: types.DoubleVariant(-500), Target: bodyB}), &res)
+	call(t, r, s, "attributes.set", mustJSON(t, wire.SetAttributeArgs{Document: id, Set: set, Name: "voltage", Value: types.DoubleVariant(0)}), &res) // document-scoped
+
+	// Each target reads back its own value (the same target re-resolves the same anchor).
+	expect := map[string]float64{bodyA: 1000, bodyB: -500}
+	for target, want := range expect {
+		call(t, r, s, "attributes.get", mustJSON(t, wire.GetAttributeArgs{Document: id, Set: set, Name: "voltage", Target: target}), &res)
+		if !res.Found || res.Attribute.Target != target {
+			t.Fatalf("get %s: found=%v target=%q", target, res.Found, res.Attribute.Target)
+		}
+		if v, _ := res.Attribute.Value.Double(); v != want {
+			t.Errorf("get %s voltage = %g, want %g", target, v, want)
+		}
+	}
+
+	// allTargets lists every anchor's attribute, each carrying its target (document + 2 bodies).
+	var list wire.ListAttributesResult
+	call(t, r, s, "attributes.list", mustJSON(t, wire.ListAttributesArgs{Document: id, Set: set, AllTargets: true}), &list)
+	seen := map[string]bool{}
+	for _, a := range list.Attributes {
+		seen[a.Target] = true
+	}
+	if !seen[bodyA] || !seen[bodyB] || !seen[""] {
+		t.Errorf("allTargets saw targets %v, want bodyA, bodyB and the document", seen)
+	}
+
+	// Deleting one target leaves the other intact.
+	var del wire.DeleteAttributeResult
+	call(t, r, s, "attributes.delete", mustJSON(t, wire.DeleteAttributeArgs{Document: id, Set: set, Name: "voltage", Target: bodyA}), &del)
+	if del.Removed != 1 {
+		t.Errorf("delete bodyA removed %d, want 1", del.Removed)
+	}
+	call(t, r, s, "attributes.get", mustJSON(t, wire.GetAttributeArgs{Document: id, Set: set, Name: "voltage", Target: bodyA}), &res)
+	if res.Found {
+		t.Error("bodyA attribute still present after delete")
+	}
+	call(t, r, s, "attributes.get", mustJSON(t, wire.GetAttributeArgs{Document: id, Set: set, Name: "voltage", Target: bodyB}), &res)
+	if !res.Found {
+		t.Error("bodyB attribute wrongly removed")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.92.0
+	oblikovati.org/api v0.92.1
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.92.0
+	oblikovati.org/api v0.92.1
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/attr/manager.go
+++ b/model/attr/manager.go
@@ -59,6 +59,28 @@ func (m *AttributeManager) Remove(key identity.RefKey) bool {
 // Count returns the number of anchored objects.
 func (m *AttributeManager) Count() int { return len(m.byKey) }
 
+// Anchor is one anchored object: its reference key and its attribute sets — the unit a
+// "list every target" query iterates over.
+type Anchor struct {
+	Key  identity.RefKey
+	Sets *AttributeSets
+}
+
+// Anchors returns every anchored object, in key insertion order, so a caller can enumerate the
+// attributes of all targets (document and entities) at once. A corrupt anchor key is skipped
+// rather than failing the whole enumeration.
+func (m *AttributeManager) Anchors() []Anchor {
+	out := make([]Anchor, 0, len(m.order))
+	for _, k := range m.order {
+		key, err := identity.DecodeKey([]byte(k))
+		if err != nil {
+			continue
+		}
+		out = append(out, Anchor{Key: key, Sets: m.byKey[k]})
+	}
+	return out
+}
+
 // AttributeHit is one result of [AttributeManager.FindAttributes]: the anchoring
 // key plus the matching set and attribute.
 type AttributeHit struct {

--- a/model/attr/manager_test.go
+++ b/model/attr/manager_test.go
@@ -155,3 +155,32 @@ func TestDecodeAttributesRejectsTruncated(t *testing.T) {
 		t.Error("DecodeAttributes accepted truncated data")
 	}
 }
+
+// TestAnchorsAndExternalKeyRoundTrip checks the per-target enumeration and that an external-anchor
+// (a wire reference key wrapped by identity.ExternalKey) survives serialize/reload and re-resolves.
+func TestAnchorsAndExternalKeyRoundTrip(t *testing.T) {
+	mgr := NewAttributeManager()
+	mgr.AttributeSets(identity.DocumentKey()).Set("traceon").Put("default", FloatValue(0))
+	mgr.AttributeSets(identity.ExternalKey([]byte("body-A"))).Set("traceon").Put("voltage", FloatValue(1000))
+	mgr.AttributeSets(identity.ExternalKey([]byte("body-B"))).Set("traceon").Put("voltage", FloatValue(-500))
+
+	if n := len(mgr.Anchors()); n != 3 {
+		t.Fatalf("anchors = %d, want 3 (document + two bodies)", n)
+	}
+
+	back, err := DecodeAttributes(mgr.Encode())
+	if err != nil {
+		t.Fatalf("DecodeAttributes: %v", err)
+	}
+	ss, ok := back.Lookup(identity.ExternalKey([]byte("body-A")))
+	if !ok {
+		t.Fatal("external anchor lost across reload (key did not re-resolve)")
+	}
+	a, _ := ss.Set("traceon").Attribute("voltage")
+	if a == nil {
+		t.Fatal("external attribute missing after reload")
+	}
+	if v, _ := a.Value().Float(); v != 1000 {
+		t.Errorf("body-A voltage = %g after reload, want 1000", v)
+	}
+}

--- a/model/identity/entity.go
+++ b/model/identity/entity.go
@@ -37,6 +37,11 @@ const (
 	// KindDocument names the document itself — the anchor for document-level
 	// attribute sets (#155). There is one such key per document; see [DocumentKey].
 	KindDocument EntityKind = 20
+	// KindExternal anchors to an entity addressed by an opaque EXTERNAL reference
+	// key — a kernel/topo reference key (which sits below this package and cannot
+	// mint identity keys), as surfaced to add-ins by body.list / model.referenceKeys.
+	// The external key is stored verbatim as the payload; see [ExternalKey].
+	KindExternal EntityKind = 21
 )
 
 // DocumentKey is the single well-known reference key that names the document itself
@@ -44,6 +49,27 @@ const (
 // It is fixed (no lineage payload), so it survives recompute and round-trips through
 // the attribute codec like any other key.
 func DocumentKey() RefKey { return RefKey{kind: KindDocument} }
+
+// ExternalKey anchors attributes to an entity an add-in can name but this package did not mint:
+// it wraps the opaque external reference key the add-in received over the wire (a kernel/topo
+// reference key from body.list / model.referenceKeys) verbatim as the payload. Equal external
+// bytes — the same body/face re-minting the same reference key after a recompute — yield an equal
+// RefKey, so the anchored attributes are found again (the per-entity counterpart of [DocumentKey]).
+//
+// Example: ss := mgr.AttributeSets(identity.ExternalKey(bodyInfo.Key))
+func ExternalKey(external []byte) RefKey {
+	return RefKey{kind: KindExternal, payload: append([]byte(nil), external...)}
+}
+
+// ExternalRef returns the external reference key wrapped by [ExternalKey], and true, when this is
+// an external anchor; otherwise (a document or minted key) it returns nil, false. It is the
+// inverse used to render an anchor back to the wire target an add-in addressed it by.
+func (k RefKey) ExternalRef() ([]byte, bool) {
+	if k.kind != KindExternal {
+		return nil, false
+	}
+	return k.payload, true
+}
 
 // String returns a stable lowercase name for diagnostics.
 func (k EntityKind) String() string {
@@ -62,6 +88,8 @@ func (k EntityKind) String() string {
 		return "parameter"
 	case KindDocument:
 		return "document"
+	case KindExternal:
+		return "external"
 	default:
 		return "unknown"
 	}

--- a/model/identity/entity_test.go
+++ b/model/identity/entity_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package identity
+
+import "testing"
+
+// TestExternalKey checks the external-anchor bridge: it round-trips through the key codec, equal
+// external bytes produce an equal key (so a re-minted reference key re-finds its attributes),
+// distinct bytes produce distinct keys, and ExternalRef recovers the wrapped bytes.
+func TestExternalKey(t *testing.T) {
+	ref := []byte{4, 0x11, 0x22, 0x33} // a kernel/topo reference key (kind byte + lineage)
+	k := ExternalKey(ref)
+
+	if k.Kind() != KindExternal {
+		t.Errorf("kind = %v, want external", k.Kind())
+	}
+	got, ok := k.ExternalRef()
+	if !ok || string(got) != string(ref) {
+		t.Errorf("ExternalRef = (%v, %v), want (%v, true)", got, ok, ref)
+	}
+	// Round-trips through Encode/DecodeKey (persistence) preserving the external ref.
+	dec, err := DecodeKey(k.Encode())
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !dec.Equal(k) {
+		t.Errorf("decoded key != original")
+	}
+	if r2, ok := dec.ExternalRef(); !ok || string(r2) != string(ref) {
+		t.Errorf("decoded ExternalRef = (%v, %v), want %v", r2, ok, ref)
+	}
+	// Equal bytes → equal encoded key (recompute survival); distinct bytes → distinct.
+	if string(ExternalKey(ref).Encode()) != string(k.Encode()) {
+		t.Error("equal external bytes did not produce an equal key")
+	}
+	if string(ExternalKey([]byte{4, 0x11, 0x22, 0x99}).Encode()) == string(k.Encode()) {
+		t.Error("distinct external bytes produced the same key")
+	}
+	// A document key is not an external anchor.
+	if _, ok := DocumentKey().ExternalRef(); ok {
+		t.Error("DocumentKey reported as external")
+	}
+}


### PR DESCRIPTION
## What

Implement the per-entity attribute **target** the API wire DTOs now carry (the #155 follow-up). Pairs with **Oblikovati.API#214**.

The `attr.AttributeManager` is already keyed by `identity.RefKey` and built to survive recompute; this wires the missing bridge from the reference key an add-in addresses over the wire to that anchor:

- **model/identity:** `ExternalKey` wraps the opaque external reference key an add-in received (a `kernel/topo` reference key from `body.list` / `model.referenceKeys` — topo sits below identity and can't mint identity keys) verbatim as the payload, so equal external bytes (a body/face re-minting its key after recompute) yield an equal `RefKey` and re-find their attributes. `ExternalRef` recovers the bytes; `KindExternal` discriminates.
- **model/attr:** `AttributeManager.Anchors` enumerates every anchored object for the "list every target" query.
- **addin/router/attributes:** resolve the wire target → anchor (empty = document, else `ExternalKey`), thread it through set/get/delete/list, echo it on every result, serve `allTargets`.

Per-entity tags survive serialize/reload and recompute — covered at the identity, manager, and router layers.

## Dependency

Requires the API `Target` DTOs (Oblikovati.API#214). Builds locally via the go.work replace; the go.mod pin will move to the API release that ships #214 before merge.

## Verification

- `go build ./...` clean; `model/identity`, `model/attr`, `addin/router` tests green; `golangci-lint` 0 issues; GPL headers present.