### PR TITLE
M40 B-series: value-type boundaries (B9, B10, B11)

### DIFF
--- a/addin/router/body_query.go
+++ b/addin/router/body_query.go
@@ -282,9 +282,10 @@ func orientedRangeBoxReply(b *topo.Body) (json.RawMessage, error) {
 		return nil, err
 	}
 	vec := func(v math.Vector3) []float64 { return []float64{float64(v.X), float64(v.Y), float64(v.Z)} }
+	corner, edges := obb.MinCorner(), obb.EdgeVectors()
 	return json.Marshal(wire.BodyRangeBoxResult{
-		Corner:       []float64{float64(obb.Corner.X), float64(obb.Corner.Y), float64(obb.Corner.Z)},
-		DirectionOne: vec(obb.DirectionOne), DirectionTwo: vec(obb.DirectionTwo), DirectionThree: vec(obb.DirectionThree),
+		Corner:       []float64{float64(corner.X), float64(corner.Y), float64(corner.Z)},
+		DirectionOne: vec(edges[0]), DirectionTwo: vec(edges[1]), DirectionThree: vec(edges[2]),
 	})
 }
 

--- a/addin/router/camera.go
+++ b/addin/router/camera.go
@@ -11,7 +11,6 @@ import (
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
 	"oblikovati.org/math"
-	"oblikovati.org/scene"
 )
 
 // getCamera returns a document's active-view camera as a look-at frame (Document 0 ⇒ the
@@ -58,8 +57,8 @@ func setCamera(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
 	return json.Marshal(cameraView(out))
 }
 
