### PR TITLE
Render placed mesh references in the viewport (#1773)

### DIFF
--- a/app/mesh_render.go
+++ b/app/mesh_render.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"strconv"
+	"strings"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/renderer"
+)
+
+// Placed-mesh display (#1773): a Mesh ▸ Place Mesh reference (#1764/#700) has no B-rep body, so the
+// body draw list never sees it and it renders as nothing. It is drawn instead as its own display
+// object. The head flattens these items ONCE and caches them on MeshDisplaySignature, so a dense
+// scan is not re-flattened every frame — putting it on the per-frame overlay path would reintroduce
+// the O(triangles)-per-frame cost #1771 removed.
+
+// meshRefColor is the neutral surface colour a placed mesh reference is shaded with — a light,
+// faintly cool grey, so a reference mesh reads as reference rather than as a modelled body.
+var meshRefColor = [4]float32{0.72, 0.74, 0.78, 1}
+
+// MeshDrawItems returns one shaded-triangle draw item per visible placed mesh reference on the
+// active part. Each facet is flat-shaded — its triangles carry their own vertices and the facet's
+// geometric normal — because a scan/visualization mesh has no smoothing groups to average across.
+// Empty when the active document is not a part or carries no mesh references. Building a dense
+// mesh's item is O(triangles); the head calls this only when MeshDisplaySignature changes.
+//
+//	items := s.MeshDrawItems() // one renderer.DrawItem per placed STL
+func (s *Session) MeshDrawItems() []renderer.DrawItem {
+	part, err := activePart(s)
+	if err != nil {
+		return nil
+	}
+	feats := part.Features()
+	var items []renderer.DrawItem
+	for i := 0; i < feats.Count(); i++ {
+		pf := feats.Item(i)
+		if pf.Suppressed() {
+			continue
+		}
+		if mf, ok := pf.Definition().(*feature.MeshFeature); ok {
+			items = append(items, meshTriangleItem(mf.Geometry(), uint64(pf.ID())))
+		}
+	}
+	return items
+}
+
+// MeshDisplaySignature is a cheap identity for the current placed-mesh SET — the visible mesh
+// features' ids — so the head's flatten cache rebuilds only when a mesh is placed, removed or
+// suppressed, not on an unrelated edit or an orbit (which leave the set unchanged). It walks the
+// feature list without building any geometry. ok is false when there is nothing to display.
+func (s *Session) MeshDisplaySignature() (string, bool) {
+	part, err := activePart(s)
+	if err != nil {
+		return "", false
+	}
+	feats := part.Features()
+	var sig strings.Builder
+	for i := 0; i < feats.Count(); i++ {
+		pf := feats.Item(i)
+		if pf.Suppressed() {
+			continue
+		}
+		if _, ok := pf.Definition().(*feature.MeshFeature); ok {
+			sig.WriteString(strconv.FormatUint(uint64(pf.ID()), 10))
+			sig.WriteByte(';')
+		}
+	}
+	if sig.Len() == 0 {
+		return "", false
+	}
+	return sig.String(), true
+}
+
+// meshTriangleItem builds the flat-shaded triangle draw item for one placed mesh geometry.
+func meshTriangleItem(g *feature.MeshGeometry, objectID uint64) renderer.DrawItem {
+	pos, norm, idx := triangulateFacets(g)
+	return renderer.DrawItem{
+		Primitive: renderer.Triangles,
+		Positions: pos,
+		Normals:   norm,
+		Indices:   idx,
+		Color:     meshRefColor,
+		Roughness: 0.6,
+		Opacity:   1,
+		Shading:   renderer.ShadeFlat, // a reference mesh has no extracted edges — always lit
+		ObjectID:  objectID,
+	}
+}
+
+// triangulateFacets fan-triangulates every facet into flat-shaded, UNSHARED-vertex streams — each
+// triangle carries its own three vertices and the facet's geometric normal, so neighbours never
+// average and the faceting reads crisply.
+func triangulateFacets(g *feature.MeshGeometry) (pos []math.Point3, norm []math.Vector3, idx []int) {
+	tris := 0
+	for _, f := range g.Facets {
+		if len(f) >= 3 {
+			tris += len(f) - 2
+		}
+	}
+	pos = make([]math.Point3, 0, tris*3)
+	norm = make([]math.Vector3, 0, tris*3)
+	idx = make([]int, 0, tris*3)
+	for _, f := range g.Facets {
+		for k := 2; k < len(f); k++ { // a triangle contributes one iteration
+			a, b, c := g.Vertices[f[0]], g.Vertices[f[k-1]], g.Vertices[f[k]]
+			n := faceNormal(a, b, c)
+			base := len(pos)
+			pos = append(pos, a, b, c)
+			norm = append(norm, n, n, n)
+			idx = append(idx, base, base+1, base+2)
+		}
+	}
+	return pos, norm, idx
+}
+
+// faceNormal is the unit geometric normal of triangle a-b-c by the right-hand rule over its vertex
+// winding, or +Z for a degenerate (zero-area) triangle so shading stays defined.
+func faceNormal(a, b, c math.Point3) math.Vector3 {
+	n := a.VectorTo(b).Cross(a.VectorTo(c))
+	l := n.Length()
+	if l < 1e-12 {
+		return math.V3(0, 0, 1)
+	}
+	return n.Scale(1 / l)
+}

