### PR TITLE
feat(extrude): select regions by interior seed point (profilePoints)

### DIFF
--- a/model/feature/serialize_extrude.go
+++ b/model/feature/serialize_extrude.go
@@ -2,7 +2,13 @@
 
 package feature
 
-import "fmt"
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
 
 // ExtrudeData is an extrude's recipe: which sketch region(s), the boolean operation, and
 // the full extent (type, direction, distances, taper, and any work-plane targets). The
@@ -20,6 +26,11 @@ type ExtrudeData struct {
 	Taper     float64 `yaml:"taper,omitempty"`
 	ToPlane   string  `yaml:"toPlane,omitempty"`   // WorkRef of the to-face / from-to end / distance-from-face target
 	FromPlane string  `yaml:"fromPlane,omitempty"` // WorkRef of the from-to start
+	// ProfilePoints selects the extruded region(s) by an interior seed point (sketch 2-D cm),
+	// one per region, instead of by index. An external author (e.g. the Inventor exporter) cannot
+	// predict the reader's DCEL region ordering, so it names regions by containment. When present
+	// it wins over Profiles/Profile; absent, the index-based selection is used unchanged.
+	ProfilePoints [][]float64 `yaml:"profilePoints,omitempty"`
 }
 
 // extrudeProfiles returns the region indices a payload selects, accepting both the
@@ -94,7 +105,41 @@ func restoreExtrude(fs *PartFeatures, ed *ExtrudeData, sk SketchIndexer, work *W
 	if err != nil {
 		return nil, err
 	}
-	return NewExtrudeFeatures(fs).AddExtrude(skt, ed.extrudeProfiles(), op, extent, ed.Taper), nil
+	profiles := resolveSeeds(skt, ed.ProfilePoints, ed.extrudeProfiles())
+	return NewExtrudeFeatures(fs).AddExtrude(skt, profiles, op, extent, ed.Taper), nil
+}
+
+// resolveSeeds maps each interior seed point to the smallest closed region that contains it,
+// falling back to the explicit index list when no seeds are given or none resolve. Region
+// ordering is a DCEL-walk artifact (regions.go), so an author that knows only the region
+// geometry must select by containment, not index. It never returns empty (an empty selection
+// would extrude the whole body).
+func resolveSeeds(skt *sketch.Sketch, seeds [][]float64, fallback []int) []int {
+	if len(seeds) == 0 {
+		return fallback
+	}
+	profs := skt.Profiles()
+	var idx []int
+	for _, s := range seeds {
+		if len(s) != 2 {
+			continue
+		}
+		q := math.P2(s[0], s[1])
+		best, bestArea := -1, stdmath.Inf(1)
+		for i := 0; i < profs.Count(); i++ {
+			p := profs.Item(i)
+			if p.IsClosed() && p.Contains(q) && p.Area() < bestArea {
+				best, bestArea = i, p.Area()
+			}
+		}
+		if best >= 0 {
+			idx = append(idx, best)
+		}
+	}
+	if len(idx) == 0 {
+		return fallback
+	}
+	return idx
 }
 
 // restoreExtent rebuilds the extent from its recipe, resolving any work-plane targets.

--- a/model/feature/serialize_extrude_seeds_test.go
+++ b/model/feature/serialize_extrude_seeds_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// A rectangle split by a vertical line into a small left region (area 2) and a large
+// right region (area 6). Region *ordering* is a DCEL artifact, so an external author
+// must select by an interior seed point, not an index.
+func splitRectSketch() *sketch.Sketch {
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	l := sk.Lines()
+	l.AddByTwoPoints(math.P2(0, 0), math.P2(4, 0))
+	l.AddByTwoPoints(math.P2(4, 0), math.P2(4, 2))
+	l.AddByTwoPoints(math.P2(4, 2), math.P2(0, 2))
+	l.AddByTwoPoints(math.P2(0, 2), math.P2(0, 0))
+	l.AddByTwoPoints(math.P2(1, 0), math.P2(1, 2)) // split at x=1
+	return sk
+}
+
+func TestResolveSeedsSelectsRegionByContainment(t *testing.T) {
+	sk := splitRectSketch()
+
+	// A seed in the large right region resolves to whichever index holds area 6.
+	got := resolveSeeds(sk, [][]float64{{2.5, 1}}, []int{0})
+	if len(got) != 1 {
+		t.Fatalf("want one resolved index, got %v", got)
+	}
+	if a := sk.Profiles().Item(got[0]).Area(); stdmath.Abs(a-6) > 1e-6 {
+		t.Errorf("seed (2.5,1) resolved to a region of area %v, want the area-6 region", a)
+	}
+
+	// A seed in the small left region resolves to the area-2 region.
+	left := resolveSeeds(sk, [][]float64{{0.5, 1}}, []int{0})
+	if a := sk.Profiles().Item(left[0]).Area(); stdmath.Abs(a-2) > 1e-6 {
+		t.Errorf("seed (0.5,1) resolved to a region of area %v, want the area-2 region", a)
+	}
+}
+
+func TestResolveSeedsFallsBack(t *testing.T) {
+	sk := splitRectSketch()
+
+	// No seeds -> the explicit index list is used unchanged.
+	if got := resolveSeeds(sk, nil, []int{3}); len(got) != 1 || got[0] != 3 {
+		t.Errorf("no seeds: want fallback [3], got %v", got)
+	}
+	// A seed that lands in no region -> fall back (never an empty, whole-body selection).
+	if got := resolveSeeds(sk, [][]float64{{99, 99}}, []int{5}); len(got) != 1 || got[0] != 5 {
+		t.Errorf("unmatched seed: want fallback [5], got %v", got)
+	}
+}


### PR DESCRIPTION
## What

Adds an optional `profilePoints` field to `ExtrudeData`: one interior seed point (sketch 2D, cm) per extruded region. The reader resolves each seed to the region that **contains** it (`Profile.Contains`), instead of trusting a region **index**.

## Why

An external author (the Autodesk Inventor exporter) cannot predict the reader's DCEL region ordering (`regions.go`). Selecting a cut's region by index therefore picks the wrong region — usually a tiny sliver — so the cut removes almost no material. This is the dominant cause of over-volume on real imported parts (e.g. a shield block recomputed at +826% of its true volume).

`resolveSeeds` falls back to the explicit `profiles`/`profile` index list when no seeds are given or none resolve, and **never** returns an empty (whole-body) selection. Fully back-compatible.

## Test

`TestResolveSeedsSelectsRegionByContainment` / `TestResolveSeedsFallsBack` (a rectangle split into a small + large region; a seed selects the correct region regardless of ordering; unmatched/no seeds fall back). `go test ./model/feature/` green.

## Paired change

The Inventor exporter emits these seeds from Inventor's actual selected regions. Measured end-to-end with this change: two machined-holder parts went from +255%/+153% to +13%/+9% of true volume.