### PR TITLE
Archguard: allowlist every first-party import edge (audit B12)

### DIFF
--- a/archguard/edge_allowlist_test.go
+++ b/archguard/edge_allowlist_test.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package archguard
+
+import (
+	"os/exec"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// The edge allowlist (#1623, audit B12): every import between first-party package trees
+// must be declared here, so a new dependency edge is an explicit architecture decision
+// (a row in this table, reviewed) instead of a convenient import nobody notices. The
+// table is seeded from the INTENDED architecture — the two edges the 2026-07 audit found
+// inverted are marked TODO with the issue that owns removing them, so the debt stays
+// visible where it is enforced.
+//
+// Granularity: one row per top-level tree (addin/* split per subpackage — the router's
+// allowances must not leak to the other add-in infrastructure). Direct imports are
+// checked, which fully governs the transitive graph too: third-party packages cannot
+// import oblikovati.org, so every first-party dependency chain is a walk over the edges
+// in this table. TestDomainPackagesAreGpuFree (boundary_test.go) stays as the transitive
+// belt-and-braces for the domain roots.
+var allowedTreeImports = map[string][]string{
+	// Domain (ADR-0014: pure, headless, cgo-free; also held by TestDomainPackagesAreGpuFree).
+	"kernel": {"api", "build", "math"},
+	"model": {"api", "build", "event", "kernel", "math", "solve",
+		// TODO(B4 #1615): INVERSION — the domain must not depend on the persistence
+		// layer; yamlcodec moves to a neutral leaf package, then this entry goes.
+		"persistence"},
+	"math":  {},
+	"solve": {"math"},
+
+	// Application & orchestration.
+	"app": {"addincat", "api", "build", "clientgraphics", "command", "event", "kernel",
+		"math", "model", "osfont", "persistence", "renderer", "report", "scene", "theme",
+		"update", "userconfig"},
+	"command": {"model"},
+	"event":   {},
+	"script":  {"addin/dispatch", "api", "app"},
+
+	// Persistence & small leaves.
+	"persistence": {"api", "model", "userconfig"},
+	"userconfig":  {},
+	"build":       {},
+	"crcpost":     {},
+	"perf":        {},
+	"release":     {},
+	"report":      {"crcpost"},
+	"theme":       {"api", "persistence", "userconfig"},
+	"update":      {},
+	"usagestats":  {"crcpost", "persistence"},
+	"addincat":    {"persistence"},
+	// osfont adapts host-installed fonts to the pure text model (model/text); the
+	// dependency points at the domain, never the reverse (ADR-0031).
+	"osfont": {"model"},
+
+	// Presentation (ADR-0014: renderer swappable, scene is its own leaf).
+	"renderer":       {"kernel", "math", "scene"},
+	"scene":          {"math"},
+	"clientgraphics": {"api", "math", "renderer", "scene"},
+
+	// Add-in infrastructure (thin-router rule: the router adapts wire to app/model,
+	// nothing else grows presentation reach).
+	"addin/dispatch":    {},
+	"addin/events":      {"api", "app", "event", "math", "model"},
+	"addin/modelaccess": {"app", "model"},
+	"addin/opregistry":  {"addin/modelaccess", "api", "app", "kernel", "math", "model"},
+	"addin/router": {"addin/modelaccess", "addin/opregistry", "addin/trace", "api", "app",
+		"clientgraphics", "event", "kernel", "math", "model", "osfont", "script",
+		// TODO(B10 #1621): the router reaches renderer/scene internals for lighting/
+		// environment state; app-owned value types replace these, then both entries go.
+		"renderer", "scene"},
+	"addin/trace": {"api"},
+
+	// Composition roots may reach anything below them.
+	"cmd": {"addin/opregistry", "addin/router", "api", "app", "build", "kernel", "math",
+		"model", "perf", "persistence", "release", "script", "update"},
+
+	// The guard itself (shells out to go list; imports nothing first-party).
+	"archguard": {},
+}
+
+// unenforcedTrees are checked-in trees that hold no shipped code: disposable experiments
+// and test fixtures may import whatever they need without a table row.
+var unenforcedTrees = map[string]bool{"experiments": true, "test-utilities": true}
+
+// TestFirstPartyImportEdgesAreAllowlisted walks the DIRECT import edges of every
+// first-party package (one `go list` invocation) and fails on any tree-to-tree edge
+// missing from allowedTreeImports — including a tree with no row at all, so a new
+// top-level package must declare its dependencies to exist.
+func TestFirstPartyImportEdgesAreAllowlisted(t *testing.T) {
+	for pkg, imports := range firstPartyImports(t) {
+		src := packageTree(pkg)
+		if unenforcedTrees[src] {
+			continue
+		}
+		allowed, known := allowedTreeImports[src]
+		if !known {
+			t.Errorf("package %s belongs to tree %q which has no row in allowedTreeImports — "+
+				"declare the tree's allowed imports in archguard/edge_allowlist_test.go (#1623).", pkg, src)
+			continue
+		}
+		reportForbiddenEdges(t, pkg, src, imports, allowed)
+	}
+}
+
+// reportForbiddenEdges fails on every import of pkg that crosses trees without a row.
+func reportForbiddenEdges(t *testing.T, pkg, src string, imports, allowed []string) {
+	for _, imp := range imports {
+		dst := packageTree(imp)
+		if dst == src {
+			continue
+		}
+		if !slices.Contains(allowed, dst) {
+			t.Errorf("%s imports %s: edge %q -> %q is not in allowedTreeImports — either the "+
+				"import is an architecture violation, or the edge is a deliberate decision that "+
+				"belongs in the table with a comment (#1623).", pkg, imp, src, dst)
+		}
+	}
+}
+
+// packageTree maps an import path to its allowlist row: the top-level directory, except
+// addin/* which is split one level deeper (the router's allowances are its own).
+func packageTree(importPath string) string {
+	p := strings.TrimPrefix(importPath, "oblikovati.org/")
+	parts := strings.Split(p, "/")
+	if parts[0] == "addin" && len(parts) > 1 {
+		return parts[0] + "/" + parts[1]
+	}
+	return parts[0]
+}
+
+// firstPartyImports returns, for every first-party package, its DIRECT first-party
+// imports — one `go list` invocation over the module (F.I.R.S.T-fast, no per-package
+// process spawns).
+func firstPartyImports(t *testing.T) map[string][]string {
+	t.Helper()
+	cmd := exec.Command("go", "list", "-f", `{{.ImportPath}} {{join .Imports " "}}`, "./...")
+	cmd.Dir = ".."
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("go list -f imports ./... : %v", err)
+	}
+	return parseImportLines(string(out))
+}
+
+// parseImportLines keeps only oblikovati.org packages and their oblikovati.org imports.
+func parseImportLines(out string) map[string][]string {
+	edges := map[string][]string{}
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 || !strings.HasPrefix(fields[0], "oblikovati.org/") {
+			continue
+		}
+		var deps []string
+		for _, imp := range fields[1:] {
+			if strings.HasPrefix(imp, "oblikovati.org/") {
+				deps = append(deps, imp)
+			}
+		}
+		edges[fields[0]] = deps
+	}
+	return edges
+}


