### PR TITLE
P4: curved boolean preserves target survivor identity (ADR-0043, #1539)

### DIFF
--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -97,7 +97,11 @@ func join(lin topo.Lineage, target, tool *topo.Body, rel relation, rec *diag.Rec
 // (a cylinder, cone, etc.). A nil B-rep result is a (valid) empty body.
 func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.Lineage, rec *diag.Recorder) (*topo.Body, error) {
 	if body, ok := curvedExactBoolean(op, target, tool, rec); ok {
-		return body, nil // an exact analytic curved result (M2 #1334/#1335) — keeps surfaces, no CSG soup
+		// Provenance (ADR-0043): like the planar path, restore the identity of original boundaries the
+		// curved cut passed through whole (the new surface-intersection curves keep their ordinal name
+		// — full SSI-edge provenance is a follow-up). An exact analytic result (M2 #1334/#1335).
+		body.InheritOriginalEdges(append(append([]*topo.Edge(nil), target.Edges()...), tool.Edges()...))
+		return body, nil
 	}
 	bop, ok := toBrepOp(op)
 	if !ok {

--- a/kernel/ops/boolean_drilled_plate_test.go
+++ b/kernel/ops/boolean_drilled_plate_test.go
@@ -79,6 +79,34 @@ func TestDrilledPlateIsExact(t *testing.T) {
 	}
 }
 
+// TestCurvedBooleanKeepsTargetEdgeIdentity is ADR-0043 P4: the exact analytic curved cut keeps the
+// hole's cylinder wall AND lets the target's untouched boundaries keep their identity — a slab edge
+// the drill never reached stays bound to its slab:* key rather than a fresh curvedbool:e#N ordinal,
+// so a selection on it survives the operation.
+func TestCurvedBooleanKeepsTargetEdgeIdentity(t *testing.T) {
+	slab := slabBody(t)
+	in := map[string]bool{}
+	for _, e := range slab.Edges() {
+		in[string(e.ReferenceKey())] = true
+	}
+	res, err := ops.Boolean(ops.Cut, slab, throughRod(t, 0, 0, 1.5))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasCylinderFace(res) {
+		t.Fatal("not the analytic curved path (no cylinder face) — test premise invalid")
+	}
+	kept := 0
+	for _, e := range res.Edges() {
+		if in[string(e.ReferenceKey())] {
+			kept++
+		}
+	}
+	if kept == 0 {
+		t.Error("no slab edge kept its identity through the curved cut — all renamed to curvedbool:e#N")
+	}
+}
+
 // TestDrilledPlateClippedDefers: a hole whose circle clips the slab edge is NOT a clean through-hole, so
 // the exact path declines and the general boolean still produces a valid solid (the fallback is intact).
 func TestDrilledPlateClippedDefers(t *testing.T) {


### PR DESCRIPTION
## What

The exact analytic curved boolean now keeps the identity of the target boundaries it passes through whole, instead of renaming the result to `curvedbool:e#N`.

## How

Mirror the planar boolean (P2′): after `curvedExactBoolean` builds the analytic result, run `InheritOriginalEdges` over both operands' edges so a survivor edge keeps its original lineage. The new surface-intersection (SSI) curves keep their ordinal name.

## Verification

- Whole kernel + model suite green.
- New `TestCurvedBooleanKeepsTargetEdgeIdentity`: a drilled plate keeps its analytic cylinder wall **and** an untouched slab edge's identity.
- **Full** `golangci-lint ./kernel/ops/` (not just `--new-from-rev`): 0 issues.

Tracked follow-up: **full SSI-edge provenance** — name each curved intersection edge by its two crossing surfaces (the curved analogue of the planar face-pair naming), so the new curves are provenance-named too, not just survivors.

Refs #1539

🤖 Generated with [Claude Code](https://claude.com/claude-code)