### PR TITLE
Share one parameter/assembly-feature mutation seam between the wire router and the head UI (audit B1)

### DIFF
--- a/addin/router/assembly_features.go
+++ b/addin/router/assembly_features.go
@@ -70,11 +70,7 @@ func assemblyFeaturesAdd(s *app.Session, raw json.RawMessage) (json.RawMessage, 
 	if err != nil {
 		return nil, err
 	}
-	af, err := s.CommitAssemblyFeature(cut, "Add Assembly Feature")
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
+	return commitAssemblyFeatureResult(s, asm, cut, "Add Assembly Feature")
 }
 
 // assemblyFeaturesAddProxyCut adds a feature whose tool is the proxied geometry of the
@@ -97,11 +93,7 @@ func assemblyFeaturesAddProxyCut(s *app.Session, raw json.RawMessage) (json.RawM
 	if !ok {
 		return nil, fmt.Errorf("%s: no occurrence with id %d in the assembly", wire.MethodAssemblyFeaturesAddProxyCut, in.Source)
 	}
-	af, err := s.CommitAssemblyFeature(feature.NewAssemblyProxyCutFeature(source, op), "Add Assembly Feature")
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
+	return commitAssemblyFeatureResult(s, asm, feature.NewAssemblyProxyCutFeature(source, op), "Add Assembly Feature")
 }
 
 // assemblyFeaturesAddExtrude extrudes a closed sketch profile (authored on an assembly
@@ -127,11 +119,7 @@ func assemblyFeaturesAddExtrude(s *app.Session, raw json.RawMessage) (json.RawMe
 		return nil, fmt.Errorf("%s: distance %g must be positive", wire.MethodAssemblyFeaturesAddExtrude, in.Distance)
 	}
 	distance := in.Distance
-	af, err := s.CommitAssemblyFeature(feature.NewAssemblyExtrudeFeature(sk, in.ProfileIndex, op, func() float64 { return distance }), "Extrude")
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
+	return commitAssemblyFeatureResult(s, asm, feature.NewAssemblyExtrudeFeature(sk, in.ProfileIndex, op, func() float64 { return distance }), "Extrude")
 }
 
 // assemblyFeaturesAddRevolve revolves a closed sketch profile (authored on an assembly
@@ -159,11 +147,7 @@ func assemblyFeaturesAddRevolve(s *app.Session, raw json.RawMessage) (json.RawMe
 		return nil, err
 	}
 	angle := in.Angle
-	af, err := s.CommitAssemblyFeature(feature.NewAssemblyRevolveFeature(sk, in.ProfileIndex, axis, op, func() float64 { return angle }), "Add Assembly Feature")
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
+	return commitAssemblyFeatureResult(s, asm, feature.NewAssemblyRevolveFeature(sk, in.ProfileIndex, axis, op, func() float64 { return angle }), "Add Assembly Feature")
 }
 
 // revolveAxisFromArgs builds the assembly-space revolve axis from the request's origin and
@@ -202,11 +186,7 @@ func assemblyFeaturesAddSweep(s *app.Session, raw json.RawMessage) (json.RawMess
 	if err != nil {
 		return nil, err
 	}
-	af, err := s.CommitAssemblyFeature(feature.NewAssemblySweepFeature(sk, in.ProfileIndex, op, path), "Sweep")
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
+	return commitAssemblyFeatureResult(s, asm, feature.NewAssemblySweepFeature(sk, in.ProfileIndex, op, path), "Sweep")
 }
 
 // assemblySweepPath converts a wire path polyline to assembly-space points, requiring at
@@ -240,11 +220,7 @@ func assemblyFeaturesAddChamfer(s *app.Session, raw json.RawMessage) (json.RawMe
 		return nil, err
 	}
 	dist := in.Distance
-	af, err := s.CommitAssemblyFeature(feature.NewAssemblyChamferFeature(suffixes, func() float64 { return dist }), "Chamfer")
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
+	return commitAssemblyFeatureResult(s, asm, feature.NewAssemblyChamferFeature(suffixes, func() float64 { return dist }), "Chamfer")
 }
 
 // assemblyFeaturesAddFillet rounds picked component edges on every participant.
@@ -265,11 +241,7 @@ func assemblyFeaturesAddFillet(s *app.Session, raw json.RawMessage) (json.RawMes
 		return nil, err
 	}
 	r := in.Radius
-	af, err := s.CommitAssemblyFeature(feature.NewAssemblyFilletFeature(suffixes, func() float64 { return r }), "Fillet")
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
+	return commitAssemblyFeatureResult(s, asm, feature.NewAssemblyFilletFeature(suffixes, func() float64 { return r }), "Fillet")
 }
 
 // assemblyFeaturesAddMoveFace translates picked component faces on every participant.
@@ -287,11 +259,7 @@ func assemblyFeaturesAddMoveFace(s *app.Session, raw json.RawMessage) (json.RawM
 		return nil, err
 	}
 	delta := math.V3(in.Translation[0], in.Translation[1], in.Translation[2])
-	af, err := s.CommitAssemblyFeature(feature.NewAssemblyMoveFaceFeature(suffixes, delta), "Move Face")
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
+	return commitAssemblyFeatureResult(s, asm, feature.NewAssemblyMoveFaceFeature(suffixes, delta), "Move Face")
 }
 
 // assemblyEdgeSuffixes resolves each edge ref to a component-local lineage suffix, after
@@ -390,11 +358,7 @@ func assemblyFeaturesAddHole(s *app.Session, raw json.RawMessage) (json.RawMessa
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", wire.MethodAssemblyFeaturesAddHole, err)
 	}
-	af, err := s.CommitAssemblyFeature(hole, "Hole")
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
+	return commitAssemblyFeatureResult(s, asm, hole, "Hole")
 }
 
 // assemblyFeaturesSetParticipants replaces a feature's participation set.
@@ -415,13 +379,10 @@ func assemblyFeaturesSetParticipants(s *app.Session, raw json.RawMessage) (json.
 	if err != nil {
 		return nil, err
 	}
-	if err := s.CommitAssemblyFeatureChange("Edit Participants", func(*compdef.AssemblyComponentDefinition) error {
+	return commitAssemblyProgramChange(s, "Edit Participants", func(*compdef.AssemblyComponentDefinition) error {
 		af.SetParticipants(occs)
 		return nil
-	}); err != nil {
-		return nil, err
-	}
-	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
+	}, func() any { return wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)} })
 }
 
 // assemblyFeaturesSetParticipantPaths restricts a feature to specific nested occurrence
@@ -443,13 +404,10 @@ func assemblyFeaturesSetParticipantPaths(s *app.Session, raw json.RawMessage) (j
 	if err != nil {
 		return nil, err
 	}
-	if err := s.CommitAssemblyFeatureChange("Edit Participants", func(*compdef.AssemblyComponentDefinition) error {
+	return commitAssemblyProgramChange(s, "Edit Participants", func(*compdef.AssemblyComponentDefinition) error {
 		af.SetParticipantPaths(paths)
 		return nil
-	}); err != nil {
-		return nil, err
-	}
-	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
+	}, func() any { return wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)} })
 }
 
 // resolveParticipantPaths validates each instance-name path resolves to an occurrence
@@ -494,13 +452,10 @@ func assemblyFeaturesEdit(s *app.Session, raw json.RawMessage) (json.RawMessage,
 	if err != nil {
 		return nil, err
 	}
-	if err := s.CommitAssemblyFeatureChange("Edit Assembly Feature", func(*compdef.AssemblyComponentDefinition) error {
+	return commitAssemblyProgramChange(s, "Edit Assembly Feature", func(*compdef.AssemblyComponentDefinition) error {
 		apply()
 		return nil
-	}); err != nil {
-		return nil, err
-	}
-	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
+	}, func() any { return wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)} })
 }
 
 // assemblyFeaturesSetSuppressed suppresses or unsuppresses the named features in batch.
@@ -513,17 +468,14 @@ func assemblyFeaturesSetSuppressed(s *app.Session, raw json.RawMessage) (json.Ra
 	if err := decode(raw, &in); err != nil {
 		return nil, err
 	}
-	if err := s.CommitAssemblyFeatureChange("Suppress Assembly Feature", func(a *compdef.AssemblyComponentDefinition) error {
+	return commitAssemblyProgramChange(s, "Suppress Assembly Feature", func(a *compdef.AssemblyComponentDefinition) error {
 		if in.Suppressed {
 			a.Features().SuppressFeatures(in.IDs...)
 		} else {
 			a.Features().UnsuppressFeatures(in.IDs...)
 		}
 		return nil
-	}); err != nil {
-		return nil, err
-	}
-	return json.Marshal(assemblyFeaturesResult(asm))
+	}, func() any { return assemblyFeaturesResult(asm) })
 }
 
 // assemblyGetEndOfFeatures returns the active assembly's rollback-marker state.
