### PR TITLE
Conclude EPIC #1403: curved-boolean KIND taxonomy for drill / coaxial / boss

### DIFF
--- a/architecture/decisions/ADR-0045-curved-boolean-kind-taxonomy.md
+++ b/architecture/decisions/ADR-0045-curved-boolean-kind-taxonomy.md
@@ -1,0 +1,110 @@
+# ADR-0045 — Curved-boolean KIND taxonomy
+
+**Status:** Accepted (2026-07-01). · **Closes / concludes** the EPIC
+[Oblikovati#1403](https://github.com/Oblikovati/Oblikovati/issues/1403) (fold the bespoke
+analytic curved-boolean handlers into the general pipeline). · **Builds on**
+[ADR-0027](ADR-0027-curved-face-boolean.md) §M2 (the exact analytic curved boolean),
+Oblikovati#1476 (the general SSI → (u,v)-arrangement → classify → stitch pipeline),
+[ADR-0043](ADR-0043-generalized-provenance-naming.md) (curved-stitch edge provenance) and
+[ADR-0042](ADR-0042-model-scale-and-relative-tolerances.md) (model-relative tolerances). ·
+**Touches:** `kernel/ops/boolean.go` (`curvedExactPaths` dispatch),
+`kernel/ops/boolean_crossing_cylinder.go`, `kernel/brep/curved_coaxial_cylinder.go`,
+`kernel/brep/curved_cylinder_boss.go`, `kernel/brep/drill.go`.
+
+## Context
+
+EPIC #1403 set out to replace the ~21 bespoke per-primitive-pair analytic curved-boolean
+handlers with **one general pipeline**: trace the surface–surface intersection (SSI) imprint,
+project it into each operand's `(u,v)` band, subdivide that band with a planar arrangement,
+classify each cell by 3-D solid membership, and re-emit the kept boundary as exact analytic
+edges (`kernel/brep/curved_halfspace_uv_*`). Over #1403 that pipeline absorbed **every
+transversal ruled∩ruled crossing** — crossing cylinders, cone∩cone, cone∩cylinder, partial
+penetration, and finally the equal-radius Steinmetz bicylinder (intersect, cut and join;
+PR#1587/#1589), whose self-intersecting imprint is split at its analytic pinches into four open
+arcs so the arrangement never sees the crossing.
+
+Three bespoke handlers remained: **DrillThroughHole** (box − cylinder), **CoaxialCylinderUnion**
+(two coaxial equal-radius cylinders), and **JoinCylindricalBoss** (cylinder seated on a plate).
+The open question was whether these should also be routed through the `(u,v)` arrangement, or
+whether they are something else.
+
+Tracing the actual `uvSide` seam settles it. The `(u,v)` arrangement is built **exclusively for
+periodic parametric surfaces**: `paramOf` reads `u` as an azimuth (`atan2` about the axis, minus a
+placed `seamU`) and `v` as axial distance between two **rim circles**; the segment tags are
+`segImprint`/`segRim`/`segSeam`; `clipParams`/`sampleImprintUV` clip to an axial band
+`[vMin, vMax]`; `wrapsAllU` tests azimuthal wrap. This machinery earns its keep only when the
+imprint is a **1-D curve that non-trivially subdivides a periodic band** (multi-valued in `v`, or
+self-crossing). None of the three remaining handlers is that:
+
+- **Coaxial** — the two cylinders' side surfaces are **coincident** (the same `geom.Cylinder`).
+  There is no transversal crossing curve at all; the contact is a 2-D region. SSI is structurally
+  undefined, so the arrangement cannot apply.
+- **Drill / Boss** — the tool cylinder crosses the slab's/plate's **planar** faces in a circle
+  that lies **strictly inside one face**. A flat, bounded, non-periodic polygon face has no
+  azimuth seam and no rim circles; a `planeUV` operand would have to *fabricate* both to satisfy
+  the interface. And the result of a strictly-interior circle is trivially "add the circle as an
+  inner loop" — the arrangement's cell subdivision buys nothing.
+
+Meanwhile the dispatch is already sound: each path is gated once by `gatedCurved` (op guard +
+`validBooleanSolid`), and a boolean that reaches triangle-soup CSG is **already recorded** as a
+`CodeBooleanCSGFallback` defect (#1407) — not silent. The O(n²) *explosion* the EPIC targeted was
+the transversal ruled family (18 near-identical handlers), which is folded. The remaining three
+are one general analytic handler **each**, generic over face count and model-relative in
+tolerance — not per-pair bespoke growth.
+
+## Decision
+
+**Curved booleans form three KINDs, distinguished by the dimensionality of the operands' contact.
+Each KIND has one general analytic handler; only the transversal KIND uses the `(u,v)`
+arrangement. The taxonomy is the deliverable, not a forced merge into one function.**
+
+| KIND | Contact | SSI defined? | Handler | Examples |
+| --- | --- | --- | --- | --- |
+| **Transversal crossing** | 1-D curve, surfaces cross | yes | the general SSI → (u,v)-arrangement → classify → stitch pipeline (+ curved∩convex-planar half-space cuts) | crossing cyl, cone∩cone, cone∩cyl, partial penetration, Steinmetz |
+| **Curved-on-planar** | one closed conic **strictly inside** a planar face, added as an inner loop | degenerate (no band to subdivide) | build the pierced face + wall + cap and `curvedStitch` | drill through-hole, cylinder boss |
+| **Degenerate overlap** | 2-D region of **coincident** surfaces | no | simplify to the merged analytic solid | coaxial cylinder union |
+
+Concretely:
+
+1. **Do not build a `planeUV` operand.** Forcing drill/boss through the periodic arrangement would
+   fabricate a seam and rims that do not exist — ceremony that distorts the abstraction to fit a
+   case that needs no subdivision, on correctness-critical, already-tested code.
+2. **Recategorize coaxial** as the degenerate-overlap KIND (documentation + dispatch tag); it is a
+   coincident-surface *simplification*, not an SSI handler. It stays a gated path (low risk); it is
+   not promoted to a pre-normalization pass, because the gated form already produces the exact
+   solid and a pre-pass would add control-flow risk for no correctness gain.
+3. **Unify the one genuine duplication.** `CutCylindricalHole` carried a second, bespoke planar
+   welder (`classifyDrillFaces` + `assembleDrilled`) that re-implemented what the `curvedStitch`
+   drill path (`drillThroughCurved`) already does. `CutCylindricalHole` now delegates to that
+   shared path — one drill assembly, not two. The shared welder helpers (`weldPlanarFaces`,
+   `buildHoleEdges`, …) remain, used by the blind/counterbore/countersink variants.
+4. **Name the KIND on every path and file** (dispatch `[T]`/`[P]`/`[D]` tags, file headers) so a
+   future primitive pair is classified into an existing KIND, not appended as new bespoke growth.
+
+## Consequences
+
+- **Buys:** an honest, discoverable taxonomy; the removal of ~60 lines of duplicated planar-welder
+  code; the load-bearing invariant stated once — *the `(u,v)` arrangement is for transversal
+  crossings of periodic surfaces, nothing else*; and EPIC #1403 concluded on its real intent (kill
+  the O(n²) bespoke explosion + no silent CSG), both already met.
+- **Costs:** drill and boss stay outside the `(u,v)` pipeline, so **partial** curved-on-planar
+  contacts (a hole clipping a face edge, a boss straddling two faces) still fall to CSG rather than
+  producing an exact analytic result. Extending analytic coverage there is a *new feature* (a
+  genuine `planeUV` arrangement or a planar-face imprint trimmer), tracked separately — not a
+  refactor of these handlers.
+- **Dispatch order is unchanged** (the try-order within an op is load-bearing); the KIND tags are
+  annotations, so this decision carries **zero behavioral risk** and is validated by the existing
+  brep/ops/model boolean regression suites staying green.
+
+## Rejected alternatives
+
+- **Build a `planeUV` operand and route drill/boss through `trimByImprint`.** Rejected: distorts a
+  periodicity-centric abstraction to fit a flat face, adds machinery to a case that needs no cell
+  subdivision, and is high-risk churn on correctness-critical tested code — the opposite of "the
+  lightest structure that protects the real invariant." The one legitimate upside (partial-contact
+  analytic coverage) is a separable new feature, not a reason to rebuild working handlers.
+- **Fold coaxial into the SSI pipeline via an ε-perturbation** to manufacture a crossing. Rejected:
+  invents a spurious sliver imprint at exactly the tolerance ADR-0042 warns about.
+- **A heavyweight `classifyContact` pre-classifier replacing the gated try-list.** Rejected: the
+  gated list already declines cleanly and logs its CSG fallback; a classifier would be ceremony
+  isolating no new invariant.

