### PR TITLE
Normalize release package names to oblikovati- prefix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,7 +160,7 @@ jobs:
           # with the user's GPU driver). ldd lists the mingw deps.
           for dll in $(ldd oblikovati-head.exe | grep -i mingw64 | awk '{print $3}'); do cp "$dll" .; done
           cp /mingw64/bin/glfw3.dll . 2>/dev/null || true
-          zip -j "oblikovati-head-${VER}-windows-amd64.zip" oblikovati-head.exe ./*.dll
+          zip -j "oblikovati-${VER}-windows-amd64.zip" oblikovati-head.exe ./*.dll
       - uses: actions/upload-artifact@v6
         with:
           name: head-windows

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ prereleases under the rolling `nightly` tag.
   loader is bundled; your GPU's Vulkan driver is used from the system.
 - **Windows** — download and unzip `*-windows-amd64.zip`, run `oblikovati-head.exe`
   (the GLFW + runtime DLLs are bundled; `vulkan-1.dll` comes from your GPU driver).
-- **macOS** — download `Oblikovati-*-macos-universal.zip`, unzip, and double-click
+- **macOS** — download `oblikovati-*-macos-universal.zip`, unzip, and double-click
   **`Oblikovati.app`** (one universal build for Intel + Apple Silicon). Vulkan runs over
   **MoltenVK**, bundled inside the app; it is codesigned + notarized, so it launches with
   no Gatekeeper prompt and needs no Vulkan SDK or setup.

--- a/scripts/macos-sign.sh
+++ b/scripts/macos-sign.sh
@@ -46,7 +46,9 @@ sign "$app"
 codesign --verify --deep --strict --verbose=2 "$app"
 
 # Notarize the zipped bundle and wait for Apple's verdict (non-zero exit fails the job).
-zip="$out/Oblikovati-$version-macos-universal.zip"
+# The zipped asset is lowercase `oblikovati-` for parity with the Linux/Windows/CLI
+# release names; the bundle inside stays `Oblikovati.app` (its display name).
+zip="$out/oblikovati-$version-macos-universal.zip"
 ditto -c -k --keepParent "$app" "$zip"
 xcrun notarytool submit "$zip" \
 	--apple-id "$AC_APPLE_ID" --password "$AC_PASSWORD" --team-id "$AC_TEAM_ID" --wait

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -48,5 +48,5 @@ export VERSION="$version"
 	--icon-file "$icon" \
 	--output appimage )
 
-mv "$work"/*.AppImage "$out/oblikovati-head-$version-linux-amd64.AppImage"
-echo "built $out/oblikovati-head-$version-linux-amd64.AppImage"
+mv "$work"/*.AppImage "$out/oblikovati-$version-linux-amd64.AppImage"
+echo "built $out/oblikovati-$version-linux-amd64.AppImage"


### PR DESCRIPTION
## What

Publish every desktop-app release asset as `oblikovati-<ver>-<os>-<arch>`, keeping the CLI at `oblikovati-cli-<ver>-<os>-<arch>`. Drops the inconsistent `head` segment (Linux AppImage, Windows zip) and lowercases the macOS zip prefix (`Oblikovati-` → `oblikovati-`).

## Why

The release packages had three different prefixes — `oblikovati-head-*`, `Oblikovati-*`, and `oblikovati-cli-*` — for what is one product line. Consistent naming makes the downloads predictable and scriptable.

## Scope

Only the packaged **asset filenames** change. The internal executables (`oblikovati-head`, `oblikovati-head.exe`) and the `Oblikovati.app` bundle keep their names. The `release.yml`/`nightly.yml` publish globs (`*.AppImage`, `*-macos-universal.zip`, `*-windows-amd64.zip`, `oblikovati-cli-*`) still match unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)