### PR TITLE
fix(pointcloud): read integer-resolution E57 scans as millimetres (#1789)

### DIFF
--- a/kernel/exchange/e57fmt/e57fmt.go
+++ b/kernel/exchange/e57fmt/e57fmt.go
@@ -52,6 +52,26 @@ func (d *Document) Vertices() ([]omath.Point3, error) {
 	return data.Points, nil
 }
 
+// CartesianIntegerResolution reports whether the scan's cartesian XYZ channels are all stored at
+// integer resolution — a ScaledInteger with unit scale, or a plain Integer. Such a file quantises
+// positions to whole file-units, which is meaningless at the ASTM E2807 metre default (no scanner
+// captures at 1-metre resolution), so its raw integers are in practice millimetres; callers use this
+// to keep such a scan from importing 1000× oversized (Oblikovati/Oblikovati#1789). Returns false
+// when any cartesian channel is a Float, carries a sub-unit scale, or is absent — i.e. whenever the
+// spec's metre unit should stand.
+func (d *Document) CartesianIntegerResolution() bool {
+	xi, yi, zi, err := d.cartesianIndices()
+	if err != nil {
+		return false
+	}
+	for _, i := range []int{xi, yi, zi} {
+		if !d.points.fields[i].integerResolution() {
+			return false
+		}
+	}
+	return true
+}
+
 // cartesianIndices returns the prototype positions of cartesianX/Y/Z.
 func (d *Document) cartesianIndices() (int, int, int, error) {
 	xi, yi, zi := -1, -1, -1

--- a/kernel/exchange/e57fmt/e57fmt_test.go
+++ b/kernel/exchange/e57fmt/e57fmt_test.go
@@ -434,6 +434,58 @@ func TestVerticesErrorsWithoutCartesian(t *testing.T) {
 	}
 }
 
+// TestCartesianIntegerResolution covers the #1789 signal: cartesian XYZ stored at integer
+// resolution (unit-scale ScaledInteger, or plain Integer) is flagged, while a sub-unit scale, a
+// Float, or a missing channel is not — those keep the ASTM E2807 metre unit.
+func TestCartesianIntegerResolution(t *testing.T) {
+	xyz := func(kind fieldKind, scale float64) []protoField {
+		return []protoField{
+			{name: "cartesianX", kind: kind, scale: scale},
+			{name: "cartesianY", kind: kind, scale: scale},
+			{name: "cartesianZ", kind: kind, scale: scale},
+		}
+	}
+	cases := []struct {
+		name   string
+		fields []protoField
+		want   bool
+	}{
+		{"scaled-integer unit scale", xyz(kindScaledInteger, 1), true},
+		{"plain integer", xyz(kindInteger, 1), true},
+		{"scaled-integer sub-unit scale", xyz(kindScaledInteger, 0.001), false},
+		{"float", xyz(kindFloat, 1), false},
+		{"missing cartesianZ", []protoField{
+			{name: "cartesianX", kind: kindScaledInteger, scale: 1},
+			{name: "cartesianY", kind: kindScaledInteger, scale: 1},
+		}, false},
+		{"one float among integers", []protoField{
+			{name: "cartesianX", kind: kindScaledInteger, scale: 1},
+			{name: "cartesianY", kind: kindFloat},
+			{name: "cartesianZ", kind: kindScaledInteger, scale: 1},
+		}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			doc := &Document{points: pointsSection{fields: c.fields}}
+			if got := doc.CartesianIntegerResolution(); got != c.want {
+				t.Errorf("CartesianIntegerResolution() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestCartesianIntegerResolutionFromBytes confirms the flag survives a real parse: the builder's
+// default cartesian is a unit-scale ScaledInteger, the exact non-conformant pattern of #1789.
+func TestCartesianIntegerResolutionFromBytes(t *testing.T) {
+	doc, err := Parse(e57Builder{points: samplePoints(4), perPacket: 16}.bytes())
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !doc.CartesianIntegerResolution() {
+		t.Error("a unit-scale ScaledInteger cartesian scan should report integer resolution")
+	}
+}
+
 func TestBitReaderLSBFirst(t *testing.T) {
 	r := bitReader{buf: []byte{0b1010_0011}} // low bits first: 3-bit reads → 011, 100, 01(0 pad)
 	if v := r.read(3); v != 0b011 {

--- a/kernel/exchange/e57fmt/proto.go
+++ b/kernel/exchange/e57fmt/proto.go
@@ -30,6 +30,21 @@ type protoField struct {
 	doublePrec bool
 }
 
+// integerResolution reports whether the field quantises values to whole file-units: a plain
+// Integer, or a ScaledInteger whose scale is exactly 1 (so the stored integer IS the real value).
+// A sub-unit scale (e.g. 0.001) or a Float encodes finer resolution and is not flagged. Callers use
+// this on the cartesian channels to spot a scan mis-declared in metres (Oblikovati/Oblikovati#1789).
+func (f protoField) integerResolution() bool {
+	switch f.kind {
+	case kindInteger:
+		return true
+	case kindScaledInteger:
+		return f.scale == 1
+	default:
+		return false
+	}
+}
+
 // pointsSection is the decoded <points> CompressedVector: where its binary section starts
 // (a physical offset), how many records it holds, and the prototype field layout.
 type pointsSection struct {

--- a/model/pointcloud/e57.go
+++ b/model/pointcloud/e57.go
@@ -20,8 +20,34 @@ func NewE57Reader() PointReader { return e57Reader{} }
 func (e57Reader) Extensions() []string { return []string{".e57"} }
 
 // FileUnitMM: E57 cartesian coordinates are metres by the ASTM E2807 spec, so one file unit is
-// 1000 mm (#1636).
+// 1000 mm (#1636). This is the static default; fileUnitMM overrides it per file when the scan's
+// encoding shows it is really in millimetres (#1789).
 func (e57Reader) FileUnitMM() float64 { return 1000 }
+
+// e57UnitMM maps the cartesian-resolution fact to the file's length unit in millimetres:
+// integer-resolution coordinates are millimetres (#1789), otherwise the ASTM E2807 metre.
+func e57UnitMM(integerResolution bool) float64 {
+	if integerResolution {
+		return 1 // millimetres
+	}
+	return 1000 // metres (spec default)
+}
+
+// fileUnitMM overrides the metre default for a common class of non-conformant scans: an E57 whose
+// cartesian channels are integer-resolution (see e57fmt.CartesianIntegerResolution) cannot truly be
+// metres — no scanner captures at 1-metre resolution — so its raw integers are millimetres, the
+// unit its writer used. Reading them as metres imports the cloud 1000× oversized and kilometres
+// from the origin, where it renders invisibly (#1789); the millimetre reading matches the identical
+// geometry re-exported as PLY. Conformant files (float coordinates, or a sub-metre ScaledInteger
+// scale) keep the metre unit. ok is false only when the header cannot be parsed, leaving the static
+// FileUnitMM in force (the decode then fails in ReadSamples with the real error).
+func (e57Reader) fileUnitMM(data []byte) (mm float64, ok bool) {
+	doc, err := e57fmt.Parse(data)
+	if err != nil {
+		return 0, false
+	}
+	return e57UnitMM(doc.CartesianIntegerResolution()), true
+}
 
 // ReadSamples decodes the E57's scan points into cloud-local samples, carrying colour (normalised
 // 0..1 by e57fmt) and raw intensity through when the scan declares those channels.

--- a/model/pointcloud/e57_test.go
+++ b/model/pointcloud/e57_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"oblikovati.org/kernel/exchange"
+	"oblikovati.org/math"
 )
 
 // The E57 decode itself is covered in kernel/exchange/e57fmt; here we cover the model-layer
@@ -24,5 +25,71 @@ func TestReadScanDispatchesE57Error(t *testing.T) {
 	_, _, err := ReadScan("scan.e57", []byte("this is not an E57 file"), exchange.TranslationOptions{})
 	if err == nil {
 		t.Fatal("want a decode error for non-E57 bytes routed to the e57 reader")
+	}
+}
+
+// TestE57UnitMM maps the cartesian-resolution fact to the file's length unit: an integer-resolution
+// scan is treated as millimetres (#1789), a conformant scan keeps the ASTM E2807 metre.
+func TestE57UnitMM(t *testing.T) {
+	if got := e57UnitMM(true); got != 1 {
+		t.Errorf("e57UnitMM(integerResolution) = %v mm, want 1 (millimetres)", got)
+	}
+	if got := e57UnitMM(false); got != 1000 {
+		t.Errorf("e57UnitMM(conformant) = %v mm, want 1000 (metres)", got)
+	}
+}
+
+// TestE57ReaderImplementsPerFileUnit: the E57 reader must expose the per-file unit seam, and an
+// undecodable header must decline (ok=false) so the static FileUnitMM stays in force (#1789).
+func TestE57ReaderImplementsPerFileUnit(t *testing.T) {
+	r, ok := NewE57Reader().(perFileUnitReader)
+	if !ok {
+		t.Fatal("E57 reader must implement perFileUnitReader for the #1789 mm override")
+	}
+	if _, ok := r.fileUnitMM([]byte("not an E57 file")); ok {
+		t.Error("fileUnitMM should report ok=false for undecodable bytes, leaving FileUnitMM in force")
+	}
+}
+
+// fakeUnitReader is a named fake PointReader (per the test guidelines) whose per-file unit differs
+// from its static unit, so readScaled's preference for the per-file override is observable (#1789).
+type fakeUnitReader struct {
+	staticMM  float64
+	perFileMM float64
+	perFileOK bool
+}
+
+func (fakeUnitReader) Extensions() []string                         { return []string{".fake"} }
+func (f fakeUnitReader) FileUnitMM() float64                        { return f.staticMM }
+func (fakeUnitReader) Read([]byte) ([]math.Point3, []string, error) { return nil, nil, nil }
+func (fakeUnitReader) ReadSamples([]byte) ([]PointSample, []string, error) {
+	return []PointSample{{Point: math.P3(5, 0, 0)}}, nil, nil
+}
+func (f fakeUnitReader) fileUnitMM([]byte) (float64, bool) { return f.perFileMM, f.perFileOK }
+
+// TestReadScaledPrefersPerFileUnit: with a metre static unit but a millimetre per-file override, a
+// point at x=5 scales as millimetres (×1 into the mm database unit → 5), not metres (which would
+// give 5000) — the exact 1000× the override exists to prevent (#1789).
+func TestReadScaledPrefersPerFileUnit(t *testing.T) {
+	r := fakeUnitReader{staticMM: 1000, perFileMM: 1, perFileOK: true}
+	samples, _, err := readScaled(r, nil, exchange.TranslationOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := samples[0].Point.X; got != 5 {
+		t.Errorf("per-file mm override: x = %v, want 5 (metre path would give 5000)", got)
+	}
+}
+
+// TestReadScaledFallsBackToStaticUnit: when the per-file override declines (ok=false), the static
+// metre unit applies, so x=5 scales to 5000.
+func TestReadScaledFallsBackToStaticUnit(t *testing.T) {
+	r := fakeUnitReader{staticMM: 1000, perFileMM: 1, perFileOK: false}
+	samples, _, err := readScaled(r, nil, exchange.TranslationOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := samples[0].Point.X; got != 5000 {
+		t.Errorf("static metre fallback: x = %v, want 5000", got)
 	}
 }

--- a/model/pointcloud/reader.go
+++ b/model/pointcloud/reader.go
@@ -73,7 +73,7 @@ func readScaled(r PointReader, data []byte, opts exchange.TranslationOptions) ([
 	if err := opts.Report("points", len(samples), len(samples)); err != nil { // #1647: report the record count
 		return nil, nil, err
 	}
-	f := math.Scalar(opts.ImportScale(r.FileUnitMM()))
+	f := math.Scalar(opts.ImportScale(fileUnitMM(r, data)))
 	if f == 1 {
 		return samples, warns, nil
 	}
@@ -82,6 +82,25 @@ func readScaled(r PointReader, data []byte, opts exchange.TranslationOptions) ([
 		samples[i] = s
 	}
 	return samples, warns, nil
+}
+
+// perFileUnitReader is an optional PointReader that derives the file's length unit from the decoded
+// content, overriding the static FileUnitMM. It exists for formats whose spec unit is unreliable in
+// the wild — an E57 that stores millimetre coordinates in the metre-typed cartesian field
+// (#1789). A reader that does not implement it keeps its static FileUnitMM.
+type perFileUnitReader interface {
+	fileUnitMM(data []byte) (mm float64, ok bool)
+}
+
+// fileUnitMM resolves the file→millimetre unit for r's data: a reader that inspects the content
+// (perFileUnitReader) wins when it can decide, else the reader's static FileUnitMM stands.
+func fileUnitMM(r PointReader, data []byte) float64 {
+	if pf, ok := r.(perFileUnitReader); ok {
+		if mm, ok := pf.fileUnitMM(data); ok {
+			return mm
+		}
+	}
+	return r.FileUnitMM()
 }
 
 // IsScanFile reports whether a path's extension is a 3D-scan point-cloud format handled by a


### PR DESCRIPTION
## What

Non-conformant E57 scans that store **millimetre-magnitude integers in the metre-typed cartesian field** (no `scale` attribute) now import at their true size instead of 1000× oversized.

Before: `capstan vertraging.e57` imported at **392000 × 604000 × 641000** db-units, ~6 km from the origin, and rendered as an empty viewport. The identical geometry as `.ply` imported fine.

After: the `.e57` matches its `.ply` sibling — **392 × 604 × 641**, centred near origin, and renders (verified live with the MCP bridge on lavapipe):

| file | extent | centre |
|------|--------|--------|
| `.e57` (before) | 392000 × 604000 × 641000 | (19000, −79000, −60500) |
| `.e57` (after)  | 392.00 × 604.00 × 641.00 | (19.0, −79.0, −60.5) |
| `.ply` (oracle) | 392.02 × 604.15 × 641.07 | (18.6, −78.7, −60.6) |

## Why

E57 cartesian coordinates are metres by ASTM E2807, so the reader's `FileUnitMM=1000` is spec-correct. But many real scanners (this file's writer is `E57RefImpl-1.1.unknown`) emit millimetre values into that metre field with no `scale`, so per spec they're read as metres — 1000× too big.

There is no in-file unit metadata to honour (scale defaults to 1, `coordinateMetadata` empty). The principled signal: a scan whose cartesian channels are **integer-resolution** (a unit-scale `ScaledInteger`, or a plain `Integer`) cannot really be metres — no scanner captures at 1-metre resolution — so its raw integers are millimetres. That reinterpretation reproduces the PLY exactly.

## How

- `e57fmt` exposes the neutral fact `Document.CartesianIntegerResolution()` (pure decode info).
- The point-cloud reader owns the mm **policy** via a new per-file unit override (`perFileUnitReader`) on the shared import-scaling seam (#1636), so the static `FileUnitMM` stays in force for every other reader and format.
- Conformant files are untouched: float coordinates, or a sub-metre `ScaledInteger` scale (e.g. 0.001), keep the metre unit.

## Scope

E57 only, as requested. LAS shares `FileUnitMM=1000` but has its own header scale/offset + GeoKey units — a separate concern, left for a follow-up. The secondary render-robustness gap (a *legitimately* far-from-origin cloud should still be framable) from #1789 is also left as a follow-up.

## Tests

- `e57fmt`: `CartesianIntegerResolution` across unit-scale/sub-scale/Integer/Float/missing cases, plus a parsed-from-bytes check.
- `pointcloud`: the mm/metre mapping, the `readScaled` per-file-unit preference and fallback (named fake reader), and the malformed-header decline.
- Full local suite + `golangci-lint` clean; coverage 84% (e57fmt) / 85.7% (pointcloud).

Closes #1789