### PR TITLE
Scale-relative revolve surface-type classification (audit A7)

### DIFF
--- a/kernel/brep/revolution.go
+++ b/kernel/brep/revolution.go
@@ -10,10 +10,16 @@ import (
 	"oblikovati.org/math"
 )
 
-// revTol is the absolute slope tolerance classifying a meridian edge as axis-parallel
-// (cylinder) or axis-perpendicular (plane). Database units are small (cm), so 1e-7 is well
-// below any real feature size yet above floating noise from the model→(r,z) projection.
-const revTol = 1e-7 // tol:calibrated — TODO(#1603, audit A7): make scale-relative
+// revSlopeTol is the DIMENSIONLESS meridian slope threshold classifying an edge as axis-parallel
+// (cylinder: |Δr| ≤ revSlopeTol·|Δz|) or axis-perpendicular (plane: |Δz| ≤ revSlopeTol·|Δr|).
+// Surface type is a question about the edge's DIRECTION — an angle — so the threshold is an
+// angular tolerance, scale-free by construction (#1603, audit A7). 1e-9 matches geom's epsRel
+// relative-precision precedent: it sits a decade below the smallest taper classification must
+// preserve (1e-8 rad) and ~2 decades above the slope noise of a double-precision model→(r,z)
+// projection on proportionate geometry (ε·r/L ≈ 1e-13 at r/L ~ 1e3). OCCT can run its analogous
+// cone-vs-cylinder recognition at Precision::Angular()=1e-12 only because it reads exact curve
+// directions; we difference meridian endpoints, so Δr carries cancellation noise ~ε·r.
+const revSlopeTol = 1e-9 // tol:angular
 
 // SolidOfRevolution builds a closed ANALYTIC B-rep by revolving a meridian a full 360° about
 // the axis line through axisOrigin along axisDir. meridian is the cross-section in the (radius,
