### PR TITLE
Fix #1490: add-in dockable panel labels no longer crop (stack caption above full-width input)

### DIFF
--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -17,6 +17,7 @@ int  obk_ig_begin(const char* name);
 int  obk_ig_begin_closable(const char* name, int* open);
 void obk_ig_end(void);
 void obk_ig_text(const char* s);
+void obk_ig_text_wrapped(const char* s);
 int  obk_ig_button(const char* label);
 void obk_ig_same_line(void);
 void obk_ig_separator(void);
@@ -249,6 +250,14 @@ func Text(s string) {
 	c, free := cstr(s)
 	defer free()
 	C.obk_ig_text(c)
+}
+
+// TextWrapped draws text that wraps at the content region's right edge instead of clipping —
+// used for long add-in panel labels in a narrow docked panel (#1490).
+func TextWrapped(s string) {
+	c, free := cstr(s)
+	defer free()
+	C.obk_ig_text_wrapped(c)
 }
 
 // Button draws a button and reports whether it was clicked this frame.

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -45,6 +45,8 @@ int  obk_ig_begin_closable(const char* name, int* open) {
 }
 void obk_ig_end(void)                        { ImGui::End(); }
 void obk_ig_text(const char* s)              { ImGui::TextUnformatted(s); }
+// "%s" guard: the text is user/add-in supplied and may contain '%' — never pass it as the format.
+void obk_ig_text_wrapped(const char* s)      { ImGui::TextWrapped("%s", s); }
 int  obk_ig_button(const char* label)        { return ImGui::Button(label) ? 1 : 0; }
 void obk_ig_same_line(void)                  { ImGui::SameLine(); }
 void obk_ig_separator(void)                  { ImGui::Separator(); }

