### PR TITLE
fix(head): extend the far clip plane to enclose point clouds (#1789)

### DIFF
--- a/app/point_cloud_render_test.go
+++ b/app/point_cloud_render_test.go
@@ -41,6 +41,33 @@ func TestPointCloudItemsRendersVisibleClouds(t *testing.T) {
 	}
 }
 
+// TestPointCloudBounds returns the model-space extent of the visible clouds — the box the viewport
+// far plane consults to enclose a large or distant scan (#1789). No clouds, or only hidden ones,
+// yield an empty box.
+func TestPointCloudBounds(t *testing.T) {
+	s, def := emptyPartSession(t)
+	if !s.PointCloudBounds().IsEmpty() {
+		t.Fatal("a part with no clouds must report an empty point-cloud box")
+	}
+
+	rid := def.AddResource(doc.Resource{Encoding: doc.EncodingUTF8, Value: []byte("scan")})
+	pts := []math.Point3{math.P3(-100, -200, -300), math.P3(100, 200, 300)}
+	pc, err := def.PointClouds().Add("Cloud1", "c.xyz", rid, pts)
+	if err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+
+	box := s.PointCloudBounds()
+	if box.Min != math.P3(-100, -200, -300) || box.Max != math.P3(100, 200, 300) {
+		t.Errorf("cloud bounds = %v..%v, want (-100,-200,-300)..(100,200,300)", box.Min, box.Max)
+	}
+
+	pc.SetVisible(false)
+	if !s.PointCloudBounds().IsEmpty() {
+		t.Error("a hidden cloud must not contribute to the point-cloud box")
+	}
+}
+
 // TestPointCloudItemsColorsByDisplayMode checks the draw batch carries per-point colors when a
 // cloud is set to RGB or intensity display.
 func TestPointCloudItemsColorsByDisplayMode(t *testing.T) {

--- a/app/view.go
+++ b/app/view.go
@@ -163,6 +163,15 @@ func (s *Session) unionCloudBounds(box math.Box) math.Box {
 	return box
 }
 
+// PointCloudBounds returns the model-space extent of the active part's visible point clouds, or an
+// empty box when none are attached. Point clouds render from a separate retained GL-points buffer
+// that the viewport's instanced/overlay framing bounds never see, so the far clip plane must consult
+// this to enclose a large or distant scan — otherwise the scan falls beyond the fixed far plane and
+// renders as nothing (#1789).
+func (s *Session) PointCloudBounds() math.Box {
+	return s.unionCloudBounds(math.EmptyBox())
+}
+
 // unionSketchBounds widens box by the model-space extent of the active part's visible 2D and 3D
 // sketches. Curves are sampled the same way the viewport overlay and ray picker sample them
 // (EntityPolyline / SamplePolyline3D), so the framed box matches what is drawn. The sample

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -739,6 +739,10 @@ func viewportFarPlane(s *app.Session, cam scene.Camera, mn, mx [3]float32, hasGe
 		lo, hi = unionBounds(lo, hi, ok, smn, smx)
 		ok = true
 	}
+	if cmn, cmx, cok := pointCloudFarBounds(s); cok { // #1789: enclose a large/distant scan
+		lo, hi = unionBounds(lo, hi, ok, cmn, cmx)
+		ok = true
+	}
 	return viewportClipFar(cam, lo, hi, ok)
 }
 

--- a/head/ui/viewport_clip_cloud_test.go
+++ b/head/ui/viewport_clip_cloud_test.go
@@ -1,0 +1,51 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/scene"
+)
+
+// TestViewportFarPlaneEnclosesPointCloud: a large point cloud viewed from far enough that the fixed
+// 5000 far plane would clip it must get a far plane beyond the farthest point. Clouds render from a
+// separate retained-buffer draw the instanced/overlay frameBounds never see, so without unioning
+// their bounds a scan-only part would fall entirely behind the far plane and render nothing (#1789).
+func TestViewportFarPlaneEnclosesPointCloud(t *testing.T) {
+	s := framedSession()
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	rid := def.AddResource(doc.Resource{Encoding: doc.EncodingUTF8, Value: []byte("scan")})
+	// A 100k-unit-wide cloud centred at the origin.
+	if _, err := def.PointClouds().Add("Scan", "s.xyz", rid,
+		[]math.Point3{math.P3(-50000, -50000, -50000), math.P3(50000, 50000, 50000)}); err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+
+	// Camera pulled back 150k on Z with no body/overlay geometry (hasGeom=false), so only the cloud
+	// bounds can extend the far plane.
+	cam := scene.Camera{Eye: math.P3(0, 0, 150000), Target: math.P3(0, 0, 0), Up: math.V3(0, 1, 0), FOV: 0.8, Width: inWinW, Height: inWinH}
+	far := viewportFarPlane(s, cam, [3]float32{}, [3]float32{}, false)
+	if far <= viewportFar {
+		t.Fatalf("scan-only far = %v, expected it to extend past the fixed %v", far, viewportFar)
+	}
+	farthest := cam.Eye.DistanceTo(math.P3(50000, 50000, 50000))
+	if far < farthest {
+		t.Errorf("far plane %v does not enclose the farthest cloud point at %v", far, farthest)
+	}
+}
+
+// TestViewportFarPlaneKeepsDefaultWithoutClouds: a part with no clouds and no framed geometry keeps
+// the fixed far plane, so the cloud-bounds union leaves ordinary scenes unchanged.
+func TestViewportFarPlaneKeepsDefaultWithoutClouds(t *testing.T) {
+	s := framedSession()
+	cam := scene.Camera{Eye: math.P3(40, 40, 40), Target: math.P3(0, 0, 0), Up: math.V3(0, 1, 0), FOV: 0.8, Width: inWinW, Height: inWinH}
+	if got := viewportFarPlane(s, cam, [3]float32{}, [3]float32{}, false); got != viewportFar {
+		t.Errorf("no-cloud far = %v, want fixed %v", got, viewportFar)
+	}
+}

