### PR TITLE
Record the tangency nudge as a defect; fix the inside-out prisms it hid (audit A4)

### DIFF
--- a/kernel/brep/boolean.go
+++ b/kernel/brep/boolean.go
@@ -5,6 +5,7 @@ package brep
 import (
 	"errors"
 
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -39,9 +40,15 @@ type subFace struct {
 // segments, splits each face along them (the 2D arrangement), classifies the sub-faces
 // against the other solid, keeps the ones the operation calls for (reversing B's where
 // needed), and stitches them into a watertight solid. Unlike the triangle-soup CSG this
-// produces a low-face-count result and is sound under chaining. Coplanar (shared-plane)
-// faces are a follow-up — operands that don't share a face plane work today.
+// produces a low-face-count result and is sound under chaining.
 func Boolean(op Op, a, b *topo.Body) (*topo.Body, error) {
+	return BooleanDiag(op, a, b, nil)
+}
+
+// BooleanDiag is [Boolean] with a diagnostic recorder (nil to discard): the tangency-retry
+// last resort records a Defect when it ships, so the displaced-geometry escape hatch is
+// observable instead of silent (#1600).
+func BooleanDiag(op Op, a, b *topo.Body, rec *diag.Recorder) (*topo.Body, error) {
 	fa, oka := facesOf(a)
 	fb, okb := facesOf(b)
 	if !oka || !okb {
@@ -51,7 +58,13 @@ func Boolean(op Op, a, b *topo.Body) (*topo.Body, error) {
 	if err != nil || away.LengthSquared() == 0 {
 		return res, err
 	}
-	return retryNudged(op, fa, fb, a, res, away)
+	// A tangent/grazing contact was hit. The nudged rerun stays the resolution for a GENUINE
+	// tangency — downstream re-welds (facet, fillet) collapse an exactly-coincident seam back
+	// into a non-manifold contact, so the topologically resolved exact result cannot ship yet
+	// (TestTangentContactUnionStaysManifold pins that contract) — but it is no longer silent:
+	// shipping it records a Defect (#1600). Retiring the displaced coordinates entirely needs
+	// the downstream re-welds to respect existing topology; tracked on the issue.
+	return retryNudged(op, fa, fb, a, res, away, rec)
 }
 
 // booleanOnce runs one pass: imprint, split, classify, keep, stitch. The vector is a non-zero
@@ -74,11 +87,19 @@ func booleanOnce(op Op, fa, fb []planarFace, a, b *topo.Body) (*topo.Body, math.
 // the two must move together (#1602).
 const nudgeEps = 10 * planarStitchGrid // tol:calibrated — imprint nudge tied to the planar weld grid
 
+// CodeBooleanNudgedGeometry marks a boolean that shipped the displaced-geometry tangency
+// retry: the topological resolution of a tangent contact failed to close, so the result
+// contains operand B translated by nudgeEps (#1600). A tracked defect — the displaced
+// coordinates poison flush mating, coplanar detection, and exports downstream — kept only as
+// the last resort until the topological path covers every configuration.
+const CodeBooleanNudgedGeometry diag.Code = "boolean.nudged-geometry"
+
 // retryNudged re-runs the boolean with operand B nudged a hair along `away` (out of the
-// tangent contact) so the degenerate touch becomes a clean clearance. It keeps the nudged
-// result only when it is a proper solid, so a nudge that would disconnect the part falls back
-// to the original (topologically resolved) result.
-func retryNudged(op Op, fa, fb []planarFace, a, original *topo.Body, away math.Vector3) (*topo.Body, error) {
+// tangent contact) so the degenerate touch becomes a clean clearance. It is the LAST RESORT
+// behind the topological resolution (#1600): it runs only when the un-nudged result is not a
+// proper solid, and shipping it records a Defect because the output carries the displaced
+// coordinates. A nudge that fails too falls back to the original result.
+func retryNudged(op Op, fa, fb []planarFace, a, original *topo.Body, away math.Vector3, rec *diag.Recorder) (*topo.Body, error) {
 	fbp := translateFaces(fb, away.Scale(nudgeEps))
 	bp, _, err := stitch(planarToSubFaces(fbp), nil) // materialising nudged B: no intersections to name
 	if err != nil || bp == nil {
@@ -88,6 +109,9 @@ func retryNudged(op Op, fa, fb []planarFace, a, original *topo.Body, away math.V
 	if err != nil || res == nil || !res.IsSolid() {
 		return original, nil
 	}
+	rec.Recordf(CodeBooleanNudgedGeometry, diag.Defect,
+		"tangent contact did not resolve topologically: shipping operand B displaced by %g along (%g, %g, %g)",
+		nudgeEps, float64(away.X), float64(away.Y), float64(away.Z))
 	return res, nil
 }
 

--- a/kernel/brep/boolean_classify.go
+++ b/kernel/brep/boolean_classify.go
@@ -34,7 +34,12 @@ func insideSolid(b *topo.Body, p math.Point3) bool {
 	for _, f := range faces {
 		sum += faceSolidAngle(f, p, onPlane)
 	}
-	return sum > insideSolidWindingThreshold
+	// |sum|: membership of the CLOSED REGION is orientation-independent, and legacy builders can
+	// emit a consistently inside-out body (loops wound opposite their outward normals — the
+	// buildPrism CW-poly class found while fixing #1600). The magnitude reads ~4π inside such a
+	// body either way; a signed threshold would write its entire interior off as outside, which
+	// the (orientation-blind) parity ray never did.
+	return stdmath.Abs(sum) > insideSolidWindingThreshold
 }
 
 // faceSolidAngle sums the signed solid angle every loop of the planar face subtends at p, fanning

--- a/kernel/brep/boolean_classify_test.go
+++ b/kernel/brep/boolean_classify_test.go
@@ -97,3 +97,23 @@ func TestInsideSolidEdgeGrazingDirection(t *testing.T) {
 		t.Errorf("exterior point %v (old ray through a corner) classified inside", outside)
 	}
 }
+
+// TestInsideSolidToleratesInsideOutBody: membership of the closed REGION is orientation-
+// independent, and legacy builders emitted consistently inside-out bodies (loops wound opposite
+// their outward normals — the buildPrism CW-poly class, #1600). The classifier must read the
+// magnitude of the winding sum: a signed threshold writes such a body's entire interior off as
+// outside, which mangles any boolean against it.
+func TestInsideSolidToleratesInsideOutBody(t *testing.T) {
+	verts := []math.Point3{
+		math.P3(0, 0, 0), math.P3(2, 0, 0), math.P3(2, 2, 0), math.P3(0, 2, 0),
+		math.P3(0, 0, 2), math.P3(2, 0, 2), math.P3(2, 2, 2), math.P3(0, 2, 2),
+	}
+	facesIn := [][]int{{0, 1, 2, 3}, {4, 7, 6, 5}, {0, 4, 5, 1}, {3, 2, 6, 7}, {0, 3, 7, 4}, {1, 5, 6, 2}} // all wound inward
+	blk := subd.ToBody(subd.Mesh{Verts: verts, Faces: facesIn}, "insideout")
+	if !insideSolid(blk, math.P3(1, 1, 1)) {
+		t.Error("interior point of an inside-out box classified outside (signed-threshold regression)")
+	}
+	if insideSolid(blk, math.P3(5, 5, 5)) {
+		t.Error("exterior point of an inside-out box classified inside")
+	}
+}

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -114,7 +114,7 @@ func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.L
 	if !ok {
 		return booleanCSG(op, target, tool, lin, rec)
 	}
-	body, err := brep.Boolean(bop, target, tool)
+	body, err := brep.BooleanDiag(bop, target, tool, rec)
 	if err != nil {
 		return booleanCSG(op, target, tool, lin, rec) // non-planar operand → triangle CSG
 	}

--- a/kernel/ops/boolean_volume_guard_test.go
+++ b/kernel/ops/boolean_volume_guard_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 )
@@ -47,5 +48,26 @@ func TestBooleanVolumeGuardTwoSided(t *testing.T) {
 		if got := invalidBooleanVolume(c.op, target, tool, c.result); got != c.invalid {
 			t.Errorf("%s: invalidBooleanVolume = %v, want %v", c.name, got, c.invalid)
 		}
+	}
+}
+
+// TestTangentUnionRecordsNudgedGeometry pins #1600's visibility guarantee: a union across a
+// tangent (edge-sharing) contact resolves through the nudged retry — the result carries operand
+// B displaced by the nudge — and that MUST surface as a boolean.nudged-geometry Defect instead of
+// shipping silently. (Retiring the displacement itself needs the downstream re-welds to respect
+// existing topology; tracked on the issue.)
+func TestTangentUnionRecordsNudgedGeometry(t *testing.T) {
+	a := guardBlock(t, math.P3(0, 0, 0), math.P3(2, 2, 2), "a")
+	b := guardBlock(t, math.P3(2, 2, 0), math.P3(4, 4, 2), "b") // shares only the vertical edge x=2,y=2
+	rec := &diag.Recorder{}
+	res, err := BooleanWithDiagnostics(Join, a, b, rec)
+	if err != nil {
+		t.Fatalf("tangent union: %v", err)
+	}
+	if res == nil || !res.IsSolid() {
+		t.Fatal("tangent union did not produce a solid")
+	}
+	if !rec.Has(brep.CodeBooleanNudgedGeometry) {
+		t.Errorf("tangent union shipped without a %q diagnostic; got %v", brep.CodeBooleanNudgedGeometry, rec.Records())
 	}
 }

--- a/model/feature/extrude.go
+++ b/model/feature/extrude.go
@@ -223,6 +223,15 @@ func appendCombined(running []*topo.Body, res *topo.Body) []*topo.Body {
 // draft outward (positive) or inward (negative); the far cap stays perpendicular to the
 // normal, and each side stays a planar trapezoid.
 func buildPrism(poly []math.Point2, plane sketch.Plane, sp span, taper float64, feat string) *topo.Body {
+	// Normalise the cross-section to CCW: a CW input (a chamfer wedge whose edge frame happens to
+	// wind that way) previously produced a topologically INSIDE-OUT prism — outward face normals
+	// with loops traversed clockwise about them — which the orientation-faithful winding
+	// classifier (#1599) reads as an empty solid and the boolean then mangles (#1600). One
+	// canonical winding makes every downstream orientation decision (caps, sides, taper offset)
+	// consistent by construction.
+	if outwardSign(poly) < 0 {
+		poly = reversePoly(poly)
+	}
 	n := len(poly)
 	normal := plane.Normal().AsVector()
 	topPoly := taperedLoop(poly, sp.depth(), taper)
@@ -239,6 +248,15 @@ func buildPrism(poly []math.Point2, plane sketch.Plane, sp span, taper float64, 
 	addCaps(bld, bottom, top, be, te, normal, feat)
 	addSides(bld, bottom, top, be, te, ve, outwardSign(poly), feat)
 	return bld.Build()
+}
+
+// reversePoly returns the polygon with its winding reversed.
+func reversePoly(poly []math.Point2) []math.Point2 {
+	out := make([]math.Point2, len(poly))
+	for i, p := range poly {
+		out[len(poly)-1-i] = p
+	}
+	return out
 }
 
 // taperedLoop returns the far-loop polygon: poly unchanged when taper is 0, else each


### PR DESCRIPTION
## What

The tangent-contact retry re-runs the boolean with operand B translated by `nudgeEps` (0.1 µm) and shipped the displaced result **silently**. Making it observable (the A4 ask) exposed a deeper pre-existing bug that the retired parity classifier had masked and that the winding classifier (#1599) had just turned into a develop-wide regression:

- **`buildPrism` emitted inside-out solids for CW cross-section polygons** (outward normals, loops traversed CW about them). Chamfer wedges from certain edge frames are exactly that. The orientation-faithful winding classifier read such tools as empty, the kept fragment set went inconsistent, the stitch saw phantom >2-use tangent contacts, and the nudge shipped displaced garbage — holed caps + micro sliver walls — breaking the **chamfer / delete-face-heal / simplify families on develop** (≈10 tests; both prior PRs' CI missed the interaction because their branches were green independently). `buildPrism` now normalises to CCW at the source.
- **`insideSolid` thresholds |sum|**: region membership is orientation-independent; a signed threshold writes an inside-out operand's whole interior off as outside.
- **The nudge is now recorded, never silent**: `brep.BooleanDiag` records a `boolean.nudged-geometry` **Defect** whenever the displaced result ships; `kernel/ops` threads its recorder through, so it reaches feature diagnostics and the API via the #1601 channel.

## What deliberately does NOT change

The nudge remains the resolution for **genuine** tangencies: shipping the exact, topologically-resolved coincident seam breaks downstream re-welds (facet/fillet collapse it back into a non-manifold contact — `TestTangentContactUnionStaysManifold` pins that contract; a prefer-exact gate was tried and reverted against it). Retiring the displaced coordinates entirely (the issue's end state) requires downstream re-welds to respect existing topology — left open on #1600, which stays open.

## Tests

- `TestInsideSolidToleratesInsideOutBody` — inside-out box classifies by region.
- `TestTangentUnionRecordsNudgedGeometry` — an edge-sharing union resolves via the nudge AND surfaces the Defect.
- The previously-red develop family (chamfer modes/corner/miter, delete-face heal ×4, simplify, app tools) is back green; full suite green; `golangci-lint` 0 issues.

## Live test

counterbore, faceplate, squatrim, facetdiag drivers all PASS against the running app.

Part of #1600

🤖 Generated with [Claude Code](https://claude.com/claude-code)