### PR TITLE
Audit S10: emit object.renamed / property.changed for metadata mutations (#1644)

### DIFF
--- a/addin/events/events.go
+++ b/addin/events/events.go
@@ -163,6 +163,18 @@ func subscribeModeling(bus *event.Bus, sink Sink) []event.Subscription {
 				Type: sketchEditEventType(e.Entered), Document: uint64(e.Document), Sketch: e.Sketch, Name: e.Name,
 			})
 		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.ObjectRenamed) event.Outcome {
+			return relayJSON(sink, wire.ObjectRenamedEvent{
+				Type: wire.EventObjectRenamed, Document: uint64(e.Document), Kind: e.Kind,
+				Key: e.Key, OldName: e.OldName, NewName: e.NewName,
+			})
+		}),
+		event.Subscribe(bus, event.After, func(_ event.Context, e app.PropertyChanged) event.Outcome {
+			return relayJSON(sink, wire.PropertyChangedEvent{
+				Type: wire.EventPropertyChanged, Document: uint64(e.Document), Kind: e.Kind,
+				Key: e.Key, Property: e.Property, OldValue: e.OldValue, NewValue: e.NewValue,
+			})
+		}),
 	}
 }
 
@@ -331,6 +343,7 @@ func relayJSON[E wire.BrowserNodeEvent | wire.DockableWindowChangedEvent |
 	wire.JointEventPayload | wire.ParameterChangedEvent |
 	wire.ModelChangedEvent | wire.PanelValueChangedEvent |
 	wire.FeatureLifecycleEvent | wire.SketchEditEvent |
+	wire.ObjectRenamedEvent | wire.PropertyChangedEvent |
 	wire.PanelReferencesChangedEvent | wire.TaskPanelClosedEvent](sink Sink, ev E) event.Outcome {
 	if b, err := json.Marshal(ev); err == nil {
 		sink(b)

--- a/addin/events/metadata_relay_test.go
+++ b/addin/events/metadata_relay_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package events
+
+import (
+	"encoding/json"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/event"
+)
+
+// TestForwardsObjectRenamed: a metadata rename raised on the session bus is relayed to the add-in
+// sink as an object.renamed wire event carrying the object kind, key, and old/new names (#1644).
+func TestForwardsObjectRenamed(t *testing.T) {
+	s := app.NewSession()
+	var rec rawRecorder
+	if subs := Subscribe(s, rec.sink); len(subs) == 0 {
+		t.Fatal("Subscribe returned no subscriptions")
+	}
+	event.Emit(s.Events(), event.After, app.ObjectRenamed{
+		Document: 5, Kind: types.ObjectKindFeature, Key: "7", OldName: "Extrusion1", NewName: "Base",
+	})
+	if !hasObjectRenamed(rec.got) {
+		t.Errorf("no object.renamed relayed; got %d payloads", len(rec.got))
+	}
+}
+
+func hasObjectRenamed(got []string) bool {
+	for _, raw := range got {
+		var e wire.ObjectRenamedEvent
+		if json.Unmarshal([]byte(raw), &e) == nil && e.Type == wire.EventObjectRenamed &&
+			e.Document == 5 && e.Kind == types.ObjectKindFeature && e.Key == "7" &&
+			e.OldName == "Extrusion1" && e.NewName == "Base" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestForwardsPropertyChanged: a suppression change raised on the session bus is relayed as a
+// property.changed wire event carrying the property name and old/new values (#1644).
+func TestForwardsPropertyChanged(t *testing.T) {
+	s := app.NewSession()
+	var rec rawRecorder
+	if subs := Subscribe(s, rec.sink); len(subs) == 0 {
+		t.Fatal("Subscribe returned no subscriptions")
+	}
+	event.Emit(s.Events(), event.After, app.PropertyChanged{
+		Document: 5, Kind: types.ObjectKindFeature, Key: "7", Property: "suppressed", OldValue: "false", NewValue: "true",
+	})
+	if !hasPropertyChanged(rec.got) {
+		t.Errorf("no property.changed relayed; got %d payloads", len(rec.got))
+	}
+}
+
+func hasPropertyChanged(got []string) bool {
+	for _, raw := range got {
+		var e wire.PropertyChangedEvent
+		if json.Unmarshal([]byte(raw), &e) == nil && e.Type == wire.EventPropertyChanged &&
+			e.Property == "suppressed" && e.OldValue == "false" && e.NewValue == "true" {
+			return true
+		}
+	}
+	return false
+}

--- a/app/feature_lifecycle.go
+++ b/app/feature_lifecycle.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
 )
@@ -46,8 +47,10 @@ func (s *Session) RenameFeature(f *feature.PartFeature, name string) error {
 	if other, ok := part.Features().ByName(name); ok && other != f {
 		return fmt.Errorf("app: RenameFeature: name %q is already used by another feature", name)
 	}
+	old := f.Name()
 	f.SetName(name)
 	s.recordEdit(part, "Rename Feature")
+	s.emitObjectRenamed(types.ObjectKindFeature, featureMetaKey(f), old, name) // #1644
 	return nil
 }
 
@@ -65,6 +68,8 @@ func (s *Session) SetFeatureSuppressed(f *feature.PartFeature, suppressed bool) 
 	f.SetSuppressed(suppressed)
 	part.Recompute()
 	s.recordEdit(part, suppressLabel(suppressed))
+	// #1644: the previous state is the negation, since we only reach here on an actual change.
+	s.emitPropertyChanged(types.ObjectKindFeature, featureMetaKey(f), "suppressed", boolProperty(!suppressed), boolProperty(suppressed))
 	return nil
 }
 

--- a/app/metadata_events.go
+++ b/app/metadata_events.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"strconv"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/event"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/feature"
+)
+
+// Metadata-mutation events (S10, #1644): renames and property changes (suppression, sketch
+// settings) previously fired nothing, so add-ins mirroring the document went stale and had to
+// poll. Like the feature-lifecycle events (#1085) these are emitted at the SESSION seam — the
+// shared verb both the UI and the wire router call — so an interactive rename and a body.rename
+// call alike reach the relay. 0x08xx = the modeling event block (see modeling_events.go).
+const (
+	tidObjectRenamed   event.TypeID = 0x0803
+	tidPropertyChanged event.TypeID = 0x0804
+)
+
+// ObjectRenamed announces that a document object (body/sketch/feature/occurrence/document) was
+// renamed. Kind is the object kind, Key its stable reference key, and Old/New the prior and new
+// names — enough for a relay to forward object.renamed without re-querying the model.
+type ObjectRenamed struct {
+	Document doc.ID
+	Kind     types.ObjectKind
+	Key      string
+	OldName  string
+	NewName  string
+}
+
+// EventID implements event.Event.
+func (ObjectRenamed) EventID() event.TypeID { return tidObjectRenamed }
+
+// PropertyChanged announces that a document object's property changed (e.g. suppression toggled, a
+// sketch setting edited). Property names the property; Old/New are its values as strings so one
+// event carries any property.
+type PropertyChanged struct {
+	Document doc.ID
+	Kind     types.ObjectKind
+	Key      string
+	Property string
+	OldValue string
+	NewValue string
+}
+
+// EventID implements event.Event.
+func (PropertyChanged) EventID() event.TypeID { return tidPropertyChanged }
+
+// activeDocID returns the active document's id, or the zero id when none is active — the shared
+// keying every metadata emit uses.
+func (s *Session) activeDocID() doc.ID {
+	if active := s.ActiveDocument(); active != nil {
+		return active.ID()
+	}
+	return 0
+}
+
+// emitObjectRenamed publishes an object.renamed notification on the session bus, keyed to the
+// active document, so the add-in relay forwards it for UI- and wire-driven renames alike (#1644).
+func (s *Session) emitObjectRenamed(kind types.ObjectKind, key, oldName, newName string) {
+	event.Emit(s.bus, event.After, ObjectRenamed{
+		Document: s.activeDocID(), Kind: kind, Key: key, OldName: oldName, NewName: newName,
+	})
+}
+
+// emitPropertyChanged publishes a property.changed notification on the session bus, keyed to the
+// active document (#1644).
+func (s *Session) emitPropertyChanged(kind types.ObjectKind, key, property, oldVal, newVal string) {
+	event.Emit(s.bus, event.After, PropertyChanged{
+		Document: s.activeDocID(), Kind: kind, Key: key, Property: property, OldValue: oldVal, NewValue: newVal,
+	})
+}
+
+// featureMetaKey is a feature's stable reference key for a metadata event — its session id, the
+// same identity the feature-lifecycle events carry, rendered as a string for the generic Key field.
+func featureMetaKey(f *feature.PartFeature) string {
+	return strconv.FormatUint(uint64(f.ID()), 10)
+}
+
+// boolProperty renders a bool property value for a [PropertyChanged] event ("true"/"false").
+func boolProperty(v bool) string { return strconv.FormatBool(v) }

--- a/app/metadata_events_test.go
+++ b/app/metadata_events_test.go
@@ -63,3 +63,40 @@ func TestSetFeatureSuppressedEmitsPropertyChanged(t *testing.T) {
 		t.Errorf("an idempotent suppress fired a spurious property.changed (fired=%d)", fired)
 	}
 }
