### PR TITLE
fix(identity): uniform mint-time anchor capture for dress-up geometric recovery (ADR-0043 P6b)

### DIFF
--- a/addin/opregistry/dressup_anchor_test.go
+++ b/addin/opregistry/dressup_anchor_test.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"testing"
+
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+)
+
+// TestFilletViaWireAPICapturesAnchors is the end-to-end proof of ADR-0043 P6b for the path that
+// was the gap: authoring a fillet through the public wire operation — edge reference keys only,
+// never the GUI's resolved EdgeHandles — must still capture each picked edge's mint-time anchor,
+// so a wire/MCP-authored fillet carries the geometric-recovery witness. Before the fix this map
+// was always empty for API-authored dress-ups and the geometric tier was silently unreachable.
+func TestFilletViaWireAPICapturesAnchors(t *testing.T) {
+	s, edge, _ := extrudedSolid(t)
+
+	if _, err := applyMap(t, s, "fillet", map[string]any{"edgeRefs": []string{edge}, "radius": "1 mm"}); err != nil {
+		t.Fatalf("fillet via wire API: %v", err)
+	}
+
+	fdef := lastFilletDef(t, s.ActiveDocument().Content().(*compdef.PartComponentDefinition))
+	if len(fdef.EdgeAnchors) != 1 {
+		t.Fatalf("wire-API fillet captured %d mint-time anchors, want 1 (EdgeAnchors=%v)", len(fdef.EdgeAnchors), fdef.EdgeAnchors)
+	}
+}
+
+// lastFilletDef returns the most recently added fillet definition in the part.
+func lastFilletDef(t *testing.T, def *compdef.PartComponentDefinition) *feature.FilletDefinition {
+	t.Helper()
+	feats := def.Features()
+	for i := feats.Count() - 1; i >= 0; i-- {
+		if ff, ok := feats.Item(i).Definition().(*feature.FilletFeature); ok {
+			return ff.Definition()
+		}
+	}
+	t.Fatal("no fillet feature found in part")
+	return nil
+}

--- a/app/chamfer_tool.go
+++ b/app/chamfer_tool.go
@@ -138,9 +138,9 @@ func (t *ChamferTool) Commit(s *Session) error {
 // both Commit (the part's engine) and DraftFeature (a scratch engine).
 func (t *ChamferTool) addChamfer(dress *feature.DressUpFeatures) *feature.PartFeature {
 	d := t.distance
-	pf := dress.AddChamferConcave(t.selectedEdgeKeys(), func() float64 { return d }, t.flatCorners, t.concaveStrategy)
-	pf.Definition().(*feature.ChamferFeature).Definition().EdgeAnchors = edgeHandleAnchors(t.edges) // P6b
-	return pf
+	// Mint-time anchors are captured by AddChamferConcave against the running body (ADR-0043 P6b),
+	// uniformly with every other authoring path — no per-tool capture needed here.
+	return dress.AddChamferConcave(t.selectedEdgeKeys(), func() float64 { return d }, t.flatCorners, t.concaveStrategy)
 }
 
 // AddedFeature returns the feature created on commit (for inspection/tests).

--- a/app/fillet_tool.go
+++ b/app/fillet_tool.go
@@ -262,7 +262,8 @@ func (t *FilletTool) addFillet(dress *feature.DressUpFeatures) *feature.PartFeat
 	def.ConcaveStrategy = t.concaveStrategy
 	def.CrossSection = t.crossSection
 	def.Rho = t.rho
-	def.EdgeAnchors = edgeHandleAnchors(t.edges) // mint-time anchors for geometric recovery (P6b)
+	// Mint-time anchors are captured by the AddFillet* builder against the running body (ADR-0043
+	// P6b), uniformly with every other authoring path — no per-tool capture needed here.
 	return pf
 }
 

--- a/architecture/decisions/ADR-0043-generalized-provenance-naming.md
+++ b/architecture/decisions/ADR-0043-generalized-provenance-naming.md
@@ -133,11 +133,15 @@ residual naming collision becomes an honest failure, never a wrong-rebind.
     **ancestral** tier through a `model/feature` adapter; a lost reference with a lone surviving
     parent-sibling heals to a Warning instead of going Sick. No format change (the parent is derived
     from the key). The exact-one P0 guard stays authoritative; only a 0/>1 miss escalates.
