### PR TITLE
feat(ops): sheet-edge provenance for surface edits (ADR-0043)

### DIFF
--- a/kernel/ops/surface_edit.go
+++ b/kernel/ops/surface_edit.go
@@ -96,6 +96,7 @@ func buildSheet(patches []sheetPatch, feat string) *topo.Body {
 		edges[k] = e
 		return e
 	}
+	provByFace := map[*topo.Face]topo.Lineage{}
 	for fi, r := range rings {
 		surf, _ := geom.NewPlane(w.points[r[0]], normals[fi])
 		uses := make([]topo.Use, len(r))
@@ -103,9 +104,16 @@ func buildSheet(patches []sheetPatch, feat string) *topo.Body {
 			a, b := r[i], r[(i+1)%len(r)]
 			uses[i] = topo.Use{Edge: edge(a, b), Reversed: a > b}
 		}
-		bld.AddFace(surf, topo.NewLineage(topo.Tok(feat, "patch", fi)), topo.OuterLoop(uses...))
+		lineage := topo.NewLineage(topo.Tok(feat, "patch", fi))
+		provByFace[bld.AddFace(surf, lineage, topo.OuterLoop(uses...))] = lineage
 	}
-	return bld.Build()
+	body := bld.Build()
+	// ADR-0043 provenance: the welded edges above carry a build-order weld counter that renumbers under
+	// an upstream edit. Each patch face has a stable lineage (feat:patch#fi), so name a shared seam by
+	// its two patches and a boundary edge by its one patch (geometrically ranked among that patch's
+	// boundary edges), so a reference to a sheet edge survives a re-weld.
+	body.RelineageByFaceProvenance(provByFace, topo.Tok(feat, "x", 0), topo.Tok(feat, "seg", 0))
+	return body
 }
 
 // sheetWelder merges coincident boundary points onto a shared index list (a fine grid snap).

--- a/kernel/ops/surface_edit_test.go
+++ b/kernel/ops/surface_edit_test.go
@@ -3,6 +3,7 @@
 package ops
 
 import (
+	"strings"
 	"testing"
 
 	"oblikovati.org/kernel/topo"
@@ -67,6 +68,31 @@ func TestTrimMultiFaceSheet(t *testing.T) {
 	box := trimmed.RangeBox()
 	if !approx(box.Min.X, 1) || !approx(box.Max.X, 4) {
 		t.Errorf("trimmed x-span = [%v,%v], want [1,4]", box.Min.X, box.Max.X)
+	}
+}
+
+// TestSheetEdgesAreProvenanceNamed is ADR-0043: a sheet built by buildSheet (here via OffsetSurface)
+// used to mint its welded edges with a build-order weld counter (feat:edge#N) that renumbers under an
+// upstream edit. They must now be named by their patch provenance — a shared seam by its two patches,
+// a boundary edge by its one patch — so a reference to a sheet edge survives a re-weld.
+func TestSheetEdgesAreProvenanceNamed(t *testing.T) {
+	off, err := OffsetSurface(twoQuadSheet(t), 0.5, "off")
+	if err != nil {
+		t.Fatalf("OffsetSurface: %v", err)
+	}
+	seams := 0
+	for _, e := range off.Edges() {
+		k := string(e.ReferenceKey())
+		if strings.Contains(k, "off:edge#") {
+			t.Errorf("sheet edge kept a weld-counter ordinal: %q (provenance naming missing)", k)
+		}
+		// The one shared seam borders both patches, so it carries the separator between them.
+		if strings.Contains(k, "off:patch#0/off:x#0/off:patch#1") {
+			seams++
+		}
+	}
+	if seams != 1 {
+		t.Errorf("shared seam named by its two patches: got %d such edges, want 1", seams)
 	}
 }
 


### PR DESCRIPTION
## What

`buildSheet` (the welder behind `OffsetSurface`, `TrimByPlane`, `ExtendByEdge`, `MidSurfaces`) minted its welded edges with a build-order counter `Tok(feat,"edge",len(edges))`. That counter renumbers under any unrelated upstream edit, so a reference to a sheet edge broke on recompute. This was the **last ordinal user** of edge identity outside the degraded CSG triangle-soup fallback (which has no analytic parents to name from, by design).

Each patch face already carries a stable lineage (`feat:patch#fi`), so `buildSheet` now relineages its result through `topo.RelineageByFaceProvenance`: a shared seam is named by its **two patches**, a boundary edge by its **one patch** (geometrically ranked among that patch's boundary edges via the rank disambiguation introduced for the curved boolean's SSI edges in #1551). No sheet edge keeps a weld-counter name.

## Verification

- New `TestSheetEdgesAreProvenanceNamed`: an offset two-quad sheet keeps **zero** `off:edge#N` weld-counter names; the single shared seam is named `off:patch#0/off:x#0/off:patch#1`.
- All surface-edit tests + full `kernel/...` + `model/...` regression green; full `golangci-lint ./kernel/ops/` = 0 issues.

Completes the ADR-0043 provenance-naming milestone (#1539): every derived-topology generator in the modeling kernel now names by generating parents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)