### PR TITLE
M40 I8: unify exchange format routing behind a DrawingDecoder registry

### DIFF
--- a/model/exchange/dispatch.go
+++ b/model/exchange/dispatch.go
@@ -6,12 +6,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/exchange"
-	"oblikovati.org/kernel/exchange/meshio"
-	"oblikovati.org/kernel/exchange/step"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/param"
@@ -64,20 +61,14 @@ func Export(part *compdef.PartComponentDefinition, path string, format types.Exc
 	if len(bodies) == 0 {
 		return ExportResult{}, fmt.Errorf("export %q: part has no bodies", path)
 	}
-	var (
-		data  []byte
-		tris  int
-		warns []string
-		err   error
-	)
-	switch {
-	case format.IsMesh():
-		data, tris, err = meshio.ExportBodies(format, bodies, res, exportUnits(part))
-	case format == types.FormatSTEP:
-		data, warns, err = step.Writer{}.ExportSolids(bodies, exportUnits(part))
-	default:
+	// Registry lookup instead of a format switch: the export capability registers with the
+	// format's extensions in format_routes.go, so menu recognition and dispatch cannot
+	// drift (#1631, audit I8).
+	route, ok := formatRoutes.byFormat[format]
+	if !ok || route.exportBodies == nil {
 		return ExportResult{}, fmt.Errorf("export: unsupported format %q (want stl|obj|3mf|step)", format)
 	}
+	data, tris, warns, err := route.exportBodies(bodies, res, exportUnits(part))
 	if err != nil {
 		return ExportResult{}, fmt.Errorf("export %q: %w", path, err)
 	}
@@ -108,24 +99,8 @@ func workingUnitMM(part *compdef.PartComponentDefinition) float64 {
 
 // FormatFromPath infers the exchange format from a file's extension (case-insensitive), so the
 // File ▸ Import/Export menu can route by what the user typed. The bool is false for an unknown
-// extension.
+// extension. It is a lookup over the same registry the dispatchers use (format_routes.go), so
+// an extension this recognizes always has a routed format behind it (#1631, audit I8).
 func FormatFromPath(path string) (types.ExchangeFormat, bool) {
-	switch strings.ToLower(filepath.Ext(path)) {
-	case ".stl":
-		return types.FormatSTL, true
-	case ".obj":
-		return types.FormatOBJ, true
-	case ".3mf":
-		return types.Format3MF, true
-	case ".step", ".stp":
-		return types.FormatSTEP, true
-	case ".dwg":
-		return types.FormatDWG, true
-	case ".dxf":
-		return types.FormatDXF, true
-	case ".pdf":
-		return types.FormatPDF, true
-	default:
-		return "", false
-	}
+	return formatForExtension(filepath.Ext(path))
 }

--- a/model/exchange/drawing_decoder.go
+++ b/model/exchange/drawing_decoder.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package exchange
+
+import (
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/exchange/drawing"
+	"oblikovati.org/kernel/exchange/dwg"
+	"oblikovati.org/kernel/exchange/dxf"
+	"oblikovati.org/kernel/exchange/pdf"
+)
+
+// DrawingDecoder is one drawing format's decode entry (#1631, audit I8): the format it
+// serves, the file extensions it claims, and the decode from raw bytes to the format-neutral
+// drawing model every importer shares (sketch_from_drawing.go). Format identity, extensions
+// and decode travel together through one registration (format_routes.go), so the format
+// dispatch and the extension mapping — formerly two independently maintained switches — can
+// never drift apart (the #1416 shape: a format the menu recognized but the dispatch refused).
+type DrawingDecoder interface {
+	// Format names the exchange format this decoder serves; it must be a sketch
+	// format (types.ExchangeFormat.IsSketch), enforced at registry construction.
+	Format() types.ExchangeFormat
+	// Extensions lists the file extensions (lowercase, dot-prefixed: ".dwg") the
+	// format is recognized by.
+	Extensions() []string
+	// Decode parses src into format-neutral drawings: one for a single-model file
+	// (DWG/DXF), one per page for a paged plot set (PDF). The warnings are
+	// per-entity decode notes; err is a hard parse failure.
+	Decode(src []byte) ([]*drawing.Drawing, []string, error)
+}
+
+// dwgDrawingDecoder wraps the clean-room DWG codec (kernel/exchange/dwg).
+type dwgDrawingDecoder struct{}
+
+func (dwgDrawingDecoder) Format() types.ExchangeFormat { return types.FormatDWG }
+func (dwgDrawingDecoder) Extensions() []string         { return []string{".dwg"} }
+func (dwgDrawingDecoder) Decode(src []byte) ([]*drawing.Drawing, []string, error) {
+	dr, warns, err := dwg.Decode(src)
+	if err != nil {
+		return nil, nil, err
+	}
+	return []*drawing.Drawing{dr}, warns, nil
+}
+
+// dxfDrawingDecoder wraps the ASCII DXF codec (kernel/exchange/dxf).
+type dxfDrawingDecoder struct{}
+
+func (dxfDrawingDecoder) Format() types.ExchangeFormat { return types.FormatDXF }
+func (dxfDrawingDecoder) Extensions() []string         { return []string{".dxf"} }
+func (dxfDrawingDecoder) Decode(src []byte) ([]*drawing.Drawing, []string, error) {
+	dr, warns, err := dxf.Decode(src)
+	if err != nil {
+		return nil, nil, err
+	}
+	return []*drawing.Drawing{dr}, warns, nil
+}
+
+// pdfDrawingDecoder wraps the vector-PDF page decoder (kernel/exchange/pdf). A PDF plot
+// set decodes to one drawing per page, so its entry shape is the general one — the
+// single-drawing formats are the one-element case.
+type pdfDrawingDecoder struct{}
+
+func (pdfDrawingDecoder) Format() types.ExchangeFormat { return types.FormatPDF }
+func (pdfDrawingDecoder) Extensions() []string         { return []string{".pdf"} }
+func (pdfDrawingDecoder) Decode(src []byte) ([]*drawing.Drawing, []string, error) {
+	return pdf.DecodePages(src)
+}
+
+// Each drawing codec must satisfy the decode seam it is registered under.
+var (
+	_ DrawingDecoder = dwgDrawingDecoder{}
+	_ DrawingDecoder = dxfDrawingDecoder{}
+	_ DrawingDecoder = pdfDrawingDecoder{}
+)

--- a/model/exchange/dwgimport.go
+++ b/model/exchange/dwgimport.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	"oblikovati.org/kernel/exchange/dwg"
+	"oblikovati.org/api/types"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/sketch"
 )
@@ -37,18 +37,13 @@ type DWGImportResult = SketchImportResult
 
 // ImportDWG decodes DWG bytes and adds their geometry to part. A planar drawing becomes a
 // 2D Sketch on plane (the world origin mapping to the plane origin, per the caller's chosen
-// work plane); a non-planar drawing becomes a Sketch3D and plane is ignored. The decode and
-// the sketch conversion are shared with every drawing format (see sketch_from_drawing.go);
-// only the dwg.Decode call is DWG-specific.
+// work plane); a non-planar drawing becomes a Sketch3D and plane is ignored. The whole path
+// is shared with every drawing format: the registered [DrawingDecoder] decodes, and
+// importSketchFormat places the result (#1631, audit I8).
 //
 // Example:
 //
 //	res, err := exchange.ImportDWG(part, data, workPlane.Plane())
 func ImportDWG(part *compdef.PartComponentDefinition, data []byte, plane sketch.Plane) (DWGImportResult, error) {
-	dr, warns, err := dwg.Decode(data)
-	if err != nil {
-		return DWGImportResult{}, fmt.Errorf("import dwg: %w", err)
-	}
-	imp := importDrawing(part, dr, plane)
-	return DWGImportResult{Is3D: imp.is3D, EntityCount: imp.entityCount, Warnings: append(warns, imp.warnings...)}, nil
+	return importSketchFormat(part, types.FormatDWG, data, plane)
 }

--- a/model/exchange/format_routes.go
+++ b/model/exchange/format_routes.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package exchange
+
+import (
+	"fmt"
+	"strings"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/exchange"
+	"oblikovati.org/kernel/exchange/meshio"
+	"oblikovati.org/kernel/exchange/step"
+	"oblikovati.org/kernel/topo"
+)
+
+// Exchange format routing is one registry (#1631, audit I8): each format registers its
+// extensions and its capabilities (a drawing decode entry, a body export entry) together,
+// replacing the two hand-maintained switches in dispatch.go — the format dispatch and the
+// FormatFromPath extension map — whose independent upkeep let a format be recognized from
+// the menu yet refused at import (the #1416 drift class). The set is built by ONE visible
+// construction (defaultFormatRoutes; no init() registration, matching the feature-codec
+// registry's #1617 discipline), and registration panics on a duplicate format or extension.
+
+// exportBodiesFunc writes bodies to a format's byte encoding: data, triangle count (0 for an
+// exact B-rep write), warnings, error — the body-export capability of a formatRoute.
+type exportBodiesFunc func(bodies []*topo.Body, res types.MeshResolution, opts exchange.TranslationOptions) ([]byte, int, []string, error)
+
+// formatRoute is everything the dispatcher knows about one exchange format: the extensions
+// it is recognized by, and its optional capabilities. A sketch (drawing) format carries its
+// decoder; a body format carries its exporter. Both are registered in the same call, so
+// extension recognition and dispatch cannot drift.
+type formatRoute struct {
+	format       types.ExchangeFormat
+	extensions   []string
+	decoder      DrawingDecoder   // non-nil exactly for sketch formats
+	exportBodies exportBodiesFunc // non-nil for formats Export can write
+}
+
+// formatRouteSet indexes the routes by format and by extension — the seam FormatFromPath,
+// Export and the drawing importers all consult.
+type formatRouteSet struct {
+	byFormat    map[types.ExchangeFormat]formatRoute
+	byExtension map[string]types.ExchangeFormat
+}
+
+// register records one format's route, panicking on a duplicate format or extension and on
+// a capability/format mismatch — programming errors caught at construction, not silent
+// menu-vs-dispatch drift at runtime.
+func (s *formatRouteSet) register(r formatRoute) {
+	if _, dup := s.byFormat[r.format]; dup {
+		panic(fmt.Sprintf("exchange: format %q registered twice", r.format))
+	}
+	if r.format.IsSketch() != (r.decoder != nil) {
+		panic(fmt.Sprintf("exchange: format %q IsSketch=%v but decoder present=%v — a sketch format needs exactly one DrawingDecoder", r.format, r.format.IsSketch(), r.decoder != nil))
+	}
+	s.byFormat[r.format] = r
+	s.registerExtensions(r)
+}
+
+// registerExtensions claims the route's extensions, panicking when one is already taken.
+func (s *formatRouteSet) registerExtensions(r formatRoute) {
+	for _, ext := range r.extensions {
+		if owner, dup := s.byExtension[ext]; dup {
+			panic(fmt.Sprintf("exchange: extension %q registered by both %q and %q", ext, owner, r.format))
+		}
+		s.byExtension[ext] = r.format
+	}
+}
+
+// registerDrawing wraps a DrawingDecoder as a route — format, extensions and decode
+// entry travel as one unit, the seam the next drawing importer registers through.
+func (s *formatRouteSet) registerDrawing(d DrawingDecoder) {
+	s.register(formatRoute{format: d.Format(), extensions: d.Extensions(), decoder: d})
+}
+
+// formatRoutes is the package's composition site: every production format, in one visible
+// order. Adding an importer/exporter is one registration here plus its own package.
+var formatRoutes = defaultFormatRoutes()
+
+// defaultFormatRoutes assembles the full production route set: the mesh formats, STEP, and
+// the drawing formats (DWG/DXF/PDF).
+func defaultFormatRoutes() *formatRouteSet {
+	s := &formatRouteSet{byFormat: map[types.ExchangeFormat]formatRoute{}, byExtension: map[string]types.ExchangeFormat{}}
+	for _, f := range []types.ExchangeFormat{types.FormatSTL, types.FormatOBJ, types.Format3MF} {
+		s.register(formatRoute{format: f, extensions: []string{"." + string(f)}, exportBodies: meshExportRoute(f)})
+	}
+	s.register(formatRoute{format: types.FormatSTEP, extensions: []string{".step", ".stp"}, exportBodies: stepExportRoute})
+	s.registerDrawing(dwgDrawingDecoder{})
+	s.registerDrawing(dxfDrawingDecoder{})
+	s.registerDrawing(pdfDrawingDecoder{})
+	return s
+}
+
+// meshExportRoute adapts the mesh translator to the export capability for one mesh format.
+func meshExportRoute(f types.ExchangeFormat) exportBodiesFunc {
+	return func(bodies []*topo.Body, res types.MeshResolution, opts exchange.TranslationOptions) ([]byte, int, []string, error) {
+		data, tris, err := meshio.ExportBodies(f, bodies, res, opts)
+		return data, tris, nil, err
+	}
+}
+
+// stepExportRoute adapts the STEP writer (exact B-rep; resolution ignored) to the export
+// capability.
+func stepExportRoute(bodies []*topo.Body, _ types.MeshResolution, opts exchange.TranslationOptions) ([]byte, int, []string, error) {
+	data, warns, err := step.Writer{}.ExportSolids(bodies, opts)
+	return data, 0, warns, err
+}
+
+// drawingDecoderFor returns the registered decoder for a sketch format; ok is false for a
+// format with no drawing decode entry.
+func drawingDecoderFor(format types.ExchangeFormat) (DrawingDecoder, bool) {
+	r, ok := formatRoutes.byFormat[format]
+	if !ok || r.decoder == nil {
+		return nil, false
+	}
+	return r.decoder, true
+}
+
+// formatForExtension resolves a lowercase dot-prefixed extension (".dwg") to its registered
+// format — the one lookup behind FormatFromPath.
+func formatForExtension(ext string) (types.ExchangeFormat, bool) {
+	f, ok := formatRoutes.byExtension[strings.ToLower(ext)]
+	return f, ok
+}

--- a/model/exchange/format_routes_test.go
+++ b/model/exchange/format_routes_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package exchange
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/api/types"
+)
+
+// Audit I8 (#1631): format routing is one registry, not two hand-maintained switches. These tests
+// lock the anti-drift guarantee — a format recognized by extension is also dispatchable, and the
+// two can never diverge (the #1416 class: a menu-offered format the dispatch then refuses).
+
+// TestEverySketchFormatHasADecoder is the parity that made the two-switch design fragile: every
+// format that reports IsSketch must carry a registered DrawingDecoder, or a file the menu accepts
+// falls through to "no drawing decoder" at import time.
+func TestEverySketchFormatHasADecoder(t *testing.T) {
+	for _, f := range []types.ExchangeFormat{types.FormatDWG, types.FormatDXF, types.FormatPDF} {
+		if !f.IsSketch() {
+			t.Errorf("%q should report IsSketch (it is a drawing format)", f)
+		}
+		if _, ok := drawingDecoderFor(f); !ok {
+			t.Errorf("sketch format %q has no registered DrawingDecoder — the menu would offer it and import would refuse it", f)
+		}
+	}
+}
+
+// TestDecodersAgreeWithTheirFormat: a decoder registered under a format must claim that format and a
+// sketch format, and its extensions must resolve back to it — the round-trip that keeps FormatFromPath
+// and dispatch in lockstep.
+func TestDecodersAgreeWithTheirFormat(t *testing.T) {
+	for _, d := range []DrawingDecoder{dwgDrawingDecoder{}, dxfDrawingDecoder{}, pdfDrawingDecoder{}} {
+		if !d.Format().IsSketch() {
+			t.Errorf("decoder %T serves %q, which is not a sketch format", d, d.Format())
+		}
+		for _, ext := range d.Extensions() {
+			if ext != strings.ToLower(ext) || !strings.HasPrefix(ext, ".") {
+				t.Errorf("decoder %T extension %q must be lowercase and dot-prefixed", d, ext)
+			}
+			if f, ok := formatForExtension(ext); !ok || f != d.Format() {
+				t.Errorf("extension %q resolves to (%q, %v), want %q", ext, f, ok, d.Format())
+			}
+		}
+	}
+}
+
+// TestFormatFromPathRoutesEveryRegisteredExtension: FormatFromPath is now a registry lookup, so every
+// extension the registry knows resolves (case-insensitively) and an unknown extension is rejected.
+func TestFormatFromPathRoutesEveryRegisteredExtension(t *testing.T) {
+	for ext, want := range formatRoutes.byExtension {
+		if got, ok := FormatFromPath("drawing" + strings.ToUpper(ext)); !ok || got != want {
+			t.Errorf("FormatFromPath(%q) = (%q, %v), want %q", ext, got, ok, want)
+		}
+	}
+	if f, ok := FormatFromPath("mystery.zzz"); ok {
+		t.Errorf("FormatFromPath(unknown) = (%q, true), want not-found", f)
+	}
+}
+
+// TestRegisterRejectsDuplicateFormatAndExtension is the decisive guard: a second route claiming an
+// already-registered format or extension panics at construction, so a copy-paste registration cannot
+// silently shadow another format.
+func TestRegisterRejectsDuplicateFormatAndExtension(t *testing.T) {
+	assertPanics(t, "duplicate format", func() {
+		s := &formatRouteSet{byFormat: map[types.ExchangeFormat]formatRoute{}, byExtension: map[string]types.ExchangeFormat{}}
+		s.registerDrawing(dwgDrawingDecoder{})
+		s.registerDrawing(dwgDrawingDecoder{}) // same format again
+	})
+	assertPanics(t, "duplicate extension", func() {
+		s := &formatRouteSet{byFormat: map[types.ExchangeFormat]formatRoute{}, byExtension: map[string]types.ExchangeFormat{}}
+		s.register(formatRoute{format: types.FormatDWG, extensions: []string{".shared"}, decoder: dwgDrawingDecoder{}})
+		s.register(formatRoute{format: types.FormatDXF, extensions: []string{".shared"}, decoder: dxfDrawingDecoder{}})
+	})
+	assertPanics(t, "sketch format without decoder", func() {
+		s := &formatRouteSet{byFormat: map[types.ExchangeFormat]formatRoute{}, byExtension: map[string]types.ExchangeFormat{}}
+		s.register(formatRoute{format: types.FormatDWG, extensions: []string{".dwg"}}) // sketch format, no decoder
+	})
+}
+
+// assertPanics fails the named case unless fn panics.
+func assertPanics(t *testing.T, name string, fn func()) {
+	t.Helper()
+	defer func() {
+		if recover() == nil {
+			t.Errorf("%s: expected a panic, got none", name)
+		}
+	}()
+	fn()
+}

--- a/model/exchange/sketch_from_drawing.go
+++ b/model/exchange/sketch_from_drawing.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/exchange/drawing"
 	gmath "oblikovati.org/math"
 	"oblikovati.org/model/compdef"
@@ -30,6 +31,30 @@ type drawingImport struct {
 	is3D        bool
 	entityCount int
 	warnings    []string
+}
+
+// importSketchFormat is the one entry every drawing-format import goes through (#1631,
+// audit I8): it looks up the format's registered [DrawingDecoder] (format_routes.go),
+// decodes the bytes into one drawing per model/page, and places each on the part via
+// importDrawing. The format wrappers (ImportDWG/ImportDXF/ImportPDF) are one-line
+// delegations, so adding a drawing format is a decoder registration, not a new entry shape.
+func importSketchFormat(part *compdef.PartComponentDefinition, format types.ExchangeFormat, data []byte, plane sketch.Plane) (SketchImportResult, error) {
+	dec, ok := drawingDecoderFor(format)
+	if !ok {
+		return SketchImportResult{}, fmt.Errorf("import %s: no drawing decoder registered (want dwg|dxf|pdf)", format)
+	}
+	drawings, warns, err := dec.Decode(data)
+	if err != nil {
+		return SketchImportResult{}, fmt.Errorf("import %s: %w", format, err)
+	}
+	res := SketchImportResult{Warnings: warns}
+	for _, dr := range drawings {
+		imp := importDrawing(part, dr, plane)
+		res.EntityCount += imp.entityCount
+		res.Is3D = res.Is3D || imp.is3D
+		res.Warnings = append(res.Warnings, imp.warnings...)
+	}
+	return res, nil
 }
 
 // importDrawing scales a decoded drawing into the part's database unit and adds it as a 2D


### PR DESCRIPTION
Format routing lived in two independently maintained switches in `model/exchange/dispatch.go` — the format dispatch and the `FormatFromPath` extension map — over the same set of formats. That is the **#1416 drift class** verbatim: a format added to one switch but not the other is offered by the menu and then refused at import. PDF's divergent entry shape also meant drawing importers could not be treated uniformly.

## Fix

One registry (`format_routes.go`) carries each format's extensions and capabilities together:
- a `DrawingDecoder` for sketch formats (DWG/DXF/PDF — PDF's per-page plot set is the general shape the single-drawing formats specialize as the one-element case);
- a body-export entry for mesh/STEP.

`register` panics on a duplicate format, a duplicate extension, or an `IsSketch`/decoder mismatch, so menu-vs-dispatch drift is caught at construction rather than at a user's import. Both switches are deleted; `FormatFromPath` and the drawing-import path are registry lookups. Adding a format is now one registration plus its own codec package — the same discipline as the feature-codec registry (#1617).

## Tests

`format_routes_test.go` locks the anti-drift guarantee: every sketch format has a decoder, decoders agree with their format and extensions round-trip through `FormatFromPath`, and duplicate-format/duplicate-extension/sketch-without-decoder registrations panic. Full `go build ./...`, `go test ./model/exchange/...`, and `golangci-lint` pass locally.

Closes #1631

🤖 Generated with [Claude Code](https://claude.com/claude-code)