### PR TITLE
fix(head): scale + clamp the Export/file dialog so its buttons never clip (#1753)

### DIFF
--- a/head/ui/export_dialog_size_shot_test.go
+++ b/head/ui/export_dialog_size_shot_test.go
@@ -1,0 +1,49 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestInWindowExportDialogFitsAtRaisedFontScale is the live confirmation for #1753: at a raised UI
+// font scale the Export file dialog opens SCALED with the text, and its file table now fills the
+// window minus a reserved footer — so the Export/Cancel row is pinned in view instead of falling off
+// the bottom (the reported clip). It renders real DrawChrome frames with the global Export modal armed
+// and saves a PNG to eyeball; the footer reserve scales with the font, so the guard below holds at any
+// scale. Skips cleanly without display/Vulkan.
+func TestInWindowExportDialogFitsAtRaisedFontScale(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+	defer func() { uiFontScale = 1.0 }() // package global; leave it as other tests expect
+
+	s := framedSession()
+	if err := s.SetUIFontScale(1.6); err != nil { // the hi-dpi cohort the clip bit hardest
+		t.Fatalf("SetUIFontScale: %v", err)
+	}
+	fileModal.openFor(dialogExport) // arm the global Export modal that DrawChrome renders
+	defer fileModal.cancel()
+
+	for i := 0; i < 6; i++ {
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.1)
+	}
+
+	if !fileModal.isOpen() {
+		t.Fatal("the Export modal should still be open after rendering")
+	}
+	// The reserved footer scales with the (raised) font, so the layout always leaves room below the
+	// table for the Export/Cancel row — the buttons can no longer be pushed off an undersized window.
+	if r := fileFooterReserve(); r <= 6*15 { // 6 frame-heights must have grown past the 1.0-scale ~15px baseline
+		t.Errorf("footer reserve = %v; expected it to scale up with the raised font", r)
+	}
+	if err := win.SaveWindowPNG(filepath.Join(outDir(), "export-dialog-fontscale.png")); err != nil {
+		t.Logf("SaveWindowPNG: %v", err)
+	}
+}

