### PR TITLE
fix(fillet): honest rejection for fillet-over-fillet on a curved seam

### DIFF
--- a/kernel/ops/fillet.go
+++ b/kernel/ops/fillet.go
@@ -230,6 +230,9 @@ func computeEdgeFillet(body *topo.Body, p filletPick, blends map[uint64]*cornerB
 	if cyl, pl, ok := cylinderPlaneEdge(e); ok {
 		return edgeFillet{}, curvedFilletError(e, cyl, pl) // fillet of a fillet — Phase A: classify & report
 	}
+	if err := curvedAdjacentError(e); err != nil {
+		return edgeFillet{}, err // any other curved neighbour (cyl∩cyl miter seam, torus, sphere)
+	}
 	a, b, nA, nB, err := edgePlanarFaces(e)
 	if err != nil {
 		return edgeFillet{}, err

--- a/kernel/ops/fillet_curved.go
+++ b/kernel/ops/fillet_curved.go
@@ -47,3 +47,35 @@ func curvedFilletError(e *topo.Edge, cyl geom.Cylinder, pl geom.Plane) error {
 	}
 	return fmt.Errorf("fillet: rounding an edge that borders a curved (cylinder) face is not yet supported")
 }
+
+// curvedAdjacentError rejects an edge bordering a curved (non-planar) face that the cylinder+plane
+// classifier does not cover — the miter SEAM between two edge fillets (cylinder∩cylinder), or a
+// torus/sphere neighbour a prior round left. The rolling-ball blend needs two PLANAR walls; these
+// curved∩curved (and curved∩*) contacts are a fillet-over-fillet the general blend does not yet
+// build. Rejecting here with the offending surface named — BEFORE the model layer facets the whole
+// body — replaces the misleading "not a valid solid" the triangle-cage path produced (scenario 07).
+// Returns nil when both faces are planar (the ordinary edge fillet the caller then solves).
+func curvedAdjacentError(e *topo.Edge) error {
+	for _, f := range e.Faces() {
+		if _, planar := f.Geometry().(geom.Plane); !planar {
+			return fmt.Errorf("fillet: cannot round an edge bordering a curved (%s) face — rounding a filleted or otherwise curved edge is not yet supported", surfaceKind(f.Geometry()))
+		}
+	}
+	return nil
+}
+
+// surfaceKind names a surface for an error message (its concrete geometry type), e.g. "cylinder".
+func surfaceKind(s geom.Surface) string {
+	switch s.(type) {
+	case geom.Cylinder:
+		return "cylinder"
+	case geom.Cone:
+		return "cone"
+	case geom.Sphere:
+		return "sphere"
+	case geom.Torus:
+		return "torus"
+	default:
+		return fmt.Sprintf("%T", s)
+	}
+}

--- a/kernel/ops/fillet_curved_internal_test.go
+++ b/kernel/ops/fillet_curved_internal_test.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+)
+
+// TestSurfaceKindNames covers every branch of the error-message surface namer, including the
+// %T fallback for a surface the switch does not special-case.
+func TestSurfaceKindNames(t *testing.T) {
+	cases := []struct {
+		s    geom.Surface
+		want string
+	}{
+		{geom.Cylinder{}, "cylinder"},
+		{geom.Cone{}, "cone"},
+		{geom.Sphere{}, "sphere"},
+		{geom.Torus{}, "torus"},
+		{geom.Plane{}, "geom.Plane"}, // default: the %T type name
+	}
+	for _, c := range cases {
+		if got := surfaceKind(c.s); got != c.want {
+			t.Errorf("surfaceKind(%T) = %q, want %q", c.s, got, c.want)
+		}
+	}
+}

--- a/kernel/ops/fillet_test.go
+++ b/kernel/ops/fillet_test.go
@@ -393,6 +393,59 @@ func TestFilletCurvedAdjacentReported(t *testing.T) {
 	}
 }
 
