### PR TITLE
P6b: geometric recovery tier for lost dress-up references (ADR-0043, #1539)

### DIFF
--- a/app/chamfer_tool.go
+++ b/app/chamfer_tool.go
@@ -138,7 +138,9 @@ func (t *ChamferTool) Commit(s *Session) error {
 // both Commit (the part's engine) and DraftFeature (a scratch engine).
 func (t *ChamferTool) addChamfer(dress *feature.DressUpFeatures) *feature.PartFeature {
 	d := t.distance
-	return dress.AddChamferConcave(t.selectedEdgeKeys(), func() float64 { return d }, t.flatCorners, t.concaveStrategy)
+	pf := dress.AddChamferConcave(t.selectedEdgeKeys(), func() float64 { return d }, t.flatCorners, t.concaveStrategy)
+	pf.Definition().(*feature.ChamferFeature).Definition().EdgeAnchors = edgeHandleAnchors(t.edges) // P6b
+	return pf
 }
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
@@ -176,6 +178,7 @@ func (t *ChamferTool) Cancel(s *Session) {
 func (t *ChamferTool) commitEdit(s *Session) error {
 	def := t.target.Definition().(*feature.ChamferFeature).Definition()
 	def.EdgeKeys = t.selectedEdgeKeys()
+	def.EdgeAnchors = edgeHandleAnchors(t.edges)
 	def.Distance = konst(t.distance)
 	def.FlatCorners = t.flatCorners
 	def.ConcaveStrategy = t.concaveStrategy

--- a/app/fillet_tool.go
+++ b/app/fillet_tool.go
@@ -262,6 +262,7 @@ func (t *FilletTool) addFillet(dress *feature.DressUpFeatures) *feature.PartFeat
 	def.ConcaveStrategy = t.concaveStrategy
 	def.CrossSection = t.crossSection
 	def.Rho = t.rho
+	def.EdgeAnchors = edgeHandleAnchors(t.edges) // mint-time anchors for geometric recovery (P6b)
 	return pf
 }
 
@@ -277,6 +278,7 @@ func (t *FilletTool) commitEdit(s *Session) error {
 		return commitFeatureEdit(s, t.target)
 	}
 	def.EdgeKeys, def.Radius, def.EdgeSets = t.selectedEdgeKeys(), konst(t.radius), nil
+	def.EdgeAnchors = edgeHandleAnchors(t.edges)
 	return commitFeatureEdit(s, t.target)
 }
 

--- a/app/selection.go
+++ b/app/selection.go
@@ -5,12 +5,33 @@ package app
 import (
 	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
 	"oblikovati.org/model/assembly"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/occurrence"
 	"oblikovati.org/model/sketch"
 )
+
+// edgeHandleAnchors captures each picked edge's midpoint, keyed by its reference key, at
+// SELECTION time (the edge still exists) — the mint-time anchor a dress-up feature persists
+// for the geometric recovery tier (ADR-0043 P6b). The midpoint uses the edge's endpoints, the
+// same representative point the resolver compares siblings by, so a captured anchor and a live
+// sibling's anchor are computed identically. Returns nil when nothing anchorable was picked.
+func edgeHandleAnchors(edges []EdgeHandle) map[string]math.Point3 {
+	anchors := make(map[string]math.Point3, len(edges))
+	for _, h := range edges {
+		s, e := h.Edge.StartVertex(), h.Edge.EndVertex()
+		if s == nil || e == nil {
+			continue
+		}
+		anchors[string(h.Edge.ReferenceKey())] = s.Point().Midpoint(e.Point())
+	}
+	if len(anchors) == 0 {
+		return nil
+	}
+	return anchors
+}
 
 // SelectionKind classifies what is selected — Inventor's selection-filter
 // categories. A [SelectionFilter] restricts which kinds a pick accepts.

--- a/architecture/decisions/ADR-0043-generalized-provenance-naming.md
+++ b/architecture/decisions/ADR-0043-generalized-provenance-naming.md
@@ -133,9 +133,11 @@ residual naming collision becomes an honest failure, never a wrong-rebind.
     **ancestral** tier through a `model/feature` adapter; a lost reference with a lone surviving
     parent-sibling heals to a Warning instead of going Sick. No format change (the parent is derived
     from the key). The exact-one P0 guard stays authoritative; only a 0/>1 miss escalates.
-  - **P6b** — persist the mint-time **anchor** and enable the **geometric** tier, so several
-    surviving siblings are disambiguated by nearness (the binder still refuses a tie). Isolated
-    serialization change.
+  - **P6b** *(done)* — persist the mint-time **anchor** (`EdgeDressData.EdgeAnchors`, captured at
+    selection from the live edge midpoint) and enable the **geometric** tier, so several surviving
+    siblings are disambiguated by nearness (the binder still refuses a tie). The anchor is keyed by
+    reference key (a map), so it tolerates the seeded/picked split and an absent anchor degrades to
+    ancestral-only.
   - **P6c** — retire the now-dead silent-match resolution branches; make `Input.Keys`/`fs.keys` live
     (or remove). The no-parent ordinal fallback and the degraded CSG soup fallback legitimately stay.
 

--- a/model/feature/assembly_dressup.go
+++ b/model/feature/assembly_dressup.go
@@ -39,7 +39,7 @@ func (f *AssemblyChamferFeature) Kind() string { return kindAssemblyChamfer }
 func (f *AssemblyChamferFeature) Recompute(in Input) (Output, error) {
 	dist := f.distance()
 	bodies, err := dressParticipants(in.Bodies, edgeSuffixKeys(f.edgeSuffixes), func(body *topo.Body, keys [][]byte) (*topo.Body, error) {
-		out, err := chamferEdges(Input{Bodies: []*topo.Body{body}}, keys, dist, dist, "asmChamfer", f.flatCorners, types.ChamferConcaveOutward)
+		out, err := chamferEdges(Input{Bodies: []*topo.Body{body}}, keys, dist, dist, "asmChamfer", f.flatCorners, types.ChamferConcaveOutward, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/model/feature/chamfer.go
+++ b/model/feature/chamfer.go
@@ -36,7 +36,7 @@ const singularDetTol = 1e-12
 // a tetrahedron cut that trims the pointy three-plane intersection into one flat triangular face
 // — the default corner blend. With it clear the three chamfer planes are left to meet at a point.
 // The blend honours per-face setbacks (d1, d2), so it is correct for asymmetric chamfers too.
-func chamferEdges(in Input, keys [][]byte, d1, d2 float64, feat string, flatCorners bool, strategy types.ChamferConcaveStrategy) (Output, error) {
+func chamferEdges(in Input, keys [][]byte, d1, d2 float64, feat string, flatCorners bool, strategy types.ChamferConcaveStrategy, anchors map[string]math.Point3) (Output, error) {
 	body, err := runningBody(in)
 	if err != nil {
 		return Output{}, err
@@ -44,7 +44,7 @@ func chamferEdges(in Input, keys [][]byte, d1, d2 float64, feat string, flatCorn
 	if d1 <= 0 || d2 <= 0 {
 		return Output{}, fmt.Errorf("chamfer: setbacks (%g, %g) must both be > 0", d1, d2)
 	}
-	edges, heals, err := resolveEdges(body, keys)
+	edges, heals, err := resolveEdges(body, keys, anchors)
 	if err != nil {
 		return Output{}, err
 	}
@@ -162,7 +162,7 @@ func applyChamferTools(work *topo.Body, tools []wedgeOp) (*topo.Body, error) {
 // the key's parent lineage — and reported as a heal (the engine turns heals into a
 // Warning, ADR-0043 P6); only a genuinely unrecoverable or ambiguous key is a hard
 // error, so the feature goes Sick honestly rather than dressing up the wrong edge.
-func resolveEdges(body *topo.Body, keys [][]byte) ([]*topo.Edge, []ReferenceHeal, error) {
+func resolveEdges(body *topo.Body, keys [][]byte, anchors map[string]math.Point3) ([]*topo.Edge, []ReferenceHeal, error) {
 	edges := make([]*topo.Edge, len(keys))
 	var heals []ReferenceHeal
 	var ents []identity.Entity // built lazily, only when an exact match misses
@@ -175,7 +175,7 @@ func resolveEdges(body *topo.Body, keys [][]byte) ([]*topo.Edge, []ReferenceHeal
 		if ents == nil {
 			ents = edgeEntities(body)
 		}
-		if e, mt := recoverEdge(k, ents); mt.IsFallback() && e != nil {
+		if e, mt := recoverEdge(k, anchorFor(k, anchors), ents); mt.IsFallback() && e != nil {
 			edges[i] = e
 			heals = append(heals, ReferenceHeal{Key: append([]byte(nil), k...), Match: mt})
 			continue

--- a/model/feature/dressup.go
+++ b/model/feature/dressup.go
@@ -81,6 +81,12 @@ type FilletDefinition struct {
 	// recompute (see bindGeomEdges) and fold into the edge list; absent for a normal
 	// Oblikovati-authored fillet.
 	GeomEdges []topo.GeometricEdgeRef
+	// EdgeAnchors maps an EdgeKeys entry (raw reference key, as a string) to the edge's
+	// midpoint captured when the user picked it. It feeds the GEOMETRIC recovery tier
+	// (ADR-0043 P6b): when a lost key's parent has several surviving siblings, the anchor
+	// disambiguates by nearness. Absent for an older recipe or an edit-mode retained key —
+	// such a reference degrades to exact/ancestral recovery only.
+	EdgeAnchors map[string]math.Point3
 }
 
 // FilletType reports the definition's discriminator: always an edge fillet for now (the
@@ -107,7 +113,7 @@ func (f *FilletFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	return filletBody(in, keys, callOrZero(f.def.Radius), f.def.CornerType, f.def.ConcaveStrategy, prof, "fillet")
+	return filletBody(in, keys, callOrZero(f.def.Radius), f.def.CornerType, f.def.ConcaveStrategy, prof, "fillet", f.def.EdgeAnchors)
 }
 
 // ChamferType aliases the public chamfer-mode discriminator (ADR-0018).
@@ -132,6 +138,9 @@ type ChamferDefinition struct {
 	FlatCorners     bool
 	ConcaveStrategy ChamferConcaveStrategy  // zero value ⇒ outward (fill the inside corner)
 	GeomEdges       []topo.GeometricEdgeRef // externally-authored edges by geometric descriptor (see FilletDefinition.GeomEdges)
+	// EdgeAnchors maps an EdgeKeys entry to its mint-time midpoint for the geometric recovery
+	// tier (ADR-0043 P6b); see FilletDefinition.EdgeAnchors.
+	EdgeAnchors map[string]math.Point3
 }
 
 // ChamferFeature bevels selected edges (equal-distance, two-distance, or distance-and-angle).
@@ -156,7 +165,7 @@ func (c *ChamferFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	return chamferEdges(in, keys, d1, d2, featOr(c.featName, "chamfer"), c.def.FlatCorners, c.def.ConcaveStrategy)
+	return chamferEdges(in, keys, d1, d2, featOr(c.featName, "chamfer"), c.def.FlatCorners, c.def.ConcaveStrategy, c.def.EdgeAnchors)
 }
 
 // ShellDefinition hollows a body, removing the selected faces, to a wall thickness.

--- a/model/feature/face_fillet.go
+++ b/model/feature/face_fillet.go
@@ -60,7 +60,7 @@ func faceFilletBody(in Input, faceKeysA, faceKeysB [][]byte, radius float64, fea
 	if len(edgeKeys) == 0 {
 		return nonAdjacentFaceFilletBody(in, body, faceKeysA, faceKeysB, radius, feat)
 	}
-	return filletBody(in, edgeKeys, radius, types.FilletCornerMiter, types.FilletConcaveOutward, blendProfile{}, feat)
+	return filletBody(in, edgeKeys, radius, types.FilletCornerMiter, types.FilletConcaveOutward, blendProfile{}, feat, nil)
 }
 
 // nonAdjacentFaceFilletBody rounds two face sets that share no edge (#694): it deletes the faces in

--- a/model/feature/fillet.go
+++ b/model/feature/fillet.go
@@ -95,7 +95,7 @@ type blendProfile struct {
 	rho   float64
 }
 
-func filletBody(in Input, edgeKeys [][]byte, radius float64, corner FilletCornerType, concave types.FilletConcaveStrategy, prof blendProfile, feat string) (Output, error) {
+func filletBody(in Input, edgeKeys [][]byte, radius float64, corner FilletCornerType, concave types.FilletConcaveStrategy, prof blendProfile, feat string, anchors map[string]math.Point3) (Output, error) {
 	body, err := runningBody(in)
 	if err != nil {
 		return Output{}, err
@@ -104,10 +104,11 @@ func filletBody(in Input, edgeKeys [][]byte, radius float64, corner FilletCorner
 		return Output{}, fmt.Errorf("%s: radius %g must be > 0", feat, radius)
 	}
 	// Resolve once at the top so a lost reference can heal through the tiered binder
-	// (ADR-0043 P6). The downstream kernel ops re-resolve by EXACT key, so feed them the
-	// recovered edges' CURRENT keys — identical to the stored key for an exact match, the
-	// live key of the recovered sibling for a healed one — and carry the heals to the Output.
-	edges, heals, err := resolveEdges(body, edgeKeys)
+	// (ADR-0043 P6; anchors drive its geometric tier). The downstream kernel ops re-resolve by
+	// EXACT key, so feed them the recovered edges' CURRENT keys — identical to the stored key
+	// for an exact match, the live key of the recovered sibling for a healed one — and carry
+	// the heals to the Output.
+	edges, heals, err := resolveEdges(body, edgeKeys, anchors)
 	if err != nil {
 		return Output{}, err
 	}
@@ -145,7 +146,7 @@ func blendFilletEdges(in Input, body *topo.Body, keys0 [][]byte, radius float64,
 // cylinder rim becomes a surface of revolution (#127); the cylinder/cap RIM or ARC a prior fillet
 // leaves becomes a toroidal band / torus + setback caps. ok=false means no analytic case applied.
 func analyticFilletFastPath(in Input, body *topo.Body, edgeKeys [][]byte, radius float64, feat string) (Output, bool, error) {
-	if origEdges, _, e := resolveEdges(body, edgeKeys); e == nil {
+	if origEdges, _, e := resolveEdges(body, edgeKeys, nil); e == nil {
 		if res, ok := analyticCylinderFillet(body, origEdges, radius, feat); ok {
 			return Output{Bodies: replaceBody(in.Bodies, body, res)}, true, nil
 		}
@@ -164,7 +165,7 @@ func analyticFilletFastPath(in Input, body *topo.Body, edgeKeys [][]byte, radius
 // segment so the rolling-ball blend works instead of failing on a degenerate closed edge (#129/#127).
 // A planar body — or an unresolvable key, surfaced later by the kernel — passes through unchanged.
 func planarizedFillet(body *topo.Body, edgeKeys [][]byte, feat string) (*topo.Body, [][]byte) {
-	origEdges, _, err := resolveEdges(body, edgeKeys)
+	origEdges, _, err := resolveEdges(body, edgeKeys, nil)
 	if err != nil {
 		return body, edgeKeys
 	}
@@ -187,7 +188,7 @@ func planarizedFillet(body *topo.Body, edgeKeys [][]byte, feat string) (*topo.Bo
 // A single constant set routes through filletBody to keep the analytic cylinder-rim path.
 func filletBodySets(in Input, sets []FilletEdgeSet, corner FilletCornerType, concave types.FilletConcaveStrategy, prof blendProfile, feat string) (Output, error) {
 	if len(sets) == 1 && !sets[0].variable() {
-		return filletBody(in, sets[0].EdgeKeys, callOrZero(sets[0].Radius), corner, concave, prof, feat)
+		return filletBody(in, sets[0].EdgeKeys, callOrZero(sets[0].Radius), corner, concave, prof, feat, nil)
 	}
 	body, err := runningBody(in)
 	if err != nil {
@@ -220,7 +221,7 @@ func healPickKeys(body *topo.Body, picks []ops.EdgeFilletRadii) ([]ReferenceHeal
 	for i, p := range picks {
 		keys[i] = p.Key
 	}
-	edges, heals, err := resolveEdges(body, keys)
+	edges, heals, err := resolveEdges(body, keys, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -275,7 +276,7 @@ func planarizeFilletPicks(body *topo.Body, picks []ops.EdgeFilletRadii, feat str
 	for i, p := range picks {
 		keys[i] = p.Key
 	}
-	origEdges, _, err := resolveEdges(body, keys)
+	origEdges, _, err := resolveEdges(body, keys, nil)
 	if err != nil {
 		return body
 	}

--- a/model/feature/identity_adapter.go
+++ b/model/feature/identity_adapter.go
@@ -88,12 +88,26 @@ func currentKeys(edges []*topo.Edge) [][]byte {
 	return keys
 }
 
-// recoverEdge attempts to recover a lost/ambiguous edge reference through the tiered
-// binder: a lone surviving sibling sharing the key's parent lineage binds ancestrally
-// (anchor nil → ancestral only, the P6a scope). It returns the recovered edge and the
-// match tier, or (nil, MatchNone) when no defensible recovery exists.
-func recoverEdge(refKey []byte, ents []identity.Entity) (*topo.Edge, identity.MatchType) {
-	ent, mt := identity.RecoverLost(identity.KindEdge, parentOfKey(refKey), nil, ents)
+// anchorFor returns the mint-time anchor stored for a reference key, or nil when none was
+// captured (an older recipe, an edit-mode retained key) — in which case recovery falls back
+// to the ancestral tier only.
+func anchorFor(refKey []byte, anchors map[string]math.Point3) *math.Point3 {
+	if anchors == nil {
+		return nil
+	}
+	if p, ok := anchors[string(refKey)]; ok {
+		return &p
+	}
+	return nil
+}
+
+// recoverEdge attempts to recover a lost/ambiguous edge reference through the tiered binder:
+// a lone surviving sibling sharing the key's parent lineage binds ancestrally; with a mint-time
+// anchor, several surviving siblings are disambiguated by nearness (the geometric tier, P6b).
+// It returns the recovered edge and the match tier, or (nil, MatchNone) when no defensible
+// recovery exists.
+func recoverEdge(refKey []byte, anchor *math.Point3, ents []identity.Entity) (*topo.Edge, identity.MatchType) {
+	ent, mt := identity.RecoverLost(identity.KindEdge, parentOfKey(refKey), anchor, ents)
 	if ent == nil {
 		return nil, mt
 	}

--- a/model/feature/lip.go
+++ b/model/feature/lip.go
@@ -45,7 +45,7 @@ func (l *LipFeature) Recompute(in Input) (Output, error) {
 	if w <= 0 || h <= 0 {
 		return Output{}, fmt.Errorf("lip: width %g and height %g must both be > 0", w, h)
 	}
-	edges, heals, err := resolveEdges(body, l.def.EdgeKeys)
+	edges, heals, err := resolveEdges(body, l.def.EdgeKeys, nil)
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/reference_recovery_test.go
+++ b/model/feature/reference_recovery_test.go
@@ -52,7 +52,7 @@ func TestResolveEdgesHealsLostReferenceToAncestralSibling(t *testing.T) {
 	body, kept := siblingTriBody(t, 7, false)
 	lost := edgeKeyFor(2) // same parent grp:e#0, a last step the body no longer has
 
-	edges, heals, err := resolveEdges(body, [][]byte{lost})
+	edges, heals, err := resolveEdges(body, [][]byte{lost}, nil)
 	if err != nil {
 		t.Fatalf("a recoverable reference must heal, not error: %v", err)
 	}
@@ -72,12 +72,61 @@ func TestResolveEdgesRefusesAmbiguousSiblingsWithoutAnchor(t *testing.T) {
 	body, _ := siblingTriBody(t, 7, true) // two edges now share parent grp:e#0
 	lost := edgeKeyFor(2)
 
-	_, _, err := resolveEdges(body, [][]byte{lost})
+	_, _, err := resolveEdges(body, [][]byte{lost}, nil)
 	if err == nil {
 		t.Fatal("two same-parent siblings with no anchor must NOT heal — recovery guessed")
 	}
 	if !strings.Contains(err.Error(), "lost") {
 		t.Errorf("error %q should report the reference as lost", err)
+	}
+}
+
+// TestResolveEdgesHealsAmbiguousSiblingsByAnchor is the ADR-0043 P6b geometric tier: when the
+// lost key's parent has several surviving siblings, the mint-time anchor disambiguates by
+// nearness — recovering the sibling the user originally picked instead of staying lost (the P6a
+// outcome). The anchor sits on edge "ab"'s midpoint, so recovery must bind ab, not its peer.
+func TestResolveEdgesHealsAmbiguousSiblingsByAnchor(t *testing.T) {
+	body, ab := siblingTriBody(t, 7, true) // ab + bc both under parent grp:e#0
+	lost := edgeKeyFor(2)
+	anchors := map[string]math.Point3{string(lost): math.P3(0.5, 0, 0)} // ab's endpoint midpoint
+
+	edges, heals, err := resolveEdges(body, [][]byte{lost}, anchors)
+	if err != nil {
+		t.Fatalf("geometric recovery should heal an anchored ambiguous reference: %v", err)
+	}
+	if len(edges) != 1 || edges[0] != ab {
+		t.Fatalf("anchor near ab must bind ab, got %v", edges)
+	}
+	if len(heals) != 1 || heals[0].Match != identity.MatchGeometric {
+		t.Fatalf("expected one geometric heal, got %+v", heals)
+	}
+}
+
+// TestFilletEdgeAnchorsRoundTrip pins that a fillet's mint-time edge anchors survive a recipe
+// round trip (ADR-0043 P6b) — without them, a reopened document could not use the geometric tier.
+func TestFilletEdgeAnchorsRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil, nil)
+	key := edgeKeyFor(7)
+	anchors := map[string]math.Point3{string(key): math.P3(1.25, -2.5, 3)}
+	NewDressUpFeatures(fs).addFillet(&FilletDefinition{
+		EdgeKeys: [][]byte{key}, Radius: constFloat(0.5), EdgeAnchors: anchors,
+	})
+
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil, nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	got := fresh.Item(0).Definition().(*FilletFeature).Definition().EdgeAnchors
+	if len(got) != 1 {
+		t.Fatalf("edge anchors after round trip = %v, want one entry", got)
+	}
+	p, ok := got[string(key)]
+	if !ok || !p.IsEqualTo(math.P3(1.25, -2.5, 3), 1e-9) {
+		t.Errorf("anchor after round trip = %v (present=%v), want (1.25,-2.5,3)", p, ok)
 	}
 }
 

--- a/model/feature/resolve_guard_test.go
+++ b/model/feature/resolve_guard_test.go
@@ -35,11 +35,11 @@ func collidingTriBody() (body *topo.Body, dupKey, uniqueKey []byte) {
 func TestResolveEdgesRejectsAmbiguousKey(t *testing.T) {
 	body, dupKey, uniqueKey := collidingTriBody()
 
-	if _, _, err := resolveEdges(body, [][]byte{uniqueKey}); err != nil {
+	if _, _, err := resolveEdges(body, [][]byte{uniqueKey}, nil); err != nil {
 		t.Fatalf("unique key should resolve, got %v", err)
 	}
 
-	_, _, err := resolveEdges(body, [][]byte{dupKey})
+	_, _, err := resolveEdges(body, [][]byte{dupKey}, nil)
 	if err == nil {
 		t.Fatal("ambiguous key resolved without error — the guard let a naming collision through")
 	}
@@ -48,7 +48,7 @@ func TestResolveEdgesRejectsAmbiguousKey(t *testing.T) {
 	}
 
 	lost := topo.NewLineage(topo.Tok("ghost", "edge", 99))
-	_, _, err = resolveEdges(body, [][]byte{appendKindByte(lost)})
+	_, _, err = resolveEdges(body, [][]byte{appendKindByte(lost)}, nil)
 	if err == nil || !strings.Contains(err.Error(), "lost") {
 		t.Errorf("a missing key should report 'lost', got %v", err)
 	}

--- a/model/feature/rule_fillet.go
+++ b/model/feature/rule_fillet.go
@@ -87,7 +87,7 @@ func ruleFilletBody(in Input, rule RuleFilletRule, radius float64, feat string) 
 	if len(keys) == 0 {
 		return Output{Bodies: in.Bodies}, nil
 	}
-	return filletBody(in, keys, radius, types.FilletCornerMiter, types.FilletConcaveOutward, blendProfile{}, feat)
+	return filletBody(in, keys, radius, types.FilletCornerMiter, types.FilletConcaveOutward, blendProfile{}, feat, nil)
 }
 
 // ruleEdgeKeys returns the reference keys of every edge whose dihedral class matches rule.

--- a/model/feature/serialize_codecs_dressup.go
+++ b/model/feature/serialize_codecs_dressup.go
@@ -20,7 +20,7 @@ func init() {
 				fd.Fillet = &EdgeDressData{Sets: serializeFilletSets(ff.def.EdgeSets), CornerType: int32(ff.def.CornerType), CrossSection: crossSectionWire(ff.def.CrossSection), Rho: ff.def.Rho}
 				return nil
 			}
-			fd.Fillet = &EdgeDressData{Edges: encodeKeys(ff.def.EdgeKeys), Value: evalFloat(ff.def.Radius), CornerType: int32(ff.def.CornerType), CrossSection: crossSectionWire(ff.def.CrossSection), Rho: ff.def.Rho, GeomEdges: encodeGeomEdges(ff.def.GeomEdges)}
+			fd.Fillet = &EdgeDressData{Edges: encodeKeys(ff.def.EdgeKeys), Value: evalFloat(ff.def.Radius), CornerType: int32(ff.def.CornerType), CrossSection: crossSectionWire(ff.def.CrossSection), Rho: ff.def.Rho, GeomEdges: encodeGeomEdges(ff.def.GeomEdges), EdgeAnchors: encodeEdgeAnchors(ff.def.EdgeAnchors)}
 			return nil
 		},
 		decode: decodeFillet,
@@ -32,7 +32,7 @@ func init() {
 			fd.Chamfer = &EdgeDressData{
 				Edges: encodeKeys(cf.def.EdgeKeys), Value: evalFloat(cf.def.Distance), FlatCorners: &flat,
 				ChamferType: int32(cf.def.Type), Value2: evalFloat(cf.def.Distance2), Angle: evalFloat(cf.def.Angle),
-				GeomEdges: encodeGeomEdges(cf.def.GeomEdges),
+				GeomEdges: encodeGeomEdges(cf.def.GeomEdges), EdgeAnchors: encodeEdgeAnchors(cf.def.EdgeAnchors),
 			}
 			return nil
 		},
@@ -132,7 +132,7 @@ func decodeFillet(rc *restoreContext, fd FeatureData) (*PartFeature, error) {
 		return nil, err
 	}
 	return du.addFillet(&FilletDefinition{
-		EdgeKeys: d.keys, GeomEdges: d.geom, Radius: constFloat(d.value), CornerType: corner,
+		EdgeKeys: d.keys, GeomEdges: d.geom, EdgeAnchors: d.anchors, Radius: constFloat(d.value), CornerType: corner,
 		CrossSection: cross, Rho: rho,
 	}), nil
 }
@@ -145,7 +145,7 @@ func decodeChamfer(rc *restoreContext, fd FeatureData) (*PartFeature, error) {
 		return nil, err
 	}
 	def := &ChamferDefinition{
-		EdgeKeys: d.keys, GeomEdges: d.geom, Distance: constFloat(d.value),
+		EdgeKeys: d.keys, GeomEdges: d.geom, EdgeAnchors: d.anchors, Distance: constFloat(d.value),
 		Type: types.ChamferType(fd.Chamfer.ChamferType), FlatCorners: chamferFlatCornersOr(fd.Chamfer.FlatCorners),
 	}
 	switch def.Type {

--- a/model/feature/serialize_dressup.go
+++ b/model/feature/serialize_dressup.go
@@ -5,6 +5,7 @@ package feature
 import (
 	"encoding/base64"
 	"fmt"
+	"sort"
 
 	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/topo"
@@ -52,6 +53,17 @@ type EdgeDressData struct {
 	// an external author (the NX exporter) uses because it cannot mint Oblikovati lineage
 	// keys. Empty for an Oblikovati-authored dress-up (which uses Edges).
 	GeomEdges []GeomEdgeRefData `yaml:"geomEdges,omitempty"`
+	// EdgeAnchors carry each picked edge's mint-time midpoint (keyed by its reference key) for
+	// the geometric recovery tier (ADR-0043 P6b). Omitted for an older recipe, which then
+	// recovers a lost reference by exact/ancestral binding only.
+	EdgeAnchors []EdgeAnchorData `yaml:"edgeAnchors,omitempty"`
+}
+
+// EdgeAnchorData is the serialized mint-time anchor of one picked edge: its reference key
+// (base64) and midpoint, used to disambiguate surviving siblings when the exact key is lost.
+type EdgeAnchorData struct {
+	Key      string    `yaml:"key"`
+	Midpoint []float64 `yaml:"midpoint,flow"`
 }
 
 // GeomEdgeRefData is the serialized form of a geometric edge descriptor: the edge's
@@ -233,12 +245,14 @@ type ThreadData struct {
 }
 
 // dressInputs is the decoded (keys, value) pair shared by edge/face dress-ups, plus any
-// geometric edge descriptors (externally-authored selections, ADR-0040).
+// geometric edge descriptors (externally-authored selections, ADR-0040) and the mint-time
+// edge anchors for geometric recovery (ADR-0043 P6b).
 type dressInputs struct {
 	keys      [][]byte
 	value     float64
 	geom      []topo.GeometricEdgeRef
 	geomFaces []topo.GeometricFaceRef
+	anchors   map[string]math.Point3
 }
 
 func requireEdgeDress(d *EdgeDressData, kind string) (dressInputs, error) {
@@ -249,7 +263,42 @@ func requireEdgeDress(d *EdgeDressData, kind string) (dressInputs, error) {
 	if err != nil {
 		return dressInputs{}, err
 	}
-	return dressInputs{keys: keys, value: d.Value, geom: decodeGeomEdges(d.GeomEdges)}, nil
+	anchors, err := decodeEdgeAnchors(d.EdgeAnchors)
+	if err != nil {
+		return dressInputs{}, err
+	}
+	return dressInputs{keys: keys, value: d.Value, geom: decodeGeomEdges(d.GeomEdges), anchors: anchors}, nil
+}
+
+// encodeEdgeAnchors / decodeEdgeAnchors round-trip the mint-time edge-anchor map (ADR-0043
+// P6b): keys are base64-encoded reference keys (opaque lineage bytes, like Edges), values are
+// midpoints. Empty for a dress-up authored before P6b or with no captured anchors.
+func encodeEdgeAnchors(anchors map[string]math.Point3) []EdgeAnchorData {
+	if len(anchors) == 0 {
+		return nil
+	}
+	out := make([]EdgeAnchorData, 0, len(anchors))
+	for k, p := range anchors {
+		out = append(out, EdgeAnchorData{Key: encodeKey([]byte(k)), Midpoint: encodePoint3(p)})
+	}
+	// Deterministic order so the serialized document is stable across runs (maps iterate randomly).
+	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
+	return out
+}
+
+func decodeEdgeAnchors(data []EdgeAnchorData) (map[string]math.Point3, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]math.Point3, len(data))
+	for _, d := range data {
+		k, err := decodeKey(d.Key)
+		if err != nil {
+			return nil, err
+		}
+		out[string(k)] = decodePoint3(d.Midpoint)
+	}
+	return out, nil
 }
 
 // encodeGeomEdges / decodeGeomEdges convert geometric edge descriptors to and from their

--- a/model/feature/sheet_metal_contour_flange.go
+++ b/model/feature/sheet_metal_contour_flange.go
@@ -56,7 +56,7 @@ func (f *SheetMetalContourFlangeFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	edges, heals, err := resolveEdges(body, [][]byte{f.def.EdgeKey})
+	edges, heals, err := resolveEdges(body, [][]byte{f.def.EdgeKey}, nil)
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/sheet_metal_corner.go
+++ b/model/feature/sheet_metal_corner.go
@@ -79,7 +79,7 @@ func (f *SheetMetalCornerFeature) Recompute(in Input) (Output, error) {
 func (f *SheetMetalCornerFeature) roundCorners(in Input, body *topo.Body, radius float64) (Output, error) {
 	// Heal the keys before the kernel pass (ops.FilletEdges re-resolves by exact key), so a
 	// recovered reference is addressed by its live key and the heal reaches the Output (P6).
-	edges, heals, err := resolveEdges(body, f.def.EdgeKeys)
+	edges, heals, err := resolveEdges(body, f.def.EdgeKeys, nil)
 	if err != nil {
 		return Output{}, err
 	}
@@ -92,7 +92,7 @@ func (f *SheetMetalCornerFeature) roundCorners(in Input, body *topo.Body, radius
 
 // chamferCorners cuts a flat bevel of the given setback across the corner edges.
 func (f *SheetMetalCornerFeature) chamferCorners(in Input, body *topo.Body, setback float64) (Output, error) {
-	edges, heals, err := resolveEdges(body, f.def.EdgeKeys)
+	edges, heals, err := resolveEdges(body, f.def.EdgeKeys, nil)
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/sheet_metal_corner_seam.go
+++ b/model/feature/sheet_metal_corner_seam.go
@@ -68,7 +68,7 @@ func (f *SheetMetalCornerSeamFeature) Recompute(in Input) (Output, error) {
 	if len(f.def.EdgeKeys) == 0 {
 		return Output{}, fmt.Errorf("sheet-metal corner seam: no corner edges selected")
 	}
-	edges, heals, err := resolveEdges(body, f.def.EdgeKeys)
+	edges, heals, err := resolveEdges(body, f.def.EdgeKeys, nil)
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/sheet_metal_flange.go
+++ b/model/feature/sheet_metal_flange.go
@@ -63,7 +63,7 @@ func (f *SheetMetalFlangeFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	edges, heals, err := resolveEdges(body, [][]byte{f.def.EdgeKey})
+	edges, heals, err := resolveEdges(body, [][]byte{f.def.EdgeKey}, nil)
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/sheet_metal_hem.go
+++ b/model/feature/sheet_metal_hem.go
@@ -63,7 +63,7 @@ func (f *SheetMetalHemFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	edges, heals, err := resolveEdges(body, [][]byte{f.def.EdgeKey})
+	edges, heals, err := resolveEdges(body, [][]byte{f.def.EdgeKey}, nil)
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/sheet_metal_lip.go
+++ b/model/feature/sheet_metal_lip.go
@@ -56,7 +56,7 @@ func (f *SheetMetalLipFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	edges, heals, err := resolveEdges(body, [][]byte{f.def.EdgeKey})
+	edges, heals, err := resolveEdges(body, [][]byte{f.def.EdgeKey}, nil)
 	if err != nil {
 		return Output{}, err
 	}


### PR DESCRIPTION
## What

Adds the **geometric** recovery tier to the dress-up reference binder. **P6a** (#1569, merged) recovered a lost reference only when its parent lineage named *exactly one* surviving edge. **P6b** persists each picked edge's **mint-time midpoint** and uses it to disambiguate when the parent has *several* surviving siblings — binding the nearest, and still refusing a tie (never a guessed wrong-rebind).

Second of the three P6 slices closing epic #1539.

## How

- **`FilletDefinition`/`ChamferDefinition`** gain `EdgeAnchors map[string]math.Point3` (reference key → midpoint).
- **Mint at selection time** — the fillet/chamfer tools capture the anchor from the *live* edge (`edgeHandleAnchors`) the moment the user picks it, when the edge provably exists (purity-respecting; no mutation during recompute).
- The anchor is the edge's **endpoint midpoint** — the exact representative point the resolver compares siblings by (`edgeEntity.Anchor`), so mint and resolve are computed identically.
- **`resolveEdges`** threads the anchors map to the binder's geometric tier; only the top-level resolve needs it (downstream kernel ops act on already-healed *current* keys).
- **Serialized** as `EdgeDressData.EdgeAnchors` (base64 key + midpoint, deterministically ordered for stable documents). Absent for an older recipe or an edit-mode retained key → degrades to exact/ancestral recovery only.

Keyed by reference key (a map) rather than a parallel slice, so it tolerates the seeded/picked split and partial coverage cleanly.

## Tests

`model/feature/reference_recovery_test.go`:
- an **anchored ambiguous** reference heals **geometrically** to the nearest sibling (where P6a left it lost);
- fillet **edge anchors survive a recipe round trip** (without persistence, a reopened document couldn't use the tier).

Full `./model/... ./app/... ./addin/...` green; `golangci-lint` and `markdownlint` clean. No visual change to the happy path (anchors are captured metadata); the geometric tier is proven deterministically by the unit tests.

## Remaining

- **P6c** — retire the now-dead silent-match resolution branches; make `Input.Keys`/`fs.keys` live. Then #1539 closes.

Refs #1539.

🤖 Generated with [Claude Code](https://claude.com/claude-code)