### PR TITLE
Deduplicate shot-driver scaffolding (follow-up to #1595)

### DIFF
--- a/head/cmd/filletgateshot/main.go
+++ b/head/cmd/filletgateshot/main.go
@@ -14,19 +14,13 @@ package main
 import (
 	"flag"
 	"fmt"
-	stdmath "math"
 	"os"
 
 	"oblikovati.org/app"
+	"oblikovati.org/head/cmd/internal/shotscene"
 	"oblikovati.org/head/internal/native"
 	"oblikovati.org/head/ui"
-	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
-	"oblikovati.org/math"
-	"oblikovati.org/model/compdef"
-	"oblikovati.org/model/feature"
-	"oblikovati.org/model/sketch"
-	"oblikovati.org/scene"
 )
 
 const gateDocName = "filletgateshot.opd"
@@ -47,10 +41,10 @@ func run(out string, frames int) error {
 	if err := app.RegisterStandardCommands(s); err != nil {
 		return err
 	}
-	def := buildBaseBox(s)
+	def := shotscene.BuildBox(s, gateDocName, 6, 6)
 	body := def.SurfaceBodies().Item(0)
-	edge := verticalEdge(body.Edges())
-	aimCameraAtEdge(s, body, edge)
+	edge := shotscene.VerticalEdge(body.Edges())
+	shotscene.AimCameraAtEdge(s, body, edge)
 
 	win, err := native.CreateWindow(1280, 800, "filletgateshot")
 	if err != nil {
@@ -86,72 +80,4 @@ func capture(win *native.Window, s *app.Session, edge *topo.Edge, radius float64
 		win.EndFrame(ui.WindowClearColor())
 	}
 	return win.SaveWindowPNG(path)
-}
-
-func buildBaseBox(s *app.Session) *compdef.PartComponentDefinition {
-	pd, err := compdef.AddPart(s.Workspace(), gateDocName, true)
-	if err != nil {
-		panic(err)
-	}
-	_ = s.Workspace().SetActiveDocument(pd)
-	def := pd.Content().(*compdef.PartComponentDefinition)
-	sk := addSquare(def, 0, 0, 6)
-	feature.NewExtrudeFeatures(def.Features()).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 6 })
-	def.Recompute()
-	return def
-}
-
-func addSquare(def *compdef.PartComponentDefinition, ox, oy, side float64) *sketch.Sketch {
-	sk := def.Sketches().Add(sketch.XYPlane())
-	c0 := sk.Points().Add(math.P2(ox, oy))
-	c1 := sk.Points().Add(math.P2(ox+side, oy))
-	c2 := sk.Points().Add(math.P2(ox+side, oy+side))
-	c3 := sk.Points().Add(math.P2(ox, oy+side))
-	sk.Lines().Add(c0, c1)
-	sk.Lines().Add(c1, c2)
-	sk.Lines().Add(c2, c3)
-	sk.Lines().Add(c3, c0)
-	return sk
-}
-
-// aimCameraAtEdge frames the body from outside the given edge so the filleted corner faces us.
-func aimCameraAtEdge(s *app.Session, body *topo.Body, e *topo.Edge) {
-	pts := ops.TessellateEdge(e, ops.DefaultQuality())
-	mid := pts[len(pts)/2]
-	rb := body.RangeBox()
-	cx, cy := (rb.Min.X+rb.Max.X)/2, (rb.Min.Y+rb.Max.Y)/2
-	ox, oy := mid.X-cx, mid.Y-cy
-	n := stdmath.Hypot(ox, oy)
-	if n == 0 {
-		n = 1
-	}
-	dist := (rb.Max.X - rb.Min.X) * 2.4
-	cam := scene.NewCamera(1280, 800)
-	cam.Target = mid
-	cam.Eye = math.P3(mid.X+ox/n*dist, mid.Y+oy/n*dist, mid.Z+dist*0.5)
-	cam.Up = math.V3(0, 0, 1)
-	s.SetCamera(cam)
-}
-
-// verticalEdge returns the first edge running mostly along Z (a box's vertical corner).
-func verticalEdge(edges []*topo.Edge) *topo.Edge {
-	for _, e := range edges {
-		pts := ops.TessellateEdge(e, ops.DefaultQuality())
-		if len(pts) < 2 {
-			continue
-		}
-		a, b := pts[0], pts[len(pts)-1]
-		dz := abs(a.Z - b.Z)
-		if dz > abs(a.X-b.X) && dz > abs(a.Y-b.Y) {
-			return e
-		}
-	}
-	return edges[0]
-}
-
-func abs(x float64) float64 {
-	if x < 0 {
-		return -x
-	}
-	return x
 }

