### PR TITLE
feat(brep): watertight partial-boss assembler over planeUV (#1591 Slice B)

### DIFF
--- a/kernel/brep/curved_halfspace_uv_arrangement.go
+++ b/kernel/brep/curved_halfspace_uv_arrangement.go
@@ -696,7 +696,10 @@ func recoverEdge(d dedge, segs []uvSeg) (recoveredEdge, bool) {
 	}
 	s := segs[best]
 	re := recoveredEdge{kind: s.kind, curve: s.curve, a: d.a, b: d.b}
-	if s.kind == segImprint {
+	// An imprint arc AND a non-periodic face-polygon edge (planeUV, #1591) both re-emit through emitImprintRun,
+	// which needs the curve parameters at the dedge endpoints; a rim recomputes its own span in emitRimRun, so
+	// it is left out. Interpolate the parameter from the matched segment's tagged endpoints.
+	if s.kind == segImprint || s.kind == segPolygon {
 		re.tA = math.Lerp(s.tA, s.tB, projFraction(d.a, s.a, s.b))
 		re.tB = math.Lerp(s.tA, s.tB, projFraction(d.b, s.a, s.b))
 	}

--- a/kernel/brep/curved_plane_partial_boss.go
+++ b/kernel/brep/curved_plane_partial_boss.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Partial cylindrical boss union — the curved-on-planar boolean KIND for a boss whose base circle CLIPS the
+// seat face edge (a spigot straddling / overhanging a plate edge), #1591 / ADR-0049. Where JoinCylindricalBoss
+// requires the base circle strictly inside one seat face, this handles the base circle crossing the seat
+// boundary: the seat face keeps the plate minus the in-seat footprint (a planeUV trim), the overhang gets an
+// exposed underside cap (the same base plane, inside the boss, outside the plate), the boss adds a full wall
+// (its base split at the two crossings so it welds to seat + cap) and a top cap, and every OTHER target face
+// that the crossings land on is split there so curvedStitch (which does not resolve T-junctions) welds clean.
+
+// JoinPartialBoss returns target ∪ tool when tool is a cylinder seated flush and perpendicular on one planar
+// face of target, protruding outward, with its base circle CLIPPING that face's boundary (a straddling boss),
+// or ok=false to defer (a strictly-interior boss takes JoinCylindricalBoss; anything else keeps CSG).
+func JoinPartialBoss(target, tool *topo.Body) (*topo.Body, bool) {
+	cyl, base, height, ok := cylinderSolidParams(facesOfAny(tool))
+	if !ok {
+		return nil, false
+	}
+	ua := cyl.AxisDir.AsVector()
+	c0, c1 := base, base.TranslateBy(ua.Scale(math.Scalar(height)))
+	faces := facesOfAny(target)
+	seat, near, far, ok := partialBossSeat(faces, c0, c1, ua, cyl.Radius)
+	if !ok {
+		return nil, false
+	}
+	body := assemblePartialBoss(faces, seat, near, far, cyl.Radius)
+	if body == nil {
+		return nil, false
+	}
+	return body, true
+}
+
+// partialBossSeat finds the planar face a boss cap sits flush on, protruding outward, whose base circle
+// CLIPS the face boundary (pierced centre but not clean) — the straddling case. Returns the seat index and
+// the seated (near) and protruding (far) cap centres, or ok=false.
+func partialBossSeat(faces []curvedFace, c0, c1 math.Point3, ua math.Vector3, radius float64) (idx int, near, far math.Point3, ok bool) {
+	for i, f := range faces {
+		pl, isPlane := f.surface.(geom.Plane)
+		if !isPlane || stdmath.Abs(float64(unit(pl.Normal()).Dot(ua))) < 1-1e-7 {
+			continue
+		}
+		nOut := faceOutwardNormal(f, pl)
+		flushTol := geom.ResolutionForSize(radius).Plane()
+		for _, cap := range [2][2]math.Point3{{c0, c1}, {c1, c0}} {
+			n, fr := cap[0], cap[1]
+			if stdmath.Abs(pointPlaneDistance(n, pl)) > flushTol || float64(n.VectorTo(fr).Dot(nOut)) <= 0 {
+				continue
+			}
+			if pierced, clean := circleVsCap(n, radius, f, pl); pierced && !clean {
+				return i, n, fr, true
+			}
+		}
+	}
+	return 0, math.Point3{}, math.Point3{}, false
+}
+
+// assemblePartialBoss builds the union: the planeUV-trimmed seat, the overhang underside cap, the split-base
+// boss wall and top cap, plus every other face split at the crossings so the T-junctions weld.
+func assemblePartialBoss(faces []curvedFace, seatIdx int, near, far math.Point3, radius float64) *topo.Body {
+	nearCirc, farCirc, axis, ok := bossBaseCircles(near, far, radius)
+	if !ok {
+		return nil
+	}
+	seatFace := faces[seatIdx]
+	pl, _ := seatFace.surface.(geom.Plane)
+	c := bossPlaneUV(seatFace, pl, near, axis, radius)
+	crossings := c.planeCrossingsOf(nearCirc)
+	if len(crossings) != 2 {
+		return nil // Slice B scope: exactly one clipped edge → two crossings
+	}
+	seatOut, capOut, ok := trimSeatAndCap(c, seatFace, pl, nearCirc)
+	if !ok {
+		return nil
+	}
+	out := splitFacesAtCrossings(copyExcept(faces, seatIdx), crossings)
+	out = append(out, seatOut...)
+	out = append(out, capOut...)
+	out = append(out, partialBossWall(near, axis, radius, nearCirc, farCirc, crossings), partialBossTopCap(far, axis, farCirc, bossSeamAngle(crossings)))
+	return curvedStitch(out)
+}
+
+// bossBaseCircles builds the boss's near (seated) and far (protruding) base circles and axis, sharing one
+// frame (Normal/RefDir) so their parameter t agrees — the wall's seam and split arcs anchor on that shared t.
+func bossBaseCircles(near, far math.Point3, radius float64) (nearC, farC geom.Circle, axis math.Vector3, ok bool) {
+	axis = unit(near.VectorTo(far))
+	nearC, err := geom.NewCircle(near, axis, radius)
+	if err != nil {
+		return geom.Circle{}, geom.Circle{}, math.Vector3{}, false
+	}
+	farC = geom.Circle{Center: far, Normal: nearC.Normal, RefDir: nearC.RefDir, Radius: radius}
+	return nearC, farC, axis, true
+}
+
+// trimSeatAndCap trims the seat plane to keep the plate minus the in-boss footprint (planeMaterial) and the
+// coincident overhang underside to keep the in-boss-but-off-plate cantilever cap (capMaterial). ok=false if
+// either trim yields nothing (a degenerate contact outside Slice B's straddling scope).
+func trimSeatAndCap(c *planeUV, seatFace curvedFace, pl geom.Plane, nearCirc geom.Circle) (seat, cap []curvedFace, ok bool) {
+	seat, _, err := trimByImprint(c, seatFace, pl, []geom.Curve3{nearCirc}, planeMaterial(c))
+	if err != nil || len(seat) == 0 {
+		return nil, nil, false
+	}
+	capIn := curvedFace{surface: pl, reversed: !seatFace.reversed, lineage: topo.NewLineage(topo.Tok("brep", "bosscapunder", 0))}
+	cap, _, err = trimByImprint(c, capIn, pl, []geom.Curve3{nearCirc}, capMaterial(c))
+	if err != nil || len(cap) == 0 {
+		return nil, nil, false
+	}
+	return seat, cap, true
+}
+
+// bossSeamAngle returns the smaller of the two crossing parameters — the conic t where the wall seam and the
+// top cap anchor, so the full top circle is never bisected by the seam (it starts and ends at a crossing).
+func bossSeamAngle(crossings []planeCrossing) float64 {
+	ta := crossings[0].tConic
+	if crossings[1].tConic < ta {
+		return crossings[1].tConic
+	}
+	return ta
+}
+
+// bossPlaneUV builds the planeUV operand for the seat plane: the seat polygon as the frame, and inside-the-
+// boss (radial distance below the base circle radius) as the tool membership.
+func bossPlaneUV(seatFace curvedFace, pl geom.Plane, near math.Point3, axis math.Vector3, radius float64) *planeUV {
+	seat3D := make([][]math.Point3, len(seatFace.loops))
+	for i, lp := range seatFace.loops {
+		seat3D[i] = sampleCurvedLoop(lp)
+	}
+	seatUV := make([][]math.Point2, len(seat3D))
+	for i, ring := range seat3D {
+		uv := make([]math.Point2, len(ring))
+		for j, p := range ring {
+			uv[j] = to2D(pl, p)
+		}
+		seatUV[i] = uv
+	}
+	inTool := func(p math.Point3) bool {
+		return offAxisDistance(near, axis, p) < radius-geom.ResolutionForSize(radius).Weld()
+	}
+	return &planeUV{plane: pl, seatUV: seatUV, seat3D: seat3D, inTool: inTool, res: geom.ResolutionForSize(2 * radius)}
+}
+
+// copyExcept returns all faces but the one at skip (a shallow copy; loops are shared, never mutated).
+func copyExcept(faces []curvedFace, skip int) []curvedFace {
+	out := make([]curvedFace, 0, len(faces))
+	for i, f := range faces {
+		if i != skip {
+			out = append(out, f)
+		}
+	}
+	return out
+}

--- a/kernel/brep/curved_plane_partial_boss_test.go
+++ b/kernel/brep/curved_plane_partial_boss_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// TestJoinPartialBossStraddlesEdge: a boss whose base circle CLIPS the plate's top-face edge (centre (4,0),
+// r2, on a plate spanning x∈[-5,5]) unions to a watertight solid of volume 200 + 12π (the whole cantilevered
+// boss added, no volume overlap since the boss sits at z≥2). Exercises planeUV end-to-end (#1591 Slice B).
+func TestJoinPartialBossStraddlesEdge(t *testing.T) {
+	plate, _ := SolidBlock(math.P3(-5, -5, 0), math.P3(5, 5, 2), "plate")
+	boss, _ := SolidCylinder(math.P3(4, 0, 2), math.V3(0, 0, 1), 2, 3)
+	res, ok := JoinPartialBoss(plate, boss)
+	if !ok {
+		t.Fatal("partial boss union declined; want plate + straddling boss")
+	}
+	freeEdges := 0
+	for _, e := range res.Edges() {
+		if len(e.Uses()) != 2 {
+			freeEdges++
+		}
+	}
+	t.Logf("faces=%d edges=%d freeEdges=%d solid=%v shells=%d", len(res.Faces()), len(res.Edges()), freeEdges, res.IsSolid(), len(res.Shells()))
+	if freeEdges != 0 {
+		t.Errorf("partial boss has %d free edges (want 0 — a watertight manifold)", freeEdges)
+	}
+}
+
+var (
+	_ = topo.Body{}
+	_ = stdmath.Pi
+)

--- a/kernel/brep/curved_plane_partial_boss_wall.go
+++ b/kernel/brep/curved_plane_partial_boss_wall.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// partialBossWall builds the boss side wall as an outward cylinder face whose BASE circle is split at the two
+// seat crossings, so its in-seat sub-arc welds to the trimmed seat face and its out-seat sub-arc welds to the
+// overhang cap. The seam is placed AT a crossing (ta) so the seam never bisects the out-seat arc — the far
+// (top) circle stays whole. Mirrors bossWallFace's winding (seam up, top reversed, seam down, base forward).
+func partialBossWall(near math.Point3, axis math.Vector3, radius float64, nearCirc, farCirc geom.Circle, crossings []planeCrossing) curvedFace {
+	cyl, _ := geom.NewCylinder(near, axis, radius)
+	ta, tb := crossings[0].tConic, crossings[1].tConic
+	if tb < ta {
+		ta, tb = tb, ta
+	}
+	seam := geom.NewLineSegment(nearCirc.PointAt(ta), farCirc.PointAt(ta))
+	loop := curvedLoop{edges: []loopEdge{
+		{curve: seam, t0: 0, t1: 1},
+		{curve: farCirc, t0: ta + 1, t1: ta}, // full top circle, reversed, anchored at the seam angle
+		{curve: seam, t0: 1, t1: 0},
+		{curve: nearCirc, t0: ta, t1: tb},     // in-seat base arc (welds to the trimmed seat)
+		{curve: nearCirc, t0: tb, t1: ta + 1}, // out-seat base arc (welds to the overhang cap), wraps the seam
+	}}
+	return curvedFace{surface: cyl, reversed: false, loops: []curvedLoop{loop}, lineage: topo.NewLineage(topo.Tok("brep", "bosswall", 0))}
+}
+
+// partialBossTopCap builds the boss's outer top disc anchored at the seam angle ta, so its full boundary
+// circle matches the split-base wall's top edge (also anchored at ta) — a full-circle edge welds only when
+// both sides share the same parameter anchoring, so the standard 0-anchored cap would leave the top open.
+func partialBossTopCap(center math.Point3, axis math.Vector3, farCirc geom.Circle, ta float64) curvedFace {
+	pl, _ := geom.NewPlane(center, axis)
+	loop := curvedLoop{edges: []loopEdge{{curve: farCirc, t0: ta, t1: ta + 1}}}
+	return curvedFace{surface: pl, reversed: false, loops: []curvedLoop{loop}, lineage: topo.NewLineage(topo.Tok("brep", "bosscap", 0))}
+}
+
+// splitFacesAtCrossings inserts each crossing point into any straight face edge that passes through it, so a
+// copied target face adjacent to the clipped seat edge welds to the seat/cap sub-edges — curvedStitch does
+// not resolve T-junctions itself, so the vertex must already be present on both sides (#1591).
+func splitFacesAtCrossings(faces []curvedFace, crossings []planeCrossing) []curvedFace {
+	pts := make([]math.Point3, len(crossings))
+	for i, cr := range crossings {
+		pts[i] = cr.at
+	}
+	out := make([]curvedFace, len(faces))
+	for i, f := range faces {
+		out[i] = curvedFace{surface: f.surface, reversed: f.reversed, lineage: f.lineage, outerless: f.outerless, loops: splitLoopsAt(f.loops, pts)}
+	}
+	return out
+}
+
+// splitLoopsAt splits every straight edge of every loop at the crossing points lying on it.
+func splitLoopsAt(loops []curvedLoop, pts []math.Point3) []curvedLoop {
+	out := make([]curvedLoop, len(loops))
+	for i, lp := range loops {
+		var edges []loopEdge
+		for _, e := range lp.edges {
+			edges = append(edges, splitLineEdgeAt(e, pts)...)
+		}
+		out[i] = curvedLoop{edges: edges}
+	}
+	return out
+}
+
+// splitLineEdgeAt breaks one straight loop edge at any crossing points on its interior (ordered along it),
+// re-emitting straight sub-segments through those shared points. Non-straight edges pass through untouched.
+func splitLineEdgeAt(e loopEdge, pts []math.Point3) []loopEdge {
+	if _, ok := e.curve.(geom.LineSegment); !ok {
+		return []loopEdge{e}
+	}
+	a, b := e.start(), e.end()
+	on := pointsOnSegment(a, b, pts)
+	if len(on) == 0 {
+		return []loopEdge{e}
+	}
+	verts := append([]math.Point3{a}, on...)
+	verts = append(verts, b)
+	out := make([]loopEdge, 0, len(verts)-1)
+	for i := 1; i < len(verts); i++ {
+		out = append(out, loopEdge{curve: geom.NewLineSegment(verts[i-1], verts[i]), t0: 0, t1: 1})
+	}
+	return out
+}
+
+// pointsOnSegment returns the points lying on the interior of segment a→b, ordered by their parameter along
+// it (within a stitch tolerance of the line, strictly between the endpoints).
+func pointsOnSegment(a, b math.Point3, pts []math.Point3) []math.Point3 {
+	tol := geom.ResolutionForSize(float64(a.DistanceTo(b))).Stitch()
+	d := a.VectorTo(b)
+	l2 := float64(d.Dot(d))
+	type sp struct {
+		s float64
+		p math.Point3
+	}
+	var hits []sp
+	for _, p := range pts {
+		s := float64(a.VectorTo(p).Dot(d)) / l2
+		if s <= 1e-9 || s >= 1-1e-9 {
+			continue
+		}
+		if a.TranslateBy(d.Scale(math.Scalar(s))).DistanceTo(p) > math.Scalar(tol) {
+			continue
+		}
+		hits = append(hits, sp{s: s, p: p})
+	}
+	for i := 1; i < len(hits); i++ { // insertion sort by parameter (few hits per edge)
+		for j := i; j > 0 && hits[j].s < hits[j-1].s; j-- {
+			hits[j], hits[j-1] = hits[j-1], hits[j]
+		}
+	}
+	out := make([]math.Point3, len(hits))
+	for i, h := range hits {
+		out[i] = h.p
+	}
+	return out
+}

--- a/kernel/brep/curved_plane_uv.go
+++ b/kernel/brep/curved_plane_uv.go
@@ -208,6 +208,27 @@ func sortedEdgeCrossings(crossings []planeCrossing, loop, edge int) []planeCross
 	return on
 }
 
+// capMaterial builds the material predicate for the exposed overhang UNDERSIDE of a boss straddling the seat
+// edge: keep a cell inside the tool (the boss footprint) AND outside the seat polygon — the mirror of
+// planeMaterial, run on the SAME base-plane arrangement so the two share the imprint arc exactly (#1591).
+func capMaterial(c *planeUV) func() materialPredicate {
+	return func() materialPredicate {
+		return func(uv math.Point2) bool {
+			return c.inTool(to3D(c.plane, uv)) && !pointInUVLoops(uv, c.seatUV)
+		}
+	}
+}
+
+// planeCrossingsOf returns the exact seat-boundary crossings of one imprint conic (the assembler shares them
+// with the wall base split and the T-junction resolution so every face meets on the same points).
+func (c *planeUV) planeCrossingsOf(cv geom.Curve3) []planeCrossing {
+	pc, ok := toPlaneConic(cv, c.plane)
+	if !ok {
+		return nil
+	}
+	return c.conicCrossings(cv, pc)
+}
+
 // pointInUVLoops reports whether q is inside a face given as (u,v) loops (outer first, then holes): inside the
 // outer loop and outside every hole — the even-odd containment the planar boolean uses (pointInPolygon2D).
 func pointInUVLoops(q math.Point2, loops [][]math.Point2) bool {

--- a/kernel/ops/partial_boss_certification_test.go
+++ b/kernel/ops/partial_boss_certification_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Partial curved-on-planar boss certification (#1591, ADR-0049 Slice B). A cylindrical boss whose base circle
+// CLIPS the seat face edge (a spigot straddling / overhanging a plate edge) unions through the planeUV
+// operand — the seat face is trimmed by the base conic, an overhang underside cap closes the cantilever, and
+// the split-base wall welds to both. Certified by an INDEPENDENT analytic mass (the boss sits at z≥2, the
+// plate at z≤2, so the union has no volume overlap: 10·10·2 + π·2²·3 = 200 + 12π) plus the top-priority
+// tessellation-watertightness gate (the user only ever sees the mesh).
+
+// straddlingBoss builds the fixture: a 10×10×2 plate unioned with a boss (r=2, h=3) seated on the top face at
+// (4,0) so its base circle (x∈[2,6]) overhangs the plate edge at x=5.
+func straddlingBoss(t *testing.T) *topo.Body {
+	t.Helper()
+	plate, err := brep.SolidBlock(math.P3(-5, -5, 0), math.P3(5, 5, 2), "plate")
+	if err != nil {
+		t.Fatalf("plate: %v", err)
+	}
+	boss, err := brep.SolidCylinder(math.P3(4, 0, 2), math.V3(0, 0, 1), 2, 3)
+	if err != nil {
+		t.Fatalf("boss: %v", err)
+	}
+	res, ok := brep.JoinPartialBoss(plate, boss)
+	if !ok {
+		t.Fatal("JoinPartialBoss declined the straddling boss")
+	}
+	return res
+}
+
+func TestPartialBossIsWatertightManifold(t *testing.T) {
+	res := straddlingBoss(t)
+	if !res.IsSolid() {
+		t.Fatal("straddling boss is not a solid")
+	}
+	if n := len(res.Shells()); n != 1 {
+		t.Errorf("straddling boss has %d shells, want 1", n)
+	}
+	free := 0
+	for _, e := range res.Edges() {
+		if len(e.Uses()) != 2 {
+			free++
+		}
+	}
+	if free != 0 {
+		t.Errorf("straddling boss B-rep has %d free edges, want 0 (a closed manifold)", free)
+	}
+}
+
+func TestPartialBossVolumeMatchesAnalytic(t *testing.T) {
+	res := straddlingBoss(t)
+	want := 200 + 12*stdmath.Pi // plate + cantilevered boss, no overlap
+	got := BodyGeometryProperties(res, DefaultQuality()).Volume
+	if rel := stdmath.Abs(got-want) / want; rel > 0.01 {
+		t.Errorf("straddling boss volume %.4f vs analytic %.4f (200+12π); rel %.4f > 0.01", got, want, rel)
+	}
+}
+
+// TestPartialBossTessellationIsWatertight is the top-priority tessellation gate (CLAUDE.md: the user only
+// ever sees the mesh). The planeUV-trimmed seat, the overhang cap and the split-base wall must weld into a
+// crack-free surface — every triangle edge shared by exactly two triangles — so the rendered frame shows no
+// tear where the base conic crosses the plate edge.
+func TestPartialBossTessellationIsWatertight(t *testing.T) {
+	res := straddlingBoss(t)
+	mesh, _ := TessellateBody(res, DefaultQuality())
+	if free := cornerMeshFreeEdges(mesh); free != 0 {
+		t.Errorf("straddling boss tessellation has %d free edges (want 0) — a visible crack at the clipped seat", free)
+	}
+}

--- a/kernel/ops/saddle_band_loft.go
+++ b/kernel/ops/saddle_band_loft.go
@@ -27,10 +27,27 @@ import (
 // welds. ok=false unless the face is a developable side carrying both a full-circle rim and an open
 // (notched) rim edge — so a plain two-circle band (which already bypasses toUVLoops) is untouched.
 func notchedRimBandMesh(f *topo.Face, s geom.Surface, q Quality) (*Mesh, bool) {
-	if !isDevelopableSide(s) || !hasFullCircleAndNotchedRim(f) {
-		return nil, false
+	if !isDevelopableSide(s) || faceHasLensHole(f, s, q) || !hasFullCircleAndNotchedRim(f) {
+		return nil, false // a band carrying a genuine (non-wrapping) lens hole is twoRimHoledBandMesh's job:
+		// the saddle loft pools ALL open edges into one rim, so it would fold the lens into the base rim (#1591).
 	}
 	return saddleBandLoftMesh(f, s, q)
+}
+
+// faceHasLensHole reports whether the face carries a genuine LENS hole — an interior loop that does NOT wrap
+// the full period. A non-outer loop that DOES wrap (a second full-wrap rim faceHoleBoundaries mis-demoted to a
+// "hole") is still a valid two-rim-band rim the saddle loft meshes, so it must NOT disqualify the face; only a
+// true lens (a drilled tunnel's entry, spanning a small arc) does, since the pure two-rim loft can't carry it.
+func faceHasLensHole(f *topo.Face, s geom.Surface, q Quality) bool {
+	for _, l := range f.Loops() {
+		if l.IsOuter() {
+			continue
+		}
+		if !holeWrapsPeriod(s, loopBoundary(l, q)) {
+			return true
+		}
+	}
+	return false
 }
 
 // twoClosedRimBandMesh meshes a developable side (cylinder/cone) bounded by exactly TWO closed full-wrap
@@ -73,25 +90,27 @@ func hasTwoClosedRimsNoOpen(f *topo.Face) bool {
 	return closed == 2
 }
 
-// hasFullCircleAndNotchedRim reports whether the face has BOTH a full-period closed-circle rim edge and
-// at least one open (non-closed) rim edge — the notched-band signature. Seam edges (used twice within
-// the face) are excluded, as they bridge the rims and belong to neither.
+// hasFullCircleAndNotchedRim reports whether the face has BOTH a full-period closed rim edge and at least
+// one open (non-closed) rim edge — the notched-band signature. Seam edges (used twice within the face) are
+// excluded, as they bridge the rims and belong to neither. Closure (start==end vertex), not curve type,
+// identifies the full-wrap rim — consistent with hasTwoClosedRimsNoOpen: on a developable side a closed rim
+// necessarily wraps the whole period. The old geom.Circle-only gate mis-declined #1591's split-base boss
+// wall, whose top rim is stored as a full-turn geom.Arc3d (anchored at the seam angle), not a geom.Circle,
+// so the wall fell through to a full-periodic grid that ignores the shared arc discretization → a crack.
 func hasFullCircleAndNotchedRim(f *topo.Face) bool {
 	seam := seamEdgesOf(f)
-	fullCircle, notched := false, false
+	closedRim, notched := false, false
 	for _, e := range f.Edges() {
 		if seam[e] {
 			continue
 		}
 		if e.StartVertex() == e.EndVertex() {
-			if _, isCircle := e.Geometry().(geom.Circle); isCircle {
-				fullCircle = true
-			}
+			closedRim = true
 		} else {
 			notched = true
 		}
 	}
-	return fullCircle && notched
+	return closedRim && notched
 }
 
 // saddleBandLoftMesh meshes a singly-periodic ruled band (a trimmed cylinder/cone side) bounded by two


### PR DESCRIPTION
## What

Implements the **straddling/overhanging boss** union for #1591 (ADR-0049 Slice B): a cylindrical boss whose base circle **CLIPS** the seat face edge — a spigot cantilevered over a plate edge — unions through the new `planeUV` operand. Where `JoinCylindricalBoss` requires the base strictly interior to one seat face, this handles the base conic crossing the seat boundary.

Two commits, two concerns:

1. **`feat(brep)`: the assembler.** The seat plane is trimmed by the base conic (`planeMaterial`: plate minus the in-boss footprint); the coincident overhang underside becomes an exposed cap (`capMaterial`: in-boss but off-plate); the boss adds a full wall whose base is split at the two seat crossings so its in-seat sub-arc welds to the seat and its out-seat sub-arc welds to the cap, plus a top cap anchored at the seam angle so the full top circle is never bisected. `recoverEdge` now interpolates `tA/tB` for `segPolygon` runs (as it already did for `segImprint`) — without it the seat's non-periodic planar-frame perimeter came back zero-length, leaving free edges.

2. **`fix(ops)`: the tessellation.** The split-base wall's full-wrap top rim is a topologically **closed `geom.Arc3d`** (a full turn anchored at the seam angle), not a `geom.Circle`, so `hasFullCircleAndNotchedRim`'s curve-type gate mis-declined it and it fell through to a full-periodic cylinder grid that samples uniform angular stations **independently** of the shared arc edges — 120 free mesh edges (a visible crack). Closure, not curve type, identifies a full-wrap rim on a developable side (consistent with the sibling `hasTwoClosedRimsNoOpen`). `faceHasLensHole` then guards the relaxation so a band carrying a genuine **lens** hole (a drilled tunnel's entry) still routes to `twoRimHoledBandMesh` and is never folded into the base rim.

## Why

`planeUV` is the operand that runs partial curved-on-planar contacts through the shared `(u,v)`-arrangement pipeline instead of CSG (ADR-0049). Slice B proves it end-to-end on the additive (boss) case.

## Certification

`kernel/ops/partial_boss_certification_test.go` (top-priority mesh gate — the user only ever sees the mesh):
- **watertight manifold** (0 B-rep free edges, 1 shell);
- **volume** matches the independent analytic mass `200 + 12π` (plate + cantilevered boss, no overlap);
- **tessellation watertight** (0 free mesh edges).

Plus `kernel/brep/curved_plane_partial_boss_test.go` (B-rep end-to-end).

Full `kernel/...` suite green; the shared-mesher change was verified to not regress the radial-bore, partial-rim-cut, and OCC-oracle cases (the initial over-broad guard caught and fixed during review). `golangci-lint` clean.

Closes part of #1591 (Slice B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)