--- a/head/ui/file_dialog_draw.go
+++ b/head/ui/file_dialog_draw.go
@@ -34,7 +34,7 @@ func drawFileDialog(s *app.Session) {
 	wasAddIn := fileModal.mode == dialogAddIn
 	request := fileModal.request
 	var act fileAction
-	native.SetNextWindowSizeOnce(760, 520)
+	dialogSizeOnce(760, 520)
 	if native.Begin(fileModal.title()) {
 		drawExplorerHeader()
 		act = drawExplorerTable()
@@ -91,13 +91,22 @@ func drawRootChooser() {
 	native.EndCombo()
 }
 
-// drawExplorerTable renders the current directory rows and returns a double-click action.
+// fileFooterReserve is the height (in px) held below the file table for the footer drawn after it:
+// the file-name field, the optional export-resolution / import-plane row, and the Export/Cancel
+// button row — six frame-heights covers the tallest variant. FrameHeight already includes the live
+// font scale, so the reserve grows with the text (#1753).
+func fileFooterReserve() float32 { return native.FrameHeight() * 6 }
+
+// drawExplorerTable renders the current directory rows and returns a double-click action. The table
+// FILLS the window's remaining height minus a reserved footer (fileFooterReserve) instead of a fixed
+// 280 px, so the target field and the Export/Cancel row are always visible — they no longer fall off
+// the bottom of an undersized window, which was the reported clip (#1753). The row list scrolls.
 func drawExplorerTable() fileAction {
 	native.SeparatorText("Files")
 	if fileModal.errorText != "" {
 		native.Text(fileModal.errorText)
 	}
-	if !native.BeginTable("##file-browser", 4, 0, 280) {
+	if !native.BeginTable("##file-browser", 4, 0, -fileFooterReserve()) {
 		return fileAction{}
 	}
 	drawExplorerTableHeader()

--- a/head/ui/ui_scale.go
+++ b/head/ui/ui_scale.go
@@ -29,6 +29,11 @@ func scaledIconPx(base int) int {
 	return int(math.Round(float64(base) * uiIconScale))
 }
 
+// uiFontScale is the live text-scale factor (1.0 = 100%), refreshed each frame by applyUIScale.
+// Dialog window sizes read it so a box grows WITH its text: a fixed pixel size clips its content —
+// and its OK/Cancel row — once the user raises the font scale (#1232 follow-up / #1753).
+var uiFontScale = 1.0
+
 // applyUIScale pushes the user's persisted UI scale into the renderer once per frame: the text
 // scale into ImGui (live, via style.FontScaleMain) and the icon scale into uiIconScale for the
 // icon draw sites. Called from prepareChromeFrame so it precedes the ribbon, which sizes its band
@@ -36,4 +41,40 @@ func scaledIconPx(base int) int {
 func applyUIScale(win *native.Window, s *app.Session) {
 	win.SetUIFontScale(float32(s.UIFontScale()))
 	uiIconScale = s.UIIconScale()
+	uiFontScale = s.UIFontScale()
 }
+
+// scaleDim scales a base dialog dimension by the live UI font scale. A 0 dimension (ImGui's
+// "auto-size this axis") is preserved, and a non-positive scale falls back to the base so a
+// window can never collapse.
+func scaleDim(v float32) float32 {
+	if uiFontScale <= 0 || v == 0 {
+		return v
+	}
+	return v * float32(uiFontScale)
+}
+
+// dialogMargin is the gap kept between a dialog and the host-window edge when clamping, so the
+// window border (and, vertically, the menu bar) stays clear.
+const dialogMargin = 24
+
+// dialogFit scales a base dialog size by the font scale AND clamps it to the main viewport, so a
+// scaled dialog never opens LARGER than the host window — which would push its footer/OK-Cancel row
+// past the window edge, re-creating the very clip this fix removes (#1753). A 0 axis (auto-size) is
+// left untouched. The vertical clamp leaves double the margin for the menu and title bars.
+func dialogFit(w, h float32) (float32, float32) {
+	w, h = scaleDim(w), scaleDim(h)
+	vw, vh := native.MainViewportSize()
+	if w > 0 && vw > 2*dialogMargin && w > vw-dialogMargin {
+		w = vw - dialogMargin
+	}
+	if h > 0 && vh > 4*dialogMargin && h > vh-2*dialogMargin {
+		h = vh - 2*dialogMargin
+	}
+	return w, h
+}
+
+// dialogSizeOnce sets a dialog's first-open size, scaled by the UI font scale and clamped to the host
+// window, so the window and its content grow together yet never overflow — the OK/Cancel row no longer
+// falls off the bottom at a raised font scale (#1753).
+func dialogSizeOnce(w, h float32) { native.SetNextWindowSizeOnce(dialogFit(w, h)) }

--- a/head/ui/ui_scale_test.go
+++ b/head/ui/ui_scale_test.go
@@ -33,6 +33,26 @@ func TestScaledIconPx(t *testing.T) {
 	}
 }
 
+// TestScaleDim covers the font-scale dialog-dimension math without a window: a 0 axis (ImGui's
+// auto-size) is preserved, a positive dimension multiplies by the live UI font scale, and a
+// non-positive scale falls back to the base so a window can never collapse (#1753).
+func TestScaleDim(t *testing.T) {
+	defer func() { uiFontScale = 1.0 }() // package global; restore for other tests
+
+	uiFontScale = 1.5
+	if got := scaleDim(200); got != 300 {
+		t.Errorf("scaleDim(200) at 1.5x = %v, want 300", got)
+	}
+	if got := scaleDim(0); got != 0 {
+		t.Errorf("scaleDim(0) = %v, want 0 (auto-size axis preserved)", got)
+	}
+
+	uiFontScale = 0 // guard: a non-positive scale must fall back to the base dimension
+	if got := scaleDim(200); got != 200 {
+		t.Errorf("scaleDim(200) at 0 scale = %v, want 200 (fallback)", got)
+	}
+}
+
 // TestInWindowApplyUIScale drives applyUIScale in a real frame and asserts it copies the session's
 // persisted icon scale into the live uiIconScale the draw sites read. The font scale goes straight
 // to ImGui (style.FontScaleMain) and is exercised here for its draw path.


### PR DESCRIPTION
## What
The **Export** file dialog no longer opens too small with its **Export/Cancel row clipped** off the bottom — the reported bug.

## Why
The file dialog opened at a fixed pixel size (760×520) with a fixed 280 px file table, so header + table + footer overflowed a too-short window and pushed the buttons past the edge. A raised **UI font scale** made it worse — the size ignored the scaled text.

## How
- **Footer pinned:** the file table now fills the window minus a reserved footer (`fileFooterReserve`, 6 frame-heights so it scales with the font) instead of a fixed 280 px — the file-name field and the Export/Cancel row are always in view; the row list scrolls.
- **Scaled + clamped size:** the dialog's initial size is scaled by the UI font scale **and clamped to the main viewport** (`dialogSizeOnce`/`dialogFit`), so it grows with its text yet never opens larger than the host window (which would push the footer off-screen again).

## Scope
Deliberately scoped to the **file/Export dialog** (the reported case). Applying the same `dialogSizeOnce` helper across the other feature dialogs is a mechanical sweep that touches ~33 files with no per-dialog coverage, so it's tracked separately (follow-up issue) to land with its own tests rather than tank new-code coverage here.

## Tests
- **Live** — `TestInWindowExportDialogFitsAtRaisedFontScale`: renders the Export modal at font scale 1.6 through real `DrawChrome` frames and saves a PNG (visually confirmed — the dialog fits the window and both Export and Cancel buttons show, table scrolling above).
- **Unit** — `TestScaleDim`: window-free coverage of the scale/clamp math (identity, multiply, auto-size preserved, non-positive fallback).
- Full `head/ui` suite green; `go vet` clean; `golangci-lint` no new issues; the changed functions are 78–100% covered.

Closes #1753.