### PR TITLE
M40 S3: surface mesh-import weld/unit failures as ImportResult warnings

### DIFF
--- a/kernel/exchange/meshio/dispatch.go
+++ b/kernel/exchange/meshio/dispatch.go
@@ -42,19 +42,32 @@ func ImportBody(format types.ExchangeFormat, data []byte, feat string, weldTol f
 	if err != nil {
 		return nil, nil, err
 	}
-	scaleRaw(&raw, opts.ImportScale(importFileUnitMM(format, data)))
-	return SolidOrSurface(raw, feat, weldTol)
+	fileUnitMM, unitWarns := importFileUnitMM(format, data)
+	scaleRaw(&raw, opts.ImportScale(fileUnitMM))
+	body, warns, err := SolidOrSurface(raw, feat, weldTol)
+	if err != nil {
+		return nil, nil, err
+	}
+	return body, append(unitWarns, warns...), nil
 }
 
-// importFileUnitMM is the millimetre size of the file's length unit on import:
-// STL/OBJ are unitless (millimetre convention); 3MF declares its unit, read here.
-func importFileUnitMM(format types.ExchangeFormat, data []byte) float64 {
-	if format == types.Format3MF {
-		if mm, ok := mmPer3MFUnit[read3MFUnit(data)]; ok {
-			return mm
-		}
+// importFileUnitMM is the millimetre size of the file's length unit on import, plus any
+// warning about how it was resolved: STL/OBJ are unitless (millimetre convention); 3MF
+// declares its unit, read here. An unrecognised (non-empty) 3MF unit spelling falls back to
+// millimetre WITH a warning so the user is not silently handed a wrong-scale mesh (#1638); an
+// absent unit is the 3MF spec default (millimetre) and warns nothing.
+func importFileUnitMM(format types.ExchangeFormat, data []byte) (float64, []string) {
+	if format != types.Format3MF {
+		return 1, nil // STL/OBJ are unitless — millimetre convention
 	}
-	return 1 // mm
+	unit := read3MFUnit(data)
+	if mm, ok := mmPer3MFUnit[unit]; ok {
+		return mm, nil
+	}
+	if unit == "" {
+		return 1, nil // absent unit → 3MF spec default is millimetre
+	}
+	return 1, []string{fmt.Sprintf("3MF declares unknown unit %q; imported as millimetres", unit)}
 }
 
 // ExportBody tessellates a body at the given resolution and encodes it in the given

--- a/kernel/exchange/meshio/meshio_test.go
+++ b/kernel/exchange/meshio/meshio_test.go
@@ -40,7 +40,7 @@ func cubeSoup(s float64) RawMesh {
 
 func TestWeldCollapsesCoincidentVertices(t *testing.T) {
 	raw := cubeSoup(1) // 12 triangles × 3 = 36 repeated vertices
-	cage := Weld(raw, DefaultWeldTolerance)
+	cage, _ := Weld(raw, DefaultWeldTolerance)
 	if len(cage.Verts) != 8 {
 		t.Errorf("welded vertices = %d, want 8 (a cube has 8 corners)", len(cage.Verts))
 	}

--- a/kernel/exchange/meshio/tobody.go
+++ b/kernel/exchange/meshio/tobody.go
@@ -21,12 +21,18 @@ import (
 //
 //	body, warns := meshio.SolidOrSurface(raw, "import:stl#0", meshio.DefaultWeldTolerance)
 func SolidOrSurface(raw RawMesh, feat string, weldTol float64) (*topo.Body, []string, error) {
-	cage := Weld(raw, weldTol)
+	cage, dropped := Weld(raw, weldTol)
 	if len(cage.Faces) == 0 {
 		return nil, nil, fmt.Errorf("mesh import: no non-degenerate triangles in %d-triangle soup", raw.TriangleCount())
 	}
+	var warns []string
+	if dropped > 0 {
+		// Dropped triangles are discarded geometry — surface them like the DWG decoder's
+		// per-entity warnings instead of thinning the mesh silently (#1638).
+		warns = append(warns, fmt.Sprintf("%d of %d triangles were degenerate after welding and were dropped", dropped, raw.TriangleCount()))
+	}
 	body := orientedBody(cage, feat)
-	return body, validateWarnings(body), nil
+	return body, append(warns, validateWarnings(body)...), nil
 }
 
 // orientedBody builds the body and rebuilds it face-reversed if it came out inside-out

--- a/kernel/exchange/meshio/warnings_test.go
+++ b/kernel/exchange/meshio/warnings_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package meshio
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"oblikovati.org/kernel/exchange"
+	"oblikovati.org/math"
+)
+
+// Mesh-import warning tests (M40 audit S3, #1638): every weld/validation decision that discards
+// or degrades geometry surfaces as an ImportResult warning naming the offending entity and value,
+// matching the DWG decoder's warn-and-continue policy — no silent drops.
+
+// TestSolidOrSurfaceWarnsOnDroppedDegenerateTriangles: a soup with degenerate triangles imports
+// the good geometry and reports how many triangles were dropped, instead of silently thinning.
+func TestSolidOrSurfaceWarnsOnDroppedDegenerateTriangles(t *testing.T) {
+	raw := cubeSoup(2)
+	// Two degenerate triangles: a repeated corner and three collinear-welded points.
+	raw.AddTriangle(math.P3(0, 0, 0), math.P3(0, 0, 0), math.P3(2, 0, 0))
+	raw.AddTriangle(math.P3(0, 0, 0), math.P3(0, 0, 0), math.P3(0, 2, 0))
+	body, warns, err := SolidOrSurface(raw, "import:test#0", DefaultWeldTolerance)
+	if err != nil {
+		t.Fatalf("SolidOrSurface: %v", err)
+	}
+	if !body.IsSolid() {
+		t.Fatalf("cube with extra degenerate triangles should still weld into a solid; warns=%v", warns)
+	}
+	want := fmt.Sprintf("2 of %d triangles", raw.TriangleCount())
+	if len(warns) != 1 || !strings.Contains(warns[0], want) || !strings.Contains(warns[0], "degenerate") {
+		t.Errorf("warns = %v, want one naming %q dropped as degenerate", warns, want)
+	}
+}
+
+// TestSolidOrSurfaceCleanSoupHasZeroWarnings: the regression guard — a clean watertight soup
+// imports without any warning (#1638).
+func TestSolidOrSurfaceCleanSoupHasZeroWarnings(t *testing.T) {
+	_, warns, err := SolidOrSurface(cubeSoup(2), "import:test#0", DefaultWeldTolerance)
+	if err != nil {
+		t.Fatalf("SolidOrSurface: %v", err)
+	}
+	if len(warns) != 0 {
+		t.Errorf("clean cube import warns = %v, want none", warns)
+	}
+}
+
+// threeMFWithUnit assembles a minimal valid 3MF (ZIP + model XML) of one triangle, declaring the
+// given unit spelling — a named fake for the on-disk container.
+func threeMFWithUnit(t *testing.T, unit string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	w, err := zw.Create("3D/3dmodel.model")
+	if err != nil {
+		t.Fatal(err)
+	}
+	xml := fmt.Sprintf(`<?xml version="1.0"?>
+<model unit=%q xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+ <resources><object id="1" type="model"><mesh>
+  <vertices><vertex x="0" y="0" z="0"/><vertex x="10" y="0" z="0"/><vertex x="0" y="10" z="0"/></vertices>
+  <triangles><triangle v1="0" v2="1" v3="2"/></triangles>
+ </mesh></object></resources>
+</model>`, unit)
+	if _, err := w.Write([]byte(xml)); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// TestImportBodyWarnsOnUnknown3MFUnit: an unrecognised 3MF unit spelling falls back to
+// millimetres WITH a warning naming the offending value — no silent wrong-scale import (#1638).
+func TestImportBodyWarnsOnUnknown3MFUnit(t *testing.T) {
+	data := threeMFWithUnit(t, "parsec")
+	_, warns, err := ImportBody("3mf", data, "import:3mf#0", 0, exchange.TranslationOptions{TargetUnitMM: 10})
+	if err != nil {
+		t.Fatalf("ImportBody: %v", err)
+	}
+	joined := strings.Join(warns, "; ")
+	if !strings.Contains(joined, "parsec") || !strings.Contains(joined, "millimet") {
+		t.Errorf("warns = %v, want one naming the unknown unit \"parsec\" and the millimetre fallback", warns)
+	}
+}
+
+// TestImportBodyKnown3MFUnitNoUnitWarning: a spec unit spelling scales silently (the warning is
+// only for the unknown-value fallback).
+func TestImportBodyKnown3MFUnitNoUnitWarning(t *testing.T) {
+	data := threeMFWithUnit(t, "meter")
+	body, warns, err := ImportBody("3mf", data, "import:3mf#0", 0, exchange.TranslationOptions{TargetUnitMM: 10})
+	if err != nil {
+		t.Fatalf("ImportBody: %v", err)
+	}
+	for _, w := range warns {
+		if strings.Contains(w, "unit") {
+			t.Errorf("unexpected unit warning for a spec spelling: %q", w)
+		}
+	}
+	// 10 m in file units = 1000 database cm — proof the declared unit was honored.
+	if got := float64(body.RangeBox().Max.X); got != 1000 {
+		t.Errorf("meter-unit vertex X = %v database units, want 1000", got)
+	}
+}

--- a/kernel/exchange/meshio/weld.go
+++ b/kernel/exchange/meshio/weld.go
@@ -18,25 +18,28 @@ const DefaultWeldTolerance = 1e-6
 // subd.Mesh whose faces (triangles) reference the shared vertices — the form
 // subd.ToBody welds into a B-rep. A watertight soup welds into a cage whose every edge
 // is shared by two faces (⇒ a solid body); an open soup keeps boundary edges (⇒ a
-// surface body). Degenerate triangles (two welded corners coincide) are dropped.
+// surface body). Degenerate triangles (two welded corners coincide) are dropped;
+// dropped reports how many, so the importer warns instead of thinning the mesh
+// silently (#1638).
 //
 // Example:
 //
-//	cage := meshio.Weld(raw, meshio.DefaultWeldTolerance)
+//	cage, dropped := meshio.Weld(raw, meshio.DefaultWeldTolerance)
 //	body := subd.ToBody(cage, "import:stl#0")
-func Weld(raw RawMesh, tol float64) subd.Mesh {
+func Weld(raw RawMesh, tol float64) (cage subd.Mesh, dropped int) {
 	if tol <= 0 {
 		tol = DefaultWeldTolerance
 	}
-	cage := subd.Mesh{}
 	index := map[[3]int64]int{}
 	for _, tri := range raw.Tris {
 		face := weldFace(raw, tri, tol, &cage, index)
-		if face != nil {
-			cage.Faces = append(cage.Faces, face)
+		if face == nil {
+			dropped++
+			continue
 		}
+		cage.Faces = append(cage.Faces, face)
 	}
-	return cage
+	return cage, dropped
 }
 
 // weldFace welds a triangle's three corners into cage, returning its shared-vertex loop


### PR DESCRIPTION
Mesh import (`kernel/exchange/meshio`) degraded **silently** where the drawing importers warn: `Weld` dropped degenerate triangles and an unrecognised 3MF unit fell back to millimetres with no indication. A user could import an STL/3MF, see a body, and trust a mesh that was quietly thinned or wrong-scaled — corrupting every downstream consumer (mass properties, booleans, export) undiagnosably. The audit's importer matrix: *"warnings everywhere except meshes."*

## Fix (the DWG policy, exactly)

- `Weld` now reports how many triangles it dropped; `SolidOrSurface` turns that into an `ImportResult` warning naming the count, alongside the existing watertight→surface demotion warning.
- `importFileUnitMM` warns on a **non-empty** unrecognised 3MF unit spelling (naming the offending value and the millimetre fallback); an **absent** unit stays the silent 3MF spec default.
- Warnings ride the same `ImportResult.Warnings` slot the DWG/DXF/PDF paths already fill, so the head and the wire API surface them uniformly. Recoverable degradations warn; only *no usable geometry* stays a hard error.

## Tests

`warnings_test.go` pins four distinct cases — dropped degenerate triangles (named count), unknown 3MF unit (`"parsec"` + millimetre fallback), a known unit scaling silently, and a clean watertight soup with **zero** warnings (the regression guard). Full `go build ./...`, `go test ./kernel/exchange/meshio/... ./model/exchange/...`, and `golangci-lint` pass locally.

Closes #1638

🤖 Generated with [Claude Code](https://claude.com/claude-code)