### PR TITLE
2D constraint-kind coverage guard; wire the smooth (G2) constraint it caught (audit S8)

### DIFF
--- a/addin/router/sketch2d_constraints_coverage_test.go
+++ b/addin/router/sketch2d_constraints_coverage_test.go
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"fmt"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// The 2D twin of the sketch3d declared-kind coverage guard (#1643, audit S8): every
+// GeometricConstraintKind declared in api/types must be accepted end-to-end by
+// sketch.addConstraint, or carry an explicit justification below — never a silent gap.
+//
+// Retro-verification: run against the pre-#1574 code shape this fails on "symmetry"
+// (enumerable-but-not-creatable — the exact bug class this guard exists to prevent),
+// and on the pre-#1643 shape it fails on "smooth" (the gap closed alongside this file).
+
+// constraint2DFixture builds the minimal geometry for one kind and returns the
+// addConstraint entity refs (plus optional clientId/name for the custom kind).
+type constraint2DFixture func(t *testing.T, r *Router, s *app.Session) []uint64
+
+// addEntity2D posts one sketch.addEntity call and returns the new entity's id.
+func addEntity2D(t *testing.T, r *Router, s *app.Session, args string) uint64 {
+	t.Helper()
+	var res wire.AddSketchEntityResult
+	call(t, r, s, "sketch.addEntity", args, &res)
+	return res.EntityID
+}
+
+// twoLines2D builds two non-parallel lines and returns their entity ids.
+func twoLines2D(t *testing.T, r *Router, s *app.Session) []uint64 {
+	t.Helper()
+	return []uint64{
+		addEntity2D(t, r, s, `{"sketchIndex":0,"kind":"line","points":[[10,0],[11,0]]}`),
+		addEntity2D(t, r, s, `{"sketchIndex":0,"kind":"line","points":[[10,1],[11,2]]}`),
+	}
+}
+
+// nPoints2D builds n standalone points and returns their ids.
+func nPoints2D(n int) constraint2DFixture {
+	return func(t *testing.T, r *Router, s *app.Session) []uint64 {
+		t.Helper()
+		out := make([]uint64, n)
+		for i := range out {
+			out[i] = addEntity2D(t, r, s,
+				fmt.Sprintf(`{"sketchIndex":0,"kind":"point","points":[[%d,%d]]}`, 10+i, 2*i))
+		}
+		return out
+	}
+}
+
+// pointAndLine2D builds a standalone point and a line, point first.
+func pointAndLine2D(t *testing.T, r *Router, s *app.Session) []uint64 {
+	t.Helper()
+	return []uint64{
+		addEntity2D(t, r, s, `{"sketchIndex":0,"kind":"point","points":[[10.5,0.5]]}`),
+		addEntity2D(t, r, s, `{"sketchIndex":0,"kind":"line","points":[[10,0],[11,0]]}`),
+	}
+}
+
+// pointAndCircle2D builds a standalone point and a circle, point first.
+func pointAndCircle2D(t *testing.T, r *Router, s *app.Session) []uint64 {
+	t.Helper()
+	return []uint64{
+		addEntity2D(t, r, s, `{"sketchIndex":0,"kind":"point","points":[[12,0]]}`),
+		addEntity2D(t, r, s, `{"sketchIndex":0,"kind":"circle","variant":"center","points":[[10,0]],"radius":"2 cm"}`),
+	}
+}
+
+// twoCircles2D builds two circles of different radii and returns their ids.
+func twoCircles2D(t *testing.T, r *Router, s *app.Session) []uint64 {
+	t.Helper()
+	return []uint64{
+		addEntity2D(t, r, s, `{"sketchIndex":0,"kind":"circle","variant":"center","points":[[10,0]],"radius":"2 cm"}`),
+		addEntity2D(t, r, s, `{"sketchIndex":0,"kind":"circle","variant":"center","points":[[16,0]],"radius":"1 cm"}`),
+	}
+}
+
+// lineAndCircle2D builds a line clear of a circle and returns [line, circle].
+func lineAndCircle2D(t *testing.T, r *Router, s *app.Session) []uint64 {
+	t.Helper()
+	return []uint64{
+		addEntity2D(t, r, s, `{"sketchIndex":0,"kind":"line","points":[[10,5],[16,5]]}`),
+		addEntity2D(t, r, s, `{"sketchIndex":0,"kind":"circle","variant":"center","points":[[10,0]],"radius":"2 cm"}`),
+	}
+}
+
+// symmetryTrio2D builds two points and the mirror line, in the (a, b, about) order
+// symmetryConstraint expects.
+func symmetryTrio2D(t *testing.T, r *Router, s *app.Session) []uint64 {
+	t.Helper()
+	pts := nPoints2D(2)(t, r, s)
+	return append(pts, addEntity2D(t, r, s, `{"sketchIndex":0,"kind":"line","points":[[13,-1],[13,1]]}`))
+}
+
+// lineAndSpline2D builds a line and a fit spline starting near the line's end —
+// the smooth (G2) fixture; at least one side must be a spline.
+func lineAndSpline2D(t *testing.T, r *Router, s *app.Session) []uint64 {
+	t.Helper()
+	return []uint64{
+		addEntity2D(t, r, s, `{"sketchIndex":0,"kind":"line","points":[[9,0],[10,0]]}`),
+		addEntity2D(t, r, s, `{"sketchIndex":0,"kind":"spline","points":[[10.2,0.1],[11,1],[12,0]]}`),
+	}
+}
+
+// declared2DConstraintFixtures maps every wire-creatable kind to its minimal fixture.
+var declared2DConstraintFixtures = map[types.GeometricConstraintKind]constraint2DFixture{
+	types.GeoConstraintCoincident:    nPoints2D(2),
+	types.GeoConstraintPointOnLine:   pointAndLine2D,
+	types.GeoConstraintMidpoint:      pointAndLine2D,
+	types.GeoConstraintPointOnCircle: pointAndCircle2D,
+	types.GeoConstraintHorizontal:    nPoints2D(2),
+	types.GeoConstraintVertical:      nPoints2D(2),
+	types.GeoConstraintParallel:      twoLines2D,
+	types.GeoConstraintPerpendicular: twoLines2D,
+	types.GeoConstraintCollinear:     twoLines2D,
+	types.GeoConstraintConcentric:    twoCircles2D,
+	types.GeoConstraintEqualLength:   twoLines2D,
+	types.GeoConstraintEqualRadius:   twoCircles2D,
+	types.GeoConstraintTangent:       lineAndCircle2D,
+	types.GeoConstraintSymmetry:      symmetryTrio2D,
+	types.GeoConstraintFix:           nPoints2D(1),
+	types.GeoConstraintSmooth:        lineAndSpline2D,
+	types.GeoConstraintGround:        nPoints2D(1),
+	types.GeoConstraintOffset:        twoLines2D,
+	types.GeoConstraintPattern:       nPoints2D(2),
+	types.GeoConstraintCustom:        nPoints2D(2),
+}
+
+// intentionallyNotWireCreatable2D are declared kinds that sketch.addConstraint must NOT
+// accept, each with the reason — the policy mirror of the 3D guard's tracked list.
+var intentionallyNotWireCreatable2D = map[types.GeometricConstraintKind]string{
+	// The text-box anchor is auto-created with its text box and refuses standalone
+	// deletion (M06-F11, #626); standalone creation would orphan it.
+	types.GeoConstraintTextBox: "auto-created with its text box (M06-F11)",
+	// The sentinel for model constraints with no wire mapping; never a real kind.
+	types.GeoConstraintUnknown: "enumeration sentinel, not a constraint",
+}
+
+// allDeclared2DConstraintKinds mirrors the const block in api/types/sketch.go
+// (Go cannot enumerate constants); keep in sync when the API grows.
+var allDeclared2DConstraintKinds = []types.GeometricConstraintKind{
+	types.GeoConstraintCoincident, types.GeoConstraintPointOnLine, types.GeoConstraintMidpoint,
+	types.GeoConstraintPointOnCircle, types.GeoConstraintHorizontal, types.GeoConstraintVertical,
+	types.GeoConstraintParallel, types.GeoConstraintPerpendicular, types.GeoConstraintCollinear,
+	types.GeoConstraintConcentric, types.GeoConstraintEqualLength, types.GeoConstraintEqualRadius,
+	types.GeoConstraintTangent, types.GeoConstraintSymmetry, types.GeoConstraintFix,
+	types.GeoConstraintSmooth, types.GeoConstraintGround, types.GeoConstraintOffset,
+	types.GeoConstraintPattern, types.GeoConstraintTextBox, types.GeoConstraintCustom,
+	types.GeoConstraintUnknown,
+}
+
+// TestEvery2DConstraintKindAccepted drives sketch.addConstraint for every declared kind
+// with a fixture and asserts the constraint lands with the same kind enumerated back by
+// sketch.constraints.
+func TestEvery2DConstraintKindAccepted(t *testing.T) {
+	for kind, fixture := range declared2DConstraintFixtures {
+		t.Run(string(kind), func(t *testing.T) {
+			r, s := seededSession(t)
+			refs := fixture(t, r, s)
+			var res wire.AddConstraintResult
+			call(t, r, s, "sketch.addConstraint", mustJSON(t, wire.AddConstraintArgs{
+				SketchIndex: 0, Kind: string(kind), Entities: refs,
+				ClientID: "coverage-test", Name: "tag", // read only by the custom kind
+			}), &res)
+			if res.Kind != string(kind) {
+				t.Errorf("addConstraint kind = %q, want %q", res.Kind, kind)
+			}
+			assertEnumerated2DKind(t, r, s, kind)
+		})
+	}
+}
+
+// assertEnumerated2DKind fails unless sketch.constraints lists at least one constraint
+// of the given kind (the custom kind enumerates per its add-in mapping, checked too).
+func assertEnumerated2DKind(t *testing.T, r *Router, s *app.Session, kind types.GeometricConstraintKind) {
+	t.Helper()
+	var cons wire.ListConstraintsResult
+	call(t, r, s, "sketch.constraints", `{"sketchIndex":0}`, &cons)
+	for _, c := range cons.Constraints {
+		if c.Kind == string(kind) {
+			return
+		}
+	}
+	t.Errorf("sketch.constraints lists no %q constraint after addConstraint accepted it", kind)
+}
+
+// TestNotWireCreatable2DKindsRefused pins the policy list: the kinds justified above
+// must actually be refused, so a future implementation removes the entry deliberately.
+func TestNotWireCreatable2DKindsRefused(t *testing.T) {
+	for kind, why := range intentionallyNotWireCreatable2D {
+		t.Run(string(kind), func(t *testing.T) {
+			r, s := seededSession(t)
+			refs := nPoints2D(2)(t, r, s)
+			err := tryCall(t, r, s, "sketch.addConstraint", mustJSON(t, wire.AddConstraintArgs{
+				SketchIndex: 0, Kind: string(kind), Entities: refs,
+			}))
+			if err == nil {
+				t.Errorf("kind %q (%s) was accepted over the wire — implement it deliberately and "+
+					"move it to declared2DConstraintFixtures", kind, why)
+			}
+		})
+	}
+}
+
+// TestDeclared2DConstraintKindsComplete fails when a declared kind is neither covered by
+// a fixture nor justified as not-wire-creatable — the guard that api/types can never
+// again advertise 2D kinds the vertical does not deliver (#1574's bug class).
+func TestDeclared2DConstraintKindsComplete(t *testing.T) {
+	for _, kind := range allDeclared2DConstraintKinds {
+		_, covered := declared2DConstraintFixtures[kind]
+		why, excluded := intentionallyNotWireCreatable2D[kind]
+		switch {
+		case covered && excluded:
+			t.Errorf("kind %q is both covered and excluded (%s) — remove one", kind, why)
+		case !covered && !excluded:
+			t.Errorf("kind %q is declared in api/types but has no fixture and no justification", kind)
+		}
+	}
+}

