### PR TITLE
Fix three #1693 kernel regressions: pinched-vertex contacts, flush blind holes, sweep path invalidation

### DIFF
--- a/addin/opregistry/feature_advanced.go
+++ b/addin/opregistry/feature_advanced.go
@@ -102,12 +102,19 @@ func sweepDefinitionFromArgs(part *compdef.PartComponentDefinition, in sweepArgs
 	if _, err := pathFromSketch(part, in.PathSketchIndex, in.PathIndex); err != nil {
 		return nil, err
 	}
+	pathSk, err := sketchAt(part, in.PathSketchIndex)
+	if err != nil {
+		return nil, err
+	}
 	def := &feature.SweepDefinition{
 		ProfileIndex: in.ProfileIndex,
 		Path: func() *sketch.Path3D {
 			p, _ := pathFromSketch(part, in.PathSketchIndex, in.PathIndex)
 			return p
 		},
+		// Attribute the live path to its sketch so a parameter driving the rail re-sweeps the
+		// body (#1414 tail invalidation; Oblikovati#1693).
+		PathSketch: pathSk,
 	}
 	if err := sweepScalars(part, in, def); err != nil {
 		return nil, err
@@ -173,6 +180,9 @@ func sweepVariantFields(part *compdef.PartComponentDefinition, in sweepArgs, def
 		def.GuideRail = func() *sketch.Path3D {
 			p, _ := pathFromSketch(part, in.RailSketchIndex, in.RailIndex)
 			return p
+		}
+		if railSk, err := sketchAt(part, in.RailSketchIndex); err == nil {
+			def.GuideRailSketch = railSk // rail-driving parameters re-sweep too (#1693)
 		}
 		return sweepScaling(in, def)
 	case "pathAndGuideSurface":

--- a/app/sweep_tool.go
+++ b/app/sweep_tool.go
@@ -224,6 +224,7 @@ func (t *SweepTool) addSweep(fs *feature.PartFeatures) (*feature.PartFeature, er
 		Sketch:       t.profile.Sketch,
 		ProfileIndex: t.profile.ProfileIndex,
 		Path:         livePathProvider(*t.path),
+		PathSketch:   t.path.Sketch,
 		Twist:        func() float64 { return twist },
 		Taper:        func() float64 { return taper },
 		Operation:    t.operation,
@@ -231,6 +232,7 @@ func (t *SweepTool) addSweep(fs *feature.PartFeatures) (*feature.PartFeature, er
 	}
 	if t.guideRail != nil {
 		def.GuideRail = livePathProvider(*t.guideRail)
+		def.GuideRailSketch = t.guideRail.Sketch
 		def.Scaling = t.scaling
 	}
 	return feature.NewSweepFeatures(fs).AddDefinition(def), nil

--- a/kernel/brep/boolean_nonmanifold.go
+++ b/kernel/brep/boolean_nonmanifold.go
@@ -65,11 +65,15 @@ func allUsesPaired(uses map[[2]int][]loopEdgeUse) bool {
 func buildResolvedEdges(bld *topo.Builder, verts []math.Point3, tv []*topo.Vertex, uses map[[2]int][]loopEdgeUse, faces []builtFace, prov []imprintSeg) map[[3]int]*topo.Edge {
 	builds := planEdgeBuilds(verts, uses, faces, prov)
 	rankSamePairEdges(builds, prov)
+	// Pinched vertices (a sub-grid contact patch, or the endpoints of resolved tangent-contact
+	// edges) are cut apart into fan-specific coincident duplicates so the shell stays a true
+	// closed 2-manifold (#1693); a manifold vertex resolves to its shared tv entry.
+	endpoint := pinchedEndpoints(bld, verts, tv, builds)
 	useEdge := make(map[[3]int]*topo.Edge)
 	idx := 0
 	for i := range builds {
 		b := &builds[i]
-		e := bld.AddEdge(geom.NewLineSegment(verts[b.k[0]], verts[b.k[1]]), tv[b.k[0]], tv[b.k[1]], edgeBuildLineage(b, &idx))
+		e := bld.AddEdge(geom.NewLineSegment(verts[b.k[0]], verts[b.k[1]]), endpoint[[2]int{i, b.k[0]}], endpoint[[2]int{i, b.k[1]}], edgeBuildLineage(b, &idx))
 		for _, h := range b.group {
 			useEdge[[3]int{h.face, h.ring, h.pos}] = e
 		}

--- a/kernel/brep/boolean_pinch.go
+++ b/kernel/brep/boolean_pinch.go
@@ -65,44 +65,16 @@ func pinchedEndpoints(bld *topo.Builder, verts []math.Point3, tv []*topo.Vertex,
 // buildFans partitions a vertex's incident edge builds into fans: two builds are one fan iff
 // some face loop uses both (their use groups share a face). A manifold vertex yields one fan.
 func buildFans(builds []edgeBuild, inc []int) [][]int {
-	parent := make(map[int]int, len(inc))
-	var find func(x int) int
-	find = func(x int) int {
-		if parent[x] != x {
-			parent[x] = find(parent[x])
-		}
-		return parent[x]
-	}
-	for _, bi := range inc {
-		parent[bi] = bi
-	}
-	byFace := map[int]int{} // face → first incident build seen using it
-	for _, bi := range inc {
-		for _, u := range builds[bi].group {
-			if first, ok := byFace[u.face]; ok {
-				parent[find(bi)] = find(first)
-			} else {
-				byFace[u.face] = bi
+	return topo.ComponentGroups(inc, func(join func(a, b int)) {
+		byFace := map[int]int{} // face → first incident build seen using it
+		for _, bi := range inc {
+			for _, u := range builds[bi].group {
+				if first, ok := byFace[u.face]; ok {
+					join(bi, first)
+				} else {
+					byFace[u.face] = bi
+				}
 			}
 		}
-	}
-	return groupFans(inc, find)
-}
-
-// groupFans collects union-find components in first-seen order.
-func groupFans(inc []int, find func(int) int) [][]int {
-	groups := map[int][]int{}
-	order := []int{}
-	for _, i := range inc {
-		r := find(i)
-		if _, seen := groups[r]; !seen {
-			order = append(order, r)
-		}
-		groups[r] = append(groups[r], i)
-	}
-	fans := make([][]int, 0, len(order))
-	for _, r := range order {
-		fans = append(fans, groups[r])
-	}
-	return fans
+	})
 }

--- a/kernel/brep/boolean_pinch.go
+++ b/kernel/brep/boolean_pinch.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"sort"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Pinched-vertex resolution for the planar-boolean stitch (Oblikovati#1693).
+//
+// Two configurations weld a contact down to a vertex the per-edge checks cannot see:
+//
+//   - a contact PATCH thinner than the weld grid (a fan blade tip designed exactly on its rim's
+//     faceted inner wall meets it in a ~14 µm lens) collapses onto one vertex shared by two
+//     disjoint face fans;
+//   - a tangent contact EDGE (a fine-pitch coil whose turns touch — pitch equal to the wire
+//     diameter — welds turn-to-turn contact chains) is correctly split by resolveEdgeUses into
+//     two coincident manifold edges, but the endpoints of every resolved pair remain ONE welded
+//     vertex, pinching at each chain vertex (319 of them on the NopSCADlib threaded rod). The
+//     nudge retry cannot help there: a SELF-contact of one operand moves with itself, and the
+//     opposing contact normals cancel in awayFromContacts.
+//
+// Either way every edge still carries exactly two faces; only the Euler characteristic drops,
+// one per pinch, shipping an inadmissible "valid-looking" solid. The repair mirrors the tangent-
+// EDGE resolution one dimension down: group each vertex's incident RESOLVED edges into fans
+// (two edges connect iff some face uses both at that vertex) and give every fan beyond the first
+// its own coincident duplicate vertex — the shells then touch at a point, the resolution-faithful
+// result for a sub-grid contact (the CSG cage applies the same repair in ops).
+
+// pinchedEndpoints returns, for every planned edge build, the topo vertex to use at each of its
+// two endpoints: the shared welded vertex for a manifold vertex, or the build's fan-specific
+// coincident duplicate at a pinched one. Keys are (build index, welded vertex index).
+func pinchedEndpoints(bld *topo.Builder, verts []math.Point3, tv []*topo.Vertex, builds []edgeBuild) map[[2]int]*topo.Vertex {
+	incident := map[int][]int{} // welded vertex → indices into builds
+	for bi := range builds {
+		incident[builds[bi].k[0]] = append(incident[builds[bi].k[0]], bi)
+		incident[builds[bi].k[1]] = append(incident[builds[bi].k[1]], bi)
+	}
+	order := make([]int, 0, len(incident))
+	for v := range incident {
+		order = append(order, v)
+	}
+	sort.Ints(order) // deterministic duplicate lineage regardless of map iteration
+	endpoint := make(map[[2]int]*topo.Vertex, 2*len(builds))
+	dup := 0
+	for _, v := range order {
+		inc := incident[v]
+		for fanIdx, fan := range buildFans(builds, inc) {
+			use := tv[v]
+			if fanIdx > 0 {
+				use = bld.AddVertex(verts[v], topo.NewLineage(topo.Tok("brep", "pinch", dup)))
+				dup++
+			}
+			for _, bi := range fan {
+				endpoint[[2]int{bi, v}] = use
+			}
+		}
+	}
+	return endpoint
+}
+
+// buildFans partitions a vertex's incident edge builds into fans: two builds are one fan iff
+// some face loop uses both (their use groups share a face). A manifold vertex yields one fan.
+func buildFans(builds []edgeBuild, inc []int) [][]int {
+	parent := make(map[int]int, len(inc))
+	var find func(x int) int
+	find = func(x int) int {
+		if parent[x] != x {
+			parent[x] = find(parent[x])
+		}
+		return parent[x]
+	}
+	for _, bi := range inc {
+		parent[bi] = bi
+	}
+	byFace := map[int]int{} // face → first incident build seen using it
+	for _, bi := range inc {
+		for _, u := range builds[bi].group {
+			if first, ok := byFace[u.face]; ok {
+				parent[find(bi)] = find(first)
+			} else {
+				byFace[u.face] = bi
+			}
+		}
+	}
+	return groupFans(inc, find)
+}
+
+// groupFans collects union-find components in first-seen order.
+func groupFans(inc []int, find func(int) int) [][]int {
+	groups := map[int][]int{}
+	order := []int{}
+	for _, i := range inc {
+		r := find(i)
+		if _, seen := groups[r]; !seen {
+			order = append(order, r)
+		}
+		groups[r] = append(groups[r], i)
+	}
+	fans := make([][]int, 0, len(order))
+	for _, r := range order {
+		fans = append(fans, groups[r])
+	}
+	return fans
+}

--- a/kernel/brep/boolean_pinch_test.go
+++ b/kernel/brep/boolean_pinch_test.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep_test
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+)
+
+// TestUnionPointContactSplitsPinch pins the pinched-vertex resolution (Oblikovati#1693): two
+// boxes sharing exactly ONE corner point union into a body whose contact vertex must be CUT
+// APART into coincident duplicates (two point-touching shells, χ = 4) — not welded into a single
+// vertex with two face fans, which every per-edge check passes while χ = 3 marks the solid
+// topologically impossible. This is the minimized fan-blade-tip-on-rim failure.
+func TestUnionPointContactSplitsPinch(t *testing.T) {
+	a := box(0, 0, 0, 2, 2, 2)
+	b := box(2, 2, 2, 2, 2, 2) // shares only the corner (2,2,2) with a
+	res, err := brep.Boolean(brep.Union, a, b)
+	if err != nil {
+		t.Fatalf("union: %v", err)
+	}
+	r := ops.Validate(res)
+	if !r.Valid {
+		t.Errorf("point-contact union invalid: χ=%d issues=%v", r.EulerCharacteristic, r.Issues)
+	}
+	if r.EulerCharacteristic != 4 {
+		t.Errorf("χ = %d, want 4 (two sphere-topology shells after the pinch split)", r.EulerCharacteristic)
+	}
+}
+
+// TestUnionEdgeContactStaysManifold guards the neighbouring behavior the pinch split must not
+// disturb: two boxes sharing a full EDGE resolve through the tangent-edge machinery
+// (resolveEdgeUses) into a valid solid — and with the endpoints of the resolved coincident edges
+// now split per fan, the result must still validate.
+func TestUnionEdgeContactStaysManifold(t *testing.T) {
+	a := box(0, 0, 0, 2, 2, 2)
+	b := box(2, 2, 0, 2, 2, 2) // shares the vertical edge x=2,y=2, z∈[0,2]
+	res, err := brep.Boolean(brep.Union, a, b)
+	if err != nil {
+		t.Fatalf("union: %v", err)
+	}
+	if r := ops.Validate(res); !r.Valid {
+		t.Errorf("edge-contact union invalid: χ=%d issues=%v", r.EulerCharacteristic, r.Issues)
+	}
+}

--- a/kernel/ops/csg_body.go
+++ b/kernel/ops/csg_body.go
@@ -71,7 +71,13 @@ func trianglesToBody(tris []tri, feat string) *topo.Body {
 		return nil
 	}
 	verts, faces = removeTJunctions(verts, faces, res.Plane())
-	return cageToBody(verts, dropDegenerate(faces), feat)
+	faces = dropDegenerate(faces)
+	// A sub-resolution tangency (a face designed exactly on another body's wall) welds into a
+	// PINCHED vertex — two fans on one vertex, χ off by one per pinch, invisible to the edge
+	// checks. Cut such vertices apart into coincident duplicates so the cage is a true closed
+	// 2-manifold; the shells then touch at a point instead of sharing an inadmissible vertex (#1693).
+	verts = splitPinchedVertices(verts, faces)
+	return cageToBody(verts, faces, feat)
 }
 
 // dedupTriangles cancels coincident triangles produced where coplanar faces of the two

--- a/kernel/ops/csg_pinch.go
+++ b/kernel/ops/csg_pinch.go
@@ -2,7 +2,10 @@
 
 package ops
 
-import "oblikovati.org/math"
+import (
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
 
 // Pinched-vertex splitting for the CSG cage (#1693).
 //
@@ -54,47 +57,19 @@ func splitVertexFans(verts []math.Point3, faces [][3]int, v int, inc []int) []ma
 // belong to the same fan iff they share an edge THROUGH v (the same opposite endpoint). A clean
 // manifold vertex yields exactly one fan.
 func vertexFans(faces [][3]int, v int, inc []int) [][]int {
-	parent := make(map[int]int, len(inc))
-	var find func(x int) int
-	find = func(x int) int {
-		if parent[x] != x {
-			parent[x] = find(parent[x])
-		}
-		return parent[x]
-	}
-	for _, fi := range inc {
-		parent[fi] = fi
-	}
-	byOther := map[int]int{} // opposite endpoint of a v-incident edge → first face seen
-	for _, fi := range inc {
-		for _, w := range faces[fi] {
-			if w == v {
-				continue
-			}
-			if first, ok := byOther[w]; ok {
-				parent[find(fi)] = find(first)
-			} else {
-				byOther[w] = fi
+	return topo.ComponentGroups(inc, func(join func(a, b int)) {
+		byOther := map[int]int{} // opposite endpoint of a v-incident edge → first face seen
+		for _, fi := range inc {
+			for _, w := range faces[fi] {
+				if w == v {
+					continue
+				}
+				if first, ok := byOther[w]; ok {
+					join(fi, first)
+				} else {
+					byOther[w] = fi
+				}
 			}
 		}
-	}
-	return groupFanComponents(inc, find)
-}
-
-// groupFanComponents collects union-find components in first-seen order.
-func groupFanComponents(inc []int, find func(int) int) [][]int {
-	groups := map[int][]int{}
-	order := []int{}
-	for _, i := range inc {
-		r := find(i)
-		if _, seen := groups[r]; !seen {
-			order = append(order, r)
-		}
-		groups[r] = append(groups[r], i)
-	}
-	fans := make([][]int, 0, len(order))
-	for _, r := range order {
-		fans = append(fans, groups[r])
-	}
-	return fans
+	})
 }

--- a/kernel/ops/csg_pinch.go
+++ b/kernel/ops/csg_pinch.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import "oblikovati.org/math"
+
+// Pinched-vertex splitting for the CSG cage (#1693).
+//
+// A near-tangent boolean contact — a fan blade tip designed exactly on its rim's inner wall
+// touches it in a lens thinner than the facet resolution — collapses under the vertex weld into
+// ONE vertex whose incident triangles form TWO disjoint fans. That pinch is invisible to
+// edge-manifoldness (every edge still has exactly two faces) but is not a valid closed 2-manifold:
+// each pinch drops the Euler characteristic by one, which is exactly how the blade JOIN measured
+// χ = −1 and a reparametrized threaded rod χ = −319. The standard mesh-repair resolution is to CUT
+// the vertex apart: one duplicate vertex (same coordinates) per extra fan, giving coincident but
+// topologically distinct shells that touch at a point — the resolution-faithful result when the
+// true contact patch is far below the weld grid.
+
+// splitPinchedVertices duplicates every vertex whose incident triangles form more than one
+// edge-connected fan, rewriting the extra fans onto fresh coincident vertices. Faces are updated
+// in place; the (possibly extended) vertex slice is returned.
+func splitPinchedVertices(verts []math.Point3, faces [][3]int) []math.Point3 {
+	incident := make([][]int, len(verts))
+	for fi, f := range faces {
+		for _, v := range f {
+			incident[v] = append(incident[v], fi)
+		}
+	}
+	for v := range incident {
+		verts = splitVertexFans(verts, faces, v, incident[v])
+	}
+	return verts
+}
+
+// splitVertexFans groups vertex v's incident faces into fans connected by shared v-incident
+// edges and moves every fan beyond the first onto a fresh duplicate vertex.
+func splitVertexFans(verts []math.Point3, faces [][3]int, v int, inc []int) []math.Point3 {
+	fans := vertexFans(faces, v, inc)
+	for _, fan := range fans[1:] {
+		nv := len(verts)
+		verts = append(verts, verts[v])
+		for _, fi := range fan {
+			for k, w := range faces[fi] {
+				if w == v {
+					faces[fi][k] = nv
+				}
+			}
+		}
+	}
+	return verts
+}
+
+// vertexFans partitions the faces incident to vertex v into edge-connected components: two faces
+// belong to the same fan iff they share an edge THROUGH v (the same opposite endpoint). A clean
+// manifold vertex yields exactly one fan.
+func vertexFans(faces [][3]int, v int, inc []int) [][]int {
+	parent := make(map[int]int, len(inc))
+	var find func(x int) int
+	find = func(x int) int {
+		if parent[x] != x {
+			parent[x] = find(parent[x])
+		}
+		return parent[x]
+	}
+	for _, fi := range inc {
+		parent[fi] = fi
+	}
+	byOther := map[int]int{} // opposite endpoint of a v-incident edge → first face seen
+	for _, fi := range inc {
+		for _, w := range faces[fi] {
+			if w == v {
+				continue
+			}
+			if first, ok := byOther[w]; ok {
+				parent[find(fi)] = find(first)
+			} else {
+				byOther[w] = fi
+			}
+		}
+	}
+	return groupFanComponents(inc, find)
+}
+
+// groupFanComponents collects union-find components in first-seen order.
+func groupFanComponents(inc []int, find func(int) int) [][]int {
+	groups := map[int][]int{}
+	order := []int{}
+	for _, i := range inc {
+		r := find(i)
+		if _, seen := groups[r]; !seen {
+			order = append(order, r)
+		}
+		groups[r] = append(groups[r], i)
+	}
+	fans := make([][]int, 0, len(order))
+	for _, r := range order {
+		fans = append(fans, groups[r])
+	}
+	return fans
+}

--- a/kernel/ops/csg_pinch_test.go
+++ b/kernel/ops/csg_pinch_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// tetTris returns the four CCW-outward triangles of a tetrahedron with apex at p and a small
+// base offset so the two test tets meet the shared point only at their apexes.
+func tetTris(base math.Point3, dir float64) []tri {
+	a := base
+	b := math.P3(base.X+dir, base.Y, base.Z-dir)
+	c := math.P3(base.X+dir, base.Y+0.6*math.Scalar(dir), base.Z-dir)
+	d := math.P3(base.X+0.4*math.Scalar(dir), base.Y+0.2*math.Scalar(dir), base.Z-1.6*math.Scalar(dir))
+	mk := func(p, q, r math.Point3) tri {
+		t, _ := newTri(p, q, r)
+		return t
+	}
+	if dir > 0 {
+		return []tri{mk(a, b, c), mk(a, c, d), mk(a, d, b), mk(b, d, c)}
+	}
+	return []tri{mk(a, c, b), mk(a, d, c), mk(a, b, d), mk(b, c, d)}
+}
+
+// TestCSGCageSplitsPinchedVertex pins #1693: a triangle soup whose two closed shells meet at ONE
+// coincident point (the sub-resolution tangency lens a near-tangent JOIN welds down to) must
+// assemble into a VALID body — the pinched vertex cut apart into coincident duplicates (χ = 4 for
+// two shells), never a χ = 3 one-vertex pinch that ships as a silently inadmissible solid. This is
+// the minimized fan-blade-tip-on-rim-wall failure (13 red bridge e2e, MCPBridge#86).
+func TestCSGCageSplitsPinchedVertex(t *testing.T) {
+	apex := math.P3(0, 0, 0)
+	soup := append(tetTris(apex, 1), tetTris(apex, -1)...)
+	b := trianglesToBody(soup, "pinch")
+	if b == nil {
+		t.Fatal("trianglesToBody returned nil")
+	}
+	r := Validate(b)
+	if !r.Valid {
+		t.Errorf("point-contact shells assemble invalid: χ=%d issues=%v", r.EulerCharacteristic, r.Issues)
+	}
+	if r.EulerCharacteristic != 4 {
+		t.Errorf("χ = %d, want 4 (two sphere shells after the pinch split)", r.EulerCharacteristic)
+	}
+	if nv := len(b.Vertices()); nv != 8 {
+		t.Errorf("body has %d vertices, want 8 (7 welded + one coincident duplicate at the contact)", nv)
+	}
+}

--- a/kernel/topo/component_groups.go
+++ b/kernel/topo/component_groups.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package topo
+
+// ComponentGroups partitions ids into connected components under caller-declared equivalences:
+// link is invoked once with a join function the caller uses to declare two ids equivalent, and
+// the components come back in first-seen id order (deterministic for deterministic input). The
+// boolean stitch and the CSG cage both use it to group a vertex's incident faces/edges into
+// fans when cutting pinched vertices apart (Oblikovati#1693).
+//
+//	fans := topo.ComponentGroups(incident, func(join func(a, b int)) {
+//		for _, pair := range sharedEdges { join(pair[0], pair[1]) }
+//	})
+func ComponentGroups(ids []int, link func(join func(a, b int))) [][]int {
+	parent := make(map[int]int, len(ids))
+	var find func(x int) int
+	find = func(x int) int {
+		if parent[x] != x {
+			parent[x] = find(parent[x])
+		}
+		return parent[x]
+	}
+	for _, id := range ids {
+		parent[id] = id
+	}
+	link(func(a, b int) {
+		if _, ok := parent[a]; !ok {
+			return
+		}
+		if _, ok := parent[b]; !ok {
+			return
+		}
+		parent[find(a)] = find(b)
+	})
+	return collectComponents(ids, find)
+}
+
+// collectComponents gathers ids by union-find root, in first-seen order.
+func collectComponents(ids []int, find func(int) int) [][]int {
+	groups := map[int][]int{}
+	order := []int{}
+	for _, id := range ids {
+		r := find(id)
+		if _, seen := groups[r]; !seen {
+			order = append(order, r)
+		}
+		groups[r] = append(groups[r], id)
+	}
+	out := make([][]int, 0, len(order))
+	for _, r := range order {
+		out = append(out, groups[r])
+	}
+	return out
+}

--- a/kernel/topo/component_groups_test.go
+++ b/kernel/topo/component_groups_test.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package topo
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestComponentGroupsPartitionsAndOrders(t *testing.T) {
+	got := ComponentGroups([]int{4, 7, 9, 2}, func(join func(a, b int)) {
+		join(7, 2)
+		join(9, 9)
+		join(11, 4) // unknown id: ignored
+	})
+	want := [][]int{{4}, {7, 2}, {9}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ComponentGroups = %v, want %v", got, want)
+	}
+}

--- a/model/compdef/param_sweep_path_recompute_test.go
+++ b/model/compdef/param_sweep_path_recompute_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// TestSweepPathParameterEditResweeps pins the sweep path attribution (Oblikovati#1693): a
+// parameter that drives the sweep's PATH sketch — not its profile sketch — must re-sweep the
+// body. The path reaches the feature through an opaque live provider, so without the
+// definition's PathSketch attribution the #1414 tail invalidation saw no dependent feature: the
+// rail sketch re-solved to its new length while the swept body silently kept the old one (the
+// resized NopSCADlib tubing measured its pre-edit volume).
+func TestSweepPathParameterEditResweeps(t *testing.T) {
+	def := compdef.NewPartComponentDefinition()
+	if _, err := def.Parameters().AddUserParameter("rail", "20 mm"); err != nil {
+		t.Fatalf("AddUserParameter: %v", err)
+	}
+
+	// Profile: a 4×4 mm square about the origin on XY.
+	prof := def.Sketches().Add(sketch.XYPlane())
+	c0 := prof.Points().Add(math.P2(-0.2, -0.2))
+	c1 := prof.Points().Add(math.P2(0.2, -0.2))
+	c2 := prof.Points().Add(math.P2(0.2, 0.2))
+	c3 := prof.Points().Add(math.P2(-0.2, 0.2))
+	prof.Lines().Add(c0, c1)
+	prof.Lines().Add(c1, c2)
+	prof.Lines().Add(c2, c3)
+	prof.Lines().Add(c3, c0)
+
+	// Path: a straight rail up +Z on XZ, its length driven by the user parameter.
+	railSk := def.Sketches().Add(sketch.XZPlane())
+	p0 := railSk.Points().Add(math.P2(0, 0))
+	p1 := railSk.Points().Add(math.P2(0, 2))
+	railSk.Lines().Add(p0, p1)
+	if _, err := railSk.DimensionConstraints().AddDistance(p0, p1, "rail"); err != nil {
+		t.Fatalf("AddDistance(rail): %v", err)
+	}
+
+	sweep := feature.NewSweepFeatures(def.Features()).AddDefinition(&feature.SweepDefinition{
+		Sketch:       prof,
+		ProfileIndex: 0,
+		Path: func() *sketch.Path3D {
+			paths := railSk.Paths()
+			if len(paths) == 0 {
+				return nil
+			}
+			pts := paths[0].Points()
+			chain := make([]*sketch.Point3D, len(pts))
+			for i, q := range pts {
+				chain[i] = sketch.NewPoint3D(railSk.Plane().ToModel(q))
+			}
+			return sketch.NewPath3D(chain, paths[0].IsClosed())
+		},
+		PathSketch: railSk, // the attribution under test
+		Operation:  ops.NewBody,
+	})
+	def.Recompute()
+	if !sweep.Health().OK() {
+		t.Fatalf("sweep sick: %+v", sweep.Health())
+	}
+	volumeAt := func() float64 {
+		return ops.BodyGeometryProperties(def.Features().Result()[0], ops.DefaultQuality()).Volume
+	}
+	before := volumeAt()
+
+	if err := def.Parameters().SetExpression(userParamID(t, def, "rail"), "30 mm"); err != nil {
+		t.Fatalf("SetExpression: %v", err)
+	}
+	def.RecomputeAfterChange()
+	after := volumeAt()
+
+	// The rail grew 20→30 mm, so the swept volume must grow by the same 1.5 factor.
+	if want := before * 1.5; stdmath.Abs(after-want) > 1e-6*want {
+		t.Errorf("swept volume after rail edit = %.6f, want %.6f (1.5× of %.6f) — the path edit did not re-sweep", after, want, before)
+	}
+}

--- a/model/feature/hole_boss.go
+++ b/model/feature/hole_boss.go
@@ -8,6 +8,7 @@ import (
 
 	"oblikovati.org/kernel/brep"
 	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -233,6 +234,15 @@ func (h *HoleFeature) facetedCounterbore(body *topo.Body, center math.Point3, in
 // depth would exit), it falls back to the faceted boolean — a through-cut when `through`, the
 // requested depth otherwise.
 func (h *HoleFeature) cutCylinder(body *topo.Body, center math.Point3, into math.UnitVector3, r, depth float64, through bool, rec *diag.Recorder) (*topo.Body, error) {
+	// A blind hole whose bottom reaches (or passes) the part's far extent along the axis IS a
+	// through hole: the flush-bottom "blind" cut would leave a zero-thickness membrane for a
+	// floor, which the exact blind drill rightly rejects — and the rejection used to fall to the
+	// faceted prism cut, silently costing the bore its analytic cylinder wall (the tapped-hole
+	// thread had nothing to attach to, Oblikovati#1693). Promote it to the through cut, matching
+	// drill break-through behavior.
+	if !through && depth >= throughDepth(body, center, into)-cutterOverhang-geom.ResolutionForBox(body.RangeBox()).Plane() {
+		through = true
+	}
 	if through {
 		if res, err := brep.CutCylindricalHole(body, center, into.AsVector(), r); err == nil {
 			return res, nil

--- a/model/feature/hole_boss_test.go
+++ b/model/feature/hole_boss_test.go
@@ -403,3 +403,35 @@ func TestPatternOfHoleCutsEachOccurrence(t *testing.T) {
 		t.Errorf("patterned hole removed %g extra (%.2f bores), want ~2 bores (one body, three holes)", extra, extra/bore)
 	}
 }
+
+// TestHoleFlushBlindDepthBreaksThrough pins the flush-bottom promotion (Oblikovati#1693): a
+// BLIND hole whose depth equals the part thickness has a zero-thickness membrane for a floor —
+// it IS a through hole. The exact blind drill rightly rejects the out-of-part bottom, and the
+// rejection used to fall to the faceted prism cut, silently costing the bore its analytic
+// cylinder wall (the tapped-hole thread had nothing to attach to). The cut must route through
+// the through-hole drill and keep the TRUE cylinder wall.
+func TestHoleFlushBlindDepthBreaksThrough(t *testing.T) {
+	block := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}}, sketch.XYPlane(), span{near: 0, far: 2}, 0, "blk")
+	top := block.Faces()[1].ReferenceKey() // z=2 cap, normal +Z
+
+	fs := NewPartFeatures(nil)
+	NewBaseFeatures(fs).AddBase(block)
+	hole := NewHoleFeatures(fs).AddDrilled(top, func() float64 { return 2 }, func() float64 { return 2 }) // depth == thickness
+	fs.Recompute()
+	if !hole.Health().OK() {
+		t.Fatalf("flush blind hole sick: %+v", hole.Health())
+	}
+	res := fs.Result()
+	if r := ops.Validate(res[0]); !r.Valid || !res[0].IsSolid() {
+		t.Fatalf("flush-drilled body not a valid solid: %+v", r)
+	}
+	cylFaces := 0
+	for _, f := range res[0].Faces() {
+		if _, ok := f.Geometry().(geom.Cylinder); ok {
+			cylFaces++
+		}
+	}
+	if cylFaces != 1 {
+		t.Errorf("flush blind hole has %d cylinder faces, want 1 (analytic bore, not a faceted prism)", cylFaces)
+	}
+}

--- a/model/feature/sketch_consumer.go
+++ b/model/feature/sketch_consumer.go
@@ -72,7 +72,9 @@ func (e *ExtrudeFeature) ConsumedSketches() []*sketch.Sketch { return nonNilSket
 func (f *EmbossFeature) ConsumedSketches() []*sketch.Sketch  { return nonNilSketches(f.def.Sketch) }
 func (c *CoilFeature) ConsumedSketches() []*sketch.Sketch    { return nonNilSketches(c.def.Sketch) }
 func (r *RibFeature) ConsumedSketches() []*sketch.Sketch     { return nonNilSketches(r.def.Sketch) }
-func (s *SweepFeature) ConsumedSketches() []*sketch.Sketch   { return nonNilSketches(s.def.Sketch) }
+func (s *SweepFeature) ConsumedSketches() []*sketch.Sketch {
+	return nonNilSketches(s.def.Sketch, s.def.PathSketch, s.def.GuideRailSketch)
+}
 
 func (r *RevolveFeature) ConsumedSketches() []*sketch.Sketch {
 	return nonNilSketches(r.def.Sketch, r.def.AxisCenterlineSketch)

--- a/model/feature/sweep_loft.go
+++ b/model/feature/sweep_loft.go
@@ -88,8 +88,16 @@ type SweepDefinition struct {
 	Taper         func() float64                // draft angle (radians) along the path
 	TwistStations []SweepTwistStation           // pathAndSectionTwists rows (override Twist)
 	GuideRail     func() *sketch.Path3D         // pathAndGuideRail steering/scaling rail
-	Scaling       types.SweepProfileScaling     // rail scaling mode (0 ⇒ xy)
-	GuideFaceKey  []byte                        // pathAndGuideSurface face (running bodies)
+	// PathSketch / GuideRailSketch name the sketches the live Path / GuideRail providers read,
+	// so the #1414 tail invalidation (and the browser's chronological nesting) can attribute a
+	// parameter that drives the rail to this feature — the providers alone are opaque closures,
+	// and without the attribution a rail-driving parameter edit re-solved the sketch but never
+	// re-swept the body (silent stale geometry, Oblikovati#1693: the resized tubing kept its
+	// old length). nil for a deserialized point-snapshot path (which nothing can re-drive).
+	PathSketch      *sketch.Sketch
+	GuideRailSketch *sketch.Sketch
+	Scaling         types.SweepProfileScaling // rail scaling mode (0 ⇒ xy)
+	GuideFaceKey    []byte                    // pathAndGuideSurface face (running bodies)
 	// SolidToolIndex sweeps the running body at this index along the path
 	// instead of a profile (the reference SolidSweepDefinition).
 	SolidToolIndex *int


### PR DESCRIPTION
## What

Three of the four #1693 failure families, each root-caused and fixed at its source; **5 of the 13 red bridge e2e tests recover** (`TestBladeJoinBooleanIsTheDefect`, `TestFanBodyStaysManifold`, `TestNopThreadedRod`, `TestNopTappedHole`, `TestNopTubingSweep`).

### 1. Pinched-vertex resolution (boolean stitch + CSG cage)

A sub-resolution contact welds down to one vertex with two disjoint face fans — the fan blade tip exactly on its rim wall (a ~14 µm lens), or a fine-pitch coil's touching turns (whole contact chains). Edge-manifoldness passes; χ drops one per pinch (−1 on the blade join, **−319** on the threaded rod). The tangent-edge machinery can't see it — `resolveEdgeUses` splits >2-use edges correctly but their endpoints stay welded, and the nudge retry is powerless against self-contact (opposing normals cancel in `awayFromContacts`). Fix: fan analysis per vertex over the **resolved** edge builds (ring-level pairs see one fan where the resolved edges carry two), duplicating a coincident vertex per extra fan — the same repair applied in the CSG cage before `cageToBody`. Deliberate: `ops.Validate` semantics unchanged — the exact Steinmetz path legitimately ships χ-admissible pinch vertices at its tangency points, and the boolean pipeline's route gates key on `Validate`.

### 2. Flush-bottom blind holes promote to through cuts

Blind depth == part thickness leaves a zero-thickness floor; the exact blind drill rightly rejects it, but the rejection silently fell to the faceted prism cut — the bore lost its analytic cylinder wall and the tapped-hole thread had nothing to attach to. `cutCylinder` now promotes such cuts to the through-hole drill (model-relative tolerance).

### 3. Sweep path/guide-rail sketch attribution

The path reaches the sweep through an opaque live provider, so the #1414 tail invalidation saw no dependent feature: the rail sketch re-solved while the swept body kept its old shape. `SweepDefinition.PathSketch`/`GuideRailSketch` + `ConsumedSketches` reporting, populated by both live constructors.

## Tests

All red-verified: point-contact union χ=4 two-shell split (+ edge-contact guard), CSG cage pinch split, flush blind hole keeps the analytic bore, sweep path parameter edit re-sweeps (1.5× volume). Full repo suite + golangci-lint green.

## Live

`mcplive -part thread` (coil-join, real thread surface), `-part counterbore`, `-part squatrim` (exact volume) PASS against the live app.

## Remaining #1693 families (tracked on the issue)

BoxTray 7-rim fillet non-manifold; StarWasher sketch-solver convergence on resize (A13 #1609 territory); stale assembly/registry e2e premises.

Part of #1693

🤖 Generated with [Claude Code](https://claude.com/claude-code)