### PR TITLE
Exact rational blend surfaces for variable/conic fillets (audit A10)

### DIFF
--- a/archguard/contract_assertions_test.go
+++ b/archguard/contract_assertions_test.go
@@ -163,8 +163,11 @@ func assertedContractNames(t *testing.T) map[string]bool {
 
 // skipNonSourceDir prunes trees that never hold shipped host code.
 func skipNonSourceDir(name string) error {
+	if strings.HasPrefix(name, ".") && name != "." && name != ".." { // .git AND .claude agent worktrees
+		return filepath.SkipDir
+	}
 	switch name {
-	case ".git", "experiments", "test-utilities", "node_modules":
+	case "experiments", "test-utilities", "node_modules":
 		return filepath.SkipDir
 	}
 	return nil

--- a/archguard/init_registration_test.go
+++ b/archguard/init_registration_test.go
@@ -61,8 +61,12 @@ func initRegistrationSources(t *testing.T) []string {
 			return err
 		}
 		if info.IsDir() {
+			// Dot-directories cover .git AND .claude (agent worktrees carry full repo copies).
+			if strings.HasPrefix(info.Name(), ".") && info.Name() != ".." && info.Name() != "." {
+				return filepath.SkipDir
+			}
 			switch info.Name() {
-			case ".git", "experiments", "test-utilities", "architecture", "testdata", "node_modules":
+			case "experiments", "test-utilities", "architecture", "testdata", "node_modules":
 				return filepath.SkipDir
 			}
 			return nil

--- a/archguard/sketch_entity_switch_test.go
+++ b/archguard/sketch_entity_switch_test.go
@@ -87,8 +87,11 @@ func skipNonModuleDirs(path, name string) error {
 	if strings.HasSuffix(filepath.ToSlash(path), "model/sketch") {
 		return filepath.SkipDir
 	}
+	if strings.HasPrefix(name, ".") && name != "." && name != ".." { // .git AND .claude agent worktrees
+		return filepath.SkipDir
+	}
 	switch name {
-	case ".git", "experiments", "test-utilities", "architecture", "testdata", "node_modules":
+	case "experiments", "test-utilities", "architecture", "testdata", "node_modules":
 		return filepath.SkipDir
 	}
 	return nil

--- a/kernel/geom/blend_ruled_arc.go
+++ b/kernel/geom/blend_ruled_arc.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// Exact rational representation of a ruled blend between two circular arcs (#1606, audit A10).
+//
+// A linear-taper variable fillet on a straight edge sweeps a circular profile arc whose radius
+// grows linearly along the edge. The blend it traces is an OBLIQUE circular cone: the profile
+// planes stay parallel (perpendicular to the edge) but the arc centres walk the dihedral
+// bisector as the radius grows, so no right-circular geom.Cone represents it. It IS exactly
+// representable as a NURBS surface: the profile arc is a rational quadratic (Piegl & Tiller
+// ch. 7), and ruling two arcs with the SAME sweep in parallel frames is degree 1 in v with
+// column-wise identical weights — so the ruled surface reproduces the blend exactly, not as the
+// C0 polyhedral strip it used to facet into (~11° creases).
+
+// arcNurbsSegments returns the number of ≤90° rational-quadratic segments an arc of the given
+// sweep needs (P&T A7.1's quadrant split).
+func arcNurbsSegments(sweep float64) int {
+	return int(stdmath.Ceil(sweep/(stdmath.Pi/2) - 1e-12)) // tol:parametric — quadrant count rounding
+}
+
+// arcNurbsBasis returns the unit-circle control directions and weights of a rational quadratic
+// arc from angle 0 through sweep, in the plane spanned by (xdir, ydir): dir(θ) = cosθ·xdir +
+// sinθ·ydir. The caller scales/translates the directions per profile (centre + radius·dir), so
+// two arcs sharing one sweep share this basis — the key to an exact ruled blend.
+func arcNurbsBasis(xdir, ydir math.Vector3, sweep float64) (dirs []math.Vector3, weights []float64, knots []float64) {
+	segs := arcNurbsSegments(sweep)
+	d := sweep / float64(segs)
+	w := stdmath.Cos(d / 2)
+	at := func(theta float64) math.Vector3 {
+		return xdir.Scale(stdmath.Cos(theta)).Add(ydir.Scale(stdmath.Sin(theta)))
+	}
+	dirs = append(dirs, at(0))
+	weights = append(weights, 1)
+	knots = []float64{0, 0, 0}
+	for s := 0; s < segs; s++ {
+		mid := float64(s)*d + d/2
+		// The interior control direction sits on the tangent intersection: dir(mid)/cos(d/2).
+		dirs = append(dirs, at(mid).Scale(1/w), at(float64(s+1)*d))
+		weights = append(weights, w, 1)
+		u := float64(s+1) / float64(segs)
+		if s+1 < segs {
+			knots = append(knots, u, u)
+		} else {
+			knots = append(knots, 1, 1, 1)
+		}
+	}
+	return dirs, weights, knots
+}
+
+// NewRuledArcBlend builds the exact rational ruled surface between two circular arcs that share
+// one angular frame: arc v=0 is c0 + r0·dir(θ), arc v=1 is c1 + r1·dir(θ), θ from 0 through
+// sweep in the (xdir, ydir) plane. r1 (or r0) may be zero — the column collapses to the apex
+// point and the surface is the exact oblique cone of a fillet run-out.
+//
+//	blend, err := geom.NewRuledArcBlend(c0, r0, c1, r1, xdir, ydir, math.Pi/2)
+func NewRuledArcBlend(c0 math.Point3, r0 float64, c1 math.Point3, r1 float64, xdir, ydir math.Vector3, sweep float64) (BSplineSurface, error) {
+	if sweep <= 0 || sweep > 2*stdmath.Pi {
+		return BSplineSurface{}, fmt.Errorf("geom: ruled arc blend sweep %g out of (0, 2π]", sweep)
+	}
+	if r0 < 0 || r1 < 0 || (r0 == 0 && r1 == 0) {
+		return BSplineSurface{}, fmt.Errorf("geom: ruled arc blend radii (%g, %g) must be ≥ 0 and not both zero", r0, r1)
+	}
+	dirs, w, uKnots := arcNurbsBasis(xdir, ydir, sweep)
+	ctrl := make([][]math.Point3, len(dirs))
+	weights := make([][]float64, len(dirs))
+	for i, d := range dirs {
+		ctrl[i] = []math.Point3{c0.TranslateBy(d.Scale(r0)), c1.TranslateBy(d.Scale(r1))}
+		weights[i] = []float64{w[i], w[i]}
+	}
+	return NewBSplineSurface(2, 1, ctrl, weights, uKnots, []float64{0, 0, 1, 1})
+}
+
+// NewConicSectionCurve is the single-segment rational quadratic p0–s–p2 with interior (shoulder)
+// weight w — the exact conic every fillet cross-section that is an arc (w = cos of the half
+// wedge) or a rho conic (w = rho/(1−rho)) reduces to. It satisfies Curve3, so a blend face's
+// boundary edge carries the SAME geometry as the blend surface's end isoline.
+func NewConicSectionCurve(p0, s, p2 math.Point3, w float64) (BSplineCurve, error) {
+	return NewBSplineCurve(2, []math.Point3{p0, s, p2}, []float64{1, w, 1}, []float64{0, 0, 0, 1, 1, 1})
+}
+
+// NewRuledSectionBlend rules two conic sections (p0–s–p2 control triangles sharing shoulder
+// weight w) into the exact degree (2,1) rational blend surface — the variable fillet's span
+// between two cross-section profiles (#1606). One section may be fully degenerate (all three
+// points equal): a fillet run-out's apex column.
+func NewRuledSectionBlend(sec0, sec1 [3]math.Point3, w float64) (BSplineSurface, error) {
+	if w <= 0 {
+		return BSplineSurface{}, fmt.Errorf("geom: ruled section blend shoulder weight %g must be > 0", w)
+	}
+	weights := []float64{1, w, 1}
+	ctrl := make([][]math.Point3, 3)
+	wts := make([][]float64, 3)
+	for i := 0; i < 3; i++ {
+		ctrl[i] = []math.Point3{sec0[i], sec1[i]}
+		wts[i] = []float64{weights[i], weights[i]}
+	}
+	return NewBSplineSurface(2, 1, ctrl, wts, []float64{0, 0, 0, 1, 1, 1}, []float64{0, 0, 1, 1})
+}

--- a/kernel/geom/blend_ruled_arc_test.go
+++ b/kernel/geom/blend_ruled_arc_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestRuledArcBlendReproducesArcsExactly pins the exactness claim (#1606): the rational ruled
+// blend's v=0 / v=1 isolines ARE the two circular arcs — sampled position error at machine
+// precision, not chord error.
+func TestRuledArcBlendReproducesArcsExactly(t *testing.T) {
+	c0, c1 := math.P3(0, 2, 2), math.P3(5, 3, 3) // centres walking a bisector as r grows
+	const r0, r1, sweep = 2.0, 3.0, stdmath.Pi / 2
+	x, y := math.V3(0, -1, 0), math.V3(0, 0, -1)
+	s, err := NewRuledArcBlend(c0, r0, c1, r1, x, y, sweep)
+	if err != nil {
+		t.Fatalf("NewRuledArcBlend: %v", err)
+	}
+	for i := 0; i <= 16; i++ {
+		u := float64(i) / 16
+		theta := u * sweep
+		d := x.Scale(stdmath.Cos(theta)).Add(y.Scale(stdmath.Sin(theta)))
+		for _, end := range []struct {
+			v float64
+			c math.Point3
+			r float64
+		}{{0, c0, r0}, {1, c1, r1}} {
+			// NOTE: the rational quadratic's parameter is not arc length, so compare by
+			// DISTANCE-FROM-CENTRE and plane membership, which are parameterization-free.
+			p := s.PointAt(u, end.v)
+			if got := float64(end.c.DistanceTo(p)); stdmath.Abs(got-end.r) > 1e-12 {
+				t.Fatalf("u=%g v=%g: |p-c| = %.15f, want %g (point off the circle)", u, end.v, got, end.r)
+			}
+			_ = d
+			if got := float64(end.c.VectorTo(p).Dot(math.V3(1, 0, 0))); stdmath.Abs(got) > 1e-12 {
+				t.Fatalf("u=%g v=%g: point off the profile plane by %g", u, end.v, got)
+			}
+		}
+	}
+}
+
+// TestRuledArcBlendRunoutCollapsesToApex: r1=0 collapses the v=1 column to the apex — the exact
+// oblique cone of a fillet run-out, still a valid surface.
+func TestRuledArcBlendRunoutCollapsesToApex(t *testing.T) {
+	apex := math.P3(4, 0, 0)
+	s, err := NewRuledArcBlend(math.P3(0, 1, 1), 1.5, apex, 0, math.V3(0, -1, 0), math.V3(0, 0, -1), stdmath.Pi/2)
+	if err != nil {
+		t.Fatalf("NewRuledArcBlend(runout): %v", err)
+	}
+	for i := 0; i <= 8; i++ {
+		if d := float64(apex.DistanceTo(s.PointAt(float64(i)/8, 1))); d > 1e-12 {
+			t.Fatalf("v=1 isoline point %g from the apex, want 0", d)
+		}
+	}
+}
+
+// TestRuledArcBlendIsG1AcrossSegments: a 3/4-turn sweep needs multiple rational segments; the
+// surface normal must be continuous across the segment joins (the C0 strip creases this
+// replaces were ~11° — assert machine-precision continuity).
+func TestRuledArcBlendIsG1AcrossSegments(t *testing.T) {
+	const sweep = 3 * stdmath.Pi / 2
+	s, err := NewRuledArcBlend(math.P3(0, 0, 0), 2, math.P3(6, 0.5, 0.5), 3, math.V3(0, 1, 0), math.V3(0, 0, 1), sweep)
+	if err != nil {
+		t.Fatalf("NewRuledArcBlend: %v", err)
+	}
+	segs := arcNurbsSegments(sweep)
+	for k := 1; k < segs; k++ {
+		u := float64(k) / float64(segs)
+		nl := s.NormalAt(u-1e-9, 0.5)
+		nr := s.NormalAt(u+1e-9, 0.5)
+		if dot := nl.Dot(nr); dot < 1-1e-9 {
+			t.Errorf("normal jump at segment join u=%g: cos=%.12f, want ~1 (G1)", u, dot)
+		}
+	}
+}
+
+// TestRuledSectionBlendMatchesConicBoundary: the blend's v=0 isoline equals the conic section
+// curve point-for-point (same parameterization) — so a face boundary built from
+// NewConicSectionCurve lies exactly on the surface.
+func TestRuledSectionBlendMatchesConicBoundary(t *testing.T) {
+	sec0 := [3]math.Point3{math.P3(1, 0, 0), math.P3(1, 1, 0), math.P3(0, 1, 0)}
+	sec1 := [3]math.Point3{math.P3(2, 0, 3), math.P3(2, 2, 3), math.P3(0, 2, 3)}
+	const w = 0.75
+	s, err := NewRuledSectionBlend(sec0, sec1, w)
+	if err != nil {
+		t.Fatalf("NewRuledSectionBlend: %v", err)
+	}
+	c, err := NewConicSectionCurve(sec0[0], sec0[1], sec0[2], w)
+	if err != nil {
+		t.Fatalf("NewConicSectionCurve: %v", err)
+	}
+	for i := 0; i <= 10; i++ {
+		u := float64(i) / 10
+		if d := float64(c.PointAt(u).DistanceTo(s.PointAt(u, 0))); d > 1e-13 {
+			t.Fatalf("u=%g: boundary curve %g off the surface isoline", u, d)
+		}
+	}
+	// A degenerate (run-out) column still evaluates: every v=1 point is the apex.
+	apex := math.P3(5, 5, 5)
+	r, err := NewRuledSectionBlend(sec0, [3]math.Point3{apex, apex, apex}, w)
+	if err != nil {
+		t.Fatalf("NewRuledSectionBlend(runout): %v", err)
+	}
+	if d := float64(apex.DistanceTo(r.PointAt(0.3, 1))); d > 1e-13 {
+		t.Fatalf("runout column point %g off the apex", d)
+	}
+}

--- a/kernel/ops/fillet.go
+++ b/kernel/ops/fillet.go
@@ -7,6 +7,7 @@ import (
 	stdmath "math"
 
 	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -101,7 +102,22 @@ const (
 // FilletEdgesCorner is FilletEdgesVarying with an explicit 2-edge corner strategy. Lone curved
 // (rim/arc) picks ignore it (they have no shared corner). CornerRound augments the selection with the
 // sharp third edge of each 2-edge corner so the corner resolves as a watertight 3-edge sphere blend.
+// CodeFilletFacetedBlend marks a fillet whose blend shipped as the C0 polyhedral strip fallback
+// — a G2-quintic cross-section, or a variable blend terminated by a miter/blend corner — so
+// "advertised smooth, shipped faceted" is a counted degradation, never silent (#1606, audit A10).
+const CodeFilletFacetedBlend diag.Code = "fillet.faceted-blend"
+
+// FilletEdgesCornerDiag is FilletEdgesCorner with a diagnostic recorder (nil to discard): any
+// pick whose blend falls back to the faceted strip records CodeFilletFacetedBlend.
+func FilletEdgesCornerDiag(body *topo.Body, picks []EdgeFilletRadii, corner CornerStrategy, concave ConcaveFill, rec *diag.Recorder) (*topo.Body, error) {
+	return filletEdgesCornerRec(body, picks, corner, concave, rec)
+}
+
 func FilletEdgesCorner(body *topo.Body, picks []EdgeFilletRadii, corner CornerStrategy, concave ConcaveFill) (*topo.Body, error) {
+	return filletEdgesCornerRec(body, picks, corner, concave, nil)
+}
+
+func filletEdgesCornerRec(body *topo.Body, picks []EdgeFilletRadii, corner CornerStrategy, concave ConcaveFill, rec *diag.Recorder) (*topo.Body, error) {
 	if rim := loneRimPick(body, picks); rim != nil {
 		return FilletCylinderRim(body, rim.Key, rim.R0) // a circular cylinder/cap rim → toroidal band
 	}
@@ -118,13 +134,13 @@ func FilletEdgesCorner(body *topo.Body, picks []EdgeFilletRadii, corner CornerSt
 	case CornerSetback:
 		edges = setbackThirdEdges(edges) // taper the third edge (r→0 run-out) → smooth set-back sphere
 	}
-	return filletResolvedEdges(body, edges, concave)
+	return filletResolvedEdges(body, edges, concave, rec)
 }
 
 // filletResolvedEdges solves the corners and edge fillets of an already-resolved pick list and
 // assembles the validated result body. Round/setback corners have already been reduced to 3-edge
 // sphere blends by augmenting the third edge, so the corner solver only ever sees miters and blends.
-func filletResolvedEdges(body *topo.Body, edges []filletPick, concave ConcaveFill) (*topo.Body, error) {
+func filletResolvedEdges(body *topo.Body, edges []filletPick, concave ConcaveFill, rec *diag.Recorder) (*topo.Body, error) {
 	blends, miters, err := computeCorners(edges)
 	if err != nil {
 		return nil, err
@@ -134,6 +150,10 @@ func filletResolvedEdges(body *topo.Body, edges []filletPick, concave ConcaveFil
 		ef, err := computeEdgeFillet(body, p, blends, miters, concave)
 		if err != nil {
 			return nil, err
+		}
+		if ef.varying && !ef.exact {
+			rec.Recordf(CodeFilletFacetedBlend, diag.Defect,
+				"fillet blend on edge %d shipped as the C0 faceted strip (G2-quintic section or miter/blend-terminated variable end)", p.edge.ID())
 		}
 		fils = append(fils, ef)
 	}
@@ -193,6 +213,8 @@ type corner struct {
 	cen     math.Point3 // cylinder centre at this end (sphere centre when blended)
 	ta, tb  math.Point3
 	mid     math.Point3
+	sh      math.Point3   // exact blends (#1606): the shoulder (tangent-intersection) control point
+	crossW  float64       // exact CONIC cross-section only: the shoulder weight the end trim must carry
 	chords  []math.Point3 // variable fillet only: the end arc as chord samples ta…tb
 	endFace *topo.Face    // the flat end cap to arc (nil at a blend or miter corner)
 	vertex  *topo.Vertex
@@ -220,6 +242,10 @@ type edgeFillet struct {
 	edge    *topo.Edge
 	varying bool
 	flip    bool // concave fillet: the cylinder face's outward sense is inverted (surface faces the centre)
+	// exact marks a varying/conic blend emitted as the EXACT rational ruled surface (#1606,
+	// audit A10) instead of the C0 polyhedral strip; secW is the sections' shoulder weight.
+	exact bool
+	secW  float64
 }
 
 // computeEdgeFillet solves the rolling-ball geometry for one convex straight edge, using a
@@ -284,9 +310,19 @@ func solvedEdgeFillet(e *topo.Edge, p filletPick, in cornerInputs, blends map[ui
 		return edgeFillet{}, err
 	}
 	if p.chordPath() {
-		sampleCornerChords(&c0, &c1, in, p.cross, p.rho)
 		mids := midProfiles(e, in, p.mids, cornerChordCount(in), p.cross, p.rho)
-		return edgeFillet{a: in.a, b: in.b, c0: c0, c1: c1, mids: mids, edge: e, varying: true, flip: in.flip}, nil
+		ef := edgeFillet{a: in.a, b: in.b, c0: c0, c1: c1, mids: mids, edge: e, varying: true, flip: in.flip}
+		if w, ok := exactSectionWeight(p, in); ok && plainEnds(c0, c1) {
+			// The blend is exactly a rational ruled surface between conic sections (#1606):
+			// no chord sampling — corners keep their true arcs (or carry the conic weight for
+			// the end trims) and the faces are emitted analytic. G2-quintic cross-sections and
+			// miter/blend-terminated ends keep the strip fallback, now diagnostic-flagged.
+			ef.exact, ef.secW = true, w
+			setBlendShoulders(&ef, in, p)
+			return ef, nil
+		}
+		sampleCornerChords(&ef.c0, &ef.c1, in, p.cross, p.rho)
+		return ef, nil
 	}
 	cyl, err := geom.NewCylinder(c0.cen, in.axis, p.r0)
 	if err != nil {
@@ -357,6 +393,7 @@ func midProfiles(e *topo.Edge, in cornerInputs, mids []FilletRadiusPoint, k int,
 		p := p0.TranslateBy(span.Scale(m.T))
 		cen := p.TranslateBy(in.offDir.Scale(m.R))
 		c := corner{a: in.a, b: in.b, cen: cen, ta: cen.TranslateBy(in.nA.Scale(m.R)), tb: cen.TranslateBy(in.nB.Scale(m.R))}
+		c.mid = cen.TranslateBy(slerpVec(in.nA, in.nB, 0.5).Scale(m.R))
 		c.chords = crossSectionChords(c, in, k, cross, rho)
 		out = append(out, c)
 	}
@@ -402,6 +439,49 @@ func shoulder(c corner, in cornerInputs) math.Point3 {
 	r := c.cen.DistanceTo(c.ta)
 	cdot := in.nA.Dot(in.nB)
 	return c.cen.TranslateBy(in.nA.Add(in.nB).Scale(r / (1 + cdot)))
+}
+
+// exactSectionWeight returns the shoulder weight of the pick's cross-section when it is a
+// rational quadratic — an ARC (w = cos of the half wedge, since cos(wedge) = nA·nB) or a rho
+// CONIC (w = rho/(1−rho)) — and ok=false for the G2 quintic, which is not (#1606).
+func exactSectionWeight(p filletPick, in cornerInputs) (float64, bool) {
+	switch {
+	case p.cross.IsArc():
+		return stdmath.Sqrt((1 + in.nA.Dot(in.nB)) / 2), true // tol-free: dihedral wedge < π keeps this > 0
+	case p.cross == FilletConic:
+		rho := p.rho
+		if rho <= 0 || rho >= 1 {
+			rho = 0.5
+		}
+		return rho / (1 - rho), true
+	default:
+		return 0, false
+	}
+}
+
+// plainEnds reports whether both corners terminate against plain end faces or run-outs — the
+// configurations the exact ruled blend covers; miter seams and corner-sphere blends keep the
+// chord strips (their shared boundaries are chord polylines).
+func plainEnds(c0, c1 corner) bool {
+	return !c0.miter && !c0.blend && !c1.miter && !c1.blend
+}
+
+// setBlendShoulders stamps every profile's shoulder control point (and, for a conic
+// cross-section, the weight its end trim must carry) on the exact blend's corners.
+func setBlendShoulders(ef *edgeFillet, in cornerInputs, p filletPick) {
+	conicW := 0.0
+	if p.cross == FilletConic {
+		conicW = ef.secW
+	}
+	stamp := func(c *corner) {
+		c.sh = shoulder(*c, in)
+		c.crossW = conicW
+	}
+	stamp(&ef.c0)
+	stamp(&ef.c1)
+	for i := range ef.mids {
+		stamp(&ef.mids[i])
+	}
 }
 
 // conicChords samples a rho-controlled conic cross-section (rational quadratic Bézier ta–S–tb) into

--- a/kernel/ops/fillet_faces.go
+++ b/kernel/ops/fillet_faces.go
@@ -19,11 +19,14 @@ func filletResultFaces(body *topo.Body, fils []edgeFillet, blends map[uint64]*co
 		out = append(out, transformFace(f, abSubst[f], endCorner[f], edgeInserts[f]))
 	}
 	for _, ef := range fils {
-		if ef.varying {
+		switch {
+		case ef.varying && ef.exact:
+			out = append(out, ruledBlendFaces(ef)...)
+		case ef.varying:
 			out = append(out, rulingStripFaces(ef)...)
-			continue
+		default:
+			out = append(out, cylinderFace(ef))
 		}
-		out = append(out, cylinderFace(ef))
 	}
 	for _, cb := range blends {
 		out = append(out, spherePatchFace(cb))
@@ -208,8 +211,7 @@ func orientedInserts(pts []math.Point3, reversed bool) []math.Point3 {
 // constant fillet, or the chord fan (shared with the ruling strips) for a variable one.
 func addCornerRound(fl *filletLoop, c corner, tIn, tOut math.Point3) {
 	if len(c.chords) == 0 {
-		arc, _ := geom.Arc3dByThreePoints(tIn, c.mid, tOut)
-		fl.add(tIn, arc)
+		fl.add(tIn, cornerSectionCurve(c, tIn, tOut))
 		fl.add(tOut, nil)
 		return
 	}
@@ -447,4 +449,101 @@ func arcMidpoints(loop filletLoop) []math.Point3 {
 		}
 	}
 	return mids
+}
+
+// cornerSectionCurve is the exact cross-section trim tIn→tOut at a corner: the circular arc for
+// an arc profile, or the rational conic (shoulder weight crossW) for a conic profile — the same
+// geometry as the blend surface's end isoline, so the seam welds curve-for-curve (#1606).
+func cornerSectionCurve(c corner, tIn, tOut math.Point3) geom.Curve3 {
+	if c.crossW > 0 {
+		if conic, err := geom.NewConicSectionCurve(tIn, c.sh, tOut, c.crossW); err == nil {
+			return conic
+		}
+	}
+	arc, _ := geom.Arc3dByThreePoints(tIn, c.mid, tOut)
+	return arc
+}
+
+// ruledBlendFaces emits a variable (or conic) fillet's blend as EXACT rational ruled faces —
+// one degree (2,1) NURBS span between each pair of adjacent cross-section profiles — instead of
+// the C0 chord strips (#1606, audit A10). Each span's boundary reuses the profiles' exact
+// section curves and the straight tangent rulings, so adjacent faces and end caps weld exactly.
+func ruledBlendFaces(ef edgeFillet) []filletFace {
+	profiles := append([]corner{ef.c0}, ef.mids...)
+	profiles = append(profiles, ef.c1)
+	out := make([]filletFace, 0, len(profiles)-1)
+	for i := 0; i+1 < len(profiles); i++ {
+		out = append(out, ruledBlendSpan(ef, profiles[i], profiles[i+1], i))
+	}
+	return out
+}
+
+// ruledBlendSpan builds one exact blend span between profiles a and b, falling back to the
+// planar strip for the span only if the surface constructor rejects it (degenerate frame).
+func ruledBlendSpan(ef edgeFillet, a, b corner, i int) filletFace {
+	surf, err := geom.NewRuledSectionBlend(
+		[3]math.Point3{a.ta, a.sh, a.tb}, [3]math.Point3{b.ta, b.sh, b.tb}, ef.secW)
+	if err != nil {
+		return planarFaceFromRing([]math.Point3{a.ta, b.ta, b.tb, a.tb}, a.cen.Midpoint(b.cen))
+	}
+	segs := blendSpanSegs(a, b)
+	if blendSegsFlipped(surf, a, b) != ef.flip {
+		segs = reverseEndSegs(segs)
+	}
+	ff := filletFace{surface: surf, loops: []filletLoop{loopFromSegs(segs)}, parent: blendSpanProvenance(ef.edge, i)}
+	return ff
+}
+
+// blendSpanSegs is the span's boundary chain: A-tangent ruling, profile section at b, B-tangent
+// ruling back, profile section at a reversed. A run-out profile contributes no section (its
+// three points coincide at the apex), so the chain closes through the apex vertex.
+func blendSpanSegs(a, b corner) []endSeg {
+	segs := []endSeg{{from: a.ta, to: b.ta}}
+	if !b.runout {
+		segs = append(segs, endSeg{from: b.ta, to: b.tb, curve: cornerSectionCurve(b, b.ta, b.tb), mid: b.mid, arc: true})
+	}
+	segs = append(segs, endSeg{from: b.tb, to: a.tb})
+	if !a.runout {
+		segs = append(segs, endSeg{from: a.tb, to: a.ta, curve: cornerSectionCurve(a, a.tb, a.ta), mid: a.mid, arc: true})
+	}
+	return segs
+}
+
+// blendSegsFlipped reports whether the natural loop winding (as emitted by blendSpanSegs) runs
+// against the blend's OUTWARD normal — the winding probe cylinderSegsFlipped performs for the
+// constant blend, evaluated on the exact surface: outward is the surface normal at the span
+// centre oriented away from the rolling-ball centre line, and the loop's winding is its Newell
+// normal over the boundary corners (the wedge spans < π, so both signs are robust).
+func blendSegsFlipped(surf geom.BSplineSurface, a, b corner) bool {
+	n := surf.NormalAt(0.5, 0.5)
+	if a.cen.Midpoint(b.cen).VectorTo(surf.PointAt(0.5, 0.5)).Dot(n) < 0 {
+		n = n.Scale(-1) // outward: away from the ball centre line
+	}
+	ring := []math.Point3{a.ta, b.ta}
+	if !b.runout {
+		ring = append(ring, b.mid, b.tb)
+	}
+	ring = append(ring, a.tb)
+	if !a.runout {
+		ring = append(ring, a.mid)
+	}
+	return newellNormal(ring).Dot(n) < 0
+}
+
+// newellNormal is the Newell winding normal of a 3D point ring.
+func newellNormal(ring []math.Point3) math.Vector3 {
+	var nx, ny, nz float64
+	for i := range ring {
+		c, d := ring[i], ring[(i+1)%len(ring)]
+		nx += float64((c.Y - d.Y) * (c.Z + d.Z))
+		ny += float64((c.Z - d.Z) * (c.X + d.X))
+		nz += float64((c.X - d.X) * (c.Y + d.Y))
+	}
+	return math.V3(math.Scalar(nx), math.Scalar(ny), math.Scalar(nz))
+}
+
+// blendSpanProvenance names an exact blend span by its generating edge and span ordinal
+// (ADR-0043), mirroring filletEdgeProvenance.
+func blendSpanProvenance(e *topo.Edge, i int) topo.Lineage {
+	return topo.NewLineage(append(e.Lineage().Tokens(), topo.Tok("fillet", "blend", i))...)
 }

--- a/kernel/ops/fillet_varying_test.go
+++ b/kernel/ops/fillet_varying_test.go
@@ -9,18 +9,17 @@ import (
 
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
 )
 
-// The variable-radius fillet (M09-F01 PBI-099, #323): the blend is a generalized
-// cone built as exactly planar trapezoids between rulings, so the result's
-// tessellated volume is closed-form in the chord count.
+// The variable-radius fillet (M09-F01 PBI-099, #323; exact since #1606): the blend is the
+// EXACT rational ruled surface between the end cross-sections — an oblique circular cone for a
+// linear taper — so the removed volume follows the smooth-blend integral, and the only error in
+// the measured value is the tessellator's chordal deviation on the curved faces.
 
-// varyingNotchFactor is the cross-section fraction of r² a chorded 90° fillet
-// removes: the square corner r² minus the K-chord fan (K·r²/2·sin(π/2/K)),
-// with K = filletChordsPerTurn/4 chords over the quarter turn.
-func varyingNotchFactor(k int) float64 {
-	return 1 - float64(k)/2*stdmath.Sin(stdmath.Pi/2/float64(k))
-}
+// smoothNotchFactor is the cross-section fraction of r² a smooth 90° fillet removes: the square
+// corner r² minus the quarter disc.
+func smoothNotchFactor() float64 { return 1 - stdmath.Pi/4 }
 
 // TestFilletVaryingRadiusVolume rounds one vertical edge of a 2×2×2 box from
 // r=0.3 at one end to r=0.6 at the other. The removed volume is the exact
@@ -36,15 +35,33 @@ func TestFilletVaryingRadiusVolume(t *testing.T) {
 	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
 		t.Fatalf("variable-filleted box not a valid solid: %+v", r)
 	}
-	if n := hasCylinderFaces(res); n != 0 {
-		t.Errorf("variable fillet produced %d cylinder faces, want 0 (planar ruling strips)", n)
+	if n := blendSurfaceFaces(res); n != 1 {
+		t.Errorf("variable fillet produced %d rational blend faces, want 1 (the exact oblique cone, #1606)", n)
 	}
-	const k = 8 // ceil((π/2) / (2π/32)) chords across the 90° wedge
-	removed := varyingNotchFactor(k) * 2 * (0.3*0.3 + 0.3*0.6 + 0.6*0.6) / 3
+	removed := smoothNotchFactor() * 2 * (0.3*0.3 + 0.3*0.6 + 0.6*0.6) / 3
 	want := 8 - removed
-	if got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume; stdmath.Abs(got-want) > 1e-9 {
-		t.Errorf("variable fillet volume = %g, want %g (exact chord geometry)", got, want)
+	// Measure at fine quality: the exact blend CONVERGES to the smooth integral as the chord
+	// tolerance tightens — the discriminating property the old C0 strips could never satisfy
+	// (they converge to the chord integral regardless of tessellation).
+	if got := ops.BodyGeometryProperties(res, fineQuality()).Volume; stdmath.Abs(got-want) > 0.03*removed {
+		t.Errorf("variable fillet volume = %g, want %g (smooth-blend integral, 3%%-of-notch band)", got, want)
 	}
+}
+
+// fineQuality is the tight tessellation the smooth-volume assertions measure at.
+func fineQuality() ops.Quality {
+	return ops.Quality{ChordTolerance: 0.002, AngleTolerance: 2 * stdmath.Pi / 180}
+}
+
+// blendSurfaceFaces counts the body's rational blend faces (the exact variable-fillet surface).
+func blendSurfaceFaces(b *topo.Body) int {
+	n := 0
+	for _, f := range b.Faces() {
+		if _, ok := f.Geometry().(geom.BSplineSurface); ok {
+			n++
+		}
+	}
+	return n
 }
 
 // TestFilletIntermediateRadiiVolume rounds one vertical edge of a 2×2×2 box with a
@@ -64,15 +81,14 @@ func TestFilletIntermediateRadiiVolume(t *testing.T) {
 	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
 		t.Fatalf("intermediate-radii box not a valid solid: %+v", r)
 	}
-	if n := hasCylinderFaces(res); n != 0 {
-		t.Errorf("intermediate-radii fillet produced %d cylinder faces, want 0 (planar strips)", n)
+	if n := blendSurfaceFaces(res); n != 2 {
+		t.Errorf("intermediate-radii fillet produced %d rational blend faces, want 2 (one exact span per radius segment, #1606)", n)
 	}
-	const k = 8 // ceil((π/2) / (2π/32)) chords across the 90° wedge
 	seg := func(ra, rb, length float64) float64 { return length * (ra*ra + ra*rb + rb*rb) / 3 }
-	removed := varyingNotchFactor(k) * (seg(0.3, 0.7, 1.0) + seg(0.7, 0.4, 1.0))
+	removed := smoothNotchFactor() * (seg(0.3, 0.7, 1.0) + seg(0.7, 0.4, 1.0))
 	want := 8 - removed
-	if got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume; stdmath.Abs(got-want) > 1e-9 {
-		t.Errorf("intermediate-radii fillet volume = %g, want %g (exact chord geometry)", got, want)
+	if got := ops.BodyGeometryProperties(res, fineQuality()).Volume; stdmath.Abs(got-want) > 0.03*removed {
+		t.Errorf("intermediate-radii fillet volume = %g, want %g (smooth-blend integral, 3%%-of-notch band)", got, want)
 	}
 }
 
@@ -131,24 +147,38 @@ func TestFilletVaryingAtSharedCornerRejected(t *testing.T) {
 	}
 }
 
-// TestFilletVaryingStripsAreTrulyPlanar: every blend face's vertices lie on its
-// reported plane (the exactness claim the volume test builds on).
-func TestFilletVaryingStripsAreTrulyPlanar(t *testing.T) {
+// TestFilletVaryingBlendIsExactAndG1 (premise inverted by #1606, audit A10): the variable
+// blend used to ship as C0 planar strips with ~11° creases; it is now the EXACT rational ruled
+// surface. Assert every boundary vertex lies exactly on the blend surface and the surface is
+// G1 across its interior (machine-precision normal continuity — it is one analytic patch).
+func TestFilletVaryingBlendIsExactAndG1(t *testing.T) {
 	box := shellBox(2, 2, 2)
 	pick := ops.EdgeFilletRadii{Key: verticalEdgeKey(t, box), R0: 0.2, R1: 0.7}
 	res, err := ops.FilletEdgesVarying(box, []ops.EdgeFilletRadii{pick})
 	if err != nil {
 		t.Fatal(err)
 	}
+	blends := 0
 	for _, f := range res.Faces() {
-		pl, ok := f.Geometry().(geom.Plane)
+		surf, ok := f.Geometry().(geom.BSplineSurface)
 		if !ok {
-			t.Fatalf("non-planar face %T in a variable fillet result", f.Geometry())
+			continue
 		}
+		blends++
 		for _, v := range f.Vertices() {
-			if d := stdmath.Abs(float64(pl.Origin.VectorTo(v.Point()).Dot(pl.Normal()))); d > 1e-9 {
-				t.Fatalf("face vertex %.12g off its plane by %g", v.Point(), d)
+			u, vv := surf.ParamAt(v.Point())
+			if d := float64(surf.PointAt(u, vv).DistanceTo(v.Point())); d > 1e-9 {
+				t.Fatalf("blend boundary vertex %.12g off the exact surface by %g", v.Point(), d)
 			}
 		}
+		for i := 1; i < 8; i++ {
+			u := float64(i) / 8
+			if dot := surf.NormalAt(u-1e-9, 0.5).Dot(surf.NormalAt(u+1e-9, 0.5)); dot < 1-1e-9 {
+				t.Fatalf("blend normal creases at u=%g: cos=%.12f (the old strips creased every ~11°)", u, dot)
+			}
+		}
+	}
+	if blends != 1 {
+		t.Fatalf("variable fillet has %d rational blend faces, want 1", blends)
 	}
 }

--- a/model/feature/fillet.go
+++ b/model/feature/fillet.go
@@ -134,7 +134,7 @@ func blendFilletEdges(in Input, body *topo.Body, keys0 [][]byte, radius float64,
 	for i, k := range keys {
 		picks[i] = ops.EdgeFilletRadii{Key: k, R0: radius, R1: radius, Cross: cross, Rho: prof.rho}
 	}
-	result, err := ops.FilletEdgesCorner(work, picks, cornerStrategy(corner), concaveFill(concave))
+	result, err := ops.FilletEdgesCornerDiag(work, picks, cornerStrategy(corner), concaveFill(concave), in.Diag)
 	if err != nil {
 		return Output{}, err
 	}
@@ -206,7 +206,7 @@ func filletBodySets(in Input, sets []FilletEdgeSet, corner FilletCornerType, con
 		return Output{}, err
 	}
 	work := planarizeFilletPicks(body, picks, feat)
-	result, err := ops.FilletEdgesCorner(work, picks, cornerStrategy(corner), concaveFill(concave))
+	result, err := ops.FilletEdgesCornerDiag(work, picks, cornerStrategy(corner), concaveFill(concave), in.Diag)
 	if err != nil {
 		return Output{}, err
 	}

--- a/model/feature/fillet_sets_test.go
+++ b/model/feature/fillet_sets_test.go
@@ -57,8 +57,9 @@ func TestFilletSetsMixedConstantRadii(t *testing.T) {
 	}
 }
 
-// TestFilletVariableSetThroughEngine rounds one vertical edge 0.3→0.6 through
-// the feature engine — the exact chord-geometry volume (planar strips).
+// TestFilletVariableSetThroughEngine rounds one vertical edge 0.3→0.6 through the feature
+// engine — the smooth-blend volume, since the variable blend is the exact rational ruled
+// surface (#1606; the pre-A10 planar strips followed the chord integral instead).
 func TestFilletVariableSetThroughEngine(t *testing.T) {
 	fs, keys := boxAndVerticalEdges(t)
 	pf := NewDressUpFeatures(fs).AddFilletSets([]FilletEdgeSet{
@@ -69,11 +70,10 @@ func TestFilletVariableSetThroughEngine(t *testing.T) {
 		t.Fatalf("variable fillet sick: %+v", pf.Health())
 	}
 	res := fs.Result()[0]
-	const k = 8 // chords across the 90° wedge at the holeFacets density
-	c := 1 - float64(k)/2*stdmath.Sin(stdmath.Pi/2/float64(k))
-	want := 8 - c*2*(0.3*0.3+0.3*0.6+0.6*0.6)/3
-	if got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume; stdmath.Abs(got-want) > 1e-9 {
-		t.Errorf("variable fillet volume = %g, want %g", got, want)
+	removed := (1 - stdmath.Pi/4) * 2 * (0.3*0.3 + 0.3*0.6 + 0.6*0.6) / 3
+	want := 8 - removed
+	if got := ops.BodyGeometryProperties(res, fineFilletQuality()).Volume; stdmath.Abs(got-want) > 0.03*removed {
+		t.Errorf("variable fillet volume = %g, want %g (smooth blend, 3%%-of-notch band)", got, want)
 	}
 	if pf.Definition().(*FilletFeature).Definition().FilletType() != 61697 {
 		t.Error("fillet type discriminator != edge fillet")
@@ -82,7 +82,7 @@ func TestFilletVariableSetThroughEngine(t *testing.T) {
 
 // TestFilletRadiusPointsThroughEngine rounds one vertical edge with an intermediate
 // radius stop (0.3 → 0.7 at T=0.5 → 0.4) through the feature engine — the per-segment
-// chord-geometry volume (#695).
+// smooth-blend volume (#695, exact spans since #1606).
 func TestFilletRadiusPointsThroughEngine(t *testing.T) {
 	fs, keys := boxAndVerticalEdges(t)
 	pf := NewDressUpFeatures(fs).AddFilletSets([]FilletEdgeSet{{
@@ -99,13 +99,18 @@ func TestFilletRadiusPointsThroughEngine(t *testing.T) {
 	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
 		t.Fatalf("radius-points fillet not a valid solid: %+v", r)
 	}
-	const k = 8 // chords across the 90° wedge at the holeFacets density
-	c := 1 - float64(k)/2*stdmath.Sin(stdmath.Pi/2/float64(k))
 	seg := func(ra, rb float64) float64 { return 1.0 * (ra*ra + ra*rb + rb*rb) / 3 }
-	want := 8 - c*(seg(0.3, 0.7)+seg(0.7, 0.4))
-	if got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume; stdmath.Abs(got-want) > 1e-9 {
-		t.Errorf("radius-points fillet volume = %g, want %g", got, want)
+	removed := (1 - stdmath.Pi/4) * (seg(0.3, 0.7) + seg(0.7, 0.4))
+	want := 8 - removed
+	if got := ops.BodyGeometryProperties(res, fineFilletQuality()).Volume; stdmath.Abs(got-want) > 0.03*removed {
+		t.Errorf("radius-points fillet volume = %g, want %g (smooth blend, 3%%-of-notch band)", got, want)
 	}
+}
+
+// fineFilletQuality is the tight tessellation the smooth-blend volume brackets measure at (the
+// exact blend converges to the smooth integral as the chord tolerance tightens, #1606).
+func fineFilletQuality() ops.Quality {
+	return ops.Quality{ChordTolerance: 0.002, AngleTolerance: 2 * stdmath.Pi / 180}
 }
 
 // TestFilletVariableSetNeedsOneEdge: a variable set over two edges is a


### PR DESCRIPTION
## What

Variable-radius and rho-conic fillet blends are now the **exact degree (2,1) rational ruled surface** between their cross-section profiles instead of C0 polyhedral strips with ~11° creases. The audit's "cone frustum" hint refined: the linear-taper blend is an *oblique* circular cone (arc centres walk the dihedral bisector), not a right-circular `geom.Cone` — but every arc/conic section is a single rational quadratic (profile turn < π), so the ruled NURBS represents the blend exactly.

- `geom.NewConicSectionCurve` / `NewRuledSectionBlend` (+ general `NewRuledArcBlend`): exactness (isolines ARE the circles, 1e-12), run-out apex degeneracy, machine-precision G1 across rational segments.
- One exact span per radius segment (piecewise-linear laws included); boundaries reuse the true section curves so end caps and neighbours weld curve-for-curve; winding via a Newell-vs-outward probe mirroring the constant path.
- Residual strip fallback (G2-quintic sections; miter/blend-terminated variable ends) records **`CodeFilletFacetedBlend` Defect** through the A5 plumbing — acceptance criterion "no silent C0 where smooth is advertised".
- Volume premises move from the chord integral to the smooth integral `(1−π/4)·∫r²`, measured at fine quality where the exact blend **converges** (strips never did); planar-strips test inverted into exact-and-G1.
- archguard walkers skip dot-directories (agent worktrees under `.claude/` carry full repo copies).

## Tests

Red-verified premise inversions + new exactness/G1/run-out suites; full repo suite + golangci-lint green.

## Live

Variable fillet (3→12 mm) committed through the wire on the running app — healthy, and the screenshot shows a perfectly smooth tapered blend with zero shading bands (the strips' facet banding is gone).

Closes #1606

🤖 Generated with [Claude Code](https://claude.com/claude-code)