### PR TITLE
Solver robustness: CPQR rank, Marquardt/Moré-Nielsen LM, relative FD step, redundancy naming (audit A13)

### DIFF
--- a/model/sketch/autodiff_convergence_test.go
+++ b/model/sketch/autodiff_convergence_test.go
@@ -118,19 +118,18 @@ func TestFarFromOriginAnalyticBeatsFiniteDifference(t *testing.T) {
 	cons, vars = build()
 	fd := solve.Solve(fdResiduals(cons), vars, solve.Options{MaxIterations: 200})
 
-	// FD's step underflows: it barely moves off the initial residual, so it never reaches
-	// the (now relative, #1420) tolerance — it reports non-convergence.
-	if fd.Converged || fd.Residual < initial*0.5 {
-		t.Errorf("finite-difference solve made unexpected progress (converged=%v residual=%g vs initial %g) — it was expected to stall at this scale", fd.Converged, fd.Residual, initial)
+	// Premise inverted by A13 (#1609): the FD fallback's step is now RELATIVE per variable
+	// (h = ∛ε·max(1, |x|)), so it no longer underflows at 1e10 — BOTH paths must converge to
+	// the relative tolerance. (The original premise pinned the absolute h=1e-7 stall; the
+	// analytic path stays primary, FD is the fallback that now merely works.)
+	if !fd.Converged {
+		t.Errorf("finite-difference solve stalled at scale despite the relative step: residual %g (initial %g)", fd.Residual, initial)
 	}
-	// The exact analytic Jacobian drives the system to the relative tolerance and converges
-	// — the relative tolerance (relTol·scale) is the achievable precision at scale 1e10
-	// (below it the coordinate ULP dominates, #1399).
 	if !analytic.Converged {
 		t.Errorf("analytic solve did not converge at scale: residual %g", analytic.Residual)
 	}
-	if analytic.Residual >= fd.Residual {
-		t.Errorf("analytic residual %g not better than stalled FD %g", analytic.Residual, fd.Residual)
+	if analytic.Residual > initial {
+		t.Errorf("analytic residual %g worse than initial %g", analytic.Residual, initial)
 	}
 	t.Logf("initial %.3e → analytic %.3e conv=%v (it=%d) vs FD %.3e conv=%v (it=%d)",
 		initial, analytic.Residual, analytic.Converged, analytic.Iterations, fd.Residual, fd.Converged, fd.Iterations)

--- a/model/sketch/solve_sketch.go
+++ b/model/sketch/solve_sketch.go
@@ -5,6 +5,7 @@ package sketch
 import (
 	"oblikovati.org/math"
 	"oblikovati.org/model/health"
+	"oblikovati.org/solve"
 )
 
 // variables returns the full DOF universe of the planar sketch: every point's X,Y
@@ -52,6 +53,21 @@ func (s *Sketch) ConflictingConstraints() []Constraint {
 	}
 	out := make([]Constraint, 0, len(r.Conflicts))
 	for _, i := range r.Conflicts {
+		out = append(out, cons[i])
+	}
+	return out
+}
+
+// RedundantConstraints returns the constraints whose removal restores full rank on an
+// over-constrained sketch — solvespace-style leave-one-out identification (audit A13, #1609):
+// where ConflictingConstraints names UNSATISFIABLE dimensions on a failed solve, this names
+// the linearly DEPENDENT ones behind an "over-constrained" verdict, so the UI can point at a
+// specific constraint to remove. nil when the sketch is not redundant.
+func (s *Sketch) RedundantConstraints() []Constraint {
+	cons := s.Constraints()
+	idx := solve.RedundantSources(residualSources(cons), s.variables())
+	out := make([]Constraint, 0, len(idx))
+	for _, i := range idx {
 		out = append(out, cons[i])
 	}
 	return out

--- a/model/sketch/solve_sketch_test.go
+++ b/model/sketch/solve_sketch_test.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestRedundantConstraintsNamesRemovableDuplicate pins the sketch-level surface of the A13
+// leave-one-out identification (#1609): a point pinned by a ground AND a duplicate anchor is
+// over-constrained; the sketch must name a removable constraint whose removal restores clean
+// DOF bookkeeping.
+func TestRedundantConstraintsNamesRemovableDuplicate(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	a := s.Points().Add(math.P2(0, 0))
+	b := s.Points().Add(math.P2(1, 0))
+	g := s.GeometricConstraints()
+	g.AddFix(a)
+	g.AddFix(b)
+	g.AddFix(b) // duplicate: redundant
+	if got := s.AnalyzeConstraints(); got.Redundant == 0 {
+		t.Fatalf("fixture drifted: expected an over-constrained sketch, got %+v", got)
+	}
+	red := s.RedundantConstraints()
+	if len(red) == 0 {
+		t.Fatal("RedundantConstraints named nothing on an over-constrained sketch")
+	}
+}

--- a/solve/linalg.go
+++ b/solve/linalg.go
@@ -116,59 +116,6 @@ func triangularSolve(a [][]float64, y []float64, cols int) []float64 {
 	return x
 }
 
-// matrixRank returns the numerical rank of an m×n matrix via Gauss–Jordan
-// elimination, counting pivots whose magnitude exceeds tol.
-func matrixRank(src [][]float64, tol float64) int {
-	rows := len(src)
-	if rows == 0 || len(src[0]) == 0 {
-		return 0
-	}
-	cols := len(src[0])
-	a := make([][]float64, rows)
-	for i := range a {
-		a[i] = append([]float64(nil), src[i]...)
-	}
-	rank, pivotRow := 0, 0
-	for col := 0; col < cols && pivotRow < rows; col++ {
-		if !pivotAt(a, pivotRow, col, tol) {
-			continue
-		}
-		clearColumn(a, pivotRow, col, cols)
-		pivotRow++
-		rank++
-	}
-	return rank
-}
-
-// pivotAt finds the largest-magnitude entry in col at or below pivotRow and swaps
-// it up; it reports whether a usable pivot (> tol) was found.
-func pivotAt(a [][]float64, pivotRow, col int, tol float64) bool {
-	sel := pivotRow
-	for r := pivotRow + 1; r < len(a); r++ {
-		if stdmath.Abs(a[r][col]) > stdmath.Abs(a[sel][col]) {
-			sel = r
-		}
-	}
-	if stdmath.Abs(a[sel][col]) < tol {
-		return false
-	}
-	a[pivotRow], a[sel] = a[sel], a[pivotRow]
-	return true
-}
-
-// clearColumn eliminates col from every other row using the pivot row.
-func clearColumn(a [][]float64, pivotRow, col, cols int) {
-	for r := 0; r < len(a); r++ {
-		if r == pivotRow {
-			continue
-		}
-		f := a[r][col] / a[pivotRow][col]
-		for c := col; c < cols; c++ {
-			a[r][c] -= f * a[pivotRow][c]
-		}
-	}
-}
-
 // infNorm returns the maximum absolute component of v.
 func infNorm(v []float64) float64 {
 	max := 0.0
@@ -178,4 +125,93 @@ func infNorm(v []float64) float64 {
 		}
 	}
 	return max
+}
+
+// pivotedQRRank is the rank of src by column-pivoted Householder QR with a threshold RELATIVE
+// to the largest pivot (Golub & Van Loan §5.4.2; audit A13 #1609): at step k the remaining
+// column of largest norm is swapped in, one Householder reflection zeroes it below the
+// diagonal, and the factorization stops when the pivot falls under relTol times the first
+// (largest) pivot — scale-invariant where the retired Gauss–Jordan absolute threshold dropped
+// rank on large-coordinate sketches.
+// rankRelTol is the CPQR pivot threshold RELATIVE to the largest pivot: rows are unit-
+// normalized upstream, so 1e-9 marks a pivot ~9 decades below the leading one as numerically
+// dependent — scale-free by construction.
+const rankRelTol = 1e-9 // tol:numeric — relative rank-revealing threshold
+
+func pivotedQRRank(src [][]float64) int {
+	rows := len(src)
+	if rows == 0 || len(src[0]) == 0 {
+		return 0
+	}
+	cols := len(src[0])
+	a := make([][]float64, rows)
+	for i := range a {
+		a[i] = append([]float64(nil), src[i]...)
+	}
+	rank, first := 0, 0.0
+	for k := 0; k < min(rows, cols); k++ {
+		swapLargestColumn(a, k)
+		v, pivot, ok := householderVector(a, k, rows)
+		if !ok {
+			break
+		}
+		if k == 0 {
+			first = stdmath.Abs(pivot)
+		}
+		if stdmath.Abs(pivot) < rankRelTol*first {
+			break
+		}
+		applyHouseholder(a, v, k, rows, cols)
+		rank++
+	}
+	return rank
+}
+
+// swapLargestColumn swaps the trailing column of largest sub-column norm (rows k..end) into
+// position k — the column pivoting that makes the QR factorization rank-revealing.
+func swapLargestColumn(a [][]float64, k int) {
+	cols := len(a[0])
+	best, bestNorm := k, subColumnNorm(a, k, k)
+	for c := k + 1; c < cols; c++ {
+		if n := subColumnNorm(a, c, k); n > bestNorm {
+			best, bestNorm = c, n
+		}
+	}
+	if best == k {
+		return
+	}
+	for r := range a {
+		a[r][k], a[r][best] = a[r][best], a[r][k]
+	}
+}
+
+// subColumnNorm is the Euclidean norm of column c from row k down.
+func subColumnNorm(a [][]float64, c, k int) float64 {
+	s := 0.0
+	for r := k; r < len(a); r++ {
+		s += a[r][c] * a[r][c]
+	}
+	return stdmath.Sqrt(s)
+}
+
+// applyHouseholder applies the reflection for Householder vector v (from householderVector at
+// step k) to the trailing columns of a.
+func applyHouseholder(a [][]float64, v []float64, k, rows, cols int) {
+	vTv := 0.0
+	for i := k; i < rows; i++ {
+		vTv += v[i] * v[i]
+	}
+	if vTv == 0 {
+		return
+	}
+	for c := k; c < cols; c++ {
+		dot := 0.0
+		for i := k; i < rows; i++ {
+			dot += v[i] * a[i][c]
+		}
+		f := 2 * dot / vTv
+		for i := k; i < rows; i++ {
+			a[i][c] -= f * v[i]
+		}
+	}
 }

--- a/solve/scaling.go
+++ b/solve/scaling.go
@@ -73,17 +73,19 @@ func rowNormalized(j [][]float64) [][]float64 {
 	return out
 }
 
-// augmentedLM builds the Levenberg–Marquardt least-squares system [J; √λ·I]·δ = [−r; 0],
+// augmentedLM builds the Levenberg–Marquardt least-squares system [J; √λ·D]·δ = [−r; 0]
+// with D = the Marquardt scaling diagonal (per-variable column norms, audit A13 #1609) —
 // whose QR solution is the damped Gauss–Newton step WITHOUT forming the normal equations
-// JᵀJ — so the condition number of an already-delicate J is not squared (#1420). The √λ·I
+// whose QR solution is the damped Gauss–Newton step WITHOUT forming the normal equations
+// JᵀJ — so the condition number of an already-delicate J is not squared (#1420). The √λ·D
 // block is the trust-region damping that keeps the augmented matrix full column rank near
-// singularities. The step uses the RAW Jacobian (not row-weighted): weighting by 1/‖Jᵢ‖
+// singularities, scaled so ill-scaled variables damp proportionally. The step uses the RAW Jacobian (not row-weighted): weighting by 1/‖Jᵢ‖
 // would down-weight a stiff constraint — e.g. a curvature (G2) residual — exactly where it
 // needs the most attention, stalling the solve. Nondimensionalisation is applied to the
 // convergence test, rank and conflict report instead (the observable, scale-sensitive
 // parts), not to the step direction.
-func augmentedLM(j [][]float64, r []float64, lambda float64, n int) ([][]float64, []float64) {
-	m := len(j)
+func augmentedLM(j [][]float64, r []float64, lambda float64, diag []float64) ([][]float64, []float64) {
+	m, n := len(j), len(diag)
 	sqrtL := stdmath.Sqrt(lambda)
 	aug := make([][]float64, m+n)
 	rhs := make([]float64, m+n)
@@ -93,7 +95,7 @@ func augmentedLM(j [][]float64, r []float64, lambda float64, n int) ([][]float64
 	}
 	for d := 0; d < n; d++ {
 		row := make([]float64, n)
-		row[d] = sqrtL
+		row[d] = sqrtL * diag[d] // Marquardt scaling: damping proportional to the column norm (#1609)
 		aug[m+d] = row
 	}
 	return aug, rhs

--- a/solve/solve.go
+++ b/solve/solve.go
@@ -166,29 +166,78 @@ func converged(r []float64, j [][]float64, scale, relTol float64) bool {
 }
 
 // dampedStep performs one damped Gauss–Newton update from the precomputed Jacobian j,
-// adjusting lambda. The step solves the nondimensionalised LM system [Jₛ; √λ·I]·δ = [−rₛ; 0]
-// by Householder QR — no normal-equations JᵀJ, so the condition number is not squared
-// (#1420). It accepts the step only if it reduces the weighted residual norm, otherwise it
-// raises the damping and retries. Returns the new residual vector and whether it improved.
+// adjusting lambda by the Moré/Nielsen gain-ratio schedule (audit A13, #1609). The step solves
+// the Marquardt-scaled LM system [Jₛ; √λ·D]·δ = [−rₛ; 0] by Householder QR — D = diag of the
+// column norms, so damping is invariant to per-variable scaling (an ill-scaled sketch mixing
+// 1e-2 and 1e3 dimensions no longer stalls) — and accepts on any residual decrease: λ shrinks
+// by the gain-ratio factor max(1/3, 1−(2ρ−1)³) on accept and grows by a doubling ν on reject
+// (Madsen/Nielsen/Tingleff 2004), terminating when λ overflows the trust budget instead of the
+// old fixed ×10/8-try cap that declared solvable systems falsely stuck.
 func dampedStep(res []Residual, vars []*math.Scalar, j [][]float64, r []float64, lambda *float64) ([]float64, bool) {
 	current := sumSquares(r)
-	n := len(vars)
-	for try := 0; try < 8; try++ {
-		aug, rhs := augmentedLM(j, r, *lambda, n)
-		delta, ok := leastSquares(aug, rhs)
-		if ok {
+	d := columnNorms(j, len(vars))
+	nu := 2.0
+	for *lambda < lambdaMax {
+		aug, rhs := augmentedLM(j, r, *lambda, d)
+		if delta, ok := leastSquares(aug, rhs); ok {
 			snapshot := readVars(vars)
 			applyDelta(vars, delta)
 			trial := evalResiduals(res)
-			if sumSquares(trial) < current {
-				*lambda = stdmath.Max(*lambda/10, 1e-12) // tol:numeric — LM damping floor
+			if next := sumSquares(trial); next < current {
+				*lambda *= gainRatioShrink(current, next, delta, j, r)
+				*lambda = stdmath.Max(*lambda, 1e-12) // tol:numeric — LM damping floor
 				return trial, true
 			}
 			writeVars(vars, snapshot)
 		}
-		*lambda *= 10
+		*lambda *= nu
+		nu *= 2
 	}
 	return r, false
+}
+
+// lambdaMax is the damping magnitude at which LM gives up: the step is then ~1e15 times
+// shorter than Gauss–Newton, indistinguishable from no progress in float64.
+const lambdaMax = 1e15 // tol:numeric — LM trust-budget ceiling
+
+// gainRatioShrink is the Moré/Nielsen accept-side damping factor max(1/3, 1−(2ρ−1)³), where
+// the gain ratio ρ compares the achieved decrease against the linear model's prediction
+// L(0)−L(δ) = δᵀ(λ·D²·δ − Jᵀr) (Madsen/Nielsen/Tingleff eq. 2.21, with Marquardt scaling).
+func gainRatioShrink(current, next float64, delta []float64, j [][]float64, r []float64) float64 {
+	predicted := predictedDecrease(delta, j, r)
+	if predicted <= 0 {
+		return 1.0 / 3
+	}
+	rho := (current - next) / predicted
+	f := 1 - (2*rho-1)*(2*rho-1)*(2*rho-1)
+	return stdmath.Max(1.0/3, f)
+}
+
+// predictedDecrease is the linear-model decrease ‖r‖² − ‖r + J·δ‖² for step δ.
+func predictedDecrease(delta []float64, j [][]float64, r []float64) float64 {
+	after := 0.0
+	for i := range j {
+		ri := r[i]
+		for c, dc := range delta {
+			ri += j[i][c] * dc
+		}
+		after += ri * ri
+	}
+	return sumSquares(r) - after
+}
+
+// columnNorms returns the Marquardt scaling diagonal: each variable's Jacobian column norm,
+// floored at 1 so a variable no constraint currently touches still receives bounded damping.
+func columnNorms(j [][]float64, n int) []float64 {
+	d := make([]float64, n)
+	for c := 0; c < n; c++ {
+		s := 0.0
+		for i := range j {
+			s += j[i][c] * j[i][c]
+		}
+		d[c] = stdmath.Max(stdmath.Sqrt(s), 1)
+	}
+	return d
 }
 
 // conflictingSources returns the residual sources still unsatisfied at a failed solve —
@@ -239,7 +288,7 @@ func AnalyzeDOF(res []Residual, vars []*math.Scalar) DOFAnalysis {
 // never spuriously dropped, giving scale-invariant DOF classification (#1420).
 func analyzeJacobian(j [][]float64, n int) DOFAnalysis {
 	m := len(j)
-	rank := matrixRank(rowNormalized(j), 1e-7) // tol:numeric — relative rank tolerance (rows are unit-norm)
+	rank := pivotedQRRank(rowNormalized(j)) // relative rank-revealing CPQR (see rankRelTol)
 	a := DOFAnalysis{Variables: n, Equations: m, Rank: rank, DOF: n - rank, Redundant: m - rank}
 	switch {
 	case a.Redundant > 0:
@@ -313,11 +362,13 @@ func scatterRow(partials []float64, dvars []*math.Scalar, col map[*math.Scalar]i
 	return row
 }
 
-// finiteDiffJacobian builds the Jacobian by central differences (h=1e-7) — the fallback
-// for residual sources that cannot supply analytic partials. It perturbs the live
-// variables and restores them, so it must not be used on the interactive analysis path.
+// finiteDiffJacobian builds the Jacobian by central differences with a per-variable RELATIVE
+// step h = ∛ε·max(1, |x|) (Nocedal & Wright §8.1; cube root for central differences) — the
+// fallback for residual sources that cannot supply analytic partials. The retired absolute
+// h=1e-7 made partials vanish into round-off at large coordinates (a sketch translated to 1e5
+// lost rank for no geometric reason, audit A13 #1609). It perturbs the live variables and
+// restores them, so it must not be used on the interactive analysis path.
 func finiteDiffJacobian(res []Residual, vars []*math.Scalar) [][]float64 {
-	const h = 1e-7 // tol:numeric — finite-difference Jacobian step (analytic path is #1417)
 	m := len(evalResiduals(res))
 	j := make([][]float64, m)
 	for i := range j {
@@ -325,17 +376,22 @@ func finiteDiffJacobian(res []Residual, vars []*math.Scalar) [][]float64 {
 	}
 	for col, v := range vars {
 		orig := *v
+		h := math.Scalar(fdStep * stdmath.Max(1, stdmath.Abs(float64(orig))))
 		*v = orig + h
 		rp := evalResiduals(res)
 		*v = orig - h
 		rm := evalResiduals(res)
 		*v = orig
 		for i := 0; i < m; i++ {
-			j[i][col] = (rp[i] - rm[i]) / (2 * h)
+			j[i][col] = (rp[i] - rm[i]) / float64(2*h)
 		}
 	}
 	return j
 }
+
+// fdStep is the relative central-difference step coefficient ∛ε ≈ 6e-6: optimal for the
+// O(h²) truncation vs ε/h round-off tradeoff of central differences (Nocedal & Wright).
+const fdStep = 6.06e-6 // tol:numeric — cube root of float64 machine epsilon
 
 func readVars(vars []*math.Scalar) []float64 {
 	out := make([]float64, len(vars))
@@ -355,4 +411,31 @@ func applyDelta(vars []*math.Scalar, delta []float64) {
 	for i, v := range vars {
 		*v += delta[i]
 	}
+}
+
+// RedundantSources identifies WHICH residual sources are removable to fix an over-constrained
+// system by solvespace's leave-one-out search (System::FindWhichToRemoveToFixJacobian; audit
+// A13 #1609): a source is removable when dropping its rows leaves the rank unchanged — its
+// equations were linearly dependent on the rest — so removing it restores DOF bookkeeping
+// without freeing the sketch. Returns source indices in input order; empty when the system is
+// not redundant. O(sources × rank cost), invoked on demand (a diagnosis, not the solve path).
+//
+//	for _, i := range solve.RedundantSources(residuals, vars) { flag(residuals[i]) }
+func RedundantSources(res []Residual, vars []*math.Scalar) []int {
+	j := Jacobian(res, vars)
+	full := analyzeJacobian(j, len(vars))
+	if full.Redundant == 0 {
+		return nil
+	}
+	var out []int
+	row := 0
+	for i, src := range res {
+		k := len(src.Residuals())
+		rest := append(append([][]float64(nil), j[:row]...), j[row+k:]...)
+		if pivotedQRRank(rowNormalized(rest)) == full.Rank {
+			out = append(out, i)
+		}
+		row += k
+	}
+	return out
 }

--- a/solve/solver_robustness_test.go
+++ b/solve/solver_robustness_test.go
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package solve
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// Audit A13 (#1609): solver robustness vs solvespace practice — redundant-constraint
+// identification, scale-invariant CPQR rank, Marquardt-scaled Moré/Nielsen LM damping, and a
+// relative finite-difference step.
+
+// linRes is a linear residual source a·x − c with exact partials, for constructing systems
+// with known rank/redundancy.
+type linRes struct {
+	vars []*math.Scalar
+	a    [][]float64
+	c    []float64
+}
+
+func (l linRes) Residuals() []float64 {
+	out := make([]float64, len(l.a))
+	for i, row := range l.a {
+		s := -l.c[i]
+		for k, v := range l.vars {
+			s += row[k] * float64(*v)
+		}
+		out[i] = s
+	}
+	return out
+}
+
+func (l linRes) Partials(int) []float64 { return nil } // not used; FD covers it
+
+// TestRedundantSourcesNamesTheRemovableConstraint: x=1, y=2, and a REDUNDANT duplicate of x=1
+// — the leave-one-out search must name both copies of the dependent constraint (removing
+// either restores full rank) and never the independent y constraint.
+func TestRedundantSourcesNamesTheRemovableConstraint(t *testing.T) {
+	x, y := math.Scalar(0), math.Scalar(0)
+	vars := []*math.Scalar{&x, &y}
+	res := []Residual{
+		linRes{vars, [][]float64{{1, 0}}, []float64{1}}, // 0: x = 1
+		linRes{vars, [][]float64{{0, 1}}, []float64{2}}, // 1: y = 2
+		linRes{vars, [][]float64{{2, 0}}, []float64{2}}, // 2: 2x = 2 — dependent on 0
+	}
+	got := RedundantSources(res, vars)
+	want := map[int]bool{0: true, 2: true}
+	if len(got) != 2 || !want[got[0]] || !want[got[1]] {
+		t.Errorf("RedundantSources = %v, want the two dependent x-constraints {0, 2}", got)
+	}
+}
+
+// TestRankIsScaleInvariant: the same rank-2 system evaluated at 1e-6…1e6 coordinate scales
+// must report identical rank — the retired absolute Gauss–Jordan threshold dropped rank at
+// scale (audit A13).
+func TestRankIsScaleInvariant(t *testing.T) {
+	for _, scale := range []float64{1e-6, 1e-3, 1, 1e3, 1e6} {
+		j := [][]float64{
+			{scale, 0, 0},
+			{0, scale, 0},
+			{scale, scale, 0}, // dependent
+		}
+		if rank := pivotedQRRank(rowNormalized(j)); rank != 2 {
+			t.Errorf("scale %g: rank = %d, want 2", scale, rank)
+		}
+	}
+}
+
+// TestPivotedQRRankKnownDeficiency: constructed Jacobians with known ranks across magnitudes.
+func TestPivotedQRRankKnownDeficiency(t *testing.T) {
+	cases := []struct {
+		j    [][]float64
+		want int
+	}{
+		{[][]float64{{1, 2}, {2, 4}}, 1}, // proportional rows
+		{[][]float64{{1, 0}, {0, 1}}, 2}, // identity
+		// NOTE deliberately absent: {{1e6,0},{0,1e-6}} — a 1e12 pivot spread IS numerical
+		// rank 1 at relTol 1e-9 (Golub & Van Loan numerical rank); the production path
+		// row-normalizes first, covered by TestRankIsScaleInvariant.
+		{[][]float64{{1, 1}, {1, 1 + 1e-13}}, 1},             // numerically dependent
+		{[][]float64{{0, 0}, {0, 0}}, 0},                     // zero
+		{[][]float64{{3, 1, 2}, {6, 2, 4}, {1, 0, 0}}, 2},    // one dependent of three
+		{[][]float64{{1, 0, 0}, {0, 1, 0}, {0, 0, 1e-4}}, 3}, // small but genuine pivot
+	}
+	for i, c := range cases {
+		if got := pivotedQRRank(c.j); got != c.want {
+			t.Errorf("case %d: rank = %d, want %d", i, got, c.want)
+		}
+	}
+}
+
+// distRes is a nonlinear distance residual |p−q|−d with FD partials, for convergence fixtures.
+type distRes struct {
+	px, py, qx, qy *math.Scalar
+	d              float64
+}
+
+func (r distRes) Residuals() []float64 {
+	dx := float64(*r.qx - *r.px)
+	dy := float64(*r.qy - *r.py)
+	return []float64{stdmath.Hypot(dx, dy) - r.d}
+}
+
+// TestIllScaledSystemConverges: dimensions spanning 1e-2…1e3 in one system — the retired ×10
+// 8-try damping cap declared such systems falsely stuck; Marquardt scaling with Moré/Nielsen
+// damping must converge (audit A13). The false-stuck verdict froze whole dialog flows through
+// the sick-config commit gate (#1595).
+func TestIllScaledSystemConverges(t *testing.T) {
+	ax, ay := math.Scalar(0), math.Scalar(0)
+	bx, by := math.Scalar(900), math.Scalar(100) // far from the 1000-length target
+	cx, cy := math.Scalar(900.004), math.Scalar(100.002)
+	vars := []*math.Scalar{&bx, &by, &cx, &cy}
+	res := []Residual{
+		distRes{&ax, &ay, &bx, &by, 1000}, // large dimension
+		distRes{&bx, &by, &cx, &cy, 0.01}, // tiny dimension hanging off it
+	}
+	r := Solve(res, vars, Options{})
+	if !r.Converged {
+		t.Fatalf("ill-scaled but solvable system reported stuck: residual %g after %d iterations", r.Residual, r.Iterations)
+	}
+	if got := stdmath.Hypot(float64(bx), float64(by)); stdmath.Abs(got-1000) > 1e-6*1000 {
+		t.Errorf("|b| = %g, want 1000", got)
+	}
+	if got := stdmath.Hypot(float64(cx-bx), float64(cy-by)); stdmath.Abs(got-0.01) > 1e-4 {
+		t.Errorf("|c-b| = %g, want 0.01", got)
+	}
+}
+
+// TestLargeCoordinateSystemKeepsRank: a well-constrained system translated to (1e5, 1e5) must
+// keep DOF=0 — the absolute FD step and absolute rank threshold both used to break this.
+func TestLargeCoordinateSystemKeepsRank(t *testing.T) {
+	const off = 1e5
+	px, py := math.Scalar(off), math.Scalar(off)
+	qx, qy := math.Scalar(off+3), math.Scalar(off)
+	vars := []*math.Scalar{&qx, &qy}
+	res := []Residual{
+		distRes{&px, &py, &qx, &qy, 5},                            // distance from the fixed p
+		linRes{vars, [][]float64{{0, 1}}, []float64{float64(py)}}, // qy pinned at the offset height
+	}
+	r := Solve(res, vars, Options{})
+	if !r.Converged {
+		t.Fatalf("large-coordinate solve stuck: residual %g", r.Residual)
+	}
+	if r.DOF != 0 || r.Redundant != 0 {
+		t.Errorf("DOF analysis at 1e5 = DOF %d, redundant %d, want 0/0 (phantom rank drop)", r.DOF, r.Redundant)
+	}
+}
+
+// TestVerdictsAreScaleInvariant: the same system at 1e-3× and 1e3× uniform scale must produce
+// identical DOF and redundancy verdicts.
+func TestVerdictsAreScaleInvariant(t *testing.T) {
+	verdict := func(scale float64) DOFAnalysis {
+		px, py := math.Scalar(0), math.Scalar(0)
+		qx, qy := math.Scalar(3*scale), math.Scalar(0)
+		vars := []*math.Scalar{&qx, &qy}
+		res := []Residual{
+			distRes{&px, &py, &qx, &qy, 5 * scale},
+			linRes{vars, [][]float64{{0, 1}}, []float64{0}},
+		}
+		return Solve(res, vars, Options{}).DOFAnalysis
+	}
+	small, big := verdict(1e-3), verdict(1e3)
+	if small.DOF != big.DOF || small.Redundant != big.Redundant || small.Status != big.Status {
+		t.Errorf("verdicts differ across scale: 1e-3 → %+v, 1e3 → %+v", small, big)
+	}
+}


### PR DESCRIPTION
## What

All four A13 solver corners, per the issue's prescription and the solvespace oracle:

1. **Column-pivoted QR rank** with a relative-to-largest-pivot threshold replaces Gauss–Jordan @ absolute 1e-7 — scale-invariant DOF/redundancy verdicts (retired code deleted).
2. **Marquardt scaling + Moré/Nielsen damping** replaces the ×10/8-try LM cap: √λ·diag(column norms) augmentation, gain-ratio shrink `max(1/3, 1−(2ρ−1)³)` on accept, ν-doubling on reject, trust-budget termination. The false-stuck class is gone — including the **NopSCADlib star washer resize** (one of the 13 red bridge e2e in #1693/MCPBridge#86, now green).
3. **Relative FD step** `h = ∛ε·max(1,|x|)` central differences: the absolute-step stall at large coordinates is fixed, and the test that pinned the stall now asserts both Jacobian paths converge at 1e10.
4. **Leave-one-out redundancy identification** (`solve.RedundantSources` + `Sketch.RedundantConstraints`): over-constrained sketches name WHICH constraint to remove.

## Tests

New: redundancy naming (solve + sketch level), CPQR known-rank across scales, ill-scaled convergence (1e-2…1e3 span), large-coordinate DOF=0 at 1e5, scale-invariant verdicts at 1e-3×/1e3×. Premise inversion: the FD-stall test (documented). Full repo suite + lint green; bridge `TestNopStarWasher` verified green live in-proc.

Closes #1609

🤖 Generated with [Claude Code](https://claude.com/claude-code)