### PR TITLE
M40 A4/A5: surface silent analytic-facet degradations; pin flush-boolean exact coordinates

### DIFF
--- a/kernel/brep/boolean_flush_test.go
+++ b/kernel/brep/boolean_flush_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// TestFlushFaceUnionShipsExactCoordinates is audit A4's flush-contact regression (#1600): the union
+// of two boxes sharing an EXACT face plane must come back watertight, at the analytic volume, and
+// with every output vertex coinciding EXACTLY with an operand vertex — no coordinate displaced. A
+// flush union resolves through the coplanar ON/ON path (not the tangency nudge), so exact coordinates
+// are already the contract; this pins it, and would catch any 1e-5 nudge leaking into a mating face.
+func TestFlushFaceUnionShipsExactCoordinates(t *testing.T) {
+	a := box(0, 0, 0, 2, 2, 2) // [0,2]³, V=8
+	b := box(0, 0, 2, 2, 2, 2) // [0,2]²×[2,4], V=8; shares the whole z=2 face with a
+	res, err := brep.Boolean(brep.Union, a, b)
+	if err != nil {
+		t.Fatalf("flush union: %v", err)
+	}
+	checkSolid(t, "flush-face-union", res, 16) // two abutting 8-vol boxes → one 2×2×4 box
+	assertVerticesAreOperandExact(t, "flush-face-union", res, a, b)
+}
+
+// TestBossFlushUnionShipsExactCoordinates is the issue's headline case: a boss seated FLUSH on a wall
+// (a smaller box whose bottom face lies exactly in the target's top face). The boss rim imprints the
+// wall's top face; every result vertex — the wall corners, the boss corners, and the imprinted rim
+// points (which ARE the boss's bottom corners) — must stay at its exact operand coordinate.
+func TestBossFlushUnionShipsExactCoordinates(t *testing.T) {
+	wall := box(0, 0, 0, 4, 4, 2) // top face at z=2, V=32
+	boss := box(1, 1, 2, 2, 2, 2) // bottom face flush on the wall's top, V=8
+	res, err := brep.Boolean(brep.Union, wall, boss)
+	if err != nil {
+		t.Fatalf("boss-flush union: %v", err)
+	}
+	checkSolid(t, "boss-flush-union", res, 40) // 32 + 8, zero overlap volume
+	assertVerticesAreOperandExact(t, "boss-flush-union", res, wall, boss)
+}
+
+// assertVerticesAreOperandExact fails if any result vertex is farther than a float-noise tolerance
+// (1e-9 cm) from the NEAREST operand vertex. For a flush union no new interior intersection vertices
+// arise (the mating faces are coplanar and drop out), so every survivor must be an exact operand
+// corner — a 0.1 µm tangency nudge would move an operand's corners off this set and be caught.
+func assertVerticesAreOperandExact(t *testing.T, label string, res *topo.Body, operands ...*topo.Body) {
+	t.Helper()
+	var src []math.Point3
+	for _, o := range operands {
+		for _, v := range o.Vertices() {
+			src = append(src, v.Point())
+		}
+	}
+	for _, v := range res.Vertices() {
+		if d := nearestPointDistance(v.Point(), src); d > 1e-9 {
+			t.Errorf("%s: result vertex %v sits %g cm off every operand vertex (>1e-9) — the boolean "+
+				"displaced flush geometry; coordinates must be exact, no nudge", label, v.Point(), d)
+		}
+	}
+}
+
+// nearestPointDistance returns the distance from p to the closest point in pts (+Inf if pts empty).
+func nearestPointDistance(p math.Point3, pts []math.Point3) float64 {
+	best := stdmath.Inf(1)
+	for _, q := range pts {
+		if d := float64(p.DistanceTo(q)); d < best {
+			best = d
+		}
+	}
+	return best
+}

