### PR TITLE
fix(dwg): read 5-byte Modular Chars in the object map (#1549)

### DIFF
--- a/head/cmd/dwgshot/main.go
+++ b/head/cmd/dwgshot/main.go
@@ -1,0 +1,138 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Command dwgshot is a throwaway live-capture driver to confirm a DWG import renders: it
+// imports a .dwg onto the XY plane of a fresh part, frames it top-down from the decoded
+// geometry's extent, and saves a PNG from the real DrawChrome viewport. Used to verify the
+// #1549 fix (large object-map location deltas) end to end.
+//
+//	go run ./head/cmd/dwgshot -in /path/file.dwg -out /tmp/dwgshot.png
+package main
+
+import (
+	"flag"
+	"fmt"
+	"math"
+	"os"
+	"sort"
+
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+	"oblikovati.org/head/ui"
+	"oblikovati.org/kernel/exchange/drawing"
+	"oblikovati.org/kernel/exchange/dwg"
+	gmath "oblikovati.org/math"
+)
+
+func main() {
+	in := flag.String("in", "", "DWG file to import")
+	out := flag.String("out", "/tmp/dwgshot.png", "output PNG path")
+	frames := flag.Int("frames", 8, "frames to render before capture")
+	flag.Parse()
+	if *in == "" {
+		fmt.Fprintln(os.Stderr, "dwgshot: -in is required")
+		os.Exit(2)
+	}
+	if err := run(*in, *out, *frames); err != nil {
+		fmt.Fprintln(os.Stderr, "dwgshot:", err)
+		os.Exit(1)
+	}
+}
+
+func run(in, out string, frames int) error {
+	s := app.NewSession()
+	if err := app.RegisterStandardCommands(s); err != nil {
+		return err
+	}
+	if _, err := s.NewPart(); err != nil {
+		return err
+	}
+	res, err := s.ImportDWGOnPlane(in, "XY Plane")
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "imported %d entities (3D=%v, %d warnings) from %s\n", res.EntityCount, res.Is3D, len(res.Warnings), in)
+	frameDrawing(s, in)
+	s.TickCameraAnimation(100)
+	return capture(s, out, frames)
+}
+
+func frameDrawing(s *app.Session, in string) {
+	box, ok := drawingBox(in)
+	if !ok {
+		return
+	}
+	cam := s.Camera()
+	cam.Up = gmath.V3(0, 1, 0)
+	cam.Target = box.Center()
+	cam.Eye = box.Center().TranslateBy(gmath.V3(0, 0, 1).Scale(float64(box.Diagonal().Length())))
+	s.SetCamera(cam.Fit(box))
+}
+
+// drawingBox returns an origin-centred framing box for the drawing's dense core. A
+// georeferenced survey carries a few stray entities millions of units away that would blow up
+// a raw min/max box, so we mirror the importer: subtract the per-axis median (which it shifts
+// to the origin) and frame the 95th percentile of |offset|, in the model's cm (1 unit = 10 mm).
+func drawingBox(in string) (gmath.Box, bool) {
+	data, err := os.ReadFile(in)
+	if err != nil {
+		return gmath.Box{}, false
+	}
+	dr, _, err := dwg.Decode(data)
+	if err != nil {
+		return gmath.Box{}, false
+	}
+	xs, ys := points(dr)
+	if len(xs) == 0 {
+		return gmath.Box{}, false
+	}
+	hx := percentileAbs(xs, gmath.Median(append([]float64{}, xs...)), 0.95)
+	hy := percentileAbs(ys, gmath.Median(append([]float64{}, ys...)), 0.95)
+	return gmath.NewBox(gmath.P3(-hx*0.1, -hy*0.1, -1), gmath.P3(hx*0.1, hy*0.1, 1)), true
+}
+
+// points collects the 2D vertices of every line and polyline (in the decoder's millimetres).
+func points(dr *drawing.Drawing) ([]float64, []float64) {
+	var xs, ys []float64
+	for _, e := range dr.Entities {
+		switch g := e.(type) {
+		case *drawing.LwPolyline:
+			for _, p := range g.Points {
+				xs, ys = append(xs, p[0]), append(ys, p[1])
+			}
+		case *drawing.Line:
+			xs, ys = append(xs, g.Start[0], g.End[0]), append(ys, g.Start[1], g.End[1])
+		}
+	}
+	return xs, ys
+}
+
+// percentileAbs returns the q-quantile of |v - center| over vs (the robust half-extent).
+func percentileAbs(vs []float64, center, q float64) float64 {
+	d := make([]float64, len(vs))
+	for i, v := range vs {
+		d[i] = math.Abs(v - center)
+	}
+	sort.Float64s(d)
+	return d[int(q*float64(len(d)-1))]
+}
+
+func capture(s *app.Session, out string, frames int) error {
+	win, err := native.CreateWindow(1400, 1000, "dwgshot")
+	if err != nil {
+		return err
+	}
+	defer win.Destroy()
+	win.InitViewport()
+	for i := 0; i < frames; i++ {
+		win.BeginFrame()
+		ui.DrawChrome(win, s)
+		win.EndFrame(ui.WindowClearColor())
+	}
+	if err := win.SaveViewportPNG(out); err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stdout, "wrote", out)
+	return nil
+}

