### PR TITLE
feat(brep): snap near-equal crossing cylinders onto exact Steinmetz (#1780 Direction 1)

### DIFF
--- a/kernel/brep/curved_crossing_imprint.go
+++ b/kernel/brep/curved_crossing_imprint.go
@@ -37,10 +37,12 @@ const CodeImprintUnclosedChain diag.Code = "imprint.unclosed-chain"
 // recorded instead of silent.
 const CodeImprintFallbackContour diag.Code = "imprint.fallback-contour"
 
-// CodeImprintNearPinchDeclined marks a crossing-cylinder imprint declined because the radii are
-// near-equal (the near-pinch Steinmetz band): the general rod-band assembly is input-sensitive
-// there, so the boolean takes the deterministic faceted fallback and records the degradation
-// instead of assembling silently wrong analytic topology (#1598; unification tracked by #1403).
+// CodeImprintNearPinchDeclined marks a crossing-cylinder imprint declined in the near-pinch RESIDUAL band —
+// radii unequal by more than the snap ceiling but by less than 2.5e-4·r: the two intersection loops have a
+// resolvable but narrow neck √(2R·Δr), where the general rod-band split/classify is input-sensitive (#1598),
+// so the boolean takes the deterministic faceted fallback and records the degradation instead of assembling
+// silently wrong analytic topology. Radii closer than the snap ceiling do NOT record this — they snap to the
+// exact Steinmetz constructor (#1780); folding this residual band onto the analytic path is #1780 Direction 2.
 const CodeImprintNearPinchDeclined diag.Code = "imprint.near-pinch-declined"
 
 // imprintTraceLoops traces base∩other over window and keeps the loops that close — the shared trace
@@ -71,19 +73,26 @@ func crossingCylinderImprint(a, b *topo.Body, rec *diag.Recorder) ([]geom.Polyli
 	if !okA || !okB {
 		return nil, false
 	}
-	// Near-equal radii approach the pinched Steinmetz configuration: the intersection
-	// loops hug the tangency line with hairpin turns, and the general rod-band
-	// split/classify downstream is input-sensitive there (face count and volume vary
-	// with sampling — observed at |Δr|/r ≤ 5e-5, #1598). Equal radii take the exact
-	// bespoke Steinmetz constructor; the near-equal band between declines the general
-	// path so the boolean falls back to the recorded, deterministic faceted route
-	// instead of assembling silently wrong analytic topology (#1403 tracks unifying it).
-	if relDr := stdmath.Abs(ca.Radius-cb.Radius) / stdmath.Max(ca.Radius, cb.Radius); relDr > 0 && relDr < 2.5e-4 {
-		rec.Recordf(CodeImprintNearPinchDeclined, diag.Defect,
-			"crossing cylinders with near-equal radii (|Δr|/r = %.2g) decline the general imprint: near-pinch saddle topology, falling back", relDr)
-		return nil, false
-	}
 	res := geom.ResolutionForBox(a.RangeBox().Union(b.RangeBox())) // model-relative loop-closure weld (#1399)
+	// Unequal radii near the pinched Steinmetz configuration split into two bands by the neck √(2R·Δr):
+	//   |Δr| ≤ snap ceiling  → the neck is below the SSI producer noise floor; the exact Steinmetz
+	//     constructor snaps the radii to their mean and builds the pinched bicylinder (#1780). Decline the
+	//     rod-band path SILENTLY so dispatch falls through to it — there is no degradation to record.
+	//   snap ceiling < |Δr| < 2.5e-4·r  → a resolvable but narrow neck where the general rod-band
+	//     split/classify is input-sensitive (face count and volume vary with sampling, #1598): record the
+	//     degradation and fall back to the deterministic faceted route (unifying this band is #1780 Direction 2).
+	// Exactly-equal radii (|Δr| = 0) are the Steinmetz pinch itself and trace through (both ellipse loops).
+	if ca.Radius != cb.Radius {
+		dr := stdmath.Abs(ca.Radius - cb.Radius)
+		if dr <= steinmetzSnapCeiling(res) {
+			return nil, false
+		}
+		if relDr := dr / stdmath.Max(ca.Radius, cb.Radius); relDr < 2.5e-4 {
+			rec.Recordf(CodeImprintNearPinchDeclined, diag.Defect,
+				"crossing cylinders with near-equal radii (|Δr|/r = %.2g) decline the general imprint: near-pinch saddle topology, falling back", relDr)
+			return nil, false
+		}
+	}
 	loops := imprintTraceLoops(ca, cb, cylinderTraceWindow(ca, baseA, heightA), res, rec)
 	if len(loops) == 0 {
 		return nil, false

--- a/kernel/brep/curved_crossing_imprint_test.go
+++ b/kernel/brep/curved_crossing_imprint_test.go
@@ -169,6 +169,40 @@ func TestCrossingCylinderImprintSquatFat(t *testing.T) {
 	}
 }
 
+// TestCrossingCylinderImprintSnapBandSilent: radii closer than the snap ceiling decline the rod-band imprint
+// (so dispatch falls through to the exact Steinmetz constructor, which snaps them — #1780) WITHOUT recording a
+// degradation. The snap is honest, not a fallback, so it must raise no near-pinch defect.
+func TestCrossingCylinderImprintSnapBandSilent(t *testing.T) {
+	a, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 3, 12)
+	base, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	ceil := geom.ResolutionForBox(a.RangeBox().Union(base.RangeBox())).Stitch()
+	b, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3+0.5*ceil, 12)
+	rec := &diag.Recorder{}
+	if _, ok := crossingCylinderImprint(a, b, rec); ok {
+		t.Fatal("snap-band radii must decline the rod-band imprint (Steinmetz snaps instead)")
+	}
+	if rec.Count(diag.Defect) != 0 || rec.Has(CodeImprintNearPinchDeclined) {
+		t.Errorf("snap-band decline must be SILENT (no degradation to record); got %v", rec.Records())
+	}
+}
+
+// TestCrossingCylinderImprintResidualBandRecords: radii ABOVE the snap ceiling but inside the near-pinch band
+// decline AND record exactly one CodeImprintNearPinchDeclined defect — the genuine, non-silent fallback the
+// residual band still takes until #1780 Direction 2 folds it onto the analytic path.
+func TestCrossingCylinderImprintResidualBandRecords(t *testing.T) {
+	a, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 3, 12)
+	base, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	ceil := geom.ResolutionForBox(a.RangeBox().Union(base.RangeBox())).Stitch()
+	b, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3+4*ceil, 12)
+	rec := &diag.Recorder{}
+	if _, ok := crossingCylinderImprint(a, b, rec); ok {
+		t.Fatal("residual-band radii must decline the rod-band imprint")
+	}
+	if !rec.Has(CodeImprintNearPinchDeclined) || rec.Count(diag.Defect) != 1 {
+		t.Errorf("residual-band decline must record exactly one near-pinch defect; got %v", rec.Records())
+	}
+}
+
 // TestKeepImprintLoopsRecordsFallbackContour: curves whose provenance is the marching-squares fallback
 // must raise CodeImprintFallbackContour — the imprint proceeds on contour-quality loops, but the
 // degradation is recorded instead of silent (#1597).