@@ -546,13 +498,29 @@ func assemblySetEndOfFeatures(s *app.Session, raw json.RawMessage) (json.RawMess
 	if err := decode(raw, &in); err != nil {
 		return nil, err
 	}
-	if err := s.CommitAssemblyFeatureChange("Set End of Features", func(a *compdef.AssemblyComponentDefinition) error {
+	return commitAssemblyProgramChange(s, "Set End of Features", func(a *compdef.AssemblyComponentDefinition) error {
 		a.Features().SetEndOfFeatures(in.Position)
 		return nil
-	}); err != nil {
+	}, func() any { return assemblyFeaturesResult(asm) })
+}
+
+// commitAssemblyFeatureResult finishes an add handler through the shared
+// Session verb and renders the hosted feature (#1612).
+func commitAssemblyFeatureResult(s *app.Session, asm *compdef.AssemblyComponentDefinition, f feature.Feature, label string) (json.RawMessage, error) {
+	af, err := s.CommitAssemblyFeature(f, label)
+	if err != nil {
 		return nil, err
 	}
-	return json.Marshal(assemblyFeaturesResult(asm))
+	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
+}
+
+// commitAssemblyProgramChange finishes an in-place program edit through the
+// shared Session verb and renders the refreshed result (#1612).
+func commitAssemblyProgramChange(s *app.Session, label string, mutate func(*compdef.AssemblyComponentDefinition) error, render func() any) (json.RawMessage, error) {
+	if err := s.CommitAssemblyFeatureChange(label, mutate); err != nil {
+		return nil, err
+	}
+	return json.Marshal(render())
 }
 
 // assemblyCutFromArgs builds the assembly-space box-tool cut feature from the request.

--- a/addin/router/assembly_features.go
+++ b/addin/router/assembly_features.go
@@ -70,15 +70,16 @@ func assemblyFeaturesAdd(s *app.Session, raw json.RawMessage) (json.RawMessage, 
 	if err != nil {
 		return nil, err
 	}
-	af := asm.AddFeature(cut)
-	af.SetName(asm.Features().UniqueName(af.Kind()))
-	asm.RecomputeFeatures()
+	af, err := s.CommitAssemblyFeature(cut, "Add Assembly Feature")
+	if err != nil {
+		return nil, err
+	}
 	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
 }
 
 // assemblyFeaturesAddProxyCut adds a feature whose tool is the proxied geometry of the
-// source occurrence, re-resolved each rebuild. The source is excluded from the new
-// feature's default participation — a component does not machine itself.
+// source occurrence, re-resolved each rebuild. The self-machining exclusion (a component
+// does not machine itself) is the aggregate's AddFeature policy (#1612).
 func assemblyFeaturesAddProxyCut(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	asm, err := modelaccess.ActiveAssembly(s)
 	if err != nil {
@@ -96,10 +97,10 @@ func assemblyFeaturesAddProxyCut(s *app.Session, raw json.RawMessage) (json.RawM
 	if !ok {
 		return nil, fmt.Errorf("%s: no occurrence with id %d in the assembly", wire.MethodAssemblyFeaturesAddProxyCut, in.Source)
 	}
-	af := asm.AddFeature(feature.NewAssemblyProxyCutFeature(source, op))
-	af.RemoveParticipant(source)
-	af.SetName(asm.Features().UniqueName(af.Kind()))
-	asm.RecomputeFeatures()
+	af, err := s.CommitAssemblyFeature(feature.NewAssemblyProxyCutFeature(source, op), "Add Assembly Feature")
+	if err != nil {
+		return nil, err
+	}
 	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
 }
 
@@ -126,9 +127,10 @@ func assemblyFeaturesAddExtrude(s *app.Session, raw json.RawMessage) (json.RawMe
 		return nil, fmt.Errorf("%s: distance %g must be positive", wire.MethodAssemblyFeaturesAddExtrude, in.Distance)
 	}
 	distance := in.Distance
-	af := asm.AddFeature(feature.NewAssemblyExtrudeFeature(sk, in.ProfileIndex, op, func() float64 { return distance }))
-	af.SetName(asm.Features().UniqueName(af.Kind()))
-	asm.RecomputeFeatures()
+	af, err := s.CommitAssemblyFeature(feature.NewAssemblyExtrudeFeature(sk, in.ProfileIndex, op, func() float64 { return distance }), "Extrude")
+	if err != nil {
+		return nil, err
+	}
 	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
 }
 
@@ -157,9 +159,10 @@ func assemblyFeaturesAddRevolve(s *app.Session, raw json.RawMessage) (json.RawMe
 		return nil, err
 	}
 	angle := in.Angle
-	af := asm.AddFeature(feature.NewAssemblyRevolveFeature(sk, in.ProfileIndex, axis, op, func() float64 { return angle }))
-	af.SetName(asm.Features().UniqueName(af.Kind()))
-	asm.RecomputeFeatures()
+	af, err := s.CommitAssemblyFeature(feature.NewAssemblyRevolveFeature(sk, in.ProfileIndex, axis, op, func() float64 { return angle }), "Add Assembly Feature")
+	if err != nil {
+		return nil, err
+	}
 	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
 }
 
@@ -199,9 +202,10 @@ func assemblyFeaturesAddSweep(s *app.Session, raw json.RawMessage) (json.RawMess
 	if err != nil {
 		return nil, err
 	}
-	af := asm.AddFeature(feature.NewAssemblySweepFeature(sk, in.ProfileIndex, op, path))
-	af.SetName(asm.Features().UniqueName(af.Kind()))
-	asm.RecomputeFeatures()
+	af, err := s.CommitAssemblyFeature(feature.NewAssemblySweepFeature(sk, in.ProfileIndex, op, path), "Sweep")
+	if err != nil {
+		return nil, err
+	}
 	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
 }
 
@@ -236,9 +240,10 @@ func assemblyFeaturesAddChamfer(s *app.Session, raw json.RawMessage) (json.RawMe
 		return nil, err
 	}
 	dist := in.Distance
-	af := asm.AddFeature(feature.NewAssemblyChamferFeature(suffixes, func() float64 { return dist }))
-	af.SetName(asm.Features().UniqueName(af.Kind()))
-	asm.RecomputeFeatures()
+	af, err := s.CommitAssemblyFeature(feature.NewAssemblyChamferFeature(suffixes, func() float64 { return dist }), "Chamfer")
+	if err != nil {
+		return nil, err
+	}
 	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
 }
 
@@ -260,9 +265,10 @@ func assemblyFeaturesAddFillet(s *app.Session, raw json.RawMessage) (json.RawMes
 		return nil, err
 	}
 	r := in.Radius
-	af := asm.AddFeature(feature.NewAssemblyFilletFeature(suffixes, func() float64 { return r }))
-	af.SetName(asm.Features().UniqueName(af.Kind()))
-	asm.RecomputeFeatures()
+	af, err := s.CommitAssemblyFeature(feature.NewAssemblyFilletFeature(suffixes, func() float64 { return r }), "Fillet")
+	if err != nil {
+		return nil, err
+	}
 	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
 }
 
@@ -281,9 +287,10 @@ func assemblyFeaturesAddMoveFace(s *app.Session, raw json.RawMessage) (json.RawM
 		return nil, err
 	}
 	delta := math.V3(in.Translation[0], in.Translation[1], in.Translation[2])
-	af := asm.AddFeature(feature.NewAssemblyMoveFaceFeature(suffixes, delta))
-	af.SetName(asm.Features().UniqueName(af.Kind()))
-	asm.RecomputeFeatures()
+	af, err := s.CommitAssemblyFeature(feature.NewAssemblyMoveFaceFeature(suffixes, delta), "Move Face")
+	if err != nil {
+		return nil, err
+	}
 	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
 }
 
@@ -383,9 +390,10 @@ func assemblyFeaturesAddHole(s *app.Session, raw json.RawMessage) (json.RawMessa
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", wire.MethodAssemblyFeaturesAddHole, err)
 	}
-	af := asm.AddFeature(hole)
-	af.SetName(asm.Features().UniqueName(af.Kind()))
-	asm.RecomputeFeatures()
+	af, err := s.CommitAssemblyFeature(hole, "Hole")
+	if err != nil {
+		return nil, err
+	}
 	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
 }
 
