### PR TITLE
fix(head): render on demand so an idle window stops burning CPU (#1493)

### DIFF
--- a/addin/dispatch/queue.go
+++ b/addin/dispatch/queue.go
@@ -38,6 +38,7 @@ type Dispatcher struct {
 	queue     chan *request
 	done      chan struct{}
 	closeOnce sync.Once
+	wakeup    func() // optional; see SetWakeup
 }
 
 // New returns a dispatcher whose queue holds up to capacity pending jobs before
@@ -52,6 +53,13 @@ func New(capacity int) *Dispatcher {
 	}
 }
 
+// SetWakeup registers a callback invoked (on the submitting goroutine) immediately after a
+// job is enqueued, so a consumer that is asleep waiting for work can be woken to Drain it.
+// The head sets this to post an empty window event (#1493): the render-on-demand loop blocks
+// when idle, and without a wake an add-in's submitted call would not run until the next OS
+// input event. Set it once before any Submit; fn must be safe to call from any goroutine.
+func (d *Dispatcher) SetWakeup(fn func()) { d.wakeup = fn }
+
 // Submit enqueues job and blocks until Drain runs it (returning its result), ctx is
 // cancelled, or the dispatcher is closed. NOTE: if ctx fires after the job is queued
 // but before it runs, Submit returns ctx.Err() yet the job may still run on a later