### PR DESCRIPTION
## What

Closes #1623 (audit B12).

`archguard/edge_allowlist_test.go` holds the full first-party import graph as an explicit allowlist: one row per package tree (with `addin/*` split per subpackage so the router's allowances stay its own), checked against the DIRECT import edges from a single `go list -f '{{.ImportPath}} {{.Imports}}' ./...` invocation. A package in a tree with no row, or an import crossing trees without an entry, is a red build naming the offending package pair.

The table is seeded from the **intended** architecture, and the audit's two live inversions are TODO rows tied to their owning issues rather than silently blessed:

- `model → persistence` — TODO(B4 #1615): the domain must not depend on the persistence layer; deleting the row is that issue's definition of done.
- `addin/router → renderer|scene` — TODO(B10 #1621): app-owned lighting/environment value types replace the direct reach.

Deliberate-but-unusual edges carry their rationale in place (`osfont → model/text` pure-model adaptation per ADR-0031, composition-root breadth for `cmd`/`app`), so the table doubles as living architecture documentation, per the issue.

## Why direct edges, not `-deps`

Third-party packages cannot import `oblikovati.org`, so every first-party transitive chain is a walk over direct first-party edges — a flat table over direct imports fully governs the transitive graph while keeping failures attributable to the exact import that created them. `TestDomainPackagesAreGpuFree` stays untouched as the domain roots' transitive belt-and-braces.

`experiments/` and `test-utilities/` are exempt (no shipped code).

## Verification

- Green on the current graph (0.3s, one `go list` process — F.I.R.S.T-fast).
- Red-verified: a probe `event → math` import fails with the package pair and remediation named; removing it restores green. (Note: like the existing boundary tests, a *cached* local `go test` run can miss a just-added edge since the graph lives outside the package; CI always runs uncached.)
- `golangci-lint` 0 issues.

Remaining B12 acceptance items owned elsewhere, as the issue anticipates: the B7 wire-literal grep (#1618) and the `boundary_test.go` add-in-deferral comment update land with B3 (#1614).

🤖 Generated with [Claude Code](https://claude.com/claude-code)