### PR TITLE
M40 I11: give work-plane definitions a Redefine method so create and redefine share one dispatch

### DIFF
--- a/model/feature/work_plane.go
+++ b/model/feature/work_plane.go
@@ -21,11 +21,24 @@ import (
 const defaultOriginPlaneSize = 5.0
 
 // planeDefinition computes a work plane from its references. Concrete kinds capture the
-// references + parameters; eval resolves the references through the work resolver.
+// references + parameters; eval resolves the references through the work resolver. The
+// redefine half (redefineSlots/editableScalars/snapshotState) lives on the same interface so
+// create and redefine share one dispatch: a kind that can be created but not re-edited is a
+// compile error, not a greyed Edit entry (#1634, audit I11; implementations in
+// work_plane_redefine.go).
 type planeDefinition interface {
 	kindName() string
 	refs() []WorkRef
 	eval(r workResolver) (sketch.Plane, error)
+	// redefineSlots returns the definition's re-pickable reference inputs in display order
+	// (each wired through w.slot so a rebind is validated); nil when it has none.
+	redefineSlots(w *WorkPlane) []WorkRefSlot
+	// editableScalars returns the definition's editable scalar inputs (offset distance,
+	// swing angle); nil when it has none.
+	editableScalars() []EditableParam
+	// snapshotState captures the definition's current inputs and returns the closure that
+	// restores them (an edit's Cancel); a no-op for the grounded kinds.
+	snapshotState() func()
 }
 
 // fixedPlaneDef is a grounded plane (an origin plane): fixed geometry, no references.

--- a/model/feature/work_plane_redefine.go
+++ b/model/feature/work_plane_redefine.go
@@ -11,6 +11,12 @@ import "oblikovati.org/model/param"
 // make every user work plane editable on browser double-click (issue #132 follow-up). A plane
 // whose definition has neither (the origin frame, an absolute fixed-frame plane) reports both
 // empty and is not opened for editing.
+//
+// Each definition declares its own slots/scalars/snapshot (the redefineSlots/editableScalars/
+// snapshotState half of [planeDefinition]), so create and redefine share ONE dispatch — the
+// definition type. The former hand switches here trailed the create side: a kind added to the
+// constructors but not to a switch was creatable-but-not-editable (#1634, audit I11; the #1521
+// tool-without-edit-path shape).
 
 // WorkRefKind is the kind of geometry a redefine slot accepts, so the editor sets the right
 // pick filter and the caller maps the pick to the matching [WorkRef].
@@ -70,116 +76,15 @@ func (w *WorkPlane) slot(label string, kind WorkRefKind, assign func(WorkRef)) W
 }
 
 // RedefineSlots returns the plane's re-pickable reference inputs in display order, or nil when
