### PR TITLE
refactor(brep): collapse duplicated curved-boolean dispatch into a table (#1502)

### DIFF
--- a/kernel/brep/curved_general_ruled_cutjoin.go
+++ b/kernel/brep/curved_general_ruled_cutjoin.go
@@ -84,7 +84,7 @@ func (o ruledOperand) split(imprint []geom.Curve3, op Op, isB bool, other func(m
 
 // require2Loops gates a cut/join on the imprint being exactly two closed loops — a clean rod-through-fat
 // crossing (entry + exit). Anything else (a tangency, a partial penetration, an open chain) declines so the
-// caller keeps its bespoke fallback (#1403).
+// caller keeps its CSG fallback (#1403).
 func require2Loops(loops []geom.Polyline, ok bool) ([]geom.Polyline, bool) {
 	return loops, ok && len(loops) == 2
 }
@@ -174,80 +174,63 @@ func filterCaps(b *topo.Body, keep func(math.Point3) bool) []curvedFace {
 	return caps
 }
 
-// CrossingCylinderCutGeneral routes crossing-cylinder subtract through the general ruled cut (#1403/#1476):
-// a fat cylinder drilled by a rod (one solid) or a rod sliced by a fat (two stubs). ok=false outside the
-// wired clean-side-breach crossing so kernel/ops keeps its bespoke fallback.
-func CrossingCylinderCutGeneral(target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	loops, ok := require2Loops(crossingCylinderImprint(target, tool, rec))
-	tgt, okT := cylinderOperand(target)
-	tl, okL := cylinderOperand(tool)
-	if !ok || !okT || !okL {
+// ruledPairGeneral is the shared body of the full-crossing ruled cut/join exports below: trace the
+// imprint as two loops (the entry + exit of a clean side breach), resolve both operands to their ruled
+// type, and combine. The three injected functions are all that differ between the pairs — the imprint
+// tracer, the operand resolver, and ruledCutGeneral vs ruledJoinGeneral (#1502, collapsing six
+// near-identical wrappers). ok=false when the imprint is not a clean two-loop crossing or an operand is
+// not the expected ruled surface, so kernel/ops keeps its CSG fallback.
+func ruledPairGeneral(a, b *topo.Body, rec *diag.Recorder,
+	imprint func(*topo.Body, *topo.Body, *diag.Recorder) ([]geom.Polyline, bool),
+	operand func(*topo.Body) (ruledOperand, bool),
+	combine func(target, tool ruledOperand, loops []geom.Polyline) (*topo.Body, bool)) (*topo.Body, bool) {
+	loops, ok := require2Loops(imprint(a, b, rec))
+	oa, okA := operand(a)
+	ob, okB := operand(b)
+	if !ok || !okA || !okB {
 		return nil, false
 	}
-	return ruledCutGeneral(tgt, tl, loops)
+	return combine(oa, ob, loops)
+}
+
+// CrossingCylinderCutGeneral routes crossing-cylinder subtract through the general ruled cut (#1403/#1476):
+// a fat cylinder drilled by a rod (one solid) or a rod sliced by a fat (two stubs). ok=false outside the
+// wired clean-side-breach crossing so kernel/ops keeps its CSG fallback.
+func CrossingCylinderCutGeneral(target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	return ruledPairGeneral(target, tool, rec, crossingCylinderImprint, cylinderOperand, ruledCutGeneral)
 }
 
 // CrossingCylinderJoinGeneral routes crossing-cylinder JOIN through the general ruled join (#1403/#1476):
 // a fat cylinder side-breached by a rod, welded into one solid (keyhole holed wall + two stubs + whole caps).
 func CrossingCylinderJoinGeneral(a, b *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	loops, ok := require2Loops(crossingCylinderImprint(a, b, rec))
-	oa, okA := cylinderOperand(a)
-	ob, okB := cylinderOperand(b)
-	if !ok || !okA || !okB {
-		return nil, false
-	}
-	return ruledJoinGeneral(oa, ob, loops)
+	return ruledPairGeneral(a, b, rec, crossingCylinderImprint, cylinderOperand, ruledJoinGeneral)
 }
 
 // ConeConeCutGeneral routes cone∩cone subtract through the general ruled cut (#1403): a fat frustum drilled by
 // a crossing rod frustum (one solid) or a rod frustum sliced by a fat (two tapered stubs). ok=false outside
 // the wired clean-side-breach frustum crossing.
 func ConeConeCutGeneral(target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	loops, ok := require2Loops(coneConeImprint(target, tool, rec))
-	tgt, okT := coneOperand(target)
-	tl, okL := coneOperand(tool)
-	if !ok || !okT || !okL {
-		return nil, false
-	}
-	return ruledCutGeneral(tgt, tl, loops)
+	return ruledPairGeneral(target, tool, rec, coneConeImprint, coneOperand, ruledCutGeneral)
 }
 
 // ConeConeJoinGeneral routes cone∩cone JOIN through the general ruled join (#1403): a fat frustum side-breached
 // by a crossing rod frustum, welded into one solid (holed fat wall + a tapered stub each side + whole caps).
 func ConeConeJoinGeneral(a, b *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	loops, ok := require2Loops(coneConeImprint(a, b, rec))
-	oa, okA := coneOperand(a)
-	ob, okB := coneOperand(b)
-	if !ok || !okA || !okB {
-		return nil, false
-	}
-	return ruledJoinGeneral(oa, ob, loops)
+	return ruledPairGeneral(a, b, rec, coneConeImprint, coneOperand, ruledJoinGeneral)
 }
 
 // ConeCylinderCutGeneral routes cone∩cylinder subtract through the general ruled cut (#1403): a fat cylinder
 // drilled by a crossing cone (or vice-versa). The operands resolve by type (ruledOperandOf), so target/tool
 // may be cone-then-cylinder or the reverse. ok=false outside the wired clean-side-breach crossing.
 func ConeCylinderCutGeneral(target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	loops, ok := require2Loops(coneCylinderImprint(target, tool, rec))
-	tgt, okT := ruledOperandOf(target)
-	tl, okL := ruledOperandOf(tool)
-	if !ok || !okT || !okL {
-		return nil, false
-	}
-	return ruledCutGeneral(tgt, tl, loops)
+	return ruledPairGeneral(target, tool, rec, coneCylinderImprint, ruledOperandOf, ruledCutGeneral)
 }
 
 // ConeCylinderJoinGeneral routes cone∩cylinder JOIN through the general ruled join (#1403): a fat cylinder
 // side-breached by a crossing cone (or vice-versa), welded into one solid. ok=false outside the wired
 // clean-side-breach crossing.
 func ConeCylinderJoinGeneral(a, b *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	loops, ok := require2Loops(coneCylinderImprint(a, b, rec))
-	oa, okA := ruledOperandOf(a)
-	ob, okB := ruledOperandOf(b)
-	if !ok || !okA || !okB {
-		return nil, false
-	}
-	return ruledJoinGeneral(oa, ob, loops)
+	return ruledPairGeneral(a, b, rec, coneCylinderImprint, ruledOperandOf, ruledJoinGeneral)
 }
 
 // partialImprint returns the SINGLE imprint loop of a partial penetration — a thin rod that breaches one wall

--- a/kernel/brep/curved_general_wrapping_band.go
+++ b/kernel/brep/curved_general_wrapping_band.go
@@ -13,11 +13,12 @@ import (
 // that keeps the part of a ruled side OUTSIDE the other solid produces a band that WRAPS the whole azimuth —
 // a tube with no contractible outer loop. The half-space (u,v) emission assumes a contractible outer
 // (loops[0]) with the rest as holes, so it mis-files one of the tube's two ends (a rim) as a "hole" and the
-// mesher carves the wrong region. The two correct shapes the bespoke handlers build are reproduced here:
+// mesher carves the wrong region. The two correct shapes are reproduced here (these are the shapes the
+// removed per-pair bespoke handlers used to build; the general pipeline is now the only path):
 //
 //   - a HOLED tube (the fat wall punched by the rod): two constant-v rims plus contractible imprint holes.
 //     Bridged by a seam ruling into one keyhole outer loop (rim→seam→rim→seam), holes inside — the
-//     seam-cut form periodicBandGrid meshes (the bespoke addFatCapsAndHoledWall shape).
+//     seam-cut form periodicBandGrid meshes (the holed-wall shape).
 //   - a TWO-RIM band (a rod stub poking out): one cap rim + one imprint rim, both full-wrap, no holes —
 //     emitted as a two-closed-loop face the ruled saddle loft (twoClosedRimBandMesh) lofts rim-to-rim.
 //
@@ -89,8 +90,8 @@ func (c ruledUV) keyholeTubeFace(holes []emittedLoop, surface geom.Surface, f cu
 // keyholeOuter bridges the band's two rims into one outer loop at their NATIVE seam (the rim circles' own
 // angle-zero ruling, where both rims are anchored to the same azimuth, so the bridge is a v-ruling on the
 // surface). The loop runs up the bridge, around the top rim (reversed when the source side traverses its top
-// rim opposite its cap), back down the bridge, around the bottom rim — the bespoke addFatCapsAndHoledWall
-// keyhole, but reusing the original rim circles so the outer's rims weld to the caps without re-seaming (#1476).
+// rim opposite its cap), back down the bridge, around the bottom rim — the holed-wall keyhole shape, but
+// reusing the original rim circles so the outer's rims weld to the caps without re-seaming (#1476).
 func (c ruledUV) keyholeOuter() []loopEdge {
 	seamBot := c.band.bottomCirc.PointAt(0)
 	seamTop := c.band.topCirc.PointAt(0)

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -8,300 +8,71 @@ import (
 	"oblikovati.org/kernel/topo"
 )
 
-// Exact crossing-cylinder intersection (M2 Phase 2, Oblikovati/Oblikovati#1335). Wires
-// brep.CrossingCylinderIntersect into the boolean: a rod ∩ a fatter cylinder builds straight from the
-// traced imprint loops into a watertight analytic solid (rod band + two fat-wall lens caps), keeping the
-// exact cylinder surfaces instead of triangle-soup CSG. Anything outside the thin-through-fat case (a
-// non-cylinder operand, equal radii, a partial penetration) returns ok=false so booleanGeneral keeps its
-// CSG fallback — no regression.
+// Exact analytic curved-boolean paths for crossing/coaxial cylinder & cone pairs (M2, EPIC #1403).
+// Each path routes a recognised (op, target, tool) pair to a brep builder that constructs the result
+// straight from the traced SSI imprint as a watertight ANALYTIC solid — keeping the exact cylinder/cone
+// surfaces instead of triangle-soup CSG. A pair the builder does not handle (a non-matching op, an
+// out-of-scope configuration, an inside-out or open assembly) returns ok=false so booleanGeneral keeps
+// its planar CSG fallback — no regression.
+//
+// Every path is the SAME two checks around a builder — the op guard and the validBooleanSolid gate —
+// so they are written ONCE in gatedCurved (#1502). The gate is a correctness invariant (an unvalidated
+// boolean must never be adopted); centralising it means a pair added to the table below cannot forget
+// it, the copy-paste hazard this file used to carry as 18 near-identical handlers.
 
-// curvedCrossingIntersect returns the exact intersection of two crossing cylinders, or ok=false to defer.
-// Only Intersect maps here, and only a valid closed manifold result is adopted (an inside-out or open
-// assembly is rejected so the fallback runs instead).
-func curvedCrossingIntersect(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	if op != Intersect {
-		return nil, false
+// ruledBuild builds the exact analytic result for one curved pair. The general SSI pipeline builders
+// (brep.*General) take the imprint recorder; the bespoke analytic constructors (equal-radius Steinmetz,
+// drill-through, coaxial, boss) take none and are adapted with withoutRecorder.
+type ruledBuild func(target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool)
+
+// gatedCurved wraps a builder with the op guard and the single validBooleanSolid gate every curved pair
+// must pass, returning a curvedExactPaths entry. ok=false (defer to the CSG fallback) when the op does
+// not match or the analytic result is not a valid closed manifold solid.
+func gatedCurved(want PartFeatureOperation, build ruledBuild) func(PartFeatureOperation, *topo.Body, *topo.Body, *diag.Recorder) (*topo.Body, bool) {
+	return func(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+		if op != want {
+			return nil, false
+		}
+		res, ok := build(target, tool, rec)
+		if !ok || !validBooleanSolid(res) {
+			return nil, false
+		}
+		return res, true
 	}
-	// EPIC #1403: route crossing-cylinder intersect through the GENERAL pipeline first (an out-of-scope pair declines to the planar CSG fallback.
-	res, ok := brep.CrossingCylinderIntersectGeneral(target, tool, rec)
-	if !ok || !validBooleanSolid(res) {
-		return nil, false
-	}
-	return res, true
 }
 
-// curvedConeCylinderIntersect returns the exact intersection of a cone crossing a cylinder (the cone band
-// plus two cylinder-wall lens caps), or ok=false to defer. Only Intersect maps here, and only a valid closed
-// manifold result is adopted.
-func curvedConeCylinderIntersect(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	if op != Intersect {
-		return nil, false
-	}
-	// EPIC #1403: route cone∩cylinder through the GENERAL pipeline first an out-of-scope pair declines to the planar CSG fallback.
-	res, ok := brep.ConeCylinderIntersectGeneral(target, tool, rec)
-	if !ok || !validBooleanSolid(res) {
-		return nil, false
-	}
-	return res, true
+// withoutRecorder adapts a bespoke analytic constructor (one that traces no SSI imprint) to ruledBuild.
+func withoutRecorder(build func(target, tool *topo.Body) (*topo.Body, bool)) ruledBuild {
+	return func(target, tool *topo.Body, _ *diag.Recorder) (*topo.Body, bool) { return build(target, tool) }
 }
 
-// curvedConeConeIntersect returns the exact intersection of a cone crossing a fatter cone (the rod-cone band
-// plus two fat-cone lens caps), or ok=false to defer. Only Intersect maps here, and only a valid closed
-// manifold result is adopted.
-func curvedConeConeIntersect(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	if op != Intersect {
-		return nil, false
-	}
-	// EPIC #1403: route cone∩cone through the GENERAL SSI→trim→classify→stitch pipeline . An out-of-scope configuration declines to the planar CSG fallback.
-	res, ok := brep.ConeConeIntersectGeneral(target, tool, rec)
-	if !ok || !validBooleanSolid(res) {
-		return nil, false
-	}
-	return res, true
-}
+// The curved-pair paths, each an (op, builder) gated once by gatedCurved. Names are referenced by
+// curvedExactPaths in boolean.go, which fixes their try-order; the comment on each records the pair it
+// handles. The general SSI→trim→classify→stitch pipeline (#1403/#1476) builds every ruled pair; the
+// equal-radius Steinmetz cases stay on a bespoke constructor (the pinch self-intersects into four lobes
+// the general (u,v) arrangement cannot yet split — see brep.EqualRadiusSteinmetzIntersect).
+var (
+	// Intersect — the band of the thin operand plus the fat operand's two lens caps.
+	curvedCrossingIntersect     = gatedCurved(Intersect, brep.CrossingCylinderIntersectGeneral) // two crossing cylinders
+	curvedSteinmetzIntersect    = gatedCurved(Intersect, withoutRecorder(brep.EqualRadiusSteinmetzIntersect))
+	curvedConeCylinderIntersect = gatedCurved(Intersect, brep.ConeCylinderIntersectGeneral) // cone ∩ cylinder
+	curvedConeConeIntersect     = gatedCurved(Intersect, brep.ConeConeIntersectGeneral)     // cone ∩ fatter cone
+	curvedPartialIntersect      = gatedCurved(Intersect, brep.PartialPenetrationIntersectGeneral)
 
-// curvedSteinmetzIntersect returns the exact intersection of two equal-radius perpendicular cylinders (the
-// Steinmetz bicylinder), or ok=false to defer. Only Intersect maps here, and only a valid closed manifold
-// result is adopted. This is the ONE crossing case kept on its bespoke analytic constructor (the general
-// curved∩curved pipeline, #1403, handles every other ruled pair): the equal-radius pinch makes the imprint
-// self-intersect into four lobes, which the general (u,v) arrangement cannot yet split or weld — see the
-// detailed rationale on brep.EqualRadiusSteinmetzIntersect. The general crossing path declines equal radii
-// (its result fails validBooleanSolid), so it does not race this handler.
-func curvedSteinmetzIntersect(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	if op != Intersect {
-		return nil, false
-	}
-	res, ok := brep.EqualRadiusSteinmetzIntersect(target, tool)
-	if !ok || !validBooleanSolid(res) {
-		return nil, false
-	}
-	return res, true
-}
+	// Cut — drilling the target with the tool (through, blind, or two stubs of tool − target).
+	curvedCylindricalHoleCut = gatedCurved(Cut, withoutRecorder(brep.DrillThroughHole)) // straight cylinder through a planar slab
+	curvedPartialCut         = gatedCurved(Cut, brep.PartialPenetrationCutGeneral)      // blind rod hole
+	curvedSteinmetzCut       = gatedCurved(Cut, withoutRecorder(brep.EqualRadiusSteinmetzCut))
+	curvedConeCylinderCut    = gatedCurved(Cut, brep.ConeCylinderCutGeneral)
+	curvedConeConeCut        = gatedCurved(Cut, brep.ConeConeCutGeneral)
+	curvedCrossingCut        = gatedCurved(Cut, brep.CrossingCylinderCutGeneral)
 
-// curvedPartialIntersect returns the exact intersection of a thin rod ending inside a fatter cylinder (the
-// rod plug), or ok=false to defer. Only Intersect maps here, and only a valid closed manifold result is
-// adopted. This is the partial-penetration case the imprint traces as a single loop (one wall breach).
-func curvedPartialIntersect(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	if op != Intersect {
-		return nil, false
-	}
-	// EPIC #1403: route the partial-penetration plug through the GENERAL pipeline first (#1476 wrapping-band +
-	// the cap generalisation that keeps the rod's interior-ending blind cap); an out-of-scope pair declines to the planar CSG fallback (booleanGeneral).
-	res, ok := brep.PartialPenetrationIntersectGeneral(target, tool, rec)
-	if !ok || !validBooleanSolid(res) {
-		return nil, false
-	}
-	return res, true
-}
-
-// curvedPartialCut returns target − tool when tool is a thin rod ending inside the fatter target (a blind
-// hole), or ok=false to defer. Only Cut maps here, and only a valid closed manifold result is adopted.
-func curvedPartialCut(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	if op != Cut {
-		return nil, false
-	}
-	// EPIC #1403: route the partial-penetration blind hole / stub through the GENERAL pipeline first (#1476);
-	// an out-of-scope pair declines to the planar CSG fallback (booleanGeneral).
-	res, ok := brep.PartialPenetrationCutGeneral(target, tool, rec)
-	if !ok || !validBooleanSolid(res) {
-		return nil, false
-	}
-	return res, true
-}
-
-// curvedPartialJoin returns target ∪ tool for a thin rod ending inside the fatter cylinder (the fat with a
-// single rod stub sticking out the entry side), or ok=false to defer. Only Join maps here, and only a valid
-// closed manifold result is adopted.
-func curvedPartialJoin(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	if op != Join {
-		return nil, false
-	}
-	// EPIC #1403: route the partial-penetration union (fat + entry stub) through the GENERAL pipeline first
-	// (#1476); an out-of-scope pair declines to the planar CSG fallback (booleanGeneral).
-	res, ok := brep.PartialPenetrationJoinGeneral(target, tool, rec)
-	if !ok || !validBooleanSolid(res) {
-		return nil, false
-	}
-	return res, true
-}
-
-// curvedCylindricalHoleCut returns target − tool when the tool is a straight cylinder drilling a clean
-// through-hole in an all-planar target (a drilled plate), or ok=false to defer. The result is an EXACT
-// curved B-rep — the two pierced faces gain a circular hole and a single geom.Cylinder face forms the
-// hole wall — so the most common curved cut no longer degrades to triangle-soup CSG (M2 Phase 3,
-// Oblikovati/Oblikovati#1336, reverse of the #1334 cylinder − box case). Only Cut maps here; a tool that
-// is not a single full cylinder, or a hole that clips a face or does not pass clean through, returns
-// ok=false so the CSG fallback still runs.
-func curvedCylindricalHoleCut(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	if op != Cut {
-		return nil, false
-	}
-	res, ok := brep.DrillThroughHole(target, tool)
-	if !ok || !validBooleanSolid(res) {
-		return nil, false
-	}
-	return res, true
-}
-
-// curvedCoaxialJoin returns target ∪ tool when both are coaxial equal-radius cylinders overlapping or
-// abutting along the axis — one cylinder spanning their merged extent — or ok=false to defer. Their side
-// faces are coincident (the curved analogue of a coplanar overlap), which the CSG fallback faceted; the
-// exact union keeps the analytic cylinder. Only Join maps here, and only a valid closed manifold result is
-// adopted.
-func curvedCoaxialJoin(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	if op != Join {
-		return nil, false
-	}
-	res, ok := brep.CoaxialCylinderUnion(target, tool)
-	if !ok || !validBooleanSolid(res) {
-		return nil, false
-	}
-	return res, true
-}
-
-// curvedCylinderBossJoin returns target ∪ tool when tool is a cylinder seated flush and perpendicular on
-// one planar face of target, protruding outward (a boss / spigot), or ok=false to defer. The boss base
-// disk is coplanar with the seat face — the canonical coplanar overlap the CSG fallback faceted; the exact
-// union keeps the analytic cylinder wall. Only Join maps here, and only a valid closed manifold result is
-// adopted.
-func curvedCylinderBossJoin(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	if op != Join {
-		return nil, false
-	}
-	res, ok := brep.JoinCylindricalBoss(target, tool)
-	if !ok || !validBooleanSolid(res) {
-		return nil, false
-	}
-	return res, true
-}
-
-// curvedConeCylinderCut returns target − tool for a cone crossing a cylinder (drilling the fat cylinder with
-// the cone, or the two cone stubs of cone − fat), or ok=false to defer. Only Cut maps here, and only a valid
-// closed manifold result is adopted.
-func curvedConeCylinderCut(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	if op != Cut {
-		return nil, false
-	}
-	// EPIC #1403: route cone∩cylinder subtract through the GENERAL ruled cut first (#1476 OUTSIDE-keep
-	// emission); an out-of-scope pair declines to the planar CSG fallback (booleanGeneral).
-	res, ok := brep.ConeCylinderCutGeneral(target, tool, rec)
-	if !ok || !validBooleanSolid(res) {
-		return nil, false
-	}
-	return res, true
-}
-
-// curvedConeCylinderJoin returns target ∪ tool for a cone crossing a cylinder (a fat cylinder side-breached
-// by a cone passing through it, leaving a tapered stub each side), or ok=false to defer. Only Join maps here,
-// and only a valid closed manifold result is adopted.
-func curvedConeCylinderJoin(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	if op != Join {
-		return nil, false
-	}
-	// EPIC #1403: route cone∩cylinder JOIN through the GENERAL ruled join first (#1476 OUTSIDE-keep emission);
-	// an out-of-scope pair declines to the planar CSG fallback (booleanGeneral).
-	res, ok := brep.ConeCylinderJoinGeneral(target, tool, rec)
-	if !ok || !validBooleanSolid(res) {
-		return nil, false
-	}
-	return res, true
-}
-
-// curvedConeConeCut returns target − tool for a cone crossing a fatter cone (drilling the fat cone with the
-// rod cone, or the two rod-cone stubs of cone − fat), or ok=false to defer. Only Cut maps here, and only a
-// valid closed manifold result is adopted.
-func curvedConeConeCut(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	if op != Cut {
-		return nil, false
-	}
-	// EPIC #1403: route cone∩cone subtract through the GENERAL ruled cut first (#1476 OUTSIDE-keep emission);
-	// an out-of-scope pair declines to the planar CSG fallback (booleanGeneral).
-	res, ok := brep.ConeConeCutGeneral(target, tool, rec)
-	if !ok || !validBooleanSolid(res) {
-		return nil, false
-	}
-	return res, true
-}
-
-// curvedConeConeJoin returns target ∪ tool for a cone crossing a fatter cone (the fat cone side-breached by a
-// rod cone passing through it, leaving a tapered stub each side), or ok=false to defer. Only Join maps here,
-// and only a valid closed manifold result is adopted.
-func curvedConeConeJoin(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	if op != Join {
-		return nil, false
-	}
-	// EPIC #1403: route cone∩cone JOIN through the GENERAL ruled join first (#1476 OUTSIDE-keep emission);
-	// an out-of-scope pair declines to the planar CSG fallback (booleanGeneral).
-	res, ok := brep.ConeConeJoinGeneral(target, tool, rec)
-	if !ok || !validBooleanSolid(res) {
-		return nil, false
-	}
-	return res, true
-}
-
-// curvedSteinmetzCut returns target − tool for two equal-radius perpendicular cylinders (the target with
-// the tool's saddle bite removed), or ok=false to defer. Only Cut maps here, and only a valid closed
-// manifold result is adopted. Like curvedSteinmetzIntersect, this stays on the bespoke analytic constructor:
-// the equal-radius pinch is the one case the general pipeline (#1403) does not handle — see the rationale on
-// brep.EqualRadiusSteinmetzIntersect.
-func curvedSteinmetzCut(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	if op != Cut {
-		return nil, false
-	}
-	res, ok := brep.EqualRadiusSteinmetzCut(target, tool)
-	if !ok || !validBooleanSolid(res) {
-		return nil, false
-	}
-	return res, true
-}
-
-// curvedCrossingCut returns target − tool for two crossing cylinders (drilling a fat cylinder with a
-// crossing rod, or the two rod stubs of rod − fat), or ok=false to defer. Only Cut maps here, and only a
-// valid closed manifold result is adopted.
-func curvedCrossingCut(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	if op != Cut {
-		return nil, false
-	}
-	// EPIC #1403: route crossing-cylinder subtract through the GENERAL pipeline first (the OUTSIDE-keep
-	// wrapping-band emission, Oblikovati#1476, makes it mesh the right region; the tool tunnel reverses into the
-	// cavity); an out-of-scope pair declines to the CSG fallback (a
-	// breach reaching a cap, a partial penetration), so no OCC case regresses.
-	res, ok := brep.CrossingCylinderCutGeneral(target, tool, rec)
-	if !ok || !validBooleanSolid(res) {
-		return nil, false
-	}
-	return res, true
-}
-
-// curvedSteinmetzJoin returns target ∪ tool for two equal-radius perpendicular cylinders (the union of two
-// crossing cylinders of the same radius), or ok=false to defer. Only Join maps here, and only a valid closed
-// manifold result is adopted. Like curvedSteinmetzIntersect, this stays on the bespoke analytic constructor:
-// the equal-radius pinch is the one case the general pipeline (#1403) does not handle — see the rationale on
-// brep.EqualRadiusSteinmetzIntersect.
-func curvedSteinmetzJoin(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	if op != Join {
-		return nil, false
-	}
-	res, ok := brep.EqualRadiusSteinmetzJoin(target, tool)
-	if !ok || !validBooleanSolid(res) {
-		return nil, false
-	}
-	return res, true
-}
-
-// curvedCrossingJoin returns target ∪ tool for two crossing cylinders (a fat cylinder side-breached by a
-// rod passing through it, leaving a stub each side), or ok=false to defer. Only Join maps here, and only a
-// valid closed manifold result is adopted.
-func curvedCrossingJoin(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	if op != Join {
-		return nil, false
-	}
-	// EPIC #1403: crossing-cylinder JOIN is built by the GENERAL pipeline (the OUTSIDE-keep wrapping-band
-	// emission, Oblikovati#1476, meshes the fat's keyhole-bridged holed wall plus the two split rod stubs); an
-	// out-of-scope pair (a breach reaching a cap, equal radii) declines to the planar CSG fallback (booleanGeneral).
-	res, ok := brep.CrossingCylinderJoinGeneral(target, tool, rec)
-	if !ok || !validBooleanSolid(res) {
-		return nil, false
-	}
-	return res, true
-}
+	// Join — the union, keeping the analytic wall where the operands' faces are coincident or breached.
+	curvedCoaxialJoin      = gatedCurved(Join, withoutRecorder(brep.CoaxialCylinderUnion)) // coaxial equal-radius cylinders
+	curvedCylinderBossJoin = gatedCurved(Join, withoutRecorder(brep.JoinCylindricalBoss))  // cylinder seated flush on a face
+	curvedPartialJoin      = gatedCurved(Join, brep.PartialPenetrationJoinGeneral)         // fat + entry stub
+	curvedConeCylinderJoin = gatedCurved(Join, brep.ConeCylinderJoinGeneral)
+	curvedConeConeJoin     = gatedCurved(Join, brep.ConeConeJoinGeneral)
+	curvedCrossingJoin     = gatedCurved(Join, brep.CrossingCylinderJoinGeneral)
+	curvedSteinmetzJoin    = gatedCurved(Join, withoutRecorder(brep.EqualRadiusSteinmetzJoin))
+)

--- a/kernel/ops/gated_curved_test.go
+++ b/kernel/ops/gated_curved_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// TestGatedCurvedCentralisesTheValidityGate pins the contract of gatedCurved — the single adapter the
+// curved-pair paths are built from (#1502). It must apply BOTH the op guard and the validBooleanSolid
+// gate in one place, so a pair added to the table cannot ship an unvalidated boolean. The non-solid case
+// is the load-bearing one: a builder that reports ok=true but returns geometry that is not a closed
+// manifold solid must still be rejected.
+func TestGatedCurvedCentralisesTheValidityGate(t *testing.T) {
+	cyl, err := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2, 5)
+	if err != nil {
+		t.Fatalf("SolidCylinder: %v", err)
+	}
+	// A body carrying the cylinder's faces but flagged NOT solid (an open shell): IsSolid() is false, so
+	// validBooleanSolid rejects it regardless of its faces — the gate the adapter must apply.
+	openShell := topo.MergeBodies(topo.NewLineage(topo.Tok("test", "open", 0)), false, cyl)
+	returns := func(b *topo.Body, ok bool) ruledBuild {
+		return func(_, _ *topo.Body, _ *diag.Recorder) (*topo.Body, bool) { return b, ok }
+	}
+
+	// Op guard: a path declines when the requested op is not the one it handles.
+	if _, ok := gatedCurved(Intersect, returns(cyl, true))(Cut, cyl, cyl, nil); ok {
+		t.Error("gatedCurved must decline when the op does not match its want")
+	}
+	// A declining builder propagates as a decline.
+	if _, ok := gatedCurved(Intersect, returns(nil, false))(Intersect, cyl, cyl, nil); ok {
+		t.Error("gatedCurved must decline when the builder declines (ok=false)")
+	}
+	// The centralised gate: a non-solid result is rejected even though the builder said ok=true.
+	if _, ok := gatedCurved(Intersect, returns(openShell, true))(Intersect, cyl, cyl, nil); ok {
+		t.Error("gatedCurved must gate out a non-solid result (the validBooleanSolid invariant)")
+	}
+	// A valid solid with a matching op is adopted unchanged.
+	if res, ok := gatedCurved(Intersect, returns(cyl, true))(Intersect, cyl, cyl, nil); !ok || res != cyl {
+		t.Errorf("gatedCurved must adopt a valid solid result (ok=%v, same=%v)", ok, res == cyl)
+	}
+}
+
+// TestWithoutRecorderDropsTheRecorder confirms the adapter that lets a bespoke constructor (no SSI
+// imprint) satisfy ruledBuild ignores the recorder and forwards the operands unchanged.
+func TestWithoutRecorderDropsTheRecorder(t *testing.T) {
+	cyl, err := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2, 5)
+	if err != nil {
+		t.Fatalf("SolidCylinder: %v", err)
+	}
+	var gotTarget, gotTool *topo.Body
+	build := withoutRecorder(func(target, tool *topo.Body) (*topo.Body, bool) {
+		gotTarget, gotTool = target, tool
+		return target, true
+	})
+	res, ok := build(cyl, cyl, nil) // nil recorder must be fine (it is dropped)
+	if !ok || res != cyl || gotTarget != cyl || gotTool != cyl {
+		t.Errorf("withoutRecorder must forward operands and drop the recorder (ok=%v)", ok)
+	}
+}


### PR DESCRIPTION
## What

Removes ~220 lines of duplication in the curved-boolean dispatch and puts the validity gate in one place.

1. **`kernel/ops/boolean_crossing_cylinder.go` (307 → 78 lines):** the 18 byte-identical handlers become a table of `(op, builder)` entries built from one `gatedCurved` adapter that applies the op guard **and** the `validBooleanSolid` gate exactly once. `withoutRecorder` adapts the bespoke constructors (Steinmetz/drill/coaxial/boss) that take no SSI recorder. Handler names and their order in `curvedExactPaths` are unchanged → dispatch precedence identical.
2. **`kernel/brep/curved_general_ruled_cutjoin.go`:** the 6 near-identical `*General` wrappers collapse into one `ruledPairGeneral(a, b, rec, imprintFn, operandFn, combineFn)`; the exports are one-liners.
3. **Stale comments:** reworded the "bespoke fallback" lines and dropped the `addFatCapsAndHoledWall` references (a removed handler that implied a dual code path).

## Why

The repeated `if !ok || !validBooleanSolid(res)` gate is a correctness invariant — an unvalidated boolean must never be adopted. Copy-pasting it onto every pair means the next person adding a shape pair can forget it and silently ship an unvalidated result (exactly the region/validity bug class this milestone is hardening against). Centralising it in `gatedCurved` makes that impossible.

## Verification

- New `gated_curved_test.go` proves `gatedCurved` applies both the op guard and the validity gate — **a non-solid result is rejected even when the builder reports ok=true** (the load-bearing case) — plus op-mismatch/decline/adopt, and `withoutRecorder` forwarding.
- The full curved-boolean suite (`go test ./kernel/ops/ ./kernel/brep/`) stays green — behavior identical (the OCC-oracle volume tests and every crossing/cone-cone/cone-cylinder cut/join/intersect case pass).
- `grep` for `addFatCapsAndHoledWall` is clean.

The documented equal-radius Steinmetz exception is untouched (a legitimate analytic special-case, not duplication).

Closes #1502

🤖 Generated with [Claude Code](https://claude.com/claude-code)