### PR TITLE
Offer the disk inside a circle as its own sketch region (#1526)

### DIFF
--- a/app/loft_nested_circle_test.go
+++ b/app/loft_nested_circle_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/sketch"
+)
+
+// #1526: lofting "the circle in the first sketch" to a circle in the second produced no preview and
+// no body. The first sketch had a circle drawn inside a rectangle, and the profile finder absorbed the
+// circle as a hole of the rectangle (one annulus region) — so there was no disk profile to loft, and
+// picking the circle gave the annulus, whose hole count (1) cannot pair with the plain circle's (0).
+// The fix offers the disk as its own region; these lock the end-to-end loft.
+
+// yzPlaneAtX is the YZ plane (normal +X) shifted to x — the bug's two parallel circle planes.
+func yzPlaneAtX(x float64) sketch.Plane {
+	p, _ := sketch.NewPlane(math.P3(math.Scalar(x), 0, 0), math.V3(0, 1, 0).AsUnit(), math.V3(0, 0, 1).AsUnit())
+	return p
+}
+
+func circleSketchOn(def *compdef.PartComponentDefinition, plane sketch.Plane, r float64) *sketch.Sketch {
+	sk := def.Sketches().Add(plane)
+	sk.Circles().AddByCenterRadius(math.P2(0, 0), math.Scalar(r))
+	return sk
+}
+
+// rectWithInnerCircle mirrors #1526's Sketch1: a rectangle that encloses a centred circle.
+func rectWithInnerCircle(def *compdef.PartComponentDefinition, plane sketch.Plane, r float64) *sketch.Sketch {
+	sk := def.Sketches().Add(plane)
+	p0 := sk.Points().Add(math.P2(-3.354, -3.367))
+	p1 := sk.Points().Add(math.P2(3.545, -3.367))
+	p2 := sk.Points().Add(math.P2(3.545, 3.668))
+	p3 := sk.Points().Add(math.P2(-3.354, 3.668))
+	sk.Lines().Add(p0, p1)
+	sk.Lines().Add(p1, p2)
+	sk.Lines().Add(p2, p3)
+	sk.Lines().Add(p3, p0)
+	sk.Circles().AddByCenterRadius(math.P2(0, 0), math.Scalar(r))
+	return sk
+}
+
+func loftPartSession(t *testing.T) (*Session, *compdef.PartComponentDefinition) {
+	t.Helper()
+	s := NewSession()
+	def := compdef.NewPartComponentDefinition()
+	pd, err := s.Workspace().Add(doc.Part, "part.obk", true)
+	if err != nil {
+		t.Fatalf("Add part: %v", err)
+	}
+	pd.SetContent(def)
+	return s, def
+}
+
+// diskProfileIndex returns the index of the sketch's hole-less (disk) region.
+func diskProfileIndex(t *testing.T, sk *sketch.Sketch) int {
+	t.Helper()
+	ps := sk.Profiles()
+	for i := 0; i < ps.Count(); i++ {
+		if len(ps.Item(i).InnerLoops()) == 0 {
+			return i
+		}
+	}
+	t.Fatalf("sketch offers no hole-less disk region (regions=%d)", ps.Count())
+	return -1
+}
+
+// TestLoftCircleInsideRectangleToCircle is the #1526 regression: the disk of a circle drawn inside a
+// rectangle lofts to a plain circle on a parallel plane, with a live preview and a valid solid.
+func TestLoftCircleInsideRectangleToCircle(t *testing.T) {
+	s, def := loftPartSession(t)
+	sk1 := rectWithInnerCircle(def, yzPlaneAtX(0), 2.539)
+	sk2 := circleSketchOn(def, yzPlaneAtX(10), 3.549)
+	if sk1.Profiles().Count() != 2 {
+		t.Fatalf("Sketch1 offers %d regions, want 2 (the disk and the annulus)", sk1.Profiles().Count())
+	}
+
+	l := NewLoftTool()
+	s.StartTool(l)
+	l.Pick(s, ProfileHandle{Sketch: sk1, ProfileIndex: diskProfileIndex(t, sk1)})
+	l.Pick(s, ProfileHandle{Sketch: sk2, ProfileIndex: 0})
+	if _, ok := l.DraftFeature(s); !ok {
+		t.Error("the loft showed no preview (the #1526 symptom)")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("commit loft: %v", err)
+	}
+	if def.SurfaceBodies().Count() != 1 {
+		t.Fatalf("loft produced %d bodies, want 1 (#1526)", def.SurfaceBodies().Count())
+	}
+	body := def.SurfaceBodies().Item(0)
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("lofted body is not a valid solid: %+v", r)
+	}
+}

