### PR TITLE
Fix SSI extent collapse on closed/periodic surfaces (audit A1)

### DIFF
--- a/kernel/brep/curved_cone_cone_imprint.go
+++ b/kernel/brep/curved_cone_cone_imprint.go
@@ -32,7 +32,7 @@ func coneConeImprint(a, b *topo.Body, rec *diag.Recorder) ([]geom.Polyline, bool
 	}
 	window := geom.SurfaceGrid{VMin: vMin, VMax: vMax}
 	res := geom.ResolutionForBox(a.RangeBox().Union(b.RangeBox())) // model-relative loop-closure weld (#1399)
-	loops := closedTraceLoops(geom.IntersectSurfaceSurface(ca, cb, window), res, rec)
+	loops := imprintTraceLoops(ca, cb, window, res, rec)
 	if len(loops) == 0 {
 		return nil, false
 	}

--- a/kernel/brep/curved_cone_cylinder_imprint.go
+++ b/kernel/brep/curved_cone_cylinder_imprint.go
@@ -30,7 +30,7 @@ func coneCylinderImprint(a, b *topo.Body, rec *diag.Recorder) ([]geom.Polyline, 
 	}
 	window := geom.SurfaceGrid{VMin: vMin, VMax: vMax}
 	res := geom.ResolutionForBox(a.RangeBox().Union(b.RangeBox())) // model-relative loop-closure weld (#1399)
-	loops := closedTraceLoops(geom.IntersectSurfaceSurface(cone, cyl, window), res, rec)
+	loops := imprintTraceLoops(cone, cyl, window, res, rec)
 	if len(loops) == 0 {
 		return nil, false
 	}

--- a/kernel/brep/curved_crossing_imprint.go
+++ b/kernel/brep/curved_crossing_imprint.go
@@ -29,6 +29,29 @@ import (
 // imprint degraded (and the boolean will fall back) rather than discover it later downstream.
 const CodeImprintUnclosedChain diag.Code = "imprint.unclosed-chain"
 
+// CodeImprintFallbackContour marks an imprint whose SSI curves came from the fixed-grid
+// marching-squares fallback, not the continuation tracer (#1597). Fallback loops are contour-quality
+// (sub-grid features lost, tangencies invisible), so the imprint proceeds but the degradation is
+// recorded instead of silent.
+const CodeImprintFallbackContour diag.Code = "imprint.fallback-contour"
+
+// imprintTraceLoops traces base∩other over window and keeps the loops that close — the shared trace
+// step of every curved-imprint pair (cylinder∩cylinder, cone∩cylinder, cone∩cone).
+func imprintTraceLoops(base, other geom.Surface, window geom.SurfaceGrid, res geom.Resolution, rec *diag.Recorder) []geom.Polyline {
+	return keepImprintLoops(geom.TraceSurfaceIntersection(base, other, window), res, rec)
+}
+
+// keepImprintLoops keeps the closed loops of a trace result, recording the fallback-contour
+// diagnostic when the curves came from marching squares rather than the tracer (#1597). Split from
+// imprintTraceLoops so the recording branch is unit-testable without forcing a live fallback.
+func keepImprintLoops(tr geom.SurfaceIntersection, res geom.Resolution, rec *diag.Recorder) []geom.Polyline {
+	if tr.ViaFallback {
+		rec.Recordf(CodeImprintFallbackContour, diag.Defect,
+			"SSI tracer found no curve; %d contour(s) supplied by the marching-squares fallback", len(tr.Curves))
+	}
+	return closedTraceLoops(tr.Curves, res, rec)
+}
+
 // crossingCylinderImprint returns the intersection loops of two bare cylinder bodies as closed polylines,
 // or ok=false when either body is not a bare cylinder or no closed loop is traced. The trace window spans
 // the first body's axial extent (the cylinders cross within it), and the periodic angular direction is
@@ -41,7 +64,7 @@ func crossingCylinderImprint(a, b *topo.Body, rec *diag.Recorder) ([]geom.Polyli
 		return nil, false
 	}
 	res := geom.ResolutionForBox(a.RangeBox().Union(b.RangeBox())) // model-relative loop-closure weld (#1399)
-	loops := closedTraceLoops(geom.IntersectSurfaceSurface(ca, cb, cylinderTraceWindow(ca, baseA, heightA)), res, rec)
+	loops := imprintTraceLoops(ca, cb, cylinderTraceWindow(ca, baseA, heightA), res, rec)
 	if len(loops) == 0 {
 		return nil, false
 	}

--- a/kernel/brep/curved_crossing_imprint_test.go
+++ b/kernel/brep/curved_crossing_imprint_test.go
@@ -141,3 +141,46 @@ func TestCrossingCylinderImprintDisjointHasNoLoops(t *testing.T) {
 		t.Error("disjoint cylinders should trace no imprint loop (ok=false)")
 	}
 }
