### PR TITLE
Give the surface-edit and direct-geometry features serialization codecs (fix silent save/undo refusal)

### DIFF
--- a/model/feature/freeform.go
+++ b/model/feature/freeform.go
@@ -178,7 +178,13 @@ func NewAliasFreeformFeatures(engine *PartFeatures) *AliasFreeformFeatures {
 // AddFromCage wraps an imported sub-D cage (vertices + polygon faces) as an editable
 // free-form feature.
 func (c *AliasFreeformFeatures) AddFromCage(verts []math.Point3, faces [][]int, level int) *PartFeature {
-	cage := subd.Mesh{Verts: verts, Faces: faces}
+	return c.add(subd.Mesh{Verts: verts, Faces: faces}, level)
+}
+
+// add registers an imported Alias free-form feature over the given cage, preserving the
+// cage's creases and subdivision level — the seam the serialization restore path uses so a
+// round-trip keeps sharp edges (AddFromCage's caller passes a crease-free cage).
+func (c *AliasFreeformFeatures) add(cage subd.Mesh, level int) *PartFeature {
 	af := &AliasFreeformFeature{FreeformFeature{body: &FreeformBody{cage: cage.Clone(), level: level}, featName: "AliasFreeform"}}
 	pf := c.engine.Add(af)
 	af.featName = pf.name

--- a/model/feature/serialize.go
+++ b/model/feature/serialize.go
@@ -69,19 +69,33 @@ type FeatureData struct {
 	FairSurface      *FairSurfaceData      `yaml:"fairSurface,omitempty"`
 	FitSurface       *FitSurfaceData       `yaml:"fitSurface,omitempty"`
 	FaceEdit         *FaceEditData         `yaml:"faceEdit,omitempty"`
-	Thicken          *ThickenData          `yaml:"thicken,omitempty"`
-	Revolve          *RevolveData          `yaml:"revolve,omitempty"`
-	Coil             *CoilData             `yaml:"coil,omitempty"`
-	Sweep            *SweepData            `yaml:"sweep,omitempty"`
-	Loft             *LoftData             `yaml:"loft,omitempty"`
-	Move             *MoveData             `yaml:"move,omitempty"`
-	Bend             *BendData             `yaml:"bend,omitempty"`
-	Decal            *DecalData            `yaml:"decal,omitempty"`
-	Reference        *ReferenceData        `yaml:"reference,omitempty"`
-	Client           *ClientData           `yaml:"client,omitempty"`
-	Mark             *MarkData             `yaml:"mark,omitempty"`
-	Finish           *FinishData           `yaml:"finish,omitempty"`
-	Import           *ImportData           `yaml:"import,omitempty"`
+
+	// Surface-editing and direct-geometry families (M10-F01..F04). These kinds were creatable but
+	// carried no codec, so a part containing one refused to marshal until #1617.
+	Trim          *TrimData          `yaml:"trim,omitempty"`
+	Extend        *ExtendData        `yaml:"extend,omitempty"`
+	SurfaceOffset *SurfaceOffsetData `yaml:"surfaceOffset,omitempty"`
+	MidSurface    *MidSurfaceData    `yaml:"midSurface,omitempty"`
+	Stitch        *StitchData        `yaml:"stitch,omitempty"`
+	Sculpt        *SculptData        `yaml:"sculpt,omitempty"`
+	Mesh          *MeshData          `yaml:"mesh,omitempty"`
+	Freeform      *FreeformData      `yaml:"freeform,omitempty"`
+	Hull          *HullData          `yaml:"hull,omitempty"`
+	CoreCavity    *CoreCavityData    `yaml:"coreCavity,omitempty"`
+
+	Thicken   *ThickenData   `yaml:"thicken,omitempty"`
+	Revolve   *RevolveData   `yaml:"revolve,omitempty"`
+	Coil      *CoilData      `yaml:"coil,omitempty"`
+	Sweep     *SweepData     `yaml:"sweep,omitempty"`
+	Loft      *LoftData      `yaml:"loft,omitempty"`
+	Move      *MoveData      `yaml:"move,omitempty"`
+	Bend      *BendData      `yaml:"bend,omitempty"`
+	Decal     *DecalData     `yaml:"decal,omitempty"`
+	Reference *ReferenceData `yaml:"reference,omitempty"`
+	Client    *ClientData    `yaml:"client,omitempty"`
+	Mark      *MarkData      `yaml:"mark,omitempty"`
+	Finish    *FinishData    `yaml:"finish,omitempty"`
+	Import    *ImportData    `yaml:"import,omitempty"`
 
 	DerivedAssembly *DerivedAssemblyData `yaml:"derivedAssembly,omitempty"`
 	DerivedPart     *DerivedPartData     `yaml:"derivedPart,omitempty"`

--- a/model/feature/serialize_codecs_directmodel.go
+++ b/model/feature/serialize_codecs_directmodel.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+// Codec registrations for the direct-geometry family (mesh / freeform / alias-freeform / hull /
+// core-cavity). Encode and decode are paired so they cannot drift (#1416); the closures call the
+// serializeX/restoreX helpers in serialize_direct_model.go. Before #1617 these kinds had no codec,
+// so a part containing any of them refused to marshal.
+
+// registerDirectModelCodecs contributes this family's codecs to the default set (#1617).
+func (r featureCodecSet) registerDirectModelCodecs() {
+	r.register("mesh", featureCodec{
+		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
+			fd.Mesh = serializeMesh(f.(*MeshFeature).Geometry())
+			return nil
+		},
+		decode: func(rc *restoreContext, fd FeatureData) (*PartFeature, error) {
+			return restoreMesh(rc.fs, fd.Mesh)
+		},
+	})
+	r.register("freeform", featureCodec{
+		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
+			fd.Freeform = serializeFreeform(f.(*FreeformFeature).FreeformBody())
+			return nil
+		},
+		decode: func(rc *restoreContext, fd FeatureData) (*PartFeature, error) {
+			return restoreFreeform(rc.fs, fd.Freeform)
+		},
+	})
+	r.register("alias-freeform", featureCodec{
+		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
+			fd.Freeform = serializeFreeform(f.(*AliasFreeformFeature).FreeformBody())
+			return nil
+		},
+		decode: func(rc *restoreContext, fd FeatureData) (*PartFeature, error) {
+			return restoreAliasFreeform(rc.fs, fd.Freeform)
+		},
+	})
+	r.register("hull", featureCodec{
+		encode: func(fd *FeatureData, _ Feature, _ SketchIndexer, _ map[ID]int) error {
+			fd.Hull = &HullData{}
+			return nil
+		},
+		decode: func(rc *restoreContext, fd FeatureData) (*PartFeature, error) {
+			return restoreHull(rc.fs, fd.Hull)
+		},
+	})
+	r.register("core-cavity", featureCodec{
+		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
+			fd.CoreCavity = serializeCoreCavity(f.(*CoreCavityFeature).Definition())
+			return nil
+		},
+		decode: func(rc *restoreContext, fd FeatureData) (*PartFeature, error) {
+			return restoreCoreCavity(rc.fs, fd.CoreCavity)
+		},
+	})
+}