--- a/kernel/brep/curved_steinmetz.go
+++ b/kernel/brep/curved_steinmetz.go
@@ -26,28 +26,59 @@ import (
 // β=±α. The two intersection ellipses therefore lie in the planes β=α and β=−α; they meet only where
 // α=β=0, i.e. at the PINCH points O±R·n, where the two surfaces are tangent.
 
+// steinmetzSnapCeiling is the radius gap |Δr| below which two near-equal perpendicular crossing cylinders
+// snap to a common radius and take the exact bicylinder constructor (#1780). It is the model-relative stitch
+// weld (1e-6·size), the SSI producer's OWN noise floor: below it the two-loop neck the general rod-band path
+// would otherwise build has closest-approach √(2R·Δr) that is itself unresolvable, so representing the
+// near-pinch as the exact pinch is honest, not a loss — the only error is each wall displaced by ≤|Δr|/2,
+// well under the weld. ABOVE it the neck is macroscopic, genuine two-loop geometry that must NOT snap (that
+// residual band stays with the deterministic faceted route; unifying it analytically is #1780 Direction 2).
+// It is deliberately the same value both steinmetzFrame (accept) and crossingCylinderImprint (decline) read,
+// so the two paths meet at exactly one radius gap with neither a hole nor an overlap between them.
+func steinmetzSnapCeiling(res geom.Resolution) float64 { return res.Stitch() }
+
+// steinmetzSnapRadius returns the common radius two crossing cylinders snap to and whether they are close
+// enough to snap (|Δr| ≤ steinmetzSnapCeiling). The common radius is the MEAN, which minimises the maximum
+// wall displacement to |Δr|/2 (min/max would move one wall by the full |Δr|); the snap is symmetric because
+// both operands are rebuilt at the common radius, so no operation-aware bias is needed — crossing cylinders
+// meet transversally, never near-tangentially, so a sub-noise radius nudge cannot open a sliver (#1780).
+// Δr is formed directly as ra−rb, never via ra²−rb², which would square the floating-point cancellation.
+func steinmetzSnapRadius(ra, rb float64, res geom.Resolution) (radius float64, ok bool) {
+	if stdmath.Abs(ra-rb) > steinmetzSnapCeiling(res) {
+		return 0, false
+	}
+	return (ra + rb) / 2, true
+}
+
 // steinmetzFrame resolves two bodies into the Steinmetz frame: the axis crossing point O, the two unit axis
-// directions, and the shared radius R. ok=false unless both are bare cylinders of equal radius whose axes
-// are perpendicular, cross, and whose finite extents each reach at least R either side of O (so the
-// bicylinder is not clipped by a cap).
+// directions, and the common radius R the bicylinder is built at. ok=false unless both are bare cylinders
+// whose radii are within steinmetzSnapCeiling (equal, or near-equal and snapped to their mean — #1780) and
+// whose axes are perpendicular, cross, and whose finite extents each reach at least R either side of O (so
+// the bicylinder is not clipped by a cap).
 func steinmetzFrame(a, b *topo.Body) (o math.Point3, dirA, dirB math.Vector3, r float64, ok bool) {
 	ca, baseA, hA, okA := cylinderSolidParams(facesOfAny(a))
 	cb, baseB, hB, okB := cylinderSolidParams(facesOfAny(b))
-	if !okA || !okB || !nearEqual(ca.Radius, cb.Radius) {
+	if !okA || !okB {
+		return math.Point3{}, math.Vector3{}, math.Vector3{}, 0, false
+	}
+	// Axis-intersection coincidence and the radius-snap ceiling are both model-relative (#1399/#1780),
+	// from the two operands' combined extent.
+	res := geom.ResolutionForBox(a.RangeBox().Union(b.RangeBox()))
+	rc, snap := steinmetzSnapRadius(ca.Radius, cb.Radius, res)
+	if !snap {
 		return math.Point3{}, math.Vector3{}, math.Vector3{}, 0, false
 	}
 	dirA, dirB = ca.AxisDir.AsVector(), cb.AxisDir.AsVector()
-	if !math.IsNearZero(dirA.Dot(dirB), 1e-7) { // tol:angular — perpendicular-axes dot of unit vectors
+	if !math.IsNearZero(dirA.Dot(dirB), 1e-7) { // tol:angular — perpendicular gate, kept isolated from the radius snap (#1780)
 		return math.Point3{}, math.Vector3{}, math.Vector3{}, 0, false
 	}
 	lineA, _ := geom.NewLine(ca.Origin, dirA)
 	lineB, _ := geom.NewLine(cb.Origin, dirB)
-	// Axis-intersection coincidence is model-relative (#1399), from the two operands' extent.
-	o, ok = geom.LineLineIntersection(lineA, lineB, geom.ResolutionForBox(a.RangeBox().Union(b.RangeBox())).Plane())
+	o, ok = geom.LineLineIntersection(lineA, lineB, res.Plane())
 	if !ok || !axisReachesR(ca, baseA, hA, o) || !axisReachesR(cb, baseB, hB, o) {
 		return math.Point3{}, math.Vector3{}, math.Vector3{}, 0, false
 	}
-	return o, dirA, dirB, ca.Radius, true
+	return o, dirA, dirB, rc, true
 }
 
 // axisReachesR reports whether the cylinder's finite extent reaches at least its radius either side of O

--- a/kernel/brep/curved_steinmetz_general.go
+++ b/kernel/brep/curved_steinmetz_general.go
@@ -122,6 +122,13 @@ func steinmetzGeneral(a, b *topo.Body, op Op,
 	if !okA || !okB || !okMA || !okMB {
 		return nil, false
 	}
+	// Route the common (snapped) radius into BOTH wall surfaces so they are built self-consistent with the
+	// r-radius imprint arcs (#1780). trimByImprint emits each kept lobe/band face ON this geom.Cylinder, so
+	// equal walls and equal arcs weld exactly at the two shared pinches; patching only the arcs would leave a
+	// |Δr|-scale gap between an arc and the wall it bounds. For exactly-equal radii r is unchanged and this is
+	// a no-op. Membership (insideA/insideB) keeps the true radii — it classifies cell-interior points O(R)
+	// from any wall, where a ≤|Δr|/2 boundary shift cannot flip a cell.
+	cylA.Radius, cylB.Radius = r, r
 	arcs := steinmetzImprintArcs(o, dirA, dirB, r)
 	pinch := o.TranslateBy(dirA.Cross(dirB).Scale(math.Scalar(r))) // P+ = O + R·n, a shared pinch point
 	wallA, okWA := steinmetzSideSplit(fA, cylA, bandA, arcs, pinch, op, false, insideB)

--- a/kernel/brep/curved_steinmetz_general_test.go
+++ b/kernel/brep/curved_steinmetz_general_test.go
@@ -3,6 +3,7 @@
 package brep
 
 import (
+	stdmath "math"
 	"testing"
 
 	"oblikovati.org/kernel/geom"
@@ -87,6 +88,59 @@ func TestSteinmetzGeneralDeclinesUnequalRadius(t *testing.T) {
 	cz, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
 	if _, ok := SteinmetzIntersectGeneral(cx, cz, nil); ok {
 		t.Error("general Steinmetz must decline unequal radii (ok=false)")
+	}
+}
+
+// nearEqualSteinmetz builds the canonical perpendicular pair with the z-axis cylinder's radius offset by dr
+// from the x-axis cylinder's radius 3 — the near-pinch band the snap targets (#1780).
+func nearEqualSteinmetz(dr float64) (cx, cz *topo.Body) {
+	cx, _ = SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 3, 12)
+	cz, _ = SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3+dr, 12)
+	return cx, cz
+}
+
+// TestSteinmetzIntersectGeneralNearEqualSnaps pins the #1780 snap: cylinders whose radii differ by less than
+// the model-relative ceiling build the SAME watertight four-face bicylinder as the exactly-equal case, and —
+// the load-bearing check — EVERY wall face carries the snapped MEAN radius, not either operand's true radius.
+// If the snap routed only into the imprint arcs and left the walls at their true radii, the two z-cylinder
+// lobes would report 3+dr and this fails: it is the regression guard for the holistic-routing pitfall.
+func TestSteinmetzIntersectGeneralNearEqualSnaps(t *testing.T) {
+	cx, cz := nearEqualSteinmetz(0)
+	ceil := geom.ResolutionForBox(cx.RangeBox().Union(cz.RangeBox())).Stitch()
+	dr := 0.5 * ceil // strictly within the snap ceiling
+	cx, cz = nearEqualSteinmetz(dr)
+
+	body, ok := SteinmetzIntersectGeneral(cx, cz, nil)
+	if !ok {
+		t.Fatalf("near-equal (|Δr|=%.3g ≤ ceiling %.3g) must snap and build the bicylinder", dr, ceil)
+	}
+	if !body.IsSolid() || len(body.Faces()) != 4 || len(body.Edges()) != 4 || len(body.Vertices()) != 2 {
+		t.Fatalf("snapped topology F/E/V = %d/%d/%d, want 4/4/2 (identical to the equal case)",
+			len(body.Faces()), len(body.Edges()), len(body.Vertices()))
+	}
+	wantR := 3 + dr/2 // the mean; both walls AND arcs must be rebuilt here
+	for _, f := range body.Faces() {
+		cyl, isCyl := f.Geometry().(geom.Cylinder)
+		if !isCyl {
+			t.Errorf("face %T is not a cylinder", f.Geometry())
+			continue
+		}
+		if d := stdmath.Abs(cyl.Radius - wantR); d > 1e-12 {
+			t.Errorf("wall radius %.12f, want the mean %.12f — a wall left at a true radius means only the arcs snapped", cyl.Radius, wantR)
+		}
+	}
+}
+
+// TestSteinmetzGeneralDeclinesResidualBand pins that a radius gap ABOVE the snap ceiling (but still inside the
+// near-pinch band, |Δr| < 2.5e-4·r) is NOT snapped: the neck √(2R·Δr) is resolvable two-loop geometry, so the
+// general Steinmetz path declines and the boolean keeps the deterministic faceted route (#1780 Direction 2).
+func TestSteinmetzGeneralDeclinesResidualBand(t *testing.T) {
+	cx, cz := nearEqualSteinmetz(0)
+	ceil := geom.ResolutionForBox(cx.RangeBox().Union(cz.RangeBox())).Stitch()
+	dr := 4 * ceil // above the ceiling, still ≪ 2.5e-4·3
+	cx, cz = nearEqualSteinmetz(dr)
+	if _, ok := SteinmetzIntersectGeneral(cx, cz, nil); ok {
+		t.Errorf("residual band (|Δr|=%.3g > ceiling %.3g) must decline the snap (ok=false)", dr, ceil)
 	}
 }
 

--- a/kernel/ops/boolean_crossing_cylinder_test.go
+++ b/kernel/ops/boolean_crossing_cylinder_test.go
@@ -385,6 +385,62 @@ func TestBooleanJoinEqualRadiusSteinmetz(t *testing.T) {
 	}
 }
 
+// TestBooleanIntersectNearPinchContinuity sweeps the z-cylinder's radius across the near-pinch snap ceiling
+// (#1780) and pins two things. (1) BELOW the ceiling the snap produces a clean watertight analytic bicylinder
+// — the four-face, manifold, 16/3·R³ solid — where before #1780 the same input fell to the faceted route and
+// came out NON-manifold; the snap is a watertightness win, not just smoothness. (2) Volume is CONTINUOUS
+// across the ceiling: the snapped exact bicylinder (below) and the deterministic faceted fallback (above)
+// both track the analytic crossing-intersection volume to the faceting budget, so crossing the ceiling is no
+// volume jump — the true B-rep step is O(Δr·R²), well under 1e-3 here. This is the guard the old silent
+// fallback lacked (it would show as a VOLUME step). The residual band above the ceiling is still the faceted,
+// non-manifold route — folding it onto the analytic path is #1780 Direction 2 — so watertightness is asserted
+// only where the snap owns the result.
+func TestBooleanIntersectNearPinchContinuity(t *testing.T) {
+	const r = 3.0
+	baseX, _ := brep.SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), r, 12)
+	baseZ, _ := brep.SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), r, 12)
+	ceil := geom.ResolutionForBox(baseX.RangeBox().Union(baseZ.RangeBox())).Stitch()
+
+	// δ straddling the ceiling: 0, 0.4·ceil, 0.9·ceil snap (exact bicylinder); 2·ceil, 6·ceil fall to the
+	// faceted route (still ≪ 2.5e-4·r, so the near-pinch band, not a clean crossing).
+	type sample struct {
+		d       float64
+		snapped bool // within the ceiling: the exact analytic bicylinder the snap owns
+	}
+	samples := []sample{{0, true}, {0.4 * ceil, true}, {0.9 * ceil, true}, {2 * ceil, false}, {6 * ceil, false}}
+	vols := make([]float64, len(samples))
+	for i, s := range samples {
+		cx, _ := brep.SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), r, 12)
+		cz, _ := brep.SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), r+s.d, 12)
+		res, err := ops.Boolean(ops.Intersect, cx, cz)
+		if err != nil {
+			t.Fatalf("δ=%.3g: Boolean(Intersect): %v", s.d, err)
+		}
+		if s.snapped {
+			if v := ops.Validate(res); !v.Valid || !v.Closed || !v.Manifold || !res.IsSolid() {
+				t.Fatalf("δ=%.3g (snap band): must be a valid closed manifold solid, got %+v", s.d, v)
+			}
+			if n := len(res.Faces()); n != 4 {
+				t.Errorf("δ=%.3g (snap band): %d faces, want the four-lobe bicylinder", s.d, n)
+			}
+		}
+		got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+		want := crossingIntersectVolume(r, r+s.d)
+		if rel := stdmath.Abs(got-want) / want; rel > 0.04 {
+			t.Errorf("δ=%.3g: volume %.4f, want %.4f (analytic) — rel %.4f > 4%%", s.d, got, want, rel)
+		}
+		vols[i] = got
+	}
+	// Volume continuity: no sample departs from the equal-radius baseline by more than the faceting budget, so
+	// the ceiling is not a volume discontinuity (the ~1.6% snap→faceted change is meshing noise — inscribed
+	// four-lobe vs CSG facets — not a geometry step; both B-reps are ~16/3·R³).
+	for i, v := range vols {
+		if rel := stdmath.Abs(v-vols[0]) / vols[0]; rel > 0.04 {
+			t.Errorf("δ=%.3g volume %.4f jumped %.4f from the equal-radius baseline %.4f — a step across the snap ceiling", samples[i].d, v, rel, vols[0])
+		}
+	}
+}
+
 // TestBooleanIntersectEqualRadiusDefersFromExactPath: two EQUAL-radius perpendicular cylinders are the
 // Steinmetz case — its bicylinder pinches into four lobes, which the general crossing-intersect path cannot
 // emit as a clean watertight solid. The path must therefore NOT be adopted (validBooleanSolid rejects it),

