### PR TITLE
fix(undo): Ctrl+Z/Y work while a tool is armed (undo dead during sketch drawing) (#1750)

### DIFF
--- a/app/bindings.go
+++ b/app/bindings.go
@@ -79,17 +79,21 @@ func dispatchHomeView(s *Session) error {
 	return nil
 }
 
-// dispatchUndo runs undo only when no interactive tool is mid-operation — undo is
-// forbidden while a transaction is in progress, so the keystroke is a no-op otherwise.
+// dispatchUndo runs undo unless a bounded transaction (an open recipe group) is mid-record —
+// undoing then would corrupt the unit being written. A merely-armed interactive tool is NOT
+// such a transaction: in continuous drawing each segment auto-commits, so between clicks no
+// group is open and Ctrl+Z rewinds the last committed segment with the tool still running —
+// Inventor's behavior. The old `s.tool != nil` guard was far broader than its own comment
+// ("transaction in progress") and silently no-op'd undo for the entire sketch session (#1750).
 func dispatchUndo(s *Session) error {
-	if s.tool != nil {
+	if s.InTransaction() {
 		return nil
 	}
 	return s.Undo()
 }
 
 func dispatchRedo(s *Session) error {
-	if s.tool != nil {
+	if s.InTransaction() {
 		return nil
 	}
 	return s.Redo()

--- a/app/bindings_test.go
+++ b/app/bindings_test.go
@@ -309,7 +309,12 @@ func TestPressKeyRebindTakesEffect(t *testing.T) {
 	}
 }
 
-func TestDispatchUndoGuardedWhileToolActive(t *testing.T) {
+// TestDispatchUndoFiresWhileToolArmed pins the corrected #1750 semantics at the Dispatch layer:
+// undo is NOT blocked merely because an interactive tool is armed — only a genuinely open
+// bounded transaction blocks it (see TestKeyboardUndoBlockedDuringOpenTransaction). Before #1750
+// the guard was `s.tool != nil`, so an armed tool silently killed undo and this test asserted that
+// no-op; it now guards against regressing back to the over-broad guard.
+func TestDispatchUndoFiresWhileToolArmed(t *testing.T) {
 	s, profile := newPartWithSquare(t, 2)
 	trackFromHere(s)
 	s.SetPicker(stubPicker{sel: profile})
@@ -324,19 +329,17 @@ func TestDispatchUndoGuardedWhileToolActive(t *testing.T) {
 		t.Fatal("precondition: the extrude should be undoable")
 	}
 
-	s.StartTool(bindingStubTool{}) // a tool is now active
+	s.StartTool(bindingStubTool{}) // a tool is now armed, but no bounded transaction is open
+	if s.InTransaction() {
+		t.Fatal("precondition: a merely-armed tool opens no bounded transaction")
+	}
 	if err := s.Bindings().Dispatch(ActionUndo, s); err != nil {
 		t.Fatalf("Dispatch undo: %v", err)
 	}
-	if !s.CanUndo() {
-		t.Error("undo must be a no-op while a tool is active (guard preserved)")
-	}
-
-	s.CancelTool()
-	if err := s.Bindings().Dispatch(ActionUndo, s); err != nil {
-		t.Fatalf("Dispatch undo after cancel: %v", err)
-	}
 	if s.CanUndo() {
-		t.Error("with no tool, undo should consume the extrude transaction")
+		t.Error("undo must fire while a tool is armed (no open transaction) — #1750")
+	}
+	if !s.CanRedo() {
+		t.Error("the undone extrude should be redoable")
 	}
 }

--- a/app/undo_keyboard_test.go
+++ b/app/undo_keyboard_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// sketchWithPerpConstraint sets up a part in an open sketch with two lines and a committed
+// Perpendicular constraint (its own undo step), leaving the sketch active. It is the shared
+// fixture for the keyboard-undo regressions below: an undoable step exists and the session
+// is in the exact state a user is in mid-edit.
+func sketchWithPerpConstraint(t *testing.T) *Session {
+	t.Helper()
+	s, _ := emptyPartSession(t)
+	sk, err := s.CreateSketch(sketch.XYPlane())
+	if err != nil {
+		t.Fatalf("CreateSketch: %v", err)
+	}
+	sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0))
+	sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 4))
+	s.RecordActiveEdit("Sketch Geometry") // baseline: the two lines, before the constraint
+
+	s.StartTool(constraintToolDefs[3].new()) // Perpendicular
+	s.feedPick(SketchEntityHandle{Entity: sk.Lines().Item(0)})
+	s.feedPick(SketchEntityHandle{Entity: sk.Lines().Item(1)}) // auto-commits via OK → records "Perpendicular"
+	if !s.CanUndo() || s.UndoLabel() != "Perpendicular" {
+		t.Fatalf("fixture: CanUndo=%v UndoLabel=%q; want true/Perpendicular", s.CanUndo(), s.UndoLabel())
+	}
+	return s
+}
+
+// TestKeyboardUndoWorksWhileToolArmed is the #1750 regression: Ctrl+Z routed through the real
+// keyboard path (PressKey → RunChord → dispatchUndo) must undo the last committed step even when
+// an interactive tool is armed — the state a user is in for the ENTIRE duration of sketch drawing.
+// The old guard `s.tool != nil` silently no-op'd here, so undo appeared dead during sketching; the
+// fix narrows the guard to an actually-open transaction (s.InTransaction()).
+func TestKeyboardUndoWorksWhileToolArmed(t *testing.T) {
+	s := sketchWithPerpConstraint(t)
+	s.StartTool(NewLineTool()) // arm a tool: this is precisely the old guard's kill condition
+	if s.InTransaction() {
+		t.Fatal("fixture: no bounded transaction should be open with a merely-armed tool")
+	}
+
+	if err := s.PressKey(KeyEvent{Key: "z", Mods: CtrlMod}); err != nil { // Ctrl+Z
+		t.Fatalf("PressKey(Ctrl+Z): %v", err)
+	}
+
+	if n := len(s.ActiveSketch().Constraints()); n != 0 {
+		t.Errorf("after Ctrl+Z with a tool armed, sketch has %d constraints; want 0 (undo must fire)", n)
+	}
+	if !s.InSketch() {
+		t.Error("undo of the constraint should keep the sketch open for editing")
+	}
+	if !s.CanRedo() {
+		t.Error("after undo, the step should be redoable")
+	}
+}
+
+// TestKeyboardUndoBlockedDuringOpenTransaction pins the invariant the guard exists to protect:
+// while a bounded transaction (a recipe group) is genuinely open, Ctrl+Z must NOT fire — undoing
+// mid-record would corrupt the unit being written. This is the narrow condition the #1750 fix
+// keeps blocking (the old guard's over-broad `s.tool != nil` conflated this with "any tool armed").
+func TestKeyboardUndoBlockedDuringOpenTransaction(t *testing.T) {
+	s := sketchWithPerpConstraint(t)
+	if err := s.BeginTransaction("group edit"); err != nil {
+		t.Fatalf("BeginTransaction: %v", err)
+	}
+	if !s.InTransaction() {
+		t.Fatal("fixture: BeginTransaction should open a bounded transaction")
+	}
+
+	if err := s.PressKey(KeyEvent{Key: "z", Mods: CtrlMod}); err != nil { // Ctrl+Z — must be a no-op
+		t.Fatalf("PressKey(Ctrl+Z): %v", err)
+	}
+
+	if n := len(s.ActiveSketch().Constraints()); n != 1 {
+		t.Errorf("Ctrl+Z during an open transaction changed the sketch (%d constraints); want it blocked at 1", n)
+	}
+	if !s.CanUndo() || s.UndoLabel() != "Perpendicular" {
+		t.Errorf("the committed step must survive a blocked undo; CanUndo=%v label=%q", s.CanUndo(), s.UndoLabel())
+	}
+	if err := s.EndTransaction(); err != nil {
+		t.Fatalf("EndTransaction: %v", err)
+	}
+}


