### PR TITLE
Gate feature commits on a sick configuration

### DIFF
--- a/app/commit_gate.go
+++ b/app/commit_gate.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+
+	"oblikovati.org/model/feature"
+)
+
+// The commit gate enforces one rule for every feature tool: a configuration that would recompute
+// SICK must not be committable. The tool already builds a DRAFT of the exact feature OK would
+// create (DraftPreviewable), and PartFeatures.PreviewResult evaluates it non-destructively — the
+// same recompute a commit runs — so its error is precisely "this would be sick". The gate reads
+// that: s.OK() refuses (nothing enters the design) and the head disables the OK button while it
+// holds, so a sick node can never persist in the tree.
+
+// commitBlockedReason reports why the active tool's pending feature cannot be committed: a
+// non-empty reason when evaluating its draft against the current model yields a sick recompute.
+// It is empty when there is no tool, the tool builds no draft (non-DraftPreviewable, e.g. sketch
+// tools — unconstrained here), the draft is not ready (CanCommit already gates that), the context
+// is not a part, or the draft previews healthy. A DEFERRED result is a warning, not sick, so it
+// does not block.
+func (s *Session) commitBlockedReason() string {
+	if s.tool == nil {
+		return ""
+	}
+	dp, ok := s.tool.tool.(DraftPreviewable)
+	if !ok {
+		return ""
+	}
+	// Only NEW-feature creation is gated. An in-place EDIT re-applies the feature at its own
+	// position in the history, but PreviewResult appends the draft at end-of-part, where an
+	// edited feature's references resolve against a different (later) topology — so its result
+	// says nothing about the edit's real health. Editing keeps its existing commit-time check.
+	if ed, editing := s.tool.tool.(interface{ IsEditing() bool }); editing && ed.IsEditing() {
+		return ""
+	}
+	draft, ready := dp.DraftFeature(s)
+	if !ready {
+		return ""
+	}
+	part, err := activePart(s)
+	if err != nil {
+		return ""
+	}
+	if _, err := part.Features().PreviewResult(draft); err != nil && !errors.Is(err, feature.ErrDeferred) {
+		return err.Error()
+	}
+	return ""
+}
+
+// CommitBlockedReason is [commitBlockedReason] for the head: "" when the active tool's pending
+// feature can be committed, otherwise the reason it is sick — shown beside the disabled OK button
+// so the user knows why the commit is unavailable.
+func (s *Session) CommitBlockedReason() string { return s.commitBlockedReason() }

--- a/app/fillet_tool_test.go
+++ b/app/fillet_tool_test.go
@@ -127,6 +127,43 @@ func TestFilletUnbuildableSurfacesNotice(t *testing.T) {
 	}
 }
 