-// cameraView projects a scene.Camera onto the wire look-at DTO.
-func cameraView(c scene.Camera) wire.CameraView {
+// cameraView projects an app camera frame onto the wire look-at DTO.
+func cameraView(c app.CameraFrame) wire.CameraView {
 	return wire.CameraView{
 		Eye:    types.Point{X: c.Eye.X, Y: c.Eye.Y, Z: c.Eye.Z},
 		Target: types.Point{X: c.Target.X, Y: c.Target.Y, Z: c.Target.Z},

--- a/addin/router/lighting.go
+++ b/addin/router/lighting.go
@@ -9,7 +9,6 @@ import (
 	"oblikovati.org/api/types"
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
-	"oblikovati.org/renderer"
 )
 
 // getLightingStyle returns the active lighting style's global controls
@@ -35,7 +34,7 @@ func setLightingStyle(s *app.Session, args json.RawMessage) (json.RawMessage, er
 // (wire.MethodLightingListStyles).
 func listLightingStyles(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
 	active := s.LightingStyleName()
-	gallery := renderer.LightingStyleGallery()
+	gallery := app.LightingStyleGallery()
 	out := make([]wire.LightingStyleInfo, len(gallery))
 	for i, opt := range gallery {
 		out[i] = wire.LightingStyleInfo{Name: opt.Name, Active: opt.Name == active}
@@ -60,7 +59,7 @@ func addLight(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
 	if err := decode(args, &a); err != nil {
 		return nil, err
 	}
-	l, err := s.AddLight(app.LightKindForDefinition(a.DefinitionType))
+	l, err := s.AddLight(a.DefinitionType)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +72,7 @@ func setLight(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
 	if err := decode(args, &a); err != nil {
 		return nil, err
 	}
-	if err := s.SetLight(a.Index, sceneLight(a.Light)); err != nil {
+	if err := s.SetLight(a.Index, appLight(a.Light)); err != nil {
 		return nil, err
 	}
 	return json.Marshal(lightInfo(a.Index, s.Lights()[a.Index]))
@@ -90,7 +89,7 @@ func setShadows(s *app.Session, args json.RawMessage) (json.RawMessage, error) {
 	if err := decode(args, &a); err != nil {
 		return nil, err
 	}
-	s.SetShadowSettings(rendererShadows(a))
+	s.SetShadowSettings(shadowRigFromWire(a))
 	return json.Marshal(shadowSettings(s.ShadowSettings()))
 }
 
@@ -106,12 +105,11 @@ func setEnvironment(s *app.Session, args json.RawMessage) (json.RawMessage, erro
 	if err := decode(args, &a); err != nil {
 		return nil, err
 	}
-	preset, ok := app.EnvironmentPresetByName(a.Preset)
-	if !ok {
+	if _, ok := app.EnvironmentPresetByName(a.Preset); !ok {
 		return nil, fmt.Errorf("router: unknown environment preset %q", a.Preset)
 	}
-	s.SetEnvironment(renderer.Environment{
-		Preset:    preset,
+	s.SetEnvironment(app.EnvironmentState{
+		Preset:    a.Preset,
 		Rotation:  float32(a.Rotation),
 		Intensity: float32(a.Intensity),
 		ShowImage: a.ShowImage,
@@ -123,10 +121,10 @@ func setEnvironment(s *app.Session, args json.RawMessage) (json.RawMessage, erro
 // (wire.MethodEnvironmentListPresets).
 func listEnvironmentPresets(s *app.Session, _ json.RawMessage) (json.RawMessage, error) {
 	active := s.Environment()
-	gallery := renderer.EnvironmentGallery()
+	gallery := app.EnvironmentGallery()
 	out := make([]wire.EnvironmentPresetInfo, len(gallery))
 	for i, opt := range gallery {
-		isActive := active.FilePath == "" && active.Preset == opt.Preset
+		isActive := active.FilePath == "" && active.Preset == opt.Name
 		out[i] = wire.EnvironmentPresetInfo{Name: opt.Name, Active: isActive}
 	}
 	return json.Marshal(wire.EnvironmentPresetListResult{Presets: out})
@@ -168,12 +166,12 @@ func marshalLightingStyle(s *app.Session) (json.RawMessage, error) {
 	})
 }
 
-// lightInfo converts a renderer light at index into the wire DTO.
-func lightInfo(index int, l renderer.SceneLight) wire.LightInfo {
+// lightInfo converts an app light value at index into the wire DTO.
+func lightInfo(index int, l app.Light) wire.LightInfo {
 	return wire.LightInfo{
 		Index:               index,
 		LightType:           types.ModelSpaceLight,
-		LightDefinitionType: app.DefinitionForLightKind(l.Kind),
+		LightDefinitionType: l.Definition,
 		On:                  l.On,
 		Color:               types.Rgba{R: l.Color[0], G: l.Color[1], B: l.Color[2], A: 1},
 		Intensity:           float64(l.Intensity),
@@ -185,10 +183,10 @@ func lightInfo(index int, l renderer.SceneLight) wire.LightInfo {
 	}
 }
 
-// sceneLight converts a wire light DTO into a renderer light.
-func sceneLight(in wire.LightInfo) renderer.SceneLight {
-	return renderer.SceneLight{
-		Kind:        app.LightKindForDefinition(in.LightDefinitionType),
+// appLight converts a wire light DTO into the app light value.
+func appLight(in wire.LightInfo) app.Light {
+	return app.Light{
+		Definition:  in.LightDefinitionType,
 		Direction:   [3]float32{float32(in.Direction.X), float32(in.Direction.Y), float32(in.Direction.Z)},
 		Position:    [3]float32{float32(in.Position.X), float32(in.Position.Y), float32(in.Position.Z)},
 		Color:       [3]float32{in.Color.R, in.Color.G, in.Color.B},
@@ -200,9 +198,9 @@ func sceneLight(in wire.LightInfo) renderer.SceneLight {
 	}
 }
 
-// shadowSettings converts renderer shadow flags into the wire DTO (folding the ground flags
-// into the public GroundShadowEnum).
-func shadowSettings(sh renderer.ShadowSettings) wire.ShadowSettings {
+// shadowSettings converts an app shadow rig into the wire DTO (folding the ground flags into
+// the public GroundShadowEnum).
+func shadowSettings(sh app.ShadowRig) wire.ShadowSettings {
 	return wire.ShadowSettings{
 		GroundShadow:   app.GroundShadowForSettings(sh),
 		ObjectShadows:  sh.ObjectShadows,
@@ -212,9 +210,9 @@ func shadowSettings(sh renderer.ShadowSettings) wire.ShadowSettings {
 	}
 }
 
-// rendererShadows converts a wire shadow DTO into renderer flags.
-func rendererShadows(in wire.ShadowSettings) renderer.ShadowSettings {
-	sh := renderer.ShadowSettings{
+// shadowRigFromWire converts a wire shadow DTO into the app shadow rig.
+func shadowRigFromWire(in wire.ShadowSettings) app.ShadowRig {
+	sh := app.ShadowRig{
 		ObjectShadows:  in.ObjectShadows,
 		AmbientShadows: in.AmbientShadows,
 		Density:        float32(in.Density),
@@ -224,11 +222,11 @@ func rendererShadows(in wire.ShadowSettings) renderer.ShadowSettings {
 	return sh
 }
 
-// environmentView converts a renderer environment into the wire DTO.
-func environmentView(e renderer.Environment) wire.EnvironmentView {
+// environmentView converts an app environment into the wire DTO.
+func environmentView(e app.EnvironmentState) wire.EnvironmentView {
 	preset := ""
 	if e.FilePath == "" {
-		preset = e.Preset.String()
+		preset = e.Preset
 	}
 	return wire.EnvironmentView{
 		Preset:    preset,

--- a/addin/router/named_views.go
+++ b/addin/router/named_views.go
@@ -55,7 +55,7 @@ func restoreNamedView(s *app.Session, args json.RawMessage) (json.RawMessage, er
 	if err := s.RestoreNamedView(a.Name); err != nil {
 		return nil, err
 	}
-	return json.Marshal(cameraView(s.Camera()))
+	return json.Marshal(cameraView(s.CameraFrame()))
 }
 
 // deleteNamedView removes a saved named view (wire.MethodViewsDeleteNamed).
@@ -83,7 +83,7 @@ func setViewOrientation(s *app.Session, args json.RawMessage) (json.RawMessage, 
 	if err := s.SetViewOrientation(a.Orientation, a.Fit); err != nil {
 		return nil, err
 	}
-	return json.Marshal(cameraView(s.Camera()))
+	return json.Marshal(cameraView(s.CameraFrame()))
 }
 
 // namedViewInfo projects a saved named view into its wire shape.

--- a/addin/router/twin_drift_test.go
+++ b/addin/router/twin_drift_test.go
@@ -87,7 +87,7 @@ func assertDriveResultCarried(t *testing.T, src assembly.DriveResult, got wire.D
 		t.Fatalf("drive frame fields dropped: %+v", f)
 	}
 	p := f.Placements[0]
-	if p.Occurrence != 7 || p.Transform.Cells != [16]float64(cells) {
+	if p.Occurrence != 7 || p.Transform.Cells != cells {
 		t.Errorf("placement dropped: occurrence=%d transform=%v", p.Occurrence, p.Transform.Cells)
 	}
 }

--- a/addin/router/twin_drift_test.go
+++ b/addin/router/twin_drift_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/math"
+	"oblikovati.org/model/assembly"
+	"oblikovati.org/model/sheetmetal"
+)
+
+// These guards protect the hand-converted model↔wire twin structs the 2026-07 audit flagged
+// (B9, #1620): a field added to one side compiles fine while the hand converter silently drops
+// it on the other, producing a partly-populated DTO no test notices. The alias pattern can't
+// collapse these — the model side speaks kernel types (math.Matrix4) and the wire side the
+// api's serialization types (types.Matrix, json tags) across the ADR-0018 dependency wall — so
+// each twin is guarded here instead. Red-verify by adding a phantom field to either side of a
+// pair: TestModelWireTwinsHaveMatchingFields then names it.
+
+// twinPair is one model/wire twin whose exported field NAMES must stay in lockstep.
+type twinPair struct {
+	name        string
+	model, wire reflect.Type
+}
+
+// modelWireTwins is the registry of hand-converted twins (add a row when a new one appears).
+var modelWireTwins = []twinPair{
+	{"DriveResult", reflect.TypeOf(assembly.DriveResult{}), reflect.TypeOf(wire.DriveResult{})},
+	{"DriveFrame", reflect.TypeOf(assembly.DriveFrame{}), reflect.TypeOf(wire.DriveFrame{})},
+	{"Placement", reflect.TypeOf(assembly.OccurrencePlacement{}), reflect.TypeOf(wire.DrivePlacement{})},
+	{"FlatPatternSettings", reflect.TypeOf(sheetmetal.FlatPatternSettings{}), reflect.TypeOf(wire.FlatPatternSettings{})},
+}
+
+// TestModelWireTwinsHaveMatchingFields fails when the exported field-name sets of a twin pair
+// diverge — the drift signal, caught before someone forgets to update the converter.
+func TestModelWireTwinsHaveMatchingFields(t *testing.T) {
+	for _, tw := range modelWireTwins {
+		got, want := exportedFieldNames(tw.model), exportedFieldNames(tw.wire)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("%s twin field drift: model %v vs wire %v — update the twin and its hand "+
+				"converter together (audit B9, #1620)", tw.name, got, want)
+		}
+	}
+}
+
+// exportedFieldNames returns t's exported field names in sorted order.
+func exportedFieldNames(t reflect.Type) []string {
+	var names []string
+	for i := 0; i < t.NumField(); i++ {
+		if f := t.Field(i); f.IsExported() {
+			names = append(names, f.Name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// TestDriveResultToWirePopulatesEveryField converts a fully non-zero model DriveResult and
+// asserts every wire field carried over — so a converter that drops a newly added field fails
+// here rather than shipping a half-empty DTO.
+func TestDriveResultToWirePopulatesEveryField(t *testing.T) {
+	cells := [16]math.Scalar{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	res := assembly.DriveResult{
+		StoppedByCollision: true,
+		StoppedAtStep:      3,
+		Frames: []assembly.DriveFrame{{
+			Value:      1.5,
+			Collided:   true,
+			Placements: []assembly.OccurrencePlacement{{Occurrence: 7, Transform: math.Matrix4FromCells(cells)}},
+		}},
+	}
+	assertDriveResultCarried(t, res, driveResultToWire(res), cells)
+}
+
+// assertDriveResultCarried checks every field of the converted wire result matches the source.
+func assertDriveResultCarried(t *testing.T, src assembly.DriveResult, got wire.DriveResult, cells [16]math.Scalar) {
+	t.Helper()
+	if !got.StoppedByCollision || got.StoppedAtStep != src.StoppedAtStep || len(got.Frames) != 1 {
+		t.Fatalf("drive result header dropped: %+v", got)
+	}
+	f := got.Frames[0]
+	if f.Value != 1.5 || !f.Collided || len(f.Placements) != 1 {
+		t.Fatalf("drive frame fields dropped: %+v", f)
+	}
+	p := f.Placements[0]
+	if p.Occurrence != 7 || p.Transform.Cells != [16]float64(cells) {
+		t.Errorf("placement dropped: occurrence=%d transform=%v", p.Occurrence, p.Transform.Cells)
+	}
+}
+
+// TestFlatPatternSettingsRoundTrip proves the sheet-metal twin's 1:1 mapping is identity in
+// both directions; paired with the field-parity guard, a dropped/renamed field is caught.
+func TestFlatPatternSettingsRoundTrip(t *testing.T) {
+	m := sheetmetal.FlatPatternSettings{DeferUpdate: true}
+	w := wire.FlatPatternSettings{DeferUpdate: m.DeferUpdate}
+	if back := (sheetmetal.FlatPatternSettings{DeferUpdate: w.DeferUpdate}); back != m {
+		t.Errorf("flat-pattern settings round-trip = %+v, want %+v", back, m)
+	}
+}

--- a/app/bug_report_diag.go
+++ b/app/bug_report_diag.go
@@ -6,11 +6,10 @@ import (
 	"fmt"
 	"runtime"
 
-	"gopkg.in/yaml.v3"
-
 	"oblikovati.org/app/options"
 	"oblikovati.org/build"
 	"oblikovati.org/model/doc"
+	"oblikovati.org/persistence/yamlcodec"
 	"oblikovati.org/report"
 )
 
@@ -130,7 +129,7 @@ func documentYAML(m documentMarshaler, d *doc.Document) string {
 // marshalOptions renders the user's typed options as YAML for the report (the same shape
 // they are persisted in), so a triager sees exactly the preferences in effect.
 func marshalOptions(all options.All) string {
-	b, err := yaml.Marshal(all)
+	b, err := yamlcodec.Marshal(all)
 	if err != nil {
 		return fmt.Sprintf("(failed to render options: %v)", err)
 	}

--- a/app/commands_lighting.go
+++ b/app/commands_lighting.go
@@ -51,15 +51,15 @@ func environmentCommands() []*CommandDefinition {
 	for _, opt := range renderer.EnvironmentGallery() {
 		cmds = append(cmds, NewCommand("View.Environment."+opt.Name, opt.Name, "Environment",
 			func(s *Session) error {
-				s.SetEnvironment(renderer.Environment{
-					Preset: opt.Preset, Intensity: 1, ShowImage: opt.Preset != renderer.EnvNone,
+				s.SetEnvironment(EnvironmentState{
+					Preset: opt.Name, Intensity: 1, ShowImage: opt.Preset != renderer.EnvNone,
 				})
 				return nil
 			}).WithTab("View").WithKind(ComboControl).
 			WithTooltip("Environment — "+opt.Name).
 			WithActive(func(s *Session) bool {
 				e := s.Environment()
-				return e.FilePath == "" && e.Preset == opt.Preset
+				return e.FilePath == "" && e.Preset == opt.Name
 			}))
 	}
 	return append(cmds, NewCommand("View.LoadHDR", "Load HDR…", "Environment",
@@ -75,24 +75,24 @@ func shadowCommands() []*CommandDefinition {
 	return []*CommandDefinition{
 		shadowToggle("View.ObjectShadows", "Object Shadows", "shadow-object",
 			"Object Shadows — bodies cast shadows from the primary light.",
-			func(sh *renderer.ShadowSettings) { sh.ObjectShadows = !sh.ObjectShadows },
-			func(sh renderer.ShadowSettings) bool { return sh.ObjectShadows }),
+			func(sh *ShadowRig) { sh.ObjectShadows = !sh.ObjectShadows },
+			func(sh ShadowRig) bool { return sh.ObjectShadows }),
 		shadowToggle("View.GroundShadows", "Ground Shadows", "shadow-ground",
 			"Ground Shadows — shadows cast onto the ground plane.",
-			func(sh *renderer.ShadowSettings) { sh.GroundShadows = !sh.GroundShadows },
-			func(sh renderer.ShadowSettings) bool { return sh.GroundShadows }),
+			func(sh *ShadowRig) { sh.GroundShadows = !sh.GroundShadows },
+			func(sh ShadowRig) bool { return sh.GroundShadows }),
 		shadowToggle("View.AmbientShadows", "Ambient Shadows", "shadow-ambient",
 			"Ambient Shadows — contact ambient occlusion.",
-			func(sh *renderer.ShadowSettings) { sh.AmbientShadows = !sh.AmbientShadows },
-			func(sh renderer.ShadowSettings) bool { return sh.AmbientShadows }),
+			func(sh *ShadowRig) { sh.AmbientShadows = !sh.AmbientShadows },
+			func(sh ShadowRig) bool { return sh.AmbientShadows }),
 	}
 }
 
 // shadowToggle builds one Shadows-panel toggle: flip mutates the session's shadow settings and
 // checked reports the current state. Enabling any shadow with a zero density seeds a visible
 // default so the toggle has an immediate effect.
-func shadowToggle(id, label, icon, tip string, flip func(*renderer.ShadowSettings),
-	checked func(renderer.ShadowSettings) bool,
+func shadowToggle(id, label, icon, tip string, flip func(*ShadowRig),
+	checked func(ShadowRig) bool,
 ) *CommandDefinition {
 	return NewCommand(id, label, "Shadows", func(s *Session) error {
 		sh := s.ShadowSettings()

--- a/app/commands_lighting_test.go
+++ b/app/commands_lighting_test.go
@@ -2,11 +2,7 @@
 
 package app
 
-import (
-	"testing"
-
-	"oblikovati.org/renderer"
-)
+import "testing"
 
 // TestLightingStyleCommandsSetRig checks the View-tab Lighting Style options activate the rig
 // on the session, end to end through the ribbon command.
@@ -34,7 +30,7 @@ func TestEnvironmentCommandsSetEnvironment(t *testing.T) {
 	if err := s.Execute("View.Environment.Studio"); err != nil {
 		t.Fatalf("execute Environment.Studio: %v", err)
 	}
-	if e := s.Environment(); e.Preset != renderer.EnvStudio || !e.ShowImage {
+	if e := s.Environment(); e.Preset != "Studio" || !e.ShowImage {
 		t.Errorf("environment = %+v, want Studio shown", e)
 	}
 	if err := s.Execute("View.Environment.None"); err != nil {

--- a/app/lighting.go
+++ b/app/lighting.go
@@ -57,17 +57,18 @@ func lightingStyleByName(name string) (renderer.LightingStyleID, bool) {
 	return renderer.LightingDefault, false
 }
 
-// Environment returns the active image-based-lighting environment.
-func (s *Session) Environment() renderer.Environment { return s.lighting.Environment }
+// Environment returns the active image-based-lighting environment as an app value
+// (audit B10, #1621: the router speaks [Environment], not the renderer's type).
+func (s *Session) Environment() EnvironmentState { return environmentValue(s.lighting.Environment) }
 
 // SetEnvironment sets the active environment (preset or loaded file) on the live rig.
-func (s *Session) SetEnvironment(e renderer.Environment) { s.lighting.Environment = e }
+func (s *Session) SetEnvironment(e EnvironmentState) { s.lighting.Environment = renderEnvironment(e) }
 
-// ShadowSettings returns the active shadow settings.
-func (s *Session) ShadowSettings() renderer.ShadowSettings { return s.lighting.Shadows }
+// ShadowSettings returns the active shadow settings as an app [ShadowRig].
+func (s *Session) ShadowSettings() ShadowRig { return shadowRigValue(s.lighting.Shadows) }
 
 // SetShadowSettings sets the active shadow settings on the live rig.
-func (s *Session) SetShadowSettings(sh renderer.ShadowSettings) { s.lighting.Shadows = sh }
+func (s *Session) SetShadowSettings(sh ShadowRig) { s.lighting.Shadows = renderShadowRig(sh) }
 
 // Exposure/Brightness/Ambience read the active rig's global tone controls; the Set* forms edit
 // them in place (the Lighting settings panel's sliders).
@@ -99,37 +100,43 @@ func (s *Session) TakeLoadEnvironmentRequest() bool {
 // LoadEnvironmentFile sets a user HDR file as the active environment (shown as the background).
 // It is what the head calls when the load-HDR file dialog is confirmed.
 func (s *Session) LoadEnvironmentFile(path string) {
-	s.SetEnvironment(renderer.Environment{FilePath: path, Intensity: 1, ShowImage: true})
+	s.SetEnvironment(EnvironmentState{FilePath: path, Intensity: 1, ShowImage: true})
 }
 
-// Lights returns the live rig's lights.
-func (s *Session) Lights() []renderer.SceneLight { return s.lighting.Lights }
+// Lights returns the live rig's lights as app [Light] values.
+func (s *Session) Lights() []Light {
+	out := make([]Light, len(s.lighting.Lights))
+	for i, l := range s.lighting.Lights {
+		out[i] = lightValue(l)
+	}
+	return out
+}
 
-// AddLight appends a new light of the given kind with neutral defaults (white, intensity 1,
-// on), returning it; it is a no-op past [renderer.MaxSceneLights] (returning the last light).
-func (s *Session) AddLight(kind renderer.LightKind) (renderer.SceneLight, error) {
+// AddLight appends a new light of the given public definition kind with neutral defaults
+// (white, intensity 1, on), returning it; it errors past [renderer.MaxSceneLights].
+func (s *Session) AddLight(def LightDefinitionTypeEnum) (Light, error) {
 	if len(s.lighting.Lights) >= renderer.MaxSceneLights {
-		return renderer.SceneLight{}, fmt.Errorf("app: cannot add light, at the %d-light maximum",
+		return Light{}, fmt.Errorf("app: cannot add light, at the %d-light maximum",
 			renderer.MaxSceneLights)
 	}
 	l := renderer.SceneLight{
-		Kind:      kind,
+		Kind:      LightKindForDefinition(def),
 		Direction: [3]float32{0, 0, 1},
 		Color:     [3]float32{1, 1, 1},
 		Intensity: 1,
 		On:        true,
 	}
 	s.lighting.Lights = append(s.lighting.Lights, l)
-	return l, nil
+	return lightValue(l), nil
 }
 
 // SetLight replaces the light at index, erroring on an out-of-range index (so a bad request is
 // rejected rather than panicking).
-func (s *Session) SetLight(index int, l renderer.SceneLight) error {
+func (s *Session) SetLight(index int, l Light) error {
 	if index < 0 || index >= len(s.lighting.Lights) {
 		return fmt.Errorf("app: light index %d out of range [0,%d)", index, len(s.lighting.Lights))
 	}
-	s.lighting.Lights[index] = l
+	s.lighting.Lights[index] = renderLight(l)
 	return nil
 }
 
@@ -168,9 +175,9 @@ func EnvironmentPresetByName(name string) (renderer.EnvironmentPreset, bool) {
 	return renderer.EnvNone, false
 }
 
-// GroundShadowForSettings maps the renderer's ground-shadow flags back onto the public
+// GroundShadowForSettings maps a [ShadowRig]'s ground-shadow flags onto the public
 // GroundShadowEnum (None / Ground / X-Ray).
-func GroundShadowForSettings(sh renderer.ShadowSettings) GroundShadowEnum {
+func GroundShadowForSettings(sh ShadowRig) GroundShadowEnum {
 	switch {
 	case !sh.GroundShadows:
 		return types.NoGroundShadow
@@ -181,8 +188,8 @@ func GroundShadowForSettings(sh renderer.ShadowSettings) GroundShadowEnum {
 	}
 }
 
-// ApplyGroundShadow sets the renderer's ground-shadow flags from the public GroundShadowEnum.
-func ApplyGroundShadow(sh *renderer.ShadowSettings, g GroundShadowEnum) {
+// ApplyGroundShadow sets a [ShadowRig]'s ground-shadow flags from the public GroundShadowEnum.
+func ApplyGroundShadow(sh *ShadowRig, g GroundShadowEnum) {
 	sh.GroundShadows = g != types.NoGroundShadow
 	sh.GroundXRay = g == types.XRayGroundShadow
 }

--- a/app/lighting_test.go
+++ b/app/lighting_test.go
@@ -45,11 +45,11 @@ func TestAddLightClampsToMax(t *testing.T) {
 	s := NewSession()
 	// Default starts with one light; fill to the max, then expect an error.
 	for len(s.Lights()) < renderer.MaxSceneLights {
-		if _, err := s.AddLight(renderer.PointLight); err != nil {
+		if _, err := s.AddLight(types.PointLight); err != nil {
 			t.Fatalf("AddLight before max: %v", err)
 		}
 	}
-	if _, err := s.AddLight(renderer.PointLight); err == nil {
+	if _, err := s.AddLight(types.PointLight); err == nil {
 		t.Errorf("AddLight past max (%d) should error", renderer.MaxSceneLights)
 	}
 }
@@ -57,7 +57,7 @@ func TestAddLightClampsToMax(t *testing.T) {
 // TestSetLightRejectsOutOfRange checks SetLight validates the index instead of panicking.
 func TestSetLightRejectsOutOfRange(t *testing.T) {
 	s := NewSession()
-	if err := s.SetLight(99, renderer.SceneLight{}); err == nil {
+	if err := s.SetLight(99, Light{}); err == nil {
 		t.Error("SetLight(99) should error on an out-of-range index")
 	}
 }
@@ -66,14 +66,14 @@ func TestSetLightRejectsOutOfRange(t *testing.T) {
 // (including the X-ray distinction) at the app layer.
 func TestGroundShadowMappingRoundTrips(t *testing.T) {
 	for _, g := range types.AllGroundShadows() {
-		var sh renderer.ShadowSettings
+		var sh ShadowRig
 		ApplyGroundShadow(&sh, g)
 		if got := GroundShadowForSettings(sh); got != g {
 			t.Errorf("ground shadow %v round-tripped to %v", g, got)
 		}
 	}
 	// Sanity: None clears the flag; X-ray sets both.
-	var sh renderer.ShadowSettings
+	var sh ShadowRig
 	ApplyGroundShadow(&sh, types.XRayGroundShadow)
 	if !sh.GroundShadows || !sh.GroundXRay {
 		t.Errorf("X-ray should set GroundShadows and GroundXRay, got %+v", sh)
@@ -94,7 +94,7 @@ func TestLightKindDefinitionBijection(t *testing.T) {
 // environment (IBL + sky background) — the default skymap (ADR-0026 §8).
 func TestNewSessionDefaultsToSkyEnvironment(t *testing.T) {
 	env := NewSession().Environment()
-	if env.Preset != renderer.EnvSky || !env.ShowImage || env.Intensity != 1 {
+	if env.Preset != "Sky" || !env.ShowImage || env.Intensity != 1 {
 		t.Errorf("default environment = %+v, want EnvSky shown at intensity 1", env)
 	}
 }
@@ -107,13 +107,13 @@ func TestSetLightingStyleKeepsEnvironment(t *testing.T) {
 	if err := s.SetLightingStyle("Sun"); err != nil {
 		t.Fatalf("SetLightingStyle(Sun): %v", err)
 	}
-	if got := s.Environment().Preset; got != renderer.EnvSky {
+	if got := s.Environment().Preset; got != "Sky" {
 		t.Errorf("environment after Sun = %v, want the Sky default kept", got)
 	}
 	if err := s.SetLightingStyle("Outdoors"); err != nil {
 		t.Fatalf("SetLightingStyle(Outdoors): %v", err)
 	}
-	if got := s.Environment().Preset; got != renderer.EnvOutdoors {
+	if got := s.Environment().Preset; got != "Outdoors" {
 		t.Errorf("environment after Outdoors = %v, want the style's own EnvOutdoors", got)
 	}
 }

--- a/app/scene_values.go
+++ b/app/scene_values.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "oblikovati.org/math"
+
+// App-owned scene value types (audit B10, #1621): the lighting / environment / camera settings
+// the add-in router (and any other application consumer) speaks, so nothing outside the
+// renderer wall (ADR-0014) has to name a renderer.* or scene.* type. The Session translates
+// these to and from the renderer's internal GPU representations in scene_values_adapt.go — the
+// single wall crossing — keeping the router an adapter that imports only app + api.
+
+// Light is one scene light in application terms: its public definition kind plus emission
+// parameters. It mirrors the renderer's per-light data without the renderer import; the wall
+// maps Definition onto the renderer's LightKind.
+type Light struct {
+	Definition  LightDefinitionTypeEnum
+	On          bool
+	Color       [3]float32
+	Intensity   float32
+	Direction   [3]float32
+	Position    [3]float32
+	SpotInner   float32
+	SpotOuter   float32
+	Attenuation [3]float32
+}
+
+// ShadowRig is the application's shadow settings: the ground / object / ambient toggles and the
+// density / softness controls. The GroundShadows+GroundXRay pair folds into the public
+// GroundShadowEnum via [GroundShadowForSettings] / [ApplyGroundShadow].
+type ShadowRig struct {
+	GroundShadows  bool
+	GroundXRay     bool
+	ObjectShadows  bool
+	AmbientShadows bool
+	Density        float32
+	Softness       float32
+}
+
+// EnvironmentState is the application's image-based-lighting environment: a built-in preset by
+// NAME ("" or "None" when inactive), an optional user HDR file that overrides it, and the
+// display controls. Naming the preset as a string keeps this type free of the renderer's preset
+// enum. (Named EnvironmentState, not Environment, because app.Environment is already the ribbon
+// context alias types.Environment.)
+type EnvironmentState struct {
+	Preset    string
+	FilePath  string
+	Rotation  float32
+	Intensity float32
+	ShowImage bool
+}
+
+// IsActive reports whether the environment contributes IBL/skybox — a file is set or a real
+// preset (not the empty/"None" preset) is selected. Mirrors renderer.Environment.IsActive so
+// call sites read the same across the wall.
+func (e EnvironmentState) IsActive() bool {
+	return e.FilePath != "" || (e.Preset != "" && e.Preset != "None")
+}
+
+// CameraFrame is the application's view camera: a look-at frame plus the transient viewport
+// pixel size and projection mode. It mirrors the renderer's scene camera without the scene
+// import (the router only edits the look-at frame; Width/Height/Orthographic pass through).
+type CameraFrame struct {
+	Eye          math.Point3
+	Target       math.Point3
+	Up           math.Vector3
+	FOV          float64
+	Width        int
+	Height       int
+	Orthographic bool
+}
+
+// LightingStyleOption is one lighting-style gallery entry — its user-facing name (the router
+// flags the active one by comparing against [Session.LightingStyleName]).
+type LightingStyleOption struct{ Name string }
+
+// EnvironmentOption is one environment-preset gallery entry — its user-facing name.
+type EnvironmentOption struct{ Name string }

--- a/app/scene_values_adapt.go
+++ b/app/scene_values_adapt.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"oblikovati.org/renderer"
+	"oblikovati.org/scene"
+)
+
+// This file is the ONE renderer/scene wall crossing for the scene value types (audit B10,
+// #1621): every translation between the app-owned [Light]/[ShadowRig]/[Environment]/
+// [CameraFrame] and the renderer's internal GPU/scene representations lives here. Session
+// accessors and the head go through these so no other consumer — the router above all — needs
+// to import renderer or scene.
+
+// lightValue converts a renderer scene light into the app value type.
+func lightValue(l renderer.SceneLight) Light {
+	return Light{
+		Definition:  DefinitionForLightKind(l.Kind),
+		On:          l.On,
+		Color:       l.Color,
+		Intensity:   l.Intensity,
+		Direction:   l.Direction,
+		Position:    l.Position,
+		SpotInner:   l.SpotInner,
+		SpotOuter:   l.SpotOuter,
+		Attenuation: l.Attenuation,
+	}
+}
+
+// renderLight converts an app light value into the renderer's internal light.
+func renderLight(l Light) renderer.SceneLight {
+	return renderer.SceneLight{
+		Kind:        LightKindForDefinition(l.Definition),
+		On:          l.On,
+		Color:       l.Color,
+		Intensity:   l.Intensity,
+		Direction:   l.Direction,
+		Position:    l.Position,
+		SpotInner:   l.SpotInner,
+		SpotOuter:   l.SpotOuter,
+		Attenuation: l.Attenuation,
+	}
+}
+
+// shadowRigValue converts renderer shadow settings into the app value type (field-for-field).
+func shadowRigValue(s renderer.ShadowSettings) ShadowRig {
+	return ShadowRig{
+		GroundShadows: s.GroundShadows, GroundXRay: s.GroundXRay,
+		ObjectShadows: s.ObjectShadows, AmbientShadows: s.AmbientShadows,
+		Density: s.Density, Softness: s.Softness,
+	}
+}
+
+// renderShadowRig converts an app shadow rig into the renderer's internal settings.
+func renderShadowRig(s ShadowRig) renderer.ShadowSettings {
+	return renderer.ShadowSettings{
+		GroundShadows: s.GroundShadows, GroundXRay: s.GroundXRay,
+		ObjectShadows: s.ObjectShadows, AmbientShadows: s.AmbientShadows,
+		Density: s.Density, Softness: s.Softness,
+	}
+}
+
+// environmentValue converts a renderer environment into the app value type, naming the preset.
+func environmentValue(e renderer.Environment) EnvironmentState {
+	return EnvironmentState{
+		Preset: e.Preset.String(), FilePath: e.FilePath,
+		Rotation: e.Rotation, Intensity: e.Intensity, ShowImage: e.ShowImage,
+	}
+}
+
+// renderEnvironment converts an app environment into the renderer's internal environment,
+// resolving the preset name back to its enum (unknown ⇒ EnvNone).
+func renderEnvironment(e EnvironmentState) renderer.Environment {
+	preset, _ := EnvironmentPresetByName(e.Preset)
+	return renderer.Environment{
+		Preset: preset, FilePath: e.FilePath,
+		Rotation: e.Rotation, Intensity: e.Intensity, ShowImage: e.ShowImage,
+	}
+}
+
+// RenderEnvironment exposes the app→renderer environment translation for the head's render loop
+// (the composition root legitimately lives across the wall). Application-internal code and the
+// router never need it.
+func RenderEnvironment(e EnvironmentState) renderer.Environment { return renderEnvironment(e) }
+
+// cameraFrameValue converts a renderer scene camera into the app value type.
+func cameraFrameValue(c scene.Camera) CameraFrame {
+	return CameraFrame{
+		Eye: c.Eye, Target: c.Target, Up: c.Up, FOV: c.FOV,
+		Width: c.Width, Height: c.Height, Orthographic: c.Orthographic,
+	}
+}
+
+// CameraFrame returns the live viewport camera as an app value (audit B10, #1621): the
+// router-facing accessor, so a caller need not name scene.Camera. The head keeps the
+// scene-typed [Session.Camera] for the render loop.
+func (s *Session) CameraFrame() CameraFrame { return cameraFrameValue(s.camera) }
+
+// renderCamera converts an app camera frame into the renderer's scene camera.
+func renderCamera(c CameraFrame) scene.Camera {
+	return scene.Camera{
+		Eye: c.Eye, Target: c.Target, Up: c.Up, FOV: c.FOV,
+		Width: c.Width, Height: c.Height, Orthographic: c.Orthographic,
+	}
+}
+
+// LightingStyleGallery returns the lighting styles in gallery order as app options (name only) —
+// the application-typed view of the renderer gallery, for the router and pickers.
+func LightingStyleGallery() []LightingStyleOption {
+	g := renderer.LightingStyleGallery()
+	out := make([]LightingStyleOption, len(g))
+	for i, o := range g {
+		out[i] = LightingStyleOption{Name: o.Name}
+	}
+	return out
+}
+
+// EnvironmentGallery returns the built-in environment presets in gallery order as app options.
+func EnvironmentGallery() []EnvironmentOption {
+	g := renderer.EnvironmentGallery()
+	out := make([]EnvironmentOption, len(g))
+	for i, o := range g {
+		out[i] = EnvironmentOption{Name: o.Name}
+	}
+	return out
+}

--- a/app/scene_values_test.go
+++ b/app/scene_values_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/renderer"
+)
+
+// The scene value types are the router-facing mirror of the renderer/scene internals (audit
+// B10, #1621). These tests pin the wall converters as bijections and check the Session
+// accessors round-trip through them, so a dropped field surfaces here rather than as a
+// half-populated add-in reply.
+
+// TestLightValueRoundTrip: renderLight∘lightValue is identity on a fully non-zero light.
+func TestLightValueRoundTrip(t *testing.T) {
+	in := renderer.SceneLight{
+		Kind: renderer.SpotLight, On: true, Color: [3]float32{0.1, 0.2, 0.3}, Intensity: 2,
+		Direction: [3]float32{0, 0, 1}, Position: [3]float32{4, 5, 6},
+		SpotInner: 0.3, SpotOuter: 0.6, Attenuation: [3]float32{1, 0.1, 0.01},
+	}
+	if got := renderLight(lightValue(in)); got != in {
+		t.Errorf("light round-trip = %+v, want %+v", got, in)
+	}
+}
+
+// TestShadowRigRoundTrip: renderShadowRig∘shadowRigValue is identity.
+func TestShadowRigRoundTrip(t *testing.T) {
+	in := renderer.ShadowSettings{
+		GroundShadows: true, GroundXRay: true, ObjectShadows: true,
+		AmbientShadows: true, Density: 0.7, Softness: 0.4,
+	}
+	if got := renderShadowRig(shadowRigValue(in)); got != in {
+		t.Errorf("shadow round-trip = %+v, want %+v", got, in)
+	}
+}
+
+// TestEnvironmentValueRoundTrip: a preset and a file environment both survive the wall.
+func TestEnvironmentValueRoundTrip(t *testing.T) {
+	preset := renderer.Environment{Preset: renderer.EnvStudio, Rotation: 1, Intensity: 2, ShowImage: true}
+	if got := renderEnvironment(environmentValue(preset)); got != preset {
+		t.Errorf("preset env round-trip = %+v, want %+v", got, preset)
+	}
+	file := renderer.Environment{Preset: renderer.EnvNone, FilePath: "/tmp/x.hdr", Intensity: 1, ShowImage: true}
+	if got := renderEnvironment(environmentValue(file)); got != file {
+		t.Errorf("file env round-trip = %+v, want %+v", got, file)
+	}
+}
+
+// TestEnvironmentStateIsActive matches renderer.Environment.IsActive across the wall.
+func TestEnvironmentStateIsActive(t *testing.T) {
+	cases := []EnvironmentState{{Preset: "None"}, {Preset: "Sky"}, {FilePath: "/x.hdr"}, {}}
+	for _, e := range cases {
+		want := renderEnvironment(e).IsActive()
+		if e.IsActive() != want {
+			t.Errorf("IsActive(%+v) = %v, want %v", e, e.IsActive(), want)
+		}
+	}
+}
+
+// TestCameraFrameRoundTrip: renderCamera∘cameraFrameValue is identity.
+func TestCameraFrameRoundTrip(t *testing.T) {
+	in := renderCamera(CameraFrame{FOV: 0.8, Width: 1280, Height: 800, Orthographic: true})
+	if got := renderCamera(cameraFrameValue(in)); got != in {
+		t.Errorf("camera round-trip = %+v, want %+v", got, in)
+	}
+}
+
+// TestSessionLightingValueSeam round-trips the value types through the Session accessors.
+func TestSessionLightingValueSeam(t *testing.T) {
+	s := NewSession()
+	s.SetShadowSettings(ShadowRig{ObjectShadows: true, Density: 0.5})
+	if !s.ShadowSettings().ObjectShadows {
+		t.Error("shadow rig did not round-trip through the Session")
+	}
+	l, err := s.AddLight(types.SpotLight)
+	if err != nil {
+		t.Fatalf("AddLight: %v", err)
+	}
+	if l.Definition != types.SpotLight {
+		t.Errorf("AddLight returned definition %v, want SpotLight", l.Definition)
+	}
+}
+
+// TestSceneGalleriesAreNamed: the app-typed galleries expose the renderer gallery names.
+func TestSceneGalleriesAreNamed(t *testing.T) {
+	if len(LightingStyleGallery()) != len(renderer.LightingStyleGallery()) {
+		t.Error("lighting-style gallery lost entries crossing the wall")
+	}
+	if got := EnvironmentGallery(); len(got) == 0 || got[0].Name == "" {
+		t.Errorf("environment gallery is empty or unnamed: %+v", got)
+	}
+}

--- a/app/view_prefs_test.go
+++ b/app/view_prefs_test.go
@@ -67,10 +67,11 @@ func TestSessionViewManagement(t *testing.T) {
 	if err := s.SetViewCamera(0, cam); err != nil {
 		t.Errorf("SetViewCamera: %v", err)
 	}
-	if _, ok := s.ViewCameraAt(0); !ok {
+	camAt, ok := s.ViewCameraAt(0) // scene.Camera (the tiled-viewport accessor the head uses)
+	if !ok {
 		t.Error("ViewCameraAt(0) should resolve the first open document's camera")
 	}
-	s.SetViewCameraAt(0, cam)
+	s.SetViewCameraAt(0, camAt)
 
 	if err := s.NewView(); err != nil {
 		t.Errorf("NewView: %v", err)

--- a/app/views.go
+++ b/app/views.go
@@ -424,26 +424,28 @@ func (s *Session) AddView(docID uint64, name string, copyActiveCamera bool) (int
 }
 
 // ViewCamera returns a document's active-view camera (id 0 = active document), sized to
-// the current viewport.
-func (s *Session) ViewCamera(docID uint64) (scene.Camera, error) {
+// the current viewport, as an app [CameraFrame] (audit B10, #1621: the router speaks the
+// app value type, not scene.Camera).
+func (s *Session) ViewCamera(docID uint64) (CameraFrame, error) {
 	d, err := s.DocumentByID(docID)
 	if err != nil {
-		return scene.Camera{}, err
+		return CameraFrame{}, err
 	}
 	v := d.Views().Active()
 	c := s.camera // carry the transient viewport pixel size
 	c.Eye, c.Target, c.Up, c.FOV = v.Eye, v.Target, v.Up, v.FOV
-	return c, nil
+	return cameraFrameValue(c), nil
 }
 
-// SetViewCamera applies c to a document's active view (id 0 = active document). When the
+// SetViewCamera applies frame to a document's active view (id 0 = active document). When the
 // addressed document is the active one this routes through SetCamera (picker + cache
 // sync); otherwise it writes the off-screen document's view frame directly.
-func (s *Session) SetViewCamera(docID uint64, c scene.Camera) error {
+func (s *Session) SetViewCamera(docID uint64, frame CameraFrame) error {
 	d, err := s.DocumentByID(docID)
 	if err != nil {
 		return err
 	}
+	c := renderCamera(frame)
 	if d == s.ActiveDocument() {
 		s.SetCamera(c)
 		return nil

--- a/archguard/edge_allowlist_test.go
+++ b/archguard/edge_allowlist_test.go
@@ -69,11 +69,12 @@ var allowedTreeImports = map[string][]string{
 	"addin/events":      {"api", "app", "event", "math", "model"},
 	"addin/modelaccess": {"app", "model"},
 	"addin/opregistry":  {"addin/modelaccess", "api", "app", "kernel", "math", "model"},
+	// B10 (#1621, RESOLVED): the router no longer reaches renderer/scene — lighting/
+	// environment/camera state crosses the wall as app-owned value types
+	// (app.Light/ShadowRig/EnvironmentState/CameraFrame), so renderer and scene are
+	// deliberately ABSENT here; re-adding either import fails this test.
 	"addin/router": {"addin/modelaccess", "addin/opregistry", "addin/trace", "api", "app",
-		"clientgraphics", "event", "kernel", "math", "model", "osfont", "script",
-		// TODO(B10 #1621): the router reaches renderer/scene internals for lighting/
-		// environment state; app-owned value types replace these, then both entries go.
-		"renderer", "scene"},
+		"clientgraphics", "event", "kernel", "math", "model", "osfont", "script"},
 	"addin/trace": {"api"},
 
 	// Composition roots may reach anything below them.

--- a/archguard/yaml_wrapper_test.go
+++ b/archguard/yaml_wrapper_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package archguard
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// The YAML-wrapper guard (#1622, audit B11): gopkg.in/yaml.v3 is the project's single
+// third-party YAML surface and must be reached ONLY through the yamlcodec wrapper
+// (CLAUDE.md dependency rule + ADR-0020), so a library swap or a format quirk (indent
+// style, anchor handling, !!binary encoding) is absorbed in one place — the .obk document
+// format depends on that stability. Any other package that imports yaml.v3 directly
+// bypasses the seam; this test fails unless the package is on the explicit, commented
+// allowlist below. Red-verify by adding a raw `gopkg.in/yaml.v3` import to a non-exempt
+// package — the test then names it.
+var yamlDirectImportAllowlist = map[string]string{
+	// The wrapper itself — the one legitimate home of the yaml.v3 dependency.
+	"oblikovati.org/persistence/yamlcodec": "the owned wrapper (ADR-0020)",
+	// release/version.go parses version.yaml. Routing it through yamlcodec would add a
+	// release -> persistence edge (persistence pulls in model/api), coupling a zero-dep
+	// version leaf to the document layer. Exempt until B4 (#1615) relocates yamlcodec to a
+	// neutral leaf, after which this entry should go and release should use the wrapper.
+	"oblikovati.org/release": "version.yaml parsing; awaiting B4 yamlcodec relocation (#1615)",
+	// model/feature's emboss_text_test.go marshals a fixture struct for a round-trip
+	// assertion — a test helper, not the .obk document path the wrapper guards.
+	"oblikovati.org/model/feature": "test-only fixture marshal (emboss_text_test.go)",
+}
+
+// yamlV3Path is the third-party YAML import the guard fences off.
+const yamlV3Path = "gopkg.in/yaml.v3"
+
+// TestRawYamlImportsAreWrapped fails if a first-party package outside the allowlist imports
+// gopkg.in/yaml.v3 directly (in production, internal-test, or external-test files).
+func TestRawYamlImportsAreWrapped(t *testing.T) {
+	for _, pkg := range packagesImportingYaml(t) {
+		if _, ok := yamlDirectImportAllowlist[pkg]; ok {
+			continue
+		}
+		t.Errorf("package %s imports %s directly — route YAML through "+
+			"oblikovati.org/persistence/yamlcodec (the owned wrapper, ADR-0020) or add an "+
+			"explicit, commented exemption in yamlDirectImportAllowlist (#1622).", pkg, yamlV3Path)
+	}
+}
+
+// packagesImportingYaml returns every first-party package that lists yaml.v3 among its
+// production, internal-test, or external-test imports (one `go list` over the module).
+func packagesImportingYaml(t *testing.T) []string {
+	t.Helper()
+	cmd := exec.Command("go", "list", "-f",
+		`{{.ImportPath}}::{{join .Imports " "}} {{join .TestImports " "}} {{join .XTestImports " "}}`, "./...")
+	cmd.Dir = ".."
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("go list imports ./...: %v", err)
+	}
+	return matchYamlImporters(string(out))
+}
+
+// matchYamlImporters keeps the import paths whose import lists contain yaml.v3.
+func matchYamlImporters(listing string) []string {
+	var pkgs []string
+	for _, line := range strings.Split(strings.TrimSpace(listing), "\n") {
+		path, imports, ok := strings.Cut(line, "::")
+		if ok && strings.Contains(imports, yamlV3Path) {
+			pkgs = append(pkgs, path)
+		}
+	}
+	return pkgs
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.102.1
+	oblikovati.org/api v0.103.1
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.102.1
+	oblikovati.org/api v0.103.1
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -499,8 +499,8 @@ func renderViewportImage(win *native.Window, s *app.Session, slot int, cam scene
 	mvp := renderer.ViewProjection(cam, viewportNear, viewportFarPlane(s, cam, mn, mx, hasGeom))
 	eye := frameEye(cam) // reused scratch; RenderViewport copies it into the push constant synchronously (#1423)
 	win.SetViewportLighting(viewport.PackLighting(s.SceneLighting()))
-	applyEnvironment(win, s.Environment())
-	applySkybox(win, s.Environment(), mvp)
+	applyEnvironment(win, app.RenderEnvironment(s.Environment())) // app value -> renderer at the wall (B10 #1621)
+	applySkybox(win, app.RenderEnvironment(s.Environment()), mvp)
 	applyShadow(win, s, mn, mx, hasGeom)
 	tg := frameClock()
 	win.RenderViewport(slot, pw, ph, mvp[:], eye,

--- a/kernel/ops/body_query_test.go
+++ b/kernel/ops/body_query_test.go
@@ -104,10 +104,11 @@ func TestOrientedMinimumRangeBoxRotatedBox(t *testing.T) {
 	if v := obb.Volume(); stdmath.Abs(v-8) > 1e-6 {
 		t.Errorf("rotated-box OBB volume = %g, want 8 (tight)", v)
 	}
+	edges := obb.EdgeVectors()
 	dims := []float64{
-		float64(obb.DirectionOne.Length()),
-		float64(obb.DirectionTwo.Length()),
-		float64(obb.DirectionThree.Length()),
+		float64(edges[0].Length()),
+		float64(edges[1].Length()),
+		float64(edges[2].Length()),
 	}
 	for _, d := range dims {
 		if stdmath.Abs(d-2) > 1e-6 {

--- a/kernel/ops/oriented_box.go
+++ b/kernel/ops/oriented_box.go
@@ -17,28 +17,20 @@ import (
 // with a hull face (always true for polyhedra, per O'Rourke); curved bodies
 // are sampled at edge density, so the box is sample-accurate.
 
-// OrientedBox is a corner with three mutually perpendicular edge vectors —
-// the reference OrientedBox shape.
-type OrientedBox struct {
-	Corner                       math.Point3
-	DirectionOne                 math.Vector3
-	DirectionTwo, DirectionThree math.Vector3
-}
-
-// Volume returns the box volume.
-func (b OrientedBox) Volume() float64 {
-	return float64(b.DirectionOne.Length()) * float64(b.DirectionTwo.Length()) * float64(b.DirectionThree.Length())
-}
+// The oriented box value type is the ONE in-module [math.OrientedBox] (audit B9, #1620:
+// this file used to declare a second OrientedBox — corner + three edge vectors — a plain
+// duplicate; it now builds the result in that corner+edges form and hands it to
+// math.NewOrientedBoxFromEdges, so there is a single oriented-box type).
 
 // OrientedMinimumRangeBox computes the minimal oriented box over the body's
 // sampled geometry (vertices + 32 samples per curved edge).
 //
 // Example: obb := ops.OrientedMinimumRangeBox(body)
-func OrientedMinimumRangeBox(b *topo.Body) (OrientedBox, error) {
+func OrientedMinimumRangeBox(b *topo.Body) (math.OrientedBox, error) {
 	pts := bodySamplePoints(b)
 	hull, err := ConvexHull(pts, "obb")
 	if err != nil {
-		return OrientedBox{}, err
+		return math.OrientedBox{}, err
 	}
 	// Only hull vertices matter for extents — they dominate every interior
 	// sample, and there are far fewer of them than raw edge samples.
@@ -46,7 +38,7 @@ func OrientedMinimumRangeBox(b *topo.Body) (OrientedBox, error) {
 	for _, v := range hull.Vertices() {
 		hullPts = append(hullPts, v.Point())
 	}
-	best, bestVol := OrientedBox{}, stdmath.Inf(1)
+	best, bestVol := math.OrientedBox{}, stdmath.Inf(1)
 	for _, f := range hull.Faces() {
 		box, ok := boxFlushWithFace(f, hullPts)
 		if ok && box.Volume() < bestVol {
@@ -84,11 +76,11 @@ func bodySamplePoints(b *topo.Body) []math.Point3 {
 
 // boxFlushWithFace builds the best box whose base plane is flush with the hull
 // face: axis w = face normal, in-plane axes from 2D rotating calipers.
-func boxFlushWithFace(f *topo.Face, pts []math.Point3) (OrientedBox, bool) {
+func boxFlushWithFace(f *topo.Face, pts []math.Point3) (math.OrientedBox, bool) {
 	w := f.Geometry().NormalAt(0, 0)
 	l := float64(w.Length())
 	if l == 0 {
-		return OrientedBox{}, false
+		return math.OrientedBox{}, false
 	}
 	w = w.Scale(math.Scalar(1 / l))
 	u := perpUnit(w)
@@ -103,7 +95,7 @@ func boxFlushWithFace(f *topo.Face, pts []math.Point3) (OrientedBox, bool) {
 	}
 	rect, ok := minAreaRectangle(proj)
 	if !ok {
-		return OrientedBox{}, false
+		return math.OrientedBox{}, false
 	}
 	return liftRectangle(rect, u, v, w, wLo, wHi), true
 }
@@ -124,9 +116,10 @@ type rect2 struct {
 	e1, e2 math.Vector2
 }
 
-// liftRectangle assembles the 3D box from the in-plane rectangle and the
-// normal extent.
-func liftRectangle(r rect2, u, v, w math.Vector3, wLo, wHi float64) OrientedBox {
+// liftRectangle assembles the 3D box from the in-plane rectangle and the normal extent,
+// as a corner and three orthogonal edge vectors handed to [math.NewOrientedBoxFromEdges]
+// (the single oriented-box value type).
+func liftRectangle(r rect2, u, v, w math.Vector3, wLo, wHi float64) math.OrientedBox {
 	corner := math.P3(0, 0, 0).
 		TranslateBy(u.Scale(r.corner.X)).
 		TranslateBy(v.Scale(r.corner.Y)).
@@ -134,11 +127,7 @@ func liftRectangle(r rect2, u, v, w math.Vector3, wLo, wHi float64) OrientedBox 
 	lift := func(e math.Vector2) math.Vector3 {
 		return u.Scale(e.X).Add(v.Scale(e.Y))
 	}
-	return OrientedBox{
-		Corner:       corner,
-		DirectionOne: lift(r.e1), DirectionTwo: lift(r.e2),
-		DirectionThree: w.Scale(math.Scalar(wHi - wLo)),
-	}
+	return math.NewOrientedBoxFromEdges(corner, lift(r.e1), lift(r.e2), w.Scale(math.Scalar(wHi-wLo)))
 }
 
 // minAreaRectangle runs rotating calipers over the 2D convex hull: the minimum

--- a/math/box.go
+++ b/math/box.go
@@ -8,6 +8,16 @@ import stdmath "math"
 // region between Min and Max. It is the range-query primitive used throughout
 // the model. The empty box (see [EmptyBox]) has Min > Max so that extending it
 // with the first point yields a degenerate box at that point.
+//
+// Deliberate math↔types duality (audit B9, #1620): the same shape is defined a
+// second time as types.Box in the Apache-2.0 api module. This is NOT accidental
+// duplication — it is forced by the dependency direction (ADR-0018): the api
+// module must never import this GPL module, and this kernel-facing math package
+// must not depend on the api's serialization concerns (json tags, the wire
+// Point). So each side owns a Box in its own value type (math.Point3 here,
+// types.Point there). The two are kept in lockstep by hand; a field added to one
+// MUST be mirrored on the other. Cross-reference: keep this in sync with
+// types.Box in Oblikovati.API/types/geom_box.go.
 type Box struct {
 	Min, Max Point3
 }

--- a/math/oriented_box_edges.go
+++ b/math/oriented_box_edges.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package math
+
+// NewOrientedBoxFromEdges builds an oriented box from a corner and the three edge vectors
+// spanning from it — the corner+edge-vectors form kernel/ops.OrientedMinimumRangeBox
+// produces and the reference types.OrientedBox exposes (audit B9, #1620: the seam that let
+// the former kernel/ops.OrientedBox twin be collapsed into [OrientedBox]). The edges are
+// assumed mutually orthogonal; each becomes a unit axis with half its length as the
+// half-extent. A zero-length edge yields a zero half-extent on an orthonormally completed
+// axis, so a degenerate (flat/segment/point) box stays representable without a non-unit axis.
+//
+// Example: obb := math.NewOrientedBoxFromEdges(corner, e0, e1, e2)
+func NewOrientedBoxFromEdges(corner Point3, e0, e1, e2 Vector3) OrientedBox {
+	edges := [3]Vector3{e0, e1, e2}
+	axes, half := orientedFrame(edges)
+	center := corner
+	for _, e := range edges {
+		center = center.TranslateBy(e.Scale(0.5))
+	}
+	return OrientedBox{Center: center, Axes: axes, HalfExtents: half}
+}
+
+// orientedFrame splits three (assumed orthogonal) edge vectors into unit axes and
+// half-extents, completing any zero-length edge's axis orthonormally so [OrientedBox.Contains]
+// can still project onto an orthonormal frame.
+func orientedFrame(edges [3]Vector3) ([3]UnitVector3, [3]Scalar) {
+	var axes [3]UnitVector3
+	var half [3]Scalar
+	for i, e := range edges {
+		half[i] = e.Length() * 0.5
+		if u, err := UnitVector3FromVector(e); err == nil {
+			axes[i] = u
+		}
+	}
+	return completeOrthonormal(axes), half
+}
+
+// completeOrthonormal fills any unset (zero) axis with a unit vector orthogonal to the
+// already-set ones, in order, so the three axes end up orthonormal even after a degenerate
+// edge. A solid body never produces a zero edge; this only guards pathological input.
+func completeOrthonormal(axes [3]UnitVector3) [3]UnitVector3 {
+	for i := range axes {
+		if !axisSet(axes[i]) {
+			axes[i] = perpToOthers(axes, i)
+		}
+	}
+	return axes
+}
+
+// perpToOthers returns a unit vector orthogonal to whichever of the OTHER two axes are set:
+// their cross product when both are set, any perpendicular of the single set one, or the
+// world axis i when neither is.
+func perpToOthers(axes [3]UnitVector3, i int) UnitVector3 {
+	j, k := (i+1)%3, (i+2)%3
+	switch {
+	case axisSet(axes[j]) && axisSet(axes[k]):
+		return axes[j].Cross(axes[k]).AsUnit()
+	case axisSet(axes[j]):
+		return anyPerpendicular(axes[j])
+	case axisSet(axes[k]):
+		return anyPerpendicular(axes[k])
+	default:
+		return worldAxis(i)
+	}
+}
+
+// axisSet reports whether u is a real (non-zero) axis rather than the zero value left by a
+// degenerate edge.
+func axisSet(u UnitVector3) bool { return u.AsVector().LengthSquared() != 0 }
+
+// worldAxis returns the i-th world basis vector as a unit vector.
+func worldAxis(i int) UnitVector3 {
+	switch i {
+	case 0:
+		return V3(1, 0, 0).AsUnit()
+	case 1:
+		return V3(0, 1, 0).AsUnit()
+	default:
+		return V3(0, 0, 1).AsUnit()
+	}
+}

--- a/math/orientedbox.go
+++ b/math/orientedbox.go
@@ -6,7 +6,20 @@ import stdmath "math"
 
 // OrientedBox is a box with an arbitrary orientation in 3D (contract:
 // OrientedBox): the region within HalfExtents of Center along three orthonormal
-// Axes. Unlike a [Box] it can be tight around rotated geometry.
+// Axes. Unlike a [Box] it can be tight around rotated geometry. This is the ONE
+// in-module oriented-box value type — kernel/ops.OrientedMinimumRangeBox returns
+// it, and the router serializes it via [OrientedBox.MinCorner]/[OrientedBox.EdgeVectors]
+// (audit B9, #1620: the former kernel/ops.OrientedBox corner+edge-vectors twin was
+// collapsed into this center+axes form).
+//
+// Deliberate math↔types duality (audit B9, #1620): the same concept is defined a
+// second time as types.OrientedBox in the Apache-2.0 api module, in the reference
+// corner+axes+extents form. This is NOT accidental duplication — the dependency
+// direction (ADR-0018) forbids the api module from importing this GPL math package
+// and forbids this package from taking on the api's serialization concerns, so
+// each side owns its own value type. The two are kept in lockstep by hand; a field
+// added to one MUST be mirrored on the other. Cross-reference: keep this in sync
+// with types.OrientedBox in Oblikovati.API/types/geom_box.go.
 type OrientedBox struct {
 	Center      Point3
 	Axes        [3]UnitVector3
@@ -53,4 +66,31 @@ func (b OrientedBox) Corners() [8]Point3 {
 func (b OrientedBox) ToAABB() Box {
 	corners := b.Corners()
 	return BoxFromPoints(corners[:]...)
+}
+
+// Volume returns the box volume — the product of the three full edge lengths
+// (each axis's full extent is twice its half-extent).
+func (b OrientedBox) Volume() Scalar {
+	return 8 * b.HalfExtents[0] * b.HalfExtents[1] * b.HalfExtents[2]
+}
+
+// MinCorner returns the corner at the negative end of every axis — the origin of
+// the reference corner+edge-vectors form (the inverse of [NewOrientedBoxFromEdges]).
+func (b OrientedBox) MinCorner() Point3 {
+	c := b.Center
+	for i := 0; i < 3; i++ {
+		c = c.TranslateBy(b.Axes[i].AsVector().Scale(-b.HalfExtents[i]))
+	}
+	return c
+}
+
+// EdgeVectors returns the three full-length edge vectors spanning from [MinCorner]
+// (each axis scaled by its full extent) — the corner+edges form the reference
+// OrientedBox and the wire DTO use.
+func (b OrientedBox) EdgeVectors() [3]Vector3 {
+	var e [3]Vector3
+	for i := 0; i < 3; i++ {
+		e[i] = b.Axes[i].AsVector().Scale(2 * b.HalfExtents[i])
+	}
+	return e
 }

--- a/math/orientedbox_test.go
+++ b/math/orientedbox_test.go
@@ -52,3 +52,45 @@ func TestOrientedBoxToAABB(t *testing.T) {
 		t.Errorf("AABB min Z = %v, want -1", aabb.Min.Z)
 	}
 }
+
+// Volume is the product of the three full edge lengths (2×half-extent each).
+func TestOrientedBoxVolume(t *testing.T) {
+	b := NewOrientedBox(P3(1, 2, 3),
+		mustUnit3(t, 1, 0, 0), mustUnit3(t, 0, 1, 0), mustUnit3(t, 0, 0, 1),
+		[3]Scalar{2, 1.5, 0.5})
+	if v := b.Volume(); !approxEqual(v, 4*3*1, 1e-12) { // (2·2)(2·1.5)(2·0.5)
+		t.Errorf("volume = %v, want 12", v)
+	}
+}
+
+// NewOrientedBoxFromEdges round-trips against MinCorner/EdgeVectors: a corner and three
+// orthogonal edge vectors reconstruct exactly (the collapse seam, audit B9 #1620).
+func TestOrientedBoxFromEdgesRoundTrip(t *testing.T) {
+	corner := P3(1, -2, 0.5)
+	e0, e1, e2 := V3(3, 0, 0), V3(0, 2, 0), V3(0, 0, 4)
+	b := NewOrientedBoxFromEdges(corner, e0, e1, e2)
+	got := b.MinCorner()
+	if !approxEqual(got.X, corner.X, 1e-9) || !approxEqual(got.Y, corner.Y, 1e-9) || !approxEqual(got.Z, corner.Z, 1e-9) {
+		t.Errorf("MinCorner = %v, want %v", got, corner)
+	}
+	edges := b.EdgeVectors()
+	for i, want := range [3]Vector3{e0, e1, e2} {
+		if !approxEqual(float64(edges[i].Length()), float64(want.Length()), 1e-9) {
+			t.Errorf("edge[%d] length = %v, want %v", i, edges[i].Length(), want.Length())
+		}
+	}
+}
+
+// A degenerate edge (zero length) still yields an orthonormal frame — no non-unit axis, no
+// panic — so a flat/segment box stays representable.
+func TestOrientedBoxFromEdgesDegenerate(t *testing.T) {
+	b := NewOrientedBoxFromEdges(P3(0, 0, 0), V3(2, 0, 0), V3(0, 0, 0), V3(0, 0, 2))
+	if b.HalfExtents[1] != 0 {
+		t.Errorf("degenerate axis half-extent = %v, want 0", b.HalfExtents[1])
+	}
+	for i, ax := range b.Axes {
+		if !approxEqual(float64(ax.AsVector().Length()), 1, 1e-12) {
+			t.Errorf("axis[%d] is not unit-length: %v", i, ax.AsVector().Length())
+		}
+	}
+}


### PR DESCRIPTION
## What

Three MINOR value-type / dependency-direction findings from the 2026-07 deep audit (M40), one commit each:

- **B9 (#1620) — math↔types duality + twin drift.** Documents the deliberate math↔types value-type duality on `math.Box`/`math.OrientedBox` (forced by the ADR-0018 dependency direction), cross-referencing `types.Box`/`types.OrientedBox`. Collapses the in-module `OrientedBox` duplicate — `kernel/ops` had its own corner+edge-vectors `OrientedBox` alongside `math.OrientedBox`; `OrientedMinimumRangeBox` now returns the single `math.OrientedBox` via a new `math.NewOrientedBoxFromEdges` seam, and the router serializes it with new `MinCorner`/`EdgeVectors` accessors (wire shape unchanged). Guards the hand-converted model/wire twins (assembly-drive, sheet-metal) with a reflect field-parity test plus a fully-populated `DriveResult` conversion test.

- **B10 (#1621) — router↔renderer decoupling.** `addin/router` imported `renderer` and `scene` because `app.Session` leaked those types in its signatures, violating the ADR-0014 renderer wall. Introduces app-owned value types (`app.Light`, `app.ShadowRig`, `app.EnvironmentState`, `app.CameraFrame` + name-only galleries) with all renderer/scene translation in one adapter (`app/scene_values_adapt.go`). The router now imports only `app` + `api`; the archguard edge allowlist drops its renderer/scene entries so re-adding either import fails CI.

- **B11 (#1622) — yaml.v3 wrapper.** Routes `app/bug_report_diag.go` through the owned `yamlcodec` wrapper (byte-identical output) and adds an archguard guard restricting raw `gopkg.in/yaml.v3` imports to `yamlcodec` plus an explicit, commented allowlist (`release/version.go` exempted pending B4's yamlcodec relocation; a test fixture exempted).

## Why

Twin structs and leaked types drift silently and couple layers that should be swappable. Each change is guarded by a test that red-fails on the exact regression it prevents (phantom field, re-added renderer import, stray yaml import — all red-verified locally).

## Verification

`go build ./...` + `go build ./head/...`, full `go test ./...` (0 failures), `golangci-lint run ./...` (0 issues). Router confirmed free of renderer/scene direct imports; head/ui pre-existing funlen issues are untouched.

Closes #1620
Closes #1621
Closes #1622

🤖 Generated with [Claude Code](https://claude.com/claude-code)