### PR TITLE
Route dockableWindows.setValue to Session.PanelValueChanged

### DIFF
--- a/addin/router/ui_surfaces.go
+++ b/addin/router/ui_surfaces.go
@@ -17,6 +17,7 @@ func (r *Router) registerUISurfaceHandlers() {
 	r.readOnly(wire.MethodBrowserListPanes, listBrowserPanes)
 	r.readOnly(wire.MethodDockableWindowsSet, setDockableWindow)
 	r.readOnly(wire.MethodDockableWindowsSetVisible, setDockableWindowVisible)
+	r.readOnly(wire.MethodDockableWindowsSetValue, setDockableWindowValue)
 	r.readOnly(wire.MethodDockableWindowsDelete, deleteDockableWindow)
 	r.readOnly(wire.MethodDockableWindowsList, listDockableWindows)
 	r.readOnly(wire.MethodUIListEnvironments, listEnvironments)
@@ -73,6 +74,19 @@ func setDockableWindowVisible(s *app.Session, args json.RawMessage) (json.RawMes
 	if err := s.SetDockableWindowVisible(req.ID, req.Visible); err != nil {
 		return nil, err
 	}
+	return ok()
+}
+
+// setDockableWindowValue drives one editable control of a dockable window to a value, exactly as a
+// user edit would: the host updates the stored control and notifies the owning add-in
+// (wire dockableWindows.setValue). Lets automation/MCP edit add-in panels (e.g. switch the CAM
+// simulator's View dropdown).
+func setDockableWindowValue(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
+	var req wire.SetDockableWindowValueArgs
+	if err := decode(args, &req); err != nil {
+		return nil, err
+	}
+	s.PanelValueChanged(req.WindowId, req.ControlId, req.Value)
 	return ok()
 }
 

--- a/addin/router/ui_surfaces_test.go
+++ b/addin/router/ui_surfaces_test.go
@@ -57,6 +57,22 @@ func TestDockableWindowsOverWire(t *testing.T) {
 	}
 }
 
+// TestDockableWindowSetValueOverWire checks setValue drives an editable control to a new value (as a
+// user edit would), updating the stored window so a re-read reflects it.
+func TestDockableWindowSetValueOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "dockableWindows.set",
+		`{"window":{"id":"sim.panel","title":"Sim","dock":2,"visible":true,"controls":[{"kind":6,"id":"sim_view","value":"Material","options":["Material","Path"]}]}}`, nil)
+
+	call(t, r, s, "dockableWindows.setValue", `{"windowId":"sim.panel","controlId":"sim_view","value":"Path"}`, nil)
+
+	var lst wire.ListDockableWindowsResult
+	call(t, r, s, "dockableWindows.list", "{}", &lst)
+	if len(lst.Windows) != 1 || lst.Windows[0].Controls[0].Value != "Path" {
+		t.Errorf("control value = %+v, want Path after setValue", lst.Windows)
+	}
+}
+
 func TestListEnvironmentsOverWire(t *testing.T) {
 	r, s := seededSession(t)
 	var res wire.ListEnvironmentsResult

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.99.0
+	oblikovati.org/api v0.100.1
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.99.0
+	oblikovati.org/api v0.100.1
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)


### PR DESCRIPTION
## What

Implements the new `dockableWindows.setValue` wire method: drive one editable control of an add-in dockable window to a value, taking the **same path the head UI takes on a user edit** — `Session.PanelValueChanged` updates the stored control and emits the event the owning add-in reacts to.

Lets automation/MCP edit add-in panels — e.g. switch the CAM simulator's **View** dropdown to **Path**.

## Tests

`TestDockableWindowSetValueOverWire`: `setValue` drives a dropdown to a new value, and a re-read reflects it.

## Dependency

Requires `oblikovati.org/api` with `dockableWindows.setValue` — **Oblikovati.API#221**. Merge that first (CI resolves the sibling api).

🤖 Generated with [Claude Code](https://claude.com/claude-code)