-// the definition has none (the origin frame, fixed-geometry planes).
-func (w *WorkPlane) RedefineSlots() []WorkRefSlot {
-	if slots := w.pointPlaneSlots(); slots != nil {
-		return slots
-	}
-	if slots := w.linePlaneSlots(); slots != nil {
-		return slots
-	}
-	return w.tangentSlots()
-}
-
-// pointPlaneSlots returns the slots for the planes defined by plane/point references (offset,
-// three-point, plane-and-point, two-planes); nil for the other kinds.
-func (w *WorkPlane) pointPlaneSlots() []WorkRefSlot {
-	switch d := w.def.(type) {
-	case *offsetPlaneDef:
-		return []WorkRefSlot{w.slot("Base plane", WorkRefPlane, func(r WorkRef) { d.base = r })}
-	case *threePointPlaneDef:
-		return []WorkRefSlot{
-			w.slot("Point 1", WorkRefPoint, func(r WorkRef) { d.a = r }),
-			w.slot("Point 2", WorkRefPoint, func(r WorkRef) { d.b = r }),
-			w.slot("Point 3", WorkRefPoint, func(r WorkRef) { d.c = r }),
-		}
-	case *planeAndPointPlaneDef:
-		return []WorkRefSlot{
-			w.slot("Base plane", WorkRefPlane, func(r WorkRef) { d.base = r }),
-			w.slot("Through point", WorkRefPoint, func(r WorkRef) { d.point = r }),
-		}
-	case *twoPlanesPlaneDef:
-		return []WorkRefSlot{
-			w.slot("Plane 1", WorkRefPlane, func(r WorkRef) { d.p1 = r }),
-			w.slot("Plane 2", WorkRefPlane, func(r WorkRef) { d.p2 = r }),
-		}
-	default:
-		return nil
-	}
-}
-
-// linePlaneSlots returns the slots for the planes defined by a line/axis (line-plane-angle,
-// two-lines, normal-to-curve); nil for the other kinds.
-func (w *WorkPlane) linePlaneSlots() []WorkRefSlot {
-	switch d := w.def.(type) {
-	case *linePlaneAnglePlaneDef:
-		return []WorkRefSlot{
-			w.slot("Line", WorkRefAxis, func(r WorkRef) { d.line = r }),
-			w.slot("Plane", WorkRefPlane, func(r WorkRef) { d.base = r }),
-		}
-	case *twoLinesPlaneDef:
-		return []WorkRefSlot{
-			w.slot("Line 1", WorkRefAxis, func(r WorkRef) { d.l1 = r }),
-			w.slot("Line 2", WorkRefAxis, func(r WorkRef) { d.l2 = r }),
-		}
-	case *normalToCurvePlaneDef:
-		return []WorkRefSlot{
-			w.slot("Curve", WorkRefAxis, func(r WorkRef) { d.curve = r }),
-			w.slot("Point", WorkRefPoint, func(r WorkRef) { d.point = r }),
-		}
-	default:
-		return nil
-	}
-}
-
-// tangentSlots returns the slots for the surface-tangent planes (built on a B-rep face), each
-// of which exposes that face as a re-pickable WorkRefFace; nil for every other kind.
-func (w *WorkPlane) tangentSlots() []WorkRefSlot {
-	switch d := w.def.(type) {
-	case *torusMidPlaneDef:
-		return []WorkRefSlot{w.slot("Torus face", WorkRefFace, func(r WorkRef) { d.face = r })}
-	case *pointAndTangentPlaneDef:
-		return []WorkRefSlot{
-			w.slot("Point", WorkRefPoint, func(r WorkRef) { d.point = r }),
-			w.slot(labelTangentFace, WorkRefFace, func(r WorkRef) { d.face = r }),
-		}
-	case *planeAndTangentPlaneDef:
-		return []WorkRefSlot{
-			w.slot("Parallel plane", WorkRefPlane, func(r WorkRef) { d.base = r }),
-			w.slot(labelTangentFace, WorkRefFace, func(r WorkRef) { d.face = r }),
-		}
-	case *lineAndTangentPlaneDef:
-		return []WorkRefSlot{
-			w.slot("Line", WorkRefAxis, func(r WorkRef) { d.line = r }),
-			w.slot(labelTangentFace, WorkRefFace, func(r WorkRef) { d.face = r }),
-		}
-	default:
-		return nil
-	}
-}
+// the definition has none (the origin frame, fixed-geometry planes). The definition itself
+// declares its slots, so create and redefine dispatch through the same type (#1634).
+func (w *WorkPlane) RedefineSlots() []WorkRefSlot { return w.def.redefineSlots(w) }
 
 // EditableScalars returns the plane's editable scalar inputs in display order, or nil when it
 // has none. Reuses the feature [EditableParam] shape (get/set in database units), so the head
 // renders and the session converts them exactly like a feature's scalar fields. Set mutates
 // the pointer-held definition, so a scalar edit and a slot re-pick compose in either order.
-func (w *WorkPlane) EditableScalars() []EditableParam {
-	switch d := w.def.(type) {
-	case *offsetPlaneDef:
-		return []EditableParam{{
-			Label: "Offset", Unit: param.Length,
-			Get: func() float64 { return d.distance() },
-			Set: func(v float64) { d.setDistance(v) },
-		}}
-	case *linePlaneAnglePlaneDef:
-		return []EditableParam{{
-			Label: "Angle", Unit: param.Angle,
-			Get: func() float64 { return d.angle() },
-			Set: func(v float64) { d.angle = func() float64 { return v } },
-		}}
-	default:
-		return nil
-	}
-}
+func (w *WorkPlane) EditableScalars() []EditableParam { return w.def.editableScalars() }
 
 // IsRedefinable reports whether the plane exposes any editable scalar or reference, i.e. whether
 // browser double-click should open it for editing.
