### PR TITLE
Solve 3D sketches on recompute so 3D-sketch dimensions drive geometry (#1566)

### DIFF
--- a/model/compdef/part.go
+++ b/model/compdef/part.go
@@ -169,6 +169,7 @@ func (d *PartComponentDefinition) recomputeGeometry() {
 	// dimension's target value, and only a solve moves the profile to match.
 	// Without this, features downstream rebuild on stale, pre-edit geometry.
 	d.solveSketches()
+	d.solveSketches3D()
 	// Two passes around the feature program: the first so features can reference work
 	// axes/planes (e.g. a revolve axis); the second so surface-tangent work planes can
 	// resolve their picked faces against the freshly built body. The first pass sees the
@@ -277,6 +278,18 @@ func (d *PartComponentDefinition) solveSketches() {
 	for i := 0; i < d.sketches.Count(); i++ {
 		sk := d.sketches.Item(i)
 		sk.SetParameterFootprint(d.params.TrackKeys(func() { sk.Solve() }))
+	}
+}
+
+// solveSketches3D re-solves every 3D sketch so parameter-driven 3D dimensions move the
+// geometry on recompute, mirroring solveSketches for 2D (Oblikovati#1566). The dimension
+// reads bubble into the part's whole-recompute footprint (see Recompute's Track); not being
+// attributable to a feature yet, they land in the wholesale set, so a 3D-dimension edit
+// conservatively rebuilds the whole program — correct (the geometry follows), with precise
+// feature attribution a follow-up that plugs into the same depend.Key seam (ADR-0044).
+func (d *PartComponentDefinition) solveSketches3D() {
+	for i := 0; i < d.sketches3D.Count(); i++ {
+		d.sketches3D.Item(i).Solve()
 	}
 }
 

--- a/model/compdef/serialize_test.go
+++ b/model/compdef/serialize_test.go
@@ -57,7 +57,10 @@ func reopenThroughStore(t *testing.T, d *doc.Document) *compdef.PartComponentDef
 }
 
 // TestSketch3DSurvivesRoundTrip checks a part's 3D sketches (points, properties, and a
-// geometric constraint) survive the real save→YAML→open path (M22-F01).
+// geometric constraint) survive the real save→YAML→open path (M22-F01). Reopening recomputes
+// the part, which now re-solves 3D sketches (Oblikovati#1566), so the round-tripped coincident
+// constraint is enforced — the two points, authored apart, coincide after reopen. That proves
+// the constraint survives BOTH as data (count) and functionally (it moves geometry on solve).
 func TestSketch3DSurvivesRoundTrip(t *testing.T) {
 	ws := doc.NewWorkspace(nil)
 	d, err := compdef.AddPart(ws, "Part1", true)
@@ -84,11 +87,13 @@ func TestSketch3DSurvivesRoundTrip(t *testing.T) {
 	if got.EntityCount() != 2 {
 		t.Errorf("3D sketch entity count after reopen = %d, want 2", got.EntityCount())
 	}
-	if pts := got.AllPoints3D(); pts[0].Position() != math.P3(1, 2, 3) || pts[1].Position() != math.P3(4, 5, 6) {
-		t.Errorf("3D point positions after reopen = %v", pts)
-	}
 	if got.GeometricConstraints3D().Count() != 1 {
 		t.Errorf("3D constraint count after reopen = %d, want 1", got.GeometricConstraints3D().Count())
+	}
+	// The coincident constraint round-tripped and is enforced on recompute: the two points
+	// (authored apart) now share a location.
+	if pts := got.AllPoints3D(); !pts[0].Position().IsEqualTo(pts[1].Position(), 1e-6) {
+		t.Errorf("3D points after reopen = %v / %v, want coincident (constraint enforced on solve)", pts[0].Position(), pts[1].Position())
 	}
 }
 

--- a/model/compdef/sketch3d_recompute_test.go
+++ b/model/compdef/sketch3d_recompute_test.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef_test
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+)
+
+// A parameter that drives a 3D-sketch dimension must move the 3D geometry on recompute, the
+// way a 2D-sketch dimension does. This is the regression test for #1566: 3D sketches were not
+// re-solved during part recompute (solveSketches was 2D-only), so editing a 3D dimension's
+// parameter left the 3D geometry on its pre-edit shape.
+func TestSketch3DDimensionParameterDrivesGeometryOnRecompute(t *testing.T) {
+	def := compdef.NewPartComponentDefinition()
+	span, err := def.Parameters().AddUserParameter("span", "5 cm")
+	if err != nil {
+		t.Fatalf("AddUserParameter: %v", err)
+	}
+
+	// A 3D line authored at length 3, dimensioned to follow "span" (5 cm initially).
+	sk := def.Sketches3D().Add()
+	line := sk.AddLine3D(math.P3(0, 0, 0), math.P3(3, 0, 0))
+	if _, err := sk.DimensionConstraints3D().AddDistance(line.StartPoint(), line.EndPoint(), "span"); err != nil {
+		t.Fatalf("AddDistance: %v", err)
+	}
+
+	def.Recompute()
+	if l := line.Length(); l < 4.999 || l > 5.001 {
+		t.Fatalf("after recompute, line length = %v cm, want ~5 (dimension solved to span)", l)
+	}
+
+	// Drive the parameter: the 3D geometry must follow on recompute.
+	if err := def.Parameters().SetExpression(span.ID(), "8 cm"); err != nil {
+		t.Fatalf("SetExpression: %v", err)
+	}
+	def.RecomputeAfterChange()
+	if l := line.Length(); l < 7.999 || l > 8.001 {
+		t.Errorf("after span→8, line length = %v cm, want ~8 (3D sketch must re-solve on recompute, #1566)", l)
+	}
+}


### PR DESCRIPTION
## What & why

`PartComponentDefinition.recomputeGeometry` re-solved only **2D** sketches (`solveSketches`); `Sketch3D.Solve()` was never invoked in the recompute path. So a parameter driving a **3D-sketch dimension** did not move the 3D geometry on recompute — editing it left the sketch (and any sweep/coil built on its path) on its pre-edit shape.

Surfaced while implementing M39-F07 / ADR-0044 (PR #1565) and filed as #1566.

## Fix

Add `solveSketches3D`, mirroring the 2D pass, run right after `solveSketches` (before the feature program, so a consuming sweep/coil sees solved geometry). Each 3D sketch re-solves every recompute.

Its dimension reads bubble into the part's whole-recompute footprint (`Recompute`'s `Track`); not being attributable to a feature yet, they land in the **wholesale set**, so a 3D-dimension edit conservatively rebuilds the whole program — **correct** (the geometry follows). Precise per-feature attribution (targeting only the consuming sweep/coil) is a deliberate follow-up: it requires threading the `*Sketch3D` reference into those feature defs (today opaque `func() *sketch.Path3D` closures), and it plugs into the same `depend.Key` seam with no rework. Per ADR-0044, wholesale is a valid point on the contract — this is correct today, just not yet incremental for 3D-dim edits.

## Tests
- **Regression** (`TestSketch3DDimensionParameterDrivesGeometryOnRecompute`): a 3D line dimensioned to a parameter follows the parameter on recompute (fails on `develop`: length stays at the authored value; passes here).
- `TestSketch3DSurvivesRoundTrip` updated: reopening recomputes, which now **enforces** the round-tripped coincident constraint (two points authored apart coincide on solve). The prior assertion expected the *unsolved* authored positions — a premise only valid while 3D solving was missing — so the test now verifies the constraint survives both as data (count) and functionally (it moves geometry on solve).
- Full `./model/... ./addin/... ./app/...` suite green; `golangci-lint` 0 issues; gofmt clean. GPL-only — no API surface touched.

Closes #1566.

🤖 Generated with [Claude Code](https://claude.com/claude-code)