### PR TITLE
Memoize Body.RangeBox: orbit 1 fps → 60 fps on large bodies (#1771)

### DIFF
--- a/kernel/topo/body.go
+++ b/kernel/topo/body.go
@@ -41,6 +41,13 @@ type Body struct {
 	edgeIndex       map[string][]*Edge
 	faceIndex       map[string][]*Face
 	vertexIndex     map[string][]*Vertex
+
+	// rangeBox memoizes the axis-aligned bound, built once for the same immutability reason as the
+	// key indices above (#1771). RangeBox is a render hot path — instancedBounds and per-frame
+	// frustum culling call it every frame — but a static body's bound never changes, so the O(edges)
+	// sweep runs once, not once per orbit frame (~87% of frame time before this).
+	rangeBoxOnce sync.Once
+	rangeBox     math.Box
 }
 
 // edgeKeyIndex returns the edge reference-key index, building it once. See the index
@@ -177,6 +184,19 @@ func deriveVerticesFrom(edges []*Edge) []*Vertex {
 // cones and arcs are bounded by their true silhouette rather than collapsing to
 // their seam vertices (see extendBoxByEdges).
 func (b *Body) RangeBox() math.Box {
+	// Before finalize the body is still changing, so compute live and do not memoize an incomplete
+	// bound — the same pre-finalize rule the key indices follow. After finalize the body is immutable,
+	// so the O(vertices+edges) sweep runs once and every subsequent (per-frame) call is a cache read.
+	if !b.derived {
+		return b.computeRangeBox()
+	}
+	b.rangeBoxOnce.Do(func() { b.rangeBox = b.computeRangeBox() })
+	return b.rangeBox
+}
+
+// computeRangeBox is the raw axis-aligned bound over the body's vertices, edges and boundaryless
+// faces — the sweep RangeBox memoizes once the body is finalized (#1771).
+func (b *Body) computeRangeBox() math.Box {
 	box := math.EmptyBox()
 	for _, v := range b.Vertices() {
 		box = box.ExtendPoint(v.point)

--- a/kernel/topo/topology_test.go
+++ b/kernel/topo/topology_test.go
@@ -151,6 +151,21 @@ func TestRangeBoxes(t *testing.T) {
 	}
 }
 
+// TestBodyRangeBoxMemoized pins #1771: a finalized body's RangeBox equals the raw sweep (the memo is
+// correct) and is stable across calls — the render hot path reads a cached bound rather than
+// re-iterating every vertex/edge each frame.
+func TestBodyRangeBoxMemoized(t *testing.T) {
+	body := buildTetra()
+	want := body.computeRangeBox()
+	got := body.RangeBox()
+	if got.Min != want.Min || got.Max != want.Max {
+		t.Errorf("memoized RangeBox %v..%v != live sweep %v..%v", got.Min, got.Max, want.Min, want.Max)
+	}
+	if again := body.RangeBox(); again.Min != got.Min || again.Max != got.Max {
+		t.Errorf("RangeBox not stable across calls: %v..%v then %v..%v", got.Min, got.Max, again.Min, again.Max)
+	}
+}
+
 func TestSurfaceBodiesCollection(t *testing.T) {
 	c := NewSurfaceBodies()
 	b1 := c.Add(buildTetra())


### PR DESCRIPTION
## What

Orbiting a large body ran at **~1 fps** (1.38M triangles) — **~8 fps** even at 153k — with the GPU idle. A steady-state orbit-frame profile showed **87% of every frame** in `topo.Body.RangeBox`:

```
frameBounds → instancedBounds → Body.RangeBox()
            → extendBoxByEdges (47%) → Box.ExtendPoint (34%)
```

`RangeBox` recomputes the axis-aligned bound by iterating every vertex + edge, once per body **per frame** (`instancedBounds`, plus per-frame frustum culling `visible(cam, b.RangeBox())`) — even though a static body's bound never changes while the camera moves. Frame time was dead-linear at ~0.8 µs/triangle.

Memoize `RangeBox` with a `sync.Once`, exactly like the reference-key indices (#1580): a body is **immutable after `finalizeDerived`** (a recompute builds a new body, never mutates it), so the O(vertices+edges) sweep runs once and every later call is a cache read. Before finalize it still computes live and does not memoize an incomplete bound — the same `derived`-guard the key indices use.

## Why it's safe

Same immutability contract the struct already documents and the #1580 index memoization already relies on. The pre-finalize guard means a partially-built body never caches an incomplete box; after finalize the body's geometry is frozen. Full `topo`/`ops`/`renderer`/`app`/`model/feature` suites pass unchanged.

## Measured (1280×800, AMD Radeon 8060S, warm tessellation cache)

| mesh | before | after |
|------|--------|-------|
| n=2 (153k tris) | 8 fps | **60 fps** |
| n=6 (1.38M tris) | 1 fps | **60 fps** |
| n=7 (1.88M tris) | 0.7 fps | **60 fps** |

Frame time is now a constant ~16.6 ms (the vsync cap) regardless of triangle count — the per-frame O(edges) cost is eliminated. Also speeds every other `RangeBox` caller in the frame loop (frustum culling, framing).

## Tests

`TestBodyRangeBoxMemoized` asserts the memoized bound equals the raw sweep and is stable across calls; existing `TestRangeBoxes`/`TestRangeBoxBoundarylessSphere` unchanged and green. Lint clean.

Closes #1771.

🤖 Generated with [Claude Code](https://claude.com/claude-code)