### PR TITLE
feat(lasfmt): honour the LAS CRS linear unit from its VLRs (#1789)

### DIFF
--- a/kernel/exchange/lasfmt/header.go
+++ b/kernel/exchange/lasfmt/header.go
@@ -28,7 +28,9 @@ var signature = []byte("LASF")
 type lasHeader struct {
 	versionMajor    uint8
 	versionMinor    uint8
+	headerSize      uint16
 	pointDataOffset uint32
+	vlrCount        uint32
 	pointFormat     uint8
 	recordLength    uint16
 	pointCount      uint64
@@ -48,7 +50,9 @@ func parseHeader(data []byte) (lasHeader, error) {
 	h := lasHeader{
 		versionMajor:    data[24],
 		versionMinor:    data[25],
+		headerSize:      binary.LittleEndian.Uint16(data[94:]),
 		pointDataOffset: binary.LittleEndian.Uint32(data[96:]),
+		vlrCount:        binary.LittleEndian.Uint32(data[100:]),
 		pointFormat:     data[104] & 0x3f, // mask the compression bits a LAZ writer may set
 		recordLength:    binary.LittleEndian.Uint16(data[105:]),
 	}

--- a/kernel/exchange/lasfmt/lasfmt.go
+++ b/kernel/exchange/lasfmt/lasfmt.go
@@ -56,6 +56,16 @@ func (d *Document) Header() Header {
 // Raw returns the original file bytes so callers can decode record extensions beyond XYZ.
 func (d *Document) Raw() []byte { return d.data }
 
+// CoordinateUnitMetres returns the size in metres of the file's horizontal coordinate unit as
+// declared by its CRS VLRs (WKT record 2112, or the GeoTIFF GeoKeys), and whether one was found —
+// 1.0 for metre, 0.3048 for the international foot, 0.30480060960121924 for the US survey foot, etc.
+// A point-cloud import uses it to place a scan at true scale instead of assuming metres; ok is false
+// when the file declares no linear CRS (a geographic degrees CRS, or no projection VLR at all), and
+// the caller falls back to its own unit policy (Oblikovati/Oblikovati#1789).
+func (d *Document) CoordinateUnitMetres() (float64, bool) {
+	return coordinateUnitMetres(d.data, d.header)
+}
+
 // Vertices decodes every point record's XYZ into real coordinates. It errors if the record stride
 // cannot hold an XYZ triple or the records run past the end of the file.
 func (d *Document) Vertices() ([]omath.Point3, error) {

--- a/kernel/exchange/lasfmt/lasfmt_test.go
+++ b/kernel/exchange/lasfmt/lasfmt_test.go
@@ -258,3 +258,110 @@ func TestCoordinateUnitMetresNoCRS(t *testing.T) {
 		t.Error("a LAS with no CRS VLR must not declare a coordinate unit")
 	}
 }
+
+// TestCoordinateUnitMetresGeoKeyUserDefined: a user-defined linear unit (32767) reads its metre size
+// from the ProjLinearUnitSizeGeoKey entry in the GeoDoubleParams VLR.
+func TestCoordinateUnitMetresGeoKeyUserDefined(t *testing.T) {
+	dir := make([]byte, 24)                   // 4-uint16 header + two keys
+	binary.LittleEndian.PutUint16(dir[0:], 1) // KeyDirectoryVersion
+	binary.LittleEndian.PutUint16(dir[6:], 2) // NumberOfKeys
+	binary.LittleEndian.PutUint16(dir[8:], projLinearUnitsGeoKey)
+	binary.LittleEndian.PutUint16(dir[14:], geoKeyUserDefined) // tagLoc 0, value inline = user-defined
+	binary.LittleEndian.PutUint16(dir[16:], projLinearSizeGeoKey)
+	binary.LittleEndian.PutUint16(dir[18:], geoDoubleRecordID) // size lives in GeoDoubleParams
+	binary.LittleEndian.PutUint16(dir[22:], 0)                 // at index 0
+	doubles := make([]byte, 8)
+	binary.LittleEndian.PutUint64(doubles, math.Float64bits(0.5)) // 0.5 m per unit
+
+	doc, err := Parse(lasBuilder{points: [][3]int32{{1, 1, 1}}, scale: [3]float64{1, 1, 1},
+		vlrs: [][]byte{crsVLR(geoKeyDirRecordID, dir), crsVLR(geoDoubleRecordID, doubles)}}.bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := doc.CoordinateUnitMetres(); !ok || got != 0.5 {
+		t.Errorf("user-defined unit = %v, %v; want 0.5, true", got, ok)
+	}
+}
+
+// TestCoordinateUnitMetresDeclines covers the malformed / non-linear inputs that must fall back to
+// the caller's policy rather than guess a unit.
+func TestCoordinateUnitMetresDeclines(t *testing.T) {
+	// A GeoKey whose linear-units key is stored out-of-line (tagLoc != 0) is malformed.
+	badLoc := geoKeyDir(projLinearUnitsGeoKey, geoDoubleRecordID, 0)
+	if _, ok := lasWithVLR(crsVLR(geoKeyDirRecordID, badLoc)).CoordinateUnitMetres(); ok {
+		t.Error("an out-of-line linear-units key must decline")
+	}
+	// A GeoKey directory that carries no linear-units key at all declines.
+	other := geoKeyDir(4099 /* VerticalUnitsGeoKey */, 0, 9001)
+	if _, ok := lasWithVLR(crsVLR(geoKeyDirRecordID, other)).CoordinateUnitMetres(); ok {
+		t.Error("a directory without ProjLinearUnitsGeoKey must decline")
+	}
+	// A VLR whose declared length runs past the file: the walk stops, no unit.
+	v := crsVLR(wktRecordID, []byte("PROJCS"))
+	binary.LittleEndian.PutUint16(v[20:], 9999) // lie about the payload length
+	if _, ok := lasWithVLR(v).CoordinateUnitMetres(); ok {
+		t.Error("a truncated VLR must decline")
+	}
+}
+
+// TestUnitFactorAfterName exercises the WKT unit-value parser's success and every reject branch.
+func TestUnitFactorAfterName(t *testing.T) {
+	if f, ok := unitFactorAfterName(`"metre",0.5]`); !ok || f != 0.5 {
+		t.Errorf("valid = %v, %v; want 0.5, true", f, ok)
+	}
+	if f, ok := unitFactorAfterName(`"metre",2`); !ok || f != 2 { // no trailing bracket (stop < 0)
+		t.Errorf("unterminated factor = %v, %v; want 2, true", f, ok)
+	}
+	for _, bad := range []string{`no quote`, `"unterminated`, `"m"]`, `"m",notanumber]`, `"m",-1]`} {
+		if _, ok := unitFactorAfterName(bad); ok {
+			t.Errorf("%q must decline", bad)
+		}
+	}
+}
+
+// TestGeoDoubleAtBounds: an out-of-range index or a non-positive size declines.
+func TestGeoDoubleAtBounds(t *testing.T) {
+	if _, ok := geoDoubleAt(nil, 0); ok {
+		t.Error("empty doubles must decline")
+	}
+	neg := make([]byte, 8)
+	binary.LittleEndian.PutUint64(neg, math.Float64bits(-1))
+	if _, ok := geoDoubleAt(neg, 0); ok {
+		t.Error("non-positive size must decline")
+	}
+}
+
+// TestCoordinateUnitMetresWalkEdges covers the VLR-walk edges: a leading non-CRS record is skipped,
+// a VLR count larger than the file stops the walk after the real records, and a GeoKey directory
+// claiming more keys than it holds stops at the truncation.
+func TestCoordinateUnitMetresWalkEdges(t *testing.T) {
+	metreWKT := append([]byte(`PROJCS["x",UNIT["metre",1]]`), 0)
+
+	other := make([]byte, vlrHeaderSize+4)
+	copy(other[2:18], "OTHER_PRODUCER")
+	binary.LittleEndian.PutUint16(other[20:], 4)
+	doc, err := Parse(lasBuilder{points: [][3]int32{{1, 1, 1}}, scale: [3]float64{1, 1, 1},
+		vlrs: [][]byte{other, crsVLR(wktRecordID, metreWKT)}}.bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := doc.CoordinateUnitMetres(); !ok || got != 1.0 {
+		t.Errorf("leading non-CRS VLR: got %v, %v; want 1, true", got, ok)
+	}
+
+	raw := lasBuilder{points: [][3]int32{{1, 1, 1}}, scale: [3]float64{1, 1, 1},
+		vlrs: [][]byte{crsVLR(wktRecordID, metreWKT)}}.bytes()
+	binary.LittleEndian.PutUint32(raw[100:], 5) // claim 5 VLRs; only 1 present
+	if doc, err = Parse(raw); err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := doc.CoordinateUnitMetres(); !ok || got != 1.0 {
+		t.Errorf("VLR count past end: got %v, %v; want 1, true (first read, rest skipped)", got, ok)
+	}
+
+	short := geoKeyDir(projLinearUnitsGeoKey, 0, 9001)
+	binary.LittleEndian.PutUint16(short[6:], 5) // claim 5 keys; only 1 present
+	if got, ok := lasWithVLR(crsVLR(geoKeyDirRecordID, short)).CoordinateUnitMetres(); !ok || got != 1.0 {
+		t.Errorf("truncated geokey dir: got %v, %v; want 1, true", got, ok)
+	}
+}

--- a/kernel/exchange/lasfmt/lasfmt_test.go
+++ b/kernel/exchange/lasfmt/lasfmt_test.go
@@ -17,8 +17,9 @@ type lasBuilder struct {
 	points       [][3]int32
 	scale        [3]float64
 	offset       [3]float64
-	v14          bool   // LAS 1.4 header (375 bytes, 64-bit count) vs 1.2 (227 bytes, 32-bit)
-	recordLength uint16 // 0 → format-0 default of 20
+	v14          bool     // LAS 1.4 header (375 bytes, 64-bit count) vs 1.2 (227 bytes, 32-bit)
+	recordLength uint16   // 0 → format-0 default of 20
+	vlrs         [][]byte // full VLRs (54-byte header + payload), placed between the header and points
 }
 
 func (b lasBuilder) bytes() []byte {
@@ -36,15 +37,23 @@ func (b lasBuilder) bytes() []byte {
 	if b.v14 {
 		hdr[25] = 4
 	}
+	vlrBytes := 0
+	for _, v := range b.vlrs {
+		vlrBytes += len(v)
+	}
 	binary.LittleEndian.PutUint16(hdr[94:], uint16(headerSize))
-	binary.LittleEndian.PutUint32(hdr[96:], uint32(headerSize)) // point data starts right after header
-	hdr[104] = 0                                                // point format 0
+	binary.LittleEndian.PutUint32(hdr[96:], uint32(headerSize+vlrBytes)) // point data starts after header + VLRs
+	binary.LittleEndian.PutUint32(hdr[100:], uint32(len(b.vlrs)))
+	hdr[104] = 0 // point format 0
 	binary.LittleEndian.PutUint16(hdr[105:], recLen)
 	b.writeCount(hdr)
 	putVec3(hdr, 131, b.scale)
 	putVec3(hdr, 155, b.offset)
 
 	out := hdr
+	for _, v := range b.vlrs {
+		out = append(out, v...)
+	}
 	for _, p := range b.points {
 		rec := make([]byte, recLen)
 		for c, off := 0, 0; c < 3 && off+4 <= int(recLen); c, off = c+1, off+4 {
@@ -53,6 +62,28 @@ func (b lasBuilder) bytes() []byte {
 		out = append(out, rec...)
 	}
 	return out
+}
+
+// crsVLR assembles one "LASF_Projection" VLR (54-byte header + payload) for the CRS record id.
+func crsVLR(recordID uint16, payload []byte) []byte {
+	v := make([]byte, vlrHeaderSize+len(payload))
+	copy(v[2:18], crsUserID)
+	binary.LittleEndian.PutUint16(v[18:], recordID)
+	binary.LittleEndian.PutUint16(v[20:], uint16(len(payload)))
+	copy(v[vlrHeaderSize:], payload)
+	return v
+}
+
+// geoKeyDir packs a GeoKey directory holding a single (keyID, tagLoc, count, valueOffset) entry.
+func geoKeyDir(keyID, tagLoc, valueOffset uint16) []byte {
+	dir := make([]byte, 16)                   // 4-uint16 header + one 4-uint16 key
+	binary.LittleEndian.PutUint16(dir[0:], 1) // KeyDirectoryVersion
+	binary.LittleEndian.PutUint16(dir[6:], 1) // NumberOfKeys
+	binary.LittleEndian.PutUint16(dir[8:], keyID)
+	binary.LittleEndian.PutUint16(dir[10:], tagLoc)
+	binary.LittleEndian.PutUint16(dir[12:], 1) // count
+	binary.LittleEndian.PutUint16(dir[14:], valueOffset)
+	return dir
 }
 
 // writeCount populates the legacy 32-bit count, and for a 1.4 header the authoritative 64-bit one
@@ -149,5 +180,81 @@ func TestVerticesRecordTooSmall(t *testing.T) {
 	}
 	if _, err := doc.Vertices(); err == nil || !strings.Contains(err.Error(), "too small") {
 		t.Errorf("want record-length error, got %v", err)
+	}
+}
+
+// --- CRS / unit VLR tests (#1789) ---
+
+func lasWithVLR(vlr []byte) *Document {
+	doc, err := Parse(lasBuilder{points: [][3]int32{{1, 1, 1}}, scale: [3]float64{1, 1, 1}, vlrs: [][]byte{vlr}}.bytes())
+	if err != nil {
+		panic(err)
+	}
+	return doc
+}
+
+// TestCoordinateUnitMetresWKT: a projected WKT declares a linear unit whose metre factor is read
+// straight from the string (WKT2 LENGTHUNIT or WKT1 UNIT), regardless of the unit's name.
+func TestCoordinateUnitMetresWKT(t *testing.T) {
+	cases := []struct {
+		name string
+		wkt  string
+		want float64
+		ok   bool
+	}{
+		{"wkt2 us survey foot",
+			`PROJCRS["NAD83 / test",BASEGEOGCRS["NAD83",DATUM["x",ELLIPSOID["GRS 1980",6378137,298.257,LENGTHUNIT["metre",1]]],ANGLEUNIT["degree",0.0174532925199433]],CS[Cartesian,2],AXIS["e",east],AXIS["n",north],LENGTHUNIT["US survey foot",0.30480060960121924]]`,
+			0.30480060960121924, true},
+		{"wkt1 metre last unit",
+			`PROJCS["x",GEOGCS["y",DATUM["d",SPHEROID["s",6378137,298.257]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],PROJECTION["Transverse_Mercator"],PARAMETER["scale",1],UNIT["metre",1],AXIS["E",EAST],AXIS["N",NORTH]]`,
+			1.0, true},
+		{"geographic only (degrees) is not linear",
+			`GEOGCS["WGS 84",DATUM["d",SPHEROID["WGS 84",6378137,298.257]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]]`,
+			0, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := lasWithVLR(crsVLR(wktRecordID, append([]byte(c.wkt), 0))).CoordinateUnitMetres()
+			if ok != c.ok || (ok && got != c.want) {
+				t.Errorf("CoordinateUnitMetres() = %v, %v; want %v, %v", got, ok, c.want, c.ok)
+			}
+		})
+	}
+}
+
+// TestCoordinateUnitMetresGeoKey: a GeoTIFF ProjLinearUnitsGeoKey with an inline EPSG code maps to
+// the unit's size in metres; an unknown code declines so the caller falls back to the heuristic.
+func TestCoordinateUnitMetresGeoKey(t *testing.T) {
+	cases := []struct {
+		name string
+		code uint16
+		want float64
+		ok   bool
+	}{
+		{"metre", 9001, 1.0, true},
+		{"international foot", 9002, 0.3048, true},
+		{"us survey foot", 9003, 0.30480060960121924, true},
+		{"unknown code declines", 9999, 0, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := geoKeyDir(projLinearUnitsGeoKey, 0, c.code) // tagLoc 0 → value inline
+			got, ok := lasWithVLR(crsVLR(geoKeyDirRecordID, dir)).CoordinateUnitMetres()
+			if ok != c.ok || (ok && got != c.want) {
+				t.Errorf("CoordinateUnitMetres() = %v, %v; want %v, %v", got, ok, c.want, c.ok)
+			}
+		})
+	}
+}
+
+// TestCoordinateUnitMetresNoCRS: a file with no projection VLR declares no unit, so the reader falls
+// back to its own policy.
+func TestCoordinateUnitMetresNoCRS(t *testing.T) {
+	doc, err := Parse(lasBuilder{points: [][3]int32{{1, 1, 1}}, scale: [3]float64{0.01, 0.01, 0.01}}.bytes())
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, ok := doc.CoordinateUnitMetres(); ok {
+		t.Error("a LAS with no CRS VLR must not declare a coordinate unit")
 	}
 }

--- a/kernel/exchange/lasfmt/vlr.go
+++ b/kernel/exchange/lasfmt/vlr.go
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package lasfmt
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// LAS carries its coordinate reference system in Variable Length Records (VLRs) under the
+// "LASF_Projection" user id: either an OGC WKT string (record id 2112, the LAS 1.4 default) or a
+// GeoTIFF GeoKey directory (record id 34735, with its double params in 34736). Both spell out the
+// horizontal linear unit and its size in metres, which a point-cloud import needs to place the scan
+// at true scale — a survey in US survey feet is otherwise read as metres (~3.28x too large) and a
+// millimetre-declared scan 1000x too large (Oblikovati/Oblikovati#1789). This file walks the VLRs
+// and extracts that metres-per-unit factor.
+
+const (
+	vlrHeaderSize     = 54 // reserved(2) + userID(16) + recordID(2) + recordLen(2) + description(32)
+	crsUserID         = "LASF_Projection"
+	wktRecordID       = 2112  // OGC Coordinate System WKT
+	geoKeyDirRecordID = 34735 // GeoKeyDirectoryTag
+	geoDoubleRecordID = 34736 // GeoDoubleParamsTag
+
+	projLinearUnitsGeoKey = 3076  // EPSG code of the projected CRS's linear unit
+	projLinearSizeGeoKey  = 3077  // user-defined linear unit size in metres (when 3076 == user-defined)
+	geoKeyUserDefined     = 32767 // "the value is user-defined; read the size key"
+)
+
+// coordinateUnitMetres returns the horizontal linear unit's size in metres declared by the file's
+// CRS VLRs (e.g. 1.0 for metre, 0.3048 for the international foot, 0.30480060960121924 for the US
+// survey foot), and whether one was found. WKT is preferred over the GeoTIFF GeoKeys when both are
+// present (it is the LAS 1.4 canonical form and carries the exact factor); a geographic-only CRS
+// (degrees, no linear XY) yields ok=false.
+func coordinateUnitMetres(data []byte, h lasHeader) (float64, bool) {
+	wkt, geoDir, geoDoubles := crsVLRs(data, h)
+	if f, ok := wktLinearUnitMetres(wkt); ok {
+		return f, true
+	}
+	return geoKeyLinearUnitMetres(geoDir, geoDoubles)
+}
+
+// crsVLRs walks the VLR block after the public header and returns the raw payloads of the CRS
+// records: the WKT string and the GeoKey directory plus its double-params array. Missing records
+// come back empty. Malformed lengths stop the walk rather than reading past the file.
+func crsVLRs(data []byte, h lasHeader) (wkt string, geoDir, geoDoubles []byte) {
+	pos := int(h.headerSize)
+	for i := uint32(0); i < h.vlrCount; i++ {
+		userID, recordID, payload, next, ok := readVLR(data, pos)
+		if !ok {
+			return
+		}
+		pos = next
+		if userID != crsUserID {
+			continue
+		}
+		switch recordID {
+		case wktRecordID:
+			wkt = cString(payload)
+		case geoKeyDirRecordID:
+			geoDir = payload
+		case geoDoubleRecordID:
+			geoDoubles = payload
+		}
+	}
+	return
+}
+
+// readVLR parses the VLR at pos, returning its user id, record id, payload, and the offset of the
+// next VLR. ok is false when the record header or its declared length runs past the file.
+func readVLR(data []byte, pos int) (userID string, recordID uint16, payload []byte, next int, ok bool) {
+	if pos+vlrHeaderSize > len(data) {
+		return "", 0, nil, 0, false
+	}
+	recordLen := int(binary.LittleEndian.Uint16(data[pos+20:]))
+	body := pos + vlrHeaderSize
+	if body+recordLen > len(data) {
+		return "", 0, nil, 0, false
+	}
+	return cString(data[pos+2 : pos+18]), binary.LittleEndian.Uint16(data[pos+18:]), data[body : body+recordLen], body + recordLen, true
+}
+
+// wktLinearUnitMetres extracts the linear unit's metre conversion factor from an OGC WKT string. The
+// factor is the second argument of the linear unit keyword, so no unit-name table is needed. Only a
+// projected CRS has a linear XY unit; a geographic CRS (degrees) yields ok=false. WKT2 tags the
+// linear unit LENGTHUNIT (angular is ANGLEUNIT); WKT1 uses UNIT, whose last occurrence in a PROJCS
+// is the linear one (the earlier UNIT is the base geographic degree).
+func wktLinearUnitMetres(wkt string) (float64, bool) {
+	if wkt == "" {
+		return 0, false
+	}
+	up := strings.ToUpper(wkt)
+	if !strings.Contains(up, "PROJCRS") && !strings.Contains(up, "PROJCS") {
+		return 0, false // geographic (degrees) — not a linear scan unit
+	}
+	if f, ok := lastUnitFactor(up, "LENGTHUNIT"); ok { // WKT2
+		return f, true
+	}
+	return lastUnitFactor(up, "UNIT") // WKT1
+}
+
+// lastUnitFactor reads the metre-conversion factor from the last `KEYWORD["name",factor…]` in wkt.
+// It takes the LAST occurrence because a projected CRS nests the base geographic unit before its own
+// coordinate unit.
+func lastUnitFactor(wkt, keyword string) (float64, bool) {
+	idx := strings.LastIndex(wkt, keyword+"[")
+	if idx < 0 {
+		return 0, false
+	}
+	return unitFactorAfterName(wkt[idx+len(keyword)+1:])
+}
+
+// unitFactorAfterName parses `"unit name",factor…` and returns the factor, skipping the quoted name
+// so a comma or bracket inside it cannot confuse the parse.
+func unitFactorAfterName(s string) (float64, bool) {
+	open := strings.IndexByte(s, '"')
+	if open < 0 {
+		return 0, false
+	}
+	end := strings.IndexByte(s[open+1:], '"')
+	if end < 0 {
+		return 0, false
+	}
+	s = s[open+1+end+1:]
+	comma := strings.IndexByte(s, ',')
+	if comma < 0 {
+		return 0, false
+	}
+	stop := strings.IndexAny(s[comma+1:], ",]")
+	if stop < 0 {
+		stop = len(s) - comma - 1
+	}
+	f, err := strconv.ParseFloat(strings.TrimSpace(s[comma+1:comma+1+stop]), 64)
+	if err != nil || f <= 0 {
+		return 0, false
+	}
+	return f, true
+}
+
+// geoKeyLinearUnitMetres reads ProjLinearUnitsGeoKey (3076) from a GeoTIFF GeoKey directory. An
+// inline EPSG code maps through epsgLinearMetres; a user-defined unit (32767) reads its metre size
+// from ProjLinearUnitSizeGeoKey (3077) in the GeoDoubleParams array.
+func geoKeyLinearUnitMetres(dir, doubles []byte) (float64, bool) {
+	unit, sizeIndex, hasSize, ok := scanLinearUnitKeys(dir)
+	if !ok {
+		return 0, false
+	}
+	if unit == geoKeyUserDefined && hasSize {
+		return geoDoubleAt(doubles, sizeIndex)
+	}
+	if unit == 0 {
+		return 0, false
+	}
+	return epsgLinearMetres(unit)
+}
+
+// scanLinearUnitKeys reads ProjLinearUnitsGeoKey (the unit code) and ProjLinearUnitSizeGeoKey (its
+// GeoDoubleParams index, for a user-defined unit) from a GeoKey directory of [4-uint16 header, then
+// 4 uint16 per key]. ok is false on a malformed directory or a units key stored anywhere but inline.
+func scanLinearUnitKeys(dir []byte) (unit, sizeIndex int, hasSize, ok bool) {
+	if len(dir) < 8 {
+		return 0, 0, false, false
+	}
+	u16 := func(i int) uint16 { return binary.LittleEndian.Uint16(dir[i*2:]) }
+	numKeys := int(u16(3))
+	for k := 0; k < numKeys; k++ {
+		base := 4 + k*4
+		if (base+4)*2 > len(dir) {
+			break
+		}
+		keyID, tagLoc, valOff := u16(base), u16(base+1), u16(base+3)
+		switch keyID {
+		case projLinearUnitsGeoKey:
+			if tagLoc != 0 { // linear units are a SHORT stored inline (tagLoc 0); anything else is malformed
+				return 0, 0, false, false
+			}
+			unit = int(valOff)
+		case projLinearSizeGeoKey:
+			if tagLoc == geoDoubleRecordID { // the size lives in the GeoDoubleParams VLR (34736)
+				sizeIndex, hasSize = int(valOff), true
+			}
+		}
+	}
+	return unit, sizeIndex, hasSize, true
+}
+
+// epsgLinearMetres maps the common EPSG linear-unit codes to their size in metres. Unknown codes
+// yield ok=false so the caller falls back to the quantisation heuristic rather than guessing.
+func epsgLinearMetres(code int) (float64, bool) {
+	switch code {
+	case 9001:
+		return 1.0, true // metre
+	case 9002:
+		return 0.3048, true // international foot
+	case 9003:
+		return 0.30480060960121924, true // US survey foot (1200/3937)
+	default:
+		return 0, false
+	}
+}
+
+// geoDoubleAt returns the float64 at index i of the GeoDoubleParams array (8 bytes each).
+func geoDoubleAt(doubles []byte, i int) (float64, bool) {
+	if i < 0 || (i+1)*8 > len(doubles) {
+		return 0, false
+	}
+	v := math.Float64frombits(binary.LittleEndian.Uint64(doubles[i*8:]))
+	if v <= 0 {
+		return 0, false
+	}
+	return v, true
+}
+
+// cString trims a fixed-width byte field at its first NUL (LAS pads userID/description with NULs).
+func cString(b []byte) string {
+	if i := bytes.IndexByte(b, 0); i >= 0 {
+		b = b[:i]
+	}
+	return strings.TrimRight(string(b), " ")
+}

--- a/model/pointcloud/las.go
+++ b/model/pointcloud/las.go
@@ -36,17 +36,30 @@ func lasMillimetreScan(scale [3]float64) bool {
 	return scale[0] >= 1 && scale[1] >= 1 && scale[2] >= 1
 }
 
-// fileUnitMM overrides the metre default (see FileUnitMM) for a LAS whose coordinate quantisation is
-// too coarse to be metres, reading it as millimetres so a millimetre-authored scan does not import
-// 1000× oversized and kilometres from the origin, where it renders invisibly (#1789). Conformant
-// surveys (sub-metre scale) keep the metre unit. ok is false only when the header cannot be parsed,
-// leaving the static FileUnitMM in force (the decode then fails in ReadSamples with the real error).
+// fileUnitMM overrides the static metre default (see FileUnitMM) with the file's true coordinate
+// unit (#1789). It first honours an explicit CRS declaration — a WKT or GeoTIFF linear unit in the
+// VLRs — so a survey in US survey feet (~3.28× off if read as metres) or a WKT-declared millimetre
+// scan places at true scale. With no linear CRS it falls back to the quantisation heuristic: a scan
+// quantised to a whole metre or coarser is really millimetres, else the ASPRS metre. ok is false
+// only when the header cannot be parsed, leaving the static FileUnitMM in force (the decode then
+// fails in ReadSamples with the real error).
 func (lasReader) fileUnitMM(data []byte) (mm float64, ok bool) {
 	doc, err := lasfmt.Parse(data)
 	if err != nil {
 		return 0, false
 	}
-	return scanUnitMM(lasMillimetreScan(doc.Header().Scale)), true
+	crsMetres, declared := doc.CoordinateUnitMetres()
+	return lasUnitMM(crsMetres, declared, doc.Header().Scale), true
+}
+
+// lasUnitMM chooses the file's millimetres-per-unit: an explicit CRS linear unit wins (its
+// metres-per-unit scaled to mm), else the coarse-quantisation heuristic decides mm vs metre (#1789).
+// Kept pure so the CRS-over-heuristic precedence is tested without synthesising LAS bytes.
+func lasUnitMM(crsMetres float64, crsDeclared bool, scale [3]float64) float64 {
+	if crsDeclared {
+		return crsMetres * 1000 // metres-per-unit → millimetres-per-unit
+	}
+	return scanUnitMM(lasMillimetreScan(scale))
 }
 
 // ReadSamples decodes the LAS point records into cloud-local samples.

--- a/model/pointcloud/las_test.go
+++ b/model/pointcloud/las_test.go
@@ -50,6 +50,34 @@ func TestLASMillimetreScan(t *testing.T) {
 	}
 }
 
+// TestLASUnitMM: an explicit CRS linear unit wins over the quantisation heuristic — a survey in feet
+// or a WKT-declared millimetre keeps its true scale even when its coarse integer scale would
+// otherwise be read as millimetres — while a file with no CRS falls back to the heuristic (#1789).
+func TestLASUnitMM(t *testing.T) {
+	coarse := [3]float64{1, 1, 1}   // heuristic alone → millimetres
+	fine := [3]float64{0.001, 1, 1} // heuristic alone → metres (a sub-metre axis)
+	cases := []struct {
+		name        string
+		crsMetres   float64
+		crsDeclared bool
+		scale       [3]float64
+		want        float64
+	}{
+		{"metre CRS over coarse scale", 1.0, true, coarse, 1000},
+		{"US survey foot CRS over coarse scale", 0.30480060960121924, true, coarse, 304.80060960121924},
+		{"millimetre CRS over fine scale", 0.001, true, fine, 1},
+		{"no CRS, coarse scale → mm heuristic", 0, false, coarse, 1},
+		{"no CRS, fine scale → metre heuristic", 0, false, fine, 1000},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := lasUnitMM(c.crsMetres, c.crsDeclared, c.scale); got != c.want {
+				t.Errorf("lasUnitMM(%v, %v, %v) = %v, want %v", c.crsMetres, c.crsDeclared, c.scale, got, c.want)
+			}
+		})
+	}
+}
+
 // TestLASReaderImplementsPerFileUnit: the LAS reader must expose the per-file unit seam, and an
 // undecodable header must decline (ok=false) so the static FileUnitMM stays in force (#1789).
 func TestLASReaderImplementsPerFileUnit(t *testing.T) {


### PR DESCRIPTION
## What

The LAS reader now reads the **coordinate reference system's linear unit** from the file's VLRs and places the scan at that true scale, instead of assuming metres and leaning only on the coarse-quantisation heuristic.

End-to-end (same integer coords, `scale [1,1,1]` — which the heuristic alone would call millimetres):

| declared CRS | metres/unit | a raw 2000-unit span imports as |
|---|---|---|
| metre | 1.0 | 2000 m |
| US survey foot | 0.30480060960121924 | 609.60 m (exact) |
| _(no CRS VLR)_ | — | heuristic decides (mm/metre) |

## Why

LAS stores its CRS under the `LASF_Projection` user id as either an **OGC WKT** string (record 2112, the LAS 1.4 default) or a **GeoTIFF GeoKey directory** (34735). Both spell out the horizontal linear unit and its metre size. Reading it fixes the classes the #1789 heuristic can't:
- a survey in **US survey feet** was taken as metres → ~3.28× too large;
- a **WKT-declared millimetre** scan → 1000× too large.

## How

New `lasfmt/vlr.go` walks the VLRs and exposes `Document.CoordinateUnitMetres()`:
- **WKT**: reads the metre factor straight out of the linear unit keyword (WKT2 `LENGTHUNIT`, WKT1 `UNIT`) — the factor is the keyword's second argument, so **no unit-name table** is needed and any unit is handled. Only a projected CRS has a linear XY unit; a geographic (degrees) CRS declines.
- **GeoTIFF**: maps the common EPSG linear codes (`9001` metre, `9002` international foot, `9003` US survey foot) from `ProjLinearUnitsGeoKey`, plus a user-defined unit via `ProjLinearUnitSizeGeoKey` in `GeoDoubleParams`. Unknown codes decline.

Precedence in the point-cloud reader: **explicit CRS wins**, else the #1789 coarse-quantisation heuristic decides mm vs metre, else metre. The unit choice is factored into a pure `lasUnitMM` so the precedence is unit-tested without synthesising bytes.

## Tests

- `lasfmt`: `CoordinateUnitMetres` across WKT2 (foot), WKT1 (metre), geographic-declines, and GeoKey (metre/foot/US-foot/unknown-declines/no-CRS) — driven through the builder, now extended with VLR support.
- `pointcloud`: `TestLASUnitMM` pins the CRS-over-heuristic precedence (metre/foot/mm CRS beat a coarse scale; no-CRS falls back).
- Full root suite + `golangci-lint` clean; coverage 82% (lasfmt) / 86% (pointcloud).

Completes the #1789 follow-ups (E57 unit #1790, LAS unit #1791, far-plane render #1792). A LAS whose XY and Z declare *different* units, and LAZ, remain out of scope.