+// TestSickConfigIsNotCommitted is the rule "no mutable operation commits a sick configuration":
+// a fillet whose radius overruns the block previews sick, so CommitBlockedReason names the cause,
+// s.OK() refuses, and — crucially — NO feature is appended to the design (the sick node must not
+// persist in the tree). Fixing the radius then commits cleanly, adding exactly one feature.
+func TestSickConfigIsNotCommitted(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	f := NewFilletTool()
+	s.StartTool(f)
+	f.Pick(s, verticalEdgeOf(t, block))
+	f.SetRadius(10) // impossible: the rolling ball overruns the 2×2×2 block
+
+	before := activePartDef(t, s).Features().Count()
+	if s.CommitBlockedReason() == "" {
+		t.Fatal("a sick fillet config should report a commit-blocked reason")
+	}
+	if err := s.OK(); err == nil {
+		t.Fatal("OK on a sick config should be refused")
+	}
+	if after := activePartDef(t, s).Features().Count(); after != before {
+		t.Errorf("a sick config must not append a feature: count %d → %d", before, after)
+	}
+	if s.ActiveTool() == nil {
+		t.Fatal("tool should stay open after a refused commit")
+	}
+
+	f.SetRadius(0.5) // now valid
+	if r := s.CommitBlockedReason(); r != "" {
+		t.Fatalf("a valid config must not be blocked, got %q", r)
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK on a valid config: %v", err)
+	}
+	if after := activePartDef(t, s).Features().Count(); after != before+1 {
+		t.Errorf("a valid commit should append exactly one feature: count %d → %d", before, after)
+	}
+}
+
 // TestFilletToolNeedsEdge checks the tool is not committable until an edge is picked.
 func TestFilletToolNeedsEdge(t *testing.T) {
 	s, block := newPartWithBlock(t, 2)

--- a/app/session_input.go
+++ b/app/session_input.go
@@ -71,6 +71,13 @@ func (s *Session) OK() error {
 	if !s.tool.tool.CanCommit() {
 		return errors.New("app: active tool is not ready to commit")
 	}
+	// A configuration that would recompute SICK must never enter the design: evaluate the pending
+	// feature speculatively and refuse the commit if it is invalid, so the tree never gains a sick
+	// node (the OK button is likewise disabled while this holds). See commitBlockedReason.
+	if reason := s.commitBlockedReason(); reason != "" {
+		s.notice = reason
+		return errors.New(reason)
+	}
 	toolName := s.tool.tool.Name()
 	if err := s.tool.tool.Commit(s); err != nil {
 		s.notice = err.Error() // surface why (the status bar shows it); keep the tool open
@@ -85,13 +92,19 @@ func (s *Session) OK() error {
 	if s.InSketch() || s.InSketch3D() {
 		s.RecordActiveEdit(toolName)
 	}
+	s.finishToolCommit()
+	return nil
+}
+
+// finishToolCommit tears down the active tool after a successful commit: clear the notice, drop the
+// tool, and retire its transient UI (selection filter, preview graphics, mini-toolbars, gizmos).
+func (s *Session) finishToolCommit() {
 	s.notice = ""
 	s.tool = nil
 	s.restoreSelectionFilter()      // hand selection back to the ambient filter (engine)
 	s.Graphics().ClearInteraction() // a committed command's transient preview vanishes
 	s.dropCommandMiniToolbars()     // command-bound mini-toolbars die with the tool (M05-F07)
 	s.dropCommandGizmos()           // and the command-bound triad/manipulators (M05-F13)
-	return nil
 }
 
 // CancelTool abandons the active tool (Inventor's Escape / Cancel).

--- a/head/cmd/filletgateshot/main.go
+++ b/head/cmd/filletgateshot/main.go
@@ -1,0 +1,157 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Command filletgateshot is a throwaway live-capture driver for the sick-config commit gate:
+// it opens the real native window, starts the Fillet tool on a base cube with a radius the block
+// cannot admit (a sick configuration), runs the production DrawChrome frame loop, and saves the
+// whole window — so the PNG shows the OK button DISABLED with the amber "why" line exactly as the
+// app draws it. It then repeats with a buildable radius so the second PNG shows OK ENABLED.
+//
+//	go run ./head/cmd/filletgateshot -out /tmp/gate      # writes /tmp/gate-sick.png and /tmp/gate-ok.png
+package main
+
+import (
+	"flag"
+	"fmt"
+	stdmath "math"
+	"os"
+
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+	"oblikovati.org/head/ui"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+	"oblikovati.org/scene"
+)
+
+const gateDocName = "filletgateshot.opd"
+
+func main() {
+	out := flag.String("out", "/tmp/gate", "output PNG prefix (writes <prefix>-sick.png and <prefix>-ok.png)")
+	frames := flag.Int("frames", 8, "frames to render before each capture")
+	flag.Parse()
+	if err := run(*out, *frames); err != nil {
+		fmt.Fprintln(os.Stderr, "filletgateshot:", err)
+		os.Exit(1)
+	}
+	fmt.Fprintln(os.Stdout, "wrote", *out+"-sick.png", "and", *out+"-ok.png")
+}
+
+func run(out string, frames int) error {
+	s := app.NewSession()
+	if err := app.RegisterStandardCommands(s); err != nil {
+		return err
+	}
+	def := buildBaseBox(s)
+	body := def.SurfaceBodies().Item(0)
+	edge := verticalEdge(body.Edges())
+	aimCameraAtEdge(s, body, edge)
+
+	win, err := native.CreateWindow(1280, 800, "filletgateshot")
+	if err != nil {
+		return err
+	}
+	defer win.Destroy()
+	win.InitViewport()
+
+	// The Fillet panel seeds its radius buffer once per tool instance and writes it back to the
+	// tool every frame, so each capture needs a FRESH tool started at its own radius.
+	// Sick: a 10-unit rolling ball cannot round a 6×6×6 cube's edge — the gate must disable OK.
+	if err := capture(win, s, edge, 10, true, frames, out+"-sick.png"); err != nil {
+		return err
+	}
+	s.CancelTool()
+	// Buildable: a small radius previews healthy — OK must be enabled, no warning line.
+	return capture(win, s, edge, 1.2, false, frames, out+"-ok.png")
+}
+
+// capture starts a fresh Fillet at radius on edge, asserts the gate's blocked-state matches
+// wantBlocked, then renders and saves the window (panel + viewport) to path.
+func capture(win *native.Window, s *app.Session, edge *topo.Edge, radius float64, wantBlocked bool, frames int, path string) error {
+	fillet := app.NewFilletTool()
+	s.StartTool(fillet)
+	fillet.Pick(s, app.EdgeHandle{Edge: edge})
+	fillet.SetRadius(radius)
+	if r := s.CommitBlockedReason(); (r != "") != wantBlocked {
+		return fmt.Errorf("radius %g: blocked=%q, want blocked=%v", radius, r, wantBlocked)
+	}
+	for i := 0; i < frames; i++ {
+		win.BeginFrame()
+		ui.DrawChrome(win, s)
+		win.EndFrame(ui.WindowClearColor())
+	}
+	return win.SaveWindowPNG(path)
+}
+
+func buildBaseBox(s *app.Session) *compdef.PartComponentDefinition {
+	pd, err := compdef.AddPart(s.Workspace(), gateDocName, true)
+	if err != nil {
+		panic(err)
+	}
+	_ = s.Workspace().SetActiveDocument(pd)
+	def := pd.Content().(*compdef.PartComponentDefinition)
+	sk := addSquare(def, 0, 0, 6)
+	feature.NewExtrudeFeatures(def.Features()).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 6 })
+	def.Recompute()
+	return def
+}
+
+func addSquare(def *compdef.PartComponentDefinition, ox, oy, side float64) *sketch.Sketch {
+	sk := def.Sketches().Add(sketch.XYPlane())
+	c0 := sk.Points().Add(math.P2(ox, oy))
+	c1 := sk.Points().Add(math.P2(ox+side, oy))
+	c2 := sk.Points().Add(math.P2(ox+side, oy+side))
+	c3 := sk.Points().Add(math.P2(ox, oy+side))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+	return sk
+}
+
+// aimCameraAtEdge frames the body from outside the given edge so the filleted corner faces us.
+func aimCameraAtEdge(s *app.Session, body *topo.Body, e *topo.Edge) {
+	pts := ops.TessellateEdge(e, ops.DefaultQuality())
+	mid := pts[len(pts)/2]
+	rb := body.RangeBox()
+	cx, cy := (rb.Min.X+rb.Max.X)/2, (rb.Min.Y+rb.Max.Y)/2
+	ox, oy := mid.X-cx, mid.Y-cy
+	n := stdmath.Hypot(ox, oy)
+	if n == 0 {
+		n = 1
+	}
+	dist := (rb.Max.X - rb.Min.X) * 2.4
+	cam := scene.NewCamera(1280, 800)
+	cam.Target = mid
+	cam.Eye = math.P3(mid.X+ox/n*dist, mid.Y+oy/n*dist, mid.Z+dist*0.5)
+	cam.Up = math.V3(0, 0, 1)
+	s.SetCamera(cam)
+}
+
+// verticalEdge returns the first edge running mostly along Z (a box's vertical corner).
+func verticalEdge(edges []*topo.Edge) *topo.Edge {
+	for _, e := range edges {
+		pts := ops.TessellateEdge(e, ops.DefaultQuality())
+		if len(pts) < 2 {
+			continue
+		}
+		a, b := pts[0], pts[len(pts)-1]
+		dz := abs(a.Z - b.Z)
+		if dz > abs(a.X-b.X) && dz > abs(a.Y-b.Y) {
+			return e
+		}
+	}
+	return edges[0]
+}
+
+func abs(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/head/ui/dialog_buttons.go
+++ b/head/ui/dialog_buttons.go
@@ -5,12 +5,27 @@
 package ui
 
 import (
+	"strings"
+
 	"oblikovati.org/app"
 	"oblikovati.org/head/internal/native"
 )
 
+// commitBlockedColor tints the "why OK is unavailable" line amber — the config is not an error to
+// fix in the field, just not yet buildable.
+var commitBlockedColor = [4]float32{0.95, 0.55, 0.25, 1}
+
+// drawCommitCancelButtons draws a feature panel's OK/Cancel row. OK is disabled both when the tool
+// lacks its basic inputs (canCommit) AND when the pending configuration would recompute SICK
+// (CommitBlockedReason) — the rule that no sick feature may be committed to the design. When
+// blocked for the latter reason, a short amber line explains why, since a disabled button shows no
+// tooltip.
 func drawCommitCancelButtons(s *app.Session, canCommit bool) {
-	native.BeginDisabled(!canCommit)
+	blocked := ""
+	if canCommit {
+		blocked = s.CommitBlockedReason() // only meaningful once the required inputs are present
+	}
+	native.BeginDisabled(!canCommit || blocked != "")
 	if native.Button("OK") {
 		_ = s.OK()
 	}
@@ -19,4 +34,23 @@ func drawCommitCancelButtons(s *app.Session, canCommit bool) {
 	if native.Button("Cancel") {
 		s.CancelTool()
 	}
+	if blocked != "" {
+		native.PushStyleColor("Text", commitBlockedColor)
+		native.TextWrapped("! " + shortCommitReason(blocked)) // "!" over "⚠": the ImGui font lacks ⚠
+		native.PopStyleColor(1)
+	}
+}
+
+// shortCommitReason trims a kernel health reason to one readable line for the panel: it drops a
+// bracketed detail list (e.g. an inconsistent-orientation dump enumerating dozens of edges) and
+// caps the length, so the warning stays a hint rather than flooding the dialog.
+func shortCommitReason(r string) string {
+	if i := strings.IndexByte(r, '['); i > 0 {
+		r = strings.TrimSpace(r[:i])
+	}
+	const max = 140
+	if len(r) > max {
+		r = r[:max] + "…"
+	}
+	return r
 }

--- a/head/ui/dialog_buttons_test.go
+++ b/head/ui/dialog_buttons_test.go
@@ -1,0 +1,34 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestShortCommitReason keeps the disabled-OK explanation to one readable line: it drops a
+// bracketed detail list (the kernel's per-edge dump) and caps the length, so a huge
+// inconsistent-orientation reason does not flood the panel.
+func TestShortCommitReason(t *testing.T) {
+	dump := "fillet: result is not a valid solid [inconsistent orientation at edge 1 inconsistent orientation at edge 2 inconsistent orientation at edge 3]"
+	got := shortCommitReason(dump)
+	if strings.Contains(got, "[") {
+		t.Errorf("bracketed detail list should be dropped, got %q", got)
+	}
+	if got != "fillet: result is not a valid solid" {
+		t.Errorf("shortCommitReason = %q, want the summary before the detail list", got)
+	}
+
+	long := "fillet: " + strings.Repeat("x", 300)
+	if s := shortCommitReason(long); len(s) > 145 || !strings.HasSuffix(s, "…") {
+		t.Errorf("a long reason should be capped with an ellipsis, got len %d", len(s))
+	}
+
+	short := "fillet: cannot round an edge bordering a curved (cylinder) face"
+	if s := shortCommitReason(short); s != short {
+		t.Errorf("a short reason should pass through unchanged, got %q", s)
+	}
+}

--- a/head/ui/fillet_dialog.go
+++ b/head/ui/fillet_dialog.go
@@ -33,7 +33,9 @@ func drawFilletDialog(s *app.Session) {
 	if filletUI.seeded != f {
 		seedFilletUI(f)
 	}
-	native.SetNextWindowSizeOnce(340, 300)
+	// Tall enough that the disabled-OK "why it's sick" line (drawCommitCancelButtons) shows
+	// without scrolling when a radius the geometry can't admit is entered.
+	native.SetNextWindowSizeOnce(340, 348)
 	if native.Begin("Fillet") {
 		drawFilletPanelBody(s, f)
 	}


### PR DESCRIPTION
## What

No mutable feature operation may be committed while its configuration is **sick**. The **OK/Apply** button is now disabled until the pending configuration is valid, and a sick node can never enter the feature tree.

## Why

A feature tool let the user press OK/Apply even when the pending configuration was geometrically impossible: the commit ran, the kernel recompute failed, and a **Sick** node was left in the history. This surfaced while adding a second fillet to `fvar-1` — a radius the geometry could not admit was applied and produced a sick feature instead of being refused up front.

Closes #1594.

## How it works

One **shared** gate for every `DraftPreviewable` creation tool, at the two commit chokepoints:

- `Session.OK()` refuses a blocked draft — nothing enters the tree, the tool stays open, and the reason lands in the status notice.
- The shared OK/Cancel row (`drawCommitCancelButtons`) disables **OK** while the gate holds and shows the kernel's health reason on an amber line (a disabled button has no tooltip).

It reuses the exact "would this be sick" signal that already exists: `PartFeatures.PreviewResult(draft)` evaluates the drafted feature non-destructively and returns the candidate's recompute error — the same criterion `engine.classify` uses to mark a feature Sick.

Scoped deliberately:
- A **Deferred** result is a warning, not sick, so it does **not** block.
- **In-place edits** are skipped: an edit sits mid-history, where the end-of-part preview mis-resolves references; editing keeps its existing commit-time check.
- The gate applies uniformly to every part-feature tool, not just fillet.

## Tests

- `app`: `TestSickConfigIsNotCommitted` drives the real Fillet tool + part + `PreviewResult` end-to-end — an impossible radius reports a blocked reason, `OK()` is refused, **no** feature is appended; fixing the radius commits exactly one. All existing edit-mode commit tests still pass (gate correctly skips edits).
- `head/ui`: `TestShortCommitReason` covers the one-line reason trimming (bracket-drop + length cap).
- All of `./app/...`, `./model/feature/...`, `./head/ui/...` green; lint clean.

## Live verification

Throwaway driver `head/cmd/filletgateshot` renders the real Fillet panel via `DrawChrome` and captures the window:

- **Sick** (radius the cube can't admit): OK greyed/disabled, amber line `! fillet: edge is not convex (only convex edges are supported)`.
- **Valid** (buildable radius): OK enabled, no warning, live preview ghost on the edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)