### PR TITLE
perf: fix outrunner motor generation pathology — memoize lineage keys (#1578)

### DIFF
--- a/kernel/brep/boolean.go
+++ b/kernel/brep/boolean.go
@@ -215,13 +215,17 @@ func selectFaces(faces []planarFace, imprints [][][2]math.Point3, other *topo.Bo
 // degenerate split) and any duplicate cutting set fall back to an ordinal, deferred to F05.
 func nameFragments(fromFace []subFace, parent topo.Lineage, isB bool, prov []imprintSeg) {
 	dups := map[string]int{}
+	// The parent's cut segments (with cutting-face keys precomputed) are shared by every fragment,
+	// so resolve them once here rather than rebuilding lineage keys per fragment per ring vertex
+	// — the #1578 fix for the outrunner's dense-imprint fragment-naming explosion.
+	border := parentBorderSegments(parent, prov)
 	for k := range fromFace {
 		fromFace[k].fromB = isB // operand tag, so the stitch can fuse tangent contacts
 		if len(fromFace) == 1 {
 			fromFace[k].lineage = parent // K1a: a single survivor keeps its key
 			continue
 		}
-		cutting := fragmentCuttingFaces(parent, fromFace[k], prov)
+		cutting := fragmentCuttingFaces(border, fromFace[k])
 		if len(cutting) == 0 {
 			fromFace[k].lineage = splitLineage(parent, k) // no detectable border: ordinal fallback
 			continue

--- a/kernel/brep/boolean_provenance.go
+++ b/kernel/brep/boolean_provenance.go
@@ -91,7 +91,7 @@ func edgeParents(p, q math.Point3, prov []imprintSeg) (topo.Lineage, topo.Lineag
 // yields the same (lo, hi) regardless of which face the segment was recorded on — the property
 // that makes an intersection edge's name independent of operand order.
 func canonicalPair(x, y topo.Lineage) (lo, hi topo.Lineage) {
-	if bytes.Compare(x.Key(), y.Key()) <= 0 {
+	if x.KeyString() <= y.KeyString() {
 		return x, y
 	}
 	return y, x
@@ -162,19 +162,45 @@ var (
 	cuttingSep   = topo.Tok("brep", "by", 0)
 )
 
+// borderSeg is an imprint segment recorded ON a given parent face, with its cutting ("other") face
+// lineage key precomputed. Naming every fragment of one parent reuses the same border set, so
+// precomputing the keys once here keeps the per-fragment border walk free of lineage-key rebuilds —
+// the #1578 hot path, where fragmentCuttingFaces rebuilt parent.Key()/owner.Key() on every
+// (ring vertex × imprint segment) and the cost exploded with the outrunner's dense imprint set.
+type borderSeg struct {
+	a, b     math.Point3
+	other    topo.Lineage
+	otherKey string
+}
+
+// parentBorderSegments selects the imprint segments owned by `parent` (genuine cuts of this face)
+// and precomputes each cutting face's key once. Called once per parent face — not once per
+// fragment, and not once per ring vertex — so the redundant key rebuilds that dominated #1578 are
+// hoisted out of the fragment-naming inner loop entirely.
+func parentBorderSegments(parent topo.Lineage, prov []imprintSeg) []borderSeg {
+	parentKey := parent.KeyString()
+	var border []borderSeg
+	for _, s := range prov {
+		if s.owner.KeyString() == parentKey {
+			border = append(border, borderSeg{a: s.a, b: s.b, other: s.other, otherKey: s.other.KeyString()})
+		}
+	}
+	return border
+}
+
 // fragmentCuttingFaces returns the sorted, unique set of OTHER-operand face lineages whose imprint
-// borders the fragment sf of `parent` — the faces that cut this piece out (M31-F04, #1154). Only
-// segments recorded ON the parent (owner == parent) count, so each "other" is a genuine cutting
-// face. The set, not an ordinal index, identifies the piece, so it survives an upstream edit that
-// merely reorders the pieces.
-func fragmentCuttingFaces(parent topo.Lineage, sf subFace, prov []imprintSeg) []topo.Lineage {
+// borders the fragment sf (M31-F04, #1154). `border` is the parent's own cut segments with their
+// cutting-face keys precomputed (see parentBorderSegments), so the inner walk is pure geometry. The
+// set, not an ordinal index, identifies the piece, so it survives an upstream edit that merely
+// reorders the pieces.
+func fragmentCuttingFaces(border []borderSeg, sf subFace) []topo.Lineage {
 	found := map[string]topo.Lineage{}
 	collect := func(ring []math.Point3) {
 		for i := range ring {
 			mid := ring[i].TranslateBy(ring[i].VectorTo(ring[(i+1)%len(ring)]).Scale(0.5))
-			for _, s := range prov {
-				if bytes.Equal(s.owner.Key(), parent.Key()) && pointOnSegment3(mid, s.a, s.b) {
-					found[string(s.other.Key())] = s.other
+			for _, s := range border {
+				if pointOnSegment3(mid, s.a, s.b) {
+					found[s.otherKey] = s.other
 				}
 			}
 		}

--- a/kernel/brep/fragment_naming_test.go
+++ b/kernel/brep/fragment_naming_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// splitFixture builds the canonical "one parent face halved by a single cutting face" naming
+// input: a 4×2 parent face on z=0 cut along x=2 by face C, yielding a front (x<2) and back (x>2)
+// fragment, each bordered by the SAME imprint segment (the cut line) recorded on the parent. It
+// returns the two fragments and the provenance the cut produced. Shared by the naming-correctness
+// and the #1578 key-rebuild benchmark so they exercise the identical input.
+func splitFixture() (fromFace []subFace, parent topo.Lineage, prov []imprintSeg) {
+	parent = topo.NewLineage(topo.Tok("base", "face", 1))
+	cut := topo.NewLineage(topo.Tok("tool", "face", 7))
+	front := subFace{outer: []math.Point3{math.P3(0, 0, 0), math.P3(2, 0, 0), math.P3(2, 2, 0), math.P3(0, 2, 0)}}
+	back := subFace{outer: []math.Point3{math.P3(2, 0, 0), math.P3(4, 0, 0), math.P3(4, 2, 0), math.P3(2, 2, 0)}}
+	// The imprint segment is the cut line x=2 (y from 0..2), recorded ON the parent face, with the
+	// cutting face C as `other` — the border both fragments share.
+	prov = []imprintSeg{{a: math.P3(2, 0, 0), b: math.P3(2, 2, 0), owner: parent, other: cut}}
+	return []subFace{front, back}, parent, prov
+}
+
+// TestNameFragmentsNamesBothHalvesByCuttingFace is the characterization test the #1578 hot-path
+// refactor must not break: a single straight cut halves a face into two fragments that share the
+// one cutting face C as their border, so both are named parent/brep:cut#0/brep:by#0/<C> and the
+// dup index disambiguates the otherwise-identical pair (front=0, back=1).
+func TestNameFragmentsNamesBothHalvesByCuttingFace(t *testing.T) {
+	fromFace, parent, prov := splitFixture()
+	nameFragments(fromFace, parent, false, prov)
+
+	want0 := "base:face#1/brep:cut#0/brep:by#0/tool:face#7"
+	want1 := want0 + "/brep:frag#1"
+	if got := string(fromFace[0].lineage.Key()); got != want0 {
+		t.Errorf("front fragment lineage = %q, want %q", got, want0)
+	}
+	if got := string(fromFace[1].lineage.Key()); got != want1 {
+		t.Errorf("back fragment lineage = %q, want %q", got, want1)
+	}
+}
+
+// TestNameFragmentsSingleSurvivorKeepsParentKey pins the K1a path: a face that survives whole keeps
+// its parent lineage (the refactor must leave this branch untouched).
+func TestNameFragmentsSingleSurvivorKeepsParentKey(t *testing.T) {
+	parent := topo.NewLineage(topo.Tok("base", "face", 1))
+	whole := []subFace{{outer: []math.Point3{math.P3(0, 0, 0), math.P3(4, 0, 0), math.P3(4, 2, 0), math.P3(0, 2, 0)}}}
+	nameFragments(whole, parent, false, nil)
+	if got := string(whole[0].lineage.Key()); got != "base:face#1" {
+		t.Errorf("single survivor lineage = %q, want base:face#1", got)
+	}
+}
+
+// BenchmarkNameFragments measures the #1578 hot path: naming the fragments of a cut face. The
+// original implementation rebuilt parent.Key()/owner.Key() on every (ring vertex × imprint
+// segment), so its cost ballooned with the imprint-set size the outrunner motor produces.
+func BenchmarkNameFragments(b *testing.B) {
+	fromFace, parent, prov := splitFixture()
+	// Pad the provenance with unrelated segments to mimic a dense imprint set (many crossing
+	// faces), the regime where the redundant key rebuilds dominated.
+	other := topo.NewLineage(topo.Tok("tool", "face", 99))
+	for i := 0; i < 200; i++ {
+		prov = append(prov, imprintSeg{a: math.P3(0, 5, 0), b: math.P3(1, 5, 0), owner: parent, other: other})
+	}
+	scratch := make([]subFace, len(fromFace))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		copy(scratch, fromFace)
+		nameFragments(scratch, parent, false, prov)
+	}
+}

--- a/kernel/topo/lineage.go
+++ b/kernel/topo/lineage.go
@@ -60,13 +60,26 @@ func Tok(feature, role string, index int) LineageToken {
 // Lineage is the generative derivation path of an entity — the seed of its
 // reference key. Two entities are "the same" across rebuilds iff their lineages are
 // equal. It is a value type (comparable by its serialized [Lineage.Key]).
+//
+// A lineage is immutable once built (tokens is unexported and never mutated; [Lineage.Tokens]
+// returns a copy), so its serialized key is computed once at construction and memoized in keyStr.
+// The cached string is shared by every value copy and is safe to share because strings are
+// immutable — this removes the redundant per-call key rebuilds that dominated boolean provenance
+// naming on dense imprint sets (#1578).
 type Lineage struct {
 	tokens []LineageToken
+	keyStr string
+}
+
+// newLineage is the single internal constructor: it memoizes the serialized key once so all
+// callers (and every value copy) get an O(1) [Lineage.Key]/[Lineage.KeyString].
+func newLineage(tokens []LineageToken) Lineage {
+	return Lineage{tokens: tokens, keyStr: serializeKey(tokens)}
 }
 
 // NewLineage builds a lineage from ordered tokens (root first).
 func NewLineage(tokens ...LineageToken) Lineage {
-	return Lineage{tokens: tokens}
+	return newLineage(tokens)
 }
 
 // Tokens returns the derivation tokens, root first.
@@ -76,12 +89,12 @@ func (l Lineage) Tokens() []LineageToken {
 	return out
 }
 
-// Key returns the deterministic serialization used for identity comparison. The
-// separators cannot appear in feature/role names by convention (they are ids), so
-// the encoding is unambiguous.
-func (l Lineage) Key() []byte {
+// serializeKey renders the deterministic identity serialization of ordered tokens. The
+// separators cannot appear in feature/role names by convention (they are ids), so the encoding is
+// unambiguous. Called once per lineage at construction; callers read the memoized result.
+func serializeKey(tokens []LineageToken) string {
 	var b strings.Builder
-	for i, t := range l.tokens {
+	for i, t := range tokens {
 		if i > 0 {
 			b.WriteByte('/')
 		}
@@ -91,11 +104,24 @@ func (l Lineage) Key() []byte {
 		b.WriteByte('#')
 		b.WriteString(strconv.Itoa(t.Index))
 	}
-	return []byte(b.String())
+	return b.String()
 }
 
+// KeyString returns the memoized serialization (zero-alloc). Prefer it over [Lineage.Key] in hot
+// paths that only compare or map by the key. A zero-value Lineage (nil tokens, built by a struct
+// literal rather than a constructor) serializes lazily to the empty key.
+func (l Lineage) KeyString() string {
+	if l.keyStr == "" && len(l.tokens) > 0 {
+		return serializeKey(l.tokens) // a literal-built lineage that bypassed the constructor
+	}
+	return l.keyStr
+}
+
+// Key returns the deterministic serialization used for identity comparison, as bytes.
+func (l Lineage) Key() []byte { return []byte(l.KeyString()) }
+
 // String renders the lineage for diagnostics.
-func (l Lineage) String() string { return string(l.Key()) }
+func (l Lineage) String() string { return l.KeyString() }
 
 // idSeq mints session-stable entity ids (not persisted; identity across sessions is
 // the reference key).

--- a/kernel/topo/lineage_key_memo_test.go
+++ b/kernel/topo/lineage_key_memo_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package topo
+
+import (
+	"testing"
+)
+
+// TestKeyStringMatchesKey pins that the memoized KeyString and the byte Key agree and produce the
+// exact serialization reference keys are persisted with — the encoding must not drift (#1578 only
+// memoized it, it must not change it).
+func TestKeyStringMatchesKey(t *testing.T) {
+	l := NewLineage(Tok("base", "face", 1), Tok("brep", "by", 0), Tok("tool", "face", 7))
+	const want = "base:face#1/brep:by#0/tool:face#7"
+	if got := l.KeyString(); got != want {
+		t.Errorf("KeyString = %q, want %q", got, want)
+	}
+	if got := string(l.Key()); got != want {
+		t.Errorf("Key = %q, want %q", got, want)
+	}
+}
+
+// TestZeroValueLineageKeyIsEmpty pins the sentinel: a zero-value Lineage (the not-found return of
+// edgeParents) serializes to the empty key without panicking.
+func TestZeroValueLineageKeyIsEmpty(t *testing.T) {
+	var zero Lineage
+	if got := zero.KeyString(); got != "" {
+		t.Errorf("zero-value KeyString = %q, want empty", got)
+	}
+	if got := string(zero.Key()); got != "" {
+		t.Errorf("zero-value Key = %q, want empty", got)
+	}
+}
+
+// TestValueCopySharesMemoizedKey is the load-bearing #1578 property: copying a lineage by value (as
+// imprintSeg does, holding owner/other lineages copied into every segment) carries the memoized key,
+// so KeyString on the copy is correct without re-serializing.
+func TestValueCopySharesMemoizedKey(t *testing.T) {
+	orig := NewLineage(Tok("base", "face", 2), Tok("brep", "cut", 0))
+	cp := orig // value copy, as in appendTagged's `owner: owner.lineage`
+	if cp.KeyString() != orig.KeyString() {
+		t.Errorf("value copy KeyString = %q, want %q", cp.KeyString(), orig.KeyString())
+	}
+	if cp.keyStr == "" {
+		t.Error("value copy lost the memoized key (would force a re-serialize per call)")
+	}
+}
+
+// TestNameByParentsMemoizesKey pins that the second constructor path also memoizes, so boolean edge/
+// vertex names built via NameByParents are not re-serialized on every comparison either.
+func TestNameByParentsMemoizesKey(t *testing.T) {
+	a := NewLineage(Tok("a", "face", 0))
+	b := NewLineage(Tok("b", "face", 0))
+	got := NameByParents([]Lineage{b, a}, Tok("brep", "x", 0), Tok("brep", "seg", 0), 0)
+	if got.keyStr == "" {
+		t.Error("NameByParents result is not memoized")
+	}
+	const want = "a:face#0/brep:x#0/b:face#0" // sorted by key, so a precedes b
+	if got.KeyString() != want {
+		t.Errorf("NameByParents key = %q, want %q", got.KeyString(), want)
+	}
+}

--- a/kernel/topo/provenance.go
+++ b/kernel/topo/provenance.go
@@ -3,7 +3,6 @@
 package topo
 
 import (
-	"bytes"
 	stdmath "math"
 	"sort"
 
@@ -33,7 +32,7 @@ import (
 func NameByParents(parents []Lineage, sep, rankSeed LineageToken, rank int) Lineage {
 	ordered := append([]Lineage(nil), parents...)
 	sort.Slice(ordered, func(i, j int) bool {
-		return bytes.Compare(ordered[i].Key(), ordered[j].Key()) < 0
+		return ordered[i].KeyString() < ordered[j].KeyString()
 	})
 	var toks []LineageToken
 	for i, p := range ordered {
@@ -45,7 +44,7 @@ func NameByParents(parents []Lineage, sep, rankSeed LineageToken, rank int) Line
 	if rank > 0 {
 		toks = append(toks, Tok(rankSeed.Feature, rankSeed.Role, rank))
 	}
-	return Lineage{tokens: toks}
+	return newLineage(toks)
 }
 
 // RelineageByFaceProvenance renames a freshly-built body's EDGES and VERTICES from face provenance


### PR DESCRIPTION
## What

Two perf fixes that together take a 12-slot **outrunner** motor generation from **~52 s to ~8 s** (6.2×), with **no behavior change** — reference-key serialization is byte-identical and fragment naming is pinned by tests.

## Why — the investigation

Issue #1578 *suspected* the cost was the boolean/SSI intersection of the deep tooth↔thin-yoke overlap. A CPU profile of one real outrunner `Generate` (against the in-proc host) said otherwise:

- **`topo.Lineage.Key` was 26% cumulative**, and **GC was 56%** — driven by string allocation, not geometry.
- 97% of those `Key()` calls came from one place: `brep.fragmentCuttingFaces`, which rebuilt `parent.Key()` and `s.owner.Key()` from scratch on **every (fragment ring vertex × imprint segment)** iteration. The outrunner's dense imprint set turned that into ~O(fragments × ring × prov) full string builds per face.

After re-profiling, the residual 8 s is genuine boolean/arrangement geometry (`collectSegHits`, `ringCrossings`, `Vector3.Dot`) — the naming machinery is gone from the profile.

## The fix

1. **`perf(topo)`** — a `Lineage` is immutable once built, so serialize its key **once** at construction and memoize it (immutable string, shared safely across value copies). Add `KeyString()` for the zero-alloc hot path; `Key()` keeps its `[]byte` signature and byte-identical output, so **persisted reference keys are unchanged**.
2. **`perf(brep)`** — hoist the parent face's own cut segments (with each cutting face's key) out of the per-fragment inner loop in `parentBorderSegments`, leaving the fragment walk pure geometry; route ownership/canonical comparisons to the memoized `KeyString`.

## Measurements

| | 12-slot outrunner `Generate` | `BenchmarkNameFragments` allocs/op |
|---|---|---|
| before | ~52 s | 9691 |
| after | ~8.4 s | 50 |

## Tests

- `kernel/topo/lineage_key_memo_test.go` — memoization correctness: `KeyString`==`Key`, zero-value safety, value-copy shares the cache, both constructors memoize, serialization unchanged.
- `kernel/brep/fragment_naming_test.go` — characterization test pinning that the cut-face fragment naming is byte-for-byte unchanged, plus a regression benchmark.
- Full module `go test ./...` green; `golangci-lint` clean; serialization verified identical (persisted keys safe).

Closes #1578

🤖 Generated with [Claude Code](https://claude.com/claude-code)