### PR TITLE
Surface boolean facet/CSG fallback diagnostics on features and the API (audit A5)

### DIFF
--- a/addin/opregistry/feature_diagnostics_test.go
+++ b/addin/opregistry/feature_diagnostics_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/sketch"
+)
+
+// circledPart seeds a part with two circle sketches (radius 2 at origin, radius 1 at x=1.5) so
+// an extrude+cut pair forms two crossing analytic cylinders — the configuration no exact curved
+// path handles, which facets the operands for the planar boolean.
+func circledPart(t *testing.T) *app.Session {
+	t.Helper()
+	s := app.NewSession()
+	d, err := s.Workspace().Add(doc.Part, "diag.obk", true)
+	if err != nil {
+		t.Fatalf("add document: %v", err)
+	}
+	def := compdef.NewPartComponentDefinition()
+	d.SetContent(def)
+	def.Sketches().Add(sketch.XYPlane()).Circles().AddByCenterRadius(math.P2(0, 0), 2)
+	def.Sketches().Add(sketch.XYPlane()).Circles().AddByCenterRadius(math.P2(1.5, 0), 1)
+	def.Recompute()
+	return s
+}
+
+// TestFeatureReplyCarriesFallbackDiagnostics is the #1601 wire-level regression: a cut that
+// facets its analytic operands (cylinder on cylinder, no exact curved path) must report the
+// degradation in the feature reply's diagnostics — the API caller's only window into it.
+func TestFeatureReplyCarriesFallbackDiagnostics(t *testing.T) {
+	s := circledPart(t)
+	if _, err := apply(t, s, "extrude", `{"sketchIndex":0,"distance":"30 mm","operation":"new"}`); err != nil {
+		t.Fatalf("base cylinder: %v", err)
+	}
+	out, err := apply(t, s, "extrude", `{"sketchIndex":1,"distance":"30 mm","operation":"cut"}`)
+	if err != nil {
+		t.Fatalf("cylinder-on-cylinder cut: %v", err)
+	}
+	var r struct {
+		Healthy     bool `json:"healthy"`
+		Diagnostics []struct {
+			Code     string `json:"code"`
+			Severity string `json:"severity"`
+			Detail   string `json:"detail"`
+		} `json:"diagnostics"`
+	}
+	if err := json.Unmarshal(out, &r); err != nil {
+		t.Fatalf("unmarshal reply: %v", err)
+	}
+	if !r.Healthy {
+		t.Fatalf("cut reported unhealthy; want healthy-but-degraded: %s", out)
+	}
+	for _, d := range r.Diagnostics {
+		if d.Code == string(ops.CodeBooleanAnalyticFaceted) {
+			return
+		}
+	}
+	t.Errorf("feature reply carries no %q diagnostic; got %s", ops.CodeBooleanAnalyticFaceted, out)
+}

--- a/addin/opregistry/feature_refs.go
+++ b/addin/opregistry/feature_refs.go
@@ -107,6 +107,18 @@ type featureResult struct {
 	Bodies  int    `json:"bodies"`
 	Healthy bool   `json:"healthy"`
 	Reason  string `json:"reason,omitempty"`
+	// Diagnostics are the kernel degradations recorded while the feature rebuilt — a boolean
+	// faceting analytic surfaces, a triangle-CSG fallback (#1601). A feature can be healthy AND
+	// degraded; callers that care about surface quality must check this, not Healthy.
+	Diagnostics []featureDiagnostic `json:"diagnostics,omitempty"`
+}
+
+// featureDiagnostic is one kernel diagnostic on a feature reply: the typed code (searchable,
+// e.g. "boolean.analytic-faceted"), its severity, and the human-readable detail.
+type featureDiagnostic struct {
+	Code     string `json:"code"`
+	Severity string `json:"severity"`
+	Detail   string `json:"detail"`
 }
 
 // lastFeatureResult recomputes and reports the most recently added feature — used by the
@@ -127,8 +139,21 @@ func recomputeResult(part *compdef.PartComponentDefinition, pf *feature.PartFeat
 	h := pf.Health()
 	return json.Marshal(featureResult{
 		Feature: pf.Name(), Kind: pf.Kind(), Bodies: len(part.SurfaceBodies().All()),
-		Healthy: h.OK(), Reason: h.Reason,
+		Healthy: h.OK(), Reason: h.Reason, Diagnostics: featureDiagnostics(pf),
 	})
+}
+
+// featureDiagnostics converts the feature's recorded kernel diagnostics to the reply shape.
+func featureDiagnostics(pf *feature.PartFeature) []featureDiagnostic {
+	recorded := pf.Diagnostics()
+	if len(recorded) == 0 {
+		return nil
+	}
+	out := make([]featureDiagnostic, len(recorded))
+	for i, d := range recorded {
+		out[i] = featureDiagnostic{Code: string(d.Code), Severity: d.Severity.String(), Detail: d.Detail}
+	}
+	return out
 }
 
 // constIntFn wraps a constant as the func() int the pattern builders take for live counts.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.102.0
