### PR TITLE
P5c: stitch/sew seam edges are provenance-named (ADR-0043, #1539)

### DIFF
--- a/kernel/ops/stitch.go
+++ b/kernel/ops/stitch.go
@@ -149,10 +149,21 @@ func (w *weld) build(maintainSurface bool, feat string) *topo.Body {
 	bld := topo.NewBuilder(solid, topo.NewLineage(topo.Tok(feat, "body", 0)))
 	verts := w.buildVertices(bld, feat)
 	edges := w.buildEdges(bld, verts, feat)
+	provByFace := map[*topo.Face]topo.Lineage{}
 	for _, wf := range w.faces {
-		bld.AddFace(wf.surface, wf.lineage, w.faceLoops(wf, edges)...)
+		face := bld.AddFace(wf.surface, wf.lineage, w.faceLoops(wf, edges)...)
+		if len(wf.lineage.Key()) > 0 {
+			provByFace[face] = wf.lineage
+		}
 	}
-	return bld.Build()
+	body := bld.Build()
+	// Provenance (ADR-0043): each surviving face keeps its source surface's identity; a seam edge is
+	// then named by the two faces it joins (and a boundary edge by its one face), replacing the
+	// synthesized weld-edge/-vertex ordinal so a reference survives an upstream edit.
+	if len(provByFace) > 0 {
+		body.RelineageByFaceProvenance(provByFace, topo.Tok(feat, "x", 0), topo.Tok(feat, "seg", 0))
+	}
+	return body
 }
 
 // buildVertices creates one shared vertex per welded cell, in sorted-key order so

--- a/kernel/ops/stitch_test.go
+++ b/kernel/ops/stitch_test.go
@@ -3,6 +3,7 @@
 package ops
 
 import (
+	"strings"
 	"testing"
 
 	"oblikovati.org/kernel/geom"
@@ -61,6 +62,45 @@ func TestStitchClosedSurfacesYieldsSolid(t *testing.T) {
 	}
 	if r := Validate(body); !r.Valid || !r.Closed || !r.Manifold || !r.OrientationOK {
 		t.Errorf("stitched cube validation = %+v, want fully valid", r)
+	}
+}
+
+// TestStitchSeamEdgesAreProvenanceNamed is ADR-0043: a stitched seam edge is named by the two
+// source faces it joins (and the body keeps each source face's identity), not by a synthesized
+// weld-edge ordinal — so a selection on a sewn edge/face survives an upstream edit.
+func TestStitchSeamEdgesAreProvenanceNamed(t *testing.T) {
+	body, err := Stitch(cubeFaces(), 0, false, "stitch")
+	if err != nil {
+		t.Fatalf("Stitch: %v", err)
+	}
+	ks := func(k []byte) string {
+		if len(k) > 0 && k[0] < 0x20 {
+			return string(k[1:])
+		}
+		return string(k)
+	}
+	faceKept, weldOrd, prov := false, 0, 0
+	for _, f := range body.Faces() {
+		if ks(f.ReferenceKey()) == "bottom:face#0" {
+			faceKept = true // a source face kept its identity through the weld
+		}
+	}
+	for _, e := range body.Edges() {
+		switch k := ks(e.ReferenceKey()); {
+		case strings.Contains(k, "weld-edge#"):
+			weldOrd++
+		case strings.Contains(k, "/stitch:x#0/"):
+			prov++ // a seam named by its two joining faces
+		}
+	}
+	if !faceKept {
+		t.Error("a stitched face lost its source identity (bottom:face#0)")
+	}
+	if weldOrd > 0 {
+		t.Errorf("%d edges still carry a synthesized weld-edge ordinal", weldOrd)
+	}
+	if prov == 0 {
+		t.Error("no seam edge is provenance-named (face / stitch:x#0 / face) by its joining faces")
 	}
 }
 


### PR DESCRIPTION
## What

`Stitch`/`Sew` now name welded seam edges/vertices by **provenance** (the source faces they join), instead of synthesized `weld-edge#N` / `weld-vertex#N` ordinals.

## How

The weld already keeps each surviving face's source lineage. After the faces are added, run `RelineageByFaceProvenance`: a seam edge → `NameByParents([faceA, faceB])`, a boundary edge → its one face's lineage.

## Verification

- Whole kernel + model suite green (Sew shares the weld path and benefits too).
- New `TestStitchSeamEdgesAreProvenanceNamed`: stitching the six named cube faces leaves **no** weld-edge ordinal, the seams are provenance-named (`face / stitch:x#0 / face`), and a source face keeps its identity.
- **Full** `golangci-lint ./kernel/ops/`: 0 issues.

Remaining on #1539: full SSI-edge provenance (new curved curves), buildSheet/CSG ordinals (stable, rare), P6 F06 integration.

Refs #1539

🤖 Generated with [Claude Code](https://claude.com/claude-code)