### PR TITLE
feat(exchange): import vector PDFs into a sketch

### DIFF
--- a/addin/router/exchange.go
+++ b/addin/router/exchange.go
@@ -20,6 +20,7 @@ func (r *Router) registerExchangeHandlers() {
 	r.readOnly(wire.MethodDocumentsExport, exportDocument)
 	r.readOnly(wire.MethodImportDWG, importDWG)
 	r.readOnly(wire.MethodImportDXF, importDXF)
+	r.readOnly(wire.MethodImportPDF, importPDF)
 	r.readOnly(wire.MethodExportDXF, exportDXF)
 }
 
@@ -49,6 +50,21 @@ func importDXF(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 		return nil, fmt.Errorf("import.dxf: %w", err)
 	}
 	return json.Marshal(wire.ImportDXFResult{Is3D: res.Is3D, EntityCount: res.EntityCount, Warnings: res.Warnings})
+}
+
+// importPDF imports a vector .pdf (a CAD drawing plotted to PDF) into the active part: each
+// page's vector paths become a 2D sketch on the named work plane (default: first origin
+// plane). Text and raster images in the page are skipped.
+func importPDF(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
+	var in wire.ImportPDFArgs
+	if err := decode(raw, &in); err != nil {
+		return nil, err
+	}
+	res, err := s.ImportPDFOnPlane(in.Path, in.Plane)
+	if err != nil {
+		return nil, fmt.Errorf("import.pdf: %w", err)
+	}
+	return json.Marshal(wire.ImportPDFResult{Is3D: res.Is3D, EntityCount: res.EntityCount, Warnings: res.Warnings})
 }
 
 // exportDXF writes the active 2D sketch to a .dxf file at the requested version.

--- a/app/pdf_import_session.go
+++ b/app/pdf_import_session.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+
+	"oblikovati.org/model/exchange"
+	"oblikovati.org/model/sketch"
+)
+
+// ImportPDFFile imports a vector .pdf (a CAD drawing plotted to PDF) into the active part:
+// each page's curve geometry becomes a 2D sketch on plane (the user's chosen work plane).
+// The whole import is one undoable edit. It reuses DWGPlaneChoices for the plane list — the
+// drawing-import target planes are the same regardless of source format.
+//
+// Example:
+//
+//	choices, _ := s.DWGPlaneChoices()
+//	res, err := s.ImportPDFFile("plan.pdf", choices[0].Plane) // onto XY
+func (s *Session) ImportPDFFile(path string, plane sketch.Plane) (exchange.PDFImportResult, error) {
+	part, err := activePart(s)
+	if err != nil {
+		return exchange.PDFImportResult{}, err
+	}
+	// Open the undo baseline at the pre-import state so the (often many thousands of)
+	// per-entity sketch additions collapse into ONE undo step. Idempotent.
+	s.EnsureActiveEditBaseline()
+	res, err := exchange.ImportPDFFile(part, path, plane)
+	if err != nil {
+		return res, err
+	}
+	s.recordEdit(part, fmt.Sprintf("Import PDF (%d entities)", res.EntityCount))
+	return res, nil
+}
+
+// ImportPDFOnPlane imports a .pdf onto the named work plane (case-insensitive; e.g.
+// "XY Plane"), defaulting to the first origin plane when planeName is empty or unknown. It
+// is the name-keyed entry the RPC/CLI layer calls; the GUI uses ImportPDFFile with a plane
+// chosen from DWGPlaneChoices.
+func (s *Session) ImportPDFOnPlane(path, planeName string) (exchange.PDFImportResult, error) {
+	choices, err := s.DWGPlaneChoices()
+	if err != nil {
+		return exchange.PDFImportResult{}, err
+	}
+	if len(choices) == 0 {
+		return exchange.PDFImportResult{}, fmt.Errorf("import pdf: active part has no work planes")
+	}
+	plane := choices[0].Plane
+	if planeName != "" {
+		match, ok := planeByName(choices, planeName)
+		if !ok {
+			return exchange.PDFImportResult{}, fmt.Errorf("import pdf: no work plane named %q (have %s)", planeName, planeNames(choices))
+		}
+		plane = match
+	}
+	return s.ImportPDFFile(path, plane)
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.93.0
+	oblikovati.org/api v0.94.0
 )
 
 require (

--- a/head/cmd/pdfshot/main.go
+++ b/head/cmd/pdfshot/main.go
@@ -1,0 +1,141 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Command pdfshot is a throwaway live-capture driver for the vector-PDF importer: it imports
+// a CAD plot-to-PDF onto the XY plane of a fresh part, frames it top-down, and saves a PNG
+// from the real DrawChrome viewport — so the image is exactly what the app renders, proving
+// the imported sketch reproduces the source drawing.
+//
+//	go run ./head/cmd/pdfshot -in /path/plan.pdf -out /tmp/pdfshot.png
+package main
+
+import (
+	"flag"
+	"fmt"
+	"math"
+	"os"
+
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+	"oblikovati.org/head/ui"
+	"oblikovati.org/kernel/exchange/drawing"
+	"oblikovati.org/kernel/exchange/pdf"
+	gmath "oblikovati.org/math"
+)
+
+func main() {
+	in := flag.String("in", "", "PDF file to import")
+	out := flag.String("out", "/tmp/pdfshot.png", "output PNG path")
+	frames := flag.Int("frames", 8, "frames to render before capture")
+	flag.Parse()
+	if *in == "" {
+		fmt.Fprintln(os.Stderr, "pdfshot: -in is required")
+		os.Exit(2)
+	}
+	if err := run(*in, *out, *frames); err != nil {
+		fmt.Fprintln(os.Stderr, "pdfshot:", err)
+		os.Exit(1)
+	}
+}
+
+func run(in, out string, frames int) error {
+	s := app.NewSession()
+	if err := app.RegisterStandardCommands(s); err != nil {
+		return err
+	}
+	if _, err := s.NewPart(); err != nil {
+		return err
+	}
+	res, err := s.ImportPDFOnPlane(in, "XY Plane")
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "imported %d entities (3D=%v, %d warnings) from %s\n", res.EntityCount, res.Is3D, len(res.Warnings), in)
+	// The app's Zoom-All frames body bounds, which a sketch-only part lacks; frame the
+	// drawing's own extent (computed from the decoded geometry) so the capture shows it all.
+	frameDrawing(s, in)
+	s.TickCameraAnimation(100)
+	return capture(s, out, frames)
+}
+
+// frameDrawing points a top-down camera at the imported drawing's bounding box (in the
+// model's cm unit), so the whole sketch is visible in the capture.
+func frameDrawing(s *app.Session, in string) {
+	box, ok := drawingBox(in)
+	if !ok {
+		return
+	}
+	cam := s.Camera()
+	cam.Up = gmath.V3(0, 1, 0)
+	cam.Target = box.Center()
+	cam.Eye = box.Center().TranslateBy(gmath.V3(0, 0, 1).Scale(float64(box.Diagonal().Length())))
+	s.SetCamera(cam.Fit(box))
+}
+
+// drawingBox decodes the PDF and returns the bounding box of all page geometry, converted
+// from the decoder's millimetres to the model's centimetres (1 unit = 10 mm).
+func drawingBox(in string) (gmath.Box, bool) {
+	data, err := os.ReadFile(in)
+	if err != nil {
+		return gmath.Box{}, false
+	}
+	pages, _, err := pdf.DecodePages(data)
+	if err != nil {
+		return gmath.Box{}, false
+	}
+	lo := gmath.P3(math.Inf(1), math.Inf(1), -1)
+	hi := gmath.P3(math.Inf(-1), math.Inf(-1), 1)
+	for _, dr := range pages {
+		lo, hi = accumulate(dr, lo, hi)
+	}
+	if math.IsInf(float64(lo.X), 1) {
+		return gmath.Box{}, false
+	}
+	return gmath.NewBox(lo, hi), true
+}
+
+// accumulate expands lo/hi by every polyline vertex and spline control point of a page.
+func accumulate(dr *drawing.Drawing, lo, hi gmath.Point3) (gmath.Point3, gmath.Point3) {
+	for _, e := range dr.Entities {
+		switch g := e.(type) {
+		case *drawing.LwPolyline:
+			for _, p := range g.Points {
+				lo, hi = expand(lo, hi, p[0], p[1])
+			}
+		case *drawing.Spline:
+			for _, p := range g.ControlPoints {
+				lo, hi = expand(lo, hi, p[0], p[1])
+			}
+		}
+	}
+	return lo, hi
+}
+
+// expand grows the lo/hi corners to include (x, y) — converting the decoder's millimetres
+// to the model's centimetres (1 unit = 10 mm) — while keeping the z margin.
+func expand(lo, hi gmath.Point3, xmm, ymm float64) (gmath.Point3, gmath.Point3) {
+	x, y := xmm*0.1, ymm*0.1
+	return gmath.P3(math.Min(float64(lo.X), x), math.Min(float64(lo.Y), y), float64(lo.Z)),
+		gmath.P3(math.Max(float64(hi.X), x), math.Max(float64(hi.Y), y), float64(hi.Z))
+}
+
+// capture opens the live window, renders frames of the real chrome, and writes the viewport.
+func capture(s *app.Session, out string, frames int) error {
+	win, err := native.CreateWindow(1400, 1000, "pdfshot")
+	if err != nil {
+		return err
+	}
+	defer win.Destroy()
+	win.InitViewport()
+	for i := 0; i < frames; i++ {
+		win.BeginFrame()
+		ui.DrawChrome(win, s)
+		win.EndFrame(ui.WindowClearColor())
+	}
+	if err := win.SaveViewportPNG(out); err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stdout, "wrote", out)
+	return nil
+}

--- a/head/ui/file_dialog.go
+++ b/head/ui/file_dialog.go
@@ -131,7 +131,7 @@ var staticDialogTitles = map[fileDialogMode]string{
 	dialogMeshRef:        "Place Mesh (.stl)",
 	dialogPointCloud:     "Import Point Cloud (.xyz/.pts)",
 	dialogPlaceComponent: "Place Component",
-	dialogImport:         "Import (.stl/.obj/.3mf/.step/.dwg/.dxf · scans .ply/.e57/.las/.xyz/.pts)",
+	dialogImport:         "Import (.stl/.obj/.3mf/.step/.dwg/.dxf/.pdf · scans .ply/.e57/.las/.xyz/.pts)",
 	dialogExport:         "Export (.stl/.obj/.3mf/.step/.dxf)",
 	dialogExportBOM:      "Export BOM (.csv)",
 }
