### PR TITLE
Project Geometry: pick model edges/datums from the viewport in-sketch (#1496)

### DIFF
--- a/app/session_input.go
+++ b/app/session_input.go
@@ -193,9 +193,15 @@ func (s *Session) Pointer(e PointerEvent) {
 	if s.sketchClick(e.X, e.Y) {
 		return
 	}
-	// In the sketch environment clicks pick sketch entities: fed to an active
-	// constraint/dimension tool, or (with no tool) added to the selection.
+	// In the sketch environment clicks normally pick sketch entities: fed to an active
+	// constraint/dimension tool, or (with no tool) added to the selection. The exception is
+	// a tool that projects 3D model references (Project Geometry) — its edges/vertices/datums
+	// live in the 3D hit-test, so its clicks must run the RayPicker even in-sketch (#1496).
 	if s.InSketch() {
+		if s.toolPicksModelReferences() {
+			s.pickModelReferenceInSketch(e)
+			return
+		}
 		s.sketchEntityPointer(e)
 		return
 	}
@@ -212,6 +218,37 @@ func (s *Session) Pointer(e PointerEvent) {
 		return
 	}
 	s.applyPickToSelection(sel, e.Mods)
+}
+
+// modelReferencePicker is an in-sketch tool that picks 3D MODEL references — B-rep edges and
+// vertices, plus datum geometry — through the viewport rather than the active sketch's own 2D
+// entities. Project Geometry is the case: the references it projects into the sketch live in the
+// 3D hit-test, so the input router must run the RayPicker while a sketch is being edited (#1496).
+type modelReferencePicker interface {
+	PicksModelReferences() bool
+}
+
+// toolPicksModelReferences reports whether the active tool wants 3D model-reference picks while
+// in-sketch, so Pointer routes its clicks to the RayPicker instead of the 2D sketch picker.
+func (s *Session) toolPicksModelReferences() bool {
+	if s.tool == nil {
+		return false
+	}
+	mr, ok := s.tool.tool.(modelReferencePicker)
+	return ok && mr.PicksModelReferences()
+}
+
+// pickModelReferenceInSketch runs the 3D hit-test for an in-sketch reference-picking tool and
+// feeds any hit (a B-rep edge/vertex or datum) to the tool, so model geometry becomes projectable
+// from the viewport while editing a sketch (#1496). A miss is ignored — there is no ambient sketch
+// selection to clear, and the tool keeps waiting for a reference.
+func (s *Session) pickModelReferenceInSketch(e PointerEvent) {
+	if s.picker == nil {
+		return
+	}
+	if sel, ok := s.picker.Pick(e.X, e.Y, s.pickFilter()); ok {
+		s.feedPickMods(sel, e.Mods)
+	}
 }
 
 // clearSelectionOnEmptyClick clears the selection when the user clicks empty space with

--- a/app/sketch_project_in_sketch_test.go
+++ b/app/sketch_project_in_sketch_test.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/sketch"
+)
+
+// stubEdgePicker is a Picker that returns the given B-rep edge for any pixel, so a test can drive
+// an in-sketch edge pick without aiming a real ray at a tessellated edge.
+type stubEdgePicker struct{ handle EdgeHandle }
+
+func (p stubEdgePicker) Pick(_, _ float64, f *SelectionFilter) (Selectable, bool) {
+	if !f.Accepts(SelectEdge) {
+		return nil, false
+	}
+	return p.handle, true
+}
+
+// TestProjectGeometryPicksModelEdgeInSketch is the #1496 regression: with a sketch on a block's
+// side face being edited, clicking the block's edge in the viewport must reach the 3D hit-test and
+// feed the Project Geometry tool — before the fix every in-sketch click went to the 2D sketch-entity
+// picker, which knows nothing about B-rep edges, so the tool silently received nothing and committing
+// produced no projected curve ("the button does nothing").
+func TestProjectGeometryPicksModelEdgeInSketch(t *testing.T) {
+	s := extrudedBox(t, 2, 4) // [0,2]x[0,2]x[0,4]
+	part, _ := activePart(s)
+	body := partBodies(s)()[0]
+
+	plane := sideFaceSketchPlane(t, body)
+	sk, err := s.CreateSketch(plane)
+	if err != nil {
+		t.Fatalf("CreateSketch: %v", err)
+	}
+	if !s.InSketch() {
+		t.Fatal("expected to be editing the new side-face sketch")
+	}
+
+	edge := projectableEdge(t, part, body, plane)
+	s.SetPicker(stubEdgePicker{handle: EdgeHandle{Edge: edge}})
+	s.StartTool(NewProjectGeometryTool())
+
+	before := countProjectedCurves(sk)
+	s.Click(120, 120) // in-sketch click: the #1496 fix routes it to the 3D picker, not the 2D one
+	tool := s.ActiveTool().Tool().(*ProjectGeometryTool)
+	if !tool.CanCommit() {
+		t.Fatal("clicking a model edge in-sketch must feed the Project tool (the #1496 routing fix)")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	curves := projectedCurves(sk)
+	if len(curves)-before != 1 {
+		t.Fatalf("committing projected %d curves, want 1", len(curves)-before)
+	}
+	if got := distinctPointCount(curves[len(curves)-1].Points()); got < 2 {
+		t.Errorf("projected curve is degenerate (%d distinct points), want a real segment", got)
+	}
+}
+
+// TestInSketchRoutingOnlyForReferenceTools guards the routing seam: only a tool that declares it
+// picks model references (Project Geometry) diverts in-sketch clicks to the 3D picker; a plain
+// sketch-entity tool (Trim) keeps using the 2D sketch picker, and so does no-tool selection.
+func TestInSketchRoutingOnlyForReferenceTools(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	if _, err := s.CreateSketch(sketch.XYPlane()); err != nil {
+		t.Fatalf("CreateSketch: %v", err)
+	}
+	if s.toolPicksModelReferences() {
+		t.Error("no active tool must not route in-sketch clicks to the 3D picker")
+	}
+	s.StartTool(NewProjectGeometryTool())
+	if !s.toolPicksModelReferences() {
+		t.Error("Project Geometry must route in-sketch clicks to the 3D picker (#1496)")
+	}
+	s.StartTool(NewSketchTrimTool())
+	if s.toolPicksModelReferences() {
+		t.Error("a sketch-entity tool must keep the 2D sketch picker, not the 3D picker")
+	}
+}
+
+// sideFaceSketchPlane returns a sketch plane on one of the box's vertical side faces (the #1496
+// setting — a sketch hosted on a side rather than the top cap).
+func sideFaceSketchPlane(t *testing.T, body *topo.Body) sketch.Plane {
+	t.Helper()
+	for _, f := range body.Faces() {
+		pl, ok := f.Geometry().(geom.Plane)
+		if !ok || stdmath.Abs(float64(pl.Normal().Z)) > 0.1 {
+			continue // skip the top/bottom caps
+		}
+		if plane, ok := sketchPlaneFromFace(FaceHandle{Face: f, Body: body}); ok {
+			return plane
+		}
+	}
+	t.Fatal("no side face found on the box")
+	return sketch.Plane{}
+}
+
+// projectableEdge returns a box edge whose projection onto plane is a real segment (≥2 distinct
+// sketch points) — i.e. an edge not perpendicular to the sketch plane — so the regression asserts a
+// visible projected curve rather than a degenerate point.
+func projectableEdge(t *testing.T, part *compdef.PartComponentDefinition, body *topo.Body, plane sketch.Plane) *topo.Edge {
+	t.Helper()
+	for _, e := range body.Edges() {
+		src := compdef.NewEdgeRefSource(part, string(e.ReferenceKey()))
+		pts, ok := src.SamplePoints()
+		if !ok {
+			continue
+		}
+		projected := make([]math.Point2, 0, len(pts))
+		for _, q := range pts {
+			projected = append(projected, plane.ToSketch(q))
+		}
+		if distinctPointCount(projected) >= 2 {
+			return e
+		}
+	}
+	t.Fatal("no projectable (non-perpendicular) edge found on the box")
+	return nil
+}
+
+func projectedCurves(sk *sketch.Sketch) []*sketch.ProjectedCurve {
+	var out []*sketch.ProjectedCurve
+	for _, e := range sk.Entities() {
+		if c, ok := e.(*sketch.ProjectedCurve); ok {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func countProjectedCurves(sk *sketch.Sketch) int { return len(projectedCurves(sk)) }
+
+func distinctPointCount(pts []math.Point2) int {
+	if len(pts) == 0 {
+		return 0
+	}
+	n := 1
+	for i := 1; i < len(pts); i++ {
+		if !pts[i].IsEqualTo(pts[i-1], 1e-9) {
+			n++
+		}
+	}
+	return n
+}

--- a/app/sketch_project_tool.go
+++ b/app/sketch_project_tool.go
@@ -35,6 +35,13 @@ func (t *ProjectGeometryTool) Name() string { return "Project Geometry" }
 // Start is a no-op; the engine installs the filter from AcceptedKinds.
 func (t *ProjectGeometryTool) Start(*Session) {}
 
+// PicksModelReferences routes this tool's in-sketch viewport clicks to the 3D model hit-test
+// (B-rep edges/vertices and datum geometry) instead of the 2D sketch-entity picker. Without it
+// the input router short-circuits every in-sketch click to the sketch's own 2D entities, so the
+// references to project were unreachable from the viewport and the tool silently did nothing
+// (#1496). The browser tree fed picks through SelectBrowserNode, but the 3D view did not.
+func (t *ProjectGeometryTool) PicksModelReferences() bool { return true }
+
 // AcceptedKinds declares project-geometry picks projectable references: B-rep edges and
 // vertices, plus the part's datum geometry (work points, axes and planes — the Origin folder
 // and user work features).

--- a/head/ui/projected_edge_side_sketch_test.go
+++ b/head/ui/projected_edge_side_sketch_test.go
@@ -1,0 +1,78 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// TestProjectedModelEdgeOnSideSketchDraws is the #1496 render-layer confirmation: a B-rep edge of a
+// block, projected into a sketch hosted on a vertical (side-like) plane, becomes a drawn polyline in
+// the viewport. The reported symptom was "Project Geometry does nothing" — once the routing fix lets
+// the edge reach the tool and be projected, this proves the result actually renders on a non-XY
+// sketch (the same overlay that draws datum projections, exercised here with a model edge + side plane).
+func TestProjectedModelEdgeOnSideSketchDraws(t *testing.T) {
+	def := boxPart(t)
+	body := def.SurfaceBodies().All()[0]
+
+	side := def.Sketches().Add(sketch.XZPlane()) // a vertical sketch standing in for a side face
+	edge := projectableEdgeOnto(t, def, body, side.Plane())
+	side.ProjectCurve(compdef.NewEdgeRefSource(def, string(edge.ReferenceKey())))
+
+	if got := projectedCurveOverlay(side); len(got) == 0 {
+		t.Fatal("a model edge projected onto a side sketch must draw a polyline (#1496)")
+	}
+}
+
+// boxPart builds a [0,2]x[0,2]x[0,4] solid box on a fresh part and returns its definition.
+func boxPart(t *testing.T) *compdef.PartComponentDefinition {
+	t.Helper()
+	s := app.NewSession()
+	pd, err := compdef.AddPart(s.Workspace(), "box.opd", true)
+	if err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	def := pd.Content().(*compdef.PartComponentDefinition)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	c0 := sk.Points().Add(math.P2(0, 0))
+	c1 := sk.Points().Add(math.P2(2, 0))
+	c2 := sk.Points().Add(math.P2(2, 2))
+	c3 := sk.Points().Add(math.P2(0, 2))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+	feature.NewExtrudeFeatures(def.Features()).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 4 })
+	def.Recompute()
+	return def
+}
+
+// projectableEdgeOnto returns a box edge whose projection onto plane spans ≥2 distinct sketch points
+// (an edge not perpendicular to the plane), so the overlay has a real polyline to draw.
+func projectableEdgeOnto(t *testing.T, def *compdef.PartComponentDefinition, body *topo.Body, plane sketch.Plane) *topo.Edge {
+	t.Helper()
+	for _, e := range body.Edges() {
+		pts, ok := compdef.NewEdgeRefSource(def, string(e.ReferenceKey())).SamplePoints()
+		if !ok || len(pts) < 2 {
+			continue
+		}
+		first := plane.ToSketch(pts[0])
+		for _, q := range pts[1:] {
+			if !plane.ToSketch(q).IsEqualTo(first, 1e-9) {
+				return e
+			}
+		}
+	}
+	t.Fatal("no projectable (non-perpendicular) edge found on the box")
+	return nil
+}


### PR DESCRIPTION
## What

The in-sketch **Project Geometry** tool did nothing when you tried to project a block's edge from the 3D viewport (no projected curve, no error, no popup) — the reported symptom on a sketch hosted on a block's side face.

## Root cause

While editing a 2D sketch, **every** viewport left-click is short-circuited to the 2D sketch-entity picker:

```go
// app/session_input.go — Pointer
if s.InSketch() {
    s.sketchEntityPointer(e) // only the active sketch's own points/lines/arcs
    return                   // <-- never reaches the 3D RayPicker below
}
```

That 2D picker knows nothing about B-rep edges/vertices/datums. The 3D `RayPicker` — the only thing that hit-tests model edges — was never invoked in-sketch. Project Geometry's entire purpose is to click those *model* references and project them into the sketch, so from the 3D view it received no pick at all → `CanCommit` stayed false → committing produced nothing. The browser tree still fed picks through `SelectBrowserNode`, which masked the gap (and is why datum projection appeared to work).

This affected **all** edges, not the geometric-degeneracy subset — confirmed by reproduction: projecting onto a side-face sketch produces correct line segments for 8 of a box's 12 edges *when the reference reaches the tool*; the bug was that it never did.

## Fix

Add a small seam — `modelReferencePicker` (`PicksModelReferences() bool`), implemented by `ProjectGeometryTool`. `Pointer` routes an in-sketch click to the 3D `RayPicker` when the active tool declares it picks model references, and otherwise keeps the 2D sketch picker:

```go
if s.InSketch() {
    if s.toolPicksModelReferences() { s.pickModelReferenceInSketch(e); return }
    s.sketchEntityPointer(e)
    return
}
```

Edges, vertices and datums are now projectable from the viewport — on a side-face sketch as on any other — bringing the 3D-view flow to parity with the browser+Enter datum flow already shipped for #1262. The pick is filtered by the tool's `AcceptedKinds`, so only edges/vertices/datums are hit (not faces or the sketch plane).

## Verification

- **`TestProjectGeometryPicksModelEdgeInSketch`** (app) — drives the real input router: on a sketch hosted on a box's side face, `s.Click` in-sketch now reaches the 3D picker, feeds the edge to the tool, and committing yields one projected curve with a real (≥2 distinct point) polyline. This is the exact reported scenario.
- **`TestInSketchRoutingOnlyForReferenceTools`** (app) — guards the seam: only Project Geometry diverts in-sketch clicks to the 3D picker; a sketch-entity tool (Trim) and no-tool selection keep the 2D picker.
- **`TestProjectedModelEdgeOnSideSketchDraws`** (head/ui) — render-layer confirmation that a model edge projected onto a side (vertical) sketch actually draws a polyline overlay — the visible result the user was missing.
- Full `go test ./app/` and `./head/ui/` green; `gofmt`/`go vet` clean; head builds.

Closes #1496

🤖 Generated with [Claude Code](https://claude.com/claude-code)