--- a/kernel/exchange/dwg/bitreader.go
+++ b/kernel/exchange/dwg/bitreader.go
@@ -274,11 +274,14 @@ func (r *BitReader) Read2BD() [2]float64 { return [2]float64{r.ReadBD(), r.ReadB
 func (r *BitReader) Read3BD() [3]float64 { return [3]float64{r.ReadBD(), r.ReadBD(), r.ReadBD()} }
 
 // ReadMC reads a Modular Char: little-endian 7-bit groups, high bit = continue,
-// with the terminating group's 0x40 bit as the sign. Spans at most 4 bytes.
+// with the terminating group's 0x40 bit as the sign. Spans at most 5 bytes: a
+// large positive value whose 4th 7-bit group already uses 0x40 needs a 5th group
+// to carry the sign (e.g. object-map location deltas in big files; see #1549).
+// This matches the reference decoder (libredwg bit_read_MC reads byte[5]).
 func (r *BitReader) ReadMC() int {
 	var result uint
 	var shift uint
-	for i := 0; i < 4; i++ {
+	for i := 0; i < 5; i++ {
 		b := uint(r.ReadRC())
 		if b&0x80 == 0 { // terminating group
 			result |= (b & 0x3f) << shift
@@ -290,7 +293,7 @@ func (r *BitReader) ReadMC() int {
 		result |= (b & 0x7f) << shift
 		shift += 7
 	}
-	r.fail("ReadMC exceeded 4 bytes")
+	r.fail("ReadMC exceeded 5 bytes")
 	return 0
 }
 

--- a/kernel/exchange/dwg/bitreader_test.go
+++ b/kernel/exchange/dwg/bitreader_test.go
@@ -197,6 +197,10 @@ func TestReadMC(t *testing.T) {
 		{"neg-five", []byte{0x45}, -5},
 		{"sixtyfour", []byte{0xC0, 0x00}, 64},
 		{"neg-sixtyfour", []byte{0xC0, 0x40}, -64},
+		// #1549: an object-map location delta from a 70 MB file whose 4th 7-bit
+		// group sets 0x40, forcing a 5th group to carry the (positive) sign. The
+		// old 4-byte cap rejected this as "exceeded 4 bytes".
+		{"five-bytes", []byte{0x86, 0x89, 0xb0, 0xde, 0x00}, 197919878},
 	}
 	for _, c := range cases {
 		var w bitWriter


### PR DESCRIPTION
## What

`ReadMC` (the DWG bit reader's signed Modular-Char decoder) now reads up to **5 bytes** instead of 4.

## Why

Importing a real 70 MB AutoCAD survey (`piracicaba.dwg`, issue #1549) failed hard with:

```
Import failed: import dwg: dwg object map: dwg bitreader at bit 216: ReadMC exceeded 4 bytes
```

The object map stores each object's file offset as a **signed** Modular-Char (MC) delta. The sign lives in the `0x40` bit of the *terminating* group, so a large positive offset whose 4th 7-bit group already uses `0x40` needs a **5th** group just to carry the sign. Big files (large/many object offsets) routinely hit this. The cap of 4 bytes aborted the entire import on the first such value.

This was also a latent round-trip bug: our `WriteMC` is unbounded and already emits 5-byte MCs, so the reader couldn't decode what the writer produces.

Raising the cap to 5 matches the reference decoder (libredwg `bit_read_MC` uses `byte[5]`). 5 groups give a 34-bit magnitude — ample for any object-data-stream offset.

## Verification

- New regression case in `TestReadMC` using the exact 5-byte MC lexed from the failing file (`0x86 0x89 0xb0 0xde 0x00` → `197919878`); the cursor-at-bit-216 failure reproduced the issue precisely.
- The file now decodes to **75,530 entities, 0 warnings** (was: hard error).
- Live-verified end to end with a throwaway `head/cmd/dwgshot` capture driver: the import renders as the full Piracicaba street map in the real viewport.
- `kernel/exchange/dwg`, `model/exchange`, `app` test suites green; `golangci-lint` clean on touched code.

Closes #1549

🤖 Generated with [Claude Code](https://claude.com/claude-code)