### PR TITLE
P3: delete-face preserves surviving face/edge identity (ADR-0043, #1539)

### DIFF
--- a/kernel/ops/delete_face.go
+++ b/kernel/ops/delete_face.go
@@ -29,6 +29,9 @@ func DeleteFaces(solid *topo.Body, faceKeys [][]byte) (*topo.Body, error) {
 	if r := Validate(body); !r.Valid || !body.IsSolid() {
 		return nil, fmt.Errorf("delete-face: heal did not close the body %v", r.Issues)
 	}
+	// Provenance (ADR-0043): a surviving edge the heal carried through unchanged keeps its original
+	// identity rather than the rebuild's build-order name; the new healed edges keep the fallback.
+	body.InheritOriginalEdges(solid.Edges())
 	return body, nil
 }
 
@@ -172,8 +175,9 @@ func lineHitsPlane(p0 math.Point3, dir math.Vector3, c geom.Plane) (float64, boo
 // ploop is a surviving face as 3D point rings (outer first) plus its normal, ready for
 // welding into a body.
 type ploop struct {
-	normal math.Vector3
-	rings  [][]math.Point3
+	normal  math.Vector3
+	rings   [][]math.Point3
+	lineage topo.Lineage // provenance: the surviving original face this loop came from (ADR-0043)
 }
 
 // survivingLoops returns every non-deleted face as a point-ring loop with its vertices
@@ -184,7 +188,7 @@ func survivingLoops(solid *topo.Body, del map[uint64]bool, moved map[uint64]math
 		if del[f.ID()] {
 			continue
 		}
-		pl := ploop{normal: f.Geometry().NormalAt(0, 0)}
+		pl := ploop{normal: f.Geometry().NormalAt(0, 0), lineage: f.Lineage()}
 		for _, l := range f.Loops() {
 			pl.rings = append(pl.rings, healedRing(l, moved))
 		}
@@ -259,7 +263,13 @@ func assembleLoops(verts []math.Point3, faces []ploop, rings [][][]int, edgeUse 
 			specs = append(specs, indexLoop(ri == 0, r, edges))
 		}
 		surf, _ := geom.NewPlane(centroidPts(faces[fi].rings[0]), faces[fi].normal)
-		bld.AddFace(surf, topo.NewLineage(topo.Tok("delface", "f", fi)), specs...)
+		// Provenance (ADR-0043): a surviving face keeps its original identity; fall back to the
+		// build-order name only if a loop arrived without one.
+		lin := faces[fi].lineage
+		if len(lin.Key()) == 0 {
+			lin = topo.NewLineage(topo.Tok("delface", "f", fi))
+		}
+		bld.AddFace(surf, lin, specs...)
 	}
 	return bld.Build()
 }

--- a/kernel/ops/delete_face_test.go
+++ b/kernel/ops/delete_face_test.go
@@ -59,6 +59,43 @@ func TestDeleteFaceHealsChamfer(t *testing.T) {
 	}
 }
 
+// TestDeleteFaceKeepsSurvivingIdentity is ADR-0043 P3: healing a deleted face rebuilds the body,
+// but the faces and edges it carries through unchanged must keep their ORIGINAL identity rather
+// than be renumbered to the rebuild's delface:* ordinals — so a selection on an untouched face or
+// edge survives the operation. Before P3 every result key was a fresh delface ordinal.
+func TestDeleteFaceKeepsSurvivingIdentity(t *testing.T) {
+	chamfered := chamferedBox(t)
+	inFaces, inEdges := map[string]bool{}, map[string]bool{}
+	for _, f := range chamfered.Faces() {
+		inFaces[string(f.ReferenceKey())] = true
+	}
+	for _, e := range chamfered.Edges() {
+		inEdges[string(e.ReferenceKey())] = true
+	}
+
+	healed, err := ops.DeleteFaces(chamfered, [][]byte{chamferFaceKey(t, chamfered)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	faceKept, edgeKept := 0, 0
+	for _, f := range healed.Faces() {
+		if inFaces[string(f.ReferenceKey())] {
+			faceKept++
+		}
+	}
+	for _, e := range healed.Edges() {
+		if inEdges[string(e.ReferenceKey())] {
+			edgeKept++
+		}
+	}
+	if faceKept == 0 {
+		t.Error("no surviving face kept its identity — all renamed to delface:f#N")
+	}
+	if edgeKept == 0 {
+		t.Error("no surviving edge kept its identity — all renamed to delface:e#N")
+	}
+}
+
 // TestDeleteFaceLostKeyErrors reports a vanished face key so the feature can go Sick.
 func TestDeleteFaceLostKeyErrors(t *testing.T) {
 	box := shellBox(2, 2, 2)


### PR DESCRIPTION
## What

Delete-face now keeps the identity of the faces and edges it heals **through unchanged**, instead of renumbering everything to a `delface:*` build-order ordinal — fifth phase of the ADR-0043 milestone (epic #1539).

## Why

`DeleteFaces` heals a removed face by rebuilding the body from the surviving loops, naming every face/edge/vertex `delface:f#N` / `delface:e#N`. That re-identified the survivors too, so a selection on any untouched face or edge was lost after a delete-face.

## How (reusing the established patterns)

- The surviving-face loop carries its **original face lineage** (`ploop.lineage`), so a survivor face is named by its own identity.
- `DeleteFaces` runs `topo.Body.InheritOriginalEdges` (from P2′) over the input body's edges, so a survivor edge keeps its original identity. The genuinely-new healed edges keep the `delface` fallback (a later phase); the P0 guard backstops collisions.

## Migration (forward-only)

Surviving keys change from `delface:*` back to their original lineage — strictly **more** stable.

## Verification

- Whole **kernel + model** suite green.
- New `TestDeleteFaceKeepsSurvivingIdentity`: after healing a chamfer-face deletion, surviving faces **and** edges keep their input keys (before P3, every result key was a fresh `delface` ordinal).
- `golangci-lint --new-from-rev`: 0 new issues.

Note: the CSG/BSP triangle-soup fallback (`csg_body.go`) still uses ordinals — it's a faceted path rarely referenced; tracked for a later phase. Next: P4 curved boolean (+ split-fragment ranking), P5 ruled/sweep/wire/rim, P6 F06 integration.

Refs #1539

🤖 Generated with [Claude Code](https://claude.com/claude-code)