### PR TITLE
Classify planar-boolean fragments by winding number (audit A3)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.102.0
+	oblikovati.org/api v0.102.1
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.102.0
+	oblikovati.org/api v0.102.1
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/kernel/brep/boolean_classify.go
+++ b/kernel/brep/boolean_classify.go
@@ -5,39 +5,58 @@ package brep
 import (
 	stdmath "math"
 
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 )
 
-// insideSolid reports whether p is inside the solid b, by casting a skewed ray from p and
-// counting crossings of b's planar faces (odd ⇒ inside). The direction is off-axis to
-// avoid grazing a face plane or hitting an edge/vertex.
+// insideSolidWindingThreshold is the generalized-winding-number cutoff for "inside", in raw
+// steradians: the winding number w = Σ/4π is ~1 strictly inside an outward-oriented closed
+// boundary and ~0 strictly outside, so thresholding the sum at 2π (w = 0.5) is the maximally
+// robust split — a fragment sample point near a shared edge perturbs the sum by ≪2π, where the
+// retired single-ray parity count flipped outright (#1599).
+const insideSolidWindingThreshold = 2 * stdmath.Pi
+
+// insideSolid reports whether p is inside the solid b, by thresholding the generalized winding
+// number of b's planar faces at p (Jacobson, Kavan & Sorkine, SIGGRAPH 2013). It replaces a
+// parity count along one fixed skewed ray (#1599): parity had no reselection when the ray grazed
+// an edge/vertex or ran near-parallel to a face, so fragments whose sample point sat near a
+// shared boundary — or models with faces near the magic direction — misclassified
+// deterministically. The winding number integrates the WHOLE boundary; it has no direction to
+// graze.
 func insideSolid(b *topo.Body, p math.Point3) bool {
 	faces, ok := facesOf(b)
 	if !ok {
 		return false
 	}
-	dir := math.V3(0.5773, 0.5774, 0.5775)
-	crossings := 0
+	onPlane := geom.ResolutionForBox(b.RangeBox()).Plane()
+	sum := 0.0
 	for _, f := range faces {
-		if rayHitsFace(p, dir, f) {
-			crossings++
-		}
+		sum += faceSolidAngle(f, p, onPlane)
 	}
-	return crossings%2 == 1
+	return sum > insideSolidWindingThreshold
 }
 
