### PR TITLE
fix(sketch): accept arcs in radius/diameter dimension restore

### DIFF
--- a/model/sketch/serialize_dimensions_roundtrip_test.go
+++ b/model/sketch/serialize_dimensions_roundtrip_test.go
@@ -62,3 +62,44 @@ func TestAllDimensionKindsSurviveRoundTrip(t *testing.T) {
 		t.Errorf("entity count after round trip = %d, want %d", got, wantEnts)
 	}
 }
+
+// TestArcRadiusDiameterSurviveRoundTrip guards the reader fix for radius/diameter
+// dimensions whose target is an *arc* (not a circle). AddRadius/AddDiameter accept any
+// CircularCurve, and Inventor commonly radius-dimensions arcs, but restoreDimension used
+// to resolve the operand via r.circle and reject arcs with "entity N is *sketch.Arc,
+// want a circle" — which blocked ~40% of real Inventor-exported parts on open. The
+// dimensions must restore and still target the arc.
+func TestArcRadiusDiameterSurviveRoundTrip(t *testing.T) {
+	sc := NewSketches()
+	s := sc.Add(XYPlane())
+	dc := s.DimensionConstraints()
+
+	pt := func(x, y float64) *Point { return s.NewPoint(math.P2(x, y)) }
+	rArc := s.Arcs().Add(pt(0, 0), pt(3, 0), pt(0, 3), true)
+	dArc := s.Arcs().Add(pt(10, 0), pt(12, 0), pt(10, 2), true)
+
+	if _, err := dc.AddRadius(rArc, "5 cm"); err != nil {
+		t.Fatalf("AddRadius on arc: %v", err)
+	}
+	if _, err := dc.AddDiameter(dArc, "8 cm"); err != nil {
+		t.Fatalf("AddDiameter on arc: %v", err)
+	}
+
+	// ApplyRecipe inside roundTrip is where the old r.circle restore path failed.
+	out := roundTrip(t, sc)
+	dims := out.DimensionConstraints().All()
+	if len(dims) != 2 {
+		t.Fatalf("restored dimension count = %d, want 2", len(dims))
+	}
+	for _, d := range dims {
+		if d.Kind() != RadiusDim && d.Kind() != DiameterDim {
+			t.Errorf("restored dim kind = %v, want radius or diameter", d.Kind())
+		}
+		if len(d.Refs()) != 1 {
+			t.Fatalf("restored dim refs = %d, want 1", len(d.Refs()))
+		}
+		if _, ok := d.Refs()[0].(*Arc); !ok {
+			t.Errorf("restored dim target = %T, want *Arc", d.Refs()[0])
+		}
+	}
+}

--- a/model/sketch/serialize_restore.go
+++ b/model/sketch/serialize_restore.go
@@ -274,13 +274,18 @@ func (r *sketchRestorer) restoreDimension(dd DimensionData) (*DimensionConstrain
 		}
 		return dc.AddDistance(a, b, dd.Expression)
 	case "radius":
-		c, err := r.circle(dd.Curves, 0)
+		// AddRadius accepts any CircularCurve (circle or arc) — an arc radius/diameter
+		// dimension is common (esp. from CAD imports), so resolve as a circular curve,
+		// not a *Circle. Restoring via r.circle rejected radius-dimensioned arcs and
+		// blocked ~40% of real Inventor-exported parts. Symmetric with the write side,
+		// which serializes d.refs regardless of circle-vs-arc.
+		c, err := r.curve(dd.Curves, 0)
 		if err != nil {
 			return nil, err
 		}
 		return dc.AddRadius(c, dd.Expression)
 	case "diameter":
-		c, err := r.circle(dd.Curves, 0)
+		c, err := r.curve(dd.Curves, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/model/sketch/serialize_restore.go
+++ b/model/sketch/serialize_restore.go
@@ -474,18 +474,6 @@ func (r *sketchRestorer) line(ids []int, i int) (*Line, error) {
 	return l, nil
 }
 
-func (r *sketchRestorer) circle(ids []int, i int) (*Circle, error) {
-	e, err := r.entity(ids, i)
-	if err != nil {
-		return nil, err
-	}
-	c, ok := e.(*Circle)
-	if !ok {
-		return nil, fmt.Errorf("entity %d is %T, want a circle", ids[i], e)
-	}
-	return c, nil
-}
-
 func (r *sketchRestorer) arc(ids []int, i int) (*Arc, error) {
 	e, err := r.entity(ids, i)
 	if err != nil {


### PR DESCRIPTION
## What

`restoreDimension` resolved the **radius**/**diameter** operand via `r.circle`, which rejects arcs. So a document carrying a radius/diameter dimension on an **arc** failed to load:

```
entity 37 is *sketch.Arc, want a circle
```

The rest of the stack already supports arcs — the model (`AddRadius`/`AddDiameter` take a `CircularCurve`), the serializer (writes `d.refs` regardless of curve kind), and the live-add router path. Only the **deserialize** codec was too strict. This resolves the operand via `r.curve` (any `CircularCurve`) in both the radius and diameter cases.

## How it surfaced

Round-tripping the Autodesk Inventor exporter's output through the real reader on a corpus of production parts: **21 of 51** parts carry an arc radius dimension and would not load. A radius dimension on an arc is extremely common in real CAD.

## Test

Adds `TestArcRadiusDiameterSurviveRoundTrip`. The existing all-kinds round-trip only dimensioned a **circle**, so it never exercised the arc path. `go test ./model/sketch/` passes.

## Related

Unblocks the arc-radius parts in the companion exporter change: Oblikovati/Oblikovati.Exporter.Inventor#28.
