### PR TITLE
Skip conformance repair for faceted triangle bodies (#1766)

### DIFF
--- a/kernel/ops/conformance_repair.go
+++ b/kernel/ops/conformance_repair.go
@@ -20,6 +20,11 @@ import (
 // does NOT re-mesh planes: re-triangulating a planar multi-hole face cascades new mismatches, so a crack
 // where the PLANE is the absorber is left to a future pass.
 func conformCylConeFaces(faces []*topo.Face, idx map[*topo.Face]int, fm []*Mesh, q Quality) {
+	if allBareTriangleFaces(faces) {
+		return // a pure faceted triangle soup (e.g. an imported STL body) has no near-collinear
+		// boundary point any mesher could drop, so no face can crack — skip the O(edges) free-segment
+		// scan and per-face re-mesh that would each be a no-op (#1766).
+	}
 	w := meshSegWelder(fm...)
 	free := freeSegments(fm, w)
 	if len(free) == 0 {
@@ -88,6 +93,52 @@ func conformable(s geom.Surface) bool {
 	return false
 }
 
+// allBareTriangleFaces reports whether every face is a straight-edged planar triangle with no hole
+// loop — a pure faceted triangle soup (e.g. an imported STL body). Such a body has no near-collinear
+// boundary point any mesher could drop, so the conformance-repair pass can never change it and the
+// caller skips it. Topology + curve/surface kind only, no discretization (#1766).
+func allBareTriangleFaces(faces []*topo.Face) bool {
+	if len(faces) == 0 {
+		return false
+	}
+	for _, f := range faces {
+		if !isBareTriangleFace(f) {
+			return false
+		}
+	}
+	return true
+}
+
+// isBareTriangleFace reports whether f is a planar face bounded by exactly three straight (line) edges
+// and no hole loops, so its discretized boundary is exactly its three corners: a straight edge with no
+// healing snap samples to two points (subdivide stops immediately on a zero-curvature run), and three
+// such edges close to three points. A snapped edge is excluded — it can discretize to a polyline.
+func isBareTriangleFace(f *topo.Face) bool {
+	if _, planar := f.Geometry().(geom.Plane); !planar {
+		return false
+	}
+	loops := f.Loops()
+	if len(loops) != 1 || !loops[0].IsOuter() {
+		return false
+	}
+	uses := loops[0].EdgeUses()
+	if len(uses) != 3 {
+		return false
+	}
+	for _, u := range uses {
+		e := u.Edge()
+		if e.SnappedCurve() != nil {
+			return false
+		}
+		switch e.Geometry().(type) {
+		case geom.Line, geom.LineSegment: // straight: samples to its two endpoints
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 // conformingCylConeMesh re-meshes a non-rectangular cyl/cone trim with a boundary-only metric-(u,v)
 // constrained Delaunay, the conforming alternative to the plane ear-clip. nil if not applicable (the
 // trim is a full periodic band / apex cap / iso-rectangle handled watertight by other meshers, or its
@@ -136,6 +187,10 @@ func conformingPlaneMesh(f *topo.Face, q Quality) *Mesh {
 		return nil
 	}
 	holes3D := faceHoleBoundaries(f, q)
+	if len(outer3D) == 3 && len(holes3D) == 0 {
+		return nil // an already-triangular boundary: planarCDT of three points reproduces the same
+		// single triangle the initial mesher built, so re-meshing is a no-op — keep it (#1766).
+	}
 	outer2D := project2D(outer3D, flat)
 	holes2D := make([][]math.Point2, len(holes3D))
 	for i, h := range holes3D {

--- a/kernel/ops/conformance_repair_test.go
+++ b/kernel/ops/conformance_repair_test.go
@@ -54,6 +54,56 @@ func TestConformingPlaneMeshKeepsNearCollinearPoint(t *testing.T) {
 	}
 }
 
+// TestIsBareTriangleFace pins the #1766 predicate: a straight-edged planar triangle is bare, while a
+// 5-point boundary (an absorber's shape, whose near-collinear point must be re-meshed) is NOT — so the
+// conformance-repair skip can never fire on a face that could crack a neighbour.
+func TestIsBareTriangleFace(t *testing.T) {
+	tri := planarFaceFromLoop(t, []math.Point3{math.P3(0, 0, 0), math.P3(1, 0, 0), math.P3(0, 1, 0)})
+	if !isBareTriangleFace(tri) {
+		t.Error("a straight-edged planar triangle should be a bare triangle")
+	}
+	pent := planarFaceFromLoop(t, []math.Point3{
+		math.P3(0, 0, 0), math.P3(2, 0, 0), math.P3(2, 2, 0), math.P3(1, 2.0001, 0), math.P3(0, 2, 0),
+	})
+	if isBareTriangleFace(pent) {
+		t.Error("a 5-point (absorber) boundary must not be classified as a bare triangle")
+	}
+	for _, f := range tetra(1, math.V3(0, 0, 0)).Faces() {
+		if !isBareTriangleFace(f) {
+			t.Error("every tetra face is a straight-edged planar triangle")
+		}
+	}
+	if !allBareTriangleFaces(tetra(1, math.V3(0, 0, 0)).Faces()) {
+		t.Error("a tetra is a pure bare-triangle soup")
+	}
+}
+
+// TestConformingMeshIsNoOpOnBareTriangle: re-meshing a triangle reproduces the same triangle, so
+// conformingPlaneMesh returns nil (keep existing) — the skip that drops the per-face CDT (#1766).
+func TestConformingMeshIsNoOpOnBareTriangle(t *testing.T) {
+	tri := planarFaceFromLoop(t, []math.Point3{math.P3(0, 0, 0), math.P3(1, 0, 0), math.P3(0, 1, 0)})
+	if m := conformingPlaneMesh(tri, DefaultQuality()); m != nil {
+		t.Errorf("conformingPlaneMesh should skip a bare triangle (return nil), got %d tris", m.TriangleCount())
+	}
+}
+
+// TestBareTriangleSoupTessellatesWatertight proves the body-level conformance skip is a genuine no-op
+// on a closed triangle soup: the tetra still tessellates watertight (zero free edges), one triangle per
+// face — i.e. skipping the repair pass did not reintroduce a crack (#1766).
+func TestBareTriangleSoupTessellatesWatertight(t *testing.T) {
+	body := tetra(1, math.V3(0, 0, 0))
+	if !allBareTriangleFaces(body.Faces()) {
+		t.Fatal("tetra should be a bare-triangle soup (the skip path)")
+	}
+	mesh, _ := TessellateBody(body, DefaultQuality())
+	if got := weldedFreeEdgeCount(mesh); got != 0 {
+		t.Errorf("tessellated tetra has %d free edges, want 0 (watertight)", got)
+	}
+	if mesh.TriangleCount() != 4 {
+		t.Errorf("tetra tessellated to %d triangles, want 4 (one per face)", mesh.TriangleCount())
+	}
+}
+
 // planarFaceFromLoop builds a single planar (z=0) face from a CCW 3D point loop, each side a line
 // edge — the fixture for the plane-conformance tests.
 func planarFaceFromLoop(t *testing.T, loop []math.Point3) *topo.Face {


### PR DESCRIPTION
## What

Rendering an imported dense mesh (STL → B-rep, one planar triangle per face) is CPU-bound. A profile of render-prep on the n=6 Calabi-Yau body (1.38M faces) shows **91% is `ops.TessellateBody`**, and within it the cross-face **conformance-repair** pass (`conformCylConeFaces`) burns **10.4 s of 16.2 s** — running CDT on faces that are already single triangles.

That pass exists to repair a crack where a curved-rim mesher drops a near-collinear boundary point its planar neighbour keeps (an "absorber", #1073). A faceted triangle soup has no such point — every face's boundary is exactly its three corners — so nothing is repairable, yet the open surface's boundary edges all register as free segments and every touching face was re-meshed via CDT to reproduce the identical triangle.

Two provably-idempotent skips:
- **Body level** — skip the whole pass when every face is a straight-edged planar triangle with no hole loop (`allBareTriangleFaces`): topology + curve-kind only, no discretization.
- **Per face** — `conformingPlaneMesh` returns nil (keep existing) when the outer boundary is 3 points with no holes: `planarCDT` of three points is the same triangle. Covers mixed bodies with incidental triangle faces.

## Why they're safe (vetted with the geometry-math advisor)

Both are no-ops **by construction**. A real absorber's mesh is one triangle but its *boundary* `faceOuterBoundary(f,q)` has >3 points — the dropped point stays a topological boundary vertex (`loopBoundary` concatenates per-coedge samples, keeping every junction regardless of collinearity; a straight edge with no healing snap samples to exactly 2 points). So the skips gate on the **boundary**, never the mesh triangle-count, and can never fire on a face that could crack. The body predicate excludes snapped/curved edges, so a pure straight-triangle soup provably has no absorber.

## Validation

- **Byte-identical render**: the n=6 shaded PNG has the **same md5** before and after — pixel-for-pixel no-op.
- **Speed**: `TessellateBody` on n=6 drops **16.2 s → 4.8 s (3.4×)**; total render-prep 17.9 s → 6.4 s.
- **Correctness**: the #1073 near-collinear absorber test (`TestConformingPlaneMeshKeepsNearCollinearPoint`) and every watertight/certification test stay green. New tests: `TestIsBareTriangleFace`, `TestConformingMeshIsNoOpOnBareTriangle`, `TestBareTriangleSoupTessellatesWatertight` (tetra tessellates watertight, freeEdgeCount 0, via the skip path). Full `kernel/ops`, `renderer`, `model/feature`, `model/exchange` suites green; lint clean.

## Scope

Addresses the tessellation re-work that made the render CPU-bound. The residual end-to-end time (import + CPU→GPU flatten + upload of ~1.4M tris) is separate. Per-triangle edge-lace is already crease-gated by `VisibleEdges`; not changed here.

Closes #1766.

🤖 Generated with [Claude Code](https://claude.com/claude-code)