### PR TITLE
Scale the curved-stitch weld grid with the model (audit A6)

### DIFF
--- a/kernel/brep/boolean.go
+++ b/kernel/brep/boolean.go
@@ -67,10 +67,12 @@ func booleanOnce(op Op, fa, fb []planarFace, a, b *topo.Body) (*topo.Body, math.
 }
 
 // nudgeEps is the magnitude (cm) of the clearance opened at a tangent contact: above the weld
-// grid (1e-6) so it survives, far below any modelled feature so it is geometrically
-// irrelevant. A line tangency carries no material, so replacing it with a ~0.1 µm gap loses
-// nothing and — unlike the exact tangent — leaves no coincident edge for a re-weld to collapse.
-const nudgeEps = 1e-5 // tol:calibrated — imprint nudge tied to the planar weld grid (see arrange2d arrTol)
+// grid (planarStitchGrid, 1e-6) so it survives, far below any modelled feature so it is
+// geometrically irrelevant. A line tangency carries no material, so replacing it with a ~0.1 µm
+// gap loses nothing and — unlike the exact tangent — leaves no coincident edge for a re-weld to
+// collapse. Calibrated with — and only meaningful relative to — the absolute planar weld grid:
+// the two must move together (#1602).
+const nudgeEps = 10 * planarStitchGrid // tol:calibrated — imprint nudge tied to the planar weld grid
 
 // retryNudged re-runs the boolean with operand B nudged a hair along `away` (out of the
 // tangent contact) so the degenerate touch becomes a clean clearance. It keeps the nudged

--- a/kernel/brep/boolean_provenance_test.go
+++ b/kernel/brep/boolean_provenance_test.go
@@ -3,6 +3,8 @@
 package brep
 
 import (
+	"fmt"
+	stdmath "math"
 	"testing"
 
 	"oblikovati.org/kernel/subd"
@@ -96,11 +98,17 @@ func TestImprintAllMatchesProvenanceSegments(t *testing.T) {
 	}
 }
 
-// segKey is an endpoint-order-independent key for a 3D segment, rounded to the weld grid.
+// segKey is an endpoint-order-independent key for a 3D segment, rounded to a fixed test grid
+// (the compared segments come from the same computation, so exact-cell rounding is safe here).
 func segKey(a, b math.Point3) string {
-	ka, kb := roundKey(a), roundKey(b)
+	ka, kb := testPointKey(a), testPointKey(b)
 	if ka <= kb {
 		return ka + "|" + kb
 	}
 	return kb + "|" + ka
+}
+
+func testPointKey(p math.Point3) string {
+	const grid = 1e-6
+	return fmt.Sprintf("%d,%d,%d", int64(stdmath.Round(p.X/grid)), int64(stdmath.Round(p.Y/grid)), int64(stdmath.Round(p.Z/grid)))
 }