+
+// TestMetadataEventIDsAreStable pins the wire-facing event type ids: an add-in relay routes on them,
+// so a silent change would misroute every metadata event. They live in the 0x08xx modeling block.
+func TestMetadataEventIDsAreStable(t *testing.T) {
+	if got := (ObjectRenamed{}).EventID(); got != tidObjectRenamed {
+		t.Errorf("ObjectRenamed.EventID() = %#x, want %#x", got, tidObjectRenamed)
+	}
+	if got := (PropertyChanged{}).EventID(); got != tidPropertyChanged {
+		t.Errorf("PropertyChanged.EventID() = %#x, want %#x", got, tidPropertyChanged)
+	}
+	if tidObjectRenamed == tidPropertyChanged {
+		t.Errorf("the two metadata events share type id %#x; they must be distinct to route", tidObjectRenamed)
+	}
+}
+
+// TestEmitObjectRenamedKeysToZeroWithoutActiveDocument checks the no-document branch of activeDocID:
+// a session with nothing open still emits (keyed to the zero doc id) rather than panicking, so an
+// early rename before any document is open is observable, not a crash.
+func TestEmitObjectRenamedKeysToZeroWithoutActiveDocument(t *testing.T) {
+	s := NewSession()
+	if s.ActiveDocument() != nil {
+		t.Fatalf("a fresh session must have no active document")
+	}
+	var got ObjectRenamed
+	fired := 0
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e ObjectRenamed) event.Outcome {
+		got, fired = e, fired+1
+		return event.Continue()
+	})
+	s.emitObjectRenamed(types.ObjectKindBody, "b1", "Old", "New")
+	if fired != 1 {
+		t.Fatalf("object.renamed fired %d times, want exactly 1", fired)
+	}
+	if got.Document != 0 {
+		t.Errorf("event document id = %d, want 0 (no active document)", got.Document)
+	}
+}

