### PR TITLE
Explicit construction for the feature-codec, feature-editor, dockable-panel and theme registries (B6, 2-4/4)

### DIFF
--- a/app/assembly_derive_commands_test.go
+++ b/app/assembly_derive_commands_test.go
@@ -113,7 +113,7 @@ func TestDerivedFeatureMenuHasUpdateAndBreakLink(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DeriveAssembly: %v", err)
 	}
-	labels := menuLabels(BrowserMenu(BrowserNode{Kind: "feature", Select: FeatureHandle{Feature: f}}))
+	labels := menuLabels(BrowserMenu(s, BrowserNode{Kind: "feature", Select: FeatureHandle{Feature: f}}))
 	joined := strings.Join(labels, "|")
 	if !strings.Contains(joined, "Update") || !strings.Contains(joined, "Break Link") {
 		t.Errorf("derive feature menu = %q, want Update + Break Link", joined)

--- a/app/assembly_feature_edit_test.go
+++ b/app/assembly_feature_edit_test.go
@@ -140,7 +140,7 @@ func TestAssemblyFeatureMenuAndDelete(t *testing.T) {
 	af := asm.Features().Item(0)
 	node := findBrowserNode(BuildBrowser(s), "assemblyFeature", af.Name())
 
-	if labels := strings.Join(menuLabels(BrowserMenu(*node)), "|"); labels != "Edit|Suppress|Delete" {
+	if labels := strings.Join(menuLabels(BrowserMenu(s, *node)), "|"); labels != "Edit|Suppress|Delete" {
 		t.Errorf("feature menu = %q, want Edit|Suppress|Delete", labels)
 	}
 	trackFromHere(s)

--- a/app/browser_menu.go
+++ b/app/browser_menu.go
@@ -19,8 +19,8 @@ type BrowserMenuItem struct {
 // BrowserMenu returns the context-menu entries for a node, keyed on its Kind. Folder and
 // other non-actionable nodes return nil (no menu). The entries close over the node's
 // concrete handle, so a wrong handle/kind pairing safely yields no menu.
-func BrowserMenu(n BrowserNode) []BrowserMenuItem {
-	if items := partNodeMenu(n); items != nil {
+func BrowserMenu(s *Session, n BrowserNode) []BrowserMenuItem {
+	if items := partNodeMenu(s, n); items != nil {
 		return items
 	}
 	if items := assemblyNodeMenu(n); items != nil {
@@ -50,12 +50,12 @@ func drawingViewMenu(sel Selectable) []BrowserMenuItem {
 }
 
 // partNodeMenu returns the menu for a part-document node kind, or nil.
-func partNodeMenu(n BrowserNode) []BrowserMenuItem {
+func partNodeMenu(s *Session, n BrowserNode) []BrowserMenuItem {
 	switch n.Kind {
 	case "sketch":
 		return sketchMenu(n.Select)
 	case "feature":
-		return featureMenu(n.Select)
+		return featureMenu(s, n.Select)
 	case "workplane":
 		return workPlaneMenu(n.Select)
 	case "workaxis":
@@ -231,7 +231,7 @@ func sketchMenu(sel Selectable) []BrowserMenuItem {
 // featureMenu offers Edit (opens the parameter editor, like double-click), a
 // Suppress/Unsuppress toggle (label reflects current state), and Delete. Edit is greyed for a
 // feature with no editable parameters (e.g. a mirror, which has only geometric references).
-func featureMenu(sel Selectable) []BrowserMenuItem {
+func featureMenu(s *Session, sel Selectable) []BrowserMenuItem {
 	h, ok := sel.(FeatureHandle)
 	if !ok {
 		return nil
@@ -241,7 +241,7 @@ func featureMenu(sel Selectable) []BrowserMenuItem {
 		suppressLabel = "Unsuppress"
 	}
 	items := []BrowserMenuItem{
-		{Label: "Edit", Enabled: FeatureIsEditable(h.Feature), Invoke: func(s *Session) error { s.BeginEditFeature(h); return nil }},
+		{Label: "Edit", Enabled: s.FeatureIsEditable(h.Feature), Invoke: func(s *Session) error { s.BeginEditFeature(h); return nil }},
 		{Label: suppressLabel, Enabled: true, Invoke: func(s *Session) error { return s.ToggleFeatureSuppressed(h.Feature) }},
 		{Label: "Delete", Enabled: true, Invoke: func(s *Session) error { return s.DeleteFeature(h.Feature) }},
 	}

--- a/app/browser_menu_test.go
+++ b/app/browser_menu_test.go
@@ -77,22 +77,22 @@ func TestBrowserMenuByKind(t *testing.T) {
 	s, _ := extrudedBoxPart(t)
 	root := BuildBrowser(s)
 
-	if labels := menuLabels(BrowserMenu(findNode(t, root, "sketch"))); !equalStrings(labels, []string{"Edit Sketch", "Share Sketch", "Visibility", "Delete"}) {
+	if labels := menuLabels(BrowserMenu(s, findNode(t, root, "sketch"))); !equalStrings(labels, []string{"Edit Sketch", "Share Sketch", "Visibility", "Delete"}) {
 		t.Errorf("sketch menu = %v", labels)
 	}
-	if labels := menuLabels(BrowserMenu(findNode(t, root, "feature"))); !equalStrings(labels, []string{"Edit", "Suppress", "Delete"}) {
+	if labels := menuLabels(BrowserMenu(s, findNode(t, root, "feature"))); !equalStrings(labels, []string{"Edit", "Suppress", "Delete"}) {
 		t.Errorf("feature menu = %v", labels)
 	}
-	if labels := menuLabels(BrowserMenu(findNode(t, root, "workplane"))); !equalStrings(labels, []string{"New Sketch", "Visibility"}) {
+	if labels := menuLabels(BrowserMenu(s, findNode(t, root, "workplane"))); !equalStrings(labels, []string{"New Sketch", "Visibility"}) {
 		t.Errorf("workplane menu = %v", labels)
 	}
-	if labels := menuLabels(BrowserMenu(findNode(t, root, "workaxis"))); !equalStrings(labels, []string{"Visibility"}) {
+	if labels := menuLabels(BrowserMenu(s, findNode(t, root, "workaxis"))); !equalStrings(labels, []string{"Visibility"}) {
 		t.Errorf("workaxis menu = %v", labels)
 	}
-	if labels := menuLabels(BrowserMenu(findNode(t, root, "body"))); !equalStrings(labels, []string{"Visibility"}) {
+	if labels := menuLabels(BrowserMenu(s, findNode(t, root, "body"))); !equalStrings(labels, []string{"Visibility"}) {
 		t.Errorf("body menu = %v", labels)
 	}
-	if m := BrowserMenu(findNode(t, root, "parameters")); m != nil {
+	if m := BrowserMenu(s, findNode(t, root, "parameters")); m != nil {
 		t.Errorf("parameters folder should have no menu, got %v", menuLabels(m))
 	}
 }
@@ -102,7 +102,7 @@ func TestBrowserMenuWorkAxisVisibilityToggles(t *testing.T) {
 	node := findNode(t, BuildBrowser(s), "workaxis")
 	axis := node.Select.(WorkAxisHandle).Axis
 	before := axis.Visible()
-	if err := menuItem(t, BrowserMenu(node), "Visibility").Invoke(s); err != nil {
+	if err := menuItem(t, BrowserMenu(s, node), "Visibility").Invoke(s); err != nil {
 		t.Fatalf("Visibility: %v", err)
 	}
 	if axis.Visible() == before {
@@ -117,7 +117,7 @@ func TestBrowserMenuBodyVisibilityToggles(t *testing.T) {
 	if !s.BodyVisible(body) {
 		t.Fatal("body should start visible")
 	}
-	if err := menuItem(t, BrowserMenu(node), "Visibility").Invoke(s); err != nil {
+	if err := menuItem(t, BrowserMenu(s, node), "Visibility").Invoke(s); err != nil {
 		t.Fatalf("Visibility: %v", err)
 	}
 	if s.BodyVisible(body) || len(s.VisibleBodies()) != 0 {
@@ -128,7 +128,7 @@ func TestBrowserMenuBodyVisibilityToggles(t *testing.T) {
 func TestBrowserMenuDeleteSketchRemovesIt(t *testing.T) {
 	s, def := extrudedBoxPart(t)
 	node := findNode(t, BuildBrowser(s), "sketch")
-	del := menuItem(t, BrowserMenu(node), "Delete")
+	del := menuItem(t, BrowserMenu(s, node), "Delete")
 	if err := del.Invoke(s); err != nil {
 		t.Fatalf("Delete sketch: %v", err)
 	}
@@ -140,7 +140,7 @@ func TestBrowserMenuDeleteSketchRemovesIt(t *testing.T) {
 func TestBrowserMenuDeleteFeatureRemovesAndRecomputes(t *testing.T) {
 	s, def := extrudedBoxPart(t)
 	node := findNode(t, BuildBrowser(s), "feature")
-	del := menuItem(t, BrowserMenu(node), "Delete")
+	del := menuItem(t, BrowserMenu(s, node), "Delete")
 	if err := del.Invoke(s); err != nil {
 		t.Fatalf("Delete feature: %v", err)
 	}
@@ -155,20 +155,20 @@ func TestBrowserMenuDeleteFeatureRemovesAndRecomputes(t *testing.T) {
 func TestBrowserMenuSuppressTogglesLabel(t *testing.T) {
 	s, _ := extrudedBoxPart(t)
 	node := findNode(t, BuildBrowser(s), "feature")
-	if err := menuItem(t, BrowserMenu(node), "Suppress").Invoke(s); err != nil {
+	if err := menuItem(t, BrowserMenu(s, node), "Suppress").Invoke(s); err != nil {
 		t.Fatalf("Suppress: %v", err)
 	}
 	// Rebuild: the same feature node should now offer Unsuppress.
 	node = findNode(t, BuildBrowser(s), "feature")
-	if _, ok := findMenuItem(BrowserMenu(node), "Unsuppress"); !ok {
-		t.Errorf("after Suppress, menu = %v, want an Unsuppress entry", menuLabels(BrowserMenu(node)))
+	if _, ok := findMenuItem(BrowserMenu(s, node), "Unsuppress"); !ok {
+		t.Errorf("after Suppress, menu = %v, want an Unsuppress entry", menuLabels(BrowserMenu(s, node)))
 	}
 }
 
 func TestBrowserMenuEditSketchEntersIt(t *testing.T) {
 	s, def := extrudedBoxPart(t)
 	node := findNode(t, BuildBrowser(s), "sketch")
-	if err := menuItem(t, BrowserMenu(node), "Edit Sketch").Invoke(s); err != nil {
+	if err := menuItem(t, BrowserMenu(s, node), "Edit Sketch").Invoke(s); err != nil {
 		t.Fatalf("Edit Sketch: %v", err)
 	}
 	if s.ActiveSketch() != def.Sketches().Item(0) {

--- a/app/browser_timeline_test.go
+++ b/app/browser_timeline_test.go
@@ -125,7 +125,7 @@ func TestToggleSketchSharedRoundTripsThroughMenu(t *testing.T) {
 	if !hasTopLevelKind(root, "sketch") {
 		t.Error("shared sketch should be top level after toggle")
 	}
-	labels := menuLabels(BrowserMenu(findNode(t, root, "sketch")))
+	labels := menuLabels(BrowserMenu(s, findNode(t, root, "sketch")))
 	if !containsLabel(labels, "Unshare Sketch") {
 		t.Errorf("shared sketch menu = %v, want an Unshare Sketch entry", labels)
 	}

--- a/app/drawing_view_tools_test.go
+++ b/app/drawing_view_tools_test.go
@@ -417,7 +417,7 @@ func TestDrawingViewBrowserNodesAndMenu(t *testing.T) {
 	if viewNode.Kind != "drawingView" {
 		t.Fatalf("view node kind = %q, want drawingView", viewNode.Kind)
 	}
-	menu := BrowserMenu(viewNode)
+	menu := BrowserMenu(s, viewNode)
 	if len(menu) != 2 || menu[0].Label != "Edit" || menu[1].Label != "Delete" {
 		t.Errorf("view menu = %+v, want [Edit Delete]", menu)
 	}

--- a/app/dressup_depth_test.go
+++ b/app/dressup_depth_test.go
@@ -60,7 +60,7 @@ func TestFilletEditSeedsVariableState(t *testing.T) {
 		t.Fatalf("OK: %v", err)
 	}
 
-	tool, ok := editToolFor(s, f.AddedFeature())
+	tool, ok := s.editToolFor(f.AddedFeature())
 	if !ok {
 		t.Fatal("a single-set fillet must re-open in the fillet panel")
 	}

--- a/app/feature_edit.go
+++ b/app/feature_edit.go
@@ -163,7 +163,7 @@ func (t *FeatureEditTool) recompute(s *Session) {
 // available (editToolFor). Other editable features open the generic parameter/
 // reference editor; a feature with neither is a no-op.
 func (s *Session) BeginEditFeature(h FeatureHandle) {
-	tool, ok := editToolFor(s, h.Feature)
+	tool, ok := s.editToolFor(h.Feature)
 	if !ok {
 		t := newFeatureEditTool(h.Feature)
 		if !t.editable() {
@@ -185,8 +185,8 @@ func (s *Session) BeginEditFeature(h FeatureHandle) {
 // emboss, the patterns, mirror, move). Checking the registry here keeps the Edit gate consistent with
 // what BeginEditFeature can actually open — the bug behind loft/sweep, whose tools existed but whose
 // edit path did not, leaving Edit greyed (#1521).
-func FeatureIsEditable(f *feature.PartFeature) bool {
-	if hasFeatureEditor(f.Kind()) {
+func (s *Session) FeatureIsEditable(f *feature.PartFeature) bool {
+	if s.hasFeatureEditor(f.Kind()) {
 		return true
 	}
 	if ed, ok := f.Definition().(feature.Editable); ok && len(ed.EditableParams()) > 0 {

--- a/app/feature_edit_registry.go
+++ b/app/feature_edit_registry.go
@@ -29,36 +29,46 @@ import (
 // falls back to the generic editor.
 type featureEditor func(s *Session, f *feature.PartFeature) (Tool, bool)
 
-// featureEditors maps a feature kind to its full-panel editor. Populated by registerFeatureEditor in
-// this package's init()s; read by editToolFor. Read-only after init, so no synchronization is needed.
-var featureEditors = map[string]featureEditor{}
+// featureEditorSet maps feature kinds to their full-panel editors — the value the
+// Session's edit flow consults, injectable in tests (#1617, audit B6).
+type featureEditorSet map[string]featureEditor
+
+// defaultFeatureEditors assembles the full production editor set in one visible
+// order — the composition site newSession wires into the Session (#1617); there
+// are no init() registrations.
+func defaultFeatureEditors() featureEditorSet {
+	r := featureEditorSet{}
+	r.registerSolidFeatureEditors()
+	r.registerDressUpFeatureEditors()
+	return r
+}
 
 // registerFeatureEditor records one kind's full-panel editor, panicking on an empty kind, a nil
 // editor, or a duplicate — a programming error caught at startup, not a silent overwrite.
-func registerFeatureEditor(kind string, e featureEditor) {
+func (r featureEditorSet) register(kind string, e featureEditor) {
 	if kind == "" {
-		panic("app: registerFeatureEditor with empty kind")
+		panic("app: feature-editor register with empty kind")
 	}
 	if e == nil {
 		panic(fmt.Sprintf("app: nil feature editor for kind %q", kind))
 	}
-	if _, dup := featureEditors[kind]; dup {
+	if _, dup := r[kind]; dup {
 		panic(fmt.Sprintf("app: duplicate feature editor for kind %q", kind))
 	}
-	featureEditors[kind] = e
+	r[kind] = e
 }
 
-// hasFeatureEditor reports whether a kind has a registered full-panel editor (so the browser can
-// enable Edit without constructing the tool).
-func hasFeatureEditor(kind string) bool {
-	_, ok := featureEditors[kind]
+// hasFeatureEditor reports whether a kind has a full-panel editor in the session's
+// injected set (so the browser can enable Edit without constructing the tool).
+func (s *Session) hasFeatureEditor(kind string) bool {
+	_, ok := s.featureEditors[kind]
 	return ok
 }
 
 // editToolFor builds the full-panel creation tool re-opened over a committed feature, or false for
 // kinds the generic parameter/reference editor serves (or which are not editable at all).
-func editToolFor(s *Session, f *feature.PartFeature) (Tool, bool) {
-	e, ok := featureEditors[f.Kind()]
+func (s *Session) editToolFor(f *feature.PartFeature) (Tool, bool) {
+	e, ok := s.featureEditors[f.Kind()]
 	if !ok {
 		return nil, false
 	}
@@ -73,20 +83,20 @@ func editToolFor(s *Session, f *feature.PartFeature) (Tool, bool) {
 // Each closure type-asserts the concrete feature and calls the family's seeder; a mismatched kind→type
 // registration would fail that assertion in the enforcement test, so the map cannot silently bind the
 // wrong tool.
-func registerSolidFeatureEditors() {
-	registerFeatureEditor("extrude", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
+func (r featureEditorSet) registerSolidFeatureEditors() {
+	r.register("extrude", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
 		return editExtrudeTool(f, f.Definition().(*feature.ExtrudeFeature)), true
 	})
-	registerFeatureEditor("revolve", func(s *Session, f *feature.PartFeature) (Tool, bool) {
+	r.register("revolve", func(s *Session, f *feature.PartFeature) (Tool, bool) {
 		return editRevolveTool(s, f, f.Definition().(*feature.RevolveFeature)), true
 	})
-	registerFeatureEditor("coil", func(s *Session, f *feature.PartFeature) (Tool, bool) {
+	r.register("coil", func(s *Session, f *feature.PartFeature) (Tool, bool) {
 		return editCoilTool(s, f, f.Definition().(*feature.CoilFeature)), true
 	})
-	registerFeatureEditor("hole", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
+	r.register("hole", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
 		return editHoleTool(f, f.Definition().(*feature.HoleFeature)), true
 	})
-	registerFeatureEditor("loft", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
+	r.register("loft", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
 		return editLoftTool(f, f.Definition().(*feature.LoftFeature)), true
 	})
 }
@@ -94,28 +104,23 @@ func registerSolidFeatureEditors() {
 // registerDressUpFeatureEditors wires the dress-up / local-operation features (fillet, face fillet,
 // full-round fillet, chamfer, shell, draft) to their creation panels. The fillet panel declines a
 // multi-set fillet (returns false), routing it to the generic editor.
-func registerDressUpFeatureEditors() {
-	registerFeatureEditor("fillet", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
+func (r featureEditorSet) registerDressUpFeatureEditors() {
+	r.register("fillet", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
 		return editFilletToolOr(f, f.Definition().(*feature.FilletFeature))
 	})
-	registerFeatureEditor("face-fillet", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
+	r.register("face-fillet", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
 		return editFaceFilletTool(f, f.Definition().(*feature.FaceFilletFeature)), true
 	})
-	registerFeatureEditor("full-round-fillet", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
+	r.register("full-round-fillet", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
 		return editFullRoundFilletTool(f, f.Definition().(*feature.FullRoundFilletFeature)), true
 	})
-	registerFeatureEditor("chamfer", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
+	r.register("chamfer", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
 		return editChamferTool(f, f.Definition().(*feature.ChamferFeature)), true
 	})
-	registerFeatureEditor("shell", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
+	r.register("shell", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
 		return editShellTool(f, f.Definition().(*feature.ShellFeature)), true
 	})
-	registerFeatureEditor("draft", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
+	r.register("draft", func(_ *Session, f *feature.PartFeature) (Tool, bool) {
 		return editDraftTool(f, f.Definition().(*feature.FaceDraftFeature)), true
 	})
-}
-
-func init() {
-	registerSolidFeatureEditors()
-	registerDressUpFeatureEditors()
 }

--- a/app/feature_edit_registry_test.go
+++ b/app/feature_edit_registry_test.go
@@ -40,8 +40,9 @@ var primarySolidFeatures = []struct {
 // neither a registered full-panel editor nor a generic editable surface is not editable in the browser
 // — the exact loft/sweep defect. A new solid feature added without an edit path fails here.
 func TestPrimarySolidFeaturesAreEditable(t *testing.T) {
+	editors := defaultFeatureEditors()
 	for _, f := range primarySolidFeatures {
-		if hasFeatureEditor(f.kind) || implementsEditableContract(f.proto) {
+		if _, hasEditor := editors[f.kind]; hasEditor || implementsEditableContract(f.proto) {
 			continue
 		}
 		t.Errorf("primary solid feature %q is not editable: no registered full-panel editor and its "+
@@ -63,9 +64,9 @@ func implementsEditableContract(f feature.Feature) bool {
 // overwriting — the same discipline the serialization codec registry enforces (#1416).
 func TestRegisterFeatureEditorRejectsBadRegistration(t *testing.T) {
 	ok := func(_ *Session, _ *feature.PartFeature) (Tool, bool) { return nil, false }
-	assertPanicsApp(t, "empty kind", func() { registerFeatureEditor("", ok) })
-	assertPanicsApp(t, "nil editor", func() { registerFeatureEditor("test.nil-editor", nil) })
-	assertPanicsApp(t, "duplicate", func() { registerFeatureEditor("loft", ok) }) // loft is already registered
+	assertPanicsApp(t, "empty kind", func() { featureEditorSet{}.register("", ok) })
+	assertPanicsApp(t, "nil editor", func() { featureEditorSet{}.register("test.nil-editor", nil) })
+	assertPanicsApp(t, "duplicate", func() { defaultFeatureEditors().register("loft", ok) }) // loft is already registered
 }
 
 // assertPanicsApp fails unless fn panics.
@@ -99,7 +100,7 @@ func loftedFeatureSession(t *testing.T) (*Session, FeatureHandle) {
 // committed loft re-opens the Loft tool in edit mode, seeded with its sections — not the generic editor.
 func TestBeginEditFeatureReopensLoftPanel(t *testing.T) {
 	s, h := loftedFeatureSession(t)
-	if !FeatureIsEditable(h.Feature) {
+	if !s.FeatureIsEditable(h.Feature) {
 		t.Fatal("a committed loft must report as editable (#1521)")
 	}
 	s.BeginEditFeature(h)
@@ -174,7 +175,7 @@ func sweptFeatureSession(t *testing.T) (*Session, FeatureHandle) {
 // has no full-panel re-pick, so the generic scalar/reference editor is the honest fit.
 func TestSweepIsEditableViaGenericEditor(t *testing.T) {
 	s, h := sweptFeatureSession(t)
-	if !FeatureIsEditable(h.Feature) {
+	if !s.FeatureIsEditable(h.Feature) {
 		t.Fatal("a committed sweep must report as editable (#1521)")
 	}
 	s.BeginEditFeature(h)
@@ -226,5 +227,25 @@ func setGenericEditParam(s *Session, label string, value float64) {
 			s.SetEditFeatureParamValue(i, value)
 			return
 		}
+	}
+}
+
+// TestSessionConsultsInjectedEditorSet pins the B6 seam (#1617): the edit flow
+// consults the editor set the Session carries — a session given a minimal
+// one-entry set edits through it and nothing falls back to a package global.
+func TestSessionConsultsInjectedEditorSet(t *testing.T) {
+	s := NewSession()
+	marker := &FilletTool{}
+	s.featureEditors = featureEditorSet{}
+	s.featureEditors.register("test.injected", func(*Session, *feature.PartFeature) (Tool, bool) {
+		return marker, true
+	})
+	if !s.hasFeatureEditor("test.injected") {
+		t.Error("the injected editor kind is not visible through the session")
+	}
+	// extrude has an editor in the DEFAULT set; a session with a minimal set must
+	// not see it — if it does, a package-global fallback still exists.
+	if s.hasFeatureEditor("extrude") {
+		t.Error("a kind outside the injected set is visible — a global fallback exists")
 	}
 }

--- a/app/feature_edit_test.go
+++ b/app/feature_edit_test.go
@@ -122,7 +122,7 @@ func TestFeatureEditAPIsAreNoOpsWhenNotEditing(t *testing.T) {
 func TestFeatureEditIsEditableReflectsCapability(t *testing.T) {
 	s, h := extrudedFeatureSession(t)
 	_ = s
-	if !FeatureIsEditable(h.Feature) {
+	if !s.FeatureIsEditable(h.Feature) {
 		t.Error("an extrude should be editable")
 	}
 }

--- a/app/occurrence_browser_test.go
+++ b/app/occurrence_browser_test.go
@@ -66,12 +66,12 @@ func TestOccurrenceMenuTogglesLabels(t *testing.T) {
 	o := asm.Occurrences().Item(0)
 	node := findBrowserNode(BuildBrowser(s), "occurrence", "widget:1")
 
-	if labels := strings.Join(menuLabels(BrowserMenu(*node)), "|"); labels != "Edit|Ground|Suppress|Delete" {
+	if labels := strings.Join(menuLabels(BrowserMenu(s, *node)), "|"); labels != "Edit|Ground|Suppress|Delete" {
 		t.Errorf("fresh occurrence menu = %q, want Edit|Ground|Suppress|Delete", labels)
 	}
 	o.SetGrounded(true)
 	o.SetSuppressed(true)
-	if labels := strings.Join(menuLabels(BrowserMenu(*node)), "|"); labels != "Edit|Unground|Unsuppress|Delete" {
+	if labels := strings.Join(menuLabels(BrowserMenu(s, *node)), "|"); labels != "Edit|Unground|Unsuppress|Delete" {
 		t.Errorf("grounded+suppressed menu = %q, want Edit|Unground|Unsuppress|Delete", labels)
 	}
 }

--- a/app/point_cloud_ui_test.go
+++ b/app/point_cloud_ui_test.go
@@ -54,7 +54,7 @@ func TestPointCloudMenuVisibilityAndDelete(t *testing.T) {
 	pc, _ := def.PointClouds().Add("C", "c.xyz", rid, nil)
 	node := BrowserNode{Kind: "pointCloud", Select: PointCloudHandle{Clouds: def.PointClouds(), Cloud: pc}}
 
-	menu := BrowserMenu(node)
+	menu := BrowserMenu(s, node)
 	if len(menu) != 2 || menu[0].Label != "Visibility" || menu[1].Label != "Delete" {
 		t.Fatalf("menu = %+v, want Visibility + Delete", menu)
 	}
@@ -109,7 +109,7 @@ func TestBrowserNestsCropsWithMenu(t *testing.T) {
 		t.Fatalf("cloud node children = %+v, want one Crop1", cloudNode)
 	}
 
-	menu := BrowserMenu(cloudNode.Children[0])
+	menu := BrowserMenu(s, cloudNode.Children[0])
 	if len(menu) != 2 || menu[0].Label != "Deactivate" {
 		t.Fatalf("crop menu = %+v, want Deactivate + Delete", menu)
 	}
@@ -122,7 +122,7 @@ func TestBrowserNestsCropsWithMenu(t *testing.T) {
 	if cloudNode.Children[0].Label != "Crop1  (inactive)" {
 		t.Errorf("inactive crop label = %q, want the (inactive) tag", cloudNode.Children[0].Label)
 	}
-	if BrowserMenu(cloudNode.Children[0])[0].Label != "Activate" {
+	if BrowserMenu(s, cloudNode.Children[0])[0].Label != "Activate" {
 		t.Error("an inactive crop's menu should offer Activate")
 	}
 	_ = menu[1].Invoke(s)

--- a/app/session.go
+++ b/app/session.go
@@ -216,20 +216,11 @@ func newSession(store doc.Store) *Session {
 		camera:         scene.NewCamera(800, 600),
 		hiddenBodyKeys: map[string]bool{}, hiddenBodyKeysByDoc: map[doc.ID]map[string]bool{},
 		graphics: clientgraphics.NewStore(), graphicsByDoc: map[doc.ID]*clientgraphics.Store{},
-		featureEditors:  defaultFeatureEditors(),
-		addins:          NewAddInManager(),
-		clientApps:      NewClientApplicationRegistry(),
-		browserPanes:    NewAddInBrowserPanes(),
-		dockableWindows: NewAddInDockableWindows(),
-		taskPanels:      newAddInTaskPanels(),
-		appOptions:      options.Defaults(),
-		messageCenter:   NewMessageCenter(),
-		progress:        NewProgressLedger(),
-		balloonTips:     NewBalloonTipCenter(),
-		prompts:         NewPromptCenter(),
-		miniToolbars:    NewMiniToolbarRack(),
-		manipulators:    NewManipulatorBoard(),
-		visualStyle:     renderer.ShadedWithEdges,
+		featureEditors: defaultFeatureEditors(),
+		addins:         NewAddInManager(),
+		clientApps:     NewClientApplicationRegistry(),
+		appOptions:     options.Defaults(),
+		visualStyle:    renderer.ShadedWithEdges,
 		// Three Point is the out-of-the-box rig for every visual style: a studio
 		// key/fill/back setup reads far better than the legacy single headlight now
 		// that the whole rig lights every shaded mode (ADR-0026 §8).
@@ -239,12 +230,28 @@ func newSession(store doc.Store) *Session {
 		hudEnabled:         true, // dynamic-input HUD on by default, like Inventor (#790)
 		chamferConcaveOut:  true, // concave edges fill the inside corner by default (outward)
 	}
+	s.initSurfaceCenters()
 	s.seedVisualState()
 	s.graphics.SetBodyResolver(s.resolveOverlayMesh) // scratch store (no active document)
 	s.messageCenter.sink = s.routeMessage            // M26 F03: mirror message-center entries to the command line
 	s.initShellSurfaces()
 	s.wireDocumentWatchers()
 	return s
+}
+
+// initSurfaceCenters wires the session's UI surface managers (add-in panes,
+// message/progress/prompt centers, mini-toolbars, manipulators) — split from
+// newSession to keep the composition root readable.
+func (s *Session) initSurfaceCenters() {
+	s.browserPanes = NewAddInBrowserPanes()
+	s.dockableWindows = NewAddInDockableWindows()
+	s.taskPanels = newAddInTaskPanels()
+	s.messageCenter = NewMessageCenter()
+	s.progress = NewProgressLedger()
+	s.balloonTips = NewBalloonTipCenter()
+	s.prompts = NewPromptCenter()
+	s.miniToolbars = NewMiniToolbarRack()
+	s.manipulators = NewManipulatorBoard()
 }
 
 // wireDocumentWatchers starts the session's background document and transaction watchers. Split out

--- a/app/session.go
+++ b/app/session.go
@@ -54,6 +54,7 @@ type Session struct {
 	selection                 *Selection
 	highlightSets             *HighlightSets // named, colored emphasis groups for add-ins (#157)
 	tool                      *ToolInstance
+	featureEditors            featureEditorSet // full-panel editors, assembled at the composition root (#1617)
 	picker                    Picker
 	regionPicker              RegionPicker          // resolves a box-select rectangle (nil ⇒ box-select disabled)
 	boxSelect                 BoxSelection          // the in-progress rubber-band rectangle, if any
@@ -215,6 +216,7 @@ func newSession(store doc.Store) *Session {
 		camera:         scene.NewCamera(800, 600),
 		hiddenBodyKeys: map[string]bool{}, hiddenBodyKeysByDoc: map[doc.ID]map[string]bool{},
 		graphics: clientgraphics.NewStore(), graphicsByDoc: map[doc.ID]*clientgraphics.Store{},
+		featureEditors:  defaultFeatureEditors(),
 		addins:          NewAddInManager(),
 		clientApps:      NewClientApplicationRegistry(),
 		browserPanes:    NewAddInBrowserPanes(),

--- a/app/ui_shell.go
+++ b/app/ui_shell.go
@@ -140,7 +140,7 @@ func runnableMenuItem(item wire.ContextMenuItemSpec) BrowserMenuItem {
 // BrowserMenuFor returns a node's context menu: the built-in entries plus any
 // add-in injections for its kind (M05-F12). The head renders this, not BrowserMenu.
 func BrowserMenuFor(s *Session, n BrowserNode) []BrowserMenuItem {
-	return append(BrowserMenu(n), s.injectedMenuItems(n.Kind)...)
+	return append(BrowserMenu(s, n), s.injectedMenuItems(n.Kind)...)
 }
 
 // SearchCommands finds registered commands whose id, display name, or alias

--- a/app/work_plane_ops_test.go
+++ b/app/work_plane_ops_test.go
@@ -348,7 +348,7 @@ func TestWorkPlaneBrowserVisibilityMenuToggles(t *testing.T) {
 	s, _ := emptyPartSession(t)
 	node := originFolder(BuildBrowser(s)).Children[0] // XY plane node
 	wp := node.Select.(WorkPlaneHandle).Plane
-	menu := BrowserMenu(node)
+	menu := BrowserMenu(s, node)
 	var vis BrowserMenuItem
 	for _, m := range menu {
 		if m.Label == "Visibility" {

--- a/archguard/init_registration_test.go
+++ b/archguard/init_registration_test.go
@@ -27,13 +27,6 @@ var initRegistrationPattern = regexp.MustCompile(`func init\(\) \{[^}]*[rR]egist
 // migrate the registry to an explicit default-set constructor and delete the
 // entry. Never add to it.
 var pendingInitRegistrations = map[string]struct{}{
-	"model/feature/serialize_codecs_cosmetic.go":      {}, // feature codecs → defaultFeatureCodecs()
-	"model/feature/serialize_codecs_dressup.go":       {},
-	"model/feature/serialize_codecs_faceedit.go":      {},
-	"model/feature/serialize_codecs_pattern.go":       {},
-	"model/feature/serialize_codecs_sheetmetal.go":    {},
-	"model/feature/serialize_codecs_solid.go":         {},
-	"model/feature/serialize_codecs_surface.go":       {},
 	"model/sketch/serialize_codecs_3d.go":             {}, // sketch entity/constraint codecs (#1624/#1625) → follow-up
 	"model/sketch/serialize_codecs_curves.go":         {},
 	"model/sketch/serialize_codecs_extras.go":         {},

--- a/archguard/init_registration_test.go
+++ b/archguard/init_registration_test.go
@@ -32,7 +32,6 @@ var pendingInitRegistrations = map[string]struct{}{
 	"model/sketch/serialize_codecs_extras.go":         {},
 	"model/sketch/serialize_codecs_constraints.go":    {},
 	"model/sketch/serialize_codecs_constraints_3d.go": {},
-	"app/feature_edit_registry.go":                    {}, // feature editors → Session default
 	"head/ui/dockable_panel.go":                       {}, // dockable-panel registry → UI-loop object
 }
 

--- a/archguard/init_registration_test.go
+++ b/archguard/init_registration_test.go
@@ -32,7 +32,6 @@ var pendingInitRegistrations = map[string]struct{}{
 	"model/sketch/serialize_codecs_extras.go":         {},
 	"model/sketch/serialize_codecs_constraints.go":    {},
 	"model/sketch/serialize_codecs_constraints_3d.go": {},
-	"head/ui/dockable_panel.go":                       {}, // dockable-panel registry → UI-loop object
 }
 
 func TestNoInitTimeRegistrations(t *testing.T) {

--- a/head/ui/chrome_ribbon.go
+++ b/head/ui/chrome_ribbon.go
@@ -307,9 +307,9 @@ func drawVariantDropdown(btn app.RibbonButton) string {
 // icon never hides the command.
 func drawButtonControl(btn app.RibbonButton) bool {
 	if btn.Active { // a toggled-on stateful control renders in the accent color
-		native.PushStyleColor("Button", accentColor)
-		native.PushStyleColor("ButtonHovered", accentColor)
-		native.PushStyleColor("ButtonActive", accentColor)
+		native.PushStyleColor("Button", chromeTheme.accentColor)
+		native.PushStyleColor("ButtonHovered", chromeTheme.accentColor)
+		native.PushStyleColor("ButtonActive", chromeTheme.accentColor)
 		defer native.PopStyleColor(3)
 	}
 	if px, ok := iconSizeFor(btn.Command.ButtonStyle()); ok {

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -292,7 +292,7 @@ func renderActiveTile(win *native.Window, s *app.Session, i int, cam scene.Camer
 // the user can tell which view is focused (drawn after the image, so it sits on top).
 func drawActiveTileBorder(x, y, w, h float32) {
 	const thickness = 2
-	c := activeViewportBorderColor // themed (types.TokenViewportActiveBorder)
+	c := chromeTheme.activeViewportBorderColor // themed (types.TokenViewportActiveBorder)
 	x0, y0, x1, y1 := x+1, y+1, x+w-1, y+h-1
 	native.DrawLine(x0, y0, x1, y0, c, thickness)
 	native.DrawLine(x1, y0, x1, y1, c, thickness)
@@ -705,7 +705,7 @@ func toolPreview(s *app.Session) (renderer.DrawItem, bool) {
 	}
 	acc := &segAccum{}
 	acc.polyline(s.ActiveSketch().Plane(), pts, closed)
-	return renderer.DrawItem{Primitive: renderer.Lines, Positions: acc.pos, Indices: acc.idx, Color: previewColor}, true
+	return renderer.DrawItem{Primitive: renderer.Lines, Positions: acc.pos, Indices: acc.idx, Color: chromeTheme.previewColor}, true
 }
 
 const (

--- a/head/ui/dimension_overlay.go
+++ b/head/ui/dimension_overlay.go
@@ -34,8 +34,8 @@ func dimensionLines(plane sketch.Plane, views []app.DimensionView) []renderer.Dr
 		}
 	}
 	var items []renderer.DrawItem
-	items = appendGrid(items, driving, dimensionColor)
-	items = appendGrid(items, driven, dimensionDrivenColor)
+	items = appendGrid(items, driving, chromeTheme.dimensionColor)
+	items = appendGrid(items, driven, chromeTheme.dimensionDrivenColor)
 	return items
 }
 

--- a/head/ui/dockable_panel.go
+++ b/head/ui/dockable_panel.go
@@ -36,21 +36,24 @@ type dockablePanel struct {
 	after     func(*app.Session)
 }
 
-// dockablePanels is the ordered registry of built-in dockable windows. Order is the View-menu
-// order. Registered once at init by registerDockablePanel from each panel's file.
-var dockablePanels []dockablePanel
+// dockablePanels is the ordered registry of built-in dockable windows, in
+// View-menu order — the package default, constructed explicitly from the
+// builtinDockablePanels table instead of init()-time self-registration
+// (#1617, audit B6).
+var dockablePanels = defaultDockablePanels()
 
-// registerDockablePanel adds a built-in dockable window to the registry. Call it from a panel
-// file's init so the panel is self-describing and the View menu / render loop pick it up with no
-// central edit (the self-registration pattern). Panics on a duplicate title since the title is the
+// defaultDockablePanels validates and returns the built-in dockable-window
+// set; a duplicate title panics at construction since the title is the
 // window id and must be unique.
-func registerDockablePanel(p dockablePanel) {
-	for _, e := range dockablePanels {
-		if e.title == p.title {
+func defaultDockablePanels() []dockablePanel {
+	seen := map[string]bool{}
+	for _, p := range builtinDockablePanels {
+		if seen[p.title] {
 			panic("duplicate dockable panel title: " + p.title)
 		}
+		seen[p.title] = true
 	}
-	dockablePanels = append(dockablePanels, p)
+	return builtinDockablePanels
 }
 
 // drawDockablePanels renders every registered built-in dockable window through the shared path,
@@ -106,14 +109,6 @@ func panelMenuLabel(p *dockablePanel) string {
 		return p.menuLabel
 	}
 	return p.title
-}
-
-// init registers the built-in dockable windows once (so the duplicate-title guard runs). The set
-// itself is the data-driven builtinDockablePanels table below.
-func init() {
-	for _, p := range builtinDockablePanels {
-		registerDockablePanel(p)
-	}
 }
 
 // builtinDockablePanels is the ordered table of built-in dockable windows, in View-menu order.

--- a/head/ui/edge_highlight.go
+++ b/head/ui/edge_highlight.go
@@ -31,7 +31,7 @@ func selectedEdgeOverlay(s *app.Session) []renderer.DrawItem {
 	if len(acc.pos) == 0 {
 		return nil
 	}
-	return []renderer.DrawItem{lineItem(acc, selectionHighlight)}
+	return []renderer.DrawItem{lineItem(acc, chromeTheme.selectionHighlight)}
 }
 
 // highlightedEdges returns a lone selected edge (outside any tool) to highlight. An active

--- a/head/ui/face_fillet_dialog.go
+++ b/head/ui/face_fillet_dialog.go
@@ -62,9 +62,9 @@ func drawFaceFilletPanelBody(s *app.Session, f *app.FaceFilletTool) {
 func drawFaceSetRow(label, id string, count int, armed bool, onArm, onClear func()) {
 	propertyRow(label)
 	if armed {
-		native.PushStyleColor("Button", accentColor)
-		native.PushStyleColor("ButtonHovered", accentColor)
-		native.PushStyleColor("ButtonActive", accentColor)
+		native.PushStyleColor("Button", chromeTheme.accentColor)
+		native.PushStyleColor("ButtonHovered", chromeTheme.accentColor)
+		native.PushStyleColor("ButtonActive", chromeTheme.accentColor)
 	}
 	if native.Button(countChipText(count, "Face", "Select Faces") + "##" + id) {
 		onArm()

--- a/head/ui/grid_overlay.go
+++ b/head/ui/grid_overlay.go
@@ -35,8 +35,8 @@ func gridOverlay(plane sketch.Plane, spacing float64, major int) []renderer.Draw
 		vAcc.seg(plane, math.P2(-half, c), math.P2(half, c)) // line of constant v (the X axis at i==0)
 	}
 	var items []renderer.DrawItem
-	items = appendGrid(items, minor, gridMinorColor)
-	items = appendGrid(items, maj, gridMajorColor)
+	items = appendGrid(items, minor, chromeTheme.gridMinorColor)
+	items = appendGrid(items, maj, chromeTheme.gridMajorColor)
 	items = appendGrid(items, xAxis, axisColorX)
 	items = appendGrid(items, yAxis, axisColorY)
 	return items

--- a/head/ui/grid_overlay_test.go
+++ b/head/ui/grid_overlay_test.go
@@ -64,10 +64,10 @@ func TestGridOverlayOriginAxisColors(t *testing.T) {
 // TestGridOverlayKeepsMinorAndMajor: the axis split does not drop the minor/major groups.
 func TestGridOverlayKeepsMinorAndMajor(t *testing.T) {
 	items := gridOverlay(xyPlane(t), 1.0, 5)
-	if _, ok := itemWithColor(items, gridMinorColor); !ok {
+	if _, ok := itemWithColor(items, chromeTheme.gridMinorColor); !ok {
 		t.Errorf("no minor grid item; colors=%v", colorsOf(items))
 	}
-	if _, ok := itemWithColor(items, gridMajorColor); !ok {
+	if _, ok := itemWithColor(items, chromeTheme.gridMajorColor); !ok {
 		t.Errorf("no major grid item; colors=%v", colorsOf(items))
 	}
 }

--- a/head/ui/highlight.go
+++ b/head/ui/highlight.go
@@ -22,7 +22,7 @@ func highlightSelection(list renderer.DrawList, sel app.Selectable, partBodies [
 	if len(ids) == 0 {
 		return list
 	}
-	return recolorByObjectID(list, ids, selectionHighlight)
+	return recolorByObjectID(list, ids, chromeTheme.selectionHighlight)
 }
 
 // bodyHighlightIDs returns the set of body ObjectIDs to highlight for a selection: the

--- a/head/ui/highlight_test.go
+++ b/head/ui/highlight_test.go
@@ -33,7 +33,7 @@ func TestHighlightSelectionRecolorsOnlyTheSelectedBody(t *testing.T) {
 
 	got := highlightSelection(list, app.BodyHandle{Body: b}, nil)
 
-	if got.Items[0].Color != selectionHighlight {
+	if got.Items[0].Color != chromeTheme.selectionHighlight {
 		t.Errorf("selected body item not highlighted: %v", got.Items[0].Color)
 	}
 	if got.Items[1].Color != base {

--- a/head/ui/icon_cache.go
+++ b/head/ui/icon_cache.go
@@ -31,7 +31,7 @@ var icons *iconCache
 
 // iconCache turns embedded SVG glyphs into themed ImGui textures in two stages: each
 // glyph is rasterized ONCE into theme-independent per-role coverage masks, and the
-// masks are composed with the active theme's icon colors (iconColors, theme_apply.go)
+// masks are composed with the active theme's icon colors (chromeTheme.iconColors, theme_apply.go)
 // into the uploaded texture. A theme change only re-composes and re-uploads — lazily,
 // per icon actually drawn — which is what makes the appearance editor's live preview
 // affordable. Replaced textures are retired for a few frames before destruction.
@@ -109,7 +109,7 @@ func (c *iconCache) compose(k iconKey) uint64 {
 	if masks == nil {
 		return 0
 	}
-	img := masks.Compose(iconColors)
+	img := masks.Compose(chromeTheme.iconColors)
 	return c.win.CreateTexture(img.Pix, k.px, k.px)
 }
 

--- a/head/ui/inference_glyphs.go
+++ b/head/ui/inference_glyphs.go
@@ -43,7 +43,7 @@ func inferenceGlyphs(s *app.Session, plane sketch.Plane, hWorld float64) (render
 		anchor := glyphAnchor(cur, i, hWorld)
 		glyphSegments(acc, plane, anchor, hWorld, sg.Kind)
 	}
-	return renderer.DrawItem{Primitive: renderer.Lines, Positions: acc.pos, Indices: acc.idx, Color: previewColor}, true
+	return renderer.DrawItem{Primitive: renderer.Lines, Positions: acc.pos, Indices: acc.idx, Color: chromeTheme.previewColor}, true
 }
 
 // glyphAnchor places the i-th glyph in a row beside the cursor.

--- a/head/ui/navigation_bar.go
+++ b/head/ui/navigation_bar.go
@@ -83,9 +83,9 @@ func drawNavBarButton(s *app.Session, b navBarButton, iconPx int) bool {
 	}
 	on := b.active != nil && b.active(s)
 	if on {
-		native.PushStyleColor("Button", accentColor)
-		native.PushStyleColor("ButtonHovered", accentColor)
-		native.PushStyleColor("ButtonActive", accentColor)
+		native.PushStyleColor("Button", chromeTheme.accentColor)
+		native.PushStyleColor("ButtonHovered", chromeTheme.accentColor)
+		native.PushStyleColor("ButtonActive", chromeTheme.accentColor)
 		defer native.PopStyleColor(3)
 	}
 	if b.enabled != nil && !b.enabled(s) {

--- a/head/ui/plane_overlay.go
+++ b/head/ui/plane_overlay.go
@@ -52,20 +52,20 @@ type scopeFilter func(seq uint64) bool
 
 func axisColor(axis, selected *feature.WorkAxis) [4]float32 {
 	if axis == selected {
-		return selectedPlaneColor
+		return chromeTheme.selectedPlaneColor
 	}
-	return faintPlaneColor
+	return chromeTheme.faintPlaneColor
 }
 
 // planeColor chooses a plane border's draw color: selected wins, then hovered, then faint.
 func planeColor(wp, selected, hovered *feature.WorkPlane) [4]float32 {
 	switch wp {
 	case selected:
-		return selectedPlaneColor
+		return chromeTheme.selectedPlaneColor
 	case hovered:
-		return hoverPlaneColor
+		return chromeTheme.hoverPlaneColor
 	default:
-		return faintPlaneColor
+		return chromeTheme.faintPlaneColor
 	}
 }
 
@@ -94,8 +94,8 @@ func planeFill(wp *feature.WorkPlane) renderer.DrawItem {
 		Positions: pos,
 		Normals:   []math.Vector3{n, n, n, n},
 		Indices:   []int{0, 1, 2, 0, 2, 3},
-		Color:     planeFillColor,
-		Opacity:   planeFillColor[3],
+		Color:     chromeTheme.planeFillColor,
+		Opacity:   chromeTheme.planeFillColor[3],
 		Biased:    true, // a reference overlay: depth-bias it so a coplanar body face wins (no z-fight)
 	}
 }

--- a/head/ui/property_panel.go
+++ b/head/ui/property_panel.go
@@ -118,9 +118,9 @@ func propertySelectorChip(id, text string, filled, required bool) bool {
 		drawEmptySelectorChip(id, text, required)
 		return false
 	}
-	native.PushStyleColor("Button", accentColor)
-	native.PushStyleColor("ButtonHovered", accentColor)
-	native.PushStyleColor("ButtonActive", accentColor)
+	native.PushStyleColor("Button", chromeTheme.accentColor)
+	native.PushStyleColor("ButtonHovered", chromeTheme.accentColor)
+	native.PushStyleColor("ButtonActive", chromeTheme.accentColor)
 	native.Button(text + "##" + id)
 	native.PopStyleColor(3)
 	native.SameLine()
@@ -131,7 +131,7 @@ func propertySelectorChip(id, text string, filled, required bool) bool {
 // signals state (picking happens in the viewport, so clicking it has no action).
 func drawEmptySelectorChip(id, text string, required bool) {
 	if required {
-		native.PushStyleColor("Text", dangerColor)
+		native.PushStyleColor("Text", chromeTheme.dangerColor)
 		defer native.PopStyleColor(1)
 	}
 	native.Button(text + "##" + id)
@@ -170,12 +170,12 @@ func armableSlotChip(id, text string, filled, armed, clearable, required bool) (
 // — in the danger color for a required slot, the normal color for an optional one.
 func drawArmableChipButton(id, text string, filled, armed, required bool) bool {
 	if armed || filled {
-		native.PushStyleColor("Button", accentColor)
-		native.PushStyleColor("ButtonHovered", accentColor)
-		native.PushStyleColor("ButtonActive", accentColor)
+		native.PushStyleColor("Button", chromeTheme.accentColor)
+		native.PushStyleColor("ButtonHovered", chromeTheme.accentColor)
+		native.PushStyleColor("ButtonActive", chromeTheme.accentColor)
 		defer native.PopStyleColor(3)
 	} else if required {
-		native.PushStyleColor("Text", dangerColor)
+		native.PushStyleColor("Text", chromeTheme.dangerColor)
 		defer native.PopStyleColor(1)
 	}
 	return native.Button(text + "##" + id)
@@ -202,9 +202,9 @@ func propertyIconToggles(id string, keys, tips []string, active int) int {
 // when selected, with the option tooltip on hover.
 func drawPropertyToggle(group, key, tip string, selected bool) bool {
 	if selected {
-		native.PushStyleColor("Button", accentColor)
-		native.PushStyleColor("ButtonHovered", accentColor)
-		native.PushStyleColor("ButtonActive", accentColor)
+		native.PushStyleColor("Button", chromeTheme.accentColor)
+		native.PushStyleColor("ButtonHovered", chromeTheme.accentColor)
+		native.PushStyleColor("ButtonActive", chromeTheme.accentColor)
 		defer native.PopStyleColor(3)
 	}
 	clicked := drawPropertyToggleControl(group, key, tip)

--- a/head/ui/revolve_highlight.go
+++ b/head/ui/revolve_highlight.go
@@ -23,14 +23,14 @@ func revolveCenterlineHighlight(s *app.Session) []renderer.DrawItem {
 	if pts, plane, ok := rv.CenterlineOutline(); ok {
 		acc := &segAccum{}
 		acc.polyline(plane, pts, false)
-		items = appendGrid(items, acc, sketchSelectedColor)
+		items = appendGrid(items, acc, chromeTheme.sketchSelectedColor)
 	}
 	if native.IsItemHovered() {
 		x, y := viewportCursor()
 		if pts, plane, ok := s.HoveredCenterlineOutline(x, y); ok {
 			acc := &segAccum{}
 			acc.polyline(plane, pts, false)
-			items = appendGrid(items, acc, sketchCandidateColor)
+			items = appendGrid(items, acc, chromeTheme.sketchCandidateColor)
 		}
 	}
 	return items

--- a/head/ui/sheet_canvas_input.go
+++ b/head/ui/sheet_canvas_input.go
@@ -97,7 +97,7 @@ func drawViewCtxMenu(s *app.Session) {
 		return
 	}
 	node := app.BrowserNode{Kind: "drawingView", Select: canvasCtx.handle}
-	for _, item := range app.BrowserMenu(node) {
+	for _, item := range app.BrowserMenu(s, node) {
 		if native.MenuItem(item.Label) && item.Invoke != nil {
 			_ = item.Invoke(s)
 		}

--- a/head/ui/sketch3d_overlay.go
+++ b/head/ui/sketch3d_overlay.go
@@ -130,8 +130,8 @@ func sketch3DLiveOverlay(s *app.Session, h float64) []renderer.DrawItem {
 	}
 	highlightPickedSketch3D(s, sel, h)
 	var items []renderer.DrawItem
-	items = appendGrid(items, normal, sketchColor)
-	items = appendGrid(items, sel, sketchSelectedColor)
+	items = appendGrid(items, normal, chromeTheme.sketchColor)
+	items = appendGrid(items, sel, chromeTheme.sketchSelectedColor)
 	return items
 }
 
@@ -176,7 +176,7 @@ func buildSketch3DCurves(s *app.Session) (curves []renderer.DrawItem, points []m
 		}
 		points = accumSketch3DCurves(sk, acc, points)
 	}
-	return appendGrid(nil, acc, sketchColor), points
+	return appendGrid(nil, acc, chromeTheme.sketchColor), points
 }
 
 // buildSketch3DCurvesOnly is buildSketch3DCurves discarding the points — the un-keyed bounds

--- a/head/ui/sketch_overlay.go
+++ b/head/ui/sketch_overlay.go
@@ -194,7 +194,7 @@ func projectedCurveOverlay(sk *sketch.Sketch) []renderer.DrawItem {
 			acc.polyline(plane, pc.Points(), false)
 		}
 	}
-	return appendGrid(nil, acc, sketchColor)
+	return appendGrid(nil, acc, chromeTheme.sketchColor)
 }
 
 func sketchSegmentsFor(sk *sketch.Sketch, selected func(sketch.Entity) bool, candidate sketch.Entity) (*segAccum, *segAccum, *segAccum) {
@@ -239,9 +239,9 @@ func addBlockInstances(pick accumFor, plane sketch.Plane, sk *sketch.Sketch) {
 
 func sketchItems(normal, sel, cand *segAccum) []renderer.DrawItem {
 	var items []renderer.DrawItem
-	items = appendGrid(items, normal, sketchColor)
-	items = appendGrid(items, sel, sketchSelectedColor)
-	items = appendGrid(items, cand, sketchCandidateColor)
+	items = appendGrid(items, normal, chromeTheme.sketchColor)
+	items = appendGrid(items, sel, chromeTheme.sketchSelectedColor)
+	items = appendGrid(items, cand, chromeTheme.sketchCandidateColor)
 	return items
 }
 

--- a/head/ui/snap_glyph.go
+++ b/head/ui/snap_glyph.go
@@ -26,7 +26,7 @@ const (
 	triBaseDrop      = 0.5       // sin(30°)
 )
 
-// snapGlyphColor (the cursor snap marker) and pointMarkerColor (placed sketch points,
+// chromeTheme.snapGlyphColor (the cursor snap marker) and chromeTheme.pointMarkerColor (placed sketch points,
 // matching the sketch wireframe) are theme-driven and declared in theme_apply.go.
 
 // snapGlyph builds the snap marker at the snapped point: a square for an endpoint, a
@@ -47,7 +47,7 @@ func snapGlyph(plane sketch.Plane, r app.SnapResult, hWorld float64) (renderer.D
 	default:
 		return renderer.DrawItem{}, false
 	}
-	return lineItem(acc, snapGlyphColor), true
+	return lineItem(acc, chromeTheme.snapGlyphColor), true
 }
 
 // pointsOverlay draws Inventor's target glyph (a circle with a centred crosshair) at every
@@ -72,7 +72,7 @@ func pointsOverlay(plane sketch.Plane, sk *sketch.Sketch, hWorld float64) (rende
 	if len(acc.pos) == 0 {
 		return renderer.DrawItem{}, false
 	}
-	return lineItem(acc, pointMarkerColor), true
+	return lineItem(acc, chromeTheme.pointMarkerColor), true
 }
 
 // targetMarker adds the sketch-point glyph at c: a small circle with a centred crosshair

--- a/head/ui/theme_apply.go
+++ b/head/ui/theme_apply.go
@@ -19,7 +19,13 @@ import (
 // values before the first applyThemeIfChanged and in any headless head test, then
 // overwritten from the active theme whenever it changes (ADR-0021). The overlay files
 // read these vars by name exactly as before.
-var (
+// themePalette is the theme cache the overlay builders and icon cache read each
+// frame: every themed overlay/icon color in ONE object instead of ~16 mutable
+// package arrays (#1617, audit B6). Single writer: applyThemeIfChanged, at the
+// top of DrawChrome — the UI loop owns the palette's lifecycle; nothing else may
+// mutate it. Seeded from the Dark built-in so it holds correct values before the
+// first frame and in any headless head test.
+type themePalette struct {
 	gridMinorColor, gridMajorColor                         [4]float32
 	sketchColor, sketchSelectedColor, sketchCandidateColor [4]float32
 	previewColor                                           [4]float32 // rubber-band preview
@@ -33,9 +39,18 @@ var (
 	accentColor                                            [4]float32      // active/toggled ribbon button
 	dangerColor                                            [4]float32      // required-but-empty selector / error affordances
 	windowClearColor                                       [3]float32      // swapchain (chrome) clear
-)
+}
 
-func init() { refreshThemeColors(theme.DefaultDark()) }
+// chromeTheme is the UI loop's palette instance, constructed once from the Dark
+// default (no init() side effects — #1617).
+var chromeTheme = defaultThemePalette()
+
+// defaultThemePalette seeds a palette from the built-in Dark theme.
+func defaultThemePalette() themePalette {
+	var p themePalette
+	p.refresh(theme.DefaultDark())
+	return p
+}
 
 // appliedThemeRevision / appliedColorSchemeRevision are the library + color-scheme revisions
 // last pushed into Dear ImGui and the color vars, so applyThemeIfChanged is a cheap no-op on
@@ -56,7 +71,7 @@ func applyThemeIfChanged(win *native.Window, s *app.Session) {
 	appliedThemeRevision, appliedColorSchemeRevision = rev, schemeRev
 	active := s.Theme()
 	applyChromeStyle(active)
-	refreshThemeColors(active)
+	chromeTheme.refresh(active)
 	applyColorSchemeColors(s)
 	vp := viewportClear(s)
 	win.SetViewportClear(vp.R, vp.G, vp.B)
@@ -66,66 +81,66 @@ func applyThemeIfChanged(win *native.Window, s *app.Session) {
 // background (M16-F06 #642), so its screen color overrides the theme's viewport-bg token.
 func viewportClear(s *app.Session) theme.Rgba { return s.ActiveColorScheme().Screen.Rgba() }
 
-// applyColorSchemeColors pushes the active scheme's highlight color into the selection-overlay
-// var so a scheme switch repaints selection highlighting along with the background.
+// applyColorSchemeColors pushes the active scheme's highlight color into the palette
+// so a scheme switch repaints selection highlighting along with the background.
 func applyColorSchemeColors(s *app.Session) {
 	h := s.ActiveColorScheme().Highlight.Rgba()
-	selectionHighlight = [4]float32{h.R, h.G, h.B, 1}
+	chromeTheme.selectionHighlight = [4]float32{h.R, h.G, h.B, 1}
 }
 
-// refreshThemeColors copies the active theme's overlay/icon colors into the package vars
+// refresh copies the active theme's overlay/icon colors into the palette
 // the overlay builders read each frame.
-func refreshThemeColors(t contract.Theme) {
+func (p *themePalette) refresh(t contract.Theme) {
 	arr := func(tok types.ThemeToken) [4]float32 { return t.Color(tok).Array() }
-	refreshGridThemeColors(arr)
-	refreshSketchThemeColors(arr)
-	refreshPlaneThemeColors(arr)
-	refreshIconThemeColors(arr)
-	selectionHighlight = arr(types.TokenSelectionHighlight)
-	accentColor = arr(types.TokenChromeAccent)
-	dangerColor = arr(types.TokenChromeDanger)
+	p.gridThemeColors(arr)
+	p.sketchThemeColors(arr)
+	p.planeThemeColors(arr)
+	p.iconThemeColors(arr)
+	p.selectionHighlight = arr(types.TokenSelectionHighlight)
+	p.accentColor = arr(types.TokenChromeAccent)
+	p.dangerColor = arr(types.TokenChromeDanger)
 	c := t.Color(types.TokenChromeWindowBg)
-	windowClearColor = [3]float32{c.R, c.G, c.B}
+	p.windowClearColor = [3]float32{c.R, c.G, c.B}
 }
 
-func refreshGridThemeColors(arr func(types.ThemeToken) [4]float32) {
-	gridMinorColor = arr(types.TokenGridMinor)
-	gridMajorColor = arr(types.TokenGridMajor)
+func (p *themePalette) gridThemeColors(arr func(types.ThemeToken) [4]float32) {
+	p.gridMinorColor = arr(types.TokenGridMinor)
+	p.gridMajorColor = arr(types.TokenGridMajor)
 }
 
-func refreshSketchThemeColors(arr func(types.ThemeToken) [4]float32) {
-	sketchColor = arr(types.TokenSketchGeometry)
-	sketchSelectedColor = arr(types.TokenSketchSelected)
-	sketchCandidateColor = arr(types.TokenSketchCandidate)
-	previewColor = arr(types.TokenSketchPreview)
-	dimensionColor = arr(types.TokenDimensionDriving)
-	dimensionDrivenColor = arr(types.TokenDimensionDriven)
-	snapGlyphColor = arr(types.TokenSnapGlyph)
-	activeViewportBorderColor = arr(types.TokenViewportActiveBorder)
-	pointMarkerColor = sketchColor // placed points match the sketch wireframe
+func (p *themePalette) sketchThemeColors(arr func(types.ThemeToken) [4]float32) {
+	p.sketchColor = arr(types.TokenSketchGeometry)
+	p.sketchSelectedColor = arr(types.TokenSketchSelected)
+	p.sketchCandidateColor = arr(types.TokenSketchCandidate)
+	p.previewColor = arr(types.TokenSketchPreview)
+	p.dimensionColor = arr(types.TokenDimensionDriving)
+	p.dimensionDrivenColor = arr(types.TokenDimensionDriven)
+	p.snapGlyphColor = arr(types.TokenSnapGlyph)
+	p.activeViewportBorderColor = arr(types.TokenViewportActiveBorder)
+	p.pointMarkerColor = p.sketchColor // placed points match the sketch wireframe
 }
 
-func refreshPlaneThemeColors(arr func(types.ThemeToken) [4]float32) {
-	faintPlaneColor = arr(types.TokenPlaneFaint)
-	hoverPlaneColor = arr(types.TokenPlaneHover)
-	selectedPlaneColor = arr(types.TokenPlaneSelected)
-	planeFillColor = arr(types.TokenPlaneFill)
+func (p *themePalette) planeThemeColors(arr func(types.ThemeToken) [4]float32) {
+	p.faintPlaneColor = arr(types.TokenPlaneFaint)
+	p.hoverPlaneColor = arr(types.TokenPlaneHover)
+	p.selectedPlaneColor = arr(types.TokenPlaneSelected)
+	p.planeFillColor = arr(types.TokenPlaneFill)
 }
 
 // refreshIconThemeColors maps the icon.* tokens onto the glyph color roles. The icon
 // cache composes its masks with these on the next texture lookup after a theme change
 // (the revision flush in iconCache.beginFrame).
-func refreshIconThemeColors(arr func(types.ThemeToken) [4]float32) {
-	iconColors[icon.RolePrimary] = arr(types.TokenIconPrimary)
-	iconColors[icon.RoleSecondary] = arr(types.TokenIconSecondary)
-	iconColors[icon.RoleTertiary] = arr(types.TokenIconTertiary)
-	iconColors[icon.RoleBackground] = arr(types.TokenIconBackground)
+func (p *themePalette) iconThemeColors(arr func(types.ThemeToken) [4]float32) {
+	p.iconColors[icon.RolePrimary] = arr(types.TokenIconPrimary)
+	p.iconColors[icon.RoleSecondary] = arr(types.TokenIconSecondary)
+	p.iconColors[icon.RoleTertiary] = arr(types.TokenIconTertiary)
+	p.iconColors[icon.RoleBackground] = arr(types.TokenIconBackground)
 }
 
 // WindowClearColor is the themed background the frame loop clears the swapchain to (the
 // area behind/around the docked panels). The main loop passes it to Window.EndFrame.
 func WindowClearColor() (r, g, b float32) {
-	return windowClearColor[0], windowClearColor[1], windowClearColor[2]
+	return chromeTheme.windowClearColor[0], chromeTheme.windowClearColor[1], chromeTheme.windowClearColor[2]
 }
 
 // chromeBinding maps each chrome token to the Dear ImGui color slots it drives, by name

--- a/head/ui/theme_apply_test.go
+++ b/head/ui/theme_apply_test.go
@@ -30,17 +30,17 @@ func TestChromeBindingSlotsUnique(t *testing.T) {
 // the active theme, not frozen at their seeded Dark values: switching to Light must change
 // the sketch-geometry color.
 func TestRefreshThemeColorsReadsActiveTheme(t *testing.T) {
-	refreshThemeColors(theme.DefaultDark())
-	dark := sketchColor
-	refreshThemeColors(theme.DefaultLight())
-	if sketchColor == dark {
-		t.Errorf("sketchColor unchanged after switching Dark->Light (%v); not reading the theme", sketchColor)
+	chromeTheme.refresh(theme.DefaultDark())
+	dark := chromeTheme.sketchColor
+	chromeTheme.refresh(theme.DefaultLight())
+	if chromeTheme.sketchColor == dark {
+		t.Errorf("chromeTheme.sketchColor unchanged after switching Dark->Light (%v); not reading the theme", chromeTheme.sketchColor)
 	}
-	// pointMarkerColor must track sketchColor (placed points match the wireframe).
-	if pointMarkerColor != sketchColor {
-		t.Errorf("pointMarkerColor %v != sketchColor %v", pointMarkerColor, sketchColor)
+	// chromeTheme.pointMarkerColor must track chromeTheme.sketchColor (placed points match the wireframe).
+	if chromeTheme.pointMarkerColor != chromeTheme.sketchColor {
+		t.Errorf("chromeTheme.pointMarkerColor %v != chromeTheme.sketchColor %v", chromeTheme.pointMarkerColor, chromeTheme.sketchColor)
 	}
-	refreshThemeColors(theme.DefaultDark()) // restore the package default for other tests
+	chromeTheme.refresh(theme.DefaultDark()) // restore the package default for other tests
 }
 
 // TestInputTextCursorBoundToText guards the light-mode caret fix: ImGui 1.92 draws the

--- a/head/ui/tool_highlight.go
+++ b/head/ui/tool_highlight.go
@@ -85,7 +85,7 @@ func toolHoverHighlight(s *app.Session) []renderer.DrawItem {
 	if !ok {
 		return nil
 	}
-	return drawSelectable(sel, sketchCandidateColor)
+	return drawSelectable(sel, chromeTheme.sketchCandidateColor)
 }
 
 // faceFill returns a translucent, always-on-top tint of a face's tessellation — the visible part
@@ -113,7 +113,7 @@ const faceFillOpacity = 0.5
 func toolSelectedHighlight(s *app.Session) []renderer.DrawItem {
 	var items []renderer.DrawItem
 	for _, sel := range s.ToolPicks() {
-		items = append(items, drawSelectable(sel, selectionHighlight)...)
+		items = append(items, drawSelectable(sel, chromeTheme.selectionHighlight)...)
 	}
 	return items
 }

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -142,7 +142,13 @@ func (fs *PartFeatures) indexByID() map[ID]int {
 // serializeFeature projects one feature into its FeatureData via the kind's registered codec (see
 // serialize_registry.go). A kind without a codec errors rather than dropping the feature silently.
 func serializeFeature(pf *PartFeature, sk SketchIndexer, idx map[ID]int) (FeatureData, error) {
-	c, ok := featureCodecs[pf.Kind()]
+	return serializeFeatureWith(featureCodecs, pf, sk, idx)
+}
+
+// serializeFeatureWith consults exactly the codec set it is handed — the injection
+// seam proving nothing falls back to a global (#1617, audit B6).
+func serializeFeatureWith(codecs featureCodecSet, pf *PartFeature, sk SketchIndexer, idx map[ID]int) (FeatureData, error) {
+	c, ok := codecs[pf.Kind()]
 	if !ok {
 		return FeatureData{}, fmt.Errorf("no serialization codec for feature kind %q", pf.Kind())
 	}
@@ -176,7 +182,12 @@ func (fs *PartFeatures) ApplyRecipe(data []FeatureData, sk SketchIndexer, work *
 // FindEdgeByKey/FindFaceByKey); patterns resolve their source features from restored (the features
 // built so far).
 func buildFeature(fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored []*PartFeature, work *WorkGeometry) (*PartFeature, error) {
-	c, ok := featureCodecs[fd.Kind]
+	return buildFeatureWith(featureCodecs, fs, fd, sk, restored, work)
+}
+
+// buildFeatureWith is the decode half of the injection seam (#1617).
+func buildFeatureWith(codecs featureCodecSet, fs *PartFeatures, fd FeatureData, sk SketchIndexer, restored []*PartFeature, work *WorkGeometry) (*PartFeature, error) {
+	c, ok := codecs[fd.Kind]
 	if !ok {
 		return nil, fmt.Errorf("no restore codec for feature kind %q", fd.Kind)
 	}

--- a/model/feature/serialize_codecs_cosmetic.go
+++ b/model/feature/serialize_codecs_cosmetic.go
@@ -12,8 +12,10 @@ func decodeCosmetic(rc *restoreContext, fd FeatureData) (*PartFeature, error) {
 	return restoreCosmetic(rc.fs, fd)
 }
 
-func init() {
-	registerFeatureCodec("decal", featureCodec{
+// registerCosmeticCodecs contributes this family's codecs to the default set (#1617);
+// formerly an init() registration.
+func (r featureCodecSet) registerCosmeticCodecs() {
+	r.register("decal", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			d := f.(*DecalFeature)
 			fd.Decal = &DecalData{Face: encodeKey(d.def.FaceKey), Image: d.def.Image}
@@ -21,7 +23,7 @@ func init() {
 		},
 		decode: decodeCosmetic,
 	})
-	registerFeatureCodec("reference", featureCodec{
+	r.register("reference", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			r := f.(*ReferenceFeature)
 			fd.Reference = &ReferenceData{Label: r.def.Label, Source: encodeKey(r.def.SourceKey)}
@@ -29,7 +31,7 @@ func init() {
 		},
 		decode: decodeCosmetic,
 	})
-	registerFeatureCodec("client", featureCodec{
+	r.register("client", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			c := f.(*ClientFeature)
 			fd.Client = &ClientData{AddIn: c.def.AddInID, Attributes: c.def.Attributes}
@@ -37,7 +39,7 @@ func init() {
 		},
 		decode: decodeCosmetic,
 	})
-	registerFeatureCodec("mark", featureCodec{
+	r.register("mark", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			m := f.(*MarkFeature)
 			fd.Mark = &MarkData{Faces: encodeKeys(m.def.FaceKeys), Text: m.def.Text}
@@ -45,7 +47,7 @@ func init() {
 		},
 		decode: decodeCosmetic,
 	})
-	registerFeatureCodec("finish", featureCodec{
+	r.register("finish", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fn := f.(*FinishFeature)
 			fd.Finish = &FinishData{Faces: encodeKeys(fn.def.FaceKeys), Spec: fn.def.Spec}
@@ -53,7 +55,7 @@ func init() {
 		},
 		decode: decodeCosmetic,
 	})
-	registerFeatureCodec("derivedAssembly", featureCodec{
+	r.register("derivedAssembly", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.DerivedAssembly = serializeDerivedAssembly(f.(*DerivedAssemblyComponent))
 			return nil
@@ -62,7 +64,7 @@ func init() {
 			return restoreDerivedAssembly(rc.fs, fd.DerivedAssembly)
 		},
 	})
-	registerFeatureCodec("derived", featureCodec{
+	r.register("derived", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.DerivedPart = serializeDerivedPart(f.(*DerivedPartComponent))
 			return nil
@@ -71,7 +73,7 @@ func init() {
 			return restoreDerivedPart(rc.fs, fd.DerivedPart)
 		},
 	})
-	registerFeatureCodec("shrinkwrap", featureCodec{
+	r.register("shrinkwrap", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.Shrinkwrap = serializeShrinkwrap(f.(*ShrinkwrapComponent))
 			return nil
@@ -80,7 +82,7 @@ func init() {
 			return restoreShrinkwrap(rc.fs, fd.Shrinkwrap)
 		},
 	})
-	registerFeatureCodec(kindBendPart, featureCodec{
+	r.register(kindBendPart, featureCodec{
 		encode: func(fd *FeatureData, f Feature, sk SketchIndexer, _ map[ID]int) error {
 			bd, err := serializeBend(f.(*BendPartFeature).def, sk)
 			fd.Bend = bd

--- a/model/feature/serialize_codecs_dressup.go
+++ b/model/feature/serialize_codecs_dressup.go
@@ -12,8 +12,10 @@ import (
 // simplify/unwrap clean-ups). Edge/face inputs persist as reference keys that re-bind to the
 // regenerated topology on the next recompute. Encode and decode are paired so they cannot drift (#1416).
 
-func init() {
-	registerFeatureCodec("fillet", featureCodec{
+// registerDressUpCodecs contributes this family's codecs to the default set (#1617);
+// formerly an init() registration.
+func (r featureCodecSet) registerDressUpCodecs() {
+	r.register("fillet", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			ff := f.(*FilletFeature)
 			if len(ff.def.EdgeSets) > 0 {
@@ -25,7 +27,7 @@ func init() {
 		},
 		decode: decodeFillet,
 	})
-	registerFeatureCodec("chamfer", featureCodec{
+	r.register("chamfer", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			cf := f.(*ChamferFeature)
 			flat := cf.def.FlatCorners
@@ -38,7 +40,7 @@ func init() {
 		},
 		decode: decodeChamfer,
 	})
-	registerFeatureCodec("face-fillet", featureCodec{
+	r.register("face-fillet", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			ff := f.(*FaceFilletFeature)
 			fd.FaceFillet = &FaceFilletData{FacesA: encodeKeys(ff.def.FaceKeysA), FacesB: encodeKeys(ff.def.FaceKeysB), Value: evalFloat(ff.def.Radius)}
@@ -46,7 +48,7 @@ func init() {
 		},
 		decode: decodeFaceFillet,
 	})
-	registerFeatureCodec("full-round-fillet", featureCodec{
+	r.register("full-round-fillet", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fr := f.(*FullRoundFilletFeature)
 			fd.FullRound = &FullRoundData{Side1: encodeKeys(fr.def.Side1Keys), Center: encodeKeys(fr.def.CenterKeys), Side2: encodeKeys(fr.def.Side2Keys)}
@@ -54,7 +56,7 @@ func init() {
 		},
 		decode: decodeFullRound,
 	})
-	registerFeatureCodec("rule-fillet", featureCodec{
+	r.register("rule-fillet", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			rf := f.(*RuleFilletFeature)
 			fd.RuleFillet = &RuleFilletData{Rule: rf.def.Rule.String(), Value: evalFloat(rf.def.Radius)}
@@ -62,7 +64,7 @@ func init() {
 		},
 		decode: decodeRuleFillet,
 	})
-	registerFeatureCodec("shell", featureCodec{
+	r.register("shell", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			sf := f.(*ShellFeature)
 			fd.Shell = &FaceDressData{Faces: encodeKeys(sf.def.RemovedFaceKeys), Value: evalFloat(sf.def.Thickness), GeomFaces: encodeGeomFaces(sf.def.GeomFaces)}
@@ -70,7 +72,7 @@ func init() {
 		},
 		decode: decodeShell,
 	})
-	registerFeatureCodec("draft", featureCodec{
+	r.register("draft", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			df := f.(*FaceDraftFeature)
 			p := df.def.PullDir
@@ -79,7 +81,7 @@ func init() {
 		},
 		decode: decodeDraft,
 	})
-	registerFeatureCodec("lip", featureCodec{
+	r.register("lip", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			lf := f.(*LipFeature)
 			fd.Lip = &LipData{Edges: encodeKeys(lf.def.EdgeKeys), Width: evalFloat(lf.def.Width), Height: evalFloat(lf.def.Height), Groove: lf.def.Groove}
@@ -89,7 +91,7 @@ func init() {
 			return restoreLip(rc.fs, fd.Lip)
 		},
 	})
-	registerFeatureCodec("simplify", featureCodec{
+	r.register("simplify", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			sf := f.(*SimplifyFeature)
 			fd.Simplify = &SimplifyData{RemoveFaces: encodeKeys(sf.def.RemoveFaceKeys), FillVoids: sf.def.FillVoids}
@@ -99,7 +101,7 @@ func init() {
 			return restoreSimplify(rc.fs, fd.Simplify)
 		},
 	})
-	registerFeatureCodec("unwrap", featureCodec{
+	r.register("unwrap", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			uf := f.(*UnwrapFeature)
 			fd.Unwrap = &UnwrapData{Face: encodeKey(uf.def.FaceKey), FaceAnchors: encodeFaceAnchors(uf.def.FaceAnchors)}

--- a/model/feature/serialize_codecs_faceedit.go
+++ b/model/feature/serialize_codecs_faceedit.go
@@ -12,15 +12,17 @@ func decodeFaceEdit(rc *restoreContext, fd FeatureData) (*PartFeature, error) {
 	return restoreFaceEdit(rc.fs, fd.Kind, fd.FaceEdit)
 }
 
-func init() {
-	registerFeatureCodec("move-face", featureCodec{
+// registerFaceEditCodecs contributes this family's codecs to the default set (#1617);
+// formerly an init() registration.
+func (r featureCodecSet) registerFaceEditCodecs() {
+	r.register("move-face", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.FaceEdit = serializeMoveFace(f.(*MoveFaceFeature))
 			return nil
 		},
 		decode: decodeFaceEdit,
 	})
-	registerFeatureCodec("face-offset", featureCodec{
+	r.register("face-offset", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fo := f.(*FaceOffsetFeature)
 			fd.FaceEdit = &FaceEditData{Faces: encodeKeys(fo.FaceKeys()), Distance: fo.Distance(),
@@ -29,7 +31,7 @@ func init() {
 		},
 		decode: decodeFaceEdit,
 	})
-	registerFeatureCodec("replace-face", featureCodec{
+	r.register("replace-face", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			rf := f.(*ReplaceFaceFeature)
 			fd.FaceEdit = &FaceEditData{Faces: encodeKeys(rf.FaceKeys()), Target: encodeKey(rf.TargetKey())}
@@ -40,7 +42,7 @@ func init() {
 	// split and delete-face carry only their face keys, via the generic faceEditor interface (any
 	// feature exposing FaceKeys() that is not one of the explicit kinds above).
 	for _, kind := range []string{"split", "delete-face"} {
-		registerFeatureCodec(kind, featureCodec{
+		r.register(kind, featureCodec{
 			encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 				fd.FaceEdit = &FaceEditData{Faces: encodeKeys(f.(faceEditor).FaceKeys())}
 				return nil

--- a/model/feature/serialize_codecs_pattern.go
+++ b/model/feature/serialize_codecs_pattern.go
@@ -6,8 +6,10 @@ package feature
 // records the earlier features it replicates as program indices (resolved through idx on encode and the
 // restored slice on decode). Encode and decode are paired so they cannot drift (#1416).
 
-func init() {
-	registerFeatureCodec("rectangular-pattern", featureCodec{
+// registerPatternCodecs contributes this family's codecs to the default set (#1617);
+// formerly an init() registration.
+func (r featureCodecSet) registerPatternCodecs() {
+	r.register("rectangular-pattern", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, idx map[ID]int) error {
 			p := f.(*RectangularPatternFeature)
 			src, err := sourceIndices(p.def.SourceFeatures, idx)
@@ -25,7 +27,7 @@ func init() {
 			return restoreRectPattern(rc.fs, fd.RectPattern, rc.restored)
 		},
 	})
-	registerFeatureCodec("circular-pattern", featureCodec{
+	r.register("circular-pattern", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, idx map[ID]int) error {
 			p := f.(*CircularPatternFeature)
 			src, err := sourceIndices(p.def.SourceFeatures, idx)
@@ -43,7 +45,7 @@ func init() {
 			return restoreCircPattern(rc.fs, fd.CircPattern, rc.restored)
 		},
 	})
-	registerFeatureCodec("sketch-driven-pattern", featureCodec{
+	r.register("sketch-driven-pattern", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, idx map[ID]int) error {
 			p := f.(*SketchDrivenPatternFeature)
 			src, err := sourceIndices(p.def.SourceFeatures, idx)
@@ -57,7 +59,7 @@ func init() {
 			return restoreSketchPattern(rc.fs, fd.SketchPattern, rc.restored)
 		},
 	})
-	registerFeatureCodec("mirror", featureCodec{
+	r.register("mirror", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, idx map[ID]int) error {
 			p := f.(*MirrorFeature)
 			src, err := sourceIndices(p.def.SourceFeatures, idx)

--- a/model/feature/serialize_codecs_sheetmetal.go
+++ b/model/feature/serialize_codecs_sheetmetal.go
@@ -7,8 +7,10 @@ package feature
 // paired so they cannot drift (#1416); the closures call the serializeX/restoreX helpers in this
 // family's serialize_sheet_metal_*.go files.
 
-func init() {
-	registerFeatureCodec("sheet-metal-face", featureCodec{
+// registerSheetMetalCodecs contributes this family's codecs to the default set (#1617);
+// formerly an init() registration.
+func (r featureCodecSet) registerSheetMetalCodecs() {
+	r.register("sheet-metal-face", featureCodec{
 		encode: func(fd *FeatureData, f Feature, sk SketchIndexer, _ map[ID]int) error {
 			sm, err := serializeSheetMetalFace(f.(*SheetMetalFaceFeature).def, sk)
 			fd.SheetMetalFace = sm
@@ -18,7 +20,7 @@ func init() {
 			return restoreSheetMetalFace(rc.fs, fd.SheetMetalFace, rc.sk)
 		},
 	})
-	registerFeatureCodec("sheet-metal-flange", featureCodec{
+	r.register("sheet-metal-flange", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.SheetMetalFlange = serializeSheetMetalFlange(f.(*SheetMetalFlangeFeature).def)
 			return nil
@@ -27,7 +29,7 @@ func init() {
 			return restoreSheetMetalFlange(rc.fs, fd.SheetMetalFlange)
 		},
 	})
-	registerFeatureCodec("sheet-metal-hem", featureCodec{
+	r.register("sheet-metal-hem", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.SheetMetalHem = serializeSheetMetalHem(f.(*SheetMetalHemFeature).def)
 			return nil
@@ -36,7 +38,7 @@ func init() {
 			return restoreSheetMetalHem(rc.fs, fd.SheetMetalHem)
 		},
 	})
-	registerFeatureCodec("sheet-metal-bend", featureCodec{
+	r.register("sheet-metal-bend", featureCodec{
 		encode: func(fd *FeatureData, f Feature, sk SketchIndexer, _ map[ID]int) error {
 			smb, err := serializeSheetMetalBend(f.(*SheetMetalBendFeature).def, sk)
 			fd.SheetMetalBend = smb
@@ -46,7 +48,7 @@ func init() {
 			return restoreSheetMetalBend(rc.fs, fd.SheetMetalBend, rc.sk)
 		},
 	})
-	registerFeatureCodec("sheet-metal-cosmetic-bend", featureCodec{
+	r.register("sheet-metal-cosmetic-bend", featureCodec{
 		encode: func(fd *FeatureData, f Feature, sk SketchIndexer, _ map[ID]int) error {
 			smcb, err := serializeSheetMetalCosmeticBend(f.(*SheetMetalCosmeticBendFeature).def, sk)
 			fd.SheetMetalCosmeticBend = smcb
@@ -56,7 +58,7 @@ func init() {
 			return restoreSheetMetalCosmeticBend(rc.fs, fd.SheetMetalCosmeticBend, rc.sk)
 		},
 	})
-	registerFeatureCodec("sheet-metal-rip", featureCodec{
+	r.register("sheet-metal-rip", featureCodec{
 		encode: func(fd *FeatureData, f Feature, sk SketchIndexer, _ map[ID]int) error {
 			smr, err := serializeSheetMetalRip(f.(*SheetMetalRipFeature).def, sk)
 			fd.SheetMetalRip = smr
@@ -66,7 +68,7 @@ func init() {
 			return restoreSheetMetalRip(rc.fs, fd.SheetMetalRip, rc.sk)
 		},
 	})
-	registerFeatureCodec("sheet-metal-punch", featureCodec{
+	r.register("sheet-metal-punch", featureCodec{
 		encode: func(fd *FeatureData, f Feature, sk SketchIndexer, _ map[ID]int) error {
 			smp, err := serializeSheetMetalPunch(f.(*SheetMetalPunchFeature).def, sk)
 			fd.SheetMetalPunch = smp
@@ -76,7 +78,7 @@ func init() {
 			return restoreSheetMetalPunch(rc.fs, fd.SheetMetalPunch, rc.sk)
 		},
 	})
-	registerFeatureCodec("sheet-metal-lip", featureCodec{
+	r.register("sheet-metal-lip", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.SheetMetalLip = serializeSheetMetalLip(f.(*SheetMetalLipFeature).def)
 			return nil
@@ -85,7 +87,7 @@ func init() {
 			return restoreSheetMetalLip(rc.fs, fd.SheetMetalLip)
 		},
 	})
-	registerFeatureCodec("sheet-metal-fold", featureCodec{
+	r.register("sheet-metal-fold", featureCodec{
 		encode: func(fd *FeatureData, f Feature, sk SketchIndexer, _ map[ID]int) error {
 			smf, err := serializeSheetMetalFold(f.(*SheetMetalFoldFeature).def, sk)
 			fd.SheetMetalFold = smf
@@ -95,7 +97,7 @@ func init() {
 			return restoreSheetMetalFold(rc.fs, fd.SheetMetalFold, rc.sk)
 		},
 	})
-	registerFeatureCodec("sheet-metal-corner", featureCodec{
+	r.register("sheet-metal-corner", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.SheetMetalCorner = serializeSheetMetalCorner(f.(*SheetMetalCornerFeature).def)
 			return nil
@@ -104,7 +106,7 @@ func init() {
 			return restoreSheetMetalCorner(rc.fs, fd.SheetMetalCorner)
 		},
 	})
-	registerFeatureCodec("sheet-metal-contour-flange", featureCodec{
+	r.register("sheet-metal-contour-flange", featureCodec{
 		encode: func(fd *FeatureData, f Feature, sk SketchIndexer, _ map[ID]int) error {
 			smcf, err := serializeSheetMetalContourFlange(f.(*SheetMetalContourFlangeFeature).def, sk)
 			fd.SheetMetalContourFlange = smcf
@@ -114,7 +116,7 @@ func init() {
 			return restoreSheetMetalContourFlange(rc.fs, fd.SheetMetalContourFlange, rc.sk)
 		},
 	})
-	registerFeatureCodec("sheet-metal-lofted-flange", featureCodec{
+	r.register("sheet-metal-lofted-flange", featureCodec{
 		encode: func(fd *FeatureData, f Feature, sk SketchIndexer, _ map[ID]int) error {
 			smlf, err := serializeSheetMetalLoftedFlange(f.(*SheetMetalLoftedFlangeFeature).def, sk)
 			fd.SheetMetalLoftedFlange = smlf
@@ -124,7 +126,7 @@ func init() {
 			return restoreSheetMetalLoftedFlange(rc.fs, fd.SheetMetalLoftedFlange, rc.sk)
 		},
 	})
-	registerFeatureCodec("sheet-metal-contour-roll", featureCodec{
+	r.register("sheet-metal-contour-roll", featureCodec{
 		encode: func(fd *FeatureData, f Feature, sk SketchIndexer, _ map[ID]int) error {
 			smcr, err := serializeSheetMetalContourRoll(f.(*SheetMetalContourRollFeature).def, sk)
 			fd.SheetMetalContourRoll = smcr
@@ -134,7 +136,7 @@ func init() {
 			return restoreSheetMetalContourRoll(rc.fs, fd.SheetMetalContourRoll, rc.sk)
 		},
 	})
-	registerFeatureCodec("sheet-metal-corner-seam", featureCodec{
+	r.register("sheet-metal-corner-seam", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.SheetMetalCornerSeam = serializeSheetMetalCornerSeam(f.(*SheetMetalCornerSeamFeature).def)
 			return nil
@@ -143,7 +145,7 @@ func init() {
 			return restoreSheetMetalCornerSeam(rc.fs, fd.SheetMetalCornerSeam)
 		},
 	})
-	registerFeatureCodec("sheet-metal-cut", featureCodec{
+	r.register("sheet-metal-cut", featureCodec{
 		encode: func(fd *FeatureData, f Feature, sk SketchIndexer, _ map[ID]int) error {
 			smc, err := serializeSheetMetalCut(f.(*SheetMetalCutFeature).def, sk)
 			fd.SheetMetalCut = smc
@@ -153,7 +155,7 @@ func init() {
 			return restoreSheetMetalCut(rc.fs, fd.SheetMetalCut, rc.sk)
 		},
 	})
-	registerFeatureCodec("sheet-metal-unfold", featureCodec{
+	r.register("sheet-metal-unfold", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.SheetMetalUnfold = &SheetMetalUnfoldData{Bends: serializeBendTransforms(f.(*SheetMetalUnfoldFeature).def.Bends)}
 			return nil
@@ -162,7 +164,7 @@ func init() {
 			return restoreSheetMetalUnfold(rc.fs, fd.SheetMetalUnfold)
 		},
 	})
-	registerFeatureCodec("sheet-metal-refold", featureCodec{
+	r.register("sheet-metal-refold", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.SheetMetalRefold = &SheetMetalRefoldData{Bends: serializeBendTransforms(f.(*SheetMetalRefoldFeature).def.Bends)}
 			return nil

--- a/model/feature/serialize_codecs_solid.go
+++ b/model/feature/serialize_codecs_solid.go
@@ -8,8 +8,10 @@ import "fmt"
 // per-face/whole-body modifiers). Each pairs the kind's encode and decode so they cannot drift (#1416);
 // the closures call the serializeX/restoreX helpers that live in this family's serialize_*.go files.
 
-func init() {
-	registerFeatureCodec("extrude", featureCodec{
+// registerSolidCodecs contributes this family's codecs to the default set (#1617);
+// formerly an init() registration.
+func (r featureCodecSet) registerSolidCodecs() {
+	r.register("extrude", featureCodec{
 		encode: func(fd *FeatureData, f Feature, sk SketchIndexer, _ map[ID]int) error {
 			ed, err := serializeExtrude(f.(*ExtrudeFeature).def, sk)
 			fd.Extrude = ed
@@ -19,7 +21,7 @@ func init() {
 			return requireExtrude(rc.fs, fd.Extrude, rc.sk, rc.work)
 		},
 	})
-	registerFeatureCodec("revolve", featureCodec{
+	r.register("revolve", featureCodec{
 		encode: func(fd *FeatureData, f Feature, sk SketchIndexer, _ map[ID]int) error {
 			rv, err := serializeRevolve(f.(*RevolveFeature).def, sk)
 			fd.Revolve = rv
@@ -29,7 +31,7 @@ func init() {
 			return restoreRevolve(rc.fs, fd.Revolve, rc.sk, rc.work)
 		},
 	})
-	registerFeatureCodec("coil", featureCodec{
+	r.register("coil", featureCodec{
 		encode: func(fd *FeatureData, f Feature, sk SketchIndexer, _ map[ID]int) error {
 			cd, err := serializeCoil(f.(*CoilFeature).def, sk)
 			fd.Coil = cd
@@ -39,7 +41,7 @@ func init() {
 			return restoreCoil(rc.fs, fd.Coil, rc.sk, rc.work)
 		},
 	})
-	registerFeatureCodec("sweep", featureCodec{
+	r.register("sweep", featureCodec{
 		encode: func(fd *FeatureData, f Feature, sk SketchIndexer, _ map[ID]int) error {
 			sw, err := serializeSweep(f.(*SweepFeature).def, sk)
 			fd.Sweep = sw
@@ -49,7 +51,7 @@ func init() {
 			return restoreSweep(rc.fs, fd.Sweep, rc.sk)
 		},
 	})
-	registerFeatureCodec("loft", featureCodec{
+	r.register("loft", featureCodec{
 		encode: func(fd *FeatureData, f Feature, sk SketchIndexer, _ map[ID]int) error {
 			lo, err := serializeLoft(f.(*LoftFeature).def, sk)
 			fd.Loft = lo
@@ -59,7 +61,7 @@ func init() {
 			return restoreLoft(rc.fs, fd.Loft, rc.sk)
 		},
 	})
-	registerFeatureCodec("rib", featureCodec{
+	r.register("rib", featureCodec{
 		encode: func(fd *FeatureData, f Feature, sk SketchIndexer, _ map[ID]int) error {
 			rd, err := serializeRib(f.(*RibFeature).def, sk)
 			fd.Rib = rd
@@ -69,7 +71,7 @@ func init() {
 			return restoreRib(rc.fs, fd.Rib, rc.sk)
 		},
 	})
-	registerFeatureCodec("emboss", featureCodec{
+	r.register("emboss", featureCodec{
 		encode: func(fd *FeatureData, f Feature, sk SketchIndexer, _ map[ID]int) error {
 			ed, err := serializeEmboss(f.(*EmbossFeature).def, sk)
 			fd.Emboss = ed
@@ -79,7 +81,7 @@ func init() {
 			return restoreEmboss(rc.fs, fd.Emboss, rc.sk)
 		},
 	})
-	registerFeatureCodec("rest", featureCodec{
+	r.register("rest", featureCodec{
 		encode: func(fd *FeatureData, f Feature, sk SketchIndexer, _ map[ID]int) error {
 			rd, err := serializeRest(f.(*RestFeature).def, sk)
 			fd.Rest = rd
@@ -89,7 +91,7 @@ func init() {
 			return restoreRest(rc.fs, fd.Rest, rc.sk)
 		},
 	})
-	registerFeatureCodec("grill", featureCodec{
+	r.register("grill", featureCodec{
 		encode: func(fd *FeatureData, f Feature, sk SketchIndexer, _ map[ID]int) error {
 			gd, err := serializeGrill(f.(*GrillFeature).def, sk)
 			fd.Grill = gd
@@ -99,7 +101,7 @@ func init() {
 			return restoreGrill(rc.fs, fd.Grill, rc.sk)
 		},
 	})
-	registerFeatureCodec("combine", featureCodec{
+	r.register("combine", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			cf := f.(*CombineFeature)
 			op, err := operationName(cf.def.Operation)
@@ -113,7 +115,7 @@ func init() {
 			return restoreCombine(rc.fs, fd.Combine)
 		},
 	})
-	registerFeatureCodec("splitSolid", featureCodec{
+	r.register("splitSolid", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			sd, err := serializeSplitSolid(f.(*SplitSolidFeature).def)
 			fd.SplitSolid = sd
@@ -123,7 +125,7 @@ func init() {
 			return restoreSplitSolid(rc.fs, fd.SplitSolid, rc.work)
 		},
 	})
-	registerFeatureCodec("delete-body", featureCodec{
+	r.register("delete-body", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.DeleteBody = serializeDeleteBody(f.(*DeleteBodyFeature).def)
 			return nil
@@ -132,7 +134,7 @@ func init() {
 			return restoreDeleteBody(rc.fs, fd.DeleteBody)
 		},
 	})
-	registerFeatureCodec("hole", featureCodec{
+	r.register("hole", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			h, err := serializeHole(f.(*HoleFeature).def)
 			fd.Hole = h
@@ -142,7 +144,7 @@ func init() {
 			return restoreHole(rc.fs, fd.Hole)
 		},
 	})
-	registerFeatureCodec("boss", featureCodec{
+	r.register("boss", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			b := f.(*BossFeature)
 			fd.Boss = &BossData{Face: encodeKey(b.def.PlacementFaceKey), Diameter: evalFloat(b.def.Diameter), Height: evalFloat(b.def.Height), FaceAnchors: encodeFaceAnchors(b.def.FaceAnchors)}
@@ -152,7 +154,7 @@ func init() {
 			return restoreBoss(rc.fs, fd.Boss)
 		},
 	})
-	registerFeatureCodec("thread", featureCodec{
+	r.register("thread", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			t := f.(*ThreadFeature)
 			fd.Thread = &ThreadData{Face: encodeKey(t.def.FaceKey), Designation: t.def.Designation, Cut: t.def.Cut,
@@ -162,7 +164,7 @@ func init() {
 		},
 		decode: decodeThread,
 	})
-	registerFeatureCodec("snap-fit", featureCodec{
+	r.register("snap-fit", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			d := f.(*SnapFitFeature).def
 			fd.SnapFit = &SnapFitData{
@@ -173,7 +175,7 @@ func init() {
 		},
 		decode: decodeSnapFit,
 	})
-	registerFeatureCodec("thicken", featureCodec{
+	r.register("thicken", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			t := f.(*ThickenFeature)
 			fd.Thicken = &ThickenData{Value: t.Thickness(), Approximation: approximationName(t.Approximation())}
@@ -181,7 +183,7 @@ func init() {
 		},
 		decode: decodeThicken,
 	})
-	registerFeatureCodec("move", featureCodec{
+	r.register("move", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.Move = serializeMove(f.(*MoveFeature).def)
 			return nil
@@ -190,7 +192,7 @@ func init() {
 			return restoreMove(rc.fs, fd.Move)
 		},
 	})
-	registerFeatureCodec("directEdit", featureCodec{
+	r.register("directEdit", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.DirectEdit = serializeDirectEdit(f.(*DirectEditFeature).def)
 			return nil
@@ -199,7 +201,7 @@ func init() {
 			return restoreDirectEdit(rc.fs, fd.DirectEdit)
 		},
 	})
-	registerFeatureCodec("importedBody", featureCodec{
+	r.register("importedBody", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.Import = serializeImportedBody(f.(*ImportedBodyFeature))
 			return nil
@@ -208,7 +210,7 @@ func init() {
 			return restoreImportedBody(rc.fs, fd.Import)
 		},
 	})
-	registerFeatureCodec("mesh-solid", featureCodec{
+	r.register("mesh-solid", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.MeshSolid = serializeMeshSolid(f.(*MeshSolidFeature).geom)
 			return nil
@@ -217,7 +219,7 @@ func init() {
 			return restoreMeshSolid(rc.fs, fd.MeshSolid)
 		},
 	})
-	registerFeatureCodec("modelTolerance", featureCodec{
+	r.register("modelTolerance", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.ModelTolerance = serializeModelTolerance(f.(*ModelToleranceFeature).def)
 			return nil

--- a/model/feature/serialize_codecs_surface.go
+++ b/model/feature/serialize_codecs_surface.go
@@ -6,8 +6,10 @@ package feature
 // rebuild/match/extend/untrim/fair/fit surface edits). Encode and decode are paired so they cannot
 // drift (#1416); the closures call the serializeX/restoreX helpers in this family's serialize_*.go files.
 
-func init() {
-	registerFeatureCodec("boundary-patch", featureCodec{
+// registerSurfaceCodecs contributes this family's codecs to the default set (#1617);
+// formerly an init() registration.
+func (r featureCodecSet) registerSurfaceCodecs() {
+	r.register("boundary-patch", featureCodec{
 		encode: func(fd *FeatureData, f Feature, sk SketchIndexer, _ map[ID]int) error {
 			bp, err := serializeBoundaryPatch(f.(*BoundaryPatchFeature).def, sk)
 			fd.BoundaryPatch = bp
@@ -17,7 +19,7 @@ func init() {
 			return restoreBoundaryPatch(rc.fs, fd.BoundaryPatch, rc.sk)
 		},
 	})
-	registerFeatureCodec("ruled-surface", featureCodec{
+	r.register("ruled-surface", featureCodec{
 		encode: func(fd *FeatureData, f Feature, sk SketchIndexer, _ map[ID]int) error {
 			rs, err := serializeRuledSurface(f.(*RuledSurfaceFeature).def, sk)
 			fd.RuledSurface = rs
@@ -27,7 +29,7 @@ func init() {
 			return restoreRuledSurface(rc.fs, fd.RuledSurface, rc.sk)
 		},
 	})
-	registerFeatureCodec("rebuild-surface", featureCodec{
+	r.register("rebuild-surface", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.Rebuild = serializeRebuild(f.(*RebuildFeature).def)
 			return nil
@@ -36,7 +38,7 @@ func init() {
 			return restoreRebuild(rc.fs, fd.Rebuild)
 		},
 	})
-	registerFeatureCodec("control-point-edit", featureCodec{
+	r.register("control-point-edit", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.ControlPointEdit = serializeControlPointEdit(f.(*ControlPointEditFeature).def)
 			return nil
@@ -45,7 +47,7 @@ func init() {
 			return restoreControlPointEdit(rc.fs, fd.ControlPointEdit)
 		},
 	})
-	registerFeatureCodec("nurbs-plane", featureCodec{
+	r.register("nurbs-plane", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.NurbsPlane = serializeNurbsPlane(f.(*NurbsPlaneFeature).def)
 			return nil
@@ -54,7 +56,7 @@ func init() {
 			return restoreNurbsPlane(rc.fs, fd.NurbsPlane)
 		},
 	})
-	registerFeatureCodec("match-surface", featureCodec{
+	r.register("match-surface", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.Match = serializeMatch(f.(*MatchFeature).def)
 			return nil
@@ -63,7 +65,7 @@ func init() {
 			return restoreMatch(rc.fs, fd.Match)
 		},
 	})
-	registerFeatureCodec("extend-surface", featureCodec{
+	r.register("extend-surface", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.ExtendSurface = serializeExtendSurface(f.(*ExtendSurfaceFeature).def)
 			return nil
@@ -72,7 +74,7 @@ func init() {
 			return restoreExtendSurface(rc.fs, fd.ExtendSurface)
 		},
 	})
-	registerFeatureCodec("untrim-surface", featureCodec{
+	r.register("untrim-surface", featureCodec{
 		encode: func(fd *FeatureData, _ Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.Untrim = &UntrimData{}
 			return nil
@@ -81,7 +83,7 @@ func init() {
 			return restoreUntrim(rc.fs, fd.Untrim)
 		},
 	})
-	registerFeatureCodec("fill-surface", featureCodec{
+	r.register("fill-surface", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.FillSurface = serializeFillSurface(f.(*FillFeature).def)
 			return nil
@@ -90,7 +92,7 @@ func init() {
 			return restoreFillSurface(rc.fs, fd.FillSurface)
 		},
 	})
-	registerFeatureCodec("bridge-surface", featureCodec{
+	r.register("bridge-surface", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.BridgeSurface = serializeBridgeSurface(f.(*BridgeFeature).def)
 			return nil
@@ -99,7 +101,7 @@ func init() {
 			return restoreBridgeSurface(rc.fs, fd.BridgeSurface)
 		},
 	})
-	registerFeatureCodec("network-surface", featureCodec{
+	r.register("network-surface", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.NetworkSurface = serializeNetworkSurface(f.(*NetworkFeature).def)
 			return nil
@@ -108,7 +110,7 @@ func init() {
 			return restoreNetworkSurface(rc.fs, fd.NetworkSurface)
 		},
 	})
-	registerFeatureCodec("fair-surface", featureCodec{
+	r.register("fair-surface", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.FairSurface = serializeFairSurface(f.(*FairFeature).def)
 			return nil
@@ -117,7 +119,7 @@ func init() {
 			return restoreFairSurface(rc.fs, fd.FairSurface)
 		},
 	})
-	registerFeatureCodec("fit-surface", featureCodec{
+	r.register("fit-surface", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			fd.FitSurface = serializeFitSurface(f.(*FitFeature).def)
 			return nil

--- a/model/feature/serialize_registry.go
+++ b/model/feature/serialize_registry.go
@@ -31,23 +31,44 @@ type restoreContext struct {
 	work     *WorkGeometry
 }
 
-// featureCodecs maps a feature kind to its codec. Populated by the serialize_codecs_*.go init()s; read
-// by serializeFeature/buildFeature. Read-only after init, so no synchronization is needed.
-var featureCodecs = map[string]featureCodec{}
+// featureCodecSet maps feature kinds to their codecs — the value serializeFeature/buildFeature
+// consult, and the seam a test can inject a minimal set through (#1617, audit B6).
+type featureCodecSet map[string]featureCodec
 
-// registerFeatureCodec records one kind's codec, panicking on a duplicate or an incomplete pair — a
-// programming error caught at startup, not a silent overwrite. Called from family init()s.
-func registerFeatureCodec(kind string, c featureCodec) {
+// featureCodecs is the package default: every production codec, constructed in ONE
+// visible order by defaultFeatureCodecs. This is the package's composition site —
+// there are no init() registrations (#1617), so what serializes is decided by
+// explicit construction, not import linkage.
+var featureCodecs = defaultFeatureCodecs()
+
+// defaultFeatureCodecs assembles the full production codec set, one register call
+// per feature family (the former serialize_codecs_*.go init() bodies, now named
+// and explicitly ordered).
+func defaultFeatureCodecs() featureCodecSet {
+	r := featureCodecSet{}
+	r.registerSolidCodecs()
+	r.registerDressUpCodecs()
+	r.registerPatternCodecs()
+	r.registerFaceEditCodecs()
+	r.registerSurfaceCodecs()
+	r.registerSheetMetalCodecs()
+	r.registerCosmeticCodecs()
+	return r
+}
+
+// register records one kind's codec, panicking on a duplicate or an incomplete pair — a
+// programming error caught at construction, not a silent overwrite.
+func (r featureCodecSet) register(kind string, c featureCodec) {
 	if kind == "" {
-		panic("feature: registerFeatureCodec with empty kind")
+		panic("feature: register with empty kind")
 	}
 	if c.encode == nil || c.decode == nil {
 		panic(fmt.Sprintf("feature: codec for kind %q must have both encode and decode", kind))
 	}
-	if _, dup := featureCodecs[kind]; dup {
+	if _, dup := r[kind]; dup {
 		panic(fmt.Sprintf("feature: duplicate serialization codec for kind %q", kind))
 	}
-	featureCodecs[kind] = c
+	r[kind] = c
 }
 
 // registeredFeatureKinds returns the kinds with a codec, for the enumerating round-trip test.

--- a/model/feature/serialize_registry_test.go
+++ b/model/feature/serialize_registry_test.go
@@ -71,14 +71,14 @@ func TestRegisterFeatureCodecRejectsHalfCodec(t *testing.T) {
 		{"empty kind", "", good},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			assertPanics(t, func() { registerFeatureCodec(tc.kind, tc.c) })
+			assertPanics(t, func() { featureCodecs.register(tc.kind, tc.c) })
 		})
 	}
 
 	// A duplicate registration (two codecs claiming one kind) must also panic — pick an already-registered
 	// kind so the second registration collides.
 	t.Run("duplicate", func(t *testing.T) {
-		assertPanics(t, func() { registerFeatureCodec("extrude", good) })
+		assertPanics(t, func() { featureCodecs.register("extrude", good) })
 	})
 }
 
@@ -92,3 +92,34 @@ func assertPanics(t *testing.T, fn func()) {
 	}()
 	fn()
 }
+
+// TestSerializeConsultsInjectedCodecSet pins the B6 injection seam (#1617): the
+// marshal/unmarshal helpers consult exactly the set they are handed — a minimal
+// one-codec set serializes its kind and honestly rejects every other, proving
+// nothing falls back to a package global.
+func TestSerializeConsultsInjectedCodecSet(t *testing.T) {
+	minimal := featureCodecSet{}
+	minimal.register("test.minimal", featureCodec{
+		encode: func(fd *FeatureData, _ Feature, _ SketchIndexer, _ map[ID]int) error {
+			fd.Name = "via-injected-codec"
+			return nil
+		},
+		decode: func(*restoreContext, FeatureData) (*PartFeature, error) { return nil, nil },
+	})
+	pf := &PartFeature{feature: minimalKindFeature{}}
+	fd, err := serializeFeatureWith(minimal, pf, nil, nil)
+	if err != nil || fd.Name != "via-injected-codec" {
+		t.Fatalf("injected encode = (%+v, %v), want the minimal codec's output", fd, err)
+	}
+	if _, err := serializeFeatureWith(minimal, &PartFeature{feature: fakeFeature{}}, nil, nil); err == nil {
+		t.Error("a kind outside the injected set serialized — a global fallback exists")
+	}
+	if _, err := buildFeatureWith(minimal, nil, FeatureData{Kind: "extrude"}, nil, nil, nil); err == nil {
+		t.Error("extrude decoded through a set that does not contain it — a global fallback exists")
+	}
+}
+
+// minimalKindFeature carries the kind the minimal injected codec registers.
+type minimalKindFeature struct{ fakeFeature }
+
+func (minimalKindFeature) Kind() string { return "test.minimal" }


### PR DESCRIPTION
Closes #1617 (audit B6). Completes the composition-root migration begun in #1686 (contentFactories + the init-registration guard).

## What

Three slices, each an in-package registry converted from init()-time side effects to ONE explicit, ordered default-set constructor per ADR-1 of the architect consult (injection seams only at true variation points — threading these sets through `doc.RecipeContent` would couple persistence vocabulary into the content-agnostic format boundary, ADR-0020):

- **Feature codecs (2/4)**: `defaultFeatureCodecs()` builds the 79-codec set by calling each family's register method in one visible order; the seven init()s are gone. `serializeFeatureWith`/`buildFeatureWith` consult exactly the set they are handed; `TestSerializeConsultsInjectedCodecSet` proves a minimal one-codec set works with no global fallback.
- **Feature editors (3/4)**: the full-panel editor registry becomes a `featureEditorSet` Session field assembled by `defaultFeatureEditors()` in `newSession` — the composition root the acceptance criteria name. Consumers become Session methods, threading the session through the browser-menu chain. `TestSessionConsultsInjectedEditorSet` pins it.
- **Theme + dockable panels (4/4)**: the ~16 mutable package-level color arrays collapse into one `themePalette` object with a single writer (`applyThemeIfChanged`, top of DrawChrome — the UI loop owns its lifecycle); the dockable-panel registry constructs from its table via `defaultDockablePanels()` (duplicate-title panic preserved).

The archguard init-registration allowlist (red-verified in #1686) shrinks to only the model/sketch codec files — the #1624/#1625 registries, same in-package class, tracked as a follow-up.

## Documented deviation

The issue's acceptance wording has `NewSession` receive the codec set too; per the architect consult that seam would be fake — feature codecs are registered AND consumed inside model/feature, so the injection point is the consumption functions, where a test can actually vary the set. The Session receives what it genuinely owns (the editor set).

## Verification

- Full suite green (`go test -count=1 ./...`), golangci-lint 0 issues (root config and head's `make lint`).
- **Live**: `mcplive -part entityseam` .obk round trip green on the stacked branch; `head/cmd/i3gateshot` renders the full themed chrome through the palette object — accents, highlights and clear colors intact, PNGs inspected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)