### PR TITLE
P2′: boolean preserves original edge identity (ADR-0043, #1539)

### DIFF
--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -110,6 +110,11 @@ func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.L
 	if body == nil {
 		return topo.MergeBodies(lin, true), nil
 	}
+	// Provenance (ADR-0043): the planar boolean names intersection edges by their crossing faces but
+	// falls surviving ORIGINAL boundaries back to a build-order ordinal (brep:edge#N). Restore those
+	// boundaries' original identity so a reference to an edge the operation passed through whole — a
+	// box edge a chamfer/combine/hole left untouched — survives an upstream edit.
+	body.InheritOriginalEdges(append(append([]*topo.Edge(nil), target.Edges()...), tool.Edges()...))
 	// Guard: the exact planar boolean can still produce an INVALID (non-manifold) result on a
 	// degenerate arrangement — notably a coplanar flush face combined with an oblique partial
 	// penetration (the "V2" oblique-into-corner-with-flush-bottom case), where the coplanar

--- a/kernel/topo/provenance.go
+++ b/kernel/topo/provenance.go
@@ -84,6 +84,40 @@ func provNameFromFaces(faces []*Face, faceProv map[*Face]Lineage, sep, rankSeed 
 	return NameByParents(parents, sep, rankSeed, 0), true
 }
 
+// InheritOriginalEdges restores original edge identity to a derived body (ADR-0043): a result edge
+// whose two endpoints coincide with an input edge's endpoints — an untouched boundary the operation
+// passed through WHOLE — takes that input edge's lineage, instead of the build-order fallback a
+// boolean assigns to surviving (non-intersection) edges. Only an input edge matched by EXACTLY ONE
+// result edge (an unsplit survivor) is inherited, so two result edges never claim the same lineage;
+// a split edge's fragments and the intersection edges (which have new endpoints) are left untouched.
+// Coincidence is tested at a tolerance scaled to the body's size. Call during construction.
+func (b *Body) InheritOriginalEdges(originals []*Edge) {
+	tol := float64(b.RangeBox().Diagonal().Length())*1e-9 + 1e-9
+	res := b.Edges()
+	for _, o := range originals {
+		var match *Edge
+		count := 0
+		for _, r := range res {
+			if edgeEndpointsCoincide(r, o, tol) {
+				match, count = r, count+1
+			}
+		}
+		if count == 1 {
+			match.lineage = o.lineage
+		}
+	}
+}
+
+// edgeEndpointsCoincide reports whether r and o have the same endpoint PAIR (in either direction),
+// within tol — the test that r is the same boundary as the original edge o.
+func edgeEndpointsCoincide(r, o *Edge, tol float64) bool {
+	rs, re, os, oe := r.start.point, r.end.point, o.start.point, o.end.point
+	if float64(rs.DistanceTo(os)) <= tol && float64(re.DistanceTo(oe)) <= tol {
+		return true
+	}
+	return float64(rs.DistanceTo(oe)) <= tol && float64(re.DistanceTo(os)) <= tol
+}
+
 // vertexFaces returns the distinct faces meeting at v, via its incident edges.
 func vertexFaces(v *Vertex) []*Face {
 	seen := map[*Face]bool{}

--- a/kernel/topo/provenance_test.go
+++ b/kernel/topo/provenance_test.go
@@ -107,3 +107,37 @@ func TestRelineageSkipsUnprovenancedFaces(t *testing.T) {
 		t.Errorf("edge renamed despite no face provenance: %q → %q", before, got)
 	}
 }
+
+// TestInheritOriginalEdges pins ADR-0043 P2′: a result edge coincident with an input edge takes
+// that edge's lineage (an unsplit survivor), while a result edge matching no input edge keeps its
+// build-order fallback. Only a 1:1 match inherits.
+func TestInheritOriginalEdges(t *testing.T) {
+	bld := NewBuilder(false, NewLineage(Tok("res", "body", 0)))
+	a := bld.AddVertex(math.P3(0, 0, 0), NewLineage(Tok("res", "v", 0)))
+	b := bld.AddVertex(math.P3(1, 0, 0), NewLineage(Tok("res", "v", 1)))
+	c := bld.AddVertex(math.P3(0, 1, 0), NewLineage(Tok("res", "v", 2)))
+	ab := bld.AddEdge(geom.NewLineSegment(a.Point(), b.Point()), a, b, NewLineage(Tok("brep", "edge", 0)))
+	bc := bld.AddEdge(geom.NewLineSegment(b.Point(), c.Point()), b, c, NewLineage(Tok("brep", "edge", 1)))
+	ca := bld.AddEdge(geom.NewLineSegment(c.Point(), a.Point()), c, a, NewLineage(Tok("brep", "edge", 2)))
+	pl, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	bld.AddFace(pl, NewLineage(Tok("res", "face", 0)), OuterLoop(Fwd(ab), Fwd(bc), Fwd(ca)))
+	body := bld.Build()
+
+	// Original edges: one coincident with ab (reversed, to exercise both directions), one far away.
+	ob := NewBuilder(false, NewLineage(Tok("orig", "body", 0)))
+	o1 := ob.AddVertex(math.P3(1, 0, 0), NewLineage(Tok("orig", "v", 0)))
+	o2 := ob.AddVertex(math.P3(0, 0, 0), NewLineage(Tok("orig", "v", 1)))
+	origAB := ob.AddEdge(geom.NewLineSegment(o1.Point(), o2.Point()), o1, o2, NewLineage(Tok("Extrusion1", "bottom-edge", 3)))
+	f1 := ob.AddVertex(math.P3(9, 9, 9), NewLineage(Tok("orig", "v", 2)))
+	f2 := ob.AddVertex(math.P3(9, 9, 8), NewLineage(Tok("orig", "v", 3)))
+	far := ob.AddEdge(geom.NewLineSegment(f1.Point(), f2.Point()), f1, f2, NewLineage(Tok("Extrusion1", "x", 0)))
+
+	body.InheritOriginalEdges([]*Edge{origAB, far})
+
+	if got := string(ab.Lineage().Key()); got != "Extrusion1:bottom-edge#3" {
+		t.Errorf("coincident edge ab = %q, want it to inherit Extrusion1:bottom-edge#3", got)
+	}
+	if got := string(bc.Lineage().Key()); got != "brep:edge#1" {
+		t.Errorf("non-matching edge bc = %q, want it unchanged (brep:edge#1)", got)
+	}
+}

--- a/model/feature/boolean_provenance_test.go
+++ b/model/feature/boolean_provenance_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// TestChamferKeepsUntouchedEdgeIdentity is ADR-0043 P2′: a boolean (here a chamfer's wedge cut)
+// must leave the edges it passes through WHOLE with their original identity, not renumber them to a
+// build-order ordinal. Chamfering one box edge leaves the diagonally-opposite vertical edge
+// untouched, so a selection on it stays bound to Extrusion1:side-edge#3 across the operation —
+// where the boolean's brep:edge#N fallback would have lost it.
+func TestChamferKeepsUntouchedEdgeIdentity(t *testing.T) {
+	box := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 3}, {X: 0, Y: 3}},
+		sketch.XYPlane(), span{near: 0, far: 5}, 0, "Extrusion1")
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(box)
+	NewDressUpFeatures(fs).AddChamfer([][]byte{edgeByKeySuffix1536(t, box, "Extrusion1:side-edge#1")}, func() float64 { return 0.6 })
+	fs.Recompute()
+
+	untouched, anyOrdinal := false, false
+	for _, e := range fs.Result()[0].Edges() {
+		switch k := keyString1536(e.ReferenceKey()); {
+		case k == "Extrusion1:side-edge#3":
+			untouched = true
+		case strings.HasPrefix(k, "brep:edge#"):
+			anyOrdinal = true // a split fragment near the chamfer keeps the fallback (a later phase)
+		}
+	}
+	if !untouched {
+		t.Error("the untouched opposite edge lost its Extrusion1:side-edge#3 identity through the chamfer")
+	}
+	_ = anyOrdinal // documented: split fragments are not yet provenance-named (epic #1539)
+}


