### PR TITLE
feat(brep): non-periodic (u,v) core seam for a planar operand (#1591 Slice 0)

### DIFF
--- a/architecture/decisions/ADR-0049-partial-curved-on-planar-planeuv.md
+++ b/architecture/decisions/ADR-0049-partial-curved-on-planar-planeuv.md
@@ -1,0 +1,186 @@
+# ADR-0049 — Partial curved-on-planar boolean via a `planeUV` operand
+
+**Status:** Proposed (2026-07-04) — design for
+[Oblikovati#1591](https://github.com/Oblikovati/Oblikovati/issues/1591), the partial
+curved-on-planar contact deliberately deferred as a new feature by
+[ADR-0045](ADR-0045-curved-boolean-kind-taxonomy.md) §Consequences. · **Builds on**
+[ADR-0045](ADR-0045-curved-boolean-kind-taxonomy.md) (the T/P/D KIND taxonomy — this adds the
+partial case under the curved-on-planar `[P]` KIND), [ADR-0046](ADR-0046-curved-boolean-cap-crossing.md)
+(the shared `(u,v)` arrangement + OCCT-certification protocol), [ADR-0048](ADR-0048-corner-junction-coupled-overlay.md)
+(the shared-exact-point weld discipline), [ADR-0042](ADR-0042-model-scale-and-relative-tolerances.md)
+(model-relative tolerances) and [ADR-0043](ADR-0043-generalized-provenance-naming.md) (curved-stitch
+provenance). · **Touches (when built):** new `kernel/brep/curved_plane_uv*.go` +
+`curved_plane_partial_{drill,boss}.go`; two **additive** widenings of the shared
+`kernel/brep/curved_halfspace_uv_arrangement.go` + `curved_halfspace_uv_side.go`; the interior-path
+goldens; the OCCT oracle harness (`experiments/occ-boolean-oracle`, `kernel/ops/*_certification_test.go`).
+
+## Context
+
+The curved-on-planar KIND (a cylinder/cone tool crossing a **planar** face) is exact in one sub-case
+only: the imprint conic (circle for a perpendicular axis, ellipse for oblique) lies **strictly inside
+one face**, where the trim is a trivial "add the conic as an inner loop" (`drill.go`/`drill_multi.go`
+`capWithHole`, `curved_cylinder_boss.go` `JoinCylindricalBoss`). The gates
+(`circleVsCap`→`circleInsideFace`, `bossSeatFace`) return `ok=false` the moment the conic **clips a
+face boundary**, dropping the operation to triangle-soup CSG (`CodeBooleanCSGFallback`, #1407):
+
+- a drilled hole whose entry circle runs off a plate edge;
+- a boss/spigot whose base ellipse straddles or overhangs the seat-face edge.
+
+ADR-0045 asserted a `planeUV` operand was a poor fit — the shared `(u,v)` trimmer's vocabulary
+(`placeSeams`, `wrapsAllU`, `vPeriodic`, rim/seam segment tags) is steeped in **periodicity**, and a
+bounded, non-periodic, polygon-framed plane has no seam, no rims and no wrap. This ADR re-opens that
+for the **partial** case (only) now that a code-grounded audit quantifies the mismatch as **two
+additive core touches**, not a fatal leak — and now that `cutCylinderUV` has already proven the
+`uvSide` seam tolerates a non-rim frame (it substitutes a prior-trim loop for the rim circles).
+
+## Decision
+
+**Implement a `planeUV` operand that satisfies the existing `uvSide` interface, route partial
+curved-on-planar contacts through the one shared `trimByImprint` pipeline, and inject EXACT
+conic∩polygon crossings into the sampled arrangement.** Three load-bearing sub-decisions:
+
+### D-a — `planeUV` implements `uvSide` (not a parallel planar pipeline)
+
+The plane's `(u,v) = to2D(plane, ·)` arrangement *is* the planar boolean's own `Arrange`. `planeUV`
+implements `uvSide` with the periodic concepts made **inert**: `placeSeams` a no-op, `vPeriodic` /
+`uPeriodic` / `wrapsAllU` false, `wrappingSolidFaces` `(nil,false)`, and the **face polygon**
+(the seat face's outer + hole loops) tagged `segPolygon` as the arrangement frame in place of the
+ruled rim+seam frame. The DCEL walk (`chainLoops`/`nextByAngle`), cell classifier
+(`keptCells`/`interiorOfCell` pole-of-inaccessibility), loop grouping (`groupLoopFaces`) and arc
+re-emission (`emitImprintRun`) are reused **verbatim** — they are already surface-agnostic and, being
+pure planar combinatorics, are better suited to a plane than to a periodic band.
+
+### D-b — Keep the strictly-interior fast-path; add the partial path beside it (do NOT unify)
+
+The interior drill/boss handlers are fast because they **skip** imprint intersection + arrangement.
+Gate on the **existing** classification: `clean` (strictly interior) → the unchanged interior path,
+provably byte-identical; `pierced && !clean` (partial) → the new `planeUV` path, tried **before**
+returning `ok=false` to CSG. Only genuinely-partial booleans pay the arrangement cost — and those
+otherwise pay far more as CSG triangle soup.
+
+### D-c — The face polygon replaces rim+seam framing; two additive core widenings
+
+The ghost-periodic audit (below) found exactly **one** genuine leak in the shared core plus one
+tag-collision risk. Fix both additively, so every existing `uvSide` implementer stays byte-identical:
+
+1. **`segPolygon`** — a new `segKind` value. Its `sameRun` compares **curve identity** (like
+   `segImprint`), not v-level, so two distinct polygon edges at the same `v` do not wrongly merge
+   (the `segRim` constant-v assumption).
+2. **`uPeriodic`** — a new `bool` on `seamWelder` and a new `uvSide.uPeriodic()` method (ruled/torus
+   return `true`, plane `false`). The welder's currently-**unconditional** u-fold (folds any vertex at
+   `u≈2π` to `u=0`) is gated on it — the exact mirror of the v-fold already gated on `vPeriodic`.
+
+### D-d — Crossings EXACT, arrangement sampled (the numerics strategy)
+
+Keep the 256-sample imprint polyline seeding the arrangement's **non-critical interior**, but replace
+every topologically-decisive **conic∩polygon-edge crossing** with the exact algebraic root, injected
+as a split vertex carrying its exact conic parameter — the same `clipEndToBand`/`refineCurveV`
+rim-snap discipline the ruled side already uses, applied at polygon edges instead of rims. This is
+what averts the blind-straddle failure mode (a *sampled* crossing that two adjacent faces compute
+differently, leaving sliver free-edges).
+
+- **Circle ∩ edge:** the stable quadratic `qq = −½(b + sign(b)·√Δ)`, roots `t₁=qq/a`, `t₂=c₂/qq`
+  (Kahan; kills the cancellation that afflicts one root when `b²≫4ac₂`), `Δ = 4L²(r²−h²)`.
+- **Ellipse ∩ edge:** affine-normalize the ellipse to the **unit circle** (an isometry-preserving
+  linear map whose condition number is exactly `A/B = 1/cos φ`) and solve the same well-conditioned
+  quadratic — never the general `Ax²+Bxy+Cy²+…` conic quadratic.
+- **Conic parameter by closed-form inversion** (`t = atan2(...)/2π`, no iteration) is the **weld
+  currency**: the seat-face arc endpoint and the tool wall's base-rim vertex are **both** generated by
+  one shared `C.PointAt(t)`, so they are byte-identical → `freeEdgeCount == 0` (the ADR-0048 lesson:
+  shared exact points, never independently re-derived endpoints).
+- **Decline-biased gate** (mirrors `bossSeatFace`/`circleVsCap`): tangency (double root within a weld:
+  `|r²−h²| ≤ (Weld()/2)²`, a **curvature-scaled** band, not a magic constant), eccentric ellipse
+  (`B/A < 1e-3`, grazing-oblique), odd crossing parity, or a residual sub-tolerance sliver
+  (`area < Area()` or shortest edge `< Weld()` after a merge attempt) → return `ok=false` → CSG. Merge
+  slivers, never cull a kept one (culling opens a leak).
+
+## Consequences
+
+- Partial holes and straddling bosses become **exact analytic** solids (analytic `geom.Plane` seat +
+  `geom.Cylinder`/`Cone` wall preserved), no `CodeBooleanCSGFallback`.
+- Zero duplication of the hardest combinatorial code (the self-touch-correct DCEL walk, the cell
+  classifier, loop grouping) — one arrangement pipeline serves ruled, torus **and** plane.
+- The two core edits are additive: existing ruled/torus/cutCylinder goldens stay byte-identical (the
+  new flags default to current behavior).
+- Cost: the arrangement (`O((N+E)log(N+E))`, grid-hashed) is paid **only** on genuinely-partial
+  contacts; the common fully-interior bore is untouched (D-b).
+- The tolerance classifications (tangency band, sliver cull, vertex snap) are **tolerance-bounded**
+  and model-scaled; the crossings, conic parameters and the shared weld point are **EXACT**. This
+  ledger is explicit so the class of "looked exact, shipped a sliver" bug cannot recur.
+
+## Rejected alternatives
+
+- **A parallel planar imprint pipeline** (ADR-0045's implied path if `planeUV` were ever built):
+  re-implements `chainLoops`/`nextByAngle`/`groupLoopFaces` — a second self-touch-correct DCEL
+  walker — for no invariant gain. The exact bespoke-growth ADR-0045 fought.
+- **ADR-0045's "never build `planeUV`"**: superseded **only for partial contact**. Its reasoning
+  ("the cell subdivision buys nothing") stays law for the strictly-interior circle; for a
+  boundary-*clipping* conic the subdivision is precisely what is needed.
+- **Unify all drill/boss onto `planeUV`** (retire the interior fast-path): regresses the hot path and
+  re-opens tested, already-exact code for no correctness gain (D-b).
+- **General polygon clipping (Greiner–Hormann / Vatti)** carrying the conic as an edge attribute:
+  imports a clipper we do not need, whose known fragility is exactly on the vertex-on-edge / tangency
+  degeneracies this problem is dominated by.
+- **Sampled-only crossings** (trust the arrangement to find the crossing on the polyline): the
+  blind-straddle failure — a decisive vertex at a *sampled* point that adjacent faces disagree on.
+- **Reuse `segRim` for polygon edges** / **offset `planeUV`'s `(u,v)` to dodge `u≈2π`**: the first
+  trips `sameRun`'s constant-v merge; the second hides the real u-fold leak instead of gating it (D-c).
+
+## Ghost-periodic-assumptions audit (the load-bearing finding)
+
+Tracing every `uvSide` method **and** every shared free-function consumer reached from
+`trimByImprint`, a non-periodic polygon plane trips exactly **one** genuine assumption:
+
+| Shared consumer | Periodic assumption | Trips a plane? | Resolution |
+|---|---|---|---|
+| `seamWelder` u-fold (`uv_arrangement.go:517`) | folds **any** `u≈2π` vertex to `u=0`, unconditionally | **YES** — a seat vertex at ~6.283 db-units is silently welded to `u=0` | gate on `uPeriodic` (D-c), mirroring the gated v-fold |
+| `sameRun` `segRim` branch (`:1082`) | rim is constant-v ⇒ equal-v ⇒ same run | YES **if** polygon edges are tagged `segRim` | new `segPolygon` kind, `sameRun` by curve identity (D-c) |
+| `placeSeams` / `chooseSeamU` / `clipParams` / azimuth-unwrap | seam/band/wrap | No — `planeUV` overrides `assembleSegments`, makes `placeSeams` a no-op, never calls them | none |
+| `dropArtificialLoops` / `wrappingSolidFaces` / `wrapsAllU` / `segSeam` | vPeriodic / wrap band | No — early-return / `false` / no-op; branches never fire | none |
+| `chainLoops` / `nextByAngle` / `interiorOfCell` / `groupLoopFaces` / `dedgeLoopArea` | none — pure planar combinatorics | No — **better** suited to a plane (all loops contractible) | none |
+
+**Conclusion: one additive core gate + one additive segment tag — not a periodicity-neutral rewrite.**
+
+## Handoff — file tree, the math seam, and the slice plan
+
+New files under `kernel/brep/` (each <500 LOC, SRP, SPDX `GPL-2.0-only`):
+`curved_plane_uv.go` (the `planeUV` type + its `uvSide` methods, most one-liners) ·
+`curved_plane_uv_frame.go` (polygon framing + the conic∩polygon clip) ·
+`curved_plane_partial_drill.go` (`DrillPartialHole`) · `curved_plane_partial_boss.go`
+(`JoinPartialBoss`). No `Oblikovati.API` surface change — the boolean dispatch is already wired.
+
+The numerics seam the implementer calls (certified against OCCT `getMass`/section as oracle;
+tolerances are model-scaled expressions, never bare literals — `Weld()=1e-9·size`,
+`Plane()=1e-7·size`, `Stitch()=1e-6·size`, `Area()=1e-9·size²`):
+
+```go
+type planeConic struct{ c math.Point2; maj, min math.Vector2; A, B float64 } // circle: A==B==r
+type hitClass int
+const ( hitTransversal hitClass = iota; hitTangent; hitVertex; hitMiss )
+
+// conicEdgeHits solves C ∩ (a→b) EXACTLY: stable quadratic (ellipse affine-normalized to the unit
+// circle), s the edge param in (tjTol,1−tjTol), t the conic param in [0,1) (feeds uvSeg.tA/tB and
+// emitImprintRun). Returns hitTangent when |r²−h²| ≤ (Weld()/2)² (curvature-scaled).
+func conicEdgeHits(C planeConic, a, b math.Point2, res geom.Resolution) (hits []conicHit, cls hitClass)
+
+// planeUVContactOK generalizes bossSeatFace/circleVsCap, decline-biased: eccentric ellipse (B/A<1e-3),
+// any tangency, odd crossing parity, or a residual sub-tolerance sliver → false → CSG.
+func planeUVContactOK(C planeConic, f planarFace, res geom.Resolution) bool
+```
+
+Vertical slices, each independently shippable and green, gate = **volume-vs-OCC `getMass`
+(ADR-0042 relative) · `freeEdgeCount==0` · `Validate.Valid && Closed && Manifold`**:
+
+- **Slice 0 (prep):** the two additive core touches (`segPolygon` + `uPeriodic`). Gate: **all existing
+  brep/ops boolean goldens byte-identical** (flags default to current behavior). De-risks the core edit
+  alone, no feature yet.
+- **Slice A:** partial hole clipping one face edge — `planeUV` + frame + `DrillPartialHole`, off the
+  `pierced && !clean` branch. OCC oracle `box − cylinder`; interior golden still byte-identical.
+- **Slice B:** straddling/overhanging boss — `JoinPartialBoss`, reusing `planeUV` unchanged; only the
+  material closure + wall/cap assembler differ. OCC oracle `plate ∪ cylinder`.
+- **Slice C:** pin the interior drill/boss/counterbore output byte-identical (characterization golden),
+  document D-b in-code, optionally DRY the shared `interior|partial|CSG` gate. Coverage >80%,
+  duplication <3%.
+- **Slice D:** this ADR → Accepted; extend ADR-0045's taxonomy table with a "curved-on-planar
+  (partial)" row; live MCP visual test (plate + edge-clipping hole and a straddling boss; screenshot;
+  confirm crack-free tessellation, `freeEdgeCount==0`).

--- a/kernel/brep/curved_general_wrapping_band.go
+++ b/kernel/brep/curved_general_wrapping_band.go
@@ -34,7 +34,7 @@ func (c ruledUV) wrappingSolidFaces(kept []Face2D, segs []uvSeg, surface geom.Su
 		return nil, false
 	}
 	var faces []curvedFace
-	for _, comp := range keptComponents(kept, c.vPeriodic()) {
+	for _, comp := range keptComponents(kept, c.uPeriodic(), c.vPeriodic()) {
 		face, ok := c.bandFace(comp, segs, surface, f)
 		if !ok {
 			return nil, false
@@ -48,7 +48,7 @@ func (c ruledUV) wrappingSolidFaces(kept []Face2D, segs []uvSeg, surface geom.Su
 // band's two full-wrap ends and its contractible holes, then assembled as a keyhole (holed tube) or a
 // two-closed-loop band (a clean stub) — the two shapes the curved mesher renders correctly (#1476).
 func (c ruledUV) bandFace(comp []Face2D, segs []uvSeg, surface geom.Surface, f curvedFace) (curvedFace, bool) {
-	loops := dropArtificialLoops(&c, chainLoops(keptBoundaryEdges(comp, c.vPeriodic())), segs)
+	loops := dropArtificialLoops(&c, chainLoops(keptBoundaryEdges(comp, c.uPeriodic(), c.vPeriodic())), segs)
 	emitted, ok := emitKeptLoops(&c, loops, segs)
 	if !ok {
 		return curvedFace{}, false
@@ -152,8 +152,8 @@ func (c ruledUV) loopWrapsU(e emittedLoop) bool {
 // two disjoint stubs a rod leaves either side of the fat become separate faces (#1476). Two cells are in the
 // same band iff they share an edge; the seam fold makes cells on either side of the azimuth seam adjacent, so
 // a band wrapping the seam stays one component.
-func keptComponents(kept []Face2D, vPeriodic bool) [][]Face2D {
-	w := newSeamWelder(vPeriodic)
+func keptComponents(kept []Face2D, uPeriodic, vPeriodic bool) [][]Face2D {
+	w := newSeamWelder(uPeriodic, vPeriodic)
 	uf := newBandUF(len(kept))
 	edgeCell := map[[2]int]int{}
 	for ci, cell := range kept {

--- a/kernel/brep/curved_general_wrapping_band_test.go
+++ b/kernel/brep/curved_general_wrapping_band_test.go
@@ -15,7 +15,7 @@ func TestKeptComponentsSplitsDisjointBands(t *testing.T) {
 		return Face2D{Outer: []math.Point2{math.P2(x, 0), math.P2(x+1, 0), math.P2(x+1, 1), math.P2(x, 1)}}
 	}
 	left, mid, far := cellAt(0), cellAt(1), cellAt(10) // left & mid share the edge x=1; far is disjoint
-	comps := keptComponents([]Face2D{left, mid, far}, false)
+	comps := keptComponents([]Face2D{left, mid, far}, true, false)
 	if len(comps) != 2 {
 		t.Fatalf("keptComponents = %d bands, want 2 (left+mid joined, far separate)", len(comps))
 	}

--- a/kernel/brep/curved_halfspace_ruled_uv.go
+++ b/kernel/brep/curved_halfspace_ruled_uv.go
@@ -79,6 +79,10 @@ func (c *ruledUV) placeSeams(imprint []geom.Curve3) { c.seamU = c.chooseSeamU(im
 // vPeriodic reports that a ruled side's v (axial distance) does NOT wrap — only u does (uvSide).
 func (c ruledUV) vPeriodic() bool { return false }
 
+// uPeriodic reports that a ruled side's u (azimuth) DOES wrap (u=0≡2π), so the boundary welder folds the
+// seam (uvSide). cutCylinderUV inherits this through embedding (#1591).
+func (c ruledUV) uPeriodic() bool { return true }
+
 // multiFace reports whether the kept region may be disconnected (uvSide): only the general curved∩curved
 // cut (solidMode) can leave several faces (the two lens caps a rod punches in a fat cone); a plane half-space
 // always leaves one connected region (#1403).

--- a/kernel/brep/curved_halfspace_torus_uv.go
+++ b/kernel/brep/curved_halfspace_torus_uv.go
@@ -59,6 +59,9 @@ func (c *torusUV) placeSeams(imprint []geom.Curve3) {
 // are dropped (uvSide).
 func (c torusUV) vPeriodic() bool { return true }
 
+// uPeriodic reports that a torus's azimuth u wraps (u=0≡2π), so the welder folds the u-seam (uvSide, #1591).
+func (c torusUV) uPeriodic() bool { return true }
+
 // wrapsAllU is unused by the torus orientation (it classifies loops by winding, not a wrap flag), so it
 // reports false (uvSide).
 func (c torusUV) wrapsAllU() bool { return false }

--- a/kernel/brep/curved_halfspace_uv_arrangement.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement.go
@@ -43,14 +43,19 @@ func (c ruledUV) paramOf(p math.Point3) math.Point2 {
 }
 
 // segKind tags what a (u,v) segment re-emits to when it bounds a kept cell: an imprint sub-arc (the cut),
-// a band rim (constant v, a circle arc), or the azimuth SEAM ruling (u=0≡2π — an ARTIFICIAL edge that
-// closes the parameter rectangle for the arrangement and dissolves wherever the kept region wraps it).
+// a band rim (constant v, a circle arc), the azimuth SEAM ruling (u=0≡2π — an ARTIFICIAL edge that
+// closes the parameter rectangle for the arrangement and dissolves wherever the kept region wraps it), or a
+// non-periodic face-POLYGON boundary edge (a bounded plane's real analytic frame — see planeUV, #1591).
 type segKind int
 
 const (
 	segImprint segKind = iota
 	segRim
 	segSeam
+	// segPolygon frames a non-periodic planar face by its boundary edges instead of rim circles + a seam.
+	// Unlike segRim (constant v ⇒ equal-v means same run) each polygon edge is a distinct analytic curve, so
+	// sameRun compares curve identity like segImprint — two polygon edges at the same v must NOT merge (#1591).
+	segPolygon
 )
 
 // uvSeg is one sampled segment of an imprint curve in the side's (u,v) band, tagged with the analytic
@@ -503,18 +508,21 @@ const seamWeldGrid = 1e-7
 type seamWelder struct {
 	index     map[[2]int64]int
 	points    []math.Point2
+	uPeriodic bool
 	vPeriodic bool
 }
 
-func newSeamWelder(vPeriodic bool) *seamWelder {
-	return &seamWelder{index: map[[2]int64]int{}, vPeriodic: vPeriodic}
+func newSeamWelder(uPeriodic, vPeriodic bool) *seamWelder {
+	return &seamWelder{index: map[[2]int64]int{}, uPeriodic: uPeriodic, vPeriodic: vPeriodic}
 }
 
 // add returns the welded index of p, normalising u=2π to u=0 (and, on a v-periodic surface, v=2π to v=0)
-// first so a seam vertex on either side of the parameter rectangle maps to one ruling/tube vertex.
+// first so a seam vertex on either side of the parameter rectangle maps to one ruling/tube vertex. On a
+// NON-periodic side (a bounded plane, planeUV) u is a real world distance, not an azimuth: folding u≈2π
+// would silently weld a genuine face vertex onto u=0, so the u-fold is gated on uPeriodic (#1591).
 func (w *seamWelder) add(p math.Point2) int {
 	u, v := float64(p.X), float64(p.Y)
-	if stdmath.Abs(u-2*stdmath.Pi) < seamWeldGrid {
+	if w.uPeriodic && stdmath.Abs(u-2*stdmath.Pi) < seamWeldGrid {
 		u = 0
 	}
 	if w.vPeriodic && stdmath.Abs(v-2*stdmath.Pi) < seamWeldGrid {
@@ -543,8 +551,8 @@ type dedge struct {
 // wrapping region traverses on both sides) appears as a reverse-twin pair and cancels, leaving exactly the
 // edges between kept material and dropped material (or the band rims). This is the cross-seam merge and the
 // shared-edge dissolve in one pass (#1405).
-func keptBoundaryEdges(kept []Face2D, vPeriodic bool) []dedge {
-	w := newSeamWelder(vPeriodic)
+func keptBoundaryEdges(kept []Face2D, uPeriodic, vPeriodic bool) []dedge {
+	w := newSeamWelder(uPeriodic, vPeriodic)
 	var all []dedge
 	add := func(poly []math.Point2) {
 		for i, n := 0, len(poly); i < n; i++ {
@@ -1076,7 +1084,9 @@ func sameRun(a, b recoveredEdge) bool {
 		return false
 	}
 	switch a.kind {
-	case segImprint:
+	case segImprint, segPolygon:
+		// A polygon edge, like an imprint arc, is a distinct analytic curve; equal v does NOT imply same run
+		// (that is only true for a constant-v rim), so identity is the run test (#1591).
 		return a.curve == b.curve
 	case segRim:
 		return stdmath.Abs(float64(a.a.Y)-float64(b.a.Y)) < 1e-6

--- a/kernel/brep/curved_halfspace_uv_arrangement_test.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement_test.go
@@ -223,7 +223,7 @@ func TestKeptBoundaryWrappingBandTwoLoops(t *testing.T) {
 	c := cylinderRuledUV(3, -5, 5)
 	c.s = 1 // g(u,v)=v -> keep v<0
 	cells := arrangeBand(c.assembleBandSegments(c.horizontalCutImprint(t, 0)))
-	loops := chainLoops(keptBoundaryEdges(keptCells(cells, c.halfSpaceMaterial()), false))
+	loops := chainLoops(keptBoundaryEdges(keptCells(cells, c.halfSpaceMaterial()), true, false))
 	if len(loops) != 2 {
 		t.Fatalf("wrapping band: %d boundary loops, want 2 (rim + section)", len(loops))
 	}
@@ -257,7 +257,7 @@ func TestKeptBoundaryTongueSingleLoop(t *testing.T) {
 	if len(kept) != 1 {
 		t.Fatalf("tongue: %d kept cells, want 1", len(kept))
 	}
-	if loops := chainLoops(keptBoundaryEdges(kept, false)); len(loops) != 1 {
+	if loops := chainLoops(keptBoundaryEdges(kept, true, false)); len(loops) != 1 {
 		t.Fatalf("tongue: %d boundary loops, want 1", len(loops))
 	}
 }
@@ -406,7 +406,7 @@ func TestEmitLoopEdgesStructurallyValid(t *testing.T) {
 	c := cylinderRuledUV(3, -5, 5)
 	c.s = 1 // g(u,v)=v -> keep v<0
 	segs := c.assembleBandSegments(c.horizontalCutImprint(t, 0))
-	loops := chainLoops(keptBoundaryEdges(keptCells(arrangeBand(segs), c.halfSpaceMaterial()), false))
+	loops := chainLoops(keptBoundaryEdges(keptCells(arrangeBand(segs), c.halfSpaceMaterial()), true, false))
 	if len(loops) != 2 {
 		t.Fatalf("want 2 boundary loops, got %d", len(loops))
 	}

--- a/kernel/brep/curved_halfspace_uv_side.go
+++ b/kernel/brep/curved_halfspace_uv_side.go
@@ -33,6 +33,10 @@ type uvSide interface {
 	// vPeriodic reports whether v wraps (a torus): the boundary welder then folds the v-seam too, and an
 	// all-seam (artificial-frame) boundary loop is dropped — a closed surface has no real boundary there.
 	vPeriodic() bool
+	// uPeriodic reports whether u wraps (every ruled/torus side: u is an azimuth, u=0≡2π). A bounded plane
+	// (planeUV) is NOT periodic in u — u is a real world distance — so the boundary welder must NOT fold u≈2π
+	// onto u=0, which would weld a genuine face vertex to the origin ruling (#1591).
+	uPeriodic() bool
 	// emitRun re-emits one run of recovered boundary edges (all on one analytic curve) as a single loopEdge.
 	emitRun(run []recoveredEdge) (loopEdge, bool)
 	// wrapsAllU reports whether the kept region is non-empty at every azimuth (gates the rim-orientation flip).
@@ -76,7 +80,7 @@ func trimByImprint(c uvSide, f curvedFace, surface geom.Surface, imprint []geom.
 	if faces, ok := c.wrappingSolidFaces(kept, segs, surface, f); ok {
 		return faces, nil, nil
 	}
-	loops := dropArtificialLoops(c, chainLoops(keptBoundaryEdges(kept, c.vPeriodic())), segs)
+	loops := dropArtificialLoops(c, chainLoops(keptBoundaryEdges(kept, c.uPeriodic(), c.vPeriodic())), segs)
 	var faces []curvedFace
 	var lid []loopEdge
 	// A curved∩curved cut can leave the kept region DISCONNECTED (the two lens caps a rod punches in a fat

--- a/kernel/brep/curved_plane_uv_core_test.go
+++ b/kernel/brep/curved_plane_uv_core_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// The two additive (u,v)-core touches for the non-periodic planeUV operand (#1591, ADR-0049 D-c): the
+// seamWelder u-fold gated on uPeriodic, and segPolygon's curve-identity sameRun. Unit-tested directly here
+// so the mechanism is pinned before planeUV consumes it in Slice A.
+
+// TestSeamWelderUFoldGatedOnUPeriodic: a u-periodic side folds u≈2π onto u=0 (the azimuth seam is one
+// ruling); a NON-periodic plane must NOT — u is a real world distance, so a genuine face vertex near u=2π
+// stays distinct from the origin.
+func TestSeamWelderUFoldGatedOnUPeriodic(t *testing.T) {
+	twoPi := math.Scalar(2 * stdmath.Pi)
+	origin, seam := math.P2(0, 1), math.P2(twoPi, 1)
+
+	periodic := newSeamWelder(true, false)
+	if periodic.add(origin) != periodic.add(seam) {
+		t.Error("u-periodic welder must fold u=2π onto u=0 (one azimuth ruling)")
+	}
+
+	plane := newSeamWelder(false, false)
+	if plane.add(origin) == plane.add(seam) {
+		t.Error("non-periodic (plane) welder must NOT fold u≈2π onto u=0 — that welds a real face vertex to the origin (#1591)")
+	}
+}
+
+// TestSameRunSegPolygonByCurveIdentity: two polygon edges at the SAME v are the same run only if they are the
+// same analytic curve — unlike a constant-v rim, where equal v alone means same run. This is why polygon
+// edges need their own segKind (#1591).
+func TestSameRunSegPolygonByCurveIdentity(t *testing.T) {
+	edgeA := geom.NewLineSegment(math.P3(0, 0, 0), math.P3(1, 0, 0))
+	edgeB := geom.NewLineSegment(math.P3(1, 0, 0), math.P3(1, 1, 0))
+	at := func(kind segKind, c geom.Curve3) recoveredEdge {
+		return recoveredEdge{kind: kind, curve: c, a: math.P2(0, 5), b: math.P2(1, 5)} // same v=5
+	}
+
+	if !sameRun(at(segPolygon, edgeA), at(segPolygon, edgeA)) {
+		t.Error("same polygon curve must be one run")
+	}
+	if sameRun(at(segPolygon, edgeA), at(segPolygon, edgeB)) {
+		t.Error("two DISTINCT polygon curves at equal v must NOT merge into one run (the segRim constant-v trap)")
+	}
+	// Contrast: two rims at equal v DO merge — the behaviour segPolygon deliberately does not inherit.
+	if !sameRun(at(segRim, edgeA), at(segRim, edgeB)) {
+		t.Error("two rims at equal v are one run (constant-v rim invariant)")
+	}
+}


### PR DESCRIPTION
## What

**Slice 0 of #1591** (partial curved-on-planar boolean). Two **additive** touches to the shared `(u,v)`-arrangement core so a bounded, non-periodic **plane** can later implement `uvSide` without the periodic machinery corrupting it, plus the design record **ADR-0049 (Proposed)**. No feature behavior yet — this de-risks the core edit in isolation.

## Why

The shared trimmer (`trimByImprint`) is built for periodic surfaces (cylinder/cone azimuth seam, torus double-periodicity). A code-grounded audit of adding a `planeUV` operand found exactly **one** genuine periodic leak in the stable core plus one tag-collision risk (ADR-0049 §Ghost-periodic audit):

- **`seamWelder` u-fold** (`curved_halfspace_uv_arrangement.go`) folds any vertex at `u≈2π` onto `u=0` (the azimuth-seam identity). For a plane, `u = to2D(...)` is a real world distance — folding it would silently weld a genuine face vertex onto the origin. Now gated on a new **`uvSide.uPeriodic()`**, the exact mirror of the already-gated `vPeriodic` v-fold. `ruledUV`/`torusUV`/`cutCylinderUV` return `true`.
- **`segPolygon`** — a new `segKind` framing a plane by its face-polygon boundary edges instead of rim circles + a seam. Its `sameRun` compares **curve identity** (like `segImprint`); two polygon edges at equal `v` must not merge — the `segRim` constant-`v` rule is a rim-only invariant.

## Test / gate

- Full `kernel/brep` + `kernel/ops` suites green and **byte-identical** (all existing goldens unchanged — the new flags default to current behavior).
- Direct unit tests: `TestSeamWelderUFoldGatedOnUPeriodic` (fold on/off), `TestSameRunSegPolygonByCurveIdentity` (polygon run rule vs the rim constant-v trap).
- Local: `go build ./kernel/...`, `go vet`, full `kernel/...` suite, `golangci-lint` (0 issues), `markdownlint-cli2` (0 errors) all clean.

## Design

ADR-0049 records the full `planeUV` design (operand seam, exact conic∩polygon numerics, decline-biased tangent/sliver gate, exact weld) synthesized from an architecture brief + a numerics brief. Extends [ADR-0045](../blob/develop/architecture/decisions/ADR-0045-curved-boolean-kind-taxonomy.md), which deferred partial curved-on-planar as a new feature.

Part of #1591 (Slice A: partial drilled hole; B: straddling boss; C: keep-interior characterization; D: ADR Accepted + live visual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)