--- a/app/mesh_render_test.go
+++ b/app/mesh_render_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/renderer"
+)
+
+// TestMeshDrawItemsRendersPlacedMesh pins #1773: a placed mesh reference produces a shaded-triangle
+// draw item so the viewport can draw it (before this it yielded no body and nothing rendered). The
+// tetra STL is 4 facets → 4 flat-shaded triangles, each with its own three vertices and a unit
+// face normal.
+func TestMeshDrawItemsRendersPlacedMesh(t *testing.T) {
+	s, _ := newPartWithBlock(t, 6)
+	pf, err := s.ImportMeshFile(tempSTL(t))
+	if err != nil {
+		t.Fatalf("ImportMeshFile: %v", err)
+	}
+
+	items := s.MeshDrawItems()
+	if len(items) != 1 {
+		t.Fatalf("MeshDrawItems = %d items, want 1", len(items))
+	}
+	it := items[0]
+	if it.Primitive != renderer.Triangles {
+		t.Errorf("primitive = %v, want Triangles", it.Primitive)
+	}
+	if it.Shading != renderer.ShadeFlat {
+		t.Errorf("shading = %v, want ShadeFlat (a reference mesh is always lit)", it.Shading)
+	}
+	// 4 facets, flat-shaded with unshared vertices: 12 positions / normals / indices.
+	if len(it.Positions) != 12 || len(it.Normals) != 12 || len(it.Indices) != 12 {
+		t.Fatalf("pos/norm/idx = %d/%d/%d, want 12/12/12", len(it.Positions), len(it.Normals), len(it.Indices))
+	}
+	for i, n := range it.Normals {
+		if l := n.Length(); math.Abs(float64(l)-1) > 1e-6 {
+			t.Errorf("normal %d length = %v, want unit", i, l)
+		}
+	}
+	if it.ObjectID != uint64(pf.ID()) {
+		t.Errorf("ObjectID = %d, want the feature id %d (for picking)", it.ObjectID, uint64(pf.ID()))
+	}
+}
+
+// TestMeshDisplaySignatureTracksSet pins the cheap cache key (#1773): the signature is present once a
+// mesh is placed and drops to absent when the only mesh is suppressed — so the head's flatten cache
+// rebuilds exactly when the visible mesh set changes, not on an orbit.
+func TestMeshDisplaySignatureTracksSet(t *testing.T) {
+	s, _ := newPartWithBlock(t, 6)
+	if _, ok := s.MeshDisplaySignature(); ok {
+		t.Fatal("signature should be absent before any mesh is placed")
+	}
+
+	pf, err := s.ImportMeshFile(tempSTL(t))
+	if err != nil {
+		t.Fatalf("ImportMeshFile: %v", err)
+	}
+	sig, ok := s.MeshDisplaySignature()
+	if !ok || sig == "" {
+		t.Fatal("signature should be present after placing a mesh")
+	}
+
+	pf.SetSuppressed(true)
+	if _, ok := s.MeshDisplaySignature(); ok {
+		t.Error("signature should be absent when the only mesh is suppressed")
+	}
+}

