### PR TITLE
Loft: align section winding so opposite-normal profiles don't bow-tie (#1495)

### DIFF
--- a/app/loft_issue1495_test.go
+++ b/app/loft_issue1495_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/sketch"
+)
+
+// userPlane rebuilds a sketch plane from a saved document's exact origin + axes (the .opd stores
+// the same triple), so this test lofts the issue #1495 geometry verbatim rather than an idealization.
+func userPlane(t *testing.T, ox, oy, oz, xx, xy, xz, yx, yy, yz float64) sketch.Plane {
+	t.Helper()
+	p, err := sketch.NewPlane(
+		math.P3(ox, oy, oz),
+		math.V3(xx, xy, xz).AsUnit(),
+		math.V3(yx, yy, yz).AsUnit(),
+	)
+	if err != nil {
+		t.Fatalf("NewPlane: %v", err)
+	}
+	return p
+}
+
+// userCircleSketch adds a circle at the document's sketch-space centre + radius on the given plane.
+func userCircleSketch(def *compdef.PartComponentDefinition, plane sketch.Plane, cx, cy, r float64) *sketch.Sketch {
+	sk := def.Sketches().Add(plane)
+	sk.Circles().AddByCenterRadius(math.P2(cx, cy), math.Scalar(r))
+	return sk
+}
+
+// TestLoftUserCirclesIssue1495 verifies the reported scenario from issue #1495 ("two circles in
+// different planes, fail to create a loft between them") on the user's verbatim demo.opd geometry:
+//
+//	Sketch2 — plane origin (0,0,5), xAxis (0,1,0), yAxis (-1,0,0), circle centre (1.3958,-1.8419) r=0.8760
+//	Sketch4 — plane origin (0,0,0), xAxis (0,-1,0), yAxis (-1,0,0), circle centre (-2,-1)        r=0.5128
+//
+// Lofting the two circle profiles must yield one validated solid (an oblique circular frustum).
+func TestLoftUserCirclesIssue1495(t *testing.T) {
+	s := NewSession()
+	def := compdef.NewPartComponentDefinition()
+	pd, err := s.Workspace().Add(doc.Part, "demo.obk", true)
+	if err != nil {
+		t.Fatalf("Add part: %v", err)
+	}
+	pd.SetContent(def)
+
+	top := userCircleSketch(def, // Sketch2 @ z=5
+		userPlane(t, 0, 0, 5, 0, 1, 0, -1, 0, 0), 1.3958273142764592, -1.8419164559524412, 0.8760172654982382)
+	bottom := userCircleSketch(def, // Sketch4 @ z=0
+		userPlane(t, 0, 0, 0, 0, -1, 0, -1, 0, 0), -2, -1, 0.512836453031296)
+
+	l := NewLoftTool()
+	s.SetPicker(&seqPicker{sels: []Selectable{
+		ProfileHandle{Sketch: bottom, ProfileIndex: 0},
+		ProfileHandle{Sketch: top, ProfileIndex: 0},
+	}})
+	s.StartTool(l)
+	s.Click(10, 200) // bottom circle
+	s.Click(10, 10)  // top circle
+	if !l.CanCommit() {
+		t.Fatalf("loft not ready with %d sections (issue #1495: two circles must be loftable)", l.SectionCount())
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("loft commit failed (issue #1495 regression): %v", err)
+	}
+
+	if def.SurfaceBodies().Count() != 1 {
+		t.Fatalf("part has %d bodies after loft, want 1 solid", def.SurfaceBodies().Count())
+	}
+	body := def.SurfaceBodies().Item(0)
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("lofted body is not a valid solid: %+v", r)
+	}
+
+	// Oblique circular frustum: parallel sections, so volume matches the straight frustum
+	// V = (π h/3)(r0² + r0·r1 + r1²); tessellated circles undershoot the analytic value slightly.
+	const r0, r1, h = 0.512836453031296, 0.8760172654982382, 5.0
+	want := stdmath.Pi * h / 3 * (r0*r0 + r0*r1 + r1*r1)
+	got := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume
+	if got <= 0 {
+		t.Fatalf("lofted solid has non-positive volume %g", got)
+	}
+	if rel := stdmath.Abs(got-want) / want; rel > 0.05 {
+		t.Errorf("loft volume = %g, want ≈%.3f (analytic frustum), relErr %.3f", got, want, rel)
+	}
+	t.Logf("issue #1495 loft OK: valid solid, volume=%.4f (analytic frustum ≈%.4f)", got, want)
+}