--- a/model/feature/serialize_codecs_surfaceedit.go
+++ b/model/feature/serialize_codecs_surfaceedit.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+// Codec registrations for the surface-editing family (trim / extend / surface-offset / mid-surface /
+// stitch / sculpt). Encode and decode are paired so they cannot drift (#1416); the closures call the
+// serializeX/restoreX helpers in serialize_surface_edits.go. Before #1617 these kinds had no codec at
+// all, so a part containing one refused to marshal — the exact silent-drop class the registry closes.
+
+// registerSurfaceEditCodecs contributes this family's codecs to the default set (#1617).
+func (r featureCodecSet) registerSurfaceEditCodecs() {
+	r.register("trim", featureCodec{
+		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
+			fd.Trim = serializeTrim(f.(*TrimFeature).Definition())
+			return nil
+		},
+		decode: func(rc *restoreContext, fd FeatureData) (*PartFeature, error) {
+			return restoreTrim(rc.fs, fd.Trim)
+		},
+	})
+	r.register("extend", featureCodec{
+		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
+			fd.Extend = serializeExtend(f.(*ExtendFeature).Definition())
+			return nil
+		},
+		decode: func(rc *restoreContext, fd FeatureData) (*PartFeature, error) {
+			return restoreExtend(rc.fs, fd.Extend)
+		},
+	})
+	r.register("surface-offset", featureCodec{
+		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
+			fd.SurfaceOffset = serializeSurfaceOffset(f.(*SurfaceOffsetFeature).Definition())
+			return nil
+		},
+		decode: func(rc *restoreContext, fd FeatureData) (*PartFeature, error) {
+			return restoreSurfaceOffset(rc.fs, fd.SurfaceOffset)
+		},
+	})
+	r.register("mid-surface", featureCodec{
+		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
+			fd.MidSurface = serializeMidSurface(f.(*MidSurfaceFeature).Definition())
+			return nil
+		},
+		decode: func(rc *restoreContext, fd FeatureData) (*PartFeature, error) {
+			return restoreMidSurface(rc.fs, fd.MidSurface)
+		},
+	})
+	r.register("stitch", featureCodec{
+		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
+			fd.Stitch = serializeStitch(f.(*StitchFeature).Definition())
+			return nil
+		},
+		decode: func(rc *restoreContext, fd FeatureData) (*PartFeature, error) {
+			return restoreStitch(rc.fs, fd.Stitch)
+		},
+	})
+	r.register("sculpt", featureCodec{
+		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
+			s, err := serializeSculpt(f.(*SculptFeature).Definition())
+			fd.Sculpt = s
+			return err
+		},
+		decode: func(rc *restoreContext, fd FeatureData) (*PartFeature, error) {
+			return restoreSculpt(rc.fs, fd.Sculpt)
+		},
+	})
+}