--- a/head/cmd/internal/shotscene/shotscene.go
+++ b/head/cmd/internal/shotscene/shotscene.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package shotscene holds the small scene-building helpers shared by the head's throwaway
+// live-capture drivers (previewshot, filletgateshot, …): building a base box, adding a square
+// sketch, finding a box's vertical edge, and framing the camera on an edge. Extracted so the
+// drivers do not each re-declare the same geometry scaffolding.
+package shotscene
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/app"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+	"oblikovati.org/scene"
+)
+
+// NewPart adds and activates an empty part named name, returning its definition.
+func NewPart(s *app.Session, name string) *compdef.PartComponentDefinition {
+	pd, err := compdef.AddPart(s.Workspace(), name, true)
+	if err != nil {
+		panic(err)
+	}
+	_ = s.Workspace().SetActiveDocument(pd)
+	return pd.Content().(*compdef.PartComponentDefinition)
+}
+
+// BuildBox commits a side×side×height base solid in a fresh part (its corner at the origin).
+func BuildBox(s *app.Session, name string, side, height float64) *compdef.PartComponentDefinition {
+	def := NewPart(s, name)
+	sk := AddSquare(def, 0, 0, side)
+	feature.NewExtrudeFeatures(def.Features()).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return height })
+	def.Recompute()
+	return def
+}
+
+// AddSquare adds a side×side square sketch on the XY plane with its corner at (ox,oy).
+func AddSquare(def *compdef.PartComponentDefinition, ox, oy, side float64) *sketch.Sketch {
+	sk := def.Sketches().Add(sketch.XYPlane())
+	c0 := sk.Points().Add(math.P2(ox, oy))
+	c1 := sk.Points().Add(math.P2(ox+side, oy))
+	c2 := sk.Points().Add(math.P2(ox+side, oy+side))
+	c3 := sk.Points().Add(math.P2(ox, oy+side))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+	return sk
+}
+
+// AimCameraAtEdge frames body from outside edge e (looking at its midpoint along the outward
+// direction, tilted down), so a thin edge wedge faces the camera rather than presenting edge-on.
+func AimCameraAtEdge(s *app.Session, body *topo.Body, e *topo.Edge) {
+	pts := ops.TessellateEdge(e, ops.DefaultQuality())
+	mid := pts[len(pts)/2]
+	rb := body.RangeBox()
+	cx, cy := (rb.Min.X+rb.Max.X)/2, (rb.Min.Y+rb.Max.Y)/2
+	ox, oy := mid.X-cx, mid.Y-cy
+	n := stdmath.Hypot(ox, oy)
+	if n == 0 {
+		n = 1
+	}
+	dist := (rb.Max.X - rb.Min.X) * 2.4
+	cam := scene.NewCamera(1280, 800)
+	cam.Target = mid
+	cam.Eye = math.P3(mid.X+ox/n*dist, mid.Y+oy/n*dist, mid.Z+dist*0.5)
+	cam.Up = math.V3(0, 0, 1)
+	s.SetCamera(cam)
+}
+
+// VerticalEdge returns the first edge running mostly along Z (a box's vertical corner).
+func VerticalEdge(edges []*topo.Edge) *topo.Edge {
+	for _, e := range edges {
+		pts := ops.TessellateEdge(e, ops.DefaultQuality())
+		if len(pts) < 2 {
+			continue
+		}
+		a, b := pts[0], pts[len(pts)-1]
+		dz := stdmath.Abs(a.Z - b.Z)
+		if dz > stdmath.Abs(a.X-b.X) && dz > stdmath.Abs(a.Y-b.Y) {
+			return e
+		}
+	}
+	return edges[0]
+}

