### PR TITLE
Make feature editability a uniform, enforced contract (loft & sweep)

### DIFF
--- a/app/feature_edit.go
+++ b/app/feature_edit.go
@@ -178,9 +178,17 @@ func (s *Session) BeginEditFeature(h FeatureHandle) {
 	s.beginEditScope(h.Feature.Seq()) // roll back to this feature: hide everything after it
 }
 
-// FeatureIsEditable reports whether a feature exposes editable parameters or references (so the
-// browser shows/enables an Edit entry).
+// FeatureIsEditable reports whether a feature can be edited in place (so the browser shows/enables
+// an Edit entry). A feature is editable two ways, checked uniformly here: it has a registered
+// full-panel editor (its creation tool re-opens — extrude, hole, loft, sweep …, see
+// feature_edit_registry.go), OR it exposes generic editable scalars / re-pickable references (rib,
+// emboss, the patterns, mirror, move). Checking the registry here keeps the Edit gate consistent with
+// what BeginEditFeature can actually open — the bug behind loft/sweep, whose tools existed but whose
+// edit path did not, leaving Edit greyed (#1521).
 func FeatureIsEditable(f *feature.PartFeature) bool {
+	if hasFeatureEditor(f.Kind()) {
+		return true
+	}
 	if ed, ok := f.Definition().(feature.Editable); ok && len(ed.EditableParams()) > 0 {
 		return true
 	}

--- a/app/feature_edit_mode.go
+++ b/app/feature_edit_mode.go
@@ -73,42 +73,9 @@ func cancelFeatureEdit(s *Session, f *feature.PartFeature, restore func()) {
 	}
 }
 
-// editToolFor builds the creation tool re-opened over a committed feature, or false for
-// feature kinds the generic editor still serves.
-func editToolFor(s *Session, f *feature.PartFeature) (Tool, bool) {
-	switch d := f.Definition().(type) {
-	case *feature.ExtrudeFeature:
-		return editExtrudeTool(f, d), true
-	case *feature.RevolveFeature:
-		return editRevolveTool(s, f, d), true
-	case *feature.CoilFeature:
-		return editCoilTool(s, f, d), true
-	case *feature.HoleFeature:
-		return editHoleTool(f, d), true
-	}
-	return editDressUpTool(f)
-}
-
-// editDressUpTool seeds the edit panel for the dress-up / local-op features (fillet, face fillet,
-// chamfer, shell, draft); any other kind falls through to the generic editor.
-func editDressUpTool(f *feature.PartFeature) (Tool, bool) {
-	switch d := f.Definition().(type) {
-	case *feature.FilletFeature:
-		return editFilletToolOr(f, d)
-	case *feature.FaceFilletFeature:
-		return editFaceFilletTool(f, d), true
-	case *feature.FullRoundFilletFeature:
-		return editFullRoundFilletTool(f, d), true
-	case *feature.ChamferFeature:
-		return editChamferTool(f, d), true
-	case *feature.ShellFeature:
-		return editShellTool(f, d), true
-	case *feature.FaceDraftFeature:
-		return editDraftTool(f, d), true
-	default:
-		return nil, false
-	}
-}
+// The dispatch from a feature to its full-panel creation tool lives in the feature-editor registry
+// (feature_edit_registry.go), not in a type-switch here — see that file's rationale (#1521). The
+// seeders below (editExtrudeTool, editFilletTool, …) are the per-tool bodies the registry calls.
 
 // editExtrudeTool seeds an ExtrudeTool from a committed extrude: profiles, operation,
 // extent (type, direction, distances, asymmetry) and taper — the full creation surface.