+// TestFilletOnCurvedSeamRejectsClearly guards the fillet-over-fillet case the cylinder+plane
+// classifier does NOT cover: the miter SEAM between two adjacent edge fillets is bounded by two
+// CYLINDER faces (not a plane), so rounding it is not yet supported. It must be rejected with a
+// message that names the curved neighbour — not the generic "both faces must be planar", which
+// reads like a caller bug rather than an unsupported operation (the live scenario-07 defect).
+func TestFilletOnCurvedSeamRejectsClearly(t *testing.T) {
+	box := shellBox(4, 3, 2)
+	// The two top edges meeting at corner (4,3,2): along X at y=3, and along Y at x=4.
+	var top [][]byte
+	for _, e := range box.Edges() {
+		a, c := e.StartVertex().Point(), e.EndVertex().Point()
+		if a.Z != 2 || c.Z != 2 {
+			continue
+		}
+		if (a.Y == 3 && c.Y == 3) || (a.X == 4 && c.X == 4) {
+			top = append(top, e.ReferenceKey())
+		}
+	}
+	if len(top) != 2 {
+		t.Fatalf("expected 2 adjacent top edges, got %d", len(top))
+	}
+	f1, err := ops.FilletEdges(box, top, 0.5) // miter: two cylinders meeting at a seam
+	if err != nil {
+		t.Fatalf("first two-edge fillet: %v", err)
+	}
+	seam := cylinderCylinderEdge(t, f1)
+	_, err = ops.FilletEdges(f1, [][]byte{seam.ReferenceKey()}, 0.2)
+	if err == nil {
+		t.Fatal("filleting a cylinder∩cylinder seam edge should be rejected, got nil")
+	}
+	if !strings.Contains(err.Error(), "curved") {
+		t.Errorf("error should name the curved neighbour, got: %v", err)
+	}
+}
+
+// cylinderCylinderEdge returns an edge of b bounded by two cylinder faces (a miter fillet seam).
+func cylinderCylinderEdge(t *testing.T, b *topo.Body) *topo.Edge {
+	t.Helper()
+	for _, e := range b.Edges() {
+		fs := e.Faces()
+		if len(fs) != 2 {
+			continue
+		}
+		_, c0 := fs[0].Geometry().(geom.Cylinder)
+		_, c1 := fs[1].Geometry().(geom.Cylinder)
+		if c0 && c1 {
+			return e
+		}
+	}
+	t.Fatal("no cylinder∩cylinder seam edge")
+	return nil
+}
+
 // TestFilletEdgesRoutesArc drives the public FilletEdges with the sharp ARC cap a prior vertical-edge
 // fillet leaves: it routes to the torus + setback end-cap arc fillet, producing a valid watertight
 // solid with one torus face and two planar setback end-caps, with the arc material removed.

--- a/model/feature/engine.go
+++ b/model/feature/engine.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"oblikovati.org/kernel/exchange"
 	"oblikovati.org/kernel/ops"
@@ -344,6 +345,17 @@ func lastSolid(bodies []*topo.Body) *topo.Body {
 	return bodies[len(bodies)-1]
 }
 
+// sickReason prefixes a feature's failure with its kind for the browser, unless the error already
+// leads with that kind — many kernel ops prefix their own errors with the same word (e.g. a fillet
+// op returns "fillet: …"), which otherwise produced a "fillet: fillet: …" double prefix.
+func sickReason(kind string, err error) string {
+	msg := err.Error()
+	if strings.HasPrefix(msg, kind+":") {
+		return msg
+	}
+	return fmt.Sprintf("%s: %s", kind, msg)
+}
+
 // classify turns a feature's recompute result into health + the running body state:
 // ErrDeferred → warning (passthrough); other error → sick (poison); a healed
 // reference (ADR-0043 P6) → warning with the rebuilt body kept; nil → healthy.
