### PR TITLE
refactor(geom): extend the absolute-epsilon guard across kernel/geom (#1504)

### DIFF
--- a/kernel/geom/evaluator_common.go
+++ b/kernel/geom/evaluator_common.go
@@ -10,7 +10,7 @@ import stdmath "math"
 
 const (
 	// lengthRelTol is the relative accuracy target of arc-length integration.
-	lengthRelTol = 1e-10
+	lengthRelTol = 1e-10 // tol:numeric — a RELATIVE integration-error target, not a model length
 	// lengthMaxDepth bounds the adaptive-Simpson recursion.
 	lengthMaxDepth = 24
 	// strokeMaxDepth bounds the chordal-subdivision recursion.

--- a/kernel/geom/evaluator_point2.go
+++ b/kernel/geom/evaluator_point2.go
@@ -44,7 +44,7 @@ func segmentParamAtPoint2(g LineSegment2d, p math.Point2) float64 {
 // itself is equidistant from the whole circle.
 func circleParamAtPoint2(g Circle2d, p math.Point2) (float64, SolutionNature) {
 	d := g.Center.VectorTo(p)
-	if float64(d.Length()) <= 1e-12*stdmath.Max(1, g.Radius) {
+	if float64(d.Length()) <= 1e-12*stdmath.Max(1, g.Radius) { // tol:numeric — point AT the circle/arc centre: param undefined (relative to radius)
 		return 0, InfinitelyManySolutions
 	}
 	return wrap2pi(stdmath.Atan2(d.Y, d.X)) / twoPi, UniqueSolution
@@ -53,7 +53,7 @@ func circleParamAtPoint2(g Circle2d, p math.Point2) (float64, SolutionNature) {
 // arcParamAtPoint2 inverts the angle and resolves it against the sweep.
 func arcParamAtPoint2(g Arc2d, p math.Point2) (float64, SolutionNature) {
 	d := g.Center.VectorTo(p)
-	if float64(d.Length()) <= 1e-12*stdmath.Max(1, g.Radius) {
+	if float64(d.Length()) <= 1e-12*stdmath.Max(1, g.Radius) { // tol:numeric — point AT the circle/arc centre: param undefined (relative to radius)
 		return 0, InfinitelyManySolutions
 	}
 	angle := stdmath.Atan2(d.Y, d.X)
@@ -77,7 +77,7 @@ func polylineParamAtPoint2(g Polyline2d, p math.Point2) (float64, SolutionNature
 		// FINITE reference: seeding best with +Inf made 1e-12*best = +Inf, so best-tol was NaN and
 		// the "strictly closer" guard was always false — every point on a polyline resolved to the
 		// start (param 0). Base it on the candidate distance, and always accept the first segment.
-		tol := 1e-12 * stdmath.Max(1, d)
+		tol := 1e-12 * stdmath.Max(1, d) // tol:numeric — first-segment acceptance, relative to candidate distance
 		switch {
 		case stdmath.IsInf(best, 1) || d < best-tol:
 			best, bestT, ties, bestFoot = d, (float64(i)+local)/float64(segs), 0, foot
@@ -103,7 +103,7 @@ func genericParamAtPoint2(c Curve2, p math.Point2) (float64, SolutionNature) {
 	for _, d := range ds {
 		best = stdmath.Min(best, d)
 	}
-	tol := 1e-9 * stdmath.Max(1, best)
+	tol := 1e-9 * stdmath.Max(1, best) // tol:numeric — near-minimum clustering, relative to best distance
 	if count := nearCount(ds, best, tol); count > closestSamples/2 {
 		return ts[0], InfinitelyManySolutions
 	}
@@ -154,7 +154,7 @@ func refineClosest2(c Curve2, p math.Point2, t, lo, hi float64) float64 {
 		r := p.VectorTo(c.PointAt(t))
 		g := float64(r.Dot(d1))
 		dg := float64(d1.LengthSquared()) + float64(r.Dot(d2))
-		if dg == 0 || stdmath.Abs(g) < 1e-14 {
+		if dg == 0 || stdmath.Abs(g) < 1e-14 { // tol:numeric — Newton denominator near-zero guard
 			return t
 		}
 		t = clampTo(t-g/dg, lo, hi)

--- a/kernel/geom/evaluator_point3.go
+++ b/kernel/geom/evaluator_point3.go
@@ -105,7 +105,7 @@ func arcParamAtPoint3(g Arc3d, p math.Point3) (float64, SolutionNature) {
 func inPlaneAngle(center math.Point3, ref, bin math.Vector3, radius float64, p math.Point3) (float64, bool) {
 	d := center.VectorTo(p)
 	x, y := float64(d.Dot(ref)), float64(d.Dot(bin))
-	if stdmath.Hypot(x, y) <= 1e-12*stdmath.Max(1, radius) {
+	if stdmath.Hypot(x, y) <= 1e-12*stdmath.Max(1, radius) { // tol:numeric — point on the axis: angular param undefined (relative to radius)
 		return 0, false
 	}
 	return stdmath.Atan2(y, x), true
@@ -124,7 +124,7 @@ func resolveSweep(rel, sweep float64, distAt func(float64) float64) (float64, So
 	}
 	gapMid := span + (twoPi-span)/2
 	d0, d1 := distAt(0), distAt(1)
-	if stdmath.Abs(rel-gapMid) <= 1e-12 || stdmath.Abs(d0-d1) <= 1e-12*stdmath.Max(1, d0) {
+	if stdmath.Abs(rel-gapMid) <= 1e-12 || stdmath.Abs(d0-d1) <= 1e-12*stdmath.Max(1, d0) { // tol:numeric — antipodal/equal-distance degeneracy guard
 		return closerEnd(d0, d1), DistinctlyManySolutions
 	}
 	return closerEnd(d0, d1), UniqueSolution
@@ -149,7 +149,7 @@ func polylineParamAtPoint3(g Polyline, p math.Point3) (float64, SolutionNature) 
 		local := segmentParamAtPoint3(seg, p)
 		foot := seg.PointAt(local)
 		d := foot.DistanceTo(p)
-		tol := 1e-12 * stdmath.Max(1, best)
+		tol := 1e-12 * stdmath.Max(1, best) // tol:numeric — first-segment acceptance, relative to best distance
 		switch {
 		case d < best-tol:
 			best, bestT, ties, bestFoot = d, (float64(i)+local)/float64(segs), 0, foot
@@ -176,7 +176,7 @@ func genericParamAtPoint3(c Curve3, p math.Point3) (float64, SolutionNature) {
 	for _, d := range ds {
 		best = stdmath.Min(best, d)
 	}
-	tol := 1e-9 * stdmath.Max(1, best)
+	tol := 1e-9 * stdmath.Max(1, best) // tol:numeric — near-minimum clustering, relative to best distance
 	if count := nearCount(ds, best, tol); count > closestSamples/2 {
 		return ts[0], InfinitelyManySolutions
 	}
@@ -249,7 +249,7 @@ func refineClosest3(c Curve3, p math.Point3, t, lo, hi float64) float64 {
 		r := p.VectorTo(c.PointAt(t))
 		g := float64(r.Dot(d1))
 		dg := float64(d1.LengthSquared()) + float64(r.Dot(d2))
-		if dg == 0 || stdmath.Abs(g) < 1e-14 {
+		if dg == 0 || stdmath.Abs(g) < 1e-14 { // tol:numeric — Newton denominator near-zero guard
 			return t
 		}
 		t = clampTo(t-g/dg, lo, hi)

--- a/kernel/geom/resolution.go
+++ b/kernel/geom/resolution.go
@@ -131,6 +131,28 @@ func (r Resolution) Area() float64 { return epsRel * r.size * r.size }
 // with size³.
 func (r Resolution) Volume() float64 { return volCoef * r.size * r.size * r.size }
 
+// How geom primitives relate to Resolution (ADR-0042, #1504).
+//
+// The geometry primitives in this package — line/plane/curve intersection, point inversion,
+// B-spline/NURBS knot removal and degree reduction, curve stroking, arc-length integration —
+// take a SCALAR `tol float64`, not a Resolution. That is deliberate: they are general,
+// reusable math kernels, and the RIGHT tolerance depends on the caller's purpose, which only
+// the caller knows. A model-coincidence caller (the brep/ops booleans and welders) passes a
+// size-relative length from a Resolution — res.Weld() for a vertex coincidence, res.Plane()
+// for an on-line/on-plane test — so the size-relative tolerance flows all the way down. Other
+// callers pass a tolerance of a DIFFERENT kind entirely: a fitting/approximation bound (knot
+// removal, degree reduction), a relative integration-error target (arc length), or a chord
+// deflection (stroking). Threading a typed Resolution into these primitives would be wrong —
+// it would erase the caller's choice of WHICH tolerance and couple pure math to model scale.
+//
+// What ADR-0042 actually requires of the low layer is that no model-coincidence decision is
+// gated on a cm-anchored ABSOLUTE epsilon. That is enforced directly, not through the type
+// system: TestNoUnjustifiedAbsoluteEpsilons (kernel/ops) scans this package's tolerance hot
+// paths for bare 1e-N length literals; each must be relativised via a Resolution or annotated
+// `// tol:<kind>` (angular / parametric / numeric / area / volume / calibrated) to declare it
+// is not a model length. So the `tol float64` parameters stay, and the guard — not a signature
+// rewrite — is what keeps the bottom of the stack scale-faithful.
+
 // spanCeilingOrders is the usable dynamic range of one model in float64: ~15.95 significant
 // decimal digits, so a feature more than ~10^15 smaller than the model extent is below the
 // representable floor and would be silently merged (ADR-0042 §Phase 2). We use 15 as the

--- a/kernel/ops/tolerance_guard_test.go
+++ b/kernel/ops/tolerance_guard_test.go
@@ -37,9 +37,24 @@ func TestNoUnjustifiedAbsoluteEpsilons(t *testing.T) {
 		// geom: the analytic + numeric surface-intersection classifiers and the SSI tracer.
 		"../geom/intersect_analytic.go",
 		"../geom/intersect2d.go",
+		"../geom/intersect2d_circle.go",
 		"../geom/intersect_surface_trace.go",
 		"../geom/trace_surface_zero.go",
 		"../geom/network_surface.go",
+		// geom: line/plane/line queries, 2D arc containment, and the curve evaluators
+		// (stroking deflection, arc-length integration, point-inversion clustering) + the
+		// B-spline / NURBS knot-removal & degree-reduction fitting tolerances (#1504).
+		"../geom/query.go",
+		"../geom/arc2d.go",
+		"../geom/evaluator_common.go",
+		"../geom/evaluator_curve2.go",
+		"../geom/evaluator_curve3.go",
+		"../geom/evaluator_point2.go",
+		"../geom/evaluator_point3.go",
+		"../geom/bspline_remove.go",
+		"../geom/bspline_reduce.go",
+		"../geom/nurbs_remove.go",
+		"../geom/nurbs_reduce.go",
 		// brep: the curved-boolean weld / imprint / half-space machinery.
 		"../brep/curved_halfspace_general.go",
 		"../brep/curved_halfspace_cylinder.go",


### PR DESCRIPTION
## What (#1504, ADR-0042)

Investigating the 46 `tol float64` parameters in `kernel/geom` showed the issue's premise ("retire raw tolerance floats; thread `geom.Resolution` down") needed correcting. Those parameters are **the correct interface** for general math primitives (line/plane/curve intersection, point inversion, B-spline/NURBS knot removal & degree reduction, stroking, arc-length integration): the right tolerance depends on the **caller's purpose**, which only the caller knows. A model-coincidence caller (brep/ops) passes `res.Weld()`/`res.Plane()` from a `Resolution`; a fitting caller passes an approximation bound; an integrator passes a relative-error target. Threading a typed `Resolution` into them would erase that choice and couple pure math to model scale.

What ADR-0042 actually requires of the bottom layer is that **no model-coincidence decision is gated on a cm-anchored absolute epsilon** — and that is enforced by the guard, not the type system.

- **Extended `TestNoUnjustifiedAbsoluteEpsilons`** to the geom tolerance hot paths (`query`, `intersect2d_circle`, `arc2d`, the curve/point evaluators, `bspline_remove`/`reduce`, `nurbs_remove`/`reduce`). Running it surfaced **11 bare `1e-N` literals, all in the point-inversion / arc-length evaluators** — every one a numeric guard (Newton denominator, centre/axis degeneracy, near-minimum clustering), most already relative (`×max(1, radius/best)`). Annotated each `// tol:numeric`.
- The `bspline`/`nurbs`/`query`/`arc2d`/`intersect2d` files have **no internal absolute epsilon** — their tolerance is entirely the caller's `tol` param, confirming the primitive design.
- **Documented the convention** in `resolution.go`: geom primitives take a scalar `tol`; callers derive it from `Resolution`; the guard keeps the layer scale-faithful.

## Why this is the right resolution (not a signature rewrite)

Forcing `Resolution` into `LineLineIntersection(a, b, tol)` etc. would remove the caller's ability to choose `Weld()` vs `Plane()` semantics and make `adaptiveSimpson`/`CurveStrokes`/knot-removal — whose tolerances are *not lengths at all* — depend on model scale. The duplication the audit worried about isn't real here; the genuine risk (hardcoded absolutes hiding at the bottom) is now caught across `geom` by the guard.

## Verification

`go test ./kernel/geom/ ./kernel/ops/ ./kernel/brep/` green; the extended guard passes; lint clean. Annotations + doc + a test-scope widening only — no behavioral change.

Closes #1504

🤖 Generated with [Claude Code](https://claude.com/claude-code)
