### PR TITLE
api: single-source all six duplicated enums via api/types (closes #1501)

### DIFF
--- a/kernel/ops/fillet.go
+++ b/kernel/ops/fillet.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	stdmath "math"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -18,20 +19,17 @@ type FilletRadiusPoint struct {
 	T, R float64
 }
 
-// FilletCrossSection is the shape of a fillet's cross-section profile (M36-F08). The default arc is
-// the circular rolling-ball blend (G1 — tangent to both walls); G2 and Conic flow more smoothly for
-// Class-A styling, where the tell-tale circular-arc highlight break is unacceptable.
-type FilletCrossSection int
+// FilletCrossSection is the shape of a fillet's cross-section profile (M36-F08). It ALIASES the
+// canonical api/types definition (ADR-0018): a string enum whose empty/"arc" value is the circular
+// rolling-ball blend (G1 — tangent to both walls), with G2 (curvature-continuous) and Conic
+// (rho-controlled) flowing more smoothly for Class-A styling. The kernel selects its blend builder on
+// this value (see crossSectionChords); IsArc() reports the default so a never-set Cross reads as arc.
+type FilletCrossSection = types.FilletCrossSection
 
 const (
-	// FilletArc is the circular rolling-ball cross-section (G1, the default/zero value).
-	FilletArc FilletCrossSection = iota
-	// FilletG2 is a curvature-continuous cross-section: zero curvature at both tangency lines, so a
-	// blend between flat walls has NO curvature jump where it meets them (a quintic profile).
-	FilletG2
-	// FilletConic is a conic (rho-controlled) cross-section: a rational quadratic whose shoulder
-	// fullness is set by Rho (0<ρ<1; 0.5 = parabola, <0.5 flatter/elliptic, >0.5 fuller/hyperbolic).
-	FilletConic
+	FilletArc   = types.FilletSectionArc   // circular rolling-ball cross-section (G1, the default)
+	FilletG2    = types.FilletSectionG2    // curvature-continuous cross-section (quintic, no curvature jump)
+	FilletConic = types.FilletSectionConic // conic (rho-controlled) cross-section; pair with Rho
 )
 
 // EdgeFilletRadii is one picked edge with its blend radius at each end: R0 at the edge's
@@ -162,7 +160,7 @@ func (p filletPick) varying() bool { return p.r0 != p.r1 || len(p.mids) > 0 }
 // chordPath reports whether the fillet builds via the chord-sampled ruling band rather than the
 // analytic cylinder: a varying radius OR any non-arc (G2/conic) cross-section, since those are swept
 // NURBS profiles, not a cylinder.
-func (p filletPick) chordPath() bool { return p.varying() || p.cross != FilletArc }
+func (p filletPick) chordPath() bool { return p.varying() || !p.cross.IsArc() }
 
 // resolveFilletPicks resolves the edge reference keys against the body, erroring on a lost
 // key or a non-positive radius.

--- a/kernel/ops/fillet_crosssection_test.go
+++ b/kernel/ops/fillet_crosssection_test.go
@@ -18,10 +18,10 @@ func filletCross(t *testing.T, cross ops.FilletCrossSection, rho float64) float6
 		{Key: verticalEdgeKey(t, box), R0: 0.5, R1: 0.5, Cross: cross, Rho: rho},
 	})
 	if err != nil {
-		t.Fatalf("fillet (cross=%d rho=%g): %v", cross, rho, err)
+		t.Fatalf("fillet (cross=%s rho=%g): %v", cross, rho, err)
 	}
 	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
-		t.Fatalf("cross=%d fillet not a valid solid: %+v", cross, r)
+		t.Fatalf("cross=%s fillet not a valid solid: %+v", cross, r)
 	}
 	return ops.BodyGeometryProperties(res, ops.Quality{ChordTolerance: 1e-3}).Volume
 }

--- a/model/attr/codec.go
+++ b/model/attr/codec.go
@@ -41,8 +41,16 @@ func encodeSets(buf []byte, ss *AttributeSets) []byte {
 	return buf
 }
 