+
+// TestCrossingCylinderImprintSquatFat: squat proportions (R ≫ h) used to size the SSI march from the
+// axial height alone — the corner-to-corner extent estimate maps the periodic angular corners to the
+// same generator line (#1597) — starving the trace of step and tolerance. The rod's entry and exit
+// through the squat fat wall must still give two clean closed loops, with no recorded degradation.
+func TestCrossingCylinderImprintSquatFat(t *testing.T) {
+	fat, _ := SolidCylinder(math.P3(0, 0, -2), math.V3(0, 0, 1), 50, 4)     // squat: R=50, h=4
+	rod, _ := SolidCylinder(math.P3(-60, 0, 0), math.V3(1, 0, 0), 1.5, 120) // axis x, through both walls
+	rec := &diag.Recorder{}
+	loops, ok := crossingCylinderImprint(fat, rod, rec)
+	if !ok || len(loops) != 2 {
+		t.Fatalf("squat-fat imprint: ok=%v loops=%d, want 2 closed loops", ok, len(loops))
+	}
+	if rec.Count(diag.Defect) != 0 {
+		t.Errorf("squat-fat imprint recorded %d defects, want 0; got %v", rec.Count(diag.Defect), rec.Records())
+	}
+	ca, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 50)
+	cb, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(1, 0, 0), 1.5)
+	for i, lp := range loops {
+		if !samePoint(lp.PointAt(0), lp.PointAt(1), geom.ResolutionForSize(1)) {
+			t.Errorf("loop %d is not closed: %v vs %v", i, lp.PointAt(0), lp.PointAt(1))
+		}
+		if err := onBothCylinders(lp, ca, cb); err > 1e-4 {
+			t.Errorf("loop %d sits %.2e off a cylinder surface, want it on both", i, err)
+		}
+	}
+}
+
+// TestKeepImprintLoopsRecordsFallbackContour: curves whose provenance is the marching-squares fallback
+// must raise CodeImprintFallbackContour — the imprint proceeds on contour-quality loops, but the
+// degradation is recorded instead of silent (#1597).
+func TestKeepImprintLoopsRecordsFallbackContour(t *testing.T) {
+	res := geom.ResolutionForSize(10)
+	square := []math.Point3{math.P3(0, 0, 0), math.P3(1, 0, 0), math.P3(1, 1, 0), math.P3(0, 1, 0), math.P3(0, 0, 0)}
+	rec := &diag.Recorder{}
+	loops := keepImprintLoops(geom.SurfaceIntersection{Curves: [][]math.Point3{square}, ViaFallback: true}, res, rec)
+	if len(loops) != 1 {
+		t.Fatalf("got %d loops, want 1 (fallback curves are kept, only flagged)", len(loops))
+	}
+	if !rec.Has(CodeImprintFallbackContour) {
+		t.Errorf("fallback-supplied curves recorded no %q diagnostic; got %v", CodeImprintFallbackContour, rec.Records())
+	}
+}

