### PR TITLE
ADR-0043 + topological-naming resolution guard (P0 of #1539)

### DIFF
--- a/architecture/decisions/ADR-0043-generalized-provenance-naming.md
+++ b/architecture/decisions/ADR-0043-generalized-provenance-naming.md
@@ -1,0 +1,129 @@
+# ADR-0043 — Generalized provenance naming for all generated topology
+
+**Status:** Accepted — design (2026-06-28). **Builds on / refines:** the M31 topological-naming
+work — provenance naming for the planar boolean (`kernel/brep/boolean_provenance.go`,
+`boolean_nonmanifold.go`; #1152/#1153/#1155), tiered binding (`model/identity/binding.go`, F06),
+versioned encoding (F07) — and [ADR-0027](ADR-0027-curved-face-boolean.md) (curved boolean),
+[ADR-0040](ADR-0040-external-geometric-references.md) (external geometric references).
+**Touches (when implemented):** `kernel/topo` (a new shared provenance seam), the entity-
+generating operations in `kernel/ops/*` and `kernel/brep/*`, and the dress-up resolution in
+`model/feature/*`.
+
+## Context
+
+Every realized edge/face/vertex of the running body carries a **lineage reference key** — a kind
+byte plus a `Feature:Role#Index` string (`kernel/topo/lineage.go`) — and feature selections
+(fillet, chamfer, shell, draft, hole/boss faces, …) persist that key and re-resolve it each
+recompute by exact match (`Body.FindEdgeByKey` / `FindFaceByKey`, via `resolveEdges`).
+
+A reference is only as stable as the **name**. The M31 work established the robust rule for the
+planar boolean (Kripac 1997): name a generated edge by the **two parent faces whose crossing
+produced it**, captured from the ORIGINAL faces (before any split) and disambiguated, when a pair
+recurs, by a **transform-invariant geometric characteristic** (position along the parents'
+intersection line) rather than a build-order counter. That name survives an unrelated upstream
+edit that reorders the stitch — the defining property of a topological name.
+
+**The gap:** that robust scheme was applied **only to the planar boolean**. Every other operation
+that generates topology still mints **construction-order ordinal names** whose index is a build
+counter — fragile by exactly the mechanism M31 fixed for booleans:
+
+| Site | Generates | Current scheme |
+|---|---|---|
+| `kernel/ops/assemble_curved.go:106` | fillet + curved-boolean assembly edges | `Tok(tag,"e",len(c.edges))` |
+| `kernel/ops/delete_face.go:282` | delete-face stitch edges | `Tok("delface","e",i)` over a map |
+| `kernel/ops/csg_body.go:417` | BSP/CSG edges | `Tok(feat,"edge",i)` |
+| `kernel/ops/ruled_surface.go`, `wire_offset_corners.go`, `fillet_rim_build.go`, … | ruled/wire/rim edges | per-op ordinals |
+| `model/feature/dressup.go` | every fillet/chamfer's result | hardcoded `"fillet"`/`"chamfer"` tag → all features of a kind **share one namespace** |
+| `kernel/topo/body.go` `FindEdgeByKey` etc. | resolution | silent **first-match**, no ambiguity guard |
+
+These do not all surface as user bugs today (e.g. `fillet:e#13` is stable in #1536 because the
+curved blend's build order happens to be deterministic for that geometry), but each is a latent
+wrong-rebind waiting for an upstream edit that reorders construction — the class behind #1494 /
+#1536 / #1537.
+
+## Decision
+
+Make provenance naming **the single naming discipline for all generated topology**, generalizing
+the boolean's mechanism out of `kernel/brep` into a reusable seam, and retrofitting every
+entity-generating operation to it.
+
+### 1. A shared provenance seam (`kernel/topo/provenance`)
+
+Lift the three boolean-private pieces into a small reusable package, behaviour-preserving:
+
+- **`NameByParents(parents []topo.Lineage, rank int) topo.Lineage`** — generalizes
+  `intersectionLineage`: a canonical, order-independent concatenation of the parent lineages
+  (sorted by `Key()`), separated by a reserved token, with `rank>0` appended when several entities
+  share one parent set. The parents are *original* entities, so the name is invariant to later
+  subdivision and to build/stitch order.
+- **`RankByAxis(entities, parentAxis)`** — generalizes `rankSamePairEdges`/`lineCharacteristic`:
+  order entities that share a parent set by a transform-invariant characteristic along a parent-
+  derived axis (equivariant under rigid motion), never by a build counter.
+- **`Witness` resolution** — generalizes `edgeParents`: assign a built entity its parent set by
+  geometric containment (midpoint-on-segment for edges; centroid-in-region for faces) against the
+  op's recorded provenance.
+
+The boolean is refactored to consume this seam (its tests stay green), proving the extraction.
+
+### 2. Per-operation provenance capture
+
+Each op records, for every entity it generates, the **generating parent set** — the input
+entities that produced it. The parent set is op-specific but always *original* lineages:
+
+| Operation | Generated entity | Generating parent set |
+|---|---|---|
+| Boolean (planar/curved) | intersection edge | the two crossing faces *(done; curved = Phase 4)* |
+| **Fillet** | cylinder/torus/sphere blend face | the filleted edge (or its vertex, for a corner blend) |
+| **Fillet** | tangent edge | (filleted edge, adjacent original face) |
+| **Chamfer** | bevel face / edges | the chamfered edge + adjacent faces |
+| **Delete-face** | stitch edge | the bordering surviving faces |
+| **CSG/BSP** | cut edge | the two BSP half-space faces that bound it |
+| Ruled / wire-offset / rim | rail/ruling edge | the generating section/wire entity |
+
+An entity with no parent (a genuinely new free vertex) keeps an ordinal fallback under the op's
+**unique feature tag** (see 3), which the uniqueness guard (4) backstops.
+
+### 3. Per-feature unique lineage tags
+
+`model/feature` passes each feature's **unique name** (`Fillet1`, `Fillet2`, … from
+`PartFeatures.UniqueName`) as the lineage tag, replacing the hardcoded `"fillet"`/`"chamfer"`
+constants, so two features of the same kind never share a namespace.
+
+### 4. A resolution uniqueness guard
+
+`FindEdgeByKey`/`FindFaceByKey`/`FindVertexByKey` and `resolveEdges`/`resolveFaceSet` detect **more
+than one** match for a key and surface a clear error (or route to the F06 tiered binding to
+disambiguate), instead of silently returning the first. This is the universal safety net: any
+residual naming collision becomes an honest failure, never a wrong-rebind.
+
+## Consequences
+
+- **Buys:** references survive upstream edits across *all* operations, not just booleans; the
+  fillet-stack class of bugs (#1494/#1536/#1537) is closed at the root; silent wrong-rebinds become
+  honest errors; one naming discipline instead of two.
+- **Costs:** each op's geometry builder must thread parent provenance through — a delicate change to
+  the kernel's most intricate code (the curved blend). Done op-by-op behind the shared seam, each
+  gated by a cross-edit stability test (the name must survive an upstream edit that reorders the
+  build). Names get longer (parent concatenations); the F07 versioned encoding already absorbs this.
+- **Rejected:** *transform-invariant geometric ordinals everywhere* (sort entities by a canonical
+  geometric key) — stable under build/stitch reordering but NOT under geometry-moving edits that
+  reorder the sort, so not a true topological name. *Guard-only* — turns wrong-rebinds into errors
+  but leaves the names fragile. Both are strictly weaker than provenance and were folded in only as
+  the no-parent fallback (geometric ordinal) and the safety net (guard).
+
+## Scope & phasing (tracked as a milestone)
+
+- **P0 — shared seam.** Extract `kernel/topo/provenance`; refactor the boolean onto it (no
+  behaviour change). The uniqueness guard (4) and per-feature unique tags (3), which are
+  independent of any single op.
+- **P1 — fillet.** Thread parent provenance through the rolling-ball blend → `assemble_curved.go`.
+  The user's pain point; gated by a cross-edit-stability regression test.
+- **P2 — chamfer.** Same seam, bevel provenance.
+- **P3 — delete-face, CSG/BSP.** Stitch/cut-edge provenance.
+- **P4 — curved boolean.** Bring `curvedbool` onto the shared seam (it shares `assemble_curved`).
+- **P5 — remaining generators** (ruled, sweep, wire-offset, rim, split, steinmetz, halfspace).
+- **P6 — integrate with F06 tiered binding & F07 encoding**; retire the ordinal fallbacks that are
+  no longer reachable.
+
+Each phase is one or more PRs; each adds a regression test that mutates an upstream feature and
+asserts the downstream selection still binds to the same physical entity.

--- a/kernel/ops/resolve_faceset_guard_test.go
+++ b/kernel/ops/resolve_faceset_guard_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// TestResolveFaceSetRejectsAmbiguousKey is the ADR-0043 guard for face-set resolution (shell /
+// draft): a key that binds to more than one face is a topological-naming collision and must fail
+// honestly rather than silently shelling an unintended face. A clean key still resolves; a lost
+// one reports honestly.
+func TestResolveFaceSetRejectsAmbiguousKey(t *testing.T) {
+	bld := topo.NewBuilder(false, topo.NewLineage(topo.Tok("f", "body", 0)))
+	mk := func(x, y float64, i int) *topo.Vertex {
+		return bld.AddVertex(math.P3(x, y, 0), topo.NewLineage(topo.Tok("f", "vertex", i)))
+	}
+	pl, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	tri := func(a, b, c *topo.Vertex, e int, lin topo.Lineage) *topo.Face {
+		ab := bld.AddEdge(geom.NewLineSegment(a.Point(), b.Point()), a, b, topo.NewLineage(topo.Tok("f", "edge", e)))
+		bc := bld.AddEdge(geom.NewLineSegment(b.Point(), c.Point()), b, c, topo.NewLineage(topo.Tok("f", "edge", e+1)))
+		ca := bld.AddEdge(geom.NewLineSegment(c.Point(), a.Point()), c, a, topo.NewLineage(topo.Tok("f", "edge", e+2)))
+		return bld.AddFace(pl, lin, topo.OuterLoop(topo.Fwd(ab), topo.Fwd(bc), topo.Fwd(ca)))
+	}
+	dup := topo.NewLineage(topo.Tok("f", "face", 0))
+	f1 := tri(mk(0, 0, 0), mk(1, 0, 1), mk(0, 1, 2), 0, dup)
+	tri(mk(3, 0, 3), mk(4, 0, 4), mk(3, 1, 5), 3, dup)
+	uniq := tri(mk(6, 0, 6), mk(7, 0, 7), mk(6, 1, 8), 6, topo.NewLineage(topo.Tok("f", "face", 1)))
+	body := bld.Build()
+
+	if _, err := resolveFaceSet(body, [][]byte{uniq.ReferenceKey()}); err != nil {
+		t.Fatalf("unique face key should resolve, got %v", err)
+	}
+	_, err := resolveFaceSet(body, [][]byte{f1.ReferenceKey()})
+	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Errorf("ambiguous face key should be rejected, got %v", err)
+	}
+	if _, err := resolveFaceSet(body, [][]byte{{0x01, 'z'}}); err == nil || !strings.Contains(err.Error(), "lost") {
+		t.Errorf("missing face key should report lost, got %v", err)
+	}
+}

--- a/kernel/ops/shell.go
+++ b/kernel/ops/shell.go
@@ -44,11 +44,17 @@ func shellFacePlane(f *topo.Face, removed map[uint64]bool, t float64) geom.Plane
 func resolveFaceSet(solid *topo.Body, keys [][]byte) (map[uint64]bool, error) {
 	set := make(map[uint64]bool, len(keys))
 	for _, k := range keys {
-		f, ok := solid.FindFaceByKey(k)
-		if !ok {
+		// ADR-0043 resolution guard: a key must bind to exactly one face. >1 is a topological-
+		// naming collision, surfaced as an honest error rather than a silent first-match.
+		match := solid.FacesByKey(k)
+		switch len(match) {
+		case 1:
+			set[match[0].ID()] = true
+		case 0:
 			return nil, fmt.Errorf("face reference lost: %x", k)
+		default:
+			return nil, fmt.Errorf("face reference %x is ambiguous — it matches %d faces (a topological-naming collision)", k, len(match))
 		}
-		set[f.ID()] = true
 	}
 	return set, nil
 }

--- a/kernel/topo/body.go
+++ b/kernel/topo/body.go
@@ -154,6 +154,30 @@ func (b *Body) FindEdgeByKey(key []byte) (*Edge, bool) {
 	return nil, false
 }
 
+// EdgesByKey returns EVERY edge whose reference key matches — normally one. More than one means a
+// topological-naming collision (two distinct edges minted the same lineage), the wrong-rebind
+// hazard ADR-0043's resolution guard turns into an honest error instead of a silent first-match.
+func (b *Body) EdgesByKey(key []byte) []*Edge {
+	var out []*Edge
+	for _, e := range b.Edges() {
+		if bytes.Equal(e.ReferenceKey(), key) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// FacesByKey returns EVERY face whose reference key matches — the face counterpart of [EdgesByKey].
+func (b *Body) FacesByKey(key []byte) []*Face {
+	var out []*Face
+	for _, f := range b.Faces() {
+		if bytes.Equal(f.ReferenceKey(), key) {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
 // FindVertexByKey re-binds a vertex reference key by lineage — used to resolve a picked
 // B-rep vertex as a work-feature point input after the body is rebuilt.
 func (b *Body) FindVertexByKey(key []byte) (*Vertex, bool) {

--- a/kernel/topo/edges_by_key_test.go
+++ b/kernel/topo/edges_by_key_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package topo
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// TestEdgesByKeyDetectsCollision pins ADR-0043's resolution-guard primitive: EdgesByKey returns
+// EVERY edge sharing a reference key, so a caller can tell a clean 1:1 bind from a topological-
+// naming collision (two distinct edges minted the same lineage) instead of silently taking the
+// first. A correct body binds 1; a colliding body binds >1.
+func TestEdgesByKeyDetectsCollision(t *testing.T) {
+	bld := NewBuilder(false, NewLineage(Tok("f", "body", 0)))
+	a := bld.AddVertex(math.P3(0, 0, 0), NewLineage(Tok("f", "vertex", 0)))
+	b := bld.AddVertex(math.P3(1, 0, 0), NewLineage(Tok("f", "vertex", 1)))
+	c := bld.AddVertex(math.P3(0, 1, 0), NewLineage(Tok("f", "vertex", 2)))
+
+	dup := NewLineage(Tok("f", "edge", 0)) // ab and bc deliberately share one lineage ⇒ one key
+	ab := bld.AddEdge(geom.NewLineSegment(a.Point(), b.Point()), a, b, dup)
+	bc := bld.AddEdge(geom.NewLineSegment(b.Point(), c.Point()), b, c, dup)
+	ca := bld.AddEdge(geom.NewLineSegment(c.Point(), a.Point()), c, a, NewLineage(Tok("f", "edge", 1)))
+	pl, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	bld.AddFace(pl, NewLineage(Tok("f", "face", 0)), OuterLoop(Fwd(ab), Fwd(bc), Fwd(ca)))
+	body := bld.Build()
+
+	if got := body.EdgesByKey(ca.ReferenceKey()); len(got) != 1 {
+		t.Errorf("unique key bound %d edges, want 1", len(got))
+	}
+	if got := body.EdgesByKey(ab.ReferenceKey()); len(got) != 2 {
+		t.Errorf("colliding key bound %d edges, want 2 (ab and bc share a lineage)", len(got))
+	}
+}
+
+// TestFacesByKeyDetectsCollision is the face counterpart: FacesByKey returns every face sharing a
+// reference key, so a collision (two faces minted the same lineage) is detectable (ADR-0043).
+func TestFacesByKeyDetectsCollision(t *testing.T) {
+	bld := NewBuilder(false, NewLineage(Tok("f", "body", 0)))
+	mk := func(x, y float64, i int) *Vertex {
+		return bld.AddVertex(math.P3(x, y, 0), NewLineage(Tok("f", "vertex", i)))
+	}
+	pl, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	tri := func(a, b, c *Vertex, e int, lin Lineage) *Face {
+		ab := bld.AddEdge(geom.NewLineSegment(a.Point(), b.Point()), a, b, NewLineage(Tok("f", "edge", e)))
+		bc := bld.AddEdge(geom.NewLineSegment(b.Point(), c.Point()), b, c, NewLineage(Tok("f", "edge", e+1)))
+		ca := bld.AddEdge(geom.NewLineSegment(c.Point(), a.Point()), c, a, NewLineage(Tok("f", "edge", e+2)))
+		return bld.AddFace(pl, lin, OuterLoop(Fwd(ab), Fwd(bc), Fwd(ca)))
+	}
+	dup := NewLineage(Tok("f", "face", 0)) // two faces deliberately share one lineage ⇒ one key
+	f1 := tri(mk(0, 0, 0), mk(1, 0, 1), mk(0, 1, 2), 0, dup)
+	tri(mk(3, 0, 3), mk(4, 0, 4), mk(3, 1, 5), 3, dup)
+	uniq := tri(mk(6, 0, 6), mk(7, 0, 7), mk(6, 1, 8), 6, NewLineage(Tok("f", "face", 1)))
+	body := bld.Build()
+
+	if got := body.FacesByKey(uniq.ReferenceKey()); len(got) != 1 {
+		t.Errorf("unique face key bound %d faces, want 1", len(got))
+	}
+	if got := body.FacesByKey(f1.ReferenceKey()); len(got) != 2 {
+		t.Errorf("colliding face key bound %d faces, want 2", len(got))
+	}
+}

--- a/model/feature/chamfer.go
+++ b/model/feature/chamfer.go
@@ -154,13 +154,33 @@ func applyChamferTools(work *topo.Body, tools []wedgeOp) (*topo.Body, error) {
 func resolveEdges(body *topo.Body, keys [][]byte) ([]*topo.Edge, error) {
 	edges := make([]*topo.Edge, len(keys))
 	for i, k := range keys {
-		edge, ok := body.FindEdgeByKey(k)
-		if !ok {
-			return nil, fmt.Errorf("chamfer: edge reference lost")
+		// ADR-0043 resolution guard: a key must bind to EXACTLY one edge. Zero means the reference
+		// was lost; more than one means a topological-naming collision (two edges minted the same
+		// lineage) — surfaced as an honest error rather than a silent first-match wrong-rebind that
+		// would dress up an unintended edge (the #1536 hazard class).
+		match := body.EdgesByKey(k)
+		switch len(match) {
+		case 1:
+			edges[i] = match[0]
+		case 0:
+			return nil, fmt.Errorf("dress-up: edge reference %q lost (no edge with that lineage on the running body)", keyText(k))
+		default:
+			return nil, fmt.Errorf("dress-up: edge reference %q is ambiguous — it matches %d edges (a topological-naming collision); the selection cannot be resolved safely", keyText(k), len(match))
 		}
-		edges[i] = edge
 	}
 	return edges, nil
+}
+
+// keyText renders a reference key as its readable lineage string (the leading kind byte stripped)
+// for diagnostics, falling back to a hex-free best effort for an empty key.
+func keyText(k []byte) string {
+	if len(k) == 0 {
+		return "<empty>"
+	}
+	if k[0] < 0x20 {
+		return string(k[1:])
+	}
+	return string(k)
 }
 
 // chamferSetbacks resolves a chamfer definition's mode into the two face setbacks (d1 along

--- a/model/feature/fillet_repro1536_test.go
+++ b/model/feature/fillet_repro1536_test.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// keyString returns an edge reference key as a readable string (the \x02 kind byte stripped).
+func keyString1536(k []byte) string {
+	if len(k) > 0 && k[0] < 0x20 {
+		return string(k[1:])
+	}
+	return string(k)
+}
+
+// TestRepro1536SecondFilletEdgeKey instruments the #1536 scenario: a first fillet on
+// Extrusion1:side-edge#2, then a second fillet on the OPPOSITE vertical edge whose key was
+// captured from the displayed (filleted) body. It reports (a) whether any fillet:e#N key collides
+// onto more than one edge, and (b) whether the second fillet keeps the first fillet's geometry.
+func TestRepro1536SecondFilletEdgeKey(t *testing.T) {
+	poly := []math.Point2{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4.89099465009204, Y: 5.1416568653588115}, {X: 0, Y: 3}}
+	box := buildPrism(poly, sketch.XYPlane(), span{near: 0, far: 5}, 0, "Extrusion1")
+
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(box)
+
+	// First fillet on side-edge#2 (corner 2, the far-out corner), exactly as the report stored it.
+	edge1 := edgeByKeySuffix1536(t, box, "Extrusion1:side-edge#2")
+	f1 := NewDressUpFeatures(fs).AddFillet([][]byte{edge1}, func() float64 { return 1 })
+	fs.Recompute()
+	if !f1.Health().OK() {
+		t.Fatalf("first fillet sick: %+v", f1.Health())
+	}
+	res1 := fs.Result()[0]
+	if n := cylinderFaces1494(res1); n != 1 {
+		t.Fatalf("after first fillet: %d cylinder faces, want 1", n)
+	}
+
+	// Report key collisions on the first-fillet body: any key bound to >1 edge is the #1536 hazard.
+	collisions := map[string]int{}
+	for _, e := range res1.Edges() {
+		collisions[keyString1536(e.ReferenceKey())]++
+	}
+	dupes := 0
+	for k, c := range collisions {
+		if c > 1 {
+			dupes++
+			t.Logf("COLLISION: key %q is bound to %d edges", k, c)
+		}
+	}
+	t.Logf("first-fillet body: %d edges, %d distinct keys, %d colliding keys", len(res1.Edges()), len(collisions), dupes)
+
+	// What does fillet:e#13 (the reported second-fillet pick) resolve to, and is it the opposite
+	// vertical edge or something on the first fillet?
+	for _, e := range res1.Edges() {
+		if keyString1536(e.ReferenceKey()) == "fillet:e#13" {
+			a, b := e.StartVertex().Point(), e.EndVertex().Point()
+			_, isLine := e.Geometry().(geom.LineSegment)
+			t.Logf("fillet:e#13 → edge %v→%v (line=%v)", a, b, isLine)
+		}
+	}
+
+	// Now stack the second fillet on the EXACT edge the report stored — fillet:e#13, captured from
+	// the displayed (first-fillet) body — and recompute the whole tree.
+	edge2 := edgeByKeySuffix1536(t, res1, "fillet:e#13")
+	f2 := NewDressUpFeatures(fs).AddFillet([][]byte{edge2}, func() float64 { return 1 })
+	fs.Recompute()
+
+	if !f2.Health().OK() {
+		t.Fatalf("second fillet sick: %+v", f2.Health())
+	}
+	res2 := fs.Result()[0]
+	if r := ops.Validate(res2); !r.Valid || !res2.IsSolid() {
+		t.Fatalf("after second fillet: not a valid solid: %+v", r.Issues)
+	}
+	if n := cylinderFaces1494(res2); n != 2 {
+		t.Errorf("after second fillet: %d cylinder faces, want 2 (the first fillet was broken/re-used)", n)
+	}
+}
+
+// TestRepro1536NamingStability probes whether the fillet's construction-order edge naming
+// (assembleBody → Tok("fillet","e",len(c.edges))) is STABLE across an upstream edit — the core
+// property a topological-naming system must guarantee. It builds the first fillet at several
+// radii and reports which physical edge "fillet:e#13" maps to each time. If the same key names a
+// different edge as the radius changes, a stored second-fillet reference silently rebinds to the
+// wrong edge after any upstream edit — the systemic fragility behind #1536/#1537.
+func TestRepro1536NamingStability(t *testing.T) {
+	poly := []math.Point2{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4.89099465009204, Y: 5.1416568653588115}, {X: 0, Y: 3}}
+	foot := func(radius float64) (math.Point3, bool) {
+		box := buildPrism(poly, sketch.XYPlane(), span{near: 0, far: 5}, 0, "Extrusion1")
+		fs := NewPartFeatures(nil, nil)
+		NewBaseFeatures(fs).AddBase(box)
+		edge1 := edgeByKeySuffix1536(t, box, "Extrusion1:side-edge#2")
+		NewDressUpFeatures(fs).AddFillet([][]byte{edge1}, func() float64 { return radius })
+		fs.Recompute()
+		for _, e := range fs.Result()[0].Edges() {
+			if keyString1536(e.ReferenceKey()) == "fillet:e#13" {
+				return e.StartVertex().Point(), true
+			}
+		}
+		return math.Point3{}, false
+	}
+
+	var ref math.Point3
+	for i, r := range []float64{0.5, 1.0, 1.5, 2.0} {
+		p, ok := foot(r)
+		if !ok {
+			t.Logf("radius %.1f: no fillet:e#13", r)
+			continue
+		}
+		t.Logf("radius %.1f: fillet:e#13 foot = %v", r, p)
+		if i == 0 {
+			ref = p
+		} else if p.DistanceTo(ref) > 1e-6 {
+			t.Errorf("UNSTABLE NAMING: fillet:e#13 names a DIFFERENT edge at radius %.1f (%v vs %v at 0.5) "+
+				"— a stored reference silently rebinds after an upstream edit (#1536 systemic flaw)", r, p, ref)
+		}
+	}
+}
+
+// TestRepro1536PreviewResult drives the live-preview seam exactly as the fillet tool does: it
+// builds the first fillet, then asks PreviewResult for a DRAFT second fillet on fillet:e#13 and
+// checks the previewed body keeps the first fillet (2 cylinders) rather than dropping/re-cutting
+// it. A wrong preview here is what shows the user TWO red wedges in #1536.
+func TestRepro1536PreviewResult(t *testing.T) {
+	poly := []math.Point2{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4.89099465009204, Y: 5.1416568653588115}, {X: 0, Y: 3}}
+	box := buildPrism(poly, sketch.XYPlane(), span{near: 0, far: 5}, 0, "Extrusion1")
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(box)
+	edge1 := edgeByKeySuffix1536(t, box, "Extrusion1:side-edge#2")
+	NewDressUpFeatures(fs).AddFillet([][]byte{edge1}, func() float64 { return 1 })
+	fs.Recompute()
+	base := fs.Result()[0]
+
+	draft := &FilletFeature{def: &FilletDefinition{
+		EdgeKeys: [][]byte{edgeByKeySuffix1536(t, base, "fillet:e#13")},
+		Radius:   func() float64 { return 1 },
+	}}
+	preview, err := fs.PreviewResult(draft)
+	if err != nil {
+		t.Fatalf("PreviewResult: %v", err)
+	}
+	if n := cylinderFaces1494(preview[0]); n != 2 {
+		t.Errorf("preview body has %d cylinder faces, want 2 (first fillet + previewed second)", n)
+	}
+}
+
+// edgeByKeySuffix1536 returns the reference key of the body edge whose readable key equals want.
+func edgeByKeySuffix1536(t *testing.T, b *topo.Body, want string) []byte {
+	t.Helper()
+	for _, e := range b.Edges() {
+		if keyString1536(e.ReferenceKey()) == want {
+			return e.ReferenceKey()
+		}
+	}
+	t.Fatalf("no edge with key %q", want)
+	return nil
+}

--- a/model/feature/resolve_guard_test.go
+++ b/model/feature/resolve_guard_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// collidingTriBody builds a one-triangle body whose edges ab and bc deliberately share one
+// lineage (and therefore one reference key), so a key resolves ambiguously — the topological-
+// naming collision ADR-0043's guard must reject.
+func collidingTriBody() (body *topo.Body, dupKey, uniqueKey []byte) {
+	bld := topo.NewBuilder(false, topo.NewLineage(topo.Tok("f", "body", 0)))
+	a := bld.AddVertex(math.P3(0, 0, 0), topo.NewLineage(topo.Tok("f", "vertex", 0)))
+	b := bld.AddVertex(math.P3(1, 0, 0), topo.NewLineage(topo.Tok("f", "vertex", 1)))
+	c := bld.AddVertex(math.P3(0, 1, 0), topo.NewLineage(topo.Tok("f", "vertex", 2)))
+	dup := topo.NewLineage(topo.Tok("f", "edge", 0))
+	ab := bld.AddEdge(geom.NewLineSegment(a.Point(), b.Point()), a, b, dup)
+	bc := bld.AddEdge(geom.NewLineSegment(b.Point(), c.Point()), b, c, dup)
+	ca := bld.AddEdge(geom.NewLineSegment(c.Point(), a.Point()), c, a, topo.NewLineage(topo.Tok("f", "edge", 1)))
+	pl, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	bld.AddFace(pl, topo.NewLineage(topo.Tok("f", "face", 0)), topo.OuterLoop(topo.Fwd(ab), topo.Fwd(bc), topo.Fwd(ca)))
+	return bld.Build(), ab.ReferenceKey(), ca.ReferenceKey()
+}
+
+// TestResolveEdgesRejectsAmbiguousKey is the ADR-0043 resolution guard: a dress-up selection key
+// that binds to MORE THAN ONE edge (a naming collision) must fail with a clear error instead of
+// silently dressing up the first match — the wrong-rebind that breaks an unintended edge (#1536
+// hazard class). A clean key still resolves, and a lost key reports honestly.
+func TestResolveEdgesRejectsAmbiguousKey(t *testing.T) {
+	body, dupKey, uniqueKey := collidingTriBody()
+
+	if _, err := resolveEdges(body, [][]byte{uniqueKey}); err != nil {
+		t.Fatalf("unique key should resolve, got %v", err)
+	}
+
+	_, err := resolveEdges(body, [][]byte{dupKey})
+	if err == nil {
+		t.Fatal("ambiguous key resolved without error — the guard let a naming collision through")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") {
+		t.Errorf("error %q should name the ambiguity", err)
+	}
+
+	lost := topo.NewLineage(topo.Tok("ghost", "edge", 99))
+	_, err = resolveEdges(body, [][]byte{appendKindByte(lost)})
+	if err == nil || !strings.Contains(err.Error(), "lost") {
+		t.Errorf("a missing key should report 'lost', got %v", err)
+	}
+}
+
+// appendKindByte renders an edge lineage as a reference key (kind byte 0x02 + lineage string),
+// matching topo.referenceKey(KindEdge, …) for a key the body cannot contain.
+func appendKindByte(lin topo.Lineage) []byte {
+	return append([]byte{0x02}, lin.Key()...)
+}
+
+// TestKeyText pins the diagnostic key renderer used in the resolution-guard errors: an empty key
+// reads "<empty>", a real key has its leading kind byte stripped, and a key without a kind byte
+// passes through unchanged.
+func TestKeyText(t *testing.T) {
+	if got := keyText(nil); got != "<empty>" {
+		t.Errorf("keyText(nil) = %q, want <empty>", got)
+	}
+	if got := keyText([]byte{0x02, 'a', 'b'}); got != "ab" {
+		t.Errorf("keyText(kind+ab) = %q, want ab", got)
+	}
+	if got := keyText([]byte("plain")); got != "plain" {
+		t.Errorf("keyText(plain) = %q, want plain", got)
+	}
+}


### PR DESCRIPTION
## What

First, non-breaking phase of the **generalized provenance-naming** milestone (ADR-0043, epic #1539): the universal **resolution uniqueness guard**.

## Why

Investigating the fillet-stack reports (#1536/#1537) showed they're **already fixed by #1534** — the exact reported document recomputes, previews, and renders correctly, with stable naming and **zero** key collisions (regression tests added here). But it exposed a real systemic gap: the robust provenance-based naming (M31, Kripac face-pair) exists **only for the planar boolean**, while every other generator (fillet, chamfer, delete-face, CSG, …) still mints **construction-order ordinal names** that renumber when an upstream edit reorders the build — and resolution silently returns the **first** match on a collision, which would dress up an unintended edge.

**ADR-0043** records the decision to make provenance naming the single naming discipline for all generated topology, with a phased plan (P0…P6) tracked in #1539. This PR lands **P0's safety net** — no names change, so no document migration.

## How

- `topo.Body.EdgesByKey` / `FacesByKey` return **every** entity matching a key.
- `resolveEdges` (dress-up) and `resolveFaceSet` (shell/draft) now require **exactly one** match: zero → honest *"reference lost"*; more than one → honest *"ambiguous — topological-naming collision"*, instead of a silent first-match wrong-rebind (the #1536 hazard class).

## Verification

- The whole kernel + model suite is green — the guard **never fires on a correctly-named body** (so it's safe to enforce).
- New regression tests: `TestEdgesByKeyDetectsCollision`, `TestResolveEdgesRejectsAmbiguousKey` (a deliberately-colliding body is rejected; clean/lost keys behave), and `TestRepro1536*` (the #1536/#1537 scenario — recompute, naming stability across radius edits, and the live-preview seam — all correct, proving the reports are resolved).
- `golangci-lint --new-from-rev=origin/develop`: 0 new issues.

Subsequent phases (P1 fillet provenance … P6) follow as tracked PRs under #1539.

Refs #1539, #1536, #1537

🤖 Generated with [Claude Code](https://claude.com/claude-code)