@@ -105,9 +111,10 @@ type revNode struct {
 // an arc; on-axis line edges skipped).
 func buildRevolution(axisOrigin math.Point3, a, ref math.UnitVector3, verts []RevolveVertex, feat string) *topo.Body {
 	bld := topo.NewBuilder(true, revLin(feat, "body", 0))
+	res := revolveResolution(verts)
 	nodes := make([]revNode, len(verts))
 	for i, vrt := range verts {
-		nodes[i] = makeRevNode(bld, axisOrigin, a, ref, float64(vrt.P.X), float64(vrt.P.Y), feat, i)
+		nodes[i] = makeRevNode(bld, axisOrigin, a, ref, float64(vrt.P.X), float64(vrt.P.Y), res.Plane(), feat, i)
 	}
 	for i := range verts {
 		j := (i + 1) % len(verts)
@@ -115,16 +122,30 @@ func buildRevolution(axisOrigin math.Point3, a, ref math.UnitVector3, verts []Re
 			addRevolutionTorus(bld, nodes[i], nodes[j], *verts[j].ArcCenter, axisOrigin, a, ref, feat, i)
 			continue
 		}
-		addRevolutionFace(bld, nodes[i], nodes[j], a, ref, feat, i)
+		addRevolutionFace(bld, nodes[i], nodes[j], a, ref, res.Weld(), feat, i)
 	}
 	return bld.Build()
 }
 
+// revolveResolution derives the meridian's own model-relative coincidence scale (ADR-0042): the
+// LENGTH tolerances the build needs — the on-axis vertex weld and the degenerate-edge guard — flow
+// from the meridian's extent instead of a cm-anchored absolute constant (#1603, audit A7).
+func revolveResolution(verts []RevolveVertex) geom.Resolution {
+	pts := make([]math.Point2, len(verts))
+	for i, v := range verts {
+		pts[i] = v.P
+	}
+	return geom.ResolutionForPoints2D(pts)
+}
+
 // makeRevNode builds the circle (and seam vertex) for one meridian vertex, or just an apex vertex
-// when the vertex lies on the axis (r≈0).
-func makeRevNode(bld *topo.Builder, axisOrigin math.Point3, a, ref math.UnitVector3, r, z float64, feat string, i int) revNode {
+// when the vertex lies on the axis. axisTol is the meridian-relative on-line classification
+// tolerance (res.Plane()): a radius below it is coincident with the axis at this model's
+// resolution, so the node welds to an apex/disk-centre vertex (r stored as exactly 0 — downstream
+// on-axis tests read circle == nil).
+func makeRevNode(bld *topo.Builder, axisOrigin math.Point3, a, ref math.UnitVector3, r, z, axisTol float64, feat string, i int) revNode {
 	center := axisOrigin.TranslateBy(a.AsVector().Scale(math.Scalar(z)))
-	if r <= revTol {
+	if r <= axisTol {
 		return revNode{center: center, r: 0, v: bld.AddVertex(center, revLin(feat, "apex", i))}
 	}
 	c := geom.Circle{Center: center, Normal: a, RefDir: ref, Radius: r}
@@ -132,17 +153,50 @@ func makeRevNode(bld *topo.Builder, axisOrigin math.Point3, a, ref math.UnitVect
 	return revNode{center: center, r: r, circle: bld.AddEdge(c, v, v, revLin(feat, "circle", i)), v: v}
 }
 
+// revEdgeClass is the surface type a straight meridian edge revolves to.
+type revEdgeClass int
+
+const (
+	revEdgeOnAxis   revEdgeClass = iota // both endpoints on the axis: traces no surface
+	revEdgeCylinder                     // axis-parallel (or a sub-resolution noise edge)
+	revEdgePlane                        // axis-perpendicular: disk / annulus
+	revEdgeCone                         // oblique: cone frustum
+)
+
+// classifyRevolveEdge dispatches a straight meridian edge on its DIRECTION: the dimensionless
+// slope ratio against revSlopeTol decides cylinder vs plane vs cone, so the classification is
+// invariant under uniform model scaling (#1603, audit A7). weld (res.Weld()) guards the one
+// length-scale degeneracy: an edge shorter than the meridian's coincidence resolution is float
+// noise, kept as a (degenerate) cylinder — the old behavior — rather than extrapolating a cone
+// apex at r/Δr ≈ 1/noise away.
+func classifyRevolveEdge(ni, nj revNode, a math.UnitVector3, weld float64) revEdgeClass {
+	if ni.circle == nil && nj.circle == nil {
+		return revEdgeOnAxis
+	}
+	dr := stdmath.Abs(ni.r - nj.r)
+	dz := stdmath.Abs(axialGap(ni, nj, a))
+	switch {
+	case stdmath.Hypot(dr, dz) <= weld:
+		return revEdgeCylinder
+	case dr <= revSlopeTol*dz:
+		return revEdgeCylinder
+	case dz <= revSlopeTol*dr:
+		return revEdgePlane
+	default:
+		return revEdgeCone
+	}
+}
+
 // addRevolutionFace adds the surface-of-revolution face for one meridian edge: a cylinder (axis-
 // parallel), a planar disk/annulus (axis-perpendicular), or a cone frustum (oblique). An edge that
 // lies on the axis traces no surface and is skipped.
-func addRevolutionFace(bld *topo.Builder, ni, nj revNode, a, ref math.UnitVector3, feat string, i int) {
-	if ni.r <= revTol && nj.r <= revTol {
+func addRevolutionFace(bld *topo.Builder, ni, nj revNode, a, ref math.UnitVector3, weld float64, feat string, i int) {
+	switch classifyRevolveEdge(ni, nj, a, weld) {
+	case revEdgeOnAxis:
 		return // edge on the axis: no face
-	}
-	switch {
-	case stdmath.Abs(ni.r-nj.r) <= revTol:
+	case revEdgeCylinder:
 		addRevolutionCylinder(bld, ni, nj, a, ref, feat, i)
-	case stdmath.Abs(axialGap(ni, nj, a)) <= revTol:
+	case revEdgePlane:
 		addRevolutionPlane(bld, ni, nj, a, feat, i)
 	default:
 		addRevolutionCone(bld, ni, nj, a, ref, feat, i)
@@ -179,7 +233,7 @@ func addRevolutionCylinder(bld *topo.Builder, ni, nj revNode, a, ref math.UnitVe
 func addRevolutionCone(bld *topo.Builder, ni, nj revNode, a, ref math.UnitVector3, feat string, i int) {
 	apex := coneApex(ni, nj)
 	base := ni
-	if ni.r <= revTol {
+	if ni.circle == nil {
 		base = nj
 	}
 	axisDir := apex.VectorTo(base.center) // along the axis, apex → base (increasing radius)
@@ -244,12 +298,13 @@ func arcMidpoint(axisOrigin math.Point3, a, ref math.UnitVector3, c math.Point2,
 }
 
 // coneApex returns the point where the meridian edge's slant line meets the axis (r=0). An endpoint
-// already on the axis IS the apex; otherwise it is the linear extrapolation to zero radius.
+// already on the axis (circle == nil, r stored as exactly 0) IS the apex; otherwise it is the
+// linear extrapolation to zero radius.
 func coneApex(ni, nj revNode) math.Point3 {
-	if ni.r <= revTol {
+	if ni.circle == nil {
 		return ni.v.Point()
 	}
-	if nj.r <= revTol {
+	if nj.circle == nil {
 		return nj.v.Point()
 	}
 	t := ni.r / (ni.r - nj.r) // r(t)=ni.r+t(nj.r-ni.r)=0
@@ -299,7 +354,7 @@ func planeLoops(outer, inner revNode, down bool) []topo.LoopSpec {
 		outerUse, innerUse = topo.Rev, topo.Fwd
 	}
 	loops := []topo.LoopSpec{topo.OuterLoop(outerUse(outer.circle))}
-	if inner.r > revTol {
+	if inner.circle != nil {
 		loops = append(loops, topo.InnerLoop(innerUse(inner.circle)))
 	}
 	return loops

--- a/kernel/brep/revolution_test.go
+++ b/kernel/brep/revolution_test.go
@@ -150,6 +150,96 @@ func TestRevolutionFilletedCylinder(t *testing.T) {
 	}
 }
 
+// TestRevolutionSubMicronTaperIsCone pins audit A7 (#1603): a meridian wall with a REAL slope of
+// 1e-8 rad (Δr = 1e-8 over 1 cm — under the old absolute revTol of 1e-7) must classify as an
+// analytic geom.Cone, not silently flatten to a cylinder. Surface type is load-bearing identity
+// downstream (recognizer, fillet eligibility, STEP), so a sub-µm taper the user modeled must
+// survive classification.
+func TestRevolutionSubMicronTaperIsCone(t *testing.T) {
+	// Wall kept thick (3 cm) so default-quality faceting error on the two walls cancels inside the
+	// 3% band — a 0.5 cm-thin ring measures ~4.5% high at DefaultQuality (bore vs outer inscription
+	// imbalance), a pre-existing tessellation-resolution effect unrelated to classification.
+	const rIn, rOut, h, taper = 10.0, 13.0, 1.0, 1e-8 // inner wall slope = taper/h = 1e-8 rad
+	mer := []math.Point2{math.P2(rIn, 0), math.P2(rOut, 0), math.P2(rOut, h), math.P2(rIn+taper, h)}
+	body, err := brep.SolidOfRevolution(math.P3(0, 0, 0), math.V3(0, 0, 1), mer, "taper")
+	if err != nil || body == nil {
+		t.Fatalf("SolidOfRevolution(taper) = %v, %v; want a body", body, err)
+	}
+	got := revVolume(t, body)
+	want := stdmath.Pi * (rOut*rOut - rIn*rIn) * h // taper's volume contribution is ~1e-7 — negligible
+	if rel := stdmath.Abs(got-want) / want; rel > 0.03 {
+		t.Errorf("tapered tube volume = %.4f, want ≈%.4f (rel %.4f > 3%% band)", got, want, rel)
+	}
+	if c, k := coneFaceCount(body), cylFaceCount(body); c != 1 || k != 1 {
+		t.Errorf("tapered tube has %d cone + %d cylinder faces, want 1 cone (inner taper) + 1 cylinder (outer)", c, k)
+	}
+}
+
+// TestRevolutionLargeRadiusCylinderStaysCylinder pins audit A7's other direction (#1603): a true
+// axis-parallel wall at radial coordinate 1e4 carries upstream model→(r,z) projection noise far
+// above the old absolute 1e-7 (here 3e-7 ≈ 3e-11 relative), yet its SLOPE is 3e-11 — a cylinder
+// beyond doubt. The old absolute compare promoted it to a cone; classification must read the
+// dimensionless slope instead.
+func TestRevolutionLargeRadiusCylinderStaysCylinder(t *testing.T) {
+	const rIn, rOut, h, noise = 1e4, 1.05e4, 1e4, 3e-7
+	mer := []math.Point2{math.P2(rIn, 0), math.P2(rOut, 0), math.P2(rOut, h), math.P2(rIn+noise, h)}
+	body, err := brep.SolidOfRevolution(math.P3(0, 0, 0), math.V3(0, 0, 1), mer, "bigtube")
+	if err != nil || body == nil {
+		t.Fatalf("SolidOfRevolution(bigtube) = %v, %v; want a body", body, err)
+	}
+	got := revVolume(t, body)
+	want := stdmath.Pi * (rOut*rOut - rIn*rIn) * h
+	if rel := stdmath.Abs(got-want) / want; rel > 0.03 {
+		t.Errorf("large tube volume = %.4g, want ≈%.4g (rel %.4f > 3%% band)", got, want, rel)
+	}
+	if c, k := coneFaceCount(body), cylFaceCount(body); c != 0 || k != 2 {
+		t.Errorf("large tube has %d cone + %d cylinder faces, want 0 cones + 2 cylinders (bore + outer)", c, k)
+	}
+}
+
+// TestRevolutionTaperClassIsScaleInvariant pins audit A7's core demand (#1603): the SAME
+// normalized taper (slope 1e-6 rad) must classify identically — as a cone — at 1e-3×, 1× and
+// 1e3× model scale. The old absolute revTol flipped the 1e-3× copy to a cylinder (Δr = 1e-9
+// < 1e-7) while the 1× and 1e3× copies stayed cones.
+func TestRevolutionTaperClassIsScaleInvariant(t *testing.T) {
+	const slope = 1e-6
+	for _, scale := range []float64{1e-3, 1, 1e3} {
+		rIn, rOut, h := 10*scale, 10.5*scale, 1*scale
+		mer := []math.Point2{
+			math.P2(rIn, 0), math.P2(rOut, 0), math.P2(rOut, h), math.P2(rIn+slope*h, h),
+		}
+		body, err := brep.SolidOfRevolution(math.P3(0, 0, 0), math.V3(0, 0, 1), mer, "sweep")
+		if err != nil || body == nil {
+			t.Fatalf("scale %g: SolidOfRevolution = %v, %v; want a body", scale, body, err)
+		}
+		if c, k := coneFaceCount(body), cylFaceCount(body); c != 1 || k != 1 {
+			t.Errorf("scale %g: %d cone + %d cylinder faces, want 1 + 1 (classification must not depend on scale)",
+				scale, c, k)
+		}
+	}
+}
+
+// TestRevolutionAxisWeldIsScaleRelative pins the on-axis vertex test's move to a meridian-relative
+// tolerance (#1603): on a 1e4-extent part, an inner radius of 1e-4 (1e-8 of the model — far below
+// the on-line classification resolution) is coincident with the axis, so the revolve must produce
+// a SOLID cylinder (3 faces), not an annulus with a sub-resolution sliver bore.
+func TestRevolutionAxisWeldIsScaleRelative(t *testing.T) {
+	const rBore, r, h = 1e-4, 1e4, 1e4
+	mer := []math.Point2{math.P2(rBore, 0), math.P2(r, 0), math.P2(r, h), math.P2(rBore, h)}
+	body, err := brep.SolidOfRevolution(math.P3(0, 0, 0), math.V3(0, 0, 1), mer, "weld")
+	if err != nil || body == nil {
+		t.Fatalf("SolidOfRevolution(weld) = %v, %v; want a body", body, err)
+	}
+	got := revVolume(t, body)
+	want := stdmath.Pi * r * r * h
+	if rel := stdmath.Abs(got-want) / want; rel > 0.03 {
+		t.Errorf("welded-bore volume = %.4g, want ≈%.4g (rel %.4f > 3%% band)", got, want, rel)
+	}
+	if n := len(body.Faces()); n != 3 {
+		t.Errorf("welded-bore solid has %d faces, want 3 (wall + 2 disc caps; sub-resolution bore welds to axis)", n)
+	}
+}
+
 func torusFaceCount(b *topo.Body) int {
 	return surfFaceCount(b, func(g geom.Surface) bool { _, ok := g.(geom.Torus); return ok })
 }

--- a/kernel/ops/tolerance_guard_test.go
+++ b/kernel/ops/tolerance_guard_test.go
@@ -123,7 +123,8 @@ func TestNoUnjustifiedAbsoluteEpsilons(t *testing.T) {
 		"../topo/face_evaluator.go",
 		"../topo/provenance.go",
 		"../topo/wire.go",
-		// brep: revolution surface classification (revTol — annotated pending #1603).
+		// brep: revolution surface classification (#1603: dimensionless slope ratio + meridian-
+		// relative axis weld; the only literal left is the annotated angular revSlopeTol).
 		"../brep/revolution.go",
 	}
 	var offenders []string


### PR DESCRIPTION
## What

Retires the absolute `revTol = 1e-7` that classified the surface TYPE a revolved meridian edge produces, replacing it with:

- **A dimensionless slope ratio** (`revSlopeTol = 1e-9`, annotated `tol:angular`) for cylinder-vs-plane-vs-cone dispatch — the edge's direction is an angle, so the classification is now invariant under uniform model scaling. The threshold sits a decade below the smallest taper the audit requires preserved (1e-8 rad) and ~2 decades above double-precision projection noise on proportionate geometry; the comment documents why OCCT's 1e-12 `Precision::Angular()` does not transfer (we difference endpoints, so Δr carries ε·r cancellation noise).
- **Meridian-relative length tolerances** (ADR-0042) for the two decisions that genuinely are lengths: the on-axis vertex weld uses `ResolutionForPoints2D(meridian).Plane()` (point-on-line semantics, reproducing the old 1e-7 at the historical ~1 cm scale), and a sub-`Weld()` noise edge stays a degenerate cylinder rather than extrapolating a cone apex ~1/noise away.

On-axis state is now encoded once (`makeRevNode` stores r=0, downstream reads `circle == nil`), and `brep/revolution.go` passes the tolerance guard with no `tol:calibrated` exemption.

## Why

Surface type is load-bearing identity — the curved-boolean recognizer, stitching, fillet/chamfer eligibility, and STEP export all dispatch on it. The absolute constant silently flattened sub-µm tapers to cylinders, promoted large-coordinate cylinders (upstream projection noise > 1e-7) to cones, and flipped the same normalized shape's class across model scales (audit A7, #1603).

## Tests (all red-verified against the old classifier)

- `TestRevolutionSubMicronTaperIsCone` — 1e-8 rad taper (Δr = 1e-8 < old revTol) classifies cone.
- `TestRevolutionLargeRadiusCylinderStaysCylinder` — axis-parallel wall at r = 1e4 with 3e-7 injected projection noise stays a cylinder.
- `TestRevolutionTaperClassIsScaleInvariant` — the same slope-1e-6 taper classifies cone at 1e-3×, 1×, 1e3×.
- `TestRevolutionAxisWeldIsScaleRelative` — a 1e-8-of-model-size bore welds to the axis (solid, 3 faces).
- Tolerance guard scope updated; full suite + golangci-lint green locally.

## Live test

`mcplive -part revtaper` (new driver, MCPBridge PR to follow): a fully-constrained (DOF=0) stepped-shaft sketch revolved 360°, taper→cone and wall→cylinder from real solver coordinates, volumes within 0.64% of analytic; then `r1 := r0` re-solve — the solver-noise vertical-by-value case — stays a cylinder. Viewport screenshots visually confirmed (frustum + wall, clean shading, no far-apex artifacts).

Found while live-testing (pre-existing, bisected on develop): the general wedge-cut chamfer on this shaft's rim silently zeroes the body while reporting healthy — filed as #1689.

Closes #1603

🤖 Generated with [Claude Code](https://claude.com/claude-code)