### PR TITLE
P0b: shared NameByParents provenance seam (ADR-0043, #1539)

### DIFF
--- a/kernel/brep/boolean_provenance.go
+++ b/kernel/brep/boolean_provenance.go
@@ -109,13 +109,10 @@ var intersectionSep = topo.Tok("brep", "x", 0)
 // the common one-edge-per-pair case; a second edge sharing the same parent pair (a face crossed
 // twice) gets dup>0, an interim disambiguator the geometric one in F05 (#1155) replaces.
 func intersectionLineage(lo, hi topo.Lineage, dup int) topo.Lineage {
-	toks := append([]topo.LineageToken{}, lo.Tokens()...)
-	toks = append(toks, intersectionSep)
-	toks = append(toks, hi.Tokens()...)
-	if dup > 0 {
-		toks = append(toks, topo.Tok("brep", "seg", dup))
-	}
-	return topo.NewLineage(toks...)
+	// The shared provenance composer (ADR-0043): lo/hi are already canonical (canonicalPair), so
+	// NameByParents's canonical ordering is a no-op here and the bytes are unchanged — lo / brep:x#0
+	// / hi [ / brep:seg#dup].
+	return topo.NameByParents([]topo.Lineage{lo, hi}, intersectionSep, topo.Tok("brep", "seg", 0), dup)
 }
 
 // pairLineDir returns the intersection line's direction for the parent pair (lo, hi), derived

--- a/kernel/topo/provenance.go
+++ b/kernel/topo/provenance.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package topo
+
+import (
+	"bytes"
+	"sort"
+)
+
+// Provenance naming (ADR-0043). A derived entity — an edge a boolean cuts, a fillet's tangent
+// edge, a delete-face stitch edge — should be named by the INPUT entities that GENERATED it, not
+// by a construction-order counter. A parent-derived name survives an unrelated upstream edit that
+// reorders the build/stitch (the property an ordinal index lacks), because the parents' lineages
+// are themselves stable. The boolean established this for face-pair intersection edges
+// (kernel/brep); this is the shared, op-agnostic mechanism every generator names through.
+
+// NameByParents composes a provenance lineage from the lineages of the entities that generated a
+// derived entity. The parents are CANONICALLY ORDERED (by serialized key) so the name is
+// independent of the order the generator happened to discover them in (operand order, stitch
+// order); their token runs are concatenated with sep between each parent; and rank, when > 0, is
+// appended as a disambiguator token carrying rankSeed's feature/role — distinguishing several
+// derived entities that share the same parents (e.g. one parent pair crossed twice), ordered by a
+// transform-invariant geometric characteristic the caller computes, never by a build counter.
+//
+// sep and rankSeed must carry no '/' ':' '#' in their feature/role (they are ids by convention),
+// so the composite key parses unambiguously back into parent token runs.
+//
+// Example (a boolean intersection edge of two faces): NameByParents([]Lineage{faceA, faceB},
+// Tok("brep","x",0), Tok("brep","seg",0), 0) → faceA / brep:x#0 / faceB.
+func NameByParents(parents []Lineage, sep, rankSeed LineageToken, rank int) Lineage {
+	ordered := append([]Lineage(nil), parents...)
+	sort.Slice(ordered, func(i, j int) bool {
+		return bytes.Compare(ordered[i].Key(), ordered[j].Key()) < 0
+	})
+	var toks []LineageToken
+	for i, p := range ordered {
+		if i > 0 {
+			toks = append(toks, sep)
+		}
+		toks = append(toks, p.tokens...)
+	}
+	if rank > 0 {
+		toks = append(toks, Tok(rankSeed.Feature, rankSeed.Role, rank))
+	}
+	return Lineage{tokens: toks}
+}

--- a/kernel/topo/provenance_test.go
+++ b/kernel/topo/provenance_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package topo
+
+import "testing"
+
+// TestNameByParentsIsOrderIndependent pins the defining property (ADR-0043): the provenance name
+// depends only on the SET of parents, not the order the generator discovered them in. Swapping the
+// parents yields byte-identical keys; the parents' token runs are joined by the separator.
+func TestNameByParentsIsOrderIndependent(t *testing.T) {
+	a := NewLineage(Tok("Extrusion1", "side", 2))
+	b := NewLineage(Tok("Extrusion1", "side", 0))
+	sep := Tok("brep", "x", 0)
+
+	ab := NameByParents([]Lineage{a, b}, sep, Tok("brep", "seg", 0), 0)
+	ba := NameByParents([]Lineage{b, a}, sep, Tok("brep", "seg", 0), 0)
+	if string(ab.Key()) != string(ba.Key()) {
+		t.Fatalf("order changed the name: %q vs %q", ab.Key(), ba.Key())
+	}
+	// b sorts before a (…side#0 < …side#2), so the canonical form is b / brep:x#0 / a.
+	if got, want := string(ab.Key()), "Extrusion1:side#0/brep:x#0/Extrusion1:side#2"; got != want {
+		t.Errorf("name = %q, want %q", got, want)
+	}
+}
+
+// TestNameByParentsRank appends the disambiguator only when rank > 0, carrying the rank seed's
+// feature/role with the rank as its index.
+func TestNameByParentsRank(t *testing.T) {
+	a := NewLineage(Tok("f", "a", 0))
+	b := NewLineage(Tok("f", "b", 0))
+	sep, seed := Tok("brep", "x", 0), Tok("brep", "seg", 0)
+
+	if got, want := string(NameByParents([]Lineage{a, b}, sep, seed, 0).Key()), "f:a#0/brep:x#0/f:b#0"; got != want {
+		t.Errorf("rank 0 name = %q, want %q (no disambiguator)", got, want)
+	}
+	if got, want := string(NameByParents([]Lineage{a, b}, sep, seed, 3).Key()), "f:a#0/brep:x#0/f:b#0/brep:seg#3"; got != want {
+		t.Errorf("rank 3 name = %q, want %q", got, want)
+	}
+}
+
+// TestNameByParentsThreeParents generalizes past the boolean's two-parent case: a vertex where
+// three faces meet is named by all three, canonically ordered and sep-joined.
+func TestNameByParentsThreeParents(t *testing.T) {
+	p := []Lineage{NewLineage(Tok("f", "c", 0)), NewLineage(Tok("f", "a", 0)), NewLineage(Tok("f", "b", 0))}
+	got := string(NameByParents(p, Tok("f", "at", 0), Tok("f", "dup", 0), 0).Key())
+	want := "f:a#0/f:at#0/f:b#0/f:at#0/f:c#0"
+	if got != want {
+		t.Errorf("three-parent name = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## What

The reusable provenance-naming primitive that the per-operation phases (P1 fillet …) name through — the second step of the ADR-0043 milestone (epic #1539).

## How

`topo.NameByParents(parents, sep, rankSeed, rank)` composes a provenance lineage from the lineages of the entities that **generated** a derived entity: the parents **canonically ordered** (by key, so the name is independent of the order the generator discovered them in — operand/stitch order), their token runs joined by `sep`, with a `rank` disambiguator appended when several derived entities share the same parents. A parent-derived name survives an upstream edit that reorders the build, because the parents' identities are stable — the property an ordinal counter lacks.

`kernel/brep`'s `intersectionLineage` (boolean intersection edges) now delegates to it. The boolean already canonicalises its face pair, so the composed names are **byte-identical** — the whole `kernel/brep` suite stays green, proving the extraction changes **no persisted reference key**.

## Verification

- `TestNameByParentsIsOrderIndependent` / `…Rank` / `…ThreeParents` pin the format, order-independence, and the rank disambiguator (incl. the >2-parent case the fillet/vertex naming needs).
- `go test ./kernel/...` green — the boolean's names are unchanged (byte-identity proof).
- `golangci-lint --new-from-rev`: 0 new issues.

No behaviour change. Next: **P1** threads parent provenance through the fillet blend (`assemble_curved.go`) to name through this seam.

Refs #1539

🤖 Generated with [Claude Code](https://claude.com/claude-code)