### PR TITLE
Invisible work planes are not mouse-pickable (#1520)

### DIFF
--- a/app/create_sketch_face_host_test.go
+++ b/app/create_sketch_face_host_test.go
@@ -124,6 +124,39 @@ func TestSelectedSketchHostPlaneFromFace(t *testing.T) {
 	}
 }
 
+// emptyPartLookingDown installs the production picker (bodies + PickableWorkPlanes) on an empty
+// part viewed straight down -Z at the origin — the fresh-part setting of issue #1520, where a
+// click on the empty viewport background must not snap to a hidden origin plane.
+func emptyPartLookingDown(t *testing.T) *Session {
+	t.Helper()
+	s, _ := emptyPartSession(t)
+	cam := scene.NewCamera(400, 400)
+	cam.Eye, cam.Target, cam.Up = math.P3(0, 0, 20), math.P3(0, 0, 0), math.V3(0, 1, 0)
+	s.SetCamera(cam)
+	s.SetPicker(NewRayPicker(cam, partBodies(s)).
+		WithPlanes(func() []*feature.WorkPlane { return s.PickableWorkPlanes() }))
+	return s
+}
+
+// TestCreateSketchBackgroundClickIgnoresHiddenOriginPlane is the issue-#1520 regression at the
+// interaction level: with Create 2D Sketch active and every origin plane hidden, clicking the
+// empty viewport background must NOT enter a sketch — a click resolves no invisible plane. Showing
+// the XY plane makes that same click host a sketch on it (the browser node is the only other way in).
+func TestCreateSketchBackgroundClickIgnoresHiddenOriginPlane(t *testing.T) {
+	s := emptyPartLookingDown(t)
+	s.StartTool(NewCreateSketchTool())
+	s.Click(200, 200) // center ray crosses the XY plane, but it is hidden
+	if s.InSketch() || s.ActiveTool() == nil {
+		t.Fatal("clicking the empty background must not start a sketch on a hidden origin plane")
+	}
+	wg, _ := s.ActiveWorkGeometry()
+	wg.WorkPlanes().Item(0).SetVisible(true) // show the XY plane
+	s.Click(200, 200)
+	if !s.InSketch() {
+		t.Fatal("clicking a now-visible origin plane should enter the sketch")
+	}
+}
+
 // sameDir reports whether two vectors point the same or exactly opposite way (a plane's normal
 // sign is orientation-dependent; either matches the host face).
 func sameDir(a, b math.Vector3) bool {

--- a/app/ui_shell_test.go
+++ b/app/ui_shell_test.go
@@ -107,9 +107,12 @@ func TestObjectVisibilityGatesPickablePlanes(t *testing.T) {
 	if !s.ObjectVisibility().WorkPlanes {
 		t.Fatal("planes should default visible")
 	}
-	before := len(s.PickableWorkPlanes())
-	if before == 0 {
-		t.Fatal("expected origin planes to be pickable")
+	// Origin planes default hidden (issue #1520), so show one before asserting the KIND toggle
+	// gates pickability — otherwise there is nothing pickable to gate.
+	wg, _ := s.ActiveWorkGeometry()
+	wg.WorkPlanes().Item(0).SetVisible(true)
+	if len(s.PickableWorkPlanes()) == 0 {
+		t.Fatal("a shown origin plane should be pickable")
 	}
 	vis := s.ObjectVisibility()
 	vis.WorkPlanes = false

--- a/app/work_geometry_assembly_test.go
+++ b/app/work_geometry_assembly_test.go
@@ -37,13 +37,19 @@ func TestActiveWorkGeometryResolvesAssembly(t *testing.T) {
 	}
 }
 
-// TestPickableWorkPlanesIncludesAssemblyOrigin: an assembly's three origin planes are pickable (so
-// they can host a sketch in the assembly), where before they were absent — PickableWorkPlanes was
-// part-gated and returned nil for an assembly.
-func TestPickableWorkPlanesIncludesAssemblyOrigin(t *testing.T) {
+// TestPickableWorkPlanesFollowsVisibilityInAssembly: an assembly's origin planes, like a part's,
+// are hidden by default (issue #1520) and become mouse-pickable only once shown — and the assembly
+// path is no longer part-gated (PickableWorkPlanes returned nil for an assembly before). A hidden
+// origin plane is reachable solely through its browser node, never a viewport click.
+func TestPickableWorkPlanesFollowsVisibilityInAssembly(t *testing.T) {
 	s := activeAssemblySession(t)
-	if got := len(s.PickableWorkPlanes()); got != 3 {
-		t.Errorf("assembly PickableWorkPlanes = %d, want 3 origin planes (XY/XZ/YZ)", got)
+	if got := len(s.PickableWorkPlanes()); got != 0 {
+		t.Fatalf("assembly PickableWorkPlanes (default) = %d, want 0 (origin planes hidden until shown)", got)
+	}
+	wg, _ := s.ActiveWorkGeometry()
+	wg.WorkPlanes().Item(0).SetVisible(true)
+	if got := len(s.PickableWorkPlanes()); got != 1 {
+		t.Errorf("a shown assembly origin plane should be pickable: got %d, want 1", got)
 	}
 }
 

--- a/app/work_plane_ops.go
+++ b/app/work_plane_ops.go
@@ -49,12 +49,15 @@ func (s *Session) ActiveWorkGeometry() (*feature.WorkGeometry, bool) {
 }
 
 // PickableWorkPlanes returns the work planes the viewport hit-test should offer: every
-// origin plane (always pickable as a sketch host — the Origin folder — even though
-// origin planes default to hidden) plus every VISIBLE user-created datum not hidden by the
-// active edit scope (a plane the overlays don't draw must not be clickable either). User
-// planes were previously absent from the picker, so a ribbon-created plane could not be
-// clicked as a new sketch's reference in the 3D view (issue #132); the head feeds this to
-// the RayPicker. Works for an assembly too (its origin planes are sketch hosts as well).
+// VISIBLE datum plane — origin or user-created — not hidden by the active edit scope. A
+// plane the overlays do not draw must not be mouse-clickable; a hidden plane (origin
+// planes default to hidden) is reachable only through its browser node, which feeds the
+// active tool independently of the RayPicker (issue #1520 — clicking the empty viewport
+// background must not snap to an invisible origin plane). This mirrors PickableWorkAxes,
+// which already gates origin and user axes alike on Visible(). User planes were previously
+// absent from the picker, so a ribbon-created plane could not be clicked as a new sketch's
+// reference in the 3D view (issue #132); the head feeds this to the RayPicker. Works for an
+// assembly too (its origin planes are sketch hosts as well, once shown).
 func (s *Session) PickableWorkPlanes() []*feature.WorkPlane {
 	if !s.objectVisibility.WorkPlanes { // hidden kinds are not pickable (M05-F12)
 		return nil
@@ -66,8 +69,7 @@ func (s *Session) PickableWorkPlanes() []*feature.WorkPlane {
 	planes := wg.WorkPlanes()
 	out := make([]*feature.WorkPlane, 0, planes.Count())
 	for i := 0; i < planes.Count(); i++ {
-		wp := planes.Item(i)
-		if wp.IsCoordinateSystemElement() || (wp.Visible() && !s.EditScopeHides(wp.Seq())) {
+		if wp := planes.Item(i); wp.Visible() && !s.EditScopeHides(wp.Seq()) {
 			out = append(out, wp)
 		}
 	}

--- a/app/work_plane_ops_test.go
+++ b/app/work_plane_ops_test.go
@@ -75,24 +75,43 @@ func TestOffsetWorkPlaneToolWaitsForDistanceThenCreates(t *testing.T) {
 }
 
 // TestPickableWorkPlanesIncludesVisibleUserPlanes is the issue-#132 regression: the viewport
-// picker must offer ribbon-created user planes (not only the origin frame), so a new sketch
-// can be hosted on one by clicking it in the 3D view. A hidden user plane drops out.
+// picker must offer a ribbon-created user plane, so a new sketch can be hosted on one by
+// clicking it in the 3D view. A hidden user plane drops out. Origin planes default hidden
+// (issue #1520), so the visible user plane is the only mouse-pickable plane here.
 func TestPickableWorkPlanesIncludesVisibleUserPlanes(t *testing.T) {
 	s, def := emptyPartSession(t)
-	origin := len(def.OriginPlanes()) // the always-pickable coordinate-system planes
 	wp := def.WorkPlanes().AddByPlaneAndOffset(feature.OriginXYPlane, func() float64 { return 2 })
 
 	got := s.PickableWorkPlanes()
-	if len(got) != origin+1 {
-		t.Fatalf("PickableWorkPlanes = %d, want %d (origin) + 1 user plane", len(got), origin)
-	}
-	if !containsPlane(got, wp) {
-		t.Errorf("PickableWorkPlanes omitted the visible user plane %p", wp)
+	if len(got) != 1 || !containsPlane(got, wp) {
+		t.Fatalf("PickableWorkPlanes = %d planes, want only the visible user plane", len(got))
 	}
 
 	wp.SetVisible(false)
-	if got := s.PickableWorkPlanes(); len(got) != origin || containsPlane(got, wp) {
-		t.Errorf("a hidden user plane must not be pickable: got %d planes (want %d)", len(got), origin)
+	if got := s.PickableWorkPlanes(); len(got) != 0 {
+		t.Errorf("a hidden user plane must not be pickable: got %d planes (want 0)", len(got))
+	}
+}
+
+// TestHiddenOriginPlanesNotMousePickable is the issue-#1520 regression: origin planes default
+// hidden, and a datum the overlays do not draw must not be mouse-clickable — clicking the empty
+// viewport background must not snap to an invisible origin plane (the browser node still selects
+// it, fed to the tool independently of the RayPicker). Showing an origin plane restores its
+// viewport pickability.
+func TestHiddenOriginPlanesNotMousePickable(t *testing.T) {
+	s, def := emptyPartSession(t)
+	for _, wp := range def.OriginPlanes() {
+		if wp.Visible() {
+			t.Fatalf("origin plane %q should default hidden", wp.Name())
+		}
+	}
+	if got := s.PickableWorkPlanes(); len(got) != 0 {
+		t.Fatalf("hidden origin planes must not be mouse-pickable: got %d", len(got))
+	}
+	xy := def.OriginPlanes()[0]
+	xy.SetVisible(true)
+	if got := s.PickableWorkPlanes(); len(got) != 1 || !containsPlane(got, xy) {
+		t.Errorf("a shown origin plane must be mouse-pickable: got %d planes", len(got))
 	}
 }
 


### PR DESCRIPTION
## What

Clicking the empty viewport background — e.g. while **Create 2D Sketch** is active — could snap a new sketch onto an **invisible origin plane**. Origin planes default to hidden, yet `Session.PickableWorkPlanes` fed *every* origin plane to the viewport RayPicker via an `IsCoordinateSystemElement()` bypass, so a click on the blue background resolved to whichever hidden origin plane the ray happened to cross.

This makes the picker obey the rule the rest of the datum picking already follows (and that `PickableWorkAxes` already enforced): **a datum the overlays do not draw must not be mouse-clickable.** Hidden planes — origin or user — are now reachable only through their **browser node**, which feeds the active tool independently of the RayPicker.

## Why

User report (#1520): *"when the origin planes are not visible in the viewport they should not be pickable with a mouse click … as a general rule, an entity for any tool where Visible = false should not be pickable by mouse, only by browser nodes."*

## How

- `PickableWorkPlanes` now gates origin and user planes uniformly on `Visible() && !EditScopeHides(seq)` — dropping the coordinate-system short-circuit. One line of behavior; the surrounding doc comment is updated to record the bug and the new rule.
- The browser path is untouched and visibility-blind by design, so a hidden origin plane's tree node still selects it and still auto-commits Create 2D Sketch (verified by the existing browser-selection tests).

## Verification

- **Interaction-level regression** `TestCreateSketchBackgroundClickIgnoresHiddenOriginPlane` — drives the *production* RayPicker (real camera + `WithPlanes(PickableWorkPlanes)`) with Create 2D Sketch active: a center-background `Click` enters **no** sketch while origin planes are hidden, and enters one the instant the XY plane is shown. This bug has no visual signature (origin planes are hidden before and after; the defect was the erroneous *pick*), so a behavioral test is the meaningful artifact rather than a screenshot.
- **Unit regressions** `TestHiddenOriginPlanesNotMousePickable` (hidden → 0 pickable; shown → pickable) and the updated `TestPickableWorkPlanesIncludesVisibleUserPlanes`.
- Updated `TestObjectVisibilityGatesPickablePlanes` and `TestPickableWorkPlanesFollowsVisibilityInAssembly` to the visibility-gated premise (mirroring the existing axes test).
- `go test ./app/` green; `gofmt`/`go vet` clean; head (`./head/ui/...`, `./head/cmd/oblikovati-head/...`) builds.

Closes #1520

🤖 Generated with [Claude Code](https://claude.com/claude-code)