### PR TITLE
M40 S2: carry all 22 constraint kinds in sketch copy (or warn) instead of silently dropping six

### DIFF
--- a/addin/router/sketch_copy.go
+++ b/addin/router/sketch_copy.go
@@ -5,6 +5,7 @@ package router
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 
 	"oblikovati.org/addin/modelaccess"
 	"oblikovati.org/api/wire"
@@ -37,7 +38,13 @@ func sketchCopyTo(s *app.Session, raw json.RawMessage) (json.RawMessage, error) 
 	if err != nil {
 		return nil, err
 	}
-	created := target.CopyEntitiesWithConstraints(source, ents, offset)
+	created, warnings := target.CopyEntitiesWithConstraints(source, ents, offset)
+	// Constraint kinds that cannot travel with a copy (#1637) are logged rather than
+	// dropped silently; surfacing them in CopySketchResult needs a wire DTO field
+	// (api bump), tracked as the #1637 follow-up.
+	for _, w := range warnings {
+		slog.Warn("sketch.copyTo constraint skipped", "warning", w)
+	}
 	ids := make([]uint64, len(created))
 	for i, e := range created {
 		ids[i] = uint64(e.EntityID())

--- a/model/sketch/copy_constraints.go
+++ b/model/sketch/copy_constraints.go
@@ -9,7 +9,9 @@ import "oblikovati.org/math"
 // constraints and dimensions whose operands are *entirely* within the copied set, dropping
 // any that reference geometry left behind. CopyEntitiesWithConstraints adds that carry-over
 // on top of the geometry clone: every operand is remapped through the source→clone maps, and
-// a relation with any external operand is silently dropped.
+// a relation with any external operand is silently dropped. A kind that cannot travel at all
+// (a documented skip in copy_constraints_registry.go) is reported as a warning instead of
+// vanishing (#1637).
 
 // cloneMap resolves a source operand (a point or an entity) to its clone. Points are keyed
 // separately from entities because a constraint references the shared *Point inside a line or
@@ -60,86 +62,68 @@ func (m *cloneMap) ellipse(e *Ellipse) (*Ellipse, bool) {
 	return ne, ok
 }
 
+func (m *cloneMap) smoothCurve(c SmoothCurve) (SmoothCurve, bool) {
+	e, ok := m.entities[c]
+	if !ok {
+		return nil, false
+	}
+	nc, ok := e.(SmoothCurve)
+	return nc, ok
+}
+
 // CopyEntitiesWithConstraints clones a selection from source into this sketch (translated by
 // v) and carries over every geometric constraint and dimension whose operands lie entirely
 // within the copied set, remapping operands to the clones and dropping any relation with an
 // external operand (Inventor CopyEntitiesTo with constraint carry-over, #1083). A copied
 // driving dimension mints a fresh parameter in this sketch (DimensionConstraints.nextName),
-// so names never collide with the source's. Returns the created entity clones.
+// so names never collide with the source's. Returns the created entity clones plus one
+// warning per constraint that could not be copied *by kind* (a documented skip, #1637) —
+// silent drops are reserved for relations referencing geometry left behind.
 //
-// Example: target.CopyEntitiesWithConstraints(source, source.Entities(), math.V2(50, 0))
-// duplicates the whole source sketch 50 units to the right, fully constrained.
-func (target *Sketch) CopyEntitiesWithConstraints(source *Sketch, ents []Entity, v math.Vector2) []Entity {
+// Example: clones, warns := target.CopyEntitiesWithConstraints(source, source.Entities(),
+// math.V2(50, 0)) duplicates the whole source sketch 50 units to the right, fully
+// constrained, reporting any constraint that cannot travel.
+func (target *Sketch) CopyEntitiesWithConstraints(source *Sketch, ents []Entity, v math.Vector2) ([]Entity, []string) {
 	clones, pmap, emap := target.cloneEntitiesFull(ents, translation(v))
 	m := &cloneMap{points: pmap, entities: emap}
+	requested := requestedEntitySet(ents)
+	var warnings []string
 	for _, c := range source.geomCons.All() {
-		target.geomCons.carryFrom(c, m)
+		if _, skip := target.geomCons.carryFrom(c, m); skip != "" && allOperandsRequested(c, requested) {
+			warnings = append(warnings, skip)
+		}
 	}
 	for _, d := range source.dimCons.All() {
 		target.carryDimension(d, m)
 	}
-	return clones
+	return clones, warnings
 }
 
-// carryFrom re-creates one source geometric constraint on this (target) collection via the
-// clone map, returning whether it was carried. It is dropped when any operand lies outside
-// the copied set or the kind is not a carryable 2D constraint. The dispatch is split into the
-// point-anchored and line/curve-anchored kinds to keep each switch within the complexity bound.
-func (g *GeometricConstraints) carryFrom(c Constraint, m *cloneMap) bool {
-	if carried, matched := carryPointConstraint(g, c, m); matched {
-		return carried
+// requestedEntitySet indexes the entities the caller asked to copy, so a documented
+// skip can be reported only when its operands were actually part of the request.
+func requestedEntitySet(ents []Entity) map[Entity]bool {
+	out := make(map[Entity]bool, len(ents))
+	for _, e := range ents {
+		out[e] = true
 	}
-	return carryLineCurveConstraint(g, c, m)
+	return out
 }
 
-// carryPointConstraint handles the geometric constraints whose operands are points (some with a
-// line or curve anchor). matched reports whether c was one of these kinds, so carryFrom can fall
-// through to the line/curve kinds; carried reports whether it was actually re-created.
-func carryPointConstraint(g *GeometricConstraints, c Constraint, m *cloneMap) (carried, matched bool) {
-	switch v := c.(type) {
-	case *CoincidentConstraint:
-		return carryPoints(m, v.A, v.B, g.AddCoincident), true
-	case *HorizontalConstraint:
-		return carryPoints(m, v.A, v.B, g.AddHorizontal), true
-	case *VerticalConstraint:
-		return carryPoints(m, v.A, v.B, g.AddVertical), true
-	case *MidpointConstraint:
-		return carryPointLine(m, v.P, v.L, g.AddMidpoint), true
-	case *PointOnLineConstraint:
-		return carryPointLine(m, v.P, v.L, g.AddPointOnLine), true
-	case *PointOnCircleConstraint:
-		return carryPointCurve(m, v.P, v.C, g.AddPointOnCircle), true
-	case *SymmetryConstraint:
-		return carrySymmetry(m, v, g), true
-	case *FixConstraint:
-		return carryFix(m, v.P, g), true
+// allOperandsRequested reports whether every entity the constraint relates was part of
+// the requested copy. A skip about geometry left behind would be noise — it follows the
+// same silent rule as the external-operand drop (#1083); only a skip whose operands the
+// user did copy becomes a warning (#1637).
+func allOperandsRequested(c Constraint, requested map[Entity]bool) bool {
+	kc, ok := c.(KindedConstraint)
+	if !ok {
+		return true // no operand info: always surface the (programming-error) skip
 	}
-	return false, false
-}
-
-// carryLineCurveConstraint handles the geometric constraints whose operands are whole lines or
-// circular curves, returning whether the constraint was carried (false for any other kind).
-func carryLineCurveConstraint(g *GeometricConstraints, c Constraint, m *cloneMap) bool {
-	switch v := c.(type) {
-	case *ParallelConstraint:
-		return carryLines(m, v.L1, v.L2, g.AddParallel)
-	case *PerpendicularConstraint:
-		return carryLines(m, v.L1, v.L2, g.AddPerpendicular)
-	case *CollinearConstraint:
-		return carryLines(m, v.L1, v.L2, g.AddCollinear)
-	case *EqualLengthConstraint:
-		return carryLines(m, v.L1, v.L2, g.AddEqualLength)
-	case *ConcentricConstraint:
-		return carryCurves(m, v.C1, v.C2, g.AddConcentric)
-	case *EqualRadiusConstraint:
-		return carryCurves(m, v.C1, v.C2, g.AddEqualRadius)
-	case *CircularTangentConstraint:
-		return carryCurves(m, v.C1, v.C2, g.AddCircularTangent)
-	case *TangentConstraint:
-		return carryLineCurve(m, v.L, v.C, g.AddTangent)
-	default:
-		return false
+	for _, e := range kc.RelatedEntities() {
+		if !requested[e] {
+			return false
+		}
 	}
+	return true
 }
 
 // The carry* helpers remap a fixed operand shape and invoke the matching factory iff every

--- a/model/sketch/copy_constraints_registry.go
+++ b/model/sketch/copy_constraints_registry.go
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import "fmt"
+
+// Constraint copy carry-over is a registry keyed by [ConstraintKind], mirroring
+// the serialization registry in serialize_constraint_registry.go (#1637, audit
+// S2). The previous dispatch was a pair of hand-maintained type switches whose
+// `default: return false` silently dropped Smooth, Ground, Offset, PatternLink,
+// Custom and TextBoxAnchor — the same drift class the codec registry was built
+// to kill (#1574, #1625). Now every persisted kind must register either a carry
+// function or a documented skip reason; the registry closure test asserts the
+// registered set matches the persisted vocabulary exactly, so a new kind is a
+// compile-visible decision, never an accidental drop.
+
+// constraintCarrier is one 2D kind's copy decision: either carry (remap the
+// constraint's operands through the clone map and re-add it on the target,
+// returning false when any operand lies outside the copied set) or a non-empty
+// skipReason documenting why the kind cannot travel with a copy.
+type constraintCarrier struct {
+	carry      func(g *GeometricConstraints, c Constraint, m *cloneMap) bool
+	skipReason string
+}
+
+// carrier adapts a kind's typed carry function to the registry shape, doing the
+// concrete-type assertion the old switch cases did.
+func carrier[T Constraint](carry func(g *GeometricConstraints, v T, m *cloneMap) bool) constraintCarrier {
+	return constraintCarrier{carry: func(g *GeometricConstraints, c Constraint, m *cloneMap) bool {
+		return carry(g, c.(T), m)
+	}}
+}
+
+// constraintCarriers2D maps every persisted 2D kind to its copy decision.
+// Duplicate keys are a compile error; completeness against the persisted
+// vocabulary is enforced by TestConstraintCarrierRegistryMatchesVocabulary.
+var constraintCarriers2D = map[ConstraintKind]constraintCarrier{
+	CoincidentKind:      carrier(carryCoincident),
+	HorizontalKind:      carrier(carryHorizontal),
+	VerticalKind:        carrier(carryVertical),
+	PointOnLineKind:     carrier(carryPointOnLine),
+	MidpointKind:        carrier(carryMidpoint),
+	PointOnCircleKind:   carrier(carryPointOnCircle),
+	ParallelKind:        carrier(carryParallel),
+	PerpendicularKind:   carrier(carryPerpendicular),
+	CollinearKind:       carrier(carryCollinear),
+	EqualLengthKind:     carrier(carryEqualLength),
+	ConcentricKind:      carrier(carryConcentric),
+	EqualRadiusKind:     carrier(carryEqualRadius),
+	CircularTangentKind: carrier(carryCircularTangent),
+	TangentKind:         carrier(carryTangent),
+	SymmetryKind:        carrier(carrySymmetryKind),
+	FixKind:             carrier(carryFixKind),
+	SmoothKind:          carrier(carrySmooth),
+	GroundKind:          carrier(carryGround),
+	OffsetKind:          carrier(carryOffset),
+	PatternLinkKind:     carrier(carryPatternLink),
+	CustomKind:          carrier(carryCustom),
+	// A text-box anchor is auto-created with its TextBox (anchorTextBox) and
+	// sketch copy does not clone text boxes (cloneEntity has no TextBox case),
+	// so the anchor can never be remapped — the one documented skip (#1637).
+	TextBoxAnchorKind: {skipReason: "textBox anchor constraint not copied: sketch copy does not clone text boxes, and the anchor is re-created with its box"},
+}
+
+// registeredCarrierKinds2D returns the kinds with a copy decision, for the
+// registry closure test.
+func registeredCarrierKinds2D() []ConstraintKind {
+	out := make([]ConstraintKind, 0, len(constraintCarriers2D))
+	for k := range constraintCarriers2D {
+		out = append(out, k)
+	}
+	return out
+}
+
+// carryFrom re-creates one source geometric constraint on this (target)
+// collection via the clone map. carried reports success; skip is a non-empty
+// reason when the kind is a documented uncarryable (or, guarded by the closure
+// test, has no registered decision) — never both. A registered kind whose
+// operands lie outside the copied set drops silently, matching the external-
+// operand rule for every carryable kind (#1083).
+func (g *GeometricConstraints) carryFrom(c Constraint, m *cloneMap) (carried bool, skip string) {
+	kc, ok := c.(KindedConstraint)
+	if !ok {
+		return false, fmt.Sprintf("constraint %T not copied: it carries no ConstraintKind (expected a registered 2D kind)", c)
+	}
+	cc, ok := constraintCarriers2D[kc.ConstraintKind()]
+	if !ok {
+		return false, fmt.Sprintf("constraint kind %q not copied: no copy decision registered", kc.ConstraintKind())
+	}
+	if cc.carry == nil {
+		return false, cc.skipReason
+	}
+	return cc.carry(g, c, m), ""
+}
+
+// The per-kind carry functions. Each remaps its operand shape through the clone
+// map and calls the matching Add* factory, returning false when any operand is
+// outside the copied set.
+
+func carryCoincident(g *GeometricConstraints, v *CoincidentConstraint, m *cloneMap) bool {
+	return carryPoints(m, v.A, v.B, g.AddCoincident)
+}
+
+func carryHorizontal(g *GeometricConstraints, v *HorizontalConstraint, m *cloneMap) bool {
+	return carryPoints(m, v.A, v.B, g.AddHorizontal)
+}
+
+func carryVertical(g *GeometricConstraints, v *VerticalConstraint, m *cloneMap) bool {
+	return carryPoints(m, v.A, v.B, g.AddVertical)
+}
+
+func carryPointOnLine(g *GeometricConstraints, v *PointOnLineConstraint, m *cloneMap) bool {
+	return carryPointLine(m, v.P, v.L, g.AddPointOnLine)
+}
+
+func carryMidpoint(g *GeometricConstraints, v *MidpointConstraint, m *cloneMap) bool {
+	return carryPointLine(m, v.P, v.L, g.AddMidpoint)
+}
+
+func carryPointOnCircle(g *GeometricConstraints, v *PointOnCircleConstraint, m *cloneMap) bool {
+	return carryPointCurve(m, v.P, v.C, g.AddPointOnCircle)
+}
+
+func carryParallel(g *GeometricConstraints, v *ParallelConstraint, m *cloneMap) bool {
+	return carryLines(m, v.L1, v.L2, g.AddParallel)
+}
+
+func carryPerpendicular(g *GeometricConstraints, v *PerpendicularConstraint, m *cloneMap) bool {
+	return carryLines(m, v.L1, v.L2, g.AddPerpendicular)
+}
+
+func carryCollinear(g *GeometricConstraints, v *CollinearConstraint, m *cloneMap) bool {
+	return carryLines(m, v.L1, v.L2, g.AddCollinear)
+}
+
+func carryEqualLength(g *GeometricConstraints, v *EqualLengthConstraint, m *cloneMap) bool {
+	return carryLines(m, v.L1, v.L2, g.AddEqualLength)
+}
+
+func carryConcentric(g *GeometricConstraints, v *ConcentricConstraint, m *cloneMap) bool {
+	return carryCurves(m, v.C1, v.C2, g.AddConcentric)
+}
+
+func carryEqualRadius(g *GeometricConstraints, v *EqualRadiusConstraint, m *cloneMap) bool {
+	return carryCurves(m, v.C1, v.C2, g.AddEqualRadius)
+}
+
+func carryCircularTangent(g *GeometricConstraints, v *CircularTangentConstraint, m *cloneMap) bool {
+	return carryCurves(m, v.C1, v.C2, g.AddCircularTangent)
+}
+
+func carryTangent(g *GeometricConstraints, v *TangentConstraint, m *cloneMap) bool {
+	return carryLineCurve(m, v.L, v.C, g.AddTangent)
+}
+
+func carrySymmetryKind(g *GeometricConstraints, v *SymmetryConstraint, m *cloneMap) bool {
+	return carrySymmetry(m, v, g)
+}
+
+func carryFixKind(g *GeometricConstraints, v *FixConstraint, m *cloneMap) bool {
+	return carryFix(m, v.P, g)
+}
+
+// carrySmooth remaps the two joined curves and their join endpoints; the clone
+// keeps the G2 join, so Class-A continuity survives a copy (#1637).
+func carrySmooth(g *GeometricConstraints, v *SmoothConstraint, m *cloneMap) bool {
+	c1, ok1 := m.smoothCurve(v.C1)
+	c2, ok2 := m.smoothCurve(v.C2)
+	p1, ok3 := m.point(v.P1)
+	p2, ok4 := m.point(v.P2)
+	if !ok1 || !ok2 || !ok3 || !ok4 {
+		return false
+	}
+	g.AddSmooth(c1, c2, p1, p2)
+	return true
+}
+
+// carryGround re-grounds every clone at its own (translated) position —
+// AddGroundPoints re-freezes coordinates, so the copy is locked where it landed.
+func carryGround(g *GeometricConstraints, v *GroundConstraint, m *cloneMap) bool {
+	pts := make([]*Point, 0, len(v.Points()))
+	for _, p := range v.Points() {
+		np, ok := m.point(p)
+		if !ok {
+			return false
+		}
+		pts = append(pts, np)
+	}
+	g.AddGroundPoints(pts...)
+	return true
+}
+
+func carryOffset(g *GeometricConstraints, v *OffsetConstraint, m *cloneMap) bool {
+	l1, ok1 := m.line(v.L1)
+	l2, ok2 := m.line(v.L2)
+	if !ok1 || !ok2 {
+		return false
+	}
+	g.AddOffset(l1, l2, v.Dist)
+	return true
+}
+
+// carryPatternLink clones the link as a frozen offset: a live link's offset
+// closure reads the source pattern's parameters, which do not travel with a
+// copy — the same degradation the persistence codec applies on save (#1637).
+func carryPatternLink(g *GeometricConstraints, v *PatternConstraint, m *cloneMap) bool {
+	seed, ok1 := m.point(v.Seed)
+	member, ok2 := m.point(v.Member)
+	if !ok1 || !ok2 {
+		return false
+	}
+	g.AddPatternLink(seed, member)
+	return true
+}
+
+// carryCustom remaps the tag's entity set; the owning add-in's ClientID and
+// name travel unchanged (the attribute-set payload stays with the source).
+func carryCustom(g *GeometricConstraints, v *CustomConstraint, m *cloneMap) bool {
+	ents := make([]Entity, 0, len(v.Entities))
+	for _, e := range v.Entities {
+		ne, ok := m.entities[e]
+		if !ok {
+			return false
+		}
+		ents = append(ents, ne)
+	}
+	_, err := g.AddCustom(v.ClientID, v.Name, ents)
+	return err == nil
+}

--- a/model/sketch/copy_constraints_registry_test.go
+++ b/model/sketch/copy_constraints_registry_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestConstraintCarrierRegistryMatchesVocabulary: every persisted 2D constraint
+// kind has a copy decision — a carry function or a documented skip — so a new
+// kind cannot ship as a silent copy drop (#1637; mirrors the codec closure test).
+func TestConstraintCarrierRegistryMatchesVocabulary(t *testing.T) {
+	assertConstraintKindSetsEqual(t, "2D carry", registeredCarrierKinds2D(), persistedConstraintVocabulary2D)
+}
+
+// TestConstraintCarrierDecisionsAreExclusive: a carrier is either a carry
+// function or a documented skip, never both and never neither (#1637).
+func TestConstraintCarrierDecisionsAreExclusive(t *testing.T) {
+	for kind, cc := range constraintCarriers2D {
+		if (cc.carry == nil) == (cc.skipReason == "") {
+			t.Errorf("carrier %q must have exactly one of carry or skipReason (carry=%v, skipReason=%q)",
+				kind, cc.carry != nil, cc.skipReason)
+		}
+	}
+}
+
+// TestCopySmoothSketchPreservesDOF: a whole-sketch copy has the same degrees of
+// freedom as the source. The fixture leans on Smooth, Ground and Offset — the
+// DOF-removing kinds the pre-#1637 switch dropped, which made the copy solve to
+// a different shape on the next edit (G2 regression for the Smooth spline pair).
+func TestCopySmoothSketchPreservesDOF(t *testing.T) {
+	src := NewSketches().Add(XYPlane())
+	g := src.GeometricConstraints()
+	sp1 := src.Splines().AddByPoints([]math.Point2{math.P2(0, 0), math.P2(1, 1), math.P2(2, 0)}, false)
+	sp2 := src.Splines().AddByPoints([]math.Point2{math.P2(2, 0), math.P2(3, -1), math.P2(4, 0)}, false)
+	j1, j2, ok := NearestSmoothJoin(sp1, sp2)
+	if !ok {
+		t.Fatal("no smooth join between the two splines")
+	}
+	g.AddSmooth(sp1, sp2, j1, j2)
+	l1 := src.Lines().AddByTwoPoints(math.P2(0, 5), math.P2(4, 5))
+	l2 := src.Lines().AddByTwoPoints(math.P2(0, 6), math.P2(4, 6))
+	g.AddOffset(l1, l2, 1)
+	g.AddGround(l1)
+
+	dst := NewSketches().Add(XYPlane())
+	if _, warns := dst.CopyEntitiesWithConstraints(src, src.Entities(), math.V2(10, 0)); len(warns) != 0 {
+		t.Fatalf("copy warnings = %q, want none", warns)
+	}
+	if got, want := dst.DegreesOfFreedom(), src.DegreesOfFreedom(); got != want {
+		t.Errorf("copied sketch DOF = %d, want %d (source)", got, want)
+	}
+	if got, want := dst.GeometricConstraints().Count(), src.GeometricConstraints().Count(); got != want {
+		t.Errorf("carried constraints = %d, want %d", got, want)
+	}
+}
+
+// TestCopyWarnsOnTextBoxAnchorConstraint: the text-box anchor is the one
+// documented skip — copying a text box emits a warning instead of a silent
+// drop, and copying geometry that leaves the text box behind stays silent
+// (external-operand rule) (#1637).
+func TestCopyWarnsOnTextBoxAnchorConstraint(t *testing.T) {
+	src := NewSketches().Add(XYPlane())
+	src.TextBoxes().Add(math.P2(1, 1), "NOTE", 0.5, 0, TextLeft)
+	l := src.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0))
+
+	whole := NewSketches().Add(XYPlane())
+	_, warns := whole.CopyEntitiesWithConstraints(src, src.Entities(), math.V2(10, 0))
+	if len(warns) != 1 || !strings.Contains(warns[0], "textBox") {
+		t.Errorf("whole-sketch copy warnings = %q, want one textBox anchor skip", warns)
+	}
+	if got := whole.GeometricConstraints().Count(); got != 0 {
+		t.Errorf("carried constraints = %d, want 0 (the anchor cannot travel)", got)
+	}
+
+	lineOnly := NewSketches().Add(XYPlane())
+	if _, warns := lineOnly.CopyEntitiesWithConstraints(src, []Entity{l}, math.V2(10, 0)); len(warns) != 0 {
+		t.Errorf("line-only copy warnings = %q, want none (text box was left behind)", warns)
+	}
+}
+
+// TestCopyLivePatternLinkDegradesToFrozen: a live pattern link (its offset
+// closure reads the source pattern's parameters) is carried as a frozen link,
+// matching the persistence codec's degradation on save (#1637).
+func TestCopyLivePatternLinkDegradesToFrozen(t *testing.T) {
+	src := NewSketches().Add(XYPlane())
+	seed := src.Points().Add(math.P2(0, 0))
+	member := src.Points().Add(math.P2(3, 0))
+	src.GeometricConstraints().AddPatternLinkLive(seed, member, func() (float64, float64) { return 3, 0 })
+
+	dst := NewSketches().Add(XYPlane())
+	if _, warns := dst.CopyEntitiesWithConstraints(src, src.Entities(), math.V2(10, 0)); len(warns) != 0 {
+		t.Fatalf("copy warnings = %q, want none", warns)
+	}
+	if got := dst.GeometricConstraints().Count(); got != 1 {
+		t.Fatalf("carried constraints = %d, want 1 (frozen pattern link)", got)
+	}
+	link, ok := dst.GeometricConstraints().Item(0).(*PatternConstraint)
+	if !ok {
+		t.Fatalf("carried constraint is %T, want *PatternConstraint", dst.GeometricConstraints().Item(0))
+	}
+	if link.live != nil {
+		t.Error("copied pattern link kept the source's live offset closure; want frozen")
+	}
+	if res := dst.Solve(); !res.Converged {
+		t.Errorf("copied sketch did not solve: %+v", res)
+	}
+}

--- a/model/sketch/copy_constraints_test.go
+++ b/model/sketch/copy_constraints_test.go
@@ -21,7 +21,7 @@ func TestCopyCarriesInternalConstraintAndDimension(t *testing.T) {
 	}
 
 	dst := NewSketches().Add(XYPlane())
-	clones := dst.CopyEntitiesWithConstraints(src, []Entity{l}, math.V2(0, 50))
+	clones, _ := dst.CopyEntitiesWithConstraints(src, []Entity{l}, math.V2(0, 50))
 	if len(clones) != 1 {
 		t.Fatalf("clones = %d, want 1", len(clones))
 	}
@@ -123,6 +123,22 @@ func TestCopyCarriesEveryConstraintAndDimensionKind(t *testing.T) {
 	g.AddSymmetry(pa, pb, l3)
 	g.AddFix(pa)
 
+	// The six kinds the pre-#1637 switch silently dropped (TextBoxAnchor is the
+	// documented skip, exercised in TestCopyWarnsOnTextBoxAnchorConstraint).
+	sp1 := src.Splines().AddByPoints([]math.Point2{math.P2(20, 0), math.P2(21, 1), math.P2(22, 0)}, false)
+	sp2 := src.Splines().AddByPoints([]math.Point2{math.P2(22, 0), math.P2(23, -1), math.P2(24, 0)}, false)
+	j1, j2, ok := NearestSmoothJoin(sp1, sp2)
+	if !ok {
+		t.Fatal("no smooth join between the two splines")
+	}
+	g.AddSmooth(sp1, sp2, j1, j2)
+	g.AddGround(l2)
+	g.AddOffset(l1, l2, 1)
+	g.AddPatternLink(pa, pb)
+	if _, err := g.AddCustom("test-addin", "tag", []Entity{l1}); err != nil {
+		t.Fatalf("source custom constraint: %v", err)
+	}
+
 	// add spreads a (dimension, error) factory result, failing fast on a build error.
 	add := func(_ *DimensionConstraint, err error) {
 		t.Helper()
@@ -143,7 +159,10 @@ func TestCopyCarriesEveryConstraintAndDimensionKind(t *testing.T) {
 	wantC, wantD := g.Count(), dc.Count()
 
 	dst := NewSketches().Add(XYPlane())
-	dst.CopyEntitiesWithConstraints(src, src.Entities(), math.V2(100, 0))
+	_, warns := dst.CopyEntitiesWithConstraints(src, src.Entities(), math.V2(100, 0))
+	if len(warns) != 0 {
+		t.Errorf("copy warnings = %q, want none (every kind here is carryable)", warns)
+	}
 	if got := dst.GeometricConstraints().Count(); got != wantC {
 		t.Errorf("carried geometric constraints = %d, want %d (every kind)", got, wantC)
 	}


### PR DESCRIPTION
Sketch copy previously replicated only the constraint kinds it had explicit cases for, silently dropping the other six — a copied sketch came back under-constrained with no diagnostic. This carries all 22 constraint kinds through the copy, and for any kind that genuinely cannot be replicated in the target context emits a documented warning instead of a silent drop.

`go build ./...`, `go test ./model/sketch/...`, and `golangci-lint ./model/sketch/...` pass locally.

Closes #1637

🤖 Generated with [Claude Code](https://claude.com/claude-code)