--- a/kernel/brep/curved_coaxial_cylinder.go
+++ b/kernel/brep/curved_coaxial_cylinder.go
@@ -10,12 +10,15 @@ import (
 	"oblikovati.org/math"
 )
 
-// Coaxial cylinder union (M2 Phase 3, Oblikovati/Oblikovati#1336 — the coplanar/tangent curved-overlap
-// case). Two coaxial same-radius cylinders that overlap or abut along their shared axis have COINCIDENT
-// side surfaces (both lie on the very same geom.Cylinder) and their inner caps fall inside the other body
-// — the curved analogue of a coplanar overlap. The general boolean sends this to triangle-soup CSG, which
-// faceted it (a coaxial-cylinder union came back ~2.5% under volume with zero analytic faces). The union
-// is exactly one taller cylinder spanning the merged axial interval, so build that directly and keep the
+// Coaxial cylinder union — the DEGENERATE-OVERLAP boolean KIND (ADR-0045; M2 Phase 3,
+// Oblikovati/Oblikovati#1336). Two coaxial same-radius cylinders that overlap or abut along their shared
+// axis have COINCIDENT side surfaces (both lie on the very same geom.Cylinder) and their inner caps fall
+// inside the other body. This is NOT a transversal crossing: the two side surfaces do not cross in a curve,
+// they coincide over a 2-D region, so there is no SSI imprint and the (u,v)-arrangement pipeline (which
+// trims a periodic ruled band by a 1-D imprint) does not apply — coaxial is a distinct KIND, a simplification
+// of a coincident overlap, not an SSI handler. The general boolean sends it to triangle-soup CSG, which
+// faceted it (a coaxial-cylinder union came back ~2.5% under volume with zero analytic faces). The union is
+// exactly one taller cylinder spanning the merged axial interval, so build that directly and keep the
 // analytic surface. Anything off the coaxial-same-radius-overlapping case (different radius, skew axis, an
 // axial gap) returns ok=false so the caller keeps its fallback.
 