@@ -407,8 +415,12 @@ func assemblyFeaturesSetParticipants(s *app.Session, raw json.RawMessage) (json.
 	if err != nil {
 		return nil, err
 	}
-	af.SetParticipants(occs)
-	asm.RecomputeFeatures()
+	if err := s.CommitAssemblyFeatureChange("Edit Participants", func(*compdef.AssemblyComponentDefinition) error {
+		af.SetParticipants(occs)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
 	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
 }
 
@@ -431,8 +443,12 @@ func assemblyFeaturesSetParticipantPaths(s *app.Session, raw json.RawMessage) (j
 	if err != nil {
 		return nil, err
 	}
-	af.SetParticipantPaths(paths)
-	asm.RecomputeFeatures()
+	if err := s.CommitAssemblyFeatureChange("Edit Participants", func(*compdef.AssemblyComponentDefinition) error {
+		af.SetParticipantPaths(paths)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
 	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
 }
 
@@ -478,8 +494,12 @@ func assemblyFeaturesEdit(s *app.Session, raw json.RawMessage) (json.RawMessage,
 	if err != nil {
 		return nil, err
 	}
-	apply()
-	asm.RecomputeFeatures()
+	if err := s.CommitAssemblyFeatureChange("Edit Assembly Feature", func(*compdef.AssemblyComponentDefinition) error {
+		apply()
+		return nil
+	}); err != nil {
+		return nil, err
+	}
 	return json.Marshal(wire.AssemblyFeatureResult{Feature: assemblyFeatureInfo(asm, af)})
 }
 
@@ -493,12 +513,16 @@ func assemblyFeaturesSetSuppressed(s *app.Session, raw json.RawMessage) (json.Ra
 	if err := decode(raw, &in); err != nil {
 		return nil, err
 	}
-	if in.Suppressed {
-		asm.Features().SuppressFeatures(in.IDs...)
-	} else {
-		asm.Features().UnsuppressFeatures(in.IDs...)
+	if err := s.CommitAssemblyFeatureChange("Suppress Assembly Feature", func(a *compdef.AssemblyComponentDefinition) error {
+		if in.Suppressed {
+			a.Features().SuppressFeatures(in.IDs...)
+		} else {
+			a.Features().UnsuppressFeatures(in.IDs...)
+		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
-	asm.RecomputeFeatures()
 	return json.Marshal(assemblyFeaturesResult(asm))
 }
 
@@ -522,8 +546,12 @@ func assemblySetEndOfFeatures(s *app.Session, raw json.RawMessage) (json.RawMess
 	if err := decode(raw, &in); err != nil {
 		return nil, err
 	}
-	asm.Features().SetEndOfFeatures(in.Position)
-	asm.RecomputeFeatures()
+	if err := s.CommitAssemblyFeatureChange("Set End of Features", func(a *compdef.AssemblyComponentDefinition) error {
+		a.Features().SetEndOfFeatures(in.Position)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
 	return json.Marshal(assemblyFeaturesResult(asm))
 }
 

--- a/addin/router/mutation_seam_parity_test.go
+++ b/addin/router/mutation_seam_parity_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/app"
+)
+
+// The B1 regression tests (#1612): the wire router and the head UI's Session
+// verbs must produce the SAME outcome for the same mutation, because both now
+// finish through one seam whose invariant lives on the aggregate. Before the
+// fix, parameters.delete refused an in-use parameter while
+// Session.DeleteParameter deleted it unconditionally ("dependents go sick").
+
+// deleteInUseOverBothDrivers drives the same in-use delete through one driver
+// and reports the outcome; the parameter must survive either way.
+func deleteInUseOverBothDrivers(t *testing.T, drive func(r *Router, s *app.Session) error) error {
+	t.Helper()
+	r, s := seededSession(t)
+	call(t, r, s, "parameters.add", `{"name":"half","expression":"width / 2"}`, nil)
+	err := drive(r, s)
+	holder, findErr := modelaccess.ActiveParameterHolder(s)
+	if findErr != nil {
+		t.Fatalf("resolving the holder: %v", findErr)
+	}
+	if _, ok := holder.Parameters().ByName("width"); !ok {
+		t.Fatal("width was deleted while in use — the invariant did not hold on this driver")
+	}
+	return err
+}
+
+// TestParameterDeleteInvariantSharedAcrossDrivers is the test that would have
+// caught B1: both drivers refuse the in-use delete and name the blocker.
+func TestParameterDeleteInvariantSharedAcrossDrivers(t *testing.T) {
+	wireErr := deleteInUseOverBothDrivers(t, func(r *Router, s *app.Session) error {
+		_, err := r.Handle(s, "parameters.delete", []byte(`{"name":"width"}`))
+		return err
+	})
+	uiErr := deleteInUseOverBothDrivers(t, func(r *Router, s *app.Session) error {
+		holder, err := modelaccess.ActiveParameterHolder(s)
+		if err != nil {
+			return err
+		}
+		p, _ := holder.Parameters().ByName("width")
+		return s.DeleteParameter(p.ID())
+	})
+	for driver, err := range map[string]error{"wire": wireErr, "ui": uiErr} {
+		if err == nil || !strings.Contains(err.Error(), "half") {
+			t.Errorf("%s delete(in-use) err = %v, want a refusal naming the blocker \"half\"", driver, err)
+		}
+	}
+}
+
+// TestGroupRenameInvariantSharedAcrossDrivers: the empty-display-name refusal
+// comes from the aggregate on both drivers (it used to live only in the wire
+// handler while Session.RenameParameterGroup wrote the field unchecked).
+func TestGroupRenameInvariantSharedAcrossDrivers(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "parameters.groups.add", `{"internalName":"frame","displayName":"Frame"}`, nil)
+
+	if _, err := r.Handle(s, "parameters.groups.setDisplayName", []byte(`{"internalName":"frame","displayName":""}`)); err == nil {
+		t.Error("wire setDisplayName(\"\") must be refused")
+	}
+	if err := s.RenameParameterGroup("frame", ""); err == nil {
+		t.Error("ui RenameParameterGroup(\"\") must be refused")
+	}
+	holder, err := modelaccess.ActiveParameterHolder(s)
+	if err != nil {
+		t.Fatalf("resolving the holder: %v", err)
+	}
+	g, ok := holder.Parameters().GroupByKey("frame")
+	if !ok || g.DisplayName() != "Frame" {
+		t.Fatalf("group after refused renames = %+v, want display name Frame kept", g)
+	}
+}

--- a/addin/router/parameter_groups.go
+++ b/addin/router/parameter_groups.go
@@ -15,14 +15,15 @@ import (
 
 // Custom parameter groups over the wire (M02-F05, Oblikovati#604):
 // parameters.groups.list/add/delete/setDisplayName/addMember/removeMember.
-// Mutations finalize through Session.RecordActiveEdit so they are undoable and
-// broadcast as edit.committed (mutatingMethods).
+// Mutations delegate to the Session verbs the head UI also uses, so both
+// drivers share one seam (#1612, audit B1); undo/replication ride the central
+// MutatingMethod seam.
 
 // parameterGroupInfo marshals one group with its member names in collection order.
 func parameterGroupInfo(holder compdef.ParameterHolder, g *param.ParameterGroup) wire.ParameterGroupInfo {
 	ps := holder.Parameters()
 	return wire.ParameterGroupInfo{
-		InternalName: g.InternalName(), DisplayName: g.DisplayName, ClientID: g.ClientID,
+		InternalName: g.InternalName(), DisplayName: g.DisplayName(), ClientID: g.ClientID,
 		Members: paramNames(ps, ps.GroupMembers(g.InternalName())),
 	}
 }
@@ -60,70 +61,63 @@ func addParameterGroup(s *app.Session, args json.RawMessage) (json.RawMessage, e
 	if err := decode(args, &in); err != nil {
 		return nil, err
 	}
+	g, err := s.AddParameterGroup(in.InternalName, in.DisplayName, in.ClientID)
+	if err != nil {
+		return nil, err
+	}
 	holder, err := modelaccess.ActiveParameterHolder(s)
 	if err != nil {
 		return nil, err
 	}
-	g, err := holder.Parameters().AddGroup(in.InternalName, in.DisplayName, in.ClientID)
-	if err != nil {
-		return nil, err
-	}
-	s.RecordActiveEdit("Add Parameter Group")
 	return json.Marshal(parameterGroupInfo(holder, g))
 }
 
 // deleteParameterGroup removes a group; the deleteParameters flag opts into
-// the cascade that also deletes the member parameters (their dependents then
-// need a recompute, like parameters.delete).
+// the cascade that also deletes the member parameters. The cascade's
+// may-not-sicken-a-survivor refusal comes from the aggregate (#1612).
 func deleteParameterGroup(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
 	var in wire.ParameterGroupDeleteArgs
 	if err := decode(args, &in); err != nil {
 		return nil, err
 	}
-	holder, _, err := groupByKey(s, "parameters.groups.delete", in.InternalName)
-	if err != nil {
+	if err := s.DeleteParameterGroup(in.InternalName, in.DeleteParameters); err != nil {
 		return nil, err
 	}
-	if err := holder.Parameters().DeleteGroup(in.InternalName, in.DeleteParameters); err != nil {
-		return nil, err
-	}
-	if in.DeleteParameters {
-		holder.RecomputeAfterChange()
-	}
-	s.RecordActiveEdit("Delete Parameter Group")
 	return json.Marshal(struct{}{})
 }
 
-// setParameterGroupDisplayName edits the editable half of the group's naming.
+// setParameterGroupDisplayName edits the editable half of the group's naming;
+// the non-empty rule comes from the aggregate, shared with the UI (#1612).
 func setParameterGroupDisplayName(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
 	var in wire.ParameterGroupDisplayNameArgs
 	if err := decode(args, &in); err != nil {
+		return nil, err
+	}
+	if err := s.RenameParameterGroup(in.InternalName, in.DisplayName); err != nil {
 		return nil, err
 	}
 	holder, g, err := groupByKey(s, "parameters.groups.setDisplayName", in.InternalName)
 	if err != nil {
 		return nil, err
 	}
-	if in.DisplayName == "" {
-		return nil, fmt.Errorf("parameters.groups.setDisplayName: display name for %q must not be empty", in.InternalName)
-	}
-	g.DisplayName = in.DisplayName
-	s.RecordActiveEdit("Rename Parameter Group")
 	return json.Marshal(parameterGroupInfo(holder, g))
 }
 
 // addParameterGroupMember / removeParameterGroupMember manage one membership.
+// The group's existence was checked by the caller, so AddParameterToGroup's
+// create-on-first-use (a UI journey) can never trigger on the wire path.
 func addParameterGroupMember(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
-	return editParameterGroupMember(s, "parameters.groups.addMember", args, (*param.Parameters).AddToGroup)
+	return editParameterGroupMember(s, "parameters.groups.addMember", args, (*app.Session).AddParameterToGroup)
 }
 
 func removeParameterGroupMember(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
-	return editParameterGroupMember(s, "parameters.groups.removeMember", args, (*param.Parameters).RemoveFromGroup)
+	return editParameterGroupMember(s, "parameters.groups.removeMember", args, (*app.Session).DetachParameterFromGroup)
 }
 
-// editParameterGroupMember resolves the group and the parameter, applies one
-// membership edit, and returns the updated group.
-func editParameterGroupMember(s *app.Session, method string, args json.RawMessage, edit func(*param.Parameters, param.ID, string) error) (json.RawMessage, error) {
+// editParameterGroupMember resolves the group and the parameter (wire-strict:
+// both must exist), applies one membership edit through the shared Session
+// verb, and returns the updated group.
+func editParameterGroupMember(s *app.Session, method string, args json.RawMessage, edit func(*app.Session, param.ID, string) error) (json.RawMessage, error) {
 	var in wire.ParameterGroupMemberArgs
 	if err := decode(args, &in); err != nil {
 		return nil, err
@@ -136,9 +130,8 @@ func editParameterGroupMember(s *app.Session, method string, args json.RawMessag
 	if !ok {
 		return nil, fmt.Errorf("%s: no parameter named %q", method, in.Parameter)
 	}
-	if err := edit(holder.Parameters(), p.ID(), in.InternalName); err != nil {
+	if err := edit(s, p.ID(), in.InternalName); err != nil {
 		return nil, err
 	}
-	s.RecordActiveEdit("Edit Parameter Group")
 	return json.Marshal(parameterGroupInfo(holder, g))
 }

--- a/addin/router/parameters_detail.go
+++ b/addin/router/parameters_detail.go
@@ -5,7 +5,6 @@ package router
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"oblikovati.org/addin/modelaccess"
 	"oblikovati.org/api/types"
@@ -283,37 +282,22 @@ func replaceExpressionList(p *param.Parameter, in wire.ParameterExpressionListAr
 	return nil
 }
 
-// deleteParameter removes an unused parameter; an in-use one is rejected with
-// the offending dependents so the caller can resolve them first.
+// deleteParameter removes an unused parameter through the shared Session verb;
+// the in-use refusal (with the blockers named) comes from the aggregate, so
+// this wire path and the head UI enforce one invariant (#1612, audit B1).
 func deleteParameter(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
 	var in wire.ParameterNameArgs
 	if err := decode(args, &in); err != nil {
 		return nil, err
 	}
-	holder, p, err := paramByName(s, "parameters.delete", in.Name)
+	_, p, err := paramByName(s, "parameters.delete", in.Name)
 	if err != nil {
 		return nil, err
 	}
-	ps := holder.Parameters()
-	if ps.InUse(p.ID()) {
-		return nil, fmt.Errorf("parameters.delete: %q is in use by [%s]; remove those references first",
-			in.Name, strings.Join(deleteBlockers(ps, p), ", "))
-	}
-	if err := ps.Delete(p.ID()); err != nil {
+	if err := s.DeleteParameter(p.ID()); err != nil {
 		return nil, err
 	}
-	holder.RecomputeAfterChange()
-	s.RecordActiveEdit("Delete Parameter")
 	return json.Marshal(struct{}{})
-}
-
-// deleteBlockers names what keeps a parameter alive: its dependents, or its
-// owning feature dimension for model parameters.
-func deleteBlockers(ps *param.Parameters, p *param.Parameter) []string {
-	if names := paramNames(ps, ps.Dependents(p.ID())); len(names) > 0 {
-		return names
-	}
-	return []string{"its feature dimension"}
 }
 
 // parameterDrivenBy / parameterDependents answer the dependency queries.

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -4,7 +4,12 @@
 // contract (commands.*, documents.*, parameters.*, model.*, features.*) to the live
 // *app.Session. It is the single place that contract is wired to the model, and is
 // pure Go (no cgo, no MCP/HTTP) so it is fully headless-testable. Handle runs on the
-// session goroutine (via the Dispatcher), so handlers may touch the model directly.
+// session goroutine (via the Dispatcher), so handlers may READ the model directly —
+// queries carry no invariants to drift. MUTATIONS delegate to an app.Session verb
+// (the application service the head UI also drives), so both drivers share one
+// invariant per aggregate instead of the divergence audited as B1 (#1612); the
+// archguard router-seam test enforces this, with the not-yet-migrated handlers
+// pinned in its shrink-only allowlist.
 //
 // This is the same contract the future M16 gRPC api/ will serve; keeping it here and
 // transport-agnostic lets the bridge retarget onto that layer with minimal churn.

--- a/app/assembly_dressup_tools.go
+++ b/app/assembly_dressup_tools.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 
 	"oblikovati.org/kernel/topo"
-	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
 )
 
@@ -69,29 +68,27 @@ func (t *assemblyEdgeSelectTool) Cancel(s *Session) {
 	t.edges = nil
 }
 
-// resolve returns the active assembly and the component-local suffix of each picked edge, erroring
+// resolve returns the component-local suffix of each picked edge, erroring
 // when no assembly is active or nothing was picked.
-func (t *assemblyEdgeSelectTool) resolve(s *Session, op string) (*compdef.AssemblyComponentDefinition, [][]byte, error) {
-	asm, err := activeAssembly(s)
-	if err != nil {
-		return nil, nil, err
+func (t *assemblyEdgeSelectTool) resolve(s *Session, op string) ([][]byte, error) {
+	if _, err := activeAssembly(s); err != nil {
+		return nil, err
 	}
 	if len(t.edges) == 0 {
-		return nil, nil, errors.New(op + ": pick a component edge first")
+		return nil, errors.New(op + ": pick a component edge first")
 	}
 	suffixes := make([][]byte, len(t.edges))
 	for i, e := range t.edges {
 		suffixes[i] = componentEdgeSuffix(e.Edge.ReferenceKey())
 	}
-	return asm, suffixes, nil
+	return suffixes, nil
 }
 
-// finish names the new dress-up feature, recomputes the assembly so the participants re-machine,
-// records the undo step (the feature program now persists, #785), and clears the edge filter.
-func (t *assemblyEdgeSelectTool) finish(s *Session, asm *compdef.AssemblyComponentDefinition, af *compdef.AssemblyFeature) {
-	af.SetName(asm.Features().UniqueName(af.Kind()))
-	asm.RecomputeFeatures()
-	s.recordEdit(asm, af.Kind())
+// finish commits the new dress-up feature through the shared assembly-feature
+// seam (naming lives on the aggregate, recompute + undo on the verb — #1612).
+func (t *assemblyEdgeSelectTool) finish(s *Session, f feature.Feature, label string) error {
+	_, err := s.CommitAssemblyFeature(f, label)
+	return err
 }
 
 // --- Chamfer --------------------------------------------------------------
@@ -111,14 +108,12 @@ func (t *AssemblyChamferTool) Prompt(*Session) string {
 func (t *AssemblyChamferTool) CanCommit() bool { return len(t.edges) > 0 && t.distance > 0 }
 
 func (t *AssemblyChamferTool) Commit(s *Session) error {
-	asm, suffixes, err := t.resolve(s, "chamfer")
+	suffixes, err := t.resolve(s, "chamfer")
 	if err != nil {
 		return err
 	}
 	d := t.distance
-	af := asm.AddFeature(feature.NewAssemblyChamferFeature(suffixes, func() float64 { return d }))
-	t.finish(s, asm, af)
-	return nil
+	return t.finish(s, feature.NewAssemblyChamferFeature(suffixes, func() float64 { return d }), "Chamfer")
 }
 
 func (t *AssemblyChamferTool) Params() ToolParams {
@@ -144,14 +139,12 @@ func (t *AssemblyFilletTool) Prompt(*Session) string {
 func (t *AssemblyFilletTool) CanCommit() bool { return len(t.edges) > 0 && t.radius > 0 }
 
 func (t *AssemblyFilletTool) Commit(s *Session) error {
-	asm, suffixes, err := t.resolve(s, "fillet")
+	suffixes, err := t.resolve(s, "fillet")
 	if err != nil {
 		return err
 	}
 	r := t.radius
-	af := asm.AddFeature(feature.NewAssemblyFilletFeature(suffixes, func() float64 { return r }))
-	t.finish(s, asm, af)
-	return nil
+	return t.finish(s, feature.NewAssemblyFilletFeature(suffixes, func() float64 { return r }), "Fillet")
 }
 
 func (t *AssemblyFilletTool) Params() ToolParams {

--- a/app/assembly_feature_commit.go
+++ b/app/assembly_feature_commit.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+)
+
+// CommitAssemblyFeature hosts f on the active assembly, recomputes the feature
+// program, and records one undo step under label — the single mutation seam
+// both the head UI tools and the wire router finish an assembly-feature add
+// through (#1612, audit B1). The attach policy itself (unique naming, proxy-cut
+// source exclusion) lives on the aggregate's AddFeature.
+//
+//	af, err := s.CommitAssemblyFeature(feature.NewAssemblyProxyCutFeature(src, ops.Cut), "Add Assembly Feature")
+func (s *Session) CommitAssemblyFeature(f feature.Feature, label string) (*compdef.AssemblyFeature, error) {
+	asm, err := activeAssembly(s)
+	if err != nil {
+		return nil, err
+	}
+	af := asm.AddFeature(f)
+	asm.RecomputeFeatures()
+	s.recordEdit(asm, label) // the feature program persists + undoes (#785)
+	return af, nil
+}
+
+// CommitAssemblyFeatureChange finalizes an in-place change to the active
+// assembly's feature program (participation, suppression, scalar edits, the
+// rollback marker): mutate runs against the assembly, then one recompute and
+// one undo step under label — the shared sequencing both drivers finish
+// through (#1612, audit B1).
+//
+//	err := s.CommitAssemblyFeatureChange("Edit Participants", func(asm *compdef.AssemblyComponentDefinition) error {
+//		af.SetParticipants(occs); return nil
+//	})
+func (s *Session) CommitAssemblyFeatureChange(label string, mutate func(asm *compdef.AssemblyComponentDefinition) error) error {
+	asm, err := activeAssembly(s)
+	if err != nil {
+		return err
+	}
+	if err := mutate(asm); err != nil {
+		return err
+	}
+	asm.RecomputeFeatures()
+	s.recordEdit(asm, label)
+	return nil
+}

--- a/app/assembly_feature_commit_test.go
+++ b/app/assembly_feature_commit_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+)
+
+// The assembly-feature commit verbs (#1612, audit B1): the one seam the UI
+// tools and the wire router add/edit the feature program through.
+
+func TestCommitAssemblyFeatureHostsAndNames(t *testing.T) {
+	s := activeAssemblySession(t)
+	tool, err := brep.SolidBlock(math.P3(0, 0, 0), math.P3(1, 1, 1), "asmTool")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	af, err := s.CommitAssemblyFeature(feature.NewAssemblyCutFeature(tool, ops.Cut), "Add Assembly Feature")
+	if err != nil {
+		t.Fatalf("CommitAssemblyFeature: %v", err)
+	}
+	if af.Name() == "" {
+		t.Error("the aggregate must have named the hosted feature")
+	}
+	asm, err := activeAssembly(s)
+	if err != nil {
+		t.Fatalf("activeAssembly: %v", err)
+	}
+	if asm.Features().Count() != 1 {
+		t.Fatalf("feature count = %d, want 1", asm.Features().Count())
+	}
+
+	// An in-place change runs mutate, then recompute + one undo record.
+	if err := s.CommitAssemblyFeatureChange("Suppress Assembly Feature", func(a *compdef.AssemblyComponentDefinition) error {
+		a.Features().SuppressFeatures(af.ID())
+		return nil
+	}); err != nil {
+		t.Fatalf("CommitAssemblyFeatureChange: %v", err)
+	}
+	if !af.Suppressed() {
+		t.Error("the change must have applied")
+	}
+
+	// A failing mutate surfaces its error without recording.
+	boom := errors.New("boom")
+	if err := s.CommitAssemblyFeatureChange("x", func(*compdef.AssemblyComponentDefinition) error { return boom }); !errors.Is(err, boom) {
+		t.Errorf("failing mutate = %v, want boom", err)
+	}
+}
+
+// TestCommitAssemblyFeatureNeedsAnAssembly covers both verbs' resolution error
+// on a part document.
+func TestCommitAssemblyFeatureNeedsAnAssembly(t *testing.T) {
+	s := newSessionWithPart(t)
+	if _, err := s.CommitAssemblyFeature(nil, "x"); err == nil {
+		t.Error("CommitAssemblyFeature on a part must error")
+	}
+	if err := s.CommitAssemblyFeatureChange("x", func(*compdef.AssemblyComponentDefinition) error { return nil }); err == nil {
+		t.Error("CommitAssemblyFeatureChange on a part must error")
+	}
+}

--- a/app/assembly_machining_tools.go
+++ b/app/assembly_machining_tools.go
@@ -72,8 +72,7 @@ func (t *AssemblyRevolveTool) CanCommit() bool {
 }
 
 func (t *AssemblyRevolveTool) Commit(s *Session) error {
-	asm, err := activeAssembly(s)
-	if err != nil {
+	if _, err := activeAssembly(s); err != nil {
 		return err
 	}
 	if t.profile == nil {
@@ -81,11 +80,8 @@ func (t *AssemblyRevolveTool) Commit(s *Session) error {
 	}
 	axis := feature.NewDatumAxis(math.P3(0, 0, 0), signedAxisDir(t.axisIndex))
 	a := t.angle
-	af := asm.AddFeature(feature.NewAssemblyRevolveFeature(t.profile.Sketch, t.profile.ProfileIndex, axis, assemblyExtrudeOps[t.operation], func() float64 { return a }))
-	af.SetName(asm.Features().UniqueName(af.Kind()))
-	asm.RecomputeFeatures()
-	s.recordEdit(asm, "Revolve") // the feature program persists + undoes (#785)
-	return nil
+	_, err := s.CommitAssemblyFeature(feature.NewAssemblyRevolveFeature(t.profile.Sketch, t.profile.ProfileIndex, axis, assemblyExtrudeOps[t.operation], func() float64 { return a }), "Revolve")
+	return err
 }
 
 func (t *AssemblyRevolveTool) Params() ToolParams {
@@ -126,19 +122,15 @@ func (t *AssemblyHoleTool) Prompt(*Session) string {
 func (t *AssemblyHoleTool) CanCommit() bool { return t.diameter > 0 && t.depth > 0 }
 
 func (t *AssemblyHoleTool) Commit(s *Session) error {
-	asm, err := activeAssembly(s)
-	if err != nil {
+	if _, err := activeAssembly(s); err != nil {
 		return err
 	}
 	hole, err := feature.NewAssemblyHoleFeature(math.P3(t.cx, t.cy, t.cz), signedAxisDir(t.axisIndex), t.diameter, t.depth)
 	if err != nil {
 		return err
 	}
-	af := asm.AddFeature(hole)
-	af.SetName(asm.Features().UniqueName(af.Kind()))
-	asm.RecomputeFeatures()
-	s.recordEdit(asm, "Hole") // the feature program persists + undoes (#785)
-	return nil
+	_, cerr := s.CommitAssemblyFeature(hole, "Hole")
+	return cerr
 }
 
 func (t *AssemblyHoleTool) Params() ToolParams {

--- a/app/assembly_sketch_features.go
+++ b/app/assembly_sketch_features.go
@@ -50,8 +50,7 @@ func (t *AssemblyExtrudeTool) Cancel(*Session) { t.profile = nil }
 func (t *AssemblyExtrudeTool) CanCommit() bool { return t.profile != nil && t.distance > 0 }
 
 func (t *AssemblyExtrudeTool) Commit(s *Session) error {
-	asm, err := activeAssembly(s)
-	if err != nil {
+	if _, err := activeAssembly(s); err != nil {
 		return err
 	}
 	if t.profile == nil {
@@ -59,11 +58,8 @@ func (t *AssemblyExtrudeTool) Commit(s *Session) error {
 	}
 	d := t.distance
 	op := assemblyExtrudeOps[t.operation]
-	af := asm.AddFeature(feature.NewAssemblyExtrudeFeature(t.profile.Sketch, t.profile.ProfileIndex, op, func() float64 { return d }))
-	af.SetName(asm.Features().UniqueName(af.Kind()))
-	asm.RecomputeFeatures()
-	s.recordEdit(asm, "Extrude") // the feature program persists + undoes (#785)
-	return nil
+	_, err := s.CommitAssemblyFeature(feature.NewAssemblyExtrudeFeature(t.profile.Sketch, t.profile.ProfileIndex, op, func() float64 { return d }), "Extrude")
+	return err
 }
 
 func (t *AssemblyExtrudeTool) Params() ToolParams {

--- a/app/parameters.go
+++ b/app/parameters.go
@@ -88,7 +88,7 @@ func firstGroupDisplayName(ps *param.Parameters, id param.ID) string {
 		return ""
 	}
 	if g, ok := ps.GroupByKey(keys[0]); ok {
-		return g.DisplayName
+		return g.DisplayName()
 	}
 	return keys[0]
 }

--- a/app/parameters_edit.go
+++ b/app/parameters_edit.go
@@ -102,9 +102,11 @@ func (s *Session) CopyParameterToUser(id param.ID) error {
 	})
 }
 
-// DeleteParameter removes a parameter (its dependents go sick on the lost reference).
+// DeleteParameter removes an unused parameter. The in-use refusal (with the
+// blockers named) comes from the aggregate, so this UI path and the wire
+// router share one invariant instead of the divergence audited as B1 (#1612).
 func (s *Session) DeleteParameter(id param.ID) error {
-	return s.editParameters(func(ps *param.Parameters) error { return ps.Delete(id) })
+	return s.editParametersLabeled("Delete Parameter", func(ps *param.Parameters) error { return ps.Delete(id) })
 }
 
 // AddParameterToGroup / RemoveParameterFromGroup manage a parameter's group
@@ -125,23 +127,53 @@ func (s *Session) RemoveParameterFromGroup(id param.ID) error {
 	return s.editParameters(func(ps *param.Parameters) error { return ps.RemoveFromAllGroups(id) })
 }
 
+// AddParameterGroup creates an empty custom group keyed by its immutable
+// internal name, returning it so a wire caller can render the result.
+func (s *Session) AddParameterGroup(internalName, displayName, clientID string) (*param.ParameterGroup, error) {
+	var g *param.ParameterGroup
+	err := s.editGroups("Add Parameter Group", func(ps *param.Parameters) error {
+		var addErr error
+		g, addErr = ps.AddGroup(internalName, displayName, clientID)
+		return addErr
+	})
+	return g, err
+}
+
 // RenameParameterGroup edits a group's display name; the internal name a group
-// is addressed by never changes (M02-F05).
+// is addressed by never changes (M02-F05). The non-empty rule comes from the
+// aggregate's SetDisplayName, shared with the wire path (#1612, audit B1).
 func (s *Session) RenameParameterGroup(key, displayName string) error {
-	return s.editParameters(func(ps *param.Parameters) error {
+	return s.editGroups("Rename Parameter Group", func(ps *param.Parameters) error {
 		g, ok := ps.GroupByKey(key)
 		if !ok {
 			return fmt.Errorf("app: no parameter group named %q", key)
 		}
-		g.DisplayName = displayName
-		return nil
+		return g.SetDisplayName(displayName)
 	})
 }
 
-// DeleteParameterGroup removes a group and its member parameters (the head
-// UI's journey semantics; the wire surface exposes the opt-in cascade).
-func (s *Session) DeleteParameterGroup(name string) error {
-	return s.editParameters(func(ps *param.Parameters) error { return ps.DeleteGroup(name, true) })
+// DeleteParameterGroup removes a group; deleteParameters opts into the member
+// cascade (the head UI's journey passes true, the wire surface exposes the
+// flag). The cascade's may-not-sicken-a-survivor refusal comes from the
+// aggregate. Only the cascade changes geometry, so only it recomputes.
+func (s *Session) DeleteParameterGroup(name string, deleteParameters bool) error {
+	if !deleteParameters {
+		return s.editGroups("Delete Parameter Group", func(ps *param.Parameters) error {
+			return ps.DeleteGroup(name, false)
+		})
+	}
+	return s.editParametersLabeled("Delete Parameter Group", func(ps *param.Parameters) error {
+		return ps.DeleteGroup(name, true)
+	})
+}
+
+// DetachParameterFromGroup removes a parameter from one named group, keeping
+// its other memberships (the wire removeMember semantics; RemoveParameterFromGroup
+// is the UI journey that detaches from every group).
+func (s *Session) DetachParameterFromGroup(id param.ID, key string) error {
+	return s.editGroups("Edit Parameter Group", func(ps *param.Parameters) error {
+		return ps.RemoveFromGroup(id, key)
+	})
 }
 
 // ImportParameters applies a parameter-set XML document atomically: the holder
@@ -183,6 +215,26 @@ func (s *Session) editParam(id param.ID, edit func(*param.Parameter) error) erro
 // records any error as the session notice, recomputes the holder on success, and returns the
 // error.
 func (s *Session) editParameters(edit func(*param.Parameters) error) error {
+	return s.editParametersLabeled("Edit Parameters", edit)
+}
+
+// editParametersLabeled is editParameters with the undo-step label the edit
+// records under — the one mutation seam both the head UI and the wire router
+// finish through (#1612, audit B1).
+func (s *Session) editParametersLabeled(label string, edit func(*param.Parameters) error) error {
+	return s.finishParameterEdit(label, true, edit)
+}
+
+// editGroups applies a group-only edit: membership and naming never affect
+// parameter semantics (see model/param/group.go), so no geometry recompute.
+func (s *Session) editGroups(label string, edit func(*param.Parameters) error) error {
+	return s.finishParameterEdit(label, false, edit)
+}
+
+// finishParameterEdit resolves the active holder, applies edit, surfaces any
+// error as the session notice, then recomputes (when the edit can move
+// geometry) and records one undo step.
+func (s *Session) finishParameterEdit(label string, recompute bool, edit func(*param.Parameters) error) error {
 	holder, err := s.activeParameterHolder()
 	if err != nil {
 		s.notice = err.Error()
@@ -193,7 +245,9 @@ func (s *Session) editParameters(edit func(*param.Parameters) error) error {
 		return err
 	}
 	s.notice = ""
-	holder.RecomputeAfterChange() // mark dirty before recompute, or the edit leaves stale geometry (#1413)
-	s.recordEdit(holder, "Edit Parameters")
+	if recompute {
+		holder.RecomputeAfterChange() // mark dirty before recompute, or the edit leaves stale geometry (#1413)
+	}
+	s.recordEdit(holder, label)
 	return nil
 }

--- a/app/parameters_groups_verbs_test.go
+++ b/app/parameters_groups_verbs_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+// The group Session verbs added for the shared mutation seam (#1612, audit B1):
+// each is the one path both the head UI and the wire router mutate through, so
+// they are covered here once, on the verb, not per driver.
+
+func TestParameterGroupVerbsRoundTrip(t *testing.T) {
+	s := newSessionWithPart(t)
+	g, err := s.AddParameterGroup("frame", "Frame", "com.example")
+	if err != nil {
+		t.Fatalf("AddParameterGroup: %v", err)
+	}
+	if g.InternalName() != "frame" || g.DisplayName() != "Frame" {
+		t.Fatalf("created group = %+v, want frame/Frame", g)
+	}
+	if err := s.RenameParameterGroup("frame", "Chassis"); err != nil {
+		t.Fatalf("RenameParameterGroup: %v", err)
+	}
+	if g.DisplayName() != "Chassis" {
+		t.Errorf("display name = %q, want Chassis", g.DisplayName())
+	}
+	// The empty rename is refused by the aggregate through the verb.
+	if err := s.RenameParameterGroup("frame", ""); err == nil {
+		t.Error("RenameParameterGroup(\"\") must be refused")
+	}
+	if err := s.RenameParameterGroup("nope", "x"); err == nil {
+		t.Error("renaming an unknown group must error")
+	}
+}
+
+func TestDetachParameterFromGroupKeepsOtherMemberships(t *testing.T) {
+	s := newSessionWithPart(t)
+	ps := partParams(t, s)
+	p, err := ps.AddUserParameter("len", "10 mm")
+	if err != nil {
+		t.Fatalf("AddUserParameter: %v", err)
+	}
+	for _, key := range []string{"frame", "gears"} {
+		if _, err := s.AddParameterGroup(key, "", ""); err != nil {
+			t.Fatalf("AddParameterGroup(%s): %v", key, err)
+		}
+		if err := s.AddParameterToGroup(p.ID(), key); err != nil {
+			t.Fatalf("AddParameterToGroup(%s): %v", key, err)
+		}
+	}
+	if err := s.DetachParameterFromGroup(p.ID(), "frame"); err != nil {
+		t.Fatalf("DetachParameterFromGroup: %v", err)
+	}
+	if got := ps.GroupsOf(p.ID()); len(got) != 1 || got[0] != "gears" {
+		t.Errorf("memberships after detach = %v, want [gears] kept", got)
+	}
+}
+
+func TestDeleteParameterGroupFlagControlsCascade(t *testing.T) {
+	s := newSessionWithPart(t)
+	ps := partParams(t, s)
+	p, _ := ps.AddUserParameter("len", "10 mm")
+	if _, err := s.AddParameterGroup("keepers", "", ""); err != nil {
+		t.Fatalf("AddParameterGroup: %v", err)
+	}
+	if err := s.AddParameterToGroup(p.ID(), "keepers"); err != nil {
+		t.Fatalf("AddParameterToGroup: %v", err)
+	}
+	// Plain delete keeps the member.
+	if err := s.DeleteParameterGroup("keepers", false); err != nil {
+		t.Fatalf("DeleteParameterGroup(false): %v", err)
+	}
+	if _, ok := ps.ByID(p.ID()); !ok {
+		t.Fatal("plain group delete must keep the members")
+	}
+	// Cascade deletes it.
+	if _, err := s.AddParameterGroup("doomed", "", ""); err != nil {
+		t.Fatalf("AddParameterGroup: %v", err)
+	}
+	if err := s.AddParameterToGroup(p.ID(), "doomed"); err != nil {
+		t.Fatalf("AddParameterToGroup: %v", err)
+	}
+	if err := s.DeleteParameterGroup("doomed", true); err != nil {
+		t.Fatalf("DeleteParameterGroup(true): %v", err)
+	}
+	if _, ok := ps.ByID(p.ID()); ok {
+		t.Error("cascade group delete must delete the members")
+	}
+}
+
+// TestDeleteParameterRefusalSetsNotice: the UI surfaces the aggregate's
+// refusal through the session notice (the B1 UI path, #1612).
+func TestDeleteParameterRefusalSetsNotice(t *testing.T) {
+	s := newSessionWithPart(t)
+	ps := partParams(t, s)
+	w, _ := ps.AddUserParameter("width", "10 mm")
+	if _, err := ps.AddUserParameter("half", "width / 2"); err != nil {
+		t.Fatalf("AddUserParameter(half): %v", err)
+	}
+	err := s.DeleteParameter(w.ID())
+	if err == nil || !strings.Contains(err.Error(), "half") {
+		t.Fatalf("DeleteParameter(in-use) = %v, want a refusal naming half", err)
+	}
+	if !strings.Contains(s.Notice(), "half") {
+		t.Errorf("notice = %q, want the refusal surfaced to the UI", s.Notice())
+	}
+	if _, ok := ps.ByID(w.ID()); !ok {
+		t.Error("a refused delete must keep the parameter")
+	}
+}

--- a/archguard/router_mutation_seam_test.go
+++ b/archguard/router_mutation_seam_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package archguard
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The router is a wire adapter (ADR-0018): handlers decode a DTO, call an
+// app.Session verb, and encode the result. Reads may walk the model directly
+// (queries carry no invariants to drift), but a handler that orchestrates its
+// own mutation — recomputing and recording undo itself instead of delegating —
+// re-creates the divergence audited as B1 (#1612): a rule enforced in one
+// driver and forgotten in the other. This guard holds the amended rule from
+// addin/router/router.go's package doc: files that still self-orchestrate are
+// pinned in a shrink-only allowlist; a new one is a red build.
+
+// routerSelfOrchestrationMarkers are the calls only an app.Session verb should
+// make on a mutation path: the recompute sequencing and the undo record.
+var routerSelfOrchestrationMarkers = regexp.MustCompile(
+	`RecordActiveEdit\(|RecomputeAfterChange\(|RecomputeFeatures\(|\.Recompute\(\)`)
+
+// pendingRouterSeamMigrations pins the router files that still orchestrate
+// mutations in-handler, mapped to why they are pending. Shrink-only: migrate a
+// file to Session verbs, delete its row. Never add a row for new code — write
+// the Session verb instead (#1612).
+var pendingRouterSeamMigrations = map[string]string{
+	"bodies.go":               "body rename/delete not yet behind Session verbs",
+	"assembly_derive.go":      "derive/export program edits not yet behind Session verbs",
+	"assembly_replication.go": "replication rebuild not yet behind a Session verb",
+
+	"document_end_of_part.go": "end-of-part marker move not yet behind a Session verb",
+	"documents_update.go":     "document metadata update not yet behind a Session verb",
+	"drawing_views.go":        "drawing view edits not yet behind Session verbs",
+	"parameter_settings.go":   "settings/import sweep not yet behind Session verbs",
+	"parameters.go":           "parameters.set fast path not yet behind a Session verb",
+	"parameters_detail.go":    "update/tolerance/value-list edits not yet behind Session verbs (delete IS migrated)",
+	"sheet_metal.go":          "sheet-metal rule edits not yet behind Session verbs",
+	"work_planes.go":          "work-geometry edits not yet behind Session verbs",
+}
+
+// centralSeamFiles hold the router's own post-success machinery (commitMutation
+// calls RecordActiveEdit for every MutatingMethod) — the seam itself, exempt.
+var centralSeamFiles = map[string]bool{"router.go": true}
+
+// TestRouterHandlersDelegateMutations fails when a router file outside the
+// allowlist self-orchestrates a mutation, and when an allowlist row went stale.
+func TestRouterHandlersDelegateMutations(t *testing.T) {
+	dirty := routerFilesWithOrchestrationMarkers(t)
+	for file := range dirty {
+		if centralSeamFiles[file] || pendingRouterSeamMigrations[file] != "" {
+			continue
+		}
+		t.Errorf("addin/router/%s orchestrates a mutation in-handler (recompute/undo-record marker found) — "+
+			"delegate to an app.Session verb so the UI and the wire share one seam (#1612, audit B1). "+
+			"Do not add it to pendingRouterSeamMigrations.", file)
+	}
+	for file, why := range pendingRouterSeamMigrations {
+		if !dirty[file] {
+			t.Errorf("pendingRouterSeamMigrations[%q] (%s) is stale — the file delegates now; delete the entry.", file, why)
+		}
+	}
+}
+
+// routerFilesWithOrchestrationMarkers scans addin/router's non-test sources for
+// the self-orchestration markers, returning the offending file names.
+func routerFilesWithOrchestrationMarkers(t *testing.T) map[string]bool {
+	t.Helper()
+	entries, err := os.ReadDir("../addin/router")
+	if err != nil {
+		t.Fatalf("reading ../addin/router: %v", err)
+	}
+	dirty := map[string]bool{}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Join("../addin/router", name))
+		if err != nil {
+			t.Fatalf("reading router source %s: %v", name, err)
+		}
+		if routerSelfOrchestrationMarkers.Match(src) {
+			dirty[name] = true
+		}
+	}
+	return dirty
+}

--- a/model/compdef/assembly.go
+++ b/model/compdef/assembly.go
@@ -242,10 +242,18 @@ func (a *AssemblyComponentDefinition) DriveJoint(jointID uint64, settings assemb
 
 // AddFeature appends an assembly machining feature wrapping f, defaulting its
 // participation to every component currently present (the reference API's behavior:
-// components added later do not participate unless added to the feature). It returns
-// the hosted feature so the caller can adjust participation or suppression.
+// components added later do not participate unless added to the feature). The
+// aggregate owns the attach policy so no driver can miss it (#1612, audit B1):
+// the feature is named uniquely by kind (a load path overrides with the
+// persisted name), and a proxy cut never machines its own source component. It
+// returns the hosted feature so the caller can adjust participation or suppression.
 func (a *AssemblyComponentDefinition) AddFeature(f feature.Feature) *AssemblyFeature {
-	return a.features.Add(f, distinctSources(a.PlacedBodies()))
+	af := a.features.Add(f, distinctSources(a.PlacedBodies()))
+	af.SetName(a.features.UniqueName(af.Kind()))
+	if pc, ok := f.(*feature.AssemblyProxyCutFeature); ok {
+		af.RemoveParticipant(pc.Source())
+	}
+	return af
 }
 
 // Parameters returns the assembly's parameter DAG (shared with its sketches so

--- a/model/compdef/assembly_features_test.go
+++ b/model/compdef/assembly_features_test.go
@@ -244,3 +244,22 @@ func TestAssemblyFeaturesLookupsAndRemove(t *testing.T) {
 		t.Error("removed feature still resolves by id")
 	}
 }
+
+// TestAddFeatureOwnsAttachPolicy: the aggregate names a new feature uniquely by
+// kind and excludes a proxy cut's source from participation — policy that used
+// to be duplicated across the router, the UI tools, and the load path (#1612).
+func TestAddFeatureOwnsAttachPolicy(t *testing.T) {
+	asm, occs := assemblyOfUnitBoxes(t, 0, 5)
+	first := asm.AddFeature(feature.NewAssemblyCutFeature(topHalfCutter(t), ops.Cut))
+	second := asm.AddFeature(feature.NewAssemblyCutFeature(topHalfCutter(t), ops.Cut))
+	if first.Name() == "" || first.Name() == second.Name() {
+		t.Errorf("default names = %q / %q, want unique non-empty names by kind", first.Name(), second.Name())
+	}
+
+	pc := asm.AddFeature(feature.NewAssemblyProxyCutFeature(occs[1], ops.Cut))
+	for _, o := range pc.Participants() {
+		if o == occs[1] {
+			t.Error("a proxy cut's source must be excluded from its default participation")
+		}
+	}
+}

--- a/model/compdef/assembly_serialize.go
+++ b/model/compdef/assembly_serialize.go
@@ -262,14 +262,11 @@ func (a *AssemblyComponentDefinition) restoreFeatures() error {
 		if err != nil {
 			return fmt.Errorf("compdef: restore assembly feature: %w", err)
 		}
+		// AddFeature owns the attach policy (unique naming, proxy-cut source
+		// exclusion — #1612); the persisted name then overrides the default.
 		af := a.AddFeature(f)
 		af.SetName(fr.Name)
 		af.SetSuppressed(fr.Suppressed)
-		// A proxy-cut never machines its own source component (the router excludes it on add),
-		// so drop the source from the participants AddFeature snapshotted.
-		if pc, ok := f.(*feature.AssemblyProxyCutFeature); ok {
-			af.RemoveParticipant(pc.Source())
-		}
 	}
 	a.RecomputeFeatures()
 	return nil

--- a/model/compdef/param_recipe.go
+++ b/model/compdef/param_recipe.go
@@ -240,8 +240,8 @@ func parameterGroupsRecipeOf(params *param.Parameters) []parameterGroupRecipe {
 	var out []parameterGroupRecipe
 	for _, g := range params.Groups() {
 		gr := parameterGroupRecipe{InternalName: g.InternalName(), ClientID: g.ClientID}
-		if g.DisplayName != g.InternalName() {
-			gr.DisplayName = g.DisplayName
+		if g.DisplayName() != g.InternalName() {
+			gr.DisplayName = g.DisplayName()
 		}
 		for _, id := range params.GroupMembers(g.InternalName()) {
 			if p, ok := params.ByID(id); ok {

--- a/model/compdef/serialize_test.go
+++ b/model/compdef/serialize_test.go
@@ -226,7 +226,7 @@ func TestParameterFieldsSurviveRoundTrip(t *testing.T) {
 		t.Errorf("multi-value not restored: %v custom=%v", rl.ExpressionList(), rl.AllowsCustomValue())
 	}
 	rg, ok := r.GroupByKey("com.example:frame")
-	if !ok || rg.DisplayName != "Frame" || rg.ClientID != "com.example" {
+	if !ok || rg.DisplayName() != "Frame" || rg.ClientID != "com.example" {
 		t.Errorf("group record = %+v, want key/display/client restored", rg)
 	}
 	if got := r.GroupsOf(rl.ID()); len(got) != 1 || got[0] != "com.example:frame" {

--- a/model/param/graph_test.go
+++ b/model/param/graph_test.go
@@ -198,3 +198,17 @@ func TestInUseFollowsDependentsAndModelKind(t *testing.T) {
 		t.Error("a model parameter is in use by construction")
 	}
 }
+
+// TestDeleteRefusesOwnedModelParameter: with no dependents, a model parameter's
+// blocker is its owning feature dimension; DeleteForOwner errors on unknown ids.
+func TestDeleteRefusesOwnedModelParameter(t *testing.T) {
+	ps := NewParameters()
+	dim, _ := ps.AddModelParameter("d0", "2 mm")
+	err := ps.Delete(dim.ID())
+	if err == nil || !strings.Contains(err.Error(), "feature dimension") {
+		t.Fatalf("Delete(model param) = %v, want a refusal naming its feature dimension", err)
+	}
+	if err := ps.DeleteForOwner(dim.ID() + 999); err == nil {
+		t.Error("DeleteForOwner(unknown id) must error")
+	}
+}

--- a/model/param/graph_test.go
+++ b/model/param/graph_test.go
@@ -2,7 +2,10 @@
 
 package param
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // mustAdd is a test helper that adds a user parameter and fails on error.
 func mustAdd(t *testing.T, ps *Parameters, name, expr string) *Parameter {
@@ -139,15 +142,38 @@ func TestRenamePreservesEdgesAndRewritesDisplay(t *testing.T) {
 	}
 }
 
-func TestDeleteDriverSickensDependents(t *testing.T) {
+// Deleting an in-use driver is refused with the blockers named — the aggregate
+// invariant every driver (wire, UI) now shares (#1612, audit B1). The old
+// behavior on this path ("dependents go sick") survives only for the owner
+// cascade, checked below.
+func TestDeleteRefusesInUseDriver(t *testing.T) {
 	ps := NewParameters()
 	w, _ := ps.AddUserParameter("width", "10 cm")
 	h, _ := ps.AddUserParameter("height", "2 * width")
-	if err := ps.Delete(w.ID()); err != nil {
-		t.Fatalf("Delete: %v", err)
+	err := ps.Delete(w.ID())
+	if err == nil || !strings.Contains(err.Error(), "height") {
+		t.Fatalf("Delete(in-use) = %v, want a refusal naming the blocker \"height\"", err)
+	}
+	if _, ok := ps.ByID(w.ID()); !ok {
+		t.Error("a refused delete must leave the parameter in place")
+	}
+	if h.Health().Status == Failed {
+		t.Errorf("dependent health after refused delete = %+v, want untouched", h.Health())
+	}
+}
+
+// TestDeleteForOwnerSickensDependents keeps the owner-cascade contract: a
+// dimension tearing down its own model parameter bypasses the guard, and
+// former dependents go sick on the lost reference.
+func TestDeleteForOwnerSickensDependents(t *testing.T) {
+	ps := NewParameters()
+	w, _ := ps.AddModelParameter("d0", "10 cm")
+	h, _ := ps.AddUserParameter("height", "2 * d0")
+	if err := ps.DeleteForOwner(w.ID()); err != nil {
+		t.Fatalf("DeleteForOwner: %v", err)
 	}
 	if h.Health().Status != Failed {
-		t.Errorf("dependent health after driver delete = %+v, want Failed", h.Health())
+		t.Errorf("dependent health after owner delete = %+v, want Failed", h.Health())
 	}
 }
 

--- a/model/param/group.go
+++ b/model/param/group.go
@@ -5,6 +5,7 @@ package param
 import (
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 // Custom parameter groups (the reference API's CustomParameterGroups, M02-F05,
@@ -15,16 +16,31 @@ import (
 // touches nothing else, and deleting a parameter detaches it everywhere.
 
 // ParameterGroup is one custom group record. The internal name is fixed at
-// creation; DisplayName and the membership live beside it. ClientID records
-// which add-in created the group (empty for user-created groups).
+// creation; the display name is editable through [ParameterGroup.SetDisplayName]
+// and the membership lives beside it. ClientID records which add-in created the
+// group (empty for user-created groups).
 type ParameterGroup struct {
 	internalName string
-	DisplayName  string
+	displayName  string
 	ClientID     string
 }
 
 // InternalName returns the immutable key the group is addressed by.
 func (g *ParameterGroup) InternalName() string { return g.internalName }
+
+// DisplayName returns the group's editable presentation name.
+func (g *ParameterGroup) DisplayName() string { return g.displayName }
+
+// SetDisplayName edits the presentation name. An empty name is refused here, on
+// the aggregate, so the rule holds for every driver — it used to live only in
+// the wire handler while the UI path skipped it (#1612, audit B1).
+func (g *ParameterGroup) SetDisplayName(name string) error {
+	if name == "" {
+		return fmt.Errorf("param: display name for group %q must not be empty", g.internalName)
+	}
+	g.displayName = name
+	return nil
+}
 
 // Groups returns the custom groups in creation order.
 func (ps *Parameters) Groups() []*ParameterGroup {
@@ -53,19 +69,27 @@ func (ps *Parameters) AddGroup(internalName, displayName, clientID string) (*Par
 	if displayName == "" {
 		displayName = internalName
 	}
-	g := &ParameterGroup{internalName: internalName, DisplayName: displayName, ClientID: clientID}
+	g := &ParameterGroup{internalName: internalName, displayName: displayName, ClientID: clientID}
 	ps.groups = append(ps.groups, g)
 	return g, nil
 }
 
 // DeleteGroup removes a group. deleteParameters opts into the cascade that
 // also deletes the member parameters; without it the members stay, only the
-// group goes.
+// group goes. The cascade may not sicken a survivor: it is refused when a
+// member is still read by a parameter outside the doomed set, or is a model
+// parameter whose owning feature dimension survives (#1612, audit B1 — the
+// same invariant as [Parameters.Delete], stated once for the batch).
 func (ps *Parameters) DeleteGroup(key string, deleteParameters bool) error {
 	if _, ok := ps.GroupByKey(key); !ok {
 		return fmt.Errorf(errNoGroup, key)
 	}
 	members := ps.GroupMembers(key)
+	if deleteParameters {
+		if err := ps.refuseCascadeBlockers(key, members); err != nil {
+			return err
+		}
+	}
 	for _, id := range members {
 		delete(ps.memberships[id], key)
 	}
@@ -74,6 +98,41 @@ func (ps *Parameters) DeleteGroup(key string, deleteParameters bool) error {
 	}
 	ps.dropGroup(key)
 	return nil
+}
+
+// refuseCascadeBlockers rejects a member cascade that would leave a surviving
+// parameter (or a feature dimension) referencing a deleted member.
+func (ps *Parameters) refuseCascadeBlockers(key string, members []ID) error {
+	doomed := map[ID]bool{}
+	for _, id := range members {
+		doomed[id] = true
+	}
+	for _, id := range members {
+		p, ok := ps.byID[id]
+		if !ok {
+			continue
+		}
+		if blockers := ps.survivorBlockers(p, doomed); len(blockers) > 0 {
+			return fmt.Errorf("param: cannot cascade-delete group %q: member %q is in use by [%s]; remove those references first",
+				key, p.name, strings.Join(blockers, ", "))
+		}
+	}
+	return nil
+}
+
+// survivorBlockers names what outside the doomed set still reads p: dependents
+// that are not themselves being deleted, or p's owning feature dimension.
+func (ps *Parameters) survivorBlockers(p *Parameter, doomed map[ID]bool) []string {
+	var names []string
+	for _, dep := range ps.Dependents(p.id) {
+		if d, ok := ps.byID[dep]; ok && !doomed[dep] {
+			names = append(names, d.name)
+		}
+	}
+	if len(names) == 0 && p.kind == ModelParam {
+		names = []string{"its feature dimension"}
+	}
+	return names
 }
 
 // deleteMembers removes the cascade-deleted member parameters (a member may

--- a/model/param/group.go
+++ b/model/param/group.go
@@ -108,10 +108,8 @@ func (ps *Parameters) refuseCascadeBlockers(key string, members []ID) error {
 		doomed[id] = true
 	}
 	for _, id := range members {
-		p, ok := ps.byID[id]
-		if !ok {
-			continue
-		}
+		// GroupMembers walks ps.order, so every member is live.
+		p := ps.byID[id]
 		if blockers := ps.survivorBlockers(p, doomed); len(blockers) > 0 {
 			return fmt.Errorf("param: cannot cascade-delete group %q: member %q is in use by [%s]; remove those references first",
 				key, p.name, strings.Join(blockers, ", "))

--- a/model/param/group_test.go
+++ b/model/param/group_test.go
@@ -4,6 +4,7 @@ package param
 
 import (
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -16,7 +17,7 @@ func TestGroupRecordLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AddGroup: %v", err)
 	}
-	if g.InternalName() != "com.example:bracket" || g.DisplayName != "Bracket" || g.ClientID != "com.example" {
+	if g.InternalName() != "com.example:bracket" || g.DisplayName() != "Bracket" || g.ClientID != "com.example" {
 		t.Fatalf("group record = %+v, want key/display/client kept", g)
 	}
 	if _, err := ps.AddGroup("com.example:bracket", "", ""); err == nil {
@@ -27,8 +28,8 @@ func TestGroupRecordLifecycle(t *testing.T) {
 	}
 	// An empty display name defaults to the internal name.
 	plain, _ := ps.AddGroup("Frame", "", "")
-	if plain.DisplayName != "Frame" {
-		t.Errorf("display name = %q, want the internal-name default", plain.DisplayName)
+	if plain.DisplayName() != "Frame" {
+		t.Errorf("display name = %q, want the internal-name default", plain.DisplayName())
 	}
 
 	if err := ps.AddToGroup(a.ID(), "com.example:bracket"); err != nil {
@@ -65,9 +66,11 @@ func TestGroupRecordLifecycle(t *testing.T) {
 func TestGroupDisplayNameEditsKeepKey(t *testing.T) {
 	ps := NewParameters()
 	g, _ := ps.AddGroup("ratios", "Ratios", "")
-	g.DisplayName = "Gear Ratios"
+	if err := g.SetDisplayName("Gear Ratios"); err != nil {
+		t.Fatalf("SetDisplayName: %v", err)
+	}
 	got, ok := ps.GroupByKey("ratios")
-	if !ok || got.DisplayName != "Gear Ratios" {
+	if !ok || got.DisplayName() != "Gear Ratios" {
 		t.Errorf("group after display rename = %+v, want addressable by its key with the new display", got)
 	}
 }
@@ -152,5 +155,81 @@ func TestCopyToUser(t *testing.T) {
 	_ = cp.SetExpression("9 mm")
 	if approxScalar(src.Value().Value, 0.9) {
 		t.Error("editing the copy must not change the source")
+	}
+}
+
+// TestSetDisplayNameRefusesEmpty holds the naming rule on the aggregate so
+// every driver shares it (#1612, audit B1).
+func TestSetDisplayNameRefusesEmpty(t *testing.T) {
+	ps := NewParameters()
+	g, _ := ps.AddGroup("ratios", "Ratios", "")
+	if err := g.SetDisplayName(""); err == nil {
+		t.Fatal("SetDisplayName(\"\") must be refused")
+	}
+	if g.DisplayName() != "Ratios" {
+		t.Errorf("display name after refused rename = %q, want Ratios kept", g.DisplayName())
+	}
+}
+
+// TestDeleteGroupCascadeRefusesSickeningASurvivor: the cascade is refused when
+// a member is still read from outside the doomed set (or is a model parameter,
+// whose owning dimension survives); members that only reference each other
+// cascade fine (#1612, audit B1).
+func TestDeleteGroupCascadeRefusesSickeningASurvivor(t *testing.T) {
+	ps := NewParameters()
+	a, _ := ps.AddUserParameter("a", "1 mm")
+	if _, err := ps.AddUserParameter("outside", "2 * a"); err != nil {
+		t.Fatalf("AddUserParameter(outside): %v", err)
+	}
+	if _, err := ps.AddGroup("doomed", "", ""); err != nil {
+		t.Fatalf("AddGroup: %v", err)
+	}
+	if err := ps.AddToGroup(a.ID(), "doomed"); err != nil {
+		t.Fatalf("AddToGroup: %v", err)
+	}
+	err := ps.DeleteGroup("doomed", true)
+	if err == nil || !strings.Contains(err.Error(), "outside") {
+		t.Fatalf("cascade with an external dependent = %v, want a refusal naming \"outside\"", err)
+	}
+	if _, ok := ps.ByID(a.ID()); !ok {
+		t.Fatal("a refused cascade must leave the members in place")
+	}
+	if _, ok := ps.GroupByKey("doomed"); !ok {
+		t.Fatal("a refused cascade must leave the group in place")
+	}
+}
+
+func TestDeleteGroupCascadeAllowsInternalDependencies(t *testing.T) {
+	ps := NewParameters()
+	a, _ := ps.AddUserParameter("base", "1 mm")
+	b, _ := ps.AddUserParameter("derived", "2 * base")
+	if _, err := ps.AddGroup("doomed", "", ""); err != nil {
+		t.Fatalf("AddGroup: %v", err)
+	}
+	for _, p := range []*Parameter{a, b} {
+		if err := ps.AddToGroup(p.ID(), "doomed"); err != nil {
+			t.Fatalf("AddToGroup: %v", err)
+		}
+	}
+	if err := ps.DeleteGroup("doomed", true); err != nil {
+		t.Fatalf("cascade over an internal dependency: %v", err)
+	}
+	if _, ok := ps.ByID(a.ID()); ok {
+		t.Error("cascade must delete the members")
+	}
+}
+
+func TestDeleteGroupCascadeRefusesModelParameterMember(t *testing.T) {
+	ps := NewParameters()
+	dim, _ := ps.AddModelParameter("d0", "2 mm")
+	if _, err := ps.AddGroup("doomed", "", ""); err != nil {
+		t.Fatalf("AddGroup: %v", err)
+	}
+	if err := ps.AddToGroup(dim.ID(), "doomed"); err != nil {
+		t.Fatalf("AddToGroup: %v", err)
+	}
+	err := ps.DeleteGroup("doomed", true)
+	if err == nil || !strings.Contains(err.Error(), "feature dimension") {
+		t.Fatalf("cascade over a model parameter = %v, want a refusal naming its feature dimension", err)
 	}
 }

--- a/model/param/parameters.go
+++ b/model/param/parameters.go
@@ -2,7 +2,10 @@
 
 package param
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // Parameters is the owning collection for a document's parameters (contract:
 // Parameters / ModelParameters / UserParameters). It assigns stable ids,
@@ -233,14 +236,50 @@ func (ps *Parameters) Rename(id ID, newName string) error {
 	return nil
 }
 
-// Delete removes a parameter from the collection.
+// Delete removes an unused parameter. Deleting an in-use one is refused with
+// the blockers named — the aggregate owns this invariant so every driver (wire
+// router, head UI) gets the same refusal instead of the divergence audited as
+// B1 (#1612): the reference API likewise refuses deleting a referenced
+// parameter. An owner tearing down its own model parameter uses
+// [Parameters.DeleteForOwner].
 func (ps *Parameters) Delete(id ID) error {
+	p, ok := ps.byID[id]
+	if !ok {
+		return fmt.Errorf(errNoParameter, id)
+	}
+	if ps.InUse(id) {
+		return fmt.Errorf("param: cannot delete %q: it is in use by [%s]; remove those references first",
+			p.name, strings.Join(ps.deleteBlockers(p), ", "))
+	}
+	ps.remove(p)
+	return nil
+}
+
+// DeleteForOwner removes a parameter without the in-use guard — for the owner
+// cascade only (a dimension/feature deleting the model parameter it owns as it
+// is itself torn down). Former dependents go sick on the lost reference.
+func (ps *Parameters) DeleteForOwner(id ID) error {
 	p, ok := ps.byID[id]
 	if !ok {
 		return fmt.Errorf(errNoParameter, id)
 	}
 	ps.remove(p)
 	return nil
+}
+
+// deleteBlockers names what keeps a parameter alive: its dependents, or its
+// owning feature dimension for a model parameter.
+func (ps *Parameters) deleteBlockers(p *Parameter) []string {
+	if deps := ps.Dependents(p.id); len(deps) > 0 {
+		names := make([]string, 0, len(deps))
+		for _, id := range deps {
+			if d, ok := ps.byID[id]; ok {
+				names = append(names, d.name)
+			}
+		}
+		return names
+	}
+	return []string{"its feature dimension"}
 }
 
 // remove deletes a parameter from all indices and detaches its edges; former

--- a/model/sketch/dimension.go
+++ b/model/sketch/dimension.go
@@ -165,7 +165,9 @@ func (dc *DimensionConstraints) Delete(d *DimensionConstraint) bool {
 	for i, x := range dc.items {
 		if x == d {
 			dc.items = append(dc.items[:i], dc.items[i+1:]...)
-			_ = dc.params.Delete(d.param.ID())
+			// Owner cascade: the dimension owns this model parameter, so the
+			// in-use guard on Delete does not apply (the owner itself is going).
+			_ = dc.params.DeleteForOwner(d.param.ID())
 			return true
 		}
 	}


### PR DESCRIPTION
Closes #1612.

## What

Business rules had leaked into the wire-router adapter with divergent duplicates in `app/` — most visibly: `parameters.delete` refused deleting an in-use parameter while the UI's `Session.DeleteParameter` deleted unconditionally, silently sickening every dependent. This PR reconciles the invariant once and restores the thin-adapter rule (ADR-0018).

## Why this shape

- **Invariants moved to the aggregate** (`model/param`, `model/compdef`), not to a new service layer: the delete-in-use refusal (with blockers named), the group cascade's may-not-sicken-a-survivor rule, the group display-name non-empty rule, and the assembly `AddFeature` attach policy (kind-unique naming + proxy-cut self-machining exclusion, previously copied at THREE places — router, UI tools, recipe load). A rule on the aggregate cannot be missed by any driver.
- **`app.Session` is the application service** both drivers finish through: it already owns notice/undo/recompute sequencing, so router handlers shrink to decode → verb → encode. No new layer.
- **Delete-in-use semantics**: refuse (no force flag), matching the reference API's behavior. The owner cascade (a dimension tearing down its own model parameter) keeps a dedicated `DeleteForOwner`.

## Guards

- `addin/router/mutation_seam_parity_test.go` drives the in-use delete and the empty group rename through **both** drivers — the regression test that would have caught B1.
- `archguard/router_mutation_seam_test.go`: a router file carrying recompute/undo-record markers must be the central seam or sit in a shrink-only allowlist (11 pending files pinned); red-verified in both directions.
- `addin/router/router.go` package doc states the amended rule: reads may walk the model, mutations delegate.
- Aggregate invariant tests live once, on `model/param` / `model/compdef`.

## Verification

- Full root-module suite + `head/ui` green; full `golangci-lint` clean.
- Live MCP test (`mcplive -part paramseam`, bridge PR to follow): in-use deletes refused over the wire naming `[half, d0]`, parameters survive, empty group rename refused from the aggregate, parameter-driven geometry renders correctly (viewport capture inspected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)