--- a/model/feature/serialize_direct_model.go
+++ b/model/feature/serialize_direct_model.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+	"sort"
+
+	"oblikovati.org/kernel/subd"
+)
+
+// Serialized forms of the direct-geometry features (M10-F03/F04): mesh (imported tessellation),
+// free-form / Alias free-form (sub-D control cage), hull (OpenSCAD-style convex hull), and mold
+// core/cavity. Like the surface edits, these kinds were creatable but had no serialization codec,
+// so a part containing one refused to marshal (#1416/#1617). The sub-D cage's creases and level
+// survive the round-trip so sharp edges are not lost on reload.
+
+// MeshData is imported tessellated geometry: shared vertices and facets (each an ordered loop of
+// vertex indices). A mesh is reference geometry, so nothing else needs storing.
+type MeshData struct {
+	Vertices [][]float64 `yaml:"vertices"`
+	Facets   [][]int     `yaml:"facets"`
+}
+
+func serializeMesh(g *MeshGeometry) *MeshData {
+	return &MeshData{Vertices: encodePoints(g.Vertices), Facets: cloneFacets(g.Facets)}
+}
+
+func restoreMesh(fs *PartFeatures, d *MeshData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("mesh feature is missing its payload")
+	}
+	g := &MeshGeometry{Vertices: decodePoints(d.Vertices), Facets: cloneFacets(d.Facets)}
+	return NewMeshFeatures(fs).Add(g), nil
+}
+
+// cloneFacets deep-copies a facet list so the serialized/restored geometry does not alias the
+// live cage (facets are variable-length loops, not fixed triangles).
+func cloneFacets(facets [][]int) [][]int {
+	out := make([][]int, len(facets))
+	for i, f := range facets {
+		out[i] = append([]int(nil), f...)
+	}
+	return out
+}
+
+// CreaseData is one sub-D cage edge's crease: its undirected endpoint indices and sharpness.
+type CreaseData struct {
+	A         int     `yaml:"a"`
+	B         int     `yaml:"b"`
+	Sharpness float64 `yaml:"sharpness"`
+}
+
+// FreeformData is a sub-D free-form body's recipe: the control cage (vertices, polygon faces, and
+// creases) and the subdivision level. Shared by the freeform and alias-freeform codecs.
+type FreeformData struct {
+	Vertices [][]float64  `yaml:"vertices"`
+	Faces    [][]int      `yaml:"faces"`
+	Creases  []CreaseData `yaml:"creases,omitempty"`
+	Level    int          `yaml:"level"`
+}
+
+func serializeFreeform(b *FreeformBody) *FreeformData {
+	return &FreeformData{
+		Vertices: encodePoints(b.cage.Verts),
+		Faces:    cloneFacets(b.cage.Faces),
+		Creases:  encodeCreases(b.cage.Creases),
+		Level:    b.level,
+	}
+}
+
+// freeformCage rebuilds the sub-D cage from serialized data (both freeform kinds share it).
+func freeformCage(d *FreeformData) subd.Mesh {
+	cage := subd.Mesh{Verts: decodePoints(d.Vertices), Faces: cloneFacets(d.Faces)}
+	for _, c := range d.Creases {
+		cage.SetCrease(c.A, c.B, c.Sharpness)
+	}
+	return cage
+}
+
+func restoreFreeform(fs *PartFeatures, d *FreeformData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("freeform feature is missing its payload")
+	}
+	return NewFreeformFeatures(fs).add(freeformCage(d), d.Level), nil
+}
+
+func restoreAliasFreeform(fs *PartFeatures, d *FreeformData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("alias-freeform feature is missing its payload")
+	}
+	return NewAliasFreeformFeatures(fs).add(freeformCage(d), d.Level), nil
+}
+
+// encodeCreases flattens the crease map into a slice sorted by (a,b) so the serialized order is
+// deterministic (a map iterates in random order, which would churn the document on every save).
+func encodeCreases(creases map[[2]int]float64) []CreaseData {
+	if len(creases) == 0 {
+		return nil
+	}
+	out := make([]CreaseData, 0, len(creases))
+	for k, s := range creases {
+		out = append(out, CreaseData{A: k[0], B: k[1], Sharpness: s})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].A != out[j].A {
+			return out[i].A < out[j].A
+		}
+		return out[i].B < out[j].B
+	})
+	return out
+}
+
+// HullData is a hull's recipe. The hull is taken over the running solids with no parameters, so
+// the payload is empty — but a codec must still exist (a kind with no payload struct silently
+// dropped on save; #1416).
+type HullData struct{}
+
+func restoreHull(fs *PartFeatures, d *HullData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("hull feature is missing its payload")
+	}
+	return NewHullFeatures(fs).Add(), nil
+}
+
+// CoreCavityData is a mold split's recipe: the parting axis, its position, and the shrinkage
+// allowance (fractional oversize compensating part shrink).
+type CoreCavityData struct {
+	Axis      int     `yaml:"axis"`
+	Position  float64 `yaml:"position"`
+	Shrinkage float64 `yaml:"shrinkage"`
+}
+
+func serializeCoreCavity(def *CoreCavityDefinition) *CoreCavityData {
+	return &CoreCavityData{Axis: int(def.Axis), Position: evalFloat(def.Position), Shrinkage: def.Shrinkage}
+}
+
+func restoreCoreCavity(fs *PartFeatures, d *CoreCavityData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("core-cavity feature is missing its payload")
+	}
+	return NewCoreCavityFeatures(fs).AddByPartingPlaneFn(PartingAxis(d.Axis), constFloat(d.Position), d.Shrinkage), nil
+}