--- a/kernel/brep/curved_cylinder_boss.go
+++ b/kernel/brep/curved_cylinder_boss.go
@@ -10,14 +10,18 @@ import (
 	"oblikovati.org/math"
 )
 
-// Cylindrical boss union (M2 Phase 3, Oblikovati/Oblikovati#1336 — the coplanar curved+planar overlap
-// case). A cylinder sitting flush on a planar face of a solid (a boss: think a spigot on a plate) shares
-// that face's plane: its base disk is COINCIDENT and counter-oriented with the disk it covers, the
-// canonical coplanar overlap. The general boolean faceted this through CSG. The union is exact — the seat
-// face loses the boss-footprint disk (gains a circular hole), the boss adds one cylinder wall and a top
-// cap — so build it directly through the curvedFace model and keep the analytic surface. The boss is the
-// join analogue of CutCylindricalHole: a hole in the seat face plus an OUTWARD-facing wall (a solid boss,
-// material toward the axis) rather than a reversed one. Anything else (the cylinder not seated flush and
+// Cylindrical boss union — the CURVED-ON-PLANAR boolean KIND (ADR-0045; M2 Phase 3,
+// Oblikovati/Oblikovati#1336). A cylinder sitting flush on a planar face of a solid (a boss: think a spigot
+// on a plate) meets that face in its base circle, a contact that lies STRICTLY INSIDE the seat face, so the
+// result is that single closed conic added as an inner loop — the same shape as the drilled through-hole
+// (CutCylindricalHole), its join analogue. This is a transversal curved∩PLANAR contact, not a ruled∩ruled
+// crossing: the tool cylinder crosses a plane (not another periodic ruled band), and the imprint is one
+// interior circle, so no (u,v) SSI arrangement is involved (ADR-0045 taxonomy). The base disk is additionally
+// COINCIDENT and counter-oriented with the disk it covers — a degenerate-overlap detail absorbed by the seat
+// hole. The general boolean faceted this through CSG; the union is exact — the seat face loses the
+// boss-footprint disk (gains a circular hole), the boss adds one cylinder wall and a top cap — so build it
+// directly through the curvedFace model and keep the analytic surface. The wall faces OUTWARD (a solid boss,
+// material toward the axis) rather than reversed. Anything else (the cylinder not seated flush and
 // perpendicular on a single face, the circle clipping the face) returns ok=false so the caller keeps CSG.
 
 // JoinCylindricalBoss returns target ∪ tool when tool is a cylinder seated flush and perpendicular on one

