### PR TITLE
Show placed mesh references in mesh-color debug mode (#1775)

### DIFF
--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -439,7 +439,11 @@ func frameMeshAndInstances(s *app.Session, cam scene.Camera, list renderer.DrawL
 	}
 	// Legacy flatten: a fresh world-space mesh with no stable atlas key, so geomKey 0 ⇒ the native
 	// renderer always re-uploads it (correct, just unoptimised — the instanced path is the hot one).
+	// Placed mesh references have no instanced source, so add them to the world list here too so they
+	// still show in mesh-color debug mode (#1775). Flatten routes the opaque tris correctly. This
+	// re-flattens the mesh per frame, acceptable in this debug/fallback path (not the hot instanced one).
 	list.Items = append(list.Items, ground...)
+	list.Items = append(list.Items, s.MeshDrawItems()...)
 	return viewport.Flatten(list), nil, nil, 0
 }
 


### PR DESCRIPTION
Closes #1775.

Placed meshes render in all normal tiles (#1773) — and passive multi-view tiles, which share `renderViewportImage`→`cachedPlacedMesh` — but vanished in **mesh-color debug mode**, where `frameMeshAndInstances` skips the instanced path (the retained placed-mesh lane) and the legacy fallback never added the mesh.

**Fix:** append the placed mesh's draw items to the world list in the legacy branch; `Flatten` routes the opaque triangles correctly. Re-flattens per frame — acceptable in this debug/fallback path (the instanced path stays the retained hot one).

**Verified live:** placed mesh (Calabi-Yau n=2) renders with mesh-color mode on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)