### PR TITLE
feat(head): render CSS-grid-like nested panel containers (ADR-0019)

### DIFF
--- a/app/dockwindow_nesting.go
+++ b/app/dockwindow_nesting.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/wire"
+)
+
+// Nesting support for dockable-window control trees (grid/group/tabs, ADR-0019). The wire
+// spec became a tree, so two flat-era assumptions are corrected here: edits must find a
+// control at any depth, and the host must be guarded against a runaway/deep tree before it
+// recurses while rendering.
+
+// maxControlNestDepth bounds how deeply controls may nest. A real layout (tabs ▸ group ▸
+// grid ▸ field) is ~4 deep; 16 is generous headroom while still a hard backstop so a buggy
+// add-in can't stack-overflow the immediate-mode renderer. Top-level controls are depth 1.
+const maxControlNestDepth = 16
+
+// validateControlTree rejects a control tree the renderer could not safely draw: one nested
+// past maxControlNestDepth, or one using the reserved RowSpan (ADR-0020 defers row span, so
+// the host renders rows as content-height auto-flow and RowSpan must be 1). Messages name the
+// offending window and value so the add-in author can fix it.
+func validateControlTree(windowID string, controls []wire.PanelControlSpec, depth int) error {
+	if depth > maxControlNestDepth {
+		return fmt.Errorf("app: dockable window %q nests controls %d deep, max %d", windowID, depth, maxControlNestDepth)
+	}
+	for _, c := range controls {
+		if c.Cell != nil && c.Cell.RowSpan > 1 {
+			return fmt.Errorf("app: dockable window %q control %q uses RowSpan=%d (reserved; must be 1)", windowID, c.ID, c.Cell.RowSpan)
+		}
+		if err := validateControlTree(windowID, c.Children, depth+1); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// setControlValue updates, in place, the value of the control identified by id anywhere in
+// the tree, returning whether it was found. IDs are unique within a window (the add-in's
+// contract), so the first match is authoritative. Mutating through the shared slice backing
+// arrays updates the stored window without a rebuild.
+func setControlValue(controls []wire.PanelControlSpec, id, value string) bool {
+	for i := range controls {
+		if controls[i].ID == id {
+			controls[i].Value = value
+			return true
+		}
+		if setControlValue(controls[i].Children, id, value) {
+			return true
+		}
+	}
+	return false
+}

--- a/app/dockwindow_nesting_test.go
+++ b/app/dockwindow_nesting_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+)
+
+// nestedWindow is a window whose edited control lives two levels deep (tabs ▸ grid ▸ field),
+// exercising that state updates and validation walk the whole tree (ADR-0019).
+func nestedWindow() wire.DockableWindowSpec {
+	field := wire.PanelControlSpec{Kind: types.PanelTextBox, ID: "startDepth", Value: "0"}
+	grid := wire.PanelControlSpec{
+		Kind: types.PanelGrid, ID: "depths",
+		Columns:  []types.GridTrack{{Kind: types.GridTrackAuto}, {Kind: types.GridTrackFraction, Value: 1}},
+		Children: []wire.PanelControlSpec{{Kind: types.PanelLabel, Text: "Start"}, field},
+	}
+	return wire.DockableWindowSpec{
+		ID: "job.edit", Title: "Job Edit", Visible: true,
+		Controls: []wire.PanelControlSpec{{
+			Kind: types.PanelTabs, ID: "tabs",
+			Children: []wire.PanelControlSpec{{Kind: types.PanelGroup, Title: "Setup", Children: []wire.PanelControlSpec{grid}}},
+		}},
+	}
+}
+
+// TestPanelValueChangedUpdatesNestedControl is the regression for the flat-only walk:
+// editing a deeply nested grid field must update its stored value, not silently miss it.
+func TestPanelValueChangedUpdatesNestedControl(t *testing.T) {
+	s := NewSession()
+	if err := s.SetDockableWindow(nestedWindow()); err != nil {
+		t.Fatalf("SetDockableWindow: %v", err)
+	}
+	s.PanelValueChanged("job.edit", "startDepth", "12 mm")
+
+	spec, _ := s.DockableWindows().Get("job.edit")
+	got := findControlValue(spec.Controls, "startDepth")
+	if got != "12 mm" {
+		t.Errorf("nested stored value = %q, want %q", got, "12 mm")
+	}
+}
+
+// findControlValue walks the control tree returning the value of the control with id.
+func findControlValue(controls []wire.PanelControlSpec, id string) string {
+	for _, c := range controls {
+		if c.ID == id {
+			return c.Value
+		}
+		if v := findControlValue(c.Children, id); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// TestSetDockableWindowRejectsTooDeep guards the host renderer against a runaway tree:
+// nesting beyond the depth bound is rejected with a message naming the window.
+func TestSetDockableWindowRejectsTooDeep(t *testing.T) {
+	deep := wire.PanelControlSpec{Kind: types.PanelLabel, Text: "x"}
+	for i := 0; i < maxControlNestDepth+2; i++ {
+		deep = wire.PanelControlSpec{Kind: types.PanelGroup, Title: "g", Children: []wire.PanelControlSpec{deep}}
+	}
+	w := wire.DockableWindowSpec{ID: "deep", Title: "Deep", Controls: []wire.PanelControlSpec{deep}}
+	if err := NewSession().SetDockableWindow(w); err == nil {
+		t.Error("over-deep control tree should be rejected")
+	}
+}
+
+// TestSetDockableWindowRejectsReservedRowSpan pins ADR-0020: row span is reserved, so a
+// child requesting RowSpan > 1 is rejected until the feature ships.
+func TestSetDockableWindowRejectsReservedRowSpan(t *testing.T) {
+	child := wire.PanelControlSpec{Kind: types.PanelLabel, Text: "x", Cell: &types.GridCell{RowSpan: 2}}
+	grid := wire.PanelControlSpec{Kind: types.PanelGrid, ID: "g", Columns: []types.GridTrack{{Kind: types.GridTrackAuto}}, Children: []wire.PanelControlSpec{child}}
+	w := wire.DockableWindowSpec{ID: "rs", Title: "RowSpan", Controls: []wire.PanelControlSpec{grid}}
+	if err := NewSession().SetDockableWindow(w); err == nil {
+		t.Error("RowSpan > 1 should be rejected as reserved")
+	}
+}
+
+// TestSetDockableWindowAcceptsValidNesting ensures the validator passes a normal nested tree.
+func TestSetDockableWindowAcceptsValidNesting(t *testing.T) {
+	if err := NewSession().SetDockableWindow(nestedWindow()); err != nil {
+		t.Errorf("valid nested window rejected: %v", err)
+	}
+}

--- a/app/dockwindow_store.go
+++ b/app/dockwindow_store.go
@@ -60,6 +60,9 @@ func (s *Session) SetDockableWindow(spec wire.DockableWindowSpec) error {
 	if spec.ID == "" || spec.Title == "" {
 		return fmt.Errorf("app: dockable window needs id and title, got id=%q title=%q", spec.ID, spec.Title)
 	}
+	if err := validateControlTree(spec.ID, spec.Controls, 1); err != nil {
+		return err
+	}
 	prev, existed := s.dockableWindows.windows[spec.ID]
 	if !existed {
 		s.dockableWindows.order = append(s.dockableWindows.order, spec.ID)
@@ -95,12 +98,9 @@ func (s *Session) SetDockableWindowVisible(id string, visible bool) error {
 // (text box, value editor, checkbox, dropdown, combo, slider) is edited.
 func (s *Session) PanelValueChanged(windowID, controlID, value string) {
 	if spec, ok := s.dockableWindows.windows[windowID]; ok {
-		for i := range spec.Controls {
-			if spec.Controls[i].ID == controlID {
-				spec.Controls[i].Value = value
-				s.dockableWindows.windows[windowID] = spec
-				break
-			}
+		// Walk the whole tree: an edited control may be a grid cell several levels deep.
+		if setControlValue(spec.Controls, controlID, value) {
+			s.dockableWindows.windows[windowID] = spec
 		}
 	}
 	event.Emit(s.bus, event.After, PanelValueChanged{WindowID: windowID, ControlID: controlID, Value: value})

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.95.0
+	oblikovati.org/api v0.96.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.95.0
+	oblikovati.org/api v0.96.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -106,6 +106,7 @@ float obk_ig_delta_time(void);
 void obk_ig_mouse_delta(float* dx, float* dy);
 void obk_ig_get_cursor_pos(float* x, float* y);
 void obk_ig_set_cursor_pos(float x, float y);
+void obk_ig_dummy(float w, float h);
 int  obk_ig_begin_ribbon_band(const char* name, float height);
 float obk_ig_scroll_max_x(void);
 float obk_ig_scrollbar_size(void);
@@ -1030,6 +1031,11 @@ func GetCursorPos() (float32, float32) {
 	return float32(x), float32(y)
 }
 func SetCursorPos(x, y float32) { C.obk_ig_set_cursor_pos(C.float(x), C.float(y)) }
+
+// Dummy submits an invisible item of size w×h, reserving layout space. After positioning
+// content by hand with SetCursorPos (e.g. grid cells), a trailing Dummy grows the parent's
+// content bounds so following items flow correctly and ImGui's boundary check is satisfied.
+func Dummy(w, h float32) { C.obk_ig_dummy(C.float(w), C.float(h)) }
 
 // SetNextWindowPos / SetNextWindowSize force the next Begin's window geometry — used by
 // in-window tests to put the viewport panel at a known rect so injected input lands on it.

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -647,6 +647,7 @@ void obk_ig_get_cursor_pos(float* x, float* y) {
     *y = p.y;
 }
 void obk_ig_set_cursor_pos(float x, float y)  { ImGui::SetCursorPos(ImVec2(x, y)); }
+void obk_ig_dummy(float w, float h)           { ImGui::Dummy(ImVec2(w, h)); }
 
 // image draws a previously-rendered texture (the 3D viewport color image) at the given
 // size; content_region_avail reports the free space in the current window so the

--- a/head/ui/addin_grid.go
+++ b/head/ui/addin_grid.go
@@ -1,0 +1,221 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"fmt"
+	"strconv"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+	"oblikovati.org/head/ui/gridlayout"
+)
+
+// Container rendering for the CSS-grid-like panel layout (ADR-0019). ImGui has no grid, so a
+// grid is laid out by hand: the pure gridlayout package resolves column pixel widths and flows
+// children into rows, then each cell is positioned with SetCursorPos and its content is width-
+// constrained to the cell. Rows are content-height (ADR-0020): a row's height is the tallest
+// cell, measured from the cursor after each cell's group. group and tabs are the simpler
+// containers built on the same recursion.
+
+const (
+	// groupIndent insets a group's children under its caption, like a QGroupBox frame.
+	groupIndent = 8
+	// autoColumnPadding pads a measured auto-column width past the bare text so the content
+	// isn't flush against the next column.
+	autoColumnPadding = 16
+)
+
+// drawGrid lays its children into the grid declared by control.Columns/ColumnGap/RowGap. With
+// no columns it degrades to a vertical stack.
+func drawGrid(s *app.Session, windowID string, control wire.PanelControlSpec) {
+	n := len(control.Columns)
+	if n == 0 {
+		drawControlList(s, windowID, control.Children)
+		return
+	}
+	rows := gridlayout.FlowRows(childCells(control.Children), n)
+	availW, _ := native.ContentRegionAvail()
+	widths := gridlayout.ResolveColumnWidths(control.Columns, float64(availW), control.ColumnGap,
+		measureAutoColumns(control, rows, n))
+	offsets := columnOffsets(widths, control.ColumnGap)
+
+	originX, originY := native.GetCursorPos()
+	y := layoutGridRows(s, windowID, control, rows, widths, offsets, originX, float64(originY))
+	// Leave the cursor below the whole grid, then submit a zero-size Dummy so ImGui grows the
+	// parent's content bounds to here — a bare SetCursorPos that extends the boundary without a
+	// following item trips ImGui's manual-layout assertion.
+	native.SetCursorPos(originX, float32(y))
+	native.Dummy(0, 0)
+}
+
+// layoutGridRows positions each row's cells absolutely, returning the y below the last row.
+// A row's height is its tallest cell (content-height auto-flow, ADR-0020), measured from the
+// cursor after each cell's group.
+func layoutGridRows(s *app.Session, windowID string, control wire.PanelControlSpec,
+	rows [][]gridlayout.Placement, widths, offsets []float64, originX float32, startY float64) float64 {
+	y := startY
+	for _, row := range rows {
+		bottom := y
+		for _, p := range row {
+			native.SetCursorPos(originX+float32(offsets[p.Col]), float32(y))
+			native.BeginGroup()
+			cellW := spanWidth(widths, control.ColumnGap, p.Col, p.ColSpan)
+			drawGridCell(s, windowID, p.Child, control.Children[p.Child], float32(cellW))
+			native.EndGroup()
+			if _, by := native.GetCursorPos(); float64(by) > bottom {
+				bottom = float64(by)
+			}
+		}
+		y = bottom + control.RowGap
+	}
+	return y
+}
+
+// childCells extracts each child's optional placement for the flow algorithm.
+func childCells(children []wire.PanelControlSpec) []*types.GridCell {
+	cells := make([]*types.GridCell, len(children))
+	for i := range children {
+		cells[i] = children[i].Cell
+	}
+	return cells
+}
+
+// columnOffsets is the left x of each column = prefix sum of widths and gaps.
+func columnOffsets(widths []float64, gap float64) []float64 {
+	offsets := make([]float64, len(widths))
+	x := 0.0
+	for i, w := range widths {
+		offsets[i] = x
+		x += w + gap
+	}
+	return offsets
+}
+
+// spanWidth is the pixel width a cell covers: its columns plus the gaps it bridges.
+func spanWidth(widths []float64, gap float64, col, span int) float64 {
+	if span < 1 {
+		span = 1
+	}
+	w := 0.0
+	for i := col; i < col+span && i < len(widths); i++ {
+		w += widths[i]
+	}
+	return w + gap*float64(span-1)
+}
+
+// measureAutoColumns measures each auto column's natural width as the widest text of the
+// single-span children placed in it (labels dominate auto columns), so a label column sizes to
+// its content rather than flexing. Non-auto columns get 0 (ignored by the resolver).
+func measureAutoColumns(control wire.PanelControlSpec, rows [][]gridlayout.Placement, n int) []float64 {
+	autoW := make([]float64, n)
+	for ci := 0; ci < n; ci++ {
+		if control.Columns[ci].Kind != types.GridTrackAuto {
+			continue
+		}
+		widest := 0.0
+		for _, row := range rows {
+			for _, p := range row {
+				if p.Col != ci || p.ColSpan != 1 {
+					continue
+				}
+				if w := float64(native.CalcTextWidth(control.Children[p.Child].Text)) + autoColumnPadding; w > widest {
+					widest = w
+				}
+			}
+		}
+		autoW[ci] = widest
+	}
+	return autoW
+}
+
+// drawGridCell renders one cell. Editable controls render bare (no stacked caption — the label
+// is a sibling cell) and width-constrained to the cell; everything else (labels, buttons,
+// checkboxes, nested containers) delegates to the ordinary control renderer.
+func drawGridCell(s *app.Session, windowID string, index int, control wire.PanelControlSpec, cellW float32) {
+	switch control.Kind {
+	case types.PanelTextBox, types.PanelValueEditor, types.PanelComboBox, types.PanelDropdown, types.PanelSlider:
+		native.PushIDInt(index)
+		defer native.PopID()
+		drawCellEditable(s, windowID, control, cellW)
+	default:
+		drawAddInPanelControl(s, windowID, index, control)
+	}
+}
+
+// drawCellEditable renders an editable control sized to cellW with a suppressed label.
+func drawCellEditable(s *app.Session, windowID string, control wire.PanelControlSpec, cellW float32) {
+	switch control.Kind {
+	case types.PanelTextBox, types.PanelValueEditor, types.PanelComboBox:
+		buf := panelBuffer(windowID+"/"+control.ID, control.Value)
+		native.SetNextItemWidth(cellW)
+		if native.InputText("##cell", buf) {
+			s.PanelValueChanged(windowID, control.ID, bufString(buf))
+		}
+	case types.PanelDropdown:
+		native.SetNextItemWidth(cellW)
+		if native.BeginCombo("##cell", control.Value) {
+			for _, opt := range control.Options {
+				if native.Selectable(opt, opt == control.Value) {
+					s.PanelValueChanged(windowID, control.ID, opt)
+				}
+			}
+			native.EndCombo()
+		}
+	case types.PanelSlider:
+		v, _ := strconv.ParseFloat(control.Value, 64)
+		f := float32(v)
+		native.SetNextItemWidth(cellW)
+		if native.SliderFloat("##cell", &f, float32(control.Min), float32(control.Max)) {
+			s.PanelValueChanged(windowID, control.ID, strconv.FormatFloat(float64(f), 'g', -1, 64))
+		}
+	}
+}
+
+// drawGroup renders a titled box: a caption separator over the children, indented like a frame.
+func drawGroup(s *app.Session, windowID string, control wire.PanelControlSpec) {
+	if control.Title != "" {
+		native.SeparatorText(control.Title)
+	}
+	native.Indent(groupIndent)
+	drawControlList(s, windowID, control.Children)
+	native.Unindent(groupIndent)
+}
+
+// drawTabs renders each child as a tab whose caption is the child's Title.
+func drawTabs(s *app.Session, windowID string, control wire.PanelControlSpec) {
+	if !native.BeginTabBar("##tabs") {
+		return
+	}
+	for i, pane := range control.Children {
+		native.PushIDInt(i)
+		if native.BeginTabItem(tabCaption(pane, i)) {
+			drawTabPane(s, windowID, pane)
+			native.EndTabItem()
+		}
+		native.PopID()
+	}
+	native.EndTabBar()
+}
+
+// tabCaption is a pane's tab label, falling back to a 1-based index when it has no Title.
+func tabCaption(pane wire.PanelControlSpec, i int) string {
+	if pane.Title != "" {
+		return pane.Title
+	}
+	return fmt.Sprintf("Tab %d", i+1)
+}
+
+// drawTabPane renders a pane's body. A group pane renders its children without repeating its
+// title (the tab already shows it); any other pane (e.g. a grid) renders normally.
+func drawTabPane(s *app.Session, windowID string, pane wire.PanelControlSpec) {
+	if pane.Kind == types.PanelGroup {
+		drawControlList(s, windowID, pane.Children)
+		return
+	}
+	drawAddInPanelControl(s, windowID, 0, pane)
+}

--- a/head/ui/addin_grid_inwindow_test.go
+++ b/head/ui/addin_grid_inwindow_test.go
@@ -1,0 +1,89 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"os"
+	"testing"
+
+	"oblikovati.org/api/client"
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// jobEditDemoControls is a faithful slice of FreeCAD's CAM Job Edit window built from the new
+// container vocabulary: a tab strip (Setup/General/Output) whose Setup pane stacks two grouped
+// grids — a 2-column [auto label | 1fr field] Stock form with a full-width spanning button, and
+// a 3-column Alignment button pad. It exercises tabs + group + grid + auto/fraction tracks +
+// column span together.
+func jobEditDemoControls() []wire.PanelControlSpec {
+	labelField := []types.GridTrack{client.TrackAuto(), client.TrackFr(1)}
+	stock := client.PanelGroup("stock", "Stock",
+		client.PanelGrid("stockform", labelField, 8, 4,
+			client.PanelLabel("ml", "Method"),
+			client.PanelDropdown("method", "", []string{"Box", "Cylinder", "Extend bbox", "Existing"}, "Extend bbox"),
+			client.PanelLabel("xl", "Ext X"), client.PanelTextBox("extx", "", "1.0 mm"),
+			client.PanelLabel("yl", "Ext Y"), client.PanelTextBox("exty", "", "1.0 mm"),
+			client.PanelLabel("zl", "Ext Z"), client.PanelTextBox("extz", "", "1.0 mm"),
+			client.PlaceAt(client.PanelButton("refresh", "Refresh stock", "CAM.Refresh"), 0, 2),
+		),
+	)
+	thirds := []types.GridTrack{client.TrackFr(1), client.TrackFr(1), client.TrackFr(1)}
+	align := client.PanelGroup("align", "Origin & Orientation",
+		client.PanelGrid("alignpad", thirds, 4, 4,
+			client.PanelButton("xaxis", "X-Axis", ""), client.PanelButton("yaxis", "Y-Axis", ""), client.PanelButton("zaxis", "Z-Axis", ""),
+			client.PanelButton("x0", "X=0", ""), client.PanelButton("y0", "Y=0", ""), client.PanelButton("z0", "Z=0", ""),
+		),
+	)
+	return []wire.PanelControlSpec{
+		client.PanelTabs("jobtabs",
+			client.PanelTab("Setup", stock, align),
+			client.PanelTab("General", client.PanelLabel("g", "Label · Model · Description · Machine")),
+			client.PanelTab("Output", client.PanelLabel("o", "Output file · Post Processor · WCS")),
+		),
+	}
+}
+
+// TestInWindowGridPanelScreenshot renders the demo Job Edit panel full-window in the live head
+// and writes a PNG of the whole window so the grid/group/tabs layout can be inspected. It also
+// proves the tree passes validation and renders without a crash. Skips without Vulkan.
+func TestInWindowGridPanelScreenshot(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+
+	s := app.NewSession()
+	spec := wire.DockableWindowSpec{ID: "job.edit", Title: "CAM Job Edit", Visible: true, Controls: jobEditDemoControls()}
+	if err := s.SetDockableWindow(spec); err != nil {
+		t.Fatalf("SetDockableWindow (validation): %v", err)
+	}
+
+	for i := 0; i < 3; i++ { // settle immediate-mode layout + tab selection
+		win.BeginFrame()
+		native.SetNextWindowPos(0, 0)
+		native.SetNextWindowSize(inWinW, inWinH)
+		visible, _ := native.BeginClosable("CAM Job Edit###addin-job.edit")
+		if visible {
+			drawControlList(s, "job.edit", spec.Controls)
+		}
+		native.End()
+		win.EndFrame(0.12, 0.12, 0.13)
+	}
+
+	out := os.Getenv("GRID_SHOT")
+	if out == "" {
+		out = "/tmp/grid_panel.png"
+	}
+	if err := win.SaveWindowPNG(out); err != nil {
+		t.Fatalf("SaveWindowPNG: %v", err)
+	}
+	if fi, err := os.Stat(out); err != nil || fi.Size() == 0 {
+		t.Fatalf("screenshot not written: %v", err)
+	}
+	t.Logf("grid panel screenshot written to %s", out)
+}

--- a/head/ui/addin_panels.go
+++ b/head/ui/addin_panels.go
@@ -64,9 +64,7 @@ func drawAddInPanel(s *app.Session, spec wire.DockableWindowSpec) {
 	applyInitialDock(spec.Dock)
 	visible, open := native.BeginClosable(spec.Title + "###addin-" + spec.ID)
 	if visible {
-		for i, control := range spec.Controls {
-			drawAddInPanelControl(s, spec.ID, i, control)
-		}
+		drawControlList(s, spec.ID, spec.Controls)
 	}
 	native.End()
 	if !open {
@@ -106,12 +104,41 @@ func panelBuffer(key, value string) []byte {
 	return buf
 }
 
+// drawControlList renders a vertical run of controls — a panel body, or a group/tab pane.
+// Each control's index joins the id stack (in drawAddInPanelControl) so nested controls get
+// collision-free ImGui ids from their structural path while keeping their flat logical ID.
+func drawControlList(s *app.Session, windowID string, controls []wire.PanelControlSpec) {
+	for i, control := range controls {
+		drawAddInPanelControl(s, windowID, i, control)
+	}
+}
+
+// drawPanelContainer renders the container kinds (grid/group/tabs, ADR-0019), which recurse
+// into their Children, and reports whether control was one — keeping the leaf dispatch in
+// drawAddInPanelControl simple.
+func drawPanelContainer(s *app.Session, windowID string, control wire.PanelControlSpec) bool {
+	switch control.Kind {
+	case types.PanelGrid:
+		drawGrid(s, windowID, control)
+	case types.PanelGroup:
+		drawGroup(s, windowID, control)
+	case types.PanelTabs:
+		drawTabs(s, windowID, control)
+	default:
+		return false
+	}
+	return true
+}
+
 // drawAddInPanelControl renders one declared control by kind, pushing edits back to the owning
 // add-in via Session.PanelValueChanged. The index joins the id stack so two controls never
-// collide.
+// collide. Container kinds (grid/group/tabs, ADR-0019) recurse into their Children.
 func drawAddInPanelControl(s *app.Session, windowID string, index int, control wire.PanelControlSpec) {
 	native.PushIDInt(index)
 	defer native.PopID()
+	if drawPanelContainer(s, windowID, control) || drawEditableControl(s, windowID, control) {
+		return
+	}
 	switch control.Kind {
 	case types.PanelButton:
 		if native.Button(control.Text) && control.CommandID != "" {
@@ -121,6 +148,21 @@ func drawAddInPanelControl(s *app.Session, windowID string, index int, control w
 		}
 	case types.PanelSeparator:
 		native.Separator()
+	default: // PanelLabel renders its text. A future unknown CONTAINER kind degrades to a
+		// vertical stack of its children rather than vanishing; a leaf degrades to its text.
+		if len(control.Children) > 0 {
+			drawControlList(s, windowID, control.Children)
+		} else {
+			native.TextWrapped(control.Text)
+		}
+	}
+}
+
+// drawEditableControl renders the editable control kinds with the stacked-caption layout
+// (#1490) and reports whether control was one, keeping the leaf dispatch small. Edits push back
+// through Session.PanelValueChanged.
+func drawEditableControl(s *app.Session, windowID string, control wire.PanelControlSpec) bool {
+	switch control.Kind {
 	case types.PanelTextBox, types.PanelValueEditor, types.PanelComboBox:
 		buf := panelBuffer(windowID+"/"+control.ID, control.Value)
 		panelFieldLabel(control.Text)
@@ -135,14 +177,21 @@ func drawAddInPanelControl(s *app.Session, windowID string, index int, control w
 	case types.PanelDropdown:
 		drawPanelDropdown(s, windowID, control)
 	case types.PanelSlider:
-		v, _ := strconv.ParseFloat(control.Value, 64)
-		f := float32(v)
-		panelFieldLabel(control.Text)
-		if native.SliderFloat("##field", &f, float32(control.Min), float32(control.Max)) {
-			s.PanelValueChanged(windowID, control.ID, strconv.FormatFloat(float64(f), 'g', -1, 64))
-		}
-	default: // PanelLabel (and any future kind degrades to its text)
-		native.TextWrapped(control.Text)
+		drawPanelSlider(s, windowID, control)
+	default:
+		return false
+	}
+	return true
+}
+
+// drawPanelSlider renders a bounded numeric slider with its caption stacked above (#1490),
+// pushing the new value to the add-in on change.
+func drawPanelSlider(s *app.Session, windowID string, control wire.PanelControlSpec) {
+	v, _ := strconv.ParseFloat(control.Value, 64)
+	f := float32(v)
+	panelFieldLabel(control.Text)
+	if native.SliderFloat("##field", &f, float32(control.Min), float32(control.Max)) {
+		s.PanelValueChanged(windowID, control.ID, strconv.FormatFloat(float64(f), 'g', -1, 64))
 	}
 }
 

--- a/head/ui/gridlayout/gridlayout.go
+++ b/head/ui/gridlayout/gridlayout.go
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package gridlayout is the pure, headless-testable math behind the CSS-grid-like panel
+// container (ADR-0019, ADR-0020): resolving column-track pixel widths against an available
+// width, and flowing children into rows. It is deliberately free of cgo/ImGui so the
+// algorithm — where the bugs live — is unit-tested without a windowed build; the cgo
+// renderer in package ui measures auto-column content (via CalcTextWidth), then calls this.
+package gridlayout
+
+import "oblikovati.org/api/types"
+
+// defaultAutoWidth is the fallback width for an auto column whose content could not be
+// measured (the renderer passes 0). Wide enough for a short label.
+const defaultAutoWidth = 80.0
+
+// ResolveColumnWidths returns the pixel width of each column track. Fixed tracks take their
+// Value; auto tracks take their measured content width (autoWidths[i], or defaultAutoWidth
+// when 0); fraction tracks split the leftover space — after fixed/auto and the inter-column
+// gaps are removed — in proportion to their weight. Every width is clamped to the track's
+// [MinPx, MaxPx] (0 = unbounded) and floored at 0. autoWidths may be nil.
+func ResolveColumnWidths(cols []types.GridTrack, avail, colGap float64, autoWidths []float64) []float64 {
+	n := len(cols)
+	widths := make([]float64, n)
+	if n == 0 {
+		return widths
+	}
+	leftover := avail - colGap*float64(n-1)
+	frWeight := resolveSizedTracks(cols, autoWidths, widths, &leftover)
+	if frWeight > 0 {
+		resolveFractionTracks(cols, widths, leftover, frWeight)
+	}
+	for i := range widths {
+		if widths[i] < 0 {
+			widths[i] = 0
+		}
+	}
+	return widths
+}
+
+// resolveSizedTracks fills the fixed and auto column widths (subtracting each from leftover)
+// and returns the total fraction weight left for resolveFractionTracks to distribute.
+func resolveSizedTracks(cols []types.GridTrack, autoWidths, widths []float64, leftover *float64) float64 {
+	var frWeight float64
+	for i, t := range cols {
+		switch t.Kind {
+		case types.GridTrackFixed:
+			widths[i] = clampTrack(t, t.Value)
+			*leftover -= widths[i]
+		case types.GridTrackAuto:
+			widths[i] = clampTrack(t, autoOrDefault(autoWidths, i))
+			*leftover -= widths[i]
+		case types.GridTrackFraction:
+			frWeight += fractionWeight(t)
+		}
+	}
+	return frWeight
+}
+
+// resolveFractionTracks splits leftover across the fraction columns by weight.
+func resolveFractionTracks(cols []types.GridTrack, widths []float64, leftover, frWeight float64) {
+	for i, t := range cols {
+		if t.Kind == types.GridTrackFraction {
+			widths[i] = clampTrack(t, leftover*fractionWeight(t)/frWeight)
+		}
+	}
+}
+
+// autoOrDefault is the measured width of auto column i, or defaultAutoWidth when unmeasured.
+func autoOrDefault(autoWidths []float64, i int) float64 {
+	if autoWidths != nil && autoWidths[i] > 0 {
+		return autoWidths[i]
+	}
+	return defaultAutoWidth
+}
+
+// fractionWeight reads a fraction track's weight, treating a non-positive weight as 1 so a
+// bare TrackFr()/auto-flex column still claims an equal share.
+func fractionWeight(t types.GridTrack) float64 {
+	if t.Value <= 0 {
+		return 1
+	}
+	return t.Value
+}
+
+// clampTrack bounds w to the track's [MinPx, MaxPx] (0 = unset).
+func clampTrack(t types.GridTrack, w float64) float64 {
+	if t.MinPx > 0 && w < t.MinPx {
+		w = t.MinPx
+	}
+	if t.MaxPx > 0 && w > t.MaxPx {
+		w = t.MaxPx
+	}
+	return w
+}
+
+// Placement is one child positioned in a grid row: which child (index into the original
+// children slice), its starting column, and how many columns it spans.
+type Placement struct {
+	Child   int
+	Col     int
+	ColSpan int
+}
+
+// FlowRows assigns each child to a row and column. cells[i] is child i's optional placement
+// (nil = auto-flow). Auto-flow fills left-to-right, wrapping when the next child's span would
+// overrun nCols. A cell with ColSpan>1 keeps its span (wrapping to a fresh row if it doesn't
+// fit). A cell with an explicit Col>0 is placed at that column on its own row — the common
+// "put this at column k" case — without the bookkeeping of arbitrary 2-D packing (deferred
+// with row span, ADR-0020).
+func FlowRows(cells []*types.GridCell, nCols int) [][]Placement {
+	if nCols < 1 {
+		nCols = 1
+	}
+	f := &rowFlow{cols: nCols}
+	for i := range cells {
+		span, explicitCol := readCell(cells[i], nCols)
+		f.place(i, span, explicitCol)
+	}
+	f.flush()
+	return f.rows
+}
+
+// rowFlow accumulates placements into rows as children are visited left-to-right.
+type rowFlow struct {
+	rows [][]Placement
+	cur  []Placement
+	col  int
+	cols int
+}
+
+// flush ends the current row if it holds anything.
+func (f *rowFlow) flush() {
+	if len(f.cur) > 0 {
+		f.rows = append(f.rows, f.cur)
+		f.cur = nil
+		f.col = 0
+	}
+}
+
+// place positions child i: an explicit column takes its own row; otherwise the child auto-flows
+// into the current row, wrapping when its span no longer fits.
+func (f *rowFlow) place(child, span, explicitCol int) {
+	if explicitCol >= 0 {
+		f.flush()
+		f.rows = append(f.rows, []Placement{{Child: child, Col: clampCol(explicitCol, span, f.cols), ColSpan: span}})
+		return
+	}
+	if f.col+span > f.cols {
+		f.flush()
+	}
+	f.cur = append(f.cur, Placement{Child: child, Col: f.col, ColSpan: span})
+	f.col += span
+	if f.col >= f.cols {
+		f.flush()
+	}
+}
+
+// readCell extracts (span, explicitCol) from a cell. span is clamped to [1, nCols]. An
+// explicit column is only honored when Col>0 (Col 0 is indistinguishable from auto-flow's
+// natural start and so flows); explicitCol is -1 when the child should auto-flow.
+func readCell(c *types.GridCell, nCols int) (span, explicitCol int) {
+	span, explicitCol = 1, -1
+	if c == nil {
+		return
+	}
+	if c.ColSpan > 1 {
+		span = c.ColSpan
+	}
+	if span > nCols {
+		span = nCols
+	}
+	if c.Col > 0 {
+		explicitCol = c.Col
+	}
+	return
+}
+
+// clampCol keeps an explicit column within the grid so col+span never overruns nCols.
+func clampCol(col, span, nCols int) int {
+	if col+span > nCols {
+		col = nCols - span
+	}
+	if col < 0 {
+		col = 0
+	}
+	return col
+}

--- a/head/ui/gridlayout/gridlayout_test.go
+++ b/head/ui/gridlayout/gridlayout_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package gridlayout
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+)
+
+func fixed(px float64) types.GridTrack { return types.GridTrack{Kind: types.GridTrackFixed, Value: px} }
+func fr(w float64) types.GridTrack     { return types.GridTrack{Kind: types.GridTrackFraction, Value: w} }
+func auto() types.GridTrack            { return types.GridTrack{Kind: types.GridTrackAuto} }
+
+func eq(t *testing.T, got []float64, want ...float64) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if d := got[i] - want[i]; d > 0.01 || d < -0.01 {
+			t.Errorf("col %d = %.2f, want %.2f", i, got[i], want[i])
+		}
+	}
+}
+
+func TestResolveFixed(t *testing.T) {
+	eq(t, ResolveColumnWidths([]types.GridTrack{fixed(100), fixed(50)}, 300, 0, nil), 100, 50)
+}
+
+func TestResolveFixedPlusFraction(t *testing.T) {
+	eq(t, ResolveColumnWidths([]types.GridTrack{fixed(100), fr(1)}, 300, 0, nil), 100, 200)
+}
+
+func TestResolveFractionsByWeight(t *testing.T) {
+	eq(t, ResolveColumnWidths([]types.GridTrack{fr(1), fr(2)}, 300, 0, nil), 100, 200)
+}
+
+func TestResolveAutoUsesMeasuredWidth(t *testing.T) {
+	eq(t, ResolveColumnWidths([]types.GridTrack{auto(), fr(1)}, 300, 0, []float64{80, 0}), 80, 220)
+}
+
+func TestResolveSubtractsGaps(t *testing.T) {
+	eq(t, ResolveColumnWidths([]types.GridTrack{fr(1), fr(1)}, 300, 20, nil), 140, 140)
+}
+
+func TestResolveClampsMax(t *testing.T) {
+	capped := fr(1)
+	capped.MaxPx = 50
+	eq(t, ResolveColumnWidths([]types.GridTrack{capped, fr(1)}, 300, 0, nil), 50, 150)
+}
+
+// cells builds a placement slice: -1 colSpan means "no cell" (auto-flow).
+func cells(specs ...[2]int) []*types.GridCell {
+	out := make([]*types.GridCell, len(specs))
+	for i, s := range specs {
+		if s[1] < 0 {
+			continue // nil = auto-flow
+		}
+		out[i] = &types.GridCell{Col: s[0], ColSpan: s[1]}
+	}
+	return out
+}
+
+func TestFlowAutoWraps(t *testing.T) {
+	rows := FlowRows(cells([2]int{0, -1}, [2]int{0, -1}, [2]int{0, -1}, [2]int{0, -1}), 2)
+	if len(rows) != 2 || len(rows[0]) != 2 || rows[1][0].Child != 2 || rows[1][1].Col != 1 {
+		t.Fatalf("auto-flow rows = %+v", rows)
+	}
+}
+
+func TestFlowSpanWrapsToOwnRow(t *testing.T) {
+	// a (span1), b (span2 — can't fit beside a in 2 cols), c (span1).
+	rows := FlowRows(cells([2]int{0, -1}, [2]int{0, 2}, [2]int{0, -1}), 2)
+	if len(rows) != 3 {
+		t.Fatalf("want 3 rows, got %+v", rows)
+	}
+	if rows[1][0].ColSpan != 2 || rows[1][0].Child != 1 {
+		t.Errorf("span row = %+v", rows[1])
+	}
+}
+
+func TestFlowExplicitColGetsOwnRow(t *testing.T) {
+	rows := FlowRows(cells([2]int{0, -1}, [2]int{1, 1}), 2)
+	if len(rows) != 2 || rows[1][0].Col != 1 || rows[1][0].Child != 1 {
+		t.Fatalf("explicit-col rows = %+v", rows)
+	}
+}


### PR DESCRIPTION
## What

Implements the **host half** of the panel-nesting contract (Oblikovati.API#218, api v0.96.0): the head now renders `grid`/`group`/`tabs` containers, so add-ins and native panels can build complex window layouts. ImGui has no grid, so a grid is laid out by hand.

- **head/ui/gridlayout** — pure, headless-tested layout math: resolve column-track pixel widths (fixed/auto/fraction + minmax) against the available width, and flow children into rows honoring column span.
- **head/ui/addin_grid.go** — the cgo renderer: measure `auto` columns via `CalcTextWidth`, position each cell with `SetCursorPos`, width-constrain cell content; `group` is a titled stack, `tabs` a `BeginTabBar` strip. `addin_panels.go` recurses into `Children` and degrades an unknown container to a vertical stack.
- **app** — validate the control tree on `dockableWindows.set` (depth bound; reject reserved `RowSpan>1`) and update edited control values **recursively**, so a deeply nested grid field's edit is recorded (the old flat loop only updated top-level controls — a real bug).
- **native** — add a `Dummy(w,h)` wrapper so a hand-positioned grid can grow the parent's content bounds (ImGui asserts otherwise).

## Why

The motivating case is replicating FreeCAD's tabbed CAM Job Edit window faithfully — impossible with a flat control list. `grid`+`group`+`tabs` is the foundational mechanism; `table`/`tree` are cheap additive follow-ons.

## Verification

Live-verified: a `tabs`+`group`+`grid` Job-Edit slice renders correctly to a full-window screenshot (auto-label / fraction-field columns, full-width spanning button, 3-column button pad). Pure layout math unit-tested headlessly; existing #1490 stacked-label guard preserved.

Closes the host side of the grid-layout primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)