--- a/model/feature/serialize_missing_codecs_test.go
+++ b/model/feature/serialize_missing_codecs_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+)
+
+// Regression for #1617: eleven creatable feature kinds (the surface-edit and direct-geometry
+// families) carried no serialization codec, so a part containing any of them failed to marshal with
+// "no serialization codec for feature kind …" — a silent save/undo refusal. Each must now round-trip.
+
+// TestSurfaceEditCodecsRoundTrip builds one part holding every surface-edit kind, marshals and
+// restores it, and asserts each recipe's parameters survived.
+func TestSurfaceEditCodecsRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	NewTrimFeatures(fs).AddByPlane(math.P3(1, 2, 3), math.V3(0, 0, 1), true)
+	NewExtendFeatures(fs).Add([]byte("edge-key-\x00\xff"), func() float64 { return 2.5 })
+	NewSurfaceOffsetFeatures(fs).AddByDistance(func() float64 { return -1.25 })
+	NewMidSurfaceFeatures(fs).AddByThickness(4)
+	NewStitchFeatures(fs).Add(0.001, true)
+	NewSculptFeatures(fs).Add(ops.Cut, 0.002)
+
+	fresh := marshalRestore(t, fs)
+
+	trim := featAt[*TrimFeature](t, fresh, 0).Definition()
+	if trim.CutOrigin != math.P3(1, 2, 3) || trim.CutNormal != math.V3(0, 0, 1) || !trim.KeepPositive {
+		t.Errorf("restored trim = %+v, want origin (1,2,3) normal (0,0,1) keepPositive", trim)
+	}
+	ext := featAt[*ExtendFeature](t, fresh, 1).Definition()
+	if string(ext.EdgeKey) != "edge-key-\x00\xff" || ext.Distance() != 2.5 {
+		t.Errorf("restored extend key=%q dist=%g, want the original key and 2.5", ext.EdgeKey, ext.Distance())
+	}
+	if off := featAt[*SurfaceOffsetFeature](t, fresh, 2).Definition(); off.Distance() != -1.25 {
+		t.Errorf("restored surface-offset distance = %g, want -1.25", off.Distance())
+	}
+	if mid := featAt[*MidSurfaceFeature](t, fresh, 3).Definition(); mid.MaxThickness != 4 {
+		t.Errorf("restored mid-surface maxThickness = %g, want 4", mid.MaxThickness)
+	}
+	if st := featAt[*StitchFeature](t, fresh, 4).Definition(); st.Tolerance != 0.001 || !st.MaintainAsSurface {
+		t.Errorf("restored stitch = %+v, want tol 0.001 maintainAsSurface", st)
+	}
+	if sc := featAt[*SculptFeature](t, fresh, 5).Definition(); sc.Operation != ops.Cut || sc.Tolerance != 0.002 {
+		t.Errorf("restored sculpt = %+v, want op Cut tol 0.002", sc)
+	}
+}
+
+// TestDirectModelCodecsRoundTrip builds one part holding every direct-geometry kind (mesh,
+// freeform, alias-freeform, hull, core-cavity) and asserts the geometry payload survived — for the
+// sub-D cages, that the crease and subdivision level are not lost.
+func TestDirectModelCodecsRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	g := &MeshGeometry{Vertices: []math.Point3{math.P3(0, 0, 0), math.P3(1, 0, 0), math.P3(0, 1, 0)}, Facets: [][]int{{0, 1, 2}}}
+	NewMeshFeatures(fs).Add(g)
+	ff := NewFreeformFeatures(fs).AddBox(2, 2, 2, 1)
+	ff.Definition().(*FreeformFeature).FreeformBody().CreaseEdges([][2]int{{0, 1}}, 0.5)
+	NewAliasFreeformFeatures(fs).AddFromCage([]math.Point3{math.P3(0, 0, 0), math.P3(1, 0, 0), math.P3(1, 1, 0), math.P3(0, 1, 0)}, [][]int{{0, 1, 2, 3}}, 2)
+	NewHullFeatures(fs).Add()
+	NewCoreCavityFeatures(fs).AddByPartingPlane(PartingY, 3.5, 0.02)
+
+	fresh := marshalRestore(t, fs)
+
+	mesh := featAt[*MeshFeature](t, fresh, 0).Geometry()
+	if len(mesh.Vertices) != 3 || len(mesh.Facets) != 1 || len(mesh.Facets[0]) != 3 {
+		t.Errorf("restored mesh = %d verts %d facets, want 3/1", len(mesh.Vertices), len(mesh.Facets))
+	}
+	body := featAt[*FreeformFeature](t, fresh, 1).FreeformBody()
+	if body.Level() != 1 {
+		t.Errorf("restored freeform level = %d, want 1", body.Level())
+	}
+	if s := body.cage.Creases[[2]int{0, 1}]; s != 0.5 {
+		t.Errorf("restored freeform crease(0,1) = %g, want 0.5 (crease dropped on round-trip)", s)
+	}
+	if alias := featAt[*AliasFreeformFeature](t, fresh, 2).FreeformBody(); alias.Level() != 2 {
+		t.Errorf("restored alias-freeform level = %d, want 2", alias.Level())
+	}
+	if k := fresh.Item(3).Kind(); k != "hull" {
+		t.Errorf("fourth feature kind = %q, want hull", k)
+	}
+	cc := featAt[*CoreCavityFeature](t, fresh, 4).Definition()
+	if cc.Axis != PartingY || cc.Position() != 3.5 || cc.Shrinkage != 0.02 {
+		t.Errorf("restored core-cavity = axis %d pos %g shrink %g, want Y/3.5/0.02", cc.Axis, cc.Position(), cc.Shrinkage)
+	}
+}
+
+// marshalRestore projects a feature program to its serialized form and rebuilds it into a fresh
+// engine — the save→reload path under test.
+func marshalRestore(t *testing.T, fs *PartFeatures) *PartFeatures {
+	t.Helper()
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	return fresh
+}
+
+// featAt returns the i-th restored feature type-asserted to T, failing the test if the kind differs.
+func featAt[T Feature](t *testing.T, fs *PartFeatures, i int) T {
+	t.Helper()
+	f, ok := fs.Item(i).Definition().(T)
+	if !ok {
+		t.Fatalf("feature %d has type %T, want %T", i, fs.Item(i).Definition(), *new(T))
+	}
+	return f
+}

