### PR TITLE
feat(keybindings): reserve bare alphanumeric keys precisely (#1751 S1)

### DIFF
--- a/app/bindings.go
+++ b/app/bindings.go
@@ -5,6 +5,7 @@ package app
 import (
 	"fmt"
 	"strings"
+	"unicode"
 
 	"oblikovati.org/api/types"
 	"oblikovati.org/app/cmdline"
@@ -145,12 +146,18 @@ func dispatchDelete(s *Session) error { return s.DeleteSelectedSketchEntities() 
 // dispatchSave saves the active document (Ctrl+S / the "SAVE" command word, M26 F05).
 func dispatchSave(s *Session) error { return s.SaveActiveDocument() }
 
-// isBareLetterChord reports whether c is a single printable character with no modifier. Such
-// chords are reserved (M26): single-letter shortcuts must carry Shift or Control, so they are
-// never a default and the keybinding editor rejects them. Multi-character keys (Escape, F5)
-// and modified chords (Ctrl+S) are unaffected.
-func isBareLetterChord(c types.KeyChord) bool {
-	return !c.IsZero() && len([]rune(c.Key)) == 1 && !c.Ctrl && !c.Alt && !c.Shift
+// isReservedBareChord reports whether c is a bare (unmodified) ALPHANUMERIC key — a single letter
+// a–z or digit 0–9. These are reserved (M26 / #1751): pressing one with the viewport focused begins
+// typing a command in the command window (the user means to type a command, not fire a shortcut), so
+// an alphanumeric key may become a shortcut only when carried by Ctrl/Alt/Shift. It is therefore never
+// a default and the keybinding editor rejects it as a user binding. Non-alphanumeric single keys —
+// F1–F12, Tab, Delete, Insert, Escape, Enter, symbols — are NOT reserved and may be bound bare.
+func isReservedBareChord(c types.KeyChord) bool {
+	if c.IsZero() || c.Ctrl || c.Alt || c.Shift {
+		return false
+	}
+	r := []rune(c.Key)
+	return len(r) == 1 && (unicode.IsLetter(r[0]) || unicode.IsDigit(r[0]))
 }
 
 // mustChord parses a constant chord literal from the built-in table, panicking on a
@@ -226,7 +233,7 @@ func commandDefaultChord(c *CommandDefinition) types.KeyChord {
 		return dc
 	}
 	dc, _ := types.ParseChord(c.Alias())
-	if isBareLetterChord(dc) {
+	if isReservedBareChord(dc) {
 		return types.KeyChord{}
 	}
 	return dc
@@ -337,8 +344,8 @@ func (b *Bindings) SetChord(actionID string, c types.KeyChord) error {
 	if _, ok := b.findBindable(actionID); !ok {
 		return fmt.Errorf("app: unknown action %q for SetChord; expected a command or built-in action id", actionID)
 	}
-	if isBareLetterChord(c) {
-		return fmt.Errorf("app: single-letter shortcut %q must use Shift or Control (M26)", c.String())
+	if isReservedBareChord(c) {
+		return fmt.Errorf("app: alphanumeric shortcut %q must use Shift, Ctrl or Alt (a bare letter/digit types into the command window) (M26/#1751)", c.String())
 	}
 	if !c.IsZero() {
 		if owner, ok := b.ResolveChord(c); ok && owner != actionID {

--- a/app/bindings_test.go
+++ b/app/bindings_test.go
@@ -290,6 +290,52 @@ func TestDispatchCancelDismissesSteeringWheel(t *testing.T) {
 	}
 }
 
+// TestReservedBareChordPolicy pins the #1751 keybinding policy at the predicate: bare alphanumeric
+// keys (a–z, 0–9) are reserved — pressing one types into the command window, so it may only be a
+// shortcut with Ctrl/Alt/Shift — while F-keys, Tab, Delete, Insert and other named/special keys, and
+// any modified chord, are NOT reserved and may be bound bare.
+func TestReservedBareChordPolicy(t *testing.T) {
+	parse := func(s string) types.KeyChord {
+		c, err := types.ParseChord(s)
+		if err != nil {
+			t.Fatalf("ParseChord(%q): %v", s, err)
+		}
+		return c
+	}
+	for _, s := range []string{"A", "L", "Z", "0", "5", "9"} {
+		if !isReservedBareChord(parse(s)) {
+			t.Errorf("%q should be reserved (bare alphanumeric)", s)
+		}
+	}
+	for _, s := range []string{"F1", "F12", "Tab", "Delete", "Insert", "Escape", "Enter", "Ctrl+L", "Shift+A", "Alt+5"} {
+		if isReservedBareChord(parse(s)) {
+			t.Errorf("%q should NOT be reserved (special key or modified chord)", s)
+		}
+	}
+}
+
+// TestSetChordEnforcesReservedPolicy pins the editor-facing half: SetChord refuses a bare letter or
+// digit, but accepts a bare special key (F8) and a modified alphanumeric (Alt+L) — #1751.
+func TestSetChordEnforcesReservedPolicy(t *testing.T) {
+	s := NewSession()
+	if err := s.Commands().Add(NewCommand("Test.Thing", "Thing", "Test", func(*Session) error { return nil })); err != nil {
+		t.Fatalf("add command: %v", err)
+	}
+	parse := func(str string) types.KeyChord { c, _ := types.ParseChord(str); return c }
+	if err := s.Bindings().SetChord("Test.Thing", parse("L")); err == nil {
+		t.Error("SetChord must reject a bare letter L")
+	}
+	if err := s.Bindings().SetChord("Test.Thing", parse("5")); err == nil {
+		t.Error("SetChord must reject a bare digit 5")
+	}
+	if err := s.Bindings().SetChord("Test.Thing", parse("F8")); err != nil {
+		t.Errorf("SetChord must accept a bare special key F8: %v", err)
+	}
+	if err := s.Bindings().SetChord("Test.Thing", parse("Alt+L")); err != nil {
+		t.Errorf("SetChord must accept a modified alphanumeric Alt+L: %v", err)
+	}
+}
+
 func TestPressKeyRunsCommandViaDefaultChord(t *testing.T) {
 	s := NewSession()
 	ran := false


### PR DESCRIPTION
## What
Codifies the keybinding policy (first of three slices for #1751): a bare **`a`–`z` / `0`–`9`** key is **reserved** and can only become a shortcut with Ctrl/Alt/Shift; **F1–F12, Tab, Delete, Insert, Escape, Enter, symbols** may be bound bare.

## Why
The reason bare letters are reserved: pressing one should start typing a command in the command window — the user means to type, not fire a shortcut. (That focus behavior is slice 2.)

The old `isBareLetterChord` reserved **every** single-character key — over-reserving symbols, and named "letter" though it also caught digits. `isReservedBareChord` now gates on "single rune that is a letter or digit", matching the policy exactly, with an honest name. Applied to both consult sites:
- shipped-default derivation (`commandDefaultChord`)
- the editor's user-binding validation (`SetChord`)

## Scope
No shortcut resolution changes. Foundation for:
- **S2** — a bare alphanumeric press focuses the command window and seeds the character (the behavior this reservation exists for).
- **S3** — curated modifier-chord / special-key default shortcuts.

## Tests
- `TestReservedBareChordPolicy` — predicate: `A/L/Z/0/5/9` reserved; `F1/F12/Tab/Delete/Insert/Escape/Enter/Ctrl+L/Shift+A/Alt+5` not.
- `TestSetChordEnforcesReservedPolicy` — editor path: rejects bare `L`/`5`, accepts bare `F8` and `Alt+L`.
- Full `app` suite green; archguard, `go vet`, `golangci-lint` clean.

Part of #1751.