### PR TITLE
fix: sketch dimension / parameter bare number multiplied by 10 (units-aware authoring seam)

### DIFF
--- a/addin/router/parameters.go
+++ b/addin/router/parameters.go
@@ -66,10 +66,14 @@ func setParameter(s *app.Session, holder compdef.ParameterHolder, in wire.Parame
 	if !ok {
 		return wire.ParameterInfo{}, errors.New("parameters.set: no parameter named " + in.Name)
 	}
+	// A bare number means the parameter's own display unit (7 → 7 mm for a Length parameter),
+	// not the raw database unit — qualify before setting, matching the dimension/feature paths
+	// and the head, so the wire and UI resolve typed values identically (#1783).
+	expr := p.QualifyAuthored(in.Expression, p.Unit(), holder.Units())
 	// Edit through the Parameters graph (not p.SetExpression, which only updates
 	// this parameter): the graph rewires edges and recomputes transitive
 	// dependents, so a dimension like "od/2" follows when od changes.
-	if err := holder.Parameters().SetExpression(p.ID(), in.Expression); err != nil {
+	if err := holder.Parameters().SetExpression(p.ID(), expr); err != nil {
 		return wire.ParameterInfo{}, err
 	}
 	// A parameter edit can change any feature's live inputs (sketch dimensions,

--- a/app/parameters_edit.go
+++ b/app/parameters_edit.go
@@ -45,6 +45,7 @@ func (s *Session) SetParameterName(id param.ID, name string) error {
 // SetParameterEquation sets a parameter's equation: an expression for numeric parameters
 // (a list choice when multi-value), or the literal for text parameters.
 func (s *Session) SetParameterEquation(id param.ID, equation string) error {
+	units := s.DocumentUnits()
 	return s.editParam(id, func(p *param.Parameter) error {
 		if p.IsMultiValue() {
 			return p.SelectValue(equation)
@@ -52,7 +53,9 @@ func (s *Session) SetParameterEquation(id param.ID, equation string) error {
 		if p.IsText() {
 			return p.SetText(equation)
 		}
-		return p.SetExpression(equation)
+		// A bare number means the parameter's own display unit (7 → 7 mm for a Length
+		// parameter), never the raw database unit — qualify before the raw setter (#1783).
+		return p.SetExpression(p.QualifyAuthored(equation, p.Unit(), units))
 	})
 }
 

--- a/app/sketch_dimension_edit.go
+++ b/app/sketch_dimension_edit.go
@@ -5,6 +5,7 @@ package app
 import (
 	"errors"
 
+	"oblikovati.org/model/param"
 	"oblikovati.org/model/sketch"
 )
 
@@ -40,7 +41,11 @@ func (s *Session) CommitPendingDimension(expression string) error {
 	if s.pendingDim == nil {
 		return errors.New("app: no dimension is being edited")
 	}
-	if err := s.pendingDim.Parameter().SetExpression(expression); err != nil {
+	// A bare number typed here means the document's display unit (7 → 7 mm), not the raw
+	// database unit — qualify before the raw setter, or every unitless value inflates 10× (#1783).
+	p := s.pendingDim.Parameter()
+	qualified := p.QualifyAuthored(expression, dimensionCategory(s.pendingDim.Kind()), s.DocumentUnits())
+	if err := p.SetExpression(qualified); err != nil {
 		return err
 	}
 	s.pendingDim = nil
@@ -54,3 +59,15 @@ func (s *Session) CommitPendingDimension(expression string) error {
 // CancelPendingDimension dismisses the edit box, keeping the dimension at its current
 // (measured) value — Inventor accepts the placed dimension when you cancel the edit.
 func (s *Session) CancelPendingDimension() { s.pendingDim = nil }
+
+// dimensionCategory is the unit category a dimension kind's value is authored in — Angle for the
+// angular dimensions, Length for every distance/radius/arc-length kind — so a bare number is
+// qualified with the right document display unit (#1783).
+func dimensionCategory(k sketch.DimKind) param.Unit {
+	switch k {
+	case sketch.AngleDim, sketch.ThreePointAngleDim:
+		return param.Angle
+	default:
+		return param.Length
+	}
+}

--- a/app/sketch_dimension_edit_test.go
+++ b/app/sketch_dimension_edit_test.go
@@ -47,6 +47,25 @@ func TestCommitPendingDimensionDrivesGeometry(t *testing.T) {
 	}
 }
 
+// TestCommitBareNumberUsesDocumentUnit is the regression for the "×10 dimension" bug: a bare
+// number typed into the value box means the document's display unit (7 → 7 mm), not the raw
+// database unit (which would drive 7 cm = 70 mm). The default document is millimetres (#1783).
+func TestCommitBareNumberUsesDocumentUnit(t *testing.T) {
+	s, sk := sketchSession(t)
+	a := sk.Points().Add(math.P2(0, 0))
+	b := sk.Points().Add(math.P2(3, 0)) // 3 cm apart
+	s.StartTool(newDimensionTool())
+	s.feedPick(SketchEntityHandle{Entity: a})
+	s.feedPick(SketchEntityHandle{Entity: b})
+	if err := s.CommitPendingDimension("7"); err != nil { // bare "7" → 7 mm, not 7 cm
+		t.Fatalf("CommitPendingDimension(\"7\"): %v", err)
+	}
+	// 7 mm = 0.7 cm: the solver drives the points to 0.7 db-units apart, NOT 7.
+	if d := a.Position().DistanceTo(b.Position()); d < 0.699 || d > 0.701 {
+		t.Errorf("bare \"7\" drove the points %.4f cm apart, want ~0.7 (7 mm); ~7 means the ×10 bug", d)
+	}
+}
+
 func TestCommitInvalidExpressionKeepsPending(t *testing.T) {
 	s, sk := sketchSession(t)
 	placeDistanceDim(t, s, sk, math.P2(0, 0), math.P2(3, 0))

--- a/model/param/authored_expression.go
+++ b/model/param/authored_expression.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package param
+
+import (
+	"strconv"
+	"strings"
+)
+
+// User-authored expressions must be interpreted in the DOCUMENT'S display unit, never the raw
+// database unit. A bare number typed into a dimension/parameter field means the displayed unit —
+// "7" in a millimetre document is 7 mm (0.7 cm database), NOT 7 database units (7 cm = 70 mm).
+// The expression grammar makes a bare number Unitless (expr_parser.go), and a Unitless value
+// consumed by a Length/Angle parameter is taken as the database unit, so raw SetExpression on
+// user input inflates every bare number by the db/display factor (10× for a mm document). Every
+// path that receives a typed expression MUST pass it through QualifyAuthored first; raw
+// SetExpression is reserved for deserialised or already-unit-bearing source.
+
+// QualifyAuthored returns src rewritten so a bare/unitless value is expressed in units' preferred
+// unit for cat, leaving an already-dimensioned value or a parameter-referencing formula untouched
+// so it stays live. It is the units-aware seam every user-input path runs a typed expression
+// through before SetExpression (see the package note above).
+//
+//	p.QualifyAuthored("7", Length, mmUnits)        // → "7 mm"      (0.7 cm database)
+//	p.QualifyAuthored("3*2", Length, mmUnits)      // → "(3*2) * 1 mm"
+//	p.QualifyAuthored("7 mm", Length, mmUnits)     // → "7 mm"      (already dimensioned)
+//	p.QualifyAuthored("width/2", Length, mmUnits)  // → "width/2"   (formula, kept live)
+func (p *Parameter) QualifyAuthored(src string, cat Unit, units UnitsOfMeasure) string {
+	if cat == Unitless {
+		return src // a unitless field takes the bare number as-is
+	}
+	unit := units.PreferredName(cat)
+	if unit == "" {
+		return src // category has no configured display unit — nothing to attach
+	}
+	q, err := p.evalAuthored(src)
+	if err != nil || q.Unit != Unitless {
+		// A parse error, an unresolved reference, or an already-dimensioned result: leave src
+		// untouched so a formula stays live and the downstream parser reports any real error.
+		return src
+	}
+	if isLoneNumber(src) {
+		return strings.TrimSpace(src) + " " + unit
+	}
+	// A compound unitless expression ("3*2", "1/8"): multiply by one display unit so the whole
+	// expression carries the category's dimension. Parenthesised to keep operator precedence.
+	return "(" + strings.TrimSpace(src) + ") * 1 " + unit
+}
+
+// evalAuthored evaluates src to learn its dimension: against the owning parameter table (so
+// formulas and references resolve) when the parameter belongs to one, else as a constant.
+func (p *Parameter) evalAuthored(src string) (Quantity, error) {
+	if p.owner != nil {
+		return p.owner.EvaluateExpression(src)
+	}
+	e, err := Parse(src)
+	if err != nil {
+		return Quantity{}, err
+	}
+	return e.Eval(nil)
+}
+
+// isLoneNumber reports whether src is a single numeric literal with no unit or operator, so it can
+// be qualified by appending the unit name directly ("7" → "7 mm") rather than the multiply form.
+func isLoneNumber(src string) bool {
+	_, err := strconv.ParseFloat(strings.TrimSpace(src), 64)
+	return err == nil
+}

--- a/model/param/authored_expression_test.go
+++ b/model/param/authored_expression_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package param
+
+import "testing"
+
+// mmDoc is a millimetre-length document (the default), where the database unit is the centimetre,
+// so a bare "7" authored for a Length field must resolve to 7 mm = 0.7 cm, not 7 cm.
+func mmDoc() UnitsOfMeasure { return DefaultUnitsOfMeasure() }
+
+func TestQualifyAuthoredBareNumberGetsDisplayUnit(t *testing.T) {
+	ps := NewParameters()
+	p, err := ps.AddUserParameter("d0", "10 mm")
+	if err != nil {
+		t.Fatalf("AddUserParameter: %v", err)
+	}
+	cases := []struct{ src, want string }{
+		{"7", "7 mm"},           // the reported bug: a lone bare number
+		{" 7 ", "7 mm"},         // surrounding whitespace trimmed
+		{"3*2", "(3*2) * 1 mm"}, // compound unitless expression
+		{"7 mm", "7 mm"},        // already unit-bearing — untouched
+		{"1 cm", "1 cm"},        // a different length unit — untouched (still Length)
+		{"d0/2", "d0/2"},        // formula resolving to Length — kept live, untouched
+	}
+	for _, c := range cases {
+		if got := p.QualifyAuthored(c.src, Length, mmDoc()); got != c.want {
+			t.Errorf("QualifyAuthored(%q, Length) = %q, want %q", c.src, got, c.want)
+		}
+	}
+}
+
+// TestQualifyAuthoredBareNumberResolvesToDisplayValue is the end-to-end proof: a bare "7" set on a
+// Length parameter through the seam evaluates to 0.7 cm (7 mm), where raw SetExpression gives 7 cm.
+func TestQualifyAuthoredBareNumberResolvesToDisplayValue(t *testing.T) {
+	ps := NewParameters()
+	p, _ := ps.AddUserParameter("d0", "10 mm")
+
+	if err := p.SetExpression(p.QualifyAuthored("7", Length, mmDoc())); err != nil {
+		t.Fatalf("SetExpression(qualified): %v", err)
+	}
+	if got := p.Value(); got.Unit != Length || got.Value < 0.6999 || got.Value > 0.7001 {
+		t.Errorf("bare \"7\" resolved to %+v, want {0.7 Length} (7 mm)", got)
+	}
+
+	// The compound form round-trips through the parser to the same 6 mm = 0.6 cm.
+	if err := p.SetExpression(p.QualifyAuthored("3*2", Length, mmDoc())); err != nil {
+		t.Fatalf("SetExpression(compound): %v", err)
+	}
+	if got := p.Value(); got.Unit != Length || got.Value < 0.5999 || got.Value > 0.6001 {
+		t.Errorf("\"3*2\" resolved to %+v, want {0.6 Length} (6 mm)", got)
+	}
+}
+
+func TestQualifyAuthoredAngleAndUnitlessCategory(t *testing.T) {
+	ps := NewParameters()
+	p, _ := ps.AddUserParameter("a0", "30 deg")
+
+	if got := p.QualifyAuthored("45", Angle, mmDoc()); got != "45 deg" {
+		t.Errorf("QualifyAuthored(\"45\", Angle) = %q, want %q", got, "45 deg")
+	}
+	// A unitless target category takes the bare number verbatim (no unit to attach).
+	if got := p.QualifyAuthored("5", Unitless, mmDoc()); got != "5" {
+		t.Errorf("QualifyAuthored(\"5\", Unitless) = %q, want %q", got, "5")
+	}
+}

--- a/model/param/parameter.go
+++ b/model/param/parameter.go
@@ -195,6 +195,12 @@ func (p *Parameter) SetTolerance(t Tolerance) { p.tol = t }
 // SetExpression replaces the expression and re-evaluates if it is constant. A
 // reference-bearing expression is left OutOfDate for the graph to recompute. It
 // errors for read-only kinds and for malformed source.
+//
+// This is the RAW setter: it takes src verbatim, so a bare number is Unitless and a
+// Length/Angle parameter consumes it as the database unit. USER-typed input must first go
+// through [Parameter.QualifyAuthored] (see authored_expression.go), which expresses a bare
+// number in the document's display unit; raw SetExpression is only for deserialised or
+// already-unit-bearing source.
 func (p *Parameter) SetExpression(src string) error {
 	if !p.kind.Editable() {
 		return fmt.Errorf(errReadOnly, p.kind, p.name)


### PR DESCRIPTION
Closes #1783.

## What
A bare number typed into a sketch dimension or parameter field was driven at **10×** the intended size — on a millimetre document, `7` became `70` mm on OK.

## Why
The kernel database length unit is the **centimetre** (1 unit = 10 mm). The expression grammar makes a number with no unit suffix `Unitless`, and a `Unitless` literal backing a `Length` parameter is consumed as the raw database unit. Three user-input paths reached a raw `Parameter.SetExpression` that never applies the display-unit factor:

- `CommitPendingDimension` (head 2D/3D dimension box) — the reported path
- `SetParameterEquation` (Parameters panel)
- router `setParameter` (MCP `parameters.set`)

The wire `driveDimension` path was already correct because it parses through `Units().Parse`; the interactive **seed** (`lengthExpr` → `"7 mm"`) was also fine. The bug only fired when a user cleared the box and typed a plain number.

## Fix
One units-aware seam, `Parameter.QualifyAuthored(src, cat, units)`, expresses a bare/unitless value in the document's display unit (`"7"`→`"7 mm"`, `"3*2"`→`"(3*2) * 1 mm"`) and leaves already-dimensioned formulas (`"width/2"`, `"7 mm"`) untouched so they stay **live**. Every user-input expression path now qualifies before `SetExpression`; raw `SetExpression` is documented as reserved for deserialised / already-unit-bearing source.

**Invariant established: no user-input path reaches a raw `SetExpression`.**

## Tests
- `model/param`: seam unit tests (lone number, compound, unit-bearing, formula, angle, unitless category) + end-to-end value resolution (`"7"`→0.7 cm, `"3*2"`→0.6 cm).
- `app`: `TestCommitBareNumberUsesDocumentUnit` reproduces the exact head flow — place a distance dimension, `CommitPendingDimension("7")`, assert the geometry is driven to 0.7 cm (7 mm), not 7 cm.
- Full local suite green; gofmt + golangci-lint clean on all touched packages.

## Notes / follow-ups
- Router `dimensionUnit` (`sketch_dimensions.go`) maps only `AngleDim` (not `ThreePointAngleDim`) to Angle — a pre-existing latent inconsistency for MCP 3-point-angle drive; left out of scope. The new `app.dimensionCategory` handles both.
- `resolveQuantity` (router) and `evalParamText` (app) duplicate the evaluate-then-parse resolution; a future dedup could route both through the `param` layer. Not tackled here to keep the fix focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)