### PR TITLE
Assemble document content factories at the composition root (B6, 1/4)

### DIFF
--- a/app/bug_report_test.go
+++ b/app/bug_report_test.go
@@ -23,9 +23,11 @@ type fakeMarshalStore struct{ yaml string }
 
 func (fakeMarshalStore) Save(*doc.Document) error                               { return nil }
 func (fakeMarshalStore) SaveCopy(*doc.Document, string, doc.CopyMetadata) error { return nil }
-func (fakeMarshalStore) Load(string) (*doc.Document, error)                     { return nil, errors.New("no store") }
-func (fakeMarshalStore) Exists(string) bool                                     { return false }
-func (f fakeMarshalStore) MarshalDocument(*doc.Document) ([]byte, error)        { return []byte(f.yaml), nil }
+func (fakeMarshalStore) Load(string, doc.ContentFactories) (*doc.Document, error) {
+	return nil, errors.New("no store")
+}
+func (fakeMarshalStore) Exists(string) bool                              { return false }
+func (f fakeMarshalStore) MarshalDocument(*doc.Document) ([]byte, error) { return []byte(f.yaml), nil }
 
 // fakeBugSubmitter records the payload it is handed instead of POSTing it, so the
 // capture→submit flow can be driven without a network.

--- a/app/file_ui_hooks_test.go
+++ b/app/file_ui_hooks_test.go
@@ -26,12 +26,12 @@ func (f *fakeDocStore) SaveCopy(d *doc.Document, target string, _ doc.CopyMetada
 	return nil
 }
 