--- a/head/cmd/previewshot/main.go
+++ b/head/cmd/previewshot/main.go
@@ -22,6 +22,7 @@ import (
 
 	"oblikovati.org/api/types"
 	"oblikovati.org/app"
+	"oblikovati.org/head/cmd/internal/shotscene"
 	"oblikovati.org/head/internal/native"
 	"oblikovati.org/head/ui"
 	"oblikovati.org/kernel/brep"
@@ -149,48 +150,24 @@ func setupOp(s *app.Session, op string) error {
 
 // --- base solids -----------------------------------------------------------------------
 
-// newPart adds and activates an empty part, returning its definition.
-func newPart(s *app.Session, name string) *compdef.PartComponentDefinition {
-	pd, err := compdef.AddPart(s.Workspace(), name, true)
-	if err != nil {
-		panic(err)
-	}
-	_ = s.Workspace().SetActiveDocument(pd)
-	return pd.Content().(*compdef.PartComponentDefinition)
+// newPart adds and activates an empty part (this driver's single document), returning its def.
+func newPart(s *app.Session) *compdef.PartComponentDefinition {
+	return shotscene.NewPart(s, previewDocName)
 }
 
 // mustBaseBox commits a 6×6×6 base cube (the target for join/cut/fillet/chamfer).
-func mustBaseBox(s *app.Session) *compdef.PartComponentDefinition { return buildBaseBox(s) }
-
-func buildBaseBox(s *app.Session) *compdef.PartComponentDefinition {
-	def := newPart(s, previewDocName)
-	sk := addSquare(def, 0, 0, 6)
-	feature.NewExtrudeFeatures(def.Features()).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 6 })
-	def.Recompute()
-	return def
+func mustBaseBox(s *app.Session) *compdef.PartComponentDefinition {
+	return shotscene.BuildBox(s, previewDocName, 6, 6)
 }
 
 // mustBlock commits a 6×6×3 base solid (the target for shell/draft/hole).
 func mustBlock(s *app.Session) *compdef.PartComponentDefinition {
-	def := newPart(s, previewDocName)
-	sk := addSquare(def, 0, 0, 6)
-	feature.NewExtrudeFeatures(def.Features()).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 3 })
-	def.Recompute()
-	return def
+	return shotscene.BuildBox(s, previewDocName, 6, 3)
 }
 
 // addSquare adds a side×side square sketch on the XY plane with its corner at (ox,oy).
 func addSquare(def *compdef.PartComponentDefinition, ox, oy, side float64) *sketch.Sketch {
-	sk := def.Sketches().Add(sketch.XYPlane())
-	c0 := sk.Points().Add(math.P2(ox, oy))
-	c1 := sk.Points().Add(math.P2(ox+side, oy))
-	c2 := sk.Points().Add(math.P2(ox+side, oy+side))
-	c3 := sk.Points().Add(math.P2(ox, oy+side))
-	sk.Lines().Add(c0, c1)
-	sk.Lines().Add(c1, c2)
-	sk.Lines().Add(c2, c3)
-	sk.Lines().Add(c3, c0)
-	return sk
+	return shotscene.AddSquare(def, ox, oy, side)
 }
 
 // offsetSquare adds a side×side square on XY whose lower-left corner is at (x0,0).