--- a/kernel/ops/near_pinch_mesh_test.go
+++ b/kernel/ops/near_pinch_mesh_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// TestNearPinchSnapMeshWatertight pins the tessellation-correctness gate — the mesh the user actually sees.
+// Two crossing cylinders whose radii differ by less than the snap ceiling (#1780) intersect to a bicylinder
+// whose TESSELLATED mesh is watertight (0 free edges): the snap produces a clean closed surface, where the
+// SAME input took the non-manifold ~6300-face faceted fallback before #1780. This is the mesh-level companion
+// to the B-rep-level Validate checks in boolean_crossing_cylinder_test.go.
+func TestNearPinchSnapMeshWatertight(t *testing.T) {
+	const r = 3.0
+	bx, _ := brep.SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), r, 12)
+	bz, _ := brep.SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), r, 12)
+	dr := 0.5 * geom.ResolutionForBox(bx.RangeBox().Union(bz.RangeBox())).Stitch() // within the snap ceiling
+
+	cx, _ := brep.SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), r, 12)
+	cz, _ := brep.SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), r+dr, 12)
+	res, err := Boolean(Intersect, cx, cz)
+	if err != nil {
+		t.Fatalf("Boolean(Intersect near-equal): %v", err)
+	}
+	m, _ := TessellateBody(res, DefaultQuality())
+	if free := freeEdgeCount(m); free != 0 {
+		t.Errorf("snapped near-equal bicylinder meshed with %d free edges; want 0 (watertight surface)", free)
+	}
+}


