### PR TITLE
M40 G4/G5/G6: adopt builtin min/max + Clamp, slices.Contains, shared Lerp

### DIFF
--- a/addin/router/bodies.go
+++ b/addin/router/bodies.go
@@ -5,6 +5,7 @@ package router
 import (
 	"encoding/json"
 	"fmt"
+	stdmath "math"
 
 	"oblikovati.org/addin/modelaccess"
 	"oblikovati.org/api/types"
@@ -189,17 +190,10 @@ func shellInfo(i int, sh *topo.Shell, q ops.Quality) wire.FaceShellInfo {
 	return wire.FaceShellInfo{
 		Index: i, Closed: sh.IsClosed(), Void: sh.IsClosed() && vol < 0,
 		Faces: len(sh.Faces()), Edges: len(sh.Edges()),
-		Volume:   absFloat(vol),
+		Volume:   stdmath.Abs(vol),
 		RangeBox: boxSpan(box),
 		Key:      string(sh.ReferenceKey()), TransientKey: sh.ID(),
 	}
-}
-
-func absFloat(v float64) float64 {
-	if v < 0 {
-		return -v
-	}
-	return v
 }
 
 func boxSpan(b math.Box) []float64 {

--- a/app/browser_timeline_test.go
+++ b/app/browser_timeline_test.go
@@ -3,6 +3,7 @@
 package app
 
 import (
+	"slices"
 	"testing"
 
 	"oblikovati.org/model/feature"
@@ -16,16 +17,6 @@ func childrenKinds(n BrowserNode) []string {
 		kinds[i] = c.Kind
 	}
 	return kinds
-}
-
-// topLevelKind reports whether the part root has a direct child of the given kind.
-func containsLabel(labels []string, want string) bool {
-	for _, l := range labels {
-		if l == want {
-			return true
-		}
-	}
-	return false
 }
 
 func hasTopLevelKind(root BrowserNode, kind string) bool {
@@ -126,7 +117,7 @@ func TestToggleSketchSharedRoundTripsThroughMenu(t *testing.T) {
 		t.Error("shared sketch should be top level after toggle")
 	}
 	labels := menuLabels(BrowserMenu(s, findNode(t, root, "sketch")))
-	if !containsLabel(labels, "Unshare Sketch") {
+	if !slices.Contains(labels, "Unshare Sketch") {
 		t.Errorf("shared sketch menu = %v, want an Unshare Sketch entry", labels)
 	}
 

--- a/app/continuity_check_tool.go
+++ b/app/continuity_check_tool.go
@@ -120,7 +120,7 @@ func continuityOverlay(rep analysis.ContinuityReport, at func(float64) math.Poin
 // continuitySeverity maps one sample's deviations to [0,1] — the worst of a 0.1mm gap, a 1° normal
 // break, or a 50% curvature jump reads as fully discontinuous.
 func continuitySeverity(s analysis.ContinuitySample) float64 {
-	return clampUnit(max(s.Gap/0.1, s.NormalDeg/1.0, s.CurvPct/50.0))
+	return math.Clamp01(max(s.Gap/0.1, s.NormalDeg/1.0, s.CurvPct/50.0))
 }
 
 // severityColor blends green (0, continuous) to red (1, discontinuous).
@@ -133,6 +133,3 @@ func continuitySummary(rep analysis.ContinuityReport) string {
 	return fmt.Sprintf("Continuity — G0 gap max %.4g (avg %.4g), G1 angle max %.3f° (avg %.3f°), G2 curvature max %.1f%% (avg %.1f%%)",
 		rep.MaxGap, rep.AvgGap, rep.MaxNormalDeg, rep.AvgNormalDeg, rep.MaxCurvPct, rep.AvgCurvPct)
 }
-
-// clampUnit clamps x to [0,1].
-func clampUnit(x float64) float64 { return max(0, min(1, x)) }

--- a/app/continuity_check_tool_test.go
+++ b/app/continuity_check_tool_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"oblikovati.org/math"
+
 	"oblikovati.org/kernel/topo"
 )
 
@@ -95,8 +97,8 @@ func TestContinuitySeverityHelpers(t *testing.T) {
 		in, want float64
 	}{{-1, 0}, {0.4, 0.4}, {2, 1}}
 	for _, c := range cases {
-		if got := clampUnit(c.in); got != c.want {
-			t.Errorf("clampUnit(%g) = %g, want %g", c.in, got, c.want)
+		if got := math.Clamp01(c.in); got != c.want {
+			t.Errorf("math.Clamp01(%g) = %g, want %g", c.in, got, c.want)
 		}
 	}
 	// A mid-severity sample produces a colour between green and red.

--- a/app/drawing_view_tools.go
+++ b/app/drawing_view_tools.go
@@ -423,13 +423,6 @@ func (t *DetailViewTool) Params() ToolParams {
 	}
 }
 
-func maxf64(a, b float64) float64 {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 // breakOrientations is the orientation choice for the Break View tool (index → orientation).
 var breakOrientations = []struct {
 	label  string
@@ -552,7 +545,7 @@ func viewCentreRegionMM(s *Session, parent string) (cx, cy, r float64, ok bool) 
 	if !has {
 		return 0, 0, 0, false
 	}
-	return (minX + maxX) / 2, (minY + maxY) / 2, 0.4 * maxf64(maxX-minX, maxY-minY), true
+	return (minX + maxX) / 2, (minY + maxY) / 2, 0.4 * max(maxX-minX, maxY-minY), true
 }
 
 // SliceViewTool cuts a zero-thickness slice through a base view's horizontal/vertical centreline.

--- a/app/feature_preview.go
+++ b/app/feature_preview.go
@@ -413,14 +413,14 @@ func sigEqual(a, b faceSig) bool {
 		return false
 	}
 	if a.kind == 0 {
-		return a.centroid.IsEqualTo(b.centroid, 1e-4) && absVal(a.area-b.area) <= 1e-3*maxVal(a.area, b.area)+1e-9
+		return a.centroid.IsEqualTo(b.centroid, 1e-4) && stdmath.Abs(a.area-b.area) <= 1e-3*max(a.area, b.area)+1e-9
 	}
-	return a.dir.IsEqualTo(b.dir, 1e-4) && a.anchor.IsEqualTo(b.anchor, 1e-4) && absVal(a.r1-b.r1) <= 1e-4 && absVal(a.r2-b.r2) <= 1e-4
+	return a.dir.IsEqualTo(b.dir, 1e-4) && a.anchor.IsEqualTo(b.anchor, 1e-4) && stdmath.Abs(a.r1-b.r1) <= 1e-4 && stdmath.Abs(a.r2-b.r2) <= 1e-4
 }
 
 // signNorm flips v so its dominant component is positive (a surface and its reverse share a sig).
 func signNorm(v math.Vector3) math.Vector3 {
-	ax, ay, az := absVal(v.X), absVal(v.Y), absVal(v.Z)
+	ax, ay, az := stdmath.Abs(v.X), stdmath.Abs(v.Y), stdmath.Abs(v.Z)
 	if (ax >= ay && ax >= az && v.X < 0) || (ay > ax && ay >= az && v.Y < 0) || (az > ax && az > ay && v.Z < 0) {
 		return v.Scale(-1)
 	}
@@ -453,19 +453,6 @@ func faceAreaCentroid(f *topo.Face) (math.Point3, float64) {
 		return math.P3(0, 0, 0), 0
 	}
 	return math.P3(cx/area, cy/area, cz/area), area
-}
-
-func absVal(x float64) float64 {
-	if x < 0 {
-		return -x
-	}
-	return x
-}
-func maxVal(a, b float64) float64 {
-	if a > b {
-		return a
-	}
-	return b
 }
 
 // previewBodyFill wraps a body mesh as a translucent, on-top triangle item — drawn ignoring

--- a/app/feature_preview_test.go
+++ b/app/feature_preview_test.go
@@ -3,6 +3,7 @@
 package app
 
 import (
+	stdmath "math"
 	"testing"
 
 	"oblikovati.org/kernel/ops"
@@ -222,11 +223,11 @@ func TestFaceSigHelpers(t *testing.T) {
 	if !a.IsEqualTo(b, 1e-9) {
 		t.Errorf("axisFoot not invariant along axis: %v vs %v", a, b)
 	}
-	if got := maxVal(2, 5); got != 5 {
-		t.Errorf("maxVal(2,5) = %g, want 5", got)
+	if got := max(2.0, 5.0); got != 5 {
+		t.Errorf("max(2,5) = %g, want 5", got)
 	}
-	if got := absVal(-3); got != 3 {
-		t.Errorf("absVal(-3) = %g, want 3", got)
+	if got := stdmath.Abs(-3); got != 3 {
+		t.Errorf("stdmath.Abs(-3) = %g, want 3", got)
 	}
 
 	// Two freeform sigs (kind 0) with equal area+centroid match; differing area does not.

--- a/app/highlight_set.go
+++ b/app/highlight_set.go
@@ -4,6 +4,7 @@ package app
 
 import (
 	"fmt"
+	"slices"
 
 	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/topo"
@@ -34,7 +35,7 @@ func (h *HighlightSet) SetColor(c types.Color) { h.color = c }
 // AddItems appends reference strings, ignoring blanks and duplicates.
 func (h *HighlightSet) AddItems(refs ...string) {
 	for _, r := range refs {
-		if r != "" && !containsRef(h.refs, r) {
+		if r != "" && !slices.Contains(h.refs, r) {
 			h.refs = append(h.refs, r)
 		}
 	}
@@ -164,13 +165,4 @@ func findVertex(bodies []*topo.Body, key []byte) (Selectable, bool) {
 		}
 	}
 	return nil, false
-}
-
-func containsRef(refs []string, r string) bool {
-	for _, x := range refs {
-		if x == r {
-			return true
-		}
-	}
-	return false
 }

--- a/app/point_cloud_render.go
+++ b/app/point_cloud_render.go
@@ -154,23 +154,9 @@ func projectBoxToScreen(box math.Box, cam scene.Camera) (screenBox, bool) {
 			fully = false
 		}
 		if ok {
-			r.minX, r.minY = minOf(r.minX, x), minOf(r.minY, y)
-			r.maxX, r.maxY = maxOf(r.maxX, x), maxOf(r.maxY, y)
+			r.minX, r.minY = min(r.minX, x), min(r.minY, y)
+			r.maxX, r.maxY = max(r.maxX, x), max(r.maxY, y)
 		}
 	}
 	return r, fully
-}
-
-func minOf(a, b float64) float64 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func maxOf(a, b float64) float64 {
-	if a > b {
-		return a
-	}
-	return b
 }

--- a/app/raypicker.go
+++ b/app/raypicker.go
@@ -473,18 +473,11 @@ func closestRaySegParams(dir, e, r math.Vector3, eLen float64) (s, u float64) {
 	}
 	switch u = (bDot*s + f) / eLen; {
 	case u < 0:
-		u, s = 0, clampNonNeg(-c)
+		u, s = 0, max(0, -c)
 	case u > 1:
-		u, s = 1, clampNonNeg(bDot-c)
+		u, s = 1, max(0, bDot-c)
 	}
 	return s, u
-}
-
-func clampNonNeg(x float64) float64 {
-	if x < 0 {
-		return 0
-	}
-	return x
 }
 
 // nearestPlane returns the closest origin work plane whose display square the ray

--- a/app/region_pick.go
+++ b/app/region_pick.go
@@ -116,7 +116,7 @@ type screenRect struct{ minX, minY, maxX, maxY float64 }
 
 // orderedRect builds a normalized rectangle from two opposite corners.
 func orderedRect(x0, y0, x1, y1 float64) screenRect {
-	return screenRect{minF(x0, x1), minF(y0, y1), maxF(x0, x1), maxF(y0, y1)}
+	return screenRect{min(x0, x1), min(y0, y1), max(x0, x1), max(y0, y1)}
 }
 
 // contains reports whether r fully encloses inner (window-select test).
@@ -166,22 +166,8 @@ func (p *RayPicker) projectPointsRect(pts []math.Point3) (screenRect, bool) {
 			first = false
 			continue
 		}
-		r.minX, r.minY = minF(r.minX, sx), minF(r.minY, sy)
-		r.maxX, r.maxY = maxF(r.maxX, sx), maxF(r.maxY, sy)
+		r.minX, r.minY = min(r.minX, sx), min(r.minY, sy)
+		r.maxX, r.maxY = max(r.maxX, sx), max(r.maxY, sy)
 	}
 	return r, !first
-}
-
-func minF(a, b float64) float64 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func maxF(a, b float64) float64 {
-	if a > b {
-		return a
-	}
-	return b
 }

--- a/app/region_pick_curved_test.go
+++ b/app/region_pick_curved_test.go
@@ -3,6 +3,7 @@
 package app
 
 import (
+	"slices"
 	"testing"
 
 	"oblikovati.org/kernel/ops"
@@ -77,7 +78,7 @@ func TestPickRegionCurvedEdgeSampledNotEndpoints(t *testing.T) {
 	}
 
 	hits := p.PickRegion(rect.minX, rect.minY, rect.maxX, rect.maxY, true, edges)
-	if !containsEdge(hits, edge) {
+	if !slices.ContainsFunc(hits, func(h Selectable) bool { eh, ok := h.(EdgeHandle); return ok && eh.Edge == edge }) {
 		t.Fatalf("crossing over a curved rim's mid-span did not select it (got %d hits) — sampling regressed", len(hits))
 	}
 }
@@ -101,20 +102,10 @@ func TestPickRegionCurvedEdgeWindowNeedsWholeSpan(t *testing.T) {
 	// the far side of the rim falls outside it.
 	minX, maxX := midX-12, midX+12
 
-	if got := p.PickRegion(minX, -1e6, maxX, 1e6, true, edges); !containsEdge(got, edge) {
+	if got := p.PickRegion(minX, -1e6, maxX, 1e6, true, edges); !slices.ContainsFunc(got, func(h Selectable) bool { eh, ok := h.(EdgeHandle); return ok && eh.Edge == edge }) {
 		t.Fatalf("crossing over part of the rim should select it, got %d hits", len(got))
 	}
-	if got := p.PickRegion(minX, -1e6, maxX, 1e6, false, edges); containsEdge(got, edge) {
+	if got := p.PickRegion(minX, -1e6, maxX, 1e6, false, edges); slices.ContainsFunc(got, func(h Selectable) bool { eh, ok := h.(EdgeHandle); return ok && eh.Edge == edge }) {
 		t.Error("window over only part of the rim must NOT select it (the rim extends outside the band)")
 	}
-}
-
-// containsEdge reports whether hits include the given edge.
-func containsEdge(hits []Selectable, e *topo.Edge) bool {
-	for _, h := range hits {
-		if eh, ok := h.(EdgeHandle); ok && eh.Edge == e {
-			return true
-		}
-	}
-	return false
 }

--- a/app/sheet_metal_tools_exercise_test.go
+++ b/app/sheet_metal_tools_exercise_test.go
@@ -3,6 +3,7 @@
 package app
 
 import (
+	stdmath "math"
 	"testing"
 
 	gmath "oblikovati.org/math"
@@ -37,18 +38,11 @@ func lineSketch(part *compdef.PartComponentDefinition, a, b gmath.Point2) Sketch
 func verticalEdge(s *Session, part *compdef.PartComponentDefinition) (EdgeHandle, bool) {
 	for _, e := range part.Features().Result()[0].Edges() {
 		a, b := e.StartVertex().Point(), e.EndVertex().Point()
-		if abs(a.X-b.X) < 1e-6 && abs(a.Y-b.Y) < 1e-6 && abs(a.Z-b.Z) > 1e-6 {
+		if stdmath.Abs(a.X-b.X) < 1e-6 && stdmath.Abs(a.Y-b.Y) < 1e-6 && stdmath.Abs(a.Z-b.Z) > 1e-6 {
 			return EdgeHandle{Edge: e}, true
 		}
 	}
 	return EdgeHandle{}, false
-}
-
-func abs(v float64) float64 {
-	if v < 0 {
-		return -v
-	}
-	return v
 }
 
 // wantDraftReady asserts a commit-ready tool builds a non-nil draft — the contract the

--- a/app/sketch_pick_index.go
+++ b/app/sketch_pick_index.go
@@ -105,20 +105,10 @@ func buildPickIndex(sk *sketch.Sketch, count int) *sketchPickIndex {
 }
 
 func (idx *sketchPickIndex) col(x float64) int {
-	return clampCell(int((x-idx.originX)/idx.cell), idx.cols)
+	return math.Clamp(int((x-idx.originX)/idx.cell), 0, idx.cols-1)
 }
 func (idx *sketchPickIndex) row(y float64) int {
-	return clampCell(int((y-idx.originY)/idx.cell), idx.rows)
-}
-
-func clampCell(c, n int) int {
-	if c < 0 {
-		return 0
-	}
-	if c >= n {
-		return n - 1
-	}
-	return c
+	return math.Clamp(int((y-idx.originY)/idx.cell), 0, idx.rows-1)
 }
 
 // forCandidates calls visit for each segment that could be within tol of the ray:

--- a/app/sketch_region_test.go
+++ b/app/sketch_region_test.go
@@ -36,8 +36,8 @@ func TestPickSketchRegionWindowEnclosesEntities(t *testing.T) {
 	ax, ay := proj(math.P2(-1, 0))
 	bx, by := proj(math.P2(1, 0))
 	pad := 6.0
-	x0, y0 := minF(ax, bx)-pad, minF(ay, by)-pad
-	x1, y1 := maxF(ax, bx)+pad, maxF(ay, by)+pad
+	x0, y0 := min(ax, bx)-pad, min(ay, by)-pad
+	x1, y1 := max(ax, bx)+pad, max(ay, by)+pad
 
 	hits := s.pickSketchRegion(x0, y0, x1, y1, false) // window
 	if len(hits) != 1 {
@@ -84,11 +84,11 @@ func TestBoxSelectStateMachineInSketch(t *testing.T) {
 	ax, ay := proj(math.P2(-1, 0))
 	bx, by := proj(math.P2(1, 0))
 
-	s.BeginBoxSelect(minF(ax, bx)-6, minF(ay, by)-6) // editing a sketch, so this is allowed
+	s.BeginBoxSelect(min(ax, bx)-6, min(ay, by)-6) // editing a sketch, so this is allowed
 	if !s.BoxSelectActive() {
 		t.Fatal("BeginBoxSelect should start a box in the sketch editor (no RegionPicker needed)")
 	}
-	s.UpdateBoxSelect(maxF(ax, bx)+6, maxF(ay, by)+6) // L→R window enclosing the line
+	s.UpdateBoxSelect(max(ax, bx)+6, max(ay, by)+6) // L→R window enclosing the line
 	if n := s.CommitBoxSelect(0); n != 1 {
 		t.Fatalf("commit should select the enclosed line, got %d hits", n)
 	}

--- a/app/style_assign.go
+++ b/app/style_assign.go
@@ -5,6 +5,8 @@ package app
 import (
 	"fmt"
 
+	"oblikovati.org/math"
+
 	"oblikovati.org/model/style"
 	"oblikovati.org/renderer"
 )
@@ -53,19 +55,8 @@ func styleSurface(cs style.ColorStyle) renderer.Surface {
 	return renderer.Surface{
 		Albedo:    cs.Diffuse.Rgba().Array(),
 		Metallic:  0,
-		Roughness: clamp01(1 - cs.Shininess),
+		Roughness: float32(math.Clamp01(1 - cs.Shininess)),
 		Emissive:  [3]float32{em.R, em.G, em.B},
-		Opacity:   clamp01(cs.Opacity),
+		Opacity:   float32(math.Clamp01(cs.Opacity)),
 	}
-}
-
-// clamp01 clamps v to [0,1].
-func clamp01(v float64) float32 {
-	if v < 0 {
-		return 0
-	}
-	if v > 1 {
-		return 1
-	}
-	return float32(v)
 }

--- a/app/surface_deviation_tool.go
+++ b/app/surface_deviation_tool.go
@@ -4,6 +4,9 @@ package app
 
 import (
 	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/math"
 
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/model/analysis"
@@ -141,28 +144,11 @@ func deviationColor(d, tol, absMax float64) [4]float32 {
 	}
 	f := float32(0.3)
 	if absMax > tol {
-		over := (absAbs(d) - tol) / (absMax - tol)
-		f = 0.3 + 0.7*float32(clamp01dev(over))
+		over := (stdmath.Abs(d) - tol) / (absMax - tol)
+		f = 0.3 + 0.7*float32(math.Clamp01(over))
 	}
 	if d > 0 {
 		return [4]float32{f, 1 - f, 0.1, 1} // over: toward red
 	}
 	return [4]float32{0.1, 1 - f, f, 1} // under: toward blue
-}
-
-func absAbs(x float64) float64 {
-	if x < 0 {
-		return -x
-	}
-	return x
-}
-
-func clamp01dev(x float64) float64 {
-	if x < 0 {
-		return 0
-	}
-	if x > 1 {
-		return 1
-	}
-	return x
 }

--- a/app/thread_tool.go
+++ b/app/thread_tool.go
@@ -5,6 +5,8 @@ package app
 import (
 	"errors"
 
+	"oblikovati.org/math"
+
 	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/model/feature"
@@ -222,18 +224,13 @@ func (t *ThreadTool) DraftFeature(*Session) (feature.Feature, bool) {
 	})
 }
 
-// clampRange keeps an index within [0, n).
+// clampRange keeps an index within [0, n). It stays a wrapper over math.Clamp
+// (#1652) for its empty-list contract: n == 0 yields 0, not -1.
 func clampRange(i, n int) int {
 	if n == 0 {
 		return 0
 	}
-	if i < 0 {
-		return 0
-	}
-	if i >= n {
-		return n - 1
-	}
-	return i
+	return math.Clamp(i, 0, n-1)
 }
 
 // ClearFace empties the picked cylindrical face — the property panel's selector clear

--- a/app/ui_pref.go
+++ b/app/ui_pref.go
@@ -2,6 +2,8 @@
 
 package app
 
+import "oblikovati.org/math"
+
 // User-facing UI scale surface (#1232 follow-up: icons/text too small on high-resolution
 // monitors). The session owns the persisted FontScale/IconScale preferences; the head reads
 // them live each frame (font scale → ImGui style.FontScaleMain, icon scale → icon rasterization
@@ -27,7 +29,7 @@ func (s *Session) UIFontScale() float64 {
 // SetUIFontScale clamps v to [minUIScale, maxUIFontScale] and persists it to the user's
 // options file. Out-of-range and non-positive inputs are clamped, never rejected.
 func (s *Session) SetUIFontScale(v float64) error {
-	s.appOptions.UI.FontScale = clampScale(v, minUIScale, maxUIFontScale)
+	s.appOptions.UI.FontScale = math.Clamp(v, minUIScale, maxUIFontScale)
 	return s.saveOptions()
 }
 
@@ -39,7 +41,7 @@ func (s *Session) UIIconScale() float64 {
 
 // SetUIIconScale clamps v to [minUIScale, maxUIIconScale] and persists it.
 func (s *Session) SetUIIconScale(v float64) error {
-	s.appOptions.UI.IconScale = clampScale(v, minUIScale, maxUIIconScale)
+	s.appOptions.UI.IconScale = math.Clamp(v, minUIScale, maxUIIconScale)
 	return s.saveOptions()
 }
 
@@ -48,18 +50,6 @@ func (s *Session) SetUIIconScale(v float64) error {
 func scaleOrDefault(v float64) float64 {
 	if v <= 0 {
 		return 1
-	}
-	return v
-}
-
-// clampScale confines v to [lo, hi], treating a non-positive v as the low bound rather than
-// snapping it to 1.0 — an explicit setter call honors the user's intent up to the safe minimum.
-func clampScale(v, lo, hi float64) float64 {
-	if v < lo {
-		return lo
-	}
-	if v > hi {
-		return hi
 	}
 	return v
 }

--- a/app/work_plane_ops_test.go
+++ b/app/work_plane_ops_test.go
@@ -3,6 +3,7 @@
 package app
 
 import (
+	"slices"
 	"testing"
 
 	"oblikovati.org/api/types"
@@ -83,7 +84,7 @@ func TestPickableWorkPlanesIncludesVisibleUserPlanes(t *testing.T) {
 	wp := def.WorkPlanes().AddByPlaneAndOffset(feature.OriginXYPlane, func() float64 { return 2 })
 
 	got := s.PickableWorkPlanes()
-	if len(got) != 1 || !containsPlane(got, wp) {
+	if len(got) != 1 || !slices.Contains(got, wp) {
 		t.Fatalf("PickableWorkPlanes = %d planes, want only the visible user plane", len(got))
 	}
 
@@ -110,7 +111,7 @@ func TestHiddenOriginPlanesNotMousePickable(t *testing.T) {
 	}
 	xy := def.OriginPlanes()[0]
 	xy.SetVisible(true)
-	if got := s.PickableWorkPlanes(); len(got) != 1 || !containsPlane(got, xy) {
+	if got := s.PickableWorkPlanes(); len(got) != 1 || !slices.Contains(got, xy) {
 		t.Errorf("a shown origin plane must be mouse-pickable: got %d planes", len(got))
 	}
 }
@@ -124,22 +125,13 @@ func TestPickableWorkPlanesHonorsEditScope(t *testing.T) {
 	def.Recompute()
 
 	s.BeginEditFeature(FeatureHandle{Feature: f1})
-	if containsPlane(s.PickableWorkPlanes(), wp) {
+	if slices.Contains(s.PickableWorkPlanes(), wp) {
 		t.Error("a plane hidden by the edit scope must not be pickable")
 	}
 	s.CancelTool()
-	if !containsPlane(s.PickableWorkPlanes(), wp) {
+	if !slices.Contains(s.PickableWorkPlanes(), wp) {
 		t.Error("the plane must be pickable again after the edit closes")
 	}
-}
-
-func containsPlane(planes []*feature.WorkPlane, want *feature.WorkPlane) bool {
-	for _, p := range planes {
-		if p == want {
-			return true
-		}
-	}
-	return false
 }
 
 func TestOffsetWorkPlaneToolNotCommittableWithoutBase(t *testing.T) {

--- a/archguard/edge_allowlist_test.go
+++ b/archguard/edge_allowlist_test.go
@@ -38,7 +38,9 @@ var allowedTreeImports = map[string][]string{
 		"update", "userconfig"},
 	"command": {"model"},
 	"event":   {},
-	"script":  {"addin/dispatch", "api", "app"},
+	// script -> math: the console editor clamps cursor/column indices with the shared
+	// math.Clamp instead of re-rolling clampInt locally (G4 #1652).
+	"script": {"addin/dispatch", "api", "app", "math"},
 
 	// Persistence & small leaves.
 	"persistence": {"api", "model", "userconfig"},

--- a/crcpost/crcpost_test.go
+++ b/crcpost/crcpost_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -69,7 +70,7 @@ func TestSendRejectsNon2xxWithBodyContext(t *testing.T) {
 	if err == nil || errors.Is(err, ErrOffline) {
 		t.Fatalf("err = %v, want a non-offline error on 401", err)
 	}
-	if !contains(err.Error(), "invalid authorization token") {
+	if !strings.Contains(err.Error(), "invalid authorization token") {
 		t.Errorf("err missing body context: %v", err)
 	}
 }
@@ -91,13 +92,4 @@ func TestSendBadEndpointErrors(t *testing.T) {
 	if err == nil || errors.Is(err, ErrOffline) {
 		t.Fatalf("err = %v, want a build-request error (not offline)", err)
 	}
-}
-
-func contains(s, sub string) bool {
-	for i := 0; i+len(sub) <= len(s); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
 }

--- a/kernel/brep/boolean.go
+++ b/kernel/brep/boolean.go
@@ -191,27 +191,13 @@ func intersectIntervals(a, b [][2]float64) [][2]float64 {
 	var out [][2]float64
 	for _, x := range a {
 		for _, y := range b {
-			lo, hi := maxf(x[0], y[0]), minf(x[1], y[1])
+			lo, hi := max(x[0], y[0]), min(x[1], y[1])
 			if hi > lo {
 				out = append(out, [2]float64{lo, hi})
 			}
 		}
 	}
 	return out
-}
-
-func maxf(a, b float64) float64 {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-func minf(a, b float64) float64 {
-	if a < b {
-		return a
-	}
-	return b
 }
 
 // selectFaces splits each face by its imprints and keeps the material sub-faces this

--- a/kernel/brep/boolean_geom.go
+++ b/kernel/brep/boolean_geom.go
@@ -141,7 +141,7 @@ func collinearEdgeSpans(o2 math.Point2, d2 math.Vector2, f planarFace) [][2]floa
 			}
 			ta := o2.VectorTo(a).Dot(d2) / lenSq
 			tb := o2.VectorTo(b).Dot(d2) / lenSq
-			out = append(out, [2]float64{minf(ta, tb), maxf(ta, tb)})
+			out = append(out, [2]float64{min(ta, tb), max(ta, tb)})
 		}
 	}
 	return out

--- a/kernel/brep/curved_halfspace_uv_arrangement.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement.go
@@ -699,7 +699,7 @@ func perpDistToSeg(p, a, b math.Point2) float64 {
 	if l2 < arrTol*arrTol {
 		return float64(p.DistanceTo(a))
 	}
-	t := clamp01(float64(a.VectorTo(p).Dot(ab)) / l2)
+	t := math.Clamp01(float64(a.VectorTo(p).Dot(ab)) / l2)
 	return float64(p.DistanceTo(a.TranslateBy(ab.Scale(math.Scalar(t)))))
 }
 
@@ -710,18 +710,7 @@ func projFraction(p, a, b math.Point2) float64 {
 	if l2 < arrTol*arrTol {
 		return 0
 	}
-	return clamp01(float64(a.VectorTo(p).Dot(ab)) / l2)
-}
-
-// clamp01 clamps t to [0,1].
-func clamp01(t float64) float64 {
-	if t < 0 {
-		return 0
-	}
-	if t > 1 {
-		return 1
-	}
-	return t
+	return math.Clamp01(float64(a.VectorTo(p).Dot(ab)) / l2)
 }
 
 // emitLoopEdges re-emits a (u,v) boundary loop as a chain of exact analytic loopEdges: recover each dedge's

--- a/kernel/brep/curved_halfspace_uv_arrangement.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement.go
@@ -387,8 +387,8 @@ func interiorOfCell(cell Face2D) (math.Point2, bool) {
 	scan := func(lo, hi math.Point2, n int) {
 		for i := 0; i <= n; i++ {
 			for j := 0; j <= n; j++ {
-				p := math.P2(lerp(float64(lo.X), float64(hi.X), float64(i)/float64(n)),
-					lerp(float64(lo.Y), float64(hi.Y), float64(j)/float64(n)))
+				p := math.P2(math.Lerp(float64(lo.X), float64(hi.X), float64(i)/float64(n)),
+					math.Lerp(float64(lo.Y), float64(hi.Y), float64(j)/float64(n)))
 				if d := cellEdgeClearance(p, cell); d > bestDist && insideCell(p, cell) {
 					best, bestDist = p, d
 				}
@@ -467,7 +467,7 @@ func interiorPointOf(poly []math.Point2) (math.Point2, bool) {
 		a, b := poly[i], poly[(i+1)%len(poly)]
 		mid := math.P2((float64(a.X)+float64(b.X))/2, (float64(a.Y)+float64(b.Y))/2)
 		for _, f := range []float64{1e-3, 1e-2, 0.1, 0.5} {
-			p := math.P2(lerp(float64(mid.X), float64(c.X), f), lerp(float64(mid.Y), float64(c.Y), f))
+			p := math.P2(math.Lerp(float64(mid.X), float64(c.X), f), math.Lerp(float64(mid.Y), float64(c.Y), f))
 			if pointInPolygon2D(p, poly) {
 				return p, true
 			}
@@ -485,9 +485,6 @@ func centroidOf(poly []math.Point2) math.Point2 {
 	n := float64(len(poly))
 	return math.P2(sx/n, sy/n)
 }
-
-// lerp linearly interpolates from a to b by fraction f.
-func lerp(a, b, f float64) float64 { return a + f*(b-a) }
 
 // seamWeld grid (matches the arrangement welder, arrTol/tjTol family) used to identify (u,v) boundary
 // vertices, with the azimuth seam folded: u=2π is the SAME ruling as u=0, so both weld to one vertex.
@@ -686,8 +683,8 @@ func recoverEdge(d dedge, segs []uvSeg) (recoveredEdge, bool) {
 	s := segs[best]
 	re := recoveredEdge{kind: s.kind, curve: s.curve, a: d.a, b: d.b}
 	if s.kind == segImprint {
-		re.tA = lerp(s.tA, s.tB, projFraction(d.a, s.a, s.b))
-		re.tB = lerp(s.tA, s.tB, projFraction(d.b, s.a, s.b))
+		re.tA = math.Lerp(s.tA, s.tB, projFraction(d.a, s.a, s.b))
+		re.tB = math.Lerp(s.tA, s.tB, projFraction(d.b, s.a, s.b))
 	}
 	return re, true
 }

--- a/kernel/exchange/dwg/r2004_test.go
+++ b/kernel/exchange/dwg/r2004_test.go
@@ -71,13 +71,6 @@ func TestParseR2004ContainerCorpus(t *testing.T) {
 	}
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // TestLogicalSectionOnR2000Rejected guards the version branch: asking a flat R2000
 // file for a named logical section is a programming error and must be reported.
 func TestLogicalSectionOnR2000Rejected(t *testing.T) {

--- a/kernel/exchange/e57fmt/paged.go
+++ b/kernel/exchange/e57fmt/paged.go
@@ -32,7 +32,7 @@ func (p *pagedFile) readLogical(phys uint64, n uint64) ([]byte, uint64, error) {
 	for uint64(len(out)) < n {
 		pageStart := (pos / p.pageSize) * p.pageSize
 		payloadEnd := pageStart + p.payloadPerPage()
-		take := minU64(payloadEnd-pos, n-uint64(len(out)))
+		take := min(payloadEnd-pos, n-uint64(len(out)))
 		if pos+take > uint64(len(p.data)) {
 			return nil, 0, fmt.Errorf("e57fmt: truncated reading %d logical bytes at physical %d (file is %d bytes)", n, phys, len(p.data))
 		}
@@ -43,11 +43,4 @@ func (p *pagedFile) readLogical(phys uint64, n uint64) ([]byte, uint64, error) {
 		}
 	}
 	return out, pos, nil
-}
-
-func minU64(a, b uint64) uint64 {
-	if a < b {
-		return a
-	}
-	return b
 }

--- a/kernel/exchange/step/part21/lexer_test.go
+++ b/kernel/exchange/step/part21/lexer_test.go
@@ -2,7 +2,10 @@
 
 package part21
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // lexAll drains the lexer into a slice, failing the test on a lex error.
 func lexAll(t *testing.T, src string) []Token {
@@ -99,17 +102,7 @@ func TestLexErrorPositionTracked(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if got := err.Error(); got == "" || !contains(got, "2:3") {
+	if got := err.Error(); got == "" || !strings.Contains(got, "2:3") {
 		t.Errorf("error %q should cite position 2:3", got)
 	}
-}
-
-// contains is a tiny substring helper (avoids importing strings in the test).
-func contains(s, sub string) bool {
-	for i := 0; i+len(sub) <= len(s); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
 }

--- a/kernel/geom/bridge_surface.go
+++ b/kernel/geom/bridge_surface.go
@@ -60,7 +60,7 @@ func bridgeNet(ca, cb BSplineCurve) (BSplineSurface, error) {
 		ctrl[i] = make([]math.Point3, bridgeVRows)
 		w[i] = make([]float64, bridgeVRows)
 		for r := 0; r < bridgeVRows; r++ {
-			ctrl[i][r] = lerpP(ca.Ctrl[i], cb.Ctrl[i], float64(r)/float64(bridgeVRows-1))
+			ctrl[i][r] = ca.Ctrl[i].Lerp(cb.Ctrl[i], float64(r)/float64(bridgeVRows-1))
 			w[i][r] = 1
 		}
 	}

--- a/kernel/geom/coons_fill.go
+++ b/kernel/geom/coons_fill.go
@@ -81,17 +81,12 @@ func CoonsFill(c0, c1, d0, d1 BSplineCurve) (BSplineSurface, error) {
 // (i,j), minus the bilinear corner term — the discrete Coons formula.
 func coonsControl(c0, c1, d0, d1 BSplineCurve, i, j int, a, b float64) math.Point3 {
 	nu := len(c0.Ctrl)
-	lc := lerpP(c0.Ctrl[i], c1.Ctrl[i], b)        // (1−b)c0[i] + b·c1[i]
-	ld := lerpP(d0.Ctrl[j], d1.Ctrl[j], a)        // (1−a)d0[j] + a·d1[j]
-	bottom := lerpP(c0.Ctrl[0], c0.Ctrl[nu-1], a) // bilinear corner blend along v=0
-	top := lerpP(c1.Ctrl[0], c1.Ctrl[nu-1], a)    // along v=1
-	corner := lerpP(bottom, top, b)
+	lc := c0.Ctrl[i].Lerp(c1.Ctrl[i], b)        // (1−b)c0[i] + b·c1[i]
+	ld := d0.Ctrl[j].Lerp(d1.Ctrl[j], a)        // (1−a)d0[j] + a·d1[j]
+	bottom := c0.Ctrl[0].Lerp(c0.Ctrl[nu-1], a) // bilinear corner blend along v=0
+	top := c1.Ctrl[0].Lerp(c1.Ctrl[nu-1], a)    // along v=1
+	corner := bottom.Lerp(top, b)
 	return math.P3(lc.X+ld.X-corner.X, lc.Y+ld.Y-corner.Y, lc.Z+ld.Z-corner.Z)
-}
-
-// lerpP returns (1−t)·a + t·b.
-func lerpP(a, b math.Point3, t float64) math.Point3 {
-	return math.P3(a.X+(b.X-a.X)*math.Scalar(t), a.Y+(b.Y-a.Y)*math.Scalar(t), a.Z+(b.Z-a.Z)*math.Scalar(t))
 }
 
 // grevilleAbscissae returns each control point's Greville abscissa (mean of its p covering knots),

--- a/kernel/geom/coverage_test.go
+++ b/kernel/geom/coverage_test.go
@@ -10,13 +10,13 @@ import (
 )
 
 func TestScalarHelpers(t *testing.T) {
-	if clamp01(-1) != 0 || clamp01(2) != 1 || clamp01(0.5) != 0.5 {
+	if math.Clamp01(-1) != 0 || math.Clamp01(2) != 1 || math.Clamp01(0.5) != 0.5 {
 		t.Error("clamp01")
 	}
-	if clampUnit(2) != 1 || clampUnit(-2) != -1 || clampUnit(0.25) != 0.25 {
+	if math.Clamp(2, -1, 1) != 1 || math.Clamp(-2, -1, 1) != -1 || math.Clamp(0.25, -1, 1) != 0.25 {
 		t.Error("clampUnit")
 	}
-	if clampTo(-1, 0, 1) != 0 || clampTo(2, 0, 1) != 1 || clampTo(0.5, 0, 1) != 0.5 {
+	if math.Clamp(-1, 0, 1) != 0 || math.Clamp(2, 0, 1) != 1 || math.Clamp(0.5, 0, 1) != 0.5 {
 		t.Error("clampTo")
 	}
 }
@@ -126,7 +126,7 @@ func TestIntersectParamHelpers(t *testing.T) {
 	if paramTol(0) != 1e-9 || paramTol(0.1) != 0.1 {
 		t.Error("paramTol")
 	}
-	if clampUnitParam(-0.5) != 0 || clampUnitParam(1.5) != 1 || clampUnitParam(0.5) != 0.5 {
+	if math.Clamp01(-0.5) != 0 || math.Clamp01(1.5) != 1 || math.Clamp01(0.5) != 0.5 {
 		t.Error("clampUnitParam")
 	}
 }

--- a/kernel/geom/evaluator_curve2.go
+++ b/kernel/geom/evaluator_curve2.go
@@ -97,11 +97,11 @@ func constantSpeedParam2(c Curve2, from, length float64) (float64, bool) {
 	case Line2d:
 		return from + length, true
 	case LineSegment2d:
-		return clamp01(from + length/g.Length()), true
+		return math.Clamp01(from + length/g.Length()), true
 	case Circle2d:
 		return from + length/g.Circumference(), true
 	case Arc2d:
-		return clamp01(from + length/g.Length()), true
+		return math.Clamp01(from + length/g.Length()), true
 	default:
 		return 0, false
 	}
@@ -158,7 +158,7 @@ func chordDeviation2(a, b, p math.Point2) float64 {
 	if den == 0 {
 		return a.DistanceTo(p)
 	}
-	t := clamp01(float64(a.VectorTo(p).Dot(chord)) / den)
+	t := math.Clamp01(float64(a.VectorTo(p).Dot(chord)) / den)
 	return a.TranslateBy(chord.Scale(t)).DistanceTo(p)
 }
 

--- a/kernel/geom/evaluator_curve3.go
+++ b/kernel/geom/evaluator_curve3.go
@@ -104,11 +104,11 @@ func constantSpeedParam3(c Curve3, from, length float64) (float64, bool) {
 	case Line:
 		return from + length, true
 	case LineSegment:
-		return clamp01(from + length/g.Length()), true
+		return math.Clamp01(from + length/g.Length()), true
 	case Circle:
 		return from + length/g.Circumference(), true
 	case Arc3d:
-		return clamp01(from + length/g.Length()), true
+		return math.Clamp01(from + length/g.Length()), true
 	default:
 		return 0, false
 	}
@@ -189,7 +189,7 @@ func chordDeviation3(a, b, p math.Point3) float64 {
 	if den == 0 {
 		return a.DistanceTo(p)
 	}
-	t := clamp01(float64(a.VectorTo(p).Dot(chord)) / den)
+	t := math.Clamp01(float64(a.VectorTo(p).Dot(chord)) / den)
 	return a.TranslateBy(chord.Scale(t)).DistanceTo(p)
 }
 

--- a/kernel/geom/evaluator_point2.go
+++ b/kernel/geom/evaluator_point2.go
@@ -37,7 +37,7 @@ func segmentParamAtPoint2(g LineSegment2d, p math.Point2) float64 {
 	if den == 0 {
 		return 0
 	}
-	return clamp01(float64(g.StartPoint.VectorTo(p).Dot(chord)) / den)
+	return math.Clamp01(float64(g.StartPoint.VectorTo(p).Dot(chord)) / den)
 }
 
 // circleParamAtPoint2 inverts the angle of p about the center; the center
@@ -157,7 +157,7 @@ func refineClosest2(c Curve2, p math.Point2, t, lo, hi float64) float64 {
 		if dg == 0 || stdmath.Abs(g) < 1e-14 { // tol:numeric — Newton denominator near-zero guard
 			return t
 		}
-		t = clampTo(t-g/dg, lo, hi)
+		t = math.Clamp(t-g/dg, lo, hi)
 	}
 	return t
 }

--- a/kernel/geom/evaluator_point3.go
+++ b/kernel/geom/evaluator_point3.go
@@ -74,7 +74,7 @@ func segmentParamAtPoint3(g LineSegment, p math.Point3) float64 {
 	if den == 0 {
 		return 0
 	}
-	return clamp01(float64(g.StartPoint.VectorTo(p).Dot(chord)) / den)
+	return math.Clamp01(float64(g.StartPoint.VectorTo(p).Dot(chord)) / den)
 }
 
 // circleParamAtPoint3 inverts the circle angle of p's in-plane direction; a
@@ -252,7 +252,7 @@ func refineClosest3(c Curve3, p math.Point3, t, lo, hi float64) float64 {
 		if dg == 0 || stdmath.Abs(g) < 1e-14 { // tol:numeric — Newton denominator near-zero guard
 			return t
 		}
-		t = clampTo(t-g/dg, lo, hi)
+		t = math.Clamp(t-g/dg, lo, hi)
 	}
 	return t
 }

--- a/kernel/geom/fair_surface.go
+++ b/kernel/geom/fair_surface.go
@@ -30,7 +30,7 @@ func FairSurface(s BSplineSurface, holdOrder int, strength float64, iterations i
 		for i := band; i < nu-band; i++ {
 			for j := band; j < nv-band; j++ {
 				avg := neighbourAverage(cur, i, j)
-				next[i][j] = lerpP(cur[i][j], avg, strength)
+				next[i][j] = cur[i][j].Lerp(avg, strength)
 			}
 		}
 		cur = next

--- a/kernel/geom/geom_internal.go
+++ b/kernel/geom/geom_internal.go
@@ -16,18 +16,6 @@ func cosSin(a float64) (cos, sin float64) {
 	return stdmath.Cos(a), stdmath.Sin(a)
 }
 
-// clamp01 constrains t to [0, 1], used to project a line parameter onto a
-// bounded segment.
-func clamp01(t float64) float64 {
-	if t < 0 {
-		return 0
-	}
-	if t > 1 {
-		return 1
-	}
-	return t
-}
-
 // wrapPositive maps an angle delta into the half-open range (0, 2π], used to
 // turn a raw end−start difference into a positive (counter-clockwise) sweep.
 func wrapPositive(delta float64) float64 {
@@ -46,29 +34,6 @@ func wrap2pi(a float64) float64 {
 		d += twoPi
 	}
 	return d
-}
-
-// clampUnit constrains x to [−1, 1] so it is a valid argument to asin/acos after
-// the rounding of a normalized-direction component.
-func clampUnit(x float64) float64 {
-	if x > 1 {
-		return 1
-	}
-	if x < -1 {
-		return -1
-	}
-	return x
-}
-
-// clampTo constrains x to [lo, hi].
-func clampTo(x, lo, hi float64) float64 {
-	if x < lo {
-		return lo
-	}
-	if x > hi {
-		return hi
-	}
-	return x
 }
 
 // signedArea2 returns twice the signed area of triangle (a, b, c). Positive

--- a/kernel/geom/intersect2d.go
+++ b/kernel/geom/intersect2d.go
@@ -29,7 +29,7 @@ func Segment2dIntersection(a, b LineSegment2d, tol float64) (pt math.Point2, s, 
 	if s < -tol || s > 1+tol || t < -tol || t > 1+tol {
 		return math.Point2{}, 0, 0, false
 	}
-	return a.PointAt(clampUnitParam(s)), clampUnitParam(s), clampUnitParam(t), true
+	return a.PointAt(math.Clamp01(s)), math.Clamp01(s), math.Clamp01(t), true
 }
 
 // paramTol resolves a non-positive tolerance to a small default for the [0,1]
@@ -39,16 +39,4 @@ func paramTol(tol float64) float64 {
 		return 1e-9 // tol:parametric — default acceptance widening for segment params s,t in [0,1]
 	}
 	return tol
-}
-
-// clampUnitParam pins a parameter into [0,1] (a crossing reported just outside the
-// range by tol resolves to the nearest endpoint).
-func clampUnitParam(x float64) float64 {
-	if x < 0 {
-		return 0
-	}
-	if x > 1 {
-		return 1
-	}
-	return x
 }

--- a/kernel/geom/intersect_surface_seed.go
+++ b/kernel/geom/intersect_surface_seed.go
@@ -131,10 +131,10 @@ func (c *ssiSeedField) seeds(leaf float64) []math.Point3 {
 // rule is the correctness (a thin loop's cell is never pruned and is split until seen).
 func (c *ssiSeedField) refine(i0, j0, i1, j1 int, leaf float64, sink *ssiSeedSink) {
 	s00, s10, s01, s11 := c.at(i0, j0), c.at(i1, j0), c.at(i0, j1), c.at(i1, j1)
-	minAbs := minOf4(stdmath.Abs(s00.f), stdmath.Abs(s10.f), stdmath.Abs(s01.f), stdmath.Abs(s11.f))
+	minAbs := min(stdmath.Abs(s00.f), stdmath.Abs(s10.f), stdmath.Abs(s01.f), stdmath.Abs(s11.f))
 	su, sv := float64(i1-i0)*c.du, float64(j1-j0)*c.dv
-	tu := maxOf4(s00.tu, s10.tu, s01.tu, s11.tu)
-	tv := maxOf4(s00.tv, s10.tv, s01.tv, s11.tv)
+	tu := max(s00.tu, s10.tu, s01.tu, s11.tu)
+	tv := max(s00.tv, s10.tv, s01.tv, s11.tv)
 	variation := ssiSeedSafety * (tu*su + tv*sv) // upper bound on |Δf| across the cell (|∇f| ≤ 1)
 	if minAbs > variation {
 		return // every interior point keeps a corner's sign: no crossing here
@@ -205,14 +205,4 @@ func (c *ssiSeedField) minCorner(i0, j0, i1, j1 int, s00, s10, s01, s11 ssiSampl
 		}
 	}
 	return c.point(bi, bj)
-}
-
-// minOf4 returns the smallest of four values.
-func minOf4(a, b, c, d float64) float64 {
-	return stdmath.Min(stdmath.Min(a, b), stdmath.Min(c, d))
-}
-
-// maxOf4 returns the largest of four values.
-func maxOf4(a, b, c, d float64) float64 {
-	return stdmath.Max(stdmath.Max(a, b), stdmath.Max(c, d))
 }

--- a/kernel/geom/intersect_surface_seed_test.go
+++ b/kernel/geom/intersect_surface_seed_test.go
@@ -93,7 +93,7 @@ func TestSSISeederBoundIsConservative(t *testing.T) {
 	res := 1 << ssiSeedMaxDepth
 	a, b := c.at(0, 0), c.at(res, res) // opposite corners of one coarse cell
 	su, sv := float64(res)*c.du, float64(res)*c.dv
-	bound := ssiSeedSafety * (maxOf4(a.tu, b.tu, a.tu, b.tu)*su + maxOf4(a.tv, b.tv, a.tv, b.tv)*sv)
+	bound := ssiSeedSafety * (max(a.tu, b.tu, a.tu, b.tu)*su + max(a.tv, b.tv, a.tv, b.tv)*sv)
 	if change := stdmath.Abs(a.f - b.f); bound < change {
 		t.Errorf("variation bound %g below the actual field change %g — prune could drop a crossing", bound, change)
 	}

--- a/kernel/geom/intersect_surface_surface_test.go
+++ b/kernel/geom/intersect_surface_surface_test.go
@@ -137,7 +137,7 @@ func TestTraceHelpersDirect(t *testing.T) {
 	if finiteOr(stdmath.Inf(1), 7) != 7 || finiteOr(3, 7) != 3 {
 		t.Error("finiteOr should fall back only for infinities")
 	}
-	if lerp(0, 10, 0.25) != 2.5 {
+	if math.Lerp(0, 10, 0.25) != 2.5 {
 		t.Error("lerp wrong")
 	}
 	if straddlesZero(1, 2) || !straddlesZero(-1, 2) || !straddlesZero(2, -1) {

--- a/kernel/geom/paramat.go
+++ b/kernel/geom/paramat.go
@@ -40,7 +40,7 @@ func (c Cone) ParamAt(q math.Point3) (u, v float64) {
 // closest point on the sphere (the radial direction from the center to q).
 func (s Sphere) ParamAt(q math.Point3) (u, v float64) {
 	d := unitOrZero(s.Center.VectorTo(q))
-	return wrap2pi(stdmath.Atan2(d.Y, d.X)), stdmath.Asin(clampUnit(d.Z))
+	return wrap2pi(stdmath.Atan2(d.Y, d.X)), stdmath.Asin(math.Clamp(d.Z, -1, 1))
 }
 
 // ParamAt returns the around-axis angle u and around-tube angle v, both in [0, 2π).

--- a/kernel/geom/query.go
+++ b/kernel/geom/query.go
@@ -35,7 +35,7 @@ func ClosestPointOnSegment(s LineSegment, p math.Point3) math.Point3 {
 	if len2 == 0 {
 		return s.StartPoint
 	}
-	return s.PointAt(clamp01(s.StartPoint.VectorTo(p).Dot(d) / len2))
+	return s.PointAt(math.Clamp01(s.StartPoint.VectorTo(p).Dot(d) / len2))
 }
 
 // DistancePointToSegment returns the distance from p to the nearest point of

--- a/kernel/geom/spiric.go
+++ b/kernel/geom/spiric.go
@@ -62,7 +62,7 @@ func (s SpiricArc) uOfV(v float64) float64 {
 	cv, sv := cosSin(v)
 	denom := s.M * (s.Torus.MajorRadius + s.Torus.MinorRadius*cv)
 	w := (s.K - s.C*s.Torus.MinorRadius*sv) / denom
-	return s.Phi + s.Branch*stdmath.Acos(clampUnit(w))
+	return s.Phi + s.Branch*stdmath.Acos(math.Clamp(w, -1, 1))
 }
 
 // UAt returns the azimuth u on this branch at tube angle v — the spiric section's single-valued u(v).

--- a/kernel/geom/threaded_cylinder.go
+++ b/kernel/geom/threaded_cylinder.go
@@ -52,7 +52,7 @@ func (t ThreadedCylinder) runout(v float64) float64 {
 	if t.Pitch <= 0 {
 		return 1
 	}
-	return stdmath.Min(clamp01((v-t.VMin)/t.Pitch), clamp01((t.VMax-v)/t.Pitch))
+	return stdmath.Min(math.Clamp01((v-t.VMin)/t.Pitch), math.Clamp01((t.VMax-v)/t.Pitch))
 }
 
 // PointAt returns the threaded surface point at (u = angle, v = axial distance).

--- a/kernel/geom/trace_surface_zero.go
+++ b/kernel/geom/trace_surface_zero.go
@@ -148,7 +148,7 @@ func bisectEdge(s Surface, f scalarField, ua, va, fa, ub, vb float64) math.Point
 	lo, hi := 0.0, 1.0
 	for k := 0; k < traceBisectIter; k++ {
 		mid := (lo + hi) / 2
-		um, vm := lerp(ua, ub, mid), lerp(va, vb, mid)
+		um, vm := math.Lerp(ua, ub, mid), math.Lerp(va, vb, mid)
 		fm := f(um, vm)
 		if fm == 0 {
 			return s.PointAt(um, vm)
@@ -160,11 +160,8 @@ func bisectEdge(s Surface, f scalarField, ua, va, fa, ub, vb float64) math.Point
 		}
 	}
 	m := (lo + hi) / 2
-	return s.PointAt(lerp(ua, ub, m), lerp(va, vb, m))
+	return s.PointAt(math.Lerp(ua, ub, m), math.Lerp(va, vb, m))
 }
-
-// lerp linearly interpolates between a and b at t.
-func lerp(a, b, t float64) float64 { return a + (b-a)*t }
 
 // chainSegments3D links marching-squares segments into ordered polylines by matching
 // shared endpoints within tolerance.

--- a/kernel/hlr/project.go
+++ b/kernel/hlr/project.go
@@ -73,7 +73,7 @@ func Project(body *topo.Body, view View, q ops.Quality) []Segment {
 	// edge-on adjacent face, which a midpoint ray can graze. Scaling it to the model size
 	// (0.5% of the bounding diagonal) makes the classification platform-stable — a grazing
 	// face sits within the bias band and is ignored, while a real occluder is far beyond it.
-	bias := maxf(2*q.ChordTolerance, 0.005*meshDiagonal(mesh)) + 1e-9
+	bias := max(2*q.ChordTolerance, 0.005*meshDiagonal(mesh)) + 1e-9
 	var segs []Segment
 	for _, e := range body.Edges() {
 		poly := ops.TessellateEdge(e, q)
@@ -135,31 +135,10 @@ func meshDiagonal(m *ops.Mesh) float64 {
 	}
 	lo, hi := m.Positions[0], m.Positions[0]
 	for _, p := range m.Positions {
-		lo = math.P3(minS(lo.X, p.X), minS(lo.Y, p.Y), minS(lo.Z, p.Z))
-		hi = math.P3(maxS(hi.X, p.X), maxS(hi.Y, p.Y), maxS(hi.Z, p.Z))
+		lo = math.P3(min(lo.X, p.X), min(lo.Y, p.Y), min(lo.Z, p.Z))
+		hi = math.P3(max(hi.X, p.X), max(hi.Y, p.Y), max(hi.Z, p.Z))
 	}
 	return float64(lo.VectorTo(hi).Length())
-}
-
-func minS(a, b math.Scalar) math.Scalar {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func maxS(a, b math.Scalar) math.Scalar {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-func maxf(a, b float64) float64 {
-	if a > b {
-		return a
-	}
-	return b
 }
 
 func unit(v math.Vector3) math.Vector3 {

--- a/kernel/hlr/section.go
+++ b/kernel/hlr/section.go
@@ -23,7 +23,7 @@ import (
 // (KindCut, always visible) and hatch lines (KindHatch) filling the cut cross-section.
 func ProjectSection(body *topo.Body, view View, q ops.Quality) []Segment {
 	mesh, _ := ops.TessellateBody(body, q)
-	bias := maxf(2*q.ChordTolerance, 0.005*meshDiagonal(mesh)) + 1e-9
+	bias := max(2*q.ChordTolerance, 0.005*meshDiagonal(mesh)) + 1e-9
 	keep := clipMeshToHalfSpace(mesh, view) // occlusion tests against the retained half only
 	segs := sectionEdges(body, view, keep, q, bias)
 	loops, cut := sectionOutline(body, view, q)

--- a/kernel/hlr/section_test.go
+++ b/kernel/hlr/section_test.go
@@ -3,6 +3,7 @@
 package hlr
 
 import (
+	stdmath "math"
 	"testing"
 
 	"oblikovati.org/kernel/ops"
@@ -49,7 +50,7 @@ func TestSectionBoxCutsHatchesAndClips(t *testing.T) {
 	// outside it would mean the removed near half leaked into the projection.
 	for _, s := range segs {
 		for _, p := range [2]math.Point2{s.A, s.B} {
-			if abs(float64(p.X)) > 1.001 || abs(float64(p.Y)) > 1.001 {
+			if stdmath.Abs(float64(p.X)) > 1.001 || stdmath.Abs(float64(p.Y)) > 1.001 {
 				t.Fatalf("segment point %v outside the cross-section — near half not clipped", p)
 			}
 		}
@@ -67,11 +68,4 @@ func TestSectionEdgesAllVisible(t *testing.T) {
 			t.Errorf("retained-half edge %v→%v hidden, want visible in a cut-away", s.A, s.B)
 		}
 	}
-}
-
-func abs(x float64) float64 {
-	if x < 0 {
-		return -x
-	}
-	return x
 }

--- a/kernel/ops/body_query.go
+++ b/kernel/ops/body_query.go
@@ -190,7 +190,7 @@ func raySegmentApproach(origin math.Point3, dir math.Vector3, a, b math.Point3) 
 	denom := aDD*cAA - bDA*bDA
 	s := 0.0
 	if denom > 1e-15 {
-		s = clamp01((bDA*dDW - aDD*eAW) / denom)
+		s = math.Clamp01((bDA*dDW - aDD*eAW) / denom)
 	}
 	onSeg := a.TranslateBy(ab.Scale(math.Scalar(s)))
 	t := float64(origin.VectorTo(onSeg).Dot(dir)) / aDD

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -235,27 +235,13 @@ func invalidBooleanVolume(op PartFeatureOperation, target, tool, body *topo.Body
 	// second boolean, too expensive for a guard — and is trivially ≥ 0 without it.
 	switch op {
 	case Join:
-		return bodyVol+tol < maxFloat(targetVol, toolVol) || bodyVol > targetVol+toolVol+tol
+		return bodyVol+tol < max(targetVol, toolVol) || bodyVol > targetVol+toolVol+tol
 	case Cut:
 		return bodyVol > targetVol+tol || bodyVol+tol < targetVol-toolVol
 	case Intersect:
-		return bodyVol > minFloat(targetVol, toolVol)+tol
+		return bodyVol > min(targetVol, toolVol)+tol
 	}
 	return false
-}
-
-func minFloat(a, b float64) float64 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func maxFloat(a, b float64) float64 {
-	if a > b {
-		return a
-	}
-	return b
 }
 
 // csgFallbackFaceLimit bounds the operand size for the invalid-result CSG fallback (see

--- a/kernel/ops/fill_nsided_test.go
+++ b/kernel/ops/fill_nsided_test.go
@@ -31,9 +31,9 @@ func edgeNeighbour(t *testing.T, a, b, center math.Point3, reach float64) *topo.
 		w[i] = []float64{1, 1, 1, 1}
 		for j := 0; j < 4; j++ {
 			s := float64(j) / 3
-			inner := lerp3(a, b, s)
-			outer := lerp3(aOut, bOut, s)
-			ctrl[i][j] = lerp3(inner, outer, float64(i)/3)
+			inner := a.Lerp(b, s)
+			outer := aOut.Lerp(bOut, s)
+			ctrl[i][j] = inner.Lerp(outer, float64(i)/3)
 		}
 	}
 	bez := []float64{0, 0, 0, 0, 1, 1, 1, 1}
@@ -42,10 +42,6 @@ func edgeNeighbour(t *testing.T, a, b, center math.Point3, reach float64) *topo.
 		t.Fatalf("edge neighbour: %v", err)
 	}
 	return surfaceFaceBody(t, srf)
-}
-
-func lerp3(a, b math.Point3, t float64) math.Point3 {
-	return math.P3(a.X+(b.X-a.X)*math.Scalar(t), a.Y+(b.Y-a.Y)*math.Scalar(t), a.Z+(b.Z-a.Z)*math.Scalar(t))
 }
 
 // polygonNeighbours builds one outward edge-neighbour per side of the regular n-gon of radius r,
@@ -117,7 +113,7 @@ func pointToSegment(p, a, b math.Point3) float64 {
 	} else if tt > 1 {
 		tt = 1
 	}
-	return float64(p.DistanceTo(lerp3(a, b, tt)))
+	return float64(p.DistanceTo(a.Lerp(b, tt)))
 }
 
 // fillInterpolatesVertices checks the fill surface passes through every n-gon vertex (the corners

--- a/kernel/ops/fillet.go
+++ b/kernel/ops/fillet.go
@@ -439,8 +439,8 @@ func rationalQuad(p0, p1, p2 math.Point3, w, t float64) math.Point3 {
 func g2Chords(c corner, in cornerInputs, k int) []math.Point3 {
 	s := shoulder(c, in)
 	ctrl := [6]math.Point3{
-		c.ta, lerp3(c.ta, s, 1.0/3), lerp3(c.ta, s, 2.0/3),
-		lerp3(s, c.tb, 1.0/3), lerp3(s, c.tb, 2.0/3), c.tb,
+		c.ta, c.ta.Lerp(s, 1.0/3), c.ta.Lerp(s, 2.0/3),
+		s.Lerp(c.tb, 1.0/3), s.Lerp(c.tb, 2.0/3), c.tb,
 	}
 	out := make([]math.Point3, k+1)
 	for j := 0; j <= k; j++ {
@@ -449,22 +449,13 @@ func g2Chords(c corner, in cornerInputs, k int) []math.Point3 {
 	return out
 }
 
-// lerp3 returns (1−t)·a + t·b.
-func lerp3(a, b math.Point3, t float64) math.Point3 {
-	return math.P3(
-		a.X+(b.X-a.X)*math.Scalar(t),
-		a.Y+(b.Y-a.Y)*math.Scalar(t),
-		a.Z+(b.Z-a.Z)*math.Scalar(t),
-	)
-}
-
 // bezier5 evaluates a quintic Bézier via de Casteljau.
 func bezier5(ctrl [6]math.Point3, t float64) math.Point3 {
 	p := ctrl
 	pts := p[:]
 	for n := 5; n > 0; n-- {
 		for i := 0; i < n; i++ {
-			pts[i] = lerp3(pts[i], pts[i+1], t)
+			pts[i] = pts[i].Lerp(pts[i+1], t)
 		}
 	}
 	return pts[0]

--- a/kernel/ops/fillet_miter.go
+++ b/kernel/ops/fillet_miter.go
@@ -93,7 +93,7 @@ func sampleMiterSeam(v math.Point3, r float64, nS math.Vector3, a1, a2 miterArm)
 	if stdmath.Abs(denom) < 1e-9 {
 		return nil, fmt.Errorf("fillet: degenerate miter (edge axis lies in the seam plane)")
 	}
-	w := stdmath.Acos(clamp(nS.Dot(a1.nF), -1, 1)) // rolling-ball wedge spanned on arm 1
+	w := stdmath.Acos(math.Clamp(nS.Dot(a1.nF), -1, 1)) // rolling-ball wedge spanned on arm 1
 	k := int(stdmath.Ceil(w / (2 * stdmath.Pi / filletChordsPerTurn)))
 	if k < 4 {
 		k = 4
@@ -111,7 +111,7 @@ func sampleMiterSeam(v math.Point3, r float64, nS math.Vector3, a1, a2 miterArm)
 // slerpVec interpolates the unit direction from a to b along the shorter great-circle arc at
 // parameter s∈[0,1] (the exact rolling-ball contact direction between two face normals).
 func slerpVec(a, b math.Vector3, s float64) math.Vector3 {
-	w := stdmath.Acos(clamp(a.Dot(b), -1, 1))
+	w := stdmath.Acos(math.Clamp(a.Dot(b), -1, 1))
 	if w < 1e-9 {
 		return a
 	}

--- a/kernel/ops/mindistance.go
+++ b/kernel/ops/mindistance.go
@@ -38,13 +38,13 @@ func segmentParams(a, e, f, c, b float64) (s, t float64) {
 		return 0, 0
 	}
 	if a <= eps { // segment 1 degenerates to a point
-		return 0, clamp01(f / e)
+		return 0, math.Clamp01(f / e)
 	}
 	if e <= eps { // segment 2 degenerates to a point
-		return clamp01(-c / a), 0
+		return math.Clamp01(-c / a), 0
 	}
 	if denom := a*e - b*b; denom > eps {
-		s = clamp01((b*f - c*e) / denom)
+		s = math.Clamp01((b*f - c*e) / denom)
 	}
 	return reclampSForT(s, (b*s+f)/e, a, b, c)
 }
@@ -52,10 +52,10 @@ func segmentParams(a, e, f, c, b float64) (s, t float64) {
 // reclampSForT re-derives s after clamping t back into [0,1] (the unclamped t left the segment).
 func reclampSForT(s, t, a, b, c float64) (float64, float64) {
 	if t < 0 {
-		return clamp01(-c / a), 0
+		return math.Clamp01(-c / a), 0
 	}
 	if t > 1 {
-		return clamp01((b - c) / a), 1
+		return math.Clamp01((b - c) / a), 1
 	}
 	return s, t
 }

--- a/kernel/ops/nurbs_interior.go
+++ b/kernel/ops/nurbs_interior.go
@@ -198,18 +198,10 @@ func regionSagitta(s geom.Surface, umin, umax, vmin, vmax float64) float64 {
 	return max
 }
 
-// bilerp bilinearly interpolates the four corners at (fu, fv) ∈ [0,1]².
+// bilerp bilinearly interpolates the four corners at (fu, fv) ∈ [0,1]²:
+// two nested [math.Point3.Lerp] passes (#1654), no bespoke arithmetic.
 func bilerp(c00, c10, c01, c11 math.Point3, fu, fv float64) math.Point3 {
-	x := lerp2(c00.X, c10.X, c01.X, c11.X, fu, fv)
-	y := lerp2(c00.Y, c10.Y, c01.Y, c11.Y, fu, fv)
-	z := lerp2(c00.Z, c10.Z, c01.Z, c11.Z, fu, fv)
-	return math.P3(x, y, z)
-}
-
-func lerp2(a00, a10, a01, a11 math.Scalar, fu, fv float64) math.Scalar {
-	bottom := float64(a00) + (float64(a10)-float64(a00))*fu
-	top := float64(a01) + (float64(a11)-float64(a01))*fu
-	return math.Scalar(bottom + (top-bottom)*fv)
+	return c00.Lerp(c10, fu).Lerp(c01.Lerp(c11, fu), fv)
 }
 
 // clearOfTrim reports whether p is inside the trim AND at least `margin` (in u and v) from the

--- a/kernel/ops/nurbs_interior.go
+++ b/kernel/ops/nurbs_interior.go
@@ -176,8 +176,10 @@ func adaptiveStep(s geom.Surface, umin, umax, vmin, vmax float64, q Quality) (st
 	return clampStep(uExt*frac, uExt), clampStep(vExt*frac, vExt)
 }
 
+// clampStep stays a wrapper over math.Clamp (#1652): it owns the derived
+// per-axis bounds [ext/maxInteriorCells, ext/minInteriorCells], not new arithmetic.
 func clampStep(step, ext float64) float64 {
-	return stdmath.Max(ext/maxInteriorCells, stdmath.Min(step, ext/minInteriorCells))
+	return math.Clamp(step, ext/maxInteriorCells, ext/minInteriorCells)
 }
 
 // regionSagitta estimates how far the surface bulges from the flat bilinear quad spanning the (u,v)

--- a/kernel/ops/oriented_box.go
+++ b/kernel/ops/oriented_box.go
@@ -99,7 +99,7 @@ func boxFlushWithFace(f *topo.Face, pts []math.Point3) (OrientedBox, bool) {
 		d := p.AsVector()
 		proj[i] = math.P2(d.Dot(u), d.Dot(v))
 		h := float64(d.Dot(w))
-		wLo, wHi = minFloat(wLo, h), maxFloat(wHi, h)
+		wLo, wHi = min(wLo, h), max(wHi, h)
 	}
 	rect, ok := minAreaRectangle(proj)
 	if !ok {
@@ -170,8 +170,8 @@ func rectAlong(hull []math.Point2, dir math.Vector2) rect2 {
 	yLo, yHi := stdmath.Inf(1), stdmath.Inf(-1)
 	for _, p := range hull {
 		x, y := float64(p.AsVector().Dot(dir)), float64(p.AsVector().Dot(perp))
-		xLo, xHi = minFloat(xLo, x), maxFloat(xHi, x)
-		yLo, yHi = minFloat(yLo, y), maxFloat(yHi, y)
+		xLo, xHi = min(xLo, x), max(xHi, x)
+		yLo, yHi = min(yLo, y), max(yHi, y)
 	}
 	corner := dir.Scale(math.Scalar(xLo)).Add(perp.Scale(math.Scalar(yLo))).AsPoint()
 	return rect2{

--- a/kernel/ops/self_intersect.go
+++ b/kernel/ops/self_intersect.go
@@ -3,6 +3,8 @@
 package ops
 
 import (
+	stdmath "math"
+
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 )
@@ -184,7 +186,7 @@ func triCoplanar(s [3]float64) bool {
 func intervalOverlap(t1 [3]math.Point3, s1 [3]float64, t2 [3]math.Point3, s2 [3]float64, line math.Vector3) (math.Point3, bool) {
 	a0, a1, pa := crossingInterval(t1, s1, line)
 	b0, b1, _ := crossingInterval(t2, s2, line)
-	lo, hi := maxFloat(a0, b0), minFloat(a1, b1)
+	lo, hi := max(a0, b0), min(a1, b1)
 	if lo+selfIntersectEps >= hi {
 		return math.Point3{}, false
 	}
@@ -239,7 +241,7 @@ func coplanarOverlap(t1, t2 [3]math.Point3, n math.Vector3) (math.Point3, bool) 
 // planeAxes picks two in-plane axes for the dominant-normal projection.
 func planeAxes(n math.Vector3) (math.Vector3, math.Vector3) {
 	ref := math.V3(1, 0, 0)
-	if abs(float64(n.X)) > abs(float64(n.Y)) && abs(float64(n.X)) > abs(float64(n.Z)) {
+	if stdmath.Abs(float64(n.X)) > stdmath.Abs(float64(n.Y)) && stdmath.Abs(float64(n.X)) > stdmath.Abs(float64(n.Z)) {
 		ref = math.V3(0, 1, 0)
 	}
 	u := n.Cross(ref)
@@ -275,7 +277,7 @@ func axisInterval(t [3][2]float64, nx, ny float64) (float64, float64) {
 	lo, hi := 1e308, -1e308
 	for _, p := range t {
 		v := nx*p[0] + ny*p[1]
-		lo, hi = minFloat(lo, v), maxFloat(hi, v)
+		lo, hi = min(lo, v), max(hi, v)
 	}
 	return lo, hi
 }
@@ -283,11 +285,4 @@ func axisInterval(t [3][2]float64, nx, ny float64) (float64, float64) {
 func triangleCenter(t [3]math.Point3) math.Point3 {
 	v := t[0].AsVector().Add(t[1].AsVector()).Add(t[2].AsVector())
 	return v.Scale(math.Scalar(1.0 / 3)).AsPoint()
-}
-
-func abs(v float64) float64 {
-	if v < 0 {
-		return -v
-	}
-	return v
 }

--- a/kernel/ops/sew.go
+++ b/kernel/ops/sew.go
@@ -151,7 +151,7 @@ func sewStampResiduals(w *weld) {
 		s0 := curve.PointAt(domainLo(curve))
 		s1 := curve.PointAt(domainHi(curve))
 		d0, d1 := alignSnapDeltas(e, s0, s1)
-		residual := maxFloat(float64(d0.Length()), float64(d1.Length()))
+		residual := max(float64(d0.Length()), float64(d1.Length()))
 		if residual <= w.tol {
 			continue
 		}
@@ -231,7 +231,7 @@ func nearestGap(e *topo.Edge, all []*topo.Edge) float64 {
 		}
 		for _, p := range []math.Point3{e.StartVertex().Point(), e.EndVertex().Point()} {
 			for _, q := range []math.Point3{o.StartVertex().Point(), o.EndVertex().Point()} {
-				best = minFloat(best, float64(p.DistanceTo(q)))
+				best = min(best, float64(p.DistanceTo(q)))
 			}
 		}
 	}

--- a/kernel/ops/sphere_cap_mesh.go
+++ b/kernel/ops/sphere_cap_mesh.go
@@ -94,7 +94,7 @@ func rimPolarAngle(sph geom.Sphere, outer3D []math.Point3, axis math.Vector3) fl
 	sum := 0.0
 	for _, p := range outer3D {
 		dir := sph.Center.VectorTo(p).Scale(math.Scalar(1 / sph.Radius))
-		sum += stdmath.Acos(clampUnit(float64(dir.Dot(axis))))
+		sum += stdmath.Acos(math.Clamp(float64(dir.Dot(axis)), -1, 1))
 	}
 	return sum / float64(len(outer3D))
 }
@@ -173,15 +173,4 @@ func centroidOf(pts []math.Point3) math.Point3 {
 	}
 	n := float64(len(pts))
 	return math.P3(math.Scalar(x/n), math.Scalar(y/n), math.Scalar(z/n))
-}
-
-// clampUnit clamps x to [−1, 1] so acos of a dot product that floated just past ±1 is finite.
-func clampUnit(x float64) float64 {
-	if x > 1 {
-		return 1
-	}
-	if x < -1 {
-		return -1
-	}
-	return x
 }

--- a/kernel/ops/surface_edit.go
+++ b/kernel/ops/surface_edit.go
@@ -184,7 +184,7 @@ func clipHalfSpace(poly []math.Point3, origin math.Point3, normal math.Vector3, 
 			out = append(out, cur)
 		}
 		if (ds < 0) != (de < 0) {
-			out = append(out, lerpToPlane(cur, nxt, ds, de))
+			out = append(out, planeCrossing(cur, nxt, ds, de))
 		}
 	}
 	return out
@@ -200,11 +200,10 @@ func keepDistance(p, origin math.Point3, normal math.Vector3, keepPositive bool)
 	return -d
 }
 
-// lerpToPlane returns the point where segment a→b crosses the cutting plane, given
-// the signed keep-distances at each end.
-func lerpToPlane(a, b math.Point3, da, db float64) math.Point3 {
-	t := da / (da - db)
-	return a.TranslateBy(a.VectorTo(b).Scale(t))
+// planeCrossing returns the point where segment a→b crosses the cutting plane,
+// given the signed keep-distances at each end.
+func planeCrossing(a, b math.Point3, da, db float64) math.Point3 {
+	return a.Lerp(b, da/(da-db))
 }
 
 // OffsetSurface offsets a single-face planar surface body by distance along its face

--- a/kernel/ops/tessellate.go
+++ b/kernel/ops/tessellate.go
@@ -241,18 +241,8 @@ func turnAngle(a, b, c math.Point3) float64 {
 	if d1.LengthSquared() == 0 || d2.LengthSquared() == 0 {
 		return 0
 	}
-	cosA := clamp(d1.Dot(d2)/(d1.Length()*d2.Length()), -1, 1)
+	cosA := math.Clamp(d1.Dot(d2)/(d1.Length()*d2.Length()), -1, 1)
 	return stdmath.Acos(cosA)
-}
-
-func clamp(x, lo, hi float64) float64 {
-	if x < lo {
-		return lo
-	}
-	if x > hi {
-		return hi
-	}
-	return x
 }
 
 // pointToSegment returns the distance from p to segment [a, b].
@@ -262,18 +252,8 @@ func pointToSegment(p, a, b math.Point3) float64 {
 	if denom < math.DefaultTolerance {
 		return p.DistanceTo(a)
 	}
-	t := clamp01(a.VectorTo(p).Dot(ab) / denom)
+	t := math.Clamp01(a.VectorTo(p).Dot(ab) / denom)
 	return p.DistanceTo(a.TranslateBy(ab.Scale(t)))
-}
-
-func clamp01(x float64) float64 {
-	if x < 0 {
-		return 0
-	}
-	if x > 1 {
-		return 1
-	}
-	return x
 }
 
 // clampSpan replaces infinite domain bounds with a finite window.

--- a/kernel/ops/torus_complement_mesh.go
+++ b/kernel/ops/torus_complement_mesh.go
@@ -57,10 +57,10 @@ func centroidUV(loop []math.Point2) (uc, vc float64) {
 // then meshes the whole window (up to the full chart minus the oval), which stays well-conditioned.
 func ovalWindow(us, vs []float64, ovalUV []math.Point2) (i0, i1, j0, j1 int) {
 	uMin, uMax, vMin, vMax := loopUVBounds(ovalUV)
-	i0 = clampIndex(lastBelow(us, uMin)-1, 0, len(us)-2)
-	i1 = clampIndex(firstAbove(us, uMax)+1, i0+1, len(us)-1)
-	j0 = clampIndex(lastBelow(vs, vMin)-1, 0, len(vs)-2)
-	j1 = clampIndex(firstAbove(vs, vMax)+1, j0+1, len(vs)-1)
+	i0 = math.Clamp(lastBelow(us, uMin)-1, 0, len(us)-2)
+	i1 = math.Clamp(firstAbove(us, uMax)+1, i0+1, len(us)-1)
+	j0 = math.Clamp(lastBelow(vs, vMin)-1, 0, len(vs)-2)
+	j1 = math.Clamp(firstAbove(vs, vMax)+1, j0+1, len(vs)-1)
 	return i0, i1, j0, j1
 }
 
@@ -125,15 +125,4 @@ func firstAbove(xs []float64, x float64) int {
 		}
 	}
 	return len(xs) - 1
-}
-
-// clampIndex folds i into [lo, hi].
-func clampIndex(i, lo, hi int) int {
-	if i < lo {
-		return lo
-	}
-	if i > hi {
-		return hi
-	}
-	return i
 }

--- a/kernel/ops/torus_complement_mesh_test.go
+++ b/kernel/ops/torus_complement_mesh_test.go
@@ -24,8 +24,8 @@ func TestComplementWindowHelpers(t *testing.T) {
 		t.Errorf("firstAbove(9)=%d, want 4", got)
 	}
 	for _, tc := range []struct{ in, lo, hi, want int }{{-1, 0, 4, 0}, {9, 0, 4, 4}, {2, 0, 4, 2}} {
-		if got := clampIndex(tc.in, tc.lo, tc.hi); got != tc.want {
-			t.Errorf("clampIndex(%d,%d,%d)=%d, want %d", tc.in, tc.lo, tc.hi, got, tc.want)
+		if got := math.Clamp(tc.in, tc.lo, tc.hi); got != tc.want {
+			t.Errorf("math.Clamp(%d,%d,%d)=%d, want %d", tc.in, tc.lo, tc.hi, got, tc.want)
 		}
 	}
 }

--- a/kernel/subd/coverage_test.go
+++ b/kernel/subd/coverage_test.go
@@ -44,8 +44,8 @@ func TestSubdivideOpenMeshKeepsBoundaryMidpoints(t *testing.T) {
 }
 
 func TestClamp01Bounds(t *testing.T) {
-	if clamp01(-0.5) != 0 || clamp01(1.5) != 1 || clamp01(0.25) != 0.25 {
-		t.Fatalf("clamp01 = %v/%v/%v, want 0/1/0.25", clamp01(-0.5), clamp01(1.5), clamp01(0.25))
+	if gmath.Clamp01(-0.5) != 0 || gmath.Clamp01(1.5) != 1 || gmath.Clamp01(0.25) != 0.25 {
+		t.Fatalf("clamp01 = %v/%v/%v, want 0/1/0.25", gmath.Clamp01(-0.5), gmath.Clamp01(1.5), gmath.Clamp01(0.25))
 	}
 }
 

--- a/kernel/subd/subd.go
+++ b/kernel/subd/subd.go
@@ -50,7 +50,7 @@ func (m *Mesh) SetCrease(a, b int, sharpness float64) {
 		delete(m.Creases, k)
 		return
 	}
-	m.Creases[k] = clamp01(sharpness)
+	m.Creases[k] = math.Clamp01(sharpness)
 }
 
 // Clone returns a deep copy of the cage so edits do not alias a recomputed body.

--- a/kernel/subd/subdivide.go
+++ b/kernel/subd/subdivide.go
@@ -87,7 +87,7 @@ func (m Mesh) edgePoint(k [2]int, faces []int, fp []math.Point3) math.Point3 {
 		return mid
 	}
 	smooth := average([]math.Point3{a, b, fp[faces[0]], fp[faces[1]]})
-	return lerpP(smooth, mid, clamp01(m.sharpness(k[0], k[1])))
+	return lerpP(smooth, mid, math.Clamp01(m.sharpness(k[0], k[1])))
 }
 
 // vertexPoints repositions every original vertex per its incidence and creasing.
@@ -194,15 +194,4 @@ func other(e [2]int, v int) int {
 
 func lerpP(a, b math.Point3, t float64) math.Point3 {
 	return math.P3(a.X+(b.X-a.X)*t, a.Y+(b.Y-a.Y)*t, a.Z+(b.Z-a.Z)*t)
-}
-
-func clamp01(x float64) float64 {
-	switch {
-	case x < 0:
-		return 0
-	case x > 1:
-		return 1
-	default:
-		return x
-	}
 }

--- a/kernel/subd/subdivide.go
+++ b/kernel/subd/subdivide.go
@@ -87,7 +87,7 @@ func (m Mesh) edgePoint(k [2]int, faces []int, fp []math.Point3) math.Point3 {
 		return mid
 	}
 	smooth := average([]math.Point3{a, b, fp[faces[0]], fp[faces[1]]})
-	return lerpP(smooth, mid, math.Clamp01(m.sharpness(k[0], k[1])))
+	return smooth.Lerp(mid, math.Clamp01(m.sharpness(k[0], k[1])))
 }
 
 // vertexPoints repositions every original vertex per its incidence and creasing.
@@ -190,8 +190,4 @@ func other(e [2]int, v int) int {
 		return e[1]
 	}
 	return e[0]
-}
-
-func lerpP(a, b math.Point3, t float64) math.Point3 {
-	return math.P3(a.X+(b.X-a.X)*t, a.Y+(b.Y-a.Y)*t, a.Z+(b.Z-a.Z)*t)
 }

--- a/kernel/topo/coverage_test.go
+++ b/kernel/topo/coverage_test.go
@@ -30,7 +30,7 @@ func TestClampDomainReplacesInfiniteBounds(t *testing.T) {
 }
 
 func TestClampBounds(t *testing.T) {
-	if clamp(-1, 0, 1) != 0 || clamp(2, 0, 1) != 1 || clamp(0.5, 0, 1) != 0.5 {
+	if math.Clamp(-1, 0, 1) != 0 || math.Clamp(2, 0, 1) != 1 || math.Clamp(0.5, 0, 1) != 0.5 {
 		t.Fatal("clamp did not bound correctly")
 	}
 }

--- a/kernel/topo/geometric_ref.go
+++ b/kernel/topo/geometric_ref.go
@@ -2,7 +2,11 @@
 
 package topo
 
-import "oblikovati.org/math"
+import (
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
 
 // SPIKE (M8, NX exporter): resolving a face/edge selection from a SERIALIZED geometric
 // descriptor rather than an Oblikovati lineage key. The exact-lineage binder
@@ -80,7 +84,7 @@ func (b *Body) FindEdgeByGeometry(ref GeometricEdgeRef, tol math.Scalar) (*Edge,
 		if d > tol {
 			continue
 		}
-		if want.LengthSquared() > 0 && absScalar(edgeDirection(e).Dot(want)) < normalAlignMin {
+		if want.LengthSquared() > 0 && stdmath.Abs(edgeDirection(e).Dot(want)) < normalAlignMin {
 			continue
 		}
 		best, bestD, second, secondD = rankEdge(e, d, best, bestD, second, secondD)
@@ -177,11 +181,4 @@ func unitOrZero(v math.Vector3) math.Vector3 {
 		return math.Vector3{}
 	}
 	return v.Scale(1 / v.Length())
-}
-
-func absScalar(s math.Scalar) math.Scalar {
-	if s < 0 {
-		return -s
-	}
-	return s
 }

--- a/kernel/topo/surface_evaluator.go
+++ b/kernel/topo/surface_evaluator.go
@@ -78,8 +78,8 @@ func gridSeed(s geom.Surface, p math.Point3, uLo, uHi, vLo, vHi float64) (float6
 func projectStep(s geom.Surface, p math.Point3, u, v, uLo, uHi, vLo, vHi float64) (float64, float64) {
 	du, dv := s.DerivativesAt(u, v)
 	res := s.PointAt(u, v).VectorTo(p)
-	u = clamp(u+projectOnto(res, du), uLo, uHi)
-	v = clamp(v+projectOnto(res, dv), vLo, vHi)
+	u = math.Clamp(u+projectOnto(res, du), uLo, uHi)
+	v = math.Clamp(v+projectOnto(res, dv), vLo, vHi)
 	return u, v
 }
 
@@ -103,14 +103,4 @@ func clampDomain(lo, hi float64) (float64, float64) {
 		hi = window
 	}
 	return lo, hi
-}
-
-func clamp(x, lo, hi float64) float64 {
-	if x < lo {
-		return lo
-	}
-	if x > hi {
-		return hi
-	}
-	return x
 }

--- a/math/clamp.go
+++ b/math/clamp.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package math
+
+import "cmp"
+
+// Clamp limits v to [lo, hi]; it requires lo <= hi (an inverted range is a
+// caller bug, not a case Clamp arbitrates). It is the single clamp for the
+// whole codebase (#1652) — the eight hand-rolled shapes it replaced disagreed
+// on range conventions, so one documented contract lives here instead.
+// NaN handling is comparison-based: a NaN v passes through unchanged.
+//
+//	u := math.Clamp(u, uMin, uMax) // pin a surface parameter to its domain
+func Clamp[T cmp.Ordered](v, lo, hi T) T {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+// Clamp01 limits v to the unit interval [0, 1] — the ubiquitous
+// curve/segment-parameter guard (#1652).
+//
+//	t := math.Clamp01(dot / lenSq) // project onto a bounded segment
+func Clamp01(v float64) float64 {
+	return Clamp(v, 0, 1)
+}

--- a/math/clamp_test.go
+++ b/math/clamp_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package math
+
+import (
+	stdmath "math"
+	"testing"
+)
+
+func TestClampFloat64(t *testing.T) {
+	cases := []struct {
+		name            string
+		v, lo, hi, want float64
+	}{
+		{"below", -2, -1, 1, -1},
+		{"above", 2, -1, 1, 1},
+		{"inside", 0.5, -1, 1, 0.5},
+		{"at-lo", -1, -1, 1, -1},
+		{"at-hi", 1, -1, 1, 1},
+		{"degenerate-range", 3, 2, 2, 2},
+	}
+	for _, c := range cases {
+		if got := Clamp(c.v, c.lo, c.hi); got != c.want {
+			t.Errorf("%s: Clamp(%v, %v, %v) = %v, want %v", c.name, c.v, c.lo, c.hi, got, c.want)
+		}
+	}
+}
+
+func TestClampInt(t *testing.T) {
+	cases := []struct {
+		name            string
+		v, lo, hi, want int
+	}{
+		{"below", -5, 0, 9, 0},
+		{"above", 12, 0, 9, 9},
+		{"inside", 4, 0, 9, 4},
+	}
+	for _, c := range cases {
+		if got := Clamp(c.v, c.lo, c.hi); got != c.want {
+			t.Errorf("%s: Clamp(%d, %d, %d) = %d, want %d", c.name, c.v, c.lo, c.hi, got, c.want)
+		}
+	}
+}
+
+// A NaN v fails both ordered comparisons, so it passes through — the documented
+// comparison-based contract.
+func TestClampNaNPassesThrough(t *testing.T) {
+	if got := Clamp(stdmath.NaN(), 0.0, 1.0); !stdmath.IsNaN(got) {
+		t.Errorf("Clamp(NaN, 0, 1) = %v, want NaN", got)
+	}
+}
+
+func TestClamp01(t *testing.T) {
+	cases := []struct{ v, want float64 }{
+		{-0.5, 0}, {0, 0}, {0.25, 0.25}, {1, 1}, {1.5, 1},
+	}
+	for _, c := range cases {
+		if got := Clamp01(c.v); got != c.want {
+			t.Errorf("Clamp01(%v) = %v, want %v", c.v, got, c.want)
+		}
+	}
+}

--- a/math/lerp.go
+++ b/math/lerp.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package math
+
+// Lerp interpolates a→b at t — the ONE evaluation order for the whole kernel
+// (#1654). The codebase had forked into a+(b−a)*t and a+t*(b−a) spellings;
+// in a B-rep kernel two packages interpolating the "same" point along a shared
+// edge must agree to the last bit, so every lerp now routes through here.
+//
+// Form: the fused a + t*(b−a) (bit-identical to both historical spellings —
+// IEEE-754 multiplication commutes), which is exact at t=0 and monotone, but
+// not always exact at t=1 (a + (b−a) can round past b, e.g. a=0.1, b=0.3).
+// The t==1 pin restores endpoint exactness, mirroring C++ std::lerp (P0811).
+//
+//	mid := math.Lerp(lo, hi, 0.5)
+func Lerp(a, b, t Scalar) Scalar {
+	if t == 1 {
+		return b
+	}
+	return a + t*(b-a)
+}

--- a/math/lerp_test.go
+++ b/math/lerp_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package math
+
+import "testing"
+
+// The endpoint-exactness property is the point of the t==1 pin: with the raw
+// fused form, Lerp(0.1, 0.3, 1) = 0.30000000000000004 ≠ 0.3.
+func TestLerpEndpointsExact(t *testing.T) {
+	pairs := []struct{ a, b Scalar }{
+		{0, 1}, {0.1, 0.3}, {-2.5, 7.25}, {1e-9, 1e9}, {3, 3},
+	}
+	for _, c := range pairs {
+		if got := Lerp(c.a, c.b, 0); got != c.a {
+			t.Errorf("Lerp(%v, %v, 0) = %v, want exactly a", c.a, c.b, got)
+		}
+		if got := Lerp(c.a, c.b, 1); got != c.b {
+			t.Errorf("Lerp(%v, %v, 1) = %v, want exactly b", c.a, c.b, got)
+		}
+	}
+}
+
+func TestLerpInteriorAndExtrapolation(t *testing.T) {
+	if got := Lerp(2, 6, 0.5); got != 4 {
+		t.Errorf("Lerp(2, 6, 0.5) = %v, want 4", got)
+	}
+	if got := Lerp(2, 6, 0.25); got != 3 {
+		t.Errorf("Lerp(2, 6, 0.25) = %v, want 3", got)
+	}
+	// t outside [0,1] extrapolates along the same line — no clamping.
+	if got := Lerp(2, 6, 2); got != 10 {
+		t.Errorf("Lerp(2, 6, 2) = %v, want 10", got)
+	}
+	if got := Lerp(2, 6, -0.5); got != 0 {
+		t.Errorf("Lerp(2, 6, -0.5) = %v, want 0", got)
+	}
+}
+
+func TestPoint2LerpEndpointsAndMidpoint(t *testing.T) {
+	a, b := P2(0.1, -1), P2(0.3, 3)
+	if got := a.Lerp(b, 0); got != a {
+		t.Errorf("a.Lerp(b, 0) = %v, want exactly %v", got, a)
+	}
+	if got := a.Lerp(b, 1); got != b {
+		t.Errorf("a.Lerp(b, 1) = %v, want exactly %v", got, b)
+	}
+	if got := P2(0, 2).Lerp(P2(4, 6), 0.5); got != P2(2, 4) {
+		t.Errorf("midpoint = %v, want (2, 4)", got)
+	}
+}
+
+func TestPoint3LerpEndpointsAndMidpoint(t *testing.T) {
+	a, b := P3(0.1, -1, 5), P3(0.3, 3, -5)
+	if got := a.Lerp(b, 0); got != a {
+		t.Errorf("a.Lerp(b, 0) = %v, want exactly %v", got, a)
+	}
+	if got := a.Lerp(b, 1); got != b {
+		t.Errorf("a.Lerp(b, 1) = %v, want exactly %v", got, b)
+	}
+	if got := P3(0, 2, -2).Lerp(P3(4, 6, 2), 0.5); got != P3(2, 4, 0) {
+		t.Errorf("midpoint = %v, want (2, 4, 0)", got)
+	}
+}

--- a/math/matrix4_transform.go
+++ b/math/matrix4_transform.go
@@ -74,7 +74,7 @@ func Reflection4(origin Point3, normal UnitVector3) Matrix4 {
 // rotates π about an arbitrary perpendicular axis, since the axis is otherwise
 // undetermined.
 func RotateBetween(from, to UnitVector3) Matrix4 {
-	d := clampUnit(from.Dot(to))
+	d := Clamp(from.Dot(to), -1, 1)
 	if approxEqual(d, 1, AngleTolerance) {
 		return Identity4()
 	}

--- a/math/point2.go
+++ b/math/point2.go
@@ -50,3 +50,11 @@ func (p Point2) IsEqualTo(o Point2, tol Scalar) bool {
 func (p Point2) Midpoint(o Point2) Point2 {
 	return Point2{(p.X + o.X) / 2, (p.Y + o.Y) / 2}
 }
+
+// Lerp interpolates this point toward q at t, one [Lerp] per coordinate — the
+// single evaluation order of #1654 (exact at t=0 and t=1).
+//
+//	quarter := a.Lerp(b, 0.25)
+func (p Point2) Lerp(q Point2, t Scalar) Point2 {
+	return P2(Lerp(p.X, q.X, t), Lerp(p.Y, q.Y, t))
+}

--- a/math/point3.go
+++ b/math/point3.go
@@ -50,3 +50,11 @@ func (p Point3) IsEqualTo(o Point3, tol Scalar) bool {
 func (p Point3) Midpoint(o Point3) Point3 {
 	return Point3{(p.X + o.X) / 2, (p.Y + o.Y) / 2, (p.Z + o.Z) / 2}
 }
+
+// Lerp interpolates this point toward q at t, one [Lerp] per coordinate — the
+// single evaluation order of #1654 (exact at t=0 and t=1).
+//
+//	quarter := a.Lerp(b, 0.25)
+func (p Point3) Lerp(q Point3, t Scalar) Point3 {
+	return P3(Lerp(p.X, q.X, t), Lerp(p.Y, q.Y, t), Lerp(p.Z, q.Z, t))
+}

--- a/math/robust_bounds.go
+++ b/math/robust_bounds.go
@@ -53,7 +53,7 @@ func RobustPointBox(pts []Point3) Box {
 // (a true stray) is excluded. ok is false when there is no spread to bound.
 func robustWindow(pts []Point3) (lo, hi Point3, ok bool) {
 	xs, ys, zs := axisValues(pts)
-	margin := robustExtentMargin * maxFloat(coreSize(xs), maxFloat(coreSize(ys), coreSize(zs)))
+	margin := robustExtentMargin * max(coreSize(xs), max(coreSize(ys), coreSize(zs)))
 	if margin <= 0 {
 		return Point3{}, Point3{}, false
 	}
@@ -83,12 +83,4 @@ func axisValues(pts []Point3) (xs, ys, zs []float64) {
 // characteristic size on that axis, immune to the extreme tails a stray occupies.
 func coreSize(v []float64) float64 {
 	return Percentile(v, 0.99) - Percentile(v, 0.01)
-}
-
-// maxFloat returns the larger of two float64s.
-func maxFloat(a, b float64) float64 {
-	if a > b {
-		return a
-	}
-	return b
 }

--- a/math/scalar.go
+++ b/math/scalar.go
@@ -50,15 +50,3 @@ func resolveAngleTolerance(tol Scalar) Scalar {
 func IsNearZero(x, tol Scalar) bool {
 	return approxEqual(x, 0, resolveTolerance(tol))
 }
-
-// clampUnit constrains x to [-1, 1]; used to guard math.Acos against inputs
-// that float64 rounding pushed just outside the valid cosine range.
-func clampUnit(x Scalar) Scalar {
-	if x < -1 {
-		return -1
-	}
-	if x > 1 {
-		return 1
-	}
-	return x
-}

--- a/math/unitvector2.go
+++ b/math/unitvector2.go
@@ -53,7 +53,7 @@ func (u UnitVector2) Dot(o UnitVector2) Scalar {
 
 // AngleTo returns the unsigned angle in radians between u and o, in [0, π].
 func (u UnitVector2) AngleTo(o UnitVector2) Scalar {
-	return stdmath.Acos(clampUnit(u.Dot(o)))
+	return stdmath.Acos(Clamp(u.Dot(o), -1, 1))
 }
 
 // IsEqualTo reports whether u and o are componentwise equal within tol. Pass

--- a/math/unitvector3.go
+++ b/math/unitvector3.go
@@ -59,7 +59,7 @@ func (u UnitVector3) Dot(o UnitVector3) Scalar {
 
 // AngleTo returns the unsigned angle in radians between u and o, in [0, π].
 func (u UnitVector3) AngleTo(o UnitVector3) Scalar {
-	return stdmath.Acos(clampUnit(u.Dot(o)))
+	return stdmath.Acos(Clamp(u.Dot(o), -1, 1))
 }
 
 // Cross returns the cross product u×o as a plain [Vector3]; it is unit length

--- a/math/vector2.go
+++ b/math/vector2.go
@@ -70,7 +70,7 @@ func (v Vector2) AngleTo(o Vector2) Scalar {
 	if denom == 0 {
 		return 0
 	}
-	return stdmath.Acos(clampUnit(v.Dot(o) / denom))
+	return stdmath.Acos(Clamp(v.Dot(o)/denom, -1, 1))
 }
 
 // IsEqualTo reports whether v and o are componentwise equal within tol. Pass

--- a/math/vector3.go
+++ b/math/vector3.go
@@ -74,7 +74,7 @@ func (v Vector3) AngleTo(o Vector3) Scalar {
 		return 0
 	}
 	// clampUnit guards against |cos| slightly exceeding 1 from rounding.
-	return stdmath.Acos(clampUnit(v.Dot(o) / denom))
+	return stdmath.Acos(Clamp(v.Dot(o)/denom, -1, 1))
 }
 
 // IsEqualTo reports whether v and o are componentwise equal within tol. Pass

--- a/model/assembly/contact.go
+++ b/model/assembly/contact.go
@@ -4,6 +4,7 @@ package assembly
 
 import (
 	"fmt"
+	"slices"
 
 	"oblikovati.org/api/contract"
 )
@@ -157,7 +158,7 @@ func (s *ContactSolver) PartnersOf(occID uint64) []uint64 {
 	seen := map[uint64]bool{}
 	var out []uint64
 	for _, cs := range s.sets {
-		if !contains(cs.members, occID) {
+		if !slices.Contains(cs.members, occID) {
 			continue
 		}
 		for _, m := range cs.members {
@@ -174,17 +175,7 @@ func (s *ContactSolver) PartnersOf(occID uint64) []uint64 {
 // solver keeps from interpenetrating.
 func (s *ContactSolver) Contacts(a, b uint64) bool {
 	for _, cs := range s.sets {
-		if contains(cs.members, a) && contains(cs.members, b) {
-			return true
-		}
-	}
-	return false
-}
-
-// contains reports whether ids holds v.
-func contains(ids []uint64, v uint64) bool {
-	for _, id := range ids {
-		if id == v {
+		if slices.Contains(cs.members, a) && slices.Contains(cs.members, b) {
 			return true
 		}
 	}

--- a/model/doc/views.go
+++ b/model/doc/views.go
@@ -134,18 +134,8 @@ func (vs *DocumentViews) Split() (x, y float32) {
 
 // SetSplit sets the divider positions, clamped to [0.1, 0.9] so no tile collapses.
 func (vs *DocumentViews) SetSplit(x, y float32) {
-	vs.splitX = clampSplit(x)
-	vs.splitY = clampSplit(y)
-}
-
-func clampSplit(v float32) float32 {
-	if v < minSplit {
-		return minSplit
-	}
-	if v > maxSplit {
-		return maxSplit
-	}
-	return v
+	vs.splitX = math.Clamp(x, minSplit, maxSplit)
+	vs.splitY = math.Clamp(y, minSplit, maxSplit)
 }
 
 // Views returns the document's view collection, seeding a single default view on first

--- a/model/drawing/derived_view.go
+++ b/model/drawing/derived_view.go
@@ -69,7 +69,7 @@ func clipToCircle(a, b gmath.Point2, cx, cy, r float64) (gmath.Point2, gmath.Poi
 		return a, b, cc < 0
 	}
 	sq := math.Sqrt(disc)
-	t0, t1 := maxf2((-bb-sq)/(2*aa), 0), minf2((-bb+sq)/(2*aa), 1)
+	t0, t1 := max((-bb-sq)/(2*aa), 0), min((-bb+sq)/(2*aa), 1)
 	if t0 >= t1 {
 		return a, b, false
 	}
@@ -78,20 +78,6 @@ func clipToCircle(a, b gmath.Point2, cx, cy, r float64) (gmath.Point2, gmath.Poi
 
 func lerp2(a gmath.Point2, dx, dy, t float64) gmath.Point2 {
 	return gmath.P2(a.X+gmath.Scalar(dx*t), a.Y+gmath.Scalar(dy*t))
-}
-
-func maxf2(a, b float64) float64 {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-func minf2(a, b float64) float64 {
-	if a < b {
-		return a
-	}
-	return b
 }
 
 // breakBand is a break view's removed band. g0/g1 bound it (g0<g1) along the break axis in the
@@ -190,7 +176,7 @@ func perpBounds(segs []hlr.Segment, axisX bool) (lo, hi float64) {
 	for _, s := range segs {
 		for _, p := range [2]gmath.Point2{s.A, s.B} {
 			c := axisCoord(p, !axisX)
-			lo, hi = minf2(lo, c), maxf2(hi, c)
+			lo, hi = min(lo, c), max(hi, c)
 		}
 	}
 	return lo, hi

--- a/model/drawing/derived_view.go
+++ b/model/drawing/derived_view.go
@@ -73,11 +73,7 @@ func clipToCircle(a, b gmath.Point2, cx, cy, r float64) (gmath.Point2, gmath.Poi
 	if t0 >= t1 {
 		return a, b, false
 	}
-	return lerp2(a, dx, dy, t0), lerp2(a, dx, dy, t1), true
-}
-
-func lerp2(a gmath.Point2, dx, dy, t float64) gmath.Point2 {
-	return gmath.P2(a.X+gmath.Scalar(dx*t), a.Y+gmath.Scalar(dy*t))
+	return a.Lerp(b, t0), a.Lerp(b, t1), true
 }
 
 // breakBand is a break view's removed band. g0/g1 bound it (g0<g1) along the break axis in the
@@ -148,7 +144,7 @@ func clipHalfAxis(a, b gmath.Point2, axisX bool, limit float64, keepLE bool) (gm
 		return a, b, false
 	}
 	t := (limit - sa) / (sb - sa)
-	cross := lerp2(a, float64(b.X-a.X), float64(b.Y-a.Y), t)
+	cross := a.Lerp(b, t)
 	if ina {
 		return a, cross, true
 	}

--- a/model/drawing/view.go
+++ b/model/drawing/view.go
@@ -118,25 +118,11 @@ func (v *DrawingView) BoundsMM() (minX, minY, maxX, maxY float64, ok bool) {
 	maxX, maxY = minX, minY
 	for _, c := range v.curves {
 		for _, p := range [2]math.Point2{c.A, c.B} {
-			minX, minY = minF(minX, float64(p.X)), minF(minY, float64(p.Y))
-			maxX, maxY = maxFl(maxX, float64(p.X)), maxFl(maxY, float64(p.Y))
+			minX, minY = min(minX, float64(p.X)), min(minY, float64(p.Y))
+			maxX, maxY = max(maxX, float64(p.X)), max(maxY, float64(p.Y))
 		}
 	}
 	return minX, minY, maxX, maxY, true
-}
-
-func minF(a, b float64) float64 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func maxFl(a, b float64) float64 {
-	if a > b {
-		return a
-	}
-	return b
 }
 
 // VisibleHidden counts the view's visible and hidden curves.
@@ -291,22 +277,8 @@ func bodyCenter(body *topo.Body) math.Point3 {
 	lo, hi := verts[0].Point(), verts[0].Point()
 	for _, vt := range verts {
 		p := vt.Point()
-		lo = math.P3(minS(lo.X, p.X), minS(lo.Y, p.Y), minS(lo.Z, p.Z))
-		hi = math.P3(maxS(hi.X, p.X), maxS(hi.Y, p.Y), maxS(hi.Z, p.Z))
+		lo = math.P3(min(lo.X, p.X), min(lo.Y, p.Y), min(lo.Z, p.Z))
+		hi = math.P3(max(hi.X, p.X), max(hi.Y, p.Y), max(hi.Z, p.Z))
 	}
 	return math.P3((lo.X+hi.X)/2, (lo.Y+hi.Y)/2, (lo.Z+hi.Z)/2)
-}
-
-func minS(a, b math.Scalar) math.Scalar {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func maxS(a, b math.Scalar) math.Scalar {
-	if a > b {
-		return a
-	}
-	return b
 }

--- a/model/feature/editable.go
+++ b/model/feature/editable.go
@@ -5,6 +5,7 @@ package feature
 import (
 	"bytes"
 	"fmt"
+	"slices"
 
 	"oblikovati.org/api/types"
 	"oblikovati.org/math"
@@ -96,7 +97,7 @@ func keyRefSlotMulti(label string, kind RefKind, field *[][]byte) EditableRefSlo
 		Count: func() int { return len(*field) },
 		Keys:  func() [][]byte { return *field },
 		Add: func(r PickedRef) {
-			if !containsRefKey(*field, r.Key) {
+			if !slices.ContainsFunc(*field, func(k []byte) bool { return bytes.Equal(k, r.Key) }) {
 				*field = append(*field, r.Key)
 			}
 		},
@@ -196,15 +197,6 @@ func planeRefSlot(label string, origin *math.Point3, normal *math.Vector3, key *
 			}
 		},
 	}
-}
-
-func containsRefKey(ks [][]byte, key []byte) bool {
-	for _, k := range ks {
-		if bytes.Equal(k, key) {
-			return true
-		}
-	}
-	return false
 }
 
 func cloneRefKeys(ks [][]byte) [][]byte {

--- a/model/feature/face_fillet.go
+++ b/model/feature/face_fillet.go
@@ -4,6 +4,7 @@ package feature
 
 import (
 	"fmt"
+	stdmath "math"
 
 	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/geom"
@@ -201,19 +202,11 @@ func facePlanes(body *topo.Body, keys [][]byte) []geom.Plane {
 func onAnyPlane(p geom.Plane, set []geom.Plane) bool {
 	for _, q := range set {
 		if float64(p.Normal().Dot(q.Normal())) > 0.999 &&
-			abs(float64(p.Origin.VectorTo(q.Origin).Dot(q.Normal()))) < 1e-6 {
+			stdmath.Abs(float64(p.Origin.VectorTo(q.Origin).Dot(q.Normal()))) < 1e-6 {
 			return true
 		}
 	}
 	return false
-}
-
-// abs is the float64 absolute value (local to avoid a math import alias clash).
-func abs(x float64) float64 {
-	if x < 0 {
-		return -x
-	}
-	return x
 }
 
 // sharedEdgeKeys returns the reference key of every edge of body whose two adjacent faces lie one in

--- a/model/feature/full_round_fillet.go
+++ b/model/feature/full_round_fillet.go
@@ -71,7 +71,7 @@ func fullRoundFilletBody(in Input, def *FullRoundFilletDefinition, feat string) 
 
 // parallelSides reports whether the two side faces' planes are parallel (the constant-cylinder case).
 func parallelSides(side1, side2 planarFace) bool {
-	return abs(float64(normalize(side1.Normal()).Dot(normalize(side2.Normal())))) > 0.999
+	return stdmath.Abs(float64(normalize(side1.Normal()).Dot(normalize(side2.Normal())))) > 0.999
 }
 
 // parallelFullRound cuts the constant half-cylinder corner tool between two parallel sides.

--- a/model/feature/loft_skin.go
+++ b/model/feature/loft_skin.go
@@ -504,7 +504,7 @@ func sectionTangents(sections [][]math.Point3, closed bool, ends loftEnds, wrapS
 		if closed {
 			return ((i % m) + m) % m
 		}
-		return clampInt(i, 0, m-1)
+		return math.Clamp(i, 0, m-1)
 	}
 	// Across the closed seam (between section m-1 and 0) the correspondence is offset by the
 	// monodromy wrapShift, so a periodic neighbour's matching point is reindexed by it. Without this
@@ -1108,14 +1108,4 @@ func shiftLoop(loop []math.Point3, dir math.Vector3, d float64) []math.Point3 {
 		out[i] = p.TranslateBy(delta)
 	}
 	return out
-}
-
-func clampInt(v, lo, hi int) int {
-	if v < lo {
-		return lo
-	}
-	if v > hi {
-		return hi
-	}
-	return v
 }

--- a/model/feature/sketch_consumer.go
+++ b/model/feature/sketch_consumer.go
@@ -2,7 +2,11 @@
 
 package feature
 
-import "oblikovati.org/model/sketch"
+import (
+	"slices"
+
+	"oblikovati.org/model/sketch"
+)
 
 // SketchConsumer is implemented by feature definitions that consume one or more sketches
 // as profile/path/centerline input. The model browser uses it to nest a consumed sketch
@@ -36,20 +40,11 @@ func nonNilSketches(sks ...*sketch.Sketch) []*sketch.Sketch {
 		if sk == nil {
 			continue
 		}
-		if !containsSketch(out, sk) {
+		if !slices.Contains(out, sk) {
 			out = append(out, sk)
 		}
 	}
 	return out
-}
-
-func containsSketch(in []*sketch.Sketch, want *sketch.Sketch) bool {
-	for _, sk := range in {
-		if sk == want {
-			return true
-		}
-	}
-	return false
 }
 
 // Compile-time proof that every sketch-consuming feature reports its sketches, so the

--- a/model/linetype/dash.go
+++ b/model/linetype/dash.go
@@ -75,7 +75,7 @@ func (c *dashCursor) walkEdge(segs [][2]math.Point2, p, q math.Point2) [][2]math
 			step = left
 		}
 		if c.steps[c.i].down {
-			segs = append(segs, [2]math.Point2{lerp2(p, q, at/total), lerp2(p, q, (at+step)/total)})
+			segs = append(segs, [2]math.Point2{p.Lerp(q, at/total), p.Lerp(q, (at+step)/total)})
 		}
 		at += step
 		c.advance(step)
@@ -90,9 +90,4 @@ func (c *dashCursor) advance(used float64) {
 		c.i = (c.i + 1) % len(c.steps)
 		c.rem = c.steps[c.i].length
 	}
-}
-
-// lerp2 interpolates between two points at parameter t ∈ [0,1].
-func lerp2(p, q math.Point2, t float64) math.Point2 {
-	return math.P2(p.X+(q.X-p.X)*math.Scalar(t), p.Y+(q.Y-p.Y)*math.Scalar(t))
 }

--- a/model/param/expr_parser.go
+++ b/model/param/expr_parser.go
@@ -4,6 +4,7 @@ package param
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 )
 
@@ -63,7 +64,7 @@ func (p *parser) parseBinary(sub func() (node, error), ops ...tokenKind) (node, 
 	if err != nil {
 		return nil, err
 	}
-	for containsKind(ops, p.peek().kind) {
+	for slices.Contains(ops, p.peek().kind) {
 		op := p.advance()
 		rhs, err := sub()
 		if err != nil {
@@ -172,13 +173,4 @@ func (p *parser) parseParen() (node, error) {
 	}
 	p.advance()
 	return inner, nil
-}
-
-func containsKind(kinds []tokenKind, k tokenKind) bool {
-	for _, x := range kinds {
-		if x == k {
-			return true
-		}
-	}
-	return false
 }

--- a/model/param/expression_list.go
+++ b/model/param/expression_list.go
@@ -4,6 +4,7 @@ package param
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 )
 
@@ -61,21 +62,11 @@ func (p *Parameter) AllowsCustomValue() bool { return p.allowCustom }
 // allowed), routing to the numeric or text setter. It errors when the value is not in the
 // list and custom values are not allowed.
 func (p *Parameter) SelectValue(expr string) error {
-	if p.IsMultiValue() && !p.allowCustom && !contains(p.exprList, expr) {
+	if p.IsMultiValue() && !p.allowCustom && !slices.Contains(p.exprList, expr) {
 		return fmt.Errorf("param: %q is not an allowed value for %q", expr, p.name)
 	}
 	if p.IsText() {
 		return p.SetText(expr)
 	}
 	return p.SetExpression(expr)
-}
-
-// contains reports whether s is in list.
-func contains(list []string, s string) bool {
-	for _, v := range list {
-		if v == s {
-			return true
-		}
-	}
-	return false
 }

--- a/model/param/graph.go
+++ b/model/param/graph.go
@@ -2,7 +2,10 @@
 
 package param
 
-import "fmt"
+import (
+	"fmt"
+	"slices"
+)
 
 // This file is the parameter dependency graph (F04): the same dirty-propagation
 // machinery the feature engine will reuse (architecture core/04). Edges are
@@ -91,7 +94,7 @@ func (ps *Parameters) rebind(id ID) error {
 // parameter's name but could not bind before it existed.
 func (ps *Parameters) onParameterAdded(p *Parameter) {
 	for _, other := range ps.All() {
-		if other.id != p.id && containsString(other.expr.References(), p.name) {
+		if other.id != p.id && slices.Contains(other.expr.References(), p.name) {
 			_ = ps.rebind(other.id) // a re-add cannot introduce a new cycle here
 		}
 	}
@@ -234,14 +237,4 @@ func keysOf(set idSet) []ID {
 		out = append(out, id)
 	}
 	return out
-}
-
-// containsString reports whether s is in list.
-func containsString(list []string, s string) bool {
-	for _, x := range list {
-		if x == s {
-			return true
-		}
-	}
-	return false
 }

--- a/model/sheetmetal/bend_table.go
+++ b/model/sheetmetal/bend_table.go
@@ -2,7 +2,10 @@
 
 package sheetmetal
 
-import "sort"
+import (
+	stdmath "math"
+	"sort"
+)
 
 // BendTable is a measured bend-allowance table: rows of (angle, radius, thickness →
 // allowance) captured from shop tests for a material. Lookups select the rows whose radius
@@ -52,7 +55,7 @@ func (t *BendTable) BendAllowance(angle, radius, thickness float64) (float64, bo
 func (t *BendTable) rowsMatching(radius, thickness float64) []BendTableRow {
 	var out []BendTableRow
 	for _, r := range t.rows {
-		if abs(r.Radius-radius) <= matchTol && abs(r.Thickness-thickness) <= matchTol {
+		if stdmath.Abs(r.Radius-radius) <= matchTol && stdmath.Abs(r.Thickness-thickness) <= matchTol {
 			out = append(out, r)
 		}
 	}
@@ -82,11 +85,4 @@ func interpolateByAngle(rows []BendTableRow, angle float64) float64 {
 		}
 	}
 	return last.Allowance
-}
-
-func abs(x float64) float64 {
-	if x < 0 {
-		return -x
-	}
-	return x
 }

--- a/model/sketch/arrangement.go
+++ b/model/sketch/arrangement.go
@@ -156,8 +156,8 @@ func gridCuts(segs []taggedSeg, cuts [][]cut) {
 	cell := stdmath.Max(stdmath.Max(maxX-minX, maxY-minY)/float64(dim), 1e-9) // tol:numeric — degenerate spatial-grid cell floor
 	cols := int((maxX-minX)/cell) + 1
 	rows := int((maxY-minY)/cell) + 1
-	col := func(x float64) int { return clampInt(int((x-minX)/cell), cols) }
-	row := func(y float64) int { return clampInt(int((y-minY)/cell), rows) }
+	col := func(x float64) int { return math.Clamp(int((x-minX)/cell), 0, cols-1) }
+	row := func(y float64) int { return math.Clamp(int((y-minY)/cell), 0, rows-1) }
 	bins := binSegments(segs, col, row, cols, rows)
 	testBinnedPairs(segs, bins, cuts)
 }
@@ -217,16 +217,6 @@ func testBinnedPairs(segs []taggedSeg, bins [][]int32, cuts [][]cut) {
 			}
 		}
 	}
-}
-
-func clampInt(c, n int) int {
-	if c < 0 {
-		return 0
-	}
-	if c >= n {
-		return n - 1
-	}
-	return c
 }
 
 // splitPoints returns a segment's points in order: its start, the interior crossing

--- a/model/sketch/auto_dimension.go
+++ b/model/sketch/auto_dimension.go
@@ -130,7 +130,7 @@ func miterJoin(s *Sketch, a, b *Line) {
 	if !ok {
 		return
 	}
-	join := s.newPoint(lerpLine(a, t))
+	join := s.newPoint(a.A.Position().Lerp(a.B.Position(), t))
 	a.B = join
 	b.A = join
 }

--- a/model/sketch/dimension_3d.go
+++ b/model/sketch/dimension_3d.go
@@ -244,19 +244,7 @@ func angleBetweenLines3D(l1, l2 *Line3D) float64 {
 		return 0
 	}
 	cos := float64(d1.Dot(d2)) / (n1 * n2)
-	return stdmath.Acos(clampUnit3D(cos))
-}
-
-// clampUnit3D pins x into [-1, 1] so it is a valid argument to Acos after rounding error.
-func clampUnit3D(x float64) float64 {
-	switch {
-	case x > 1:
-		return 1
-	case x < -1:
-		return -1
-	default:
-		return x
-	}
+	return stdmath.Acos(math.Clamp(cos, -1, 1))
 }
 
 func (dc *DimensionConstraints3D) nextName() string {

--- a/model/sketch/dimension_3d_more_test.go
+++ b/model/sketch/dimension_3d_more_test.go
@@ -112,7 +112,7 @@ func TestDimension3DRefsAndDrive(t *testing.T) {
 		t.Errorf("after Drive(7) + solve, |a-b| = %v, want 7", a.Position().DistanceTo(b.Position()))
 	}
 	// Acos clamp guards rounding past ±1 (degenerate zero-length line ⇒ angle 0).
-	if clampUnit3D(1.0000001) != 1 || clampUnit3D(-1.0000001) != -1 || clampUnit3D(0.5) != 0.5 {
+	if gmath.Clamp(1.0000001, -1, 1) != 1 || gmath.Clamp(-1.0000001, -1, 1) != -1 || gmath.Clamp(0.5, -1, 1) != 0.5 {
 		t.Error("clampUnit3D must pin out-of-range cosines into [-1,1]")
 	}
 	zero := s.AddLine3D(gmath.P3(0, 0, 0), gmath.P3(0, 0, 0))

--- a/model/sketch/edit_trim.go
+++ b/model/sketch/edit_trim.go
@@ -16,7 +16,7 @@ func (s *Sketch) SplitLine(l *Line, pick math.Point2) ([]Entity, error) {
 	if t <= 1e-9 || t >= 1-1e-9 {
 		return nil, fmt.Errorf("split: point projects to t=%.4g, not strictly inside the line", t)
 	}
-	mid := s.newPoint(lerpLine(l, t))
+	mid := s.newPoint(l.A.Position().Lerp(l.B.Position(), t))
 	second := s.lines.Add(mid, l.B)
 	l.B = mid
 	return []Entity{l, second}, nil
@@ -44,14 +44,14 @@ func (s *Sketch) reshapeTrimmed(l *Line, lo, hi float64) []Entity {
 		s.deleteEntity(l)
 		return nil
 	case lo <= 1e-9: // trim the front: keep [hi, 1]
-		l.A = s.newPoint(lerp(a, b, hi))
+		l.A = s.newPoint(a.Lerp(b, hi))
 		return []Entity{l}
 	case hi >= 1-1e-9: // trim the tail: keep [0, lo]
-		l.B = s.newPoint(lerp(a, b, lo))
+		l.B = s.newPoint(a.Lerp(b, lo))
 		return []Entity{l}
 	default: // interior gap: keep [0, lo] and [hi, 1]
-		tail := s.lines.Add(s.newPoint(lerp(a, b, hi)), s.newPoint(b))
-		l.B = s.newPoint(lerp(a, b, lo))
+		tail := s.lines.Add(s.newPoint(a.Lerp(b, hi)), s.newPoint(b))
+		l.B = s.newPoint(a.Lerp(b, lo))
 		return []Entity{l, tail}
 	}
 }
@@ -91,7 +91,7 @@ func (s *Sketch) nearestExtension(l *Line, atEnd bool) (math.Point2, bool) {
 			}
 		}
 	}
-	return lerpLine(l, bestT), found
+	return l.A.Position().Lerp(l.B.Position(), bestT), found
 }
 
 // pickBeyond reports whether param t lies past the picked end of a [0,1] line.
@@ -137,13 +137,6 @@ func projectParamOnLine(l *Line, pick math.Point2) float64 {
 	}
 	return (float64(pick.X-a.X)*dx + float64(pick.Y-a.Y)*dy) / d2
 }
-
-// lerp returns the point at parameter t along a→b; lerpLine does the same for a line.
-func lerp(a, b math.Point2, t float64) math.Point2 {
-	return math.P2(a.X+math.Scalar(t)*(b.X-a.X), a.Y+math.Scalar(t)*(b.Y-a.Y))
-}
-
-func lerpLine(l *Line, t float64) math.Point2 { return lerp(l.A.Position(), l.B.Position(), t) }
 
 // bracketParam returns the adjacent cut params surrounding t (the picked segment).
 func bracketParam(cuts []float64, t float64) (float64, float64, bool) {

--- a/model/sketch/helix_3d.go
+++ b/model/sketch/helix_3d.go
@@ -3,6 +3,8 @@
 package sketch
 
 import (
+	stdmath "math"
+
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/math"
 )
@@ -82,17 +84,9 @@ func (s *Sketch3D) addHelix3DPt(origin *Point3D, axis math.UnitVector3, startRad
 // reference direction). It picks the world axis least aligned with u to stay well-conditioned.
 func perpendicularTo(u math.UnitVector3) math.Vector3 {
 	seed := math.V3(1, 0, 0)
-	if absScalar(u.X()) > 0.9 {
+	if stdmath.Abs(u.X()) > 0.9 {
 		seed = math.V3(0, 1, 0)
 	}
 	perp := seed.Sub(u.AsVector().Scale(seed.Dot(u.AsVector())))
 	return perp
-}
-
-// absScalar returns the absolute value of a scalar.
-func absScalar(s math.Scalar) math.Scalar {
-	if s < 0 {
-		return -s
-	}
-	return s
 }

--- a/model/sketch/projection_test.go
+++ b/model/sketch/projection_test.go
@@ -3,6 +3,7 @@
 package sketch
 
 import (
+	"slices"
 	"testing"
 
 	"oblikovati.org/math"
@@ -121,21 +122,12 @@ func TestProjectedAnchorIsPickable(t *testing.T) {
 	free := s.Points().Add(math.P2(0, 0))
 
 	pts := s.AllPoints()
-	if !containsPoint(pts, pp.Anchor()) {
+	if !slices.Contains(pts, pp.Anchor()) {
 		t.Error("AllPoints must include the projected anchor so it can be picked/snapped")
 	}
-	if !containsPoint(pts, free) {
+	if !slices.Contains(pts, free) {
 		t.Error("AllPoints must still include free points")
 	}
-}
-
-func containsPoint(pts []*Point, p *Point) bool {
-	for _, q := range pts {
-		if q == p {
-			return true
-		}
-	}
-	return false
 }
 
 // TestProjectedLostReferenceFreezes checks UpdateProjections breaks the link and freezes

--- a/model/text/font.go
+++ b/model/text/font.go
@@ -119,11 +119,13 @@ func scaleContour(c []pt, penX, scale float64) []math.Point2 {
 // pt is a design-unit point during flattening.
 type pt struct{ X, Y float64 }
 
-func f26(v fixed.Int26_6) float64        { return float64(v) / 64 }
-func ptOf(p fixed.Point26_6) pt          { return pt{f26(p.X), f26(p.Y)} }
-func lerp(a, b pt, t float64) pt         { return pt{a.X + (b.X-a.X)*t, a.Y + (b.Y-a.Y)*t} }
-func quad(a, c, b pt, t float64) pt      { return lerp(lerp(a, c, t), lerp(c, b, t), t) }
-func cube(a, c1, c2, b pt, t float64) pt { return lerp(quad(a, c1, c2, t), quad(c1, c2, b, t), t) }
+func f26(v fixed.Int26_6) float64 { return float64(v) / 64 }
+func ptOf(p fixed.Point26_6) pt   { return pt{f26(p.X), f26(p.Y)} }
+
+// lerp blends two design-unit points through the kernel-wide math.Lerp (#1654).
+func (a pt) lerp(b pt, t float64) pt     { return pt{math.Lerp(a.X, b.X, t), math.Lerp(a.Y, b.Y, t)} }
+func quad(a, c, b pt, t float64) pt      { return a.lerp(c, t).lerp(c.lerp(b, t), t) }
+func cube(a, c1, c2, b pt, t float64) pt { return quad(a, c1, c2, t).lerp(quad(c1, c2, b, t), t) }
 
 // flattenSegments turns a glyph's sfnt segments into closed polygon contours (design units),
 // flattening quadratic/cubic curves and dropping each contour's closing duplicate point.

--- a/model/text/layout_test.go
+++ b/model/text/layout_test.go
@@ -18,24 +18,11 @@ func boundsOf(cs [][][2]float64) (minX, maxX, minY, maxY float64) {
 				first = false
 				continue
 			}
-			minX, maxX = min2(minX, p[0]), max2(maxX, p[0])
-			minY, maxY = min2(minY, p[1]), max2(maxY, p[1])
+			minX, maxX = min(minX, p[0]), max(maxX, p[0])
+			minY, maxY = min(minY, p[1]), max(maxY, p[1])
 		}
 	}
 	return
-}
-
-func min2(a, b float64) float64 {
-	if a < b {
-		return a
-	}
-	return b
-}
-func max2(a, b float64) float64 {
-	if a > b {
-		return a
-	}
-	return b
 }
 
 // floatPairs flattens contours to [][2]float64 for assertions.

--- a/scene/camera.go
+++ b/scene/camera.go
@@ -170,18 +170,13 @@ func (c Camera) Facing(target math.Point3, normal, up math.Vector3) Camera {
 // viewport size — the per-frame step of a camera transition (e.g. entering a sketch).
 func Lerp(a, b Camera, t float64) Camera {
 	return Camera{
-		Eye:    lerpPoint(a.Eye, b.Eye, t),
-		Target: lerpPoint(a.Target, b.Target, t),
+		Eye:    a.Eye.Lerp(b.Eye, t),
+		Target: a.Target.Lerp(b.Target, t),
 		Up:     a.Up.Add(b.Up.Sub(a.Up).Scale(t)),
 		FOV:    b.FOV,
 		Width:  b.Width,
 		Height: b.Height,
 	}
-}
-
-// lerpPoint linearly interpolates two points.
-func lerpPoint(a, b math.Point3, t float64) math.Point3 {
-	return a.TranslateBy(a.VectorTo(b).Scale(t))
 }
 
 // Dolly moves the eye toward (factor<1) or away from (factor>1) the target along the

--- a/script/console/complete/chain.go
+++ b/script/console/complete/chain.go
@@ -2,6 +2,8 @@
 
 package complete
 
+import "oblikovati.org/math"
+
 // parseChain walks left from the caret at rune column col over a dotted identifier chain and
 // returns it left-to-right together with the column where the trailing (partial) segment began
 // — the span a chosen candidate replaces. The trailing segment is the prefix being typed and
@@ -11,7 +13,7 @@ package complete
 //	col at end      -> chain {"oblikovati","sketch","rect"}, start at the 'r'
 //	col after a '.' -> chain {"oblikovati","sketch",""},     start at the caret
 func parseChain(line []rune, col int) (chain []string, replaceStart int) {
-	col = clampInt(col, 0, len(line))
+	col = math.Clamp(col, 0, len(line))
 	j := scanIdentLeft(line, col)
 	chain = []string{string(line[j:col])}
 	replaceStart = j
@@ -48,15 +50,4 @@ func isIdentPart(r rune) bool {
 	default:
 		return r == '_'
 	}
-}
-
-// clampInt constrains v to [lo, hi].
-func clampInt(v, lo, hi int) int {
-	if v < lo {
-		return lo
-	}
-	if v > hi {
-		return hi
-	}
-	return v
 }

--- a/script/console/complete/complete_test.go
+++ b/script/console/complete/complete_test.go
@@ -2,7 +2,10 @@
 
 package complete
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 // methodsFixture is a small but representative slice of the dotted wire-method names the host
 // publishes, exercising multiple groups and a two-level namespace.
@@ -69,7 +72,7 @@ func TestBarePrefixCompletesKeywordsAndBuiltins(t *testing.T) {
 	e := New(methodsFixture)
 	got, ctx := e.Suggest("  pr", 4)
 	names := texts(got)
-	if !contains(names, "print") {
+	if !slices.Contains(names, "print") {
 		t.Errorf("bare 'pr' = %v, want it to include builtin 'print'", names)
 	}
 	if ctx.ReplaceStart != 2 {
@@ -77,7 +80,7 @@ func TestBarePrefixCompletesKeywordsAndBuiltins(t *testing.T) {
 	}
 	// 'lo' should surface the keyword 'local'.
 	got2, _ := e.Suggest("lo", 2)
-	if !contains(texts(got2), "local") {
+	if !slices.Contains(texts(got2), "local") {
 		t.Errorf("bare 'lo' = %v, want keyword 'local'", texts(got2))
 	}
 }
@@ -111,13 +114,4 @@ func equal(a, b []string) bool {
 		}
 	}
 	return true
-}
-
-func contains(xs []string, want string) bool {
-	for _, x := range xs {
-		if x == want {
-			return true
-		}
-	}
-	return false
 }

--- a/script/console/textbuf/buffer.go
+++ b/script/console/textbuf/buffer.go
@@ -7,7 +7,11 @@
 // input events into these operations and reads back the buffer (lua-scripting-plan, ADR-0028).
 package textbuf
 
-import "strings"
+import (
+	"strings"
+
+	"oblikovati.org/math"
+)
 
 // Position addresses a caret location: Line is a 0-based line index and Col is a 0-based
 // rune offset within that line (Col == len(line runes) is the valid end-of-line caret).
@@ -86,7 +90,7 @@ func (b *Buffer) Clamp(p Position) Position {
 		last := len(b.lines) - 1
 		return Position{last, len(b.lines[last])}
 	}
-	return Position{p.Line, clampInt(p.Col, 0, len(b.lines[p.Line]))}
+	return Position{p.Line, math.Clamp(p.Col, 0, len(b.lines[p.Line]))}
 }
 
 // Insert inserts text at p (assumed already valid) and returns the caret Position just past

--- a/script/console/textbuf/cursor.go
+++ b/script/console/textbuf/cursor.go
@@ -2,6 +2,8 @@
 
 package textbuf
 
+import "oblikovati.org/math"
+
 // Selection is a caret with an anchor. When Anchor == Caret it is a bare caret (no
 // highlighted range); otherwise it spans [Anchor, Caret) in either direction. The editor holds
 // one Selection; shift-movement moves Caret and leaves Anchor, plain movement collapses both.
@@ -53,7 +55,7 @@ func (b *Buffer) Up(p Position, goalCol int) Position {
 	if p.Line == 0 {
 		return Position{0, 0}
 	}
-	return Position{p.Line - 1, clampInt(goalCol, 0, b.LineLen(p.Line-1))}
+	return Position{p.Line - 1, math.Clamp(goalCol, 0, b.LineLen(p.Line-1))}
 }
 
 // Down moves the caret one line down, keeping goalCol clamped to the target line. At the
@@ -63,7 +65,7 @@ func (b *Buffer) Down(p Position, goalCol int) Position {
 		last := b.LineCount() - 1
 		return Position{last, b.LineLen(last)}
 	}
-	return Position{p.Line + 1, clampInt(goalCol, 0, b.LineLen(p.Line+1))}
+	return Position{p.Line + 1, math.Clamp(goalCol, 0, b.LineLen(p.Line+1))}
 }
 
 // LineEnd returns the end-of-line caret for p's line.

--- a/script/console/textbuf/helpers.go
+++ b/script/console/textbuf/helpers.go
@@ -10,17 +10,6 @@ func lineRangeError(i, count int) string {
 	return fmt.Sprintf("textbuf: line index %d out of range [0,%d)", i, count)
 }
 
-// clampInt constrains v to [lo, hi].
-func clampInt(v, lo, hi int) int {
-	if v < lo {
-		return lo
-	}
-	if v > hi {
-		return hi
-	}
-	return v
-}
-
 // insertLines returns lines with mid spliced in at index at, without aliasing mid into the
 // destination (the caller may reuse its slice). at is assumed in [0, len(lines)].
 func insertLines(lines [][]rune, at int, mid [][]rune) [][]rune {

--- a/solve/solve_test.go
+++ b/solve/solve_test.go
@@ -9,8 +9,6 @@ import (
 	"oblikovati.org/math"
 )
 
-func abs(v float64) float64 { return stdmath.Abs(v) }
-
 // fixedValue is a residual source pinning a single scalar to a target — the minimal
 // constraint for exercising the shared solver: residual = v − target.
 type fixedValue struct {
@@ -34,7 +32,7 @@ func TestSolveDrivesSingleVariableToTarget(t *testing.T) {
 	if !r.Converged {
 		t.Fatalf("did not converge: %+v", r)
 	}
-	if abs(x-5) > 1e-6 {
+	if stdmath.Abs(x-5) > 1e-6 {
 		t.Errorf("x = %v, want 5", x)
 	}
 	if r.Status != WellConstrained {
@@ -50,7 +48,7 @@ func TestSolveReportsUnderConstrained(t *testing.T) {
 	if !r.Converged {
 		t.Fatalf("did not converge: %+v", r)
 	}
-	if abs((b-a)-2) > 1e-6 {
+	if stdmath.Abs((b-a)-2) > 1e-6 {
 		t.Errorf("b-a = %v, want 2", b-a)
 	}
 	if r.Status != UnderConstrained || r.DOF != 1 {

--- a/test-utilities/nopscad/metrics.go
+++ b/test-utilities/nopscad/metrics.go
@@ -67,35 +67,21 @@ func meshMetrics(tris []triangle) Metrics {
 		return Metrics{}
 	}
 	var vol, area float64
-	min := omath.P3(omath.Scalar(math.Inf(1)), omath.Scalar(math.Inf(1)), omath.Scalar(math.Inf(1)))
-	max := omath.P3(omath.Scalar(math.Inf(-1)), omath.Scalar(math.Inf(-1)), omath.Scalar(math.Inf(-1)))
+	lo := omath.P3(omath.Scalar(math.Inf(1)), omath.Scalar(math.Inf(1)), omath.Scalar(math.Inf(1)))
+	hi := omath.P3(omath.Scalar(math.Inf(-1)), omath.Scalar(math.Inf(-1)), omath.Scalar(math.Inf(-1)))
 	o := omath.P3(0, 0, 0)
 	for _, t := range tris {
 		vol += float64(o.VectorTo(t.a).Dot(o.VectorTo(t.b).Cross(o.VectorTo(t.c)))) / 6
 		area += float64(t.a.VectorTo(t.b).Cross(t.a.VectorTo(t.c)).Length()) / 2
 		for _, p := range []omath.Point3{t.a, t.b, t.c} {
-			min = omath.P3(minS(min.X, p.X), minS(min.Y, p.Y), minS(min.Z, p.Z))
-			max = omath.P3(maxS(max.X, p.X), maxS(max.Y, p.Y), maxS(max.Z, p.Z))
+			lo = omath.P3(min(lo.X, p.X), min(lo.Y, p.Y), min(lo.Z, p.Z))
+			hi = omath.P3(max(hi.X, p.X), max(hi.Y, p.Y), max(hi.Z, p.Z))
 		}
 	}
 	if vol < 0 {
 		vol = -vol // orientation-agnostic: report enclosed magnitude
 	}
-	return Metrics{Volume: vol, Area: area, Min: min, Max: max, TriCount: len(tris)}
-}
-
-func minS(a, b omath.Scalar) omath.Scalar {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func maxS(a, b omath.Scalar) omath.Scalar {
-	if a > b {
-		return a
-	}
-	return b
+	return Metrics{Volume: vol, Area: area, Min: lo, Max: hi, TriCount: len(tris)}
 }
 
 // loadSTL reads a binary or ASCII STL file into facets. The 80-byte header of a


### PR DESCRIPTION
Three mechanical debt-retirement findings from the 2026-07 deep audit (§7), one commit per issue.

## G4 — builtin min/max + shared math.Clamp (#1652)

**63 helpers retired** (28 min/max, 11 abs, 24 clamp) across kernel, model, app, addin, script, solve and test-utilities:

- `math.Clamp[T cmp.Ordered]` and `math.Clamp01` landed with table tests — one documented contract (requires `lo <= hi`; NaN passes through) instead of the 8 divergent clamp shapes the audit measured.
- All local `min`/`max` deleted; call sites use the Go 1.21 builtins (incl. `minOf4/maxOf4` → variadic `min`/`max`).
- All `abs` copies deleted; call sites use stdlib `math.Abs`.
- `app.clampRange` and `ops.clampStep` thinned to documented wrappers over `math.Clamp` (empty-list contract / derived bounds).
- New `script -> math` edge added to archguard's import allowlist with a comment (console editor index clamping).

**Deliberate keeps** (semantics are not plain `[lo,hi]` clamping): `geom.clampFinite` (ignores ±Inf bounds), `geom.clampStep` (SSI rate limiter, stdmath NaN semantics), `ops.clampSpan` / `topo.clampDomain` (Inf→window substitution), `app/drawing_view_tools.clampIndex` (out-of-range resets to 0, not nearest bound), `gopherlua.clampLine` (out-of-range → last line), `theme.clamp01` (deliberately one-sided), `scene.absDot` (domain helper), and all `clamped*Knots` NURBS knot-vector constructors (not clamps). `head/` float32 helpers untouched per ADR-0026 §6.

**NaN note:** the retired if-based `min`/`max` returned the second operand for NaN inputs; the builtins propagate NaN. No call site relied on the old behavior (full suite green). `minOf4/maxOf4` already used `stdmath.Min/Max`, which match the builtins on NaN/-0.

## G5 — slices.Contains (#1653)

**14 helpers retired**: exact-equality membership (strings, uint64 ids, tokenKind, pointer identity for `*WorkPlane`/`*Point`/`*Sketch`) → `slices.Contains`; keyed searches (EdgeHandle unwrap, `bytes.Equal` ref-key) → `slices.ContainsFunc`; two substring helpers in tests → `strings.Contains`. `model/param`'s two side-by-side identical string searches are both gone.

**Deliberate keeps** (semantic, not membership): `sketch.containsLoop` (geometric loop containment), `geom.containsKnot` (tolerance-based, knotEps), `ops.strictlyContains` (B-rep body containment), `brep.dedgeLoopContains` (point-in-loop), `step.enumContains` (case-folded enum probe), and domain-type `contains`/`Contains` methods.

## G6 — one math.Lerp + Point2/Point3 Lerp (#1654)

**16 lerp sites converted, 13 helpers deleted** (+2 reworked, +1 thinned): `math.Lerp` fixes ONE canonical evaluation order — the fused `a + t*(b−a)`, bit-identical to both historical spellings (IEEE-754 multiplication commutes), with a `t==1` pin for endpoint exactness mirroring C++ `std::lerp` (P0811). `Point2.Lerp`/`Point3.Lerp` apply it per coordinate. Tests pin exact endpoints (`Lerp(a,b,0)==a`, `Lerp(a,b,1)==b`, including the adversarial `0.1→0.3` pair where the raw fused form rounds past `b`), midpoint, and extrapolation.

`ops.bilerp` is now two nested `Point3.Lerp` passes; `lerpToPlane` → `planeCrossing` over `Point3.Lerp`; `derived_view`'s disguised segment lerp converted; grep gate `func lerp` in kernel/model returns nothing.

**Deliberate keeps:** `geom.hpoint4.lerp` (homogeneous 4D blend in the NURBS-book `α·b+(1−α)·a` form, A5.1), `ops.slerpVec` (spherical), `clientgraphics.lerpColor` (float32 color ramp outside the kernel/model gate), `head/ui/viewcube.lerp3` (head module, ADR-0026 §6).

## Verification

- Full suite `go test ./... -count=1`: **green** (includes tessellation/volume/manifold regressions guarding the clamp/lerp consumers).
- `golangci-lint run ./...`: **0 issues** (run with `GOTOOLCHAIN=go1.24.2`; the local go1.26 toolchain crashes golangci-lint v2.1.0 regardless of this change).
- `gofmt`/`goimports` clean; retired-helper tests adapted to the shared functions, none weakened.

Closes #1652
Closes #1653
Closes #1654

🤖 Generated with [Claude Code](https://claude.com/claude-code)