-func (f *fakeDocStore) Load(name string) (*doc.Document, error) {
+func (f *fakeDocStore) Load(name string, factories doc.ContentFactories) (*doc.Document, error) {
 	t, ok := f.saved[name]
 	if !ok {
 		return nil, errors.New("fakeDocStore: nothing at " + name)
 	}
-	return doc.Restore(t, name, "")
+	return doc.Restore(t, name, "", factories)
 }
 
 func (f *fakeDocStore) Exists(name string) bool { _, ok := f.saved[name]; return ok }

--- a/app/session.go
+++ b/app/session.go
@@ -17,6 +17,7 @@ import (
 	"oblikovati.org/model/bom"
 	"oblikovati.org/model/colorscheme"
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/display"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/model/facetstore"
@@ -206,7 +207,7 @@ func NewSessionWithStore(store doc.Store) *Session { return newSession(store) }
 func newSession(store doc.Store) *Session {
 	s := &Session{
 		store:     store,
-		workspace: doc.NewWorkspace(store),
+		workspace: doc.NewWorkspace(store, contentset.Default()),
 		commands:  NewCommandManager(),
 		histories: map[doc.ID]*docHistory{}, txAudit: map[doc.ID]*command.SnapshotLog{},
 		bus:       event.NewBus(),

--- a/archguard/init_registration_test.go
+++ b/archguard/init_registration_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package archguard
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Registries must be assembled by explicit construction at a composition root,
+// not by init() side effects (#1617, audit B6): init()-time registration makes
+// correctness depend on a binary's import list (documents silently opened as
+// stubs when a blank import was forgotten) and blocks constructing a minimal
+// set in tests. The contentFactories migration removed the pattern from
+// model/doc/compdef/drawing; this guard keeps it out everywhere else too,
+// with a SHRINK-ONLY allowlist for the registries whose migration is pending.
+
+// initRegistrationPattern matches an init() whose body performs a registration
+// call — the import-linkage wiring B6 retires.
+var initRegistrationPattern = regexp.MustCompile(`func init\(\) \{[^}]*[rR]egister`)
+
+// pendingInitRegistrations are files whose init()-time registrations await
+// their own migration PR (#1617 lands one registry per PR). SHRINK-ONLY:
+// migrate the registry to an explicit default-set constructor and delete the
+// entry. Never add to it.
+var pendingInitRegistrations = map[string]struct{}{
+	"model/feature/serialize_codecs_cosmetic.go":      {}, // feature codecs → defaultFeatureCodecs()
+	"model/feature/serialize_codecs_dressup.go":       {},
+	"model/feature/serialize_codecs_faceedit.go":      {},
+	"model/feature/serialize_codecs_pattern.go":       {},
+	"model/feature/serialize_codecs_sheetmetal.go":    {},
+	"model/feature/serialize_codecs_solid.go":         {},
+	"model/feature/serialize_codecs_surface.go":       {},
+	"model/sketch/serialize_codecs_3d.go":             {}, // sketch entity/constraint codecs (#1624/#1625) → follow-up
+	"model/sketch/serialize_codecs_curves.go":         {},
+	"model/sketch/serialize_codecs_extras.go":         {},
+	"model/sketch/serialize_codecs_constraints.go":    {},
+	"model/sketch/serialize_codecs_constraints_3d.go": {},
+	"app/feature_edit_registry.go":                    {}, // feature editors → Session default
+	"head/ui/dockable_panel.go":                       {}, // dockable-panel registry → UI-loop object
+}
+
+func TestNoInitTimeRegistrations(t *testing.T) {
+	offenders := initRegistrationSources(t)
+	seen := map[string]struct{}{}
+	for _, f := range offenders {
+		seen[f] = struct{}{}
+		if _, pending := pendingInitRegistrations[f]; !pending {
+			t.Errorf("%s registers via init() — assemble the registry in an explicit default-set constructor wired at the composition root instead (#1617, audit B6)", f)
+		}
+	}
+	for f := range pendingInitRegistrations {
+		if _, ok := seen[f]; !ok {
+			t.Errorf("pendingInitRegistrations entry %q is stale — the file no longer registers via init(); delete the entry (shrink-only, #1617)", f)
+		}
+	}
+}
+
+// initRegistrationSources walks the module's first-party sources — INCLUDING
+// model/sketch and the head submodule, which other guards prune — and returns
+// the files whose init() performs a registration.
+func initRegistrationSources(t *testing.T) []string {
+	t.Helper()
+	var offenders []string
+	err := filepath.Walk("..", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			switch info.Name() {
+			case ".git", "experiments", "test-utilities", "architecture", "testdata", "node_modules":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		src, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return rerr
+		}
+		if initRegistrationPattern.Match(src) {
+			offenders = append(offenders, strings.TrimPrefix(path, "../"))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking module sources: %v", err)
+	}
+	return offenders
+}

--- a/archguard/init_registration_test.go
+++ b/archguard/init_registration_test.go
@@ -84,7 +84,8 @@ func initRegistrationSources(t *testing.T) []string {
 			return rerr
 		}
 		if initRegistrationPattern.Match(src) {
-			offenders = append(offenders, strings.TrimPrefix(path, "../"))
+			// ToSlash so the allowlist's forward-slash keys match on Windows too.
+			offenders = append(offenders, strings.TrimPrefix(filepath.ToSlash(path), "../"))
 		}
 		return nil
 	})

--- a/archguard/sketch_entity_switch_test.go
+++ b/archguard/sketch_entity_switch_test.go
@@ -68,7 +68,9 @@ func goSourcesMatching(t *testing.T, pattern *regexp.Regexp) []string {
 			return rerr
 		}
 		if pattern.Match(src) {
-			offenders = append(offenders, strings.TrimPrefix(path, "../"))
+			// ToSlash so reported paths (and any caller matching on them) are
+			// separator-stable on Windows.
+			offenders = append(offenders, strings.TrimPrefix(filepath.ToSlash(path), "../"))
 		}
 		return nil
 	})

--- a/cmd/oblikovati-cli/cmd_export.go
+++ b/cmd/oblikovati-cli/cmd_export.go
@@ -10,6 +10,7 @@ import (
 
 	"oblikovati.org/api/types"
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/model/exchange"
 	"oblikovati.org/persistence"
@@ -39,7 +40,7 @@ func cmdExport(args []string, out io.Writer) error {
 // openCLIPart opens an .opd and returns its part component definition, erroring if the document
 // is missing or is not a part.
 func openCLIPart(src string) (*compdef.PartComponentDefinition, error) {
-	d, err := doc.NewWorkspace(persistence.NewPackageStore()).Open(src, true)
+	d, err := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default()).Open(src, true)
 	if err != nil {
 		return nil, fmt.Errorf("open %q: %w", src, err)
 	}

--- a/cmd/oblikovati-cli/cmd_export_test.go
+++ b/cmd/oblikovati-cli/cmd_export_test.go
@@ -11,6 +11,7 @@ import (
 	"oblikovati.org/kernel/ops"
 	gmath "oblikovati.org/math"
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/sketch"
@@ -22,7 +23,7 @@ import (
 func saveCLIPart(t *testing.T, dir, name string, build func(*compdef.PartComponentDefinition)) string {
 	t.Helper()
 	opd := filepath.Join(dir, name)
-	ws := doc.NewWorkspace(persistence.NewPackageStore())
+	ws := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
 	d, err := compdef.AddPart(ws, opd, true)
 	if err != nil {
 		t.Fatalf("AddPart: %v", err)

--- a/cmd/oblikovati-cli/cmd_generate_assembly.go
+++ b/cmd/oblikovati-cli/cmd_generate_assembly.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	"oblikovati.org/model/benchgen"
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/perf/benchprof"
 	"oblikovati.org/persistence"
@@ -52,7 +53,7 @@ func generateAssembly(profile benchgen.Profile, outDir string, save bool, out io
 	if err != nil {
 		return err
 	}
-	ws := doc.NewWorkspace(persistence.NewPackageStore())
+	ws := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
 	root, stats, err := benchgen.Generate(ws, outDir, profile)
 	if err != nil {
 		return err

--- a/cmd/oblikovati-cli/cmd_generate_assembly_test.go
+++ b/cmd/oblikovati-cli/cmd_generate_assembly_test.go
@@ -10,6 +10,7 @@ import (
 
 	"oblikovati.org/model/benchgen"
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/persistence"
 )
@@ -30,7 +31,7 @@ func cliTinyProfile() benchgen.Profile {
 
 func TestGenerateAssemblyWritesAndReopens(t *testing.T) {
 	prefix := filepath.Join(t.TempDir(), "tinycar")
-	build := doc.NewWorkspace(persistence.NewPackageStore())
+	build := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
 	root, _, err := benchgen.Generate(build, prefix, cliTinyProfile())
 	if err != nil {
 		t.Fatalf("Generate: %v", err)
@@ -43,7 +44,7 @@ func TestGenerateAssemblyWritesAndReopens(t *testing.T) {
 	// does — resolving the assembly's references to its part/sub-assembly files and
 	// recomputing geometry, proving the fixture is loadable (not just generated).
 	rootPath := root.FullFileName()
-	ws := doc.NewWorkspace(persistence.NewPackageStore())
+	ws := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
 	reopened, err := ws.Open(rootPath, false)
 	if err != nil {
 		t.Fatalf("reopen %q: %v", rootPath, err)

--- a/cmd/oblikovati-cli/cmd_import.go
+++ b/cmd/oblikovati-cli/cmd_import.go
@@ -8,6 +8,7 @@ import (
 
 	"oblikovati.org/api/types"
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/model/exchange"
 	"oblikovati.org/persistence"
@@ -28,7 +29,7 @@ func cmdImport(args []string, out io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("import: %w", err)
 	}
-	ws := doc.NewWorkspace(persistence.NewPackageStore())
+	ws := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
 	d, err := compdef.AddPart(ws, dst, true)
 	if err != nil {
 		return fmt.Errorf("import: %w", err)

--- a/cmd/oblikovati-cli/cmd_inspect.go
+++ b/cmd/oblikovati-cli/cmd_inspect.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"strings"
 
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/persistence"
 )
@@ -21,7 +22,7 @@ func cmdOpen(args []string, out io.Writer) error {
 		return fmt.Errorf("open: expected <path>, got %d arg(s)", len(args))
 	}
 	path := args[0]
-	ws := doc.NewWorkspace(persistence.NewPackageStore())
+	ws := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
 	d, err := ws.Open(path, true)
 	if err != nil {
 		return fmt.Errorf("open: %w", err)

--- a/cmd/oblikovati-cli/cmd_new.go
+++ b/cmd/oblikovati-cli/cmd_new.go
@@ -12,6 +12,7 @@ import (
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/sketch"
@@ -38,7 +39,7 @@ func cmdNew(args []string, out io.Writer) error {
 		return fmt.Errorf(errNew, err)
 	}
 	path := withDocExt(operands[1], t)
-	ws := doc.NewWorkspace(persistence.NewPackageStore())
+	ws := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
 	d, err := createDocument(ws, t, path, *seed, out)
 	if err != nil {
 		return err

--- a/cmd/oblikovati-cli/cmd_new_error_test.go
+++ b/cmd/oblikovati-cli/cmd_new_error_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"testing"
 
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/persistence"
 )
@@ -13,7 +14,7 @@ import (
 // TestCreateDocumentWrapsAddFailure covers the "new: %w" wraps: re-adding a document at a path
 // already taken fails, and createDocument wraps that error for both the part and non-part paths.
 func TestCreateDocumentWrapsAddFailure(t *testing.T) {
-	ws := doc.NewWorkspace(persistence.NewPackageStore())
+	ws := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
 	part, _ := doc.ParseDocumentType("part")
 	asm, _ := doc.ParseDocumentType("assembly")
 

--- a/cmd/oblikovati-cli/cmd_saveas.go
+++ b/cmd/oblikovati-cli/cmd_saveas.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/persistence"
 )
@@ -18,7 +19,7 @@ func cmdSaveAs(args []string, out io.Writer) error {
 	if len(args) != 2 {
 		return fmt.Errorf("save-as: expected <src> <dst>, got %d arg(s)", len(args))
 	}
-	ws := doc.NewWorkspace(persistence.NewPackageStore())
+	ws := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
 	d, err := ws.Open(args[0], true)
 	if err != nil {
 		return fmt.Errorf("save-as: open %q: %w", args[0], err)

--- a/command/transaction_test.go
+++ b/command/transaction_test.go
@@ -6,12 +6,13 @@ import (
 	"errors"
 	"testing"
 
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
 )
 
 func newPart(t *testing.T) *doc.Document {
 	t.Helper()
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, contentset.Default())
 	d, err := ws.Add(doc.Part, "p.obk", true)
 	if err != nil {
 		t.Fatalf("Add: %v", err)

--- a/model/benchgen/benchgen_test.go
+++ b/model/benchgen/benchgen_test.go
@@ -7,6 +7,7 @@ import (
 
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/persistence"
 )
@@ -27,7 +28,7 @@ func tinyProfile() Profile {
 }
 
 func newMemWorkspace() *doc.Workspace {
-	return doc.NewWorkspace(persistence.NewPackageStore())
+	return doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
 }
 
 func TestGenerateRealizesTierCounts(t *testing.T) {

--- a/model/benchgen/generate.go
+++ b/model/benchgen/generate.go
@@ -30,7 +30,7 @@ type Stats struct {
 // sub-assembly is a registered document placed by file reference, so the result both
 // drives the in-memory benchmarks and saves to a loadable .obk set. Example:
 //
-//	ws := doc.NewWorkspace(persistence.NewPackageStore())
+//	ws := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
 //	root, stats, err := benchgen.Generate(ws, "car30k", benchgen.Auto30k())
 func Generate(ws *doc.Workspace, dirPrefix string, p Profile) (*doc.Document, Stats, error) {
 	b, err := newBuilder(ws, dirPrefix, p)

--- a/model/compdef/addpart_test.go
+++ b/model/compdef/addpart_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAddPartInstallsRealizedContentAndActivates(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, testContentFactories())
 	d, err := AddPart(ws, "bracket.obk", true)
 	if err != nil {
 		t.Fatalf("AddPart: %v", err)
@@ -26,7 +26,7 @@ func TestAddPartInstallsRealizedContentAndActivates(t *testing.T) {
 }
 
 func TestAddPartDuplicateNameErrors(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, testContentFactories())
 	if _, err := AddPart(ws, "dup.obk", true); err != nil {
 		t.Fatalf("first AddPart: %v", err)
 	}

--- a/model/compdef/assembly.go
+++ b/model/compdef/assembly.go
@@ -94,14 +94,11 @@ var (
 	_ doc.ReferenceResolver = (*AssemblyComponentDefinition)(nil)
 )
 
-// init registers the real assembly content with the document layer so opening or
-// creating an assembly document yields a live AssemblyComponentDefinition, not the
-// identity-only stub (see doc.RegisterContentFactory). Its recipe (assembly_serialize.go)
-// restores the occurrence structure; the component documents those occurrences instance
-// are resolved through the reference graph after the assembly is registered (#715).
-func init() {
-	doc.RegisterContentFactory(doc.Assembly, func() doc.Content { return NewAssemblyComponentDefinition() })
-}
+// The real assembly content reaches the document layer through the composition
+// root (model/contentset.Default → doc.NewWorkspace, #1617). Its recipe
+// (assembly_serialize.go) restores the occurrence structure; the component
+// documents those occurrences instance are resolved through the reference graph
+// after the assembly is registered (#715).
 
 // AddAssembly creates a new assembly document in ws with a realized assembly
 // component definition installed (not the bare doc-package placeholder), makes it

--- a/model/compdef/assembly_derive_bench_test.go
+++ b/model/compdef/assembly_derive_bench_test.go
@@ -7,6 +7,7 @@ import (
 
 	"oblikovati.org/model/benchgen"
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/persistence"
 )
@@ -17,7 +18,7 @@ import (
 // top-level subtrees across workers (~1.8× faster wall time at 30k). allocs/op is the
 // GC-pressure signal the trim targets.
 func BenchmarkCollectPlacedBodies(b *testing.B) {
-	ws := doc.NewWorkspace(persistence.NewPackageStore())
+	ws := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
 	root, stats, err := benchgen.Generate(ws, "bench", benchgen.Auto30k())
 	if err != nil {
 		b.Fatal(err)

--- a/model/compdef/assembly_serialize_test.go
+++ b/model/compdef/assembly_serialize_test.go
@@ -9,6 +9,7 @@ import (
 
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/model/occurrence"
 	"oblikovati.org/persistence"
@@ -19,7 +20,7 @@ import (
 func assemblyWorkspace(t *testing.T) (*persistence.PackageStore, *doc.Workspace, string) {
 	t.Helper()
 	store := persistence.NewPackageStore()
-	return store, doc.NewWorkspace(store), t.TempDir()
+	return store, doc.NewWorkspace(store, contentset.Default()), t.TempDir()
 }
 
 // newAssembly adds and returns an assembly document and its definition at name in dir.
@@ -85,7 +86,7 @@ func reopenAssembly(t *testing.T, store *persistence.PackageStore, ws *doc.Works
 // reference-resolution path) and returns its assembly definition.
 func openAssembly(t *testing.T, store *persistence.PackageStore, name string) *compdef.AssemblyComponentDefinition {
 	t.Helper()
-	reopened, err := doc.NewWorkspace(store).Open(name, true)
+	reopened, err := doc.NewWorkspace(store, contentset.Default()).Open(name, true)
 	if err != nil {
 		t.Fatalf("Open assembly %q: %v", name, err)
 	}

--- a/model/compdef/assembly_test.go
+++ b/model/compdef/assembly_test.go
@@ -51,7 +51,7 @@ func TestAssemblyRangeBoxUnionsOccurrencesAndVersionTracks(t *testing.T) {
 }
 
 func TestAddAssemblyInstallsAssemblyContentAndActivates(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, testContentFactories())
 	d, err := AddAssembly(ws, "frame.oad", true)
 	if err != nil {
 		t.Fatalf("AddAssembly: %v", err)
@@ -68,7 +68,7 @@ func TestAddAssemblyInstallsAssemblyContentAndActivates(t *testing.T) {
 // plain ws.Add(Assembly) (the path documents.create and the CLI use) yields the real
 // content, not the identity-only doc stub.
 func TestAssemblyFactoryRegisteredForWorkspaceAdd(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, testContentFactories())
 	d, err := ws.Add(doc.Assembly, "sub.oad", true)
 	if err != nil {
 		t.Fatalf("ws.Add(assembly): %v", err)
@@ -82,7 +82,7 @@ func TestAssemblyFactoryRegisteredForWorkspaceAdd(t *testing.T) {
 // document level: two placements of one part document share its definition (the
 // flyweight), so editing the part would update both.
 func TestPlaceComponentSharesDefinitionAcrossPlacements(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, testContentFactories())
 	partDoc, err := AddPart(ws, "pin.opd", true)
 	if err != nil {
 		t.Fatalf("AddPart: %v", err)
@@ -105,7 +105,7 @@ func TestPlaceComponentSharesDefinitionAcrossPlacements(t *testing.T) {
 }
 
 func TestPlaceComponentRejectsNonComponentDocument(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, testContentFactories())
 	drawingDoc, err := ws.Add(doc.Drawing, "sheet.odd", true) // drawing content has no range box
 	if err != nil {
 		t.Fatalf("ws.Add(drawing): %v", err)
@@ -118,7 +118,7 @@ func TestPlaceComponentRejectsNonComponentDocument(t *testing.T) {
 // TestNestedAssemblyResolvableByPath is the PBI-119 acceptance with real definitions:
 // a sub-assembly placed in a parent assembly has its nested part addressable by path.
 func TestNestedAssemblyResolvableByPath(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, testContentFactories())
 	pinDoc, err := AddPart(ws, "pin.opd", true)
 	if err != nil {
 		t.Fatalf("AddPart: %v", err)

--- a/model/compdef/content_factories_for_test.go
+++ b/model/compdef/content_factories_for_test.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import "oblikovati.org/model/doc"
+
+// testContentFactories mirrors model/contentset.Default for this package's tests —
+// compdef cannot import contentset (it imports compdef back); the workspace gets the
+// same live part/assembly content the composition root wires (#1617). Drawing content
+// stays stubbed: these tests never open drawings.
+func testContentFactories() doc.ContentFactories {
+	return doc.ContentFactories{
+		doc.Part:     func() doc.Content { return NewPartComponentDefinition() },
+		doc.Assembly: func() doc.Content { return NewAssemblyComponentDefinition() },
+	}
+}

--- a/model/compdef/derived_persistence_test.go
+++ b/model/compdef/derived_persistence_test.go
@@ -9,6 +9,7 @@ import (
 
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/persistence"
@@ -33,7 +34,7 @@ func deriveSourceIntoPart(t *testing.T, ws *doc.Workspace, dir, name string, sou
 // reference-resolution path) and returns its part definition.
 func openPart(t *testing.T, store *persistence.PackageStore, name string) *compdef.PartComponentDefinition {
 	t.Helper()
-	reopened, err := doc.NewWorkspace(store).Open(name, true)
+	reopened, err := doc.NewWorkspace(store, contentset.Default()).Open(name, true)
 	if err != nil {
 		t.Fatalf("Open part %q: %v", name, err)
 	}

--- a/model/compdef/part_test.go
+++ b/model/compdef/part_test.go
@@ -35,7 +35,7 @@ func TestPartDocumentExposesBodiesAndBoundingBox(t *testing.T) {
 	def.SurfaceBodies().Add(bodyWithCorner(4, 3, 2))
 
 	// Wire the real content onto a part document (M03) and retrieve it back.
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, testContentFactories())
 	pd, _ := ws.Add(doc.Part, "bracket.obk", true)
 	pd.SetContent(def)
 

--- a/model/compdef/relocate_test.go
+++ b/model/compdef/relocate_test.go
@@ -9,6 +9,7 @@ import (
 
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/persistence"
 )
@@ -42,7 +43,7 @@ func TestAssemblyReopensAfterTreeMove(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(src, "parts"), 0o755); err != nil {
 		t.Fatalf("mkdir parts: %v", err)
 	}
-	ws := doc.NewWorkspace(store)
+	ws := doc.NewWorkspace(store, contentset.Default())
 	widget := savePartDoc(t, ws, filepath.Join(src, "parts"), "widget.obk")
 	asm, asmDef := newAssembly(t, ws, src, "asm.obk")
 	placeFromFile(t, asm, widget, asmDef, "widget:1", math.Identity4())

--- a/model/compdef/serialize.go
+++ b/model/compdef/serialize.go
@@ -18,12 +18,10 @@ import (
 	"oblikovati.org/persistence/yamlcodec"
 )
 
-// init registers the real part content with the document layer so opening a part
-// document reconstructs a live PartComponentDefinition (with its recipe machinery),
-// not the identity-only stub (see doc.RegisterContentFactory).
-func init() {
-	doc.RegisterContentFactory(doc.Part, func() doc.Content { return NewPartComponentDefinition() })
-}
+// The real part content reaches the document layer through the composition root
+// (model/contentset.Default → doc.NewWorkspace), not init()-time registration
+// (#1617): opening a part document reconstructs a live PartComponentDefinition
+// because the workspace was CONSTRUCTED with that factory.
 
 // var assertion: a part definition is recipe-bearing content (doc.RecipeContent), so
 // the store persists and restores its model on save/open.

--- a/model/compdef/serialize_test.go
+++ b/model/compdef/serialize_test.go
@@ -13,6 +13,7 @@ import (
 
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/param"
@@ -26,7 +27,7 @@ func reopenThroughStore(t *testing.T, d *doc.Document) *compdef.PartComponentDef
 	t.Helper()
 	store := persistence.NewPackageStore()
 	path := filepath.Join(t.TempDir(), "part.obk")
-	saveWS := doc.NewWorkspace(store)
+	saveWS := doc.NewWorkspace(store, contentset.Default())
 	// Re-register d under the store-backed workspace identity, then save.
 	saved, err := compdef.AddPart(saveWS, path, true)
 	if err != nil {
@@ -45,7 +46,7 @@ func reopenThroughStore(t *testing.T, d *doc.Document) *compdef.PartComponentDef
 		t.Fatalf("Save: %v", err)
 	}
 
-	reopened, err := doc.NewWorkspace(store).Open(path, true)
+	reopened, err := doc.NewWorkspace(store, contentset.Default()).Open(path, true)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -62,7 +63,7 @@ func reopenThroughStore(t *testing.T, d *doc.Document) *compdef.PartComponentDef
 // constraint is enforced — the two points, authored apart, coincide after reopen. That proves
 // the constraint survives BOTH as data (count) and functionally (it moves geometry on solve).
 func TestSketch3DSurvivesRoundTrip(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, contentset.Default())
 	d, err := compdef.AddPart(ws, "Part1", true)
 	if err != nil {
 		t.Fatalf("AddPart: %v", err)
@@ -98,7 +99,7 @@ func TestSketch3DSurvivesRoundTrip(t *testing.T) {
 }
 
 func TestParametersSurviveRoundTrip(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, contentset.Default())
 	d, err := compdef.AddPart(ws, "Part1", true)
 	if err != nil {
 		t.Fatalf("AddPart: %v", err)
@@ -133,7 +134,7 @@ func TestParametersSurviveRoundTrip(t *testing.T) {
 // is for loading onto a fresh part — so undo would otherwise duplicate sketches and
 // re-add parameters.)
 func TestRestoreSnapshotReplacesRatherThanMerges(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, contentset.Default())
 	d, err := compdef.AddPart(ws, "Part1", true)
 	if err != nil {
 		t.Fatalf("AddPart: %v", err)
@@ -180,7 +181,7 @@ func TestRestoreSnapshotReplacesRatherThanMerges(t *testing.T) {
 // TestParameterFieldsSurviveRoundTrip exercises the extended parameter recipe: text and
 // boolean parameters, comment/key/export/tolerance/multi-value state, and group membership.
 func TestParameterFieldsSurviveRoundTrip(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, contentset.Default())
 	d, _ := compdef.AddPart(ws, "Part1", true)
 	ps := d.Content().(*compdef.PartComponentDefinition).Parameters()
 
@@ -254,7 +255,7 @@ func TestParameterFieldsSurviveRoundTrip(t *testing.T) {
 // TestDerivedTableSurvivesRoundTrip checks a derived parameter table restores
 // with its id, source link, and produced parameters reconnected by name.
 func TestDerivedTableSurvivesRoundTrip(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, contentset.Default())
 	d, _ := compdef.AddPart(ws, "Part1", true)
 	ps := d.Content().(*compdef.PartComponentDefinition).Parameters()
 	src := []param.SourceParameterValue{{Name: "module", Value: param.Quantity{Value: 0.2, Unit: param.Length}}}
@@ -283,7 +284,7 @@ func TestDerivedTableSurvivesRoundTrip(t *testing.T) {
 }
 
 func TestSketchGeometrySurvivesRoundTrip(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, contentset.Default())
 	d, _ := compdef.AddPart(ws, "Part1", true)
 	def := d.Content().(*compdef.PartComponentDefinition)
 	sk := def.Sketches().Add(sketch.XYPlane())
@@ -306,7 +307,7 @@ func TestSketchGeometrySurvivesRoundTrip(t *testing.T) {
 }
 
 func TestExtrudedSolidSurvivesRoundTrip(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, contentset.Default())
 	d, _ := compdef.AddPart(ws, "Part1", true)
 	def := d.Content().(*compdef.PartComponentDefinition)
 	sk := def.Sketches().Add(sketch.XYPlane())
@@ -349,7 +350,7 @@ func rectangle(s *sketch.Sketch, w, h float64) {
 // global creation stamps that interleave sketches/work planes/features, and a sketch's
 // Shared flag, must round-trip so a reopened browser shows the same chronological tree.
 func TestCreationOrderAndSharedSurviveRoundTrip(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, contentset.Default())
 	d, _ := compdef.AddPart(ws, "Part1", true)
 	def := d.Content().(*compdef.PartComponentDefinition)
 
@@ -398,7 +399,7 @@ func strictlyAscending(seqs ...uint64) bool {
 }
 
 func TestFilletEdgeKeyRebindsAfterReopen(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, contentset.Default())
 	d, _ := compdef.AddPart(ws, "Part1", true)
 	def := d.Content().(*compdef.PartComponentDefinition)
 	sk := def.Sketches().Add(sketch.XYPlane())
@@ -440,7 +441,7 @@ func featureByKind(fs *feature.PartFeatures, kind string) (*feature.PartFeature,
 }
 
 func TestWorkFeaturesSurviveRoundTrip(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, contentset.Default())
 	d, _ := compdef.AddPart(ws, "Part1", true)
 	def := d.Content().(*compdef.PartComponentDefinition)
 	// A user work plane offset 5 above the origin XY plane (references the origin).
@@ -468,7 +469,7 @@ func TestWorkFeaturesSurviveRoundTrip(t *testing.T) {
 // value; the serializer must persist the EFFECTIVE distance, and the reopened plane must sit
 // at the edited offset.
 func TestEditedWorkPlaneScalarSurvivesRoundTrip(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, contentset.Default())
 	d, _ := compdef.AddPart(ws, "Part1", true)
 	def := d.Content().(*compdef.PartComponentDefinition)
 	wp := def.WorkPlanes().AddByPlaneAndOffset(feature.OriginXYPlane, func() float64 { return 2 })
@@ -491,7 +492,7 @@ func TestEditedWorkPlaneScalarSurvivesRoundTrip(t *testing.T) {
 // added to a reopened document must sort after every restored node, or the browser timeline
 // would interleave new work into the middle of the restored history.
 func TestNodesCreatedAfterReopenSortLast(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, contentset.Default())
 	d, _ := compdef.AddPart(ws, "Part1", true)
 	def := d.Content().(*compdef.PartComponentDefinition)
 	sk1 := def.Sketches().Add(sketch.XYPlane())
@@ -517,7 +518,7 @@ func TestNodesCreatedAfterReopenSortLast(t *testing.T) {
 }
 
 func TestRevolveAxisRebindsAfterReopen(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, contentset.Default())
 	d, _ := compdef.AddPart(ws, "Part1", true)
 	def := d.Content().(*compdef.PartComponentDefinition)
 	sk := def.Sketches().Add(sketch.XYPlane())
@@ -538,7 +539,7 @@ func TestRevolveAxisRebindsAfterReopen(t *testing.T) {
 }
 
 func TestLengthUnitSurvivesRoundTrip(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, contentset.Default())
 	d, _ := compdef.AddPart(ws, "Part1", true)
 	def := d.Content().(*compdef.PartComponentDefinition)
 	if err := def.SetLengthUnit("in"); err != nil {
@@ -554,7 +555,7 @@ func TestLengthUnitSurvivesRoundTrip(t *testing.T) {
 // TestUnitsPrecisionAndFormatSurviveRoundTrip persists the display precision and
 // the length/angle formats (the #146 additions) and restores them.
 func TestUnitsPrecisionAndFormatSurviveRoundTrip(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, contentset.Default())
 	d, _ := compdef.AddPart(ws, "Part1", true)
 	def := d.Content().(*compdef.PartComponentDefinition)
 
@@ -584,7 +585,7 @@ func TestUnitsPrecisionAndFormatSurviveRoundTrip(t *testing.T) {
 // TestRevolveTwoDirectionalSurvivesReopen: the second-direction sweep (#313)
 // persists and the restored revolve rebuilds the same straddling solid.
 func TestRevolveTwoDirectionalSurvivesReopen(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, contentset.Default())
 	d, _ := compdef.AddPart(ws, "Part1", true)
 	def := d.Content().(*compdef.PartComponentDefinition)
 	sk := def.Sketches().Add(sketch.XYPlane())
@@ -626,7 +627,7 @@ func offsetRect(sk *sketch.Sketch, x0, side float64) {
 // twist stations, rail, scaling, orientation) persist and the restored sweep
 // rebuilds the same solid.
 func TestSweepUnionSurvivesReopen(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, contentset.Default())
 	d, _ := compdef.AddPart(ws, "Part1", true)
 	def := d.Content().(*compdef.PartComponentDefinition)
 	sk := def.Sketches().Add(sketch.XYPlane())
@@ -683,7 +684,7 @@ func centeredRect(sk *sketch.Sketch, half float64) {
 // TestFilletEdgeSetsSurviveReopen: a mixed constant + variable edge-set fillet
 // (#323) reopens with its sets intact — same health, same volume.
 func TestFilletEdgeSetsSurviveReopen(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, contentset.Default())
 	d, _ := compdef.AddPart(ws, "Part1", true)
 	def := d.Content().(*compdef.PartComponentDefinition)
 	sk := def.Sketches().Add(sketch.XYPlane())

--- a/model/compdef/sketch_refkey_multidoc_test.go
+++ b/model/compdef/sketch_refkey_multidoc_test.go
@@ -8,6 +8,7 @@ import (
 
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/persistence"
 )
@@ -90,7 +91,7 @@ func editSketch(t *testing.T, part *compdef.PartComponentDefinition, a, b math.P
 // openPartDoc reopens a saved document from disk in a fresh workspace, returning doc + def.
 func openPartDoc(t *testing.T, store *persistence.PackageStore, path string) (*doc.Document, *compdef.PartComponentDefinition) {
 	t.Helper()
-	d, err := doc.NewWorkspace(store).Open(path, true)
+	d, err := doc.NewWorkspace(store, contentset.Default()).Open(path, true)
 	if err != nil {
 		t.Fatalf("Open %q: %v", path, err)
 	}

--- a/model/compdef/sketch_refkey_persistence_test.go
+++ b/model/compdef/sketch_refkey_persistence_test.go
@@ -8,6 +8,7 @@ import (
 
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/model/identity"
 	"oblikovati.org/model/sketch"
@@ -76,7 +77,7 @@ func TestSketchKeySurvivesRealFileRoundTrip(t *testing.T) {
 	}
 
 	// Reopen from disk in a fresh workspace to force the on-disk load path.
-	reopenedDoc, err := doc.NewWorkspace(store).Open(path, true)
+	reopenedDoc, err := doc.NewWorkspace(store, contentset.Default()).Open(path, true)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}

--- a/model/compdef/snapshot_test.go
+++ b/model/compdef/snapshot_test.go
@@ -11,6 +11,7 @@ import (
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/sketch"
@@ -21,7 +22,7 @@ import (
 // fillet keyed on a real edge. Returns the document and its definition.
 func richPart(t *testing.T) (*doc.Document, *compdef.PartComponentDefinition) {
 	t.Helper()
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, contentset.Default())
 	d, err := compdef.AddPart(ws, "Part1", true)
 	if err != nil {
 		t.Fatalf("AddPart: %v", err)
@@ -119,7 +120,7 @@ func TestPartSnapshotRestoreReplacesOtherPart(t *testing.T) {
 	}
 
 	// A second, differently-populated part.
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, contentset.Default())
 	d2, _ := compdef.AddPart(ws, "Part2", true)
 	dst := d2.Content().(*compdef.PartComponentDefinition)
 	dst.Sketches().Add(sketch.XYPlane())
@@ -142,7 +143,7 @@ func TestPartSnapshotRestoreReplacesOtherPart(t *testing.T) {
 // TestEmptyPartSnapshotRoundTrips: an empty part snapshots and restores without error, staying
 // empty — the baseline a document's undo stream captures the moment it opens.
 func TestEmptyPartSnapshotRoundTrips(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, contentset.Default())
 	d, _ := compdef.AddPart(ws, "Empty", true)
 	def := d.Content().(*compdef.PartComponentDefinition)
 	snap, err := def.MarshalSnapshot()
@@ -161,7 +162,7 @@ func TestEmptyPartSnapshotRoundTrips(t *testing.T) {
 // byte-stable across a full round-trip — there is no float drift to mask, so restoring then
 // re-marshalling must reproduce the exact snapshot. Pins that the codec itself loses nothing.
 func TestParamsOnlySnapshotByteStable(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, contentset.Default())
 	d, _ := compdef.AddPart(ws, "Params", true)
 	def := d.Content().(*compdef.PartComponentDefinition)
 	_, _ = def.Parameters().AddUserParameter("a", "10 mm")
@@ -184,7 +185,7 @@ func TestParamsOnlySnapshotByteStable(t *testing.T) {
 // the part is untouched) and structurally-valid JSON carrying bad content (an unparseable
 // parameter expression or an unknown unit). Covers the restore-error paths for part + assembly.
 func TestRestoreSnapshotRejectsBadSnapshots(t *testing.T) {
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, contentset.Default())
 	d, _ := compdef.AddPart(ws, "Part1", true)
 	def := d.Content().(*compdef.PartComponentDefinition)
 	def.Sketches().Add(sketch.XYPlane())
@@ -293,7 +294,7 @@ func BenchmarkPartMarshalRecipe(b *testing.B) {
 // richPartB is richPart for a benchmark (testing.B has no *testing.T).
 func richPartB(b *testing.B) (*doc.Document, *compdef.PartComponentDefinition) {
 	b.Helper()
-	ws := doc.NewWorkspace(nil)
+	ws := doc.NewWorkspace(nil, contentset.Default())
 	d, err := compdef.AddPart(ws, "Part1", true)
 	if err != nil {
 		b.Fatalf("AddPart: %v", err)

--- a/model/contentset/contentset.go
+++ b/model/contentset/contentset.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package contentset assembles the default document-content factory set — the
+// composition-root wiring that pairs each document kind with its real content
+// constructor (#1617, audit B6). It exists as its own package because doc cannot
+// import the content packages (cycle) and because SEVERAL roots compose the model
+// directly (app.NewSession, the oblikovati-cli commands, benchgen): each passes
+// Default() to doc.NewWorkspace instead of relying on init()-time registration,
+// so which kinds open live is decided by explicit construction, not by a binary's
+// import list.
+package contentset
+
+import (
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/drawing"
+)
+
+// Default returns the full production content-factory set: parts and assemblies
+// open as live component definitions, drawings as live sheet content.
+//
+//	ws := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
+func Default() doc.ContentFactories {
+	return doc.ContentFactories{
+		doc.Part:     func() doc.Content { return compdef.NewPartComponentDefinition() },
+		doc.Assembly: func() doc.Content { return compdef.NewAssemblyComponentDefinition() },
+		doc.Drawing:  func() doc.Content { return drawing.NewContent() },
+	}
+}

--- a/model/doc/attachments_test.go
+++ b/model/doc/attachments_test.go
@@ -46,7 +46,7 @@ func (f *fakeExternalFiles) ReadFile(name string) ([]byte, error) {
 // filesystem holding loads.csv.
 func attachmentFixture(t *testing.T) (*Document, *fakeExternalFiles, time.Time) {
 	t.Helper()
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	ext := newFakeExternalFiles()
 	ws.SetExternalFileProbe(ext)
 	attached := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)

--- a/model/doc/changemanager_test.go
+++ b/model/doc/changemanager_test.go
@@ -21,7 +21,7 @@ func (p *recordingProcessor) ProcessChange(e ModelChanged) error {
 }
 
 func TestRegisteredProcessorInvokedOnModelChange(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	cm := NewChangeManager(ws.Events())
 	defer cm.Close()
 	proc := &recordingProcessor{name: "bom"}
@@ -49,7 +49,7 @@ func TestRegisteredProcessorInvokedOnModelChange(t *testing.T) {
 }
 
 func TestProcessControlEnableDisable(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	cm := NewChangeManager(ws.Events())
 	proc := &recordingProcessor{name: "p"}
 	reg := cm.Register(proc)
@@ -83,7 +83,7 @@ func TestProcessControlEnableDisable(t *testing.T) {
 }
 
 func TestModelChangeCanBeVetoed(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	cm := NewChangeManager(ws.Events())
 	proc := &recordingProcessor{name: "p"}
 	cm.Register(proc)

--- a/model/doc/content.go
+++ b/model/doc/content.go
@@ -31,20 +31,15 @@ type RecipeContent interface {
 	ApplyRecipe(model []byte) error
 }
 
-// contentFactories holds the constructor for each document kind's REAL content,
-// registered by the owning package's init (e.g. model/compdef). It is the seam that
-// lets [Restore] rebuild live content — with its recipe machinery — without doc
-// importing the heavy model packages (which would cycle). Writes happen at init
-// (single-threaded); reads happen later.
-var contentFactories = map[DocumentType]func() Content{}
-
-// RegisterContentFactory installs the constructor for a kind's real content. Call it
-// from an init() in the package that owns the content type, so any binary that imports
-// that package gets live content on open. Without a registered factory, [newContent]
-// falls back to the identity-only stub.
-func RegisterContentFactory(t DocumentType, factory func() Content) {
-	contentFactories[t] = factory
-}
+// ContentFactories maps each document kind to the constructor of its REAL content.
+// It is the port that lets [Restore] rebuild live content — with its recipe
+// machinery — without doc importing the heavy model packages (which would cycle).
+// The set is assembled at the composition root (model/contentset.Default, passed to
+// [NewWorkspace]) instead of by init()-time registration, so which kinds open live
+// is decided by explicit construction, not by a binary's import list (#1617, audit
+// B6 — forgetting a blank import used to silently open documents as stubs).
+// Without a factory for a kind, [newContent] falls back to the identity-only stub.
+type ContentFactories map[DocumentType]func() Content
 
 // PartComponentDefinition is the stub for a part's modeling content: sketches,
 // features and the resulting B-rep body (M07). Modernizes COM

--- a/model/doc/content_injection_test.go
+++ b/model/doc/content_injection_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package doc
+
+import "testing"
+
+// fakeInjectedContent is a named fake content proving factory injection (#1617):
+// it can only reach a document through the ContentFactories the workspace was
+// constructed with — there is no global registry left to fall back to.
+type fakeInjectedContent struct{ marker string }
+
+func (*fakeInjectedContent) DocumentType() DocumentType { return Part }
+
+// TestWorkspaceBuildsContentFromInjectedFactories pins audit B6's seam: a
+// workspace constructed with a minimal one-entry factory set builds part
+// content through it, and a kind WITHOUT a factory falls back to the
+// identity-only stub — injection decides, not import linkage.
+func TestWorkspaceBuildsContentFromInjectedFactories(t *testing.T) {
+	ws := NewWorkspace(nil, ContentFactories{
+		Part: func() Content { return &fakeInjectedContent{marker: "injected"} },
+	})
+	d, err := ws.Add(Part, "injected.opd", false)
+	if err != nil {
+		t.Fatalf("Add(Part): %v", err)
+	}
+	got, ok := d.Content().(*fakeInjectedContent)
+	if !ok || got.marker != "injected" {
+		t.Fatalf("part content = %T, want the injected fake", d.Content())
+	}
+	drawing, err := ws.Add(Drawing, "stub.odd", false)
+	if err != nil {
+		t.Fatalf("Add(Drawing): %v", err)
+	}
+	if _, stub := drawing.Content().(*DrawingContent); !stub {
+		t.Fatalf("drawing content = %T, want the identity-only stub (no factory injected)", drawing.Content())
+	}
+}

--- a/model/doc/events_test.go
+++ b/model/doc/events_test.go
@@ -38,7 +38,7 @@ func TestVetoErrorMessage(t *testing.T) {
 
 func TestLifecycleFiresBeforeAndAfterEvents(t *testing.T) {
 	store := newFakeStore()
-	ws := NewWorkspace(store)
+	ws := NewWorkspace(store, nil)
 	var log []string
 	event.Subscribe(ws.Events(), event.After, func(_ event.Context, e DocumentCreated) event.Outcome {
 		log = append(log, "created:"+e.Document.DisplayName())
@@ -64,7 +64,7 @@ func TestLifecycleFiresBeforeAndAfterEvents(t *testing.T) {
 }
 
 func TestCloseCanBeVetoed(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	d, _ := ws.Add(Part, "p.obk", true)
 
 	sub := event.Subscribe(ws.Events(), event.Before, func(_ event.Context, e DocumentClose) event.Outcome {
@@ -97,7 +97,7 @@ func TestCloseCanBeVetoed(t *testing.T) {
 
 func TestSaveAndOpenCanBeVetoed(t *testing.T) {
 	store := newFakeStore()
-	ws := NewWorkspace(store)
+	ws := NewWorkspace(store, nil)
 	d, _ := ws.Add(Part, "p.obk", true)
 
 	saveSub := event.Subscribe(ws.Events(), event.Before, func(_ event.Context, _ DocumentSave) event.Outcome {
@@ -121,7 +121,7 @@ func TestSaveAndOpenCanBeVetoed(t *testing.T) {
 }
 
 func TestQuitVetoAndClose(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	_, _ = ws.Add(Part, "a.obk", true)
 	_, _ = ws.Add(Part, "b.obk", true)
 
@@ -148,7 +148,7 @@ func TestQuitVetoAndClose(t *testing.T) {
 }
 
 func TestDocumentActivateEventOnSetActive(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	a, _ := ws.Add(Part, "a.obk", true)
 	_, _ = ws.Add(Part, "b.obk", true)
 	activated := ""

--- a/model/doc/file_events_test.go
+++ b/model/doc/file_events_test.go
@@ -13,7 +13,7 @@ import (
 // case, M04-F05); the After phase reports the outcome to observers.
 func TestFileResolutionSuppliesSubstitutePath(t *testing.T) {
 	store := newFakeStore()
-	ws := NewWorkspace(store)
+	ws := NewWorkspace(store, nil)
 	moved, _ := ws.Add(Part, "/new/home/bracket.obk", true)
 	if err := ws.Save(moved); err != nil {
 		t.Fatalf("Save: %v", err)
@@ -49,7 +49,7 @@ func TestFileResolutionSuppliesSubstitutePath(t *testing.T) {
 // TestFileResolutionUnansweredStillFails: with no handler (or no answer) the
 // open fails with the original error and the After event reports no substitute.
 func TestFileResolutionUnansweredStillFails(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	var observed []FileResolution
 	event.Subscribe(ws.Events(), event.After, func(_ event.Context, e FileResolution) event.Outcome {
 		observed = append(observed, e)
@@ -79,7 +79,7 @@ func TestFileResolutionFirstAnswerSticks(t *testing.T) {
 // open/save announces; re-marking an already dirty document is silent.
 func TestFileDirtyFiresOnCleanToDirtyTransition(t *testing.T) {
 	store := newFakeStore()
-	ws := NewWorkspace(store)
+	ws := NewWorkspace(store, nil)
 	d, err := ws.Add(Part, "Part1", true)
 	if err != nil {
 		t.Fatalf("Add: %v", err)

--- a/model/doc/file_identity_test.go
+++ b/model/doc/file_identity_test.go
@@ -7,7 +7,7 @@ import "testing"
 // TestFileIdentityMintedAtCreation: every document file gets a unique GUID and
 // the creating software version from the moment it exists (M03-F07, #159).
 func TestFileIdentityMintedAtCreation(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	a, _ := ws.Add(Part, "a.obk", true)
 	b, _ := ws.Add(Part, "b.obk", true)
 	idA, idB := a.FileIdentity(), b.FileIdentity()
@@ -25,7 +25,7 @@ func TestFileIdentityMintedAtCreation(t *testing.T) {
 // TestSaveBumpsIdentity: a save advances the counter and re-mints the content
 // revision; the database revision re-mints only when the recipe changed.
 func TestSaveBumpsIdentity(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	d, _ := ws.Add(Part, "a.obk", true)
 	if err := ws.Save(d); err != nil {
 		t.Fatalf("Save: %v", err)
@@ -53,7 +53,7 @@ func TestSaveBumpsIdentity(t *testing.T) {
 // TestFailedSaveRollsIdentityBack: identity must never drift ahead of the
 // bytes on disk.
 func TestFailedSaveRollsIdentityBack(t *testing.T) {
-	ws := NewWorkspace(&failingStore{})
+	ws := NewWorkspace(&failingStore{}, nil)
 	d, _ := ws.Add(Part, "a.obk", true)
 	before := d.FileIdentity()
 	if err := ws.Save(d); err == nil {
@@ -71,7 +71,7 @@ func (s *failingStore) Save(*Document) error { return errNotStored{"write failed
 func (s *failingStore) SaveCopy(*Document, string, CopyMetadata) error {
 	return errNotStored{"write failed"}
 }
-func (s *failingStore) Load(name string) (*Document, error) {
+func (s *failingStore) Load(name string, factories ContentFactories) (*Document, error) {
 	return nil, errNotStored{name}
 }
 func (s *failingStore) Exists(string) bool { return false }

--- a/model/doc/file_reference_test.go
+++ b/model/doc/file_reference_test.go
@@ -12,7 +12,7 @@ import (
 // in the same tree — the canonical descriptor fixture.
 func referencingWorkspace(t *testing.T) (*Workspace, *Document, *Document) {
 	t.Helper()
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	part, _ := ws.Add(Part, "/asm/parts/pin.obk", true)
 	if err := ws.Save(part); err != nil {
 		t.Fatalf("Save part: %v", err)

--- a/model/doc/identity_collision_test.go
+++ b/model/doc/identity_collision_test.go
@@ -17,7 +17,7 @@ func TestOpenWithCollidingIdentityReassigns(t *testing.T) {
 	store := newFakeStore()
 	store.saved["original.opd"] = storedDoc{docType: Part, displayName: "original", internalName: sharedGUID}
 	store.saved["clone.opd"] = storedDoc{docType: Part, displayName: "clone", internalName: sharedGUID}
-	ws := NewWorkspace(store)
+	ws := NewWorkspace(store, nil)
 
 	var reassigned *DocumentIdentityReassigned
 	event.Subscribe(ws.Events(), event.After, func(_ event.Context, e DocumentIdentityReassigned) event.Outcome {
@@ -65,7 +65,7 @@ func TestClosingFreesIdentityForReopen(t *testing.T) {
 	const guid = "22222222-2222-4222-8222-222222222222"
 	store := newFakeStore()
 	store.saved["a.opd"] = storedDoc{docType: Part, displayName: "a", internalName: guid}
-	ws := NewWorkspace(store)
+	ws := NewWorkspace(store, nil)
 
 	d, err := ws.Open("a.opd", true)
 	if err != nil {

--- a/model/doc/interests_test.go
+++ b/model/doc/interests_test.go
@@ -11,7 +11,7 @@ import (
 // TestInterestRegistryRules: identity is (ClientID, Name); re-adding updates
 // in place; HasInterest matches either id or name; removal reports existence.
 func TestInterestRegistryRules(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	d, _ := ws.Add(Part, "bracket.obk", true)
 	d.ClearDirty()
 

--- a/model/doc/refgraph_test.go
+++ b/model/doc/refgraph_test.go
@@ -5,7 +5,7 @@ package doc
 import "testing"
 
 func TestAssemblyReportsPartsAndPartReportsAssembly(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	asm, _ := ws.Add(Assembly, "top.iam.obk", true)
 	p1, _ := ws.Add(Part, "a.obk", true)
 	p2, _ := ws.Add(Part, "b.obk", true)
@@ -31,7 +31,7 @@ func TestAssemblyReportsPartsAndPartReportsAssembly(t *testing.T) {
 }
 
 func TestBrokenReferenceFlaggedNotFatal(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	asm, _ := ws.Add(Assembly, "top.obk", true)
 	present, _ := ws.Add(Part, "here.obk", true)
 	_, _ = asm.AddReference("here.obk")
@@ -47,7 +47,7 @@ func TestBrokenReferenceFlaggedNotFatal(t *testing.T) {
 }
 
 func TestAllReferencedIsTransitive(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	top, _ := ws.Add(Assembly, "top.obk", true)
 	sub, _ := ws.Add(Assembly, "sub.obk", true)
 	leaf, _ := ws.Add(Part, "leaf.obk", true)
@@ -62,7 +62,7 @@ func TestAllReferencedIsTransitive(t *testing.T) {
 
 func TestReferencedDocumentLazyLoadsFromStore(t *testing.T) {
 	store := newFakeStore()
-	ws := NewWorkspace(store)
+	ws := NewWorkspace(store, nil)
 	part, _ := ws.Add(Part, "part.obk", true)
 	_ = ws.Save(part)
 	_ = ws.Close(part, true) // gone from the collection, still on disk
@@ -86,7 +86,7 @@ func TestReferencedDocumentLazyLoadsFromStore(t *testing.T) {
 }
 
 func TestRemoveReference(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	asm, _ := ws.Add(Assembly, "top.obk", true)
 	part, _ := ws.Add(Part, "p.obk", true)
 	_, _ = asm.AddReference("p.obk")
@@ -109,7 +109,7 @@ func TestRemoveReference(t *testing.T) {
 }
 
 func TestUnreferencedCloseKeepsReferencedPart(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	top, _ := ws.Add(Assembly, "top.obk", true)
 	_, _ = ws.Add(Part, "p.obk", true)
 	_, _ = top.AddReference("p.obk")
@@ -140,7 +140,7 @@ func TestStandaloneDocumentHasNoGraph(t *testing.T) {
 }
 
 func TestDocumentReferencesListsDescriptors(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	if ws.References() == nil {
 		t.Fatal("Workspace.References() is nil")
 	}
@@ -158,7 +158,7 @@ func TestDocumentReferencesListsDescriptors(t *testing.T) {
 }
 
 func TestDescriptorReferenceKey(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	asm, _ := ws.Add(Assembly, "top.obk", true)
 	desc, _ := asm.AddReference("p.obk")
 	if desc.ReferenceKey() != nil {

--- a/model/doc/store.go
+++ b/model/doc/store.go
@@ -21,8 +21,9 @@ type Store interface {
 	// NEW file: the implementation mints it a fresh identity ([CopyIdentity]).
 	SaveCopy(d *Document, targetFullFileName string, meta CopyMetadata) error
 	// Load reads the document at the given full document name and returns it open
-	// (content paged in). It returns an error if nothing is stored there.
-	Load(fullDocumentName string) (*Document, error)
+	// (content paged in), building live content through factories (#1617). It
+	// returns an error if nothing is stored there.
+	Load(fullDocumentName string, factories ContentFactories) (*Document, error)
 	// Exists reports whether a document is stored at the given full document name.
 	Exists(fullDocumentName string) bool
 }
@@ -37,12 +38,12 @@ type CopyMetadata struct {
 }
 
 // newContent builds the content object for a document kind. It prefers a real content
-// factory registered by the owning package (e.g. model/compdef via
-// [RegisterContentFactory]) so Load reconstructs live, recipe-bearing content; absent a
+// factory from the injected set (assembled at the composition root — see
+// [ContentFactories]) so Load reconstructs live, recipe-bearing content; absent a
 // factory it returns the identity-only stub. Save/Load and the create-from-template
 // path use it so a kind always pairs with matching content.
-func newContent(t DocumentType) (Content, error) {
-	if factory, ok := contentFactories[t]; ok {
+func newContent(t DocumentType, factories ContentFactories) (Content, error) {
+	if factory, ok := factories[t]; ok {
 		return factory(), nil
 	}
 	switch t {
@@ -60,11 +61,12 @@ func newContent(t DocumentType) (Content, error) {
 }
 
 // Restore reconstructs an open document from its persisted identity. A [Store]
-// implementation calls it after reading a package manifest; the session ID is
-// freshly minted because ids are not persisted (core/02). The kind must be a real
-// document type — Unknown and out-of-range values are rejected.
-func Restore(t DocumentType, fullDocumentName, displayName string) (*Document, error) {
-	content, err := newContent(t)
+// implementation calls it after reading a package manifest, forwarding the content
+// factories its Load was handed (#1617); the session ID is freshly minted because
+// ids are not persisted (core/02). The kind must be a real document type — Unknown
+// and out-of-range values are rejected.
+func Restore(t DocumentType, fullDocumentName, displayName string, factories ContentFactories) (*Document, error) {
+	content, err := newContent(t, factories)
 	if err != nil {
 		return nil, err
 	}

--- a/model/doc/workspace.go
+++ b/model/doc/workspace.go
@@ -26,14 +26,18 @@ type Workspace struct {
 	graph         *RefGraph            // shared document reference graph (M03-F04)
 	bus           *event.Bus           // application/document/modeling events (M04-F04)
 	externalFiles ExternalFileProbe    // foreign-file access for attachments (M03-F08)
+	factories     ContentFactories     // real-content constructors, injected at the composition root (#1617)
 	active        *Document
 }
 
-// NewWorkspace creates an empty workspace backed by store. A nil store is allowed
-// for purely in-memory sessions; Save/Open then return an error.
-func NewWorkspace(store Store) *Workspace {
+// NewWorkspace creates an empty workspace backed by store, building document
+// content through factories (the composition root passes model/contentset.Default;
+// nil yields identity-only stubs — #1617). A nil store is allowed for purely
+// in-memory sessions; Save/Open then return an error.
+func NewWorkspace(store Store, factories ContentFactories) *Workspace {
 	ws := &Workspace{
 		store:         store,
+		factories:     factories,
 		byID:          map[ID]*Document{},
 		byName:        map[string]*Document{},
 		byGUID:        map[string]*Document{},
@@ -78,7 +82,7 @@ func (ws *Workspace) Add(t DocumentType, fullDocumentName string, visible bool) 
 	if _, taken := ws.byName[fullDocumentName]; taken {
 		return nil, fmt.Errorf("doc: a document named %q is already open", fullDocumentName)
 	}
-	content, err := newContent(t)
+	content, err := newContent(t, ws.factories)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +161,7 @@ func (ws *Workspace) loadNew(fullDocumentName string, opts OpenOptions) (*Docume
 // load (a moved or renamed reference, M04-F05). The After phase reports the
 // outcome to passive observers whether or not anything resolved it.
 func (ws *Workspace) loadResolving(fullDocumentName string) (*Document, error) {
-	d, err := ws.store.Load(fullDocumentName)
+	d, err := ws.store.Load(fullDocumentName, ws.factories)
 	if err == nil {
 		return d, nil
 	}
@@ -165,7 +169,7 @@ func (ws *Workspace) loadResolving(fullDocumentName string) (*Document, error) {
 	event.Emit(ws.bus, event.Before, resolution)
 	defer event.Emit(ws.bus, event.After, resolution)
 	if substitute := resolution.Resolved(); substitute != "" {
-		if d, retryErr := ws.store.Load(substitute); retryErr == nil {
+		if d, retryErr := ws.store.Load(substitute, ws.factories); retryErr == nil {
 			return d, nil
 		}
 	}

--- a/model/doc/workspace_edge_test.go
+++ b/model/doc/workspace_edge_test.go
@@ -5,7 +5,7 @@ package doc
 import "testing"
 
 func TestTypedViewHelpers(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	part, _ := ws.Add(Part, "p.obk", true)
 	asm, _ := ws.Add(Assembly, "a.obk", true)
 	dwg, _ := ws.Add(Drawing, "d.obk", true)
@@ -39,7 +39,7 @@ func TestCompactedIsFalse(t *testing.T) {
 }
 
 func TestNilStoreErrorsOnSaveAndOpen(t *testing.T) {
-	ws := NewWorkspace(nil)
+	ws := NewWorkspace(nil, nil)
 	d, _ := ws.Add(Part, "p.obk", true)
 	if err := ws.Save(d); err == nil {
 		t.Error("Save with nil store did not error")
@@ -54,14 +54,14 @@ func TestNilStoreErrorsOnSaveAndOpen(t *testing.T) {
 }
 
 func TestOpenMissingDocumentErrors(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	if _, err := ws.Open("/nowhere.obk", true); err == nil {
 		t.Error("Open of an unstored document did not error")
 	}
 }
 
 func TestByIDAndSetActiveErrors(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	d, _ := ws.Add(Part, "p.obk", true)
 	if got, ok := ws.ByID(d.ID()); !ok || got != d {
 		t.Error("ByID did not return the document")
@@ -76,7 +76,7 @@ func TestByIDAndSetActiveErrors(t *testing.T) {
 }
 
 func TestSaveAsRejectsCollision(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	a, _ := ws.Add(Part, "a.obk", true)
 	_, _ = ws.Add(Part, "b.obk", true)
 	if err := ws.SaveAs(a, "b.obk"); err == nil {
@@ -89,10 +89,10 @@ func TestSaveAsRejectsCollision(t *testing.T) {
 }
 
 func TestNewContentRejectsUnknown(t *testing.T) {
-	if _, err := newContent(Unknown); err == nil {
-		t.Error("newContent(Unknown) did not error")
+	if _, err := newContent(Unknown, nil); err == nil {
+		t.Error("newContent(Unknown, nil) did not error")
 	}
-	if _, err := Restore(DocumentType(42), "x.obk", "x"); err == nil {
+	if _, err := Restore(DocumentType(42), "x.obk", "x", nil); err == nil {
 		t.Error("Restore with bad type did not error")
 	}
 }

--- a/model/doc/workspace_test.go
+++ b/model/doc/workspace_test.go
@@ -35,13 +35,13 @@ func (s *fakeStore) SaveCopy(d *Document, target string, meta CopyMetadata) erro
 	return nil
 }
 
-func (s *fakeStore) Load(fullDocumentName string) (*Document, error) {
+func (s *fakeStore) Load(fullDocumentName string, factories ContentFactories) (*Document, error) {
 	rec, ok := s.saved[fullDocumentName]
 	if !ok {
 		return nil, errNotStored{fullDocumentName}
 	}
 	s.loads++
-	d, err := Restore(rec.docType, fullDocumentName, rec.displayName)
+	d, err := Restore(rec.docType, fullDocumentName, rec.displayName, factories)
 	if err == nil && rec.internalName != "" {
 		d.SetFileIdentity(FileIdentity{InternalName: rec.internalName})
 	}
@@ -58,7 +58,7 @@ type errNotStored struct{ name string }
 func (e errNotStored) Error() string { return "no document stored at " + e.name }
 
 func TestAddCreatesFromTemplateAndAppears(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 
 	d, err := ws.Add(Part, "/proj/bracket.obk", true)
 	if err != nil {
@@ -82,7 +82,7 @@ func TestAddCreatesFromTemplateAndAppears(t *testing.T) {
 }
 
 func TestVisibleVsHiddenOpen(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	vis, _ := ws.Add(Part, "shown.obk", true)
 	hid, _ := ws.Add(Assembly, "hidden.obk", false)
 
@@ -99,7 +99,7 @@ func TestVisibleVsHiddenOpen(t *testing.T) {
 
 func TestDeferContentOpensStubWithoutLoad(t *testing.T) {
 	store := newFakeStore()
-	ws := NewWorkspace(store)
+	ws := NewWorkspace(store, nil)
 
 	stub, err := ws.OpenWithOptions("/lib/screw.obk", OpenOptions{DeferContent: true})
 	if err != nil {
@@ -118,7 +118,7 @@ func TestDeferContentOpensStubWithoutLoad(t *testing.T) {
 
 func TestSavedDocumentReopensIdentically(t *testing.T) {
 	store := newFakeStore()
-	ws := NewWorkspace(store)
+	ws := NewWorkspace(store, nil)
 	d, _ := ws.Add(Assembly, "/proj/top.obk", true)
 	d.SetDisplayName("Top Assembly")
 	if err := ws.Save(d); err != nil {
@@ -129,7 +129,7 @@ func TestSavedDocumentReopensIdentically(t *testing.T) {
 	}
 
 	// A fresh workspace forces the load path (not the already-open shortcut).
-	reopened, err := NewWorkspace(store).Open("/proj/top.obk", true)
+	reopened, err := NewWorkspace(store, nil).Open("/proj/top.obk", true)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestSavedDocumentReopensIdentically(t *testing.T) {
 
 func TestSaveAsRenamesAndPersists(t *testing.T) {
 	store := newFakeStore()
-	ws := NewWorkspace(store)
+	ws := NewWorkspace(store, nil)
 	d, _ := ws.Add(Part, "draft.obk", true)
 
 	if err := ws.SaveAs(d, "final.obk"); err != nil {
@@ -168,7 +168,7 @@ func TestSaveAsRenamesAndPersists(t *testing.T) {
 
 func TestOpenAlreadyOpenReturnsSameInstance(t *testing.T) {
 	store := newFakeStore()
-	ws := NewWorkspace(store)
+	ws := NewWorkspace(store, nil)
 	d, _ := ws.Add(Part, "p.obk", true)
 	_ = ws.Save(d)
 
@@ -186,7 +186,7 @@ func TestOpenAlreadyOpenReturnsSameInstance(t *testing.T) {
 
 func TestCloseSavesDirtyUnlessSkipped(t *testing.T) {
 	store := newFakeStore()
-	ws := NewWorkspace(store)
+	ws := NewWorkspace(store, nil)
 	d, _ := ws.Add(Part, "p.obk", true) // dirty
 
 	if err := ws.Close(d, false); err != nil { // should save on the way out
@@ -210,7 +210,7 @@ func TestCloseSavesDirtyUnlessSkipped(t *testing.T) {
 
 func TestCloseAllUnreferencedKeepsReferenced(t *testing.T) {
 	store := newFakeStore()
-	ws := NewWorkspace(store)
+	ws := NewWorkspace(store, nil)
 	top, _ := ws.Add(Assembly, "top.obk", true)
 	part, _ := ws.Add(Part, "part.obk", true)
 	part.acquireRef() // pretend top references part (graph lands in F04)
@@ -239,7 +239,7 @@ func TestCloseAllUnreferencedKeepsReferenced(t *testing.T) {
 }
 
 func TestActiveDocumentReassignedOnClose(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	a, _ := ws.Add(Part, "a.obk", true)
 	b, _ := ws.Add(Part, "b.obk", true)
 	if ws.ActiveDocument() != b {
@@ -259,7 +259,7 @@ func TestActiveDocumentReassignedOnClose(t *testing.T) {
 }
 
 func TestAddRejectsDuplicateNameAndBadType(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	if _, err := ws.Add(Part, "dup.obk", true); err != nil {
 		t.Fatalf("first Add: %v", err)
 	}
@@ -276,7 +276,7 @@ func TestAddRejectsDuplicateNameAndBadType(t *testing.T) {
 // stealing the active document, so placing a part never switches the tab away from the
 // assembly.
 func TestBackgroundOpenKeepsActiveAndHidden(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	asm, _ := ws.Add(Assembly, "asm.obk", true)
 	part, _ := ws.Add(Part, "part.obk", true) // stage in the store
 	if err := ws.Save(part); err != nil {
@@ -307,7 +307,7 @@ func TestBackgroundOpenKeepsActiveAndHidden(t *testing.T) {
 // TestBackgroundOpenOfOpenDocPreservesIt checks that re-placing a part the user already has
 // open in a tab does not hide it or steal focus.
 func TestBackgroundOpenOfOpenDocPreservesIt(t *testing.T) {
-	ws := NewWorkspace(newFakeStore())
+	ws := NewWorkspace(newFakeStore(), nil)
 	asm, _ := ws.Add(Assembly, "asm.obk", true)
 	part, _ := ws.Add(Part, "part.obk", true) // user has it open, visible, active
 	if _, err := ws.OpenWithOptions("part.obk", OpenOptions{Visible: false, Background: true}); err != nil {

--- a/model/drawing/content_factories_for_test.go
+++ b/model/drawing/content_factories_for_test.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package drawing
+
+import "oblikovati.org/model/doc"
+
+// testContentFactories mirrors model/contentset.Default for this package's tests —
+// drawing cannot import contentset (it imports drawing back). Part/assembly content
+// stays stubbed: these tests only exercise drawing recipes.
+func testContentFactories() doc.ContentFactories {
+	return doc.ContentFactories{
+		doc.Drawing: func() doc.Content { return NewContent() },
+	}
+}

--- a/model/drawing/persistence_test.go
+++ b/model/drawing/persistence_test.go
@@ -18,7 +18,7 @@ func TestDrawingSurvivesStoreRoundTrip(t *testing.T) {
 	store := persistence.NewPackageStore()
 	path := filepath.Join(t.TempDir(), "drawing.odd")
 
-	saveWS := doc.NewWorkspace(store)
+	saveWS := doc.NewWorkspace(store, testContentFactories())
 	d, err := saveWS.Add(doc.Drawing, path, true)
 	if err != nil {
 		t.Fatalf("Add(Drawing): %v", err)
@@ -35,7 +35,7 @@ func TestDrawingSurvivesStoreRoundTrip(t *testing.T) {
 		t.Fatalf("Save: %v", err)
 	}
 
-	reopened, err := doc.NewWorkspace(store).Open(path, true)
+	reopened, err := doc.NewWorkspace(store, testContentFactories()).Open(path, true)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}

--- a/model/drawing/recipe.go
+++ b/model/drawing/recipe.go
@@ -13,12 +13,9 @@ import (
 	"oblikovati.org/persistence/yamlcodec"
 )
 
-// init registers the real drawing content with the document layer so opening a .odd
-// reconstructs live sheets (with the recipe machinery), not the identity-only stub
-// (see doc.RegisterContentFactory).
-func init() {
-	doc.RegisterContentFactory(doc.Drawing, func() doc.Content { return NewContent() })
-}
+// The real drawing content reaches the document layer through the composition
+// root (model/contentset.Default → doc.NewWorkspace), not init()-time
+// registration (#1617).
 
 // var assertion: a drawing's content is recipe-bearing (doc.RecipeContent), so the
 // store persists and restores its sheets on save/open.

--- a/model/exchange/resources_roundtrip_test.go
+++ b/model/exchange/resources_roundtrip_test.go
@@ -10,6 +10,7 @@ import (
 
 	"oblikovati.org/api/types"
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/persistence"
 )
@@ -24,7 +25,7 @@ func TestImportedDocumentReopensWithoutSourceFile(t *testing.T) {
 	obkPath := filepath.Join(dir, "part.obk")
 
 	store := persistence.NewPackageStore()
-	d, err := doc.NewWorkspace(store).Add(doc.Part, obkPath, true)
+	d, err := doc.NewWorkspace(store, contentset.Default()).Add(doc.Part, obkPath, true)
 	if err != nil {
 		t.Fatalf("Add: %v", err)
 	}
@@ -46,7 +47,7 @@ func TestImportedDocumentReopensWithoutSourceFile(t *testing.T) {
 		}
 	}
 
-	if err := doc.NewWorkspace(store).Save(d); err != nil {
+	if err := doc.NewWorkspace(store, contentset.Default()).Save(d); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
 	// The whole point: the source file is gone, yet the document still rebuilds.
@@ -54,7 +55,7 @@ func TestImportedDocumentReopensWithoutSourceFile(t *testing.T) {
 		t.Fatalf("remove source: %v", err)
 	}
 
-	reopened, err := doc.NewWorkspace(store).Open(obkPath, true)
+	reopened, err := doc.NewWorkspace(store, contentset.Default()).Open(obkPath, true)
 	if err != nil {
 		t.Fatalf("Open (source deleted): %v", err)
 	}

--- a/persistence/attachments_test.go
+++ b/persistence/attachments_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"oblikovati.org/api/types"
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
 )
 
@@ -43,7 +44,7 @@ func TestAttachmentsRoundTripThroughPackage(t *testing.T) {
 		mod:   time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC),
 	}
 
-	ws := doc.NewWorkspace(store)
+	ws := doc.NewWorkspace(store, contentset.Default())
 	ws.SetExternalFileProbe(ext)
 	d, err := ws.Add(doc.Part, path, true)
 	if err != nil {
@@ -59,7 +60,7 @@ func TestAttachmentsRoundTripThroughPackage(t *testing.T) {
 		t.Fatalf("Save: %v", err)
 	}
 
-	ws2 := doc.NewWorkspace(store)
+	ws2 := doc.NewWorkspace(store, contentset.Default())
 	ws2.SetExternalFileProbe(ext)
 	reopened, err := ws2.Open(path, true)
 	if err != nil {
@@ -88,7 +89,7 @@ func TestInterestsRoundTripThroughPackage(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "bracket.obk")
 	store := NewPackageStore()
-	ws := doc.NewWorkspace(store)
+	ws := doc.NewWorkspace(store, contentset.Default())
 	d, err := ws.Add(doc.Part, path, true)
 	if err != nil {
 		t.Fatalf("Add: %v", err)
@@ -102,7 +103,7 @@ func TestInterestsRoundTripThroughPackage(t *testing.T) {
 		t.Fatalf("Save: %v", err)
 	}
 
-	reopened, err := doc.NewWorkspace(store).Open(path, true)
+	reopened, err := doc.NewWorkspace(store, contentset.Default()).Open(path, true)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}

--- a/persistence/attributes_test.go
+++ b/persistence/attributes_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"oblikovati.org/model/attr"
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/model/identity"
 )
@@ -17,7 +18,7 @@ func TestAttributesRoundTripThroughPackage(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "tagged.obk")
 	store := NewPackageStore()
-	ws := doc.NewWorkspace(store)
+	ws := doc.NewWorkspace(store, contentset.Default())
 	d, err := ws.Add(doc.Part, path, true)
 	if err != nil {
 		t.Fatalf("Add: %v", err)
@@ -28,7 +29,7 @@ func TestAttributesRoundTripThroughPackage(t *testing.T) {
 		t.Fatalf("Save: %v", err)
 	}
 
-	reopened, err := doc.NewWorkspace(store).Open(path, true)
+	reopened, err := doc.NewWorkspace(store, contentset.Default()).Open(path, true)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -57,7 +58,7 @@ func TestUnannotatedDocumentWritesNoAttributes(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "plain.obk")
 	store := NewPackageStore()
-	ws := doc.NewWorkspace(store)
+	ws := doc.NewWorkspace(store, contentset.Default())
 	d, err := ws.Add(doc.Part, path, true)
 	if err != nil {
 		t.Fatalf("Add: %v", err)
@@ -65,7 +66,7 @@ func TestUnannotatedDocumentWritesNoAttributes(t *testing.T) {
 	if err := ws.Save(d); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	reopened, err := doc.NewWorkspace(store).Open(path, true)
+	reopened, err := doc.NewWorkspace(store, contentset.Default()).Open(path, true)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}

--- a/persistence/file_identity_test.go
+++ b/persistence/file_identity_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
 )
 
@@ -19,7 +20,7 @@ func TestFileIdentityRoundTripsThroughPackage(t *testing.T) {
 	path := filepath.Join(dir, "bracket.obk")
 	store := NewPackageStore()
 
-	ws := doc.NewWorkspace(store)
+	ws := doc.NewWorkspace(store, contentset.Default())
 	d, err := ws.Add(doc.Part, path, true)
 	if err != nil {
 		t.Fatalf("Add: %v", err)
@@ -37,7 +38,7 @@ func TestFileIdentityRoundTripsThroughPackage(t *testing.T) {
 		t.Errorf("the .obk must carry the identity block; got:\n%s", raw)
 	}
 
-	ws2 := doc.NewWorkspace(store)
+	ws2 := doc.NewWorkspace(store, contentset.Default())
 	reopened, err := ws2.Open(path, true)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
@@ -60,7 +61,7 @@ func TestFileIdentityRoundTripsThroughPackage(t *testing.T) {
 func TestFileReferencesRoundTripThroughPackage(t *testing.T) {
 	dir := t.TempDir()
 	store := NewPackageStore()
-	ws := doc.NewWorkspace(store)
+	ws := doc.NewWorkspace(store, contentset.Default())
 	part, err := ws.Add(doc.Part, filepath.Join(dir, "pin.obk"), true)
 	if err != nil {
 		t.Fatalf("Add part: %v", err)
@@ -79,7 +80,7 @@ func TestFileReferencesRoundTripThroughPackage(t *testing.T) {
 		t.Fatalf("Save owner: %v", err)
 	}
 
-	reopened, err := doc.NewWorkspace(store).Open(owner.FullFileName(), true)
+	reopened, err := doc.NewWorkspace(store, contentset.Default()).Open(owner.FullFileName(), true)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -103,7 +104,7 @@ func TestFileReferencesRoundTripThroughPackage(t *testing.T) {
 func TestResaveWithoutLiveEdgesKeepsReferenceRecords(t *testing.T) {
 	dir := t.TempDir()
 	store := NewPackageStore()
-	ws := doc.NewWorkspace(store)
+	ws := doc.NewWorkspace(store, contentset.Default())
 	part, _ := ws.Add(doc.Part, filepath.Join(dir, "pin.obk"), true)
 	if err := ws.Save(part); err != nil {
 		t.Fatalf("Save part: %v", err)
@@ -116,7 +117,7 @@ func TestResaveWithoutLiveEdgesKeepsReferenceRecords(t *testing.T) {
 		t.Fatalf("Save owner: %v", err)
 	}
 
-	ws2 := doc.NewWorkspace(store)
+	ws2 := doc.NewWorkspace(store, contentset.Default())
 	reopened, err := ws2.Open(owner.FullFileName(), true)
 	if err != nil {
 		t.Fatalf("Open: %v", err)

--- a/persistence/pointcloud_roundtrip_test.go
+++ b/persistence/pointcloud_roundtrip_test.go
@@ -8,6 +8,7 @@ import (
 
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/model/pointcloud"
 )
@@ -19,7 +20,7 @@ func TestPointCloudSurvivesStoreRoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "scan.obk")
 	store := NewPackageStore()
 
-	ws := doc.NewWorkspace(store)
+	ws := doc.NewWorkspace(store, contentset.Default())
 	d, err := compdef.AddPart(ws, path, true)
 	if err != nil {
 		t.Fatalf("AddPart: %v", err)
@@ -47,7 +48,7 @@ func TestPointCloudSurvivesStoreRoundTrip(t *testing.T) {
 		t.Fatalf("Save: %v", err)
 	}
 
-	reopened, err := doc.NewWorkspace(store).Open(path, true)
+	reopened, err := doc.NewWorkspace(store, contentset.Default()).Open(path, true)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}

--- a/persistence/save_copy_test.go
+++ b/persistence/save_copy_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
 )
 
@@ -16,7 +17,7 @@ import (
 func TestSaveCopyMintsAFreshFile(t *testing.T) {
 	dir := t.TempDir()
 	store := NewPackageStore()
-	ws := doc.NewWorkspace(store)
+	ws := doc.NewWorkspace(store, contentset.Default())
 	src, err := ws.Add(doc.Part, filepath.Join(dir, "bracket.obk"), true)
 	if err != nil {
 		t.Fatalf("Add: %v", err)
@@ -34,7 +35,7 @@ func TestSaveCopyMintsAFreshFile(t *testing.T) {
 		t.Error("the source must keep its binding and dirty state")
 	}
 
-	copyDoc, err := doc.NewWorkspace(store).Open(target, true)
+	copyDoc, err := doc.NewWorkspace(store, contentset.Default()).Open(target, true)
 	if err != nil {
 		t.Fatalf("Open copy: %v", err)
 	}
@@ -61,7 +62,7 @@ func TestSaveRetainsOldVersions(t *testing.T) {
 	dir := t.TempDir()
 	store := NewPackageStore()
 	store.SetOldVersionsToKeep(2)
-	ws := doc.NewWorkspace(store)
+	ws := doc.NewWorkspace(store, contentset.Default())
 	d, err := ws.Add(doc.Part, filepath.Join(dir, "bracket.obk"), true)
 	if err != nil {
 		t.Fatalf("Add: %v", err)

--- a/persistence/store.go
+++ b/persistence/store.go
@@ -115,7 +115,7 @@ func (s *PackageStore) buildPackage(d *doc.Document, displayName, subType string
 
 // Load opens the package at fullDocumentName, migrates it, and reconstructs the
 // document from its manifest.
-func (s *PackageStore) Load(fullDocumentName string) (*doc.Document, error) {
+func (s *PackageStore) Load(fullDocumentName string, factories doc.ContentFactories) (*doc.Document, error) {
 	pkg, err := OpenPackage(fullDocumentName)
 	if err != nil {
 		return nil, err
@@ -124,7 +124,7 @@ func (s *PackageStore) Load(fullDocumentName string) (*doc.Document, error) {
 	if err != nil {
 		return nil, fmt.Errorf(errLoad, fullDocumentName, err)
 	}
-	d, err := doc.Restore(doc.DocumentType(manifest.DocumentType), fullDocumentName, manifest.DisplayName)
+	d, err := doc.Restore(doc.DocumentType(manifest.DocumentType), fullDocumentName, manifest.DisplayName, factories)
 	if err != nil {
 		return nil, err
 	}

--- a/persistence/store_test.go
+++ b/persistence/store_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
 )
 
@@ -14,7 +15,7 @@ func TestWorkspaceRoundTripsThroughPackageStore(t *testing.T) {
 	path := filepath.Join(dir, "bracket.obk")
 	store := NewPackageStore()
 
-	ws := doc.NewWorkspace(store)
+	ws := doc.NewWorkspace(store, contentset.Default())
 	d, err := ws.Add(doc.Part, path, true)
 	if err != nil {
 		t.Fatalf("Add: %v", err)
@@ -28,7 +29,7 @@ func TestWorkspaceRoundTripsThroughPackageStore(t *testing.T) {
 	}
 
 	// Reopen in a fresh workspace to force the on-disk load path.
-	reopened, err := doc.NewWorkspace(store).Open(path, true)
+	reopened, err := doc.NewWorkspace(store, contentset.Default()).Open(path, true)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -50,7 +51,7 @@ func TestBodyNameSurvivesStoreRoundTrip(t *testing.T) {
 	path := filepath.Join(dir, "case.obk")
 	store := NewPackageStore()
 
-	ws := doc.NewWorkspace(store)
+	ws := doc.NewWorkspace(store, contentset.Default())
 	d, err := ws.Add(doc.Part, path, true)
 	if err != nil {
 		t.Fatalf("Add: %v", err)
@@ -60,7 +61,7 @@ func TestBodyNameSurvivesStoreRoundTrip(t *testing.T) {
 		t.Fatalf("Save: %v", err)
 	}
 
-	reopened, err := doc.NewWorkspace(store).Open(path, true)
+	reopened, err := doc.NewWorkspace(store, contentset.Default()).Open(path, true)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -92,7 +93,7 @@ func TestDerivedDisplayNameFollowsSaveAs(t *testing.T) {
 	src := filepath.Join(dir, "original.obk")
 	dst := filepath.Join(dir, "renamed.obk")
 
-	ws := doc.NewWorkspace(store)
+	ws := doc.NewWorkspace(store, contentset.Default())
 	d, err := ws.Add(doc.Part, src, true) // derived name "original", no override
 	if err != nil {
 		t.Fatalf("Add: %v", err)
@@ -101,7 +102,7 @@ func TestDerivedDisplayNameFollowsSaveAs(t *testing.T) {
 		t.Fatalf("Save: %v", err)
 	}
 
-	editing := doc.NewWorkspace(store)
+	editing := doc.NewWorkspace(store, contentset.Default())
 	reopened, err := editing.Open(src, true)
 	if err != nil {
 		t.Fatalf("Open: %v", err)
@@ -110,7 +111,7 @@ func TestDerivedDisplayNameFollowsSaveAs(t *testing.T) {
 		t.Fatalf("SaveAs: %v", err)
 	}
 
-	final, err := doc.NewWorkspace(store).Open(dst, true)
+	final, err := doc.NewWorkspace(store, contentset.Default()).Open(dst, true)
 	if err != nil {
 		t.Fatalf("Open renamed: %v", err)
 	}
@@ -125,7 +126,7 @@ func TestPackageStoreLoadRejectsNonPackage(t *testing.T) {
 	if err := WriteDataToFile(bogus, "client.bin", []byte("no manifest here")); err != nil {
 		t.Fatalf("seed bogus package: %v", err)
 	}
-	if _, err := NewPackageStore().Load(bogus); err == nil {
+	if _, err := NewPackageStore().Load(bogus, nil); err == nil {
 		t.Error("Load accepted a package with no manifest as a document")
 	}
 }


### PR DESCRIPTION
First slice of #1617 (audit B6) — the issue lands one registry per PR; this PR migrates the one with a REAL correctness hazard and establishes the CI guard.

## What

`doc.contentFactories` was populated by init() side effects in model/compdef and model/drawing: whether a document opened as live content or a silent identity-only stub depended on which packages a binary happened to import.

- **`doc.ContentFactories` is now a port**: passed to `doc.NewWorkspace`, threaded through `Store.Load` into `doc.Restore`. `RegisterContentFactory` and the three init() registrations are deleted.
- **`model/contentset` owns the default set**: doc cannot import the content packages (cycle), and several roots compose the model directly (app's `newSession`, every oblikovati-cli command, benchgen) — each passes `contentset.Default()` explicitly. Binaries' public entry points are unchanged (`app.NewSession()` keeps its signature).
- **Guards**: `TestWorkspaceBuildsContentFromInjectedFactories` proves a minimal one-entry injected set works and nothing falls back to a global (there is no global left). archguard `TestNoInitTimeRegistrations` (red-verified) bans init()-time registration repo-wide with a shrink-only allowlist naming the pending registries (feature codecs, feature editors, sketch codecs, head/ui dockable panels) — each next PR shrinks it.

Design per the architect consult: injection seams only at true variation points; app/cli/benchgen are the composition roots; the store receives factories through the Load call so binaries never learn about content types.

## Verification

- Full suite green (`go test -count=1 ./...`), golangci-lint 0 issues, head builds.
- **Live**: `mcplive -part entityseam` against this branch — real .obk save → force-close → reopen with entity census identical; a stub-open (missing factory) would have emptied the census.

Part of #1617 — remaining slices: feature codecs (2/4), feature editors (3/4), head/ui theme object (4/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)