### PR TITLE
fix(sketch): reveal origin planes in the viewport for Create 2D Sketch (#1752)

### DIFF
--- a/app/create_sketch_face_host_test.go
+++ b/app/create_sketch_face_host_test.go
@@ -8,6 +8,7 @@ import (
 
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/scene"
 )
@@ -138,23 +139,57 @@ func emptyPartLookingDown(t *testing.T) *Session {
 	return s
 }
 
-// TestCreateSketchBackgroundClickIgnoresHiddenOriginPlane is the issue-#1520 regression at the
-// interaction level: with Create 2D Sketch active and every origin plane hidden, clicking the
-// empty viewport background must NOT enter a sketch — a click resolves no invisible plane. Showing
-// the XY plane makes that same click host a sketch on it (the browser node is the only other way in).
-func TestCreateSketchBackgroundClickIgnoresHiddenOriginPlane(t *testing.T) {
+// TestCreateSketchRevealsHiddenOriginPlaneForPicking is the issue-#1591/#1752 fix at the interaction
+// level: starting Create 2D Sketch on a brand-new part temporarily REVEALS the origin planes, so a
+// click where the (default-hidden) XY plane lies enters the sketch directly — no manual "show plane"
+// step, no detour through the browser Origin folder. This completes the #1520 UX: that fix stopped a
+// background click from snapping to an INVISIBLE plane; here the plane is drawn and pickable while the
+// host is being chosen, so the click is intentional (see TestPickableWorkPlanesRevealScoping for the
+// scoping that keeps #1520's guard outside Create-Sketch).
+func TestCreateSketchRevealsHiddenOriginPlaneForPicking(t *testing.T) {
 	s := emptyPartLookingDown(t)
 	s.StartTool(NewCreateSketchTool())
-	s.Click(200, 200) // center ray crosses the XY plane, but it is hidden
-	if s.InSketch() || s.ActiveTool() == nil {
-		t.Fatal("clicking the empty background must not start a sketch on a hidden origin plane")
-	}
-	wg, _ := s.ActiveWorkGeometry()
-	wg.WorkPlanes().Item(0).SetVisible(true) // show the XY plane
-	s.Click(200, 200)
+	s.Click(200, 200) // center ray crosses the XY origin plane, revealed for the host pick (#1752)
 	if !s.InSketch() {
-		t.Fatal("clicking a now-visible origin plane should enter the sketch")
+		t.Fatal("Create Sketch must reveal the hidden origin planes so a click on one enters the sketch")
 	}
+}
+
+// TestPickableWorkPlanesRevealScoping pins the reveal's shape (#1752): the origin frame is pickable
+// ONLY while a datum-host tool (Create 2D Sketch) is active, and the reveal is scoped to the grounded
+// origin planes — a user plane the user hid stays hidden. Outside Create-Sketch the origins are back
+// to unpickable, which is exactly the #1520 guard.
+func TestPickableWorkPlanesRevealScoping(t *testing.T) {
+	s, def := emptyPartSession(t)
+	hideUserPlane(t, s, def) // add a user plane and hide it — it must never be revealed by Create Sketch
+
+	if got := len(s.PickableWorkPlanes()); got != 0 { // #1520: no host pick ⇒ hidden origins unpickable
+		t.Fatalf("with no datum-host tool, hidden origin planes must not be pickable; got %d", got)
+	}
+
+	s.StartTool(NewCreateSketchTool())
+	if got := len(s.PickableWorkPlanes()); got != 3 { // the 3 grounded origins revealed; hidden user plane NOT
+		t.Fatalf("Create Sketch should reveal exactly the 3 origin planes; got %d", got)
+	}
+
+	s.CancelTool()
+	if got := len(s.PickableWorkPlanes()); got != 0 {
+		t.Errorf("after the tool ends, origin planes must return to unpickable; got %d", got)
+	}
+}
+
+// hideUserPlane creates one offset user plane on the part and toggles it hidden, so a test can assert
+// the Create-Sketch reveal touches only the grounded origin frame, never a user-hidden plane.
+func hideUserPlane(t *testing.T, s *Session, def *compdef.PartComponentDefinition) {
+	t.Helper()
+	tool := NewOffsetWorkPlaneTool()
+	s.StartTool(tool)
+	tool.Pick(s, WorkPlaneHandle{Plane: def.OriginPlanes()[0]}) // base: XY plane
+	s.SetOffsetDistanceDisplay(25)
+	if err := s.OK(); err != nil {
+		t.Fatalf("create user plane: %v", err)
+	}
+	tool.AddedPlane().SetVisible(false) // user hides it (addUser makes it visible by default)
 }
 
 // sameDir reports whether two vectors point the same or exactly opposite way (a plane's normal

--- a/app/create_sketch_tool.go
+++ b/app/create_sketch_tool.go
@@ -29,6 +29,11 @@ func (t *CreateSketchTool) Name() string { return "Create 2D Sketch" }
 // Start is a no-op; the engine installs the filter from AcceptedKinds.
 func (t *CreateSketchTool) Start(*Session) {}
 
+// RevealsDatumHosts marks this as a datum-host pick so the host reveals the normally-hidden
+// origin planes (XY/XZ/YZ) — otherwise a brand-new part offers nothing to click in the viewport
+// and the only route to the first sketch is the browser Origin folder (#1752).
+func (t *CreateSketchTool) RevealsDatumHosts() bool { return true }
+
 // AcceptedKinds declares the valid sketch hosts: work planes and planar faces. Declaring the
 // face here (not just the plane) is what lets a face in front win over the origin plane behind it.
 func (t *CreateSketchTool) AcceptedKinds() []SelectionKind {

--- a/app/work_plane_ops.go
+++ b/app/work_plane_ops.go
@@ -66,14 +66,33 @@ func (s *Session) PickableWorkPlanes() []*feature.WorkPlane {
 	if !ok {
 		return nil
 	}
+	reveal := s.RevealSketchHostDatums() // Create Sketch temporarily reveals the hidden origin frame (#1752)
 	planes := wg.WorkPlanes()
 	out := make([]*feature.WorkPlane, 0, planes.Count())
 	for i := 0; i < planes.Count(); i++ {
-		if wp := planes.Item(i); wp.Visible() && !s.EditScopeHides(wp.Seq()) {
+		wp := planes.Item(i)
+		if wp.ShownForHostPick(reveal) && !s.EditScopeHides(wp.Seq()) {
 			out = append(out, wp)
 		}
 	}
 	return out
+}
+
+// datumHostPicker is a tool that selects a datum plane as its host, so the normally-hidden
+// origin frame should be revealed (drawn + pickable) for its duration. Deriving the reveal from
+// the active tool keeps it stateless — no flag to reset on commit/cancel that could desync (#1752).
+type datumHostPicker interface {
+	RevealsDatumHosts() bool
+}
+
+// RevealSketchHostDatums reports whether the active tool wants the hidden origin datum planes
+// revealed for picking — true while Create 2D Sketch is choosing its host, false otherwise.
+func (s *Session) RevealSketchHostDatums() bool {
+	if s.tool == nil {
+		return false
+	}
+	r, ok := s.tool.tool.(datumHostPicker)
+	return ok && r.RevealsDatumHosts()
 }
 
 // PickableWorkAxes returns the datum axes (origin X/Y/Z and user) the viewport hit-test should

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -572,7 +572,7 @@ func modelOverlays(s *app.Session, cam scene.Camera, hovered *feature.WorkPlane,
 	hidden := s.EditScopeHides          // hide datums created after the node being edited (issue #132)
 	vis := s.ObjectVisibility()         // View ▸ Object visibility (M05-F12): hidden kinds neither draw nor pick
 	if hasWG && vis.WorkPlanes {
-		list.Items = append(list.Items, planesOverlay(wg.WorkPlanes(), s.SelectedWorkPlane(), hovered, hidden)...)
+		list.Items = append(list.Items, planesOverlay(wg.WorkPlanes(), s.SelectedWorkPlane(), hovered, hidden, s.RevealSketchHostDatums())...)
 	}
 	if hasWG && vis.WorkAxes {
 		list.Items = append(list.Items, axesOverlay(wg.WorkAxes(), selectedWorkAxis(s), hidden)...)

--- a/head/ui/create_sketch_face_highlight_shot_test.go
+++ b/head/ui/create_sketch_face_highlight_shot_test.go
@@ -90,6 +90,46 @@ func TestInWindowCreateSketchHoversFaceHighlight(t *testing.T) {
 	}
 }
 
+// TestInWindowCreateSketchRevealsOriginPlane is the live confirmation for #1752: on a brand-new part
+// (no body), starting Create 2D Sketch reveals the default-hidden origin frame, so the XY plane both
+// draws in the viewport AND resolves under the cursor through the production picker — clicking it opens
+// the sketch. Before the fix the viewport was empty and the only way into the first sketch was the
+// browser Origin folder. Saves a PNG for eyeball confirmation. Skips cleanly without display/Vulkan.
+func TestInWindowCreateSketchRevealsOriginPlane(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+
+	s := framedSession() // part; camera looks down −Z at the origin; origin planes default hidden
+	s.SetPicker(app.NewRayPicker(s.Camera(), func() []*topo.Body { return nil }).
+		WithPlanes(func() []*feature.WorkPlane { return s.PickableWorkPlanes() }))
+	s.StartTool(app.NewCreateSketchTool())
+
+	cx, cy := float32(inWinW/2), float32(inWinH/2)
+	for i := 0; i < 10; i++ { // settle layout + hover so the reveal overlay renders into the frame
+		native.InjectMousePos(cx, cy)
+		viewportFrame(win, s)
+	}
+
+	ox, oy := native.ItemRectMin()
+	sel, ok := s.PickAt(float64(cx-ox), float64(cy-oy), s.Selection().Filter())
+	if _, isPlane := sel.(app.WorkPlaneHandle); !ok || !isPlane {
+		t.Fatalf("Create Sketch over the revealed origin frame resolved to %T (ok=%v); want a WorkPlaneHandle", sel, ok)
+	}
+	if err := win.SaveWindowPNG(filepath.Join(outDir(), "create-sketch-origin-reveal.png")); err != nil {
+		t.Logf("SaveWindowPNG: %v", err)
+	}
+
+	native.InjectMouseButton(native.MouseLeft, true) // click the revealed plane → the sketch opens on it
+	viewportFrame(win, s)
+	native.InjectMouseButton(native.MouseLeft, false)
+	viewportFrame(win, s)
+	if !s.InSketch() {
+		t.Error("clicking the revealed origin plane should enter the sketch")
+	}
+}
+
 // TestInWindowToolFaceHighlightGeneralizes proves the unified face highlight is not bespoke to
 // Create Sketch: a DIFFERENT face-picking tool (Shell, which declares AcceptedKinds = {Face}) lights
 // the hovered face through the same engine path, with no Shell-specific head code (ADR-0041).

--- a/head/ui/plane_overlay.go
+++ b/head/ui/plane_overlay.go
@@ -16,14 +16,17 @@ import (
 // selected plane's border is highlighted; the plane under the cursor uses the hover color. Shown
 // outside the sketch environment. Takes the plane collection (not a part) so it serves a part or an
 // assembly — both expose WorkPlanes() through their work geometry.
-func planesOverlay(planes *feature.WorkPlanes, selected, hovered *feature.WorkPlane, hidden scopeFilter) []renderer.DrawItem {
+// The reveal flag mirrors [app.Session.RevealSketchHostDatums]: while Create 2D Sketch is picking
+// its host, the grounded origin planes are drawn even though they default to hidden, so the user
+// can see the plane they are about to click (#1752). The picker gates on the same predicate.
+func planesOverlay(planes *feature.WorkPlanes, selected, hovered *feature.WorkPlane, hidden scopeFilter, reveal bool) []renderer.DrawItem {
 	if planes == nil {
 		return nil
 	}
 	var items []renderer.DrawItem
 	for i := 0; i < planes.Count(); i++ {
 		wp := planes.Item(i)
-		if !wp.Visible() || hidden(wp.Seq()) {
+		if hidden(wp.Seq()) || !wp.ShownForHostPick(reveal) { // shared rule with the app-side picker (#1752)
 			continue
 		}
 		items = append(items, planeFill(wp), planeBorder(wp, planeColor(wp, selected, hovered)))

--- a/head/ui/plane_overlay_test.go
+++ b/head/ui/plane_overlay_test.go
@@ -44,10 +44,33 @@ func TestAssemblyOriginDatumsDrawWhenShown(t *testing.T) {
 	showAllDatums(wg)
 	noHide := func(uint64) bool { return false }
 
-	if got := len(planesOverlay(wg.WorkPlanes(), nil, nil, noHide)); got == 0 {
+	if got := len(planesOverlay(wg.WorkPlanes(), nil, nil, noHide, false)); got == 0 {
 		t.Error("planesOverlay drew nothing for an assembly's visible origin planes")
 	}
 	if got := len(axesOverlay(wg.WorkAxes(), nil, noHide)); got == 0 {
 		t.Error("axesOverlay drew nothing for an assembly's visible origin axes")
+	}
+}
+
+// TestPlanesOverlayRevealsHiddenOriginFrame: with reveal on (Create 2D Sketch picking its host), the
+// overlay draws the default-hidden grounded origin planes so the user can see the plane they click —
+// the head half of #1752, matching app.PickableWorkPlanes. With reveal off they stay undrawn.
+func TestPlanesOverlayRevealsHiddenOriginFrame(t *testing.T) {
+	s := app.NewSession()
+	if _, err := compdef.AddPart(s.Workspace(), "part.opd", true); err != nil { // origin planes default hidden
+		t.Fatalf("AddPart: %v", err)
+	}
+	wg, ok := s.ActiveWorkGeometry()
+	if !ok {
+		t.Fatal("ActiveWorkGeometry returned false for an active part")
+	}
+	noHide := func(uint64) bool { return false }
+
+	if got := len(planesOverlay(wg.WorkPlanes(), nil, nil, noHide, false)); got != 0 {
+		t.Errorf("with reveal off, hidden origin planes must not draw; got %d draw items", got)
+	}
+	// 3 grounded origin planes × (fill + border) = 6 draw items when revealed.
+	if got := len(planesOverlay(wg.WorkPlanes(), nil, nil, noHide, true)); got != 6 {
+		t.Errorf("with reveal on, the 3 origin planes should draw (6 items: fill+border each); got %d", got)
 	}
 }

--- a/model/feature/work_features_test.go
+++ b/model/feature/work_features_test.go
@@ -181,6 +181,31 @@ func TestWorkPlaneVisibilityDefaultsAndToggles(t *testing.T) {
 	}
 }
 
+// TestShownForHostPickRevealsOnlyGroundedOrigins pins the #1752 rule the app-side picker and the
+// viewport overlay share: a hidden grounded origin plane is shown ONLY while a datum host is being
+// picked, a visible plane is always shown, and a hidden USER plane is never revealed — the reveal is
+// scoped to the origin frame so Create Sketch does not un-hide planes the user chose to hide.
+func TestShownForHostPickRevealsOnlyGroundedOrigins(t *testing.T) {
+	g := NewWorkGeometry()
+	origin := g.WorkPlanes().Item(0) // grounded, hidden by default
+	if origin.ShownForHostPick(false) {
+		t.Error("a hidden origin plane must not show without a host pick (#1520 guard)")
+	}
+	if !origin.ShownForHostPick(true) {
+		t.Error("a hidden origin plane must show while revealing for a host pick (#1752)")
+	}
+
+	user := g.WorkPlanes().AddByPlaneAndOffset(OriginXYPlane, func() float64 { return 1 })
+	user.SetVisible(false) // the user hid it
+	if user.ShownForHostPick(true) {
+		t.Error("a hidden USER plane must not be revealed — the reveal is scoped to the grounded origin frame")
+	}
+	user.SetVisible(true)
+	if !user.ShownForHostPick(false) {
+		t.Error("a visible plane is always shown regardless of the host-pick reveal")
+	}
+}
+
 func TestUserCoordinateSystem(t *testing.T) {
 	ucs := NewUserCoordinateSystems().AddByPlane(offsetXY(5))
 	ucs.SetName("Frame")

--- a/model/feature/work_plane.go
+++ b/model/feature/work_plane.go
@@ -169,6 +169,15 @@ func (w *WorkPlane) Grounded() bool                  { return w.grounded }
 func (w *WorkPlane) Visible() bool     { return w.visible }
 func (w *WorkPlane) SetVisible(v bool) { w.visible = v }
 
+// ShownForHostPick reports whether the plane should be drawn AND pickable given whether a datum-host
+// pick (Create 2D Sketch) is revealing the origin frame: any visible plane, plus the grounded origin
+// planes while revealing — they default hidden, so a brand-new part would otherwise offer nothing to
+// click. The viewport overlay and the app-side picker share this one rule so a plane the user can SEE
+// during host selection is always one they can CLICK, and vice versa (#1752).
+func (w *WorkPlane) ShownForHostPick(revealing bool) bool {
+	return w.visible || (revealing && w.grounded)
+}
+
 // recompute re-derives the plane from its definition, going sick on failure (e.g.
 // degenerate three points) rather than producing garbage.
 func (w *WorkPlane) recompute(r workResolver) {


### PR DESCRIPTION
## What
Starting **Create 2D Sketch** on a brand-new part now **reveals the origin planes (XY/XZ/YZ) in the viewport**, so you can see and click one as the sketch host. Previously the viewport offered nothing to click and the only way into the first sketch was the browser Origin folder.

## Why
Origin planes are created hidden (`addOrigin` never sets `visible`) and `CreateSketchTool.Start` was a no-op, while both the picker (`PickableWorkPlanes`) and the overlay gate on `Visible()`. So a fresh part in Create-Sketch mode showed and picked nothing. This **completes the #1520 UX**: that fix correctly stopped a background click from snapping to an *invisible* plane, but removed the accidental path without adding the intended one (reveal the planes for the pick).

## How
- A **stateless** reveal, derived from the active tool: `CreateSketchTool` implements `datumHostPicker`, and `Session.RevealSketchHostDatums()` reports true only while such a tool is active — nothing to reset on commit/cancel that could desync.
- Scoped to the **grounded origin frame**: a user plane the user hid is never un-hidden.
- One shared rule, `feature.WorkPlane.ShownForHostPick(revealing)`, consumed by **both** the app-side picker and the viewport overlay — so a plane the user can SEE during host selection is always one they can CLICK (and vice versa). No duplicated predicate across the module boundary.

`dispatchCancel`/`dispatchCommit` and the #1520 pickability gate are otherwise unchanged.

## Tests
- **model** — `ShownForHostPick`: grounded-only, revealing-only, hidden-user-plane-never-revealed.
- **app** — `TestPickableWorkPlanesRevealScoping`: no tool ⇒ hidden origins unpickable (the #1520 guard); Create Sketch ⇒ exactly the 3 origins pickable; after cancel ⇒ hidden again. The prior `TestCreateSketchBackgroundClickIgnoresHiddenOriginPlane` (which pinned the old hidden behavior) is rewritten to the new invariant as `TestCreateSketchRevealsHiddenOriginPlaneForPicking`.
- **head (live)** — `TestInWindowCreateSketchRevealsOriginPlane` opens the real Vulkan window, drives the production picker over the revealed frame, asserts the cursor resolves a `WorkPlaneHandle` and a click enters the sketch, and saves a PNG (visually confirmed: the XY plane border + fill render TOP-down).
- Full `model/feature`, `app`, and affected `head/ui` suites green; `go vet` + `golangci-lint` clean on all changed files; gofmt clean.

Closes #1752.