--- a/kernel/brep/drill.go
+++ b/kernel/brep/drill.go
@@ -11,17 +11,22 @@ import (
 	"oblikovati.org/math"
 )
 
-// CutCylindricalHole drills a clean cylindrical through-hole in a planar-faced slab — the
-// first end-to-end plane∩cylinder boolean (K1b slice 3) and the geometry a "through all"
-// Hole feature needs. The cylinder axis (line through base along axisDir) must enter and
-// exit through two planar faces whose interiors fully contain the hole circle; every other
-// face is parallel to the axis and is copied unchanged. The result is a TRUE curved B-rep:
-// the two pierced faces gain a circular hole, a single cylinder face forms the hole wall
-// (its material side faces the axis, AddReversedFace), and — because copied/pierced faces
-// keep their source lineage — every original face's reference key survives the cut (K1a/K1b).
+// CutCylindricalHole drills a clean cylindrical through-hole in a slab — the geometry a
+// "through all" Hole feature needs. The cylinder axis (line through base along axisDir) must
+// enter and exit through two planar faces whose interiors fully contain the hole circle;
+// every other face is parallel to the axis and is copied unchanged. The result is a TRUE
+// curved B-rep: the two pierced faces gain a circular hole, a single cylinder face forms the
+// hole wall (its material side faces the axis), and — because copied/pierced faces keep their
+// source lineage — every original face's reference key survives the cut (K1a/K1b).
 //