--- a/model/feature/analytic_facet_visibility_test.go
+++ b/model/feature/analytic_facet_visibility_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+)
+
+// TestPlanarizedDiagRecordsAnalyticFaceting pins the audit-A5 chokepoint (#1601): converting a body
+// that carries an analytic curved face into a planar B-rep is a PERMANENT degradation and must be
+// observable. planarizedDiag records CodeBooleanAnalyticFaceted for a curved operand, stays quiet for
+// an already-planar one, and in both cases returns a body with no curved face left.
+func TestPlanarizedDiagRecordsAnalyticFaceting(t *testing.T) {
+	cyl, err := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 1, 2)
+	if err != nil {
+		t.Fatalf("SolidCylinder: %v", err)
+	}
+	block, err := brep.SolidBlock(math.P3(0, 0, 0), math.P3(1, 1, 1), "block")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+
+	rec := &diag.Recorder{}
+	out := planarizedDiag(cyl, "unit", rec)
+	if hasCurvedFace(out) {
+		t.Error("planarizedDiag left a curved face on an analytic operand")
+	}
+	if !rec.Has(ops.CodeBooleanAnalyticFaceted) {
+		t.Errorf("faceting an analytic cylinder recorded no %q; got %v", ops.CodeBooleanAnalyticFaceted, rec.Records())
+	}
+
+	quiet := &diag.Recorder{}
+	if got := planarizedDiag(block, "unit", quiet); hasCurvedFace(got) {
+		t.Error("planarizedDiag altered an already-planar body's face kinds")
+	}
+	if quiet.Has(ops.CodeBooleanAnalyticFaceted) {
+		t.Errorf("planarizing an already-planar block recorded a spurious facet defect: %v", quiet.Records())
+	}
+}
+
+// TestPlanarizedDiagNilRecorderSafe confirms the chokepoint is safe on the nil recorder the legacy
+// (diagnostic-less) call paths still pass.
+func TestPlanarizedDiagNilRecorderSafe(t *testing.T) {
+	cyl, err := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 1, 2)
+	if err != nil {
+		t.Fatalf("SolidCylinder: %v", err)
+	}
+	if out := planarizedDiag(cyl, "unit", nil); hasCurvedFace(out) {
+		t.Error("planarizedDiag(nil recorder) did not facet the analytic operand")
+	}
+}
+
+// TestNoSilentFacetBeforeConsumer is audit A5's "grep/guard test over decline paths" (#1601): NO
+// feature may facet an analytic operand into a planar-only consumer (a boolean or a face delete)
+// through the plain, diagnostic-less planarized() — every such site must route through planarizedDiag
+// so the permanent analytic→facet loss always surfaces as a diagnostic. (hull is exempt: its result
+// is a polyhedron by definition, so it feeds ConvexHullOf, not a boolean — the facet is inherent, not
+// a hidden degradation.)
+func TestNoSilentFacetBeforeConsumer(t *testing.T) {
+	consumer := regexp.MustCompile(`ops\.(Boolean|BooleanWithDiagnostics|DeleteFaces)\(`)
+	bareFacet := regexp.MustCompile(`[^D]planarized\(`) // planarized( but not planarizedDiag(
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatalf("ReadFile %s: %v", name, err)
+		}
+		for i, line := range strings.Split(string(src), "\n") {
+			if consumer.MatchString(line) && bareFacet.MatchString(line) {
+				t.Errorf("%s:%d facets an operand into a planar consumer via plain planarized() — "+
+					"route it through planarizedDiag so the analytic→facet loss is observable:\n\t%s",
+					name, i+1, strings.TrimSpace(line))
+			}
+		}
+	}
+}

--- a/model/feature/extrude.go
+++ b/model/feature/extrude.go
@@ -191,16 +191,10 @@ func combine(in Input, body *topo.Body, op ops.PartFeatureOperation) ([]*topo.Bo
 	}
 	// Otherwise re-facet any analytic curved face into a planar B-rep before the planar boolean — it hangs
 	// on a full periodic curved face it cannot consume (#129). A standalone primitive that is never
