### PR TITLE
Curvature-based step control and step acceptance for SSI marching

### DIFF
--- a/kernel/brep/curved_crossing_imprint.go
+++ b/kernel/brep/curved_crossing_imprint.go
@@ -3,6 +3,8 @@
 package brep
 
 import (
+	stdmath "math"
+
 	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
@@ -35,6 +37,12 @@ const CodeImprintUnclosedChain diag.Code = "imprint.unclosed-chain"
 // recorded instead of silent.
 const CodeImprintFallbackContour diag.Code = "imprint.fallback-contour"
 
+// CodeImprintNearPinchDeclined marks a crossing-cylinder imprint declined because the radii are
+// near-equal (the near-pinch Steinmetz band): the general rod-band assembly is input-sensitive
+// there, so the boolean takes the deterministic faceted fallback and records the degradation
+// instead of assembling silently wrong analytic topology (#1598; unification tracked by #1403).
+const CodeImprintNearPinchDeclined diag.Code = "imprint.near-pinch-declined"
+
 // imprintTraceLoops traces base∩other over window and keeps the loops that close — the shared trace
 // step of every curved-imprint pair (cylinder∩cylinder, cone∩cylinder, cone∩cone).
 func imprintTraceLoops(base, other geom.Surface, window geom.SurfaceGrid, res geom.Resolution, rec *diag.Recorder) []geom.Polyline {
@@ -61,6 +69,18 @@ func crossingCylinderImprint(a, b *topo.Body, rec *diag.Recorder) ([]geom.Polyli
 	ca, baseA, heightA, okA := cylinderSolidParams(facesOfAny(a))
 	cb, _, _, okB := cylinderSolidParams(facesOfAny(b))
 	if !okA || !okB {
+		return nil, false
+	}
+	// Near-equal radii approach the pinched Steinmetz configuration: the intersection
+	// loops hug the tangency line with hairpin turns, and the general rod-band
+	// split/classify downstream is input-sensitive there (face count and volume vary
+	// with sampling — observed at |Δr|/r ≤ 5e-5, #1598). Equal radii take the exact
+	// bespoke Steinmetz constructor; the near-equal band between declines the general
+	// path so the boolean falls back to the recorded, deterministic faceted route
+	// instead of assembling silently wrong analytic topology (#1403 tracks unifying it).
+	if relDr := stdmath.Abs(ca.Radius-cb.Radius) / stdmath.Max(ca.Radius, cb.Radius); relDr > 0 && relDr < 2.5e-4 {
+		rec.Recordf(CodeImprintNearPinchDeclined, diag.Defect,
+			"crossing cylinders with near-equal radii (|Δr|/r = %.2g) decline the general imprint: near-pinch saddle topology, falling back", relDr)
 		return nil, false
 	}
 	res := geom.ResolutionForBox(a.RangeBox().Union(b.RangeBox())) // model-relative loop-closure weld (#1399)

--- a/kernel/geom/intersect_surface_trace.go
+++ b/kernel/geom/intersect_surface_trace.go
@@ -37,7 +37,65 @@ const (
 	// tolerance reachable by the NURBS Gauss–Newton projection; 4e-3 keeps a full curve to a few
 	// thousand points while resolving curvature.
 	ssiToleranceFraction = 1e-7 // tol:numeric — dimensionless fraction of the patch 3D extent (model-relative)
-	ssiStepFraction      = 4e-3 // tol:numeric — dimensionless fraction of the patch 3D extent (model-relative)
+	// ssiStepFraction is the INITIAL march step h₀ (the pre-#1598 fixed step, now only a
+	// bootstrap guess): the curvature controller below adapts h from there each accepted
+	// step, and the acceptance gates halve it out of high-curvature trouble at the first
+	// prediction if the seed sits in a tight region.
+	ssiStepFraction = 4e-3 // tol:numeric — dimensionless fraction of the patch 3D extent (model-relative)
+	// Curvature-based step control (#1598, audit A2; Bajaj et al. 1988). The chord of a
+	// step h on a curve of curvature κ sags ≈ κh²/8; bounding the sag by the chordal
+	// budget ε gives h = 2√(2ε/κ). ε is the DOWNSTREAM deflection budget (what the
+	// splitter/tessellator absorbs, ADR-0042 model-relative) — three decades looser than
+	// the on-curve tolerance. h is clamped to [min,max] fractions of the extent: the max
+	// keeps a straight line from crawling, the min (200× the on-curve tol) is what lets
+	// loops far smaller than the old fixed step be traced at all.
+	ssiChordFraction   = 1e-4 // tol:numeric — chordal sag budget ε as a fraction of the extent
+	ssiMinStepFraction = 2e-5 // tol:numeric — h floor (200× on-curve tol; below it corrector jitter dominates)
+	// The h ceiling equals the pre-#1598 fixed step: the controller only ever REFINES
+	// below the historical spacing, never coarsens past it — the curved-boolean
+	// split/stitch consumers are tuned to chords of at most that length, and letting
+	// h grow 5× beyond it silently corrupted near-tangent unions (their long low-κ
+	// flanks coarsened while the loops themselves stayed correct). Raising the ceiling
+	// is a follow-up for when the consumers derive their gates from the polyline
+	// itself rather than the historical step (#1403 pipeline work).
+	ssiMaxStepFraction = ssiStepFraction
+	// Per-step controller limits: grow at most ×1.4 per accepted step (≈√2 — doubles h in
+	// two steps on a straightening curve), halve on rejection; at the h floor allow two
+	// retries before terminating the sweep OPEN (an honest partial curve beats marching
+	// onto the wrong branch).
+	ssiStepGrow           = 1.4
+	ssiRejectRetriesAtMin = 2
+	// Step acceptance gates (the OCCT IntWalk_PWalking StatusDeflection pattern in object
+	// space). A legitimate same-branch step turns by ≈ κh = 2√(2εκ) ≤ ~40° at the h floor,
+	// so 45° is the tightest turn gate that never rejects a legal step — while a
+	// branch-jump at a pinch turns by the full crossing angle or reverses outright. The
+	// corrector displacement on a legal step is ≈ the sag ≈ ε ≪ h, so half a step is a
+	// generous displacement bound that only a jump or a curvature under-estimate trips.
+	ssiTurnGateCos = 0.70710678118654752 // cos 45° — max tangent turn per accepted step
+	// The corrector displacement on a same-branch step is ≈ κh²/2 = 4× the chord sag, so
+	// gating it at 4ε enforces the sag budget DIRECTLY — including on the very first
+	// bootstrap steps, before any curvature estimate exists. The ½h cap stays as the
+	// coarse branch-jump bound. The step law plans with a 0.8 safety factor so a
+	// κ-planned step sits at ≈2.6ε, comfortably inside the gate.
+	ssiDisplacementGate    = 0.5 // max corrector displacement as a fraction of h
+	ssiDisplacementSagGate = 4.0 // max corrector displacement as a multiple of ε
+	ssiStepSafety          = 0.8 // fraction of the exact sag-limited step the law plans
+	// Loop closure requires position AND direction (#1404): within ¾ of the CURRENT step
+	// of the start, with the tangent aligned to the first accepted step's tangent within
+	// 30° — at a pinch the other branch crosses at a steeper angle (90° for equal-radius
+	// Steinmetz) and is rejected, so the march keeps going instead of falsely closing.
+	// The gate opens only after 3 current-steps of accumulated arc length, so a loop
+	// traced at the h floor can still close while the first few steps cannot self-close.
+	ssiCloseTangentCos = 0.86602540378443865 // cos 30° — closure tangent alignment
+	// ssiTangencyBrakeCos opens the near-tangency brake band: once the surface normals
+	// align within ~8° the march is entering a pinch/tangency neighbourhood and the step
+	// caps at half the bootstrap (see accept), regardless of the discrete curvature.
+	ssiTangencyBrakeCos = 0.99 // tol:angular
+	ssiCloseArcSteps    = 3.0  // min accumulated arc length before closing, in current steps
+	// ssiMaxArcExtents caps a sweep by ACCUMULATED ARC LENGTH (in extents): the old
+	// fixed-step count cap alone would let a pathological h-floor march spin thousands of
+	// tiny steps; a real intersection curve on the patch cannot exceed a few extents.
+	ssiMaxArcExtents = 64.0
 	// Step multiples used while marching: a seed within ssiDedupSteps of an existing curve is a
 	// duplicate of it; the loop closes when the march returns within ssiLoopCloseSteps of its start;
 	// a tangency seed may sit up to ssiTangencyGapSteps from the contact (the strict normal test, not
@@ -63,7 +121,10 @@ const (
 type ssiTracer struct {
 	base, other Surface
 	g           SurfaceGrid
-	step, tol   float64
+	step, tol   float64 // step = the BOOTSTRAP h₀; the controller adapts from it (#1598)
+	eps         float64 // chordal sag budget ε (model-relative)
+	hMin, hMax  float64 // adaptive-step clamps
+	arcCap      float64 // max accumulated arc length per sweep
 }
 
 // traceIntersectionCurves returns the intersection curve(s) of base and other as polylines whose every
@@ -75,7 +136,7 @@ func traceIntersectionCurves(base, other Surface, grid SurfaceGrid) [][]math.Poi
 	if g.UMax <= g.UMin || g.VMax <= g.VMin {
 		return nil
 	}
-	tr := ssiTracer{base: base, other: other, g: g, step: ssiStep(base, g), tol: ssiTolerance(base, g)}
+	tr := newSSITracer(base, other, g)
 	var curves [][]math.Point3
 	for _, seed := range ssiSeeds(base, other, g) {
 		if len(curves) >= ssiMaxCurves {
@@ -121,33 +182,197 @@ func (tr ssiTracer) marchCurve(pc math.Point3, nb, no math.Vector3) []math.Point
 }
 
 // marchOneWay steps from start in one direction (forward=along +nb×no, else −) and returns the points
-// reached plus whether it closed back onto start (a loop).
+// reached plus whether it closed back onto start (a loop). Each step is curvature-controlled and
+// gate-checked (#1598): predict h along the tangent, correct onto the curve, then accept only if the
+// corrector stayed near the prediction, made forward progress, and turned the tangent within the
+// same-branch bound — otherwise reject and halve. The step then follows h = 2√(2ε/κ) from the discrete
+// curvature of the last three accepted points, rate-limited so the controller cannot thrash.
 func (tr ssiTracer) marchOneWay(start math.Point3, nb, no math.Vector3, forward bool) ([]math.Point3, bool) {
-	var pts []math.Point3
-	p := start
 	dir, ok := curveTangent(nb, no, forward)
 	if !ok {
-		return pts, false
+		return nil, false
 	}
-	for i := 0; i < ssiMaxStepsPerCurve; i++ {
-		pred := p.TranslateBy(dir.Scale(math.Scalar(tr.step)))
-		pc, nbc, noc, ok := correctToBothSurfaces(tr.base, tr.other, pred, tr.tol)
-		if !ok {
-			return pts, false
+	sw := ssiSweep{tr: tr, p: start, start: start, dir: dir, h: tr.step}
+	for i := 0; i < ssiMaxStepsPerCurve && sw.arc < tr.arcCap; i++ {
+		pc, tc, verdict := sw.attemptStep()
+		switch verdict {
+		case ssiStepRejected:
+			if !sw.halve() {
+				return sw.pts, false // stuck at the h floor: honest open curve (#1598)
+			}
+		case ssiStepExited:
+			return append(sw.pts, pc), false // exited the base window: keep the boundary point
+		case ssiStepClosed:
+			return append(sw.pts, sw.start), true
+		case ssiStepAccepted:
+			sw.accept(pc, tc)
 		}
-		if !inWindow(tr.base, pc, tr.g) {
-			return append(pts, pc), false // exited the base window: keep the boundary point
-		}
-		if i > 2 && start.DistanceTo(pc) < tr.step*ssiLoopCloseSteps {
-			return append(pts, start), true // closed the loop
-		}
-		if moved, err := math.UnitVector3FromVector(p.VectorTo(pc)); err == nil {
-			dir = orient(nbc.Cross(noc), moved.AsVector()) // keep marching in the same heading
-		}
-		pts = append(pts, pc)
-		p = pc
 	}
-	return pts, false
+	return sw.pts, false
+}
+
+// newSSITracer derives the model-relative controller context from the base patch extent.
+func newSSITracer(base, other Surface, g SurfaceGrid) ssiTracer {
+	h0 := ssiStep(base, g)
+	extent := h0 / ssiStepFraction
+	return ssiTracer{
+		base: base, other: other, g: g,
+		step: h0, tol: ssiTolerance(base, g),
+		eps:  ssiChordFraction * extent,
+		hMin: ssiMinStepFraction * extent, hMax: ssiMaxStepFraction * extent,
+		arcCap: ssiMaxArcExtents * extent,
+	}
+}
+
+// ssiStepVerdict classifies one predict-correct attempt.
+type ssiStepVerdict int
+
+const (
+	ssiStepAccepted ssiStepVerdict = iota
+	ssiStepRejected
+	ssiStepExited
+	ssiStepClosed
+)
+
+// ssiSweep is the mutable state of one directional march: current point and heading, adaptive step,
+// accumulated arc length, the last accepted point (for the discrete curvature), and the tangent of the
+// first accepted step (the closure gate's direction reference — the seed's analytic tangent may sit
+// within tolerance of a pinch where nb×no is unreliable).
+type ssiSweep struct {
+	tr           ssiTracer
+	p, start     math.Point3
+	pPrev        math.Point3
+	havePrev     bool
+	dir          math.Vector3
+	startTan     math.Vector3
+	haveStartTan bool
+	h, arc       float64
+	align        float64 // |nb·no| at the last corrected point (tangency proximity)
+	rejectsAtMin int
+	pts          []math.Point3
+}
+
+// attemptStep predicts one step of h along the heading, corrects onto the curve, and runs the
+// acceptance gates in order: corrector convergence, forward progress (a corrector landing behind the
+// heading has jumped branches or folded), corrector displacement, tangent turn, window exit, closure.
+func (sw *ssiSweep) attemptStep() (math.Point3, math.Vector3, ssiStepVerdict) {
+	pred := sw.p.TranslateBy(sw.dir.Scale(math.Scalar(sw.h)))
+	pc, nbc, noc, ok := correctToBothSurfaces(sw.tr.base, sw.tr.other, pred, sw.tr.tol)
+	if !ok {
+		return pc, math.Vector3{}, ssiStepRejected
+	}
+	moved, err := math.UnitVector3FromVector(sw.p.VectorTo(pc))
+	if err != nil || float64(moved.AsVector().Dot(sw.dir)) <= 0 {
+		return pc, math.Vector3{}, ssiStepRejected // no progress, or backtracked
+	}
+	if d := float64(pred.DistanceTo(pc)); d > ssiDisplacementGate*sw.h || d > ssiDisplacementSagGate*sw.tr.eps {
+		return pc, math.Vector3{}, ssiStepRejected // corrector left the prediction / sag over budget
+	}
+	tc := orient(nbc.Cross(noc), moved.AsVector())
+	sw.align = stdmath.Abs(float64(nbc.Dot(noc)))
+	if float64(tc.Dot(sw.dir)) < ssiTurnGateCos {
+		return pc, tc, ssiStepRejected // turned harder than any same-branch step can (#1598)
+	}
+	if !inWindow(sw.tr.base, pc, sw.tr.g) {
+		return pc, tc, ssiStepExited
+	}
+	if sw.closes(pc, tc) {
+		return pc, tc, ssiStepClosed
+	}
+	return pc, tc, ssiStepAccepted
+}
+
+// closes reports whether pc closes the loop: enough arc marched, back within ¾ of the CURRENT step of
+// the start, AND heading the same way as the sweep's first accepted step — position alone falsely
+// closes at a pinch, where the other branch passes through the start point at a crossing angle (#1404).
+func (sw *ssiSweep) closes(pc math.Point3, tc math.Vector3) bool {
+	if !sw.haveStartTan || sw.arc <= ssiCloseArcSteps*sw.h {
+		return false
+	}
+	if float64(sw.start.DistanceTo(pc)) >= sw.h*ssiLoopCloseSteps {
+		return false
+	}
+	return float64(tc.Dot(sw.startTan)) >= ssiCloseTangentCos
+}
+
+// halve rejects the pending step: shrink h toward the floor, and once AT the floor allow a bounded
+// number of retries before the sweep gives up (returning the curve traced so far, open).
+func (sw *ssiSweep) halve() bool {
+	if sw.h > sw.tr.hMin {
+		sw.h = stdmath.Max(sw.h/2, sw.tr.hMin)
+		return true
+	}
+	sw.rejectsAtMin++
+	return sw.rejectsAtMin <= ssiRejectRetriesAtMin
+}
+
+// accept commits pc: record it, advance the heading, and re-plan h from the discrete curvature of the
+// last three accepted points via h = 2√(2ε/κ), rate-limited to [½, ×1.4] per step and clamped to
+// [hMin, hMax]. The one-step lag of the discrete estimate is covered by the acceptance gates.
+func (sw *ssiSweep) accept(pc math.Point3, tc math.Vector3) {
+	sw.rejectsAtMin = 0
+	if !sw.haveStartTan {
+		sw.startTan, sw.haveStartTan = tc, true
+	}
+	sw.arc += float64(sw.p.DistanceTo(pc))
+	hPlan := sw.tr.hMax
+	if kappa := sw.curvatureEstimate(pc, tc); kappa > 0 {
+		hPlan = ssiStepSafety * 2 * stdmath.Sqrt(2*sw.tr.eps/kappa)
+	}
+	// Tangency brake: the ANALYTIC intersection-curve curvature carries a 1/sin²θ pole at
+	// a tangency (θ = angle between the surface normals) that the discrete estimate — the
+	// finite per-branch curvature — cannot see. Approaching a pinch (#1404), cap the step
+	// at half the bootstrap so the delicate neighbourhood is sampled densely and the
+	// pinch crossing is REPRESENTED by vertices, not merely straddled within the sag
+	// budget by one long chord.
+	if sw.align > ssiTangencyBrakeCos {
+		hPlan = stdmath.Min(hPlan, sw.tr.step/2)
+	}
+	sw.h = clampStep(hPlan, sw.h, sw.tr.hMin, sw.tr.hMax)
+	sw.pPrev, sw.havePrev = sw.p, true
+	sw.p, sw.dir = pc, tc
+	sw.pts = append(sw.pts, pc)
+}
+
+// curvatureEstimate is the controller's κ: the larger of the 3-point circumcircle estimate and
+// the tangent turning rate Δθ/Δs over the accepted step. The turn rate is available from the very
+// FIRST step (the circumcircle needs three points), so the bootstrap adapts one step sooner; both
+// saturate near a pinch instead of diverging like the analytic intersection-curve curvature,
+// driving h to the floor there — exactly the wanted slowdown.
+func (sw *ssiSweep) curvatureEstimate(pc math.Point3, tc math.Vector3) float64 {
+	kappa := sw.discreteCurvature(pc)
+	ds := float64(sw.p.DistanceTo(pc))
+	if ds <= 10*sw.tr.tol {
+		return kappa
+	}
+	cosTurn := stdmath.Min(1, stdmath.Max(-1, float64(tc.Dot(sw.dir))))
+	if turn := stdmath.Acos(cosTurn) / ds; turn > kappa {
+		return turn
+	}
+	return kappa
+}
+
+// discreteCurvature is the circumcircle curvature of (pPrev, p, pc) — exact for circles, O(h²)
+// otherwise, always finite (it saturates near a pinch instead of diverging like the analytic
+// intersection-curve curvature, which drives h to the floor there — exactly the wanted slowdown).
+// Spacings below 10·tol are corrector jitter, not geometry: keep the previous plan (return 0).
+func (sw *ssiSweep) discreteCurvature(pc math.Point3) float64 {
+	if !sw.havePrev {
+		return 0
+	}
+	e1, e2 := sw.pPrev.VectorTo(sw.p), sw.p.VectorTo(pc)
+	l1, l2 := float64(e1.Length()), float64(e2.Length())
+	chord := float64(sw.pPrev.DistanceTo(pc))
+	if l1 < 10*sw.tr.tol || l2 < 10*sw.tr.tol || chord == 0 {
+		return 0
+	}
+	return 2 * float64(e1.Cross(e2).Length()) / (l1 * l2 * chord)
+}
+
+// clampStep rate-limits the controller (halve fast, grow ≤×1.4) and clamps to the global bounds.
+func clampStep(plan, current, hMin, hMax float64) float64 {
+	h := stdmath.Min(stdmath.Max(plan, current/2), current*ssiStepGrow)
+	return stdmath.Min(stdmath.Max(h, hMin), hMax)
 }
 
 // curveTangent returns the unit curve tangent nb×no, reversed for the backward sweep; ok is false at a

--- a/kernel/geom/intersect_surface_trace_test.go
+++ b/kernel/geom/intersect_surface_trace_test.go
@@ -277,3 +277,60 @@ func loopAxisRadius(loop []math.Point3) (mean, worst float64) {
 	}
 	return mean, worst
 }
+
+// TestSSITracesLoopSmallerThanBootstrapStep is acceptance criterion 3 of #1598 (audit A2): a loop whose
+// whole circumference is SMALLER than the bootstrap march step h₀ = 4e-3·extent must still be traced and
+// closed — the curvature controller collapses h toward its floor (200× the on-curve tolerance) instead
+// of stepping clean over the feature. A sphere of radius 0.002 centred on the unit sphere meets it in a
+// circle of circumference ≈ 0.0126 < h₀ ≈ 0.0139.
+func TestSSITracesLoopSmallerThanBootstrapStep(t *testing.T) {
+	big, _ := NewSphere(math.P3(0, 0, 0), 1)
+	centre := big.PointAt(0.31, 0.21) // off the coarse seed lattice, as in the #1400 fixture
+	small, _ := NewSphere(centre, 0.002)
+
+	loops := closedOnly(IntersectSurfaceSurface(big, small, SurfaceGrid{}))
+	if len(loops) != 1 {
+		t.Fatalf("got %d closed loops, want 1 (the sub-step circle must close, #1598)", len(loops))
+	}
+	onSurfacePair(t, loops, big, small, 1e-5)
+	perimeter := polylineLength(loops[0])
+	want := 2 * stdmath.Pi * 0.002 // tiny circle on a unit sphere: radius ≈ the small sphere's
+	if stdmath.Abs(perimeter-want) > 0.15*want {
+		t.Errorf("traced perimeter %g, want ≈ %g (analytic small-circle circumference)", perimeter, want)
+	}
+}
+
+// TestSSIChordalDeviationOnTightCircle is acceptance criterion 4 of #1598: through a high-curvature
+// region (a fillet-radius cylinder crossing a much larger plane) the traced polyline's mid-chord sag
+// against the analytic circle must stay within the chordal budget ε = 1e-4·extent that drives the
+// h = 2√(2ε/κ) step law.
+func TestSSIChordalDeviationOnTightCircle(t *testing.T) {
+	pl, _ := NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	cyl, _ := NewCylinder(math.P3(0.37, 0.11, 0), math.V3(0, 0, 1), 0.05)
+	grid := SurfaceGrid{UMin: -5, UMax: 5, VMin: -5, VMax: 5}
+
+	loops := closedOnly(IntersectSurfaceSurface(pl, cyl, grid))
+	if len(loops) != 1 {
+		t.Fatalf("got %d closed loops, want 1 (plane ∩ thin cylinder)", len(loops))
+	}
+	extent := stdmath.Sqrt(200) // 10×10 planar window diagonal
+	eps := ssiChordFraction * extent
+	centre, r := math.P3(0.37, 0.11, 0), 0.05
+	for i := 1; i < len(loops[0]); i++ {
+		a, b := loops[0][i-1], loops[0][i]
+		mid := math.P3((a.X+b.X)/2, (a.Y+b.Y)/2, (a.Z+b.Z)/2)
+		sag := stdmath.Abs(float64(centre.DistanceTo(mid)) - r)
+		if sag > 1.5*eps {
+			t.Fatalf("mid-chord sag %g at segment %d exceeds the chordal budget ε=%g (#1598)", sag, i, eps)
+		}
+	}
+}
+
+// polylineLength sums a polyline's segment lengths.
+func polylineLength(pts []math.Point3) float64 {
+	var l float64
+	for i := 1; i < len(pts); i++ {
+		l += float64(pts[i-1].DistanceTo(pts[i]))
+	}
+	return l
+}

--- a/kernel/ops/boolean_curved_target_test.go
+++ b/kernel/ops/boolean_curved_target_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 
 	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 )
 
@@ -38,4 +40,66 @@ func TestBooleanCutCurvedTargetRemovesTunnel(t *testing.T) {
 	if want := full - 16; stdmath.Abs(got-want) > 1e-3 {
 		t.Errorf("curved-target cut volume = %.5f, want %.5f (full %.5f − 16)", got, want, full)
 	}
+}
+
+// TestBooleanNearTangentCylindersStayManifold extends the curved-boolean suite per #1598
+// (audit A2): perpendicular analytic cylinders with nearly equal radii approach the pinched
+// Steinmetz configuration — the near-tangent booleans where the SSI marcher used to
+// branch-jump or falsely close and the trim then followed the wrong locus. At |Δr|/r = 5e-4
+// the general rod-band path must produce an Euler–Poincaré-valid solid within the analytic
+// volume bracket. At |Δr|/r = 5e-5 (inside the near-pinch band) the general imprint DECLINES
+// (input-sensitive saddle topology) and the boolean takes the recorded faceted fallback: the
+// volume stays inside the bracket and the degradation is visible on the recorder — never a
+// silently wrong analytic assembly (#1403 tracks unifying the band onto the exact path).
+func TestBooleanNearTangentCylindersStayManifold(t *testing.T) {
+	const r = 2.0
+	vCyl := stdmath.Pi * r * r * 6
+	steinmetz := 16.0 * r * r * r / 3
+	want := 2*vCyl - steinmetz // union volume; the intersection is a hair under Steinmetz
+
+	t.Run("general path at dr=1e-3", func(t *testing.T) {
+		union, rec := nearTangentUnion(t, r, 1e-3)
+		if res := ops.Validate(union); !res.Valid || !union.IsSolid() {
+			t.Fatalf("near-tangent union not a valid solid: %+v", res)
+		}
+		if rec.Has(brep.CodeImprintNearPinchDeclined) {
+			t.Fatal("dr=1e-3 must stay on the general path, not decline")
+		}
+		got := ops.BodyGeometryProperties(union, ops.DefaultQuality()).Volume
+		if stdmath.Abs(got-want) > 0.02*want {
+			t.Errorf("union volume = %.4f, want ≈ %.4f (2·cyl − Steinmetz)", got, want)
+		}
+	})
+
+	t.Run("recorded fallback inside the near-pinch band", func(t *testing.T) {
+		union, rec := nearTangentUnion(t, r, 1e-4)
+		if !rec.Has(brep.CodeImprintNearPinchDeclined) {
+			t.Fatal("near-pinch decline must be RECORDED, not silent (#1598)")
+		}
+		got := ops.BodyGeometryProperties(union, ops.DefaultQuality()).Volume
+		// The faceted fallback inscribes the cylinders, so it systematically under-measures
+		// by the facet sagitta — allow 3% where the general path gets 2%.
+		if stdmath.Abs(got-want) > 0.03*want {
+			t.Errorf("fallback union volume = %.4f, want ≈ %.4f — the faceted route must not lose material", got, want)
+		}
+	})
+}
+
+// nearTangentUnion joins two perpendicular solid cylinders of radius r and r−dr with a recorder.
+func nearTangentUnion(t *testing.T, r, dr float64) (*topo.Body, *diag.Recorder) {
+	t.Helper()
+	a, err := brep.SolidCylinder(math.P3(0, 0, -3), math.V3(0, 0, 1), r, 6)
+	if err != nil {
+		t.Fatalf("SolidCylinder a: %v", err)
+	}
+	b, err := brep.SolidCylinder(math.P3(-3, 0, 0), math.V3(1, 0, 0), r-dr, 6)
+	if err != nil {
+		t.Fatalf("SolidCylinder b: %v", err)
+	}
+	rec := &diag.Recorder{}
+	union, err := ops.BooleanWithDiagnostics(ops.Join, a, b, rec)
+	if err != nil {
+		t.Fatalf("Boolean(Join): %v", err)
+	}
+	return union, rec
 }


### PR DESCRIPTION
Closes #1598 (audit A2). Design per the geometry-math consult (Bajaj et al. 1988 step law; OCCT StatusDeflection acceptance pattern in object space; discrete-curvature controller with gate-based safety net).

## What

- **Curvature-controlled step**: h = 2√(2ε/κ) with ε = 1e-4·extent (the ADR-0042 model-relative chordal budget), κ = max(3-point circumcircle, tangent turning rate — available from the first step), rate-limited ×[½, 1.4] per step and clamped to [2e-5, 4e-3]·extent. The ceiling deliberately equals the old fixed step: the controller only ever **refines below** the historical spacing (the boolean split/stitch consumers proved input-sensitive to coarser chords; raising the ceiling awaits the #1403 pipeline work).
- **Step acceptance** (reject-and-halve): forward progress; corrector displacement ≤ min(h/2, 4ε) — 4ε enforces the sag budget DIRECTLY, covering the bootstrap steps before any κ exists; tangent turn ≤ 45° (the tightest gate that never rejects a legal step at the h floor, while a branch-jump turns by the full crossing angle). At the floor, two retries then an honest OPEN termination — never marching onto the wrong branch.
- **Direction-gated loop closure** (#1404): proximity (¾ of the CURRENT step) AND tangent alignment within 30° of the first accepted step's tangent; arc-length (not step-index) closure guard and sweep cap.
- **Tangency brake**: h caps at half the bootstrap where the surface normals align within ~8° — the analytic intersection-curve curvature carries a 1/sin²θ pole there that the discrete estimate cannot see, so pinch neighbourhoods get dense vertices rather than one in-budget straddling chord.

## Acceptance fixtures

- **Small loop**: an intersection loop smaller than the whole bootstrap step (circumference 0.0126 < h₀ 0.0139) is traced and CLOSED, perimeter within 15% of analytic.
- **Chordal deviation**: mid-chord sag on a fillet-radius circle (κ·extent ≈ 283) stays within the ε budget.
- All pre-existing pinch/near-pinch/Steinmetz/tangency fixtures pass unchanged.

## Real defect found and contained

The new near-tangent boolean fixture caught the general crossing-cylinder rod-band assembly being **input-sensitive in the near-pinch band**: at |Δr|/r = 5e-5, face count and union volume varied run-to-run with 34% of the material silently missing (`Validate` green throughout — the audit's silent-corruption class exactly). `crossingCylinderImprint` now declines that band with a recorded `CodeImprintNearPinchDeclined` defect, so the boolean takes the deterministic faceted fallback: volume correct within the facet-inscription bound and the degradation VISIBLE. The new fixture pins both regimes (general path at |Δr|/r = 5e-4; recorded fallback inside the band). Unifying the band onto the exact Steinmetz path stays with the #1403 EPIC.

## Verification

- Full suite green (`go test -count=1 ./...`), golangci-lint 0 issues.
- **Live**: `mcplive -part squatrim` (the crossing-cylinder cut over the C-ABI stack) — volume 30.709462 vs analytic 30.709068 cm³. (`tubing`/`thread` failures are the pre-existing MCPBridge#86 breakage, bisected pre-existing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)