@@ -216,7 +193,7 @@ func startPendingExtrude(s *app.Session, def *compdef.PartComponentDefinition, o
 }
 
 func startPendingRevolve(s *app.Session) {
-	def := newPart(s, previewDocName)
+	def := newPart(s)
 	prof := offsetSquare(def, 3, 2) // 2×2 square 3 units off the Y axis → a ring
 	def.Recompute()
 	rv := app.NewRevolveTool()
@@ -227,7 +204,7 @@ func startPendingRevolve(s *app.Session) {
 }
 
 func startPendingSweep(s *app.Session) {
-	def := newPart(s, previewDocName)
+	def := newPart(s)
 	prof := app.ProfileHandle{Sketch: centeredSquare(def, sketch.XYPlane(), 1), ProfileIndex: 0}
 	pathSk := def.Sketches().Add(sketch.XZPlane())
 	a := pathSk.Points().Add(math.P2(0, 0))
@@ -241,7 +218,7 @@ func startPendingSweep(s *app.Session) {
 }
 
 func startPendingLoft(s *app.Session) {
-	def := newPart(s, previewDocName)
+	def := newPart(s)
 	bottom := app.ProfileHandle{Sketch: centeredSquare(def, sketch.XYPlane(), 3), ProfileIndex: 0}
 	top := app.ProfileHandle{Sketch: centeredSquare(def, planeAtZ(6), 1), ProfileIndex: 0}
 	def.Recompute()
@@ -252,7 +229,7 @@ func startPendingLoft(s *app.Session) {
 }
 
 func startPendingCoil(s *app.Session) {
-	def := newPart(s, previewDocName)
+	def := newPart(s)
 	prof := offsetSquare(def, 3, 1) // 1×1 square 3 off the Y axis → a helical spring
 	def.Recompute()
 	c := app.NewCoilTool()
@@ -338,7 +315,7 @@ func startPendingThread(s *app.Session) error {
 	if err != nil {
 		return err
 	}
-	def := newPart(s, previewDocName)
+	def := newPart(s)
 	feature.NewBaseFeatures(def.Features()).AddBase(cyl)
 	def.Recompute()
 	body := def.SurfaceBodies().Item(0)
@@ -404,7 +381,7 @@ func startPendingCoreCavity(s *app.Session, def *compdef.PartComponentDefinition
 
 // startPendingRib thickens an open profile into a rib joined to a base block (tool body → green).
 func startPendingRib(s *app.Session) {
-	def := newPart(s, previewDocName)
+	def := newPart(s)
 	sk := addSquare(def, 0, 0, 6)
 	feature.NewExtrudeFeatures(def.Features()).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 2 })
 	rs := def.Sketches().Add(sketch.XYPlane())
@@ -418,7 +395,7 @@ func startPendingRib(s *app.Session) {
 
 // startPendingThicken thickens a planar surface patch into a solid (surface→solid → green).
 func startPendingThicken(s *app.Session) {
-	def := newPart(s, previewDocName)
+	def := newPart(s)
 	feature.NewBaseFeatures(def.Features()).AddBase(patchSurface(4, 4))
 	def.Recompute()
 	t := app.NewThickenTool()
@@ -462,7 +439,7 @@ func startPendingRest(s *app.Session, def *compdef.PartComponentDefinition) {
 
 // startPendingSnapFit previews a free-standing cantilever snap-fit hook (adds material → green).
 func startPendingSnapFit(s *app.Session) {
-	newPart(s, previewDocName)
+	newPart(s)
 	t := app.NewSnapFitTool()
 	s.StartTool(t)
 	t.SetLength(6)
@@ -501,7 +478,7 @@ func startPendingReplaceFace(s *app.Session, def *compdef.PartComponentDefinitio
 
 // startPendingPatch fills a sketched region with a surface patch (creates surface → green).
 func startPendingPatch(s *app.Session) {
-	def := newPart(s, previewDocName)
+	def := newPart(s)
 	sk := addSquare(def, 0, 0, 4)
 	def.Recompute()
 	t := app.NewPatchTool()
@@ -511,7 +488,7 @@ func startPendingPatch(s *app.Session) {
 
 // startPendingStitch welds two adjacent surface patches (result surface → green).
 func startPendingStitch(s *app.Session) {
-	def := newPart(s, previewDocName)
+	def := newPart(s)
 	addPatchFeature(def, 0, 0, 2, 3)
 	addPatchFeature(def, 2, 0, 4, 3)
 	def.Recompute()
@@ -520,7 +497,7 @@ func startPendingStitch(s *app.Session) {
 
 // startPendingSurfaceTrim trims a surface patch by a work plane (removes area → red).
 func startPendingSurfaceTrim(s *app.Session) {
-	def := newPart(s, previewDocName)
+	def := newPart(s)
 	addPatchFeature(def, 0, 0, 4, 4)
 	wp := def.WorkPlanes().AddByPlaneAndOffset(feature.OriginYZPlane, func() float64 { return 2 })
 	def.Recompute()
@@ -531,7 +508,7 @@ func startPendingSurfaceTrim(s *app.Session) {
 
 // startPendingSculpt closes a 6-face surface shell into a solid (creates volume → green).
 func startPendingSculpt(s *app.Session) {
-	def := newPart(s, previewDocName)
+	def := newPart(s)
 	feature.NewBaseFeatures(def.Features()).AddBase(unitCubeShell()...)
 	def.Recompute()
 	s.StartTool(app.NewSculptTool())
@@ -539,7 +516,7 @@ func startPendingSculpt(s *app.Session) {
 
 // startPendingExtend grows a surface patch beyond its bottom edge (adds area → green).
 func startPendingExtend(s *app.Session) {
-	def := newPart(s, previewDocName)
+	def := newPart(s)
 	addPatchFeature(def, 0, 0, 4, 4)
 	def.Recompute()
 	body := def.SurfaceBodies().Item(0)

--- a/head/cmd/previewshot/main_test.go
+++ b/head/cmd/previewshot/main_test.go
@@ -19,7 +19,7 @@ func previewSession(t *testing.T, op string) *app.Session {
 	if err := app.RegisterStandardCommands(s); err != nil {
 		t.Fatalf("RegisterStandardCommands: %v", err)
 	}
-	startPendingExtrude(s, buildBaseBox(s), op)
+	startPendingExtrude(s, mustBaseBox(s), op)
 	return s
 }
 


### PR DESCRIPTION
## What

Extract the head live-capture drivers' shared scene scaffolding into `head/cmd/internal/shotscene` and route `filletgateshot` and `previewshot` through it.

## Why

#1595 (the sick-config commit gate) added the `filletgateshot` live driver, which copied its base-box / square-sketch / vertical-edge / camera-framing helpers verbatim from `previewshot`. That merged before SonarCloud finished (Sonar is not a required check, so auto-merge fired on the required checks), leaving new-code duplication in develop (SonarCloud: 17.1% > 3% on `filletgateshot/main.go`, 58 duplicated lines).

This removes the duplication at the source: the shared bodies (`BuildBox`, `AddSquare`, `VerticalEdge`, `AimCameraAtEdge`, `NewPart`) now live once in `shotscene`, and both drivers delegate to it.

## Tests

- `go build ./head/cmd/...` clean.
- `previewshot` setup-coverage test (`TestSetupOpPreviewsEveryFeature`) still green; `filletgateshot` still captures OK-disabled vs OK-enabled (behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)