### PR TITLE
feat(kernel): cone-tool cap-crossing curved-boolean cut (#1724)

### DIFF
--- a/head/ui/cone_cap_crossing_render_test.go
+++ b/head/ui/cone_cap_crossing_render_test.go
@@ -1,0 +1,90 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Cone-tool cap-crossing cut live render (EPIC Oblikovati/Oblikovati#1724, ADR-0046). The kernel certifies
+// the cone-tool cap-crossing cut against OCC moments + a membership audit (kernel/ops); this drives the SAME
+// cut through the real feature pipeline and renders it offscreen, proving the holed wall + ellipse-holed top
+// cap + bottom cap + cone tunnel reach the screen as lit geometry. Shares bodyFractionOf/backgroundRendered
+// with the rim-crossing render (robust to the second-window llvmpipe dimming/black-frame harness artifact).
+package ui
+
+import (
+	stdmath "math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/scene"
+)
+
+// coneCapPart returns a session whose active part holds the cone-tool cap-crossing cut: an r=3 h=10 target
+// minus an oblique frustum (rBase 0.9 → rTop 0.6, 45°) that enters the wall once and exits the top cap.
+func coneCapPart(t *testing.T) *app.Session {
+	t.Helper()
+	s := app.NewSession()
+	pd, err := compdef.AddPart(s.Workspace(), "cone-cap.opd", true)
+	if err != nil {
+		t.Fatalf("add part: %v", err)
+	}
+	def := pd.Content().(*compdef.PartComponentDefinition)
+	sc := 1 / stdmath.Sqrt2
+	target, err := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 10)
+	if err != nil {
+		t.Fatalf("target cylinder: %v", err)
+	}
+	top := math.P3(math.Scalar(-6.5+16*sc), 0, math.Scalar(2+16*sc))
+	tool, err := brep.SolidCylinderCone(math.P3(-6.5, 0, 2), top, 0.9, 0.6, "cone")
+	if err != nil {
+		t.Fatalf("tool frustum: %v", err)
+	}
+	feature.NewBaseFeatures(def.Features()).AddBase(target)
+	feature.NewBaseFeatures(def.Features()).AddBase(tool)
+	feature.NewModifyFeatures(def.Features()).AddCombine(0, 1, ops.Cut)
+	def.Recompute()
+	cam := scene.NewCamera(inWinW, inWinH)
+	cam.Eye, cam.Target, cam.Up = math.P3(10, -8.5, 14), math.P3(0, 0, 5.5), math.V3(0, 0, 1)
+	s.SetCamera(cam)
+	return s
+}
+
+// TestConeCapCrossingCutRendersLive asserts the cone-tool cut reaches the viewport as a large solid and
+// writes a PNG for visual inspection.
+func TestConeCapCrossingCutRendersLive(t *testing.T) {
+	dockLaidOut = false
+	icons = nil
+	win := newViewportWindow(t)
+	defer win.Destroy()
+
+	s := coneCapPart(t)
+	for i := 0; i < 8; i++ {
+		viewportFrame(win, s)
+	}
+	px, w, h, ok := win.ReadbackViewport(0)
+	if !ok {
+		t.Fatal("viewport readback unavailable")
+	}
+	if !backgroundRendered(px) {
+		t.Skip("offscreen frame did not composite (all-black, no background) — second-window llvmpipe harness artifact")
+	}
+	body := bodyFractionOf(px, w, h)
+	t.Logf("cone-cap cut body fraction = %.4f", body)
+	if body < 0.10 {
+		t.Errorf("cone-cap cut rendered near-blank: body fraction %.4f — the cut B-rep is not reaching the screen", body)
+	}
+	dir := t.TempDir()
+	if p := os.Getenv("OBK_SHOT_DIR"); p != "" {
+		dir = p
+	}
+	out := filepath.Join(dir, "cone-cap-cut.png")
+	if err := writeBGRAPNG(px, w, h, out); err != nil {
+		t.Fatalf("write PNG: %v", err)
+	}
+	t.Logf("saved cone-cap cut render to %s", out)
+}

--- a/kernel/brep/curved_cone_cap_crossing.go
+++ b/kernel/brep/curved_cone_cap_crossing.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+)
+
+// Curved-boolean CAP-CROSSING with a CONE tool (EPIC Oblikovati/Oblikovati#1724, ADR-0046). The cylinder-tool
+// cap-crossing (curved_cap_crossing.go) enters the target wall once and exits ONE cap through an ellipse
+// strictly inside the rim. A conical tool (a countersink/tapered pin) makes the SAME arrangement — its only
+// differences are analytic: the wall entry is the cone∩cylinder imprint (coneCylinderImprint, not the
+// cylinder∩cylinder one) and the exit section is the cone∩plane ellipse (geom.IntersectSurfacesAnalytic, not
+// the r/|n·d| cylinder ellipse). Because capCrossPlan and buildCapCrossCut are operand-generic over
+// ruledOperand, the whole assembly (wall with entry hole + holed exit cap + reversed cone tunnel) is REUSED;
+// only the recognizer changes. Non-ellipse exit sections (a parabola/hyperbola — the tool grazes the cap) and
+// rim-crossing cone exits are out of this slice and decline to the CSG fallback.
+
+// ConeCapCrossingCutGeneral is the exported entry kernel/ops routes a cone-tool cap-crossing subtract
+// through. ok=false outside the recognised interior-exit slice so kernel/ops keeps its CSG fallback.
+func ConeCapCrossingCutGeneral(target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	plan, ok := classifyConeCapCross(target, tool, rec)
+	if !ok {
+		return nil, false
+	}
+	return buildCapCrossCut(plan)
+}
+
+// classifyConeCapCross recognises a cone tool making an interior-exit cap-crossing on a cylinder target, or
+// ok=false otherwise. Positive gate: target a cylinder, tool a cone/frustum; the tool exits EXACTLY ONE cap
+// through an ellipse strictly inside that cap's rim; and the cone∩wall imprint is EXACTLY ONE closed in-band
+// loop (the single wall-entry hole, clear of the caps).
+func classifyConeCapCross(target, tool *topo.Body, rec *diag.Recorder) (capCrossPlan, bool) {
+	tgtOp, ok1 := cylinderOperand(target)
+	toolOp, ok2 := coneOperand(tool)
+	if !ok1 || !ok2 {
+		return capCrossPlan{}, false
+	}
+	cone, ok := toolOp.surface.(geom.Cone)
+	if !ok {
+		return capCrossPlan{}, false
+	}
+	exitCap, ellipse, ok := coneInteriorExitCap(target, cone)
+	if !ok {
+		return capCrossPlan{}, false
+	}
+	traced, ok := coneCylinderImprint(target, tool, rec)
+	if !ok {
+		return capCrossPlan{}, false
+	}
+	// A long frustum's wall meets the target cylinder's INFINITE-surface trace both where it really enters the
+	// finite wall AND where it would exit past the cap (a loop lying entirely BEYOND the exit cap plane). Keep
+	// only the loops strictly inside the target's cap band; a loop that STRADDLES a cap level is a rim-crossing
+	// (out of this interior-exit slice) and declines. See wallEntryLoops (#1724).
+	entry, ok := wallEntryLoops(tgtOp.newUV(Difference, false, toolOp.inside), traced)
+	if !ok || len(entry) != 1 {
+		return capCrossPlan{}, false
+	}
+	return capCrossPlan{tgt: tgtOp, tool: toolOp, exitCap: exitCap, ellipse: ellipse, entry: entry}, true
+}
+
+// wallEntryLoops partitions traced imprint loops against the target side's cap band: it KEEPS the loops that
+// sit strictly between the two cap levels (the genuine wall-entry holes) and DROPS loops lying entirely
+// beyond a cap (phantom crossings of the target's infinite ruled surface past its finite wall — a long tool
+// that reaches past the exit cap). ok=false if any loop STRADDLES a cap level, because a loop reaching a cap
+// is a rim-crossing/cap-reaching breach this interior-exit slice does not build (it keeps its CSG fallback).
+func wallEntryLoops(side ruledUV, loops []geom.Polyline) ([]geom.Polyline, bool) {
+	margin := geom.ResolutionForSize(side.band.vMax - side.band.vMin).Plane()
+	lo, hi := side.band.vMin+margin, side.band.vMax-margin
+	var kept []geom.Polyline
+	for _, lp := range loops {
+		below, above := 0, 0
+		for _, p := range lp.Vertices {
+			v := float64(side.base.VectorTo(p).Dot(side.axis))
+			switch {
+			case v < lo:
+				below++
+			case v > hi:
+				above++
+			}
+		}
+		switch {
+		case below == 0 && above == 0:
+			kept = append(kept, lp) // strictly in-band: a real wall-entry hole
+		case below == len(lp.Vertices) || above == len(lp.Vertices):
+			continue // entirely beyond one cap: a phantom past the finite wall — drop it
+		default:
+			return nil, false // straddles a cap level: a rim-crossing this slice does not build
+		}
+	}
+	return kept, true
+}
+
+// coneInteriorExitCap returns the single target cap the cone exits through an ellipse strictly inside that
+// cap's rim, with that ellipse. ok=false unless EXACTLY ONE cap qualifies (zero → no cap exit; two → a
+// two-cap exit, deferred).
+func coneInteriorExitCap(target *topo.Body, cone geom.Cone) (curvedFace, geom.EllipseFull, bool) {
+	var exitCap curvedFace
+	var ellipse geom.EllipseFull
+	found := 0
+	for _, cap := range planarCapFaces(target) {
+		e, ok := coneCapEllipseInsideRim(cap, cone)
+		if !ok {
+			continue
+		}
+		exitCap, ellipse, found = cap, e, found+1
+	}
+	return exitCap, ellipse, found == 1
+}
+
+// coneCapEllipseInsideRim returns the cone∩cap ellipse when cap is planar, the section is a bounded ELLIPSE,
+// and that ellipse lies strictly inside cap's rim circle; ok=false otherwise (a non-planar cap, an open
+// parabola/hyperbola section, or an ellipse reaching the rim — the latter a rim-crossing case, deferred).
+func coneCapEllipseInsideRim(cap curvedFace, cone geom.Cone) (geom.EllipseFull, bool) {
+	pl, ok := cap.surface.(geom.Plane)
+	if !ok {
+		return geom.EllipseFull{}, false
+	}
+	rim, ok := capRimCircle(cap)
+	if !ok {
+		return geom.EllipseFull{}, false
+	}
+	curves, handled := geom.IntersectSurfacesAnalytic(cone, pl, geom.ResolutionForSize(rim.Radius))
+	if !handled || len(curves) != 1 {
+		return geom.EllipseFull{}, false
+	}
+	ell, ok := curves[0].(geom.EllipseFull)
+	if !ok {
+		return geom.EllipseFull{}, false // an open section (parabola/hyperbola): not an interior cap exit
+	}
+	if !ellipseInsideRim(ell, rim.Center, rim.Radius, geom.ResolutionForSize(rim.Radius).Plane()) {
+		return geom.EllipseFull{}, false
+	}
+	return ell, true
+}