@@ -353,7 +365,7 @@ func (fs *PartFeatures) classify(pf *PartFeature, bodies []*topo.Body, out Outpu
 		pf.health = health.Health{Status: health.Warning, Reason: err.Error()}
 		pf.cached = out.Bodies
 	case err != nil:
-		pf.health = health.Sicken(fmt.Sprintf("%s: %v", pf.Kind(), err))
+		pf.health = health.Sicken(sickReason(pf.Kind(), err))
 		sick[pf.id] = true
 		pf.cached = bodies
 	case len(out.Heals) > 0:

--- a/model/feature/fillet.go
+++ b/model/feature/fillet.go
@@ -172,7 +172,7 @@ func planarizedFillet(body *topo.Body, edgeKeys [][]byte, feat string) (*topo.Bo
 	if !anyEdgeNeedsPlanarize(origEdges) {
 		return body, edgeKeys // #1494: every selected edge is straight between planar faces — blend on the analytic body
 	}
-	pb, mapped := planarizeForEdges(body, origEdges, feat)
+	pb, mapped := planarizeCylinderForEdges(body, origEdges, feat)
 	if pb == body {
 		return body, edgeKeys
 	}
@@ -283,7 +283,7 @@ func planarizeFilletPicks(body *topo.Body, picks []ops.EdgeFilletRadii, feat str
 	if !anyEdgeNeedsPlanarize(origEdges) {
 		return body // #1494: every selected edge is straight between planar faces — blend on the analytic body
 	}
-	pb, mapped := planarizeForEdges(body, origEdges, feat)
+	pb, mapped := planarizeCylinderForEdges(body, origEdges, feat)
 	if pb == body {
 		return body
 	}

--- a/model/feature/fillet_over_fillet_test.go
+++ b/model/feature/fillet_over_fillet_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// adjacentTopEdgeKeys returns the two top edges of a box (both endpoints at z==top) that meet at
+// the (hx,hy) corner — the pair whose miter fillet leaves a cylinder∩cylinder seam.
+func adjacentTopEdgeKeys(t *testing.T, b *topo.Body, hx, hy, top float64) [][]byte {
+	t.Helper()
+	var keys [][]byte
+	for _, e := range b.Edges() {
+		a, c := e.StartVertex().Point(), e.EndVertex().Point()
+		if float64(a.Z) != top || float64(c.Z) != top {
+			continue
+		}
+		onY := float64(a.Y) == hy && float64(c.Y) == hy
+		onX := float64(a.X) == hx && float64(c.X) == hx
+		if onX || onY {
+			keys = append(keys, e.ReferenceKey())
+		}
+	}
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 adjacent top edges at corner (%g,%g), got %d", hx, hy, len(keys))
+	}
+	return keys
+}
+
+// cylinderSeamKey returns the key of an edge bounded by two cylinder faces (a miter fillet seam).
+func cylinderSeamKey(t *testing.T, b *topo.Body) []byte {
+	t.Helper()
+	for _, e := range b.Edges() {
+		fs := e.Faces()
+		if len(fs) != 2 {
+			continue
+		}
+		_, c0 := fs[0].Geometry().(geom.Cylinder)
+		_, c1 := fs[1].Geometry().(geom.Cylinder)
+		if c0 && c1 {
+			return e.ReferenceKey()
+		}
+	}
+	t.Fatal("no cylinder∩cylinder seam edge on the filleted body")
+	return nil
+}
+
+// TestFilletOverFilletSeamGivesHonestReason reproduces live scenario 07: after filleting two
+// adjacent top edges (a miter, leaving a cylinder∩cylinder seam), a second fillet on that seam edge
+// is an unsupported fillet-over-fillet. It must go Sick with a reason that NAMES the curved cause —
+// not the misleading "result is not a valid solid" the whole-body facet path produced (the second
+// fillet was faceting the first fillet's cylinder into a triangle cage that could not close).
+func TestFilletOverFilletSeamGivesHonestReason(t *testing.T) {
+	box := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 3}, {X: 0, Y: 3}},
+		sketch.XYPlane(), span{near: 0, far: 2}, 0, "box")
+
+	fs := NewPartFeatures(nil)
+	NewBaseFeatures(fs).AddBase(box)
+
+	top := adjacentTopEdgeKeys(t, box, 4, 3, 2)
+	f1 := NewDressUpFeatures(fs).AddFilletCorner(top, func() float64 { return 0.5 }, types.FilletCornerMiter)
+	fs.Recompute()
+	if !f1.Health().OK() {
+		t.Fatalf("first (miter) fillet sick: %+v", f1.Health())
+	}
+
+	seam := cylinderSeamKey(t, fs.Result()[0])
+	f2 := NewDressUpFeatures(fs).AddFillet([][]byte{seam}, func() float64 { return 0.2 })
+	fs.Recompute()
+
+	if f2.Health().OK() {
+		t.Fatal("fillet on a curved (cylinder∩cylinder) seam should go Sick, but it reported healthy")
+	}
+	reason := f2.Health().Reason
+	if !strings.Contains(reason, "curved") {
+		t.Errorf("Sick reason should name the curved cause, got: %q", reason)
+	}
+	if strings.Contains(reason, "not a valid solid") {
+		t.Errorf("Sick reason should be the honest curved-adjacent message, not the facet-cage failure: %q", reason)
+	}
+	if strings.Contains(reason, "fillet: fillet:") {
+		t.Errorf("Sick reason should not double the feature-kind prefix: %q", reason)
+	}
+}

