### PR TITLE
fix(head): pin SteeringWheels ring so its wedges are clickable (#1754)

### DIFF
--- a/app/bindings.go
+++ b/app/bindings.go
@@ -100,14 +100,18 @@ func dispatchRedo(s *Session) error {
 }
 
 // dispatchCancel is ESC, the universal cancel (M26): it stops any pending command-line
-// question, closes any feature/tool creation or editing window (the active tool), and with
-// nothing in progress clears the selection. It always asks the head to return keyboard focus
-// to the command-window input so the next command can be typed immediately.
+// question, dismisses the SteeringWheels menu, closes any feature/tool creation or editing window
+// (the active tool), and with nothing in progress clears the selection. It always asks the head to
+// return keyboard focus to the command-window input so the next command can be typed immediately.
 func dispatchCancel(s *Session) error {
 	s.RequestCommandInputFocus()
 	cancelled := false
 	if _, ok := s.Prompts().Pending(); ok {
 		s.Prompts().CancelPending()
+		cancelled = true
+	}
+	if s.SteeringWheelActive() {
+		s.DisarmSteeringWheel() // the pinned wheel's escape hatch — dismiss without picking a wedge (#1754)
 		cancelled = true
 	}
 	if s.tool != nil {

--- a/app/bindings_test.go
+++ b/app/bindings_test.go
@@ -274,6 +274,22 @@ func TestDispatchCancelClearsToolThenSelection(t *testing.T) {
 	}
 }
 
+// TestDispatchCancelDismissesSteeringWheel: Esc dismisses the SteeringWheels menu, the pinned wheel's
+// escape hatch so a user can back out without clicking a wedge (#1754).
+func TestDispatchCancelDismissesSteeringWheel(t *testing.T) {
+	s := NewSession()
+	s.ToggleSteeringWheel()
+	if !s.SteeringWheelActive() {
+		t.Fatal("precondition: the SteeringWheels menu should be active")
+	}
+	if err := dispatchCancel(s); err != nil {
+		t.Fatalf("dispatchCancel: %v", err)
+	}
+	if s.SteeringWheelActive() {
+		t.Error("Esc should dismiss the SteeringWheels menu")
+	}
+}
+
 func TestPressKeyRunsCommandViaDefaultChord(t *testing.T) {
 	s := NewSession()
 	ran := false

--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -878,7 +878,7 @@ func viewNavigateCommands() []*CommandDefinition {
 			return nil
 		}).WithTab("View").WithIcon("steering-wheel").WithButtonStyle(LargeIconButton).WithEnable(hasActivePart).
 			WithActive(func(s *Session) bool { return s.SteeringWheelActive() }).
-			WithTooltip("SteeringWheels — a radial menu of navigation tools that follows the cursor."),
+			WithTooltip("SteeringWheels — a radial menu of navigation tools summoned at the cursor; click a wedge to run it, Esc to dismiss."),
 	}
 }
 

--- a/head/ui/steering_wheel.go
+++ b/head/ui/steering_wheel.go
@@ -11,9 +11,10 @@ import (
 	"oblikovati.org/head/internal/native"
 )
 
-// SteeringWheels (#913 N26): a radial menu of navigation tools drawn around the cursor, for rapid
+// SteeringWheels (#913 N26): a radial menu of navigation tools summoned at the cursor, for rapid
 // switching between them. Like the Navigation Bar it re-exposes the existing app tools; here they are