--- a/app/view.go
+++ b/app/view.go
@@ -5,6 +5,7 @@ package app
 import (
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
 	"oblikovati.org/model/sketch"
 )
 
@@ -107,16 +108,42 @@ func (s *Session) lookAtPlane(target math.Point3, normal, up math.Vector3) {
 	s.animateCameraTo(s.Camera().Facing(target, normal, up), sketchViewTweenSeconds)
 }
 
-// modelBounds is the union of the active part's body bounding boxes, its visible sketch geometry
-// AND its visible point clouds, so Fit/Home frame a sketch-only part — e.g. a DWG/DXF import that
-// produces a 2D sketch or a Sketch3D with no solid body (issue #1146) — or a scan-only part whose
-// only visible geometry is an attached point cloud (#1645). Empty when there is nothing visible.
+// modelBounds is the union of the active part's body bounding boxes, its visible sketch geometry,
+// its visible point clouds AND its placed mesh references, so Fit/Home frame a sketch-only part —
+// e.g. a DWG/DXF import that produces a 2D sketch or a Sketch3D with no solid body (issue #1146) —
+// a scan-only part whose only visible geometry is an attached point cloud (#1645), or a part whose
+// only geometry is a placed reference mesh (#1773). Empty when there is nothing visible.
 func (s *Session) modelBounds() math.Box {
 	box := math.EmptyBox()
 	for _, b := range s.sceneBodies() {
 		box = box.Union(b.RangeBox())
 	}
-	return s.unionCloudBounds(s.unionSketchBounds(box))
+	return s.unionMeshBounds(s.unionCloudBounds(s.unionSketchBounds(box)))
+}
+
+// unionMeshBounds widens box by the model-space extent of the active part's visible placed mesh
+// references, so a reference mesh placed into an otherwise empty part is framed by Fit/Home (#1773).
+// A suppressed mesh contributes nothing.
+func (s *Session) unionMeshBounds(box math.Box) math.Box {
+	part, err := activePart(s)
+	if err != nil {
+		return box
+	}
+	feats := part.Features()
+	for i := 0; i < feats.Count(); i++ {
+		pf := feats.Item(i)
+		if pf.Suppressed() {
+			continue
+		}
+		mf, ok := pf.Definition().(*feature.MeshFeature)
+		if !ok {
+			continue
+		}
+		for _, v := range mf.Geometry().Vertices {
+			box = box.ExtendPoint(v)
+		}
+	}
+	return box
 }
 
 // unionCloudBounds widens box by the model-space extent of the active part's visible point clouds,

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -432,7 +432,8 @@ func frameMeshAndInstances(s *app.Session, cam scene.Camera, list renderer.DrawL
 		decorate := func(l renderer.DrawList) renderer.DrawList {
 			return highlightSelection(l, s.Selection().First(), sources)
 		}
-		if m, mats, recs, key, ok := buildInstancedFrame(groups, culled, overlay, cam, s.SurfaceLookup(), s.VisualStyle(), decorate, instancedSourceKey(s)); ok {
+		placedMesh, placedMeshKey, _ := cachedPlacedMesh(s) // retained placed-mesh lane (#1773)
+		if m, mats, recs, key, ok := buildInstancedFrame(groups, culled, overlay, placedMesh, placedMeshKey, cam, s.SurfaceLookup(), s.VisualStyle(), decorate, instancedSourceKey(s)); ok {
 			return m, mats, recs, geomUploadKey(key)
 		}
 	}

--- a/head/ui/instancing_cache_test.go
+++ b/head/ui/instancing_cache_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"oblikovati.org/head/viewport"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
@@ -109,7 +110,7 @@ func TestBuildInstancedFrameDedupes(t *testing.T) {
 		t.Fatalf("VisibleInstances = %d groups, want 1 (copies share one mesh)", len(groups))
 	}
 	n := len(groups[0].Transforms)
-	m, mats, recs, _, ok := buildInstancedFrame(groups, groups, renderer.DrawList{}, instCamera(), nullSurface, renderer.Shaded, nil, "k")
+	m, mats, recs, _, ok := buildInstancedFrame(groups, groups, renderer.DrawList{}, viewport.Mesh{}, "", instCamera(), nullSurface, renderer.Shaded, nil, "k")
 	if !ok {
 		t.Fatal("buildInstancedFrame returned ok=false")
 	}

--- a/head/ui/mesh_source.go
+++ b/head/ui/mesh_source.go
@@ -1,0 +1,51 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"oblikovati.org/head/viewport"
+	"oblikovati.org/renderer"
+)
+
+// placedMeshSource is the ≤6-method view of the session cachedPlacedMesh needs — a mesh-set
+// signature and the draw items. Depending on this narrow interface instead of the whole
+// *app.Session keeps head/ui's session coupling from rising (archguard I5, arrowSession pattern).
+type placedMeshSource interface {
+	MeshDisplaySignature() (string, bool)
+	MeshDrawItems() []renderer.DrawItem
+}
+
+// Placed-mesh render lane (#1773): a Mesh ▸ Place Mesh reference has no body, so it is drawn as a
+// retained atlas region rather than through the per-frame overlay. Its flattened geometry is cached
+// on the mesh-SET signature (not a content hash), so a dense scan is flattened ONCE and never
+// re-flattened while orbiting or on an unrelated edit — the same retained-source discipline the body
+// lane uses (sourceMeshCache), which is what keeps a 1.88M-triangle scan at full frame rate.
+
+// placedMeshCache retains the last flattened placed-mesh geometry and the set signature it was built
+// for. The render loop is single-threaded, so one package-level entry is safe (like frameAtlasCache
+// and sourceMeshCache).
+var placedMeshCache struct {
+	sig  string
+	mesh viewport.Mesh
+	has  bool
+}
+
+// cachedPlacedMesh returns the flattened geometry of the active part's placed mesh references plus a
+// cheap key identifying the mesh set. The flatten (O(triangles)) runs only when the set signature
+// changes — a mesh placed, removed or suppressed — so orbiting a dense scan re-flattens nothing.
+// has is false when there are no placed meshes to draw.
+func cachedPlacedMesh(s placedMeshSource) (mesh viewport.Mesh, key string, has bool) {
+	sig, ok := s.MeshDisplaySignature()
+	if !ok {
+		placedMeshCache.sig, placedMeshCache.has = "", false
+		return viewport.Mesh{}, "", false
+	}
+	if placedMeshCache.sig == sig && placedMeshCache.has {
+		return placedMeshCache.mesh, sig, true
+	}
+	m := viewport.Flatten(renderer.DrawList{Items: s.MeshDrawItems()})
+	placedMeshCache.sig, placedMeshCache.mesh, placedMeshCache.has = sig, m, true
+	return m, sig, true
+}

