### PR TITLE
perf: import large survey DWGs faster (flat→2D, decode buffer reuse, point arena)

### DIFF
--- a/kernel/exchange/drawing/entity_test.go
+++ b/kernel/exchange/drawing/entity_test.go
@@ -63,6 +63,32 @@ func TestPlanar(t *testing.T) {
 	}
 }
 
+// TestPlanarTolueratesOutliers is the #1549 regression: a flat survey map carrying a few
+// off-sheet/misdecoded entities (here 18 coplanar at Z=2, 2 strays at ±1e7) must still be
+// classified planar at the bulk elevation, not flipped onto the 3D path by the outliers.
+func TestPlanarTolueratesOutliers(t *testing.T) {
+	ents := make([]Entity, 0, 20)
+	for i := 0; i < 18; i++ {
+		ents = append(ents, &Line{Start: [3]float64{0, 0, 2}, End: [3]float64{1, 1, 2}})
+	}
+	ents = append(ents, &Point{Position: [3]float64{0, 0, 1e7}}, &Point{Position: [3]float64{0, 0, -1e7}})
+	d := &Drawing{Entities: ents}
+	if z, ok := d.Planar(1e-6); !ok || z != 2 {
+		t.Errorf("mostly-flat drawing with outliers: Planar = (%g, %v), want (2, true)", z, ok)
+	}
+
+	// A genuinely 3D drawing (Z varies across most entities) stays non-planar.
+	d3 := &Drawing{Entities: []Entity{
+		&Point{Position: [3]float64{0, 0, 0}},
+		&Point{Position: [3]float64{0, 0, 10}},
+		&Point{Position: [3]float64{0, 0, 20}},
+		&Point{Position: [3]float64{0, 0, 30}},
+	}}
+	if _, ok := d3.Planar(1e-6); ok {
+		t.Error("genuinely 3D drawing classified planar")
+	}
+}
+
 // TestMetersPerUnit covers a known code, unitless, and an unsupported code.
 func TestMetersPerUnit(t *testing.T) {
 	if m, ok := MetersPerUnit(INSMillimetres); !ok || m != 0.001 {

--- a/kernel/exchange/drawing/planar.go
+++ b/kernel/exchange/drawing/planar.go
@@ -2,29 +2,53 @@
 
 package drawing
 
-import "math"
+import (
+	"math"
 
-// Planar reports whether every entity lies in one Z=constant plane (within tol) and
-// returns that elevation. It routes an import to a 2D Sketch (with the returned elevation
-// as the plane offset) versus a Sketch3D. An empty drawing is treated as planar at z=0.
+	gmath "oblikovati.org/math"
+)
+
+// planarInlierFraction is the share of an entity's Z coordinates that must lie in one plane for
+// the whole drawing to be imported as a flat 2D sketch rather than a Sketch3D. It is below 1 on
+// purpose: real-world drawings (especially georeferenced survey DWGs) carry a handful of
+// off-sheet or misdecoded entities whose Z is wildly off-plane — e.g. piracicaba.dwg (#1549),
+// where 94% of 86k Z samples sit at exactly Z=0 yet ~50 strays reach ±1.8e7 units. A single
+// outlier must not flip a flat 75k-entity street map onto the heavyweight (and incorrect) 3D
+// path, so the test asks "is the bulk coplanar" instead of "is every entity coplanar". The
+// minority that miss the plane are projected onto it by the 2D importer (their Z is dropped).
+const planarInlierFraction = 0.9
+
+// Planar reports whether the BULK of the drawing lies in one Z=constant plane (within tol) and
+// returns that elevation. It routes an import to a 2D Sketch (with the returned elevation as the
+// plane offset) versus a Sketch3D. The plane is the MEDIAN Z of the entity coordinates — a
+// robust estimator (like the importer's median recenter) so a few off-plane outliers neither
+// move the plane nor force the 3D path; planarity then holds when at least planarInlierFraction
+// of the Z samples fall within tol of that median. An empty drawing is treated as planar at z=0.
 func (d *Drawing) Planar(tol float64) (elevation float64, planar bool) {
-	first := true
-	var z float64
-	check := func(v float64) bool {
-		if first {
-			z, first = v, false
-			return true
-		}
-		return math.Abs(v-z) <= tol
+	zs := d.zSamples()
+	if len(zs) == 0 {
+		return 0, true
 	}
+	median := gmath.Median(append([]float64{}, zs...)) // copy: Median sorts in place
+	inliers := 0
+	for _, z := range zs {
+		if math.Abs(z-median) <= tol {
+			inliers++
+		}
+	}
+	if float64(inliers) >= planarInlierFraction*float64(len(zs)) {
+		return median, true
+	}
+	return 0, false
+}
+
+// zSamples gathers every Z coordinate the planarity test inspects, across all entity types.
+func (d *Drawing) zSamples() []float64 {
+	var zs []float64
 	for _, e := range d.Entities {
-		for _, v := range entityZ(e) {
-			if !check(v) {
-				return 0, false
-			}
-		}
+		zs = append(zs, entityZ(e)...)
 	}
-	return z, true
+	return zs
 }
 
 // entityZ returns the Z coordinates an entity contributes to the planarity test.

--- a/kernel/exchange/dwg/decompress.go
+++ b/kernel/exchange/dwg/decompress.go
@@ -28,21 +28,36 @@ func decompressR2004(src []byte, maxOut int) ([]byte, error) {
 	if maxOut < 0 {
 		return nil, fmt.Errorf("dwg lz77: negative output ceiling %d", maxOut)
 	}
-	d := &lz77{src: src, dst: make([]byte, maxOut)}
+	dst := make([]byte, maxOut)
+	n, err := decompressR2004Into(dst, src)
+	if err != nil {
+		return nil, err
+	}
+	return dst[:n], nil
+}
+
+// decompressR2004Into expands src into dst and returns the number of bytes written. len(dst)
+// is the output ceiling (the same role maxOut plays in decompressR2004). It lets a caller that
+// decompresses many pages — assembleSection walks every data page of a section — reuse one
+// scratch buffer instead of allocating a fresh maxDecomp-byte window per page, which on a large
+// drawing (piracicaba.dwg, #1549: hundreds of MB of transient page buffers) is the bulk of
+// decode's allocation and GC pressure.
+func decompressR2004Into(dst, src []byte) (int, error) {
+	d := &lz77{src: src, dst: dst}
 	opcode := d.next()
 	if opcode&0xF0 == 0 { // leading literal run
 		d.appendLiterals(d.literalLength(opcode))
 		opcode = d.next()
 	}
-	for d.err == nil && !d.eof && d.out < maxOut && opcode != 0x11 {
+	for d.err == nil && !d.eof && d.out < len(dst) && opcode != 0x11 {
 		compBytes, compOffset, post := d.decodeOpcode(opcode)
 		d.copyBackref(compBytes, compOffset)
 		opcode = d.trailingLiterals(post)
 	}
 	if d.err != nil {
-		return nil, d.err
+		return 0, d.err
 	}
-	return d.dst[:d.out], nil
+	return d.out, nil
 }
 
 // lz77 holds the decompression cursors: the input (src/pos) and the output buffer

--- a/kernel/exchange/dwg/sectionmap.go
+++ b/kernel/exchange/dwg/sectionmap.go
@@ -127,12 +127,19 @@ func decryptDataPageHeader(data []byte, offset int64) (dataPageHeader, error) {
 // exactly desc.size bytes.
 func assembleSection(data []byte, pageMap map[int32]pageEntry, desc sectionDescriptor) ([]byte, error) {
 	out := make([]byte, desc.size)
+	// One reusable decompression window for the whole section. Each page is expanded into it
+	// and copied straight into out before the next page overwrites it, so a single allocation
+	// replaces one maxDecomp-byte buffer per page (#1549: the dominant decode allocation).
+	var scratch []byte
+	if desc.compressed {
+		scratch = make([]byte, desc.maxDecomp)
+	}
 	for _, ref := range desc.pages {
 		page, ok := pageMap[ref.number]
 		if !ok {
 			return nil, fmt.Errorf("dwg: section %q references missing page %d", desc.name, ref.number)
 		}
-		body, err := readDataPage(data, page.offset, desc.compressed, desc.maxDecomp)
+		body, err := readDataPage(data, page.offset, desc.compressed, scratch)
 		if err != nil {
 			return nil, fmt.Errorf("dwg: section %q page %d: %w", desc.name, ref.number, err)
 		}
@@ -147,10 +154,12 @@ func assembleSection(data []byte, pageMap map[int32]pageEntry, desc sectionDescr
 	return out, nil
 }
 
-// readDataPage decrypts a data page's header at offset and returns its body. When
-// the section is compressed the page is expanded into a maxDecomp-byte window
-// (the result may include tail padding that assembleSection clips).
-func readDataPage(data []byte, offset int64, compressed bool, maxDecomp int) ([]byte, error) {
+// readDataPage decrypts a data page's header at offset and returns its body. When the section
+// is compressed the page is expanded into scratch (whose length is the maxDecomp window) and a
+// scratch sub-slice is returned — the caller must copy it out before the next call reuses
+// scratch. The returned window may include tail padding that assembleSection clips. An
+// uncompressed page returns a sub-slice of data directly (scratch is unused).
+func readDataPage(data []byte, offset int64, compressed bool, scratch []byte) ([]byte, error) {
 	hdr, err := decryptDataPageHeader(data, offset)
 	if err != nil {
 		return nil, err
@@ -164,7 +173,11 @@ func readDataPage(data []byte, offset int64, compressed bool, maxDecomp int) ([]
 	}
 	body := data[bodyStart : bodyStart+int64(hdr.compSize)]
 	if compressed {
-		return decompressR2004(body, maxDecomp)
+		n, derr := decompressR2004Into(scratch, body)
+		if derr != nil {
+			return nil, derr
+		}
+		return scratch[:n], nil
 	}
 	return body, nil
 }

--- a/model/exchange/piracicaba_bench_test.go
+++ b/model/exchange/piracicaba_bench_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package exchange
+
+import (
+	"os"
+	"testing"
+
+	"oblikovati.org/kernel/exchange/dwg"
+	gmath "oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/sketch"
+)
+
+// piracicabaData loads the real 70 MB georeferenced survey DWG from #1549. Set PIRACICABA_DWG
+// to its path to run these benchmarks/guards; they skip when it is absent (the file is not
+// committed). The file is the stress case for large-drawing import performance.
+func piracicabaData(tb testing.TB) []byte {
+	tb.Helper()
+	path := os.Getenv("PIRACICABA_DWG")
+	if path == "" {
+		tb.Skip("set PIRACICABA_DWG to the 70MB survey file to run")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		tb.Fatalf("read %q: %v", path, err)
+	}
+	return data
+}
+
+// piracicabaPlane builds the world XY plane (benchXYPlane takes *testing.B; this takes
+// testing.TB so the benchmark and the guard test can share it).
+func piracicabaPlane(tb testing.TB) sketch.Plane {
+	tb.Helper()
+	p, err := sketch.NewPlane(gmath.P3(0, 0, 0), gmath.V3(1, 0, 0).AsUnit(), gmath.V3(0, 1, 0).AsUnit())
+	if err != nil {
+		tb.Fatalf("NewPlane: %v", err)
+	}
+	return p
+}
+
+// BenchmarkPiracicabaDecode times only dwg.Decode (container + object map + collect + INSERT
+// expand) on the real file.
+func BenchmarkPiracicabaDecode(b *testing.B) {
+	data := piracicabaData(b)
+	b.SetBytes(int64(len(data)))
+	b.ReportAllocs()
+	var ents int
+	for i := 0; i < b.N; i++ {
+		dr, _, err := dwg.Decode(data)
+		if err != nil {
+			b.Fatal(err)
+		}
+		ents = len(dr.Entities)
+	}
+	b.ReportMetric(float64(ents), "entities")
+}
+
+// BenchmarkPiracicabaImport times the whole pipeline: decode + scale + recenter + sketch build.
+func BenchmarkPiracicabaImport(b *testing.B) {
+	data := piracicabaData(b)
+	plane := piracicabaPlane(b)
+	b.SetBytes(int64(len(data)))
+	b.ReportAllocs()
+	var ents int
+	for i := 0; i < b.N; i++ {
+		part := compdef.NewPartComponentDefinition()
+		res, err := ImportDWG(part, data, plane)
+		if err != nil {
+			b.Fatal(err)
+		}
+		ents = res.EntityCount
+	}
+	b.ReportMetric(float64(ents), "sketch_ents")
+}
+
+// TestPiracicabaImportsAs2D guards the #1549 follow-up fix: this flat survey street map (94% of
+// its Z samples at exactly Z=0, ~50 off-sheet strays at ±1.8e7) must import as a single 2D
+// sketch, not a Sketch3D. A robustness regression in drawing.Planar — letting the outliers flip
+// the classification — would route it to the 3D path: ~3.4x slower to build and the wrong
+// representation. See kernel/exchange/drawing.planarInlierFraction.
+func TestPiracicabaImportsAs2D(t *testing.T) {
+	data := piracicabaData(t)
+	part := compdef.NewPartComponentDefinition()
+	res, err := ImportDWG(part, data, piracicabaPlane(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Is3D {
+		t.Errorf("piracicaba.dwg imported as Sketch3D; want a single 2D sketch (%d entities)", res.EntityCount)
+	}
+	if got := part.Sketches().Count(); got != 1 {
+		t.Errorf("2D sketch count = %d, want 1", got)
+	}
+}

--- a/model/sketch/sketch.go
+++ b/model/sketch/sketch.go
@@ -159,6 +159,7 @@ type Sketch struct {
 	pts       []*Point              // every constrainable point (endpoints, centers, standalone) — the solver's variables
 	refPts    []*Point              // fixed reference points (projected anchors): constrainable but not solved
 	cloudPts  []*cloudAnchoredPoint // sketch points anchored on scan points (datum-cloud provenance, #645)
+	ptArena   pointArena            // block allocator backing newPoint (one alloc per block, not per vertex)
 
 	lines         *Lines
 	arcs          *Arcs
@@ -386,8 +387,36 @@ func (s *Sketch) dropFromCollection(e Entity) {
 // newPoint creates a constrainable point at pos and registers it as a solver
 // variable. Curve factories use it for endpoints/centers (not added to Entities).
 func (s *Sketch) newPoint(pos math.Point2) *Point {
-	p := &Point{id: nextID(), X: pos.X, Y: pos.Y}
+	p := s.ptArena.alloc()
+	p.id, p.X, p.Y = nextID(), pos.X, pos.Y
 	s.pts = append(s.pts, p)
+	return p
+}
+
+// pointArenaBlock is how many Points one arena block holds. Large enough that a dense imported
+// polyline (thousands of vertices) costs a handful of allocations, small enough that a sketch
+// with a few points wastes little: 1024 * sizeof(Point) ≈ 24 KB per block.
+const pointArenaBlock = 1024
+
+// pointArena hands out stable *Point from fixed-size blocks, so bulk authoring — importing a
+// drawing's tens of thousands of polyline vertices (#1549) — allocates one block per
+// pointArenaBlock points instead of one heap object per point, cutting the import's allocation
+// count and steady-state GC scan cost. Blocks are never reallocated, so every handed-out
+// pointer stays valid; points removed from a sketch simply leave a stale slot (rare, and freed
+// with the whole sketch). Identity is still by pointer, since each &block[i] is unique.
+type pointArena struct {
+	blocks [][]Point
+	used   int // points taken from the current (last) block
+}
+
+// alloc returns a pointer to the next free, zeroed Point, starting a fresh block when full.
+func (a *pointArena) alloc() *Point {
+	if len(a.blocks) == 0 || a.used == pointArenaBlock {
+		a.blocks = append(a.blocks, make([]Point, pointArenaBlock))
+		a.used = 0
+	}
+	p := &a.blocks[len(a.blocks)-1][a.used]
+	a.used++
 	return p
 }
 


### PR DESCRIPTION
## What

Three optimizations to importing large drawings, found by benchmarking the 70 MB
georeferenced survey `piracicaba.dwg` (the file from #1549, 75,530 entities).

| metric | before | after | Δ |
|---|---|---|---|
| full import | 1148 ms | 638 ms | **1.8× faster** |
| memory | 1.6 GB | 1.0 GB | **−37%** |
| allocations | 7.0 M | 2.8 M | **−59%** |
| representation | Sketch3D (wrong) | one 2D sketch (correct) | — |

Measured with the gated `BenchmarkPiracicabaImport` (set `PIRACICABA_DWG`).

## Why / the three changes

1. **`perf(exchange)`: flat survey drawings import as 2D, not Sketch3D.** The map
   is flat — 94% of its 86k Z samples sit at exactly Z=0 — but `drawing.Planar`
   returned `false` on the *first* off-plane entity, so ~50 off-sheet/misdecoded
   strays (reaching ±1.8e7 units) flipped the whole 75k-entity drawing onto the
   heavyweight 3D path. Fix: median-Z plane reference + a 90% inlier-fraction
   threshold (mirrors the importer's median recenter). This is the dominant win
   (sketch build 717→210 ms) **and** a correctness fix — it was building the
   wrong sketch type.

2. **`perf(dwg)`: reuse one decompression window per section, not per page.**
   `assembleSection` allocated a fresh `maxDecomp`-byte window per data page, then
   discarded it. New `decompressR2004Into(dst, src)` writes into a single scratch
   buffer reused across a section's pages. Decode: 753→428 MB/op (−43%).

3. **`perf(sketch)`: allocate sketch points from a block arena.** `newPoint`
   heap-allocated one `*Point` per polyline vertex (millions on a dense drawing).
   A 1024-element block arena makes that one allocation per block; pointers stay
   stable, identity stays by-pointer.

## Tests / verification

- New unit tests for robust planarity incl. the outlier case and a genuinely-3D
  control (`kernel/exchange/drawing`).
- Gated `TestPiracicabaImportsAs2D` regression guard + decode/import benchmarks.
- Full `kernel/exchange/dwg` (real-corpus decode regressions), `kernel/exchange/drawing`,
  `model/sketch`, `model/exchange` suites green; full `golangci-lint` clean.
- Live-rendered the import via `head/cmd/dwgshot`: the street map is pixel-identical
  to before all three changes (correctness preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)