### PR TITLE
feat(topo): SSI-edge provenance for the curved boolean (ADR-0043)

### DIFF
--- a/architecture/decisions/ADR-0043-generalized-provenance-naming.md
+++ b/architecture/decisions/ADR-0043-generalized-provenance-naming.md
@@ -72,7 +72,7 @@ entities that produced it. The parent set is op-specific but always *original* l
 
 | Operation | Generated entity | Generating parent set |
 |---|---|---|
-| Boolean (planar/curved) | intersection edge | the two crossing faces *(done; curved = Phase 4)* |
+| Boolean (planar/curved) | intersection edge | the two crossing faces *(done; curved = Phases 4 + SSI-edge)* |
 | **Fillet** | cylinder/torus/sphere blend face | the filleted edge (or its vertex, for a corner blend) |
 | **Fillet** | tangent edge | (filleted edge, adjacent original face) |
 | **Chamfer** | bevel face / edges | the chamfered edge + adjacent faces |
@@ -120,7 +120,12 @@ residual naming collision becomes an honest failure, never a wrong-rebind.
   The user's pain point; gated by a cross-edit-stability regression test.
 - **P2 — chamfer.** Same seam, bevel provenance.
 - **P3 — delete-face, CSG/BSP.** Stitch/cut-edge provenance.
-- **P4 — curved boolean.** Bring `curvedbool` onto the shared seam (it shares `assemble_curved`).
+- **P4 — curved boolean.** Bring `curvedbool` onto the shared seam (it shares `assemble_curved`):
+  P4 restored survivor identity on the curved path; the **SSI-edge** follow-up then named the new
+  surface-intersection curves by their bordering face pair in `curvedStitch`
+  (`RelineageByFaceProvenance`), with a geometric rank that disambiguates two intersection branches
+  between one face pair (a bigon) by their curve midpoint. So no curved-boolean result keeps a
+  `curvedbool:e#N` ordinal.
 - **P5 — remaining generators** (ruled, sweep, wire-offset, rim, split, steinmetz, halfspace).
 - **P6 — integrate with F06 tiered binding & F07 encoding**; retire the ordinal fallbacks that are
   no longer reachable.

--- a/kernel/brep/curved_stitch.go
+++ b/kernel/brep/curved_stitch.go
@@ -23,15 +23,30 @@ import (
 func curvedStitch(faces []curvedFace) *topo.Body {
 	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok("curvedbool", "body", 0)))
 	w := &curveWelder{bld: bld, verts: map[string]*topo.Vertex{}, edges: map[string]*topo.Edge{}}
+	provByFace := map[*topo.Face]topo.Lineage{}
 	for _, f := range faces {
 		specs := w.loopSpecs(f.loops, f.outerless)
+		var built *topo.Face
 		if f.reversed {
-			bld.AddReversedFace(f.surface, f.lineage, specs...)
+			built = bld.AddReversedFace(f.surface, f.lineage, specs...)
 		} else {
-			bld.AddFace(f.surface, f.lineage, specs...)
+			built = bld.AddFace(f.surface, f.lineage, specs...)
+		}
+		if len(f.lineage.Key()) > 0 {
+			provByFace[built] = f.lineage
 		}
 	}
