### PR TITLE
arch: guard domain purity and API-source independence in archguard (#1499)

### DIFF
--- a/archguard/boundary_test.go
+++ b/archguard/boundary_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package archguard
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// The project rests on four import-boundary invariants. TestSourceDoesNotDependOnAnAddIn (this package)
+// holds the first (source must not require an add-in module). These tests add two more with the actual
+// import GRAPH (go list -deps / go.mod), so a leak becomes a red build instead of a convention nobody
+// checks:
+//
+//   - DOMAIN PURITY: kernel/model/math/solve must not import the presentation layer (head/renderer/scene/
+//     addin-router). Keeps the kernel cgo-free and headless-testable and the renderer swappable (ADR-0014).
+//   - API PURITY: the Apache-2.0 api module must not depend on the GPL source. The license split (ADR-0018)
+//     depends on the dependency flowing only one way (source -> api).
+//
+// The fourth invariant — an add-in's shipped (non-test) code must not import the GPL source — is enforced
+// per add-in repo (each add-in is its own module; MCPBridge legitimately requires source for _test.go
+// drivers), so it belongs in each add-in's CI, not here.
+
+// presentationPrefixes are the import paths the domain must never reach.
+var presentationPrefixes = []string{
+	"oblikovati.org/head",
+	"oblikovati.org/renderer",
+	"oblikovati.org/scene",
+	"oblikovati.org/addin/router",
+}
+
+// domainRoots are the pure-domain package trees this guard holds GPU-free.
+var domainRoots = []string{"./kernel/...", "./model/...", "./math/...", "./solve/..."}
+
+// TestDomainPackagesAreGpuFree fails if any package under the domain roots TRANSITIVELY imports the
+// presentation layer. It uses `go list -deps` (the full transitive import graph), so a leak two hops deep
+// (domain -> helper -> renderer) is caught, not only a direct import.
+func TestDomainPackagesAreGpuFree(t *testing.T) {
+	deps := listDeps(t, "..", domainRoots...)
+	for _, dep := range deps {
+		for _, p := range presentationPrefixes {
+			if dep == p || strings.HasPrefix(dep, p+"/") {
+				t.Errorf("a domain package depends on %q — kernel/model/math/solve must not import the "+
+					"presentation layer (head/renderer/scene/addin-router). Relocate the adapter out of the "+
+					"domain (see #1500, ADR-0014).", dep)
+			}
+		}
+	}
+}
+
+// listDeps returns the deduped transitive dependency import paths of the given package patterns, as
+// reported by `go list -deps` run in dir (the module root for those patterns).
+func listDeps(t *testing.T, dir string, patterns ...string) []string {
+	t.Helper()
+	cmd := exec.Command("go", append([]string{"list", "-deps"}, patterns...)...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("go list -deps %v (dir %s): %v", patterns, dir, err)
+	}
+	var deps []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line != "" {
+			deps = append(deps, line)
+		}
+	}
+	return deps
+}
+
+// apiModuleGoMod is the sibling Apache-2.0 contract module's go.mod, resolved via the workspace layout.
+const apiModuleGoMod = "../../Oblikovati.API/go.mod"
+
+// TestApiModuleDoesNotRequireSource fails if the Apache-2.0 api module requires ANY oblikovati.org module
+// — it is the root of the dependency graph, so it must require none (the GPL source requires it, never the
+// reverse). The license split (ADR-0018) depends on this direction. Skips when the sibling is not checked
+// out (a source-only build).
+func TestApiModuleDoesNotRequireSource(t *testing.T) {
+	if _, err := os.Stat(apiModuleGoMod); err != nil {
+		t.Skipf("api module not checked out at %s: %v", apiModuleGoMod, err)
+	}
+	for _, mod := range requiredInternalModules(t, apiModuleGoMod) {
+		t.Errorf("Oblikovati.API/go.mod requires %q — the Apache-2.0 contract must require no oblikovati.org "+
+			"module (the dependency flows source -> api, never the reverse). ADR-0018.", mod)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.92.1
+	oblikovati.org/api v0.93.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.92.1
+	oblikovati.org/api v0.93.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)


### PR DESCRIPTION
## What

`archguard` held only one of the four import-boundary invariants (source must not require an add-in). This adds two more as import-graph tests:

- **`TestDomainPackagesAreGpuFree`** — `go list -deps` over `kernel/model/math/solve` must not reach `head`/`renderer`/`scene`/`addin/router`. Uses the **full transitive** graph, so a leak two hops deep is caught, not just a direct import. Passes now that `model/clientgraphics` was relocated (#1500) — it flagged exactly that package before the move.
- **`TestApiModuleDoesNotRequireSource`** — the Apache-2.0 `api` module must require no `oblikovati.org` module (the dependency flows source → api only; ADR-0018). Skips gracefully if the sibling isn't checked out.

The **fourth** invariant (an add-in's shipped *non-test* code must not import source) is per-add-in-repo — each add-in is its own module, and MCPBridge legitimately `require`s source for `_test.go` drivers — so it belongs in each add-in's CI, not this module's. Noted in the test file.

## Each guard shown to bite (then reverted)

- Domain: a temporary `import _ "oblikovati.org/renderer"` in a `model/` package turns `TestDomainPackagesAreGpuFree` red — and catches both `renderer` **and** `scene` (pulled transitively), proving the transitive check works.
- API: a temporary `require oblikovati.org v0.0.0` appended to `Oblikovati.API/go.mod` turns `TestApiModuleDoesNotRequireSource` red.

## Verification

`go test ./archguard/` green (all three guards), lint clean.

Closes #1499

🤖 Generated with [Claude Code](https://claude.com/claude-code)