@@ -383,6 +350,64 @@ func editDraftTool(f *feature.PartFeature, d *feature.FaceDraftFeature) *DraftTo
 func snapshotDraftDef(def *feature.FaceDraftDefinition) func() {
 	orig := *def
 	orig.FaceKeys = cloneKeys(def.FaceKeys)
+	return func() { *def = orig }
+}
+
+// editLoftTool seeds a LoftTool from a committed loft: its cross-sections (profiles, apex points, and
+// tangent faces), closure, operation, end conditions and area-graph waist. The guide providers (rails /
+// centerline / map curves) are opaque live closures that cannot be reversed into re-pickable handles,
+// so the panel opens with no guide chips populated; commitEdit preserves the committed guides unless
+// the user re-picks them (see LoftTool.applyRepickedGuides). Live end conditions are read through their
+// provider so the seeded values match what the loft currently evaluates.
+func editLoftTool(f *feature.PartFeature, lf *feature.LoftFeature) *LoftTool {
+	def := lf.Definition()
+	t := NewLoftTool()
+	t.sections = loftPicksFromSections(def.Sections)
+	t.closed, t.operation = def.Closed, def.Operation
+	t.first, t.last = def.First, def.Last
+	if def.LiveEnds != nil {
+		t.first, t.last = def.LiveEnds()
+	}
+	t.areaMidScale = midAreaScale(def.AreaGraph)
+	t.bindEdit(f, snapshotLoftDef(def))
+	return t
+}
+
+// loftPicksFromSections rebuilds the tool's picked cross-sections from a committed loft's sections —
+// the inverse of LoftTool.loftSections.
+func loftPicksFromSections(sections []feature.LoftSection) []loftPick {
+	picks := make([]loftPick, len(sections))
+	for i, s := range sections {
+		switch {
+		case s.IsPoint():
+			picks[i] = loftPick{apex: s.Point}
+		case s.IsFace():
+			picks[i] = loftPick{faceKey: append([]byte(nil), s.FaceKey...)}
+		default:
+			picks[i] = loftPick{profile: ProfileHandle{Sketch: s.Sketch, ProfileIndex: s.ProfileIndex}}
+		}
+	}
+	return picks
+}
+
+// midAreaScale recovers the loft tool's mid-height area scale from a committed area graph (the inverse
+// of LoftTool.areaStops, which emits a single stop at T=0.5); 0 when there is no waist control.
+func midAreaScale(stops []feature.LoftAreaStop) float64 {
+	for _, s := range stops {
+		if s.T == 0.5 {
+			return s.Scale
+		}
+	}
+	return 0
+}
+
+// snapshotLoftDef captures a loft definition for Cancel: the value plus deep copies of the slices the
+// edit replaces (sections, area graph). The guide providers are func values restored by the shallow
+// struct copy — commitEdit replaces whole slices rather than mutating them, so this is sufficient.
+func snapshotLoftDef(def *feature.LoftDefinition) func() {
+	orig := *def
+	orig.Sections = append([]feature.LoftSection(nil), def.Sections...)
+	orig.AreaGraph = append([]feature.LoftAreaStop(nil), def.AreaGraph...)
 	return func() { *def = orig }
 }
 

