### PR TITLE
P5a: local face ops preserve topology identity (ADR-0043, #1539)

### DIFF
--- a/kernel/ops/draft.go
+++ b/kernel/ops/draft.go
@@ -27,7 +27,7 @@ func DraftFaces(solid *topo.Body, faceKeys [][]byte, pull math.Vector3, angle fl
 	if perr != nil {
 		return nil, perr
 	}
-	return rebuildWithPlanes(solid, "draft", func(f *topo.Face) geom.Plane {
+	return rebuildWithPlanes(solid, "draft", true, func(f *topo.Face) geom.Plane {
 		if !sel[f.ID()] {
 			return f.Geometry().(geom.Plane)
 		}

--- a/kernel/ops/draft_test.go
+++ b/kernel/ops/draft_test.go
@@ -32,6 +32,31 @@ func TestDraftTapersSideFace(t *testing.T) {
 	}
 }
 
+// TestDraftPreservesFaceIdentity is ADR-0043: drafting moves geometry but preserves every
+// face/edge's identity (a 1:1 rebuild), so a selection on ANY face — the drafted one or an
+// untouched neighbour — survives. Before, the rebuild renamed everything to draft:f#N / draft:e#N.
+func TestDraftPreservesFaceIdentity(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	var side, top []byte
+	for _, f := range box.Faces() {
+		if n := f.Geometry().NormalAt(0, 0); n.X > 0.99 {
+			side = f.ReferenceKey()
+		} else if n.Z > 0.99 {
+			top = f.ReferenceKey()
+		}
+	}
+	res, err := ops.DraftFaces(box, [][]byte{side}, math.V3(0, 0, 1), -stdmath.Atan(0.25))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := res.FindFaceByKey(side); !ok {
+		t.Error("the drafted side face lost its identity")
+	}
+	if _, ok := res.FindFaceByKey(top); !ok {
+		t.Error("the untouched top face lost its identity — the rebuild renamed it")
+	}
+}
+
 // TestDraftLostKeyErrors reports a vanished face key so the feature can go Sick.
 func TestDraftLostKeyErrors(t *testing.T) {
 	box := shellBox(2, 2, 2)

--- a/kernel/ops/move_face.go
+++ b/kernel/ops/move_face.go
@@ -18,7 +18,7 @@ func MoveFaces(solid *topo.Body, faceKeys [][]byte, delta math.Vector3) (*topo.B
 	if err != nil {
 		return nil, err
 	}
-	return rebuildWithPlanes(solid, "move-face", func(f *topo.Face) geom.Plane {
+	return rebuildWithPlanes(solid, "move-face", true, func(f *topo.Face) geom.Plane {
 		pl := f.Geometry().(geom.Plane)
 		if !sel[f.ID()] {
 			return pl
@@ -34,7 +34,7 @@ func OffsetFaces(solid *topo.Body, faceKeys [][]byte, dist float64) (*topo.Body,
 	if err != nil {
 		return nil, err
 	}
-	return rebuildWithPlanes(solid, "offset-face", func(f *topo.Face) geom.Plane {
+	return rebuildWithPlanes(solid, "offset-face", true, func(f *topo.Face) geom.Plane {
 		pl := f.Geometry().(geom.Plane)
 		if !sel[f.ID()] {
 			return pl
@@ -53,7 +53,7 @@ func RotateFaces(solid *topo.Body, faceKeys [][]byte, axisPoint math.Point3, axi
 		return nil, err
 	}
 	rot := math.Rotation4(angle, axisDir, axisPoint)
-	return rebuildWithPlanes(solid, "rotate-face", func(f *topo.Face) geom.Plane {
+	return rebuildWithPlanes(solid, "rotate-face", true, func(f *topo.Face) geom.Plane {
 		pl := f.Geometry().(geom.Plane)
 		if !sel[f.ID()] {
 			return pl

--- a/kernel/ops/replace_face.go
+++ b/kernel/ops/replace_face.go
@@ -17,7 +17,7 @@ func ReplaceFaces(solid *topo.Body, faceKeys [][]byte, target geom.Plane) (*topo
 	if err != nil {
 		return nil, err
 	}
-	return rebuildWithPlanes(solid, "replace-face", func(f *topo.Face) geom.Plane {
+	return rebuildWithPlanes(solid, "replace-face", true, func(f *topo.Face) geom.Plane {
 		if sel[f.ID()] {
 			return target
 		}

--- a/kernel/ops/retopo.go
+++ b/kernel/ops/retopo.go
@@ -15,7 +15,13 @@ import (
 // planes don't invert the topology (a modest move). It is the shared engine behind the local
 // face operations — shell (offset kept faces inward), move/offset face, draft — which differ
 // only in how planeOf changes the selected faces' planes.
-func rebuildWithPlanes(solid *topo.Body, tag string, planeOf func(*topo.Face) geom.Plane) *topo.Body {
+// keepIdentity (ADR-0043): because the rebuild is a 1:1 clone of the combinatorial structure, a
+// direct-result op (draft, move/offset/rotate-face, replace-face) preserves each face/edge/vertex's
+// ORIGINAL lineage — the geometry moves but identity does not, so a selection on a drafted face
+// survives. A throwaway tool (shell's cavity, fed to the boolean) instead takes fresh ordinal names
+// under tag, so its faces don't share lineages with the target and confuse the boolean's face-pair
+// edge naming.
+func rebuildWithPlanes(solid *topo.Body, tag string, keepIdentity bool, planeOf func(*topo.Face) geom.Plane) *topo.Body {
 	vf := vertexFaceMap(solid)
 	planes := make(map[uint64]geom.Plane, len(solid.Faces()))
 	for _, f := range solid.Faces() {
@@ -25,17 +31,26 @@ func rebuildWithPlanes(solid *topo.Body, tag string, planeOf func(*topo.Face) ge
 	bld := topo.NewBuilder(true, lin)
 	nv := make(map[uint64]*topo.Vertex, len(solid.Vertices()))
 	for i, v := range solid.Vertices() {
-		nv[v.ID()] = bld.AddVertex(vertexAtPlanes(v, vf[v.ID()], planes), topo.NewLineage(topo.Tok(tag, "v", i)))
+		nv[v.ID()] = bld.AddVertex(vertexAtPlanes(v, vf[v.ID()], planes), cloneName(keepIdentity, v.Lineage(), tag, "v", i))
 	}
 	ne := make(map[uint64]*topo.Edge, len(solid.Edges()))
 	for i, e := range solid.Edges() {
 		a, b := nv[e.StartVertex().ID()], nv[e.EndVertex().ID()]
-		ne[e.ID()] = bld.AddEdge(geom.NewLineSegment(a.Point(), b.Point()), a, b, topo.NewLineage(topo.Tok(tag, "e", i)))
+		ne[e.ID()] = bld.AddEdge(geom.NewLineSegment(a.Point(), b.Point()), a, b, cloneName(keepIdentity, e.Lineage(), tag, "e", i))
 	}
 	for i, f := range solid.Faces() {
-		bld.AddFace(planes[f.ID()], topo.NewLineage(topo.Tok(tag, "f", i)), cloneLoops(f, ne)...)
+		bld.AddFace(planes[f.ID()], cloneName(keepIdentity, f.Lineage(), tag, "f", i), cloneLoops(f, ne)...)
 	}
 	return bld.Build()
+}
+
+// cloneName returns orig when a 1:1 rebuild keeps identity, else a fresh build-order ordinal under
+// tag — the per-entity naming choice rebuildWithPlanes makes (ADR-0043).
+func cloneName(keepIdentity bool, orig topo.Lineage, tag, role string, i int) topo.Lineage {
+	if keepIdentity {
+		return orig
+	}
+	return topo.NewLineage(topo.Tok(tag, role, i))
 }
 
 // vertexAtPlanes returns where a vertex lands as the least-squares meeting point of its

--- a/kernel/ops/shell.go
+++ b/kernel/ops/shell.go
@@ -22,7 +22,7 @@ func Shell(solid *topo.Body, removedKeys [][]byte, t float64) (*topo.Body, error
 	if err != nil {
 		return nil, err
 	}
-	cavity := rebuildWithPlanes(solid, "shell-cavity", func(f *topo.Face) geom.Plane {
+	cavity := rebuildWithPlanes(solid, "shell-cavity", false, func(f *topo.Face) geom.Plane {
 		return shellFacePlane(f, removed, t)
 	})
 	return Boolean(Cut, solid, cavity)


### PR DESCRIPTION
## What

`draft`, `move`/`offset`/`rotate`-face, and `replace-face` now preserve the identity of every face/edge/vertex, instead of renaming the whole body to a per-op ordinal. One shared change fixes all five (they funnel through `rebuildWithPlanes`).

## Why

`rebuildWithPlanes` clones a solid's combinatorial structure **1:1** (it only moves the planes), but named everything `draft:f#N` / `move-face:e#N` / … — so a selection on any face, *including untouched neighbours*, was lost after a draft or move.

## How

Because the rebuild is structural and 1:1, the exact fix is to keep each entity's **original lineage**: a `keepIdentity` flag makes the direct-result ops name each face/edge/vertex by its input lineage (geometry moves, identity doesn't). Shell's throwaway **cavity tool** keeps fresh ordinals (`keepIdentity=false`) so its faces don't share lineages with the target and confuse the boolean's face-pair edge naming.

## Verification

- Whole **kernel + model** suite green.
- New `TestDraftPreservesFaceIdentity`: a draft keeps **both** the drafted face's and an untouched neighbour's identity (before, every result key was a fresh `draft:*`).
- `golangci-lint --new-from-rev`: 0 new issues.

Per the audit (#1539), this is the highest-impact survivor-identity gap. Remaining: CapHoles / buildSheet / Stitch (survivor inheritance), P4 curved boolean, then F06.

Refs #1539

🤖 Generated with [Claude Code](https://claude.com/claude-code)