-// laid out in a ring so a flick of the cursor reaches any of them. Choosing a tool hides the wheel.
+// laid out in a ring so a flick of the cursor reaches any of them. The ring is PINNED where it is
+// summoned so its wedges can be clicked (#1754); choosing a tool, or Esc, hides the wheel.
 
 // steeringWheelTool is one wedge of the SteeringWheel: an icon and the session action it runs.
 type steeringWheelTool struct {
@@ -37,15 +38,33 @@ const (
 	steeringRingSeg = 40
 )
 
-// drawSteeringWheel draws the SteeringWheels menu as a ring of icon buttons centred on the cursor
-// while the tool is active and the viewport is hovered (#913 N26). ox,oy is the viewport panel's
-// window-local origin. Choosing a tool runs it and hides the wheel. No-op when inactive/unhovered.
+// Pin state (#1754): the ring is SUMMONED at the cursor the first frame it is shown, then HELD there
+// (in viewport-local coords) while active. A ring that re-centred on the live cursor every frame could
+// never be reached — moving toward a wedge dragged the whole wheel by the same amount, so the icons
+// fled the pointer and no wedge could ever be clicked.
+var (
+	steeringLocalX, steeringLocalY float32
+	steeringPinned                 bool
+)
+
+// drawSteeringWheel draws the SteeringWheels menu as a ring of icon buttons, SUMMONED at the cursor
+// when the tool is activated over the viewport and then PINNED there for as long as it stays active
+// (#913 N26, #1754). ox,oy is the viewport panel's window-local origin. Choosing a tool runs it and
+// hides the wheel; the wheel's wedges are discrete nav commands (Home/Fit/…), so a click is the right
+// gesture once the ring holds still.
 func drawSteeringWheel(s *app.Session, ox, oy float32) {
-	if !s.SteeringWheelActive() || !native.IsItemHovered() {
+	if !s.SteeringWheelActive() {
+		steeringPinned = false
 		return
 	}
-	vcx, vcy := viewportCursor()
-	cx, cy := ox+float32(vcx), oy+float32(vcy)
+	if !steeringPinned {
+		if !native.IsItemHovered() {
+			return // wait until the cursor is over the viewport, then summon the ring at that spot
+		}
+		vcx, vcy := viewportCursor()
+		steeringLocalX, steeringLocalY, steeringPinned = float32(vcx), float32(vcy), true
+	}
+	cx, cy := ox+steeringLocalX, oy+steeringLocalY
 	drawSteeringRing(cx, cy)
 	iconPx := scaledIconPx(steeringIconPx)
 	for i, tool := range steeringWheelTools {
@@ -53,15 +72,23 @@ func drawSteeringWheel(s *app.Session, ox, oy float32) {
 		if !ok {
 			continue
 		}
-		a := 2*stdmath.Pi*float64(i)/float64(len(steeringWheelTools)) - stdmath.Pi/2 // start at the top
-		bx := cx + float32(steeringRadius*stdmath.Cos(a)) - float32(iconPx)/2
-		by := cy + float32(steeringRadius*stdmath.Sin(a)) - float32(iconPx)/2
+		bx, by := steeringWedgePos(cx, cy, i, len(steeringWheelTools), iconPx)
 		native.SetCursorPos(bx, by)
 		if native.ImageButton(tool.id, tex, float32(iconPx), float32(iconPx), identityTint) {
 			tool.run(s)
 			s.DisarmSteeringWheel()
 		}
 	}
+}
+
+// steeringWedgePos is the top-left of wedge i's icon button on the ring around (cx,cy): the i-th of n
+// tools laid clockwise from the top. Pure geometry (no session), so it is unit-testable and adds no
+// head→Session coupling.
+func steeringWedgePos(cx, cy float32, i, n, iconPx int) (float32, float32) {
+	a := 2*stdmath.Pi*float64(i)/float64(n) - stdmath.Pi/2 // start at the top
+	bx := cx + float32(steeringRadius*stdmath.Cos(a)) - float32(iconPx)/2
+	by := cy + float32(steeringRadius*stdmath.Sin(a)) - float32(iconPx)/2
+	return bx, by
 }
 
 // drawSteeringRing draws the faint hub circle the tool icons sit on.

--- a/head/ui/steering_wheel_test.go
+++ b/head/ui/steering_wheel_test.go
@@ -5,9 +5,11 @@
 package ui
 
 import (
+	"path/filepath"
 	"testing"
 
 	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
 )
 
 // TestSteeringWheelToolsRunActions: each wheel tool runs its session action — spot-check that the
@@ -37,6 +39,21 @@ func TestSteeringWheelToolsRunActions(t *testing.T) {
 	}
 }
 
+// TestSteeringWedgePos checks the pure ring geometry: wedge 0 is laid at the top (angle -π/2), so its
+// icon's top-left is radius above (cx,cy), inset by half the icon. No window needed.
+func TestSteeringWedgePos(t *testing.T) {
+	const cx, cy, iconPx = 100.0, 100.0, 20
+	bx, by := steeringWedgePos(cx, cy, 0, 6, iconPx)
+	wantX := float32(cx) - float32(iconPx)/2
+	wantY := float32(cy) - float32(steeringRadius) - float32(iconPx)/2
+	if d := bx - wantX; d > 1e-3 || d < -1e-3 {
+		t.Errorf("wedge 0 x = %v, want %v (top of ring, centred)", bx, wantX)
+	}
+	if d := by - wantY; d > 1e-3 || d < -1e-3 {
+		t.Errorf("wedge 0 y = %v, want %v (radius above centre)", by, wantY)
+	}
+}
+
 // TestInWindowSteeringWheelDraws activates the SteeringWheels menu over a part and runs frames, so a
 // mismatched ImGui Begin/End or a bad ImageButton call would trip an assertion.
 func TestInWindowSteeringWheelDraws(t *testing.T) {
@@ -53,5 +70,49 @@ func TestInWindowSteeringWheelDraws(t *testing.T) {
 		win.BeginFrame()
 		DrawChrome(win, s)
 		win.EndFrame(0.1, 0.1, 0.1)
+	}
+}
+
+// TestInWindowSteeringWheelPinsAtSummonPoint is the #1754 regression: once the wheel is summoned it
+// must STAY where it appeared, not re-centre on the live cursor every frame. The old ring chased the
+// cursor, so moving toward a wedge dragged the whole wheel by the same amount and no wedge could ever
+// be clicked. Here we summon the ring, then move the cursor far away and assert the ring's centre did
+// not budge — the property that makes the wedges reachable. Saves a PNG for eyeball confirmation.
+func TestInWindowSteeringWheelPinsAtSummonPoint(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+	defer func() { steeringPinned = false }() // package global; reset for other tests
+
+	s := framedSession()
+	s.ToggleSteeringWheel()
+	frame := func() {
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.1)
+	}
+	cx, cy := float32(inWinW/2), float32(inWinH/2)
+
+	// Hover the viewport centre so the ring summons + pins there (an ImGui item is not reported hovered
+	// on its first appearance, so settle a few frames).
+	for i := 0; i < 4; i++ {
+		native.InjectMousePos(cx, cy)
+		frame()
+	}
+	if !steeringPinned {
+		t.Fatal("the wheel should have pinned at the summon point after hovering the viewport")
+	}
+	px, py := steeringLocalX, steeringLocalY
+	if err := win.SaveWindowPNG(filepath.Join(outDir(), "steering-wheel-pinned.png")); err != nil {
+		t.Logf("SaveWindowPNG: %v", err)
+	}
+
+	// Move the cursor well away and render: the ring must NOT follow it.
+	native.InjectMousePos(cx+140, cy+90)
+	frame()
+	if steeringLocalX != px || steeringLocalY != py {
+		t.Errorf("the summoned ring must stay put, not follow the cursor: (%v,%v) -> (%v,%v)",
+			px, py, steeringLocalX, steeringLocalY)
 	}
 }


### PR DESCRIPTION
## What
The **SteeringWheels** navigation menu is now usable — its wedge icons can be clicked. Previously clicking any of them did nothing.

## Why
The ring re-centred on the **live cursor every frame** (`viewportCursor()` in `drawSteeringWheel`), so it laid the six icons on a 62 px ring around wherever the mouse currently was. Moving toward an icon to click it translated the whole wheel by the same amount — the icons fled the pointer, and ImGui hit-tested each `ImageButton` while the mouse sat 62 px away at the ring centre, so no wedge ever fired. The command tooltip even advertised the bug ("follows the cursor").

## How
The wheel's six wedges are **discrete** nav commands (Home, Fit, Zoom Window, Constrained-Orbit toggle, Look At, Rewind), so a click is the right gesture — the ring just needs to hold still. It is now **summoned at the cursor** the first frame it is shown and **pinned** there (in viewport-local coords, robust to panel moves) for as long as it stays active. Choosing a wedge runs its command and dismisses the wheel; **Esc** now dismisses it too (via `dispatchCancel`) so a user can back out without picking. The stale "follows the cursor" tooltip and docstring are corrected.

## Tests
- **Live** — `TestInWindowSteeringWheelPinsAtSummonPoint` summons the ring, moves the cursor far away, and asserts the ring centre does **not** budge (the property the old code lacked); saves a PNG (visually confirmed: a fixed ring of six clickable wedges).
- **app** — `TestDispatchCancelDismissesSteeringWheel`: Esc disarms the wheel.
- Existing `TestSteeringWheelToolsRunActions` / `TestInWindowSteeringWheelDraws` still green. Full `app` suite + affected `head/ui` suites green; `go vet` + `golangci-lint` clean (no new issues).

Closes #1754.