### PR TITLE
Fix develop CI: ADR-0043 MD018 + assembleBody funlen

### DIFF
--- a/architecture/decisions/ADR-0043-generalized-provenance-naming.md
+++ b/architecture/decisions/ADR-0043-generalized-provenance-naming.md
@@ -38,8 +38,8 @@ counter — fragile by exactly the mechanism M31 fixed for booleans:
 
 These do not all surface as user bugs today (e.g. `fillet:e#13` is stable in #1536 because the
 curved blend's build order happens to be deterministic for that geometry), but each is a latent
-wrong-rebind waiting for an upstream edit that reorders construction — the class behind #1494 /
-#1536 / #1537.
+wrong-rebind waiting for an upstream edit that reorders construction — the fillet-stack class
+(#1494, #1536, #1537).
 
 ## Decision
 

--- a/kernel/ops/assemble_curved.go
+++ b/kernel/ops/assemble_curved.go
@@ -58,11 +58,22 @@ func assembleBody(faces []filletFace, tag string) *topo.Body {
 		tv[i] = bld.AddVertex(p, topo.NewLineage(topo.Tok(tag, "v", i)))
 	}
 	ec := &edgeCatalog{bld: bld, verts: w.points, tv: tv, edges: map[[2]int]edgeRec{}, tag: tag}
-	// Provenance naming (ADR-0043): a face with a parent lineage is named by it; its edges and
-	// vertices are then renamed by their bordering faces' provenance, replacing the build-order
-	// counter that renumbered on an upstream edit. Faces without provenance (e.g. variable-fillet
-	// ruling strips, not yet provenanced) keep the ordinal name, and edges/vertices touching them
-	// stay ordinal too — a partial body remains consistent.
+	provByFace := addCurvedFaces(bld, faces, rings, ec, tag)
+	body := bld.Build()
+	// Provenance naming (ADR-0043): once the faces are named by their parents, the edges and
+	// vertices are renamed by their bordering faces' provenance, replacing the build-order counter
+	// that renumbered on an upstream edit. A body with no provenanced faces is left as built.
+	if len(provByFace) > 0 {
+		body.RelineageByFaceProvenance(provByFace, topo.Tok("fillet", "x", 0), topo.Tok("fillet", "seg", 0))
+	}
+	return body
+}
+
+// addCurvedFaces builds each result face against the edge catalog and names it by its provenance
+// parent when it has one (a transformed original face, a blend cylinder), else a build-order
+// ordinal under tag (e.g. a variable-fillet ruling strip, not yet provenanced). Returns the
+// provenanced faces so the caller can rename their edges/vertices by provenance (ADR-0043).
+func addCurvedFaces(bld *topo.Builder, faces []filletFace, rings [][][]int, ec *edgeCatalog, tag string) map[*topo.Face]topo.Lineage {
 	provByFace := map[*topo.Face]topo.Lineage{}
 	for fi, f := range faces {
 		specs := make([]topo.LoopSpec, len(f.loops))
@@ -78,11 +89,7 @@ func assembleBody(faces []filletFace, tag string) *topo.Body {
 			provByFace[face] = f.parent
 		}
 	}
-	body := bld.Build()
-	if len(provByFace) > 0 {
-		body.RelineageByFaceProvenance(provByFace, topo.Tok("fillet", "x", 0), topo.Tok("fillet", "seg", 0))
-	}
-	return body
+	return provByFace
 }
 
 // curvedSolid reports whether every undirected edge of the faces is used exactly twice (the


### PR DESCRIPTION
Unblocks develop (and the in-flight P5a/P5b PRs, which inherit the breakage).

- **docs-lint MD018**: ADR-0043 wrapped so a line started with `#1536` (read as a heading). Reworded.
- **lint funlen**: P1 pushed `assembleBody` to 29 statements; extracted `addCurvedFaces` (behaviour unchanged).

Verified: `markdownlint-cli2 architecture/**/*.md` → 0 errors; full `golangci-lint` on kernel/ops+topo+model/feature → 0 issues; fillet tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)