### PR DESCRIPTION
## What
Keyboard **undo/redo now works while an interactive tool is armed** — most importantly, throughout sketch drawing. Ctrl+Z / Ctrl+Y previously did nothing during a sketch (or any active tool/dialog), with no feedback.

## Why
`dispatchUndo`/`dispatchRedo` guarded on `s.tool != nil`. The guard's own comment says undo is "forbidden while a transaction is in progress" — but `s.tool != nil` is far broader: a sketch geometry tool (Line, continuous mode, …) stays **armed for the entire draw session**, so the keyboard shortcut was a dead key the whole time. The Edit ▸ Undo menu worked because it calls `s.Undo()` directly and bypasses the guard — that asymmetry is what hid the bug.

The fix narrows the guard to the real invariant it was meant to protect: **`s.InTransaction()`** (an open recipe group, `groupDepth > 0`). In continuous drawing each segment auto-commits (a group opens and closes synchronously), so between clicks no group is open and Ctrl+Z rewinds the last committed segment with the tool still running — matching Inventor's behavior.

`dispatchCancel` (Esc) and `dispatchCommit` (Enter) intentionally keep acting on the armed tool and are unchanged.

## Tests
- `app/undo_keyboard_test.go` (new) drives the **exact keyboard seam** the head uses (`PressKey → RunChord → dispatchUndo`):
  - `TestKeyboardUndoWorksWhileToolArmed` — Ctrl+Z with a Line tool armed undoes the last committed step (fails under the old guard; verified).
  - `TestKeyboardUndoBlockedDuringOpenTransaction` — Ctrl+Z is still a no-op while a bounded transaction is genuinely open (the invariant the guard exists to protect).
- `app/bindings_test.go` — the prior `TestDispatchUndoGuardedWhileToolActive`, which asserted the buggy "no-op while a tool is active" behavior, is rewritten as `TestDispatchUndoFiresWhileToolArmed` to pin the corrected semantics.
- Full `app` suite green; head keyboard-forwarding tests (`TestDispatchPressedKeys*`) green; `go vet` + `golangci-lint` clean.

Closes #1750.