### PR TITLE
feat(ops): dispatch straddling-boss union to the analytic assembler + fix cap orientation (#1591)

### DIFF
--- a/kernel/brep/curved_plane_partial_boss.go
+++ b/kernel/brep/curved_plane_partial_boss.go
@@ -114,7 +114,24 @@ func trimSeatAndCap(c *planeUV, seatFace curvedFace, pl geom.Plane, nearCirc geo
 	if err != nil || len(cap) == 0 {
 		return nil, nil, false
 	}
-	return seat, cap, true
+	return seat, reverseCapLoops(cap), true
+}
+
+// reverseCapLoops flips each overhang-cap face's loop winding. trimByImprint's orientLoops winds every kept
+// loop for the seat plane's NATURAL (+normal) sense regardless of the input face's reversed flag; the cap
+// faces the OPPOSITE way (its reversed=true normal points down, away from the boss), so its loops must be
+// reversed to wind CCW about that normal — otherwise its shared edges run the same way as the wall's and the
+// plate side's, an inconsistent orientation the manifold gate rejects (#1591).
+func reverseCapLoops(faces []curvedFace) []curvedFace {
+	out := make([]curvedFace, len(faces))
+	for i, f := range faces {
+		loops := make([]curvedLoop, len(f.loops))
+		for j, lp := range f.loops {
+			loops[j] = reverseCurvedLoop(lp)
+		}
+		out[i] = curvedFace{surface: f.surface, reversed: f.reversed, loops: loops, lineage: f.lineage, outerless: f.outerless}
+	}
+	return out
 }
 
 // bossSeamAngle returns the smaller of the two crossing parameters — the conic t where the wall seam and the

--- a/kernel/brep/curved_plane_partial_boss_test.go
+++ b/kernel/brep/curved_plane_partial_boss_test.go
@@ -20,15 +20,25 @@ func TestJoinPartialBossStraddlesEdge(t *testing.T) {
 	if !ok {
 		t.Fatal("partial boss union declined; want plate + straddling boss")
 	}
-	freeEdges := 0
+	freeEdges, inconsistent := 0, 0
 	for _, e := range res.Edges() {
-		if len(e.Uses()) != 2 {
+		uses := e.Uses()
+		if len(uses) != 2 {
 			freeEdges++
+			continue
+		}
+		if uses[0].Reversed() == uses[1].Reversed() { // both traverse the edge the same way → not orientable
+			inconsistent++
 		}
 	}
-	t.Logf("faces=%d edges=%d freeEdges=%d solid=%v shells=%d", len(res.Faces()), len(res.Edges()), freeEdges, res.IsSolid(), len(res.Shells()))
+	t.Logf("faces=%d edges=%d freeEdges=%d inconsistent=%d solid=%v shells=%d", len(res.Faces()), len(res.Edges()), freeEdges, inconsistent, res.IsSolid(), len(res.Shells()))
 	if freeEdges != 0 {
 		t.Errorf("partial boss has %d free edges (want 0 — a watertight manifold)", freeEdges)
+	}
+	// Orientation consistency: every shared edge's two face-uses must run opposite ways, or the analytic
+	// manifold gate (validBooleanSolid) rejects the body and ops.Boolean silently falls back to CSG (#1591).
+	if inconsistent != 0 {
+		t.Errorf("partial boss has %d inconsistently-oriented edges (want 0 — an orientable manifold)", inconsistent)
 	}
 }
 

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -239,8 +239,8 @@ var curvedExactPaths = []func(PartFeatureOperation, *topo.Body, *topo.Body, *dia
 	curvedPartialIntersect,
 	// Cut — [P] the drill through-hole (curved-on-planar), the rest [T] transversal.
 	curvedCylindricalHoleCut, curvedFlatSubtract, curvedPartialCut, curvedSteinmetzCut, curvedConeCylinderCut, curvedConeConeCut, curvedCapCrossCut, curvedRimCrossCut, curvedTwoCapCrossCut, curvedConeCapCrossCut, curvedPartialRimCut, curvedPartialRimCornerCut, curvedCrossingCut,
-	// Join — [D] coaxial (degenerate overlap), [P] boss (curved-on-planar), the rest [T] transversal.
-	curvedCoaxialJoin, curvedCylinderBossJoin, curvedPartialJoin, curvedConeCylinderJoin, curvedConeConeJoin, curvedCrossingJoin, curvedSteinmetzJoin,
+	// Join — [D] coaxial (degenerate overlap), [P] boss interior then straddling (curved-on-planar), the rest [T] transversal.
+	curvedCoaxialJoin, curvedCylinderBossJoin, curvedPartialBossJoin, curvedPartialJoin, curvedConeCylinderJoin, curvedConeConeJoin, curvedCrossingJoin, curvedSteinmetzJoin,
 }
 
 func shouldFallbackBoolean(op PartFeatureOperation, target, tool, body *topo.Body) bool {

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -81,7 +81,8 @@ var (
 
 	// Join — the union, keeping the analytic wall where the operands' faces are coincident or breached.
 	curvedCoaxialJoin      = gatedCurved(Join, withoutRecorder(brep.CoaxialCylinderUnion)) // coaxial equal-radius cylinders
-	curvedCylinderBossJoin = gatedCurved(Join, withoutRecorder(brep.JoinCylindricalBoss))  // cylinder seated flush on a face
+	curvedCylinderBossJoin = gatedCurved(Join, withoutRecorder(brep.JoinCylindricalBoss))  // cylinder seated flush on a face, base strictly interior
+	curvedPartialBossJoin  = gatedCurved(Join, withoutRecorder(brep.JoinPartialBoss))      // cylinder boss whose base circle straddles the seat edge (#1591)
 	curvedPartialJoin      = gatedCurved(Join, brep.PartialPenetrationJoinGeneral)         // fat + entry stub
 	curvedConeCylinderJoin = gatedCurved(Join, brep.ConeCylinderJoinGeneral)
 	curvedConeConeJoin     = gatedCurved(Join, brep.ConeConeJoinGeneral)

--- a/kernel/ops/partial_boss_certification_test.go
+++ b/kernel/ops/partial_boss_certification_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 )
@@ -74,5 +75,40 @@ func TestPartialBossTessellationIsWatertight(t *testing.T) {
 	mesh, _ := TessellateBody(res, DefaultQuality())
 	if free := cornerMeshFreeEdges(mesh); free != 0 {
 		t.Errorf("straddling boss tessellation has %d free edges (want 0) — a visible crack at the clipped seat", free)
+	}
+}
+
+// TestPartialBossJoinsViaAnalyticDispatch is the reachability gate: ops.Boolean(Join) must ROUTE the
+// straddling boss to the analytic planeUV assembler (curvedPartialBossJoin), not fall through to the planar
+// CSG triangle-soup. CSG returns a watertight body of the right volume too, so volume alone can't tell them
+// apart — the analytic result is distinguished by KEEPING the boss's cylinder wall as one analytic face (a
+// handful of faces), where CSG shatters it into ~200 planar facets and loses the exact surface.
+func TestPartialBossJoinsViaAnalyticDispatch(t *testing.T) {
+	plate, _ := brep.SolidBlock(math.P3(-5, -5, 0), math.P3(5, 5, 2), "plate")
+	boss, _ := brep.SolidCylinder(math.P3(4, 0, 2), math.V3(0, 0, 1), 2, 3)
+	res, err := Boolean(Join, plate, boss)
+	if err != nil {
+		t.Fatalf("Boolean(Join): %v", err)
+	}
+	if n := len(res.Faces()); n > 20 {
+		t.Errorf("union has %d faces; want the analytic assembler (~9), not CSG triangle-soup", n)
+	}
+	hasCyl := false
+	for _, f := range res.Faces() {
+		if _, ok := f.Geometry().(geom.Cylinder); ok {
+			hasCyl = true
+			break
+		}
+	}
+	if !hasCyl {
+		t.Error("union kept no analytic cylinder face — the boss wall was not preserved (CSG fallback)")
+	}
+	mesh, _ := TessellateBody(res, DefaultQuality())
+	if free := cornerMeshFreeEdges(mesh); free != 0 {
+		t.Errorf("dispatched union tessellation has %d free edges (want 0)", free)
+	}
+	want := 200 + 12*stdmath.Pi
+	if got := BodyGeometryProperties(res, DefaultQuality()).Volume; stdmath.Abs(got-want)/want > 0.01 {
+		t.Errorf("dispatched union volume %.4f vs analytic %.4f (200+12π); rel %.4f > 0.01", got, want, stdmath.Abs(got-want)/want)
 	}
 }


### PR DESCRIPTION
## What

Makes the Slice B straddling-boss assembler (`brep.JoinPartialBoss`, merged in #1745) actually **reachable** from `ops.Boolean(Join)`, and fixes a latent orientation defect it exposed.

Two commits:

1. **`fix(brep)`: orient the overhang cap.** The assembler's overhang underside cap came out watertight but **not orientable**: `trimByImprint`'s `orientLoops` winds every kept loop for the seat plane's natural (+normal) sense regardless of the input face's `reversed` flag, but the cap faces the opposite way (normal down, away from the boss). Its shared edges therefore ran the *same* direction as the wall's and the plate side's. The B-rep free-edge count missed this (every edge still had two uses), but `ops.Validate` flags `inconsistent orientation` and the analytic manifold gate rejects the body. `reverseCapLoops` flips the cap loop winding to wind CCW about the cap's own normal.

2. **`feat(ops)`: wire the dispatch.** Only the *interior* `curvedCylinderBossJoin` was in the curved-Join dispatch, so a boss whose base clips the seat edge fell through to planar CSG — a watertight but **226-face triangle-soup** that loses the analytic cylinder wall. Registering `curvedPartialBossJoin` right after the interior boss (the two are disjoint) routes it to the exact ~9-face analytic solid.

## Why

Slice B proved the assembler at the `brep` level but the certification called `JoinPartialBoss` directly. End-to-end, `ops.Boolean(Join, plate, straddlingBoss)` still produced CSG — and the reason it couldn't be adopted was the orientation bug, which the free-edge-only test never caught. This closes both gaps and hardens the tests against them.

## Certification

- `TestPartialBossJoinsViaAnalyticDispatch` (new): `ops.Boolean(Join)` yields the analytic solid — ≤20 faces, an analytic `geom.Cylinder` wall face preserved, 0 free mesh edges, volume `200 + 12π`.
- `TestJoinPartialBossStraddlesEdge` (hardened): now also asserts **zero inconsistently-oriented edges**, not just zero free edges.

Full `kernel/...` suite green; `golangci-lint` clean.

Part of #1591 (Slice B integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)