--- a/head/ui/addin_panels.go
+++ b/head/ui/addin_panels.go
@@ -123,7 +123,8 @@ func drawAddInPanelControl(s *app.Session, windowID string, index int, control w
 		native.Separator()
 	case types.PanelTextBox, types.PanelValueEditor, types.PanelComboBox:
 		buf := panelBuffer(windowID+"/"+control.ID, control.Value)
-		if native.InputText(control.Text, buf) {
+		panelFieldLabel(control.Text)
+		if native.InputText("##field", buf) {
 			s.PanelValueChanged(windowID, control.ID, bufString(buf))
 		}
 	case types.PanelCheckBox:
@@ -136,17 +137,31 @@ func drawAddInPanelControl(s *app.Session, windowID string, index int, control w
 	case types.PanelSlider:
 		v, _ := strconv.ParseFloat(control.Value, 64)
 		f := float32(v)
-		if native.SliderFloat(control.Text, &f, float32(control.Min), float32(control.Max)) {
+		panelFieldLabel(control.Text)
+		if native.SliderFloat("##field", &f, float32(control.Min), float32(control.Max)) {
 			s.PanelValueChanged(windowID, control.ID, strconv.FormatFloat(float64(f), 'g', -1, 64))
 		}
 	default: // PanelLabel (and any future kind degrades to its text)
-		native.Text(control.Text)
+		native.TextWrapped(control.Text)
 	}
 }
 
+// panelFieldLabel draws an editable control's caption on its own line above a full-width input,
+// then widens the next item to fill the panel. Add-in labels are long, descriptive captions
+// ("Pressure on loaded faces (MPa)"); ImGui's default label-to-the-RIGHT-of-the-widget layout,
+// with the widget at ~65% of the panel, cropped them against a narrow docked panel's right edge
+// (#1490). Stacking a wrapped label above a full-width input keeps the whole caption readable at
+// any panel width.
+func panelFieldLabel(text string) {
+	native.TextWrapped(text)
+	native.SetNextItemWidth(-1) // fill the panel width; the input's own label is suppressed ("##field")
+}
+
 // drawPanelDropdown renders a single-select dropdown; picking an option pushes it to the add-in.
+// The label is stacked above a full-width combo (#1490), like the other value controls.
 func drawPanelDropdown(s *app.Session, windowID string, control wire.PanelControlSpec) {
-	if !native.BeginCombo(control.Text, control.Value) {
+	panelFieldLabel(control.Text)
+	if !native.BeginCombo("##field", control.Value) {
 		return
 	}
 	for _, opt := range control.Options {

--- a/head/ui/addin_panels_test.go
+++ b/head/ui/addin_panels_test.go
@@ -3,6 +3,8 @@
 package ui
 
 import (
+	"os"
+	"regexp"
 	"testing"
 
 	"oblikovati.org/api/types"
@@ -100,5 +102,42 @@ func TestInWindowAddInPanelRendersEditableControls(t *testing.T) {
 	}
 	if _, ok := panelEditBuffers["form/name"]; !ok {
 		t.Error("text-control buffer was not seeded while rendering the panel")
+	}
+}
+
+// TestAddInPanelValueControlsStackTheirLabel is the #1490 guard: an add-in dockable panel is
+// narrow and its captions are long descriptive sentences ("Pressure on loaded faces (MPa)").
+// Passing the caption straight into an ImGui value widget draws it to the RIGHT of the
+// ~65%-wide control, so it is cropped against the panel edge. The fix stacks the caption on its
+// own line (panelFieldLabel → TextWrapped) above a full-width input, with the widget's own label
+// suppressed ("##field"). This guard fails if a value control regresses to the label-on-the-right
+// form, so the cropping cannot come back.
+func TestAddInPanelValueControlsStackTheirLabel(t *testing.T) {
+	src, err := os.ReadFile("addin_panels.go")
+	if err != nil {
+		t.Fatalf("read addin_panels.go: %v", err)
+	}
+	text := string(src)
+
+	// No value widget may take control.Text as its (right-side) label.
+	banned := map[string]*regexp.Regexp{
+		"InputText":   regexp.MustCompile(`native\.InputText\(\s*control\.Text`),
+		"SliderFloat": regexp.MustCompile(`native\.SliderFloat\(\s*control\.Text`),
+		"BeginCombo":  regexp.MustCompile(`native\.BeginCombo\(\s*control\.Text`),
+	}
+	for widget, re := range banned {
+		if re.MatchString(text) {
+			t.Errorf("addin_panels.go passes control.Text straight into native.%s — the caption draws "+
+				"to the widget's right and crops in a narrow docked panel (#1490). Stack it with "+
+				"panelFieldLabel and pass a suppressed \"##\" label instead.", widget)
+		}
+	}
+
+	// And the stacked-label helper must exist and be used by the value controls.
+	if !regexp.MustCompile(`func panelFieldLabel\(`).MatchString(text) {
+		t.Error("addin_panels.go must define panelFieldLabel (stacks a wrapped caption above a full-width input, #1490)")
+	}
+	if !regexp.MustCompile(`panelFieldLabel\(control\.Text\)`).MatchString(text) {
+		t.Error("addin_panels.go value controls must call panelFieldLabel(control.Text) (#1490)")
 	}
 }


### PR DESCRIPTION
## What

Add-in dockable windows (e.g. the **CalculiX FEA** panel) rendered each value control by passing the caption straight into the ImGui widget (`InputText`/`SliderFloat`/`BeginCombo`). ImGui draws a widget's label to its **right**, and the default item width is ~65% of the panel — so in a narrow docked panel the long descriptive captions had little room and clipped against the panel edge: *"Modes (freque…", "Max element s…", "Pressure on lo…", "Deformation s…"*. The long standalone label *"Select the fixed face first, then the loaded face(s)."* clipped too (the label case used non-wrapping `Text`).

This is the issue reported in #1490.

## How

Stack a **wrapped caption on its own line above a full-width input**:
- New `native.TextWrapped` binding (`ImGui::TextWrapped("%s", s)` — `%s` guard since the text is add-in supplied).
- New `panelFieldLabel` helper: draws the wrapped caption, then `SetNextItemWidth(-1)` to fill the panel.
- Value / slider / dropdown controls draw the caption above the widget and **suppress the widget's own label** (`"##field"`, kept unique by the existing per-control `PushIDInt`). The standalone `PanelLabel` case now wraps.
- Checkbox and button keep their conventional label-right / text-in-button form.

## Verification

Throwaway driver building a CalculiX-style panel docked right (long captions beside narrow inputs):

| before | after |
|---|---|
| inputs ~½ the panel, captions to the right clipped at the edge | each caption full and readable on its own line; the long sentence wraps; inputs/dropdowns full-width |

Tests:
- **`TestAddInPanelValueControlsStackTheirLabel`** — source-grep regression guard (mirrors the #1519 `TestParameterInputIsEnforced` guard) banning `native.{InputText,SliderFloat,BeginCombo}(control.Text` so the cropping cannot regress.
- **`TestInWindowAddInPanelRendersEditableControls`** (existing) — renders every control kind through a real frame.

`go test ./head/ui/ ./head/internal/native/ ./head/viewport/` green; `golangci-lint --new-from-rev=origin/develop` reports 0 new issues.

Closes #1490

🤖 Generated with [Claude Code](https://claude.com/claude-code)