### PR TITLE
Build edge→faces adjacency once per ToBody (#1765, part 2)

### DIFF
--- a/kernel/subd/body.go
+++ b/kernel/subd/body.go
@@ -14,12 +14,16 @@ import (
 // edge used by two faces — becomes a solid; an open cage a surface body. Faces are
 // approximated as planar in phase A; the exact bicubic limit surface is a NURBS phase.
 func ToBody(m Mesh, feat string) *topo.Body {
-	bld := topo.NewBuilder(m.isClosed(), topo.NewLineage(topo.Tok(feat, "body", 0)))
+	// edgeFaces is O(edges) to build; compute the adjacency once and share it between the
+	// closed-cage test and the shared-edge build rather than rebuilding it per call — the
+	// second-largest allocation source on a dense mesh import (#1765).
+	ef := m.edgeFaces()
+	bld := topo.NewBuilder(cageClosed(ef), topo.NewLineage(topo.Tok(feat, "body", 0)))
 	verts := make([]*topo.Vertex, len(m.Verts))
 	for i, p := range m.Verts {
 		verts[i] = bld.AddVertex(p, topo.NewLineage(topo.Tok(feat, "vertex", i)))
 	}
-	edges := buildBodyEdges(m, bld, verts, feat)
+	edges := buildBodyEdges(m, ef, bld, verts, feat)
 	for fi, f := range m.Faces {
 		bld.AddFace(facePlane(m, f), topo.NewLineage(topo.Tok(feat, "face", fi)), faceLoop(f, edges))
 	}
@@ -28,8 +32,8 @@ func ToBody(m Mesh, feat string) *topo.Body {
 
 // buildBodyEdges creates one shared topo edge per undirected cage edge (sorted-key
 // order for stable lineage).
-func buildBodyEdges(m Mesh, bld *topo.Builder, verts []*topo.Vertex, feat string) map[[2]int]*topo.Edge {
-	keys := sortedEdgeKeys(m.edgeFaces())
+func buildBodyEdges(m Mesh, ef map[[2]int][]int, bld *topo.Builder, verts []*topo.Vertex, feat string) map[[2]int]*topo.Edge {
+	keys := sortedEdgeKeys(ef)
 	edges := make(map[[2]int]*topo.Edge, len(keys))
 	for i, k := range keys {
 		seg := geom.NewLineSegment(m.Verts[k[0]], m.Verts[k[1]])
@@ -49,12 +53,14 @@ func faceLoop(f []int, edges map[[2]int]*topo.Edge) topo.LoopSpec {
 	return topo.OuterLoop(uses...)
 }
 
-// isClosed reports whether every cage edge is shared by exactly two faces.
-func (m Mesh) isClosed() bool {
-	if len(m.Faces) == 0 {
+// cageClosed reports whether every cage edge is shared by exactly two faces (a watertight
+// solid), from a precomputed edge→faces adjacency so ToBody builds it only once (#1765).
+// An empty cage (no edges) is not closed.
+func cageClosed(ef map[[2]int][]int) bool {
+	if len(ef) == 0 {
 		return false
 	}
-	for _, fs := range m.edgeFaces() {
+	for _, fs := range ef {
 		if len(fs) != 2 {
 			return false
 		}

--- a/kernel/subd/coverage_test.go
+++ b/kernel/subd/coverage_test.go
@@ -10,13 +10,13 @@ import (
 )
 
 func TestIsClosedEmptyAndOpen(t *testing.T) {
-	if (Mesh{}).isClosed() {
+	if cageClosed((Mesh{}).edgeFaces()) {
 		t.Error("empty mesh should not be closed")
 	}
-	if Plane(1, 1).isClosed() {
+	if cageClosed(Plane(1, 1).edgeFaces()) {
 		t.Error("a single-face plane has boundary edges; should not be closed")
 	}
-	if !Box(1, 1, 1).isClosed() {
+	if !cageClosed(Box(1, 1, 1).edgeFaces()) {
 		t.Error("a box should be closed")
 	}
 }


### PR DESCRIPTION
## What

`subd.ToBody` rebuilt `Mesh.edgeFaces()` **twice** — once for the closed-cage test (`isClosed`) and once inside `buildBodyEdges` — each an O(edges) map allocation over the whole mesh. This computes the adjacency once at the top of `ToBody` and shares it; `isClosed` becomes the free function `cageClosed(ef)` reading the precomputed map.

The result is byte-identical: both sites are pure reads of the same edge→faces map, computed once instead of twice.

## Why

From the Calabi-Yau STL stress test, `subd.Mesh.edgeFaces` was ~863 MB of churn on a 1.4M-triangle B-rep import — the second-largest allocation source after the decode (addressed in the sibling PR).

**Measured** (B-rep import, n=6, 1.38M tris):
- `edgeFaces` churn: **863 → 426 MB** (halved — one of the two per-`ToBody` builds eliminated).
- total allocation: 5935 → **5487 MB**; GCs 17 → 15.
- Stacks with the decode preallocation (#1765 part 1): together they take the n=6 import from 5935 MB toward ~4.8 GB of churn.

## Tests

- Existing `subd` tests (`TestIsClosedEmptyAndOpen` updated to call `cageClosed(m.edgeFaces())` — empty/open/box cases), plus `meshio`, `model/exchange`, `model/feature` import tests (solid-vs-surface, manifold, volume-sign) all green — the closed/open classification and built body are unchanged.
- Lint clean.

Closes #1765.

🤖 Generated with [Claude Code](https://claude.com/claude-code)