--- a/kernel/geom/intersect_surface_surface.go
+++ b/kernel/geom/intersect_surface_surface.go
@@ -19,11 +19,28 @@ import "oblikovati.org/math"
 //	pl, _ := geom.NewPlane(math.P3(0,0,0), math.V3(0,0,1))
 //	loops := geom.IntersectSurfaceSurface(sp, pl, geom.SurfaceGrid{}) // one loop on z=0
 func IntersectSurfaceSurface(base, other Surface, grid SurfaceGrid) [][]math.Point3 {
+	return TraceSurfaceIntersection(base, other, grid).Curves
+}
+
+// SurfaceIntersection carries the intersection curves plus their provenance: ViaFallback reports that
+// the continuation tracer found no curve and the fixed-grid marching-squares contour supplied the
+// result. Fallback curves are contour-quality — sub-grid loops lost, tangencies invisible — so a
+// caller holding a diag recorder must surface that degradation instead of shipping it silently
+// (#1597; vacuously false when there is no intersection at all).
+type SurfaceIntersection struct {
+	Curves      [][]math.Point3
+	ViaFallback bool
+}
+
+// TraceSurfaceIntersection is IntersectSurfaceSurface with provenance, for callers that need to see —
+// not just receive — a degraded fallback result.
+func TraceSurfaceIntersection(base, other Surface, grid SurfaceGrid) SurfaceIntersection {
 	if curves := traceIntersectionCurves(base, other, grid); len(curves) > 0 {
-		return curves
+		return SurfaceIntersection{Curves: curves}
 	}
 	field := func(u, v float64) float64 {
 		return SignedDistanceToSurface(other, base.PointAt(u, v))
 	}
-	return traceZeroOnSurface(base, field, grid)
+	curves := traceZeroOnSurface(base, field, grid)
+	return SurfaceIntersection{Curves: curves, ViaFallback: len(curves) > 0}
 }

--- a/kernel/geom/intersect_surface_surface_test.go
+++ b/kernel/geom/intersect_surface_surface_test.go
@@ -144,3 +144,15 @@ func TestTraceHelpersDirect(t *testing.T) {
 		t.Error("straddlesZero wrong")
 	}
 }
+
+// TestTraceSurfaceIntersectionDisjointIsQuiet: no intersection at all is not a fallback result —
+// ViaFallback flags only curves the marching-squares contour supplied (#1597), so a caller recording
+// the degradation does not raise a defect for every disjoint candidate face pair.
+func TestTraceSurfaceIntersectionDisjointIsQuiet(t *testing.T) {
+	sp, _ := NewSphere(math.P3(0, 0, 0), 1)
+	pl, _ := NewPlane(math.P3(0, 0, 10), math.V3(0, 0, 1))
+	tr := TraceSurfaceIntersection(sp, pl, SurfaceGrid{})
+	if len(tr.Curves) != 0 || tr.ViaFallback {
+		t.Errorf("disjoint sphere/plane: curves=%d fallback=%v, want none and false", len(tr.Curves), tr.ViaFallback)
+	}
+}