--- a/model/feature/fillet_over_fillet_test.go
+++ b/model/feature/fillet_over_fillet_test.go
@@ -90,3 +90,23 @@ func TestFilletOverFilletSeamGivesHonestReason(t *testing.T) {
 		t.Errorf("Sick reason should not double the feature-kind prefix: %q", reason)
 	}
 }
+
+// TestPlanarizeCylinderForEdgesPrismifiesSimpleCylinder covers the one curved body the fillet's
+// planarise DOES re-facet: a simple extrude-circle cylinder becomes a prism and its rim maps onto
+// the prism's faceted segments (the #127/#129 path). Any other curved body is left analytic (the
+// pass-through path is exercised by TestFilletOverFilletSeamGivesHonestReason).
+func TestPlanarizeCylinderForEdgesPrismifiesSimpleCylinder(t *testing.T) {
+	fs, rim := extrudedCylinderTopRim(t, 2, 5)
+	body := fs.Result()[0]
+	edges, _, err := resolveEdges(body, [][]byte{rim}, nil)
+	if err != nil {
+		t.Fatalf("resolve rim: %v", err)
+	}
+	pb, mapped := planarizeCylinderForEdges(body, edges, "fillet")
+	if pb == body {
+		t.Fatal("a simple cylinder must be prism-ified for the rim fillet, got the body unchanged")
+	}
+	if len(mapped) == 0 {
+		t.Fatal("the rim edge must map onto the prism's faceted segments")
+	}
+}

--- a/model/feature/planarize.go
+++ b/model/feature/planarize.go
@@ -203,6 +203,31 @@ func planarizeForEdges(body *topo.Body, edges []*topo.Edge, feat string) (*topo.
 	return pb, mapped
 }
 
