### PR TITLE
Unify sketch-constraint kind derivation behind KindedConstraint + a paired codec registry

### DIFF
--- a/addin/router/sketch3d_constraints.go
+++ b/addin/router/sketch3d_constraints.go
@@ -9,7 +9,6 @@ import (
 	"oblikovati.org/api/types"
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
-	"oblikovati.org/math"
 	"oblikovati.org/model/sketch"
 )
 
@@ -171,34 +170,21 @@ func bendConstraint3D(sk *sketch.Sketch3D, refs []uint64) (sketch.Constraint, er
 
 // equalConstraint3D forces two radius DOFs equal — the operands are circle (radius) or
 // helix (start radius) entities. Surfaced by the issue-#142 kind-coverage guard:
-// Geo3DEqual was declared and Equal3D implemented, but no router case existed.
+// Geo3DEqual was declared and Equal3D implemented, but no router case existed. The
+// model resolves the radius DOFs itself (#1625) so the constraint keeps its refs.
 func equalConstraint3D(sk *sketch.Sketch3D, refs []uint64) (sketch.Constraint, error) {
 	if len(refs) != 2 {
 		return nil, fmt.Errorf("sketch3d.addConstraint: equal needs 2 circle/helix refs, got %d", len(refs))
 	}
-	a, err := radiusScalar3D(sk, refs[0])
-	if err != nil {
-		return nil, err
-	}
-	b, err := radiusScalar3D(sk, refs[1])
-	if err != nil {
-		return nil, err
-	}
-	return sketch.NewEqual3D(a, b), nil
-}
-
-// radiusScalar3D resolves an entity id to its radius solver DOF through the
-// entity's own RadiusDOF capability (#1624).
-func radiusScalar3D(sk *sketch.Sketch3D, id uint64) (*math.Scalar, error) {
-	e, ok := sk.EntityByID(sketch.ID(id))
+	e1, ok := sk.EntityByID(sketch.ID(refs[0]))
 	if !ok {
-		return nil, fmt.Errorf(errNoSketch3DEntity, id)
+		return nil, fmt.Errorf(errNoSketch3DEntity, refs[0])
 	}
-	rd, ok := e.(interface{ RadiusDOF() *math.Scalar })
+	e2, ok := sk.EntityByID(sketch.ID(refs[1]))
 	if !ok {
-		return nil, fmt.Errorf("sketch3d: entity %d is %T, want a circle or helix (radius DOF)", id, e)
+		return nil, fmt.Errorf(errNoSketch3DEntity, refs[1])
 	}
-	return rd.RadiusDOF(), nil
+	return sketch.NewEqual3D(e1, e2)
 }
 
 // pointConstraint3D builds the point-operand constraints (coincident/collinear/concentric).

--- a/addin/router/sketch3d_enumerate.go
+++ b/addin/router/sketch3d_enumerate.go
@@ -132,80 +132,15 @@ func p3coords(p math.Point3) []float64 {
 	return []float64{float64(p.X), float64(p.Y), float64(p.Z)}
 }
 
-// constraint3DKind maps a 3D constraint to its wire kind and the session ids it relates.
+// constraint3DKind maps a 3D constraint to its wire kind and the session ids
+// it relates, both self-reported by the KindedConstraint capability (#1625).
+// The 3D wire enum spells every kind exactly like the model's persisted
+// vocabulary (by construction), so the kind maps by conversion; a constraint
+// without the capability enumerates honestly as unknown.
 func constraint3DKind(c sketch.Constraint) (types.Geometric3DConstraintKind, []uint64) {
-	switch v := c.(type) {
-	case *sketch.Coincident3D:
-		return types.Geo3DCoincident, []uint64{uint64(v.A.EntityID()), uint64(v.B.EntityID())}
-	case *sketch.Collinear3D:
-		return types.Geo3DCollinear, []uint64{uint64(v.A.EntityID()), uint64(v.B.EntityID()), uint64(v.C.EntityID())}
-	case *sketch.Concentric3D:
-		return types.Geo3DConcentric, []uint64{uint64(v.Center1.EntityID()), uint64(v.Center2.EntityID())}
-	case *sketch.Equal3D:
-		return types.Geo3DEqual, nil
-	default:
-		return lineConstraint3DKind(c)
-	}
-}
-
-// lineConstraint3DKind maps the line/point-operand constraints (M22-F05) to their kind.
-func lineConstraint3DKind(c sketch.Constraint) (types.Geometric3DConstraintKind, []uint64) {
-	switch v := c.(type) {
-	case *sketch.Parallel3D:
-		return types.Geo3DParallel, []uint64{uint64(v.L1.EntityID()), uint64(v.L2.EntityID())}
-	case *sketch.Perpendicular3D:
-		return types.Geo3DPerpendicular, []uint64{uint64(v.L1.EntityID()), uint64(v.L2.EntityID())}
-	case *sketch.Midpoint3D:
-		return types.Geo3DMidpoint, []uint64{uint64(v.P.EntityID()), uint64(v.L.EntityID())}
-	case *sketch.Ground3D:
-		return types.Geo3DGround, []uint64{uint64(v.P.EntityID())}
-	case *sketch.ParallelToAxis3D:
-		return axisConstraintKind(v), []uint64{uint64(v.L.EntityID())}
-	case *sketch.ParallelToPlane3D:
-		return planeConstraintKind(v), []uint64{uint64(v.L.EntityID())}
-	default:
-		return curveConstraint3DKind(c)
-	}
-}
-
-// curveConstraint3DKind maps the curve-join constraints (issue #142) to their kind.
-func curveConstraint3DKind(c sketch.Constraint) (types.Geometric3DConstraintKind, []uint64) {
-	switch v := c.(type) {
-	case *sketch.Tangent3D:
-		return types.Geo3DTangent, []uint64{uint64(v.C1.EntityID()), uint64(v.C2.EntityID())}
-	case *sketch.Smooth3D:
-		return types.Geo3DSmooth, []uint64{uint64(v.C1.EntityID()), uint64(v.C2.EntityID())}
-	case *sketch.SplineFitPoints3D:
-		return types.Geo3DSplineFitPoints, []uint64{uint64(v.Spline.EntityID()), uint64(v.P.EntityID())}
-	case *sketch.Helical3D:
-		return types.Geo3DHelical, []uint64{uint64(v.H.EntityID()), uint64(v.C.EntityID())}
-	case *sketch.Bend3D:
-		return types.Geo3DBend, []uint64{uint64(v.Arc.EntityID()), uint64(v.L1.EntityID()), uint64(v.L2.EntityID())}
-	default:
+	kc, ok := c.(sketch.KindedConstraint)
+	if !ok {
 		return types.Geo3DUnknown, nil
 	}
-}
-
-// axisConstraintKind names a parallel-to-axis constraint by which world axis it pins to.
-func axisConstraintKind(c *sketch.ParallelToAxis3D) types.Geometric3DConstraintKind {
-	switch {
-	case c.Axis.X != 0:
-		return types.Geo3DParallelToXAxis
-	case c.Axis.Y != 0:
-		return types.Geo3DParallelToYAxis
-	default:
-		return types.Geo3DParallelToZAxis
-	}
-}
-
-// planeConstraintKind names a parallel-to-plane constraint by its plane normal.
-func planeConstraintKind(c *sketch.ParallelToPlane3D) types.Geometric3DConstraintKind {
-	switch {
-	case c.Normal.Z != 0:
-		return types.Geo3DParallelToXYPlane
-	case c.Normal.Y != 0:
-		return types.Geo3DParallelToXZPlane
-	default:
-		return types.Geo3DParallelToYZPlane
-	}
+	return types.Geometric3DConstraintKind(kc.ConstraintKind()), ids(kc.RelatedEntities()...)
 }

--- a/addin/router/sketch3d_missing_entity_test.go
+++ b/addin/router/sketch3d_missing_entity_test.go
@@ -15,8 +15,8 @@ func TestSketch3DRefHelpersRejectMissingEntity(t *testing.T) {
 	sk := sketch.NewSketches3D().Add()
 	const bad = uint64(999)
 
-	if _, err := radiusScalar3D(sk, bad); err == nil {
-		t.Error("radiusScalar3D(missing) should error")
+	if _, err := equalConstraint3D(sk, []uint64{bad, bad}); err == nil {
+		t.Error("equalConstraint3D(missing) should error")
 	}
 	if _, err := pointRef3D(sk, bad); err == nil {
 		t.Error("pointRef3D(missing) should error")

--- a/addin/router/sketch_enumerate.go
+++ b/addin/router/sketch_enumerate.go
@@ -186,109 +186,55 @@ func point2Slice(pts []math.Point2) [][]float64 {
 	return out
 }
 
-// geometricShape returns a geometric constraint's wire kind and the ids of the entities
-// (points/lines/curves) it relates. Split into point- and curve-anchored groups to keep
-// each type switch small.
+// geometricShape returns a geometric constraint's wire kind and the ids of the
+// entities it relates, both self-reported by the constraint's KindedConstraint
+// capability (#1625) — the per-consumer type switches this replaces are the
+// structure that shipped #1574's enumerable-but-not-creatable Symmetry.
 func geometricShape(c sketch.Constraint) (types.GeometricConstraintKind, []uint64) {
-	if k, refs, ok := pointConstraintShape(c); ok {
-		return k, refs
+	kc, ok := c.(sketch.KindedConstraint)
+	if !ok {
+		return types.GeoConstraintUnknown, nil
 	}
-	if k, refs, ok := lineConstraintShape(c); ok {
-		return k, refs
-	}
-	if k, refs, ok := circularConstraintShape(c); ok {
-		return k, refs
-	}
-	if k, refs, ok := extraConstraintShape(c); ok {
-		return k, refs
-	}
-	return types.GeoConstraintUnknown, nil
+	return wireConstraintKind(kc.ConstraintKind()), ids(kc.RelatedEntities()...)
 }
 
-// extraConstraintShape handles the M21 constraints (ground/offset/pattern
-// link) and the M06-F11 tag constraints (text-box anchor, custom).
-func extraConstraintShape(c sketch.Constraint) (types.GeometricConstraintKind, []uint64, bool) {
-	switch v := c.(type) {
-	case *sketch.GroundConstraint:
-		return types.GeoConstraintGround, ids(pointsAsEntities(v.Points())...), true
-	case *sketch.OffsetConstraint:
-		return types.GeoConstraintOffset, ids(v.L1, v.L2), true
-	case *sketch.PatternConstraint:
-		return types.GeoConstraintPattern, ids(v.Seed, v.Member), true
-	case *sketch.TextBoxAnchorConstraint:
-		return types.GeoConstraintTextBox, ids(v.Text), true
-	case *sketch.CustomConstraint:
-		return types.GeoConstraintCustom, ids(v.Entities...), true
-	default:
-		return "", nil, false
+// wireConstraintKind maps the model's persisted constraint vocabulary to the
+// wire enum at the router boundary (the two follow different compatibility
+// contracts: .obk stability vs API SemVer). The wire enum is coarser: a
+// circular tangent enumerates as the wire "tangent".
+func wireConstraintKind(kind sketch.ConstraintKind) types.GeometricConstraintKind {
+	if kind == sketch.CircularTangentKind {
+		return types.GeoConstraintTangent
 	}
+	if wire, ok := wireConstraintKinds[kind]; ok {
+		return wire
+	}
+	return types.GeoConstraintUnknown
 }
 
-// pointsAsEntities adapts a slice of points to the Entity interface for ids().
-func pointsAsEntities(pts []*sketch.Point) []sketch.Entity {
-	out := make([]sketch.Entity, len(pts))
-	for i, p := range pts {
-		out[i] = p
-	}
-	return out
-}
-
-// pointConstraintShape handles the constraints anchored on points (and point↔line).
-func pointConstraintShape(c sketch.Constraint) (types.GeometricConstraintKind, []uint64, bool) {
-	switch v := c.(type) {
-	case *sketch.CoincidentConstraint:
-		return types.GeoConstraintCoincident, ids(v.A, v.B), true
-	case *sketch.PointOnLineConstraint:
-		return types.GeoConstraintPointOnLine, ids(v.P, v.L), true
-	case *sketch.MidpointConstraint:
-		return types.GeoConstraintMidpoint, ids(v.P, v.L), true
-	case *sketch.PointOnCircleConstraint:
-		return types.GeoConstraintPointOnCircle, append(ids(v.P), curveID(v.C)...), true
-	case *sketch.HorizontalConstraint:
-		return types.GeoConstraintHorizontal, ids(v.A, v.B), true
-	case *sketch.VerticalConstraint:
-		return types.GeoConstraintVertical, ids(v.A, v.B), true
-	case *sketch.SymmetryConstraint:
-		return types.GeoConstraintSymmetry, ids(v.A, v.B, v.About), true
-	case *sketch.FixConstraint:
-		return types.GeoConstraintFix, ids(v.P), true
-	default:
-		return "", nil, false
-	}
-}
-
-// lineConstraintShape handles the constraints anchored on straight lines.
-func lineConstraintShape(c sketch.Constraint) (types.GeometricConstraintKind, []uint64, bool) {
-	switch v := c.(type) {
-	case *sketch.ParallelConstraint:
-		return types.GeoConstraintParallel, ids(v.L1, v.L2), true
-	case *sketch.PerpendicularConstraint:
-		return types.GeoConstraintPerpendicular, ids(v.L1, v.L2), true
-	case *sketch.CollinearConstraint:
-		return types.GeoConstraintCollinear, ids(v.L1, v.L2), true
-	case *sketch.EqualLengthConstraint:
-		return types.GeoConstraintEqualLength, ids(v.L1, v.L2), true
-	case *sketch.TangentConstraint:
-		return types.GeoConstraintTangent, append(ids(v.L), curveID(v.C)...), true
-	default:
-		return "", nil, false
-	}
-}
-
-// circularConstraintShape handles the constraints anchored on circular/smooth curves.
-func circularConstraintShape(c sketch.Constraint) (types.GeometricConstraintKind, []uint64, bool) {
-	switch v := c.(type) {
-	case *sketch.ConcentricConstraint:
-		return types.GeoConstraintConcentric, append(curveID(v.C1), curveID(v.C2)...), true
-	case *sketch.EqualRadiusConstraint:
-		return types.GeoConstraintEqualRadius, append(curveID(v.C1), curveID(v.C2)...), true
-	case *sketch.CircularTangentConstraint:
-		return types.GeoConstraintTangent, append(curveID(v.C1), curveID(v.C2)...), true
-	case *sketch.SmoothConstraint:
-		return types.GeoConstraintSmooth, ids(v.C1, v.C2), true
-	default:
-		return "", nil, false
-	}
+// wireConstraintKinds is the 1:1 part of the model→wire kind mapping.
+var wireConstraintKinds = map[sketch.ConstraintKind]types.GeometricConstraintKind{
+	sketch.CoincidentKind:    types.GeoConstraintCoincident,
+	sketch.PointOnLineKind:   types.GeoConstraintPointOnLine,
+	sketch.MidpointKind:      types.GeoConstraintMidpoint,
+	sketch.PointOnCircleKind: types.GeoConstraintPointOnCircle,
+	sketch.HorizontalKind:    types.GeoConstraintHorizontal,
+	sketch.VerticalKind:      types.GeoConstraintVertical,
+	sketch.SymmetryKind:      types.GeoConstraintSymmetry,
+	sketch.FixKind:           types.GeoConstraintFix,
+	sketch.ParallelKind:      types.GeoConstraintParallel,
+	sketch.PerpendicularKind: types.GeoConstraintPerpendicular,
+	sketch.CollinearKind:     types.GeoConstraintCollinear,
+	sketch.EqualLengthKind:   types.GeoConstraintEqualLength,
+	sketch.TangentKind:       types.GeoConstraintTangent,
+	sketch.ConcentricKind:    types.GeoConstraintConcentric,
+	sketch.EqualRadiusKind:   types.GeoConstraintEqualRadius,
+	sketch.SmoothKind:        types.GeoConstraintSmooth,
+	sketch.GroundKind:        types.GeoConstraintGround,
+	sketch.OffsetKind:        types.GeoConstraintOffset,
+	sketch.PatternLinkKind:   types.GeoConstraintPattern,
+	sketch.TextBoxAnchorKind: types.GeoConstraintTextBox,
+	sketch.CustomKind:        types.GeoConstraintCustom,
 }
 
 // dimensionKind maps a model DimKind to its wire kind.
@@ -341,12 +287,4 @@ func ids(es ...sketch.Entity) []uint64 {
 		}
 	}
 	return out
-}
-
-// curveID returns the id of a circular curve (a *Circle or *Arc, both Entity), or nil.
-func curveID(c sketch.CircularCurve) []uint64 {
-	if e, ok := c.(sketch.Entity); ok {
-		return []uint64{uint64(e.EntityID())}
-	}
-	return nil
 }

--- a/archguard/sketch_constraint_switch_test.go
+++ b/archguard/sketch_constraint_switch_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package archguard
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Sketch constraints name their own kind and related entities (#1625, audit
+// I2) — a consumer outside model/sketch that re-derives what a constraint is
+// with a `case *sketch.X:` type switch re-creates the drift class that left
+// Symmetry enumerable but not creatable (#1574) and Equal3D failing every
+// save at runtime (#1416 class). The forbidden type list is parsed from
+// model/sketch's ConstraintKind() declarations, so a new constraint kind
+// extends this guard automatically. Entity-type switches are guarded by
+// sketch_entity_switch_test (#1624); single type assertions stay fine.
+
+// constraintKindReceiverPattern extracts the receiver type of every
+// ConstraintKind() method in model/sketch — the closed set of constraint types.
+var constraintKindReceiverPattern = regexp.MustCompile(`func \(\w+ \*(\w+)\) ConstraintKind\(\) ConstraintKind`)
+
+func TestNoSketchConstraintTypeSwitchesOutsideModelSketch(t *testing.T) {
+	constraintTypes := sketchConstraintTypeNames(t)
+	if len(constraintTypes) < 30 {
+		t.Fatalf("parsed only %d constraint types from model/sketch (want the full ~37) — did ConstraintKind() move out of constraint_kind.go / constraint_kind_3d.go?", len(constraintTypes))
+	}
+	constraintCase := regexp.MustCompile(`case [^:\n]*\*sketch\.(` + strings.Join(constraintTypes, "|") + `)\b`)
+	for _, offender := range goSourcesMatching(t, constraintCase) {
+		t.Errorf("%s switches on a sketch constraint type — use the constraint's KindedConstraint capability (ConstraintKind/RelatedEntities) or a single typed assertion instead (#1625, audit I2)", offender)
+	}
+}
+
+// sketchConstraintTypeNames parses the ConstraintKind() receivers out of
+// model/sketch's kind declaration files.
+func sketchConstraintTypeNames(t *testing.T) []string {
+	t.Helper()
+	var out []string
+	for _, file := range []string{"../model/sketch/constraint_kind.go", "../model/sketch/constraint_kind_3d.go"} {
+		src, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("reading %s: %v", file, err)
+		}
+		for _, m := range constraintKindReceiverPattern.FindAllStringSubmatch(string(src), -1) {
+			out = append(out, m[1])
+		}
+	}
+	return out
+}

--- a/model/sketch/autodiff_3d_test.go
+++ b/model/sketch/autodiff_3d_test.go
@@ -21,7 +21,9 @@ func TestConstraint3DPartialsMatchFiniteDifference(t *testing.T) {
 	c := s.AddPoint3D(math.P3(2.2, -1.1, 0.8))
 	l1 := s.AddLine3D(math.P3(0.2, 0.5, 0.1), math.P3(2.6, 1.9, -0.4))
 	l2 := s.AddLine3D(math.P3(-1.1, 0.3, 0.7), math.P3(1.7, 2.8, 1.3))
-	r1, r2 := math.Scalar(2.5), math.Scalar(3.1)
+	zUp, _ := math.NewUnitVector3(0, 0, 1)
+	c1 := s.AddCircle3D(math.P3(0, 0, 0), zUp, 2.5)
+	c2 := s.AddCircle3D(math.P3(5, 0, 0), zUp, 3.1)
 
 	cases := []struct {
 		name string
@@ -30,7 +32,7 @@ func TestConstraint3DPartialsMatchFiniteDifference(t *testing.T) {
 		{"coincident3d", NewCoincident3D(a, b)},
 		{"collinear3d", NewCollinear3D(a, b, c)},
 		{"concentric3d", NewConcentric3D(a, b)},
-		{"equal3d", NewEqual3D(&r1, &r2)},
+		{"equal3d", mustEqual3D(t, c1, c2)},
 		{"parallel3d", NewParallel3D(l1, l2)},
 		{"perpendicular3d", NewPerpendicular3D(l1, l2)},
 		{"midpoint3d", NewMidpoint3D(a, l1)},
@@ -128,4 +130,15 @@ func TestDimension3DPartialsMatchFiniteDifference(t *testing.T) {
 	for _, tc := range cases {
 		assertAnalyticMatchesFD(t, tc.name, tc.c)
 	}
+}
+
+// mustEqual3D builds an Equal3D over two radius-bearing curves, failing the test
+// on a refused operand (#1625).
+func mustEqual3D(t *testing.T, e1, e2 Entity) *Equal3D {
+	t.Helper()
+	eq, err := NewEqual3D(e1, e2)
+	if err != nil {
+		t.Fatalf("NewEqual3D(%T, %T): %v", e1, e2, err)
+	}
+	return eq
 }

--- a/model/sketch/constraint_kind.go
+++ b/model/sketch/constraint_kind.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+// ConstraintKind names what a geometric constraint IS — the stable identifier
+// its persistence codec and creation factory are registered under (#1625,
+// audit I2). The string values are the .obk recipe vocabulary (ADR-0020) and
+// must never change once shipped; they intentionally stay decoupled from the
+// wire enum api/types.GeometricConstraintKind, which follows API SemVer and is
+// coarser (circularTangent enumerates as the wire "tangent") — the router maps
+// between the two at its boundary, exactly as EntityKind does (#1624).
+type ConstraintKind string
+
+// The persisted 2D geometric constraint kinds.
+const (
+	CoincidentKind      ConstraintKind = "coincident"
+	HorizontalKind      ConstraintKind = "horizontal"
+	VerticalKind        ConstraintKind = "vertical"
+	PointOnLineKind     ConstraintKind = "pointOnLine"
+	MidpointKind        ConstraintKind = "midpoint"
+	PointOnCircleKind   ConstraintKind = "pointOnCircle"
+	ParallelKind        ConstraintKind = "parallel"
+	PerpendicularKind   ConstraintKind = "perpendicular"
+	CollinearKind       ConstraintKind = "collinear"
+	EqualLengthKind     ConstraintKind = "equalLength"
+	ConcentricKind      ConstraintKind = "concentric"
+	EqualRadiusKind     ConstraintKind = "equalRadius"
+	CircularTangentKind ConstraintKind = "circularTangent"
+	TangentKind         ConstraintKind = "tangent"
+	SymmetryKind        ConstraintKind = "symmetry"
+	FixKind             ConstraintKind = "fix"
+	SmoothKind          ConstraintKind = "smooth"
+	GroundKind          ConstraintKind = "ground"
+	OffsetKind          ConstraintKind = "offset"
+	PatternLinkKind     ConstraintKind = "patternLink"
+	TextBoxAnchorKind   ConstraintKind = "textBox"
+	CustomKind          ConstraintKind = "custom"
+)
+
+// KindedConstraint is the capability the serializer and the router enumerate
+// consume: what kind of constraint am I, and which entities do I relate — so
+// no consumer re-derives either with a type switch (#1625, audit I2; the
+// switch-per-consumer structure shipped #1574's enumerable-but-not-creatable
+// Symmetry and keeps the #1416 save-failure class open).
+type KindedConstraint interface {
+	Constraint
+	// ConstraintKind returns the constraint's persisted kind.
+	ConstraintKind() ConstraintKind
+	// RelatedEntities returns the entities the constraint relates, in the
+	// order the API enumerates them.
+	RelatedEntities() []Entity
+}
+
+// ConstraintKind identifies each 2D constraint for codec and factory dispatch
+// (and, mapped at the router boundary, for enumeration). Each concrete type
+// declares its own — like Kind() on entities — so no consumer needs a switch.
+func (c *CoincidentConstraint) ConstraintKind() ConstraintKind      { return CoincidentKind }
+func (c *HorizontalConstraint) ConstraintKind() ConstraintKind      { return HorizontalKind }
+func (c *VerticalConstraint) ConstraintKind() ConstraintKind        { return VerticalKind }
+func (c *PointOnLineConstraint) ConstraintKind() ConstraintKind     { return PointOnLineKind }
+func (c *MidpointConstraint) ConstraintKind() ConstraintKind        { return MidpointKind }
+func (c *PointOnCircleConstraint) ConstraintKind() ConstraintKind   { return PointOnCircleKind }
+func (c *ParallelConstraint) ConstraintKind() ConstraintKind        { return ParallelKind }
+func (c *PerpendicularConstraint) ConstraintKind() ConstraintKind   { return PerpendicularKind }
+func (c *CollinearConstraint) ConstraintKind() ConstraintKind       { return CollinearKind }
+func (c *EqualLengthConstraint) ConstraintKind() ConstraintKind     { return EqualLengthKind }
+func (c *ConcentricConstraint) ConstraintKind() ConstraintKind      { return ConcentricKind }
+func (c *EqualRadiusConstraint) ConstraintKind() ConstraintKind     { return EqualRadiusKind }
+func (c *CircularTangentConstraint) ConstraintKind() ConstraintKind { return CircularTangentKind }
+func (c *TangentConstraint) ConstraintKind() ConstraintKind         { return TangentKind }
+func (c *SymmetryConstraint) ConstraintKind() ConstraintKind        { return SymmetryKind }
+func (c *FixConstraint) ConstraintKind() ConstraintKind             { return FixKind }
+func (c *SmoothConstraint) ConstraintKind() ConstraintKind          { return SmoothKind }
+func (c *GroundConstraint) ConstraintKind() ConstraintKind          { return GroundKind }
+func (c *OffsetConstraint) ConstraintKind() ConstraintKind          { return OffsetKind }
+func (c *PatternConstraint) ConstraintKind() ConstraintKind         { return PatternLinkKind }
+func (c *TextBoxAnchorConstraint) ConstraintKind() ConstraintKind   { return TextBoxAnchorKind }
+func (c *CustomConstraint) ConstraintKind() ConstraintKind          { return CustomKind }
+
+// RelatedEntities per type, in API enumeration order.
+func (c *CoincidentConstraint) RelatedEntities() []Entity    { return []Entity{c.A, c.B} }
+func (c *HorizontalConstraint) RelatedEntities() []Entity    { return []Entity{c.A, c.B} }
+func (c *VerticalConstraint) RelatedEntities() []Entity      { return []Entity{c.A, c.B} }
+func (c *PointOnLineConstraint) RelatedEntities() []Entity   { return []Entity{c.P, c.L} }
+func (c *MidpointConstraint) RelatedEntities() []Entity      { return []Entity{c.P, c.L} }
+func (c *PointOnCircleConstraint) RelatedEntities() []Entity { return []Entity{c.P, c.C} }
+func (c *ParallelConstraint) RelatedEntities() []Entity      { return []Entity{c.L1, c.L2} }
+func (c *PerpendicularConstraint) RelatedEntities() []Entity { return []Entity{c.L1, c.L2} }
+func (c *CollinearConstraint) RelatedEntities() []Entity     { return []Entity{c.L1, c.L2} }
+func (c *EqualLengthConstraint) RelatedEntities() []Entity   { return []Entity{c.L1, c.L2} }
+func (c *ConcentricConstraint) RelatedEntities() []Entity    { return []Entity{c.C1, c.C2} }
+func (c *EqualRadiusConstraint) RelatedEntities() []Entity   { return []Entity{c.C1, c.C2} }
+func (c *CircularTangentConstraint) RelatedEntities() []Entity {
+	return []Entity{c.C1, c.C2}
+}
+func (c *TangentConstraint) RelatedEntities() []Entity  { return []Entity{c.L, c.C} }
+func (c *SymmetryConstraint) RelatedEntities() []Entity { return []Entity{c.A, c.B, c.About} }
+func (c *FixConstraint) RelatedEntities() []Entity      { return []Entity{c.P} }
+func (c *SmoothConstraint) RelatedEntities() []Entity   { return []Entity{c.C1, c.C2} }
+func (c *GroundConstraint) RelatedEntities() []Entity {
+	pts := c.Points()
+	out := make([]Entity, len(pts))
+	for i, p := range pts {
+		out[i] = p
+	}
+	return out
+}
+func (c *OffsetConstraint) RelatedEntities() []Entity  { return []Entity{c.L1, c.L2} }
+func (c *PatternConstraint) RelatedEntities() []Entity { return []Entity{c.Seed, c.Member} }
+func (c *TextBoxAnchorConstraint) RelatedEntities() []Entity {
+	return []Entity{c.Text}
+}
+func (c *CustomConstraint) RelatedEntities() []Entity { return c.Entities }
+
+// Every 2D constraint carries the capability — a lost method fails the build.
+var (
+	_ KindedConstraint = (*CoincidentConstraint)(nil)
+	_ KindedConstraint = (*HorizontalConstraint)(nil)
+	_ KindedConstraint = (*VerticalConstraint)(nil)
+	_ KindedConstraint = (*PointOnLineConstraint)(nil)
+	_ KindedConstraint = (*MidpointConstraint)(nil)
+	_ KindedConstraint = (*PointOnCircleConstraint)(nil)
+	_ KindedConstraint = (*ParallelConstraint)(nil)
+	_ KindedConstraint = (*PerpendicularConstraint)(nil)
+	_ KindedConstraint = (*CollinearConstraint)(nil)
+	_ KindedConstraint = (*EqualLengthConstraint)(nil)
+	_ KindedConstraint = (*ConcentricConstraint)(nil)
+	_ KindedConstraint = (*EqualRadiusConstraint)(nil)
+	_ KindedConstraint = (*CircularTangentConstraint)(nil)
+	_ KindedConstraint = (*TangentConstraint)(nil)
+	_ KindedConstraint = (*SymmetryConstraint)(nil)
+	_ KindedConstraint = (*FixConstraint)(nil)
+	_ KindedConstraint = (*SmoothConstraint)(nil)
+	_ KindedConstraint = (*GroundConstraint)(nil)
+	_ KindedConstraint = (*OffsetConstraint)(nil)
+	_ KindedConstraint = (*PatternConstraint)(nil)
+	_ KindedConstraint = (*TextBoxAnchorConstraint)(nil)
+	_ KindedConstraint = (*CustomConstraint)(nil)
+)

--- a/model/sketch/constraint_kind_3d.go
+++ b/model/sketch/constraint_kind_3d.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+// The persisted 3D geometric constraint kinds (#1625, audit I2). 2D and 3D
+// constraints share one ConstraintKind vocabulary where the relation is the
+// same (coincident, parallel, …); the dimension is carried by which codec
+// registry the kind is looked up in, exactly as EntityKind does (#1624).
+const (
+	Collinear3PointKind ConstraintKind = "collinear"
+	EqualKind           ConstraintKind = "equal"
+	ParallelToXAxisKind ConstraintKind = "parallelToXAxis"
+	ParallelToYAxisKind ConstraintKind = "parallelToYAxis"
+	ParallelToZAxisKind ConstraintKind = "parallelToZAxis"
+	ParallelToXYKind    ConstraintKind = "parallelToXYPlane"
+	ParallelToXZKind    ConstraintKind = "parallelToXZPlane"
+	ParallelToYZKind    ConstraintKind = "parallelToYZPlane"
+	SplineFitPointsKind ConstraintKind = "splineFitPoints"
+	// HelicalJoinKind avoids colliding with the helical EntityKind; the
+	// persisted spelling is the same "helical" in the constraint table.
+	HelicalJoinKind ConstraintKind = "helical"
+	BendKind        ConstraintKind = "bend"
+)
+
+// ConstraintKind per 3D type. ParallelToAxis3D/ParallelToPlane3D derive their
+// kind from the constrained axis/normal — one type, three persisted kinds each
+// (the pre-#1625 axisRowKind/planeRowKind spellings, kept for .obk stability).
+func (c *Coincident3D) ConstraintKind() ConstraintKind    { return CoincidentKind }
+func (c *Collinear3D) ConstraintKind() ConstraintKind     { return Collinear3PointKind }
+func (c *Concentric3D) ConstraintKind() ConstraintKind    { return ConcentricKind }
+func (c *Equal3D) ConstraintKind() ConstraintKind         { return EqualKind }
+func (c *Parallel3D) ConstraintKind() ConstraintKind      { return ParallelKind }
+func (c *Perpendicular3D) ConstraintKind() ConstraintKind { return PerpendicularKind }
+func (c *Midpoint3D) ConstraintKind() ConstraintKind      { return MidpointKind }
+func (c *Ground3D) ConstraintKind() ConstraintKind        { return GroundKind }
+func (c *ParallelToAxis3D) ConstraintKind() ConstraintKind {
+	switch {
+	case c.Axis.X != 0:
+		return ParallelToXAxisKind
+	case c.Axis.Y != 0:
+		return ParallelToYAxisKind
+	default:
+		return ParallelToZAxisKind
+	}
+}
+func (c *ParallelToPlane3D) ConstraintKind() ConstraintKind {
+	switch {
+	case c.Normal.Z != 0:
+		return ParallelToXYKind
+	case c.Normal.Y != 0:
+		return ParallelToXZKind
+	default:
+		return ParallelToYZKind
+	}
+}
+func (c *Tangent3D) ConstraintKind() ConstraintKind         { return TangentKind }
+func (c *Smooth3D) ConstraintKind() ConstraintKind          { return SmoothKind }
+func (c *SplineFitPoints3D) ConstraintKind() ConstraintKind { return SplineFitPointsKind }
+func (c *Helical3D) ConstraintKind() ConstraintKind         { return HelicalJoinKind }
+func (c *Bend3D) ConstraintKind() ConstraintKind            { return BendKind }
+
+// RelatedEntities per 3D type, in API enumeration order.
+func (c *Coincident3D) RelatedEntities() []Entity    { return []Entity{c.A, c.B} }
+func (c *Collinear3D) RelatedEntities() []Entity     { return []Entity{c.A, c.B, c.C} }
+func (c *Concentric3D) RelatedEntities() []Entity    { return []Entity{c.Center1, c.Center2} }
+func (c *Equal3D) RelatedEntities() []Entity         { return []Entity{c.E1, c.E2} }
+func (c *Parallel3D) RelatedEntities() []Entity      { return []Entity{c.L1, c.L2} }
+func (c *Perpendicular3D) RelatedEntities() []Entity { return []Entity{c.L1, c.L2} }
+func (c *Midpoint3D) RelatedEntities() []Entity      { return []Entity{c.P, c.L} }
+func (c *Ground3D) RelatedEntities() []Entity        { return []Entity{c.P} }
+func (c *ParallelToAxis3D) RelatedEntities() []Entity {
+	return []Entity{c.L}
+}
+func (c *ParallelToPlane3D) RelatedEntities() []Entity {
+	return []Entity{c.L}
+}
+func (c *Tangent3D) RelatedEntities() []Entity { return []Entity{c.C1, c.C2} }
+func (c *Smooth3D) RelatedEntities() []Entity  { return []Entity{c.C1, c.C2} }
+func (c *SplineFitPoints3D) RelatedEntities() []Entity {
+	return []Entity{c.Spline, c.P}
+}
+func (c *Helical3D) RelatedEntities() []Entity { return []Entity{c.H, c.C} }
+func (c *Bend3D) RelatedEntities() []Entity {
+	return []Entity{c.Arc, c.L1, c.L2}
+}
+
+// Every 3D constraint carries the capability — a lost method fails the build.
+var (
+	_ KindedConstraint = (*Coincident3D)(nil)
+	_ KindedConstraint = (*Collinear3D)(nil)
+	_ KindedConstraint = (*Concentric3D)(nil)
+	_ KindedConstraint = (*Equal3D)(nil)
+	_ KindedConstraint = (*Parallel3D)(nil)
+	_ KindedConstraint = (*Perpendicular3D)(nil)
+	_ KindedConstraint = (*Midpoint3D)(nil)
+	_ KindedConstraint = (*Ground3D)(nil)
+	_ KindedConstraint = (*ParallelToAxis3D)(nil)
+	_ KindedConstraint = (*ParallelToPlane3D)(nil)
+	_ KindedConstraint = (*Tangent3D)(nil)
+	_ KindedConstraint = (*Smooth3D)(nil)
+	_ KindedConstraint = (*SplineFitPoints3D)(nil)
+	_ KindedConstraint = (*Helical3D)(nil)
+	_ KindedConstraint = (*Bend3D)(nil)
+)

--- a/model/sketch/constraint_kind_test.go
+++ b/model/sketch/constraint_kind_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestConstraintKindSelfDescription spot-checks the KindedConstraint capability
+// (#1625, audit I2): the derived axis/plane kinds, and the RelatedEntities
+// order the API enumerates (which consumers previously re-derived by switch).
+func TestConstraintKindSelfDescription(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	l1 := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(2, 0))
+	l2 := s.Lines().AddByTwoPoints(math.P2(0, 1), math.P2(2, 1))
+	c1 := s.Circles().AddByCenterRadius(math.P2(5, 0), 1)
+	g := s.GeometricConstraints()
+
+	sym := g.AddSymmetry(l1.A, l1.B, l2)
+	if sym.ConstraintKind() != SymmetryKind {
+		t.Errorf("symmetry kind = %q, want %q", sym.ConstraintKind(), SymmetryKind)
+	}
+	assertRelated(t, "symmetry", sym, l1.A.EntityID(), l1.B.EntityID(), l2.EntityID())
+
+	tan := g.AddTangent(l1, c1)
+	assertRelated(t, "tangent", tan, l1.EntityID(), c1.EntityID())
+	if tan.ConstraintKind() != TangentKind {
+		t.Errorf("tangent kind = %q, want %q", tan.ConstraintKind(), TangentKind)
+	}
+
+	grd := g.AddGroundPoints(l1.A, l2.B)
+	assertRelated(t, "ground", grd, l1.A.EntityID(), l2.B.EntityID())
+}
+
+// TestConstraintKind3DDerivedKinds pins the one-type-many-kinds constraints:
+// parallel-to-axis/plane derive their persisted kind from the constrained
+// direction (the pre-#1625 axisRowKind/planeRowKind spellings).
+func TestConstraintKind3DDerivedKinds(t *testing.T) {
+	s := NewSketches3D().Add()
+	l := s.AddLine3D(math.P3(0, 0, 0), math.P3(1, 1, 1))
+
+	axisKinds := map[ConstraintKind]*ParallelToAxis3D{
+		ParallelToXAxisKind: NewParallelToXAxis3D(l),
+		ParallelToYAxisKind: NewParallelToYAxis3D(l),
+		ParallelToZAxisKind: NewParallelToZAxis3D(l),
+	}
+	for want, c := range axisKinds {
+		if c.ConstraintKind() != want {
+			t.Errorf("axis kind = %q, want %q", c.ConstraintKind(), want)
+		}
+	}
+	planeKinds := map[ConstraintKind]*ParallelToPlane3D{
+		ParallelToXYKind: NewParallelToXYPlane3D(l),
+		ParallelToXZKind: NewParallelToXZPlane3D(l),
+		ParallelToYZKind: NewParallelToYZPlane3D(l),
+	}
+	for want, c := range planeKinds {
+		if c.ConstraintKind() != want {
+			t.Errorf("plane kind = %q, want %q", c.ConstraintKind(), want)
+		}
+	}
+}
+
+// TestEqual3DKeepsOperandEntities pins the #1625 Equal3D fix: the constraint
+// names its radius-bearing operands, so it can enumerate refs and serialize
+// (an Equal3D save failed at runtime before).
+func TestEqual3DKeepsOperandEntities(t *testing.T) {
+	s := NewSketches3D().Add()
+	zUp, _ := math.NewUnitVector3(0, 0, 1)
+	a := s.AddCircle3D(math.P3(0, 0, 0), zUp, 2)
+	b := s.AddCircle3D(math.P3(5, 0, 0), zUp, 2)
+	eq := mustEqual3D(t, a, b)
+	if eq.ConstraintKind() != EqualKind {
+		t.Errorf("equal kind = %q, want %q", eq.ConstraintKind(), EqualKind)
+	}
+	assertRelated(t, "equal", eq, a.EntityID(), b.EntityID())
+}
+
+// assertRelated asserts a constraint's RelatedEntities ids in order.
+func assertRelated(t *testing.T, name string, c KindedConstraint, want ...ID) {
+	t.Helper()
+	got := c.RelatedEntities()
+	if len(got) != len(want) {
+		t.Fatalf("%s related = %d entities, want %d", name, len(got), len(want))
+	}
+	for i, e := range got {
+		if e.EntityID() != want[i] {
+			t.Errorf("%s related[%d] = id %d, want %d", name, i, e.EntityID(), want[i])
+		}
+	}
+}

--- a/model/sketch/constraints_3d.go
+++ b/model/sketch/constraints_3d.go
@@ -3,6 +3,8 @@
 package sketch
 
 import (
+	"fmt"
+
 	"oblikovati.org/math"
 	"oblikovati.org/solve/ad"
 )
@@ -106,15 +108,38 @@ func (c *Concentric3D) Variables() []*math.Scalar {
 	return []*math.Scalar{&c.Center1.X, &c.Center1.Y, &c.Center1.Z, &c.Center2.X, &c.Center2.Y, &c.Center2.Z}
 }
 
-// Equal3D forces two scalar DOFs (e.g. radii or distances) to be equal.
+// Equal3D forces the radius DOFs of two radius-bearing curves to be equal. It
+// keeps the operand entities, not just their scalar DOFs: without them the
+// constraint could not name its refs over the API nor serialize at all — an
+// Equal3D save failed at runtime until #1625 (the #1416 drift class).
 type Equal3D struct {
 	constraintBase
-	A, B *math.Scalar
+	E1, E2 Entity
+	A, B   *math.Scalar
 }
 
-// NewEqual3D constrains two scalar DOFs to be equal.
-func NewEqual3D(a, b *math.Scalar) *Equal3D {
-	return &Equal3D{constraintBase: newConstraint(), A: a, B: b}
+// NewEqual3D constrains the radius DOFs of two radius-bearing curves (a circle
+// or a helix) to be equal, rejecting entities without a radius DOF.
+func NewEqual3D(e1, e2 Entity) (*Equal3D, error) {
+	a, err := radiusDOFOf(e1)
+	if err != nil {
+		return nil, err
+	}
+	b, err := radiusDOFOf(e2)
+	if err != nil {
+		return nil, err
+	}
+	return &Equal3D{constraintBase: newConstraint(), E1: e1, E2: e2, A: a, B: b}, nil
+}
+
+// radiusDOFOf resolves an entity's radius solver DOF through its RadiusDOF
+// capability (#1624).
+func radiusDOFOf(e Entity) (*math.Scalar, error) {
+	rd, ok := e.(interface{ RadiusDOF() *math.Scalar })
+	if !ok {
+		return nil, fmt.Errorf("sketch: equal needs radius-bearing curves (circle/helix), got %T", e)
+	}
+	return rd.RadiusDOF(), nil
 }
 
 // residualAD: v = [A, B]; the two scalar DOFs must be equal.

--- a/model/sketch/constraints_3d_test.go
+++ b/model/sketch/constraints_3d_test.go
@@ -46,15 +46,21 @@ func TestConstraints3DResiduals(t *testing.T) {
 		t.Error("concentric3D not satisfied for equal centers")
 	}
 
-	// Equal scalar DOFs.
-	r1, r2 := math.Scalar(4), math.Scalar(4)
-	eq := NewEqual3D(&r1, &r2)
+	// Equal radius DOFs, resolved from the operand curves (#1625).
+	s3 := NewSketches3D().Add()
+	zUp, _ := math.NewUnitVector3(0, 0, 1)
+	circA := s3.AddCircle3D(math.P3(0, 0, 0), zUp, 4)
+	circB := s3.AddCircle3D(math.P3(9, 0, 0), zUp, 4)
+	eq := mustEqual3D(t, circA, circB)
 	if !satisfied(eq) {
-		t.Error("equal3D not satisfied for equal scalars")
+		t.Error("equal3D not satisfied for equal radii")
 	}
-	r2 = 5
+	circB.Radius = 5
 	if satisfied(eq) {
-		t.Error("equal3D satisfied after changing one scalar")
+		t.Error("equal3D satisfied after changing one radius")
+	}
+	if _, err := NewEqual3D(s3.AddPoint3D(math.P3(0, 0, 0)), circA); err == nil {
+		t.Error("NewEqual3D should refuse a non-radius-bearing operand")
 	}
 }
 

--- a/model/sketch/serialize.go
+++ b/model/sketch/serialize.go
@@ -294,55 +294,24 @@ func flattenPoints(pts []math.Point2) []float64 {
 	return out
 }
 
+// serializeConstraint encodes through the paired codec registry, keyed on the
+// constraint's self-reported kind (#1625) — no per-type switch, so an encode
+// half can no longer ship without its decode half.
 func serializeConstraint(c Constraint) (ConstraintData, error) {
-	switch v := c.(type) {
-	case *CoincidentConstraint:
-		return ConstraintData{Kind: "coincident", Points: []int{int(v.A.id), int(v.B.id)}}, nil
-	case *HorizontalConstraint:
-		return ConstraintData{Kind: "horizontal", Points: []int{int(v.A.id), int(v.B.id)}}, nil
-	case *VerticalConstraint:
-		return ConstraintData{Kind: "vertical", Points: []int{int(v.A.id), int(v.B.id)}}, nil
-	case *PointOnLineConstraint:
-		return ConstraintData{Kind: "pointOnLine", Points: []int{int(v.P.id)}, Curves: []int{int(v.L.id)}}, nil
-	case *MidpointConstraint:
-		return ConstraintData{Kind: "midpoint", Points: []int{int(v.P.id)}, Curves: []int{int(v.L.id)}}, nil
-	case *PointOnCircleConstraint:
-		return ConstraintData{Kind: "pointOnCircle", Points: []int{int(v.P.id)}, Curves: []int{int(v.C.EntityID())}}, nil
-	case *ParallelConstraint:
-		return ConstraintData{Kind: "parallel", Curves: []int{int(v.L1.id), int(v.L2.id)}}, nil
-	case *PerpendicularConstraint:
-		return ConstraintData{Kind: "perpendicular", Curves: []int{int(v.L1.id), int(v.L2.id)}}, nil
-	case *CollinearConstraint:
-		return ConstraintData{Kind: "collinear", Curves: []int{int(v.L1.id), int(v.L2.id)}}, nil
-	case *EqualLengthConstraint:
-		return ConstraintData{Kind: "equalLength", Curves: []int{int(v.L1.id), int(v.L2.id)}}, nil
-	case *ConcentricConstraint:
-		return ConstraintData{Kind: "concentric", Curves: []int{int(v.C1.EntityID()), int(v.C2.EntityID())}}, nil
-	case *EqualRadiusConstraint:
-		return ConstraintData{Kind: "equalRadius", Curves: []int{int(v.C1.EntityID()), int(v.C2.EntityID())}}, nil
-	case *CircularTangentConstraint:
-		return ConstraintData{Kind: "circularTangent", Curves: []int{int(v.C1.EntityID()), int(v.C2.EntityID())}}, nil
-	case *TangentConstraint:
-		return ConstraintData{Kind: "tangent", Curves: []int{int(v.L.id), int(v.C.EntityID())}}, nil
-	case *SymmetryConstraint:
-		return ConstraintData{Kind: "symmetry", Points: []int{int(v.A.id), int(v.B.id)}, Curves: []int{int(v.About.id)}}, nil
-	case *FixConstraint:
-		return ConstraintData{Kind: "fix", Points: []int{int(v.P.id)}}, nil
-	case *SmoothConstraint:
-		return ConstraintData{Kind: "smooth", Points: []int{int(v.P1.id), int(v.P2.id)}, Curves: []int{int(v.C1.EntityID()), int(v.C2.EntityID())}}, nil
-	case *GroundConstraint:
-		return ConstraintData{Kind: "ground", Points: pointIDsOf(v.pts)}, nil
-	case *OffsetConstraint:
-		return ConstraintData{Kind: "offset", Curves: []int{int(v.L1.id), int(v.L2.id)}, Value: v.Dist}, nil
-	case *PatternConstraint:
-		return ConstraintData{Kind: "patternLink", Points: []int{int(v.Seed.id), int(v.Member.id)}}, nil
-	case *TextBoxAnchorConstraint:
-		return ConstraintData{Kind: "textBox", Curves: []int{int(v.Text.id)}}, nil
-	case *CustomConstraint:
-		return ConstraintData{Kind: "custom", ClientID: v.ClientID, Name: v.Name, Curves: entityIDsOf(v.Entities)}, nil
-	default:
-		return ConstraintData{}, fmt.Errorf("cannot serialize constraint of type %T (no codec)", c)
+	kc, ok := c.(KindedConstraint)
+	if !ok {
+		return ConstraintData{}, fmt.Errorf("cannot serialize constraint of type %T (no ConstraintKind capability)", c)
 	}
+	codec, ok := constraintCodecs2D[kc.ConstraintKind()]
+	if !ok {
+		return ConstraintData{}, fmt.Errorf("cannot serialize constraint kind %q of type %T (no codec)", kc.ConstraintKind(), c)
+	}
+	cd, err := codec.encode(c)
+	if err != nil {
+		return ConstraintData{}, err
+	}
+	cd.Kind = string(kc.ConstraintKind())
+	return cd, nil
 }
 
 // fitMethodSpelling renders a spline fit method for persistence; the smooth

--- a/model/sketch/serialize_3d.go
+++ b/model/sketch/serialize_3d.go
@@ -283,71 +283,29 @@ func unflattenPoint3s(coords []float64) []math.Point3 {
 	return out
 }
 
-// serializeConstraint3D captures one geometric 3D constraint by its point operands.
+// serializeConstraint3D encodes through the paired 3D codec registry, keyed on
+// the constraint's self-reported kind (#1625) — no per-type switch, so an
+// encode half can no longer ship without its decode half (Equal3D did exactly
+// that: creatable, enumerable, and failing every save at runtime).
 func serializeConstraint3D(c Constraint) (Constraint3DRow, error) {
-	switch v := c.(type) {
-	case *Coincident3D:
-		return Constraint3DRow{Kind: "coincident", Points: []int{int(v.A.id), int(v.B.id)}}, nil
-	case *Collinear3D:
-		return Constraint3DRow{Kind: "collinear", Points: []int{int(v.A.id), int(v.B.id), int(v.C.id)}}, nil
-	case *Concentric3D:
-		return Constraint3DRow{Kind: "concentric", Points: []int{int(v.Center1.id), int(v.Center2.id)}}, nil
-	case *Parallel3D:
-		return Constraint3DRow{Kind: "parallel", Curves: []int{int(v.L1.id), int(v.L2.id)}}, nil
-	case *Perpendicular3D:
-		return Constraint3DRow{Kind: "perpendicular", Curves: []int{int(v.L1.id), int(v.L2.id)}}, nil
-	case *Midpoint3D:
-		return Constraint3DRow{Kind: "midpoint", Points: []int{int(v.P.id)}, Curves: []int{int(v.L.id)}}, nil
-	case *Ground3D:
-		return Constraint3DRow{Kind: "ground", Points: []int{int(v.P.id)}}, nil
-	case *ParallelToAxis3D:
-		return Constraint3DRow{Kind: axisRowKind(v.Axis), Curves: []int{int(v.L.id)}}, nil
-	case *ParallelToPlane3D:
-		return Constraint3DRow{Kind: planeRowKind(v.Normal), Curves: []int{int(v.L.id)}}, nil
-	case *Tangent3D:
-		return Constraint3DRow{Kind: "tangent", Curves: entity3DIDPair(v.C1, v.C2), Points: []int{int(v.P1.id), int(v.P2.id)}}, nil
-	case *Smooth3D:
-		return Constraint3DRow{Kind: "smooth", Curves: entity3DIDPair(v.C1, v.C2), Points: []int{int(v.P1.id), int(v.P2.id)}}, nil
-	case *SplineFitPoints3D:
-		return Constraint3DRow{Kind: "splineFitPoints", Curves: []int{int(v.Spline.id)}, Points: []int{int(v.P.id)}, Index: v.FitIndex}, nil
-	case *Helical3D:
-		return Constraint3DRow{Kind: "helical", Curves: []int{int(v.H.id), int(v.C.id)}}, nil
-	case *Bend3D:
-		return Constraint3DRow{
-			Kind: "bend", Curves: []int{int(v.Arc.id), int(v.L1.id), int(v.L2.id)},
-			Points: []int{int(v.P1.id), int(v.P2.id)}, Radius: v.Radius,
-		}, nil
-	default:
-		return Constraint3DRow{}, fmt.Errorf("cannot serialize 3D constraint of type %T (no codec yet)", c)
+	kc, ok := c.(KindedConstraint)
+	if !ok {
+		return Constraint3DRow{}, fmt.Errorf("cannot serialize 3D constraint of type %T (no ConstraintKind capability)", c)
 	}
+	codec, ok := constraintCodecs3D[kc.ConstraintKind()]
+	if !ok {
+		return Constraint3DRow{}, fmt.Errorf("cannot serialize 3D constraint kind %q of type %T (no codec)", kc.ConstraintKind(), c)
+	}
+	row, err := codec.encode(c)
+	if err != nil {
+		return Constraint3DRow{}, err
+	}
+	row.Kind = string(kc.ConstraintKind())
+	return row, nil
 }
 
 // entity3DIDPair returns two curve entities' ids in order.
 func entity3DIDPair(a, b Entity) []int { return []int{int(a.EntityID()), int(b.EntityID())} }
-
-// axisRowKind names a parallel-to-axis constraint for serialization by its axis vector.
-func axisRowKind(axis math.Vector3) string {
-	switch {
-	case axis.X != 0:
-		return "parallelToXAxis"
-	case axis.Y != 0:
-		return "parallelToYAxis"
-	default:
-		return "parallelToZAxis"
-	}
-}
-
-// planeRowKind names a parallel-to-plane constraint for serialization by its normal.
-func planeRowKind(normal math.Vector3) string {
-	switch {
-	case normal.Z != 0:
-		return "parallelToXYPlane"
-	case normal.Y != 0:
-		return "parallelToXZPlane"
-	default:
-		return "parallelToYZPlane"
-	}
-}
 
 // ApplyRecipe3D rebuilds the collection's 3D sketches from their serialized forms.
 func (c *Sketches3D) ApplyRecipe3D(data []SketchData3D) error {
@@ -532,77 +490,22 @@ func restoreEntity3D(s *Sketch3D, ed Entity3DData, idmap map[int]*Point3D) (Enti
 	return c.decode(s, ed, pts)
 }
 
-// restoreConstraint3D re-adds one geometric 3D constraint, binding its point operands
-// through idmap and its line operands through entmap. The curve-join kinds (tangent/
-// smooth/splineFitPoints/helical, issue #142) dispatch first — their Curves are not
-// necessarily lines, so they resolve against the full entity map.
+// restoreConstraint3D decodes one geometric 3D constraint through the paired
+// codec registry (#1625), binding its point operands through idmap and its
+// curve operands through entmap. An unknown kind is a corrupt-recipe error.
 func restoreConstraint3D(s *Sketch3D, cd Constraint3DRow, idmap map[int]*Point3D, entmap map[int]Entity) error {
+	codec, ok := constraintCodecs3D[ConstraintKind(cd.Kind)]
+	if !ok {
+		return fmt.Errorf("unknown constraint kind %q", cd.Kind)
+	}
 	pts, err := lookupPoints3D(cd.Points, idmap)
 	if err != nil {
 		return fmt.Errorf(errConstraintWrap, cd.Kind, err)
 	}
-	if c, handled, err := curveConstraint3DFromRow(cd, pts, entmap); handled {
-		if err != nil {
-			return fmt.Errorf(errConstraintWrap, cd.Kind, err)
-		}
-		s.geomCons.add(c)
-		return nil
-	}
-	lines, err := lookupLines3D(cd.Curves, entmap)
-	if err != nil {
+	if err := codec.decode(s, cd, pts, entmap); err != nil {
 		return fmt.Errorf(errConstraintWrap, cd.Kind, err)
 	}
-	c, err := constraint3DFromRow(cd.Kind, pts, lines)
-	if err != nil {
-		return err
-	}
-	s.geomCons.add(c)
 	return nil
-}
-
-// curveConstraint3DFromRow rebuilds the curve-join constraint kinds; handled is false
-// for every other kind (which restoreConstraint3D resolves over line operands).
-func curveConstraint3DFromRow(cd Constraint3DRow, pts []*Point3D, entmap map[int]Entity) (Constraint, bool, error) {
-	switch cd.Kind {
-	case "tangent", "smooth":
-		c, err := restoreSmoothJoin3D(cd, pts, entmap)
-		return c, true, err
-	case "splineFitPoints":
-		sp, err := lookupSpline3D(cd.Curves, entmap)
-		if err != nil {
-			return nil, true, err
-		}
-		c, err := NewSplineFitPoints3DAt(sp, pts[0], cd.Index)
-		return c, true, err
-	case "helical":
-		c, err := restoreHelical3D(cd, entmap)
-		return c, true, err
-	case "bend":
-		c, err := restoreBend3D(cd, pts, entmap)
-		return c, true, err
-	default:
-		return nil, false, nil
-	}
-}
-
-// restoreSmoothJoin3D rebuilds a tangent or smooth join from its two curves and their
-// serialized join endpoints.
-func restoreSmoothJoin3D(cd Constraint3DRow, pts []*Point3D, entmap map[int]Entity) (Constraint, error) {
-	if len(cd.Curves) != 2 || len(pts) != 2 {
-		return nil, fmt.Errorf("needs 2 curves + 2 points, got %d/%d", len(cd.Curves), len(pts))
-	}
-	c1, err := lookupSmoothCurve3D(cd.Curves[0], entmap)
-	if err != nil {
-		return nil, err
-	}
-	c2, err := lookupSmoothCurve3D(cd.Curves[1], entmap)
-	if err != nil {
-		return nil, err
-	}
-	if cd.Kind == "tangent" {
-		return NewTangent3D(c1, c2, pts[0], pts[1]), nil
-	}
-	return NewSmooth3D(c1, c2, pts[0], pts[1]), nil
 }
 
 // restoreBend3D rebuilds a bend from its arc + two lines, re-binding the exact saved
@@ -661,49 +564,6 @@ func lookupSpline3D(ids []int, entmap map[int]Entity) (*Spline3D, error) {
 		return nil, fmt.Errorf("entity id %d is %T, want a 3D spline", ids[0], entmap[ids[0]])
 	}
 	return sp, nil
-}
-
-// constraint3DFromRow builds the constraint for a serialized kind from its resolved
-// point and line operands.
-func constraint3DFromRow(kind string, pts []*Point3D, lines []*Line3D) (Constraint, error) {
-	switch kind {
-	case "coincident":
-		return NewCoincident3D(pts[0], pts[1]), nil
-	case "collinear":
-		return NewCollinear3D(pts[0], pts[1], pts[2]), nil
-	case "concentric":
-		return NewConcentric3D(pts[0], pts[1]), nil
-	case "parallel":
-		return NewParallel3D(lines[0], lines[1]), nil
-	case "perpendicular":
-		return NewPerpendicular3D(lines[0], lines[1]), nil
-	case "midpoint":
-		return NewMidpoint3D(pts[0], lines[0]), nil
-	case "ground":
-		return NewGround3D(pts[0]), nil
-	default:
-		return orientationFromRow(kind, lines)
-	}
-}
-
-// orientationFromRow builds the parallel-to-axis/plane constraints from a serialized kind.
-func orientationFromRow(kind string, lines []*Line3D) (Constraint, error) {
-	switch kind {
-	case "parallelToXAxis":
-		return NewParallelToXAxis3D(lines[0]), nil
-	case "parallelToYAxis":
-		return NewParallelToYAxis3D(lines[0]), nil
-	case "parallelToZAxis":
-		return NewParallelToZAxis3D(lines[0]), nil
-	case "parallelToXYPlane":
-		return NewParallelToXYPlane3D(lines[0]), nil
-	case "parallelToXZPlane":
-		return NewParallelToXZPlane3D(lines[0]), nil
-	case "parallelToYZPlane":
-		return NewParallelToYZPlane3D(lines[0]), nil
-	default:
-		return nil, fmt.Errorf("unknown 3D constraint kind %q", kind)
-	}
 }
 
 // restoreConic3D rebuilds a full or partial ellipse from its serialized form.

--- a/model/sketch/serialize_codecs_constraints.go
+++ b/model/sketch/serialize_codecs_constraints.go
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+// Codec registrations for the 2D geometric constraints. Bodies are the former
+// switch cases of serializeConstraint and restoreConstraint/
+// restoreExtraConstraint, paired per kind (#1625, audit I2) — including the
+// default: branch that used to fail a save at runtime for a kind missing from
+// the encode switch.
+
+func init() {
+	registerTwoPointConstraintCodecs()
+	registerTwoLineConstraintCodecs()
+	registerTwoCurveConstraintCodecs()
+	registerMixedConstraintCodecs()
+	registerTagConstraintCodecs()
+}
+
+// twoPointConstraintCodec pairs a two-point constraint row with its factory.
+func twoPointConstraintCodec(pts func(Constraint) (*Point, *Point), add func(*GeometricConstraints, *Point, *Point)) constraintCodec {
+	return constraintCodec{
+		encode: func(c Constraint) (ConstraintData, error) {
+			a, b := pts(c)
+			return ConstraintData{Points: []int{int(a.id), int(b.id)}}, nil
+		},
+		decode: func(r *sketchRestorer, cd ConstraintData) error {
+			return r.twoPoints(cd, func(a, b *Point) { add(r.s.geomCons, a, b) })
+		},
+	}
+}
+
+// twoLineConstraintCodec pairs a two-line constraint row with its factory.
+func twoLineConstraintCodec(lines func(Constraint) (*Line, *Line), add func(*GeometricConstraints, *Line, *Line)) constraintCodec {
+	return constraintCodec{
+		encode: func(c Constraint) (ConstraintData, error) {
+			a, b := lines(c)
+			return ConstraintData{Curves: []int{int(a.id), int(b.id)}}, nil
+		},
+		decode: func(r *sketchRestorer, cd ConstraintData) error {
+			return r.twoLines(cd, func(a, b *Line) { add(r.s.geomCons, a, b) })
+		},
+	}
+}
+
+// twoCurveConstraintCodec pairs a two-circular-curve constraint row with its factory.
+func twoCurveConstraintCodec(curves func(Constraint) (CircularCurve, CircularCurve), add func(*GeometricConstraints, CircularCurve, CircularCurve)) constraintCodec {
+	return constraintCodec{
+		encode: func(c Constraint) (ConstraintData, error) {
+			a, b := curves(c)
+			return ConstraintData{Curves: []int{int(a.EntityID()), int(b.EntityID())}}, nil
+		},
+		decode: func(r *sketchRestorer, cd ConstraintData) error {
+			return r.twoCurves(cd, func(a, b CircularCurve) { add(r.s.geomCons, a, b) })
+		},
+	}
+}
+
+// pointLineConstraintCodec pairs a point-on-line-shaped row with its factory.
+func pointLineConstraintCodec(ops func(Constraint) (*Point, *Line), add func(*GeometricConstraints, *Point, *Line)) constraintCodec {
+	return constraintCodec{
+		encode: func(c Constraint) (ConstraintData, error) {
+			p, l := ops(c)
+			return ConstraintData{Points: []int{int(p.id)}, Curves: []int{int(l.id)}}, nil
+		},
+		decode: func(r *sketchRestorer, cd ConstraintData) error {
+			return r.pointAndLine(cd, func(p *Point, l *Line) { add(r.s.geomCons, p, l) })
+		},
+	}
+}
+
+func registerTwoPointConstraintCodecs() {
+	registerConstraintCodec(CoincidentKind, twoPointConstraintCodec(
+		func(c Constraint) (*Point, *Point) { v := c.(*CoincidentConstraint); return v.A, v.B },
+		func(g *GeometricConstraints, a, b *Point) { g.AddCoincident(a, b) }))
+	registerConstraintCodec(HorizontalKind, twoPointConstraintCodec(
+		func(c Constraint) (*Point, *Point) { v := c.(*HorizontalConstraint); return v.A, v.B },
+		func(g *GeometricConstraints, a, b *Point) { g.AddHorizontal(a, b) }))
+	registerConstraintCodec(VerticalKind, twoPointConstraintCodec(
+		func(c Constraint) (*Point, *Point) { v := c.(*VerticalConstraint); return v.A, v.B },
+		func(g *GeometricConstraints, a, b *Point) { g.AddVertical(a, b) }))
+	registerConstraintCodec(PatternLinkKind, twoPointConstraintCodec(
+		func(c Constraint) (*Point, *Point) { v := c.(*PatternConstraint); return v.Seed, v.Member },
+		func(g *GeometricConstraints, a, b *Point) { g.AddPatternLink(a, b) }))
+}
+
+func registerTwoLineConstraintCodecs() {
+	registerConstraintCodec(ParallelKind, twoLineConstraintCodec(
+		func(c Constraint) (*Line, *Line) { v := c.(*ParallelConstraint); return v.L1, v.L2 },
+		func(g *GeometricConstraints, a, b *Line) { g.AddParallel(a, b) }))
+	registerConstraintCodec(PerpendicularKind, twoLineConstraintCodec(
+		func(c Constraint) (*Line, *Line) { v := c.(*PerpendicularConstraint); return v.L1, v.L2 },
+		func(g *GeometricConstraints, a, b *Line) { g.AddPerpendicular(a, b) }))
+	registerConstraintCodec(CollinearKind, twoLineConstraintCodec(
+		func(c Constraint) (*Line, *Line) { v := c.(*CollinearConstraint); return v.L1, v.L2 },
+		func(g *GeometricConstraints, a, b *Line) { g.AddCollinear(a, b) }))
+	registerConstraintCodec(EqualLengthKind, twoLineConstraintCodec(
+		func(c Constraint) (*Line, *Line) { v := c.(*EqualLengthConstraint); return v.L1, v.L2 },
+		func(g *GeometricConstraints, a, b *Line) { g.AddEqualLength(a, b) }))
+}
+
+func registerTwoCurveConstraintCodecs() {
+	registerConstraintCodec(ConcentricKind, twoCurveConstraintCodec(
+		func(c Constraint) (CircularCurve, CircularCurve) { v := c.(*ConcentricConstraint); return v.C1, v.C2 },
+		func(g *GeometricConstraints, a, b CircularCurve) { g.AddConcentric(a, b) }))
+	registerConstraintCodec(EqualRadiusKind, twoCurveConstraintCodec(
+		func(c Constraint) (CircularCurve, CircularCurve) { v := c.(*EqualRadiusConstraint); return v.C1, v.C2 },
+		func(g *GeometricConstraints, a, b CircularCurve) { g.AddEqualRadius(a, b) }))
+	registerConstraintCodec(CircularTangentKind, twoCurveConstraintCodec(
+		func(c Constraint) (CircularCurve, CircularCurve) {
+			v := c.(*CircularTangentConstraint)
+			return v.C1, v.C2
+		},
+		func(g *GeometricConstraints, a, b CircularCurve) { g.AddCircularTangent(a, b) }))
+}
+
+func registerMixedConstraintCodecs() {
+	registerConstraintCodec(PointOnLineKind, pointLineConstraintCodec(
+		func(c Constraint) (*Point, *Line) { v := c.(*PointOnLineConstraint); return v.P, v.L },
+		func(g *GeometricConstraints, p *Point, l *Line) { g.AddPointOnLine(p, l) }))
+	registerConstraintCodec(MidpointKind, pointLineConstraintCodec(
+		func(c Constraint) (*Point, *Line) { v := c.(*MidpointConstraint); return v.P, v.L },
+		func(g *GeometricConstraints, p *Point, l *Line) { g.AddMidpoint(p, l) }))
+	registerConstraintCodec(PointOnCircleKind, pointOnCircleCodec())
+	registerConstraintCodec(TangentKind, tangentCodec())
+	registerConstraintCodec(SymmetryKind, symmetryCodec())
+	registerConstraintCodec(FixKind, fixCodec())
+	registerConstraintCodec(SmoothKind, smoothCodec())
+}
+
+func pointOnCircleCodec() constraintCodec {
+	return constraintCodec{
+		encode: func(c Constraint) (ConstraintData, error) {
+			v := c.(*PointOnCircleConstraint)
+			return ConstraintData{Points: []int{int(v.P.id)}, Curves: []int{int(v.C.EntityID())}}, nil
+		},
+		decode: func(r *sketchRestorer, cd ConstraintData) error {
+			p, err := r.point(cd.Points, 0)
+			if err != nil {
+				return err
+			}
+			c, err := r.curve(cd.Curves, 0)
+			if err != nil {
+				return err
+			}
+			r.s.geomCons.AddPointOnCircle(p, c)
+			return nil
+		},
+	}
+}
+
+func tangentCodec() constraintCodec {
+	return constraintCodec{
+		encode: func(c Constraint) (ConstraintData, error) {
+			v := c.(*TangentConstraint)
+			return ConstraintData{Curves: []int{int(v.L.id), int(v.C.EntityID())}}, nil
+		},
+		decode: func(r *sketchRestorer, cd ConstraintData) error {
+			l, err := r.line(cd.Curves, 0)
+			if err != nil {
+				return err
+			}
+			c, err := r.curve(cd.Curves, 1)
+			if err != nil {
+				return err
+			}
+			r.s.geomCons.AddTangent(l, c)
+			return nil
+		},
+	}
+}
+
+func symmetryCodec() constraintCodec {
+	return constraintCodec{
+		encode: func(c Constraint) (ConstraintData, error) {
+			v := c.(*SymmetryConstraint)
+			return ConstraintData{Points: []int{int(v.A.id), int(v.B.id)}, Curves: []int{int(v.About.id)}}, nil
+		},
+		decode: func(r *sketchRestorer, cd ConstraintData) error {
+			a, err := r.point(cd.Points, 0)
+			if err != nil {
+				return err
+			}
+			b, err := r.point(cd.Points, 1)
+			if err != nil {
+				return err
+			}
+			about, err := r.line(cd.Curves, 0)
+			if err != nil {
+				return err
+			}
+			r.s.geomCons.AddSymmetry(a, b, about)
+			return nil
+		},
+	}
+}
+
+func fixCodec() constraintCodec {
+	return constraintCodec{
+		encode: func(c Constraint) (ConstraintData, error) {
+			v := c.(*FixConstraint)
+			return ConstraintData{Points: []int{int(v.P.id)}}, nil
+		},
+		decode: func(r *sketchRestorer, cd ConstraintData) error {
+			p, err := r.point(cd.Points, 0)
+			if err != nil {
+				return err
+			}
+			r.s.geomCons.AddFix(p)
+			return nil
+		},
+	}
+}
+
+func smoothCodec() constraintCodec {
+	return constraintCodec{
+		encode: func(c Constraint) (ConstraintData, error) {
+			v := c.(*SmoothConstraint)
+			return ConstraintData{
+				Points: []int{int(v.P1.id), int(v.P2.id)},
+				Curves: []int{int(v.C1.EntityID()), int(v.C2.EntityID())},
+			}, nil
+		},
+		decode: decodeSmooth,
+	}
+}
+
+func decodeSmooth(r *sketchRestorer, cd ConstraintData) error {
+	c1, err := r.smooth(cd.Curves, 0)
+	if err != nil {
+		return err
+	}
+	c2, err := r.smooth(cd.Curves, 1)
+	if err != nil {
+		return err
+	}
+	p1, err := r.point(cd.Points, 0)
+	if err != nil {
+		return err
+	}
+	p2, err := r.point(cd.Points, 1)
+	if err != nil {
+		return err
+	}
+	r.s.geomCons.AddSmooth(c1, c2, p1, p2)
+	return nil
+}
+
+// registerTagConstraintCodecs covers the M21 constraints (ground/offset) and
+// the M06-F11 tag constraints (text-box anchor, custom).
+func registerTagConstraintCodecs() {
+	registerConstraintCodec(GroundKind, groundCodec())
+	registerConstraintCodec(OffsetKind, offsetCodec())
+	registerConstraintCodec(TextBoxAnchorKind, textBoxAnchorCodec())
+	registerConstraintCodec(CustomKind, customCodec())
+}
+
+func groundCodec() constraintCodec {
+	return constraintCodec{
+		encode: func(c Constraint) (ConstraintData, error) {
+			return ConstraintData{Points: pointIDsOf(c.(*GroundConstraint).pts)}, nil
+		},
+		decode: func(r *sketchRestorer, cd ConstraintData) error {
+			pts, err := r.points(cd.Points, len(cd.Points))
+			if err != nil {
+				return err
+			}
+			r.s.geomCons.AddGroundPoints(pts...)
+			return nil
+		},
+	}
+}
+
+func offsetCodec() constraintCodec {
+	return constraintCodec{
+		encode: func(c Constraint) (ConstraintData, error) {
+			v := c.(*OffsetConstraint)
+			return ConstraintData{Curves: []int{int(v.L1.id), int(v.L2.id)}, Value: v.Dist}, nil
+		},
+		decode: func(r *sketchRestorer, cd ConstraintData) error {
+			return r.twoLines(cd, func(a, b *Line) { r.s.geomCons.AddOffset(a, b, cd.Value) })
+		},
+	}
+}
+
+func textBoxAnchorCodec() constraintCodec {
+	return constraintCodec{
+		encode: func(c Constraint) (ConstraintData, error) {
+			return ConstraintData{Curves: []int{int(c.(*TextBoxAnchorConstraint).Text.id)}}, nil
+		},
+		// The anchor record is auto-created with its text box; restoring it
+		// explicitly would duplicate it, so the persisted row is a no-op.
+		decode: func(r *sketchRestorer, cd ConstraintData) error { return nil },
+	}
+}
+
+func customCodec() constraintCodec {
+	return constraintCodec{
+		encode: func(c Constraint) (ConstraintData, error) {
+			v := c.(*CustomConstraint)
+			return ConstraintData{ClientID: v.ClientID, Name: v.Name, Curves: entityIDsOf(v.Entities)}, nil
+		},
+		decode: func(r *sketchRestorer, cd ConstraintData) error {
+			ents := make([]Entity, 0, len(cd.Curves))
+			for i := range cd.Curves {
+				e, err := r.entity(cd.Curves, i)
+				if err != nil {
+					return err
+				}
+				ents = append(ents, e)
+			}
+			_, err := r.s.geomCons.AddCustom(cd.ClientID, cd.Name, ents)
+			return err
+		},
+	}
+}

--- a/model/sketch/serialize_codecs_constraints_3d.go
+++ b/model/sketch/serialize_codecs_constraints_3d.go
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import "fmt"
+
+// Codec registrations for the 3D geometric constraints. Bodies are the former
+// switch cases of serializeConstraint3D and constraint3DFromRow/
+// orientationFromRow/curveConstraint3DFromRow, paired per kind (#1625, audit
+// I2). The "equal" codec is NEW: Equal3D was creatable and enumerable over the
+// wire but missing from BOTH serialize switches, so saving a document with one
+// failed at runtime — the exact drift class this registry closes (#1416).
+
+func init() {
+	registerPoint3DConstraintCodecs()
+	registerLine3DConstraintCodecs()
+	registerOrientation3DConstraintCodecs()
+	registerCurveJoin3DConstraintCodecs()
+}
+
+// point3DConstraintCodec pairs an all-points 3D constraint row with its factory.
+func point3DConstraintCodec(n int, operands func(Constraint) []*Point3D, build func(pts []*Point3D) Constraint) constraintCodec3D {
+	return constraintCodec3D{
+		encode: func(c Constraint) (Constraint3DRow, error) {
+			return Constraint3DRow{Points: point3DIDs(operands(c))}, nil
+		},
+		decode: func(s *Sketch3D, cd Constraint3DRow, pts []*Point3D, entmap map[int]Entity) error {
+			if len(pts) != n {
+				return fmt.Errorf("needs %d points, got %d", n, len(pts))
+			}
+			s.geomCons.add(build(pts))
+			return nil
+		},
+	}
+}
+
+// line3DConstraintCodec pairs an all-lines 3D constraint row with its factory.
+func line3DConstraintCodec(n int, operands func(Constraint) []*Line3D, build func(lines []*Line3D) Constraint) constraintCodec3D {
+	return constraintCodec3D{
+		encode: func(c Constraint) (Constraint3DRow, error) {
+			ls := operands(c)
+			ids := make([]int, len(ls))
+			for i, l := range ls {
+				ids[i] = int(l.id)
+			}
+			return Constraint3DRow{Curves: ids}, nil
+		},
+		decode: func(s *Sketch3D, cd Constraint3DRow, pts []*Point3D, entmap map[int]Entity) error {
+			lines, err := lookupLines3D(cd.Curves, entmap)
+			if err != nil {
+				return err
+			}
+			if len(lines) != n {
+				return fmt.Errorf("needs %d lines, got %d", n, len(lines))
+			}
+			s.geomCons.add(build(lines))
+			return nil
+		},
+	}
+}
+
+func registerPoint3DConstraintCodecs() {
+	registerConstraintCodec3D(CoincidentKind, point3DConstraintCodec(2,
+		func(c Constraint) []*Point3D { v := c.(*Coincident3D); return []*Point3D{v.A, v.B} },
+		func(pts []*Point3D) Constraint { return NewCoincident3D(pts[0], pts[1]) }))
+	registerConstraintCodec3D(Collinear3PointKind, point3DConstraintCodec(3,
+		func(c Constraint) []*Point3D { v := c.(*Collinear3D); return []*Point3D{v.A, v.B, v.C} },
+		func(pts []*Point3D) Constraint { return NewCollinear3D(pts[0], pts[1], pts[2]) }))
+	registerConstraintCodec3D(ConcentricKind, point3DConstraintCodec(2,
+		func(c Constraint) []*Point3D { v := c.(*Concentric3D); return []*Point3D{v.Center1, v.Center2} },
+		func(pts []*Point3D) Constraint { return NewConcentric3D(pts[0], pts[1]) }))
+	registerConstraintCodec3D(GroundKind, point3DConstraintCodec(1,
+		func(c Constraint) []*Point3D { return []*Point3D{c.(*Ground3D).P} },
+		func(pts []*Point3D) Constraint { return NewGround3D(pts[0]) }))
+	registerConstraintCodec3D(EqualKind, equal3DCodec())
+}
+
+// equal3DCodec serializes an equal-radius constraint by its two radius-bearing
+// curve operands (#1625) — the refs Equal3D now carries.
+func equal3DCodec() constraintCodec3D {
+	return constraintCodec3D{
+		encode: func(c Constraint) (Constraint3DRow, error) {
+			v := c.(*Equal3D)
+			return Constraint3DRow{Curves: []int{int(v.E1.EntityID()), int(v.E2.EntityID())}}, nil
+		},
+		decode: func(s *Sketch3D, cd Constraint3DRow, pts []*Point3D, entmap map[int]Entity) error {
+			if len(cd.Curves) != 2 {
+				return fmt.Errorf("needs 2 radius-bearing curves, got %d", len(cd.Curves))
+			}
+			e1, ok1 := entmap[cd.Curves[0]]
+			e2, ok2 := entmap[cd.Curves[1]]
+			if !ok1 || !ok2 {
+				return fmt.Errorf("unknown curve ref in %v", cd.Curves)
+			}
+			eq, err := NewEqual3D(e1, e2)
+			if err != nil {
+				return err
+			}
+			s.geomCons.add(eq)
+			return nil
+		},
+	}
+}
+
+func registerLine3DConstraintCodecs() {
+	registerConstraintCodec3D(ParallelKind, line3DConstraintCodec(2,
+		func(c Constraint) []*Line3D { v := c.(*Parallel3D); return []*Line3D{v.L1, v.L2} },
+		func(lines []*Line3D) Constraint { return NewParallel3D(lines[0], lines[1]) }))
+	registerConstraintCodec3D(PerpendicularKind, line3DConstraintCodec(2,
+		func(c Constraint) []*Line3D { v := c.(*Perpendicular3D); return []*Line3D{v.L1, v.L2} },
+		func(lines []*Line3D) Constraint { return NewPerpendicular3D(lines[0], lines[1]) }))
+	registerConstraintCodec3D(MidpointKind, midpoint3DCodec())
+}
+
+func midpoint3DCodec() constraintCodec3D {
+	return constraintCodec3D{
+		encode: func(c Constraint) (Constraint3DRow, error) {
+			v := c.(*Midpoint3D)
+			return Constraint3DRow{Points: []int{int(v.P.id)}, Curves: []int{int(v.L.id)}}, nil
+		},
+		decode: func(s *Sketch3D, cd Constraint3DRow, pts []*Point3D, entmap map[int]Entity) error {
+			lines, err := lookupLines3D(cd.Curves, entmap)
+			if err != nil {
+				return err
+			}
+			if len(pts) != 1 || len(lines) != 1 {
+				return fmt.Errorf("needs 1 point + 1 line, got %d/%d", len(pts), len(lines))
+			}
+			s.geomCons.add(NewMidpoint3D(pts[0], lines[0]))
+			return nil
+		},
+	}
+}
+
+// registerOrientation3DConstraintCodecs covers the parallel-to-axis/plane
+// family: ONE type serializes under three kinds each, derived from the
+// constrained direction by ConstraintKind() (the pre-#1625 axisRowKind/
+// planeRowKind spellings). All six share the one-line row shape; each kind's
+// decode rebuilds the matching origin-frame variant.
+func registerOrientation3DConstraintCodecs() {
+	axisEncode := func(c Constraint) (Constraint3DRow, error) {
+		return Constraint3DRow{Curves: []int{int(c.(*ParallelToAxis3D).L.id)}}, nil
+	}
+	planeEncode := func(c Constraint) (Constraint3DRow, error) {
+		return Constraint3DRow{Curves: []int{int(c.(*ParallelToPlane3D).L.id)}}, nil
+	}
+	builders := map[ConstraintKind]struct {
+		encode func(Constraint) (Constraint3DRow, error)
+		build  func(*Line3D) Constraint
+	}{
+		ParallelToXAxisKind: {axisEncode, func(l *Line3D) Constraint { return NewParallelToXAxis3D(l) }},
+		ParallelToYAxisKind: {axisEncode, func(l *Line3D) Constraint { return NewParallelToYAxis3D(l) }},
+		ParallelToZAxisKind: {axisEncode, func(l *Line3D) Constraint { return NewParallelToZAxis3D(l) }},
+		ParallelToXYKind:    {planeEncode, func(l *Line3D) Constraint { return NewParallelToXYPlane3D(l) }},
+		ParallelToXZKind:    {planeEncode, func(l *Line3D) Constraint { return NewParallelToXZPlane3D(l) }},
+		ParallelToYZKind:    {planeEncode, func(l *Line3D) Constraint { return NewParallelToYZPlane3D(l) }},
+	}
+	for kind, b := range builders {
+		registerConstraintCodec3D(kind, orientation3DCodec(b.encode, b.build))
+	}
+}
+
+func orientation3DCodec(encode func(Constraint) (Constraint3DRow, error), build func(*Line3D) Constraint) constraintCodec3D {
+	return constraintCodec3D{
+		encode: encode,
+		decode: func(s *Sketch3D, cd Constraint3DRow, pts []*Point3D, entmap map[int]Entity) error {
+			lines, err := lookupLines3D(cd.Curves, entmap)
+			if err != nil {
+				return err
+			}
+			if len(lines) != 1 {
+				return fmt.Errorf("needs 1 line, got %d", len(lines))
+			}
+			s.geomCons.add(build(lines[0]))
+			return nil
+		},
+	}
+}
+
+// registerCurveJoin3DConstraintCodecs covers the curve-join kinds (tangent/
+// smooth/splineFitPoints/helical/bend, issue #142) — their Curves are not
+// necessarily lines, so they resolve against the full entity map.
+func registerCurveJoin3DConstraintCodecs() {
+	registerConstraintCodec3D(TangentKind, smoothJoin3DCodec(
+		func(c Constraint) (SmoothCurve3D, SmoothCurve3D, *Point3D, *Point3D) {
+			v := c.(*Tangent3D)
+			return v.C1, v.C2, v.P1, v.P2
+		},
+		func(c1, c2 SmoothCurve3D, p1, p2 *Point3D) Constraint { return NewTangent3D(c1, c2, p1, p2) }))
+	registerConstraintCodec3D(SmoothKind, smoothJoin3DCodec(
+		func(c Constraint) (SmoothCurve3D, SmoothCurve3D, *Point3D, *Point3D) {
+			v := c.(*Smooth3D)
+			return v.C1, v.C2, v.P1, v.P2
+		},
+		func(c1, c2 SmoothCurve3D, p1, p2 *Point3D) Constraint { return NewSmooth3D(c1, c2, p1, p2) }))
+	registerConstraintCodec3D(SplineFitPointsKind, splineFit3DCodec())
+	registerConstraintCodec3D(HelicalJoinKind, helical3DCodec())
+	registerConstraintCodec3D(BendKind, bend3DCodec())
+}
+
+// smoothJoin3DCodec pairs a tangent/smooth join row with its factory.
+func smoothJoin3DCodec(operands func(Constraint) (SmoothCurve3D, SmoothCurve3D, *Point3D, *Point3D), build func(c1, c2 SmoothCurve3D, p1, p2 *Point3D) Constraint) constraintCodec3D {
+	return constraintCodec3D{
+		encode: func(c Constraint) (Constraint3DRow, error) {
+			c1, c2, p1, p2 := operands(c)
+			return Constraint3DRow{Curves: entity3DIDPair(c1, c2), Points: []int{int(p1.id), int(p2.id)}}, nil
+		},
+		decode: func(s *Sketch3D, cd Constraint3DRow, pts []*Point3D, entmap map[int]Entity) error {
+			if len(cd.Curves) != 2 || len(pts) != 2 {
+				return fmt.Errorf("needs 2 curves + 2 points, got %d/%d", len(cd.Curves), len(pts))
+			}
+			c1, err := lookupSmoothCurve3D(cd.Curves[0], entmap)
+			if err != nil {
+				return err
+			}
+			c2, err := lookupSmoothCurve3D(cd.Curves[1], entmap)
+			if err != nil {
+				return err
+			}
+			s.geomCons.add(build(c1, c2, pts[0], pts[1]))
+			return nil
+		},
+	}
+}
+
+func splineFit3DCodec() constraintCodec3D {
+	return constraintCodec3D{
+		encode: func(c Constraint) (Constraint3DRow, error) {
+			v := c.(*SplineFitPoints3D)
+			return Constraint3DRow{Curves: []int{int(v.Spline.id)}, Points: []int{int(v.P.id)}, Index: v.FitIndex}, nil
+		},
+		decode: func(s *Sketch3D, cd Constraint3DRow, pts []*Point3D, entmap map[int]Entity) error {
+			sp, err := lookupSpline3D(cd.Curves, entmap)
+			if err != nil {
+				return err
+			}
+			if len(pts) != 1 {
+				return fmt.Errorf("needs 1 fit point, got %d", len(pts))
+			}
+			c, err := NewSplineFitPoints3DAt(sp, pts[0], cd.Index)
+			if err != nil {
+				return err
+			}
+			s.geomCons.add(c)
+			return nil
+		},
+	}
+}
+
+func helical3DCodec() constraintCodec3D {
+	return constraintCodec3D{
+		encode: func(c Constraint) (Constraint3DRow, error) {
+			v := c.(*Helical3D)
+			return Constraint3DRow{Curves: []int{int(v.H.id), int(v.C.id)}}, nil
+		},
+		decode: func(s *Sketch3D, cd Constraint3DRow, pts []*Point3D, entmap map[int]Entity) error {
+			c, err := restoreHelical3D(cd, entmap)
+			if err != nil {
+				return err
+			}
+			s.geomCons.add(c)
+			return nil
+		},
+	}
+}
+
+func bend3DCodec() constraintCodec3D {
+	return constraintCodec3D{
+		encode: func(c Constraint) (Constraint3DRow, error) {
+			v := c.(*Bend3D)
+			return Constraint3DRow{
+				Curves: []int{int(v.Arc.id), int(v.L1.id), int(v.L2.id)},
+				Points: []int{int(v.P1.id), int(v.P2.id)}, Radius: v.Radius,
+			}, nil
+		},
+		decode: func(s *Sketch3D, cd Constraint3DRow, pts []*Point3D, entmap map[int]Entity) error {
+			c, err := restoreBend3D(cd, pts, entmap)
+			if err != nil {
+				return err
+			}
+			s.geomCons.add(c)
+			return nil
+		},
+	}
+}

--- a/model/sketch/serialize_constraint_registry.go
+++ b/model/sketch/serialize_constraint_registry.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+// Constraint serialization is a registry keyed by [ConstraintKind]: each kind
+// contributes ONE codec pairing its encode and decode closures, registered
+// together in a serialize_codecs_constraints*.go init(). This replaces the two
+// hand-maintained switch pairs (serializeConstraint/restoreConstraint and their
+// 3D twins) whose halves nothing linked — the drift class that shipped #1574
+// (Symmetry enumerable but not creatable) and #1416 (encode half without decode
+// half), and that made an Equal3D save fail at runtime (#1625, audit I2). Now a
+// kind without BOTH halves cannot register, and the registry closure test
+// asserts the registered sets match the persisted vocabulary exactly.
+//
+// 2D and 3D registries are separate because they encode into different recipe
+// rows ([ConstraintData] vs [Constraint3DRow]) even where the kind spelling is
+// shared ("coincident" relates two points in both, but "collinear" is two lines
+// in 2D and three points in 3D).
+
+// constraintCodec is one 2D kind's serialization pair. encode receives the
+// concrete constraint (asserting its own type, as the switch case it replaces
+// did) and fills the row WITHOUT its Kind — serializeConstraint stamps that
+// from the constraint's own ConstraintKind so row and registry key can never
+// drift. decode rebuilds the constraint inside a restoring sketch, resolving
+// operand ids through the restorer.
+type constraintCodec struct {
+	encode func(c Constraint) (ConstraintData, error)
+	decode func(r *sketchRestorer, cd ConstraintData) error
+}
+
+// constraintCodec3D is one 3D kind's serialization pair. decode receives the
+// row's points already resolved (restoreConstraint3D looks them up once for
+// every kind) and resolves curve operands against the full entity map.
+type constraintCodec3D struct {
+	encode func(c Constraint) (Constraint3DRow, error)
+	decode func(s *Sketch3D, cd Constraint3DRow, pts []*Point3D, entmap map[int]Entity) error
+}
+
+// constraintCodecs2D / constraintCodecs3D map a kind to its codec. Populated by
+// the serialize_codecs_constraints*.go init()s; read-only after init.
+var (
+	constraintCodecs2D = map[ConstraintKind]constraintCodec{}
+	constraintCodecs3D = map[ConstraintKind]constraintCodec3D{}
+)
+
+// registerConstraintCodec records one 2D kind's codec, panicking on a duplicate
+// or an incomplete pair — a programming error caught at startup.
+func registerConstraintCodec(kind ConstraintKind, c constraintCodec) {
+	_, dup := constraintCodecs2D[kind]
+	mustAcceptCodec("sketch constraint", string(kind), c.encode == nil || c.decode == nil, dup)
+	constraintCodecs2D[kind] = c
+}
+
+// registerConstraintCodec3D records one 3D kind's codec under the same rules.
+func registerConstraintCodec3D(kind ConstraintKind, c constraintCodec3D) {
+	_, dup := constraintCodecs3D[kind]
+	mustAcceptCodec("sketch constraint 3D", string(kind), c.encode == nil || c.decode == nil, dup)
+	constraintCodecs3D[kind] = c
+}
+
+// registeredConstraintKinds2D returns the 2D kinds with a codec, for the
+// closure test.
+func registeredConstraintKinds2D() []ConstraintKind {
+	out := make([]ConstraintKind, 0, len(constraintCodecs2D))
+	for k := range constraintCodecs2D {
+		out = append(out, k)
+	}
+	return out
+}
+
+// registeredConstraintKinds3D returns the 3D kinds with a codec, for the
+// closure test.
+func registeredConstraintKinds3D() []ConstraintKind {
+	out := make([]ConstraintKind, 0, len(constraintCodecs3D))
+	for k := range constraintCodecs3D {
+		out = append(out, k)
+	}
+	return out
+}

--- a/model/sketch/serialize_constraint_registry_test.go
+++ b/model/sketch/serialize_constraint_registry_test.go
@@ -145,13 +145,16 @@ func populateEvery2DConstraintKind(s *Sketch) {
 	g.AddGroundPoints(l2.A, l2.B)
 	g.AddOffset(l1, l2, 1)
 	g.AddPatternLink(l1.A, l2.A)
-	mustAddCustom(g, l1)
+	// Anchor the tag to a line AND a bare point: points persist in the Points
+	// table, so the restore fallback for point-anchored tags is exercised too
+	// (surfaced by the #1625 constraintseam live test).
+	mustAddCustom(g, l1, l1.A)
 }
 
 // mustAddCustom adds a tag constraint; the factory only errors on an empty
 // client id, which this call never passes.
-func mustAddCustom(g *GeometricConstraints, e Entity) {
-	if _, err := g.AddCustom("test.client", "tag", []Entity{e}); err != nil {
+func mustAddCustom(g *GeometricConstraints, ents ...Entity) {
+	if _, err := g.AddCustom("test.client", "tag", ents); err != nil {
 		panic(err)
 	}
 }

--- a/model/sketch/serialize_constraint_registry_test.go
+++ b/model/sketch/serialize_constraint_registry_test.go
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"reflect"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// The constraint codec registry guards (#1625, audit I2), mirroring the entity
+// registry guards (#1624): the registered kind sets must equal the persisted
+// vocabulary exactly, a half or duplicate registration must panic, and one
+// instance of EVERY registered kind must round-trip to an identical recipe —
+// so a kind added to one codec half fails here at CI, not at the user's save.
+// That drift class shipped #1574 (Symmetry enumerable but not creatable) and
+// left Equal3D failing every save at runtime until this registry.
+
+// persistedConstraintVocabulary2D / 3D are the exact constraint kind sets a
+// recipe may contain, one line per kind. Adding a constraint type means
+// registering its codec AND extending this list AND giving the round-trip
+// tests below an instance — all in this package, all enforced together.
+var (
+	persistedConstraintVocabulary2D = []ConstraintKind{
+		CoincidentKind, HorizontalKind, VerticalKind,
+		PointOnLineKind, MidpointKind, PointOnCircleKind,
+		ParallelKind, PerpendicularKind, CollinearKind, EqualLengthKind,
+		ConcentricKind, EqualRadiusKind, CircularTangentKind, TangentKind,
+		SymmetryKind, FixKind, SmoothKind,
+		GroundKind, OffsetKind, PatternLinkKind, TextBoxAnchorKind, CustomKind,
+	}
+	persistedConstraintVocabulary3D = []ConstraintKind{
+		CoincidentKind, Collinear3PointKind, ConcentricKind, EqualKind,
+		ParallelKind, PerpendicularKind, MidpointKind, GroundKind,
+		ParallelToXAxisKind, ParallelToYAxisKind, ParallelToZAxisKind,
+		ParallelToXYKind, ParallelToXZKind, ParallelToYZKind,
+		TangentKind, SmoothKind, SplineFitPointsKind, HelicalJoinKind, BendKind,
+	}
+)
+
+func TestConstraintCodecRegistryMatchesVocabulary(t *testing.T) {
+	assertConstraintKindSetsEqual(t, "2D", registeredConstraintKinds2D(), persistedConstraintVocabulary2D)
+	assertConstraintKindSetsEqual(t, "3D", registeredConstraintKinds3D(), persistedConstraintVocabulary3D)
+}
+
+func assertConstraintKindSetsEqual(t *testing.T, family string, got, want []ConstraintKind) {
+	t.Helper()
+	gotSet, wantSet := constraintKindSet(got), constraintKindSet(want)
+	for k := range wantSet {
+		if !gotSet[k] {
+			t.Errorf("%s constraint kind %q is in the persisted vocabulary but has no codec", family, k)
+		}
+	}
+	for k := range gotSet {
+		if !wantSet[k] {
+			t.Errorf("%s constraint kind %q has a codec but is not in the persisted vocabulary list", family, k)
+		}
+	}
+}
+
+func constraintKindSet(kinds []ConstraintKind) map[ConstraintKind]bool {
+	out := make(map[ConstraintKind]bool, len(kinds))
+	for _, k := range kinds {
+		out[k] = true
+	}
+	return out
+}
+
+func TestRegisterConstraintCodecRejectsBadRegistration(t *testing.T) {
+	complete2D := constraintCodec{
+		encode: func(Constraint) (ConstraintData, error) { return ConstraintData{}, nil },
+		decode: func(*sketchRestorer, ConstraintData) error { return nil },
+	}
+	complete3D := constraintCodec3D{
+		encode: func(Constraint) (Constraint3DRow, error) { return Constraint3DRow{}, nil },
+		decode: func(*Sketch3D, Constraint3DRow, []*Point3D, map[int]Entity) error { return nil },
+	}
+	mustPanic(t, "2D empty kind", func() { registerConstraintCodec("", complete2D) })
+	mustPanic(t, "2D encode-only", func() { registerConstraintCodec("testHalf", constraintCodec{encode: complete2D.encode}) })
+	mustPanic(t, "2D decode-only", func() { registerConstraintCodec("testHalf", constraintCodec{decode: complete2D.decode}) })
+	mustPanic(t, "2D duplicate", func() { registerConstraintCodec(CoincidentKind, complete2D) })
+	mustPanic(t, "3D empty kind", func() { registerConstraintCodec3D("", complete3D) })
+	mustPanic(t, "3D encode-only", func() { registerConstraintCodec3D("testHalf", constraintCodec3D{encode: complete3D.encode}) })
+	mustPanic(t, "3D duplicate", func() { registerConstraintCodec3D(BendKind, complete3D) })
+}
+
+// TestEvery2DConstraintKindRoundTripsIdentically saves a sketch holding one
+// constraint of every registered 2D kind, restores it, saves again, and
+// demands the two recipes match — the enumerating closure over the registry.
+func TestEvery2DConstraintKindRoundTripsIdentically(t *testing.T) {
+	sc := NewSketches()
+	s := sc.Add(XYPlane())
+	populateEvery2DConstraintKind(s)
+
+	first, err := sc.MarshalRecipe()
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	assertConstraintRowsCoverVocabulary(t, constraintKindsIn(first), persistedConstraintVocabulary2D)
+
+	fresh := NewSketches()
+	if err := fresh.ApplyRecipe(first); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	second, err := fresh.MarshalRecipe()
+	if err != nil {
+		t.Fatalf("re-MarshalRecipe: %v", err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Errorf("recipe changed across a round trip:\nfirst:  %+v\nsecond: %+v", first, second)
+	}
+}
+
+// populateEvery2DConstraintKind creates one constraint of each persisted 2D
+// kind through the same factories the tools use. The text box goes first: its
+// anchor constraint is auto-created at entity-add time, matching the restore
+// order (entities before constraint rows).
+func populateEvery2DConstraintKind(s *Sketch) {
+	s.texts.AddStyled(math.P2(7, 7), "note", 0.5, 0, TextHJustify(0), TextVJustify(0), "sans", 0)
+	l1 := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(2, 0))
+	l2 := s.Lines().AddByTwoPoints(math.P2(0, 1), math.P2(2, 1))
+	c1 := s.Circles().AddByCenterRadius(math.P2(5, 0), 1)
+	c2 := s.Circles().AddByCenterRadius(math.P2(8, 0), 1)
+	arc := s.Arcs().AddByCenterStartEnd(math.P2(0, 5), math.P2(1, 5), math.P2(0, 6), true)
+	g := s.GeometricConstraints()
+
+	g.AddCoincident(l1.A, l2.A)
+	g.AddHorizontal(l1.A, l1.B)
+	g.AddVertical(l2.A, l2.B)
+	g.AddPointOnLine(l2.A, l1)
+	g.AddMidpoint(l2.B, l1)
+	g.AddPointOnCircle(l1.B, c1)
+	g.AddParallel(l1, l2)
+	g.AddPerpendicular(l1, l2)
+	g.AddCollinear(l1, l2)
+	g.AddEqualLength(l1, l2)
+	g.AddConcentric(c1, c2)
+	g.AddEqualRadius(c1, c2)
+	g.AddCircularTangent(c1, c2)
+	g.AddTangent(l1, c1)
+	g.AddSymmetry(l1.A, l1.B, l2)
+	g.AddFix(l1.A)
+	g.AddSmooth(l1, arc, l1.B, arc.Start)
+	g.AddGroundPoints(l2.A, l2.B)
+	g.AddOffset(l1, l2, 1)
+	g.AddPatternLink(l1.A, l2.A)
+	mustAddCustom(g, l1)
+}
+
+// mustAddCustom adds a tag constraint; the factory only errors on an empty
+// client id, which this call never passes.
+func mustAddCustom(g *GeometricConstraints, e Entity) {
+	if _, err := g.AddCustom("test.client", "tag", []Entity{e}); err != nil {
+		panic(err)
+	}
+}
+
+// TestEvery3DConstraintKindRoundTripsIdentically is the 3D closure. It pins
+// the #1625 Equal3D regression: creatable and enumerable over the wire but
+// missing from both serialize switches, it failed every save at runtime.
+func TestEvery3DConstraintKindRoundTripsIdentically(t *testing.T) {
+	c := NewSketches3D()
+	s := c.Add()
+	populateEvery3DConstraintKind(t, s)
+
+	first, err := c.MarshalRecipe3D()
+	if err != nil {
+		t.Fatalf("MarshalRecipe3D: %v", err)
+	}
+	assertConstraintRowsCoverVocabulary(t, constraintKinds3DIn(first), persistedConstraintVocabulary3D)
+
+	fresh := NewSketches3D()
+	if err := fresh.ApplyRecipe3D(first); err != nil {
+		t.Fatalf("ApplyRecipe3D: %v", err)
+	}
+	second, err := fresh.MarshalRecipe3D()
+	if err != nil {
+		t.Fatalf("re-MarshalRecipe3D: %v", err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Errorf("3D recipe changed across a round trip:\nfirst:  %+v\nsecond: %+v", first, second)
+	}
+}
+
+// populateEvery3DConstraintKind creates one constraint of each persisted 3D kind.
+func populateEvery3DConstraintKind(t *testing.T, s *Sketch3D) {
+	t.Helper()
+	uz := mustUnit3(t, 0, 0, 1)
+	a := s.AddPoint3D(math.P3(0, 0, 3))
+	b := s.AddPoint3D(math.P3(1, 0, 3))
+	c := s.AddPoint3D(math.P3(2, 0, 3))
+	l1 := s.AddLine3D(math.P3(0, 0, 0), math.P3(2, 0, 0))
+	l2 := s.AddLine3D(math.P3(0, 1, 0), math.P3(2, 1, 0))
+	c1 := s.AddCircle3D(math.P3(0, 0, 2), uz, 1.5)
+	c2 := s.AddCircle3D(math.P3(4, 0, 2), uz, 1.5)
+	arc := s.AddArc3D(math.P3(0, 5, 0), math.P3(1, 5, 0), math.P3(0, 6, 0), true)
+	h := s.AddHelix3D(math.P3(0, 0, 2), uz, 1.5, 0.5, 0, 3, false)
+	sp := s.AddSpline3D([]math.Point3{{X: 0, Y: 8, Z: 0}, {X: 1, Y: 9, Z: 0}, {X: 2, Y: 8, Z: 1}}, false, true)
+	g := s.GeometricConstraints3D()
+
+	g.Add(NewCoincident3D(a, b))
+	g.Add(NewCollinear3D(a, b, c))
+	g.Add(NewConcentric3D(a, b))
+	g.Add(mustEqual3D(t, c1, c2))
+	g.Add(NewParallel3D(l1, l2))
+	g.Add(NewPerpendicular3D(l1, l2))
+	g.Add(NewMidpoint3D(a, l1))
+	g.Add(NewGround3D(a))
+	g.Add(NewParallelToXAxis3D(l1))
+	g.Add(NewParallelToYAxis3D(l1))
+	g.Add(NewParallelToZAxis3D(l1))
+	g.Add(NewParallelToXYPlane3D(l2))
+	g.Add(NewParallelToXZPlane3D(l2))
+	g.Add(NewParallelToYZPlane3D(l2))
+	g.Add(NewTangent3D(l1, arc, l1.B, arc.Start))
+	g.Add(NewSmooth3D(arc, sp, arc.End, sp.Points[0]))
+	addSplineFit3D(t, g, sp, s.AddPoint3D(math.P3(0, 8, 0)))
+	addHelical3D(t, g, h, c1)
+	if _, err := s.AddBend3D(s.AddLine3D(math.P3(6, 0, 0), math.P3(9, 0, 0)), s.AddLine3D(math.P3(9, 0, 0), math.P3(9, 3, 0)), 0.5); err != nil {
+		t.Fatalf("AddBend3D: %v", err)
+	}
+}
+
+func addSplineFit3D(t *testing.T, g *GeometricConstraints, sp *Spline3D, p *Point3D) {
+	t.Helper()
+	c, err := NewSplineFitPoints3D(sp, p)
+	if err != nil {
+		t.Fatalf("NewSplineFitPoints3D: %v", err)
+	}
+	g.Add(c)
+}
+
+func addHelical3D(t *testing.T, g *GeometricConstraints, h *HelicalCurve3D, c *Circle3D) {
+	t.Helper()
+	hc, err := NewHelical3D(h, c)
+	if err != nil {
+		t.Fatalf("NewHelical3D: %v", err)
+	}
+	g.Add(hc)
+}
+
+// assertConstraintRowsCoverVocabulary demands the marshalled recipe exercises
+// every kind in the vocabulary — a codec the round-trip does not cover is a
+// hole in the closure.
+func assertConstraintRowsCoverVocabulary(t *testing.T, got map[ConstraintKind]bool, want []ConstraintKind) {
+	t.Helper()
+	for _, k := range want {
+		if !got[k] {
+			t.Errorf("round-trip recipe has no %q constraint row — the closure does not cover its codec", k)
+		}
+	}
+}
+
+func constraintKindsIn(data []SketchData) map[ConstraintKind]bool {
+	out := map[ConstraintKind]bool{}
+	for _, sd := range data {
+		for _, cd := range sd.Constraints {
+			out[ConstraintKind(cd.Kind)] = true
+		}
+	}
+	return out
+}
+
+func constraintKinds3DIn(data []SketchData3D) map[ConstraintKind]bool {
+	out := map[ConstraintKind]bool{}
+	for _, sd := range data {
+		for _, cd := range sd.Constraints {
+			out[ConstraintKind(cd.Kind)] = true
+		}
+	}
+	return out
+}

--- a/model/sketch/serialize_restore.go
+++ b/model/sketch/serialize_restore.go
@@ -445,11 +445,16 @@ func (r *sketchRestorer) entity(ids []int, i int) (Entity, error) {
 	if err != nil {
 		return nil, err
 	}
-	e, ok := r.entityMap[id]
-	if !ok {
-		return nil, fmt.Errorf("unresolved entity id %d", id)
+	if e, ok := r.entityMap[id]; ok {
+		return e, nil
 	}
-	return e, nil
+	// A *Point is itself an Entity (a custom tag constraint may anchor to a
+	// bare point), but points persist in the Points table, not the entity
+	// rows — fall back there. Surfaced by the #1625 constraintseam live test.
+	if p, ok := r.pointMap[id]; ok {
+		return p, nil
+	}
+	return nil, fmt.Errorf("unresolved entity id %d", id)
 }
 
 func (r *sketchRestorer) line(ids []int, i int) (*Line, error) {

--- a/model/sketch/serialize_restore.go
+++ b/model/sketch/serialize_restore.go
@@ -214,135 +214,14 @@ func (r *sketchRestorer) restoreConstraints(constraints []ConstraintData) error 
 	return nil
 }
 
+// restoreConstraint decodes through the paired codec registry (#1625) — an
+// unknown kind is a corrupt-recipe error, named honestly.
 func (r *sketchRestorer) restoreConstraint(cd ConstraintData) error {
-	g := r.s.geomCons
-	switch cd.Kind {
-	case "coincident":
-		return r.twoPoints(cd, func(a, b *Point) { g.AddCoincident(a, b) })
-	case "horizontal":
-		return r.twoPoints(cd, func(a, b *Point) { g.AddHorizontal(a, b) })
-	case "vertical":
-		return r.twoPoints(cd, func(a, b *Point) { g.AddVertical(a, b) })
-	case "parallel":
-		return r.twoLines(cd, func(a, b *Line) { g.AddParallel(a, b) })
-	case "perpendicular":
-		return r.twoLines(cd, func(a, b *Line) { g.AddPerpendicular(a, b) })
-	case "collinear":
-		return r.twoLines(cd, func(a, b *Line) { g.AddCollinear(a, b) })
-	case "equalLength":
-		return r.twoLines(cd, func(a, b *Line) { g.AddEqualLength(a, b) })
-	case "concentric":
-		return r.twoCurves(cd, func(a, b CircularCurve) { g.AddConcentric(a, b) })
-	case "equalRadius":
-		return r.twoCurves(cd, func(a, b CircularCurve) { g.AddEqualRadius(a, b) })
-	case "circularTangent":
-		return r.twoCurves(cd, func(a, b CircularCurve) { g.AddCircularTangent(a, b) })
-	case "pointOnLine":
-		return r.pointAndLine(cd, func(p *Point, l *Line) { g.AddPointOnLine(p, l) })
-	case "midpoint":
-		return r.pointAndLine(cd, func(p *Point, l *Line) { g.AddMidpoint(p, l) })
-	case "pointOnCircle":
-		p, err := r.point(cd.Points, 0)
-		if err != nil {
-			return err
-		}
-		c, err := r.curve(cd.Curves, 0)
-		if err != nil {
-			return err
-		}
-		g.AddPointOnCircle(p, c)
-		return nil
-	case "tangent":
-		l, err := r.line(cd.Curves, 0)
-		if err != nil {
-			return err
-		}
-		c, err := r.curve(cd.Curves, 1)
-		if err != nil {
-			return err
-		}
-		g.AddTangent(l, c)
-		return nil
-	case "symmetry":
-		a, err := r.point(cd.Points, 0)
-		if err != nil {
-			return err
-		}
-		b, err := r.point(cd.Points, 1)
-		if err != nil {
-			return err
-		}
-		about, err := r.line(cd.Curves, 0)
-		if err != nil {
-			return err
-		}
-		g.AddSymmetry(a, b, about)
-		return nil
-	case "fix":
-		p, err := r.point(cd.Points, 0)
-		if err != nil {
-			return err
-		}
-		g.AddFix(p)
-		return nil
-	case "smooth":
-		c1, err := r.smooth(cd.Curves, 0)
-		if err != nil {
-			return err
-		}
-		c2, err := r.smooth(cd.Curves, 1)
-		if err != nil {
-			return err
-		}
-		p1, err := r.point(cd.Points, 0)
-		if err != nil {
-			return err
-		}
-		p2, err := r.point(cd.Points, 1)
-		if err != nil {
-			return err
-		}
-		g.AddSmooth(c1, c2, p1, p2)
-		return nil
-	default:
-		return r.restoreExtraConstraint(cd)
-	}
-}
-
-// restoreExtraConstraint rebuilds the M21 constraints (ground/offset/pattern link); split
-// out of restoreConstraint to keep that switch small.
-func (r *sketchRestorer) restoreExtraConstraint(cd ConstraintData) error {
-	g := r.s.geomCons
-	switch cd.Kind {
-	case "ground":
-		pts, err := r.points(cd.Points, len(cd.Points))
-		if err != nil {
-			return err
-		}
-		g.AddGroundPoints(pts...)
-		return nil
-	case "offset":
-		return r.twoLines(cd, func(a, b *Line) { g.AddOffset(a, b, cd.Value) })
-	case "patternLink":
-		return r.twoPoints(cd, func(a, b *Point) { g.AddPatternLink(a, b) })
-	case "textBox":
-		// The anchor record is auto-created with its text box; restoring it
-		// explicitly would duplicate it, so the persisted row is a no-op.
-		return nil
-	case "custom":
-		ents := make([]Entity, 0, len(cd.Curves))
-		for i := range cd.Curves {
-			e, err := r.entity(cd.Curves, i)
-			if err != nil {
-				return err
-			}
-			ents = append(ents, e)
-		}
-		_, err := g.AddCustom(cd.ClientID, cd.Name, ents)
-		return err
-	default:
+	codec, ok := constraintCodecs2D[ConstraintKind(cd.Kind)]
+	if !ok {
 		return fmt.Errorf("unknown constraint kind %q", cd.Kind)
 	}
+	return codec.decode(r, cd)
 }
 
 // restoreSplineExtras rebuilds a spline's fit method and active tangency

--- a/model/sketch/sketch3d_test.go
+++ b/model/sketch/sketch3d_test.go
@@ -117,8 +117,9 @@ func TestSketch3DParameterStore(t *testing.T) {
 // TestSketch3DSerializeErrors covers the missing-codec and unknown-id error paths of the
 // 3D sketch codec.
 func TestSketch3DSerializeErrors(t *testing.T) {
-	// Equal3D has no point-operand codec.
-	if _, err := serializeConstraint3D(NewEqual3D(nil, nil)); err == nil {
+	// CustomConstraint3D is a solver adapter over an opaque residual closure —
+	// deliberately not serializable.
+	if _, err := serializeConstraint3D(NewCustomConstraint3D(func() []float64 { return nil }, nil)); err == nil {
 		t.Error("serializeConstraint3D should error for an unsupported constraint")
 	}
 	// Restoring a constraint that references an unknown point id fails honestly.
@@ -180,7 +181,7 @@ func TestSketch3DNameCollision(t *testing.T) {
 func TestSketch3DRecipeErrorsPropagate(t *testing.T) {
 	src := NewSketches3D()
 	s := src.Add()
-	s.GeometricConstraints3D().add(NewEqual3D(nil, nil)) // no codec ⇒ marshal fails
+	s.GeometricConstraints3D().add(NewCustomConstraint3D(func() []float64 { return nil }, nil)) // no codec ⇒ marshal fails
 	if _, err := src.MarshalRecipe3D(); err == nil {
 		t.Error("MarshalRecipe3D should propagate a constraint-codec error")
 	}


### PR DESCRIPTION
Closes #1625 (audit I2).

## What

A constraint's kind was re-derived independently in 4+ parallel switch families (serializer encode/decode, router enumerate, plus the Sketch3D twins) with nothing linking the sides — the structure that shipped #1574 (Symmetry enumerable but not creatable) and made the serializer's `default:` a runtime save failure.

- **`KindedConstraint` capability**: every 2D and 3D geometric constraint self-describes (`ConstraintKind()` + `RelatedEntities()`), with compile-time assertions for all 37 types. `ParallelToAxis3D`/`ParallelToPlane3D` derive their kind from the constrained direction (one type, three persisted kinds each, pre-existing .obk spellings kept).
- **Paired codec registry** (`serialize_constraint_registry.go` + `serialize_codecs_constraints*.go`): each kind registers encode+decode together in one `init()`; duplicate/half registration panics; all four switch pairs and their `default:` save failures are deleted.
- **Enumerate via the capability**: `geometricShape`/`constraint3DKind` read the constraint's own kind and refs; the 2D model vocabulary maps to the coarser wire enum through one boundary table (circularTangent → wire "tangent"), 3D by conversion (spellings match by construction).
- **archguard**: `sketch_constraint_switch_test` forbids `case *sketch.<ConstraintType>` outside model/sketch; the type list is parsed from the `ConstraintKind()` receivers so new kinds auto-extend it (red-verified).

## Bugs surfaced and fixed (exactly the class the audit predicted)

- **Equal3D failed every save at runtime**: creatable and enumerable over the wire but registered in NEITHER serialize switch, and it kept only raw `*math.Scalar`s so it could not even name its refs. It now carries its radius-bearing operand entities (resolving DOFs via the RadiusDOF capability), serializes, restores, and enumerates its refs.
- **Point-anchored custom tag constraints failed to reopen** ("unresolved entity id"): points persist in the Points table and the restorer's entity lookup never fell back there.

## Guards

- Registry closure tests: registered kind sets must equal the persisted vocabulary exactly (22 kinds 2D / 19 kinds 3D); one instance of EVERY kind round-trips marshal→apply→marshal identically; duplicate/half registration panic tests. Pins #1574 and the Equal3D regression.
- Creation stays a wire-kind dispatch on purpose: the wire enum is coarser than the model vocabulary (tangent overloads on ref shape, ground accepts entity-or-point), so overload resolution belongs at the boundary; the enum-iterating coverage guards (#142, #1643) already fail CI for any wire kind missing a create or enumerate side.

## Verification

- Full suite green (`go test -count=1 ./...`), golangci-lint 0 issues.
- **Live** (MCPBridge `mcplive -part constraintseam`): every wire-creatable 2D (21 kinds + textBox) and 3D (15 kinds) constraint created against the running host, document round-tripped through a real .obk save → force-close → reopen, constraint-kind census identical before/after; viewport screenshot inspected. Before this branch the SAVE itself failed on the 3D equal constraint, and the reopen failed on the point-anchored tag — the driver caught both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)