@@ -60,6 +68,9 @@ func (d *Dispatcher) Submit(ctx context.Context, job Job) ([]byte, error) {
 	req := &request{job: job, reply: make(chan result, 1)}
 	select {
 	case d.queue <- req:
+		if d.wakeup != nil {
+			d.wakeup() // rouse an idle consumer so this job drains promptly (#1493)
+		}
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	case <-d.done:

--- a/addin/dispatch/queue_test.go
+++ b/addin/dispatch/queue_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -132,6 +133,42 @@ func TestSubmitAfterClose(t *testing.T) {
 	d.Close() // idempotent
 	if _, err := d.Submit(context.Background(), func() ([]byte, error) { return nil, nil }); !errors.Is(err, ErrClosed) {
 		t.Fatalf("Submit after Close err = %v, want ErrClosed", err)
+	}
+}
+
+// TestWakeupFiresOnEnqueue pins the #1493 wake path: the head's render-on-demand loop sleeps
+// when idle, so a job an add-in submits from another goroutine must rouse the consumer or it
+// would not run until the next OS input event. SetWakeup's callback must fire when (and only
+// when) a job is enqueued — before it drains — so the head can post a window wake.
+func TestWakeupFiresOnEnqueue(t *testing.T) {
+	d := New(4)
+	var woke int32
+	d.SetWakeup(func() { atomic.AddInt32(&woke, 1) })
+
+	if got := atomic.LoadInt32(&woke); got != 0 {
+		t.Fatalf("wakeup fired %d times before any Submit, want 0", got)
+	}
+	go func() { _, _ = d.Submit(context.Background(), func() ([]byte, error) { return nil, nil }) }()
+	waitFor(t, func() bool { return atomic.LoadInt32(&woke) == 1 }, "wakeup fired once on enqueue")
+	d.Drain(0)
+	if got := atomic.LoadInt32(&woke); got != 1 {
+		t.Fatalf("wakeup fired %d times, want exactly 1 (one enqueue)", got)
+	}
+}
+
+// TestWakeupOptional confirms a dispatcher with no wakeup registered still works (the head is
+// the only caller that sets one; tests and the bridge do not).
+func TestWakeupOptional(t *testing.T) {
+	d := New(4)
+	got := make(chan []byte, 1)
+	go func() {
+		out, _ := d.Submit(context.Background(), func() ([]byte, error) { return []byte("ok"), nil })
+		got <- out
+	}()
+	waitFor(t, func() bool { return d.Pending() == 1 }, "job queued without a wakeup")
+	d.Drain(0)
+	if string(<-got) != "ok" {
+		t.Fatal("Submit without a wakeup did not run the job")
 	}
 }
 

--- a/app/redraw.go
+++ b/app/redraw.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// WantsContinuousRedraw reports whether the session has time-driven work in flight that the
+// head must keep rendering frame-after-frame even with no user input: a running camera tween
+// or joint-drive playback (both advanced by per-frame delta time), or an in-progress bug
+// report (a capture→submit state machine the loop services each frame). The render-on-demand
+// loop (#1493) sleeps when this is false and the UI is otherwise idle; it must consult this
+// so an animation in progress never freezes mid-transition. Centralize new time-driven
+// states here so the idle loop keeps covering them.
+//
+// Example: for !win.ShouldClose() { drawFrame(); if session.WantsContinuousRedraw() { tick() } else { block() } }
+func (s *Session) WantsContinuousRedraw() bool {
+	return s.CameraAnimating() || s.DriveAnimating() || s.BugReportInProgress()
+}

--- a/app/redraw_test.go
+++ b/app/redraw_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/scene"
+)
+
+// TestWantsContinuousRedraw pins the #1493 contract that the render-on-demand loop relies on: an
+// idle session reports false (so the head may block at ~0% CPU), but a running camera tween
+// reports true (so the head keeps ticking and the animation does not freeze mid-transition).
+func TestWantsContinuousRedraw(t *testing.T) {
+	s := NewSession()
+	if s.WantsContinuousRedraw() {
+		t.Fatal("a fresh idle session wants continuous redraw; the loop would never block (#1493)")
+	}
+
+	target := scene.NewCamera(800, 600)
+	s.AnimateCameraTo(target, sketchViewTweenSeconds)
+	if !s.CameraAnimating() {
+		t.Fatal("AnimateCameraTo did not start a tween; test premise invalid")
+	}
+	if !s.WantsContinuousRedraw() {
+		t.Fatal("a running camera tween must want continuous redraw, else the animation freezes (#1493)")
+	}
+
+	s.TickCameraAnimation(sketchViewTweenSeconds) // run the tween to completion
+	if s.CameraAnimating() {
+		t.Fatal("tween still active after full duration; test premise invalid")
+	}
+	if s.WantsContinuousRedraw() {
+		t.Fatal("session still wants continuous redraw after the tween finished; the loop would never idle (#1493)")
+	}
+}

--- a/head/cmd/oblikovati-head/addins.go
+++ b/head/cmd/oblikovati-head/addins.go
@@ -20,6 +20,7 @@ import (
 	"oblikovati.org/app"
 	"oblikovati.org/event"
 	"oblikovati.org/head/internal/addinhost"
+	"oblikovati.org/head/internal/native"
 	"oblikovati.org/persistence/addinstate"
 	"oblikovati.org/persistence/dialogmemory"
 	"oblikovati.org/script/bridge"
@@ -57,6 +58,9 @@ type addInHost struct {
 // the frame loop can drain.
 func startAddIns(session *app.Session) *addInHost {
 	d := dispatch.New(64)
+	// Wake the render-on-demand loop (#1493) whenever an add-in submits work, so its model
+	// change is drained and drawn promptly instead of waiting for the next OS input event.
+	d.SetWakeup(native.PostEmptyEvent)
 	rtr := router.New(opregistry.Default())
 	// Route kernel logs into the router's operation trace so a driver can read both the
 	// op-trace and any slog records over the bridge (logs.tail / tail_logs).

--- a/head/cmd/oblikovati-head/main.go
+++ b/head/cmd/oblikovati-head/main.go
@@ -73,6 +73,7 @@ func run(session *app.Session, maxFrames int) error {
 	gpu, vulkanVersion := win.GPUInfo()      // read once from the live renderer for telemetry
 	reportUsage(session, gpu, vulkanVersion) // anonymous installation telemetry, opt-out (#1182)
 
+	cooldown := animationCooldownFrames // paint a few frames at startup before idling
 	for frame := 0; ; frame++ {
 		if maxFrames > 0 && frame >= maxFrames {
 			break
@@ -80,9 +81,41 @@ func run(session *app.Session, maxFrames int) error {
 		if pumpFrame(win, session, addins, updates) {
 			break
 		}
+		if maxFrames > 0 {
+			continue // bounded smoke runs render flat-out; they must never block on events
+		}
+		cooldown = pace(win, session, cooldown)
 	}
 	return nil
 }
+
+// pace renders on demand (#1493): it sleeps the loop between frames instead of re-rasterizing
+// an unchanging scene at the FIFO present rate, which on a software Vulkan rasterizer (a VM's
+// llvmpipe) draws every frame on the CPU and pegs the cores even when nothing changed. While
+// the UI is animating — an active drag, a camera tween, or the cooldown burst after input — it
+// ticks at animationTickSeconds so transitions stay smooth; once idle it blocks until an OS
+// event or a posted wake (an add-in submitting work, a finished update check). It returns the
+// next cooldown: refilled while animation continues, reset to a fresh burst after each wake so
+// any animation an event triggers plays out, otherwise counted down toward the idle block.
+func pace(win *native.Window, session *app.Session, cooldown int) int {
+	if win.WantsAnimationFrame() || session.WantsContinuousRedraw() {
+		cooldown = animationCooldownFrames
+	}
+	if cooldown > 0 {
+		win.WaitEvents(animationTickSeconds)
+		return cooldown - 1
+	}
+	win.WaitEventsBlocking()       // idle: sleep at ~0% CPU until something happens
+	return animationCooldownFrames // woke from an event — burst a few frames so it can settle
+}
+
+// animationTickSeconds is the redraw cadence while the UI is animating; animationCooldownFrames
+// is how many frames to keep drawing after the last activity so input-triggered transitions
+// (a menu opening, a tooltip appearing) play out before the loop blocks again.
+const (
+	animationTickSeconds    = 1.0 / 60.0
+	animationCooldownFrames = 20
+)
 
 // pumpFrame renders one frame: chrome (+ executing a clicked command), draining add-in
 // calls, and the close prompt. It returns true when the loop should exit — the user closed

--- a/head/cmd/oblikovati-head/updates.go
+++ b/head/cmd/oblikovati-head/updates.go
@@ -12,6 +12,7 @@ import (
 
 	"oblikovati.org/app"
 	"oblikovati.org/build"
+	"oblikovati.org/head/internal/native"
 	"oblikovati.org/update"
 )
 
@@ -61,6 +62,7 @@ func (p *updatePoller) launch(manual bool) {
 			}
 		}
 		p.outcome.Store(&updateOutcome{res: res, manual: manual})
+		native.PostEmptyEvent() // wake the idle loop so serviceUpdates surfaces the result (#1493)
 	}()
 }
 

--- a/head/internal/native/app.cpp
+++ b/head/internal/native/app.cpp
@@ -326,6 +326,34 @@ void obk_head_set_should_close(void* h, int v) {
     glfwSetWindowShouldClose(c->window, v);
 }
 
+// obk_head_wait_events_timeout sleeps the (main) thread until a window event arrives or
+// `seconds` elapse, processing any pending events before it returns. The loop uses it as the
+// short tick WHILE the UI is animating (a camera tween, an active drag, the few frames after
+// input) so transitions stay smooth without a CPU-bound 60 Hz spin.
+void obk_head_wait_events_timeout(double seconds) {
+    glfwWaitEventsTimeout(seconds);
+}
+
+// obk_head_wait_events blocks the (main) thread INDEFINITELY until a window event arrives or
+// obk_head_post_empty_event is posted, then processes pending events and returns. The loop
+// uses it when the UI is fully idle: with FIFO present the loop's only throttle is the
+// present, which on a software Vulkan rasterizer (a VM's llvmpipe — #1493) rasterizes every
+// frame on the CPU and pegs the cores even when nothing changed. Blocking here drops idle
+// CPU to ~0 until the user acts or a background producer wakes us. Headless/smoke runs
+// (bounded frame counts) must NOT call this, or the loop would hang waiting for an event.
+void obk_head_wait_events(void) {
+    glfwWaitEvents();
+}
+
+// obk_head_post_empty_event wakes a thread blocked in obk_head_wait_events from ANY goroutine
+// (glfwPostEmptyEvent is one of the few thread-safe GLFW calls). A background producer that
+// changes what should be on screen without an OS input event — an add-in submitting model
+// work, a finished update check — posts this so the idle loop renders the change promptly
+// instead of waiting for the user to move the mouse (#1493).
+void obk_head_post_empty_event(void) {
+    glfwPostEmptyEvent();
+}
+
 // obk_head_get_window_state reports the window's current position (virtual-screen
 // coordinates, so the value encodes which monitor it's on), size, and maximized flag, for
 // persisting the placement across sessions.

--- a/head/internal/native/idle_wait_test.go
+++ b/head/internal/native/idle_wait_test.go
@@ -1,0 +1,96 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package native
+
+import (
+	"testing"
+	"time"
+)
+
+// TestWaitEventsBlocksWhenIdle pins the #1493 fix: the interactive loop renders on demand by
+// sleeping in WaitEvents between frames instead of spinning at vsync. On a software Vulkan
+// rasterizer (a VM's llvmpipe) every frame is drawn on the CPU, so an idle window that
+// re-rendered each vsync pegged the cores. The behavioural guarantee is that WaitEvents
+// actually BLOCKS for ~the timeout when no input arrives (a regression to a non-blocking poll
+// would return instantly and reintroduce the spin), while still respecting the timeout so the
+// loop never hangs.
+func TestWaitEventsBlocksWhenIdle(t *testing.T) {
+	w, err := CreateWindow(320, 240, "Oblikovati (#1493 idle-wait test)")
+	if err != nil {
+		t.Skipf("no window/Vulkan available: %v", err)
+	}
+	defer w.Destroy()
+
+	// Drain the queue of window-creation events (show/focus/refresh) so the timed calls below
+	// sleep on a genuinely empty queue rather than returning early on a startup event.
+	w.BeginFrame()
+	w.EndFrame(0.1, 0.1, 0.12)
+	for i := 0; i < 3; i++ {
+		w.WaitEvents(0.01)
+	}
+
+	// Sum several idle waits: under xvfb no spontaneous events arrive, so blocking waits total
+	// ~N*d, while a non-blocking poll would total ~0. The lower bound (2*d) sits well above
+	// timing noise yet far under the real N*d, tolerating an occasional stray early return.
+	const d = 0.1
+	const n = 5
+	start := time.Now()
+	for i := 0; i < n; i++ {
+		w.WaitEvents(d)
+	}
+	elapsed := time.Since(start).Seconds()
+
+	if elapsed < 2*d {
+		t.Errorf("%d idle WaitEvents(%.2fs) took %.3fs total; want >= %.2fs — the loop is not "+
+			"blocking when idle (reverted to a busy poll? #1493)", n, d, elapsed, 2*d)
+	}
+	if elapsed > n*d+1.0 {
+		t.Errorf("%d idle WaitEvents(%.2fs) took %.3fs total; want < %.2fs — WaitEvents is not "+
+			"respecting its timeout (the loop could hang)", n, d, elapsed, n*d+1.0)
+	}
+}
+
+// TestPostEmptyEventWakesBlockingWait pins the #1493 wake path: when fully idle the loop blocks
+// indefinitely in WaitEventsBlocking, so a background producer (an add-in submitting work, a
+// finished update check) MUST be able to rouse it from another goroutine via PostEmptyEvent —
+// otherwise its change would not render until the user moved the mouse. The wait must block
+// (not return instantly) yet return promptly once the event is posted.
+func TestPostEmptyEventWakesBlockingWait(t *testing.T) {
+	w, err := CreateWindow(320, 240, "Oblikovati (#1493 wake test)")
+	if err != nil {
+		t.Skipf("no window/Vulkan available: %v", err)
+	}
+	defer w.Destroy()
+
+	w.BeginFrame()
+	w.EndFrame(0.1, 0.1, 0.12)
+	for i := 0; i < 3; i++ {
+		w.WaitEvents(0.01) // drain startup events so the blocking wait below starts on an empty queue
+	}
+
+	const postAfter = 150 * time.Millisecond
+	go func() {
+		time.Sleep(postAfter)
+		PostEmptyEvent()
+	}()
+	// Backstop so a broken wake never hangs the suite: a far-later post forces a return, and the
+	// upper-bound assertion below then fails cleanly instead of the test timing out.
+	go func() {
+		time.Sleep(3 * time.Second)
+		PostEmptyEvent()
+	}()
+
+	start := time.Now()
+	w.WaitEventsBlocking()
+	elapsed := time.Since(start)
+
+	if elapsed < postAfter/2 {
+		t.Errorf("WaitEventsBlocking returned after %v, want >= %v — it did not block (busy return? #1493)",
+			elapsed, postAfter/2)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("WaitEventsBlocking returned after %v, want < 2s — PostEmptyEvent did not wake it (#1493)", elapsed)
+	}
+}

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -86,6 +86,7 @@ int  obk_ig_invisible_button(const char* id, float w, float h);
 int  obk_ig_begin_overlay_window(const char* name);
 int  obk_ig_is_item_active(void);
 int  obk_ig_is_item_hovered(void);
+int  obk_ig_any_mouse_down(void);
 int  obk_ig_mouse_down(int button);
 int  obk_ig_is_item_clicked(int button);
 void obk_ig_item_rect_min(float* x, float* y);
@@ -920,6 +921,26 @@ func BeginOverlayWindow(name string) bool {
 // pointer is over it this frame.
 func IsItemActive() bool  { return C.obk_ig_is_item_active() != 0 }
 func IsItemHovered() bool { return C.obk_ig_is_item_hovered() != 0 }
+
+// AnyItemActive reports whether ANY widget is mid-interaction (a slider being dragged, a
+// text field being edited). AnyMouseDown reports whether any mouse button is held. The
+// render-on-demand loop keeps drawing while either holds, so an interaction in progress
+// never stalls waiting for the next OS event (#1493).
+func AnyMouseDown() bool { return C.obk_ig_any_mouse_down() != 0 }
+
+// WantsAnimationFrame reports whether the UI is mid-motion this frame, so the render-on-demand
+// loop keeps drawing rather than blocking (#1493): a held mouse button (a drag in progress,
+// even momentarily still) or pointer movement (driving a hover, tooltip, or transition). The
+// loop ORs this with the session's own time-driven states (camera tween, drive playback) and a
+// post-input cooldown burst. NOTE: it deliberately does NOT use IsAnyItemActive — the viewport's
+// input-capturing InvisibleButton reads as active every frame, which would pin the loop on.
+func (w *Window) WantsAnimationFrame() bool {
+	if AnyMouseDown() {
+		return true
+	}
+	dx, dy := MouseDelta()
+	return dx != 0 || dy != 0
+}
 
 // MouseDown reports whether the given mouse button is currently pressed.
 func MouseDown(button int) bool { return C.obk_ig_mouse_down(C.int(button)) != 0 }

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -530,6 +530,12 @@ int  obk_ig_is_item_toggled_open(void)                 { return ImGui::IsItemTog
 void obk_ig_pop_id(void)                               { ImGui::PopID(); }
 int  obk_ig_is_item_deactivated_after_edit(void)       { return ImGui::IsItemDeactivatedAfterEdit() ? 1 : 0; }
 
+// any_mouse_down feeds the render-on-demand loop's "still animating" test (#1493): a held
+// mouse button means a drag is in progress, so the loop keeps drawing instead of sleeping.
+// (IsAnyItemActive is intentionally NOT exposed: the viewport's input-capturing
+// InvisibleButton reads as active every frame, which would defeat the idle block.)
+int  obk_ig_any_mouse_down(void)                       { return ImGui::IsAnyMouseDown() ? 1 : 0; }
+
 // want_capture_mouse reports whether ImGui consumed the pointer this frame, so the Go
 // loop knows when NOT to forward a click to the 3D viewport (picking).
 int  obk_ig_want_capture_mouse(void)         { return ImGui::GetIO().WantCaptureMouse ? 1 : 0; }

--- a/head/internal/native/native.go
+++ b/head/internal/native/native.go
@@ -21,6 +21,9 @@ int   obk_head_should_close(void* h);
 void  obk_head_set_should_close(void* h, int v);
 void  obk_head_begin_frame(void* h);
 void  obk_head_end_frame(void* h, float r, float g, float b);
+void  obk_head_wait_events_timeout(double seconds);
+void  obk_head_wait_events(void);
+void  obk_head_post_empty_event(void);
 void  obk_head_destroy(void* h);
 void  obk_head_get_window_state(void* h, int* x, int* y, int* w, int* hh, int* maximized);
 void  obk_head_apply_window_state(void* h, int x, int y, int maximized);
@@ -98,6 +101,30 @@ func (w *Window) BeginFrame() { C.obk_head_begin_frame(w.handle) }
 func (w *Window) EndFrame(r, g, b float32) {
 	C.obk_head_end_frame(w.handle, C.float(r), C.float(g), C.float(b))
 }
+
+// WaitEvents blocks until a window event arrives or `seconds` elapse, then returns. The loop
+// uses it as the short tick WHILE the UI is animating (a camera tween, an active drag, the
+// burst of frames after input), so transitions stay smooth without a 60 Hz CPU-bound spin.
+// Input wakes it immediately. Headless/smoke runs must not call it (they'd block per frame).
+func (w *Window) WaitEvents(seconds float64) {
+	C.obk_head_wait_events_timeout(C.double(seconds))
+}
+
+// WaitEventsBlocking blocks indefinitely until a window event arrives or PostEmptyEvent is
+// posted, then returns. The loop uses it when the UI is fully idle: with FIFO present the
+// only throttle is the present, and on a software Vulkan rasterizer (a VM's llvmpipe) every
+// present rasterizes the whole frame on the CPU, so an unchanging scene pegs the cores for
+// nothing (#1493). Blocking here drops idle CPU to ~0 until the user acts or a background
+// producer posts a wake. Headless/smoke runs must not call it (the loop would hang).
+func (w *Window) WaitEventsBlocking() {
+	C.obk_head_wait_events()
+}
+
+// PostEmptyEvent wakes a loop blocked in WaitEventsBlocking from ANY goroutine (it is one of
+// the few thread-safe GLFW calls). A background producer that changes what should be on
+// screen without an OS input event — an add-in submitting model work, a finished update
+// check — posts this so the idle loop renders the change promptly (#1493).
+func PostEmptyEvent() { C.obk_head_post_empty_event() }
 
 // GPUInfo reports the selected Vulkan physical device's name and API version (formatted
 // "major.minor.patch"), for anonymous installation telemetry (#1182). On macOS the device

--- a/head/ui/render_on_demand_test.go
+++ b/head/ui/render_on_demand_test.go
@@ -1,0 +1,48 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/head/internal/native"
+)
+
+// TestWantsAnimationFrameIdleVsInteracting is the #1493 regression guard for the render-on-demand
+// loop's wake predicate. It drives the FULL chrome (so the viewport's input-capturing
+// InvisibleButton is present) and asserts WantsAnimationFrame is FALSE when idle — the first cut
+// used IsAnyItemActive, which that button reads as active every frame, pinning the loop on and
+// leaving idle CPU unchanged. With a mouse button held it must read TRUE so an in-progress drag
+// never stalls. This is the behaviour that lets the loop block (idle CPU ~0) yet stay responsive.
+func TestWantsAnimationFrameIdleVsInteracting(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false // rebuild the default layout for this fresh window/context
+	icons = nil         // rebind the icon cache to this fresh window (it holds GPU handles)
+	s := framedSession()
+
+	frame := func() {
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.1)
+	}
+
+	// Settle the dock layout and the first-frame mouse delta with no synthetic input.
+	frame()
+	frame()
+	frame()
+	if win.WantsAnimationFrame() {
+		t.Fatal("WantsAnimationFrame is true while idle (no input) — the loop would never block, " +
+			"so idle CPU stays pinned (#1493); is the predicate using a stuck signal like IsAnyItemActive?")
+	}
+
+	// A held mouse button means a drag is in progress: the loop must keep drawing.
+	native.InjectMouseButton(0, true)
+	frame()
+	if !win.WantsAnimationFrame() {
+		t.Fatal("WantsAnimationFrame is false while a mouse button is held — an in-progress drag would stall (#1493)")
+	}
+	native.InjectMouseButton(0, false)
+}


### PR DESCRIPTION
## What

The windowed head now **renders on demand**: when nothing is changing it sleeps the frame loop instead of re-drawing the same scene every vsync.

## Why

A user on a VM reported a steady **~250% CPU while idle** ([#1493](https://github.com/Oblikovati/Oblikovati/issues/1493)). The diagnostic was in the report's comment: they run **Mesa llvmpipe** — software Vulkan, no GPU.

The frame loop (`oblikovati-head/main.go`) redrew unconditionally every iteration, throttled only by the `VK_PRESENT_MODE_FIFO_KHR` present. On real hardware the GPU does the rasterization so the CPU idles between vsyncs — which is why this never shows up normally. On llvmpipe **every frame is rasterized on the CPU**, so an idle, untouched scene was being fully re-drawn ~60×/second across the cores.

Measured on llvmpipe (forced via `lvp_icd.json`), reproducing the VM:

| Loop | Idle CPU |
|---|---|
| before (unconditional 60 fps) | **~310%** |
| 5 fps tick (rejected — each software frame is ~0.5–1 CPU-sec, so this barely helped: ~256%) | ~256% |
| **render-on-demand (this PR)** | **~0%** |

Because each software frame is so expensive, *lowering* the redraw rate isn't enough — the loop must not redraw **at all** when nothing changed.

## How

- **Block when idle.** `pace()` calls `WaitEventsBlocking` (`glfwWaitEvents`) once the UI is quiescent → idle CPU ~0; any OS input wakes it instantly.
- **Tick only while animating.** It ticks at ~60 Hz while `WantsAnimationFrame` (a held drag / pointer motion) or `Session.WantsContinuousRedraw` (camera tween, joint-drive playback, in-progress bug report) holds, plus a short cooldown burst after each wake so input-triggered transitions and tooltips settle.
- **Wake on background change.** `dispatch.Dispatcher.SetWakeup` posts `glfwPostEmptyEvent` (thread-safe) when an add-in submits work, and the update poller posts on completion — so model changes still render promptly without an OS input event. This keeps the MCP bridge / add-ins responsive.
- Bounded smoke runs (`-frames N`) keep rendering flat-out and never block.

`WantsAnimationFrame` deliberately avoids `IsAnyItemActive`: the viewport's input-capturing `InvisibleButton` reads as active every frame, which would pin the loop on (caught in review by a live measurement — first cut still showed full CPU).

## Tests
- `dispatch`: `TestWakeupFiresOnEnqueue` / `TestWakeupOptional` — the wake callback fires once per enqueue and is optional.
- `native`: `TestWaitEventsBlocksWhenIdle`, `TestPostEmptyEventWakesBlockingWait` — the wait blocks when idle yet returns promptly on a posted wake.
- `app`: `TestWantsContinuousRedraw` — idle false, running tween true.
- `ui`: `TestWantsAnimationFrameIdleVsInteracting` — drives the **full chrome** and asserts the predicate is false when idle (the `IsAnyItemActive` regression guard) and true while a button is held.
- Live: idle CPU 0% on llvmpipe; `-frames 8` smoke exits in 0.9 s.

Closes #1493

🤖 Generated with [Claude Code](https://claude.com/claude-code)