### PR TITLE
M40 S1/S12: scale imported point clouds to document units and route them through exchange dispatch

### DIFF
--- a/addin/router/point_clouds.go
+++ b/addin/router/point_clouds.go
@@ -46,7 +46,9 @@ func attachPointCloud(s *app.Session, raw json.RawMessage) (json.RawMessage, err
 	if err := decode(raw, &in); err != nil {
 		return nil, err
 	}
-	pc, err := s.AttachPointCloud(in.Name, in.FullFileName)
+	// Per-record decode warnings (#1646) are not yet surfaced over the wire: PointCloudInfo has
+	// no warnings slot (an api/wire DTO addition in the Apache-2.0 sibling repo).
+	pc, _, err := s.AttachPointCloud(in.Name, in.FullFileName)
 	if err != nil {
 		return nil, fmt.Errorf("pointClouds.attach: %w", err)
 	}

--- a/addin/router/point_clouds_test.go
+++ b/addin/router/point_clouds_test.go
@@ -13,7 +13,9 @@ import (
 	"oblikovati.org/model/feature"
 )
 
-// writeScan writes a small ASCII scan file and returns its path.
+// writeScan writes a small ASCII scan file and returns its path. Coordinates are in file
+// MILLIMETRES (the unitless-scan convention, #1636); the default document is centimetres, so a
+// "10" in the fixture lands at 1.0 in database units.
 func writeScan(t *testing.T, body string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "scan.xyz")
@@ -27,7 +29,7 @@ func writeScan(t *testing.T, body string) string {
 // with the cloud's point count and default state surfaced (M17-F06, #645).
 func TestPointCloudAttachListGetDelete(t *testing.T) {
 	r, s := emptyPartSession(t)
-	path := writeScan(t, "0 0 0\n1 0 0\n2 0 0\n3 0 0\n")
+	path := writeScan(t, "0 0 0\n10 0 0\n20 0 0\n30 0 0\n")
 
 	var attached wire.PointCloudInfo
 	call(t, r, s, "pointClouds.attach", mustJSON(t, wire.AttachPointCloudArgs{FullFileName: path}), &attached)
@@ -98,7 +100,7 @@ func TestPointCloudPlacementAndBudget(t *testing.T) {
 // list it, and delete it — all over the wire (#645).
 func TestPointCloudCropLifecycle(t *testing.T) {
 	r, s := emptyPartSession(t)
-	path := writeScan(t, "0 0 0\n1 0 0\n2 0 0\n3 0 0\n4 0 0\n5 0 0\n")
+	path := writeScan(t, "0 0 0\n10 0 0\n20 0 0\n30 0 0\n40 0 0\n50 0 0\n")
 	var info wire.PointCloudInfo
 	call(t, r, s, "pointClouds.attach", mustJSON(t, wire.AttachPointCloudArgs{Name: "Scan", FullFileName: path}), &info)
 	if info.DisplayedPointCount != 6 {
@@ -224,7 +226,7 @@ func TestPointCloudAttachErrors(t *testing.T) {
 // reports the new plane's name, origin (centroid), and unit normal (#645).
 func TestPointCloudFitPlane(t *testing.T) {
 	r, s := emptyPartSession(t)
-	path := writeScan(t, "0 0 5\n2 0 5\n0 2 5\n2 2 5\n1 3 5\n-1 1 5\n")
+	path := writeScan(t, "0 0 50\n20 0 50\n0 20 50\n20 20 50\n10 30 50\n-10 10 50\n")
 	var info wire.PointCloudInfo
 	call(t, r, s, "pointClouds.attach", mustJSON(t, wire.AttachPointCloudArgs{Name: "Scan", FullFileName: path}), &info)
 
@@ -248,7 +250,7 @@ func TestPointCloudFitPlane(t *testing.T) {
 // reports the distance; an unknown cloud errors (#645).
 func TestPointCloudNearestPoint(t *testing.T) {
 	r, s := emptyPartSession(t)
-	path := writeScan(t, "0 0 0\n2 0 0\n0 2 0\n")
+	path := writeScan(t, "0 0 0\n20 0 0\n0 20 0\n")
 	call(t, r, s, "pointClouds.attach", mustJSON(t, wire.AttachPointCloudArgs{Name: "Scan", FullFileName: path}), &wire.PointCloudInfo{})
 
 	var res wire.NearestPointResult

--- a/addin/router/point_clouds_test.go
+++ b/addin/router/point_clouds_test.go
@@ -270,7 +270,7 @@ func TestPointCloudNearestPoint(t *testing.T) {
 // so the datum follows without any separate recompute call (#645).
 func TestSetTransformAutoRecomputesDatums(t *testing.T) {
 	r, s := emptyPartSession(t)
-	path := writeScan(t, "0 0 5\n2 0 5\n0 2 5\n2 2 5\n")
+	path := writeScan(t, "0 0 50\n20 0 50\n0 20 50\n20 20 50\n")
 	call(t, r, s, "pointClouds.attach", mustJSON(t, wire.AttachPointCloudArgs{Name: "Scan", FullFileName: path}), &wire.PointCloudInfo{})
 
 	var fit wire.FitPointCloudPlaneResult

--- a/app/point_cloud_import.go
+++ b/app/point_cloud_import.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 
+	"oblikovati.org/kernel/exchange"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/model/pointcloud"
 )
@@ -30,7 +31,9 @@ func (s *Session) AttachPointCloud(name, fullFileName string) (*pointcloud.Point
 	if err != nil {
 		return nil, fmt.Errorf("app: read scan %q: %w", fullFileName, err)
 	}
-	points, err := pointcloud.ReadScan(fullFileName, data)
+	// Scale the scan's file unit into the document's working unit — the same TranslationOptions
+	// seam every other importer threads (#1636).
+	points, err := pointcloud.ReadScan(fullFileName, data, exchange.TranslationOptions{TargetUnitMM: part.WorkingUnitMM()})
 	if err != nil {
 		return nil, err
 	}

--- a/app/point_cloud_import.go
+++ b/app/point_cloud_import.go
@@ -4,44 +4,34 @@ package app
 
 import (
 	"fmt"
-	"os"
 
-	"oblikovati.org/kernel/exchange"
-	"oblikovati.org/model/doc"
+	"oblikovati.org/model/exchange"
 	"oblikovati.org/model/pointcloud"
 )
 
 // Point-cloud import (M17-F06, #645): the shared attach path used by both the Insert ▸ Import
-// Point Cloud command (via the head's file dialog) and the pointClouds.attach wire method, so the
-// read → embed → decode → attach sequence lives in one place.
+// Point Cloud command (via the head's file dialog) and the pointClouds.attach wire method. The
+// read → embed → decode → attach sequence lives in the model/exchange dispatch vertical
+// (exchange.ImportPointCloud, #1646) so scan imports share the standard exchange seam.
 
 // AttachPointCloud reads the scan file at fullFileName, embeds its bytes in the active part's
-// resource table (ADR-0031), decodes its points, and attaches the cloud under name (a unique name
-// is minted when name is empty). Errors when there is no active part, the file is unreadable, or
-// the scan format has no reader.
-func (s *Session) AttachPointCloud(name, fullFileName string) (*pointcloud.PointCloud, error) {
+// resource table (ADR-0031), decodes its points into the document working unit (#1636), and
+// attaches the cloud under name (a unique name is minted when name is empty). Warnings report
+// skipped malformed records (#1646). Errors when there is no active part, the file is
+// unreadable, or the scan format has no reader.
+func (s *Session) AttachPointCloud(name, fullFileName string) (*pointcloud.PointCloud, []string, error) {
 	part, err := activePart(s)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if fullFileName == "" {
-		return nil, fmt.Errorf("app: AttachPointCloud needs a file name")
+		return nil, nil, fmt.Errorf("app: AttachPointCloud needs a file name")
 	}
-	data, err := os.ReadFile(fullFileName)
+	pc, res, err := exchange.ImportPointCloud(part, name, fullFileName)
 	if err != nil {
-		return nil, fmt.Errorf("app: read scan %q: %w", fullFileName, err)
+		return nil, nil, err
 	}
-	// Scale the scan's file unit into the document's working unit — the same TranslationOptions
-	// seam every other importer threads (#1636).
-	points, err := pointcloud.ReadScan(fullFileName, data, exchange.TranslationOptions{TargetUnitMM: part.WorkingUnitMM()})
-	if err != nil {
-		return nil, err
-	}
-	if name == "" {
-		name = part.PointClouds().UniqueName("Cloud")
-	}
-	rid := part.AddResource(doc.Resource{Type: "PointCloudScan", Encoding: doc.EncodingUTF8, Value: data, Origin: fullFileName})
-	return part.PointClouds().Add(name, fullFileName, rid, points)
+	return pc, res.Warnings, nil
 }
 
 // RequestImportPointCloud flags that the user asked to import a scan; the head opens its file

--- a/app/point_cloud_ui_test.go
+++ b/app/point_cloud_ui_test.go
@@ -76,14 +76,14 @@ func TestAttachPointCloudAndRequest(t *testing.T) {
 	if err := os.WriteFile(path, []byte("0 0 0\n1 1 1\n"), 0o600); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	pc, err := s.AttachPointCloud("Scan", path)
+	pc, _, err := s.AttachPointCloud("Scan", path)
 	if err != nil || pc.TotalPointCount() != 2 {
 		t.Fatalf("AttachPointCloud = %v pts, err %v", pc, err)
 	}
 	if def.PointClouds().Count() != 1 {
 		t.Errorf("active part has %d clouds, want 1", def.PointClouds().Count())
 	}
-	if _, err := s.AttachPointCloud("X", "/no/such/file.xyz"); err == nil {
+	if _, _, err := s.AttachPointCloud("X", "/no/such/file.xyz"); err == nil {
 		t.Error("AttachPointCloud of a missing file should fail")
 	}
 
@@ -155,7 +155,7 @@ func TestPointCloudEdgeCasesWithoutPart(t *testing.T) {
 	if len(s.PointCloudItems(s.Camera(), 0.5)) != 0 {
 		t.Error("no active part should yield no point-cloud items")
 	}
-	if _, err := s.AttachPointCloud("X", "/tmp/whatever.xyz"); err == nil {
+	if _, _, err := s.AttachPointCloud("X", "/tmp/whatever.xyz"); err == nil {
 		t.Error("AttachPointCloud with no active part should fail")
 	}
 	if pointCloudMenu(BodyHandle{}) != nil {
@@ -183,17 +183,17 @@ func TestAttachPointCloudEmptyName(t *testing.T) {
 	s, _ := emptyPartSession(t)
 	path := filepath.Join(t.TempDir(), "s.xyz")
 	_ = os.WriteFile(path, []byte("0 0 0\n"), 0o600)
-	pc, err := s.AttachPointCloud("", path)
+	pc, _, err := s.AttachPointCloud("", path)
 	if err != nil || pc.Name() != "Cloud1" {
 		t.Errorf("AttachPointCloud(empty name) = %v, err %v; want Cloud1", pc, err)
 	}
 
-	if _, err := s.AttachPointCloud("X", ""); err == nil {
+	if _, _, err := s.AttachPointCloud("X", ""); err == nil {
 		t.Error("AttachPointCloud with an empty file name should fail")
 	}
 	bad := filepath.Join(t.TempDir(), "scan.las") // exists but no reader for .las
 	_ = os.WriteFile(bad, []byte("binary"), 0o600)
-	if _, err := s.AttachPointCloud("Y", bad); err == nil {
+	if _, _, err := s.AttachPointCloud("Y", bad); err == nil {
 		t.Error("AttachPointCloud of an unsupported scan format should fail")
 	}
 }

--- a/head/ui/file_dialog_draw.go
+++ b/head/ui/file_dialog_draw.go
@@ -336,8 +336,14 @@ func placeMeshFromFile(s *app.Session, path, name string) {
 // attachPointCloudFromFile attaches an ASCII scan as a referenced point cloud (3D Model ▸ Import
 // Point Cloud, #645).
 func attachPointCloudFromFile(s *app.Session, path, name string) {
-	if _, err := s.AttachPointCloud("", path); err != nil {
+	_, warns, err := s.AttachPointCloud("", path)
+	if err != nil {
 		fileNotice(s, "Import Point Cloud failed: %v", err)
+		return
+	}
+	if len(warns) > 0 {
+		// Per-record decode warnings (#1646): surface the count and the first offender.
+		fileNotice(s, "Attached point cloud %s (%d records skipped: %s)", name, len(warns), warns[0])
 		return
 	}
 	fileNotice(s, "Attached point cloud %s", name)

--- a/head/ui/point_cloud_capture_helpers_test.go
+++ b/head/ui/point_cloud_capture_helpers_test.go
@@ -28,7 +28,7 @@ func newShotWindow(t *testing.T) *native.Window {
 // shared setup for the provenance / move / auto-recompute shot tests.
 func attachSheetWithFitPlane(t *testing.T, s *app.Session) (*pointcloud.PointCloud, *feature.WorkPlane) {
 	t.Helper()
-	pc, err := s.AttachPointCloud("Sheet", tiltedSheetScan(t))
+	pc, _, err := s.AttachPointCloud("Sheet", tiltedSheetScan(t))
 	if err != nil {
 		t.Fatalf("attach scan: %v", err)
 	}

--- a/head/ui/point_cloud_crop_shot_test.go
+++ b/head/ui/point_cloud_crop_shot_test.go
@@ -49,10 +49,14 @@ func TestInWindowCropBoxRenders(t *testing.T) {
 	}
 	frameCameraOn(s, pc.RangeBox())
 
-	// Box the central model region [-6,6]² by projecting its corners to viewport pixels with the
-	// same projection the crop tool uses, so the clicks reliably enclose the inner points.
-	sx0, sy0, ok0 := renderer.Project(s.Camera(), 0.1, 5000, math.P3(-6, -6, 0))
-	sx1, sy1, ok1 := renderer.Project(s.Camera(), 0.1, 5000, math.P3(6, 6, 0))
+	// Box the central half of the cloud's actual extent by projecting those corners to viewport
+	// pixels with the same projection the crop tool uses, so the clicks reliably enclose the inner
+	// points. The extent is read from the attached cloud's RangeBox rather than the raw file
+	// coordinates because import rescales the cloud to the document's working unit (#1636) — a
+	// hard-coded world box would no longer straddle the (now smaller) cloud.
+	rb := pc.RangeBox()
+	sx0, sy0, ok0 := renderer.Project(s.Camera(), 0.1, 5000, math.P3(rb.Min.X/2, rb.Min.Y/2, 0))
+	sx1, sy1, ok1 := renderer.Project(s.Camera(), 0.1, 5000, math.P3(rb.Max.X/2, rb.Max.Y/2, 0))
 	if !ok0 || !ok1 {
 		t.Fatal("central corners must project on-screen")
 	}

--- a/head/ui/point_cloud_crop_shot_test.go
+++ b/head/ui/point_cloud_crop_shot_test.go
@@ -43,7 +43,7 @@ func TestInWindowCropBoxRenders(t *testing.T) {
 	icons = nil
 
 	s := framedSession()
-	pc, err := s.AttachPointCloud("Wide", wideGridScan(t))
+	pc, _, err := s.AttachPointCloud("Wide", wideGridScan(t))
 	if err != nil {
 		t.Fatalf("attach scan: %v", err)
 	}

--- a/head/ui/point_cloud_fit_shot_test.go
+++ b/head/ui/point_cloud_fit_shot_test.go
@@ -40,7 +40,7 @@ func TestInWindowFitPlaneRenders(t *testing.T) {
 	icons = nil
 
 	s := framedSession()
-	pc, err := s.AttachPointCloud("Sheet", tiltedPlanarScan(t))
+	pc, _, err := s.AttachPointCloud("Sheet", tiltedPlanarScan(t))
 	if err != nil {
 		t.Fatalf("attach scan: %v", err)
 	}

--- a/head/ui/point_cloud_las_shot_test.go
+++ b/head/ui/point_cloud_las_shot_test.go
@@ -62,7 +62,7 @@ func TestInWindowSyntheticLASRenders(t *testing.T) {
 	icons = nil
 
 	s := framedSession()
-	pc, err := s.AttachPointCloud("Cube LAS", path)
+	pc, _, err := s.AttachPointCloud("Cube LAS", path)
 	if err != nil {
 		t.Fatalf("attach synthetic LAS: %v", err)
 	}

--- a/head/ui/point_cloud_provenance_shot_test.go
+++ b/head/ui/point_cloud_provenance_shot_test.go
@@ -49,7 +49,7 @@ func TestInWindowProvenancePlaneFollowsCloud(t *testing.T) {
 	icons = nil
 
 	s := framedSession()
-	pc, err := s.AttachPointCloud("Sheet", tiltedSheetScan(t))
+	pc, _, err := s.AttachPointCloud("Sheet", tiltedSheetScan(t))
 	if err != nil {
 		t.Fatalf("attach scan: %v", err)
 	}

--- a/head/ui/point_cloud_real_shot_test.go
+++ b/head/ui/point_cloud_real_shot_test.go
@@ -33,7 +33,7 @@ func TestInWindowRealScanRenders(t *testing.T) {
 	icons = nil
 
 	s := framedSession()
-	pc, err := s.AttachPointCloud("Capstan", realScanPath)
+	pc, _, err := s.AttachPointCloud("Capstan", realScanPath)
 	if err != nil {
 		t.Fatalf("attach real scan: %v", err)
 	}
@@ -65,7 +65,7 @@ func TestInWindowRealE57Renders(t *testing.T) {
 	icons = nil
 
 	s := framedSession()
-	pc, err := s.AttachPointCloud("Capstan E57", realE57Path)
+	pc, _, err := s.AttachPointCloud("Capstan E57", realE57Path)
 	if err != nil {
 		t.Fatalf("attach real E57 scan: %v", err)
 	}

--- a/head/ui/point_cloud_sketch_point_shot_test.go
+++ b/head/ui/point_cloud_sketch_point_shot_test.go
@@ -46,7 +46,7 @@ func TestInWindowSketchPointFromScanRenders(t *testing.T) {
 
 	s := framedSession()
 	path, peak := flatScanNearXY(t)
-	pc, err := s.AttachPointCloud("Flat", path)
+	pc, _, err := s.AttachPointCloud("Flat", path)
 	if err != nil {
 		t.Fatalf("attach scan: %v", err)
 	}

--- a/head/ui/point_cloud_sketchpoint_provenance_shot_test.go
+++ b/head/ui/point_cloud_sketchpoint_provenance_shot_test.go
@@ -32,7 +32,7 @@ func TestInWindowSketchPointProvenanceFollowsCloud(t *testing.T) {
 
 	s := framedSession()
 	path, peak := flatScanNearXY(t) // reuses the grid+peak scan from the sketch-point shot test
-	pc, err := s.AttachPointCloud("Flat", path)
+	pc, _, err := s.AttachPointCloud("Flat", path)
 	if err != nil {
 		t.Fatalf("attach scan: %v", err)
 	}

--- a/head/ui/point_cloud_snap_shot_test.go
+++ b/head/ui/point_cloud_snap_shot_test.go
@@ -42,7 +42,7 @@ func TestInWindowSnapWorkPointRenders(t *testing.T) {
 	icons = nil
 
 	s := framedSession()
-	pc, err := s.AttachPointCloud("Grid", gridScan(t))
+	pc, _, err := s.AttachPointCloud("Grid", gridScan(t))
 	if err != nil {
 		t.Fatalf("attach scan: %v", err)
 	}

--- a/head/ui/point_cloud_tool_input_test.go
+++ b/head/ui/point_cloud_tool_input_test.go
@@ -25,7 +25,7 @@ func armCloudSession(t *testing.T) (*app.Session, *compdef.PartComponentDefiniti
 	if err := os.WriteFile(path, []byte("0 0 0\n1 0 0\n0 1 0\n1 1 0\n"), 0o644); err != nil {
 		t.Fatalf("write scan: %v", err)
 	}
-	pc, err := s.AttachPointCloud("Scan", path)
+	pc, _, err := s.AttachPointCloud("Scan", path)
 	if err != nil {
 		t.Fatalf("attach: %v", err)
 	}

--- a/head/ui/point_cloud_workpoint_provenance_shot_test.go
+++ b/head/ui/point_cloud_workpoint_provenance_shot_test.go
@@ -45,7 +45,7 @@ func TestInWindowWorkPointProvenanceFollowsCloud(t *testing.T) {
 
 	s := framedSession()
 	path, peak := flatScanWithPeak(t)
-	pc, err := s.AttachPointCloud("Peak", path)
+	pc, _, err := s.AttachPointCloud("Peak", path)
 	if err != nil {
 		t.Fatalf("attach scan: %v", err)
 	}

--- a/model/compdef/part.go
+++ b/model/compdef/part.go
@@ -5,6 +5,7 @@ package compdef
 import (
 	"strconv"
 
+	"oblikovati.org/kernel/exchange"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -329,6 +330,13 @@ func (d *PartComponentDefinition) Units() param.UnitsOfMeasure { return d.units 
 // (ADR-0042 Phase 2). The assembly placement walker reads it to convert a component placed
 // into an assembly of a different working unit (1.0 ⇒ the centimetre default).
 func (d *PartComponentDefinition) WorkingScale() float64 { return d.units.WorkingScale() }
+
+// WorkingUnitMM is the millimetre size of one stored (working) length unit — the database-unit
+// size the exchange translators scale imported files against (ADR-0042 Phase 2, #1636): the
+// working scale (centimetres per working unit) times the centimetre's 10 mm.
+func (d *PartComponentDefinition) WorkingUnitMM() float64 {
+	return d.units.WorkingScale() * exchange.DBUnitMM
+}
 
 // SetLengthUnit sets the document's preferred length unit (e.g. "mm", "in"). On a still-empty
 // document it also centres the working scale on that unit (ADR-0042 Phase 2) so coordinates

--- a/model/compdef/pointcloud_persist.go
+++ b/model/compdef/pointcloud_persist.go
@@ -46,7 +46,9 @@ func (d *PartComponentDefinition) scanPoints(rec doc.PointCloudRecord) []math.Po
 	if !ok {
 		return nil
 	}
-	points, err := pointcloud.ReadScan(rec.Source, res.Value, exchange.TranslationOptions{TargetUnitMM: d.WorkingUnitMM()})
+	// Restore is non-interactive, so per-record warnings are not surfaced here; the attach path
+	// already reported them (#1646).
+	points, _, err := pointcloud.ReadScan(rec.Source, res.Value, exchange.TranslationOptions{TargetUnitMM: d.WorkingUnitMM()})
 	if err != nil {
 		return nil
 	}

--- a/model/compdef/pointcloud_persist.go
+++ b/model/compdef/pointcloud_persist.go
@@ -3,6 +3,7 @@
 package compdef
 
 import (
+	"oblikovati.org/kernel/exchange"
 	"oblikovati.org/math"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/model/pointcloud"
@@ -38,13 +39,14 @@ func (d *PartComponentDefinition) SetPointCloudRecords(records []doc.PointCloudR
 }
 
 // scanPoints re-decodes a record's points from the embedded resource bytes, or nil when the
-// resource is missing or undecodable.
+// resource is missing or undecodable. The scan re-scales into the document's CURRENT working
+// unit (the same options the attach path used), so restored clouds match the attach scale (#1636).
 func (d *PartComponentDefinition) scanPoints(rec doc.PointCloudRecord) []math.Point3 {
 	res, ok := d.resources[rec.ResourceID]
 	if !ok {
 		return nil
 	}
-	points, err := pointcloud.ReadScan(rec.Source, res.Value)
+	points, err := pointcloud.ReadScan(rec.Source, res.Value, exchange.TranslationOptions{TargetUnitMM: d.WorkingUnitMM()})
 	if err != nil {
 		return nil
 	}

--- a/model/exchange/dispatch.go
+++ b/model/exchange/dispatch.go
@@ -30,6 +30,9 @@ func Import(part *compdef.PartComponentDefinition, path string, format types.Exc
 	if format.IsSketch() {
 		return ImportResult{}, fmt.Errorf("import %q: %s is a sketch format and imports into a sketch on a chosen work plane; use ImportDWGFile/ImportDXFFile", path, format)
 	}
+	if format.IsPointCloud() {
+		return ImportResult{}, fmt.Errorf("import %q: %s is a scan format and attaches a point cloud, not bodies; use ImportPointCloud (pointClouds.attach)", path, format)
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return ImportResult{}, fmt.Errorf("import: read %q: %w", path, err)
@@ -108,7 +111,10 @@ func workingUnitMM(part *compdef.PartComponentDefinition) float64 {
 
 // FormatFromPath infers the exchange format from a file's extension (case-insensitive), so the
 // File ▸ Import/Export menu can route by what the user typed. The bool is false for an unknown
-// extension.
+// extension. The point-cloud scan formats resolve here too (#1646): a .ply ALWAYS resolves to
+// FormatPLY — a point-cloud format, never a mesh (the documented rule, see api/types FormatPLY) —
+// and the ASCII scan family (.xyz/.pts/.asc/.txt) stays unrouted until api/types grows a
+// constant for it (it is dispatched by pointcloud.IsScanFile instead).
 func FormatFromPath(path string) (types.ExchangeFormat, bool) {
 	switch strings.ToLower(filepath.Ext(path)) {
 	case ".stl":
@@ -125,6 +131,12 @@ func FormatFromPath(path string) (types.ExchangeFormat, bool) {
 		return types.FormatDXF, true
 	case ".pdf":
 		return types.FormatPDF, true
+	case ".ply":
+		return types.FormatPLY, true
+	case ".e57":
+		return types.FormatE57, true
+	case ".las":
+		return types.FormatLAS, true
 	default:
 		return "", false
 	}

--- a/model/exchange/dispatch.go
+++ b/model/exchange/dispatch.go
@@ -99,11 +99,11 @@ func exportUnits(part *compdef.PartComponentDefinition) exchange.TranslationOpti
 }
 
 // workingUnitMM is the millimetre size of one of the part's stored (working) length units —
-// the database-unit size the translators scale against (ADR-0042 Phase 2). It is the working
-// scale (centimetres per working unit) times the centimetre's millimetre size, so a cm
-// document (working scale 1) yields the historical 10 mm and is unchanged.
+// the database-unit size the translators scale against (ADR-0042 Phase 2). The computation
+// lives on the part (WorkingUnitMM) so the point-cloud attach and persistence paths share it
+// (#1636); a cm document (working scale 1) yields the historical 10 mm and is unchanged.
 func workingUnitMM(part *compdef.PartComponentDefinition) float64 {
-	return part.Units().WorkingScale() * exchange.DBUnitMM
+	return part.WorkingUnitMM()
 }
 
 // FormatFromPath infers the exchange format from a file's extension (case-insensitive), so the

--- a/model/exchange/dispatch.go
+++ b/model/exchange/dispatch.go
@@ -116,28 +116,23 @@ func workingUnitMM(part *compdef.PartComponentDefinition) float64 {
 // and the ASCII scan family (.xyz/.pts/.asc/.txt) stays unrouted until api/types grows a
 // constant for it (it is dispatched by pointcloud.IsScanFile instead).
 func FormatFromPath(path string) (types.ExchangeFormat, bool) {
-	switch strings.ToLower(filepath.Ext(path)) {
-	case ".stl":
-		return types.FormatSTL, true
-	case ".obj":
-		return types.FormatOBJ, true
-	case ".3mf":
-		return types.Format3MF, true
-	case ".step", ".stp":
-		return types.FormatSTEP, true
-	case ".dwg":
-		return types.FormatDWG, true
-	case ".dxf":
-		return types.FormatDXF, true
-	case ".pdf":
-		return types.FormatPDF, true
-	case ".ply":
-		return types.FormatPLY, true
-	case ".e57":
-		return types.FormatE57, true
-	case ".las":
-		return types.FormatLAS, true
-	default:
-		return "", false
-	}
+	f, ok := formatByExt[strings.ToLower(filepath.Ext(path))]
+	return f, ok
+}
+
+// formatByExt maps a lower-cased file extension to its exchange format. A .ply ALWAYS
+// resolves to FormatPLY — a point-cloud format, never a mesh (the documented rule, see
+// api/types FormatPLY, #1646).
+var formatByExt = map[string]types.ExchangeFormat{
+	".stl":  types.FormatSTL,
+	".obj":  types.FormatOBJ,
+	".3mf":  types.Format3MF,
+	".step": types.FormatSTEP,
+	".stp":  types.FormatSTEP,
+	".dwg":  types.FormatDWG,
+	".dxf":  types.FormatDXF,
+	".pdf":  types.FormatPDF,
+	".ply":  types.FormatPLY,
+	".e57":  types.FormatE57,
+	".las":  types.FormatLAS,
 }

--- a/model/exchange/pointcloud_import.go
+++ b/model/exchange/pointcloud_import.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package exchange
+
+import (
+	"fmt"
+	"os"
+
+	"oblikovati.org/kernel/exchange"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/pointcloud"
+)
+
+// Point-cloud import vertical (M40 audit S12, #1646): scan files flow through the same
+// model/exchange seam as every other format — file units scale into the document working unit
+// (#1636), record-level defects warn-and-continue like the DWG decoder, and the scan bytes are
+// embedded in the document resource table (ADR-0031) so the .obk stays self-contained. The
+// session attach path (app.AttachPointCloud) and the pointClouds.attach wire method both land
+// here, so cross-cutting exchange improvements reach clouds by construction.
+
+// PointCloudImportResult reports what a scan import produced: the decoded point count and any
+// non-fatal per-record warnings (the same slot the drawing importers fill).
+type PointCloudImportResult struct {
+	PointCount int
+	Warnings   []string
+}
+
+// ImportPointCloud reads the scan file at path, embeds its bytes as a document resource, decodes
+// its points into the part's working unit, and attaches the cloud under name (a unique name is
+// minted when name is empty). Malformed records are skipped with a warning naming the record;
+// only a scan with zero decodable points errors.
+//
+// Example:
+//
+//	pc, res, err := exchange.ImportPointCloud(part, "", "survey.las")
+func ImportPointCloud(part *compdef.PartComponentDefinition, name, path string) (*pointcloud.PointCloud, PointCloudImportResult, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, PointCloudImportResult{}, fmt.Errorf("import scan: read %q: %w", path, err)
+	}
+	points, warns, err := pointcloud.ReadScan(path, data, exchange.TranslationOptions{TargetUnitMM: workingUnitMM(part)})
+	if err != nil {
+		return nil, PointCloudImportResult{}, err
+	}
+	if name == "" {
+		name = part.PointClouds().UniqueName("Cloud")
+	}
+	rid := part.AddResource(doc.Resource{Type: "PointCloudScan", Encoding: doc.EncodingUTF8, Value: data, Origin: path})
+	pc, err := part.PointClouds().Add(name, path, rid, points)
+	if err != nil {
+		return nil, PointCloudImportResult{}, err
+	}
+	return pc, PointCloudImportResult{PointCount: len(points), Warnings: warns}, nil
+}

--- a/model/exchange/pointcloud_import_test.go
+++ b/model/exchange/pointcloud_import_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package exchange
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/pointcloud"
+)
+
+// Point-cloud dispatch integration tests (M40 audit S12, #1646): scan formats route through the
+// same model/exchange vertical as every other import — FormatFromPath recognises them, the
+// body dispatch redirects them with guidance, and record-level defects warn-and-continue like
+// the DWG decoder instead of sinking the whole file.
+
+// TestFormatFromPathRoutesPointCloudFormats: the scanner formats resolve to their api/types
+// constants (case-insensitively), classified as point-cloud imports.
+func TestFormatFromPathRoutesPointCloudFormats(t *testing.T) {
+	for path, want := range map[string]types.ExchangeFormat{
+		"scan.ply": types.FormatPLY, "survey.E57": types.FormatE57, "lidar.las": types.FormatLAS,
+	} {
+		got, ok := FormatFromPath(path)
+		if !ok || got != want {
+			t.Errorf("FormatFromPath(%q) = (%q, %v), want (%q, true)", path, got, ok, want)
+		}
+		if !got.IsPointCloud() {
+			t.Errorf("FormatFromPath(%q) = %q, which is not IsPointCloud", path, got)
+		}
+	}
+}
+
+// asciiScanExtensions are the registered scan extensions that CANNOT yet appear in
+// FormatFromPath: the ASCII XYZ/PTS family has no types.ExchangeFormat constant in api/types
+// (an Apache-2.0 sibling-repo addition, #1646); .txt additionally is far too generic to claim
+// in a format-from-extension dispatch. Keep in sync with the api/types exchange formats.
+var asciiScanExtensions = map[string]bool{".xyz": true, ".pts": true, ".asc": true, ".txt": true}
+
+// TestEveryScanExtensionIsRouted is registry-driven (#1646): every extension a registered
+// PointReader handles must either resolve through FormatFromPath as a point-cloud format or be
+// on the documented ASCII allow-list above — so a new reader cannot ship unrouted.
+func TestEveryScanExtensionIsRouted(t *testing.T) {
+	for _, ext := range pointcloud.ScanExtensions() {
+		if asciiScanExtensions[ext] {
+			continue
+		}
+		format, ok := FormatFromPath("scan" + ext)
+		if !ok {
+			t.Errorf("registered scan extension %q is not routed by FormatFromPath; add it or extend the documented allow-list", ext)
+			continue
+		}
+		if !format.IsPointCloud() {
+			t.Errorf("FormatFromPath(%q) = %q, want a point-cloud format", ext, format)
+		}
+	}
+}
+
+// TestImportRejectsPointCloudFormatWithGuidance: the body-import dispatch names the point-cloud
+// attach path instead of failing obscurely, mirroring the sketch-format guard.
+func TestImportRejectsPointCloudFormatWithGuidance(t *testing.T) {
+	part := compdef.NewPartComponentDefinition()
+	_, err := Import(part, "survey.las", types.FormatLAS)
+	if err == nil || !strings.Contains(err.Error(), "point cloud") {
+		t.Fatalf("Import(las) error = %v, want a point-cloud-attach redirect", err)
+	}
+}
+
+// TestImportPointCloudWarnsAndContinues: one malformed record produces one warning naming the
+// line and value, the good points still import, and the scan bytes are embedded (#1646).
+func TestImportPointCloudWarnsAndContinues(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "scan.xyz")
+	if err := os.WriteFile(path, []byte("0 0 0\n10 zero 0\n10 0 0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	part := compdef.NewPartComponentDefinition()
+	pc, res, err := ImportPointCloud(part, "Scan", path)
+	if err != nil {
+		t.Fatalf("ImportPointCloud: %v", err)
+	}
+	if pc.TotalPointCount() != 2 || res.PointCount != 2 {
+		t.Errorf("imported %d/%d points, want 2 (malformed record skipped)", pc.TotalPointCount(), res.PointCount)
+	}
+	if len(res.Warnings) != 1 || !strings.Contains(res.Warnings[0], "line 2") || !strings.Contains(res.Warnings[0], "10 zero 0") {
+		t.Errorf("Warnings = %v, want one naming line 2 and its content", res.Warnings)
+	}
+	if pc.ResourceID() == "" {
+		t.Error("scan bytes should be embedded as a document resource (ADR-0031)")
+	}
+}
+
+// TestImportPointCloudFailsWhenNothingDecodes: a scan with zero decodable records is an error
+// naming the offending input, not an empty cloud.
+func TestImportPointCloudFailsWhenNothingDecodes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "scan.xyz")
+	if err := os.WriteFile(path, []byte("not a point\nalso bad\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	part := compdef.NewPartComponentDefinition()
+	if _, _, err := ImportPointCloud(part, "Scan", path); err == nil || !strings.Contains(err.Error(), "not a point") {
+		t.Fatalf("ImportPointCloud of an undecodable scan = %v, want an error naming the bad record", err)
+	}
+}
+
+// TestPLYAlwaysRoutesToPointCloud pins the documented .ply rule (#1646): PLY is a point-cloud
+// format by contract (api/types FormatPLY), never a mesh — the same answer from every entry
+// point (FormatFromPath, the scan-file predicate, and the mesh translator's rejection).
+func TestPLYAlwaysRoutesToPointCloud(t *testing.T) {
+	format, ok := FormatFromPath("scan.ply")
+	if !ok || !format.IsPointCloud() || format.IsMesh() {
+		t.Errorf("FormatFromPath(.ply) = (%q, %v), want the point-cloud PLY format", format, ok)
+	}
+	if !pointcloud.IsScanFile("scan.ply") {
+		t.Error("IsScanFile(.ply) = false, want true (PLY is scan data)")
+	}
+	if (MeshExchange{}).CanImport(types.FormatPLY) {
+		t.Error("MeshExchange.CanImport(ply) = true, want false — .ply never imports as a mesh")
+	}
+}

--- a/model/pointcloud/collection_test.go
+++ b/model/pointcloud/collection_test.go
@@ -3,6 +3,7 @@
 package pointcloud
 
 import (
+	"oblikovati.org/kernel/exchange"
 	"testing"
 
 	"oblikovati.org/math"
@@ -104,11 +105,11 @@ func TestFromModelSpaceDegenerate(t *testing.T) {
 
 // TestReadScanDispatch: ReadScan routes by extension and errors on an unknown one.
 func TestReadScanDispatch(t *testing.T) {
-	pts, err := ReadScan("room.PTS", []byte("1 2 3\n"))
+	pts, err := ReadScan("room.PTS", []byte("1 2 3\n"), exchange.TranslationOptions{})
 	if err != nil || len(pts) != 1 {
 		t.Fatalf("ReadScan(.PTS) = %v points, err %v", len(pts), err)
 	}
-	if _, err := ReadScan("room.bin", []byte("binary")); err == nil {
+	if _, err := ReadScan("room.bin", []byte("binary"), exchange.TranslationOptions{}); err == nil {
 		t.Error("ReadScan of an unregistered extension should fail")
 	}
 }

--- a/model/pointcloud/collection_test.go
+++ b/model/pointcloud/collection_test.go
@@ -105,11 +105,11 @@ func TestFromModelSpaceDegenerate(t *testing.T) {
 
 // TestReadScanDispatch: ReadScan routes by extension and errors on an unknown one.
 func TestReadScanDispatch(t *testing.T) {
-	pts, err := ReadScan("room.PTS", []byte("1 2 3\n"), exchange.TranslationOptions{})
+	pts, _, err := ReadScan("room.PTS", []byte("1 2 3\n"), exchange.TranslationOptions{})
 	if err != nil || len(pts) != 1 {
 		t.Fatalf("ReadScan(.PTS) = %v points, err %v", len(pts), err)
 	}
-	if _, err := ReadScan("room.bin", []byte("binary"), exchange.TranslationOptions{}); err == nil {
+	if _, _, err := ReadScan("room.bin", []byte("binary"), exchange.TranslationOptions{}); err == nil {
 		t.Error("ReadScan of an unregistered extension should fail")
 	}
 }

--- a/model/pointcloud/collection_test.go
+++ b/model/pointcloud/collection_test.go
@@ -3,8 +3,9 @@
 package pointcloud
 
 import (
-	"oblikovati.org/kernel/exchange"
 	"testing"
+
+	"oblikovati.org/kernel/exchange"
 
 	"oblikovati.org/math"
 )

--- a/model/pointcloud/e57.go
+++ b/model/pointcloud/e57.go
@@ -18,6 +18,10 @@ func NewE57Reader() PointReader { return e57Reader{} }
 
 func (e57Reader) Extensions() []string { return []string{".e57"} }
 
+// FileUnitMM: E57 cartesian coordinates are metres by the ASTM E2807 spec, so one file unit is
+// 1000 mm (#1636).
+func (e57Reader) FileUnitMM() float64 { return 1000 }
+
 // Read decodes the E57's scan points into cloud-local points (intensity/colour are ignored).
 func (e57Reader) Read(data []byte) ([]math.Point3, error) {
 	doc, err := e57fmt.Parse(data)

--- a/model/pointcloud/e57.go
+++ b/model/pointcloud/e57.go
@@ -23,10 +23,13 @@ func (e57Reader) Extensions() []string { return []string{".e57"} }
 func (e57Reader) FileUnitMM() float64 { return 1000 }
 
 // Read decodes the E57's scan points into cloud-local points (intensity/colour are ignored).
-func (e57Reader) Read(data []byte) ([]math.Point3, error) {
+// E57 points live in a checksummed bit-packed container, so a fault is structural: no
+// per-record warnings.
+func (e57Reader) Read(data []byte) ([]math.Point3, []string, error) {
 	doc, err := e57fmt.Parse(data)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return doc.Vertices()
+	pts, err := doc.Vertices()
+	return pts, nil, err
 }

--- a/model/pointcloud/e57_test.go
+++ b/model/pointcloud/e57_test.go
@@ -21,7 +21,7 @@ func TestE57ReaderExtensions(t *testing.T) {
 
 func TestReadScanDispatchesE57Error(t *testing.T) {
 	// A registered .e57 reader must be reached (not the "no reader" error) and reject non-E57 bytes.
-	_, err := ReadScan("scan.e57", []byte("this is not an E57 file"), exchange.TranslationOptions{})
+	_, _, err := ReadScan("scan.e57", []byte("this is not an E57 file"), exchange.TranslationOptions{})
 	if err == nil {
 		t.Fatal("want a decode error for non-E57 bytes routed to the e57 reader")
 	}

--- a/model/pointcloud/e57_test.go
+++ b/model/pointcloud/e57_test.go
@@ -2,7 +2,11 @@
 
 package pointcloud
 
-import "testing"
+import (
+	"testing"
+
+	"oblikovati.org/kernel/exchange"
+)
 
 // The E57 decode itself is covered in kernel/exchange/e57fmt; here we cover the model-layer
 // reader's wiring: its extension, that ReadScan dispatches .e57 to it, and that malformed bytes
@@ -17,7 +21,7 @@ func TestE57ReaderExtensions(t *testing.T) {
 
 func TestReadScanDispatchesE57Error(t *testing.T) {
 	// A registered .e57 reader must be reached (not the "no reader" error) and reject non-E57 bytes.
-	_, err := ReadScan("scan.e57", []byte("this is not an E57 file"))
+	_, err := ReadScan("scan.e57", []byte("this is not an E57 file"), exchange.TranslationOptions{})
 	if err == nil {
 		t.Fatal("want a decode error for non-E57 bytes routed to the e57 reader")
 	}

--- a/model/pointcloud/las.go
+++ b/model/pointcloud/las.go
@@ -23,10 +23,12 @@ func (lasReader) Extensions() []string { return []string{".las"} }
 func (lasReader) FileUnitMM() float64 { return 1000 }
 
 // Read decodes the LAS point records into cloud-local points (intensity/returns are ignored).
-func (lasReader) Read(data []byte) ([]math.Point3, error) {
+// LAS records are fixed-length, so a structural fault is all-or-nothing: no per-record warnings.
+func (lasReader) Read(data []byte) ([]math.Point3, []string, error) {
 	doc, err := lasfmt.Parse(data)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return doc.Vertices()
+	pts, err := doc.Vertices()
+	return pts, nil, err
 }

--- a/model/pointcloud/las.go
+++ b/model/pointcloud/las.go
@@ -18,6 +18,10 @@ func NewLASReader() PointReader { return lasReader{} }
 
 func (lasReader) Extensions() []string { return []string{".las"} }
 
+// FileUnitMM: LAS real coordinates (stored integers × header scale + offset, applied by lasfmt)
+// are metres by ASPRS convention, so one file unit is 1000 mm (#1636).
+func (lasReader) FileUnitMM() float64 { return 1000 }
+
 // Read decodes the LAS point records into cloud-local points (intensity/returns are ignored).
 func (lasReader) Read(data []byte) ([]math.Point3, error) {
 	doc, err := lasfmt.Parse(data)

--- a/model/pointcloud/las_test.go
+++ b/model/pointcloud/las_test.go
@@ -2,7 +2,11 @@
 
 package pointcloud
 
-import "testing"
+import (
+	"testing"
+
+	"oblikovati.org/kernel/exchange"
+)
 
 // The LAS decode itself is covered in kernel/exchange/lasfmt; here we cover the model-layer
 // reader's wiring: its extension, that ReadScan dispatches .las to it, and that malformed bytes
@@ -16,7 +20,7 @@ func TestLASReaderExtensions(t *testing.T) {
 }
 
 func TestReadScanDispatchesLASError(t *testing.T) {
-	_, err := ReadScan("survey.las", []byte("this is not a LAS file"))
+	_, err := ReadScan("survey.las", []byte("this is not a LAS file"), exchange.TranslationOptions{})
 	if err == nil {
 		t.Fatal("want a decode error for non-LAS bytes routed to the las reader")
 	}

--- a/model/pointcloud/las_test.go
+++ b/model/pointcloud/las_test.go
@@ -20,7 +20,7 @@ func TestLASReaderExtensions(t *testing.T) {
 }
 
 func TestReadScanDispatchesLASError(t *testing.T) {
-	_, err := ReadScan("survey.las", []byte("this is not a LAS file"), exchange.TranslationOptions{})
+	_, _, err := ReadScan("survey.las", []byte("this is not a LAS file"), exchange.TranslationOptions{})
 	if err == nil {
 		t.Fatal("want a decode error for non-LAS bytes routed to the las reader")
 	}

--- a/model/pointcloud/ply.go
+++ b/model/pointcloud/ply.go
@@ -18,6 +18,10 @@ func NewPLYReader() PointReader { return plyReader{} }
 
 func (plyReader) Extensions() []string { return []string{".ply"} }
 
+// FileUnitMM: PLY carries no unit, so it follows the same declared millimetre convention as the
+// unitless mesh formats (STL/OBJ) — the .ply mesh/cloud symmetry test pins this (#1636).
+func (plyReader) FileUnitMM() float64 { return 1 }
+
 // Read decodes the PLY's vertex positions into cloud-local points (faces are ignored).
 func (plyReader) Read(data []byte) ([]math.Point3, error) {
 	doc, err := plyfmt.Parse(data)

--- a/model/pointcloud/ply.go
+++ b/model/pointcloud/ply.go
@@ -23,10 +23,12 @@ func (plyReader) Extensions() []string { return []string{".ply"} }
 func (plyReader) FileUnitMM() float64 { return 1 }
 
 // Read decodes the PLY's vertex positions into cloud-local points (faces are ignored).
-func (plyReader) Read(data []byte) ([]math.Point3, error) {
+// The vertex list layout comes from the header, so a fault is structural: no per-record warnings.
+func (plyReader) Read(data []byte) ([]math.Point3, []string, error) {
 	doc, err := plyfmt.Parse(data)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return doc.Vertices()
+	pts, err := doc.Vertices()
+	return pts, nil, err
 }

--- a/model/pointcloud/ply_test.go
+++ b/model/pointcloud/ply_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"math"
+	"oblikovati.org/kernel/exchange"
 	"testing"
 )
 
@@ -17,7 +18,7 @@ func TestPLYASCII(t *testing.T) {
 		"element face 1\nproperty list uchar int vertex_indices\n" +
 		"end_header\n" +
 		"1 2 3 255\n4 5 6 128\n3 0 1 2\n"
-	pts, err := ReadScan("m.ply", []byte(src))
+	pts, err := ReadScan("m.ply", []byte(src), exchange.TranslationOptions{})
 	if err != nil {
 		t.Fatalf("Read ascii PLY: %v", err)
 	}
@@ -44,7 +45,7 @@ func TestPLYBinaryLittleEndian(t *testing.T) {
 		"element vertex 2\nproperty float x\nproperty float y\nproperty float z\nproperty uchar flag\n"+
 		"end_header\n"), body.Bytes()...)
 
-	pts, err := ReadScan("m.ply", src)
+	pts, err := ReadScan("m.ply", src, exchange.TranslationOptions{})
 	if err != nil {
 		t.Fatalf("Read binary PLY: %v", err)
 	}
@@ -62,7 +63,7 @@ func TestPLYBinaryDoublePrecision(t *testing.T) {
 	src := append([]byte("ply\nformat binary_little_endian 1.0\n"+
 		"element vertex 1\nproperty double x\nproperty double y\nproperty double z\n"+
 		"end_header\n"), body.Bytes()...)
-	pts, err := ReadScan("m.ply", src)
+	pts, err := ReadScan("m.ply", src, exchange.TranslationOptions{})
 	if err != nil || len(pts) != 1 || pts[0].Y != 2.5 {
 		t.Fatalf("double PLY = %+v, err %v; want (1.5,2.5,3.5)", pts, err)
 	}

--- a/model/pointcloud/ply_test.go
+++ b/model/pointcloud/ply_test.go
@@ -6,8 +6,9 @@ import (
 	"bytes"
 	"encoding/binary"
 	"math"
-	"oblikovati.org/kernel/exchange"
 	"testing"
+
+	"oblikovati.org/kernel/exchange"
 )
 
 // TestPLYASCII: an ASCII PLY's vertex positions decode, ignoring extra per-vertex columns and the

--- a/model/pointcloud/ply_test.go
+++ b/model/pointcloud/ply_test.go
@@ -18,7 +18,7 @@ func TestPLYASCII(t *testing.T) {
 		"element face 1\nproperty list uchar int vertex_indices\n" +
 		"end_header\n" +
 		"1 2 3 255\n4 5 6 128\n3 0 1 2\n"
-	pts, err := ReadScan("m.ply", []byte(src), exchange.TranslationOptions{})
+	pts, _, err := ReadScan("m.ply", []byte(src), exchange.TranslationOptions{})
 	if err != nil {
 		t.Fatalf("Read ascii PLY: %v", err)
 	}
@@ -45,7 +45,7 @@ func TestPLYBinaryLittleEndian(t *testing.T) {
 		"element vertex 2\nproperty float x\nproperty float y\nproperty float z\nproperty uchar flag\n"+
 		"end_header\n"), body.Bytes()...)
 
-	pts, err := ReadScan("m.ply", src, exchange.TranslationOptions{})
+	pts, _, err := ReadScan("m.ply", src, exchange.TranslationOptions{})
 	if err != nil {
 		t.Fatalf("Read binary PLY: %v", err)
 	}
@@ -63,7 +63,7 @@ func TestPLYBinaryDoublePrecision(t *testing.T) {
 	src := append([]byte("ply\nformat binary_little_endian 1.0\n"+
 		"element vertex 1\nproperty double x\nproperty double y\nproperty double z\n"+
 		"end_header\n"), body.Bytes()...)
-	pts, err := ReadScan("m.ply", src, exchange.TranslationOptions{})
+	pts, _, err := ReadScan("m.ply", src, exchange.TranslationOptions{})
 	if err != nil || len(pts) != 1 || pts[0].Y != 2.5 {
 		t.Fatalf("double PLY = %+v, err %v; want (1.5,2.5,3.5)", pts, err)
 	}
@@ -71,15 +71,15 @@ func TestPLYBinaryDoublePrecision(t *testing.T) {
 
 // TestPLYErrors: a non-PLY blob, a missing vertex element, and missing x/y/z are rejected.
 func TestPLYErrors(t *testing.T) {
-	if _, err := (plyReader{}).Read([]byte("not a ply")); err == nil {
+	if _, _, err := (plyReader{}).Read([]byte("not a ply")); err == nil {
 		t.Error("a non-PLY blob should fail")
 	}
 	noVtx := "ply\nformat ascii 1.0\nelement face 0\nend_header\n"
-	if _, err := (plyReader{}).Read([]byte(noVtx)); err == nil {
+	if _, _, err := (plyReader{}).Read([]byte(noVtx)); err == nil {
 		t.Error("a PLY with no vertex element should fail")
 	}
 	noXYZ := "ply\nformat ascii 1.0\nelement vertex 1\nproperty float u\nproperty float v\nend_header\n0 0\n"
-	if _, err := (plyReader{}).Read([]byte(noXYZ)); err == nil {
+	if _, _, err := (plyReader{}).Read([]byte(noXYZ)); err == nil {
 		t.Error("a vertex without x/y/z should fail")
 	}
 }

--- a/model/pointcloud/pointcloud_test.go
+++ b/model/pointcloud/pointcloud_test.go
@@ -4,6 +4,7 @@ package pointcloud
 
 import (
 	"math"
+	"strings"
 	"testing"
 
 	omath "oblikovati.org/math"
@@ -13,7 +14,7 @@ import (
 // comment, and extra-column lines, and skips a leading PTS count header.
 func TestASCIIReaderParsesXYZAndSkipsNoise(t *testing.T) {
 	src := "3\n# a comment\n\n1 2 3\n4.5 6 7 128 255 0 0\n// trailing comment\n-1 -2 -3\n"
-	pts, err := NewASCIIReader().Read([]byte(src))
+	pts, _, err := NewASCIIReader().Read([]byte(src))
 	if err != nil {
 		t.Fatalf("Read: %v", err)
 	}
@@ -25,11 +26,19 @@ func TestASCIIReaderParsesXYZAndSkipsNoise(t *testing.T) {
 	}
 }
 
-// TestASCIIReaderRejectsMalformedLine: a non-coordinate line that is not a leading count header
-// errors, citing the line.
-func TestASCIIReaderRejectsMalformedLine(t *testing.T) {
-	if _, err := NewASCIIReader().Read([]byte("1 2 3\nx y z\n")); err == nil {
-		t.Error("expected an error on a non-numeric coordinate line")
+// TestASCIIReaderWarnsOnMalformedLine: a non-coordinate line that is not a leading count header
+// is skipped with a warning citing the line — the DWG decoder's warn-and-continue policy
+// (#1646) — while a scan where NOTHING decodes still errors, naming the bad record.
+func TestASCIIReaderWarnsOnMalformedLine(t *testing.T) {
+	pts, warns, err := NewASCIIReader().Read([]byte("1 2 3\nx y z\n"))
+	if err != nil || len(pts) != 1 {
+		t.Fatalf("Read = %d points, err %v; want the good point kept", len(pts), err)
+	}
+	if len(warns) != 1 || !strings.Contains(warns[0], "line 2") || !strings.Contains(warns[0], "x y z") {
+		t.Errorf("warns = %v, want one naming line 2 and its content", warns)
+	}
+	if _, _, err := NewASCIIReader().Read([]byte("x y z\n")); err == nil {
+		t.Error("a scan with zero decodable points should error")
 	}
 }
 

--- a/model/pointcloud/reader.go
+++ b/model/pointcloud/reader.go
@@ -26,13 +26,15 @@ var registeredReaders = []PointReader{NewASCIIReader(), NewPLYReader(), NewE57Re
 // ReadScan decodes a scan file's bytes into cloud-local points, choosing the reader by the
 // filename's extension and scaling the file's unit into the document's working (database) unit —
 // the same TranslationOptions seam the mesh importers use, so a metric LAS/E57 survey lands at
-// true physical size in a cm or inch document (#1636). It errors when no registered reader
-// handles the extension, naming it.
+// true physical size in a cm or inch document (#1636). Malformed records are skipped with a
+// per-record warning like the DWG decoder (#1646); a structural failure (or zero decodable
+// points) is an error naming the offending input. An extension no registered reader handles
+// errors, naming it.
 //
 // Example:
 //
-//	pts, err := pointcloud.ReadScan("survey.las", data, exchange.TranslationOptions{TargetUnitMM: 10})
-func ReadScan(filename string, data []byte, opts exchange.TranslationOptions) ([]math.Point3, error) {
+//	pts, warns, err := pointcloud.ReadScan("survey.las", data, exchange.TranslationOptions{TargetUnitMM: 10})
+func ReadScan(filename string, data []byte, opts exchange.TranslationOptions) ([]math.Point3, []string, error) {
 	ext := strings.ToLower(filepath.Ext(filename))
 	for _, r := range registeredReaders {
 		for _, e := range r.Extensions() {
@@ -41,24 +43,24 @@ func ReadScan(filename string, data []byte, opts exchange.TranslationOptions) ([
 			}
 		}
 	}
-	return nil, fmt.Errorf("pointcloud: no reader for scan extension %q (file %q)", ext, filename)
+	return nil, nil, fmt.Errorf("pointcloud: no reader for scan extension %q (file %q)", ext, filename)
 }
 
 // readScaled decodes with r and applies the single file→database unit factor to every point —
 // the one shared scaling seam for all registered readers (#1636), mirroring meshio's scaleRaw.
-func readScaled(r PointReader, data []byte, opts exchange.TranslationOptions) ([]math.Point3, error) {
-	points, err := r.Read(data)
+func readScaled(r PointReader, data []byte, opts exchange.TranslationOptions) ([]math.Point3, []string, error) {
+	points, warns, err := r.Read(data)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	f := math.Scalar(opts.ImportScale(r.FileUnitMM()))
 	if f == 1 {
-		return points, nil
+		return points, warns, nil
 	}
 	for i, p := range points {
 		points[i] = math.P3(p.X*f, p.Y*f, p.Z*f)
 	}
-	return points, nil
+	return points, warns, nil
 }
 
 // IsScanFile reports whether a path's extension is a 3D-scan point-cloud format handled by a
@@ -94,9 +96,10 @@ func ScanExtensions() []string {
 type PointReader interface {
 	// Extensions returns the lowercase file extensions (with leading dot) this reader handles.
 	Extensions() []string
-	// Read parses scan bytes into cloud-local points, erroring with the offending input.
-	// Coordinates are returned in the FILE's unit; ReadScan applies the unit scale.
-	Read(data []byte) ([]math.Point3, error)
+	// Read parses scan bytes into cloud-local points, erroring with the offending input on a
+	// structural failure and warning per skipped record (#1646). Coordinates are returned in
+	// the FILE's unit; ReadScan applies the unit scale.
+	Read(data []byte) ([]math.Point3, []string, error)
 	// FileUnitMM is the millimetre size of the format's length unit: E57 is metres by the ASTM
 	// E2807 spec, LAS metres by ASPRS convention, and the unitless formats (ASCII XYZ/PTS, PLY)
 	// follow the same declared millimetre convention as unitless meshes (STL/OBJ) (#1636).
@@ -118,33 +121,47 @@ func (asciiReader) Extensions() []string { return []string{".xyz", ".pts", ".asc
 func (asciiReader) FileUnitMM() float64 { return 1 }
 
 // Read parses each coordinate line into a point. A line with fewer than three numeric fields
-// that is the FIRST data line is treated as a PTS count header and skipped; any other malformed
-// line is an error citing the line number and content.
-func (asciiReader) Read(data []byte) ([]math.Point3, error) {
+// that is the FIRST data line is treated as a PTS count header and skipped. Any other malformed
+// line is SKIPPED with a warning citing the line number and content — the DWG decoder's
+// warn-and-continue policy (#1646), so one bad record never sinks a million good points; a scan
+// where nothing decodes errors instead.
+func (asciiReader) Read(data []byte) ([]math.Point3, []string, error) {
 	var points []math.Point3
+	var warns []string
 	sc := bufio.NewScanner(bytes.NewReader(data))
 	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024) // tolerate long lines
 	line := 0
 	for sc.Scan() {
 		line++
-		text := strings.TrimSpace(sc.Text())
-		if skippableLine(text) {
-			continue
+		if w := scanLine(sc.Text(), line, &points, len(warns)); w != "" {
+			warns = append(warns, w)
 		}
-		p, ok := parseXYZ(text)
-		if ok {
-			points = append(points, p)
-			continue
-		}
-		if len(points) == 0 && isCountHeader(text) {
-			continue // a PTS file's leading point-count line
-		}
-		return nil, fmt.Errorf("pointcloud: line %d is not \"x y z\": %q", line, text)
 	}
 	if err := sc.Err(); err != nil {
-		return nil, fmt.Errorf("pointcloud: reading scan: %w", err)
+		return nil, nil, fmt.Errorf("pointcloud: reading scan: %w", err)
 	}
-	return points, nil
+	if len(points) == 0 && len(warns) > 0 {
+		return nil, nil, fmt.Errorf("pointcloud: no decodable points; %s", warns[0])
+	}
+	return points, warns, nil
+}
+
+// scanLine parses one line into points, returning a warning for a skipped malformed record (""
+// when the line is fine). warnCount distinguishes a leading PTS count header (only valid before
+// any point or warning) from a malformed record.
+func scanLine(raw string, line int, points *[]math.Point3, warnCount int) string {
+	text := strings.TrimSpace(raw)
+	if skippableLine(text) {
+		return ""
+	}
+	if p, ok := parseXYZ(text); ok {
+		*points = append(*points, p)
+		return ""
+	}
+	if len(*points) == 0 && warnCount == 0 && isCountHeader(text) {
+		return "" // a PTS file's leading point-count line
+	}
+	return fmt.Sprintf("pointcloud: skipped line %d, not \"x y z\": %q", line, text)
 }
 
 // skippableLine reports whether a line carries no coordinate (blank or a comment).

--- a/model/pointcloud/reader.go
+++ b/model/pointcloud/reader.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 
+	"oblikovati.org/kernel/exchange"
 	"oblikovati.org/math"
 )
 
@@ -23,17 +24,41 @@ import (
 var registeredReaders = []PointReader{NewASCIIReader(), NewPLYReader(), NewE57Reader(), NewLASReader()}
 
 // ReadScan decodes a scan file's bytes into cloud-local points, choosing the reader by the
-// filename's extension. It errors when no registered reader handles the extension, naming it.
-func ReadScan(filename string, data []byte) ([]math.Point3, error) {
+// filename's extension and scaling the file's unit into the document's working (database) unit —
+// the same TranslationOptions seam the mesh importers use, so a metric LAS/E57 survey lands at
+// true physical size in a cm or inch document (#1636). It errors when no registered reader
+// handles the extension, naming it.
+//
+// Example:
+//
+//	pts, err := pointcloud.ReadScan("survey.las", data, exchange.TranslationOptions{TargetUnitMM: 10})
+func ReadScan(filename string, data []byte, opts exchange.TranslationOptions) ([]math.Point3, error) {
 	ext := strings.ToLower(filepath.Ext(filename))
 	for _, r := range registeredReaders {
 		for _, e := range r.Extensions() {
 			if e == ext {
-				return r.Read(data)
+				return readScaled(r, data, opts)
 			}
 		}
 	}
 	return nil, fmt.Errorf("pointcloud: no reader for scan extension %q (file %q)", ext, filename)
+}
+
+// readScaled decodes with r and applies the single file→database unit factor to every point —
+// the one shared scaling seam for all registered readers (#1636), mirroring meshio's scaleRaw.
+func readScaled(r PointReader, data []byte, opts exchange.TranslationOptions) ([]math.Point3, error) {
+	points, err := r.Read(data)
+	if err != nil {
+		return nil, err
+	}
+	f := math.Scalar(opts.ImportScale(r.FileUnitMM()))
+	if f == 1 {
+		return points, nil
+	}
+	for i, p := range points {
+		points[i] = math.P3(p.X*f, p.Y*f, p.Z*f)
+	}
+	return points, nil
 }
 
 // IsScanFile reports whether a path's extension is a 3D-scan point-cloud format handled by a
@@ -70,19 +95,27 @@ type PointReader interface {
 	// Extensions returns the lowercase file extensions (with leading dot) this reader handles.
 	Extensions() []string
 	// Read parses scan bytes into cloud-local points, erroring with the offending input.
+	// Coordinates are returned in the FILE's unit; ReadScan applies the unit scale.
 	Read(data []byte) ([]math.Point3, error)
+	// FileUnitMM is the millimetre size of the format's length unit: E57 is metres by the ASTM
+	// E2807 spec, LAS metres by ASPRS convention, and the unitless formats (ASCII XYZ/PTS, PLY)
+	// follow the same declared millimetre convention as unitless meshes (STL/OBJ) (#1636).
+	FileUnitMM() float64
 }
 
 // asciiReader parses the open ASCII point formats — XYZ and PTS — where each non-empty,
 // non-comment line is "x y z" optionally followed by intensity / r g b columns (ignored for
-// now). A lone leading integer (a PTS point-count header) is skipped. Coordinates are read in
-// the file's own units; the owning PointCloud's UnitsFactor/scale maps them to model space.
+// now). A lone leading integer (a PTS point-count header) is skipped. The formats carry no unit,
+// so they follow the millimetre convention (FileUnitMM = 1), like unitless meshes (#1636).
 type asciiReader struct{}
 
 // NewASCIIReader returns the clean-room reader for .xyz/.pts/.asc/.txt scan files.
 func NewASCIIReader() PointReader { return asciiReader{} }
 
 func (asciiReader) Extensions() []string { return []string{".xyz", ".pts", ".asc", ".txt"} }
+
+// FileUnitMM: ASCII scan formats are unitless — the declared millimetre convention applies.
+func (asciiReader) FileUnitMM() float64 { return 1 }
 
 // Read parses each coordinate line into a point. A line with fewer than three numeric fields
 // that is the FIRST data line is treated as a PTS count header and skipped; any other malformed

--- a/model/pointcloud/units_test.go
+++ b/model/pointcloud/units_test.go
@@ -76,7 +76,7 @@ func TestReadScanScalesLASIntoWorkingUnits(t *testing.T) {
 		{"cm document", cmDoc, 200},
 		{"inch document", inchDoc, 2000 / 25.4},
 	} {
-		pts, err := ReadScan("survey.las", data, tc.opts)
+		pts, _, err := ReadScan("survey.las", data, tc.opts)
 		if err != nil || len(pts) != 2 {
 			t.Fatalf("%s: ReadScan = %d points, err %v", tc.name, len(pts), err)
 		}
@@ -89,7 +89,7 @@ func TestReadScanScalesLASIntoWorkingUnits(t *testing.T) {
 // TestReadScanUnitlessMillimetreConvention pins the declared fallback for unitless scan formats:
 // like STL/OBJ meshes, an ASCII XYZ is read as millimetres, so 10 units become 1 cm.
 func TestReadScanUnitlessMillimetreConvention(t *testing.T) {
-	pts, err := ReadScan("scan.xyz", []byte("10 20 30\n"), cmDoc)
+	pts, _, err := ReadScan("scan.xyz", []byte("10 20 30\n"), cmDoc)
 	if err != nil || len(pts) != 1 {
 		t.Fatalf("ReadScan = %d points, err %v", len(pts), err)
 	}
@@ -110,7 +110,7 @@ func TestPLYCloudMatchesMeshScale(t *testing.T) {
 		t.Fatalf("meshio.ImportBody: %v", err)
 	}
 	ply := "ply\nformat ascii 1.0\nelement vertex 3\nproperty float x\nproperty float y\nproperty float z\nend_header\n0 0 0\n40 0 0\n0 40 0\n"
-	pts, err := ReadScan("scan.ply", []byte(ply), cmDoc)
+	pts, _, err := ReadScan("scan.ply", []byte(ply), cmDoc)
 	if err != nil || len(pts) != 3 {
 		t.Fatalf("ReadScan(.ply) = %d points, err %v", len(pts), err)
 	}

--- a/model/pointcloud/units_test.go
+++ b/model/pointcloud/units_test.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package pointcloud
+
+import (
+	"encoding/binary"
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/exchange"
+	"oblikovati.org/kernel/exchange/meshio"
+	"oblikovati.org/math"
+)
+
+// Point-cloud unit scaling tests (M40 audit S1, #1636): scan files scale from their file unit
+// into the document's working (database) unit exactly like the mesh importers do, so a metric
+// LAS survey attached to a cm or inch document lands at true physical size.
+
+// cmDoc is the standard centimetre document translation (1 working unit = 10 mm, ADR-0042).
+var cmDoc = exchange.TranslationOptions{TargetUnitMM: exchange.DBUnitMM}
+
+// inchDoc is an inch document translation (1 working unit = 25.4 mm).
+var inchDoc = exchange.TranslationOptions{TargetUnitMM: 25.4}
+
+func approxEq(a, b float64) bool { return stdmath.Abs(a-b) < 1e-9*(1+stdmath.Abs(b)) }
+
+// TestScanReaderFileUnits pins each registered reader's declared file unit: E57 is metres by the
+// ASTM E2807 spec, LAS is metres by ASPRS convention, and the unitless formats (ASCII XYZ/PTS,
+// PLY) follow the same millimetre convention as unitless meshes (STL/OBJ) so it cannot drift.
+func TestScanReaderFileUnits(t *testing.T) {
+	want := map[string]float64{".xyz": 1, ".pts": 1, ".asc": 1, ".txt": 1, ".ply": 1, ".e57": 1000, ".las": 1000}
+	for _, r := range registeredReaders {
+		for _, ext := range r.Extensions() {
+			if got := r.FileUnitMM(); got != want[ext] {
+				t.Errorf("reader for %s: FileUnitMM = %v, want %v", ext, got, want[ext])
+			}
+		}
+	}
+}
+
+// minimalLAS assembles a tiny valid uncompressed LAS 1.2 file (a named fake for the on-disk
+// format): the 227-byte public header plus format-0 point records with the given real-coordinate
+// points, stored as scaled integers (scale 0.001 m, zero offset).
+func minimalLAS(points [][3]float64) []byte {
+	const headerSize, recLen, scale = 227, 20, 0.001
+	hdr := make([]byte, headerSize)
+	copy(hdr, "LASF")
+	hdr[24], hdr[25] = 1, 2
+	binary.LittleEndian.PutUint16(hdr[94:], uint16(headerSize))
+	binary.LittleEndian.PutUint32(hdr[96:], uint32(headerSize))
+	binary.LittleEndian.PutUint16(hdr[105:], recLen)
+	binary.LittleEndian.PutUint32(hdr[107:], uint32(len(points)))
+	for i := 0; i < 3; i++ {
+		binary.LittleEndian.PutUint64(hdr[131+i*8:], stdmath.Float64bits(scale))
+	}
+	out := hdr
+	for _, p := range points {
+		rec := make([]byte, recLen)
+		for c := 0; c < 3; c++ {
+			binary.LittleEndian.PutUint32(rec[c*4:], uint32(int32(stdmath.Round(p[c]/scale))))
+		}
+		out = append(out, rec...)
+	}
+	return out
+}
+
+// TestReadScanScalesLASIntoWorkingUnits: a metric LAS (metres) lands at true physical scale in
+// both a centimetre and an inch document — a 2 m inter-point distance is 200 cm and 78.740… in.
+func TestReadScanScalesLASIntoWorkingUnits(t *testing.T) {
+	data := minimalLAS([][3]float64{{0, 0, 0}, {2, 0, 0}})
+	for _, tc := range []struct {
+		name string
+		opts exchange.TranslationOptions
+		want float64 // distance in working units
+	}{
+		{"cm document", cmDoc, 200},
+		{"inch document", inchDoc, 2000 / 25.4},
+	} {
+		pts, err := ReadScan("survey.las", data, tc.opts)
+		if err != nil || len(pts) != 2 {
+			t.Fatalf("%s: ReadScan = %d points, err %v", tc.name, len(pts), err)
+		}
+		if got := float64(pts[0].DistanceTo(pts[1])); !approxEq(got, tc.want) {
+			t.Errorf("%s: 2 m LAS distance = %v working units, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestReadScanUnitlessMillimetreConvention pins the declared fallback for unitless scan formats:
+// like STL/OBJ meshes, an ASCII XYZ is read as millimetres, so 10 units become 1 cm.
+func TestReadScanUnitlessMillimetreConvention(t *testing.T) {
+	pts, err := ReadScan("scan.xyz", []byte("10 20 30\n"), cmDoc)
+	if err != nil || len(pts) != 1 {
+		t.Fatalf("ReadScan = %d points, err %v", len(pts), err)
+	}
+	want := math.P3(1, 2, 3)
+	if !approxEq(float64(pts[0].X), float64(want.X)) || !approxEq(float64(pts[0].Y), float64(want.Y)) || !approxEq(float64(pts[0].Z), float64(want.Z)) {
+		t.Errorf("10 20 30 mm in a cm document = %v, want %v", pts[0], want)
+	}
+}
+
+// TestPLYCloudMatchesMeshScale: the .ply symmetry guard (#1636) — a PLY point imported as a cloud
+// gets exactly the coordinate scale a mesh import applies to the same unitless millimetre data,
+// verified end to end against a one-triangle STL welded through meshio.
+func TestPLYCloudMatchesMeshScale(t *testing.T) {
+	// One triangle with vertices (0,0,0) (40,0,0) (0,40,0), in file millimetres.
+	tris := [][3][3]float32{{{0, 0, 0}, {40, 0, 0}, {0, 40, 0}}}
+	body, _, err := meshio.ImportBody("stl", binarySTL(tris), "import:stl#0", 0, cmDoc)
+	if err != nil {
+		t.Fatalf("meshio.ImportBody: %v", err)
+	}
+	ply := "ply\nformat ascii 1.0\nelement vertex 3\nproperty float x\nproperty float y\nproperty float z\nend_header\n0 0 0\n40 0 0\n0 40 0\n"
+	pts, err := ReadScan("scan.ply", []byte(ply), cmDoc)
+	if err != nil || len(pts) != 3 {
+		t.Fatalf("ReadScan(.ply) = %d points, err %v", len(pts), err)
+	}
+	cloudBox := math.EmptyBox()
+	for _, p := range pts {
+		cloudBox = cloudBox.ExtendPoint(p)
+	}
+	meshBox := body.RangeBox()
+	if !approxEq(float64(cloudBox.Max.X), float64(meshBox.Max.X)) || !approxEq(float64(cloudBox.Max.Y), float64(meshBox.Max.Y)) {
+		t.Errorf("PLY cloud box %v != mesh box %v for identical source coordinates", cloudBox, meshBox)
+	}
+}
+
+// binarySTL encodes triangles as a minimal binary STL (80-byte header, count, 50-byte records).
+func binarySTL(tris [][3][3]float32) []byte {
+	out := make([]byte, 80, 84+50*len(tris))
+	out = binary.LittleEndian.AppendUint32(out, uint32(len(tris)))
+	for _, tri := range tris {
+		out = append(out, make([]byte, 12)...) // zero normal; readers recompute
+		for _, v := range tri {
+			for _, c := range v {
+				out = binary.LittleEndian.AppendUint32(out, stdmath.Float32bits(c))
+			}
+		}
+		out = append(out, 0, 0) // attribute byte count
+	}
+	return out
+}

--- a/persistence/pointcloud_roundtrip_test.go
+++ b/persistence/pointcloud_roundtrip_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"oblikovati.org/kernel/exchange"
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/contentset"
@@ -29,7 +30,7 @@ func TestPointCloudSurvivesStoreRoundTrip(t *testing.T) {
 
 	scan := []byte("0 0 0\n1 2 3\n4 5 6\n")
 	rid := def.AddResource(doc.Resource{Type: "PointCloudScan", Encoding: doc.EncodingUTF8, Value: scan, Origin: "room.xyz"})
-	points, err := pointcloud.ReadScan("room.xyz", scan)
+	points, _, err := pointcloud.ReadScan("room.xyz", scan, exchange.TranslationOptions{TargetUnitMM: def.WorkingUnitMM()})
 	if err != nil {
 		t.Fatalf("decode scan: %v", err)
 	}


### PR DESCRIPTION
Brings point-cloud import into the same exchange vertical the mesh/B-rep importers already use, and applies the document's working-unit scale on import.

- **S1 (#1636)** — scale imported point clouds into the document working unit (ADR-0042 Phase 2), sharing `WorkingUnitMM` with the persistence path so a cm document is unchanged (still 10 mm/unit) while other working scales convert correctly, matching meshio `ImportScale`.
- **S12 (#1646)** — integrate point clouds into `FormatFromPath`/exchange dispatch: `.ply` always resolves to `FormatPLY` (a point-cloud format, never a mesh — the documented rule), and the ASCII scan family stays routed via `pointcloud.IsScanFile`.

`FormatFromPath` is now an extension→format map (the former switch tripped funlen). `go build ./...`, `go test ./kernel/exchange/... ./model/exchange/... ./model/pointcloud/...`, and `golangci-lint` on the touched packages pass locally.

Closes #1636
Closes #1646

🤖 Generated with [Claude Code](https://claude.com/claude-code)