-  - **P6b** *(done)* — persist the mint-time **anchor** (`EdgeDressData.EdgeAnchors`, captured at
-    selection from the live edge midpoint) and enable the **geometric** tier, so several surviving
-    siblings are disambiguated by nearness (the binder still refuses a tie). The anchor is keyed by
-    reference key (a map), so it tolerates the seeded/picked split and an absent anchor degrades to
-    ancestral-only.
+  - **P6b** *(done)* — persist the mint-time **anchor** (`EdgeDressData.EdgeAnchors`, the live edge
+    midpoint) and enable the **geometric** tier, so several surviving siblings are disambiguated by
+    nearness (the binder still refuses a tie). The anchor is keyed by reference key (a map), so it
+    tolerates the seeded/picked split and an absent anchor degrades to ancestral-only. **Capture is
+    a single creation-path-agnostic seam** (`captureEdgeAnchors`, invoked by the public
+    `DressUpFeatures.Add*` builders against the engine's running body) — not the GUI tool alone, or
+    the tier would be silently unavailable for wire-API / MCP / programmatically authored dress-ups.
+    Recompute stays a pure function (it never writes anchors) and the recipe restore never recaptures,
+    so reopening a document does not rewrite it.
   - **P6c** — retire the now-dead silent-match resolution branches; make `Input.Keys`/`fs.keys` live
     (or remove). The no-parent ordinal fallback and the degraded CSG soup fallback legitimately stay.
 

--- a/model/feature/anchor_capture.go
+++ b/model/feature/anchor_capture.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Mint-time anchor capture is the create-time half of the geometric recovery tier (ADR-0043
+// P6b). The tier disambiguates several surviving same-parent siblings of a lost edge reference
+// by nearness to the edge midpoint witnessed when the edge was first picked. That witness has
+// to be recorded at authoring time, against the body the edge was picked on — and uniformly
+// across EVERY authoring path (GUI, wire API, assembly, programmatic), not just the GUI, or the
+// tier silently degrades to ancestral-only depending on how the feature was created. This file
+// is that single, creation-path-agnostic capture seam; the recipe restore deliberately does NOT
+// go through it, so reopening a document never rewrites its recipe.
+
+// captureEdgeAnchors records each picked edge key's mint-time anchor (its midpoint) by
+// resolving the key against the body it was picked on. It is the model-layer counterpart of
+// the GUI's edgeHandleAnchors: the GUI holds resolved edge handles, every other authoring path
+// holds only keys, so they resolve here. A key that does not resolve to EXACTLY one edge is
+// skipped (a fresh selection always resolves; anything else degrades to ancestral-only
+// recovery), and an empty capture returns nil so the caller stores nil rather than an empty map.
+//
+// Example: def.EdgeAnchors = captureEdgeAnchors(tipBody, def.EdgeKeys)
+func captureEdgeAnchors(body *topo.Body, keys [][]byte) map[string]math.Point3 {
+	if body == nil || len(keys) == 0 {
+		return nil
+	}
+	anchors := make(map[string]math.Point3, len(keys))
+	for _, k := range keys {
+		match := body.EdgesByKey(k)
+		if len(match) != 1 {
+			continue
+		}
+		if mid, ok := edgeMidpoint(match[0]); ok {
+			anchors[string(k)] = mid
+		}
+	}
+	if len(anchors) == 0 {
+		return nil
+	}
+	return anchors
+}
+
+// edgeMidpoint returns the midpoint of an edge's two end vertices — the representative point the
+// geometric recovery tier ranks siblings against (so capture and ranking, edgeEntity.Anchor,
+// use one definition of "the edge's anchor"). ok is false for a degenerate edge missing an endpoint.
+func edgeMidpoint(e *topo.Edge) (math.Point3, bool) {
+	s, end := e.StartVertex(), e.EndVertex()
+	if s == nil || end == nil {
+		return math.Point3{}, false
+	}
+	return s.Point().Midpoint(end.Point()), true
+}
+
+// tipBody returns the engine's current running body — the body a freshly-authored dress-up
+// operates on, the one its keys were minted against. It is nil when the part has not been
+// recomputed (a batch build before the first recompute), in which case anchor capture is
+// skipped and recovery falls back to the ancestral tier.
+func (c *DressUpFeatures) tipBody() *topo.Body {
+	bodies := c.engine.Result()
+	if len(bodies) == 0 {
+		return nil
+	}
+	return bodies[len(bodies)-1]
+}

--- a/model/feature/anchor_capture_test.go
+++ b/model/feature/anchor_capture_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/math"
+)
+
+// TestAddChamferCapturesMintTimeAnchors pins ADR-0043 P6b for the NON-GUI creation path.
+// Authoring a chamfer through the public builder — the wire-API / assembly / programmatic
+// path, which only ever has reference keys, never resolved EdgeHandles — must still record
+// each picked edge's mint-time midpoint in the definition, so a later upstream edit can fall
+// back to the geometric recovery tier. Before P6b only the GUI tool captured anchors, so an
+// API-authored dress-up silently degraded to ancestral-only recovery.
+func TestAddChamferCapturesMintTimeAnchors(t *testing.T) {
+	box, edge := box2(t)
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(box)
+	fs.Recompute() // the base is live before the edge is chamfered, as in every real authoring flow
+
+	ch := NewDressUpFeatures(fs).AddChamfer([][]byte{edge}, func() float64 { return 0.3 })
+
+	def := ch.Definition().(*ChamferFeature).Definition()
+	got, ok := def.EdgeAnchors[string(edge)]
+	if !ok {
+		t.Fatalf("AddChamfer did not capture a mint-time anchor for the picked edge (EdgeAnchors=%v)", def.EdgeAnchors)
+	}
+	want := math.P3(2, 2, 1) // midpoint of the vertical edge (2,2,0)->(2,2,2)
+	if got.DistanceTo(want) > 1e-9 {
+		t.Errorf("captured anchor = %v, want the edge midpoint %v", got, want)
+	}
+}
+
+// TestAddFilletCapturesMintTimeAnchors is the fillet parity of the chamfer case: the public
+// edge-key fillet builder must capture each picked edge's mint-time midpoint, so an API-authored
+// fillet has the geometric-recovery witness just like a GUI-authored one (ADR-0043 P6b).
+func TestAddFilletCapturesMintTimeAnchors(t *testing.T) {
+	box, edge := box2(t)
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(box)
+	fs.Recompute()
+
+	fl := NewDressUpFeatures(fs).AddFillet([][]byte{edge}, func() float64 { return 0.3 })
+
+	def := fl.Definition().(*FilletFeature).Definition()
+	got, ok := def.EdgeAnchors[string(edge)]
+	if !ok {
+		t.Fatalf("AddFillet did not capture a mint-time anchor (EdgeAnchors=%v)", def.EdgeAnchors)
+	}
+	if want := math.P3(2, 2, 1); got.DistanceTo(want) > 1e-9 {
+		t.Errorf("captured anchor = %v, want the edge midpoint %v", got, want)
+	}
+}
+
+// TestRestoreEntryDoesNotCaptureAnchors pins the "restore never mutates the recipe" invariant:
+// the low-level addChamfer entry, which the recipe restore calls, must NOT capture anchors even
+// when a live body is present — reopening a document carries the persisted anchors verbatim and
+// never rewrites them. Only the public authoring builders capture.
+func TestRestoreEntryDoesNotCaptureAnchors(t *testing.T) {
+	box, edge := box2(t)
+	fs := NewPartFeatures(nil, nil)
+	NewBaseFeatures(fs).AddBase(box)
+	fs.Recompute() // a live tip body exists — yet the restore entry must still not capture
+
+	ch := NewDressUpFeatures(fs).addChamfer(&ChamferDefinition{
+		EdgeKeys: [][]byte{edge}, Distance: constFloat(0.3), Type: types.ChamferDistance,
+	})
+
+	def := ch.Definition().(*ChamferFeature).Definition()
+	if len(def.EdgeAnchors) != 0 {
+		t.Fatalf("addChamfer (the restore entry) must not capture anchors; got %v", def.EdgeAnchors)
+	}
+}
+
+// TestAuthorWithoutRunningBodySkipsCapture pins the graceful degrade: when the part has not been
+// recomputed (no tip body — a batch build), capture is skipped without error and recovery falls
+// back to the ancestral tier, rather than panicking on a missing body.
+func TestAuthorWithoutRunningBodySkipsCapture(t *testing.T) {
+	_, edge := box2(t)
+	fs := NewPartFeatures(nil, nil) // never recomputed ⇒ Result() empty ⇒ no tip body
+
+	ch := NewDressUpFeatures(fs).AddChamfer([][]byte{edge}, func() float64 { return 0.3 })
+
+	def := ch.Definition().(*ChamferFeature).Definition()
+	if len(def.EdgeAnchors) != 0 {
+		t.Fatalf("with no running body capture must be skipped (ancestral-only degrade); got %v", def.EdgeAnchors)
+	}
+}

--- a/model/feature/dressup.go
+++ b/model/feature/dressup.go
@@ -336,11 +336,23 @@ func (c *DressUpFeatures) AddFillet(edgeKeys [][]byte, radius func() float64) *P
 // AddFilletCorner rounds the given edges to radius with an explicit shared-corner treatment.
 // Concave edges fill outward (the default); use [AddFilletConcave] to round a recess inward.
 func (c *DressUpFeatures) AddFilletCorner(edgeKeys [][]byte, radius func() float64, corner FilletCornerType) *PartFeature {
-	return c.engine.Add(&FilletFeature{def: &FilletDefinition{EdgeKeys: edgeKeys, Radius: radius, CornerType: corner}})
+	return c.authorEdgeFillet(&FilletDefinition{EdgeKeys: edgeKeys, Radius: radius, CornerType: corner})
 }
 
-// addFillet adds a fillet from a fully-built definition (used by the recipe restore to
-// carry fields the public builders don't take, e.g. geometric edge refs).
+// authorEdgeFillet captures mint-time edge anchors (ADR-0043 P6b) against the running body, then
+// registers an edge-key fillet. Every PUBLIC edge-key fillet builder funnels through it so each
+// authoring path records the geometric-recovery witness; the recipe restore uses addFillet, which
+// preserves the persisted anchors and never recaptures.
+func (c *DressUpFeatures) authorEdgeFillet(def *FilletDefinition) *PartFeature {
+	if len(def.EdgeAnchors) == 0 {
+		def.EdgeAnchors = captureEdgeAnchors(c.tipBody(), def.EdgeKeys)
+	}
+	return c.engine.Add(&FilletFeature{def: def})
+}
+
+// addFillet adds a fillet from a fully-built definition without capturing anchors (used by the
+// recipe restore to carry fields the public builders don't take, e.g. geometric edge refs, and
+// the persisted anchors themselves).
 func (c *DressUpFeatures) addFillet(def *FilletDefinition) *PartFeature {
 	return c.engine.Add(&FilletFeature{def: def})
 }
@@ -348,16 +360,16 @@ func (c *DressUpFeatures) addFillet(def *FilletDefinition) *PartFeature {
 // AddFilletCross rounds the given edges to radius with a chosen cross-section shape (M36-F08): arc
 // (G1, the default), G2 (curvature-continuous), or conic with fullness rho. Shared corners miter.
 func (c *DressUpFeatures) AddFilletCross(edgeKeys [][]byte, radius func() float64, cross FilletCrossSection, rho float64) *PartFeature {
-	return c.engine.Add(&FilletFeature{def: &FilletDefinition{
+	return c.authorEdgeFillet(&FilletDefinition{
 		EdgeKeys: edgeKeys, Radius: radius, CornerType: types.FilletCornerMiter, CrossSection: cross, Rho: rho,
-	}})
+	})
 }
 
 // AddFilletConcave rounds the given edges to radius with an explicit concave-edge strategy: outward
 // fills the inside corner with material (the default), inward rounds a recess into it. Convex edges
 // are unaffected by the strategy. Shared corners miter.
 func (c *DressUpFeatures) AddFilletConcave(edgeKeys [][]byte, radius func() float64, concave types.FilletConcaveStrategy) *PartFeature {
-	return c.engine.Add(&FilletFeature{def: &FilletDefinition{EdgeKeys: edgeKeys, Radius: radius, CornerType: types.FilletCornerMiter, ConcaveStrategy: concave}})
+	return c.authorEdgeFillet(&FilletDefinition{EdgeKeys: edgeKeys, Radius: radius, CornerType: types.FilletCornerMiter, ConcaveStrategy: concave})
 }
 
 // AddFilletSets rounds any mix of constant and variable radius edge sets in one feature
@@ -393,31 +405,43 @@ func (c *DressUpFeatures) AddChamfer(edgeKeys [][]byte, distance func() float64)
 // three-edge corner is blended into a flat triangular face (true) or left pointy (false).
 // Concave edges fill outward (the default); use [AddChamferConcave] to relieve them inward.
 func (c *DressUpFeatures) AddChamferCorners(edgeKeys [][]byte, distance func() float64, flatCorners bool) *PartFeature {
-	return c.addChamfer(&ChamferDefinition{EdgeKeys: edgeKeys, Distance: distance, Type: types.ChamferDistance, FlatCorners: flatCorners})
+	return c.authorChamfer(&ChamferDefinition{EdgeKeys: edgeKeys, Distance: distance, Type: types.ChamferDistance, FlatCorners: flatCorners})
 }
 
 // AddChamferConcave bevels the given edges by distance with an explicit concave-edge strategy:
 // outward fills the inside corner with material (the default), inward cuts a recessed relief
 // groove. Convex edges are unaffected by the strategy. Three-edge corners blend flat.
 func (c *DressUpFeatures) AddChamferConcave(edgeKeys [][]byte, distance func() float64, flatCorners bool, strategy ChamferConcaveStrategy) *PartFeature {
-	return c.addChamfer(&ChamferDefinition{EdgeKeys: edgeKeys, Distance: distance, Type: types.ChamferDistance, FlatCorners: flatCorners, ConcaveStrategy: strategy})
+	return c.authorChamfer(&ChamferDefinition{EdgeKeys: edgeKeys, Distance: distance, Type: types.ChamferDistance, FlatCorners: flatCorners, ConcaveStrategy: strategy})
 }
 
 // AddChamferTwoDistances bevels the given edges with independent setbacks on the two adjacent
 // faces (an asymmetric chamfer, M20-F03). Three-edge corners blend flat by default, like the
 // equal-distance mode.
 func (c *DressUpFeatures) AddChamferTwoDistances(edgeKeys [][]byte, distance, distance2 func() float64) *PartFeature {
-	return c.addChamfer(&ChamferDefinition{EdgeKeys: edgeKeys, Distance: distance, Distance2: distance2, Type: types.ChamferTwoDistances, FlatCorners: true})
+	return c.authorChamfer(&ChamferDefinition{EdgeKeys: edgeKeys, Distance: distance, Distance2: distance2, Type: types.ChamferTwoDistances, FlatCorners: true})
 }
 
 // AddChamferDistanceAngle bevels the given edges by a setback on the first face and the
 // chamfer-face angle (radians), M20-F03. Three-edge corners blend flat by default, like the
 // equal-distance mode.
 func (c *DressUpFeatures) AddChamferDistanceAngle(edgeKeys [][]byte, distance, angle func() float64) *PartFeature {
-	return c.addChamfer(&ChamferDefinition{EdgeKeys: edgeKeys, Distance: distance, Angle: angle, Type: types.ChamferDistanceAndAngle, FlatCorners: true})
+	return c.authorChamfer(&ChamferDefinition{EdgeKeys: edgeKeys, Distance: distance, Angle: angle, Type: types.ChamferDistanceAndAngle, FlatCorners: true})
 }
 
-// addChamfer registers a chamfer feature with the given definition.
+// authorChamfer captures mint-time edge anchors (ADR-0043 P6b) against the running body, then
+// registers the chamfer. Every PUBLIC chamfer builder funnels through it so each authoring path
+// (GUI, wire API, assembly, programmatic) records the geometric-recovery witness; the recipe
+// restore calls addChamfer directly so reopening a document never recaptures or rewrites anchors.
+func (c *DressUpFeatures) authorChamfer(def *ChamferDefinition) *PartFeature {
+	if len(def.EdgeAnchors) == 0 {
+		def.EdgeAnchors = captureEdgeAnchors(c.tipBody(), def.EdgeKeys)
+	}
+	return c.addChamfer(def)
+}
+
+// addChamfer registers a chamfer feature with the given definition (no anchor capture — shared
+// by the recipe restore, which carries persisted anchors of its own).
 func (c *DressUpFeatures) addChamfer(def *ChamferDefinition) *PartFeature {
 	cf := &ChamferFeature{def: def}
 	pf := c.engine.Add(cf)

--- a/model/feature/identity_adapter.go
+++ b/model/feature/identity_adapter.go
@@ -57,13 +57,10 @@ func (a edgeEntity) EntityKind() identity.EntityKind { return identity.KindEdge 
 func (a edgeEntity) Lineage() identity.Lineage       { return edgeLineage(a.e.ReferenceKey()) }
 
 // Anchor reports the edge midpoint as its representative point — the geometric
-// tie-breaker the binder uses only when several siblings share a parent (P6b).
+// tie-breaker the binder uses only when several siblings share a parent (P6b). It shares
+// edgeMidpoint with the create-time capture so witness and ranking use one definition.
 func (a edgeEntity) Anchor() (math.Point3, bool) {
-	s, e := a.e.StartVertex(), a.e.EndVertex()
-	if s == nil || e == nil {
-		return math.Point3{}, false
-	}
-	return s.Point().Midpoint(e.Point()), true
+	return edgeMidpoint(a.e)
 }
 
 // edgeEntities views every edge of the body as an identity.Entity for the binder.


### PR DESCRIPTION
## What

Makes mint-time **edge-anchor capture** a single creation-path-agnostic seam, so the geometric reference-recovery tier (ADR-0043 P6b) works for **every** way a fillet/chamfer is authored — GUI, wire API / MCP, and programmatic — not just the interactive GUI tool.

- New `model/feature/captureEdgeAnchors(body, keys)` — resolves picked edge keys against the engine's running body and records each edge midpoint. The model-layer counterpart of the GUI's `edgeHandleAnchors`.
- The public `DressUpFeatures.Add*` builders (`authorEdgeFillet` / `authorChamfer`) capture once at authoring time. The low-level `addFillet`/`addChamfer` (used by recipe **restore**) stay non-capturing.
- Removed the now-redundant per-tool capture in the GUI fillet/chamfer **create** paths (the builder owns it); edit-mode capture stays (it mutates an existing definition outside the builder).
- `edgeEntity.Anchor` now shares `edgeMidpoint`, so capture and ranking use one definition of "the edge's anchor".

## Why

`FilletDefinition/ChamferDefinition.EdgeAnchors` was only ever populated by the GUI tools (4 duplicated call sites). Every other authoring path — the public wire op in `addin/opregistry`, MCP, programmatic — left it nil, so the geometric tier silently degraded to ancestral-only. **Robustness of reference recovery depended on how the feature was created**, which is exactly the inconsistency P6b set out to remove.

Capture is an *authoring* concern, so it lives at the creation seam — **not** in `Recompute` (which stays a pure function of `(def, input bodies)` and never writes the definition) and **not** in restore (reopening a document never rewrites its recipe). This avoids snapshot churn / spurious dirty-doc state.

## Tests

- `model/feature/anchor_capture_test.go` — chamfer & fillet capture on the builder path; the restore entry does **not** capture even with a live body; graceful degrade (no running body → no capture, no panic).
- `addin/opregistry/dressup_anchor_test.go` — end-to-end through the real **wire op** (the path that was the gap): an API-authored fillet now carries an anchor.
- Existing geometric-tier (`nearestSibling`) and recipe round-trip tests already cover the consuming end.

Full local run green for `model/feature`, `model/identity`, `app`, `addin/opregistry`, `addin/router`; `go vet` + `golangci-lint` (funlen 20) 0 issues; markdownlint 0 errors.

Refs #1539 (ADR-0043 P6b; epic stays open for P2/P4/P5/P6c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)