### PR TITLE
fix(develop): repair yamlcodec imports + assert I9 contract capability families

### DIFF
--- a/app/bug_report_diag.go
+++ b/app/bug_report_diag.go
@@ -9,8 +9,8 @@ import (
 	"oblikovati.org/app/options"
 	"oblikovati.org/build"
 	"oblikovati.org/model/doc"
-	"oblikovati.org/persistence/yamlcodec"
 	"oblikovati.org/report"
+	"oblikovati.org/yamlcodec"
 )
 
 // CollectDiagnostics gathers everything a triager needs to reproduce a bug — the user's

--- a/app/display_settings.go
+++ b/app/display_settings.go
@@ -20,6 +20,16 @@ type settingsView struct{ set display.Settings }
 
 var _ contract.DisplaySettings = settingsView{}
 
+// The capability families DisplaySettings embeds (I9, api v0.104.1). settingsView
+// satisfies each as part of the union; asserting the window-mode and ground-shadow
+// slices explicitly lets a caller depend on just one and keeps the #1619 guard honest.
+var (
+	_ contract.BackgroundDisplaySettings = settingsView{}
+	_ contract.EdgeDisplaySettings       = settingsView{}
+	_ contract.WindowDisplaySettings     = settingsView{}
+	_ contract.GroundShadowSettings      = settingsView{}
+)
+
 func (v settingsView) BackgroundType() types.BackgroundTypeEnum { return v.set.BackgroundType }
 func (v settingsView) EdgeColor() types.Color                   { return v.set.EdgeColor }
 func (v settingsView) DepthDimming() bool                       { return v.set.DepthDimming }

--- a/archguard/yaml_wrapper_test.go
+++ b/archguard/yaml_wrapper_test.go
@@ -18,7 +18,7 @@ import (
 // package — the test then names it.
 var yamlDirectImportAllowlist = map[string]string{
 	// The wrapper itself — the one legitimate home of the yaml.v3 dependency.
-	"oblikovati.org/persistence/yamlcodec": "the owned wrapper (ADR-0020)",
+	"oblikovati.org/yamlcodec": "the owned wrapper (ADR-0020)",
 	// release/version.go parses version.yaml. Routing it through yamlcodec would add a
 	// release -> persistence edge (persistence pulls in model/api), coupling a zero-dep
 	// version leaf to the document layer. Exempt until B4 (#1615) relocates yamlcodec to a

--- a/kernel/geomapi/evaluators.go
+++ b/kernel/geomapi/evaluators.go
@@ -121,6 +121,16 @@ type surfaceEvaluator struct {
 
 var _ contract.SurfaceEvaluator = surfaceEvaluator{}
 
+// The capability families SurfaceEvaluator embeds (I9, api v0.104.1). surfaceEvaluator
+// satisfies each as part of the union; the explicit assertions let a caller depend on
+// the narrowest slice (extents-only, differential-only, …) and satisfy the #1619 guard.
+var (
+	_ contract.SurfaceExtents      = surfaceEvaluator{}
+	_ contract.SurfaceDifferential = surfaceEvaluator{}
+	_ contract.SurfaceProjection   = surfaceEvaluator{}
+	_ contract.SurfaceIso          = surfaceEvaluator{}
+)
+
 // Evaluator returns the member-level query surface of this surface.
 func (s surface) Evaluator() contract.SurfaceEvaluator { return surfaceEvaluator{s: s.inner} }
 

--- a/kernel/geomapi/factory.go
+++ b/kernel/geomapi/factory.go
@@ -18,6 +18,15 @@ type Factory struct{}
 
 var _ contract.TransientGeometry = Factory{}
 
+// The 2D/3D curve-construction families TransientGeometry embeds (I9, api v0.104.1).
+// Factory satisfies each as part of the union; asserting them explicitly lets a caller
+// depend on just the 2D or 3D constructors and keeps the #1619 guard honest.
+var (
+	_ contract.TransientCurves3d = Factory{}
+	_ contract.TransientCurves2d = Factory{}
+	_ contract.TransientSurfaces = Factory{}
+)
+
 // The umbrella curve/surface contracts are satisfied by the shared adapter
 // bases every concrete adapter embeds (#1619, ADR-0018: implicit satisfaction
 // at usage sites is not enforcement — the assertion is the tripwire).

--- a/model/doc/contract_assert.go
+++ b/model/doc/contract_assert.go
@@ -10,6 +10,16 @@ import "oblikovati.org/api/contract"
 // than silently diverging the public surface from what /source actually does.
 var _ contract.Document = (*Document)(nil)
 
+// The capability families Document embeds (I9, api v0.104.1: DocumentIdentity /
+// DocumentDirtyState / DocumentLifecycle). *Document satisfies each because it
+// satisfies their union; asserting them explicitly lets a narrower host/add-in
+// signature depend on just one capability and keeps the #1619 guard honest.
+var (
+	_ contract.DocumentIdentity   = (*Document)(nil)
+	_ contract.DocumentDirtyState = (*Document)(nil)
+	_ contract.DocumentLifecycle  = (*Document)(nil)
+)
+
 // The file surface (M03-F07, #608): the file object and the two descriptor
 // views — one FileReference satisfies both the file-side flags contract and
 // the document-side status/bridge contract.
@@ -17,6 +27,12 @@ var (
 	_ contract.File                     = (*File)(nil)
 	_ contract.FileDescriptor           = (*FileReference)(nil)
 	_ contract.ReferencedFileDescriptor = (*FileReference)(nil)
+	// The identity/status/repair families FileDescriptor embeds (I9, api v0.104.1);
+	// *FileReference satisfies each as part of the union, asserted so a caller can depend
+	// on the narrow slice.
+	_ contract.FileReferenceIdentity = (*FileReference)(nil)
+	_ contract.FileReferenceStatus   = (*FileReference)(nil)
+	_ contract.FileReferenceRepair   = (*FileReference)(nil)
 )
 
 // External-file attachments (M03-F08, #609).


### PR DESCRIPTION
## What

Repairs two breakages that reached `develop` through concurrent merges and are now caught by the #1619 contract-assertion guard, blocking every open M40 PR.

### 1. Build break — stale yamlcodec imports
The B4 move (`persistence/yamlcodec` → top-level `yamlcodec`) semantically conflicted with concurrently-added importers that git's rename detection could not rewrite:
- `app/bug_report_diag.go`
- `archguard/yaml_wrapper_test.go`

Both still imported `oblikovati.org/persistence/yamlcodec`, so `app` and `archguard` failed to compile on `develop`.

### 2. Guard break — unasserted I9 capability families
The I9 split (api v0.104.1) segregated the fat `Document`, `DisplaySettings`, `FileDescriptor`, `SurfaceEvaluator` and `TransientGeometry` interfaces into 14 embedded capability families, but no host assertions were added. `TestEveryContractInterfaceIsAsserted` (#1619) failed for all 14. Each family is satisfied by the same host type that already implements its union, so an explicit `var _ contract.<Family> = <impl>` both documents the narrow capability slice and keeps the guard honest.

## Why it matters
`develop` did not build and its contract guard was red; both faults propagate into every PR that merges `develop`, stalling the whole M40 merge train.

## Verification
- `go build ./...`: green (was broken).
- `go test ./...`: green, including `TestEveryContractInterfaceIsAsserted`.
- `golangci-lint run` on touched packages: 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1632 (Audit I9: the host-side completion — the capability families the split declared are now asserted against their existing host implementers).