--- a/model/feature/loft_skin.go
+++ b/model/feature/loft_skin.go
@@ -54,10 +54,12 @@ const loftAroundStepDeg = 15.0
 // section point count.
 const loftMaxAroundSubdiv = 16
 
-// alignSections rotates each section's point order to the cyclic start offset that minimizes the
-// summed squared distance to the previous section's corresponding points. Winding is assumed
-// consistent (sketch profiles are CCW), so it never flips a section — that would invert the
-// surface; it only chooses the start point. Sections must already share a point count.
+// alignSections corresponds each section to the previous one: it first matches winding (reversing a
+// section whose world traversal is opposite the reference — issue #1495), then rotates the section's
+// point order to the cyclic start offset minimizing the summed squared distance to the reference's
+// corresponding points. Reversal is only applied to an oppositely-wound section, so a consistently-
+// wound loft (the common case, and every twisted-but-same-side section such as a Möbius band) is
+// never flipped and its surface is not inverted. Sections must already share a point count.
 func alignSections(sections [][]math.Point3) [][]math.Point3 {
 	if len(sections) < 2 {
 		return sections
@@ -65,7 +67,36 @@ func alignSections(sections [][]math.Point3) [][]math.Point3 {
 	out := make([][]math.Point3, len(sections))
 	out[0] = sections[0]
 	for i := 1; i < len(sections); i++ {
-		out[i] = rotateToBestOffset(out[i-1], sections[i])
+		out[i] = rotateToBestOffset(out[i-1], matchWinding(out[i-1], sections[i]))
+	}
+	return out
+}
+
+// matchWinding reverses cur when its world winding is opposite the reference loop's. Each profile
+// loop is sampled in its sketch's 2D order and mapped through the sketch plane, so a circle drawn
+// CCW becomes world-CCW on a +Z-normal plane but world-CW on a -Z-normal plane. Two such profiles
+// (issue #1495 — a user's two circles on oppositely-facing planes) would otherwise connect rib i of
+// one ring to the antipodal point of the next, crossing every facet into a pinched bow-tie (correct-
+// looking "valid solid" at ~1/3 the volume). Winding is compared by the loops' Newell normals;
+// consistently-wound or degenerate (point/apex, <3 pts) sections are returned unchanged.
+func matchWinding(ref, cur []math.Point3) []math.Point3 {
+	if len(ref) < 3 || len(cur) < 3 {
+		return cur
+	}
+	if float64(boundaryNormal(ref).Dot(boundaryNormal(cur))) < 0 {
+		return reverseLoop(cur)
+	}
+	return cur
+}
+
+// reverseLoop returns the loop traversed the other way, holding index 0 fixed so the subsequent
+// start-offset search begins from a stable anchor.
+func reverseLoop(p []math.Point3) []math.Point3 {
+	n := len(p)
+	out := make([]math.Point3, n)
+	out[0] = p[0]
+	for i := 1; i < n; i++ {
+		out[i] = p[n-i]
 	}
 	return out
 }

--- a/model/feature/sweep_loft_test.go
+++ b/model/feature/sweep_loft_test.go
@@ -334,6 +334,37 @@ func TestLoftBetweenSquaresIsFrustum(t *testing.T) {
 	}
 }
 
+// planeAtZFlipped is planeAtZ with the normal reversed (xAxis (0,1,0), yAxis (1,0,0) → normal -Z),
+// so a profile drawn on it is wound opposite a profile on an XY-parallel plane — the issue #1495
+// condition where a user's two circles sat on oppositely-facing sketch planes.
+func planeAtZFlipped(z float64) sketch.Plane {
+	p, _ := sketch.NewPlane(math.P3(0, 0, z), math.V3(0, 1, 0).AsUnit(), math.V3(1, 0, 0).AsUnit())
+	return p
+}
+
+// TestLoftBetweenOppositeNormalPlanesIsFrustum is the #1495 regression at the feature layer: a 4×4
+// square at z=0 (plane normal +Z) lofted to a 2×2 square at z=5 whose sketch plane normal points -Z
+// must still be the correct square frustum (V=140/3), not a winding-crossed bow-tie at ~1/3 the
+// volume. matchWinding reverses the oppositely-wound top section so the ribs connect point-for-point.
+func TestLoftBetweenOppositeNormalPlanesIsFrustum(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	bottom := centeredSquareOn(sketch.XYPlane(), 2)
+	top := centeredSquareOn(planeAtZFlipped(5), 1)
+	pf := NewLoftFeatures(fs).Add([]LoftSection{{Sketch: bottom, ProfileIndex: 0}, {Sketch: top, ProfileIndex: 0}}, false, ops.NewBody)
+	fs.Recompute()
+
+	if !pf.Health().OK() {
+		t.Fatalf("opposite-normal loft went sick: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("opposite-normal lofted body is not a valid solid: %+v", r)
+	}
+	if v := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; relErr(v, 140.0/3) > 0.02 {
+		t.Errorf("opposite-normal frustum volume = %g, want ≈46.667 (a bow-tie would be ~1/3)", v)
+	}
+}
+
 func TestSweepAndLoftRoundTrip(t *testing.T) {
 	prof := centeredSquareOn(sketch.XYPlane(), 1)
 	bottom := centeredSquareOn(sketch.XYPlane(), 2)


### PR DESCRIPTION
## What

Verifying #1495 ("two circles in different planes, fail to create a loft") against the **user's verbatim `demo.opd` geometry** revealed the loft now *runs* but produces a **pinched, bow-tied solid at ~1/3 the expected volume** — a manifold that validates but looks wrong. This fixes that.

## Why it pinched

The user's two circles sit on sketch planes with **opposite normals**:
- Sketch2 — plane normal **+Z** (xAxis (0,1,0), yAxis (-1,0,0)), circle r=0.876 at z=5
- Sketch4 — plane normal **-Z** (xAxis (0,-1,0), yAxis (-1,0,0)), circle r=0.513 at z=0

Each profile loop is sampled in its sketch's 2D order and mapped through the sketch plane (`loopToModel` → `Plane.ToModel`). A circle drawn CCW becomes **world-CCW on a +Z plane but world-CW on a -Z plane**. The section correspondence (`alignSections`) then connected rib *i* of one ring to the *antipodal* point of the next, crossing every side facet → bow-tie. `alignSections` only rotated the start vertex and, by an explicit old comment, *deliberately never reversed* a loop.

Confirmed by probing the same world-space circles on consistently-oriented planes: volume jumped from **2.61** (opposite normals) to **7.66** (consistent), against an analytic frustum of **7.75**.

## Fix

Add `matchWinding` in `model/feature/loft_skin.go`: before the start-offset search, reverse a section whose Newell normal opposes the reference section's, so every ring traverses the same way. Only an *oppositely-wound* section is reversed — consistently-wound lofts (the common case, and twisted-but-same-side sections such as a Möbius band) are returned unchanged, so no surface is inverted. Point/apex sections (<3 pts) are skipped.

## Verification (analytic volume + manifold — the prescribed gate for geometry bugs)

- **`TestLoftUserCirclesIssue1495`** (app) reconstructs the user's two circles verbatim (exact planes, centres, radii) and lofts them: now a **valid solid**, volume **7.66 ≈ analytic 7.75** (`πh/3·(r0²+r0·r1+r1²)`) within ~1% (circle tessellation). Was 2.61 before the fix.
- Full `go test ./model/feature/` (incl. the Möbius/twisted-loft fixtures) and `./app/` green; `gofmt`/`go vet` clean.

Closes #1495

🤖 Generated with [Claude Code](https://claude.com/claude-code)