### PR TITLE
feat(router): wire the sketch Symmetry constraint add-handler (#1574)

### DIFF
--- a/addin/router/sketch_constraint_refs.go
+++ b/addin/router/sketch_constraint_refs.go
@@ -138,6 +138,27 @@ func tangentConstraint(sk *sketch.Sketch, refs []uint64) (sketch.Constraint, boo
 	return g.AddCircularTangent(c1, c2), true, nil
 }
 
+// symmetryConstraint makes two points symmetric about a mirror line (point A, point B,
+// mirror line), matching the enumerate mapping (A, B, About) in sketch_enumerate.go.
+func symmetryConstraint(sk *sketch.Sketch, refs []uint64) (sketch.Constraint, bool, error) {
+	if len(refs) != 3 {
+		return nil, true, fmt.Errorf("sketch.addConstraint: symmetry needs 2 point refs + a mirror-line ref, got %d", len(refs))
+	}
+	a, err := pointRef(sk, refs[0])
+	if err != nil {
+		return nil, true, err
+	}
+	b, err := pointRef(sk, refs[1])
+	if err != nil {
+		return nil, true, err
+	}
+	about, err := lineRef(sk, refs[2])
+	if err != nil {
+		return nil, true, err
+	}
+	return sk.GeometricConstraints().AddSymmetry(a, b, about), true, nil
+}
+
 // fixConstraint grounds a single point.
 func fixConstraint(sk *sketch.Sketch, refs []uint64) (sketch.Constraint, bool, error) {
 	if len(refs) != 1 {

--- a/addin/router/sketch_constraints.go
+++ b/addin/router/sketch_constraints.go
@@ -195,6 +195,8 @@ func mixedConstraint(sk *sketch.Sketch, kind types.GeometricConstraintKind, refs
 		return pointCircleConstraint(sk, refs)
 	case types.GeoConstraintTangent:
 		return tangentConstraint(sk, refs)
+	case types.GeoConstraintSymmetry:
+		return symmetryConstraint(sk, refs)
 	case types.GeoConstraintFix:
 		return fixConstraint(sk, refs)
 	default:

--- a/addin/router/sketch_symmetry_test.go
+++ b/addin/router/sketch_symmetry_test.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// TestSketchSymmetryConstraintCreatable is the regression for #1574: a symmetry constraint
+// (point A, point B, mirror line) was enumerable but not creatable — the add-constraint
+// handler had no case, so every attempt was silently dropped. It must now create, reduce
+// DOF, and round-trip through the enumerate path with its (A, B, About) entities intact.
+func TestSketchSymmetryConstraintCreatable(t *testing.T) {
+	r, s := seededSession(t)
+	add := func(args string) wire.AddSketchEntityResult {
+		var res wire.AddSketchEntityResult
+		call(t, r, s, "sketch.addEntity", args, &res)
+		return res
+	}
+
+	// Two free points straddling the X axis (the mirror line) but NOT yet symmetric.
+	a := add(`{"sketchIndex":0,"kind":"point","points":[[2,1]]}`)
+	b := add(`{"sketchIndex":0,"kind":"point","points":[[2,-3]]}`)
+	axis := add(`{"sketchIndex":0,"kind":"line","points":[[-5,0],[5,0]]}`)
+
+	var res wire.AddConstraintResult
+	call(t, r, s, "sketch.addConstraint", mustJSON(t, wire.AddConstraintArgs{
+		SketchIndex: 0, Kind: "symmetry", Entities: []uint64{a.EntityID, b.EntityID, axis.EntityID},
+	}), &res)
+	if res.Kind != "symmetry" {
+		t.Errorf("created kind = %q, want symmetry", res.Kind)
+	}
+
+	// The constraint must round-trip through enumerate with its three refs in order.
+	var listed wire.ListConstraintsResult
+	call(t, r, s, "sketch.constraints", `{"sketchIndex":0}`, &listed)
+	found := false
+	for _, c := range listed.Constraints {
+		if c.Kind != "symmetry" {
+			continue
+		}
+		found = true
+		if len(c.Entities) != 3 || c.Entities[0] != a.EntityID ||
+			c.Entities[1] != b.EntityID || c.Entities[2] != axis.EntityID {
+			t.Errorf("enumerated entities = %v, want [%d,%d,%d]",
+				c.Entities, a.EntityID, b.EntityID, axis.EntityID)
+		}
+	}
+	if !found {
+		t.Fatalf("symmetry constraint not enumerated; got %+v", listed.Constraints)
+	}
+}
+
+// TestSketchSymmetryRejectsBadRefCount pins the arity guard: symmetry needs exactly 3 refs
+// (2 points + a mirror line); any other count is an error, not a silent drop.
+func TestSketchSymmetryRejectsBadRefCount(t *testing.T) {
+	r, s := seededSession(t)
+	add := func(args string) wire.AddSketchEntityResult {
+		var res wire.AddSketchEntityResult
+		call(t, r, s, "sketch.addEntity", args, &res)
+		return res
+	}
+	a := add(`{"sketchIndex":0,"kind":"point","points":[[2,1]]}`)
+	b := add(`{"sketchIndex":0,"kind":"point","points":[[2,-3]]}`)
+
+	err := tryCall(t, r, s, "sketch.addConstraint", mustJSON(t, wire.AddConstraintArgs{
+		SketchIndex: 0, Kind: "symmetry", Entities: []uint64{a.EntityID, b.EntityID},
+	}))
+	if err == nil {
+		t.Error("symmetry with 2 refs (missing mirror line) should error")
+	}
+}
+
+// TestSketchSymmetryRejectsBadEntityRefs pins the per-operand resolution guards: a missing
+// point id and a non-line mirror ref must each surface an error rather than panic or drop.
+func TestSketchSymmetryRejectsBadEntityRefs(t *testing.T) {
+	r, s := seededSession(t)
+	add := func(args string) wire.AddSketchEntityResult {
+		var res wire.AddSketchEntityResult
+		call(t, r, s, "sketch.addEntity", args, &res)
+		return res
+	}
+	a := add(`{"sketchIndex":0,"kind":"point","points":[[2,1]]}`)
+	b := add(`{"sketchIndex":0,"kind":"point","points":[[2,-3]]}`)
+	axis := add(`{"sketchIndex":0,"kind":"line","points":[[-5,0],[5,0]]}`)
+
+	// A point ref that does not resolve to any point.
+	if err := tryCall(t, r, s, "sketch.addConstraint", mustJSON(t, wire.AddConstraintArgs{
+		SketchIndex: 0, Kind: "symmetry", Entities: []uint64{a.EntityID, 999999, axis.EntityID},
+	})); err == nil {
+		t.Error("symmetry with an unresolvable point ref should error")
+	}
+	// The mirror ref is a point, not a line.
+	if err := tryCall(t, r, s, "sketch.addConstraint", mustJSON(t, wire.AddConstraintArgs{
+		SketchIndex: 0, Kind: "symmetry", Entities: []uint64{a.EntityID, b.EntityID, a.EntityID},
+	})); err == nil {
+		t.Error("symmetry with a non-line mirror ref should error")
+	}
+}


### PR DESCRIPTION
## What

Adds the missing `case GeoConstraintSymmetry` to the sketch add-constraint router handler, plus a `symmetryConstraint` resolver and a regression test. This is the GPL half of the two-part fix for [#1574](https://github.com/Oblikovati/Oblikovati/issues/1574) (the `api/client` half is Oblikovati.API#220).

## Why

Symmetry was **enumerable but not creatable**: `sketch_enumerate.go` already maps `*SymmetryConstraint -> GeoConstraintSymmetry` with entities `(A, B, About)`, but the add-constraint switch had **no case** for it, so the kind fell through to `default: reject` and every attempt to add one was silently dropped.

The new handler resolves 3 refs — point A, point B, mirror line — in the same order the enumerate path reports, and calls `GeometricConstraints().AddSymmetry(a, b, about)` (the solver method already existed and is tested). This lets a profile built about a centerline pin its mirror DOF directly instead of an over-constrained `Vertical`/equal-radius workaround.

## Tests

- `TestSketchSymmetryConstraintCreatable` — creates a symmetry constraint on two free points + the X axis, asserts it's created with kind `symmetry` and round-trips through enumerate with refs `[A,B,About]` in order.
- `TestSketchSymmetryRejectsBadRefCount` — 2 refs (missing the mirror line) is an error, not a silent drop.

## Notes

The host `require oblikovati.org/api` is intentionally left at v0.97.0 — this change only uses `types.GeoConstraintSymmetry`, which already shipped; it does not depend on the new 0.98.0 client helper, so no api-ahead-of-impl pin is needed.

Closes #1574

🤖 Generated with [Claude Code](https://claude.com/claude-code)