### PR TITLE
Fix #1489: on-top solid client-graphics glyphs self-occlude (FEA support cubes / load arrows)

### DIFF
--- a/head/internal/native/smoke.go
+++ b/head/internal/native/smoke.go
@@ -63,7 +63,7 @@ func RunViewportSmoke(maxFrames int) int {
 	for i := 0; i < maxFrames && !w.ShouldClose(); i++ {
 		w.BeginFrame()
 		w.RenderViewport(0, 1280, 720, mvp[:], eye, verts, len(verts)/16, idx,
-			nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil, len(idx), nil, nil, nil, 0)
+			nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil, len(idx), 0, nil, nil, nil, 0)
 		w.EndFrame(0.10, 0.10, 0.12)
 	}
 	if path := os.Getenv("OBK_SMOKE_PNG"); path != "" {

--- a/head/internal/native/viewport.cpp
+++ b/head/internal/native/viewport.cpp
@@ -1091,6 +1091,23 @@ void obk_viewport_init(void* h, const uint32_t* vert, int vlen, const uint32_t* 
     init_default_env(c, v);
 }
 
+// clear_viewport_depth resets the depth attachment to far (1.0) over the whole render area,
+// mid-pass. It lets the on-top SOLID overlay (client-graphics glyphs, #1489) draw on top of the
+// model yet still depth-test against ITSELF: after this clear, a depth-tested + depth-writing draw
+// self-occludes (a cube reads as a cube) while no model fragment can hide it. Depth aspect only —
+// the offscreen target is VK_FORMAT_D32_SFLOAT, no stencil.
+static void clear_viewport_depth(VkCommandBuffer cmd, int w, int hh) {
+    VkClearAttachment att{};
+    att.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+    att.clearValue.depthStencil = {1.0f, 0};
+    VkClearRect rect{};
+    rect.rect.offset = {0, 0};
+    rect.rect.extent = {(uint32_t)w, (uint32_t)hh};
+    rect.baseArrayLayer = 0;
+    rect.layerCount = 1;
+    vkCmdClearAttachments(cmd, 1, &att, 1, &rect);
+}
+
 // obk_viewport_render uploads the geometry (only when geomKey marks it changed — #1422), records
 // the offscreen pass, and submits it (waiting on a fence so the color image is ready to sample
 // this frame). geomKey is the merged-mesh identity from the Go atlas cache; 0 means always upload.
@@ -1101,7 +1118,7 @@ void obk_viewport_render(void* h, int slot, int w, int hh, const float* mvp, con
                          const float* hidV, int hidVC, const uint32_t* hidIdx, int hidIC,
                          const float* topTriV, int topTriVC, const uint32_t* topTriIdx, int topTriIC,
                          const float* topLineV, int topLineVC, const uint32_t* topLineIdx, int topLineIC,
-                         int triBiasFirst, const float* clip,
+                         int triBiasFirst, int topTriSolidFirst, const float* clip,
                          const float* mats, int matCount, const int32_t* recs, int recCount,
                          uint64_t geomKey) {
     HeadContext* c = (HeadContext*)h;
@@ -1292,10 +1309,24 @@ void obk_viewport_render(void* h, int slot, int w, int hh, const float* mvp, con
             VkPipeline pipes[6] = {v->occluderPipeline, v->triPipeline, v->linePipeline,
                                    v->hiddenPipeline, v->topTriPipeline, v->topLinePipeline};
             int curStream = -1;
+            bool topSolidCleared = false;
             for (int r = 0; r < recCount; r++) {
                 const int32_t* rec = recs + (size_t)r * kDrawRecInts;
                 int stream = rec[0];
                 if (stream < 0 || stream > 5 || rec[2] <= 0 || rec[5] <= 0) continue;
+                // On-top SOLID tail (stream 4, flag rec[6]==1): the opaque client-graphics glyphs.
+                // Clear depth once so they sit on top of the model, then draw them depth-tested +
+                // lit through the shaded-tri pipeline so each self-occludes as a real solid (#1489).
+                if (stream == kStreamTopTri && rec[6]) {
+                    if (!topSolidCleared) { clear_viewport_depth(cmd, w, hh); topSolidCleared = true; }
+                    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, v->triPipeline);
+                    pushLit(1.0f);
+                    curStream = -1; // force a rebind for any following stream
+                    vkCmdSetDepthBias(cmd, 0.0f, 0.0f, 0.0f);
+                    vkCmdDrawIndexed(cmd, (uint32_t)rec[2], (uint32_t)rec[5],
+                                     (uint32_t)rec[1], rec[3], (uint32_t)rec[4]);
+                    continue;
+                }
                 if (stream != curStream) {
                     vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipes[stream]);
                     pushLit(stream == kStreamTri ? (v->normalDebug ? 2.0f : 1.0f)
@@ -1356,12 +1387,27 @@ void obk_viewport_render(void* h, int slot, int w, int hh, const float* mvp, con
             vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, v->hiddenPipeline);
             vkCmdDrawIndexed(cmd, (uint32_t)hidIC, 1, (uint32_t)hidFirst, hidBase, 0);
         }
-        // 5) on-top faces — depth test disabled, so client-graphics overlays draw over the
-        //    model. Drawn flat-lit (the overlay color is authoritative), after everything else.
+        // 5) on-top faces. The stream splits at topTriSolidFirst: the flat head (translucent
+        //    ghosts/highlights, heatmap flood plots) draws with the depth test disabled so it
+        //    burns over the model; the opaque-solid tail (client-graphics glyphs — support cubes,
+        //    load arrows) draws after a depth clear, depth-tested + lit, so each glyph
+        //    self-occludes as a real solid instead of a scatter of faces (#1489).
         if (topTriIC > 0) {
-            pushLit(0.0f);
-            vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, v->topTriPipeline);
-            vkCmdDrawIndexed(cmd, (uint32_t)topTriIC, 1, (uint32_t)topTriFirst, topTriBase, 0);
+            int solidFirst = topTriSolidFirst;
+            if (solidFirst < 0 || solidFirst > topTriIC) solidFirst = topTriIC;
+            if (solidFirst > 0) {
+                pushLit(0.0f);
+                vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, v->topTriPipeline);
+                vkCmdDrawIndexed(cmd, (uint32_t)solidFirst, 1, (uint32_t)topTriFirst, topTriBase, 0);
+            }
+            if (topTriIC - solidFirst > 0) {
+                clear_viewport_depth(cmd, w, hh);
+                pushLit(1.0f);
+                vkCmdSetDepthBias(cmd, 0.0f, 0.0f, 0.0f);
+                vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, v->triPipeline);
+                vkCmdDrawIndexed(cmd, (uint32_t)(topTriIC - solidFirst), 1,
+                                 (uint32_t)(topTriFirst + solidFirst), topTriBase, 0);
+            }
         }
         // 6) on-top lines — depth test disabled (burn-through markers/edges).
         if (topLineIC > 0) {

--- a/head/internal/native/viewport.go
+++ b/head/internal/native/viewport.go
@@ -19,7 +19,7 @@ void     obk_viewport_render(void* h, int slot, int w, int hh, const float* mvp,
                              const float* hidV, int hidVC, const uint32_t* hidIdx, int hidIC,
                              const float* topTriV, int topTriVC, const uint32_t* topTriIdx, int topTriIC,
                              const float* topLineV, int topLineVC, const uint32_t* topLineIdx, int topLineIC,
-                             int triBiasFirst, const float* clip,
+                             int triBiasFirst, int topTriSolidFirst, const float* clip,
                              const float* mats, int matCount, const int32_t* recs, int recCount,
                              uint64_t geomKey);
 uint64_t obk_viewport_geom_uploads(void* h);
@@ -79,7 +79,7 @@ func (win *Window) RenderViewport(slot, w, h int, mvp []float32, camPos []float3
 	hidVerts []float32, hidVCount int, hidIdx []uint32,
 	topTriVerts []float32, topTriVCount int, topTriIdx []uint32,
 	topLineVerts []float32, topLineVCount int, topLineIdx []uint32,
-	triBiasFirst int, clip []float32,
+	triBiasFirst, topTriSolidFirst int, clip []float32,
 	mats []float32, recs []int32, geomKey uint64,
 ) {
 	C.obk_viewport_render(win.handle, C.int(slot), C.int(w), C.int(h),
@@ -90,7 +90,7 @@ func (win *Window) RenderViewport(slot, w, h int, mvp []float32, camPos []float3
 		floatPtr(hidVerts), C.int(hidVCount), uint32Ptr(hidIdx), C.int(len(hidIdx)),
 		floatPtr(topTriVerts), C.int(topTriVCount), uint32Ptr(topTriIdx), C.int(len(topTriIdx)),
 		floatPtr(topLineVerts), C.int(topLineVCount), uint32Ptr(topLineIdx), C.int(len(topLineIdx)),
-		C.int(triBiasFirst), floatPtr(clip),
+		C.int(triBiasFirst), C.int(topTriSolidFirst), floatPtr(clip),
 		floatPtr(mats), C.int(len(mats)/16), int32Ptr(recs), C.int(len(recs)/recDrawInts),
 		C.uint64_t(geomKey))
 }

--- a/head/internal/native/viewport_geom_upload_test.go
+++ b/head/internal/native/viewport_geom_upload_test.go
@@ -35,7 +35,7 @@ func TestViewportGeomUploadDirtySkip(t *testing.T) {
 		mvp := renderer.ViewProjection(cam, 0.1, 100)
 		w.BeginFrame()
 		w.RenderViewport(0, pw, ph, mvp[:], eye, verts, len(verts)/16, idx,
-			nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil, len(idx), nil, nil, nil, geomKey)
+			nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil, nil, 0, nil, len(idx), 0, nil, nil, nil, geomKey)
 		w.EndFrame(0.10, 0.10, 0.12)
 	}
 

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -510,7 +510,7 @@ func renderViewportImage(win *native.Window, s *app.Session, slot int, cam scene
 		m.HidVerts, m.HidVCount, m.HidIndices,
 		m.TopTriVerts, m.TopTriVCount, m.TopTriIndices,
 		m.TopLineVerts, m.TopLineVCount, m.TopLineIndices,
-		m.TriBiasFirst, s.ActiveSectionClip(), // section-plane clip (M12-F04)
+		m.TriBiasFirst, m.TopTriSolidFirst, s.ActiveSectionClip(), // section-plane clip (M12-F04); #1489 solid-glyph split
 		mats, recs, geomKey) // instanced draw (ADR-0038); geomKey gates the geometry re-upload (#1422)
 	frameStats.gpuNs = time.Since(tg).Nanoseconds()
 	if tex := win.ViewportTexture(slot); tex != 0 {

--- a/head/ui/viewport_instancing.go
+++ b/head/ui/viewport_instancing.go
@@ -78,8 +78,11 @@ func (b *instanceBuilder) addSource(src *topo.Body, mesh viewport.Mesh) {
 }
 
 // appendStream concatenates one stream of a source mesh into the atlas and emits its record
-// template(s) — the tri stream splits into opaque + depth-biased halves at TriBiasFirst; the rest
-// are one record. Offsets are LOCAL to the stream here; finishAtlas makes them absolute.
+// template(s). Two streams split into a normal head and a flagged tail (rec flag = 1): the
+// shaded-tri stream (1) at TriBiasFirst — opaque [0:split) then depth-biased [split:len); the
+// on-top-tri stream (4) at TopTriSolidFirst — flat [0:split) then opaque-solid [split:len)
+// (#1489). Every other stream is one record. Offsets are LOCAL to the stream; finishAtlas makes
+// them absolute.
 func (b *instanceBuilder) appendStream(st instStream, mesh *viewport.Mesh) {
 	idx := st.idx(mesh)
 	if len(idx) == 0 {
@@ -89,19 +92,30 @@ func (b *instanceBuilder) appendStream(st instStream, mesh *viewport.Mesh) {
 	ibase := int32(len(b.streamIdx[st.id]))
 	b.streamVerts[st.id] = append(b.streamVerts[st.id], st.verts(mesh)...)
 	b.streamIdx[st.id] = append(b.streamIdx[st.id], idx...)
-	if st.id != 1 {
-		b.recs = append(b.recs, [5]int32{st.id, ibase, int32(len(idx)), vbase, 0})
-		return
+	split := streamFlagSplit(st.id, mesh) // local index where the flagged tail begins (len ⇒ no tail)
+	if split < 0 || split > len(idx) {
+		split = len(idx)
 	}
-	bias := mesh.TriBiasFirst // tri: opaque [0:bias) then depth-biased [bias:len) (overlays only)
-	if bias < 0 || bias > len(idx) {
-		bias = len(idx)
+	if split > 0 {
+		b.recs = append(b.recs, [5]int32{st.id, ibase, int32(split), vbase, 0})
 	}
-	if bias > 0 {
-		b.recs = append(b.recs, [5]int32{1, ibase, int32(bias), vbase, 0})
+	if len(idx)-split > 0 {
+		b.recs = append(b.recs, [5]int32{st.id, ibase + int32(split), int32(len(idx) - split), vbase, 1})
 	}
-	if len(idx)-bias > 0 {
-		b.recs = append(b.recs, [5]int32{1, ibase + int32(bias), int32(len(idx) - bias), vbase, 1})
+}
+
+// streamFlagSplit returns the LOCAL index where stream id's flagged tail begins — the
+// depth-biased fills of the shaded-tri stream (1) and the opaque-solid glyphs of the on-top-tri
+// stream (4, #1489). Every other stream has no tail, so its whole length is the head (split ==
+// len of the stream's indices, applied by the caller's clamp).
+func streamFlagSplit(id int32, mesh *viewport.Mesh) int {
+	switch id {
+	case 1:
+		return mesh.TriBiasFirst
+	case 4:
+		return mesh.TopTriSolidFirst
+	default:
+		return int(^uint(0) >> 1) // max int ⇒ caller clamps to len(idx): one head record, no tail
 	}
 }
 

--- a/head/ui/viewport_instancing_test.go
+++ b/head/ui/viewport_instancing_test.go
@@ -105,3 +105,44 @@ func TestFrameAtlasCullsHiddenInstances(t *testing.T) {
 		t.Errorf("atlas still holds both sources' verts = %d, want 6", atlas.mesh.TriVCount)
 	}
 }
+
+// TestOnTopTriStreamSplitsAtSolidFirst pins the #1489 instanced path: the on-top-tri stream (4)
+// emits TWO records around TopTriSolidFirst — a flat HEAD (flag 0: translucent ghosts/heatmaps,
+// drawn depth-disabled) and an opaque-solid TAIL (flag 1: client-graphics glyphs, drawn after a
+// depth clear, depth-tested + lit so they self-occlude). This mirrors the shaded-tri stream's
+// existing opaque/depth-biased split.
+func TestOnTopTriStreamSplitsAtSolidFirst(t *testing.T) {
+	src := &topo.Body{}
+	var b instanceBuilder
+	// 5 on-top-tri indices: 2 flat overlays then 3 solid-glyph (TopTriSolidFirst = 2).
+	mesh := viewport.Mesh{
+		TopTriVerts: make([]float32, 5*16), TopTriVCount: 5,
+		TopTriIndices:    []uint32{0, 1, 2, 3, 4},
+		TopTriSolidFirst: 2,
+	}
+	b.addSource(src, mesh)
+	atlas := b.finishAtlas("k")
+	_, recs := atlas.assemble(map[*topo.Body][]math.Matrix4{src: {math.Identity4()}})
+
+	const streamTopTri = 4 // native kStreamTopTri (see instStreams / viewport.cpp)
+	var head, tail []int32
+	for i := 0; i < len(recs); i += 7 {
+		switch r := recs[i : i+7]; {
+		case r[0] != streamTopTri: // only the on-top-tri stream is exercised here
+			t.Fatalf("unexpected stream %d in records %v", r[0], recs)
+		case r[6] == 0:
+			head = r
+		default:
+			tail = r
+		}
+	}
+	if head == nil || tail == nil {
+		t.Fatalf("want a flat head (flag 0) and a solid tail (flag 1) record, got %v", recs)
+	}
+	if head[2] != 2 { // indexCount of the flat head
+		t.Errorf("head indexCount = %d, want 2 (the flat overlays before TopTriSolidFirst)", head[2])
+	}
+	if tail[1] != 2 || tail[2] != 3 { // firstIndex past the head, then 3 solid indices
+		t.Errorf("solid tail = firstIndex %d count %d, want firstIndex 2 count 3", tail[1], tail[2])
+	}
+}

--- a/head/viewport/flatten.go
+++ b/head/viewport/flatten.go
@@ -29,22 +29,29 @@ type Mesh struct {
 	// (Biased items — work-plane/ground-plane fills — are appended after the opaque triangles).
 	// The native pass draws [0,TriBiasFirst) at zero bias and [TriBiasFirst,len) with a small
 	// bias so coplanar reference overlays do not z-fight solid geometry.
-	TriBiasFirst   int
-	OccVerts       []float32
-	OccVCount      int
-	OccIndices     []uint32
-	LineVerts      []float32
-	LineVCount     int
-	LineIndices    []uint32
-	HidVerts       []float32
-	HidVCount      int
-	HidIndices     []uint32
-	TopTriVerts    []float32
-	TopTriVCount   int
-	TopTriIndices  []uint32
-	TopLineVerts   []float32
-	TopLineVCount  int
-	TopLineIndices []uint32
+	TriBiasFirst  int
+	OccVerts      []float32
+	OccVCount     int
+	OccIndices    []uint32
+	LineVerts     []float32
+	LineVCount    int
+	LineIndices   []uint32
+	HidVerts      []float32
+	HidVCount     int
+	HidIndices    []uint32
+	TopTriVerts   []float32
+	TopTriVCount  int
+	TopTriIndices []uint32
+	// TopTriSolidFirst is the index into TopTriIndices at which the OPAQUE SOLID on-top
+	// triangles begin (client-graphics glyphs — fixed-support cubes, load arrows — appended
+	// after the flat/translucent on-top triangles). The native pass draws [0,TopTriSolidFirst)
+	// flat with the depth test disabled (the burn-through overlay), then clears depth and draws
+	// [TopTriSolidFirst,len) depth-tested + lit so each solid self-occludes instead of rendering
+	// as a scatter of arbitrary faces — issue #1489.
+	TopTriSolidFirst int
+	TopLineVerts     []float32
+	TopLineVCount    int
+	TopLineIndices   []uint32
 }
 
 // Flatten splits a draw list into the viewport streams, interleaving each vertex as
@@ -54,8 +61,15 @@ type Mesh struct {
 // Occluder is set, and lines to the hidden stream when Hidden is set.
 func Flatten(list renderer.DrawList) Mesh {
 	var m Mesh
-	var biased []renderer.DrawItem
+	var biased, solidOnTop []renderer.DrawItem
 	for _, item := range list.Items {
+		// Opaque, normal-bearing on-top triangle meshes (client-graphics glyphs) are held to the
+		// tail of the on-top stream so the native pass can draw them depth-tested + lit; the flat
+		// on-top path (translucent ghosts/highlights, normal-less flood plots, lines) is untouched.
+		if isSolidOnTopTriangle(item) {
+			solidOnTop = append(solidOnTop, item)
+			continue
+		}
 		biased = routeItem(&m, item, biased)
 	}
 	// Biased reference overlays go at the tail of the triangle stream so the native pass can draw
@@ -64,7 +78,33 @@ func Flatten(list renderer.DrawList) Mesh {
 	for _, item := range biased {
 		m.TriVCount = appendItem(&m.TriVerts, &m.TriIndices, m.TriVCount, item)
 	}
+	// Solid on-top glyphs go at the tail of the on-top triangle stream (after the flat overlays),
+	// drawn depth-cleared + depth-tested + lit so each reads as a real solid (#1489).
+	m.TopTriSolidFirst = len(m.TopTriIndices)
+	for _, item := range solidOnTop {
+		m.TopTriVCount = appendItem(&m.TopTriVerts, &m.TopTriIndices, m.TopTriVCount, item)
+	}
 	return m
+}
+
+// isSolidOnTopTriangle reports whether item is an OPAQUE, normal-bearing on-top triangle mesh —
+// a client-graphics solid glyph (support cube, load arrow) that must self-occlude to read as a
+// 3D solid AND sit on top of every other overlay (#1489). Translucent on-top overlays
+// (feature-preview ghosts, face highlights) and normal-less flat overlays (heatmap flood plots)
+// deliberately stay on the flat burn-through path: a flood plot is a flat data skin that must NOT
+// be lit and must stay UNDER the glyphs, and depth-writing a translucent overlay changes its look.
+func isSolidOnTopTriangle(item renderer.DrawItem) bool {
+	return item.OnTop && item.Primitive == renderer.Triangles &&
+		len(item.Normals) > 0 && isOpaqueItem(item)
+}
+
+// isOpaqueItem reports whether a draw item is fully opaque: an explicit fractional Opacity
+// (0,1) marks translucency, otherwise the item's broadcast color alpha decides.
+func isOpaqueItem(item renderer.DrawItem) bool {
+	if item.Opacity > 0 && item.Opacity < 1 {
+		return false
+	}
+	return item.Color[3] >= 1
 }
 
 // routeItem appends one draw item to the stream its flags select, returning the (possibly grown)

--- a/head/viewport/flatten_test.go
+++ b/head/viewport/flatten_test.go
@@ -135,6 +135,62 @@ func TestFlattenRoutesOnTopToTopStreams(t *testing.T) {
 	}
 }
 
+// TestFlattenSplitsSolidOnTopToTail reproduces issue #1489: an OPAQUE, normal-bearing on-top
+// triangle (a client-graphics solid glyph — support cube / load arrow) must be held to the TAIL
+// of the on-top triangle stream (at/after TopTriSolidFirst) so the native pass can clear depth and
+// draw it depth-tested + lit, making it self-occlude. The flat on-top overlays — a translucent
+// ghost/highlight and a normal-less flood plot — must stay in the HEAD (before TopTriSolidFirst),
+// drawn flat with the depth test disabled, exactly as before.
+func TestFlattenSplitsSolidOnTopToTail(t *testing.T) {
+	ghost := triItem(0) // translucent on-top overlay (a feature-preview ghost / face highlight)
+	ghost.OnTop, ghost.Opacity = true, 0.5
+	flood := triItem(1) // normal-less heatmap flood plot (opaque, but flat data, not a solid)
+	flood.OnTop, flood.Normals = true, nil
+	glyph := triItem(2) // opaque, normal-bearing solid glyph — the #1489 case
+	glyph.OnTop = true
+
+	m := Flatten(renderer.DrawList{Items: []renderer.DrawItem{ghost, flood, glyph}})
+
+	// All three are on-top triangles, so all nine indices land in the on-top stream.
+	if got := len(m.TopTriIndices); got != 9 {
+		t.Fatalf("TopTriIndices = %d, want 9 (3 items × 3)", got)
+	}
+	// The two flat overlays (ghost, flood) form the head; the solid glyph is the tail.
+	if m.TopTriSolidFirst != 6 {
+		t.Errorf("TopTriSolidFirst = %d, want 6 (the glyph begins after the two flat overlays)", m.TopTriSolidFirst)
+	}
+	// Nothing leaked into the regular (depth-tested-against-model) triangle stream.
+	if m.TriVCount != 0 {
+		t.Errorf("on-top items leaked into the regular tri stream: vcount=%d", m.TriVCount)
+	}
+}
+
+// TestIsSolidOnTopTriangle pins the discriminator that routes a glyph to the self-occluding tail:
+// only an OPAQUE, normal-bearing, on-top TRIANGLE qualifies (#1489).
+func TestIsSolidOnTopTriangle(t *testing.T) {
+	base := triItem(0)
+	base.OnTop = true
+	cases := []struct {
+		name string
+		mut  func(*renderer.DrawItem)
+		want bool
+	}{
+		{"opaque glyph with normals", func(i *renderer.DrawItem) {}, true},
+		{"not on top", func(i *renderer.DrawItem) { i.OnTop = false }, false},
+		{"translucent (Opacity)", func(i *renderer.DrawItem) { i.Opacity = 0.5 }, false},
+		{"translucent (color alpha)", func(i *renderer.DrawItem) { i.Color = [4]float32{1, 0, 0, 0.4} }, false},
+		{"no normals (flood plot)", func(i *renderer.DrawItem) { i.Normals = nil }, false},
+		{"a line, not a triangle", func(i *renderer.DrawItem) { i.Primitive = renderer.Lines }, false},
+	}
+	for _, c := range cases {
+		item := base
+		c.mut(&item)
+		if got := isSolidOnTopTriangle(item); got != c.want {
+			t.Errorf("%s: isSolidOnTopTriangle = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
 func TestFlattenLinesTolerateMissingNormals(t *testing.T) {
 	m := Flatten(renderer.DrawList{Items: []renderer.DrawItem{lineItem()}})
 	// Normal slot (floats 3..6) should be zero, not a panic / garbage.


### PR DESCRIPTION
## What

The CalculiX FEA add-in draws fixed-support cubes and load arrows as **OnTop solid triangle meshes** through the client-graphics API. Every OnTop triangle was drawn in one pass with `depthCompareOp = ALWAYS` and depth writes **disabled**, so the glyph triangles could not self-occlude: with back-face culling off, the last triangle drawn per pixel won arbitrarily — a cube rendered as a scatter of random faces, an arrow as a jagged shell.

This is the issue reported in #1489: *"those faces … z-depth issue … the blue boxes and red arrows also do not look correct"*.

## Why

The on-top pass is correct for **flat** overlays (burn-through lines, translucent preview ghosts, heatmap flood plots) but wrong for **solid** 3D meshes, which need real depth testing among their own triangles to read as solids.

## How

Split the on-top triangle stream into a flat **head** and an opaque-solid **tail** (`TopTriSolidFirst`), mirroring the shaded stream's existing opaque/depth-biased split:

- Opaque, normal-bearing OnTop triangles (the glyphs) → the tail. The native pass **clears the depth buffer once** (so they still sit on top of the model), then draws the tail **depth-tested + lit** through the shaded pipeline. Each glyph now self-occludes and reads as a real solid.
- Translucent on-top overlays (feature-preview ghosts, face highlights) and normal-less flat overlays (flood plots) stay on the **unchanged** flat burn-through path, drawn *under* the glyphs.

Threaded through both the legacy and the instanced (ADR-0038) draw paths.

## Verification

Live offscreen capture — an 8×2×2 box with per-face-colored support cubes (left) and load arrows (right), driven through the real `DecodeGroup → Store.Set → DrawChrome` path:

| before | after |
|---|---|
| cubes = scatter of random single-face tiles; arrows = jagged shells | cubes = solid shaded self-occluding boxes; arrows = clean solid cones — all still on top of the model |

Headless regression tests pin the routing:
- `viewport`: `TestFlattenSplitsSolidOnTopToTail`, `TestIsSolidOnTopTriangle` — opaque+normal-bearing on-top triangles go to the solid tail; translucent / normal-less / line / non-on-top items stay put.
- `ui`: `TestOnTopTriStreamSplitsAtSolidFirst` — the instanced path emits a flat-head record (flag 0) and a solid-tail record (flag 1) around `TopTriSolidFirst`.

`go test ./head/viewport/ ./head/ui/ ./head/internal/native/` green; `golangci-lint --new-from-rev=origin/develop` reports 0 new issues.

Closes #1489

🤖 Generated with [Claude Code](https://claude.com/claude-code)