### PR DESCRIPTION
## What

Two perpendicular crossing cylinders whose radii differ by less than the model-relative **stitch weld** (`1e-6·size`) now snap to their mean radius and build the exact four-face analytic **Steinmetz bicylinder**, instead of declining to the faceted CSG route. This is **Direction 1** of #1780 — the bounded snap. The outer near-pinch band is split to #1781 (Direction 2).

## Why

Subtracting the two on-surface equations in the Steinmetz frame gives `β² − α² = R_a²−R_b² ≈ 2R·Δr`, so the true intersection of near-equal cylinders is **two loops** whose neck (closest approach) is `√(2R·Δr)` — not a pinched figure-eight. Snapping rebuilds both walls at a common radius and replaces those two loops with the exact pinch; the only error is each wall displaced by `≤|Δr|/2`.

That is honest **only while the neck is below the SSI producer's own noise floor** — the stitch weld `1e-6·size`. Below it the would-be neck is unresolvable, so representing the near-pinch as the exact pinch loses nothing. **Above** it the neck is macroscopic (up to ~2% of the model at the band top `|Δr|/r = 2.5e-4`) — genuine two-loop geometry that must **not** snap. The ceiling is ~60× tighter than the band top, so this closes only the innermost sub-band; the rest is #1781.

This corrects the original #1780 premise ("unify the whole `2.5e-4` band onto exact Steinmetz"), which the geometry-math review found geometrically unsound (snapping a resolvable neck to a pinch is a topological lie, not a tolerance nudge).

