### PR TITLE
fix(brep): ship exact tangent-contact geometry via an identity-preserving weld (A4)

### DIFF
--- a/kernel/brep/boolean.go
+++ b/kernel/brep/boolean.go
@@ -45,9 +45,14 @@ func Boolean(op Op, a, b *topo.Body) (*topo.Body, error) {
 	return BooleanDiag(op, a, b, nil)
 }
 
-// BooleanDiag is [Boolean] with a diagnostic recorder (nil to discard): the tangency-retry
-// last resort records a Defect when it ships, so the displaced-geometry escape hatch is
-// observable instead of silent (#1600).
+// BooleanDiag is [Boolean] with a diagnostic recorder (nil to discard). A tangent/grazing contact
+// (a >2-edge-use configuration) is resolved EXACTLY by the stitch first (resolveEdgeUses azimuth-
+// pairs the coincident dihedrals; pinchedEndpoints splits their shared endpoints), and that exact,
+// UNDISPLACED result is SHIPPED whenever it is a valid closed 2-manifold — the common flush/box
+// tangency (#1600). Only when the exact result stays pinched (an Euler-inadmissible χ the planar
+// pinch resolution does not yet split — a faceted-cylinder line-tangency) does it fall back to the
+// geometry-moving nudge as a recorded LAST RESORT (issue option 1); that fallback is a tracked
+// Defect, never silent. The exact path never perturbs output coordinates (SoS discipline).
 func BooleanDiag(op Op, a, b *topo.Body, rec *diag.Recorder) (*topo.Body, error) {
 	fa, oka := facesOf(a)
 	fb, okb := facesOf(b)
@@ -58,13 +63,30 @@ func BooleanDiag(op Op, a, b *topo.Body, rec *diag.Recorder) (*topo.Body, error)
 	if err != nil || away.LengthSquared() == 0 {
 		return res, err
 	}
-	// A tangent/grazing contact was hit. The nudged rerun stays the resolution for a GENUINE
-	// tangency — downstream re-welds (facet, fillet) collapse an exactly-coincident seam back
-	// into a non-manifold contact, so the topologically resolved exact result cannot ship yet
-	// (TestTangentContactUnionStaysManifold pins that contract) — but it is no longer silent:
-	// shipping it records a Defect (#1600). Retiring the displaced coordinates entirely needs
-	// the downstream re-welds to respect existing topology; tracked on the issue.
+	if exactTangentIsValid(res) {
+		rec.Recordf(CodeBooleanTangentContact, diag.Info,
+			"tangent/grazing contact resolved exactly (no displacement) near axis (%g, %g, %g)",
+			float64(away.X), float64(away.Y), float64(away.Z))
+		return res, nil
+	}
 	return retryNudged(op, fa, fb, a, res, away, rec)
+}
+
+// exactTangentIsValid reports whether the exactly-resolved tangent result is a closed 2-manifold
+// fit to ship: a solid whose every edge is shared by exactly two faces and whose χ is Euler-
+// admissible. When it is NOT — a genuine line-tangency whose endpoints stay pinched (χ odd), which
+// the planar pinch resolution does not yet split — the caller falls back to the recorded nudge so
+// the operation never ships an invalid body nor silently degrades to triangle-soup CSG (#1600).
+func exactTangentIsValid(b *topo.Body) bool {
+	if b == nil || !b.IsSolid() {
+		return false
+	}
+	for _, e := range b.Edges() {
+		if len(e.Faces()) != 2 {
+			return false
+		}
+	}
+	return b.EulerAdmissible()
 }
 
 // booleanOnce runs one pass: imprint, split, classify, keep, stitch. The vector is a non-zero
@@ -83,26 +105,32 @@ func booleanOnce(op Op, fa, fb []planarFace, a, b *topo.Body) (*topo.Body, math.
 	return stitch(kept, prov)
 }
 
-// nudgeEps is the magnitude (cm) of the clearance opened at a tangent contact: above the weld
-// grid (planarStitchGrid, 1e-6) so it survives, far below any modelled feature so it is
-// geometrically irrelevant. A line tangency carries no material, so replacing it with a ~0.1 µm
-// gap loses nothing and — unlike the exact tangent — leaves no coincident edge for a re-weld to
-// collapse. Calibrated with — and only meaningful relative to — the absolute planar weld grid:
-// the two must move together (#1602).
+// CodeBooleanTangentContact marks a boolean whose operands met at a tangent/grazing contact — a
+// coincident line where more than two faces meet — and that shipped the EXACT, undisplaced result
+// (the stitch split the coincident dihedrals by radial order and pinch-split their shared
+// endpoints). An informational note, not a defect: no coordinate moved (#1600, A5).
+const CodeBooleanTangentContact diag.Code = "boolean.tangent-contact"
+
+// nudgeEps is the magnitude (cm) of the clearance opened at a tangent contact the exact path could
+// not resolve to a valid solid: above the weld grid (planarStitchGrid, 1e-6) so it survives, far
+// below any modelled feature so it is geometrically irrelevant. A line tangency carries no
+// material, so replacing it with a ~0.1 µm gap loses nothing and leaves no pinched seam. Calibrated
+// with — and only meaningful relative to — the absolute planar weld grid: the two move together
+// (#1602).
 const nudgeEps = 10 * planarStitchGrid // tol:calibrated — imprint nudge tied to the planar weld grid
 
