### PR TITLE
refactor(M40 I4/I5/I6): checkable dialog registry, head/ui consumer interfaces, geom Kind() discriminators

### DIFF
--- a/addin/events/events.go
+++ b/addin/events/events.go
@@ -163,6 +163,18 @@ func subscribeModeling(bus *event.Bus, sink Sink) []event.Subscription {
 				Type: sketchEditEventType(e.Entered), Document: uint64(e.Document), Sketch: e.Sketch, Name: e.Name,
 			})
 		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.ObjectRenamed) event.Outcome {
+			return relayJSON(sink, wire.ObjectRenamedEvent{
+				Type: wire.EventObjectRenamed, Document: uint64(e.Document), Kind: e.Kind,
+				Key: e.Key, OldName: e.OldName, NewName: e.NewName,
+			})
+		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.PropertyChanged) event.Outcome {
+			return relayJSON(sink, wire.PropertyChangedEvent{
+				Type: wire.EventPropertyChanged, Document: uint64(e.Document), Kind: e.Kind,
+				Key: e.Key, Property: e.Property, OldValue: e.OldValue, NewValue: e.NewValue,
+			})
+		}),
 	}
 }
 
@@ -331,6 +343,7 @@ func relayJSON[E wire.BrowserNodeEvent | wire.DockableWindowChangedEvent |
 	wire.JointEventPayload | wire.ParameterChangedEvent |
 	wire.ModelChangedEvent | wire.PanelValueChangedEvent |
 	wire.FeatureLifecycleEvent | wire.SketchEditEvent |
+	wire.ObjectRenamedEvent | wire.PropertyChangedEvent |
 	wire.PanelReferencesChangedEvent | wire.TaskPanelClosedEvent](sink Sink, ev E) event.Outcome {
 	if b, err := json.Marshal(ev); err == nil {
 		sink(b)

--- a/addin/events/metadata_relay_test.go
+++ b/addin/events/metadata_relay_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package events
+
+import (
+	"encoding/json"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/event"
+)
+
+// TestForwardsObjectRenamed: a metadata rename raised on the session bus is relayed to the add-in
+// sink as an object.renamed wire event carrying the object kind, key, and old/new names (#1644).
+func TestForwardsObjectRenamed(t *testing.T) {
+	s := app.NewSession()
+	var rec rawRecorder
+	if subs := Subscribe(s, rec.sink); len(subs) == 0 {
+		t.Fatal("Subscribe returned no subscriptions")
+	}
+	event.Emit(s.Events(), event.After, app.ObjectRenamed{
+		Document: 5, Kind: types.ObjectKindFeature, Key: "7", OldName: "Extrusion1", NewName: "Base",
+	})
+	if !hasObjectRenamed(rec.got) {
+		t.Errorf("no object.renamed relayed; got %d payloads", len(rec.got))
+	}
+}
+
+func hasObjectRenamed(got []string) bool {
+	for _, raw := range got {
+		var e wire.ObjectRenamedEvent
+		if json.Unmarshal([]byte(raw), &e) == nil && e.Type == wire.EventObjectRenamed &&
+			e.Document == 5 && e.Kind == types.ObjectKindFeature && e.Key == "7" &&
+			e.OldName == "Extrusion1" && e.NewName == "Base" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestForwardsPropertyChanged: a suppression change raised on the session bus is relayed as a
+// property.changed wire event carrying the property name and old/new values (#1644).
+func TestForwardsPropertyChanged(t *testing.T) {
+	s := app.NewSession()
+	var rec rawRecorder
+	if subs := Subscribe(s, rec.sink); len(subs) == 0 {
+		t.Fatal("Subscribe returned no subscriptions")
+	}
+	event.Emit(s.Events(), event.After, app.PropertyChanged{
+		Document: 5, Kind: types.ObjectKindFeature, Key: "7", Property: "suppressed", OldValue: "false", NewValue: "true",
+	})
+	if !hasPropertyChanged(rec.got) {
+		t.Errorf("no property.changed relayed; got %d payloads", len(rec.got))
+	}
+}
+
+func hasPropertyChanged(got []string) bool {
+	for _, raw := range got {
+		var e wire.PropertyChangedEvent
+		if json.Unmarshal([]byte(raw), &e) == nil && e.Type == wire.EventPropertyChanged &&
+			e.Property == "suppressed" && e.OldValue == "false" && e.NewValue == "true" {
+			return true
+		}
+	}
+	return false
+}

--- a/app/feature_lifecycle.go
+++ b/app/feature_lifecycle.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
 )
@@ -46,8 +47,10 @@ func (s *Session) RenameFeature(f *feature.PartFeature, name string) error {
 	if other, ok := part.Features().ByName(name); ok && other != f {
 		return fmt.Errorf("app: RenameFeature: name %q is already used by another feature", name)
 	}
+	old := f.Name()
 	f.SetName(name)
 	s.recordEdit(part, "Rename Feature")
+	s.emitObjectRenamed(types.ObjectKindFeature, featureMetaKey(f), old, name) // #1644
 	return nil
 }
 
@@ -65,6 +68,8 @@ func (s *Session) SetFeatureSuppressed(f *feature.PartFeature, suppressed bool) 
 	f.SetSuppressed(suppressed)
 	part.Recompute()
 	s.recordEdit(part, suppressLabel(suppressed))
+	// #1644: the previous state is the negation, since we only reach here on an actual change.
+	s.emitPropertyChanged(types.ObjectKindFeature, featureMetaKey(f), "suppressed", boolProperty(!suppressed), boolProperty(suppressed))
 	return nil
 }
 

--- a/app/metadata_events.go
+++ b/app/metadata_events.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"strconv"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/event"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/feature"
+)
+
+// Metadata-mutation events (S10, #1644): renames and property changes (suppression, sketch
+// settings) previously fired nothing, so add-ins mirroring the document went stale and had to
+// poll. Like the feature-lifecycle events (#1085) these are emitted at the SESSION seam — the
+// shared verb both the UI and the wire router call — so an interactive rename and a body.rename
+// call alike reach the relay. 0x08xx = the modeling event block (see modeling_events.go).
+const (
+	tidObjectRenamed   event.TypeID = 0x0803
+	tidPropertyChanged event.TypeID = 0x0804
+)
+
+// ObjectRenamed announces that a document object (body/sketch/feature/occurrence/document) was
+// renamed. Kind is the object kind, Key its stable reference key, and Old/New the prior and new
+// names — enough for a relay to forward object.renamed without re-querying the model.
+type ObjectRenamed struct {
+	Document doc.ID
+	Kind     types.ObjectKind
+	Key      string
+	OldName  string
+	NewName  string
+}
+
+// EventID implements event.Event.
+func (ObjectRenamed) EventID() event.TypeID { return tidObjectRenamed }
+
+// PropertyChanged announces that a document object's property changed (e.g. suppression toggled, a
+// sketch setting edited). Property names the property; Old/New are its values as strings so one
+// event carries any property.
+type PropertyChanged struct {
+	Document doc.ID
+	Kind     types.ObjectKind
+	Key      string
+	Property string
+	OldValue string
+	NewValue string
+}
+
+// EventID implements event.Event.
+func (PropertyChanged) EventID() event.TypeID { return tidPropertyChanged }
+
+// activeDocID returns the active document's id, or the zero id when none is active — the shared
+// keying every metadata emit uses.
+func (s *Session) activeDocID() doc.ID {
+	if active := s.ActiveDocument(); active != nil {
+		return active.ID()
+	}
+	return 0
+}
+
+// emitObjectRenamed publishes an object.renamed notification on the session bus, keyed to the
+// active document, so the add-in relay forwards it for UI- and wire-driven renames alike (#1644).
+func (s *Session) emitObjectRenamed(kind types.ObjectKind, key, oldName, newName string) {
+	event.Emit(s.bus, event.After, ObjectRenamed{
+		Document: s.activeDocID(), Kind: kind, Key: key, OldName: oldName, NewName: newName,
+	})
+}
+
+// emitPropertyChanged publishes a property.changed notification on the session bus, keyed to the
+// active document (#1644).
+func (s *Session) emitPropertyChanged(kind types.ObjectKind, key, property, oldVal, newVal string) {
+	event.Emit(s.bus, event.After, PropertyChanged{
+		Document: s.activeDocID(), Kind: kind, Key: key, Property: property, OldValue: oldVal, NewValue: newVal,
+	})
+}
+
+// featureMetaKey is a feature's stable reference key for a metadata event — its session id, the
+// same identity the feature-lifecycle events carry, rendered as a string for the generic Key field.
+func featureMetaKey(f *feature.PartFeature) string {
+	return strconv.FormatUint(uint64(f.ID()), 10)
+}
+
+// boolProperty renders a bool property value for a [PropertyChanged] event ("true"/"false").
+func boolProperty(v bool) string { return strconv.FormatBool(v) }

--- a/app/metadata_events_test.go
+++ b/app/metadata_events_test.go
@@ -63,3 +63,40 @@ func TestSetFeatureSuppressedEmitsPropertyChanged(t *testing.T) {
 		t.Errorf("an idempotent suppress fired a spurious property.changed (fired=%d)", fired)
 	}
 }
+
+// TestMetadataEventIDsAreStable pins the wire-facing event type ids: an add-in relay routes on them,
+// so a silent change would misroute every metadata event. They live in the 0x08xx modeling block.
+func TestMetadataEventIDsAreStable(t *testing.T) {
+	if got := (ObjectRenamed{}).EventID(); got != tidObjectRenamed {
+		t.Errorf("ObjectRenamed.EventID() = %#x, want %#x", got, tidObjectRenamed)
+	}
+	if got := (PropertyChanged{}).EventID(); got != tidPropertyChanged {
+		t.Errorf("PropertyChanged.EventID() = %#x, want %#x", got, tidPropertyChanged)
+	}
+	if tidObjectRenamed == tidPropertyChanged {
+		t.Errorf("the two metadata events share type id %#x; they must be distinct to route", tidObjectRenamed)
+	}
+}
+
+// TestEmitObjectRenamedKeysToZeroWithoutActiveDocument checks the no-document branch of activeDocID:
+// a session with nothing open still emits (keyed to the zero doc id) rather than panicking, so an
+// early rename before any document is open is observable, not a crash.
+func TestEmitObjectRenamedKeysToZeroWithoutActiveDocument(t *testing.T) {
+	s := NewSession()
+	if s.ActiveDocument() != nil {
+		t.Fatalf("a fresh session must have no active document")
+	}
+	var got ObjectRenamed
+	fired := 0
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e ObjectRenamed) event.Outcome {
+		got, fired = e, fired+1
+		return event.Continue()
+	})
+	s.emitObjectRenamed(types.ObjectKindBody, "b1", "Old", "New")
+	if fired != 1 {
+		t.Fatalf("object.renamed fired %d times, want exactly 1", fired)
+	}
+	if got.Document != 0 {
+		t.Errorf("event document id = %d, want 0 (no active document)", got.Document)
+	}
+}

--- a/app/metadata_events_test.go
+++ b/app/metadata_events_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/event"
+)
+
+// TestRenameFeatureEmitsObjectRenamed checks a session-level feature rename fires exactly one
+// object.renamed carrying the feature kind, its key, and the old and new names (#1644) — the seam
+// both the UI and the wire router go through, so an add-in observes UI renames too.
+func TestRenameFeatureEmitsObjectRenamed(t *testing.T) {
+	s, def := extrudedBoxPart(t)
+	f := def.Features().Item(0)
+	var got ObjectRenamed
+	fired := 0
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e ObjectRenamed) event.Outcome {
+		got, fired = e, fired+1
+		return event.Continue()
+	})
+	old := f.Name()
+	if err := s.RenameFeature(f, "Base Boss"); err != nil {
+		t.Fatalf("RenameFeature: %v", err)
+	}
+	if fired != 1 {
+		t.Fatalf("object.renamed fired %d times, want exactly 1", fired)
+	}
+	if got.Kind != types.ObjectKindFeature || got.OldName != old || got.NewName != "Base Boss" {
+		t.Errorf("event = %+v, want feature %q->%q", got, old, "Base Boss")
+	}
+	if got.Key != featureMetaKey(f) {
+		t.Errorf("event key = %q, want the feature key %q", got.Key, featureMetaKey(f))
+	}
+}
+
+// TestSetFeatureSuppressedEmitsPropertyChanged checks toggling suppression fires one property.changed
+// carrying the old and new boolean state, and that an idempotent set fires nothing (#1644).
+func TestSetFeatureSuppressedEmitsPropertyChanged(t *testing.T) {
+	s, def := extrudedBoxPart(t)
+	f := def.Features().Item(0)
+	var got PropertyChanged
+	fired := 0
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e PropertyChanged) event.Outcome {
+		got, fired = e, fired+1
+		return event.Continue()
+	})
+	if err := s.SetFeatureSuppressed(f, true); err != nil {
+		t.Fatalf("SetFeatureSuppressed: %v", err)
+	}
+	if fired != 1 {
+		t.Fatalf("property.changed fired %d times, want exactly 1", fired)
+	}
+	if got.Property != "suppressed" || got.OldValue != "false" || got.NewValue != "true" {
+		t.Errorf("event = %+v, want suppressed false->true", got)
+	}
+	if err := s.SetFeatureSuppressed(f, true); err != nil { // idempotent: already suppressed
+		t.Fatalf("repeated SetFeatureSuppressed: %v", err)
+	}
+	if fired != 1 {
+		t.Errorf("an idempotent suppress fired a spurious property.changed (fired=%d)", fired)
+	}
+}

--- a/archguard/head_session_ratchet_test.go
+++ b/archguard/head_session_ratchet_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package archguard
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Audit I5: head/ui is god-coupled to the concrete *app.Session — every widget takes the
+// whole session, so every widget can touch anything, and grep cannot tell load-bearing
+// uses from incidental ones. The policy (architecture/notes/head-ui-consumer-interfaces.md)
+// is boy-scout, not big-bang: any widget touched from now on declares its own consumer-side
+// interface of ≤6 methods (the arrowSession pattern) instead of taking *app.Session. This
+// ratchet pins the current coupling count so a new *app.Session parameter fails CI; when a
+// conversion lowers it, the pin is lowered with it — the number only goes down.
+
+// headSessionParamPin is the number of *app.Session references in head/ui code (excluding
+// the compile-time interface assertions that PROVE a consumer interface, and doc comments
+// that merely mention the type). Lower it when a conversion removes references; never raise
+// it — a raise means a new widget took the whole session instead of a slim interface.
+const headSessionParamPin = 492
+
+func TestHeadSessionCouplingRatchet(t *testing.T) {
+	got := countSessionCoupling(t)
+	if got > headSessionParamPin {
+		t.Fatalf("head/ui *app.Session coupling rose to %d (pinned %d): a widget took the whole "+
+			"*app.Session — declare a ≤6-method consumer interface instead (audit I5, arrowSession pattern)",
+			got, headSessionParamPin)
+	}
+	if got < headSessionParamPin {
+		t.Fatalf("head/ui *app.Session coupling fell to %d (pinned %d): good — lower headSessionParamPin "+
+			"to %d so the ratchet holds the new floor", got, headSessionParamPin, got)
+	}
+}
+
+// countSessionCoupling counts *app.Session occurrences in head/ui code, skipping full-line
+// doc comments (prose mentions of the type) and the `var _ Iface = (*app.Session)(nil)`
+// assertions that are the seam's proof, not its coupling.
+func countSessionCoupling(t *testing.T) int {
+	t.Helper()
+	files, err := filepath.Glob("../head/ui/*.go")
+	if err != nil || len(files) == 0 {
+		t.Fatalf("globbing head/ui: %v (found %d)", err, len(files))
+	}
+	total := 0
+	for _, src := range readGoSources(t, "../head/ui/*.go") {
+		total += countSessionInSource(src)
+	}
+	return total
+}
+
+// countSessionInSource counts *app.Session in one file's source under the ratchet rules.
+func countSessionInSource(src string) int {
+	n := 0
+	for _, line := range strings.Split(src, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "//") || strings.Contains(line, "(*app.Session)(nil)") {
+			continue
+		}
+		n += strings.Count(line, "*app.Session")
+	}
+	return n
+}

