### PR TITLE
feat(brep): planeUV operand for partial curved-on-planar contact (#1591 Slice A: operand)

### DIFF
--- a/kernel/brep/curved_plane_uv.go
+++ b/kernel/brep/curved_plane_uv.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// planeUV is a bounded, NON-periodic planar seat face expressed as a uvSide, so a partial curved-on-planar
+// boolean (a drilled hole / boss base whose imprint conic CLIPS the face boundary) runs through the one
+// shared (u,v)-arrangement trimmer instead of triangle-soup CSG (#1591, ADR-0049). The chart is the plane's
+// own (u,v) = to2D(plane, ·) — an isometry, no azimuth seam, no rim circles. The frame is the face POLYGON
+// (segPolygon edges) rather than rims+seam, and the periodic machinery is inert: placeSeams a no-op,
+// u/vPeriodic and wrapsAllU false. The material predicate keeps face-interior cells that are outside the tool.
+type planeUV struct {
+	plane  geom.Plane
+	seatUV [][]math.Point2        // seat face boundary in (u,v), outer loop first (even-odd containment)
+	seat3D [][]math.Point3        // the same loops in 3D, so each polygon edge re-emits as its exact segment
+	inTool func(math.Point3) bool // reports whether a 3D point is inside the tool solid (removed for a drill)
+}
+
+// planeUV satisfies uvSide: a non-periodic, polygon-framed plane (#1591).
+var _ uvSide = (*planeUV)(nil)
+
+// paramOf inverts a seat-plane point to its (u,v) chart coordinates (uvSide) — a plain orthonormal projection,
+// no seam offset (the plane is non-periodic).
+func (c *planeUV) paramOf(p math.Point3) math.Point2 { return to2D(c.plane, p) }
+
+// placeSeams is a no-op: a bounded plane has no artificial seam to move clear of the imprint (uvSide).
+func (c *planeUV) placeSeams(_ []geom.Curve3) {}
+
+// vPeriodic reports that a plane's v does not wrap (uvSide).
+func (c *planeUV) vPeriodic() bool { return false }
+
+// uPeriodic reports that a plane's u does not wrap — u is a real world distance, so the boundary welder must
+// NOT fold u≈2π onto u=0 (uvSide, ADR-0049 D-c).
+func (c *planeUV) uPeriodic() bool { return false }
+
+// wrapsAllU reports that a plane never wraps the azimuth — there is none (uvSide).
+func (c *planeUV) wrapsAllU() bool { return false }
+
+// multiFace reports that a plane cut may leave the seat DISCONNECTED (a slot severing the face into two
+// pieces), so the boundary loops are grouped into separate faces by containment (uvSide).
+func (c *planeUV) multiFace() bool { return true }
+
+// wrappingSolidFaces never applies to a plane (there is no wrapping tube band); it defers to the standard
+// contractible-outer emission (uvSide).
+func (c *planeUV) wrappingSolidFaces(_ []Face2D, _ []uvSeg, _ geom.Surface, _ curvedFace) ([]curvedFace, bool) {
+	return nil, false
+}
+
+// finalizeLoops is identity: a plane has no apex-pole rim or torus hole to re-mark (uvSide).
+func (c *planeUV) finalizeLoops(loops []curvedLoop) []curvedLoop { return loops }
+
+// emitRun re-emits one boundary run as an exact loopEdge (uvSide). Both the imprint conic (segImprint) and a
+// polygon boundary edge (segPolygon) are analytic curves re-emitted over their recovered parameter span, so
+// emitImprintRun serves both — the shared re-emitter that makes the seat arc and the tool wall weld exactly.
+func (c *planeUV) emitRun(run []recoveredEdge) (loopEdge, bool) { return emitImprintRun(run) }
+
+// orientLoops applies the plane's winding convention (uvSide): every kept loop's edges run forward, and the
+// imprint (conic) sub-arcs are reversed into the lid — the shared cut boundary the tool wall reuses so the
+// two faces weld. A plane is open in both u and v, so the kept face always has an outer loop (outerless=false).
+func (c *planeUV) orientLoops(loops []emittedLoop, _ bool) ([]curvedLoop, []loopEdge, bool) {
+	faceLoops := make([]curvedLoop, 0, len(loops))
+	var lid []loopEdge
+	for _, e := range loops {
+		faceLoops = append(faceLoops, curvedLoop{edges: e.face})
+		lid = append(lid, reverseEdgeChain(e.section)...)
+	}
+	return faceLoops, lid, false
+}
+
+// assembleSegments samples the imprint conic(s) into the tagged (u,v) segment set and appends the face
+// polygon as the non-periodic frame (uvSide). The arrangement subdivides both, splitting each at their exact
+// crossings; keptCells then classifies cells by the material predicate.
+func (c *planeUV) assembleSegments(imprint []geom.Curve3) []uvSeg {
+	out := make([]uvSeg, 0, len(imprint)*imprintSampleCount+len(c.seat3D)*4)
+	for _, cv := range imprint {
+		out = append(out, c.sampleConicUV(cv)...)
+	}
+	return append(out, c.frameSegments()...)
+}
+
+// sampleConicUV samples one imprint conic into (u,v) segments carrying the source curve + its parameters, so
+// a boundary run along it re-emits as the exact analytic arc (not the sampled chord).
+func (c *planeUV) sampleConicUV(cv geom.Curve3) []uvSeg {
+	lo, hi := cv.Domain()
+	segs := make([]uvSeg, 0, imprintSampleCount)
+	prevP, prevT := to2D(c.plane, cv.PointAt(lo)), lo
+	for i := 1; i <= imprintSampleCount; i++ {
+		t := lo + (hi-lo)*float64(i)/imprintSampleCount
+		p := to2D(c.plane, cv.PointAt(t))
+		segs = append(segs, uvSeg{a: prevP, b: p, curve: cv, tA: prevT, tB: t, kind: segImprint})
+		prevP, prevT = p, t
+	}
+	return segs
+}
+
+// frameSegments emits the seat face boundary as segPolygon edges — the plane's non-periodic frame. Each edge
+// carries its own straight segment as the source curve so a kept boundary run re-emits it exactly.
+func (c *planeUV) frameSegments() []uvSeg {
+	var out []uvSeg
+	for _, ring := range c.seat3D {
+		for i, n := 0, len(ring); i < n; i++ {
+			a3, b3 := ring[i], ring[(i+1)%n]
+			seg := geom.NewLineSegment(a3, b3)
+			out = append(out, uvSeg{a: to2D(c.plane, a3), b: to2D(c.plane, b3), curve: seg, tA: 0, tB: 1, kind: segPolygon})
+		}
+	}
+	return out
+}
+
+// planeMaterial builds the planeUV material predicate: keep a cell whose deep-interior (u,v) point lies inside
+// the seat face polygon AND outside the tool solid (a drill removes the tool; the seat retains the rest). A
+// closure (not a bound value) so it reads the receiver live, matching the ruled/torus material builders.
+func planeMaterial(c *planeUV) func() materialPredicate {
+	return func() materialPredicate {
+		return func(uv math.Point2) bool {
+			return pointInUVLoops(uv, c.seatUV) && !c.inTool(to3D(c.plane, uv))
+		}
+	}
+}
+
+// pointInUVLoops reports whether q is inside a face given as (u,v) loops (outer first, then holes): inside the
+// outer loop and outside every hole — the even-odd containment the planar boolean uses (pointInPolygon2D).
+func pointInUVLoops(q math.Point2, loops [][]math.Point2) bool {
+	if len(loops) == 0 || !pointInPolygon2D(q, loops[0]) {
+		return false
+	}
+	for _, hole := range loops[1:] {
+		if pointInPolygon2D(q, hole) {
+			return false
+		}
+	}
+	return true
+}

--- a/kernel/brep/curved_plane_uv_frame.go
+++ b/kernel/brep/curved_plane_uv_frame.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// The exact conic∩polygon numerics for the planeUV operand (partial curved-on-planar boolean, #1591,
+// ADR-0049 D-d). The seat plane's (u,v) chart is an isometry (orthonormal Û,V̂), so the imprint conic —
+// which lies IN the seat plane — maps into the chart with its radii unchanged, and every model-scaled 3-D
+// tolerance transfers into (u,v) with no Jacobian rescaling. Crossings are solved EXACTLY (a stable
+// quadratic; the ellipse affine-normalised to the unit circle) because a crossing is the topologically
+// decisive vertex: a sampled crossing that two adjacent faces compute differently is the blind-straddle
+// sliver leak. The gate is decline-biased — any tangency/eccentric/odd-parity contact defers to CSG.
+
+// planeConic is the imprint conic in the seat plane's (u,v): centre, unit major-axis direction and the two
+// semi-axes (A≥B; a circle has A==B==r, maj arbitrary). Built from the geom.Circle / geom.EllipseFull that
+// IntersectSurfacesAnalytic returns, projected through to2D/to2Dvec.
+type planeConic struct {
+	center math.Point2
+	maj    math.Vector2 // unit major-axis direction in (u,v)
+	A, B   float64      // semi-axes, A>=B
+}
+
+// conicHit is one exact crossing of the conic with a polygon edge: the edge parameter in [0,1] and the
+// crossing point in the (u,v) chart (exactly on the edge; on the conic to the quadratic's precision).
+type conicHit struct {
+	sEdge float64
+	p     math.Point2
+}
+
+// toPlaneConic projects a 3-D imprint conic (which lies in the seat plane pl) into pl's (u,v) chart. It
+// handles the two shapes a cylinder/cone∩plane yields; ok=false for an open arm (parabola/hyperbola) or any
+// other curve, which the planeUV gate declines to CSG for now (#1591).
+func toPlaneConic(curve geom.Curve3, pl geom.Plane) (planeConic, bool) {
+	switch c := curve.(type) {
+	case geom.Circle:
+		return planeConic{center: to2D(pl, c.Center), maj: math.V2(1, 0), A: c.Radius, B: c.Radius}, true
+	case geom.EllipseFull:
+		maj := unitVec2(to2Dvec(pl, c.MajorAxis.AsVector()))
+		return planeConic{center: to2D(pl, c.Center), maj: maj, A: c.MajorRadius, B: c.MinorRadius}, true
+	default:
+		return planeConic{}, false
+	}
+}
+
+// conicEdgeHits solves C ∩ (a→b) EXACTLY. It affine-normalises the ellipse to the unit circle (a linear map
+// whose condition number is A/B, exactly), then solves the STABLE quadratic |A'+s·d|²=1 with the Kahan
+// form qq=-½(β+sign(β)√Δ) so the cancellation that afflicts one root when β²≫4αγ never bites. The edge
+// parameter s is invariant under the affine map, so the crossing point is a+s·(b−a) in the original chart.
+// tangent=true when the two roots coincide within a weld (a grazing double root — a sliver risk to decline).
+func conicEdgeHits(pc planeConic, a, b math.Point2, res geom.Resolution) (hits []conicHit, tangent bool) {
+	ax, ay := pc.normalize(a)
+	bx, by := pc.normalize(b)
+	dx, dy := bx-ax, by-ay
+	alpha := dx*dx + dy*dy
+	if alpha < res.Weld()*res.Weld() {
+		return nil, false // a degenerate (sub-weld) edge
+	}
+	beta := 2 * (ax*dx + ay*dy)
+	gamma := ax*ax + ay*ay - 1
+	disc := beta*beta - 4*alpha*gamma
+	if disc < 0 {
+		return nil, false // the edge line misses the conic
+	}
+	s1, s2 := stableQuadraticRoots(alpha, beta, gamma, disc)
+	hits = appendEdgeHit(hits, a, b, s1)
+	hits = appendEdgeHit(hits, a, b, s2)
+	return hits, conicTangent(a, b, s1, s2, disc, res)
+}
+
+// normalize maps a chart point into the frame where the conic is the unit circle: (ξ,η) = ((p−c)·maj/A,
+// (p−c)·maj⊥/B). An affine map, so segment line-parameters are preserved.
+func (pc planeConic) normalize(p math.Point2) (xi, eta float64) {
+	d := pc.center.VectorTo(p)
+	perp := math.V2(-pc.maj.Y, pc.maj.X)
+	return float64(d.Dot(pc.maj)) / pc.A, float64(d.Dot(perp)) / pc.B
+}
+
+// stableQuadraticRoots returns the two roots of αs²+βs+γ=0 via the Kahan/Numerical-Recipes form, which
+// avoids catastrophic cancellation by never subtracting two near-equal quantities in the numerator.
+func stableQuadraticRoots(alpha, beta, gamma, disc float64) (float64, float64) {
+	qq := -0.5 * (beta + stdmath.Copysign(stdmath.Sqrt(disc), beta))
+	if qq == 0 { // β=0 and γ=0: the edge passes through the conic centre tangentially in the map
+		return 0, 0
+	}
+	return qq / alpha, gamma / qq
+}
+
+// appendEdgeHit adds the crossing at edge parameter s when s lies strictly inside the edge (endpoints are
+// resolved through the vertex-snap path, not here — tjTol matches the arrangement welder's tolerance).
+func appendEdgeHit(hits []conicHit, a, b math.Point2, s float64) []conicHit {
+	if s < tjTol || s > 1-tjTol {
+		return hits
+	}
+	p := math.P2(a.X+(b.X-a.X)*math.Scalar(s), a.Y+(b.Y-a.Y)*math.Scalar(s))
+	return append(hits, conicHit{sEdge: s, p: p})
+}
+
+// conicTangent reports a grazing contact: the two crossing points fall within a weld of each other, so the
+// edge touches the conic instead of transversally piercing it — a zero-width sliver the stitch cannot weld,
+// which the gate declines. Measured in the original chart (a real length), so the band is model-scaled.
+func conicTangent(a, b math.Point2, s1, s2, disc float64, res geom.Resolution) bool {
+	if disc <= 0 {
+		return true // a true double root (or a miss treated as grazing)
+	}
+	p1 := math.P2(a.X+(b.X-a.X)*math.Scalar(s1), a.Y+(b.Y-a.Y)*math.Scalar(s1))
+	p2 := math.P2(a.X+(b.X-a.X)*math.Scalar(s2), a.Y+(b.Y-a.Y)*math.Scalar(s2))
+	if s1 < -1 || s1 > 2 || s2 < -1 || s2 > 2 {
+		return false // both roots far outside the edge — the near-miss is off this edge, not a grazing touch
+	}
+	return float64(p1.DistanceTo(p2)) < res.Weld()
+}
+
+// unitVec2 returns v normalised, or (1,0) for a degenerate vector (the conic's major axis is always
+// well-defined for a real ellipse, so the fallback is unreachable in practice).
+func unitVec2(v math.Vector2) math.Vector2 {
+	l := float64(v.Length())
+	if l < 1e-12 {
+		return math.V2(1, 0)
+	}
+	return math.V2(v.X/math.Scalar(l), v.Y/math.Scalar(l))
+}
+
+// eccCap is the minor/major ratio below which the imprint ellipse is too eccentric to trust: the tool axis
+// grazes the seat plane (φ→90°), the normalising map is ill-conditioned (cond = A/B), and the "seat contact"
+// is a graze, not a real partial hole. Below it the gate declines to CSG (ADR-0049 D-d, pitfall 5).
+const eccCap = 1e-3
+
+// planeUVContactOK is the accept/decline gate generalising bossSeatFace/circleVsCap for a PARTIAL contact.
+// It is decline-biased: an eccentric ellipse, any tangency, or an odd crossing parity (a missed grazing
+// crossing that would leave a non-manifold kept region) returns false so the caller keeps CSG. A partial
+// contact must cross the polygon boundary an EVEN number of times (in-and-out); zero crossings is not
+// partial (the strictly-interior fast path or a clean miss owns that), so it declines too.
+func planeUVContactOK(pc planeConic, uvLoops [][]math.Point2, res geom.Resolution) bool {
+	if pc.B/pc.A < eccCap {
+		return false
+	}
+	crossings := 0
+	for _, ring := range uvLoops {
+		for i, n := 0, len(ring); i < n; i++ {
+			hits, tangent := conicEdgeHits(pc, ring[i], ring[(i+1)%n], res)
+			if tangent {
+				return false
+			}
+			crossings += len(hits)
+		}
+	}
+	return crossings > 0 && crossings%2 == 0
+}

--- a/kernel/brep/curved_plane_uv_frame_test.go
+++ b/kernel/brep/curved_plane_uv_frame_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Exact conic∩polygon numerics for the planeUV operand (#1591, ADR-0049 D-d). Hand-computed fixtures so the
+// stable-quadratic crossings, the tangency decline, and the decline-biased gate are pinned independently of
+// any assembly.
+
+func unitCircleConic(cx, cy, r float64) planeConic {
+	return planeConic{center: math.P2(math.Scalar(cx), math.Scalar(cy)), maj: math.V2(1, 0), A: r, B: r}
+}
+
+// TestConicEdgeHitsCircleTwoCrossings: a horizontal chord y=1 through a radius-2 circle at the origin meets
+// it at x=±√3, i.e. edge parameters (3∓√3)/6 for the edge (−3,1)→(3,1).
+func TestConicEdgeHitsCircleTwoCrossings(t *testing.T) {
+	res := geom.ResolutionForSize(1)
+	hits, tangent := conicEdgeHits(unitCircleConic(0, 0, 2), math.P2(-3, 1), math.P2(3, 1), res)
+	if tangent {
+		t.Fatal("a transversal chord must not be flagged tangent")
+	}
+	if len(hits) != 2 {
+		t.Fatalf("got %d crossings, want 2", len(hits))
+	}
+	root := stdmath.Sqrt(3)
+	for _, h := range hits {
+		if e := stdmath.Abs(float64(h.p.Y) - 1); e > 1e-12 {
+			t.Errorf("crossing off the edge line (y=%.15g)", float64(h.p.Y))
+		}
+		if e := stdmath.Abs(stdmath.Abs(float64(h.p.X)) - root); e > 1e-9 {
+			t.Errorf("crossing x=%.9f, want ±√3=%.9f", float64(h.p.X), root)
+		}
+	}
+}
+
+// TestConicEdgeHitsTangentDeclines: the line y=2 grazes the radius-2 circle at (0,2) — a double root, which
+// must be reported tangent (a zero-width sliver the stitch cannot weld) so the gate can decline it.
+func TestConicEdgeHitsTangentDeclines(t *testing.T) {
+	res := geom.ResolutionForSize(1)
+	_, tangent := conicEdgeHits(unitCircleConic(0, 0, 2), math.P2(-3, 2), math.P2(3, 2), res)
+	if !tangent {
+		t.Error("a grazing (tangent) chord must be flagged tangent")
+	}
+}
+
+// TestConicEdgeHitsMiss: a chord clear of the circle has no crossings and is not tangent.
+func TestConicEdgeHitsMiss(t *testing.T) {
+	res := geom.ResolutionForSize(1)
+	hits, tangent := conicEdgeHits(unitCircleConic(0, 0, 2), math.P2(-3, 3), math.P2(3, 3), res)
+	if len(hits) != 0 || tangent {
+		t.Errorf("a clear miss must yield 0 hits and not-tangent, got %d hits tangent=%v", len(hits), tangent)
+	}
+}
+
+// TestConicEdgeHitsEllipseNormalizes: a radius via the unit-circle normalisation — a 2:1 ellipse (A=2,B=1)
+// axis-aligned, chord x=0 (the minor axis) crosses at y=±1; chord y=0 (major axis) at x=±2.
+func TestConicEdgeHitsEllipseNormalizes(t *testing.T) {
+	res := geom.ResolutionForSize(1)
+	ell := planeConic{center: math.P2(0, 0), maj: math.V2(1, 0), A: 2, B: 1}
+	minor, _ := conicEdgeHits(ell, math.P2(0, -3), math.P2(0, 3), res)
+	if len(minor) != 2 {
+		t.Fatalf("minor-axis chord: %d hits, want 2", len(minor))
+	}
+	for _, h := range minor {
+		if e := stdmath.Abs(stdmath.Abs(float64(h.p.Y)) - 1); e > 1e-9 {
+			t.Errorf("minor crossing y=%.9f, want ±1", float64(h.p.Y))
+		}
+	}
+	major, _ := conicEdgeHits(ell, math.P2(-3, 0), math.P2(3, 0), res)
+	for _, h := range major {
+		if e := stdmath.Abs(stdmath.Abs(float64(h.p.X)) - 2); e > 1e-9 {
+			t.Errorf("major crossing x=%.9f, want ±2", float64(h.p.X))
+		}
+	}
+}
+
+func squareUV(half float64) [][]math.Point2 {
+	h := math.Scalar(half)
+	return [][]math.Point2{{math.P2(-h, -h), math.P2(h, -h), math.P2(h, h), math.P2(-h, h)}}
+}
+
+// TestPlaneUVContactOK: a circle clipping one square edge is a valid partial contact (2 crossings); one
+// wholly inside is not partial (0 crossings); an over-eccentric ellipse declines.
+func TestPlaneUVContactOK(t *testing.T) {
+	res := geom.ResolutionForSize(1)
+	if !planeUVContactOK(unitCircleConic(3, 0, 2), squareUV(3), res) {
+		t.Error("a circle clipping the right edge (2 crossings) is a valid partial contact")
+	}
+	if planeUVContactOK(unitCircleConic(0, 0, 1), squareUV(3), res) {
+		t.Error("a circle wholly inside (0 crossings) is not a partial contact — declines to the fast path")
+	}
+	if planeUVContactOK(planeConic{center: math.P2(3, 0), maj: math.V2(1, 0), A: 2, B: 0.0005}, squareUV(3), res) {
+		t.Error("an over-eccentric ellipse (B/A<1e-3) must decline to CSG")
+	}
+}
+
+// TestToPlaneConicCircle: a circle lying in the XY plane projects to a chart circle of the same radius,
+// centred at the plane-projected centre (the chart is an isometry).
+func TestToPlaneConicCircle(t *testing.T) {
+	pl, err := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	circ, _ := geom.NewCircle(math.P3(1, 2, 0), math.V3(0, 0, 1), 2.5)
+	C, ok := toPlaneConic(circ, pl)
+	if !ok {
+		t.Fatal("a circle imprint must project")
+	}
+	if stdmath.Abs(C.A-2.5) > 1e-12 || stdmath.Abs(C.B-2.5) > 1e-12 {
+		t.Errorf("chart conic radii (%.3f,%.3f), want 2.5,2.5", C.A, C.B)
+	}
+}

--- a/kernel/brep/curved_plane_uv_test.go
+++ b/kernel/brep/curved_plane_uv_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// squareSeat builds a half×half seat square in the XY plane (z=0) as a curvedFace plus the planeUV loops.
+func squareSeat(t *testing.T, half float64) (geom.Plane, curvedFace, [][]math.Point3) {
+	t.Helper()
+	pl, err := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := math.Scalar(half)
+	ring := []math.Point3{math.P3(-h, -h, 0), math.P3(h, -h, 0), math.P3(h, h, 0), math.P3(-h, h, 0)}
+	var edges []loopEdge
+	for i := 0; i < 4; i++ {
+		edges = append(edges, loopEdge{curve: geom.NewLineSegment(ring[i], ring[(i+1)%4]), t0: 0, t1: 1})
+	}
+	return pl, curvedFace{surface: pl, loops: []curvedLoop{{edges: edges}}}, [][]math.Point3{ring}
+}
+
+// curvedFaceUVArea sums the shoelace area of a curvedFace's loops in the plane chart (outer positive, holes
+// negative). The chart is an isometry, so this is the true 3D face area. Each edge is densely sampled so a
+// conic arc contributes its real area, not a chord's.
+func curvedFaceUVArea(pl geom.Plane, f curvedFace) float64 {
+	total := 0.0
+	for _, loop := range f.loops {
+		var poly []math.Point2
+		for _, e := range loop.edges {
+			for i := 0; i < 64; i++ {
+				tt := e.t0 + (e.t1-e.t0)*float64(i)/64
+				poly = append(poly, to2D(pl, e.curve.PointAt(tt)))
+			}
+		}
+		total += shoelaceArea(poly)
+	}
+	return total
+}
+
+func shoelaceArea(poly []math.Point2) float64 {
+	a := 0.0
+	for i, n := 0, len(poly); i < n; i++ {
+		p, q := poly[i], poly[(i+1)%n]
+		a += float64(p.X)*float64(q.Y) - float64(q.X)*float64(p.Y)
+	}
+	return stdmath.Abs(a) / 2
+}
+
+// TestPlaneUVTrimsSquareBittenByCircle is the Slice A/2 milestone: a radius-2 imprint circle centred ON the
+// right edge of a 6×6 seat square bites out the half-disc that lies inside the square (area 2π). The trimmed
+// seat face must be one connected region of area 36−2π, its boundary the 3 square sides + the exact conic arc
+// — proving the planeUV operand arranges a boundary-clipping conic through the shared (u,v) trimmer (#1591).
+func TestPlaneUVTrimsSquareBittenByCircle(t *testing.T) {
+	pl, seat, ring3 := squareSeat(t, 3)
+	circ, _ := geom.NewCircle(math.P3(3, 0, 0), math.V3(0, 0, 1), 2) // centred on the x=3 edge
+	seatUV := seatLoopsUV(pl, ring3)
+	c := &planeUV{
+		plane:  pl,
+		seatUV: seatUV,
+		seat3D: ring3,
+		inTool: func(p math.Point3) bool { // inside the vertical drill cylinder through (3,0)
+			return stdmath.Hypot(float64(p.X)-3, float64(p.Y)) < 2-1e-9
+		},
+	}
+	faces, _, err := trimByImprint(c, seat, pl, []geom.Curve3{circ}, planeMaterial(c))
+	if err != nil {
+		t.Fatalf("trimByImprint: %v", err)
+	}
+	if len(faces) != 1 {
+		t.Fatalf("kept region has %d faces, want 1 connected seat", len(faces))
+	}
+	got := curvedFaceUVArea(pl, faces[0])
+	want := 36 - 2*stdmath.Pi
+	if e := stdmath.Abs(got-want) / want; e > 0.01 {
+		t.Errorf("trimmed seat area %.5f, want %.5f (36−2π); rel %.4f", got, want, e)
+	}
+}
+
+// seatLoopsUV projects 3D seat loops into the plane chart (a test mirror of the assembler's helper).
+func seatLoopsUV(pl geom.Plane, loops [][]math.Point3) [][]math.Point2 {
+	out := make([][]math.Point2, len(loops))
+	for i, ring := range loops {
+		uv := make([]math.Point2, len(ring))
+		for j, p := range ring {
+			uv[j] = to2D(pl, p)
+		}
+		out[i] = uv
+	}
+	return out
+}


### PR DESCRIPTION
## What

The **`planeUV` operand** for #1591 — the re-usable core that lets a partial curved-on-planar boolean (a drilled hole / boss base whose imprint conic **clips a face boundary**) run through the shared `(u,v)` arrangement trimmer instead of triangle-soup CSG. Two layers:

1. **Exact conic∩polygon numerics** (`curved_plane_uv_frame.go`) — `planeConic` projects the imprint conic into the seat plane's `(u,v)` chart (an isometry, radii unchanged); `conicEdgeHits` solves conic∩edge via a **stable Kahan quadratic** with the ellipse affine-normalized to the unit circle; `planeUVContactOK` is the decline-biased gate (eccentric / tangent / odd-parity → CSG).
2. **The `planeUV` `uvSide` type** (`curved_plane_uv.go`) — periodic machinery inert (no seam/rim/wrap), the face polygon as the `segPolygon` frame, `emitImprintRun` re-emitting both the conic and the polygon edges, and a material predicate keeping face-interior cells outside the tool.

## Why this is its own slice

Slice A's operand core is conceptually distinct from — and provably correct independent of — the multi-face watertight **assembly** (drill/boss body build), which is corner-junction-scale (couples `planeUV` caps + a ruled wall-trim + the degenerate poke-through side split). Landing the tested operand first keeps each PR reviewable and green; the assembler consumes this operand in the following slice. Mirrors how Slice 0 shipped the additive core seam alone. Builds on the merged ADR-0049 design + Slice 0 (`segPolygon`/`uPeriodic`, #1741).

## Test / gate

- **Numerics**: 6 hand-computed unit tests (two crossings at ±√3, tangent decline, clean miss, ellipse unit-circle normalization, the gate, chart projection).
- **Operand milestone**: `TestPlaneUVTrimsSquareBittenByCircle` — a radius-2 circle centred on a 6×6 seat square's right edge bites the interior half-disc; the trimmed seat is **one connected face of area 36−2π**, boundary = 3 square sides + the exact conic arc. Validates the exact-crossing arrangement + analytic re-emission through the real `trimByImprint` pipeline.
- Local: `go build ./...`, `go vet`, full `kernel/brep`+`kernel/ops` suites green **and byte-identical** (existing goldens unchanged), `golangci-lint` 0 issues, SPDX headers present.

Part of #1591 (next: the drill/boss watertight assembler + OCC certification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)