-// CodeBooleanNudgedGeometry marks a boolean that shipped the displaced-geometry tangency
-// retry: the topological resolution of a tangent contact failed to close, so the result
-// contains operand B translated by nudgeEps (#1600). A tracked defect — the displaced
-// coordinates poison flush mating, coplanar detection, and exports downstream — kept only as
-// the last resort until the topological path covers every configuration.
+// CodeBooleanNudgedGeometry marks a boolean that shipped the displaced-geometry tangency retry: the
+// EXACT topological resolution of a tangent contact stayed pinched (Euler-inadmissible), so the
+// result contains operand B translated by nudgeEps (#1600). A tracked Defect — the displaced
+// coordinates poison flush mating, coplanar detection and exports downstream — kept only as the
+// last resort for the residual configurations the exact planar pinch resolution does not yet split.
 const CodeBooleanNudgedGeometry diag.Code = "boolean.nudged-geometry"
 
-// retryNudged re-runs the boolean with operand B nudged a hair along `away` (out of the
-// tangent contact) so the degenerate touch becomes a clean clearance. It is the LAST RESORT
-// behind the topological resolution (#1600): it runs only when the un-nudged result is not a
-// proper solid, and shipping it records a Defect because the output carries the displaced
-// coordinates. A nudge that fails too falls back to the original result.
+// retryNudged re-runs the boolean with operand B nudged a hair along `away` (out of the tangent
+// contact) so the degenerate touch becomes a clean clearance. It is the LAST RESORT behind the
+// exact resolution (#1600): it runs only when the un-nudged result is not a valid solid, and
+// shipping it records a Defect because the output carries the displaced coordinates. A nudge that
+// fails too falls back to the original exact result.
 func retryNudged(op Op, fa, fb []planarFace, a, original *topo.Body, away math.Vector3, rec *diag.Recorder) (*topo.Body, error) {
 	fbp := translateFaces(fb, away.Scale(nudgeEps))
 	bp, _, err := stitch(planarToSubFaces(fbp), nil) // materialising nudged B: no intersections to name
@@ -114,7 +142,7 @@ func retryNudged(op Op, fa, fb []planarFace, a, original *topo.Body, away math.V
 		return original, nil
 	}
 	rec.Recordf(CodeBooleanNudgedGeometry, diag.Defect,
-		"tangent contact did not resolve topologically: shipping operand B displaced by %g along (%g, %g, %g)",
+		"tangent contact did not resolve to a valid solid exactly: shipping operand B displaced by %g along (%g, %g, %g)",
 		nudgeEps, float64(away.X), float64(away.Y), float64(away.Z))
 	return res, nil
 }
@@ -138,8 +166,8 @@ func translateFaces(faces []planarFace, d math.Vector3) []planarFace {
 	return out
 }
 