--- a/addin/router/sketch_constraint_refs.go
+++ b/addin/router/sketch_constraint_refs.go
@@ -159,6 +159,45 @@ func symmetryConstraint(sk *sketch.Sketch, refs []uint64) (sketch.Constraint, bo
 	return sk.GeometricConstraints().AddSymmetry(a, b, about), true, nil
 }
 
+// smoothConstraintFromRefs joins two smooth-capable curves (line/arc/spline, at least
+// one spline) with a G2 constraint at their nearest endpoints — the same join policy as
+// the app tool (sketch.NearestSmoothJoin). Closed the enum-vs-wire drift of #1643: the
+// kind was enumerable and persistable but not wire-creatable.
+func smoothConstraintFromRefs(sk *sketch.Sketch, refs []uint64) (sketch.Constraint, bool, error) {
+	if len(refs) != 2 {
+		return nil, true, fmt.Errorf("sketch.addConstraint: smooth needs 2 curve refs, got %d", len(refs))
+	}
+	c1, err := smoothCurveRef(sk, refs[0])
+	if err != nil {
+		return nil, true, err
+	}
+	c2, err := smoothCurveRef(sk, refs[1])
+	if err != nil {
+		return nil, true, err
+	}
+	if !sketch.HasSplineCurve([]sketch.SmoothCurve{c1, c2}) {
+		return nil, true, fmt.Errorf("sketch.addConstraint: smooth needs at least one spline, got %T and %T", c1, c2)
+	}
+	p1, p2, ok := sketch.NearestSmoothJoin(c1, c2)
+	if !ok {
+		return nil, true, fmt.Errorf("sketch.addConstraint: smooth refs %v have no usable endpoints (degenerate curve)", refs)
+	}
+	return sk.GeometricConstraints().AddSmooth(c1, c2, p1, p2), true, nil
+}
+
+// smoothCurveRef resolves one entity ref to a smooth-capable curve (line/arc/spline).
+func smoothCurveRef(sk *sketch.Sketch, ref uint64) (sketch.SmoothCurve, error) {
+	e, ok := sk.EntityByID(sketch.ID(ref))
+	if !ok {
+		return nil, fmt.Errorf("sketch.addConstraint: no entity with id %d", ref)
+	}
+	c, ok := e.(sketch.SmoothCurve)
+	if !ok {
+		return nil, fmt.Errorf("sketch.addConstraint: entity %d (%T) is not a smooth-capable curve (line/arc/spline)", ref, e)
+	}
+	return c, nil
+}
+
 // fixConstraint grounds a single point.
 func fixConstraint(sk *sketch.Sketch, refs []uint64) (sketch.Constraint, bool, error) {
 	if len(refs) != 1 {

--- a/addin/router/sketch_constraints.go
+++ b/addin/router/sketch_constraints.go
@@ -197,6 +197,8 @@ func mixedConstraint(sk *sketch.Sketch, kind types.GeometricConstraintKind, refs
 		return tangentConstraint(sk, refs)
 	case types.GeoConstraintSymmetry:
 		return symmetryConstraint(sk, refs)
+	case types.GeoConstraintSmooth:
+		return smoothConstraintFromRefs(sk, refs)
 	case types.GeoConstraintFix:
 		return fixConstraint(sk, refs)
 	default:

--- a/app/sketch_constraint_tools.go
+++ b/app/sketch_constraint_tools.go
@@ -192,7 +192,7 @@ func acceptSmoothable(e sketch.Entity) bool {
 // readySmooth needs two smoothable curves, at least one of them a spline.
 func readySmooth(ents []sketch.Entity) bool {
 	curves := smoothCurvesFrom(ents)
-	return len(curves) >= 2 && hasSpline(curves)
+	return len(curves) >= 2 && sketch.HasSplineCurve(curves)
 }
 
 func readyDimension(ents []sketch.Entity) bool {

--- a/app/sketch_constraints.go
+++ b/app/sketch_constraints.go
@@ -204,57 +204,14 @@ func smoothCurvesFrom(ents []sketch.Entity) []sketch.SmoothCurve {
 	return out
 }
 
-// hasSpline reports whether any of the curves is a spline. Smooth (G2) needs a curve
-// with adjustable curvature, so — like Inventor — the tool requires at least one spline.
-func hasSpline(curves []sketch.SmoothCurve) bool {
-	for _, c := range curves {
-		if _, ok := c.(*sketch.Spline); ok {
-			return true
-		}
-	}
-	return false
-}
-
-// curveEndpoints returns a smooth curve's two endpoints (nil for a degenerate spline).
-func curveEndpoints(c sketch.SmoothCurve) (*sketch.Point, *sketch.Point) {
-	switch t := c.(type) {
-	case *sketch.Line:
-		return t.A, t.B
-	case *sketch.Arc:
-		return t.Start, t.End
-	case *sketch.Spline:
-		if len(t.Points) >= 2 {
-			return t.Points[0], t.Points[len(t.Points)-1]
-		}
-	}
-	return nil, nil
-}
-
-// nearestEndpointPair returns the closest endpoint of c1 to an endpoint of c2 — the join
-// the Smooth constraint should make continuous.
-func nearestEndpointPair(c1, c2 sketch.SmoothCurve) (*sketch.Point, *sketch.Point, bool) {
-	a1, b1 := curveEndpoints(c1)
-	a2, b2 := curveEndpoints(c2)
-	if a1 == nil || a2 == nil {
-		return nil, nil, false
-	}
-	best1, best2, bestD := a1, a2, stdmath.Inf(1)
-	for _, p := range []*sketch.Point{a1, b1} {
-		for _, q := range []*sketch.Point{a2, b2} {
-			if d := p.Position().DistanceTo(q.Position()); d < bestD {
-				best1, best2, bestD = p, q, d
-			}
-		}
-	}
-	return best1, best2, true
-}
-
 // applySmooth joins two curves with a smooth (G2, curvature-continuous) constraint at
-// their nearest endpoints — Inventor's Smooth, which needs at least one spline.
+// their nearest endpoints — Inventor's Smooth, which needs at least one spline. The
+// endpoint/spline policy lives with the constraint (sketch.NearestSmoothJoin) so the
+// wire router creates the identical join (#1643).
 func applySmooth(s *Session, ents []sketch.Entity) error {
 	curves := smoothCurvesFrom(ents)
-	if len(curves) >= 2 && hasSpline(curves) {
-		if p1, p2, ok := nearestEndpointPair(curves[0], curves[1]); ok {
+	if len(curves) >= 2 && sketch.HasSplineCurve(curves) {
+		if p1, p2, ok := sketch.NearestSmoothJoin(curves[0], curves[1]); ok {
 			s.geom().AddSmooth(curves[0], curves[1], p1, p2)
 			return s.afterConstraint()
 		}

--- a/model/sketch/constraints_smooth.go
+++ b/model/sketch/constraints_smooth.go
@@ -52,6 +52,54 @@ func (g *GeometricConstraints) AddSmooth(c1, c2 SmoothCurve, p1, p2 *Point) *Smo
 	return c
 }
 
+// SmoothCurveEndpoints returns a smooth curve's two endpoints (nil for a degenerate
+// spline). The join-selection helpers below live with the constraint so every creation
+// surface (app tool, wire router) picks the same join (#1643).
+func SmoothCurveEndpoints(c SmoothCurve) (*Point, *Point) {
+	switch t := c.(type) {
+	case *Line:
+		return t.A, t.B
+	case *Arc:
+		return t.Start, t.End
+	case *Spline:
+		if len(t.Points) >= 2 {
+			return t.Points[0], t.Points[len(t.Points)-1]
+		}
+	}
+	return nil, nil
+}
+
+// NearestSmoothJoin returns the closest endpoint of c1 to an endpoint of c2 — the join
+// the Smooth constraint should make continuous.
+func NearestSmoothJoin(c1, c2 SmoothCurve) (*Point, *Point, bool) {
+	a1, b1 := SmoothCurveEndpoints(c1)
+	a2, b2 := SmoothCurveEndpoints(c2)
+	if a1 == nil || a2 == nil {
+		return nil, nil, false
+	}
+	best1, best2, bestD := a1, a2, stdmath.Inf(1)
+	for _, p := range []*Point{a1, b1} {
+		for _, q := range []*Point{a2, b2} {
+			if d := p.Position().DistanceTo(q.Position()); d < bestD {
+				best1, best2, bestD = p, q, d
+			}
+		}
+	}
+	return best1, best2, true
+}
+
+// HasSplineCurve reports whether any of the curves is a spline. Smooth (G2) needs a
+// curve with adjustable end curvature, so — like the reference tool — creation surfaces
+// require at least one spline.
+func HasSplineCurve(curves []SmoothCurve) bool {
+	for _, c := range curves {
+		if _, ok := c.(*Spline); ok {
+			return true
+		}
+	}
+	return false
+}
+
 // residualAD mirrors the float residual over duals: G0 join coincidence (2), G1 tangent
 // collinearity (1), G2 curvature-vector match (2). The frames carry their own exact
 // derivatives, so the spline circumcircle curvature differentiates by construction.


### PR DESCRIPTION
## What

Closes #1643 (audit S8).

**The guard.** `addin/router/sketch2d_constraints_coverage_test.go` is the 2D twin of the #142 sketch3d guard: every `GeometricConstraintKind` declared in `api/types` is driven end-to-end through the real router (`sketch.addConstraint` → enumerated back out of `sketch.constraints`) from a minimal fixture. All 22 declared kinds are accounted for:

- 20 wire-creatable kinds each have a fixture (the fixtures are named and reusable — the substrate S2's copy-completeness guard can build on);
- `textBox` (auto-created with its text box, M06-F11) and `unknown` (enumeration sentinel) are justified exclusions — and their refusal is itself pinned by `TestNotWireCreatable2DKindsRefused`, so implementing one later forces a deliberate table move;
- a kind added to `api/types` with neither fixture nor justification fails `TestDeclared2DConstraintKindsComplete`.

Retro-verification (documented in the file header): against the pre-#1574 shape this fails on `symmetry`; against yesterday's develop it fails on `smooth`.

**The catch, fixed in place.** The guard's first run surfaced that **smooth (G2) was never wire-creatable**: enumerable, persistable, app-tool-creatable since M21, but `sketch.addConstraint` refused it as `unsupported kind`. Fixed properly rather than allowlisted:

- the endpoint-join policy moved from `app` into the domain (`sketch.SmoothCurveEndpoints`, `sketch.NearestSmoothJoin`, `sketch.HasSplineCurve` in `model/sketch/constraints_smooth.go`), so the app tool and the router create the *identical* join instead of duplicating the policy;
- the router's new `smooth` case resolves two smooth-capable curves, requires at least one spline (two analytic curves can only be G2 when cocircular), and joins at the nearest endpoints; refusals name the offending types.

## Live verification

New bridge driver `mcplive smoothwire` (Oblikovati.AddIns.MCPBridge `add/squatrim-scale-sweep`, PR #85) against the rebuilt running app:

```
smooth accepted over the wire, sketch DOF now 4
splineless smooth refused as expected: sketch.addConstraint: smooth needs at least one spline, got *sketch.Line and *sketch.Line
PASS smoothwire
```

Viewport screenshot checked — sketch renders clean.

## Tests

`go test ./addin/router/ ./app/ ./model/sketch/` green (guard subtests: 20 accepted + 2 refused + completeness), `golangci-lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)