-// Partial holes (the circle clipping a face boundary, or a blind hole) need the general
-// curved arrangement and return an error here — that is a later K1b slice.
+// This is the "curved-on-planar" boolean KIND (ADR-0045): the tool cylinder crosses the slab's
+// PLANAR faces in a circle that lies STRICTLY INSIDE one face, so the contact is a single closed
+// conic added as an inner loop — no (u,v) SSI arrangement is involved. It delegates to the shared
+// curvedStitch drill assembly (drillThroughCurved), the same machinery the multi-hole, blind and
+// counterbore variants use — one drill assembly, not a second bespoke planar welder (#1403).
+//
+// Partial holes (the circle clipping a face boundary, or a blind hole) return an error here — the
+// general boolean's CSG fallback takes those (see DrillThroughHole).
 func CutCylindricalHole(slab *topo.Body, base math.Point3, axisDir math.Vector3, radius float64) (*topo.Body, error) {
 	if radius <= 0 {
 		return nil, fmt.Errorf("brep: drill radius must be positive, got %g", radius)
@@ -30,11 +35,7 @@ func CutCylindricalHole(slab *topo.Body, base math.Point3, axisDir math.Vector3,
 	if ua.LengthSquared() < 0.5 {
 		return nil, fmt.Errorf("brep: drill axis direction is degenerate: %+v", axisDir)
 	}
-	copied, caps, err := classifyDrillFaces(slab, base, ua, radius)
-	if err != nil {
-		return nil, err
-	}
-	return assembleDrilled(copied, caps, ua, radius)
+	return drillThroughCurved(slab, base, ua, radius)
 }
 
 // DrillThroughHole cuts slab − cylinderTool as an EXACT through-hole when cylinderTool is a single
@@ -54,11 +55,8 @@ func DrillThroughHole(slab, cylinderTool *topo.Body) (*topo.Body, bool) {
 		return nil, false // tool is not a single bare cylinder
 	}
 	ua := cyl.AxisDir.AsVector()
-	// All-planar slab → the proven planar assembly; a slab that already has curved faces (a prior bore's
-	// wall) → the curvedFace path, so a drilled plate chains exactly instead of falling to CSG (#1336).
-	if res, err := CutCylindricalHole(slab, base, ua, cyl.Radius); err == nil {
-		return res, true
-	}
+	// One curvedStitch drill path serves both an all-planar slab and one that already carries curved faces
+	// (a prior bore's wall), so a drilled plate chains exactly instead of falling to CSG (#1336/#1403).
 	res, err := drillThroughCurved(slab, base, ua, cyl.Radius)
 	if err != nil {
 		return nil, false // partial / clipped / overlapping / off-axis hole → defer to the general fallback
@@ -66,40 +64,11 @@ func DrillThroughHole(slab, cylinderTool *topo.Body) (*topo.Body, bool) {
 	return res, true
 }
 
-// drillCap is a planar face the hole axis pierces (an entry/exit face), with the pierce
-// point and its parameter along the axis (used to order entry before exit).
+// drillCap is a point where the hole axis pierces an entry/exit face — the centre of the hole circle
+// on that face. The blind/counterbore/countersink assemblers pass their cap centres in entry→exit order
+// to buildHoleEdges to build the hole circles and wall.
 type drillCap struct {
-	face   planarFace
 	center math.Point3
-	param  float64
-}
-
-// classifyDrillFaces splits the slab's planar faces into the two the axis drills through
-// (perpendicular to the axis, interior fully containing the circle) and the rest (copied).
-func classifyDrillFaces(slab *topo.Body, base math.Point3, ua math.Vector3, radius float64) (copied []planarFace, caps []drillCap, err error) {
-	faces, ok := facesOf(slab)
-	if !ok {
-		return nil, nil, ErrNonPlanar
-	}
-	for _, f := range faces {
-		if stdmath.Abs(float64(f.normal.Dot(ua))) < 1-1e-7 {
-			copied = append(copied, f) // a wall the hole runs alongside — unchanged
-			continue
-		}
-		t := pierceParam(base, ua, f.plane)
-		c := base.TranslateBy(ua.Scale(math.Scalar(t)))
-		if !circleInsideFace(c, f, radius) {
-			return nil, nil, fmt.Errorf("brep: hole circle (r=%g at %+v) does not fit inside the pierced face; partial holes need the general boolean", radius, c)
-		}
-		caps = append(caps, drillCap{face: f, center: c, param: t})
-	}
-	if len(caps) != 2 {
-		return nil, nil, fmt.Errorf("brep: a through-hole needs exactly 2 perpendicular pierced faces, found %d", len(caps))
-	}
-	if caps[0].param > caps[1].param {
-		caps[0], caps[1] = caps[1], caps[0]
-	}
-	return copied, caps, nil
 }
 
 // pierceParam returns the parameter t where the axis line (base + t·ua) meets the plane.
@@ -124,41 +93,6 @@ func circleInsideFace(center math.Point3, f planarFace, radius float64) bool {
 		}
 	}
 	return true
-}
-
-// assembleDrilled welds the copied + pierced planar faces, adds a circular hole to each
-// pierced face, and joins them with a single cylinder wall face into a watertight solid.
-func assembleDrilled(copied []planarFace, caps []drillCap, ua math.Vector3, radius float64) (*topo.Body, error) {
-	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok("brep", "drill", 0)))
-	planar := append(append([]planarFace{}, copied...), caps[0].face, caps[1].face)
-
-	w := newWelder3()
-	rings, edgeUse := weldPlanarFaces(w, planar)
-	tv := make([]*topo.Vertex, len(w.points))
-	for i, p := range w.points {
-		tv[i] = bld.AddVertex(p, topo.NewLineage(topo.Tok("brep", "vertex", i)))
-	}
-	lineEdges := buildEdges(bld, w.points, tv, edgeUse)
-	holeLo, holeHi, seam, cyl, err := buildHoleEdges(bld, caps, ua, radius)
-	if err != nil {
-		return nil, err
-	}
-
-	loEntry, hiEntry := len(planar)-2, len(planar)-1
-	for fi, f := range planar {
-		specs := planarLoopSpecs(rings[fi], lineEdges)
-		switch fi {
-		case loEntry:
-			specs = append(specs, topo.InnerLoop(topo.Fwd(holeLo)))
-		case hiEntry:
-			specs = append(specs, topo.InnerLoop(topo.Fwd(holeHi)))
-		}
-		bld.AddFace(f.plane, f.lineage, specs...) // copied/pierced faces keep their key (K1a)
-	}
-	// The wall's surface normal is outward-radial, so its material side faces the axis.
-	bld.AddReversedFace(cyl, topo.NewLineage(topo.Tok("brep", "wall", 0)),
-		topo.OuterLoop(topo.Rev(holeLo), topo.Fwd(seam), topo.Rev(holeHi), topo.Rev(seam)))
-	return bld.Build(), nil
 }
 
 // weldPlanarFaces welds every face's loops to shared vertex indices and tallies undirected

--- a/kernel/brep/drill_test.go
+++ b/kernel/brep/drill_test.go
@@ -78,6 +78,33 @@ func TestDrillPreservesUntouchedFaceKey(t *testing.T) {
 	}
 }
 
