### PR TITLE
docs: drop dead PARTDOC-PLAN references (#1507)

### DIFF
--- a/architecture/mapping/inventor-ribbon-structure.md
+++ b/architecture/mapping/inventor-ribbon-structure.md
@@ -230,10 +230,8 @@ Notes:
 - Sketch **`Modify`** should be: Move, Copy, Rotate, Scale, Stretch, Trim, Extend, Split,
   Offset. We currently also have Mirror (→ Pattern) and Fillet (→ Create) there.
 - Part **`Surface`** panel buttons are Patch, Stitch, Sculpt, Extend, Trim, Rule Fillet —
-  when the M10 surfacing features get UI (PARTDOC-PLAN Phase 5), place them here, not in a
-  new panel.
+  when the surfacing features get UI, place them here, not in a new panel.
 - Part **`Pattern`** panel (Rectangular, Circular, Sketch Driven, Mirror) is where the
-  flagship pattern/mirror UI (PARTDOC-PLAN Phase 3, finding U-01) must land.
+  flagship pattern/mirror UI must land.
 - Out-of-scope environments (SheetMetal/Assembly/Drawing/Presentation) are included for
-  completeness; do not build them until PartDocument is complete (see PARTDOC-PLAN.md at
-  the repo root).
+  completeness; do not build them until PartDocument is complete.


### PR DESCRIPTION
## What

Part of #1507 (stale-doc cleanup). The root-level planning docs (`ACTION-PLAN.md`, `REPORT.md`, `PARTDOC-PLAN.md`, `AGENTS.md`) were deleted as stale June-4/5/6 artifacts. This removes the now-dead `PARTDOC-PLAN` pointers from `architecture/mapping/inventor-ribbon-structure.md` (the ribbon-placement guidance stays; only the dead doc references go).

Note: the four root docs live at the **non-git workspace root** (not version-controlled), so their deletion happens directly on disk, not via a PR. The historical citations in `architecture/history/implementation-log.md` and `ADR-0027` are left intact — they are point-in-time record of the 2026-06-04 audit, not live links. The `Oblikovati.Contracts/implementation-plan/` freeze is handled separately in that repo.

Refs #1507

🤖 Generated with [Claude Code](https://claude.com/claude-code)