--- a/kernel/brep/boolean_split.go
+++ b/kernel/brep/boolean_split.go
@@ -3,7 +3,6 @@
 package brep
 
 import (
-	stdmath "math"
 	"sort"
 	"strconv"
 	"strings"
@@ -44,9 +43,10 @@ func splitFace(f planarFace, imprints [][2]math.Point3) []subFace {
 // face the surface should be.
 func mergeFilledHoles(faces []subFace) []subFace {
 	drop := make([]bool, len(faces))
+	pw := newWelder3(planarStitchGrid)
 	for i := range faces {
 		for h := 0; h < len(faces[i].holes); {
-			if j := fillerOf(faces, faces[i].holes[h], drop, i); j >= 0 {
+			if j := fillerOf(faces, faces[i].holes[h], drop, i, pw); j >= 0 {
 				drop[j] = true
 				faces[i].holes = append(faces[i].holes[:h], faces[i].holes[h+1:]...)
 				continue
@@ -65,36 +65,35 @@ func mergeFilledHoles(faces []subFace) []subFace {
 
 // fillerOf returns the index of a not-yet-dropped face (other than self) whose outer loop is
 // the same ring as hole, or −1. A face filling a hole is identified by loop coincidence.
-func fillerOf(faces []subFace, hole []math.Point3, drop []bool, self int) int {
-	want := ringSignature(hole)
+func fillerOf(faces []subFace, hole []math.Point3, drop []bool, self int, pw *welder3) int {
+	want := ringSignature(hole, pw)
 	for j := range faces {
 		if j == self || drop[j] || len(faces[j].holes) > 0 {
 			continue
 		}
-		if ringSignature(faces[j].outer) == want {
+		if ringSignature(faces[j].outer, pw) == want {
 			return j
 		}
 	}
 	return -1
 }
 
-// ringSignature is an order/winding-independent key for a 3D loop: its vertices rounded to the
-// stitch weld grid and concatenated in sorted order, so the same ring compares equal however
-// it is traversed.
-func ringSignature(ring []math.Point3) string {
-	keys := make([]string, len(ring))
+// ringSignature is an order/winding-independent key for a 3D loop: its vertices canonicalised
+// through the shared point welder and concatenated in sorted order, so the same ring compares
+// equal however it is traversed. Welding — not exact-cell rounding — makes the signature immune
+// to two copies of one vertex straddling a grid-cell boundary, and the welder's model-relative
+// grid keeps the comparison faithful across part scales (#1602).
+func ringSignature(ring []math.Point3, pw *welder3) string {
+	keys := make([]int, len(ring))
 	for i, p := range ring {
-		keys[i] = roundKey(p)
+		keys[i] = pw.add(p)
 	}
-	sort.Strings(keys)
-	return strings.Join(keys, "|")
-}
-
-func roundKey(p math.Point3) string {
-	const grid = 1e-6 // tol:calibrated — planar split weld grid (see arrange2d arrTol)
-	return strconv.FormatInt(int64(stdmath.Round(p.X/grid)), 36) + "," +
-		strconv.FormatInt(int64(stdmath.Round(p.Y/grid)), 36) + "," +
-		strconv.FormatInt(int64(stdmath.Round(p.Z/grid)), 36)
+	sort.Ints(keys)
+	parts := make([]string, len(keys))
+	for i, k := range keys {
+		parts[i] = strconv.Itoa(k)
+	}
+	return strings.Join(parts, "|")
 }
 
 // faceBoundarySegments returns a face's loop edges as 2D segments in its plane.

--- a/kernel/brep/boolean_stitch.go
+++ b/kernel/brep/boolean_stitch.go
@@ -25,7 +25,7 @@ func stitch(faces []subFace, prov []imprintSeg) (*topo.Body, math.Vector3, error
 	if len(faces) == 0 {
 		return nil, math.Vector3{}, nil
 	}
-	w := newWelder3()
+	w := newWelder3(planarStitchGrid)
 	// Pass 1: weld every face's loops to vertex indices (collect the full vertex set).
 	out := make([]builtFace, len(faces))
 	for i, sf := range faces {
@@ -41,7 +41,7 @@ func stitch(faces []subFace, prov []imprintSeg) (*topo.Body, math.Vector3, error
 	// shared edges subdivide identically (eliminates cross-face T-junctions).
 	for fi := range out {
 		for ri := range out[fi].rings {
-			out[fi].rings[ri] = splitRingTJunctions(out[fi].rings[ri], w.points)
+			out[fi].rings[ri] = splitRingTJunctions(out[fi].rings[ri], w)
 		}
 	}
 	reorientFaces(out, w.points)
@@ -73,13 +73,13 @@ func awayFromContacts(uses map[[2]int][]loopEdgeUse, faces []builtFace) math.Vec
 // splitRingTJunctions inserts, into each edge of the ring, any other vertex that lies in
 // its interior (sorted along the edge) — so a vertex that is a corner of a neighbour face
 // also subdivides this face's coincident edge.
-func splitRingTJunctions(ring []int, verts []math.Point3) []int {
+func splitRingTJunctions(ring []int, w *welder3) []int {
 	n := len(ring)
 	out := make([]int, 0, n)
 	for i := 0; i < n; i++ {
 		a, b := ring[i], ring[(i+1)%n]
 		out = append(out, a)
-		mids := verticesOnSegment(a, b, ring, verts)
+		mids := verticesOnSegment(a, b, ring, w)
 		out = append(out, mids...)
 	}
 	return out
@@ -93,14 +93,14 @@ type segHit struct {
 
 // verticesOnSegment returns the vertices (excluding the ring's own) lying strictly on the
 // segment a→b, ordered by parameter along it.
-func verticesOnSegment(a, b int, ring []int, verts []math.Point3) []int {
-	pa := verts[a]
-	ab := pa.VectorTo(verts[b])
+func verticesOnSegment(a, b int, ring []int, w *welder3) []int {
+	pa := w.points[a]
+	ab := pa.VectorTo(w.points[b])
 	lenSq := ab.LengthSquared()
 	if lenSq == 0 {
 		return nil
 	}
-	hits := collectSegHits(pa, ab, lenSq, ringSet(ring), verts)
+	hits := collectSegHits(pa, ab, lenSq, ringSet(ring), w)
 	sort.Slice(hits, func(i, j int) bool { return hits[i].t < hits[j].t })
 	out := make([]int, len(hits))
 	for i, h := range hits {
@@ -118,18 +118,19 @@ func ringSet(ring []int) map[int]bool {
 	return s
 }
 
-// collectSegHits gathers the off-ring vertices that lie strictly interior to segment pa+ab.
-func collectSegHits(pa math.Point3, ab math.Vector3, lenSq float64, onRing map[int]bool, verts []math.Point3) []segHit {
+// collectSegHits gathers the off-ring vertices that lie strictly interior to segment pa+ab
+// (within the welder's own weld grid, the same coincidence scale the vertices merged on).
+func collectSegHits(pa math.Point3, ab math.Vector3, lenSq float64, onRing map[int]bool, w *welder3) []segHit {
 	var hits []segHit
-	for c := range verts {
+	for c := range w.points {
 		if onRing[c] {
 			continue
 		}
-		t := pa.VectorTo(verts[c]).Dot(ab) / lenSq
+		t := pa.VectorTo(w.points[c]).Dot(ab) / lenSq
 		if t <= 1e-7 || t >= 1-1e-7 { // tol:parametric — edge parameter t in [0,1]
 			continue
 		}
-		if pa.TranslateBy(ab.Scale(t)).DistanceTo(verts[c]) < 1e-6 { // tol:calibrated — planar stitch weld (see arrange2d arrTol)
+		if float64(pa.TranslateBy(ab.Scale(t)).DistanceTo(w.points[c])) < w.grid {
 			hits = append(hits, segHit{t, c})
 		}
 	}
@@ -227,31 +228,42 @@ func buildEdges(bld *topo.Builder, verts []math.Point3, tv []*topo.Vertex, edgeU
 	return edges
 }
 
-// weldGrid is the coincidence tolerance for merging stitched vertices (cm). Points within it
-// are the same vertex.
-const weldGrid = 1e-6 // tol:calibrated — planar stitch weld grid (see arrange2d arrTol)
+// planarStitchGrid is the weld grid of the PLANAR boolean family (stitch, split-ring signatures,
+// T-junction hits, drill assembly) and stays deliberately ABSOLUTE, unlike the SSI-fed curved
+// stitch (which scales with the model, geom.Resolution.Stitch, #1602). The planar path's producers
+// bound their noise absolutely, not proportionally to part size: exact plane–plane arithmetic
+// errs by ~1e-16·|coordinate| (2e-14 even at 2 m), and triangle-soup CSG facets legitimately carry
+// slivers just above 1e-6 that a coarser, size-scaled grid would collapse into degenerate rings —
+// TestNopCapScrewCSG catches exactly that over-merge. See also the arrange2d arrTol calibration
+// note; nudgeEps in boolean.go is calibrated 10× above this grid so a tangency clearance survives
+// the re-weld.
+const planarStitchGrid = 1e-6 // tol:calibrated — planar stitch weld grid (see arrange2d arrTol)
 
-// welder3 merges coincident 3D points onto a shared index list.
+// welder3 merges 3D points within its weld grid onto a shared index list. The grid is
+// model-relative (geom.Resolution.Stitch of the geometry being welded, ADR-0042): the retired
+// absolute 1e-6 grid was calibrated for ~1 cm parts and left independently computed copies of the
+// same seam point unmerged as soon as their producer noise (1e-7 of the extent) outgrew it (#1602).
 type welder3 struct {
+	grid   float64
 	index  map[[3]int64]int
 	points []math.Point3
 }
 
-func newWelder3() *welder3 { return &welder3{index: map[[3]int64]int{}} }
+func newWelder3(grid float64) *welder3 { return &welder3{grid: grid, index: map[[3]int64]int{}} }
 
 // add returns the index of the welded vertex for p, merging it with any existing vertex within
-// weldGrid. The point is hashed to a grid cell, but the 26 neighbouring cells are also searched:
+// the weld grid. The point is hashed to a grid cell, but the 26 neighbouring cells are also searched:
 // two coincident points either side of a cell boundary hash to different cells, so a cell-exact
 // lookup would leave them unmerged — the failure that shredded dense self-proximate geometry
 // (a fine-pitch coil-join) into unpaired, coincident open edges (#879).
 func (w *welder3) add(p math.Point3) int {
-	cx := int64(stdmath.Round(p.X / weldGrid))
-	cy := int64(stdmath.Round(p.Y / weldGrid))
-	cz := int64(stdmath.Round(p.Z / weldGrid))
+	cx := int64(stdmath.Round(p.X / w.grid))
+	cy := int64(stdmath.Round(p.Y / w.grid))
+	cz := int64(stdmath.Round(p.Z / w.grid))
 	for dx := int64(-1); dx <= 1; dx++ {
 		for dy := int64(-1); dy <= 1; dy++ {
 			for dz := int64(-1); dz <= 1; dz++ {
-				if i, ok := w.index[[3]int64{cx + dx, cy + dy, cz + dz}]; ok && w.points[i].DistanceTo(p) <= weldGrid {
+				if i, ok := w.index[[3]int64{cx + dx, cy + dy, cz + dz}]; ok && w.points[i].DistanceTo(p) <= w.grid {
 					return i
 				}
 			}

--- a/kernel/brep/boolean_weld_test.go
+++ b/kernel/brep/boolean_weld_test.go
@@ -13,7 +13,7 @@ import (
 // vertex. The cell-exact lookup used before left such pairs unmerged, which shredded dense
 // self-proximate geometry (a fine-pitch coil-join) into coincident, unpaired open edges.
 func TestWelder3MergesAcrossGridBoundary(t *testing.T) {
-	w := newWelder3()
+	w := newWelder3(1e-6)
 	// 0.00050049 and 0.00050051 are 2e-8 cm apart (well within weldGrid) but round to cells
 	// 500 and 501 — opposite sides of a 1e-6 grid boundary.
 	a := w.add(math.P3(0.00050049, 0, 0))
@@ -21,8 +21,25 @@ func TestWelder3MergesAcrossGridBoundary(t *testing.T) {
 	if a != b {
 		t.Errorf("coincident points across a grid boundary welded to %d and %d, want one vertex", a, b)
 	}
-	// A point farther than weldGrid stays a distinct vertex.
+	// A point farther than the grid stays a distinct vertex.
 	if c := w.add(math.P3(0.01, 0, 0)); c == a {
-		t.Errorf("a point %g cm away merged with the first; weld tolerance is %g", 0.01, weldGrid)
+		t.Errorf("a point %g cm away merged with the first; weld tolerance is %g", 0.01, w.grid)
+	}
+}
+
+// TestRingSignatureImmuneToCellStraddle: two copies of one ring whose vertices sit a hair either
+// side of a weld-grid cell boundary (the #879 straddle) must produce the SAME signature, so
+// mergeFilledHoles still dissolves the filled hole. The retired exact-cell string keys rounded the
+// two copies into different cells (#1602).
+func TestRingSignatureImmuneToCellStraddle(t *testing.T) {
+	pw := newWelder3(planarStitchGrid)
+	ring := []math.Point3{math.P3(0.00050049, 0, 0), math.P3(1, 0, 0), math.P3(1, 1, 0)}
+	copyRing := []math.Point3{math.P3(0.00050051, 0, 0), math.P3(1, 0, 0), math.P3(1, 1, 0)}
+	if ringSignature(ring, pw) != ringSignature(copyRing, pw) {
+		t.Error("two coincident rings straddling a weld-grid cell boundary produced different signatures")
+	}
+	other := []math.Point3{math.P3(0.5, 0, 0), math.P3(1, 0, 0), math.P3(1, 1, 0)}
+	if ringSignature(ring, pw) == ringSignature(other, pw) {
+		t.Error("genuinely different rings produced the same signature")
 	}
 }

--- a/kernel/brep/coverage_test.go
+++ b/kernel/brep/coverage_test.go
@@ -150,7 +150,7 @@ func TestFaceLineIntervalsPerpendicularLine(t *testing.T) {
 }
 
 func TestWelder3RingDedupesAndCloses(t *testing.T) {
-	w := newWelder3()
+	w := newWelder3(1e-6)
 	// A loop with a repeated consecutive vertex and a closing duplicate.
 	loop := []math.Point3{math.P3(0, 0, 0), math.P3(0, 0, 0), math.P3(1, 0, 0), math.P3(0, 1, 0), math.P3(0, 0, 0)}
 	r := w.ring(loop)
@@ -172,14 +172,17 @@ func TestInteriorPoint2D(t *testing.T) {
 }
 
 func TestVerticesOnSegment(t *testing.T) {
-	verts := []math.Point3{math.P3(0, 0, 0), math.P3(2, 0, 0), math.P3(1, 0, 0)}
+	w := newWelder3(1e-6)
+	for _, p := range []math.Point3{math.P3(0, 0, 0), math.P3(2, 0, 0), math.P3(1, 0, 0)} {
+		w.add(p)
+	}
 	// Vertex 2 (1,0,0), which is off the ring, lies on segment 0→1.
-	got := verticesOnSegment(0, 1, []int{0, 1}, verts)
+	got := verticesOnSegment(0, 1, []int{0, 1}, w)
 	if len(got) != 1 || got[0] != 2 {
 		t.Fatalf("verticesOnSegment = %v, want [2]", got)
 	}
 	// A zero-length segment yields nothing.
-	if verticesOnSegment(0, 0, []int{0, 1}, verts) != nil {
+	if verticesOnSegment(0, 0, []int{0, 1}, w) != nil {
 		t.Error("zero-length segment should have no interior vertices")
 	}
 }

--- a/kernel/brep/curved_general_ruled_cutjoin_test.go
+++ b/kernel/brep/curved_general_ruled_cutjoin_test.go
@@ -186,3 +186,35 @@ func TestPartialPairDecline(t *testing.T) {
 		t.Error("a full crossing should decline from the partial join path")
 	}
 }
+
+// TestCurvedBooleanWatertightAcrossScales is the #1602 scale sweep: the same curved booleans run at
+// 1 cm–200 cm extents must all stitch watertight. The seam points fed to the stitch carry SSI noise
+// proportional to the extent, so a weld grid that does not scale with the model (the retired
+// absolute 1e-6) lets seams tear as parts grow.
+func TestCurvedBooleanWatertightAcrossScales(t *testing.T) {
+	for _, s := range []float64{1, 10, 50, 200} {
+		fat, _ := SolidCylinder(math.P3(0, 0, -1.2*s), math.V3(0, 0, 1), 0.6*s, 2.4*s)
+		rod, _ := SolidCylinder(math.P3(-1.2*s, 0, 0), math.V3(1, 0, 0), 0.3*s, 2.4*s)
+		if res, ok := CrossingCylinderCutGeneral(fat, rod, nil); ok {
+			assertWatertight(t, res)
+		} else {
+			t.Errorf("scale %g: crossing-cylinder cut declined", s)
+		}
+
+		fatC, _ := SolidCylinderCone(math.P3(0, 0, -1.2*s), math.P3(0, 0, 1.2*s), 0.4*s, 0.8*s, "fat")
+		rodC, _ := SolidCylinderCone(math.P3(-1.2*s, 0, 0), math.P3(1.2*s, 0, 0), 0.16*s, 0.3*s, "rod")
+		if res, ok := ConeConeCutGeneral(fatC, rodC, nil); ok {
+			assertWatertight(t, res)
+		} else {
+			t.Errorf("scale %g: cone-cone cut declined", s)
+		}
+
+		a, _ := SolidCylinder(math.P3(-1.2*s, 0, 0), math.V3(1, 0, 0), 0.6*s, 2.4*s)
+		b, _ := SolidCylinder(math.P3(0, 0, -1.2*s), math.V3(0, 0, 1), 0.6*s, 2.4*s)
+		if res, ok := SteinmetzCutGeneral(a, b, nil); ok {
+			assertWatertight(t, res)
+		} else {
+			t.Errorf("scale %g: Steinmetz cut declined", s)
+		}
+	}
+}

--- a/kernel/brep/curved_halfspace_uv_arrangement.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement.go
@@ -1068,8 +1068,11 @@ func isClosedCurve(curve geom.Curve3) bool {
 	case *geom.Polyline:
 		// An SSI imprint loop is a closed polyline (first point ≈ last). Recognising it as closed makes
 		// emitImprintRun re-emit the WHOLE loop [lo,hi] from PointAt(0), so both operand sides emit the same
-		// shared edge and the welder fuses them (#1403).
-		return roundKey(c.PointAt(0)) == roundKey(c.PointAt(1))
+		// shared edge and the welder fuses them (#1403). The gap gauge is the loop's own stitch
+		// resolution — a distance test, not grid-cell equality, so a genuinely closed loop cannot be
+		// misread as open by cell straddling (#1602).
+		gap := float64(c.PointAt(0).DistanceTo(c.PointAt(1)))
+		return gap <= geom.ResolutionForPoints(c.Vertices).Stitch()
 	}
 	return false
 }

--- a/kernel/brep/curved_stitch.go
+++ b/kernel/brep/curved_stitch.go
@@ -19,10 +19,14 @@ import (
 // tessellates over the arc, not the whole circle (TessellateEdge walks the curve's whole Domain).
 
 // curvedStitch welds curvedFaces into a body, sharing welded vertices and edges. Each face keeps its
-// surface, sense (reversed) and lineage; loops[0] is the outer loop, the rest holes.
+// surface, sense (reversed) and lineage; loops[0] is the outer loop, the rest holes. The weld grid is
+// the faces' own stitch resolution (ADR-0042, #1602): the seam points fed in carry SSI-tracer noise
+// proportional to the operands' extent, so an absolute grid tears seams on parts it was never
+// calibrated for.
 func curvedStitch(faces []curvedFace) *topo.Body {
 	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok("curvedbool", "body", 0)))
-	w := &curveWelder{bld: bld, verts: map[string]*topo.Vertex{}, edges: map[string]*topo.Edge{}}
+	pw := newWelder3(geom.ResolutionForBox(curvedFaceBox(faces)).Stitch())
+	w := &curveWelder{bld: bld, pw: pw, verts: map[int]*topo.Vertex{}, edges: map[[3]int]*topo.Edge{}}
 	provByFace := map[*topo.Face]topo.Lineage{}
 	for _, f := range faces {
 		specs := w.loopSpecs(f.loops, f.outerless)
@@ -50,12 +54,30 @@ func curvedStitch(faces []curvedFace) *topo.Body {
 }
 
 // curveWelder dedups vertices (by position) and edges (by endpoints + midpoint) as faces are added.
+// Positions canonicalise through a shared point welder (grid + 26-neighbour distance search), so two
+// independently computed copies of one seam point weld even when they straddle a grid-cell boundary —
+// the failure mode of the retired exact-cell string keys (#1602).
 type curveWelder struct {
 	bld   *topo.Builder
-	verts map[string]*topo.Vertex
-	edges map[string]*topo.Edge
+	pw    *welder3
+	verts map[int]*topo.Vertex
+	edges map[[3]int]*topo.Edge
 	nv    int
 	ne    int
+}
+
+// curvedFaceBox bounds the loop-edge endpoints of the faces being stitched — the geometry whose
+// Resolution sets the stitch weld grid (#1602).
+func curvedFaceBox(faces []curvedFace) math.Box {
+	box := math.EmptyBox()
+	for _, f := range faces {
+		for _, loop := range f.loops {
+			for _, le := range loop.edges {
+				box = box.ExtendPoint(le.start()).ExtendPoint(le.end())
+			}
+		}
+	}
+	return box
 }
 
 // loopSpecs turns a face's curved loops into builder loop specs (outer first, the rest holes). When
@@ -78,9 +100,9 @@ func (w *curveWelder) loopSpecs(loops []curvedLoop, outerless bool) []topo.LoopS
 	return specs
 }
 
-// vertex welds a point to a shared topo vertex by rounded position.
+// vertex welds a point to a shared topo vertex by canonical welded position.
 func (w *curveWelder) vertex(p math.Point3) *topo.Vertex {
-	key := roundKey(p)
+	key := w.pw.add(p)
 	if v, ok := w.verts[key]; ok {
 		return v
 	}
@@ -96,13 +118,13 @@ func (w *curveWelder) vertex(p math.Point3) *topo.Vertex {
 func (w *curveWelder) edge(le loopEdge) (*topo.Edge, bool) {
 	a, b := le.start(), le.end()
 	mid := le.curve.PointAt((le.t0 + le.t1) / 2)
-	closed := roundKey(a) == roundKey(b)
-	key := edgeKey(a, b, mid)
+	closed := w.pw.add(a) == w.pw.add(b)
+	key := w.edgeKey(a, b, mid)
 	if e, ok := w.edges[key]; ok {
 		if closed {
 			return e, le.t1 < le.t0
 		}
-		return e, roundKey(e.StartVertex().Point()) != roundKey(a)
+		return e, w.pw.add(e.StartVertex().Point()) != w.pw.add(a)
 	}
 	return w.newEdge(le, a, b, key, closed)
 }
@@ -111,14 +133,14 @@ func (w *curveWelder) edge(le loopEdge) (*topo.Edge, bool) {
 // uses it forward, except a reversed-sweep closed circle). An OPEN spiric branch is stored in its native
 // direction (V0<V1, see spiricArcOf) and anchored to the curve's own endpoints, so the reversed flag — not a
 // flipped curve — orients it; the direction-sensitive spiric mesher then meshes the same patch either way.
-func (w *curveWelder) newEdge(le loopEdge, a, b math.Point3, key string, closed bool) (*topo.Edge, bool) {
+func (w *curveWelder) newEdge(le loopEdge, a, b math.Point3, key [3]int, closed bool) (*topo.Edge, bool) {
 	curve := edgeCurveFor(le)
 	if sa, ok := curve.(geom.SpiricArc); ok && !closed {
 		ca, cb := sa.PointAt(0), sa.PointAt(1)
 		e := w.bld.AddEdge(curve, w.vertex(ca), w.vertex(cb), topo.NewLineage(topo.Tok("curvedbool", "e", w.ne)))
 		w.ne++
 		w.edges[key] = e
-		return e, roundKey(ca) != roundKey(a) // reversed when this loop starts at the arc's far end
+		return e, w.pw.add(ca) != w.pw.add(a) // reversed when this loop starts at the arc's far end
 	}
 	va, vb := w.vertex(a), w.vertex(b)
 	e := w.bld.AddEdge(curve, va, vb, topo.NewLineage(topo.Tok("curvedbool", "e", w.ne)))
@@ -130,14 +152,14 @@ func (w *curveWelder) newEdge(le loopEdge, a, b math.Point3, key string, closed 
 	return e, false
 }
 
-// edgeKey is the canonical weld key for an edge: its two endpoints (sorted, so direction does not
-// matter) plus its midpoint (so two curves joining the same endpoints stay distinct).
-func edgeKey(a, b, mid math.Point3) string {
-	ka, kb := roundKey(a), roundKey(b)
+// edgeKey is the canonical weld key for an edge: its two welded endpoints (sorted, so direction
+// does not matter) plus its welded midpoint (so two curves joining the same endpoints stay distinct).
+func (w *curveWelder) edgeKey(a, b, mid math.Point3) [3]int {
+	ka, kb := w.pw.add(a), w.pw.add(b)
 	if ka > kb {
 		ka, kb = kb, ka
 	}
-	return ka + "|" + kb + "|" + roundKey(mid)
+	return [3]int{ka, kb, w.pw.add(mid)}
 }
 
 // edgeCurveFor returns the curve to store on the topo edge so its WHOLE domain is exactly the loop

--- a/kernel/brep/curved_stitch_test.go
+++ b/kernel/brep/curved_stitch_test.go
@@ -81,3 +81,43 @@ func TestEdgeCurveForFullCircleStaysCircle(t *testing.T) {
 		t.Errorf("full-circle edge curve is %T, want geom.Circle", edgeCurveFor(le))
 	}
 }
+
+// TestCurvedStitchWeldsProducerNoiseAtScale is the mechanism regression for #1602: on a ~2 m part
+// the SSI tracer accepts an on-curve point anywhere within 1e-7·extent ≈ 2.8e-5 cm, so two
+// independently computed copies of one seam point can sit ~28× apart the retired absolute 1e-6
+// weld grid — and failed to merge, tearing the seam. The curved stitch grid now scales with the
+// stitched geometry (geom.Resolution.Stitch), so the copies weld to one vertex.
+func TestCurvedStitchWeldsProducerNoiseAtScale(t *testing.T) {
+	const extent = 280.0
+	w := newWelder3(geom.ResolutionForSize(extent).Stitch())
+	p := math.P3(100, 57.3, -42.1)
+	noisy := p.TranslateBy(math.V3(1.6e-5, -1.6e-5, 1.6e-5)) // |Δ| ≈ 2.8e-5 = the SSI acceptance at this extent
+	if w.add(p) != w.add(noisy) {
+		t.Errorf("two SSI-noise copies of one seam point (%g apart) welded to distinct vertices on a %g cm part",
+			float64(p.DistanceTo(noisy)), extent)
+	}
+	far := p.TranslateBy(math.V3(0.1, 0, 0)) // a genuinely distinct vertex stays distinct
+	if w.add(far) == w.add(p) {
+		t.Error("a point 0.1 cm away merged with the seam point; the stitch grid is too coarse")
+	}
+}
+
+// TestClosedPolylineRecognitionAtScale: a traced SSI loop on a large part whose closure gap is
+// producer noise (not zero) must still be recognised as closed by the (u,v) arrangement — the old
+// exact-cell key equality misread it as open once the gap outgrew the absolute grid, so both
+// operand sides emitted different edge runs and the seam tore (#1602).
+func TestClosedPolylineRecognitionAtScale(t *testing.T) {
+	pts := []math.Point3{math.P3(100, 0, 0), math.P3(0, 100, 0), math.P3(-100, 0, 0), math.P3(0, -100, 0), math.P3(100, 2.8e-5, 0)}
+	pl, err := geom.NewPolyline(pts)
+	if err != nil {
+		t.Fatalf("NewPolyline: %v", err)
+	}
+	if !isClosedCurve(&pl) {
+		t.Error("a loop closed to within SSI producer noise on a 200 cm part was misread as open")
+	}
+	open := []math.Point3{math.P3(100, 0, 0), math.P3(0, 100, 0), math.P3(-100, 0, 0), math.P3(0, -100, 0), math.P3(100, 1, 0)}
+	plOpen, _ := geom.NewPolyline(open)
+	if isClosedCurve(&plOpen) {
+		t.Error("a chain with a 1 cm endpoint gap was misread as closed")
+	}
+}

--- a/kernel/brep/drill_blind.go
+++ b/kernel/brep/drill_blind.go
@@ -106,7 +106,7 @@ func blindBore(copied []planarFace, entry planarFace, base, bottom math.Point3, 
 	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok("brep", "drill", 0)))
 	planar := append(append([]planarFace{}, copied...), entry)
 
-	w := newWelder3()
+	w := newWelder3(planarStitchGrid)
 	rings, edgeUse := weldPlanarFaces(w, planar)
 	tv := make([]*topo.Vertex, len(w.points))
 	for i, p := range w.points {

--- a/kernel/brep/drill_counterbore.go
+++ b/kernel/brep/drill_counterbore.go
@@ -69,7 +69,7 @@ func assembleCounterbore(copied []planarFace, entry planarFace, exitIdx int, bas
 	planar := append(append([]planarFace{}, copied...), entry)
 	entryIdx := len(planar) - 1
 
-	w := newWelder3()
+	w := newWelder3(planarStitchGrid)
 	rings, edgeUse := weldPlanarFaces(w, planar)
 	tv := make([]*topo.Vertex, len(w.points))
 	for i, p := range w.points {

--- a/kernel/brep/drill_countersink.go
+++ b/kernel/brep/drill_countersink.go
@@ -53,7 +53,7 @@ func assembleCountersink(copied []planarFace, entry planarFace, exitIdx int, bas
 	planar := append(append([]planarFace{}, copied...), entry)
 	entryIdx := len(planar) - 1
 
-	w := newWelder3()
+	w := newWelder3(planarStitchGrid)
 	rings, edgeUse := weldPlanarFaces(w, planar)
 	tv := make([]*topo.Vertex, len(w.points))
 	for i, p := range w.points {

--- a/kernel/geom/resolution.go
+++ b/kernel/geom/resolution.go
@@ -44,6 +44,13 @@ const (
 	weldCoef  = 1      // vertex / arrangement weld (epsRel × size: the convex-hull precedent)
 	planeCoef = 100    // coplanar / on-plane / on-line classification
 	sewCoef   = 100000 // default sew gap (deliberately generous, ≈1e-4 cm @ 1cm)
+	// stitchCoef is the boolean seam-stitch weld. It must be COARSER than the noise of the SSI
+	// producer feeding the stitch: the tracer accepts an on-curve point anywhere within 1e-7 of the
+	// trace extent (ssiToleranceFraction), so the same seam point computed from the two operand
+	// sides can differ by ~2e-7·size — a finer weld leaves the two copies unmerged and the seam
+	// tears open (#1602). 1000 × epsRel = 1e-6·size reproduces the proven absolute 1e-6 stitch grid
+	// at the historical ~1 cm part scale and scales with the model.
+	stitchCoef = 1000
 )
 
 // volCoef is the relative volume tolerance for boolean result classification. Volume
@@ -121,6 +128,11 @@ func (r Resolution) Plane() float64 { return planeCoef * epsRel * r.size }
 
 // Sew is the default gap a Sew with tolerance 0 closes — deliberately generous.
 func (r Resolution) Sew() float64 { return sewCoef * epsRel * r.size }
+
+// Stitch is the boolean seam-stitch weld: how close two independently computed copies of the same
+// seam point may sit and still merge into one vertex. Deliberately coarser than Weld — stitched
+// points carry SSI-tracer noise (1e-7 of the trace extent), not float noise; see stitchCoef (#1602).
+func (r Resolution) Stitch() float64 { return stitchCoef * epsRel * r.size }
 
 // Area is the relative area / cross-product tolerance for degenerate-triangle and
 // turn-direction tests in the planar arrangement: areas scale with size², so this keeps

--- a/kernel/geom/resolution_test.go
+++ b/kernel/geom/resolution_test.go
@@ -120,3 +120,18 @@ func TestSpanCeilingDiagnostic(t *testing.T) {
 		t.Errorf("zero feature size should not warn, got %q", w)
 	}
 }
+
+// TestStitchCoversSSIProducerNoise encodes the seam-stitch producer/consumer contract (#1602): the
+// stitch weld grid must stay coarser than the SSI tracer's on-curve acceptance tolerance
+// (ssiToleranceFraction of the trace extent) with margin for the two-sided ~2× noise, at every
+// model scale — otherwise two independently computed copies of one seam point fail to merge and
+// the curved boolean's seam tears open.
+func TestStitchCoversSSIProducerNoise(t *testing.T) {
+	for _, size := range []float64{1, 10, 50, 200, 1000, 1e6} {
+		stitch := ResolutionForSize(size).Stitch()
+		noise := 2 * ssiToleranceFraction * size
+		if stitch < 2*noise {
+			t.Errorf("size %g: stitch grid %g < 2× two-sided SSI noise %g — seams can tear", size, stitch, noise)
+		}
+	}
+}


### PR DESCRIPTION
## What

The curved boolean's stitch welded seam vertices on an **absolute 1e-6 grid** while its producer — the SSI tracer — accepts on-curve points within a **relative** 1e-7 of the trace extent. Past ~10 cm the producer noise outgrows the grid: two independently computed copies of one seam point stop merging and the seam can tear.

- New `geom.Resolution.Stitch()` (1e-6 of the stitched geometry's extent): reproduces the proven absolute grid at the historical ~1 cm scale, scales with the part. `curvedStitch` derives it from the faces being welded.
- Seam fusing moves off exact-cell string keys (`roundKey`, now deleted) onto the `welder3` grid + 26-neighbour **distance** search — curved vertex/edge welder, split-ring signatures, and the (u,v)-arrangement polyline-closure test (now a distance check) — killing the cell-straddle false-distinct class (#879) outside the planar welder too.
- The **planar** boolean family deliberately keeps its absolute grid (named `planarStitchGrid`, rationale documented at the constant): its producers bound noise absolutely (exact plane arithmetic ~1e-16·coord; CSG facets carry legitimate slivers just above 1e-6 that a size-scaled grid collapses — `TestNopCapScrewCSG` catches exactly that over-merge, found while developing this change). `nudgeEps` is now expressed as 10× that grid so the calibration coupling is explicit.

## Honest findings vs the issue

The audit's claimed >10 cm crack does **not** reproduce on today's production paths — both operand sides currently weld bit-identical points (they share the same traced polyline/arc objects), which an absolute grid always merges. The mismatch is real and bites as soon as any path recomputes seam points independently (the #1403 general-pipeline direction), so the contract is fixed and encoded now. `quantCoord`'s absolute grid in `kernel/ops` mesh repair is a separate subsystem and is left for its own pass (noted on the issue).

## Tests

- `TestStitchCoversSSIProducerNoise` (geom) — the encoded producer/consumer contract at sizes 1–1e6.
- `TestCurvedStitchWeldsProducerNoiseAtScale` — two SSI-noise copies of a seam point on a 2 m part weld to one vertex (fails on the retired absolute grid).
- `TestClosedPolylineRecognitionAtScale` — noise-closed loop recognised as closed at scale (fails on retired cell-key equality).
- `TestRingSignatureImmuneToCellStraddle` — straddling copies produce equal ring signatures.
- `TestCurvedBooleanWatertightAcrossScales` — crossing-cylinder, cone-cone, and Steinmetz cuts watertight at 1/10/50/200 cm.

## Live test

`mcplive squatrim` extended: after the baseline check it resizes the part 20× (Ø2 m disk, Ø60 mm rod tunnel) — volume exact to rel 1.3e-5, clean rim on screenshot (bridge PR Oblikovati.AddIns.MCPBridge#85).

Full suite green, `golangci-lint` 0 issues.

Closes #1602

🤖 Generated with [Claude Code](https://claude.com/claude-code)