--- a/archguard/tool_dialog_coverage_test.go
+++ b/archguard/tool_dialog_coverage_test.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package archguard
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+// Audit I4: head/ui once carried a hand-maintained roll-call of per-tool drawXDialog
+// calls in chrome.go; a new feature tool minus its call was headless-invisible — the tool
+// activated, collected nothing, and the user saw no UI (the #1521 shape). Dialogs now
+// self-register (head/ui/tool_dialog_registry.go) and this source-level gate asserts every
+// feature tool resolves to exactly one dialog PATH: a bespoke registered dialog, the
+// generic parameter panel (ParameterizedTool.Params), or the explicit no-dialog allowlist
+// below. A new feature tool without any of the three fails CI, not a live session.
+
+// featureToolsWithoutDialog are the feature tools that legitimately need no property
+// panel: they are driven entirely by viewport/browser picks and commit with no
+// configurable parameter, so a dialog would be an empty window. Each entry names why —
+// an undeclared gap (a tool that SHOULD have a panel) fails the coverage test instead.
+var featureToolsWithoutDialog = map[string]string{
+	"HullTool":                       "no inputs — the running solids are the input, just OK (feature_extra_tools.go)",
+	"PatchTool":                      "AutoCommitOnPick — fills the region the instant it is clicked, nothing to configure",
+	"FeatureSketchDrivenPatternTool": "driven by source-feature + driving-sketch picks; one occurrence per sketch point, no scalar params",
+}
+
+func TestEveryFeatureToolHasADialogPath(t *testing.T) {
+	feature := featureToolConstructors(t)
+	param := toolsImplementingParams(t)
+	dialog := toolsWithRegisteredDialog(t)
+	for tool := range feature {
+		if _, ok := param[tool]; ok {
+			continue
+		}
+		if _, ok := dialog[tool]; ok {
+			continue
+		}
+		if _, ok := featureToolsWithoutDialog[tool]; ok {
+			continue
+		}
+		t.Errorf("feature tool %s has no dialog path: it neither implements ParameterizedTool "+
+			"(generic panel), registers a bespoke dialog (head/ui registerToolDialog), nor is "+
+			"declared in featureToolsWithoutDialog — a new tool minus its UI must fail here, not a "+
+			"live session (#1521, audit I4)", tool)
+	}
+	assertAllowlistFresh(t, feature, param, dialog)
+}
+
+// assertAllowlistFresh fails when a featureToolsWithoutDialog entry is stale — the tool is
+// no longer a feature tool, or has since gained a dialog/params — so the allowlist cannot
+// silently mask a real gap after the tool changes.
+func assertAllowlistFresh(t *testing.T, feature, param, dialog map[string]struct{}) {
+	t.Helper()
+	for tool := range featureToolsWithoutDialog {
+		if _, ok := feature[tool]; !ok {
+			t.Errorf("featureToolsWithoutDialog entry %q is stale — no longer a feature tool; delete it", tool)
+		}
+		if _, ok := param[tool]; ok {
+			t.Errorf("featureToolsWithoutDialog entry %q now implements ParameterizedTool; delete the allowlist entry", tool)
+		}
+		if _, ok := dialog[tool]; ok {
+			t.Errorf("featureToolsWithoutDialog entry %q now has a bespoke dialog; delete the allowlist entry", tool)
+		}
+	}
+}
+
+var (
+	startFeatureToolRe = regexp.MustCompile(`StartFeatureTool\(New(\w+)\(`)
+	partFeatureThunkRe = regexp.MustCompile(`func\(\) PartFeatureTool \{ return New(\w+)\(\)`)
+	paramsMethodRe     = regexp.MustCompile(`func \(\w+ \*(\w+Tool)\) Params\(\) ToolParams`)
+	registerDialogRe   = regexp.MustCompile(`(?s)registerToolDialog\(([^)]*)\)`)
+	toolLiteralRe      = regexp.MustCompile(`"(\w+Tool)"`)
+)
+
+// featureToolConstructors collects every part-feature tool activated through
+// StartFeatureTool (directly or via a func() PartFeatureTool flyout thunk).
+func featureToolConstructors(t *testing.T) map[string]struct{} {
+	t.Helper()
+	out := map[string]struct{}{}
+	for _, src := range readGoSources(t, "../app/commands_*.go") {
+		collectMatches(startFeatureToolRe, src, out)
+		collectMatches(partFeatureThunkRe, src, out)
+	}
+	if len(out) == 0 {
+		t.Fatal("no feature-tool constructors found — the StartFeatureTool scan is broken")
+	}
+	return out
+}
+
+// toolsImplementingParams collects the tools that expose the generic parameter panel.
+func toolsImplementingParams(t *testing.T) map[string]struct{} {
+	t.Helper()
+	out := map[string]struct{}{}
+	for _, src := range readGoSources(t, "../app/*.go") {
+		collectMatches(paramsMethodRe, src, out)
+	}
+	return out
+}
+
+// toolsWithRegisteredDialog collects the tool keys claimed by head/ui registerToolDialog
+// calls — the bespoke-dialog side of the contract.
+func toolsWithRegisteredDialog(t *testing.T) map[string]struct{} {
+	t.Helper()
+	out := map[string]struct{}{}
+	for _, src := range readGoSources(t, "../head/ui/*.go") {
+		for _, call := range registerDialogRe.FindAllStringSubmatch(src, -1) {
+			for _, lit := range toolLiteralRe.FindAllStringSubmatch(call[1], -1) {
+				out[lit[1]] = struct{}{}
+			}
+		}
+	}
+	return out
+}
+
+// collectMatches records capture group 1 of every match of re in src.
+func collectMatches(re *regexp.Regexp, src string, out map[string]struct{}) {
+	for _, m := range re.FindAllStringSubmatch(src, -1) {
+		out[m[1]] = struct{}{}
+	}
+}
+
+// readGoSources reads every non-test .go file matching the glob (relative to the archguard
+// package dir) and returns their contents.
+func readGoSources(t *testing.T, glob string) []string {
+	t.Helper()
+	files, err := filepath.Glob(glob)
+	if err != nil || len(files) == 0 {
+		t.Fatalf("globbing %q: %v (found %d)", glob, err, len(files))
+	}
+	out := make([]string, 0, len(files))
+	for _, f := range files {
+		if filepath.Base(f) == "" || len(f) > 8 && f[len(f)-8:] == "_test.go" {
+			continue
+		}
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("reading %s: %v", f, err)
+		}
+		out = append(out, string(src))
+	}
+	return out
+}

--- a/architecture/notes/head-ui-consumer-interfaces.md
+++ b/architecture/notes/head-ui-consumer-interfaces.md
@@ -1,0 +1,52 @@
+# head/ui consumer interfaces — policy (audit I5)
+
+**Status:** active policy · **Applies to:** `head/ui` · **From:** 2026-07 deep audit, finding I5.
+
+## The problem
+
+`head/ui` is god-coupled to the concrete `*app.Session`: hundreds of references
+across the package reach directly into the whole session. Every widget takes the
+full session, so every widget *can* touch anything — business rules leak into
+widgets, nothing documents what a widget actually needs, no widget is testable
+against a slim fake host, and a `grep` for `*app.Session` cannot tell load-bearing
+uses from incidental ones. This is the convention-only coupling behind the shipped
+drift bugs (#1416, #1426, #1521).
+
+## The policy — boy-scout, not big-bang
+
+Every widget **touched from now on** declares its own **consumer-side interface**
+of **≤6 methods** and takes that instead of `*app.Session`. `*app.Session`
+satisfies it implicitly ("accept interfaces, return structs"; Interface Segregation
+Principle). Existing untouched widgets are left alone — there is no big-bang
+rewrite.
+
+Templates already in the repo: `head/ui/viewcube_arrows.go` (`arrowSession`) and
+`head/ui/viewport_cache.go` (`modelGeometryVersioned`). First tranche converted for
+this note: `commitCancelHost` (the shared OK/Cancel row every tool dialog draws
+through, `dialog_buttons.go`), `measureHost` and `gripSnapHost` (the Measure and
+Grip Snap panels, `measure_dialog.go` / `grip_snap_dialog.go`), and
+`activeDocumentSource` / `edgeColorSource` (the viewport-cache helpers,
+`viewport_cache.go`).
+
+### Recipe
+
+1. Name the interface after the widget's role, not the session:
+   `type browserSession interface { … }`. Keep it to ≤6 methods — the methods the
+   widget actually calls.
+2. Prove `*app.Session` satisfies it with a compile-time assertion beside the
+   interface: `var _ browserSession = (*app.Session)(nil)`.
+3. Take the interface as the parameter: `func drawBrowser(s browserSession)`.
+   Where a widget is dispatched by a registry that stores `func(*app.Session)`
+   (e.g. the tool-dialog registry, I4), keep a thin `func(s *app.Session)` adapter
+   that delegates to the interface-typed body — the seam is the body.
+4. Add a unit test driving the widget from a **named fake host** (CLAUDE.md: named
+   fake classes, not inline stubs), e.g. `fakeMeasureHost`. Previously impossible.
+
+## The ratchet
+
+`archguard.TestHeadSessionCouplingRatchet` pins the count of `*app.Session`
+references in `head/ui` production code (excluding doc-comment prose and the
+`(*app.Session)(nil)` seam assertions). The number **only goes down**: a new
+`*app.Session` parameter raises it and fails CI; a conversion lowers it and the pin
+is lowered to match. This turns the "convert opportunistically" policy into a
+mechanically enforced floor.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.102.1
+	oblikovati.org/api v0.104.1
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.102.1
+	oblikovati.org/api v0.103.1
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.104.1
+	oblikovati.org/api v0.105.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.104.1
+	oblikovati.org/api v0.105.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.102.1
+	oblikovati.org/api v0.103.1
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.102.1
+	oblikovati.org/api v0.104.1
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -89,43 +89,20 @@ func drawViewportIfPresent(win *native.Window, s *app.Session) {
 	}
 }
 
+// drawChromeDialogs draws the tool property panels. The per-tool feature dialogs
+// (extrude, revolve, chamfer, sheet-metal, surface edits, …) self-register from their own
+// files and are drawn by drawRegisteredToolDialogs — no hand-maintained roll-call, so a new
+// tool minus its dialog fails the completeness check, not a live session (audit I4). The
+// remaining entries are non-feature popups/editors that are not keyed on a single tool.
 func drawChromeDialogs(s *app.Session) {
 	drawDimensionPopup(s)
-	drawToolParamsDialog(s) // generic dialog for parameterized sketch tools
+	drawToolParamsDialog(s) // generic panel for any ParameterizedTool (the default path)
 	drawSketch3DSettings(s) // 3D-sketch settings while editing one
-	drawSolidFeatureDialogs(s)
-	drawSurfaceFeatureDialogs(s)
+	drawRegisteredToolDialogs(s)
 	drawOffsetPlaneDialog(s)
 	drawFeatureEditDialog(s)
 	drawWorkPlaneEditDialog(s)
 	drawPlaceComponentDialog(s) // Assemble ▸ Place: arms the component file picker (#763)
-}
-
-func drawSolidFeatureDialogs(s *app.Session) {
-	drawExtrudeDialog(s)
-	drawRevolveDialog(s)
-	drawCoilDialog(s)
-	drawLoftDialog(s)
-	drawSweepDialog(s)
-	drawHoleDialog(s)
-	drawChamferDialog(s)
-	drawThreadDialog(s)
-	drawFilletDialog(s)
-	drawFaceFilletDialog(s)
-	drawFullRoundFilletDialog(s)
-	drawShellDialog(s)
-	drawSplitDialog(s)
-	drawGripSnapDialog(s)
-	drawMeasureDialog(s)
-	drawSheetMetalDialogs(s)
-}
-
-func drawSurfaceFeatureDialogs(s *app.Session) {
-	drawFaceOffsetDialog(s)
-	drawDraftDialog(s)
-	drawDeleteFaceDialog(s)
-	drawReplaceFaceDialog(s)
-	drawThickenDialog(s)
 }
 
 func drawChromeWindows(s *app.Session) {

--- a/head/ui/consumer_host_test.go
+++ b/head/ui/consumer_host_test.go
@@ -1,0 +1,118 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/api/contract"
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/renderer"
+)
+
+// These tests exercise the audit-I5 consumer interfaces: each dialog now names the slim
+// session surface it consumes, so it can be driven by a NAMED fake host (CLAUDE.md: named
+// fake classes, not inline stubs) instead of the whole *app.Session — the coupling that
+// previously made no widget testable in isolation.
+
+// fakeCommitHost is a fake commitCancelHost recording the OK/Cancel it receives, so a test
+// can drive the shared button row without a real session or model.
+type fakeCommitHost struct {
+	blocked string
+	okCalls int
+	cancels int
+}
+
+func (h *fakeCommitHost) CommitBlockedReason() string { return h.blocked }
+func (h *fakeCommitHost) OK() error                   { h.okCalls++; return nil }
+func (h *fakeCommitHost) CancelTool()                 { h.cancels++ }
+
+var _ commitCancelHost = (*fakeCommitHost)(nil)
+
+// fakeMeasureHost is a fake measureHost carrying a real MeasureTool but stubbing the
+// commit controls — the panel needs no session.
+type fakeMeasureHost struct {
+	fakeCommitHost
+	measure *app.MeasureTool
+}
+
+func (h *fakeMeasureHost) ActiveMeasure() *app.MeasureTool { return h.measure }
+
+var _ measureHost = (*fakeMeasureHost)(nil)
+
+// fakeGripSnapHost is a fake gripSnapHost carrying a real GripSnapTool.
+type fakeGripSnapHost struct {
+	fakeCommitHost
+	grip *app.GripSnapTool
+}
+
+func (h *fakeGripSnapHost) ActiveGripSnap() *app.GripSnapTool { return h.grip }
+
+var _ gripSnapHost = (*fakeGripSnapHost)(nil)
+
+// fakeEdgeColorSource is a fake edgeColorSource with no active document — displayEdgeColor
+// must fall back to the renderer default without a session.
+type fakeEdgeColorSource struct{}
+
+func (fakeEdgeColorSource) ActiveDocument() *doc.Document { return nil }
+func (fakeEdgeColorSource) DocumentDisplaySettings(doc.ID) contract.DisplaySettings {
+	return nil
+}
+
+var (
+	_ edgeColorSource      = fakeEdgeColorSource{}
+	_ activeDocumentSource = fakeEdgeColorSource{}
+)
+
+// TestDisplayEdgeColorFallsBackWithoutDocument drives displayEdgeColor from a fake host with
+// no active document (a pure, native-free unit test enabled by the consumer interface).
+func TestDisplayEdgeColorFallsBackWithoutDocument(t *testing.T) {
+	if got := displayEdgeColor(fakeEdgeColorSource{}); got != renderer.DefaultEdgeColor() {
+		t.Fatalf("displayEdgeColor with no document = %v, want renderer default %v", got, renderer.DefaultEdgeColor())
+	}
+}
+
+// TestMeasurePanelDrivenByFakeHost renders the Measure panel from a fake host — proving the
+// panel consumes only measureHost, not *app.Session.
+func TestMeasurePanelDrivenByFakeHost(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	icons = nil
+
+	win.BeginFrame()
+	drawMeasure(&fakeMeasureHost{}) // no active tool → early return, draws nothing
+	drawMeasure(&fakeMeasureHost{measure: app.NewMeasureTool()})
+	win.EndFrame(0.1, 0.1, 0.1)
+}
+
+// TestGripSnapPanelDrivenByFakeHost renders the Grip Snap panel from a fake host.
+func TestGripSnapPanelDrivenByFakeHost(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	icons = nil
+
+	win.BeginFrame()
+	drawGripSnap(&fakeGripSnapHost{}) // no active tool → early return
+	drawGripSnap(&fakeGripSnapHost{grip: app.NewGripSnapTool()})
+	win.EndFrame(0.1, 0.1, 0.1)
+}
+
+// TestCommitCancelButtonsDrivenByFakeHost renders the shared OK/Cancel row from a fake host,
+// the widget every registered tool dialog draws through.
+func TestCommitCancelButtonsDrivenByFakeHost(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	icons = nil
+
+	win.BeginFrame()
+	if native.Begin("commit-probe") {
+		drawCommitCancelButtons(&fakeCommitHost{}, false)
+		drawCommitCancelButtons(&fakeCommitHost{blocked: "would recompute sick"}, true)
+	}
+	native.End()
+	win.EndFrame(0.1, 0.1, 0.1)
+}

