### PR TITLE
Rim-crossing cap-crossing cut (curved boolean slice 2, #1724)

### DIFF
--- a/head/ui/rim_crossing_render_test.go
+++ b/head/ui/rim_crossing_render_test.go
@@ -1,0 +1,133 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Rim-crossing cut live render (EPIC Oblikovati/Oblikovati#1724, ADR-0046, slice 2). The kernel certifies the
+// rim-crossing cap-crossing cut against OCC moments + a membership audit (kernel/ops); this drives the SAME
+// cut through the real feature pipeline (two base cylinders + a Combine-Cut) and renders it offscreen through
+// the actual viewport, proving the watertight two-rim-band wall + mixed-arc cap reach the screen as lit
+// geometry. Before the notched-band wall mesher (twoRimHoledBandMesh) this cut rendered as a torn, inside-out
+// band (~140 free edges); a regression there would drop the lit fraction or leave a visible hole in the wall.
+package ui
+
+import (
+	stdmath "math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/scene"
+)
+
+// rimCrossPart returns a session whose active part holds the slice-2 rim-crossing cut, built through the real
+// feature recompute: an r=3 h=10 target cylinder minus an oblique r=0.9 tool (base -5.6) whose exit ellipse
+// crosses the top rim, notching the wall.
+func rimCrossPart(t *testing.T) *app.Session {
+	t.Helper()
+	s := app.NewSession()
+	pd, err := compdef.AddPart(s.Workspace(), "rim-cross.opd", true)
+	if err != nil {
+		t.Fatalf("add part: %v", err)
+	}
+	def := pd.Content().(*compdef.PartComponentDefinition)
+	sc := 1 / stdmath.Sqrt2
+	target, err := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 10)
+	if err != nil {
+		t.Fatalf("target cylinder: %v", err)
+	}
+	tool, err := brep.SolidCylinder(math.P3(-5.6, 0, 2), math.V3(math.Scalar(sc), 0, math.Scalar(sc)), 0.9, 16)
+	if err != nil {
+		t.Fatalf("tool cylinder: %v", err)
+	}
+	feature.NewBaseFeatures(def.Features()).AddBase(target)
+	feature.NewBaseFeatures(def.Features()).AddBase(tool)
+	feature.NewModifyFeatures(def.Features()).AddCombine(0, 1, ops.Cut)
+	def.Recompute()
+	// The slice-1 3/4 view from above-front-right (shared with capCrossPart): proven to survive the shared
+	// lighting/exposure dimming a prior test leaves, and it shows both the +x top-rim notch and the wall.
+	cam := scene.NewCamera(inWinW, inWinH)
+	cam.Eye, cam.Target, cam.Up = math.P3(10, -8.5, 14), math.P3(0, 0, 5.5), math.V3(0, 0, 1)
+	s.SetCamera(cam)
+	return s
+}
+
+// bodyFractionOf returns the fraction of viewport pixels covered by the light-gray solid, detected as grayish
+// (r≈g≈b, so NOT blue-dominant like the gradient background) rather than by an absolute luma cutoff. A gray
+// body stays gray when the shared renderer exposure dims between tests, so this is robust to test order where
+// litFraction's fixed 175-luma threshold is not (Oblikovati#1724).
+func bodyFractionOf(px []byte, w, h int) float64 {
+	if w == 0 || h == 0 {
+		return 0
+	}
+	body := 0
+	for i := 0; i+3 < len(px); i += 4 {
+		b, g, r := float64(px[i]), float64(px[i+1]), float64(px[i+2])
+		if r > 30 && r > 0.75*b && g > 0.75*b { // not near-black, and not the blue-dominant background
+			body++
+		}
+	}
+	return float64(body) / float64(w*h)
+}
+
+// backgroundRendered reports whether the frame actually composited: a real frame clears to the blue gradient
+// background, so it has many blue-dominant pixels; an all-black un-presented frame (the second-window llvmpipe
+// artifact) has none.
+func backgroundRendered(px []byte) bool {
+	blue := 0
+	for i := 0; i+3 < len(px); i += 4 {
+		b, r := float64(px[i]), float64(px[i+2])
+		if b > 40 && b > r+20 { // blue-dominant and above near-black
+			blue++
+		}
+	}
+	return blue > 100
+}
+
+// TestRimCrossingCutRendersLive asserts the rim-crossing cut reaches the viewport as a large solid (a torn
+// wall or inverted tunnel would drop it off the screen) and writes a PNG for visual inspection.
+func TestRimCrossingCutRendersLive(t *testing.T) {
+	// Rebind the window-bound GPU caches to THIS fresh window/context (icons/dock globals otherwise still
+	// point at a prior test's destroyed window) — correct hygiene per TestInWindowDockedViewportIsInteractive.
+	dockLaidOut = false
+	icons = nil
+	win := newViewportWindow(t)
+	defer win.Destroy()
+
+	s := rimCrossPart(t)
+	for i := 0; i < 8; i++ {
+		viewportFrame(win, s)
+	}
+	px, w, h, ok := win.ReadbackViewport(0)
+	if !ok {
+		t.Fatal("viewport readback unavailable")
+	}
+	// A prior render test in the package can leave an offscreen Vulkan window that composites an all-black
+	// frame under llvmpipe — the SECOND window never presents (reproduces with slice-1's own geometry, so it
+	// is a harness artifact, not this cut). That frame has NO blue background either, unlike any real geometry
+	// defect (which still clears to the gradient), so it is unambiguous: skip it like a missing-driver env,
+	// while a composited frame with a torn/absent solid still hard-fails below. The kernel certification
+	// (watertight + OCC moments + CSG membership, kernel/ops) is the geometry proof; this is the visual smoke.
+	if !backgroundRendered(px) {
+		t.Skip("offscreen frame did not composite (all-black, no background) — second-window llvmpipe harness artifact")
+	}
+	body := bodyFractionOf(px, w, h)
+	t.Logf("rim-crossing cut body fraction = %.4f", body)
+	if body < 0.10 {
+		t.Errorf("rim-crossing cut rendered near-blank: body fraction %.4f — the cut B-rep is not reaching the screen", body)
+	}
+	dir := t.TempDir()
+	if p := os.Getenv("OBK_SHOT_DIR"); p != "" {
+		dir = p
+	}
+	out := filepath.Join(dir, "rim-crossing-cut.png")
+	if err := writeBGRAPNG(px, w, h, out); err != nil {
+		t.Fatalf("write PNG: %v", err)
+	}
+	t.Logf("saved rim-crossing cut render to %s", out)
+}

--- a/kernel/brep/curved_cap_crossing_corner.go
+++ b/kernel/brep/curved_cap_crossing_corner.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Cap-crossing corner solve (EPIC Oblikovati/Oblikovati#1724, ADR-0046, slice 2). The interior-exit slice
+// (slice 1) handles a tool whose exit ellipse lies strictly INSIDE the cap rim. When the ellipse CROSSES
+// the rim the exit is a rim-crossing corner: the tool exits partly through the cap and partly through the
+// wall, meeting the rim at the triple points {rim ∩ tool_wall ∩ cap_plane}. This file computes those
+// corner points exactly — the load-bearing shared vertices every rim-crossing face must reference so the
+// cross-face weld stays watertight (the slice-1 by-value/T-junction lesson generalizes to these corners).
+
+// capRimCorner is one point where the tool cylinder wall crosses the target cap's rim circle: the rim
+// angle θ (radians) and the 3D point on the rim at that angle.
+type capRimCorner struct {
+	angle float64
+	point math.Point3
+}
+
+// capRimCorners returns every point where the tool cylinder wall crosses the cap's rim circle — the exact
+// triple points rim ∩ tool_wall ∩ cap_plane. It solves g(θ) = |w(θ)|² − (w(θ)·d)² − r² = 0 on the rim
+// (w(θ) = rim(θ) − toolOrigin, d the tool axis), a first-and-second-harmonic trig equation, by dense-sample
+// bracketing + bisection. The COUNT is the recognizer gate: 0 → ellipse clear of the rim (slice 1 or no
+// contact), 2 → the single rim-crossing corner slice 2 handles, 4 → a two-lens footprint (deferred).
+func capRimCorners(tool geom.Cylinder, rim geom.Circle) []capRimCorner {
+	g := rimCornerEquation(tool, rim)
+	roots := bracketedRoots(g, cornerSamples)
+	out := make([]capRimCorner, 0, len(roots))
+	for _, th := range roots {
+		out = append(out, capRimCorner{angle: th, point: rim.PointAt(th / (2 * stdmath.Pi))})
+	}
+	return out
+}
+
+// cornerSamples is the number of equal rim-angle stations the corner equation is sampled at to bracket its
+// sign changes. 1440 = one bracket per 0.25°, dense enough that two genuine crossings are never in one cell
+// (they would have to sit within 0.25° — a near-tangency the slice-2 gate declines anyway).
+const cornerSamples = 1440
+
+// rimCornerEquation builds g(θ), the exact tool-cylinder-distance residual along the rim, as a closure over
+// the harmonic coefficients (derived in the rim's own in-plane basis e1=RefDir, e2=Normal×RefDir). Keeping
+// the tool-cylinder implicit — never reconstructing the exit ellipse's r/|n·d| semi-major — keeps the solve
+// well-conditioned for shallow tools (ADR-0046 slice-2 numerics).
+func rimCornerEquation(tool geom.Cylinder, rim geom.Circle) func(float64) float64 {
+	e1 := rim.RefDir.AsVector()
+	e2 := rim.Normal.Cross(rim.RefDir)
+	d := tool.AxisDir.AsVector()
+	w0 := tool.Origin.VectorTo(rim.Center)
+	rr, tr := rim.Radius, tool.Radius
+	d0 := float64(w0.Dot(d))
+	p1, p2 := float64(w0.Dot(e1)), float64(w0.Dot(e2))
+	al, be := float64(e1.Dot(d)), float64(e2.Dot(d))
+	a0 := float64(w0.Dot(w0)) + rr*rr - d0*d0 - tr*tr - rr*rr*(al*al+be*be)/2
+	a1, b1 := 2*rr*(p1-d0*al), 2*rr*(p2-d0*be)
+	a2, b2 := -rr*rr*(al*al-be*be)/2, -rr*rr*al*be
+	return func(th float64) float64 {
+		return a0 + a1*stdmath.Cos(th) + b1*stdmath.Sin(th) + a2*stdmath.Cos(2*th) + b2*stdmath.Sin(2*th)
+	}
+}
+
+// bracketedRoots returns the roots of a 2π-periodic function in [0, 2π) by sampling n equal cells, bracketing
+// each sign change, and bisecting it to convergence. A cell whose endpoints share a sign is skipped, so a
+// tangential (double) root that never changes sign is deliberately NOT reported — slice 2 wants only genuine
+// transversal crossings, and the tangency boundary is a distinct declined case.
+func bracketedRoots(g func(float64) float64, n int) []float64 {
+	var roots []float64
+	prevTh := 0.0
+	prev := g(prevTh)
+	for i := 1; i <= n; i++ {
+		th := 2 * stdmath.Pi * float64(i) / float64(n)
+		cur := g(th)
+		if prev == 0 {
+			roots = append(roots, prevTh)
+		} else if prev*cur < 0 {
+			roots = append(roots, bisectRoot(g, prevTh, th))
+		}
+		prevTh, prev = th, cur
+	}
+	return roots
+}
+
+// bisectRoot refines a sign-change bracket [lo, hi] of g to a model-independent angular tolerance by
+// bisection — unconditionally convergent, no derivative needed (the corner equation is smooth but its
+// derivative adds no robustness a 60-step bisection to ~1e-16 rad lacks).
+func bisectRoot(g func(float64) float64, lo, hi float64) float64 {
+	glo := g(lo)
+	for k := 0; k < 60; k++ {
+		mid := (lo + hi) / 2
+		gm := g(mid)
+		if gm == 0 || (hi-lo) < 1e-15 {
+			return mid
+		}
+		if glo*gm < 0 {
+			hi = mid
+		} else {
+			lo, glo = mid, gm
+		}
+	}
+	return (lo + hi) / 2
+}

--- a/kernel/brep/curved_cap_crossing_corner_test.go
+++ b/kernel/brep/curved_cap_crossing_corner_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// rimCircleZ returns the target's top-cap rim circle: radius R at height h, axis +z through the origin.
+func rimCircleZ(r, h float64) geom.Circle {
+	c, _ := geom.NewCircle(math.P3(0, 0, math.Scalar(h)), math.V3(0, 0, 1), r)
+	return c
+}
+
+func obliqueTool(baseX, r float64) geom.Cylinder {
+	s := 1 / stdmath.Sqrt2
+	c, _ := geom.NewCylinder(math.P3(math.Scalar(baseX), 0, 2), math.V3(math.Scalar(s), 0, math.Scalar(s)), r)
+	return c
+}
+
+// TestCapRimCornersTwoOnCrossing: the base=-5.6 tool's exit ellipse crosses the rim, so there are exactly
+// two corner points, each on the rim (r=3) AND on the tool wall (dist=0.9), symmetric about y=0.
+func TestCapRimCornersTwoOnCrossing(t *testing.T) {
+	tool := obliqueTool(-5.6, 0.9)
+	rim := rimCircleZ(3, 10)
+	corners := capRimCorners(tool, rim)
+	if len(corners) != 2 {
+		t.Fatalf("rim-crossing tool: got %d corners, want 2", len(corners))
+	}
+	for _, c := range corners {
+		if r := stdmath.Hypot(float64(c.point.X), float64(c.point.Y)); stdmath.Abs(r-3) > 1e-9 {
+			t.Errorf("corner not on rim: r=%.12f want 3 (point %v)", r, c.point)
+		}
+		if d := distToAxis(c.point, tool); stdmath.Abs(d-0.9) > 1e-7 {
+			t.Errorf("corner not on tool wall: dist=%.9f want 0.9 (point %v)", d, c.point)
+		}
+		if stdmath.Abs(float64(c.point.Z)-10) > 1e-9 {
+			t.Errorf("corner off cap plane: z=%.12f want 10", c.point.Z)
+		}
+	}
+	// symmetric about y=0: the two corners share x and have opposite y
+	if stdmath.Abs(float64(corners[0].point.X-corners[1].point.X)) > 1e-6 ||
+		stdmath.Abs(float64(corners[0].point.Y+corners[1].point.Y)) > 1e-6 {
+		t.Errorf("corners not symmetric about y=0: %v %v", corners[0].point, corners[1].point)
+	}
+}
+
+// TestCapRimCornersNoneWhenInside: the base=-6.5 tool (slice 1) exits with the ellipse strictly inside the
+// rim, so the tool wall never reaches the rim — zero corners.
+func TestCapRimCornersNoneWhenInside(t *testing.T) {
+	if n := len(capRimCorners(obliqueTool(-6.5, 0.9), rimCircleZ(3, 10))); n != 0 {
+		t.Errorf("interior-exit tool: got %d corners, want 0", n)
+	}
+}
+
+func distToAxis(p math.Point3, c geom.Cylinder) float64 {
+	w := c.Origin.VectorTo(p)
+	ax := w.Dot(c.AxisDir.AsVector())
+	return float64(w.Sub(c.AxisDir.AsVector().Scale(ax)).Length())
+}

--- a/kernel/brep/curved_cap_crossing_rim.go
+++ b/kernel/brep/curved_cap_crossing_rim.go
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Curved-boolean CAP-CROSSING, slice 2 — the RIM-CROSSING CORNER (EPIC Oblikovati/Oblikovati#1724,
+// ADR-0046). Slice 1 handled a tool whose exit ellipse lies strictly inside the cap rim. This file handles
+// the next sub-family: the exit ellipse CROSSES the rim at exactly two corner points, so the tool exits
+// partly through the cap and partly through the wall near the rim. Measured on real traced imprints, that
+// case still has a clean closed wall-ENTRY hole lower down (the tool enters the wall once) plus an EXIT
+// corner where the wall∩wall SSI is an OPEN chain between the two rim corners, closed on the cap plane by
+// an ellipse arc. It decomposes into (a) a wall with the entry hole AND a top-rim notch, (b) the exit cap
+// with a mixed rim-arc + ellipse-arc bite, and (c) a tool tunnel whose two loops are the entry rim and the
+// [exit-chain ⊕ ellipse-arc] composite, reversed into the cavity. Every configuration outside this exact
+// recognizer (tangency, two-lens footprint, two-cap exit, cone tools, no separate entry hole) is DECLINED.
+
+// rimCrossPlan is the recognised slice-2 rim-crossing: both operands as cylinders, the exit cap and its
+// exact analytic pieces (the surviving rim arc + the inside ellipse arc, meeting at the two corners), the
+// closed wall-entry imprint, and the open wall-exit chain (endpoints snapped to the corners).
+type rimCrossPlan struct {
+	tgt, tool  ruledOperand
+	exitCap    curvedFace
+	rimArc     geom.Arc3d
+	ellipseArc geom.EllipticalArc
+	entry      geom.Polyline // closed wall-entry loop
+	exitChain  geom.Polyline // open wall-exit chain p1→p2
+}
+
+// RimCrossingCutGeneral is the exported entry kernel/ops routes a rim-crossing cap-crossing subtract
+// through. ok=false outside the recognised slice so kernel/ops keeps its CSG fallback.
+func RimCrossingCutGeneral(target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	plan, ok := classifyRimCross(target, tool, rec)
+	if !ok {
+		return nil, false
+	}
+	return buildRimCrossCut(plan)
+}
+
+// classifyRimCross recognises the slice-2 rim-crossing, or ok=false for anything outside it. Positive gate:
+// both operands full cylinders; the tool exits EXACTLY ONE cap whose exit ellipse crosses that cap's rim at
+// EXACTLY TWO corners; and the tool∩wall SSI is EXACTLY ONE closed entry loop plus ONE open exit chain whose
+// endpoints are those two corners.
+func classifyRimCross(target, tool *topo.Body, rec *diag.Recorder) (rimCrossPlan, bool) {
+	toolCyl, _, _, okL := cylinderSolidParams(facesOfAny(tool))
+	tgtCyl, _, _, okT := cylinderSolidParams(facesOfAny(target))
+	tgtOp, ok1 := cylinderOperand(target)
+	toolOp, ok2 := cylinderOperand(tool)
+	if !okL || !okT || !ok1 || !ok2 {
+		return rimCrossPlan{}, false
+	}
+	exitCap, ellipse, corners, ok := rimCrossExitCap(target, toolCyl)
+	if !ok {
+		return rimCrossPlan{}, false
+	}
+	entry, exitChain, ok := traceEntryAndExit(tgtCyl, toolCyl, target, rec)
+	if !ok {
+		return rimCrossPlan{}, false
+	}
+	rimArc, ellArc, ok := cornerArcs(exitCap, ellipse, corners)
+	if !ok {
+		return rimCrossPlan{}, false
+	}
+	entryPL, e1 := geom.NewPolyline(entry)
+	exitPL, e2 := geom.NewPolyline(snapEndsToCorners(exitChain, corners))
+	if e1 != nil || e2 != nil {
+		return rimCrossPlan{}, false
+	}
+	return rimCrossPlan{tgt: tgtOp, tool: toolOp, exitCap: exitCap, rimArc: rimArc,
+		ellipseArc: ellArc, entry: entryPL, exitChain: exitPL}, true
+}
+
+// rimCrossExitCap finds the single target cap whose exit ellipse crosses that cap's rim at exactly two
+// corners; ok=false for zero (interior-exit slice 1 or no contact), a non-2 corner count (tangency or
+// two-lens), or more than one such cap (two-cap exit — deferred).
+func rimCrossExitCap(target *topo.Body, toolCyl geom.Cylinder) (curvedFace, geom.EllipseFull, []capRimCorner, bool) {
+	var exitCap curvedFace
+	var ellipse geom.EllipseFull
+	var corners []capRimCorner
+	found := 0
+	for _, cap := range planarCapFaces(target) {
+		pl, ok := cap.surface.(geom.Plane)
+		if !ok {
+			continue
+		}
+		e, ok := capExitEllipse(toolCyl, pl)
+		if !ok {
+			continue
+		}
+		rim, ok := capRimCircle(cap)
+		if !ok {
+			continue
+		}
+		cs := capRimCorners(toolCyl, rim)
+		if len(cs) != 2 {
+			continue
+		}
+		exitCap, ellipse, corners, found = cap, e, cs, found+1
+	}
+	return exitCap, ellipse, corners, found == 1
+}
+
+// CodeRimCrossTraceTopology marks a rim-crossing wall trace that, AFTER the two-corner cap gate passed, did
+// not resolve to the expected one-closed-entry + one-open-exit topology — a genuine near-miss (a tangential
+// or grazing wall trace) surfaced so the CSG fallback that follows is observable, not silent (#1724).
+const CodeRimCrossTraceTopology diag.Code = "cap-crossing.rim-trace-topology"
+
+// traceEntryAndExit traces the tool∩target-wall SSI over the target band and separates it into exactly one
+// CLOSED entry loop and one OPEN exit chain (the rim-crossing signature). ok=false for any other topology
+// (no separate entry hole, multiple exit chains) so the recognizer declines; because the two-corner cap gate
+// has already passed by the time this runs, an unexpected count is recorded as a tracked defect.
+func traceEntryAndExit(tgtCyl, toolCyl geom.Cylinder, target *topo.Body, rec *diag.Recorder) ([]math.Point3, []math.Point3, bool) {
+	band := cylinderBand(target)
+	tr := geom.TraceSurfaceIntersection(tgtCyl, toolCyl, band)
+	var entry, exit [][]math.Point3
+	for _, c := range tr.Curves {
+		if len(c) < 3 {
+			continue
+		}
+		if c[0].DistanceTo(c[len(c)-1]) < geom.ResolutionForSize(tgtCyl.Radius).Weld() {
+			entry = append(entry, c)
+		} else {
+			exit = append(exit, c)
+		}
+	}
+	if len(entry) != 1 || len(exit) != 1 {
+		rec.Recordf(CodeRimCrossTraceTopology, diag.Defect,
+			"rim-crossing wall trace gave %d closed + %d open chains, want 1 + 1; declining to CSG", len(entry), len(exit))
+		return nil, nil, false
+	}
+	return entry[0], exit[0], true
+}
+
+// cylinderBand returns the target cylinder's axial (u,v) trace window from its own extent.
+func cylinderBand(b *topo.Body) geom.SurfaceGrid {
+	c, base, h, _ := cylinderSolidParams(facesOfAny(b))
+	vLo := float64(c.Origin.VectorTo(base).Dot(c.AxisDir.AsVector()))
+	return geom.SurfaceGrid{VMin: vLo, VMax: vLo + h}
+}
+
+// snapEndsToCorners returns chain with its two endpoints replaced by the nearest analytic corner point, so
+// the wall exit chain, the cap arcs, and the tunnel all share the EXACT corner vertices (the by-value/weld
+// discipline of ADR-0046: shared vertices must be bit-identical or the cross-face stitch T-junction-cracks).
+func snapEndsToCorners(chain []math.Point3, corners []capRimCorner) []math.Point3 {
+	out := append([]math.Point3(nil), chain...)
+	out[0] = nearestCorner(out[0], corners)
+	out[len(out)-1] = nearestCorner(out[len(out)-1], corners)
+	return out
+}
+
+func nearestCorner(p math.Point3, corners []capRimCorner) math.Point3 {
+	best, bd := p, stdmath.Inf(1)
+	for _, c := range corners {
+		if d := float64(p.DistanceTo(c.point)); d < bd {
+			best, bd = c.point, d
+		}
+	}
+	return best
+}
+
+// cornerArcs builds the two exact analytic arcs the cap bite is bounded by: the surviving rim arc (the part
+// of the cap rim OUTSIDE the tool) and the inside ellipse arc (the part of the exit ellipse INSIDE the disc),
+// both running between the two corners. Each "which arc survives" choice is decided by a midpoint membership
+// test, so the construction is orientation-robust. ok=false if the ellipse parameter of a corner is not
+// recoverable (a near-tangency the gate should already have excluded).
+func cornerArcs(cap curvedFace, ell geom.EllipseFull, corners []capRimCorner) (geom.Arc3d, geom.EllipticalArc, bool) {
+	rim, _ := capRimCircle(cap)
+	th0, th1 := corners[0].angle, corners[1].angle
+	rimArc := rimArcOutsideEllipse(rim, th0, th1, ell)
+	f0, n0 := geom.CurveParamAtPoint3(&ell, corners[0].point)
+	f1, n1 := geom.CurveParamAtPoint3(&ell, corners[1].point)
+	if n0 == geom.NoSolution || n1 == geom.NoSolution {
+		return geom.Arc3d{}, geom.EllipticalArc{}, false
+	}
+	ellArc, ok := ellipseArcInsideDisc(ell, f0, f1, rim)
+	if !ok {
+		return geom.Arc3d{}, geom.EllipticalArc{}, false
+	}
+	return rimArc, ellArc, true
+}
+
+// rimArcOutsideEllipse returns the rim-circle arc between angles th0 and th1 whose midpoint lies OUTSIDE the
+// tool's exit ellipse — the part of the cap rim the cut keeps. It tries the th0→th1 sweep and flips to the
+// complementary sweep when that midpoint is inside the ellipse.
+func rimArcOutsideEllipse(rim geom.Circle, th0, th1 float64, ell geom.EllipseFull) geom.Arc3d {
+	sweep := normalizeSweep(th1 - th0)
+	a, _ := geom.NewArc3d(rim.Center, rim.Normal.AsVector(), rim.RefDir.AsVector(), rim.Radius, th0, sweep)
+	if insideEllipse(a.PointAt(0.5), ell) {
+		a, _ = geom.NewArc3d(rim.Center, rim.Normal.AsVector(), rim.RefDir.AsVector(), rim.Radius, th0, sweep-2*stdmath.Pi)
+	}
+	return a
+}
+
+// ellipseArcInsideDisc returns the ellipse arc between fractions f0 and f1 whose midpoint lies INSIDE the
+// cap rim disc — the part of the exit ellipse that actually bounds the cap bite.
+func ellipseArcInsideDisc(ell geom.EllipseFull, f0, f1 float64, rim geom.Circle) (geom.EllipticalArc, bool) {
+	const twoPi = 2 * stdmath.Pi
+	sweep := normalizeSweep(twoPi * (f1 - f0))
+	a, err := geom.NewEllipticalArc(ell.Center, ell.Normal.AsVector(), ell.MajorAxis.AsVector(),
+		ell.MajorRadius, ell.MinorRadius, twoPi*f0, sweep)
+	if err != nil {
+		return geom.EllipticalArc{}, false
+	}
+	if float64(rim.Center.VectorTo(a.PointAt(0.5)).Length()) > rim.Radius {
+		a, err = geom.NewEllipticalArc(ell.Center, ell.Normal.AsVector(), ell.MajorAxis.AsVector(),
+			ell.MajorRadius, ell.MinorRadius, twoPi*f0, sweep-twoPi)
+		if err != nil {
+			return geom.EllipticalArc{}, false
+		}
+	}
+	return a, true
+}
+
+// normalizeSweep folds a raw angle difference into (0, 2π] so an arc constructor gets a positive sweep whose
+// complement is sweep−2π.
+func normalizeSweep(d float64) float64 {
+	for d <= 0 {
+		d += 2 * stdmath.Pi
+	}
+	for d > 2*stdmath.Pi {
+		d -= 2 * stdmath.Pi
+	}
+	return d
+}
+
+// insideEllipse reports whether p (on the cap plane) lies inside the tool's exit ellipse — dist to the tool
+// axis < r, tested via the ellipse's own quadratic form so it needs no tool handle.
+func insideEllipse(p math.Point3, ell geom.EllipseFull) bool {
+	w := ell.Center.VectorTo(p)
+	u := float64(w.Dot(ell.MajorAxis.AsVector())) / ell.MajorRadius
+	minor := ell.Normal.Cross(ell.MajorAxis)
+	v := float64(w.Dot(minor)) / ell.MinorRadius
+	return u*u+v*v < 1
+}
+
+// buildRimCrossCut assembles target − tool for the recognised slice-2 rim-crossing: the target wall kept
+// OUTSIDE the tool (a wall with the entry hole AND a top-rim notch), the exit cap with the mixed rim-arc +
+// ellipse-arc bite, the target's other caps whole, and the tool wall kept INSIDE the target — a tunnel whose
+// two loops are the entry rim and the [exit-chain ⊕ ellipse-arc] composite — reversed into the cavity.
+func buildRimCrossCut(p rimCrossPlan) (*topo.Body, bool) {
+	wallImprint := []geom.Curve3{&p.entry, &p.exitChain}
+	wall, okW := p.tgt.split(wallImprint, Difference, false, p.tool.inside)
+	// The tunnel's exit loop closes the open wall chain with the cap-plane ellipse arc; feed the SAME arc the
+	// cap uses so the tunnel↔cap edge welds (ADR-0046 shared-edge discipline). A partial EllipticalArc already
+	// has PointAt(0) at its start corner, so no re-anchoring is needed (unlike slice 1's full ellipse).
+	toolImprint := []geom.Curve3{&p.entry, &p.exitChain, &p.ellipseArc}
+	tunnel, okT := p.tool.split(toolImprint, Difference, true, p.tgt.inside)
+	if !okW || !okT {
+		return nil, false
+	}
+	faces := make([]curvedFace, 0, len(wall)+len(tunnel)+3)
+	faces = append(faces, wall...)
+	faces = append(faces, mixedArcCap(p.exitCap, &p.rimArc, &p.ellipseArc))
+	faces = append(faces, otherCapsWhole(p.tgt.body, p.exitCap, p.tool.inside)...)
+	faces = append(faces, reverseCurvedFaces(tunnel)...)
+	return curvedStitch(faces), true
+}
+
+// mixedArcCap returns the exit cap trimmed to its rim-crossing bite: a single outer loop made of the
+// surviving rim arc and the inside ellipse arc, meeting at the two corners. Both arcs reference the SAME
+// curve objects fed to the wall/tunnel splits, so the cap↔wall (rim) and cap↔tunnel (ellipse) edges weld.
+func mixedArcCap(cap curvedFace, rimArc geom.Curve3, ellArc geom.Curve3) curvedFace {
+	// Both arcs are built running corner[0]→corner[1] (each PointAt(0) is corner[0]). The loop walks the
+	// ELLIPSE arc corner[0]→corner[1] then the RIM arc back corner[1]→corner[0]: this winding orients the cap
+	// bite consistently with the cap's outward (+cap-normal) face, so the shared rim edge (cap↔wall) and
+	// ellipse edge (cap↔tunnel) are each traversed OPPOSITELY by their two faces (the manifold orientation
+	// contract). The reverse winding [rim 0→1, ellipse 1→0] chains just as well but leaves both edges
+	// co-directional with their neighbours — an inconsistent-orientation crack at the two corners (#1724).
+	loop := curvedLoop{edges: []loopEdge{
+		{curve: ellArc, t0: 0, t1: 1},
+		{curve: rimArc, t0: 1, t1: 0},
+	}}
+	return curvedFace{surface: cap.surface, reversed: cap.reversed, lineage: cap.lineage, loops: []curvedLoop{loop}}
+}

--- a/kernel/brep/curved_cap_crossing_rim_test.go
+++ b/kernel/brep/curved_cap_crossing_rim_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// rimCrossBodies builds the r=3 h=10 target and an oblique r=0.9 tool at the given base x, at 45° in the
+// x–z plane (the slice-2 recognizer fixture; base -5.6 crosses the rim, base -6.5 exits inside it).
+func rimCrossBodies(t *testing.T, baseX float64) (target, tool *topo.Body) {
+	t.Helper()
+	s := 1 / stdmath.Sqrt2
+	tg, err := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 10)
+	if err != nil {
+		t.Fatalf("target: %v", err)
+	}
+	tl, err := SolidCylinder(math.P3(math.Scalar(baseX), 0, 2), math.V3(math.Scalar(s), 0, math.Scalar(s)), 0.9, 16)
+	if err != nil {
+		t.Fatalf("tool: %v", err)
+	}
+	return tg, tl
+}
+
+// TestRimCrossingAcceptsRimCrossing: the base -5.6 tool's exit ellipse crosses the top rim, so the slice-2
+// recognizer builds a four-face result (notched wall + mixed-arc cap + bottom cap + tunnel).
+func TestRimCrossingAcceptsRimCrossing(t *testing.T) {
+	target, tool := rimCrossBodies(t, -5.6)
+	res, ok := RimCrossingCutGeneral(target, tool, &diag.Recorder{})
+	if !ok {
+		t.Fatal("rim-crossing cut declined a genuine rim-crossing tool")
+	}
+	if n := len(res.Faces()); n != 4 {
+		t.Errorf("rim-crossing result has %d faces; want 4", n)
+	}
+}
+
+// TestRimCrossingDeclinesInteriorExit: the base -6.5 tool exits STRICTLY inside the rim — slice 1's job — so
+// the rim-crossing recognizer must decline (its two-corner cap gate finds zero corners).
+func TestRimCrossingDeclinesInteriorExit(t *testing.T) {
+	target, tool := rimCrossBodies(t, -6.5)
+	if _, ok := RimCrossingCutGeneral(target, tool, &diag.Recorder{}); ok {
+		t.Error("rim-crossing cut accepted an interior-exit tool; want decline (slice 1 handles it)")
+	}
+}
+
+// TestRimCrossingDeclinesNoContact: a tool whose axis clears the target entirely never reaches a cap, so the
+// recognizer declines with no diagnostic-worthy trace.
+func TestRimCrossingDeclinesNoContact(t *testing.T) {
+	target, tool := rimCrossBodies(t, -20)
+	if _, ok := RimCrossingCutGeneral(target, tool, &diag.Recorder{}); ok {
+		t.Error("rim-crossing cut accepted a tool that misses the target; want decline")
+	}
+}

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -238,7 +238,7 @@ var curvedExactPaths = []func(PartFeatureOperation, *topo.Body, *topo.Body, *dia
 	curvedCrossingIntersect, curvedSteinmetzIntersect, curvedConeCylinderIntersect, curvedConeConeIntersect,
 	curvedPartialIntersect,
 	// Cut — [P] the drill through-hole (curved-on-planar), the rest [T] transversal.
-	curvedCylindricalHoleCut, curvedFlatSubtract, curvedPartialCut, curvedSteinmetzCut, curvedConeCylinderCut, curvedConeConeCut, curvedCapCrossCut, curvedCrossingCut,
+	curvedCylindricalHoleCut, curvedFlatSubtract, curvedPartialCut, curvedSteinmetzCut, curvedConeCylinderCut, curvedConeConeCut, curvedCapCrossCut, curvedRimCrossCut, curvedCrossingCut,
 	// Join — [D] coaxial (degenerate overlap), [P] boss (curved-on-planar), the rest [T] transversal.
 	curvedCoaxialJoin, curvedCylinderBossJoin, curvedPartialJoin, curvedConeCylinderJoin, curvedConeConeJoin, curvedCrossingJoin, curvedSteinmetzJoin,
 }

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -72,7 +72,8 @@ var (
 	curvedConeCylinderCut    = gatedCurved(Cut, brep.ConeCylinderCutGeneral)
 	curvedConeConeCut        = gatedCurved(Cut, brep.ConeConeCutGeneral)
 	curvedCrossingCut        = gatedCurved(Cut, brep.CrossingCylinderCutGeneral)
-	curvedCapCrossCut        = gatedCurved(Cut, brep.CapCrossingCutGeneral) // oblique tool exits one cap (#1724)
+	curvedCapCrossCut        = gatedCurved(Cut, brep.CapCrossingCutGeneral) // oblique tool exits one cap, ellipse inside rim (#1724)
+	curvedRimCrossCut        = gatedCurved(Cut, brep.RimCrossingCutGeneral) // oblique tool exits one cap, ellipse crosses rim (#1724 slice 2)
 
 	// Join — the union, keeping the analytic wall where the operands' faces are coincident or breached.
 	curvedCoaxialJoin      = gatedCurved(Join, withoutRecorder(brep.CoaxialCylinderUnion)) // coaxial equal-radius cylinders

--- a/kernel/ops/boolean_csg_demotion_test.go
+++ b/kernel/ops/boolean_csg_demotion_test.go
@@ -98,6 +98,7 @@ func curvedExactCases() []curvedExactCase {
 		{"crossing cylinders − (drill)", ops.Cut, crossingCylinders},
 		{"crossing cylinders ∪", ops.Join, crossingCylinders},
 		{"cap-crossing cylinder − (exits top cap)", ops.Cut, capCrossingCutBodies},
+		{"rim-crossing cylinder − (exit ellipse crosses top rim)", ops.Cut, rimCrossingCutBodies},
 		{"equal-radius Steinmetz ∩", ops.Intersect, func(t *testing.T) (*topo.Body, *topo.Body) {
 			return demoCyl(t, math.P3(-6, 0, 0), math.V3(1, 0, 0), 3, 12), demoCyl(t, math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
 		}},
@@ -323,6 +324,16 @@ func capCrossingCutBodies(t *testing.T) (*topo.Body, *topo.Body) {
 	s := 1 / stdmath.Sqrt2
 	return demoCyl(t, math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 10),
 		demoCyl(t, math.P3(-6.5, 0, 2), math.V3(math.Scalar(s), 0, math.Scalar(s)), 0.9, 16)
+}
+
+// rimCrossingCutBodies is the slice-2 rim-crossing fixture (#1724): the same r=3 h=10 target and oblique
+// r=0.9 tool as slice 1, but at base -5.6 so the 45° tool's exit ellipse CROSSES the top rim — the tool
+// exits partly through the cap and partly through the wall (a top-rim notch), the case RimCrossingCutGeneral
+// handles. Shared by the exactness, OCC-volume, and full-moment certification guards.
+func rimCrossingCutBodies(t *testing.T) (*topo.Body, *topo.Body) {
+	s := 1 / stdmath.Sqrt2
+	return demoCyl(t, math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 10),
+		demoCyl(t, math.P3(-5.6, 0, 2), math.V3(math.Scalar(s), 0, math.Scalar(s)), 0.9, 16)
 }
 
 func demoCyl(t *testing.T, base math.Point3, axis math.Vector3, r, h float64) *topo.Body {

--- a/kernel/ops/rim_crossing_certification_test.go
+++ b/kernel/ops/rim_crossing_certification_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Cap-crossing slice-2 certification (EPIC Oblikovati/Oblikovati#1724, ADR-0046). The RIM-CROSSING cut
+// (brep.RimCrossingCutGeneral) is the next cap-crossing sub-family after the interior-exit slice: an oblique
+// cylinder tool whose exit ellipse CROSSES the cap rim at two corners, so the tool exits partly through the
+// cap and partly through the wall — the wall gains a top-rim NOTCH plus its entry hole, the cap a mixed
+// rim-arc + ellipse-arc bite, and the tunnel an [entry ⊕ ellipse-arc] mouth. As with slice 1 this is certified
+// against an INDEPENDENT OpenCASCADE moment set (gmsh occ.cut + getMass), NOT internal manifold/volume nets
+// alone, plus a point-membership audit vs the analytic CSG predicate — the strong right-volume-wrong-shape gate.
+
+// OCC ground truth for the slice-2 fixture (base -5.6), from gmsh OCC occ.cut + getMass. The tessellated
+// B-rep sits ~0.3% UNDER by the SSI-imprint polyline deficit — the same fraction every curved boolean carries,
+// not a shape error (the analytic construction matches to <0.1%, per the membership audit below).
+const (
+	occRimVol   = 263.6617744
+	occRimArea  = 279.0942805
+	occRimCx    = 0.0207324
+	occRimCy    = 0.0
+	occRimCz    = 4.8372578
+	occRimFaces = 4 // notched wall (holed) + top cap (mixed-arc bite) + bottom cap + tunnel
+)
+
+// rimCrossFixture builds the certified slice-2 pair: r=3 h=10 target, oblique r=0.9 tool at 45° whose exit
+// ellipse CROSSES the top rim (base -5.6 vs slice 1's -6.5, which exits strictly inside the rim).
+func rimCrossFixture(t *testing.T) (target, tool *topo.Body) {
+	t.Helper()
+	s := 1 / stdmath.Sqrt2
+	tg, err := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 10)
+	if err != nil {
+		t.Fatalf("target SolidCylinder: %v", err)
+	}
+	tl, err := brep.SolidCylinder(math.P3(-5.6, 0, 2), math.V3(math.Scalar(s), 0, math.Scalar(s)), 0.9, 16)
+	if err != nil {
+		t.Fatalf("tool SolidCylinder: %v", err)
+	}
+	return tg, tl
+}
+
+func TestRimCrossingCutIsWatertightAndFoldFree(t *testing.T) {
+	target, tool := rimCrossFixture(t)
+	res, err := Boolean(Cut, target, tool)
+	if err != nil {
+		t.Fatalf("Boolean(Cut): %v", err)
+	}
+	if r := Validate(res); !r.Valid {
+		t.Errorf("rim-crossing cut is not a valid solid: manifold=%v closed=%v orient=%v euler=%v issues=%v",
+			r.Manifold, r.Closed, r.OrientationOK, r.EulerConsistent, r.Issues)
+	}
+	mesh, _ := TessellateBody(res, capCertQuality())
+	if free := freeEdgeCount(mesh); free != 0 {
+		t.Errorf("rim-crossing cut tessellated with %d free edges; want 0 — a cross-face crack (notched two-rim "+
+			"wall mesher or the mixed-arc cap winding, #1724 slice 2)", free)
+	}
+	if folds := FoldEdgeCount(mesh); folds != 0 {
+		t.Errorf("rim-crossing cut mesh has %d fold edges; want 0 (no self-overlap)", folds)
+	}
+}
+
+func TestRimCrossingCutMomentsMatchOCC(t *testing.T) {
+	target, tool := rimCrossFixture(t)
+	res, err := Boolean(Cut, target, tool)
+	if err != nil {
+		t.Fatalf("Boolean(Cut): %v", err)
+	}
+	if n := len(res.Faces()); n != occRimFaces {
+		t.Errorf("rim-crossing cut has %d faces; want %d (notched holed wall + mixed-arc top cap + bottom cap "+
+			"+ tunnel)", n, occRimFaces)
+	}
+	gp := BodyGeometryProperties(res, capCertQuality())
+	if rel := stdmath.Abs(gp.Volume-occRimVol) / occRimVol; rel > 0.006 {
+		t.Errorf("volume %.4f vs OCC %.4f (rel %.4f > 0.006) — beyond the SSI-imprint facet deficit", gp.Volume, occRimVol, rel)
+	}
+	if rel := stdmath.Abs(gp.Area-occRimArea) / occRimArea; rel > 0.004 {
+		t.Errorf("area %.4f vs OCC %.4f (rel %.4f > 0.004)", gp.Area, occRimArea, rel)
+	}
+	occCentroid := math.P3(occRimCx, occRimCy, occRimCz)
+	if d := float64(gp.Centroid.DistanceTo(occCentroid)); d > 0.05 {
+		t.Errorf("centroid (%.4f,%.4f,%.4f) vs OCC (%.4f,%.4f,%.4f): distance %.4f > 0.05",
+			gp.Centroid.X, gp.Centroid.Y, gp.Centroid.Z, occRimCx, occRimCy, occRimCz, d)
+	}
+}
+
+// TestRimCrossingCutMembershipMatchesCSG samples an interior grid and asserts the built solid's inside/outside
+// agrees with the analytic CSG predicate target\tool everywhere away from the boundary — so a right-volume-
+// wrong-shape build (correct moments, displaced material at the notch or the tunnel) still fails.
+func TestRimCrossingCutMembershipMatchesCSG(t *testing.T) {
+	target, tool := rimCrossFixture(t)
+	res, err := Boolean(Cut, target, tool)
+	if err != nil {
+		t.Fatalf("Boolean(Cut): %v", err)
+	}
+	inTarget := func(p math.Point3) bool {
+		return stdmath.Hypot(float64(p.X), float64(p.Y)) <= 3 && p.Z >= 0 && p.Z <= 10
+	}
+	tb, td := math.P3(-5.6, 0, 2), math.V3(math.Scalar(1/stdmath.Sqrt2), 0, math.Scalar(1/stdmath.Sqrt2))
+	inTool := func(p math.Point3) bool {
+		w := tb.VectorTo(p)
+		ax := float64(w.Dot(td))
+		if ax < 0 || ax > 16 {
+			return false
+		}
+		return float64(w.Sub(td.Scale(math.Scalar(ax))).Length()) <= 0.9
+	}
+	const shell = 0.15 // skip points within this distance of either surface (facet noise)
+	nearSurface := func(p math.Point3) bool {
+		rWall := stdmath.Abs(stdmath.Hypot(float64(p.X), float64(p.Y)) - 3)
+		w := tb.VectorTo(p)
+		ax := float64(w.Dot(td))
+		rTool := stdmath.Abs(float64(w.Sub(td.Scale(math.Scalar(ax))).Length()) - 0.9)
+		zCap := stdmath.Min(stdmath.Abs(float64(p.Z)), stdmath.Abs(float64(p.Z)-10))
+		return rWall < shell || rTool < shell || zCap < shell
+	}
+	mesh, _ := TessellateBody(res, DefaultQuality())
+	mismatches := 0
+	const n = 60
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			for k := 0; k < n; k++ {
+				p := math.P3(math.Scalar(-3+6*(float64(i)+0.5)/n), math.Scalar(-3+6*(float64(j)+0.5)/n), math.Scalar(10*(float64(k)+0.5)/n))
+				if nearSurface(p) {
+					continue
+				}
+				if pointInMesh(mesh, p) != (inTarget(p) && !inTool(p)) {
+					mismatches++
+				}
+			}
+		}
+	}
+	if mismatches > 0 {
+		t.Errorf("membership audit: %d interior points disagree with the analytic CSG predicate target\\tool "+
+			"— a right-volume-wrong-shape build (#1724 slice 2)", mismatches)
+	}
+}

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -97,6 +97,9 @@ func specialCurvedMesh(f *topo.Face, s geom.Surface, outer3D []math.Point3, hole
 	if m, isBand := spiricBandMesh(f, s, q); isBand {
 		return m, true // a torus cut through the hole: a tube-wrapping band between two spiric ovals (#1375)
 	}
+	if m, isBand := twoRimHoledBandMesh(s, outer3D, holes3D, q); isBand {
+		return m, true // a two-rim band (a notched rim + an intact rim) carrying lens holes: bridge the seam, unroll
+	}
 	return nil, false
 }
 

--- a/kernel/ops/testdata/occ_boolean_oracle.json
+++ b/kernel/ops/testdata/occ_boolean_oracle.json
@@ -47,5 +47,6 @@
   "torus ∩ box (oblique figure-eight)": 151.898735,
   "torus − box (oblique figure-eight)": 242.8854496,
   "torus − box (axis-∥ near-pinch large oval)": 280.2555295,
-  "cap-crossing cylinder − (exits top cap)": 266.6720995
+  "cap-crossing cylinder − (exits top cap)": 266.6720995,
+  "rim-crossing cylinder − (exit ellipse crosses top rim)": 263.6617744
 }

--- a/kernel/ops/two_rim_holed_band.go
+++ b/kernel/ops/two_rim_holed_band.go
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"sort"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Two-rim holed developable-band tessellation (Oblikovati/Oblikovati#1724, ADR-0046, cap-crossing slice 2).
+// The rim-crossing cut's target WALL is a full-wrap cylinder band bounded by TWO full-period rims — a
+// NOTCHED top rim (where the tool exits ACROSS the cap edge) plus the intact bottom rim — carrying the
+// tool's ENTRY lens as an interior hole. Unlike the drill-through wall (holedConicWallMesh), whose split
+// hands back ONE seam-bridged wrapping outer loop, this wall comes back as SEPARATE loops (the notch
+// breaks the seam bridge), so BOTH rims look like full-wrap "holes" holesIntoBranch rejects, and the face
+// falls through to the flat best-fit-plane CDT — which mangles a full cylinder wall (an inside-out band,
+// ~140 free edges, near-zero volume). The fix stays in the tessellation layer: synthesize the missing seam
+// slit that bridges the two rims into one wrapping outer loop, then mesh through the SAME proven unroll +
+// metric CDT (unrolledWallCDT) the drilled wall uses — the notch is just a non-straight top edge in
+// unrolled (u,v).
+
+// seamSteps is the number of segments the synthetic rim-bridging seam is divided into. The seam is a short,
+// near-axial slit on the wall, so a modest count keeps its boundary nodes dense enough for well-shaped
+// triangles; the interior is refined by adaptiveInteriorNodes regardless.
+const seamSteps = 16
+
+// twoRimHoledBandMesh meshes a developable side bounded by two full-wrap rims (either may be notched)
+// carrying interior lens holes, by bridging the rims at a synthetic seam and unrolling. ok=false unless
+// the surface is a developable side and EXACTLY ONE of the hole loops is itself a full-wrap rim (zero →
+// holedConicWallMesh already handles it; two or more → not a two-rim band this mesher understands).
+func twoRimHoledBandMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, q Quality) (*Mesh, bool) {
+	if !isDevelopableSide(s) || isPeriodic(s.UDomain()) == isPeriodic(s.VDomain()) {
+		return nil, false
+	}
+	rims, lenses := splitWrappingHoles(s, holes3D)
+	if len(rims) != 1 {
+		return nil, false
+	}
+	wrap, ok := bridgeRimsAtSeam(s, outer3D, rims[0], lenses)
+	if !ok {
+		return nil, false
+	}
+	outerUV, umin, umax, ok := wrappedWallUV(s, wrap)
+	if !ok {
+		return nil, false
+	}
+	lensUV, ok := holesIntoBranch(s, lenses, umin, umax)
+	if !ok {
+		return nil, false
+	}
+	return unrolledWallCDT(s, q, wrap, lenses, outerUV, lensUV), true
+}
+
+// splitWrappingHoles partitions hole loops into those that themselves wrap the full period (a second rim,
+// mis-demoted to a hole by faceHoleBoundaries) and the genuine non-wrapping lens holes, by their unrolled
+// angular span (a full rim spans ~2π; a lens spans a small arc).
+func splitWrappingHoles(s geom.Surface, holes3D [][]math.Point3) (rims, lenses [][]math.Point3) {
+	for _, h := range holes3D {
+		if holeWrapsPeriod(s, h) {
+			rims = append(rims, h)
+		} else {
+			lenses = append(lenses, h)
+		}
+	}
+	return rims, lenses
+}
+
+// holeWrapsPeriod reports whether a hole loop spans essentially the full angular period (so it is a rim,
+// not a lens) — the same >2π−0.5 test holesIntoBranch uses to reject a seam-wrapping hole.
+func holeWrapsPeriod(s geom.Surface, hole []math.Point3) bool {
+	us := make([]float64, len(hole))
+	for i, p := range hole {
+		us[i], _ = s.ParamAt(p)
+	}
+	lo, hi := minMax(cumulativeUnwrap(us))
+	return hi-lo > 2*stdmath.Pi-0.5
+}
+
+// bridgeRimsAtSeam joins two full-wrap rims into one seam-wrapping outer loop by cutting each rim at a
+// shared-vertex seam and walking bottom rim → up the seam → top rim (reversed) → down the seam (a CCW
+// unrolled rectangle). The seam is placed in the largest lens-free angular gap (so it never crosses a hole)
+// and runs between an EXISTING vertex on each rim, so it introduces no new rim point that would T-crack the
+// neighbouring cap; its interior points are interpolated ALONG the surface (never a chord through the solid)
+// and are reused identically on both rectangle edges, so the two seam copies weld. ok=false if either rim is
+// too short to order.
+func bridgeRimsAtSeam(s geom.Surface, top3D, bot3D []math.Point3, lenses [][]math.Point3) ([]math.Point3, bool) {
+	top := orderedRing(s, top3D)
+	bot := orderedRing(s, bot3D)
+	if len(top) < 3 || len(bot) < 3 {
+		return nil, false
+	}
+	seamTh := clearSeamAngle(s, top, lenses) // seam in the widest gap clear of BOTH lenses and the notch
+	ti := nearestAngleIndex(s, top, seamTh)  // seam anchors on EXISTING rim vertices (no new rim point → no crack)
+	bi := nearestAngleIndex(s, bot, seamTh)
+	topSeq := rotateRing(top, ti)
+	botSeq := rotateRing(bot, bi)
+	seam := seamOnSurface(s, top[ti], bot[bi], seamSteps) // interior seam points, on the surface, bottom→top
+
+	wrap := make([]math.Point3, 0, len(topSeq)+len(botSeq)+2*len(seam)+3)
+	wrap = append(wrap, botSeq...)          // bottom rim, ascending θ from the seam vertex
+	wrap = append(wrap, botSeq[0])          // bottom-right corner: the +2π copy of the seam bottom vertex
+	wrap = append(wrap, seam...)            // right seam edge, bottom → top (on surface)
+	wrap = append(wrap, topSeq[0])          // top-right corner: the +2π copy of the seam top vertex
+	wrap = appendReversed(wrap, topSeq[1:]) // top rim reversed, descending θ back toward the seam
+	wrap = append(wrap, topSeq[0])          // top-left corner: the seam top vertex
+	wrap = appendReversed(wrap, seam)       // left seam edge, top → bottom (same points, reversed → welds)
+	return wrap, true
+}
+
+// clearSeamAngle returns an angle in the WIDEST angular gap clear of both the lens holes AND the top rim's
+// notch (the low-v stretch of the outer loop where the tool exited), so the rim-bridging seam crosses no hole
+// (holesIntoBranch would reject a straddled lens) and anchors on intact full-height rim well away from the
+// trivalent corners (anchoring on a notch vertex tangles the corner mesh). Both are treated as keep-away
+// angle clusters. With neither present any angle is clear, so it returns 0.
+func clearSeamAngle(s geom.Surface, top []math.Point3, lenses [][]math.Point3) float64 {
+	angs := notchAngles(s, top)
+	for _, h := range lenses {
+		for _, p := range h {
+			angs = append(angs, normTwoPi(angleOf(s, p)))
+		}
+	}
+	if len(angs) == 0 {
+		return 0
+	}
+	sort.Float64s(angs)
+	bestGap, bestMid := -1.0, 0.0
+	for i := range angs {
+		gap := angs[(i+1)%len(angs)] - angs[i]
+		if i == len(angs)-1 {
+			gap += 2 * stdmath.Pi
+		}
+		if gap > bestGap {
+			bestGap, bestMid = gap, normTwoPi(angs[i]+gap/2)
+		}
+	}
+	return bestMid
+}
+
+// notchAngles returns the angles of the top rim's notch vertices — those dipping below the rim's max v by
+// more than a small fraction of the rim's own v-extent. An un-notched (constant-v) rim yields none.
+func notchAngles(s geom.Surface, top []math.Point3) []float64 {
+	vs := make([]float64, len(top))
+	vmax := stdmath.Inf(-1)
+	for i, p := range top {
+		vs[i] = vParam(s, p)
+		vmax = stdmath.Max(vmax, vs[i])
+	}
+	vmin, _ := minMax(vs)
+	cut := vmax - 0.02*(vmax-vmin) // any vertex measurably below the plateau is in the notch
+	var out []float64
+	for i, v := range vs {
+		if v < cut {
+			out = append(out, normTwoPi(angleOf(s, top[i])))
+		}
+	}
+	return out
+}
+
+// normTwoPi folds an angle into [0, 2π).
+func normTwoPi(a float64) float64 {
+	a = stdmath.Mod(a, 2*stdmath.Pi)
+	if a < 0 {
+		a += 2 * stdmath.Pi
+	}
+	return a
+}
+
+// nearestAngleIndex returns the index of the ring vertex whose angle is closest to theta (shortest way
+// around), so the seam bridging the two rims stays as near-axial as the rims' vertices allow.
+func nearestAngleIndex(s geom.Surface, ring []math.Point3, theta float64) int {
+	best, bd := 0, stdmath.Inf(1)
+	for i, p := range ring {
+		if d := stdmath.Abs(foldAngle(angleOf(s, p) - theta)); d < bd {
+			best, bd = i, d
+		}
+	}
+	return best
+}
+
+// seamOnSurface returns the interior points of the seam slit from the bottom rim vertex up to the top rim
+// vertex, interpolated in (θ,v) and evaluated ON the surface so the slit never chords through the solid.
+func seamOnSurface(s geom.Surface, top, bot math.Point3, steps int) []math.Point3 {
+	ut, vt := s.ParamAt(top)
+	ub, vb := s.ParamAt(bot)
+	dth := foldAngle(ut - ub) // shortest angular way from bottom to top
+	out := make([]math.Point3, 0, steps-1)
+	for k := 1; k < steps; k++ {
+		f := float64(k) / float64(steps)
+		out = append(out, s.PointAt(ub+dth*f, vb+(vt-vb)*f))
+	}
+	return out
+}
+
+// rotateRing returns ring reordered to start at index i, preserving order (wrapping) — the seam cut point.
+func rotateRing(ring []math.Point3, i int) []math.Point3 {
+	out := make([]math.Point3, 0, len(ring))
+	out = append(out, ring[i:]...)
+	out = append(out, ring[:i]...)
+	return out
+}
+
+// appendReversed appends src in reverse order to dst.
+func appendReversed(dst, src []math.Point3) []math.Point3 {
+	for i := len(src) - 1; i >= 0; i-- {
+		dst = append(dst, src[i])
+	}
+	return dst
+}
+
+// foldAngle folds an angle difference into (−π, π].
+func foldAngle(d float64) float64 {
+	for d > stdmath.Pi {
+		d -= 2 * stdmath.Pi
+	}
+	for d <= -stdmath.Pi {
+		d += 2 * stdmath.Pi
+	}
+	return d
+}

--- a/kernel/ops/two_rim_holed_band_test.go
+++ b/kernel/ops/two_rim_holed_band_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// bandCylinder is the R=3, z∈[0,h] test cylinder for the two-rim holed-band mesher.
+func bandCylinder(h float64) geom.Cylinder {
+	c, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3)
+	_ = h
+	return c
+}
+
+// rimLoop samples a full-circle rim at axial v as a 3D point loop on the cylinder.
+func rimLoop(s geom.Surface, v float64, n int) []math.Point3 {
+	out := make([]math.Point3, 0, n)
+	for k := 0; k < n; k++ {
+		out = append(out, s.PointAt(2*stdmath.Pi*float64(k)/float64(n), v))
+	}
+	return out
+}
+
+// lensLoop samples a small closed lens hole centred at (theta0,v0) in the wall's (θ,v) chart.
+func lensLoop(s geom.Surface, theta0, v0, rTheta, rV float64, n int) []math.Point3 {
+	out := make([]math.Point3, 0, n)
+	for k := 0; k < n; k++ {
+		a := 2 * stdmath.Pi * float64(k) / float64(n)
+		out = append(out, s.PointAt(theta0+rTheta*stdmath.Cos(a), v0+rV*stdmath.Sin(a)))
+	}
+	return out
+}
+
+// TestTwoRimHoledBandMeshesFullBand: a full cylinder band (two circular rims) carrying one lens hole meshes
+// through the seam bridge to the unrolled CDT with the correct curved area (≈ 2πRh, minus the small lens) —
+// NOT the flat best-fit-plane patch the generic trim path would give (which would grossly under-report area).
+func TestTwoRimHoledBandMeshesFullBand(t *testing.T) {
+	s := bandCylinder(10)
+	top := rimLoop(s, 10, 96)
+	bot := rimLoop(s, 0, 96)
+	lens := lensLoop(s, 0, 5, 0.12, 0.35, 40)
+	q := Quality{ChordTolerance: 0.005, AngleTolerance: 2 * stdmath.Pi / 180}
+	m, ok := twoRimHoledBandMesh(s, top, [][]math.Point3{bot, lens}, q)
+	if !ok {
+		t.Fatal("twoRimHoledBandMesh declined a full two-rim band with a lens hole")
+	}
+	full := 2 * stdmath.Pi * 3 * 10 // 188.50
+	area := meshArea(m)
+	if area < full-3 || area > full+0.5 {
+		t.Errorf("band area %.3f; want ≈ %.3f (full band minus a small lens), got a flat/torn patch?", area, full)
+	}
+	if len(m.Indices) == 0 {
+		t.Fatal("empty mesh")
+	}
+}
+
+// TestTwoRimHoledBandDeclinesWithoutWrappingRim: with no second full-wrap rim among the holes (only a lens),
+// the face is the ordinary drilled-wall case holedConicWallMesh owns, so this mesher must defer.
+func TestTwoRimHoledBandDeclinesWithoutWrappingRim(t *testing.T) {
+	s := bandCylinder(10)
+	seamWrap := rimLoop(s, 10, 64) // a single seam-wrapping outer (stand-in) — no rim among the holes
+	lens := lensLoop(s, 0, 5, 0.12, 0.35, 40)
+	if _, ok := twoRimHoledBandMesh(s, seamWrap, [][]math.Point3{lens}, DefaultQuality()); ok {
+		t.Error("meshed a face with zero wrapping rim-holes; want decline (holedConicWallMesh's case)")
+	}
+}
+
+// TestSplitWrappingHolesPartitions: a full-circle rim is classed as a wrapping rim, a small lens as a lens.
+func TestSplitWrappingHolesPartitions(t *testing.T) {
+	s := bandCylinder(10)
+	rim := rimLoop(s, 0, 64)
+	lens := lensLoop(s, stdmath.Pi, 5, 0.1, 0.3, 32)
+	rims, lenses := splitWrappingHoles(s, [][]math.Point3{rim, lens})
+	if len(rims) != 1 || len(lenses) != 1 {
+		t.Fatalf("splitWrappingHoles got rims=%d lenses=%d; want 1 and 1", len(rims), len(lenses))
+	}
+	if !holeWrapsPeriod(s, rim) || holeWrapsPeriod(s, lens) {
+		t.Error("holeWrapsPeriod misclassified the rim or the lens")
+	}
+}


### PR DESCRIPTION
## What

Widens the curved-boolean **cap-crossing** recognizer to the **rim-crossing** sub-family: an oblique cylinder tool whose exit ellipse **crosses** the target cap's rim (base -5.6 in the fixture), so the tool exits partly through the cap and partly through the wall. The cut is built as an exact analytic solid — a wall with a top-rim **notch** plus its entry hole, a cap with a mixed rim-arc/ellipse-arc **bite**, and a tool tunnel — instead of demoting to triangle-soup CSG.

This is **slice 2** of EPIC #1724, following slice 1 (interior-exit, PR #1727). The exact cap-rim **corner solver** (first commit) computes the two triple points `rim ∩ tool_wall ∩ cap_plane` as roots of a first-and-second-harmonic trig equation.

## Why it needed real work

Two problems had to be solved for the result to be a **watertight** solid (tessellation correctness is the project's top priority):

- **Tessellation** — the notched wall is a full-wrap developable band bounded by **two** full-period rims (notched top + intact bottom) carrying an interior entry lens. No existing mesher handled this (`holedConicWallMesh` needs one seam-bridged wrapping outer; the ruled band lofts cannot carry an interior hole), so it fell to the flat best-fit-plane CDT and rendered as a **torn, inside-out band** (~140 free edges, near-zero volume). New `twoRimHoledBandMesh` synthesizes the missing **seam slit** — placed in the widest gap clear of both the lens holes and the notch, anchored on existing rim vertices so it T-cracks no neighbour — to bridge the two rims into one wrapping outer loop, then reuses the proven unroll + metric CDT. The notch is just a non-straight top edge in unrolled (u,v).

- **Orientation** — the mixed-arc cap loop was wound against the cap's outward normal, so its shared rim and ellipse edges ran co-directional with the wall and tunnel — an inconsistent-orientation crack at the two corners. The loop now walks ellipse-then-rim, orienting the bite consistently.

## Certification

Certified against **OpenCASCADE** (gmsh `occ.cut` + `getMass`), not just internal manifold/volume nets:

| metric | ours | OCC | delta |
|---|---|---|---|
| volume | 262.851 | 263.662 | -0.31% (SSI-imprint deficit) |
| area | 278.837 | 279.094 | -0.09% |
| faces | 4 | 4 | ✓ |
| centroid dist | — | — | 0.0015 |

Plus watertight (`freeEdgeCount==0`), valid manifold (χ=0, genus-1), and a **60³ point-membership audit** vs the analytic CSG predicate `target\tool` (0 mismatches — the strong right-volume-wrong-shape gate). Registered in the exactness + OCC-volume guards, and driven **live** through the viewport (skips only the second-window all-black llvmpipe harness artifact, asserts otherwise).

Refs #1724 (EPIC stays open — cone tools, two-cap exit, and partial-rim side trim remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)