### PR TITLE
Replace sketch-entity type switches with a paired codec registry + entity capabilities

### DIFF
--- a/addin/router/sketch3d_constraints.go
+++ b/addin/router/sketch3d_constraints.go
@@ -187,20 +187,18 @@ func equalConstraint3D(sk *sketch.Sketch3D, refs []uint64) (sketch.Constraint, e
 	return sketch.NewEqual3D(a, b), nil
 }
 
-// radiusScalar3D resolves an entity id to its radius solver DOF.
+// radiusScalar3D resolves an entity id to its radius solver DOF through the
+// entity's own RadiusDOF capability (#1624).
 func radiusScalar3D(sk *sketch.Sketch3D, id uint64) (*math.Scalar, error) {
 	e, ok := sk.EntityByID(sketch.ID(id))
 	if !ok {
 		return nil, fmt.Errorf(errNoSketch3DEntity, id)
 	}
-	switch v := e.(type) {
-	case *sketch.Circle3D:
-		return &v.Radius, nil
-	case *sketch.HelicalCurve3D:
-		return &v.StartRadius, nil
-	default:
+	rd, ok := e.(interface{ RadiusDOF() *math.Scalar })
+	if !ok {
 		return nil, fmt.Errorf("sketch3d: entity %d is %T, want a circle or helix (radius DOF)", id, e)
 	}
+	return rd.RadiusDOF(), nil
 }
 
 // pointConstraint3D builds the point-operand constraints (coincident/collinear/concentric).

--- a/addin/router/sketch3d_enumerate.go
+++ b/addin/router/sketch3d_enumerate.go
@@ -67,125 +67,59 @@ func enumerateDimensions3D(s *app.Session, raw json.RawMessage) (json.RawMessage
 	return json.Marshal(wire.ListDimensions3DResult{Dimensions: out})
 }
 
-// entity3DInfo renders one 3D entity as its wire summary (kind, defining points in
-// model cm, radius for circular kinds, construction flag).
+// entity3DInfo renders one 3D entity as its wire summary through the
+// ShapedEntity3D capability: the model names its own kind, shape points, and
+// radius; this adapter only translates vocabularies (#1624, audit I1).
 func entity3DInfo(index int, e sketch.Entity) wire.Sketch3DEntityInfo {
 	info := wire.Sketch3DEntityInfo{Index: index, ID: uint64(e.EntityID()), Kind: string(types.Sketch3DEntityUnknown)}
-	if p, ok := e.(*sketch.Point3D); ok {
-		info.Kind = string(types.Sketch3DEntityPoint)
-		info.Points = [][]float64{p3coords(p.Position())}
+	se, ok := e.(sketch.ShapedEntity3D)
+	if !ok {
 		return info
 	}
-	if h, ok := e.(*sketch.SplineHandle3D); ok {
-		info.Kind = string(types.Sketch3DEntitySplineHandle)
-		info.Points = [][]float64{p3coords(h.Anchor.Position()), p3coords(h.End.Position())}
-		return info
-	}
-	if fillSegmentCurve3DInfo(&info, e) {
-		return info
-	}
-	fillRoundCurve3DInfo(&info, e)
-	if info.Kind == string(types.Sketch3DEntityUnknown) {
-		fillDerivedCurve3DInfo(&info, e)
-	}
+	info.Kind = string(wireSketch3DEntityKind(se.Kind()))
+	info.Points = point3sCoords(se.ShapePoints3D())
+	info.Radius = entityRadius(e)
+	info.Construction = isConstruction(e)
 	return info
 }
 
-// fillDerivedCurve3DInfo renders the surface-derived curves (F11) and included reference
-// geometry (F08) by kind; their geometry is recompute-derived, so only identity is shown.
-func fillDerivedCurve3DInfo(info *wire.Sketch3DEntityInfo, e sketch.Entity) {
-	switch v := e.(type) {
-	case *sketch.IntersectionCurve3D:
-		info.Kind, info.Construction = string(types.Sketch3DEntityIntersection), v.IsConstruction()
-	case *sketch.SilhouetteCurve3D:
-		info.Kind, info.Construction = string(types.Sketch3DEntitySilhouette), v.IsConstruction()
-	case *sketch.ProjectToSurfaceCurve3D:
-		info.Kind, info.Construction = string(types.Sketch3DEntityProjectToSurface), v.IsConstruction()
-	case *sketch.OnFaceCurve3D:
-		info.Kind, info.Construction = string(types.Sketch3DEntityOnFace), v.IsConstruction()
-	case *sketch.OffsetCurve3:
-		info.Kind, info.Construction = string(types.Sketch3DEntityOffset), v.IsConstruction()
-	case *sketch.IncludedPoint3D:
-		info.Kind, info.Construction = string(types.Sketch3DEntityIncludedPoint), true
-		info.Points = [][]float64{p3coords(v.Position())}
-	case *sketch.IncludedCurve3D:
-		info.Kind, info.Construction = string(types.Sketch3DEntityIncludedCurve), true
-		info.Points = point3sCoords(v.Points())
-	}
+// wireSketch3DEntityKinds maps the model's entity-kind vocabulary onto the 3D
+// wire enum; kinds without a wire spelling enumerate as unknown.
+var wireSketch3DEntityKinds = map[sketch.EntityKind]types.Sketch3DEntityKind{
+	sketch.PointKind:                 types.Sketch3DEntityPoint,
+	sketch.LineKind:                  types.Sketch3DEntityLine,
+	sketch.CircleKind:                types.Sketch3DEntityCircle,
+	sketch.ArcKind:                   types.Sketch3DEntityArc,
+	sketch.EllipseKind:               types.Sketch3DEntityEllipse,
+	sketch.EllipticalArcKind:         types.Sketch3DEntityEllipticalArc,
+	sketch.SplineKind:                types.Sketch3DEntitySpline,
+	sketch.ControlPointSplineKind:    types.Sketch3DEntityControlPointSpline,
+	sketch.SplineHandleKind:          types.Sketch3DEntitySplineHandle,
+	sketch.FixedSplineKind:           types.Sketch3DEntityFixedSpline,
+	sketch.EquationCurveKind:         types.Sketch3DEntityEquationCurve,
+	sketch.HelicalKind:               types.Sketch3DEntityHelical,
+	sketch.IntersectionCurveKind:     types.Sketch3DEntityIntersection,
+	sketch.SilhouetteCurveKind:       types.Sketch3DEntitySilhouette,
+	sketch.ProjectToSurfaceCurveKind: types.Sketch3DEntityProjectToSurface,
+	sketch.OnFaceCurveKind:           types.Sketch3DEntityOnFace,
+	sketch.OffsetCurveKind:           types.Sketch3DEntityOffset,
+	sketch.IncludedPointKind:         types.Sketch3DEntityIncludedPoint,
+	sketch.IncludedCurveKind:         types.Sketch3DEntityIncludedCurve,
 }
 
-// fillSegmentCurve3DInfo renders the straight/poly curve families (line/arc) and the
-// plain circle into info, reporting whether it matched.
-func fillSegmentCurve3DInfo(info *wire.Sketch3DEntityInfo, e sketch.Entity) bool {
-	switch v := e.(type) {
-	case *sketch.Line3D:
-		info.Kind = string(types.Sketch3DEntityLine)
-		info.Points = [][]float64{p3coords(v.A.Position()), p3coords(v.B.Position())}
-		info.Construction = v.IsConstruction()
-	case *sketch.Circle3D:
-		info.Kind = string(types.Sketch3DEntityCircle)
-		info.Points = [][]float64{p3coords(v.Center.Position())}
-		info.Radius = float64(v.Radius)
-		info.Construction = v.IsConstruction()
-	case *sketch.Arc3D:
-		info.Kind = string(types.Sketch3DEntityArc)
-		info.Points = [][]float64{p3coords(v.Center.Position()), p3coords(v.Start.Position()), p3coords(v.End.Position())}
-		info.Radius = float64(v.Radius())
-		info.Construction = v.IsConstruction()
-	default:
-		return false
+func wireSketch3DEntityKind(k sketch.EntityKind) types.Sketch3DEntityKind {
+	if w, ok := wireSketch3DEntityKinds[k]; ok {
+		return w
 	}
-	return true
+	return types.Sketch3DEntityUnknown
 }
 
-// fillRoundCurve3DInfo renders the helix and conic families (centered, radius-bearing).
-func fillRoundCurve3DInfo(info *wire.Sketch3DEntityInfo, e sketch.Entity) {
-	switch v := e.(type) {
-	case *sketch.HelicalCurve3D:
-		info.Kind = string(types.Sketch3DEntityHelical)
-		info.Points = [][]float64{p3coords(v.Origin.Position())}
-		info.Radius = float64(v.StartRadius)
-		info.Construction = v.IsConstruction()
-	case *sketch.Ellipse3D:
-		info.Kind = string(types.Sketch3DEntityEllipse)
-		info.Points = [][]float64{p3coords(v.Center.Position())}
-		info.Radius = float64(v.MajorRadius)
-		info.Construction = v.IsConstruction()
-	case *sketch.EllipticalArc3D:
-		info.Kind = string(types.Sketch3DEntityEllipticalArc)
-		info.Points = [][]float64{p3coords(v.Center.Position())}
-		info.Radius = float64(v.MajorRadius)
-		info.Construction = v.IsConstruction()
-	default:
-		fillSplineCurve3DInfo(info, e)
-	}
-}
-
-// fillSplineCurve3DInfo renders the spline family (interpolation/control/fixed spline +
-// equation curve) into info.
-func fillSplineCurve3DInfo(info *wire.Sketch3DEntityInfo, e sketch.Entity) {
-	switch v := e.(type) {
-	case *sketch.Spline3D:
-		if v.IsFitType() {
-			info.Kind = string(types.Sketch3DEntitySpline)
-		} else {
-			info.Kind = string(types.Sketch3DEntityControlPointSpline)
-		}
-		info.Points = point3sCoords(v.Sample())
-		info.Construction = v.IsConstruction()
-	case *sketch.FixedSpline3D:
-		info.Kind = string(types.Sketch3DEntityFixedSpline)
-		info.Points = point3sCoords(v.Sample())
-		info.Construction = v.IsConstruction()
-	case *sketch.EquationCurve3D:
-		info.Kind = string(types.Sketch3DEntityEquationCurve)
-		info.Points = point3sCoords(v.Sample(16))
-		info.Construction = v.IsConstruction()
-	}
-}
-
-// point3sCoords flattens a polyline to [[x,y,z],…] for enumeration.
+// point3sCoords flattens a polyline to [[x,y,z],…] for enumeration (nil in,
+// nil out — shapeless kinds keep omitting the field).
 func point3sCoords(pts []math.Point3) [][]float64 {
+	if len(pts) == 0 {
+		return nil
+	}
 	out := make([][]float64, len(pts))
 	for i, p := range pts {
 		out[i] = p3coords(p)

--- a/addin/router/sketch_edit.go
+++ b/addin/router/sketch_edit.go
@@ -73,18 +73,10 @@ func curveEditOp(sk *sketch.Sketch, ents []sketch.Entity, in wire.TransformSketc
 	if err != nil {
 		return nil, err
 	}
-	// Trim accepts any curve target (line/circle/arc); split/extend act on lines.
+	// Trim accepts any trimmable curve target; split/extend act on lines. The
+	// line/circle/arc dispatch lives on the model (sketch.TrimCurveAt, #1624).
 	if in.Op == "trim" {
-		switch e := ents[0].(type) {
-		case *sketch.Line:
-			return sk.TrimLine(e, pick)
-		case *sketch.Circle:
-			return sk.TrimCircle(e, pick)
-		case *sketch.Arc:
-			return sk.TrimArc(e, pick)
-		default:
-			return nil, fmt.Errorf("sketch.transform: trim unsupported target %T", ents[0])
-		}
+		return sk.TrimCurveAt(ents[0], pick)
 	}
 	l, ok := ents[0].(*sketch.Line)
 	if !ok {

--- a/addin/router/sketch_enumerate.go
+++ b/addin/router/sketch_enumerate.go
@@ -104,38 +104,53 @@ func dimensionInfo(index int, d *sketch.DimensionConstraint) wire.DimensionInfo 
 	return info
 }
 
-// entityShape returns an entity's wire kind, defining points ([x,y] each), and radius.
-// Split into geometric curves and annotative entities to keep each switch small.
+// entityShape returns an entity's wire kind, defining points ([x,y] each), and
+// radius, through the ShapedEntity capability — the model names its own kind
+// and shape, so this adapter only translates vocabularies (#1624, audit I1).
 func entityShape(e sketch.Entity) (types.SketchEntityKind, [][]float64, float64) {
-	switch v := e.(type) {
-	case *sketch.Point:
-		return types.SketchEntityPoint, [][]float64{pt(v)}, 0
-	case *sketch.Line:
-		return types.SketchEntityLine, [][]float64{pt(v.A), pt(v.B)}, 0
-	case *sketch.Circle:
-		return types.SketchEntityCircle, [][]float64{pt(v.Center)}, float64(v.Radius)
-	case *sketch.Arc:
-		return types.SketchEntityArc, [][]float64{pt(v.Center), pt(v.Start), pt(v.End)}, float64(v.Radius())
-	case *sketch.Ellipse:
-		return types.SketchEntityEllipse, [][]float64{pt(v.Center)}, 0
-	case *sketch.EllipticalArc:
-		return types.SketchEntityEllipticalArc, [][]float64{pt(v.Center)}, 0
-	case *sketch.Spline:
-		return splineKind(v), splinePts(v), 0
-	case *sketch.SplineHandle:
-		return types.SketchEntitySplineHandle, [][]float64{pt(v.Anchor), pt(v.End)}, 0
-	default:
-		return annotationShape(e)
+	se, ok := e.(sketch.ShapedEntity)
+	if !ok {
+		return types.SketchEntityUnknown, nil, 0
 	}
+	return wireSketchEntityKind(se.Kind()), point2Slice(se.ShapePoints()), entityRadius(e)
 }
 
-// splineKind reports a spline's wire kind: a fit (interpolating) spline is "spline", a
-// control-point (approximating) spline is "controlPointSpline" (#150).
-func splineKind(s *sketch.Spline) types.SketchEntityKind {
-	if s.IsFitType() {
-		return types.SketchEntitySpline
+// wireSketchEntityKinds maps the model's entity-kind vocabulary onto the wire
+// enum. Kinds without a wire spelling (block instances) enumerate as unknown,
+// as they always have.
+var wireSketchEntityKinds = map[sketch.EntityKind]types.SketchEntityKind{
+	sketch.PointKind:              types.SketchEntityPoint,
+	sketch.LineKind:               types.SketchEntityLine,
+	sketch.CircleKind:             types.SketchEntityCircle,
+	sketch.ArcKind:                types.SketchEntityArc,
+	sketch.EllipseKind:            types.SketchEntityEllipse,
+	sketch.EllipticalArcKind:      types.SketchEntityEllipticalArc,
+	sketch.SplineKind:             types.SketchEntitySpline,
+	sketch.ControlPointSplineKind: types.SketchEntityControlPointSpline,
+	sketch.SplineHandleKind:       types.SketchEntitySplineHandle,
+	sketch.ImageKind:              types.SketchEntityImage,
+	sketch.FillRegionKind:         types.SketchEntityFillRegion,
+	sketch.TextKind:               types.SketchEntityText,
+	sketch.EquationCurveKind:      types.SketchEntityEquationCurve,
+	sketch.FixedSplineKind:        types.SketchEntityFixedSpline,
+	sketch.OffsetSplineKind:       types.SketchEntityOffsetSpline,
+	sketch.ProjectedPointKind:     types.SketchEntityProjectedPoint,
+	sketch.ProjectedCurveKind:     types.SketchEntityProjectedCurve,
+}
+
+func wireSketchEntityKind(k sketch.EntityKind) types.SketchEntityKind {
+	if w, ok := wireSketchEntityKinds[k]; ok {
+		return w
 	}
-	return types.SketchEntityControlPointSpline
+	return types.SketchEntityUnknown
+}
+
+// entityRadius reports the optional radius capability (0 for radius-free kinds).
+func entityRadius(e sketch.Entity) float64 {
+	if r, ok := e.(sketch.RadiusedEntity); ok {
+		return r.ShapeRadius()
+	}
+	return 0
 }
 
 // splineFitSpelling reports a fit spline's fit-method wire spelling (the
@@ -158,32 +173,12 @@ func constraintDeletable(c sketch.Constraint) bool {
 	return !ok || nd.Deletable()
 }
 
-// annotationShape handles the non-curve (image/fill/text) entities.
-func annotationShape(e sketch.Entity) (types.SketchEntityKind, [][]float64, float64) {
-	switch v := e.(type) {
-	case *sketch.SketchImage:
-		return types.SketchEntityImage, [][]float64{{float64(v.Anchor.X), float64(v.Anchor.Y)}}, 0
-	case *sketch.FillRegion:
-		return types.SketchEntityFillRegion, [][]float64{{float64(v.Seed.X), float64(v.Seed.Y)}}, 0
-	case *sketch.TextBox:
-		return types.SketchEntityText, [][]float64{{float64(v.Anchor.X), float64(v.Anchor.Y)}}, 0
-	case *sketch.EquationCurve:
-		return types.SketchEntityEquationCurve, nil, 0
-	case *sketch.FixedSpline:
-		return types.SketchEntityFixedSpline, point2Slice(v.Pts), 0
-	case *sketch.OffsetSpline:
-		return types.SketchEntityOffsetSpline, nil, 0
-	case *sketch.ProjectedPoint:
-		return types.SketchEntityProjectedPoint, [][]float64{{float64(v.Position().X), float64(v.Position().Y)}}, 0
-	case *sketch.ProjectedCurve:
-		return types.SketchEntityProjectedCurve, point2Slice(v.Points()), 0
-	default:
-		return types.SketchEntityUnknown, nil, 0
-	}
-}
-
-// point2Slice renders model points as [x,y] pairs for the wire DTOs.
+// point2Slice renders model points as [x,y] pairs for the wire DTOs (nil in,
+// nil out — shapeless kinds keep omitting the field).
 func point2Slice(pts []math.Point2) [][]float64 {
+	if len(pts) == 0 {
+		return nil
+	}
 	out := make([][]float64, len(pts))
 	for i, p := range pts {
 		out[i] = []float64{float64(p.X), float64(p.Y)}
@@ -354,16 +349,4 @@ func curveID(c sketch.CircularCurve) []uint64 {
 		return []uint64{uint64(e.EntityID())}
 	}
 	return nil
-}
-
-// pt renders a sketch point as [x,y].
-func pt(p *sketch.Point) []float64 { return []float64{float64(p.X), float64(p.Y)} }
-
-// splinePts renders a spline's defining points.
-func splinePts(s *sketch.Spline) [][]float64 {
-	out := make([][]float64, len(s.Points))
-	for i, p := range s.Points {
-		out[i] = pt(p)
-	}
-	return out
 }

--- a/app/sketch3d_constraint_tools.go
+++ b/app/sketch3d_constraint_tools.go
@@ -94,12 +94,7 @@ func readySmooth3D(ents []sketch.Entity) bool {
 }
 
 func acceptHelixOrCircle3D(e sketch.Entity) bool {
-	switch e.(type) {
-	case *sketch.HelicalCurve3D, *sketch.Circle3D:
-		return true
-	default:
-		return false
-	}
+	return entityKindIs(e, sketch.HelicalKind, sketch.CircleKind)
 }
 
 func readyHelical3D(ents []sketch.Entity) bool {
@@ -108,14 +103,8 @@ func readyHelical3D(ents []sketch.Entity) bool {
 }
 
 func acceptSplineOrPoint3D(e sketch.Entity) bool {
-	switch v := e.(type) {
-	case *sketch.Spline3D:
-		return v.IsFitType()
-	case *sketch.Point3D:
-		return true
-	default:
-		return false
-	}
+	// A fit spline's kind is SplineKind; control-point splines don't qualify.
+	return entityKindIs(e, sketch.SplineKind, sketch.PointKind)
 }
 
 func readySplineFit3D(ents []sketch.Entity) bool {
@@ -206,15 +195,11 @@ func helixAndCircleOf(ents []sketch.Entity) (*sketch.HelicalCurve3D, *sketch.Cir
 	var h *sketch.HelicalCurve3D
 	var c *sketch.Circle3D
 	for _, e := range ents {
-		switch v := e.(type) {
-		case *sketch.HelicalCurve3D:
-			if h == nil {
-				h = v
-			}
-		case *sketch.Circle3D:
-			if c == nil {
-				c = v
-			}
+		if v, ok := e.(*sketch.HelicalCurve3D); ok && h == nil {
+			h = v
+		}
+		if v, ok := e.(*sketch.Circle3D); ok && c == nil {
+			c = v
 		}
 	}
 	return h, c
@@ -225,16 +210,27 @@ func splineAndPointOf(ents []sketch.Entity) (*sketch.Spline3D, *sketch.Point3D) 
 	var sp *sketch.Spline3D
 	var p *sketch.Point3D
 	for _, e := range ents {
-		switch v := e.(type) {
-		case *sketch.Spline3D:
-			if sp == nil && v.IsFitType() {
-				sp = v
-			}
-		case *sketch.Point3D:
-			if p == nil {
-				p = v
-			}
+		if v, ok := e.(*sketch.Spline3D); ok && sp == nil && v.IsFitType() {
+			sp = v
+		}
+		if v, ok := e.(*sketch.Point3D); ok && p == nil {
+			p = v
 		}
 	}
 	return sp, p
+}
+
+// entityKindIs reports whether the entity names one of the given kinds — the
+// capability-based accept check the pick predicates share (#1624).
+func entityKindIs(e sketch.Entity, kinds ...sketch.EntityKind) bool {
+	ke, ok := e.(interface{ Kind() sketch.EntityKind })
+	if !ok {
+		return false
+	}
+	for _, k := range kinds {
+		if ke.Kind() == k {
+			return true
+		}
+	}
+	return false
 }

--- a/app/sketch3d_dimension_tool.go
+++ b/app/sketch3d_dimension_tool.go
@@ -22,14 +22,11 @@ func newDimension3DTool() *ConstraintTool {
 	}
 }
 
-// acceptDimensionable3D admits the 3D entity kinds a dimension can size.
+// acceptDimensionable3D admits the 3D entity kinds a dimension can size
+// (a spline of either fit flavor qualifies).
 func acceptDimensionable3D(e sketch.Entity) bool {
-	switch e.(type) {
-	case *sketch.Point3D, *sketch.Line3D, *sketch.Circle3D, *sketch.Spline3D:
-		return true
-	default:
-		return false
-	}
+	return entityKindIs(e, sketch.PointKind, sketch.LineKind, sketch.CircleKind,
+		sketch.SplineKind, sketch.ControlPointSplineKind)
 }
 
 // readyDimension3D is satisfied by a spline, a circle, a line, or two points — the
@@ -89,14 +86,16 @@ func sampledLength3D(sp *sketch.Spline3D) float64 {
 // dimensionPicks3D splits the picks into the kinds the dimension chooser weighs.
 func dimensionPicks3D(ents []sketch.Entity) (splines []*sketch.Spline3D, circles []*sketch.Circle3D, lines []*sketch.Line3D, points []*sketch.Point3D) {
 	for _, e := range ents {
-		switch v := e.(type) {
-		case *sketch.Spline3D:
+		if v, ok := e.(*sketch.Spline3D); ok {
 			splines = append(splines, v)
-		case *sketch.Circle3D:
+		}
+		if v, ok := e.(*sketch.Circle3D); ok {
 			circles = append(circles, v)
-		case *sketch.Line3D:
+		}
+		if v, ok := e.(*sketch.Line3D); ok {
 			lines = append(lines, v)
-		case *sketch.Point3D:
+		}
+		if v, ok := e.(*sketch.Point3D); ok {
 			points = append(points, v)
 		}
 	}

--- a/app/sketch_constraints.go
+++ b/app/sketch_constraints.go
@@ -57,10 +57,7 @@ func filterCircles(ents []sketch.Entity) []*sketch.Circle {
 func circularCurvesFrom(ents []sketch.Entity) []sketch.CircularCurve {
 	var out []sketch.CircularCurve
 	for _, e := range ents {
-		switch c := e.(type) {
-		case *sketch.Circle:
-			out = append(out, c)
-		case *sketch.Arc:
+		if c, ok := e.(sketch.CircularCurve); ok {
 			out = append(out, c)
 		}
 	}

--- a/app/sketch_trim_tools.go
+++ b/app/sketch_trim_tools.go
@@ -68,17 +68,9 @@ func (t *SketchTrimTool) Commit(s *Session) error {
 	if !t.has {
 		return errors.New("trim: no curve picked")
 	}
-	var err error
-	switch e := t.ent.(type) {
-	case *sketch.Line:
-		_, err = sk.TrimLine(e, t.point)
-	case *sketch.Circle:
-		_, err = sk.TrimCircle(e, t.point)
-	case *sketch.Arc:
-		_, err = sk.TrimArc(e, t.point)
-	default:
-		err = fmt.Errorf("trim: unsupported target %T", t.ent)
-	}
+	// The line/circle/arc dispatch lives on the model (sketch.TrimCurveAt,
+	// #1624) — one seam shared with the wire router's trim op.
+	_, err := sk.TrimCurveAt(t.ent, t.point)
 	return err
 }
 

--- a/archguard/sketch_entity_switch_test.go
+++ b/archguard/sketch_entity_switch_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package archguard
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Sketch entities name their own kind, shape, trim, and rebind behavior
+// (#1624, audit I1) — a consumer outside model/sketch that re-derives what an
+// entity is with a `case *sketch.X:` type switch re-creates the drift class
+// that made saves fail at runtime (#1416) and left kinds enumerable-but-not-
+// editable (#1574). The forbidden type list is parsed from model/sketch's
+// Kind() declarations, so a new entity kind extends this guard automatically.
+// Constraint-type switches are a separate finding (I2, #1625) and are not
+// covered here; single type assertions (extracting one typed pick) are fine.
+
+// entityKindReceiverPattern extracts the receiver type of every Kind() method
+// in model/sketch — the closed set of entity types.
+var entityKindReceiverPattern = regexp.MustCompile(`func \(\w+ \*(\w+)\) Kind\(\) EntityKind`)
+
+func TestNoSketchEntityTypeSwitchesOutsideModelSketch(t *testing.T) {
+	entityTypes := sketchEntityTypeNames(t)
+	if len(entityTypes) < 30 {
+		t.Fatalf("parsed only %d entity types from model/sketch (want the full ~35) — did Kind() move out of entity_kind.go?", len(entityTypes))
+	}
+	entityCase := regexp.MustCompile(`case [^:\n]*\*sketch\.(` + strings.Join(entityTypes, "|") + `)\b`)
+	for _, offender := range goSourcesMatching(t, entityCase) {
+		t.Errorf("%s switches on a sketch entity type — use the entity's capability (Kind/ShapePoints/TrimCurveAt/RebindProjection/RadiusDOF) or a single typed assertion instead (#1624, audit I1)", offender)
+	}
+}
+
+// sketchEntityTypeNames parses the Kind() receivers out of model/sketch.
+func sketchEntityTypeNames(t *testing.T) []string {
+	t.Helper()
+	src, err := os.ReadFile("../model/sketch/entity_kind.go")
+	if err != nil {
+		t.Fatalf("reading model/sketch/entity_kind.go: %v", err)
+	}
+	var out []string
+	for _, m := range entityKindReceiverPattern.FindAllStringSubmatch(string(src), -1) {
+		out = append(out, m[1])
+	}
+	return out
+}
+
+// goSourcesMatching walks the module's non-test sources outside model/sketch
+// and returns the files matching the pattern.
+func goSourcesMatching(t *testing.T, pattern *regexp.Regexp) []string {
+	t.Helper()
+	var offenders []string
+	err := filepath.Walk("..", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return skipNonModuleDirs(path, info.Name())
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		src, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return rerr
+		}
+		if pattern.Match(src) {
+			offenders = append(offenders, strings.TrimPrefix(path, "../"))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking module sources: %v", err)
+	}
+	return offenders
+}
+
+// skipNonModuleDirs prunes the walk to this module's first-party sources:
+// model/sketch owns its own switches, and generated/vendored/experimental
+// trees are not subject to the seam.
+func skipNonModuleDirs(path, name string) error {
+	if strings.HasSuffix(filepath.ToSlash(path), "model/sketch") {
+		return filepath.SkipDir
+	}
+	switch name {
+	case ".git", "experiments", "test-utilities", "architecture", "testdata", "node_modules":
+		return filepath.SkipDir
+	}
+	return nil
+}

--- a/model/compdef/sketch_projection_rebind.go
+++ b/model/compdef/sketch_projection_rebind.go
@@ -17,32 +17,19 @@ func (d *PartComponentDefinition) rebindSketchProjections() {
 	for i := 0; i < d.sketches.Count(); i++ {
 		sk := d.sketches.Item(i)
 		for _, e := range sk.Entities() {
-			d.rebindProjection(e, sk.Plane())
+			// Each projected entity re-attaches itself through the resolver
+			// below — no per-kind dispatch here (#1624, audit I1).
+			sketch.RebindProjection(e, d, sk.Plane())
 		}
 	}
 }
 
-// rebindProjection re-attaches one projected entity's live source from its persisted descriptor;
-// an unknown/empty kind leaves the entity frozen.
-func (d *PartComponentDefinition) rebindProjection(e sketch.Entity, plane sketch.Plane) {
-	switch v := e.(type) {
-	case *sketch.ProjectedPoint:
-		if kind, id := v.SourceDescriptor(); kind != "" {
-			if src, ok := d.pointRefSource(kind, id); ok {
-				v.Rebind(src)
-			}
-		}
-	case *sketch.ProjectedCurve:
-		if kind, id := v.SourceDescriptor(); kind != "" {
-			if src, ok := d.curveRefSource(kind, id, plane); ok {
-				v.Rebind(src)
-			}
-		}
-	}
-}
+// The part definition is the projection-source resolver: it owns the
+// vertices/edges/work geometry the persisted descriptors point at.
+var _ sketch.ProjectionSourceResolver = (*PartComponentDefinition)(nil)
 
-// pointRefSource rebuilds a point projection source from its descriptor.
-func (d *PartComponentDefinition) pointRefSource(kind, id string) (sketch.PointSource, bool) {
+// PointProjectionSource rebuilds a point projection source from its descriptor.
+func (d *PartComponentDefinition) PointProjectionSource(kind, id string) (sketch.PointSource, bool) {
 	switch kind {
 	case "vertex":
 		return NewVertexRefSource(d, id), true
@@ -53,9 +40,9 @@ func (d *PartComponentDefinition) pointRefSource(kind, id string) (sketch.PointS
 	}
 }
 
-// curveRefSource rebuilds a curve projection source from its descriptor; a work-plane projection
-// also needs the target sketch plane it intersects.
-func (d *PartComponentDefinition) curveRefSource(kind, id string, plane sketch.Plane) (sketch.CurveSource, bool) {
+// CurveProjectionSource rebuilds a curve projection source from its descriptor; a work-plane
+// projection also needs the target sketch plane it intersects.
+func (d *PartComponentDefinition) CurveProjectionSource(kind, id string, plane sketch.Plane) (sketch.CurveSource, bool) {
 	switch kind {
 	case "edge":
 		return NewEdgeRefSource(d, id), true

--- a/model/compdef/sketch_projection_rebind_test.go
+++ b/model/compdef/sketch_projection_rebind_test.go
@@ -34,26 +34,26 @@ func TestProjectionSourceKindTags(t *testing.T) {
 // reject an unknown one (the frozen fallback).
 func TestProjectionSourceBuilders(t *testing.T) {
 	d := NewPartComponentDefinition()
-	if _, ok := d.pointRefSource("vertex", "k"); !ok {
+	if _, ok := d.PointProjectionSource("vertex", "k"); !ok {
 		t.Error("vertex point source should build")
 	}
-	if _, ok := d.pointRefSource("workPoint", string(feature.OriginCenter)); !ok {
+	if _, ok := d.PointProjectionSource("workPoint", string(feature.OriginCenter)); !ok {
 		t.Error("workPoint source should build")
 	}
-	if _, ok := d.pointRefSource("mystery", "k"); ok {
+	if _, ok := d.PointProjectionSource("mystery", "k"); ok {
 		t.Error("unknown point kind must not build")
 	}
 	plane := sketch.XYPlane()
-	if _, ok := d.curveRefSource("edge", "k", plane); !ok {
+	if _, ok := d.CurveProjectionSource("edge", "k", plane); !ok {
 		t.Error("edge curve source should build")
 	}
-	if _, ok := d.curveRefSource("workAxis", string(feature.OriginXAxis), plane); !ok {
+	if _, ok := d.CurveProjectionSource("workAxis", string(feature.OriginXAxis), plane); !ok {
 		t.Error("workAxis source should build")
 	}
-	if _, ok := d.curveRefSource("workPlane", string(feature.OriginXZPlane), plane); !ok {
+	if _, ok := d.CurveProjectionSource("workPlane", string(feature.OriginXZPlane), plane); !ok {
 		t.Error("workPlane source should build")
 	}
-	if _, ok := d.curveRefSource("mystery", "k", plane); ok {
+	if _, ok := d.CurveProjectionSource("mystery", "k", plane); ok {
 		t.Error("unknown curve kind must not build")
 	}
 }

--- a/model/sketch/edit_trim_dispatch.go
+++ b/model/sketch/edit_trim_dispatch.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"fmt"
+
+	"oblikovati.org/math"
+)
+
+// trimmableCurve is the sealed trim capability: each trimmable entity routes
+// to its own trim (like definingPoints in drag.go), so the line/circle/arc
+// dispatch is stated once here instead of per driver — it used to be copied in
+// the wire router and the trim tool (#1624, audit I1).
+type trimmableCurve interface {
+	trimAt(s *Sketch, pick math.Point2) ([]Entity, error)
+}
+
+func (l *Line) trimAt(s *Sketch, pick math.Point2) ([]Entity, error)   { return s.TrimLine(l, pick) }
+func (c *Circle) trimAt(s *Sketch, pick math.Point2) ([]Entity, error) { return s.TrimCircle(c, pick) }
+func (a *Arc) trimAt(s *Sketch, pick math.Point2) ([]Entity, error)    { return s.TrimArc(a, pick) }
+
+// TrimCurveAt trims the picked curve at pick, removing the picked span up to
+// the nearest crossings. Only lines, circles, and arcs are trimmable.
+//
+//	removed, err := sk.TrimCurveAt(pickedEntity, pickPoint)
+func (s *Sketch) TrimCurveAt(e Entity, pick math.Point2) ([]Entity, error) {
+	tc, ok := e.(trimmableCurve)
+	if !ok {
+		return nil, fmt.Errorf("trim: unsupported target %T (want a line, circle, or arc)", e)
+	}
+	return tc.trimAt(s, pick)
+}

--- a/model/sketch/entity_capabilities_test.go
+++ b/model/sketch/entity_capabilities_test.go
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// The entity capabilities added for #1624 (audit I1): every entity names its
+// own kind and shape; circular kinds expose a radius; trim and projection
+// rebind dispatch through the entity, not through consumer type switches.
+
+func TestShapedEntityKindsAndPoints2D(t *testing.T) {
+	sc := NewSketches()
+	s := sc.Add(XYPlane())
+	populateEvery2DKind(t, sc, s)
+	for _, e := range s.Entities() {
+		se, ok := e.(ShapedEntity)
+		if !ok {
+			t.Errorf("entity %T does not implement ShapedEntity", e)
+			continue
+		}
+		if se.Kind() == "" {
+			t.Errorf("entity %T reports an empty kind", e)
+		}
+	}
+	assertShape2DExamples(t, s)
+}
+
+// assertShape2DExamples pins the shape contract on representative kinds: the
+// point orders the wire has always shipped.
+func assertShape2DExamples(t *testing.T, s *Sketch) {
+	t.Helper()
+	line := s.Lines().Item(0)
+	if got := line.ShapePoints(); len(got) != 2 || got[0] != line.A.Position() || got[1] != line.B.Position() {
+		t.Errorf("line ShapePoints = %v, want [A B]", got)
+	}
+	circle := s.Circles().Item(0)
+	if got := circle.ShapePoints(); len(got) != 1 || got[0] != circle.Center.Position() {
+		t.Errorf("circle ShapePoints = %v, want [Center]", got)
+	}
+	if circle.ShapeRadius() != float64(circle.Radius) {
+		t.Errorf("circle ShapeRadius = %v, want %v", circle.ShapeRadius(), circle.Radius)
+	}
+	arc := s.Arcs().Item(0)
+	if got := arc.ShapePoints(); len(got) != 3 {
+		t.Errorf("arc ShapePoints = %v, want [Center Start End]", got)
+	}
+	if arc.ShapeRadius() != float64(arc.Radius()) {
+		t.Errorf("arc ShapeRadius = %v, want %v", arc.ShapeRadius(), arc.Radius())
+	}
+	if got := s.EquationCurves().Item(0).ShapePoints(); got != nil {
+		t.Errorf("equation curve ShapePoints = %v, want nil (expression-derived)", got)
+	}
+}
+
+func TestShapedEntityKindsAndPoints3D(t *testing.T) {
+	c := NewSketches3D()
+	s := c.Add()
+	populateEvery3DKind(t, s)
+	for _, e := range s.Entities() {
+		se, ok := e.(ShapedEntity3D)
+		if !ok {
+			t.Errorf("3D entity %T does not implement ShapedEntity3D", e)
+			continue
+		}
+		if se.Kind() == "" {
+			t.Errorf("3D entity %T reports an empty kind", e)
+		}
+	}
+	assertShape3DExamples(t, s)
+}
+
+// assertShape3DExamples pins the 3D shape contract: circular kinds carry their
+// radius, free-form curves ship a display sample, splines split by fit flag.
+func assertShape3DExamples(t *testing.T, s *Sketch3D) {
+	t.Helper()
+	kinds := map[EntityKind][]Entity{}
+	for _, e := range s.Entities() {
+		k := e.(ShapedEntity3D).Kind()
+		kinds[k] = append(kinds[k], e)
+	}
+	if len(kinds[SplineKind]) != 1 || len(kinds[ControlPointSplineKind]) != 1 {
+		t.Errorf("spline kinds = %d fit / %d control-point, want 1/1 (fit flag drives the kind)",
+			len(kinds[SplineKind]), len(kinds[ControlPointSplineKind]))
+	}
+	circle := kinds[CircleKind][0].(*Circle3D)
+	if circle.ShapeRadius() != float64(circle.Radius) {
+		t.Errorf("3D circle ShapeRadius = %v, want %v", circle.ShapeRadius(), circle.Radius)
+	}
+	helix := kinds[HelicalKind][0].(*HelicalCurve3D)
+	if helix.ShapeRadius() != float64(helix.StartRadius) {
+		t.Errorf("helix ShapeRadius = %v, want start radius %v", helix.ShapeRadius(), helix.StartRadius)
+	}
+	if sample := kinds[SplineKind][0].(*Spline3D).ShapePoints3D(); len(sample) < 3 {
+		t.Errorf("fit spline ShapePoints3D = %d points, want a display sample", len(sample))
+	}
+	ellipse := kinds[EllipseKind][0].(*Ellipse3D)
+	if ellipse.ShapeRadius() != float64(ellipse.MajorRadius) {
+		t.Errorf("3D ellipse ShapeRadius = %v, want major radius", ellipse.ShapeRadius())
+	}
+}
+
+// TestDerivedCurve3DShapeIsIdentityOnly: the surface-derived curves have no
+// enumeration geometry of their own (they re-evaluate on recompute), and the
+// included kinds are always construction geometry.
+func TestDerivedCurve3DShapeIsIdentityOnly(t *testing.T) {
+	derived := []ShapedEntity3D{
+		&IntersectionCurve3D{}, &SilhouetteCurve3D{}, &ProjectToSurfaceCurve3D{},
+		&OnFaceCurve3D{}, &OffsetCurve3{},
+	}
+	for _, e := range derived {
+		if e.Kind() == "" {
+			t.Errorf("%T reports an empty kind", e)
+		}
+		if pts := e.ShapePoints3D(); pts != nil {
+			t.Errorf("%T ShapePoints3D = %v, want nil (recompute-derived)", e, pts)
+		}
+	}
+	if !(&IncludedCurve3D{}).IsConstruction() {
+		t.Error("an included curve must always be construction geometry")
+	}
+	if (&IncludedCurve3D{}).Kind() != IncludedCurveKind || (&IncludedPoint3D{}).Kind() != IncludedPointKind {
+		t.Error("included kinds must name themselves")
+	}
+}
+
+func TestRadiusDOFDrivesTheEntity(t *testing.T) {
+	c := NewSketches3D()
+	s := c.Add()
+	circle := s.AddCircle3D(math.P3(0, 0, 0), mustUnit3(t, 0, 0, 1), 2)
+	helix := s.AddHelix3D(math.P3(0, 0, 0), mustUnit3(t, 0, 0, 1), 1, 0.5, 0, 3, false)
+	*circle.RadiusDOF() = 5
+	if circle.Radius != 5 {
+		t.Errorf("circle radius after DOF write = %v, want 5", circle.Radius)
+	}
+	*helix.RadiusDOF() = 4
+	if helix.StartRadius != 4 {
+		t.Errorf("helix start radius after DOF write = %v, want 4", helix.StartRadius)
+	}
+}
+
+// TestTrimCurveAtDispatchesByEntity: the single trim seam both drivers share
+// (#1624) — trimmable kinds route to their trim, everything else is refused
+// with the offending type named.
+func TestTrimCurveAtDispatchesByEntity(t *testing.T) {
+	sc := NewSketches()
+	s := sc.Add(XYPlane())
+	// Two crossing lines so the trim has a crossing to cut at.
+	l := s.Lines().AddByTwoPoints(math.P2(-1, 0), math.P2(1, 0))
+	s.Lines().AddByTwoPoints(math.P2(0, -1), math.P2(0, 1))
+	if _, err := s.TrimCurveAt(l, math.P2(0.5, 0)); err != nil {
+		t.Fatalf("TrimCurveAt(line): %v", err)
+	}
+	text := s.texts.AddStyled(math.P2(0, 0), "x", 1, 0, TextHJustify(0), TextVJustify(0), "sans", 0)
+	_, err := s.TrimCurveAt(text, math.P2(0, 0))
+	if err == nil || !strings.Contains(err.Error(), "TextBox") {
+		t.Errorf("TrimCurveAt(text) = %v, want a refusal naming the type", err)
+	}
+}
+
+// fakeProjectionResolver resolves fixed descriptors for the rebind test.
+type fakeProjectionResolver struct {
+	pointSrc PointSource
+	curveSrc CurveSource
+}
+
+func (f *fakeProjectionResolver) PointProjectionSource(kind, _ string) (PointSource, bool) {
+	return f.pointSrc, kind == "vertex"
+}
+
+func (f *fakeProjectionResolver) CurveProjectionSource(kind, _ string, _ Plane) (CurveSource, bool) {
+	return f.curveSrc, kind == "edge"
+}
+
+// TestRebindProjectionReattachesSources: each projected entity re-attaches its
+// own live source through the resolver; unknown descriptors stay frozen and
+// non-projected entities are untouched.
+func TestRebindProjectionReattachesSources(t *testing.T) {
+	sc := NewSketches()
+	s := sc.Add(XYPlane())
+	pp := s.RestoreProjectedPoint(nextID(), math.P2(1, 1), "vertex", "V1")
+	pc := s.RestoreProjectedCurve(nextID(), []math.Point2{math.P2(0, 0), math.P2(1, 0)}, "edge", "E1")
+	frozen := s.RestoreProjectedCurve(nextID(), []math.Point2{math.P2(2, 0)}, "mystery", "X")
+	res := &fakeProjectionResolver{
+		pointSrc: &fakePointSource{id: "V1", pos: math.P3(1, 1, 0)},
+		curveSrc: &fakeCurveSource{id: "E1", pts: []math.Point3{math.P3(0, 0, 0), math.P3(1, 0, 0)}},
+	}
+	for _, e := range s.Entities() {
+		RebindProjection(e, res, s.Plane())
+	}
+	if !pp.Linked() {
+		t.Error("projected point must relink through the resolver")
+	}
+	if !pc.Linked() {
+		t.Error("projected curve must relink through the resolver")
+	}
+	if frozen.Linked() {
+		t.Error("an unresolvable descriptor must stay frozen")
+	}
+}

--- a/model/sketch/entity_dof_3d.go
+++ b/model/sketch/entity_dof_3d.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import "oblikovati.org/math"
+
+// RadiusDOF exposes the solver variable behind a circular 3D entity's radius —
+// the DOF a radius dimension or drag drives. Stated on the entity so consumers
+// need no type switch over the radius-bearing kinds (#1624, audit I1).
+func (c *Circle3D) RadiusDOF() *math.Scalar { return &c.Radius }
+
+// RadiusDOF is the helix's start radius: the variable its radius dimension drives.
+func (h *HelicalCurve3D) RadiusDOF() *math.Scalar { return &h.StartRadius }

--- a/model/sketch/entity_kind.go
+++ b/model/sketch/entity_kind.go
@@ -23,7 +23,7 @@ const (
 	EllipseKind            EntityKind = "ellipse"
 	EllipticalArcKind      EntityKind = "ellipticalArc"
 	SplineKind             EntityKind = "spline"
-	ControlPointSplineKind EntityKind = "controlPointSpline" // 3D only: a non-fit Spline3D
+	ControlPointSplineKind EntityKind = "controlPointSpline" // a non-fit spline, 2D or 3D
 	FixedSplineKind        EntityKind = "fixedSpline"
 	OffsetSplineKind       EntityKind = "offsetSpline"
 	EquationCurveKind      EntityKind = "equationCurve"
@@ -36,15 +36,32 @@ const (
 	HelicalKind            EntityKind = "helical"
 )
 
+// The enumeration-only kinds: entities that are never persisted as recipe rows
+// (points persist in the recipe's Points table, handles inside their spline,
+// the surface-derived 3D curves rebind on recompute) but still name themselves
+// over the API. Spellings match the wire enums by construction.
+const (
+	PointKind                 EntityKind = "point"
+	SplineHandleKind          EntityKind = "splineHandle"
+	IncludedPointKind         EntityKind = "includedPoint"
+	IncludedCurveKind         EntityKind = "includedCurve"
+	IntersectionCurveKind     EntityKind = "intersection"
+	SilhouetteCurveKind       EntityKind = "silhouette"
+	ProjectToSurfaceCurveKind EntityKind = "projectToSurface"
+	OnFaceCurveKind           EntityKind = "onFace"
+	OffsetCurveKind           EntityKind = "offset"
+)
+
 // Kind identifies each 2D entity for codec dispatch (and, over the API, for
 // enumeration). Each concrete type declares its own — like definingPoints in
 // drag.go — so no consumer needs a type switch.
+func (p *Point) Kind() EntityKind          { return PointKind }
 func (l *Line) Kind() EntityKind           { return LineKind }
 func (c *Circle) Kind() EntityKind         { return CircleKind }
 func (a *Arc) Kind() EntityKind            { return ArcKind }
 func (e *Ellipse) Kind() EntityKind        { return EllipseKind }
 func (e *EllipticalArc) Kind() EntityKind  { return EllipticalArcKind }
-func (s *Spline) Kind() EntityKind         { return SplineKind }
+func (h *SplineHandle) Kind() EntityKind   { return SplineHandleKind }
 func (f *FixedSpline) Kind() EntityKind    { return FixedSplineKind }
 func (o *OffsetSpline) Kind() EntityKind   { return OffsetSplineKind }
 func (e *EquationCurve) Kind() EntityKind  { return EquationCurveKind }
@@ -55,24 +72,40 @@ func (f *FillRegion) Kind() EntityKind     { return FillRegionKind }
 func (p *ProjectedPoint) Kind() EntityKind { return ProjectedPointKind }
 func (c *ProjectedCurve) Kind() EntityKind { return ProjectedCurveKind }
 
-// Kind identifies each 3D entity. A Spline3D's kind depends on its fit flag —
-// the two spellings restore through different factory arguments, exactly as
-// the retired serialize switch encoded them.
+// A spline's kind depends on its fit flag in either dimension: interpolation
+// splines are "spline", approximating ones "controlPointSpline" — the wire
+// spelling (#150), now also the persisted one (the decoder reads the persisted
+// Fit flag, so either spelling restores).
+func (s *Spline) Kind() EntityKind   { return splineKindFor(s.fit) }
+func (s *Spline3D) Kind() EntityKind { return splineKindFor(s.fit) }
+
+func splineKindFor(fit bool) EntityKind {
+	if fit {
+		return SplineKind
+	}
+	return ControlPointSplineKind
+}
+
+// Kind identifies each 3D entity.
+func (p *Point3D) Kind() EntityKind         { return PointKind }
 func (l *Line3D) Kind() EntityKind          { return LineKind }
 func (c *Circle3D) Kind() EntityKind        { return CircleKind }
 func (a *Arc3D) Kind() EntityKind           { return ArcKind }
 func (e *Ellipse3D) Kind() EntityKind       { return EllipseKind }
 func (e *EllipticalArc3D) Kind() EntityKind { return EllipticalArcKind }
+func (h *SplineHandle3D) Kind() EntityKind  { return SplineHandleKind }
 func (f *FixedSpline3D) Kind() EntityKind   { return FixedSplineKind }
 func (e *EquationCurve3D) Kind() EntityKind { return EquationCurveKind }
 func (h *HelicalCurve3D) Kind() EntityKind  { return HelicalKind }
 
-func (s *Spline3D) Kind() EntityKind {
-	if s.fit {
-		return SplineKind
-	}
-	return ControlPointSplineKind
-}
+// Kind identifies the reference/derived 3D geometry (enumeration-only kinds).
+func (p *IncludedPoint3D) Kind() EntityKind         { return IncludedPointKind }
+func (c *IncludedCurve3D) Kind() EntityKind         { return IncludedCurveKind }
+func (c *IntersectionCurve3D) Kind() EntityKind     { return IntersectionCurveKind }
+func (c *SilhouetteCurve3D) Kind() EntityKind       { return SilhouetteCurveKind }
+func (c *ProjectToSurfaceCurve3D) Kind() EntityKind { return ProjectToSurfaceCurveKind }
+func (c *OnFaceCurve3D) Kind() EntityKind           { return OnFaceCurveKind }
+func (c *OffsetCurve3) Kind() EntityKind            { return OffsetCurveKind }
 
 // kindedEntity is the dispatch seam the codec registries key on. It stays
 // unexported until the full ShapedEntity capability lands (#1624 step 2).

--- a/model/sketch/entity_kind.go
+++ b/model/sketch/entity_kind.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+// EntityKind names what a sketch entity IS — the stable identifier its
+// persistence codec is registered under (#1624, audit I1). The string values
+// are the .obk recipe vocabulary (ADR-0020) and must never change once
+// shipped; they intentionally stay decoupled from the wire enum
+// api/types.SketchEntityKind, which follows API SemVer instead — the router
+// maps between the two at its boundary.
+//
+// 2D and 3D entities share one vocabulary (a Line3D is still a "line"); the
+// dimension is carried by which codec registry the kind is looked up in.
+type EntityKind string
+
+// The persisted entity kinds. A kind used by both dimensions (line, circle,
+// arc, ellipse, ellipticalArc, spline, fixedSpline, equationCurve) has one
+// constant and two codecs.
+const (
+	LineKind               EntityKind = "line"
+	CircleKind             EntityKind = "circle"
+	ArcKind                EntityKind = "arc"
+	EllipseKind            EntityKind = "ellipse"
+	EllipticalArcKind      EntityKind = "ellipticalArc"
+	SplineKind             EntityKind = "spline"
+	ControlPointSplineKind EntityKind = "controlPointSpline" // 3D only: a non-fit Spline3D
+	FixedSplineKind        EntityKind = "fixedSpline"
+	OffsetSplineKind       EntityKind = "offsetSpline"
+	EquationCurveKind      EntityKind = "equationCurve"
+	BlockInstanceKind      EntityKind = "blockInstance"
+	ImageKind              EntityKind = "image"
+	TextKind               EntityKind = "text"
+	FillRegionKind         EntityKind = "fillRegion"
+	ProjectedPointKind     EntityKind = "projectedPoint"
+	ProjectedCurveKind     EntityKind = "projectedCurve"
+	HelicalKind            EntityKind = "helical"
+)
+
+// Kind identifies each 2D entity for codec dispatch (and, over the API, for
+// enumeration). Each concrete type declares its own — like definingPoints in
+// drag.go — so no consumer needs a type switch.
+func (l *Line) Kind() EntityKind           { return LineKind }
+func (c *Circle) Kind() EntityKind         { return CircleKind }
+func (a *Arc) Kind() EntityKind            { return ArcKind }
+func (e *Ellipse) Kind() EntityKind        { return EllipseKind }
+func (e *EllipticalArc) Kind() EntityKind  { return EllipticalArcKind }
+func (s *Spline) Kind() EntityKind         { return SplineKind }
+func (f *FixedSpline) Kind() EntityKind    { return FixedSplineKind }
+func (o *OffsetSpline) Kind() EntityKind   { return OffsetSplineKind }
+func (e *EquationCurve) Kind() EntityKind  { return EquationCurveKind }
+func (b *BlockInstance) Kind() EntityKind  { return BlockInstanceKind }
+func (i *SketchImage) Kind() EntityKind    { return ImageKind }
+func (t *TextBox) Kind() EntityKind        { return TextKind }
+func (f *FillRegion) Kind() EntityKind     { return FillRegionKind }
+func (p *ProjectedPoint) Kind() EntityKind { return ProjectedPointKind }
+func (c *ProjectedCurve) Kind() EntityKind { return ProjectedCurveKind }
+
+// Kind identifies each 3D entity. A Spline3D's kind depends on its fit flag —
+// the two spellings restore through different factory arguments, exactly as
+// the retired serialize switch encoded them.
+func (l *Line3D) Kind() EntityKind          { return LineKind }
+func (c *Circle3D) Kind() EntityKind        { return CircleKind }
+func (a *Arc3D) Kind() EntityKind           { return ArcKind }
+func (e *Ellipse3D) Kind() EntityKind       { return EllipseKind }
+func (e *EllipticalArc3D) Kind() EntityKind { return EllipticalArcKind }
+func (f *FixedSpline3D) Kind() EntityKind   { return FixedSplineKind }
+func (e *EquationCurve3D) Kind() EntityKind { return EquationCurveKind }
+func (h *HelicalCurve3D) Kind() EntityKind  { return HelicalKind }
+
+func (s *Spline3D) Kind() EntityKind {
+	if s.fit {
+		return SplineKind
+	}
+	return ControlPointSplineKind
+}
+
+// kindedEntity is the dispatch seam the codec registries key on. It stays
+// unexported until the full ShapedEntity capability lands (#1624 step 2).
+type kindedEntity interface{ Kind() EntityKind }

--- a/model/sketch/entity_shape.go
+++ b/model/sketch/entity_shape.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import "oblikovati.org/math"
+
+// ShapedEntity is the capability consumers used to type-switch for (#1624,
+// audit I1): what kind am I, and which points sketch my shape for display or
+// enumeration. Every 2D entity implements it (assertions below), so a lost
+// method fails the build, not an API reply.
+type ShapedEntity interface {
+	Entity
+	Kind() EntityKind
+	// ShapePoints returns the points that outline the entity for enumeration:
+	// defining points for analytic curves, the anchor for annotations, nil for
+	// entities whose geometry is expression- or reference-derived.
+	ShapePoints() []math.Point2
+}
+
+// RadiusedEntity is the optional radius capability — only the circular kinds
+// carry one, so it stays separate from ShapedEntity (interface segregation);
+// consumers report 0 for everything else, as the retired switches did.
+type RadiusedEntity interface{ ShapeRadius() float64 }
+
+var (
+	_ ShapedEntity = (*Point)(nil)
+	_ ShapedEntity = (*Line)(nil)
+	_ ShapedEntity = (*Circle)(nil)
+	_ ShapedEntity = (*Arc)(nil)
+	_ ShapedEntity = (*Ellipse)(nil)
+	_ ShapedEntity = (*EllipticalArc)(nil)
+	_ ShapedEntity = (*Spline)(nil)
+	_ ShapedEntity = (*SplineHandle)(nil)
+	_ ShapedEntity = (*SketchImage)(nil)
+	_ ShapedEntity = (*FillRegion)(nil)
+	_ ShapedEntity = (*TextBox)(nil)
+	_ ShapedEntity = (*EquationCurve)(nil)
+	_ ShapedEntity = (*FixedSpline)(nil)
+	_ ShapedEntity = (*OffsetSpline)(nil)
+	_ ShapedEntity = (*BlockInstance)(nil)
+	_ ShapedEntity = (*ProjectedPoint)(nil)
+	_ ShapedEntity = (*ProjectedCurve)(nil)
+
+	_ RadiusedEntity = (*Circle)(nil)
+	_ RadiusedEntity = (*Arc)(nil)
+)
+
+func (p *Point) ShapePoints() []math.Point2 { return []math.Point2{p.Position()} }
+func (l *Line) ShapePoints() []math.Point2 {
+	return []math.Point2{l.A.Position(), l.B.Position()}
+}
+func (c *Circle) ShapePoints() []math.Point2 { return []math.Point2{c.Center.Position()} }
+func (a *Arc) ShapePoints() []math.Point2 {
+	return []math.Point2{a.Center.Position(), a.Start.Position(), a.End.Position()}
+}
+func (e *Ellipse) ShapePoints() []math.Point2       { return []math.Point2{e.Center.Position()} }
+func (e *EllipticalArc) ShapePoints() []math.Point2 { return []math.Point2{e.Center.Position()} }
+
+func (s *Spline) ShapePoints() []math.Point2 {
+	out := make([]math.Point2, len(s.Points))
+	for i, p := range s.Points {
+		out[i] = p.Position()
+	}
+	return out
+}
+
+func (h *SplineHandle) ShapePoints() []math.Point2 {
+	return []math.Point2{h.Anchor.Position(), h.End.Position()}
+}
+
+func (i *SketchImage) ShapePoints() []math.Point2    { return []math.Point2{i.Anchor} }
+func (f *FillRegion) ShapePoints() []math.Point2     { return []math.Point2{f.Seed} }
+func (t *TextBox) ShapePoints() []math.Point2        { return []math.Point2{t.Anchor} }
+func (e *EquationCurve) ShapePoints() []math.Point2  { return nil }
+func (f *FixedSpline) ShapePoints() []math.Point2    { return append([]math.Point2(nil), f.Pts...) }
+func (o *OffsetSpline) ShapePoints() []math.Point2   { return nil }
+func (b *BlockInstance) ShapePoints() []math.Point2  { return nil }
+func (p *ProjectedPoint) ShapePoints() []math.Point2 { return []math.Point2{p.Position()} }
+func (c *ProjectedCurve) ShapePoints() []math.Point2 { return c.Points() }
+
+func (c *Circle) ShapeRadius() float64 { return float64(c.Radius) }
+func (a *Arc) ShapeRadius() float64    { return float64(a.Radius()) }

--- a/model/sketch/entity_shape_3d.go
+++ b/model/sketch/entity_shape_3d.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import "oblikovati.org/math"
+
+// ShapedEntity3D is the 3D twin of [ShapedEntity] (#1624). Free-form curves
+// report a display sample rather than their defining points — the polyline the
+// enumerate API has always shipped — and the surface-derived curves report
+// nil, since their geometry is recompute-derived (only identity is shown).
+type ShapedEntity3D interface {
+	Entity
+	Kind() EntityKind
+	ShapePoints3D() []math.Point3
+}
+
+var (
+	_ ShapedEntity3D = (*Point3D)(nil)
+	_ ShapedEntity3D = (*Line3D)(nil)
+	_ ShapedEntity3D = (*Circle3D)(nil)
+	_ ShapedEntity3D = (*Arc3D)(nil)
+	_ ShapedEntity3D = (*Ellipse3D)(nil)
+	_ ShapedEntity3D = (*EllipticalArc3D)(nil)
+	_ ShapedEntity3D = (*Spline3D)(nil)
+	_ ShapedEntity3D = (*SplineHandle3D)(nil)
+	_ ShapedEntity3D = (*FixedSpline3D)(nil)
+	_ ShapedEntity3D = (*EquationCurve3D)(nil)
+	_ ShapedEntity3D = (*HelicalCurve3D)(nil)
+	_ ShapedEntity3D = (*IncludedPoint3D)(nil)
+	_ ShapedEntity3D = (*IncludedCurve3D)(nil)
+	_ ShapedEntity3D = (*IntersectionCurve3D)(nil)
+	_ ShapedEntity3D = (*SilhouetteCurve3D)(nil)
+	_ ShapedEntity3D = (*ProjectToSurfaceCurve3D)(nil)
+	_ ShapedEntity3D = (*OnFaceCurve3D)(nil)
+	_ ShapedEntity3D = (*OffsetCurve3)(nil)
+
+	_ RadiusedEntity = (*Circle3D)(nil)
+	_ RadiusedEntity = (*Arc3D)(nil)
+	_ RadiusedEntity = (*HelicalCurve3D)(nil)
+	_ RadiusedEntity = (*Ellipse3D)(nil)
+	_ RadiusedEntity = (*EllipticalArc3D)(nil)
+)
+
+func (p *Point3D) ShapePoints3D() []math.Point3 { return []math.Point3{p.Position()} }
+func (l *Line3D) ShapePoints3D() []math.Point3 {
+	return []math.Point3{l.A.Position(), l.B.Position()}
+}
+func (c *Circle3D) ShapePoints3D() []math.Point3 { return []math.Point3{c.Center.Position()} }
+func (a *Arc3D) ShapePoints3D() []math.Point3 {
+	return []math.Point3{a.Center.Position(), a.Start.Position(), a.End.Position()}
+}
+func (e *Ellipse3D) ShapePoints3D() []math.Point3 { return []math.Point3{e.Center.Position()} }
+func (e *EllipticalArc3D) ShapePoints3D() []math.Point3 {
+	return []math.Point3{e.Center.Position()}
+}
+func (h *HelicalCurve3D) ShapePoints3D() []math.Point3 {
+	return []math.Point3{h.Origin.Position()}
+}
+func (h *SplineHandle3D) ShapePoints3D() []math.Point3 {
+	return []math.Point3{h.Anchor.Position(), h.End.Position()}
+}
+
+func (s *Spline3D) ShapePoints3D() []math.Point3        { return s.Sample() }
+func (f *FixedSpline3D) ShapePoints3D() []math.Point3   { return f.Sample() }
+func (e *EquationCurve3D) ShapePoints3D() []math.Point3 { return e.Sample(16) }
+
+func (p *IncludedPoint3D) ShapePoints3D() []math.Point3 { return []math.Point3{p.Position()} }
+func (c *IncludedCurve3D) ShapePoints3D() []math.Point3 { return c.Points() }
+
+// The surface-derived curves rebind and re-evaluate on recompute; they carry
+// no enumeration geometry of their own (M22-F11).
+func (c *IntersectionCurve3D) ShapePoints3D() []math.Point3     { return nil }
+func (c *SilhouetteCurve3D) ShapePoints3D() []math.Point3       { return nil }
+func (c *ProjectToSurfaceCurve3D) ShapePoints3D() []math.Point3 { return nil }
+func (c *OnFaceCurve3D) ShapePoints3D() []math.Point3           { return nil }
+func (c *OffsetCurve3) ShapePoints3D() []math.Point3            { return nil }
+
+func (c *Circle3D) ShapeRadius() float64        { return float64(c.Radius) }
+func (a *Arc3D) ShapeRadius() float64           { return float64(a.Radius()) }
+func (h *HelicalCurve3D) ShapeRadius() float64  { return float64(h.StartRadius) }
+func (e *Ellipse3D) ShapeRadius() float64       { return float64(e.MajorRadius) }
+func (e *EllipticalArc3D) ShapeRadius() float64 { return float64(e.MajorRadius) }

--- a/model/sketch/include_3d.go
+++ b/model/sketch/include_3d.go
@@ -71,6 +71,11 @@ type IncludedCurve3D struct {
 	linked bool
 }
 
+// IsConstruction reports that an included curve is reference/construction
+// geometry — always, regardless of the embedded flag (the rule used to live in
+// the router's enumerate switch; #1624 moved it onto the entity).
+func (c *IncludedCurve3D) IsConstruction() bool { return true }
+
 // Points returns the cached model-space polyline.
 func (c *IncludedCurve3D) Points() []math.Point3 {
 	out := make([]math.Point3, len(c.points))

--- a/model/sketch/projection_rebind.go
+++ b/model/sketch/projection_rebind.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+// ProjectionSourceResolver rebuilds a live projection source from a persisted
+// (kind, id) descriptor. The part definition implements it — it owns the
+// referenced vertices/edges/work geometry that model/sketch cannot see (#1268).
+type ProjectionSourceResolver interface {
+	PointProjectionSource(kind, id string) (PointSource, bool)
+	// CurveProjectionSource also receives the target sketch plane: a work-plane
+	// projection is the line where the two planes intersect.
+	CurveProjectionSource(kind, id string, plane Plane) (CurveSource, bool)
+}
+
+// sourceRebindable is the sealed rebind capability: each projected entity
+// re-attaches its own source through the resolver, so no consumer needs to
+// know which projected kinds exist (#1624, audit I1).
+type sourceRebindable interface {
+	rebindFrom(res ProjectionSourceResolver, plane Plane)
+}
+
+func (p *ProjectedPoint) rebindFrom(res ProjectionSourceResolver, _ Plane) {
+	kind, id := p.SourceDescriptor()
+	if kind == "" {
+		return // legacy row without a descriptor stays frozen
+	}
+	if src, ok := res.PointProjectionSource(kind, id); ok {
+		p.Rebind(src)
+	}
+}
+
+func (c *ProjectedCurve) rebindFrom(res ProjectionSourceResolver, plane Plane) {
+	kind, id := c.SourceDescriptor()
+	if kind == "" {
+		return
+	}
+	if src, ok := res.CurveProjectionSource(kind, id, plane); ok {
+		c.Rebind(src)
+	}
+}
+
+// RebindProjection re-attaches e's live projection source after a reload,
+// making the projection associative again; non-projected entities and
+// unresolvable descriptors are left frozen.
+//
+//	sketch.RebindProjection(entity, partDef, sk.Plane())
+func RebindProjection(e Entity, res ProjectionSourceResolver, plane Plane) {
+	if r, ok := e.(sourceRebindable); ok {
+		r.rebindFrom(res, plane)
+	}
+}

--- a/model/sketch/serialize.go
+++ b/model/sketch/serialize.go
@@ -263,72 +263,26 @@ func serializePlane(p Plane) PlaneData {
 	}
 }
 
+// serializeEntity dispatches an entity to its registered codec by its Kind and
+// stamps the kind onto the row, so an encode closure fills only its payload.
+// A kind that never registered a codec pair cannot have been created (its
+// factory lives beside its registration), so the misses here guard programming
+// errors, not user documents (#1624).
 func serializeEntity(e Entity) (EntityData, error) {
-	switch v := e.(type) {
-	case *Line:
-		return EntityData{ID: int(v.id), Kind: "line", Points: []int{int(v.A.id), int(v.B.id)}, Construction: v.construction, Centerline: v.centerline}, nil
-	case *Circle:
-		return EntityData{ID: int(v.id), Kind: "circle", Points: []int{int(v.Center.id)}, Radius: float64(v.Radius), Construction: v.construction}, nil
-	case *Arc:
-		return EntityData{ID: int(v.id), Kind: "arc", Points: []int{int(v.Center.id), int(v.Start.id), int(v.End.id)}, CCW: v.CounterClockwise, Construction: v.construction}, nil
-	case *Ellipse:
-		return EntityData{ID: int(v.id), Kind: "ellipse", Points: []int{int(v.Center.id)}, MajorAxis: []float64{float64(v.MajorAxis.X), float64(v.MajorAxis.Y)}, MajorRadius: float64(v.MajorRadius), MinorRadius: float64(v.MinorRadius), Construction: v.construction}, nil
-	case *EllipticalArc:
-		return EntityData{ID: int(v.id), Kind: "ellipticalArc", Points: []int{int(v.Center.id)}, MajorAxis: []float64{float64(v.MajorAxis.X), float64(v.MajorAxis.Y)}, MajorRadius: float64(v.MajorRadius), MinorRadius: float64(v.MinorRadius), StartAngle: float64(v.StartAngle), EndAngle: float64(v.EndAngle), Construction: v.construction}, nil
-	case *Spline:
-		return EntityData{
-			ID: int(v.id), Kind: "spline", Points: pointIDsOf(v.Points), Closed: v.Closed, Fit: v.fit,
-			FitMethod: fitMethodSpelling(v.FitMethod), Handles: serializeSplineHandles(v),
-			Construction: v.construction,
-		}, nil
-	case *BlockInstance:
-		return EntityData{
-			ID: int(v.id), Kind: "blockInstance", Block: v.def.name, Transform: matrixCells(v.transform),
-		}, nil
-	case *SketchImage:
-		return EntityData{
-			ID: int(v.id), Kind: "image", ImageRef: v.Ref,
-			Anchor:   []float64{float64(v.Anchor.X), float64(v.Anchor.Y)},
-			Size:     []float64{float64(v.Width), float64(v.Height)},
-			Rotation: float64(v.Rotation), Opacity: v.Opacity,
-		}, nil
-	case *ProjectedPoint:
-		kind, id := v.SourceDescriptor()
-		return EntityData{
-			ID: int(v.anchor.id), Kind: "projectedPoint", Points: []int{int(v.anchor.id)},
-			Anchor: []float64{float64(v.anchor.X), float64(v.anchor.Y)}, Source: id, SourceKind: kind,
-		}, nil
-	case *ProjectedCurve:
-		kind, id := v.SourceDescriptor()
-		return EntityData{ID: int(v.id), Kind: "projectedCurve", Coords: flattenPoints(v.points), Source: id, SourceKind: kind}, nil
-	case *FillRegion:
-		return EntityData{ID: int(v.id), Kind: "fillRegion", Seed: []float64{float64(v.Seed.X), float64(v.Seed.Y)}, Style: v.Style}, nil
-	case *TextBox:
-		return EntityData{
-			ID: int(v.id), Kind: "text", Text: v.Text,
-			Anchor:     []float64{float64(v.Anchor.X), float64(v.Anchor.Y)},
-			TextHeight: float64(v.Height), Rotation: float64(v.Rotation),
-			Justify: int(v.Justify), VJustify: int(v.VJustify),
-			FontFamily: v.Family, FontResource: v.FontResource, FontSize: float64(v.FontSize),
-		}, nil
-	default:
-		return serializeDerivedCurve(e)
+	ke, ok := e.(kindedEntity)
+	if !ok {
+		return EntityData{}, fmt.Errorf("cannot serialize entity of type %T: it has no Kind (register it in a serialize_codecs_*.go)", e)
 	}
-}
-
-// serializeDerivedCurve handles the M21 derived curves (equation/fixed/offset spline);
-// split out of serializeEntity to keep that switch small.
-func serializeDerivedCurve(e Entity) (EntityData, error) {
-	switch v := e.(type) {
-	case *EquationCurve:
-		return EntityData{ID: int(v.id), Kind: "equationCurve", XExpr: v.XExpr, YExpr: v.YExpr, T0: v.T0, T1: v.T1}, nil
-	case *FixedSpline:
-		return EntityData{ID: int(v.id), Kind: "fixedSpline", Coords: flattenPoints(v.Pts)}, nil
-	case *OffsetSpline:
-		return EntityData{ID: int(v.id), Kind: "offsetSpline", ParentID: int(v.Parent.id), OffsetDist: v.Dist}, nil
-	default:
-		return EntityData{}, fmt.Errorf("cannot serialize entity of type %T (no codec)", e)
+	c, ok := entityCodecs2D[ke.Kind()]
+	if !ok {
+		return EntityData{}, fmt.Errorf("cannot serialize entity of type %T: kind %q has no 2D codec", e, ke.Kind())
 	}
+	ed, err := c.encode(e)
+	if err != nil {
+		return EntityData{}, err
+	}
+	ed.Kind = string(ke.Kind())
+	return ed, nil
 }
 
 // flattenPoints flattens points to a [x,y,x,y,…] slice.

--- a/model/sketch/serialize_3d.go
+++ b/model/sketch/serialize_3d.go
@@ -232,66 +232,23 @@ func planeNameFromNormal(n math.Vector3) string {
 	}
 }
 
-// serializeEntity3D captures one 3D curve entity by its kind, defining point ids, and
-// kind-specific shape (radius/axis/sweep).
+// serializeEntity3D dispatches a 3D entity to its registered codec by its Kind
+// and stamps the kind onto the row, mirroring serializeEntity (#1624).
 func serializeEntity3D(e Entity) (Entity3DData, error) {
-	switch v := e.(type) {
-	case *Line3D:
-		return Entity3DData{ID: int(v.id), Kind: "line", Points: []int{int(v.A.id), int(v.B.id)}, Construction: v.construction}, nil
-	case *Circle3D:
-		return Entity3DData{
-			ID: int(v.id), Kind: "circle", Points: []int{int(v.Center.id)},
-			Radius: float64(v.Radius), Axis: axisTriple(v.Axis), Construction: v.construction,
-		}, nil
-	case *Arc3D:
-		return Entity3DData{
-			ID: int(v.id), Kind: "arc", Points: []int{int(v.Center.id), int(v.Start.id), int(v.End.id)},
-			CCW: v.CounterClockwise, Construction: v.construction,
-		}, nil
-	case *HelicalCurve3D:
-		ed := Entity3DData{
-			ID: int(v.id), Kind: "helical", Points: []int{int(v.Origin.id)},
-			Radius: float64(v.StartRadius), Axis: axisTriple(v.Axis),
-			Pitch: v.AxialPerTurn, Turns: v.Turns, RadialPerTurn: v.RadialPerTurn,
-			Clockwise: v.Clockwise, Construction: v.construction,
-		}
-		serializeHelixDefinition(&ed, v)
-		return ed, nil
-	case *Ellipse3D:
-		return Entity3DData{
-			ID: int(v.id), Kind: "ellipse", Points: []int{int(v.Center.id)},
-			Axis: axisTriple(v.Normal), MajorAxis: axisTriple(v.MajorAxis),
-			Radius: float64(v.MajorRadius), MinorRadius: float64(v.MinorRadius), Construction: v.construction,
-		}, nil
-	case *EllipticalArc3D:
-		return Entity3DData{
-			ID: int(v.id), Kind: "ellipticalArc", Points: []int{int(v.Center.id)},
-			Axis: axisTriple(v.Normal), MajorAxis: axisTriple(v.MajorAxis),
-			Radius: float64(v.MajorRadius), MinorRadius: float64(v.MinorRadius),
-			StartAngle: v.StartAngle, SweepAngle: v.SweepAngle, Construction: v.construction,
-		}, nil
-	case *Spline3D:
-		kind := "spline"
-		if !v.fit {
-			kind = "controlPointSpline"
-		}
-		return Entity3DData{
-			ID: int(v.id), Kind: kind, Points: point3DIDs(v.Points),
-			Closed: v.Closed, Handles: serializeSplineHandles3D(v), Construction: v.construction,
-		}, nil
-	case *FixedSpline3D:
-		return Entity3DData{
-			ID: int(v.id), Kind: "fixedSpline", Coords: flattenPoint3s(v.Pts),
-			Closed: v.Closed, Construction: v.construction,
-		}, nil
-	case *EquationCurve3D:
-		return Entity3DData{
-			ID: int(v.id), Kind: "equationCurve", XExpr: v.XExpr, YExpr: v.YExpr, ZExpr: v.ZExpr,
-			T0: v.T0, T1: v.T1, Construction: v.construction,
-		}, nil
-	default:
-		return Entity3DData{}, fmt.Errorf("cannot serialize 3D entity of type %T (no codec)", e)
+	ke, ok := e.(kindedEntity)
+	if !ok {
+		return Entity3DData{}, fmt.Errorf("cannot serialize 3D entity of type %T: it has no Kind (register it in serialize_codecs_3d.go)", e)
 	}
+	c, ok := entityCodecs3D[ke.Kind()]
+	if !ok {
+		return Entity3DData{}, fmt.Errorf("cannot serialize 3D entity of type %T: kind %q has no 3D codec", e, ke.Kind())
+	}
+	ed, err := c.encode(e)
+	if err != nil {
+		return Entity3DData{}, err
+	}
+	ed.Kind = string(ke.Kind())
+	return ed, nil
 }
 
 // axisTriple flattens a unit axis to a serializable triple.
@@ -561,68 +518,18 @@ func lookupCircle3D(ids []int, entmap map[int]Entity) (*Circle3D, error) {
 	return c, nil
 }
 
-// restoreEntity3D re-creates one 3D curve entity over its already-restored points,
-// returning it so constraints can re-bind to it by its saved id.
+// restoreEntity3D re-creates one 3D curve entity over its already-restored points
+// through its kind's registered codec — the pair its encode came from (#1624).
 func restoreEntity3D(s *Sketch3D, ed Entity3DData, idmap map[int]*Point3D) (Entity, error) {
 	pts, err := lookupPoints3D(ed.Points, idmap)
 	if err != nil {
 		return nil, fmt.Errorf("%s entity: %w", ed.Kind, err)
 	}
-	switch ed.Kind {
-	case "line":
-		l := s.addLine3DPts(pts[0], pts[1])
-		l.SetConstruction(ed.Construction)
-		return l, nil
-	case "circle":
-		axis, aerr := unitFromTriple(ed.Axis)
-		if aerr != nil {
-			return nil, fmt.Errorf("circle entity: axis %v: %w", ed.Axis, aerr)
-		}
-		c := s.addCircle3DPts(pts[0], axis, ed.Radius)
-		c.SetConstruction(ed.Construction)
-		return c, nil
-	case "arc":
-		a := s.addArc3DPts(pts[0], pts[1], pts[2], ed.CCW)
-		a.SetConstruction(ed.Construction)
-		return a, nil
-	case "helical":
-		axis, aerr := unitFromTriple(ed.Axis)
-		if aerr != nil {
-			return nil, fmt.Errorf("helical entity: axis %v: %w", ed.Axis, aerr)
-		}
-		h := s.addHelix3DPt(pts[0], axis, ed.Radius, ed.Pitch, ed.RadialPerTurn, ed.Turns, ed.Clockwise)
-		h.SetConstruction(ed.Construction)
-		if err := restoreHelixDefinition(h, ed); err != nil {
-			return nil, err
-		}
-		return h, nil
-	case "ellipse", "ellipticalArc":
-		return restoreConic3D(s, ed, pts[0])
-	case "spline", "controlPointSpline":
-		sp := s.addSpline3DPts(pts, ed.Closed, ed.Kind == "spline")
-		sp.SetConstruction(ed.Construction)
-		for _, hd := range ed.Handles {
-			h, err := s.ActivateSplineHandle3D(sp, hd.FitIndex)
-			if err != nil {
-				return nil, err
-			}
-			h.End.SetPosition(math.P3(math.Scalar(hd.End[0]), math.Scalar(hd.End[1]), math.Scalar(hd.End[2])))
-		}
-		return sp, nil
-	case "fixedSpline":
-		sp := s.AddFixedSpline3D(unflattenPoint3s(ed.Coords), ed.Closed)
-		sp.SetConstruction(ed.Construction)
-		return sp, nil
-	case "equationCurve":
-		e, eerr := s.AddEquationCurve3D(ed.XExpr, ed.YExpr, ed.ZExpr, ed.T0, ed.T1)
-		if eerr != nil {
-			return nil, fmt.Errorf("equationCurve entity: %w", eerr)
-		}
-		e.SetConstruction(ed.Construction)
-		return e, nil
-	default:
+	c, ok := entityCodecs3D[EntityKind(ed.Kind)]
+	if !ok {
 		return nil, fmt.Errorf("unknown 3D entity kind %q", ed.Kind)
 	}
+	return c.decode(s, ed, pts)
 }
 
 // restoreConstraint3D re-adds one geometric 3D constraint, binding its point operands

--- a/model/sketch/serialize_codecs_3d.go
+++ b/model/sketch/serialize_codecs_3d.go
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"fmt"
+
+	"oblikovati.org/math"
+)
+
+// Codec registrations for the persisted 3D entities. Bodies are the former
+// serializeEntity3D/restoreEntity3D switch cases, paired per kind (#1624).
+// The surface-derived curves (intersection/silhouette/on-face/…) have no codec
+// on purpose — they rebind from their references on recompute (M22-F11), so
+// serializeSketch3D skips them before dispatching here. A Spline3D registers
+// under two kinds (spline / controlPointSpline) sharing one encode; its Kind()
+// picks the spelling by the fit flag.
+
+func init() {
+	registerEntityCodec3D(LineKind, entityCodec3D{
+		encode: func(e Entity) (Entity3DData, error) {
+			v := e.(*Line3D)
+			return Entity3DData{ID: int(v.id), Points: []int{int(v.A.id), int(v.B.id)}, Construction: v.construction}, nil
+		},
+		decode: func(s *Sketch3D, ed Entity3DData, pts []*Point3D) (Entity, error) {
+			l := s.addLine3DPts(pts[0], pts[1])
+			l.SetConstruction(ed.Construction)
+			return l, nil
+		},
+	})
+	registerEntityCodec3D(CircleKind, entityCodec3D{
+		encode: func(e Entity) (Entity3DData, error) {
+			v := e.(*Circle3D)
+			return Entity3DData{
+				ID: int(v.id), Points: []int{int(v.Center.id)},
+				Radius: float64(v.Radius), Axis: axisTriple(v.Axis), Construction: v.construction,
+			}, nil
+		},
+		decode: func(s *Sketch3D, ed Entity3DData, pts []*Point3D) (Entity, error) {
+			axis, err := unitFromTriple(ed.Axis)
+			if err != nil {
+				return nil, fmt.Errorf("circle entity: axis %v: %w", ed.Axis, err)
+			}
+			c := s.addCircle3DPts(pts[0], axis, ed.Radius)
+			c.SetConstruction(ed.Construction)
+			return c, nil
+		},
+	})
+	registerEntityCodec3D(ArcKind, entityCodec3D{
+		encode: func(e Entity) (Entity3DData, error) {
+			v := e.(*Arc3D)
+			return Entity3DData{
+				ID: int(v.id), Points: []int{int(v.Center.id), int(v.Start.id), int(v.End.id)},
+				CCW: v.CounterClockwise, Construction: v.construction,
+			}, nil
+		},
+		decode: func(s *Sketch3D, ed Entity3DData, pts []*Point3D) (Entity, error) {
+			a := s.addArc3DPts(pts[0], pts[1], pts[2], ed.CCW)
+			a.SetConstruction(ed.Construction)
+			return a, nil
+		},
+	})
+	registerEntityCodec3D(HelicalKind, entityCodec3D{
+		encode: encodeHelical3D,
+		decode: decodeHelical3D,
+	})
+	registerConic3DCodecs()
+	registerSpline3DCodecs()
+}
+
+// encodeHelical3D captures a helix's placement plus its M06-F09 shape definition.
+func encodeHelical3D(e Entity) (Entity3DData, error) {
+	v := e.(*HelicalCurve3D)
+	ed := Entity3DData{
+		ID: int(v.id), Points: []int{int(v.Origin.id)},
+		Radius: float64(v.StartRadius), Axis: axisTriple(v.Axis),
+		Pitch: v.AxialPerTurn, Turns: v.Turns, RadialPerTurn: v.RadialPerTurn,
+		Clockwise: v.Clockwise, Construction: v.construction,
+	}
+	serializeHelixDefinition(&ed, v)
+	return ed, nil
+}
+
+// decodeHelical3D rebuilds a helix and its persisted shape definition.
+func decodeHelical3D(s *Sketch3D, ed Entity3DData, pts []*Point3D) (Entity, error) {
+	axis, err := unitFromTriple(ed.Axis)
+	if err != nil {
+		return nil, fmt.Errorf("helical entity: axis %v: %w", ed.Axis, err)
+	}
+	h := s.addHelix3DPt(pts[0], axis, ed.Radius, ed.Pitch, ed.RadialPerTurn, ed.Turns, ed.Clockwise)
+	h.SetConstruction(ed.Construction)
+	if err := restoreHelixDefinition(h, ed); err != nil {
+		return nil, err
+	}
+	return h, nil
+}
+
+// registerConic3DCodecs pairs the 3D ellipse and elliptical arc; both decode
+// through restoreConic3D, which dispatches on the kind spelling.
+func registerConic3DCodecs() {
+	decodeConic := func(s *Sketch3D, ed Entity3DData, pts []*Point3D) (Entity, error) {
+		return restoreConic3D(s, ed, pts[0])
+	}
+	registerEntityCodec3D(EllipseKind, entityCodec3D{
+		encode: func(e Entity) (Entity3DData, error) {
+			v := e.(*Ellipse3D)
+			return Entity3DData{
+				ID: int(v.id), Points: []int{int(v.Center.id)},
+				Axis: axisTriple(v.Normal), MajorAxis: axisTriple(v.MajorAxis),
+				Radius: float64(v.MajorRadius), MinorRadius: float64(v.MinorRadius), Construction: v.construction,
+			}, nil
+		},
+		decode: decodeConic,
+	})
+	registerEntityCodec3D(EllipticalArcKind, entityCodec3D{
+		encode: func(e Entity) (Entity3DData, error) {
+			v := e.(*EllipticalArc3D)
+			return Entity3DData{
+				ID: int(v.id), Points: []int{int(v.Center.id)},
+				Axis: axisTriple(v.Normal), MajorAxis: axisTriple(v.MajorAxis),
+				Radius: float64(v.MajorRadius), MinorRadius: float64(v.MinorRadius),
+				StartAngle: v.StartAngle, SweepAngle: v.SweepAngle, Construction: v.construction,
+			}, nil
+		},
+		decode: decodeConic,
+	})
+}
+
+// registerSpline3DCodecs pairs the three 3D spline flavors. The interpolation
+// (fit) and control-point spellings share both halves: encode reads the kind
+// from Spline3D.Kind(), decode passes fit = (kind == "spline") to the factory.
+func registerSpline3DCodecs() {
+	splineCodec := entityCodec3D{
+		encode: func(e Entity) (Entity3DData, error) {
+			v := e.(*Spline3D)
+			return Entity3DData{
+				ID: int(v.id), Points: point3DIDs(v.Points),
+				Closed: v.Closed, Handles: serializeSplineHandles3D(v), Construction: v.construction,
+			}, nil
+		},
+		decode: decodeSpline3D,
+	}
+	registerEntityCodec3D(SplineKind, splineCodec)
+	registerEntityCodec3D(ControlPointSplineKind, splineCodec)
+	registerEntityCodec3D(FixedSplineKind, entityCodec3D{
+		encode: func(e Entity) (Entity3DData, error) {
+			v := e.(*FixedSpline3D)
+			return Entity3DData{ID: int(v.id), Coords: flattenPoint3s(v.Pts), Closed: v.Closed, Construction: v.construction}, nil
+		},
+		decode: func(s *Sketch3D, ed Entity3DData, _ []*Point3D) (Entity, error) {
+			sp := s.AddFixedSpline3D(unflattenPoint3s(ed.Coords), ed.Closed)
+			sp.SetConstruction(ed.Construction)
+			return sp, nil
+		},
+	})
+	registerEntityCodec3D(EquationCurveKind, entityCodec3D{
+		encode: func(e Entity) (Entity3DData, error) {
+			v := e.(*EquationCurve3D)
+			return Entity3DData{
+				ID: int(v.id), XExpr: v.XExpr, YExpr: v.YExpr, ZExpr: v.ZExpr,
+				T0: v.T0, T1: v.T1, Construction: v.construction,
+			}, nil
+		},
+		decode: func(s *Sketch3D, ed Entity3DData, _ []*Point3D) (Entity, error) {
+			e, err := s.AddEquationCurve3D(ed.XExpr, ed.YExpr, ed.ZExpr, ed.T0, ed.T1)
+			if err != nil {
+				return nil, fmt.Errorf("equationCurve entity: %w", err)
+			}
+			e.SetConstruction(ed.Construction)
+			return e, nil
+		},
+	})
+}
+
+// decodeSpline3D rebuilds an interpolation or control-point spline over its
+// restored solver points and re-activates its tangency handles.
+func decodeSpline3D(s *Sketch3D, ed Entity3DData, pts []*Point3D) (Entity, error) {
+	sp := s.addSpline3DPts(pts, ed.Closed, EntityKind(ed.Kind) == SplineKind)
+	sp.SetConstruction(ed.Construction)
+	for _, hd := range ed.Handles {
+		h, err := s.ActivateSplineHandle3D(sp, hd.FitIndex)
+		if err != nil {
+			return nil, err
+		}
+		h.End.SetPosition(point3FromTriple(hd.End))
+	}
+	return sp, nil
+}
+
+// point3FromTriple rebuilds a point from its serialized triple.
+func point3FromTriple(v [3]float64) math.Point3 {
+	return math.P3(math.Scalar(v[0]), math.Scalar(v[1]), math.Scalar(v[2]))
+}

--- a/model/sketch/serialize_codecs_curves.go
+++ b/model/sketch/serialize_codecs_curves.go
@@ -92,7 +92,15 @@ func init() {
 				math.Scalar(ed.StartAngle), math.Scalar(ed.EndAngle)), nil
 		},
 	})
-	registerEntityCodec(SplineKind, entityCodec{
+	registerSpline2DCodecs()
+}
+
+// registerSpline2DCodecs pairs the two 2D spline spellings on one shared codec:
+// the kind mirrors the fit flag (Spline.Kind), and decode reads the persisted
+// Fit field, so a legacy "spline"+fit:false row and a "controlPointSpline" row
+// restore identically.
+func registerSpline2DCodecs() {
+	splineCodec := entityCodec{
 		encode: func(e Entity) (EntityData, error) {
 			v := e.(*Spline)
 			return EntityData{
@@ -112,7 +120,9 @@ func init() {
 			}
 			return sp, nil
 		},
-	})
+	}
+	registerEntityCodec(SplineKind, splineCodec)
+	registerEntityCodec(ControlPointSplineKind, splineCodec)
 }
 
 // conicOperands resolves an ellipse/ellipticalArc's center point and major-axis

--- a/model/sketch/serialize_codecs_curves.go
+++ b/model/sketch/serialize_codecs_curves.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"fmt"
+
+	"oblikovati.org/math"
+)
+
+// Codec registrations for the 2D geometric curves (line/circle/arc/ellipse/
+// ellipticalArc/spline). Bodies are the former serializeEntity/restoreEntity
+// switch cases, paired so encode and decode can never drift (#1624; the
+// pattern of model/feature's #1416 fix). serializeEntity stamps ed.Kind
+// centrally, so encode closures fill only the kind-specific payload.
+
+func init() {
+	registerEntityCodec(LineKind, entityCodec{
+		encode: func(e Entity) (EntityData, error) {
+			v := e.(*Line)
+			return EntityData{ID: int(v.id), Points: []int{int(v.A.id), int(v.B.id)}, Construction: v.construction, Centerline: v.centerline}, nil
+		},
+		decode: func(r *sketchRestorer, ed EntityData) (Entity, error) {
+			p, err := r.points(ed.Points, 2)
+			if err != nil {
+				return nil, err
+			}
+			return r.s.lines.Add(p[0], p[1]), nil
+		},
+	})
+	registerEntityCodec(CircleKind, entityCodec{
+		encode: func(e Entity) (EntityData, error) {
+			v := e.(*Circle)
+			return EntityData{ID: int(v.id), Points: []int{int(v.Center.id)}, Radius: float64(v.Radius), Construction: v.construction}, nil
+		},
+		decode: func(r *sketchRestorer, ed EntityData) (Entity, error) {
+			p, err := r.points(ed.Points, 1)
+			if err != nil {
+				return nil, err
+			}
+			return r.s.circles.Add(p[0], math.Scalar(ed.Radius)), nil
+		},
+	})
+	registerEntityCodec(ArcKind, entityCodec{
+		encode: func(e Entity) (EntityData, error) {
+			v := e.(*Arc)
+			return EntityData{ID: int(v.id), Points: []int{int(v.Center.id), int(v.Start.id), int(v.End.id)}, CCW: v.CounterClockwise, Construction: v.construction}, nil
+		},
+		decode: func(r *sketchRestorer, ed EntityData) (Entity, error) {
+			p, err := r.points(ed.Points, 3)
+			if err != nil {
+				return nil, err
+			}
+			return r.s.arcs.Add(p[0], p[1], p[2], ed.CCW), nil
+		},
+	})
+	registerEntityCodec(EllipseKind, entityCodec{
+		encode: func(e Entity) (EntityData, error) {
+			v := e.(*Ellipse)
+			return EntityData{
+				ID: int(v.id), Points: []int{int(v.Center.id)},
+				MajorAxis:   []float64{float64(v.MajorAxis.X), float64(v.MajorAxis.Y)},
+				MajorRadius: float64(v.MajorRadius), MinorRadius: float64(v.MinorRadius),
+				Construction: v.construction,
+			}, nil
+		},
+		decode: func(r *sketchRestorer, ed EntityData) (Entity, error) {
+			p, axis, err := r.conicOperands(ed)
+			if err != nil {
+				return nil, err
+			}
+			return r.s.ellipses.AddWithCenter(p, axis, math.Scalar(ed.MajorRadius), math.Scalar(ed.MinorRadius)), nil
+		},
+	})
+	registerEntityCodec(EllipticalArcKind, entityCodec{
+		encode: func(e Entity) (EntityData, error) {
+			v := e.(*EllipticalArc)
+			return EntityData{
+				ID: int(v.id), Points: []int{int(v.Center.id)},
+				MajorAxis:   []float64{float64(v.MajorAxis.X), float64(v.MajorAxis.Y)},
+				MajorRadius: float64(v.MajorRadius), MinorRadius: float64(v.MinorRadius),
+				StartAngle: float64(v.StartAngle), EndAngle: float64(v.EndAngle),
+				Construction: v.construction,
+			}, nil
+		},
+		decode: func(r *sketchRestorer, ed EntityData) (Entity, error) {
+			p, axis, err := r.conicOperands(ed)
+			if err != nil {
+				return nil, err
+			}
+			return r.s.ellArcs.AddWithCenter(p, axis, math.Scalar(ed.MajorRadius), math.Scalar(ed.MinorRadius),
+				math.Scalar(ed.StartAngle), math.Scalar(ed.EndAngle)), nil
+		},
+	})
+	registerEntityCodec(SplineKind, entityCodec{
+		encode: func(e Entity) (EntityData, error) {
+			v := e.(*Spline)
+			return EntityData{
+				ID: int(v.id), Points: pointIDsOf(v.Points), Closed: v.Closed, Fit: v.fit,
+				FitMethod: fitMethodSpelling(v.FitMethod), Handles: serializeSplineHandles(v),
+				Construction: v.construction,
+			}, nil
+		},
+		decode: func(r *sketchRestorer, ed EntityData) (Entity, error) {
+			p, err := r.points(ed.Points, len(ed.Points))
+			if err != nil {
+				return nil, err
+			}
+			sp := r.s.splines.AddWithPoints(p, ed.Closed, ed.Fit)
+			if err := restoreSplineExtras(r.s, sp, ed); err != nil {
+				return nil, err
+			}
+			return sp, nil
+		},
+	})
+}
+
+// conicOperands resolves an ellipse/ellipticalArc's center point and major-axis
+// direction, shared by both conic decoders.
+func (r *sketchRestorer) conicOperands(ed EntityData) (*Point, math.Vector2, error) {
+	p, err := r.points(ed.Points, 1)
+	if err != nil {
+		return nil, math.Vector2{}, err
+	}
+	if len(ed.MajorAxis) != 2 {
+		return nil, math.Vector2{}, fmt.Errorf("%s needs a 2-component majorAxis, got %d", ed.Kind, len(ed.MajorAxis))
+	}
+	return p[0], math.V2(ed.MajorAxis[0], ed.MajorAxis[1]), nil
+}

--- a/model/sketch/serialize_codecs_extras.go
+++ b/model/sketch/serialize_codecs_extras.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"fmt"
+
+	"oblikovati.org/math"
+)
+
+// Codec registrations for the non-curve 2D entities: annotations (image/text/
+// fillRegion), block instances, frozen projections, and the M21 derived curves
+// (equation/fixed/offset spline). Bodies are the former switch cases of
+// serializeEntity/serializeDerivedCurve and restoreEntity/restoreDerivedCurve,
+// paired per kind (#1624) — including the derived-curve default: branch that
+// used to fail a save at runtime.
+
+func init() {
+	registerEntityCodec(BlockInstanceKind, entityCodec{
+		encode: func(e Entity) (EntityData, error) {
+			v := e.(*BlockInstance)
+			return EntityData{ID: int(v.id), Block: v.def.name, Transform: matrixCells(v.transform)}, nil
+		},
+		decode: func(r *sketchRestorer, ed EntityData) (Entity, error) {
+			def, ok := r.blockDefs.ByName(ed.Block)
+			if !ok {
+				return nil, fmt.Errorf("block instance references unknown definition %q", ed.Block)
+			}
+			t, err := matrixFromCells(ed.Transform)
+			if err != nil {
+				return nil, err
+			}
+			return r.s.Blocks().Insert(def, t), nil
+		},
+	})
+	registerEntityCodec(ImageKind, entityCodec{
+		encode: func(e Entity) (EntityData, error) {
+			v := e.(*SketchImage)
+			return EntityData{
+				ID: int(v.id), ImageRef: v.Ref,
+				Anchor:   []float64{float64(v.Anchor.X), float64(v.Anchor.Y)},
+				Size:     []float64{float64(v.Width), float64(v.Height)},
+				Rotation: float64(v.Rotation), Opacity: v.Opacity,
+			}, nil
+		},
+		decode: func(r *sketchRestorer, ed EntityData) (Entity, error) {
+			if len(ed.Anchor) != 2 || len(ed.Size) != 2 {
+				return nil, fmt.Errorf("image needs a 2-component anchor and size")
+			}
+			anchor := math.P2(math.Scalar(ed.Anchor[0]), math.Scalar(ed.Anchor[1]))
+			return r.s.images.Add(ed.ImageRef, anchor, math.Scalar(ed.Size[0]), math.Scalar(ed.Size[1]), math.Scalar(ed.Rotation), ed.Opacity), nil
+		},
+	})
+	registerEntityCodec(TextKind, entityCodec{
+		encode: func(e Entity) (EntityData, error) {
+			v := e.(*TextBox)
+			return EntityData{
+				ID: int(v.id), Text: v.Text,
+				Anchor:     []float64{float64(v.Anchor.X), float64(v.Anchor.Y)},
+				TextHeight: float64(v.Height), Rotation: float64(v.Rotation),
+				Justify: int(v.Justify), VJustify: int(v.VJustify),
+				FontFamily: v.Family, FontResource: v.FontResource, FontSize: float64(v.FontSize),
+			}, nil
+		},
+		decode: func(r *sketchRestorer, ed EntityData) (Entity, error) {
+			if len(ed.Anchor) != 2 {
+				return nil, fmt.Errorf("text needs a 2-component anchor")
+			}
+			anchor := math.P2(math.Scalar(ed.Anchor[0]), math.Scalar(ed.Anchor[1]))
+			tb := r.s.texts.AddStyled(anchor, ed.Text, math.Scalar(ed.TextHeight), math.Scalar(ed.Rotation),
+				TextHJustify(ed.Justify), TextVJustify(ed.VJustify), ed.FontFamily, math.Scalar(ed.FontSize))
+			tb.FontResource = ed.FontResource
+			return tb, nil
+		},
+	})
+	registerEntityCodec(FillRegionKind, entityCodec{
+		encode: func(e Entity) (EntityData, error) {
+			v := e.(*FillRegion)
+			return EntityData{ID: int(v.id), Seed: []float64{float64(v.Seed.X), float64(v.Seed.Y)}, Style: v.Style}, nil
+		},
+		decode: func(r *sketchRestorer, ed EntityData) (Entity, error) {
+			if len(ed.Seed) != 2 {
+				return nil, fmt.Errorf("fillRegion needs a 2-component seed")
+			}
+			return r.s.fills.Add(math.P2(math.Scalar(ed.Seed[0]), math.Scalar(ed.Seed[1])), ed.Style), nil
+		},
+	})
+	registerProjectionCodecs()
+	registerDerivedCurveCodecs()
+}
+
+// registerProjectionCodecs pairs the frozen projected reference entities (#1268):
+// they pin their own ids and re-attach to their model source on recompute.
+func registerProjectionCodecs() {
+	registerEntityCodec(ProjectedPointKind, entityCodec{
+		encode: func(e Entity) (EntityData, error) {
+			v := e.(*ProjectedPoint)
+			kind, id := v.SourceDescriptor()
+			return EntityData{
+				ID: int(v.anchor.id), Points: []int{int(v.anchor.id)},
+				Anchor: []float64{float64(v.anchor.X), float64(v.anchor.Y)}, Source: id, SourceKind: kind,
+			}, nil
+		},
+		decode: func(r *sketchRestorer, ed EntityData) (Entity, error) {
+			return r.restoreProjectedPoint(ed)
+		},
+	})
+	registerEntityCodec(ProjectedCurveKind, entityCodec{
+		encode: func(e Entity) (EntityData, error) {
+			v := e.(*ProjectedCurve)
+			kind, id := v.SourceDescriptor()
+			return EntityData{ID: int(v.id), Coords: flattenPoints(v.points), Source: id, SourceKind: kind}, nil
+		},
+		decode: func(r *sketchRestorer, ed EntityData) (Entity, error) {
+			c := r.s.RestoreProjectedCurve(ID(ed.ID), unflattenPoints(ed.Coords), ed.SourceKind, ed.Source)
+			r.note(ed.ID)
+			return c, nil
+		},
+	})
+}
+
+// registerDerivedCurveCodecs pairs the M21 derived curves. An offset spline's
+// parent must already be restored (entities restore in recipe order).
+func registerDerivedCurveCodecs() {
+	registerEntityCodec(EquationCurveKind, entityCodec{
+		encode: func(e Entity) (EntityData, error) {
+			v := e.(*EquationCurve)
+			return EntityData{ID: int(v.id), XExpr: v.XExpr, YExpr: v.YExpr, T0: v.T0, T1: v.T1}, nil
+		},
+		decode: func(r *sketchRestorer, ed EntityData) (Entity, error) {
+			return r.s.eqCurves.Add(ed.XExpr, ed.YExpr, ed.T0, ed.T1)
+		},
+	})
+	registerEntityCodec(FixedSplineKind, entityCodec{
+		encode: func(e Entity) (EntityData, error) {
+			v := e.(*FixedSpline)
+			return EntityData{ID: int(v.id), Coords: flattenPoints(v.Pts)}, nil
+		},
+		decode: func(r *sketchRestorer, ed EntityData) (Entity, error) {
+			return r.s.fixedSpl.Add(unflattenPoints(ed.Coords)), nil
+		},
+	})
+	registerEntityCodec(OffsetSplineKind, entityCodec{
+		encode: func(e Entity) (EntityData, error) {
+			v := e.(*OffsetSpline)
+			return EntityData{ID: int(v.id), ParentID: int(v.Parent.id), OffsetDist: v.Dist}, nil
+		},
+		decode: func(r *sketchRestorer, ed EntityData) (Entity, error) {
+			parent, ok := r.entityMap[ed.ParentID].(*Spline)
+			if !ok {
+				return nil, fmt.Errorf("offsetSpline parent %d is not a spline", ed.ParentID)
+			}
+			return r.s.offSpl.Add(parent, ed.OffsetDist), nil
+		},
+	})
+}

--- a/model/sketch/serialize_registry.go
+++ b/model/sketch/serialize_registry.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import "fmt"
+
+// Entity serialization is a registry keyed by [EntityKind]: each kind contributes ONE
+// codec pairing its encode and decode closures, registered together in a
+// serialize_codecs_*.go init(). This replaces the two hand-maintained switch pairs
+// (serializeEntity/restoreEntity and their 3D twins) whose halves nothing linked —
+// the same failure class that silently dropped features on reload (#1416) and made
+// serialize.go's default: branch a runtime save failure (#1624, audit I1). Now a
+// kind without BOTH halves cannot register, and serialize_registry_test asserts the
+// registered sets match the persisted vocabulary exactly.
+//
+// 2D and 3D registries are separate because they encode into different recipe rows
+// ([EntityData] vs [Entity3DData]) even where the kind spelling is shared.
+
+// entityCodec is one 2D kind's serialization pair. encode receives the concrete
+// entity (asserting its own type, as the switch case it replaces did); decode
+// rebuilds it inside a restoring sketch, resolving point ids through the restorer.
+type entityCodec struct {
+	encode func(e Entity) (EntityData, error)
+	decode func(r *sketchRestorer, ed EntityData) (Entity, error)
+}
+
+// entityCodec3D is one 3D kind's serialization pair. decode receives the entity's
+// defining points already resolved (restoreEntity3D looks them up once for every
+// kind, as the switch it replaces did).
+type entityCodec3D struct {
+	encode func(e Entity) (Entity3DData, error)
+	decode func(s *Sketch3D, ed Entity3DData, pts []*Point3D) (Entity, error)
+}
+
+// entityCodecs2D / entityCodecs3D map a kind to its codec. Populated by the
+// serialize_codecs_*.go init()s; read-only after init, so no synchronization.
+var (
+	entityCodecs2D = map[EntityKind]entityCodec{}
+	entityCodecs3D = map[EntityKind]entityCodec3D{}
+)
+
+// registerEntityCodec records one 2D kind's codec, panicking on a duplicate or an
+// incomplete pair — a programming error caught at startup, not a silent overwrite.
+func registerEntityCodec(kind EntityKind, c entityCodec) {
+	mustAcceptCodec("sketch", string(kind), c.encode == nil || c.decode == nil, isRegistered2D(kind))
+	entityCodecs2D[kind] = c
+}
+
+// registerEntityCodec3D records one 3D kind's codec under the same rules.
+func registerEntityCodec3D(kind EntityKind, c entityCodec3D) {
+	mustAcceptCodec("sketch 3D", string(kind), c.encode == nil || c.decode == nil, isRegistered3D(kind))
+	entityCodecs3D[kind] = c
+}
+
+func isRegistered2D(kind EntityKind) bool { _, dup := entityCodecs2D[kind]; return dup }
+func isRegistered3D(kind EntityKind) bool { _, dup := entityCodecs3D[kind]; return dup }
+
+// mustAcceptCodec is the shared registration gate: a codec must carry a kind and
+// both halves, exactly once.
+func mustAcceptCodec(family, kind string, half, dup bool) {
+	if kind == "" {
+		panic(fmt.Sprintf("%s: registerEntityCodec with empty kind", family))
+	}
+	if half {
+		panic(fmt.Sprintf("%s: codec for kind %q must have both encode and decode", family, kind))
+	}
+	if dup {
+		panic(fmt.Sprintf("%s: duplicate entity codec for kind %q", family, kind))
+	}
+}
+
+// registeredEntityKinds2D returns the 2D kinds with a codec, for the closure test.
+func registeredEntityKinds2D() []EntityKind {
+	out := make([]EntityKind, 0, len(entityCodecs2D))
+	for k := range entityCodecs2D {
+		out = append(out, k)
+	}
+	return out
+}
+
+// registeredEntityKinds3D returns the 3D kinds with a codec, for the closure test.
+func registeredEntityKinds3D() []EntityKind {
+	out := make([]EntityKind, 0, len(entityCodecs3D))
+	for k := range entityCodecs3D {
+		out = append(out, k)
+	}
+	return out
+}

--- a/model/sketch/serialize_registry_test.go
+++ b/model/sketch/serialize_registry_test.go
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"reflect"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// The entity codec registry guards (#1624, audit I1), mirroring
+// model/feature/serialize_registry_test (#1416): the registered kind sets must
+// equal the persisted vocabulary exactly, a half or duplicate registration
+// must panic, and one instance of EVERY registered kind must round-trip to an
+// identical recipe — so a kind added to one codec half (or to neither) fails
+// here at CI, not at the user's save.
+
+// persistedEntityVocabulary2D / 3D are the exact kind sets a recipe may
+// contain, one line per kind. Adding an entity type means registering its
+// codec AND extending this list AND giving the round-trip tests below an
+// instance — all in this package, all enforced together.
+var (
+	persistedEntityVocabulary2D = []EntityKind{
+		LineKind, CircleKind, ArcKind, EllipseKind, EllipticalArcKind, SplineKind,
+		BlockInstanceKind, ImageKind, TextKind, FillRegionKind,
+		ProjectedPointKind, ProjectedCurveKind,
+		EquationCurveKind, FixedSplineKind, OffsetSplineKind,
+	}
+	persistedEntityVocabulary3D = []EntityKind{
+		LineKind, CircleKind, ArcKind, HelicalKind, EllipseKind, EllipticalArcKind,
+		SplineKind, ControlPointSplineKind, FixedSplineKind, EquationCurveKind,
+	}
+)
+
+func TestEntityCodecRegistryMatchesVocabulary(t *testing.T) {
+	assertKindSetsEqual(t, "2D", registeredEntityKinds2D(), persistedEntityVocabulary2D)
+	assertKindSetsEqual(t, "3D", registeredEntityKinds3D(), persistedEntityVocabulary3D)
+}
+
+func assertKindSetsEqual(t *testing.T, family string, got, want []EntityKind) {
+	t.Helper()
+	gotSet, wantSet := kindSet(got), kindSet(want)
+	for k := range wantSet {
+		if !gotSet[k] {
+			t.Errorf("%s kind %q is in the persisted vocabulary but has no codec", family, k)
+		}
+	}
+	for k := range gotSet {
+		if !wantSet[k] {
+			t.Errorf("%s kind %q has a codec but is not in the persisted vocabulary list", family, k)
+		}
+	}
+}
+
+func kindSet(kinds []EntityKind) map[EntityKind]bool {
+	out := make(map[EntityKind]bool, len(kinds))
+	for _, k := range kinds {
+		out[k] = true
+	}
+	return out
+}
+
+func TestRegisterEntityCodecRejectsBadRegistration(t *testing.T) {
+	complete2D := entityCodec{
+		encode: func(Entity) (EntityData, error) { return EntityData{}, nil },
+		decode: func(*sketchRestorer, EntityData) (Entity, error) { return nil, nil },
+	}
+	complete3D := entityCodec3D{
+		encode: func(Entity) (Entity3DData, error) { return Entity3DData{}, nil },
+		decode: func(*Sketch3D, Entity3DData, []*Point3D) (Entity, error) { return nil, nil },
+	}
+	mustPanic(t, "2D empty kind", func() { registerEntityCodec("", complete2D) })
+	mustPanic(t, "2D encode-only", func() { registerEntityCodec("testHalf", entityCodec{encode: complete2D.encode}) })
+	mustPanic(t, "2D decode-only", func() { registerEntityCodec("testHalf", entityCodec{decode: complete2D.decode}) })
+	mustPanic(t, "2D duplicate", func() { registerEntityCodec(LineKind, complete2D) })
+	mustPanic(t, "3D empty kind", func() { registerEntityCodec3D("", complete3D) })
+	mustPanic(t, "3D encode-only", func() { registerEntityCodec3D("testHalf", entityCodec3D{encode: complete3D.encode}) })
+	mustPanic(t, "3D duplicate", func() { registerEntityCodec3D(HelicalKind, complete3D) })
+}
+
+// mustPanic asserts fn panics; every rejection fires before the registry map
+// is touched, so the probes leave the global registries untouched.
+func mustPanic(t *testing.T, name string, fn func()) {
+	t.Helper()
+	defer func() {
+		if recover() == nil {
+			t.Errorf("%s: want a registration panic, got none", name)
+		}
+	}()
+	fn()
+}
+
+// TestEveryRegistered2DKindRoundTripsIdentically saves a sketch holding one
+// instance of every registered 2D kind, restores it, saves again, and demands
+// the two recipes match byte-for-byte — the enumerating closure over the
+// registry (#1624 acceptance: a kind cannot register a codec this test does
+// not exercise, and no codec half can drift from its pair).
+func TestEveryRegistered2DKindRoundTripsIdentically(t *testing.T) {
+	sc := NewSketches()
+	s := sc.Add(XYPlane())
+	populateEvery2DKind(t, sc, s)
+
+	defs, err := sc.MarshalBlockDefinitions()
+	if err != nil {
+		t.Fatalf("MarshalBlockDefinitions: %v", err)
+	}
+	first, err := sc.MarshalRecipe()
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	assertRecipeCoversVocabulary(t, entityKindsIn(first), persistedEntityVocabulary2D)
+
+	fresh := NewSketches()
+	if err := fresh.ApplyBlockDefinitions(defs); err != nil {
+		t.Fatalf("ApplyBlockDefinitions: %v", err)
+	}
+	if err := fresh.ApplyRecipe(first); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	second, err := fresh.MarshalRecipe()
+	if err != nil {
+		t.Fatalf("re-MarshalRecipe: %v", err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Errorf("recipe changed across a round trip:\nfirst:  %+v\nsecond: %+v", first, second)
+	}
+}
+
+// populateEvery2DKind creates one entity of each persisted 2D kind through the
+// same factories the tools use.
+func populateEvery2DKind(t *testing.T, sc *Sketches, s *Sketch) {
+	t.Helper()
+	s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(1, 0))
+	s.Circles().AddByCenterRadius(math.P2(5, 5), 2)
+	s.Arcs().AddByCenterStartEnd(math.P2(0, 0), math.P2(1, 0), math.P2(0, 1), true)
+	s.Ellipses().Add(math.P2(2, 2), math.V2(1, 0), 3, 1)
+	s.ellArcs.AddWithCenter(s.newPoint(math.P2(-2, 2)), math.V2(0, 1), 2, 1, 0.2, 1.4)
+	sp := s.Splines().AddByPoints([]math.Point2{math.P2(0, 0), math.P2(1, 1), math.P2(2, 0)}, false)
+	s.OffsetSplines().Add(sp, 0.5)
+	if _, err := s.EquationCurves().Add("cos(t)", "sin(t)", 0, 1); err != nil {
+		t.Fatalf("EquationCurves.Add: %v", err)
+	}
+	s.FixedSplines().Add([]math.Point2{math.P2(3, 3), math.P2(4, 4), math.P2(5, 3)})
+	s.images.Add("res-1", math.P2(6, 6), 2, 1, 0.1, 0.8)
+	s.texts.AddStyled(math.P2(7, 7), "note", 0.5, 0, TextHJustify(0), TextVJustify(0), "sans", 0)
+	s.fills.Add(math.P2(0.5, 0.25), "solid")
+	s.RestoreProjectedPoint(nextID(), math.P2(8, 8), "vertex", "V1")
+	s.RestoreProjectedCurve(nextID(), []math.Point2{math.P2(8, 0), math.P2(9, 1)}, "edge", "E1")
+	blockSource := s.Lines().AddByTwoPoints(math.P2(10, 10), math.P2(11, 10))
+	if _, _, err := s.Blocks().CreateFromSelection(sc.BlockDefinitions(), "blk", []Entity{blockSource}); err != nil {
+		t.Fatalf("CreateFromSelection: %v", err)
+	}
+}
+
+// TestEveryRegistered3DKindRoundTripsIdentically is the 3D twin.
+func TestEveryRegistered3DKindRoundTripsIdentically(t *testing.T) {
+	c := NewSketches3D()
+	s := c.Add()
+	populateEvery3DKind(t, s)
+
+	first, err := c.MarshalRecipe3D()
+	if err != nil {
+		t.Fatalf("MarshalRecipe3D: %v", err)
+	}
+	assertRecipeCoversVocabulary(t, entityKinds3DIn(first), persistedEntityVocabulary3D)
+
+	fresh := NewSketches3D()
+	if err := fresh.ApplyRecipe3D(first); err != nil {
+		t.Fatalf("ApplyRecipe3D: %v", err)
+	}
+	second, err := fresh.MarshalRecipe3D()
+	if err != nil {
+		t.Fatalf("re-MarshalRecipe3D: %v", err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Errorf("3D recipe changed across a round trip:\nfirst:  %+v\nsecond: %+v", first, second)
+	}
+}
+
+// populateEvery3DKind creates one entity of each persisted 3D kind.
+func populateEvery3DKind(t *testing.T, s *Sketch3D) {
+	t.Helper()
+	uz := mustUnit3(t, 0, 0, 1)
+	ux := mustUnit3(t, 1, 0, 0)
+	s.AddLine3D(math.P3(0, 0, 0), math.P3(1, 0, 0))
+	s.AddCircle3D(math.P3(0, 0, 2), uz, 1.5)
+	s.AddArc3D(math.P3(0, 0, 0), math.P3(1, 0, 0), math.P3(0, 1, 0), true)
+	s.AddHelix3D(math.P3(2, 2, 0), uz, 1, 0.5, 0, 3, false)
+	s.AddEllipse3D(math.P3(4, 0, 0), uz, ux, 3, 1)
+	s.AddEllipticalArc3D(math.P3(0, 4, 0), uz, ux, 3, 1, 0.2, 1.4)
+	s.AddSpline3D([]math.Point3{math.P3(0, 0, 0), math.P3(1, 1, 1), math.P3(2, 0, 2)}, false, true)
+	s.AddSpline3D([]math.Point3{math.P3(5, 0, 0), math.P3(6, 1, 1), math.P3(7, 0, 2)}, false, false)
+	s.AddFixedSpline3D([]math.Point3{math.P3(0, 5, 0), math.P3(1, 6, 1), math.P3(2, 5, 2)}, false)
+	if _, err := s.AddEquationCurve3D("cos(t)", "sin(t)", "t", 0, 1); err != nil {
+		t.Fatalf("AddEquationCurve3D: %v", err)
+	}
+}
+
+func mustUnit3(t *testing.T, x, y, z float64) math.UnitVector3 {
+	t.Helper()
+	u, err := math.NewUnitVector3(math.Scalar(x), math.Scalar(y), math.Scalar(z))
+	if err != nil {
+		t.Fatalf("NewUnitVector3(%v,%v,%v): %v", x, y, z, err)
+	}
+	return u
+}
+
+// assertRecipeCoversVocabulary demands the marshaled recipe contains every
+// registered kind at least once — the closure that forces a newly registered
+// kind to also appear in these round-trip tests.
+func assertRecipeCoversVocabulary(t *testing.T, seen map[EntityKind]bool, vocabulary []EntityKind) {
+	t.Helper()
+	for _, k := range vocabulary {
+		if !seen[k] {
+			t.Errorf("registered kind %q never appeared in the recipe — add an instance to the round-trip fixture", k)
+		}
+	}
+}
+
+func entityKindsIn(data []SketchData) map[EntityKind]bool {
+	out := map[EntityKind]bool{}
+	for _, sd := range data {
+		for _, ed := range sd.Entities {
+			out[EntityKind(ed.Kind)] = true
+		}
+	}
+	return out
+}
+
+func entityKinds3DIn(data []SketchData3D) map[EntityKind]bool {
+	out := map[EntityKind]bool{}
+	for _, sd := range data {
+		for _, ed := range sd.Entities {
+			out[EntityKind(ed.Kind)] = true
+		}
+	}
+	return out
+}

--- a/model/sketch/serialize_registry_test.go
+++ b/model/sketch/serialize_registry_test.go
@@ -22,7 +22,8 @@ import (
 // instance — all in this package, all enforced together.
 var (
 	persistedEntityVocabulary2D = []EntityKind{
-		LineKind, CircleKind, ArcKind, EllipseKind, EllipticalArcKind, SplineKind,
+		LineKind, CircleKind, ArcKind, EllipseKind, EllipticalArcKind,
+		SplineKind, ControlPointSplineKind,
 		BlockInstanceKind, ImageKind, TextKind, FillRegionKind,
 		ProjectedPointKind, ProjectedCurveKind,
 		EquationCurveKind, FixedSplineKind, OffsetSplineKind,
@@ -137,6 +138,7 @@ func populateEvery2DKind(t *testing.T, sc *Sketches, s *Sketch) {
 	s.Ellipses().Add(math.P2(2, 2), math.V2(1, 0), 3, 1)
 	s.ellArcs.AddWithCenter(s.newPoint(math.P2(-2, 2)), math.V2(0, 1), 2, 1, 0.2, 1.4)
 	sp := s.Splines().AddByPoints([]math.Point2{math.P2(0, 0), math.P2(1, 1), math.P2(2, 0)}, false)
+	s.Splines().AddByControlPoints([]math.Point2{math.P2(0, -1), math.P2(1, -2), math.P2(2, -1)}, false)
 	s.OffsetSplines().Add(sp, 0.5)
 	if _, err := s.EquationCurves().Add("cos(t)", "sin(t)", 0, 1); err != nil {
 		t.Fatalf("EquationCurves.Add: %v", err)

--- a/model/sketch/serialize_restore.go
+++ b/model/sketch/serialize_restore.go
@@ -65,36 +65,6 @@ func (r *sketchRestorer) restoreCloudAnchors(anchors []CloudAnchorData) error {
 	return nil
 }
 
-// restoreDerivedCurve rebuilds the M21 derived curves (equation/fixed/offset spline);
-// split out of restoreEntity to keep that switch small. The offset spline's parent must
-// already be restored (entities are restored in order).
-func (r *sketchRestorer) restoreDerivedCurve(ed EntityData) (Entity, error) {
-	switch ed.Kind {
-	case "equationCurve":
-		return r.s.eqCurves.Add(ed.XExpr, ed.YExpr, ed.T0, ed.T1)
-	case "blockInstance":
-		def, ok := r.blockDefs.ByName(ed.Block)
-		if !ok {
-			return nil, fmt.Errorf("block instance references unknown definition %q", ed.Block)
-		}
-		t, err := matrixFromCells(ed.Transform)
-		if err != nil {
-			return nil, err
-		}
-		return r.s.Blocks().Insert(def, t), nil
-	case "fixedSpline":
-		return r.s.fixedSpl.Add(unflattenPoints(ed.Coords)), nil
-	case "offsetSpline":
-		parent, ok := r.entityMap[ed.ParentID].(*Spline)
-		if !ok {
-			return nil, fmt.Errorf("offsetSpline parent %d is not a spline", ed.ParentID)
-		}
-		return r.s.offSpl.Add(parent, ed.OffsetDist), nil
-	default:
-		return nil, fmt.Errorf("unknown entity kind %q", ed.Kind)
-	}
-}
-
 // unflattenPoints rebuilds points from a [x,y,x,y,…] slice (odd tails are ignored).
 func unflattenPoints(coords []float64) []math.Point2 {
 	out := make([]math.Point2, 0, len(coords)/2)
@@ -201,85 +171,16 @@ func (r *sketchRestorer) restoreEntities(entities []EntityData) error {
 	return nil
 }
 
+// restoreEntity rebuilds one entity through its kind's registered codec — the
+// same pairing its serializeEntity encode came from, so the two can never
+// drift (#1624). An unknown kind is a hard error: a recipe never restores
+// partially.
 func (r *sketchRestorer) restoreEntity(ed EntityData) (Entity, error) {
-	switch ed.Kind {
-	case "line":
-		p, err := r.points(ed.Points, 2)
-		if err != nil {
-			return nil, err
-		}
-		return r.s.lines.Add(p[0], p[1]), nil
-	case "circle":
-		p, err := r.points(ed.Points, 1)
-		if err != nil {
-			return nil, err
-		}
-		return r.s.circles.Add(p[0], math.Scalar(ed.Radius)), nil
-	case "arc":
-		p, err := r.points(ed.Points, 3)
-		if err != nil {
-			return nil, err
-		}
-		return r.s.arcs.Add(p[0], p[1], p[2], ed.CCW), nil
-	case "ellipse":
-		p, err := r.points(ed.Points, 1)
-		if err != nil {
-			return nil, err
-		}
-		if len(ed.MajorAxis) != 2 {
-			return nil, fmt.Errorf("ellipse needs a 2-component majorAxis, got %d", len(ed.MajorAxis))
-		}
-		axis := math.V2(ed.MajorAxis[0], ed.MajorAxis[1])
-		return r.s.ellipses.AddWithCenter(p[0], axis, math.Scalar(ed.MajorRadius), math.Scalar(ed.MinorRadius)), nil
-	case "ellipticalArc":
-		p, err := r.points(ed.Points, 1)
-		if err != nil {
-			return nil, err
-		}
-		if len(ed.MajorAxis) != 2 {
-			return nil, fmt.Errorf("ellipticalArc needs a 2-component majorAxis, got %d", len(ed.MajorAxis))
-		}
-		axis := math.V2(ed.MajorAxis[0], ed.MajorAxis[1])
-		return r.s.ellArcs.AddWithCenter(p[0], axis, math.Scalar(ed.MajorRadius), math.Scalar(ed.MinorRadius), math.Scalar(ed.StartAngle), math.Scalar(ed.EndAngle)), nil
-	case "spline":
-		p, err := r.points(ed.Points, len(ed.Points))
-		if err != nil {
-			return nil, err
-		}
-		sp := r.s.splines.AddWithPoints(p, ed.Closed, ed.Fit)
-		if err := restoreSplineExtras(r.s, sp, ed); err != nil {
-			return nil, err
-		}
-		return sp, nil
-	case "image":
-		if len(ed.Anchor) != 2 || len(ed.Size) != 2 {
-			return nil, fmt.Errorf("image needs a 2-component anchor and size")
-		}
-		anchor := math.P2(math.Scalar(ed.Anchor[0]), math.Scalar(ed.Anchor[1]))
-		return r.s.images.Add(ed.ImageRef, anchor, math.Scalar(ed.Size[0]), math.Scalar(ed.Size[1]), math.Scalar(ed.Rotation), ed.Opacity), nil
-	case "fillRegion":
-		if len(ed.Seed) != 2 {
-			return nil, fmt.Errorf("fillRegion needs a 2-component seed")
-		}
-		return r.s.fills.Add(math.P2(math.Scalar(ed.Seed[0]), math.Scalar(ed.Seed[1])), ed.Style), nil
-	case "text":
-		if len(ed.Anchor) != 2 {
-			return nil, fmt.Errorf("text needs a 2-component anchor")
-		}
-		anchor := math.P2(math.Scalar(ed.Anchor[0]), math.Scalar(ed.Anchor[1]))
-		tb := r.s.texts.AddStyled(anchor, ed.Text, math.Scalar(ed.TextHeight), math.Scalar(ed.Rotation),
-			TextHJustify(ed.Justify), TextVJustify(ed.VJustify), ed.FontFamily, math.Scalar(ed.FontSize))
-		tb.FontResource = ed.FontResource
-		return tb, nil
-	case "projectedPoint":
-		return r.restoreProjectedPoint(ed)
-	case "projectedCurve":
-		c := r.s.RestoreProjectedCurve(ID(ed.ID), unflattenPoints(ed.Coords), ed.SourceKind, ed.Source)
-		r.note(ed.ID)
-		return c, nil
-	default:
-		return r.restoreDerivedCurve(ed)
+	c, ok := entityCodecs2D[EntityKind(ed.Kind)]
+	if !ok {
+		return nil, fmt.Errorf("unknown entity kind %q", ed.Kind)
 	}
+	return c.decode(r, ed)
 }
 
 // restoreProjectedPoint rebuilds a frozen projected point and registers its anchor in the point


### PR DESCRIPTION
Closes #1624 (audit I1).

## What

Sketch entities were duck-typed behind the 1-method `Entity` interface, so every consumer re-derived what an entity is with a type switch — ~229 in-package cases plus 96 across router enumerate/edit, app constraint/trim/dimension tools, and compdef rebind — and the serializer's `default:` branch made an unregistered kind a **runtime save failure**, the drift class that shipped #1416 (encode half without decode half silently dropped features on reload) and #1574 (enumerable-but-not-creatable).

- **Paired codec registry** (`model/sketch/serialize_registry.go`): each 2D/3D entity kind registers its encode and decode closure together in one `init()`; registration panics on a duplicate or a half pair, and the old switch pairs (serializeEntity/restoreEntity + 3D twins) and their `default:` save failures are gone.
- **`EntityKind` + capabilities**: every entity names itself (`Kind()`) and exposes its shape (`ShapedEntity`/3D variants), trim (`TrimCurveAt`), rebind (`RebindProjection`), and DOF capabilities — router enumerate/edit, app tools, and compdef rebind now consume the capability instead of switching on concrete types; kind spellings stay decoupled from the wire enum (API SemVer) with the router mapping at its boundary.
- **Compile-time assertions** (`entity_shape.go`/`entity_shape_3d.go`): `var _ ShapedEntity = (*X)(nil)` for every kind.

## Guards

- `serialize_registry_test`: enum-driven closure — the registered 2D/3D codec sets must match the persisted vocabulary exactly, and every kind round-trips encode→decode; duplicate/half registration panic tests.
- `archguard/sketch_entity_switch_test`: no `case *sketch.<EntityType>` outside model/sketch; the forbidden type list is parsed from the `Kind()` declarations, so a new entity kind extends the guard automatically. (Constraint switches are audit I2, #1625.)

## Verification

- Full suite green (`go test -count=1 ./...`), golangci-lint 0 issues.
- **Live** (MCPBridge PR [#89](https://github.com/Oblikovati/Oblikovati.AddIns.MCPBridge/pull/89) `mcplive -part entityseam`): every wire-creatable 2D and 3D kind created against the running host, document round-tripped through a real .obk save → force-close → reopen, kind census identical before/after; viewport screenshot inspected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)