+// planarizeCylinderForEdges re-facets ONLY a simple analytic cylinder (an extrude-circle) into a
+// prism for the FILLET, mapping each selected edge onto the prism's segments — the one curved body a
+// rolling-ball fillet can round after prism-ification (a circular rim, #127/#129). Any OTHER curved
+// body is returned UNCHANGED so the kernel rejects a genuinely-unsupported curved-adjacent edge with
+// a clear message (curvedAdjacentError) instead of ops.Facet shattering the whole body into a
+// triangle cage the blend cannot close — the misleading "not a valid solid" of a fillet-over-fillet
+// on a rounded seam. chamfer/sheet-metal keep planarizeForEdges: they cut with the planar boolean
+// and legitimately need the whole-body facet.
+func planarizeCylinderForEdges(body *topo.Body, edges []*topo.Edge, feat string) (*topo.Body, []*topo.Edge) {
+	prism := planarizeSimpleCylinder(body, feat+"/planar")
+	if prism == nil {
+		return body, edges
+	}
+	var mapped []*topo.Edge
+	for _, pe := range prism.Edges() {
+		for _, orig := range edges {
+			if edgeOnEdge(pe, orig) {
+				mapped = append(mapped, pe)
+				break
+			}
+		}
+	}
+	return prism, mapped
+}
+
 // edgeOnEdge reports whether both endpoints of pe lie on orig's curve — i.e. pe is a faceted segment of
 // orig (or orig itself).
 func edgeOnEdge(pe, orig *topo.Edge) bool {


### PR DESCRIPTION
## What

A deep audit of the fillet tool (see below) surfaced one real defect: filleting an edge left by a **prior fillet** whose neighbour is a curved face — the miter **seam between two edge fillets** (a cylinder∩cylinder edge), or a torus/sphere neighbour — went Sick with the misleading:

```
fillet: fillet: result is not a valid solid []
```

It now reports the honest, actionable:

```
fillet: cannot round an edge bordering a curved (cylinder) face —
rounding a filleted or otherwise curved edge is not yet supported
```

…and leaves the body unchanged (no broken geometry shipped).

## Why

Three compounding causes:

1. The kernel's curved-adjacent classifier only recognised **cylinder+plane** edges; a cylinder∩cylinder seam fell through to the generic "both faces must be planar".
2. The model layer planarised the whole body first — for a non-simple-cylinder curved body it called `ops.Facet`, shattering the prior fillet's cylinder into a **triangle cage** the rolling ball couldn't close, producing the generic invalid-solid error and hiding the true cause.
3. The feature engine double-prefixed the reason (`fillet: fillet:`).

## How

- **kernel/ops** — reject any curved (non-planar) neighbour up front with a clear, surface-named message (`curvedAdjacentError`), before the planar path can mislead.
- **model/feature** — the fillet's planarise now only prism-ifies a **simple cylinder** (the one curved case a rolling-ball fillet can round after re-faceting); any other curved body is left analytic so the kernel's clear error surfaces. chamfer / sheet-metal keep the whole-body facet — they cut with the planar boolean and need it.
- **model/feature engine** — de-dupe the feature-kind prefix.

Building a fillet over a curved seam (rolling-ball over two cylinders) remains future work; this PR only makes the current rejection honest.

## Audit result (the rest of the tool is healthy)

Verified live over the MCP bridge with `body_validate` (manifold/watertight) + volume gating, and normal-debug (green=outward) + per-triangle mesh inspection across: single / multi / 3-edge sphere-blend / miter / round corners, variable radius (faceted ruling strips), G2 and conic cross-sections, concave (outward) on an L-bracket, face fillet, full-round, rule fillet, torus re-fillet, and an in-place **radius edit** (3→6 mm). All produced valid, manifold, correctly-wound meshes — no winding / crack / sliver defects. The single defect above is the only issue found and fixed.

## Tests

- `kernel/ops`: `TestFilletOnCurvedSeamRejectsClearly` — a cylinder∩cylinder seam is rejected with a message naming the curved neighbour.
- `model/feature`: `TestFilletOverFilletSeamGivesHonestReason` — reproduces the live scenario at the feature layer; asserts an honest Sick reason (no "not a valid solid", no doubled prefix).
- Full `model/… kernel/… addin/… app/…` suites green; `golangci-lint` clean on touched packages.

Closes #1592

🤖 Generated with [Claude Code](https://claude.com/claude-code)