--- a/head/ui/mesh_source_test.go
+++ b/head/ui/mesh_source_test.go
@@ -1,0 +1,77 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/head/viewport"
+	"oblikovati.org/math"
+	"oblikovati.org/renderer"
+)
+
+// fakeMeshSource is a stand-in placed-mesh provider that counts how often the (expensive) draw-item
+// build runs, so a test can prove the head flattens a mesh once and retains it across frames.
+type fakeMeshSource struct {
+	sig   string
+	items []renderer.DrawItem
+	calls int
+}
+
+func (f *fakeMeshSource) MeshDisplaySignature() (string, bool) {
+	return f.sig, f.sig != ""
+}
+
+func (f *fakeMeshSource) MeshDrawItems() []renderer.DrawItem {
+	f.calls++
+	return f.items
+}
+
+func oneTriangleItem() renderer.DrawItem {
+	return renderer.DrawItem{
+		Primitive: renderer.Triangles,
+		Positions: []math.Point3{math.P3(0, 0, 0), math.P3(1, 0, 0), math.P3(0, 1, 0)},
+		Normals:   []math.Vector3{math.V3(0, 0, 1), math.V3(0, 0, 1), math.V3(0, 0, 1)},
+		Indices:   []int{0, 1, 2},
+		Shading:   renderer.ShadeFlat,
+	}
+}
+
+// TestCachedPlacedMeshRetainsAcrossFrames pins #1773: the placed mesh is flattened ONCE and held
+// while its set signature is unchanged (an orbit re-calls this every frame), and re-flattened only
+// when the mesh set changes — the retention that keeps a dense scan off the per-frame O(n) path.
+func TestCachedPlacedMeshRetainsAcrossFrames(t *testing.T) {
+	placedMeshCache.sig, placedMeshCache.has, placedMeshCache.mesh = "", false, viewport.Mesh{}
+	src := &fakeMeshSource{sig: "m1;", items: []renderer.DrawItem{oneTriangleItem()}}
+
+	m1, k1, has1 := cachedPlacedMesh(src)
+	if !has1 || k1 != "m1;" || m1.TriVCount == 0 {
+		t.Fatalf("first call: has=%v key=%q triVerts=%d, want true/\"m1;\"/>0", has1, k1, m1.TriVCount)
+	}
+	if m2, k2, _ := cachedPlacedMesh(src); k2 != k1 || m2.TriVCount != m1.TriVCount {
+		t.Errorf("second call diverged from cache: key %q vs %q, triVerts %d vs %d", k2, k1, m2.TriVCount, m1.TriVCount)
+	}
+	if src.calls != 1 {
+		t.Errorf("MeshDrawItems built %d times over two frames, want 1 (retained)", src.calls)
+	}
+
+	src.sig = "m1;m2;" // a mesh placed/removed changes the set signature → rebuild
+	if _, k3, _ := cachedPlacedMesh(src); k3 != "m1;m2;" || src.calls != 2 {
+		t.Errorf("signature change should rebuild: key=%q calls=%d, want \"m1;m2;\"/2", k3, src.calls)
+	}
+}
+
+// TestCachedPlacedMeshEmptyWhenNoMeshes: with no placed meshes the source reports no signature, so
+// there is nothing to draw and no flatten happens.
+func TestCachedPlacedMeshEmptyWhenNoMeshes(t *testing.T) {
+	placedMeshCache.sig, placedMeshCache.has, placedMeshCache.mesh = "", false, viewport.Mesh{}
+	src := &fakeMeshSource{sig: ""}
+	if _, _, has := cachedPlacedMesh(src); has {
+		t.Error("cachedPlacedMesh should report has=false when there are no placed meshes")
+	}
+	if src.calls != 0 {
+		t.Errorf("MeshDrawItems built %d times with no meshes, want 0", src.calls)
+	}
+}

