### PR TITLE
Coverage-gate the terminal ear-clip patch fallback (audit A9)

### DIFF
--- a/kernel/ops/patch_acceptance.go
+++ b/kernel/ops/patch_acceptance.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Acceptance gate for the terminal ear-clip patch fallback (#1605, audit A9).
+//
+// boundaryPatchMesh is the last line of defense for hard trimmed curved faces — exactly the faces
+// most likely to be degenerate — and ear clipping is only guaranteed for SIMPLE polygons (the
+// two-ears theorem). On a self-touching or self-crossing trim it either breaks early (a literal
+// hole in the body) or emits count-complete but OVERLAPPING triangles (a self-touching pentagon
+// measured 3× its area). Both shipped silently. Every ear-clip result is now acceptance-checked,
+// recovered once through the true CDT (#1604 — its split-at-vertex recovery handles precisely the
+// self-touching case), and any residual defect ships LOUDLY as a diag.Defect on the mesh.
+
+// CodePatchCoverage marks a boundary-patch triangulation that failed coverage acceptance — free
+// (unshared) edges beyond the boundary's own, or a triangulated area that disagrees with the trim
+// polygon's — after the CDT recovery tier also failed. The mesh still ships (a flagged partial
+// covering beats a missing face) but the degradation is counted, never silent (#1605).
+const CodePatchCoverage diag.Code = "tessellate.patch-coverage"
+
+// patchCoverageGate runs the two acceptance signals on an ear-clipped patch and recovers through
+// the constrained-Delaunay path when they fail, returning the triangles to ship and the acceptance
+// verdict of the shipped set. pos2D is the boundary in the ear-clip's own projection plane (outer
+// followed by the holes, the order the triangle indices address).
+func patchCoverageGate(outer2D []math.Point2, holes2D [][]math.Point2, tris [][3]int) ([][3]int, bool) {
+	if patchCovers(outer2D, holes2D, tris) {
+		return tris, true
+	}
+	if ctris, ok := cdtPatchRecovery(outer2D, holes2D); ok && patchCovers(outer2D, holes2D, ctris) {
+		return ctris, true
+	}
+	return tris, false
+}
+
+// patchCovers reports whether the 2D triangulation covers the trim polygon exactly: every
+// triangle must be positively oriented (a negative one is folded against the covering — and would
+// silently CANCEL an overlapping positive one in a signed sum, which is exactly how the
+// self-touching pentagon's 3× cover measured "correct"), and the unsigned area sum must equal the
+// loops' shoelace area (holes subtracted). The comparison happens in the projection plane where
+// both sides are exact polygon arithmetic — a hole under-counts, an overlap over-counts, so the
+// bracket is two-sided. The free-edge signal (weldedFreeEdgeCount) is applied by the caller on the
+// final welded mesh, where duplicate boundary samples have merged.
+func patchCovers(outer2D []math.Point2, holes2D [][]math.Point2, tris [][3]int) bool {
+	pts := flattenLoops2D(outer2D, holes2D)
+	want := stdmath.Abs(float64(signedArea(outer2D)))
+	for _, h := range holes2D {
+		want -= stdmath.Abs(float64(signedArea(h)))
+	}
+	got := 0.0
+	for _, tr := range tris {
+		a := orient2d(pts[tr[0]], pts[tr[1]], pts[tr[2]]) / 2
+		if a < 0 {
+			return false // inverted against the covering: folded or self-crossing input
+		}
+		got += a
+	}
+	res := geom.ResolutionForPoints2D(outer2D)
+	return stdmath.Abs(got-want) <= res.Area()
+}
+
+// cdtPatchRecovery retriangulates the boundary loops with the constrained Delaunay path — strictly
+// more robust than ear clipping since #1604: a vertex exactly on another loop edge splits the
+// constraint instead of defeating it, and coincident duplicate samples weld to representatives.
+// ok is false when the CDT itself reports unrecovered constraints or a leak (a genuinely ambiguous
+// self-crossing trim), so the caller keeps the ear-clip result and flags it.
+func cdtPatchRecovery(outer2D []math.Point2, holes2D [][]math.Point2) ([][3]int, bool) {
+	pts2 := flattenLoops2D(outer2D, holes2D)
+	loops := make([][]int, 0, 1+len(holes2D))
+	next := 0
+	for _, n := range append([]int{len(outer2D)}, loopLens(holes2D)...) {
+		idx := make([]int, n)
+		for i := range idx {
+			idx[i] = next + i
+		}
+		loops = append(loops, idx)
+		next += n
+	}
+	tris, unrecovered, fellBack := constrainedDelaunayChecked(pts2, loops)
+	if len(tris) == 0 || len(unrecovered) > 0 || fellBack {
+		return nil, false
+	}
+	return tris, true
+}
+
+// flattenLoops2D concatenates the outer loop and holes into the flat [2]float64 point slice the
+// CDT and the coverage sum index (the same order the ear-clip triangle indices address).
+func flattenLoops2D(outer2D []math.Point2, holes2D [][]math.Point2) [][2]float64 {
+	pts := make([][2]float64, 0, len(outer2D))
+	for _, p := range outer2D {
+		pts = append(pts, [2]float64{float64(p.X), float64(p.Y)})
+	}
+	for _, h := range holes2D {
+		for _, p := range h {
+			pts = append(pts, [2]float64{float64(p.X), float64(p.Y)})
+		}
+	}
+	return pts
+}
+
+// loopLens returns each hole loop's point count.
+func loopLens(holes [][]math.Point2) []int {
+	out := make([]int, len(holes))
+	for i, h := range holes {
+		out[i] = len(h)
+	}
+	return out
+}
+
+// diagnosePatchCoverage records the coverage Defect when the shipped patch failed acceptance and
+// the CDT recovery could not repair it (#1605). For a boundary-only patch the 2D bracket subsumes
+// hole detection — an interior hole is an area deficit, an overlap a surplus, a fold a negative
+// triangle — so acceptance is the verdict; the welded free-edge count (the in-tree watertightness
+// metric) is reported as the diagnostic's evidence. The mesh still ships — flagged, never silent.
+func diagnosePatchCoverage(m *Mesh, accepted bool) {
+	if accepted {
+		return
+	}
+	m.Diagnose(diag.Diagnostic{
+		Code:     CodePatchCoverage,
+		Severity: diag.Defect,
+		Detail: fmt.Sprintf("boundary-patch triangulation failed coverage acceptance and CDT recovery (%d free edges after welding); "+
+			"the trim boundary is degenerate or self-crossing and the face mesh may carry a hole or overlap", weldedFreeEdgeCount(m)),
+	})
+}

--- a/kernel/ops/patch_acceptance_test.go
+++ b/kernel/ops/patch_acceptance_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Audit A9 (#1605): the terminal ear-clip patch fallback must never ship a defective covering
+// silently — acceptance-check every result, recover once through the CDT (#1604), and flag any
+// residual defect loudly.
+
+// planarBoundaryPatch runs boundaryPatchMesh on a z=0 polygon over an actual plane surface.
+func planarBoundaryPatch(t *testing.T, poly []math.Point2) *Mesh {
+	t.Helper()
+	s, err := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	if err != nil {
+		t.Fatalf("NewPlane: %v", err)
+	}
+	outer3D := make([]math.Point3, len(poly))
+	for i, p := range poly {
+		outer3D[i] = math.P3(p.X, p.Y, 0)
+	}
+	return boundaryPatchMesh(s, outer3D, nil)
+}
+
+// patchCoverageDefects counts CodePatchCoverage Defect diagnostics on the mesh.
+func patchCoverageDefects(m *Mesh) int {
+	n := 0
+	for _, d := range m.Diagnostics {
+		if d.Code == CodePatchCoverage && d.Severity == diag.Defect {
+			n++
+		}
+	}
+	return n
+}
+
+// TestBoundaryPatchSelfTouchRecoveredByCDT pins the recovery tier (#1605): a self-touching trim —
+// a vertex lying exactly ON another boundary edge — defeats ear clipping into count-complete but
+// OVERLAPPING triangles (measured 24 for an 8-area region, a silent 3× cover). The coverage gate
+// must detect the area mismatch and retriangulate through the CDT, whose split-at-vertex recovery
+// (#1604) handles exactly this: correct area, watertight free-edge budget, no defect flag.
+func TestBoundaryPatchSelfTouchRecoveredByCDT(t *testing.T) {
+	poly := []math.Point2{math.P2(0, 0), math.P2(4, 0), math.P2(4, 4), math.P2(2, 0), math.P2(0, 4)}
+	m := planarBoundaryPatch(t, poly)
+	const want = 8.0 // |shoelace| of the self-touching pentagon
+	if got := meshArea(m); stdmath.Abs(got-want) > 1e-9*want {
+		t.Errorf("self-touching patch area = %.6f, want %.6f (ear-clip overlap not recovered)", got, want)
+	}
+	if free := weldedFreeEdgeCount(m); free > len(poly)+2 {
+		// +2: the split at the on-edge vertex doubles that boundary station into two edges.
+		t.Errorf("self-touching patch has %d free edges, want ≤ %d", free, len(poly)+2)
+	}
+	if n := patchCoverageDefects(m); n != 0 {
+		t.Errorf("recovered patch must carry no %s defect, got %d", CodePatchCoverage, n)
+	}
+}
+
+// TestBoundaryPatchSelfCrossingShipsLoudly pins the loud-failure guarantee (#1605): a genuinely
+// self-crossing trim (bow-tie — winding area zero, ear-clip emits overlapping garbage) cannot be
+// covered consistently by ANY triangulation of its loops, so whatever ships must carry the
+// CodePatchCoverage Defect — visible in feature diagnostics and over the wire — never a silent
+// return.
+func TestBoundaryPatchSelfCrossingShipsLoudly(t *testing.T) {
+	poly := []math.Point2{math.P2(0, 0), math.P2(4, 0), math.P2(0, 4), math.P2(4, 4)}
+	m := planarBoundaryPatch(t, poly)
+	if n := patchCoverageDefects(m); n == 0 {
+		t.Errorf("self-crossing trim shipped without a %s defect (silent degradation)", CodePatchCoverage)
+	}
+}
+
+// TestBoundaryPatchCleanTrimUnflagged guards against false positives: an ordinary concave simple
+// polygon ear-clips exactly and must ship with the exact area and no coverage defect.
+func TestBoundaryPatchCleanTrimUnflagged(t *testing.T) {
+	poly := []math.Point2{math.P2(0, 0), math.P2(6, 0), math.P2(6, 2), math.P2(2, 2), math.P2(2, 4), math.P2(0, 4)}
+	m := planarBoundaryPatch(t, poly)
+	const want = 16.0 // L-shape: 6×2 + 2×2
+	if got := meshArea(m); stdmath.Abs(got-want) > 1e-9*want {
+		t.Errorf("clean trim area = %.6f, want %.6f", got, want)
+	}
+	if n := patchCoverageDefects(m); n != 0 {
+		t.Errorf("clean trim must carry no %s defect, got %d", CodePatchCoverage, n)
+	}
+}

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -182,6 +182,11 @@ func boundaryPatchMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.P
 	} else {
 		tris = earClip(outer2D)
 	}
+	// Ear clipping is only guaranteed on a simple polygon; a degenerate/self-touching trim makes it
+	// break early (a hole) or emit count-complete but OVERLAPPING triangles — the coverage gate
+	// detects both in the projection plane and retriangulates through the CDT, whose
+	// split-at-vertex recovery handles the self-touching case exactly (#1605; recovery tier = #1604).
+	tris, accepted := patchCoverageGate(outer2D, holes2D, tris)
 	// The ear-clip output is consistently oriented in the projection plane; patchMeshFrom keeps that
 	// winding and flips the whole patch once if it faces inward overall. Winding each triangle to its
 	// own vertex normals instead flips slivers inconsistently — the back-facing hole walls in Normal-Debug.
@@ -192,6 +197,7 @@ func boundaryPatchMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.P
 	}
 	m := patchMeshFrom(pos, nrm, tris)
 	repairFolds(m, 8) // a curved cap's boundary triangulation can crease; flip the folding diagonals (#585)
