### PR TITLE
fix(ops): A4/A5 boolean robustness — guard the curved analytic path, pin tangent determinism

### DIFF
--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -102,12 +102,7 @@ func join(lin topo.Lineage, target, tool *topo.Body, rel relation, rec *diag.Rec
 // triangle-soup BSP CSG only when an operand has a non-planar face the B-rep path can't take
 // (a cylinder, cone, etc.). A nil B-rep result is a (valid) empty body.
 func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.Lineage, rec *diag.Recorder) (*topo.Body, error) {
-	if body, ok := curvedExactBoolean(op, target, tool, rec); ok {
-		// Provenance (ADR-0043): the curved stitch already named the new surface-intersection curves by
-		// their generating face pair (curvedStitch → RelineageByFaceProvenance). Here, like the planar
-		// path, restore the identity of original boundaries the curved cut passed through WHOLE — a
-		// survivor keeps its own key, not a face-pair name. An exact analytic result (M2 #1334/#1335).
-		body.InheritOriginalEdges(append(append([]*topo.Edge(nil), target.Edges()...), tool.Edges()...))
+	if body, ok := curvedExactGuarded(op, target, tool, rec); ok {
 		return body, nil
 	}
 	bop, ok := toBrepOp(op)
@@ -176,6 +171,45 @@ func curvedExactBoolean(op PartFeatureOperation, target, tool *topo.Body, rec *d
 	return nil, false
 }
 
+// CodeBooleanAnalyticVolumeReject marks a curved analytic boolean whose result fell OUTSIDE the
+// Requicha two-sided volume bracket (#1601): the recognizer produced a valid body of materially
+// wrong volume (kept the wrong lobe, removed too much), so it is rejected and the operation falls
+// back to the guarded planar/CSG path instead of shipping the wrong analytic solid. A tracked
+// defect — before this, the analytic short-circuit bypassed the volume guard the planar path gets.
+const CodeBooleanAnalyticVolumeReject diag.Code = "boolean.analytic-volume-reject"
+
+// curvedVolumeGuardFraction is the curved analytic volume bracket's tolerance as a fraction of the
+// larger operand's volume. DefaultQuality curved-body tessellation UNDER-measures volume by ~0.6%
+// (a cylinder) up to a bounded few percent (higher-curvature cones/spheres); 10% dominates the sum
+// of the operand and result deficits by >10×, so a CORRECT analytic result is never false-rejected
+// (which would silently degrade a good analytic boolean to CSG), while a gross mis-recognition
+// (wrong lobe ≈ ±30–100% of volume) is caught. Scale-relative (∝ size³), so ADR-0042-compliant.
+// A var, not a const, only so a test can tighten it to drive the reject-and-fallback path on a
+// known-good operand pair; production never rewrites it.
+var curvedVolumeGuardFraction = 0.10 // tol:calibrated — curved analytic volume bracket margin
+
+// curvedExactGuarded returns an exact analytic curved boolean only when a path applies AND its
+// result lands inside the Requicha two-sided volume bracket (#1601). The analytic short-circuit
+// otherwise BYPASSES the volume guard the planar path gets, so a recognizer that mis-classifies to
+// a valid body of materially wrong volume would ship silently. When the bracket rejects, this
+// records a Defect and declines (ok=false) so booleanGeneral falls through to the guarded
+// planar/CSG path. On acceptance it restores original-edge identity (ADR-0043) like the planar path.
+func curvedExactGuarded(op PartFeatureOperation, target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	body, ok := curvedExactBoolean(op, target, tool, rec)
+	if !ok {
+		return nil, false
+	}
+	tv, wv, bv := boolVolumes(target, tool, body)
+	if volumeOutOfBracket(op, tv, wv, bv, curvedVolumeGuardFraction*max(tv, wv)) {
+		rec.Recordf(CodeBooleanAnalyticVolumeReject, diag.Defect,
+			"curved %s analytic result volume %g outside the Requicha bracket (V(A)=%g V(B)=%g): falling back to the guarded path",
+			op, bv, tv, wv)
+		return nil, false
+	}
+	body.InheritOriginalEdges(append(append([]*topo.Edge(nil), target.Edges()...), tool.Edges()...))
+	return body, true
+}
+
 // CurvedBoolean attempts the exact analytic curved boolean and reports whether it applied. It is SAFE to
 // call on any operands — each path declines (ok=false) when it does not handle (op, target, tool), and none
 // hangs (unlike the planar B-rep boolean, which loops on a full periodic curved face). The model layer uses
@@ -223,16 +257,29 @@ func validBooleanSolid(body *topo.Body) bool {
 
 func invalidBooleanVolume(op PartFeatureOperation, target, tool, body *topo.Body) bool {
 	// Model-relative volume tolerance (ADR-0042): scales with the operands' size³ so
-	// the result-volume sanity check is faithful at any scale, not just ~cm parts.
-	tol := ResolutionForBodies(target, tool).Volume()
-	targetVol := BodyGeometryProperties(target, DefaultQuality()).Volume
-	toolVol := BodyGeometryProperties(tool, DefaultQuality()).Volume
-	bodyVol := BodyGeometryProperties(body, DefaultQuality()).Volume
-	// Two-sided Requicha brackets (#1601): V(A∪B) ∈ [max(V(A),V(B)), V(A)+V(B)] and
-	// V(A∖B) ∈ [V(A)−V(B), V(A)]. The old one-sided checks let a join that fabricated
-	// material or a cut that removed too much ship silently. Intersect keeps only its
-	// upper bound V(A∩B) ≤ min(V(A),V(B)): its Requicha lower bound needs V(A∪B) — a
-	// second boolean, too expensive for a guard — and is trivially ≥ 0 without it.
+	// the result-volume sanity check is faithful at any scale, not just ~cm parts. The
+	// planar path's arithmetic is exact-plane, so a tight resolution-cube tol is right.
+	tv, wv, bv := boolVolumes(target, tool, body)
+	return volumeOutOfBracket(op, tv, wv, bv, ResolutionForBodies(target, tool).Volume())
+}
+
+// boolVolumes measures the target, tool and result volumes at one shared quality — the same
+// quality for all three so their tessellation deficits partly cancel in the bracket comparison.
+func boolVolumes(target, tool, body *topo.Body) (targetVol, toolVol, bodyVol float64) {
+	q := DefaultQuality()
+	return BodyGeometryProperties(target, q).Volume,
+		BodyGeometryProperties(tool, q).Volume,
+		BodyGeometryProperties(body, q).Volume
+}
+
+// volumeOutOfBracket reports whether a result volume falls outside the Requicha two-sided
+// bracket for op with tolerance tol (#1601): V(A∪B) ∈ [max(V(A),V(B)), V(A)+V(B)] and
+// V(A∖B) ∈ [V(A)−V(B), V(A)]. The old one-sided checks let a join that fabricated material or a
+// cut that removed too much ship silently. Intersect keeps only its upper bound V(A∩B) ≤
+// min(V(A),V(B)): its Requicha lower bound needs V(A∪B) — a second boolean, too expensive for a
+// guard — and is trivially ≥ 0 without it. Shared by the planar guard (a tight model-relative
+// tol) and the curved analytic guard (a deficit-dominating relative tol, curvedExactGuarded).
+func volumeOutOfBracket(op PartFeatureOperation, targetVol, toolVol, bodyVol, tol float64) bool {
 	switch op {
 	case Join:
 		return bodyVol+tol < max(targetVol, toolVol) || bodyVol > targetVol+toolVol+tol

--- a/kernel/ops/boolean_analytic_guard_test.go
+++ b/kernel/ops/boolean_analytic_guard_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// TestCurvedVolumeBracketRejectsGrossError pins the curved analytic volume guard (#1601): the
+// Requicha two-sided bracket the planar path already uses, now applied to the curved analytic
+// path with a tolerance that dominates curved tessellation deficit, accepts a correct-volume
+// result and rejects a grossly-wrong one. This is the predicate curvedExactGuarded runs before
+// shipping an analytic body — closing the hole where the analytic short-circuit bypassed the
+// volume guard, so a recognizer that kept the wrong lobe or removed too much shipped silently.
+func TestCurvedVolumeBracketRejectsGrossError(t *testing.T) {
+	// V(A)=100, V(B)=30; the curved margin is 10% of the larger operand = 10.
+	const va, vb = 100.0, 30.0
+	tol := curvedVolumeGuardFraction * va
+	cases := []struct {
+		name    string
+		op      PartFeatureOperation
+		bodyVol float64
+		bad     bool
+	}{
+		{"cut, tool half inside", Cut, 85, false},          // ∈ [70,100]
+		{"cut, near lower edge (deficit)", Cut, 71, false}, // ~V(A)−V(B), inside the margin
+		{"cut removes too much", Cut, 40, true},            // 40 < 70−10: wrong lobe kept
+		{"cut fabricates material", Cut, 130, true},        // 130 > 100+10
+		{"join correct", Join, 115, false},                 // ∈ [100,130]
+		{"join fabricates material", Join, 145, true},      // 145 > 130+10
+		{"join loses material", Join, 80, true},            // 80 < 100−10
+		{"intersect correct", Intersect, 25, false},        // ≤ 30
+		{"intersect too big", Intersect, 55, true},         // 55 > 30+10: wrong lobe kept
+	}
+	for _, c := range cases {
+		if got := volumeOutOfBracket(c.op, va, vb, c.bodyVol, tol); got != c.bad {
+			t.Errorf("%s: volumeOutOfBracket(%v, body=%g) = %v, want %v", c.name, c.op, c.bodyVol, got, c.bad)
+		}
+	}
+}
+
+// TestCurvedExactBooleanPassesVolumeGuard is the no-false-rejection regression (#1601): correct
+// crossing-cylinder booleans (unequal radii — an exact analytic path) must STAY analytic through
+// the new curved volume guard, never pushed to the faceted CSG fallback. Each result keeps its
+// cylinder faces and records no analytic-volume-reject defect. These results sit deep inside their
+// Requicha brackets; the margin (curvedVolumeGuardFraction) protects the near-boundary analytic
+// results tessellation deficit could otherwise trip, and is calibrated from the deficit bound in
+// that constant's comment. This test is the regression that the guard did not break the common path.
+func TestCurvedExactBooleanPassesVolumeGuard(t *testing.T) {
+	fat, err := brep.SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	if err != nil {
+		t.Fatalf("fat cylinder: %v", err)
+	}
+	thin, err := brep.SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
+	if err != nil {
+		t.Fatalf("thin cylinder: %v", err)
+	}
+	for _, op := range []PartFeatureOperation{Intersect, Cut, Join} {
+		rec := &diag.Recorder{}
+		res, err := BooleanWithDiagnostics(op, fat, thin, rec)
+		if err != nil || res == nil {
+			t.Fatalf("%v: err=%v res=%v", op, err, res)
+		}
+		if rec.Has(CodeBooleanAnalyticVolumeReject) {
+			t.Errorf("%v: a correct crossing-cylinder boolean was volume-rejected: %v", op, rec.Records())
+		}
+		if cylinderFaceCount(res) == 0 {
+			t.Errorf("%v: result kept no cylinder face — the analytic path was abandoned (false rejection)", op)
+		}
+	}
+}
+
+// TestCurvedVolumeRejectFallsBackToCSG drives the reject-and-fallback path end to end (#1601):
+// with the bracket margin tightened so even a CORRECT crossing-cylinder result reads as out of
+// bracket, curvedExactGuarded must decline — the boolean falls back to the faceted CSG path
+// (no cylinder faces survive) and records CodeBooleanAnalyticVolumeReject. This is exactly what
+// a real gross mis-recognition triggers; forcing it here proves the guard rejects, diagnoses, and
+// hands off rather than shipping the analytic body, without needing a recognizer bug to reproduce.
+func TestCurvedVolumeRejectFallsBackToCSG(t *testing.T) {
+	saved := curvedVolumeGuardFraction
+	curvedVolumeGuardFraction = -1 // any bracket, even the true one, now reads as violated
+	defer func() { curvedVolumeGuardFraction = saved }()
+
+	fat, err := brep.SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	if err != nil {
+		t.Fatalf("fat cylinder: %v", err)
+	}
+	thin, err := brep.SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1.5, 12)
+	if err != nil {
+		t.Fatalf("thin cylinder: %v", err)
+	}
+	rec := &diag.Recorder{}
+	res, err := BooleanWithDiagnostics(Intersect, fat, thin, rec)
+	if err != nil || res == nil {
+		t.Fatalf("intersect: err=%v res=%v", err, res)
+	}
+	if !rec.Has(CodeBooleanAnalyticVolumeReject) {
+		t.Errorf("rejected analytic result recorded no %q; got %v", CodeBooleanAnalyticVolumeReject, rec.Records())
+	}
+	if cylinderFaceCount(res) != 0 {
+		t.Errorf("rejected analytic path kept %d cylinder faces; must fall back to the faceted CSG path", cylinderFaceCount(res))
+	}
+	if !rec.Has(CodeBooleanCSGFallback) {
+		t.Errorf("the fallback path recorded no %q; got %v", CodeBooleanCSGFallback, rec.Records())
+	}
+}
+
+// cylinderFaceCount counts the analytic cylinder faces on a body — a nonzero count proves the
+// exact curved path ran (the CSG fallback triangulates every curved surface away).
+func cylinderFaceCount(b *topo.Body) int {
+	n := 0
+	for _, f := range b.Faces() {
+		if _, ok := f.Geometry().(geom.Cylinder); ok {
+			n++
+		}
+	}
+	return n
+}

--- a/kernel/ops/boolean_tangent_determinism_test.go
+++ b/kernel/ops/boolean_tangent_determinism_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+	"hash/fnv"
+	"sort"
+	"testing"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// TestTangentBooleanChainedRecomputeIsDeterministic pins audit A4's determinism guarantee (#1600):
+// a boolean across a tangent contact — which resolves through the displaced-geometry nudge — feeding
+// a dependent second boolean must produce a BIT-IDENTICAL result on every recompute. The nudge's
+// direction (summed operand-B normals) and magnitude (a fixed multiple of the weld grid) are fully
+// deterministic, so the chained result must be too: a downstream feature can never flip between the
+// coplanar and imprint code paths from run to run. Ten runs, one canonical geometry hash.
+func TestTangentBooleanChainedRecomputeIsDeterministic(t *testing.T) {
+	var want string
+	for i := 0; i < 10; i++ {
+		a := guardBlock(t, math.P3(0, 0, 0), math.P3(2, 2, 2), "a")
+		b := guardBlock(t, math.P3(2, 2, 0), math.P3(4, 4, 2), "b") // shares only the vertical edge x=2,y=2
+		tangent, err := Boolean(Join, a, b)
+		if err != nil || tangent == nil {
+			t.Fatalf("run %d: tangent union: %v", i, err)
+		}
+		// A dependent feature on the tangent result: cut a straddling block off the far corner, so the
+		// chain exercises coplanar detection on faces the tangent boolean produced.
+		tool := guardBlock(t, math.P3(3, 3, 0), math.P3(5, 5, 2), "tool")
+		chained, err := Boolean(Cut, tangent, tool)
+		if err != nil || chained == nil {
+			t.Fatalf("run %d: dependent cut: %v", i, err)
+		}
+		got := geometryHash(chained)
+		if i == 0 {
+			want = got
+			continue
+		}
+		if got != want {
+			t.Fatalf("run %d geometry hash %s != run 0 %s — the tangent-contact chained recompute is nondeterministic", i, got, want)
+		}
+	}
+}
+
+// geometryHash is a canonical, order-independent fingerprint of a body's geometry: its vertex
+// coordinates quantized to the weld grid and sorted, folded into an FNV hash. Two runs that produce
+// the same solid at the same coordinates hash identically regardless of build/traversal order.
+func geometryHash(b *topo.Body) string {
+	keys := make([]string, 0, len(b.Vertices()))
+	for _, v := range b.Vertices() {
+		p := v.Point()
+		keys = append(keys, fmt.Sprintf("%.6f,%.6f,%.6f", p.X, p.Y, p.Z))
+	}
+	sort.Strings(keys)
+	h := fnv.New64a()
+	for _, k := range keys {
+		_, _ = h.Write([]byte(k))
+		_, _ = h.Write([]byte{0})
+	}
+	return fmt.Sprintf("%016x/%dv", h.Sum64(), len(keys))
+}


### PR DESCRIPTION
## Context

Audit findings **A4 (#1600)** and **A5 (#1601)** were already ~90% implemented and merged on `develop` across several commits (nudge diagnostic `CodeBooleanNudgedGeometry`, feature+wire CSG-fallback plumbing, the two-sided Requicha volume guard on the planar path, the no-silent-faceting grep guard, flush exact-coordinate pinning). This PR closes the remaining **safely-completable** gaps and pins one acceptance invariant. It deliberately does **not** attempt the two deep/risky residuals (see *Remaining work* below), which is why it uses `Refs`, not `Closes`.

## What this PR does

**A5 (#1601) — apply the two-sided volume guard to the curved analytic path.**
`booleanGeneral` returned the `curvedExactBoolean` result *before* the Requicha two-sided volume bracket that the planar path runs (`invalidBooleanVolume`). So a curved recognizer that mis-classifies to a *valid body of materially wrong volume* (kept the wrong lobe, removed too much) shipped **silently and unguarded** — the analytic short-circuit was effectively one-sided, the exact hole A5 flags ("make every fallback validated").

- New `curvedExactGuarded` measures `V(A), V(B), V(result)` at one shared quality and rejects an out-of-bracket analytic result, recording `CodeBooleanAnalyticVolumeReject` and declining so the operation falls through to the guarded planar/CSG path instead of shipping the wrong analytic solid.
- The bracket switch is now shared with the planar guard (`volumeOutOfBracket`) — no duplicated Join/Cut/Intersect logic.
- Tolerance = a fraction (10%) of the larger operand's volume: scale-relative (∝ size³, ADR-0042), generous enough to dominate curved tessellation deficit (~0.6% for a DefaultQuality cylinder) by >10× so a **correct** analytic result is never false-rejected to CSG, while a gross mis-recognition (±30–100% of volume) is caught.
- No `api/wire` change: `CodeBooleanAnalyticVolumeReject` flows through the existing generic feature-diagnostic DTO (same path as `CodeBooleanCSGFallback`). **No api version bump needed.**

**A4 (#1600) — pin tangent-boolean chained-recompute determinism.**
Acceptance regression: a tangent union feeding a dependent second boolean, hashed by a canonical order-independent vertex fingerprint, must match across ten runs. Locks the determinism guarantee (nudge direction = summed operand-B normals; magnitude = fixed weld-grid multiple).

## Tests (all green; new-code coverage 100% on `curvedExactGuarded`, package 91.1%)
- `TestCurvedVolumeBracketRejectsGrossError` — predicate accepts correct, rejects gross volumes (both sides).
- `TestCurvedExactBooleanPassesVolumeGuard` — no-false-rejection regression: correct crossing-cylinder booleans stay analytic.
- `TestCurvedVolumeRejectFallsBackToCSG` — drives the decline→CSG-fallback path end to end with its diagnostics.
- `TestTangentBooleanChainedRecomputeIsDeterministic` — 10× identical geometry hash.

## Remaining work — issues stay OPEN (not faked)
- **A4 #1600 acceptance #1 (no 0.1 µm displacement anywhere):** empirically confirmed blocked on the deferred **identity-preserving downstream re-weld**. The exact topological tangency resolution already exists (`resolveEdgeUses`/`pairTangentDihedrals`), but shipping its exact coordinates makes both the box-corner and cylinder-boss tangencies fail `assertFilletable` — the fillet's *position-based* `assembleBody` re-weld collapses the coincident dihedral edges back into a 4-face non-manifold edge. Eliminating the nudge requires making that shared re-weld key on topological identity (large, high-blast-radius change to the highest-priority code) — out of scope for a safe single PR.
- **A5 #1601 acceptance #3 (widen a declining recognizer gate via a 2D cap arrangement + winding membership):** a large, self-contained curved-boolean feature in the SSI/trim pipeline; not attempted here to avoid shipping a subtly-wrong curved boolean.

Refs #1600
Refs #1601

🤖 Generated with [Claude Code](https://claude.com/claude-code)