### PR TITLE
P6a: heal lost dress-up references via the tiered binder (ADR-0043, #1539)

### DIFF
--- a/architecture/decisions/ADR-0043-generalized-provenance-naming.md
+++ b/architecture/decisions/ADR-0043-generalized-provenance-naming.md
@@ -128,7 +128,16 @@ residual naming collision becomes an honest failure, never a wrong-rebind.
   `curvedbool:e#N` ordinal.
 - **P5 — remaining generators** (ruled, sweep, wire-offset, rim, split, steinmetz, halfspace).
 - **P6 — integrate with F06 tiered binding & F07 encoding**; retire the ordinal fallbacks that are
-  no longer reachable.
+  no longer reachable. Sub-phased so the serialization change is isolated:
+  - **P6a** — wire the live dress-up edge resolution (`resolveEdges`) to the tiered binder's
+    **ancestral** tier through a `model/feature` adapter; a lost reference with a lone surviving
+    parent-sibling heals to a Warning instead of going Sick. No format change (the parent is derived
+    from the key). The exact-one P0 guard stays authoritative; only a 0/>1 miss escalates.
+  - **P6b** — persist the mint-time **anchor** and enable the **geometric** tier, so several
+    surviving siblings are disambiguated by nearness (the binder still refuses a tie). Isolated
+    serialization change.
+  - **P6c** — retire the now-dead silent-match resolution branches; make `Input.Keys`/`fs.keys` live
+    (or remove). The no-parent ordinal fallback and the degraded CSG soup fallback legitimately stay.
 
 Each phase is one or more PRs; each adds a regression test that mutates an upstream feature and
 asserts the downstream selection still binds to the same physical entity.

--- a/model/feature/chamfer.go
+++ b/model/feature/chamfer.go
@@ -12,6 +12,7 @@ import (
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
+	"oblikovati.org/model/identity"
 	"oblikovati.org/model/sketch"
 )
 
@@ -43,7 +44,7 @@ func chamferEdges(in Input, keys [][]byte, d1, d2 float64, feat string, flatCorn
 	if d1 <= 0 || d2 <= 0 {
 		return Output{}, fmt.Errorf("chamfer: setbacks (%g, %g) must both be > 0", d1, d2)
 	}
-	edges, err := resolveEdges(body, keys)
+	edges, heals, err := resolveEdges(body, keys)
 	if err != nil {
 		return Output{}, err
 	}
@@ -54,10 +55,15 @@ func chamferEdges(in Input, keys [][]byte, d1, d2 float64, feat string, flatCorn
 		// A rim of a simple analytic cylinder gets a TRUE conical chamfer (one geom.Cone face) by
 		// rebuilding the body as a surface of revolution (#127). Anything else falls through.
 		if res, ok := analyticCylinderChamfer(body, edges, d1, feat); ok {
-			return Output{Bodies: replaceBody(in.Bodies, body, res)}, nil
+			return Output{Bodies: replaceBody(in.Bodies, body, res), Heals: heals}, nil
 		}
 	}
-	return chamferByWedges(in, body, edges, d1, d2, feat, flatCorners, strategy)
+	out, err := chamferByWedges(in, body, edges, d1, d2, feat, flatCorners, strategy)
+	if err != nil {
+		return Output{}, err
+	}
+	out.Heals = heals
+	return out, nil
 }
 
 // allConvex reports whether every edge is a convex dihedral (so the analytic conical fast path,
@@ -149,26 +155,37 @@ func applyChamferTools(work *topo.Body, tools []wedgeOp) (*topo.Body, error) {
 	return result, nil
 }
 
-// resolveEdges binds every edge key against the original body, erroring if a key is lost
-// (so the feature goes sick honestly).
-func resolveEdges(body *topo.Body, keys [][]byte) ([]*topo.Edge, error) {
+// resolveEdges binds every edge key against the running body. A key that matches
+// EXACTLY one edge binds cleanly (the ADR-0043 P0 guard: more than one is a
+// topological-naming collision, never a silent first-match). A key whose exact entity
+// is gone is recovered through the tiered binder — a lone surviving sibling sharing
+// the key's parent lineage — and reported as a heal (the engine turns heals into a
+// Warning, ADR-0043 P6); only a genuinely unrecoverable or ambiguous key is a hard
+// error, so the feature goes Sick honestly rather than dressing up the wrong edge.
+func resolveEdges(body *topo.Body, keys [][]byte) ([]*topo.Edge, []ReferenceHeal, error) {
 	edges := make([]*topo.Edge, len(keys))
+	var heals []ReferenceHeal
+	var ents []identity.Entity // built lazily, only when an exact match misses
 	for i, k := range keys {
-		// ADR-0043 resolution guard: a key must bind to EXACTLY one edge. Zero means the reference
-		// was lost; more than one means a topological-naming collision (two edges minted the same
-		// lineage) — surfaced as an honest error rather than a silent first-match wrong-rebind that
-		// would dress up an unintended edge (the #1536 hazard class).
 		match := body.EdgesByKey(k)
-		switch len(match) {
-		case 1:
+		if len(match) == 1 {
 			edges[i] = match[0]
-		case 0:
-			return nil, fmt.Errorf("dress-up: edge reference %q lost (no edge with that lineage on the running body)", keyText(k))
-		default:
-			return nil, fmt.Errorf("dress-up: edge reference %q is ambiguous — it matches %d edges (a topological-naming collision); the selection cannot be resolved safely", keyText(k), len(match))
+			continue
 		}
+		if ents == nil {
+			ents = edgeEntities(body)
+		}
+		if e, mt := recoverEdge(k, ents); mt.IsFallback() && e != nil {
+			edges[i] = e
+			heals = append(heals, ReferenceHeal{Key: append([]byte(nil), k...), Match: mt})
+			continue
+		}
+		if len(match) > 1 {
+			return nil, nil, fmt.Errorf("dress-up: edge reference %q is ambiguous — it matches %d edges (a topological-naming collision) and no surviving sibling could be recovered", keyText(k), len(match))
+		}
+		return nil, nil, fmt.Errorf("dress-up: edge reference %q lost (no edge with that lineage on the running body, and no surviving sibling to recover it)", keyText(k))
 	}
-	return edges, nil
+	return edges, heals, nil
 }
 
 // keyText renders a reference key as its readable lineage string (the leading kind byte stripped)

--- a/model/feature/engine.go
+++ b/model/feature/engine.go
@@ -347,7 +347,8 @@ func lastSolid(bodies []*topo.Body) *topo.Body {
 }
 
 // classify turns a feature's recompute result into health + the running body state:
-// ErrDeferred → warning (passthrough), other error → sick (poison), nil → healthy.
+// ErrDeferred → warning (passthrough); other error → sick (poison); a healed
+// reference (ADR-0043 P6) → warning with the rebuilt body kept; nil → healthy.
 func (fs *PartFeatures) classify(pf *PartFeature, bodies []*topo.Body, out Output, err error, sick map[ID]bool) []*topo.Body {
 	switch {
 	case errors.Is(err, ErrDeferred):
@@ -357,6 +358,12 @@ func (fs *PartFeatures) classify(pf *PartFeature, bodies []*topo.Body, out Outpu
 		pf.health = health.Sicken(fmt.Sprintf("%s: %v", pf.Kind(), err))
 		sick[pf.id] = true
 		pf.cached = bodies
+	case len(out.Heals) > 0:
+		// The feature rebuilt successfully, but one or more references bound through a
+		// degraded tier instead of an exact match — keep the rebuilt body and flag the
+		// drift so the user can re-pick, rather than reporting a clean recompute.
+		pf.health = health.Health{Status: health.Warning, Reason: healReason(out.Heals)}
+		pf.cached = out.Bodies
 	default:
 		pf.health = health.Healthy
 		pf.cached = out.Bodies

--- a/model/feature/feature.go
+++ b/model/feature/feature.go
@@ -4,6 +4,7 @@ package feature
 
 import (
 	"errors"
+	"fmt"
 	"sync/atomic"
 
 	"oblikovati.org/kernel/ops"
@@ -66,9 +67,30 @@ type ToolFeature interface {
 	ToolBody() *topo.Body
 }
 
-// Output is what a feature produces: the new running body state.
+// Output is what a feature produces: the new running body state, plus any reference
+// heals that occurred while resolving its inputs (ADR-0043 P6). Heals ride with the
+// Output — they are part of the recompute result, not an error — and the engine
+// turns a non-empty Heals into health.Warning while keeping the rebuilt body.
 type Output struct {
 	Bodies []*topo.Body
+	Heals  []ReferenceHeal
+}
+
+// ReferenceHeal records that a stored reference key did not match any entity exactly
+// but was recovered by a degraded tier of the topological binder (ADR-0043 P6): the
+// feature still rebuilds on the recovered entity, but the drift is surfaced as a
+// Warning so the user can re-pick if the recovery was not what they meant.
+type ReferenceHeal struct {
+	Key   []byte             // the stored reference key whose exact entity was gone
+	Match identity.MatchType // the tier that recovered it (ancestral or geometric)
+}
+
+// healReason renders one or more reference heals as a single Warning message.
+func healReason(heals []ReferenceHeal) string {
+	if len(heals) == 1 {
+		return fmt.Sprintf("reference %q healed (%s match) — re-pick to confirm", keyText(heals[0].Key), heals[0].Match)
+	}
+	return fmt.Sprintf("%d references healed by degraded binding — re-pick to confirm", len(heals))
 }
 
 // Feature is one recipe in the history. Recompute is pure: it reads the input and

--- a/model/feature/fillet.go
+++ b/model/feature/fillet.go
@@ -103,14 +103,31 @@ func filletBody(in Input, edgeKeys [][]byte, radius float64, corner FilletCorner
 	if radius <= 0 {
 		return Output{}, fmt.Errorf("%s: radius %g must be > 0", feat, radius)
 	}
+	// Resolve once at the top so a lost reference can heal through the tiered binder
+	// (ADR-0043 P6). The downstream kernel ops re-resolve by EXACT key, so feed them the
+	// recovered edges' CURRENT keys — identical to the stored key for an exact match, the
+	// live key of the recovered sibling for a healed one — and carry the heals to the Output.
+	edges, heals, err := resolveEdges(body, edgeKeys)
+	if err != nil {
+		return Output{}, err
+	}
+	keys0 := currentKeys(edges)
 	// The analytic fast path builds exact cylinder/torus surfaces (circular arc only); a G2/conic
 	// cross-section must go through the swept ruling band instead.
 	if prof.cross.IsArc() {
-		if out, ok, err := analyticFilletFastPath(in, body, edgeKeys, radius, feat); ok || err != nil {
+		if out, ok, err := analyticFilletFastPath(in, body, keys0, radius, feat); ok || err != nil {
+			out.Heals = heals
 			return out, err
 		}
 	}
-	work, keys := planarizedFillet(body, edgeKeys, feat)
+	return blendFilletEdges(in, body, keys0, radius, corner, concave, prof, feat, heals)
+}
+
+// blendFilletEdges runs the general rolling-ball blend for already-resolved edge keys: it
+// planarizes a curved body where needed (#129), builds the per-edge radius picks, and applies
+// FilletEdgesCorner, carrying any reference heals onto the result (ADR-0043 P6).
+func blendFilletEdges(in Input, body *topo.Body, keys0 [][]byte, radius float64, corner FilletCornerType, concave types.FilletConcaveStrategy, prof blendProfile, feat string, heals []ReferenceHeal) (Output, error) {
+	work, keys := planarizedFillet(body, keys0, feat)
 	picks := make([]ops.EdgeFilletRadii, len(keys))
 	cross := prof.cross
 	for i, k := range keys {
@@ -120,7 +137,7 @@ func filletBody(in Input, edgeKeys [][]byte, radius float64, corner FilletCorner
 	if err != nil {
 		return Output{}, err
 	}
-	return Output{Bodies: replaceBody(in.Bodies, body, result)}, nil
+	return Output{Bodies: replaceBody(in.Bodies, body, result), Heals: heals}, nil
 }
 
 // analyticFilletFastPath rounds a curved fillet target directly on the ANALYTIC body, before the
@@ -128,7 +145,7 @@ func filletBody(in Input, edgeKeys [][]byte, radius float64, corner FilletCorner
 // cylinder rim becomes a surface of revolution (#127); the cylinder/cap RIM or ARC a prior fillet
 // leaves becomes a toroidal band / torus + setback caps. ok=false means no analytic case applied.
 func analyticFilletFastPath(in Input, body *topo.Body, edgeKeys [][]byte, radius float64, feat string) (Output, bool, error) {
-	if origEdges, e := resolveEdges(body, edgeKeys); e == nil {
+	if origEdges, _, e := resolveEdges(body, edgeKeys); e == nil {
 		if res, ok := analyticCylinderFillet(body, origEdges, radius, feat); ok {
 			return Output{Bodies: replaceBody(in.Bodies, body, res)}, true, nil
 		}
@@ -147,7 +164,7 @@ func analyticFilletFastPath(in Input, body *topo.Body, edgeKeys [][]byte, radius
 // segment so the rolling-ball blend works instead of failing on a degenerate closed edge (#129/#127).
 // A planar body — or an unresolvable key, surfaced later by the kernel — passes through unchanged.
 func planarizedFillet(body *topo.Body, edgeKeys [][]byte, feat string) (*topo.Body, [][]byte) {
-	origEdges, err := resolveEdges(body, edgeKeys)
+	origEdges, _, err := resolveEdges(body, edgeKeys)
 	if err != nil {
 		return body, edgeKeys
 	}
@@ -180,12 +197,37 @@ func filletBodySets(in Input, sets []FilletEdgeSet, corner FilletCornerType, con
 	if err != nil {
 		return Output{}, err
 	}
+	// Heal each pick's edge key before the kernel pass: substitute the recovered edge's
+	// current key (exact for a clean match) so FilletEdgesCorner re-resolves it, and carry
+	// the heals to the Output (ADR-0043 P6).
+	heals, err := healPickKeys(body, picks)
+	if err != nil {
+		return Output{}, err
+	}
 	work := planarizeFilletPicks(body, picks, feat)
 	result, err := ops.FilletEdgesCorner(work, picks, cornerStrategy(corner), concaveFill(concave))
 	if err != nil {
 		return Output{}, err
 	}
-	return Output{Bodies: replaceBody(in.Bodies, body, result)}, nil
+	return Output{Bodies: replaceBody(in.Bodies, body, result), Heals: heals}, nil
+}
+
+// healPickKeys resolves every pick's edge key against the body and rewrites it to the
+// resolved edge's CURRENT key (so a healed reference becomes the live sibling's key the
+// kernel can exact-match), returning the heals that occurred. See resolveEdges.
+func healPickKeys(body *topo.Body, picks []ops.EdgeFilletRadii) ([]ReferenceHeal, error) {
+	keys := make([][]byte, len(picks))
+	for i, p := range picks {
+		keys[i] = p.Key
+	}
+	edges, heals, err := resolveEdges(body, keys)
+	if err != nil {
+		return nil, err
+	}
+	for i, e := range edges {
+		picks[i].Key = e.ReferenceKey()
+	}
+	return heals, nil
 }
 
 // filletPicksOf flattens the edge sets into per-edge radius picks, rejecting a variable set
@@ -233,7 +275,7 @@ func planarizeFilletPicks(body *topo.Body, picks []ops.EdgeFilletRadii, feat str
 	for i, p := range picks {
 		keys[i] = p.Key
 	}
-	origEdges, err := resolveEdges(body, keys)
+	origEdges, _, err := resolveEdges(body, keys)
 	if err != nil {
 		return body
 	}

--- a/model/feature/identity_adapter.go
+++ b/model/feature/identity_adapter.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"bytes"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/identity"
+)
+
+// This file is the anticorruption adapter between the kernel's topology
+// (kernel/topo) and the identity package's tiered binder (model/identity), the one
+// place both are visible without inverting the dependency rule (ADR-0043 P6). It
+// lets a lost dress-up edge reference be recovered through the same tested binder
+// the F06 key manager uses, instead of going Sick on the first exact miss.
+
+// parentOfKey returns the PARENT lineage of a kernel reference key — the key's
+// lineage with its most-specific token dropped — computed identically for a lost key
+// and for every candidate sibling, so the two compare. A reference key is a kind
+// byte followed by the lineage string "feat:role#idx/feat:role#idx/…" (kernel/topo
+// referenceKey + Lineage.Key); the parent is everything before the final '/'. A
+// single-token (root) lineage has no parent and returns nil — no ancestral fallback.
+func parentOfKey(refKey []byte) []byte {
+	s := refKey
+	if len(s) > 0 && s[0] < 0x20 { // strip the leading kind byte (kinds are < 0x20)
+		s = s[1:]
+	}
+	i := bytes.LastIndexByte(s, '/')
+	if i < 0 {
+		return nil
+	}
+	return append([]byte(nil), s[:i]...)
+}
+
+// edgeLineage adapts a kernel edge's reference key to identity.Lineage +
+// AncestralLineage. ParentKey derives the parent the same way for every entity (see
+// parentOfKey), which is what makes ancestral sibling matching consistent.
+type edgeLineage []byte // the edge's kernel reference key (kind byte + lineage)
+
+func (l edgeLineage) LineageKey() []byte {
+	if len(l) > 0 && l[0] < 0x20 {
+		return append([]byte(nil), l[1:]...)
+	}
+	return append([]byte(nil), l...)
+}
+
+func (l edgeLineage) ParentKey() []byte { return parentOfKey(l) }
+
+// edgeEntity adapts a *topo.Edge to identity.Entity (+ AncestralLineage for
+// ancestral recovery, + AnchoredEntity for the geometric tie-break used by P6b). It
+// carries the live edge so a recovered match can be unwrapped back to it.
+type edgeEntity struct{ e *topo.Edge }
+
+func (a edgeEntity) EntityKind() identity.EntityKind { return identity.KindEdge }
+func (a edgeEntity) Lineage() identity.Lineage       { return edgeLineage(a.e.ReferenceKey()) }
+
+// Anchor reports the edge midpoint as its representative point — the geometric
+// tie-breaker the binder uses only when several siblings share a parent (P6b).
+func (a edgeEntity) Anchor() (math.Point3, bool) {
+	s, e := a.e.StartVertex(), a.e.EndVertex()
+	if s == nil || e == nil {
+		return math.Point3{}, false
+	}
+	return s.Point().Midpoint(e.Point()), true
+}
+
+// edgeEntities views every edge of the body as an identity.Entity for the binder.
+func edgeEntities(body *topo.Body) []identity.Entity {
+	edges := body.Edges()
+	out := make([]identity.Entity, len(edges))
+	for i, e := range edges {
+		out[i] = edgeEntity{e}
+	}
+	return out
+}
+
+// currentKeys returns each resolved edge's CURRENT reference key — the same bytes as
+// the stored key for an exact match, the recovered sibling's live key for a healed one.
+// Callers that feed kernel ops (which re-resolve by exact key) use it so a healed edge
+// is addressed by a key the kernel can match.
+func currentKeys(edges []*topo.Edge) [][]byte {
+	keys := make([][]byte, len(edges))
+	for i, e := range edges {
+		keys[i] = e.ReferenceKey()
+	}
+	return keys
+}
+
+// recoverEdge attempts to recover a lost/ambiguous edge reference through the tiered
+// binder: a lone surviving sibling sharing the key's parent lineage binds ancestrally
+// (anchor nil → ancestral only, the P6a scope). It returns the recovered edge and the
+// match tier, or (nil, MatchNone) when no defensible recovery exists.
+func recoverEdge(refKey []byte, ents []identity.Entity) (*topo.Edge, identity.MatchType) {
+	ent, mt := identity.RecoverLost(identity.KindEdge, parentOfKey(refKey), nil, ents)
+	if ent == nil {
+		return nil, mt
+	}
+	return ent.(edgeEntity).e, mt
+}

--- a/model/feature/lip.go
+++ b/model/feature/lip.go
@@ -45,7 +45,7 @@ func (l *LipFeature) Recompute(in Input) (Output, error) {
 	if w <= 0 || h <= 0 {
 		return Output{}, fmt.Errorf("lip: width %g and height %g must both be > 0", w, h)
 	}
-	edges, err := resolveEdges(body, l.def.EdgeKeys)
+	edges, heals, err := resolveEdges(body, l.def.EdgeKeys)
 	if err != nil {
 		return Output{}, err
 	}
@@ -63,7 +63,7 @@ func (l *LipFeature) Recompute(in Input) (Output, error) {
 			return Output{}, err
 		}
 	}
-	return Output{Bodies: replaceBody(in.Bodies, body, result)}, nil
+	return Output{Bodies: replaceBody(in.Bodies, body, result), Heals: heals}, nil
 }
 
 // lipBead builds the Width×Height bead swept along an edge: a rectangle in the plane

--- a/model/feature/reference_recovery_test.go
+++ b/model/feature/reference_recovery_test.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/health"
+	"oblikovati.org/model/identity"
+)
+
+// edgeKeyFor renders a two-token edge lineage (parent "grp:e#0", a given last step) as the
+// reference key a feature would have stored when the user picked that edge.
+func edgeKeyFor(lastIndex int) []byte {
+	lin := topo.NewLineage(topo.Tok("grp", "e", 0), topo.Tok("base", "side", lastIndex))
+	return append([]byte{0x02}, lin.Key()...) // 0x02 = topo.KindEdge
+}
+
+// siblingTriBody builds a triangle whose edge "ab" carries a TWO-token lineage sharing the parent
+// "grp:e#0" with the given last step; the other two edges are unrelated (single-token, no parent).
+// extraSibling adds a SECOND edge under the same parent (a different last step) so the parent has
+// two surviving siblings — the case ancestral recovery must refuse without a geometric anchor.
+func siblingTriBody(t *testing.T, lastIndex int, extraSibling bool) (*topo.Body, *topo.Edge) {
+	t.Helper()
+	bld := topo.NewBuilder(false, topo.NewLineage(topo.Tok("f", "body", 0)))
+	a := bld.AddVertex(math.P3(0, 0, 0), topo.NewLineage(topo.Tok("f", "vertex", 0)))
+	b := bld.AddVertex(math.P3(1, 0, 0), topo.NewLineage(topo.Tok("f", "vertex", 1)))
+	c := bld.AddVertex(math.P3(0, 1, 0), topo.NewLineage(topo.Tok("f", "vertex", 2)))
+	abLin := topo.NewLineage(topo.Tok("grp", "e", 0), topo.Tok("base", "side", lastIndex))
+	ab := bld.AddEdge(geom.NewLineSegment(a.Point(), b.Point()), a, b, abLin)
+	bcLin := topo.NewLineage(topo.Tok("f", "edge", 1))
+	if extraSibling {
+		bcLin = topo.NewLineage(topo.Tok("grp", "e", 0), topo.Tok("base", "side", lastIndex+1))
+	}
+	bc := bld.AddEdge(geom.NewLineSegment(b.Point(), c.Point()), b, c, bcLin)
+	ca := bld.AddEdge(geom.NewLineSegment(c.Point(), a.Point()), c, a, topo.NewLineage(topo.Tok("f", "edge", 2)))
+	pl, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	bld.AddFace(pl, topo.NewLineage(topo.Tok("f", "face", 0)), topo.OuterLoop(topo.Fwd(ab), topo.Fwd(bc), topo.Fwd(ca)))
+	return bld.Build(), ab
+}
+
+// TestResolveEdgesHealsLostReferenceToAncestralSibling is the ADR-0043 P6 headline: a stored edge
+// key whose EXACT entity is gone (its lineage drifted under an upstream edit) but whose PARENT
+// lineage still names exactly one surviving edge is recovered ancestrally — bound to that sibling
+// and reported as a heal — instead of going Sick. This is what turns the fillet-stack reference
+// loss into an auto-healed warning.
+func TestResolveEdgesHealsLostReferenceToAncestralSibling(t *testing.T) {
+	body, kept := siblingTriBody(t, 7, false)
+	lost := edgeKeyFor(2) // same parent grp:e#0, a last step the body no longer has
+
+	edges, heals, err := resolveEdges(body, [][]byte{lost})
+	if err != nil {
+		t.Fatalf("a recoverable reference must heal, not error: %v", err)
+	}
+	if len(edges) != 1 || edges[0] != kept {
+		t.Fatalf("heal bound the wrong edge: got %v, want the lone parent sibling", edges)
+	}
+	if len(heals) != 1 || heals[0].Match != identity.MatchAncestral {
+		t.Fatalf("expected one ancestral heal, got %+v", heals)
+	}
+}
+
+// TestResolveEdgesRefusesAmbiguousSiblingsWithoutAnchor pins the honesty invariant: when the lost
+// key's parent has MORE THAN ONE surviving sibling, ancestral recovery cannot pick one and — with
+// no mint-time anchor yet (the geometric tier is P6b) — the reference stays lost rather than binding
+// a guess. A wrong heal is worse than an honest Sick.
+func TestResolveEdgesRefusesAmbiguousSiblingsWithoutAnchor(t *testing.T) {
+	body, _ := siblingTriBody(t, 7, true) // two edges now share parent grp:e#0
+	lost := edgeKeyFor(2)
+
+	_, _, err := resolveEdges(body, [][]byte{lost})
+	if err == nil {
+		t.Fatal("two same-parent siblings with no anchor must NOT heal — recovery guessed")
+	}
+	if !strings.Contains(err.Error(), "lost") {
+		t.Errorf("error %q should report the reference as lost", err)
+	}
+}
+
+// healingFeature is a fake feature that rebuilds successfully but reports a reference heal, to pin
+// the engine's classification of a heal.
+type healingFeature struct{ heals []ReferenceHeal }
+
+func (healingFeature) Kind() string { return "healtest" }
+func (f healingFeature) Recompute(in Input) (Output, error) {
+	return Output{Bodies: append(append([]*topo.Body(nil), in.Bodies...), makeBody()), Heals: f.heals}, nil
+}
+
+// TestHealedReferenceClassifiesAsWarningNotSick pins ADR-0043 P6's health mapping: a feature that
+// rebuilt on a recovered reference is a Warning (the body is kept, the drift is surfaced), distinct
+// from both a clean recompute and a Sick lost-reference failure.
+func TestHealedReferenceClassifiesAsWarningNotSick(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	fs.Add(body()) // a base body to operate on
+	pf := fs.Add(healingFeature{heals: []ReferenceHeal{{Key: edgeKeyFor(2), Match: identity.MatchAncestral}}})
+	fs.Recompute()
+
+	if got := pf.Health().Status; got != health.Warning {
+		t.Fatalf("a healed reference must classify as Warning, got %v (%s)", got, pf.Health().Reason)
+	}
+	if !strings.Contains(pf.Health().Reason, "healed") {
+		t.Errorf("the warning should explain the heal, got %q", pf.Health().Reason)
+	}
+	if len(fs.Result()) == 0 {
+		t.Error("the rebuilt body must be kept — a heal is not a passthrough")
+	}
+}
+
+// TestParentOfKeyDropsMostSpecificToken pins the parent derivation both tiers compare on: the
+// parent of a reference key is its lineage with the final token removed, and a single-token (root)
+// key has no parent (nil) — so it has no ancestral fallback.
+func TestParentOfKeyDropsMostSpecificToken(t *testing.T) {
+	two := edgeKeyFor(5) // grp:e#0/base:side#5
+	if got := string(parentOfKey(two)); got != "grp:e#0" {
+		t.Errorf("parentOfKey(two-token) = %q, want grp:e#0", got)
+	}
+	root := append([]byte{0x02}, topo.NewLineage(topo.Tok("only", "e", 1)).Key()...)
+	if got := parentOfKey(root); got != nil {
+		t.Errorf("parentOfKey(root) = %q, want nil (no parent)", got)
+	}
+}

--- a/model/feature/resolve_guard_test.go
+++ b/model/feature/resolve_guard_test.go
@@ -35,11 +35,11 @@ func collidingTriBody() (body *topo.Body, dupKey, uniqueKey []byte) {
 func TestResolveEdgesRejectsAmbiguousKey(t *testing.T) {
 	body, dupKey, uniqueKey := collidingTriBody()
 
-	if _, err := resolveEdges(body, [][]byte{uniqueKey}); err != nil {
+	if _, _, err := resolveEdges(body, [][]byte{uniqueKey}); err != nil {
 		t.Fatalf("unique key should resolve, got %v", err)
 	}
 
-	_, err := resolveEdges(body, [][]byte{dupKey})
+	_, _, err := resolveEdges(body, [][]byte{dupKey})
 	if err == nil {
 		t.Fatal("ambiguous key resolved without error — the guard let a naming collision through")
 	}
@@ -48,7 +48,7 @@ func TestResolveEdgesRejectsAmbiguousKey(t *testing.T) {
 	}
 
 	lost := topo.NewLineage(topo.Tok("ghost", "edge", 99))
-	_, err = resolveEdges(body, [][]byte{appendKindByte(lost)})
+	_, _, err = resolveEdges(body, [][]byte{appendKindByte(lost)})
 	if err == nil || !strings.Contains(err.Error(), "lost") {
 		t.Errorf("a missing key should report 'lost', got %v", err)
 	}

--- a/model/feature/sheet_metal_contour_flange.go
+++ b/model/feature/sheet_metal_contour_flange.go
@@ -56,7 +56,7 @@ func (f *SheetMetalContourFlangeFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	edges, err := resolveEdges(body, [][]byte{f.def.EdgeKey})
+	edges, heals, err := resolveEdges(body, [][]byte{f.def.EdgeKey})
 	if err != nil {
 		return Output{}, err
 	}
@@ -68,7 +68,7 @@ func (f *SheetMetalContourFlangeFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	return Output{Bodies: bodies}, nil
+	return Output{Bodies: bodies, Heals: heals}, nil
 }
 
 // buildContourFlangeSolid builds the contour-flange solid: the profile band mapped onto the

--- a/model/feature/sheet_metal_corner.go
+++ b/model/feature/sheet_metal_corner.go
@@ -77,16 +77,22 @@ func (f *SheetMetalCornerFeature) Recompute(in Input) (Output, error) {
 
 // roundCorners rolls a fillet of the given radius around the corner edges.
 func (f *SheetMetalCornerFeature) roundCorners(in Input, body *topo.Body, radius float64) (Output, error) {
-	res, err := ops.FilletEdges(body, f.def.EdgeKeys, radius)
+	// Heal the keys before the kernel pass (ops.FilletEdges re-resolves by exact key), so a
+	// recovered reference is addressed by its live key and the heal reaches the Output (P6).
+	edges, heals, err := resolveEdges(body, f.def.EdgeKeys)
+	if err != nil {
+		return Output{}, err
+	}
+	res, err := ops.FilletEdges(body, currentKeys(edges), radius)
 	if err != nil {
 		return Output{}, fmt.Errorf("sheet-metal corner round: %w", err)
 	}
-	return Output{Bodies: replaceBody(in.Bodies, body, res)}, nil
+	return Output{Bodies: replaceBody(in.Bodies, body, res), Heals: heals}, nil
 }
 
 // chamferCorners cuts a flat bevel of the given setback across the corner edges.
 func (f *SheetMetalCornerFeature) chamferCorners(in Input, body *topo.Body, setback float64) (Output, error) {
-	edges, err := resolveEdges(body, f.def.EdgeKeys)
+	edges, heals, err := resolveEdges(body, f.def.EdgeKeys)
 	if err != nil {
 		return Output{}, err
 	}
@@ -99,7 +105,7 @@ func (f *SheetMetalCornerFeature) chamferCorners(in Input, body *topo.Body, setb
 	if err != nil {
 		return Output{}, fmt.Errorf("sheet-metal corner chamfer: %w", err)
 	}
-	return Output{Bodies: replaceBody(in.Bodies, body, res)}, nil
+	return Output{Bodies: replaceBody(in.Bodies, body, res), Heals: heals}, nil
 }
 
 // SheetMetalCornerFeatures adds corner features into the engine.

--- a/model/feature/sheet_metal_corner_seam.go
+++ b/model/feature/sheet_metal_corner_seam.go
@@ -68,7 +68,7 @@ func (f *SheetMetalCornerSeamFeature) Recompute(in Input) (Output, error) {
 	if len(f.def.EdgeKeys) == 0 {
 		return Output{}, fmt.Errorf("sheet-metal corner seam: no corner edges selected")
 	}
-	edges, err := resolveEdges(body, f.def.EdgeKeys)
+	edges, heals, err := resolveEdges(body, f.def.EdgeKeys)
 	if err != nil {
 		return Output{}, err
 	}
@@ -81,7 +81,7 @@ func (f *SheetMetalCornerSeamFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, fmt.Errorf("sheet-metal corner seam: %w", err)
 	}
-	return Output{Bodies: replaceBody(in.Bodies, body, res)}, nil
+	return Output{Bodies: replaceBody(in.Bodies, body, res), Heals: heals}, nil
 }
 
 // seamCutters builds the gap-relief notch cutter for each corner edge.

--- a/model/feature/sheet_metal_flange.go
+++ b/model/feature/sheet_metal_flange.go
@@ -63,7 +63,7 @@ func (f *SheetMetalFlangeFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	edges, err := resolveEdges(body, [][]byte{f.def.EdgeKey})
+	edges, heals, err := resolveEdges(body, [][]byte{f.def.EdgeKey})
 	if err != nil {
 		return Output{}, err
 	}
@@ -77,7 +77,7 @@ func (f *SheetMetalFlangeFeature) Recompute(in Input) (Output, error) {
 		return Output{}, err
 	}
 	f.placement = &placement // record the resolved bend for the flat pattern (M13-F04)
-	return Output{Bodies: bodies}, nil
+	return Output{Bodies: bodies, Heals: heals}, nil
 }
 
 // Placement returns the resolved bend geometry captured by the last successful recompute,

--- a/model/feature/sheet_metal_hem.go
+++ b/model/feature/sheet_metal_hem.go
@@ -63,7 +63,7 @@ func (f *SheetMetalHemFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	edges, err := resolveEdges(body, [][]byte{f.def.EdgeKey})
+	edges, heals, err := resolveEdges(body, [][]byte{f.def.EdgeKey})
 	if err != nil {
 		return Output{}, err
 	}
@@ -76,7 +76,7 @@ func (f *SheetMetalHemFeature) Recompute(in Input) (Output, error) {
 		return Output{}, err
 	}
 	f.placement = &placement // record the resolved bend for the flat pattern (M13-F04)
-	return Output{Bodies: bodies}, nil
+	return Output{Bodies: bodies, Heals: heals}, nil
 }
 
 // Placement returns the resolved bend geometry captured by the last successful recompute,

--- a/model/feature/sheet_metal_lip.go
+++ b/model/feature/sheet_metal_lip.go
@@ -56,7 +56,7 @@ func (f *SheetMetalLipFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	edges, err := resolveEdges(body, [][]byte{f.def.EdgeKey})
+	edges, heals, err := resolveEdges(body, [][]byte{f.def.EdgeKey})
 	if err != nil {
 		return Output{}, err
 	}
@@ -68,7 +68,7 @@ func (f *SheetMetalLipFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	return Output{Bodies: bodies}, nil
+	return Output{Bodies: bodies, Heals: heals}, nil
 }
 
 // lipDims is the resolved, validated set of lip dimensions for one recompute. The return bend

--- a/model/identity/recover.go
+++ b/model/identity/recover.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package identity
+
+import "oblikovati.org/math"
+
+// RecoverLost attempts the degraded binding tiers (M31-F06; Kripac 1997) for a
+// reference whose EXACT entity is gone from the current topology — the live
+// counterpart of [KeyManager.BindKeyToObject]'s fallback, reachable without a key
+// context for callers that resolve raw kernel reference keys (the dress-up features,
+// ADR-0043 P6). It is a thin, pure wrapper over the same tested binder, so there is
+// one recovery implementation, not two.
+//
+// parentKey is the lost key's PARENT lineage (its lineage with the most-specific
+// step dropped): a lone surviving sibling that shares it binds ancestrally. anchor,
+// when non-nil, is the reference's mint-time point: several surviving siblings are
+// then disambiguated by geometric nearness to it (anchor nil → ancestral only).
+// ents enumerates the current entities of the body. The result is [MatchNone] (nil
+// entity) whenever no recovery is defensible — an empty parent, several siblings
+// with no anchor, or a geometric tie — so recovery never binds the wrong entity.
+//
+// Example: e, m := identity.RecoverLost(identity.KindEdge, parent, nil, edgeEnts)
+func RecoverLost(kind EntityKind, parentKey []byte, anchor *math.Point3, ents []Entity) (Entity, MatchType) {
+	if len(parentKey) == 0 {
+		return nil, MatchNone
+	}
+	k := RefKey{kind: kind, parent: ancestryHint{key: parentKey, ok: true}}
+	if anchor != nil {
+		k.anchor = anchorHint{point: *anchor, ok: true}
+	}
+	return fallbackMatch(k, ents)
+}


### PR DESCRIPTION
## What

Wires the live dress-up edge resolution path to the F06 **tiered binder** — built and unit-tested since M31 but, until now, **never reachable from a running model** (`BindKeyToObject`/`fs.keys` had zero non-test callers). A stored reference key whose **exact** entity is gone is now **recovered** when its **parent lineage** still names exactly one surviving edge, instead of the feature going Sick. The feature rebuilds on the recovered edge and reports a **Warning** so the user can re-pick.

This is **P6a** — the first, zero-serialization-risk slice of the last phase of epic #1539. All naming phases (P0–P5, SSI, buildSheet) already shipped; this completes the **resolution** half.

## Why

ADR-0043 closed reference **minting** (every generator names by generating parents) but left **resolution exact-only**: any drift exact naming can't absorb dropped straight to Sick, even when a single ancestral sibling unambiguously survives. P6a realizes the F06/F07 investment.

## How (architect-reviewed seam — ADR-0043 §P6)

- **`model/identity/recover.go`** — `RecoverLost`, an exported, pure recovery entrypoint reusing the tested `fallbackMatch` (one binder, not two).
- **`model/feature/identity_adapter.go`** — the only place `kernel/topo` and `model/identity` are both visible; adapts topo edges to `identity.Entity` (+ ancestral parent derived from the key, + anchor for the future geometric tier) **without inverting the dependency rule**.
- **`resolveEdges`** — exact-one stays authoritative (the P0 uniqueness guard is intact); a `0`-or-`>1` miss escalates to **ancestral** recovery; a heal substitutes the recovered edge's **current key** so the downstream kernel ops exact-match it. Heals ride on `Output`; the engine's `classify` maps a non-empty `Heals` to `health.Warning` with the rebuilt body kept.
- **Honesty invariant preserved**: with no mint-time anchor yet, two same-parent siblings stay **lost** rather than binding a guess (the geometric tier is **P6b**).

Covers fillet (single + sets + analytic + sheet-metal round), chamfer, lip, and all sheet-metal edge features.

## Tests

`model/feature/reference_recovery_test.go`:
- ancestral heal binds the lone surviving parent-sibling (no error, `MatchAncestral`);
- ambiguous siblings **refuse** to heal without an anchor (stays "lost");
- a heal classifies as **Warning** with the body kept (not Sick, not a clean recompute);
- `parentOfKey` = lineage minus the most-specific token (root → no parent).

Full `./model/...` suite green; `golangci-lint` (funlen 20) and `markdownlint` clean locally.

## Follow-ups (tracked under #1539 P6)

- **P6b** — persist the mint-time anchor + enable the geometric tier (isolated serialization change).
- **P6c** — retire dead silent-match branches; make `Input.Keys`/`fs.keys` live.

Refs #1539.

🤖 Generated with [Claude Code](https://claude.com/claude-code)