-	return bld.Build()
+	body := bld.Build()
+	// ADR-0043 SSI-edge provenance: the welded edges are minted with build-order ordinals
+	// (curvedbool:e#N) that renumber under any upstream edit. Each result face carries a stable
+	// provenance lineage (an original face's key, or a wall/cap's parent-derived name), so rename the
+	// surface-intersection edges by their bordering face pair — a build-order-independent name. The
+	// caller's InheritOriginalEdges then restores the identity of original boundaries passed through
+	// whole (a survivor must keep its OWN key, not a face-pair name), see booleanGeneral.
+	if len(provByFace) > 0 {
+		body.RelineageByFaceProvenance(provByFace, topo.Tok("curvedbool", "x", 0), topo.Tok("curvedbool", "seg", 0))
+	}
+	return body
 }
 
 // curveWelder dedups vertices (by position) and edges (by endpoints + midpoint) as faces are added.

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -97,9 +97,10 @@ func join(lin topo.Lineage, target, tool *topo.Body, rel relation, rec *diag.Rec
 // (a cylinder, cone, etc.). A nil B-rep result is a (valid) empty body.
 func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.Lineage, rec *diag.Recorder) (*topo.Body, error) {
 	if body, ok := curvedExactBoolean(op, target, tool, rec); ok {
-		// Provenance (ADR-0043): like the planar path, restore the identity of original boundaries the
-		// curved cut passed through whole (the new surface-intersection curves keep their ordinal name
-		// — full SSI-edge provenance is a follow-up). An exact analytic result (M2 #1334/#1335).
+		// Provenance (ADR-0043): the curved stitch already named the new surface-intersection curves by
+		// their generating face pair (curvedStitch → RelineageByFaceProvenance). Here, like the planar
+		// path, restore the identity of original boundaries the curved cut passed through WHOLE — a
+		// survivor keeps its own key, not a face-pair name. An exact analytic result (M2 #1334/#1335).
 		body.InheritOriginalEdges(append(append([]*topo.Edge(nil), target.Edges()...), tool.Edges()...))
 		return body, nil
 	}

--- a/kernel/ops/boolean_drilled_plate_test.go
+++ b/kernel/ops/boolean_drilled_plate_test.go
@@ -4,6 +4,7 @@ package ops_test
 
 import (
 	stdmath "math"
+	"strings"
 	"testing"
 
 	"oblikovati.org/kernel/brep"
@@ -104,6 +105,41 @@ func TestCurvedBooleanKeepsTargetEdgeIdentity(t *testing.T) {
 	}
 	if kept == 0 {
 		t.Error("no slab edge kept its identity through the curved cut — all renamed to curvedbool:e#N")
+	}
+}
+
+// TestSecondBoreRimIsProvenanceNamed is ADR-0043 SSI-edge provenance: the second bore of a chained
+// drill welds through the curved stitch (drillThroughCurved → curvedStitch), whose new rim edges used
+// to get build-order ordinals (curvedbool:e#N) that renumber under any upstream edit. They must now be
+// named by their generating face pair — the new cylinder wall crossing a slab cap — a name that does
+// not depend on the weld order. No edge of the finished part may keep a curvedbool:e#N ordinal.
+func TestSecondBoreRimIsProvenanceNamed(t *testing.T) {
+	slab := slabBody(t)
+	s1, err := ops.Boolean(ops.Cut, slab, throughRod(t, -4, 0, 1.5))
+	if err != nil {
+		t.Fatalf("first bore: %v", err)
+	}
+	s2, err := ops.Boolean(ops.Cut, s1, throughRod(t, 4, 0, 1.5))
+	if err != nil {
+		t.Fatalf("second bore: %v", err)
+	}
+	if rr := ops.Validate(s2); !rr.Valid || !rr.Closed || !rr.Manifold || !s2.IsSolid() {
+		t.Fatalf("double-bored plate not a watertight solid: %+v", rr)
+	}
+	pairNamed := 0
+	for _, e := range s2.Edges() {
+		k := string(e.ReferenceKey())
+		if strings.Contains(k, "curvedbool:e#") {
+			t.Errorf("edge kept a build-order ordinal: %q (SSI-edge provenance missing)", k)
+		}
+		// A face-pair name carries the separator between the two parent faces' keys; the second bore's
+		// rim joins its cylinder wall (brep:drillwall) to a slab cap (slab:face).
+		if strings.Contains(k, "/curvedbool:x#0/") && strings.Contains(k, "drillwall") && strings.Contains(k, "slab:face") {
+			pairNamed++
+		}
+	}
+	if pairNamed == 0 {
+		t.Error("no second-bore rim edge got a wall×cap provenance name — SSI-edge provenance did not fire")
 	}
 }
 

--- a/kernel/topo/provenance.go
+++ b/kernel/topo/provenance.go
@@ -4,7 +4,10 @@ package topo
 
 import (
 	"bytes"
+	stdmath "math"
 	"sort"
+
+	"oblikovati.org/math"
 )
 
 // Provenance naming (ADR-0043). A derived entity — an edge a boolean cuts, a fillet's tangent
@@ -52,36 +55,121 @@ func NameByParents(parents []Lineage, sep, rankSeed LineageToken, rank int) Line
 // or vertex any of whose faces is absent from faceProv keeps its existing (ordinal) name — so a
 // PARTIALLY-provenanced body (e.g. a constant fillet's cylinder + caps provenanced, a variable
 // fillet's ruling strips not yet) stays consistent, the un-provenanced region simply keeping its
-// build-order name. It mutates identity, so call it only during construction, before the body is
+// build-order name.
+//
+// Two derived entities can share the SAME parent set — two surface-intersection curves between the
+// same face pair (a cone crossing a cylinder cuts two branches), or two seam vertices where the same
+// faces meet. Naming both by the bare parent name would collide (one reference key, two entities), so
+// a parent set borne by more than one entity is disambiguated by a transform-invariant geometric
+// order (the entity's midpoint/position) into ranks 1..n — the rank disambiguator NameByParents
+// reserves. Edges and vertices are ranked in SEPARATE groups so a vertex's name never depends on the
+// edges around it. It mutates identity, so call it only during construction, before the body is
 // observed elsewhere. sep/rankSeed parameterize the composed names (see NameByParents).
 func (b *Body) RelineageByFaceProvenance(faceProv map[*Face]Lineage, sep, rankSeed LineageToken) {
+	edges := make([]provTarget, 0, len(b.Edges()))
 	for _, e := range b.Edges() {
-		if name, ok := provNameFromFaces(e.Faces(), faceProv, sep, rankSeed); ok {
-			e.lineage = name
-		}
+		edges = append(edges, provTarget{faces: e.Faces(), at: edgeRankPoint(e), set: func(l Lineage) { e.lineage = l }})
 	}
+	assignProvNames(edges, faceProv, sep, rankSeed)
+
+	verts := make([]provTarget, 0, len(b.Vertices()))
 	for _, v := range b.Vertices() {
-		if name, ok := provNameFromFaces(vertexFaces(v), faceProv, sep, rankSeed); ok {
-			v.lineage = name
+		verts = append(verts, provTarget{faces: vertexFaces(v), at: v.point, set: func(l Lineage) { v.lineage = l }})
+	}
+	assignProvNames(verts, faceProv, sep, rankSeed)
+}
+
+// provTarget is one entity (edge or vertex) to be provenance-named: its bordering faces, a
+// transform-invariant geometric point that orders siblings sharing a parent set, and a setter that
+// stamps the resolved lineage onto the entity.
+type provTarget struct {
+	faces []*Face
+	at    math.Point3
+	set   func(Lineage)
+}
+
+// provGroup collects the targets that resolve to one parent set, so a set borne by several entities
+// can be disambiguated by rank.
+type provGroup struct {
+	parents []Lineage
+	members []provTarget
+}
+
+// assignProvNames names each target by its faces' provenance, disambiguating targets that share the
+// same parent set with a geometric rank (see RelineageByFaceProvenance). A target any of whose faces
+// lacks provenance keeps its existing name.
+func assignProvNames(targets []provTarget, faceProv map[*Face]Lineage, sep, rankSeed LineageToken) {
+	groups := map[string]*provGroup{}
+	var order []string
+	for _, t := range targets {
+		parents, ok := parentLineages(t.faces, faceProv)
+		if !ok {
+			continue
 		}
+		key := string(NameByParents(parents, sep, rankSeed, 0).Key())
+		if groups[key] == nil {
+			groups[key] = &provGroup{parents: parents}
+			order = append(order, key)
+		}
+		groups[key].members = append(groups[key].members, t)
+	}
+	for _, key := range order {
+		nameGroup(groups[key], sep, rankSeed)
 	}
 }
 
-// provNameFromFaces composes a provenance name from faces' provenance lineages, or ok=false when
-// any face has no provenance (so the entity keeps its existing name).
-func provNameFromFaces(faces []*Face, faceProv map[*Face]Lineage, sep, rankSeed LineageToken) (Lineage, bool) {
+// nameGroup stamps a group's members: the bare parent name when one entity bears the set, else the
+// parent name plus a geometric rank (1..n, ordered by the members' points) so the keys stay distinct.
+func nameGroup(g *provGroup, sep, rankSeed LineageToken) {
+	if len(g.members) == 1 {
+		g.members[0].set(NameByParents(g.parents, sep, rankSeed, 0))
+		return
+	}
+	sort.Slice(g.members, func(i, j int) bool { return lessPoint(g.members[i].at, g.members[j].at) })
+	for i, m := range g.members {
+		m.set(NameByParents(g.parents, sep, rankSeed, i+1))
+	}
+}
+
+// parentLineages collects the provenance lineages of an entity's faces, or ok=false when any face has
+// no provenance (so the entity keeps its existing name).
+func parentLineages(faces []*Face, faceProv map[*Face]Lineage) ([]Lineage, bool) {
 	if len(faces) == 0 {
-		return Lineage{}, false
+		return nil, false
 	}
 	parents := make([]Lineage, 0, len(faces))
 	for _, f := range faces {
 		p, ok := faceProv[f]
 		if !ok {
-			return Lineage{}, false
+			return nil, false
 		}
 		parents = append(parents, p)
 	}
-	return NameByParents(parents, sep, rankSeed, 0), true
+	return parents, true
+}
+
+// edgeRankPoint is a transform-invariant point that orders edges sharing a parent set. It samples the
+// edge's CURVE at its mid-parameter, not the endpoint midpoint, so the two arcs of a bigon — two
+// intersection branches between the same face pair that share BOTH endpoints (e.g. a Steinmetz
+// front/back pair, or a closed seam circle whose endpoints coincide) — get DISTINCT points and stable
+// ranks. A non-finite domain (an unbounded line) falls back to the endpoint midpoint.
+func edgeRankPoint(e *Edge) math.Point3 {
+	lo, hi := e.curve.Domain()
+	if stdmath.IsInf(lo, 0) || stdmath.IsInf(hi, 0) {
+		return edgeMidpoint(e)
+	}
+	return e.curve.PointAt((lo + hi) / 2)
+}
+
+// lessPoint is a total order on points (x, then y, then z) for stable sibling ranking.
+func lessPoint(a, b math.Point3) bool {
+	if a.X != b.X {
+		return a.X < b.X
+	}
+	if a.Y != b.Y {
+		return a.Y < b.Y
+	}
+	return a.Z < b.Z
 }
 
 // InheritOriginalEdges restores original edge identity to a derived body (ADR-0043): a result edge

--- a/kernel/topo/provenance_test.go
+++ b/kernel/topo/provenance_test.go
@@ -3,6 +3,8 @@
 package topo
 
 import (
+	stdmath "math"
+	"strings"
 	"testing"
 
 	"oblikovati.org/kernel/geom"
@@ -77,13 +79,59 @@ func TestRelineageByFaceProvenance(t *testing.T) {
 	provB := NewLineage(Tok("g", "b", 0))
 	body.RelineageByFaceProvenance(map[*Face]Lineage{f1: provA, f2: provB}, Tok("x", "x", 0), Tok("x", "seg", 0))
 
-	// bc borders both provenanced faces ⇒ named by both, canonically ordered.
+	// bc borders both provenanced faces, the only edge to do so ⇒ named by both, canonically ordered,
+	// no rank (a unique parent set needs none).
 	if got, want := string(bc.Lineage().Key()), "g:a#0/x:x#0/g:b#0"; got != want {
 		t.Errorf("shared edge bc = %q, want %q", got, want)
 	}
-	// ab borders only f1 ⇒ named by its single parent.
-	if got, want := string(ab.Lineage().Key()), "g:a#0"; got != want {
-		t.Errorf("boundary edge ab = %q, want %q", got, want)
+	// ab and ca BOTH border only f1 ⇒ they share the parent set {provA}; without disambiguation both
+	// would collide on "g:a#0". The geometric rank (ordered by midpoint) keeps the keys distinct.
+	abKey, caKey := string(ab.Lineage().Key()), string(ca.Lineage().Key())
+	if abKey == caKey {
+		t.Errorf("boundary edges ab and ca collide on %q — rank disambiguation missing", abKey)
+	}
+	for _, k := range []string{abKey, caKey} {
+		if !strings.HasPrefix(k, "g:a#0/x:seg#") {
+			t.Errorf("ranked boundary edge = %q, want prefix g:a#0/x:seg#", k)
+		}
+	}
+}
+
+// TestRelineageRanksBigonByCurveMidpoint pins the bigon case (ADR-0043 SSI-edge provenance): two
+// edges that share BOTH the same face pair AND the same endpoints — the two arcs of a bigon, as a cone
+// crossing a cylinder cuts two branches between one face pair — would collide on the bare parent name
+// AND on the endpoint midpoint. Ranking by the CURVE midpoint (edgeRankPoint) gives them distinct,
+// stable keys, ordered by geometry not build order.
+func TestRelineageRanksBigonByCurveMidpoint(t *testing.T) {
+	bld := NewBuilder(false, NewLineage(Tok("f", "body", 0)))
+	a := bld.AddVertex(math.P3(1, 0, 0), NewLineage(Tok("f", "vertex", 0)))
+	b := bld.AddVertex(math.P3(-1, 0, 0), NewLineage(Tok("f", "vertex", 1)))
+	// Two semicircle arcs a→b: e1 bows through (0,+1,0), e2 through (0,-1,0) — same endpoints, distinct
+	// curve midpoints.
+	up, _ := geom.NewArc3d(math.P3(0, 0, 0), math.V3(0, 0, 1), math.V3(1, 0, 0), 1, 0, stdmath.Pi)
+	dn, _ := geom.NewArc3d(math.P3(0, 0, 0), math.V3(0, 0, 1), math.V3(1, 0, 0), 1, 0, -stdmath.Pi)
+	e1 := bld.AddEdge(up, a, b, NewLineage(Tok("f", "edge", 0)))
+	e2 := bld.AddEdge(dn, a, b, NewLineage(Tok("f", "edge", 1)))
+	pl, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	f1 := bld.AddFace(pl, NewLineage(Tok("f", "face", 0)), OuterLoop(Fwd(e1), Rev(e2)))
+	f2 := bld.AddFace(pl, NewLineage(Tok("f", "face", 1)), OuterLoop(Fwd(e2), Rev(e1)))
+	body := bld.Build()
+
+	provA, provB := NewLineage(Tok("g", "a", 0)), NewLineage(Tok("g", "b", 0))
+	body.RelineageByFaceProvenance(map[*Face]Lineage{f1: provA, f2: provB}, Tok("x", "x", 0), Tok("x", "seg", 0))
+
+	k1, k2 := string(e1.Lineage().Key()), string(e2.Lineage().Key())
+	if k1 == k2 {
+		t.Fatalf("bigon arcs collide on %q — curve-midpoint rank disambiguation missing", k1)
+	}
+	for _, k := range []string{k1, k2} {
+		if !strings.HasPrefix(k, "g:a#0/x:x#0/g:b#0/x:seg#") {
+			t.Errorf("ranked bigon arc = %q, want prefix g:a#0/x:x#0/g:b#0/x:seg#", k)
+		}
+	}
+	// e2 (curve midpoint y=-1) sorts before e1 (y=+1), so e2 is rank 1, e1 rank 2 — geometry, not order.
+	if !strings.HasSuffix(k2, "x:seg#1") || !strings.HasSuffix(k1, "x:seg#2") {
+		t.Errorf("ranks not ordered by curve midpoint: e1=%q e2=%q", k1, k2)
 	}
 }
 


### PR DESCRIPTION
## What

The curved boolean's stitch (`curvedStitch`) minted every welded edge with a build-order ordinal (`curvedbool:e#N`). These renumber under any unrelated upstream edit, so a selection on a surface-intersection curve broke on recompute. This was the **last real naming gap** the curved boolean left open — `booleanGeneral` explicitly flagged it as a follow-up.

`curvedStitch` now relineages its result through `topo.RelineageByFaceProvenance`: each result face already carries a stable provenance lineage (an original face's key, or a wall/cap's parent-derived name), so the new intersection edges are named by their **bordering face pair** — a name independent of weld order. The downstream `InheritOriginalEdges` still restores the identity of original boundaries the cut passed through whole, so a survivor keeps its own key rather than a face-pair name.

## Why this is the right fix, not the cheap one

`RelineageByFaceProvenance` gains **geometric rank disambiguation**: when one face pair borders more than one edge — a cone crossing a cylinder cuts two branches (a *bigon*) — the siblings are ordered by their **curve midpoint** (not the endpoint midpoint, which a bigon's two arcs share) into ranks `1..n`, so the keys stay distinct instead of collapsing to one ambiguous reference. This also closes the same latent collision for the existing **fillet** and **stitch** callers of the shared primitive.

## Verification

- New `TestSecondBoreRimIsProvenanceNamed` (ops): a double-bored plate keeps **zero** `curvedbool:e#N` ordinals and names the second bore's rim by `brep:drillwall x slab:face` provenance; result stays a watertight manifold solid. Confirmed the gap was real — pre-change the same model left `curvedbool:e#15/16/17`.
- New `TestRelineageRanksBigonByCurveMidpoint` (topo): two arcs sharing one face pair AND both endpoints get distinct, geometry-ordered ranks.
- Full `kernel/...` + `model/...` regression green; full `golangci-lint` (not `--new-from-rev`) = 0 issues; `markdownlint-cli2` over `architecture/**` = 0 errors.

Part of the ADR-0043 provenance-naming milestone (#1539).

🤖 Generated with [Claude Code](https://claude.com/claude-code)