--- a/model/feature/serialize_registry.go
+++ b/model/feature/serialize_registry.go
@@ -51,6 +51,8 @@ func defaultFeatureCodecs() featureCodecSet {
 	r.registerPatternCodecs()
 	r.registerFaceEditCodecs()
 	r.registerSurfaceCodecs()
+	r.registerSurfaceEditCodecs()
+	r.registerDirectModelCodecs()
 	r.registerSheetMetalCodecs()
 	r.registerCosmeticCodecs()
 	return r

--- a/model/feature/serialize_registry_test.go
+++ b/model/feature/serialize_registry_test.go
@@ -13,7 +13,7 @@ import "testing"
 // registry must hold the full feature surface (a registration silently dropped would shrink this).
 func TestFeatureCodecRegistryComplete(t *testing.T) {
 	kinds := registeredFeatureKinds()
-	const wantAtLeast = 78 // the audited feature-kind count (#1416); grows as kinds are added
+	const wantAtLeast = 88 // the audited feature-kind count (#1416/#1617); grows as kinds are added
 	if len(kinds) < wantAtLeast {
 		t.Fatalf("registry has %d feature codecs, want at least %d — a registration was dropped", len(kinds), wantAtLeast)
 	}

--- a/model/feature/serialize_surface_edits.go
+++ b/model/feature/serialize_surface_edits.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// Serialized forms of the surface-editing features (M10-F01/F02): trim, extend, surface offset,
+// mid-surface, stitch, and sculpt. These kinds were creatable but carried no serialization codec,
+// so any part containing one failed to marshal — a save/undo silently refused to record the edit
+// ("no serialization codec for feature kind …", #1416/#1617). Each parameter-driven distance is
+// stored as its evaluated value and restored as a constant closure, the same convention the extrude
+// and dress-up codecs use.
+
+// TrimData is a surface trim's recipe: the cutting plane (origin+normal) and which side to keep.
+type TrimData struct {
+	Origin       []float64 `yaml:"origin"`
+	Normal       []float64 `yaml:"normal"`
+	KeepPositive bool      `yaml:"keepPositive"`
+}
+
+func serializeTrim(def *TrimDefinition) *TrimData {
+	return &TrimData{Origin: encodePoint3(def.CutOrigin), Normal: encodeVec3(def.CutNormal), KeepPositive: def.KeepPositive}
+}
+
+func restoreTrim(fs *PartFeatures, d *TrimData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("trim feature is missing its payload")
+	}
+	return NewTrimFeatures(fs).AddByPlane(decodePoint3(d.Origin), decodeVec3(d.Normal), d.KeepPositive), nil
+}
+
+// ExtendData is a surface extend's recipe: the boundary edge (base64 reference key) and the
+// outward distance.
+type ExtendData struct {
+	EdgeKey  string  `yaml:"edgeKey"`
+	Distance float64 `yaml:"distance"`
+}
+
+func serializeExtend(def *ExtendDefinition) *ExtendData {
+	return &ExtendData{EdgeKey: encodeKey(def.EdgeKey), Distance: evalFloat(def.Distance)}
+}
+
+func restoreExtend(fs *PartFeatures, d *ExtendData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("extend feature is missing its payload")
+	}
+	key, err := decodeKey(d.EdgeKey)
+	if err != nil {
+		return nil, fmt.Errorf("extend feature edge key: %w", err)
+	}
+	return NewExtendFeatures(fs).Add(key, constFloat(d.Distance)), nil
+}
+
+// SurfaceOffsetData is a surface offset's recipe: the offset distance along the face normal.
+type SurfaceOffsetData struct {
+	Distance float64 `yaml:"distance"`
+}
+
+func serializeSurfaceOffset(def *SurfaceOffsetDefinition) *SurfaceOffsetData {
+	return &SurfaceOffsetData{Distance: evalFloat(def.Distance)}
+}
+
+func restoreSurfaceOffset(fs *PartFeatures, d *SurfaceOffsetData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("surface-offset feature is missing its payload")
+	}
+	return NewSurfaceOffsetFeatures(fs).AddByDistance(constFloat(d.Distance)), nil
+}
+
+// MidSurfaceData is a mid-surface's recipe: the maximum thin-wall thickness a face pair may have.
+// The extracted per-pair thicknesses are a recompute result, not part of the recipe.
+type MidSurfaceData struct {
+	MaxThickness float64 `yaml:"maxThickness"`
+}
+
+func serializeMidSurface(def *MidSurfaceDefinition) *MidSurfaceData {
+	return &MidSurfaceData{MaxThickness: def.MaxThickness}
+}
+
+func restoreMidSurface(fs *PartFeatures, d *MidSurfaceData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("mid-surface feature is missing its payload")
+	}
+	return NewMidSurfaceFeatures(fs).AddByThickness(d.MaxThickness), nil
+}
+
+// StitchData is a stitch/knit's recipe: the coincidence tolerance and whether to keep a closed
+// quilt as a surface rather than promoting it to a solid.
+type StitchData struct {
+	Tolerance         float64 `yaml:"tolerance"`
+	MaintainAsSurface bool    `yaml:"maintainAsSurface"`
+}
+
+func serializeStitch(def *StitchDefinition) *StitchData {
+	return &StitchData{Tolerance: def.Tolerance, MaintainAsSurface: def.MaintainAsSurface}
+}
+
+func restoreStitch(fs *PartFeatures, d *StitchData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("stitch feature is missing its payload")
+	}
+	return NewStitchFeatures(fs).Add(d.Tolerance, d.MaintainAsSurface), nil
+}
+
+// SculptData is a sculpt's recipe: the boolean operation against existing material and the
+// coincidence tolerance for closing the bounding surfaces.
+type SculptData struct {
+	Operation string  `yaml:"operation"`
+	Tolerance float64 `yaml:"tolerance"`
+}
+
+func serializeSculpt(def *SculptDefinition) (*SculptData, error) {
+	op, err := operationName(def.Operation)
+	if err != nil {
+		return nil, err
+	}
+	return &SculptData{Operation: op, Tolerance: def.Tolerance}, nil
+}
+
+func restoreSculpt(fs *PartFeatures, d *SculptData) (*PartFeature, error) {
+	if d == nil {
+		return nil, fmt.Errorf("sculpt feature is missing its payload")
+	}
+	op, err := parseOperation(d.Operation)
+	if err != nil {
+		return nil, fmt.Errorf("sculpt feature operation: %w", err)
+	}
+	return NewSculptFeatures(fs).Add(op, d.Tolerance), nil
+}


