### PR TITLE
feat(keybindings): curated Shift+mnemonic tool shortcuts (#1751 S3)

### DIFF
--- a/app/commands_sketch.go
+++ b/app/commands_sketch.go
@@ -23,7 +23,7 @@ func sketchTabCommands() []*CommandDefinition {
 	cmds = append(cmds, NewCommand("Sketch.Dimension", "Dimension", "Constrain", func(s *Session) error {
 		s.StartTool(newDimensionTool())
 		return nil
-	}).WithTab("Sketch").WithEnvironment(SketchEnvironment).WithAlias("D").WithEnable(inSketch).
+	}).WithTab("Sketch").WithEnvironment(SketchEnvironment).WithAlias("D").WithDefaultChord("Shift+D").WithEnable(inSketch).
 		WithIcon("dimension").WithButtonStyle(SmallIconButton).
 		WithTooltip("Dimension — then pick points/a line/a circle/two lines to dimension."))
 	cmds = append(cmds, NewCommand("Sketch.AutoDimension", "Auto Dimension", "Constrain", func(s *Session) error {
@@ -73,6 +73,9 @@ func sketchTabCommands() []*CommandDefinition {
 // captioned buttons; the rest stack as small labeled rows.
 type sketchToolEntry struct {
 	id, name, alias, tip string
+	// chord is a shipped default keyboard shortcut ("Shift+L" for Line, …). Bare a–z/0–9 are
+	// reserved for command-window typing (#1751), so a headline tool's shortcut carries Shift.
+	chord string
 	// icon overrides the lowercased-name asset key for multi-word names
 	// (asset filenames are kebab-case).
 	icon     string
@@ -106,6 +109,9 @@ func buildToolCommands(panel string, entries []sketchToolEntry) []*CommandDefini
 		}
 		cmd := newToolCommand(panel, e).WithAlias(e.alias).
 			WithIcon(key).WithButtonStyle(style)
+		if e.chord != "" {
+			cmd.WithDefaultChord(e.chord) // shipped Shift+mnemonic shortcut (#1751 S3)
+		}
 		if len(e.variants) > 0 {
 			variants := make([]*CommandDefinition, len(e.variants))
 			for j, v := range e.variants {
@@ -148,15 +154,15 @@ func sketchPatternCommands() []*CommandDefinition {
 // which the reference UI places in Create, not Modify).
 func createCommands() []*CommandDefinition {
 	return buildToolCommands("Create", []sketchToolEntry{
-		{id: "Sketch.Line", name: "Line", alias: "L", large: true, tip: "Line — draw a line between two points.", start: func() Tool { return NewLineTool() }},
+		{id: "Sketch.Line", name: "Line", alias: "L", chord: "Shift+L", large: true, tip: "Line — draw a line between two points.", start: func() Tool { return NewLineTool() }},
 		{id: "Sketch.Rectangle", name: "Rectangle", alias: "REC", large: true, tip: "Rectangle — draw a two-corner rectangle.", start: func() Tool { return NewRectangleTool() }, variants: []sketchToolEntry{
 			{id: "Sketch.Rectangle.ThreePoint", name: "Three Point Rectangle", tip: "Three Point Rectangle — base edge then width.", start: func() Tool { return NewThreePointRectangleTool() }},
 			{id: "Sketch.Rectangle.Center", name: "Two Point Center Rectangle", tip: "Two Point Center Rectangle — center then a corner.", start: func() Tool { return NewCenterRectangleTool() }},
 		}},
-		{id: "Sketch.Circle", name: "Circle", alias: "C", large: true, tip: "Circle — draw a circle from its center and radius.", start: func() Tool { return NewCircleTool() }, variants: []sketchToolEntry{
+		{id: "Sketch.Circle", name: "Circle", alias: "C", chord: "Shift+C", large: true, tip: "Circle — draw a circle from its center and radius.", start: func() Tool { return NewCircleTool() }, variants: []sketchToolEntry{
 			{id: "Sketch.Circle.ThreePoint", name: "Three Point Circle", tip: "Three Point Circle — the circle through three points.", start: func() Tool { return NewThreePointCircleTool() }},
 		}},
-		{id: "Sketch.Arc", name: "Arc", alias: "A", large: true, tip: "Arc — draw a three-point arc.", start: func() Tool { return NewArcTool() }, variants: []sketchToolEntry{
+		{id: "Sketch.Arc", name: "Arc", alias: "A", chord: "Shift+A", large: true, tip: "Arc — draw a three-point arc.", start: func() Tool { return NewArcTool() }, variants: []sketchToolEntry{
 			{id: "Sketch.Arc.CenterPoint", name: "Center Point Arc", tip: "Center Point Arc — center, start, then end.", start: func() Tool { return NewCenterPointArcTool() }},
 		}},
 		{id: "Sketch.Slot", name: "Slot", tip: "Slot — click two centre points for a straight slot.", start: func() Tool { return NewSketchSlotTool(1) }, variants: []sketchToolEntry{

--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -599,7 +599,7 @@ func cutFeatureCommands() []*CommandDefinition {
 		NewCommand("Modify.Hole", "Hole", "Modify", func(s *Session) error {
 			s.StartFeatureTool(NewHoleTool())
 			return nil
-		}).WithTab(tabCreateModify).WithAlias("H").WithEnable(notInSketch).
+		}).WithTab(tabCreateModify).WithAlias("H").WithDefaultChord("Shift+H").WithEnable(notInSketch).
 			WithIcon("hole").WithButtonStyle(LargeIconButton).
 			WithTooltip("Hole — drill a cylindrical hole into a planar face of the solid."),
 		NewCommand("Modify.Boss", "Boss", "Modify", func(s *Session) error {
@@ -650,7 +650,7 @@ func filletCommand() *CommandDefinition {
 	return NewCommand("Modify.Fillet", "Fillet", "Modify", func(s *Session) error {
 		s.StartFeatureTool(NewFilletTool())
 		return nil
-	}).WithTab(tabCreateModify).WithAlias("F").WithEnable(notInSketch).
+	}).WithTab(tabCreateModify).WithAlias("F").WithDefaultChord("Shift+F").WithEnable(notInSketch).
 		WithIcon("fillet").WithButtonStyle(LargeIconButton).
 		WithTooltip("Fillet — round selected convex edges with a rolling-ball radius.").
 		WithVariants(faceFillet, fullRound)
@@ -717,13 +717,13 @@ func profileSolidCommands() []*CommandDefinition {
 		NewCommand("Create.Extrude", "Extrude", "Create", func(s *Session) error {
 			s.StartFeatureTool(NewExtrudeTool())
 			return nil
-		}).WithTab(tabCreateModify).WithAlias("E").WithEnable(notInSketch).
+		}).WithTab(tabCreateModify).WithAlias("E").WithDefaultChord("Shift+E").WithEnable(notInSketch).
 			WithIcon("extrude").WithButtonStyle(LargeIconButton).
 			WithTooltip("Extrude — add depth to a sketch profile to create or modify a solid."),
 		NewCommand("Create.Revolve", "Revolve", "Create", func(s *Session) error {
 			s.StartFeatureTool(NewRevolveTool())
 			return nil
-		}).WithTab(tabCreateModify).WithAlias("R").WithEnable(notInSketch).
+		}).WithTab(tabCreateModify).WithAlias("R").WithDefaultChord("Shift+R").WithEnable(notInSketch).
 			WithIcon("revolve").WithButtonStyle(LargeIconButton).
 			WithTooltip("Revolve — spin a sketch profile about an axis to create or modify a solid."),
 	}

--- a/app/curated_shortcuts_test.go
+++ b/app/curated_shortcuts_test.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+)
+
+// TestCuratedDefaultShortcutsResolve pins the shipped Shift+mnemonic shortcuts (#1751 S3): each
+// headline sketch/feature tool resolves from its Shift+<letter> chord. Shift is mandatory because
+// bare a–z are reserved for command-window typing (S1/S2); the letter mirrors the tool's mnemonic
+// so Shift+L is Line, Shift+E is Extrude, etc. Collision-freedom across the whole registry is
+// guarded separately by TestStandardCommandsPassCheckDefaults (CheckDefaults).
+func TestCuratedDefaultShortcutsResolve(t *testing.T) {
+	s := NewSession()
+	if err := RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	want := map[string]string{
+		"Shift+L": "Sketch.Line",
+		"Shift+C": "Sketch.Circle",
+		"Shift+A": "Sketch.Arc",
+		"Shift+D": "Sketch.Dimension",
+		"Shift+E": "Create.Extrude",
+		"Shift+R": "Create.Revolve",
+		"Shift+H": "Modify.Hole",
+		"Shift+F": "Modify.Fillet",
+	}
+	for chordStr, id := range want {
+		c, err := types.ParseChord(chordStr)
+		if err != nil {
+			t.Fatalf("ParseChord(%q): %v", chordStr, err)
+		}
+		got, ok := s.Bindings().ResolveChord(c)
+		if !ok || got != id {
+			t.Errorf("ResolveChord(%q) = %q,%v; want %q", chordStr, got, ok, id)
+		}
+	}
+}

--- a/head/internal/native/app.cpp
+++ b/head/internal/native/app.cpp
@@ -441,6 +441,10 @@ static void obk_apply_inject() {
     if (g_inject.posSet) io.AddMousePosEvent(g_inject.mx, g_inject.my);
     for (int b = 0; b < 5; b++) io.AddMouseButtonEvent(b, g_inject.down[b]);
     if (g_inject.wheel != 0.0f) { io.AddMouseWheelEvent(0.0f, g_inject.wheel); g_inject.wheel = 0.0f; }
+    // Drive io.KeyShift through the PHYSICAL key: ImGui derives the modifier flag from
+    // Left/Right Shift down-state, so a bare AddKeyEvent(ImGuiMod_Shift,…) alone does not make
+    // GetIO().KeyShift (what obk_ig_key_shift reads) true. Needed for chord tests, e.g. Shift+L.
+    io.AddKeyEvent(ImGuiKey_LeftShift, g_inject.shift);
     io.AddKeyEvent(ImGuiMod_Shift, g_inject.shift);
     io.AddKeyEvent(ImGuiKey_F2, g_inject.fkey == 2);
     io.AddKeyEvent(ImGuiKey_F3, g_inject.fkey == 3);

--- a/head/ui/curated_shortcuts_inwindow_test.go
+++ b/head/ui/curated_shortcuts_inwindow_test.go
@@ -1,0 +1,80 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/sketch"
+	"oblikovati.org/scene"
+)
+
+// TestInWindowShiftLetterStartsTool drives a real Shift+L keystroke with the viewport focused in a
+// sketch and asserts it starts the Line tool — the #1751 S3 curated shortcut through the full head
+// path. It also guards the S1/S2 boundary: a MODIFIED letter must dispatch as a shortcut, never be
+// routed to command-window typing (that path is for BARE letters only). A bare "l" here would seed
+// the command line and leave no active tool.
+func TestInWindowShiftLetterStartsTool(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+	s := app.NewSession()
+	if err := app.RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+	docu, _ := compdef.AddPart(s.Workspace(), "shortcut.opd", true)
+	part := docu.Content().(*compdef.PartComponentDefinition)
+	sk := part.Sketches().Add(sketch.XYPlane())
+	s.EnterSketch(sk)
+	s.TickCameraAnimation(100) // finish the enter-sketch swing (test dt≈0)
+	cam := scene.NewCamera(inWinW, inWinH)
+	cam.Eye, cam.Target, cam.Up = math.P3(0, 0, 10), math.P3(0, 0, 0), math.V3(0, 1, 0)
+	s.SetCamera(cam)
+
+	// Keep keyboard focus on the VIEWPORT (not the command line): a Shift-only chord fires as a
+	// viewport shortcut only when no text field owns typing (a focused command line would capitalise
+	// the letter instead — only Ctrl/Alt chords bypass it). This is the state after the user clicks
+	// into the 3D view. Suppress the command line's default focus-grab BEFORE the first frame so it
+	// never claims the keyboard. commandFocusNext/commandInputBuf are package globals; reset for others.
+	commandFocusNext = false
+	clearBuf(commandInputBuf)
+	defer func() { commandFocusNext = true; clearBuf(commandInputBuf) }()
+
+	frame := func() {
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.1)
+	}
+	frame()
+	frame()
+
+	// Shift+L with the viewport focused → the Line tool starts (not command-window typing).
+	// Hold Shift on a prior frame so io.KeyShift is settled before the letter is pressed (ImGui
+	// derives the modifier flag from the physical key's down-state a frame after the event).
+	native.InjectKeyShift(true)
+	frame()
+	native.InjectLetter(int('l'-'a'), true)
+	frame()
+	native.InjectLetter(int('l'-'a'), false)
+	native.InjectKeyShift(false)
+	frame()
+
+	ti := s.ActiveTool()
+	name := "<none>"
+	if ti != nil {
+		name = ti.Name()
+	}
+	if name != "Line" {
+		t.Fatalf("Shift+L in a sketch should start the Line tool, got %q (and the command window must not have eaten it)", name)
+	}
+	if got := bufString(commandInputBuf); got != "" {
+		t.Errorf("Shift+L must dispatch, not type into the command line; buffer = %q", got)
+	}
+}


### PR DESCRIPTION
## What

Ship default keyboard shortcuts for the eight headline sketch & feature tools, each **Shift+\<its mnemonic letter\>**:

| Chord | Tool | | Chord | Tool |
|-------|------|-|-------|------|
| Shift+L | Line | | Shift+E | Extrude |
| Shift+C | Circle | | Shift+R | Revolve |
| Shift+A | Arc | | Shift+H | Hole |
| Shift+D | Dimension | | Shift+F | Fillet |

This is the final slice of #1751 and closes it.

## Why

The report (#1744) asked for single-key sketch shortcuts (L=Line, …). Slices 1–2
reserved bare a–z/0–9 for command-window typing, so a bare `L` now focuses the
command line. Shift+letter recovers the mnemonic as a real shortcut **without**
colliding with that policy — the letter still maps to the tool the user expects.

## How

- Each command gets `WithDefaultChord("Shift+<letter>")` (a `chord` field on the
  data-driven `sketchToolEntry` for Line/Circle/Arc; inline on the feature commands).
- **Collision-free by construction**: each command's existing `WithEnable`
  predicate gates it to its environment — `Session.Execute` refuses a disabled
  command — so exactly one command is live per chord. The shipped-registry guard
  `CheckDefaults` (already run at startup and in `TestStandardCommandsPassCheckDefaults`)
  confirms no conflict with built-ins or between commands.
- A Shift chord fires as a viewport shortcut only when no text field owns the
  keyboard; a focused command line capitalises the letter instead (only Ctrl/Alt
  chords bypass a focused field — existing behaviour).

## Tests

- `TestCuratedDefaultShortcutsResolve`: each of the 8 chords resolves to its command.
- `TestInWindowShiftLetterStartsTool`: a real Shift+L keystroke with the viewport
  focused in a sketch starts the Line tool — and asserts it dispatched, not typed
  (the S1/S2 boundary: a modified letter is a shortcut, a bare letter is typing).
- Harness fix: injected Shift now drives `io.KeyShift` via the physical Left-Shift
  key, so Shift+letter chords can be exercised in-window at all.

All shortcuts remain user-rebindable and resettable in the keybinding editor.

Closes #1751.