--- a/kernel/geom/intersect_surface_trace.go
+++ b/kernel/geom/intersect_surface_trace.go
@@ -41,8 +41,12 @@ const (
 	// Step multiples used while marching: a seed within ssiDedupSteps of an existing curve is a
 	// duplicate of it; the loop closes when the march returns within ssiLoopCloseSteps of its start;
 	// a tangency seed may sit up to ssiTangencyGapSteps from the contact (the strict normal test, not
-	// this gate, is the real discriminator).
-	ssiDedupSteps       = 1.5
+	// this gate, is the real discriminator). ssiDedupSteps pairs with the SEGMENT-distance dedup in
+	// nearAnyCurve (#1597): a duplicate seed corrects onto the already-traced curve and sits within
+	// chord sag of its polyline (≤ step²·κ/8, ≪ a step), while a genuinely distinct neighbouring loop
+	// keeps its full 3D separation — so the radius must cover sag, not a whole step, or two
+	// near-tangent circles closer than a step apart collapse into one.
+	ssiDedupSteps       = 0.25
 	ssiLoopCloseSteps   = 0.75
 	ssiTangencyGapSteps = 5.0
 	// ssiDescentGain damps the steepest-descent corrector step taken where the two surface normals are
@@ -273,11 +277,18 @@ func inWindow(base Surface, pc math.Point3, g SurfaceGrid) bool {
 	return u >= g.UMin-mu && u <= g.UMax+mu && v >= g.VMin-mv && v <= g.VMax+mv
 }
 
-// nearAnyCurve reports whether p is within tol of any point of an already-traced curve.
+// nearAnyCurve reports whether p is within tol of an already-traced curve, measured to the polyline
+// SEGMENTS (a single-point tangency marker degenerates to its point). Vertex distance conflated a
+// duplicate seed (on the same curve, within chord sag of its polyline) with a distinct neighbouring
+// loop as soon as the loops sat closer together than the dedup radius — e.g. the two near-tangent
+// circles where a sphere barely clears a cylinder (#1597).
 func nearAnyCurve(curves [][]math.Point3, p math.Point3, tol float64) bool {
 	for _, c := range curves {
-		for _, q := range c {
-			if float64(p.DistanceTo(q)) < tol {
+		if len(c) == 1 && float64(p.DistanceTo(c[0])) < tol {
+			return true
+		}
+		for i := 0; i+1 < len(c); i++ {
+			if DistancePointToSegment(LineSegment{StartPoint: c[i], EndPoint: c[i+1]}, p) < tol {
 				return true
 			}
 		}
@@ -297,14 +308,37 @@ func ssiStep(base Surface, g SurfaceGrid) float64 {
 	return ssiStepFraction * ssiExtent(base, g)
 }
 
-// ssiExtent estimates the base patch's 3D size over the grid window (the diagonal of its corner box),
-// used to scale the tolerance and step.
+// ssiExtentSamples is the per-axis lattice for the extent estimate. Five samples put nodes at the
+// quarter points of a full-period window, so a closed direction contributes the four cardinal points
+// of every circular section — its true girth — to the bounding box (#1597).
+const ssiExtentSamples = 5
+
+// ssiExtent estimates the base patch's 3D size over the grid window — the diagonal of the bounding
+// box of a sampled parameter lattice — used to scale the tolerance and step. The previous
+// corner-to-corner estimate collapsed wherever the window is periodic: on a torus both corners map to
+// the SAME 3D point (measured 1.5e-14 for R=50/r=10, true ≈171), and on a cylinder they differ by the
+// axial height only, missing the girth entirely — which drove step and tolerance toward 0 and pushed
+// every trace onto the marching-squares fallback silently (#1597). OCCT sizes its walking step from
+// surface bounding boxes the same way (IntWalk_PWalking via Bnd_Box/adaptor resolution).
 func ssiExtent(base Surface, g SurfaceGrid) float64 {
-	c00 := base.PointAt(g.UMin, g.VMin)
-	c11 := base.PointAt(g.UMax, g.VMax)
-	d := float64(c00.DistanceTo(c11))
+	d := float64(sampledPatchBox(base, g).Diagonal().Length())
 	if d <= 0 {
 		return 1
 	}
 	return d
+}
+
+// sampledPatchBox is the axis-aligned box of base evaluated on an ssiExtentSamples² lattice over the
+// grid window (corners included).
+func sampledPatchBox(base Surface, g SurfaceGrid) math.Box {
+	n := ssiExtentSamples - 1
+	pts := make([]math.Point3, 0, ssiExtentSamples*ssiExtentSamples)
+	for i := 0; i <= n; i++ {
+		u := g.UMin + (g.UMax-g.UMin)*float64(i)/float64(n)
+		for j := 0; j <= n; j++ {
+			v := g.VMin + (g.VMax-g.VMin)*float64(j)/float64(n)
+			pts = append(pts, base.PointAt(u, v))
+		}
+	}
+	return math.BoxFromPoints(pts...)
 }

--- a/kernel/geom/intersect_surface_trace_test.go
+++ b/kernel/geom/intersect_surface_trace_test.go
@@ -220,3 +220,60 @@ func TestSSIAgreesWithAnalyticOnSpherePlane(t *testing.T) {
 		}
 	}
 }
+
+// TestSSIExtentClosedSurfaceSampledBox: the extent estimate must survive closed/periodic parameter
+// windows (#1597). The old corner-to-corner estimate mapped both corners of a torus domain to the SAME
+// 3D point (extent ~1e-14 for R=50/r=10), and measured a cylinder window by its axial height alone —
+// collapsing step and tolerance until every trace silently fell back to marching squares. The sampled
+// lattice keeps each closed direction's girth in the bounding box.
+func TestSSIExtentClosedSurfaceSampledBox(t *testing.T) {
+	torus, _ := NewTorus(math.P3(0, 0, 0), math.V3(0, 0, 1), 50, 10)
+	if ext := ssiExtent(torus, resolveGrid(torus, SurfaceGrid{})); ext < 120 || ext > 180 {
+		t.Errorf("torus R=50/r=10 extent %g, want the sampled-box diagonal ≈170.9 (corner estimate was ~1e-14)", ext)
+	}
+	squat, _ := NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 50)
+	if ext := ssiExtent(squat, resolveGrid(squat, SurfaceGrid{VMin: 0, VMax: 1})); ext < 100 {
+		t.Errorf("squat cylinder R=50/h=1 extent %g, want ≥ its girth 100 (corner estimate was the height, 1)", ext)
+	}
+}
+
+// TestSSITorusPlaneTwoCircles: a torus R=50/r=10 cut by its equatorial plane must yield the two
+// analytic circles r=40 and r=60 VIA THE TRACER — the #1597 regression: with the collapsed extent
+// every seed failed to march and the (coarser) marching-squares fallback silently supplied the curves.
+func TestSSITorusPlaneTwoCircles(t *testing.T) {
+	torus, _ := NewTorus(math.P3(0, 0, 0), math.V3(0, 0, 1), 50, 10)
+	pl, _ := NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	tr := TraceSurfaceIntersection(torus, pl, SurfaceGrid{})
+	if tr.ViaFallback {
+		t.Fatal("torus∩plane curves came from the marching-squares fallback, want the continuation tracer")
+	}
+	loops := closedOnly(tr.Curves)
+	if len(loops) != 2 {
+		t.Fatalf("got %d closed loops, want the 2 analytic equator circles r=40 and r=60", len(loops))
+	}
+	var radii []float64
+	for i, loop := range loops {
+		r, err := loopAxisRadius(loop)
+		if err > 1e-3 {
+			t.Errorf("loop %d wobbles %.2e off a constant axis radius, want an exact circle", i, err)
+		}
+		radii = append(radii, r)
+	}
+	lo, hi := stdmath.Min(radii[0], radii[1]), stdmath.Max(radii[0], radii[1])
+	if stdmath.Abs(lo-40) > 1e-3 || stdmath.Abs(hi-60) > 1e-3 {
+		t.Errorf("loop radii [%g, %g], want the analytic [40, 60]", lo, hi)
+	}
+}
+
+// loopAxisRadius returns the mean distance of the loop's points from the z axis and the largest
+// deviation of any point from that mean (0 for an exact axis-centred circle).
+func loopAxisRadius(loop []math.Point3) (mean, worst float64) {
+	for _, p := range loop {
+		mean += stdmath.Hypot(float64(p.X), float64(p.Y))
+	}
+	mean /= float64(len(loop))
+	for _, p := range loop {
+		worst = stdmath.Max(worst, stdmath.Abs(stdmath.Hypot(float64(p.X), float64(p.Y))-mean))
+	}
+	return mean, worst
+}


### PR DESCRIPTION
## What

The SSI tracer sized its march step and on-curve tolerance from the 3D distance between the base patch's parameter-window **corners**. On a periodic window the corners coincide in 3D — a torus R=50/r=10 measured **1.5e-14** against a true ~171 — and a cylinder window measured its **axial height only**, missing the girth. Both starved the tracer until every trace silently degraded to the coarse 96×96 marching-squares contour.

- `ssiExtent` now returns the bounding-box diagonal of a **5×5 sampled lattice** over the window (OCCT sizes walking steps from surface bounds the same way, `IntWalk_PWalking`/`Bnd_Box`). Five samples per axis land on the quarter points of a full-period window, so each closed direction contributes its true girth. This fixes both the torus/sphere-seam case and the squat-cylinder case (the cylinder imprint flows through the same `ssiStep`/`ssiTolerance`).
- The corrected (larger) step exposed a latent dedup defect: seeds were deduped by **vertex** distance at 1.5 steps, which swallowed genuinely distinct loops closer together than the dedup radius (the two near-tangent circles where a sphere barely clears a cylinder). `nearAnyCurve` now measures distance to the polyline **segments** with a 0.25-step radius — a duplicate seed lies within chord sag of the same curve (≪ step), a distinct neighbouring loop keeps its full separation.
- The fallback is no longer silent: `geom.TraceSurfaceIntersection` returns `ViaFallback` provenance, and the three curved-imprint sites record a **`imprint.fallback-contour` Defect** diagnostic when contour-quality curves feed an imprint (the recorder stays in `brep`; `geom` stays free of the `diag` dependency).

## Why

Every curved boolean whose SSI involves a torus, sphere seam, closed B-spline, or squat cylinder silently degraded to a coarse grid contour — missing/coarse intersection curves feeding `boolean_split`, producing non-watertight or wrongly-trimmed output with no diagnostic. This is the top silent-degradation risk from the 2026-07 deep audit (`architecture/audits/deep-audit-2026-07.md` §3, A1).

## Tests

- `TestSSIExtentClosedSurfaceSampledBox` — torus extent in [120,180] (the issue's [100,150] band assumed the *diameter* 120; the bbox *diagonal* √(120²+120²+20²)≈170.9 is the correct quantity), squat-cylinder extent ≥ girth.
- `TestSSITorusPlaneTwoCircles` — torus∩equatorial-plane yields the two analytic circles r=40/r=60 **via the tracer** (`ViaFallback` asserted false), radii to 1e-3.
- `TestCrossingCylinderImprintSquatFat` — R=50/h=4 disk crossed by an r=1.5 rod: two closed on-surface loops, zero defects.
- `TestKeepImprintLoopsRecordsFallbackContour`, `TestTraceSurfaceIntersectionDisjointIsQuiet` — the diagnostic fires exactly when fallback curves exist (not for disjoint pairs).

Note on the truncation acceptance criterion: with analytic cylinder pairs, a loop long enough to hit the 6000-step cap under the *old* sizing cannot also close inside a squat window (it either encircles the thin rod — short — or exits the axial band), so the discriminating regression for the collapse is the torus test; the squat-fat test guards the sizing path end-to-end.

## Live test

New `mcplive squatrim` driver (Oblikovati.AddIns.MCPBridge): Ø100×4 mm disk, Ø3 mm rod tunnel cut through the rim — the crossing-cylinder curved boolean with squat proportions. Both sketches DOF=0, volume **30.709462 vs analytic 30.709068 cm³ (rel 1.3e-5)**, screenshots show a clean round tunnel entering and exiting the rim.

Full suite green, `golangci-lint` 0 issues.

Closes #1597

🤖 Generated with [Claude Code](https://claude.com/claude-code)