### PR TITLE
test(brep): assert kept region in torus/cone-side half-space cuts (#1497)

### DIFF
--- a/kernel/ops/halfspace_cone_side_test.go
+++ b/kernel/ops/halfspace_cone_side_test.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Region-correctness coverage for the frustum SIDE cut — a plane PARALLEL to the cone axis
+// (Oblikovati/Oblikovati#1372 arc-band, #1374 annulus/tongue). The brep-package tests assert the cut
+// stays watertight, analytic, and carries a hyperbola; these assert the right region survived. The
+// complementary cuts (same plane, opposite normals) must partition the frustum, and each must be
+// centred on its kept side — the gap #1497 flags, where annulus and tongue asserted nothing relating
+// their volumes. Frustum: axis z∈[0,10], radius 3→6, so ρ(z) = 3 + 0.3z.
+
+// frustumSideRemoved is the analytic volume of the slab of the frustum lying beyond |x| = d (the part a
+// side plane at distance d removes), integrated as ∫_0^10 segmentArea(ρ(z), d) dz by Simpson's rule —
+// an independent oracle for the kept volume (frustum − removed).
+func frustumSideRemoved(d float64) float64 {
+	seg := func(rad, m float64) float64 {
+		if m >= rad {
+			return 0
+		}
+		return rad*rad*stdmath.Acos(m/rad) - m*stdmath.Sqrt(rad*rad-m*m)
+	}
+	const n = 2000
+	h := 10.0 / float64(n)
+	sum := seg(3, d) + seg(3+0.3*10, d)
+	for i := 1; i < n; i++ {
+		z := float64(i) * h
+		w := 2.0
+		if i%2 == 1 {
+			w = 4
+		}
+		sum += w * seg(3+0.3*z, d)
+	}
+	return sum * h / 3
+}
+
+// TestHalfSpaceCutConeSideArcBandVolume cuts the frustum by x=2 (∥ axis, |D|=2 < bottom r=3) keeping
+// each side, and checks: each kept volume matches its analytic value (frustum ∓ removed), the two sides
+// partition the frustum, and each centroid is on its kept side. The axis side is the major part.
+func TestHalfSpaceCutConeSideArcBandVolume(t *testing.T) {
+	frustum, _ := brep.SolidCylinderCone(math.P3(0, 0, 0), math.P3(0, 0, 10), 3, 6, "frustum")
+	full := ops.BodyGeometryProperties(frustum, ops.DefaultQuality()).Volume
+	removed := frustumSideRemoved(2)
+
+	axisOrigin, axisNormal := math.P3(2, 0, 0), math.V3(1, 0, 0) // keep x ≤ 2 (axis side, major part)
+	farOrigin, farNormal := math.P3(2, 0, 0), math.V3(-1, 0, 0)  // keep x ≥ 2 (far side, the shaved flat)
+
+	axisPlane, _ := geom.NewPlane(axisOrigin, axisNormal)
+	farPlane, _ := geom.NewPlane(farOrigin, farNormal)
+	axisSide, err := brep.HalfSpaceCut(frustum, axisPlane)
+	if err != nil {
+		t.Fatalf("HalfSpaceCut(axis): %v", err)
+	}
+	farSide, err := brep.HalfSpaceCut(frustum, farPlane)
+	if err != nil {
+		t.Fatalf("HalfSpaceCut(far): %v", err)
+	}
+
+	assertKeptVolume(t, axisSide, full-removed, 0.02, "arc-band axis side (x≤2)")
+	assertKeptVolume(t, farSide, removed, 0.05, "arc-band far side (x≥2)") // thin slab → looser inscription tol
+	assertCentroidKeptSide(t, axisSide, axisOrigin, axisNormal, "arc-band axis side")
+	assertCentroidKeptSide(t, farSide, farOrigin, farNormal, "arc-band far side")
+	assertComplementaryPartition(t, axisSide, farSide, full, "arc-band x=2")
+}
+
+// TestHalfSpaceCutConeSideAnnulusTongueComplementary cuts the frustum by x=4 (bottom r=3 < |D|=4 <
+// top r=6) keeping each side: the axis side is the notched ANNULUS (#1374), the far side the TONGUE.
+// They must partition the frustum, the annulus must dwarf the tongue, and each be on its kept side.
+func TestHalfSpaceCutConeSideAnnulusTongueComplementary(t *testing.T) {
+	frustum, _ := brep.SolidCylinderCone(math.P3(0, 0, 0), math.P3(0, 0, 10), 3, 6, "frustum")
+	full := ops.BodyGeometryProperties(frustum, ops.DefaultQuality()).Volume
+	removed := frustumSideRemoved(4)
+
+	annOrigin, annNormal := math.P3(4, 0, 0), math.V3(1, 0, 0)  // keep x ≤ 4 → annulus (apex kept)
+	tonOrigin, tonNormal := math.P3(4, 0, 0), math.V3(-1, 0, 0) // keep x ≥ 4 → tongue (apex dropped)
+
+	annPlane, _ := geom.NewPlane(annOrigin, annNormal)
+	tonPlane, _ := geom.NewPlane(tonOrigin, tonNormal)
+	annulus, err := brep.HalfSpaceCut(frustum, annPlane)
+	if err != nil {
+		t.Fatalf("HalfSpaceCut(annulus): %v", err)
+	}
+	tongue, err := brep.HalfSpaceCut(frustum, tonPlane)
+	if err != nil {
+		t.Fatalf("HalfSpaceCut(tongue): %v", err)
+	}
+
+	annVol := ops.BodyGeometryProperties(annulus, ops.DefaultQuality()).Volume
+	tonVol := ops.BodyGeometryProperties(tongue, ops.DefaultQuality()).Volume
+	assertKeptVolume(t, annulus, full-removed, 0.02, "annulus (x≤4)")
+	assertKeptVolume(t, tongue, removed, 0.05, "tongue (x≥4)") // thin sliver → looser inscription tol
+	if annVol <= tonVol {
+		t.Errorf("annulus volume %.4f should exceed tongue volume %.4f (axis side is the major part)", annVol, tonVol)
+	}
+	assertCentroidKeptSide(t, annulus, annOrigin, annNormal, "annulus")
+	assertCentroidKeptSide(t, tongue, tonOrigin, tonNormal, "tongue")
+	assertComplementaryPartition(t, annulus, tongue, full, "annulus/tongue x=4")
+}
+
+// TestHalfSpaceCutConeSideClearsKeepsFullVolume strengthens the brep-package face-count check: a side
+// plane clear of the whole frustum (|D| ≥ top radius) on the axis side keeps the WHOLE volume.
+func TestHalfSpaceCutConeSideClearsKeepsFullVolume(t *testing.T) {
+	frustum, _ := brep.SolidCylinderCone(math.P3(0, 0, 0), math.P3(0, 0, 10), 3, 6, "frustum")
+	full := ops.BodyGeometryProperties(frustum, ops.DefaultQuality()).Volume
+	keep, _ := geom.NewPlane(math.P3(7, 0, 0), math.V3(1, 0, 0)) // x ≤ 7 ⊇ whole frustum (top r=6)
+	res, err := brep.HalfSpaceCut(frustum, keep)
+	if err != nil {
+		t.Fatalf("HalfSpaceCut(keep): %v", err)
+	}
+	assertKeptVolume(t, res, full, 1e-6, "clearing side plane keeps whole frustum")
+}
+
+// assertComplementaryPartition fails unless two complementary cuts (same plane, opposite normals) sum
+// to the whole volume and are individually non-empty (neither side swallowed the whole or nothing).
+func assertComplementaryPartition(t *testing.T, a, b *topo.Body, full float64, label string) {
+	t.Helper()
+	va := ops.BodyGeometryProperties(a, ops.DefaultQuality()).Volume
+	vb := ops.BodyGeometryProperties(b, ops.DefaultQuality()).Volume
+	if rel := stdmath.Abs(va+vb-full) / full; rel > 0.01 {
+		t.Errorf("%s: complementary cuts sum to %.4f, want %.4f (full) — rel %.4f > 1%% (not a partition)",
+			label, va+vb, full, rel)
+	}
+	if va <= 0 || vb <= 0 {
+		t.Errorf("%s: a complementary cut is empty (va=%.4f vb=%.4f); both sides must be non-empty", label, va, vb)
+	}
+}

--- a/kernel/ops/halfspace_region_helpers_test.go
+++ b/kernel/ops/halfspace_region_helpers_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Region-correctness assertions for half-space cuts. Watertightness and analytic face counts are
+// necessary-but-not-sufficient: a cut that keeps the wrong half or clips to the wrong depth stays
+// watertight with the same face count. These helpers make "which region survived" a first-class
+// assertion — volume against an analytic/oracle value and centroid on the kept side of the plane
+// (Oblikovati/Oblikovati#1497, guarding the known "OUTSIDE-keep wrong region" failure mode).
+
+// assertKeptVolume fails unless the body's tessellated volume is within relTol of want. Tessellation
+// inscribes the true surface, so the measured volume runs slightly UNDER analytic; relTol absorbs that.
+func assertKeptVolume(t *testing.T, body *topo.Body, want, relTol float64, label string) {
+	t.Helper()
+	got := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume
+	if rel := stdmath.Abs(got-want) / want; rel > relTol {
+		t.Errorf("%s: kept volume %.4f, want %.4f — rel %.4f > %.2f%% (wrong region kept or wrong depth)",
+			label, got, want, rel, relTol*100)
+	}
+}
+
+// assertCentroidKeptSide fails unless the body's centroid lies on the kept side of the cutting plane.
+// HalfSpaceCut keeps { p : normal·(p−origin) ≤ 0 } (the side the normal points away from), so the
+// centroid must satisfy the same inequality with a margin. This catches a cut that ignores the plane
+// normal even when the complementary regions happen to have equal volume (e.g. a symmetric mid-plane).
+func assertCentroidKeptSide(t *testing.T, body *topo.Body, origin math.Point3, normal math.Vector3, label string) {
+	t.Helper()
+	c := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Centroid
+	signed := origin.VectorTo(c).Dot(normal)
+	if signed > -1e-6 {
+		t.Errorf("%s: centroid signed distance %.4f from plane is not on the kept side (want < 0; wrong half kept)",
+			label, signed)
+	}
+}

--- a/kernel/ops/halfspace_torus_side_test.go
+++ b/kernel/ops/halfspace_torus_side_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+)
+
+// Region-correctness coverage for the torus perpendicular-band cut (Oblikovati/Oblikovati#1375). The
+// brep-package tests assert the band stays watertight and analytic; these assert the RIGHT region
+// survived, the gap #1497 flags (keep-below and keep-above asserted identical things, so a normal-
+// ignoring cut would have passed). Tessellation runs ~1.3–1.6% under analytic here, hence 3% tol.
+
+const (
+	torusR = 5.0 // major radius
+	torusr = 2.0 // minor (tube) radius
+)
+
+// torusBelowVolume is the analytic volume of a solid torus (major R, minor r, axis z, centred at the
+// origin) lying at z ≤ c for −r ≤ c ≤ r. The cross-section at height z is an annulus of area
+// 4πR·√(r²−z²), so the volume is 4πR·∫_{-r}^{c} √(r²−z²) dz. At c=0 this is π²Rr² (exactly half).
+func torusBelowVolume(major, minor, c float64) float64 {
+	antideriv := func(z float64) float64 {
+		return z/2*stdmath.Sqrt(minor*minor-z*z) + minor*minor/2*stdmath.Asin(z/minor)
+	}
+	return 4 * stdmath.Pi * major * (antideriv(c) - antideriv(-minor))
+}
+
+// TestHalfSpaceCutTorusPerpendicularBandVolume checks both the symmetric mid-plane halves and an
+// off-centre slab. The two mid-plane halves have EQUAL volume (so volume alone cannot tell them
+// apart — the centroid-side check is what distinguishes keep-below from keep-above); the off-centre
+// plane yields a distinct analytic slab volume.
+func TestHalfSpaceCutTorusPerpendicularBandVolume(t *testing.T) {
+	halfVol := torusBelowVolume(torusR, torusr, 0) // = π²Rr², half the torus
+	for _, tc := range []struct {
+		name   string
+		origin math.Point3
+		normal math.Vector3
+		want   float64
+	}{
+		{"keep below mid-plane", math.P3(0, 0, 0), math.V3(0, 0, 1), halfVol},
+		{"keep above mid-plane", math.P3(0, 0, 0), math.V3(0, 0, -1), halfVol},
+		{"keep below off-centre", math.P3(0, 0, 1), math.V3(0, 0, 1), torusBelowVolume(torusR, torusr, 1)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tor, _ := brep.SolidTorus(math.P3(0, 0, 0), math.V3(0, 0, 1), torusR, torusr, "torus")
+			plane, _ := geom.NewPlane(tc.origin, tc.normal)
+			res, err := brep.HalfSpaceCut(tor, plane)
+			if err != nil {
+				t.Fatalf("HalfSpaceCut: %v", err)
+			}
+			assertKeptVolume(t, res, tc.want, 0.03, tc.name)
+			assertCentroidKeptSide(t, res, tc.origin, tc.normal, tc.name)
+		})
+	}
+}
+
+// TestHalfSpaceCutTorusMidPlaneHalvesAreComplementary cuts the same mid-plane both ways and checks the
+// two halves partition the whole torus (volumes sum to the full torus) and are individually centred on
+// opposite sides. A cut that ignored the plane normal would return the same region twice and fail the
+// opposite-side requirement.
+func TestHalfSpaceCutTorusMidPlaneHalvesAreComplementary(t *testing.T) {
+	tor, _ := brep.SolidTorus(math.P3(0, 0, 0), math.V3(0, 0, 1), torusR, torusr, "torus")
+	full := ops.BodyGeometryProperties(tor, ops.DefaultQuality()).Volume
+
+	below, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))  // keep z ≤ 0
+	above, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, -1)) // keep z ≥ 0
+	lo, err := brep.HalfSpaceCut(tor, below)
+	if err != nil {
+		t.Fatalf("HalfSpaceCut(below): %v", err)
+	}
+	hi, err := brep.HalfSpaceCut(tor, above)
+	if err != nil {
+		t.Fatalf("HalfSpaceCut(above): %v", err)
+	}
+	vlo := ops.BodyGeometryProperties(lo, ops.DefaultQuality()).Volume
+	vhi := ops.BodyGeometryProperties(hi, ops.DefaultQuality()).Volume
+	if rel := stdmath.Abs(vlo+vhi-full) / full; rel > 0.01 {
+		t.Errorf("torus halves sum to %.4f, want %.4f (full) — rel %.4f > 1%% (not a partition)", vlo+vhi, full, rel)
+	}
+	// Centroids must straddle the plane: below half centred at −8r/3π, above at +8r/3π (mirror images).
+	assertCentroidKeptSide(t, lo, math.P3(0, 0, 0), math.V3(0, 0, 1), "below half")
+	assertCentroidKeptSide(t, hi, math.P3(0, 0, 0), math.V3(0, 0, -1), "above half")
+}
+
+// TestHalfSpaceCutTorusClearsKeepsFullVolume strengthens the brep-package face-count check: a plane
+// clear of the tube must keep the WHOLE torus volume, not merely the same face count (a sliver shave
+// preserves face count but loses volume).
+func TestHalfSpaceCutTorusClearsKeepsFullVolume(t *testing.T) {
+	tor, _ := brep.SolidTorus(math.P3(0, 0, 0), math.V3(0, 0, 1), torusR, torusr, "torus")
+	full := ops.BodyGeometryProperties(tor, ops.DefaultQuality()).Volume
+	clear, _ := geom.NewPlane(math.P3(0, 0, 3), math.V3(0, 0, 1)) // z ≤ 3 holds the whole tube (to z=2)
+	res, err := brep.HalfSpaceCut(tor, clear)
+	if err != nil {
+		t.Fatalf("HalfSpaceCut(clears): %v", err)
+	}
+	assertKeptVolume(t, res, full, 1e-6, "clearing plane keeps whole torus")
+}