+	diagnosePatchCoverage(m, accepted)
 	return m
 }
 

--- a/kernel/ops/tolerance_guard_test.go
+++ b/kernel/ops/tolerance_guard_test.go
@@ -109,6 +109,7 @@ func TestNoUnjustifiedAbsoluteEpsilons(t *testing.T) {
 		// ops: the CDT / conformance / orientation weld grids and trim-grid gates (#1610).
 		"../ops/conformance_repair.go",
 		"../ops/tessellate_trim.go",
+		"../ops/patch_acceptance.go",
 		"../ops/planar_faithful.go",
 		"../ops/refined_patch.go",
 		"../ops/mesh_orient.go",


### PR DESCRIPTION
## What

`boundaryPatchMesh` — the terminal fallback every hard trimmed-curved-face path lands on — trusted ear clipping blind. Ear clipping is only guaranteed for simple polygons (two-ears theorem); on degenerate/self-touching trims it breaks early (a hole) or emits count-complete but **overlapping** triangles. Both shipped silently — the audit's silent-degradation pattern 1 on the highest-priority defect class (tessellation).

Now every ear-clip result passes a **coverage gate** in the projection plane:
- every triangle positively oriented, and
- the **unsigned** area sum equal to the loops' shoelace area (holes subtracted), within the model-relative `Resolution.Area()`.

A signed sum is insufficient — a folded triangle cancels an overlapping one, which is exactly how a self-touching pentagon's 3× cover measured "correct" (24 for an 8-area region, found while writing the tests).

On failure the patch retriangulates once through the **CDT recovery tier**: #1604's split-at-vertex recovery handles the self-touching (vertex-on-edge) case exactly. A residual failure ships **loudly**: `CodePatchCoverage` `diag.Defect` with the `weldedFreeEdgeCount` evidence, visible in feature diagnostics and over the wire (A5 plumbing). `patch_acceptance.go` joins the tolerance-guard scope.

## Tests

Red-verified with the gate disabled: self-touching trim recovered to the exact area via CDT (no defect flag), self-crossing bow-tie ships with the defect, clean concave trim stays unflagged at exact area. Full repo suite + lint green.

## Live test

`mcplive -part benttube`, `-part loftcurved`, `-part shaftcoupling` (curved-trim + holed-wall patch paths) all PASS against the live app; viewport screenshot inspected — the coupling's four lens-shaped grub-hole openings on the curved wall render with no gaps or artifacts.

Closes #1605

🤖 Generated with [Claude Code](https://claude.com/claude-code)