### PR TITLE
Normalise point-cloud RGB to 0..1 at decode by known bit depth (#1787)

### DIFF
--- a/app/point_cloud_render.go
+++ b/app/point_cloud_render.go
@@ -169,22 +169,11 @@ func displaySampleColor(pc *pointcloud.PointCloud, s pointcloud.PointSample, low
 	return renderer.PointCloudColor
 }
 
+// rgbMarkerColor is the marker colour for an RGB-mode scan point. The readers normalise colour to
+// 0..1 per the file's known bit depth at decode (#1787), so this only clamps into the valid range and
+// adds opaque alpha — no per-point bit-depth guessing, which mis-scaled dark 16-bit points.
 func rgbMarkerColor(rgb [3]float32) [4]float32 {
-	m := rgb[0]
-	if rgb[1] > m {
-		m = rgb[1]
-	}
-	if rgb[2] > m {
-		m = rgb[2]
-	}
-	if m <= 1 {
-		return [4]float32{clamp01(rgb[0]), clamp01(rgb[1]), clamp01(rgb[2]), 1}
-	}
-	scale := float32(255)
-	if m > 255 {
-		scale = 65535
-	}
-	return [4]float32{clamp01(rgb[0] / scale), clamp01(rgb[1] / scale), clamp01(rgb[2] / scale), 1}
+	return [4]float32{clamp01(rgb[0]), clamp01(rgb[1]), clamp01(rgb[2]), 1}
 }
 
 func intensityMarkerColor(pc *pointcloud.PointCloud, intensity float64, low, high [4]float32) ([4]float32, bool) {

--- a/app/point_cloud_render_test.go
+++ b/app/point_cloud_render_test.go
@@ -41,6 +41,34 @@ func TestPointCloudItemsRendersVisibleClouds(t *testing.T) {
 	}
 }
 
+// TestRGBModeDoesNotReamplifyNormalisedColor is the #1787 regression: colour arrives at the renderer
+// already normalised to 0..1 by the reader (a dark 16-bit point is ~0.003, not 200), so RGB mode must
+// pass it through with a clamp — no per-point bit-depth guessing that divided a dark point by 255 and
+// rendered it ~256× too bright. A dark point stays dark; a saturated point stays white.
+func TestRGBModeDoesNotReamplifyNormalisedColor(t *testing.T) {
+	s, def := emptyPartSession(t)
+	rid := def.AddResource(doc.Resource{Encoding: doc.EncodingUTF8, Value: []byte("scan")})
+	dark := [3]float32{200.0 / 65535, 200.0 / 65535, 200.0 / 65535} // a dark 16-bit point, decoded
+	pc, err := def.PointClouds().AddWithSamples("Cloud1", "c.las", rid, []pointcloud.PointSample{
+		{Point: math.P3(0, 0, 5), HasRGB: true, RGB: dark},
+		{Point: math.P3(1, 0, 5), HasRGB: true, RGB: [3]float32{1, 1, 1}},
+	})
+	if err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	pc.SetDisplayMode(types.PointCloudDisplayModeRGB)
+	items := s.PointCloudItems(s.Camera(), 0.5)
+	if len(items) != 1 {
+		t.Fatalf("items = %+v, want one batch", items)
+	}
+	if got := items[0].Colors[0]; got != [4]float32{dark[0], dark[1], dark[2], 1} {
+		t.Errorf("dark 16-bit point rendered %v, want it dim %v (not re-amplified)", got, dark)
+	}
+	if got := items[0].Colors[6]; got != [4]float32{1, 1, 1, 1} {
+		t.Errorf("saturated point rendered %v, want white {1,1,1,1}", got)
+	}
+}
+
 // TestPointCloudBounds returns the model-space extent of the visible clouds — the box the viewport
 // far plane consults to enclose a large or distant scan (#1789). No clouds, or only hidden ones,
 // yield an empty box.

--- a/kernel/exchange/lasfmt/lasfmt_test.go
+++ b/kernel/exchange/lasfmt/lasfmt_test.go
@@ -220,8 +220,10 @@ func TestScanDecodesIntensityAndRGB(t *testing.T) {
 	if len(s.Points) != 1 || !s.HasIntensity() || !s.HasRGB() {
 		t.Fatalf("scan = %+v, want 1 point with intensity+rgb", s)
 	}
-	if s.Intensity[0] != 77 || s.RGB[0] != [3]float32{9, 8, 7} || float64(s.Points[0].X) != 10 {
-		t.Errorf("scan row = pt %+v int %v rgb %v, want x=10 int=77 rgb=9/8/7", s.Points[0], s.Intensity[0], s.RGB[0])
+	// LAS colour is 16-bit, normalised to 0..1 by /65535 at decode (#1787); intensity stays raw.
+	wantRGB := [3]float32{float32(9) / 65535, float32(8) / 65535, float32(7) / 65535}
+	if s.Intensity[0] != 77 || s.RGB[0] != wantRGB || float64(s.Points[0].X) != 10 {
+		t.Errorf("scan row = pt %+v int %v rgb %v, want x=10 int=77 rgb=9,8,7 /65535", s.Points[0], s.Intensity[0], s.RGB[0])
 	}
 }
 

--- a/kernel/exchange/lasfmt/scan.go
+++ b/kernel/exchange/lasfmt/scan.go
@@ -13,8 +13,9 @@ import (
 // intensity and RGB colour when the point data record format carries them (#645, #1788). Intensity
 // and RGB are nil when the format omits them and otherwise align 1:1 with Points. Every LAS record
 // format (0–10) holds intensity, so any record whose stride reaches it yields an intensity column;
-// RGB comes only from the colour formats (2, 3, 5, 7, 8, 10). RGB holds the raw 16-bit channel
-// values; per-cloud normalisation to 0..1 is the model layer's job (#1787).
+// RGB comes only from the colour formats (2, 3, 5, 7, 8, 10). RGB is normalised to 0..1 from the
+// ASPRS 16-bit colour range (/65535), so a caller renders colour without guessing the bit depth per
+// point (#1787) — the same contract as e57fmt.Scan. Intensity is the raw decoded value.
 //
 // Example:
 //
@@ -68,8 +69,12 @@ func newLASScanData(h lasHeader) ScanData {
 	return data
 }
 
+// lasColorMax is the ASPRS 16-bit colour channel maximum; RGB is normalised to 0..1 by it (#1787).
+const lasColorMax = 65535
+
 // setChannels writes row i's intensity and colour columns from the point record. It reads only the
-// columns newLASScanData allocated, so the stride is known to hold whatever offset it reads.
+// columns newLASScanData allocated, so the stride is known to hold whatever offset it reads. Colour
+// is normalised to 0..1 from the 16-bit range; intensity stays raw (the model ramps it per cloud).
 func (data ScanData) setChannels(i int, rec []byte, h lasHeader) {
 	if data.Intensity != nil {
 		data.Intensity[i] = float64(binary.LittleEndian.Uint16(rec[12:14]))
@@ -77,9 +82,9 @@ func (data ScanData) setChannels(i int, rec []byte, h lasHeader) {
 	if data.RGB != nil {
 		off, _ := rgbRecordOffset(h.pointFormat)
 		data.RGB[i] = [3]float32{
-			float32(binary.LittleEndian.Uint16(rec[off : off+2])),
-			float32(binary.LittleEndian.Uint16(rec[off+2 : off+4])),
-			float32(binary.LittleEndian.Uint16(rec[off+4 : off+6])),
+			float32(binary.LittleEndian.Uint16(rec[off:off+2])) / lasColorMax,
+			float32(binary.LittleEndian.Uint16(rec[off+2:off+4])) / lasColorMax,
+			float32(binary.LittleEndian.Uint16(rec[off+4:off+6])) / lasColorMax,
 		}
 	}
 }

--- a/kernel/exchange/plyfmt/plyfmt_test.go
+++ b/kernel/exchange/plyfmt/plyfmt_test.go
@@ -131,12 +131,19 @@ func TestScanASCIIChannels(t *testing.T) {
 	if len(s.Points) != 2 || !s.HasIntensity() || !s.HasRGB() {
 		t.Fatalf("scan = %+v, want 2 points with intensity+rgb", s)
 	}
-	if s.Points[1].X != 4 || s.Intensity[0] != 77 || s.RGB[0] != [3]float32{9, 8, 7} {
-		t.Errorf("row 0 = pt %+v int %v rgb %v, want x=1 int=77 rgb=9/8/7", s.Points[0], s.Intensity[0], s.RGB[0])
+	// uchar colour is normalised to 0..1 by /255 at decode (#1787); intensity stays raw.
+	if s.Points[1].X != 4 || s.Intensity[0] != 77 || s.RGB[0] != uchar255(9, 8, 7) {
+		t.Errorf("row 0 = pt %+v int %v rgb %v, want x=1 int=77 rgb=9,8,7 /255", s.Points[0], s.Intensity[0], s.RGB[0])
 	}
-	if s.Intensity[1] != 12 || s.RGB[1] != [3]float32{1, 2, 3} {
-		t.Errorf("row 1 = int %v rgb %v, want 12 and 1/2/3", s.Intensity[1], s.RGB[1])
+	if s.Intensity[1] != 12 || s.RGB[1] != uchar255(1, 2, 3) {
+		t.Errorf("row 1 = int %v rgb %v, want 12 and 1,2,3 /255", s.Intensity[1], s.RGB[1])
 	}
+}
+
+// uchar255 is the expected 0..1 normalisation of a uchar colour triple (the same float32 /255 the
+// decoder applies, so the comparison is bit-exact).
+func uchar255(r, g, b float32) [3]float32 {
+	return [3]float32{r / 255, g / 255, b / 255}
 }
 
 // TestScanBinaryChannels: a binary vertex with a uint16 intensity and uchar RGB decodes its channels
@@ -160,8 +167,49 @@ func TestScanBinaryChannels(t *testing.T) {
 	if err != nil || len(s.Points) != 1 {
 		t.Fatalf("Scan = %+v, err %v", s, err)
 	}
-	if s.Intensity[0] != 77 || s.RGB[0] != [3]float32{9, 8, 7} || s.Points[0].Z != 3 {
-		t.Errorf("scan row = pt %+v int %v rgb %v, want z=3 int=77 rgb=9/8/7", s.Points[0], s.Intensity[0], s.RGB[0])
+	if s.Intensity[0] != 77 || s.RGB[0] != uchar255(9, 8, 7) || s.Points[0].Z != 3 {
+		t.Errorf("scan row = pt %+v int %v rgb %v, want z=3 int=77 rgb=9,8,7 /255", s.Points[0], s.Intensity[0], s.RGB[0])
+	}
+}
+
+// TestColorScale maps each PLY colour scalar type to its 0..1 normaliser: integers by their unsigned
+// max, float/unknown passed through (#1787).
+func TestColorScale(t *testing.T) {
+	cases := map[string]float32{
+		"uchar": 255, "uint8": 255, "char": 255, "int8": 255,
+		"ushort": 65535, "uint16": 65535, "short": 65535, "int16": 65535,
+		"uint": 4294967295, "int32": 4294967295,
+		"float": 1, "double": 1, "weird": 1,
+	}
+	for typ, want := range cases {
+		if got := colorScale(typ); got != want {
+			t.Errorf("colorScale(%q) = %v, want %v", typ, got, want)
+		}
+	}
+}
+
+// TestScanUint16ColorNormalised: a ushort colour triple normalises by /65535, not /255, so a value
+// that would read near-white as 8-bit reads its true dim shade (#1787).
+func TestScanUint16ColorNormalised(t *testing.T) {
+	var b bytes.Buffer
+	for _, c := range []float32{0, 0, 0} {
+		_ = binary.Write(&b, binary.LittleEndian, c)
+	}
+	for _, c := range []uint16{200, 100, 65535} {
+		_ = binary.Write(&b, binary.LittleEndian, c)
+	}
+	src := append([]byte("ply\nformat binary_little_endian 1.0\n"+
+		"element vertex 1\nproperty float x\nproperty float y\nproperty float z\n"+
+		"property ushort red\nproperty ushort green\nproperty ushort blue\n"+
+		"end_header\n"), b.Bytes()...)
+	d, _ := Parse(src)
+	s, err := d.Scan()
+	if err != nil || len(s.RGB) != 1 {
+		t.Fatalf("Scan = %+v, err %v", s, err)
+	}
+	want := [3]float32{float32(200) / 65535, float32(100) / 65535, 1}
+	if s.RGB[0] != want {
+		t.Errorf("uint16 colour = %v, want %v (/65535, blue saturates to 1)", s.RGB[0], want)
 	}
 }
 

--- a/kernel/exchange/plyfmt/scan.go
+++ b/kernel/exchange/plyfmt/scan.go
@@ -14,14 +14,15 @@ import (
 
 // ScanData is the vertex element's decoded channels for a point-cloud import: the XYZ positions plus
 // any intensity and colour vertex properties the header declares (#645, #1788). RGB and Intensity are
-// nil when the vertex has no such property and otherwise align 1:1 with Points. RGB holds the raw
-// property values (a uchar 0..255 colour stays 0..255, a uint16 colour 0..65535); per-cloud
-// normalisation to 0..1 is the model layer's job, tracked separately (#1787).
+// nil when the vertex has no such property and otherwise align 1:1 with Points. RGB is normalised to
+// 0..1 from each colour property's declared scalar type (uchar → /255, uint16 → /65535, float passed
+// through), so a caller renders colour without guessing the bit depth per point (#1787) — the same
+// contract as e57fmt.Scan. Intensity is the raw decoded value (the model ramps it per cloud).
 //
 // Example:
 //
 //	d, _ := plyfmt.Parse(data)
-//	scan, err := d.Scan() // scan.Points, scan.RGB (or nil), scan.Intensity (or nil)
+//	scan, err := d.Scan() // scan.Points, scan.RGB (or nil, 0..1), scan.Intensity (or nil)
 type ScanData struct {
 	Points    []omath.Point3
 	RGB       [][3]float32
@@ -35,16 +36,34 @@ func (s ScanData) HasRGB() bool { return s.RGB != nil }
 func (s ScanData) HasIntensity() bool { return s.Intensity != nil }
 
 // vertexChannelIndices are the property positions of a vertex's decoded channels within its record;
-// -1 marks an absent channel.
+// -1 marks an absent channel. rgbScale is each colour component's 0..1 normaliser, derived once from
+// its declared scalar type so the per-record decode is a plain divide (#1787).
 type vertexChannelIndices struct {
 	x, y, z   int
 	intensity int
 	rgb       [3]int
+	rgbScale  [3]float32
 }
 
 // hasRGB reports whether all three colour components were located.
 func (ch vertexChannelIndices) hasRGB() bool {
 	return ch.rgb[0] >= 0 && ch.rgb[1] >= 0 && ch.rgb[2] >= 0
+}
+
+// colorScale returns the divisor that maps a PLY colour property of the given scalar type to 0..1:
+// the integer types by their unsigned maximum, the float types passed through (PLY float colour is
+// already 0..1 by convention). An unknown type falls back to 1 rather than distort the value (#1787).
+func colorScale(scalar string) float32 {
+	switch scalar {
+	case "char", "int8", "uchar", "uint8":
+		return 255
+	case "short", "int16", "ushort", "uint16":
+		return 65535
+	case "int", "int32", "uint", "uint32":
+		return 4294967295
+	default: // float, double, or unknown — already 0..1
+		return 1
+	}
 }
 
 // Scan decodes the vertex element's positions and any intensity / colour channels in a single pass.
@@ -86,6 +105,11 @@ func vertexChannels(vtx Element) (vertexChannelIndices, error) {
 	if ch.x < 0 || ch.y < 0 || ch.z < 0 {
 		return ch, fmt.Errorf("plyfmt: vertex has no x/y/z properties")
 	}
+	for i, idx := range ch.rgb {
+		if idx >= 0 {
+			ch.rgbScale[i] = colorScale(vtx.Props[idx].Scalar)
+		}
+	}
 	return ch, nil
 }
 
@@ -122,13 +146,18 @@ func (d *Document) binaryScan(vtx Element, ch vertexChannelIndices) (ScanData, e
 	return data, nil
 }
 
-// setBinaryChannels writes row i's intensity and colour columns from the per-record value accessor.
+// setBinaryChannels writes row i's intensity and colour columns from the per-record value accessor,
+// normalising each colour component to 0..1 by its declared scalar type (#1787).
 func (data ScanData) setBinaryChannels(i int, val func(int) float64, ch vertexChannelIndices) {
 	if ch.intensity >= 0 {
 		data.Intensity[i] = val(ch.intensity)
 	}
 	if ch.hasRGB() {
-		data.RGB[i] = [3]float32{float32(val(ch.rgb[0])), float32(val(ch.rgb[1])), float32(val(ch.rgb[2]))}
+		data.RGB[i] = [3]float32{
+			float32(val(ch.rgb[0])) / ch.rgbScale[0],
+			float32(val(ch.rgb[1])) / ch.rgbScale[1],
+			float32(val(ch.rgb[2])) / ch.rgbScale[2],
+		}
 	}
 }
 
@@ -169,7 +198,11 @@ func (data ScanData) setAsciiRow(i int, f []string, ch vertexChannelIndices) boo
 		}
 	}
 	if ch.hasRGB() {
-		data.RGB[i] = [3]float32{asciiColor(f, ch.rgb[0]), asciiColor(f, ch.rgb[1]), asciiColor(f, ch.rgb[2])}
+		data.RGB[i] = [3]float32{
+			asciiColor(f, ch.rgb[0]) / ch.rgbScale[0],
+			asciiColor(f, ch.rgb[1]) / ch.rgbScale[1],
+			asciiColor(f, ch.rgb[2]) / ch.rgbScale[2],
+		}
 	}
 	return true
 }

--- a/model/pointcloud/pointcloud_test.go
+++ b/model/pointcloud/pointcloud_test.go
@@ -41,11 +41,12 @@ func TestASCIIReaderParsesChannels(t *testing.T) {
 	if !samples[0].HasIntensity || samples[0].Intensity != 7 {
 		t.Errorf("first sample intensity = %+v, want 7", samples[0])
 	}
-	if !samples[1].HasRGB || samples[1].RGB != [3]float32{255, 128, 0} {
-		t.Errorf("second sample rgb = %+v, want [255 128 0]", samples[1])
+	// ASCII colour is normalised to 0..1 from the 0..255 convention at decode (#1787).
+	if !samples[1].HasRGB || samples[1].RGB != rgb255(255, 128, 0) {
+		t.Errorf("second sample rgb = %+v, want 255,128,0 /255", samples[1])
 	}
-	if !samples[2].HasIntensity || !samples[2].HasRGB || samples[2].Intensity != 42 || samples[2].RGB != [3]float32{10, 20, 30} {
-		t.Errorf("third sample = %+v, want intensity+rgb", samples[2])
+	if !samples[2].HasIntensity || !samples[2].HasRGB || samples[2].Intensity != 42 || samples[2].RGB != rgb255(10, 20, 30) {
+		t.Errorf("third sample = %+v, want intensity 42 and 10,20,30 /255", samples[2])
 	}
 }
 
@@ -297,8 +298,9 @@ func TestReadScanSamplesPreservesPLYAndLASChannels(t *testing.T) {
 	if len(samples) != 1 || !samples[0].HasIntensity || !samples[0].HasRGB {
 		t.Fatalf("PLY samples = %+v, want intensity+rgb", samples)
 	}
-	if samples[0].Intensity != 77 || samples[0].RGB != [3]float32{9, 8, 7} {
-		t.Errorf("PLY sample = %+v, want intensity 77 and rgb 9/8/7", samples[0])
+	// PLY uchar colour normalises /255, LAS 16-bit colour normalises /65535 (#1787).
+	if samples[0].Intensity != 77 || samples[0].RGB != rgb255(9, 8, 7) {
+		t.Errorf("PLY sample = %+v, want intensity 77 and rgb 9,8,7 /255", samples[0])
 	}
 
 	las := syntheticLASFormat3([3]int32{1, 2, 3}, 77, [3]uint16{9, 8, 7})
@@ -309,9 +311,16 @@ func TestReadScanSamplesPreservesPLYAndLASChannels(t *testing.T) {
 	if len(samples) != 1 || !samples[0].HasIntensity || !samples[0].HasRGB {
 		t.Fatalf("LAS samples = %+v, want intensity+rgb", samples)
 	}
-	if samples[0].Intensity != 77 || samples[0].RGB != [3]float32{9, 8, 7} {
-		t.Errorf("LAS sample = %+v, want intensity 77 and rgb 9/8/7", samples[0])
+	wantLAS := [3]float32{float32(9) / 65535, float32(8) / 65535, float32(7) / 65535}
+	if samples[0].Intensity != 77 || samples[0].RGB != wantLAS {
+		t.Errorf("LAS sample = %+v, want intensity 77 and rgb 9,8,7 /65535", samples[0])
 	}
+}
+
+// rgb255 is the expected 0..1 normalisation of an 8-bit colour triple (the same float32 /255 the
+// ASCII and PLY-uchar decoders apply, so the comparison is bit-exact).
+func rgb255(r, g, b float32) [3]float32 {
+	return [3]float32{r / 255, g / 255, b / 255}
 }
 
 func syntheticLASFormat3(xyz [3]int32, intensity uint16, rgb [3]uint16) []byte {

--- a/model/pointcloud/reader.go
+++ b/model/pointcloud/reader.go
@@ -312,6 +312,10 @@ func setSampleIntensity(s *PointSample, field string) {
 	}
 }
 
+// asciiColorMax is the ASCII scan colour convention's channel maximum; RGB is normalised to 0..1 by
+// it at decode so the renderer never guesses the bit depth per point (#1787).
+const asciiColorMax = 255
+
 // setSampleRGB sets the RGB channel from three ASCII fields, leaving it unset if any is unparsable.
 func setSampleRGB(s *PointSample, fields []string) {
 	if rgb, ok := parseRGBFields(fields); ok {
@@ -320,6 +324,8 @@ func setSampleRGB(s *PointSample, fields []string) {
 	}
 }
 
+// parseRGBFields parses three ASCII colour columns, normalising each to 0..1 from the 0..255 scan
+// convention (#1787). Returns false if any field is not numeric.
 func parseRGBFields(fields []string) ([3]float32, bool) {
 	var rgb [3]float32
 	for i := 0; i < 3; i++ {
@@ -327,7 +333,7 @@ func parseRGBFields(fields []string) ([3]float32, bool) {
 		if err != nil {
 			return [3]float32{}, false
 		}
-		rgb[i] = float32(v)
+		rgb[i] = float32(v) / asciiColorMax
 	}
 	return rgb, true
 }


### PR DESCRIPTION
## Problem

`rgbMarkerColor` (`app/point_cloud_render.go`) picked the 8-bit vs 16-bit divisor from a **single point's** max channel:

```go
scale := float32(255)
if m > 255 { scale = 65535 }
```

LAS stores RGB as `uint16` (ASPRS spec). In a true-16-bit cloud, a **dark** point whose three channels are all ≤255 (shadows, dark surfaces) was divided by 255 instead of 65535 and rendered **~256× too bright** — dark regions glowed and the same cloud showed inconsistent brightness.

## Fix

Normalise RGB to 0..1 **per cloud, at decode**, from the format's known bit depth — the way `e57fmt.Scan` already does — then collapse `rgbMarkerColor` to a clamp, removing the per-point guessing entirely:

- **LAS** (`lasfmt.Scan`): uint16 → `/65535`.
- **PLY** (`plyfmt.Scan`): per declared scalar type — `uchar → /255`, `uint16 → /65535`, float passed through (PLY float colour is already 0..1). Derived once per channel from the header, so the per-record decode is a plain divide.
- **ASCII** (`pointcloud/reader.go`): the 0..255 scan convention → `/255`.

All three format packages' `ScanData.RGB` now share the same 0..1 contract. Intensity stays raw (the model ramps it per cloud via its own range).

## Validation

- **Unit**, at every layer: `colorScale` mapping, `plyfmt`/`lasfmt` `Scan` channel decode (a uint16 200 → dim `200/65535`, not near-white), ASCII/PLY/LAS end-to-end channel assertions, and an app-layer regression (`TestRGBModeDoesNotReamplifyNormalisedColor`) proving a decoded dark 16-bit point renders dim and a saturated one white.
- **Live** on lavapipe: a PLY with a dark 16-bit block (value 200) beside a bright block — the dark block renders **near-black** (previously a glowing grey), the bright block its true colour.
- Coverage: plyfmt 91.7%, lasfmt 98.7%, model/pointcloud 92.5%. Full `go test ./...` green; format/model packages lint clean.

Closes #1787

🤖 Generated with [Claude Code](https://claude.com/claude-code)