### PR DESCRIPTION
## What

Adds region-correctness assertions to the curved half-space cut test suites, so a boolean that keeps the **wrong region** can no longer pass. Test-only change (no production code touched).

New `ops_test` helpers (`kernel/ops/halfspace_region_helpers_test.go`):
- `assertKeptVolume` — tessellated volume vs an analytic/Simpson oracle.
- `assertCentroidKeptSide` — centroid lies on the kept side of the cutting plane. This distinguishes complementary halves **even when their volumes are equal** (the symmetric torus mid-plane), which volume alone cannot.
- `assertComplementaryPartition` — opposite-normal cuts on one plane sum to the whole and are each non-empty.

Coverage filled for the two suites that had a watertightness check but **no volume oracle**:
- **Torus perpendicular-band** (#1375) — `halfspace_torus_side_test.go`
- **Frustum side cut** (#1372 arc-band, #1374 annulus/tongue) — `halfspace_cone_side_test.go`

## Why

Watertightness + analytic face count are necessary-but-not-sufficient: a cut that keeps the wrong half or clips to the wrong depth stays watertight with the same face count. This is the exact failure mode tracked as an open bug ("OUTSIDE-keep wrong region"). The torus keep-below / keep-above cases previously asserted *identical* things, so a normal-ignoring cut would have shipped green.

These live in `ops_test` (not `package brep`) because volume needs `ops.BodyGeometryProperties`, and `ops` imports `brep` — the established split the existing `halfspace_cylinder_side_test.go` already follows.

## Red-bar verification (acceptance criterion)

Injecting a normal-ignoring bug turns the new assertions red, then reverted:

1. **General path** — `n = n.Scale(-1)` in `HalfSpaceCut`: cone-side tests fail on both volume and centroid-side (e.g. `annulus volume 30.80 should exceed tongue volume 625.88`, `centroid not on the kept side`).
2. **Torus path** — `nAxis = abs(nAxis)` in `torusHalfSpace` (always keep low half): `keep above mid-plane` fails the centroid-side check while the legitimately-low cases stay green — exactly the symmetric blind spot this issue names.

Tolerances are tuned to measured tessellation inscription (torus ~1.3–1.6% under → 3%; cone complementarity sums <0.2% → 1%; thin tongue sliver ~3% → 5% analytic bracket), not loosened to always pass.

Note: `curved_cone_cylinder_imprint_test.go` produces SSI *loops*, not a solid, and already asserts loop-on-surface offsets, so a volume oracle doesn't apply there.

No existing watertightness/topology assertions were removed. `go test ./kernel/ops/ ./kernel/brep/` green.

Closes #1497

🤖 Generated with [Claude Code](https://claude.com/claude-code)