### PR DESCRIPTION
## What

The planar boolean now keeps the identity of edges it passes through **whole**, instead of renumbering them to a build-order ordinal — closing the surviving-edge gap that affects *every* boolean consumer (chamfer, combine, hole, split). Fourth phase of the ADR-0043 milestone (epic #1539).

## Why

M31 names boolean **intersection** edges by their crossing faces, but surviving **original** boundary edges fall back to `brep:edge#N`. So chamfering/combining one edge of a box silently re-identified all the *other* edges, which then renumber again on the next edit — the construction-order fragility, generalized.

## How

A post-pass, not a change to the boolean's geometry pipeline:
- `topo.Body.InheritOriginalEdges(originals)` matches each result edge to an input edge by **coincident endpoints** and, for an **unsplit survivor** (1:1 match), gives it the input edge's lineage. Intersection edges (new endpoints) and split fragments (no whole-edge match) are untouched — their provenance is a later phase — and the P0 uniqueness guard backstops any collision.
- `booleanGeneral` runs it on the planar B-rep result over both operands' edges.

Example: chamfering `Extrusion1:side-edge#1` now leaves the 7 untouched box edges with their `Extrusion1:` identities (was `brep:edge#N`); only the 4 split fragments adjacent to the chamfer keep the fallback.

## Migration (forward-only)

Surviving-edge keys change from `brep:edge#N` back to their original lineage — strictly **more** stable.

## Verification

- Whole **kernel + model + app + persistence** suite green — the existing M31 naming tests (`tnp_naming_test`, `encoding_test`) assert intersection/fragment edges, which are untouched.
- New tests: `TestInheritOriginalEdges` (topo — coincident inherits, non-match keeps fallback, 1:1 only); `TestChamferKeepsUntouchedEdgeIdentity` (model — an untouched box edge stays `Extrusion1:side-edge#3` through a chamfer).
- `golangci-lint --new-from-rev`: 0 new issues.

Next: P3 delete-face/CSG, P4 curved boolean (split-fragment ranking folds in here), P5 remaining generators, P6 F06 integration.

Refs #1539

🤖 Generated with [Claude Code](https://claude.com/claude-code)