### PR TITLE
True CDT: legalize after recovery, walk-seeded insertion, split-at-vertex, pinched-wall parity (audit A8)

### DIFF
--- a/kernel/ops/cdt.go
+++ b/kernel/ops/cdt.go
@@ -32,10 +32,15 @@ type cdtTri struct {
 type cdt struct {
 	pts  [][2]float64
 	tris []cdtTri
-	dead []bool          // tris[t] was deleted by an insertion
-	con  map[[2]int]bool // constrained undirected edges (sorted vertex pair)
-	nsup int             // index of the first super-triangle vertex (points >= nsup are super)
-	last int             // a recently-live triangle, the seed hint for the next point-location walk (#1408)
+	dead []bool // tris[t] was deleted by an insertion
+	// con maps a constrained undirected edge (sorted vertex pair) to its MULTIPLICITY: how many
+	// loop passes constrained it. Degenerate trims can run a hole boundary EXACTLY along a stretch
+	// of the outer boundary (the unrolled holed wall does this at its seam), making one mesh edge a
+	// DOUBLE wall — the domain flood must toggle inside/outside once per wall (odd/even parity), and
+	// a plain set under-toggled there, silently mislabeling everything beyond the pinch (#1604).
+	con  map[[2]int]int
+	nsup int // index of the first super-triangle vertex (points >= nsup are super)
+	last int // a recently-live triangle, the seed hint for the next point-location walk (#1408)
 	// unrecovered collects the constraint endpoint pairs whose edge the flip recovery never realized
 	// (the flip cap hit, or a non-convex crossing stalled). Such a constraint is NOT recorded in con —
 	// a phantom con entry has no mesh edge for floodInside to toggle at, so the domain boundary leaks
@@ -51,10 +56,15 @@ type cdt struct {
 	// built once before recovery (buildIncident) and kept current by touch() on every addTri/flip. nil
 	// before recovery, so insertion (which runs first) pays nothing; a stale entry is detected and rescanned.
 	incident []int
-	// flipSteps counts Lawson flips performed over this triangulation's life (recovery only — flip is
-	// called nowhere else), read by tests to assert constraint recovery flips O(crossings) edges, not the
-	// O(T²) whole-mesh rescan-per-flip the corridor walk replaced (#1409).
+	// flipSteps counts Lawson flips performed over this triangulation's life (constraint recovery and
+	// the post-recovery legalization it queues — flip is called nowhere else), read by tests to assert
+	// constraint recovery flips O(crossings) edges, not the O(T²) whole-mesh rescan-per-flip the
+	// corridor walk replaced (#1409).
 	flipSteps int
+	// pendingLegal queues the diagonal created by each flip for in-circle legalization once the
+	// current segment's recovery completes (#1604): recovery alone leaves the corridor non-Delaunay,
+	// which both degrades triangle quality and invalidates the walk-based point location.
+	pendingLegal [][2]int
 }
 
 func conKey(a, b int) [2]int {
@@ -101,7 +111,7 @@ func newCDT(pts [][2]float64) *cdt {
 	all := append([][2]float64(nil), pts...)
 	all = append(all,
 		[2]float64{cx - 20*d, cy - d}, [2]float64{cx + 20*d, cy - d}, [2]float64{cx, cy + 20*d})
-	m := &cdt{pts: all, con: map[[2]int]bool{}, nsup: nsup}
+	m := &cdt{pts: all, con: map[[2]int]int{}, nsup: nsup}
 	m.tris = []cdtTri{{v: [3]int{nsup, nsup + 1, nsup + 2}, n: [3]int{-1, -1, -1}}}
 	m.dead = []bool{false}
 	return m

--- a/kernel/ops/cdt_build.go
+++ b/kernel/ops/cdt_build.go
@@ -6,14 +6,12 @@ package ops
 // contains the point, delete the connected star of such triangles, and fan the cavity boundary to the
 // new point. Skips a point coinciding with an existing vertex (no strictly-bad triangle).
 //
-// Seeding the cavity depends on whether constraints are present. With NONE (the dense unconstrained
-// insertion — every interior Steiner node of a hole-free patch, the case the O(N²) scan choked on), the
-// mesh stays Delaunay and fold-free, so the O(√N) adjacency WALK to the triangle containing p gives a
-// valid seed — the #1408 near-linear win. After constraints are recovered, the recovery flips can leave
-// the mesh momentarily FOLDED, where the triangle that geometrically contains p is the wrong topological
-// region (its connected bad-component is disjoint from p's true cavity); there the exact circumcircle
-// scan picks the correct seed. That post-constraint set is the smaller refined-path interior, so keeping
-// the robust scan for it costs little.
+// The cavity is always seeded by the O(√N) adjacency WALK to the triangle containing p (#1408).
+// Constraint recovery once left the mesh momentarily FOLDED — where the geometric walk lands in the
+// wrong topological region — which forced an exact O(T) circumcircle scan per post-constraint
+// insertion; recovery now legalizes its corridor (#1604), so the mesh is a true CDT between
+// insertions and the walk is valid in both phases. collectCavity keeps the cavity star-shaped by
+// never growing across a constrained edge.
 func (m *cdt) insert(ip int) {
 	p := m.pts[ip]
 	seed := m.locateSeed(p)
@@ -23,14 +21,12 @@ func (m *cdt) insert(ip int) {
 	m.fanCavity(ip, m.collectCavity(seed, p))
 }
 
-// locateSeed returns a circumcircle-bad triangle to seed the Bowyer–Watson cavity, or -1 when p
-// coincides with an existing vertex. It walks the adjacency from the last insertion while the mesh is
-// unconstrained (and so fold-free); once constraints exist it falls back to the exact scan, which is
-// robust to the folds constraint recovery can introduce (#1408).
+// locateSeed returns the circumcircle-bad triangle containing p to seed the Bowyer–Watson cavity, or
+// -1 when p coincides with an existing vertex. The walk is valid with or without constraints because
+// post-recovery legalization keeps the mesh a true CDT (#1604); a point strictly inside (or on an
+// open edge of) its containing triangle is strictly inside that triangle's circumdisk, so
+// inCircle ≤ 0 exactly characterizes a vertex-coincident duplicate.
 func (m *cdt) locateSeed(p [2]float64) int {
-	if len(m.con) > 0 {
-		return m.firstBad(p)
-	}
 	loc := m.locate(p)
 	t := m.tris[loc]
 	if inCircle(m.pts[t.v[0]], m.pts[t.v[1]], m.pts[t.v[2]], p) <= 0 {
@@ -128,7 +124,7 @@ func (m *cdt) collectCavity(seed int, p [2]float64) cavity {
 			// boundary is constrained must not engulf triangles on the far side of a wire and erase it
 			// (OCCT's BRepMesh protects frontier edges the same way). con is empty while the boundary
 			// itself is being inserted, so existing callers are unaffected.
-			if a, b := m.tris[t].v[(i+1)%3], m.tris[t].v[(i+2)%3]; m.con[conKey(a, b)] {
+			if a, b := m.tris[t].v[(i+1)%3], m.tris[t].v[(i+2)%3]; m.con[conKey(a, b)] > 0 {
 				continue
 			}
 			if inCircle(m.pts[m.tris[ne].v[0]], m.pts[m.tris[ne].v[1]], m.pts[m.tris[ne].v[2]], p) > 0 {
@@ -246,9 +242,12 @@ func (m *cdt) rebuildFlip(t, s, c, pp, d, q, nPD, nCP, nDQ, nQC int) {
 	m.relinkOpposite(nCP, c, pp, t)
 	m.relinkOpposite(nDQ, d, q, s)
 	m.relinkOpposite(nQC, q, c, s)
-	m.flipSteps++ // recovery flips only (flip is called nowhere else) — instrumented for #1409
+	m.flipSteps++ // recovery + legalization flips (flip is called nowhere else) — instrumented for #1409
 	m.touch(t)    // both reused triangles changed their vertex sets; refresh the incidence hint
 	m.touch(s)
+	// Queue the new diagonal for post-recovery legalization (#1604). During legalization itself the
+	// entry is redundant (a fresh Lawson diagonal is locally Delaunay) and pops in O(1).
+	m.pendingLegal = append(m.pendingLegal, [2]int{c, d})
 }
 
 // representatives maps each input point index to the inserted vertex that carries its coordinates:
@@ -291,13 +290,18 @@ func (m *cdt) flipOneCrossing(a, b int) bool {
 	return false
 }
 
-// segmentsCross reports whether open segments p1p2 and p3p4 properly intersect.
+// segmentsCross reports whether open segments p1p2 and p3p4 PROPERLY intersect: each segment's
+// endpoints strictly straddle the other's line. An endpoint lying exactly ON the other segment
+// (orient2d == 0) is a touch, not a crossing — the old `(d > 0) != (d > 0)` form lumped the exact
+// zero in with the negative side, so recoverByFlips "resolved" a segment-through-vertex constraint
+// by flipping an edge that merely touched it, wrecking the corridor without ever recovering the
+// segment (#1604; the split-at-vertex path handles that degeneracy instead).
 func segmentsCross(p1, p2, p3, p4 [2]float64) bool {
 	d1 := orient2d(p3, p4, p1)
 	d2 := orient2d(p3, p4, p2)
 	d3 := orient2d(p1, p2, p3)
 	d4 := orient2d(p1, p2, p4)
-	return ((d1 > 0) != (d2 > 0)) && ((d3 > 0) != (d4 > 0))
+	return d1*d2 < 0 && d3*d4 < 0
 }
 
 // extractDomain 2-colours the triangulation inside/outside by flooding adjacency from the
@@ -351,7 +355,7 @@ func (m *cdt) floodStep(t int, inside, visited []bool, queue []int) []int {
 		}
 		a, b := m.tris[t].v[(i+1)%3], m.tris[t].v[(i+2)%3]
 		visited[s] = true
-		inside[s] = inside[t] != m.con[conKey(a, b)]
+		inside[s] = inside[t] != (m.con[conKey(a, b)]%2 == 1) // odd wall multiplicity toggles; a doubled (pinched) wall cancels
 		queue = append(queue, s)
 	}
 	return queue

--- a/kernel/ops/cdt_constraint.go
+++ b/kernel/ops/cdt_constraint.go
@@ -2,6 +2,11 @@
 
 package ops
 
+import (
+	"cmp"
+	"slices"
+)
+
 // Constraint (boundary segment) recovery by corridor-walk flips (#1409).
 //
 // Forcing a loop edge (a,b) into the triangulation means flipping the existing edges that the segment
@@ -35,10 +40,77 @@ func (m *cdt) insertConstraint(a, b int) {
 		return
 	}
 	if m.recoverSegment(a, b) {
-		m.con[conKey(a, b)] = true
+		m.con[conKey(a, b)]++
+		m.legalizePending() // #1604: restore the Delaunay property around the recovered corridor
 		return
 	}
+	m.legalizePending() // a failed recovery's flips are real corridor work: leave them Delaunay too
+	if m.splitConstraintAtVertices(a, b) {
+		return // recovered piecewise; each sub-segment reported its own status
+	}
 	m.unrecovered = append(m.unrecovered, [2]int{a, b})
+}
+
+// splitConstraintAtVertices handles the segment-through-vertex degeneracy (#1604): a constraint
+// whose open interior passes EXACTLY through mesh vertices (the exact orient2d says so) can never
+// be recovered as one edge — flips cannot remove a vertex from the segment's path. The standard
+// resolution (Shewchuk's Triangle; Anglada 1997) splits the constraint at those vertices and
+// recovers each sub-segment, which walls off the same geometric boundary for the domain flood.
+// The unrolled periodic wall hits this on its seam: the hole corners' axial stations reappear as
+// exact on-seam samples, and the whole seam used to be dropped as unrecoverable — the silent
+// domain leak behind the #1410 fallback. Returns false when no on-segment vertex exists (a
+// genuine non-recovery the caller records).
+func (m *cdt) splitConstraintAtVertices(a, b int) bool {
+	on := m.verticesOnSegment(a, b)
+	if len(on) == 0 {
+		return false
+	}
+	prev := a
+	for _, v := range on {
+		m.insertConstraint(prev, v)
+		prev = v
+	}
+	m.insertConstraint(prev, b)
+	return true
+}
+
+// verticesOnSegment returns the real vertices lying exactly on the open segment (a,b), ordered
+// from a to b. Endpoint-coincident duplicates split nothing and are excluded; sub-segments
+// between consecutive on-vertices contain no further on-vertices by construction, so the split
+// recursion terminates after one level.
+func (m *cdt) verticesOnSegment(a, b int) []int {
+	pa, pb := m.pts[a], m.pts[b]
+	var on []int
+	for v := 0; v < m.nsup; v++ {
+		p := m.pts[v]
+		if v == a || v == b || p == pa || p == pb {
+			continue
+		}
+		if orient2d(pa, pb, p) != 0 || !inSegmentBox(pa, pb, p) {
+			continue
+		}
+		on = append(on, v)
+	}
+	slices.SortFunc(on, func(u, w int) int {
+		du := sqDist(pa, m.pts[u])
+		dw := sqDist(pa, m.pts[w])
+		return cmp.Compare(du, dw)
+	})
+	return on
+}
+
+// inSegmentBox reports whether collinear point p lies within segment (pa,pb)'s bounding box —
+// with exact collinearity established, this is the open-segment containment test.
+func inSegmentBox(pa, pb, p [2]float64) bool {
+	return p[0] >= min(pa[0], pb[0]) && p[0] <= max(pa[0], pb[0]) &&
+		p[1] >= min(pa[1], pb[1]) && p[1] <= max(pa[1], pb[1])
+}
+
+// sqDist is the squared distance between two points (a monotone along-segment order for
+// collinear points).
+func sqDist(a, b [2]float64) float64 {
+	dx, dy := b[0]-a[0], b[1]-a[1]
+	return dx*dx + dy*dy
 }
 
 // recoverSegment ensures edge (a,b) exists, returning whether it does afterwards. It walks the

--- a/kernel/ops/cdt_delaunay_test.go
+++ b/kernel/ops/cdt_delaunay_test.go
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+)
+
+// Audit A8 (#1604): the CDT must be a TRUE constrained Delaunay triangulation. Constraint
+// recovery used to flip only until the segment existed — no in-circle legalization afterwards —
+// leaving the corridor non-Delaunay (arbitrarily bad triangles), and Bowyer–Watson insertion into
+// the constrained mesh was seeded by an exhaustive circumcircle scan (firstBad) instead of the
+// adjacency walk, hiding the damage at O(T)-per-point cost. These tests pin the repaired
+// invariants on fixtures whose recovery genuinely degrades the mesh.
+
+// cdtNonDelaunayEdges returns the interior edges violating the empty-circumcircle property:
+// non-constrained edges between REAL vertices whose two adjacent triangles are also fully real
+// (super-vertex circumcircles are the hull scaffold, not the domain property the CDT guarantees).
+func cdtNonDelaunayEdges(m *cdt) [][2]int {
+	seen := map[[2]int]bool{}
+	var bad [][2]int
+	for t := range m.tris {
+		if m.dead[t] || m.hasSuper(t) {
+			continue
+		}
+		for i := 0; i < 3; i++ {
+			u, w := m.tris[t].v[(i+1)%3], m.tris[t].v[(i+2)%3]
+			k := conKey(u, w)
+			if seen[k] || m.con[k] > 0 {
+				continue
+			}
+			seen[k] = true
+			s := m.tris[t].n[i]
+			if s < 0 || m.dead[s] || m.hasSuper(s) {
+				continue
+			}
+			d := m.apex(s, u, w)
+			if d < 0 {
+				continue
+			}
+			if inCircle(m.pts[m.tris[t].v[0]], m.pts[m.tris[t].v[1]], m.pts[m.tris[t].v[2]], m.pts[d]) > 0 {
+				bad = append(bad, k)
+			}
+		}
+	}
+	return bad
+}
+
+// assertCCWLive fails the test if any live non-super triangle is inverted or degenerate.
+func assertCCWLive(t *testing.T, m *cdt) {
+	t.Helper()
+	for tr := range m.tris {
+		if m.dead[tr] || m.hasSuper(tr) {
+			continue
+		}
+		v := m.tris[tr].v
+		if orient2d(m.pts[v[0]], m.pts[v[1]], m.pts[v[2]]) <= 0 {
+			t.Fatalf("triangle %d is inverted/degenerate", tr)
+		}
+	}
+}
+
+// TestCDTLegalizedAfterRecovery pins A8 step 1 (#1604): recovering a chord through the alternating
+// strip retriangulates its corridor as two fans, which are NOT Delaunay — before legalization this
+// left 2 empty-circumcircle violations behind (measured). insertConstraint must legalize the
+// corridor (recursive Lawson flips honoring constraints, Anglada/Sloan) after every recovery.
+func TestCDTLegalizedAfterRecovery(t *testing.T) {
+	for _, n := range []int{12, 40} {
+		m := alternatingStripCDT(n)
+		m.insertConstraint(0, 1)
+		if m.con[conKey(0, 1)] == 0 {
+			t.Fatalf("n=%d: chord (0,1) was not recovered", n)
+		}
+		if bad := cdtNonDelaunayEdges(m); len(bad) != 0 {
+			t.Errorf("n=%d: %d non-constrained edges are not locally Delaunay after recovery (first: %v)", n, len(bad), bad[0])
+		}
+		if !edgeManifold(m) {
+			t.Errorf("n=%d: legalization left a non-manifold edge", n)
+		}
+		assertCCWLive(t, m)
+	}
+}
+
+// TestCDTInsertionIntoRecoveredCorridor pins the firstBad failure mode (#1604): points inserted
+// INTO a just-recovered (previously folded) corridor must land in a mesh that legalization has
+// restored to Delaunay, so the walk finds the containing triangle and the cavity is star-shaped —
+// the result stays manifold, CCW, and fully Delaunay away from constraints.
+func TestCDTInsertionIntoRecoveredCorridor(t *testing.T) {
+	const n = 24
+	pts := [][2]float64{{0, 0.5}, {float64(n + 1), 0.5}}
+	for i := 1; i <= n; i++ {
+		y := 0.0
+		if i%2 == 1 {
+			y = 1.0
+		}
+		pts = append(pts, [2]float64{float64(i), y})
+	}
+	nStrip := len(pts)
+	for i := 0; i < 6; i++ { // probes straddling the recovered chord, mid-corridor
+		pts = append(pts, [2]float64{3.3 + 3*float64(i), 0.4 + 0.2*float64(i%2)})
+	}
+	m := newCDT(pts)
+	for ip := 0; ip < nStrip; ip++ {
+		m.insert(ip)
+	}
+	m.buildIncident()
+	m.insertConstraint(0, 1)
+	if m.con[conKey(0, 1)] == 0 {
+		t.Fatal("chord (0,1) was not recovered")
+	}
+	area := liveArea(m)
+	for ip := nStrip; ip < m.nsup; ip++ {
+		m.insert(ip)
+	}
+	if !edgeManifold(m) {
+		t.Error("insertion into the recovered corridor left a non-manifold edge")
+	}
+	assertCCWLive(t, m)
+	if got := liveArea(m); stdmath.Abs(got-area) > 1e-9 {
+		t.Errorf("insertion changed the hull area %.9f → %.9f (overlap or gap)", area, got)
+	}
+	if bad := cdtNonDelaunayEdges(m); len(bad) != 0 {
+		t.Errorf("%d non-constrained edges non-Delaunay after corridor insertion (first: %v)", len(bad), bad[0])
+	}
+}
+
+// combFixture is the end-to-end adversarial fixture: a wide slab whose top edge is a deep sawtooth
+// comb (every tooth flank is an oblique constraint recovered through the unconstrained Delaunay),
+// plus a jittered interior Steiner band under the teeth — insertions landing next to the recovered
+// corridors. Returns points, the boundary loop, and the frontier count.
+func combFixture() ([][2]float64, []int, int) {
+	var pts [][2]float64
+	pts = append(pts, [2]float64{0, 0}, [2]float64{12, 0}, [2]float64{12, 4})
+	for x := 11.0; x >= 1.0; x -= 1.0 {
+		pts = append(pts, [2]float64{x, 4}, [2]float64{x - 0.5, 0.8})
+	}
+	pts = append(pts, [2]float64{0, 4})
+	loop := make([]int, len(pts))
+	for i := range loop {
+		loop[i] = i
+	}
+	nFrontier := len(pts)
+	for x := 0.4; x <= 11.6; x += 0.4 {
+		pts = append(pts, [2]float64{x, 0.2 + 0.2*stdmath.Sin(x*7)})
+	}
+	return pts, loop, nFrontier
+}
+
+// TestCDTConstraintSplitsAtOnSegmentVertex pins the segment-through-vertex resolution (#1604): a
+// boundary segment whose open interior passes EXACTLY through another mesh vertex can never be one
+// edge, so it must recover PIECEWISE (split at the on-segment vertex, Shewchuk/Anglada) instead of
+// being dropped as unrecovered — which is how the unrolled periodic wall silently leaked its seam:
+// the flood poured through the gap and the extracted domain lost a third of its area while the old
+// folded scan-seeded mesh double-covered enough of it to pass the 3D area band.
+func TestCDTConstraintSplitsAtOnSegmentVertex(t *testing.T) {
+	// Unit-ish square whose bottom edge (0)-(1) passes exactly through point 4 at (2,0); 4 is not
+	// part of the loop, so the constraint (0,1) is structurally unrecoverable as a single edge.
+	pts := [][2]float64{{0, 0}, {4, 0}, {4, 4}, {0, 4}, {2, 0}}
+	m := newCDT(pts)
+	for i := 0; i < m.nsup; i++ {
+		m.insert(i)
+	}
+	m.constrain([][]int{{0, 1, 2, 3}})
+	if len(m.unrecovered) != 0 {
+		t.Fatalf("constraint through an on-segment vertex was dropped as unrecovered (%v), want piecewise recovery", m.unrecovered)
+	}
+	if m.con[conKey(0, 4)] == 0 || m.con[conKey(4, 1)] == 0 {
+		t.Error("split constraint pieces (0,4) and (4,1) are not recorded constrained")
+	}
+	tris := m.extractDomain()
+	if got, want := cdtAreaSum(pts, tris), 16.0; stdmath.Abs(got-want) > 1e-9 {
+		t.Errorf("domain area = %g, want %g (the split boundary leaked)", got, want)
+	}
+	if bad := cdtNonDelaunayEdges(m); len(bad) != 0 {
+		t.Errorf("%d non-constrained edges non-Delaunay after split recovery", len(bad))
+	}
+}
+
+// TestCDTPinchedHoleWallParity pins the doubled-wall parity rule (#1604): when a hole boundary
+// runs EXACTLY along a stretch of the outer boundary (the unrolled holed cylinder wall does this
+// at its seam — the window's seam-side edge coincides with the outer seam segment), that stretch
+// is TWO coincident walls on one mesh edge. The flood must toggle inside/outside once per wall
+// (odd multiplicity toggles, even cancels); the old boolean con set under-toggled and every
+// triangle beyond the pinch was mislabeled — the extracted domain was ~10% off while Validate
+// stayed green.
+func TestCDTPinchedHoleWallParity(t *testing.T) {
+	// 10×10 square with a 4×4 notch-hole whose right edge lies ON the outer right edge x=10:
+	// outer CCW, hole (6,3)-(10,3)-(10,7)-(6,7). Domain area = 100 − 16 = 84.
+	pts := [][2]float64{
+		{0, 0}, {10, 0}, {10, 3}, {10, 7}, {10, 10}, {0, 10}, // outer chain (right edge sampled at the pinch)
+		{6, 3}, {10, 3}, {10, 7}, {6, 7}, // hole; 7 and 8 duplicate outer samples 2 and 3
+	}
+	outer := []int{0, 1, 2, 3, 4, 5}
+	hole := []int{6, 7, 8, 9}
+	m := newCDT(pts)
+	for i := 0; i < m.nsup; i++ {
+		m.insert(i)
+	}
+	m.constrain([][]int{outer, hole})
+	if len(m.unrecovered) != 0 {
+		t.Fatalf("pinched fixture left %d constraints unrecovered", len(m.unrecovered))
+	}
+	if got := m.con[conKey(2, 3)]; got != 2 {
+		t.Errorf("pinched edge (2,3) multiplicity = %d, want 2 (outer wall + hole wall)", got)
+	}
+	tris := m.extractDomain()
+	if got, want := cdtAreaSum(pts, tris), 84.0; stdmath.Abs(got-want) > 1e-9 {
+		t.Errorf("pinched domain area = %g, want %g (double wall parity broken)", got, want)
+	}
+	assertCCWLive(t, m)
+}
+
+// TestCDTSteinerInsertionAfterConstraintsWalks pins A8 step 2 (#1604): interior Steiner points
+// inserted into the constrained mesh must locate their cavity seed by the adjacency WALK (valid
+// because legalization keeps the mesh a true CDT), not the O(T)-per-point firstBad scan — and the
+// refined domain must stay exact: CCW everywhere, area equal two-sided, Delaunay off-constraints.
+func TestCDTSteinerInsertionAfterConstraintsWalks(t *testing.T) {
+	pts, loop, nFrontier := combFixture()
+	m := newCDT(pts)
+	for i := 0; i < nFrontier; i++ {
+		m.insert(i)
+	}
+	m.constrain([][]int{loop})
+	if len(m.unrecovered) != 0 {
+		t.Fatalf("fixture drifted: %d boundary constraints unrecovered", len(m.unrecovered))
+	}
+	preWalk := m.walkSteps
+	for i := nFrontier; i < m.nsup; i++ {
+		m.insert(i)
+	}
+	if m.walkSteps == preWalk {
+		t.Error("interior insertion after constraints never used the adjacency walk (firstBad scan seeding remains)")
+	}
+	assertCCWLive(t, m)
+	tris := m.extractDomain()
+	want := cdtPolyArea(pts, loop)
+	if got := cdtAreaSum(pts, tris); stdmath.Abs(got-want) > 1e-9*want {
+		t.Errorf("triangulated area = %.9f, want %.9f (gaps or overlaps near recovered corridors)", got, want)
+	}
+	if bad := cdtNonDelaunayEdges(m); len(bad) != 0 {
+		t.Errorf("%d non-constrained edges non-Delaunay after Steiner insertion (first: %v)", len(bad), bad[0])
+	}
+}

--- a/kernel/ops/cdt_legalize.go
+++ b/kernel/ops/cdt_legalize.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+// In-circle legalization after constraint recovery (#1604, audit A8).
+//
+// recoverSegment flips edges only until the constraint segment exists, which retriangulates the
+// corridor as two fans hanging off the segment — a valid triangulation but generally NOT Delaunay
+// (arbitrarily thin triangles). Every flip therefore queues its new diagonal (see rebuildFlip),
+// and insertConstraint drains the queue through recursive Lawson legalization once the segment is
+// recorded, restoring the empty-circumcircle property everywhere except across constrained edges
+// (Anglada 1997; Sloan 1993). With the mesh a true CDT again, Bowyer–Watson insertion can seed its
+// cavity by the adjacency walk instead of the exhaustive firstBad scan (see locateSeed).
+
+// legalizePending drains the diagonals queued by recovery flips, restoring the local Delaunay
+// property. Terminates because each Lawson flip strictly lowers the lifted-paraboloid surface (the
+// classic flip-algorithm argument) and the exact in-circle predicate admits no cocircular cycling;
+// the iteration cap is insurance against a predicate bug — bailing leaves a valid, merely
+// less-Delaunay mesh, never a broken one.
+func (m *cdt) legalizePending() {
+	for guard := 8*len(m.tris) + 64; len(m.pendingLegal) > 0 && guard > 0; guard-- {
+		e := m.pendingLegal[len(m.pendingLegal)-1]
+		m.pendingLegal = m.pendingLegal[:len(m.pendingLegal)-1]
+		m.legalizeEdge(e[0], e[1])
+	}
+	m.pendingLegal = m.pendingLegal[:0]
+}
+
+// legalizeEdge applies one Lawson step at edge (u,w): if the apex across the edge lies strictly
+// inside the adjacent triangle's circumcircle, flip the edge and re-enqueue the four quad sides —
+// the only edges whose local Delaunay status the flip can change (the new diagonal is Delaunay by
+// construction, so the queue shrinks). Constrained edges are walls the Delaunay property is
+// exempt across; a stale queue entry whose edge an earlier flip already removed is skipped.
+func (m *cdt) legalizeEdge(u, w int) {
+	if m.con[conKey(u, w)] > 0 {
+		return
+	}
+	t, i, ok := m.edgeTriangle(u, w)
+	if !ok {
+		return
+	}
+	s := m.tris[t].n[i]
+	if s < 0 {
+		return
+	}
+	c, d := m.tris[t].v[i], m.apex(s, u, w)
+	if d < 0 || inCircle(m.pts[m.tris[t].v[0]], m.pts[m.tris[t].v[1]], m.pts[m.tris[t].v[2]], m.pts[d]) <= 0 {
+		return // already locally Delaunay (or exactly cocircular: either diagonal is legal)
+	}
+	// A strict in-circle violation in a valid planar triangulation implies the quad is strictly
+	// convex, so the flip cannot fail; the guard is belt-and-braces against degenerate coordinates.
+	if !m.flip(t, i) {
+		return
+	}
+	m.pendingLegal = append(m.pendingLegal, [2]int{u, c}, [2]int{c, w}, [2]int{w, d}, [2]int{d, u})
+}

--- a/kernel/ops/cdt_recovery_test.go
+++ b/kernel/ops/cdt_recovery_test.go
@@ -157,22 +157,13 @@ func TestHoledCylinderWallNonRecoverySurfacedAndWatertight(t *testing.T) {
 		}
 	}
 
-	var info, defect int
+	// Premise updated by #1604: the seam constraint used to be structurally unrecoverable (the hole
+	// corners' axial stations lie exactly ON the seam), surfacing one benign Info diagnostic. The
+	// segment-through-vertex split now recovers the seam piecewise, so a healthy wall must carry NO
+	// constraint-leak diagnostic at any severity — and certainly no Defect.
 	for _, d := range mesh.Diagnostics {
-		if d.Code != CodeCDTConstraintLeak {
-			continue
+		if d.Code == CodeCDTConstraintLeak {
+			t.Errorf("holed wall raised %s (%v: %s); the split-at-vertex recovery must realize the seam", d.Code, d.Severity, d.Detail)
 		}
-		switch d.Severity {
-		case diag.Info:
-			info++
-		case diag.Defect:
-			defect++
-		}
-	}
-	if info != 1 {
-		t.Errorf("seam non-recovery must surface exactly one Info %s, got %d", CodeCDTConstraintLeak, info)
-	}
-	if defect != 0 {
-		t.Errorf("the watertight holed wall must not raise a leak Defect, got %d", defect)
 	}
 }


### PR DESCRIPTION
## What

Makes the in-house CDT a **true** constrained Delaunay triangulation (audit A8):

- **Legalization after every segment recovery**: each recovery flip queues its new diagonal; `insertConstraint` drains the queue through recursive Lawson in-circle legalization honoring constrained edges (Anglada/Sloan). Terminates by the lifted-paraboloid argument with the in-tree exact predicates; a generous cap is belt-and-braces only.
- **Walk-seeded Bowyer–Watson in both phases**: the `firstBad` O(T)-per-point scan branch for post-constraint insertion is gone — with the mesh a true CDT between insertions, the #1408 adjacency walk is valid on the refined path too (with the existing capped-walk→scan degenerate fallback intact).
- **Segment-through-vertex splitting**: a constraint passing exactly through mesh vertices recovers piecewise at those vertices (Shewchuk's Triangle) instead of being dropped as unrecovered.
- **Strict proper-crossing predicate**: `segmentsCross` no longer counts an exact endpoint-touch as a crossing, so `recoverByFlips` stops destructively flipping edges that merely touch an unrecoverable segment.
- **Wall multiplicity parity**: `con` is now a multiplicity map; the domain flood toggles on odd wall count, so a pinched trim (hole boundary running exactly along the outer boundary) forms a double wall that correctly cancels.

## What this caught

The unrolled holed cylinder wall — the #1335/#1410 fixture — was **never triangulated correctly**: its seam constraint passes exactly through the window's seam-side samples (structurally unrecoverable, silently dropped), the flood leaked through the gap AND through the pinched window edge, and the old scan-seeded mesh contained **3 folded (overlapping) triangles** whose double-cover pushed the 3D area back inside the test band (`repairFolds` cleaned up the rest). The honest walk-seeded mesh exposed the whole chain. It now triangulates **exactly**: 2D domain area equals the polygon area to ~1e-12 relative, fold-free, fully Delaunay off-constraints, all constraints recovered — so the holed-wall diagnostic test's premise inverted (a healthy wall now carries NO `cdt-constraint-leak` diagnostic).

## Tests

Red-verified against the old code: corridor legalization (`alternatingStrip` chord leaves 2 empty-circumcircle violations), insertion into a recovered corridor, walk usage + CCW + two-sided area + Delaunay property on an adversarial sawtooth-comb refined fixture, split-at-vertex recovery, pinched-hole wall parity (multiplicity 2 cancels). Full repo suite + golangci-lint green.

## Live test

`mcplive -part squatrim` (crossing-cylinder boolean → holed-wall tessellation, exact volume), `-part polyhole`, `-part counterbore` all PASS against the live app (volumes within 0.03% of analytic); viewport screenshot visually inspected (clean counterbored block, no shading/tessellation artifacts).

Closes #1604

🤖 Generated with [Claude Code](https://claude.com/claude-code)