### PR TITLE
M39 F07: recompute dependency-key foundation + work-plane-offset incremental tail (#1563)

### DIFF
--- a/addin/router/parameter_groups.go
+++ b/addin/router/parameter_groups.go
@@ -88,7 +88,7 @@ func deleteParameterGroup(s *app.Session, args json.RawMessage) (json.RawMessage
 		return nil, err
 	}
 	if in.DeleteParameters {
-		holder.RecomputeAfterParameterEdit()
+		holder.RecomputeAfterChange()
 	}
 	s.RecordActiveEdit("Delete Parameter Group")
 	return json.Marshal(struct{}{})

--- a/addin/router/parameter_settings.go
+++ b/addin/router/parameter_settings.go
@@ -116,7 +116,7 @@ func sweepParameterModelValues(s *app.Session, args json.RawMessage) (json.RawMe
 	if err != nil {
 		return nil, err
 	}
-	holder.RecomputeAfterParameterEdit()
+	holder.RecomputeAfterChange()
 	s.RecordActiveEdit("Sweep Tolerances")
 	return json.Marshal(wire.ParameterSweepResult{Affected: affected})
 }

--- a/addin/router/parameters.go
+++ b/addin/router/parameters.go
@@ -91,7 +91,7 @@ func setParameter(s *app.Session, args json.RawMessage) (json.RawMessage, error)
 	// A parameter edit can change any feature's live inputs (sketch dimensions,
 	// value closures), which the engine does not track as dependencies, so force a
 	// full parametric rebuild — the shared seam every edit path uses (#1413).
-	holder.RecomputeAfterParameterEdit()
+	holder.RecomputeAfterChange()
 	info := paramInfo(holder, p)
 	emitParameterChanged(s, info) // #148 granular parameter-change notification
 	return json.Marshal(info)

--- a/addin/router/parameters_detail.go
+++ b/addin/router/parameters_detail.go
@@ -121,7 +121,7 @@ func updateParameter(s *app.Session, args json.RawMessage) (json.RawMessage, err
 	}
 	// A model-value selection change moves the value features consume.
 	if in.ModelValueType != nil {
-		holder.RecomputeAfterParameterEdit()
+		holder.RecomputeAfterChange()
 	}
 	s.RecordActiveEdit("Edit Parameter")
 	return json.Marshal(paramDetail(holder, p))
@@ -196,7 +196,7 @@ func setParameterTolerance(s *app.Session, args json.RawMessage) (json.RawMessag
 	if err := applyToleranceMode(holder, p, in); err != nil {
 		return nil, err
 	}
-	holder.RecomputeAfterParameterEdit()
+	holder.RecomputeAfterChange()
 	s.RecordActiveEdit("Edit Tolerance")
 	return json.Marshal(paramDetail(holder, p))
 }
@@ -302,7 +302,7 @@ func deleteParameter(s *app.Session, args json.RawMessage) (json.RawMessage, err
 	if err := ps.Delete(p.ID()); err != nil {
 		return nil, err
 	}
-	holder.RecomputeAfterParameterEdit()
+	holder.RecomputeAfterChange()
 	s.RecordActiveEdit("Delete Parameter")
 	return json.Marshal(struct{}{})
 }

--- a/addin/router/sketch.go
+++ b/addin/router/sketch.go
@@ -11,6 +11,7 @@ import (
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
 	"oblikovati.org/math"
+	"oblikovati.org/model/depend"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/param"
 	"oblikovati.org/model/sketch"
@@ -52,7 +53,7 @@ func createSketch(s *app.Session, raw json.RawMessage) (json.RawMessage, error) 
 	if err := decode(raw, &in); err != nil {
 		return nil, err
 	}
-	plane, name, planeHost, err := sketchCreatePlane(host, in)
+	plane, name, wp, err := sketchCreatePlane(host, in)
 	if err != nil {
 		return nil, err
 	}
@@ -63,9 +64,12 @@ func createSketch(s *app.Session, raw json.RawMessage) (json.RawMessage, error) 
 	// sketch keeps an isolated param store and "od/2" resolves to 0, collapsing
 	// the geometry.
 	sk.SetParameters(host.Parameters())
-	// On a work plane, track it so the sketch follows when the plane moves.
-	if planeHost != nil {
-		sk.SetPlaneHost(planeHost)
+	// On a work plane, track it so the sketch follows when the plane moves, and fold the
+	// plane's offset parameter into the sketch's footprint so an offset edit targets this
+	// sketch's features instead of forcing a wholesale rebuild (ADR-0044).
+	if wp != nil {
+		sk.SetPlaneHost(func() sketch.Plane { return wp.Plane() })
+		sk.SetHostFootprint(func() []depend.Key { return wp.ParameterFootprint() })
 	}
 	return json.Marshal(wire.CreateSketchResult{SketchIndex: host.Sketches().Count() - 1, Plane: name})
 }
@@ -73,7 +77,7 @@ func createSketch(s *app.Session, raw json.RawMessage) (json.RawMessage, error) 
 // sketchCreatePlane resolves the plane a new sketch starts on: a user work plane (when
 // WorkPlaneIndex is set — the way to sketch on a plane built on a feature-created face) or an
 // origin plane otherwise.
-func sketchCreatePlane(host sketchHost, in wire.CreateSketchArgs) (sketch.Plane, string, func() sketch.Plane, error) {
+func sketchCreatePlane(host sketchHost, in wire.CreateSketchArgs) (sketch.Plane, string, *feature.WorkPlane, error) {
 	if in.WorkPlaneIndex == nil {
 		plane, name, err := parsePlane(in.Plane)
 		return plane, name, nil, err // origin planes are fixed, no host to track
@@ -84,8 +88,9 @@ func sketchCreatePlane(host sketchHost, in wire.CreateSketchArgs) (sketch.Plane,
 		return sketch.Plane{}, "", nil, fmt.Errorf("sketch.create: work plane %d out of range (have %d)", i, planes.Count())
 	}
 	wp := planes.Item(i)
-	// The host re-reads the work plane (recomputed in place) so the sketch tracks it.
-	return wp.Plane(), wp.Name(), func() sketch.Plane { return wp.Plane() }, nil
+	// The caller re-reads the work plane (recomputed in place) so the sketch tracks it, and
+	// reads its footprint so the offset parameter is attributed to the sketch.
+	return wp.Plane(), wp.Name(), wp, nil
 }
 
 // sketchRectangle adds a closed rectangle (one profile) to a sketch, ready to extrude.

--- a/app/derived_tables.go
+++ b/app/derived_tables.go
@@ -129,7 +129,7 @@ func (s *Session) SetDerivedTableLinked(id int, linked []string) error {
 		return err
 	}
 	s.autoExportSourceParameters(t.SourceDocument(), linked) // Add2 semantics: linking exports the source params
-	target.RecomputeAfterParameterEdit()
+	target.RecomputeAfterChange()
 	s.recordEdit(target, "Edit Derived Parameters")
 	return nil
 }
@@ -144,7 +144,7 @@ func (s *Session) DeleteDerivedParameterTable(id int) error {
 	if err := target.Parameters().DeleteDerivedTable(id); err != nil {
 		return err
 	}
-	target.RecomputeAfterParameterEdit()
+	target.RecomputeAfterChange()
 	s.recordEdit(target, "Delete Derived Parameters")
 	return nil
 }
@@ -193,7 +193,7 @@ func (s *Session) resyncDocumentFrom(d *doc.Document, sourceName string, values 
 		synced = true
 	}
 	if synced {
-		holder.RecomputeAfterParameterEdit()
+		holder.RecomputeAfterChange()
 	}
 	return synced
 }

--- a/app/parameters_edit.go
+++ b/app/parameters_edit.go
@@ -163,7 +163,7 @@ func (s *Session) ImportParameters(xml string) (added, updated int, err error) {
 		}
 		return 0, 0, err
 	}
-	holder.RecomputeAfterParameterEdit()
+	holder.RecomputeAfterChange()
 	s.recordEdit(holder, "Import Parameters")
 	return added, updated, nil
 }
@@ -193,7 +193,7 @@ func (s *Session) editParameters(edit func(*param.Parameters) error) error {
 		return err
 	}
 	s.notice = ""
-	holder.RecomputeAfterParameterEdit() // mark dirty before recompute, or the edit leaves stale geometry (#1413)
+	holder.RecomputeAfterChange() // mark dirty before recompute, or the edit leaves stale geometry (#1413)
 	s.recordEdit(holder, "Edit Parameters")
 	return nil
 }

--- a/app/parameters_rebuild_test.go
+++ b/app/parameters_rebuild_test.go
@@ -60,7 +60,7 @@ func TestParameterEditViaAppPathRebuildsFeature(t *testing.T) {
 }
 
 // TestParameterEditPathsInvalidateIdentically is the #1413 parity check: the app dialog verb and the