--- a/head/ui/viewport_instancing.go
+++ b/head/ui/viewport_instancing.go
@@ -432,6 +432,26 @@ func cachedSourceMesh(src *topo.Body, cam scene.Camera, lookup renderer.SurfaceL
 // instancedBounds is the world-space bounding box of every instance, computed from each source's
 // range box transformed by its occurrence matrices — O(instances) and NO tessellation, so a 10k-copy
 // assembly frames its shadow/ground without building a world-body mesh. ok is false when empty.
+// cloudBounder is the one-method slice pointCloudFarBounds consumes (audit I5, the arrowSession
+// pattern): the visible point-cloud extent. *app.Session satisfies it implicitly, so the far-plane
+// helper does not take the whole session.
+type cloudBounder interface {
+	PointCloudBounds() math.Box
+}
+
+// pointCloudFarBounds returns the active part's visible point-cloud extent as float32 corners, so
+// viewportFarPlane can extend the far clip to enclose it. Point clouds are a separate retained-buffer
+// draw (uploadPointClouds); the instanced/overlay frameBounds never see them, so a large or distant
+// scan would otherwise fall beyond the fixed far plane and render as nothing (#1789).
+func pointCloudFarBounds(s cloudBounder) (mn, mx [3]float32, ok bool) {
+	box := s.PointCloudBounds()
+	if box.IsEmpty() {
+		return mn, mx, false
+	}
+	return [3]float32{float32(box.Min.X), float32(box.Min.Y), float32(box.Min.Z)},
+		[3]float32{float32(box.Max.X), float32(box.Max.Y), float32(box.Max.Z)}, true
+}
+
 func instancedBounds(groups []app.InstanceGroup) (min, max [3]float32, ok bool) {
 	min = [3]float32{stdmath.MaxFloat32, stdmath.MaxFloat32, stdmath.MaxFloat32}
 	max = [3]float32{-stdmath.MaxFloat32, -stdmath.MaxFloat32, -stdmath.MaxFloat32}


### PR DESCRIPTION
## What

A large-extent point cloud rendered as **nothing** — an empty viewport, even under `View.Home`. This is the render-robustness follow-up from #1789 (the E57/LAS scan that imported ~6 km from the origin was invisible).

Live proof on lavapipe — a 40k-unit cube-shell scan, `View.Home`:

| | before | after |
|---|--------|-------|
| large-extent scan (40k) | ⬛ empty viewport | ✅ frames + renders |
| near-origin scan | ✅ renders | ✅ unchanged |
| small scan far from origin (~5e5) | ✅ renders | ✅ unchanged |

## Root cause

The viewport's **adaptive far clip plane** (`viewportFarPlane` → `viewportClipFar`) is computed from the body-instance bounds and the sketch overlays. **Point clouds are excluded**: they draw from a separate retained GL-points buffer (`uploadPointClouds`) that the instanced/overlay `frameBounds` never see. So on a scan-only or large-scan part, `hasGeom` was false and the far plane fell back to the fixed `viewportFar = 5000`. A cloud whose camera-fit distance exceeds 5000 sat entirely beyond the far plane → clipped → black. A near-origin scan rendered only because it happened to fit inside 5000.

Note this is a **far-plane** bug, not a precision one: a *small* scan placed at ~5e5 renders crisply (float32 holds up), so the failure is large **extent** (camera distance ≫ 5000), which is exactly what the mis-scaled #1789 scan was.

## Fix

Union the active part's visible point-cloud extent into the far-plane bounds — the same mechanism already used to fold in finished 2D/3D sketch overlays (`cachedSketch3DBounds`). The far plane then grows to enclose the scan.

Deliberately minimal and matching the established pattern:
- The **near plane stays fixed** (0.1) and the **framing/shadow bounds are untouched** — so ordinary scenes are byte-for-byte unchanged and clouds never enlarge the shadow frustum (they cast none).
- `app.Session` exposes `PointCloudBounds()`; the head consumes it through a **one-method `cloudBounder` interface** (audit I5, the arrowSession pattern), so the `*app.Session` coupling ratchet does not rise.

## Tests

- `app`: `TestPointCloudBounds` — visible-cloud extent, empty with none, hidden clouds excluded.
- `head/ui`: `TestViewportFarPlaneEnclosesPointCloud` (a 100k scan pulled back 150k gets a far plane past the farthest point) and `TestViewportFarPlaneKeepsDefaultWithoutClouds` (no-cloud scenes keep the fixed far).
- Full root + head/ui suites pass; `golangci-lint` clean; the head-session coupling ratchet holds.

Follow-up to #1789 (E57 unit fix #1790, LAS unit fix #1791). The remaining item from that issue — honouring an explicit LAS CRS/unit VLR — needs VLR parsing in `lasfmt` and stays a separate enhancement.