--- a/head/ui/dialog_buttons.go
+++ b/head/ui/dialog_buttons.go
@@ -15,12 +15,26 @@ import (
 // fix in the field, just not yet buildable.
 var commitBlockedColor = [4]float32{0.95, 0.55, 0.25, 1}
 
+// commitCancelHost is the slim session surface the OK/Cancel button row consumes: the
+// commit-gate reason, the commit, and the cancel — nothing else. Every registered tool
+// dialog draws through this widget, so naming exactly what it touches (audit I5, the
+// arrowSession pattern) segregates the whole dialog subsystem from the rest of the
+// session and lets the button row be tested against a small fake host. *app.Session
+// satisfies it implicitly.
+type commitCancelHost interface {
+	CommitBlockedReason() string
+	OK() error
+	CancelTool()
+}
+
+var _ commitCancelHost = (*app.Session)(nil)
+
 // drawCommitCancelButtons draws a feature panel's OK/Cancel row. OK is disabled both when the tool
 // lacks its basic inputs (canCommit) AND when the pending configuration would recompute SICK
 // (CommitBlockedReason) — the rule that no sick feature may be committed to the design. When
 // blocked for the latter reason, a short amber line explains why, since a disabled button shows no
 // tooltip.
-func drawCommitCancelButtons(s *app.Session, canCommit bool) {
+func drawCommitCancelButtons(s commitCancelHost, canCommit bool) {
 	blocked := ""
 	if canCommit {
 		blocked = s.CommitBlockedReason() // only meaningful once the required inputs are present

--- a/head/ui/grip_snap_dialog.go
+++ b/head/ui/grip_snap_dialog.go
@@ -9,12 +9,25 @@ import (
 	"oblikovati.org/head/internal/native"
 )
 
-// drawGripSnapDialog shows the Grip Snap Move-Options panel while the tool is active: the Constraint
+// gripSnapHost is the slim session surface the Grip Snap panel consumes (audit I5, the
+// arrowSession pattern): the running Grip Snap tool plus the shared commit/cancel
+// controls. *app.Session satisfies it implicitly.
+type gripSnapHost interface {
+	ActiveGripSnap() *app.GripSnapTool
+	commitCancelHost
+}
+
+var _ gripSnapHost = (*app.Session)(nil)
+
+// drawGripSnapDialog is the registry-facing adapter; the panel itself consumes gripSnapHost.
+func drawGripSnapDialog(s *app.Session) { drawGripSnap(s) }
+
+// drawGripSnap shows the Grip Snap Move-Options panel while the tool is active: the Constraint
 // override (Auto/Mate/Flush/Insert/Tangent) that the snap will create, and a HUD line reporting the
 // constraint inferred on the last snap. The two face picks happen in the viewport (see the tool's
 // prompt in the command window).
-func drawGripSnapDialog(s *app.Session) {
-	g := s.ActiveGripSnap()
+func drawGripSnap(h gripSnapHost) {
+	g := h.ActiveGripSnap()
 	if g == nil {
 		return
 	}
@@ -31,7 +44,7 @@ func drawGripSnapDialog(s *app.Session) {
 			}
 		}
 		native.Separator()
-		drawCommitCancelButtons(s, g.CanCommit())
+		drawCommitCancelButtons(h, g.CanCommit())
 	}
 	native.End()
 }

--- a/head/ui/measure_dialog.go
+++ b/head/ui/measure_dialog.go
@@ -9,11 +9,26 @@ import (
 	"oblikovati.org/head/internal/native"
 )
 
-// drawMeasureDialog shows the Measure readout panel while the tool is active: the running
+// measureHost is the slim session surface the Measure readout panel consumes (audit I5,
+// the arrowSession pattern): the running Measure tool plus the shared commit/cancel
+// controls — not the whole session. *app.Session satisfies it implicitly, so drawMeasure
+// is unit-testable against a small fake host.
+type measureHost interface {
+	ActiveMeasure() *app.MeasureTool
+	commitCancelHost
+}
+
+var _ measureHost = (*app.Session)(nil)
+
+// drawMeasureDialog is the registry-facing adapter; the panel itself consumes only
+// measureHost.
+func drawMeasureDialog(s *app.Session) { drawMeasure(s) }
+
+// drawMeasure shows the Measure readout panel while the tool is active: the running
 // measurement for the picked faces/edges/vertices. Picking happens in the viewport (see the tool's
 // prompt in the command window); the panel echoes the result and offers Close.
-func drawMeasureDialog(s *app.Session) {
-	m := s.ActiveMeasure()
+func drawMeasure(h measureHost) {
+	m := h.ActiveMeasure()
 	if m == nil {
 		return
 	}
@@ -29,7 +44,7 @@ func drawMeasureDialog(s *app.Session) {
 			native.Text(readout)
 		}
 		native.Separator()
-		drawCommitCancelButtons(s, m.CanCommit())
+		drawCommitCancelButtons(h, m.CanCommit())
 	}
 	native.End()
 }

--- a/head/ui/tool_dialog_registry.go
+++ b/head/ui/tool_dialog_registry.go
@@ -1,0 +1,144 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"fmt"
+	"sort"
+
+	"oblikovati.org/app"
+)
+
+// A tool's property dialog is a modeless ImGui window drawn every frame while its tool is
+// active; each dialog self-gates by querying the session (e.g. s.ActiveChamfer() returns
+// nil when its tool is not running) and returns early otherwise. Rather than a
+// hand-maintained roll-call in chrome.go — where a new tool minus its call is
+// headless-invisible, the #1521 shape (audit I4) — the dialogs are assembled into one
+// explicit set by defaultToolDialogSet; chrome draws the set, and a source-level
+// completeness check (archguard TestEveryFeatureToolHasADialogPath) asserts every feature
+// tool resolves to a registered dialog, the generic parameter panel (ParameterizedTool),
+// or an explicit no-dialog allowlist.
+//
+// The set is built by ONE explicit constructor at package scope, never by scattered init()
+// side effects (audit B6, #1617): init()-time registration makes correctness depend on a
+// binary's import list (a forgotten blank import silently drops a dialog) and blocks
+// building a minimal set in tests. Enumerating every dialog in one constructor keeps the
+// contract in a single readable place.
+
+// toolDialogDraw draws one tool's property panel for the frame. It MUST self-gate on the
+// session — a no-op when its tool is not active — because the set draws every dialog each
+// frame and relies on at most one painting a window.
+type toolDialogDraw func(s *app.Session)
+
+// toolDialogSet is an explicitly constructed collection of tool property dialogs plus the
+// set of tool type names each covers (for the completeness check).
+type toolDialogSet struct {
+	draws        []toolDialogDraw
+	coveredTools map[string]struct{}
+}
+
+// newToolDialogSet returns an empty set; tests build a minimal one, the head uses the
+// default assembled by defaultToolDialogSet.
+func newToolDialogSet() *toolDialogSet {
+	return &toolDialogSet{coveredTools: map[string]struct{}{}}
+}
+
+// registerToolDialog adds a bespoke dialog draw and the tool type name(s) it serves (e.g.
+// "ChamferTool"). It panics on a duplicate tool key — two dialogs claiming one tool is a
+// construction bug, caught when the default set is built, not in a live session.
+func (s *toolDialogSet) registerToolDialog(draw toolDialogDraw, tools ...string) {
+	if draw == nil || len(tools) == 0 {
+		panic(fmt.Sprintf("registerToolDialog: need a draw func and ≥1 tool key, got draw!=nil=%v tools=%v", draw != nil, tools))
+	}
+	for _, name := range tools {
+		if _, dup := s.coveredTools[name]; dup {
+			panic(fmt.Sprintf("registerToolDialog: duplicate dialog registration for tool %q", name))
+		}
+		s.coveredTools[name] = struct{}{}
+	}
+	s.draws = append(s.draws, draw)
+}
+
+// draw renders every dialog in the set for the frame; each draw self-gates, so at most one
+// paints. This replaces chrome.go's per-tool roll-call.
+func (s *toolDialogSet) draw(sess *app.Session) {
+	for _, d := range s.draws {
+		d(sess)
+	}
+}
+
+// toolNames returns the sorted tool type names the set covers.
+func (s *toolDialogSet) toolNames() []string {
+	names := make([]string, 0, len(s.coveredTools))
+	for n := range s.coveredTools {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// toolDialogs is the head's default dialog set, assembled once by explicit construction —
+// the composition point for head/ui's own tool panels (every DrawChrome caller shares it).
+var toolDialogs = defaultToolDialogSet()
+
+// defaultToolDialogSet assembles the full set of bespoke tool dialogs. Split into
+// panel-scoped helpers so each stays within the statement budget and the grouping mirrors
+// the ribbon.
+func defaultToolDialogSet() *toolDialogSet {
+	s := newToolDialogSet()
+	registerSolidToolDialogs(s)
+	registerSurfaceToolDialogs(s)
+	registerSheetMetalToolDialogs(s)
+	return s
+}
+
+// registerSolidToolDialogs adds the solid-feature and interaction dialogs.
+func registerSolidToolDialogs(s *toolDialogSet) {
+	s.registerToolDialog(drawExtrudeDialog, "ExtrudeTool")
+	s.registerToolDialog(drawRevolveDialog, "RevolveTool")
+	s.registerToolDialog(drawCoilDialog, "CoilTool")
+	s.registerToolDialog(drawLoftDialog, "LoftTool")
+	s.registerToolDialog(drawSweepDialog, "SweepTool")
+	s.registerToolDialog(drawHoleDialog, "HoleTool")
+	s.registerToolDialog(drawChamferDialog, "ChamferTool")
+	s.registerToolDialog(drawThreadDialog, "ThreadTool")
+	s.registerToolDialog(drawFilletDialog, "FilletTool")
+	s.registerToolDialog(drawFaceFilletDialog, "FaceFilletTool")
+	s.registerToolDialog(drawFullRoundFilletDialog, "FullRoundFilletTool")
+	s.registerToolDialog(drawShellDialog, "ShellTool")
+	s.registerToolDialog(drawSplitDialog, "SplitTool")
+	s.registerToolDialog(drawGripSnapDialog, "GripSnapTool")
+	s.registerToolDialog(drawMeasureDialog, "MeasureTool")
+}
+
+// registerSurfaceToolDialogs adds the surface-edit dialogs.
+func registerSurfaceToolDialogs(s *toolDialogSet) {
+	s.registerToolDialog(drawFaceOffsetDialog, "FaceOffsetTool")
+	s.registerToolDialog(drawDraftDialog, "DraftTool")
+	s.registerToolDialog(drawDeleteFaceDialog, "DeleteFaceTool")
+	s.registerToolDialog(drawReplaceFaceDialog, "ReplaceFaceTool")
+	s.registerToolDialog(drawThickenDialog, "ThickenTool")
+}
+
+// registerSheetMetalToolDialogs adds the one Sheet Metal router, which serves all seventeen
+// wall/modify/flat tools by their session accessor. SheetMetalStyleTool is a settings
+// dialog (drawSheetMetalStyle), covered inside the router, not a feature commit.
+func registerSheetMetalToolDialogs(s *toolDialogSet) {
+	s.registerToolDialog(drawSheetMetalDialogs,
+		"SheetMetalFaceTool", "SheetMetalFlangeTool", "SheetMetalContourFlangeTool",
+		"SheetMetalLoftedFlangeTool", "SheetMetalHemTool", "SheetMetalContourRollTool",
+		"SheetMetalBendTool", "SheetMetalFoldTool", "SheetMetalCornerTool",
+		"SheetMetalCornerSeamTool", "SheetMetalCutTool", "SheetMetalPunchTool",
+		"SheetMetalRipTool", "SheetMetalUnfoldTool", "SheetMetalRefoldTool",
+		"SheetMetalCosmeticBendTool", "SheetMetalLipTool")
+}
+
+// drawRegisteredToolDialogs draws the head's default dialog set for the frame.
+func drawRegisteredToolDialogs(s *app.Session) { toolDialogs.draw(s) }
+
+// registeredDialogTools returns the sorted tool type names that have a bespoke dialog in
+// the default set. The head-side completeness test reads it; the archguard CI gate reads
+// the source instead.
+func registeredDialogTools() []string { return toolDialogs.toolNames() }

--- a/head/ui/tool_dialog_registry_test.go
+++ b/head/ui/tool_dialog_registry_test.go
@@ -1,0 +1,51 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+)
+
+// TestToolDialogRegistryPopulated pins that the bespoke dialogs migrated off chrome.go's
+// roll-call are present in the default set (audit I4) — a dialog dropped from
+// defaultToolDialogSet would silently stop drawing, so this is the parity guard that made
+// deleting the roll-call safe.
+func TestToolDialogRegistryPopulated(t *testing.T) {
+	want := []string{
+		"ChamferTool", "CoilTool", "DeleteFaceTool", "DraftTool", "ExtrudeTool",
+		"FaceFilletTool", "FaceOffsetTool", "FilletTool", "FullRoundFilletTool", "HoleTool",
+		"LoftTool", "ReplaceFaceTool", "RevolveTool", "ShellTool", "SheetMetalFaceTool",
+		"SplitTool", "SweepTool", "ThickenTool", "ThreadTool",
+	}
+	got := map[string]struct{}{}
+	for _, name := range registeredDialogTools() {
+		got[name] = struct{}{}
+	}
+	for _, name := range want {
+		if _, ok := got[name]; !ok {
+			t.Errorf("tool %q lost its dialog registration — its init() no longer calls registerToolDialog", name)
+		}
+	}
+	if len(toolDialogs.draws) == 0 {
+		t.Fatal("no dialog draws in the default set — chrome would draw no tool panels")
+	}
+}
+
+// TestRegisterToolDialogPanicsOnDuplicate asserts a second dialog claiming an
+// already-registered tool key fails at construction, not in a live session (the house
+// registry contract, serialize_registry #1416). It uses a fresh set so it does not mutate
+// the shared default.
+func TestRegisterToolDialogPanicsOnDuplicate(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("registerToolDialog did not panic on a duplicate tool key")
+		}
+	}()
+	s := newToolDialogSet()
+	s.registerToolDialog(func(*app.Session) {}, "ChamferTool")
+	s.registerToolDialog(func(*app.Session) {}, "ChamferTool")
+}

--- a/head/ui/viewport_cache.go
+++ b/head/ui/viewport_cache.go
@@ -6,8 +6,10 @@ import (
 	"strconv"
 	"strings"
 
+	"oblikovati.org/api/contract"
 	"oblikovati.org/app"
 	"oblikovati.org/kernel/ops"
+	"oblikovati.org/model/doc"
 	"oblikovati.org/renderer"
 	"oblikovati.org/scene"
 )
@@ -81,9 +83,26 @@ func bodyGeometryKey(s *app.Session) string {
 	return b.String()
 }
 
+// activeDocumentSource is the slim session surface a viewport helper needs to reach the
+// active document (audit I5, the arrowSession pattern). *app.Session satisfies it.
+type activeDocumentSource interface {
+	ActiveDocument() *doc.Document
+}
+
+var _ activeDocumentSource = (*app.Session)(nil)
+
+// edgeColorSource is the active document plus its per-document display settings — the slim
+// surface displayEdgeColor consumes.
+type edgeColorSource interface {
+	activeDocumentSource
+	DocumentDisplaySettings(id doc.ID) contract.DisplaySettings
+}
+
+var _ edgeColorSource = (*app.Session)(nil)
+
 // displayEdgeColor is the active document's display-settings edge color as an rgba float array,
 // falling back to the renderer's default when there is no active document (M16-F07 #643).
-func displayEdgeColor(s *app.Session) [4]float32 {
+func displayEdgeColor(s edgeColorSource) [4]float32 {
 	if s.ActiveDocument() == nil {
 		return renderer.DefaultEdgeColor()
 	}
@@ -97,7 +116,7 @@ type modelGeometryVersioned interface{ ModelGeometryVersion() string }
 
 // activeModelGeometryVersion returns the active document's geometry version, or false when no
 // renderable model (part or assembly) is active — in which case there is nothing to cache.
-func activeModelGeometryVersion(s *app.Session) (string, bool) {
+func activeModelGeometryVersion(s activeDocumentSource) (string, bool) {
 	d := s.ActiveDocument()
 	if d == nil {
 		return "", false

--- a/kernel/brep/boolean_flush_test.go
+++ b/kernel/brep/boolean_flush_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// TestFlushFaceUnionShipsExactCoordinates is audit A4's flush-contact regression (#1600): the union
+// of two boxes sharing an EXACT face plane must come back watertight, at the analytic volume, and
+// with every output vertex coinciding EXACTLY with an operand vertex — no coordinate displaced. A
+// flush union resolves through the coplanar ON/ON path (not the tangency nudge), so exact coordinates
+// are already the contract; this pins it, and would catch any 1e-5 nudge leaking into a mating face.
+func TestFlushFaceUnionShipsExactCoordinates(t *testing.T) {
+	a := box(0, 0, 0, 2, 2, 2) // [0,2]³, V=8
+	b := box(0, 0, 2, 2, 2, 2) // [0,2]²×[2,4], V=8; shares the whole z=2 face with a
+	res, err := brep.Boolean(brep.Union, a, b)
+	if err != nil {
+		t.Fatalf("flush union: %v", err)
+	}
+	checkSolid(t, "flush-face-union", res, 16) // two abutting 8-vol boxes → one 2×2×4 box
+	assertVerticesAreOperandExact(t, "flush-face-union", res, a, b)
+}
+
+// TestBossFlushUnionShipsExactCoordinates is the issue's headline case: a boss seated FLUSH on a wall
+// (a smaller box whose bottom face lies exactly in the target's top face). The boss rim imprints the
+// wall's top face; every result vertex — the wall corners, the boss corners, and the imprinted rim
+// points (which ARE the boss's bottom corners) — must stay at its exact operand coordinate.
+func TestBossFlushUnionShipsExactCoordinates(t *testing.T) {
+	wall := box(0, 0, 0, 4, 4, 2) // top face at z=2, V=32
+	boss := box(1, 1, 2, 2, 2, 2) // bottom face flush on the wall's top, V=8
+	res, err := brep.Boolean(brep.Union, wall, boss)
+	if err != nil {
+		t.Fatalf("boss-flush union: %v", err)
+	}
+	checkSolid(t, "boss-flush-union", res, 40) // 32 + 8, zero overlap volume
+	assertVerticesAreOperandExact(t, "boss-flush-union", res, wall, boss)
+}
+
+// assertVerticesAreOperandExact fails if any result vertex is farther than a float-noise tolerance
+// (1e-9 cm) from the NEAREST operand vertex. For a flush union no new interior intersection vertices
+// arise (the mating faces are coplanar and drop out), so every survivor must be an exact operand
+// corner — a 0.1 µm tangency nudge would move an operand's corners off this set and be caught.
+func assertVerticesAreOperandExact(t *testing.T, label string, res *topo.Body, operands ...*topo.Body) {
+	t.Helper()
+	var src []math.Point3
+	for _, o := range operands {
+		for _, v := range o.Vertices() {
+			src = append(src, v.Point())
+		}
+	}
+	for _, v := range res.Vertices() {
+		if d := nearestPointDistance(v.Point(), src); d > 1e-9 {
+			t.Errorf("%s: result vertex %v sits %g cm off every operand vertex (>1e-9) — the boolean "+
+				"displaced flush geometry; coordinates must be exact, no nudge", label, v.Point(), d)
+		}
+	}
+}
+
+// nearestPointDistance returns the distance from p to the closest point in pts (+Inf if pts empty).
+func nearestPointDistance(p math.Point3, pts []math.Point3) float64 {
+	best := stdmath.Inf(1)
+	for _, q := range pts {
+		if d := float64(p.DistanceTo(q)); d < best {
+			best = d
+		}
+	}
+	return best
+}

--- a/kernel/exchange/step/geommap/curve_to_step.go
+++ b/kernel/exchange/step/geommap/curve_to_step.go
@@ -10,24 +10,43 @@ import (
 	"oblikovati.org/math"
 )
 
-// CurveToStep emits the STEP curve for a kernel edge curve and returns its id plus
-// the EDGE_CURVE.same_sense flag relating the STEP curve's natural direction to the
-// kernel edge's start→end direction. A LINE/CIRCLE is always emitted same_sense
-// agreeing with start→end, except an Arc3d swept clockwise emits same_sense=.F.
-// (the CIRCLE's natural direction is CCW about its normal).
-func (e *Emitter) CurveToStep(c geom.Curve3) (id int, sameSense bool, err error) {
-	switch v := c.(type) {
-	case geom.LineSegment:
+// stepCurveWriter emits a STEP curve for one analytic curve kind, returning its id and the
+// EDGE_CURVE.same_sense flag (the STEP curve's natural direction vs the edge's start→end).
+type stepCurveWriter func(e *Emitter, c geom.Curve3) (int, bool, error)
+
+// stepCurveWriters is the table-driven routing from curve kind to STEP emitter (audit I6);
+// coverage is a map-keys check against geom.CurveKinds (TestStepCurveWriterCoverage).
+var stepCurveWriters = map[geom.CurveKind]stepCurveWriter{
+	geom.CurveLineSegment: func(e *Emitter, c geom.Curve3) (int, bool, error) {
+		v := c.(geom.LineSegment)
 		return e.lineToStep(v.StartPoint, v.StartPoint.VectorTo(v.EndPoint)), true, nil
-	case geom.Line:
+	},
+	geom.CurveLine: func(e *Emitter, c geom.Curve3) (int, bool, error) {
+		v := c.(geom.Line)
 		return e.lineToStep(v.Origin, v.Dir.AsVector()), true, nil
-	case geom.Circle:
+	},
+	geom.CurveCircle: func(e *Emitter, c geom.Curve3) (int, bool, error) {
+		v := c.(geom.Circle)
 		return e.circleToStep(v.Center, v.Normal.AsVector(), v.RefDir.AsVector(), v.Radius), true, nil
-	case geom.Arc3d:
-		return e.arcToStep(v)
-	default:
-		return 0, false, fmt.Errorf("geommap: cannot export curve type %T to STEP", c)
+	},
+	geom.CurveArc: func(e *Emitter, c geom.Curve3) (int, bool, error) { return e.arcToStep(c.(geom.Arc3d)) },
+}
+
+// CurveToStep emits the STEP curve for a kernel edge curve and returns its id plus the
+// EDGE_CURVE.same_sense flag. A LINE/CIRCLE is always emitted same_sense agreeing with
+// start→end, except an Arc3d swept clockwise emits same_sense=.F. (the CIRCLE's natural
+// direction is CCW about its normal). A curve kind without a writer errors, naming the kind
+// and consumer.
+func (e *Emitter) CurveToStep(c geom.Curve3) (id int, sameSense bool, err error) {
+	kc, ok := c.(geom.KindedCurve)
+	if !ok {
+		return 0, false, fmt.Errorf("geommap.CurveToStep: curve type %T is not a geom.KindedCurve", c)
 	}
+	write, ok := stepCurveWriters[kc.Kind()]
+	if !ok {
+		return 0, false, fmt.Errorf("geommap.CurveToStep: no STEP writer for curve kind %v (%T) — analytic export is table-driven; add a writer or fall back to a polyline", kc.Kind(), c)
+	}
+	return write(e, c)
 }
 
 // lineToStep emits LINE(point, VECTOR(direction, 1.0)).

--- a/kernel/exchange/step/geommap/kind_coverage_test.go
+++ b/kernel/exchange/step/geommap/kind_coverage_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geommap
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+)
+
+// Audit I6: the STEP analytic export is table-driven (stepSurfaceWriters / stepCurveWriters
+// keyed on geom kind). These coverage tests enumerate the geom kind enum and assert every
+// kind is EITHER handled by a writer OR explicitly declared unsupported with a reason — so a
+// new geom kind that no one wired fails here, at CI, instead of silently hitting the
+// table-miss default at runtime (the #1403 class this refactor closes for STEP export).
+
+// stepSurfaceUnsupported are the surface kinds with no STEP analytic entity; export falls
+// back to a tessellated face (deferred to PBI-E). Each names why — an undeclared gap fails.
+var stepSurfaceUnsupported = map[geom.SurfaceKind]string{
+	geom.SurfaceBSpline:            "B_SPLINE_SURFACE export deferred to PBI-E (tessellated-face fallback for now)",
+	geom.SurfaceEllipticalCylinder: "no STEP analytic entity for an elliptical cylinder; exported via tessellation",
+	geom.SurfaceEllipticalCone:     "no STEP analytic entity for an elliptical cone; exported via tessellation",
+	geom.SurfaceOffset:             "offset surface has no direct STEP entity; exported via tessellation",
+	geom.SurfaceThreadedCylinder:   "thread is cosmetic; export the underlying cylinder, not a distinct entity",
+}
+
+func TestStepSurfaceWriterCoverage(t *testing.T) {
+	for _, k := range geom.SurfaceKinds() {
+		_, hasWriter := stepSurfaceWriters[k]
+		reason, declared := stepSurfaceUnsupported[k]
+		if hasWriter && declared {
+			t.Errorf("surface kind %v is both a STEP writer and declared unsupported — remove one", k)
+		}
+		if !hasWriter && !declared {
+			t.Errorf("surface kind %v has no STEP writer and is not in stepSurfaceUnsupported — add a writer "+
+				"or declare it unsupported with a reason (audit I6)", k)
+		}
+		if declared && reason == "" {
+			t.Errorf("surface kind %v is declared unsupported with an empty reason", k)
+		}
+	}
+	assertNoStaleSurfaceUnsupported(t)
+}
+
+func assertNoStaleSurfaceUnsupported(t *testing.T) {
+	t.Helper()
+	for k := range stepSurfaceUnsupported {
+		if _, hasWriter := stepSurfaceWriters[k]; hasWriter {
+			t.Errorf("stepSurfaceUnsupported entry %v now has a writer — delete the stale entry", k)
+		}
+	}
+}
+
+// stepCurveUnsupported are the curve kinds with no STEP analytic writer yet; export falls
+// back to a polyline/tessellation.
+var stepCurveUnsupported = map[geom.CurveKind]string{
+	geom.CurvePolyline:      "polyline is emitted as its constituent segments, not a single STEP entity",
+	geom.CurveEllipse:       "ELLIPSE export not yet implemented; falls back to a polyline",
+	geom.CurveEllipticalArc: "elliptical-arc export not yet implemented; falls back to a polyline",
+	geom.CurveHyperbolicArc: "HYPERBOLA export not yet implemented; falls back to a polyline",
+	geom.CurveParabola:      "PARABOLA export not yet implemented; falls back to a polyline",
+	geom.CurveBSpline:       "B_SPLINE_CURVE export handled by bspline_from_step's inverse path, not this table",
+	geom.CurveHelix:         "helix has no STEP analytic entity; exported via a polyline",
+	geom.CurveVariableHelix: "variable-pitch helix has no STEP analytic entity; exported via a polyline",
+	geom.CurveSpiric:        "spiric arc (torus-section) has no STEP analytic entity; exported via a polyline",
+}
+
+func TestStepCurveWriterCoverage(t *testing.T) {
+	for _, k := range geom.CurveKinds() {
+		_, hasWriter := stepCurveWriters[k]
+		reason, declared := stepCurveUnsupported[k]
+		if hasWriter && declared {
+			t.Errorf("curve kind %v is both a STEP writer and declared unsupported — remove one", k)
+		}
+		if !hasWriter && !declared {
+			t.Errorf("curve kind %v has no STEP writer and is not in stepCurveUnsupported — add a writer "+
+				"or declare it unsupported with a reason (audit I6)", k)
+		}
+		if declared && reason == "" {
+			t.Errorf("curve kind %v is declared unsupported with an empty reason", k)
+		}
+	}
+	for k := range stepCurveUnsupported {
+		if _, hasWriter := stepCurveWriters[k]; hasWriter {
+			t.Errorf("stepCurveUnsupported entry %v now has a writer — delete the stale entry", k)
+		}
+	}
+}

--- a/kernel/exchange/step/geommap/surface_to_step.go
+++ b/kernel/exchange/step/geommap/surface_to_step.go
@@ -11,24 +11,34 @@ import (
 	"oblikovati.org/math"
 )
 
-// SurfaceToStep emits a STEP surface entity for s, returning its id. The analytic
-// surfaces map exactly; an unhandled surface type errors (the caller may then fall
-// back to a tessellated face — deferred to PBI-E).
+// stepSurfaceWriter emits a STEP entity for one analytic surface kind, returning its id.
+type stepSurfaceWriter func(e *Emitter, s geom.Surface) (int, error)
+
+// stepSurfaceWriters is the table-driven routing from surface kind to STEP emitter (audit
+// I6): coverage is a map-keys check against geom.SurfaceKinds (TestStepSurfaceWriterCoverage),
+// not a switch audit, so a new geom kind that lacks a writer AND is not declared unsupported
+// fails CI instead of falling into a silent default.
+var stepSurfaceWriters = map[geom.SurfaceKind]stepSurfaceWriter{
+	geom.SurfacePlane:    func(e *Emitter, s geom.Surface) (int, error) { return e.planeToStep(s.(geom.Plane)), nil },
+	geom.SurfaceCylinder: func(e *Emitter, s geom.Surface) (int, error) { return e.cylinderToStep(s.(geom.Cylinder)), nil },
+	geom.SurfaceCone:     func(e *Emitter, s geom.Surface) (int, error) { return e.coneToStep(s.(geom.Cone)), nil },
+	geom.SurfaceSphere:   func(e *Emitter, s geom.Surface) (int, error) { return e.sphereToStep(s.(geom.Sphere)), nil },
+	geom.SurfaceTorus:    func(e *Emitter, s geom.Surface) (int, error) { return e.torusToStep(s.(geom.Torus)), nil },
+}
+
+// SurfaceToStep emits a STEP surface entity for s, returning its id. The analytic surfaces
+// with a STEP entity map exactly; a surface kind without a writer errors, naming the kind
+// and consumer (the caller may then fall back to a tessellated face — deferred to PBI-E).
 func (e *Emitter) SurfaceToStep(s geom.Surface) (int, error) {
-	switch v := s.(type) {
-	case geom.Plane:
-		return e.planeToStep(v), nil
-	case geom.Cylinder:
-		return e.cylinderToStep(v), nil
-	case geom.Cone:
-		return e.coneToStep(v), nil
-	case geom.Sphere:
-		return e.sphereToStep(v), nil
-	case geom.Torus:
-		return e.torusToStep(v), nil
-	default:
-		return 0, fmt.Errorf("geommap: cannot export surface type %T to STEP", s)
+	ks, ok := s.(geom.KindedSurface)
+	if !ok {
+		return 0, fmt.Errorf("geommap.SurfaceToStep: surface type %T is not a geom.KindedSurface", s)
 	}
+	write, ok := stepSurfaceWriters[ks.Kind()]
+	if !ok {
+		return 0, fmt.Errorf("geommap.SurfaceToStep: no STEP writer for surface kind %v (%T) — analytic export is table-driven; add a writer or fall back to tessellation", ks.Kind(), s)
+	}
+	return write(e, s)
 }
 
 // planeToStep emits PLANE with a placement at the plane origin, Z=normal, X=UAxis.

--- a/kernel/geom/evaluator_surface_query.go
+++ b/kernel/geom/evaluator_surface_query.go
@@ -250,13 +250,24 @@ func ellipticNature(major, minor float64) SolutionNature {
 // surfaceSeed is one refined closest-point candidate in parameter space.
 type surfaceSeed struct{ u, v float64 }
 
-// bsplineParamAtPoint searches a coarse grid for near-minimal cells, refines
-// each with the seeded projector, and clusters the winners.
+// bsplineParamAtPoint seeds a knot-span-aware lattice (one basin per span, #1608),
+// refines the near-minimal cells with the seeded projector, and clusters the winners so
+// a point equidistant from several feet is reported as DistinctlyManySolutions.
 func bsplineParamAtPoint(g BSplineSurface, p math.Point3) (float64, float64, SolutionNature) {
-	const grid = 24
-	uLo, uHi := g.UDomain()
-	vLo, vHi := g.VDomain()
-	us, vs, ds, best := surfaceGridDistances(g, p, uLo, uHi, vLo, vHi, grid)
+	uSeeds := knotSpanSeedParams(g.UKnots, g.UDegree)
+	vSeeds := knotSpanSeedParams(g.VKnots, g.VDegree)
+	us, vs, ds, best := seedLatticeDistances(g, p, uSeeds, vSeeds)
+	uW, vW := minSeedSpacing(uSeeds), minSeedSpacing(vSeeds)
+	bestU, bestV, clusters := refineSeedClusters(g, p, us, vs, ds, best, uW, vW)
+	if len(clusters) > 1 {
+		return bestU, bestV, DistinctlyManySolutions
+	}
+	return bestU, bestV, UniqueSolution
+}
+
+// refineSeedClusters polishes every seed within tol of the best coarse distance and
+// returns the closest foot plus the distinct feet it clustered into (uW, vW: merge radii).
+func refineSeedClusters(g BSplineSurface, p math.Point3, us, vs, ds []float64, best, uW, vW float64) (float64, float64, []surfaceSeed) {
 	tol := 1e-9 * stdmath.Max(1, best)
 	var clusters []surfaceSeed
 	bestU, bestV, refinedBest := us[0], vs[0], stdmath.Inf(1)
@@ -269,23 +280,19 @@ func bsplineParamAtPoint(g BSplineSurface, p math.Point3) (float64, float64, Sol
 		if rd < refinedBest-tol {
 			refinedBest, bestU, bestV, clusters = rd, ru, rv, clusters[:0]
 		}
-		if rd <= refinedBest+tol && !inSeedCluster(clusters, ru, rv, (uHi-uLo)/grid, (vHi-vLo)/grid) {
+		if rd <= refinedBest+tol && !inSeedCluster(clusters, ru, rv, uW, vW) {
 			clusters = append(clusters, surfaceSeed{ru, rv})
 		}
 	}
-	if len(clusters) > 1 {
-		return bestU, bestV, DistinctlyManySolutions
-	}
-	return bestU, bestV, UniqueSolution
+	return bestU, bestV, clusters
 }
 
-// surfaceGridDistances samples the distance field on a uniform parameter grid.
-func surfaceGridDistances(s Surface, p math.Point3, uLo, uHi, vLo, vHi float64, grid int) (us, vs, ds []float64, best float64) {
+// seedLatticeDistances evaluates the distance field on the uSeeds×vSeeds knot-span lattice,
+// returning the flattened (u, v, d) samples and the minimum distance found.
+func seedLatticeDistances(s Surface, p math.Point3, uSeeds, vSeeds []float64) (us, vs, ds []float64, best float64) {
 	best = stdmath.Inf(1)
-	for i := 0; i <= grid; i++ {
-		for j := 0; j <= grid; j++ {
-			u := uLo + (uHi-uLo)*float64(i)/float64(grid)
-			v := vLo + (vHi-vLo)*float64(j)/float64(grid)
+	for _, u := range uSeeds {
+		for _, v := range vSeeds {
 			d := s.PointAt(u, v).DistanceTo(p)
 			us, vs, ds = append(us, u), append(vs, v), append(ds, d)
 			best = stdmath.Min(best, d)

--- a/kernel/geom/intersect2d_bezier_clip.go
+++ b/kernel/geom/intersect2d_bezier_clip.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// Bézier-clipping intersection of a 2D B-spline curve with a straight support line (Oblikovati#1608,
+// audit A12). The retired 256-sample sign-change bracketing (intersect2d_curve.go) saw only
+// TRANSVERSAL crossings: an even-multiplicity contact — a curve tangent to the line — touches the
+// signed field's zero without changing sign, so no bracket ever formed and the contact was invisible
+// in trim/offset paths. Bézier clipping is certified. On each Bézier segment the signed line distance
+// is a scalar Bézier N(t) = Σ wᵢ·f(Pᵢ)·Bᵢ(t): because f is affine and the rational weights sum to a
+// strictly positive denominator, sign(f(C(t))) = sign(N(t)) with the SAME root multiplicities. The
+// convex-hull property then isolates every root — a sub-interval whose control coefficients are all
+// one sign holds no root (discard); one straddling zero is subdivided until it isolates the single or
+// tangential root. Sederberg & Nishita, "Curve intersection using Bézier clipping" (CAD 1990).
+
+// bezierRootIters bounds the convex-hull subdivision depth: 60 halvings shrink a sub-interval below
+// 1e-18 of a Bézier segment — past float64 resolution — mirroring bisectCurveZero's iteration floor.
+const bezierRootIters = 60
+
+// bezierSeg2d is one Bézier piece of a decomposed B-spline: its degree+1 control points and weights,
+// and the [t0, t1] sub-domain of the parent curve it spans (so a local root maps back to the curve).
+type bezierSeg2d struct {
+	ctrl   []math.Point2
+	w      []float64
+	t0, t1 float64
+}
+
+// lineBSpline2dIntersection returns every point where the affine field f (a line/segment side) meets
+// the B-spline c, including even-multiplicity tangential contacts, via per-segment Bézier clipping.
+// Acceptance is model-relative (ADR-0042): a candidate is a contact only if it lands within the
+// on-line tolerance, and duplicates within the weld tolerance (a root on a segment seam) merge.
+func lineBSpline2dIntersection(f func(math.Point2) float64, c BSplineCurve2d) []math.Point2 {
+	res := ResolutionForPoints2D(c.Ctrl)
+	var pts []math.Point2
+	for _, seg := range bezierSegments2d(c) {
+		for _, s := range bezierSegmentRoots(seg, f) {
+			p := c.PointAt(seg.t0 + s*(seg.t1-seg.t0))
+			if stdmath.Abs(f(p)) <= res.Plane() && !containsPoint2(pts, p, res.Weld()) {
+				pts = append(pts, p)
+			}
+		}
+	}
+	return pts
+}
+
+// bezierSegmentRoots isolates the local [0,1] roots of the affine field over one Bézier segment: the
+// scalar field-Bézier coefficients are dᵢ = wᵢ·f(Pᵢ) (see file header), clipped by the convex hull.
+func bezierSegmentRoots(seg bezierSeg2d, f func(math.Point2) float64) []float64 {
+	d := make([]float64, len(seg.ctrl))
+	for i, p := range seg.ctrl {
+		d[i] = seg.w[i] * f(p)
+	}
+	var roots []float64
+	clipBezierRoots(d, 0, 1, bezierRootIters, &roots)
+	return roots
+}
+
+// clipBezierRoots appends every root of the scalar Bézier (control coefficients d) in [lo,hi]. A hull
+// that does not straddle zero holds no root; otherwise the segment is subdivided (de Casteljau) and
+// each half recursed, so an even-multiplicity touch is isolated exactly like a transversal crossing.
+func clipBezierRoots(d []float64, lo, hi float64, iter int, out *[]float64) {
+	if !hullStraddlesZero(d) {
+		return
+	}
+	if iter <= 0 {
+		*out = append(*out, (lo+hi)/2)
+		return
+	}
+	left, right := splitBezierHalf(d)
+	mid := (lo + hi) / 2
+	clipBezierRoots(left, lo, mid, iter-1, out)
+	clipBezierRoots(right, mid, hi, iter-1, out)
+}
+
+// hullStraddlesZero reports whether the Bézier control coefficients bracket zero — the convex-hull
+// necessary condition for a root in the interval (variation-diminishing property).
+func hullStraddlesZero(d []float64) bool {
+	lo, hi := d[0], d[0]
+	for _, v := range d[1:] {
+		lo, hi = stdmath.Min(lo, v), stdmath.Max(hi, v)
+	}
+	return lo <= 0 && hi >= 0
+}
+
+// splitBezierHalf subdivides a scalar Bézier at t=0.5 (de Casteljau), returning the control
+// coefficients of the left and right halves.
+func splitBezierHalf(d []float64) (left, right []float64) {
+	n := len(d)
+	tmp := append([]float64(nil), d...)
+	left, right = make([]float64, n), make([]float64, n)
+	left[0], right[n-1] = tmp[0], tmp[n-1]
+	for i := 1; i < n; i++ {
+		for j := 0; j < n-i; j++ {
+			tmp[j] = (tmp[j] + tmp[j+1]) / 2
+		}
+		left[i], right[n-1-i] = tmp[0], tmp[n-1-i]
+	}
+	return left, right
+}
+
+// bezierSegments2d decomposes a 2D B-spline into its Bézier segments by inserting every interior knot
+// to full multiplicity (Piegl & Tiller §5.6): the refined control net then splits into degree+1-point
+// Bézier pieces sharing seam points, one per knot span. A knot insertion that fails to validate leaves
+// the original span un-split — clipping still runs on the whole span, only less tightly bracketed.
+func bezierSegments2d(c BSplineCurve2d) []bezierSeg2d {
+	breaks := domainBreakpoints(c.Knots, c.Degree)
+	refined := c
+	for _, u := range breaks[1 : len(breaks)-1] {
+		if add := c.Degree - knotMultiplicity(c.Knots, u); add > 0 {
+			if r, err := refined.InsertKnot(u, add); err == nil {
+				refined = r
+			}
+		}
+	}
+	return sliceBezierSegments(refined, breaks)
+}
+
+// sliceBezierSegments carves the fully knot-refined curve into per-span Bézier control groups; segment
+// k owns control points [k·degree, k·degree+degree] and the parent domain [breaks[k], breaks[k+1]].
+func sliceBezierSegments(c BSplineCurve2d, breaks []float64) []bezierSeg2d {
+	d := c.Degree
+	segs := make([]bezierSeg2d, 0, len(breaks)-1)
+	for k := 0; k+1 < len(breaks) && k*d+d < len(c.Ctrl); k++ {
+		lo := k * d
+		segs = append(segs, bezierSeg2d{ctrl: c.Ctrl[lo : lo+d+1], w: c.Weights[lo : lo+d+1], t0: breaks[k], t1: breaks[k+1]})
+	}
+	return segs
+}
+
+// containsPoint2 reports whether p already appears in pts within tol.
+func containsPoint2(pts []math.Point2, p math.Point2, tol float64) bool {
+	for _, q := range pts {
+		if float64(q.DistanceTo(p)) <= tol {
+			return true
+		}
+	}
+	return false
+}

--- a/kernel/geom/intersect2d_curve.go
+++ b/kernel/geom/intersect2d_curve.go
@@ -32,7 +32,7 @@ func SegmentCurve2dIntersection(seg LineSegment2d, c Curve2) []math.Point2 {
 		return float64(dir.Cross(seg.StartPoint.VectorTo(p)))
 	}
 	var out []math.Point2
-	for _, p := range curveSignedCrossings(c, side) {
+	for _, p := range curve2dLineCrossings(c, side) {
 		if t := projectOnSegment(seg, p); t >= 0 && t <= 1 {
 			out = append(out, p)
 		}
@@ -45,6 +45,16 @@ func SegmentCurve2dIntersection(seg LineSegment2d, c Curve2) []math.Point2 {
 func LineCurve2dIntersection(l Line2d, c Curve2) []math.Point2 {
 	side := func(p math.Point2) float64 {
 		return float64(l.Dir.AsVector().Cross(l.Origin.VectorTo(p)))
+	}
+	return curve2dLineCrossings(c, side)
+}
+
+// curve2dLineCrossings finds where the affine field side (a line/segment signed distance) meets c. A
+// B-spline routes through certified Bézier clipping so even-multiplicity tangential contacts are found
+// (#1608); every other curve type keeps the sign-change bracketing (its analytic pairs are exact).
+func curve2dLineCrossings(c Curve2, side func(math.Point2) float64) []math.Point2 {
+	if bs, ok := c.(BSplineCurve2d); ok {
+		return lineBSpline2dIntersection(side, bs)
 	}
 	return curveSignedCrossings(c, side)
 }

--- a/kernel/geom/intersect2d_curve_test.go
+++ b/kernel/geom/intersect2d_curve_test.go
@@ -69,6 +69,32 @@ func TestCircleCurve2dIntersectionEllipse(t *testing.T) {
 	}
 }
 
+// TestLineCurve2dTangentialContact is the #1608 even-multiplicity regression: the quadratic
+// Bézier with y(t) = (3t−2)² is tangent to the x-axis at t = 2/3 — the field touches zero
+// WITHOUT changing sign, so sample-and-bracket seeding can never see it (and t = 2/3 is not
+// a dyadic sample, so no sample lands on the zero by luck). The certified root isolation
+// must report exactly the one contact, at (11/9, 0).
+func TestLineCurve2dTangentialContact(t *testing.T) {
+	curve, err := NewBSplineCurve2dUniformWeights(2,
+		[]math.Point2{math.P2(-1, 4), math.P2(1, -2), math.P2(2, 1)},
+		[]float64{0, 0, 0, 1, 1, 1})
+	if err != nil {
+		t.Fatalf("NewBSplineCurve2dUniformWeights: %v", err)
+	}
+	axis, err := NewLine2d(math.P2(0, 0), math.V2(1, 0))
+	if err != nil {
+		t.Fatalf("NewLine2d: %v", err)
+	}
+	hits := LineCurve2dIntersection(axis, curve)
+	if len(hits) != 1 {
+		t.Fatalf("tangential contacts = %d (%v), want exactly 1 at (11/9, 0)", len(hits), hits)
+	}
+	want := math.P2(11.0/9.0, 0)
+	if hits[0].DistanceTo(want) > 1e-5 {
+		t.Errorf("contact = %v, want %v within 1e-5", hits[0], want)
+	}
+}
+
 // TestLineCurve2dIntersectionBSpline: a fitted spline through a known zigzag
 // crosses the x-axis once per sign change of its fit points, on the curve.
 func TestLineCurve2dIntersectionBSpline(t *testing.T) {

--- a/kernel/geom/intersect_surface_seed.go
+++ b/kernel/geom/intersect_surface_seed.go
@@ -26,9 +26,15 @@ const (
 	// zero, and never sampled where it is not.
 	ssiSeedCoarse   = 8
 	ssiSeedMaxDepth = 7
-	// ssiSeedSafety inflates the tangent-magnitude variation bound so the prune stays conservative when
-	// corner sampling underestimates a larger interior tangent. With it no zero is pruned in practice;
-	// a rigorous bound would use the NURBS control-net derivative hodograph (deferred).
+	// ssiSeedCoarseMax caps the knot-span-aware coarse subdivision (#1608) so a pathological
+	// import with thousands of tiny spans cannot allocate an unbounded coarse lattice; beyond
+	// it the adaptive quadtree still resolves finer features per cell.
+	ssiSeedCoarseMax = 96
+	// ssiSeedSafety inflates the SAMPLED corner-tangent bound in the fallback path only — for a surface
+	// type with no rigorous hodograph bound (a rational NURBS, an unknown Surface). The primary path now
+	// uses a certified boxTangentBounder (tangent_bound.go, #1608), so this guess is no longer on the
+	// critical path; when it is used the field records a decline (ssiSeedField.declined) rather than
+	// silently trusting a guess (issue #1608 point 5).
 	ssiSeedSafety = 2.0
 )
 
@@ -37,11 +43,14 @@ const (
 // computed once. evals counts the (expensive, projection-bearing) field evaluations actually performed —
 // the metric the adaptive seeder drives down versus the fixed grid.
 type ssiSeedField struct {
-	base, other Surface
-	u0, v0      float64 // lattice origin (UMin, VMin)
-	du, dv      float64 // finest lattice spacing (one max-depth cell)
-	cache       map[[2]int]ssiSample
-	evals       int
+	base, other      Surface
+	bounder          boxTangentBounder // certified per-cell tangent bound; nil ⇒ sampled fallback (#1608)
+	declined         bool              // set when a cell fell back to the sampled 2.0 bound (issue #1608 pt5)
+	u0, v0           float64           // lattice origin (UMin, VMin)
+	du, dv           float64           // finest lattice spacing (one max-depth cell)
+	coarseU, coarseV int               // knot-span-aware initial subdivisions per axis (#1608)
+	cache            map[[2]int]ssiSample
+	evals            int
 }
 
 // ssiSample is one lattice node: the signed-distance field f and the base surface tangent magnitudes
@@ -76,14 +85,35 @@ func (c *ssiSeedField) point(i, j int) math.Point3 {
 // newSSISeedField builds the cached dyadic-lattice field over the base parameter window. The finest
 // lattice is ssiSeedCoarse·2^ssiSeedMaxDepth nodes per axis; the quadtree samples it adaptively.
 func newSSISeedField(base, other Surface, g SurfaceGrid) *ssiSeedField {
-	nodes := float64(ssiSeedCoarse << ssiSeedMaxDepth)
+	bounder, _ := base.(boxTangentBounder)
+	coarseU, coarseV := ssiCoarseCounts(base)
+	res := float64(int(1) << ssiSeedMaxDepth)
 	return &ssiSeedField{
-		base: base, other: other,
+		base: base, other: other, bounder: bounder,
 		u0: g.UMin, v0: g.VMin,
-		du:    (g.UMax - g.UMin) / nodes,
-		dv:    (g.VMax - g.VMin) / nodes,
+		du:      (g.UMax - g.UMin) / (float64(coarseU) * res),
+		dv:      (g.VMax - g.VMin) / (float64(coarseV) * res),
+		coarseU: coarseU, coarseV: coarseV,
 		cache: map[[2]int]ssiSample{},
 	}
+}
+
+// ssiCoarseCounts returns the initial quadtree subdivision per axis: ≈one cell per knot span
+// (clamped to [ssiSeedCoarse, ssiSeedCoarseMax]) for a B-spline base, else the fixed
+// ssiSeedCoarse. A span-sized coarse cell is the fix for the aliasing that dropped whole
+// intersection loops on high-span imports (#1608).
+func ssiCoarseCounts(base Surface) (int, int) {
+	counter, ok := base.(ssiSpanCounter)
+	if !ok {
+		return ssiSeedCoarse, ssiSeedCoarse
+	}
+	uSpans, vSpans := counter.knotSpanCounts()
+	return clampInt(uSpans, ssiSeedCoarse, ssiSeedCoarseMax), clampInt(vSpans, ssiSeedCoarse, ssiSeedCoarseMax)
+}
+
+// clampInt returns v clamped to [lo, hi].
+func clampInt(v, lo, hi int) int {
+	return max(lo, min(v, hi))
 }
 
 // ssiSeedSink collects seeds in two tiers so transversal crossings are returned BEFORE interior minima.
@@ -114,8 +144,8 @@ func ssiSeeds(base, other Surface, g SurfaceGrid) []math.Point3 {
 func (c *ssiSeedField) seeds(leaf float64) []math.Point3 {
 	res := 1 << ssiSeedMaxDepth
 	sink := &ssiSeedSink{}
-	for ci := 0; ci < ssiSeedCoarse; ci++ {
-		for cj := 0; cj < ssiSeedCoarse; cj++ {
+	for ci := 0; ci < c.coarseU; ci++ {
+		for cj := 0; cj < c.coarseV; cj++ {
 			c.refine(ci*res, cj*res, (ci+1)*res, (cj+1)*res, leaf, sink)
 		}
 	}
@@ -133,12 +163,14 @@ func (c *ssiSeedField) refine(i0, j0, i1, j1 int, leaf float64, sink *ssiSeedSin
 	s00, s10, s01, s11 := c.at(i0, j0), c.at(i1, j0), c.at(i0, j1), c.at(i1, j1)
 	minAbs := min(stdmath.Abs(s00.f), stdmath.Abs(s10.f), stdmath.Abs(s01.f), stdmath.Abs(s11.f))
 	su, sv := float64(i1-i0)*c.du, float64(j1-j0)*c.dv
-	tu := max(s00.tu, s10.tu, s01.tu, s11.tu)
-	tv := max(s00.tv, s10.tv, s01.tv, s11.tv)
-	variation := ssiSeedSafety * (tu*su + tv*sv) // upper bound on |Δf| across the cell (|∇f| ≤ 1)
+	tu, tv := c.cellTangentBound(i0, i1, j0, j1, s00, s10, s01, s11)
+	variation := tu*su + tv*sv // certified upper bound on |Δf| across the cell (|∇f| ≤ 1)
 	if minAbs > variation {
 		return // every interior point keeps a corner's sign: no crossing here
 	}
+	// A clean two-edge crossing resolves to one curve — safe now that the coarse cells are
+	// knot-span-sized (ssiCoarseCounts, #1608), so several parallel crossings can no longer
+	// alias to one pattern the way they did under the retired fixed 8×8 coarse grid.
 	if variation <= leaf || i1-i0 <= 1 || j1-j0 <= 1 || ssiCrossings(s00, s10, s01, s11) == 2 {
 		c.emitLeaf(i0, j0, i1, j1, s00, s10, s01, s11, sink)
 		return
@@ -148,6 +180,23 @@ func (c *ssiSeedField) refine(i0, j0, i1, j1 int, leaf float64, sink *ssiSeedSin
 	c.refine(im, j0, i1, jm, leaf, sink)
 	c.refine(i0, jm, im, j1, leaf, sink)
 	c.refine(im, jm, i1, j1, leaf, sink)
+}
+
+// cellTangentBound returns rigorous upper bounds on |S_u|,|S_v| over the cell: the certified
+// hodograph / closed-form bounder when the base surface offers one, else the sampled corner
+// tangents inflated by ssiSeedSafety — a guess, so the field records the decline (#1608 pt5).
+func (c *ssiSeedField) cellTangentBound(i0, i1, j0, j1 int, s00, s10, s01, s11 ssiSample) (float64, float64) {
+	if c.bounder != nil {
+		u0, u1 := c.u0+float64(i0)*c.du, c.u0+float64(i1)*c.du
+		v0, v1 := c.v0+float64(j0)*c.dv, c.v0+float64(j1)*c.dv
+		if tu, tv, ok := c.bounder.tangentBoundOverBox(u0, u1, v0, v1); ok {
+			return tu, tv
+		}
+	}
+	c.declined = true
+	tu := max(s00.tu, s10.tu, s01.tu, s11.tu)
+	tv := max(s00.tv, s10.tv, s01.tv, s11.tv)
+	return ssiSeedSafety * tu, ssiSeedSafety * tv
 }
 
 // ssiCrossings counts how many of the cell's four edges change sign — 2 for a simple transversal curve

--- a/kernel/geom/intersect_surface_seed_test.go
+++ b/kernel/geom/intersect_surface_seed_test.go
@@ -96,9 +96,15 @@ func TestSSIRippleFindsEveryCrossing(t *testing.T) {
 	if len(loops) != want {
 		t.Fatalf("traced %d intersection curves, want the analytic count %d — a crossing was silently dropped", len(loops), want)
 	}
+	// Every traced point must lie on BOTH surfaces: on the plane (z=0) AND — via the knot-span-aware
+	// point inversion (Piece 1) — back on the high-span ripple within the model-relative tolerance.
+	res := surfaceNetResolution(ripple)
 	for _, p := range allPoints(t, loops) {
 		if stdmath.Abs(float64(p.Z)) > 1e-4 { // tol:numeric — on-plane check vs the trace tolerance, not a weld
 			t.Errorf("traced point %v is off the z=0 plane", p)
+		}
+		if _, _, d := ProjectPointToSurface(ripple, p); d > res.Sew() {
+			t.Errorf("traced point %v inverts %g off the ripple (> %g) — seeding recovered the wrong foot", p, d, res.Sew())
 		}
 	}
 }

--- a/kernel/geom/intersect_surface_seed_test.go
+++ b/kernel/geom/intersect_surface_seed_test.go
@@ -81,9 +81,76 @@ func TestSSISeederPrunesEmptySpace(t *testing.T) {
 		c.evals, float64(fixedGridNodes)/float64(c.evals), fixedGridNodes)
 }
 
+// TestSSIRippleFindsEveryCrossing is the #1608 prune-soundness guard: a 24-span rippled
+// B-spline sheet (one bump per span) crossed by the z=0 plane meets it in one iso-u curve per
+// sign change of the sheet's height spline. The quadtree prune — now certified by the
+// hodograph derivative bound instead of a sampled 2.0 guess — must not discard any cell
+// containing a crossing, so the tracer must find EVERY crossing curve, not a grid-dependent
+// subset.
+func TestSSIRippleFindsEveryCrossing(t *testing.T) {
+	ripple := rippledSheet(t, 24, 1, 1.0, false)
+	plane, _ := NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+
+	want := rippleZeroCrossings(ripple, 4096)
+	loops := IntersectSurfaceSurface(ripple, plane, SurfaceGrid{})
+	if len(loops) != want {
+		t.Fatalf("traced %d intersection curves, want the analytic count %d — a crossing was silently dropped", len(loops), want)
+	}
+	for _, p := range allPoints(t, loops) {
+		if stdmath.Abs(float64(p.Z)) > 1e-4 { // tol:numeric — on-plane check vs the trace tolerance, not a weld
+			t.Errorf("traced point %v is off the z=0 plane", p)
+		}
+	}
+}
+
+// TestRippleSSIUsesCertifiedHodographBound is the #1608 no-guess guard: on the high-span sheet the
+// prune must run on the rigorous hodograph bound (never fall back to the sampled 2.0 factor), and that
+// bound must be a true upper bound on the surface's tangent magnitude — otherwise a crossing could be
+// pruned. It samples |S_u|,|S_v| densely and asserts the hodograph bound dominates every sample.
+func TestRippleSSIUsesCertifiedHodographBound(t *testing.T) {
+	ripple := rippledSheet(t, 24, 3, 1.0, true)
+	plane, _ := NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	g := resolveGrid(ripple, SurfaceGrid{})
+	f := newSSISeedField(ripple, plane, g)
+	f.seeds(ssiStep(ripple, g))
+	if f.declined {
+		t.Fatal("SSI prune fell back to the sampled 2.0 guess on a B-spline surface — hodograph bound not used")
+	}
+	su, sv, ok := ripple.tangentBoundOverBox(0, 1, 0, 1)
+	if !ok {
+		t.Fatal("non-rational B-spline reported no hodograph bound")
+	}
+	for i := 0; i <= 200; i++ {
+		du, dv := ripple.DerivativesAt(float64(i)/200, float64(i%40)/40)
+		if float64(du.Length()) > su+1e-9 || float64(dv.Length()) > sv+1e-9 {
+			t.Fatalf("hodograph bound (%.3f,%.3f) below actual tangent (%.3f,%.3f) — not an upper bound", su, sv, du.Length(), dv.Length())
+		}
+	}
+}
+
+// rippleZeroCrossings counts the sign changes of the sheet's height along u at mid-v by
+// dense sampling — the independent 1D oracle for the number of plane-crossing curves (the
+// ripple's z is constant in v by construction).
+func rippleZeroCrossings(s BSplineSurface, samples int) int {
+	uLo, uHi := s.UDomain()
+	vLo, vHi := s.VDomain()
+	vMid := (vLo + vHi) / 2
+	crossings := 0
+	prev := float64(s.PointAt(uLo, vMid).Z)
+	for i := 1; i <= samples; i++ {
+		z := float64(s.PointAt(uLo+(uHi-uLo)*float64(i)/float64(samples), vMid).Z)
+		if (prev > 0) != (z > 0) {
+			crossings++
+		}
+		prev = z
+	}
+	return crossings
+}
+
 // TestSSISeederBoundIsConservative checks the prune never discards a cell that brackets a crossing: the
-// field-variation bound must be at least the actual corner-to-corner field change. (A direct guard on
-// the Lipschitz bound that the whole approach rests on.)
+// certified tangent bound (cellTangentBound → the sphere's closed-form hodograph bound, #1608) times
+// the cell size must be at least the actual corner-to-corner field change. A direct guard on the
+// Lipschitz bound that the whole approach rests on — now on the rigorous bound, not the retired guess.
 func TestSSISeederBoundIsConservative(t *testing.T) {
 	big, _ := NewSphere(math.P3(0, 0, 0), 1)
 	other, _ := NewSphere(math.P3(1.2, 0, 0), 1)
@@ -93,8 +160,8 @@ func TestSSISeederBoundIsConservative(t *testing.T) {
 	res := 1 << ssiSeedMaxDepth
 	a, b := c.at(0, 0), c.at(res, res) // opposite corners of one coarse cell
 	su, sv := float64(res)*c.du, float64(res)*c.dv
-	bound := ssiSeedSafety * (max(a.tu, b.tu, a.tu, b.tu)*su + max(a.tv, b.tv, a.tv, b.tv)*sv)
-	if change := stdmath.Abs(a.f - b.f); bound < change {
-		t.Errorf("variation bound %g below the actual field change %g — prune could drop a crossing", bound, change)
+	tu, tv := c.cellTangentBound(0, res, 0, res, a, c.at(res, 0), c.at(0, res), b)
+	if bound := tu*su + tv*sv; bound < stdmath.Abs(a.f-b.f) {
+		t.Errorf("variation bound %g below the actual field change %g — prune could drop a crossing", bound, stdmath.Abs(a.f-b.f))
 	}
 }

--- a/kernel/geom/kind.go
+++ b/kernel/geom/kind.go
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+// Analytic special-casing of surfaces and curves is legitimate — OCCT does exactly this
+// (GeomAdaptor_Surface::GetType / GeomAbs_SurfaceType classify a closed analytic set through
+// one enum discriminator that every consumer switches on). The problem the audit (I6) names
+// is that our special-casing was UNCHECKABLE: ~77 `case geom.X:` type switches spread across
+// consumers, each deciding independently which kinds it handles and what its default does —
+// often a silent zero value (the #1403 class). Kind() is that single discriminator: every
+// surface/curve names its kind, so switches become enumerable data (a coverage test can probe
+// one instance of each kind), pure translators become tables keyed on the kind, and a new
+// kind that a consumer forgot fails that consumer's coverage test instead of falling into a
+// silent default.
+
+// SurfaceKind classifies the analytic and freeform surfaces. Add a value here AND its Kind()
+// method AND a probe in the coverage test (kind_coverage_test.go) when a new surface lands —
+// the coverage test enforces all three.
+type SurfaceKind uint8
+
+const (
+	SurfacePlane SurfaceKind = iota
+	SurfaceCylinder
+	SurfaceSphere
+	SurfaceCone
+	SurfaceTorus
+	SurfaceBSpline
+	SurfaceEllipticalCylinder
+	SurfaceEllipticalCone
+	SurfaceOffset
+	SurfaceThreadedCylinder
+	// surfaceKindCount is the sentinel one past the last real kind; range over
+	// [0, surfaceKindCount) to enumerate every SurfaceKind.
+	surfaceKindCount
+)
+
+// String names the kind for error messages (CLAUDE.md: exception messages name the value).
+func (k SurfaceKind) String() string {
+	if int(k) >= len(surfaceKindNames) {
+		return "SurfaceKind(?)"
+	}
+	return surfaceKindNames[k]
+}
+
+var surfaceKindNames = [...]string{
+	SurfacePlane:              "Plane",
+	SurfaceCylinder:           "Cylinder",
+	SurfaceSphere:             "Sphere",
+	SurfaceCone:               "Cone",
+	SurfaceTorus:              "Torus",
+	SurfaceBSpline:            "BSplineSurface",
+	SurfaceEllipticalCylinder: "EllipticalCylinder",
+	SurfaceEllipticalCone:     "EllipticalCone",
+	SurfaceOffset:             "OffsetSurface",
+	SurfaceThreadedCylinder:   "ThreadedCylinder",
+}
+
+// SurfaceKinds returns every SurfaceKind in declaration order — the enumerator external
+// coverage tests (e.g. step/geommap) range over to prove they handle or explicitly declare
+// each kind, so a new kind fails a stale consumer at CI.
+func SurfaceKinds() []SurfaceKind {
+	all := make([]SurfaceKind, 0, surfaceKindCount)
+	for k := SurfaceKind(0); k < surfaceKindCount; k++ {
+		all = append(all, k)
+	}
+	return all
+}
+
+// KindedSurface is a Surface that names its analytic kind. Every surface in the kernel
+// satisfies it (asserted below); consumers that special-case may switch on Kind() instead of
+// a type assertion, and pure translators key a table on it.
+type KindedSurface interface {
+	Surface
+	Kind() SurfaceKind
+}
+
+func (p Plane) Kind() SurfaceKind              { return SurfacePlane }
+func (c Cylinder) Kind() SurfaceKind           { return SurfaceCylinder }
+func (s Sphere) Kind() SurfaceKind             { return SurfaceSphere }
+func (c Cone) Kind() SurfaceKind               { return SurfaceCone }
+func (t Torus) Kind() SurfaceKind              { return SurfaceTorus }
+func (s BSplineSurface) Kind() SurfaceKind     { return SurfaceBSpline }
+func (c EllipticalCylinder) Kind() SurfaceKind { return SurfaceEllipticalCylinder }
+func (c EllipticalCone) Kind() SurfaceKind     { return SurfaceEllipticalCone }
+func (o OffsetSurface) Kind() SurfaceKind      { return SurfaceOffset }
+func (t ThreadedCylinder) Kind() SurfaceKind   { return SurfaceThreadedCylinder }
+
+var (
+	_ KindedSurface = Plane{}
+	_ KindedSurface = Cylinder{}
+	_ KindedSurface = Sphere{}
+	_ KindedSurface = Cone{}
+	_ KindedSurface = Torus{}
+	_ KindedSurface = BSplineSurface{}
+	_ KindedSurface = EllipticalCylinder{}
+	_ KindedSurface = EllipticalCone{}
+	_ KindedSurface = OffsetSurface{}
+	_ KindedSurface = ThreadedCylinder{}
+)
+
+// CurveKind classifies the analytic and freeform 3D curves. Add a value here AND its Kind()
+// method AND a probe in the coverage test when a new curve lands.
+type CurveKind uint8
+
+const (
+	CurveLine CurveKind = iota
+	CurveLineSegment
+	CurvePolyline
+	CurveCircle
+	CurveArc
+	CurveEllipse
+	CurveEllipticalArc
+	CurveHyperbolicArc
+	CurveParabola
+	CurveBSpline
+	CurveHelix
+	CurveVariableHelix
+	CurveSpiric
+	// curveKindCount is the sentinel one past the last real kind.
+	curveKindCount
+)
+
+// String names the kind for error messages.
+func (k CurveKind) String() string {
+	if int(k) >= len(curveKindNames) {
+		return "CurveKind(?)"
+	}
+	return curveKindNames[k]
+}
+
+var curveKindNames = [...]string{
+	CurveLine:          "Line",
+	CurveLineSegment:   "LineSegment",
+	CurvePolyline:      "Polyline",
+	CurveCircle:        "Circle",
+	CurveArc:           "Arc3d",
+	CurveEllipse:       "EllipseFull",
+	CurveEllipticalArc: "EllipticalArc",
+	CurveHyperbolicArc: "HyperbolicArc",
+	CurveParabola:      "Parabola",
+	CurveBSpline:       "BSplineCurve",
+	CurveHelix:         "Helix3d",
+	CurveVariableHelix: "VariableHelix3d",
+	CurveSpiric:        "SpiricArc",
+}
+
+// CurveKinds returns every CurveKind in declaration order (see SurfaceKinds).
+func CurveKinds() []CurveKind {
+	all := make([]CurveKind, 0, curveKindCount)
+	for k := CurveKind(0); k < curveKindCount; k++ {
+		all = append(all, k)
+	}
+	return all
+}
+
+// KindedCurve is a Curve3 that names its analytic kind.
+type KindedCurve interface {
+	Curve3
+	Kind() CurveKind
+}
+
+func (l Line) Kind() CurveKind            { return CurveLine }
+func (s LineSegment) Kind() CurveKind     { return CurveLineSegment }
+func (p Polyline) Kind() CurveKind        { return CurvePolyline }
+func (c Circle) Kind() CurveKind          { return CurveCircle }
+func (a Arc3d) Kind() CurveKind           { return CurveArc }
+func (e EllipseFull) Kind() CurveKind     { return CurveEllipse }
+func (e EllipticalArc) Kind() CurveKind   { return CurveEllipticalArc }
+func (h HyperbolicArc) Kind() CurveKind   { return CurveHyperbolicArc }
+func (p Parabola) Kind() CurveKind        { return CurveParabola }
+func (c BSplineCurve) Kind() CurveKind    { return CurveBSpline }
+func (h Helix3d) Kind() CurveKind         { return CurveHelix }
+func (h VariableHelix3d) Kind() CurveKind { return CurveVariableHelix }
+func (s SpiricArc) Kind() CurveKind       { return CurveSpiric }
+
+var (
+	_ KindedCurve = Line{}
+	_ KindedCurve = LineSegment{}
+	_ KindedCurve = Polyline{}
+	_ KindedCurve = Circle{}
+	_ KindedCurve = Arc3d{}
+	_ KindedCurve = EllipseFull{}
+	_ KindedCurve = EllipticalArc{}
+	_ KindedCurve = HyperbolicArc{}
+	_ KindedCurve = Parabola{}
+	_ KindedCurve = BSplineCurve{}
+	_ KindedCurve = Helix3d{}
+	_ KindedCurve = VariableHelix3d{}
+	_ KindedCurve = SpiricArc{}
+)

--- a/kernel/geom/kind_coverage_test.go
+++ b/kernel/geom/kind_coverage_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import "testing"
+
+// The kind enums are only useful if every value maps to exactly one type and vice versa.
+// These coverage tests enumerate the enum and assert a probe instance of each kind reports
+// itself — so adding a SurfaceKind/CurveKind value without a Kind() method (or with the
+// wrong one), or a new type without an enum value, fails here rather than silently widening
+// a consumer's default (#1403, audit I6). Kind() ignores the receiver's fields, so a
+// zero-value struct is a sufficient probe.
+
+var surfaceKindProbes = map[SurfaceKind]KindedSurface{
+	SurfacePlane:              Plane{},
+	SurfaceCylinder:           Cylinder{},
+	SurfaceSphere:             Sphere{},
+	SurfaceCone:               Cone{},
+	SurfaceTorus:              Torus{},
+	SurfaceBSpline:            BSplineSurface{},
+	SurfaceEllipticalCylinder: EllipticalCylinder{},
+	SurfaceEllipticalCone:     EllipticalCone{},
+	SurfaceOffset:             OffsetSurface{},
+	SurfaceThreadedCylinder:   ThreadedCylinder{},
+}
+
+func TestSurfaceKindCoverage(t *testing.T) {
+	if len(surfaceKindProbes) != int(surfaceKindCount) {
+		t.Fatalf("surfaceKindProbes has %d entries, want %d (one per SurfaceKind) — a new kind needs a probe",
+			len(surfaceKindProbes), int(surfaceKindCount))
+	}
+	for k := SurfaceKind(0); k < surfaceKindCount; k++ {
+		probe, ok := surfaceKindProbes[k]
+		if !ok {
+			t.Errorf("SurfaceKind %v has no probe — add its type to surfaceKindProbes", k)
+			continue
+		}
+		if got := probe.Kind(); got != k {
+			t.Errorf("probe for %v reports Kind %v — its Kind() method is wrong", k, got)
+		}
+	}
+}
+
+var curveKindProbes = map[CurveKind]KindedCurve{
+	CurveLine:          Line{},
+	CurveLineSegment:   LineSegment{},
+	CurvePolyline:      Polyline{},
+	CurveCircle:        Circle{},
+	CurveArc:           Arc3d{},
+	CurveEllipse:       EllipseFull{},
+	CurveEllipticalArc: EllipticalArc{},
+	CurveHyperbolicArc: HyperbolicArc{},
+	CurveParabola:      Parabola{},
+	CurveBSpline:       BSplineCurve{},
+	CurveHelix:         Helix3d{},
+	CurveVariableHelix: VariableHelix3d{},
+	CurveSpiric:        SpiricArc{},
+}
+
+func TestCurveKindCoverage(t *testing.T) {
+	if len(curveKindProbes) != int(curveKindCount) {
+		t.Fatalf("curveKindProbes has %d entries, want %d (one per CurveKind) — a new kind needs a probe",
+			len(curveKindProbes), int(curveKindCount))
+	}
+	for k := CurveKind(0); k < curveKindCount; k++ {
+		probe, ok := curveKindProbes[k]
+		if !ok {
+			t.Errorf("CurveKind %v has no probe — add its type to curveKindProbes", k)
+			continue
+		}
+		if got := probe.Kind(); got != k {
+			t.Errorf("probe for %v reports Kind %v — its Kind() method is wrong", k, got)
+		}
+	}
+}
+
+// TestSurfaceKindNamesComplete asserts every SurfaceKind has a distinct non-placeholder name
+// (used verbatim in error messages), so a new kind cannot ship with a "SurfaceKind(?)" label.
+func TestSurfaceKindNamesComplete(t *testing.T) {
+	seen := map[string]bool{}
+	for k := SurfaceKind(0); k < surfaceKindCount; k++ {
+		name := k.String()
+		if name == "SurfaceKind(?)" || seen[name] {
+			t.Errorf("SurfaceKind %d has a missing or duplicate name %q", k, name)
+		}
+		seen[name] = true
+	}
+}
+
+// TestCurveKindNamesComplete is the curve analogue.
+func TestCurveKindNamesComplete(t *testing.T) {
+	seen := map[string]bool{}
+	for k := CurveKind(0); k < curveKindCount; k++ {
+		name := k.String()
+		if name == "CurveKind(?)" || seen[name] {
+			t.Errorf("CurveKind %d has a missing or duplicate name %q", k, name)
+		}
+		seen[name] = true
+	}
+}

--- a/kernel/geom/nurbs_seed_params.go
+++ b/kernel/geom/nurbs_seed_params.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// Knot-structure-aware seeding for NURBS point/surface inversion (Oblikovati#1608).
+// Newton point inversion (Piegl & Tiller §6.1) is only LOCALLY convergent: it walks to
+// the foot in whose basin the seed already lies. A seed grid with fewer nodes than the
+// surface has knot spans skips whole spans, so on a high-span import (STEP surfaces
+// routinely carry dozens of spans) the polish locks onto the wrong foot and reports the
+// wrong signed distance. Seeding PER KNOT SPAN fixes this: candidate feet cluster near
+// knots, and within one span the surface is a single polynomial of degree p that can
+// turn at most p−1 times, so p+1 samples inside every span resolve its bending and no
+// span is ever skipped. This mirrors OCCT's Extrema_GenExtPS (samples per knot interval)
+// and the Greville-abscissa density Piegl & Tiller recommend for span-aware sampling.
+
+// knotSpanSeedParams returns point-inversion seed parameters over a knot vector's clamped
+// domain, placing degree+1 samples inside every distinct knot span. A surface with S
+// spans is thus seeded S·(degree+1)+1 times in that direction — dense where it can bend,
+// never skipping a span the way the retired fixed 16×16 / 24 grid did (#1608).
+func knotSpanSeedParams(knots []float64, degree int) []float64 {
+	breaks := domainBreakpoints(knots, degree)
+	per := degree + 1
+	out := []float64{breaks[0]}
+	for i := 0; i+1 < len(breaks); i++ {
+		a, b := breaks[i], breaks[i+1]
+		for k := 1; k <= per; k++ {
+			out = append(out, a+(b-a)*float64(k)/float64(per))
+		}
+	}
+	return out
+}
+
+// domainBreakpoints returns the distinct knot values that bound the spans of the clamped
+// domain [knots[degree], knots[len−1−degree]], both ends included and sorted ascending.
+func domainBreakpoints(knots []float64, degree int) []float64 {
+	lo, hi := knots[degree], knots[len(knots)-1-degree]
+	out := []float64{lo}
+	for _, k := range knots {
+		if k > lo+knotEps && k < hi-knotEps && !containsKnot(out, k) {
+			out = append(out, k)
+		}
+	}
+	out = append(out, hi)
+	sortFloats(out)
+	return out
+}
+
+// nearestSeed returns the (u, v) from the us×vs seed lattice whose surface point is
+// closest to q — the Gauss–Newton starting guess for point inversion.
+func nearestSeed(s Surface, q math.Point3, us, vs []float64) (float64, float64) {
+	bu, bv, bd := us[0], vs[0], stdmath.Inf(1)
+	for _, u := range us {
+		for _, v := range vs {
+			if d := s.PointAt(u, v).DistanceSquaredTo(q); d < bd {
+				bu, bv, bd = u, v, d
+			}
+		}
+	}
+	return bu, bv
+}
+
+// minSeedSpacing returns the smallest positive gap between consecutive sorted seed params
+// — the natural cluster-merge radius for distinguishing multiple feet in one neighbourhood.
+func minSeedSpacing(params []float64) float64 {
+	gap := stdmath.Inf(1)
+	for i := 1; i < len(params); i++ {
+		if d := params[i] - params[i-1]; d > 0 && d < gap {
+			gap = d
+		}
+	}
+	if stdmath.IsInf(gap, 1) {
+		return 1
+	}
+	return gap
+}

--- a/kernel/geom/nurbs_seed_params.go
+++ b/kernel/geom/nurbs_seed_params.go
@@ -19,15 +19,22 @@ import (
 // span is ever skipped. This mirrors OCCT's Extrema_GenExtPS (samples per knot interval)
 // and the Greville-abscissa density Piegl & Tiller recommend for span-aware sampling.
 
+// seedMinSamples floors the per-direction seed count so a LOW-span surface (a single Bézier
+// patch) is still sampled as densely as the retired fixed grid; a high-span surface exceeds
+// it naturally at one sample per span. This is the issue's "grid = max(16, spans+1)" (#1608).
+const seedMinSamples = 16
+
 // knotSpanSeedParams returns point-inversion seed parameters over a knot vector's clamped
-// domain, placing degree+1 samples inside every distinct knot span. A surface with S
-// spans is thus seeded S·(degree+1)+1 times in that direction — dense where it can bend,
-// never skipping a span the way the retired fixed 16×16 / 24 grid did (#1608).
+// domain, placing at least one sample inside every distinct knot span so no span is skipped,
+// and enough per span that the total reaches seedMinSamples on a low-span surface. A surface
+// with S spans is seeded ≈max(16, S)+1 times — the issue's span-aware grid (#1608), Θ(S) not
+// the retired fixed grid, so the cost matches the old 16/24 grid on ordinary surfaces.
 func knotSpanSeedParams(knots []float64, degree int) []float64 {
 	breaks := domainBreakpoints(knots, degree)
-	per := degree + 1
+	spans := len(breaks) - 1
+	per := (seedMinSamples + spans - 1) / spans // ceil(min/spans): ≥1, larger only when spans<16
 	out := []float64{breaks[0]}
-	for i := 0; i+1 < len(breaks); i++ {
+	for i := 0; i < spans; i++ {
 		a, b := breaks[i], breaks[i+1]
 		for k := 1; k <= per; k++ {
 			out = append(out, a+(b-a)*float64(k)/float64(per))
@@ -63,6 +70,21 @@ func nearestSeed(s Surface, q math.Point3, us, vs []float64) (float64, float64) 
 		}
 	}
 	return bu, bv
+}
+
+// ssiSpanCounter reports a surface's distinct-knot-span counts so the SSI seeder can start its
+// quadtree at ≈one coarse cell per span (OCCT Extrema_GenExtPS samples per knot interval, #1608).
+// The retired fixed 8×8 coarse grid put several knot spans in one cell on a high-span surface, so
+// many parallel intersection curves aliased to a single two-edge crossing and all but one were
+// silently dropped. A span-sized coarse cell holds at most a few crossings, so the transversal
+// shortcut is sound again without forcing the whole domain to refine. No knot structure ⇒ (0,0).
+type ssiSpanCounter interface {
+	knotSpanCounts() (uSpans, vSpans int)
+}
+
+// knotSpanCounts returns the number of distinct knot spans in each parameter direction.
+func (s BSplineSurface) knotSpanCounts() (int, int) {
+	return len(domainBreakpoints(s.UKnots, s.UDegree)) - 1, len(domainBreakpoints(s.VKnots, s.VDegree)) - 1
 }
 
 // minSeedSpacing returns the smallest positive gap between consecutive sorted seed params

--- a/kernel/geom/nurbs_seed_params_test.go
+++ b/kernel/geom/nurbs_seed_params_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	"math/rand"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// rippledSheet builds a degree-3 B-spline sheet over uniform open knots with uSpans × vSpans
+// knot spans and one bump per span: control z alternates ±amplitude per control column (and
+// per row when eggcrate is true). It is the high-span fixture of Oblikovati#1608 — imported
+// STEP surfaces routinely carry dozens of spans, far more than a fixed 16×16 seed grid can see.
+func rippledSheet(t *testing.T, uSpans, vSpans int, amplitude float64, eggcrate bool) BSplineSurface {
+	t.Helper()
+	ctrl, weights := rippledNet(uSpans+3, vSpans+3, amplitude, eggcrate)
+	s, err := NewBSplineSurface(3, 3, ctrl, weights, uniformOpenKnots(uSpans, 3), uniformOpenKnots(vSpans, 3))
+	if err != nil {
+		t.Fatalf("rippledSheet(%d×%d spans): %v", uSpans, vSpans, err)
+	}
+	return s
+}
+
+// rippledNet lays the control points on an integer grid with alternating-sign z.
+func rippledNet(nu, nv int, amplitude float64, eggcrate bool) (ctrl [][]math.Point3, weights [][]float64) {
+	ctrl = make([][]math.Point3, nu)
+	weights = make([][]float64, nu)
+	for i := 0; i < nu; i++ {
+		ctrl[i] = make([]math.Point3, nv)
+		weights[i] = make([]float64, nv)
+		for j := 0; j < nv; j++ {
+			ctrl[i][j] = math.P3(float64(i), float64(j), rippleHeight(i, j, amplitude, eggcrate))
+			weights[i][j] = 1
+		}
+	}
+	return ctrl, weights
+}
+
+// rippleHeight alternates the bump sign per column (u ripple) or per diagonal (eggcrate).
+func rippleHeight(i, j int, amplitude float64, eggcrate bool) float64 {
+	parity := i
+	if eggcrate {
+		parity = i + j
+	}
+	if parity%2 == 0 {
+		return amplitude
+	}
+	return -amplitude
+}
+
+// uniformOpenKnots returns the clamped knot vector with `spans` uniform interior spans on
+// [0, 1] for the given degree.
+func uniformOpenKnots(spans, degree int) []float64 {
+	knots := make([]float64, 0, spans+2*degree+1)
+	for k := 0; k <= degree; k++ {
+		knots = append(knots, 0)
+	}
+	for k := 1; k < spans; k++ {
+		knots = append(knots, float64(k)/float64(spans))
+	}
+	for k := 0; k <= degree; k++ {
+		knots = append(knots, 1)
+	}
+	return knots
+}
+
+// TestParamAtHighSpanSurfaceInversion is the #1608 seeding-completeness regression: on a
+// 33×33-span eggcrate — one bump per knot span — a fixed 16×16 seed grid skips whole spans,
+// the Gauss–Newton polish converges to the wrong bump, and ParamAt returns a foot far from
+// an ON-SURFACE query point. Span-aware seeding must recover every sampled point: the
+// surface is a height field (injective in xy), so the zero-distance foot is unique.
+func TestParamAtHighSpanSurfaceInversion(t *testing.T) {
+	s := rippledSheet(t, 33, 33, 8.0, true)
+	res := surfaceNetResolution(s)
+	uLo, uHi := s.UDomain()
+	vLo, vHi := s.VDomain()
+	rng := rand.New(rand.NewSource(1)) // deterministic: repeatable failures
+	failures := 0
+	for k := 0; k < 100; k++ {
+		u := uLo + (uHi-uLo)*rng.Float64()
+		v := vLo + (vHi-vLo)*rng.Float64()
+		p := s.PointAt(u, v)
+		ru, rv := s.ParamAt(p)
+		if d := s.PointAt(ru, rv).DistanceTo(p); float64(d) > res.Sew() {
+			failures++
+			t.Errorf("ParamAt foot off by %g (> %g) for on-surface point at (u,v)=(%.4f,%.4f)", d, res.Sew(), u, v)
+		}
+	}
+	if failures > 0 {
+		t.Logf("%d/100 on-surface points inverted to the wrong span", failures)
+	}
+}
+
+// surfaceNetResolution derives the model-relative Resolution from the control net extent.
+func surfaceNetResolution(s BSplineSurface) Resolution {
+	var pts []math.Point3
+	for _, row := range s.Ctrl {
+		pts = append(pts, row...)
+	}
+	return ResolutionForPoints(pts)
+}

--- a/kernel/geom/paramat.go
+++ b/kernel/geom/paramat.go
@@ -62,12 +62,13 @@ const (
 	surfaceNearMaxIter   = 24
 )
 
-// ParamAt projects q onto the NURBS surface numerically: a coarse grid seed then the shared
-// damped Gauss–Newton point inversion (Piegl & Tiller §6.1), with an early convergence exit.
+// ParamAt projects q onto the NURBS surface numerically: a knot-span-aware seed
+// (knotSpanSeedParams — one basin per span, #1608) then the shared damped Gauss–Newton
+// point inversion (Piegl & Tiller §6.1), with an early convergence exit.
 func (s BSplineSurface) ParamAt(q math.Point3) (u, v float64) {
-	uLo, uHi := s.UDomain()
-	vLo, vHi := s.VDomain()
-	u, v = surfaceGridSeed(s, q, uLo, uHi, vLo, vHi)
+	us := knotSpanSeedParams(s.UKnots, s.UDegree)
+	vs := knotSpanSeedParams(s.VKnots, s.VDegree)
+	u, v = nearestSeed(s, q, us, vs)
 	u, v, _ = refineSurfaceParam(s, q, u, v, surfaceInvertMaxIter)
 	return u, v
 }
@@ -83,21 +84,4 @@ func (s BSplineSurface) ParamNear(q math.Point3, u0, v0 float64) (u, v float64) 
 	u, v = clampToSurface(s, u0, v0)
 	u, v, _ = refineSurfaceParam(s, q, u, v, surfaceNearMaxIter)
 	return u, v
-}
-
-// surfaceGridSeed returns the sampled (u, v) over a coarse grid whose point is
-// nearest q — the starting guess for the Gauss–Newton refinement.
-func surfaceGridSeed(s Surface, q math.Point3, uLo, uHi, vLo, vHi float64) (float64, float64) {
-	const n = 16
-	bu, bv, bd := uLo, vLo, stdmath.Inf(1)
-	for i := 0; i <= n; i++ {
-		u := uLo + (uHi-uLo)*float64(i)/n
-		for j := 0; j <= n; j++ {
-			v := vLo + (vHi-vLo)*float64(j)/n
-			if d := s.PointAt(u, v).DistanceSquaredTo(q); d < bd {
-				bu, bv, bd = u, v, d
-			}
-		}
-	}
-	return bu, bv
 }

--- a/kernel/geom/surface_inversion_test.go
+++ b/kernel/geom/surface_inversion_test.go
@@ -101,10 +101,8 @@ func TestParamAtConvergesAndStopsEarly(t *testing.T) {
 	if r := perpCosine(s, q, u, v); r > 1e-7 {
 		t.Errorf("ParamAt foot not perpendicular: residual %g", r)
 	}
-	// Re-run the refinement from ParamAt's grid seed to observe the iteration count.
-	uLo, uHi := s.UDomain()
-	vLo, vHi := s.VDomain()
-	su, sv := surfaceGridSeed(s, q, uLo, uHi, vLo, vHi)
+	// Re-run the refinement from ParamAt's knot-span seed to observe the iteration count.
+	su, sv := nearestSeed(s, q, knotSpanSeedParams(s.UKnots, s.UDegree), knotSpanSeedParams(s.VKnots, s.VDegree))
 	_, _, iters := refineSurfaceParam(s, q, su, sv, surfaceInvertMaxIter)
 	if iters >= surfaceInvertMaxIter {
 		t.Errorf("ParamAt refinement ran the full %d iterations — early exit not working", surfaceInvertMaxIter)

--- a/kernel/geom/tangent_bound.go
+++ b/kernel/geom/tangent_bound.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// Rigorous per-box tangent-magnitude bounds for the SSI quadtree prune (Oblikovati#1608,
+// audit A12). The signed-distance field f the seeder marches is 1-Lipschitz in 3D, so
+// across a parameter cell |Δf| ≤ ∫|dS| ≤ (max|S_u|)·Δu + (max|S_v|)·Δv. The prune discards
+// a cell only when its smallest corner |f| exceeds that bound; the bound must therefore be
+// a TRUE upper bound on the tangent magnitude anywhere in the cell, not a sampled estimate.
+// The retired seeder inflated the four corner tangents by a guessed factor of 2.0, which
+// still UNDER-estimated the interior tangent on a high-curvature span and silently pruned
+// cells that held a crossing. These closed-form / hodograph bounds replace that guess:
+//   - analytic surfaces: their tangent magnitude has a known closed form (Piegl & Tiller);
+//   - non-rational B-spline: the derivative surface is itself a B-spline whose control
+//     points bound |S_u|,|S_v| by the convex-hull property (P&T §3.3, the hodograph net).
+// A surface with no rigorous bound (a rational NURBS, an unknown type) returns ok=false so
+// the seeder records the fallback (issue #1608 point 5) instead of pruning on a guess.
+
+// boxTangentBounder reports rigorous upper bounds on |∂S/∂u| and |∂S/∂v| anywhere in the
+// parameter box [u0,u1]×[v0,v1]. ok=false means no certified bound is available and the
+// caller must fall back (and record the decline). It is consumed by the SSI seeder prune.
+type boxTangentBounder interface {
+	tangentBoundOverBox(u0, u1, v0, v1 float64) (maxSu, maxSv float64, ok bool)
+}
+
+// tangentBoundOverBox: the plane's partials are the constant unit in-plane axes.
+func (p Plane) tangentBoundOverBox(_, _, _, _ float64) (float64, float64, bool) {
+	return 1, 1, true
+}
+
+// tangentBoundOverBox: |S_u| = Radius (around), |S_v| = 1 (unit axis) — both constant.
+func (c Cylinder) tangentBoundOverBox(_, _, _, _ float64) (float64, float64, bool) {
+	return c.Radius, 1, true
+}
+
+// tangentBoundOverBox: on a cone |S_u| = v·tan(HalfAngle) grows with v, so it is bounded by
+// the larger |v| end of the box; |S_v| = sqrt(1+tan²) is constant.
+func (c Cone) tangentBoundOverBox(_, _, v0, v1 float64) (float64, float64, bool) {
+	t := stdmath.Abs(stdmath.Tan(c.HalfAngle))
+	vMax := stdmath.Max(stdmath.Abs(v0), stdmath.Abs(v1))
+	return vMax * t, stdmath.Sqrt(1 + t*t), true
+}
+
+// tangentBoundOverBox: |S_u| = R·cos v ≤ R, |S_v| = R (P&T sphere parameterisation).
+func (s Sphere) tangentBoundOverBox(_, _, _, _ float64) (float64, float64, bool) {
+	return s.Radius, s.Radius, true
+}
+
+// tangentBoundOverBox: |S_u| = Major + Minor·cos v ≤ Major+Minor, |S_v| = Minor.
+func (t Torus) tangentBoundOverBox(_, _, _, _ float64) (float64, float64, bool) {
+	return t.MajorRadius + t.MinorRadius, t.MinorRadius, true
+}
+
+// tangentBoundOverBox bounds a non-rational B-spline surface's partials by its hodograph
+// (derivative) control net: S_u is a B-spline in the control points Q^u_{i,j} =
+// deg·(P_{i+1,j}−P_{i,j})/(U_{i+deg+1}−U_{i+1}), a convex combination of them, so |S_u| ≤
+// max|Q^u| (P&T §3.3). The bound is over the whole net (an over-estimate for a sub-box, but
+// always sound). A rational net has no such simple hodograph, so it declines (ok=false).
+func (s BSplineSurface) tangentBoundOverBox(_, _, _, _ float64) (float64, float64, bool) {
+	if !s.hasUnitWeights() {
+		return 0, 0, false
+	}
+	return s.hodographBound(s.UDegree, s.UKnots, true), s.hodographBound(s.VDegree, s.VKnots, false), true
+}
+
+// hodographBound returns max|Q| over the derivative control net in one direction: alongU
+// selects the u-differences P_{i+1,j}−P_{i,j} scaled by deg/(knot[i+deg+1]−knot[i+1]),
+// else the v-differences. Zero-width knot spans (clamped ends never differenced) are skipped.
+func (s BSplineSurface) hodographBound(degree int, knots []float64, alongU bool) float64 {
+	best := 0.0
+	nu, nv := len(s.Ctrl), len(s.Ctrl[0])
+	iMax, jMax := nu, nv
+	if alongU {
+		iMax = nu - 1
+	} else {
+		jMax = nv - 1
+	}
+	for i := 0; i < iMax; i++ {
+		for j := 0; j < jMax; j++ {
+			best = stdmath.Max(best, hodographCoeff(s.Ctrl, i, j, degree, knots, alongU))
+		}
+	}
+	return best
+}
+
+// hodographCoeff is |Q_{i,j}| for one derivative-net control point (0 if its knot span is
+// degenerate: a repeated knot contributes no derivative there).
+func hodographCoeff(ctrl [][]math.Point3, i, j, degree int, knots []float64, alongU bool) float64 {
+	var diff math.Vector3
+	var span float64
+	if alongU {
+		diff, span = ctrl[i][j].VectorTo(ctrl[i+1][j]), knots[i+degree+1]-knots[i+1]
+	} else {
+		diff, span = ctrl[i][j].VectorTo(ctrl[i][j+1]), knots[j+degree+1]-knots[j+1]
+	}
+	if span <= knotEps {
+		return 0
+	}
+	return float64(degree) * float64(diff.Length()) / span
+}
+
+// hasUnitWeights reports whether every control weight is 1 (within knotEps), i.e. the
+// surface is polynomial (non-rational) and its hodograph is the plain control differences.
+func (s BSplineSurface) hasUnitWeights() bool {
+	for _, row := range s.Weights {
+		for _, w := range row {
+			if stdmath.Abs(w-1) > knotEps {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/kernel/geom/tangent_bound_test.go
+++ b/kernel/geom/tangent_bound_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestTangentBoundIsUpperBound is the #1608 certification guard for the analytic surfaces: each
+// closed-form tangentBoundOverBox must dominate the ACTUAL partial magnitudes everywhere in the box,
+// or the SSI prune could discard a cell that holds a crossing. It samples DerivativesAt on a lattice
+// and fails if any sample exceeds the claimed bound.
+func TestTangentBoundIsUpperBound(t *testing.T) {
+	plane, _ := NewPlane(math.P3(1, 2, 3), math.V3(0, 0, 1))
+	cyl, _ := NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 4)
+	cone, _ := NewCone(math.P3(0, 0, 0), math.V3(0, 0, 1), 0.6)
+	sphere, _ := NewSphere(math.P3(0, 0, 0), 5)
+	torus, _ := NewTorus(math.P3(0, 0, 0), math.V3(0, 0, 1), 10, 3)
+	cases := []struct {
+		name           string
+		s              boxTangentBounder
+		u0, u1, v0, v1 float64
+	}{
+		{"plane", plane, -3, 3, -3, 3},
+		{"cylinder", cyl, 0, 2 * stdmath.Pi, -5, 5},
+		{"cone", cone, 0, 2 * stdmath.Pi, 0, 8},
+		{"sphere", sphere, 0, 2 * stdmath.Pi, -stdmath.Pi / 2, stdmath.Pi / 2},
+		{"torus", torus, 0, 2 * stdmath.Pi, 0, 2 * stdmath.Pi},
+	}
+	for _, c := range cases {
+		assertTangentBound(t, c.name, c.s, c.u0, c.u1, c.v0, c.v1)
+	}
+}
+
+// assertTangentBound samples the surface's partials over the box and checks they never exceed its bound.
+func assertTangentBound(t *testing.T, name string, b boxTangentBounder, u0, u1, v0, v1 float64) {
+	t.Helper()
+	su, sv, ok := b.tangentBoundOverBox(u0, u1, v0, v1)
+	if !ok {
+		t.Fatalf("%s: analytic surface must offer a certified bound", name)
+	}
+	s := b.(Surface)
+	for i := 0; i <= 20; i++ {
+		for j := 0; j <= 20; j++ {
+			u := u0 + (u1-u0)*float64(i)/20
+			v := v0 + (v1-v0)*float64(j)/20
+			du, dv := s.DerivativesAt(u, v)
+			if float64(du.Length()) > su+1e-9 || float64(dv.Length()) > sv+1e-9 {
+				t.Fatalf("%s: bound (%.4f,%.4f) below tangent (%.4f,%.4f) at (%.3f,%.3f)", name, su, sv, du.Length(), dv.Length(), u, v)
+			}
+		}
+	}
+}
+
+// TestRationalSurfaceDeclinesHodograph guards issue #1608 point 5: a rational NURBS has no simple
+// control-net hodograph, so it must DECLINE (ok=false) — the SSI seeder then records the fallback
+// rather than pruning on a bound it cannot certify.
+func TestRationalSurfaceDeclinesHodograph(t *testing.T) {
+	ctrl := [][]math.Point3{
+		{math.P3(0, 0, 0), math.P3(0, 1, 0)},
+		{math.P3(1, 0, 0), math.P3(1, 1, 1)},
+	}
+	weights := [][]float64{{1, 2}, {1, 1}} // a non-unit weight ⇒ rational
+	knots := []float64{0, 0, 1, 1}
+	s, err := NewBSplineSurface(1, 1, ctrl, weights, knots, knots)
+	if err != nil {
+		t.Fatalf("NewBSplineSurface: %v", err)
+	}
+	if _, _, ok := s.tangentBoundOverBox(0, 1, 0, 1); ok {
+		t.Error("rational surface reported a certified hodograph bound; want decline")
+	}
+}

--- a/model/feature/analytic_facet_visibility_test.go
+++ b/model/feature/analytic_facet_visibility_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+)
+
+// TestPlanarizedDiagRecordsAnalyticFaceting pins the audit-A5 chokepoint (#1601): converting a body
+// that carries an analytic curved face into a planar B-rep is a PERMANENT degradation and must be
+// observable. planarizedDiag records CodeBooleanAnalyticFaceted for a curved operand, stays quiet for
+// an already-planar one, and in both cases returns a body with no curved face left.
+func TestPlanarizedDiagRecordsAnalyticFaceting(t *testing.T) {
+	cyl, err := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 1, 2)
+	if err != nil {
+		t.Fatalf("SolidCylinder: %v", err)
+	}
+	block, err := brep.SolidBlock(math.P3(0, 0, 0), math.P3(1, 1, 1), "block")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+
+	rec := &diag.Recorder{}
+	out := planarizedDiag(cyl, "unit", rec)
+	if hasCurvedFace(out) {
+		t.Error("planarizedDiag left a curved face on an analytic operand")
+	}
+	if !rec.Has(ops.CodeBooleanAnalyticFaceted) {
+		t.Errorf("faceting an analytic cylinder recorded no %q; got %v", ops.CodeBooleanAnalyticFaceted, rec.Records())
+	}
+
+	quiet := &diag.Recorder{}
+	if got := planarizedDiag(block, "unit", quiet); hasCurvedFace(got) {
+		t.Error("planarizedDiag altered an already-planar body's face kinds")
+	}
+	if quiet.Has(ops.CodeBooleanAnalyticFaceted) {
+		t.Errorf("planarizing an already-planar block recorded a spurious facet defect: %v", quiet.Records())
+	}
+}
+
+// TestPlanarizedDiagNilRecorderSafe confirms the chokepoint is safe on the nil recorder the legacy
+// (diagnostic-less) call paths still pass.
+func TestPlanarizedDiagNilRecorderSafe(t *testing.T) {
+	cyl, err := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 1, 2)
+	if err != nil {
+		t.Fatalf("SolidCylinder: %v", err)
+	}
+	if out := planarizedDiag(cyl, "unit", nil); hasCurvedFace(out) {
+		t.Error("planarizedDiag(nil recorder) did not facet the analytic operand")
+	}
+}
+
+// TestNoSilentFacetBeforeConsumer is audit A5's "grep/guard test over decline paths" (#1601): NO
+// feature may facet an analytic operand into a planar-only consumer (a boolean or a face delete)
+// through the plain, diagnostic-less planarized() — every such site must route through planarizedDiag
+// so the permanent analytic→facet loss always surfaces as a diagnostic. (hull is exempt: its result
+// is a polyhedron by definition, so it feeds ConvexHullOf, not a boolean — the facet is inherent, not
+// a hidden degradation.)
+func TestNoSilentFacetBeforeConsumer(t *testing.T) {
+	consumer := regexp.MustCompile(`ops\.(Boolean|BooleanWithDiagnostics|DeleteFaces)\(`)
+	bareFacet := regexp.MustCompile(`[^D]planarized\(`) // planarized( but not planarizedDiag(
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatalf("ReadFile %s: %v", name, err)
+		}
+		for i, line := range strings.Split(string(src), "\n") {
+			if consumer.MatchString(line) && bareFacet.MatchString(line) {
+				t.Errorf("%s:%d facets an operand into a planar consumer via plain planarized() — "+
+					"route it through planarizedDiag so the analytic→facet loss is observable:\n\t%s",
+					name, i+1, strings.TrimSpace(line))
+			}
+		}
+	}
+}

--- a/model/feature/extrude.go
+++ b/model/feature/extrude.go
@@ -191,16 +191,10 @@ func combine(in Input, body *topo.Body, op ops.PartFeatureOperation) ([]*topo.Bo
 	}
 	// Otherwise re-facet any analytic curved face into a planar B-rep before the planar boolean — it hangs
 	// on a full periodic curved face it cannot consume (#129). A standalone primitive that is never
-	// combined keeps its analytic face for thread/chamfer/fillet. Faceting is PERMANENT — every
-	// downstream feature then operates on facets — so it is recorded as a defect, not done silently
-	// (#1601; the pre-facet here is why the inner boolean's own CSG-fallback diagnostic alone would
-	// miss this path: by the time ops.Boolean runs, the operands already look planar).
-	if hasCurvedFace(target) || hasCurvedFace(body) {
-		in.Diag.Recordf(ops.CodeBooleanAnalyticFaceted, diag.Defect,
-			"%s faceted analytic operand(s) for the planar boolean (no exact curved path applied): the result and all downstream features are polyhedral", op)
-	}
-	target = planarized(target, "combine-target")
-	body = planarized(body, "combine-tool")
+	// combined keeps its analytic face for thread/chamfer/fillet. Faceting is PERMANENT, so planarizedDiag
+	// records it as a defect rather than degrading silently (#1601, audit A5).
+	target = planarizedDiag(target, "combine-target", in.Diag)
+	body = planarizedDiag(body, "combine-tool", in.Diag)
 	res, err := ops.BooleanWithDiagnostics(op, target, body, in.Diag)
 	if err != nil {
 		return nil, err

--- a/model/feature/face_fillet.go
+++ b/model/feature/face_fillet.go
@@ -76,7 +76,7 @@ func nonAdjacentFaceFilletBody(in Input, body *topo.Body, faceKeysA, faceKeysB [
 		return Output{}, fmt.Errorf("%s: the two face sets are not separated by a fillable gap "+
 			"(parallel or disjoint faces are not supported)", feat)
 	}
-	healed, err := ops.DeleteFaces(planarized(body, feat), gap)
+	healed, err := ops.DeleteFaces(planarizedDiag(body, feat, in.Diag), gap)
 	if err != nil {
 		return Output{}, fmt.Errorf("%s: healing the gap between the faces: %w", feat, err)
 	}

--- a/model/feature/full_round_fillet.go
+++ b/model/feature/full_round_fillet.go
@@ -86,7 +86,7 @@ func parallelFullRound(in Input, body *topo.Body, def *FullRoundFilletDefinition
 	if err != nil {
 		return Output{}, err
 	}
-	result, err := ops.BooleanWithDiagnostics(ops.Cut, planarized(body, feat), tool, in.Diag)
+	result, err := ops.BooleanWithDiagnostics(ops.Cut, planarizedDiag(body, feat, in.Diag), tool, in.Diag)
 	if err != nil {
 		return Output{}, err
 	}
@@ -120,7 +120,7 @@ func nonParallelFullRound(in Input, body *topo.Body, center, side1, side2 planar
 		if perr != nil {
 			return Output{}, perr
 		}
-		result, err = ops.BooleanWithDiagnostics(ops.Cut, planarized(result, feat), prism, in.Diag)
+		result, err = ops.BooleanWithDiagnostics(ops.Cut, planarizedDiag(result, feat, in.Diag), prism, in.Diag)
 		if err != nil {
 			return Output{}, fmt.Errorf("%s: cutting the corner round: %w", feat, err)
 		}
@@ -297,7 +297,7 @@ func fullRoundCornerTool(pc math.Point3, up, sideN, axisDir math.Vector3, r, l f
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", feat, err)
 	}
-	corner, err := ops.BooleanWithDiagnostics(ops.Cut, planarized(box, feat), planarized(cyl, feat), rec)
+	corner, err := ops.BooleanWithDiagnostics(ops.Cut, planarizedDiag(box, feat, rec), planarizedDiag(cyl, feat, rec), rec)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", feat, err)
 	}

--- a/model/feature/patterns.go
+++ b/model/feature/patterns.go
@@ -161,11 +161,11 @@ func (p *patternBase) replicateTools(bodies []*topo.Body, tools []groupTool, tra
 	// a full periodic cylinder face, so a circular pattern of a Ø-hole cut used to blow up into
 	// tens of thousands of edges (#129). A faceted tool is left unchanged.
 	for i := range tools {
-		tools[i].body = planarized(tools[i].body, feat)
+		tools[i].body = planarizedDiag(tools[i].body, feat, rec)
 	}
 	running := append([]*topo.Body(nil), bodies...)
 	last := len(running) - 1
-	running[last] = planarized(running[last], feat) // ditto for a curved running target
+	running[last] = planarizedDiag(running[last], feat, rec) // ditto for a curved running target
 	for k := 1; k < len(transforms); k++ {
 		if p.skip(k) {
 			continue

--- a/model/feature/planarize.go
+++ b/model/feature/planarize.go
@@ -3,6 +3,7 @@
 package feature
 
 import (
+	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
@@ -67,6 +68,22 @@ func planarized(b *topo.Body, feat string) *topo.Body {
 		}
 	}
 	return b
+}
+
+// planarizedDiag is [planarized] that makes the analytic→facet degradation OBSERVABLE (#1601, audit
+// A5). Turning a body that carries an analytic curved face into a planar B-rep is PERMANENT — the
+// analytic surface is unrecoverable and every downstream feature (fillet, chamfer, thread, export)
+// then operates on facets — so it must ride on the feature as a Defect, never happen silently. Every
+// feature that facets an operand before a planar boolean (combine, patterns, full-round/face fillet)
+// routes through here, so no path can facet an analytic surface without a CodeBooleanAnalyticFaceted
+// diagnostic — the inner boolean's own CSG-fallback code cannot catch it, since by the time the
+// boolean runs the operand already looks planar. rec is nil-safe.
+func planarizedDiag(b *topo.Body, feat string, rec *diag.Recorder) *topo.Body {
+	if b != nil && hasCurvedFace(b) {
+		rec.Recordf(ops.CodeBooleanAnalyticFaceted, diag.Defect,
+			"%s faceted an analytic operand for the planar path: the result and every downstream feature is polyhedral", feat)
+	}
+	return planarized(b, feat)
 }
 
 // planarizeSimpleCylinder rebuilds a body that is exactly one analytic cylinder (1 geom.Cylinder side


### PR DESCRIPTION
## What

Three M40 deep-audit remediation refactors that replace convention-only contracts with mechanically-checked ones.

**I4 — tool-keyed dialog set (head/ui)**
`chrome.go`'s 30+ entry hand-maintained per-tool `drawXDialog` roll-call is replaced by one explicit `toolDialogSet` assembled by `defaultToolDialogSet` (composition at package scope, not scattered `init()`s — respects audit B6/#1617). A source-level gate (`archguard.TestEveryFeatureToolHasADialogPath`) asserts every feature tool resolves to a bespoke registered dialog, the generic `ParameterizedTool` panel, or an explicit no-dialog allowlist (Hull/Patch/SketchDrivenPattern are pure pick-and-commit tools). Duplicate registration panics at construction; a head parity test pins that each migrated dialog stayed in the set.

**I5 — per-widget consumer interfaces (head/ui)**
Widgets touched here name the ≤6-method session surface they consume instead of taking the whole `*app.Session` (the `arrowSession` pattern): `commitCancelHost` (the OK/Cancel row every tool dialog draws through), `measureHost`, `gripSnapHost`, `activeDocumentSource`/`edgeColorSource`. Each has a compile-time `var _ Iface = (*app.Session)(nil)` assertion and a named fake-host test. A ratchet (`archguard.TestHeadSessionCouplingRatchet`) pins the `*app.Session` reference count so it only decreases (494→492); the policy is written down in `architecture/notes/head-ui-consumer-interfaces.md`.

**I6 — geom Kind() discriminators (kernel/geom)**
Every analytic surface/curve carries a `Kind()` discriminator (`SurfaceKind`/`CurveKind`, `KindedSurface`/`KindedCurve`) with per-type compile-time assertions and enumerating coverage tests. The STEP analytic export (`step/geommap`) becomes table-driven (`map[Kind]writer`) with a coverage test that enumerates the kind enum and requires each kind to be handled or explicitly declared unsupported with a reason; the table-miss default names the kind and consumer.

## Why

Each finding is the same shape: a capability sits on one side of a convention-only contract and its counterpart can silently go missing — the #1521 (UI path missing for an existing tool) and #1403 (a default path silently swallowing unhandled cases) classes. Making the contract enumerable turns "someone forgot" from a live-session surprise into a CI failure.

Closes #1627
Closes #1628
Closes #1629

## Verification

- `go build ./...` and `head` cgo build clean.
- `go test ./archguard/ ./kernel/geom/ ./kernel/exchange/step/... ./kernel/geomapi/ ./kernel/brep/ ./model/feature/` green; full `head/ui` cgo suite green.
- `golangci-lint` 0 new issues on touched packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)