**Bonus:** below the ceiling the pre-existing faceted fallback produced **non-manifold** output (~6300-face CSG with sliver edges); the snap replaces it with a watertight analytic solid — a correctness win, not just smoothness.

## How (key choices)

- `steinmetzSnapCeiling(res) = res.Stitch()` — one ceiling both the accept gate (`steinmetzFrame`) and the decline gate (`crossingCylinderImprint`) read, so they meet at exactly one radius gap.
- **Mean** common radius (minimises max wall displacement to `|Δr|/2`); `Δr` formed directly, never via `R_a²−R_b²` (which squares the cancellation); symmetric, **not** operation-aware — crossing cylinders meet transversally, never near-tangentially, so a sub-noise nudge cannot open a sliver.
- The mean radius routes into **both** the imprint arcs **and** the wall surfaces (`steinmetzGeneral`) so they weld self-consistently at the shared pinches; patching only the arcs would leave a `|Δr|`-scale gap.
- Perpendicularity gate kept isolated from the radius snap.
- The near-pinch decline records `CodeImprintNearPinchDeclined` **only** in the residual band; the snap band declines silently (Steinmetz handles it cleanly).

## Tests

- `TestSteinmetzIntersectGeneralNearEqualSnaps` — walls carry the **mean**, not either true radius (the holistic-routing guard: proves walls snap WITH the arcs).
- `TestSteinmetzGeneralDeclinesResidualBand` — above the ceiling declines.
- `TestCrossingCylinderImprintSnapBandSilent` / `…ResidualBandRecords` — silent below ceiling, exactly one recorded defect above.
- `TestBooleanIntersectNearPinchContinuity` — end-to-end sweep straddling the ceiling: watertight + 4-face on the snap band, volume continuous vs the analytic crossing-intersection oracle (equal limit `16R³/3`) across the whole sweep.
- `TestNearPinchSnapMeshWatertight` — the **tessellated mesh** has 0 free edges (the surface the user sees).

Full `kernel/brep` + `kernel/ops` suites green, `golangci-lint` 0 issues, build-all + downstream `model` green.

## Live visual pass

The MCP bridge was not connected in this session, so a live screenshot pass was not run here. The snapped B-rep is topologically identical to the already-live-verified equal-radius Steinmetz bicylinder (4 analytic cylinder faces), and mesh watertightness is asserted directly. Happy to run a live confirmation against a running instance if wanted.

Closes #1780. Follow-up: #1781 (Direction 2 — the residual band).