### PR DESCRIPTION
## Problem

Eleven creatable feature kinds had a `Kind()` but **no serialization codec**:

- **Surface edits:** `trim`, `extend`, `surface-offset`, `mid-surface`, `stitch`, `sculpt`
- **Direct geometry:** `mesh`, `freeform`, `alias-freeform`, `hull`, `core-cavity`

Any part containing one refused to marshal — `MarshalRecipe` returned `no serialization codec for feature kind …`, so **Save and every undo snapshot of that part failed** (the engine refuses to record rather than silently drop, protecting the model). This is the silent-drop class the #1416/#1617 codec registry exists to prevent, but the registry can only guarantee encode+decode are *paired* — it cannot force a brand-new kind to have a codec at all. The MCPBridge `TestE2EFeatureRegistryCoverage` end-to-end test is the enforcement that every creatable kind round-trips, and it caught these (visible as a cascade of `undo: recording an edit failed for "Part1": … no serialization codec for feature kind "mesh"/"freeform"/"hull"/…` in the bridge CI).

## Fix

A paired encode/decode codec per kind, following the existing family pattern:

- Parameter-driven distances are stored as their evaluated value and restored as a constant closure (the extrude/dress-up convention).
- Sub-D free-form cages carry their **creases and subdivision level** through the round-trip, so sharp edges survive a reload. `AliasFreeform`'s crease-free `AddFromCage` now routes through a shared private constructor so restore can rebuild a full cage.
- The registry coverage floor moves 78 → 88.

## Tests

`TestSurfaceEditCodecsRoundTrip` and `TestDirectModelCodecsRoundTrip` build a part holding every new kind, marshal→restore, and assert each recipe (and the cage crease/level) survives. Full `go build ./...`, `go test ./model/feature/... ./model/compdef/... ./persistence/...`, and `golangci-lint` pass locally.

Unblocks the MCPBridge feature-registry-coverage e2e (a precondition for the G2 bridge/API PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)