@@ -285,9 +285,9 @@ func (d *fileDialog) allowedExts() []string {
 	case dialogPointCloud:
 		return []string{".xyz", ".pts", ".asc", ".txt"}
 	case dialogImport:
-		// DWG/DXF import into a sketch, scan formats (.ply/.e57/.las/.xyz/.pts/.asc) into a point
-		// cloud, the rest into bodies.
-		return []string{".stl", ".obj", ".3mf", ".step", ".stp", ".dwg", ".dxf", ".ply", ".e57", ".las", ".xyz", ".pts", ".asc"}
+		// DWG/DXF/PDF import into a sketch, scan formats (.ply/.e57/.las/.xyz/.pts/.asc) into a
+		// point cloud, the rest into bodies.
+		return []string{".stl", ".obj", ".3mf", ".step", ".stp", ".dwg", ".dxf", ".pdf", ".ply", ".e57", ".las", ".xyz", ".pts", ".asc"}
 	case dialogExport:
 		// DXF exports the active sketch; the others export the part's bodies.
 		return []string{".stl", ".obj", ".3mf", ".step", ".stp", ".dxf"}

--- a/head/ui/file_dialog_draw.go
+++ b/head/ui/file_dialog_draw.go
@@ -359,71 +359,80 @@ func isDWGPath(path string) bool { return strings.EqualFold(filepath.Ext(path), 
 // isDXFPath reports whether path is a .dxf file (the other sketch-importing branch).
 func isDXFPath(path string) bool { return strings.EqualFold(filepath.Ext(path), ".dxf") }
 
-// isSketchPath reports whether path is a drawing file (.dwg/.dxf) that imports into a sketch.
-func isSketchPath(path string) bool { return isDWGPath(path) || isDXFPath(path) }
+// isPDFPath reports whether path is a .pdf file (a CAD drawing plotted to PDF → a sketch).
+func isPDFPath(path string) bool { return strings.EqualFold(filepath.Ext(path), ".pdf") }
 
-// importDWGFromFile imports a .dwg into the active part on the chosen work plane
-// (2D drawing → a sketch on that plane; 3D drawing → a Sketch3D), reporting the
-// outcome (File ▸ Import of a .dwg).
-func importDWGFromFile(s *app.Session, act fileAction, name string) {
+// isSketchPath reports whether path is a drawing file (.dwg/.dxf/.pdf) that imports into a sketch.
+func isSketchPath(path string) bool { return isDWGPath(path) || isDXFPath(path) || isPDFPath(path) }
+
+// importSketchFromFile imports a drawing file into the active part on the chosen work plane
+// (2D drawing → a sketch on that plane; 3D drawing → a Sketch3D), reporting the outcome.
+// readDrawing performs the format-specific read for the resolved plane and returns whether
+// it landed in 3D and how many entities were added — the shared body for the .dwg/.dxf/.pdf
+// import branches (File ▸ Import).
+func importSketchFromFile(s *app.Session, act fileAction, name string,
+	readDrawing func(app.WorkPlaneChoice) (is3D bool, entities int, err error)) {
 	choices, err := s.DWGPlaneChoices()
 	if err != nil {
 		fileNotice(s, importFailedFmt, err)
 		return
 	}
-	plane := choices[0].Plane
+	choice := choices[0]
 	if act.PlaneIndex >= 0 && act.PlaneIndex < len(choices) {
-		plane = choices[act.PlaneIndex].Plane
+		choice = choices[act.PlaneIndex]
 	}
-	res, err := s.ImportDWGFile(act.Path, plane)
+	is3D, entities, err := readDrawing(choice)
 	if err != nil {
 		fileNotice(s, importFailedFmt, err)
 		return
 	}
 	kind := "2D sketch"
-	if res.Is3D {
+	if is3D {
 		kind = "3D sketch"
 	}
-	fileNotice(s, "Imported %s into a %s (%d entities)", name, kind, res.EntityCount)
+	fileNotice(s, "Imported %s into a %s (%d entities)", name, kind, entities)
 }
 
-// importFromFile routes a File ▸ Import to the right reader by extension: .dwg/.dxf import
-// into a sketch (on the chosen work plane), the mesh/B-rep formats into bodies.
+// importDWGFromFile imports a .dwg into the active part on the chosen work plane.
+func importDWGFromFile(s *app.Session, act fileAction, name string) {
+	importSketchFromFile(s, act, name, func(c app.WorkPlaneChoice) (bool, int, error) {
+		res, err := s.ImportDWGFile(act.Path, c.Plane)
+		return res.Is3D, res.EntityCount, err
+	})
+}
+
+// importDXFFromFile imports a .dxf into the active part on the chosen work plane.
+func importDXFFromFile(s *app.Session, act fileAction, name string) {
+	importSketchFromFile(s, act, name, func(c app.WorkPlaneChoice) (bool, int, error) {
+		res, err := s.ImportDXFFile(act.Path, c.Plane)
+		return res.Is3D, res.EntityCount, err
+	})
+}
+
+// importPDFFromFile imports a vector .pdf (a CAD drawing plotted to PDF) into the active
+// part on the chosen work plane — each page's vector paths become a 2D sketch.
+func importPDFFromFile(s *app.Session, act fileAction, name string) {
+	importSketchFromFile(s, act, name, func(c app.WorkPlaneChoice) (bool, int, error) {
+		res, err := s.ImportPDFFile(act.Path, c.Plane)
+		return res.Is3D, res.EntityCount, err
+	})
+}
+
+// importFromFile routes a File ▸ Import to the right reader by extension: .dwg/.dxf/.pdf
+// import into a sketch (on the chosen work plane), the mesh/B-rep formats into bodies.
 func importFromFile(s *app.Session, act fileAction, name string) {
 	switch {
 	case isDWGPath(act.Path):
 		importDWGFromFile(s, act, name)
 	case isDXFPath(act.Path):
 		importDXFFromFile(s, act, name)
+	case isPDFPath(act.Path):
+		importPDFFromFile(s, act, name)
 	case pointcloud.IsScanFile(act.Path):
 		attachPointCloudFromFile(s, act.Path, name) // a 3D scan (.ply/.xyz/.pts…) → a point cloud (#645)
 	default:
 		importBodyFromFile(s, act.Path, name)
 	}
-}
-
-// importDXFFromFile imports a .dxf into the active part on the chosen work plane (2D drawing
-// → a sketch on that plane; 3D drawing → a Sketch3D), reporting the outcome.
-func importDXFFromFile(s *app.Session, act fileAction, name string) {
-	choices, err := s.DWGPlaneChoices()
-	if err != nil {
-		fileNotice(s, importFailedFmt, err)
-		return
-	}
-	plane := choices[0].Plane
-	if act.PlaneIndex >= 0 && act.PlaneIndex < len(choices) {
-		plane = choices[act.PlaneIndex].Plane
-	}
-	res, err := s.ImportDXFFile(act.Path, plane)
-	if err != nil {
-		fileNotice(s, importFailedFmt, err)
-		return
-	}
-	kind := "2D sketch"
-	if res.Is3D {
-		kind = "3D sketch"
-	}
-	fileNotice(s, "Imported %s into a %s (%d entities)", name, kind, res.EntityCount)
 }
 
 // exportToFile writes the active part to the chosen file: a .dxf exports the active sketch's

--- a/kernel/exchange/pdf/content.go
+++ b/kernel/exchange/pdf/content.go
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package pdf
+
+import (
+	"bytes"
+	"fmt"
+
+	"oblikovati.org/kernel/exchange/drawing"
+)
+
+// pdfPoint is a point already mapped to device space (PDF points) by the CTM in force when
+// the path operator ran — so later cm changes never move already-placed geometry.
+type pdfPoint struct{ x, y float64 }
+
+// segKind tags a path segment as a straight line or a cubic Bézier.
+type segKind int
+
+const (
+	segLine segKind = iota
+	segCurve
+)
+
+// segment is one element of a subpath: a line (one end point) or a cubic Bézier (its two
+// control points and its end point).
+type segment struct {
+	kind segKind
+	pts  []pdfPoint
+}
+
+// subpath is a connected run of segments from a start point, optionally closed back to it.
+type subpath struct {
+	start  pdfPoint
+	segs   []segment
+	closed bool
+}
+
+// maxFormDepth bounds Form-XObject recursion against a malformed self-referential page.
+const maxFormDepth = 16
+
+// interp executes a content stream's path/painting/state operators against a current
+// transformation matrix, accumulating the resulting curve geometry. Text, colour, and
+// raster operators are ignored — only vector paths become geometry.
+type interp struct {
+	doc       *document
+	resources dictObj
+	ctm       matrix
+	ctmStack  []matrix
+	operands  []objectValue
+	path      []subpath
+	cur       pdfPoint
+	open      bool // a subpath is in progress (an m without a following painting op)
+	out       []drawing.Entity
+	warns     []string
+	seen      map[string]bool
+	depth     int
+}
+
+// run interprets a content-stream byte slice, dispatching each operator and pushing each
+// operand onto the stack until end of input.
+func (in *interp) run(content []byte) {
+	lex := newLexer(content)
+	p := newParser(lex)
+	for {
+		t := p.read()
+		if t.kind == tokEOF {
+			return
+		}
+		if t.kind == tokKeyword {
+			in.dispatchKeyword(t, lex)
+			continue
+		}
+		p.unread(t)
+		if v := p.parseValue(); v != nil {
+			in.operands = append(in.operands, v)
+		} else {
+			p.read() // consume a stray token to make progress
+		}
+	}
+}
+
+// dispatchKeyword handles a keyword token: the three literals push operands, BI skips an
+// inline image, and any other keyword is an operator that consumes the operand stack.
+func (in *interp) dispatchKeyword(t token, lex *lexer) {
+	switch t.text {
+	case "true":
+		in.operands = append(in.operands, boolObj(true))
+	case "false":
+		in.operands = append(in.operands, boolObj(false))
+	case "null":
+		in.operands = append(in.operands, nullObj{})
+	case "BI":
+		skipInlineImage(lex)
+		in.operands = in.operands[:0]
+	default:
+		in.execute(t.text)
+		in.operands = in.operands[:0]
+	}
+}
+
+// execute dispatches one operator. Unhandled operators (colour, text, line params,
+// marked-content) are intentional no-ops; their operands are cleared by the caller.
+func (in *interp) execute(op string) {
+	switch op {
+	case "m", "l", "c", "v", "y", "re", "h":
+		in.pathOp(op)
+	case "S", "s", "f", "F", "f*", "B", "B*", "b", "b*", "n":
+		in.paint(op)
+	case "q":
+		in.ctmStack = append(in.ctmStack, in.ctm)
+	case "Q":
+		in.popCTM()
+	case "cm":
+		in.ctm = concat(in.matrixOperand(), in.ctm)
+	case "Do":
+		in.doXObject()
+	}
+}
+
+// popCTM restores the previous CTM, ignoring an unbalanced Q.
+func (in *interp) popCTM() {
+	if n := len(in.ctmStack); n > 0 {
+		in.ctm = in.ctmStack[n-1]
+		in.ctmStack = in.ctmStack[:n-1]
+	}
+}
+
+// matrixOperand reads the six operands of a cm operator into a matrix.
+func (in *interp) matrixOperand() matrix {
+	return matrix{in.f(0), in.f(1), in.f(2), in.f(3), in.f(4), in.f(5)}
+}
+
+// f returns the i-th operand as a float (0 when missing or non-numeric).
+func (in *interp) f(i int) float64 {
+	if i < len(in.operands) {
+		if n, ok := in.operands[i].(numberObj); ok {
+			return float64(n)
+		}
+	}
+	return 0
+}
+
+// device maps a user-space (x, y) through the current CTM to device space.
+func (in *interp) device(x, y float64) pdfPoint {
+	dx, dy := in.ctm.apply(x, y)
+	return pdfPoint{dx, dy}
+}
+
+// warnOnce records a warning the first time a given message occurs, so a page that draws
+// many images or hits one unsupported operator repeatedly yields a single note.
+func (in *interp) warnOnce(msg string) {
+	if in.seen == nil {
+		in.seen = map[string]bool{}
+	}
+	if in.seen[msg] {
+		return
+	}
+	in.seen[msg] = true
+	in.warns = append(in.warns, msg)
+}
+
+// doXObject paints a named XObject: a Form is interpreted in-line under its matrix; an
+// Image (raster) is skipped with a one-time warning.
+func (in *interp) doXObject() {
+	name, ok := in.firstName()
+	if !ok {
+		return
+	}
+	xdict, ok := in.doc.dictOf(in.resources["XObject"])
+	if !ok {
+		return
+	}
+	form, ok := in.doc.resolve(xdict[name]).(streamObj)
+	if !ok {
+		return
+	}
+	if sub, _ := in.doc.nameOf(form.dict["Subtype"]); sub == "Image" {
+		in.warnOnce("import: skipped raster image XObject (only vector paths are imported)")
+		return
+	}
+	in.runForm(form)
+}
+
+// runForm interprets a Form XObject's content with its own matrix and resources, isolating
+// its graphics state (CTM, path) from the caller's.
+func (in *interp) runForm(form streamObj) {
+	if in.depth >= maxFormDepth {
+		in.warnOnce("import: Form XObject nesting too deep; skipped")
+		return
+	}
+	content, err := decodeStream(in.doc, form)
+	if err != nil {
+		in.warnOnce(fmt.Sprintf("import: undecodable Form XObject (%v)", err))
+		return
+	}
+	saved := in.enterForm(form)
+	in.run(content)
+	in.leaveForm(saved)
+}
+
+// firstName returns the first name operand (the XObject name for a Do).
+func (in *interp) firstName() (string, bool) {
+	for _, o := range in.operands {
+		if n, ok := o.(nameObj); ok {
+			return string(n), true
+		}
+	}
+	return "", false
+}
+
+// skipInlineImage advances the lexer past a BI…ID…EI inline image's binary payload, which
+// must not be lexed as operators. Best-effort: it stops at the first EI delimited by
+// whitespace (CAD plot-to-PDF content streams place raster data in XObjects, not inline).
+func skipInlineImage(lex *lexer) {
+	rest := lex.data[lex.pos:]
+	if i := bytes.Index(rest, []byte("EI")); i >= 0 {
+		lex.pos += i + 2
+		return
+	}
+	lex.pos = len(lex.data)
+}

--- a/kernel/exchange/pdf/content_path.go
+++ b/kernel/exchange/pdf/content_path.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package pdf
+
+// pathOp dispatches the path-construction operators. Coordinates are transformed to device
+// space immediately so a later cm never moves already-placed points.
+func (in *interp) pathOp(op string) {
+	switch op {
+	case "m":
+		in.moveTo(in.f(0), in.f(1))
+	case "l":
+		in.lineTo(in.f(0), in.f(1))
+	case "c":
+		in.curveTo(in.device(in.f(0), in.f(1)), in.device(in.f(2), in.f(3)), in.device(in.f(4), in.f(5)))
+	case "v":
+		in.curveTo(in.cur, in.device(in.f(0), in.f(1)), in.device(in.f(2), in.f(3)))
+	case "y":
+		end := in.device(in.f(2), in.f(3))
+		in.curveTo(in.device(in.f(0), in.f(1)), end, end)
+	case "re":
+		in.rect(in.f(0), in.f(1), in.f(2), in.f(3))
+	case "h":
+		in.closeSubpath()
+	}
+}
+
+// moveTo begins a new subpath at (x, y).
+func (in *interp) moveTo(x, y float64) {
+	in.cur = in.device(x, y)
+	in.path = append(in.path, subpath{start: in.cur})
+	in.open = true
+}
+
+// lineTo adds a straight segment to (x, y), starting an implicit subpath if none is open.
+func (in *interp) lineTo(x, y float64) {
+	p := in.device(x, y)
+	in.appendSeg(segment{kind: segLine, pts: []pdfPoint{p}})
+	in.cur = p
+}
+
+// curveTo adds a cubic Bézier with the two given control points and end point (already in
+// device space).
+func (in *interp) curveTo(c1, c2, end pdfPoint) {
+	in.appendSeg(segment{kind: segCurve, pts: []pdfPoint{c1, c2, end}})
+	in.cur = end
+}
+
+// appendSeg appends a segment to the current subpath, opening one at the current point when
+// a path operator arrives without a preceding moveto.
+func (in *interp) appendSeg(s segment) {
+	if !in.open || len(in.path) == 0 {
+		in.path = append(in.path, subpath{start: in.cur})
+		in.open = true
+	}
+	last := len(in.path) - 1
+	in.path[last].segs = append(in.path[last].segs, s)
+}
+
+// rect adds a closed rectangular subpath (the re operator); each corner is transformed by
+// the CTM so a rotated/sheared rectangle stays a parallelogram.
+func (in *interp) rect(x, y, w, h float64) {
+	c0 := in.device(x, y)
+	in.path = append(in.path, subpath{
+		start: c0,
+		segs: []segment{
+			{kind: segLine, pts: []pdfPoint{in.device(x+w, y)}},
+			{kind: segLine, pts: []pdfPoint{in.device(x+w, y+h)}},
+			{kind: segLine, pts: []pdfPoint{in.device(x, y+h)}},
+		},
+		closed: true,
+	})
+	in.cur = c0
+	in.open = true
+}
+
+// closeSubpath marks the current subpath closed (the h operator).
+func (in *interp) closeSubpath() {
+	if n := len(in.path); n > 0 {
+		in.path[n-1].closed = true
+		in.cur = in.path[n-1].start
+	}
+}
+
+// paint flushes the current path to geometry per the painting operator, then clears it. The
+// n operator (clip / no-paint) discards the path without emitting — that is how page-border
+// clip rectangles are kept out of the sketch. The close-then-paint operators (s, b, b*)
+// close every subpath first, as do the fill operators (PDF closes subpaths implicitly when
+// filling).
+func (in *interp) paint(op string) {
+	switch op {
+	case "n":
+		// clip-only or no-op paint: emit nothing.
+	case "S":
+		in.flush(false)
+	default: // s, f, F, f*, B, B*, b, b*
+		in.flush(true)
+	}
+	in.path = nil
+	in.open = false
+}
+
+// flush converts the accumulated subpaths to drawing entities; closeAll forces every
+// subpath closed (for fill/close-and-paint operators).
+func (in *interp) flush(closeAll bool) {
+	for i := range in.path {
+		if closeAll {
+			in.path[i].closed = true
+		}
+		in.out = append(in.out, subpathEntities(in.path[i])...)
+	}
+}
+
+// formState captures the graphics state runForm must restore after a Form XObject.
+type formState struct {
+	ctm       matrix
+	ctmDepth  int
+	resources dictObj
+	path      []subpath
+	cur       pdfPoint
+	open      bool
+}
+
+// enterForm isolates the caller's state, applies the form's /Matrix, and switches to the
+// form's /Resources (falling back to the inherited ones).
+func (in *interp) enterForm(form streamObj) formState {
+	saved := formState{ctm: in.ctm, ctmDepth: len(in.ctmStack), resources: in.resources, path: in.path, cur: in.cur, open: in.open}
+	if m, ok := in.formMatrix(form.dict["Matrix"]); ok {
+		in.ctm = concat(m, in.ctm)
+	}
+	if r, ok := in.doc.dictOf(form.dict["Resources"]); ok {
+		in.resources = r
+	}
+	in.path = nil
+	in.open = false
+	in.depth++
+	return saved
+}
+
+// leaveForm restores the state captured by enterForm.
+func (in *interp) leaveForm(saved formState) {
+	in.depth--
+	in.ctm = saved.ctm
+	in.ctmStack = in.ctmStack[:saved.ctmDepth]
+	in.resources = saved.resources
+	in.path = saved.path
+	in.cur = saved.cur
+	in.open = saved.open
+}
+
+// formMatrix reads a Form XObject's /Matrix array into a matrix, if present and well-formed.
+func (in *interp) formMatrix(v objectValue) (matrix, bool) {
+	arr, ok := in.doc.arrayOf(v)
+	if !ok || len(arr) != 6 {
+		return matrix{}, false
+	}
+	var m matrix
+	for i := 0; i < 6; i++ {
+		n, ok := in.doc.resolve(arr[i]).(numberObj)
+		if !ok {
+			return matrix{}, false
+		}
+		m[i] = float64(n)
+	}
+	return m, true
+}

--- a/kernel/exchange/pdf/corpus_test.go
+++ b/kernel/exchange/pdf/corpus_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package pdf
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/kernel/exchange/drawing"
+)
+
+// corpusFile loads a large real PDF from PDF_TESTFILES_DIR (the workspace root holds the
+// pdf-vector*.pdf samples), skipping the test when the corpus is unavailable — the
+// multi-megabyte files are not committed, mirroring the DWG corpus convention.
+func corpusFile(t *testing.T, name string) []byte {
+	t.Helper()
+	dir := os.Getenv("PDF_TESTFILES_DIR")
+	if dir == "" {
+		dir = filepath.Join("..", "..", "..", "..")
+	}
+	data, err := os.ReadFile(filepath.Join(dir, name))
+	if err != nil {
+		t.Skipf("corpus unavailable: %v", err)
+	}
+	return data
+}
+
+// TestDecodeRealAutoCADPlot decodes a real AutoCAD plot-to-PDF and checks it yields a
+// drawing-sized body of curve geometry on a single page, in millimetres.
+func TestDecodeRealAutoCADPlot(t *testing.T) {
+	pages, _, err := DecodePages(corpusFile(t, "pdf-vector2.pdf"))
+	if err != nil {
+		t.Fatalf("DecodePages: %v", err)
+	}
+	if len(pages) != 1 {
+		t.Fatalf("got %d pages, want 1", len(pages))
+	}
+	dr := pages[0]
+	if dr.Units != drawing.INSMillimetres {
+		t.Errorf("Units = %d, want mm", dr.Units)
+	}
+	if len(dr.Entities) < 100 {
+		t.Errorf("decoded only %d entities; expected a dense drawing", len(dr.Entities))
+	}
+}

--- a/kernel/exchange/pdf/decode.go
+++ b/kernel/exchange/pdf/decode.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package pdf
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/exchange/drawing"
+)
+
+// Decode parses a vector PDF and returns the curve geometry of its FIRST page, mirroring
+// dwg.Decode / dxf.Decode so a single-page CAD plot imports onto one sketch. Use
+// DecodePages for every page. Coordinates are returned in millimetres (Units =
+// drawing.INSMillimetres); the page user-space-to-millimetre scale (1 pt = 1/72 inch) is
+// baked in. Per-page problems (unsupported operators, skipped text/images) are warnings,
+// not errors.
+//
+// Example:
+//
+//	dr, warns, err := pdf.Decode(bytes)
+//	for _, e := range dr.Entities { /* convert to sketch geometry */ }
+func Decode(data []byte) (*drawing.Drawing, []string, error) {
+	pages, warns, err := DecodePages(data)
+	if err != nil {
+		return nil, warns, err
+	}
+	return pages[0], warns, nil
+}
+
+// DecodePages parses a vector PDF and returns one drawing per page, in document order, plus
+// the aggregated per-page warnings. It errors only on a whole-file failure (an unsupported
+// xref-stream/object-stream PDF, or a structure with no pages); a page that decodes to no
+// geometry yields an empty drawing rather than an error.
+func DecodePages(data []byte) ([]*drawing.Drawing, []string, error) {
+	doc, err := newDocument(data)
+	if err != nil {
+		return nil, nil, err
+	}
+	pages, err := doc.pages()
+	if err != nil {
+		return nil, nil, err
+	}
+	drawings := make([]*drawing.Drawing, 0, len(pages))
+	var warns []string
+	for i, pg := range pages {
+		ents, pageWarns := interpretPage(doc, pg)
+		warns = append(warns, prefixPageWarnings(i+1, pageWarns)...)
+		drawings = append(drawings, &drawing.Drawing{Units: drawing.INSMillimetres, Entities: ents})
+	}
+	return drawings, warns, nil
+}
+
+// interpretPage runs the content interpreter over one page and returns its entities and
+// warnings. The initial CTM subtracts the media-box origin so content sits near (0,0).
+func interpretPage(doc *document, pg page) ([]drawing.Entity, []string) {
+	in := &interp{
+		doc:       doc,
+		resources: pg.resources,
+		ctm:       translateMatrix(-pg.originX, -pg.originY),
+	}
+	in.run(pg.content)
+	return in.out, in.warns
+}
+
+// prefixPageWarnings tags each warning with its page number so a multi-page import says
+// where a problem occurred.
+func prefixPageWarnings(pageNum int, warns []string) []string {
+	if len(warns) == 0 {
+		return nil
+	}
+	out := make([]string, len(warns))
+	for i, w := range warns {
+		out[i] = fmt.Sprintf("page %d: %s", pageNum, w)
+	}
+	return out
+}

--- a/kernel/exchange/pdf/decode_test.go
+++ b/kernel/exchange/pdf/decode_test.go
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package pdf
+
+import (
+	"bytes"
+	"compress/zlib"
+	"fmt"
+	"math"
+	"testing"
+
+	"oblikovati.org/kernel/exchange/drawing"
+)
+
+// minimalPDF assembles a one-page, uncompressed PDF around the given content-stream body.
+// The decoder resolves objects by header scan and reads /Root from the trailer, so no xref
+// table is needed — keeping the fixture readable.
+func minimalPDF(content string) []byte {
+	var b bytes.Buffer
+	b.WriteString("%PDF-1.7\n")
+	b.WriteString("1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n")
+	b.WriteString("2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n")
+	b.WriteString("3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 720 720] /Contents 4 0 R >>\nendobj\n")
+	fmt.Fprintf(&b, "4 0 obj\n<< >>\nstream\n%s\nendstream\nendobj\n", content)
+	b.WriteString("trailer\n<< /Root 1 0 R >>\n")
+	return b.Bytes()
+}
+
+// approxMM compares a millimetre coordinate against a point value converted to millimetres.
+func approxMM(t *testing.T, got, wantPoints float64) {
+	t.Helper()
+	want := wantPoints * mmPerPoint
+	if math.Abs(got-want) > 1e-6 {
+		t.Errorf("coordinate = %g mm, want %g mm", got, want)
+	}
+}
+
+// TestDecodeLineRectBezier covers the three path shapes a CAD plot uses: a stroked line
+// (open polyline), a rectangle (closed polyline), and a cubic Bézier (degree-3 spline).
+func TestDecodeLineRectBezier(t *testing.T) {
+	content := "1 0 0 1 0 0 cm\n" +
+		"0 0 m 72 0 l S\n" +
+		"100 0 100 100 re S\n" +
+		"200 200 m 200 272 272 272 272 200 c S\n"
+	dr, warns, err := Decode(minimalPDF(content))
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(warns) != 0 {
+		t.Fatalf("unexpected warnings: %v", warns)
+	}
+	if dr.Units != drawing.INSMillimetres {
+		t.Errorf("Units = %d, want %d (mm)", dr.Units, drawing.INSMillimetres)
+	}
+	polys, splines := classify(dr.Entities)
+	if len(polys) != 2 || len(splines) != 1 {
+		t.Fatalf("got %d polylines + %d splines, want 2 + 1", len(polys), len(splines))
+	}
+	assertLine(t, polys)
+	assertRect(t, polys)
+	assertBezier(t, splines[0])
+}
+
+// assertLine checks the open two-point polyline from "0 0 m 72 0 l S".
+func assertLine(t *testing.T, polys []*drawing.LwPolyline) {
+	t.Helper()
+	line := findOpenPolyline(polys, 2)
+	if line == nil {
+		t.Fatal("no open 2-point polyline (the line) found")
+	}
+	approxMM(t, line.Points[1][0], 72)
+	approxMM(t, line.Points[1][1], 0)
+}
+
+// assertRect checks the closed four-point polyline from "100 0 100 100 re".
+func assertRect(t *testing.T, polys []*drawing.LwPolyline) {
+	t.Helper()
+	for _, p := range polys {
+		if p.Closed && len(p.Points) == 4 {
+			approxMM(t, p.Points[0][0], 100)
+			approxMM(t, p.Points[2][1], 100)
+			return
+		}
+	}
+	t.Fatal("no closed 4-point polyline (the rectangle) found")
+}
+
+// assertBezier checks the degree-3, four-control-point spline from the c operator.
+func assertBezier(t *testing.T, sp *drawing.Spline) {
+	t.Helper()
+	if sp.Degree != 3 || len(sp.ControlPoints) != 4 {
+		t.Fatalf("spline degree=%d controls=%d, want 3 and 4", sp.Degree, len(sp.ControlPoints))
+	}
+	approxMM(t, sp.ControlPoints[0][0], 200) // start
+	approxMM(t, sp.ControlPoints[3][0], 272) // end
+}
+
+// TestDecodeClipPathDiscarded asserts a W n clip path emits no geometry (page borders).
+func TestDecodeClipPathDiscarded(t *testing.T) {
+	dr, _, err := Decode(minimalPDF("0 0 m 100 0 l 100 100 l W n\n"))
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(dr.Entities) != 0 {
+		t.Errorf("clip path produced %d entities, want 0", len(dr.Entities))
+	}
+}
+
+// TestDecodeCTMScalesCoordinates asserts the current transformation matrix is applied: a
+// 2× scale doubles the device coordinate before the point→mm conversion.
+func TestDecodeCTMScalesCoordinates(t *testing.T) {
+	dr, _, err := Decode(minimalPDF("2 0 0 2 0 0 cm\n0 0 m 10 0 l S\n"))
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	polys, _ := classify(dr.Entities)
+	if len(polys) != 1 {
+		t.Fatalf("got %d polylines, want 1", len(polys))
+	}
+	approxMM(t, polys[0].Points[1][0], 20) // 10 user units × 2 (CTM) = 20 points
+}
+
+// TestFlateDecodeContentStream covers the FlateDecode path: a compressed content stream
+// decodes to the same geometry as its plaintext form.
+func TestFlateDecodeContentStream(t *testing.T) {
+	var raw bytes.Buffer
+	w := zlib.NewWriter(&raw)
+	if _, err := w.Write([]byte("0 0 m 72 0 l S\n")); err != nil {
+		t.Fatal(err)
+	}
+	w.Close()
+	var b bytes.Buffer
+	b.WriteString("%PDF-1.7\n")
+	b.WriteString("1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n")
+	b.WriteString("2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n")
+	b.WriteString("3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 720 720] /Contents 4 0 R >>\nendobj\n")
+	fmt.Fprintf(&b, "4 0 obj\n<< /Filter /FlateDecode /Length %d >>\nstream\n", raw.Len())
+	b.Write(raw.Bytes())
+	b.WriteString("\nendstream\nendobj\ntrailer\n<< /Root 1 0 R >>\n")
+	dr, _, err := Decode(b.Bytes())
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	polys, _ := classify(dr.Entities)
+	if len(polys) != 1 || len(polys[0].Points) != 2 {
+		t.Fatalf("FlateDecode content gave %d polylines", len(polys))
+	}
+}
+
+// TestDecodeRejectsObjectStreamPDF asserts an xref-stream / object-stream PDF (no classic
+// indirect objects) fails with a clear, scoped error rather than importing nothing.
+func TestDecodeRejectsObjectStreamPDF(t *testing.T) {
+	_, _, err := Decode([]byte("%PDF-1.7\n%%EOF\n"))
+	if err == nil {
+		t.Fatal("expected an error for a PDF with no classic objects")
+	}
+}
+
+// classify splits decoded entities into polylines and splines for assertions.
+func classify(ents []drawing.Entity) ([]*drawing.LwPolyline, []*drawing.Spline) {
+	var polys []*drawing.LwPolyline
+	var splines []*drawing.Spline
+	for _, e := range ents {
+		switch g := e.(type) {
+		case *drawing.LwPolyline:
+			polys = append(polys, g)
+		case *drawing.Spline:
+			splines = append(splines, g)
+		}
+	}
+	return polys, splines
+}
+
+// findOpenPolyline returns the first open polyline with n points.
+func findOpenPolyline(polys []*drawing.LwPolyline, n int) *drawing.LwPolyline {
+	for _, p := range polys {
+		if !p.Closed && len(p.Points) == n {
+			return p
+		}
+	}
+	return nil
+}

--- a/kernel/exchange/pdf/document.go
+++ b/kernel/exchange/pdf/document.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package pdf
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+// objHeader matches an indirect-object header "N G obj". We resolve objects by scanning
+// these headers rather than trusting the cross-reference table: it is robust against the
+// byte-offset drift that incremental-update PDFs introduce, and it sidesteps xref-stream
+// parsing entirely (the later occurrence of a given object number wins, which is exactly
+// the incremental-update override rule).
+var objHeader = regexp.MustCompile(`(?m)(\d+)\s+(\d+)\s+obj\b`)
+
+// document is a parsed PDF: a map from object number to the file offset of its header,
+// plus a small resolved-object cache. It deliberately models only what page-geometry
+// extraction needs.
+type document struct {
+	data    []byte
+	offsets map[int]int
+	cache   map[int]objectValue
+}
+
+// newDocument builds the object-offset index. It errors only when the file carries no
+// classic indirect objects at all — the signature of an xref-stream / object-stream PDF,
+// which this scoped reader does not support (it would otherwise silently import nothing).
+func newDocument(data []byte) (*document, error) {
+	offsets := map[int]int{}
+	for _, m := range objHeader.FindAllSubmatchIndex(data, -1) {
+		num, err := strconv.Atoi(string(data[m[2]:m[3]]))
+		if err != nil {
+			continue
+		}
+		offsets[num] = m[0] // later occurrence wins (incremental-update override)
+	}
+	if len(offsets) == 0 {
+		return nil, fmt.Errorf("pdf: no classic indirect objects found (xref-stream / object-stream PDFs are unsupported); %d bytes", len(data))
+	}
+	return &document{data: data, offsets: offsets, cache: map[int]objectValue{}}, nil
+}
+
+// object returns the parsed object with the given number, or nullObj when it is missing
+// or unparseable. Results are cached.
+func (d *document) object(num int) objectValue {
+	if v, ok := d.cache[num]; ok {
+		return v
+	}
+	off, ok := d.offsets[num]
+	if !ok {
+		return nullObj{}
+	}
+	d.cache[num] = nullObj{} // guard against reference cycles during parse
+	v := d.parseObjectAt(off)
+	d.cache[num] = v
+	return v
+}
+
+// parseObjectAt parses the indirect object whose header starts at off, attaching the
+// stream body when the value is a dictionary followed by the stream keyword.
+func (d *document) parseObjectAt(off int) objectValue {
+	lex := &lexer{data: d.data, pos: off}
+	p := newParser(lex)
+	p.read() // object number
+	p.read() // generation
+	p.read() // "obj"
+	v := p.parseValue()
+	dict, ok := v.(dictObj)
+	if !ok {
+		return v
+	}
+	if t := p.read(); t.kind == tokKeyword && t.text == "stream" {
+		return streamObj{dict: dict, raw: d.extractStream(lex, dict)}
+	}
+	return dict
+}
+
+// extractStream slices a stream body starting just after the stream keyword. It prefers a
+// direct /Length when that lands exactly on an endstream marker, and otherwise searches
+// for endstream — robust to a missing or indirect /Length and to FlateDecode payloads.
+func (d *document) extractStream(lex *lexer, dict dictObj) []byte {
+	start := skipStreamEOL(d.data, lex.pos)
+	if n, ok := dict["Length"].(numberObj); ok {
+		end := start + int(n)
+		if end <= len(d.data) && endsAtEndstream(d.data, end) {
+			return d.data[start:end]
+		}
+	}
+	if rel := bytes.Index(d.data[start:], []byte("endstream")); rel >= 0 {
+		return d.data[start : start+trimTrailingEOL(d.data[start:start+rel])]
+	}
+	return nil
+}
+
+// skipStreamEOL advances past the single EOL (CRLF or LF, tolerating a lone CR) that
+// must follow the stream keyword before the body begins.
+func skipStreamEOL(data []byte, pos int) int {
+	if pos < len(data) && data[pos] == '\r' {
+		pos++
+	}
+	if pos < len(data) && data[pos] == '\n' {
+		pos++
+	}
+	return pos
+}
+
+// endsAtEndstream reports whether endstream follows position end (allowing one EOL of gap).
+func endsAtEndstream(data []byte, end int) bool {
+	rest := data[end:]
+	rest = bytes.TrimLeft(rest, "\r\n")
+	return bytes.HasPrefix(rest, []byte("endstream"))
+}
+
+// trimTrailingEOL returns the length of body with a single trailing EOL removed (the EOL
+// that precedes the endstream keyword is not part of the stream data).
+func trimTrailingEOL(body []byte) int {
+	n := len(body)
+	if n > 0 && body[n-1] == '\n' {
+		n--
+	}
+	if n > 0 && body[n-1] == '\r' {
+		n--
+	}
+	return n
+}
+
+// resolve dereferences an indirect reference (following a single hop), returning other
+// values unchanged. A nil input resolves to nullObj so callers can type-switch safely.
+func (d *document) resolve(v objectValue) objectValue {
+	if v == nil {
+		return nullObj{}
+	}
+	if r, ok := v.(refObj); ok {
+		return d.object(r.num)
+	}
+	return v
+}
+
+// dictOf resolves v and returns it as a dictionary (a stream's dict counts), if it is one.
+func (d *document) dictOf(v objectValue) (dictObj, bool) {
+	switch g := d.resolve(v).(type) {
+	case dictObj:
+		return g, true
+	case streamObj:
+		return g.dict, true
+	default:
+		return nil, false
+	}
+}
+
+// arrayOf resolves v and returns it as an array, if it is one.
+func (d *document) arrayOf(v objectValue) (arrayObj, bool) {
+	a, ok := d.resolve(v).(arrayObj)
+	return a, ok
+}
+
+// nameOf resolves v and returns it as a name string, if it is one.
+func (d *document) nameOf(v objectValue) (string, bool) {
+	n, ok := d.resolve(v).(nameObj)
+	return string(n), ok
+}

--- a/kernel/exchange/pdf/geometry.go
+++ b/kernel/exchange/pdf/geometry.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package pdf
+
+import "oblikovati.org/kernel/exchange/drawing"
+
+// subpathEntities converts one device-space subpath to drawing entities, in millimetres. A
+// straight-only subpath is a single LwPolyline; a subpath containing a cubic Bézier is split
+// into polyline runs and one degree-3 Spline per Bézier — consecutive entities share their
+// endpoint coordinates, so the chain stays connected (the DWG/DXF importers emit per-entity
+// too). A cubic Bézier maps exactly onto a 4-control-point clamped degree-3 NURBS, which is
+// how the sketch converter rebuilds it (model/exchange add2DSpline).
+func subpathEntities(sp subpath) []drawing.Entity {
+	if !hasCurve(sp) {
+		pts := linePoints(sp)
+		if len(pts) < 2 {
+			return nil
+		}
+		return []drawing.Entity{&drawing.LwPolyline{Points: pts, Closed: sp.closed}}
+	}
+	return mixedEntities(sp)
+}
+
+// hasCurve reports whether the subpath contains any Bézier segment.
+func hasCurve(sp subpath) bool {
+	for _, s := range sp.segs {
+		if s.kind == segCurve {
+			return true
+		}
+	}
+	return false
+}
+
+// linePoints returns the polyline vertices (start plus each line end) in millimetres.
+func linePoints(sp subpath) [][2]float64 {
+	pts := make([][2]float64, 0, len(sp.segs)+1)
+	pts = append(pts, mm2(sp.start))
+	for _, s := range sp.segs {
+		pts = append(pts, mm2(s.pts[0]))
+	}
+	return pts
+}
+
+// mixedEntities splits a curve-bearing subpath into polyline runs and per-Bézier splines. A
+// closed subpath gets an explicit closing line so the closing edge is preserved.
+func mixedEntities(sp subpath) []drawing.Entity {
+	segs := sp.segs
+	if sp.closed {
+		segs = append(append([]segment{}, segs...), segment{kind: segLine, pts: []pdfPoint{sp.start}})
+	}
+	var out []drawing.Entity
+	cur := sp.start
+	run := [][2]float64{mm2(cur)}
+	for _, s := range segs {
+		if s.kind == segLine {
+			cur = s.pts[0]
+			run = append(run, mm2(cur))
+			continue
+		}
+		out = appendPolyline(out, run)
+		out = append(out, bezierSpline(cur, s.pts))
+		cur = s.pts[2]
+		run = [][2]float64{mm2(cur)}
+	}
+	return appendPolyline(out, run)
+}
+
+// appendPolyline appends an open LwPolyline for a run of two or more vertices, dropping a
+// degenerate single-vertex run.
+func appendPolyline(out []drawing.Entity, run [][2]float64) []drawing.Entity {
+	if len(run) < 2 {
+		return out
+	}
+	return append(out, &drawing.LwPolyline{Points: run, Closed: false})
+}
+
+// bezierSpline builds a degree-3 NURBS from a cubic Bézier's start point and its [c1, c2,
+// end] control points (the four-control-point, clamped-knot form that is the Bézier exactly).
+func bezierSpline(start pdfPoint, ctrl []pdfPoint) *drawing.Spline {
+	return &drawing.Spline{
+		Degree:        3,
+		ControlPoints: [][3]float64{mm3(start), mm3(ctrl[0]), mm3(ctrl[1]), mm3(ctrl[2])},
+	}
+}
+
+// mm2 converts a device point to a 2-D millimetre coordinate.
+func mm2(p pdfPoint) [2]float64 { return [2]float64{toMM(p.x), toMM(p.y)} }
+
+// mm3 converts a device point to a 3-D millimetre coordinate (Z = 0; PDF pages are planar).
+func mm3(p pdfPoint) [3]float64 { return [3]float64{toMM(p.x), toMM(p.y), 0} }

--- a/kernel/exchange/pdf/lexer.go
+++ b/kernel/exchange/pdf/lexer.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package pdf is a clean-room, scoped reader for vector PDFs whose page content was
+// generated from a CAD drawing (e.g. an AutoCAD plot-to-PDF). It decodes the page
+// content streams into the format-neutral drawing model (kernel/exchange/drawing) so
+// the shared Sketch importer can place them like any other drawing format.
+//
+// Scope (deliberately narrow): classic cross-reference tables (no xref streams / object
+// streams), FlateDecode content streams, and the path-construction/painting subset of
+// the content-stream operator set under the current transformation matrix. Text and
+// raster images are skipped; only vector paths become geometry. Anything outside this
+// subset is reported as a warning rather than failing the whole import.
+package pdf
+
+// tokenKind classifies one lexical token of PDF syntax (object syntax and the
+// content-stream operator syntax share this lexer).
+type tokenKind int
+
+const (
+	tokEOF        tokenKind = iota
+	tokNumber               // an integer or real number (value in token.num)
+	tokName                 // a /Name (token.text without the leading slash)
+	tokString               // a (literal) or <hex> string (decoded bytes in token.str)
+	tokKeyword              // a bare word: obj, R, true, stream, or a content operator (m, l, S, …)
+	tokDictOpen             // <<
+	tokDictClose            // >>
+	tokArrayOpen            // [
+	tokArrayClose           // ]
+)
+
+// token is one lexed unit. Only the field matching kind is meaningful.
+type token struct {
+	kind tokenKind
+	num  float64
+	text string
+	str  []byte
+}
+
+// lexer scans PDF bytes one token at a time over a cursor, so a caller (the object
+// parser or the content interpreter) can also reach into the raw bytes directly — needed
+// to grab a stream's body and to skip an inline image's binary payload.
+type lexer struct {
+	data []byte
+	pos  int
+}
+
+func newLexer(data []byte) *lexer { return &lexer{data: data} }
+
+// isWhitespace reports the PDF whitespace bytes (incl. NUL and form feed).
+func isWhitespace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '\f' || c == 0
+}
+
+// isDelimiter reports the PDF delimiter bytes that bound a token without whitespace.
+func isDelimiter(c byte) bool {
+	switch c {
+	case '(', ')', '<', '>', '[', ']', '{', '}', '/', '%':
+		return true
+	}
+	return false
+}
+
+// skipSpace advances over whitespace and % comments (a comment runs to end of line).
+func (l *lexer) skipSpace() {
+	for l.pos < len(l.data) {
+		c := l.data[l.pos]
+		if c == '%' {
+			for l.pos < len(l.data) && l.data[l.pos] != '\n' && l.data[l.pos] != '\r' {
+				l.pos++
+			}
+			continue
+		}
+		if !isWhitespace(c) {
+			return
+		}
+		l.pos++
+	}
+}
+
+// next returns the next token, or a tokEOF token at end of input.
+func (l *lexer) next() token {
+	l.skipSpace()
+	if l.pos >= len(l.data) {
+		return token{kind: tokEOF}
+	}
+	if t, ok := l.lexDelimiter(); ok {
+		return t
+	}
+	if c := l.data[l.pos]; c == '+' || c == '-' || c == '.' || (c >= '0' && c <= '9') {
+		return l.lexNumber()
+	}
+	return l.lexKeyword()
+}
+
+// lexDelimiter lexes a token that begins with a PDF delimiter (dict/array brackets, name,
+// or string), reporting false when the cursor is not on such a delimiter.
+func (l *lexer) lexDelimiter() (token, bool) {
+	switch l.data[l.pos] {
+	case '<':
+		if l.peek(1) == '<' {
+			l.pos += 2
+			return token{kind: tokDictOpen}, true
+		}
+		return l.lexHexString(), true
+	case '>':
+		l.pos += 2 // ">>"; a lone '>' is malformed PDF, so consume the pair defensively
+		return token{kind: tokDictClose}, true
+	case '[':
+		l.pos++
+		return token{kind: tokArrayOpen}, true
+	case ']':
+		l.pos++
+		return token{kind: tokArrayClose}, true
+	case '/':
+		return l.lexName(), true
+	case '(':
+		return l.lexLiteralString(), true
+	}
+	return token{}, false
+}
+
+// peek returns the byte n positions ahead of the cursor, or 0 past end.
+func (l *lexer) peek(n int) byte {
+	if l.pos+n < len(l.data) {
+		return l.data[l.pos+n]
+	}
+	return 0
+}

--- a/kernel/exchange/pdf/lexer_tokens.go
+++ b/kernel/exchange/pdf/lexer_tokens.go
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package pdf
+
+import "strconv"
+
+// lexNumber reads an integer or real number token. PDF numbers carry no exponent; a
+// malformed run parses as 0 (a defensive fallback — the surrounding operator simply
+// receives a zero operand rather than the whole stream aborting).
+func (l *lexer) lexNumber() token {
+	start := l.pos
+	for l.pos < len(l.data) {
+		c := l.data[l.pos]
+		if c == '+' || c == '-' || c == '.' || (c >= '0' && c <= '9') {
+			l.pos++
+			continue
+		}
+		break
+	}
+	v, _ := strconv.ParseFloat(string(l.data[start:l.pos]), 64)
+	return token{kind: tokNumber, num: v}
+}
+
+// lexKeyword reads a bare word: an object keyword (obj/R/true/false/null/stream) or a
+// content-stream operator (m, l, c, re, cm, S, …). It runs to the next whitespace or
+// delimiter.
+func (l *lexer) lexKeyword() token {
+	start := l.pos
+	for l.pos < len(l.data) && !isWhitespace(l.data[l.pos]) && !isDelimiter(l.data[l.pos]) {
+		l.pos++
+	}
+	if l.pos == start { // a stray delimiter we don't special-case (e.g. ')','{'); consume one byte.
+		l.pos++
+		return token{kind: tokKeyword, text: string(l.data[start:l.pos])}
+	}
+	return token{kind: tokKeyword, text: string(l.data[start:l.pos])}
+}
+
+// lexName reads a /Name token, decoding #xx hex escapes (PDF 1.2+). The returned text
+// omits the leading slash.
+func (l *lexer) lexName() token {
+	l.pos++ // consume '/'
+	var b []byte
+	for l.pos < len(l.data) {
+		c := l.data[l.pos]
+		if isWhitespace(c) || isDelimiter(c) {
+			break
+		}
+		if c == '#' && l.pos+2 < len(l.data) {
+			if h, ok := hexByte(l.data[l.pos+1], l.data[l.pos+2]); ok {
+				b = append(b, h)
+				l.pos += 3
+				continue
+			}
+		}
+		b = append(b, c)
+		l.pos++
+	}
+	return token{kind: tokName, text: string(b)}
+}
+
+// lexLiteralString reads a (…) string, honouring balanced parentheses, backslash escapes,
+// and line-continuations. The bytes are returned decoded; we never interpret them as
+// geometry (text is skipped) but must consume them correctly so operators stay aligned.
+func (l *lexer) lexLiteralString() token {
+	l.pos++ // consume '('
+	var b []byte
+	depth := 1
+	for l.pos < len(l.data) {
+		c := l.data[l.pos]
+		l.pos++
+		switch c {
+		case '\\':
+			b = l.appendEscaped(b)
+		case '(':
+			depth++
+			b = append(b, c)
+		case ')':
+			depth--
+			if depth == 0 {
+				return token{kind: tokString, str: b}
+			}
+			b = append(b, c)
+		default:
+			b = append(b, c)
+		}
+	}
+	return token{kind: tokString, str: b}
+}
+
+// appendEscaped consumes and appends a backslash escape's resolved byte (no-op at EOF).
+func (l *lexer) appendEscaped(b []byte) []byte {
+	if l.pos < len(l.data) {
+		b = append(b, l.escape(l.data[l.pos]))
+		l.pos++
+	}
+	return b
+}
+
+// escape resolves a backslash escape's payload byte (the common control escapes; an
+// unknown escape yields the literal byte, per the spec).
+func (l *lexer) escape(c byte) byte {
+	switch c {
+	case 'n':
+		return '\n'
+	case 'r':
+		return '\r'
+	case 't':
+		return '\t'
+	case 'b':
+		return '\b'
+	case 'f':
+		return '\f'
+	default:
+		return c
+	}
+}
+
+// lexHexString reads a <…> hex string. Whitespace between digits is ignored; an odd final
+// digit is padded with 0 (spec §7.3.4.3).
+func (l *lexer) lexHexString() token {
+	l.pos++ // consume '<'
+	var b []byte
+	hi := -1
+	for l.pos < len(l.data) {
+		c := l.data[l.pos]
+		l.pos++
+		if c == '>' {
+			break
+		}
+		if isWhitespace(c) {
+			continue
+		}
+		v := hexDigit(c)
+		if v < 0 {
+			continue
+		}
+		if hi < 0 {
+			hi = v
+		} else {
+			b = append(b, byte(hi<<4|v))
+			hi = -1
+		}
+	}
+	if hi >= 0 {
+		b = append(b, byte(hi<<4))
+	}
+	return token{kind: tokString, str: b}
+}
+
+// hexDigit returns the value of a hex digit, or -1 if c is not one.
+func hexDigit(c byte) int {
+	switch {
+	case c >= '0' && c <= '9':
+		return int(c - '0')
+	case c >= 'a' && c <= 'f':
+		return int(c-'a') + 10
+	case c >= 'A' && c <= 'F':
+		return int(c-'A') + 10
+	}
+	return -1
+}
+
+// hexByte combines two hex digits into a byte (for #xx name escapes).
+func hexByte(a, b byte) (byte, bool) {
+	hi, lo := hexDigit(a), hexDigit(b)
+	if hi < 0 || lo < 0 {
+		return 0, false
+	}
+	return byte(hi<<4 | lo), true
+}

--- a/kernel/exchange/pdf/matrix.go
+++ b/kernel/exchange/pdf/matrix.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package pdf
+
+// matrix is a 2-D affine transform stored as the six PDF operands [a b c d e f], which
+// denote the 3×3 matrix [[a b 0] [c d 0] [e f 1]]. A point row-vector [x y 1] maps as
+// [x y 1]·M, i.e. (a·x + c·y + e, b·x + d·y + f) — the PDF current-transformation-matrix
+// convention (spec §8.3.3).
+type matrix [6]float64
+
+// translateMatrix shifts by (dx, dy).
+func translateMatrix(dx, dy float64) matrix { return matrix{1, 0, 0, 1, dx, dy} }
+
+// apply transforms a user-space point to the space this matrix maps into.
+func (m matrix) apply(x, y float64) (float64, float64) {
+	return m[0]*x + m[2]*y + m[4], m[1]*x + m[3]*y + m[5]
+}
+
+// concat returns a·b: the transform that applies a first, then b (row-vector order
+// p·a·b). The cm operator uses concat(Mcm, CTM) so new user space maps through Mcm into
+// the previous user space and on to device space.
+func concat(a, b matrix) matrix {
+	return matrix{
+		a[0]*b[0] + a[1]*b[2],
+		a[0]*b[1] + a[1]*b[3],
+		a[2]*b[0] + a[3]*b[2],
+		a[2]*b[1] + a[3]*b[3],
+		a[4]*b[0] + a[5]*b[2] + b[4],
+		a[4]*b[1] + a[5]*b[3] + b[5],
+	}
+}

--- a/kernel/exchange/pdf/object.go
+++ b/kernel/exchange/pdf/object.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package pdf
+
+// objectValue is one parsed PDF object. PDF objects form a small closed sum type
+// (number, name, string, boolean, null, array, dictionary, indirect reference, stream);
+// callers discriminate with a type switch. The isObject marker keeps the set closed.
+type objectValue interface{ isObject() }
+
+type (
+	numberObj float64                // a numeric object
+	nameObj   string                 // a /Name object (without the slash)
+	stringObj []byte                 // a (literal) or <hex> string object
+	boolObj   bool                   // true / false
+	nullObj   struct{}               // null
+	arrayObj  []objectValue          // an [ … ] array
+	dictObj   map[string]objectValue // a << … >> dictionary, keyed by name
+	refObj    struct{ num, gen int } // an "n g R" indirect reference
+	streamObj struct {               // a dictionary followed by a stream body
+		dict dictObj
+		raw  []byte
+	}
+)
+
+func (numberObj) isObject() {}
+func (nameObj) isObject()   {}
+func (stringObj) isObject() {}
+func (boolObj) isObject()   {}
+func (nullObj) isObject()   {}
+func (arrayObj) isObject()  {}
+func (dictObj) isObject()   {}
+func (refObj) isObject()    {}
+func (streamObj) isObject() {}
+
+// parser turns the lexer's token stream into objectValues, with a pushback stack so it can
+// recognise the three-token "n g R" indirect-reference form — which needs two tokens of
+// look-back when the trailing keyword is not "R".
+type parser struct {
+	lex  *lexer
+	back []token
+}
+
+func newParser(l *lexer) *parser { return &parser{lex: l} }
+
+// read returns the next token, drawing from the pushback stack (LIFO) first.
+func (p *parser) read() token {
+	if n := len(p.back); n > 0 {
+		t := p.back[n-1]
+		p.back = p.back[:n-1]
+		return t
+	}
+	return p.lex.next()
+}
+
+// unread pushes a token back so a later read returns it (LIFO: the last unread is read
+// first, so parseNumberOrRef can unread its two-token look-ahead in reverse).
+func (p *parser) unread(t token) { p.back = append(p.back, t) }
+
+// parseValue parses a single object value. A bare keyword that is not a literal
+// (true/false/null) is returned to the caller via pushback and signalled as nil — the
+// caller (array/dict loop, or indirect-object reader) decides whether that ends its run.
+func (p *parser) parseValue() objectValue {
+	t := p.read()
+	switch t.kind {
+	case tokNumber:
+		return p.parseNumberOrRef(t)
+	case tokName:
+		return nameObj(t.text)
+	case tokString:
+		return stringObj(t.str)
+	case tokDictOpen:
+		return p.parseDict()
+	case tokArrayOpen:
+		return p.parseArray()
+	case tokKeyword:
+		return literalKeyword(t)
+	default:
+		p.unread(t)
+		return nil
+	}
+}
+
+// parseNumberOrRef disambiguates a plain number from an "n g R" reference using two-token
+// lookahead.
+func (p *parser) parseNumberOrRef(first token) objectValue {
+	t2 := p.read()
+	if t2.kind == tokNumber {
+		t3 := p.read()
+		if t3.kind == tokKeyword && t3.text == "R" {
+			return refObj{num: int(first.num), gen: int(t2.num)}
+		}
+		p.unread(t3)
+	}
+	p.unread(t2)
+	return numberObj(first.num)
+}
+
+// literalKeyword maps the three literal keywords (true/false/null) to objects; any other
+// keyword ends the current value (caller receives nil).
+func literalKeyword(t token) objectValue {
+	switch t.text {
+	case "true":
+		return boolObj(true)
+	case "false":
+		return boolObj(false)
+	case "null":
+		return nullObj{}
+	}
+	return nil
+}
+
+// parseArray reads array elements until the closing bracket.
+func (p *parser) parseArray() arrayObj {
+	var arr arrayObj
+	for {
+		t := p.read()
+		if t.kind == tokArrayClose || t.kind == tokEOF {
+			return arr
+		}
+		p.unread(t)
+		v := p.parseValue()
+		if v == nil { // a stray keyword inside an array — skip it to stay aligned.
+			p.read()
+			continue
+		}
+		arr = append(arr, v)
+	}
+}
+
+// parseDict reads name/value pairs until the closing >>.
+func (p *parser) parseDict() dictObj {
+	d := dictObj{}
+	for {
+		t := p.read()
+		if t.kind == tokDictClose || t.kind == tokEOF {
+			return d
+		}
+		if t.kind != tokName { // resync on malformed key
+			continue
+		}
+		v := p.parseValue()
+		if v == nil {
+			continue
+		}
+		d[t.text] = v
+	}
+}

--- a/kernel/exchange/pdf/pages.go
+++ b/kernel/exchange/pdf/pages.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package pdf
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// page is one decoded page: its resource dictionary (for XObject lookups), its media box
+// lower-left (subtracted so content sits near the origin), and its concatenated, decoded
+// content-stream bytes.
+type page struct {
+	resources dictObj
+	originX   float64
+	originY   float64
+	content   []byte
+}
+
+// pages walks the page tree and returns each leaf page in document order.
+func (d *document) pages() ([]page, error) {
+	cat, ok := d.catalog()
+	if !ok {
+		return nil, fmt.Errorf("pdf: no document catalog (/Type /Catalog) found")
+	}
+	root, ok := d.dictOf(cat["Pages"])
+	if !ok {
+		return nil, fmt.Errorf("pdf: catalog has no page tree (/Pages)")
+	}
+	var out []page
+	d.walkPageTree(root, dictObj{}, [2]float64{}, 0, &out)
+	if len(out) == 0 {
+		return nil, fmt.Errorf("pdf: page tree contains no pages")
+	}
+	return out, nil
+}
+
+// walkPageTree recurses the /Pages tree, propagating the inheritable /Resources and
+// /MediaBox attributes, and appends one page per leaf. Depth is bounded to stop a
+// malformed self-referential tree.
+func (d *document) walkPageTree(node, resources dictObj, origin [2]float64, depth int, out *[]page) {
+	if depth > 64 {
+		return
+	}
+	resources, origin = inherit(d, node, resources, origin)
+	kids, hasKids := d.arrayOf(node["Kids"])
+	if !hasKids {
+		*out = append(*out, d.leafPage(node, resources, origin))
+		return
+	}
+	for _, kid := range kids {
+		child, ok := d.dictOf(kid)
+		if !ok {
+			continue
+		}
+		d.walkPageTree(child, resources, origin, depth+1, out)
+	}
+}
+
+// inherit overrides the inherited resources/media-box origin with this node's own when present.
+func inherit(d *document, node, resources dictObj, origin [2]float64) (dictObj, [2]float64) {
+	if r, ok := d.dictOf(node["Resources"]); ok {
+		resources = r
+	}
+	if mb, ok := d.mediaBoxOrigin(node["MediaBox"]); ok {
+		origin = mb
+	}
+	return resources, origin
+}
+
+// leafPage assembles a leaf page from its inherited attributes and content streams.
+func (d *document) leafPage(node, resources dictObj, origin [2]float64) page {
+	return page{
+		resources: resources,
+		originX:   origin[0],
+		originY:   origin[1],
+		content:   d.pageContent(node["Contents"]),
+	}
+}
+
+// pageContent decodes and concatenates a page's content stream(s); a /Contents value is
+// either one stream or an array of streams (joined with a newline so the last operator of
+// one and the first of the next stay separated).
+func (d *document) pageContent(contents objectValue) []byte {
+	if arr, ok := d.arrayOf(contents); ok {
+		var buf [][]byte
+		for _, e := range arr {
+			buf = append(buf, d.streamBytes(e))
+		}
+		return bytes.Join(buf, []byte{'\n'})
+	}
+	return d.streamBytes(contents)
+}
+
+// streamBytes resolves v to a stream and returns its decoded bytes (empty on any failure —
+// a page with one unreadable stream still imports the rest).
+func (d *document) streamBytes(v objectValue) []byte {
+	s, ok := d.resolve(v).(streamObj)
+	if !ok {
+		return nil
+	}
+	out, err := decodeStream(d, s)
+	if err != nil {
+		return nil
+	}
+	return out
+}
+
+// mediaBoxOrigin resolves a /MediaBox to its lower-left corner, if it is a 4-number array.
+func (d *document) mediaBoxOrigin(v objectValue) ([2]float64, bool) {
+	arr, ok := d.arrayOf(v)
+	if !ok || len(arr) != 4 {
+		return [2]float64{}, false
+	}
+	llx, okx := d.resolve(arr[0]).(numberObj)
+	lly, oky := d.resolve(arr[1]).(numberObj)
+	if !okx || !oky {
+		return [2]float64{}, false
+	}
+	return [2]float64{float64(llx), float64(lly)}, true
+}
+
+// catalog locates the document catalog, preferring the trailer's /Root and falling back to
+// scanning every object for /Type /Catalog (some files have an unparsed or absent trailer).
+func (d *document) catalog() (dictObj, bool) {
+	if root, ok := d.rootFromTrailer(); ok {
+		return root, true
+	}
+	return d.scanForType("Catalog")
+}
+
+// rootFromTrailer parses the last trailer dictionary and resolves its /Root.
+func (d *document) rootFromTrailer() (dictObj, bool) {
+	idx := bytes.LastIndex(d.data, []byte("trailer"))
+	if idx < 0 {
+		return nil, false
+	}
+	lex := &lexer{data: d.data, pos: idx + len("trailer")}
+	dict, ok := newParser(lex).parseValue().(dictObj)
+	if !ok {
+		return nil, false
+	}
+	return d.dictOf(dict["Root"])
+}
+
+// scanForType returns the first object that is a dictionary with the given /Type.
+func (d *document) scanForType(typ string) (dictObj, bool) {
+	for num := range d.offsets {
+		dict, ok := d.dictOf(d.object(num))
+		if !ok {
+			continue
+		}
+		if name, ok := d.nameOf(dict["Type"]); ok && name == typ {
+			return dict, true
+		}
+	}
+	return nil, false
+}

--- a/kernel/exchange/pdf/stream.go
+++ b/kernel/exchange/pdf/stream.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package pdf
+
+import (
+	"bytes"
+	"compress/zlib"
+	"fmt"
+	"io"
+)
+
+// decodeStream returns a stream's decoded bytes. It handles the one filter CAD plot-to-PDF
+// content streams use — FlateDecode with Predictor 1 (no predictor) — and reports an
+// explicit error for any other filter or a >1 predictor, so an unsupported encoding
+// surfaces as a per-page warning rather than as silent empty geometry.
+func decodeStream(d *document, s streamObj) ([]byte, error) {
+	filter, ok := streamFilter(d, s.dict)
+	if !ok || filter == "" {
+		return s.raw, nil // unfiltered content stream
+	}
+	if filter != "FlateDecode" {
+		return nil, fmt.Errorf("pdf: unsupported stream filter %q (only FlateDecode)", filter)
+	}
+	if p := predictor(d, s.dict); p > 1 {
+		return nil, fmt.Errorf("pdf: unsupported FlateDecode predictor %d (only 1)", p)
+	}
+	return inflate(s.raw)
+}
+
+// streamFilter returns the (single) filter name. A filter array longer than one element is
+// rejected by returning a sentinel the caller treats as unsupported — content streams here
+// carry at most one filter.
+func streamFilter(d *document, dict dictObj) (string, bool) {
+	switch f := d.resolve(dict["Filter"]).(type) {
+	case nameObj:
+		return string(f), true
+	case arrayObj:
+		if len(f) == 1 {
+			if n, ok := d.nameOf(f[0]); ok {
+				return n, true
+			}
+		}
+		return "array", true // a multi-filter chain we don't support
+	default:
+		return "", false
+	}
+}
+
+// predictor reads /DecodeParms /Predictor, defaulting to 1 (none).
+func predictor(d *document, dict dictObj) int {
+	parms, ok := d.dictOf(dict["DecodeParms"])
+	if !ok {
+		return 1
+	}
+	if n, ok := parms["Predictor"].(numberObj); ok {
+		return int(n)
+	}
+	return 1
+}
+
+// inflate zlib-decompresses FlateDecode bytes.
+func inflate(raw []byte) ([]byte, error) {
+	r, err := zlib.NewReader(bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("pdf: flate header: %w", err)
+	}
+	defer r.Close()
+	out, err := io.ReadAll(r)
+	if err != nil && len(out) == 0 {
+		return nil, fmt.Errorf("pdf: flate inflate: %w", err)
+	}
+	return out, nil // tolerate a truncated tail when some bytes decoded
+}

--- a/kernel/exchange/pdf/unit_test.go
+++ b/kernel/exchange/pdf/unit_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package pdf
+
+import (
+	"math"
+	"testing"
+)
+
+// TestMatrixConcatApply checks that concat composes transforms in row-vector order: a
+// translate-then-scale maps a point through the translate first.
+func TestMatrixConcatApply(t *testing.T) {
+	translate := translateMatrix(1, 2)
+	scale := matrix{2, 0, 0, 2, 0, 0}
+	m := concat(translate, scale) // apply translate, then scale
+	x, y := m.apply(3, 4)
+	if x != (3+1)*2 || y != (4+2)*2 {
+		t.Errorf("concat(translate,scale).apply(3,4) = (%g,%g), want (8,12)", x, y)
+	}
+}
+
+// TestParseNumberArrayNotRef pins the regression behind the pushback fix: an array of
+// numbers must not be misread as indirect references, which truncated page dictionaries.
+func TestParseNumberArrayNotRef(t *testing.T) {
+	p := newParser(newLexer([]byte("[0 0 2384 1684]")))
+	arr, ok := p.parseValue().(arrayObj)
+	if !ok || len(arr) != 4 {
+		t.Fatalf("parsed %v (ok=%v), want a 4-element array", arr, ok)
+	}
+	for i, want := range []float64{0, 0, 2384, 1684} {
+		if n, ok := arr[i].(numberObj); !ok || float64(n) != want {
+			t.Errorf("element %d = %v, want %g", i, arr[i], want)
+		}
+	}
+}
+
+// TestParseIndirectReference checks the three-token "n g R" form still parses as a ref.
+func TestParseIndirectReference(t *testing.T) {
+	p := newParser(newLexer([]byte("8 0 R")))
+	r, ok := p.parseValue().(refObj)
+	if !ok || r.num != 8 || r.gen != 0 {
+		t.Fatalf("parsed %v (ok=%v), want refObj{8,0}", r, ok)
+	}
+}
+
+// TestLexNameHexEscape checks a /Name with a #xx escape decodes (PDF 1.2+ name syntax).
+func TestLexNameHexEscape(t *testing.T) {
+	tok := newLexer([]byte("/Pa#20ge")).next()
+	if tok.kind != tokName || tok.text != "Pa ge" {
+		t.Errorf("lexed name = %q (kind %d), want \"Pa ge\"", tok.text, tok.kind)
+	}
+}
+
+// TestToMM checks the point→millimetre conversion (1 inch = 72 pt = 25.4 mm).
+func TestToMM(t *testing.T) {
+	if got := toMM(72); math.Abs(got-25.4) > 1e-9 {
+		t.Errorf("toMM(72) = %g, want 25.4", got)
+	}
+}

--- a/kernel/exchange/pdf/units.go
+++ b/kernel/exchange/pdf/units.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package pdf
+
+// mmPerPoint converts a PDF user-space unit (1/72 inch) to millimetres. The decoder
+// bakes this factor into every emitted coordinate and tags the drawing as millimetres
+// (drawing.INSMillimetres) so the shared importer scales it into the document's
+// database unit like any other drawing.
+const mmPerPoint = 25.4 / 72.0
+
+// toMM converts a coordinate in PDF points to millimetres.
+func toMM(pt float64) float64 { return pt * mmPerPoint }

--- a/model/exchange/dispatch.go
+++ b/model/exchange/dispatch.go
@@ -123,6 +123,8 @@ func FormatFromPath(path string) (types.ExchangeFormat, bool) {
 		return types.FormatDWG, true
 	case ".dxf":
 		return types.FormatDXF, true
+	case ".pdf":
+		return types.FormatPDF, true
 	default:
 		return "", false
 	}

--- a/model/exchange/pdfimport.go
+++ b/model/exchange/pdfimport.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package exchange
+
+import (
+	"fmt"
+	"os"
+
+	"oblikovati.org/kernel/exchange/pdf"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/sketch"
+)
+
+// PDFImportResult is SketchImportResult under the PDF name, kept parallel to
+// DWGImportResult so callers read symmetrically.
+type PDFImportResult = SketchImportResult
+
+// ImportPDFFile reads a vector .pdf file and imports it into part, each page's curve
+// geometry becoming its own 2D sketch on the chosen plane — the path-based companion to
+// ImportPDF.
+func ImportPDFFile(part *compdef.PartComponentDefinition, path string, plane sketch.Plane) (PDFImportResult, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return PDFImportResult{}, fmt.Errorf("import pdf: read %q: %w", path, err)
+	}
+	return ImportPDF(part, data, plane)
+}
+
+// ImportPDF decodes vector PDF bytes (a CAD drawing plotted to PDF) and adds each page's
+// geometry to part as a 2D sketch on plane — one sketch per page, so a multi-page plot set
+// imports as several sketches. The decode and the per-page sketch conversion are shared
+// with every drawing format (see sketch_from_drawing.go); only pdf.DecodePages is
+// PDF-specific.
+//
+// Example:
+//
+//	res, err := exchange.ImportPDF(part, data, workPlane.Plane())
+func ImportPDF(part *compdef.PartComponentDefinition, data []byte, plane sketch.Plane) (PDFImportResult, error) {
+	pages, warns, err := pdf.DecodePages(data)
+	if err != nil {
+		return PDFImportResult{}, fmt.Errorf("import pdf: %w", err)
+	}
+	res := PDFImportResult{Warnings: warns}
+	for _, dr := range pages {
+		imp := importDrawing(part, dr, plane)
+		res.EntityCount += imp.entityCount
+		res.Is3D = res.Is3D || imp.is3D
+		res.Warnings = append(res.Warnings, imp.warnings...)
+	}
+	return res, nil
+}

--- a/model/exchange/pdfimport_test.go
+++ b/model/exchange/pdfimport_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package exchange
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/model/compdef"
+)
+
+// onePagePDF assembles a one-page, uncompressed PDF around a content-stream body — enough
+// to exercise the model-level import without committing a binary fixture.
+func onePagePDF(content string) []byte {
+	var b bytes.Buffer
+	b.WriteString("%PDF-1.7\n")
+	b.WriteString("1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n")
+	b.WriteString("2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n")
+	b.WriteString("3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 720 720] /Contents 4 0 R >>\nendobj\n")
+	fmt.Fprintf(&b, "4 0 obj\n<< >>\nstream\n%s\nendstream\nendobj\n", content)
+	b.WriteString("trailer\n<< /Root 1 0 R >>\n")
+	return b.Bytes()
+}
+
+// TestImportPDFPlanarOneSketch imports a vector PDF and checks it lands as a single 2D
+// sketch on the chosen plane with the expected curve entities.
+func TestImportPDFPlanarOneSketch(t *testing.T) {
+	part := compdef.NewPartComponentDefinition()
+	content := "0 0 m 72 0 l 72 72 l S\n100 100 100 172 172 172 c S\n"
+	res, err := ImportPDF(part, onePagePDF(content), xyPlane(t))
+	if err != nil {
+		t.Fatalf("ImportPDF: %v", err)
+	}
+	if res.Is3D {
+		t.Errorf("planar PDF imported as 3D")
+	}
+	if part.Sketches().Count() != 1 || part.Sketches3D().Count() != 0 {
+		t.Fatalf("expected one 2D sketch, got %d/%d", part.Sketches().Count(), part.Sketches3D().Count())
+	}
+	sk := part.Sketches().Item(0)
+	if got := sk.Lines().Count(); got != 2 { // the 3-point stroke is two line segments
+		t.Errorf("lines = %d, want 2", got)
+	}
+	if got := sk.Splines().Count(); got != 1 {
+		t.Errorf("splines = %d, want 1", got)
+	}
+}
+
+// TestImportPDFRealFile imports a real AutoCAD plot (corpus-gated) and checks the dense
+// drawing lands as one 2D sketch.
+func TestImportPDFRealFile(t *testing.T) {
+	dir := os.Getenv("PDF_TESTFILES_DIR")
+	if dir == "" {
+		dir = filepath.Join("..", "..", "..")
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "pdf-vector2.pdf"))
+	if err != nil {
+		t.Skipf("corpus unavailable: %v", err)
+	}
+	part := compdef.NewPartComponentDefinition()
+	res, err := ImportPDF(part, data, xyPlane(t))
+	if err != nil {
+		t.Fatalf("ImportPDF: %v", err)
+	}
+	if res.EntityCount < 100 {
+		t.Errorf("imported only %d entities", res.EntityCount)
+	}
+	if part.Sketches().Count() != 1 {
+		t.Errorf("expected one 2D sketch, got %d", part.Sketches().Count())
+	}
+}