+// After the ADR-0045 dedup, CutCylindricalHole delegates to the shared curvedStitch drill path, so it now
+// drills a slab that ALREADY carries a curved face (a prior bore) — the old bespoke planar welder required
+// an all-planar slab and errored here. Drill a second, clearing hole along +X through a once-bored slab and
+// assert an exact analytic solid results (two cylinder walls now, no CSG fallback).
+func TestCutCylindricalHoleThroughAlreadyCurvedSlab(t *testing.T) {
+	bored := drilledSlab(t) // 10×10×4 with a +Z bore at centre → carries a cylinder face
+	got, err := brep.CutCylindricalHole(bored, math.P3(0, 1.5, 2), math.V3(1, 0, 0), 1)
+	if err != nil {
+		t.Fatalf("CutCylindricalHole through a curved-faced slab: %v", err)
+	}
+	if r := ops.Validate(got); !r.Valid || !got.IsSolid() {
+		t.Fatalf("second-bore slab is not a valid solid: %+v", r)
+	}
+	if open := ops.BoundaryEdges(got); len(open) != 0 {
+		t.Fatalf("second-bore slab has %d boundary edges, want 0 (watertight)", len(open))
+	}
+	nCyl := 0
+	for _, f := range got.Faces() {
+		if _, ok := f.Geometry().(geom.Cylinder); ok {
+			nCyl++
+		}
+	}
+	if nCyl != 2 {
+		t.Errorf("cylinder faces = %d, want 2 (both bore walls kept analytic, no CSG)", nCyl)
+	}
+}
+
 // A hole whose circle spills past the face boundary needs the general boolean, not this
 // through-hole specialization — it must error rather than build a broken body.
 func TestDrillRejectsOversizeHole(t *testing.T) {

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -142,20 +142,25 @@ func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.L
 
 // curvedExactBoolean tries each exact analytic curved-boolean path in turn, returning the first that
 // applies (M2, ADR-0027 §M2). Each keeps the operands' exact analytic surfaces instead of the triangle-soup
-// CSG fallback; one that does not apply returns ok=false so booleanGeneral moves on:
-//   - a curved solid ∩ a convex planar tool (a box) → composed half-space cuts (#1334);
-//   - a curved solid − a convex prism tunnelling through it (cylinder − box) (#1334);
-//   - two crossing cylinders ∩ (rod band + fat-wall lens caps) (#1335);
-//   - a cone crossing a cylinder ∩ (cone band + cylinder-wall lens caps) (#1335);
-//   - a cone crossing a fatter cone ∩/−/∪ (rod-cone band + fat-cone lens caps; drill/stubs/join) (#1335);
-//   - two EQUAL-radius perpendicular cylinders ∩/−/∪ (the Steinmetz bicylinder and its cut/union, fitted as crossing ellipses) (#1335);
-//   - a thin rod ending inside a fatter cylinder ∩/−/∪ (a partial penetration: the plug, a blind hole, a one-sided stub) (#1335);
-//   - drilling a fat cylinder with a crossing rod (fat − rod), and the two rod stubs of rod − fat (#1335);
-//   - joining two crossing cylinders (fat ∪ rod: the fat with a rod stub each side) (#1335);
-//   - drilling/joining a fat cylinder with a crossing CONE (the tapered tunnel/stubs of cone − fat / fat ∪ cone) (#1335);
-//   - drilling a clean through-hole in an all-planar slab with a straight cylinder (a drilled plate: box − cylinder) (#1336);
-//   - the union of two coaxial equal-radius cylinders that overlap/abut → one taller cylinder (a coplanar/tangent overlap) (#1336);
-//   - the union of a cylinder seated flush on a planar face (a boss/spigot) → seat-face hole + outward wall + cap (a coplanar overlap) (#1336).
+// CSG fallback; one that does not apply returns ok=false so booleanGeneral moves on. Every path belongs to
+// one of three boolean KINDs (ADR-0045), distinguished by the DIMENSIONALITY of the operands' contact:
+//
+//	TRANSVERSAL CROSSING (contact = a 1-D curve; the general SSI → (u,v)-arrangement → classify → stitch
+//	pipeline, or a curved solid trimmed by a convex tool's planar half-spaces, #1403/#1476):
+//	  - a curved solid ∩/− a convex planar tool or prism (a box; cylinder − box) → composed half-space cuts (#1334);
+//	  - two crossing cylinders ∩/−/∪ (rod band + fat-wall lens caps) (#1335);
+//	  - a cone crossing a cylinder, and a cone crossing a fatter cone, ∩/−/∪ (#1335);
+//	  - two EQUAL-radius perpendicular cylinders ∩/−/∪ (the Steinmetz bicylinder, imprint split at its pinches) (#1403);
+//	  - a thin rod ending inside a fatter solid ∩/−/∪ (a partial penetration: plug, blind hole, one-sided stub) (#1335).
+//
+//	CURVED-ON-PLANAR (contact = one closed conic STRICTLY INSIDE a planar face, added as an inner loop; no
+//	SSI arrangement — the periodic (u,v) machinery does not apply to a flat bounded face, ADR-0045):
+//	  - drilling a clean through-hole in a slab with a straight cylinder (box − cylinder) (#1336);
+//	  - the union of a cylinder seated flush on a planar face (a boss/spigot) → seat-face hole + wall + cap (#1336).
+//
+//	DEGENERATE OVERLAP (contact = a 2-D region of COINCIDENT surfaces; a simplification, not an SSI handler,
+//	ADR-0045):
+//	  - the union of two coaxial equal-radius cylinders that overlap/abut → one taller cylinder (#1336).
 func curvedExactBoolean(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
 	for _, exact := range curvedExactPaths {
 		if body, ok := exact(op, target, tool, rec); ok {
@@ -176,12 +181,18 @@ func CurvedBoolean(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body
 
 // curvedExactPaths is the ordered list of exact analytic curved-boolean paths curvedExactBoolean tries; each
 // returns ok=false when it does not apply to (op, target, tool). The recorder carries the SSI imprint's
-// closure diagnostics (#1404) up to the boolean's caller; a path that takes no imprint ignores it.
+// closure diagnostics (#1404) up to the boolean's caller; a path that takes no imprint ignores it. The paths
+// are grouped by op (the try-order within an op is load-bearing; do not reorder across a pair that two paths
+// could both accept) and tagged with their boolean KIND (ADR-0045): [T] transversal crossing, [P] curved-on-
+// planar, [D] degenerate overlap.
 var curvedExactPaths = []func(PartFeatureOperation, *topo.Body, *topo.Body, *diag.Recorder) (*topo.Body, bool){
+	// Intersect — all [T] transversal (curved∩convex-planar half-space, then ruled crossings).
 	curvedConvexIntersect, curvedConvexSubtract,
 	curvedCrossingIntersect, curvedSteinmetzIntersect, curvedConeCylinderIntersect, curvedConeConeIntersect,
 	curvedPartialIntersect,
+	// Cut — [P] the drill through-hole (curved-on-planar), the rest [T] transversal.
 	curvedCylindricalHoleCut, curvedFlatSubtract, curvedPartialCut, curvedSteinmetzCut, curvedConeCylinderCut, curvedConeConeCut, curvedCrossingCut,
+	// Join — [D] coaxial (degenerate overlap), [P] boss (curved-on-planar), the rest [T] transversal.
 	curvedCoaxialJoin, curvedCylinderBossJoin, curvedPartialJoin, curvedConeCylinderJoin, curvedConeConeJoin, curvedCrossingJoin, curvedSteinmetzJoin,
 }
 

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -20,9 +20,10 @@ import (
 // boolean must never be adopted); centralising it means a pair added to the table below cannot forget
 // it, the copy-paste hazard this file used to carry as 18 near-identical handlers.
 
-// ruledBuild builds the exact analytic result for one curved pair. The general SSI pipeline builders
-// (brep.*General) take the imprint recorder; the bespoke analytic constructors (equal-radius Steinmetz,
-// drill-through, coaxial, boss) take none and are adapted with withoutRecorder.
+// ruledBuild builds the exact analytic result for one curved pair. The transversal SSI pipeline builders
+// (brep.*General) take the imprint recorder; the curved-on-planar and degenerate-overlap constructors
+// (drill-through, coaxial, boss — ADR-0045) trace no SSI imprint, take none, and are adapted with
+// withoutRecorder.
 type ruledBuild func(target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool)
 
 // gatedCurved wraps a builder with the op guard and the single validBooleanSolid gate every curved pair
@@ -48,11 +49,14 @@ func withoutRecorder(build func(target, tool *topo.Body) (*topo.Body, bool)) rul
 
 // The curved-pair paths, each an (op, builder) gated once by gatedCurved. Names are referenced by
 // curvedExactPaths in boolean.go, which fixes their try-order; the comment on each records the pair it
-// handles. The general SSI→trim→classify→stitch pipeline (#1403/#1476) builds every ruled pair; the
-// equal-radius Steinmetz INTERSECT now rides it too (#1403) — its self-intersecting imprint is split at the
-// analytic pinches into four open arcs so the arrangement never sees the crossing (brep.SteinmetzIntersect-
-// General). The Steinmetz CUT and JOIN keep the bespoke band assembler for now (their kept region is the
-// cylinders' pinched OUTSIDE bands, not lobes; folding those into the general pipeline is tracked follow-up).
+// handles. Most are the TRANSVERSAL-crossing KIND (ADR-0045): the general SSI→trim→classify→stitch pipeline
+// (#1403/#1476) builds every ruled pair, and the whole equal-radius Steinmetz family — intersect, cut AND
+// join — now rides it (#1403), its self-intersecting imprint split at the analytic pinches into four open
+// arcs so the arrangement never sees the crossing (brep.Steinmetz*General). The remaining three are the
+// other two KINDs, which are NOT transversal SSI and correctly do NOT ride the (u,v) arrangement: the drill
+// through-hole and the cylinder boss are CURVED-ON-PLANAR (a tool cylinder crossing a planar face in a
+// strictly-interior circle), and the coaxial union is a DEGENERATE OVERLAP (coincident side surfaces, no SSI
+// curve). See ADR-0045 for why each stays a distinct analytic handler rather than folding into the pipeline.
 var (
 	// Intersect — the band of the thin operand plus the fat operand's two lens caps.
 	curvedCrossingIntersect     = gatedCurved(Intersect, brep.CrossingCylinderIntersectGeneral) // two crossing cylinders


### PR DESCRIPTION
## What

Concludes EPIC #1403 (fold the bespoke analytic curved-boolean handlers into the general pipeline) by settling the **last three** handlers — `DrillThroughHole`, `CoaxialCylinderUnion`, `JoinCylindricalBoss` — with a **taxonomy**, plus the one genuine code de-duplication they hid.

- **ADR-0045** — names the three curved-boolean **KINDs**, distinguished by the dimensionality of the operands' contact:
  - **Transversal crossing** (1-D curve) → the general SSI → `(u,v)`-arrangement → classify → stitch pipeline (crossing cyl, cone∩cone/cyl, partial penetration, Steinmetz).
  - **Curved-on-planar** (one closed conic *strictly inside* a planar face, added as an inner loop) → drill through-hole, cylinder boss.
  - **Degenerate overlap** (2-D region of *coincident* surfaces, no SSI) → coaxial cylinder union.
- **`CutCylindricalHole` de-dup** — it carried a second, bespoke planar welder (`classifyDrillFaces` + `assembleDrilled`) that re-implemented the shared `curvedStitch` drill path (`drillThroughCurved`). It now delegates to that path — one drill assembly, not two (~60 lines removed) — which also **widens** it to drill a slab that already carries a curved face (a prior bore), kept exact instead of erroring / falling to CSG.
- Dispatch is annotated with KIND tags (`[T]`/`[P]`/`[D]`); **try-order is unchanged**, so the behavior is preserved.

## Why

Tracing the actual `uvSide` seam shows the `(u,v)` arrangement is built **exclusively for periodic surfaces** (azimuth seam + rim-bounded axial band). A flat, non-periodic, polygon-bounded plane face has no seam and no rims — routing drill/boss through it would *fabricate* both to fit a case that needs no cell subdivision. And coaxial has coincident surfaces, so SSI is structurally undefined. These are distinct KINDs, each already one general analytic handler; forcing them into the arrangement would be ceremony that distorts the abstraction on correctness-critical, tested code. The EPIC's real intent (kill the O(n²) bespoke explosion — the 18-handler ruled family, already folded — and no *silent* CSG, already logged via `CodeBooleanCSGFallback`) is met. See ADR-0045 for the full rationale and rejected alternatives (incl. a `planeUV` operand, deferred as a *new feature* for partial-contact analytic coverage).

## Testing

- `go test ./kernel/brep/ ./kernel/ops/ ./model/feature/` green; new `TestCutCylindricalHoleThroughAlreadyCurvedSlab` pins the widened contract (would have failed on the old `facesOf`→`ErrNonPlanar` path by construction).
- `golangci-lint` (0 issues) + `markdownlint-cli2` (0 errors) locally.
- **Live** over the MCP bridge (rebuilt against this kernel): a block drilled twice — the second bore through the now-curved slab — renders **watertight analytic hole walls**, volume 72 → 65.76 → 64.32 cm³.

Advances #1403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)