### PR TITLE
feat(app): emit a body/<key> selection reference for a whole-body pick (#1492)

### DIFF
--- a/addin/router/model_select.go
+++ b/addin/router/model_select.go
@@ -39,7 +39,7 @@ func modelSelect(s *app.Session, bodies []*topo.Body, in wire.SelectArgs) (wire.
 	for _, ref := range in.Refs {
 		sel, ok := resolveSelectionRef(bodies, ref)
 		if !ok {
-			return wire.SelectionResult{}, fmt.Errorf("%s: cannot resolve reference %q (not a face/vertex of the active part)", wire.MethodModelSelect, ref)
+			return wire.SelectionResult{}, fmt.Errorf("%s: cannot resolve reference %q (not a face/vertex/body of the active part)", wire.MethodModelSelect, ref)
 		}
 		s.Selection().Add(sel)
 	}
@@ -76,9 +76,10 @@ func activeBodies(s *app.Session, method string) ([]*topo.Body, error) {
 	return bodies, nil
 }
 
-// resolveSelectionRef resolves a face/vertex reference string to a selectable handle on the bodies.
-// Edges/work-features are not round-trippable through model.selection yet (it reports no ref for
-// them), so they are not resolved here.
+// resolveSelectionRef resolves a face/vertex/body reference string to a selectable handle on the
+// bodies (a whole-body pick round-trips via body/<key>, #1492). Edges/work-features are not
+// round-trippable through model.selection yet (it reports no ref for them), so they are not
+// resolved here.
 func resolveSelectionRef(bodies []*topo.Body, ref string) (app.Selectable, bool) {
 	return app.ResolveRefOnBodies(bodies, ref)
 }

--- a/addin/router/model_select_mutation_test.go
+++ b/addin/router/model_select_mutation_test.go
@@ -57,6 +57,36 @@ func TestModelSelectVertexByReference(t *testing.T) {
 	}
 }
 
+// boxBodyRef returns the box's whole-body selection reference (the body/<key> form, #1492).
+func boxBodyRef(t *testing.T, s *app.Session) string {
+	t.Helper()
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		t.Fatalf("active part: %v", err)
+	}
+	return string(feature.BodyRef(part.SurfaceBodies().Item(0).ReferenceKey()))
+}
+
+// TestModelSelectBodyByReference drives the #1492 round trip over the wire: selecting a whole body
+// by its body/<key> reference resolves, and model.selection reports that SAME non-empty ref back
+// (was "" before #1492) so an add-in can read which body was picked.
+func TestModelSelectBodyByReference(t *testing.T) {
+	r, s, _, _ := boxFaceRefs(t)
+	bodyRef := boxBodyRef(t, s)
+
+	var sel wire.SelectionResult
+	call(t, r, s, "model.select", mustJSON(t, wire.SelectArgs{Refs: []string{bodyRef}}), &sel)
+	if sel.Count != 1 {
+		t.Fatalf("select body = %+v, want 1", sel)
+	}
+	if len(sel.Refs) != 1 || sel.Refs[0] != bodyRef {
+		t.Errorf("body selection reported refs %v, want [%q]", sel.Refs, bodyRef)
+	}
+	if int(app.SelectBody) != sel.Kinds[0] {
+		t.Errorf("body selection kind = %d, want %d (SelectBody)", sel.Kinds[0], app.SelectBody)
+	}
+}
+
 // TestModelSelectNoActivePartFails: the mutation methods reject when there is no active part.
 func TestModelSelectNoActivePartFails(t *testing.T) {
 	r := New(opregistry.Default())

--- a/app/highlight_set.go
+++ b/app/highlight_set.go
@@ -3,6 +3,7 @@
 package app
 
 import (
+	"bytes"
 	"fmt"
 	"slices"
 
@@ -128,6 +129,11 @@ func ResolveRefOnBodies(bodies []*topo.Body, ref string) (Selectable, bool) {
 			return sel, true
 		}
 	}
+	if key, ok := feature.BodyRefKey(feature.WorkRef(ref)); ok {
+		if sel, found := findBody(bodies, key); found {
+			return sel, true
+		}
+	}
 	// Raw reference-key form (model.referenceKeys): try face, edge, then vertex.
 	raw := []byte(ref)
 	if sel, found := findFace(bodies, raw); found {
@@ -162,6 +168,18 @@ func findVertex(bodies []*topo.Body, key []byte) (Selectable, bool) {
 	for _, b := range bodies {
 		if v, ok := b.FindVertexByKey(key); ok {
 			return VertexHandle{Vertex: v}, true
+		}
+	}
+	return nil, false
+}
+
+// findBody binds a whole-body reference key to its BodyHandle (#1492). A body is matched by its
+// own ReferenceKey rather than a FindByKey lookup — the key names the body itself, not a
+// sub-entity — so a picked body round-trips through model.select.
+func findBody(bodies []*topo.Body, key []byte) (Selectable, bool) {
+	for _, b := range bodies {
+		if bytes.Equal(b.ReferenceKey(), key) {
+			return BodyHandle{Body: b}, true
 		}
 	}
 	return nil, false

--- a/app/highlight_set_test.go
+++ b/app/highlight_set_test.go
@@ -68,6 +68,39 @@ func TestResolveRefOnBodiesBothForms(t *testing.T) {
 	}
 }
 
+// TestBodySelectionRefRoundTrips: a whole-body pick reports a non-empty body/<key> reference in
+// Selection.References() (was "" — #1492), and that reference resolves back to the SAME body's
+// BodyHandle through ResolveRefOnBodies, so an add-in can read and re-select a directly-picked body.
+func TestBodySelectionRefRoundTrips(t *testing.T) {
+	_, def := boxBodySession(t)
+	bodies := def.SurfaceBodies().All()
+	if len(bodies) == 0 {
+		t.Fatal("no bodies after recompute")
+	}
+	b := bodies[0]
+
+	sel := NewSelection()
+	if !sel.Add(BodyHandle{Body: b}) {
+		t.Fatal("adding a BodyHandle to the selection failed")
+	}
+	ref := sel.References()[0]
+	if ref == "" {
+		t.Fatal("a selected body still reports an empty reference (#1492 regression)")
+	}
+	if want := string(feature.BodyRef(b.ReferenceKey())); ref != want {
+		t.Errorf("body ref = %q, want %q", ref, want)
+	}
+
+	resolved, ok := ResolveRefOnBodies(bodies, ref)
+	if !ok {
+		t.Fatalf("body ref %q did not resolve", ref)
+	}
+	h, isBody := resolved.(BodyHandle)
+	if !isBody || h.Body != b {
+		t.Errorf("resolved to %#v, want the original BodyHandle", resolved)
+	}
+}
+
 // TestSessionResolveReference covers the session entry point, its no-part guard, and the lazily
 // created highlight-set registry.
 func TestSessionResolveReference(t *testing.T) {

--- a/app/selection.go
+++ b/app/selection.go
@@ -313,9 +313,10 @@ func (s *Selection) First() Selectable {
 }
 
 // References returns, parallel to Items, the work-feature reference for each selected
-// entity — a datum plane/axis/point key, or a face/vertex reference — the string an
-// automation client passes to a work-plane constructor. Entities with no such reference
-// (a body, a sketch entity) yield an empty string, so the slice stays index-aligned.
+// entity — a datum plane/axis/point key, or a face/vertex/body reference — the string an
+// automation client passes to a work-plane constructor or a body-scoped operation. Entities
+// with no such reference (a sketch entity) yield an empty string, so the slice stays
+// index-aligned. A whole-body pick reports a body/<key> reference (#1492).
 func (s *Selection) References() []string {
 	refs := make([]string, len(s.items))
 	for i, it := range s.items {
@@ -337,6 +338,8 @@ func selectionRef(it Selectable) feature.WorkRef {
 		return feature.FaceRef(h.Face.ReferenceKey())
 	case VertexHandle:
 		return feature.VertexRef(h.Vertex.ReferenceKey())
+	case BodyHandle:
+		return feature.BodyRef(h.Body.ReferenceKey())
 	default:
 		return ""
 	}

--- a/model/feature/body_ref_test.go
+++ b/model/feature/body_ref_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "testing"
+
+// TestBodyRefRoundTrips: a body reference key folds into a body/<url-base64> WorkRef and decodes
+// back to the exact bytes, so a picked whole body round-trips through model.selection/model.select
+// (#1492). The encoding uses RawURLEncoding, so a key containing the WorkRef path separator or
+// padding-sensitive bytes survives intact.
+func TestBodyRefRoundTrips(t *testing.T) {
+	key := []byte{0x00, 0x2f, 0x2b, 0xff, 'b', 'o', 'd', 'y'} // includes '/' (0x2f) and '+' (0x2b)
+	ref := BodyRef(key)
+	if got := string(ref); got[:len("body/")] != "body/" {
+		t.Fatalf("BodyRef = %q, want a body/ prefix", got)
+	}
+	back, ok := BodyRefKey(ref)
+	if !ok {
+		t.Fatalf("BodyRefKey(%q) reported not-a-body-ref", ref)
+	}
+	if string(back) != string(key) {
+		t.Errorf("round-trip key = %x, want %x", back, key)
+	}
+}
+
+// TestBodyRefKeyRejectsOtherForms: BodyRefKey must not claim a face/vertex ref or a corrupt
+// payload, so ResolveRefOnBodies dispatches each form to the right finder and never binds a
+// face key as a body.
+func TestBodyRefKeyRejectsOtherForms(t *testing.T) {
+	if _, ok := BodyRefKey(FaceRef([]byte("f"))); ok {
+		t.Error("BodyRefKey accepted a face ref")
+	}
+	if _, ok := BodyRefKey(VertexRef([]byte("v"))); ok {
+		t.Error("BodyRefKey accepted a vertex ref")
+	}
+	if _, ok := BodyRefKey(WorkRef("body/not*base64")); ok {
+		t.Error("BodyRefKey accepted a corrupt base64 payload")
+	}
+}

--- a/model/feature/work_surface_ref.go
+++ b/model/feature/work_surface_ref.go
@@ -108,6 +108,24 @@ func FaceRefKey(ref WorkRef) ([]byte, bool) { return decodeRefKey(string(ref), f
 // VertexRefKey decodes a vertex WorkRef back to its reference key, reporting ok=false otherwise.
 func VertexRefKey(ref WorkRef) ([]byte, bool) { return decodeRefKey(string(ref), vertexRefPrefix) }
 
+// bodyRefPrefix folds a whole-body reference key into a WorkRef so a directly-picked body,
+// like a face or vertex, round-trips through model.selection / model.select (#1492). It shares
+// the "<kind>/<url-base64(key)>" encoding of the face/vertex forms; the body key is the same
+// recompute-stable key surfaced as BodyInfo.Key (api v0.92.1).
+const bodyRefPrefix = "body/"
+
+// BodyRef encodes a B-rep body's reference key (topo.Body.ReferenceKey) as a WorkRef, so a
+// selected body reports a non-empty, resolvable reference in a SelectionResult (#1492).
+//
+//	ref := BodyRef(body.ReferenceKey())
+func BodyRef(key []byte) WorkRef {
+	return WorkRef(bodyRefPrefix + base64.RawURLEncoding.EncodeToString(key))
+}
+
+// BodyRefKey decodes a body WorkRef back to its reference key, reporting ok=false for a ref that
+// is not a body reference (selection resolution round-trips a picked body this way, #1492).
+func BodyRefKey(ref WorkRef) ([]byte, bool) { return decodeRefKey(string(ref), bodyRefPrefix) }
+
 // decodeRefKey strips prefix and base64-decodes the key, reporting ok=false on a prefix mismatch
 // or a malformed payload.
 func decodeRefKey(s, prefix string) ([]byte, bool) {


### PR DESCRIPTION
## What

A whole-body viewport pick now reports a non-empty `body/<url-base64(key)>` reference in the parallel `Refs` slot of a `SelectionResult`, and that reference round-trips through `model.select`.

## Why

`selectionRef` handled work-plane/axis/point, face, and vertex — a `BodyHandle` fell through to `default` and returned `""`. So `model.selection` carried an empty string for a selected body, and an automation client / add-in could not tell **which** body was picked, even though a body already has a persistent, recompute-stable reference key (`BodyInfo.Key`, api v0.92.1).

Found while wiring **Oblikovati.AddIns.CalculiX**: with `BodyInfo.Key` a body is a first-class reference, so an FEA add-in wants to let the user **pick which bodies a study analyses** — today that has to be inferred indirectly by mapping selected *faces* to their owning bodies. A `body/<key>` selection reference lets an add-in read a directly-selected body (scope a study, assign a support/load to a whole body, tag a body) directly and unambiguously.

## How

- `feature.BodyRef` / `BodyRefKey` — the `body/` encoding, mirroring the existing `face/` and `vertex/` forms (URL-safe base64, no `/` collision).
- `selectionRef` returns `feature.BodyRef(h.Body.ReferenceKey())` for a `BodyHandle`.
- `ResolveRefOnBodies` decodes the body form and binds it via a new `findBody` helper — a body is matched by its own `ReferenceKey` (the key names the body itself, not a sub-entity), so `model.select` round-trips it.

Additive and backward-compatible: face/vertex/work refs are unchanged; the previously-empty body slot becomes non-empty. Paired with the contract-doc PR Oblikovati.API#231 (ADR-0018).

## Tests

- `model/feature`: `BodyRef`/`BodyRefKey` round-trip + rejects face/vertex/corrupt forms.
- `app`: a selected body reports the `body/<key>` ref and it resolves back to the same `BodyHandle`.
- `addin/router`: `model.select` of a body over the wire resolves, reports the same non-empty ref, and the `SelectBody` kind.

Closes #1492

🤖 Generated with [Claude Code](https://claude.com/claude-code)