### PR TITLE
Scale-invariant math-layer numerics (audit A15)

### DIFF
--- a/kernel/geom/bspline_remove.go
+++ b/kernel/geom/bspline_remove.go
@@ -2,7 +2,11 @@
 
 package geom
 
-import "oblikovati.org/math"
+import (
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
 
 // Public knot removal on the rational B-spline types. Removal is approximate and so
 // reports how many of the requested removals were actually applied within tol; it is
@@ -21,7 +25,7 @@ func (c BSplineCurve) RemoveKnot(u float64, num int, tol float64) (BSplineCurve,
 	if err != nil {
 		return BSplineCurve{}, 0, err
 	}
-	newU, newPw, removed := removeKnotHomog(c.Degree, c.Knots, curveToHomog(c.Ctrl, c.Weights), u, r, s, eff, tol)
+	newU, newPw, removed := removeKnotHomog(c.Degree, c.Knots, curveToHomog(c.Ctrl, c.Weights), u, r, s, eff, rationalRemovalTol(tol, ctrlNorms3(c.Ctrl), c.Weights))
 	if removed == 0 {
 		return c, 0, nil
 	}
@@ -36,7 +40,7 @@ func (c BSplineCurve2d) RemoveKnot(u float64, num int, tol float64) (BSplineCurv
 	if err != nil {
 		return BSplineCurve2d{}, 0, err
 	}
-	newU, newPw, removed := removeKnotHomog(c.Degree, c.Knots, curve2dToHomog(c.Ctrl, c.Weights), u, r, s, eff, tol)
+	newU, newPw, removed := removeKnotHomog(c.Degree, c.Knots, curve2dToHomog(c.Ctrl, c.Weights), u, r, s, eff, rationalRemovalTol(tol, ctrlNorms2(c.Ctrl), c.Weights))
 	if removed == 0 {
 		return c, 0, nil
 	}
@@ -125,4 +129,42 @@ func rowToHomog(s BSplineSurface, i int) []hpoint4 {
 		row[j] = hpoint4FromCurve(s.Ctrl[i][j], s.Weights[i][j])
 	}
 	return row
+}
+
+// rationalRemovalTol converts a GEOMETRIC (3D) knot-removal tolerance into the homogeneous
+// 4-space threshold that bounds it (Piegl & Tiller eq. 5.30): a homogeneous control move of d
+// displaces the rational curve by at most d·(1+maxᵢ|Pᵢ|)/minᵢwᵢ, so the homogeneous test uses
+// tol·min(w)/(1+max|P|). For a non-rational curve near the origin this reduces to ≈tol, and for
+// heavy weights it prevents the silent over-removal the raw 4-space distance allowed (audit
+// A15, #1611).
+func rationalRemovalTol(tol float64, maxNorm float64, weights []float64) float64 {
+	minW := weights[0]
+	for _, w := range weights {
+		if w < minW {
+			minW = w
+		}
+	}
+	return tol * minW / (1 + maxNorm)
+}
+
+// ctrlNorms3 is the largest control-point distance from the origin.
+func ctrlNorms3(ctrl []math.Point3) float64 {
+	m := 0.0
+	for _, p := range ctrl {
+		if d := stdmath.Sqrt(float64(p.X*p.X + p.Y*p.Y + p.Z*p.Z)); d > m {
+			m = d
+		}
+	}
+	return m
+}
+
+// ctrlNorms2 is the 2D analogue of ctrlNorms3.
+func ctrlNorms2(ctrl []math.Point2) float64 {
+	m := 0.0
+	for _, p := range ctrl {
+		if d := stdmath.Sqrt(float64(p.X*p.X + p.Y*p.Y)); d > m {
+			m = d
+		}
+	}
+	return m
 }

--- a/kernel/geom/nurbs_remove_weighted_test.go
+++ b/kernel/geom/nurbs_remove_weighted_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestWeightedKnotRemovalBoundsGeometricDeviation (audit A15, #1611): on a rational curve with
+// weights spanning [0.1, 10], the homogeneous 4-space removal test must bound the TRUE 3D
+// deviation (P&T eq. 5.30 weight correction) — the raw 4-space distance under-weighted heavy
+// control points and silently deformed the curve beyond tolerance.
+func TestWeightedKnotRemovalBoundsGeometricDeviation(t *testing.T) {
+	knots := []float64{0, 0, 0, 0.5, 1, 1, 1}
+	ctrl := []math.Point3{math.P3(0, 0, 0), math.P3(1, 2, 0), math.P3(3, 2.2, 0), math.P3(4, 0, 0)}
+	weights := []float64{1, 20, 0.05, 1} // 400× spread: the raw 4-space distance under-bounds the low-weight point's 3D motion
+	c, err := NewBSplineCurve(2, ctrl, weights, knots)
+	if err != nil {
+		t.Fatalf("NewBSplineCurve: %v", err)
+	}
+	const tol = 2e-3
+	out, removed, err := c.RemoveKnot(0.5, 1, tol)
+	if err != nil {
+		t.Fatalf("RemoveKnot: %v", err)
+	}
+	if removed == 0 {
+		return // refusing is always within contract; the bound test below only applies to removals
+	}
+	worst := 0.0
+	for i := 0; i <= 64; i++ {
+		u := float64(i) / 64
+		if d := float64(c.PointAt(u).DistanceTo(out.PointAt(u))); d > worst {
+			worst = d
+		}
+	}
+	if worst > tol {
+		t.Errorf("knot removal moved the rational curve by %g > tol %g (weight correction missing)", worst, tol)
+	}
+}
+
+// TestBenignKnotRemovalStillHappens: the weight correction must not be so conservative that a
+// plainly redundant knot (inserted then removed on a benign non-rational curve) is refused.
+func TestBenignKnotRemovalStillHappens(t *testing.T) {
+	knots := []float64{0, 0, 0, 1, 1, 1}
+	ctrl := []math.Point3{math.P3(0, 0, 0), math.P3(1, 1, 0), math.P3(2, 0, 0)}
+	c, err := NewBSplineCurve(2, ctrl, []float64{1, 1, 1}, knots)
+	if err != nil {
+		t.Fatalf("NewBSplineCurve: %v", err)
+	}
+	dense, err := c.InsertKnot(0.5, 1)
+	if err != nil {
+		t.Fatalf("InsertKnot: %v", err)
+	}
+	_, removed, err := dense.RemoveKnot(0.5, 1, 1e-9)
+	if err != nil {
+		t.Fatalf("RemoveKnot: %v", err)
+	}
+	if removed != 1 {
+		t.Errorf("redundant knot not removed (removed=%d) — the 5.30 correction is over-conservative", removed)
+	}
+}

--- a/math/mat_internal.go
+++ b/math/mat_internal.go
@@ -2,6 +2,8 @@
 
 package math
 
+import stdmath "math"
+
 // Shared small-matrix kernels used by both Matrix4 (its 3×3 linear block) and
 // Matrix3 (its full 3×3 homogeneous form). Row-major throughout: index r*n+c.
 
@@ -12,11 +14,16 @@ func det3(m [9]Scalar) Scalar {
 		m[2]*(m[3]*m[7]-m[4]*m[6])
 }
 
-// invert3x3 returns the inverse of a row-major 3×3 matrix and true, or the zero
-// matrix and false when it is singular (|det| <= DefaultTolerance).
+// invert3x3 returns the inverse of a row-major 3×3 matrix and true, or the zero matrix and
+// false when it is singular. Singularity is judged by the determinant NORMALIZED by the
+// Hadamard bound (the product of row norms, |det| ≤ Πᵢ‖rᵢ‖, Golub & Van Loan): the ratio is a
+// scale-invariant conditioning measure, where the retired absolute |det| ≤ DefaultTolerance
+// falsely rejected a perfectly conditioned uniform-scale-1e-3 matrix (det = 1e-9; audit A15,
+// #1611).
 func invert3x3(m [9]Scalar) ([9]Scalar, bool) {
 	det := det3(m)
-	if det <= DefaultTolerance && det >= -DefaultTolerance {
+	h := hadamardBound(m)
+	if h == 0 || stdmath.Abs(float64(det)) <= 1e-12*float64(h) { // tol:numeric — relative singularity ratio
 		return [9]Scalar{}, false
 	}
 	inv := adjugate3(m)
@@ -44,4 +51,13 @@ func mul3x3(a, b [9]Scalar) [9]Scalar {
 		}
 	}
 	return out
+}
+
+// hadamardBound is the product of the row norms — the Hadamard upper bound on |det|, used to
+// normalize the singularity test so it is invariant under uniform scaling.
+func hadamardBound(m [9]Scalar) Scalar {
+	row := func(i int) float64 {
+		return stdmath.Sqrt(float64(m[3*i]*m[3*i] + m[3*i+1]*m[3*i+1] + m[3*i+2]*m[3*i+2]))
+	}
+	return Scalar(row(0) * row(1) * row(2))
 }

--- a/math/scale_numerics_test.go
+++ b/math/scale_numerics_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package math
+
+import (
+	stdmath "math"
+	"testing"
+)
+
+// Audit A15 (#1611): foundation-layer primitives must be scale-invariant.
+
+// TestInvert3x3ScaleSweep: a perfectly conditioned uniform-scale matrix must invert at every
+// scale (the retired absolute |det| test rejected s ≤ 1e-3, whose det is 1e-9), and a genuinely
+// rank-deficient matrix must be rejected at every scale.
+func TestInvert3x3ScaleSweep(t *testing.T) {
+	for _, s := range []float64{1e-6, 1e-3, 1, 1e3, 1e6} {
+		m := [9]Scalar{Scalar(s), 0, 0, 0, Scalar(s), 0, 0, 0, Scalar(s)}
+		inv, ok := invert3x3(m)
+		if !ok {
+			t.Errorf("scale %g: conditioned diagonal falsely singular", s)
+			continue
+		}
+		for i := 0; i < 3; i++ {
+			if got := float64(inv[4*i] * m[4*i]); stdmath.Abs(got-1) > 1e-12 {
+				t.Errorf("scale %g: M·M⁻¹ diagonal = %g, want 1", s, got)
+			}
+		}
+		deficient := [9]Scalar{Scalar(s), 0, 0, Scalar(2 * s), 0, 0, 0, 0, Scalar(s)} // rows 0∥1
+		if _, ok := invert3x3(deficient); ok {
+			t.Errorf("scale %g: rank-deficient matrix inverted", s)
+		}
+	}
+}
+
+// TestAngleToAccurateNearZeroAndPi: pairs with analytic angles 1e-9…1e-5 rad (constructed by
+// exact small rotations) must compute to within a tenth of the 1e-9 angular tolerance — the
+// retired acos form had a ~1e-8 noise floor at the clamped ±1 ends.
+func TestAngleToAccurateNearZeroAndPi(t *testing.T) {
+	for _, theta := range []float64{1e-9, 1e-8, 1e-7, 1e-6, 1e-5} {
+		u := V3(1, 0, 0)
+		v := V3(Scalar(stdmath.Cos(theta)), Scalar(stdmath.Sin(theta)), 0)
+		if got := float64(u.AngleTo(v)); stdmath.Abs(got-theta) > 1e-10+1e-6*theta {
+			t.Errorf("angle %g: computed %g (err %g)", theta, got, got-theta)
+		}
+		w := V3(Scalar(-stdmath.Cos(theta)), Scalar(stdmath.Sin(theta)), 0) // π−θ from u
+		want := stdmath.Pi - theta
+		if got := float64(u.AngleTo(w)); stdmath.Abs(got-want) > 1e-10+1e-6*want {
+			t.Errorf("angle near π (%g): computed %g (err %g)", want, got, got-want)
+		}
+	}
+}

--- a/math/vector3.go
+++ b/math/vector3.go
@@ -68,13 +68,15 @@ func (v Vector3) AsPoint() Point3 {
 
 // AngleTo returns the unsigned angle in radians between v and o, in [0, π].
 // Returns 0 when either vector is zero-length (no defined direction).
+// Computed in the Kahan form atan2(|v×o|, v·o), which is fully accurate near 0 and π —
+// the retired acos(dot) form had a ~1e-8 rad noise floor there (√ε amplification at the
+// clamped ±1 ends), noisier than the 1e-9 tolerances its consumers compare against
+// (audit A15, #1611).
 func (v Vector3) AngleTo(o Vector3) Scalar {
-	denom := v.Length() * o.Length()
-	if denom == 0 {
+	if v.Length() == 0 || o.Length() == 0 {
 		return 0
 	}
-	// clampUnit guards against |cos| slightly exceeding 1 from rounding.
-	return stdmath.Acos(Clamp(v.Dot(o)/denom, -1, 1))
+	return Scalar(stdmath.Atan2(float64(v.Cross(o).Length()), float64(v.Dot(o))))
 }
 
 // IsEqualTo reports whether v and o are componentwise equal within tol. Pass


### PR DESCRIPTION
## What

- **`invert3x3`**: Hadamard-normalized determinant test (relative ratio) replaces the absolute `|det| ≤ DefaultTolerance` — uniform-scale-1e-3 matrices no longer falsely singular; scale sweep 1e-6…1e6 with rank-deficient rejection at every scale.
- **`Vector3.AngleTo`**: Kahan `atan2(|u×v|, u·v)` replaces `acos(dot)` — accurate at 0/π where the old form's ~1e-8 noise floor exceeded the 1e-9 tolerances consumers gate on; accuracy tests at 1e-9…1e-5 rad near both ends.
- **Rational knot removal**: geometric tolerance now converts through the P&T eq. 5.30 weight correction `tol·min(w)/(1+max|P|)` before the homogeneous 4-space comparison; deviation-bound invariant test (weights spanning 400×) + benign-removal anti-over-conservatism guard. Honest note: the bound test locks the invariant but did not go red on constructible fixtures — the correction is strictly conservative and literature-prescribed.
- Item 3 of the audit (absolute wire closure tolerances) was **already fixed by A14/#1610** — verified resolution-relative and guard-scoped; stale premise documented.

Full repo suite + lint green.

Closes #1611

🤖 Generated with [Claude Code](https://claude.com/claude-code)