### PR TITLE
Partial-rim second cut: analytic disjoint sub-family (#1732)

### DIFF
--- a/kernel/brep/curved_arrangement_golden_test.go
+++ b/kernel/brep/curved_arrangement_golden_test.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep_test
+
+import (
+	stdmath "math"
+	"runtime"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Characterization golden for the shared curved-boolean (u,v)-arrangement core (#1732, Slice 0).
+//
+// This is the REGRESSION GATE for the partial-rim side-trim work (issue Oblikovati/Oblikovati#1732):
+// composing a prior section-arc boundary with a new cut requires generalizing the arrangement machinery
+// EVERY curved boolean shares — trimByImprint → assembleSegments → arrangeBand → keptCells — plus adding
+// cutCylinderOperand to the ruledOperandOf dispatch. Both changes touch code the four certified #1724
+// cap-crossing slices and the whole ruled/solid cut family depend on. This golden captures their output
+// on develop BEFORE any change so the bare-band path stays BYTE-IDENTICAL through the refactor: the new
+// operand and the constraint-edge ingest must be strictly ADDITIVE, engaged only for an already-cut
+// target, so every fixture here — none of which is partial-rim — must come out unchanged.
+//
+// TWO TIERS, because the fixtures are faceted (cos/sin coordinates) and this job runs on ubuntu, macOS AND
+// Windows (ci.yml Tier-1 matrix):
+//   - structSig (V/E/F/chi/free-edge count) is integer-valued and platform-STABLE — the cross-platform hard
+//     gate that catches a lost/gained cell, a merged face, or a torn boundary anywhere.
+//   - sewSignature (the SHA over sorted reference keys, ADR-0043 naming) is coordinate-fragile: a ULP-level
+//     divergence in a faceted rim can flip a same-parent rank and thus a key, the exact sensitivity that
+//     failed a macOS golden in #1726. It is the byte-identical NAMING-drift gate and runs on Linux ONLY,
+//     where the capture was taken; it is skipped elsewhere rather than allowed to flake CI red.
+//
+// sewSignature is shared with boolean_sew_golden_test.go (same brep_test package).
+
+// structSig is the platform-stable structural fingerprint: counts only, no coordinates.
+func structSig(b *topo.Body) string {
+	free := 0
+	for _, e := range b.Edges() {
+		if len(e.Faces()) != 2 {
+			free++
+		}
+	}
+	return sprintfSig(len(b.Vertices()), len(b.Edges()), len(b.Faces()), b.EulerCharacteristic(), free)
+}
+
+func sprintfSig(v, e, f, chi, free int) string {
+	return "V" + itoa(v) + "E" + itoa(e) + "F" + itoa(f) + "chi" + itoa(chi) + "free" + itoa(free)
+}
+
+// itoa avoids fmt in the hot signature path and keeps the format explicit (negative chi allowed).
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+// arrangementGoldenCase is one curved boolean whose exact output must survive the #1732 refactor.
+type arrangementGoldenCase struct {
+	name       string
+	wantStruct string // asserted on every OS
+	wantKeys   string // asserted on Linux only (reference-key SHA)
+	make       func() (*topo.Body, bool)
+}
+
+func cylZ(z, r, h float64) *topo.Body {
+	b, _ := brep.SolidCylinder(math.P3(0, 0, math.Scalar(z)), math.V3(0, 0, 1), math.Scalar(r), math.Scalar(h))
+	return b
+}
+
+func cylX(x, r, h float64) *topo.Body {
+	b, _ := brep.SolidCylinder(math.P3(math.Scalar(x), 0, 0), math.V3(1, 0, 0), math.Scalar(r), math.Scalar(h))
+	return b
+}
+
+// oblique45 builds the certified 45° cylinder tool (r0.9, 16-gon) at the given base x — slices 1/2's fixture.
+func oblique45(baseX float64) *topo.Body {
+	s := 1 / stdmath.Sqrt2
+	b, _ := brep.SolidCylinder(math.P3(math.Scalar(baseX), 0, 2), math.V3(math.Scalar(s), 0, math.Scalar(s)), 0.9, 16)
+	return b
+}
+
+func arrangementGoldenCases() []arrangementGoldenCase {
+	target := func() *topo.Body { return cylZ(0, 3, 10) } // the r=3 h=10 cap-crossing target
+	return []arrangementGoldenCase{
+		// --- solid-cut family (rides trimByImprint + ruledOperandOf directly) ---
+		{"crossing-cylinder", "V4E5F4chi0free1", "V4E5F4chi0-daf5165df038e441", func() (*topo.Body, bool) {
+			return brep.CrossingCylinderCutGeneral(cylZ(-6, 3, 12), cylX(-6, 1.5, 12), nil)
+		}},
+		{"cone-cone-cut", "V4E5F4chi0free1", "V4E5F4chi0-62b46082d3a6e2e7", func() (*topo.Body, bool) {
+			fat, _ := brep.SolidCylinderCone(math.P3(0, 0, -6), math.P3(0, 0, 6), 2, 4, "fat")
+			rod, _ := brep.SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 0.8, 1.5, "rod")
+			return brep.ConeConeCutGeneral(fat, rod, nil)
+		}},
+		{"cone-cylinder-cut", "V4E5F4chi0free1", "V4E5F4chi0-1f6dd86ad3e40a48", func() (*topo.Body, bool) {
+			cyl := cylZ(-6, 3, 12)
+			cone, _ := brep.SolidCylinderCone(math.P3(-6, 0, 0), math.P3(6, 0, 0), 1, 2.5, "cone")
+			return brep.ConeCylinderCutGeneral(cyl, cone, nil)
+		}},
+		{"steinmetz-cut", "V4E6F6chi2free0", "V4E6F6chi2-9ebec3decb26122b", func() (*topo.Body, bool) {
+			return brep.SteinmetzCutGeneral(cylX(-6, 3, 12), cylZ(-6, 3, 12), nil)
+		}},
+		{"partial-penetration", "V4E5F5chi2free1", "V4E5F5chi2-324d24b080bb6f9b", func() (*topo.Body, bool) {
+			return brep.PartialPenetrationCutGeneral(cylZ(-6, 3, 12), cylX(-6, 1.5, 6), nil)
+		}},
+		// --- the four certified #1724 cap-crossing slices (ride ruledOperandOf dispatch) ---
+		{"cap-crossing-interior", "V4E5F4chi0free1", "V4E5F4chi0-5970beadaf185034", func() (*topo.Body, bool) {
+			return brep.CapCrossingCutGeneral(target(), oblique45(-6.5), nil)
+		}},
+		{"rim-crossing", "V4E5F4chi0free0", "V4E5F4chi0-5015ac6e262cd9e0", func() (*topo.Body, bool) {
+			return brep.RimCrossingCutGeneral(target(), oblique45(-5.6), nil)
+		}},
+		{"two-cap-tunnel", "V4E5F4chi0free1", "V4E5F4chi0-0adcb840d5945a7f", func() (*topo.Body, bool) {
+			th := 20.0 * stdmath.Pi / 180
+			ux, uz := stdmath.Sin(th), stdmath.Cos(th)
+			tool, _ := brep.SolidCylinder(math.P3(-2.416, 0, -2.518), math.V3(math.Scalar(ux), 0, math.Scalar(uz)), 0.7, 16)
+			return brep.TwoCapCrossingCutGeneral(target(), tool, nil)
+		}},
+		{"cone-cap-crossing", "V4E5F4chi0free1", "V4E5F4chi0-5308a224b7afb0c5", func() (*topo.Body, bool) {
+			s := 1 / stdmath.Sqrt2
+			top := math.P3(math.Scalar(-6.5+16*s), 0, math.Scalar(2+16*s))
+			tool, _ := brep.SolidCylinderCone(math.P3(-6.5, 0, 2), top, 0.9, 0.6, "cone")
+			return brep.ConeCapCrossingCutGeneral(target(), tool, nil)
+		}},
+	}
+}
+
+func TestCurvedArrangementGolden(t *testing.T) {
+	for _, c := range arrangementGoldenCases() {
+		t.Run(c.name, func(t *testing.T) {
+			b, ok := c.make()
+			if !ok || b == nil {
+				t.Fatalf("%s: builder declined (ok=%v nil=%v) — fixture no longer classifies", c.name, ok, b == nil)
+			}
+			gotStruct := structSig(b)
+			if c.wantStruct == "" {
+				t.Fatalf("%s: CAPTURE struct=%q keys=%q", c.name, gotStruct, sewSignature(b))
+			}
+			if gotStruct != c.wantStruct {
+				t.Fatalf("%s: structural signature drifted\n  got  %s\n  want %s", c.name, gotStruct, c.wantStruct)
+			}
+			if runtime.GOOS != "linux" {
+				return // reference-key hash is Linux-anchored (faceted-coordinate ULP fragility, #1726)
+			}
+			if got := sewSignature(b); got != c.wantKeys {
+				t.Fatalf("%s: reference-key signature drifted (naming/ADR-0043)\n  got  %s\n  want %s", c.name, got, c.wantKeys)
+			}
+		})
+	}
+}

--- a/kernel/brep/curved_general_ruled_cutjoin.go
+++ b/kernel/brep/curved_general_ruled_cutjoin.go
@@ -35,6 +35,10 @@ type ruledOperand struct {
 	// (isB marks this operand as the boolean's B). It builds the same ruledUV the split and the cap-clearance
 	// check consume, so the cone/cylinder distinction lives only here.
 	newUV func(op Op, isB bool, other func(math.Point3) bool) ruledUV
+	// splitCut, when non-nil, overrides split for an ALREADY-CUT side (the partial-rim second cut, #1732): it
+	// builds a cutCylinderUV that composes the surviving prior boundary as constraint edges and runs the
+	// disjoint gate, declining any config outside the disjoint sub-family. nil for a bare side.
+	splitCut func(imprint []geom.Curve3, op Op, isB bool, other func(math.Point3) bool) ([]curvedFace, bool)
 }
 
 // cylinderOperand resolves a bare cylinder body into a ruledOperand, or ok=false when it has no cylinder side
@@ -78,6 +82,9 @@ func ruledOperandOf(b *topo.Body) (ruledOperand, bool) {
 // returns the kept curved faces (ok=false when the split fails or keeps nothing). The cone/cylinder UV frame
 // is built by newUV; the predicate binds the seam-shifted receiver via ruledSolidMaterial (#1403).
 func (o ruledOperand) split(imprint []geom.Curve3, op Op, isB bool, other func(math.Point3) bool) ([]curvedFace, bool) {
+	if o.splitCut != nil {
+		return o.splitCut(imprint, op, isB, other)
+	}
 	c := o.newUV(op, isB, other)
 	return keptOrNone(trimByImprint(&c, o.face, o.surface, imprint, ruledSolidMaterial(&c)))
 }

--- a/kernel/brep/curved_halfspace_cut_cylinder_gate.go
+++ b/kernel/brep/curved_halfspace_cut_cylinder_gate.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"sort"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Disjoint gate for the partial-rim second cut (#1732). The first shippable sub-family is the DISJOINT case:
+// the new SSI imprint lies entirely in the still-full part of the band, clear of the prior notch, so the
+// slice-1 builder reuses without solving 3-curve arrangement vertices. disjointFromPrior decides ship vs
+// decline; every non-disjoint config (imprint crossing the notch, tangent to it, enclosing it, wrapping the
+// whole azimuth) declines to CSG, which the caller records observably.
+//
+// The test is deliberately small because belowPrior over the imprint samples already subsumes crossing AND
+// notch-containment AND notch-enclosure: an imprint whose every point survived the first cut cannot cross into
+// the removed notch, lie inside it, or surround it (the notch is above the surviving boundary). What remains is
+// a 3D near-approach margin (a tangent imprint stays technically below but must decline before the arrangement
+// welds two within-tol boundaries) and the contractible/seam-clear precondition.
+
+// disjointMarginRel scales the near-approach margin to the rim radius, floored well above the weld grid so a
+// grazing imprint declines before the arrangement can merge it with the prior boundary (#1732).
+const disjointMarginRel = 1e-3
+
+// minWrapGap: the new imprint must leave at least this azimuthal gap (radians); a loop covering the whole
+// circle is non-contractible, so (u,v) containment is undefined and it is out of the disjoint sub-family.
+const minWrapGap = 0.05
+
+// priorSampleCount samples each prior edge for the 3D near-approach test — dense enough that the chord error is
+// far below the margin.
+const priorSampleCount = 64
+
+// disjointFromPrior reports whether the new imprint is disjoint from the surviving prior boundary — the ship
+// condition for the partial-rim second cut. It assumes placeSeams has run (u is seam-relative).
+func (c *cutCylinderUV) disjointFromPrior(imprint []geom.Curve3) bool {
+	impUV := c.imprintUV(imprint)
+	if len(impUV) == 0 || c.imprintWrapsAzimuth(impUV) {
+		return false
+	}
+	prior := c.priorUVSegments()
+	for _, s := range impUV {
+		if !belowPrior(prior, s.a) || !belowPrior(prior, s.b) {
+			return false // the imprint enters the removed notch (crosses it, lies in it, or surrounds it)
+		}
+	}
+	return c.clearOfPrior(imprint)
+}
+
+// imprintUV samples the new imprint into seam-relative (u,v) segments.
+func (c *cutCylinderUV) imprintUV(imprint []geom.Curve3) []uvSeg {
+	var out []uvSeg
+	for _, cv := range imprint {
+		out = append(out, c.sampleImprintUV(cv)...)
+	}
+	return out
+}
+
+// imprintWrapsAzimuth reports whether the imprint covers the whole circle with no gap >= minWrapGap — a
+// non-contractible belt cut, outside the disjoint sub-family.
+func (c *cutCylinderUV) imprintWrapsAzimuth(impUV []uvSeg) bool {
+	us := make([]float64, 0, len(impUV))
+	for _, s := range impUV {
+		us = append(us, float64(s.a.X))
+	}
+	return widestGap(us) < minWrapGap
+}
+
+// clearOfPrior reports whether every sampled new-imprint point is at least the model-scaled margin (3D) from
+// the prior boundary — so a tangent or near-coincident imprint declines before the arrangement welds the two.
+func (c *cutCylinderUV) clearOfPrior(imprint []geom.Curve3) bool {
+	prior3D := c.priorSegments3D()
+	margin := stdmath.Max(disjointMarginRel*c.band.rBot, 1e3*planarStitchGrid)
+	for _, cv := range imprint {
+		for i := 0; i <= imprintSampleCount; i++ {
+			if minDistToSegs3D(cv.PointAt(float64(i)/imprintSampleCount), prior3D) < margin {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// priorSegments3D samples the prior loop into 3D segments for the near-approach test.
+func (c *cutCylinderUV) priorSegments3D() [][2]math.Point3 {
+	var out [][2]math.Point3
+	for _, e := range c.prior.edges {
+		prev := e.curve.PointAt(e.t0)
+		for i := 1; i <= priorSampleCount; i++ {
+			p := e.curve.PointAt(e.t0 + (e.t1-e.t0)*float64(i)/float64(priorSampleCount))
+			out = append(out, [2]math.Point3{prev, p})
+			prev = p
+		}
+	}
+	return out
+}
+
+// minDistToSegs3D is the minimum distance from p to any of the 3D segments.
+func minDistToSegs3D(p math.Point3, segs [][2]math.Point3) float64 {
+	best := stdmath.Inf(1)
+	for _, s := range segs {
+		if d := distPointSegment(p, s[0], s[1]); d < best {
+			best = d
+		}
+	}
+	return best
+}
+
+// widestGap returns the largest azimuthal gap (radians) between consecutive angles around the circle.
+func widestGap(angles []float64) float64 {
+	if len(angles) < 2 {
+		return 2 * stdmath.Pi
+	}
+	sort.Float64s(angles)
+	twoPi := 2 * stdmath.Pi
+	gap := angles[0] + twoPi - angles[len(angles)-1]
+	for i := 1; i < len(angles); i++ {
+		if g := angles[i] - angles[i-1]; g > gap {
+			gap = g
+		}
+	}
+	return gap
+}

--- a/kernel/brep/curved_halfspace_cut_cylinder_gate_test.go
+++ b/kernel/brep/curved_halfspace_cut_cylinder_gate_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// cylLoop builds a closed on-cylinder imprint loop from (azimuth θ, height z) vertices on the r=3 axis-z
+// cylinder — the synthetic second-cut imprint the disjoint gate classifies.
+func cylLoop(pts ...[2]float64) geom.Curve3 {
+	verts := make([]math.Point3, 0, len(pts)+1)
+	for _, p := range pts {
+		th, z := p[0], p[1]
+		verts = append(verts, math.P3(math.Scalar(3*stdmath.Cos(th)), math.Scalar(3*stdmath.Sin(th)), math.Scalar(z)))
+	}
+	verts = append(verts, verts[0]) // close the loop
+	pl, _ := geom.NewPolyline(verts)
+	return &pl
+}
+
+// TestDisjointFromPriorClassifies exercises the ship/decline gate for the partial-rim second cut against the
+// notched cylinder (first cut = the plane x+z<=9.5, notch floor at the front reaching z=6.5). The prior loop is
+// the notched top boundary.
+func TestDisjointFromPriorClassifies(t *testing.T) {
+	c := cutUVFromNotched(t)
+	pi := stdmath.Pi
+	cases := []struct {
+		name     string
+		imprint  geom.Curve3
+		disjoint bool
+	}{
+		// A small loop on the back wall, low, far from the front notch — the shippable disjoint case.
+		{"back-clear", cylLoop([2]float64{pi - 0.3, 2.5}, [2]float64{pi + 0.3, 2.5}, [2]float64{pi + 0.3, 3.5}, [2]float64{pi - 0.3, 3.5}), true},
+		// A front loop straddling the notch floor (z 5.5..7.5 at θ≈0, floor 6.5) — crosses into removed material.
+		{"crosses-notch", cylLoop([2]float64{-0.3, 5.5}, [2]float64{0.3, 5.5}, [2]float64{0.3, 7.5}, [2]float64{-0.3, 7.5}), false},
+		// A loop entirely inside the removed notch (z 7.5..9 at θ≈0) — nothing survived to cut.
+		{"in-notch", cylLoop([2]float64{-0.3, 7.5}, [2]float64{0.3, 7.5}, [2]float64{0.3, 9}, [2]float64{-0.3, 9}), false},
+		// A loop grazing the notch floor within the ~30µm margin (top vertex 10µm below the z=6.5 boundary point).
+		{"near-tangent", cylLoop([2]float64{0, 6.499}, [2]float64{-0.08, 6.35}, [2]float64{0.08, 6.35}), false},
+		// A full belt around the whole azimuth — non-contractible, outside the disjoint sub-family.
+		{"wraps-azimuth", cylLoop([2]float64{0, 3}, [2]float64{pi / 2, 3}, [2]float64{pi, 3}, [2]float64{3 * pi / 2, 3}), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := c.disjointFromPrior([]geom.Curve3{tc.imprint}); got != tc.disjoint {
+				t.Errorf("disjointFromPrior(%s) = %v, want %v", tc.name, got, tc.disjoint)
+			}
+		})
+	}
+}

--- a/kernel/brep/curved_halfspace_cut_cylinder_side.go
+++ b/kernel/brep/curved_halfspace_cut_cylinder_side.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Already-cut cylinder-side recognition for the partial-rim second cut (Oblikovati/Oblikovati#1732).
+// fullCylinderSideBand (curved_halfspace_cylinder_side.go) resolves a BARE side — two full-circle rims — for
+// cylinderOperand. After a first cut the side carries ONE surviving full-circle rim plus a NOTCHED boundary
+// (rim arcs + the first cut's section conic); it fails the two-circle test there and, until now, fell straight
+// to CSG. cutCylinderSideBand recognises that cut side so a second curved boolean can compose the prior
+// boundary as constraint edges instead. It is the deliberate mirror of fullCylinderSideBand: a bare side (two
+// full circles) is declined HERE and resolved by cylinderOperand, so the two partition cleanly.
+
+// priorTrimLoop is the surviving boundary of an earlier cut on a cylinder side: the ordered analytic edges of
+// the notched-rim loop (rim arcs + the first cut's section conic). A SECOND cut's (u,v) arrangement ingests
+// these as constraint edges so it composes with the first removal instead of re-including the notch (#1732).
+// Held apart from coneSideBand_ because the bare-band path has no prior boundary.
+type priorTrimLoop struct {
+	edges []loopEdge
+}
+
+// bandTopPadRel pads the recovered vMax as a fraction of the rim radius, floored well above the weld grid, so
+// the arrangement's artificial top edge sits clear of the prior loop's highest point. Without the pad an
+// oblique section conic's apex lands EXACTLY on v=vMax — a tangency arrangement vertex, the most fragile case —
+// instead of strictly inside the padded rectangle where the top edge bounds no real geometry (#1732).
+const bandTopPadRel = 1e-3
+
+// cutCylinderSideBand reports whether f is an ALREADY-CUT cylinder side — a geom.Cylinder bounded by exactly
+// ONE full-circle rim (the surviving bottom, the v=0 band anchor) plus a closed prior-trim loop — and returns
+// the cylinder, the band anchored on that bottom circle with vMax recovered from the prior loop's highest
+// surviving point, and the prior loop. A first cut that also severed the bottom rim leaves no full circle (or
+// leaves the surviving circle above the notch) and declines here: the v=0 anchor is load-bearing for
+// band-extent recovery (#1732).
+func cutCylinderSideBand(f curvedFace) (geom.Cylinder, coneSideBand_, priorTrimLoop, bool) {
+	cyl, ok := f.surface.(geom.Cylinder)
+	if !ok || len(f.loops) == 0 {
+		return geom.Cylinder{}, coneSideBand_{}, priorTrimLoop{}, false
+	}
+	anchor, prior, ok := anchorCircleAndPrior(f)
+	if !ok {
+		return geom.Cylinder{}, coneSideBand_{}, priorTrimLoop{}, false
+	}
+	axis := cyl.AxisDir.AsVector()
+	vMax, ok := recoverBandTop(prior, anchor.Center, axis, cyl.Radius)
+	if !ok {
+		return geom.Cylinder{}, coneSideBand_{}, priorTrimLoop{}, false
+	}
+	top := anchor.Center.TranslateBy(axis.Scale(math.Scalar(vMax)))
+	band := coneSideBand_{
+		bottom: anchor.Center, top: top, bottomCirc: anchor,
+		vMin: 0, vMax: vMax, rBot: cyl.Radius, rTop: cyl.Radius,
+	}
+	return cyl, band, prior, true
+}
+
+// anchorCircleAndPrior partitions a cut cylinder side's edges into its single surviving full-circle rim (the
+// anchor) and the prior-trim loop (everything else). Exactly one full circle is the cut-side signature: two is
+// a BARE side (fullCylinderSideBand's job), zero means the first cut removed the anchor rim — both decline.
+func anchorCircleAndPrior(f curvedFace) (geom.Circle, priorTrimLoop, bool) {
+	var circles []geom.Circle
+	var prior []loopEdge
+	for _, lp := range f.loops {
+		for _, e := range lp.edges {
+			if c, isFull := fullRimCircle(e); isFull {
+				circles = append(circles, c)
+				continue
+			}
+			prior = append(prior, e)
+		}
+	}
+	if len(circles) != 1 || len(prior) == 0 {
+		return geom.Circle{}, priorTrimLoop{}, false
+	}
+	return circles[0], priorTrimLoop{edges: prior}, true
+}
+
+// fullRimCircle reports whether an edge is a full-domain circle (a whole rim), returning that circle.
+func fullRimCircle(e loopEdge) (geom.Circle, bool) {
+	if c, ok := e.curve.(geom.Circle); ok && isFullDomain(e.t0, e.t1) {
+		return c, true
+	}
+	return geom.Circle{}, false
+}
+
+// recoverBandTop returns the padded vMax for a cut side's full-rectangle domain: the prior loop's highest
+// axial coordinate above the anchor, plus a model-scaled pad. It declines when the prior loop dips BELOW the
+// anchor (the surviving full circle is the top rim, not the bottom — the v=0 anchor is gone) or sits at/below
+// it (no band). Axial coordinate is distance along the axis from the anchor centre origin (#1732).
+func recoverBandTop(prior priorTrimLoop, origin math.Point3, axis math.Vector3, r float64) (float64, bool) {
+	lo, hi := priorAxialRange(prior, origin, axis)
+	pad := stdmath.Max(bandTopPadRel*r, 1e3*planarStitchGrid)
+	if lo < -pad || hi <= pad {
+		return 0, false
+	}
+	return hi + pad, true
+}
+
+// priorAxialRange returns the min and max axial coordinate (distance along axis from origin) over the prior loop,
+// sampled per edge. vMax is an artificial, PADDED domain bound — never emitted geometry — so a dense sample
+// whose chord error (sub-µm on a cm-scale conic at this density) is dwarfed by the pad is a rigorous upper
+// bound; no per-curve extremum solve is needed (#1732).
+func priorAxialRange(prior priorTrimLoop, origin math.Point3, axis math.Vector3) (lo, hi float64) {
+	lo, hi = stdmath.Inf(1), stdmath.Inf(-1)
+	const n = 64
+	for _, e := range prior.edges {
+		for i := 0; i <= n; i++ {
+			t := e.t0 + (e.t1-e.t0)*float64(i)/float64(n)
+			a := float64(origin.VectorTo(e.curve.PointAt(t)).Dot(axis))
+			lo, hi = stdmath.Min(lo, a), stdmath.Max(hi, a)
+		}
+	}
+	return lo, hi
+}

--- a/kernel/brep/curved_halfspace_cut_cylinder_side_test.go
+++ b/kernel/brep/curved_halfspace_cut_cylinder_side_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// firstCylinderFace returns the body's cylinder side as a curvedFace (the recogniser's input).
+func firstCylinderFace(t *testing.T, faces []curvedFace) curvedFace {
+	t.Helper()
+	for _, f := range faces {
+		if _, ok := f.surface.(geom.Cylinder); ok {
+			return f
+		}
+	}
+	t.Fatal("no cylinder side face on body")
+	return curvedFace{}
+}
+
+// notchedCylinder clips a cylinder with an oblique plane so ONE rim survives as a full circle and the other is
+// notched (a rim arc + a section ellipse) — the already-cut side cutCylinderSideBand must accept/decline on.
+// topNotch true clips the top rim (bottom survives = valid v=0 anchor); false clips the bottom (anchor gone).
+func notchedCylinder(t *testing.T, topNotch bool) []curvedFace {
+	t.Helper()
+	cyl, err := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 10)
+	if err != nil {
+		t.Fatalf("cylinder: %v", err)
+	}
+	var pl geom.Plane
+	if topNotch {
+		pl, _ = geom.NewPlane(math.P3(1.5, 0, 8), math.V3(1, 0, 1)) // wedge off the top, bottom disc intact
+	} else {
+		pl, _ = geom.NewPlane(math.P3(1.5, 0, 2), math.V3(1, 0, -1)) // wedge off the bottom, top disc intact
+	}
+	out, err := HalfSpaceCut(cyl, pl)
+	if err != nil {
+		t.Fatalf("half-space cut: %v", err)
+	}
+	return facesOfAny(out)
+}
+
+// TestCutCylinderSideBandAcceptsTopNotch: a cylinder whose top rim was clipped keeps a full bottom circle plus
+// a notched top loop, so cutCylinderSideBand accepts it, anchors v=0 on the bottom, and recovers vMax at the
+// surviving top-rim height (10) plus the pad — never the removed original height by assumption, but here the
+// top-rim arc survives so vMax rounds to ~10.
+func TestCutCylinderSideBandAcceptsTopNotch(t *testing.T) {
+	f := firstCylinderFace(t, notchedCylinder(t, true))
+	cyl, band, prior, ok := cutCylinderSideBand(f)
+	if !ok {
+		t.Fatal("top-notched cylinder side declined; want accepted with a v=0 bottom anchor")
+	}
+	if cyl.Radius != 3 {
+		t.Errorf("radius %v, want 3", cyl.Radius)
+	}
+	if band.vMin != 0 || band.rBot != 3 {
+		t.Errorf("band vMin=%v rBot=%v, want 0 and 3", band.vMin, band.rBot)
+	}
+	if band.vMax <= 10 || band.vMax > 10.1 {
+		t.Errorf("recovered vMax=%v, want just above the surviving top-rim height 10 (pad ~3e-3)", band.vMax)
+	}
+	if len(prior.edges) == 0 {
+		t.Error("prior trim loop is empty; want the notched-rim boundary (arc + section conic)")
+	}
+	if hasFullCircle(prior) {
+		t.Error("prior trim loop contains a full circle; the anchor rim must have been split out")
+	}
+}
+
+// TestCutCylinderSideBandDeclinesBottomNotch: clipping the BOTTOM rim leaves the surviving full circle at the
+// TOP with the notch below it, so the v=0 anchor is gone — cutCylinderSideBand must decline (band-extent
+// recovery has no bottom to anchor on).
+func TestCutCylinderSideBandDeclinesBottomNotch(t *testing.T) {
+	f := firstCylinderFace(t, notchedCylinder(t, false))
+	if _, _, _, ok := cutCylinderSideBand(f); ok {
+		t.Fatal("bottom-notched cylinder side accepted; the v=0 anchor rim was removed and must decline")
+	}
+}
+
+// TestCutCylinderSideBandDeclinesBareCylinder: a bare cylinder side has TWO full-circle rims — fullCylinderSideBand's
+// case — so cutCylinderSideBand declines it, keeping the two operands partitioned (no double classification).
+func TestCutCylinderSideBandDeclinesBareCylinder(t *testing.T) {
+	cyl, err := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 10)
+	if err != nil {
+		t.Fatalf("cylinder: %v", err)
+	}
+	f := firstCylinderFace(t, facesOfAny(cyl))
+	if _, _, _, ok := cutCylinderSideBand(f); ok {
+		t.Fatal("bare two-circle cylinder side accepted by cutCylinderSideBand; must be cylinderOperand's job")
+	}
+}
+
+// hasFullCircle reports whether the prior loop still carries a whole-rim circle (it must not — the anchor).
+func hasFullCircle(prior priorTrimLoop) bool {
+	for _, e := range prior.edges {
+		if _, ok := fullRimCircle(e); ok {
+			return true
+		}
+	}
+	return false
+}

--- a/kernel/brep/curved_halfspace_cut_cylinder_uv.go
+++ b/kernel/brep/curved_halfspace_cut_cylinder_uv.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// cutCylinderUV is the (u,v) model of an ALREADY-CUT cylinder side under a SECOND curved boolean (#1732). It
+// embeds the bare-side ruledUV for the geometry frame, seam, point3, re-emission and orientation, and adds the
+// surviving prior-trim loop. The second cut's arrangement subdivides by {new imprint, bottom rim, seam, PRIOR
+// loop} — the prior loop replaces the removed top rim as constraint edges — and a cell is kept iff it is BELOW
+// the prior boundary (survived the first cut) AND selected by the second cut. Only the segment assembly and
+// the material predicate differ from ruledUV; the bare-side path is untouched (its golden is byte-identical),
+// so the two compose cleanly.
+type cutCylinderUV struct {
+	ruledUV
+	prior priorTrimLoop
+}
+
+var _ uvSide = (*cutCylinderUV)(nil)
+
+// cutEdgeVSpanRel: an edge spanning more than this fraction of the band height is a first-cut section boundary
+// (v-varying), not a near-flat rim arc the seam may safely cross.
+const cutEdgeVSpanRel = 1e-3
+
+// newCutCylinderUVSolid frames an already-cut cylinder side cut by another SOLID's imprint: the ruledUV solid
+// frame over the recovered band, plus the prior loop the arrangement composes as constraint edges (#1732).
+func newCutCylinderUVSolid(cyl geom.Cylinder, band coneSideBand_, prior priorTrimLoop, op Op, isB bool, inside func(math.Point3) bool) cutCylinderUV {
+	return cutCylinderUV{ruledUV: newCylinderUVSolid(cyl, band, op, isB, inside), prior: prior}
+}
+
+// placeSeams moves the artificial azimuth seam clear of BOTH the new imprint and the prior loop's CUT boundary
+// (its v-varying edges — the first cut's section conic), so the seam crosses only the smooth surviving rim arc,
+// never a notch vertex or the new imprint (uvSide, #1732). The rim arc is a legitimate seam crossing, exactly
+// as the bare side's top rim is.
+func (c *cutCylinderUV) placeSeams(imprint []geom.Curve3) {
+	c.seamU = c.chooseSeamU(append(append([]geom.Curve3{}, imprint...), c.priorCutCurves()...))
+}
+
+// priorCutCurves returns the prior loop's v-varying edges (the first cut's section boundary), excluding the
+// near-constant-v rim arcs the seam may safely cross.
+func (c *cutCylinderUV) priorCutCurves() []geom.Curve3 {
+	var out []geom.Curve3
+	for _, e := range c.prior.edges {
+		if c.edgeVSpan(e) > cutEdgeVSpanRel*c.band.vMax {
+			out = append(out, e.curve)
+		}
+	}
+	return out
+}
+
+// edgeVSpan is the axial (v) extent an edge covers — near zero for a rim arc, large for a section conic.
+func (c *cutCylinderUV) edgeVSpan(e loopEdge) float64 {
+	lo, hi := priorAxialRange(priorTrimLoop{edges: []loopEdge{e}}, c.band.bottom, c.axis)
+	return hi - lo
+}
+
+// assembleSegments builds the second cut's tagged (u,v) segment set: the new imprint (clipped to the band) +
+// the prior loop as constraint edges + the bottom rim + the seam — but NO top rim (the prior loop is the top
+// boundary now). uvSide override; the bare ruledUV assembly is unchanged (#1732).
+func (c *cutCylinderUV) assembleSegments(imprint []geom.Curve3) []uvSeg {
+	var imp []uvSeg
+	for _, cv := range imprint {
+		imp = append(imp, c.sampleImprintUV(cv)...)
+	}
+	segs := c.clipImprintToBand(imp)
+	segs = append(segs, c.priorUVSegments()...)
+	return append(segs, c.cutFrameSegments()...)
+}
+
+// priorUVSegments samples the prior loop into tagged (u,v) segments, seam-split so none spans the azimuth
+// discontinuity and dropped where welded to zero length. They re-emit to their own analytic curves so the kept
+// face's top boundary follows the prior loop exactly. This same segment set is the polyline belowPrior tests.
+func (c *cutCylinderUV) priorUVSegments() []uvSeg {
+	var out []uvSeg
+	for _, e := range c.prior.edges {
+		for _, s := range c.sampleRange(e.curve, e.t0, e.t1) {
+			for _, split := range splitSeamCrossing(s) {
+				if split.a.DistanceTo(split.b) > arrTol {
+					out = append(out, split)
+				}
+			}
+		}
+	}
+	return out
+}
+
+// cutFrameSegments is bandFrameSegments MINUS the top rim: a cut side has no full top circle, so only the
+// bottom rim (v=0, the surviving anchor) and the two seam verticals close the rectangle; the prior loop is the
+// top boundary (#1732).
+func (c *cutCylinderUV) cutFrameSegments() []uvSeg {
+	twoPi := 2 * stdmath.Pi
+	seam := geom.NewLineSegment(c.point3(0, c.band.vMin), c.point3(0, c.band.vMax))
+	return []uvSeg{
+		{a: math.P2(0, c.band.vMin), b: math.P2(twoPi, c.band.vMin), curve: c.band.bottomCirc, tA: 0, tB: 1, kind: segRim},
+		{a: math.P2(0, c.band.vMin), b: math.P2(0, c.band.vMax), curve: seam, tA: 0, tB: 1, kind: segSeam},
+		{a: math.P2(twoPi, c.band.vMin), b: math.P2(twoPi, c.band.vMax), curve: seam, tA: 0, tB: 1, kind: segSeam},
+	}
+}
+
+// cutCylinderMaterial composes the survival predicate (below the prior boundary — the cell outlived the first
+// cut) with the second cut's own material test (solid membership or plane half-space), read live off the
+// seam-shifted receiver after placeSeams (#1732).
+func cutCylinderMaterial(c *cutCylinderUV) func() materialPredicate {
+	return func() materialPredicate {
+		poly := c.priorUVSegments()
+		base := c.baseMaterial()
+		return func(uv math.Point2) bool { return belowPrior(poly, uv) && base(uv) }
+	}
+}
+
+// baseMaterial returns the second cut's own predicate: solid membership in solidMode, else the plane half-space.
+func (c *cutCylinderUV) baseMaterial() materialPredicate {
+	if c.solidMode {
+		return func(uv math.Point2) bool { return c.keptBySolid(uv.X, uv.Y) }
+	}
+	return c.halfSpaceMaterial()
+}
+
+// belowPrior reports whether a (u,v) point survived the first cut: it lies BELOW the prior top boundary. An
+// upward v-ray from the point crosses the prior loop an odd number of times iff the point is under it — the
+// prior loop is the side's top boundary spanning all azimuth, so the ray exits the band exactly through it.
+// This is the disjoint sub-family's survival test; a prior loop that is a detached interior lens (not the top
+// boundary) is out of scope and gated out upstream (#1732).
+func belowPrior(poly []uvSeg, uv math.Point2) bool {
+	return priorRayCrossings(poly, float64(uv.X), float64(uv.Y))%2 == 1
+}
+
+// priorRayCrossings counts prior-loop segments an upward v-ray at azimuth qu, from height qv, passes through.
+// Half-open in u ([lo,hi)) so a shared vertex between two segments is counted once.
+func priorRayCrossings(poly []uvSeg, qu, qv float64) int {
+	n := 0
+	for _, s := range poly {
+		lo, hi := float64(s.a.X), float64(s.b.X)
+		ylo, yhi := float64(s.a.Y), float64(s.b.Y)
+		if lo > hi {
+			lo, hi, ylo, yhi = hi, lo, yhi, ylo
+		}
+		if lo == hi || qu < lo || qu >= hi {
+			continue
+		}
+		if ylo+(yhi-ylo)*(qu-lo)/(hi-lo) > qv {
+			n++
+		}
+	}
+	return n
+}

--- a/kernel/brep/curved_halfspace_cut_cylinder_uv_test.go
+++ b/kernel/brep/curved_halfspace_cut_cylinder_uv_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// cutUVFromNotched builds a cutCylinderUV over a top-notched cylinder (bottom rim intact, top wedge clipped by
+// the plane x+z=9.5), with a dummy second-cut membership. Its prior loop is the notched top boundary and its
+// seam is placed clear of the notch — the fixture the survival predicate and segment assembly run on.
+func cutUVFromNotched(t *testing.T) cutCylinderUV {
+	t.Helper()
+	f := firstCylinderFace(t, notchedCylinder(t, true))
+	cyl, band, prior, ok := cutCylinderSideBand(f)
+	if !ok {
+		t.Fatal("notched cylinder side not recognised")
+	}
+	c := newCutCylinderUVSolid(cyl, band, prior, Difference, false, func(math.Point3) bool { return false })
+	c.placeSeams(nil) // no new imprint yet; seam goes to the widest gap clear of the notch
+	return c
+}
+
+// TestBelowPriorClassifiesSurvivalAgainstFirstCut: the survival predicate must agree with the first cut's
+// half-space x+z≤9.5 — a point below the notched top boundary survived, one above it was removed. Points are
+// mapped through the SAME paramOf the prior polyline uses, so the seam shift cancels.
+func TestBelowPriorClassifiesSurvivalAgainstFirstCut(t *testing.T) {
+	c := cutUVFromNotched(t)
+	poly := c.priorUVSegments()
+	// (surface point, want-survived). x+z ≤ 9.5 survived the first cut; > 9.5 was removed.
+	cases := []struct {
+		p        math.Point3
+		survived bool
+	}{
+		{math.P3(-3, 0, 5), true},   // back wall, mid height: x+z=2, deep in surviving material
+		{math.P3(-3, 0, 9.9), true}, // back wall near the top: rim intact here (x+z=6.9)
+		{math.P3(3, 0, 5), true},    // front wall below the notch: x+z=8 ≤ 9.5
+		{math.P3(3, 0, 8), false},   // front wall inside the notch: x+z=11 > 9.5, removed
+		{math.P3(3, 0, 6.4), true},  // front wall just under the notch floor (~6.5)
+		{math.P3(3, 0, 6.6), false}, // front wall just above the notch floor
+	}
+	// The composed material predicate (survival ∧ second cut) reduces to belowPrior here: the dummy inside is
+	// always false, so under Difference the target keeps every point (keep(Difference,false,false)=true).
+	mat := cutCylinderMaterial(&c)()
+	for _, tc := range cases {
+		uv := c.paramOf(tc.p)
+		if got := belowPrior(poly, uv); got != tc.survived {
+			t.Errorf("belowPrior at %v (uv=%.3f,%.3f) = %v, want survived=%v", tc.p, uv.X, uv.Y, got, tc.survived)
+		}
+		if got := mat(uv); got != tc.survived {
+			t.Errorf("composed material at %v = %v, want %v (base is all-keep, so it must equal survival)", tc.p, got, tc.survived)
+		}
+	}
+}
+
+// TestCutFrameHasNoTopRim: an already-cut side has no full top circle, so the frame carries the bottom rim and
+// the two seam verticals but NO second rim — the prior loop is the top boundary the arrangement uses instead.
+func TestCutFrameHasNoTopRim(t *testing.T) {
+	c := cutUVFromNotched(t)
+	frame := c.cutFrameSegments()
+	rims, seams := 0, 0
+	for _, s := range frame {
+		switch s.kind {
+		case segRim:
+			rims++
+			if s.a.Y != c.band.vMin {
+				t.Errorf("the only rim must be the bottom (v=%v); got a rim at v=%v", c.band.vMin, s.a.Y)
+			}
+		case segSeam:
+			seams++
+		}
+	}
+	if rims != 1 || seams != 2 {
+		t.Errorf("cut frame has %d rims + %d seams; want 1 bottom rim + 2 seams (no top rim)", rims, seams)
+	}
+}
+
+// TestAssembleSegmentsIngestsPriorLoop: the second cut's segment set must include the prior loop's edges as
+// constraint segments so the arrangement subdivides at the surviving boundary; without them a cell straddling
+// the old notch would classify as one material and re-include removed geometry.
+func TestAssembleSegmentsIngestsPriorLoop(t *testing.T) {
+	c := cutUVFromNotched(t)
+	if got, want := len(c.priorUVSegments()), 1; got < want {
+		t.Fatalf("prior loop produced %d (u,v) segments; want at least the notched boundary", got)
+	}
+	// With no new imprint the assembled set is exactly prior segments + the cut frame (bottom rim + 2 seams).
+	segs := c.assembleSegments(nil)
+	if len(segs) != len(c.priorUVSegments())+3 {
+		t.Errorf("assembled %d segments; want prior(%d) + frame(3)", len(segs), len(c.priorUVSegments()))
+	}
+}

--- a/kernel/brep/curved_halfspace_uv_arrangement.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement.go
@@ -226,12 +226,18 @@ func (c ruledUV) bandFrameSegments() []uvSeg {
 // segment (seam-split so none spans the azimuth discontinuity) plus the rim+seam frame that closes the
 // parameter rectangle. Degenerate segments (both endpoints welded by the seam split) are dropped.
 func (c ruledUV) assembleBandSegments(imprint []uvSeg) []uvSeg {
+	return append(c.clipImprintToBand(imprint), c.bandFrameSegments()...)
+}
+
+// clipImprintToBand seam-splits every imprint segment so none spans the azimuth discontinuity, clips each to
+// the band's axial range (a tilted cut's ellipse can rise past the rim — sampling that out-of-band part would
+// inject a spurious arc; clipping lands the imprint exactly on the rim where it crosses), and drops segments
+// welded to zero length. Extracted from assembleBandSegments so the already-cut side (cutCylinderUV) reuses
+// the identical imprint clip while supplying its own prior-boundary frame instead of a top rim (#1732).
+func (c ruledUV) clipImprintToBand(imprint []uvSeg) []uvSeg {
 	out := make([]uvSeg, 0, len(imprint)+4)
 	for _, s := range imprint {
 		for _, split := range splitSeamCrossing(s) {
-			// Clip each imprint segment to the band's axial range: a section can leave [vMin,vMax] (a tilted
-			// cut's ellipse rises past the rim), and sampling that out-of-band part would inject a spurious
-			// arc; clipping lands the imprint exactly on the rim where it crosses, the real rim split.
 			for _, clipped := range c.clipSegToVBand(split) {
 				if clipped.a.DistanceTo(clipped.b) > arrTol {
 					out = append(out, clipped)
@@ -239,7 +245,7 @@ func (c ruledUV) assembleBandSegments(imprint []uvSeg) []uvSeg {
 			}
 		}
 	}
-	return append(out, c.bandFrameSegments()...)
+	return out
 }
 
 // clipSegToVBand clips a (u,v) imprint segment to the axial band [vMin,vMax], returning the in-band part or

--- a/kernel/brep/curved_partial_rim_cut.go
+++ b/kernel/brep/curved_partial_rim_cut.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Partial-rim second cut recognizer (EPIC Oblikovati/Oblikovati#1724 follow-up, #1732): a SECOND curved cut on
+// a target whose cylinder side was already notched by a first cut. The target resolves as a cutCylinderOperand
+// (one surviving full bottom rim + a prior-trim loop); the tool is a bare ruled solid. The operand's split
+// composes the prior boundary and runs the disjoint gate, so this reuses the general ruled cut (ruledCutGeneral
+// → cutFaces → curvedStitch) unchanged — only the target's split strategy, imprint window and membership oracle
+// differ. Anything outside the disjoint sub-family declines, and kernel/ops keeps its observable CSG fallback.
+//
+// The already-cut target is NOT a bare cylinder solid (three planar caps, not two), so the bare-solid helpers
+// cylinderSolidParams / curvedSolidMembership reject it. Two cut-aware replacements bridge that: partialRimImprint
+// traces the SSI from the cut cylinder's surface + recovered band directly, and cutCylinderSolidMembership tests
+// membership against the cylinder radius AND every planar cap's inward half-space.
+
+// cutCylinderSideFace finds a body's ALREADY-CUT cylinder side (cutCylinderSideBand) — the mirror of
+// cylinderSideFace, which finds a bare two-rim side.
+func cutCylinderSideFace(b *topo.Body) (curvedFace, geom.Cylinder, coneSideBand_, priorTrimLoop, bool) {
+	for _, f := range facesOfAny(b) {
+		if _, isCyl := f.surface.(geom.Cylinder); !isCyl {
+			continue
+		}
+		if cyl, band, prior, ok := cutCylinderSideBand(f); ok {
+			return f, cyl, band, prior, true
+		}
+	}
+	return curvedFace{}, geom.Cylinder{}, coneSideBand_{}, priorTrimLoop{}, false
+}
+
+// cutCylinderSolidMembership builds a point-inside oracle for the already-cut cylinder solid: inside the
+// cylinder radius AND on the inner side of every planar cap. Each cap's inward normal is oriented by a known
+// deep-interior point (the axis at half the recovered band height), which is inside the convex notched solid.
+// This replaces curvedSolidMembership (which recognises only a bare two-cap cylinder) for the cut target (#1732).
+func cutCylinderSolidMembership(b *topo.Body, cyl geom.Cylinder, band coneSideBand_) func(math.Point3) bool {
+	axis := cyl.AxisDir.AsVector()
+	interior := band.bottom.TranslateBy(axis.Scale(math.Scalar(band.vMax / 2)))
+	caps := inwardCapHalfSpaces(b, interior)
+	margin := geom.ResolutionForSize(cyl.Radius + band.vMax).Plane()
+	return func(p math.Point3) bool {
+		d := cyl.Origin.VectorTo(p)
+		v := d.Dot(axis)
+		if float64(d.Sub(axis.Scale(v)).Length()) >= cyl.Radius-margin {
+			return false
+		}
+		for _, h := range caps {
+			if float64(h.origin.VectorTo(p).Dot(h.normal)) < margin {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+// capHalfSpace is one planar cap oriented so its normal points INTO the solid.
+type capHalfSpace struct {
+	origin math.Point3
+	normal math.Vector3
+}
+
+// inwardCapHalfSpaces collects the body's planar caps, each normal flipped to point toward the interior sample.
+func inwardCapHalfSpaces(b *topo.Body, interior math.Point3) []capHalfSpace {
+	var out []capHalfSpace
+	for _, f := range facesOfAny(b) {
+		pl, ok := f.surface.(geom.Plane)
+		if !ok {
+			continue
+		}
+		n := pl.UAxis.AsVector().Cross(pl.VAxis.AsVector())
+		if float64(pl.Origin.VectorTo(interior).Dot(n)) < 0 {
+			n = n.Scale(-1)
+		}
+		out = append(out, capHalfSpace{origin: pl.Origin, normal: n})
+	}
+	return out
+}
+
+// partialRimImprint traces the second cut's SSI on the already-cut target's cylinder surface, using the
+// recovered band as the axial window — bypassing cylinderSolidParams, which rejects the three-cap notched body.
+func partialRimImprint(target, tool *topo.Body, rec *diag.Recorder) ([]geom.Polyline, bool) {
+	_, tgtCyl, band, _, okT := cutCylinderSideFace(target)
+	toolCyl, _, _, okB := cylinderSolidParams(facesOfAny(tool))
+	if !okT || !okB {
+		return nil, false
+	}
+	res := geom.ResolutionForBox(target.RangeBox().Union(tool.RangeBox()))
+	window := cylinderTraceWindow(tgtCyl, band.bottom, band.vMax)
+	loops := imprintTraceLoops(tgtCyl, toolCyl, window, res, rec)
+	if len(loops) == 0 {
+		return nil, false
+	}
+	return loops, true
+}
+
+// cutCylinderOperand resolves an already-cut cylinder body into a ruledOperand whose split composes the prior
+// boundary and gates on disjointness (#1732). Its newUV builds the BARE frame the cap-clearance check consumes;
+// the prior loop and the disjoint gate live in splitCut. ok=false when the body has no recognisable cut
+// cylinder side (e.g. a bare two-rim side — cylinderOperand's job).
+func cutCylinderOperand(b *topo.Body) (ruledOperand, bool) {
+	f, cyl, band, prior, ok := cutCylinderSideFace(b)
+	if !ok {
+		return ruledOperand{}, false
+	}
+	inside := cutCylinderSolidMembership(b, cyl, band)
+	o := ruledOperand{body: b, face: f, surface: cyl, inside: inside,
+		newUV: func(op Op, isB bool, other func(math.Point3) bool) ruledUV {
+			return newCylinderUVSolid(cyl, band, op, isB, other)
+		}}
+	o.splitCut = func(imprint []geom.Curve3, op Op, isB bool, other func(math.Point3) bool) ([]curvedFace, bool) {
+		c := newCutCylinderUVSolid(cyl, band, prior, op, isB, other)
+		c.placeSeams(imprint)
+		if !c.disjointFromPrior(imprint) {
+			return nil, false // outside the disjoint sub-family → decline to CSG
+		}
+		return keptOrNone(trimByImprint(&c, f, cyl, imprint, cutCylinderMaterial(&c)))
+	}
+	return o, true
+}
+
+// PartialRimCutGeneral builds target − tool where the target's cylinder side was already notched by a first cut
+// (#1732). It resolves the target as a cut operand and the tool as a bare ruled operand, then reuses the general
+// ruled cut. ok=false unless the imprint is a clean two-loop crossing, the target is a recognisable cut
+// cylinder, and the tool a bare ruled solid — so kernel/ops keeps its CSG fallback everywhere else.
+func PartialRimCutGeneral(target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	loops, ok := require2Loops(partialRimImprint(target, tool, rec))
+	tgt, okT := cutCylinderOperand(target)
+	tl, okL := ruledOperandOf(tool)
+	if !ok || !okT || !okL {
+		return nil, false
+	}
+	return ruledCutGeneral(tgt, tl, loops)
+}

--- a/kernel/brep/curved_partial_rim_cut_test.go
+++ b/kernel/brep/curved_partial_rim_cut_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// notchedCylinderBody is a r=3 h=10 cylinder whose top rim was clipped by the oblique plane x+z=9.5 — a
+// genuine already-cut side (one full bottom circle + a notched top boundary), the partial-rim target.
+func notchedCylinderBody(t *testing.T) *topo.Body {
+	t.Helper()
+	bare, err := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 10)
+	if err != nil {
+		t.Fatalf("bare cylinder: %v", err)
+	}
+	pl, _ := geom.NewPlane(math.P3(1.5, 0, 8), math.V3(1, 0, 1))
+	notched, err := brep.HalfSpaceCut(bare, pl)
+	if err != nil {
+		t.Fatalf("first cut (notch): %v", err)
+	}
+	return notched
+}
+
+func freeEdgeCount(b *topo.Body) int {
+	n := 0
+	for _, e := range b.Edges() {
+		if len(e.Faces()) != 2 {
+			n++
+		}
+	}
+	return n
+}
+
+// TestPartialRimCutDisjointRodConservesRemoval is the headline #1732 certification: a second cut (a rod drilled
+// through the still-full lower band, disjoint from the top notch) on an already-cut cylinder builds an EXACT
+// analytic solid, not a CSG fallback. It is watertight, Euler-valid, and genus-1 (the through-tunnel). Shape is
+// certified by CONSERVATION: because the rod is disjoint from the notch, it removes the identical plug from the
+// notched target as from a bare cylinder — cross-checked against the certified CrossingCylinderCutGeneral, so a
+// right-volume-wrong-shape build (which the manifold/Euler checks miss) is caught.
+func TestPartialRimCutDisjointRodConservesRemoval(t *testing.T) {
+	target := notchedCylinderBody(t)
+	rod, _ := brep.SolidCylinder(math.P3(-6, 0, 3), math.V3(1, 0, 0), 1, 12) // through the lower band, clear of the notch
+	res, ok := brep.PartialRimCutGeneral(target, rod, &diag.Recorder{})
+	if !ok || res == nil {
+		t.Fatal("partial-rim disjoint cut declined; want an exact analytic solid")
+	}
+	if r := ops.Validate(res); !r.Valid {
+		t.Fatalf("partial-rim result is not a valid solid: %v", r.Issues)
+	}
+	if fe := freeEdgeCount(res); fe != 0 {
+		t.Errorf("partial-rim result has %d free edges; want a watertight solid", fe)
+	}
+	if chi := res.EulerCharacteristic(); chi != 0 {
+		t.Errorf("partial-rim result chi=%d; want 0 (genus-1 through-tunnel)", chi)
+	}
+
+	// Shape gate (mesh-independent, the #1724 right-volume-wrong-shape check): the result must enclose exactly
+	// the analytic region {inside the notched target} ∧ {outside the rod}. A 96³ membership grid gives the
+	// smooth analytic volume; the tessellated result sits below it by the faceted-cylinder + SSI-polyline
+	// deficit — which is 2.81% for the ALREADY-CERTIFIED CrossingCylinderCutGeneral against this same oracle, so
+	// the 3.5% budget here is that established deficit, not slack. A right-Euler wrong-shape build diverges far more.
+	analytic := analyticPartialRimVolume(96)
+	if rel := stdmath.Abs(vol(res)-analytic) / analytic; rel > 0.035 {
+		t.Errorf("result volume %.4f vs analytic {target ∧ ¬rod} %.4f (%.2f%%); want the exact cut region", vol(res), analytic, rel*100)
+	}
+
+	// Tight volume gate (mesh-consistent, faceting cancels): because the rod is disjoint from the notch it
+	// removes the identical plug from the notched target as from a bare cylinder (the certified crossing cut). The
+	// two removed volumes share the same faceted cylinder and tunnel tessellation, so they must agree to well
+	// under 1% of the body — a far tighter bound than the smooth-oracle gate, catching any volume corruption the
+	// partial-rim machinery might introduce.
+	bare, _ := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 10)
+	rod2, _ := brep.SolidCylinder(math.P3(-6, 0, 3), math.V3(1, 0, 0), 1, 12)
+	bareRes, okB := brep.CrossingCylinderCutGeneral(bare, rod2, nil)
+	if !okB {
+		t.Fatal("bare crossing-cut oracle declined; cannot cross-check the removed plug")
+	}
+	removedNotched := vol(notchedCylinderBody(t)) - vol(res)
+	removedBare := vol(mustBareCylinder(t)) - vol(bareRes)
+	if rel := stdmath.Abs(removedNotched-removedBare) / vol(res); rel > 0.01 {
+		t.Errorf("removed plug: notched=%.5f bare=%.5f, differ by %.2f%% of the body; a disjoint cut removes the same plug",
+			removedNotched, removedBare, rel*100)
+	}
+}
+
+func mustBareCylinder(t *testing.T) *topo.Body {
+	t.Helper()
+	b, err := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 10)
+	if err != nil {
+		t.Fatalf("bare cylinder: %v", err)
+	}
+	return b
+}
+
+// analyticPartialRimVolume integrates the exact partial-rim region — inside the r=3 h=10 cylinder, below the
+// notch plane x+z<=9.5, and outside the r=1 rod on the x-axis at (y,z)=(0,3) — on an n³ grid over the target's
+// bounding box. Mesh-independent, so it certifies the built solid's SHAPE, not just its Euler characteristic.
+func analyticPartialRimVolume(n int) float64 {
+	inTarget := func(x, y, z float64) bool { return x*x+y*y < 9 && z > 0 && z < 10 && x+z < 9.5 }
+	inRod := func(x, y, z float64) bool { return y*y+(z-3)*(z-3) < 1 && x > -6 && x < 6 }
+	count := 0
+	for i := 0; i < n; i++ {
+		x := -3 + 6*(float64(i)+0.5)/float64(n)
+		for j := 0; j < n; j++ {
+			y := -3 + 6*(float64(j)+0.5)/float64(n)
+			for k := 0; k < n; k++ {
+				z := 10 * (float64(k) + 0.5) / float64(n)
+				if inTarget(x, y, z) && !inRod(x, y, z) {
+					count++
+				}
+			}
+		}
+	}
+	return float64(count) / float64(n*n*n) * (6 * 6 * 10)
+}
+
+// TestPartialRimCutInteractingCutDeclines: a second cut whose imprint enters the removed notch (a rod through
+// the upper band where the front wall is gone) is OUTSIDE the disjoint sub-family, so PartialRimCutGeneral
+// declines and kernel/ops keeps its observable CSG fallback — never a manifold-but-wrong analytic solid.
+func TestPartialRimCutInteractingCutDeclines(t *testing.T) {
+	target := notchedCylinderBody(t)
+	rod, _ := brep.SolidCylinder(math.P3(-6, 0, 7), math.V3(1, 0, 0), 1, 12) // z=7: front exit lands in the notch
+	if _, ok := brep.PartialRimCutGeneral(target, rod, &diag.Recorder{}); ok {
+		t.Fatal("an interacting second cut (imprint crossing the notch) must decline, not build a wrong solid")
+	}
+}

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -238,7 +238,7 @@ var curvedExactPaths = []func(PartFeatureOperation, *topo.Body, *topo.Body, *dia
 	curvedCrossingIntersect, curvedSteinmetzIntersect, curvedConeCylinderIntersect, curvedConeConeIntersect,
 	curvedPartialIntersect,
 	// Cut — [P] the drill through-hole (curved-on-planar), the rest [T] transversal.
-	curvedCylindricalHoleCut, curvedFlatSubtract, curvedPartialCut, curvedSteinmetzCut, curvedConeCylinderCut, curvedConeConeCut, curvedCapCrossCut, curvedRimCrossCut, curvedTwoCapCrossCut, curvedConeCapCrossCut, curvedCrossingCut,
+	curvedCylindricalHoleCut, curvedFlatSubtract, curvedPartialCut, curvedSteinmetzCut, curvedConeCylinderCut, curvedConeConeCut, curvedCapCrossCut, curvedRimCrossCut, curvedTwoCapCrossCut, curvedConeCapCrossCut, curvedPartialRimCut, curvedCrossingCut,
 	// Join — [D] coaxial (degenerate overlap), [P] boss (curved-on-planar), the rest [T] transversal.
 	curvedCoaxialJoin, curvedCylinderBossJoin, curvedPartialJoin, curvedConeCylinderJoin, curvedConeConeJoin, curvedCrossingJoin, curvedSteinmetzJoin,
 }

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -76,6 +76,7 @@ var (
 	curvedRimCrossCut        = gatedCurved(Cut, brep.RimCrossingCutGeneral)     // oblique tool exits one cap, ellipse crosses rim (#1724 slice 2)
 	curvedTwoCapCrossCut     = gatedCurved(Cut, brep.TwoCapCrossingCutGeneral)  // steep tool exits BOTH caps, wall intact (#1724)
 	curvedConeCapCrossCut    = gatedCurved(Cut, brep.ConeCapCrossingCutGeneral) // oblique CONE tool exits one cap, ellipse inside rim (#1724)
+	curvedPartialRimCut      = gatedCurved(Cut, brep.PartialRimCutGeneral)      // second cut on an already-notched cylinder side, disjoint from the notch (#1732)
 
 	// Join — the union, keeping the analytic wall where the operands' faces are coincident or breached.
 	curvedCoaxialJoin      = gatedCurved(Join, withoutRecorder(brep.CoaxialCylinderUnion)) // coaxial equal-radius cylinders

--- a/kernel/ops/boolean_partial_rim_test.go
+++ b/kernel/ops/boolean_partial_rim_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// notchedTarget builds a cylinder already notched by a first cut (an oblique plane clipping the top rim), the
+// target for a partial-rim second cut through the full boolean dispatch (#1732).
+func notchedTarget(t *testing.T) *topo.Body {
+	t.Helper()
+	bare, err := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 10)
+	if err != nil {
+		t.Fatalf("bare cylinder: %v", err)
+	}
+	pl, _ := geom.NewPlane(math.P3(1.5, 0, 8), math.V3(1, 0, 1))
+	target, err := brep.HalfSpaceCut(bare, pl)
+	if err != nil {
+		t.Fatalf("first cut (notch): %v", err)
+	}
+	return target
+}
+
+// TestPartialRimSecondCutTakesAnalyticPath drives the full boolean dispatch (BooleanWithDiagnostics), not the
+// brep entry directly: a rod drilled through the still-full lower band of an already-notched cylinder, disjoint
+// from the notch, must be routed to the exact analytic partial-rim path — NOT the faceted CSG fallback — and
+// yield a valid genus-1 solid. This is the user-facing proof that curvedPartialRimCut is wired into the cascade.
+func TestPartialRimSecondCutTakesAnalyticPath(t *testing.T) {
+	rod, err := brep.SolidCylinder(math.P3(-6, 0, 3), math.V3(1, 0, 0), 1, 12)
+	if err != nil {
+		t.Fatalf("rod: %v", err)
+	}
+	rec := &diag.Recorder{}
+	res, err := BooleanWithDiagnostics(Cut, notchedTarget(t), rod, rec)
+	if err != nil {
+		t.Fatalf("partial-rim cut: %v", err)
+	}
+	if rec.Has(CodeBooleanCSGFallback) {
+		t.Errorf("disjoint partial-rim cut fell back to CSG; want the exact analytic path. recs=%v", rec.Records())
+	}
+	if r := Validate(res); !r.Valid {
+		t.Fatalf("partial-rim result is not a valid solid: %v", r.Issues)
+	}
+	if chi := res.EulerCharacteristic(); chi != 0 {
+		t.Errorf("partial-rim result chi=%d; want 0 (genus-1 through-tunnel)", chi)
+	}
+}
+
+// TestPartialRimInteractingCutFallsBackObservably: a second cut whose imprint crosses the removed notch is
+// outside the disjoint sub-family, so the analytic path declines and the dispatch falls back to CSG WITH the
+// observable CodeBooleanCSGFallback defect — never a silent degradation or a manifold-but-wrong analytic solid.
+func TestPartialRimInteractingCutFallsBackObservably(t *testing.T) {
+	rod, err := brep.SolidCylinder(math.P3(-6, 0, 7), math.V3(1, 0, 0), 1, 12) // z=7: exits through the notch
+	if err != nil {
+		t.Fatalf("rod: %v", err)
+	}
+	rec := &diag.Recorder{}
+	if _, err := BooleanWithDiagnostics(Cut, notchedTarget(t), rod, rec); err != nil {
+		t.Fatalf("interacting cut errored instead of falling back: %v", err)
+	}
+	if !rec.Has(CodeBooleanCSGFallback) {
+		t.Errorf("interacting partial-rim cut did not record the CSG fallback; got %v", rec.Records())
+	}
+}


### PR DESCRIPTION
## What

Adds the exact analytic **partial-rim second cut** — a second curved boolean on a target whose cylinder side was already notched by a first cut — for the **disjoint sub-family** (the new imprint lies entirely in the still-full band, clear of the prior notch). This is the last open positive path of EPIC #1724.

`PartialRimCutGeneral` reuses the general ruled cut (`ruledCutGeneral → cutFaces → curvedStitch`) unchanged; only the target's split strategy differs, via a new nullable `splitCut` on `ruledOperand` that composes the surviving prior boundary as arrangement constraint edges and gates on disjointness.

## Why

Before this, a second cut on an already-cut cylinder always fell back to faceted CSG (observably, via `CodeBooleanCSGFallback`). The result was materially correct but low-fidelity. This ships the exact analytic solid for the common disjoint case, at the same accuracy as the already-certified crossing cut. Configs outside the sub-family (imprint crossing/touching/enclosing the notch, or wrapping the whole azimuth) still decline to CSG observably — never a manifold-but-wrong solid.

## How it holds together

- **Recognizer** `cutCylinderSideBand` — the mirror of `fullCylinderSideBand`: one surviving full bottom circle (the v=0 anchor, load-bearing) + a prior-trim loop; recovers the band top `vMax` from the prior loop, padded so the artificial top edge clears all real geometry.
- **Arrangement ingest** `cutCylinderUV` — embeds `ruledUV`, feeds the prior loop as constraint edges (no top rim), keeps a cell iff it survived the first cut (`belowPrior`, an upward v-ray test) **and** the second cut selects it.
- **Disjoint gate** — `belowPrior` over the imprint subsumes crossing/containment/enclosure; plus a model-scaled 3D near-approach margin and a contractible/seam-clear precondition.
- Cut-aware bridges (`partialRimImprint`, `cutCylinderSolidMembership`) because the already-cut body is not a bare two-cap cylinder solid.

## Safety

- A **characterization golden** over the shared arrangement core (`trimByImprint`/`assembleSegments`/`arrangeBand`/`keptCells`) freezes the 5 solid-cut builders + the 4 certified #1724 cap-crossing slices — held **byte-identical** across every commit (cross-platform V/E/F/χ everywhere, ADR-0043 reference-key SHA on Linux, where faceted cos/sin coords are stable).
- The new operand fires **only** on an already-cut target (a bare target fails its one-full-circle test), so the bare-band path is untouched.

## Certification

- Topology exact: watertight, `ops.Validate` valid, genus-1 through-tunnel.
- Shape gate (mesh-independent membership grid vs analytic `{target ∧ ¬rod}`): **2.82%**, identical to the OCC-certified `CrossingCylinderCutGeneral`'s **2.81%** against the same oracle (the faceting + SSI-polyline budget, not a defect).
- Tight volume gate (mesh-consistent, faceting cancels): removed plug matches the bare crossing to **0.33%** of the body.
- End-to-end through `BooleanWithDiagnostics`: disjoint cut takes the analytic path (no CSG fallback); interacting cut falls back observably.
- Live-rendered through the real Vulkan pipeline: notched target, partial-rim result (clean disjoint tunnel, no tears/z-fighting), and the interacting CSG fallback all render correct.

The **corner-junction** sub-case (imprint crossing the prior arc → a 3-curve arrangement vertex) stays observable-decline — the deferred follow-on tracked by #1732.

Refs #1724
Refs #1732

🤖 Generated with [Claude Code](https://claude.com/claude-code)