-// import verb (the two app-side parameter-edit seams) both route through RecomputeAfterParameterEdit,
+// import verb (the two app-side parameter-edit seams) both route through RecomputeAfterChange,
 // so each forces a rebuild. Editing the same part the same way through either must re-evaluate the
 // feature — the single shared seam, no divergence.
 func TestParameterEditPathsInvalidateIdentically(t *testing.T) {

--- a/architecture/decisions/ADR-0044-recompute-dependency-invalidation-seam.md
+++ b/architecture/decisions/ADR-0044-recompute-dependency-invalidation-seam.md
@@ -1,0 +1,129 @@
+# ADR-0044 — Recompute dependency-key invalidation seam
+
+**Status:** Accepted — design (2026-06-29). · **Builds on / refines:**
+[ADR-0018](ADR-0018-apache-api-contract-module.md) (the API/implementation split this
+follows), the M39 `ParameterHolder` seam (part-or-assembly parameter ownership),
+Oblikovati#1414 (incremental parameter recompute) and #1413 (the single parameter-edit
+invalidation seam). · **Complements** [ADR-0040](ADR-0040-external-geometric-references.md):
+that ADR supplies the *identity* of an external geometric selection (binding geometry →
+topology); this ADR supplies the *invalidation* half (which consumers a change dirties).
+Together they are the two halves a future cross-part **adaptive reference** needs. ·
+**Touches (when implemented):** new `model/depend`, `model/param/tracking.go`,
+`model/compdef/{parameter_holder,part,assembly}.go`, `model/feature/engine_param_invalidate.go`.
+
+## Context
+
+A parameter edit must trigger the **minimal correct** geometry rebuild: dirty only the
+features a change can reach, reuse cached bodies for the rest (Oblikovati#1414). Today the
+part does this with two pieces:
+
+- **Footprint capture** — `param.Parameters.Track` wraps a recompute and records which
+  `param.ID`s were read.
+- **Consumer attribution** — `PartFeatures.featureAffectedByParams`: a feature is dirty if a
+  changed parameter is in its direct `paramReads` or in a consumed 2D sketch's
+  `ParameterFootprint`.
+
+Everything else read during recompute — a work-plane offset, a 3D-sketch dimension, a
+host-plane closure — is *not* attributable to a single feature, so it is dumped into
+`wholesaleParams` and forces a full rebuild. This is the **load-bearing invariant**
+(#1403/#1414): **a read through an un-attributed path is never silently skipped — it
+conservatively rebuilds everything.** Silent-stale geometry is the worst failure class.
+
+Two pressures converge on this code:
+
+1. **F07 (#1563)** wants to *shrink* the wholesale fallback by attributing the work-plane,
+   3D-sketch, and host-plane paths to their consuming features.
+2. **Future cross-part adaptive references** (part B geometry driven by part A geometry,
+   mediated by the assembly) are the *geometry-level* sibling of Derived Parameter Tables:
+   a change in one document must dirty the dependent features in another. This is the same
+   footprint-and-attribution problem, one level up and on evaluated B-rep instead of scalars.
+
+The directive is **"set the foundation now so adaptive references just fit later, without a
+rewrite."** The trap is reading that as "build the full assembly incremental engine now": an
+incremental engine is shaped to *what it can attribute*, and the only cross-part input that
+exists today is occurrence placement (which full re-solve already handles). Building it now
+means shaping a real engine against imagined requirements — the code most likely to be
+rebuilt when real adaptivity lands.
+
+## Decision
+
+The foundation is a **stable invalidation seam + a generalized dependency key + the
+wholesale-never-skip invariant** — *not* a built-out assembly incremental engine. A
+**wholesale implementation is a valid point on the same contract** ("attribute nothing →
+rebuild everything" is the degenerate, always-correct case), so the assembly satisfies the
+seam now wholesale, and adaptivity narrows it later from inside the seam.
+
+1. **Generalize the footprint key now (`model/depend`, document-free).** Replace the
+   `param.ID`-typed footprint with an opaque comparable value:
+
+   ```go
+   type KeyKind uint8
+   const ( ParameterKey KeyKind = iota; WorkPlaneKey; SketchKey; ExternalGeometryKey )
+   type Key struct { Kind KeyKind; ID uint64 }   // comparable value type
+   type Footprint []Key
+   ```
+
+   Parameters are `Key{ParameterKey, …}`. `ExternalGeometryKey` is **defined now but
+   produced only by the future adaptivity resolver**. This is the one thing expensive to
+   retrofit: hard-coding `param.ID` through capture/footprint/attribution would force a new
+   key type through the whole engine later — the rewrite we are avoiding. Generalizing while
+   only parameters use it is cheap now.
+
+2. **Holder-agnostic attribution (`model/depend.DirtyTail`).** The
+   `changed-keys ∩ footprint → earliest dirty consumer → dirty the tail` logic is written
+   once over `depend.Key` and reused by part (incremental) and assembly (wholesale).
+
+3. **Generalized holder seam.** `ParameterHolder` gains
+   `RecomputeAfterChange(changed []depend.Key)` — the single invalidation entry for parameter
+   edits, geometry edits, and future edge kinds (subsuming `RecomputeAfterParameterEdit`,
+   keeping #1413's "one seam, no divergence"). It **MAY** rebuild wholesale for any
+   unattributable key; it **MUST NOT** silently skip one (the invariant).
+
+4. **Part narrows; assembly stays wholesale.** The part's F07 work attributes the
+   work-plane / 3D-sketch / host-plane paths over `depend.Key`. The assembly satisfies
+   `RecomputeAfterChange` with a full re-solve (its current behaviour, now behind the named
+   seam — exercised, not speculative).
+
+5. **The inter-document dependency graph is owned by orchestration, not the model.** When
+   adaptivity lands, `app.Session`/`Workspace` resolves an `ExternalGeometryKey` to a
+   `(sourceDocument, topoRefKey)` via the workspace reference graph — the **same
+   anticorruption seam** that already resolves Derived-Parameter-Table source documents. The
+   model reports "I read key K"; only the orchestrator knows K names another document. The
+   key's geometric identity reuses ADR-0040's external geometric reference and ADR-0043
+   provenance. `model` stays document-free (`compdef` must not import `app`); no cycle,
+   because `ExternalGeometryKey` is opaque to the model.
+
+## Consequences
+
+- **Adaptivity slots in behind a stable seam:** it adds an `ExternalGeometryKey` producer
+  (the Session resolver) and, when justified, narrows the assembly body — touching neither
+  the key type, the attribution logic, nor the part. The "no rebuild later" goal is met by
+  the seam, not by pre-building the engine.
+- **Assembly parameter edits stay full re-solve** until a future milestone narrows them.
+  Correct today, just not incremental — and the path to incremental is purely additive.
+- **One mechanical sweep now:** routing the existing param-id footprint path through
+  `depend.Key`. Attribution becomes shared instead of part-private.
+- **Safety floor preserved and generalized:** the wholesale-never-skip invariant now lives in
+  the shared seam, so every holder — and every future edge kind — inherits it. An adaptive
+  reference not yet in the footprint model will conservatively force a re-solve, never be
+  silently ignored.
+
+### Why not build the full assembly incremental engine now
+
+It has nothing to attribute (no cross-part edges exist yet) and would be shaped to guessed
+adaptivity requirements — maximizing, not minimizing, the chance of a later rewrite. A
+wholesale assembly behind the generalized seam gives the same external guarantee (the seam
+exists and is exercised) at a fraction of the risk.
+
+### Why not keep `param.ID` and add a parallel geometry path later
+
+Two key types means two capture paths, two attribution routines, and a divergent invalidation
+surface — exactly the divergence #1413 consolidated away, and the rebuild this ADR exists to
+prevent.
+
+## Scope
+
+This ADR + `model/depend` + the part's F07 narrowing + the assembly satisfying the seam
+wholesale are **this change (F07)**. The Session `ExternalGeometryKey` resolver and any
+assembly incremental narrowing are the **adaptivity milestone**, and plug into the seam
+defined here.

--- a/model/compdef/assembly.go
+++ b/model/compdef/assembly.go
@@ -260,10 +260,13 @@ func (a *AssemblyComponentDefinition) Properties() *attr.PropertySets { return a
 // a part and an assembly present one recompute method (#766).
 func (a *AssemblyComponentDefinition) Recompute() { a.RecomputeFeatures() }
 
-// RecomputeAfterParameterEdit re-solves the assembly after a parameter edit. An assembly has no
-// incremental parameter-edit fast path (unlike a part, #1414), so this is a full re-solve — the
-// honest implementation of the [ParameterHolder] contract for an assembly (M39-F02, #1558).
-func (a *AssemblyComponentDefinition) RecomputeAfterParameterEdit() { a.RecomputeFeatures() }
+// RecomputeAfterChange re-solves the assembly after a parameter edit (or, later, a cross-part
+// adaptive-reference change). An assembly has no incremental fast path (unlike a part, #1414), so
+// this is a full re-solve. Wholesale is a VALID point on the [ParameterHolder] invalidation
+// contract — "attribute nothing, rebuild everything" — so the seam exists and is exercised now,
+// and the adaptivity milestone narrows it from inside without reshaping the seam (M39-F02 #1558,
+// ADR-0044).
+func (a *AssemblyComponentDefinition) RecomputeAfterChange() { a.RecomputeFeatures() }
 
 // WorkGeometry returns the assembly's origin coordinate frame and user work
 // planes/axes/points, expressed in assembly space — the planes a sketch is authored on.

--- a/model/compdef/param_incremental_recompute_test.go
+++ b/model/compdef/param_incremental_recompute_test.go
@@ -80,7 +80,7 @@ func TestParameterEditRebuildsOnlyDependentTail(t *testing.T) {
 	if err := def.Parameters().SetExpression(userParamID(t, def, "drive"), "60 mm"); err != nil {
 		t.Fatalf("SetExpression: %v", err)
 	}
-	def.RecomputeAfterParameterEdit()
+	def.RecomputeAfterChange()
 	after := recomputeCounts(def)
 
 	for i := 0; i < n; i++ {
@@ -109,7 +109,7 @@ func TestIndependentParameterEditRebuildsNothing(t *testing.T) {
 	if err := def.Parameters().SetExpression(userParamID(t, def, "unused"), "20 mm"); err != nil {
 		t.Fatalf("SetExpression: %v", err)
 	}
-	def.RecomputeAfterParameterEdit()
+	def.RecomputeAfterChange()
 	after := recomputeCounts(def)
 
 	for i := range before {
@@ -130,7 +130,7 @@ func TestTargetedParameterEditMatchesFullRebuildGeometry(t *testing.T) {
 	if err := edited.Parameters().SetExpression(userParamID(t, edited, "drive"), "60 mm"); err != nil {
 		t.Fatalf("SetExpression: %v", err)
 	}
-	edited.RecomputeAfterParameterEdit()
+	edited.RecomputeAfterChange()
 
 	// ...must match a part built from scratch at 60 mm (a full evaluation).
 	fresh := compdef.NewPartComponentDefinition()

--- a/model/compdef/param_wholesale_recompute_test.go
+++ b/model/compdef/param_wholesale_recompute_test.go
@@ -6,38 +6,48 @@ import (
 	"testing"
 
 	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/depend"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/sketch"
 )
 
-// A parameter that reaches geometry through a path the engine cannot attribute to a single
-// feature — here a work-plane offset, which moves a hosted sketch and everything built on it —
-// must conservatively rebuild the whole program (Oblikovati#1414). Missing it would leave the
-// dependent feature on stale geometry, the exact silent-stale failure the targeted path must
-// never introduce. This test pins both halves: the rebuild happens (every feature recomputes)
-// AND the geometry follows the moved plane.
-func TestWorkPlaneOffsetParameterEditRebuildsWholeProgram(t *testing.T) {
+// liftedBlockPart builds a two-feature part: feature 0 is a plain block on XY (independent of
+// any parameter); feature 1 is a block on a work plane offset from XY by the "lift" parameter,
+// with the sketch wired to the plane exactly as the router wires a live work-plane sketch
+// (SetPlaneHost + SetHostFootprint). It returns the def and the lift parameter's id.
+func liftedBlockPart(t *testing.T) (*compdef.PartComponentDefinition, string) {
+	t.Helper()
 	def := compdef.NewPartComponentDefinition()
 	lift, err := def.Parameters().AddUserParameter("lift", "20 mm") // 2 cm
 	if err != nil {
 		t.Fatalf("AddUserParameter: %v", err)
 	}
 
-	// Feature 0: a plain block on XY (independent of lift).
 	base := def.Sketches().Add(sketch.XYPlane())
 	rectangle(base, 4, 3)
 	feature.NewExtrudeFeatures(def.Features()).
 		AddByDistanceExtent(base, 0, ops.NewBody, func() float64 { return 5 })
 
-	// Feature 1: a block on a work plane offset from XY by the "lift" parameter.
 	wp := def.WorkPlanes().AddByPlaneAndOffset(feature.OriginXYPlane, lift.ModelValue)
 	lifted := def.Sketches().Add(wp.Plane())
 	lifted.SetPlaneHost(func() sketch.Plane { return wp.Plane() })
+	lifted.SetHostFootprint(func() []depend.Key { return wp.ParameterFootprint() })
 	rectangle(lifted, 4, 3)
 	feature.NewExtrudeFeatures(def.Features()).
 		AddByDistanceExtent(lifted, 0, ops.NewBody, func() float64 { return 5 })
 
+	return def, lift.Name()
+}
+
+// A work-plane offset reaches geometry through the sketch hosted on that plane. Now that the
+// plane's offset parameter is folded into the hosted sketch's footprint (ADR-0044), editing it
+// must rebuild ONLY the feature that consumes the hosted sketch (and its tail) — not the
+// independent base block — while the lifted block still follows the moved plane. This pins both
+// the targeting (feature 0 untouched) and the correctness (geometry follows).
+func TestWorkPlaneOffsetParameterEditTargetsHostedSketch(t *testing.T) {
+	def, _ := liftedBlockPart(t)
 	def.Recompute()
 	before := recomputeCounts(def)
 	if z := def.RangeBox().Min.Z; z < -1e-6 || z > 1e-6 {
@@ -49,17 +59,48 @@ func TestWorkPlaneOffsetParameterEditRebuildsWholeProgram(t *testing.T) {
 	}
 	def.RecomputeAfterChange()
 
-	// The whole program rebuilds: even feature 0, independent of lift, recomputes (the
-	// conservative fallback for an unmodelled parameter path).
+	// Feature 0 is independent of lift and must NOT rebuild; feature 1 (consumes the hosted
+	// sketch) and its tail must.
 	after := recomputeCounts(def)
-	for i := range before {
-		if after[i] != before[i]+1 {
-			t.Errorf("feature %d count %d→%d, want a full rebuild (+1)", i, before[i], after[i])
-		}
+	if after[0] != before[0] {
+		t.Errorf("independent base feature rebuilt on work-plane-offset edit: count %d→%d, want unchanged", before[0], after[0])
 	}
-	// The lifted block followed its work plane: the model now spans z ∈ [0, 5+5] (base 0..5,
+	if after[1] != before[1]+1 {
+		t.Errorf("hosted feature not rebuilt: count %d→%d, want +1", before[1], after[1])
+	}
+	// The lifted block followed its work plane: the model now spans z ∈ [0, 10] (base 0..5,
 	// lifted 5..10), so the top moved from 7 cm to 10 cm.
 	if z := def.RangeBox().Max.Z; z < 9.999 || z > 10.001 {
 		t.Errorf("after lift→50 mm, model max.z = %v, want ~10 (lifted block at 5..10 cm)", z)
 	}
+}
+
+// The targeted path must produce EXACTLY the geometry a full rebuild would. We make the same
+// edit two ways — the incremental RecomputeAfterChange, then a forced full rebuild
+// (MarkAllDirty) — and assert the bounding box is identical. A targeted path that wrongly
+// skipped a dependent feature would diverge here; this is the differential guard that makes
+// narrowing the wholesale fallback safe (ADR-0044, the silent-stale failure class).
+func TestWorkPlaneOffsetTargetedMatchesFullRebuild(t *testing.T) {
+	def, _ := liftedBlockPart(t)
+	def.Recompute()
+
+	if err := def.Parameters().SetExpression(userParamID(t, def, "lift"), "50 mm"); err != nil {
+		t.Fatalf("SetExpression: %v", err)
+	}
+	def.RecomputeAfterChange() // incremental
+	targeted := def.RangeBox()
+
+	def.Features().MarkAllDirty()
+	def.Recompute() // forced full rebuild of the same state
+	full := def.RangeBox()
+
+	if !boxesEqual(targeted, full) {
+		t.Errorf("targeted rebuild geometry %v != full rebuild geometry %v (the targeted path skipped a dependent feature)", targeted, full)
+	}
+}
+
+// boxesEqual compares two range boxes within a small absolute tolerance.
+func boxesEqual(a, b math.Box) bool {
+	const tol = 1e-6
+	return a.Min.IsEqualTo(b.Min, tol) && a.Max.IsEqualTo(b.Max, tol)
 }

--- a/model/compdef/param_wholesale_recompute_test.go
+++ b/model/compdef/param_wholesale_recompute_test.go
@@ -47,7 +47,7 @@ func TestWorkPlaneOffsetParameterEditRebuildsWholeProgram(t *testing.T) {
 	if err := def.Parameters().SetExpression(userParamID(t, def, "lift"), "50 mm"); err != nil { // 5 cm
 		t.Fatalf("SetExpression: %v", err)
 	}
-	def.RecomputeAfterParameterEdit()
+	def.RecomputeAfterChange()
 
 	// The whole program rebuilds: even feature 0, independent of lift, recomputes (the
 	// conservative fallback for an unmodelled parameter path).

--- a/model/compdef/parameter_holder.go
+++ b/model/compdef/parameter_holder.go
@@ -12,8 +12,11 @@ import "oblikovati.org/model/param"
 // definition.
 //
 // The recompute methods are named by intent, not by mechanism: a part may take its
-// incremental parameter-edit fast path (#1414) while an assembly does a full re-solve — each
-// holder picks its own strategy behind the same contract.
+// incremental change fast path (#1414) while an assembly does a full re-solve — each holder
+// picks its own strategy behind the same contract. RecomputeAfterChange is the single
+// generalized invalidation seam (ADR-0044): it takes no change-set (it drains its own change
+// sources) so the same entry serves a parameter edit today and a cross-part adaptive-reference
+// change later, and a wholesale implementation (the assembly's) is a valid point on it.
 //
 // It deliberately carries NO persistence (MarshalSnapshot/RecipeContent): undo recording is a
 // separate concern, composed by the caller (see app's editable-holder seam), so this stays a
@@ -26,7 +29,7 @@ type ParameterHolder interface {
 	// wire/UI parameter surface needs them alongside the table.
 	Units() param.UnitsOfMeasure
 	Recompute()
-	RecomputeAfterParameterEdit()
+	RecomputeAfterChange()
 }
 
 // Both component definitions are parameter holders. A plain interface assertion on a

--- a/model/compdef/part.go
+++ b/model/compdef/part.go
@@ -9,6 +9,7 @@ import (
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 	"oblikovati.org/model/attr"
+	"oblikovati.org/model/depend"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/identity"
@@ -75,13 +76,13 @@ type PartComponentDefinition struct {
 	// centerlines are the flat pattern's cosmetic centerlines (M13-F06) — annotation lines that
 	// persist with the part.
 	centerlines []sheetmetal.CosmeticCenterline
-	// wholesaleParams are the parameters whose change must rebuild the whole feature program
-	// because they reach geometry through a path the engine does not model per-feature — a
-	// work-plane offset, a 3D-sketch dimension, a sketch's host plane. Captured each Recompute
-	// as (all parameters read during recompute) − (those precisely attributable to a 2D sketch
-	// or a feature's direct reads), so any unmodelled path is conservatively wholesale and a
-	// parameter edit never silently leaves stale geometry (Oblikovati#1414).
-	wholesaleParams map[param.ID]bool
+	// wholesaleParams are the dependency keys whose change must rebuild the whole feature
+	// program because they reach geometry through a path the engine does not model
+	// per-feature — a 3D-sketch dimension, a host-plane closure not yet attributed. Captured
+	// each Recompute as (all keys read during recompute) − (those precisely attributable to a
+	// sketch or a feature's direct reads), so any unmodelled path is conservatively wholesale
+	// and a change never silently leaves stale geometry (Oblikovati#1414, ADR-0044).
+	wholesaleParams map[depend.Key]bool
 }
 
 // NewPartComponentDefinition returns an empty part content object with its feature
@@ -150,7 +151,7 @@ func (d *PartComponentDefinition) Recompute() {
 	// Capture every parameter read during the recompute (total footprint); the difference
 	// against what is precisely attributable to a 2D sketch or a feature's direct reads is
 	// the wholesale set a future parameter edit must rebuild the whole program for (#1414).
-	total := d.params.Track(d.recomputeGeometry)
+	total := d.params.TrackKeys(d.recomputeGeometry)
 	d.recordWholesaleParams(total)
 	// Drop any change records produced before now (parameters added while building
 	// sketches/features, an earlier untargeted recompute) so the NEXT parameter edit sees
@@ -187,64 +188,67 @@ func (d *PartComponentDefinition) recomputeGeometry() {
 	d.refreshSketchReferences()
 }
 
-// recordWholesaleParams stores (total parameter reads − precisely-targetable reads) as the
-// set a parameter edit must rebuild the whole program for. The precise set is every 2D
-// sketch's dimension footprint plus every feature's direct reads — exactly what
-// MarkDirtyForParams can attribute to a feature. Anything else a recompute read (a
-// work-plane offset, a 3D-sketch dimension, a host-plane closure) is conservatively
-// wholesale, so no parameter path is ever silently skipped (Oblikovati#1414).
-func (d *PartComponentDefinition) recordWholesaleParams(total []param.ID) {
-	precise := map[param.ID]bool{}
+// recordWholesaleParams stores (total reads − precisely-targetable reads) as the set a
+// change must rebuild the whole program for. The precise set is every sketch's footprint
+// (its own solve plus, for a work-plane-hosted sketch, the plane's offset footprint) plus
+// every feature's direct reads — exactly what MarkDirtyForChange can attribute to a
+// feature. Anything else a recompute read (a 3D-sketch dimension, a host-plane closure not
+// yet attributed) is conservatively wholesale, so no path is ever silently skipped
+// (Oblikovati#1414, ADR-0044).
+func (d *PartComponentDefinition) recordWholesaleParams(total []depend.Key) {
+	precise := map[depend.Key]bool{}
 	for i := 0; i < d.sketches.Count(); i++ {
-		for _, id := range d.sketches.Item(i).ParameterFootprint() {
-			precise[id] = true
+		for _, k := range d.sketches.Item(i).ParameterFootprint() {
+			precise[k] = true
 		}
 	}
-	for _, id := range d.features.ParameterReads() {
-		precise[id] = true
+	for _, k := range d.features.DependencyReads() {
+		precise[k] = true
 	}
-	d.wholesaleParams = map[param.ID]bool{}
-	for _, id := range total {
-		if !precise[id] {
-			d.wholesaleParams[id] = true
+	d.wholesaleParams = map[depend.Key]bool{}
+	for _, k := range total {
+		if !precise[k] {
+			d.wholesaleParams[k] = true
 		}
 	}
 }
 
-// RecomputeAfterParameterEdit rebuilds the part after a parameter value/equation/bool edit. A
-// parameter edit can change a feature's LIVE inputs — sketch dimensions, sheet-metal thicknesses,
-// work-plane-offset closures — which the feature engine does not see as ordinary feature
-// dependencies, so a plain Recompute would find nothing dirty and hand back the cached, pre-edit
-// bodies (silent stale geometry). This is the single invalidation seam every parameter-edit path
-// shares — the UI verb, XML import, and the wire router — so they cannot diverge (Oblikovati#1413).
+// RecomputeAfterChange rebuilds the part after a parameter value/equation/bool edit (and, in
+// future, a cross-part adaptive-reference change — ADR-0044). Such a change can alter a feature's
+// LIVE inputs — sketch dimensions, sheet-metal thicknesses, work-plane-offset closures — which the
+// feature engine does not see as ordinary feature dependencies, so a plain Recompute would find
+// nothing dirty and hand back the cached, pre-edit bodies (silent stale geometry). This is the
+// single invalidation seam every change path shares — the UI verb, XML import, the wire router — so
+// they cannot diverge (Oblikovati#1413). It takes no change-set argument: it drains its own change
+// sources (the parameter graph today), keeping callers ignorant of attribution.
 //
-// It invalidates only the affected tail (Oblikovati#1414): the edit's changed parameters (and their
-// transitive dependents) come from the parameter graph; if any reaches geometry through a path the
-// engine cannot attribute to a feature (a work-plane offset, a 3D-sketch dimension — the wholesale
-// set captured last recompute) it falls back to a full rebuild, otherwise it dirties only the
-// features whose consumed-sketch dimensions or direct reads the edit touched. Editing one fillet's
-// driving parameter on a 1000-feature part then rebuilds that fillet's tail, not all 1000.
-func (d *PartComponentDefinition) RecomputeAfterParameterEdit() {
-	changed := d.params.DrainChanged()
-	if d.paramEditNeedsFullRebuild(changed) {
+// It invalidates only the affected tail (Oblikovati#1414): the changed keys (and their transitive
+// dependents) come from the parameter graph; if any reaches geometry through a path the engine
+// cannot attribute to a feature (a 3D-sketch dimension — the wholesale set captured last recompute)
+// it falls back to a full rebuild, otherwise it dirties only the features whose consumed-sketch
+// footprint or direct reads the change touched. Editing one fillet's driving parameter on a
+// 1000-feature part then rebuilds that fillet's tail, not all 1000.
+func (d *PartComponentDefinition) RecomputeAfterChange() {
+	changed := d.params.DrainChangedKeys()
+	if d.changeNeedsFullRebuild(changed) {
 		d.features.MarkAllDirty()
 	} else {
-		d.features.MarkDirtyForParams(changed)
+		d.features.MarkDirtyForChange(changed)
 	}
 	d.Recompute()
 }
 
-// paramEditNeedsFullRebuild reports whether a parameter edit must rebuild the whole program
-// rather than a targeted tail: when nothing recorded as changed (an edit path that bypassed the
-// graph, or the first edit after load — rebuild conservatively), or when a changed parameter is in
-// the wholesale set (reaches geometry through an unmodelled path). Otherwise the changed
-// parameters are precisely attributable to features and MarkDirtyForParams handles them.
-func (d *PartComponentDefinition) paramEditNeedsFullRebuild(changed []param.ID) bool {
+// changeNeedsFullRebuild reports whether a change must rebuild the whole program rather than a
+// targeted tail: when nothing recorded as changed (an edit path that bypassed the graph, or the
+// first edit after load — rebuild conservatively), or when a changed key is in the wholesale set
+// (reaches geometry through an unmodelled path). Otherwise the changed keys are precisely
+// attributable to features and MarkDirtyForChange handles them.
+func (d *PartComponentDefinition) changeNeedsFullRebuild(changed []depend.Key) bool {
 	if len(changed) == 0 {
 		return true
 	}
-	for _, id := range changed {
-		if d.wholesaleParams[id] {
+	for _, k := range changed {
+		if d.wholesaleParams[k] {
 			return true
 		}
 	}
@@ -268,7 +272,7 @@ func (d *PartComponentDefinition) refreshSketchPlanes() {
 func (d *PartComponentDefinition) solveSketches() {
 	for i := 0; i < d.sketches.Count(); i++ {
 		sk := d.sketches.Item(i)
-		sk.SetParameterFootprint(d.params.Track(func() { sk.Solve() }))
+		sk.SetParameterFootprint(d.params.TrackKeys(func() { sk.Solve() }))
 	}
 }
 

--- a/model/compdef/part.go
+++ b/model/compdef/part.go
@@ -112,6 +112,7 @@ func NewPartComponentDefinition() *PartComponentDefinition {
 	d.features.SetWorkingScaleResolver(func() float64 { return d.units.WorkingScale() }) // re-import scales into the doc working unit
 	d.sketches.ShareParameters(params)                                                   // dimension expressions resolve against user params (live + restore)
 	d.sketches3D.ShareParameters(params)                                                 // same for 3D sketches
+	d.work.SetFootprintTracker(params)                                                   // each work plane records its offset parameter, so an offset edit targets its hosted sketch (ADR-0044)
 	return d
 }
 
@@ -191,10 +192,12 @@ func (d *PartComponentDefinition) recomputeGeometry() {
 // recordWholesaleParams stores (total reads − precisely-targetable reads) as the set a
 // change must rebuild the whole program for. The precise set is every sketch's footprint
 // (its own solve plus, for a work-plane-hosted sketch, the plane's offset footprint) plus
-// every feature's direct reads — exactly what MarkDirtyForChange can attribute to a
-// feature. Anything else a recompute read (a 3D-sketch dimension, a host-plane closure not
-// yet attributed) is conservatively wholesale, so no path is ever silently skipped
-// (Oblikovati#1414, ADR-0044).
+// every feature's direct reads — exactly what MarkDirtyForChange can attribute to a feature.
+// Any other read during recompute is conservatively wholesale, so no path is ever silently
+// skipped (Oblikovati#1414, ADR-0044). (3D-sketch dimensions are not in `total` today: 3D
+// sketches are not re-solved during recompute — see solveSketches, 2D only — so their
+// parameters are never read here. When 3D re-solving lands, its reads fall safely into the
+// wholesale set until attributed to consuming features.)
 func (d *PartComponentDefinition) recordWholesaleParams(total []depend.Key) {
 	precise := map[depend.Key]bool{}
 	for i := 0; i < d.sketches.Count(); i++ {
@@ -224,10 +227,11 @@ func (d *PartComponentDefinition) recordWholesaleParams(total []depend.Key) {
 //
 // It invalidates only the affected tail (Oblikovati#1414): the changed keys (and their transitive
 // dependents) come from the parameter graph; if any reaches geometry through a path the engine
-// cannot attribute to a feature (a 3D-sketch dimension — the wholesale set captured last recompute)
-// it falls back to a full rebuild, otherwise it dirties only the features whose consumed-sketch
-// footprint or direct reads the change touched. Editing one fillet's driving parameter on a
-// 1000-feature part then rebuilds that fillet's tail, not all 1000.
+// cannot attribute to a feature (the wholesale set captured last recompute) it falls back to a full
+// rebuild, otherwise it dirties only the features whose consumed-sketch footprint or direct reads
+// the change touched. A work-plane offset is attributed through the hosted sketch's footprint, so
+// editing one fillet's (or one offset's) driving parameter on a 1000-feature part rebuilds that
+// feature's tail, not all 1000.
 func (d *PartComponentDefinition) RecomputeAfterChange() {
 	changed := d.params.DrainChangedKeys()
 	if d.changeNeedsFullRebuild(changed) {

--- a/model/compdef/snapshot_incremental.go
+++ b/model/compdef/snapshot_incremental.go
@@ -7,8 +7,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"oblikovati.org/model/depend"
 	"oblikovati.org/model/feature"
-	"oblikovati.org/model/param"
 )
 
 // restoreFeatureTail applies a snapshot that changed only a feature tail — every parameter,
@@ -87,14 +87,14 @@ func sameFeatureData(a, b feature.FeatureData) bool {
 // never shrinks it (the partial recompute did not re-read the kept prefix's parameters, so its
 // freshly-derived set is incomplete; a superset is conservative and safe — it can only force an
 // unnecessary full rebuild on a later parameter edit, never permit a stale one — #1414).
-func (d *PartComponentDefinition) mergeWholesaleParams(prior map[param.ID]bool) {
+func (d *PartComponentDefinition) mergeWholesaleParams(prior map[depend.Key]bool) {
 	if len(prior) == 0 {
 		return
 	}
 	if d.wholesaleParams == nil {
-		d.wholesaleParams = map[param.ID]bool{}
+		d.wholesaleParams = map[depend.Key]bool{}
 	}
-	for id := range prior {
-		d.wholesaleParams[id] = true
+	for k := range prior {
+		d.wholesaleParams[k] = true
 	}
 }

--- a/model/compdef/snapshot_incremental_test.go
+++ b/model/compdef/snapshot_incremental_test.go
@@ -148,7 +148,7 @@ func TestParameterSnapshotRestoreFallsBackToFullRebuild(t *testing.T) {
 	if err := def.Parameters().SetExpression(userParamID(t, def, "drive"), "60 mm"); err != nil {
 		t.Fatalf("SetExpression: %v", err)
 	}
-	def.RecomputeAfterParameterEdit()
+	def.RecomputeAfterChange()
 	firstFeatureAt60 := def.Features().Item(0)
 
 	if err := def.RestoreSnapshot(at40); err != nil { // a parameter differs → full reset path
@@ -200,7 +200,7 @@ func TestIncrementalRestoreThenWholesaleParamEditStillFullRebuilds(t *testing.T)
 	if err := def.Parameters().SetExpression(userParamID(t, def, "lift"), "50 mm"); err != nil {
 		t.Fatalf("SetExpression: %v", err)
 	}
-	def.RecomputeAfterParameterEdit()
+	def.RecomputeAfterChange()
 
 	after := recomputeCounts(def)
 	for i := range before {

--- a/model/depend/footprint.go
+++ b/model/depend/footprint.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package depend
+
+// Footprint is the set of keys one consumer (a sketch solve, a feature evaluation, a work
+// plane's recompute) read during the last recompute. The engine's whole correctness rests
+// on one rule: a consumer is dirtied by a change exactly when the change touches a key in
+// its footprint, and any read NOT captured in some footprint is treated as unattributable
+// and forces a wholesale rebuild — never silently skipped (ADR-0044, Oblikovati#1414/#1403).
+type Footprint = []Key
+
+// Set is a membership view of a change-set, built once per edit so attribution is O(1) per
+// footprint key instead of O(changed).
+type Set map[Key]struct{}
+
+// NewSet builds a membership set from a change-set slice.
+func NewSet(keys []Key) Set {
+	s := make(Set, len(keys))
+	for _, k := range keys {
+		s[k] = struct{}{}
+	}
+	return s
+}
+
+// Has reports membership.
+func (s Set) Has(k Key) bool { _, ok := s[k]; return ok }
+
+// Empty reports whether the set has no keys (an edit that changed nothing the graph
+// recorded — the caller then rebuilds conservatively).
+func (s Set) Empty() bool { return len(s) == 0 }
+
+// Intersects reports whether any key in footprint is in changed. This is the single
+// attribution predicate: a consumer is affected by the change iff its footprint intersects
+// the change-set. It is kind-agnostic — a ParameterKey and an ExternalGeometryKey are
+// compared the same way — which is exactly what lets a future adaptive reference reuse it.
+func Intersects(footprint []Key, changed Set) bool {
+	for _, k := range footprint {
+		if changed.Has(k) {
+			return true
+		}
+	}
+	return false
+}

--- a/model/depend/footprint_test.go
+++ b/model/depend/footprint_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package depend
+
+import "testing"
+
+func TestIntersectsReportsSharedKey(t *testing.T) {
+	footprint := []Key{{ParameterKey, 1}, {ParameterKey, 2}}
+	changed := NewSet([]Key{{ParameterKey, 2}, {ParameterKey, 9}})
+	if !Intersects(footprint, changed) {
+		t.Errorf("Intersects = false, want true (key {Parameter,2} is in both)")
+	}
+}
+
+func TestIntersectsDisjointIsFalse(t *testing.T) {
+	footprint := []Key{{ParameterKey, 1}}
+	changed := NewSet([]Key{{ParameterKey, 2}})
+	if Intersects(footprint, changed) {
+		t.Errorf("Intersects = true, want false (disjoint)")
+	}
+}
+
+// A ParameterKey and an ExternalGeometryKey that share the numeric ID must NOT be treated as
+// the same dependency — the Kind discriminates. This is the property that lets the two kinds
+// share the uint64 ID space without aliasing (ADR-0044).
+func TestKindDiscriminatesEqualID(t *testing.T) {
+	footprint := []Key{{ParameterKey, 7}}
+	changed := NewSet([]Key{{ExternalGeometryKey, 7}})
+	if Intersects(footprint, changed) {
+		t.Errorf("Intersects = true, want false (same ID 7 but different Kind must not collide)")
+	}
+}
+
+// The foundation's load-bearing promise (ADR-0044): the attribution is kind-agnostic, so a
+// future external-geometry change flows through the SAME Intersects an adaptive reference will
+// rely on, with no new machinery. This pins that an ExternalGeometryKey is a first-class match.
+func TestExternalGeometryKeyMatchesThroughSameMachinery(t *testing.T) {
+	footprint := []Key{{ParameterKey, 1}, {ExternalGeometryKey, 42}}
+	changed := NewSet([]Key{{ExternalGeometryKey, 42}})
+	if !Intersects(footprint, changed) {
+		t.Errorf("Intersects = false, want true (external-geometry key must match like any other)")
+	}
+}
+
+func TestNewSetHasAndEmpty(t *testing.T) {
+	if !NewSet(nil).Empty() {
+		t.Errorf("NewSet(nil).Empty() = false, want true")
+	}
+	s := NewSet([]Key{{ParameterKey, 3}})
+	if s.Empty() {
+		t.Errorf("non-empty set reports Empty()")
+	}
+	if !s.Has(Key{ParameterKey, 3}) || s.Has(Key{ParameterKey, 4}) {
+		t.Errorf("Has wrong: have {Parameter,3}, want !{Parameter,4}")
+	}
+}

--- a/model/depend/key.go
+++ b/model/depend/key.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package depend holds the document-free primitives of incremental recompute: the
+// opaque identity of anything a recompute can read (a Key) and the set-membership used to
+// decide which consumers a change dirties. It is the foundation seam described in ADR-0044
+// — the engine that today attributes parameter edits to features, and that a future
+// cross-part adaptive reference plugs into by producing a new Kind of Key, without
+// reshaping the attribution logic.
+//
+// It imports nothing from the rest of the model on purpose: param, sketch, feature, and
+// compdef all depend on it, never the reverse, so the dependency points toward this stable
+// core (the dependency rule, ADR-0044).
+package depend
+
+// Key is the opaque identity of one thing a recompute reads. The producer assigns ID
+// within its Kind; an ID is only ever compared for equality against another Key of the
+// SAME Kind, never interpreted, so two kinds may freely reuse the same numeric ID space.
+// Key is a comparable value type so it serves directly as a map key and in set membership.
+type Key struct {
+	Kind KeyKind
+	ID   uint64
+}
+
+// KeyKind is the category of thing a Key identifies. The set is closed and small by
+// design: a new kind is added only when a genuinely new SOURCE of change appears (today
+// parameters; tomorrow external geometry), and adding one must not require touching the
+// attribution logic — that is the property ADR-0044 protects.
+type KeyKind uint8
+
+const (
+	// ParameterKey identifies a model parameter (param.ID widened to uint64). It is the
+	// only kind produced today: every footprint and change-set the engine builds is
+	// parameter-keyed.
+	ParameterKey KeyKind = iota
+
+	// ExternalGeometryKey identifies a geometric entity (a face/edge) in ANOTHER document,
+	// resolved by the orchestrator (app.Session) against the workspace reference graph and
+	// given a stable identity by the external geometric reference of ADR-0040. It is
+	// reserved for cross-part adaptive references and has no producer yet (ADR-0044): the
+	// attribution machinery is already kind-agnostic, so adaptivity supplies the producer
+	// without changing the engine.
+	ExternalGeometryKey
+)

--- a/model/feature/engine.go
+++ b/model/feature/engine.go
@@ -221,7 +221,7 @@ func (fs *PartFeatures) evaluate(pf *PartFeature, bodies []*topo.Body, sick map[
 		return fs.evaluateBody(pf, bodies, sick)
 	}
 	var out []*topo.Body
-	pf.paramReads = fs.params.Track(func() { out = fs.evaluateBody(pf, bodies, sick) })
+	pf.paramReads = fs.params.TrackKeys(func() { out = fs.evaluateBody(pf, bodies, sick) })
 	return out
 }
 

--- a/model/feature/engine_param_invalidate.go
+++ b/model/feature/engine_param_invalidate.go
@@ -3,35 +3,37 @@
 package feature
 
 import (
+	"oblikovati.org/model/depend"
 	"oblikovati.org/model/health"
-	"oblikovati.org/model/param"
 )
 
-// This file is the feature side of incremental parameter recompute (Oblikovati#1414):
-// after a parameter edit, dirty only the features the edit can change instead of the
-// whole program. The engine already rebuilds a CONTIGUOUS tail from the earliest dirty
-// feature (see Recompute), so the only decision is the earliest feature an edit affects;
-// everything before it is reused, everything from it rebuilds.
+// This file is the feature side of incremental recompute (Oblikovati#1414, ADR-0044):
+// after a change, dirty only the features the change can reach instead of the whole
+// program. The engine already rebuilds a CONTIGUOUS tail from the earliest dirty feature
+// (see Recompute), so the only decision is the earliest feature a change affects;
+// everything before it is reused, everything from it rebuilds. The change-set and the
+// per-feature footprints are dependency keys (depend.Key), so the attribution is agnostic
+// to whether the changed source is a parameter (today) or external geometry (a future
+// adaptive reference) — the same intersection serves both.
 
-// MarkDirtyForParams marks dirty the earliest feature that depends on any of the changed
-// parameters, and every feature after it. A feature depends on a changed parameter when it
-// read the parameter directly (paramReads — a sheet-metal thickness, a suppression
-// condition) or through a sketch it consumes (the sketch's captured dimension footprint). A
-// sick feature is always re-evaluated, so fixing the offending parameter can recover it.
-// Features before the earliest affected one are provably independent of the edit and keep
-// their cached bodies.
+// MarkDirtyForChange marks dirty the earliest feature that depends on any of the changed
+// keys, and every feature after it. A feature depends on a changed key when it read the
+// key directly (paramReads — a sheet-metal thickness, a suppression condition) or through
+// a sketch it consumes (the sketch's captured footprint, which includes its host work
+// plane's footprint). A sick feature is always re-evaluated, so fixing the offending
+// source can recover it. Features before the earliest affected one are provably
+// independent of the change and keep their cached bodies.
 //
-// The caller must already have excluded parameters that reach geometry through paths the
-// engine does not model per-feature (work-plane offsets, 3D-sketch dimensions); those force
-// a full rebuild upstream (see compdef RecomputeAfterParameterEdit). With an empty change
-// set this is a no-op — nothing dirties.
-func (fs *PartFeatures) MarkDirtyForParams(changed []param.ID) {
+// The caller must already have excluded keys that reach geometry through paths the engine
+// does not model per-feature; those force a full rebuild upstream (see compdef
+// RecomputeAfterChange). With an empty change set this is a no-op — nothing dirties.
+func (fs *PartFeatures) MarkDirtyForChange(changed []depend.Key) {
 	if len(changed) == 0 {
 		return
 	}
-	set := idSetOf(changed)
+	set := depend.NewSet(changed)
 	for i, pf := range fs.items {
-		if fs.featureAffectedByParams(pf, set) {
+		if fs.featureAffectedByChange(pf, set) {
 			for _, tail := range fs.items[i:] {
 				tail.dirty = true
 			}
@@ -40,58 +42,39 @@ func (fs *PartFeatures) MarkDirtyForParams(changed []param.ID) {
 	}
 }
 
-// featureAffectedByParams reports whether a parameter in changed reaches pf — directly
-// (its own reads) or through a sketch it consumes. A sick feature counts as affected so a
-// parameter fix retries it.
-func (fs *PartFeatures) featureAffectedByParams(pf *PartFeature, changed map[param.ID]bool) bool {
+// featureAffectedByChange reports whether a changed key reaches pf — directly (its own
+// reads) or through a sketch it consumes. A sick feature counts as affected so a fix
+// retries it.
+func (fs *PartFeatures) featureAffectedByChange(pf *PartFeature, changed depend.Set) bool {
 	if pf.health.Status == health.Sick {
 		return true
 	}
-	if intersectsParams(pf.paramReads, changed) {
+	if depend.Intersects(pf.paramReads, changed) {
 		return true
 	}
 	for _, sk := range pf.ConsumedSketches() {
-		if intersectsParams(sk.ParameterFootprint(), changed) {
+		if depend.Intersects(sk.ParameterFootprint(), changed) {
 			return true
 		}
 	}
 	return false
 }
 
-// ParameterReads returns every model parameter any feature read directly during the last
-// recompute (the union of per-feature paramReads). The part recompute unions it with the
-// consumed-sketch footprints to form the set it can target precisely; any parameter read
-// elsewhere during recompute (a work-plane offset, a 3D-sketch dimension) falls outside it
-// and forces a full rebuild — so an unmodelled path is never silently skipped.
-func (fs *PartFeatures) ParameterReads() []param.ID {
-	seen := map[param.ID]bool{}
-	var out []param.ID
+// DependencyReads returns every key any feature read directly during the last recompute
+// (the union of per-feature paramReads). The part recompute unions it with the
+// consumed-sketch footprints to form the set it can target precisely; any read elsewhere
+// during recompute (a 3D-sketch dimension, a host-plane closure not yet attributed) falls
+// outside it and forces a full rebuild — so an unmodelled path is never silently skipped.
+func (fs *PartFeatures) DependencyReads() []depend.Key {
+	seen := map[depend.Key]bool{}
+	var out []depend.Key
 	for _, pf := range fs.items {
-		for _, id := range pf.paramReads {
-			if !seen[id] {
-				seen[id] = true
-				out = append(out, id)
+		for _, k := range pf.paramReads {
+			if !seen[k] {
+				seen[k] = true
+				out = append(out, k)
 			}
 		}
 	}
 	return out
-}
-
-// idSetOf builds a lookup set from a parameter id slice.
-func idSetOf(ids []param.ID) map[param.ID]bool {
-	set := make(map[param.ID]bool, len(ids))
-	for _, id := range ids {
-		set[id] = true
-	}
-	return set
-}
-
-// intersectsParams reports whether any id in ids is in set.
-func intersectsParams(ids []param.ID, set map[param.ID]bool) bool {
-	for _, id := range ids {
-		if set[id] {
-			return true
-		}
-	}
-	return false
 }

--- a/model/feature/engine_param_invalidate_test.go
+++ b/model/feature/engine_param_invalidate_test.go
@@ -5,12 +5,13 @@ package feature
 import (
 	"testing"
 
+	"oblikovati.org/model/depend"
 	"oblikovati.org/model/health"
 	"oblikovati.org/model/param"
 )
 
 // paramReader is a fake feature that reads one parameter directly during recompute (modelling a
-// sheet-metal thickness): the engine's read capture records it in paramReads, so MarkDirtyForParams
+// sheet-metal thickness): the engine's read capture records it in paramReads, so MarkDirtyForChange
 // can target the feature.
 type paramReader struct {
 	p *param.Parameter
@@ -32,7 +33,7 @@ func mustUserParam(t *testing.T, ps *param.Parameters, name, expr string) *param
 	return p
 }
 
-func TestMarkDirtyForParamsTargetsDirectReaderAndTail(t *testing.T) {
+func TestMarkDirtyForChangeTargetsDirectReaderAndTail(t *testing.T) {
 	ps := param.NewParameters()
 	a := mustUserParam(t, ps, "a", "10 mm")
 	b := mustUserParam(t, ps, "b", "20 mm")
@@ -43,7 +44,7 @@ func TestMarkDirtyForParamsTargetsDirectReaderAndTail(t *testing.T) {
 	fs.Recompute()
 
 	// Editing a dirties the reader and its tail, not the clean prefix.
-	fs.MarkDirtyForParams([]param.ID{a.ID()})
+	fs.MarkDirtyForChange([]depend.Key{param.Key(a.ID())})
 	fs.Recompute()
 	if c := fs.Item(0).RecomputeCount(); c != 1 {
 		t.Errorf("feature 0 (independent) recomputed again: count=%d, want 1", c)
@@ -53,7 +54,7 @@ func TestMarkDirtyForParamsTargetsDirectReaderAndTail(t *testing.T) {
 	}
 
 	// Editing b (read by no feature) dirties nothing.
-	fs.MarkDirtyForParams([]param.ID{b.ID()})
+	fs.MarkDirtyForChange([]depend.Key{param.Key(b.ID())})
 	fs.Recompute()
 	for i := 0; i < fs.Count(); i++ {
 		if c := fs.Item(i).RecomputeCount(); (i == 0 && c != 1) || (i > 0 && c != 2) {
@@ -62,7 +63,7 @@ func TestMarkDirtyForParamsTargetsDirectReaderAndTail(t *testing.T) {
 	}
 }
 
-func TestMarkDirtyForParamsAlwaysRetriesSickFeature(t *testing.T) {
+func TestMarkDirtyForChangeAlwaysRetriesSickFeature(t *testing.T) {
 	ps := param.NewParameters()
 	unrelated := mustUserParam(t, ps, "x", "1 mm")
 	fs := NewPartFeatures(ps, nil)
@@ -76,18 +77,44 @@ func TestMarkDirtyForParamsAlwaysRetriesSickFeature(t *testing.T) {
 
 	// An unrelated parameter edit must still retry the sick feature (fixing a parameter can
 	// recover it), even though it read no parameter.
-	fs.MarkDirtyForParams([]param.ID{unrelated.ID()})
+	fs.MarkDirtyForChange([]depend.Key{param.Key(unrelated.ID())})
 	fs.Recompute()
 	if after := fs.Item(1).RecomputeCount(); after != before+1 {
 		t.Errorf("sick feature not retried on parameter edit: count %d→%d", before, after)
 	}
 }
 
-func TestMarkDirtyForParamsEmptyChangeIsNoOp(t *testing.T) {
+// The foundation's promise (ADR-0044): the engine attributes ANY dependency kind, not just
+// parameters, so a future cross-part adaptive reference dirties its consuming feature through
+// the exact same path with no new machinery. We seed a feature's footprint with an
+// ExternalGeometryKey (the kind reserved for adaptivity, with no producer yet) and confirm a
+// change to that key rebuilds the feature and its tail — proving the generalization is real,
+// not speculative.
+func TestMarkDirtyForChangeAttributesExternalGeometryKey(t *testing.T) {
+	fs := NewPartFeatures(param.NewParameters(), nil)
+	fs.Add(body()) // 0: independent
+	fs.Add(body()) // 1: stands in for a feature adapted to external geometry
+	fs.Add(body()) // 2: tail of feature 1
+	fs.Recompute()
+
+	extEdge := depend.Key{Kind: depend.ExternalGeometryKey, ID: 99}
+	fs.Item(1).paramReads = []depend.Key{extEdge} // as if feature 1 read an external part's edge
+
+	fs.MarkDirtyForChange([]depend.Key{extEdge})
+	fs.Recompute()
+	if c := fs.Item(0).RecomputeCount(); c != 1 {
+		t.Errorf("independent feature 0 rebuilt on external-geometry change: count=%d, want 1", c)
+	}
+	if c1, c2 := fs.Item(1).RecomputeCount(), fs.Item(2).RecomputeCount(); c1 != 2 || c2 != 2 {
+		t.Errorf("external-geometry consumer/tail not rebuilt: counts=%d/%d, want 2/2", c1, c2)
+	}
+}
+
+func TestMarkDirtyForChangeEmptyChangeIsNoOp(t *testing.T) {
 	fs := NewPartFeatures(param.NewParameters(), nil)
 	fs.Add(body())
 	fs.Recompute()
-	fs.MarkDirtyForParams(nil)
+	fs.MarkDirtyForChange(nil)
 	fs.Recompute()
 	if c := fs.Item(0).RecomputeCount(); c != 1 {
 		t.Errorf("empty change set rebuilt a feature: count=%d, want 1", c)

--- a/model/feature/part_feature.go
+++ b/model/feature/part_feature.go
@@ -4,8 +4,8 @@ package feature
 
 import (
 	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/depend"
 	"oblikovati.org/model/health"
-	"oblikovati.org/model/param"
 )
 
 // PartFeature wraps a [Feature] with the engine's per-feature state: identity,
@@ -28,8 +28,9 @@ type PartFeature struct {
 	// evaluation — a sheet-metal thickness, a suppression condition (NOT the
 	// dimensions of a consumed sketch, which are reported via ConsumedSketches). The
 	// engine uses it, with the consumed sketches' footprints, to skip the feature on a
-	// parameter edit that touches none of them (Oblikovati#1414).
-	paramReads []param.ID
+	// parameter edit that touches none of them (Oblikovati#1414). Held as depend.Keys so
+	// the same attribution serves a future non-parameter source (ADR-0044).
+	paramReads []depend.Key
 }
 
 // ID returns the feature's stable handle (unchanged by rename).

--- a/model/feature/work_features_test.go
+++ b/model/feature/work_features_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"oblikovati.org/math"
+	"oblikovati.org/model/depend"
 	"oblikovati.org/model/param"
 	"oblikovati.org/model/sketch"
 )
@@ -37,6 +38,32 @@ func TestOriginCoordinateFrame(t *testing.T) {
 	x, err := g.axis(OriginXAxis)
 	if err != nil || !x.Direction().AsVector().IsEqualTo(math.V3(1, 0, 0), wtol) {
 		t.Errorf("origin X axis dir = %v err=%v, want +X", x.Direction(), err)
+	}
+}
+
+// With a footprint tracker injected, recomputing an offset work plane must record the
+// parameter its offset closure read, so a sketch hosted on the plane can attribute an offset
+// edit to its features instead of forcing a wholesale rebuild (ADR-0044). A plane with no
+// tracker (or a grounded origin plane) records nothing.
+func TestOffsetWorkPlaneRecordsParameterFootprint(t *testing.T) {
+	ps := param.NewParameters()
+	off, _ := ps.AddUserParameter("gap", "5 cm")
+	g := NewWorkGeometry()
+	g.SetFootprintTracker(ps)
+	wp := g.WorkPlanes().AddByPlaneAndOffset(OriginXYPlane, func() float64 { return off.ModelValue() })
+
+	g.Recompute(nil)
+
+	fp := wp.ParameterFootprint()
+	want := depend.Key{Kind: depend.ParameterKey, ID: uint64(off.ID())}
+	if len(fp) != 1 || fp[0] != want {
+		t.Errorf("offset plane footprint = %v, want one ParameterKey for gap", fp)
+	}
+	// The grounded origin planes read no parameter, so their footprints stay empty.
+	for _, origin := range g.OriginPlanes() {
+		if len(origin.ParameterFootprint()) != 0 {
+			t.Errorf("origin plane %q footprint = %v, want empty", origin.Name(), origin.ParameterFootprint())
+		}
 	}
 }
 

--- a/model/feature/work_geometry.go
+++ b/model/feature/work_geometry.go
@@ -11,6 +11,7 @@ import (
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
+	"oblikovati.org/model/depend"
 	"oblikovati.org/model/sketch"
 )
 
@@ -59,7 +60,21 @@ type WorkGeometry struct {
 	userSeq []userEntry  // user work features in global creation order (for serialization)
 	bodies  []*topo.Body // the running solid result, so surface-tangent work planes can
 	// resolve a picked B-rep face's reference key to its surface (set each Recompute).
+	tracker FootprintTracker // captures each plane's parameter footprint (set by the part); nil ⇒ no capture
 }
+
+// FootprintTracker captures the dependency keys read while fn runs — satisfied by
+// *param.Parameters (TrackKeys). The part injects it so each work plane records the
+// parameter driving its offset/angle, attributing a work-plane-offset edit to the sketches
+// hosted on that plane instead of forcing a wholesale rebuild (ADR-0044).
+type FootprintTracker interface {
+	TrackKeys(fn func()) []depend.Key
+}
+
+// SetFootprintTracker injects the per-recompute footprint capture (see [FootprintTracker]).
+// With no tracker, plane recompute is unchanged and offset edits fall back to wholesale —
+// safe, just not incremental.
+func (g *WorkGeometry) SetFootprintTracker(t FootprintTracker) { g.tracker = t }
 
 // userEntry records a user work feature's collection and index in global creation
 // order, so serialization replays them in dependency order — a work feature may
@@ -121,8 +136,20 @@ func (g *WorkGeometry) Recompute(bodies []*topo.Body) {
 		g.axes.Item(i).recompute(g)
 	}
 	for i := 0; i < g.planes.Count(); i++ {
-		g.planes.Item(i).recompute(g)
+		g.recomputePlane(g.planes.Item(i))
 	}
+}
+
+// recomputePlane recomputes one plane, capturing the parameters its definition read (its
+// offset/angle) into the plane's footprint when a tracker is set. The capture nests inside
+// the part's whole-recompute tracking, so the union still reaches the wholesale calculation
+// while each plane also gets its own footprint (ADR-0044).
+func (g *WorkGeometry) recomputePlane(p *WorkPlane) {
+	if g.tracker == nil {
+		p.recompute(g)
+		return
+	}
+	p.paramFootprint = g.tracker.TrackKeys(func() { p.recompute(g) })
 }
 
 // seedOrigin creates the grounded origin coordinate-system elements with their

--- a/model/feature/work_plane.go
+++ b/model/feature/work_plane.go
@@ -4,6 +4,7 @@ package feature
 
 import (
 	"oblikovati.org/math"
+	"oblikovati.org/model/depend"
 	"oblikovati.org/model/health"
 	"oblikovati.org/model/seq"
 	"oblikovati.org/model/sketch"
@@ -104,7 +105,19 @@ type WorkPlane struct {
 	grounded         bool
 	visible          bool
 	seq              uint64 // global creation stamp (0 for the origin frame); see model/seq
+
+	// paramFootprint is the dependency footprint this plane's last recompute read — for an
+	// offset/angle plane, the parameter driving its distance (its offset closure reads it
+	// through ModelValue). The part folds it into the footprint of sketches hosted on this
+	// plane, so a work-plane-offset edit reaches dependent features through the hosted sketch
+	// instead of forcing a wholesale rebuild (ADR-0044). Empty for a grounded origin plane.
+	paramFootprint []depend.Key
 }
+
+// ParameterFootprint returns the dependency keys this plane's last recompute read (its
+// offset/angle parameter). A sketch hosted on the plane unions this into its own footprint
+// via [sketch.Sketch.SetHostFootprint].
+func (w *WorkPlane) ParameterFootprint() []depend.Key { return w.paramFootprint }
 
 // ID/Key/Name identify the datum; Health reports its last recompute state.
 func (w *WorkPlane) ID() ID                { return w.id }

--- a/model/param/tracking.go
+++ b/model/param/tracking.go
@@ -2,6 +2,8 @@
 
 package param
 
+import "oblikovati.org/model/depend"
+
 // This file is the parameter side of incremental recompute (Oblikovati#1414): two
 // small mechanisms that let the feature engine dirty only the features a parameter
 // edit can change, instead of marking the whole program dirty and rebuilding every
@@ -47,6 +49,35 @@ func (ps *Parameters) Track(fn func()) []ID {
 	}
 	return keysOf(sink)
 }
+
+// Key is the recompute-graph identity of a parameter (ADR-0044): a parameter read becomes
+// a depend.Key the engine attributes to the consumers (sketches, features) that read it,
+// so a later edit dirties only those. The conversion lives here, at the param↔depend
+// boundary, so it is defined once.
+func Key(id ID) depend.Key { return depend.Key{Kind: depend.ParameterKey, ID: uint64(id)} }
+
+// keysOfIDs widens a parameter-id slice to dependency keys, preserving nil (an empty
+// change-set must stay empty so the edit seam falls back to a full rebuild).
+func keysOfIDs(ids []ID) []depend.Key {
+	if len(ids) == 0 {
+		return nil
+	}
+	keys := make([]depend.Key, len(ids))
+	for i, id := range ids {
+		keys[i] = Key(id)
+	}
+	return keys
+}
+
+// TrackKeys runs fn while capturing every parameter it read (through [Parameter.ModelValue])
+// and returns them as dependency keys — the footprint the recompute engine stores for the
+// piece of work fn performed (a sketch solve, a feature evaluation, a work-plane recompute).
+func (ps *Parameters) TrackKeys(fn func()) []depend.Key { return keysOfIDs(ps.Track(fn)) }
+
+// DrainChangedKeys returns the parameters an edit re-evaluated since the previous call as
+// dependency keys, and clears the record. The edit seam intersects these against consumer
+// footprints to dirty the minimal tail.
+func (ps *Parameters) DrainChangedKeys() []depend.Key { return keysOfIDs(ps.DrainChanged()) }
 
 // markChanged records that an edit re-evaluated parameter id (called from the graph
 // reflow). The set accumulates until [DrainChanged] reads and clears it.

--- a/model/param/tracking_test.go
+++ b/model/param/tracking_test.go
@@ -5,6 +5,8 @@ package param
 import (
 	"sort"
 	"testing"
+
+	"oblikovati.org/model/depend"
 )
 
 // sortedIDs returns ids sorted, for order-independent comparison.
@@ -60,6 +62,37 @@ func TestNestedTrackBubblesReadsToOuter(t *testing.T) {
 	want := sortedIDs([]ID{a.ID(), b.ID()})
 	if g := sortedIDs(outer); len(g) != 2 || g[0] != want[0] || g[1] != want[1] {
 		t.Errorf("outer Track captured %v, want %v", g, want)
+	}
+}
+
+// TrackKeys / DrainChangedKeys are the dependency-graph projections of Track / DrainChanged:
+// they widen parameter ids to depend.Keys tagged ParameterKey, so the recompute engine stores
+// footprints and change-sets in one kind-agnostic vocabulary (ADR-0044).
+func TestTrackKeysAndDrainChangedKeysTagParameterKind(t *testing.T) {
+	ps := NewParameters()
+	a := mustAdd(t, ps, "a", "10 mm")
+	ps.DrainChanged() // clear construction records
+
+	footprint := ps.TrackKeys(func() { _ = a.ModelValue() })
+	if len(footprint) != 1 || footprint[0] != (depend.Key{Kind: depend.ParameterKey, ID: uint64(a.ID())}) {
+		t.Errorf("TrackKeys = %v, want one ParameterKey for a", footprint)
+	}
+
+	if err := ps.SetExpression(a.ID(), "12 mm"); err != nil {
+		t.Fatalf("SetExpression: %v", err)
+	}
+	changed := ps.DrainChangedKeys()
+	if len(changed) != 1 || changed[0].Kind != depend.ParameterKey || changed[0].ID != uint64(a.ID()) {
+		t.Errorf("DrainChangedKeys = %v, want one ParameterKey for a", changed)
+	}
+}
+
+// An empty capture/drain must widen to nil (not an empty non-nil slice), because the edit seam
+// treats len==0 as "rebuild conservatively"; a stray empty slice must read identically.
+func TestKeysPreserveEmptyAsNil(t *testing.T) {
+	ps := NewParameters()
+	if got := ps.TrackKeys(func() {}); got != nil {
+		t.Errorf("TrackKeys with no reads = %v, want nil", got)
 	}
 }
 

--- a/model/sketch/sketch.go
+++ b/model/sketch/sketch.go
@@ -8,6 +8,7 @@ import (
 
 	"oblikovati.org/api/types"
 	"oblikovati.org/math"
+	"oblikovati.org/model/depend"
 	"oblikovati.org/model/health"
 	"oblikovati.org/model/linetype"
 	"oblikovati.org/model/param"
@@ -187,18 +188,39 @@ type Sketch struct {
 	profilesCache *Profiles
 	profilesSig   uint64
 
-	// paramFootprint is the model parameters this sketch's last solve read (its
-	// dimension targets), captured by the part recompute (Oblikovati#1414). A
-	// parameter edit re-solves and rebuilds only the features whose consumed sketch
-	// footprint it touches, instead of the whole program.
-	paramFootprint []param.ID
+	// paramFootprint is the dependency footprint this sketch's last solve read (its
+	// dimension targets), captured by the part recompute as depend.Keys (Oblikovati#1414,
+	// ADR-0044). A parameter edit re-solves and rebuilds only the features whose consumed
+	// sketch footprint it touches, instead of the whole program.
+	paramFootprint []depend.Key
+
+	// hostFootprint, when set, returns the dependency footprint of the sketch's host plane
+	// (a work plane's offset/angle parameter reads). The sketch stays content-agnostic
+	// about WHAT hosts it (ADR-0036): this is an opaque provider the part wires to the work
+	// plane, so a work-plane-offset edit reaches features through the hosted sketch's
+	// footprint instead of forcing a wholesale rebuild (ADR-0044).
+	hostFootprint func() []depend.Key
 }
 
-// SetParameterFootprint records the parameters the sketch's solve read; ParameterFootprint
-// returns them. The part recompute captures the footprint around each solve (param.Track)
-// so the feature engine can dirty only the features a parameter edit actually affects.
-func (s *Sketch) SetParameterFootprint(ids []param.ID) { s.paramFootprint = ids }
-func (s *Sketch) ParameterFootprint() []param.ID       { return s.paramFootprint }
+// SetParameterFootprint records the dependency keys the sketch's solve read; the part
+// recompute captures the footprint around each solve (param.TrackKeys) so the feature
+// engine can dirty only the features a parameter edit actually affects.
+func (s *Sketch) SetParameterFootprint(keys []depend.Key) { s.paramFootprint = keys }
+
+// SetHostFootprint registers an opaque provider of the host plane's dependency footprint
+// (nil to clear). Paired with [Sketch.SetPlaneHost] when the host is a parametric work
+// plane, so the plane's offset parameter is attributed to this sketch (ADR-0044).
+func (s *Sketch) SetHostFootprint(footprint func() []depend.Key) { s.hostFootprint = footprint }
+
+// ParameterFootprint returns the sketch's full dependency footprint: its own solve reads
+// plus, when hosted on a parametric work plane, that plane's footprint. The union is what
+// a consuming feature is attributed against (ADR-0044).
+func (s *Sketch) ParameterFootprint() []depend.Key {
+	if s.hostFootprint == nil {
+		return s.paramFootprint
+	}
+	return append(append([]depend.Key(nil), s.paramFootprint...), s.hostFootprint()...)
+}
 
 // Plane returns the sketch's host plane.
 func (s *Sketch) Plane() Plane { return s.plane }


### PR DESCRIPTION
## What & why

Closes the M39 tail (#1563) and lays the foundation so a future **cross-part adaptive reference** slots into the recompute engine without a rewrite — the user's explicit directive ("set the foundation now so adaptivity just fits"). Designed via the software-architect-advisor skill and recorded in **ADR-0044**.

### 1. Foundation — `model/depend` (the durable part)
Incremental recompute previously keyed footprints and change-sets on `param.ID`. This generalizes them to an opaque, comparable `depend.Key{Kind, ID}` with a kind-agnostic `Intersects`, so the engine attributes a change to its consumers regardless of *what* changed.

- Today every key is a `ParameterKey` (a 1:1 image of `param.ID`) — fully behavior-preserving.
- `ExternalGeometryKey` is **reserved** for adaptivity (no producer yet). A test seeds a feature's footprint with one and proves a change to it rebuilds the feature through the real attribution path — so the generalization is *exercised, not speculative*.
- The holder seam `RecomputeAfterParameterEdit()` → **`RecomputeAfterChange()`** (still arg-free; it drains its own change sources). One seam for a parameter edit today and a geometry change later (#1413 no-divergence). The assembly satisfies it with a full re-solve — **wholesale is a valid point on the contract**, so the seam exists and is exercised now while adaptivity narrows it later without reshaping it.

Why now, not later: hard-coding `param.ID` through capture/footprint/attribution would force a new key type through the whole engine when adaptivity lands — the rewrite ADR-0044 exists to prevent. `wholesaleParams` is in-memory only, so no serialization change.

### 2. Narrowing — work-plane-offset edits target their hosted sketch
A work plane now captures the parameter its offset/angle closure reads (an injected `FootprintTracker`), and a sketch hosted on the plane folds that footprint into its own (`SetHostFootprint`). The offset parameter lands in the *precise* set, and the existing consumed-sketch attribution dirties exactly the features built on that sketch — editing one offset on a 1000-feature part rebuilds that feature's tail, not all 1000.

Safe by construction: the wire is co-located with `SetPlaneHost`, so wherever the host isn't rebound (a reloaded part, ADR-0036) the footprint is simply absent and the edit falls back to a full rebuild — correct, just not incremental. Offset-plane *chains* likewise fall back safely.

### 3. Honest scope note on the "third path"
The nominal third wholesale path — **3D-sketch dimensions** — turns out **not** to be a live path: 3D sketches are not re-solved during recompute (`solveSketches` is 2D-only), so their parameters are never read there. Comments corrected. The foundation keeps any future 3D re-solve safe (unattributed reads fall to wholesale). The 3D re-solve gap is filed separately.

## Verification
- New unit tests for `depend` (incl. cross-kind collision safety + the ExternalGeometryKey proof), `param` key wrappers, and work-plane footprint capture.
- **Differential guard** (`TestWorkPlaneOffsetTargetedMatchesFullRebuild`): the same edit made incrementally then via forced full rebuild must yield identical geometry — a targeted path that skipped a dependent feature would diverge. This is what makes narrowing the wholesale fallback safe against the silent-stale failure class.
- Full `./model/... ./addin/... ./app/...` suite green; `golangci-lint` 0 issues; gofmt clean. GPL-only — no API surface touched.

Refs #1563.

🤖 Generated with [Claude Code](https://claude.com/claude-code)