--- a/head/ui/viewport_instancing.go
+++ b/head/ui/viewport_instancing.go
@@ -246,14 +246,15 @@ func sortRecsInto(out *[][7]int32, recs [][7]int32) [][7]int32 {
 // (M34-F1b) — while the matrices/records are assembled each frame from the frustum-culled instances
 // (culledGroups, M34-F1). ok is false when there is nothing to draw, so the caller falls back to
 // the legacy single-mesh path.
-func buildInstancedFrame(allGroups, culledGroups []app.InstanceGroup, overlay renderer.DrawList, cam scene.Camera,
+func buildInstancedFrame(allGroups, culledGroups []app.InstanceGroup, overlay renderer.DrawList,
+	placedMesh viewport.Mesh, placedMeshKey string, cam scene.Camera,
 	lookup renderer.SurfaceLookup, style renderer.VisualStyle,
 	decorate func(renderer.DrawList) renderer.DrawList, sourceKey string,
 ) (viewport.Mesh, []float32, []int32, string, bool) {
-	if len(allGroups) == 0 && len(overlay.Items) == 0 {
+	if len(allGroups) == 0 && len(overlay.Items) == 0 && placedMeshKey == "" {
 		return viewport.Mesh{}, nil, nil, "", false
 	}
-	atlas := cachedFrameAtlas(allGroups, overlay, cam, lookup, style, decorate, sourceKey)
+	atlas := cachedFrameAtlas(allGroups, overlay, placedMesh, placedMeshKey, cam, lookup, style, decorate, sourceKey)
 	// Reuse the visible-instances map across frames (single-threaded render loop) — clear keeps the
 	// buckets, so a static orbit re-maps the culled set without allocating a fresh map (#1423).
 	visible := visibleScratch
@@ -295,12 +296,16 @@ var visibleScratch = map[*topo.Body][]math.Matrix4{}
 // source signature (sourceKey, which bumps on any geometry/style/selection/placement change) or the
 // overlay content changes. The overlay is flattened every frame (it is small) so its hash can key
 // the cache; on a hit the expensive per-source concatenation is skipped entirely.
-func cachedFrameAtlas(allGroups []app.InstanceGroup, overlay renderer.DrawList, cam scene.Camera,
+func cachedFrameAtlas(allGroups []app.InstanceGroup, overlay renderer.DrawList,
+	placedMesh viewport.Mesh, placedMeshKey string, cam scene.Camera,
 	lookup renderer.SurfaceLookup, style renderer.VisualStyle,
 	decorate func(renderer.DrawList) renderer.DrawList, sourceKey string,
 ) frameAtlas {
 	overlayMesh := viewport.Flatten(overlay)
-	key := sourceKey + "|ov:" + strconv.FormatUint(overlayHash(overlayMesh), 16)
+	// The placed mesh keys the cache by its cheap set SIGNATURE, not a content hash: it is retained
+	// (flattened once by cachedPlacedMesh), so it must never be re-hashed per frame like the small
+	// overlay (#1773). The atlas rebuilds only when a mesh is placed/removed/suppressed.
+	key := sourceKey + "|ov:" + strconv.FormatUint(overlayHash(overlayMesh), 16) + "|pm:" + placedMeshKey
 	if frameAtlasCache.key == key && key != "" {
 		return frameAtlasCache
 	}
@@ -309,6 +314,9 @@ func cachedFrameAtlas(allGroups []app.InstanceGroup, overlay renderer.DrawList, 
 		// The per-source tessellate+flatten is cached by sourceMeshCache; addSource only concatenates
 		// the cached streams into the atlas, which is itself retained across frames by this cache.
 		b.addSource(g.Source, cachedSourceMesh(g.Source, cam, lookup, style, decorate, sourceKey))
+	}
+	if placedMeshKey != "" {
+		b.addSource(nil, placedMesh) // placed mesh: world-space, one identity instance (like the overlay)
 	}
 	if len(overlay.Items) > 0 {
 		b.addSource(nil, overlayMesh) // the overlay region: one identity instance in assemble


### PR DESCRIPTION
Closes #1773.

## What
A `Mesh ▸ Place Mesh` reference (#1764/#700) placed but rendered as **nothing** — a `MeshFeature` yields no `topo.Body`, so the body draw list never saw it. This routes a placed mesh into the viewport as its own display object.

## Why this shape (not the overlay path)
A placed mesh is world-space, identity-instance geometry like an overlay — but a dense scan must **not** ride the transient overlay lane, which `viewport.Flatten`+`overlayHash`es the whole overlay **every frame**. For 1.88M triangles that flattens+hashes ~5.6M vertices/frame → ~10–15 fps, reintroducing the per-frame O(n) cost #1771 removed.

Instead the mesh is a **retained atlas region**: flattened once, cached on a cheap mesh-set signature (feature ids, not a content hash), keyed into the frame atlas so orbiting re-flattens nothing — the same retained-source discipline the body lane uses.

## Changes
- `app`: `Session.MeshDrawItems()` (flat per-face-normal triangle items) + `MeshDisplaySignature()`; `Fit/Home` union placed-mesh bounds (`unionMeshBounds`).
- `head/ui`: signature-keyed `cachedPlacedMesh` threaded into `cachedFrameAtlas` with its key; depends on a ≤2-method `placedMeshSource` interface so the head↔session coupling ratchet holds.
- Tests: app DrawItem-snapshot regression + head retention test (flattened once, rebuilt only on set change).

## Verification
Live on the Harvard Calabi-Yau model (**1,881,600 triangles**): renders shaded, framed by Fit, and **orbits at 66 fps mean** (15 ms/frame) — the retained lane holds during camera motion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)