### PR TITLE
feat(keybindings): bare letter focuses + types into the Command Window (#1751 S2)

### DIFF
--- a/app/command_line.go
+++ b/app/command_line.go
@@ -46,6 +46,24 @@ func (s *Session) TakeCommandInputFocus() bool {
 	return want
 }
 
+// BeginCommandTyping hands keyboard focus to the Command Window and seeds it with the character
+// the user just pressed, so a bare alphanumeric key with the viewport focused starts a command
+// line rather than being swallowed as a (nonexistent) shortcut (#1751 S2). The user reserved
+// bare a–z/0–9 for exactly this: pressing one means "I want to type a command". The head reads
+// the seed once via TakeCommandTypeSeed, paired with the focus request above.
+func (s *Session) BeginCommandTyping(seed string) {
+	s.commandFocusWanted = true
+	s.commandTypeSeed = seed
+}
+
+// TakeCommandTypeSeed returns any pending character to seed the command input with and clears it,
+// so the head appends it exactly once. Empty when no bare-key typing was begun this frame.
+func (s *Session) TakeCommandTypeSeed() (string, bool) {
+	seed := s.commandTypeSeed
+	s.commandTypeSeed = ""
+	return seed, seed != ""
+}
+
 // Prompt returns the question or step the input line is waiting on: a pending command-line
 // question (M26 F03) first, then the active tool's current step prompt, else "".
 func (cl *CommandLine) Prompt(s *Session) string {

--- a/app/command_typing_test.go
+++ b/app/command_typing_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "testing"
+
+// aliasCommand registers a no-op command with the given alias and reports whether it ran, so a
+// test can assert a keystroke did NOT dispatch it (the bare-letter typing policy, #1751 S2).
+func aliasCommand(t *testing.T, s *Session, id, alias string, ran *bool) {
+	t.Helper()
+	cmd := NewCommand(id, "Thing", "Test", func(*Session) error { *ran = true; return nil }).WithAlias(alias)
+	if err := s.Commands().Add(cmd); err != nil {
+		t.Fatalf("add command %q: %v", id, err)
+	}
+}
+
+// TestBareLetterBeginsCommandTyping pins #1751 S2: a bare letter with the viewport focused hands
+// focus to the Command Window seeded with that (lower-cased) letter, rather than firing a shortcut.
+func TestBareLetterBeginsCommandTyping(t *testing.T) {
+	s := NewSession()
+	ran := false
+	aliasCommand(t, s, "Test.Line", "L", &ran)
+
+	if err := s.PressKey(KeyEvent{Key: "L"}); err != nil {
+		t.Fatalf("PressKey(L): %v", err)
+	}
+	if ran {
+		t.Error("a bare letter must not dispatch a command")
+	}
+	if !s.TakeCommandInputFocus() {
+		t.Error("a bare letter must request Command Window focus")
+	}
+	if seed, ok := s.TakeCommandTypeSeed(); !ok || seed != "l" {
+		t.Errorf("seed = %q,%v; want \"l\",true", seed, ok)
+	}
+}
+
+// TestBareDigitBeginsCommandTyping confirms digits 0–9 are reserved for typing too.
+func TestBareDigitBeginsCommandTyping(t *testing.T) {
+	s := NewSession()
+	if err := s.PressKey(KeyEvent{Key: "5"}); err != nil {
+		t.Fatalf("PressKey(5): %v", err)
+	}
+	if !s.TakeCommandInputFocus() {
+		t.Error("a bare digit must request Command Window focus")
+	}
+	if seed, ok := s.TakeCommandTypeSeed(); !ok || seed != "5" {
+		t.Errorf("seed = %q,%v; want \"5\",true", seed, ok)
+	}
+}
+
+// TestSpecialKeyDoesNotBeginTyping confirms a bare special key (F8) is NOT reserved: it dispatches
+// its bound command directly and begins no command-window typing (#1751 S1 policy, exercised via S2).
+func TestSpecialKeyDoesNotBeginTyping(t *testing.T) {
+	s := NewSession()
+	ran := false
+	cmd := NewCommand("Test.Refresh", "Refresh", "Test",
+		func(*Session) error { ran = true; return nil }).WithDefaultChord("F8")
+	if err := s.Commands().Add(cmd); err != nil {
+		t.Fatalf("add command: %v", err)
+	}
+	if err := s.PressKey(KeyEvent{Key: "F8"}); err != nil {
+		t.Fatalf("PressKey(F8): %v", err)
+	}
+	if !ran {
+		t.Error("a bare special key F8 must dispatch its bound command")
+	}
+	if s.TakeCommandInputFocus() {
+		t.Error("a bare special key must not request command typing focus")
+	}
+	if _, ok := s.TakeCommandTypeSeed(); ok {
+		t.Error("a bare special key must not seed the command input")
+	}
+}
+
+// TestModifiedLetterDoesNotBeginTyping confirms a modified alphanumeric (Ctrl+L) resolves as a
+// shortcut and does not begin typing — modifiers are exactly what turn a letter into a shortcut.
+func TestModifiedLetterDoesNotBeginTyping(t *testing.T) {
+	s := NewSession()
+	ran := false
+	cmd := NewCommand("Test.Line", "Line", "Test",
+		func(*Session) error { ran = true; return nil }).WithDefaultChord("Ctrl+L")
+	if err := s.Commands().Add(cmd); err != nil {
+		t.Fatalf("add command: %v", err)
+	}
+	if err := s.PressKey(KeyEvent{Key: "L", Mods: CtrlMod}); err != nil {
+		t.Fatalf("PressKey(Ctrl+L): %v", err)
+	}
+	if !ran {
+		t.Error("Ctrl+L should dispatch its bound command")
+	}
+	if _, ok := s.TakeCommandTypeSeed(); ok {
+		t.Error("a modified letter must not seed the command input")
+	}
+}

--- a/app/session.go
+++ b/app/session.go
@@ -123,6 +123,7 @@ type Session struct {
 	cmdLine                   *CommandLine                                     // Command Window REPL engine (M26)
 	commandWindowHidden       bool                                             // Command Window docked panel hidden? (M26; inverted so zero ⇒ visible)
 	commandFocusWanted        bool                                             // a cancel/ESC asked to refocus the command input (M26; head clears it)
+	commandTypeSeed           string                                           // char to seed the command input with when a bare key begins typing (#1751 S2; head clears it)
 	grid                      *GridSettings
 	themes                    *theme.Library
 	themeStore                *theme.Store

--- a/app/session_input.go
+++ b/app/session_input.go
@@ -4,6 +4,7 @@ package app
 
 import (
 	"errors"
+	"strings"
 
 	"oblikovati.org/api/types"
 	"oblikovati.org/event"
@@ -338,14 +339,25 @@ func normalizeKey(key string) string {
 //
 // M26 F05: a modifier chord (Ctrl/Alt, e.g. Ctrl+S, Ctrl+Z) runs through the Command Window
 // — its canonical word is echoed and then it dispatches — so a chord reads like a typed
-// command ("Ctrl+S" shows "SAVE" and saves). Plain keys still dispatch directly (this is the
-// no-text-field-focused path; in the running app a plain letter is typed into the focused
-// command line instead, filling it to await Enter).
+// command ("Ctrl+S" shows "SAVE" and saves).
+//
+// #1751 S2: a bare alphanumeric key with no text field focused hands focus to the Command Window
+// seeded with that character (see commandTypingSeed) — pressing a letter means "type a command",
+// not fire a shortcut. Bare special keys (F1–F12, Delete, …) still resolve and dispatch directly.
 func (s *Session) PressKey(e KeyEvent) error {
 	if s.CommandInputActive() {
 		return s.routeKeyToCommandInput(e)
 	}
 	chord := keyEventToChord(e)
+	// A bare alphanumeric key with no text field focused means the user wants to type a command:
+	// hand focus to the Command Window and seed the character, so the keystroke begins a command
+	// line instead of firing a (deliberately nonexistent) bare-letter shortcut (#1751 S2). The
+	// reserved-key policy lives in isReservedBareChord — special keys (F1–F12, Delete, …) fall
+	// through to the binding engine below and may be bound bare.
+	if seed, ok := commandTypingSeed(chord); ok {
+		s.BeginCommandTyping(seed)
+		return nil
+	}
 	actionID, ok := s.Bindings().ResolveChord(chord)
 	if !ok {
 		return nil
@@ -354,4 +366,15 @@ func (s *Session) PressKey(e KeyEvent) error {
 		return s.CommandLine().RunChord(s, actionID)
 	}
 	return s.Bindings().Dispatch(actionID, s)
+}
+
+// commandTypingSeed reports whether a chord should begin typing into the Command Window rather
+// than resolve as a shortcut — a bare alphanumeric key (see isReservedBareChord) — and returns
+// the character to seed the input with, lower-cased for a natural typed feel (the command
+// vocabulary matches case-insensitively, so "l" and "L" resolve alike).
+func commandTypingSeed(c types.KeyChord) (string, bool) {
+	if !isReservedBareChord(c) {
+		return "", false
+	}
+	return strings.ToLower(c.Key), true
 }

--- a/head/internal/native/app.cpp
+++ b/head/internal/native/app.cpp
@@ -407,6 +407,13 @@ struct ObkInject {
     float wheel;
     bool shift;
     int fkey; // a held hold-to-navigate function key (0 none, else 2/3/4) (#911)
+    // A plain letter key a–z, for keyboard tests (#1751 S2). hasLetter gates it (0 == 'a'
+    // would otherwise inject spuriously); charPending emits the input character exactly once
+    // on the press, so a focused InputText receives the letter as a real keystroke would.
+    bool hasLetter;
+    int  letter; // 0..25 (a..z)
+    bool letterDown;
+    bool charPending;
 };
 static ObkInject g_inject = {};
 
@@ -416,6 +423,13 @@ void obk_inject_mouse_button(int b, int down) { if (b >= 0 && b < 5) { g_inject.
 void obk_inject_mouse_wheel(float w)         { g_inject.active = true; g_inject.wheel = w; }
 void obk_inject_key_shift(int down)          { g_inject.active = true; g_inject.shift = down != 0; }
 void obk_inject_fkey(int n, int down)        { g_inject.active = true; g_inject.fkey = down ? n : 0; }
+void obk_inject_letter(int letter, int down) {
+    g_inject.active = true;
+    g_inject.hasLetter = (letter >= 0 && letter < 26);
+    g_inject.letter = letter;
+    g_inject.letterDown = down != 0;
+    if (down != 0) g_inject.charPending = true; // one character per press
+}
 }
 
 static void obk_apply_inject() {
@@ -431,6 +445,13 @@ static void obk_apply_inject() {
     io.AddKeyEvent(ImGuiKey_F2, g_inject.fkey == 2);
     io.AddKeyEvent(ImGuiKey_F3, g_inject.fkey == 3);
     io.AddKeyEvent(ImGuiKey_F4, g_inject.fkey == 4);
+    if (g_inject.hasLetter) {
+        io.AddKeyEvent((ImGuiKey)(ImGuiKey_A + g_inject.letter), g_inject.letterDown);
+        if (g_inject.letterDown && g_inject.charPending) {
+            io.AddInputCharacter((unsigned int)('a' + g_inject.letter));
+            g_inject.charPending = false;
+        }
+    }
 }
 
 // obk_ig_dockspace_over_main hosts a full-window dockspace (called every frame, after

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -178,6 +178,7 @@ void obk_inject_mouse_button(int b, int down);
 void obk_inject_mouse_wheel(float w);
 void obk_inject_key_shift(int down);
 void obk_inject_fkey(int n, int down);
+void obk_inject_letter(int letter, int down);
 */
 import "C"
 
@@ -1175,6 +1176,11 @@ func InjectKeyShift(down bool)                { C.obk_inject_key_shift(cBool(dow
 
 // InjectFKey holds (down) or releases the hold-to-navigate function key F(n), n in 2..4 (#911).
 func InjectFKey(n int, down bool) { C.obk_inject_fkey(C.int(n), cBool(down)) }
+
+// InjectLetter presses (down) or releases a plain letter key a–z (index 0=a … 25=z) for in-window
+// keyboard tests, injecting the key event (so PressedKeys sees it) and, on press, the matching
+// input character (so a focused InputText receives it) — a faithful letter keystroke (#1751 S2).
+func InjectLetter(index int, down bool) { C.obk_inject_letter(C.int(index), cBool(down)) }
 
 // cBool converts a Go bool to the 0/1 C.int the wrappers expect.
 func cBool(b bool) C.int {

--- a/head/ui/command_typing_inwindow_test.go
+++ b/head/ui/command_typing_inwindow_test.go
@@ -1,0 +1,79 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/head/internal/native"
+)
+
+// TestSeedCommandInput covers the pure seeder without a window: it appends the handed-off
+// character to the input buffer (preserving existing text) and requests focus (#1751 S2).
+func TestSeedCommandInput(t *testing.T) {
+	defer func() { clearBuf(commandInputBuf); commandFocusNext = false }()
+	clearBuf(commandInputBuf)
+	commandFocusNext = false
+
+	seedCommandInput("l")
+	if got := bufString(commandInputBuf); got != "l" {
+		t.Errorf("seed into empty buffer = %q, want \"l\"", got)
+	}
+	if !commandFocusNext {
+		t.Error("seeding must request keyboard focus for the input")
+	}
+
+	seedCommandInput("i") // appends, so a partially-typed command is never clobbered
+	if got := bufString(commandInputBuf); got != "li" {
+		t.Errorf("seed append = %q, want \"li\"", got)
+	}
+}
+
+// TestInWindowBareLetterTypesIntoCommandWindow drives real letter keystrokes with the viewport
+// focused and asserts they land in the docked Command Window input — the #1751 S2 behaviour:
+// pressing a bare letter means "I want to type a command", so keyboard focus moves to the command
+// line seeded with that letter and subsequent letters extend it. It exists to pin the ImGui
+// char-queue timing on the focus-grab frame: the triggering character must land exactly once
+// (no drop, no double), yielding "line" — not "ine" or "lline".
+func TestInWindowBareLetterTypesIntoCommandWindow(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false // rebuild the default layout (docks the command window at the bottom)
+	icons = nil         // rebind the icon cache to this fresh window/context
+	clearBuf(commandInputBuf)
+	commandFocusNext = true
+	defer clearBuf(commandInputBuf)
+	s := framedSession()
+
+	frame := func() {
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.1)
+	}
+	// Settle the dock layout; no text field should own the keyboard before typing begins.
+	frame()
+	frame()
+	if native.WantTextInput() {
+		t.Fatal("no text field should own the keyboard before typing begins")
+	}
+
+	// Type "line" one faithful keystroke at a time: the down-frame emits the key + input char,
+	// the up-frame releases so the next letter registers as a fresh press.
+	for _, r := range "line" {
+		native.InjectLetter(int(r-'a'), true)
+		frame()
+		native.InjectLetter(int(r-'a'), false)
+		frame()
+	}
+
+	_ = win.SaveWindowPNG(filepath.Join(outDir(), "1751-command-typing.png"))
+	if got := bufString(commandInputBuf); got != "line" {
+		t.Fatalf("command input = %q, want \"line\" (a bare letter must focus + seed the command window exactly once)", got)
+	}
+	if !native.WantTextInput() {
+		t.Error("after typing a letter the command window input should own the keyboard")
+	}
+}

--- a/head/ui/command_window.go
+++ b/head/ui/command_window.go
@@ -90,6 +90,9 @@ func drawCommandWindowBody(s *app.Session) {
 	if s.TakeCommandInputFocus() {
 		commandFocusNext = true // ESC/cancel asked to return focus to the input (M26)
 	}
+	if seed, ok := s.TakeCommandTypeSeed(); ok {
+		seedCommandInput(seed) // a bare key press begins a command line (#1751 S2)
+	}
 	cl := s.CommandLine()
 	sb := app.BuildStatus(s)
 	comps := refreshCompletions(s, cl)
@@ -98,6 +101,17 @@ func drawCommandWindowBody(s *app.Session) {
 	drawCommandControls(s, sb)
 	drawCommandCompletions(comps)
 	drawCommandInputLine(s, cl, comps)
+}
+
+// seedCommandInput appends the character a bare key press handed off (#1751 S2) to the input
+// buffer and focuses it, so pressing a letter with the viewport focused starts a command line
+// with that letter already typed. Appending (not replacing) preserves any text the user had
+// already entered. Focus is requested only on the frame a key was actually pressed, so this
+// never becomes a per-frame focus sink that would steal viewport hover (see handleKeyboard).
+// Pure (no Session) so it is unit-testable and stays off the head↔Session coupling ratchet.
+func seedCommandInput(seed string) {
+	setBuf(commandInputBuf, bufString(commandInputBuf)+seed)
+	commandFocusNext = true
 }
 
 // controlsHeight reserves a row for the tool controls when any is live (a running tool, a live


### PR DESCRIPTION
## What

Pressing a **bare alphanumeric key** (a–z, 0–9) while the viewport is focused now
moves keyboard focus to the docked Command Window, seeded with that character, so
the keystroke **begins typing a command** — with live autocomplete — instead of
being swallowed. Bare **special keys** (F1–F12, Delete, Insert, …) still resolve
and dispatch as shortcuts.

This is Slice 2 of #1751 and the behavioural payoff of Slice 1's reserved-key
policy: the user reserved bare a–z/0–9 precisely because pressing one means *"I
want to type a command"*, not *"fire a shortcut"*.

## Why

Reported in #1744: new users expect the sketch/feature keyboard to do something.
Bare letters had no shipped shortcuts (deliberate, M26) and simply no-op'd. Now a
bare letter starts a command line, matching the AutoCAD-style command window users
already have.

## How

- `PressKey` detects the reserved bare-alphanumeric chord (`commandTypingSeed`,
  reusing S1's `isReservedBareChord`) and calls `BeginCommandTyping` — request
  Command Window focus **and** record the character to seed.
- The head consumes it once via `TakeCommandTypeSeed` and appends it to the input
  buffer (a pure `seedCommandInput` helper — off the head↔Session coupling ratchet).
- Focus is grabbed **only on the actual keypress**, never per-frame, so viewport
  drag-orbit hover is untouched (`TestInWindowDockedViewportIsInteractive` stays green).

## Tests

- App-seam unit tests: bare letter/digit → focus + seed, no dispatch; bare F8 →
  dispatches, no typing; Ctrl+L → dispatches, no seed.
- New in-window harness capability `obk_inject_letter` (faithful key + input-char
  injection), plus a live test that presses real `l·i·n·e` keystrokes and asserts
  the buffer reads exactly `"line"` — pinning the ImGui char-queue timing on the
  focus-grab frame (no drop, no double). Screenshot confirms the focused command
  line with the `LINE` autocomplete match.

Advances #1751 (Slice 3 — curated default shortcuts — to follow, pending chord sign-off).