### PR TITLE
Preallocate mesh decode from known triangle count (#1765, part 1)

### DIFF
--- a/kernel/exchange/meshio/raw_mesh.go
+++ b/kernel/exchange/meshio/raw_mesh.go
@@ -22,6 +22,23 @@ type RawMesh struct {
 // TriangleCount returns the number of triangles in the soup.
 func (m RawMesh) TriangleCount() int { return len(m.Tris) }
 
+// Reserve grows capacity for an expected additional triangle count so a decoder that knows
+// its size up front (binary STL's header count, a 3MF mesh's triangle list) fills the soup
+// without the repeated slice reallocation that dominates allocation churn on a dense import
+// (#1765). STL/3MF store three unshared vertices per triangle, so this reserves 3× the
+// triangles in Verts. It only ever grows capacity; a non-positive count is a no-op.
+func (m *RawMesh) Reserve(triangles int) {
+	if triangles <= 0 {
+		return
+	}
+	if need := len(m.Verts) + triangles*3; cap(m.Verts) < need {
+		m.Verts = append(make([]math.Point3, 0, need), m.Verts...)
+	}
+	if need := len(m.Tris) + triangles; cap(m.Tris) < need {
+		m.Tris = append(make([][3]int, 0, need), m.Tris...)
+	}
+}
+
 // AddTriangle appends a triangle from three explicit positions, growing Verts. Used by
 // decoders (STL/3MF) that carry positions per triangle rather than an index table.
 func (m *RawMesh) AddTriangle(a, b, c math.Point3) {

--- a/kernel/exchange/meshio/raw_mesh_reserve_test.go
+++ b/kernel/exchange/meshio/raw_mesh_reserve_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package meshio
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestReserveFillsWithoutRealloc is the #1765 guard: after reserving for N triangles, adding
+// exactly N triangles must not reallocate — capacity stays at the reserved size, proving the
+// append-doubling churn is gone. It also confirms Reserve preserves the soup's contents.
+func TestReserveFillsWithoutRealloc(t *testing.T) {
+	const n = 1000
+	var m RawMesh
+	m.Reserve(n)
+	vertsCap, trisCap := cap(m.Verts), cap(m.Tris)
+	if vertsCap != n*3 || trisCap != n {
+		t.Fatalf("Reserve(%d) gave cap verts=%d tris=%d, want %d/%d", n, vertsCap, trisCap, n*3, n)
+	}
+	for i := 0; i < n; i++ {
+		f := float64(i)
+		m.AddTriangle(math.P3(f, 0, 0), math.P3(0, f, 0), math.P3(0, 0, f))
+	}
+	if cap(m.Verts) != vertsCap || cap(m.Tris) != trisCap {
+		t.Errorf("filling the reserved soup reallocated: verts cap %d->%d, tris cap %d->%d",
+			vertsCap, cap(m.Verts), trisCap, cap(m.Tris))
+	}
+	if m.TriangleCount() != n || len(m.Verts) != n*3 {
+		t.Errorf("filled soup has %d tris / %d verts, want %d/%d", m.TriangleCount(), len(m.Verts), n, n*3)
+	}
+}
+
+// TestReserveGuards covers the edge cases: a non-positive count is a no-op, and Reserve grows
+// (never shrinks) capacity relative to what is already stored.
+func TestReserveGuards(t *testing.T) {
+	var empty RawMesh
+	empty.Reserve(0)
+	empty.Reserve(-5)
+	if empty.Verts != nil || empty.Tris != nil {
+		t.Errorf("Reserve with a non-positive count should be a no-op, got %d verts / %d tris", len(empty.Verts), len(empty.Tris))
+	}
+	m := RawMesh{Verts: []math.Point3{{}, {}, {}}, Tris: [][3]int{{0, 1, 2}}}
+	m.Reserve(10) // must keep the one existing triangle and reserve room for 10 more
+	if m.TriangleCount() != 1 || len(m.Verts) != 3 {
+		t.Errorf("Reserve dropped contents: %d tris / %d verts, want 1/3", m.TriangleCount(), len(m.Verts))
+	}
+	if cap(m.Verts) < 3+10*3 || cap(m.Tris) < 1+10 {
+		t.Errorf("Reserve did not grow capacity: verts cap=%d tris cap=%d", cap(m.Verts), cap(m.Tris))
+	}
+}
+
+// TestDecodeBinarySTLPreallocatesExactly guards that the binary STL decoder sizes the soup
+// from the header count, so decoding a dense mesh does not realloc (#1765). Capacity landing
+// exactly at 3×count / count means every AddTriangle hit reserved space.
+func TestDecodeBinarySTLPreallocatesExactly(t *testing.T) {
+	const n = 512
+	tris := make([][3][3]float32, n)
+	for i := range tris {
+		f := float32(i)
+		tris[i] = [3][3]float32{{f, 0, 0}, {0, f, 0}, {0, 0, f}}
+	}
+	raw, err := DecodeSTL(binarySTLBytes(tris))
+	if err != nil {
+		t.Fatalf("DecodeSTL(binary): %v", err)
+	}
+	if raw.TriangleCount() != n {
+		t.Fatalf("decoded %d triangles, want %d", raw.TriangleCount(), n)
+	}
+	if cap(raw.Verts) != n*3 || cap(raw.Tris) != n {
+		t.Errorf("binary decode reallocated: verts cap=%d (want %d), tris cap=%d (want %d)",
+			cap(raw.Verts), n*3, cap(raw.Tris), n)
+	}
+}
+
+// binarySTLBytes encodes triangles as little-endian binary STL (80-byte header, uint32 count,
+// per triangle: zeroed normal + 3 vertices + uint16 attribute) so the decoder sees a real file.
+func binarySTLBytes(tris [][3][3]float32) []byte {
+	var b bytes.Buffer
+	b.Write(make([]byte, 80))
+	_ = binary.Write(&b, binary.LittleEndian, uint32(len(tris)))
+	for _, t := range tris {
+		_ = binary.Write(&b, binary.LittleEndian, [3]float32{})
+		for _, v := range t {
+			_ = binary.Write(&b, binary.LittleEndian, v)
+		}
+		_ = binary.Write(&b, binary.LittleEndian, uint16(0))
+	}
+	return b.Bytes()
+}

--- a/kernel/exchange/meshio/stl.go
+++ b/kernel/exchange/meshio/stl.go
@@ -44,6 +44,7 @@ func isBinarySTL(data []byte) bool {
 func decodeBinarySTL(data []byte) (RawMesh, error) {
 	count := binary.LittleEndian.Uint32(data[80:84])
 	var m RawMesh
+	m.Reserve(int(count)) // header gives the exact size; fill without reallocation (#1765)
 	off := 84
 	for i := uint32(0); i < count; i++ {
 		off += 12 // skip the per-facet normal

--- a/kernel/exchange/meshio/threemf.go
+++ b/kernel/exchange/meshio/threemf.go
@@ -108,6 +108,11 @@ func readModelPart(data []byte) ([]byte, error) {
 // soupFromModel flattens every object's mesh into one triangle soup, validating indices.
 func soupFromModel(model threeMFModel) (RawMesh, error) {
 	var m RawMesh
+	total := 0
+	for _, obj := range model.Resources.Objects {
+		total += len(obj.Mesh.Triangles)
+	}
+	m.Reserve(total) // sum every object's triangle list; fill without reallocation (#1765)
 	for oi, obj := range model.Resources.Objects {
 		verts := make([]math.Point3, len(obj.Mesh.Vertices))
 		for i, v := range obj.Mesh.Vertices {


### PR DESCRIPTION
## What

`decodeBinarySTL` reads the exact triangle count from the STL header, and 3MF's `soupFromModel` knows it from each mesh's triangle list — yet both started from a nil-slice `RawMesh` and grew it by per-triangle `append`. That reallocation doubling was the single largest allocation source on a dense import.

Adds `RawMesh.Reserve(triangles)` and calls it from the binary-STL and 3MF decoders so the soup fills its slices without reallocation. ASCII STL and OBJ stay streaming (their size isn't known up front).

## Why

From the Calabi-Yau STL stress test: `RawMesh.AddTriangle` was ~750 MB of churn on a 1.4M-triangle mesh, part of the ~40% of import CPU spent in GC.

**Measured:**

| path | total alloc | peak RSS |
|------|-------------|----------|
| lightweight mesh-reference (#1764), n=7 (1.88M tris) | 3983 → **2589 MB** (−35%) | 1993 → **1663 MB** (−17%) |
| B-rep import, n=6 (1.38M tris) | 5935 → **5280 MB** (−11%), GCs 17→13 | — |

The preallocation most benefits the #1764 lightweight path (decode-dominated).

## Tests

- `TestReserveFillsWithoutRealloc` — after `Reserve(n)`, adding N triangles does not reallocate (capacity stays at the reserved size); contents preserved.
- `TestReserveGuards` — non-positive count is a no-op; Reserve grows (never shrinks) and keeps existing contents.
- `TestDecodeBinarySTLPreallocatesExactly` — the binary decoder sizes the soup from the header, so a dense decode lands at exactly 3×count / count capacity (zero realloc).
- `meshio`, `model/exchange`, `model/feature` green; lint clean.

## Scope

This is **part 1** of #1765 (the preallocation half). The second half — reusing `subd.Mesh.edgeFaces` scratch (~863 MB churn) — is a separate, B-rep-only change in the CAD-critical `subd` path with spread-out callers, and is deferred to its own PR so it can be reviewed carefully. #1765 stays open for it.

Part of #1765.

🤖 Generated with [Claude Code](https://claude.com/claude-code)