### PR TITLE
M40 D-series: documentation debt (D1-D13)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -95,5 +95,5 @@ via `VERSION=… make build`.
   [macOS signing](#macos-signing--notarization)); otherwise the macOS release is skipped.
 - Linux/Windows **arm64 head** is deferred (no standard arm CI runner); the CLI ships
   for arm64 on all OSes.
-- `source/.goreleaser.yaml` is superseded by this pipeline (kept only for local
-  `goreleaser --snapshot`).
+- `.goreleaser.yaml` (repo root) is superseded by this pipeline (kept only for
+  local `goreleaser --snapshot`).

--- a/addin/opregistry/doc.go
+++ b/addin/opregistry/doc.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package opregistry is the self-describing registry of model-mutating operations
+// the bridge exposes that have no first-party core registry yet (features and,
+// later, sketch geometry). Each operation is an [OperationDescriptor]: a name, a
+// one-line summary, a JSON Schema for its arguments (so an LLM can fill them), and
+// an Apply func over the live session. Adding a feature kind to the MCP surface is
+// "register one descriptor" — features.list and the schema resources read this
+// registry, mirroring the future core registry (ADR-0003).
+//
+// Entry points: [New] builds an empty [Registry]; [Default] is the full built-in
+// operation set the router serves. Apply funcs run on the session goroutine (via
+// the Dispatcher), so they may touch the model directly.
+//
+// # Parameter-aware arguments (MANDATORY for every new operation)
+//
+// Every numeric argument of a feature or tool MUST be parameter-aware and survive
+// parameter edits. Do not parse an argument to a frozen float64; resolve it through
+// one of the *Closure helpers (lengthClosure, angleClosure, numberClosure, and
+// optionalAngleClosure in feature_refs.go) and pass the returned func() value to the
+// model builder. A plain literal ("10 mm") becomes a constant;
+// any expression ("h", "od/2") is backed by an auto model parameter so it joins the
+// dependency graph. set_parameter then marks features dirty and the next recompute
+// re-reads the closure at the new value (see addin/router/parameters.go and
+// compdef.PartComponentDefinition.Recompute). The model feature/tool field MUST be a
+// func() float64 (not a float64) so the value is read live on every recompute.
+//
+// The only permitted exceptions, which take a literal value, are non-dimensional
+// arguments: solver tolerances (stitch tolerance, mid-surface thin-wall threshold)
+// and free-form primitive sizes (the subdivision cage is generated once at creation
+// and then sculpted, so it has no live size). Integer-count arguments declared as
+// JSON ints (pattern occurrences) are a known gap pending a string-expression DTO.
+package opregistry

--- a/addin/opregistry/registry.go
+++ b/addin/opregistry/registry.go
@@ -1,31 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
-// Package opregistry is the self-describing registry of model-mutating operations
-// the bridge exposes that have no first-party core registry yet (features and,
-// later, sketch geometry). Each operation is an OperationDescriptor: a name, a
-// one-line summary, a JSON Schema for its arguments (so an LLM can fill them), and
-// an Apply func over the live session. Adding a feature kind to the MCP surface is
-// "register one descriptor" — features.list and the schema resources read this
-// registry, mirroring the future core registry (ADR-0003).
-//
-// # Parameter-aware arguments (MANDATORY for every new operation)
-//
-// Every numeric argument of a feature or tool MUST be parameter-aware and survive
-// parameter edits. Do not parse an argument to a frozen float64; resolve it through
-// one of the *Closure helpers (lengthClosure, angleClosure, numberClosure, and
-// optionalAngleClosure in feature_refs.go) and pass the returned func() value to the
-// model builder. A plain literal ("10 mm") becomes a constant;
-// any expression ("h", "od/2") is backed by an auto model parameter so it joins the
-// dependency graph. set_parameter then marks features dirty and the next recompute
-// re-reads the closure at the new value (see addin/router/parameters.go and
-// compdef.PartComponentDefinition.Recompute). The model feature/tool field MUST be a
-// func() float64 (not a float64) so the value is read live on every recompute.
-//
-// The only permitted exceptions, which take a literal value, are non-dimensional
-// arguments: solver tolerances (stitch tolerance, mid-surface thin-wall threshold)
-// and free-form primitive sizes (the subdivision cage is generated once at creation
-// and then sculpted, so it has no live size). Integer-count arguments declared as
-// JSON ints (pattern occurrences) are a known gap pending a string-expression DTO.
+// (The package comment was promoted to doc.go — #1669, M40 audit D12.)
+
 package opregistry
 
 import (

--- a/addin/router/doc.go
+++ b/addin/router/doc.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package router is the host-side API: it dispatches the bridge's JSON method
+// contract (commands.*, documents.*, parameters.*, model.*, features.*) to the live
+// *app.Session. It is the single place that contract is wired to the model, and is
+// pure Go (no cgo, no MCP/HTTP) so it is fully headless-testable. Handle runs on the
+// session goroutine (via the Dispatcher), so handlers may READ the model directly —
+// queries carry no invariants to drift. MUTATIONS delegate to an app.Session verb
+// (the application service the head UI also drives), so both drivers share one
+// invariant per aggregate instead of the divergence audited as B1 (#1612); the
+// archguard router-seam test enforces this, with the not-yet-migrated handlers
+// pinned in its shrink-only allowlist.
+//
+// Entry points: [New] builds the [Router]; every wire method is a [MethodHandler]
+// (one that also implements [MutatingMethod] counts as a document edit — read-only
+// is the absence of that second interface, so there is no flag to drift from the
+// handler set). Handlers are registered keyed on the api/wire method-name
+// constants, never on literal strings — the wire module is the single source of
+// truth for the surface (ADR-0018), and the router's parity guard keeps the two
+// aligned.
+//
+// This is the same contract the future M16 gRPC api/ will serve; keeping it here and
+// transport-agnostic lets the bridge retarget onto that layer with minimal churn.
+package router

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -1,18 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
-// Package router is the host-side API: it dispatches the bridge's JSON method
-// contract (commands.*, documents.*, parameters.*, model.*, features.*) to the live
-// *app.Session. It is the single place that contract is wired to the model, and is
-// pure Go (no cgo, no MCP/HTTP) so it is fully headless-testable. Handle runs on the
-// session goroutine (via the Dispatcher), so handlers may READ the model directly —
-// queries carry no invariants to drift. MUTATIONS delegate to an app.Session verb
-// (the application service the head UI also drives), so both drivers share one
-// invariant per aggregate instead of the divergence audited as B1 (#1612); the
-// archguard router-seam test enforces this, with the not-yet-migrated handlers
-// pinned in its shrink-only allowlist.
-//
-// This is the same contract the future M16 gRPC api/ will serve; keeping it here and
-// transport-agnostic lets the bridge retarget onto that layer with minimal churn.
+// (The package comment was promoted to doc.go — #1669, M40 audit D12.)
+
 package router
 
 import (

--- a/architecture/assembly/00-instancing-and-proxies.md
+++ b/architecture/assembly/00-instancing-and-proxies.md
@@ -32,7 +32,8 @@ override) lives on the **occurrence**. Placing the same part twice creates two
 `Occurrence`s sharing one `Content` — never a copy.
 
 - **`def` is shared content**, reached through the document reference graph (core/05).
-  A part open in its own window and placed in an assembly is *one* `PartContent`.
+  A part open in its own window and placed in an assembly is *one*
+  `PartComponentDefinition`.
 - **Nesting → occurrence path.** A specific instance deep in subassemblies is
   identified not by a pointer but by its **`OccurrencePath`** (the chain of
   occurrences from the top assembly down) — two instances of the same screw differ

--- a/architecture/assembly/README.md
+++ b/architecture/assembly/README.md
@@ -40,7 +40,7 @@ of a part are N transforms over one cached mesh (core/08) — GPU instancing for
 ## The assembly object model in one diagram
 
 ```
-   AssemblyContent
+   AssemblyComponentDefinition
      ├── occurrences []*Occurrence ───┐
      │      Occurrence {              │  (flyweight — parametric-cad §5)
      │        Definition  ───────────────▶ shared ComponentDefinition (a part/subassembly doc)

--- a/architecture/core/05-documents-persistence-identity.md
+++ b/architecture/core/05-documents-persistence-identity.md
@@ -1,8 +1,9 @@
 # Core 05 — Documents, persistence & reference keys
 
 *Modernizes M03 (documents, structured storage, references, reference keys,
-attributes). Two big modernizations: a portable package format replacing OLE
-structured storage, and reference keys as serializable Go values.*
+attributes). Two big modernizations: a git-friendly single-file document format
+replacing OLE structured storage (ADR-0020), and reference keys as serializable
+Go values with tiered recovery (`model/identity`).*
 
 ## Documents & the document/content split
 
@@ -17,7 +18,7 @@ type Document struct {
     typeID    TypeID         // part | assembly | drawing | presentation (stable)
     name      string
     dirty     bool
-    content   compdef.Content// PartContent | AssemblyContent (the modeling data)
+    content   Content        // PartComponentDefinition | AssemblyComponentDefinition (the modeling data)
     refs      *RefGraph      // documents this references / is referenced by
     props     attr.PropertySet
 }
@@ -27,69 +28,99 @@ type Workspace struct {     // replaces COM `Documents` collection + Application
 }
 ```
 
-`Workspace` lives on the runtime mediator (core/00) — no global `Application`.
+The live containers are `compdef.PartComponentDefinition` and
+`compdef.AssemblyComponentDefinition` (`model/compdef`); `doc.Content` is the
+seam that lets `model/doc` hold either without importing the heavy model
+packages. `Workspace` lives on the runtime mediator (core/00) — no global
+`Application`.
 
 ## Persistence — drop OLE structured storage
 
 COM used OLE compound files (`.ipt`). That is a Windows-era, single-writer binary
-storage format. We replace it with a **portable package container** that is
-cross-platform and tool-friendly:
+storage format. We replace it with a **single readable YAML file**
+([ADR-0020](../decisions/ADR-0020-yaml-git-friendly-document-format.md)) that is
+cross-platform, tool-friendly, and diffs line-by-line in git:
 
-```
-part.obk                       # a ZIP package (like .3mf/.docx/.usdz)
- ├── manifest.json             # version, TypeID of root, unit prefs, thumbnail ref
- ├── model/                    # the feature program, parameters, sketches (binary streams)
- │    ├── parameters.bin
- │    ├── features.bin
- │    └── sketches.bin
- ├── identity/keys.bin         # reference-key contexts (see below)
- ├── attributes.bin            # attribute sets / iProperties
- ├── thumbnail.png
- └── cache/                    # OPTIONAL derived data (tessellation), regenerable, may be omitted
+```yaml
+# part.obk — one YAML document (persistence/yamlcodec)
+schemaVersion: 2            # migration gate (persistence.CurrentSchemaVersion)
+documentType: 1             # stable TypeID of the root document kind
+displayName: part
+identity: { ... }           # file identity block (doc GUID, versions)
+references: [ ... ]         # as-saved file-to-file reference records
+model:                      # THE RECIPE — native nested YAML, not a quoted blob
+  parameters: [ ... ]
+  sketches: [ ... ]
+  features: [ ... ]
+resources: { ... }          # embedded imported files, base64, keyed by UUID (ADR-0031)
+data: { ... }               # add-in/attribute scratch sections, base64
 ```
 
 Design choices:
-- **Streams are columnar binary** via registered `Codec[T]`s keyed by stable
-  `TypeID` (core/02). We serialize the **recipe** (parameters + feature definitions
-  + sketches), not the evaluated B-rep — the geometry is a cache that recompute
-  rebuilds (parametric-cad §0: the definition is the truth, geometry is a cache).
-- **Atomic save**: write a temp package, fsync, rename — no half-written files
-  (replaces COM compaction-on-save with a simpler invariant).
-- **The package is inspectable** (it's a zip) — huge for debugging, diffing,
-  and CI, versus an opaque OLE blob.
-- **Migration**: `manifest.json` carries a schema version; an on-load migration
-  pipeline upgrades older packages (replaces COM `OnMigrateDocument`).
+- **We serialize the recipe** (parameters + feature definitions + sketches), not
+  the evaluated B-rep — the geometry is a cache that recompute rebuilds
+  (parametric-cad §0: the definition is the truth, geometry is a cache).
+- **Atomic save**: write a sibling temp file, fsync, rename (`persistence/io.go`)
+  — no half-written files (replaces COM compaction-on-save with a simpler
+  invariant).
+- **The file is inspectable** (it's YAML) — huge for debugging, diffing, and CI,
+  versus an opaque OLE blob. Only `persistence/yamlcodec` touches the YAML
+  library (dependency rule).
+- **Migration**: the top-level `schemaVersion` gates an on-load migration
+  pipeline (`persistence/migration.go`) that upgrades older files step by step
+  (replaces COM `OnMigrateDocument`).
 
 ## Reference keys — the hard problem, as Go values
 
 This is the single most load-bearing mechanism (parametric-cad §7). A reference
 key must re-resolve to "the same" face/edge after recompute destroys and recreates
 the B-rep, and after save/reload. In Go it is a **serializable value**, not a
-pointer:
+pointer — `identity.RefKey` (`model/identity/refkey.go`):
 
 ```go
 package identity
-type RefKey struct {        // opaque to callers; serializable; persisted in identity/keys.bin
-    ctx     ContextID
-    payload []byte          // encodes the GENERATIVE LINEAGE (topo.Lineage, core/03)
+type RefKey struct {        // opaque to callers; a value type — storable in any recipe
+    ctx     ContextID       // topology context the key was minted in
+    kind    EntityKind      // face | edge | vertex | ...
+    payload []byte          // the entity's LineageKey at mint time (topo.Lineage, core/03)
+    parent  ancestryHint    // session-only: parent lineage, for ancestral recovery
+    anchor  anchorHint      // session-only: representative point, for geometric tie-break
 }
-type KeyManager struct{ ... }
-func (m *KeyManager) Key(e topo.Entity) RefKey                     // mint from lineage
-func (m *KeyManager) Resolve(k RefKey) (topo.Entity, bool)         // rebind; bool=false ⇒ LOST
-func (m *KeyManager) NewContext() ContextID                        // versioned snapshot
-func (m *KeyManager) Save(w io.Writer) ; Load(r io.Reader)         // persist contexts
+func (k RefKey) Encode() []byte                    // persistable bytes (round-trip stable)
+func DecodeKey(data []byte) (RefKey, error)
+func RecoverLost(kind EntityKind, parentKey []byte,
+    anchor *math.Point3, ents []Entity) (Entity, MatchType) // the fallback tiers
 ```
 
 The design is driven entirely by the kernel owning topology (ADR-0002): because
 every `topo.Face` carries its `Lineage` ("end cap of feature F"), the key encodes
-that derivation path, and after a rebuild the manager re-finds the entity whose
-lineage matches — **topological naming, not addresses.**
+that derivation path, and after a rebuild the binder re-finds the entity whose
+lineage matches — **topological naming, not addresses.** Keys live *inside* the
+recipe (feature and sketch definitions store the encoded bytes); there is no
+separate key store or stream on disk.
 
-**Binding may fail, and that is normal** (parametric-cad §7): `Resolve` returns
-`false` when the referenced topology genuinely no longer exists. The contract: a
-consumer with a lost key sets its **feature health to sick** and surfaces for
-re-selection — never crashes. This is wired the same everywhere (features,
-dimensions, mates) via core/06's health propagation.
+**Binding degrades through tiers, and losing is normal.** Resolution tries
+**exact → ancestral → geometric** and reports which tier matched via
+`identity.MatchType`:
+
+1. **Exact** — a single entity with the key's kind and lineage exists
+   (`MatchExact`).
+2. **Ancestral** — the exact entity is gone, but exactly one surviving sibling
+   shares the key's parent lineage (`MatchAncestral`, auto-healed, flagged).
+3. **Geometric** — several siblings survive; the one nearest the key's mint-time
+   anchor point wins (`MatchGeometric`, auto-healed, flagged).
+4. **None** — nothing matches (`MatchNone`): the reference is **lost**, a
+   legitimate, non-fatal outcome.
+
+`MatchType.IsFallback()` is the binder's signal to resolve the reference to
+**Warning** health (auto-healed, review advised) instead of fully healthy; a lost
+key sets **feature health to sick** and surfaces for re-selection — never
+crashes. This is wired the same everywhere (features, dimensions, mates) via
+core/06's health propagation. The fallback hints are an in-memory session
+optimisation: they are not serialized, so a key reloaded from disk degrades to
+exact-only binding until re-minted (M31-F06; see `model/identity/binding.go` and
+`recover.go`; ADR-0043 generalizes the lineage/provenance naming the tiers match
+against).
 
 > **Build this early.** The reference-key design is decided *before* the feature
 > engine depends on selecting topology (iteration 2), not after — retrofitting it
@@ -106,6 +137,7 @@ registry, no OLE monikers. Broken references are flagged, never fatal.
 
 Unchanged in concept (parametric-cad §11): typed attribute sets attachable to any
 entity (keyed by `RefKey` so they survive recompute) and document property sets
-(iProperties). In Go: `attr.Set` with typed values, serialized to `attributes.bin`.
-The `NameValueMap`-as-everything COM habit is replaced by **typed option structs**
-in-proc; the only string→value maps left are at the gRPC seam (ADR-0003/0006).
+(iProperties). In Go: `attr.Set` with typed values, serialized into the
+document's attribute block. The `NameValueMap`-as-everything COM habit is
+replaced by **typed option structs** in-proc; the only string→value maps left are
+at the wire seam (ADR-0003/0006).

--- a/architecture/core/07-extensibility.md
+++ b/architecture/core/07-extensibility.md
@@ -78,7 +78,7 @@ Add-ins manage the ribbon through the same contract (no special path):
   defaulted.
 
 `RibbonKey` and `Environment` are defined once in `api/types` (Apache-2.0) and aliased
-in `/source`, like every other public enum (ADR-0018).
+in the GPL application module, like every other public enum (ADR-0018).
 
 ## Out-of-process add-ins (third-party) — gRPC
 
@@ -87,8 +87,8 @@ in `/source`, like every other public enum (ADR-0018).
 > **in-process** as a C-shared library (`.so`/`.dll`) loaded over a small **C ABI**,
 > exposing the API to LLM clients over **MCP**. The boundary carries an in-process
 > **JSON method contract** (`commands.*`, `documents.*`, `parameters.*`, `model.*`,
-> `sketch.*`, `features.*`) implemented by `source/addin/router`; the cgo loader +
-> host-call shim live in `source/head/internal/addinhost`. That contract is
+> `sketch.*`, `features.*`) implemented by `addin/router`; the cgo loader +
+> host-call shim live in `head/internal/addinhost`. That contract is
 > transport-agnostic, so the gRPC services below remain the planned *future*
 > transport behind the same surface (deferred, not abandoned). The rest of this
 > section describes that target gRPC design.
@@ -96,7 +96,7 @@ in `/source`, like every other public enum (ADR-0018).
 > Since [ADR-0018](../decisions/ADR-0018-apache-api-contract-module.md) the contract
 > is typed and Apache-2.0: the method names + DTOs live in `api/wire` and add-ins
 > call through `api/client` (a `Transport` the C-ABI `ObkHostCall` backs), so a
-> closed-source add-in links only `/api`, never the GPL `/source`.
+> closed-source add-in links only the API module, never the GPL application.
 
 Third-party add-ins are **separate processes** speaking the `api/` gRPC contract
 (ADR-0003) — the modern successor to the COM type library and the

--- a/architecture/decisions/ADR-0006-no-com-object-model.md
+++ b/architecture/decisions/ADR-0006-no-com-object-model.md
@@ -11,6 +11,12 @@
 > and `/source` implements them. The stable-`TypeID`-for-persistence decision here is
 > unchanged.
 
+> **Editor's note (2026-07, #1661 / M40 audit D4).** Paths in this ADR predate the
+> repo-root migration: the GPL application module written here as `/source` now
+> lives directly at the repository root (`kernel/`, `model/`, `app/`, `head/`, …),
+> and the Apache-2.0 `/api` module is the sibling `Oblikovati.API` repository.
+> The record below is preserved as written.
+
 ## Decision
 
 Replace the COM object-model conventions with idiomatic Go, while **preserving the

--- a/architecture/decisions/ADR-0006-no-com-object-model.md
+++ b/architecture/decisions/ADR-0006-no-com-object-model.md
@@ -11,6 +11,8 @@
 > and `/source` implements them. The stable-`TypeID`-for-persistence decision here is
 > unchanged.
 
+<!-- -->
+
 > **Editor's note (2026-07, #1661 / M40 audit D4).** Paths in this ADR predate the
 > repo-root migration: the GPL application module written here as `/source` now
 > lives directly at the repository root (`kernel/`, `model/`, `app/`, `head/`, …),

--- a/architecture/decisions/ADR-0015-build-ci-and-test-tooling.md
+++ b/architecture/decisions/ADR-0015-build-ci-and-test-tooling.md
@@ -11,6 +11,12 @@
 > and [`RELEASING.md`](../../RELEASING.md)). The `make`/lint/test/CI parts of this
 > ADR are unchanged.
 
+> **Editor's note (2026-07, #1661 / M40 audit D4).** Paths in this ADR predate the
+> repo-root migration: the GPL application module written here as `/source` (CI
+> working-directory `source`) now lives directly at the repository root
+> (`kernel/`, `model/`, `app/`, `head/`, …). The record below is preserved as
+> written.
+
 **Context:** greenfield Go implementation begins; we need
 a delivery and test-automation foundation before feature code, so every later PBI
 lands behind the same gates. Builds on [ADR-0001](ADR-0001-go-language.md) (Go),

--- a/architecture/decisions/ADR-0015-build-ci-and-test-tooling.md
+++ b/architecture/decisions/ADR-0015-build-ci-and-test-tooling.md
@@ -11,6 +11,8 @@
 > and [`RELEASING.md`](../../RELEASING.md)). The `make`/lint/test/CI parts of this
 > ADR are unchanged.
 
+<!-- -->
+
 > **Editor's note (2026-07, #1661 / M40 audit D4).** Paths in this ADR predate the
 > repo-root migration: the GPL application module written here as `/source` (CI
 > working-directory `source`) now lives directly at the repository root

--- a/architecture/decisions/ADR-0016-shared-library-addins-mcp-bridge.md
+++ b/architecture/decisions/ADR-0016-shared-library-addins-mcp-bridge.md
@@ -11,6 +11,8 @@ first add-in).
 > supplies — but the bridge and the host no longer re-declare DTOs; they share
 > `/api`. A closed-source add-in links only `/api`, never the GPL `/source`.
 
+<!-- -->
+
 > **Editor's note (2026-07, #1661 / M40 audit D4).** Paths in this ADR predate the
 > repo-root migration: the GPL application module written here as `/source` now
 > lives directly at the repository root (`kernel/`, `model/`, `app/`, `head/`, …),

--- a/architecture/decisions/ADR-0016-shared-library-addins-mcp-bridge.md
+++ b/architecture/decisions/ADR-0016-shared-library-addins-mcp-bridge.md
@@ -11,6 +11,12 @@ first add-in).
 > supplies — but the bridge and the host no longer re-declare DTOs; they share
 > `/api`. A closed-source add-in links only `/api`, never the GPL `/source`.
 
+> **Editor's note (2026-07, #1661 / M40 audit D4).** Paths in this ADR predate the
+> repo-root migration: the GPL application module written here as `/source` now
+> lives directly at the repository root (`kernel/`, `model/`, `app/`, `head/`, …),
+> and the Apache-2.0 `/api` module is the sibling `Oblikovati.API` repository.
+> The record below is preserved as written.
+
 ## Context
 
 ADR-0003 chose **out-of-process gRPC** for third-party add-ins and explicitly

--- a/architecture/decisions/ADR-0018-apache-api-contract-module.md
+++ b/architecture/decisions/ADR-0018-apache-api-contract-module.md
@@ -1,16 +1,25 @@
-# ADR-0018 — Apache-2.0 `/api` contract module extracted from the GPL `/source`
+# ADR-0018 — Apache-2.0 API contract module extracted from the GPL application
 
 **Status:** accepted (user decision, 2026-06) · **Amends:**
 [ADR-0006](ADR-0006-no-com-object-model.md) (the public surface is now defined once
-in `/api`, not "twice"), [ADR-0003](ADR-0003-extensibility-hybrid-rpc.md) /
+in the API module, not "twice"), [ADR-0003](ADR-0003-extensibility-hybrid-rpc.md) /
 [ADR-0016](ADR-0016-shared-library-addins-mcp-bridge.md) (the JSON method contract is
 now the typed, Apache-licensed `api/wire` + `api/client`).
 
+> **Editor's note (2026-07, #1661 / M40 audit D4).** Because CLAUDE.md cites this
+> ADR as *current* guidance for the public-API/implementation split, its path
+> references were updated in place after the repo-root migration: the GPL
+> application (written `/source` at decision time) lives directly at the
+> repository root, and the Apache-2.0 `oblikovati.org/api` module lives in the
+> sibling `Oblikovati.API` repository (still written `api/…` package paths
+> below). The decision itself is unchanged.
+
 ## Context
 
-The application (kernel + UI head + CLI) ships under **GPL-2.0** (`/source`). Third
+The application (kernel + UI head + CLI) ships under **GPL-2.0** at the repo
+root. Third
 parties — possibly closed-source vendors — must be able to build add-ins. The public
-automation API was **baked into** `/source`: the de-facto contract was the router's
+automation API was **baked into** the application module: the de-facto contract was the router's
 JSON method strings plus request/response DTOs declared *inline* in the GPL router
 package, and the MCP bridge re-declared the same DTOs. There was no Apache-licensed
 artifact a closed add-in could compile against, and "the surface is defined twice"
@@ -19,16 +28,16 @@ artifact a closed add-in could compile against, and "the surface is defined twic
 ## Decision
 
 Extract the public API into its own **Apache-2.0 Go module**,
-`oblikovati.org/api` (`/api`), as the single source of truth that both
-`/source` and add-ins depend on. The dependency only ever flows **toward** `/api`;
-`/api` never imports `/source` (CI-enforced).
+`oblikovati.org/api` (the sibling `Oblikovati.API` repo), as the single source of
+truth that both the application and add-ins depend on. The dependency only ever
+flows **toward** the API module; it never imports the application (CI-enforced).
 
 The module is layered:
 
 | Package | Holds | Who satisfies / consumes it |
 |---|---|---|
-| `api/types` | enums, stable ids, value/option structs — pure data | enum *definitions* (DocumentType, ParameterKind); `/source` aliases them |
-| `api/contract` | in-process Go **interfaces** (Document, Parameter, …) | `/source` types satisfy them via compile-time assertions |
+| `api/types` | enums, stable ids, value/option structs — pure data | enum *definitions* (DocumentType, ParameterKind); the application aliases them |
+| `api/contract` | in-process Go **interfaces** (Document, Parameter, …) | application types satisfy them via compile-time assertions |
 | `api/wire` | method-name constants + JSON request/response DTOs | the host router marshals into them; the wire boundary uses them |
 | `api/client` | a `Transport` interface + a typed client over it | out-of-runtime add-ins call the host through it |
 
@@ -39,19 +48,19 @@ value cannot cross the C-ABI boundary. So the contract serves two audiences with
 mechanisms, deliberately:
 
 - **In-process / first-party** code uses `api/contract` interfaces and `api/types`
-  directly (one runtime). The compile-time assertions in `/source`
+  directly (one runtime). The compile-time assertions in the application
   (`var _ contract.Document = (*doc.Document)(nil)`) keep the published interface and
   the implementation from drifting.
 - **Out-of-runtime / third-party** add-ins use `api/wire` + `api/client` over a
   transport (today the C-ABI `ObkHostCall`; tomorrow gRPC or a socket). They link
-  **only** the Apache `/api` module, never the GPL `/source`, so a closed-source
+  **only** the Apache API module, never the GPL application, so a closed-source
   add-in stays decoupled from GPL both legally (separate module) and at the ABI (the
   only thing crossing the boundary is JSON, per ADR-0016).
 
-`api/types` is how `/api` becomes the source of truth for enums without churning the
-implementation: the enum is defined once in `api/types`, and `/source` keeps its
-historical spelling via a transparent **type alias** (`type DocumentType =
-types.DocumentType`) — existing call sites are unaffected.
+`api/types` is how the API module becomes the source of truth for enums without
+churning the implementation: the enum is defined once in `api/types`, and the
+application keeps its historical spelling via a transparent **type alias**
+(`type DocumentType = types.DocumentType`) — existing call sites are unaffected.
 
 ## Scope (this pass) and what is deferred
 
@@ -71,23 +80,25 @@ Deferred (grow milestone-by-milestone, not a rewrite of the 2200+ C# interfaces)
 
 ## Consequences
 
-- **Licensing is now explicit and enforced.** `api/LICENSE` = Apache-2.0,
-  `source/LICENSE` = GPL-2.0, SPDX headers on every `.go` file
-  (`scripts/add-spdx-headers.py`), and CI fails if `/api` ever imports `/source`.
+- **Licensing is now explicit and enforced.** The API module's `LICENSE` =
+  Apache-2.0, this repo's `LICENSE` = GPL-2.0, SPDX headers on every `.go` file
+  (`scripts/add-spdx-headers.py`), and CI fails if the API module ever imports
+  the application.
 - **No more duplicated DTOs.** The router and the MCP bridge share `api/wire`; the
   bridge's host-call abstraction is `api/client.Transport`.
-- The multi-module repo grows one module (`/api`), wired via `replace` directives
-  like `/source/head` already is.
-- `gofmt`, `go vet`, `go test`, and a dependency-boundary check run against `/api`
-  in CI alongside `/source`.
+- The API becomes its own module (`oblikovati.org/api`), resolved for local dev
+  via the `go.work` workspace over sibling checkouts (like `head/` already is;
+  CI checks out the sibling and injects the same mapping).
+- `gofmt`, `go vet`, `go test`, and a dependency-boundary check run against the
+  API module in CI alongside the application.
 
 ## Shape / layering
 
 ```
-api/  (Apache-2.0, oblikovati.org/api)
+../Oblikovati.API/  (Apache-2.0, oblikovati.org/api — sibling repo)
   types/  contract/  wire/  client/
-source/  (GPL-2.0)  requires + implements api; serves api/wire via addin/router
-add-in/  (vendor-licensed)  imports only api/{types,wire,client}
+this repo root  (GPL-2.0)  requires + implements api; serves api/wire via addin/router
+add-in repos  (vendor-licensed)  import only api/{types,wire,client}
 ```
 
 ## Addendum (2026-06): transient geometry — in-process values, wire DTO encoding
@@ -110,7 +121,7 @@ C ABI would be the wrong transport. The split:
 - **Curves/surfaces are contracts, not values.** Construction validates and
   evaluation runs against the kernel, so `api/contract` defines the interfaces
   (umbrella `Curve`/`Curve2d`/`Surface`, per-kind interfaces, the single
-  `TransientGeometry` factory) and `/source/kernel/geomapi` implements them as
+  `TransientGeometry` factory) and `kernel/geomapi` implements them as
   thin adapters over `kernel/geom` — the kernel itself stays free of API
   conversions. Kind discriminators are frozen to the reference enum values.
 - The kernel keeps its own `math` package (`Scalar`-based) as the private

--- a/architecture/decisions/ADR-0023-viewport-display-modes.md
+++ b/architecture/decisions/ADR-0023-viewport-display-modes.md
@@ -7,6 +7,12 @@
 [ADR-0022](ADR-0022-materials-appearances.md) (PBR appearance data). Drives milestone
 **M23**.
 
+> **Editor's note (2026-07, #1661 / M40 audit D4).** Paths in this ADR predate the
+> repo-root migration: the GPL application module written here as `/source` now
+> lives directly at the repository root (`kernel/`, `model/`, `app/`, `head/`, …),
+> and the Apache-2.0 `/api` module is the sibling `Oblikovati.API` repository.
+> The record below is preserved as written.
+
 ## Context
 
 The viewport renders only **three** of Autodesk Inventor's display modes — `Shaded`,

--- a/architecture/decisions/ADR-0027-curved-face-boolean.md
+++ b/architecture/decisions/ADR-0027-curved-face-boolean.md
@@ -1,6 +1,9 @@
 # ADR-0027 — Curved-face B-rep boolean (K1b)
 
-**Status:** accepted, in progress (slice 1 landed 2026-06-04)
+**Status:** accepted, implemented (slice 1 landed 2026-06-04; the curved-boolean
+EPIC closed 2026-07-01 with
+[ADR-0045](ADR-0045-curved-boolean-kind-taxonomy.md), the closing kind
+taxonomy — see it for the as-shipped coverage)
 **Context:** REPORT.md §6 (G-09), DEFERRALS.md, PARTDOC-PLAN.md Phase 4.
 
 ## Problem

--- a/architecture/decisions/ADR-0028-embedded-lua-scripting.md
+++ b/architecture/decisions/ADR-0028-embedded-lua-scripting.md
@@ -13,6 +13,12 @@ scripting drives the public API; named "Lua via a pure-Go VM" as a candidate),
 [ADR-0018](ADR-0018-apache-api-contract-module.md) (`api/wire` is the automation
 surface), [ADR-0008](ADR-0008-cgo-boundary.md) (cgo confined to the platform edge).
 
+> **Editor's note (2026-07, #1661 / M40 audit D4).** Paths in this ADR predate the
+> repo-root migration: the GPL application module written here as `/source` now
+> lives directly at the repository root (`kernel/`, `model/`, `app/`, `head/`, …),
+> and the Apache-2.0 `/api` module is the sibling `Oblikovati.API` repository.
+> The record below is preserved as written.
+
 ## Problem
 
 Users need to automate the model with scripts: drive parameters, build sketches and

--- a/architecture/history/implementation-log.md
+++ b/architecture/history/implementation-log.md
@@ -1,8 +1,14 @@
 # Implementation log (historical)
 
-> Migrated verbatim (trademark-scrubbed) from `implementation-plan/PROGRESS.md` when
-> roadmap tracking moved to GitHub milestones/issues. Frozen as a historical record —
-> current status lives on the issue tracker.
+> **⚠ Historical snapshot — do not treat anything below as current.** Migrated
+> verbatim (trademark-scrubbed) from `implementation-plan/PROGRESS.md` when
+> roadmap tracking moved to GitHub milestones/issues, and frozen at that
+> migration. Paths predate the repo-root migration (`/source/...` maps to the
+> repository root today), milestone framing and statuses are as-of-migration
+> only, and none of the "next priority" notes are live. Current work is tracked
+> on the [GitHub issue tracker](https://github.com/Oblikovati/Oblikovati/issues)
+> (milestones + issues) — the body below is preserved unedited as a record
+> (#1668, M40 audit D11).
 
 Live tracker for building Oblikovati against [the roadmap](https://github.com/Oblikovati/Oblikovati/milestones). Updated as
 each PBI lands. Status legend: ⬜ not started · 🟦 in progress · ✅ done (green in CI).

--- a/architecture/implementation-conventions.md
+++ b/architecture/implementation-conventions.md
@@ -66,9 +66,10 @@ expression string — resolve via the parameter/expression engine.
 ## Persistent identity (M03)
 
 Topology references (a picked Face/Edge) must survive recompute, which destroys
-and recreates the B-rep. Use **reference keys** (`ReferenceKeyManager`), never
-pointer identity. Binding may fail ("reference lost") → the consumer goes
-`HealthStatusEnum` sick; this is normal, not exceptional.
+and recreates the B-rep. Use **reference keys** (`identity.RefKey`,
+`model/identity/refkey.go`, with tiered exact → ancestral → geometric
+bind/recover), never pointer identity. Binding may fail ("reference lost") → the
+consumer goes `HealthStatusEnum` sick; this is normal, not exceptional.
 
 ## Transactions & events (M04)
 

--- a/architecture/lua-scripting-plan.md
+++ b/architecture/lua-scripting-plan.md
@@ -5,8 +5,8 @@ typed convenience tables); Phase 3 in progress — MCP `scripts.run` shipped
 (Oblikovati.API #27 + Oblikovati #85 + AddIns #20), events + persistence outstanding.
 All merged to `develop` 2026-06-07. See [§11 Phased rollout](#11-phased-rollout) for the
 per-phase status.
-**Scope:** Integral, first-party Lua scripting in the GPL-v2 application (`/source`,
-i.e. this `oblikovati` module). **Not** an add-in.
+**Scope:** Integral, first-party Lua scripting in the GPL-v2 application (this
+`oblikovati` module, at the repo root). **Not** an add-in.
 **Companion ADR:** [ADR-0028 — Embedded Lua scripting runtime](decisions/ADR-0028-embedded-lua-scripting.md)
 **Builds on:** ADR-0013 (embedded scripting drives the public API), ADR-0016
 (in-process dispatch / session goroutine), ADR-0018 (Apache-2.0 `api/wire` is the
@@ -57,7 +57,7 @@ sandbox/quota guarantees would have to be re-proven for the cgo path.
 
 ---
 
-## 3. Package layout (in `/source`, GPL-v2)
+## 3. Package layout (at the repo root, GPL-v2)
 
 A new top-level package tree `script/` (sibling to `addin/`, `app/`, `command/`):
 
@@ -312,12 +312,13 @@ names), `api/client` (`Caller`, and the typed groups for Phase-2 sugar).
 
 - **Phase 1 & 2: none.** Lua rides the existing `api/wire` surface via the generic
   bridge. No new method-name constants, DTOs, or `api/contract` interfaces. All new
-  code is GPL-v2 in `/source` under `script/`.
+  code is GPL-v2 in this module under `script/`.
 - **Phase 3 (only if MCP `script.run` is wanted):** add `MethodScriptRun` + DTOs in
   `api/wire` and a `client.Scripts()` group in `api/client` (Apache-2.0) *first*, then
-  the router handler in `/source`. This is the standard two-part flow.
+  the router handler in this module (`addin/router`). This is the standard
+  two-part flow.
 
-Every new exported `.go` file in `/source` carries `SPDX-License-Identifier:
+Every new exported `.go` file in this module carries `SPDX-License-Identifier:
 GPL-2.0-only` (run `scripts/add-spdx-headers.py`).
 
 ---

--- a/architecture/mapping/com-to-go-cheatsheet.md
+++ b/architecture/mapping/com-to-go-cheatsheet.md
@@ -28,7 +28,7 @@ mirroring) idioms to the modernized Go architecture. Use it when porting any of 
 | `SurfaceBody`/`Face`/`Edge` (COM topo) | `topo.Body`/`Face`/`Edge` with `Lineage` | core/03 |
 | `FaceEvaluator.GetNormal(...)` | `srf.NormalAt(u,v)` method | core/03 |
 | `ref byte[] ReferenceKey` | `identity.RefKey` (serializable value) | [core/05](../core/05-documents-persistence-identity.md) |
-| `ReferenceKeyManager.BindKeyToObject` | `KeyManager.Resolve(k) (Entity, ok)` — `ok=false` ⇒ lost | core/05, parametric-cad §7 |
+| `ReferenceKeyManager.BindKeyToObject` | `identity.RefKey` tiered bind/recover: exact lineage match, else `identity.RecoverLost` (ancestral → geometric); `MatchNone` ⇒ lost (`model/identity/refkey.go`) | core/05, parametric-cad §7 |
 
 ## Parameters
 

--- a/architecture/modeling/01-feature-engine.md
+++ b/architecture/modeling/01-feature-engine.md
@@ -8,16 +8,19 @@ Implements ADR-0010. The heart of the modeler — "model = evaluated program"
 
 ```go
 package compdef
-type PartContent struct {
+type PartComponentDefinition struct {
     features  []feature.Feature   // THE ordered program (history)
     eop       int                 // end-of-part / rollback marker (index)
     params    *param.Graph        // the variable layer (core/04)
     sketches  Collection[*sketch.Sketch]
     bodies    []*topo.Body        // CACHE: result of the last evaluation
-    keys      *identity.KeyManager// reference-key contexts (core/05)
     version   uint64              // ModelGeometryVersion (bumps every edit)
 }
 ```
+
+(Reference identity needs no field here: keys are `identity.RefKey` values stored
+inside the feature/sketch definitions, rebound against each entity's `Lineage`
+after recompute — core/05.)
 
 `bodies` is a *cache* of evaluating `features[:eop]`, never the source of truth
 (parametric-cad §0). The truth is the feature list + parameters + sketches — that is

--- a/architecture/modeling/05-sheet-metal.md
+++ b/architecture/modeling/05-sheet-metal.md
@@ -7,14 +7,17 @@ feature engine (modeling/01), no new core machinery.*
 
 ## Sheet metal is a part content flavor, not a new document type
 
-A sheet-metal part is a `PartContent` (modeling/01) with a **rule set** attached and
-a **sheet-metal feature registry** active (the "environment" — a registered
-`Workspace`, core/07). It is not a separate document kind; it is the same content
-with extra invariants (constant thickness) and an extra feature family.
+A sheet-metal part is a `PartComponentDefinition` (modeling/01) with a **rule
+set** attached and a **sheet-metal feature registry** active (the "environment" —
+a registered `Workspace`, core/07). It is not a separate document kind; it is the
+same content with extra invariants (constant thickness) and an extra feature
+family. (As built, the rule lives as a nilable `sheetmetal.Rule` field on
+`PartComponentDefinition` itself — `model/compdef/part.go` — rather than the
+wrapper type sketched below.)
 
 ```go
 type SheetMetalContent struct {
-    *compdef.PartContent              // it IS a part (features, params, bodies…)
+    *compdef.PartComponentDefinition  // it IS a part (features, params, bodies…)
     rule    SheetMetalRule            // active style: thickness, bend radius, relief, gap
     unfold  UnfoldMethod              // K-factor | bend table | custom equation
     flat    *FlatPattern             // derived; nil until generated

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -2,19 +2,8 @@
 
 // SPDX-License-Identifier: GPL-2.0-only
 
-// Package ui composes the Inventor-style chrome — menu bar, ribbon, model browser,
-// and the viewport panel — from the live application Session each frame. There is no
-// retained widget tree: every frame reads app.BuildRibbon / app.BuildBrowser and the
-// current tool/selection, and Dear ImGui draws that (ADR-0004/0009). All layout lives
-// here in Go; the native package only exposes ImGui verbs.
-//
-// The chrome is split by region across sibling files in this package:
-//   - chrome.go         — DrawChrome orchestration, keyboard, shared part accessors
-//   - chrome_menubar.go — the top menu bar and New Part
-//   - chrome_ribbon.go  — the ribbon (tabs, panels, command buttons)
-//   - chrome_doctabs.go — the document tab strip and active-document follow
-//   - chrome_viewport.go— the Vulkan viewport panel, picking and overlays
-//   - chrome_statusbar.go — the status bar
+// (The package comment was promoted to doc.go — #1669, M40 audit D12.)
+
 package ui
 
 import (

--- a/head/ui/doc.go
+++ b/head/ui/doc.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package ui composes the Inventor-style chrome — menu bar, ribbon, model browser,
+// and the viewport panel — from the live application Session each frame. There is no
+// retained widget tree: every frame reads app.BuildRibbon / app.BuildBrowser and the
+// current tool/selection, and Dear ImGui draws that (ADR-0004/0009). All layout lives
+// here in Go; the native package only exposes ImGui verbs.
+//
+// The entry point is DrawChrome: called between Window.BeginFrame and
+// Window.EndFrame, it renders one frame of chrome and returns the id of the
+// command the user activated (or ""); the caller executes it, so drawing stays
+// free of side effects on the model.
+//
+// The chrome is split by region across sibling files in this package:
+//   - chrome.go         — DrawChrome orchestration, keyboard, shared part accessors
+//   - chrome_menubar.go — the top menu bar and New Part
+//   - chrome_ribbon.go  — the ribbon (tabs, panels, command buttons)
+//   - chrome_doctabs.go — the document tab strip and active-document follow
+//   - chrome_viewport.go— the Vulkan viewport panel, picking and overlays
+//   - chrome_statusbar.go — the status bar
+package ui

--- a/kernel/brep/arrange2d.go
+++ b/kernel/brep/arrange2d.go
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
-// Package brep implements the planar-faced B-rep boolean (M20·F01, the Option-A kernel):
-// imprint face–face intersections, split faces along them via a 2D planar arrangement,
-// classify the sub-faces against the other solid, and stitch the kept faces into a clean,
-// low-face-count, chainable B-rep. This file is the keystone 2D arrangement: it subdivides
-// a set of undirected segments into the bounded faces they enclose (with holes), which the
+// This file is the keystone 2D arrangement of the planar boolean (the package
+// comment lives in doc.go — #1669, M40 audit D12): it subdivides a set of
+// undirected segments into the bounded faces they enclose (with holes), which the
 // 3D boolean uses to split each planar face by its imprint segments.
+
 package brep
 
 import (

--- a/kernel/brep/doc.go
+++ b/kernel/brep/doc.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package brep implements the exact B-rep boolean (M20·F01, the Option-A kernel).
+// The planar core — [Boolean] / [BooleanDiag] over an [Op] — imprints face–face
+// intersections, splits faces along them via the 2D planar arrangement
+// ([Arrange]), classifies the sub-faces against the other solid, and stitches the
+// kept faces into a clean, low-face-count, chainable B-rep. On top of that core
+// sit the exact analytic curved paths: half-space cuts ([HalfSpaceCut]),
+// cylindrical/conical hole and boss primitives (CutCylindricalHole,
+// JoinCylindricalBoss, …), and the crossing-cylinder / cone / Steinmetz general
+// intersect–cut–join specials (ADR-0027; kind taxonomy in ADR-0045). Dispatch
+// between these paths — and the residual triangle-CSG fallback — lives one level
+// up in kernel/ops.
+//
+// The invariant that matters: every result face carries its source lineage
+// forward (and new intersection edges are named by their generating face pair,
+// ADR-0043), so reference keys survive the boolean — topological naming, not
+// addresses (K1a; architecture core/05).
+package brep

--- a/kernel/exchange/doc.go
+++ b/kernel/exchange/doc.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package exchange owns the kernel-side seam for foreign-format import/export. It
+// declares the interfaces a concrete translator satisfies — [BodyImporter] and
+// [BodyExporter], tuned by a [TranslationOptions] — so the rest of the kernel/model
+// depends on the abstraction, not on a parser; concrete codecs are wired in by the
+// model layer (model/exchange). See ADR-0018 and the M17 plan.
+//
+// Concrete format implementations live in the subpackages: step (STEP B-rep),
+// dwg and dxf (2D drawing exchange), pdf (vector plot import), meshio (STL/OBJ/3MF
+// meshes), plyfmt/e57fmt/lasfmt (point clouds), and drawing (drawing-sheet export).
+//
+// The one unit invariant: translators scale through
+// [TranslationOptions.TargetUnitMM], anchored by [DBUnitMM] — the kernel's
+// geometry is centimetres, so one database unit is 10 mm (#146); this package is
+// the single place the model↔file unit scale is anchored.
+package exchange

--- a/kernel/exchange/translate.go
+++ b/kernel/exchange/translate.go
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
-// Package exchange owns the kernel-side seam for foreign-format (STEP, IGES, …)
-// import/export. It declares the interfaces a concrete translator satisfies so the
-// rest of the kernel/model depends on the abstraction, not on a parser. The STEP
-// implementation lives under exchange/step and is wired in by the model layer (the
-// contract/wire/CLI surface is PBI-D, deferred). See ADR-0018 and the M17 plan.
+// (The package comment was promoted to doc.go — #1669, M40 audit D12.)
+
 package exchange
 
 import "oblikovati.org/kernel/topo"

--- a/kernel/ops/doc.go
+++ b/kernel/ops/doc.go
@@ -9,8 +9,10 @@
 // validation/healing, and boolean combination. Booleans cover the non-overlapping
 // topological cases (disjoint / one-contains-the-other) plus general intersecting
 // solids: planar-faceted operands go through the exact planar B-rep boolean
-// (kernel/brep), and operands with a curved face fall back to a triangle-soup BSP
-// CSG (see booleanCSG). Exact booleans on curved/NURBS solids — analytic face-face
-// intersection rather than the faceted CSG approximation — remain future work,
-// behind the same API.
+// (kernel/brep), and curved operands go through the EXACT analytic curved-boolean
+// paths (curvedExactBoolean: surface–surface intersection → (u,v) arrangement →
+// classify → stitch, plus analytic specials — ADR-0027; kind taxonomy in
+// ADR-0045). Triangle-soup BSP CSG (booleanCSG) survives only as the residual
+// fallback when no exact path applies, and taking it is recorded as a tracked
+// Defect diagnostic (CodeBooleanCSGFallback), never a silent degradation.
 package ops

--- a/model/drawing/content.go
+++ b/model/drawing/content.go
@@ -1,13 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
-// Package drawing is the modeling content of a drawing document (M14-F01, #384): an
-// ordered set of sheets (sizes/orientation, borders, title blocks) plus the primary
-// referenced model the drawing documents. Title-block fields resolve against that
-// model's iProperties, so a title block shows live part/assembly metadata.
-//
-// This is the GPL implementation of the api/contract drawing surface (ADR-0018); it
-// registers itself as the real content for doc.Drawing so opening a .odd reconstructs
-// live sheets rather than the identity-only stub.
+// (The package comment was promoted to doc.go — #1669, M40 audit D12.)
+
 package drawing
 
 import (

--- a/model/drawing/doc.go
+++ b/model/drawing/doc.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package drawing is the modeling content of a drawing document (M14-F01, #384): an
+// ordered set of sheets (sizes/orientation, borders, title blocks) plus the primary
+// referenced model the drawing documents. Title-block fields resolve against that
+// model's iProperties, so a title block shows live part/assembly metadata.
+//
+// The entry point is [Content] (built by [NewContent]), the doc.Content
+// implementation holding the sheets. The package knows nothing of the workspace:
+// the host injects resolver seams — [ModelProperties] for iProperty values,
+// [BodyResolver] for the referenced B-rep a view projects, [BOMResolver] for
+// parts-list rows — and a nil resolver degrades gracefully (blank fields,
+// unprojected views, empty lists) rather than failing.
+//
+// This is the GPL implementation of the api/contract drawing surface (ADR-0018); it
+// registers itself as the real content for doc.Drawing so opening a .odd reconstructs
+// live sheets rather than the identity-only stub.
+package drawing


### PR DESCRIPTION
Remediates the M40 deep-audit D-series documentation findings. Every claim written into a doc was verified against the current code first (grep for the symbol/path, plus a live `oblikovati-cli` document for the schema-version check). `make docs-lint` (markdownlint-cli2), `go build ./...` (root + head module), `go vet`, `golangci-lint`, and the touched packages' tests are all green.

## Per-issue summary

- **D1 #1658 — fixed.** Rewrote core/05's identity section around `identity.RefKey` and the tiered exact → ancestral → geometric bind/recover (`model/identity/refkey.go`, `binding.go`, `recover.go`, ADR-0043 P6c); no `KeyManager`/`keys.bin` remains. The persistence section was also brought to the shipped ADR-0020 single-YAML shape (the stale ZIP tree was where `keys.bin` lived), verified against `persistence/yamlcodec` and a freshly generated document.
- **D2 #1659 — fixed.** Cheatsheet row now maps `ReferenceKeyManager.BindKeyToObject` → `identity.RefKey` tiered bind/recover (`identity.RecoverLost`, `MatchNone` ⇒ lost). No other `KeyManager` references remain in the file.
- **D3 #1660 — fixed.** `PartContent`/`AssemblyContent` replaced with the real `compdef.PartComponentDefinition` / `compdef.AssemblyComponentDefinition` (verified in `model/compdef`) across modeling/01, modeling/05, core/05, assembly/README and assembly/00; modeling/01's phantom `*identity.KeyManager` field dropped from the sketch; modeling/05 gained a one-line as-built note (the rule is a field on `PartComponentDefinition`, not a wrapper type).
- **D4 #1661 — partial (see below).** Living docs (lua-scripting-plan.md, core/07-extensibility.md) purged of `/source` paths; ADR-0006/0015/0016/0023/0028 carry an editor's-note banner mapping `/source` → repo root; ADR-0018 (load-bearing per CLAUDE.md) had its normative paths corrected in place with a note recording the update. Remaining `source/` strings live only in banner-annotated ADR bodies, `history/` and the audit record. **Not done: the CI grep guard** — this PR was scoped to documentation + doc.go files only; the guard needs a follow-up touching CI config.
- **D5 #1662 — partial (out-of-repo remainder).** The named wiki page (`Oblikovati.API/docs/wiki/Oblikovati-Architecture.md`) lives in the sibling Apache-2.0 repo, out of scope here. This repo's own instance of the same stale claim was found and fixed: `kernel/ops/doc.go` said curved operands "fall back to triangle-soup BSP CSG … exact booleans remain future work"; it now states the exact SSI curved-boolean paths (ADR-0027/0045) with CSG as the diagnostics-tracked residual fallback, verified against `kernel/ops/boolean.go`.
- **D6 #1663 — fixed.** ADR-0027 status flipped to accepted/implemented with a pointer to ADR-0045 as the closing kind taxonomy; body untouched.
- **D7 #1664 — not done here (wrong repo).** `Oblikovati.API/README.md` is the sibling repo; nothing to fix in this repo.
- **D8 #1665 — fixed.** RELEASING.md now points at `.goreleaser.yaml` (repo root, verified present); no `source/` paths remain in the file.
- **D9 #1666 — fixed.** implementation-conventions.md names `identity.RefKey` with the tiered bind/recover; no `ReferenceKeyManager` remains in living docs outside the cheatsheet's COM column (which is the Inventor-side concept being mapped, per D2).
- **D10 #1667 — not done here (wrong repo).** README/wiki dedup targets are all in the sibling `Oblikovati.API` repo. This repo's README already only points at the API repo; the repo-local CLAUDE.md already carries just the layout summary.
- **D11 #1668 — fixed.** history/implementation-log.md opens with an explicit historical-snapshot banner (frozen at migration, `/source` paths predate the repo-root layout, the GitHub tracker is the source of truth); body unchanged.
- **D12 #1669 — fixed for this repo (6 of 7 packages).** `addin/router`, `head/ui`, `kernel/exchange`, `kernel/brep`, `addin/opregistry`, `model/drawing` each got a `doc.go` (SPDX `GPL-2.0-only` first line) by promoting the package comment that already lived in an ordinary file, enriched only with entry points/invariants the code already states; donor files keep a pointer comment, nothing deleted. The 7th package, `api/wire`, is in the sibling Apache-2.0 repo — left open with a comment would-be follow-up there. Build/vet/lint/tests green, including the cgo head module.
- **D13 #1670 — stale premise, closed directly (not via this PR).** The shipped `.obk` schema version is **v2**, not v3: `persistence/manifest.go` has `CurrentSchemaVersion = 2`, the migration map is empty, no v3 exists anywhere in the repo, a freshly generated document writes `schemaVersion: 2`, and ADR-0020 already says v2. Amending the ADR to v3 would have introduced drift. Closed as not-planned with the evidence.

## Needs follow-up outside this PR

- D5/D7/D10 edits in the sibling `Oblikovati.API` repo (wiki curved-boolean paragraph; README `/source` refs + shrink to pointer+quickstart; `api/wire` doc.go for D12).
- D4's CI grep guard against `/source` paths in living docs (CI config change, deliberately out of this docs-only PR).

Closes #1658
Closes #1659
Closes #1660
Closes #1663
Closes #1665
Closes #1666
Closes #1668

🤖 Generated with [Claude Code](https://claude.com/claude-code)