### PR TITLE
M40 A11: cull the boolean pipeline's all-pairs loops with spatial indexes

### DIFF
--- a/kernel/brep/arrange2d.go
+++ b/kernel/brep/arrange2d.go
@@ -51,12 +51,15 @@ func Arrange(segments [][2]math.Point2) []Face2D {
 
 // planarize splits every segment at its intersections with the others and welds the
 // resulting points, returning the welded points and the elementary (crossing-free)
-// undirected edges as index pairs.
+// undirected edges as index pairs. Pair candidacy comes from a uniform grid hash over the
+// segments' padded AABBs (#1607), retiring the O(S²) all-pairs scan; the narrow phase and
+// its ordering are unchanged, so the arrangement is identical.
 func planarize(segments [][2]math.Point2) ([]math.Point2, [][2]int) {
 	weld := newWelder()
 	edges := map[[2]int]bool{}
+	cull := newSegmentCullGrid(segments)
 	for i, seg := range segments {
-		for _, e := range splitOne(seg, segments, i, weld) {
+		for _, e := range splitOne(seg, segments, cull.candidates(i), weld) {
 			if e[0] != e[1] {
 				edges[canonEdge(e[0], e[1])] = true
 			}
@@ -91,10 +94,13 @@ const tjTol = 1e-7 // tol:calibrated — matches the welder grid; see arrTol
 // but the host edge is left whole, so the chain dangles and the face never partitions. This
 // pass welds such chains shut, the crux of robust planar arrangement under faceted-curve cuts.
 func splitTJunctions(pts []math.Point2, edges map[[2]int]bool) {
+	// The welded point set is fixed here (only edges split), so one grid hash over it culls
+	// every vertex-on-edge scan below (#1607).
+	verts := newVertexCullGrid(pts)
 	for changed := true; changed; {
 		changed = false
 		for e := range edges {
-			c := vertexOnEdgeInterior(pts, e[0], e[1])
+			c := vertexOnEdgeInterior(pts, e[0], e[1], verts)
 			if c < 0 {
 				continue
 			}
@@ -108,8 +114,10 @@ func splitTJunctions(pts []math.Point2, edges map[[2]int]bool) {
 
 // vertexOnEdgeInterior returns a vertex index lying strictly inside segment a→b (within
 // [tjTol] of it, parameter away from both ends), or −1 if none. The lowest such index is
-// returned for determinism.
-func vertexOnEdgeInterior(pts []math.Point2, a, b int) int {
+// returned for determinism. Candidates come from the vertex grid hash over the edge's padded
+// box (#1607) — every qualifying vertex lies within tjTol of the edge, so none can escape it —
+// with the qualification arithmetic unchanged from the retired full scan.
+func vertexOnEdgeInterior(pts []math.Point2, a, b int, verts *vertexCullGrid) int {
 	pa, pb := pts[a], pts[b]
 	ab := pa.VectorTo(pb)
 	lenSq := ab.LengthSquared()
@@ -117,37 +125,40 @@ func vertexOnEdgeInterior(pts []math.Point2, a, b int) int {
 		return -1
 	}
 	best := -1
-	for c := range pts {
-		if c == a || c == b {
-			continue
+	x0 := minf(float64(pa.X), float64(pb.X)) - tjCullPad
+	y0 := minf(float64(pa.Y), float64(pb.Y)) - tjCullPad
+	x1 := maxf(float64(pa.X), float64(pb.X)) + tjCullPad
+	y1 := maxf(float64(pa.Y), float64(pb.Y)) + tjCullPad
+	verts.eachInBox(x0, y0, x1, y1, func(c int) {
+		if c == a || c == b || (best >= 0 && c >= best) {
+			return
 		}
 		t := pa.VectorTo(pts[c]).Dot(ab) / lenSq
 		if t <= tjTol || t >= 1-tjTol {
-			continue
+			return
 		}
 		if pa.TranslateBy(ab.Scale(t)).DistanceTo(pts[c]) > tjTol {
-			continue
+			return
 		}
-		if best < 0 || c < best {
-			best = c
-		}
-	}
+		best = c
+	})
 	return best
 }
 
-// splitOne returns segment i's elementary edges: the chain of welded vertex indices along
-// it, split at every interior intersection with another segment.
-func splitOne(seg [2]math.Point2, all [][2]math.Point2, i int, weld *welder) [][2]int {
+// splitOne returns a segment's elementary edges: the chain of welded vertex indices along
+// it, split at every interior intersection with another segment. `cand` is the segment's
+// grid-culled candidate list (ascending, self excluded, #1607): a superset of every j the
+// narrow phase can accept, in the retired brute scan's order — the cut list feeds an
+// unstable sort, so insertion order must not drift.
+func splitOne(seg [2]math.Point2, all [][2]math.Point2, cand []int, weld *welder) [][2]int {
 	si := geom.NewLineSegment2d(seg[0], seg[1])
 	type cut struct {
 		t float64
 		p math.Point2
 	}
 	cuts := []cut{{0, seg[0]}, {1, seg[1]}}
-	for j, other := range all {
-		if j == i {
-			continue
-		}
+	for _, j := range cand {
+		other := all[j]
 		if p, s, _, ok := geom.Segment2dIntersection(si, geom.NewLineSegment2d(other[0], other[1]), arrTol); ok && s > arrTol && s < 1-arrTol {
 			cuts = append(cuts, cut{s, p})
 		}

--- a/kernel/brep/arrange2d_bench_test.go
+++ b/kernel/brep/arrange2d_bench_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"fmt"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// crossingGridSegments builds n/2 horizontal × n/2 vertical segments whose pairwise crossings
+// number (n/2)² — the dense-imprint arrangement shape (a faceted-curve cut across a face) that
+// made the O(S²) planarize scan the boolean's hot spot (#1607).
+func crossingGridSegments(n int) [][2]math.Point2 {
+	segs := make([][2]math.Point2, 0, n)
+	for i := 0; i < n/2; i++ {
+		v := float64(i) + 0.5
+		segs = append(segs,
+			[2]math.Point2{math.P2(0, v), math.P2(float64(n/2), v)},
+			[2]math.Point2{math.P2(v, 0), math.P2(v, float64(n/2))})
+	}
+	return segs
+}
+
+// BenchmarkPlanarizeCrossingGrid locks the arrangement front end's asymptotics at 1×/4×/16×
+// segment counts: with the grid-hash candidacy the per-tier cost must grow with the crossing
+// count (output size), not the S² pair count.
+func BenchmarkPlanarizeCrossingGrid(b *testing.B) {
+	for _, n := range []int{16, 64, 256} {
+		segs := crossingGridSegments(n)
+		b.Run(fmt.Sprintf("segments_%d", len(segs)), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				planarize(segs)
+			}
+		})
+	}
+}

--- a/kernel/brep/arrange2d_cull.go
+++ b/kernel/brep/arrange2d_cull.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"sort"
+
+	"oblikovati.org/math"
+)
+
+// Uniform-grid spatial hashing for the 2D arrangement (Ericson, Real-Time Collision
+// Detection §7.1) — the broad phase that retires planarize's O(S²) segment-pair scan and
+// splitTJunctions' O(E·V) vertex-on-edge scan (#1607). Only candidacy moves here: the narrow
+// phase (Segment2dIntersection at arrTol, the tjTol distance test) is untouched, and every
+// pair it can accept lies within its tolerance of both participants — far inside the padded
+// boxes hashed below — so the culled arrangement finds identical intersections and
+// T-junctions (pinned by the randomized equivalence tests in arrange2d_cull_test.go).
+
+// segCullPad inflates every segment's AABB before hashing and overlap-testing: 10× the
+// arrangement tolerance under which the narrow phase can still accept a crossing between
+// near-touching segments.
+const segCullPad = 10 * arrTol // tol:calibrated — box-cull slack over the arrangement tolerance (see arrTol)
+
+// tjCullPad inflates an edge's query box in the T-junction pass: 10× the on-edge distance
+// tolerance, so every vertex within tjTol of the edge is guaranteed to be visited.
+const tjCullPad = 10 * tjTol // tol:calibrated — box-cull slack over the T-junction tolerance (see tjTol)
+
+// segmentCullGrid hashes padded segment AABBs into square cells.
+type segmentCullGrid struct {
+	cell  float64
+	boxes [][4]float64 // per segment: padded [minX, minY, maxX, maxY]
+	cells map[[2]int32][]int32
+}
+
+// newSegmentCullGrid builds the hash over all segments' padded boxes.
+func newSegmentCullGrid(segments [][2]math.Point2) *segmentCullGrid {
+	boxes := make([][4]float64, len(segments))
+	for i, s := range segments {
+		boxes[i] = [4]float64{
+			minf(float64(s[0].X), float64(s[1].X)) - segCullPad,
+			minf(float64(s[0].Y), float64(s[1].Y)) - segCullPad,
+			maxf(float64(s[0].X), float64(s[1].X)) + segCullPad,
+			maxf(float64(s[0].Y), float64(s[1].Y)) + segCullPad,
+		}
+	}
+	g := &segmentCullGrid{cell: cullCellEdge(boxes), boxes: boxes, cells: map[[2]int32][]int32{}}
+	for i := range boxes {
+		g.eachCoveredCell(boxes[i], func(c [2]int32) { g.cells[c] = append(g.cells[c], int32(i)) })
+	}
+	return g
+}
+
+// cullCellEdge picks the hash cell edge as the mean padded-box extent — Ericson's guidance of
+// sizing cells to the average object, so a segment covers O(1) cells and a cell holds
+// O(local density) segments. Any positive value is CORRECT (candidacy is decided by the
+// padded-box overlap test, never by the cell); it only tunes bucket occupancy, so the
+// degenerate all-degenerate input just falls back to 1.
+func cullCellEdge(boxes [][4]float64) float64 {
+	if len(boxes) == 0 {
+		return 1
+	}
+	sum := 0.0
+	for _, b := range boxes {
+		sum += (b[2] - b[0]) + (b[3] - b[1])
+	}
+	if cell := sum / float64(2*len(boxes)); cell > 0 && !stdmath.IsInf(cell, 1) {
+		return cell
+	}
+	return 1
+}
+
+// candidates returns the ascending indices j ≠ i whose padded boxes overlap segment i's — a
+// superset of every pair the narrow phase can accept, iterated in the retired brute scan's
+// ascending-j order (the cut list feeds an unstable sort, so insertion order must not drift).
+func (g *segmentCullGrid) candidates(i int) []int {
+	bi := g.boxes[i]
+	var out []int
+	g.eachCoveredCell(bi, func(c [2]int32) {
+		for _, j := range g.cells[c] {
+			if int(j) != i && boxesOverlap2D(bi, g.boxes[j]) {
+				out = append(out, int(j))
+			}
+		}
+	})
+	sort.Ints(out)
+	return dedupSortedInts(out)
+}
+
+// eachCoveredCell visits every cell the box overlaps.
+func (g *segmentCullGrid) eachCoveredCell(b [4]float64, visit func(c [2]int32)) {
+	x0, y0 := cellCoord(b[0], g.cell), cellCoord(b[1], g.cell)
+	x1, y1 := cellCoord(b[2], g.cell), cellCoord(b[3], g.cell)
+	for x := x0; x <= x1; x++ {
+		for y := y0; y <= y1; y++ {
+			visit([2]int32{x, y})
+		}
+	}
+}
+
+func cellCoord(v, cell float64) int32 {
+	return int32(stdmath.Floor(v / cell))
+}
+
+func boxesOverlap2D(a, b [4]float64) bool {
+	return a[0] <= b[2] && a[2] >= b[0] && a[1] <= b[3] && a[3] >= b[1]
+}
+
+// dedupSortedInts compacts consecutive duplicates in-place (a segment straddling several
+// cells is hashed into each of them).
+func dedupSortedInts(v []int) []int {
+	out := v[:0]
+	for k, x := range v {
+		if k == 0 || x != out[len(out)-1] {
+			out = append(out, x)
+		}
+	}
+	return out
+}
+
+// vertexCullGrid hashes the welded arrangement vertices for the T-junction pass; each vertex
+// occupies exactly one cell (so queries need no dedup) and an edge queries the cells its
+// padded box covers.
+type vertexCullGrid struct {
+	cell  float64
+	cells map[[2]int32][]int32
+}
+
+// newVertexCullGrid builds the hash once per splitTJunctions run — the welded point set is
+// fixed there; only the edge set evolves.
+func newVertexCullGrid(pts []math.Point2) *vertexCullGrid {
+	g := &vertexCullGrid{cell: vertexCellEdge(pts), cells: map[[2]int32][]int32{}}
+	for i, p := range pts {
+		c := [2]int32{cellCoord(float64(p.X), g.cell), cellCoord(float64(p.Y), g.cell)}
+		g.cells[c] = append(g.cells[c], int32(i))
+	}
+	return g
+}
+
+// vertexCellEdge sizes vertex cells to the point-cloud extent over √n — ~O(1) vertices per
+// cell for a roughly uniform arrangement. Any positive value is correct (see cullCellEdge).
+func vertexCellEdge(pts []math.Point2) float64 {
+	if len(pts) == 0 {
+		return 1
+	}
+	lo := [2]float64{stdmath.Inf(1), stdmath.Inf(1)}
+	hi := [2]float64{stdmath.Inf(-1), stdmath.Inf(-1)}
+	for _, p := range pts {
+		lo[0], lo[1] = minf(lo[0], float64(p.X)), minf(lo[1], float64(p.Y))
+		hi[0], hi[1] = maxf(hi[0], float64(p.X)), maxf(hi[1], float64(p.Y))
+	}
+	if cell := maxf(hi[0]-lo[0], hi[1]-lo[1]) / stdmath.Sqrt(float64(len(pts))); cell > 0 {
+		return cell
+	}
+	return 1
+}
+
+// eachInBox visits every vertex hashed into a cell the box [x0,y0]–[x1,y1] overlaps.
+func (g *vertexCullGrid) eachInBox(x0, y0, x1, y1 float64, visit func(v int)) {
+	cx0, cy0 := cellCoord(x0, g.cell), cellCoord(y0, g.cell)
+	cx1, cy1 := cellCoord(x1, g.cell), cellCoord(y1, g.cell)
+	for x := cx0; x <= cx1; x++ {
+		for y := cy0; y <= cy1; y++ {
+			g.visitCell([2]int32{x, y}, visit)
+		}
+	}
+}
+
+func (g *vertexCullGrid) visitCell(c [2]int32, visit func(v int)) {
+	for _, v := range g.cells[c] {
+		visit(int(v))
+	}
+}

--- a/kernel/brep/arrange2d_cull_test.go
+++ b/kernel/brep/arrange2d_cull_test.go
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdrand "math/rand"
+	"reflect"
+	"sort"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// randomArrangementSegments builds a reproducible stress mix for the arrangement: random
+// chords, grid-snapped segments (exact coincidences and shared endpoints), and axis-aligned
+// runs that end ON other segments' interiors (T-junctions) — the configurations the welder,
+// splitOne and splitTJunctions each trip on.
+func randomArrangementSegments(rng *stdrand.Rand, n int) [][2]math.Point2 {
+	segs := make([][2]math.Point2, 0, n)
+	snap := func(v float64) float64 { return float64(int(v*2)) / 2 } // 0.5 grid
+	for len(segs) < n {
+		a := math.P2(rng.Float64()*10, rng.Float64()*10)
+		b := math.P2(rng.Float64()*10, rng.Float64()*10)
+		switch len(segs) % 3 {
+		case 1: // snapped: forces coincident endpoints and exact crossings
+			a, b = math.P2(snap(float64(a.X)), snap(float64(a.Y))), math.P2(snap(float64(b.X)), snap(float64(b.Y)))
+		case 2: // axis-aligned through the snapped lattice: forces T-junctions
+			b = math.P2(float64(a.X), snap(float64(b.Y)))
+		}
+		if a.DistanceTo(b) > 0 {
+			segs = append(segs, [2]math.Point2{a, b})
+		}
+	}
+	return segs
+}
+
+// bruteNarrowPhasePairs returns every (i, j) pair the splitOne narrow phase accepts — the set
+// the grid candidates must contain.
+func bruteNarrowPhasePairs(segments [][2]math.Point2) [][2]int {
+	var pairs [][2]int
+	for i, seg := range segments {
+		si := geom.NewLineSegment2d(seg[0], seg[1])
+		for j, other := range segments {
+			if j == i {
+				continue
+			}
+			if _, s, _, ok := geom.Segment2dIntersection(si, geom.NewLineSegment2d(other[0], other[1]), arrTol); ok && s > arrTol && s < 1-arrTol {
+				pairs = append(pairs, [2]int{i, j})
+			}
+		}
+	}
+	return pairs
+}
+
+// TestSegmentCullGridSupersetOfNarrowPhase is the culling-soundness gate #1607 requires: on
+// randomized fixtures, the grid candidate set must contain every pair the brute narrow phase
+// accepts — a miss would silently drop an arrangement crossing.
+func TestSegmentCullGridSupersetOfNarrowPhase(t *testing.T) {
+	rng := stdrand.New(stdrand.NewSource(7))
+	for trial := 0; trial < 20; trial++ {
+		segments := randomArrangementSegments(rng, 60)
+		cull := newSegmentCullGrid(segments)
+		cand := make([][]int, len(segments))
+		for i := range segments {
+			cand[i] = cull.candidates(i)
+		}
+		for _, pair := range bruteNarrowPhasePairs(segments) {
+			if sort.SearchInts(cand[pair[0]], pair[1]) == len(cand[pair[0]]) ||
+				cand[pair[0]][sort.SearchInts(cand[pair[0]], pair[1])] != pair[1] {
+				t.Fatalf("trial %d: narrow-phase pair %v missing from grid candidates %v", trial, pair, cand[pair[0]])
+			}
+		}
+	}
+}
+
+// brutePlanarize is the retired O(S²) planarize, kept as the oracle: same welder, same
+// narrow phase, all-pairs candidacy, brute T-junction scan.
+func brutePlanarize(segments [][2]math.Point2) ([]math.Point2, [][2]int) {
+	weld := newWelder()
+	edges := map[[2]int]bool{}
+	all := make([]int, len(segments))
+	for i := range all {
+		all[i] = i
+	}
+	for i, seg := range segments {
+		cand := append(append([]int{}, all[:i]...), all[i+1:]...)
+		for _, e := range splitOne(seg, segments, cand, weld) {
+			if e[0] != e[1] {
+				edges[canonEdge(e[0], e[1])] = true
+			}
+		}
+	}
+	bruteSplitTJunctions(weld.points, edges)
+	out := make([][2]int, 0, len(edges))
+	for e := range edges {
+		out = append(out, e)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i][0] != out[j][0] {
+			return out[i][0] < out[j][0]
+		}
+		return out[i][1] < out[j][1]
+	})
+	return weld.points, out
+}
+
+// bruteSplitTJunctions is the retired full-scan T-junction pass (vertexOnEdgeInterior with an
+// all-vertices "grid" — one giant cell — degrades to exactly the old scan).
+func bruteSplitTJunctions(pts []math.Point2, edges map[[2]int]bool) {
+	verts := &vertexCullGrid{cell: 1e30, cells: map[[2]int32][]int32{}} // tol:numeric — one-giant-cell degradation, not a length tolerance
+	for i := range pts {
+		verts.cells[[2]int32{cellCoord(float64(pts[i].X), verts.cell), cellCoord(float64(pts[i].Y), verts.cell)}] =
+			append(verts.cells[[2]int32{cellCoord(float64(pts[i].X), verts.cell), cellCoord(float64(pts[i].Y), verts.cell)}], int32(i))
+	}
+	for changed := true; changed; {
+		changed = false
+		for e := range edges {
+			c := vertexOnEdgeInterior(pts, e[0], e[1], verts)
+			if c < 0 {
+				continue
+			}
+			delete(edges, e)
+			edges[canonEdge(e[0], c)] = true
+			edges[canonEdge(c, e[1])] = true
+			changed = true
+		}
+	}
+}
+
+// TestPlanarizeGridMatchesBrute pins bit-identity of the whole culled arrangement front end
+// against the brute oracle on randomized fixtures: same welded points (same order), same
+// elementary edge set.
+func TestPlanarizeGridMatchesBrute(t *testing.T) {
+	rng := stdrand.New(stdrand.NewSource(11))
+	for trial := 0; trial < 20; trial++ {
+		segments := randomArrangementSegments(rng, 80)
+		gotPts, gotEdges := planarize(segments)
+		wantPts, wantEdges := brutePlanarize(segments)
+		if !reflect.DeepEqual(gotPts, wantPts) {
+			t.Fatalf("trial %d: welded points differ (%d vs %d)", trial, len(gotPts), len(wantPts))
+		}
+		if !reflect.DeepEqual(gotEdges, wantEdges) {
+			t.Fatalf("trial %d: elementary edges differ (%d vs %d)", trial, len(gotEdges), len(wantEdges))
+		}
+	}
+}
+
+// TestVertexOnEdgeInteriorGridMatchesFullScan pins the T-junction candidate culling: for
+// random welded point sets and edges, the grid-backed lowest-qualifying-vertex answer equals
+// the full scan's (via the one-giant-cell degradation).
+func TestVertexOnEdgeInteriorGridMatchesFullScan(t *testing.T) {
+	rng := stdrand.New(stdrand.NewSource(13))
+	for trial := 0; trial < 20; trial++ {
+		pts, edges := planarize(randomArrangementSegments(rng, 40))
+		grid := newVertexCullGrid(pts)
+		full := &vertexCullGrid{cell: 1e30, cells: map[[2]int32][]int32{}} // tol:numeric — one-giant-cell degradation, not a length tolerance
+		for i := range pts {
+			c := [2]int32{cellCoord(float64(pts[i].X), full.cell), cellCoord(float64(pts[i].Y), full.cell)}
+			full.cells[c] = append(full.cells[c], int32(i))
+		}
+		for _, e := range edges {
+			if got, want := vertexOnEdgeInterior(pts, e[0], e[1], grid), vertexOnEdgeInterior(pts, e[0], e[1], full); got != want {
+				t.Fatalf("trial %d edge %v: grid found vertex %d, full scan %d", trial, e, got, want)
+			}
+		}
+	}
+}

--- a/kernel/brep/boolean.go
+++ b/kernel/brep/boolean.go
@@ -71,11 +71,15 @@ func BooleanDiag(op Op, a, b *topo.Body, rec *diag.Recorder) (*topo.Body, error)
 // "away" direction when the pass hit a tangent/grazing contact (operand B nudged along it
 // opens a clean clearance), else the zero vector.
 func booleanOnce(op Op, fa, fb []planarFace, a, b *topo.Body) (*topo.Body, math.Vector3, error) {
-	impA, impB := imprintAll(fa, fb)
-	prov := provenanceOf(fa, fb)
+	// One AABB-culled candidate set feeds imprint, provenance AND the coplanar-cover scans —
+	// the retired brute version recomputed the O(Fa·Fb) pairing 2–3× per pass — and each
+	// operand is flattened ONCE into a solidProbe for every ray-cast classification, instead
+	// of per query point (#1607).
+	pairs := crossingFaceCandidates(fa, fb)
+	impA, impB, prov := imprintCandidates(fa, fb, pairs)
 	var kept []subFace
-	kept = append(kept, selectFaces(fa, impA, b, fb, op, false, prov)...)
-	kept = append(kept, selectFaces(fb, impB, a, fa, op, true, prov)...)
+	kept = append(kept, selectFaces(fa, impA, newSolidProbe(b), fb, pairs.bForA, op, false, prov)...)
+	kept = append(kept, selectFaces(fb, impB, newSolidProbe(a), fa, pairs.aForB, op, true, prov)...)
 	return stitch(kept, prov)
 }
 
@@ -155,17 +159,11 @@ func planarToSubFaces(faces []planarFace) []subFace {
 // and a float-wobbled near-copy of a boundary edge destabilizes the 2D arrangement. The
 // flush-cut case (#137) hits this constantly — a tool wall whose bottom edge lies exactly in
 // the target's bottom plane imprints that plane with a near-duplicate of the coplanar cap
-// edge, and imprints ITSELF with its own bottom edge.
+// edge, and imprints ITSELF with its own bottom edge. Since #1607 the pairing is AABB-culled
+// and shared with provenanceOf through imprintCandidates; this wrapper keeps the historical
+// contract for callers that only need the geometry.
 func imprintAll(fa, fb []planarFace) (impA, impB [][][2]math.Point3) {
-	impA = make([][][2]math.Point3, len(fa))
-	impB = make([][][2]math.Point3, len(fb))
-	for i := range fa {
-		for j := range fb {
-			onA, onB := pairImprints(fa[i], fb[j])
-			impA[i] = append(impA[i], onA...)
-			impB[j] = append(impB[j], onB...)
-		}
-	}
+	impA, impB, _ = imprintCandidates(fa, fb, crossingFaceCandidates(fa, fb))
 	return impA, impB
 }
 
@@ -216,13 +214,15 @@ func minf(a, b float64) float64 {
 
 // selectFaces splits each face by its imprints and keeps the material sub-faces this
 // operation wants, classifying each via [classifySubFace]. `others` is the other solid's
-// face list (for the coplanar overlap test); `other` is the body itself (for the ray cast).
-func selectFaces(faces []planarFace, imprints [][][2]math.Point3, other *topo.Body, others []planarFace, op Op, isB bool, prov []imprintSeg) []subFace {
+// face list (for the coplanar overlap test), culled per face to its box-overlap candidates
+// `otherCand` (#1607); `other` is the body's cached probe (for the winding-number cast).
+func selectFaces(faces []planarFace, imprints [][][2]math.Point3, other *solidProbe, others []planarFace, otherCand [][]int, op Op, isB bool, prov []imprintSeg) []subFace {
 	var kept []subFace
 	for i, f := range faces {
+		near := facesAt(others, otherCand[i])
 		var fromFace []subFace
 		for _, sf := range splitFace(f, imprints[i]) {
-			if out, ok := classifySubFace(sf, f, other, others, op, isB); ok {
+			if out, ok := classifySubFace(sf, f, other, near, op, isB); ok {
 				fromFace = append(fromFace, out)
 			}
 		}
@@ -270,13 +270,13 @@ func splitLineage(parent topo.Lineage, k int) topo.Lineage {
 
 // classifySubFace decides whether a sub-face survives. A fragment coplanar with a face of
 // the other solid follows the ON/ON table ([coplanarKeep]); otherwise it is kept by the
-// inside/outside table ([keep]) from a ray cast, with B's difference faces reversed to form
-// the cut walls.
-func classifySubFace(sf subFace, f planarFace, other *topo.Body, others []planarFace, op Op, isB bool) (subFace, bool) {
+// inside/outside table ([keep]) from a winding-number cast against the other solid's cached
+// probe, with B's difference faces reversed to form the cut walls.
+func classifySubFace(sf subFace, f planarFace, other *solidProbe, others []planarFace, op Op, isB bool) (subFace, bool) {
 	if covered, sameNormal := coplanarCover(f, sf.point, others); covered {
 		return sf, coplanarKeep(op, isB, sameNormal)
 	}
-	if !keep(op, isB, insideSolid(other, sf.point)) {
+	if !keep(op, isB, other.inside(sf.point)) {
 		return sf, false
 	}
 	if op == Difference && isB {

--- a/kernel/brep/boolean_bench_test.go
+++ b/kernel/brep/boolean_bench_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep_test
+
+import (
+	"fmt"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/topo"
+)
+
+// BenchmarkBooleanPatternedPocketChain locks the boolean pipeline's asymptotics on the
+// pattern-blowup shape the audit flagged (#1607): a plate with an n×n pocket grid cut one
+// boolean at a time, so the target's face count grows with every cut (6+5k faces after k
+// pockets) exactly like a patterned-feature recompute. Tiers quadruple the pocket count
+// (1×/4×/16×); with the AABB face-pair culling the cost per tier must grow sub-quadratically
+// in the total face count where the brute O(Fa·Fb) pairing grew quadratically.
+func BenchmarkBooleanPatternedPocketChain(b *testing.B) {
+	for _, n := range []int{2, 4, 8} {
+		b.Run(fmt.Sprintf("pockets_%dx%d", n, n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				pocketChain(b, n)
+			}
+		})
+	}
+}
+
+// pocketChain cuts an n×n grid of blind pockets into a 4n×4n×2 plate, one Difference at a
+// time, and returns the final body (face count 6+5n²).
+func pocketChain(tb testing.TB, n int) *topo.Body {
+	tb.Helper()
+	res := box(0, 0, 0, float64(4*n), float64(4*n), 2)
+	for k := 0; k < n*n; k++ {
+		tool := box(float64(4*(k/n))+1, float64(4*(k%n))+1, 1, 2, 2, 2)
+		out, err := brep.Boolean(brep.Difference, res, tool)
+		if err != nil {
+			tb.Fatalf("pocket %d/%d: %v", k, n*n, err)
+		}
+		res = out
+	}
+	return res
+}
+
+// TestPocketChainFixtureIsSound guards the benchmark fixture itself: the chained cuts must
+// yield a valid solid with the analytic volume (plate minus n² pockets of 2×2×1), so the
+// benchmark keeps measuring real boolean work rather than an error path.
+func TestPocketChainFixtureIsSound(t *testing.T) {
+	n := 3
+	res := pocketChain(t, n)
+	if !res.IsSolid() {
+		t.Fatal("pocket-chain result is not a solid")
+	}
+	want := float64(4*n*4*n*2 - n*n*4)
+	if got := vol(res); stdAbs(got-want) > 1e-6*want {
+		t.Fatalf("pocket-chain volume = %g, want %g", got, want)
+	}
+}
+
+func stdAbs(v float64) float64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}

--- a/kernel/brep/boolean_classify.go
+++ b/kernel/brep/boolean_classify.go
@@ -23,16 +23,40 @@ const insideSolidWindingThreshold = 2 * stdmath.Pi
 // an edge/vertex or ran near-parallel to a face, so fragments whose sample point sat near a
 // shared boundary — or models with faces near the magic direction — misclassified
 // deterministically. The winding number integrates the WHOLE boundary; it has no direction to
-// graze.
+// graze. Multi-query callers (the boolean's classification pass) should build one [solidProbe]
+// instead of calling this per point.
 func insideSolid(b *topo.Body, p math.Point3) bool {
+	return newSolidProbe(b).inside(p)
+}
+
+// solidProbe caches the per-body inputs insideSolid re-derived on EVERY query — the flattened
+// planar faces and the model-relative on-plane tolerance (facesOf + RangeBox dominated
+// classification time on the #1607 pocket-chain profile). Pure hoisting, no culling: the
+// faces, the tolerance and the summation order are exactly insideSolid's, so every verdict is
+// bit-identical.
+type solidProbe struct {
+	faces   []planarFace
+	onPlane float64
+	planar  bool
+}
+
+// newSolidProbe flattens b once for repeated inside queries.
+func newSolidProbe(b *topo.Body) *solidProbe {
 	faces, ok := facesOf(b)
 	if !ok {
+		return &solidProbe{}
+	}
+	return &solidProbe{faces: faces, onPlane: geom.ResolutionForBox(b.RangeBox()).Plane(), planar: true}
+}
+
+// inside thresholds the generalized winding number of the cached faces at p (see insideSolid).
+func (sp *solidProbe) inside(p math.Point3) bool {
+	if !sp.planar {
 		return false
 	}
-	onPlane := geom.ResolutionForBox(b.RangeBox()).Plane()
 	sum := 0.0
-	for _, f := range faces {
-		sum += faceSolidAngle(f, p, onPlane)
+	for _, f := range sp.faces {
+		sum += faceSolidAngle(f, p, sp.onPlane)
 	}
 	// |sum|: membership of the CLOSED REGION is orientation-independent, and legacy builders can
 	// emit a consistently inside-out body (loops wound opposite their outward normals — the

--- a/kernel/brep/boolean_pairs.go
+++ b/kernel/brep/boolean_pairs.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"sort"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Broad-phase face-pair culling for the planar boolean (#1607). The imprint, provenance and
+// coplanar-cover scans only ever produce output for a face pair when some point lies ON both
+// faces (an imprint/overlap segment, or a covered classification sample) within tolerances
+// orders of magnitude below the pad here, so a pair whose padded AABBs are disjoint can be
+// skipped without touching any result bit. The candidate set is computed ONCE per boolean pass
+// via a [geom.BoxTree] (the kernel/ops self-intersection broad phase of #1411, shared through
+// geom) and handed to every consumer — retiring both the O(Fa·Fb) scan and its 2–3×
+// recomputation across imprintAll/provenanceOf.
+
+// facePairCullPad inflates each face's AABB before the overlap test. It must exceed every
+// tolerance under which the narrow phase still produces output for a near-touching pair —
+// arrTol (1e-9), the 1e-7 weld/coplanar/boundary-imprint gaps, and planarStitchGrid (1e-6) —
+// and at 10× the planar stitch grid it clears the largest by an order of magnitude (applied to
+// BOTH boxes, doubling the slack). Culling only ever narrows which pairs are TESTED, never how
+// a tested pair classifies.
+const facePairCullPad = 10 * planarStitchGrid // tol:calibrated — box-cull slack over the planar weld family (see arrange2d arrTol)
+
+// facePairs is the boolean pass's shared candidate set: for each face of A, the ascending
+// indices of B faces whose padded boxes overlap it — and the same relation transposed — so
+// every consumer iterates pairs in the exact (i, then j) order the retired brute scan used.
+type facePairs struct {
+	bForA [][]int // per A-face index: candidate B-face indices, ascending
+	aForB [][]int // per B-face index: candidate A-face indices, ascending
+}
+
+// crossingFaceCandidates computes the candidate pair set once: a BoxTree over B's padded face
+// boxes, queried with each of A's padded face boxes.
+func crossingFaceCandidates(fa, fb []planarFace) facePairs {
+	boxesB := make([]math.Box, len(fb))
+	for j := range fb {
+		boxesB[j] = paddedFaceBox(fb[j])
+	}
+	tree := geom.NewBoxTree(boxesB)
+	p := facePairs{bForA: make([][]int, len(fa)), aForB: make([][]int, len(fb))}
+	for i := range fa {
+		tree.Query(paddedFaceBox(fa[i]), func(j int) bool {
+			p.bForA[i] = append(p.bForA[i], j)
+			return false
+		})
+		// The tree yields spatial order; consumers must see the brute scan's ascending-j order
+		// (imprint slice order feeds the 2D arrangement, which is order-sensitive at tolerance).
+		sort.Ints(p.bForA[i])
+		for _, j := range p.bForA[i] {
+			p.aForB[j] = append(p.aForB[j], i) // i ascends outer loop → already sorted
+		}
+	}
+	return p
+}
+
+// paddedFaceBox returns the face's loop-point bounding box inflated by [facePairCullPad] on
+// every side.
+func paddedFaceBox(f planarFace) math.Box {
+	box := math.EmptyBox()
+	for _, ring := range f.loops {
+		for _, p := range ring {
+			box = box.ExtendPoint(p)
+		}
+	}
+	pad := math.Scalar(facePairCullPad)
+	box.Min = math.Point3{X: box.Min.X - pad, Y: box.Min.Y - pad, Z: box.Min.Z - pad}
+	box.Max = math.Point3{X: box.Max.X + pad, Y: box.Max.Y + pad, Z: box.Max.Z + pad}
+	return box
+}
+
+// imprintCandidates runs the narrow phase ONCE over the culled candidate pairs, producing both
+// the per-face imprint segments (imprintAll's contract) and the tagged provenance
+// (provenanceOf's contract) from a single pairImprints call per pair — the duplicate pairing
+// the audit flagged (#1607). Pairs iterate (i asc, j asc), matching the retired brute scan, so
+// impA/impB/prov are element-for-element identical to it.
+func imprintCandidates(fa, fb []planarFace, pairs facePairs) (impA, impB [][][2]math.Point3, prov []imprintSeg) {
+	impA = make([][][2]math.Point3, len(fa))
+	impB = make([][][2]math.Point3, len(fb))
+	for i := range fa {
+		for _, j := range pairs.bForA[i] {
+			onA, onB := pairImprints(fa[i], fb[j])
+			impA[i] = append(impA[i], onA...)
+			impB[j] = append(impB[j], onB...)
+			prov = appendTagged(prov, onA, fa[i], fb[j])
+			prov = appendTagged(prov, onB, fb[j], fa[i])
+		}
+	}
+	return impA, impB, prov
+}
+
+// facesAt selects faces by index, preserving order: the coplanar-cover scan sees the same
+// first-match order the full scan did, restricted to box-overlap candidates (sound — a cover
+// witnesses a point on both faces, so its pair is always a candidate).
+func facesAt(faces []planarFace, idx []int) []planarFace {
+	out := make([]planarFace, len(idx))
+	for k, j := range idx {
+		out[k] = faces[j]
+	}
+	return out
+}

--- a/kernel/brep/boolean_pairs_test.go
+++ b/kernel/brep/boolean_pairs_test.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdrand "math/rand"
+	"reflect"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// bruteImprintPairs is the retired O(Fa·Fb) scan, kept here as the oracle: the culled
+// imprintCandidates must reproduce its impA/impB/prov element for element (#1607).
+func bruteImprintPairs(fa, fb []planarFace) (impA, impB [][][2]math.Point3, prov []imprintSeg) {
+	impA = make([][][2]math.Point3, len(fa))
+	impB = make([][][2]math.Point3, len(fb))
+	for i := range fa {
+		for j := range fb {
+			onA, onB := pairImprints(fa[i], fb[j])
+			impA[i] = append(impA[i], onA...)
+			impB[j] = append(impB[j], onB...)
+			prov = appendTagged(prov, onA, fa[i], fb[j])
+			prov = appendTagged(prov, onB, fb[j], fa[i])
+		}
+	}
+	return impA, impB, prov
+}
+
+// randomPairFixture builds a base box and a randomly placed/sized tool box: overlapping,
+// tangent (snapped-to-face), and disjoint configurations all occur across seeds.
+func randomPairFixture(rng *stdrand.Rand) (fa, fb []planarFace) {
+	fa = provFaces("base", 0, 0, 0, 8, 8, 4)
+	px := rng.Float64()*16 - 4
+	py := rng.Float64()*16 - 4
+	pz := rng.Float64()*10 - 3
+	if rng.Intn(3) == 0 { // every third tool lands exactly on a base plane: coplanar contact
+		pz = 4
+	}
+	fb = provFaces("tool", px, py, pz, 1+rng.Float64()*6, 1+rng.Float64()*6, 1+rng.Float64()*4)
+	return fa, fb
+}
+
+// TestCrossingFaceCandidatesSupersetOfImprintingPairs is the culling-soundness gate (#1607):
+// on randomized fixtures, every face pair the brute narrow phase produces ANY segment for must
+// appear in the AABB candidate set (both orientations). A miss would silently drop an imprint
+// and change the boolean's output.
+func TestCrossingFaceCandidatesSupersetOfImprintingPairs(t *testing.T) {
+	rng := stdrand.New(stdrand.NewSource(1607))
+	for trial := 0; trial < 60; trial++ {
+		fa, fb := randomPairFixture(rng)
+		pairs := crossingFaceCandidates(fa, fb)
+		for i := range fa {
+			for j := range fb {
+				onA, onB := pairImprints(fa[i], fb[j])
+				if len(onA) == 0 && len(onB) == 0 {
+					continue
+				}
+				if !containsIndex(pairs.bForA[i], j) || !containsIndex(pairs.aForB[j], i) {
+					t.Fatalf("trial %d: imprinting pair (a=%d, b=%d) missing from candidates %v / %v",
+						trial, i, j, pairs.bForA[i], pairs.aForB[j])
+				}
+			}
+		}
+	}
+}
+
+func containsIndex(idx []int, want int) bool {
+	for _, v := range idx {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestImprintCandidatesMatchesBruteScan pins bit-identity, not just superset-ness: the culled
+// single-pass imprint+provenance must emit exactly the brute scan's slices — same segments,
+// same order (the 2D arrangement is order-sensitive at tolerance) — on randomized fixtures.
+func TestImprintCandidatesMatchesBruteScan(t *testing.T) {
+	rng := stdrand.New(stdrand.NewSource(1411))
+	for trial := 0; trial < 60; trial++ {
+		fa, fb := randomPairFixture(rng)
+		wantA, wantB, wantProv := bruteImprintPairs(fa, fb)
+		gotA, gotB, gotProv := imprintCandidates(fa, fb, crossingFaceCandidates(fa, fb))
+		if !reflect.DeepEqual(gotA, wantA) || !reflect.DeepEqual(gotB, wantB) {
+			t.Fatalf("trial %d: culled imprint slices differ from the brute scan", trial)
+		}
+		if !reflect.DeepEqual(gotProv, wantProv) {
+			t.Fatalf("trial %d: culled provenance differs from the brute scan", trial)
+		}
+	}
+}
+
+// TestFacesAtPreservesOrder pins the coplanar-cover candidate contract: facesAt keeps the
+// ascending-index order the full scan iterated in, so first-match semantics are unchanged.
+func TestFacesAtPreservesOrder(t *testing.T) {
+	faces := provFaces("base", 0, 0, 0, 2, 2, 2)
+	got := facesAt(faces, []int{4, 1, 3})
+	if len(got) != 3 {
+		t.Fatalf("facesAt returned %d faces, want 3", len(got))
+	}
+	for k, j := range []int{4, 1, 3} {
+		if got[k].lineage.KeyString() != faces[j].lineage.KeyString() {
+			t.Fatalf("facesAt[%d] is not source face %d", k, j)
+		}
+	}
+}

--- a/kernel/brep/boolean_provenance.go
+++ b/kernel/brep/boolean_provenance.go
@@ -46,16 +46,11 @@ func pairImprints(a, b planarFace) (onA, onB [][2]math.Point3) {
 // provenanceOf tags every imprint segment of every crossing face pair with its generating face
 // lineages. Each segment is recorded twice (once per owning face, with owner/other swapped), so
 // an edge that survives on either side resolves to the same unordered pair; edgeParents
-// canonicalizes it. The list is the input F03 names boolean edges from.
+// canonicalizes it. The list is the input F03 names boolean edges from. Since #1607 the pairing
+// is AABB-culled and shared with imprintAll through imprintCandidates; this wrapper keeps the
+// historical contract for callers that only need the tags.
 func provenanceOf(fa, fb []planarFace) []imprintSeg {
-	var prov []imprintSeg
-	for i := range fa {
-		for j := range fb {
-			onA, onB := pairImprints(fa[i], fb[j])
-			prov = appendTagged(prov, onA, fa[i], fb[j])
-			prov = appendTagged(prov, onB, fb[j], fa[i])
-		}
-	}
+	_, _, prov := imprintCandidates(fa, fb, crossingFaceCandidates(fa, fb))
 	return prov
 }
 

--- a/kernel/geom/box_tree.go
+++ b/kernel/geom/box_tree.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	"sort"
+
+	"oblikovati.org/math"
+)
+
+// BoxTree is an axis-aligned bounding-volume hierarchy over a list of boxes — the shared
+// broad-phase pair-culling index of the boolean pipeline (#1607). It generalizes the triangle
+// BVH of kernel/ops/self_intersect_bvh.go (#1411) — which now delegates here — so kernel/brep
+// (imported BY kernel/ops, hence unable to import it back) can cull face pairs with the same
+// structure: build once over one side's boxes, then Query each of the other side's boxes,
+// visiting only the items whose boxes overlap.
+//
+// Example: t := geom.NewBoxTree(bBoxes); t.Query(aBox, func(j int) bool { narrowPhase(j); return false })
+type BoxTree struct {
+	boxes []math.Box
+	order []int // item indices, partitioned into contiguous leaf ranges
+	nodes []boxTreeNode
+	root  int
+}
+
+// boxTreeNode is a box plus EITHER a leaf range [start, start+count) into order (count > 0)
+// or two children.
+type boxTreeNode struct {
+	box          math.Box
+	start, count int
+	left, right  int
+}
+
+// boxTreeLeafSize bounds a leaf's item count: small enough to prune well, large enough that
+// the tree stays shallow and the per-node overhead does not dominate.
+const boxTreeLeafSize = 8
+
+// NewBoxTree builds the hierarchy over boxes by recursive median split on the longest
+// centroid axis. The boxes slice is retained (not copied); items keep their input indices.
+func NewBoxTree(boxes []math.Box) *BoxTree {
+	order := make([]int, len(boxes))
+	for i := range boxes {
+		order[i] = i
+	}
+	t := &BoxTree{boxes: boxes, order: order}
+	if len(boxes) > 0 {
+		t.root = t.build(0, len(boxes))
+	}
+	return t
+}
+
+// build constructs the subtree over order[start:end] and returns its node index.
+func (t *BoxTree) build(start, end int) int {
+	box := math.EmptyBox()
+	for _, bi := range t.order[start:end] {
+		box = box.Union(t.boxes[bi])
+	}
+	idx := len(t.nodes)
+	t.nodes = append(t.nodes, boxTreeNode{box: box, left: -1, right: -1})
+	if end-start <= boxTreeLeafSize {
+		t.nodes[idx].start, t.nodes[idx].count = start, end-start
+		return idx
+	}
+	axis := widestBoxAxis(box)
+	sub := t.order[start:end]
+	sort.Slice(sub, func(i, j int) bool {
+		return boxCentroidOnAxis(t.boxes[sub[i]], axis) < boxCentroidOnAxis(t.boxes[sub[j]], axis)
+	})
+	mid := (start + end) / 2
+	t.nodes[idx].left = t.build(start, mid)
+	t.nodes[idx].right = t.build(mid, end)
+	return idx
+}
+
+// Query calls hit for each item whose box overlaps box, stopping early when hit returns true.
+func (t *BoxTree) Query(box math.Box, hit func(item int) bool) {
+	if len(t.nodes) == 0 {
+		return
+	}
+	t.queryNode(t.root, box, hit)
+}
+
+func (t *BoxTree) queryNode(ni int, box math.Box, hit func(item int) bool) bool {
+	nd := t.nodes[ni]
+	if !nd.box.Intersects(box) {
+		return false
+	}
+	if nd.count > 0 {
+		for _, bi := range t.order[nd.start : nd.start+nd.count] {
+			if t.boxes[bi].Intersects(box) && hit(bi) {
+				return true
+			}
+		}
+		return false
+	}
+	return t.queryNode(nd.left, box, hit) || t.queryNode(nd.right, box, hit)
+}
+
+// widestBoxAxis returns 0/1/2 for the box's widest dimension — the split axis with the best
+// separation.
+func widestBoxAxis(box math.Box) int {
+	dx, dy, dz := box.Max.X-box.Min.X, box.Max.Y-box.Min.Y, box.Max.Z-box.Min.Z
+	if dx >= dy && dx >= dz {
+		return 0
+	}
+	if dy >= dz {
+		return 1
+	}
+	return 2
+}
+
+// boxCentroidOnAxis returns a box's centre coordinate on the given axis.
+func boxCentroidOnAxis(box math.Box, axis int) float64 {
+	switch axis {
+	case 0:
+		return float64(box.Min.X+box.Max.X) / 2
+	case 1:
+		return float64(box.Min.Y+box.Max.Y) / 2
+	default:
+		return float64(box.Min.Z+box.Max.Z) / 2
+	}
+}

--- a/kernel/geom/box_tree_test.go
+++ b/kernel/geom/box_tree_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdrand "math/rand"
+	"sort"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// randomTestBoxes returns n reproducible random boxes inside [0,20)³ with edges up to ~2.
+func randomTestBoxes(n int, seed int64) []math.Box {
+	rng := stdrand.New(stdrand.NewSource(seed))
+	boxes := make([]math.Box, n)
+	for i := range boxes {
+		p := math.P3(rng.Float64()*20, rng.Float64()*20, rng.Float64()*20)
+		q := p.TranslateBy(math.V3(rng.Float64()*2, rng.Float64()*2, rng.Float64()*2))
+		boxes[i] = math.NewBox(p, q)
+	}
+	return boxes
+}
+
+// TestBoxTreeQueryMatchesBruteOverlap is the culling-soundness gate (#1607): for random query
+// boxes, Query must report EXACTLY the items a brute scan finds overlapping — no false
+// negatives (which would change boolean results) and no spurious extras beyond the box test.
+func TestBoxTreeQueryMatchesBruteOverlap(t *testing.T) {
+	boxes := randomTestBoxes(200, 1)
+	tree := NewBoxTree(boxes)
+	for qi, q := range randomTestBoxes(50, 2) {
+		var got []int
+		tree.Query(q, func(item int) bool { got = append(got, item); return false })
+		sort.Ints(got)
+		var want []int
+		for i, b := range boxes {
+			if b.Intersects(q) {
+				want = append(want, i)
+			}
+		}
+		if len(got) != len(want) {
+			t.Fatalf("query %d: tree found %d overlaps, brute found %d", qi, len(got), len(want))
+		}
+		for k := range want {
+			if got[k] != want[k] {
+				t.Fatalf("query %d: tree overlap set %v != brute %v", qi, got, want)
+			}
+		}
+	}
+}
+
+// TestBoxTreeQueryEarlyStop pins the early-out contract: a hit callback returning true ends
+// the walk after that item.
+func TestBoxTreeQueryEarlyStop(t *testing.T) {
+	boxes := randomTestBoxes(64, 3)
+	tree := NewBoxTree(boxes)
+	visited := 0
+	all := math.NewBox(math.P3(-1, -1, -1), math.P3(25, 25, 25))
+	tree.Query(all, func(int) bool { visited++; return true })
+	if visited != 1 {
+		t.Fatalf("early-stop query visited %d items, want exactly 1", visited)
+	}
+}
+
+// TestBoxTreeEmptyAndSelfQuery covers the degenerate empty tree, and that every item is
+// reachable: querying each item's own box must report the item itself (a leaf-partitioning
+// bug would silently drop items — a false negative the boolean cannot tolerate).
+func TestBoxTreeEmptyAndSelfQuery(t *testing.T) {
+	empty := NewBoxTree(nil)
+	empty.Query(math.NewBox(math.P3(0, 0, 0), math.P3(1, 1, 1)), func(int) bool {
+		t.Fatal("empty tree Query must visit nothing")
+		return true
+	})
+	boxes := randomTestBoxes(100, 4)
+	tree := NewBoxTree(boxes)
+	for i, b := range boxes {
+		found := false
+		tree.Query(b, func(item int) bool { found = found || item == i; return found })
+		if !found {
+			t.Fatalf("item %d not reachable through its own box", i)
+		}
+	}
+}

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -372,15 +372,18 @@ func strictlyContains(outer, inner *topo.Body) bool {
 
 // allVerticesInside reports whether every vertex of inner lies strictly within outer. It
 // tessellates outer ONCE and reuses that mesh for every vertex query (#1317) — previously each
-// vertex re-tessellated the whole body, making boolean classification O(V·T).
+// vertex re-tessellated the whole body, making boolean classification O(V·T) — and classifies
+// through insideMeshQuerier, whose winding-accelerated fast path is certified against the
+// exact brute loop (#1607), so the verdicts are identical.
 func allVerticesInside(inner, outer *topo.Body) bool {
 	verts := inner.Vertices()
 	if len(verts) == 0 {
 		return false
 	}
 	mesh, _ := TessellateBody(outer, DefaultQuality())
+	inMesh := insideMeshQuerier(mesh, len(verts))
 	for _, v := range verts {
-		if !pointInMesh(mesh, v.Point()) {
+		if !inMesh(v.Point()) {
 			return false
 		}
 	}

--- a/kernel/ops/point_in_solid_bench_test.go
+++ b/kernel/ops/point_in_solid_bench_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+	stdrand "math/rand"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// windingBenchQueries builds the fixed batch a winding benchmark classifies — the
+// multi-vertex-against-one-mesh workload of allVerticesInside, mixing near-mesh points (which
+// must run the exact loop) with far-field points (which the cached early-out certifies): a
+// tool body that barely overlaps the target has most of its vertices in the far field.
+func windingBenchQueries(n int) []math.Point3 {
+	rng := stdrand.New(stdrand.NewSource(1607))
+	pts := make([]math.Point3, n)
+	for i := range pts {
+		span := 1.5
+		if i%2 == 0 {
+			span = 40 // half the batch sits deep in the far field
+		}
+		pts[i] = math.P3(rng.Float64()*2*span-span, rng.Float64()*2*span-span, rng.Float64()*2*span-span)
+	}
+	return pts
+}
+
+// windingBenchTiers quadruples the triangle count per tier (1×/4×/16×) to expose the scaling
+// of the point-in-solid query batch (#1607). The winding number is kept EXACT (see
+// winding_farfield.go for why hierarchical approximation was rejected), so near-mesh queries
+// stay linear in T by design; the certified far-field early-out removes the far half of the
+// batch entirely.
+var windingBenchTiers = []struct{ nLat, nLon int }{
+	{12, 16}, // ~352 triangles
+	{24, 32}, // ~1472
+	{48, 64}, // ~6016
+}
+
+// BenchmarkPointInMeshBruteBatch is the baseline: 64 exact brute-loop queries per iteration.
+func BenchmarkPointInMeshBruteBatch(b *testing.B) {
+	for _, tier := range windingBenchTiers {
+		mesh := uvSphereMesh(tier.nLat, tier.nLon, 1)
+		pts := windingBenchQueries(64)
+		b.Run(fmt.Sprintf("tris_%d", len(mesh.Indices)/3), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				for _, p := range pts {
+					pointInMesh(mesh, p)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkPointInMeshFarFieldBatch is the accelerated path as allVerticesInside uses it:
+// build the certified far-field cache, then run the same 64 queries through it.
+func BenchmarkPointInMeshFarFieldBatch(b *testing.B) {
+	for _, tier := range windingBenchTiers {
+		mesh := uvSphereMesh(tier.nLat, tier.nLon, 1)
+		pts := windingBenchQueries(64)
+		b.Run(fmt.Sprintf("tris_%d", len(mesh.Indices)/3), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				inMesh := insideMeshQuerier(mesh, len(pts))
+				for _, p := range pts {
+					inMesh(p)
+				}
+			}
+		})
+	}
+}

--- a/kernel/ops/self_intersect_bvh.go
+++ b/kernel/ops/self_intersect_bvh.go
@@ -3,8 +3,7 @@
 package ops
 
 import (
-	"sort"
-
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/math"
 )
 
@@ -12,109 +11,27 @@ import (
 // that replaces the O(Tₐ·T_b) all-pairs triangle test in self-intersection with ~O((Tₐ+T_b)·log T):
 // build it over one face's triangles once, then query each of the other face's triangles against it,
 // running the exact Möller test only on the few candidates whose boxes overlap (Oblikovati#1411).
+// The hierarchy itself was generalized into geom.BoxTree so the planar boolean's face-pair culling
+// (kernel/brep, which kernel/ops imports and so cannot be imported back) shares it (#1607); this
+// type keeps the triangle soup next to the tree for the narrow phase.
 type triBVH struct {
-	tris  [][3]math.Point3
-	boxes []math.Box
-	order []int // triangle indices, partitioned into contiguous node ranges
-	nodes []bvhNode
-	root  int
+	tris [][3]math.Point3
+	tree *geom.BoxTree
 }
 
-// bvhNode is a box plus EITHER a leaf range [start, start+count) into order (count > 0) or two children.
-type bvhNode struct {
-	box          math.Box
-	start, count int
-	left, right  int
-}
-
-// bvhLeafSize bounds a leaf's triangle count: small enough to prune well, large enough that the tree
-// stays shallow and the per-node overhead does not dominate.
-const bvhLeafSize = 8
-
-// newTriBVH builds the hierarchy over tris by recursive median split on the longest centroid axis.
+// newTriBVH builds the hierarchy over tris (recursive median split on the longest centroid axis,
+// see geom.NewBoxTree).
 func newTriBVH(tris [][3]math.Point3) *triBVH {
 	boxes := make([]math.Box, len(tris))
-	order := make([]int, len(tris))
 	for i, t := range tris {
 		boxes[i] = math.BoxFromPoints(t[0], t[1], t[2])
-		order[i] = i
 	}
-	b := &triBVH{tris: tris, boxes: boxes, order: order}
-	if len(tris) > 0 {
-		b.root = b.build(0, len(tris))
-	}
-	return b
-}
-
-// build constructs the subtree over order[start:end] and returns its node index.
-func (b *triBVH) build(start, end int) int {
-	box := math.EmptyBox()
-	for _, ti := range b.order[start:end] {
-		box = box.Union(b.boxes[ti])
-	}
-	idx := len(b.nodes)
-	b.nodes = append(b.nodes, bvhNode{box: box, left: -1, right: -1})
-	if end-start <= bvhLeafSize {
-		b.nodes[idx].start, b.nodes[idx].count = start, end-start
-		return idx
-	}
-	axis := longestBoxAxis(box)
-	sub := b.order[start:end]
-	sort.Slice(sub, func(i, j int) bool {
-		return centroidOnAxis(b.boxes[sub[i]], axis) < centroidOnAxis(b.boxes[sub[j]], axis)
-	})
-	mid := (start + end) / 2
-	b.nodes[idx].left = b.build(start, mid)
-	b.nodes[idx].right = b.build(mid, end)
-	return idx
+	return &triBVH{tris: tris, tree: geom.NewBoxTree(boxes)}
 }
 
 // query calls hit for each triangle whose box overlaps box, stopping early when hit returns true.
 func (b *triBVH) query(box math.Box, hit func(tri int) bool) {
-	if len(b.nodes) == 0 {
-		return
-	}
-	b.queryNode(b.root, box, hit)
-}
-
-func (b *triBVH) queryNode(ni int, box math.Box, hit func(tri int) bool) bool {
-	nd := b.nodes[ni]
-	if !nd.box.Intersects(box) {
-		return false
-	}
-	if nd.count > 0 {
-		for _, ti := range b.order[nd.start : nd.start+nd.count] {
-			if b.boxes[ti].Intersects(box) && hit(ti) {
-				return true
-			}
-		}
-		return false
-	}
-	return b.queryNode(nd.left, box, hit) || b.queryNode(nd.right, box, hit)
-}
-
-// longestBoxAxis returns 0/1/2 for the box's widest dimension — the split axis with the best separation.
-func longestBoxAxis(box math.Box) int {
-	dx, dy, dz := box.Max.X-box.Min.X, box.Max.Y-box.Min.Y, box.Max.Z-box.Min.Z
-	if dx >= dy && dx >= dz {
-		return 0
-	}
-	if dy >= dz {
-		return 1
-	}
-	return 2
-}
-
-// centroidOnAxis returns a triangle box's centre coordinate on the given axis.
-func centroidOnAxis(box math.Box, axis int) float64 {
-	switch axis {
-	case 0:
-		return float64(box.Min.X+box.Max.X) / 2
-	case 1:
-		return float64(box.Min.Y+box.Max.Y) / 2
-	default:
-		return float64(box.Min.Z+box.Max.Z) / 2
-	}
+	b.tree.Query(box, hit)
 }
 
 // meshTriangles returns a mesh's triangles as explicit point triples, the input the BVH and the Möller

--- a/kernel/ops/sew.go
+++ b/kernel/ops/sew.go
@@ -68,19 +68,72 @@ type boundaryClusters struct {
 // boundarySnap clusters the open edges' endpoints: endpoints within tol of each
 // other meld into one cluster whose centroid becomes the sewn position.
 func boundarySnap(open []*topo.Edge, tol float64) *boundaryClusters {
-	pts := boundaryEndpoints(open)
+	return endpointClusterSnap(boundaryEndpoints(open), tol)
+}
+
+// endpointClusterSnap unions endpoints within tol of each other and returns their cluster
+// centroids. The spatial hash is built FIRST and candidacy flows through it — the retired
+// O(m²) pre-pass compared every endpoint pair before the grid existed (#1607). Cells have
+// edge tol, so any pair within tol sits in the same or an adjacent cell (its 3×3×3
+// neighbourhood): the union set is exactly the brute scan's, the union-find components are
+// therefore identical, and clusterCentroids accumulates members in index order regardless of
+// union order — so the sewn positions are bit-identical.
+func endpointClusterSnap(pts []math.Point3, tol float64) *boundaryClusters {
 	cluster := make([]int, len(pts))
 	for i := range cluster {
 		cluster[i] = i
 	}
+	cells := endpointCells(pts, tol)
 	for i := range pts {
-		for j := i + 1; j < len(pts); j++ {
-			if float64(pts[i].DistanceTo(pts[j])) <= tol {
-				union(cluster, i, j)
+		unionNearbyEndpoints(cells, pts, i, tol, cluster)
+	}
+	return clusterCentroids(pts, cluster)
+}
+
+// endpointCells hashes each endpoint into its tol-edge cube cell (Ericson §7.1 spatial
+// hashing; the sparse map holds only occupied cells).
+func endpointCells(pts []math.Point3, tol float64) map[[3]int64][]int32 {
+	cells := make(map[[3]int64][]int32, len(pts))
+	for i, p := range pts {
+		c := endpointCell(p, tol)
+		cells[c] = append(cells[c], int32(i))
+	}
+	return cells
+}
+
+func endpointCell(p math.Point3, tol float64) [3]int64 {
+	return [3]int64{
+		int64(stdmath.Floor(float64(p.X) / tol)),
+		int64(stdmath.Floor(float64(p.Y) / tol)),
+		int64(stdmath.Floor(float64(p.Z) / tol)),
+	}
+}
+
+// unionNearbyEndpoints unions endpoint i with every within-tol endpoint j > i found in the
+// 27 neighbouring cells (j < i pairs were already unioned when j was the query — the same
+// each-pair-once discipline as the retired i<j double loop).
+func unionNearbyEndpoints(cells map[[3]int64][]int32, pts []math.Point3, i int, tol float64, cluster []int) {
+	c := endpointCell(pts[i], tol)
+	for _, d := range sewCellNeighborhood {
+		for _, j := range cells[[3]int64{c[0] + d[0], c[1] + d[1], c[2] + d[2]}] {
+			if int(j) > i && float64(pts[i].DistanceTo(pts[int(j)])) <= tol {
+				union(cluster, i, int(j))
 			}
 		}
 	}
-	return clusterCentroids(pts, cluster)
+}
+
+// sewCellNeighborhood is the 3×3×3 cell-offset stencil around an endpoint's own cell.
+var sewCellNeighborhood = cubeNeighborhood()
+
+func cubeNeighborhood() [][3]int64 {
+	out := make([][3]int64, 0, 27)
+	for dx := int64(-1); dx <= 1; dx++ {
+		for dy := int64(-1); dy <= 1; dy++ {
+			out = append(out, [3]int64{dx, dy, -1}, [3]int64{dx, dy, 0}, [3]int64{dx, dy, 1})
+		}
+	}
+	return out
 }
 
 // boundaryEndpoints collects each open edge's two endpoint positions.

--- a/kernel/ops/sew_bench_test.go
+++ b/kernel/ops/sew_bench_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+	stdrand "math/rand"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// sewBenchEndpoints spreads m endpoints over a shell-sized domain with every second point
+// jittered within tol of another — the open-quilt boundary soup Sew clusters.
+func sewBenchEndpoints(m int, tol float64) []math.Point3 {
+	rng := stdrand.New(stdrand.NewSource(1607))
+	pts := make([]math.Point3, 0, m)
+	for len(pts) < m {
+		p := math.P3(rng.Float64()*100, rng.Float64()*100, rng.Float64()*100)
+		pts = append(pts, p, p.TranslateBy(math.V3(tol/2, 0, 0)))
+	}
+	return pts
+}
+
+// BenchmarkEndpointClusterSnap locks the sew clustering's asymptotics at 1×/4×/16× endpoint
+// counts (#1607): with the tol-cell grid hash built first, per-tier cost must grow near
+// linearly where the retired pre-pass grew with m².
+func BenchmarkEndpointClusterSnap(b *testing.B) {
+	const tol = 0.05
+	for _, m := range []int{1024, 4096, 16384} {
+		pts := sewBenchEndpoints(m, tol)
+		b.Run(fmt.Sprintf("endpoints_%d", m), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				endpointClusterSnap(pts, tol)
+			}
+		})
+	}
+}

--- a/kernel/ops/sew_cluster_test.go
+++ b/kernel/ops/sew_cluster_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdrand "math/rand"
+	"reflect"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// bruteEndpointClusterSnap is the retired O(m²) clustering pre-pass, kept as the oracle: the
+// grid-hash version must reproduce its output bit for bit (#1607).
+func bruteEndpointClusterSnap(pts []math.Point3, tol float64) *boundaryClusters {
+	cluster := make([]int, len(pts))
+	for i := range cluster {
+		cluster[i] = i
+	}
+	for i := range pts {
+		for j := i + 1; j < len(pts); j++ {
+			if float64(pts[i].DistanceTo(pts[j])) <= tol {
+				union(cluster, i, j)
+			}
+		}
+	}
+	return clusterCentroids(pts, cluster)
+}
+
+// sewClusterFixture builds a reproducible endpoint soup: cluster nuclei with satellites
+// inside tol (must meld), strays far away (must stay singleton), and a chain of points spaced
+// just under tol (must meld transitively across grid cells).
+func sewClusterFixture(rng *stdrand.Rand, nuclei int, tol float64) []math.Point3 {
+	var pts []math.Point3
+	for k := 0; k < nuclei; k++ {
+		c := math.P3(rng.Float64()*50, rng.Float64()*50, rng.Float64()*50)
+		pts = append(pts, c)
+		for s := 0; s < 3; s++ {
+			pts = append(pts, c.TranslateBy(math.V3(rng.Float64()*tol/3, rng.Float64()*tol/3, rng.Float64()*tol/3)))
+		}
+		pts = append(pts, c.TranslateBy(math.V3(10*tol, 0, 0))) // stray
+	}
+	for s := 0; s < 8; s++ { // the transitive chain
+		pts = append(pts, math.P3(60+float64(s)*0.9*tol, 60, 60))
+	}
+	return pts
+}
+
+// TestEndpointClusterSnapMatchesBrute pins bit-identity of the grid-hash clustering against
+// the retired O(m²) oracle on randomized fixtures: same components, same centroids, same
+// cell keys.
+func TestEndpointClusterSnapMatchesBrute(t *testing.T) {
+	rng := stdrand.New(stdrand.NewSource(84)) // PBI-084, the original sew work item
+	for trial := 0; trial < 20; trial++ {
+		tol := 0.05 + rng.Float64()*0.2
+		pts := sewClusterFixture(rng, 20, tol)
+		got := endpointClusterSnap(pts, tol)
+		want := bruteEndpointClusterSnap(pts, tol)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("trial %d (tol=%g): grid clustering differs from the brute oracle", trial, tol)
+		}
+	}
+}
+
+// TestEndpointClusterSnapChainMelds pins the transitive case the grid must not break: a chain
+// spaced under tol melds into ONE cluster even though its ends are many cells apart, so every
+// chain member snaps to the same centroid.
+func TestEndpointClusterSnapChainMelds(t *testing.T) {
+	tol := 0.1
+	var pts []math.Point3
+	for s := 0; s < 10; s++ {
+		pts = append(pts, math.P3(float64(s)*0.9*tol, 0, 0))
+	}
+	bc := endpointClusterSnap(pts, tol)
+	first := bc.apply(pts[0])
+	for s, p := range pts {
+		if bc.apply(p) != first {
+			t.Fatalf("chain member %d snapped to %v, want the shared centroid %v", s, bc.apply(p), first)
+		}
+	}
+}

--- a/kernel/ops/winding_farfield.go
+++ b/kernel/ops/winding_farfield.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// Provably exact acceleration of repeated winding-number queries against one mesh (#1607).
+//
+// The generalized winding number needs EVERY triangle's solid angle, so a plain BVH prune is
+// WRONG — dropping far triangles changes the sum — and the Barill et al. 2018 hierarchical
+// dipole approximation is uncertified: its error, however small, can flip a classification for
+// a query near the w≈0.5 iso-surface, which in boolean classification is exactly a point ON
+// the other solid's boundary. A certified hierarchical variant was tried and rejected: the
+// only RIGOROUS per-subtree cap, |ΣΩ| ≤ area/d² (a patch of area A projected onto the unit
+// sphere from distance ≥ d shrinks by ≥ 1/d²), cannot see the dipole cancellation that makes
+// far patches negligible, so interior queries essentially never certify and the traversal just
+// adds overhead. The exact per-triangle loop therefore stays the classifier.
+//
+// What IS provably exact — and cached here — is the far-field early-out: from distance d
+// outside the mesh's bounding box the winding number can never exceed totalArea/(4π·d²), so a
+// query far enough away is certified outside without visiting a single triangle.
+type meshWindingFarField struct {
+	mesh      *Mesh
+	box       math.Box
+	totalArea float64
+}
+
+// newMeshWindingFarField caches the mesh's bounding box and total triangle area — one O(T)
+// pass, about the cost of a single winding query.
+func newMeshWindingFarField(mesh *Mesh) *meshWindingFarField {
+	f := &meshWindingFarField{mesh: mesh, box: math.EmptyBox()}
+	for i := 0; i+2 < len(mesh.Indices); i += 3 {
+		t := meshTriangle(mesh, i)
+		f.box = f.box.ExtendPoint(t[0]).ExtendPoint(t[1]).ExtendPoint(t[2])
+		f.totalArea += 0.5 * float64(t[0].VectorTo(t[1]).Cross(t[0].VectorTo(t[2])).Length())
+	}
+	return f
+}
+
+// inside classifies p with the same result as pointInMesh: the certified far-field early-out
+// when it applies, the exact brute loop otherwise.
+func (f *meshWindingFarField) inside(p math.Point3) bool {
+	if f.certifiedOutside(p) {
+		return false
+	}
+	return pointInMesh(f.mesh, p)
+}
+
+// windingFarFieldMaxW is the winding-number ceiling under which the far-field early-out fires:
+// 2× below the 0.5 inside cutoff, so the exact value (≤ totalArea/(4π·d²) ≤ 0.25) plus any
+// float64 summation error of the brute loop (≲ n·eps·|w|, astronomically below 0.25) can never
+// reach the cutoff — the early-out returns exactly what the brute loop would.
+const windingFarFieldMaxW = 0.25 // tol:numeric — dimensionless winding-number ceiling (certified; see above)
+
+// certifiedOutside reports whether p is provably outside: strictly beyond the mesh box, with
+// the rigorous winding cap totalArea/(4π·d²) at or below [windingFarFieldMaxW].
+func (f *meshWindingFarField) certifiedOutside(p math.Point3) bool {
+	d2 := pointBoxDistanceSq(p, f.box)
+	return d2 > 0 && f.totalArea/d2 <= windingFarFieldMaxW*(4*stdmath.Pi)
+}
+
+// pointBoxDistanceSq is the squared Euclidean distance from p to the closed box (0 inside).
+func pointBoxDistanceSq(p math.Point3, b math.Box) float64 {
+	dx := axisGap(float64(p.X), float64(b.Min.X), float64(b.Max.X))
+	dy := axisGap(float64(p.Y), float64(b.Min.Y), float64(b.Max.Y))
+	dz := axisGap(float64(p.Z), float64(b.Min.Z), float64(b.Max.Z))
+	return dx*dx + dy*dy + dz*dz
+}
+
+// axisGap is the 1D distance from v to the interval [lo, hi] (0 inside).
+func axisGap(v, lo, hi float64) float64 {
+	if v < lo {
+		return lo - v
+	}
+	if v > hi {
+		return v - hi
+	}
+	return 0
+}
+
+// windingCacheMinQueries gates the far-field cache to workloads that amortize its O(T) build
+// (a count, not a length): a single query is cheaper through the brute loop alone.
+const windingCacheMinQueries = 2
+
+// insideMeshQuerier returns the point-in-mesh classifier for `queries` upcoming queries
+// against one mesh: the far-field-cached classifier when the workload amortizes the cache
+// build, else the plain brute loop. Both classify identically (the early-out is certified —
+// see the meshWindingFarField type comment).
+//
+// Example: inMesh := insideMeshQuerier(mesh, len(verts)); for _, v := range verts { inMesh(v.Point()) }
+func insideMeshQuerier(mesh *Mesh, queries int) func(math.Point3) bool {
+	if queries < windingCacheMinQueries {
+		return func(p math.Point3) bool { return pointInMesh(mesh, p) }
+	}
+	return newMeshWindingFarField(mesh).inside
+}

--- a/kernel/ops/winding_farfield_test.go
+++ b/kernel/ops/winding_farfield_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	stdrand "math/rand"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// uvSphereMesh builds an outward-oriented closed UV-sphere mesh (radius r at the origin) with
+// nLat latitude bands × nLon longitude steps — the synthetic solid boundary the winding tests
+// and benchmarks scale by triangle count.
+func uvSphereMesh(nLat, nLon int, r float64) *Mesh {
+	m := &Mesh{}
+	at := func(i, j int) math.Point3 {
+		theta := stdmath.Pi * float64(i) / float64(nLat)
+		phi := 2 * stdmath.Pi * float64(j%nLon) / float64(nLon)
+		return math.P3(r*stdmath.Sin(theta)*stdmath.Cos(phi), r*stdmath.Sin(theta)*stdmath.Sin(phi), r*stdmath.Cos(theta))
+	}
+	push := func(pts ...math.Point3) {
+		for _, p := range pts {
+			m.Indices = append(m.Indices, len(m.Positions))
+			m.Positions = append(m.Positions, p)
+		}
+	}
+	for i := 0; i < nLat; i++ {
+		for j := 0; j < nLon; j++ {
+			a, b, c, d := at(i, j), at(i+1, j), at(i+1, j+1), at(i, j+1)
+			if i > 0 {
+				push(a, b, d) // outward CCW seen from outside
+			}
+			if i < nLat-1 {
+				push(b, c, d)
+			}
+		}
+	}
+	return m
+}
+
+// TestWindingFarFieldMatchesBruteOnRandomPoints is the exactness cross-check #1607 requires:
+// on 1000 randomized query points — near-surface, interior, and far-field alike — the cached
+// classifier must agree with the exact brute loop on EVERY point.
+func TestWindingFarFieldMatchesBruteOnRandomPoints(t *testing.T) {
+	mesh := uvSphereMesh(24, 32, 1)
+	far := newMeshWindingFarField(mesh)
+	rng := stdrand.New(stdrand.NewSource(2018)) // Barill et al. year, for flavour
+	for k := 0; k < 1000; k++ {
+		span := []float64{1.05, 1.5, 30}[k%3] // surface band, mid range, deep far field
+		p := math.P3(rng.Float64()*2*span-span, rng.Float64()*2*span-span, rng.Float64()*2*span-span)
+		if got, want := far.inside(p), pointInMesh(mesh, p); got != want {
+			t.Fatalf("point %d %v: cached inside=%v, exact loop says %v", k, p, got, want)
+		}
+	}
+}
+
+// TestWindingFarFieldCertifiesOnlyFarQueries pins both sides of the early-out: a deep
+// far-field query certifies (no triangle visits needed), while near-box and interior queries
+// must NOT certify — they belong to the exact loop.
+func TestWindingFarFieldCertifiesOnlyFarQueries(t *testing.T) {
+	far := newMeshWindingFarField(uvSphereMesh(16, 24, 1))
+	if !far.certifiedOutside(math.P3(100, 100, 100)) {
+		t.Fatal("deep far-field query did not certify outside")
+	}
+	if far.certifiedOutside(math.P3(0, 0, 0)) || far.certifiedOutside(math.P3(1.01, 0, 0)) {
+		t.Fatal("interior/near-surface query certified outside — the cap math is broken")
+	}
+	if far.inside(math.P3(100, 100, 100)) || !far.inside(math.P3(0, 0, 0)) {
+		t.Fatal("far-field classifier misclassified an obvious point")
+	}
+}
+
+// TestWindingFarFieldEmptyMesh: the degenerate no-triangle mesh classifies everything outside,
+// like the brute loop (winding 0).
+func TestWindingFarFieldEmptyMesh(t *testing.T) {
+	if newMeshWindingFarField(&Mesh{}).inside(math.P3(0, 0, 0)) {
+		t.Fatal("empty mesh classified a point inside")
+	}
+}
+
+// TestInsideMeshQuerierGates covers both querier arms: below the amortization gate it must
+// hand back the brute loop, above it the cached classifier — and both agree with pointInMesh.
+func TestInsideMeshQuerierGates(t *testing.T) {
+	mesh := uvSphereMesh(12, 16, 1)
+	for _, queries := range []int{1, 8} {
+		inMesh := insideMeshQuerier(mesh, queries)
+		for _, p := range []math.Point3{math.P3(0, 0, 0), math.P3(0.9, 0, 0), math.P3(50, 0, 0)} {
+			if got, want := inMesh(p), pointInMesh(mesh, p); got != want {
+				t.Fatalf("querier(queries=%d) at %v = %v, brute loop says %v", queries, p, got, want)
+			}
+		}
+	}
+}
+
+// TestPointBoxDistanceSq covers the far-field distance helper: inside → 0, face/corner gaps
+// exact.
+func TestPointBoxDistanceSq(t *testing.T) {
+	b := math.NewBox(math.P3(0, 0, 0), math.P3(2, 2, 2))
+	if d := pointBoxDistanceSq(math.P3(1, 1, 1), b); d != 0 {
+		t.Fatalf("inside point distance² = %g, want 0", d)
+	}
+	if d := pointBoxDistanceSq(math.P3(5, 1, 1), b); d != 9 {
+		t.Fatalf("face gap distance² = %g, want 9", d)
+	}
+	if d := pointBoxDistanceSq(math.P3(3, 3, 3), b); d != 3 {
+		t.Fatalf("corner gap distance² = %g, want 3", d)
+	}
+}


### PR DESCRIPTION
Closes #1607 (deep-audit finding A11).

Culling and hoisting ONLY — every narrow phase, tolerance, and iteration order is preserved, so results are bit-identical; the full boolean regression suite passes unchanged and each sub-fix carries a randomized brute-oracle equivalence test.

## Per-loop status

| Hot loop | Status |
|---|---|
| `brep/boolean.go` O(Fa·Fb) face pairing, computed 2–3× | **Culled** — one padded-AABB candidate set per pass via the new `geom.BoxTree` (the #1411 triangle BVH generalized out of `kernel/ops`, which now delegates to it; `ops` imports `brep`, so the tree lives in `geom`). One narrow-phase pass feeds imprint + provenance + the coplanar-cover scan. Bonus from the same profile: `insideSolid` re-flattened the whole operand (`facesOf` + `RangeBox`) per query — now hoisted into a per-operand `solidProbe` (same faces/tolerance/summation order). |
| `ops/point_in_solid.go` O(V·T) winding batch | **Left exact, with a certified far-field early-out.** The winding number needs every triangle's solid angle, so a BVH prune is wrong and Barill-2018 dipole approximations are uncertified (can flip a classification exactly at a point ON the other solid's boundary). A certified hierarchical variant was built and rejected: the only rigorous per-subtree cap (area/d²) cannot see dipole cancellation, so interior queries never certify — it benchmarked ~2× slower. Shipped instead: cached bbox+area per mesh giving a provably exact far-outside early-out (w ≤ A/(4πd²) ≤ 0.25 < 0.5), cross-checked against the brute loop on 1000 randomized points. |
| `brep/arrange2d.go` O(S²) segment pairs + O(E·V) T-junction scan | **Culled** — uniform grid hashes over padded segment AABBs and over the welded vertices (Ericson §7.1). Grid-candidates ⊇ brute-intersecting set pinned on randomized fixtures, plus whole-`planarize` DeepEqual vs the brute oracle. |
| `ops/sew.go` O(m²) endpoint clustering built before the hash | **Culled** — tol-cell spatial hash built FIRST, union through the 3×3×3 neighbourhood; quadratic pre-pass deleted. Same union set ⇒ same components ⇒ bit-identical centroids (DeepEqual vs brute oracle incl. transitive under-tol chains). |

## Tiered benchmarks (before = develop, after = this branch; AMD Ryzen AI MAX+ 395)

**Boolean patterned pocket chain** (`BenchmarkBooleanPatternedPocketChain`, n×n blind pockets cut one Difference at a time):

| Tier | develop | branch | speedup |
|---|---|---|---|
| 2×2 (4 cuts) | 3.48 ms | 1.71 ms | 2.0× |
| 4×4 (16 cuts) | 26.3 ms | 17.5 ms | 1.5× |
| 8×8 (64 cuts) | 440 ms | 331 ms | 1.3× |

Pair scans no longer dominate; the remaining cost is the exact winding-number classification per sub-face (kept exact by design — same constraint as point-in-solid).

**2D arrangement** (`BenchmarkPlanarizeCrossingGrid`, crossing grid):

| Segments | develop | branch | speedup |
|---|---|---|---|
| 16 | 88.8 µs | 78.5 µs | 1.1× |
| 64 | 3.52 ms | 0.80 ms | 4.4× |
| 256 | 648 ms | 18.0 ms | **36×** |

**Sew endpoint clustering** (`BenchmarkEndpointClusterSnap`):

| Endpoints | develop | branch | speedup |
|---|---|---|---|
| 1 024 | 1.03 ms | 0.70 ms | 1.5× |
| 4 096 | 13.9 ms | 3.04 ms | 4.6× |
| 16 384 | 205 ms | 13.3 ms | **15×** |

**Point-in-mesh 64-query batch, half far-field** (`BenchmarkPointInMeshBruteBatch` → `...FarFieldBatch`):

| Triangles | brute | far-field cache | speedup |
|---|---|---|---|
| 352 | 302 µs | 176 µs | 1.7× |
| 1 472 | 1.32 ms | 0.75 ms | 1.8× |
| 6 016 | 5.17 ms | 2.85 ms | 1.8× |

## Verification

- `go test ./... -count=1`: green except the two pre-existing `script/luadoc` failures, reproduced identically on pristine `origin/develop` (caused by the sibling Oblikovati.API working tree's in-flight client refactor, unrelated to this branch).
- `golangci-lint run ./...`: 0 issues.
- Tolerance guard (`kernel/ops/tolerance_guard_test.go`) passes: new pads derive from existing calibrated constants (`10·planarStitchGrid`, `10·arrTol`, `10·tjTol`) or are annotated dimensionless `tol:numeric` bounds.
- Culling-soundness + bit-identity oracle tests: `TestCrossingFaceCandidatesSupersetOfImprintingPairs`, `TestImprintCandidatesMatchesBruteScan`, `TestSegmentCullGridSupersetOfNarrowPhase`, `TestPlanarizeGridMatchesBrute`, `TestVertexOnEdgeInteriorGridMatchesFullScan`, `TestEndpointClusterSnapMatchesBrute`, `TestWindingFarFieldMatchesBruteOnRandomPoints`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)