### PR TITLE
feat(brep): exact conic∩polygon crossing injection for planeUV (#1591 Slice B/1)

### DIFF
--- a/kernel/brep/curved_plane_uv.go
+++ b/kernel/brep/curved_plane_uv.go
@@ -3,6 +3,8 @@
 package brep
 
 import (
+	"sort"
+
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/math"
 )
@@ -18,6 +20,16 @@ type planeUV struct {
 	seatUV [][]math.Point2        // seat face boundary in (u,v), outer loop first (even-odd containment)
 	seat3D [][]math.Point3        // the same loops in 3D, so each polygon edge re-emits as its exact segment
 	inTool func(math.Point3) bool // reports whether a 3D point is inside the tool solid (removed for a drill)
+	res    geom.Resolution        // model-relative tolerance for the exact conic∩edge crossings
+}
+
+// planeCrossing is one exact conic∩polygon-edge crossing: the shared point at = conic.PointAt(tConic), used
+// as a vertex by BOTH the conic sample and the split polygon edge so the seat/cap/wall arcs weld exactly.
+type planeCrossing struct {
+	loop, edge int
+	sEdge      float64     // edge parameter, to order splits along one edge
+	tConic     float64     // conic parameter (the weld currency)
+	at         math.Point3 // the shared crossing point = conic.PointAt(tConic)
 }
 
 // planeUV satisfies uvSide: a non-periodic, polygon-framed plane (#1591).
@@ -71,42 +83,90 @@ func (c *planeUV) orientLoops(loops []emittedLoop, _ bool) ([]curvedLoop, []loop
 	return faceLoops, lid, false
 }
 
-// assembleSegments samples the imprint conic(s) into the tagged (u,v) segment set and appends the face
-// polygon as the non-periodic frame (uvSide). The arrangement subdivides both, splitting each at their exact
-// crossings; keptCells then classifies cells by the material predicate.
+// assembleSegments samples the imprint conic(s) and the face-polygon frame into the tagged (u,v) segment
+// set (uvSide), INJECTING the exact conic∩edge crossings as shared vertices of both. Without the injection
+// the arrangement would place the crossing on the sampled chord — off the true conic by the sagitta — so the
+// re-emitted arc would miss the polygon edge and the tool wall's split base, leaving a free edge (#1591).
 func (c *planeUV) assembleSegments(imprint []geom.Curve3) []uvSeg {
+	var crossings []planeCrossing
 	out := make([]uvSeg, 0, len(imprint)*imprintSampleCount+len(c.seat3D)*4)
 	for _, cv := range imprint {
-		out = append(out, c.sampleConicUV(cv)...)
+		pc, ok := toPlaneConic(cv, c.plane)
+		if !ok {
+			continue
+		}
+		cr := c.conicCrossings(cv, pc)
+		crossings = append(crossings, cr...)
+		out = append(out, c.sampleConicUV(cv, cr)...)
 	}
-	return append(out, c.frameSegments()...)
+	return append(out, c.frameSegments(crossings)...)
+}
+
+// conicCrossings returns every exact crossing of one conic with the seat polygon: the closed-form conic
+// parameter and the shared 3D point conic.PointAt(t), which both the conic sample and the split polygon edge
+// terminate on so they weld byte-identically.
+func (c *planeUV) conicCrossings(cv geom.Curve3, pc planeConic) []planeCrossing {
+	var out []planeCrossing
+	for li, ring := range c.seatUV {
+		for i, n := 0, len(ring); i < n; i++ {
+			hits, _ := conicEdgeHits(pc, ring[i], ring[(i+1)%n], c.res)
+			for _, h := range hits {
+				tc, ok := conicParamAt(cv, to3D(c.plane, h.p))
+				if !ok {
+					continue
+				}
+				out = append(out, planeCrossing{loop: li, edge: i, sEdge: h.sEdge, tConic: tc, at: cv.PointAt(tc)})
+			}
+		}
+	}
+	return out
 }
 
 // sampleConicUV samples one imprint conic into (u,v) segments carrying the source curve + its parameters, so
-// a boundary run along it re-emits as the exact analytic arc (not the sampled chord).
-func (c *planeUV) sampleConicUV(cv geom.Curve3) []uvSeg {
+// a boundary run re-emits as the exact analytic arc. Each crossing parameter is inserted as a sample boundary
+// so a vertex lands EXACTLY on the crossing (conic.PointAt(tConic)) — the shared weld point.
+func (c *planeUV) sampleConicUV(cv geom.Curve3, crossings []planeCrossing) []uvSeg {
 	lo, hi := cv.Domain()
-	segs := make([]uvSeg, 0, imprintSampleCount)
-	prevP, prevT := to2D(c.plane, cv.PointAt(lo)), lo
-	for i := 1; i <= imprintSampleCount; i++ {
-		t := lo + (hi-lo)*float64(i)/imprintSampleCount
-		p := to2D(c.plane, cv.PointAt(t))
-		segs = append(segs, uvSeg{a: prevP, b: p, curve: cv, tA: prevT, tB: t, kind: segImprint})
-		prevP, prevT = p, t
+	params := make([]float64, 0, imprintSampleCount+len(crossings)+1)
+	for i := 0; i <= imprintSampleCount; i++ {
+		params = append(params, lo+(hi-lo)*float64(i)/imprintSampleCount)
+	}
+	for _, cr := range crossings {
+		params = append(params, cr.tConic)
+	}
+	params = sortedUniqueParams(params)
+	segs := make([]uvSeg, 0, len(params))
+	for i := 1; i < len(params); i++ {
+		a, b := to2D(c.plane, cv.PointAt(params[i-1])), to2D(c.plane, cv.PointAt(params[i]))
+		segs = append(segs, uvSeg{a: a, b: b, curve: cv, tA: params[i-1], tB: params[i], kind: segImprint})
 	}
 	return segs
 }
 
-// frameSegments emits the seat face boundary as segPolygon edges — the plane's non-periodic frame. Each edge
-// carries its own straight segment as the source curve so a kept boundary run re-emits it exactly.
-func (c *planeUV) frameSegments() []uvSeg {
+// frameSegments emits the seat polygon as segPolygon edges, each SPLIT at its conic crossings so the sub-edge
+// ends exactly on the shared crossing point (a straight segment to that point, kinked by less than a weld).
+func (c *planeUV) frameSegments(crossings []planeCrossing) []uvSeg {
 	var out []uvSeg
-	for _, ring := range c.seat3D {
+	for li, ring := range c.seat3D {
 		for i, n := 0, len(ring); i < n; i++ {
-			a3, b3 := ring[i], ring[(i+1)%n]
-			seg := geom.NewLineSegment(a3, b3)
-			out = append(out, uvSeg{a: to2D(c.plane, a3), b: to2D(c.plane, b3), curve: seg, tA: 0, tB: 1, kind: segPolygon})
+			out = append(out, c.splitEdge(li, i, ring[i], ring[(i+1)%n], crossings)...)
 		}
+	}
+	return out
+}
+
+// splitEdge breaks one polygon edge at its crossings (ordered along the edge), emitting a straight segPolygon
+// sub-edge between consecutive vertices — the corners and the shared crossing points conic.PointAt(tConic).
+func (c *planeUV) splitEdge(loop, edge int, a3, b3 math.Point3, crossings []planeCrossing) []uvSeg {
+	verts := []math.Point3{a3}
+	for _, cr := range sortedEdgeCrossings(crossings, loop, edge) {
+		verts = append(verts, cr.at)
+	}
+	verts = append(verts, b3)
+	out := make([]uvSeg, 0, len(verts)-1)
+	for i := 1; i < len(verts); i++ {
+		seg := geom.NewLineSegment(verts[i-1], verts[i])
+		out = append(out, uvSeg{a: to2D(c.plane, verts[i-1]), b: to2D(c.plane, verts[i]), curve: seg, tA: 0, tB: 1, kind: segPolygon})
 	}
 	return out
 }
@@ -120,6 +180,32 @@ func planeMaterial(c *planeUV) func() materialPredicate {
 			return pointInUVLoops(uv, c.seatUV) && !c.inTool(to3D(c.plane, uv))
 		}
 	}
+}
+
+// sortedUniqueParams sorts the parameter list and drops near-duplicates (an injected crossing that coincides
+// with a uniform sample), so no zero-length sample segment is emitted.
+func sortedUniqueParams(params []float64) []float64 {
+	sort.Float64s(params)
+	out := params[:0:0]
+	for i, p := range params {
+		if i == 0 || p-out[len(out)-1] > 1e-12 {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// sortedEdgeCrossings returns the crossings on one polygon edge ordered by their edge parameter, so the edge
+// splits into consecutive sub-segments in geometric order.
+func sortedEdgeCrossings(crossings []planeCrossing, loop, edge int) []planeCrossing {
+	var on []planeCrossing
+	for _, cr := range crossings {
+		if cr.loop == loop && cr.edge == edge {
+			on = append(on, cr)
+		}
+	}
+	sort.Slice(on, func(i, j int) bool { return on[i].sEdge < on[j].sEdge })
+	return on
 }
 
 // pointInUVLoops reports whether q is inside a face given as (u,v) loops (outer first, then holes): inside the

--- a/kernel/brep/curved_plane_uv_frame.go
+++ b/kernel/brep/curved_plane_uv_frame.go
@@ -126,6 +126,36 @@ func unitVec2(v math.Vector2) math.Vector2 {
 	return math.V2(v.X/math.Scalar(l), v.Y/math.Scalar(l))
 }
 
+// conicParamAt inverts a point on the imprint conic to its curve parameter t∈[0,1) — the closed-form
+// inversion (no iteration) that is the exact weld currency: the seat arc, the overhang-cap arc and the tool
+// wall's base all terminate at conic.PointAt(t) for the SAME t, so they weld byte-identically (ADR-0049 D-d).
+// It matches geom.Circle/EllipseFull's own PointAt convention (angle 2πt from RefDir/MajorAxis).
+func conicParamAt(cv geom.Curve3, p math.Point3) (float64, bool) {
+	switch c := cv.(type) {
+	case geom.Circle:
+		d := c.Center.VectorTo(p)
+		cos := d.Dot(c.RefDir.AsVector())
+		sin := d.Dot(c.Normal.Cross(c.RefDir))
+		return wrap01(stdmath.Atan2(float64(sin), float64(cos)) / (2 * stdmath.Pi)), true
+	case geom.EllipseFull:
+		d := c.Center.VectorTo(p)
+		cos := float64(d.Dot(c.MajorAxis.AsVector())) / c.MajorRadius
+		sin := float64(d.Dot(c.Normal.Cross(c.MajorAxis))) / c.MinorRadius
+		return wrap01(stdmath.Atan2(sin, cos) / (2 * stdmath.Pi)), true
+	default:
+		return 0, false
+	}
+}
+
+// wrap01 folds a real onto [0,1).
+func wrap01(t float64) float64 {
+	t -= stdmath.Floor(t)
+	if t >= 1 {
+		t -= 1
+	}
+	return t
+}
+
 // eccCap is the minor/major ratio below which the imprint ellipse is too eccentric to trust: the tool axis
 // grazes the seat plane (φ→90°), the normalising map is ill-conditioned (cond = A/B), and the "seat contact"
 // is a graze, not a real partial hole. Below it the gate declines to CSG (ADR-0049 D-d, pitfall 5).

--- a/kernel/brep/curved_plane_uv_test.go
+++ b/kernel/brep/curved_plane_uv_test.go
@@ -65,6 +65,7 @@ func TestPlaneUVTrimsSquareBittenByCircle(t *testing.T) {
 		plane:  pl,
 		seatUV: seatUV,
 		seat3D: ring3,
+		res:    geom.ResolutionForSize(6),
 		inTool: func(p math.Point3) bool { // inside the vertical drill cylinder through (3,0)
 			return stdmath.Hypot(float64(p.X)-3, float64(p.Y)) < 2-1e-9
 		},
@@ -80,6 +81,41 @@ func TestPlaneUVTrimsSquareBittenByCircle(t *testing.T) {
 	want := 36 - 2*stdmath.Pi
 	if e := stdmath.Abs(got-want) / want; e > 0.01 {
 		t.Errorf("trimmed seat area %.5f, want %.5f (36−2π); rel %.4f", got, want, e)
+	}
+}
+
+// TestPlaneUVInjectsExactCrossings is the watertightness linchpin (#1591, ADR-0049 D-d): a crossing that
+// falls BETWEEN conic samples (circle centred at (2,0) crosses the seat edge x=3 at y=±√3, a non-sample
+// parameter) must still re-emit the seat arc terminating EXACTLY on the edge — within a weld, not the
+// ~1e-4 sagitta a sampled crossing leaves. Without the exact-crossing injection the arc misses the edge and
+// the tool wall's split base cannot weld.
+func TestPlaneUVInjectsExactCrossings(t *testing.T) {
+	pl, seat, ring3 := squareSeat(t, 3)
+	circ, _ := geom.NewCircle(math.P3(2, 0, 0), math.V3(0, 0, 1), 2) // crosses x=3 at y=±√3, between samples
+	seatUV := seatLoopsUV(pl, ring3)
+	c := &planeUV{plane: pl, seatUV: seatUV, seat3D: ring3, res: geom.ResolutionForSize(6),
+		inTool: func(p math.Point3) bool { return stdmath.Hypot(float64(p.X)-2, float64(p.Y)) < 2-1e-9 }}
+	faces, _, err := trimByImprint(c, seat, pl, []geom.Curve3{circ}, planeMaterial(c))
+	if err != nil {
+		t.Fatal(err)
+	}
+	weld := geom.ResolutionForSize(6).Weld()
+	found := 0
+	for _, loop := range faces[0].loops {
+		for _, e := range loop.edges {
+			if _, ok := e.curve.(geom.Circle); !ok {
+				continue
+			}
+			for _, p := range []math.Point3{e.start(), e.end()} {
+				found++
+				if dx := stdmath.Abs(float64(p.X) - 3); dx > weld {
+					t.Errorf("seat conic arc endpoint x=%.10f is %.2e off the seat edge x=3 (weld=%.1e) — no exact-crossing injection", float64(p.X), dx, weld)
+				}
+			}
+		}
+	}
+	if found == 0 {
+		t.Fatal("no conic arc edge found on the trimmed seat")
 	}
 }
 


### PR DESCRIPTION
## What

Makes the `planeUV` operand (merged in #1742) **watertight-ready**: `assembleSegments` now injects the **exact** conic∩polygon-edge crossings as shared vertices of both the conic sample and the split polygon edge.

## Why

The merged operand trims correctly by *area*, but the arrangement placed each conic∩edge crossing on the **sampled chord** — off the true conic by the sagitta. Measured: a crossing falling between samples left the re-emitted seat arc endpoint **~7e-5 off** the polygon edge (vs `Weld()` ≈ 6e-9). That gap means the seat arc, the overhang-cap arc, and the tool wall's split base can't weld — a free edge. This is the math-brief's core watertightness point.

## How

- `conicParamAt` (`curved_plane_uv_frame.go`) — closed-form inversion of a point on a `Circle`/`EllipseFull` to its curve parameter (matching `PointAt`'s convention), no iteration.
- `conicCrossings` — for each conic, the exact crossing per polygon edge (`conicEdgeHits`) and its conic parameter; the shared point is `conic.PointAt(t)`.
- `sampleConicUV` inserts each crossing parameter as a sample boundary (a vertex lands exactly on the crossing); `frameSegments`/`splitEdge` splits each polygon edge at the same shared points. Both terminate on one byte-identical point → they weld.

## Test / gate

- `TestPlaneUVInjectsExactCrossings` — a crossing between samples (circle at (2,0) crossing the seat edge x=3 at y=±√3) now re-emits the seat arc ending **within a weld** of x=3.
- Existing area + numerics operand tests still green; full `kernel/...` suite green and byte-identical; `golangci-lint` 0 issues; `go build ./...`/`vet` clean.

Part of #1591. Next: the partial-boss/drill watertight assembler (which additionally splits the seat-adjacent side face's edge at these crossings — `curvedStitch` does not auto-split T-junctions) + OCC certification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)