--- a/kernel/brep/curved_cone_cap_crossing_test.go
+++ b/kernel/brep/curved_cone_cap_crossing_test.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+func coneCapTarget(t *testing.T) *topo.Body {
+	t.Helper()
+	tg, err := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 10)
+	if err != nil {
+		t.Fatalf("target: %v", err)
+	}
+	return tg
+}
+
+// coneCapTool builds the certified oblique frustum (rBase 0.9 → rTop 0.6, 45°) that enters the wall once and
+// exits the top cap through an ellipse strictly inside the rim.
+func coneCapTool(t *testing.T) *topo.Body {
+	t.Helper()
+	s := 1 / stdmath.Sqrt2
+	top := math.P3(math.Scalar(-6.5+16*s), 0, math.Scalar(2+16*s))
+	tl, err := SolidCylinderCone(math.P3(-6.5, 0, 2), top, 0.9, 0.6, "cone")
+	if err != nil {
+		t.Fatalf("tool: %v", err)
+	}
+	return tl
+}
+
+// TestConeCapAcceptsInteriorExit: the oblique frustum enters the wall once and exits ONE cap through an
+// ellipse inside the rim — the recognizer accepts and builds a four-face result.
+func TestConeCapAcceptsInteriorExit(t *testing.T) {
+	res, ok := ConeCapCrossingCutGeneral(coneCapTarget(t), coneCapTool(t), &diag.Recorder{})
+	if !ok {
+		t.Fatal("cone-cap cut declined a genuine cone interior-exit tool")
+	}
+	if n := len(res.Faces()); n != 4 {
+		t.Errorf("cone-cap result has %d faces; want 4 (holed wall + holed top cap + bottom cap + tunnel)", n)
+	}
+}
+
+// TestConeCapDeclinesCylinderTool: a CYLINDER tool (slice-1's own fixture) is not a cone, so coneOperand
+// fails and the cone recognizer declines — slice 1 (CapCrossingCutGeneral) owns that case.
+func TestConeCapDeclinesCylinderTool(t *testing.T) {
+	s := 1 / stdmath.Sqrt2
+	tool, err := SolidCylinder(math.P3(-6.5, 0, 2), math.V3(math.Scalar(s), 0, math.Scalar(s)), 0.9, 16)
+	if err != nil {
+		t.Fatalf("tool: %v", err)
+	}
+	if _, ok := ConeCapCrossingCutGeneral(coneCapTarget(t), tool, &diag.Recorder{}); ok {
+		t.Error("cone-cap cut accepted a cylinder tool; want decline (slice 1 handles it)")
+	}
+}
+
+// TestConeCapDeclinesNoContact: a frustum sitting entirely outside the target never crosses it — no cap
+// exit, no wall entry — so the recognizer declines.
+func TestConeCapDeclinesNoContact(t *testing.T) {
+	tool, err := SolidCylinderCone(math.P3(-12, 0, 2), math.P3(-9, 0, 5), 0.9, 0.6, "cone")
+	if err != nil {
+		t.Fatalf("tool: %v", err)
+	}
+	if _, ok := ConeCapCrossingCutGeneral(coneCapTarget(t), tool, &diag.Recorder{}); ok {
+		t.Error("cone-cap cut accepted a non-contacting tool; want decline")
+	}
+}
+
+// wallBand frames a v-axis band [0,10] along +z from the origin — the target's own cap band — for the
+// wallEntryLoops unit tests.
+func wallBand() ruledUV {
+	return ruledUV{base: math.P3(0, 0, 0), axis: math.V3(0, 0, 1), band: coneSideBand_{vMin: 0, vMax: 10}}
+}
+
+func zLoop(zs ...float64) geom.Polyline {
+	pts := make([]math.Point3, len(zs))
+	for i, z := range zs {
+		pts[i] = math.P3(3, 0, math.Scalar(z))
+	}
+	lp, _ := geom.NewPolyline(pts)
+	return lp
+}
+
+// TestWallEntryLoopsKeepsInBandDropsPhantom is the crux of the cone slice: a long frustum's trace against the
+// target's INFINITE surface yields a real in-band wall loop AND a phantom loop entirely above the cap. The
+// filter keeps the former and drops the latter, so exactly one wall-entry hole survives.
+func TestWallEntryLoopsKeepsInBandDropsPhantom(t *testing.T) {
+	inBand := zLoop(4.3, 5.5, 6.6)     // strictly between the caps: real wall entry
+	phantom := zLoop(10.6, 11.5, 12.4) // entirely above z=10: past the finite wall
+	kept, ok := wallEntryLoops(wallBand(), []geom.Polyline{phantom, inBand})
+	if !ok {
+		t.Fatal("wallEntryLoops declined a clean in-band + phantom pair")
+	}
+	if len(kept) != 1 {
+		t.Fatalf("kept %d loops; want 1 (the in-band wall entry, phantom dropped)", len(kept))
+	}
+	if z := float64(kept[0].Vertices[0].Z); z > 10 {
+		t.Errorf("kept the phantom loop (z=%.2f > 10) instead of the in-band one", z)
+	}
+}
+
+// TestWallEntryLoopsDeclinesStraddle: a loop that CROSSES a cap level (some points below, some above) is a
+// rim-crossing/cap-reaching breach this interior-exit slice does not build — the filter declines.
+func TestWallEntryLoopsDeclinesStraddle(t *testing.T) {
+	straddle := zLoop(9.0, 9.8, 10.4, 11.0) // crosses z=10
+	if _, ok := wallEntryLoops(wallBand(), []geom.Polyline{straddle}); ok {
+		t.Error("wallEntryLoops accepted a cap-straddling loop; want decline (rim-crossing case)")
+	}
+}

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -238,7 +238,7 @@ var curvedExactPaths = []func(PartFeatureOperation, *topo.Body, *topo.Body, *dia
 	curvedCrossingIntersect, curvedSteinmetzIntersect, curvedConeCylinderIntersect, curvedConeConeIntersect,
 	curvedPartialIntersect,
 	// Cut — [P] the drill through-hole (curved-on-planar), the rest [T] transversal.
-	curvedCylindricalHoleCut, curvedFlatSubtract, curvedPartialCut, curvedSteinmetzCut, curvedConeCylinderCut, curvedConeConeCut, curvedCapCrossCut, curvedRimCrossCut, curvedTwoCapCrossCut, curvedCrossingCut,
+	curvedCylindricalHoleCut, curvedFlatSubtract, curvedPartialCut, curvedSteinmetzCut, curvedConeCylinderCut, curvedConeConeCut, curvedCapCrossCut, curvedRimCrossCut, curvedTwoCapCrossCut, curvedConeCapCrossCut, curvedCrossingCut,
 	// Join — [D] coaxial (degenerate overlap), [P] boss (curved-on-planar), the rest [T] transversal.
 	curvedCoaxialJoin, curvedCylinderBossJoin, curvedPartialJoin, curvedConeCylinderJoin, curvedConeConeJoin, curvedCrossingJoin, curvedSteinmetzJoin,
 }

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -72,9 +72,10 @@ var (
 	curvedConeCylinderCut    = gatedCurved(Cut, brep.ConeCylinderCutGeneral)
 	curvedConeConeCut        = gatedCurved(Cut, brep.ConeConeCutGeneral)
 	curvedCrossingCut        = gatedCurved(Cut, brep.CrossingCylinderCutGeneral)
-	curvedCapCrossCut        = gatedCurved(Cut, brep.CapCrossingCutGeneral)    // oblique tool exits one cap, ellipse inside rim (#1724)
-	curvedRimCrossCut        = gatedCurved(Cut, brep.RimCrossingCutGeneral)    // oblique tool exits one cap, ellipse crosses rim (#1724 slice 2)
-	curvedTwoCapCrossCut     = gatedCurved(Cut, brep.TwoCapCrossingCutGeneral) // steep tool exits BOTH caps, wall intact (#1724)
+	curvedCapCrossCut        = gatedCurved(Cut, brep.CapCrossingCutGeneral)     // oblique tool exits one cap, ellipse inside rim (#1724)
+	curvedRimCrossCut        = gatedCurved(Cut, brep.RimCrossingCutGeneral)     // oblique tool exits one cap, ellipse crosses rim (#1724 slice 2)
+	curvedTwoCapCrossCut     = gatedCurved(Cut, brep.TwoCapCrossingCutGeneral)  // steep tool exits BOTH caps, wall intact (#1724)
+	curvedConeCapCrossCut    = gatedCurved(Cut, brep.ConeCapCrossingCutGeneral) // oblique CONE tool exits one cap, ellipse inside rim (#1724)
 
 	// Join — the union, keeping the analytic wall where the operands' faces are coincident or breached.
 	curvedCoaxialJoin      = gatedCurved(Join, withoutRecorder(brep.CoaxialCylinderUnion)) // coaxial equal-radius cylinders

--- a/kernel/ops/boolean_csg_demotion_test.go
+++ b/kernel/ops/boolean_csg_demotion_test.go
@@ -100,6 +100,7 @@ func curvedExactCases() []curvedExactCase {
 		{"cap-crossing cylinder − (exits top cap)", ops.Cut, capCrossingCutBodies},
 		{"rim-crossing cylinder − (exit ellipse crosses top rim)", ops.Cut, rimCrossingCutBodies},
 		{"two-cap-exit cylinder − (steep tool exits both caps)", ops.Cut, twoCapCrossingCutBodies},
+		{"cone-cap-crossing − (oblique cone tool exits top cap)", ops.Cut, coneCapCrossingCutBodies},
 		{"equal-radius Steinmetz ∩", ops.Intersect, func(t *testing.T) (*topo.Body, *topo.Body) {
 			return demoCyl(t, math.P3(-6, 0, 0), math.V3(1, 0, 0), 3, 12), demoCyl(t, math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
 		}},
@@ -345,6 +346,18 @@ func twoCapCrossingCutBodies(t *testing.T) (*topo.Body, *topo.Body) {
 	ux, uz := stdmath.Sin(th), stdmath.Cos(th)
 	return demoCyl(t, math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 10),
 		demoCyl(t, math.P3(-2.416, 0, -2.518), math.V3(math.Scalar(ux), 0, math.Scalar(uz)), 0.7, 16)
+}
+
+// coneCapCrossingCutBodies is the cone-tool cap-crossing fixture (#1724): the r=3 h=10 target and an oblique
+// FRUSTUM tool (rBase 0.9 → rTop 0.6) whose 45° slender wall enters the target wall once and EXITS the top
+// cap through an ellipse strictly inside the rim — the cone analogue of slice 1 (ConeCapCrossingCutGeneral).
+// The frustum is long enough that its wall also grazes the target's INFINITE surface past the cap; the
+// recognizer drops that phantom loop (wallEntryLoops) and keeps the single real wall-entry hole.
+func coneCapCrossingCutBodies(t *testing.T) (*topo.Body, *topo.Body) {
+	s := 1 / stdmath.Sqrt2
+	top := math.P3(math.Scalar(-6.5+16*s), 0, math.Scalar(2+16*s))
+	return demoCyl(t, math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 10),
+		demoCone(t, math.P3(-6.5, 0, 2), top, 0.9, 0.6)
 }
 
 func demoCyl(t *testing.T, base math.Point3, axis math.Vector3, r, h float64) *topo.Body {

--- a/kernel/ops/cone_cap_crossing_certification_test.go
+++ b/kernel/ops/cone_cap_crossing_certification_test.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Cone-tool cap-crossing certification (EPIC Oblikovati/Oblikovati#1724, ADR-0046). Slice 1 certified an
+// oblique CYLINDER tool that enters the target wall once and exits ONE cap through an ellipse strictly inside
+// the rim. A conical tool (a countersink / tapered pin) makes the SAME arrangement; only the analytics differ
+// — the wall entry is the cone∩cylinder imprint and the exit section is the cone∩plane ellipse — so the whole
+// operand-generic builder (buildCapCrossCut) is reused. Certified NOT by internal manifold/volume nets alone
+// but against an INDEPENDENT moment set from OpenCASCADE (gmsh occ.cut + occ.getMass exact B-rep moments,
+// experiments/occ-boolean-oracle/cone_cap_crossing_oracle.py): volume, area, centroid, face count, PLUS a
+// point-membership audit vs the analytic CSG predicate — the strong oracle that catches a right-volume-
+// wrong-shape build.
+
+// OCC ground truth for the cone-tool fixture, from experiments/occ-boolean-oracle/cone_cap_crossing_oracle.py
+// (occ.cut of the target cylinder and the frustum tool; occ.getMass / occ.getCenterOfMass exact moments).
+const (
+	occConeCapVol   = 271.6205285
+	occConeCapArea  = 269.5473548
+	occConeCapCx    = 0.0340767
+	occConeCapCy    = 0.0
+	occConeCapCz    = 4.8934008
+	occConeCapFaces = 4 // wall (holed) + top cap (elliptical hole) + bottom cap + cone tunnel
+)
+
+// coneCapFixture builds the certified cone-tool pair: r=3 h=10 target and an oblique frustum (rBase 0.9 →
+// rTop 0.6) at 45° whose slender wall enters the wall once and exits the top cap. Kept in lockstep with
+// experiments/occ-boolean-oracle/cone_cap_crossing_oracle.py and coneCapCrossingCutBodies.
+func coneCapFixture(t *testing.T) (target, tool *topo.Body) {
+	t.Helper()
+	s := 1 / stdmath.Sqrt2
+	tg, err := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 10)
+	if err != nil {
+		t.Fatalf("target SolidCylinder: %v", err)
+	}
+	top := math.P3(math.Scalar(-6.5+16*s), 0, math.Scalar(2+16*s))
+	tl, err := brep.SolidCylinderCone(math.P3(-6.5, 0, 2), top, 0.9, 0.6, "cone")
+	if err != nil {
+		t.Fatalf("tool SolidCylinderCone: %v", err)
+	}
+	return tg, tl
+}
+
+func TestConeCapCrossingCutIsWatertightAndValid(t *testing.T) {
+	target, tool := coneCapFixture(t)
+	res, err := Boolean(Cut, target, tool)
+	if err != nil {
+		t.Fatalf("Boolean(Cut): %v", err)
+	}
+	if r := Validate(res); !r.Valid {
+		t.Errorf("cone-cap cut is not a valid solid: manifold=%v closed=%v orient=%v euler=%v issues=%v",
+			r.Manifold, r.Closed, r.OrientationOK, r.EulerConsistent, r.Issues)
+	}
+	mesh, _ := TessellateBody(res, capCertQuality())
+	if free := freeEdgeCount(mesh); free != 0 {
+		t.Errorf("cone-cap cut tessellated with %d free edges; want 0 — a cross-face crack at the cap ellipse", free)
+	}
+	if folds := FoldEdgeCount(mesh); folds != 0 {
+		t.Errorf("cone-cap cut mesh has %d fold edges; want 0", folds)
+	}
+}
+
+func TestConeCapCrossingCutMomentsMatchOCC(t *testing.T) {
+	target, tool := coneCapFixture(t)
+	res, err := Boolean(Cut, target, tool)
+	if err != nil {
+		t.Fatalf("Boolean(Cut): %v", err)
+	}
+	if n := len(res.Faces()); n != occConeCapFaces {
+		t.Errorf("cone-cap cut has %d faces; want %d (holed wall + holed top cap + bottom cap + tunnel)", n, occConeCapFaces)
+	}
+	gp := BodyGeometryProperties(res, capCertQuality())
+	if rel := stdmath.Abs(gp.Volume-occConeCapVol) / occConeCapVol; rel > 0.006 {
+		t.Errorf("volume %.4f vs OCC %.4f (rel %.4f > 0.006) — beyond the SSI-imprint facet deficit", gp.Volume, occConeCapVol, rel)
+	}
+	if rel := stdmath.Abs(gp.Area-occConeCapArea) / occConeCapArea; rel > 0.004 {
+		t.Errorf("area %.4f vs OCC %.4f (rel %.4f > 0.004)", gp.Area, occConeCapArea, rel)
+	}
+	occCentroid := math.P3(occConeCapCx, occConeCapCy, occConeCapCz)
+	if d := float64(gp.Centroid.DistanceTo(occCentroid)); d > 0.05 {
+		t.Errorf("centroid (%.4f,%.4f,%.4f) vs OCC (%.4f,%.4f,%.4f): distance %.4f > 0.05",
+			gp.Centroid.X, gp.Centroid.Y, gp.Centroid.Z, occConeCapCx, occConeCapCy, occConeCapCz, d)
+	}
+}
+
+// TestConeCapCrossingCutMembershipMatchesCSG is the strong shape oracle: it samples an interior grid and
+// asserts the built solid's inside/outside agrees with the analytic CSG predicate target\tool everywhere
+// away from the boundary — so a right-volume-but-wrong-shape build (correct moments, displaced material)
+// still fails. The tool is a FRUSTUM: its radius tapers linearly along the axis, so the membership predicate
+// interpolates rBase→rTop by the point's fractional axial position.
+func TestConeCapCrossingCutMembershipMatchesCSG(t *testing.T) {
+	target, tool := coneCapFixture(t)
+	res, err := Boolean(Cut, target, tool)
+	if err != nil {
+		t.Fatalf("Boolean(Cut): %v", err)
+	}
+	s := 1 / stdmath.Sqrt2
+	base := math.P3(-6.5, 0, 2)
+	dir := math.V3(math.Scalar(s), 0, math.Scalar(s))
+	const rBase, rTop, coneLen = 0.9, 0.6, 16.0
+	inTarget := func(p math.Point3) bool {
+		return stdmath.Hypot(float64(p.X), float64(p.Y)) <= 3 && p.Z >= 0 && p.Z <= 10
+	}
+	axialOf := func(p math.Point3) float64 { return float64(base.VectorTo(p).Dot(dir)) }
+	radiusAt := func(ax float64) float64 { return rBase + (rTop-rBase)*ax/coneLen }
+	radialOf := func(p math.Point3, ax float64) float64 {
+		return float64(base.VectorTo(p).Sub(dir.Scale(math.Scalar(ax))).Length())
+	}
+	inTool := func(p math.Point3) bool {
+		ax := axialOf(p)
+		if ax < 0 || ax > coneLen {
+			return false
+		}
+		return radialOf(p, ax) <= radiusAt(ax)
+	}
+	const shell = 0.15
+	nearSurface := func(p math.Point3) bool {
+		rWall := stdmath.Abs(stdmath.Hypot(float64(p.X), float64(p.Y)) - 3)
+		ax := axialOf(p)
+		rCone := stdmath.Abs(radialOf(p, ax) - radiusAt(ax))
+		zCap := stdmath.Min(stdmath.Abs(float64(p.Z)), stdmath.Abs(float64(p.Z)-10))
+		return rWall < shell || rCone < shell || zCap < shell
+	}
+	mesh, _ := TessellateBody(res, DefaultQuality())
+	mismatches := 0
+	const n = 60
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			for k := 0; k < n; k++ {
+				p := math.P3(math.Scalar(-3+6*(float64(i)+0.5)/n), math.Scalar(-3+6*(float64(j)+0.5)/n), math.Scalar(10*(float64(k)+0.5)/n))
+				if nearSurface(p) {
+					continue
+				}
+				if pointInMesh(mesh, p) != (inTarget(p) && !inTool(p)) {
+					mismatches++
+				}
+			}
+		}
+	}
+	if mismatches > 0 {
+		t.Errorf("membership audit: %d interior points disagree with target\\tool (#1724 cone-cap)", mismatches)
+	}
+}

--- a/kernel/ops/testdata/occ_boolean_oracle.json
+++ b/kernel/ops/testdata/occ_boolean_oracle.json
@@ -49,5 +49,6 @@
   "torus − box (axis-∥ near-pinch large oval)": 280.2555295,
   "cap-crossing cylinder − (exits top cap)": 266.6720995,
   "rim-crossing cylinder − (exit ellipse crosses top rim)": 263.6617744,
-  "two-cap-exit cylinder − (steep tool exits both caps)": 266.3615948
+  "two-cap-exit cylinder − (steep tool exits both caps)": 266.3615948,
+  "cone-cap-crossing − (oblique cone tool exits top cap)": 271.6205285
 }


### PR DESCRIPTION
## What

Widens the curved-boolean **cap-crossing** recognizer to accept an oblique **CONE (frustum) tool** that enters the target cylinder's wall once and exits **one planar cap** through an ellipse strictly inside the rim — the cone analogue of slice 1. Previously this cut fell to the faceted CSG fallback.

The full result assembly (holed wall + ellipse-holed exit cap + reversed cone tunnel) is **reused** from slice 1 via the operand-generic `buildCapCrossCut`; only the recognizer differs. The wall entry is the cone∩cylinder SSI imprint; the exit section is the exact cone∩plane ellipse (`geom.IntersectSurfacesAnalytic`) — no geometry re-derived.

## Why the cone needs one new gate

A long frustum's wall meets the target cylinder's **infinite-surface** SSI trace both where it truly enters the finite wall **and** where it would exit *past* the cap — a phantom loop lying entirely beyond the exit-cap plane. `wallEntryLoops` partitions the traced loops against the target's cap band: it keeps the single real in-band wall-entry hole, drops the phantom, and **declines** (to the recorded CSG fallback) if any loop *straddles* a cap level — that's a rim-crossing this interior-exit slice does not build.

## Certification (vs OpenCASCADE)

Certified against gmsh `occ.cut` exact BRepGProp moments (`experiments/occ-boolean-oracle/cone_cap_crossing_oracle.py`), plus a 60³ **point-membership audit** vs the analytic frustum CSG predicate (the right-volume-wrong-shape gate):

| metric | ours | OCC | Δ |
|---|---|---|---|
| volume | 270.566 | 271.6205 | 0.39% (chord deficit) |
| area | 269.439 | 269.5474 | 0.04% |
| centroid | (0.0339, 0.0003, 4.8929) | (0.0341, 0, 4.8934) | 6e-4 |
| faces | 4 | 4 | — |

The 0.39% volume gap is the universal SSI-imprint polyline **chord deficit**, not a shape error — monotone-convergent to OCC (0.75 → 0.39 → 0.16 → 0.12% as the chord tolerance tightens). Registered in the exactness + OCC-volume guards, and rendered **live** through the real feature pipeline (top cap holed by the exit ellipse; oblique tapered tunnel carved through the wall).

## Scope

Refs #1724 — this lands the cone-tool cap-crossing slice. The last remaining EPIC item, **partial-rim side trim**, is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)