### PR TITLE
feat: tiered recovery for face references (#1579)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.97.0
+	oblikovati.org/api v0.99.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.97.0
+	oblikovati.org/api v0.99.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/compdef/reference_source.go
+++ b/model/compdef/reference_source.go
@@ -6,6 +6,7 @@ import (
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
 )
 
 // Projecting/including part geometry into a sketch (2D or 3D) and deriving surface curves
@@ -95,11 +96,14 @@ func NewFaceRefSource(part *PartComponentDefinition, ref string) FaceRefSource {
 // SourceID returns the face's reference key.
 func (s FaceRefSource) SourceID() string { return s.ref }
 
-// Surface re-resolves the face by key and returns its surface, or nil when lost.
+// Surface re-resolves the face by key and returns its surface, or nil when lost. It recovers a
+// lone ancestral sibling when the exact face is gone (ADR-0043 P6 / #1579) so an associative
+// surface source survives an upstream edit that renames its face, rather than silently projecting
+// onto nothing. FaceKeyResolves below deliberately does NOT recover — it is the health probe.
 func (s FaceRefSource) Surface() geom.Surface {
 	key := []byte(s.ref)
 	for _, b := range s.bodies() {
-		if face, ok := b.FindFaceByKey(key); ok {
+		if face, ok := feature.FindOrRecoverFace(b, key); ok {
 			return face.Geometry()
 		}
 	}

--- a/model/compdef/sheet_metal_entity_map.go
+++ b/model/compdef/sheet_metal_entity_map.go
@@ -43,6 +43,9 @@ func (d *PartComponentDefinition) MapFlatToFolded(key []byte) ([]byte, bool, err
 // returns the reference key of dst's face most strongly facing that side — the front↔front,
 // back↔back correspondence. found is false when key is not a face of src.
 func mapFace(src, dst *topo.Body, baseNormal math.Vector3, key []byte) ([]byte, bool) {
+	// Exact/first-match on purpose (NOT FindOrRecoverFace): a flat pattern's front and back faces
+	// deliberately share one reference key, and this map disambiguates them by normal direction
+	// below — so the ADR-0043 P0 collision guard (which refuses a >1-match) does not fit here.
 	face, ok := src.FindFaceByKey(key)
 	if !ok {
 		return nil, false

--- a/model/feature/anchor_capture.go
+++ b/model/feature/anchor_capture.go
@@ -55,6 +55,17 @@ func edgeMidpoint(e *topo.Edge) (math.Point3, bool) {
 	return s.Point().Midpoint(end.Point()), true
 }
 
+// faceAnchor returns a face's centroid — the representative point the geometric recovery tier
+// ranks siblings against (so capture and ranking, faceEntity.Anchor, use one definition of "the
+// face's anchor"). It reuses topo.DescribeFace so kernel/topo owns the centroid math; ok is false
+// for a degenerate face whose centroid is the zero point with no contributing vertices.
+func faceAnchor(f *topo.Face) (math.Point3, bool) {
+	if f == nil {
+		return math.Point3{}, false
+	}
+	return topo.DescribeFace(f).Centroid, true
+}
+
 // tipBody returns the engine's current running body — the body a freshly-authored dress-up
 // operates on, the one its keys were minted against. It is nil when the part has not been
 // recomputed (a batch build before the first recompute), in which case anchor capture is

--- a/model/feature/anchor_capture.go
+++ b/model/feature/anchor_capture.go
@@ -55,6 +55,35 @@ func edgeMidpoint(e *topo.Edge) (math.Point3, bool) {
 	return s.Point().Midpoint(end.Point()), true
 }
 
+// captureFaceAnchors records each picked face key's mint-time anchor (its centroid) by resolving
+// the key against the body it was picked on — the face counterpart of captureEdgeAnchors (#1579).
+// A key that does not resolve to EXACTLY one face is skipped (degrading to ancestral-only
+// recovery), and an empty capture returns nil so the caller stores nil rather than an empty map.
+//
+// Example: def.FaceAnchors = captureFaceAnchors(tipBody, [][]byte{def.PlacementFaceKey})
+func captureFaceAnchors(body *topo.Body, keys [][]byte) map[string]math.Point3 {
+	if body == nil || len(keys) == 0 {
+		return nil
+	}
+	anchors := make(map[string]math.Point3, len(keys))
+	for _, k := range keys {
+		if len(k) == 0 {
+			continue
+		}
+		match := body.FacesByKey(k)
+		if len(match) != 1 {
+			continue
+		}
+		if c, ok := faceAnchor(match[0]); ok {
+			anchors[string(k)] = c
+		}
+	}
+	if len(anchors) == 0 {
+		return nil
+	}
+	return anchors
+}
+
 // faceAnchor returns a face's centroid — the representative point the geometric recovery tier
 // ranks siblings against (so capture and ranking, faceEntity.Anchor, use one definition of "the
 // face's anchor"). It reuses topo.DescribeFace so kernel/topo owns the centroid math; ok is false
@@ -66,14 +95,18 @@ func faceAnchor(f *topo.Face) (math.Point3, bool) {
 	return topo.DescribeFace(f).Centroid, true
 }
 
-// tipBody returns the engine's current running body — the body a freshly-authored dress-up
-// operates on, the one its keys were minted against. It is nil when the part has not been
-// recomputed (a batch build before the first recompute), in which case anchor capture is
-// skipped and recovery falls back to the ancestral tier.
-func (c *DressUpFeatures) tipBody() *topo.Body {
-	bodies := c.engine.Result()
+// featuresTipBody returns the engine's current running body — the body a freshly-authored feature
+// operates on, the one its picked keys were minted against. It is nil when the part has not been
+// recomputed (a batch build before the first recompute), in which case anchor capture is skipped
+// and recovery falls back to the ancestral tier. Boss/thread/unwrap authoring share it via the
+// engine, so capture is uniform across every authoring path (not GUI-only — the P6b lesson).
+func featuresTipBody(fs *PartFeatures) *topo.Body {
+	bodies := fs.Result()
 	if len(bodies) == 0 {
 		return nil
 	}
 	return bodies[len(bodies)-1]
 }
+
+// tipBody returns the engine's current running body for a dress-up authoring path.
+func (c *DressUpFeatures) tipBody() *topo.Body { return featuresTipBody(c.engine) }

--- a/model/feature/dressup.go
+++ b/model/feature/dressup.go
@@ -494,7 +494,19 @@ func (c *DressUpFeatures) AddThread(faceKey []byte, designation string, cut bool
 	return c.AddThreadDef(&ThreadDefinition{FaceKey: faceKey, Designation: designation, Cut: cut})
 }
 
-// AddThreadDef adds a thread from a full definition (class / tapered / model diameter, #325).
+// AddThreadDef adds a thread from a full definition (class / tapered / model diameter, #325). It
+// captures the threaded face's mint-time anchor against the running body for the geometric
+// recovery tier (ADR-0043 P6 / #1579); every authoring path funnels here, while the recipe restore
+// uses addThreadDef so reopening a document never recaptures or rewrites anchors.
 func (c *DressUpFeatures) AddThreadDef(def *ThreadDefinition) *PartFeature {
+	if len(def.FaceAnchors) == 0 {
+		def.FaceAnchors = captureFaceAnchors(c.tipBody(), [][]byte{def.FaceKey})
+	}
+	return c.addThreadDef(def)
+}
+
+// addThreadDef registers a thread from a fully-built definition without capturing anchors (the
+// recipe restore path, which carries the persisted anchors of its own).
+func (c *DressUpFeatures) addThreadDef(def *ThreadDefinition) *PartFeature {
 	return c.engine.Add(&ThreadFeature{def: def})
 }

--- a/model/feature/dressup.go
+++ b/model/feature/dressup.go
@@ -230,6 +230,9 @@ type ThreadDefinition struct {
 	Class         string
 	Tapered       bool
 	ModelDiameter types.ModelDiameterFromThread
+	// FaceAnchors maps FaceKey to its mint-time centroid for the geometric recovery tier
+	// (ADR-0043 P6 / #1579); see FilletDefinition.EdgeAnchors.
+	FaceAnchors map[string]math.Point3
 }
 
 // ThreadFeature tags a cylindrical face with a cosmetic thread (Inventor's ThreadFeature): it
@@ -267,9 +270,9 @@ func (t *ThreadFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	face, ok := body.FindFaceByKey(t.def.FaceKey)
-	if !ok {
-		return Output{}, fmt.Errorf("thread: face reference lost")
+	face, mt, err := bindFace(body, t.def.FaceKey, anchorFor(t.def.FaceKey, t.def.FaceAnchors))
+	if err != nil {
+		return Output{}, fmt.Errorf("thread: %w", err)
 	}
 	cyl, ok := face.Geometry().(geom.Cylinder)
 	if !ok {
@@ -279,7 +282,7 @@ func (t *ThreadFeature) Recompute(in Input) (Output, error) {
 	spec.Internal = bodyHasMaterialOutside(body, cyl, (vMin+vMax)/2, (spec.MajorDiameter-spec.MinorDiameter)/2/10)
 	t.spec = &spec
 	if !t.def.Cut {
-		return Output{Bodies: in.Bodies}, nil // cosmetic: solid unchanged
+		return Output{Bodies: in.Bodies, Heals: faceHeal(t.def.FaceKey, mt)}, nil // cosmetic: solid unchanged
 	}
 	// Modeled (cut) thread: retype the cylindrical face to a threaded surface — O(1), no
 	// boolean — so it tessellates and measures as real threaded geometry.
@@ -289,12 +292,14 @@ func (t *ThreadFeature) Recompute(in Input) (Output, error) {
 	}
 	out := make([]*topo.Body, len(in.Bodies))
 	copy(out, in.Bodies)
-	threadedBody, err := ops.ReplaceFaceSurface(body, t.def.FaceKey, threaded)
+	// Target the RESOLVED face's current key, not the stored one: a healed thread bound to a
+	// recovered sibling whose live key differs from t.def.FaceKey (ADR-0043 P6, mirrors edges).
+	threadedBody, err := ops.ReplaceFaceSurface(body, face.ReferenceKey(), threaded)
 	if err != nil {
 		return Output{}, err
 	}
 	out[len(out)-1] = threadedBody // runningBody is the last body
-	return Output{Bodies: out}, nil
+	return Output{Bodies: out, Heals: faceHeal(t.def.FaceKey, mt)}, nil
 }
 
 // resolveFacesThenDefer resolves face keys against the running body and, if all bind, defers
@@ -305,10 +310,10 @@ func resolveFacesThenDefer(in Input, keys [][]byte, kind string) (Output, error)
 	if err != nil {
 		return Output{}, err
 	}
-	for _, k := range keys {
-		if _, ok := body.FindFaceByKey(k); !ok {
-			return Output{}, fmt.Errorf("%s: face reference lost", kind)
-		}
+	// Recover lost-but-ancestral faces so a deferred feature is not falsely Sick; ErrDeferred
+	// already classifies the deferral as a Warning, so the heals need no separate surfacing.
+	if _, _, err := resolveFaces(body, keys, nil); err != nil {
+		return Output{}, fmt.Errorf("%s: %w", kind, err)
 	}
 	return Output{Bodies: in.Bodies}, ErrDeferred
 }

--- a/model/feature/face_anchor_persistence_test.go
+++ b/model/feature/face_anchor_persistence_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestBossCapturesFaceAnchorOnAuthor pins the authoring-seam half of the face geometric tier
+// (#1579): authoring a boss against an already-recomputed tip records the placement face's
+// centroid, so the geometric recovery tier has a witness without depending on the creation path.
+func TestBossCapturesFaceAnchorOnAuthor(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	NewBaseFeatures(fs).AddBase(prismBody())
+	fs.Recompute() // a tip body must exist for capture to resolve the face
+	top := fs.Result()[0].Faces()[0].ReferenceKey()
+
+	boss := NewBossFeatures(fs).Add(top, func() float64 { return 1 }, func() float64 { return 1 })
+	anchors := boss.Definition().(*BossFeature).Definition().FaceAnchors
+	if len(anchors) != 1 {
+		t.Fatalf("boss should capture one face anchor on author, got %v", anchors)
+	}
+	if _, ok := anchors[string(top)]; !ok {
+		t.Errorf("captured anchor is not keyed by the placement face key")
+	}
+}
+
+// TestNoAnchorCaptureBeforeRecompute pins that a batch build (author before the first recompute,
+// when there is no tip body) skips capture and degrades to ancestral-only recovery — never panics.
+func TestNoAnchorCaptureBeforeRecompute(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	NewBaseFeatures(fs).AddBase(prismBody()) // no Recompute: tip is empty
+	boss := NewBossFeatures(fs).Add([]byte("some-face"), func() float64 { return 1 }, func() float64 { return 1 })
+	if a := boss.Definition().(*BossFeature).Definition().FaceAnchors; a != nil {
+		t.Errorf("capture before the first recompute should store nil anchors, got %v", a)
+	}
+}
+
+// TestFaceAnchorsCodecRoundTrip pins the serialized form: an authored face-anchor map survives
+// encode→decode unchanged (the persistence half of the geometric tier).
+func TestFaceAnchorsCodecRoundTrip(t *testing.T) {
+	key := faceKeyFor(7)
+	anchors := map[string]math.Point3{string(key): math.P3(1.25, -2.5, 3)}
+
+	back, err := decodeFaceAnchors(encodeFaceAnchors(anchors))
+	if err != nil {
+		t.Fatalf("decodeFaceAnchors: %v", err)
+	}
+	if len(back) != 1 {
+		t.Fatalf("round trip lost the anchor: got %v", back)
+	}
+	if p, ok := back[string(key)]; !ok || !p.IsEqualTo(math.P3(1.25, -2.5, 3), 1e-9) {
+		t.Errorf("anchor after round trip = %v (present=%v), want (1.25,-2.5,3)", p, ok)
+	}
+	if encodeFaceAnchors(nil) != nil {
+		t.Error("an empty anchor map must encode to nil (omitempty), not an empty slice")
+	}
+}
+
+// TestBossFaceAnchorsSurviveRecipeRoundTrip is the persistence guarantee: a boss whose definition
+// carries a face anchor round-trips through MarshalRecipe/ApplyRecipe with the centroid intact, and
+// the restore path (addBoss) does NOT recapture — it preserves the persisted anchor.
+func TestBossFaceAnchorsSurviveRecipeRoundTrip(t *testing.T) {
+	key := []byte("face-2")
+	want := math.P3(2, -1, 0.5)
+	fs := NewPartFeatures(nil)
+	NewBossFeatures(fs).addBoss(&BossDefinition{
+		PlacementFaceKey: key, Diameter: func() float64 { return 8 }, Height: func() float64 { return 4 },
+		FaceAnchors: map[string]math.Point3{string(key): want},
+	})
+
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	restored := fresh.Item(0).Definition().(*BossFeature).Definition().FaceAnchors
+	if len(restored) != 1 {
+		t.Fatalf("face anchors after recipe round trip = %v, want one entry", restored)
+	}
+	if got, ok := restored[string(key)]; !ok || !got.IsEqualTo(want, 1e-9) {
+		t.Errorf("restored anchor = %v (present=%v), want %v", got, ok, want)
+	}
+}

--- a/model/feature/face_bind.go
+++ b/model/feature/face_bind.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/identity"
+)
+
+// Face references are the counterpart of the edge dress-up references (chamfer.go resolveEdges):
+// they too must rebind to a freshly-built body on every recompute, and an upstream edit can
+// destroy the exact-keyed face while leaving a defensible successor. This file is the single seam
+// every face-key call site binds through (#1579, ADR-0043 P6), so the exact→ancestral→geometric→
+// none tier ladder and the P0 collision guard live in one place rather than scattered across the
+// dozen FindFaceByKey sites. It is the face mirror of resolveEdges and reuses the SAME tested
+// binder (model/identity.fallbackMatch) via the face adapter in identity_adapter.go.
+
+// bindFace binds one face reference key against the running body, recovering through the tiered
+// binder when the exact face is gone. It returns the bound face and the match tier (MatchExact, or
+// a fallback tier on a heal), or an error when the key is ambiguous or lost with no defensible
+// recovery — so a caller goes Sick honestly rather than dressing up the wrong face. anchor is the
+// key's mint-time point (nil degrades to ancestral-only recovery).
+//
+// Example: f, mt, err := bindFace(body, def.PlacementFaceKey, anchorFor(key, def.FaceAnchors))
+func bindFace(body *topo.Body, key []byte, anchor *math.Point3) (*topo.Face, identity.MatchType, error) {
+	match := body.FacesByKey(key)
+	if len(match) == 1 {
+		return match[0], identity.MatchExact, nil
+	}
+	if f, mt := recoverFace(key, anchor, faceEntities(body)); mt.IsFallback() && f != nil {
+		return f, mt, nil
+	}
+	if len(match) > 1 {
+		return nil, identity.MatchNone, fmt.Errorf("face reference %q is ambiguous — it matches %d faces (a topological-naming collision) and no surviving sibling could be recovered", keyText(key), len(match))
+	}
+	return nil, identity.MatchNone, fmt.Errorf("face reference %q lost (no face with that lineage on the running body, and no surviving sibling to recover it)", keyText(key))
+}
+
+// resolveFaces binds every face key against the running body, collecting the heals that the engine
+// turns into a Warning (ADR-0043 P6). It is the batch, heal-reporting form for features that pick
+// several faces and return an Output; a single lost/ambiguous key is a hard error. It mirrors
+// resolveEdges so the two reference kinds behave identically.
+func resolveFaces(body *topo.Body, keys [][]byte, anchors map[string]math.Point3) ([]*topo.Face, []ReferenceHeal, error) {
+	faces := make([]*topo.Face, len(keys))
+	var heals []ReferenceHeal
+	for i, k := range keys {
+		f, mt, err := bindFace(body, k, anchorFor(k, anchors))
+		if err != nil {
+			return nil, nil, err
+		}
+		faces[i] = f
+		if mt.IsFallback() {
+			heals = append(heals, ReferenceHeal{Key: append([]byte(nil), k...), Match: mt})
+		}
+	}
+	return faces, heals, nil
+}
+
+// faceHeal returns the one-element heal slice for a single recovered face binding, or nil for an
+// exact match — the single-key counterpart of resolveFaces' heal collection, for features that
+// pick one face and return an Output (boss, thread, unwrap).
+func faceHeal(key []byte, mt identity.MatchType) []ReferenceHeal {
+	if !mt.IsFallback() {
+		return nil
+	}
+	return []ReferenceHeal{{Key: append([]byte(nil), key...), Match: mt}}
+}
+
+// FindOrRecoverFace resolves a face key, recovering a lone ancestral sibling when the exact face is
+// gone — the drop-in replacement for body.FindFaceByKey at best-effort callers that have no health
+// channel to report a heal through (display helpers, surface sources, sheet-metal fold maps, some
+// in model/compdef). It never guesses: an ambiguous (including a P0 collision) or lost key returns
+// (nil, false), so a silent recovery is only ever the unambiguous ancestral one. These sites hold
+// no mint-time anchor, so the geometric tier does not apply here.
+//
+// Example: f, ok := feature.FindOrRecoverFace(body, faceKey)
+func FindOrRecoverFace(body *topo.Body, key []byte) (*topo.Face, bool) {
+	f, _, err := bindFace(body, key, nil)
+	if err != nil {
+		return nil, false
+	}
+	return f, true
+}

--- a/model/feature/face_fillet.go
+++ b/model/feature/face_fillet.go
@@ -188,7 +188,7 @@ func planeNormals(body *topo.Body, keys [][]byte) []math.Vector3 {
 func facePlanes(body *topo.Body, keys [][]byte) []geom.Plane {
 	var out []geom.Plane
 	for _, k := range keys {
-		if f, ok := body.FindFaceByKey(k); ok {
+		if f, ok := FindOrRecoverFace(body, k); ok {
 			if pl, ok := facePlane(f); ok {
 				out = append(out, pl)
 			}

--- a/model/feature/face_recovery_test.go
+++ b/model/feature/face_recovery_test.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/identity"
+)
+
+// faceKeyFor renders a two-token face lineage (parent "grp:f#0", a given last step) as the
+// reference key a feature would have stored when the user picked that face. 0x03 = topo.KindFace
+// (the kernel reference-key kind byte, distinct from identity.KindFace).
+func faceKeyFor(lastIndex int) []byte {
+	lin := topo.NewLineage(topo.Tok("grp", "f", 0), topo.Tok("split", "side", lastIndex))
+	return append([]byte{0x03}, lin.Key()...)
+}
+
+// siblingFaceBody builds coplanar triangles, one face each. The "keep" face carries a TWO-token
+// lineage sharing parent "grp:f#0" with the given last step; a final unrelated face is single-token
+// (no parent). extraSibling adds a SECOND face under the same parent (a different last step) so the
+// parent has two surviving siblings — the case ancestral recovery must refuse without an anchor.
+func siblingFaceBody(t *testing.T, lastIndex int, extraSibling bool) (*topo.Body, *topo.Face) {
+	t.Helper()
+	bld := topo.NewBuilder(false, topo.NewLineage(topo.Tok("f", "body", 0)))
+	pl, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	id := 0
+	tri := func(x float64, lin topo.Lineage) *topo.Face {
+		a := bld.AddVertex(math.P3(x, 0, 0), topo.NewLineage(topo.Tok("f", "vertex", id)))
+		b := bld.AddVertex(math.P3(x+1, 0, 0), topo.NewLineage(topo.Tok("f", "vertex", id+1)))
+		c := bld.AddVertex(math.P3(x, 1, 0), topo.NewLineage(topo.Tok("f", "vertex", id+2)))
+		ab := bld.AddEdge(geom.NewLineSegment(a.Point(), b.Point()), a, b, topo.NewLineage(topo.Tok("f", "edge", id)))
+		bc := bld.AddEdge(geom.NewLineSegment(b.Point(), c.Point()), b, c, topo.NewLineage(topo.Tok("f", "edge", id+1)))
+		ca := bld.AddEdge(geom.NewLineSegment(c.Point(), a.Point()), c, a, topo.NewLineage(topo.Tok("f", "edge", id+2)))
+		id += 3
+		return bld.AddFace(pl, lin, topo.OuterLoop(topo.Fwd(ab), topo.Fwd(bc), topo.Fwd(ca)))
+	}
+	keep := tri(0, topo.NewLineage(topo.Tok("grp", "f", 0), topo.Tok("split", "side", lastIndex)))
+	if extraSibling {
+		tri(3, topo.NewLineage(topo.Tok("grp", "f", 0), topo.Tok("split", "side", lastIndex+1)))
+	}
+	tri(6, topo.NewLineage(topo.Tok("f", "face", 1))) // unrelated, single-token (no parent)
+	return bld.Build(), keep
+}
+
+// TestResolveFacesHealsLostReferenceToAncestralSibling is the face counterpart of the ADR-0043 P6
+// headline: a stored face key whose EXACT entity is gone but whose PARENT lineage still names
+// exactly one surviving face is recovered ancestrally — bound and reported as a heal — not Sick.
+func TestResolveFacesHealsLostReferenceToAncestralSibling(t *testing.T) {
+	body, keep := siblingFaceBody(t, 7, false)
+	lost := faceKeyFor(2) // same parent grp:f#0, a last step the body no longer has
+
+	faces, heals, err := resolveFaces(body, [][]byte{lost}, nil)
+	if err != nil {
+		t.Fatalf("a recoverable face reference must heal, not error: %v", err)
+	}
+	if len(faces) != 1 || faces[0] != keep {
+		t.Fatalf("heal bound the wrong face: got %v, want the lone parent sibling", faces)
+	}
+	if len(heals) != 1 || heals[0].Match != identity.MatchAncestral {
+		t.Fatalf("expected one ancestral heal, got %+v", heals)
+	}
+}
+
+// TestResolveFacesRefusesAmbiguousSiblingsWithoutAnchor pins the honesty invariant for faces: two
+// surviving same-parent siblings with no mint-time anchor cannot be disambiguated, so the reference
+// stays lost rather than binding a guess.
+func TestResolveFacesRefusesAmbiguousSiblingsWithoutAnchor(t *testing.T) {
+	body, _ := siblingFaceBody(t, 7, true) // two faces now share parent grp:f#0
+	lost := faceKeyFor(2)
+
+	if _, _, err := resolveFaces(body, [][]byte{lost}, nil); err == nil {
+		t.Fatal("two same-parent face siblings with no anchor must NOT heal — recovery guessed")
+	} else if !strings.Contains(err.Error(), "lost") {
+		t.Errorf("error %q should report the reference as lost", err)
+	}
+}
+
+// TestResolveFacesHealsAmbiguousSiblingsByAnchor is the face geometric tier: several surviving
+// siblings are disambiguated by nearness to the mint-time anchor (the face centroid), recovering
+// the face the user originally picked instead of staying lost.
+func TestResolveFacesHealsAmbiguousSiblingsByAnchor(t *testing.T) {
+	body, keep := siblingFaceBody(t, 7, true)
+	lost := faceKeyFor(2)
+	anchors := map[string]math.Point3{string(lost): topo.DescribeFace(keep).Centroid}
+
+	faces, heals, err := resolveFaces(body, [][]byte{lost}, anchors)
+	if err != nil {
+		t.Fatalf("geometric recovery should heal an anchored ambiguous face reference: %v", err)
+	}
+	if len(faces) != 1 || faces[0] != keep {
+		t.Fatalf("anchor near keep must bind keep, got %v", faces)
+	}
+	if len(heals) != 1 || heals[0].Match != identity.MatchGeometric {
+		t.Fatalf("expected one geometric heal, got %+v", heals)
+	}
+}
+
+// TestResolveFacesExactMatchNoHeal confirms an exactly-resolving key binds cleanly with no heal.
+func TestResolveFacesExactMatchNoHeal(t *testing.T) {
+	body, keep := siblingFaceBody(t, 7, false)
+
+	faces, heals, err := resolveFaces(body, [][]byte{keep.ReferenceKey()}, nil)
+	if err != nil || len(faces) != 1 || faces[0] != keep {
+		t.Fatalf("exact key must bind itself with no error: faces=%v err=%v", faces, err)
+	}
+	if len(heals) != 0 {
+		t.Errorf("an exact match must not report a heal, got %+v", heals)
+	}
+}
+
+// dupFaceBody builds a body where two distinct faces share ONE lineage key — a topological-naming
+// collision — plus an unrelated third face, to exercise the P0 ambiguity guard on the face path.
+func dupFaceBody(t *testing.T) (*topo.Body, []byte) {
+	t.Helper()
+	bld := topo.NewBuilder(false, topo.NewLineage(topo.Tok("f", "body", 0)))
+	pl, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	id := 0
+	dup := topo.NewLineage(topo.Tok("f", "face", 0))
+	tri := func(x float64, lin topo.Lineage) *topo.Face {
+		a := bld.AddVertex(math.P3(x, 0, 0), topo.NewLineage(topo.Tok("f", "vertex", id)))
+		b := bld.AddVertex(math.P3(x+1, 0, 0), topo.NewLineage(topo.Tok("f", "vertex", id+1)))
+		c := bld.AddVertex(math.P3(x, 1, 0), topo.NewLineage(topo.Tok("f", "vertex", id+2)))
+		ab := bld.AddEdge(geom.NewLineSegment(a.Point(), b.Point()), a, b, topo.NewLineage(topo.Tok("f", "edge", id)))
+		bc := bld.AddEdge(geom.NewLineSegment(b.Point(), c.Point()), b, c, topo.NewLineage(topo.Tok("f", "edge", id+1)))
+		ca := bld.AddEdge(geom.NewLineSegment(c.Point(), a.Point()), c, a, topo.NewLineage(topo.Tok("f", "edge", id+2)))
+		id += 3
+		return bld.AddFace(pl, lin, topo.OuterLoop(topo.Fwd(ab), topo.Fwd(bc), topo.Fwd(ca)))
+	}
+	tri(0, dup)
+	tri(3, dup) // second face, same lineage ⇒ same key
+	tri(6, topo.NewLineage(topo.Tok("f", "face", 1)))
+	body := bld.Build()
+	return body, body.Faces()[0].ReferenceKey()
+}
+
+// TestBindFaceCollisionIsHonestError pins that a key matching MORE THAN ONE face, with no surviving
+// sibling to recover to, is an honest error (the ADR-0043 P0 guard) — never a silent first-match.
+func TestBindFaceCollisionIsHonestError(t *testing.T) {
+	body, colliding := dupFaceBody(t)
+
+	if _, _, err := bindFace(body, colliding, nil); err == nil {
+		t.Fatal("a colliding face key must error, not silently bind the first match")
+	}
+}
+
+// TestFindOrRecoverFaceAncestralSilent covers the silent (no-heal-channel) helper: it recovers a
+// lone ancestral sibling for a best-effort caller, returning the face and true.
+func TestFindOrRecoverFaceAncestralSilent(t *testing.T) {
+	body, keep := siblingFaceBody(t, 7, false)
+	lost := faceKeyFor(2)
+
+	got, ok := FindOrRecoverFace(body, lost)
+	if !ok || got != keep {
+		t.Fatalf("FindOrRecoverFace should recover the lone ancestral sibling, got (%v,%v)", got, ok)
+	}
+	// With two same-parent siblings and no anchor, a silent caller must NOT guess.
+	ambiguous, _ := siblingFaceBody(t, 7, true)
+	if _, ok := FindOrRecoverFace(ambiguous, lost); ok {
+		t.Error("FindOrRecoverFace must not guess between two anchorless siblings")
+	}
+}

--- a/model/feature/hole_boss.go
+++ b/model/feature/hole_boss.go
@@ -370,7 +370,19 @@ func (c *HoleFeatures) addHole(def *HoleDefinition) *PartFeature {
 // Add adds a cylindrical boss on the placement face, naming it (Boss1, Boss2, …) so its
 // generated topology has a stable, distinct lineage.
 func (c *BossFeatures) Add(faceKey []byte, diameter, height func() float64) *PartFeature {
-	bf := &BossFeature{def: &BossDefinition{PlacementFaceKey: faceKey, Diameter: diameter, Height: height}}
+	def := &BossDefinition{PlacementFaceKey: faceKey, Diameter: diameter, Height: height}
+	// Capture the placement face's mint-time anchor against the running body so the geometric
+	// recovery tier survives an upstream edit that renames the face (ADR-0043 P6 / #1579). Every
+	// authoring path funnels here; the recipe restore uses addBoss, which preserves persisted
+	// anchors and never recaptures (no doc-dirty churn on reopen).
+	def.FaceAnchors = captureFaceAnchors(featuresTipBody(c.engine), [][]byte{faceKey})
+	return c.addBoss(def)
+}
+
+// addBoss registers a boss from a fully-built definition without capturing anchors (the recipe
+// restore path, which carries the persisted anchors of its own).
+func (c *BossFeatures) addBoss(def *BossDefinition) *PartFeature {
+	bf := &BossFeature{def: def}
 	pf := c.engine.Add(bf)
 	pf.SetName(c.engine.UniqueName("Boss"))
 	bf.featName = pf.name

--- a/model/feature/hole_boss.go
+++ b/model/feature/hole_boss.go
@@ -248,6 +248,9 @@ type BossDefinition struct {
 	PlacementFaceKey []byte
 	Diameter         func() float64
 	Height           func() float64
+	// FaceAnchors maps the placement face key to its mint-time centroid for the geometric
+	// recovery tier (ADR-0043 P6 / #1579); see FilletDefinition.EdgeAnchors.
+	FaceAnchors map[string]math.Point3
 }
 
 // BossFeature adds a cylindrical boss to the running solid.
@@ -268,9 +271,9 @@ func (b *BossFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	face, ok := body.FindFaceByKey(b.def.PlacementFaceKey)
-	if !ok {
-		return Output{}, fmt.Errorf("boss: placement face reference lost")
+	face, mt, err := bindFace(body, b.def.PlacementFaceKey, anchorFor(b.def.PlacementFaceKey, b.def.FaceAnchors))
+	if err != nil {
+		return Output{}, fmt.Errorf("boss: %w", err)
 	}
 	r, h := callOrZero(b.def.Diameter)/2, callOrZero(b.def.Height)
 	if r <= 0 || h <= 0 {
@@ -285,7 +288,7 @@ func (b *BossFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, fmt.Errorf("boss: %w", err)
 	}
-	return Output{Bodies: replaceBody(in.Bodies, body, res)}, nil
+	return Output{Bodies: replaceBody(in.Bodies, body, res), Heals: faceHeal(b.def.PlacementFaceKey, mt)}, nil
 }
 
 // Operation reports that a boss adds material, so a pattern of a boss unions its raised

--- a/model/feature/identity_adapter.go
+++ b/model/feature/identity_adapter.go
@@ -34,19 +34,20 @@ func parentOfKey(refKey []byte) []byte {
 	return append([]byte(nil), s[:i]...)
 }
 
-// edgeLineage adapts a kernel edge's reference key to identity.Lineage +
+// keyLineage adapts a kernel reference key (of any entity kind) to identity.Lineage +
 // AncestralLineage. ParentKey derives the parent the same way for every entity (see
-// parentOfKey), which is what makes ancestral sibling matching consistent.
-type edgeLineage []byte // the edge's kernel reference key (kind byte + lineage)
+// parentOfKey), which is what makes ancestral sibling matching consistent — so edges and
+// faces share one adapter rather than two byte-identical copies.
+type keyLineage []byte // a kernel reference key (kind byte + lineage)
 
-func (l edgeLineage) LineageKey() []byte {
+func (l keyLineage) LineageKey() []byte {
 	if len(l) > 0 && l[0] < 0x20 {
 		return append([]byte(nil), l[1:]...)
 	}
 	return append([]byte(nil), l...)
 }
 
-func (l edgeLineage) ParentKey() []byte { return parentOfKey(l) }
+func (l keyLineage) ParentKey() []byte { return parentOfKey(l) }
 
 // edgeEntity adapts a *topo.Edge to identity.Entity (+ AncestralLineage for
 // ancestral recovery, + AnchoredEntity for the geometric tie-break used by P6b). It
@@ -54,7 +55,7 @@ func (l edgeLineage) ParentKey() []byte { return parentOfKey(l) }
 type edgeEntity struct{ e *topo.Edge }
 
 func (a edgeEntity) EntityKind() identity.EntityKind { return identity.KindEdge }
-func (a edgeEntity) Lineage() identity.Lineage       { return edgeLineage(a.e.ReferenceKey()) }
+func (a edgeEntity) Lineage() identity.Lineage       { return keyLineage(a.e.ReferenceKey()) }
 
 // Anchor reports the edge midpoint as its representative point — the geometric
 // tie-breaker the binder uses only when several siblings share a parent (P6b). It shares
@@ -109,4 +110,38 @@ func recoverEdge(refKey []byte, anchor *math.Point3, ents []identity.Entity) (*t
 		return nil, mt
 	}
 	return ent.(edgeEntity).e, mt
+}
+
+// faceEntity adapts a *topo.Face to identity.Entity (+ AncestralLineage via keyLineage, +
+// AnchoredEntity for the geometric tie-break). It is the face counterpart of edgeEntity, carrying
+// the live face so a recovered match can be unwrapped back to it (#1579 / ADR-0043 P6).
+type faceEntity struct{ f *topo.Face }
+
+func (a faceEntity) EntityKind() identity.EntityKind { return identity.KindFace }
+func (a faceEntity) Lineage() identity.Lineage       { return keyLineage(a.f.ReferenceKey()) }
+
+// Anchor reports the face centroid as its representative point — the geometric tie-breaker the
+// binder uses only when several siblings share a parent. It reuses topo.DescribeFace's centroid so
+// witness (captureFaceAnchors) and ranking use one definition of "the face's anchor".
+func (a faceEntity) Anchor() (math.Point3, bool) { return faceAnchor(a.f) }
+
+// faceEntities views every face of the body as an identity.Entity for the binder.
+func faceEntities(body *topo.Body) []identity.Entity {
+	faces := body.Faces()
+	out := make([]identity.Entity, len(faces))
+	for i, f := range faces {
+		out[i] = faceEntity{f}
+	}
+	return out
+}
+
+// recoverFace attempts to recover a lost/ambiguous face reference through the tiered binder — the
+// face counterpart of recoverEdge. It returns the recovered face and the match tier, or
+// (nil, MatchNone) when no defensible recovery exists.
+func recoverFace(refKey []byte, anchor *math.Point3, ents []identity.Entity) (*topo.Face, identity.MatchType) {
+	ent, mt := identity.RecoverLost(identity.KindFace, parentOfKey(refKey), anchor, ents)
+	if ent == nil {
+		return nil, mt
+	}
+	return ent.(faceEntity).f, mt
 }

--- a/model/feature/serialize_codecs_dressup.go
+++ b/model/feature/serialize_codecs_dressup.go
@@ -101,7 +101,8 @@ func init() {
 	})
 	registerFeatureCodec("unwrap", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
-			fd.Unwrap = &UnwrapData{Face: encodeKey(f.(*UnwrapFeature).def.FaceKey)}
+			uf := f.(*UnwrapFeature)
+			fd.Unwrap = &UnwrapData{Face: encodeKey(uf.def.FaceKey), FaceAnchors: encodeFaceAnchors(uf.def.FaceAnchors)}
 			return nil
 		},
 		decode: func(rc *restoreContext, fd FeatureData) (*PartFeature, error) {

--- a/model/feature/serialize_codecs_solid.go
+++ b/model/feature/serialize_codecs_solid.go
@@ -145,7 +145,7 @@ func init() {
 	registerFeatureCodec("boss", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			b := f.(*BossFeature)
-			fd.Boss = &BossData{Face: encodeKey(b.def.PlacementFaceKey), Diameter: evalFloat(b.def.Diameter), Height: evalFloat(b.def.Height)}
+			fd.Boss = &BossData{Face: encodeKey(b.def.PlacementFaceKey), Diameter: evalFloat(b.def.Diameter), Height: evalFloat(b.def.Height), FaceAnchors: encodeFaceAnchors(b.def.FaceAnchors)}
 			return nil
 		},
 		decode: func(rc *restoreContext, fd FeatureData) (*PartFeature, error) {
@@ -156,7 +156,8 @@ func init() {
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			t := f.(*ThreadFeature)
 			fd.Thread = &ThreadData{Face: encodeKey(t.def.FaceKey), Designation: t.def.Designation, Cut: t.def.Cut,
-				Class: t.def.Class, Tapered: t.def.Tapered, ModelDiameter: threadModelDiameterName(t.def.ModelDiameter)}
+				Class: t.def.Class, Tapered: t.def.Tapered, ModelDiameter: threadModelDiameterName(t.def.ModelDiameter),
+				FaceAnchors: encodeFaceAnchors(t.def.FaceAnchors)}
 			return nil
 		},
 		decode: decodeThread,
@@ -240,8 +241,12 @@ func decodeThread(rc *restoreContext, fd FeatureData) (*PartFeature, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewDressUpFeatures(rc.fs).AddThreadDef(&ThreadDefinition{FaceKey: key, Designation: fd.Thread.Designation,
-		Cut: fd.Thread.Cut, Class: fd.Thread.Class, Tapered: fd.Thread.Tapered, ModelDiameter: md}), nil
+	anchors, err := decodeFaceAnchors(fd.Thread.FaceAnchors)
+	if err != nil {
+		return nil, err
+	}
+	return NewDressUpFeatures(rc.fs).addThreadDef(&ThreadDefinition{FaceKey: key, Designation: fd.Thread.Designation,
+		Cut: fd.Thread.Cut, Class: fd.Thread.Class, Tapered: fd.Thread.Tapered, ModelDiameter: md, FaceAnchors: anchors}), nil
 }
 
 // decodeSnapFit rebuilds a cantilever snap-fit from its persisted dimensions.

--- a/model/feature/serialize_dressup.go
+++ b/model/feature/serialize_dressup.go
@@ -66,6 +66,13 @@ type EdgeAnchorData struct {
 	Midpoint []float64 `yaml:"midpoint,flow"`
 }
 
+// FaceAnchorData is the serialized mint-time anchor of one picked face: its reference key (base64)
+// and centroid, used to disambiguate surviving siblings when the exact key is lost (#1579).
+type FaceAnchorData struct {
+	Key      string    `yaml:"key"`
+	Centroid []float64 `yaml:"centroid,flow"`
+}
+
 // GeomEdgeRefData is the serialized form of a geometric edge descriptor: the edge's
 // midpoint and (sign-agnostic) direction in model space. It binds to a running-body edge
 // at recompute via [topo.Body.FindEdgeByGeometry] (ADR-0040).
@@ -236,12 +243,13 @@ type SnapFitData struct {
 // the #325 parity fields: the tolerance class, the tapered (pipe) flag, and which thread
 // diameter the modeled face represents (wire spelling; absent = major).
 type ThreadData struct {
-	Face          string `yaml:"face"`
-	Designation   string `yaml:"designation"`
-	Cut           bool   `yaml:"cut,omitempty"`
-	Class         string `yaml:"class,omitempty"`
-	Tapered       bool   `yaml:"tapered,omitempty"`
-	ModelDiameter string `yaml:"modelDiameter,omitempty"`
+	Face          string           `yaml:"face"`
+	Designation   string           `yaml:"designation"`
+	Cut           bool             `yaml:"cut,omitempty"`
+	Class         string           `yaml:"class,omitempty"`
+	Tapered       bool             `yaml:"tapered,omitempty"`
+	ModelDiameter string           `yaml:"modelDiameter,omitempty"`
+	FaceAnchors   []FaceAnchorData `yaml:"faceAnchors,omitempty"`
 }
 
 // dressInputs is the decoded (keys, value) pair shared by edge/face dress-ups, plus any
@@ -297,6 +305,37 @@ func decodeEdgeAnchors(data []EdgeAnchorData) (map[string]math.Point3, error) {
 			return nil, err
 		}
 		out[string(k)] = decodePoint3(d.Midpoint)
+	}
+	return out, nil
+}
+
+// encodeFaceAnchors / decodeFaceAnchors round-trip the mint-time face-anchor map (#1579), the
+// face counterpart of encodeEdgeAnchors: keys are base64 reference keys, values are centroids.
+// Empty for a feature authored with no captured anchors or restored from a pre-#1579 recipe.
+func encodeFaceAnchors(anchors map[string]math.Point3) []FaceAnchorData {
+	if len(anchors) == 0 {
+		return nil
+	}
+	out := make([]FaceAnchorData, 0, len(anchors))
+	for k, p := range anchors {
+		out = append(out, FaceAnchorData{Key: encodeKey([]byte(k)), Centroid: encodePoint3(p)})
+	}
+	// Deterministic order so the serialized document is stable across runs (maps iterate randomly).
+	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
+	return out
+}
+
+func decodeFaceAnchors(data []FaceAnchorData) (map[string]math.Point3, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]math.Point3, len(data))
+	for _, d := range data {
+		k, err := decodeKey(d.Key)
+		if err != nil {
+			return nil, err
+		}
+		out[string(k)] = decodePoint3(d.Centroid)
 	}
 	return out, nil
 }

--- a/model/feature/serialize_simplify.go
+++ b/model/feature/serialize_simplify.go
@@ -13,7 +13,8 @@ type SimplifyData struct {
 
 // UnwrapData is the serialized form of an UnwrapFeature: the cylindrical face flattened.
 type UnwrapData struct {
-	Face string `yaml:"face"`
+	Face        string           `yaml:"face"`
+	FaceAnchors []FaceAnchorData `yaml:"faceAnchors,omitempty"`
 }
 
 // restoreSimplify rebuilds a SimplifyFeature.
@@ -37,5 +38,9 @@ func restoreUnwrap(fs *PartFeatures, d *UnwrapData) (*PartFeature, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewModifyFeatures(fs).AddUnwrap(key), nil
+	anchors, err := decodeFaceAnchors(d.FaceAnchors)
+	if err != nil {
+		return nil, err
+	}
+	return NewModifyFeatures(fs).addUnwrap(&UnwrapDefinition{FaceKey: key, FaceAnchors: anchors}), nil
 }

--- a/model/feature/serialize_solid.go
+++ b/model/feature/serialize_solid.go
@@ -33,9 +33,10 @@ type HoleData struct {
 
 // BossData is a boss's recipe: a raised cylinder on a placement face.
 type BossData struct {
-	Face     string  `yaml:"face"`
-	Diameter float64 `yaml:"diameter"`
-	Height   float64 `yaml:"height"`
+	Face        string           `yaml:"face"`
+	Diameter    float64          `yaml:"diameter"`
+	Height      float64          `yaml:"height"`
+	FaceAnchors []FaceAnchorData `yaml:"faceAnchors,omitempty"`
 }
 
 // CombineData booleans two running bodies (by index) under an operation.
@@ -110,7 +111,13 @@ func restoreBoss(fs *PartFeatures, b *BossData) (*PartFeature, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewBossFeatures(fs).Add(key, constFloat(b.Diameter), constFloat(b.Height)), nil
+	anchors, err := decodeFaceAnchors(b.FaceAnchors)
+	if err != nil {
+		return nil, err
+	}
+	return NewBossFeatures(fs).addBoss(&BossDefinition{
+		PlacementFaceKey: key, Diameter: constFloat(b.Diameter), Height: constFloat(b.Height), FaceAnchors: anchors,
+	}), nil
 }
 
 func restoreCombine(fs *PartFeatures, c *CombineData) (*PartFeature, error) {

--- a/model/feature/sweep_loft.go
+++ b/model/feature/sweep_loft.go
@@ -470,7 +470,7 @@ func sectionNormal(s LoftSection) math.UnitVector3 {
 // findFace resolves a face reference key against the running bodies (persistent naming).
 func findFace(bodies []*topo.Body, key []byte) (*topo.Face, bool) {
 	for _, b := range bodies {
-		if f, ok := b.FindFaceByKey(key); ok {
+		if f, ok := FindOrRecoverFace(b, key); ok {
 			return f, true
 		}
 	}

--- a/model/feature/thread_display.go
+++ b/model/feature/thread_display.go
@@ -24,7 +24,7 @@ func ThreadDisplayCurves(fs *PartFeatures) [][]math.Point3 {
 			continue
 		}
 		for _, b := range bodies {
-			f, ok := b.FindFaceByKey(tf.def.FaceKey)
+			f, ok := FindOrRecoverFace(b, tf.def.FaceKey)
 			if !ok {
 				continue
 			}

--- a/model/feature/unwrap.go
+++ b/model/feature/unwrap.go
@@ -19,6 +19,9 @@ import (
 // UnwrapDefinition names the cylindrical face to flatten.
 type UnwrapDefinition struct {
 	FaceKey []byte
+	// FaceAnchors maps FaceKey to its mint-time centroid for the geometric recovery tier
+	// (ADR-0043 P6 / #1579); see FilletDefinition.EdgeAnchors.
+	FaceAnchors map[string]math.Point3
 }
 
 // UnwrapFeature appends the flattened patch of its cylindrical face.
@@ -39,15 +42,15 @@ func (u *UnwrapFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	face, ok := body.FindFaceByKey(u.def.FaceKey)
-	if !ok {
-		return Output{}, fmt.Errorf("unwrap: face reference lost")
+	face, mt, err := bindFace(body, u.def.FaceKey, anchorFor(u.def.FaceKey, u.def.FaceAnchors))
+	if err != nil {
+		return Output{}, fmt.Errorf("unwrap: %w", err)
 	}
 	patch, err := unwrapCylindricalFace(face, featOr(u.featName, "unwrap"))
 	if err != nil {
 		return Output{}, err
 	}
-	return Output{Bodies: append(append([]*topo.Body(nil), in.Bodies...), patch)}, nil
+	return Output{Bodies: append(append([]*topo.Body(nil), in.Bodies...), patch), Heals: faceHeal(u.def.FaceKey, mt)}, nil
 }
 
 // unwrapCylindricalFace unrolls a cylindrical face into a flat rectangle sheet of arc-length ×

--- a/model/feature/unwrap.go
+++ b/model/feature/unwrap.go
@@ -112,9 +112,19 @@ func flatSheet(w, h float64, feat string) *topo.Body {
 	return bld.Build()
 }
 
-// AddUnwrap appends the flattened patch of the cylindrical face referenced by faceKey.
+// AddUnwrap appends the flattened patch of the cylindrical face referenced by faceKey. It captures
+// the face's mint-time anchor against the running body for the geometric recovery tier (ADR-0043
+// P6 / #1579); the recipe restore uses addUnwrap so reopening never recaptures.
 func (c *ModifyFeatures) AddUnwrap(faceKey []byte) *PartFeature {
-	uf := &UnwrapFeature{def: &UnwrapDefinition{FaceKey: faceKey}}
+	def := &UnwrapDefinition{FaceKey: faceKey}
+	def.FaceAnchors = captureFaceAnchors(featuresTipBody(c.engine), [][]byte{faceKey})
+	return c.addUnwrap(def)
+}
+
+// addUnwrap registers an unwrap from a fully-built definition without capturing anchors (the
+// recipe restore path, which carries the persisted anchors of its own).
+func (c *ModifyFeatures) addUnwrap(def *UnwrapDefinition) *PartFeature {
+	uf := &UnwrapFeature{def: def}
 	pf := c.engine.Add(uf)
 	pf.SetName(c.engine.UniqueName("Unwrap"))
 	uf.featName = pf.name

--- a/model/feature/work_surface_ref.go
+++ b/model/feature/work_surface_ref.go
@@ -94,7 +94,7 @@ func (g *WorkGeometry) surface(ref WorkRef) (geom.Surface, error) {
 		return nil, fmt.Errorf("work geometry: no body yet to resolve face %q", ref)
 	}
 	for _, b := range g.bodies {
-		if f, ok := b.FindFaceByKey(key); ok {
+		if f, ok := FindOrRecoverFace(b, key); ok {
 			return f.Geometry(), nil
 		}
 	}


### PR DESCRIPTION
## What

Faces get the same `exact → ancestral → geometric → none` recovery ladder that edges received in ADR-0043 P6a/P6b. Before this, every face-key resolution was **exact-or-fail**: a face reference that broke across a topological transition (split/merge/rename) went straight to lost/Sick, missing the auto-heal-to-Warning edges already enjoy. Reuses the **same tested binder** (`model/identity.fallbackMatch`) via a new face adapter — one recovery implementation, not two.

Closes #1579.

## The seam (one place, mirrors `resolveEdges`)

`model/feature/face_bind.go`:
- `bindFace(body, key, anchor)` — bind one face, returns the match tier; the ADR-0043 **P0 collision guard** lives here (`>1` match with no recovery is an honest error, never a silent first-match).
- `resolveFaces(body, keys, anchors)` — batch form that collects heals for features returning an `Output`.
- `FindOrRecoverFace(body, key)` — exported silent helper (ancestral-only) for best-effort callers with no health channel.

`identity_adapter.go`: generalized `edgeLineage → keyLineage` (kind-agnostic, one copy) and added `faceEntity`/`faceEntities`/`recoverFace`. The face anchor is `topo.DescribeFace`'s centroid, so **no `kernel/topo` change** is needed.

## Per-site routing (heterogeneous on purpose)

| Treatment | Sites | Why |
|---|---|---|
| **Heal → Warning** | boss, thread, unwrap, deferred faces | authored picks with a health channel |
| **Silent recover** (ancestral) | work-surface source, loft section, face-fillet gap finder, thread-display helix, compdef face surface source | a recovered bind beats a false loss; never guesses |
| **Exact-only (left as-is)** | `FaceKeyResolves` health probe; sheet-metal fold map | the probe must report drift, not hide it; the fold map's front/back faces deliberately share one key and disambiguate by normal |

Holes keep their existing `GeomFace` descriptor recovery; unifying the two geometric mechanisms is a documented follow-up (ADR-2 in the design), not this change.

The cut-thread path now retypes the **resolved** face's current key, so a healed thread targets the recovered face rather than the stale stored key (the face analog of the edge `currentKeys` fix).

## Geometric tier: capture + persistence (2nd commit)

The geometric tier needs the picked face's mint-time centroid. `captureFaceAnchors` records it at authoring time against the running body, on **every** authoring path (not GUI-only — the P6b lesson). Boss/thread/unwrap builders were split into a capturing public path and a non-capturing restore path (`addBoss`/`addThreadDef`/`addUnwrap`), so reopening a document preserves persisted anchors and never recaptures (no doc-dirty churn) — the same split fillet/chamfer use. `FaceAnchors` round-trip through `BossData`/`ThreadData`/`UnwrapData` via a new `FaceAnchorData` codec. Capture is skipped before the first recompute, degrading cleanly to ancestral-only.

## Honesty invariant

On a transition we never bind the wrong face: recovery returns a face only on exact-one or a *defensible* tier (lone ancestral sibling, or geometric nearest with a clear winner); a tie, an anchorless ambiguity, or a true loss stays lost. Inherited free from `fallbackMatch`.

## Tests

`model/feature/face_recovery_test.go` (binder tiers: ancestral heal, anchorless-ambiguous refusal, geometric-by-anchor, exact, P0 collision, silent recover) and `face_anchor_persistence_test.go` (capture-on-author, no-capture-before-recompute, codec round trip, boss recipe round trip). Full `model/feature`, `model/compdef`, `addin/...`, `app/...` suites green; `go vet ./...` and `golangci-lint` clean.

Note: the recovery *mechanism* is unit-tested and reuses the already-live edge binder; this surface is behavioral (health classification), not visual. A real-host transition test confirming real face provenance yields parent-sharing siblings is a reasonable follow-up — the same provenance-completeness precondition the edge tier relies on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)