### PR TITLE
refactor(brep): DRY the partial curved-on-planar contact gate + keep-interior characterization (#1591 Slice C)

### DIFF
--- a/kernel/brep/curved_plane_partial_boss.go
+++ b/kernel/brep/curved_plane_partial_boss.go
@@ -45,8 +45,8 @@ func JoinPartialBoss(target, tool *topo.Body) (*topo.Body, bool) {
 // the seated (near) and protruding (far) cap centres, or ok=false.
 func partialBossSeat(faces []curvedFace, c0, c1 math.Point3, ua math.Vector3, radius float64) (idx int, near, far math.Point3, ok bool) {
 	for i, f := range faces {
-		pl, isPlane := f.surface.(geom.Plane)
-		if !isPlane || stdmath.Abs(float64(unit(pl.Normal()).Dot(ua))) < 1-1e-7 {
+		pl, ok := planarCapPerpTo(f, ua)
+		if !ok {
 			continue
 		}
 		nOut := faceOutwardNormal(f, pl)
@@ -56,7 +56,7 @@ func partialBossSeat(faces []curvedFace, c0, c1 math.Point3, ua math.Vector3, ra
 			if stdmath.Abs(pointPlaneDistance(n, pl)) > flushTol || float64(n.VectorTo(fr).Dot(nOut)) <= 0 {
 				continue
 			}
-			if pierced, clean := circleVsCap(n, radius, f, pl); pierced && !clean {
+			if circleClipsCap(n, radius, f, pl) {
 				return i, n, fr, true
 			}
 		}

--- a/kernel/brep/curved_plane_partial_drill.go
+++ b/kernel/brep/curved_plane_partial_drill.go
@@ -57,9 +57,9 @@ func partialDrillCaps(faces []curvedFace, base math.Point3, ua math.Vector3, hei
 	tol := geom.ResolutionForSize(height).Plane()
 	var found []scallopCap
 	for i, f := range faces {
-		pl, isPlane := f.surface.(geom.Plane)
-		if !isPlane || stdmath.Abs(float64(unit(pl.Normal()).Dot(ua))) < 1-1e-7 {
-			continue // not perpendicular to the drill axis
+		pl, ok := planarCapPerpTo(f, ua)
+		if !ok {
+			continue
 		}
 		t := pierceParam(base, ua, pl)
 		if t < -tol || t > height+tol {
@@ -67,12 +67,10 @@ func partialDrillCaps(faces []curvedFace, base math.Point3, ua math.Vector3, hei
 		}
 		center := base.TranslateBy(ua.Scale(math.Scalar(t)))
 		circ, err := geom.NewCircle(center, ua, radius)
-		if err != nil {
+		if err != nil || !circleClipsCap(center, radius, f, pl) {
 			continue
 		}
-		if pierced, clean := circleVsCap(center, radius, f, pl); pierced && !clean {
-			found = append(found, scallopCap{idx: i, circle: circ, plane: pl, face: f})
-		}
+		found = append(found, scallopCap{idx: i, circle: circ, plane: pl, face: f})
 	}
 	if len(found) != 2 {
 		return [2]scallopCap{}, false

--- a/kernel/brep/curved_plane_partial_gate.go
+++ b/kernel/brep/curved_plane_partial_gate.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Shared accept/decline gate for the partial curved-on-planar KIND (#1591, ADR-0049 D-b). Both the partial
+// boss (JoinPartialBoss) and the edge scallop (CutEdgeScallop) recognise the SAME contact: a cylinder tool
+// meeting a planar face perpendicular to its axis, whose base circle CLIPS the face boundary. This is the
+// characterization that routes a contact to the planeUV path instead of the strictly-interior fast-path
+// (DrillThroughHole / JoinCylindricalBoss handle the circle wholly inside one face); factoring it here keeps
+// the two assemblers from each re-deriving the "planar ∧ perpendicular ∧ pierced-but-not-clean" test.
+
+// planarCapPerpTo returns face f's plane when f is planar and its normal is (anti)parallel to the tool axis ua
+// — a cap/seat the perpendicular tool could sit flush on or drill through. ok=false otherwise.
+func planarCapPerpTo(f curvedFace, ua math.Vector3) (geom.Plane, bool) {
+	pl, isPlane := f.surface.(geom.Plane)
+	if !isPlane || stdmath.Abs(float64(unit(pl.Normal()).Dot(ua))) < 1-1e-7 {
+		return geom.Plane{}, false
+	}
+	return pl, true
+}
+
+// circleClipsCap reports whether the tool circle of radius `radius` centred at `center` CLIPS face f's
+// boundary — pierced (centre inside the face) but NOT clean (the rim crosses out). This is the partial-vs-
+// interior discriminator: pierced && clean is the strictly-interior fast-path's job, so the partial planeUV
+// path takes only pierced && !clean.
+func circleClipsCap(center math.Point3, radius float64, f curvedFace, pl geom.Plane) bool {
+	pierced, clean := circleVsCap(center, radius, f, pl)
+	return pierced && !clean
+}

--- a/kernel/ops/partial_interior_characterization_test.go
+++ b/kernel/ops/partial_interior_characterization_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Keep-interior characterization (#1591, ADR-0049 D-b, Slice C). The partial curved-on-planar paths
+// (CutEdgeScallop, JoinPartialBoss) must take ONLY the pierced-but-not-clean contact; a circle wholly inside
+// one face stays the strictly-interior fast-path's job (DrillThroughHole / JoinCylindricalBoss). These tests
+// pin that boundary: the partial recognizers decline the interior cases, and ops.Boolean still routes the
+// interior contact to its analytic fast-path (a handful of faces, an analytic cylinder wall), not to the
+// partial path nor to CSG.
+
+// TestInteriorDrillStaysThroughHole: a centered drill (circle strictly inside both caps) declines the scallop
+// path and stays DrillThroughHole — the interior/partial gate boundary is clean on the subtractive side.
+func TestInteriorDrillStaysThroughHole(t *testing.T) {
+	plate, _ := brep.SolidBlock(math.P3(-5, -5, 0), math.P3(5, 5, 2), "plate")
+	drill, _ := brep.SolidCylinder(math.P3(0, 0, -1), math.V3(0, 0, 1), 2, 4) // centered → strictly interior
+	if _, ok := brep.CutEdgeScallop(plate, drill); ok {
+		t.Error("scallop recognizer accepted a strictly-interior hole; want decline")
+	}
+	res, err := Boolean(Cut, plate, drill)
+	if err != nil {
+		t.Fatalf("Boolean(Cut): %v", err)
+	}
+	assertAnalyticCylinderSolid(t, res, "interior drill")
+}
+
+// TestInteriorBossStaysCylindricalBoss: a boss whose base circle is strictly inside the seat face declines the
+// straddling path and stays JoinCylindricalBoss — the gate boundary is clean on the additive side.
+func TestInteriorBossStaysCylindricalBoss(t *testing.T) {
+	plate, _ := brep.SolidBlock(math.P3(-5, -5, 0), math.P3(5, 5, 2), "plate")
+	boss, _ := brep.SolidCylinder(math.P3(0, 0, 2), math.V3(0, 0, 1), 2, 3) // centered on the top face → interior
+	if _, ok := brep.JoinPartialBoss(plate, boss); ok {
+		t.Error("boss recognizer accepted a strictly-interior seat; want decline")
+	}
+	res, err := Boolean(Join, plate, boss)
+	if err != nil {
+		t.Fatalf("Boolean(Join): %v", err)
+	}
+	assertAnalyticCylinderSolid(t, res, "interior boss")
+}
+
+// assertAnalyticCylinderSolid checks a boolean result is the analytic fast-path output: a watertight solid
+// with few faces (not CSG triangle-soup) that preserves an analytic cylinder wall.
+func assertAnalyticCylinderSolid(t *testing.T, res *topo.Body, label string) {
+	t.Helper()
+	if !res.IsSolid() {
+		t.Errorf("%s: result is not a solid", label)
+	}
+	if n := len(res.Faces()); n > 20 {
+		t.Errorf("%s: result has %d faces; want the analytic fast-path (few), not CSG", label, n)
+	}
+	for _, f := range res.Faces() {
+		if _, ok := f.Geometry().(geom.Cylinder); ok {
+			return
+		}
+	}
+	t.Errorf("%s: result kept no analytic cylinder face (a CSG fallback)", label)
+}


### PR DESCRIPTION
## What

Slice C of #1591 (ADR-0049 D-b): remove the duplication the boss and drill assemblers introduced, and pin the interior/partial gate boundary.

- **Gate DRY.** `JoinPartialBoss` and `CutEdgeScallop` recognise the *same* contact (a perpendicular cylinder whose base circle **clips** a planar face) but each re-derived the test inline. Extracted into two named helpers in `curved_plane_partial_gate.go`: `planarCapPerpTo` (planar cap ∥ axis) and `circleClipsCap` (pierced but **not** clean — the partial-vs-interior discriminator).
- **Keep-interior characterization.** `partial_interior_characterization_test.go` pins the boundary: a strictly-interior drill and boss both **decline** the partial recognizers, and `ops.Boolean` still routes them to their analytic interior fast-path (`DrillThroughHole` / `JoinCylindricalBoss` — few faces, an analytic cylinder wall), never to the partial path or CSG.

## Why

CLAUDE.md forbids duplication, and the partial paths must never steal a contact the strictly-interior fast-path owns. This makes the routing decision one named predicate and guards it with a regression test.

## Safety

No behavior change — the full `kernel/...` suite is byte-stable across the refactor; this only removes duplication. `golangci-lint` clean.

Part of #1591 (Slice C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)