### PR TITLE
P5b: cap-holes preserves surviving face/edge identity (ADR-0043, #1539)

### DIFF
--- a/kernel/ops/cap_holes.go
+++ b/kernel/ops/cap_holes.go
@@ -33,6 +33,7 @@ func CapHoles(body *topo.Body, wallFaceKeys [][]byte) (*topo.Body, error) {
 	if r := Validate(result); !r.Valid || !result.IsSolid() {
 		return nil, fmt.Errorf("cap-holes: result is not a closed solid (openings not coplanar with their faces?) %v", r.Issues)
 	}
+	result.InheritOriginalEdges(body.Edges()) // surviving edges keep their identity (ADR-0043)
 	return result, nil
 }
 
@@ -45,7 +46,7 @@ func cappedLoops(body *topo.Body, removed map[uint64]bool) []ploop {
 		if removed[f.ID()] {
 			continue
 		}
-		pl := ploop{normal: f.Geometry().NormalAt(0, 0)}
+		pl := ploop{normal: f.Geometry().NormalAt(0, 0), lineage: f.Lineage()} // keep the surviving face's identity (ADR-0043)
 		for _, l := range f.Loops() {
 			if !l.IsOuter() && loopBordersRemoved(l, removed) {
 				continue // an opening into the capped hole ⇒ heal flush (drop the inner loop)

--- a/kernel/ops/cap_holes_test.go
+++ b/kernel/ops/cap_holes_test.go
@@ -79,6 +79,42 @@ func TestCapHolesExplicitSelection(t *testing.T) {
 	}
 }
 
+// TestCapHolesKeepsSurvivingIdentity is ADR-0043: capping a hole rebuilds the body, but the faces
+// and edges it carries through unchanged keep their ORIGINAL identity rather than fresh ordinals,
+// so a selection on an untouched outer face/edge survives the operation.
+func TestCapHolesKeepsSurvivingIdentity(t *testing.T) {
+	holey := boxWithThroughHole(t)
+	var walls [][]byte
+	var outerSide []byte
+	for _, f := range holey.Faces() {
+		if n := f.Geometry().NormalAt(0, 0); stdmath.Abs(n.Z) < 0.1 && interiorXY(f) {
+			walls = append(walls, f.ReferenceKey())
+		} else if stdmath.Abs(n.Z) < 0.1 {
+			outerSide = f.ReferenceKey() // a fully untouched outer side face
+		}
+	}
+	inEdges := map[string]bool{}
+	for _, e := range holey.Edges() {
+		inEdges[string(e.ReferenceKey())] = true
+	}
+	capped, err := ops.CapHoles(holey, walls)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := capped.FindFaceByKey(outerSide); !ok {
+		t.Error("an untouched outer face lost its identity — the rebuild renamed it")
+	}
+	edgeKept := 0
+	for _, e := range capped.Edges() {
+		if inEdges[string(e.ReferenceKey())] {
+			edgeKept++
+		}
+	}
+	if edgeKept == 0 {
+		t.Error("no surviving edge kept its identity — all renamed to delface:e#N")
+	}
+}
+
 // TestCapHolesByDiameterIgnoresWideOpening leaves the hole when its opening exceeds the max
 // diameter (returns the body unchanged).
 func TestCapHolesByDiameterIgnoresWideOpening(t *testing.T) {


### PR DESCRIPTION
## What

`CapHoles` now keeps the identity of the faces/edges it heals through unchanged, instead of renaming the whole body to `delface:*` ordinals.

## How

Mirrors the delete-face (P3) fix: the surviving-face loop carries its original lineage (`ploop.lineage = f.Lineage()`), and `CapHoles` runs `InheritOriginalEdges` over the input body's edges. New cap geometry keeps the fallback; the P0 guard backstops collisions.

## Verification

- Whole kernel + model suite green.
- New `TestCapHolesKeepsSurvivingIdentity`: an untouched outer face and surviving edges keep their identity through a cap-holes.
- `golangci-lint --new-from-rev`: 0 new issues.

Per the audit (#1539): the remaining "LOSE" ops are legitimately new geometry (thicken, section, ruled, wire, untrim, mesh/CSG/hull — nothing to inherit) or use stable sorted-key indices. The substantive remaining piece is **P4 (curved boolean)**.

Refs #1539

🤖 Generated with [Claude Code](https://claude.com/claude-code)