--- a/app/feature_edit_registry.go
+++ b/app/feature_edit_registry.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+
+	"oblikovati.org/model/feature"
+)
+
+// The feature-editor registry is the SINGLE place a feature opts into the rich, full-panel edit
+// path (Inventor's double-click on a history feature re-opening its creation dialog). It replaces
+// the hand-maintained editToolFor type-switch whose silent omissions left whole features — loft and
+// sweep — with no in-place edit at all (#1521): a type-switch has no failure when a case is missing,
+// so the gap was invisible until a user tried to double-click a loft. A registry makes the contract
+// explicit and enumerable, so an enforcement test (feature_edit_registry_test) can assert every
+// primary solid feature is editable — the same anti-drift discipline the serialization codec
+// registry brought to save/reload (#1416). It mirrors that pattern deliberately: one registration
+// per feature, paired with its kind, validated at startup.
+//
+// A kind ABSENT from this registry is not an error — it falls back to the generic parameter /
+// reference editor (FeatureEditTool), which serves features whose whole edit surface is scalars and
+// re-pickable references (rib, emboss, the patterns, mirror, move). A kind in NEITHER the registry
+// nor the generic interfaces is not editable; the enforcement test forbids that for solid features.
+
+// featureEditor re-opens a creation tool over a committed feature, seeded from its definition, so the
+// same property panel serves creation and editing. It returns ok=false when the tool cannot show this
+// particular feature (e.g. a multi-set fillet the single-radius panel can't represent), so the caller
+// falls back to the generic editor.
+type featureEditor func(s *Session, f *feature.PartFeature) (Tool, bool)
+
+// featureEditors maps a feature kind to its full-panel editor. Populated by registerFeatureEditor in
+// this package's init()s; read by editToolFor. Read-only after init, so no synchronization is needed.
+var featureEditors = map[string]featureEditor{}
+
+// registerFeatureEditor records one kind's full-panel editor, panicking on an empty kind, a nil
+// editor, or a duplicate — a programming error caught at startup, not a silent overwrite.
+func registerFeatureEditor(kind string, e featureEditor) {
+	if kind == "" {
+		panic("app: registerFeatureEditor with empty kind")
+	}
+	if e == nil {
+		panic(fmt.Sprintf("app: nil feature editor for kind %q", kind))
+	}
+	if _, dup := featureEditors[kind]; dup {
+		panic(fmt.Sprintf("app: duplicate feature editor for kind %q", kind))
+	}
+	featureEditors[kind] = e
+}
+
+// hasFeatureEditor reports whether a kind has a registered full-panel editor (so the browser can
+// enable Edit without constructing the tool).
+func hasFeatureEditor(kind string) bool {
+	_, ok := featureEditors[kind]
+	return ok
+}
+
+// editToolFor builds the full-panel creation tool re-opened over a committed feature, or false for
+// kinds the generic parameter/reference editor serves (or which are not editable at all).
+func editToolFor(s *Session, f *feature.PartFeature) (Tool, bool) {
+	e, ok := featureEditors[f.Kind()]
+	if !ok {
+		return nil, false
+	}
+	return e(s, f)
+}
+
+// registerSolidFeatureEditors wires the sketch-based solid features whose edit surface needs the full
+// creation panel — enum choices and ordered section/condition lists the generic scalar/reference editor
+// cannot express (extrude, revolve, coil, hole, loft). Sweep, by contrast, edits cleanly through the
+// generic editor (twist, taper, profile) and its path is an opaque live provider that cannot be reversed
+// into a re-pickable handle, so it is intentionally NOT registered here — see SweepFeature.EditableParams.
+// Each closure type-asserts the concrete feature and calls the family's seeder; a mismatched kind→type
+// registration would fail that assertion in the enforcement test, so the map cannot silently bind the
+// wrong tool.
+func registerSolidFeatureEditors() {
+	registerFeatureEditor("extrude", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
+		return editExtrudeTool(f, f.Definition().(*feature.ExtrudeFeature)), true
+	})
+	registerFeatureEditor("revolve", func(s *Session, f *feature.PartFeature) (Tool, bool) {
+		return editRevolveTool(s, f, f.Definition().(*feature.RevolveFeature)), true
+	})
+	registerFeatureEditor("coil", func(s *Session, f *feature.PartFeature) (Tool, bool) {
+		return editCoilTool(s, f, f.Definition().(*feature.CoilFeature)), true
+	})
+	registerFeatureEditor("hole", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
+		return editHoleTool(f, f.Definition().(*feature.HoleFeature)), true
+	})
+	registerFeatureEditor("loft", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
+		return editLoftTool(f, f.Definition().(*feature.LoftFeature)), true
+	})
+}
+
+// registerDressUpFeatureEditors wires the dress-up / local-operation features (fillet, face fillet,
+// full-round fillet, chamfer, shell, draft) to their creation panels. The fillet panel declines a
+// multi-set fillet (returns false), routing it to the generic editor.
+func registerDressUpFeatureEditors() {
+	registerFeatureEditor("fillet", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
+		return editFilletToolOr(f, f.Definition().(*feature.FilletFeature))
+	})
+	registerFeatureEditor("face-fillet", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
+		return editFaceFilletTool(f, f.Definition().(*feature.FaceFilletFeature)), true
+	})
+	registerFeatureEditor("full-round-fillet", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
+		return editFullRoundFilletTool(f, f.Definition().(*feature.FullRoundFilletFeature)), true
+	})
+	registerFeatureEditor("chamfer", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
+		return editChamferTool(f, f.Definition().(*feature.ChamferFeature)), true
+	})
+	registerFeatureEditor("shell", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
+		return editShellTool(f, f.Definition().(*feature.ShellFeature)), true
+	})
+	registerFeatureEditor("draft", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
+		return editDraftTool(f, f.Definition().(*feature.FaceDraftFeature)), true
+	})
+}
+
+func init() {
+	registerSolidFeatureEditors()
+	registerDressUpFeatureEditors()
+}

