### PR TITLE
fix(pointcloud): read coarse-quantised LAS scans as millimetres (#1789)

### DIFF
--- a/model/pointcloud/e57.go
+++ b/model/pointcloud/e57.go
@@ -24,15 +24,6 @@ func (e57Reader) Extensions() []string { return []string{".e57"} }
 // encoding shows it is really in millimetres (#1789).
 func (e57Reader) FileUnitMM() float64 { return 1000 }
 
-// e57UnitMM maps the cartesian-resolution fact to the file's length unit in millimetres:
-// integer-resolution coordinates are millimetres (#1789), otherwise the ASTM E2807 metre.
-func e57UnitMM(integerResolution bool) float64 {
-	if integerResolution {
-		return 1 // millimetres
-	}
-	return 1000 // metres (spec default)
-}
-
 // fileUnitMM overrides the metre default for a common class of non-conformant scans: an E57 whose
 // cartesian channels are integer-resolution (see e57fmt.CartesianIntegerResolution) cannot truly be
 // metres — no scanner captures at 1-metre resolution — so its raw integers are millimetres, the
@@ -46,7 +37,7 @@ func (e57Reader) fileUnitMM(data []byte) (mm float64, ok bool) {
 	if err != nil {
 		return 0, false
 	}
-	return e57UnitMM(doc.CartesianIntegerResolution()), true
+	return scanUnitMM(doc.CartesianIntegerResolution()), true
 }
 
 // ReadSamples decodes the E57's scan points into cloud-local samples, carrying colour (normalised

--- a/model/pointcloud/e57_test.go
+++ b/model/pointcloud/e57_test.go
@@ -28,14 +28,14 @@ func TestReadScanDispatchesE57Error(t *testing.T) {
 	}
 }
 