### PR DESCRIPTION
## What

A clean-room **vector-PDF importer** that turns CAD drawings plotted to PDF (e.g. AutoCAD plot-to-PDF — the sample files carry `/Registry (PDFAUTOCAD)`) into a sketch, joining the existing DWG and DXF importers. One 2D sketch per page, on the chosen work plane.

## How

- **`kernel/exchange/pdf`** — a dependency-free reader scoped to the easy subset these files use: classic xref tables, FlateDecode content streams, and the path-construction/painting operator subset under the current transformation matrix (`m`/`l`/`c`/`v`/`y`/`re`/`h`, `q`/`Q`/`cm`, paint ops, `Do` forms). It emits the format-neutral `drawing.Drawing` IR, so the entire downstream pipeline (unit scaling, far-from-origin recenter, planar→2D / non-planar→3D split, undo batching, plane picker, warnings) is **reused unchanged**.
  - Lines/rectangles → `LwPolyline`; each cubic Bézier → an **exact** degree-3, 4-control-point `Spline` (clamped knots `[0,0,0,0,1,1,1,1]`).
  - Text and raster images are **skipped** (with warnings), per scope.
  - xref-stream / object-stream PDFs **error clearly** rather than silently importing nothing — the boundary is documented, not hidden.
- **`model/exchange`** — `ImportPDF` (one sketch per page) + `.pdf → FormatPDF` dispatch.
- **`app`** — `Session.ImportPDFFile` / `ImportPDFOnPlane`, collapsing the thousands of per-segment adds into a single undo step.
- **`addin/router`** — `import.pdf` handler keyed on `wire.MethodImportPDF`.
- **`head/ui`** — File▸Import recognizes `.pdf` and shows the work-plane picker; the duplicated DWG/DXF import wrappers fold into one shared `importSketchFromFile`.
- **`head/cmd/pdfshot`** — throwaway live-capture driver (mirrors `stepshot`) used to verify the import renders.

## Why

Requested: import PDFs of AutoCAD drawings as sketches, like DWG. Contract-first per ADR-0018 — the public surface (`FormatPDF`, `MethodImportPDF`, `client.ImportPDF`) shipped in Oblikovati.API v0.94.0 (#216); this PR pins it and implements the host side.

## Tests & verification

- `kernel/exchange/pdf` unit tests (hand-authored minimal PDFs: line/rect/Bézier, CTM scaling, FlateDecode round-trip, clip discarded, object-stream rejection) + a `PDF_TESTFILES_DIR`-gated real-file corpus (multi-MB PDFs not committed).
- `model/exchange` sketch-level tests (one sketch per page, planar→2D routing, per-collection counts).
- `kernel/exchange/pdf`, `model/exchange`, `app` suites green; `golangci-lint --new-from-rev` clean on both modules.
- **Live**: `pdfshot` captures of `pdf-vector{1,2,3}.pdf` reproduce the source `pdftoppm` rasterizations exactly (grids, sections, title blocks); text intentionally absent.

## Scope (v1) — follow-ons

Text→outline geometry, raster-image underlays, xref/object-stream PDFs, and optional-content layers are out of scope and noted as follow-ons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)