--- a/app/feature_edit_registry_test.go
+++ b/app/feature_edit_registry_test.go
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+)
+
+// #1521: editability used to be opt-in through two unrelated bespoke mechanisms (a hand-maintained
+// editToolFor type-switch and per-feature generic Editable/ReferenceEditable methods), with nothing
+// forcing a new feature into either — so loft and sweep silently shipped with NO edit path: their
+// browser Edit entry was greyed and double-clicking them did nothing. These tests pin the contract
+// that every primary solid feature is editable, and that loft (full panel) and sweep (generic editor)
+// actually round-trip.
+
+// primarySolidFeatures are the sketch-based features that add or remove solid material — the ribbon's
+// core part-modeling commands (the ToolFeature set the user places and expects to double-click-edit).
+// EVERY one MUST be editable in place, either through a registered full-panel editor (featureEditors)
+// or the generic scalar/reference editor (feature.Editable / feature.ReferenceEditable). The prototypes
+// are typed nils: interface assertions are static, so they classify the type without calling a method.
+var primarySolidFeatures = []struct {
+	kind  string
+	proto feature.Feature
+}{
+	{"extrude", (*feature.ExtrudeFeature)(nil)},
+	{"revolve", (*feature.RevolveFeature)(nil)},
+	{"coil", (*feature.CoilFeature)(nil)},
+	{"hole", (*feature.HoleFeature)(nil)},
+	{"rib", (*feature.RibFeature)(nil)},
+	{"emboss", (*feature.EmbossFeature)(nil)},
+	{"sweep", (*feature.SweepFeature)(nil)},
+	{"loft", (*feature.LoftFeature)(nil)},
+}
+
+// TestPrimarySolidFeaturesAreEditable is the regression guard for #1521: a primary solid feature with
+// neither a registered full-panel editor nor a generic editable surface is not editable in the browser
+// — the exact loft/sweep defect. A new solid feature added without an edit path fails here.
+func TestPrimarySolidFeaturesAreEditable(t *testing.T) {
+	for _, f := range primarySolidFeatures {
+		if hasFeatureEditor(f.kind) || implementsEditableContract(f.proto) {
+			continue
+		}
+		t.Errorf("primary solid feature %q is not editable: no registered full-panel editor and its "+
+			"definition implements neither feature.Editable nor feature.ReferenceEditable — double-clicking "+
+			"it in the browser would do nothing (#1521)", f.kind)
+	}
+}
+
+// implementsEditableContract reports whether a feature type exposes the generic edit surface — it
+// implements feature.Editable (scalar params) or feature.ReferenceEditable (re-pickable references).
+func implementsEditableContract(f feature.Feature) bool {
+	_, params := f.(feature.Editable)
+	_, refs := f.(feature.ReferenceEditable)
+	return params || refs
+}
+
+// TestRegisterFeatureEditorRejectsBadRegistration locks the anti-drift guard: an empty kind, a nil
+// editor, or a duplicate (a second tool claiming one kind) panics at startup rather than silently
+// overwriting — the same discipline the serialization codec registry enforces (#1416).
+func TestRegisterFeatureEditorRejectsBadRegistration(t *testing.T) {
+	ok := func(_ *Session, _ *feature.PartFeature) (Tool, bool) { return nil, false }
+	assertPanicsApp(t, "empty kind", func() { registerFeatureEditor("", ok) })
+	assertPanicsApp(t, "nil editor", func() { registerFeatureEditor("test.nil-editor", nil) })
+	assertPanicsApp(t, "duplicate", func() { registerFeatureEditor("loft", ok) }) // loft is already registered
+}
+
+// assertPanicsApp fails unless fn panics.
+func assertPanicsApp(t *testing.T, name string, fn func()) {
+	t.Helper()
+	defer func() {
+		if recover() == nil {
+			t.Errorf("%s: expected a panic, got none", name)
+		}
+	}()
+	fn()
+}
+
+// loftedFeatureSession commits a frustum loft (4×4 → 2×2, height 5) and returns a handle to it — the
+// starting point for the loft edit-flow tests.
+func loftedFeatureSession(t *testing.T) (*Session, FeatureHandle) {
+	t.Helper()
+	s, bottom, top := newPartWithStackedSquares(t)
+	s.SetPicker(&seqPicker{sels: []Selectable{bottom, top}})
+	l := NewLoftTool()
+	s.StartTool(l)
+	s.Click(10, 10)
+	s.Click(10, 200)
+	if err := s.OK(); err != nil {
+		t.Fatalf("seed loft: %v", err)
+	}
+	return s, FeatureHandle{Feature: l.AddedFeature()}
+}
+
+// TestBeginEditFeatureReopensLoftPanel locks loft's full-panel edit (#1521): double-clicking a
+// committed loft re-opens the Loft tool in edit mode, seeded with its sections — not the generic editor.
+func TestBeginEditFeatureReopensLoftPanel(t *testing.T) {
+	s, h := loftedFeatureSession(t)
+	if !FeatureIsEditable(h.Feature) {
+		t.Fatal("a committed loft must report as editable (#1521)")
+	}
+	s.BeginEditFeature(h)
+	l := s.ActiveLoft()
+	if l == nil {
+		t.Fatal("BeginEditFeature should re-open the Loft tool for a loft")
+	}
+	if !l.IsEditing() || l.EditingName() != h.Feature.Name() {
+		t.Errorf("edit binding = (%v, %q), want (true, %q)", l.IsEditing(), l.EditingName(), h.Feature.Name())
+	}
+	if l.SectionCount() != 2 {
+		t.Errorf("seeded section count = %d, want 2", l.SectionCount())
+	}
+	if s.IsEditingFeature() {
+		t.Error("the generic feature editor must not be open for a loft")
+	}
+}
+
+// TestLoftEditCommitPreservesGeometry proves the loft edit round-trips losslessly: re-opening and
+// OK-ing with no change rebuilds the same solid (sections restored, opaque guides preserved). A
+// commitEdit that dropped sections or wiped guide providers would change the volume.
+func TestLoftEditCommitPreservesGeometry(t *testing.T) {
+	s, h := loftedFeatureSession(t)
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	before := ops.BodyGeometryProperties(def.SurfaceBodies().Item(0), ops.DefaultQuality()).Volume
+	s.BeginEditFeature(h)
+	if err := s.OK(); err != nil {
+		t.Fatalf("commit loft edit: %v", err)
+	}
+	if def.SurfaceBodies().Count() != 1 {
+		t.Fatalf("part has %d bodies after a no-op loft edit, want 1", def.SurfaceBodies().Count())
+	}
+	after := ops.BodyGeometryProperties(def.SurfaceBodies().Item(0), ops.DefaultQuality()).Volume
+	if relErrApp(after, before) > 0.001 {
+		t.Errorf("a no-op loft edit changed the volume: %g → %g", before, after)
+	}
+}
+
+// TestLoftEditAppliesWaist proves a panel edit reaches the definition: pinching the mid-height area
+// scale writes an area-graph waist back into the committed loft.
+func TestLoftEditAppliesWaist(t *testing.T) {
+	s, h := loftedFeatureSession(t)
+	s.BeginEditFeature(h)
+	l := s.ActiveLoft()
+	l.SetAreaMidScale(0.5)
+	if err := s.OK(); err != nil {
+		t.Fatalf("commit loft edit: %v", err)
+	}
+	lf := h.Feature.Definition().(*feature.LoftFeature).Definition()
+	if got := midAreaScale(lf.AreaGraph); got != 0.5 {
+		t.Errorf("edited mid-area scale = %g, want 0.5 (area graph %v)", got, lf.AreaGraph)
+	}
+}
+
+// sweptFeatureSession commits a 2×2-along-5 sweep and returns a handle to it.
+func sweptFeatureSession(t *testing.T) (*Session, FeatureHandle) {
+	t.Helper()
+	s, profile, path := newPartWithProfileAndPath(t)
+	s.SetPicker(&seqPicker{sels: []Selectable{profile, path}})
+	sw := NewSweepTool()
+	s.StartTool(sw)
+	s.Click(10, 10)
+	s.Click(10, 200)
+	if err := s.OK(); err != nil {
+		t.Fatalf("seed sweep: %v", err)
+	}
+	return s, FeatureHandle{Feature: sw.AddedFeature()}
+}
+
+// TestSweepIsEditableViaGenericEditor locks sweep's edit path (#1521): a sweep is editable, and it
+// opens the GENERIC parameter editor (not a full panel) exposing its twist — its opaque path provider
+// has no full-panel re-pick, so the generic scalar/reference editor is the honest fit.
+func TestSweepIsEditableViaGenericEditor(t *testing.T) {
+	s, h := sweptFeatureSession(t)
+	if !FeatureIsEditable(h.Feature) {
+		t.Fatal("a committed sweep must report as editable (#1521)")
+	}
+	s.BeginEditFeature(h)
+	if !s.IsEditingFeature() {
+		t.Fatal("a sweep should open the generic feature editor")
+	}
+	if s.ActiveSweep() != nil {
+		t.Error("sweep has no full-panel editor; it must use the generic editor")
+	}
+	if !editParamPresent(s, "Twist") {
+		t.Error("sweep edit should expose a Twist parameter")
+	}
+}
+
+// TestSweepEditPreservesPath proves the opaque path survives a generic edit: editing the twist and
+// committing keeps the swept solid (a commitEdit that touched the path provider would lose the body).
+func TestSweepEditPreservesPath(t *testing.T) {
+	s, h := sweptFeatureSession(t)
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	before := ops.BodyGeometryProperties(def.SurfaceBodies().Item(0), ops.DefaultQuality()).Volume
+	s.BeginEditFeature(h)
+	setGenericEditParam(s, "Twist", 0) // a real edit through the generic path; geometry unchanged at twist 0
+	if err := s.OK(); err != nil {
+		t.Fatalf("commit sweep edit: %v", err)
+	}
+	if def.SurfaceBodies().Count() != 1 {
+		t.Fatalf("sweep edit wiped the body (path lost?): %d bodies", def.SurfaceBodies().Count())
+	}
+	after := ops.BodyGeometryProperties(def.SurfaceBodies().Item(0), ops.DefaultQuality()).Volume
+	if relErrApp(after, before) > 0.001 {
+		t.Errorf("a twist-0 sweep edit changed the volume: %g → %g", before, after)
+	}
+}
+
+// editParamPresent reports whether the open generic editor exposes a scalar field with the given label.
+func editParamPresent(s *Session, label string) bool {
+	for i := 0; i < s.EditFeatureParamCount(); i++ {
+		if s.EditFeatureParamLabel(i) == label {
+			return true
+		}
+	}
+	return false
+}
+
+// setGenericEditParam sets the named scalar field in the open generic editor (no-op if absent).
+func setGenericEditParam(s *Session, label string, value float64) {
+	for i := 0; i < s.EditFeatureParamCount(); i++ {
+		if s.EditFeatureParamLabel(i) == label {
+			s.SetEditFeatureParamValue(i, value)
+			return
+		}
+	}
+}