--- a/model/sketch/profile.go
+++ b/model/sketch/profile.go
@@ -255,9 +255,16 @@ func (s *Sketch) normalGeometry() []Entity {
 	return out
 }
 
-// groupRegions builds profiles from closed loops by even–odd nesting: a loop
-// contained in an even number of others is an outer boundary; loops one level
-// deeper inside it are its holes.
+// groupRegions builds profiles from closed loops by even–odd nesting: a loop contained in an even
+// number of others is an outer boundary; loops one level deeper inside it are its holes.
+//
+// As an exception, a hole loop that is a single closed PRIMITIVE the user drew — a circle or an
+// ellipse — ALSO bounds its own selectable region (the disk inside it), so a circle inside a
+// rectangle yields BOTH the annulus AND the disk, matching how Inventor lets you select either face.
+// (#1526: lofting "the circle" produced nothing because the disk was silently absorbed as a hole and
+// never offered as a profile.) The exception is deliberately narrow: text-glyph counters and abutting
+// grill cells are not single primitives, so they stay holes only and the glyph/grill region detection
+// (and the grill boolean, which uses ClosedLoops, #863) is unchanged.
 func groupRegions(loops []Loop) []*Profile {
 	depth := make([]int, len(loops))
 	for i := range loops {
@@ -269,12 +276,27 @@ func groupRegions(loops []Loop) []*Profile {
 	}
 	var profiles []*Profile
 	for i, l := range loops {
-		if depth[i]%2 != 0 {
-			continue // a hole; attached to its outer loop below
+		if depth[i]%2 == 0 || isClosedPrimitiveLoop(l) {
+			profiles = append(profiles, &Profile{outer: l, inner: holesOf(i, loops, depth)})
 		}
-		profiles = append(profiles, &Profile{outer: l, inner: holesOf(i, loops, depth)})
 	}
 	return profiles
+}
+
+// isClosedPrimitiveLoop reports whether a loop is a single closed-curve primitive (a circle or a full
+// ellipse). Such a loop unambiguously bounds a region the user can select — the basis for the
+// disk-inside-a-hole exception in groupRegions (#1526). A multi-entity loop (a polygon, a glyph
+// outline, a chain of grill bars) is not a primitive and keeps the plain even–odd hole behaviour.
+func isClosedPrimitiveLoop(l Loop) bool {
+	if len(l.entities) != 1 {
+		return false
+	}
+	switch l.entities[0].Entity.(type) {
+	case *Circle, *Ellipse:
+		return true
+	default:
+		return false
+	}
 }
 
 // holesOf returns the holes of outer (index oi): the loops one nesting level inside it. A

--- a/model/sketch/profile_test.go
+++ b/model/sketch/profile_test.go
@@ -66,24 +66,51 @@ func TestOpenProfileContainsNothing(t *testing.T) {
 	}
 }
 
+// A circle inside a rectangle yields TWO selectable regions, like Inventor: the annulus (the
+// rectangle with the circle as a hole) AND the disk (the circle bounding its own interior). Lofting,
+// extruding or revolving "the circle" picks the disk — before #1526 the disk was absorbed as a hole
+// and never offered, so selecting the circle produced nothing.
 func TestNestedLoopsClassifyInnerAndOuter(t *testing.T) {
 	s := NewSketches().Add(XYPlane())
 	addRectangle(s, 0, 0, 10, 10)                   // outer
-	s.Circles().AddByCenterRadius(math.P2(5, 5), 2) // hole inside it
+	s.Circles().AddByCenterRadius(math.P2(5, 5), 2) // a circle inside it
 	ps := s.Profiles()
-	if ps.Count() != 1 {
-		t.Fatalf("Profiles count = %d, want 1 region with a hole", ps.Count())
+	if ps.Count() != 2 {
+		t.Fatalf("Profiles count = %d, want 2 (the annulus and the disk)", ps.Count())
 	}
-	p := ps.Item(0)
-	if len(p.OuterLoop().Entities()) != 4 {
-		t.Errorf("outer loop entities = %d, want 4 (the rectangle)", len(p.OuterLoop().Entities()))
+	annulus, disk := classifyAnnulusAndDisk(t, ps)
+	if len(annulus.OuterLoop().Entities()) != 4 {
+		t.Errorf("annulus outer loop entities = %d, want 4 (the rectangle)", len(annulus.OuterLoop().Entities()))
 	}
-	if len(p.InnerLoops()) != 1 {
-		t.Fatalf("inner loops = %d, want 1 (the circle)", len(p.InnerLoops()))
+	if len(annulus.InnerLoops()) != 1 || !annulus.InnerLoops()[0].IsClosed() {
+		t.Errorf("annulus should have 1 closed inner loop (the circle); got %d", len(annulus.InnerLoops()))
 	}
-	if !p.InnerLoops()[0].IsClosed() {
-		t.Error("inner loop should be closed")
+	if len(disk.InnerLoops()) != 0 {
+		t.Errorf("the disk has no holes; got %d inner loops", len(disk.InnerLoops()))
 	}
+	if !disk.Contains(math.P2(5, 5)) {
+		t.Error("the disk region should contain the circle's centre")
+	}
+	if annulus.Contains(math.P2(5, 5)) {
+		t.Error("the annulus must NOT contain the circle's centre (that point is its hole)")
+	}
+}
+
+// classifyAnnulusAndDisk splits the two profiles into the one with a hole (the annulus) and the one
+// without (the disk).
+func classifyAnnulusAndDisk(t *testing.T, ps *Profiles) (annulus, disk *Profile) {
+	t.Helper()
+	for i := 0; i < ps.Count(); i++ {
+		if len(ps.Item(i).InnerLoops()) > 0 {
+			annulus = ps.Item(i)
+		} else {
+			disk = ps.Item(i)
+		}
+	}
+	if annulus == nil || disk == nil {
+		t.Fatalf("expected one annulus (with a hole) and one disk (no holes)")
+	}
+	return annulus, disk
 }
 
 func TestMultiRegionProfiles(t *testing.T) {


### PR DESCRIPTION
## Bug

Lofting **the circle in one sketch to a circle in another produced no preview and no body** ([#1526](https://github.com/Oblikovati/Oblikovati/issues/1526)). The first sketch had a circle drawn *inside* a rectangle.

## Root cause

`groupRegions` (model/sketch/profile.go) classifies nested loops by **even–odd nesting**: a loop at odd depth is treated *purely as a hole*. So the circle inside the rectangle became a hole of the rectangle → **one annulus region, no disk**. Selecting "the circle" gave the annulus (1 hole), and lofting it to a plain circle (0 holes) fails the hole-count match → the loft went sick silently: no preview, no loft.

Inventor offers **both** faces there — the annulus *and* the disk.

## Fix

`groupRegions` now also emits the interior region for a hole loop that is a **single closed primitive the user drew (a circle or full ellipse)**. So a circle inside a rectangle yields two selectable regions: the annulus (rectangle with the circle as a hole) and the disk (the circle bounding its interior). Picking the circle selects the disk, and the loft builds.

The exception is deliberately narrow — text-glyph counters and abutting grill cells are **not** single primitives, so they stay holes only:
- text glyph `'A'` → still one profile (body + counter hole) ✓
- crossing-bar grill → still one profile (boundary − island), and the grill boolean uses `ClosedLoops`, not `Profiles` (#863) ✓

## Tests

- `TestNestedLoopsClassifyInnerAndOuter` (model/sketch) — corrected to the Inventor-faithful behaviour: a circle in a rectangle yields the annulus **and** the disk, with the right `Contains` semantics (the disk contains the centre; the annulus does not).
- `TestLoftCircleInsideRectangleToCircle` (app) — the end-to-end #1526 regression: the disk lofts to a circle on a parallel plane → a live preview and a valid solid.
- Text-glyph and grill region tests unchanged and green.

`go test ./model/sketch ./model/feature ./app` green; `golangci-lint` clean.

Closes #1526

🤖 Generated with [Claude Code](https://claude.com/claude-code)