@@ -191,36 +96,7 @@ func (w *WorkPlane) IsRedefinable() bool {
 // restores it — an edit's Cancel calls it to undo any re-picked references and scalar changes
 // in one step. Every user definition is held behind a pointer (slots and scalar edits mutate
 // one shared instance), so the snapshot copies the pointee and the restore copies it back.
-//
-//nolint:funlen // one-case-per-definition-kind dispatch; each case only names the concrete type snapshotPointee needs.
-func (w *WorkPlane) SnapshotDefinition() func() {
-	switch d := w.def.(type) {
-	case *offsetPlaneDef:
-		return snapshotPointee(d)
-	case *threePointPlaneDef:
-		return snapshotPointee(d)
-	case *planeAndPointPlaneDef:
-		return snapshotPointee(d)
-	case *twoPlanesPlaneDef:
-		return snapshotPointee(d)
-	case *linePlaneAnglePlaneDef:
-		return snapshotPointee(d)
-	case *twoLinesPlaneDef:
-		return snapshotPointee(d)
-	case *normalToCurvePlaneDef:
-		return snapshotPointee(d)
-	case *torusMidPlaneDef:
-		return snapshotPointee(d)
-	case *pointAndTangentPlaneDef:
-		return snapshotPointee(d)
-	case *planeAndTangentPlaneDef:
-		return snapshotPointee(d)
-	case *lineAndTangentPlaneDef:
-		return snapshotPointee(d)
-	default:
-		return func() {} // grounded kinds (fixed, fixed-frame) expose nothing to redefine
-	}
-}
+func (w *WorkPlane) SnapshotDefinition() func() { return w.def.snapshotState() }
 
 // snapshotPointee copies *d and returns a closure that copies it back — the restore half of
 // [WorkPlane.SnapshotDefinition] for the pointer-held definitions.
@@ -228,3 +104,158 @@ func snapshotPointee[T any](d *T) func() {
 	cp := *d
 	return func() { *d = cp }
 }
+
+// The grounded kinds (origin planes, the absolute fixed-frame plane) expose nothing to
+// redefine — declared explicitly, so their non-editability is a decision, not a default case.
+func (fixedPlaneDef) redefineSlots(*WorkPlane) []WorkRefSlot { return nil }
+func (fixedPlaneDef) editableScalars() []EditableParam       { return nil }
+func (fixedPlaneDef) snapshotState() func()                  { return func() {} }
+
+func (*fixedFramePlaneDef) redefineSlots(*WorkPlane) []WorkRefSlot { return nil }
+func (*fixedFramePlaneDef) editableScalars() []EditableParam       { return nil }
+func (*fixedFramePlaneDef) snapshotState() func()                  { return func() {} }
+
+// pointCloudFitPlaneDef has no re-pickable inputs either: it is fit associatively to its
+// source cloud (#645), so the fit — not a user pick — defines it. Re-fitting is a recompute,
+// not a redefine. Before I11 this kind silently fell out of the redefine switches' default
+// cases; now the decision is stated here.
+func (*pointCloudFitPlaneDef) redefineSlots(*WorkPlane) []WorkRefSlot { return nil }
+func (*pointCloudFitPlaneDef) editableScalars() []EditableParam       { return nil }
+func (*pointCloudFitPlaneDef) snapshotState() func()                  { return func() {} }
+
+// offsetPlaneDef: base-plane slot + offset scalar.
+func (d *offsetPlaneDef) redefineSlots(w *WorkPlane) []WorkRefSlot {
+	return []WorkRefSlot{w.slot("Base plane", WorkRefPlane, func(r WorkRef) { d.base = r })}
+}
+func (d *offsetPlaneDef) editableScalars() []EditableParam {
+	return []EditableParam{{
+		Label: "Offset", Unit: param.Length,
+		Get: func() float64 { return d.distance() },
+		Set: func(v float64) { d.setDistance(v) },
+	}}
+}
+func (d *offsetPlaneDef) snapshotState() func() { return snapshotPointee(d) }
+
+// threePointPlaneDef: three point slots.
+func (d *threePointPlaneDef) redefineSlots(w *WorkPlane) []WorkRefSlot {
+	return []WorkRefSlot{
+		w.slot("Point 1", WorkRefPoint, func(r WorkRef) { d.a = r }),
+		w.slot("Point 2", WorkRefPoint, func(r WorkRef) { d.b = r }),
+		w.slot("Point 3", WorkRefPoint, func(r WorkRef) { d.c = r }),
+	}
+}
+func (d *threePointPlaneDef) editableScalars() []EditableParam { return nil }
+func (d *threePointPlaneDef) snapshotState() func()            { return snapshotPointee(d) }
+
+// planeAndPointPlaneDef: base-plane + through-point slots.
+func (d *planeAndPointPlaneDef) redefineSlots(w *WorkPlane) []WorkRefSlot {
+	return []WorkRefSlot{
+		w.slot("Base plane", WorkRefPlane, func(r WorkRef) { d.base = r }),
+		w.slot("Through point", WorkRefPoint, func(r WorkRef) { d.point = r }),
+	}
+}
+func (d *planeAndPointPlaneDef) editableScalars() []EditableParam { return nil }
+func (d *planeAndPointPlaneDef) snapshotState() func()            { return snapshotPointee(d) }
+
+// twoPlanesPlaneDef: the two bisected plane slots.
+func (d *twoPlanesPlaneDef) redefineSlots(w *WorkPlane) []WorkRefSlot {
+	return []WorkRefSlot{
+		w.slot("Plane 1", WorkRefPlane, func(r WorkRef) { d.p1 = r }),
+		w.slot("Plane 2", WorkRefPlane, func(r WorkRef) { d.p2 = r }),
+	}
+}
+func (d *twoPlanesPlaneDef) editableScalars() []EditableParam { return nil }
+func (d *twoPlanesPlaneDef) snapshotState() func()            { return snapshotPointee(d) }
+
+// linePlaneAnglePlaneDef: line + plane slots, plus the swing-angle scalar.
+func (d *linePlaneAnglePlaneDef) redefineSlots(w *WorkPlane) []WorkRefSlot {
+	return []WorkRefSlot{
+		w.slot("Line", WorkRefAxis, func(r WorkRef) { d.line = r }),
+		w.slot("Plane", WorkRefPlane, func(r WorkRef) { d.base = r }),
+	}
+}
+func (d *linePlaneAnglePlaneDef) editableScalars() []EditableParam {
+	return []EditableParam{{
+		Label: "Angle", Unit: param.Angle,
+		Get: func() float64 { return d.angle() },
+		Set: func(v float64) { d.angle = func() float64 { return v } },
+	}}
+}
+func (d *linePlaneAnglePlaneDef) snapshotState() func() { return snapshotPointee(d) }
+
+// twoLinesPlaneDef: the two line slots.
+func (d *twoLinesPlaneDef) redefineSlots(w *WorkPlane) []WorkRefSlot {
+	return []WorkRefSlot{
+		w.slot("Line 1", WorkRefAxis, func(r WorkRef) { d.l1 = r }),
+		w.slot("Line 2", WorkRefAxis, func(r WorkRef) { d.l2 = r }),
+	}
+}
+func (d *twoLinesPlaneDef) editableScalars() []EditableParam { return nil }
+func (d *twoLinesPlaneDef) snapshotState() func()            { return snapshotPointee(d) }
+
+// normalToCurvePlaneDef: curve + point slots.
+func (d *normalToCurvePlaneDef) redefineSlots(w *WorkPlane) []WorkRefSlot {
+	return []WorkRefSlot{
+		w.slot("Curve", WorkRefAxis, func(r WorkRef) { d.curve = r }),
+		w.slot("Point", WorkRefPoint, func(r WorkRef) { d.point = r }),
+	}
+}
+func (d *normalToCurvePlaneDef) editableScalars() []EditableParam { return nil }
+func (d *normalToCurvePlaneDef) snapshotState() func()            { return snapshotPointee(d) }
+
+// torusMidPlaneDef: the torus face slot.
+func (d *torusMidPlaneDef) redefineSlots(w *WorkPlane) []WorkRefSlot {
+	return []WorkRefSlot{w.slot("Torus face", WorkRefFace, func(r WorkRef) { d.face = r })}
+}
+func (d *torusMidPlaneDef) editableScalars() []EditableParam { return nil }
+func (d *torusMidPlaneDef) snapshotState() func()            { return snapshotPointee(d) }
+
+// pointAndTangentPlaneDef: point + tangent-face slots.
+func (d *pointAndTangentPlaneDef) redefineSlots(w *WorkPlane) []WorkRefSlot {
+	return []WorkRefSlot{
+		w.slot("Point", WorkRefPoint, func(r WorkRef) { d.point = r }),
+		w.slot(labelTangentFace, WorkRefFace, func(r WorkRef) { d.face = r }),
+	}
+}
+func (d *pointAndTangentPlaneDef) editableScalars() []EditableParam { return nil }
+func (d *pointAndTangentPlaneDef) snapshotState() func()            { return snapshotPointee(d) }
+
+// planeAndTangentPlaneDef: parallel-plane + tangent-face slots.
+func (d *planeAndTangentPlaneDef) redefineSlots(w *WorkPlane) []WorkRefSlot {
+	return []WorkRefSlot{
+		w.slot("Parallel plane", WorkRefPlane, func(r WorkRef) { d.base = r }),
+		w.slot(labelTangentFace, WorkRefFace, func(r WorkRef) { d.face = r }),
+	}
+}
+func (d *planeAndTangentPlaneDef) editableScalars() []EditableParam { return nil }
+func (d *planeAndTangentPlaneDef) snapshotState() func()            { return snapshotPointee(d) }
+
+// lineAndTangentPlaneDef: line + tangent-face slots.
+func (d *lineAndTangentPlaneDef) redefineSlots(w *WorkPlane) []WorkRefSlot {
+	return []WorkRefSlot{
+		w.slot("Line", WorkRefAxis, func(r WorkRef) { d.line = r }),
+		w.slot(labelTangentFace, WorkRefFace, func(r WorkRef) { d.face = r }),
+	}
+}
+func (d *lineAndTangentPlaneDef) editableScalars() []EditableParam { return nil }
+func (d *lineAndTangentPlaneDef) snapshotState() func()            { return snapshotPointee(d) }
+
+// Every definition kind must carry its full redefine story — a new kind missing one of the
+// redefine methods is a build error here, not a plane that can be created but not re-edited
+// (#1634, audit I11).
+var (
+	_ planeDefinition = fixedPlaneDef{}
+	_ planeDefinition = (*fixedFramePlaneDef)(nil)
+	_ planeDefinition = (*offsetPlaneDef)(nil)
+	_ planeDefinition = (*threePointPlaneDef)(nil)
+	_ planeDefinition = (*planeAndPointPlaneDef)(nil)
+	_ planeDefinition = (*twoPlanesPlaneDef)(nil)
+	_ planeDefinition = (*linePlaneAnglePlaneDef)(nil)
+	_ planeDefinition = (*twoLinesPlaneDef)(nil)
+	_ planeDefinition = (*normalToCurvePlaneDef)(nil)
+	_ planeDefinition = (*torusMidPlaneDef)(nil)
+	_ planeDefinition = (*pointAndTangentPlaneDef)(nil)
+	_ planeDefinition = (*planeAndTangentPlaneDef)(nil)
+	_ planeDefinition = (*lineAndTangentPlaneDef)(nil)
+	_ planeDefinition = (*pointCloudFitPlaneDef)(nil)
+)

--- a/model/feature/work_plane_redefine_closure_test.go
+++ b/model/feature/work_plane_redefine_closure_test.go
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Create→redefine closure over every work-plane definition kind (#1634, audit I11): for each
+// kind, a plane created with one set of inputs and then redefined (slots re-picked / scalars
+// edited) to a second set must land exactly where a fresh create with the second set lands —
+// proving create and redefine share one dispatch path (the definition). A kind creatable but
+// not redefinable fails here; a kind missing the redefine methods fails to compile
+// (work_plane_redefine.go's assertion block).
+
+// redefineClosureCase is one kind's round-trip: create with the original inputs, perturb via
+// the public redefine surface, and create the expected plane fresh from the perturbed inputs.
+type redefineClosureCase struct {
+	kind    string
+	create  func(t *testing.T, g *WorkGeometry) *WorkPlane
+	perturb func(t *testing.T, g *WorkGeometry, wp *WorkPlane)
+	fresh   func(t *testing.T, g *WorkGeometry) *WorkPlane
+}
+
+// setSlot re-picks slot i of wp to ref, failing the test on a rejected reference.
+func setSlot(t *testing.T, wp *WorkPlane, i int, ref WorkRef) {
+	t.Helper()
+	slots := wp.RedefineSlots()
+	if i >= len(slots) {
+		t.Fatalf("%s: RedefineSlots has %d slots, wanted index %d", wp.Kind(), len(slots), i)
+	}
+	if err := slots[i].Set(ref); err != nil {
+		t.Fatalf("%s: slot %d (%q) Set: %v", wp.Kind(), i, slots[i].Label, err)
+	}
+}
+
+// closureFixture is the shared geometry every case picks from: two work points on either
+// side of the origin frame and a cylinder body for the tangent kinds.
+type closureFixture struct {
+	g          *WorkGeometry
+	bodies     []*topo.Body
+	pA, pB, pC *WorkPoint
+	axisZ4     *WorkAxis // +Z line at x=4, outside the r=2 cylinder
+	axisZ5     *WorkAxis // +Z line at x=5, the perturbed pick
+	cylKey     []byte
+}
+
+func newClosureFixture(t *testing.T) *closureFixture {
+	t.Helper()
+	g := NewWorkGeometry()
+	body, key := faceBody(t, mustCylinder(t)) // axis +Z, radius 2 at origin
+	bodies := []*topo.Body{body}
+	g.Recompute(bodies)
+	f := &closureFixture{g: g, bodies: bodies, cylKey: key}
+	f.pA = g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(2, 0, 0) })
+	f.pB = g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 2, 0) })
+	f.pC = g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 0, 3) })
+	a4 := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(4, 0, 0) })
+	b4 := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(4, 0, 1) })
+	f.axisZ4 = g.WorkAxes().AddByTwoPoints(a4.Key(), b4.Key())
+	a5 := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 5, 0) })
+	b5 := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 5, 1) })
+	f.axisZ5 = g.WorkAxes().AddByTwoPoints(a5.Key(), b5.Key())
+	return f
+}
+
+// redefineClosureCases enumerates every redefinable definition kind with its perturbation.
+func redefineClosureCases(f *closureFixture) []redefineClosureCase {
+	return append(referenceKindCases(f), tangentKindCases(f)...)
+}
+
+// referenceKindCases covers the kinds built on other work features (planes/axes/points).
+func referenceKindCases(f *closureFixture) []redefineClosureCase {
+	return []redefineClosureCase{
+		{
+			kind: "plane-offset",
+			create: func(t *testing.T, g *WorkGeometry) *WorkPlane {
+				return g.WorkPlanes().AddByPlaneAndOffset(OriginXYPlane, func() float64 { return 2 })
+			},
+			perturb: func(t *testing.T, g *WorkGeometry, wp *WorkPlane) {
+				setSlot(t, wp, 0, OriginXZPlane)
+				wp.EditableScalars()[0].Set(5)
+			},
+			fresh: func(t *testing.T, g *WorkGeometry) *WorkPlane {
+				return g.WorkPlanes().AddByPlaneAndOffset(OriginXZPlane, func() float64 { return 5 })
+			},
+		},
+		{
+			kind: "three-points",
+			create: func(t *testing.T, g *WorkGeometry) *WorkPlane {
+				return g.WorkPlanes().AddByThreePoints(f.pA.Key(), f.pB.Key(), OriginCenter)
+			},
+			perturb: func(t *testing.T, g *WorkGeometry, wp *WorkPlane) {
+				setSlot(t, wp, 2, f.pC.Key())
+			},
+			fresh: func(t *testing.T, g *WorkGeometry) *WorkPlane {
+				return g.WorkPlanes().AddByThreePoints(f.pA.Key(), f.pB.Key(), f.pC.Key())
+			},
+		},
+		{
+			kind: "plane-point",
+			create: func(t *testing.T, g *WorkGeometry) *WorkPlane {
+				return g.WorkPlanes().AddByPlaneAndPoint(OriginXYPlane, f.pA.Key())
+			},
+			perturb: func(t *testing.T, g *WorkGeometry, wp *WorkPlane) {
+				setSlot(t, wp, 0, OriginXZPlane)
+				setSlot(t, wp, 1, f.pC.Key())
+			},
+			fresh: func(t *testing.T, g *WorkGeometry) *WorkPlane {
+				return g.WorkPlanes().AddByPlaneAndPoint(OriginXZPlane, f.pC.Key())
+			},
+		},
+		{
+			kind: "two-planes",
+			create: func(t *testing.T, g *WorkGeometry) *WorkPlane {
+				return g.WorkPlanes().AddByTwoPlanes(OriginXYPlane, OriginXZPlane)
+			},
+			perturb: func(t *testing.T, g *WorkGeometry, wp *WorkPlane) {
+				setSlot(t, wp, 1, OriginYZPlane)
+			},
+			fresh: func(t *testing.T, g *WorkGeometry) *WorkPlane {
+				return g.WorkPlanes().AddByTwoPlanes(OriginXYPlane, OriginYZPlane)
+			},
+		},
+		{
+			kind: "line-plane-angle",
+			create: func(t *testing.T, g *WorkGeometry) *WorkPlane {
+				return g.WorkPlanes().AddByLinePlaneAndAngle(OriginXAxis, OriginXYPlane, func() float64 { return 0 })
+			},
+			perturb: func(t *testing.T, g *WorkGeometry, wp *WorkPlane) {
+				setSlot(t, wp, 0, OriginYAxis)
+				wp.EditableScalars()[0].Set(stdmath.Pi / 4)
+			},
+			fresh: func(t *testing.T, g *WorkGeometry) *WorkPlane {
+				return g.WorkPlanes().AddByLinePlaneAndAngle(OriginYAxis, OriginXYPlane, func() float64 { return stdmath.Pi / 4 })
+			},
+		},
+		{
+			kind: "two-lines",
+			create: func(t *testing.T, g *WorkGeometry) *WorkPlane {
+				return g.WorkPlanes().AddByTwoLines(OriginXAxis, OriginYAxis)
+			},
+			perturb: func(t *testing.T, g *WorkGeometry, wp *WorkPlane) {
+				setSlot(t, wp, 1, OriginZAxis)
+			},
+			fresh: func(t *testing.T, g *WorkGeometry) *WorkPlane {
+				return g.WorkPlanes().AddByTwoLines(OriginXAxis, OriginZAxis)
+			},
+		},
+		{
+			kind: "normal-to-curve",
+			create: func(t *testing.T, g *WorkGeometry) *WorkPlane {
+				return g.WorkPlanes().AddByNormalToCurve(OriginZAxis, f.pC.Key())
+			},
+			perturb: func(t *testing.T, g *WorkGeometry, wp *WorkPlane) {
+				setSlot(t, wp, 0, OriginXAxis)
+				setSlot(t, wp, 1, f.pA.Key())
+			},
+			fresh: func(t *testing.T, g *WorkGeometry) *WorkPlane {
+				return g.WorkPlanes().AddByNormalToCurve(OriginXAxis, f.pA.Key())
+			},
+		},
+	}
+}
+
+// tangentKindCases covers the surface-tangent kinds (built on the fixture's cylinder face);
+// the torus mid-plane gets its own two-face fixture in TestTorusMidPlaneRedefineClosure.
+func tangentKindCases(f *closureFixture) []redefineClosureCase {
+	return []redefineClosureCase{
+		{
+			kind: "point-tangent",
+			create: func(t *testing.T, g *WorkGeometry) *WorkPlane {
+				return g.WorkPlanes().AddByPointAndTangent(f.pA.Key(), FaceRef(f.cylKey))
+			},
+			perturb: func(t *testing.T, g *WorkGeometry, wp *WorkPlane) {
+				setSlot(t, wp, 0, f.pB.Key())
+			},
+			fresh: func(t *testing.T, g *WorkGeometry) *WorkPlane {
+				return g.WorkPlanes().AddByPointAndTangent(f.pB.Key(), FaceRef(f.cylKey))
+			},
+		},
+		{
+			kind: "plane-tangent",
+			create: func(t *testing.T, g *WorkGeometry) *WorkPlane {
+				return g.WorkPlanes().AddByPlaneAndTangent(OriginYZPlane, FaceRef(f.cylKey))
+			},
+			perturb: func(t *testing.T, g *WorkGeometry, wp *WorkPlane) {
+				setSlot(t, wp, 0, OriginXZPlane)
+			},
+			fresh: func(t *testing.T, g *WorkGeometry) *WorkPlane {
+				return g.WorkPlanes().AddByPlaneAndTangent(OriginXZPlane, FaceRef(f.cylKey))
+			},
+		},
+		{
+			kind: "line-tangent",
+			create: func(t *testing.T, g *WorkGeometry) *WorkPlane {
+				return g.WorkPlanes().AddByLineAndTangent(f.axisZ4.Key(), FaceRef(f.cylKey))
+			},
+			perturb: func(t *testing.T, g *WorkGeometry, wp *WorkPlane) {
+				setSlot(t, wp, 0, f.axisZ5.Key())
+			},
+			fresh: func(t *testing.T, g *WorkGeometry) *WorkPlane {
+				return g.WorkPlanes().AddByLineAndTangent(f.axisZ5.Key(), FaceRef(f.cylKey))
+			},
+		},
+	}
+}
+
+func TestWorkPlaneRedefineClosureOverEveryKind(t *testing.T) {
+	f := newClosureFixture(t)
+	for _, tc := range redefineClosureCases(f) {
+		t.Run(tc.kind, func(t *testing.T) {
+			wp := tc.create(t, f.g)
+			f.g.Recompute(f.bodies)
+			if wp.Kind() != tc.kind {
+				t.Fatalf("created plane Kind() = %q, want %q", wp.Kind(), tc.kind)
+			}
+			tc.perturb(t, f.g, wp)
+			f.g.Recompute(f.bodies)
+			want := tc.fresh(t, f.g)
+			f.g.Recompute(f.bodies)
+			assertSamePlane(t, wp, want)
+		})
+	}
+}
+
+// assertSamePlane compares origin and normal only: kinds that fix just a normal (bisector,
+// angle, normal-to-curve, tangent) choose an arbitrary — but deterministic — in-plane X axis,
+// so origin+normal is the full geometric identity of the datum.
+func assertSamePlane(t *testing.T, got, want *WorkPlane) {
+	t.Helper()
+	if !got.Health().OK() || !want.Health().OK() {
+		t.Fatalf("plane health: redefined=%+v fresh=%+v", got.Health(), want.Health())
+	}
+	if !got.Plane().Origin().IsEqualTo(want.Plane().Origin(), wtol) {
+		t.Errorf("redefined origin = %v, fresh create = %v", got.Plane().Origin(), want.Plane().Origin())
+	}
+	if !got.Plane().Normal().AsVector().IsEqualTo(want.Plane().Normal().AsVector(), wtol) {
+		t.Errorf("redefined normal = %v, fresh create = %v", got.Plane().Normal(), want.Plane().Normal())
+	}
+}
+
+// TestTorusMidPlaneRedefineClosure re-picks the torus face — the mid-plane's only slot — to a
+// second torus and checks the plane re-derives from it (the tangent-family redefine pinned
+// against pre-I11 behavior).
+func TestTorusMidPlaneRedefineClosure(t *testing.T) {
+	g := NewWorkGeometry()
+	torA, err := geom.NewTorus(math.P3(0, 0, 5), math.V3(0, 0, 1), 4, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	torB, err := geom.NewTorus(math.P3(0, 0, -3), math.V3(0, 0, 1), 4, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bodyA, keyA := faceBody(t, torA)
+	bodyB, keyB := faceBodyAt(t, torB, 1)
+	bodies := []*topo.Body{bodyA, bodyB}
+	g.Recompute(bodies)
+	wp := g.WorkPlanes().AddByTorusMidPlane(FaceRef(keyA))
+	g.Recompute(bodies)
+	if !wp.Plane().Origin().IsEqualTo(math.P3(0, 0, 5), wtol) {
+		t.Fatalf("initial torus mid-plane origin = %v, want (0,0,5)", wp.Plane().Origin())
+	}
+	setSlot(t, wp, 0, FaceRef(keyB))
+	g.Recompute(bodies)
+	want := g.WorkPlanes().AddByTorusMidPlane(FaceRef(keyB))
+	g.Recompute(bodies)
+	assertSamePlane(t, wp, want)
+}
+
+// faceBodyAt is faceBody with a distinct lineage index, so two single-face bodies in one test
+// carry different reference keys (faceBody always mints index 0).
+func faceBodyAt(t *testing.T, surface geom.Surface, idx int) (*topo.Body, []byte) {
+	t.Helper()
+	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok("f", "body", idx)))
+	f := bld.AddFace(surface, topo.NewLineage(topo.Tok("f", "face", idx)))
+	return bld.Build(), f.ReferenceKey()
+}
+
+// TestNonRedefinableKindsDeclareEmptyStory pins the deliberate non-editables: the grounded
+// origin plane and the point-cloud-fit plane report no slots/scalars and a no-op snapshot —
+// explicitly (their definitions implement the redefine methods), not via a default case.
+func TestNonRedefinableKindsDeclareEmptyStory(t *testing.T) {
+	g := NewWorkGeometry()
+	origin := g.WorkPlanes().Item(0)
+	if origin.IsRedefinable() {
+		t.Errorf("origin plane %q is redefinable, want grounded/non-editable", origin.Name())
+	}
+	origin.SnapshotDefinition()() // must be a callable no-op
+
+	cloud := g.WorkPlanes().AddByPointCloudFit(staticPlaneFit{})
+	g.Recompute(nil)
+	if cloud.IsRedefinable() {
+		t.Errorf("point-cloud-fit plane is redefinable, want fit-driven/non-editable (#645)")
+	}
+	cloud.SnapshotDefinition()()
+}
+
+// staticPlaneFit is a fixed-frame PlaneFitSource stand-in for the cloud-fit redefine check.
+type staticPlaneFit struct{}
+
+func (staticPlaneFit) SourceID() string { return "cloud-1" }
+func (staticPlaneFit) FitFrame() (math.Point3, math.UnitVector3, math.UnitVector3, bool) {
+	x, _ := math.NewUnitVector3(1, 0, 0)
+	y, _ := math.NewUnitVector3(0, 1, 0)
+	return math.P3(0, 0, 1), x, y, true
+}


### PR DESCRIPTION
Work-plane redefinition duplicated the create-time construction as a hand-written switch over definition kinds, a second place that had to stay in lockstep with the constructor. This gives each work-plane definition a `Redefine` method so create and redefine flow through the same per-definition dispatch — the redefine path can no longer drift from the create path.

`go build ./...`, `go test ./model/... ./app/...`, and `golangci-lint` on the touched packages pass locally.

Closes #1634

🤖 Generated with [Claude Code](https://claude.com/claude-code)