### PR TITLE
feat(browser): add-in pane node icons and right-click context menus

### DIFF
--- a/addin/events/events.go
+++ b/addin/events/events.go
@@ -223,7 +223,7 @@ func subscribeUISurfaces(bus *event.Bus, sink Sink) []event.Subscription {
 	subs := []event.Subscription{
 		event.Subscribe(bus, event.After, func(_ event.Context, e app.BrowserPaneNodeActivated) event.Outcome {
 			return relayJSON(sink, wire.BrowserNodeEvent{
-				Type: wire.EventBrowserNode, Pane: e.Pane, Node: e.Node, Gesture: e.Gesture,
+				Type: wire.EventBrowserNode, Pane: e.Pane, Node: e.Node, Gesture: e.Gesture, MenuItem: e.MenuItem,
 			})
 		}),
 		event.Subscribe(bus, event.After, func(_ event.Context, e app.DockableWindowChanged) event.Outcome {

--- a/app/browser_panes.go
+++ b/app/browser_panes.go
@@ -18,9 +18,10 @@ import (
 // pane node; the events relay forwards it as a wire browser.node push event.
 // Gesture is one of the BrowserGesture* constants.
 type BrowserPaneNodeActivated struct {
-	Pane    string
-	Node    string
-	Gesture string
+	Pane     string
+	Node     string
+	Gesture  string
+	MenuItem string // chosen context-menu item id (Gesture BrowserGestureMenu)
 }
 
 // EventID implements event.Event.
@@ -32,6 +33,7 @@ const (
 	BrowserGestureDouble   = "double"
 	BrowserGestureExpand   = "expand"
 	BrowserGestureCollapse = "collapse"
+	BrowserGestureMenu     = "menu"
 )
 
 // AddInBrowserPanes stores the declared panes in creation order.
@@ -97,5 +99,18 @@ func (s *Session) ActivateBrowserPaneNode(pane, node, gesture string) error {
 		return fmt.Errorf("app: unknown browser gesture %q (select/double/expand/collapse)", gesture)
 	}
 	event.Emit(s.bus, event.After, BrowserPaneNodeActivated{Pane: pane, Node: node, Gesture: gesture})
+	return nil
+}
+
+// ActivateBrowserPaneNodeMenu reports that the user chose context-menu item menuItem on an
+// add-in pane node — the head calls it from the node's right-click menu; the owning add-in
+// receives it as a browser.node event with Gesture "menu" and the item id. Unknown panes error.
+func (s *Session) ActivateBrowserPaneNodeMenu(pane, node, menuItem string) error {
+	if _, ok := s.browserPanes.panes[pane]; !ok {
+		return fmt.Errorf("app: no browser pane %q", pane)
+	}
+	event.Emit(s.bus, event.After, BrowserPaneNodeActivated{
+		Pane: pane, Node: node, Gesture: BrowserGestureMenu, MenuItem: menuItem,
+	})
 	return nil
 }

--- a/app/browser_panes_test.go
+++ b/app/browser_panes_test.go
@@ -50,6 +50,30 @@ func TestBrowserPaneRejectsMissingIdentity(t *testing.T) {
 	}
 }
 
+// TestActivateBrowserPaneNodeMenuEmitsItem checks a context-menu choice reaches the add-in as a
+// "menu" gesture carrying the chosen item id.
+func TestActivateBrowserPaneNodeMenuEmitsItem(t *testing.T) {
+	s := NewSession()
+	if err := s.BrowserPanes().Set(simPane()); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	var got []BrowserPaneNodeActivated
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e BrowserPaneNodeActivated) event.Outcome {
+		got = append(got, e)
+		return event.Continue()
+	})
+
+	if err := s.ActivateBrowserPaneNodeMenu("sim", "f1", "edit"); err != nil {
+		t.Fatalf("ActivateBrowserPaneNodeMenu: %v", err)
+	}
+	if len(got) != 1 || got[0].Gesture != BrowserGestureMenu || got[0].MenuItem != "edit" {
+		t.Fatalf("events = %+v, want one menu gesture with item edit", got)
+	}
+	if err := s.ActivateBrowserPaneNodeMenu("ghost", "f1", "edit"); err == nil {
+		t.Error("unknown pane should error")
+	}
+}
+
 func TestActivateBrowserPaneNodeEmitsEvent(t *testing.T) {
 	s := NewSession()
 	if err := s.BrowserPanes().Set(simPane()); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.96.0
+	oblikovati.org/api v0.97.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.96.0
+	oblikovati.org/api v0.97.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/ui/browser_addin_inwindow_test.go
+++ b/head/ui/browser_addin_inwindow_test.go
@@ -1,0 +1,76 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"os"
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// camPaneSvg is a sentinel-coloured glyph (the ribbon convention: #00ff00 backplate, #000
+// primary, #ff0000 accent) so the rasterised node icon is themed like a document icon.
+const camPaneSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="1" width="22" height="22" rx="4" fill="#00ff00" stroke="none"/><rect x="5" y="7" width="10" height="10" rx="1"/><path d="M17 5 V9 M15 7 H19" stroke="#ff0000"/></svg>`
+
+// camDemoPane is a faithful CAM Job tree: a Job node with icons and per-node right-click menus,
+// nesting Stock and an Operations branch.
+func camDemoPane() wire.BrowserPaneSpec {
+	menu := []wire.BrowserMenuItem{{ID: "edit", Label: "Edit…"}, {ID: "del", Label: "Delete"}}
+	return wire.BrowserPaneSpec{ID: "cam", Title: "CAM", Nodes: []wire.BrowserNodeSpec{{
+		ID: "job", Label: "Job", IconSVG: camPaneSvg, Expanded: true, Menu: menu,
+		Children: []wire.BrowserNodeSpec{
+			{ID: "stock", Label: "Stock", IconSVG: camPaneSvg, Menu: menu},
+			{ID: "ops", Label: "Operations", IconSVG: camPaneSvg, Expanded: true, Children: []wire.BrowserNodeSpec{
+				{ID: "profile", Label: "Profile", IconSVG: camPaneSvg, Menu: menu},
+				{ID: "pocket", Label: "Pocket", IconSVG: camPaneSvg, Menu: menu},
+			}},
+		},
+	}}}
+}
+
+// TestInWindowCamBrowserPaneScreenshot renders the CAM browser pane (icons + nested tree) full
+// window and writes a PNG so the document-style node icons can be inspected. Proves the pane
+// renders without a crash. Skips without Vulkan.
+func TestInWindowCamBrowserPaneScreenshot(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+
+	s := app.NewSession()
+	if err := s.BrowserPanes().Set(camDemoPane()); err != nil {
+		t.Fatalf("Set pane: %v", err)
+	}
+	icons = newIconCache(win) // bind the icon cache to this fresh window/context so glyphs rasterise
+
+	for i := 0; i < 3; i++ {
+		win.BeginFrame()
+		native.SetNextWindowPos(0, 0)
+		native.SetNextWindowSize(inWinW, inWinH)
+		if vis, _ := native.BeginClosable("CAM##browser"); vis {
+			browserNodeSeq = 0
+			for _, n := range camDemoPane().Nodes { // render the CAM pane nodes directly (skip the Model tab)
+				drawAddInPaneNode(s, "cam", n)
+			}
+		}
+		native.End()
+		win.EndFrame(0.12, 0.12, 0.13)
+	}
+
+	out := os.Getenv("CAM_PANE_SHOT")
+	if out == "" {
+		out = "/tmp/cam_pane.png"
+	}
+	if err := win.SaveWindowPNG(out); err != nil {
+		t.Fatalf("SaveWindowPNG: %v", err)
+	}
+	if fi, err := os.Stat(out); err != nil || fi.Size() == 0 {
+		t.Fatalf("screenshot not written: %v", err)
+	}
+	t.Logf("CAM browser pane screenshot written to %s", out)
+}

--- a/head/ui/browser_addin_inwindow_test.go
+++ b/head/ui/browser_addin_inwindow_test.go
@@ -10,6 +10,7 @@ import (
 
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
+	"oblikovati.org/event"
 	"oblikovati.org/head/internal/native"
 )
 
@@ -73,4 +74,80 @@ func TestInWindowCamBrowserPaneScreenshot(t *testing.T) {
 		t.Fatalf("screenshot not written: %v", err)
 	}
 	t.Logf("CAM browser pane screenshot written to %s", out)
+}
+
+// TestInWindowCamPaneNodeContextMenu drives a real right-click on a pane node to open its
+// context menu and clicks the first item, asserting the chosen item reaches the session as a
+// "menu" gesture — the per-node right-click path (drawAddInNodeMenu). Skips without Vulkan.
+func TestInWindowCamPaneNodeContextMenu(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+
+	s := app.NewSession()
+	if err := s.BrowserPanes().Set(camDemoPane()); err != nil {
+		t.Fatalf("Set pane: %v", err)
+	}
+	icons = newIconCache(win)
+
+	var events []app.BrowserPaneNodeActivated
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e app.BrowserPaneNodeActivated) event.Outcome {
+		events = append(events, e)
+		return event.Continue()
+	})
+	gotMenu := func() bool {
+		for _, e := range events {
+			if e.Gesture == app.BrowserGestureMenu {
+				return true
+			}
+		}
+		return false
+	}
+
+	frame := func() {
+		win.BeginFrame()
+		native.SetNextWindowPos(0, 0)
+		native.SetNextWindowSize(inWinW, inWinH)
+		if vis, _ := native.BeginClosable("CAM##menu"); vis {
+			browserNodeSeq = 0
+			for _, n := range camDemoPane().Nodes {
+				drawAddInPaneNode(s, "cam", n)
+			}
+		}
+		native.End()
+		win.EndFrame(0.1, 0.1, 0.1)
+	}
+
+	// The "Job" root row sits just under the window title bar: its icon is far left, its label
+	// to the right. Click the icon (covers the icon-click select path).
+	native.InjectMousePos(20, 42)
+	frame()
+	frame()
+	native.InjectMouseButton(native.MouseLeft, true)
+	frame()
+	native.InjectMouseButton(native.MouseLeft, false)
+	frame()
+
+	// Right-click the row to open its context menu, then scan a small region for the first item
+	// (the popup opens at the cursor; exact item pixel varies with ImGui metrics).
+	rx, ry := float32(80), float32(42)
+	native.InjectMousePos(rx, ry)
+	frame()
+	native.InjectMouseButton(native.MouseRight, true)
+	frame()
+	native.InjectMouseButton(native.MouseRight, false)
+	frame()
+	for dy := float32(8); dy <= 40 && !gotMenu(); dy += 6 {
+		native.InjectMousePos(rx+12, ry+dy)
+		frame()
+		native.InjectMouseButton(native.MouseLeft, true)
+		frame()
+		native.InjectMouseButton(native.MouseLeft, false)
+		frame()
+	}
+
+	if !gotMenu() {
+		t.Fatal("right-click context-menu item did not reach the session as a menu gesture")
+	}
 }

--- a/head/ui/browser_view.go
+++ b/head/ui/browser_view.go
@@ -83,18 +83,59 @@ func drawAddInPaneNode(s *app.Session, paneID string, n wire.BrowserNodeSpec) {
 	native.PushID("addin-node-" + n.ID)
 	defer native.PopID()
 	if len(n.Children) == 0 {
+		drawAddInNodeIcon(s, paneID, n)
 		if native.Selectable(n.Label, false) {
 			_ = s.ActivateBrowserPaneNode(paneID, n.ID, app.BrowserGestureSelect)
 		}
 		reportDoubleClick(s, paneID, n.ID)
+		drawAddInNodeMenu(s, paneID, n)
 		return
 	}
 	drawAddInPaneBranch(s, paneID, n)
 }
 
+// drawAddInNodeIcon rasterises a node's inline themed glyph (BrowserNodeSpec.IconSVG) beside the
+// label, like a document-tree node icon — clicking it selects the node. Nodes without a glyph
+// draw nothing. The cache key is the node id (its svg also keys the texture, so re-skins update).
+func drawAddInNodeIcon(s *app.Session, paneID string, n wire.BrowserNodeSpec) {
+	if n.IconSVG == "" || icons == nil {
+		return
+	}
+	tex, ok := icons.texture("addin/"+paneID+"/"+n.ID, n.IconSVG, browserIconPx)
+	if !ok {
+		return
+	}
+	if native.ImageButton("##nodeicon", tex, browserIconPx, browserIconPx, identityTint) {
+		_ = s.ActivateBrowserPaneNode(paneID, n.ID, app.BrowserGestureSelect)
+	}
+	native.SameLine()
+	m := native.Metrics()
+	x, y := native.GetCursorScreenPos()
+	native.SetCursorScreenPos(x, y+(browserIconPx+2*m.FramePadY-native.TextLineHeight())/2)
+}
+
+// drawAddInNodeMenu opens the node's right-click context menu (BrowserNodeSpec.Menu); choosing an
+// item reports it to the owning add-in as a "menu" gesture carrying the item id. Nodes with no
+// menu draw nothing.
+func drawAddInNodeMenu(s *app.Session, paneID string, n wire.BrowserNodeSpec) {
+	if len(n.Menu) == 0 {
+		return
+	}
+	if !native.BeginPopupContextItem("##addin-menu-" + n.ID) {
+		return
+	}
+	for _, it := range n.Menu {
+		if native.MenuItemEx(it.Label, "", !it.Disabled) {
+			_ = s.ActivateBrowserPaneNodeMenu(paneID, n.ID, it.ID)
+		}
+	}
+	native.EndPopup()
+}
+
 // drawAddInPaneBranch renders a parent node, reporting expand/collapse and select
 // gestures, and recurses into its children while open.
 func drawAddInPaneBranch(s *app.Session, paneID string, n wire.BrowserNodeSpec) {
+	drawAddInNodeIcon(s, paneID, n) // before SetNextItemOpen, so the open-state targets the TreeNode, not the icon
 	if n.Expanded {
 		native.SetNextItemOpen(true, true)
 	}
@@ -110,6 +151,7 @@ func drawAddInPaneBranch(s *app.Session, paneID string, n wire.BrowserNodeSpec) 
 		_ = s.ActivateBrowserPaneNode(paneID, n.ID, app.BrowserGestureSelect)
 	}
 	reportDoubleClick(s, paneID, n.ID)
+	drawAddInNodeMenu(s, paneID, n)
 	if !open {
 		return
 	}


### PR DESCRIPTION
## What

Renders the host half of the browser-node extension (Oblikovati.API#219, api v0.97.0) so an add-in browser-pane node looks and behaves like a built-in document-tree node — the prerequisite for a faithful CAM Job tree.

- **head** — `drawAddInNodeIcon` rasterises a node's inline themed glyph (`BrowserNodeSpec.IconSVG`, the ribbon's sentinel-colour convention) beside the label, on both leaf and branch nodes. `drawAddInNodeMenu` opens the node's right-click context menu (`BrowserNodeSpec.Menu`) and reports the chosen item.
- **app** — `ActivateBrowserPaneNodeMenu` emits a `"menu"` gesture carrying the item id; `BrowserPaneNodeActivated` + the events relay carry `MenuItem` through to the add-in's `browser.node` wire event.

## Why

Requested: add-in nodes with icons "like the document does" + per-node right-click actions (Edit / Delete / Duplicate / Move…). The document tree already does both; this gives add-in panes parity, so the CAM add-in can present a Job ▸ Stock / Operations tree.

## Verification

Live-verified: a `Job ▸ Stock / Operations ▸ Profile/Pocket` tree renders with themed node icons and correct nesting to a window screenshot. Menu-event flow unit-tested at the app layer (`ActivateBrowserPaneNodeMenu` → `"menu"` gesture + item id). Note: the branch icon draws *before* `SetNextItemOpen` so the open-state still targets the tree node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)