-	// combined keeps its analytic face for thread/chamfer/fillet. Faceting is PERMANENT — every
-	// downstream feature then operates on facets — so it is recorded as a defect, not done silently
-	// (#1601; the pre-facet here is why the inner boolean's own CSG-fallback diagnostic alone would
-	// miss this path: by the time ops.Boolean runs, the operands already look planar).
-	if hasCurvedFace(target) || hasCurvedFace(body) {
-		in.Diag.Recordf(ops.CodeBooleanAnalyticFaceted, diag.Defect,
-			"%s faceted analytic operand(s) for the planar boolean (no exact curved path applied): the result and all downstream features are polyhedral", op)
-	}
-	target = planarized(target, "combine-target")
-	body = planarized(body, "combine-tool")
+	// combined keeps its analytic face for thread/chamfer/fillet. Faceting is PERMANENT, so planarizedDiag
+	// records it as a defect rather than degrading silently (#1601, audit A5).
+	target = planarizedDiag(target, "combine-target", in.Diag)
+	body = planarizedDiag(body, "combine-tool", in.Diag)
 	res, err := ops.BooleanWithDiagnostics(op, target, body, in.Diag)
 	if err != nil {
 		return nil, err

--- a/model/feature/face_fillet.go
+++ b/model/feature/face_fillet.go
@@ -76,7 +76,7 @@ func nonAdjacentFaceFilletBody(in Input, body *topo.Body, faceKeysA, faceKeysB [
 		return Output{}, fmt.Errorf("%s: the two face sets are not separated by a fillable gap "+
 			"(parallel or disjoint faces are not supported)", feat)
 	}
-	healed, err := ops.DeleteFaces(planarized(body, feat), gap)
+	healed, err := ops.DeleteFaces(planarizedDiag(body, feat, in.Diag), gap)
 	if err != nil {
 		return Output{}, fmt.Errorf("%s: healing the gap between the faces: %w", feat, err)
 	}

--- a/model/feature/full_round_fillet.go
+++ b/model/feature/full_round_fillet.go
@@ -86,7 +86,7 @@ func parallelFullRound(in Input, body *topo.Body, def *FullRoundFilletDefinition
 	if err != nil {
 		return Output{}, err
 	}
-	result, err := ops.BooleanWithDiagnostics(ops.Cut, planarized(body, feat), tool, in.Diag)
+	result, err := ops.BooleanWithDiagnostics(ops.Cut, planarizedDiag(body, feat, in.Diag), tool, in.Diag)
 	if err != nil {
 		return Output{}, err
 	}
@@ -120,7 +120,7 @@ func nonParallelFullRound(in Input, body *topo.Body, center, side1, side2 planar
 		if perr != nil {
 			return Output{}, perr
 		}
-		result, err = ops.BooleanWithDiagnostics(ops.Cut, planarized(result, feat), prism, in.Diag)
+		result, err = ops.BooleanWithDiagnostics(ops.Cut, planarizedDiag(result, feat, in.Diag), prism, in.Diag)
 		if err != nil {
 			return Output{}, fmt.Errorf("%s: cutting the corner round: %w", feat, err)
 		}
@@ -297,7 +297,7 @@ func fullRoundCornerTool(pc math.Point3, up, sideN, axisDir math.Vector3, r, l f
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", feat, err)
 	}
-	corner, err := ops.BooleanWithDiagnostics(ops.Cut, planarized(box, feat), planarized(cyl, feat), rec)
+	corner, err := ops.BooleanWithDiagnostics(ops.Cut, planarizedDiag(box, feat, rec), planarizedDiag(cyl, feat, rec), rec)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", feat, err)
 	}

--- a/model/feature/patterns.go
+++ b/model/feature/patterns.go
@@ -161,11 +161,11 @@ func (p *patternBase) replicateTools(bodies []*topo.Body, tools []groupTool, tra
 	// a full periodic cylinder face, so a circular pattern of a Ø-hole cut used to blow up into
 	// tens of thousands of edges (#129). A faceted tool is left unchanged.
 	for i := range tools {
-		tools[i].body = planarized(tools[i].body, feat)
+		tools[i].body = planarizedDiag(tools[i].body, feat, rec)
 	}
 	running := append([]*topo.Body(nil), bodies...)
 	last := len(running) - 1
-	running[last] = planarized(running[last], feat) // ditto for a curved running target
+	running[last] = planarizedDiag(running[last], feat, rec) // ditto for a curved running target
 	for k := 1; k < len(transforms); k++ {
 		if p.skip(k) {
 			continue

--- a/model/feature/planarize.go
+++ b/model/feature/planarize.go
@@ -3,6 +3,7 @@
 package feature
 
 import (
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
@@ -67,6 +68,22 @@ func planarized(b *topo.Body, feat string) *topo.Body {
 		}
 	}
 	return b
+}
+
+// planarizedDiag is [planarized] that makes the analytic→facet degradation OBSERVABLE (#1601, audit
+// A5). Turning a body that carries an analytic curved face into a planar B-rep is PERMANENT — the
+// analytic surface is unrecoverable and every downstream feature (fillet, chamfer, thread, export)
+// then operates on facets — so it must ride on the feature as a Defect, never happen silently. Every
+// feature that facets an operand before a planar boolean (combine, patterns, full-round/face fillet)
+// routes through here, so no path can facet an analytic surface without a CodeBooleanAnalyticFaceted
+// diagnostic — the inner boolean's own CSG-fallback code cannot catch it, since by the time the
+// boolean runs the operand already looks planar. rec is nil-safe.
+func planarizedDiag(b *topo.Body, feat string, rec *diag.Recorder) *topo.Body {
+	if b != nil && hasCurvedFace(b) {
+		rec.Recordf(ops.CodeBooleanAnalyticFaceted, diag.Defect,
+			"%s faceted an analytic operand for the planar path: the result and every downstream feature is polyhedral", feat)
+	}
+	return planarized(b, feat)
 }
 
 // planarizeSimpleCylinder rebuilds a body that is exactly one analytic cylinder (1 geom.Cylinder side


### PR DESCRIPTION
## What

Two audit findings in the **M40 Deep-Audit Remediation** milestone, advancing the parts that do **not** require the two deferred EPIC reworks (see *Remaining* below).

### A5 — `feat(feature)`: make every analytic→facet degradation observable (#1601)
Only `combine()` recorded `CodeBooleanAnalyticFaceted` when it faceted an analytic operand for the planar boolean. The **full-round fillet**, **face fillet** and **pattern** paths all faceted analytic surfaces *silently* through the diagnostic-less `planarized()` — a user's cylinder/cone quietly became polyhedra with no signal, and every downstream fillet/chamfer/thread then operated on facets. That is exactly audit A5's silent-degradation pattern.

- Centralize the diagnostic at a new `planarizedDiag()` — the single faceting chokepoint — and route every feature that facets an operand before a planar boolean or face-delete through it.
- `combine()` drops its bespoke recording block and uses `planarizedDiag()` too (DRY).
- A **grep/guard test** (`TestNoSilentFacetBeforeConsumer`) pins the invariant that no such site may use the bare `planarized()` again — audit **A5 acceptance item 4** ("No curved boolean can facet analytic surfaces without an observable diagnostic (grep/guard test over decline paths)"). The inner boolean's own CSG-fallback code cannot catch these paths: by the time it runs the operand already looks planar.

### A4 — `test(brep)`: pin the flush-contact boolean's exact coordinates (#1600)
Audit A4 requires flush/coplanar booleans to ship **exact** coordinates (no 0.1 µm tangency-nudge displacement leaking into a mating face) and pass Euler–Poincaré watertightness and analytic volume brackets. Adds regression fixtures for the two canonical flush cases — two boxes sharing a face plane, and **a boss seated flush on a wall** (the issue's headline case). Each must return a valid solid at the analytic volume with every output vertex coinciding exactly with an operand vertex, which would catch any nudge leaking into the result — audit **A4 acceptance item 4**.

## Why

Feature diagnostics and the wire API were starved of the kernel's most important quality signal on several real paths (A5); and the flush-modeling exact-coordinate contract had no regression pinning it (A4).

## Remaining (tracked on the issues — EPIC-scale, deliberately not in this PR)

- **#1600 (A4) exact coordinates on genuine line/edge tangencies.** The un-nudged result is already a valid manifold solid, but a downstream **position-based re-weld** (fillet re-welds the whole body by grid position, discarding topo identity) collapses its two coincident tangent edges into a 4-face non-manifold edge. Shipping exact coordinates there needs the **identity-preserving re-weld** the maintainer already scoped (weld by identity where topology pairs edges; position only for genuinely-new coincidences). A `prefer-the-exact-result` gate was implemented and reverted against `TestTangentContactUnionStaysManifold` in PR #1676.
- **#1601 (A5) gate widening** (2D cap arrangement + winding-number membership) rides with the #1403 curved-boolean EPIC. **Non-feature consumers** (`bodyapi` transient booleans, `compdef` interference) surface diagnostics through wire DTOs — a cross-repo `api/wire` change, out of scope for this single GPL-repo PR.

## Verification

`go build ./...`, `go test ./kernel/brep ./kernel/ops ./model/feature`, and `golangci-lint run` (funlen 20) all green after merging current `develop`.

Refs #1600
Refs #1601

🤖 Generated with [Claude Code](https://claude.com/claude-code)