-// rayHitsFace reports whether the ray p+t·dir (t>0) passes through the face's polygon.
-func rayHitsFace(p math.Point3, dir math.Vector3, f planarFace) bool {
-	n := f.normal
-	den := dir.Dot(n)
-	if stdmath.Abs(den) < parallelDenomTol {
-		return false // ray parallel to the face plane
+// faceSolidAngle sums the signed solid angle every loop of the planar face subtends at p, fanning
+// each ring from its first vertex. A fan is winding-exact for any simple ring, convex or not (the
+// folded triangles of a reflex fan cancel by sign), and a hole ring — wound opposite the outer —
+// subtracts its own contribution.
+//
+// A p ON the face's plane (within onPlaneTol) contributes exactly 0: a flat polygon subtends no
+// solid angle at any coplanar exterior point, and evaluating the fan there instead trips the
+// atan2 formula's sign-of-zero degeneracy (num = ±0 with den < 0 fabricates a spurious ±2π —
+// the beltb regression, where the operands share their top/bottom planes). The coplanar-INTERIOR
+// point — genuinely on the solid's boundary — never reaches this classifier: classifySubFace
+// resolves it through the coplanarCover/ON-ON table first.
+func faceSolidAngle(f planarFace, p math.Point3, onPlaneTol float64) float64 {
+	if stdmath.Abs(float64(f.normal.Dot(f.plane.Origin.VectorTo(p)))) < onPlaneTol {
+		return 0
 	}
-	t := f.plane.Origin.VectorTo(p).Dot(n) / -den // n·(p+t dir) = n·origin ⇒ t = n·(origin−p)/(n·dir)
-	if t <= 1e-9 {                                // tol:numeric — ray hit parameter near-zero guard (dir not unit)
-		return false
+	sum := 0.0
+	for _, ring := range f.loops {
+		for i := 1; i+1 < len(ring); i++ {
+			sum += geom.SignedSolidAngle(p, ring[0], ring[i], ring[i+1])
+		}
 	}
-	hit := p.TranslateBy(dir.Scale(t))
-	return pointInFace2D(to2D(f.plane, hit), f)
+	return sum
 }

--- a/kernel/brep/boolean_classify_test.go
+++ b/kernel/brep/boolean_classify_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/subd"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// classifyPolygonPrism builds an n-gon prism body for classification fixtures.
+func classifyPolygonPrism(t *testing.T, r float64, n int, z0, z1 float64, name string) *topo.Body {
+	t.Helper()
+	verts := make([]math.Point3, 0, n*2)
+	for _, z := range []float64{z0, z1} {
+		for i := 0; i < n; i++ {
+			a := 2 * stdmath.Pi * float64(i) / float64(n)
+			verts = append(verts, math.P3(r*stdmath.Cos(a), r*stdmath.Sin(a), z))
+		}
+	}
+	bottom, top := make([]int, n), make([]int, n)
+	for i := 0; i < n; i++ {
+		bottom[i], top[i] = n-1-i, n+i
+	}
+	faces := [][]int{bottom, top}
+	for i := 0; i < n; i++ {
+		faces = append(faces, []int{i, (i + 1) % n, (i+1)%n + n, i + n})
+	}
+	return subd.ToBody(subd.Mesh{Verts: verts, Faces: faces}, name)
+}
+
+// TestInsideSolidWindingBasics: the winding classifier must agree with the obvious answers on a
+// box and on a holed (annular) prism — including a query point down the hole, which only a
+// hole-aware classification gets right (#1599).
+func TestInsideSolidWindingBasics(t *testing.T) {
+	blk, _ := SolidBlock(math.P3(0, 0, 0), math.P3(1, 1, 1), "b")
+	if !insideSolid(blk, math.P3(0.5, 0.5, 0.5)) || insideSolid(blk, math.P3(2, 2, 2)) {
+		t.Error("box winding classification wrong at the trivial points")
+	}
+	ring := classifyRing(t)
+	if !insideSolid(ring, math.P3(0.74, 0, 0.3)) {
+		t.Error("point in the ring material classified outside")
+	}
+	if insideSolid(ring, math.P3(0, 0, 0.3)) {
+		t.Error("point down the ring's hole classified inside")
+	}
+}
+
+// classifyRing cuts an inner prism out of an outer one — the annular fixture whose top/bottom
+// planes coincide with other operands in the beltb/faceplate regressions.
+func classifyRing(t *testing.T) *topo.Body {
+	t.Helper()
+	outer := classifyPolygonPrism(t, 0.8, 64, 0, 0.6, "outer")
+	inner := classifyPolygonPrism(t, 0.68, 32, -0.05, 0.65, "inner")
+	ring, err := Boolean(Difference, outer, inner)
+	if err != nil {
+		t.Fatalf("ring cut: %v", err)
+	}
+	return ring
+}
+
+// TestInsideSolidCoplanarQueryPoint is the beltb regression (#1599): a query point lying ON a
+// face's PLANE — the systematic case when two operands share a top/bottom plane — must classify
+// by the rest of the boundary. Evaluating the solid-angle fan at a coplanar point instead trips
+// the atan2 sign-of-zero degeneracy and fabricates a spurious ±2π, which put hole points of the
+// beltb ring "inside" and tore the union open.
+func TestInsideSolidCoplanarQueryPoint(t *testing.T) {
+	ring := classifyRing(t)
+	if insideSolid(ring, math.P3(0, 0.0587, 0)) {
+		t.Error("point in the hole ON the ring's bottom plane classified inside (coplanar ±2π degeneracy)")
+	}
+	if insideSolid(ring, math.P3(2, 0, 0)) {
+		t.Error("point outside the ring ON its bottom plane classified inside")
+	}
+	if insideSolid(ring, math.P3(0, 0, 0.6)) {
+		t.Error("point in the hole ON the ring's top plane classified inside")
+	}
+}
+
+// TestInsideSolidEdgeGrazingDirection is the adversarial fixture for the RETIRED fixed-ray parity
+// classifier (#1599): a query point placed so a ray along the old magic direction
+// (0.5773, 0.5774, 0.5775) passes exactly through a box edge (two faces' shared boundary) or a
+// corner (three faces'), where parity counting was ambiguous. The winding number integrates the
+// whole boundary — there is no direction to graze — so these must classify exactly.
+func TestInsideSolidEdgeGrazingDirection(t *testing.T) {
+	blk, _ := SolidBlock(math.P3(0, 0, 0), math.P3(2, 2, 2), "b")
+	dir := math.V3(0.5773, 0.5774, 0.5775)
+	inside := math.P3(1, 2, 2).TranslateBy(dir.Scale(-1)) // the old ray exits exactly through the top edge midpoint
+	if !insideSolid(blk, inside) {
+		t.Errorf("interior point %v (old ray through an edge) classified outside", inside)
+	}
+	outside := math.P3(2, 2, 2).TranslateBy(dir.Scale(0.5)) // beyond the corner; the reversed old ray passes through it
+	if insideSolid(blk, outside) {
+		t.Errorf("exterior point %v (old ray through a corner) classified inside", outside)
+	}
+}

--- a/kernel/brep/coverage_test.go
+++ b/kernel/brep/coverage_test.go
@@ -110,26 +110,6 @@ func TestReverseSubFaceFlipsNormalAndRings(t *testing.T) {
 	}
 }
 
-func TestRayHitsFaceBranches(t *testing.T) {
-	faces, ok := facesOf(oneFaceBody(t, false)) // a z=0 triangle (normal +Z)
-	if !ok || len(faces) != 1 {
-		t.Fatalf("facesOf(triangle) = %v, %v", len(faces), ok)
-	}
-	f := faces[0]
-	// Hit: from below the plane, shooting +Z through an interior point.
-	if !rayHitsFace(math.P3(0.2, 0.2, -1), math.V3(0, 0, 1), f) {
-		t.Error("ray through the interior should hit")
-	}
-	// Parallel: a ray in the plane never hits.
-	if rayHitsFace(math.P3(0.2, 0.2, 1), math.V3(1, 0, 0), f) {
-		t.Error("a ray parallel to the face should miss")
-	}
-	// Behind: the face is behind the ray origin along +Z.
-	if rayHitsFace(math.P3(0.2, 0.2, 1), math.V3(0, 0, 1), f) {
-		t.Error("a face behind the ray should miss")
-	}
-}
-
 func TestInsideSolidRejectsNonPlanar(t *testing.T) {
 	if insideSolid(oneFaceBody(t, true), math.P3(0, 0, 0)) {
 		t.Error("insideSolid of a non-planar body should be false")

--- a/kernel/geom/solid_angle.go
+++ b/kernel/geom/solid_angle.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// SignedSolidAngle returns the signed solid angle (steradians) that triangle (a,b,c) subtends at p,
+// via the Van Oosterom–Strackee atan2 formula (IEEE Trans. Biomed. Eng. 1983) — numerically stable
+// across the full sphere, including the back hemisphere where a naive arccos loses sign/precision.
+// The sign follows the triangle's winding (right-hand rule), so the sum over an outward-oriented
+// closed boundary is +4π at an interior point and 0 outside — the building block of the generalized
+// winding number (Jacobson, Kavan & Sorkine, SIGGRAPH 2013) used by both the mesh classifier
+// (kernel/ops, #1317) and the planar-boolean fragment classifier (kernel/brep, #1599). A degenerate
+// triangle, or p coincident with a corner, contributes 0.
+//
+// Example — the +Z octant triangle subtends π/2 at the origin:
+//
+//	w := geom.SignedSolidAngle(math.P3(0,0,0), math.P3(1,0,0), math.P3(0,1,0), math.P3(0,0,1))
+func SignedSolidAngle(p, a, b, c math.Point3) float64 {
+	va, vb, vc := p.VectorTo(a), p.VectorTo(b), p.VectorTo(c)
+	la, lb, lc := va.Length(), vb.Length(), vc.Length()
+	if la == 0 || lb == 0 || lc == 0 {
+		return 0
+	}
+	num := float64(va.Dot(vb.Cross(vc)))
+	den := float64(la*lb*lc) + float64(va.Dot(vb))*float64(lc) +
+		float64(vb.Dot(vc))*float64(la) + float64(vc.Dot(va))*float64(lb)
+	return 2 * stdmath.Atan2(num, den)
+}

--- a/kernel/ops/boolean_planar_volume_test.go
+++ b/kernel/ops/boolean_planar_volume_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// planarVolumeCheck runs one boolean and asserts the result validates and matches the analytic
+// volume two-sided (#1599, #1601) — a misclassified fragment shifts the volume by that fragment's
+// prism, so the volume bracket is the cheap detector for a classification flip.
+func planarVolumeCheck(t *testing.T, name string, op ops.PartFeatureOperation, a, b *topo.Body, want float64) {
+	t.Helper()
+	res, err := ops.Boolean(op, a, b)
+	if err != nil {
+		t.Fatalf("%s: %v", name, err)
+	}
+	if r := ops.Validate(res); !r.Valid || !r.Closed || !r.Manifold {
+		t.Errorf("%s: result invalid: %+v", name, r)
+	}
+	got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	if stdmath.Abs(got-want) > 1e-6+1e-9*want {
+		t.Errorf("%s: volume = %.9f, want %.9f (analytic)", name, got, want)
+	}
+}
+
+// TestPlanarBooleanVolumesAnalytic pins the planar boolean's fragment classification to analytic
+// volumes on overlapping boxes and an L-bracket cut (#1599): every op, both operand orders.
+func TestPlanarBooleanVolumesAnalytic(t *testing.T) {
+	mk := func() (*topo.Body, *topo.Body) {
+		a, _ := brep.SolidBlock(math.P3(0, 0, 0), math.P3(2, 2, 2), "a") // V=8
+		b, _ := brep.SolidBlock(math.P3(1, 1, 1), math.P3(3, 3, 3), "b") // V=8, overlap 1
+		return a, b
+	}
+	a, b := mk()
+	planarVolumeCheck(t, "union", ops.Join, a, b, 15)
+	a, b = mk()
+	planarVolumeCheck(t, "cut", ops.Cut, a, b, 7)
+	a, b = mk()
+	planarVolumeCheck(t, "cut reversed", ops.Cut, b, a, 7)
+	a, b = mk()
+	planarVolumeCheck(t, "intersect", ops.Intersect, a, b, 1)
+
+	// L-bracket: cut a corner block out of a slab, leaving the L; then cut the L with a bar
+	// crossing both legs — fragments whose sample points hug shared edges on every side.
+	slab, _ := brep.SolidBlock(math.P3(0, 0, 0), math.P3(4, 4, 1), "slab") // V=16
+	corner, _ := brep.SolidBlock(math.P3(2, 2, -1), math.P3(5, 5, 2), "corner")
+	lbr, err := ops.Boolean(ops.Cut, slab, corner)
+	if err != nil {
+		t.Fatalf("L-bracket: %v", err)
+	}
+	bar, _ := brep.SolidBlock(math.P3(-1, 1, 0.25), math.P3(5, 1.5, 0.75), "bar") // 0.5×0.5 section across x
+	// L = 16 − (2×2×1 corner) = 12; the bar crosses the L's full 4-wide leg at y∈[1,1.5]:
+	// removed = 4 (x-span) × 0.5 × 0.5 = 1.
+	planarVolumeCheck(t, "L-bracket bar cut", ops.Cut, lbr, bar, 11)
+}

--- a/kernel/ops/point_in_solid.go
+++ b/kernel/ops/point_in_solid.go
@@ -5,6 +5,7 @@ package ops
 import (
 	stdmath "math"
 
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/math"
 )
 
@@ -31,21 +32,10 @@ func windingNumber(mesh *Mesh, p math.Point3) float64 {
 	return sum / (4 * stdmath.Pi)
 }
 
-// signedSolidAngle returns the signed solid angle (steradians) that triangle (a,b,c) subtends at p,
-// via the Van Oosterom–Strackee atan2 formula (IEEE Trans. Biomed. Eng. 1983) — numerically stable
-// across the full sphere, including the back hemisphere where a naive arccos loses sign/precision.
-// The sign follows the triangle's winding (right-hand rule), so the sum over an outward mesh is +4π
-// inside and 0 outside. A degenerate triangle, or p coincident with a corner, contributes 0.
+// signedSolidAngle is geom.SignedSolidAngle (the Van Oosterom–Strackee formula), shared with the
+// planar-boolean fragment classifier since #1599.
 func signedSolidAngle(p, a, b, c math.Point3) float64 {
-	va, vb, vc := p.VectorTo(a), p.VectorTo(b), p.VectorTo(c)
-	la, lb, lc := va.Length(), vb.Length(), vc.Length()
-	if la == 0 || lb == 0 || lc == 0 {
-		return 0
-	}
-	num := float64(va.Dot(vb.Cross(vc)))
-	den := float64(la*lb*lc) + float64(va.Dot(vb))*float64(lc) +
-		float64(vb.Dot(vc))*float64(la) + float64(vc.Dot(va))*float64(lb)
-	return 2 * stdmath.Atan2(num, den)
+	return geom.SignedSolidAngle(p, a, b, c)
 }
 
 // pointInMesh reports whether p lies inside the solid bounded by an outward-oriented mesh, by


### PR DESCRIPTION
## What

Fragment classification in the planar boolean shot **one fixed ray** `(0.5773, 0.5774, 0.5775)` and counted parity — no reselection on edge/vertex grazing, near-parallel faces dropped from the count. A single parity flip misclassifies an entire fragment (phantom wall / un-removed material), deterministically for models with geometry near the magic direction.

- `insideSolid` now thresholds the **generalized winding number** (Jacobson–Kavan–Sorkine 2013) summed directly over the planar faces: each loop fans from its first vertex (winding-exact for non-convex rings; opposite-wound holes subtract). No ray → nothing to graze; the fixed-direction constant is deleted.
- The Van Oosterom–Strackee signed solid angle moves to `geom.SignedSolidAngle`, shared by the mesh classifier (`kernel/ops`, #1317) and this one — no duplication.
- **Coplanar degeneracy found & handled during development**: a query point ON a face's plane (systematic when operands share top/bottom planes — the beltb fixture) trips atan2's sign-of-zero and fabricates spurious ±2π. A coplanar face now contributes exactly 0 — mathematically exact for coplanar-exterior points; the coplanar-interior case is intercepted by the coplanarCover/ON-ON table before this classifier runs.
- `drill_blind`/`drill_conical` validity probes inherit the robustness for free.

## Tests

- `TestInsideSolidWindingBasics` — box + annulus (query down the hole).
- `TestInsideSolidCoplanarQueryPoint` — the beltb-class regression (fails on a naive winding port).
- `TestInsideSolidEdgeGrazingDirection` — the adversarial fixtures for the retired ray: old-ray-through-edge (interior) and through-corner (exterior) classify exactly.
- `TestPlanarBooleanVolumesAnalytic` (ops) — two-sided analytic volume pins for union/cut(both orders)/intersect on overlapping boxes + an L-bracket bar cut, with full validation.

## Live test

counterbore, faceplate, fixingblock, hanginghole, boxtray, squatrim drivers all PASS against the running app; faceplate screenshot shows clean holes/boss (no phantom fragments).

Full suite green, `golangci-lint` 0 issues.

Closes #1599

🤖 Generated with [Claude Code](https://claude.com/claude-code)