+	oblikovati.org/api v0.102.1
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.102.0
+	oblikovati.org/api v0.102.1
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -53,6 +53,12 @@ func Boolean(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body, erro
 // volume-preserving topology error the volume guard misses (Oblikovati#1407).
 const CodeBooleanCSGFallback diag.Code = "boolean.csg-fallback"
 
+// CodeBooleanAnalyticFaceted marks a boolean whose analytic curved operand(s) were re-faceted
+// into a planar B-rep because no exact curved path applied (#1601). Faceting is permanent — the
+// analytic surface is unrecoverable and every downstream feature operates on facets — so the
+// degradation must ride with the feature that caused it, not vanish.
+const CodeBooleanAnalyticFaceted diag.Code = "boolean.analytic-faceted"
+
 // BooleanWithDiagnostics is [Boolean] with a diagnostic [diag.Recorder] (pass nil to discard). Whenever
 // the operation falls back from the exact analytic/planar path to triangle-soup CSG it records a Defect
 // diagnostic naming the operation and operands, so callers and tests can SEE and count the fallback
@@ -179,6 +185,13 @@ func CurvedBoolean(op PartFeatureOperation, target, tool *topo.Body) (*topo.Body
 	return curvedExactBoolean(op, target, tool, nil)
 }
 
+// CurvedBooleanWithDiagnostics is [CurvedBoolean] with a diagnostic recorder (nil to discard):
+// the exact paths record imprint-quality diagnostics (#1404) and their internal fallbacks, so a
+// feature-level caller carries the kernel's quality signal instead of dropping it (#1601).
+func CurvedBooleanWithDiagnostics(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	return curvedExactBoolean(op, target, tool, rec)
+}
+
 // curvedExactPaths is the ordered list of exact analytic curved-boolean paths curvedExactBoolean tries; each
 // returns ok=false when it does not apply to (op, target, tool). The recorder carries the SSI imprint's
 // closure diagnostics (#1404) up to the boolean's caller; a path that takes no imprint ignores it. The paths
@@ -215,11 +228,16 @@ func invalidBooleanVolume(op PartFeatureOperation, target, tool, body *topo.Body
 	targetVol := BodyGeometryProperties(target, DefaultQuality()).Volume
 	toolVol := BodyGeometryProperties(tool, DefaultQuality()).Volume
 	bodyVol := BodyGeometryProperties(body, DefaultQuality()).Volume
+	// Two-sided Requicha brackets (#1601): V(A∪B) ∈ [max(V(A),V(B)), V(A)+V(B)] and
+	// V(A∖B) ∈ [V(A)−V(B), V(A)]. The old one-sided checks let a join that fabricated
+	// material or a cut that removed too much ship silently. Intersect keeps only its
+	// upper bound V(A∩B) ≤ min(V(A),V(B)): its Requicha lower bound needs V(A∪B) — a
+	// second boolean, too expensive for a guard — and is trivially ≥ 0 without it.
 	switch op {
 	case Join:
-		return bodyVol+tol < maxFloat(targetVol, toolVol)
+		return bodyVol+tol < maxFloat(targetVol, toolVol) || bodyVol > targetVol+toolVol+tol
 	case Cut:
-		return bodyVol > targetVol+tol
+		return bodyVol > targetVol+tol || bodyVol+tol < targetVol-toolVol
 	case Intersect:
 		return bodyVol > minFloat(targetVol, toolVol)+tol
 	}

--- a/kernel/ops/boolean_volume_guard_test.go
+++ b/kernel/ops/boolean_volume_guard_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// guardBlock builds an axis-aligned block body with an exact, easily reasoned volume.
+func guardBlock(t *testing.T, min, max math.Point3, name string) *topo.Body {
+	t.Helper()
+	b, err := brep.SolidBlock(min, max, name)
+	if err != nil {
+		t.Fatalf("SolidBlock(%v,%v): %v", min, max, err)
+	}
+	return b
+}
+
+// TestBooleanVolumeGuardTwoSided pins the Requicha brackets on the boolean volume guard (#1601):
+// V(A∖B) ∈ [V(A)−V(B), V(A)] and V(A∪B) ∈ [max(V(A),V(B)), V(A)+V(B)]. The guard used to be
+// one-sided — a cut that removed too much material, or a join that fabricated material, passed
+// silently and shipped a materially wrong body.
+func TestBooleanVolumeGuardTwoSided(t *testing.T) {
+	target := guardBlock(t, math.P3(0, 0, 0), math.P3(2, 1, 1), "target") // V(A) = 2
+	tool := guardBlock(t, math.P3(1.5, 0, 0), math.P3(2.5, 1, 1), "tool") // V(B) = 1, overlap 0.5
+
+	cases := []struct {
+		name    string
+		op      PartFeatureOperation
+		result  *topo.Body
+		invalid bool
+	}{
+		{"cut within bracket", Cut, guardBlock(t, math.P3(0, 0, 0), math.P3(1.5, 1, 1), "ok"), false},   // 1.5 ∈ [1, 2]
+		{"cut removed too much", Cut, guardBlock(t, math.P3(0, 0, 0), math.P3(0.5, 1, 1), "low"), true}, // 0.5 < V(A)−V(B) = 1
+		{"cut removed nothing extra", Cut, guardBlock(t, math.P3(0, 0, 0), math.P3(2.5, 1, 1), "high"), true},
+		{"join within bracket", Join, guardBlock(t, math.P3(0, 0, 0), math.P3(2.5, 1, 1), "ok"), false},         // 2.5 ∈ [2, 3]
+		{"join fabricated material", Join, guardBlock(t, math.P3(0, 0, 0), math.P3(4, 1, 1), "high"), true},     // 4 > V(A)+V(B) = 3
+		{"join lost material", Join, guardBlock(t, math.P3(0, 0, 0), math.P3(1.5, 1, 1), "low"), true},          // 1.5 < max = 2
+		{"intersect within bound", Intersect, guardBlock(t, math.P3(1.5, 0, 0), math.P3(2, 1, 1), "ok"), false}, // 0.5 ≤ min = 1
+		{"intersect too big", Intersect, guardBlock(t, math.P3(0, 0, 0), math.P3(1.5, 1, 1), "high"), true},     // 1.5 > min = 1
+	}
+	for _, c := range cases {
+		if got := invalidBooleanVolume(c.op, target, tool, c.result); got != c.invalid {
+			t.Errorf("%s: invalidBooleanVolume = %v, want %v", c.name, got, c.invalid)
+		}
+	}
+}

--- a/model/feature/assembly_cut.go
+++ b/model/feature/assembly_cut.go
@@ -55,7 +55,7 @@ func (f *AssemblyCutFeature) Recompute(in Input) (Output, error) {
 	}
 	out := make([]*topo.Body, 0, len(in.Bodies))
 	for i, target := range in.Bodies {
-		res, err := ops.Boolean(f.op, target, f.tool)
+		res, err := ops.BooleanWithDiagnostics(f.op, target, f.tool, in.Diag)
 		if err != nil {
 			return Output{}, fmt.Errorf("assemblyCut: boolean on body %d: %w", i, err)
 		}

--- a/model/feature/assembly_extrude.go
+++ b/model/feature/assembly_extrude.go
@@ -5,6 +5,7 @@ package feature
 import (
 	"fmt"
 
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/model/sketch"
@@ -46,19 +47,20 @@ func (f *AssemblyExtrudeFeature) Operation() ops.PartFeatureOperation { return f
 // body is dropped). A missing/open profile or a non-positive distance is a lost input
 // the engine turns into feature health, not a panic.
 func (f *AssemblyExtrudeFeature) Recompute(in Input) (Output, error) {
-	tool, err := f.buildTool()
+	tool, err := f.buildTool(in.Diag)
 	if err != nil {
 		return Output{}, err
 	}
-	out, err := applyToolToAll(f.op, in.Bodies, tool)
+	out, err := applyToolToAll(f.op, in.Bodies, tool, in.Diag)
 	if err != nil {
 		return Output{}, err
 	}
 	return Output{Bodies: out}, nil
 }
 
-// buildTool extrudes the resolved profile into the assembly-space prism tool.
-func (f *AssemblyExtrudeFeature) buildTool() (*topo.Body, error) {
+// buildTool extrudes the resolved profile into the assembly-space prism tool. rec collects
+// the prism builder's boolean-fallback diagnostics (#1601; nil discards).
+func (f *AssemblyExtrudeFeature) buildTool(rec *diag.Recorder) (*topo.Body, error) {
 	profiles := f.sketch.Profiles()
 	if f.profileIndex < 0 || f.profileIndex >= profiles.Count() {
 		return nil, fmt.Errorf("assemblyExtrude: profile %d out of range (sketch has %d)", f.profileIndex, profiles.Count())
@@ -71,5 +73,5 @@ func (f *AssemblyExtrudeFeature) buildTool() (*topo.Body, error) {
 	if d <= 0 {
 		return nil, fmt.Errorf("assemblyExtrude: distance %g must be positive", d)
 	}
-	return buildPrismWithHoles(p, f.sketch.Plane(), span{near: 0, far: d}, 0, "asmExtrude"), nil
+	return buildPrismWithHoles(p, f.sketch.Plane(), span{near: 0, far: d}, 0, "asmExtrude", rec), nil
 }

--- a/model/feature/assembly_hole.go
+++ b/model/feature/assembly_hole.go
@@ -60,7 +60,7 @@ func (f *AssemblyHoleFeature) Recompute(in Input) (Output, error) {
 	if f.diameter <= 0 || f.depth <= 0 {
 		return Output{}, fmt.Errorf("assemblyHole: diameter %g and depth %g must be positive", f.diameter, f.depth)
 	}
-	out, err := applyToolToAll(ops.Cut, in.Bodies, f.tool())
+	out, err := applyToolToAll(ops.Cut, in.Bodies, f.tool(), in.Diag)
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/assembly_proxy_cut.go
+++ b/model/feature/assembly_proxy_cut.go
@@ -5,6 +5,7 @@ package feature
 import (
 	"fmt"
 
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/model/occurrence"
@@ -64,7 +65,7 @@ func (f *AssemblyProxyCutFeature) Recompute(in Input) (Output, error) {
 	}
 	out := append([]*topo.Body(nil), in.Bodies...)
 	for _, tool := range tools {
-		out, err = applyToolToAll(f.op, out, tool)
+		out, err = applyToolToAll(f.op, out, tool, in.Diag)
 		if err != nil {
 			return Output{}, err
 		}
@@ -92,11 +93,12 @@ func (f *AssemblyProxyCutFeature) resolveTools() ([]*topo.Body, error) {
 	return tools, nil
 }
 
-// applyToolToAll booleans tool against each body, dropping any emptied result.
-func applyToolToAll(op ops.PartFeatureOperation, bodies []*topo.Body, tool *topo.Body) ([]*topo.Body, error) {
+// applyToolToAll booleans tool against each body, dropping any emptied result. rec collects the
+// kernel's boolean-fallback diagnostics (#1601; nil discards).
+func applyToolToAll(op ops.PartFeatureOperation, bodies []*topo.Body, tool *topo.Body, rec *diag.Recorder) ([]*topo.Body, error) {
 	out := make([]*topo.Body, 0, len(bodies))
 	for i, target := range bodies {
-		res, err := ops.Boolean(op, target, tool)
+		res, err := ops.BooleanWithDiagnostics(op, target, tool, rec)
 		if err != nil {
 			return nil, fmt.Errorf("assemblyProxyCut: boolean on body %d: %w", i, err)
 		}

--- a/model/feature/assembly_revolve.go
+++ b/model/feature/assembly_revolve.go
@@ -52,7 +52,7 @@ func (f *AssemblyRevolveFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	out, err := applyToolToAll(f.op, in.Bodies, tool)
+	out, err := applyToolToAll(f.op, in.Bodies, tool, in.Diag)
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/assembly_sweep.go
+++ b/model/feature/assembly_sweep.go
@@ -50,7 +50,7 @@ func (f *AssemblySweepFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	out, err := applyToolToAll(f.op, in.Bodies, tool)
+	out, err := applyToolToAll(f.op, in.Bodies, tool, in.Diag)
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/boolean_diagnostics_test.go
+++ b/model/feature/boolean_diagnostics_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/ops"
+)
+
+// TestCombineRecordsAnalyticFaceting is the #1601 fallback-visibility regression: cutting one
+// analytic cylinder with another where no exact curved path applies facets BOTH operands for the
+// planar boolean — permanently. That degradation must ride on the feature as a diagnostic through
+// the DEFAULT engine recompute (it used to vanish: ops.Boolean was called with rec=nil, and the
+// pre-facet happened before ops.Boolean could even see curved operands).
+func TestCombineRecordsAnalyticFaceting(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	extrudes := NewExtrudeFeatures(fs)
+	base := extrudes.AddByDistanceExtent(circleSketchAt(0, 0, 2), 0, ops.NewBody, func() float64 { return 3 })
+	cut := extrudes.AddByDistanceExtent(circleSketchAt(1.5, 0, 1), 0, ops.Cut, func() float64 { return 3 })
+
+	fs.Recompute()
+	if !base.Health().OK() || !cut.Health().OK() {
+		t.Fatalf("features went unhealthy: base=%+v cut=%+v", base.Health(), cut.Health())
+	}
+	if len(base.Diagnostics()) != 0 {
+		t.Errorf("the plain extrude carries %d diagnostics, want 0: %v", len(base.Diagnostics()), base.Diagnostics())
+	}
+	if !hasDiagCode(cut.Diagnostics(), ops.CodeBooleanAnalyticFaceted) {
+		t.Errorf("cylinder-on-cylinder cut faceted its analytic operands with no %q diagnostic; got %v",
+			ops.CodeBooleanAnalyticFaceted, cut.Diagnostics())
+	}
+}
+
+// TestExactCurvedPathStaysQuiet: a cut the exact curved boolean handles (a planar box drilled by a
+// cylinder, #1472) must NOT carry the faceting defect — the diagnostic flags real degradations
+// only, or it becomes noise nobody reads (#1601).
+func TestExactCurvedPathStaysQuiet(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	extrudes := NewExtrudeFeatures(fs)
+	base := extrudes.AddByDistanceExtent(squareSketch(4), 0, ops.NewBody, func() float64 { return 2 })
+	drill := extrudes.AddByDistanceExtent(circleSketchAt(2, 2, 0.5), 0, ops.Cut, func() float64 { return 2 })
+
+	fs.Recompute()
+	if !base.Health().OK() || !drill.Health().OK() {
+		t.Fatalf("features went unhealthy: base=%+v drill=%+v", base.Health(), drill.Health())
+	}
+	if hasDiagCode(drill.Diagnostics(), ops.CodeBooleanAnalyticFaceted) || hasDiagCode(drill.Diagnostics(), ops.CodeBooleanCSGFallback) {
+		t.Errorf("the exact box-drill cut carries degradation diagnostics it should not: %v", drill.Diagnostics())
+	}
+}
+
+// hasDiagCode reports whether any recorded diagnostic carries the code.
+func hasDiagCode(diags []diag.Diagnostic, code diag.Code) bool {
+	for _, d := range diags {
+		if d.Code == code {
+			return true
+		}
+	}
+	return false
+}

--- a/model/feature/chamfer.go
+++ b/model/feature/chamfer.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
@@ -101,7 +102,7 @@ func chamferByWedges(in Input, body *topo.Body, edges []*topo.Edge, d1, d2 float
 			tools = append(tools, wedgeOp{body: t, op: ops.Cut})
 		}
 	}
-	result, err := applyChamferTools(work, tools)
+	result, err := applyChamferTools(work, tools, in.Diag)
 	if err != nil {
 		return Output{}, err
 	}
@@ -143,10 +144,11 @@ func concaveOp(strategy types.ChamferConcaveStrategy) ops.PartFeatureOperation {
 }
 
 // applyChamferTools applies each wedge to work in turn (Cut or Join), returning the body.
-func applyChamferTools(work *topo.Body, tools []wedgeOp) (*topo.Body, error) {
+// rec collects the booleans' fallback diagnostics (#1601; nil discards).
+func applyChamferTools(work *topo.Body, tools []wedgeOp, rec *diag.Recorder) (*topo.Body, error) {
 	result := work
 	for _, t := range tools {
-		r, err := ops.Boolean(t.op, result, t.body)
+		r, err := ops.BooleanWithDiagnostics(t.op, result, t.body, rec)
 		if err != nil {
 			return nil, err
 		}
@@ -235,11 +237,12 @@ func chamferWedges(edges []*topo.Edge, d1, d2 float64, feat string) ([]*topo.Bod
 }
 
 // cutAll subtracts each tool from work in turn, returning the carved body. Shared with the
-// sheet-metal corner reliefs, which only ever cut.
-func cutAll(work *topo.Body, tools []*topo.Body) (*topo.Body, error) {
+// sheet-metal corner reliefs, which only ever cut. rec collects the cuts' boolean-fallback
+// diagnostics (#1601; nil discards).
+func cutAll(work *topo.Body, tools []*topo.Body, rec *diag.Recorder) (*topo.Body, error) {
 	result := work
 	for _, tool := range tools {
-		r, err := ops.Boolean(ops.Cut, result, tool)
+		r, err := ops.BooleanWithDiagnostics(ops.Cut, result, tool, rec)
 		if err != nil {
 			return nil, err
 		}

--- a/model/feature/derived_assembly.go
+++ b/model/feature/derived_assembly.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -223,7 +224,9 @@ func (d *DerivedAssemblyComponent) Linked() bool { return d.linked }
 // BreakLink freezes the current derived bodies and severs the source link, so the part
 // keeps the derived geometry without further updates (the reference API's break link).
 func (d *DerivedAssemblyComponent) BreakLink() error {
-	bodies, err := d.derive()
+	// nil recorder: BreakLink is a user action outside a feature recompute, so there is no
+	// Input.Diag to thread (#1601).
+	bodies, err := d.derive(nil)
 	if err != nil {
 		return err
 	}
@@ -235,7 +238,7 @@ func (d *DerivedAssemblyComponent) BreakLink() error {
 // Recompute appends the derived base body (or, after a broken link, the frozen bodies)
 // to the running state.
 func (d *DerivedAssemblyComponent) Recompute(in Input) (Output, error) {
-	return recomputeLinked(in, d.linked, d.frozen, d.derive)
+	return recomputeLinked(in, d.linked, d.frozen, func() ([]*topo.Body, error) { return d.derive(in.Diag) })
 }
 
 // recomputeLinked is the shared associative-or-frozen recompute for the derive-family
@@ -257,8 +260,9 @@ func recomputeLinked(in Input, linked bool, frozen []*topo.Body, build func() ([
 // derive flattens, transforms, and combines the source's placed bodies per style into
 // the derived base bodies (zero bodies when nothing is included, otherwise one). An
 // unbound source — a restored derive whose source has not been resolved yet (or is
-// missing) — yields no bodies, so a recompute before/without binding is safe.
-func (d *DerivedAssemblyComponent) derive() ([]*topo.Body, error) {
+// missing) — yields no bodies, so a recompute before/without binding is safe. rec collects the
+// subtract booleans' fallback diagnostics (#1601; nil discards).
+func (d *DerivedAssemblyComponent) derive(rec *diag.Recorder) ([]*topo.Body, error) {
 	if d.source == nil {
 		return nil, nil
 	}
@@ -278,18 +282,19 @@ func (d *DerivedAssemblyComponent) derive() ([]*topo.Body, error) {
 			joins = append(joins, placed)
 		}
 	}
-	return combineDerived(joins, cuts)
+	return combineDerived(joins, cuts, rec)
 }
 
 // combineDerived merges the included bodies into one base and cuts the subtracted tools
-// from it, yielding zero bodies when nothing is included or the single merged base.
-func combineDerived(joins, cuts []*topo.Body) ([]*topo.Body, error) {
+// from it, yielding zero bodies when nothing is included or the single merged base. rec
+// collects the cuts' boolean-fallback diagnostics (#1601; nil discards).
+func combineDerived(joins, cuts []*topo.Body, rec *diag.Recorder) ([]*topo.Body, error) {
 	if len(joins) == 0 {
 		return nil, nil
 	}
 	base := topo.MergeBodies(topo.NewLineage(topo.Tok("derivedAssembly", "body", 0)), true, joins...)
 	for _, tool := range cuts {
-		cut, err := ops.Boolean(ops.Cut, base, tool)
+		cut, err := ops.BooleanWithDiagnostics(ops.Cut, base, tool, rec)
 		if err != nil {
 			return nil, fmt.Errorf("feature: derive-assembly subtract: %w", err)
 		}

--- a/model/feature/emboss.go
+++ b/model/feature/emboss.go
@@ -5,6 +5,7 @@ package feature
 import (
 	"fmt"
 
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -68,8 +69,8 @@ func (f *EmbossFeature) Recompute(in Input) (Output, error) {
 	if f.def.Engrave {
 		sp, op = orderedSpan(0, -d), ops.Cut // cut into the part, below the sketch plane
 	}
-	f.tool = buildProfilePrisms(profiles, f.def.Sketch.Plane(), sp, f.def.Taper, featOr(f.featName, "emboss"))
-	bodies, err := combine(in.Bodies, f.tool, op)
+	f.tool = buildProfilePrisms(profiles, f.def.Sketch.Plane(), sp, f.def.Taper, featOr(f.featName, "emboss"), in.Diag)
+	bodies, err := combine(in, f.tool, op)
 	if err != nil {
 		return Output{}, err
 	}
@@ -159,15 +160,16 @@ func resolveClosedProfiles(sk *sketch.Sketch, indices []int, what string) ([]*sk
 }
 
 // buildProfilePrisms extrudes each closed profile to a prism over span sp (with taper), merging
-// several into one tool body — the shared prism builder for extrude/emboss.
-func buildProfilePrisms(profiles []*sketch.Profile, plane sketch.Plane, sp span, taper float64, feat string) *topo.Body {
+// several into one tool body — the shared prism builder for extrude/emboss. rec collects the
+// hole-drilling booleans' fallback diagnostics (#1601; nil discards).
+func buildProfilePrisms(profiles []*sketch.Profile, plane sketch.Plane, sp span, taper float64, feat string, rec *diag.Recorder) *topo.Body {
 	prisms := make([]*topo.Body, len(profiles))
 	for i, p := range profiles {
 		name := feat
 		if len(profiles) > 1 {
 			name = fmt.Sprintf("%s/p%d", feat, i)
 		}
-		prisms[i] = buildPrismWithHoles(p, plane, sp, taper, name)
+		prisms[i] = buildPrismWithHoles(p, plane, sp, taper, name, rec)
 	}
 	if len(prisms) == 1 {
 		return prisms[0]
@@ -179,7 +181,7 @@ func buildProfilePrisms(profiles []*sketch.Profile, plane sketch.Plane, sp span,
 // becomes a solid prism, then each inner loop (a hole) is extruded over a span that
 // overshoots both caps and cut away, yielding a hollow prism (a tube for an annular
 // profile). Without this an annular profile extruded as a solid disk.
-func buildPrismWithHoles(p *sketch.Profile, plane sketch.Plane, sp span, taper float64, feat string) *topo.Body {
+func buildPrismWithHoles(p *sketch.Profile, plane sketch.Plane, sp span, taper float64, feat string, rec *diag.Recorder) *topo.Body {
 	// A full-circle profile with no holes and no taper extrudes to a TRUE cylinder (analytic side
 	// face), so thread/chamfer/fillet on it work (#129). Booleans re-facet it on demand (combine →
 	// planarized). Other shapes fall through to the faceted prism.
@@ -192,7 +194,7 @@ func buildPrismWithHoles(p *sketch.Profile, plane sketch.Plane, sp span, taper f
 	}
 	solid := buildPrism(p.OuterLoop().Polygon(), plane, sp, taper, feat)
 	if inner := p.InnerLoops(); len(inner) > 0 {
-		return drillProfileHoles(solid, inner, plane, sp, taper, feat)
+		return drillProfileHoles(solid, inner, plane, sp, taper, feat, rec)
 	}
 	return solid
 }
@@ -200,7 +202,7 @@ func buildPrismWithHoles(p *sketch.Profile, plane sketch.Plane, sp span, taper f
 // drillProfileHoles cuts each inner loop out of the solid prism, yielding a hollow prism. Each hole
 // tool overshoots both caps by the full depth so the cut is clean; a clockwise hole loop is
 // normalized to CCW so buildPrism makes a valid outward cut tool (not an inverted one).
-func drillProfileHoles(solid *topo.Body, inner []sketch.Loop, plane sketch.Plane, sp span, taper float64, feat string) *topo.Body {
+func drillProfileHoles(solid *topo.Body, inner []sketch.Loop, plane sketch.Plane, sp span, taper float64, feat string, rec *diag.Recorder) *topo.Body {
 	lo, hi := sp.near, sp.far
 	if lo > hi {
 		lo, hi = hi, lo
@@ -213,7 +215,7 @@ func drillProfileHoles(solid *topo.Body, inner []sketch.Loop, plane sketch.Plane
 			poly = reversedPolygon2D(poly)
 		}
 		hole := buildPrism(poly, plane, cut, taper, fmt.Sprintf("%s/hole%d", feat, j))
-		if res, err := ops.Boolean(ops.Cut, solid, hole); err == nil && res != nil {
+		if res, err := ops.BooleanWithDiagnostics(ops.Cut, solid, hole, rec); err == nil && res != nil {
 			solid = res
 		}
 	}

--- a/model/feature/engine.go
+++ b/model/feature/engine.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/exchange"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
@@ -239,7 +240,9 @@ func (fs *PartFeatures) evaluateBody(pf *PartFeature, bodies []*topo.Body, sick 
 		return bodies
 	}
 	pf.recomputes++
-	out, err := safeRecompute(pf, Input{Bodies: bodies, Params: fs.params, SourceTool: fs.sourceTool})
+	rec := &diag.Recorder{}
+	out, err := safeRecompute(pf, Input{Bodies: bodies, Params: fs.params, SourceTool: fs.sourceTool, Diag: rec})
+	pf.diags = rec.Records()
 	return fs.classify(pf, bodies, out, err, sick)
 }
 
@@ -302,7 +305,10 @@ func operationOf(f Feature) ops.PartFeatureOperation {
 
 // sourceDelta returns the material a feature contributed: for a cut, before−after (the
 // removed chunk, the tool clipped to the body); for join/intersect, after−before (the added
-// chunk). NewBody, an absent state, or a feature that contributed nothing (a deferred feature,
+// chunk). Its booleans are internal DIFFING of already-built state, not a user operation on
+// the model, so they deliberately run without a diagnostics recorder (#1601): a facet
+// fallback here degrades only the replicated tool a pattern derives, and the pattern's own
+// boolean records against the pattern feature. NewBody, an absent state, or a feature that contributed nothing (a deferred feature,
 // before == after → an empty difference) yields no delta, so the caller adds nothing for that
 // source rather than copying the whole body.
 func sourceDelta(before, after *topo.Body, op ops.PartFeatureOperation) (*topo.Body, error) {

--- a/model/feature/extrude.go
+++ b/model/feature/extrude.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	stdmath "math"
 
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
@@ -84,8 +85,8 @@ func (e *ExtrudeFeature) Recompute(in Input) (Output, error) {
 	if sp.depth() == 0 {
 		return Output{}, errors.New("extrude: the extent has zero depth")
 	}
-	e.tool = e.buildTool(profiles, plane, sp)
-	bodies, err := combine(in.Bodies, e.tool, e.def.Operation)
+	e.tool = e.buildTool(profiles, plane, sp, in.Diag)
+	bodies, err := combine(in, e.tool, e.def.Operation)
 	if err != nil {
 		return Output{}, err
 	}
@@ -95,8 +96,8 @@ func (e *ExtrudeFeature) Recompute(in Input) (Output, error) {
 // buildTool extrudes each selected region into a prism over the span and merges the
 // prisms into one body. The regions are distinct cells of the same sketch, so they never
 // overlap — a shell merge is exactly their union and avoids the intersecting Join.
-func (e *ExtrudeFeature) buildTool(profiles []*sketch.Profile, plane sketch.Plane, sp span) *topo.Body {
-	return buildProfilePrisms(profiles, plane, sp, e.def.Taper, e.featName)
+func (e *ExtrudeFeature) buildTool(profiles []*sketch.Profile, plane sketch.Plane, sp span, rec *diag.Recorder) *topo.Body {
+	return buildProfilePrisms(profiles, plane, sp, e.def.Taper, e.featName, rec)
 }
 
 // outerPolygons returns each profile's outer-loop polygon, the input the span resolver
@@ -166,8 +167,12 @@ func (c *ExtrudeFeatures) AddExtrudeFeature(def *ExtrudeDefinition) *PartFeature
 func NewExtrudeFeature(def *ExtrudeDefinition) *ExtrudeFeature { return &ExtrudeFeature{def: def} }
 
 // combine applies an operation between the running bodies and a new body. Phase A
-// handles the first body / new-body and the non-overlapping boolean cases.
-func combine(running []*topo.Body, body *topo.Body, op ops.PartFeatureOperation) ([]*topo.Body, error) {
+// handles the first body / new-body and the non-overlapping boolean cases. It records on
+// in.Diag every degradation of the exact path — an analytic operand faceted for the planar
+// boolean, and the planar boolean's own triangle-CSG fallback — so the feature carries the
+// quality signal instead of shipping a silently faceted body (#1601).
+func combine(in Input, body *topo.Body, op ops.PartFeatureOperation) ([]*topo.Body, error) {
+	running := in.Bodies
 	if len(running) == 0 || op == ops.NewBody {
 		return append(append([]*topo.Body(nil), running...), body), nil
 	}
@@ -180,16 +185,23 @@ func combine(running []*topo.Body, body *topo.Body, op ops.PartFeatureOperation)
 	// segments (#1472). CurvedBoolean takes (target, tool) in feature order; each kernel path checks its own
 	// operand roles, so the same call serves both directions.
 	if exactlyOneCurvedPrimitive(target, body) {
-		if res, ok := ops.CurvedBoolean(op, target, body); ok {
+		if res, ok := ops.CurvedBooleanWithDiagnostics(op, target, body, in.Diag); ok {
 			return appendCombined(running, res), nil
 		}
 	}
 	// Otherwise re-facet any analytic curved face into a planar B-rep before the planar boolean — it hangs
 	// on a full periodic curved face it cannot consume (#129). A standalone primitive that is never
-	// combined keeps its analytic face for thread/chamfer/fillet.
+	// combined keeps its analytic face for thread/chamfer/fillet. Faceting is PERMANENT — every
+	// downstream feature then operates on facets — so it is recorded as a defect, not done silently
+	// (#1601; the pre-facet here is why the inner boolean's own CSG-fallback diagnostic alone would
+	// miss this path: by the time ops.Boolean runs, the operands already look planar).
+	if hasCurvedFace(target) || hasCurvedFace(body) {
+		in.Diag.Recordf(ops.CodeBooleanAnalyticFaceted, diag.Defect,
+			"%s faceted analytic operand(s) for the planar boolean (no exact curved path applied): the result and all downstream features are polyhedral", op)
+	}
 	target = planarized(target, "combine-target")
 	body = planarized(body, "combine-tool")
-	res, err := ops.Boolean(op, target, body)
+	res, err := ops.BooleanWithDiagnostics(op, target, body, in.Diag)
 	if err != nil {
 		return nil, err
 	}

--- a/model/feature/feature.go
+++ b/model/feature/feature.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sync/atomic"
 
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/model/identity"
@@ -49,6 +50,12 @@ type Input struct {
 	Bodies     []*topo.Body
 	Params     *param.Parameters
 	SourceTool func(id ID) (tool *topo.Body, op ops.PartFeatureOperation, ok bool)
+	// Diag collects the kernel diagnostics raised while the feature rebuilds — the facet/CSG
+	// fallback defects a boolean records when it abandons the analytic path (#1601). The engine
+	// installs a fresh recorder per evaluation and stores what it collected on the PartFeature;
+	// a nil recorder is a valid sink (diag.Recorder is nil-safe), so preview paths that do not
+	// consume diagnostics pass nothing.
+	Diag *diag.Recorder
 }
 
 // OperationalFeature is a feature that applies a boolean operation against the running

--- a/model/feature/flat_pattern.go
+++ b/model/feature/flat_pattern.go
@@ -82,7 +82,9 @@ func BuildFlatPattern(baseSketch *sketch.Sketch, baseProfile int, thickness floa
 	}
 	plane := baseSketch.Plane()
 	sp := span{near: 0, far: thickness}
-	body := buildProfilePrisms(profiles, plane, sp, 0, "FlatPattern")
+	// nil recorder: BuildFlatPattern is a standalone builder (called from compdef, outside a
+	// feature recompute), so there is no Input.Diag to thread (#1601).
+	body := buildProfilePrisms(profiles, plane, sp, 0, "FlatPattern", nil)
 	centroid := polygonCentroid(profiles[0].OuterLoop().Polygon())
 	fp := &FlatPattern{Thickness: thickness}
 	for _, tab := range tabs {
@@ -105,7 +107,7 @@ func appendTab(body *topo.Body, plane sketch.Plane, sp span, tab FlatTab, baseCe
 	offset := tabOutward(tab.A, tab.B, baseCentroid).Scale(tab.Length)
 	poly := []math.Point2{tab.A, tab.B, tab.B.TranslateBy(offset), tab.A.TranslateBy(offset)}
 	plate := buildPrism(poly, plane, sp, 0, "FlatPattern")
-	merged, err := combine([]*topo.Body{body}, plate, ops.Join)
+	merged, err := combine(Input{Bodies: []*topo.Body{body}}, plate, ops.Join) // all-planar plates: nil Diag is a valid sink
 	if err != nil {
 		return nil, err
 	}

--- a/model/feature/full_round_fillet.go
+++ b/model/feature/full_round_fillet.go
@@ -7,6 +7,7 @@ import (
 	stdmath "math"
 
 	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
@@ -81,11 +82,11 @@ func parallelFullRound(in Input, body *topo.Body, def *FullRoundFilletDefinition
 	}
 	pc := center.face.RangeBox().Center()
 	l := faceExtentAlong(center.face, pc, fr.axis) + 4*fr.radius // generous overhang so the tool cuts cleanly
-	tool, err := fullRoundCornerTool(pc, fr.up, fr.sideN, fr.axis, fr.radius, l, feat)
+	tool, err := fullRoundCornerTool(pc, fr.up, fr.sideN, fr.axis, fr.radius, l, feat, in.Diag)
 	if err != nil {
 		return Output{}, err
 	}
-	result, err := ops.Boolean(ops.Cut, planarized(body, feat), tool)
+	result, err := ops.BooleanWithDiagnostics(ops.Cut, planarized(body, feat), tool, in.Diag)
 	if err != nil {
 		return Output{}, err
 	}
@@ -119,7 +120,7 @@ func nonParallelFullRound(in Input, body *topo.Body, center, side1, side2 planar
 		if perr != nil {
 			return Output{}, perr
 		}
-		result, err = ops.Boolean(ops.Cut, planarized(result, feat), prism)
+		result, err = ops.BooleanWithDiagnostics(ops.Cut, planarized(result, feat), prism, in.Diag)
 		if err != nil {
 			return Output{}, fmt.Errorf("%s: cutting the corner round: %w", feat, err)
 		}
@@ -278,8 +279,9 @@ func fullRoundFrame(body *topo.Body, def *FullRoundFilletDefinition, center plan
 // fullRoundCornerTool builds the cut tool: a box covering the center-face footprint from the round's
 // base plane up to the center face, MINUS the round cylinder — i.e. the two sharp corners the round
 // shaves off. pc is the center-face centre; up/sideN/axisDir the orthonormal rib frame; r the radius;
-// l the length along the rib.
-func fullRoundCornerTool(pc math.Point3, up, sideN, axisDir math.Vector3, r, l float64, feat string) (*topo.Body, error) {
+// l the length along the rib. rec collects the box-minus-cylinder boolean's fallback
+// diagnostics (#1601; nil discards).
+func fullRoundCornerTool(pc math.Point3, up, sideN, axisDir math.Vector3, r, l float64, feat string, rec *diag.Recorder) (*topo.Body, error) {
 	plane, err := sketch.NewPlane(pc, sideN.AsUnit(), up.AsUnit())
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", feat, err)
@@ -295,7 +297,7 @@ func fullRoundCornerTool(pc math.Point3, up, sideN, axisDir math.Vector3, r, l f
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", feat, err)
 	}
-	corner, err := ops.Boolean(ops.Cut, planarized(box, feat), planarized(cyl, feat))
+	corner, err := ops.BooleanWithDiagnostics(ops.Cut, planarized(box, feat), planarized(cyl, feat), rec)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", feat, err)
 	}

--- a/model/feature/grill.go
+++ b/model/feature/grill.go
@@ -5,6 +5,7 @@ package feature
 import (
 	"fmt"
 
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -61,8 +62,8 @@ func (g *GrillFeature) Recompute(in Input) (Output, error) {
 	plane := g.def.Sketch.Plane()
 	sp := throughSpan(in.Bodies, plane)
 	loops := g.def.Sketch.ClosedLoops()
-	cutTool := ventTool(boundaries, loops, plane, sp, g.def.Draft, featOr(g.featName, "grill"))
-	bodies, err := combine(in.Bodies, cutTool, ops.Cut)
+	cutTool := ventTool(boundaries, loops, plane, sp, g.def.Draft, featOr(g.featName, "grill"), in.Diag)
+	bodies, err := combine(in, cutTool, ops.Cut)
 	if err != nil {
 		return Output{}, fmt.Errorf("grill: %w", err)
 	}
@@ -70,8 +71,9 @@ func (g *GrillFeature) Recompute(in Input) (Output, error) {
 }
 
 // ventTool builds the merged cut tool: for each boundary, a solid prism of its outer loop drilled
-// by every closed loop (bar) lying inside it, giving boundary − union(bars).
-func ventTool(boundaries []*sketch.Profile, loops []sketch.Loop, plane sketch.Plane, sp span, draft float64, feat string) *topo.Body {
+// by every closed loop (bar) lying inside it, giving boundary − union(bars). rec collects the
+// bar-drilling booleans' fallback diagnostics (#1601; nil discards).
+func ventTool(boundaries []*sketch.Profile, loops []sketch.Loop, plane sketch.Plane, sp span, draft float64, feat string, rec *diag.Recorder) *topo.Body {
 	tools := make([]*topo.Body, 0, len(boundaries))
 	for i, b := range boundaries {
 		name := feat
@@ -81,7 +83,7 @@ func ventTool(boundaries []*sketch.Profile, loops []sketch.Loop, plane sketch.Pl
 		outer := b.OuterLoop().Polygon()
 		solid := buildPrism(outer, plane, sp, draft, name)
 		if bars := loopsInside(loops, outer); len(bars) > 0 {
-			solid = drillProfileHoles(solid, bars, plane, sp, draft, name)
+			solid = drillProfileHoles(solid, bars, plane, sp, draft, name, rec)
 		}
 		tools = append(tools, solid)
 	}

--- a/model/feature/hole_boss.go
+++ b/model/feature/hole_boss.go
@@ -7,6 +7,7 @@ import (
 	stdmath "math"
 
 	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -105,7 +106,7 @@ func (h *HoleFeature) Recompute(in Input) (Output, error) {
 	}
 	center := holeCenter(h.def, face)
 	h.tool = h.buildTool(body, center, into, r, depth)
-	res, err := h.drill(body, center, into, r, depth)
+	res, err := h.drill(body, center, into, r, depth, in.Diag)
 	if err != nil {
 		return Output{}, err
 	}
@@ -145,31 +146,32 @@ func (h *HoleFeature) buildTool(body *topo.Body, center math.Point3, into math.U
 }
 
 // drill cuts the hole by its type: a counterbore is a shallow recess plus the bore, anything
-// else a single cylinder.
-func (h *HoleFeature) drill(body *topo.Body, center math.Point3, into math.UnitVector3, r, depth float64) (*topo.Body, error) {
+// else a single cylinder. rec collects the faceted-fallback cuts' boolean diagnostics (#1601;
+// nil discards; the exact-only countersink path never booleans, so it takes no recorder).
+func (h *HoleFeature) drill(body *topo.Body, center math.Point3, into math.UnitVector3, r, depth float64, rec *diag.Recorder) (*topo.Body, error) {
 	switch h.def.Type {
 	case CounterboreHole:
-		return h.cutCounterbore(body, center, into, r, depth)
+		return h.cutCounterbore(body, center, into, r, depth, rec)
 	case CountersinkHole:
 		return h.cutCountersink(body, center, into, r, depth)
 	default:
-		return h.cutDrilled(body, center, into, r, depth)
+		return h.cutDrilled(body, center, into, r, depth, rec)
 	}
 }
 
 // cutDrilled cuts a plain drilled hole: through, or blind with either a conical drill point
 // (PointAngle > 0) or a flat bottom. A conical point that the part can't fit falls back to the
 // flat/faceted blind cut.
-func (h *HoleFeature) cutDrilled(body *topo.Body, center math.Point3, into math.UnitVector3, r, depth float64) (*topo.Body, error) {
+func (h *HoleFeature) cutDrilled(body *topo.Body, center math.Point3, into math.UnitVector3, r, depth float64, rec *diag.Recorder) (*topo.Body, error) {
 	if h.def.ThroughAll {
-		return h.cutCylinder(body, center, into, r, depth, true)
+		return h.cutCylinder(body, center, into, r, depth, true, rec)
 	}
 	if angle := callOrZero(h.def.PointAngle); angle > 0 {
 		if res, err := brep.CutBlindConicalHole(body, center, into.AsVector(), r, depth, angle/2); err == nil {
 			return res, nil
 		}
 	}
-	return h.cutCylinder(body, center, into, r, depth, false)
+	return h.cutCylinder(body, center, into, r, depth, false, rec)
 }
 
 // cutCountersink drills a conical countersink (recess widening to the sink diameter at the
@@ -196,7 +198,7 @@ func (h *HoleFeature) cutCountersink(body *topo.Body, center math.Point3, into m
 // an annular shoulder — from the planar slab; it does NOT chain two curved cuts (the second
 // would feed a curved body to the planar-only boolean). The faceted fallback cuts the recess
 // then the bore as sequential planar prisms (each stays planar, so it chains fine).
-func (h *HoleFeature) cutCounterbore(body *topo.Body, center math.Point3, into math.UnitVector3, r, depth float64) (*topo.Body, error) {
+func (h *HoleFeature) cutCounterbore(body *topo.Body, center math.Point3, into math.UnitVector3, r, depth float64, rec *diag.Recorder) (*topo.Body, error) {
 	cr, cd := callOrZero(h.def.CounterDiameter)/2, callOrZero(h.def.CounterDepth)
 	if cr <= r {
 		return nil, fmt.Errorf("counterbore: recess Ø %g must exceed bore Ø %g", 2*cr, 2*r)
@@ -207,13 +209,13 @@ func (h *HoleFeature) cutCounterbore(body *topo.Body, center math.Point3, into m
 	if res, err := brep.CutCounterboreHole(body, center, into.AsVector(), r, depth-cd, cr, cd, h.def.ThroughAll); err == nil {
 		return res, nil
 	}
-	return h.facetedCounterbore(body, center, into, r, depth, cr, cd)
+	return h.facetedCounterbore(body, center, into, r, depth, cr, cd, rec)
 }
 
 // facetedCounterbore is the fallback for shapes the exact builder rejects: cut the recess prism,
 // then the bore prism from the shoulder (both planar cuts, so they chain through the boolean).
-func (h *HoleFeature) facetedCounterbore(body *topo.Body, center math.Point3, into math.UnitVector3, r, depth, cr, cd float64) (*topo.Body, error) {
-	stepped, err := ops.Boolean(ops.Cut, body, drillTool(center, into, cr, cd, featOr(h.featName, "hole")))
+func (h *HoleFeature) facetedCounterbore(body *topo.Body, center math.Point3, into math.UnitVector3, r, depth, cr, cd float64, rec *diag.Recorder) (*topo.Body, error) {
+	stepped, err := ops.BooleanWithDiagnostics(ops.Cut, body, drillTool(center, into, cr, cd, featOr(h.featName, "hole")), rec)
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +224,7 @@ func (h *HoleFeature) facetedCounterbore(body *topo.Body, center math.Point3, in
 	if h.def.ThroughAll {
 		boreLen = throughDepth(stepped, shoulder, into)
 	}
-	return ops.Boolean(ops.Cut, stepped, drillTool(shoulder, into, r, boreLen, featOr(h.featName, "hole")))
+	return ops.BooleanWithDiagnostics(ops.Cut, stepped, drillTool(shoulder, into, r, boreLen, featOr(h.featName, "hole")), rec)
 }
 
 // cutCylinder cuts a single cylindrical hole, preferring an EXACT cylinder wall (K1b): a
@@ -230,7 +232,7 @@ func (h *HoleFeature) facetedCounterbore(body *topo.Body, center math.Point3, in
 // (wall + flat bottom). When the part shape isn't supported (the bore clips a face, or a blind
 // depth would exit), it falls back to the faceted boolean — a through-cut when `through`, the
 // requested depth otherwise.
-func (h *HoleFeature) cutCylinder(body *topo.Body, center math.Point3, into math.UnitVector3, r, depth float64, through bool) (*topo.Body, error) {
+func (h *HoleFeature) cutCylinder(body *topo.Body, center math.Point3, into math.UnitVector3, r, depth float64, through bool, rec *diag.Recorder) (*topo.Body, error) {
 	if through {
 		if res, err := brep.CutCylindricalHole(body, center, into.AsVector(), r); err == nil {
 			return res, nil
@@ -240,7 +242,7 @@ func (h *HoleFeature) cutCylinder(body *topo.Body, center math.Point3, into math
 		return res, nil
 	}
 	tool := drillTool(center, into, r, depth, featOr(h.featName, "hole"))
-	return ops.Boolean(ops.Cut, body, tool)
+	return ops.BooleanWithDiagnostics(ops.Cut, body, tool, rec)
 }
 
 // BossDefinition is the recipe for a boss: a raised cylinder on a placement face.
@@ -284,7 +286,7 @@ func (b *BossFeature) Recompute(in Input) (Output, error) {
 		return Output{}, fmt.Errorf("boss: placement face has no normal")
 	}
 	b.tool = drillTool(centroidOf(faceVertexPoints(face)), out, r, h, featOr(b.featName, "boss"))
-	res, err := ops.Boolean(ops.Join, body, b.tool)
+	res, err := ops.BooleanWithDiagnostics(ops.Join, body, b.tool, in.Diag)
 	if err != nil {
 		return Output{}, fmt.Errorf("boss: %w", err)
 	}

--- a/model/feature/lip.go
+++ b/model/feature/lip.go
@@ -59,7 +59,7 @@ func (l *LipFeature) Recompute(in Input) (Output, error) {
 		if err != nil {
 			return Output{}, err
 		}
-		if result, err = ops.Boolean(op, result, bead); err != nil {
+		if result, err = ops.BooleanWithDiagnostics(op, result, bead, in.Diag); err != nil {
 			return Output{}, err
 		}
 	}

--- a/model/feature/modify.go
+++ b/model/feature/modify.go
@@ -39,7 +39,7 @@ func (c *CombineFeature) Recompute(in Input) (Output, error) {
 	if !validIndex(ti, in.Bodies) || !validIndex(oi, in.Bodies) || ti == oi {
 		return Output{}, fmt.Errorf("combine: invalid body indices %d,%d (have %d)", ti, oi, len(in.Bodies))
 	}
-	res, err := ops.Boolean(c.def.Operation, in.Bodies[ti], in.Bodies[oi])
+	res, err := ops.BooleanWithDiagnostics(c.def.Operation, in.Bodies[ti], in.Bodies[oi], in.Diag)
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/part_feature.go
+++ b/model/feature/part_feature.go
@@ -3,6 +3,7 @@
 package feature
 
 import (
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/model/depend"
 	"oblikovati.org/model/health"
@@ -22,7 +23,8 @@ type PartFeature struct {
 	dirty      bool
 	recomputes int
 	cached     []*topo.Body
-	seq        uint64 // global creation stamp; see model/seq
+	diags      []diag.Diagnostic // kernel diagnostics from the last evaluation (#1601)
+	seq        uint64            // global creation stamp; see model/seq
 
 	// paramReads is the model parameters this feature read DIRECTLY during its last
 	// evaluation — a sheet-metal thickness, a suppression condition (NOT the
@@ -46,6 +48,11 @@ func (f *PartFeature) SetName(n string) { f.name = n }
 
 // Kind returns the wrapped feature's type name.
 func (f *PartFeature) Kind() string { return f.feature.Kind() }
+
+// Diagnostics returns the kernel diagnostics recorded during this feature's last evaluation —
+// degradations that did not sicken it (a boolean faceting analytic surfaces, a CSG fallback) but
+// that users and add-ins must be able to SEE rather than discover downstream (#1601).
+func (f *PartFeature) Diagnostics() []diag.Diagnostic { return f.diags }
 
 // Definition returns the wrapped feature recipe.
 func (f *PartFeature) Definition() Feature { return f.feature }

--- a/model/feature/patterns.go
+++ b/model/feature/patterns.go
@@ -3,6 +3,7 @@
 package feature
 
 import (
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -139,7 +140,7 @@ func (p *patternBase) replicate(in Input, sources []ID, transforms []math.Matrix
 		if len(tools) == 0 {
 			return Output{Bodies: in.Bodies}, nil
 		}
-		return p.replicateTools(in.Bodies, tools, transforms, feat)
+		return p.replicateTools(in.Bodies, tools, transforms, feat, in.Diag)
 	}
 	copies, err := p.placeCopies(in.Bodies, transforms, feat)
 	if err != nil {
@@ -151,7 +152,7 @@ func (p *patternBase) replicate(in Input, sources []ID, transforms []math.Matrix
 // replicateTools re-applies a group of source tools, transformed by each active occurrence,
 // against the running result (the original sits at occurrence 0 already). Applying the tools in
 // source order at every grid cell keeps a multi-feature group connected (#128).
-func (p *patternBase) replicateTools(bodies []*topo.Body, tools []groupTool, transforms []math.Matrix4, feat string) (Output, error) {
+func (p *patternBase) replicateTools(bodies []*topo.Body, tools []groupTool, transforms []math.Matrix4, feat string, rec *diag.Recorder) (Output, error) {
 	if len(bodies) == 0 {
 		return Output{Bodies: bodies}, nil
 	}
@@ -169,7 +170,7 @@ func (p *patternBase) replicateTools(bodies []*topo.Body, tools []groupTool, tra
 		if p.skip(k) {
 			continue
 		}
-		next, err := applyGroupAt(running[last], tools, transforms[k], feat, k)
+		next, err := applyGroupAt(running[last], tools, transforms[k], feat, k, rec)
 		if err != nil {
 			return Output{}, err
 		}
@@ -180,13 +181,14 @@ func (p *patternBase) replicateTools(bodies []*topo.Body, tools []groupTool, tra
 
 // applyGroupAt booleans every tool of the group at occurrence k against the running body, in
 // source order, transformed into place with a per-tool lineage so reference keys stay distinct.
-func applyGroupAt(running *topo.Body, tools []groupTool, xf math.Matrix4, feat string, k int) (*topo.Body, error) {
+// rec collects the booleans' fallback diagnostics (#1601; nil discards).
+func applyGroupAt(running *topo.Body, tools []groupTool, xf math.Matrix4, feat string, k int, rec *diag.Recorder) (*topo.Body, error) {
 	for bi, t := range tools {
 		tk, err := ops.TransformBody(t.body, xf, copyLineage(feat, k, bi))
 		if err != nil {
 			return nil, err
 		}
-		res, err := ops.Boolean(t.op, running, tk)
+		res, err := ops.BooleanWithDiagnostics(t.op, running, tk, rec)
 		if err != nil {
 			return nil, err
 		}

--- a/model/feature/rest.go
+++ b/model/feature/rest.go
@@ -50,8 +50,8 @@ func (f *RestFeature) Recompute(in Input) (Output, error) {
 	if f.def.Recessed {
 		sp, op = orderedSpan(0, -d), ops.Cut // recess: cut into the part, below the sketch plane
 	}
-	f.tool = buildProfilePrisms(profiles, f.def.Sketch.Plane(), sp, f.def.Taper, featOr(f.featName, "rest"))
-	bodies, err := combine(in.Bodies, f.tool, op)
+	f.tool = buildProfilePrisms(profiles, f.def.Sketch.Plane(), sp, f.def.Taper, featOr(f.featName, "rest"), in.Diag)
+	bodies, err := combine(in, f.tool, op)
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/sheet_metal_contour_flange.go
+++ b/model/feature/sheet_metal_contour_flange.go
@@ -64,7 +64,7 @@ func (f *SheetMetalContourFlangeFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	bodies, err := combine(in.Bodies, wall, ops.Join)
+	bodies, err := combine(in, wall, ops.Join)
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/sheet_metal_contour_roll.go
+++ b/model/feature/sheet_metal_contour_roll.go
@@ -64,7 +64,7 @@ func (f *SheetMetalContourRollFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, fmt.Errorf("sheet-metal contour roll: %w", err)
 	}
-	bodies, err := combine(in.Bodies, rolled, f.def.Operation)
+	bodies, err := combine(in, rolled, f.def.Operation)
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/sheet_metal_corner.go
+++ b/model/feature/sheet_metal_corner.go
@@ -101,7 +101,7 @@ func (f *SheetMetalCornerFeature) chamferCorners(in Input, body *topo.Body, setb
 	if err != nil {
 		return Output{}, fmt.Errorf("sheet-metal corner chamfer: %w", err)
 	}
-	res, err := cutAll(work, tools)
+	res, err := cutAll(work, tools, in.Diag)
 	if err != nil {
 		return Output{}, fmt.Errorf("sheet-metal corner chamfer: %w", err)
 	}

--- a/model/feature/sheet_metal_corner_seam.go
+++ b/model/feature/sheet_metal_corner_seam.go
@@ -77,7 +77,7 @@ func (f *SheetMetalCornerSeamFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	res, err := cutAll(work, tools)
+	res, err := cutAll(work, tools, in.Diag)
 	if err != nil {
 		return Output{}, fmt.Errorf("sheet-metal corner seam: %w", err)
 	}

--- a/model/feature/sheet_metal_cut.go
+++ b/model/feature/sheet_metal_cut.go
@@ -55,8 +55,8 @@ func (f *SheetMetalCutFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	tool := buildProfilePrisms(profiles, plane, sp, 0, f.featName)
-	bodies, err := combine(in.Bodies, tool, ops.Cut)
+	tool := buildProfilePrisms(profiles, plane, sp, 0, f.featName, in.Diag)
+	bodies, err := combine(in, tool, ops.Cut)
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/sheet_metal_face.go
+++ b/model/feature/sheet_metal_face.go
@@ -57,8 +57,8 @@ func (f *SheetMetalFaceFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	body := buildProfilePrisms(profiles, f.def.Sketch.Plane(), faceSpan(t, f.def.Direction), 0, f.featName)
-	bodies, err := combine(in.Bodies, body, f.def.Operation)
+	body := buildProfilePrisms(profiles, f.def.Sketch.Plane(), faceSpan(t, f.def.Direction), 0, f.featName, in.Diag)
+	bodies, err := combine(in, body, f.def.Operation)
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/sheet_metal_flange.go
+++ b/model/feature/sheet_metal_flange.go
@@ -72,7 +72,7 @@ func (f *SheetMetalFlangeFeature) Recompute(in Input) (Output, error) {
 		return Output{}, err
 	}
 	// Union the wall onto the sheet (combine planarizes both before the planar boolean).
-	bodies, err := combine(in.Bodies, wall, ops.Join)
+	bodies, err := combine(in, wall, ops.Join)
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/sheet_metal_hem.go
+++ b/model/feature/sheet_metal_hem.go
@@ -71,7 +71,7 @@ func (f *SheetMetalHemFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	bodies, err := combine(in.Bodies, wall, ops.Join)
+	bodies, err := combine(in, wall, ops.Join)
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/sheet_metal_lip.go
+++ b/model/feature/sheet_metal_lip.go
@@ -64,7 +64,7 @@ func (f *SheetMetalLipFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	bodies, err := combine(in.Bodies, wall, ops.Join)
+	bodies, err := combine(in, wall, ops.Join)
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/sheet_metal_lofted_flange.go
+++ b/model/feature/sheet_metal_lofted_flange.go
@@ -60,7 +60,7 @@ func (f *SheetMetalLoftedFlangeFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, fmt.Errorf("sheet-metal lofted flange: %w", err)
 	}
-	bodies, err := combine(in.Bodies, wall, f.def.Operation)
+	bodies, err := combine(in, wall, f.def.Operation)
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/sheet_metal_punch.go
+++ b/model/feature/sheet_metal_punch.go
@@ -57,8 +57,8 @@ func (f *SheetMetalPunchFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	tool := buildProfilePrisms(profiles, plane, sp, 0, f.featName)
-	bodies, err := combine(in.Bodies, tool, ops.Cut)
+	tool := buildProfilePrisms(profiles, plane, sp, 0, f.featName, in.Diag)
+	bodies, err := combine(in, tool, ops.Cut)
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/sheet_metal_rip.go
+++ b/model/feature/sheet_metal_rip.go
@@ -56,7 +56,7 @@ func (f *SheetMetalRipFeature) Recompute(in Input) (Output, error) {
 		return Output{}, err
 	}
 	tool := buildPrism(ripPolygon(a, b, gap), plane, sp, 0, f.featName)
-	bodies, err := combine(in.Bodies, tool, ops.Cut)
+	bodies, err := combine(in, tool, ops.Cut)
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/sketched_features.go
+++ b/model/feature/sketched_features.go
@@ -70,7 +70,7 @@ func (r *RevolveFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	bodies, err := combine(in.Bodies, r.tool, r.def.Operation)
+	bodies, err := combine(in, r.tool, r.def.Operation)
 	if err != nil {
 		return Output{}, err
 	}
@@ -389,7 +389,7 @@ func (c *CoilFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	bodies, err := combine(in.Bodies, c.tool, c.def.Operation)
+	bodies, err := combine(in, c.tool, c.def.Operation)
 	if err != nil {
 		return Output{}, err
 	}
@@ -515,7 +515,7 @@ func (r *RibFeature) Recompute(in Input) (Output, error) {
 	}
 	band := ensureCCW2(thickenPath(pts, t))
 	r.tool = buildPrism(band, r.def.Sketch.Plane(), orderedSpan(0, d), 0, "rib")
-	bodies, err := combine(in.Bodies, r.tool, r.def.Operation)
+	bodies, err := combine(in, r.tool, r.def.Operation)
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/snap_fit.go
+++ b/model/feature/snap_fit.go
@@ -67,7 +67,7 @@ func snapFitBody(in Input, def *SnapFitDefinition, feat string) (Output, error) 
 		{X: 0, Y: t},
 	}
 	hook := buildPrism(profile, sketch.XZPlane(), span{near: 0, far: w}, 0, feat)
-	bodies, err := combine(in.Bodies, hook, ops.Join)
+	bodies, err := combine(in, hook, ops.Join)
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/sweep_loft.go
+++ b/model/feature/sweep_loft.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
@@ -140,7 +141,7 @@ func (s *SweepFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	bodies, err := combine(in.Bodies, s.tool, s.def.Operation)
+	bodies, err := combine(in, s.tool, s.def.Operation)
 	if err != nil {
 		return Output{}, err
 	}
@@ -290,12 +291,12 @@ func (l *LoftFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	tool, err := l.skinTool(outers, inners, l.endsWith(normals, surfs), l.resolveGuides())
+	tool, err := l.skinTool(outers, inners, l.endsWith(normals, surfs), l.resolveGuides(), in.Diag)
 	if err != nil {
 		return Output{}, err
 	}
 	l.tool = tool
-	bodies, err := combine(in.Bodies, l.tool, l.def.Operation)
+	bodies, err := combine(in, l.tool, l.def.Operation)
 	if err != nil {
 		return Output{}, err
 	}
@@ -354,7 +355,7 @@ func (l *LoftFeature) resolveGuides() loftGuides {
 // directly-meshed tube (one hole — a pipe), or a multi-hole solid cut from the skin (rare). Guides
 // (rails + centerline) shape the OUTER surface only. The one-hole tube is meshed directly rather
 // than via a bore Cut because a bore whose caps are coplanar with the body's caps leaves it open.
-func (l *LoftFeature) skinTool(outers [][]math.Point3, inners [][][]math.Point3, ends loftEnds, guides loftGuides) (*topo.Body, error) {
+func (l *LoftFeature) skinTool(outers [][]math.Point3, inners [][][]math.Point3, ends loftEnds, guides loftGuides, rec *diag.Recorder) (*topo.Body, error) {
 	feat := featOr(l.featName, "loft")
 	switch numHoles(inners) {
 	case 0:
@@ -362,15 +363,16 @@ func (l *LoftFeature) skinTool(outers [][]math.Point3, inners [][][]math.Point3,
 	case 1:
 		return tubeLoops(outers, holeRing(inners, 0), l.def.Closed, feat, ends, guides)
 	default:
-		return hollowByCut(outers, inners, l.def.Closed, feat, ends, guides)
+		return hollowByCut(outers, inners, l.def.Closed, feat, ends, guides, rec)
 	}
 }
 
 // hollowByCut skins the outer body and cuts each bore out of it — the fallback for lofts with
 // more than one hole, where a multiply-connected end cap can't be a simple annular strip. Each
 // bore is extended past the body's end caps (extendEnds) so the through-cut is not coplanar. Guides
-// shape the outer skin only (the bores skin unguided).
-func hollowByCut(outers [][]math.Point3, inners [][][]math.Point3, closed bool, feat string, ends loftEnds, guides loftGuides) (*topo.Body, error) {
+// shape the outer skin only (the bores skin unguided). rec collects the bore cuts' boolean-fallback
+// diagnostics (#1601; nil discards).
+func hollowByCut(outers [][]math.Point3, inners [][][]math.Point3, closed bool, feat string, ends loftEnds, guides loftGuides, rec *diag.Recorder) (*topo.Body, error) {
 	tool, err := skinLoops(outers, closed, feat, ends, guides)
 	if err != nil {
 		return nil, err
@@ -385,7 +387,7 @@ func hollowByCut(outers [][]math.Point3, inners [][][]math.Point3, closed bool, 
 		if herr != nil {
 			return nil, herr
 		}
-		if tool, err = ops.Boolean(ops.Cut, tool, hole); err != nil {
+		if tool, err = ops.BooleanWithDiagnostics(ops.Cut, tool, hole, rec); err != nil {
 			return nil, err
 		}
 	}

--- a/model/feature/sweep_variants.go
+++ b/model/feature/sweep_variants.go
@@ -8,6 +8,7 @@ import (
 	stdmath "math"
 
 	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -411,12 +412,12 @@ func (s *SweepFeature) recomputeSolidSweep(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	swept, err := sweptToolEnvelope(toolSrc, path, featOr(s.featName, "sweep"))
+	swept, err := sweptToolEnvelope(toolSrc, path, featOr(s.featName, "sweep"), in.Diag)
 	if err != nil {
 		return Output{}, err
 	}
 	s.tool = swept
-	bodies, err := combine(in.Bodies, swept, s.def.Operation)
+	bodies, err := combine(in, swept, s.def.Operation)
 	if err != nil {
 		return Output{}, err
 	}
@@ -435,8 +436,9 @@ func (s *SweepFeature) resolvePathPoints() ([]math.Point3, error) {
 	return path.Points(), nil
 }
 
-// sweptToolEnvelope unions translated tool stamps along the path.
-func sweptToolEnvelope(tool *topo.Body, path []math.Point3, feat string) (*topo.Body, error) {
+// sweptToolEnvelope unions translated tool stamps along the path. rec collects the stamp
+// unions' boolean-fallback diagnostics (#1601; nil discards).
+func sweptToolEnvelope(tool *topo.Body, path []math.Point3, feat string, rec *diag.Recorder) (*topo.Body, error) {
 	samples := stampStations(tool, path)
 	origin := samples[0]
 	swept, err := stampAt(tool, origin, origin, feat, 0)
@@ -448,7 +450,7 @@ func sweptToolEnvelope(tool *topo.Body, path []math.Point3, feat string) (*topo.
 		if err != nil {
 			return nil, err
 		}
-		if swept, err = ops.Boolean(ops.Join, swept, stamp); err != nil {
+		if swept, err = ops.BooleanWithDiagnostics(ops.Join, swept, stamp, rec); err != nil {
 			return nil, fmt.Errorf("sweep: stamp %d union failed: %w", i, err)
 		}
 	}


### PR DESCRIPTION
## What

The audit's flagship silent-degradation finding: a boolean that facets analytic surfaces (or falls to triangle CSG) reported it to nobody — `ops.Boolean` was called with `rec=nil` everywhere, and the most common degradation happens **before** `ops.Boolean` even runs (`combine()` pre-facets curved operands for the planar path).

- **Feature diagnostics channel**: every recompute runs with a fresh `diag.Recorder` (`Input.Diag`), the engine stores the records on the `PartFeature` (`Diagnostics()`), and the feature reply DTO carries a `diagnostics` array `[{code, severity, detail}]`. Feature **health is untouched** — a routine fallback is a quality signal, not a failure, so nothing that legitimately falls back today goes unhealthy.
- **New `boolean.analytic-faceted` Defect** recorded by `combine()` when it facets analytic operands (permanent, downstream-poisoning); the orphaned `boolean.csg-fallback` (#1407) now actually flows — all model/feature boolean sites route through `BooleanWithDiagnostics` with the feature's recorder (combine + the hole/chamfer/pattern/sweep/emboss/grill/assembly helper chains).
- **Two-sided volume guard** (Requicha brackets): `V(A∖B) ∈ [V(A)−V(B), V(A)]`, `V(A∪B) ∈ [max, V(A)+V(B)]` — a cut that removed too much or a join that fabricated material used to pass the one-sided check silently. Intersect keeps its upper bound only (rationale in code).

## Tests

- `TestBooleanVolumeGuardTwoSided` — bracket table over doctored results (removes-too-much rejected).
- `TestCombineRecordsAnalyticFaceting` / `TestExactCurvedPathStaysQuiet` — the diagnostic fires exactly when degradation happens, and NOT on exact curved paths (no noise).
- `TestFeatureReplyCarriesFallbackDiagnostics` — wire-level: the cut reply carries the code through the opregistry DTO.

## Live test

New `mcplive facetdiag` driver against the running app: a Ø40 cylinder cut by an offset Ø20 cylinder (no exact curved path) returns `diagnostics: [{boolean.analytic-faceted, defect, ...}]` in the add_feature reply; `squatrim` re-run confirms exact paths stay quiet. (Bridge PR Oblikovati.AddIns.MCPBridge#85.)

## Deliberately out of scope (tracked on #1601)

- Recognizer-gate widening (2D cap arrangement, winding-number membership) — that is #1403-EPIC-scale kernel work.
- Non-feature consumers (`bodyapi` transient booleans, interference analysis) still pass nil.
- UI feature-browser badge for degraded features.

Full suite green, `golangci-lint` 0 issues.

Part of #1601

🤖 Generated with [Claude Code](https://claude.com/claude-code)