--- a/app/loft_tool.go
+++ b/app/loft_tool.go
@@ -14,16 +14,17 @@ import (
 // order — each a sketch region, or a vertex/work point to taper the loft to an apex (a cone or
 // dome) — optionally close the loop, set the end conditions, and OK to blend them into a solid.
 type LoftTool struct {
-	sections     []loftPick
-	rails        []PathHandle // guide curves (kLoftWithRails) — picked sketch paths
-	centerline   *PathHandle  // spine curve (kLoftWithCenterline)
-	mapCurves    []PathHandle // explicit correspondence anchors (MapPointCurves)
-	guideKind    int          // where a path pick goes: 0 rail, 1 centerline, 2 map curve
-	areaMidScale float64      // area-graph: cross-section area scale at mid height (0/1 = off)
-	closed       bool
-	operation    ops.PartFeatureOperation
-	first, last  feature.LoftEnd // end-section conditions (zero value = Free); see SetFirstCondition
-	added        *feature.PartFeature
+	featureEditMode // set ⇒ this panel re-edits a committed loft (see editLoftTool)
+	sections        []loftPick
+	rails           []PathHandle // guide curves (kLoftWithRails) — picked sketch paths
+	centerline      *PathHandle  // spine curve (kLoftWithCenterline)
+	mapCurves       []PathHandle // explicit correspondence anchors (MapPointCurves)
+	guideKind       int          // where a path pick goes: 0 rail, 1 centerline, 2 map curve
+	areaMidScale    float64      // area-graph: cross-section area scale at mid height (0/1 = off)
+	closed          bool
+	operation       ops.PartFeatureOperation
+	first, last     feature.LoftEnd // end-section conditions (zero value = Free); see SetFirstCondition
+	added           *feature.PartFeature
 }
 
 // Loft guide-path kinds: where a picked open path is routed.
@@ -163,8 +164,12 @@ func (t *LoftTool) PickedProfiles() []ProfileHandle {
 func (t *LoftTool) CanCommit() bool { return len(t.sections) >= 2 }
 
 // Commit adds the loft feature to the active part and recomputes; a sick feature keeps
-// the tool open by returning an error.
+// the tool open by returning an error. In edit mode it writes the panel state back into the
+// committed loft instead (commitEdit).
 func (t *LoftTool) Commit(s *Session) error {
+	if t.IsEditing() {
+		return t.commitEdit(s)
+	}
 	part, err := activePart(s)
 	if err != nil {
 		return err
@@ -176,6 +181,54 @@ func (t *LoftTool) Commit(s *Session) error {
 		return errors.New("loft: " + t.added.Health().Reason)
 	}
 	return nil
+}
+
+// commitEdit writes the panel state back into the committed loft's definition — the same inputs the
+// create path passes to AddGuided. Sections, closure, operation, end conditions and the area graph
+// are always rewritten. The guide providers (rails / centerline / map curves) are opaque live
+// closures the panel cannot reverse into re-pickable handles, so they are PRESERVED untouched unless
+// the user re-picked them this edit. Setting the static end conditions clears LiveEnds so the panel
+// values are authoritative (a parametric end-angle linkage is replaced by the explicit edit).
+func (t *LoftTool) commitEdit(s *Session) error {
+	def := t.target.Definition().(*feature.LoftFeature).Definition()
+	def.Sections = t.loftSections()
+	def.Closed, def.Operation = t.closed, t.operation
+	def.First, def.Last, def.LiveEnds = t.first, t.last, nil
+	def.AreaGraph = t.areaStops()
+	t.applyRepickedGuides(def)
+	return commitFeatureEdit(s, t.target)
+}
+
+// applyRepickedGuides overwrites only the guides the user actually re-picked this edit, preserving the
+// committed loft's existing opaque guide providers otherwise. A centerline (spine) is exclusive with
+// rails, matching addLoft.
+func (t *LoftTool) applyRepickedGuides(def *feature.LoftDefinition) {
+	if len(t.rails) > 0 {
+		def.Rails = t.railProviders()
+	}
+	if t.centerline != nil {
+		def.Rails, def.Centerline = nil, t.centerlineProvider()
+	}
+	if len(t.mapCurves) > 0 {
+		def.MapCurves = t.mapCurveProviders()
+	}
+}
+
+// loftSections maps the picked cross-sections to feature.LoftSections — a profile region, a point
+// (apex), or a body face (by key). Shared by addLoft (create) and commitEdit (re-edit).
+func (t *LoftTool) loftSections() []feature.LoftSection {
+	sections := make([]feature.LoftSection, len(t.sections))
+	for i, h := range t.sections {
+		switch {
+		case h.isPoint():
+			sections[i] = feature.LoftSection{Point: h.apex}
+		case h.isFace():
+			sections[i] = feature.LoftSection{FaceKey: h.faceKey}
+		default:
+			sections[i] = feature.LoftSection{Sketch: h.profile.Sketch, ProfileIndex: h.profile.ProfileIndex}
+		}
+	}
+	return sections
 }
 
 // railProviders turns the picked guide-rail paths into live model-space polyline providers
@@ -248,17 +301,7 @@ func (t *LoftTool) Prompt(*Session) string {
 // fs — the shared constructor used by both Commit (the part's engine) and DraftFeature (a
 // scratch engine), so the preview matches the committed result.
 func (t *LoftTool) addLoft(fs *feature.PartFeatures) *feature.PartFeature {
-	sections := make([]feature.LoftSection, len(t.sections))
-	for i, h := range t.sections {
-		switch {
-		case h.isPoint():
-			sections[i] = feature.LoftSection{Point: h.apex}
-		case h.isFace():
-			sections[i] = feature.LoftSection{FaceKey: h.faceKey}
-		default:
-			sections[i] = feature.LoftSection{Sketch: h.profile.Sketch, ProfileIndex: h.profile.ProfileIndex}
-		}
-	}
+	sections := t.loftSections()
 	guides := feature.LoftGuideSet{
 		Rails:     t.railProviders(),
 		MapCurves: t.mapCurveProviders(),

--- a/model/feature/editable.go
+++ b/model/feature/editable.go
@@ -127,10 +127,11 @@ func keyRefSlotSingle(label string, kind RefKind, field *[]byte) EditableRefSlot
 	}
 }
 
-// profileRefSlotIndex builds a single-profile slot over a (sketch, index) pair of fields.
-func profileRefSlotIndex(label string, skField **sketch.Sketch, idxField *int) EditableRefSlot {
+// profileRefSlotIndex builds a single-profile slot over a (sketch, index) pair of fields. Every
+// profile slot is labelled "Profile" (the only kind of single-region reference a feature re-picks).
+func profileRefSlotIndex(skField **sketch.Sketch, idxField *int) EditableRefSlot {
 	return EditableRefSlot{
-		Label: label, Kind: RefProfile, Multi: false,
+		Label: "Profile", Kind: RefProfile, Multi: false,
 		Count: func() int {
 			if *skField == nil {
 				return 0
@@ -146,10 +147,11 @@ func profileRefSlotIndex(label string, skField **sketch.Sketch, idxField *int) E
 }
 
 // profileRefSlotIndices builds a single-profile slot over a (sketch, indices) pair, replacing
-// the region set with the one picked region (re-selecting THE profile).
-func profileRefSlotIndices(label string, skField **sketch.Sketch, idxField *[]int) EditableRefSlot {
+// the region set with the one picked region (re-selecting THE profile). Labelled "Profile" like
+// profileRefSlotIndex — the multi-index form serves features that store a profile as a region set.
+func profileRefSlotIndices(skField **sketch.Sketch, idxField *[]int) EditableRefSlot {
 	return EditableRefSlot{
-		Label: label, Kind: RefProfile, Multi: false,
+		Label: "Profile", Kind: RefProfile, Multi: false,
 		Count: func() int {
 			if *skField == nil {
 				return 0
@@ -243,27 +245,27 @@ func (h *HoleFeature) EditableRefs() []EditableRefSlot {
 
 // EditableRefs exposes the extrude's profile.
 func (e *ExtrudeFeature) EditableRefs() []EditableRefSlot {
-	return []EditableRefSlot{profileRefSlotIndices("Profile", &e.def.Sketch, &e.def.ProfileIndices)}
+	return []EditableRefSlot{profileRefSlotIndices(&e.def.Sketch, &e.def.ProfileIndices)}
 }
 
 // EditableRefs exposes the revolve's profile.
 func (r *RevolveFeature) EditableRefs() []EditableRefSlot {
-	return []EditableRefSlot{profileRefSlotIndex("Profile", &r.def.Sketch, &r.def.ProfileIndex)}
+	return []EditableRefSlot{profileRefSlotIndex(&r.def.Sketch, &r.def.ProfileIndex)}
 }
 
 // EditableRefs exposes the coil's profile.
 func (c *CoilFeature) EditableRefs() []EditableRefSlot {
-	return []EditableRefSlot{profileRefSlotIndex("Profile", &c.def.Sketch, &c.def.ProfileIndex)}
+	return []EditableRefSlot{profileRefSlotIndex(&c.def.Sketch, &c.def.ProfileIndex)}
 }
 
 // EditableRefs exposes the rib's open profile.
 func (r *RibFeature) EditableRefs() []EditableRefSlot {
-	return []EditableRefSlot{profileRefSlotIndex("Profile", &r.def.Sketch, &r.def.ProfileIndex)}
+	return []EditableRefSlot{profileRefSlotIndex(&r.def.Sketch, &r.def.ProfileIndex)}
 }
 
 // EditableRefs exposes the emboss profile.
 func (e *EmbossFeature) EditableRefs() []EditableRefSlot {
-	return []EditableRefSlot{profileRefSlotIndices("Profile", &e.def.Sketch, &e.def.ProfileIndices)}
+	return []EditableRefSlot{profileRefSlotIndices(&e.def.Sketch, &e.def.ProfileIndices)}
 }
 
 // EditableRefs exposes the mirror's plane.
@@ -442,6 +444,26 @@ func (l *LipFeature) EditableParams() []EditableParam {
 		scalarParam("Width", param.Length, &l.def.Width),
 		scalarParam("Height", param.Length, &l.def.Height),
 	}
+}
+
+// EditableParams exposes a sweep's twist and taper (draft) angles. Both are always present (a nil
+// closure reads as 0), so a sweep is always editable even before either is set. The sweep PATH and a
+// solid sweep's tool body are live providers/indices, not scalars, so they are not edited here.
+func (s *SweepFeature) EditableParams() []EditableParam {
+	return []EditableParam{
+		scalarParam("Twist", param.Angle, &s.def.Twist),
+		scalarParam("Taper", param.Angle, &s.def.Taper),
+	}
+}
+
+// EditableRefs exposes a profile sweep's section profile for re-selection. A SOLID sweep drags a
+// running body along the path (SolidToolIndex) rather than a profile, so it has no profile slot; its
+// twist/taper remain editable through EditableParams.
+func (s *SweepFeature) EditableRefs() []EditableRefSlot {
+	if s.def.SolidToolIndex != nil {
+		return nil
+	}
+	return []EditableRefSlot{profileRefSlotIndex(&s.def.Sketch, &s.def.ProfileIndex)}
 }
 
 // EditableParams exposes a hole's diameter, depth (blind only), and recess inputs by type.


### PR DESCRIPTION
## What

Editability was opt-in through **two unrelated bespoke mechanisms** — a hand-maintained `editToolFor` type-switch and per-feature generic `Editable`/`ReferenceEditable` methods — with **nothing forcing a new feature into either**. A type-switch has no failure when a case is missing, so the gap was invisible: **loft and sweep shipped with no edit path at all**, their browser **Edit** entry greyed and double-click a no-op (#1521).

This PR makes editability a **single, enumerable, test-enforced contract**:

- **`featureEditors` registry** replaces the `editToolFor` type-switch — the one place a feature opts into the full creation panel, mirroring the serialization codec registry's anti-drift discipline (#1416). `registerFeatureEditor` panics on an empty kind, nil editor, or duplicate.
- **`FeatureIsEditable` is now registry-aware**, so the browser Edit gate matches what `BeginEditFeature` can actually open — the exact loft/sweep defect, where the tool existed but the edit path did not.
- **Loft** re-opens its creation panel (`LoftTool` edit mode). Sections, end conditions, closure, operation and the area-graph waist round-trip; the **opaque guide providers** (rails/centerline/map curves), which cannot be reversed into re-pickable handles, are **preserved** unless re-picked.
- **Sweep** edits through the **generic editor** (twist, taper, profile); its path is an opaque live provider with no full-panel re-pick, so the scalar/reference editor is the honest fit and leaves the path intact.

## Why this shape

The two seams (full-panel registry vs. generic scalar/reference editor) are both kept — they fit different features (enum/list edits vs. pure scalars). The fix is not a third mechanism; it is **making the choice explicit and enforced**. `FeatureIsEditable` checks both uniformly, and a test asserts every primary solid feature uses one.

## Tests

- `TestPrimarySolidFeaturesAreEditable` — the gate: every primary solid feature (extrude, revolve, coil, hole, rib, emboss, sweep, loft) must be editable via the registry or the generic surface. Verified to **fail** when loft's registration is removed.
- `TestRegisterFeatureEditorRejectsBadRegistration` — empty/nil/duplicate registration panics at startup.
- `TestBeginEditFeatureReopensLoftPanel`, `TestLoftEditCommitPreservesGeometry` (lossless round-trip — sections restored, guides preserved), `TestLoftEditAppliesWaist`.
- `TestSweepIsEditableViaGenericEditor`, `TestSweepEditPreservesPath` (opaque path survives a generic edit).

All drive the real `Session` edit flow (`BeginEditFeature` → registry dispatch → `commitEdit` → recompute → volume check). `go test ./app/ ./model/feature/` green; `golangci-lint` clean.

## Scope

This addresses the **architectural half** of #1521 (the inconsistent-Edit problem the issue calls out). The broader **loft UI/UX re-flow to match Inventor** remains as follow-up; left open intentionally.

Part of #1521.

🤖 Generated with [Claude Code](https://claude.com/claude-code)