### PR TITLE
docs(architecture): reconcile module layout & ADR index with reality (#1508)

### DIFF
--- a/architecture/README.md
+++ b/architecture/README.md
@@ -68,6 +68,17 @@ The three defining choices, plus the derived ones, are recorded as ADRs:
 | [0015](decisions/ADR-0015-build-ci-and-test-tooling.md) | Build, CI/CD, and test tooling foundation *(tooling)* |
 | [0016](decisions/ADR-0016-shared-library-addins-mcp-bridge.md) | **In-process shared-library add-ins (C ABI) + MCP automation bridge** — amends 0003 |
 | [0017](decisions/ADR-0017-release-pipeline.md) | **Channel-based release pipeline** (nightly + stable; GUI head + CLI) — supersedes 0015's CD |
+| [0018](decisions/ADR-0018-apache-api-contract-module.md) | **Apache-2.0 `api` contract module** extracted from the GPL application module |
+| [0019](decisions/ADR-0019-macos-moltenvk-support.md) | macOS support: MoltenVK runtime fixes + signed universal `.app` |
+| [0020](decisions/ADR-0020-yaml-git-friendly-document-format.md) | Documents are a single git-friendly YAML file (not a binary ZIP package) |
+| [0021](decisions/ADR-0021-ui-theming-semantic-tokens.md) | UI theming via semantic tokens (head applies, core owns state) |
+| [0022](decisions/ADR-0022-materials-appearances.md) | Materials & Appearances (typed assets, project-scoped, PBR) |
+| [0023](decisions/ADR-0023-viewport-display-modes.md) | Viewport Display-Mode Parity (software PBR, real-time HLR, NPR framework) |
+| [0024](decisions/ADR-0024-embedded-material-catalog.md) | Embedded built-in material & appearance catalog (YAML, `go:embed`) |
+| [0025](decisions/ADR-0025-anisotropic-material-properties.md) | Anisotropic material properties (isotropy class + orthotropic elastic group) |
+| [0026](decisions/ADR-0026-environment-lighting-ibl-shadows.md) | Environment Lighting, IBL Reflections & Shadows |
+| [0027](decisions/ADR-0027-curved-face-boolean.md) | Curved-face B-rep boolean (K1b) |
+| [0028](decisions/ADR-0028-embedded-lua-scripting.md) | Embedded Lua scripting runtime (pure-Go, sandboxed, wire-mirrored) |
 | [0029](decisions/ADR-0029-user-config-location.md) | **Unified per-user config location** (`~/.oblikovati`; `%AppData%\oblikovati` on Windows) via `oblikovati.org/userconfig` |
 | [0030](decisions/ADR-0030-tolerant-nurbs-meshing.md) | Tolerant NURBS surface meshing (on-surface interior nodes + shared-edge stitching) |
 | [0031](decisions/ADR-0031-embedded-document-resources.md) | Imported files are embedded in the document as a root `resources` dictionary (UUID-keyed) |
@@ -76,33 +87,42 @@ The three defining choices, plus the derived ones, are recorded as ADRs:
 | [0034](decisions/ADR-0034-per-document-type-file-extensions.md) | Per-document-type file extensions, and a project file |
 | [0035](decisions/ADR-0035-assembly-machining-features.md) | **Assembly machining features**: occurrence-relative references + a serialized feature program |
 | [0036](decisions/ADR-0036-content-agnostic-sketch-host.md) | The sketch environment hosts on a content-agnostic `sketchHost` interface (part or assembly) |
+| [0037](decisions/ADR-0037-command-window.md) | A Command Window is the single command-entry and feedback surface |
+| [0038](decisions/ADR-0038-assembly-render-instancing.md) | Assembly render instancing (one mesh per unique component) |
+| [0039](decisions/ADR-0039-script-console-code-editor.md) | The Script Console code editor is a custom pure-Go core with a thin cgo view |
+| [0040](decisions/ADR-0040-external-geometric-references.md) | External geometric references for externally-authored topology selections |
+| [0041](decisions/ADR-0041-selection-engine.md) | Tools declare their selection; one engine owns filtering, picking and highlight |
+| [0042](decisions/ADR-0042-model-scale-and-relative-tolerances.md) | Model scale & relative tolerances: a kernel resolution centred on the working scale |
 
-> Note: ADRs 0018–0028 exist under `decisions/` but predate the last index refresh; this
-> table is being backfilled separately.
+> ADR namespaces are **per-repo**. These numbers are *this* application's decisions. The
+> separate add-in repos keep their own ADR series — e.g. the CalculiX FEA add-in's ADR-0007
+> (FEA scope) / ADR-0008 (constraint-list refactor) are unrelated to this repo's ADR-0007
+> (async recompute) / ADR-0008 (cgo boundary).
 
 ## The modern stack at a glance
 
 ```
                           ┌──────────────────────────────────────────────┐
-   add-ins (link /api,  ──┤  api/  — the public contract (Apache-2.0):    │  separate module
-   never /source)         │  types · contract · wire · client (ADR-0018)  │
+   add-ins (link api,   ──┤  api  — the public contract (Apache-2.0):     │  separate sibling repo
+   never the GPL module)  │  types · contract · wire · client (ADR-0018)  │
                           └───────────────────────┬──────────────────────┘
                                                    │ C ABI in-proc today (ADR-0016) · gRPC later
  ┌────────────────────────────────────────────────▼─────────────────────────────────┐
- │ app/  — assembled application: wires the runtime mediator, picks build tags        │
- ├──────────────┬───────────────┬───────────────┬──────────────┬─────────────────────┤
- │ ui/ (ImGui)  │ renderer/      │ scene/        │ registry/    │ addins/ (rpc host)  │
- │ shell+panels │ Vulkan 1.3     │ viewport graph│ self-register│ plugin lifecycle    │
- ├──────────────┴───────────────┴───────────────┴──────────────┴─────────────────────┤
- │ runtime/  — the mediator: frame loop, ordered phases, job pool, clock, schedulers  │
+ │ head/  — the cgo Vulkan + ImGui windowed shell (separate submodule, ADR-0008):     │
+ │   head/ui (ribbon, browser, panels) · head/viewport (Vulkan loop) ·                │  cgo
+ │   head/addins (in-proc C-ABI add-in host, ADR-0016)                                │  edge
  ├────────────────────────────────────────────────────────────────────────────────────┤
- │ model/  — documents · componentdef · features · parameters · sketch · identity      │
- │ kernel/ — geom (curves/surfaces/nurbs) · topo (B-rep) · ops (boolean/fillet/tess)    │  PURE GO
+ │ app/  — the session mediator: documents, commands, environments, frame tick        │
+ │ addin/ — host-side JSON method router (addin/router, serves api/wire)              │  cgo-free
+ ├──────────────┬───────────────┬───────────────┬─────────────────────────────────────┤
+ │ renderer/    │ scene/        │ solve/        │ command/ · event/ · persistence/    │
+ │ render backend│ viewport graph│ constraint solver│ undo · event bus · .obk package  │
+ ├──────────────┴───────────────┴───────────────┴─────────────────────────────────────┤
+ │ model/  — documents · compdef · features · parameters · sketch · assembly · identity │
+ │ kernel/ — geom (curves/surfaces/nurbs) · topo (B-rep) · brep · ops (boolean/tess)     │  PURE GO
  │ math/   — vec/mat/quat (float64) · robust predicates                                 │  (no cgo)
- ├────────────────────────────────────────────────────────────────────────────────────┤
- │ platform/ (window,input,fs)  ·  persistence/ (zip+binary)  ·  build/ (tags)          │
  └────────────────────────────────────────────────────────────────────────────────────┘
-   cgo (or purego) confined here ───────────────┘
+   math/kernel/model never import renderer/scene/head — the domain never sees the GPU
 ```
 
 ## Core architecture docs (iteration 1 — the foundations)

--- a/architecture/core/01-module-layout.md
+++ b/architecture/core/01-module-layout.md
@@ -6,70 +6,80 @@ suggested layout (§"module layout") to a parametric CAD domain.*
 ## Package layout
 
 ```
-oblikovati/
+oblikovati/            # the GPL-v2 application module (this repo root)
   cmd/
-    oblikovati/        # main: assembles a Runtime (window) — build tag `app`
-    oblikovati-cli/    # headless: batch/translate/thumbnail — build tag `headless`
-  runtime/             # the mediator, frame loop, schedulers, clock, worker pool
-  build/               # compile-time constants: build.Debug, build.Editor, build.Profile
+    oblikovati/        # main: assembles the session + windowed head
+    oblikovati-cli/    # headless: batch/translate/thumbnail, CGO_ENABLED=0
 
+  build/               # compile-time constants: build.Debug, build.Editor, build.Profile
   math/                # vec2/3/4, mat3/4, quat (float64), AABB/OBB,
                        #   ROBUST PREDICATES (exact orient/incircle) — kernel depends on it
   kernel/              # PURE GO geometry/modeling kernel (ADR-0002), cgo-free
-    geom/              #   analytic curves & surfaces, NURBS, evaluators
-    topo/              #   B-rep: Body/Shell/Face/Loop/Edge/Vertex + adjacency + ref-key hooks
-    ops/               #   boolean, fillet/chamfer, sweep/loft, tessellate, heal
-    predicate/         #   exact arithmetic shims used by ops
+    geom/              #   analytic curves & surfaces, NURBS, evaluators, exact-predicate shims
+    topo/              #   B-rep topology: Body/Shell/Face/Loop/Edge/Vertex + adjacency + ref-keys
+    brep/              #   solid builders + curved-boolean/half-space dispatch over topo
+    ops/              #   boolean, fillet/chamfer, sweep/loft, tessellate, mass-props, heal
+    fit/ hlr/ subd/    #   curve/surface fitting, hidden-line removal, subdivision surfaces
+    exchange/          #   STEP/mesh import-export codecs
+    diag/ geomapi/     #   kernel diagnostics channel; the in-proc geometry API facade
 
   model/               # the DOMAIN (cgo-free): "model = evaluated program"
     doc/               #   Document, Workspace (open docs), document refs
     compdef/           #   Part/Assembly component definitions (content containers)
     feature/           #   feature history engine + Definition/Feature pairs (the triangle)
-    sketch/            #   sketch entities, constraints, the Go-native solver
+    sketch/            #   sketch entities, constraints (solver lives in /solve)
     param/             #   parameters, units, expression engine, dependency DAG
     identity/          #   reference keys (topological naming), TypeID registry hooks
     attr/              #   attributes & properties (extensible metadata)
+    assembly/ occurrence/ drawing/ sheetmetal/ material/ style/ … # the rest of the domain
 
+  solve/               # the Go-native constraint solver (Gauss-Newton/Levenberg-Marquardt)
   scene/               # VIEWPORT scene graph: entity + transform hierarchy + dirty flags
-  renderer/            # Vulkan 1.3 backend (cgo/purego edge), passes, caches, draw queue, picking
-    backend/           #   *_vulkan.go ; null/offscreen backend for tests & thumbnails
-  platform/            # window/input/fs/threading/profiler — the cgo (or purego) edge (ADR-0008)
-  ui/                  # ImGui shell (ADR-0004): panels, browser, inspector (reflection), tables
-
-  addin/               # host-side API: JSON method router, op registry, dispatch (serves api/wire)
-  addins/              # out-of-proc add-in host: discovery, lifecycle, supervision, sandbox
-  registry/            # self-registration: features, workspaces, commands, types, translators
-    types/             #   stable TypeID registry (persistence/RPC identity, ADR-0006)
+  renderer/            # render backend abstraction: passes, caches, draw queue, picking
   command/             # command-pattern history (undo/redo), ADR-0006/core-06
   event/               # typed event bus (before/after, veto), core-06
-  persistence/         # document container (zip package) + columnar binary serialization
+  persistence/         # document container (.obk YAML package) + serialization
 
-  internal/...         # non-public helpers
+  addin/               # host-side API: JSON method router (addin/router, serves api/wire), op registry
+  addincat/            # add-in catalogue client (addins.oblikovati.org)
+  app/                 # the session/mediator: orchestrates documents, commands, environments,
+                       #   the frame tick — cgo-free and headless-testable
+  script/              # embedded Lua scripting (ADR-0028)
+
+  head/                # the cgo Vulkan 1.3 + Dear ImGui windowed shell — a separate submodule so
+                       #   the cgo build never touches the headless-tested core (ADR-0008)
+    viewport/          #   the 3D viewport (Vulkan render loop)
+    ui/                #   ImGui shell: ribbon, browser, inspector, panels
+    addins/            #   the in-proc add-in host: discovery, lifecycle, C-ABI load (ADR-0016)
 ```
 
 ### Dependency direction (must stay acyclic)
 
 ```
-math → kernel → model → {scene, api, persistence}
-                         scene → renderer → platform
-                         model → command, event, identity, registry
-                         ui → runtime → (everything, as the mediator)
+math → kernel → model → {scene, api, persistence, solve}
+                         scene → renderer
+                         model → command, event, identity
+                         app → (model, command, event, addin, scene) as the session mediator
+                         head → app + renderer + scene (the cgo windowed shell on top)
 ```
 
-`math/kernel/model` never import `renderer/ui/platform`. The domain does not know
-the GPU exists. This is what keeps the kernel cgo-free and headless-testable.
+`math/kernel/model` never import `renderer`, `scene`, or `head` (the cgo edge). The
+domain does not know the GPU exists. This is what keeps the kernel cgo-free and
+headless-testable. (`model/clientgraphics` is the one place this is currently bent —
+Oblikovati/Oblikovati#1500 relocates it out of the pure domain.)
 
-### The `/api` contract module (separate, Apache-2.0)
+### The `/api` contract module (separate sibling repo, Apache-2.0)
 
-The public API is its own module, **`oblikovati.org/api`** at the repo root
-(`/api`, sibling to `/source`), licensed Apache-2.0 so add-ins — including
-closed-source ones — can build against it ([ADR-0018](../decisions/ADR-0018-apache-api-contract-module.md)).
-It has four packages: `types` (enums/value types — the canonical definitions
-`/source` aliases), `contract` (in-proc Go interfaces `/source` satisfies), `wire`
+The public API is its own module, **`oblikovati.org/api`**, in a sibling repo
+(`../Oblikovati.API`, tied in for local dev by the `go.work` replace), licensed
+Apache-2.0 so add-ins — including closed-source ones — can build against it
+([ADR-0018](../decisions/ADR-0018-apache-api-contract-module.md)).
+It has four packages: `types` (enums/value types — the canonical definitions this
+GPL module aliases), `contract` (in-proc Go interfaces this module satisfies), `wire`
 (method-name constants + JSON DTOs), and `client` (a `Transport` + typed client for
-out-of-runtime add-ins). The dependency flows **only toward** `/api`: `/source`
-requires it (via a `replace` directive, like `/source/head` does), and `/api` never
-imports `/source` (CI-enforced).
+out-of-process add-ins). The dependency flows **only toward** `api`: this module
+requires it (via the `go.work` replace, as `head` does too), and `api` never
+imports this module (CI-enforced).
 
 ## Build-time gating (realtime-3d §14)
 

--- a/architecture/decisions/ADR-0023-viewport-display-modes.md
+++ b/architecture/decisions/ADR-0023-viewport-display-modes.md
@@ -1,6 +1,6 @@
 # ADR-0023 — Viewport Display-Mode Parity (software PBR, real-time HLR, NPR framework)
 
-**Status:** proposed (2026-06-04) · **Relates to:**
+**Status:** Accepted — shipped in M23 (Renderer Display-Mode Parity) · **Relates to:**
 [ADR-0005](ADR-0005-vulkan13-renderer.md) (Vulkan renderer),
 [ADR-0012](ADR-0012-exact-hidden-line.md) (exact drawing HLR),
 [ADR-0014](ADR-0014-renderer-testability.md) (pure draw list / oracle hierarchy),

--- a/architecture/decisions/ADR-0026-environment-lighting-ibl-shadows.md
+++ b/architecture/decisions/ADR-0026-environment-lighting-ibl-shadows.md
@@ -1,6 +1,6 @@
 # ADR-0026 — Environment Lighting, IBL Reflections & Shadows
 
-**Status:** proposed (2026-06-04) · **Relates to:**
+**Status:** Accepted — shipped in M16 (HDR sky + image-based lighting + shadows) · **Relates to:**
 [ADR-0005](ADR-0005-vulkan13-renderer.md) (Vulkan renderer),
 [ADR-0014](ADR-0014-renderer-testability.md) (pure draw list / oracle hierarchy),
 [ADR-0018](ADR-0018-apache-api-contract-module.md) (API contract split),

--- a/architecture/decisions/ADR-0042-model-scale-and-relative-tolerances.md
+++ b/architecture/decisions/ADR-0042-model-scale-and-relative-tolerances.md
@@ -1,6 +1,6 @@
 # ADR-0042 — Model scale & relative tolerances: a kernel resolution centred on the working scale
 
-**Status:** Proposed (2026-06-22) · **Builds on / refines:**
+**Status:** Accepted — shipped in M35 / M37 (model-relative tolerances threaded through the kernel, PR#1427) · **Builds on / refines:**
 [ADR-0020](ADR-0020-yaml-git-friendly-document-format.md) (the `.obk` document that persists a
 document's units) and the Units-of-Measure work (Oblikovati/Oblikovati#146) — this ADR governs
 *how the kernel's numerical tolerances and working scale relate to the document unit*, so the

--- a/architecture/implementation-conventions.md
+++ b/architecture/implementation-conventions.md
@@ -14,23 +14,25 @@ sketches → features (in order) are *replayed* to produce geometry. Recompute,
 rollback, identity, and undo all follow from this. Geometry is a cache of the
 last evaluation, never the source of truth.
 
-## Public API contract (/api) ↔ implementation (/source)
+## Public API contract (api module) ↔ implementation (GPL module)
 
-The public API lives in its own Apache-2.0 module, **`oblikovati.org/api`**
-(`/api`); the GPL application (`/source`) implements it (ADR-0018). Every PBI that
-touches the public surface ships **the contract and the implementation together**:
+The public API lives in its own Apache-2.0 module, **`oblikovati.org/api`** (the
+sibling `Oblikovati.API` repo); the GPL application (this repo's module) implements
+it (ADR-0018). Every PBI that touches the public surface ships **the contract and the
+implementation together**:
 
-1. **/api (contract, Apache-2.0):** enums/value types in `api/types` (defined once
-   here; `/source` aliases them with `type X = types.X`), in-proc Go interfaces in
-   `api/contract`, method-name constants + JSON DTOs in `api/wire`, and a typed
-   method group in `api/client`.
-2. **/source (implementation, GPL-2.0):** the behavior in `kernel/model/app/head`,
+1. **api module (contract, Apache-2.0):** enums/value types in `api/types` (defined
+   once here; the GPL module aliases them with `type X = types.X`), in-proc Go
+   interfaces in `api/contract`, method-name constants + JSON DTOs in `api/wire`, and
+   a typed method group in `api/client`.
+2. **GPL module (implementation, GPL-2.0):** the behavior in `kernel/model/app/head`,
    a compile-time assertion that the impl satisfies `api/contract`
    (`var _ contract.X = (*impl.X)(nil)`), and the handler wired into `addin/router`
    keyed on the `api/wire` method constant.
 
 Never re-declare a DTO or method string outside `api/wire`; never call the host from
-an add-in with raw JSON (use `api/client`). `/api` must never import `/source`.
+an add-in with raw JSON (use `api/client`). The `api` module must never import the
+GPL module.
 
 ## The Definition → Add → Feature triangle (every modeling PBI)
 


### PR DESCRIPTION
## What

Brings the core architecture docs back in line with the actual code — they're the first place a new contributor or agent looks, and they described phantom packages and a truncated ADR index.

- **`architecture/core/01-module-layout.md`** — rewrote the package tree to reality: dropped the nonexistent `runtime/ platform/ ui/ addins/ registry/ kernel/predicate/`; showed the real `app/` (session mediator), `head/{viewport,ui,addins}` (cgo Vulkan+ImGui shell), `addin/` (host router serving api/wire), `solve/`, and the actual `kernel/{geom,topo,brep,ops,…}` + `model/` subpackages. Fixed the dependency-direction block and the `/api` section (it's a **sibling repo** tied in via `go.work`, not a `/source`-sibling dir).
- **`architecture/README.md`** — completed the ADR index: it was stuck at 0036 behind a never-honored "backfilled separately" note. Added **0018–0028** and **0037–0042** so it's contiguous **0001–0042**. Replaced the phantom-dir "stack at a glance" diagram with the real layering. Added a note that ADR namespaces are per-repo (the CalculiX FEA add-in's ADR-0007/0008 ≠ this repo's 0007/0008).
- **`architecture/implementation-conventions.md`** — fixed the retired `/api` / `/source` path labels (content unchanged).
- Flipped three shipped ADRs **Proposed → Accepted**: ADR-0023 (display modes, M23), ADR-0026 (IBL/shadows, M16), ADR-0042 (model-relative tolerances, M35/M37 PR#1427).

## Why

An ADR index that stops 6 entries short hides the most recent load-bearing decisions (including the tolerance system the kernel now depends on), and "Proposed" status on shipped ADRs makes the record untrustworthy. The phantom `runtime/`/`registry/` packages send people looking for code that was never built.

## Verification

- Every package/dir named in `01-module-layout.md` and the README diagram resolves to a real directory (checked).
- ADR index is contiguous 0001–0042, no gaps (checked).
- No `runtime/`/`platform/`/`registry/`/`kernel/predicate`/`/source`/`github.com/Oblikovati/api` references remain in the touched docs (the only residual `platform/render` is ADR-0008's own historical title; `runtime/renderer patterns` on README:13 is prose naming the skill).

Docs-only; no code touched.

Closes #1508

🤖 Generated with [Claude Code](https://claude.com/claude-code)