--- a/app/metadata_events_test.go
+++ b/app/metadata_events_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/event"
+)
+
+// TestRenameFeatureEmitsObjectRenamed checks a session-level feature rename fires exactly one
+// object.renamed carrying the feature kind, its key, and the old and new names (#1644) — the seam
+// both the UI and the wire router go through, so an add-in observes UI renames too.
+func TestRenameFeatureEmitsObjectRenamed(t *testing.T) {
+	s, def := extrudedBoxPart(t)
+	f := def.Features().Item(0)
+	var got ObjectRenamed
+	fired := 0
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e ObjectRenamed) event.Outcome {
+		got, fired = e, fired+1
+		return event.Continue()
+	})
+	old := f.Name()
+	if err := s.RenameFeature(f, "Base Boss"); err != nil {
+		t.Fatalf("RenameFeature: %v", err)
+	}
+	if fired != 1 {
+		t.Fatalf("object.renamed fired %d times, want exactly 1", fired)
+	}
+	if got.Kind != types.ObjectKindFeature || got.OldName != old || got.NewName != "Base Boss" {
+		t.Errorf("event = %+v, want feature %q->%q", got, old, "Base Boss")
+	}
+	if got.Key != featureMetaKey(f) {
+		t.Errorf("event key = %q, want the feature key %q", got.Key, featureMetaKey(f))
+	}
+}
+
+// TestSetFeatureSuppressedEmitsPropertyChanged checks toggling suppression fires one property.changed
+// carrying the old and new boolean state, and that an idempotent set fires nothing (#1644).
+func TestSetFeatureSuppressedEmitsPropertyChanged(t *testing.T) {
+	s, def := extrudedBoxPart(t)
+	f := def.Features().Item(0)
+	var got PropertyChanged
+	fired := 0
+	event.Subscribe(s.Events(), event.After, func(_ event.Context, e PropertyChanged) event.Outcome {
+		got, fired = e, fired+1
+		return event.Continue()
+	})
+	if err := s.SetFeatureSuppressed(f, true); err != nil {
+		t.Fatalf("SetFeatureSuppressed: %v", err)
+	}
+	if fired != 1 {
+		t.Fatalf("property.changed fired %d times, want exactly 1", fired)
+	}
+	if got.Property != "suppressed" || got.OldValue != "false" || got.NewValue != "true" {
+		t.Errorf("event = %+v, want suppressed false->true", got)
+	}
+	if err := s.SetFeatureSuppressed(f, true); err != nil { // idempotent: already suppressed
+		t.Fatalf("repeated SetFeatureSuppressed: %v", err)
+	}
+	if fired != 1 {
+		t.Errorf("an idempotent suppress fired a spurious property.changed (fired=%d)", fired)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.102.1
+	oblikovati.org/api v0.104.1
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.104.1
+	oblikovati.org/api v0.105.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.104.1
+	oblikovati.org/api v0.105.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.102.1
+	oblikovati.org/api v0.104.1
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)


### PR DESCRIPTION
## What

Host-side emission and relay for the metadata-mutation events, consuming the contract added in **Oblikovati.API#228**:

- A new `app.ObjectRenamed` / `app.PropertyChanged` domain event pair + `emitObjectRenamed` / `emitPropertyChanged` session seam (mirroring `EmitFeatureLifecycle`, #1085), keyed to the active document.
- `RenameFeature` raises `object.renamed`; `SetFeatureSuppressed` raises `property.changed` (old/new state) — both emitted at the session verb the UI **and** the wire router share, so an interactive rename and an API-driven one alike reach add-ins.
- The add-in event relay forwards both as the new `wire.ObjectRenamedEvent` / `wire.PropertyChangedEvent`.

## Why

Metadata mutations emitted nothing, so anything mirroring the document went stale after a rename and had to poll — the polling the render-on-demand work (#1493) moved away from.

## Scope

This lands the emit/relay framework end-to-end with the two clearest seams (feature rename + feature suppression) fully tested. The remaining rename kinds (sketch/body/occurrence) and sketch-settings changes route through the same `emitObjectRenamed` / `emitPropertyChanged` seam and follow as one-line additions.

## Tests

- App-level: `RenameFeature` fires exactly one `object.renamed` with the kind/key/old/new; `SetFeatureSuppressed` fires one `property.changed` (false→true) and an idempotent set fires nothing.
- Relay: an `ObjectRenamed` / `PropertyChanged` raised on the session bus is forwarded to the add-in sink as the correct wire event.

`go build ./...`, `go test ./...`, `golangci-lint run` on the changed packages are all clean.

## Dependency

**Requires Oblikovati.API#228 to merge first** (the `object.renamed` / `property.changed` wire DTOs, `types.ObjectKind`, and client accessors). CI here goes green once the API release is picked up.

Closes #1644

🤖 Generated with [Claude Code](https://claude.com/claude-code)