+// valueTypePersistByte maps a value-type tag to its 1-byte on-disk code, and back. The codes are the
+// original compact 0..4 sequence — NOT the api ValueType's frozen Inventor numbers — so persisted
+// metadata stays byte-identical now that ValueType is an alias of the int32 api enum (#1501). A byte
+// outside this set decodes to an invalid tag the decoder rejects (the old behaviour).
+var valueTypePersistByte = map[ValueType]byte{Boolean: 0, Integer: 1, Double: 2, String: 3, Bytes: 4}
+
+var valueTypeFromPersistByte = map[byte]ValueType{0: Boolean, 1: Integer, 2: Double, 3: String, 4: Bytes}
+
 func encodeValue(buf []byte, v Value) []byte {
-	buf = append(buf, byte(v.typ))
+	buf = append(buf, valueTypePersistByte[v.typ])
 	switch v.typ {
 	case Boolean:
 		var b byte
@@ -133,7 +141,11 @@ func decodeValue(r *bytes.Reader) (Value, error) {
 	if err != nil {
 		return Value{}, fmt.Errorf("attr: truncated value type: %w", err)
 	}
-	return decodeTypedValue(ValueType(t), r)
+	vt, ok := valueTypeFromPersistByte[t]
+	if !ok {
+		return Value{}, fmt.Errorf("attr: unknown value type code %d", t)
+	}
+	return decodeTypedValue(vt, r)
 }
 
 func decodeTypedValue(t ValueType, r *bytes.Reader) (Value, error) {

--- a/model/attr/persist_byte_test.go
+++ b/model/attr/persist_byte_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package attr
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestValueTypePersistBytesAreStable pins the on-disk type byte for every value kind. ValueType is now
+// an alias of the int32 api/types.ValueType (whose frozen Inventor numbers are large, e.g. Boolean =
+// 14597), but the attribute codec must keep writing the compact 0..4 codes so existing .obk metadata
+// stays byte-identical (#1501). This guards that mapping: a regression (e.g. reverting to byte(v.typ),
+// which would write 5 for Boolean) turns it red.
+func TestValueTypePersistBytesAreStable(t *testing.T) {
+	cases := []struct {
+		v        Value
+		wantByte byte
+	}{
+		{BoolValue(true), 0},
+		{IntValue(7), 1},
+		{FloatValue(2.5), 2},
+		{StringValue("x"), 3},
+		{BytesValue([]byte{9}), 4},
+	}
+	for _, c := range cases {
+		enc := encodeValue(nil, c.v)
+		if len(enc) == 0 || enc[0] != c.wantByte {
+			t.Errorf("%v: on-disk type byte = %v, want %d", c.v, enc, c.wantByte)
+		}
+		dv, err := decodeValue(bytes.NewReader(enc))
+		if err != nil {
+			t.Errorf("%v: decode: %v", c.v, err)
+			continue
+		}
+		if dv.Type() != c.v.Type() {
+			t.Errorf("%v: round-trip type = %v, want %v", c.v, dv.Type(), c.v.Type())
+		}
+	}
+	// An unknown type code is still rejected, not silently decoded as Boolean (the zero value).
+	if _, err := decodeValue(bytes.NewReader([]byte{9})); err == nil {
+		t.Error("decodeValue accepted an unknown type code 9; want an error")
+	}
+}

--- a/model/attr/value.go
+++ b/model/attr/value.go
@@ -13,39 +13,25 @@ package attr
 import (
 	"fmt"
 	"math"
+
+	"oblikovati.org/api/types"
 )
 
-// ValueType is the type tag of an attribute/property [Value] — the modernized
-// ValueTypeEnum. Values are stable: they are written into the persisted metadata.
-type ValueType uint8
+// ValueType is the type tag of an attribute/property [Value]. It ALIASES the canonical api/types
+// definition (ADR-0018: the value-type tag and its wire spellings are defined once, in the Apache-2.0
+// contract; String()/Parse come from there). The api uses the frozen reference ValueTypeEnum numbers,
+// which never reach the wire (Variant marshals the string spelling); the compact on-disk encoding the
+// attribute codec uses is mapped explicitly in codec.go (valueTypePersistByte), so persisted metadata
+// is unaffected by this aliasing.
+type ValueType = types.ValueType
 
 const (
-	// Boolean is the zero value, but a zero Value still needs an explicit type to
-	// be meaningful; use the constructors.
-	Boolean ValueType = 0
-	Integer ValueType = 1
-	Double  ValueType = 2
-	String  ValueType = 3
-	Bytes   ValueType = 4
+	Boolean = types.BooleanValue   // a boolean tag
+	Integer = types.IntegerValue   // an integer tag
+	Double  = types.DoubleValue    // a floating-point tag
+	String  = types.StringValue    // a string tag
+	Bytes   = types.ByteArrayValue // a byte-array tag
 )
-
-// String returns a stable name for diagnostics.
-func (t ValueType) String() string {
-	switch t {
-	case Boolean:
-		return "boolean"
-	case Integer:
-		return "integer"
-	case Double:
-		return "double"
-	case String:
-		return "string"
-	case Bytes:
-		return "bytes"
-	default:
-		return "unknown"
-	}
-}
 
 // Value is a typed attribute/property value. Exactly one field is meaningful,
 // selected by typ; the typed accessors enforce that, returning ok=false on a type

--- a/model/attr/value_test.go
+++ b/model/attr/value_test.go
@@ -49,7 +49,7 @@ func TestValueEqualAndString(t *testing.T) {
 }
 
 func TestValueTypeAndValueStrings(t *testing.T) {
-	vtypes := map[ValueType]string{Boolean: "boolean", Integer: "integer", Double: "double", String: "string", Bytes: "bytes", ValueType(9): "unknown"}
+	vtypes := map[ValueType]string{Boolean: "boolean", Integer: "integer", Double: "double", String: "string", Bytes: "bytes", ValueType(9): "valueType(?)"}
 	for vt, want := range vtypes {
 		if got := vt.String(); got != want {
 			t.Errorf("ValueType(%d).String() = %q, want %q", vt, got, want)

--- a/model/feature/derived_assembly.go
+++ b/model/feature/derived_assembly.go
@@ -5,54 +5,29 @@ package feature
 import (
 	"fmt"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 	"oblikovati.org/model/occurrence"
 )
 
-// DeriveStyle controls how one source occurrence contributes to a derived assembly's
-// base body — the reference API's per-occurrence derive style. The zero value is
-// DeriveInclude, so an unstyled occurrence is merged in.
-type DeriveStyle int
+// DeriveStyle controls how one source occurrence contributes to a derived assembly's base body — the
+// reference API's per-occurrence derive style. It ALIASES the canonical api/types definition (ADR-0018:
+// the enum and its wire spellings are defined once, in the Apache-2.0 contract); the constants and
+// String() come from there. The zero value is DeriveInclude, so an unstyled occurrence is merged in.
+type DeriveStyle = types.DeriveStyle
 
 const (
-	// DeriveInclude merges the occurrence's bodies into the derived base.
-	DeriveInclude DeriveStyle = iota
-	// DeriveExclude omits the occurrence entirely.
-	DeriveExclude
-	// DeriveSubtract cuts the occurrence's bodies from the merged base.
-	DeriveSubtract
+	DeriveInclude  = types.DeriveInclude  // merges the occurrence's bodies into the derived base
+	DeriveExclude  = types.DeriveExclude  // omits the occurrence entirely
+	DeriveSubtract = types.DeriveSubtract // cuts the occurrence's bodies from the merged base
 )
 
-// String returns the lowercase name of the derive style.
-func (s DeriveStyle) String() string {
-	switch s {
-	case DeriveInclude:
-		return "include"
-	case DeriveExclude:
-		return "exclude"
-	case DeriveSubtract:
-		return "subtract"
-	default:
-		return "unknown"
-	}
-}
-
-// DeriveStyleFromName parses a derive style spelling (the inverse of [DeriveStyle.String]),
-// reporting whether it is a known style. Used to restore a persisted per-occurrence style.
-func DeriveStyleFromName(name string) (DeriveStyle, bool) {
-	switch name {
-	case "include":
-		return DeriveInclude, true
-	case "exclude":
-		return DeriveExclude, true
-	case "subtract":
-		return DeriveSubtract, true
-	default:
-		return DeriveInclude, false
-	}
-}
+// DeriveStyleFromName parses a derive style spelling, reporting whether it is a known style. A thin
+// alias of types.ParseDeriveStyle kept so existing call sites (and the persisted-style restore path)
+// are unchanged.
+func DeriveStyleFromName(name string) (DeriveStyle, bool) { return types.ParseDeriveStyle(name) }
 
 // DeriveSourceLink identifies the source assembly document a derived component pulls from,
 // captured when the derive is created so the link survives a save (#715). Document is the

--- a/model/feature/dressup.go
+++ b/model/feature/dressup.go
@@ -60,18 +60,6 @@ const (
 	FilletConic = types.FilletSectionConic
 )
 
-// opsCrossSection maps the public cross-section to the kernel's blend selector.
-func opsCrossSection(c FilletCrossSection) ops.FilletCrossSection {
-	switch c {
-	case FilletG2:
-		return ops.FilletG2
-	case FilletConic:
-		return ops.FilletConic
-	default:
-		return ops.FilletArc
-	}
-}
-
 // FilletDefinition rounds selected edges. EdgeKeys+Radius is the original single
 // constant-radius form; EdgeSets (when non-empty) takes precedence and carries any mix of
 // constant and variable sets (#323). CornerType selects how a vertex where two filleted edges

--- a/model/feature/fillet.go
+++ b/model/feature/fillet.go
@@ -112,7 +112,7 @@ func filletBody(in Input, edgeKeys [][]byte, radius float64, corner FilletCorner
 	}
 	work, keys := planarizedFillet(body, edgeKeys, feat)
 	picks := make([]ops.EdgeFilletRadii, len(keys))
-	cross := opsCrossSection(prof.cross)
+	cross := prof.cross
 	for i, k := range keys {
 		picks[i] = ops.EdgeFilletRadii{Key: k, R0: radius, R1: radius, Cross: cross, Rho: prof.rho}
 	}
@@ -190,7 +190,7 @@ func filletBodySets(in Input, sets []FilletEdgeSet, corner FilletCornerType, con
 // follow-up).
 func filletPicksOf(sets []FilletEdgeSet, prof blendProfile, feat string) ([]ops.EdgeFilletRadii, error) {
 	var out []ops.EdgeFilletRadii
-	cross := opsCrossSection(prof.cross)
+	cross := prof.cross
 	for _, s := range sets {
 		if !s.variable() {
 			r := callOrZero(s.Radius)

--- a/model/feature/shrinkwrap.go
+++ b/model/feature/shrinkwrap.go
@@ -5,39 +5,34 @@ package feature
 import (
 	"fmt"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/brep"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 )
 
-// ShrinkwrapRemoveStyle selects which source parts a shrinkwrap drops before merging —
-// the reference API's shrinkwrap remove style. Removal makes the result lighter by
-// discarding parts a viewer never sees or that are too small to matter.
-type ShrinkwrapRemoveStyle int
+// ShrinkwrapRemoveStyle selects which source parts a shrinkwrap drops before merging — the reference
+// API's shrinkwrap remove style. It ALIASES the canonical api/types definition (ADR-0018: defined once
+// in the Apache-2.0 contract, same int values 0/1/2 and wire spellings). Removal makes the result
+// lighter by discarding parts a viewer never sees or that are too small to matter.
+type ShrinkwrapRemoveStyle = types.ShrinkwrapRemoveStyle
 
 const (
-	// RemoveNone keeps every part (the full, unsimplified set).
-	RemoveNone ShrinkwrapRemoveStyle = iota
-	// RemoveSmallParts drops parts whose body volume is below MinPartVolume.
-	RemoveSmallParts
-	// RemoveInternalParts drops parts fully enclosed by other parts (never visible
-	// from outside the assembly).
-	RemoveInternalParts
+	RemoveNone          = types.RemoveNone          // keeps every part (the full, unsimplified set)
+	RemoveSmallParts    = types.RemoveSmallParts    // drops parts whose body volume is below MinPartVolume
+	RemoveInternalParts = types.RemoveInternalParts // drops parts fully enclosed by other parts
 )
 
-// ShrinkwrapEnvelopeStyle selects how kept parts are replaced by simpler proxy
-// geometry — the reference API's envelopes-replace style. Envelopes erase internal
-// detail (and, by construction, holes) so the result is a lightweight closed solid.
-type ShrinkwrapEnvelopeStyle int
+// ShrinkwrapEnvelopeStyle selects how kept parts are replaced by simpler proxy geometry — the reference
+// API's envelopes-replace style. It ALIASES the canonical api/types definition (ADR-0018). Envelopes
+// erase internal detail (and, by construction, holes) so the result is a lightweight closed solid.
+type ShrinkwrapEnvelopeStyle = types.ShrinkwrapEnvelopeStyle
 
 const (
-	// EnvelopeNone keeps each kept part's real geometry.
-	EnvelopeNone ShrinkwrapEnvelopeStyle = iota
-	// EnvelopePerPart replaces each kept part with its axis-aligned bounding box.
-	EnvelopePerPart
-	// EnvelopeWhole replaces the entire kept set with one axis-aligned bounding box.
-	EnvelopeWhole
+	EnvelopeNone    = types.EnvelopeNone    // keeps each kept part's real geometry
+	EnvelopePerPart = types.EnvelopePerPart // replaces each kept part with its axis-aligned bounding box
+	EnvelopeWhole   = types.EnvelopeWhole   // replaces the entire kept set with one axis-aligned bounding box
 )
 
 // ShrinkwrapDefinition is the recipe for simplifying a source assembly into a

--- a/model/param/parameter.go
+++ b/model/param/parameter.go
@@ -23,22 +23,27 @@ const (
 	TableParam     = types.TableParam
 )
 
-// HealthStatus is a parameter's evaluation health (contract: HealthStatusEnum).
-type HealthStatus uint8
+// ParameterHealth is a parameter's evaluation health: a simplified three-value status (current /
+// stale / errored). It is a DISTINCT concept from api/types.HealthStatus (the entity/feature/constraint
+// health, OK/Warning/Sick/Suppressed) — a parameter has no Suppressed state and OutOfDate has no entity
+// equivalent — and it is source-internal: only its Reason text crosses the wire (the wire `health`
+// field), never the enum value, so it is deliberately NOT aliased to the api type (#1501). Named
+// distinctly so the two health vocabularies don't collide.
+type ParameterHealth uint8
 
 const (
 	// Healthy: value is current and valid.
-	Healthy HealthStatus = 0
+	Healthy ParameterHealth = 0
 	// OutOfDate: the expression depends on parameters not yet recomputed.
-	OutOfDate HealthStatus = 1
+	OutOfDate ParameterHealth = 1
 	// Failed: evaluation failed (dimensional mismatch, cycle, undefined ref).
-	Failed HealthStatus = 2
+	Failed ParameterHealth = 2
 )
 
 // Health is a parameter's status plus a human-readable reason when not healthy.
 // Modeling problems are health, never panics (parametric-cad skill §2).
 type Health struct {
-	Status HealthStatus
+	Status ParameterHealth
 	Reason string
 }
 


### PR DESCRIPTION
## What (#1501, ADR-0018 single-source) — all 6 concepts resolved

**5 duplicates → aliases of the canonical `api/types`** (the re-declared definitions deleted from source):
- `DeriveStyle = types.DeriveStyle` (persists by string name → no `.obk` change)
- `ShrinkwrapRemoveStyle` / `ShrinkwrapEnvelopeStyle = types.…` (int 0/1/2 — identical values)
- `kernel/ops.FilletCrossSection = types.FilletCrossSection` (kernel-internal; the `opsCrossSection` int converter is removed and `chordPath` uses `!IsArc()`)
- `model/attr.ValueType = types.ValueType` (the codec keeps the compact 0..4 on-disk bytes via an explicit `valueTypePersistByte` map, so `.obk` metadata is byte-identical — guarded by a new test)

**1 false positive → disambiguated:** `model/param.HealthStatus` (simplified 3-value parameter-eval health `Healthy/OutOfDate/Failed`) is **not** the api's entity `HealthStatus` (`OK/Warning/Sick/Suppressed` — a parameter has no Suppressed state; OutOfDate has no entity equivalent) and is source-internal (only its `Reason` text crosses the wire). Renamed → `ParameterHealth`; correctly **not** aliased.

## Key finding — there was no wire-divergence bug

The issue feared a silent int32-vs-uint8 divergence across the wire. In fact **every one of these enums is encoded on the wire as its string spelling** (`Variant.MarshalJSON` → `{"type":"double"}`; `Health`/`ModelValueType` are `string`; DeriveStyle/Shrinkwrap marshal via `String()`/`Parse*`). The numeric representation never reaches the wire — so this was **ADR-0018 single-source hygiene, not a correctness bug**. The api was already the complete, tested canonical source (full `String()`/`Parse*` coverage, exact value parity), so **no api change was required** — the work is the source-side aliasing.

## Verification

`go test ./model/... ./kernel/ops/ ./kernel/brep/ ./addin/router/ ./app/` green, incl:
- derive/shrinkwrap serialization round-trips,
- the full fillet suite (G2/conic blend behavior unchanged),
- `TestValueTypePersistBytesAreStable` proving the attribute codec writes byte-identical `.obk` (Boolean→0…Bytes→4) and still rejects unknown codes.

Closes #1501

🤖 Generated with [Claude Code](https://claude.com/claude-code)