-// TestE57UnitMM maps the cartesian-resolution fact to the file's length unit: an integer-resolution
-// scan is treated as millimetres (#1789), a conformant scan keeps the ASTM E2807 metre.
-func TestE57UnitMM(t *testing.T) {
-	if got := e57UnitMM(true); got != 1 {
-		t.Errorf("e57UnitMM(integerResolution) = %v mm, want 1 (millimetres)", got)
+// TestScanUnitMM maps the "coordinates are really millimetres" verdict to the file's length unit:
+// a flagged scan is millimetres (#1789), otherwise the format's metre convention stands.
+func TestScanUnitMM(t *testing.T) {
+	if got := scanUnitMM(true); got != 1 {
+		t.Errorf("scanUnitMM(millimetres) = %v mm, want 1 (millimetres)", got)
 	}
-	if got := e57UnitMM(false); got != 1000 {
-		t.Errorf("e57UnitMM(conformant) = %v mm, want 1000 (metres)", got)
+	if got := scanUnitMM(false); got != 1000 {
+		t.Errorf("scanUnitMM(metres) = %v mm, want 1000 (metres)", got)
 	}
 }
 

--- a/model/pointcloud/las.go
+++ b/model/pointcloud/las.go
@@ -23,8 +23,31 @@ func NewLASReader() PointReader { return lasReader{} }
 func (lasReader) Extensions() []string { return []string{".las"} }
 
 // FileUnitMM: LAS real coordinates (stored integers × header scale + offset, applied by lasfmt)
-// are metres by ASPRS convention, so one file unit is 1000 mm (#1636).
+// are metres by ASPRS convention, so one file unit is 1000 mm (#1636). This is the static default;
+// fileUnitMM overrides it per file when the header's scale shows it is really millimetres (#1789).
 func (lasReader) FileUnitMM() float64 { return 1000 }
+
+// lasMillimetreScan reports whether a LAS quantises coordinates to a whole metre or coarser on every
+// axis. header.Scale is the coordinate step in the assumed metre unit; a step ≥ 1 m cannot resolve
+// any real scan or survey (LiDAR is sub-centimetre), so the file's coordinates are really
+// millimetres despite the metre-unit ASPRS convention — the LAS analogue of E57's integer-resolution
+// scans (#1789). An unset/zero scale (a malformed header) is not flagged, leaving the metre default.
+func lasMillimetreScan(scale [3]float64) bool {
+	return scale[0] >= 1 && scale[1] >= 1 && scale[2] >= 1
+}
+
+// fileUnitMM overrides the metre default (see FileUnitMM) for a LAS whose coordinate quantisation is
+// too coarse to be metres, reading it as millimetres so a millimetre-authored scan does not import
+// 1000× oversized and kilometres from the origin, where it renders invisibly (#1789). Conformant
+// surveys (sub-metre scale) keep the metre unit. ok is false only when the header cannot be parsed,
+// leaving the static FileUnitMM in force (the decode then fails in ReadSamples with the real error).
+func (lasReader) fileUnitMM(data []byte) (mm float64, ok bool) {
+	doc, err := lasfmt.Parse(data)
+	if err != nil {
+		return 0, false
+	}
+	return scanUnitMM(lasMillimetreScan(doc.Header().Scale)), true
+}
 
 // ReadSamples decodes the LAS point records into cloud-local samples.
 func (lasReader) ReadSamples(data []byte) ([]PointSample, []string, error) {

--- a/model/pointcloud/las_test.go
+++ b/model/pointcloud/las_test.go
@@ -25,3 +25,39 @@ func TestReadScanDispatchesLASError(t *testing.T) {
 		t.Fatal("want a decode error for non-LAS bytes routed to the las reader")
 	}
 }
+
+// TestLASMillimetreScan covers the #1789 signal: a LAS quantised to a whole metre or coarser on
+// every axis is read as millimetres, while any sub-metre axis (a real survey) keeps the metre unit.
+// A zero/unset scale (malformed header) is not flagged, so the metre default stands.
+func TestLASMillimetreScan(t *testing.T) {
+	cases := []struct {
+		name  string
+		scale [3]float64
+		want  bool
+	}{
+		{"unit metre steps", [3]float64{1, 1, 1}, true},
+		{"coarser than metre", [3]float64{2, 3, 1.5}, true},
+		{"sub-metre survey", [3]float64{0.001, 0.001, 0.01}, false},
+		{"one sub-metre axis", [3]float64{1, 0.5, 1}, false},
+		{"unset scale", [3]float64{0, 0, 0}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := lasMillimetreScan(c.scale); got != c.want {
+				t.Errorf("lasMillimetreScan(%v) = %v, want %v", c.scale, got, c.want)
+			}
+		})
+	}
+}
+
+// TestLASReaderImplementsPerFileUnit: the LAS reader must expose the per-file unit seam, and an
+// undecodable header must decline (ok=false) so the static FileUnitMM stays in force (#1789).
+func TestLASReaderImplementsPerFileUnit(t *testing.T) {
+	r, ok := NewLASReader().(perFileUnitReader)
+	if !ok {
+		t.Fatal("LAS reader must implement perFileUnitReader for the #1789 mm override")
+	}
+	if _, ok := r.fileUnitMM([]byte("not a LAS file")); ok {
+		t.Error("fileUnitMM should report ok=false for undecodable bytes, leaving FileUnitMM in force")
+	}
+}

--- a/model/pointcloud/reader.go
+++ b/model/pointcloud/reader.go
@@ -103,6 +103,17 @@ func fileUnitMM(r PointReader, data []byte) float64 {
 	return r.FileUnitMM()
 }
 
+// scanUnitMM maps a "coordinates are really millimetres" verdict to the file's length unit in
+// millimetres: a scan whose quantisation is too coarse to be metres is millimetres (#1789),
+// otherwise the format's metre convention (E57 ASTM E2807, LAS ASPRS) stands. Shared by the E57 and
+// LAS per-file overrides.
+func scanUnitMM(millimetres bool) float64 {
+	if millimetres {
+		return 1 // millimetres
+	}
+	return 1000 // metres (the format's convention)
+}
+
 // IsScanFile reports whether a path's extension is a 3D-scan point-cloud format handled by a
 // registered reader (.xyz/.pts/.asc/.txt/.ply/.e57/.las). The import flow routes such files to the
 // point-cloud attach path — the appropriate home for scan data — rather than the body/sketch


### PR DESCRIPTION
## What

The **LAS half of #1789** (the E57 half shipped in #1790). A LAS whose header scale quantises coordinates to a whole metre or coarser on every axis is now read as **millimetres** instead of the ASPRS metre convention — so a millimetre-authored scan no longer imports 1000× oversized and off-screen.

Verified end to end through the model reader:

| fixture | header scale | imports at |
|---------|-------------|------------|
| coarse (mm-authored) | `[1, 1, 1]` | **392 × 604 × 641** (was 392000 × 604000 × 641000) |
| survey (genuine metres) | `[0.001, 0.001, 0.001]` | 392000 × 604000 × 641000 (unchanged) |

## Why

Same symptom and remedy as the E57 fix. LAS real coordinates = `int32 × header.Scale + header.Offset`, assumed metres. `header.Scale` is the coordinate step in that unit; a step ≥ 1 m cannot resolve any real scan or survey (LiDAR is sub-centimetre), so the file's coordinates are really millimetres.

`lasfmt` parses no CRS/unit VLRs (GeoKeys/WKT), so — as with E57 — there is no declared unit to honour; the header scale is the principled signal. This mirrors E57's integer-resolution test exactly.

## How

- `Header.Scale` is already exported, so unlike E57 **no `lasfmt` change is needed** — the LAS reader inspects it directly (`lasMillimetreScan`).
- Reuses the `perFileUnitReader` per-file override on the shared `#1636` scaling seam introduced in #1790; the static `FileUnitMM` stays in force for every other reader.
- The mm/metre mapping is factored into a shared `scanUnitMM` helper used by both the E57 and LAS overrides (no duplication).
- Conformant surveys (any sub-metre axis) and malformed/zero-scale headers keep the metre unit.

## Limits (unchanged from #1790)

A millimetre-authored LAS that uses a *fine* scale (e.g. 0.001) is indistinguishable from a metre survey from the header alone — the same fundamental ambiguity as an E57 with float coordinates. This catches the coarse-quantised case, which is the one that blows up 1000×. Honouring an explicit CRS/unit VLR (feet, declared mm) would need VLR parsing in `lasfmt` — a separate enhancement. The far-from-origin render-robustness gap from #1789 also remains a separate follow-up.

## Tests

- `lasMillimetreScan` across unit/coarse/sub-metre/mixed/zero-scale cases.
- The LAS reader implements the per-file seam and declines an undecodable header.
- The `readScaled` override preference/fallback is covered by the shared fake-reader tests from #1790.
- Full local suite + `golangci-lint` clean; coverage 85.8% (pointcloud).

Follow-up to #1789 (E57 half: #1790).