-// planarToSubFaces adapts whole planar faces to sub-faces (outer ring first, the rest holes)
-// so stitch can rebuild a body from them — used to materialise the nudged operand B.
+// planarToSubFaces adapts whole planar faces to sub-faces (outer ring first, the rest holes) so
+// stitch can rebuild a body from them — used to materialise the nudged operand B.
 func planarToSubFaces(faces []planarFace) []subFace {
 	out := make([]subFace, 0, len(faces))
 	for _, f := range faces {

--- a/kernel/brep/boolean_tangent_gate_test.go
+++ b/kernel/brep/boolean_tangent_gate_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// TestExactTangentIsValidGuards covers the exact-result gate's rejection branches (#1600): a nil
+// result and a non-solid (surface) body are both rejected, so the caller falls back to the recorded
+// nudge rather than shipping a body that cannot be a closed 2-manifold.
+func TestExactTangentIsValidGuards(t *testing.T) {
+	if exactTangentIsValid(nil) {
+		t.Error("nil result must be rejected by the exact-tangent gate")
+	}
+	surf := topo.NewBuilder(false, topo.NewLineage(topo.Tok("t", "surf", 0))).Build()
+	if exactTangentIsValid(surf) {
+		t.Error("a non-solid body must be rejected by the exact-tangent gate")
+	}
+}
+
+// TestExactTangentIsValidAcceptsSolid confirms the gate ACCEPTS a plain valid solid (every edge
+// used twice, χ admissible) — the common flush/box tangency the boolean now ships exactly.
+func TestExactTangentIsValidAcceptsSolid(t *testing.T) {
+	blk, err := SolidBlock(math.P3(0, 0, 0), math.P3(1, 1, 1), "blk")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	if !exactTangentIsValid(blk) {
+		t.Error("a valid closed solid must pass the exact-tangent gate")
+	}
+}

--- a/kernel/ops/assemble_curved.go
+++ b/kernel/ops/assemble_curved.go
@@ -11,9 +11,16 @@ import (
 // filletLoop is one boundary loop of a face as a ring of points with the curve along each
 // segment: curves[i] runs pts[i]→pts[(i+1)%n], or nil for a straight line. (Used to build
 // curved-faced results like fillets, where some edges are arcs.)
+// srcV[i]/srcE[i] carry the SOURCE topo identity of pts[i] and of the segment leaving it (0 =
+// op-generated): they preserve the boolean's tangent-contact topology across the re-weld. srcV
+// keeps pinch-split coincident VERTICES distinct; srcE keeps two coincident EDGES that share the
+// same endpoints distinct (the flush/box tangency where 4 faces meet on one line), so neither
+// collapses back into a non-manifold pinch (#1600, method C).
 type filletLoop struct {
 	pts    []math.Point3
 	curves []geom.Curve3
+	srcV   []uint64
+	srcE   []uint64
 }
 
 // filletFace is a result face: its surface (plane, cylinder, …) and boundary loops (outer
@@ -49,15 +56,16 @@ func assembleBody(faces []filletFace, tag string) *topo.Body {
 	rings := make([][][]int, len(faces))
 	for i, f := range faces {
 		for _, l := range f.loops {
-			rings[i] = append(rings[i], w.weldRing(l.pts))
+			rings[i] = append(rings[i], w.weldRingID(l.pts, l.srcV)) // identity-preserving weld (#1600)
 		}
 	}
-	bld := topo.NewBuilder(curvedSolid(faces, rings, w.points), topo.NewLineage(topo.Tok(tag, "body", 0)))
+	classes := pairEdgeClasses(faces, rings)
+	bld := topo.NewBuilder(curvedSolid(faces, rings, classes), topo.NewLineage(topo.Tok(tag, "body", 0)))
 	tv := make([]*topo.Vertex, len(w.points))
 	for i, p := range w.points {
 		tv[i] = bld.AddVertex(p, topo.NewLineage(topo.Tok(tag, "v", i)))
 	}
-	ec := &edgeCatalog{bld: bld, verts: w.points, tv: tv, edges: map[[2]int]edgeRec{}, tag: tag}
+	ec := &edgeCatalog{bld: bld, verts: w.points, tv: tv, edges: map[seamEdgeKey]edgeRec{}, classes: classes, tag: tag}
 	provByFace := addCurvedFaces(bld, faces, rings, ec, tag)
 	body := bld.Build()
 	// Provenance naming (ADR-0043): once the faces are named by their parents, the edges and
@@ -78,7 +86,7 @@ func addCurvedFaces(bld *topo.Builder, faces []filletFace, rings [][][]int, ec *
 	for fi, f := range faces {
 		specs := make([]topo.LoopSpec, len(f.loops))
 		for li, ring := range rings[fi] {
-			specs[li] = curvedLoopSpec(li == 0, ring, f.loops[li].curves, ec)
+			specs[li] = curvedLoopSpec(li == 0, ring, f.loops[li].curves, f.loops[li].srcE, ec)
 		}
 		lin := f.parent
 		if len(lin.Key()) == 0 {
@@ -92,14 +100,18 @@ func addCurvedFaces(bld *topo.Builder, faces []filletFace, rings [][][]int, ec *
 	return provByFace
 }
 
-// curvedSolid reports whether every undirected edge of the faces is used exactly twice (the
-// combinatorial test for a closed solid), computed before assembly to set the builder mode.
-func curvedSolid(faces []filletFace, rings [][][]int, _ []math.Point3) bool {
-	use := map[[2]int]int{}
+// curvedSolid reports whether every reconstructed edge is used exactly twice (the combinatorial
+// test for a closed solid), computed before assembly to set the builder mode. Edges are keyed by
+// their identity CLASS (a coincident tangent seam splits into two edges), matching what the edge
+// catalog builds — so a manifold tangency counts as two twice-used edges, not one four-used one.
+func curvedSolid(faces []filletFace, rings [][][]int, classes map[[2]int]int) bool {
+	use := map[seamEdgeKey]int{}
 	for fi := range faces {
-		for _, ring := range rings[fi] {
+		for li, ring := range rings[fi] {
+			ids := faces[fi].loops[li].srcE
 			for k := 0; k < len(ring); k++ {
-				use[canon2(ring[k], ring[(k+1)%len(ring)])]++
+				a, b := ring[k], ring[(k+1)%len(ring)]
+				use[seamEdgeKey{canon2(a, b), edgeClassOf(a, b, srcIDAt(ids, k), classes)}]++
 			}
 		}
 	}
@@ -111,20 +123,71 @@ func curvedSolid(faces []filletFace, rings [][][]int, _ []math.Point3) bool {
 	return true
 }
 
-// edgeCatalog creates one shared topo edge per undirected vertex pair on demand, reusing it
-// (reversed) for the second face.
-type edgeCatalog struct {
-	bld   *topo.Builder
-	verts []math.Point3
-	tv    []*topo.Vertex
-	edges map[[2]int]edgeRec
-	tag   string
+// pairEdgeClasses counts the distinct non-zero source-edge ids used along each welded vertex-pair.
+// A pair carrying two or more is a coincident tangent seam (two input edges on one line sharing
+// their endpoints) whose uses must stay on separate edges through the weld; one or zero is a plain
+// shared or op-generated edge that welds to a single edge as before (#1600).
+func pairEdgeClasses(faces []filletFace, rings [][][]int) map[[2]int]int {
+	seen := map[[2]int]map[uint64]bool{}
+	for fi := range faces {
+		for li, ring := range rings[fi] {
+			ids := faces[fi].loops[li].srcE
+			for k := 0; k < len(ring); k++ {
+				id := srcIDAt(ids, k)
+				if id == 0 {
+					continue
+				}
+				pair := canon2(ring[k], ring[(k+1)%len(ring)])
+				if seen[pair] == nil {
+					seen[pair] = map[uint64]bool{}
+				}
+				seen[pair][id] = true
+			}
+		}
+	}
+	out := make(map[[2]int]int, len(seen))
+	for p, ids := range seen {
+		out[p] = len(ids)
+	}
+	return out
 }
 
-// use returns the loop use for the directed segment a→b with the given curve (nil ⇒ a line),
-// creating the shared edge the first time in its a→b direction.
-func (c *edgeCatalog) use(a, b int, curve geom.Curve3) topo.Use {
-	key := canon2(a, b)
+// edgeClassOf returns the identity class of the segment a→b: its own source-edge id when the pair
+// is a coincident tangent seam (>=2 distinct source edges meet on it), else 0 so ordinary uses of
+// the pair all weld to one edge. It is the single keying rule shared by the catalog and the solid
+// test (#1600).
+func edgeClassOf(a, b int, srcE uint64, classes map[[2]int]int) uint64 {
+	if srcE == 0 || classes[canon2(a, b)] < 2 {
+		return 0
+	}
+	return srcE
+}
+
+// seamEdgeKey identifies a reconstructed edge by its welded vertex pair AND its identity class: a
+// coincident tangent seam (two source edges on one line, same endpoints) resolves to two keys that
+// share a pair but differ in class, so it stays two manifold edges instead of one 4-face edge.
+type seamEdgeKey struct {
+	pair  [2]int
+	class uint64
+}
+
+// edgeCatalog creates one shared topo edge per (welded vertex pair, identity class) on demand,
+// reusing it (reversed) for the second face. classes marks which pairs are coincident tangent
+// seams that must split by source-edge id (#1600).
+type edgeCatalog struct {
+	bld     *topo.Builder
+	verts   []math.Point3
+	tv      []*topo.Vertex
+	edges   map[seamEdgeKey]edgeRec
+	classes map[[2]int]int
+	tag     string
+}
+
+// use returns the loop use for the directed segment a→b with the given curve (nil ⇒ a line) and
+// source-edge id, creating the shared edge for its identity class the first time in its a→b
+// direction. Two coincident seam edges (distinct ids at a >=2-id pair) get distinct edges.
+func (c *edgeCatalog) use(a, b int, curve geom.Curve3, srcE uint64) topo.Use {
+	key := seamEdgeKey{canon2(a, b), edgeClassOf(a, b, srcE, c.classes)}
 	if rec, ok := c.edges[key]; ok {
 		return topo.Use{Edge: rec.edge, Reversed: rec.from != a}
 	}
@@ -136,11 +199,12 @@ func (c *edgeCatalog) use(a, b int, curve geom.Curve3) topo.Use {
 	return topo.Use{Edge: e, Reversed: false}
 }
 
-// curvedLoopSpec builds a face loop from a ring of welded indices and the per-segment curves.
-func curvedLoopSpec(outer bool, ring []int, curves []geom.Curve3, ec *edgeCatalog) topo.LoopSpec {
+// curvedLoopSpec builds a face loop from a ring of welded indices, the per-segment curves and the
+// per-segment source-edge ids (for tangent-seam identity, #1600).
+func curvedLoopSpec(outer bool, ring []int, curves []geom.Curve3, srcE []uint64, ec *edgeCatalog) topo.LoopSpec {
 	uses := make([]topo.Use, len(ring))
 	for k := range ring {
-		uses[k] = ec.use(ring[k], ring[(k+1)%len(ring)], curveAt(curves, k))
+		uses[k] = ec.use(ring[k], ring[(k+1)%len(ring)], curveAt(curves, k), srcIDAt(srcE, k))
 	}
 	if outer {
 		return topo.OuterLoop(uses...)

--- a/kernel/ops/boolean_tangent_identity_test.go
+++ b/kernel/ops/boolean_tangent_identity_test.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// tangentTwoBoxUnion builds the exact edge-tangent union of two 2×2×2 boxes that meet ONLY along
+// the vertical line x=2,y=2 (zero volumetric overlap): the shared line is bordered by four faces
+// (two per box) and the boolean splits it into two coincident manifold edges with EXACT coordinates
+// (#1600). The two coincident edges share their endpoint vertices, so only carried edge identity —
+// not coordinate — keeps them apart through a downstream re-weld.
+func tangentTwoBoxUnion(t *testing.T) *topo.Body {
+	t.Helper()
+	a, err := brep.SolidBlock(math.P3(0, 0, 0), math.P3(2, 2, 2), "a")
+	if err != nil {
+		t.Fatalf("SolidBlock a: %v", err)
+	}
+	b, err := brep.SolidBlock(math.P3(2, 2, 0), math.P3(4, 4, 2), "b")
+	if err != nil {
+		t.Fatalf("SolidBlock b: %v", err)
+	}
+	body, err := Boolean(Join, a, b)
+	if err != nil {
+		t.Fatalf("tangent union: %v", err)
+	}
+	return body
+}
+
+// TestFilletOnExactTangentStaysManifold is #1600's empirical blocker: filleting an edge of the body
+// that carries an exact edge-tangent seam (two coincident edges sharing endpoints) must yield a
+// VALID 2-manifold solid. Before the identity-preserving re-weld, assembleBody keyed edges by
+// welded vertex-pair alone, so the two coincident seam edges collapsed into one edge used by FOUR
+// faces ("non-manifold edge used by 4 faces") and the fillet failed. The carried source-edge id
+// (method C) keeps them distinct, so the tangency survives the re-weld.
+func TestFilletOnExactTangentStaysManifold(t *testing.T) {
+	body := tangentTwoBoxUnion(t)
+	top := highestEdge(t, body)
+	out, err := FilletEdges(body, [][]byte{top.ReferenceKey()}, 0.1)
+	if err != nil {
+		t.Fatalf("fillet on exact tangent seam failed (coincident edges collapsed?): %v", err)
+	}
+	r := Validate(out)
+	if !r.Valid {
+		t.Fatalf("filleted tangent body is not a valid manifold: %v", r.Issues)
+	}
+	if !r.Manifold {
+		t.Errorf("filleted tangent body is non-manifold: %v", r.Issues)
+	}
+	if !r.EulerConsistent {
+		t.Errorf("filleted tangent body has an inadmissible Euler characteristic (χ=%d): %v", r.EulerCharacteristic, r.Issues)
+	}
+}
+
+// highestEdge returns the body's topmost edge (by midpoint z) — the rim far from the tangent seam,
+// so the fillet exercises the re-weld of the seam without touching it directly.
+func highestEdge(t *testing.T, b *topo.Body) *topo.Edge {
+	t.Helper()
+	var top *topo.Edge
+	bz := math.Scalar(-1e18)
+	for _, e := range b.Edges() {
+		vs := e.Vertices()
+		if z := (vs[0].Point().Z + vs[len(vs)-1].Point().Z) / 2; z > bz {
+			bz, top = z, e
+		}
+	}
+	if top == nil {
+		t.Fatal("no edges on body")
+	}
+	return top
+}
+
+// TestTangentContactChainedRecomputeDeterministic pins #1600's determinism criterion: a tangent
+// union followed by a dependent coplanar feature (a fillet on the seam-bearing body) must produce a
+// bit-identical result on every recompute. A residual 1e-5 nudge made downstream coplanar/imprint
+// classification flip nondeterministically between runs; the exact, undisplaced result removes that.
+func TestTangentContactChainedRecomputeDeterministic(t *testing.T) {
+	var want string
+	for i := 0; i < 10; i++ {
+		body := tangentTwoBoxUnion(t)
+		out, err := FilletEdges(body, [][]byte{highestEdge(t, body).ReferenceKey()}, 0.1)
+		if err != nil {
+			t.Fatalf("run %d: fillet failed: %v", i, err)
+		}
+		got := bodyGeometryHash(out)
+		if i == 0 {
+			want = got
+			continue
+		}
+		if got != want {
+			t.Fatalf("run %d produced a different geometry hash than run 0 (nondeterministic tangent recompute): %s != %s", i, got, want)
+		}
+	}
+}
+
+// bodyGeometryHash summarises a body's vertex coordinates in a canonical (sorted) order, so two
+// runs with identical geometry hash identically regardless of build-order vertex numbering.
+func bodyGeometryHash(b *topo.Body) string {
+	pts := make([]string, 0, len(b.Vertices()))
+	for _, v := range b.Vertices() {
+		p := v.Point()
+		pts = append(pts, fmt.Sprintf("%0.17g,%0.17g,%0.17g", float64(p.X), float64(p.Y), float64(p.Z)))
+	}
+	sort.Strings(pts)
+	return strings.Join(pts, ";")
+}

--- a/kernel/ops/boolean_volume_guard_test.go
+++ b/kernel/ops/boolean_volume_guard_test.go
@@ -51,12 +51,13 @@ func TestBooleanVolumeGuardTwoSided(t *testing.T) {
 	}
 }
 
-// TestTangentUnionRecordsNudgedGeometry pins #1600's visibility guarantee: a union across a
-// tangent (edge-sharing) contact resolves through the nudged retry — the result carries operand
-// B displaced by the nudge — and that MUST surface as a boolean.nudged-geometry Defect instead of
-// shipping silently. (Retiring the displacement itself needs the downstream re-welds to respect
-// existing topology; tracked on the issue.)
-func TestTangentUnionRecordsNudgedGeometry(t *testing.T) {
+// TestTangentUnionShipsExactCoordinates is #1600's headline guarantee (A4): an edge-tangent union
+// (two boxes sharing only the vertical edge x=2,y=2) is resolved EXACTLY — the coincident dihedrals
+// split by radial order — and shipped with ZERO displacement. Every output vertex is bit-identical
+// to an operand vertex (distance 0 to float ulps, NOT within the retired 1e-5 nudge), the emitted
+// diagnostic is the informational tangent-contact note (never the nudged-geometry Defect), and the
+// result is an Euler-valid solid. Regression against the old geometry-moving retry.
+func TestTangentUnionShipsExactCoordinates(t *testing.T) {
 	a := guardBlock(t, math.P3(0, 0, 0), math.P3(2, 2, 2), "a")
 	b := guardBlock(t, math.P3(2, 2, 0), math.P3(4, 4, 2), "b") // shares only the vertical edge x=2,y=2
 	rec := &diag.Recorder{}
@@ -67,7 +68,33 @@ func TestTangentUnionRecordsNudgedGeometry(t *testing.T) {
 	if res == nil || !res.IsSolid() {
 		t.Fatal("tangent union did not produce a solid")
 	}
-	if !rec.Has(brep.CodeBooleanNudgedGeometry) {
-		t.Errorf("tangent union shipped without a %q diagnostic; got %v", brep.CodeBooleanNudgedGeometry, rec.Records())
+	if rec.Has(brep.CodeBooleanNudgedGeometry) {
+		t.Errorf("tangent union shipped displaced geometry (nudged) instead of the exact result; recs=%v", rec.Records())
+	}
+	if !rec.Has(brep.CodeBooleanTangentContact) {
+		t.Errorf("tangent union did not record the exact tangent-contact diagnostic; got %v", rec.Records())
+	}
+	assertVerticesExactlyOnOperands(t, res, a, b)
+	if r := Validate(res); !r.Valid {
+		t.Fatalf("exact tangent union is not a valid solid: %v", r.Issues)
+	}
+}
+
+// assertVerticesExactlyOnOperands fails if any vertex of the result is not bit-identical to a
+// vertex of one of the operands — the "distance 0 within float ulps, not within 1e-5" contract of
+// #1600. A pure edge-tangent union creates no new intersection vertices, so every result vertex
+// must coincide EXACTLY with an operand vertex; a 1e-5 nudge would move all of operand B's.
+func assertVerticesExactlyOnOperands(t *testing.T, res, a, b *topo.Body) {
+	t.Helper()
+	exact := map[math.Point3]bool{}
+	for _, src := range []*topo.Body{a, b} {
+		for _, v := range src.Vertices() {
+			exact[v.Point()] = true
+		}
+	}
+	for _, v := range res.Vertices() {
+		if !exact[v.Point()] {
+			t.Fatalf("result vertex %v is not bit-identical to any operand vertex (displaced geometry)", v.Point())
+		}
 	}
 }

--- a/kernel/ops/delete_face.go
+++ b/kernel/ops/delete_face.go
@@ -332,24 +332,59 @@ func dropRepeats(r []int) []int {
 
 // pointWelder merges coincident 3D points onto a shared index list, snapping to a
 // model-relative weld grid (ADR-0042) the caller derives from the points' size.
+// byID carries each point's SOURCE topological vertex identity through the weld: two points
+// with the same non-zero id are the SAME vertex, while two DISTINCT non-zero ids are kept apart
+// even when they quantize to one cell — so a boolean's pinch-split coincident vertices (a
+// kissing tangency) survive a re-weld instead of collapsing back into a non-manifold pinch
+// (#1600). Identity-less points (id 0, e.g. op-generated tangent points) weld by coordinate.
 type pointWelder struct {
 	index  map[[3]int64]int
+	byID   map[uint64]int
 	points []math.Point3
 	grid   float64
 }
 
 func newPointWelder(grid float64) *pointWelder {
-	return &pointWelder{index: map[[3]int64]int{}, grid: grid}
+	return &pointWelder{index: map[[3]int64]int{}, byID: map[uint64]int{}, grid: grid}
+}
+
+// pointCell quantizes p to the weld grid cell used to detect coordinate coincidence.
+func pointCell(p math.Point3, grid float64) [3]int64 {
+	return [3]int64{quantize(p.X, grid), quantize(p.Y, grid), quantize(p.Z, grid)}
 }
 
 func (w *pointWelder) add(p math.Point3) int {
-	k := [3]int64{quantize(p.X, w.grid), quantize(p.Y, w.grid), quantize(p.Z, w.grid)}
+	k := pointCell(p, w.grid)
 	if i, ok := w.index[k]; ok {
 		return i
 	}
-	w.index[k] = len(w.points)
+	return w.appendPoint(p, k)
+}
+
+// appendPoint stores p as a fresh vertex, claiming its cell for coordinate welds only if empty
+// (so a later id-0 point at a pinch coordinate welds to the FIRST fan there, not the newest).
+func (w *pointWelder) appendPoint(p math.Point3, k [3]int64) int {
+	i := len(w.points)
 	w.points = append(w.points, p)
-	return len(w.points) - 1
+	if _, ok := w.index[k]; !ok {
+		w.index[k] = i
+	}
+	return i
+}
+
+// addID welds p under its carried source-vertex identity: a non-zero id resolves to the one
+// vertex that id was first seen at (distinct ids never merge, preserving a pinch split); id 0
+// falls back to coordinate welding. See the type comment (#1600).
+func (w *pointWelder) addID(p math.Point3, id uint64) int {
+	if id == 0 {
+		return w.add(p)
+	}
+	if i, ok := w.byID[id]; ok {
+		return i
+	}
+	i := w.appendPoint(p, pointCell(p, w.grid))
+	w.byID[id] = i
+	return i
 }
 
 func (w *pointWelder) weldRing(r []math.Point3) []int {
@@ -358,6 +393,24 @@ func (w *pointWelder) weldRing(r []math.Point3) []int {
 		out[i] = w.add(p)
 	}
 	return out
+}
+
+// weldRingID welds a ring carrying a parallel source-vertex id per point (ids may be shorter than
+// pts, in which case the missing tail is treated as op-generated, id 0).
+func (w *pointWelder) weldRingID(pts []math.Point3, ids []uint64) []int {
+	out := make([]int, len(pts))
+	for i, p := range pts {
+		out[i] = w.addID(p, srcIDAt(ids, i))
+	}
+	return out
+}
+
+// srcIDAt returns ids[i] or 0 when the point has no carried identity.
+func srcIDAt(ids []uint64, i int) uint64 {
+	if i < len(ids) {
+		return ids[i]
+	}
+	return 0
 }
 
 // centroidPts averages a point set (a point on the face for its plane origin).

--- a/kernel/ops/fillet_faces.go
+++ b/kernel/ops/fillet_faces.go
@@ -170,9 +170,11 @@ func transformLoop(f *topo.Face, l *topo.Loop, subs map[uint64]math.Point3, ends
 			tOut := c.tOf(otherFace(u.Edge(), f))
 			addCornerRound(&fl, c, tIn, tOut)
 		case subs != nil && hasSubst(subs, v):
-			fl.add(subs[v.ID()], nil)
+			fl.add(subs[v.ID()], nil) // pulled-back to a tangent point: a new position, weld by coordinate
 		default:
-			fl.add(v.Point(), nil)
+			// unchanged survivor: carry its vertex id AND the edge leaving it, so a coincident
+			// tangent seam (two edges on one line sharing endpoints) stays two edges (#1600).
+			fl.addID(v.Point(), nil, v.ID(), u.Edge().ID())
 		}
 		addEdgeInserts(&fl, inserts, u)
 	}
@@ -239,10 +241,20 @@ func hasSubst(subs map[uint64]math.Point3, v *topo.Vertex) bool {
 	return ok
 }
 
-// add appends a point and the curve of the segment leaving it (nil ⇒ straight).
+// add appends an op-generated point (no carried identity) and the curve of the segment leaving it
+// (nil ⇒ straight).
 func (l *filletLoop) add(p math.Point3, curve geom.Curve3) {
+	l.addID(p, curve, 0, 0)
+}
+
+// addID appends a point carrying its source topo-vertex id and the source topo-edge id of the
+// segment leaving it (0 = op-generated), so the re-weld preserves the boolean's tangent-contact
+// vertex AND edge identity (#1600).
+func (l *filletLoop) addID(p math.Point3, curve geom.Curve3, srcV, srcE uint64) {
 	l.pts = append(l.pts, p)
 	l.curves = append(l.curves, curve)
+	l.srcV = append(l.srcV, srcV)
+	l.srcE = append(l.srcE, srcE)
 }
 
 // useFromVertex returns the from-vertex of an edge use (honouring reversal).

--- a/kernel/ops/validate.go
+++ b/kernel/ops/validate.go
@@ -60,11 +60,7 @@ func Validate(b *topo.Body) ValidationReport {
 // orientable 2-manifold) and at most 2 per shell (χ = Σ over shells of 2−2·genus, so each contributes
 // ≤ 2). A violation is a topology defect the per-edge tests can miss, recorded as an issue.
 func (r *ValidationReport) checkEuler(b *topo.Body) {
-	loops := 0
-	for _, f := range b.Faces() {
-		loops += len(f.Loops())
-	}
-	r.EulerCharacteristic = len(b.Vertices()) - len(b.Edges()) + 2*len(b.Faces()) - loops
+	r.EulerCharacteristic = b.EulerCharacteristic()
 	if !b.IsSolid() || !r.Closed {
 		return // χ = 2−2g only constrains a closed orientable solid; an open sheet is unconstrained
 	}

--- a/kernel/topo/body.go
+++ b/kernel/topo/body.go
@@ -73,6 +73,28 @@ func (b *Body) IsSolid() bool { return b.solid }
 // Shells returns the body's shells.
 func (b *Body) Shells() []*Shell { return append([]*Shell(nil), b.shells...) }
 
+// EulerCharacteristic returns the surface χ = V − E + 2F − L (the Euler–Poincaré form, correct
+// across B-rep seams and holed faces). Shared by the validator and the boolean's tangent-result
+// gate so both read χ the same way (#1600).
+func (b *Body) EulerCharacteristic() int {
+	loops := 0
+	for _, f := range b.Faces() {
+		loops += len(f.Loops())
+	}
+	return len(b.Vertices()) - len(b.Edges()) + 2*len(b.Faces()) - loops
+}
+
+// EulerAdmissible reports whether a CLOSED solid's χ is topologically possible: even and at most
+// 2 per shell (χ = Σ over shells of 2 − 2·genusₛ, genus ≥ 0). A non-solid body is unconstrained
+// and reports true. An odd or too-large χ is a pinch defect the per-edge manifold checks miss.
+func (b *Body) EulerAdmissible() bool {
+	if !b.solid {
+		return true
+	}
+	chi := b.EulerCharacteristic()
+	return chi%2 == 0 && chi <= 2*len(b.shells)
+}
+
 // Faces returns every face in the body, across all shells. The result is a fresh slice the
 // caller may keep; once the body is finalized it is a copy of the cached list.
 func (b *Body) Faces() []*Face {

--- a/kernel/topo/euler_test.go
+++ b/kernel/topo/euler_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package topo
+
+import "testing"
+
+// TestEulerCharacteristicTetra checks the shared χ = V−E+2F−L accessor on a tetrahedron
+// (V4, E6, F4, L4 → χ = 4−6+8−4 = 2) and its admissibility gate (#1600). Both the boolean's
+// exact-tangent gate and the validator read χ through these, so they are covered directly here.
+func TestEulerCharacteristicTetra(t *testing.T) {
+	body := buildTetra()
+	if chi := body.EulerCharacteristic(); chi != 2 {
+		t.Fatalf("tetra χ = %d, want 2", chi)
+	}
+	if !body.EulerAdmissible() {
+		t.Error("tetra χ=2 must be Euler-admissible")
+	}
+}
+
+// TestEulerAdmissibleNonSolid confirms a non-solid (surface) body is unconstrained: EulerAdmissible
+// reports true regardless of χ, since χ = 2−2g only binds a CLOSED orientable solid.
+func TestEulerAdmissibleNonSolid(t *testing.T) {
+	surf := NewBuilder(false, NewLineage(Tok("t", "surf", 0))).Build()
+	if !surf.EulerAdmissible() {
+		t.Error("a non-solid body must be Euler-unconstrained (admissible)")
+	}
+}


### PR DESCRIPTION
## What

Headline fix for M40 audit **A4** — retire the geometry-moving tangency nudge as the primary path and ship the **exact** boolean result.

- **Boolean (`kernel/brep`)** now ships the exactly-resolved tangent/flush result whenever it is a valid closed 2-manifold — the common box/flush tangency — with **zero coordinate displacement**. The nudge is demoted to a **recorded last resort**, taken only when the exact result stays pinched (an Euler-inadmissible χ the planar pinch resolution does not yet split). `BooleanDiag` records `boolean.tangent-contact` (Info) on the exact path and `boolean.nudged-geometry` (Defect) on the fallback — neither is silent.
- **Fillet re-weld (`ops.assembleBody`)** is now **identity-preserving** (the mathematician's *method C*): each result ring-segment carries its source topo **vertex id** (`pointWelder`) and source **edge id** (`edgeCatalog`). Two coincident-but-distinct tangent-seam edges that share their endpoints stay two manifold edges through the weld instead of collapsing into one 4-face non-manifold edge. Coordinate coincidence is demoted to a *candidate*, accepted only when carried identity agrees or is absent (op-generated).
- **`topo.Body`** gains `EulerCharacteristic()`/`EulerAdmissible()`, shared by the validator and the boolean's exact-result gate (removes the duplicated χ formula in `ops.checkEuler`).

## Why

Flush/tangent modelling is bread-and-butter CAD, but the old retry shipped every tangent contact displaced by 0.1 µm — mating faces were no longer coplanar and later features flipped nondeterministically between the coplanar and imprint code paths. Shipping the exact result exposed the downstream defect the nudge had masked: a coordinate-keyed re-weld collapses the boolean's coincident dihedral edges back into a non-manifold pinch, so a fillet on a kissing tangency failed with *"non-manifold edge used by 4 faces"*. Carrying topological identity through the weld (SoS discipline — perturbation is symbolic, output coordinates exact) lets the exact result survive the fillet as a valid 2-manifold.

## Evidence

Full `kernel/...` + `model/...` suites green; `golangci-lint` (funlen 20) 0 issues on touched packages. New guarding tests, each **red-verified** against the pre-fix path:

- `TestTangentUnionShipsExactCoordinates` — every output vertex is **bit-identical** to an operand vertex (no 1e-5 displacement); emits `tangent-contact`, never `nudged-geometry`. *(Red: forced-nudge → displaced vertex `{2.0000070710678117, …}`.)*
- `TestFilletOnExactTangentStaysManifold` — a fillet on the exact tangent seam is a valid manifold with **Euler χ per shell = 2**. *(Red: identity split disabled → "non-manifold edge 172 used by 4 faces".)*
- `TestTangentContactChainedRecomputeDeterministic` — tangent union → dependent fillet, identical geometry hash across 10 recomputes.

## Residual (tracked in #1726)

The **faceted-cylinder-on-plane line tangency** (the boss-on-lug fixture) is a genuine non-manifold contact whose exact planar result is χ-odd; it still resolves via the **recorded nudge** (issue option 1's diagnostic-only last resort) rather than shipping an invalid body or degrading to triangle-soup CSG. Making it exact needs deeper planar pinch/fan resolution (issue refactor item 2, topology-only re-derivation) — high-risk (touches the 300+ pinch cases) and out of scope here; tracked in **#1726**.

## PTCamera note

The `brep:edge#104 is ambiguous — matches 2 edges` collision (`model/feature/chamfer.go`) is a **separate topological-naming (reference-key) issue**, not the coordinate-weld collapse fixed here: it is two distinct edges minting the *same lineage*, resolved in the ADR-0043 naming layer, not the weld. Its fixture lives in the MCPBridge add-in module and was not exercised from this GPL module.

Closes #1600

🤖 Generated with [Claude Code](https://claude.com/claude-code)
