### PR TITLE
fix(ops): CSG fallback panics on an orphan vertex

### DIFF
--- a/kernel/ops/csg_pinch.go
+++ b/kernel/ops/csg_pinch.go
@@ -39,6 +39,12 @@ func splitPinchedVertices(verts []math.Point3, faces [][3]int) []math.Point3 {
 // edges and moves every fan beyond the first onto a fresh duplicate vertex.
 func splitVertexFans(verts []math.Point3, faces [][3]int, v int, inc []int) []math.Point3 {
 	fans := vertexFans(faces, v, inc)
+	// An ORPHAN vertex (a coordinate in verts referenced by no triangle — CSG clipping can leave one)
+	// has no incident fans, and a clean manifold vertex has exactly one; neither needs splitting. Guard
+	// the fans[1:] slice so an orphan does not panic the last-resort CSG fallback (#1693 regression).
+	if len(fans) < 2 {
+		return verts
+	}
 	for _, fan := range fans[1:] {
 		nv := len(verts)
 		verts = append(verts, verts[v])

--- a/kernel/ops/csg_pinch_test.go
+++ b/kernel/ops/csg_pinch_test.go
@@ -48,3 +48,22 @@ func TestCSGCageSplitsPinchedVertex(t *testing.T) {
 		t.Errorf("body has %d vertices, want 8 (7 welded + one coincident duplicate at the contact)", nv)
 	}
 }
+
+// TestSplitPinchedVerticesToleratesOrphanVertex pins the fix for a panic in the last-resort CSG fallback:
+// dropDegenerate/dedupTriangles inside trianglesToBody can strip the last triangle referencing a welded
+// vertex, orphaning that coordinate in verts. splitPinchedVertices then builds an empty incident-face list
+// for it, so vertexFans returns no fans and the fans[1:] slice paniced ("slice bounds out of range [1:0]").
+// A chained curved cut (a second Cut on an already-cut, partial-rim body) declines to CSG and hit exactly
+// this — the fallback must decline gracefully, never crash (#1693).
+func TestSplitPinchedVerticesToleratesOrphanVertex(t *testing.T) {
+	// One triangle (verts 0,1,2) plus an ORPHAN vertex at index 3 that no face references.
+	verts := []math.Point3{math.P3(0, 0, 0), math.P3(1, 0, 0), math.P3(0, 1, 0), math.P3(5, 5, 5)}
+	faces := [][3]int{{0, 1, 2}}
+	got := splitPinchedVertices(verts, faces) // must not panic on the orphan's empty fan list
+	if len(got) != 4 {
+		t.Errorf("orphan-vertex split changed vertex count to %d; want 4 (no split — the orphan and the clean triangle both need none)", len(got))
+	}
+	if faces[0] != [3]int{0, 1, 2} {
+		t.Errorf("clean triangle was rewritten to %v; want [0 1 2]", faces[0])
+	}
+}


### PR DESCRIPTION
## What

The last-resort **CSG fallback** could **panic** (`slice bounds out of range [1:0]`), crashing the whole boolean.

## Root cause

`trianglesToBody` welds the CSG-clip triangle soup, then `dedupTriangles`/`dropDegenerate` can strip the last triangle referencing a welded vertex — orphaning that coordinate in the vertex slice with no incident face. `splitPinchedVertices` then built an empty incident-face list for it → `vertexFans` returned zero fans → `fans[1:]` panicked.

Because this is the safety net **every declining curved boolean lands on**, a crash here turns an *intended observable decline* into a hard failure. Found via a chained curved cut (a second `Cut` on an already-cut, partial-rim body): it correctly declines the exact path, falls to CSG, and hit the panic.

## Fix

Guard the `fans[1:]` slice — an orphan vertex has zero fans and a clean manifold vertex has one; neither needs splitting. The regression test drives an orphan coordinate through `splitPinchedVertices` directly (it panicked before this change).

Scope note: the raw CSG mesh on such hard chained inputs is faceted and not always watertight — that is the pre-existing CSG-fidelity limitation (#1693 lineage), separate from this crash. This PR only makes the fallback **decline gracefully instead of crashing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)