### PR TITLE
feat(brep): analytic corner-junction curved boolean (#1738)

### DIFF
--- a/architecture/decisions/ADR-0048-corner-junction-coupled-overlay.md
+++ b/architecture/decisions/ADR-0048-corner-junction-coupled-overlay.md
@@ -1,10 +1,11 @@
 # ADR-0048 — Corner-junction analytic via a coupled (u,v) overlay
 
-**Status:** Proposed (2026-07-04). · **Follow-on EPIC** from the closed
-[Oblikovati#1724](https://github.com/Oblikovati/Oblikovati/issues/1724) /
+**Status:** Accepted (2026-07-04) — built and OCCT-certified under
+[Oblikovati#1738](https://github.com/Oblikovati/Oblikovati/issues/1738). · **Follow-on EPIC** from the
+closed [Oblikovati#1724](https://github.com/Oblikovati/Oblikovati/issues/1724) /
 [Oblikovati#1732](https://github.com/Oblikovati/Oblikovati/issues/1732), whose acceptance
 deliberately scoped the corner-junction to an **observable CSG decline**; this ADR records the
-design for the analytic result and is tracked by a new EPIC (TBD). · **Builds on**
+design for the analytic result, delivered by [Oblikovati#1738](https://github.com/Oblikovati/Oblikovati/issues/1738). · **Builds on**
 [ADR-0045](ADR-0045-curved-boolean-kind-taxonomy.md) (the T/P/D KIND taxonomy),
 [ADR-0046](ADR-0046-curved-boolean-cap-crossing.md) (the cap-crossing arrangement + the
 OCCT-certification protocol it defines), [ADR-0043](ADR-0043-generalized-provenance-naming.md)
@@ -152,6 +153,18 @@ quotienting the radius out of the compared quantity.
      ADR-0046 protocol) via a two-cut oracle, and every still-declining config (tangency, imprint
      through a prior corner vertex, removed bottom circle) keeps its observable decline with a
      regression fixture.
+- **Delivered (#1738).** All five DoD items met. `kernel/brep/curved_corner_junction.go` +
+  `curved_corner_junction_build.go` implement the seam; wired into the `Cut` cascade as
+  `curvedPartialRimCornerCut`, engaged only where the disjoint gate declines (golden byte-identical,
+  all ten fixtures). **One implementation correction the build confirmed:** the "planar implicit
+  quadratic" of the pre-split section is *shorthand* — the imprint chord is skew to the ellipse plane, so
+  there is no genuine planar quadratic. The crossing is the exact **triple point** where target cylinder ∩
+  tool surface ∩ notch plane meet, found as a cancellation-free 1-D root of the tool's implicit along the
+  prior conic (Method C makes **both** arms exact, not only the prior). Likewise the metric-normalized
+  angle needs **no** explicit `R` weighting in code: a cylinder is developable, so the 3D tangent-plane
+  angle already *is* the angle in `I = diag(R², 1)` — verified scale-invariant across `R = 1` vs
+  `R = 1000`. Certified vs `occ.cut(occ.cut(cyl, notch), rod)`: 5 faces, volume 239.93 (rel < 0.6%),
+  area (rel < 0.4%), centroid (< 0.05), plus a 60³ membership audit vs `((target ∖ notch) ∖ rod)`.
 
 ## Rejected alternatives
 

--- a/kernel/brep/curved_corner_junction.go
+++ b/kernel/brep/curved_corner_junction.go
@@ -1,0 +1,439 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"sort"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Corner-junction exact pre-split (EPIC Oblikovati/Oblikovati#1738, ADR-0048). A SECOND curved cut whose SSI
+// imprint CROSSES the surviving first-cut boundary (the "notch") — the hardest partial-rim sub-case. The
+// disjoint sub-family (#1732/#1735, OCC-certified #1736) ships; this file adds the crossing case.
+//
+// The failure it repairs (instrumented, curved_corner_junction_probe_test.go): the imprint arrives as a
+// sampled polyline; the (u,v) arrangement welds its crossing with the prior conic on the polyline CHORD, but
+// re-emission re-anchors each arm to its own analytic curve, so the imprint arm terminates at a chord point
+// (~sagitta INSIDE the cylinder) while the prior arm terminates exactly on the cylinder — a ~2.6e-4 gap that
+// blows the 1e-7 weld, splitting the junction into two vertices (χ=1, 5 free edges, the back entry-ellipse
+// hole collapses). This is the classic EGC failure: an approximate combinatorial decision corrupts the
+// arrangement (Yap 1997; Kettner et al. 2008).
+//
+// The fix is Method C (ADR-0048): compute the crossing as the EXACT triple point where the target cylinder,
+// the rod surface and the first-cut plane all meet — a single 3D vertex on ALL THREE surfaces — and make
+// every coupled face (target wall, notch cap, rod tunnel) re-emit to it. Because the prior boundary conic
+// lies on the target cylinder ∩ the first-cut plane already, the triple point is the root, along that conic,
+// of the rod's implicit surface value; both arms stay exact (Patrikalakis & Maekawa 2002; the section conic
+// is the exact carrier, so no facet error enters the shared vertex).
+
+// cornerJunction is one exact triple point: a point lying simultaneously on the target cylinder, on a prior
+// boundary arm (⊂ target cylinder ∩ first-cut plane) and on the rod's cylindrical surface. It is the shared
+// vertex the target wall, the notch cap and the rod tunnel all split at, so the welded shell closes (#1738).
+type cornerJunction struct {
+	point math.Point3 // exact: on target cylinder ∧ on prior conic ∧ on rod surface
+	edge  int         // index into prior.edges of the arm carrying it
+	tArm  float64     // the arm's curve parameter at the junction
+}
+
+// rodRadialDist is the perpendicular distance from p to the rod axis (the line through axisPt along the unit
+// axisDir). Its zero level set offset by the rod radius is the rod's cylindrical surface — the implicit whose
+// crossing with a prior arm is the triple point (#1738).
+func rodRadialDist(p, axisPt math.Point3, axisDir math.Vector3) float64 {
+	d := axisPt.VectorTo(p)
+	along := d.Dot(axisDir)
+	return float64(d.Sub(axisDir.Scale(along)).Length())
+}
+
+// cornerSampleCount brackets the rod crossing along each prior arm. The prior conic is smooth and low
+// curvature over an arm, so this resolves every transversal crossing into its own sign-change bracket while
+// keeping the scan cheap; the exact root is then found by bisection, independent of the sample density.
+const cornerSampleCount = 256
+
+// cornerJunctions solves every exact triple point where the rod surface (cylinder axisPt/axisDir/radius)
+// crosses the prior boundary. Along each prior edge it brackets each sign change of (rodRadialDist − radius)
+// and bisects it to the exact crossing — a point on the prior conic (hence on the target cylinder ∧ the
+// first-cut plane) AND on the rod surface. Method C of ADR-0048: the crossing is a 1-D root on the exact
+// carrier conic, so both re-emitted arms terminate at the identical vertex with no facet error (#1738).
+func cornerJunctions(prior priorTrimLoop, axisPt math.Point3, axisDir math.Vector3, radius float64) []cornerJunction {
+	var js []cornerJunction
+	for i, e := range prior.edges {
+		js = append(js, edgeRodCrossings(e, i, axisPt, axisDir, radius)...)
+	}
+	return js
+}
+
+// edgeRodCrossings returns the exact rod crossings along one prior edge. It scans the signed rod value
+// f(t)=rodRadialDist(edge(t))−radius, and on each strict sign change bisects the bracket to the exact root.
+// A sample landing exactly on the surface (f==0) is treated as its own crossing so a crossing at a sample
+// vertex is not missed (the degenerate incidence the math advisor flagged).
+func edgeRodCrossings(e loopEdge, idx int, axisPt math.Point3, axisDir math.Vector3, radius float64) []cornerJunction {
+	f := func(t float64) float64 { return rodRadialDist(e.curve.PointAt(t), axisPt, axisDir) - radius }
+	var out []cornerJunction
+	prevT, prevF := e.t0, f(e.t0)
+	for i := 1; i <= cornerSampleCount; i++ {
+		t := e.t0 + (e.t1-e.t0)*float64(i)/float64(cornerSampleCount)
+		fv := f(t)
+		if prevF*fv < 0 {
+			// bisectRoot needs an ASCENDING bracket: its (hi-lo)<1e-15 guard early-returns an unrefined
+			// midpoint on a descending one, which is exactly what a reversed edge (t0>t1, e.g. a notch cap's
+			// section walked backwards) produces — the crossing then lands ~half a sample off the surface and
+			// fails to weld with the target wall's exact point.
+			lo, hi := prevT, t
+			if lo > hi {
+				lo, hi = hi, lo
+			}
+			tc := bisectRoot(f, lo, hi)
+			out = append(out, cornerJunction{point: e.curve.PointAt(tc), edge: idx, tArm: tc})
+		}
+		prevT, prevF = t, fv
+	}
+	return out
+}
+
+// cylinderOutwardNormal is the unit outward radial of a cylinder (axisPt/axisDir) at a point p on it — the
+// surface normal used to form the SSI tangent T=n_target×n_rod and to project the prior tangent into the
+// target tangent plane for the scale-invariant tangency gate (ADR-0048 §tangency).
+func cylinderOutwardNormal(p, axisPt math.Point3, axisDir math.Vector3) math.Vector3 {
+	d := axisPt.VectorTo(p)
+	radial := d.Sub(axisDir.Scale(d.Dot(axisDir)))
+	return unitVector(radial)
+}
+
+// unitVector normalises v, returning the zero vector when v is (near) degenerate so callers can detect a
+// collapsed direction rather than divide by zero.
+func unitVector(v math.Vector3) math.Vector3 {
+	l := float64(v.Length())
+	if l < 1e-300 {
+		return math.Vector3{}
+	}
+	return v.Scale(math.Scalar(1 / l))
+}
+
+// junctionDegeneracy returns the two ADR-0048 degeneracy measures at a triple point, kept strictly distinct:
+//   - surfSurf = ‖n_target × n_rod‖, the sine of the angle between the two surface normals. →0 means the two
+//     SURFACES are tangent there, so the SSI itself is singular (Patrikalakis & Maekawa §5–6).
+//   - curveCurve = the sine between the imprint SSI tangent T=n_target×n_rod and the prior conic tangent,
+//     both in the target tangent plane. →0 means the two boundary CURVES graze (the corner-junction cusp).
+//
+// It is scale-invariant WITHOUT weighting by R: on a cylinder the {circumferential, axial} tangent basis is
+// orthonormal in 3D, so this 3D tangent-plane angle already IS the metric angle in the first fundamental form
+// I=diag(R²,1) (a cylinder is developable — the (u,v) chart with that metric is a local isometry). Measuring
+// the genuine geometric angle quotients R out by construction, as ADR-0048 requires.
+func junctionDegeneracy(j cornerJunction, prior priorTrimLoop,
+	tgtAxisPt math.Point3, tgtAxis math.Vector3, rodAxisPt math.Point3, rodAxis math.Vector3) (surfSurf, curveCurve float64) {
+	nT := cylinderOutwardNormal(j.point, tgtAxisPt, tgtAxis)
+	nR := cylinderOutwardNormal(j.point, rodAxisPt, rodAxis)
+	ssiT := nT.Cross(nR)
+	surfSurf = float64(ssiT.Length())
+	tp := prior.edges[j.edge].curve.TangentAt(j.tArm)
+	tpTan := unitVector(tp.Sub(nT.Scale(tp.Dot(nT)))) // prior tangent projected into the target tangent plane
+	curveCurve = float64(unitVector(ssiT).Cross(tpTan).Length())
+	return surfSurf, curveCurve
+}
+
+// junctionWeldTol is the coincidence radius for deciding an imprint loop passes through a triple point. It
+// sits an order below the imprint's own facet sagitta (~2.6e-4 on the cm-scale fixture) yet well above the
+// weld grid, so a genuine crossing loop is caught while a disjoint loop (the back entry ellipse) is not.
+const junctionWeldTol = 1e-2
+
+// splitPriorAtJunctions splits each prior boundary edge at the triple points that lie on it (Method C,
+// ADR-0048), so the arrangement samples the prior conic with a vertex EXACTLY at each junction and the
+// re-emitted prior sub-arc terminates at the exact triple point — the target half of the shared vertex. An
+// edge with no junction is copied through unchanged, keeping every other boolean's prior ingest identical.
+func splitPriorAtJunctions(prior priorTrimLoop, js []cornerJunction) priorTrimLoop {
+	byEdge := map[int][]float64{}
+	for _, j := range js {
+		byEdge[j.edge] = append(byEdge[j.edge], j.tArm)
+	}
+	out := make([]loopEdge, 0, len(prior.edges)+len(js))
+	for i, e := range prior.edges {
+		if ts, ok := byEdge[i]; ok {
+			out = append(out, splitLoopEdgeAtParams(e, ts)...)
+		} else {
+			out = append(out, e)
+		}
+	}
+	return priorTrimLoop{edges: out}
+}
+
+// splitLoopEdgeAtParams cuts one edge into sub-edges at the given interior parameters, ordered along the
+// edge's own traversal sense (t0→t1), each sub-edge re-emitting the SAME analytic curve over its own range.
+func splitLoopEdgeAtParams(e loopEdge, ts []float64) []loopEdge {
+	lo, hi := stdmath.Min(e.t0, e.t1), stdmath.Max(e.t0, e.t1)
+	mids := make([]float64, 0, len(ts))
+	for _, t := range ts {
+		if t > lo+1e-12 && t < hi-1e-12 {
+			mids = append(mids, t)
+		}
+	}
+	sort.Slice(mids, func(i, j int) bool { return stdmath.Abs(mids[i]-e.t0) < stdmath.Abs(mids[j]-e.t0) })
+	out := make([]loopEdge, 0, len(mids)+1)
+	prev := e.t0
+	for _, t := range mids {
+		out = append(out, loopEdge{curve: e.curve, t0: prev, t1: t})
+		prev = t
+	}
+	return append(out, loopEdge{curve: e.curve, t0: prev, t1: e.t1})
+}
+
+// splitImprintAtJunctions replaces each imprint loop the triple points lie on with OPEN sub-polylines split
+// at those points (their endpoints are the exact triple-point vertices), so the (u,v) arrangement carries
+// each junction as a shared node welding to the split prior conic; a loop clear of every junction (the
+// disjoint back entry ellipse) passes through unchanged as a closed polyline (complete loop ingest, #1738).
+func splitImprintAtJunctions(loops []geom.Polyline, js []cornerJunction) []geom.Curve3 {
+	out := make([]geom.Curve3, 0, len(loops)+len(js))
+	for i := range loops {
+		on := junctionsOnPolyline(loops[i], js)
+		if len(on) == 0 {
+			out = append(out, &loops[i]) // pointer identity: sameRun merges by curve pointer, as polylineCurves does
+			continue
+		}
+		for _, arc := range splitPolylineRing(loops[i], on) {
+			a := arc
+			out = append(out, &a)
+		}
+	}
+	return out
+}
+
+// junctionsOnPolyline returns the triple points lying on the polyline (within junctionWeldTol of it) — the
+// junctions that split THIS loop, distinguishing the crossing loop from a disjoint one.
+func junctionsOnPolyline(pl geom.Polyline, js []cornerJunction) []math.Point3 {
+	var on []math.Point3
+	for _, j := range js {
+		if _, _, d := nearestRingSeg(pl.Vertices, j.point); d < junctionWeldTol {
+			on = append(on, j.point)
+		}
+	}
+	return on
+}
+
+// splitPolylineRing cuts a closed imprint polyline into open sub-polylines at the given on-loop points: each
+// point is inserted at its nearest segment, then the ring is walked between consecutive inserted points to
+// emit one arc apiece (two junctions → the below-notch arc and the above-notch arc, meeting at the shared
+// triple-point vertices). Each arc's endpoints are the EXACT triple points.
+func splitPolylineRing(pl geom.Polyline, pts []math.Point3) []geom.Polyline {
+	verts := ringVertices(pl.Vertices)
+	ring := make([]ringNode, 0, len(verts)+len(pts))
+	for i, v := range verts {
+		ring = append(ring, ringNode{float64(i), v, false})
+	}
+	for _, p := range pts {
+		i, tloc, _ := nearestRingSeg(verts, p)
+		ring = append(ring, ringNode{float64(i) + tloc, p, true})
+	}
+	sort.Slice(ring, func(a, b int) bool { return ring[a].key < ring[b].key })
+	return arcsBetweenSplits(ring)
+}
+
+// ringNode is one vertex of the augmented split ring: its position key (integer for an original vertex,
+// fractional for an inserted split point), the 3D point, and whether it is a split point.
+type ringNode struct {
+	key   float64
+	p     math.Point3
+	split bool
+}
+
+// arcsBetweenSplits walks the sorted ring and emits one open polyline between each consecutive pair of split
+// nodes (cyclically), so each arc's endpoints are the inserted triple points.
+func arcsBetweenSplits(ring []ringNode) []geom.Polyline {
+	var splitIdx []int
+	for i, e := range ring {
+		if e.split {
+			splitIdx = append(splitIdx, i)
+		}
+	}
+	var arcs []geom.Polyline
+	m := len(ring)
+	for s := 0; s < len(splitIdx); s++ {
+		var vs []math.Point3
+		for k := splitIdx[s]; ; k = (k + 1) % m {
+			vs = append(vs, ring[k].p)
+			if k == splitIdx[(s+1)%len(splitIdx)] {
+				break
+			}
+		}
+		if arc, err := geom.NewPolyline(vs); err == nil {
+			arcs = append(arcs, arc)
+		}
+	}
+	return arcs
+}
+
+// ringVertices drops the duplicate closing vertex of a closed polyline (first≈last) so it is a clean cyclic
+// vertex ring — the form splitPolylineRing walks.
+func ringVertices(verts []math.Point3) []math.Point3 {
+	n := len(verts)
+	if n >= 2 && float64(verts[0].DistanceTo(verts[n-1])) < junctionWeldTol {
+		return verts[:n-1]
+	}
+	return verts
+}
+
+// recoverNotchPlane recovers the first-cut plane from the prior boundary: the section arms are the plane∩
+// target-cylinder conic, so any one of them (an EllipticalArc / EllipseFull) carries the plane exactly in its
+// Center + Normal. ok=false when the prior boundary has no planar-section arm (a CURVED first cut — out of
+// the corner-junction scope, declines observably; ADR-0048 §out-of-scope).
+func recoverNotchPlane(prior priorTrimLoop) (geom.Plane, bool) {
+	for _, e := range prior.edges {
+		switch c := e.curve.(type) {
+		case geom.EllipticalArc:
+			pl, err := geom.NewPlane(c.Center, c.Normal.AsVector())
+			return pl, err == nil
+		case geom.EllipseFull:
+			pl, err := geom.NewPlane(c.Center, c.Normal.AsVector())
+			return pl, err == nil
+		}
+	}
+	return geom.Plane{}, false
+}
+
+// rodNotchSection returns the tool rod's trace of the notch plane — the rod∩notch-plane ellipse — the shared
+// curve that trims the rod tunnel wall AND bites the notch cap (both split at the same triple points, so all
+// three faces meet there watertight; ADR-0048 §tool-side weld). ok=false when the analytic section is
+// unavailable.
+func rodNotchSection(notch geom.Plane, rod geom.Cylinder, res geom.Resolution) (geom.Curve3, bool) {
+	curves, handled := geom.IntersectSurfacesAnalytic(notch, rod, res)
+	if !handled || len(curves) == 0 {
+		return nil, false
+	}
+	return curves[0], true
+}
+
+// rodNotchArc returns the shared rod∩notch-plane boundary as a single exact elliptical arc spanning the two
+// triple points along the side INSIDE the target cylinder — the arc that trims the rod tunnel wall AND bounds
+// the rod's bite of the notch cap. Both consumers split at the same T± by construction, so all three coupled
+// faces meet there watertight (ADR-0048 §tool-side weld). ok=false unless there are exactly two junctions and
+// the section is the expected ellipse.
+func rodNotchArc(notch geom.Plane, rod geom.Cylinder, res geom.Resolution, js []cornerJunction,
+	tgtAxisPt math.Point3, tgtAxis math.Vector3, tgtR float64) (geom.EllipticalArc, bool) {
+	sec, ok := rodNotchSection(notch, rod, res)
+	e, isEll := sec.(geom.EllipseFull)
+	if !ok || !isEll || len(js) != 2 {
+		return geom.EllipticalArc{}, false
+	}
+	a0, a1 := ellipseAngleOf(e, js[0].point), ellipseAngleOf(e, js[1].point)
+	sweep := a1 - a0
+	for sweep <= 0 {
+		sweep += 2 * stdmath.Pi
+	}
+	start := a0
+	// rodRadialDist to the TARGET axis is the point's distance to the target cylinder axis: the arc whose
+	// midpoint lies inside the target radius is the bite boundary (the removed region is inside the rod ∧
+	// inside the target); the complementary arc bulges outside the target and is discarded.
+	midDist := rodRadialDist(e.PointAt((a0+sweep/2)/(2*stdmath.Pi)), tgtAxisPt, tgtAxis)
+	if midDist >= tgtR {
+		start, sweep = a1, 2*stdmath.Pi-sweep
+	}
+	arc, err := geom.NewEllipticalArc(e.Center, e.Normal.AsVector(), e.MajorAxis.AsVector(), e.MajorRadius, e.MinorRadius, start, sweep)
+	return arc, err == nil
+}
+
+// ellipseAngleOf returns the ellipse angle a∈(−π,π] of a point on it: from P=C+Rmaj·cos(a)·û+Rmin·sin(a)·v̂,
+// cos(a)=(P−C)·û/Rmaj and sin(a)=(P−C)·v̂/Rmin (û the major axis, v̂=n×û the minor).
+func ellipseAngleOf(e geom.EllipseFull, p math.Point3) float64 {
+	d := e.Center.VectorTo(p)
+	major := e.MajorAxis.AsVector()
+	minor := e.Normal.AsVector().Cross(major)
+	return stdmath.Atan2(float64(d.Dot(minor))/e.MinorRadius, float64(d.Dot(major))/e.MajorRadius)
+}
+
+// biteNotchCap replaces the notch cap face with its rod-bitten form: every boundary edge is split at the rod
+// crossings (reusing the exact triple-point solver on the cap's own section curve, so the params land on it
+// exactly), the sub-edges INSIDE the rod are dropped, and the resulting gap is bridged by the shared rod∩
+// notch arc — the SAME arc the rod tunnel wall carries, so cap and tunnel weld at the triple points (#1738).
+// ok=false when the cap has no rod bite (no gap), so a cap the rod does not cross is left whole by the caller.
+func biteNotchCap(cap curvedFace, rodArc geom.EllipticalArc, axisPt math.Point3, axisDir math.Vector3, radius float64) (curvedFace, bool) {
+	if len(cap.loops) != 1 {
+		return curvedFace{}, false
+	}
+	var kept []loopEdge
+	for _, e := range cap.loops[0].edges {
+		ts := junctionParams(edgeRodCrossings(e, 0, axisPt, axisDir, radius))
+		for _, se := range splitLoopEdgeAtParams(e, ts) {
+			if !edgeInsideRod(se, axisPt, axisDir, radius) {
+				kept = append(kept, se)
+			}
+		}
+	}
+	loop, ok := bridgeGapWithArc(kept, rodArc)
+	if !ok {
+		return curvedFace{}, false
+	}
+	return curvedFace{surface: cap.surface, reversed: cap.reversed, lineage: cap.lineage, loops: []curvedLoop{{edges: loop}}}, true
+}
+
+// junctionParams extracts the arm parameters of a set of rod crossings.
+func junctionParams(cs []cornerJunction) []float64 {
+	ts := make([]float64, len(cs))
+	for i, c := range cs {
+		ts[i] = c.tArm
+	}
+	return ts
+}
+
+// edgeInsideRod reports whether an edge's midpoint lies inside the rod — the sub-edges of the cap boundary
+// the rod removes. The midpoint is used (not an endpoint) because a bite sub-edge's endpoints are the triple
+// points, exactly ON the rod surface, where the strict test would be ambiguous.
+func edgeInsideRod(e loopEdge, axisPt math.Point3, axisDir math.Vector3, radius float64) bool {
+	mid := e.curve.PointAt((e.t0 + e.t1) / 2)
+	return rodRadialDist(mid, axisPt, axisDir) < radius
+}
+
+// bridgeGapWithArc closes the single gap the removed inside-rod sub-edges leave in the cap boundary by
+// inserting the rod∩notch arc, oriented to run from the gap's open start to its open end. The kept edges are
+// rotated so the chain begins right after the gap, so the arc appends cleanly as the loop's closing edge.
+func bridgeGapWithArc(kept []loopEdge, arc geom.EllipticalArc) ([]loopEdge, bool) {
+	n := len(kept)
+	if n == 0 {
+		return nil, false
+	}
+	gap := -1
+	for i := 0; i < n; i++ {
+		if float64(kept[i].end().DistanceTo(kept[(i+1)%n].start())) > 1e-6 {
+			gap = i
+			break
+		}
+	}
+	if gap < 0 {
+		return nil, false
+	}
+	rot := make([]loopEdge, 0, n+1)
+	for k := 0; k < n; k++ {
+		rot = append(rot, kept[(gap+1+k)%n])
+	}
+	return append(rot, orientArcBetween(arc, rot[n-1].end(), rot[0].start())), true
+}
+
+// orientArcBetween returns the arc as a loopEdge traversed from `from` to `to`, flipping the parameter range
+// when the arc's natural start is nearer the `to` endpoint.
+func orientArcBetween(arc geom.EllipticalArc, from, _ math.Point3) loopEdge {
+	if float64(arc.PointAt(0).DistanceTo(from)) <= float64(arc.PointAt(1).DistanceTo(from)) {
+		return loopEdge{curve: arc, t0: 0, t1: 1}
+	}
+	return loopEdge{curve: arc, t0: 1, t1: 0}
+}
+
+// nearestRingSeg returns the ring segment index i, the projection fraction tloc∈[0,1] along it, and the
+// perpendicular distance for the point p closest to the cyclic vertex ring — where an inserted split point
+// lands.
+func nearestRingSeg(verts []math.Point3, p math.Point3) (int, float64, float64) {
+	best, bestT, bestD := 0, 0.0, stdmath.Inf(1)
+	n := len(verts)
+	for i := 0; i < n; i++ {
+		a, b := verts[i], verts[(i+1)%n]
+		ab := a.VectorTo(b)
+		l2 := float64(ab.LengthSquared())
+		t := 0.0
+		if l2 > 1e-300 {
+			t = math.Clamp01(float64(a.VectorTo(p).Dot(ab)) / l2)
+		}
+		if d := float64(p.DistanceTo(a.TranslateBy(ab.Scale(math.Scalar(t))))); d < bestD {
+			best, bestT, bestD = i, t, d
+		}
+	}
+	return best, bestT, bestD
+}

--- a/kernel/brep/curved_corner_junction_build.go
+++ b/kernel/brep/curved_corner_junction_build.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Corner-junction assembly (EPIC Oblikovati/Oblikovati#1738, ADR-0048). The exact triple points (curved_
+// corner_junction.go) are the shared authority; this file resolves them once and drives the three coupled
+// faces — target cylinder wall, rod tunnel wall, bitten notch cap — through the SAME trimByImprint pipeline,
+// each split at those points, so curvedStitch welds them watertight. It fires only on the two-triple-point
+// TRANSVERSAL crossing that the disjoint gate (disjointFromPrior) declines today; every other config
+// (tangency, a higher-order junction, a removed bottom-circle anchor) returns ok=false and keeps the
+// observable CSG decline, so the arrangement golden stays byte-identical (ADR-0048 §consequences).
+
+// cornerCutSetup is the resolved corner-junction seam: the operands, the shared triple points and rod∩notch
+// arc, and the imprint/prior pre-split at those points that every coupled face consumes.
+type cornerCutSetup struct {
+	target, tool *topo.Body
+	tgtFace      curvedFace
+	tgtCyl       geom.Cylinder
+	band         coneSideBand_
+	toolOp       ruledOperand
+	rodCyl       geom.Cylinder
+	notchArc     geom.EllipticalArc
+	splitPrior   priorTrimLoop
+	splitImprint []geom.Curve3
+	tgtInside    func(math.Point3) bool
+}
+
+// PartialRimCornerCutGeneral builds target − tool for the corner-junction partial-rim case: a second curved
+// cut whose SSI imprint CROSSES the surviving first-cut notch boundary (#1738). It resolves the exact triple
+// points where the target cylinder, the rod surface and the notch plane meet, pre-splits every coupled face
+// there, and stitches a watertight analytic solid. ok=false (→ observable CSG decline) unless the config is a
+// clean two-triple-point transversal crossing of a recognisable notched cylinder by a bare rod.
+func PartialRimCornerCutGeneral(target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	s, ok := setupCornerCut(target, tool, rec)
+	if !ok {
+		return nil, false
+	}
+	return curvedStitch(assembleCornerFaces(s)), true
+}
+
+// setupCornerCut resolves the seam: it traces the imprint, recognises the notched target and bare rod,
+// solves the triple points, runs the transversal gate, and pre-splits the prior and imprint at the points.
+func setupCornerCut(target, tool *topo.Body, rec *diag.Recorder) (cornerCutSetup, bool) {
+	loops, okL := require2Loops(partialRimImprint(target, tool, rec))
+	f, cyl, band, prior, okT := cutCylinderSideFace(target)
+	toolOp, okO := ruledOperandOf(tool)
+	rodCyl, _, _, okR := cylinderSolidParams(facesOfAny(tool))
+	if !okL || !okT || !okO || !okR {
+		return cornerCutSetup{}, false
+	}
+	js := cornerJunctions(prior, rodCyl.Origin, rodCyl.AxisDir.AsVector(), rodCyl.Radius)
+	notch, okN := recoverNotchPlane(prior)
+	if !okN || !cornerJunctionTransversal(js, prior, cyl, rodCyl) {
+		return cornerCutSetup{}, false
+	}
+	res := geom.ResolutionForBox(target.RangeBox().Union(tool.RangeBox()))
+	arc, okA := rodNotchArc(notch, rodCyl, res, js, cyl.Origin, cyl.AxisDir.AsVector(), cyl.Radius)
+	if !okA {
+		return cornerCutSetup{}, false
+	}
+	return cornerCutSetup{
+		target: target, tool: tool, tgtFace: f, tgtCyl: cyl, band: band, toolOp: toolOp, rodCyl: rodCyl,
+		notchArc: arc, splitPrior: splitPriorAtJunctions(prior, js), splitImprint: splitImprintAtJunctions(loops, js),
+		tgtInside: cutCylinderSolidMembership(target, cyl, band),
+	}, true
+}
+
+// cornerAngFloor is the fixed dimensionless angular floor of the tangency-decline gate — a crossing shallower
+// than this is not worth trusting even with exact arithmetic. Set slightly high because a false accept ships a
+// wrong solid while a false decline only falls back to observable CSG (ADR-0048 §tangency, "bias to decline").
+const cornerAngFloor = 0.02
+
+// cornerJunctionTransversal is the scale-invariant tangency gate (ADR-0048): it accepts ONLY a clean pair of
+// transversal triple points. It rejects any count other than two (a tangency degenerates to a single double
+// root; a higher-order junction gives more), and rejects a pair where either the two SURFACES graze
+// (‖n_target × n_rod‖→0, a singular SSI) or the two boundary CURVES graze (sinθ_metric→0, the corner cusp).
+// The angle is the genuine 3D tangent-plane angle, which on a developable cylinder already equals the metric
+// angle in I=diag(R²,1) — scale-invariant with no R weighting. The threshold is ε_effective=max(ε_ang,
+// τ/h_local): a fixed angular floor OR the backward-error resolution ratio, whichever is larger.
+func cornerJunctionTransversal(js []cornerJunction, prior priorTrimLoop, tgt, rod geom.Cylinder) bool {
+	if len(js) != 2 {
+		return false
+	}
+	hLocal := float64(js[0].point.DistanceTo(js[1].point))
+	tau := geom.ResolutionForSize(hLocal + tgt.Radius).Stitch()
+	epsEff := cornerAngFloor
+	if hLocal > 0 {
+		epsEff = stdmath.Max(cornerAngFloor, tau/hLocal)
+	}
+	for _, j := range js {
+		surfSurf, curveCurve := junctionDegeneracy(j, prior, tgt.Origin, tgt.AxisDir.AsVector(), rod.Origin, rod.AxisDir.AsVector())
+		if surfSurf < cornerAngFloor || curveCurve < epsEff {
+			return false
+		}
+	}
+	return true
+}
+
+// assembleCornerFaces builds the result's face set: the target's breached wall + its caps (the notch cap
+// bitten by the rod, the others whole) + the rod's tunnel wall and any blind cap reversed into the cavity —
+// the corner-junction analogue of cutFaces, differing only in that three faces are split at the seam.
+func assembleCornerFaces(s cornerCutSetup) []curvedFace {
+	faces := append([]curvedFace{}, cornerTargetWall(s)...)
+	faces = append(faces, cornerCaps(s)...)
+	faces = append(faces, reverseCurvedFaces(cornerToolTunnel(s))...)
+	return append(faces, reverseCurvedFaces(capsInside(s.tool, s.tgtInside))...)
+}
+
+// cornerTargetWall trims the target cylinder side by the pre-split imprint, composing the pre-split prior
+// notch as constraint edges — the same cutCylinderUV path the disjoint case uses, now fed shared triple-point
+// vertices so its imprint↔prior junctions weld exactly.
+func cornerTargetWall(s cornerCutSetup) []curvedFace {
+	c := newCutCylinderUVSolid(s.tgtCyl, s.band, s.splitPrior, Difference, false, s.toolOp.inside)
+	c.placeSeams(s.splitImprint)
+	faces, _, _ := trimByImprint(&c, s.tgtFace, s.tgtCyl, s.splitImprint, cutCylinderMaterial(&c))
+	return faces
+}
+
+// cornerToolTunnel trims the rod side by its own imprint PLUS the rod∩notch arc, so the tunnel wall is cut by
+// the notch at the same triple points (the rod's membership already drops cells above the notch; it only
+// lacked the arrangement edge to follow — ADR-0048 §tool-side weld).
+func cornerToolTunnel(s cornerCutSetup) []curvedFace {
+	imprint := append(append([]geom.Curve3{}, s.splitImprint...), s.notchArc)
+	faces, _ := s.toolOp.split(imprint, Difference, true, s.tgtInside)
+	return faces
+}
+
+// cornerCaps returns the target's outward caps with the rod-crossed notch cap replaced by its bitten form and
+// every other cap kept whole — biteNotchCap returns ok only for a cap the rod actually crosses.
+func cornerCaps(s cornerCutSetup) []curvedFace {
+	var out []curvedFace
+	for _, cap := range capsOutside(s.target, s.toolOp.inside) {
+		if bitten, ok := biteNotchCap(cap, s.notchArc, s.rodCyl.Origin, s.rodCyl.AxisDir.AsVector(), s.rodCyl.Radius); ok {
+			out = append(out, bitten)
+		} else {
+			out = append(out, cap)
+		}
+	}
+	return out
+}

--- a/kernel/brep/curved_corner_junction_test.go
+++ b/kernel/brep/curved_corner_junction_test.go
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// notchedTargetBody builds the r=3 h=10 cylinder already notched by the first oblique cut (plane x+z≤9.5) —
+// the already-cut target the corner-junction fixtures cut a second time.
+func notchedTargetBody(t *testing.T) *topo.Body {
+	t.Helper()
+	bare, err := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 3, 10)
+	if err != nil {
+		t.Fatalf("bare cylinder: %v", err)
+	}
+	pl, _ := geom.NewPlane(math.P3(1.5, 0, 8), math.V3(1, 0, 1))
+	target, err := HalfSpaceCut(bare, pl)
+	if err != nil {
+		t.Fatalf("notch cut: %v", err)
+	}
+	return target
+}
+
+// Slice A (EPIC #1738, ADR-0048): the exact triple-point solver. The corner-junction fixture is the notched
+// r=3 cylinder cut by a rod r=1 axis +x at z=7; the rod's front loop crosses the first-cut plane x+z=9.5 at
+// two points that lie on ALL THREE surfaces (target cylinder, rod, notch plane) — the shared vertices the
+// coupled faces re-emit to. Hand-derived (Method C): on C_P(u)=(3cos u,3sin u,9.5−3cos u), the rod implicit
+// gives cos u=0.95 → (2.85, ±0.9367, 6.65).
+
+func TestCornerJunctionsAreExactTriplePoints(t *testing.T) {
+	target := notchedTargetBody(t)
+	_, _, _, prior, ok := cutCylinderSideFace(target)
+	if !ok {
+		t.Fatal("notched target has no recognisable cut cylinder side")
+	}
+	rodAxisPt, rodAxis, rodR := math.P3(-6, 0, 7), math.V3(1, 0, 0), 1.0
+	js := cornerJunctions(prior, rodAxisPt, rodAxis, rodR)
+	if len(js) != 2 {
+		t.Fatalf("cornerJunctions found %d triple points; want 2 (the front loop crosses the notch twice)", len(js))
+	}
+	for _, j := range js {
+		p := j.point
+		if d := rodRadialDist(p, rodAxisPt, rodAxis); stdmath.Abs(d-rodR) > 1e-7 {
+			t.Errorf("junction (%.5f,%.5f,%.5f) rod-axis distance %.9f; want %.1f (on rod surface)", p.X, p.Y, p.Z, d, rodR)
+		}
+		if r := stdmath.Hypot(float64(p.X), float64(p.Y)); stdmath.Abs(r-3) > 1e-7 {
+			t.Errorf("junction (%.5f,%.5f,%.5f) target-axis distance %.9f; want 3 (on target cylinder)", p.X, p.Y, p.Z, r)
+		}
+		if g := float64(p.X) + float64(p.Z) - 9.5; stdmath.Abs(g) > 1e-7 {
+			t.Errorf("junction (%.5f,%.5f,%.5f) plane residual x+z-9.5=%.9f; want 0 (on notch plane)", p.X, p.Y, p.Z, g)
+		}
+		if stdmath.Abs(float64(p.X)-2.85) > 1e-3 || stdmath.Abs(float64(p.Z)-6.65) > 1e-3 || stdmath.Abs(stdmath.Abs(float64(p.Y))-0.9367) > 1e-3 {
+			t.Errorf("junction (%.5f,%.5f,%.5f) not at the hand-derived (2.85,±0.9367,6.65)", p.X, p.Y, p.Z)
+		}
+	}
+	// Both crossings are transversal (the rod pierces the notch boundary, not grazes it): both degeneracy
+	// sines sit well clear of 0, so the tangency gate keeps this config on the analytic path.
+	for _, j := range js {
+		surfSurf, curveCurve := junctionDegeneracy(j, prior, math.P3(0, 0, 0), math.V3(0, 0, 1), rodAxisPt, rodAxis)
+		if surfSurf < 0.05 {
+			t.Errorf("junction surface-surface sine %.4f too small — surfaces near tangent (unexpected here)", surfSurf)
+		}
+		if curveCurve < 0.05 {
+			t.Errorf("junction curve-curve sine %.4f too small — boundaries near graze (unexpected here)", curveCurve)
+		}
+	}
+}
+
+// TestCornerPreSplitSharesExactVertices is the watertightness precondition (ADR-0048): after the pre-split
+// every triple point is an EXACT endpoint of both a prior sub-edge AND an imprint sub-arc, so the arrangement
+// re-emits one shared 3D vertex and the weld closes. Without this the two arms re-anchor to a chord point vs
+// an on-cylinder point (~2.6e-4 apart) and the junction splits (the χ=1/free=5 bug).
+func TestCornerPreSplitSharesExactVertices(t *testing.T) {
+	target := notchedTargetBody(t)
+	rod, err := SolidCylinder(math.P3(-6, 0, 7), math.V3(1, 0, 0), 1, 12)
+	if err != nil {
+		t.Fatalf("rod: %v", err)
+	}
+	loops, ok := require2Loops(partialRimImprint(target, rod, &diag.Recorder{}))
+	if !ok {
+		t.Fatalf("imprint did not trace as two loops")
+	}
+	_, _, _, prior, _ := cutCylinderSideFace(target)
+	js := cornerJunctions(prior, math.P3(-6, 0, 7), math.V3(1, 0, 0), 1)
+
+	sp := splitPriorAtJunctions(prior, js)
+	if len(sp.edges) != len(prior.edges)+len(js) {
+		t.Errorf("split prior has %d edges; want %d (+1 per junction)", len(sp.edges), len(prior.edges)+len(js))
+	}
+	si := splitImprintAtJunctions(loops, js)
+
+	for _, j := range js {
+		if !endpointNear(priorEdgeEndpoints(sp.edges), j.point, 1e-9) {
+			t.Errorf("triple point (%.5f,%.5f,%.5f) is not an exact prior sub-edge endpoint", j.point.X, j.point.Y, j.point.Z)
+		}
+		if !endpointNear(imprintEndpoints(si), j.point, 1e-9) {
+			t.Errorf("triple point (%.5f,%.5f,%.5f) is not an exact imprint sub-arc endpoint", j.point.X, j.point.Y, j.point.Z)
+		}
+	}
+	// The disjoint back entry ellipse must survive as ONE closed polyline (complete loop ingest, no split).
+	closed := 0
+	for _, cv := range si {
+		if pl, isPl := cv.(*geom.Polyline); isPl {
+			n := len(pl.Vertices)
+			if n >= 2 && float64(pl.Vertices[0].DistanceTo(pl.Vertices[n-1])) < 1e-6 {
+				closed++
+			}
+		}
+	}
+	if closed != 1 {
+		t.Errorf("split imprint has %d closed loops; want 1 (the untouched back entry ellipse)", closed)
+	}
+}
+
+// TestRodNotchSectionPassesThroughTriplePoints: the shared rod∩notch-plane ellipse (which trims the tunnel
+// and bites the notch cap) must pass through BOTH triple points, so all three coupled faces meet there.
+func TestRodNotchSectionPassesThroughTriplePoints(t *testing.T) {
+	target := notchedTargetBody(t)
+	_, _, _, prior, _ := cutCylinderSideFace(target)
+	notch, ok := recoverNotchPlane(prior)
+	if !ok {
+		t.Fatal("could not recover the notch plane from the prior boundary")
+	}
+	if n := notch.Normal(); stdmath.Abs(float64(n.X)-float64(n.Z)) > 1e-9 {
+		t.Errorf("notch normal (%.4f,%.4f,%.4f) not proportional to (1,0,1)", n.X, n.Y, n.Z)
+	}
+	rod, _ := SolidCylinder(math.P3(-6, 0, 7), math.V3(1, 0, 0), 1, 12)
+	rodCyl, _, _, _ := cylinderSolidParams(facesOfAny(rod))
+	res := geom.ResolutionForSize(20)
+	sec, ok := rodNotchSection(notch, rodCyl, res)
+	if !ok {
+		t.Fatal("rod∩notch-plane section unavailable")
+	}
+	// Every section sample lies on BOTH the notch plane and the rod surface — confirms the correct ellipse.
+	for i := 0; i <= 256; i++ {
+		p := sec.PointAt(float64(i) / 256)
+		if g := float64(p.X) + float64(p.Z) - 9.5; stdmath.Abs(g) > 1e-7 {
+			t.Fatalf("section sample off the notch plane by %.9f", g)
+		}
+		if d := rodRadialDist(p, math.P3(-6, 0, 7), math.V3(1, 0, 0)); stdmath.Abs(d-1) > 1e-7 {
+			t.Fatalf("section sample off the rod surface by %.9f", d-1)
+		}
+	}
+	// Each triple point lies on the section ellipse — established as "on the notch plane AND on the rod
+	// surface" (the ellipse is exactly plane∩rod), the same invariant TestCornerJunctionsAreExactTriplePoints
+	// asserts to 1e-7. So the shared section curve and the shared vertices are the same geometry.
+	for _, j := range cornerJunctions(prior, math.P3(-6, 0, 7), math.V3(1, 0, 0), 1) {
+		onPlane := stdmath.Abs(float64(j.point.X)+float64(j.point.Z)-9.5) < 1e-7
+		onRod := stdmath.Abs(rodRadialDist(j.point, math.P3(-6, 0, 7), math.V3(1, 0, 0))-1) < 1e-7
+		if !onPlane || !onRod {
+			t.Errorf("triple point (%.4f,%.4f,%.4f) not on plane∩rod (onPlane=%v onRod=%v)", j.point.X, j.point.Y, j.point.Z, onPlane, onRod)
+		}
+	}
+}
+
+// TestCornerJunctionGateAcceptsTransversalDeclinesGrazing pins the scale-invariant tangency gate (Slice B,
+// ADR-0048): a clean transversal crossing (rod at z=7, its front loop piercing the notch) is accepted, while
+// a rod that only GRAZES the notch floor (z=5.5, its top tangent to the section) declines — the bias-toward-
+// decline that keeps a shallow crossing off the analytic path.
+func TestCornerJunctionGateAcceptsTransversalDeclinesGrazing(t *testing.T) {
+	for _, tc := range []struct {
+		z    float64
+		want bool
+	}{{7.0, true}, {5.5, false}} {
+		target := notchedTargetBody(t)
+		rod, err := SolidCylinder(math.P3(-6, 0, math.Scalar(tc.z)), math.V3(1, 0, 0), 1, 12)
+		if err != nil {
+			t.Fatalf("rod z=%.1f: %v", tc.z, err)
+		}
+		_, cyl, _, prior, _ := cutCylinderSideFace(target)
+		rodCyl, _, _, _ := cylinderSolidParams(facesOfAny(rod))
+		js := cornerJunctions(prior, rodCyl.Origin, rodCyl.AxisDir.AsVector(), rodCyl.Radius)
+		if got := cornerJunctionTransversal(js, prior, cyl, rodCyl); got != tc.want {
+			t.Errorf("z=%.1f: transversal gate = %v (%d junctions); want %v", tc.z, got, len(js), tc.want)
+		}
+	}
+}
+
+// TestCornerJunctionScaleInvariantAngle confirms the gate measures the TRUE geometric crossing angle, equal
+// on cylinders of vastly different radii — the first-fundamental-form quotient (ADR-0048). The same relative
+// crossing geometry, scaled ×1000 in radius, yields the same curve-curve sine (no R shear).
+func TestCornerJunctionScaleInvariantAngle(t *testing.T) {
+	sines := make([]float64, 0, 2)
+	for _, s := range []float64{1, 1000} {
+		bare, _ := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), math.Scalar(3*s), math.Scalar(10*s))
+		pl, _ := geom.NewPlane(math.P3(math.Scalar(1.5*s), 0, math.Scalar(8*s)), math.V3(1, 0, 1))
+		target, err := HalfSpaceCut(bare, pl)
+		if err != nil {
+			t.Fatalf("scale %.0f notch: %v", s, err)
+		}
+		_, cyl, _, prior, ok := cutCylinderSideFace(target)
+		if !ok {
+			t.Fatalf("scale %.0f: no cut side", s)
+		}
+		rodPt, rodAxis, rodR := math.P3(math.Scalar(-6*s), 0, math.Scalar(7*s)), math.V3(1, 0, 0), 1*s
+		js := cornerJunctions(prior, rodPt, rodAxis, rodR)
+		if len(js) != 2 {
+			t.Fatalf("scale %.0f: %d junctions; want 2", s, len(js))
+		}
+		_, cc := junctionDegeneracy(js[0], prior, cyl.Origin, cyl.AxisDir.AsVector(), rodPt, rodAxis)
+		sines = append(sines, cc)
+	}
+	if stdmath.Abs(sines[0]-sines[1]) > 1e-6 {
+		t.Errorf("curve-curve sine drifted with radius: R=1 gave %.8f, R=1000 gave %.8f (want scale-invariant)", sines[0], sines[1])
+	}
+}
+
+func priorEdgeEndpoints(edges []loopEdge) []math.Point3 {
+	pts := make([]math.Point3, 0, 2*len(edges))
+	for _, e := range edges {
+		pts = append(pts, e.start(), e.end())
+	}
+	return pts
+}
+
+func imprintEndpoints(curves []geom.Curve3) []math.Point3 {
+	var pts []math.Point3
+	for _, c := range curves {
+		pts = append(pts, c.PointAt(0), c.PointAt(1))
+	}
+	return pts
+}
+
+func endpointNear(pts []math.Point3, target math.Point3, tol float64) bool {
+	for _, p := range pts {
+		if float64(p.DistanceTo(target)) < tol {
+			return true
+		}
+	}
+	return false
+}

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -238,7 +238,7 @@ var curvedExactPaths = []func(PartFeatureOperation, *topo.Body, *topo.Body, *dia
 	curvedCrossingIntersect, curvedSteinmetzIntersect, curvedConeCylinderIntersect, curvedConeConeIntersect,
 	curvedPartialIntersect,
 	// Cut — [P] the drill through-hole (curved-on-planar), the rest [T] transversal.
-	curvedCylindricalHoleCut, curvedFlatSubtract, curvedPartialCut, curvedSteinmetzCut, curvedConeCylinderCut, curvedConeConeCut, curvedCapCrossCut, curvedRimCrossCut, curvedTwoCapCrossCut, curvedConeCapCrossCut, curvedPartialRimCut, curvedCrossingCut,
+	curvedCylindricalHoleCut, curvedFlatSubtract, curvedPartialCut, curvedSteinmetzCut, curvedConeCylinderCut, curvedConeConeCut, curvedCapCrossCut, curvedRimCrossCut, curvedTwoCapCrossCut, curvedConeCapCrossCut, curvedPartialRimCut, curvedPartialRimCornerCut, curvedCrossingCut,
 	// Join — [D] coaxial (degenerate overlap), [P] boss (curved-on-planar), the rest [T] transversal.
 	curvedCoaxialJoin, curvedCylinderBossJoin, curvedPartialJoin, curvedConeCylinderJoin, curvedConeConeJoin, curvedCrossingJoin, curvedSteinmetzJoin,
 }

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -66,17 +66,18 @@ var (
 	curvedPartialIntersect      = gatedCurved(Intersect, brep.PartialPenetrationIntersectGeneral)
 
 	// Cut — drilling the target with the tool (through, blind, or two stubs of tool − target).
-	curvedCylindricalHoleCut = gatedCurved(Cut, withoutRecorder(brep.DrillThroughHole)) // straight cylinder through a planar slab
-	curvedPartialCut         = gatedCurved(Cut, brep.PartialPenetrationCutGeneral)      // blind rod hole
-	curvedSteinmetzCut       = gatedCurved(Cut, brep.SteinmetzCutGeneral)               // equal-R bicylinder bite, general pipeline
-	curvedConeCylinderCut    = gatedCurved(Cut, brep.ConeCylinderCutGeneral)
-	curvedConeConeCut        = gatedCurved(Cut, brep.ConeConeCutGeneral)
-	curvedCrossingCut        = gatedCurved(Cut, brep.CrossingCylinderCutGeneral)
-	curvedCapCrossCut        = gatedCurved(Cut, brep.CapCrossingCutGeneral)     // oblique tool exits one cap, ellipse inside rim (#1724)
-	curvedRimCrossCut        = gatedCurved(Cut, brep.RimCrossingCutGeneral)     // oblique tool exits one cap, ellipse crosses rim (#1724 slice 2)
-	curvedTwoCapCrossCut     = gatedCurved(Cut, brep.TwoCapCrossingCutGeneral)  // steep tool exits BOTH caps, wall intact (#1724)
-	curvedConeCapCrossCut    = gatedCurved(Cut, brep.ConeCapCrossingCutGeneral) // oblique CONE tool exits one cap, ellipse inside rim (#1724)
-	curvedPartialRimCut      = gatedCurved(Cut, brep.PartialRimCutGeneral)      // second cut on an already-notched cylinder side, disjoint from the notch (#1732)
+	curvedCylindricalHoleCut  = gatedCurved(Cut, withoutRecorder(brep.DrillThroughHole)) // straight cylinder through a planar slab
+	curvedPartialCut          = gatedCurved(Cut, brep.PartialPenetrationCutGeneral)      // blind rod hole
+	curvedSteinmetzCut        = gatedCurved(Cut, brep.SteinmetzCutGeneral)               // equal-R bicylinder bite, general pipeline
+	curvedConeCylinderCut     = gatedCurved(Cut, brep.ConeCylinderCutGeneral)
+	curvedConeConeCut         = gatedCurved(Cut, brep.ConeConeCutGeneral)
+	curvedCrossingCut         = gatedCurved(Cut, brep.CrossingCylinderCutGeneral)
+	curvedCapCrossCut         = gatedCurved(Cut, brep.CapCrossingCutGeneral)      // oblique tool exits one cap, ellipse inside rim (#1724)
+	curvedRimCrossCut         = gatedCurved(Cut, brep.RimCrossingCutGeneral)      // oblique tool exits one cap, ellipse crosses rim (#1724 slice 2)
+	curvedTwoCapCrossCut      = gatedCurved(Cut, brep.TwoCapCrossingCutGeneral)   // steep tool exits BOTH caps, wall intact (#1724)
+	curvedConeCapCrossCut     = gatedCurved(Cut, brep.ConeCapCrossingCutGeneral)  // oblique CONE tool exits one cap, ellipse inside rim (#1724)
+	curvedPartialRimCut       = gatedCurved(Cut, brep.PartialRimCutGeneral)       // second cut on an already-notched cylinder side, disjoint from the notch (#1732)
+	curvedPartialRimCornerCut = gatedCurved(Cut, brep.PartialRimCornerCutGeneral) // second cut whose imprint CROSSES the notch — the coupled corner-junction (#1738, ADR-0048)
 
 	// Join — the union, keeping the analytic wall where the operands' faces are coincident or breached.
 	curvedCoaxialJoin      = gatedCurved(Join, withoutRecorder(brep.CoaxialCylinderUnion)) // coaxial equal-radius cylinders

--- a/kernel/ops/boolean_partial_rim_test.go
+++ b/kernel/ops/boolean_partial_rim_test.go
@@ -53,19 +53,46 @@ func TestPartialRimSecondCutTakesAnalyticPath(t *testing.T) {
 	}
 }
 
-// TestPartialRimInteractingCutFallsBackObservably: a second cut whose imprint crosses the removed notch is
-// outside the disjoint sub-family, so the analytic path declines and the dispatch falls back to CSG WITH the
-// observable CodeBooleanCSGFallback defect — never a silent degradation or a manifold-but-wrong analytic solid.
-func TestPartialRimInteractingCutFallsBackObservably(t *testing.T) {
-	rod, err := brep.SolidCylinder(math.P3(-6, 0, 7), math.V3(1, 0, 0), 1, 12) // z=7: exits through the notch
+// TestPartialRimCornerJunctionTakesAnalyticPath: a second cut whose imprint CROSSES the removed notch — the
+// corner-junction (#1738, ADR-0048) — is now built as an exact analytic solid, no longer an observable CSG
+// decline. The rod at z=7 straddles the notch floor, so its front loop crosses the section conic at two
+// triple points where cylinder, rod and notch plane all meet. The result must route to the analytic path
+// (NO CSG fallback) and be a valid genus-1 solid. The OCC moment + membership certification lives in
+// partial_rim_corner_certification_test.go.
+func TestPartialRimCornerJunctionTakesAnalyticPath(t *testing.T) {
+	rod, err := brep.SolidCylinder(math.P3(-6, 0, 7), math.V3(1, 0, 0), 1, 12) // z=7: front loop crosses the notch
+	if err != nil {
+		t.Fatalf("rod: %v", err)
+	}
+	rec := &diag.Recorder{}
+	res, err := BooleanWithDiagnostics(Cut, notchedTarget(t), rod, rec)
+	if err != nil {
+		t.Fatalf("corner-junction cut: %v", err)
+	}
+	if rec.Has(CodeBooleanCSGFallback) {
+		t.Errorf("corner-junction cut fell back to CSG; want the exact analytic path. recs=%v", rec.Records())
+	}
+	if r := Validate(res); !r.Valid {
+		t.Fatalf("corner-junction result is not a valid solid: %v", r.Issues)
+	}
+	if chi := res.EulerCharacteristic(); chi != 0 {
+		t.Errorf("corner-junction result chi=%d; want 0 (genus-1 through-tunnel)", chi)
+	}
+}
+
+// TestPartialRimGrazingCutDeclinesObservably: a rod that only GRAZES the notch floor (z=5.5, its top tangent
+// to the section conic) is a non-transversal contact the tangency gate declines (ADR-0048 §tangency, out of
+// scope). It must fall to the observable CSG fallback — never a manifold-but-wrong forced analytic solid.
+func TestPartialRimGrazingCutDeclinesObservably(t *testing.T) {
+	rod, err := brep.SolidCylinder(math.P3(-6, 0, 5.5), math.V3(1, 0, 0), 1, 12) // z=5.5: top grazes the notch floor
 	if err != nil {
 		t.Fatalf("rod: %v", err)
 	}
 	rec := &diag.Recorder{}
 	if _, err := BooleanWithDiagnostics(Cut, notchedTarget(t), rod, rec); err != nil {
-		t.Fatalf("interacting cut errored instead of falling back: %v", err)
+		t.Fatalf("grazing cut errored instead of falling back: %v", err)
 	}
 	if !rec.Has(CodeBooleanCSGFallback) {
-		t.Errorf("interacting partial-rim cut did not record the CSG fallback; got %v", rec.Records())
+		t.Errorf("grazing partial-rim cut did not record the CSG fallback; got %v", rec.Records())
 	}
 }

--- a/kernel/ops/partial_rim_corner_certification_test.go
+++ b/kernel/ops/partial_rim_corner_certification_test.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Corner-junction partial-rim certification (EPIC Oblikovati/Oblikovati#1738, ADR-0048). The SECOND cut's rod
+// imprint CROSSES the first-cut notch boundary: the target cylinder, the rod surface and the notch plane meet
+// at two exact triple points, shared by the target wall, the rod tunnel and the bitten notch cap. Certified
+// against an INDEPENDENT two-cut moment set from OpenCASCADE — occ.cut(occ.cut(cyl, halfspace), rod) with the
+// rod raised to z=7 so its front loop crosses the notch (experiments/occ-boolean-oracle/
+// partial_rim_corner_junction_oracle.py) — PLUS a 60³ point-membership audit vs the analytic predicate
+// ((target \ notch) \ rod), the strong right-volume-wrong-shape oracle.
+
+// OCC ground truth for the corner-junction fixture (two chained occ.cut; exact BRepGProp moments).
+const (
+	occCornerVol   = 239.9263179
+	occCornerArea  = 255.0365956
+	occCornerCx    = -0.1529414
+	occCornerCy    = 0.0
+	occCornerCz    = 4.4347653
+	occCornerFaces = 5 // holed wall + bottom cap + partial top cap + bitten notch cap + rod tunnel
+)
+
+// cornerRod is the second-cut tool: a rod r=1 axis +x at z=7, drilled so its front loop CROSSES the notch
+// (the notch floor is z=6.5 at the front rim, so the front bite straddles it). Kept in lockstep with
+// partial_rim_corner_junction_oracle.py.
+func cornerRod(t *testing.T) *topo.Body {
+	t.Helper()
+	rod, err := brep.SolidCylinder(math.P3(-6, 0, 7), math.V3(1, 0, 0), 1, 12)
+	if err != nil {
+		t.Fatalf("corner rod SolidCylinder: %v", err)
+	}
+	return rod
+}
+
+func TestPartialRimCornerCutMomentsMatchOCC(t *testing.T) {
+	res, err := Boolean(Cut, notchedTarget(t), cornerRod(t))
+	if err != nil {
+		t.Fatalf("Boolean(Cut): %v", err)
+	}
+	if n := len(res.Faces()); n != occCornerFaces {
+		t.Errorf("corner-junction cut has %d faces; want %d (holed wall + 3 caps + tunnel)", n, occCornerFaces)
+	}
+	gp := BodyGeometryProperties(res, capCertQuality())
+	if rel := stdmath.Abs(gp.Volume-occCornerVol) / occCornerVol; rel > 0.006 {
+		t.Errorf("volume %.4f vs OCC %.4f (rel %.4f > 0.006) — beyond the SSI-imprint facet deficit", gp.Volume, occCornerVol, rel)
+	}
+	if rel := stdmath.Abs(gp.Area-occCornerArea) / occCornerArea; rel > 0.004 {
+		t.Errorf("area %.4f vs OCC %.4f (rel %.4f > 0.004)", gp.Area, occCornerArea, rel)
+	}
+	occCentroid := math.P3(occCornerCx, occCornerCy, occCornerCz)
+	if d := float64(gp.Centroid.DistanceTo(occCentroid)); d > 0.05 {
+		t.Errorf("centroid (%.4f,%.4f,%.4f) vs OCC (%.4f,%.4f,%.4f): distance %.4f > 0.05",
+			gp.Centroid.X, gp.Centroid.Y, gp.Centroid.Z, occCornerCx, occCornerCy, occCornerCz, d)
+	}
+}
+
+// cornerMeshFreeEdges welds the tessellation's coincident vertices onto a grid, then counts triangle edges
+// used by other than exactly two triangles. A watertight surface mesh has ZERO such edges; any free edge is
+// a visible crack the user would see. Grid = 1e-6 cm is far below the shared-edge discretization coincidence
+// (faces meshing a common B-rep edge emit identical vertices to ~1e-9) and far above float round-off.
+func cornerMeshFreeEdges(m *Mesh) int {
+	weld := weldMeshVertices(m.Positions, 1e-6)
+	edgeUse := map[[2]int]int{}
+	for t := 0; t+2 < len(m.Indices); t += 3 {
+		a, b, c := weld[m.Indices[t]], weld[m.Indices[t+1]], weld[m.Indices[t+2]]
+		for _, e := range [][2]int{{a, b}, {b, c}, {c, a}} {
+			if e[0] > e[1] {
+				e[0], e[1] = e[1], e[0]
+			}
+			edgeUse[e]++
+		}
+	}
+	free := 0
+	for _, used := range edgeUse {
+		if used != 2 {
+			free++
+		}
+	}
+	return free
+}
+
+// weldMeshVertices maps each vertex index to the index of the first vertex sharing its rounded grid cell, so
+// faces tessellated independently but meeting on a shared B-rep edge collapse to one topological vertex.
+func weldMeshVertices(pts []math.Point3, grid float64) []int {
+	cell := func(p math.Point3) [3]int64 {
+		return [3]int64{
+			int64(stdmath.Round(float64(p.X) / grid)),
+			int64(stdmath.Round(float64(p.Y) / grid)),
+			int64(stdmath.Round(float64(p.Z) / grid)),
+		}
+	}
+	first := map[[3]int64]int{}
+	weld := make([]int, len(pts))
+	for i, p := range pts {
+		k := cell(p)
+		if j, ok := first[k]; ok {
+			weld[i] = j
+			continue
+		}
+		first[k] = i
+		weld[i] = i
+	}
+	return weld
+}
+
+// TestPartialRimCornerCutTessellationIsWatertight is the top-priority tessellation gate (CLAUDE.md: the user
+// only ever sees the mesh). The corner-junction's coupled wall/tunnel/bitten-cap tessellation must weld into a
+// crack-free surface — every triangle edge shared by exactly two triangles — so the rendered frame shows no
+// tear at the triple points. This is the reproducible headless equivalent of the live render check.
+func TestPartialRimCornerCutTessellationIsWatertight(t *testing.T) {
+	res, err := Boolean(Cut, notchedTarget(t), cornerRod(t))
+	if err != nil {
+		t.Fatalf("Boolean(Cut): %v", err)
+	}
+	mesh, _ := TessellateBody(res, DefaultQuality())
+	if free := cornerMeshFreeEdges(mesh); free != 0 {
+		t.Errorf("corner-junction tessellation has %d free edges (want 0) — a visible crack in the rendered mesh", free)
+	}
+}
+
+// TestPartialRimCornerCutMembershipMatchesCSG is the strong shape oracle: the built solid's inside/outside
+// must agree with ((target \ notch) \ rod) everywhere away from the boundary — so a right-volume-but-wrong-
+// shape build (correct moments, displaced material) still fails. The rod is at z=7 (crossing the notch).
+func TestPartialRimCornerCutMembershipMatchesCSG(t *testing.T) {
+	res, err := Boolean(Cut, notchedTarget(t), cornerRod(t))
+	if err != nil {
+		t.Fatalf("Boolean(Cut): %v", err)
+	}
+	inTarget := func(p math.Point3) bool {
+		return stdmath.Hypot(float64(p.X), float64(p.Y)) <= 3 && p.Z >= 0 && p.Z <= 10
+	}
+	aboveNotch := func(p math.Point3) bool { return float64(p.X)+float64(p.Z) > 9.5 }
+	inRod := func(p math.Point3) bool { return stdmath.Hypot(float64(p.Y), float64(p.Z)-7) <= 1 }
+	const shell = 0.15
+	nearSurface := func(p math.Point3) bool {
+		rWall := stdmath.Abs(stdmath.Hypot(float64(p.X), float64(p.Y)) - 3)
+		rNotch := stdmath.Abs(float64(p.X)+float64(p.Z)-9.5) / stdmath.Sqrt2
+		rRod := stdmath.Abs(stdmath.Hypot(float64(p.Y), float64(p.Z)-7) - 1)
+		zCap := stdmath.Min(stdmath.Abs(float64(p.Z)), stdmath.Abs(float64(p.Z)-10))
+		return rWall < shell || rNotch < shell || rRod < shell || zCap < shell
+	}
+	mesh, _ := TessellateBody(res, DefaultQuality())
+	mismatches := 0
+	const n = 60
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			for k := 0; k < n; k++ {
+				p := math.P3(math.Scalar(-3+6*(float64(i)+0.5)/n), math.Scalar(-3+6*(float64(j)+0.5)/n), math.Scalar(10*(float64(k)+0.5)/n))
+				if nearSurface(p) {
+					continue
+				}
+				if pointInMesh(mesh, p) != (inTarget(p) && !aboveNotch(p) && !inRod(p)) {
+					mismatches++
+				}
+			}
+		}
+	}
+	if mismatches > 0 {
+		t.Errorf("membership audit: %d interior points disagree with (target\\notch)\\rod (#1738 corner-junction)", mismatches)
+	}
+}


### PR DESCRIPTION
## What

Builds the **corner-junction** partial-rim cut — a second curved cut whose SSI imprint **crosses** the surviving first-cut notch boundary — as an exact analytic solid. This was the last observable-CSG-decline sub-case of the partial-rim family (#1732); it now takes the analytic path and yields a watertight genus-1 solid.

## Why

The new rod imprint and the prior notch section are two curves that meet, in 3D, at the exact **triple points** where the target cylinder, the rod surface and the notch plane all coincide. The kept region only closes watertight if the three coupled faces — the target wall, the rod tunnel, and the bitten notch cap — share the *same* exact vertices and the same rod∩notch arc. Anything less leaves a crack at the junction (the earlier forced-analytic probe collapsed to χ=1 with 5 free edges).

## How (the load-bearing pieces)

- **Exact triple points** (`cornerJunctions`/`edgeRodCrossings`): a cancellation-free 1-D root of the rod's implicit distance along the prior conic (Method C). Both arms stay exact; no shared-vertex decision rests on an approximate combinatorial value (EGC).
- **Exact pre-split** of the prior conic *and* the new imprint at those vertices, so the unchanged (u,v) arrangement walk closes with clean degree-2 corners.
- **Bitten notch cap** (`rodNotchSection`/`biteNotchCap`): the cap section is split at the triple points, its inside-rod span replaced by the rod∩notch arc; the rod tunnel is fed that same arc.
- **Scale-invariant tangency gate** (`cornerJunctionTransversal`): distinguishes surface-surface (‖n_target×n_rod‖→0) from curve-curve (sinθ→0) tangency, ε_effective = max(ε_ang, τ/h_local), biased toward decline. Grazing contact falls to the **observable CSG fallback**, never a manifold-but-wrong forced solid.
- Wired `curvedPartialRimCornerCut` into the Cut cascade **after** the disjoint partial-rim path — engaged only where `disjointFromPrior` declines, so the arrangement golden stays **byte-identical**.

## Certification

- **OpenCASCADE two-cut oracle**: 5 faces; volume within 0.6%, area 0.4%, centroid 0.05 (the residual is the universal SSI-polyline facet deficit).
- **60³ point-membership audit** vs the analytic predicate `(target \ notch) \ rod` — the right-volume-wrong-shape oracle.
- **Tessellation watertightness gate**: zero free edges (every triangle edge shared by exactly two triangles) — the reproducible headless equivalent of the render check, per the tessellation-correctness top priority.
- **Decline fixtures**: grazing rod (z=5.5) and chained curved-first-cut both keep the observable CSG fallback.
- Live offscreen render (iso + tunnel views) confirms a clean, crack-free surface at the crossing.

ADR-0048 (Accepted).

Closes #1738

🤖 Generated with [Claude Code](https://claude.com/claude-code)