### PR TITLE
Import binary STL as lightweight mesh reference (#1764)

### DIFF
--- a/addin/opregistry/feature_mesh.go
+++ b/addin/opregistry/feature_mesh.go
@@ -12,21 +12,21 @@ import (
 	"oblikovati.org/model/feature"
 )
 
-// Mesh reference geometry (M10-F04 PBI-115, #700): an ASCII STL placed as a MeshFeature —
-// selectable facet topology that passes the running solid through. Distinct from
-// documents.import, which converts a mesh file into B-rep bodies.
+// Mesh reference geometry (M10-F04 PBI-115, #700): an STL (ASCII or binary, #1764) placed
+// as a MeshFeature — selectable facet topology that passes the running solid through.
+// Distinct from documents.import, which converts a mesh file into B-rep bodies.
 
 const meshSchema = `{
   "type": "object",
   "properties": {
-    "path": {"type": "string", "description": "Host-local path of an ASCII STL file to place as mesh reference geometry."},
+    "path": {"type": "string", "description": "Host-local path of an STL file (ASCII or binary) to place as mesh reference geometry."},
     "solid": {"type": "boolean", "description": "When true, convert the mesh to a faceted B-rep solid body (one planar face per facet) instead of placing it as reference geometry."}
   },
   "required": ["path"]
 }`
 
 func meshDescriptor() *OperationDescriptor {
-	return &OperationDescriptor{Name: featureargs.KindMesh, Summary: "Place an ASCII STL as mesh reference geometry.", Schema: json.RawMessage(meshSchema), Apply: applyMesh}
+	return &OperationDescriptor{Name: featureargs.KindMesh, Summary: "Place an STL (ASCII or binary) as mesh reference geometry.", Schema: json.RawMessage(meshSchema), Apply: applyMesh}
 }
 
 func applyMesh(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {

--- a/app/mesh_import.go
+++ b/app/mesh_import.go
@@ -10,12 +10,14 @@ import (
 	"oblikovati.org/model/feature"
 )
 
-// Mesh reference geometry placement (M10-F04 PBI-115, #700): an ASCII STL becomes a
-// MeshFeature — selectable facet topology that passes the running solid through, distinct
-// from File ▸ Import which converts meshes into bodies (ImportedBodyFeature).
+// Mesh reference geometry placement (M10-F04 PBI-115, #700): an STL (ASCII or binary)
+// becomes a MeshFeature — selectable facet topology that passes the running solid through,
+// distinct from File ▸ Import which converts meshes into bodies (ImportedBodyFeature).
+// Binary STL is read here too so a dense scan/visualization mesh imports lightweight
+// instead of being forced through B-rep promotion (#1764).
 
-// ImportMeshFile parses an ASCII STL at path and places it as a mesh reference feature
-// on the active part.
+// ImportMeshFile parses an STL (ASCII or binary) at path and places it as a mesh reference
+// feature on the active part.
 //
 //	pf, err := s.ImportMeshFile("scan.stl")
 func (s *Session) ImportMeshFile(path string) (*feature.PartFeature, error) {

--- a/head/ui/file_dialog.go
+++ b/head/ui/file_dialog.go
@@ -29,7 +29,7 @@ const (
 	dialogImport                        // File ▸ Import (STL/OBJ/3MF/STEP → imported body)
 	dialogExport                        // File ▸ Export (part bodies → STL/OBJ/3MF/STEP)
 	dialogAddIn                         // an add-in's dialogs.showFileDialog request (M05-F08)
-	dialogMeshRef                       // Mesh ▸ Place Mesh (ASCII STL → mesh reference geometry, #700)
+	dialogMeshRef                       // Mesh ▸ Place Mesh (STL, ASCII or binary → mesh reference geometry, #700, #1764)
 	dialogPlaceComponent                // Assemble ▸ Place: choose the component document to instance (#763)
 	dialogExportBOM                     // Assemble ▸ Bill of Materials ▸ Export CSV (#768)
 	dialogPointCloud                    // 3D Model ▸ Import Point Cloud (ASCII scan → referenced cloud, #645)

--- a/head/ui/file_dialog_draw.go
+++ b/head/ui/file_dialog_draw.go
@@ -333,7 +333,7 @@ func saveActiveDocumentAs(s *app.Session, path, name string) {
 	queueSaveThumbnail(s, path)
 }
 
-// placeMeshFromFile imports an ASCII STL as mesh reference geometry (Mesh ▸ Place Mesh).
+// placeMeshFromFile imports an STL (ASCII or binary, #1764) as mesh reference geometry (Mesh ▸ Place Mesh).
 func placeMeshFromFile(s *app.Session, path, name string) {
 	if _, err := s.ImportMeshFile(path); err != nil {
 		fileNotice(s, "Place Mesh failed: %v", err)

--- a/model/feature/mesh.go
+++ b/model/feature/mesh.go
@@ -3,11 +3,10 @@
 package feature
 
 import (
-	"bufio"
 	"fmt"
 	"io"
-	"strconv"
 
+	"oblikovati.org/kernel/exchange/meshio"
 	"oblikovati.org/math"
 
 	stdmath "math"
@@ -25,58 +24,49 @@ type MeshGeometry struct {
 	Facets   [][]int
 }
 
-// ParseSTL reads an ASCII STL stream into a MeshGeometry, welding coincident vertices
-// (on a tolerance grid) so facets share vertices/edges. It errors on malformed input,
-// naming the offending token. Binary STL is a separate decoder (not yet wired).
+// ParseSTL reads an STL stream (ASCII or binary, auto-detected) into a MeshGeometry,
+// welding coincident vertices (on a tolerance grid) so facets share vertices/edges. It
+// errors on malformed input and on an STL carrying no facets.
+//
+//	g, err := ParseSTL(f) // f is an ASCII or binary .stl
 func ParseSTL(r io.Reader) (*MeshGeometry, error) {
-	sc := bufio.NewScanner(r)
-	sc.Split(bufio.ScanWords)
-	g := &MeshGeometry{}
-	if err := scanFacets(sc, g); err != nil {
-		return nil, err
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("STL: read: %w", err)
 	}
-	if len(g.Facets) == 0 {
+	return DecodeSTLMesh(data)
+}
+
+// DecodeSTLMesh decodes STL bytes (ASCII or binary) into welded reference-mesh geometry.
+// It delegates the format decode to the kernel mesh reader (meshio.DecodeSTL) — the single
+// owner of STL parsing — so a binary STL (e.g. a dense scan or visualization mesh) imports
+// as a lightweight MeshFeature here, distinct from File ▸ Import which promotes a mesh to a
+// full B-rep body (#1764). The two share one decoder; only the target representation differs.
+func DecodeSTLMesh(data []byte) (*MeshGeometry, error) {
+	raw, err := meshio.DecodeSTL(data)
+	if err != nil {
+		return nil, fmt.Errorf("STL: %w", err)
+	}
+	return meshGeometryFromRaw(raw)
+}
+
+// meshGeometryFromRaw welds a decoded triangle soup into shared-vertex reference geometry:
+// each RawMesh triangle becomes a facet whose three corners are welded (1e-6 grid) so
+// coincident vertices are shared. An empty soup is a malformed/empty STL, reported as such.
+func meshGeometryFromRaw(raw meshio.RawMesh) (*MeshGeometry, error) {
+	if len(raw.Tris) == 0 {
 		return nil, fmt.Errorf("STL: no facets parsed")
 	}
+	g := &MeshGeometry{Facets: make([][]int, 0, len(raw.Tris))}
+	index := make(map[[3]int64]int, len(raw.Tris))
+	for _, tri := range raw.Tris {
+		g.Facets = append(g.Facets, []int{
+			weldVertex(g, index, raw.Verts[tri[0]]),
+			weldVertex(g, index, raw.Verts[tri[1]]),
+			weldVertex(g, index, raw.Verts[tri[2]]),
+		})
+	}
 	return g, nil
-}
-
-// scanFacets consumes the token stream, welding each facet's vertices into g.
-func scanFacets(sc *bufio.Scanner, g *MeshGeometry) error {
-	index := map[[3]int64]int{}
-	var facet []int
-	for sc.Scan() {
-		switch sc.Text() {
-		case "vertex":
-			p, err := readPoint(sc)
-			if err != nil {
-				return err
-			}
-			facet = append(facet, weldVertex(g, index, p))
-		case "endfacet":
-			if len(facet) >= 3 {
-				g.Facets = append(g.Facets, facet)
-			}
-			facet = nil
-		}
-	}
-	return sc.Err()
-}
-
-// readPoint reads three whitespace-separated floats following a "vertex" token.
-func readPoint(sc *bufio.Scanner) (math.Point3, error) {
-	var c [3]float64
-	for i := 0; i < 3; i++ {
-		if !sc.Scan() {
-			return math.Point3{}, fmt.Errorf("STL: vertex truncated at coord %d", i)
-		}
-		v, err := strconv.ParseFloat(sc.Text(), 64)
-		if err != nil {
-			return math.Point3{}, fmt.Errorf("STL: bad coordinate %q: %w", sc.Text(), err)
-		}
-		c[i] = v
-	}
-	return math.P3(c[0], c[1], c[2]), nil
 }
 
 // weldVertex returns the index of p in g, reusing a coincident vertex (1e-6 grid).

--- a/model/feature/mesh_binary_stl_test.go
+++ b/model/feature/mesh_binary_stl_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"bytes"
+	"encoding/binary"
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// tetraTris are the four triangles of the unit tetrahedron used by tetraSTL (the ASCII
+// fixture in mesh_mold_test.go), so the binary and ASCII decode paths can be compared on
+// the same solid. Each triangle is three (x,y,z) corners.
+var tetraTris = [4][3][3]float32{
+	{{0, 0, 0}, {0, 1, 0}, {1, 0, 0}},
+	{{0, 0, 0}, {1, 0, 0}, {0, 0, 1}},
+	{{0, 0, 0}, {0, 0, 1}, {0, 1, 0}},
+	{{1, 0, 0}, {0, 1, 0}, {0, 0, 1}},
+}
+
+// buildBinarySTL encodes triangles as a little-endian binary STL: 80-byte header, uint32
+// triangle count, then per triangle a zeroed normal + three vertices + a uint16 attribute.
+// It mirrors the on-disk layout meshio.decodeBinarySTL reads, so tests can exercise the
+// binary path without committing a large fixture file.
+func buildBinarySTL(tris [][3][3]float32) []byte {
+	var b bytes.Buffer
+	b.Write(make([]byte, 80)) // header (ignored on read)
+	_ = binary.Write(&b, binary.LittleEndian, uint32(len(tris)))
+	for _, t := range tris {
+		_ = binary.Write(&b, binary.LittleEndian, [3]float32{}) // normal, ignored on read
+		for _, v := range t {
+			_ = binary.Write(&b, binary.LittleEndian, v)
+		}
+		_ = binary.Write(&b, binary.LittleEndian, uint16(0)) // attribute byte count
+	}
+	return b.Bytes()
+}
+
+// TestParseSTLDecodesBinary is the #1764 regression: a binary STL now imports as welded
+// reference-mesh geometry (it used to be unsupported — "not yet wired"). The tetra's 12
+// vertex references weld to 4 distinct corners, exactly like the ASCII path.
+func TestParseSTLDecodesBinary(t *testing.T) {
+	data := buildBinarySTL(tetraTris[:])
+	g, err := ParseSTL(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("ParseSTL(binary): %v", err)
+	}
+	if len(g.Facets) != 4 {
+		t.Errorf("binary STL parsed %d facets, want 4", len(g.Facets))
+	}
+	if len(g.Vertices) != 4 {
+		t.Errorf("binary STL welded to %d vertices, want 4", len(g.Vertices))
+	}
+}
+
+// TestParseSTLBinaryAsciiParity proves the two encodings of the same solid decode to the
+// same welded geometry — same vertex/facet counts and coincident vertex positions — so the
+// representation a MeshFeature sees does not depend on the file encoding.
+func TestParseSTLBinaryAsciiParity(t *testing.T) {
+	ascii, err := ParseSTL(bytes.NewReader([]byte(tetraSTL)))
+	if err != nil {
+		t.Fatalf("ParseSTL(ascii): %v", err)
+	}
+	binaryG, err := ParseSTL(bytes.NewReader(buildBinarySTL(tetraTris[:])))
+	if err != nil {
+		t.Fatalf("ParseSTL(binary): %v", err)
+	}
+	if len(binaryG.Vertices) != len(ascii.Vertices) || len(binaryG.Facets) != len(ascii.Facets) {
+		t.Fatalf("parity: binary=%dv/%df ascii=%dv/%df",
+			len(binaryG.Vertices), len(binaryG.Facets), len(ascii.Vertices), len(ascii.Facets))
+	}
+	// Both weld to the same 4 corners; compare as sets so vertex ordering is not asserted.
+	if !sameVertexSet(binaryG.Vertices, ascii.Vertices) {
+		t.Errorf("parity: welded vertex sets differ\nbinary=%v\nascii=%v", binaryG.Vertices, ascii.Vertices)
+	}
+}
+
+// TestDecodeSTLMeshRejectsEmpty keeps the "no facets" guard the ASCII path had: an STL with
+// no triangles is an error, not an empty mesh, whichever encoding it claims.
+func TestDecodeSTLMeshRejectsEmpty(t *testing.T) {
+	if _, err := DecodeSTLMesh([]byte("solid empty\nendsolid empty\n")); err == nil {
+		t.Error("an STL with no facets should error")
+	}
+	if _, err := DecodeSTLMesh(buildBinarySTL(nil)); err == nil {
+		t.Error("a binary STL with zero triangles should error")
+	}
+}
+
+// sameVertexSet reports whether two vertex lists hold the same points (order-independent),
+// matched on the same 1e-6 grid the welder uses.
+func sameVertexSet(a, b []math.Point3) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	key := func(p math.Point3) [3]int64 {
+		const tol = 1e-6
+		return [3]int64{int64(stdmath.Round(p.X / tol)), int64(stdmath.Round(p.Y / tol)), int64(stdmath.Round(p.Z / tol))}
+	}
+	set := map[[3]int64]int{}
+	for _, p := range a {
+		set[key(p)]++
+	}
+	for _, p := range b {
+		set[key(p)]--
+	}
+	for _, n := range set {
+		if n != 0 {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## What

The *Place mesh reference* import (`ImportMeshFile`, the `mesh` op, **Mesh ▸ Place Mesh**) previously read **ASCII STL only** — *"Binary STL is a separate decoder (not yet wired)."* A binary STL therefore had no lightweight path and was forced through **File ▸ Import**'s full B-rep promotion (`subd.ToBody`), which allocates a face + 3 edges + coedges + loop + verts **per triangle**.

This wires binary support into the lightweight path by delegating `feature.ParseSTL` to the kernel decoder `meshio.DecodeSTL` (which already auto-detects ASCII vs binary) and welding the returned triangle soup into the shared-vertex `MeshGeometry`. The duplicate ASCII scanner in `model/feature` is removed — the kernel `meshio` package is now the single owner of STL parsing, and ASCII and binary decode identically.

Both `ParseSTL` callers (`app.Session.ImportMeshFile`, the `mesh` API op) and the *Place Mesh* UI button gain binary support with no further change. **File ▸ Import (B-rep) is untouched** — the two existing commands already encode the two user intents (model-on-it vs view/measure), so there is no new routing or UI.

## Why

A dense binary scan/visualization mesh a user only wants to view or measure was paying B-rep cost. Measured on the Harvard Calabi-Yau exhibit set (Wolfram binary STL), n=7 = **1,881,600 triangles**:

| path | peak RSS | wall |
|------|----------|------|
| B-rep promotion (File ▸ Import) | 5.33 GB | 12.5 s |
| **mesh reference (this PR)** | **2.0 GB** | **2.4 s** |

2.7× less memory, 5× faster. (The remaining reference-path RSS is inflated by decode-time allocation churn — tracked separately in #1765.)

## Tests

- `TestParseSTLDecodesBinary` — binary STL now decodes to welded geometry (the #1764 regression).
- `TestParseSTLBinaryAsciiParity` — ASCII and binary encodings of the same solid decode to the same welded vertex set / facet count.
- `TestDecodeSTLMeshRejectsEmpty` — the "no facets" guard is preserved for both encodings.
- Existing ASCII mesh tests unchanged and green; `model/feature`, `app`, `addin/opregistry`, `kernel/exchange/meshio`, `archguard` all pass; lint clean.

## Scope / non-goals

Rendering of placed mesh references in the viewport is a pre-existing concern (a `MeshFeature` produces no `topo.Body`, so `BuildDrawList` doesn't draw it) — identical for ASCII and binary, unaffected by this change. Redundant re-tessellation and per-triangle edge-lace on the B-rep path are tracked in #1766; decode preallocation in #1765.

Closes #1764.

🤖 Generated with [Claude Code](https://claude.com/claude-code)