### PR TITLE
OCCT fillet/chamfer/draft parity blend engine (ADR-0050, milestone #43)

### DIFF
--- a/app/chamfer_tool.go
+++ b/app/chamfer_tool.go
@@ -75,11 +75,29 @@ func (t *ChamferTool) SetConcaveStrategyIndex(i int) {
 // Pick appends the clicked edge (ignoring one already chosen, so a double-click does not
 // duplicate it).
 func (t *ChamferTool) Pick(_ *Session, sel Selectable) {
+	if e, ok := sel.(EdgeHandle); ok {
+		t.addEdge(e)
+	}
+}
+
+// PickWithMods adds the whole tangent chain through the clicked edge on Shift+click — the
+// "select tangent chain / loop" selection (#1798); a plain click adds the single edge.
+func (t *ChamferTool) PickWithMods(s *Session, sel Selectable, mods Modifier) {
 	e, ok := sel.(EdgeHandle)
-	if !ok || t.hasEdge(e) {
+	if !ok || !mods.Has(ShiftMod) {
+		t.Pick(s, sel)
 		return
 	}
-	t.edges = append(t.edges, e)
+	for _, h := range s.tangentChainHandles(e) {
+		t.addEdge(h)
+	}
+}
+
+// addEdge appends an edge unless it is already selected.
+func (t *ChamferTool) addEdge(e EdgeHandle) {
+	if !t.hasEdge(e) {
+		t.edges = append(t.edges, e)
+	}
 }
 
 func (t *ChamferTool) hasEdge(e EdgeHandle) bool {

--- a/app/fillet_tool.go
+++ b/app/fillet_tool.go
@@ -123,11 +123,29 @@ func (t *FilletTool) Picks() []Selectable { return selectables(t.Edges()) }
 
 // Pick appends the clicked edge (ignoring one already chosen).
 func (t *FilletTool) Pick(_ *Session, sel Selectable) {
+	if e, ok := sel.(EdgeHandle); ok {
+		t.addEdge(e)
+	}
+}
+
+// PickWithMods adds the whole tangent chain through the clicked edge on Shift+click — the
+// "select tangent chain / loop" selection (#1798); a plain click adds the single edge.
+func (t *FilletTool) PickWithMods(s *Session, sel Selectable, mods Modifier) {
 	e, ok := sel.(EdgeHandle)
-	if !ok || t.hasEdge(e) {
+	if !ok || !mods.Has(ShiftMod) {
+		t.Pick(s, sel)
 		return
 	}
-	t.edges = append(t.edges, e)
+	for _, h := range s.tangentChainHandles(e) {
+		t.addEdge(h)
+	}
+}
+
+// addEdge appends an edge unless it is already selected.
+func (t *FilletTool) addEdge(e EdgeHandle) {
+	if !t.hasEdge(e) {
+		t.edges = append(t.edges, e)
+	}
 }
 
 func (t *FilletTool) hasEdge(e EdgeHandle) bool {

--- a/app/tangent_chain_select.go
+++ b/app/tangent_chain_select.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+)
+
+// ownerBody returns the visible body that owns edge e (matched by identity), or nil when e is
+// not part of the current scene — the reverse lookup the tangent-chain selection needs, since a
+// picked topo.Edge carries no back-reference to its body.
+func (s *Session) ownerBody(e *topo.Edge) *topo.Body {
+	key := e.ReferenceKey()
+	for _, b := range s.VisibleBodies() {
+		if found, ok := b.FindEdgeByKey(key); ok && found == e {
+			return b
+		}
+	}
+	return nil
+}
+
+// tangentChainHandles expands a seed edge into its maximal run of tangent-continuous edge
+// handles — the "select tangent chain / loop" affordance behind Fillet and Chamfer
+// (Oblikovati/Oblikovati#1798). It returns just the seed when the owning body or the chain
+// cannot be resolved, so a Shift-click never silently drops the user's pick.
+func (s *Session) tangentChainHandles(seed EdgeHandle) []EdgeHandle {
+	b := s.ownerBody(seed.Edge)
+	if b == nil {
+		return []EdgeHandle{seed}
+	}
+	keys, _, err := ops.TangentEdgeChain(b, seed.Edge.ReferenceKey(), ops.DefaultTangentChainAngle)
+	if err != nil {
+		return []EdgeHandle{seed}
+	}
+	out := make([]EdgeHandle, 0, len(keys))
+	for _, k := range keys {
+		if e, ok := b.FindEdgeByKey(k); ok {
+			out = append(out, EdgeHandle{Edge: e})
+		}
+	}
+	return out
+}

--- a/app/tangent_chain_select_test.go
+++ b/app/tangent_chain_select_test.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/topo"
+)
+
+// TestChamferShiftClickSelectsTangentLoop is the #1798 acceptance at the UI seam: after rounding
+// a block's four vertical edges, Shift-clicking one straight edge of the resulting tangent top
+// rim selects the whole 8-edge loop in one gesture (4 sides + 4 corner arcs) — the "pick one
+// edge → select tangent chain" the Chamfer/Fillet tools were missing. A plain click still adds
+// only the clicked edge.
+func TestChamferShiftClickSelectsTangentLoop(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	roundVerticalEdges(t, s, block, 0.5)
+	rounded := activePartDef(t, s).SurfaceBodies().Item(0)
+	seed := longestTopRimEdgeHandle(t, rounded, 2.0)
+
+	ch := NewChamferTool()
+	s.StartTool(ch)
+	ch.PickWithMods(s, seed, 0) // plain click adds only the seed
+	if got := len(ch.Edges()); got != 1 {
+		t.Fatalf("plain click selected %d edges, want 1", got)
+	}
+	ch2 := NewChamferTool()
+	s.StartTool(ch2)
+	ch2.PickWithMods(s, seed, ShiftMod) // Shift-click expands to the tangent loop
+	if got := len(ch2.Edges()); got != 8 {
+		t.Fatalf("Shift-click selected %d edges, want the 8-edge tangent loop", got)
+	}
+}
+
+// roundVerticalEdges fillets all four vertical edges of the block through the Fillet tool and
+// commits, leaving the active part's body with a tangent-continuous rounded rim.
+func roundVerticalEdges(t *testing.T, s *Session, block *topo.Body, r float64) {
+	t.Helper()
+	f := NewFilletTool()
+	s.StartTool(f)
+	for _, e := range block.Edges() {
+		if a, c := e.StartVertex().Point(), e.EndVertex().Point(); a.X == c.X && a.Y == c.Y {
+			f.Pick(s, EdgeHandle{Edge: e})
+		}
+	}
+	f.SetRadius(r)
+	if err := s.OK(); err != nil {
+		t.Fatalf("fillet the four vertical edges: %v", err)
+	}
+}
+
+// longestTopRimEdgeHandle returns a handle to the longest edge whose endpoints both lie at
+// z≈top — a straight side of the rounded rim.
+func longestTopRimEdgeHandle(t *testing.T, b *topo.Body, top float64) EdgeHandle {
+	t.Helper()
+	var best *topo.Edge
+	bestLen := 0.0
+	for _, e := range b.Edges() {
+		a, c := e.StartVertex().Point(), e.EndVertex().Point()
+		if stdmath.Abs(float64(a.Z)-top) > 1e-6 || stdmath.Abs(float64(c.Z)-top) > 1e-6 {
+			continue
+		}
+		if l := float64(a.DistanceTo(c)); l > bestLen {
+			best, bestLen = e, l
+		}
+	}
+	if best == nil {
+		t.Fatalf("no top-rim edge at z=%g", top)
+	}
+	return EdgeHandle{Edge: best}
+}

--- a/architecture/decisions/ADR-0050-occt-parity-blend-engine.md
+++ b/architecture/decisions/ADR-0050-occt-parity-blend-engine.md
@@ -1,0 +1,133 @@
+# ADR-0050 — OCCT-parity blend engine: one section-driven pipeline for fillet/chamfer, a separate modifier-visitor for draft
+
+**Status:** Accepted (2026-07-07). · **Sets the direction for** fillet/chamfer/draft feature
+parity with OpenCASCADE (OCCT), reported from the Oblikovati Discord `#bug-tracker`:
+[Oblikovati#1797](https://github.com/Oblikovati/Oblikovati/issues/1797) (fillet all-around drops
+tangency → faceted top), [#1798](https://github.com/Oblikovati/Oblikovati/issues/1798)
+(no tangent-chain selection), [#1800](https://github.com/Oblikovati/Oblikovati/issues/1800)
+(large-radius distortion, no validity check), [#1801](https://github.com/Oblikovati/Oblikovati/issues/1801)
+(draft pull/neutral-plane inputs), [#1802](https://github.com/Oblikovati/Oblikovati/issues/1802)
+(draft-after-fillet crash). · **Builds on** [ADR-0027](ADR-0027-curved-face-boolean.md) /
+[ADR-0043](ADR-0043-generalized-provenance-naming.md) (SSI machinery + order-independent face-pair
+provenance naming, reused for blend edge naming), [ADR-0042](ADR-0042-model-scale-and-relative-tolerances.md)
+(model-relative tolerances). · **Touches (new, over the roadmap):** `kernel/blend/` (new pure
+engine package), `kernel/ops/modify/` (new draft modifier-visitor), `model/feature/fillet.go` /
+`chamfer.go` / `draft.go` (orchestrate the engine), the `Oblikovati.API` dressup wire DTOs (draft
+pull/neutral, chamfer modes), `app` selection (tangent-chain), `head/ui` dialogs. · **Supersedes**
+the plane-only draft retopo (`kernel/ops/retopo.go rebuildWithPlanes` for the draft path) and the
+`planarizedFillet` faceting fallback — retired case-by-case as the marcher covers each.
+
+## Context
+
+Our fillet/chamfer/draft suite is a **catalog of analytic special-cases with a faceting fallback**,
+not an engine. Fillet emits exact `geom.Cylinder`/`Sphere`/`Torus`/`Cone` (+ rational ruled NURBS
+for plain-ended variable) for the primitive cases it recognizes and otherwise **planarizes the body
+and facets** (`model/feature/fillet.go:167`). Chamfer is an analytic cone for a simple cylinder rim
+or a **planar-wedge boolean cut** that re-facets curved edges. Draft is routed through a
+**plane-only retopo** (`rebuildWithPlanes`) that casts every face to `geom.Plane` and every edge to
+a line segment — so it **panics on any curved face** (#1802) and cannot taper a body that carries a
+fillet. There is no tangent-edge chain propagation (tools append single picks), and no geometric
+max-radius/self-intersection validity (`Validate` is topological only).
+
+This shape is the failure, not any single bug: a special-case catalog can never reach general
+variable-radius blends, curved neighbours, or robust corners. OCCT solves the same problem with a
+**seam**, verified in its source (`TKFillet`, `TKOffset`, `TKBRep`): fillet and chamfer are **one
+`ChFi3d_Builder` pipeline** that differs only by a pluggable **section functional**
+(`BlendFunc_ConstRad`/`EvolRad`/chamfer families) driving a generic ODE **marcher + B-spline
+approximation** (`BRepBlend_Walking` + `BRepBlend_AppSurface`) along a tangent-continuous
+**spine** (`ChFiDS_Spine`); an analytic **known-part** fast path (`ChFiKPart_ComputeData`)
+short-circuits the marcher for primitive face pairs. **Draft is a wholly separate mechanism** — a
+`BRepTools_Modifier` visitor (`Draft_Modification`) that walks every face/edge/vertex, tilts the
+changed surfaces, and re-intersects neighbours analytically (`IntAna_QuadQuadGeo`), preserving
+topology with no marching. Errors are localized per-stripe/per-vertex (`ChFiDS_ErrorStatus`),
+yielding a partial result (`HasResult`/`BadShape`) rather than a global failure.
+
+Crucially, the numerical foundation OCCT's engine needs, **we already own**: a general SSI marching
+intersector over any surface incl. NURBS (`geom.IntersectSurfaceSurface`, predictor-corrector,
+tangency-singularity aware), analytic SSI for plane-involving pairs, a general `OffsetSurface` with
+fold rejection, the exact analytic blend surfaces, and the curved-boolean trim/classify/stitch +
+ADR-0043 provenance naming. What is absent is the **blend-surface abstraction and the driver** that
+compose those pieces — plus tangent-chain grouping, geometric validity, curved-neighbour
+re-intersection, and a curved-capable draft.
+
+## Decision
+
+Adopt OCCT's **architecture** (the seam) and implement it on **our existing numeric assets** — a
+**hybrid**, not a wholesale C++ port and not more special-cases.
+
+- **One pipeline, pluggable section.** A new pure package `kernel/blend/` builds a blend from a
+  **`Spine`** (tangent-continuous edge chain) by driving a generic **`Marcher`** parameterized by a
+  **`SectionFunctional`** port (`ConstRadiusSection`, `EvolRadiusSection`, `ChamferSection`
+  sym/two-dist/dist-angle) and fitting the sampled sections to a `geom.BSplineSurface`
+  (`approx.go`). Fillet and chamfer are the same pipeline with different section functionals.
+- **Known-part fast path retained.** The existing well-tested analytic paths
+  (`fillet_analytic`/`arc`/`rim`, `chamfer_analytic`) are **re-seated behind `kernel/blend/knownpart.go`**
+  as the closed-form short-circuit — exact where it applies, marcher elsewhere. They are wrapped,
+  not rewritten; goldens lock them byte-identical.
+- **Draft is a separate modifier-visitor.** A new `kernel/ops/modify/` package provides a
+  `Modifier` driver + `Modification` port (`NewSurface`/`NewCurve`/`NewPoint`) and a
+  `draft_mod.go` that tilts selected planar/cyl/cone faces and re-intersects neighbours via our
+  analytic + general SSI. It replaces `rebuildWithPlanes` for draft; `shell`/`move-face` may migrate
+  onto it later (they share the same latent panic).
+- **Shared tangent-chain primitive.** The G1 face-tangency predicate + chain walk lives once in
+  `kernel/blend/tangent.go` and is consumed by **both** the engine (spine building) and `app`
+  selection (expand a pick to its tangent chain). No duplication.
+- **Localized error, partial result.** Mirror `ChFiDS_ErrorStatus`: a per-stripe/per-vertex failure
+  yields a Sick-with-hole result naming the faulty entity, not a global abort — no pre-flight
+  validity oracle. A geometric max-radius/self-intersection check (absent today) gates each segment.
+- **Dependency rule.** `kernel/blend` and `kernel/ops/modify` import only `kernel/geom` +
+  `kernel/topo`; `model/feature` orchestrates them; nothing in the engine imports `model`, `app`,
+  or `head`. New public surface (draft pull/neutral, chamfer modes) is contract-first in
+  `Oblikovati.API` per ADR-0018.
+
+Delivered as a **phased milestone** (each phase independently shippable + tested): **0** draft
+crash-guard (stopgap, feature goes Sick) → **1** tangent-chain selection/spine (feeds the existing
+analytic paths first) → **2** geometric max-radius validity → **3** engine skeleton (`SectionFunctional`
+port + known-part re-seat, zero behavior change) → **4** marcher core (general constant-radius on
+curved neighbours; retires faceting case-by-case) → **5** variable-radius laws + chamfer modes →
+**6** corner/setback reconstruction → **7** curved-draft modifier-visitor (the real #1802 fix).
+Phases 4 and 6 are the hard IP and route their numerics through `geometry-math-advisor`.
+
+## Consequences
+
+- **(+)** Reaches general **variable-radius**, **curved-neighbour**, and **tangent-chain** blends
+  that the special-case catalog structurally cannot — the actual parity goal.
+- **(+)** Reuses the SSI tracer, offset surface, NURBS, and ADR-0043 naming we already own; the hard
+  new code is the marcher/approximation and corner processor, not the whole stack.
+- **(+)** Existing analytic results ship **unchanged** (re-seated as known-parts, golden-locked); the
+  faceting fallback is retired only where the marcher demonstrably covers the case, so no regression.
+- **(+)** Draft-after-fillet stops crashing at phase 0 and becomes correct at phase 7; the modifier
+  framework then generalizes shell/move-face off the plane-only retopo.
+- **(−)** The marcher (phase 4) and corner processor (phase 6) are genuinely hard numeric/topology
+  work — OCCT's own weak points (≥4-edge vertices unsupported). We inherit that difficulty and adopt
+  its partial-result honesty rather than promising totality.
+- **(−)** We temporarily carry two code paths (known-part + marcher, and the retiring faceting
+  fallback) until the marcher matures; the diagnostic counters (`CodeFilletFacetedBlend`) track the
+  crossover.
+- **(0)** Leaning on the curved boolean for blend re-intersection inherits its in-progress
+  ~28-handler state (ADR-0027/#1403); the blend engine uses SSI + trim/stitch directly where the
+  general boolean is incomplete.
+
+## Rejected
+
+- **Clean-room wholesale port of `ChFi3d`/`BRepBlend`.** Reimplementing `TopOpeBRepDS`, OCCT's
+  approximator, and ~15k lines of corner code in Go duplicates SSI/NURBS machinery we already have —
+  multi-quarter, high regression risk, no reuse. We adopt OCCT's *seam*, not its line-for-line
+  internals.
+- **Incremental-only (keep growing the analytic catalog).** Cheapest short-term but never reaches
+  general variable-radius/curved-neighbour/robust corners — it is the very shape failing in
+  #1797/#1798/#1800/#1802.
+- **Guard the draft assertion and stop there.** Fixes the panic but leaves draft plane-only forever;
+  kept as **phase 0** (the honest stopgap), not the destination.
+- **Fold draft into the blend pipeline.** Draft is geometry substitution with topology preserved,
+  not a marched blend; OCCT keeps them separate and so do we — a shared marcher would be the wrong
+  abstraction.
+
+## References
+
+OCCT `TKFillet` (`ChFi3d_Builder`, `ChFiDS_Spine/Stripe/SurfData`, `BRepBlend_Walking`,
+`BRepBlend_AppSurface`, `BlendFunc_ConstRad/EvolRad`, `ChFiKPart_ComputeData`), `TKOffset`
+(`BRepOffsetAPI_DraftAngle`, `Draft_Modification`), `TKBRep` (`BRepTools_Modifier`/`Modification`). ·
+Krivoshapko & Ivanov (2015), *Encyclopedia of Analytical Surfaces* (canal/pipe blends). ·
+software-architect-advisor and geometry-math-advisor briefs recorded on the parity milestone. ·
+ADR-0027 (curved boolean / SSI), ADR-0043 (provenance naming), ADR-0018 (API split).

--- a/head/ui/chamfer_dialog.go
+++ b/head/ui/chamfer_dialog.go
@@ -42,7 +42,7 @@ func drawChamferDialog(s *app.Session) {
 		drawFeatureBreadcrumb(title, "")
 		if propertySection("Input Geometry") {
 			drawPickChipRow("Edges", "chamfer-edges", countChipText(c.EdgeCount(), "Edge", "Select Edges"),
-				c.EdgeCount() > 0, "Click edges in the viewport to bevel", c.ClearEdges)
+				c.EdgeCount() > 0, "Click edges to bevel; Shift+click selects the whole tangent chain", c.ClearEdges)
 		}
 		if propertySection("Behavior") {
 			drawChamferBehaviorRows(s, c)

--- a/head/ui/fillet_dialog.go
+++ b/head/ui/fillet_dialog.go
@@ -52,7 +52,7 @@ func drawFilletPanelBody(s *app.Session, f *app.FilletTool) {
 	drawFeatureBreadcrumb(title, "")
 	if propertySection("Input Geometry") {
 		drawPickChipRow("Edges", "fillet-edges", countChipText(f.EdgeCount(), "Edge", "Select Edges"),
-			f.EdgeCount() > 0, "Click convex edges in the viewport to round", f.ClearEdges)
+			f.EdgeCount() > 0, "Click convex edges to round; Shift+click selects the whole tangent chain", f.ClearEdges)
 	}
 	if propertySection("Behavior") {
 		drawFilletRadiusRows(s, f)

--- a/kernel/blend/approx.go
+++ b/kernel/blend/approx.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package blend
+
+import (
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// canalGridU/V are the section-station and cross-section sample counts for the general canal fit —
+// oversampled ~2× the control net so the least-squares fit smooths (Piegl-Tiller §9.4.1). A single
+// blend segment sweeps a modest angle, so these suffice for a bicubic within tolerance.
+const (
+	canalGridU = 15
+	canalGridV = 11
+	canalCtrlU = 8
+	canalCtrlV = 7
+)
+
+// fitCanal builds the blend surface for a NON-primitive centre curve (an ellipse or a marched NURBS
+// curve, where analyticBlendSurface has no closed form): it samples the section arc of radius r at
+// each station along the centre curve's parameter span [t0,t1] and least-squares fits a bicubic
+// B-spline (u along the guide, v across the arc). It returns StatusTwistedSurface when a station has
+// no valid section (the canal folds — the pipe-embedding bound r·κ_centre ≥ 1 of ADR-0050 P4), and
+// StatusWalkingFailed if the fit's linear solve is singular.
+func fitCanal(centre geom.Curve3, a, b geom.Surface, r, t0, t1, tol float64, inside func(math.Point3) bool) (geom.Surface, ErrorStatus) {
+	pts := make([]math.Point3, 0, canalGridU*canalGridV)
+	us := make([]float64, 0, canalGridU*canalGridV)
+	vs := make([]float64, 0, canalGridU*canalGridV)
+	for iu := 0; iu < canalGridU; iu++ {
+		u := float64(iu) / (canalGridU - 1)
+		arc, ok := sectionAt(centre.PointAt(t0+u*(t1-t0)), a, b, r, tol, inside)
+		if !ok {
+			return nil, StatusTwistedSurface
+		}
+		for iv := 0; iv < canalGridV; iv++ {
+			v := float64(iv) / (canalGridV - 1)
+			pts = append(pts, arc.PointAt(v))
+			us = append(us, u)
+			vs = append(vs, v)
+		}
+	}
+	surf, err := geom.ApproximateSurfaceLS(pts, us, vs, 3, 3, canalCtrlU, canalCtrlV)
+	if err != nil {
+		return nil, StatusWalkingFailed
+	}
+	return surf, StatusOk
+}

--- a/kernel/blend/builder.go
+++ b/kernel/blend/builder.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package blend
+
+// SegmentSolver is the general marcher (Phase 4): given a spine and a section, it walks the guide
+// solving the section at each step and returns the run of blend segments with a localized status.
+// It is injected into the Builder so the Phase-3 skeleton carries no marcher yet — the ODE/Newton
+// math lands in Phase 4 behind this seam (mirrors OCCT BRepBlend_Walking + BRepBlend_AppSurface).
+type SegmentSolver interface {
+	March(sp *Spine, sec SectionFunctional) Result
+}
+
+// Builder orchestrates a blend along a spine: known analytic parts short-circuit to the closed-form
+// catalog (owned by ops, which holds the topo assembly), everything else marches. This is the
+// ADR-0050 dispatch seam. Phase 3 lands it with the general branch reporting NotImplemented unless a
+// SegmentSolver is wired, so the shipping analytic path — which ops still drives directly — is
+// unchanged; Phase 4 supplies the solver and moves the general case onto it.
+type Builder struct {
+	solver SegmentSolver // Phase 4 marcher; nil in the Phase-3 skeleton
+}
+
+// NewBuilder returns a Builder driven by the given general-case marcher (nil until Phase 4).
+func NewBuilder(solver SegmentSolver) *Builder { return &Builder{solver: solver} }
+
+// Plan classifies how a spine's blend will be built without building it — the dispatch decision ops
+// consults to route a known part to its analytic catalog and everything else to the marcher.
+func (b *Builder) Plan(sp *Spine) KnownPartKind { return ClassifyKnownPart(sp) }
+
+// March builds the general (non-known-part) blend through the injected solver, or reports
+// NotImplemented when none is wired (the Phase-3 skeleton). Known parts do not reach here — ops
+// dispatches them to the closed-form catalog on Plan == known.
+func (b *Builder) March(sp *Spine, sec SectionFunctional) Result {
+	if b.solver == nil {
+		return Result{Status: StatusNotImplemented}
+	}
+	return b.solver.March(sp, sec)
+}

--- a/kernel/blend/builder_test.go
+++ b/kernel/blend/builder_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package blend_test
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/blend"
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// blendRoundedBox fillets the four vertical edges of a box, yielding the tangent-loop top rim used
+// to exercise the not-known-part (multi-edge) classification.
+func blendRoundedBox(box *topo.Body) (*topo.Body, error) {
+	var keys [][]byte
+	for _, e := range box.Edges() {
+		if a, c := e.StartVertex().Point(), e.EndVertex().Point(); a.X == c.X && a.Y == c.Y {
+			keys = append(keys, e.ReferenceKey())
+		}
+	}
+	return ops.FilletEdges(box, keys, 0.5)
+}
+
+// fakeSolver is a named stand-in for the Phase-4 marcher, so the builder's dispatch can be tested
+// without any real geometry.
+type fakeSolver struct{ res blend.Result }
+
+func (f fakeSolver) March(*blend.Spine, blend.SectionFunctional) blend.Result { return f.res }
+
+// TestClassifyKnownPartMatchesRouting checks the known-part classifier agrees with the analytic
+// routing ops already performs: a straight box edge is a planar-edge cylinder blend, a cylinder rim
+// is a toroidal band, and a multi-edge tangent loop is not a known part (it needs the marcher).
+func TestClassifyKnownPartMatchesRouting(t *testing.T) {
+	box := spineBox(2, 2, 2)
+	boxSpine, _ := blend.NewSpine([]*topo.Edge{box.Edges()[0]}, false)
+	if k := blend.ClassifyKnownPart(boxSpine); k != blend.KnownPlanarEdge {
+		t.Errorf("box edge classified %v, want planar-edge", k)
+	}
+
+	cyl, err := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 1, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rimSpine, _ := blend.NewSpine([]*topo.Edge{circleEdge(t, cyl)}, true)
+	if k := blend.ClassifyKnownPart(rimSpine); k != blend.KnownCylinderRim {
+		t.Errorf("cylinder rim classified %v, want cylinder-rim", k)
+	}
+
+	rounded, err := blendRoundedBox(box)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loop, closed := rimChainEdges(t, rounded, 2.0)
+	loopSpine, _ := blend.NewSpine(loop, closed)
+	if k := blend.ClassifyKnownPart(loopSpine); k != blend.NotKnownPart {
+		t.Errorf("8-edge tangent loop classified %v, want not-known-part", k)
+	}
+}
+
+// TestSectionFunctionalCarriers checks the section family flags and extents distinguish fillet from
+// chamfer — the single parameter the builder routes on.
+func TestSectionFunctionalCarriers(t *testing.T) {
+	fil := blend.ConstRadiusFillet{R: 2}
+	if fil.IsChamfer() || fil.Extent(0) != 2 {
+		t.Errorf("fillet section: chamfer=%v extent=%g, want false/2", fil.IsChamfer(), fil.Extent(0))
+	}
+	ch := blend.SymmetricChamfer{D: 1.5}
+	if !ch.IsChamfer() || ch.Extent(0) != 1.5 {
+		t.Errorf("chamfer section: chamfer=%v extent=%g, want true/1.5", ch.IsChamfer(), ch.Extent(0))
+	}
+}
+
+// TestBuilderDispatch checks the skeleton: Plan classifies, March with no solver reports
+// NotImplemented (nothing built), and March with an injected solver returns its result.
+func TestBuilderDispatch(t *testing.T) {
+	box := spineBox(2, 2, 2)
+	sp, _ := blend.NewSpine([]*topo.Edge{box.Edges()[0]}, false)
+
+	stub := blend.NewBuilder(nil)
+	if k := stub.Plan(sp); k != blend.KnownPlanarEdge {
+		t.Errorf("Plan = %v, want planar-edge", k)
+	}
+	res := stub.March(sp, blend.ConstRadiusFillet{R: 1})
+	if res.Status != blend.StatusNotImplemented || res.HasResult() || !res.BadShape() {
+		t.Errorf("nil-solver March = %+v, want NotImplemented/no-result/bad-shape", res)
+	}
+
+	want := blend.Result{Segments: []blend.BlendSegment{{}}, Status: blend.StatusOk}
+	wired := blend.NewBuilder(fakeSolver{res: want})
+	if got := wired.March(sp, blend.ConstRadiusFillet{R: 1}); !got.HasResult() || got.BadShape() {
+		t.Errorf("wired March = %+v, want a usable result", got)
+	}
+}
+
+// circleEdge returns the first edge of b whose geometry is a full circle (a cylinder rim).
+func circleEdge(t *testing.T, b *topo.Body) *topo.Edge {
+	t.Helper()
+	for _, e := range b.Edges() {
+		if _, ok := e.Geometry().(geom.Circle); ok {
+			return e
+		}
+	}
+	t.Fatal("no circular edge")
+	return nil
+}

--- a/kernel/blend/builder_test.go
+++ b/kernel/blend/builder_test.go
@@ -107,3 +107,25 @@ func circleEdge(t *testing.T, b *topo.Body) *topo.Edge {
 	t.Fatal("no circular edge")
 	return nil
 }
+
+// TestMarchCylinderRimTorus drives the full SegmentSolver.March path on a real spine: a cylinder's
+// rim (a plane+cylinder support pair) marches to a single torus blend segment — the curved-neighbour
+// case the analytic catalog could not route from a general fillet (#1806).
+func TestMarchCylinderRimTorus(t *testing.T) {
+	cyl, err := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sp, _ := blend.NewSpine([]*topo.Edge{circleEdge(t, cyl)}, true)
+	m := &blend.Marcher{
+		Inside: func(p math.Point3) bool { return ops.PointInsideBody(cyl, p) },
+		Res:    geom.ResolutionForBox(cyl.RangeBox()),
+	}
+	res := m.March(sp, blend.ConstRadiusFillet{R: 0.5})
+	if res.Status != blend.StatusOk || !res.HasResult() || len(res.Segments) != 1 {
+		t.Fatalf("march = status %v, %d segments; want one Ok segment", res.Status, len(res.Segments))
+	}
+	if _, ok := res.Segments[0].Surface.(geom.Torus); !ok {
+		t.Errorf("rim blend surface is %T, want a torus", res.Segments[0].Surface)
+	}
+}

--- a/kernel/blend/chamfer_sec.go
+++ b/kernel/blend/chamfer_sec.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package blend
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// TwoDistanceChamfer is an asymmetric chamfer: setback D1 on support 1 and D2 on support 2 (OCCT
+// ChFiDS_TwoDist). Extent reports the larger setback, which sizes the max-setback validity bound.
+type TwoDistanceChamfer struct {
+	D1, D2 float64
+}
+
+// IsChamfer is true: a chamfer section is a straight chord.
+func (TwoDistanceChamfer) IsChamfer() bool { return true }
+
+// Extent returns the larger of the two setbacks.
+func (c TwoDistanceChamfer) Extent(float64) float64 { return stdmath.Max(c.D1, c.D2) }
+
+// DistanceAngleChamfer is a chamfer set by a setback D1 on support 1 and Angle measured from
+// support 1 (OCCT ChFiDS_DistAngle); the second setback is D1·tan(Angle).
+type DistanceAngleChamfer struct {
+	D1, Angle float64
+}
+
+// IsChamfer is true.
+func (DistanceAngleChamfer) IsChamfer() bool { return true }
+
+// Extent returns the larger of the setback and its angle-derived counterpart.
+func (c DistanceAngleChamfer) Extent(float64) float64 {
+	return stdmath.Max(c.D1, c.D1*stdmath.Tan(c.Angle))
+}
+
+// D2 returns the second setback D1·tan(Angle), the chamfer's contact distance on support 2.
+func (c DistanceAngleChamfer) D2() float64 { return c.D1 * stdmath.Tan(c.Angle) }
+
+// ChamferSection is a chamfer's straight cross-section: the chord from the contact on support 1
+// (FootA, v=0) to the contact on support 2 (FootB, v=1). Unlike a fillet's circular arc, the
+// chamfer surface is ruled between these two contact curves (mirrors OCCT ChFiDS_ChamfSpine).
+type ChamferSection struct {
+	FootA, FootB math.Point3
+}
+
+// PointAt returns the chord point at v∈[0,1]: FootA at 0, FootB at 1.
+func (s ChamferSection) PointAt(v float64) math.Point3 {
+	return s.FootA.TranslateBy(s.FootA.VectorTo(s.FootB).Scale(math.Scalar(v)))
+}
+
+// chamferSectionAt places the chamfer chord at edge point e: the contact on each support recedes
+// its setback distance along that support's in-face inward perpendicular (mA, mB — unit, ⟂ the
+// edge, into each face), exactly as the two-plane chamfer cuts back from the edge.
+func chamferSectionAt(e math.Point3, mA, mB math.Vector3, d1, d2 float64) ChamferSection {
+	return ChamferSection{
+		FootA: e.TranslateBy(mA.Scale(math.Scalar(d1))),
+		FootB: e.TranslateBy(mB.Scale(math.Scalar(d2))),
+	}
+}

--- a/kernel/blend/const_rad.go
+++ b/kernel/blend/const_rad.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package blend
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// SectionArc is a constant-radius fillet's cross-section at one guide station: the circular arc of
+// radius R centred at Center, sweeping Sweep radians from FootA (the contact on support 1, at v=0)
+// through the exposed side to FootB (the contact on support 2, at v=1). It lies in the plane normal
+// to the centre-curve tangent — the exact section plane, since the centre lies on both offset
+// surfaces so the tangent is perpendicular to both support normals (ADR-0050 P4, method B).
+type SectionArc struct {
+	Center       math.Point3
+	E1, E2       math.Vector3 // orthonormal in-plane basis; E1 points from Center to FootA
+	R            float64
+	Sweep        float64 // exposed-arc angle from the side-1 to the side-2 contact
+	FootA, FootB math.Point3
+}
+
+// PointAt returns the section point at v∈[0,1]: Center + R(cos(vθ)E1 + sin(vθ)E2), so PointAt(0)=FootA
+// and PointAt(1)=FootB.
+func (s SectionArc) PointAt(v float64) math.Point3 {
+	a := v * s.Sweep
+	cos, sin := stdmath.Cos(a), stdmath.Sin(a)
+	off := s.E1.Scale(math.Scalar(s.R * cos)).Add(s.E2.Scale(math.Scalar(s.R * sin)))
+	return s.Center.TranslateBy(off)
+}
+
+// sectionAt builds the fillet section of radius r at a centre point c that lies on the blend's
+// centre curve (the intersection of the two offset supports): it projects c onto each support for
+// the two contact (foot) points, frames the arc in the plane normal to the centre-curve tangent,
+// and selects the EXPOSED arc — the one whose midpoint lies outside the solid (inside==false). It
+// returns ok=false when c is not equidistant r from both supports (c is off the centre curve).
+func sectionAt(c math.Point3, a, b geom.Surface, r, tol float64, inside func(math.Point3) bool) (SectionArc, bool) {
+	fa, fb := footOn(a, c), footOn(b, c)
+	if stdmath.Abs(float64(fa.DistanceTo(c))-r) > tol || stdmath.Abs(float64(fb.DistanceTo(c))-r) > tol {
+		return SectionArc{}, false
+	}
+	e1 := unitVec(c.VectorTo(fa))
+	toB := c.VectorTo(fb)
+	e2 := unitVec(toB.Add(e1.Scale(-toB.Dot(e1)))) // Gram-Schmidt: (c→fb) component ⟂ e1
+	sweep := stdmath.Acos(clampUnit(float64(e1.Dot(unitVec(toB)))))
+	arc := SectionArc{Center: c, E1: e1, E2: e2, R: r, Sweep: sweep, FootA: fa, FootB: fb}
+	if inside(arc.PointAt(0.5)) { // the minor arc dips into the material: take the major arc instead
+		arc.E2 = e2.Negate()
+		arc.Sweep = 2*stdmath.Pi - sweep
+	}
+	return arc, true
+}
+
+// footOn returns the projection of c onto surface s (its nearest point for the plane/cylinder/sphere
+// supports, via the surface's on-frame parameter inverse).
+func footOn(s geom.Surface, c math.Point3) math.Point3 {
+	u, v := s.ParamAt(c)
+	return s.PointAt(u, v)
+}
+
+// unitVec normalizes v, returning it unchanged when it is zero length.
+func unitVec(v math.Vector3) math.Vector3 {
+	if l := float64(v.Length()); l > 0 {
+		return v.Scale(math.Scalar(1 / l))
+	}
+	return v
+}
+
+// clampUnit constrains x to [-1,1] so Acos of a rounded dot product never yields NaN.
+func clampUnit(x float64) float64 {
+	if x < -1 {
+		return -1
+	}
+	if x > 1 {
+		return 1
+	}
+	return x
+}

--- a/kernel/blend/const_rad_test.go
+++ b/kernel/blend/const_rad_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package blend
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// TestSectionArcBetweenPlanes checks the section geometry on the simplest case: a radius-1 ball
+// between the xy-plane and the yz-plane. The centre sits at (1,y,1); the contacts must land on each
+// plane at distance 1, the sweep is 90°, and every section point is exactly radius 1 from the centre
+// with PointAt(0)/PointAt(1) hitting the two contacts.
+func TestSectionArcBetweenPlanes(t *testing.T) {
+	xy, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1)) // z=0
+	yz, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(1, 0, 0)) // x=0
+	c := math.P3(1, 3, 1)                                      // equidistant 1 from both planes
+
+	arc, ok := sectionAt(c, xy, yz, 1, 1e-9, func(math.Point3) bool { return false })
+	if !ok {
+		t.Fatal("section failed on a valid centre point")
+	}
+	if d := arc.FootA.DistanceTo(math.P3(1, 3, 0)); float64(d) > 1e-9 {
+		t.Errorf("footA = %v, want (1,3,0)", arc.FootA)
+	}
+	if d := arc.FootB.DistanceTo(math.P3(0, 3, 1)); float64(d) > 1e-9 {
+		t.Errorf("footB = %v, want (0,3,1)", arc.FootB)
+	}
+	if stdmath.Abs(arc.Sweep-stdmath.Pi/2) > 1e-9 {
+		t.Errorf("sweep = %g, want π/2", arc.Sweep)
+	}
+	if d := arc.PointAt(0).DistanceTo(arc.FootA); float64(d) > 1e-9 {
+		t.Errorf("PointAt(0) = %v, want footA %v", arc.PointAt(0), arc.FootA)
+	}
+	if d := arc.PointAt(1).DistanceTo(arc.FootB); float64(d) > 1e-9 {
+		t.Errorf("PointAt(1) = %v, want footB %v", arc.PointAt(1), arc.FootB)
+	}
+	for _, v := range []float64{0, 0.25, 0.5, 0.75, 1} {
+		if d := float64(arc.PointAt(v).DistanceTo(c)); stdmath.Abs(d-1) > 1e-9 {
+			t.Errorf("section point at v=%g is %g from centre, want radius 1", v, d)
+		}
+	}
+}
+
+// TestSectionArcSelectsExposedSide checks that when the minor arc dips into the material, sectionAt
+// flips to the major arc — the exposed blend surface always bulges out of the solid.
+func TestSectionArcSelectsExposedSide(t *testing.T) {
+	xy, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	yz, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(1, 0, 0))
+	c := math.P3(1, 0, 1)
+
+	// "material" = the quarter wedge x<1 ∧ z<1 near the centre: the minor-arc midpoint (0.29,0,0.29)
+	// is inside it, so the section must flip to the major (>π/2) arc.
+	inside := func(p math.Point3) bool { return float64(p.X) < 1 && float64(p.Z) < 1 }
+	arc, ok := sectionAt(c, xy, yz, 1, 1e-9, inside)
+	if !ok {
+		t.Fatal("section failed")
+	}
+	if arc.Sweep <= stdmath.Pi/2 {
+		t.Errorf("sweep = %g, want the major arc (>π/2) when the minor dips inside", arc.Sweep)
+	}
+	if !insidePointOutsideMaterial(arc, inside) {
+		t.Error("major-arc midpoint should now be outside the material")
+	}
+}
+
+func insidePointOutsideMaterial(arc SectionArc, inside func(math.Point3) bool) bool {
+	return !inside(arc.PointAt(0.5))
+}

--- a/kernel/blend/curveutil.go
+++ b/kernel/blend/curveutil.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package blend
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+)
+
+// edgeDirections resolves, for an ordered tangent-continuous edge run, whether each edge is
+// traversed along its intrinsic parameter (lo→hi) or against it (hi→lo). It threads a frontier
+// vertex through the run: the entry of the first edge is its endpoint not shared with the next
+// edge (for a lone edge, its start), and each edge's exit becomes the next edge's entry.
+func edgeDirections(edges []*topo.Edge) []bool {
+	fwd := make([]bool, len(edges))
+	frontier := entryVertex(edges)
+	for i, e := range edges {
+		fwd[i] = e.StartVertex() == frontier
+		frontier = spineOtherVertex(e, frontier)
+	}
+	return fwd
+}
+
+// entryVertex returns the vertex the run starts at: for a multi-edge run, the endpoint of the
+// first edge not shared with the second; otherwise the first edge's start.
+func entryVertex(edges []*topo.Edge) *topo.Vertex {
+	if len(edges) < 2 {
+		return edges[0].StartVertex()
+	}
+	shared := sharedVertex(edges[0], edges[1])
+	return spineOtherVertex(edges[0], shared)
+}
+
+// sharedVertex returns the vertex common to two consecutive edges (a's end that touches b).
+func sharedVertex(a, b *topo.Edge) *topo.Vertex {
+	if a.EndVertex() == b.StartVertex() || a.EndVertex() == b.EndVertex() {
+		return a.EndVertex()
+	}
+	return a.StartVertex()
+}
+
+// spineOtherVertex returns e's endpoint that is not v (v itself for a closed edge).
+func spineOtherVertex(e *topo.Edge, v *topo.Vertex) *topo.Vertex {
+	if e.StartVertex() == v {
+		return e.EndVertex()
+	}
+	return e.StartVertex()
+}
+
+// gaussLegendre5 are the 5-point Gauss-Legendre nodes/weights on [-1,1]: exact for polynomials up
+// to degree 9 and effectively exact for the constant speed of lines and circular arcs (the common
+// spine edges), accurate for NURBS.
+var gaussLegendre5 = struct{ x, w [5]float64 }{
+	x: [5]float64{-0.9061798459386640, -0.5384693101056831, 0, 0.5384693101056831, 0.9061798459386640},
+	w: [5]float64{0.2369268850561891, 0.4786286704993665, 0.5688888888888889, 0.4786286704993665, 0.2369268850561891},
+}
+
+// arcLength integrates |dP/dt| over [lo,hi] by 5-point Gauss-Legendre — the curve's true arc
+// length (exact for constant-speed lines and arcs).
+func arcLength(c geom.Curve3, lo, hi float64) float64 {
+	if hi <= lo {
+		return 0
+	}
+	half := (hi - lo) / 2
+	mid := (hi + lo) / 2
+	sum := 0.0
+	for k := 0; k < 5; k++ {
+		t := mid + half*gaussLegendre5.x[k]
+		sum += gaussLegendre5.w[k] * float64(c.TangentAt(t).Length())
+	}
+	return sum * half
+}
+
+// paramAtArcLength inverts the arc length: it returns the parameter t in [lo,hi] whose distance
+// along the curve from lo equals target, by Newton iteration (s'(t) = |dP/dt|). Clamped at the
+// ends. Used to map a spine abscissa back to an edge-curve parameter.
+func paramAtArcLength(c geom.Curve3, lo, hi, target float64) float64 {
+	full := arcLength(c, lo, hi)
+	if target <= 0 || full == 0 {
+		return lo
+	}
+	if target >= full {
+		return hi
+	}
+	t := lo + (hi-lo)*target/full // constant-speed seed
+	for iter := 0; iter < 12; iter++ {
+		speed := float64(c.TangentAt(t).Length())
+		if speed < 1e-14 {
+			break
+		}
+		dt := (arcLength(c, lo, t) - target) / speed
+		t = clampf(t-dt, lo, hi)
+		if stdmath.Abs(dt) < 1e-12 {
+			break
+		}
+	}
+	return t
+}
+
+// clampf constrains x to [lo,hi].
+func clampf(x, lo, hi float64) float64 {
+	if x < lo {
+		return lo
+	}
+	if x > hi {
+		return hi
+	}
+	return x
+}

--- a/kernel/blend/evol_rad.go
+++ b/kernel/blend/evol_rad.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package blend
+
+// EvolRadiusFillet is a variable-radius fillet section: a circular arc whose radius follows a
+// RadiusLaw along the guide (OCCT ChFiDS_FilSpine carrying an evolutive law). The section shape is
+// the same circular arc as the constant-radius fillet (sectionAt) — only the radius the marcher
+// samples per station changes, via Extent. The per-station centre solve the varying radius needs
+// (the offset distance is no longer constant, so the centre curve is not a single offset∩offset)
+// is the marcher's variable-radius generalization; this type carries the law it reads.
+type EvolRadiusFillet struct {
+	Law RadiusLaw
+}
+
+// IsChamfer is false: an evolving fillet is still a circular-arc section.
+func (EvolRadiusFillet) IsChamfer() bool { return false }
+
+// Extent returns the law's radius at spine abscissa w.
+func (f EvolRadiusFillet) Extent(w float64) float64 { return f.Law.At(w) }

--- a/kernel/blend/knownpart.go
+++ b/kernel/blend/knownpart.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package blend
+
+import (
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+)
+
+// KnownPartKind labels the analytic fast-path cases the closed-form catalog builds exactly, without
+// marching — OCCT's ChFiKPart_ComputeData short-circuit. Anything not recognized is NotKnownPart and
+// routes to the general marcher (Phase 4).
+type KnownPartKind uint8
+
+const (
+	// NotKnownPart: no closed form applies — the general marcher must build it.
+	NotKnownPart KnownPartKind = iota
+	// KnownPlanarEdge: a straight edge between two planes → a cylindrical rolling-ball blend.
+	KnownPlanarEdge
+	// KnownCylinderRim: a full circular rim between a cylinder and a planar cap → a toroidal band.
+	KnownCylinderRim
+	// KnownCylinderArc: a circular arc between a cylinder and a plane → a torus with setback caps.
+	KnownCylinderArc
+)
+
+// String returns a stable diagnostic name.
+func (k KnownPartKind) String() string {
+	switch k {
+	case KnownPlanarEdge:
+		return "planar-edge"
+	case KnownCylinderRim:
+		return "cylinder-rim"
+	case KnownCylinderArc:
+		return "cylinder-arc"
+	default:
+		return "not-known-part"
+	}
+}
+
+// ClassifyKnownPart recognizes, from a spine's geometry alone, which analytic fast path builds its
+// blend — mirroring the routing the ops catalog already performs (loneRimPick / loneArcPick / the
+// planar analytic path). It classifies GEOMETRY only; radius admissibility is the builder's concern.
+// A multi-edge or curved-neighbour spine is NotKnownPart, so the marcher owns it (Phase 4).
+func ClassifyKnownPart(sp *Spine) KnownPartKind {
+	if sp.NbEdges() != 1 {
+		return NotKnownPart
+	}
+	e := sp.Edge(0)
+	faces := e.Faces()
+	if len(faces) != 2 {
+		return NotKnownPart
+	}
+	switch e.Geometry().(type) {
+	case geom.LineSegment:
+		if bothPlanar(faces) {
+			return KnownPlanarEdge
+		}
+	case geom.Circle:
+		if cylinderAndPlane(faces) && e.StartVertex() == e.EndVertex() {
+			return KnownCylinderRim
+		}
+	case geom.Arc3d:
+		if cylinderAndPlane(faces) {
+			return KnownCylinderArc
+		}
+	}
+	return NotKnownPart
+}
+
+// bothPlanar reports whether both faces carry a planar surface.
+func bothPlanar(faces []*topo.Face) bool {
+	_, a := faces[0].Geometry().(geom.Plane)
+	_, b := faces[1].Geometry().(geom.Plane)
+	return a && b
+}
+
+// cylinderAndPlane reports whether the two faces are one cylinder and one plane (in either order).
+func cylinderAndPlane(faces []*topo.Face) bool {
+	_, cyl0 := faces[0].Geometry().(geom.Cylinder)
+	_, pl0 := faces[0].Geometry().(geom.Plane)
+	_, cyl1 := faces[1].Geometry().(geom.Cylinder)
+	_, pl1 := faces[1].Geometry().(geom.Plane)
+	return (cyl0 && pl1) || (pl0 && cyl1)
+}

--- a/kernel/blend/law.go
+++ b/kernel/blend/law.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package blend
+
+import "sort"
+
+// RadiusLaw maps a spine abscissa to the fillet radius there — the evolution of a variable-radius
+// fillet along its guide. It mirrors OCCT Law_Function (Law_Constant / Law_Linear / Law_Interpol):
+// the marcher samples At(w) at each section station so one guide can carry a changing radius.
+type RadiusLaw interface {
+	// At returns the radius at spine abscissa w.
+	At(w float64) float64
+}
+
+// ConstLaw is a constant radius (OCCT Law_Constant) — the ordinary uniform fillet.
+type ConstLaw struct {
+	R float64
+}
+
+// At returns the constant radius.
+func (l ConstLaw) At(float64) float64 { return l.R }
+
+// LinearLaw ramps the radius linearly from R0 at abscissa S0 to R1 at S1 (OCCT Law_Linear),
+// clamped to [R0,R1] outside [S0,S1]. It is the two-ended variable fillet.
+type LinearLaw struct {
+	S0, R0, S1, R1 float64
+}
+
+// At returns the linearly interpolated radius at w, clamped at the ends.
+func (l LinearLaw) At(w float64) float64 {
+	if l.S1 == l.S0 {
+		return l.R0
+	}
+	t := (w - l.S0) / (l.S1 - l.S0)
+	if t <= 0 {
+		return l.R0
+	}
+	if t >= 1 {
+		return l.R1
+	}
+	return l.R0 + t*(l.R1-l.R0)
+}
+
+// LawStop is one (abscissa, radius) breakpoint of an interpolated radius law.
+type LawStop struct {
+	S, R float64
+}
+
+// InterpLaw is a piecewise-linear radius through ordered (abscissa,radius) stops (OCCT
+// Law_Interpol) — a fillet with intermediate radius set-points. Stops are sorted by abscissa on
+// construction; between them the radius interpolates linearly, and it is clamped outside the range.
+type InterpLaw struct {
+	stops []LawStop
+}
+
+// NewInterpLaw builds an interpolated law from stops (which need not be pre-sorted). It returns a
+// ConstLaw-equivalent single value when given fewer than two stops.
+func NewInterpLaw(stops []LawStop) InterpLaw {
+	s := append([]LawStop(nil), stops...)
+	sort.Slice(s, func(i, j int) bool { return s[i].S < s[j].S })
+	return InterpLaw{stops: s}
+}
+
+// At returns the piecewise-linear radius at w, clamped to the first/last stop outside the range.
+func (l InterpLaw) At(w float64) float64 {
+	if len(l.stops) == 0 {
+		return 0
+	}
+	if w <= l.stops[0].S {
+		return l.stops[0].R
+	}
+	last := l.stops[len(l.stops)-1]
+	if w >= last.S {
+		return last.R
+	}
+	for i := 1; i < len(l.stops); i++ {
+		if w <= l.stops[i].S {
+			a, b := l.stops[i-1], l.stops[i]
+			t := (w - a.S) / (b.S - a.S)
+			return a.R + t*(b.R-a.R)
+		}
+	}
+	return last.R
+}

--- a/kernel/blend/marcher.go
+++ b/kernel/blend/marcher.go
@@ -59,13 +59,69 @@ func (m *Marcher) segment(sp *Spine, i int, a, b geom.Surface, sec SectionFuncti
 		}
 	}
 	first, last := sp.EdgeSpineRange(i)
-	return BlendSegment{
+	seg := BlendSegment{
 		Surface:    surf,
 		OnS1:       FaceInterference{Face: sp.SupportFaces(i)[0]},
 		OnS2:       FaceInterference{Face: sp.SupportFaces(i)[1]},
 		FirstSpine: first,
 		LastSpine:  last,
-	}, StatusOk
+	}
+	if !m.fillInterferences(&seg, sp, a, b, r, first, last) {
+		return BlendSegment{}, StatusStartSectionFailed
+	}
+	return seg, StatusOk
+}
+
+// fillInterferences trims the segment against its two supports: the contact (foot-point) curve on
+// each support and the four common points bounding the tube (start/end × side). The blend is tangent
+// to each support along the centre curve's foot; a plane support yields a straight contact, a
+// cylinder support a circular one. These are the ChFiDS_FaceInterference + ChFiDS_CommonPoint the ops
+// stripe assembler stitches — consecutive segments share a junction section because both sample the
+// same spine abscissa there, so their end foot points coincide.
+func (m *Marcher) fillInterferences(seg *BlendSegment, sp *Spine, a, b geom.Surface, r, first, last float64) bool {
+	cLo, okLo := m.expectedCentre(sp.PointAt(first), a, b, r)
+	cMid, okMid := m.expectedCentre(sp.PointAt((first+last)/2), a, b, r)
+	cHi, okHi := m.expectedCentre(sp.PointAt(last), a, b, r)
+	if !okLo || !okMid || !okHi {
+		return false
+	}
+	seg.OnS1.Curve = contactCurve(a, cLo, cMid, cHi)
+	seg.OnS2.Curve = contactCurve(b, cLo, cMid, cHi)
+	seg.Start1 = CommonPoint{SpineParam: first, Point: footOn(a, cLo)}
+	seg.Start2 = CommonPoint{SpineParam: first, Point: footOn(b, cLo)}
+	seg.End1 = CommonPoint{SpineParam: last, Point: footOn(a, cHi)}
+	seg.End2 = CommonPoint{SpineParam: last, Point: footOn(b, cHi)}
+	return seg.OnS1.Curve != nil && seg.OnS2.Curve != nil
+}
+
+// contactCurve is the blend's contact on one support: the support-foot of the centre points at the
+// segment's two ends and middle — a line segment when the three feet are collinear (a plane support),
+// otherwise the circular arc through them (a cylinder/torus support).
+func contactCurve(s geom.Surface, cLo, cMid, cHi math.Point3) geom.Curve3 {
+	fa, fm, fb := footOn(s, cLo), footOn(s, cMid), footOn(s, cHi)
+	area := fa.VectorTo(fm).Cross(fa.VectorTo(fb)).Length()
+	if float64(area) < 1e-12 { // collinear feet ⇒ straight contact
+		return geom.NewLineSegment(fa, fb)
+	}
+	arc, err := geom.Arc3dByThreePoints(fa, fm, fb)
+	if err != nil {
+		return nil
+	}
+	return arc
+}
+
+// BallCentre returns the exact rolling-ball centre at a guide point between supports a and b at
+// radius r (ok=false when no seed section exists there). ops calls it at a junction vertex to place
+// the section circle two consecutive blend faces share.
+func (m *Marcher) BallCentre(guide math.Point3, a, b geom.Surface, r float64) (math.Point3, bool) {
+	return m.expectedCentre(guide, a, b, r)
+}
+
+// Section returns the exposed cross-section arc of radius r at a centre point on the blend's centre
+// curve — its FootA/FootB (the contacts on a and b) and PointAt(0.5) (the tube apex) let ops build
+// the junction edge as an arc through the three.
+func (m *Marcher) Section(centre math.Point3, a, b geom.Surface, r float64) (SectionArc, bool) {
+	return sectionAt(centre, a, b, r, m.Res.Weld(), m.Inside)
 }
 
 // centreCurve returns the rolling-ball centre curve between primitive supports a and b at radius r:

--- a/kernel/blend/marcher.go
+++ b/kernel/blend/marcher.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package blend
+
+import (
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Marcher is the general constant-radius blend solver (ADR-0050 Phase 4, method B): the rolling-ball
+// CENTRE curve is the intersection of the two support offsets, and the blend surface is the canal of
+// radius r about it. For primitive support pairs that intersection is exact (a line ⇒ a cylinder
+// blend, a circle ⇒ a torus blend) via our analytic SSI; otherwise the centre curve is marched and
+// the canal is fit as a B-spline (approx.go). It is injected into blend.Builder by ops, which
+// supplies the in-solid predicate and the model-scaled resolution (mirrors OCCT BRepBlend_Walking).
+type Marcher struct {
+	Inside func(math.Point3) bool // reports whether a point is inside the target solid
+	Res    geom.Resolution        // model-relative coincidence scale (from the body bbox)
+}
+
+// March builds a blend segment per spine edge and returns the run. A segment that cannot be built
+// (no valid seed section — the radius exceeds the local curvature bound) yields the localized status
+// and stops the run there, following OCCT's partial-result contract.
+func (m *Marcher) March(sp *Spine, sec SectionFunctional) Result {
+	var out []BlendSegment
+	for i := 0; i < sp.NbEdges(); i++ {
+		faces := sp.SupportFaces(i)
+		if len(faces) != 2 {
+			return Result{Segments: out, Status: StatusWalkingFailed}
+		}
+		seg, st := m.segment(sp, i, faces[0].Geometry(), faces[1].Geometry(), sec)
+		if st != StatusOk {
+			return Result{Segments: out, Status: st}
+		}
+		out = append(out, seg)
+	}
+	return Result{Segments: out, Status: StatusOk}
+}
+
+// segment builds one blend segment over spine edge i between supports a and b.
+func (m *Marcher) segment(sp *Spine, i int, a, b geom.Surface, sec SectionFunctional) (BlendSegment, ErrorStatus) {
+	r := sec.Extent(midSpineParam(sp, i))
+	centre, ok := m.centreCurve(a, b, r)
+	if !ok {
+		return BlendSegment{}, StatusStartSectionFailed
+	}
+	surf, ok := analyticBlendSurface(centre, r)
+	if !ok {
+		lo, hi := centre.Domain()
+		var st ErrorStatus
+		if surf, st = fitCanal(centre, a, b, r, lo, hi, m.Res.Weld(), m.Inside); st != StatusOk {
+			return BlendSegment{}, st
+		}
+	}
+	first, last := sp.EdgeSpineRange(i)
+	return BlendSegment{
+		Surface:    surf,
+		OnS1:       FaceInterference{Face: sp.SupportFaces(i)[0]},
+		OnS2:       FaceInterference{Face: sp.SupportFaces(i)[1]},
+		FirstSpine: first,
+		LastSpine:  last,
+	}, StatusOk
+}
+
+// centreCurve returns the rolling-ball centre curve between primitive supports a and b at radius r:
+// it intersects the analytic offsets for each of the four inside/outside sign combinations and
+// returns the branch whose sections are valid and whose centre lies in the solid (the convex fillet).
+func (m *Marcher) centreCurve(a, b geom.Surface, r float64) (geom.Curve3, bool) {
+	for _, sa := range [2]float64{-r, r} {
+		oa, oka := offsetPrimitive(a, sa)
+		if !oka {
+			continue
+		}
+		for _, sb := range [2]float64{-r, r} {
+			ob, okb := offsetPrimitive(b, sb)
+			if !okb {
+				continue
+			}
+			curves, handled := geom.IntersectSurfacesAnalytic(oa, ob, m.Res)
+			if !handled {
+				continue
+			}
+			for _, cv := range curves {
+				if m.centreValid(cv, a, b, r) {
+					return cv, true
+				}
+			}
+		}
+	}
+	return nil, false
+}
+
+// centreValid reports whether curve cv is the fillet centre curve: sampled points lie in the solid
+// (a convex fillet's ball centre is inside the material) and admit an exposed section of radius r.
+func (m *Marcher) centreValid(cv geom.Curve3, a, b geom.Surface, r float64) bool {
+	lo, hi := cv.Domain()
+	tol := m.Res.Weld()
+	for _, t := range []float64{lo + 0.25*(hi-lo), lo + 0.5*(hi-lo), lo + 0.75*(hi-lo)} {
+		c := cv.PointAt(t)
+		if !m.Inside(c) {
+			return false
+		}
+		if _, ok := sectionAt(c, a, b, r, tol, m.Inside); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// offsetPrimitive returns the exact offset of a primitive support by signed distance d — the plane
+// shifted d along its normal, or the coaxial cylinder of radius R+d — or ok=false for a non-primitive
+// (the general path uses geom.OffsetSurface + the SSI tracer instead).
+func offsetPrimitive(s geom.Surface, d float64) (geom.Surface, bool) {
+	switch t := s.(type) {
+	case geom.Plane:
+		p, err := geom.NewPlane(t.Origin.TranslateBy(t.Normal().Scale(math.Scalar(d))), t.Normal())
+		return p, err == nil
+	case geom.Cylinder:
+		if t.Radius+d <= 0 {
+			return nil, false
+		}
+		cyl, err := geom.NewCylinderWithRef(t.Origin, t.AxisDir.AsVector(), t.Ref.AsVector(), t.Radius+d)
+		return cyl, err == nil
+	}
+	return nil, false
+}
+
+// analyticBlendSurface returns the exact blend surface for a primitive centre curve: the canal of
+// radius r about a straight centre is a cylinder, about a circular centre a torus. Any other centre
+// (an ellipse or a marched NURBS curve) has no primitive canal and returns ok=false (approx.go fits
+// it as a B-spline).
+func analyticBlendSurface(centre geom.Curve3, r float64) (geom.Surface, bool) {
+	switch c := centre.(type) {
+	case geom.Line:
+		cyl, err := geom.NewCylinder(c.Origin, c.Dir.AsVector(), r)
+		return cyl, err == nil
+	case geom.LineSegment:
+		cyl, err := geom.NewCylinder(c.StartPoint, c.StartPoint.VectorTo(c.EndPoint), r)
+		return cyl, err == nil
+	case geom.Circle:
+		tor, err := geom.NewTorus(c.Center, c.Normal.AsVector(), c.Radius, r)
+		return tor, err == nil
+	}
+	return nil, false
+}
+
+// midSpineParam is the spine abscissa at the middle of edge i (where the section radius is sampled).
+func midSpineParam(sp *Spine, i int) float64 {
+	lo, hi := sp.EdgeSpineRange(i)
+	return (lo + hi) / 2
+}

--- a/kernel/blend/marcher.go
+++ b/kernel/blend/marcher.go
@@ -3,6 +3,8 @@
 package blend
 
 import (
+	stdmath "math"
+
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/math"
 )
@@ -40,7 +42,11 @@ func (m *Marcher) March(sp *Spine, sec SectionFunctional) Result {
 // segment builds one blend segment over spine edge i between supports a and b.
 func (m *Marcher) segment(sp *Spine, i int, a, b geom.Surface, sec SectionFunctional) (BlendSegment, ErrorStatus) {
 	r := sec.Extent(midSpineParam(sp, i))
-	centre, ok := m.centreCurve(a, b, r)
+	anchor, ok := m.expectedCentre(sp.PointAt(midSpineParam(sp, i)), a, b, r)
+	if !ok {
+		return BlendSegment{}, StatusStartSectionFailed // radius exceeds the local curvature bound here
+	}
+	centre, ok := m.centreCurve(a, b, r, anchor)
 	if !ok {
 		return BlendSegment{}, StatusStartSectionFailed
 	}
@@ -64,8 +70,12 @@ func (m *Marcher) segment(sp *Spine, i int, a, b geom.Surface, sec SectionFuncti
 
 // centreCurve returns the rolling-ball centre curve between primitive supports a and b at radius r:
 // it intersects the analytic offsets for each of the four inside/outside sign combinations and
-// returns the branch whose sections are valid and whose centre lies in the solid (the convex fillet).
-func (m *Marcher) centreCurve(a, b geom.Surface, r float64) (geom.Curve3, bool) {
+// returns the branch passing through the anchor (the analytic ball centre at the guide station). The
+// anchor — not domain sampling — selects the branch, so it is robust for an UNBOUNDED centre curve
+// (a plane∩plane blend's centre is an infinite line, whose domain midpoint is meaningless): #1797's
+// straight segments failed the old domain-sampled validation for exactly this reason.
+func (m *Marcher) centreCurve(a, b geom.Surface, r float64, anchor math.Point3) (geom.Curve3, bool) {
+	best, bestErr := geom.Curve3(nil), stdmath.Inf(1)
 	for _, sa := range [2]float64{-r, r} {
 		oa, oka := offsetPrimitive(a, sa)
 		if !oka {
@@ -81,30 +91,67 @@ func (m *Marcher) centreCurve(a, b geom.Surface, r float64) (geom.Curve3, bool) 
 				continue
 			}
 			for _, cv := range curves {
-				if m.centreValid(cv, a, b, r) {
-					return cv, true
+				if d := distPointToCurve(cv, anchor); d < bestErr {
+					best, bestErr = cv, d
 				}
 			}
 		}
 	}
-	return nil, false
+	if best == nil || bestErr > m.Res.Weld() {
+		return nil, false
+	}
+	return best, true
 }
 
-// centreValid reports whether curve cv is the fillet centre curve: sampled points lie in the solid
-// (a convex fillet's ball centre is inside the material) and admit an exposed section of radius r.
-func (m *Marcher) centreValid(cv geom.Curve3, a, b geom.Surface, r float64) bool {
+// expectedCentre returns the exact rolling-ball centre at a guide station: the point receded from the
+// spine point mid by r along the interior bisector of the two supports (offDir = −(nA+nB)/(1+nA·nB),
+// the same convex-fillet offset ops uses), with each support normal oriented outward via Inside. It
+// doubles as the seed-section existence check — ok=false when the centre admits no exposed section of
+// radius r (the radius exceeds the local curvature bound, OCCT's StartSolFailure).
+func (m *Marcher) expectedCentre(mid math.Point3, a, b geom.Surface, r float64) (math.Point3, bool) {
+	nA, nB := m.outwardNormal(a, mid), m.outwardNormal(b, mid)
+	denom := 1 + nA.Dot(nB)
+	if denom < 1e-9 { // supports face opposite ways (a ~180° edge) — no rolling-ball corner
+		return math.Point3{}, false
+	}
+	offDir := nA.Add(nB).Scale(-r / denom)
+	c := mid.TranslateBy(offDir)
+	if _, ok := sectionAt(c, a, b, r, m.Res.Weld(), m.Inside); !ok {
+		return math.Point3{}, false
+	}
+	return c, true
+}
+
+// outwardNormal returns support s's unit normal at the foot of p, flipped to point OUT of the solid
+// (a small step along it leaves the material). The sign is what makes offDir recede into the solid.
+func (m *Marcher) outwardNormal(s geom.Surface, p math.Point3) math.Vector3 {
+	u, v := s.ParamAt(p)
+	n := unitVec(s.NormalAt(u, v))
+	if m.Inside(p.TranslateBy(n.Scale(10 * m.Res.Weld()))) {
+		return n.Scale(-1)
+	}
+	return n
+}
+
+// distPointToCurve is the distance from p to curve cv — closed-form for an unbounded line, else the
+// minimum over a dense domain sampling (all other analytic centre curves — circle, ellipse — are
+// bounded). It ranks the offset-intersection branches so centreCurve picks the one through the anchor.
+func distPointToCurve(cv geom.Curve3, p math.Point3) float64 {
 	lo, hi := cv.Domain()
-	tol := m.Res.Weld()
-	for _, t := range []float64{lo + 0.25*(hi-lo), lo + 0.5*(hi-lo), lo + 0.75*(hi-lo)} {
-		c := cv.PointAt(t)
-		if !m.Inside(c) {
-			return false
-		}
-		if _, ok := sectionAt(c, a, b, r, tol, m.Inside); !ok {
-			return false
+	if stdmath.IsInf(lo, 0) || stdmath.IsInf(hi, 0) {
+		o := cv.PointAt(0)
+		d := unitVec(cv.TangentAt(0))
+		w := o.VectorTo(p)
+		return float64(w.Sub(d.Scale(w.Dot(d))).Length())
+	}
+	best := stdmath.Inf(1)
+	const n = 64
+	for i := 0; i <= n; i++ {
+		if d := float64(cv.PointAt(lo + (hi-lo)*float64(i)/n).DistanceTo(p)); d < best {
+			best = d
 		}
 	}
-	return true
+	return best
 }
 
 // offsetPrimitive returns the exact offset of a primitive support by signed distance d — the plane

--- a/kernel/blend/marcher_test.go
+++ b/kernel/blend/marcher_test.go
@@ -22,7 +22,14 @@ func TestMarcherCentreCurvePlaneCylinder(t *testing.T) {
 	}
 	m := &Marcher{Inside: inside, Res: geom.ResolutionForSize(6)}
 
-	centre, ok := m.centreCurve(plane, cyl, 0.5)
+	anchor, ok := m.expectedCentre(math.P3(2, 0, 3), plane, cyl, 0.5) // guide point on the rim edge
+	if !ok {
+		t.Fatal("no seed section at the guide station")
+	}
+	if stdmath.Abs(float64(anchor.DistanceTo(math.P3(1.5, 0, 2.5)))) > 1e-9 {
+		t.Errorf("expected centre = %v, want (1.5, 0, 2.5)", anchor)
+	}
+	centre, ok := m.centreCurve(plane, cyl, 0.5, anchor)
 	if !ok {
 		t.Fatal("no centre curve found for plane+cylinder rolling ball")
 	}
@@ -49,6 +56,39 @@ func TestMarcherCentreCurvePlaneCylinder(t *testing.T) {
 	assertBlendTangent(t, tor, 3.0, 2.0)
 }
 
+// TestMarcherCentreCurvePlanePlane is the #1797 straight-segment regression: a convex 90° edge
+// between two planes has an UNBOUNDED line as its rolling-ball centre curve, so the old
+// domain-midpoint validation sampled meaningless far-off points and the seed failed. The
+// anchor-based selection must pick that line (blend surface = a cylinder of radius r).
+func TestMarcherCentreCurvePlanePlane(t *testing.T) {
+	planeX, _ := geom.NewPlane(math.P3(1, 0, 0), math.V3(1, 0, 0)) // x = 1
+	planeZ, _ := geom.NewPlane(math.P3(0, 0, 1), math.V3(0, 0, 1)) // z = 1
+	inside := func(p math.Point3) bool { return float64(p.X) < 1 && float64(p.Z) < 1 }
+	m := &Marcher{Inside: inside, Res: geom.ResolutionForSize(4)}
+
+	anchor, ok := m.expectedCentre(math.P3(1, 0, 1), planeX, planeZ, 0.3) // guide point on the edge
+	if !ok {
+		t.Fatal("no seed section for the plane∩plane straight edge")
+	}
+	if float64(anchor.DistanceTo(math.P3(0.7, 0, 0.7))) > 1e-9 {
+		t.Errorf("expected centre = %v, want (0.7, 0, 0.7)", anchor)
+	}
+	centre, ok := m.centreCurve(planeX, planeZ, 0.3, anchor)
+	if !ok {
+		t.Fatal("no centre curve for the plane∩plane rolling ball (the unbounded-line regression)")
+	}
+	if lo, hi := centre.Domain(); !stdmath.IsInf(lo, 0) && !stdmath.IsInf(hi, 0) {
+		t.Errorf("plane∩plane centre curve should be an unbounded line, got domain [%g,%g]", lo, hi)
+	}
+	surf, ok := analyticBlendSurface(centre, 0.3)
+	if !ok {
+		t.Fatal("no analytic blend surface for a line centre curve")
+	}
+	if cyl, isCyl := surf.(geom.Cylinder); !isCyl || stdmath.Abs(cyl.Radius-0.3) > 1e-9 {
+		t.Fatalf("blend surface = %T, want a cylinder of radius 0.3", surf)
+	}
+}
+
 // assertBlendTangent samples the torus tube's extreme point on each principal direction: its top
 // must reach the cap plane and its outer equator the cylinder radius.
 func assertBlendTangent(t *testing.T, tor geom.Torus, capZ, cylR float64) {
@@ -72,7 +112,8 @@ func TestFitCanalMatchesTorusOracle(t *testing.T) {
 		return float64(p.Z) < 3 && stdmath.Hypot(float64(p.X), float64(p.Y)) < 2
 	}
 	m := &Marcher{Inside: inside, Res: geom.ResolutionForSize(6)}
-	centre, _ := m.centreCurve(plane, cyl, 0.5)
+	anchor, _ := m.expectedCentre(math.P3(2, 0, 3), plane, cyl, 0.5)
+	centre, _ := m.centreCurve(plane, cyl, 0.5, anchor)
 	lo, hi := centre.Domain()
 	// A real segment spans a bounded sub-arc (a quarter-cylinder rim is 90°); the full 360° circle
 	// as one bicubic is under-resolved. Fit the first quarter, as a bounded edge would.

--- a/kernel/blend/marcher_test.go
+++ b/kernel/blend/marcher_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package blend
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// TestMarcherCentreCurvePlaneCylinder checks the heart of method (B): between a top plane and a
+// coaxial cylinder (radius 2), the rolling-ball (r=0.5) centre curve is the EXACT circle of radius
+// R−r=1.5 at height z_top−r=2.5, and the blend surface is the torus (major 1.5, minor 0.5) tangent
+// to both supports — the curved-neighbour blend our analytic catalog could not route (#1797/#1806).
+func TestMarcherCentreCurvePlaneCylinder(t *testing.T) {
+	plane, _ := geom.NewPlane(math.P3(0, 0, 3), math.V3(0, 0, 1))
+	cyl, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2)
+	inside := func(p math.Point3) bool { // the solid: inside the cylinder AND below the cap
+		return float64(p.Z) < 3 && stdmath.Hypot(float64(p.X), float64(p.Y)) < 2
+	}
+	m := &Marcher{Inside: inside, Res: geom.ResolutionForSize(6)}
+
+	centre, ok := m.centreCurve(plane, cyl, 0.5)
+	if !ok {
+		t.Fatal("no centre curve found for plane+cylinder rolling ball")
+	}
+	circ, isCircle := centre.(geom.Circle)
+	if !isCircle {
+		t.Fatalf("centre curve is %T, want a circle", centre)
+	}
+	if stdmath.Abs(circ.Radius-1.5) > 1e-9 || stdmath.Abs(float64(circ.Center.Z)-2.5) > 1e-9 {
+		t.Errorf("centre circle radius=%g centreZ=%g, want 1.5 / 2.5", circ.Radius, circ.Center.Z)
+	}
+
+	surf, ok := analyticBlendSurface(centre, 0.5)
+	if !ok {
+		t.Fatal("no analytic blend surface for a circular centre curve")
+	}
+	tor, isTorus := surf.(geom.Torus)
+	if !isTorus {
+		t.Fatalf("blend surface is %T, want a torus", surf)
+	}
+	if stdmath.Abs(tor.MajorRadius-1.5) > 1e-9 || stdmath.Abs(tor.MinorRadius-0.5) > 1e-9 {
+		t.Errorf("torus major=%g minor=%g, want 1.5 / 0.5", tor.MajorRadius, tor.MinorRadius)
+	}
+	// tangency: the torus tube touches the cap plane at z=3 and the cylinder wall at radius 2.
+	assertBlendTangent(t, tor, 3.0, 2.0)
+}
+
+// assertBlendTangent samples the torus tube's extreme point on each principal direction: its top
+// must reach the cap plane and its outer equator the cylinder radius.
+func assertBlendTangent(t *testing.T, tor geom.Torus, capZ, cylR float64) {
+	t.Helper()
+	top := tor.MajorRadius*0 + float64(tor.Center.Z) + tor.MinorRadius
+	if stdmath.Abs(top-capZ) > 1e-9 {
+		t.Errorf("torus top z=%g, want tangent to cap at %g", top, capZ)
+	}
+	if outer := tor.MajorRadius + tor.MinorRadius; stdmath.Abs(outer-cylR) > 1e-9 {
+		t.Errorf("torus outer radius=%g, want tangent to cylinder at %g", outer, cylR)
+	}
+}
+
+// TestFitCanalMatchesTorusOracle forces the general B-spline canal fit on the plane+cylinder case
+// (whose exact blend is the torus) and checks the fitted surface lies on that torus within a fit
+// tolerance — validating approx.go against an analytic oracle for the non-primitive-centre path.
+func TestFitCanalMatchesTorusOracle(t *testing.T) {
+	plane, _ := geom.NewPlane(math.P3(0, 0, 3), math.V3(0, 0, 1))
+	cyl, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2)
+	inside := func(p math.Point3) bool {
+		return float64(p.Z) < 3 && stdmath.Hypot(float64(p.X), float64(p.Y)) < 2
+	}
+	m := &Marcher{Inside: inside, Res: geom.ResolutionForSize(6)}
+	centre, _ := m.centreCurve(plane, cyl, 0.5)
+	lo, hi := centre.Domain()
+	// A real segment spans a bounded sub-arc (a quarter-cylinder rim is 90°); the full 360° circle
+	// as one bicubic is under-resolved. Fit the first quarter, as a bounded edge would.
+	t1 := lo + 0.25*(hi-lo)
+
+	surf, st := fitCanal(centre, plane, cyl, 0.5, lo, t1, 1e-9, inside)
+	if st != StatusOk {
+		t.Fatalf("fitCanal status = %v", st)
+	}
+	const major, minor = 1.5, 0.5 // the oracle torus about (0,0,2.5), axis z
+	maxErr := 0.0
+	for iu := 0; iu <= 8; iu++ {
+		for iv := 0; iv <= 6; iv++ {
+			p := surf.PointAt(float64(iu)/8, float64(iv)/6)
+			rho := stdmath.Hypot(float64(p.X), float64(p.Y)) - major
+			d := stdmath.Hypot(rho, float64(p.Z)-2.5) - minor // signed distance to the torus tube
+			if a := stdmath.Abs(d); a > maxErr {
+				maxErr = a
+			}
+		}
+	}
+	if maxErr > 5e-3 {
+		t.Errorf("fitted canal deviates from the torus oracle by %g, want < 5e-3", maxErr)
+	}
+}

--- a/kernel/blend/section.go
+++ b/kernel/blend/section.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package blend
+
+// SectionFunctional is the pluggable cross-section that makes a fillet and a chamfer the SAME
+// pipeline differing only by their section (ADR-0050) — OCCT's Blend_Function / BlendFunc_ConstRad
+// seam. The marcher (Phase 4) sweeps this section along the spine, Newton-solving the foot points
+// so the section stays tangent to both support surfaces; the section family (circular arc for a
+// fillet, straight chord for a chamfer) decides the residual it solves.
+//
+// Phase 3 lands the port and its parameter carriers; the residual/Jacobian methods the marcher
+// needs are added by Phase 4 (a SectionSolver sub-interface), so nothing here computes geometry yet.
+type SectionFunctional interface {
+	// IsChamfer reports the section family: true ⇒ a straight chord (chamfer), false ⇒ a circular
+	// arc tangent to both walls (fillet).
+	IsChamfer() bool
+	// Extent returns the section's governing size at spine abscissa w — the fillet radius, or the
+	// chamfer's setback on side 1. It sizes the seed section and feeds the max-radius validity bound.
+	Extent(w float64) float64
+}
+
+// ConstRadiusFillet is the constant-radius rolling-ball fillet section: a circular arc of radius R
+// tangent to both support surfaces. The variable-radius law is Phase 5 (EvolRadiusSection).
+type ConstRadiusFillet struct {
+	R float64
+}
+
+// IsChamfer is false: a fillet section is a circular arc.
+func (ConstRadiusFillet) IsChamfer() bool { return false }
+
+// Extent returns the constant radius.
+func (f ConstRadiusFillet) Extent(float64) float64 { return f.R }
+
+// SymmetricChamfer is the equal-setback chamfer section: a straight chord cutting distance D back
+// along each support face. The two-distance and distance-angle modes are Phase 5 (ChamferSection).
+type SymmetricChamfer struct {
+	D float64
+}
+
+// IsChamfer is true: a chamfer section is a straight chord.
+func (SymmetricChamfer) IsChamfer() bool { return true }
+
+// Extent returns the setback distance.
+func (c SymmetricChamfer) Extent(float64) float64 { return c.D }

--- a/kernel/blend/section_p5_test.go
+++ b/kernel/blend/section_p5_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package blend
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestRadiusLaws checks the three OCCT Law_Function analogues: constant, linear (with end clamps),
+// and interpolated (sorted, piecewise-linear, end-clamped).
+func TestRadiusLaws(t *testing.T) {
+	if got := (ConstLaw{R: 2}).At(99); got != 2 {
+		t.Errorf("ConstLaw.At = %g, want 2", got)
+	}
+	lin := LinearLaw{S0: 0, R0: 1, S1: 4, R1: 3}
+	for _, tc := range []struct{ w, want float64 }{{-1, 1}, {0, 1}, {2, 2}, {4, 3}, {9, 3}} {
+		if got := lin.At(tc.w); stdmath.Abs(got-tc.want) > 1e-12 {
+			t.Errorf("LinearLaw.At(%g) = %g, want %g", tc.w, got, tc.want)
+		}
+	}
+	interp := NewInterpLaw([]LawStop{{S: 4, R: 5}, {S: 0, R: 1}, {S: 2, R: 2}}) // deliberately unsorted
+	for _, tc := range []struct{ w, want float64 }{{-1, 1}, {0, 1}, {1, 1.5}, {2, 2}, {3, 3.5}, {4, 5}, {5, 5}} {
+		if got := interp.At(tc.w); stdmath.Abs(got-tc.want) > 1e-12 {
+			t.Errorf("InterpLaw.At(%g) = %g, want %g", tc.w, got, tc.want)
+		}
+	}
+}
+
+// TestSectionFunctionalExtents checks each section family reports the right chamfer flag and the
+// governing size the validity bound reads.
+func TestSectionFunctionalExtents(t *testing.T) {
+	evol := EvolRadiusFillet{Law: LinearLaw{S0: 0, R0: 1, S1: 2, R1: 3}}
+	if evol.IsChamfer() || stdmath.Abs(evol.Extent(1)-2) > 1e-12 {
+		t.Errorf("EvolRadiusFillet: chamfer=%v extent(1)=%g, want false/2", evol.IsChamfer(), evol.Extent(1))
+	}
+	two := TwoDistanceChamfer{D1: 0.3, D2: 0.6}
+	if !two.IsChamfer() || two.Extent(0) != 0.6 {
+		t.Errorf("TwoDistanceChamfer: chamfer=%v extent=%g, want true/0.6", two.IsChamfer(), two.Extent(0))
+	}
+	da := DistanceAngleChamfer{D1: 1, Angle: stdmath.Pi / 4} // tan45=1 ⇒ D2=1
+	if !da.IsChamfer() || stdmath.Abs(da.D2()-1) > 1e-12 || stdmath.Abs(da.Extent(0)-1) > 1e-12 {
+		t.Errorf("DistanceAngleChamfer: chamfer=%v D2=%g extent=%g, want true/1/1", da.IsChamfer(), da.D2(), da.Extent(0))
+	}
+}
+
+// TestChamferSectionChord checks the chamfer chord recedes each setback along its support's inward
+// perpendicular and interpolates straight from FootA to FootB.
+func TestChamferSectionChord(t *testing.T) {
+	sec := chamferSectionAt(math.P3(0, 0, 0), math.V3(1, 0, 0), math.V3(0, 1, 0), 1, 2)
+	if d := sec.FootA.DistanceTo(math.P3(1, 0, 0)); float64(d) > 1e-12 {
+		t.Errorf("footA = %v, want (1,0,0)", sec.FootA)
+	}
+	if d := sec.FootB.DistanceTo(math.P3(0, 2, 0)); float64(d) > 1e-12 {
+		t.Errorf("footB = %v, want (0,2,0)", sec.FootB)
+	}
+	if d := sec.PointAt(0.5).DistanceTo(math.P3(0.5, 1, 0)); float64(d) > 1e-12 {
+		t.Errorf("chord midpoint = %v, want (0.5,1,0)", sec.PointAt(0.5))
+	}
+}

--- a/kernel/blend/segment.go
+++ b/kernel/blend/segment.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package blend
+
+import (
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// CommonPoint marks an endpoint of a blend segment — a point common to the blend and one support
+// face's boundary, and shared with the adjacent segment or corner. It carries the spine parameter
+// where it sits, the 3D point and tangent, and (when it lands on one) the body vertex or edge it
+// coincides with. Mirrors OCCT ChFiDS_CommonPoint (the four per-segment start/end points).
+type CommonPoint struct {
+	SpineParam float64
+	Point      math.Point3
+	Tangent    math.Vector3
+	OnVertex   *topo.Vertex // non-nil ⇒ the point is a body vertex
+	OnEdge     *topo.Edge   // non-nil ⇒ the point lies on this edge at EdgeParam
+	EdgeParam  float64
+	Tolerance  float64
+}
+
+// FaceInterference is the trimmed 3D curve where the blend surface meets one support face — the
+// boundary the segment is trimmed against on that side, with the parameter range of the curve the
+// segment spans. Mirrors OCCT ChFiDS_FaceInterference. (We hold the curve directly rather than an
+// index into a surface pool, which OCCT needs only for its transient bookkeeping.)
+type FaceInterference struct {
+	Face        *topo.Face
+	Curve       geom.Curve3 // blend ∩ face, in 3D
+	First, Last float64     // parameter span along Curve
+}
+
+// BlendSegment is one stretch of a fillet or chamfer along the spine: the blend surface, its
+// interference with each of the two support faces, and the four common points bounding it
+// (start/end × side 1/2), plus the spine-parameter range it covers. This is our ChFiDS_SurfData —
+// the marcher (Phase 4) emits a run of these, and ops trims and stitches them into the result body.
+type BlendSegment struct {
+	Surface               geom.Surface
+	OnS1, OnS2            FaceInterference // interference with support face 1 and 2
+	Start1, Start2        CommonPoint      // the segment's First endpoint on side 1 / side 2
+	End1, End2            CommonPoint      // the segment's Last endpoint on side 1 / side 2
+	FirstSpine, LastSpine float64          // spine-parameter range this segment covers
+}
+
+// SpineSpan is the guide-parameter range the segment covers, for stitching consecutive segments.
+func (s BlendSegment) SpineSpan() (first, last float64) { return s.FirstSpine, s.LastSpine }

--- a/kernel/blend/spine.go
+++ b/kernel/blend/spine.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package blend is the OCCT-parity blend engine (ADR-0050): one section-driven pipeline for
+// fillets and chamfers built on a guideline (the Spine), a section functional, an ODE marcher,
+// and a B-spline approximation. It imports only geom and topo — the fillet/chamfer features in
+// kernel/ops drive it, never the reverse, so the dependency points inward toward the domain.
+package blend
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Spine is the guideline a fillet or chamfer follows: an ordered run of tangent-continuous solid
+// edges concatenated into a single arc-length parameterization, over which the section functional
+// is swept. It mirrors OCCT ChFiDS_Spine — the same role (First/Last parameter, D0/D1, closed/open,
+// single-edge fast-path accessors) on our geom.Curve3 edges. The abscissa runs 0..Length in the
+// chain's traversal order; each edge is traversed entry→exit even when its intrinsic curve runs
+// the other way (see forward).
+//
+// Build it from a tangent chain (ops.TangentEdgeChain):
+//
+//	sp, err := blend.NewSpine(edges, closed)
+//	p := sp.PointAt(sp.Length() / 2) // midpoint of the guideline
+type Spine struct {
+	edges   []*topo.Edge
+	forward []bool    // per edge: true ⇒ traverse lo→hi, false ⇒ hi→lo
+	starts  []float64 // cumulative spine abscissa at each edge's entry vertex
+	lengths []float64 // arc length of each edge
+	total   float64
+	closed  bool
+}
+
+// NewSpine concatenates an ordered, tangent-continuous edge run into a guideline. closed marks a
+// loop (last edge's exit rejoins the first edge's entry). It errors on an empty run.
+func NewSpine(edges []*topo.Edge, closed bool) (*Spine, error) {
+	if len(edges) == 0 {
+		return nil, fmt.Errorf("blend.NewSpine: empty edge run")
+	}
+	s := &Spine{
+		edges:   edges,
+		closed:  closed,
+		forward: edgeDirections(edges),
+		starts:  make([]float64, len(edges)),
+		lengths: make([]float64, len(edges)),
+	}
+	for i, e := range edges {
+		lo, hi := e.Geometry().Domain()
+		s.starts[i] = s.total
+		s.lengths[i] = arcLength(e.Geometry(), lo, hi)
+		s.total += s.lengths[i]
+	}
+	return s, nil
+}
+
+// Length is the total guideline arc length; FirstParameter/LastParameter bound the abscissa.
+func (s *Spine) Length() float64         { return s.total }
+func (s *Spine) FirstParameter() float64 { return 0 }
+func (s *Spine) LastParameter() float64  { return s.total }
+func (s *Spine) IsClosed() bool          { return s.closed }
+func (s *Spine) NbEdges() int            { return len(s.edges) }
+func (s *Spine) Edge(i int) *topo.Edge   { return s.edges[i] }
+
+// IsSingleEdge reports the known-part fast path: a lone elementary edge (a line or a circle)
+// whose blend the analytic catalog can build without marching (ADR-0050, cf. ChFiKPart).
+func (s *Spine) IsSingleEdge() bool { return len(s.edges) == 1 }
+
+// PointAt returns the guideline position at spine abscissa absc (clamped to 0..Length).
+func (s *Spine) PointAt(absc float64) math.Point3 {
+	i, t := s.locate(absc)
+	return s.edges[i].Geometry().PointAt(t)
+}
+
+// TangentAt returns the unit guideline tangent at absc, oriented in the chain's traversal
+// direction (negated on edges traversed hi→lo).
+func (s *Spine) TangentAt(absc float64) math.Vector3 {
+	i, t := s.locate(absc)
+	v := s.edges[i].Geometry().TangentAt(t)
+	if !s.forward[i] {
+		v = v.Negate()
+	}
+	if l := float64(v.Length()); l > 0 {
+		v = v.Scale(math.Scalar(1 / l))
+	}
+	return v
+}
+
+// SupportFaces returns the two solid faces edge i bounds — the pair the section functional
+// blends between at that stretch of the guideline. Orientation (which is "left") is the
+// marcher's concern; this returns them as the topology records.
+func (s *Spine) SupportFaces(i int) []*topo.Face { return s.edges[i].Faces() }
+
+// locate maps a spine abscissa to the (edge index, curve parameter) that realizes it, inverting
+// each edge's arc length and honoring its traversal direction.
+func (s *Spine) locate(absc float64) (int, float64) {
+	absc = clampf(absc, 0, s.total)
+	i := s.edgeIndex(absc)
+	local := absc - s.starts[i]
+	lo, hi := s.edges[i].Geometry().Domain()
+	if s.forward[i] {
+		return i, paramAtArcLength(s.edges[i].Geometry(), lo, hi, local)
+	}
+	return i, paramAtArcLength(s.edges[i].Geometry(), lo, hi, s.lengths[i]-local)
+}
+
+// edgeIndex returns the edge covering abscissa absc (the last edge whose entry is ≤ absc).
+func (s *Spine) edgeIndex(absc float64) int {
+	for i := len(s.edges) - 1; i > 0; i-- {
+		if absc >= s.starts[i] {
+			return i
+		}
+	}
+	return 0
+}

--- a/kernel/blend/spine.go
+++ b/kernel/blend/spine.go
@@ -87,6 +87,12 @@ func (s *Spine) TangentAt(absc float64) math.Vector3 {
 	return v
 }
 
+// EdgeSpineRange returns the spine-abscissa span [first,last] that edge i covers — the guide range
+// the marcher builds one blend segment over.
+func (s *Spine) EdgeSpineRange(i int) (first, last float64) {
+	return s.starts[i], s.starts[i] + s.lengths[i]
+}
+
 // SupportFaces returns the two solid faces edge i bounds — the pair the section functional
 // blends between at that stretch of the guideline. Orientation (which is "left") is the
 // marcher's concern; this returns them as the topology records.

--- a/kernel/blend/spine_test.go
+++ b/kernel/blend/spine_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package blend_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/blend"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/subd"
+	"oblikovati.org/kernel/topo"
+)
+
+// spineBox builds a validated solid box for spine fixtures.
+func spineBox(sx, sy, sz float64) *topo.Body { return subd.ToBody(subd.Box(sx, sy, sz), "box") }
+
+// TestSpineSingleLineEdge: a lone straight edge is its own guideline — length equals the edge
+// length, endpoints map to abscissa 0 and Length, and the tangent is constant.
+func TestSpineSingleLineEdge(t *testing.T) {
+	box := spineBox(2, 2, 2)
+	e := box.Edges()[0] // every box edge is a straight line segment
+	sp, err := blend.NewSpine([]*topo.Edge{e}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantLen := float64(e.StartVertex().Point().DistanceTo(e.EndVertex().Point()))
+	if stdmath.Abs(sp.Length()-wantLen) > 1e-9 {
+		t.Fatalf("spine length = %g, want %g", sp.Length(), wantLen)
+	}
+	if !sp.IsSingleEdge() {
+		t.Error("single-edge spine should report the known-part fast path")
+	}
+	t0, tL := sp.TangentAt(0), sp.TangentAt(sp.Length())
+	if float64(t0.AngleTo(tL)) > 1e-9 {
+		t.Error("straight-edge spine tangent is not constant")
+	}
+}
+
+// TestSpineRoundedRimLoop concatenates the 8-edge tangent loop of a rounded box top rim into one
+// guideline: total length = 4 straight sides (len 1) + 4 quarter-arcs (r=0.5) = 4 + π, closed,
+// and the start point rejoins the end point.
+func TestSpineRoundedRimLoop(t *testing.T) {
+	box := spineBox(2, 2, 2)
+	rounded, err := ops.FilletEdges(box, boxVerticalEdgeKeys(t, box), 0.5)
+	if err != nil {
+		t.Fatalf("fillet: %v", err)
+	}
+	edges, closed := rimChainEdges(t, rounded, 2.0)
+	sp, err := blend.NewSpine(edges, closed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sp.IsClosed() {
+		t.Error("rounded rim spine should be closed")
+	}
+	const want = 4 + stdmath.Pi
+	if stdmath.Abs(sp.Length()-want) > 1e-4 {
+		t.Fatalf("rim spine length = %g, want %g", sp.Length(), want)
+	}
+	if d := sp.PointAt(0).DistanceTo(sp.PointAt(sp.Length())); float64(d) > 1e-6 {
+		t.Errorf("closed spine endpoints differ by %g", d)
+	}
+}
+
+// boxVerticalEdgeKeys returns the four vertical edges of a box.
+func boxVerticalEdgeKeys(t *testing.T, b *topo.Body) [][]byte {
+	t.Helper()
+	var keys [][]byte
+	for _, e := range b.Edges() {
+		if a, c := e.StartVertex().Point(), e.EndVertex().Point(); a.X == c.X && a.Y == c.Y {
+			keys = append(keys, e.ReferenceKey())
+		}
+	}
+	return keys
+}
+
+// rimChainEdges expands the top-rim tangent loop and resolves it to ordered edges.
+func rimChainEdges(t *testing.T, b *topo.Body, top float64) ([]*topo.Edge, bool) {
+	t.Helper()
+	var seed []byte
+	best := 0.0
+	for _, e := range b.Edges() {
+		a, c := e.StartVertex().Point(), e.EndVertex().Point()
+		if stdmath.Abs(float64(a.Z)-top) > 1e-6 || stdmath.Abs(float64(c.Z)-top) > 1e-6 {
+			continue
+		}
+		if l := float64(a.DistanceTo(c)); l > best {
+			seed, best = e.ReferenceKey(), l
+		}
+	}
+	keys, closed, err := ops.TangentEdgeChain(b, seed, ops.DefaultTangentChainAngle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	edges := make([]*topo.Edge, len(keys))
+	for i, k := range keys {
+		e, ok := b.FindEdgeByKey(k)
+		if !ok {
+			t.Fatalf("chain key %d not resolvable", i)
+		}
+		edges[i] = e
+	}
+	return edges, closed
+}

--- a/kernel/blend/status.go
+++ b/kernel/blend/status.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package blend
+
+// ErrorStatus localizes a blend failure to the stage that produced it, mirroring OCCT
+// ChFiDS_ErrorStatus. Carrying the stage lets a single bad segment or corner yield a partial
+// (Sick-with-hole) result that names what failed, instead of a global panic (ADR-0050).
+type ErrorStatus uint8
+
+const (
+	// StatusOk is a fully built blend.
+	StatusOk ErrorStatus = iota
+	// StatusStartSectionFailed: no valid seed cross-section exists — the radius exceeds what the
+	// local geometry admits (the planar closed form of this is Phase 2's max-radius check).
+	// OCCT ChFiDS_StartsolFailure.
+	StatusStartSectionFailed
+	// StatusWalkingFailed: the marcher lost the section mid-guide (a foot point left every support
+	// or the corrector diverged). OCCT ChFiDS_WalkingFailure.
+	StatusWalkingFailed
+	// StatusTwistedSurface: the approximated blend surface self-folded. OCCT ChFiDS_TwistedSurface.
+	StatusTwistedSurface
+	// StatusNotImplemented: a case the engine does not yet build (the Phase-3 marcher stub).
+	StatusNotImplemented
+)
+
+// String returns a stable diagnostic name.
+func (s ErrorStatus) String() string {
+	switch s {
+	case StatusOk:
+		return "ok"
+	case StatusStartSectionFailed:
+		return "start-section-failed"
+	case StatusWalkingFailed:
+		return "walking-failed"
+	case StatusTwistedSurface:
+		return "twisted-surface"
+	case StatusNotImplemented:
+		return "not-implemented"
+	default:
+		return "unknown"
+	}
+}
+
+// Result is the blend engine's output: the segments it built and the localized status. It follows
+// OCCT's partial-result contract — HasResult reports a usable (possibly incomplete) build, BadShape
+// a build that produced nothing usable — so the feature can go Sick-with-hole rather than fail hard.
+type Result struct {
+	Segments []BlendSegment
+	Status   ErrorStatus
+}
+
+// HasResult reports that at least one segment was built (a usable, possibly partial, blend).
+func (r Result) HasResult() bool { return len(r.Segments) > 0 }
+
+// BadShape reports a failed build that produced no usable geometry.
+func (r Result) BadShape() bool { return r.Status != StatusOk && len(r.Segments) == 0 }

--- a/kernel/ops/draft.go
+++ b/kernel/ops/draft.go
@@ -19,25 +19,18 @@ import (
 // material toward the far end); a POSITIVE angle leans it outward (adds material). See the
 // convention pinned by TestDraftTapersSideFace, which drafts inward with a negative angle.
 func DraftFaces(solid *topo.Body, faceKeys [][]byte, pull math.Vector3, angle float64) (*topo.Body, error) {
-	sel, err := resolveFaceSet(solid, faceKeys)
-	if err != nil {
-		return nil, err
-	}
 	p, perr := math.UnitVector3FromVector(pull)
 	if perr != nil {
 		return nil, perr
 	}
-	// #1802: the plane-only rebuild panics on a curved face left by a prior fillet/chamfer.
-	// Fail loudly (feature goes Sick) until the Phase-7 curved-draft modifier lands (#1809).
-	if err := requirePlanarBody(solid, "draft"); err != nil {
+	// #1802 (ADR-0050 P7): the modifier-visitor tilts the drafted planar faces and re-intersects the
+	// neighbours — so a body carrying curved faces from a prior fillet drafts into a valid tapered
+	// solid (its fillet edges re-trimmed to arcs) instead of panicking in the plane-only rebuild.
+	mod, err := newDraftMod(solid, faceKeys, p, angle)
+	if err != nil {
 		return nil, err
 	}
-	return rebuildWithPlanes(solid, "draft", true, func(f *topo.Face) geom.Plane {
-		if !sel[f.ID()] {
-			return f.Geometry().(geom.Plane)
-		}
-		return draftedPlane(f, p, angle)
-	}), nil
+	return modifyBody(solid, mod, "draft"), nil
 }
 
 // draftedPlane returns a face's plane rotated by angle about its hinge (pull × normal),

--- a/kernel/ops/draft.go
+++ b/kernel/ops/draft.go
@@ -27,6 +27,11 @@ func DraftFaces(solid *topo.Body, faceKeys [][]byte, pull math.Vector3, angle fl
 	if perr != nil {
 		return nil, perr
 	}
+	// #1802: the plane-only rebuild panics on a curved face left by a prior fillet/chamfer.
+	// Fail loudly (feature goes Sick) until the Phase-7 curved-draft modifier lands (#1809).
+	if err := requirePlanarBody(solid, "draft"); err != nil {
+		return nil, err
+	}
 	return rebuildWithPlanes(solid, "draft", true, func(f *topo.Face) geom.Plane {
 		if !sel[f.ID()] {
 			return f.Geometry().(geom.Plane)

--- a/kernel/ops/draft_mod.go
+++ b/kernel/ops/draft_mod.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// draftMod is the draft's [Modification] (ADR-0050 P7, the real #1802 fix): it tilts the selected
+// planar faces about their neutral-plane hinge and re-intersects the neighbours, so a face bordering
+// a fillet cylinder gets a re-trimmed elliptical edge instead of the plane-only rebuild panicking on
+// the curved neighbour. It mirrors OCCT Draft_Modification: all new geometry is precomputed into
+// per-entity maps, and NewSurface/NewCurve/NewPoint are lookups.
+type draftMod struct {
+	selected map[uint64]bool
+	res      geom.Resolution
+	faceSurf map[uint64]geom.Surface // every face's surface: tilted for selected, original otherwise
+	newSurf  map[uint64]geom.Surface // only the tilted (selected) faces
+	newPoint map[uint64]math.Point3  // relocated vertices
+	newCurve map[uint64]geom.Curve3  // re-intersected edges
+}
+
+// newDraftMod precomputes the draft: tilt each selected planar face, relocate every vertex on a
+// tilted face to the meeting point of its adjacent (new) surfaces, and re-intersect every edge that
+// touches a relocated vertex. Errors if a selected face is not planar (curved-face draft is future
+// work — the plane-only tilt does not yet apply to a cylinder/cone selected face).
+func newDraftMod(solid *topo.Body, faceKeys [][]byte, pull math.UnitVector3, angle float64) (*draftMod, error) {
+	sel, err := resolveFaceSet(solid, faceKeys)
+	if err != nil {
+		return nil, err
+	}
+	d := &draftMod{
+		selected: sel, res: geom.ResolutionForBox(solid.RangeBox()),
+		faceSurf: map[uint64]geom.Surface{}, newSurf: map[uint64]geom.Surface{},
+		newPoint: map[uint64]math.Point3{}, newCurve: map[uint64]geom.Curve3{},
+	}
+	if err := d.tiltSelectedFaces(solid, pull, angle); err != nil {
+		return nil, err
+	}
+	moved := d.relocateVertices(solid)
+	if err := d.reintersectEdges(solid, moved); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+// tiltSelectedFaces rotates each selected planar face about its hinge and records both the tilted
+// surface (newSurf) and every face's effective surface (faceSurf) for the re-intersection.
+func (d *draftMod) tiltSelectedFaces(solid *topo.Body, pull math.UnitVector3, angle float64) error {
+	for _, f := range solid.Faces() {
+		if !d.selected[f.ID()] {
+			d.faceSurf[f.ID()] = f.Geometry()
+			continue
+		}
+		if _, ok := f.Geometry().(geom.Plane); !ok {
+			return fmt.Errorf("draft: selected face %d is %T; only planar faces can be drafted (curved-face draft is future work)", f.ID(), f.Geometry())
+		}
+		tilted := draftedPlane(f, pull, angle)
+		d.faceSurf[f.ID()], d.newSurf[f.ID()] = tilted, tilted
+	}
+	return nil
+}
+
+// relocateVertices moves every vertex lying on a tilted face to the common point of its adjacent
+// new surfaces (a 3-surface Gauss-Newton solve from the old position), and returns the set of moved
+// vertex IDs so the edge re-intersection knows which edges changed.
+func (d *draftMod) relocateVertices(solid *topo.Body) map[uint64]bool {
+	vf := vertexFaceMap(solid)
+	moved := map[uint64]bool{}
+	for _, v := range solid.Vertices() {
+		if !d.vertexOnSelected(vf[v.ID()]) {
+			continue
+		}
+		if p, ok := intersectSurfacesNear(v.Point(), d.surfacesAt(vf[v.ID()]), d.res.Weld()); ok {
+			d.newPoint[v.ID()], moved[v.ID()] = p, true
+		}
+	}
+	return moved
+}
+
+// reintersectEdges recomputes the curve of every edge touching a moved vertex: the intersection of
+// its two faces' (new) surfaces, trimmed to the edge's new endpoints. Errors if a curve cannot be
+// rebuilt (an unhandled surface pair).
+func (d *draftMod) reintersectEdges(solid *topo.Body, moved map[uint64]bool) error {
+	for _, e := range solid.Edges() {
+		if !moved[e.StartVertex().ID()] && !moved[e.EndVertex().ID()] {
+			continue
+		}
+		faces := e.Faces()
+		if len(faces) != 2 {
+			continue
+		}
+		sA, sB := d.faceSurf[faces[0].ID()], d.faceSurf[faces[1].ID()]
+		crv, ok := d.reintersectEdge(e, sA, sB, d.endpoint(e.StartVertex()), d.endpoint(e.EndVertex()))
+		if !ok {
+			return fmt.Errorf("draft: cannot re-intersect edge %d between %T and %T", e.ID(), sA, sB)
+		}
+		d.newCurve[e.ID()] = crv
+	}
+	return nil
+}
+
+// vertexOnSelected reports whether any of the faces meeting at a vertex is drafted.
+func (d *draftMod) vertexOnSelected(faces []*topo.Face) bool {
+	for _, f := range faces {
+		if d.selected[f.ID()] {
+			return true
+		}
+	}
+	return false
+}
+
+// surfacesAt returns the effective (new) surfaces of the faces meeting at a vertex, the tilted
+// (drafted) ones first — so the three the Newton relocation pins on always include a moved surface
+// even when more than three faces meet (a filleted corner), keeping the vertex on the tilted plane.
+func (d *draftMod) surfacesAt(faces []*topo.Face) []geom.Surface {
+	out := make([]geom.Surface, 0, len(faces))
+	for _, f := range faces {
+		if d.selected[f.ID()] {
+			out = append(out, d.faceSurf[f.ID()])
+		}
+	}
+	for _, f := range faces {
+		if !d.selected[f.ID()] {
+			out = append(out, d.faceSurf[f.ID()])
+		}
+	}
+	return out
+}
+
+// endpoint returns a vertex's relocated position, or its original point if it did not move.
+func (d *draftMod) endpoint(v *topo.Vertex) math.Point3 {
+	if p, ok := d.newPoint[v.ID()]; ok {
+		return p
+	}
+	return v.Point()
+}
+
+// NewSurface returns the tilted surface of a drafted face.
+func (d *draftMod) NewSurface(f *topo.Face) (geom.Surface, bool) {
+	s, ok := d.newSurf[f.ID()]
+	return s, ok
+}
+
+// NewCurve returns the re-intersected curve of an edge touching the draft.
+func (d *draftMod) NewCurve(e *topo.Edge) (geom.Curve3, bool) {
+	c, ok := d.newCurve[e.ID()]
+	return c, ok
+}
+
+// NewPoint returns the relocated position of a vertex on a drafted face.
+func (d *draftMod) NewPoint(v *topo.Vertex) (math.Point3, bool) {
+	p, ok := d.newPoint[v.ID()]
+	return p, ok
+}

--- a/kernel/ops/draft_reintersect.go
+++ b/kernel/ops/draft_reintersect.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// intersectSurfacesNear returns the point common to three surfaces nearest a starting estimate — a
+// Gauss-Newton solve on the three signed-distance residuals (each surface contributes its normal as
+// the gradient), converging from the old vertex position. It is how the draft modifier relocates a
+// corner when its faces tilt: exact for three planes, and it handles a plane∩plane∩cylinder corner
+// (a filleted edge's endpoint) that the plane-only rebuild could not. ok=false if the normals are
+// degenerate (parallel) or fewer than three surfaces meet.
+func intersectSurfacesNear(start math.Point3, surfaces []geom.Surface, tol float64) (math.Point3, bool) {
+	if len(surfaces) < 3 {
+		return start, false
+	}
+	p := start
+	for iter := 0; iter < 40; iter++ {
+		a, b, ok := surfaceResidualSystem(p, surfaces)
+		if !ok {
+			return p, false
+		}
+		step, ok := solve3(a, b)
+		if !ok {
+			return p, false
+		}
+		p = p.TranslateBy(math.V3(step[0], step[1], step[2]))
+		if step[0]*step[0]+step[1]*step[1]+step[2]*step[2] < tol*tol {
+			return p, true
+		}
+	}
+	return p, true
+}
+
+// surfaceResidualSystem builds the 3×3 Newton system n_i·Δ = −d_i from the first three surfaces:
+// each row is the unit normal at p's projection, each right-hand side the negated signed distance.
+func surfaceResidualSystem(p math.Point3, surfaces []geom.Surface) ([3][3]float64, [3]float64, bool) {
+	var a [3][3]float64
+	var b [3]float64
+	for i := 0; i < 3; i++ {
+		u, v := surfaces[i].ParamAt(p)
+		foot := surfaces[i].PointAt(u, v)
+		n := surfaces[i].NormalAt(u, v)
+		l := float64(n.Length())
+		if l == 0 {
+			return a, b, false
+		}
+		n = n.Scale(math.Scalar(1 / l))
+		a[i] = [3]float64{float64(n.X), float64(n.Y), float64(n.Z)}
+		b[i] = -float64(foot.VectorTo(p).Dot(n))
+	}
+	return a, b, true
+}
+
+// reintersectEdge recomputes an edge's curve as the intersection of its two (new) support surfaces,
+// trimmed to the edge's new endpoints — a straight segment between planes, an arc between a plane
+// and a cylinder (circular when perpendicular, elliptical when the drafted plane cuts obliquely).
+func (d *draftMod) reintersectEdge(e *topo.Edge, sA, sB geom.Surface, p0, p1 math.Point3) (geom.Curve3, bool) {
+	curves, handled := geom.IntersectSurfacesAnalytic(sA, sB, d.res)
+	if !handled || len(curves) == 0 {
+		return geom.NewLineSegment(p0, p1), true // both planar (a line) or no analytic cross: straight
+	}
+	return trimCurveToEnds(nearestBranch(curves, edgeMidpoint(e)), p0, p1)
+}
+
+// nearestBranch picks the intersection branch whose sampled points pass nearest ref — the branch
+// the original edge lay on (an oblique plane∩cylinder yields one ellipse, but a cylinder can meet a
+// plane in two lines, so the choice matters).
+func nearestBranch(curves []geom.Curve3, ref math.Point3) geom.Curve3 {
+	best := curves[0]
+	bestD := stdmath.Inf(1)
+	for _, c := range curves {
+		for i := 0; i <= 8; i++ {
+			if d := float64(c.PointAt(float64(i) / 8).DistanceTo(ref)); d < bestD {
+				best, bestD = c, d
+			}
+		}
+	}
+	return best
+}
+
+// trimCurveToEnds bounds a full intersection curve to the arc between the two endpoints, choosing
+// the concrete bounded type: a line segment, a circular arc, or an elliptical arc.
+func trimCurveToEnds(curve geom.Curve3, p0, p1 math.Point3) (geom.Curve3, bool) {
+	switch c := curve.(type) {
+	case geom.Line, geom.LineSegment:
+		return geom.NewLineSegment(p0, p1), true
+	case geom.Circle:
+		return circleArcBetween(c, p0, p1)
+	case geom.EllipseFull:
+		return ellipseArcBetween(c, p0, p1)
+	default:
+		return geom.NewLineSegment(p0, p1), true // unknown analytic branch: straight best-effort
+	}
+}
+
+// circleArcBetween returns the arc of circle c from p0 to p1 that stays nearest the chord midpoint
+// (the shorter arc for a fillet edge, but chosen geometrically so a reflex edge also works).
+func circleArcBetween(c geom.Circle, p0, p1 math.Point3) (geom.Curve3, bool) {
+	x, y := c.RefDir.AsVector(), c.Normal.Cross(c.RefDir)
+	a0 := angleInPlane(c.Center, x, y, p0)
+	a1 := angleInPlane(c.Center, x, y, p1)
+	start, sweep := pickArc(a0, a1, p0.Midpoint(p1), func(s, sw float64) math.Point3 {
+		return pointOnCircleAt(c, s+0.5*sw)
+	})
+	arc, err := geom.NewArc3d(c.Center, c.Normal.AsVector(), x, c.Radius, start, sweep)
+	return arc, err == nil
+}
+
+// ellipseArcBetween returns the arc of ellipse c from p0 to p1 nearest the chord midpoint.
+func ellipseArcBetween(c geom.EllipseFull, p0, p1 math.Point3) (geom.Curve3, bool) {
+	x, y := c.MajorAxis.AsVector(), c.Normal.Cross(c.MajorAxis)
+	a0 := stdmath.Atan2(float64(c.Center.VectorTo(p0).Dot(y))/c.MinorRadius, float64(c.Center.VectorTo(p0).Dot(x))/c.MajorRadius)
+	a1 := stdmath.Atan2(float64(c.Center.VectorTo(p1).Dot(y))/c.MinorRadius, float64(c.Center.VectorTo(p1).Dot(x))/c.MajorRadius)
+	start, sweep := pickArc(a0, a1, p0.Midpoint(p1), func(s, sw float64) math.Point3 {
+		return ellipsePointAt(c, s+0.5*sw)
+	})
+	arc, err := geom.NewEllipticalArc(c.Center, c.Normal.AsVector(), x, c.MajorRadius, c.MinorRadius, start, sweep)
+	return arc, err == nil
+}
+
+// pickArc chooses (start=a0, sweep) so the arc from a0 to a1 bulges toward chordMid: it compares the
+// short (positive) sweep against its 2π complement by which one's midpoint is nearer chordMid.
+func pickArc(a0, a1 float64, chordMid math.Point3, midAt func(start, sweep float64) math.Point3) (float64, float64) {
+	sweep := wrapTwoPi(a1 - a0)
+	alt := sweep - 2*stdmath.Pi
+	if midAt(a0, alt).DistanceTo(chordMid) < midAt(a0, sweep).DistanceTo(chordMid) {
+		return a0, alt
+	}
+	return a0, sweep
+}
+
+// angleInPlane returns the angle of point p about origin in the (x,y) in-plane basis.
+func angleInPlane(origin math.Point3, x, y math.Vector3, p math.Point3) float64 {
+	return stdmath.Atan2(float64(origin.VectorTo(p).Dot(y)), float64(origin.VectorTo(p).Dot(x)))
+}
+
+// pointOnCircleAt evaluates circle c at angle a (RefDir at a=0).
+func pointOnCircleAt(c geom.Circle, a float64) math.Point3 {
+	x, y := c.RefDir.AsVector(), c.Normal.Cross(c.RefDir)
+	return c.Center.TranslateBy(x.Scale(math.Scalar(c.Radius * stdmath.Cos(a))).Add(y.Scale(math.Scalar(c.Radius * stdmath.Sin(a)))))
+}
+
+// ellipsePointAt evaluates ellipse c at angle a (MajorAxis at a=0).
+func ellipsePointAt(c geom.EllipseFull, a float64) math.Point3 {
+	x, y := c.MajorAxis.AsVector(), c.Normal.Cross(c.MajorAxis)
+	return c.Center.TranslateBy(x.Scale(math.Scalar(c.MajorRadius * stdmath.Cos(a))).Add(y.Scale(math.Scalar(c.MinorRadius * stdmath.Sin(a)))))
+}
+
+// wrapTwoPi maps an angle into [0, 2π).
+func wrapTwoPi(a float64) float64 {
+	for a < 0 {
+		a += 2 * stdmath.Pi
+	}
+	for a >= 2*stdmath.Pi {
+		a -= 2 * stdmath.Pi
+	}
+	return a
+}

--- a/kernel/ops/draft_test.go
+++ b/kernel/ops/draft_test.go
@@ -6,6 +6,7 @@ import (
 	stdmath "math"
 	"testing"
 
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/math"
 )
@@ -62,5 +63,33 @@ func TestDraftLostKeyErrors(t *testing.T) {
 	box := shellBox(2, 2, 2)
 	if _, err := ops.DraftFaces(box, [][]byte{[]byte("ghost")}, math.V3(0, 0, 1), 0.1); err == nil {
 		t.Error("draft with a lost key should error")
+	}
+}
+
+// TestDraftOnFilletedBodyErrors is the #1802 regression (ADR-0050 Phase 0, #1804): drafting a
+// body that carries a curved face from a prior fillet must return an error so the feature goes
+// Sick with a teaching message — NOT panic in the plane-only rebuild. Superseded by the
+// Phase-7 curved-draft modifier (#1809), which will taper such a body for real.
+func TestDraftOnFilletedBodyErrors(t *testing.T) {
+	box := csgBox(math.P3(0, 0, 0), 2, 2, 2)
+	filleted, err := ops.FilletEdges(box, [][]byte{verticalEdgeKey(t, box)}, 0.5)
+	if err != nil {
+		t.Fatalf("fillet setup: %v", err)
+	}
+	if hasCylinderFaces(filleted) == 0 {
+		t.Fatal("fillet setup produced no curved face — cannot exercise the guard")
+	}
+	var side []byte
+	for _, f := range filleted.Faces() {
+		if pl, ok := f.Geometry().(geom.Plane); ok && pl.NormalAt(0, 0).X > 0.99 {
+			side = f.ReferenceKey()
+		}
+	}
+	if side == nil {
+		t.Fatal("no planar +X face to draft on the filleted body")
+	}
+	_, err = ops.DraftFaces(filleted, [][]byte{side}, math.V3(0, 0, 1), -stdmath.Atan(0.25))
+	if err == nil {
+		t.Fatal("draft on a body with curved faces must error, not silently rebuild")
 	}
 }

--- a/kernel/ops/draft_test.go
+++ b/kernel/ops/draft_test.go
@@ -66,18 +66,18 @@ func TestDraftLostKeyErrors(t *testing.T) {
 	}
 }
 
-// TestDraftOnFilletedBodyErrors is the #1802 regression (ADR-0050 Phase 0, #1804): drafting a
-// body that carries a curved face from a prior fillet must return an error so the feature goes
-// Sick with a teaching message — NOT panic in the plane-only rebuild. Superseded by the
-// Phase-7 curved-draft modifier (#1809), which will taper such a body for real.
-func TestDraftOnFilletedBodyErrors(t *testing.T) {
+// TestDraftFilletedBodyTapers is the real #1802 fix (ADR-0050 Phase 7, #1809): drafting a planar
+// face of a body that carries a fillet's curved face produces a VALID tapered solid — the modifier
+// tilts the plane and re-intersects the cylinder (the shared edge becoming an arc), preserving the
+// fillet face — instead of panicking in the plane-only rebuild (the Phase-0 stopgap it supersedes).
+func TestDraftFilletedBodyTapers(t *testing.T) {
 	box := csgBox(math.P3(0, 0, 0), 2, 2, 2)
 	filleted, err := ops.FilletEdges(box, [][]byte{verticalEdgeKey(t, box)}, 0.5)
 	if err != nil {
 		t.Fatalf("fillet setup: %v", err)
 	}
 	if hasCylinderFaces(filleted) == 0 {
-		t.Fatal("fillet setup produced no curved face — cannot exercise the guard")
+		t.Fatal("fillet setup produced no curved face — cannot exercise the modifier")
 	}
 	var side []byte
 	for _, f := range filleted.Faces() {
@@ -88,8 +88,14 @@ func TestDraftOnFilletedBodyErrors(t *testing.T) {
 	if side == nil {
 		t.Fatal("no planar +X face to draft on the filleted body")
 	}
-	_, err = ops.DraftFaces(filleted, [][]byte{side}, math.V3(0, 0, 1), -stdmath.Atan(0.25))
-	if err == nil {
-		t.Fatal("draft on a body with curved faces must error, not silently rebuild")
+	res, err := ops.DraftFaces(filleted, [][]byte{side}, math.V3(0, 0, 1), -stdmath.Atan(0.2))
+	if err != nil {
+		t.Fatalf("draft on a filleted body must taper it, not fail: %v", err)
+	}
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("drafted filleted body is not a valid solid: %+v", r)
+	}
+	if hasCylinderFaces(res) == 0 {
+		t.Error("the fillet's cylinder face was lost by the draft — it should be re-trimmed, not dropped")
 	}
 }

--- a/kernel/ops/facet_unify_test.go
+++ b/kernel/ops/facet_unify_test.go
@@ -98,7 +98,10 @@ func TestFilletOnFacetedRimStaysManifold(t *testing.T) {
 	faceted := ops.Facet(shelledTray(t), "facet")
 	before := ops.BodyGeometryProperties(faceted, ops.DefaultQuality()).Volume
 
-	res, err := ops.FilletEdges(faceted, topRimEdges(faceted), 0.15)
+	// r must clear the max-radius bound (#1800): the outer AND inner rim edges are both filleted
+	// and their bands recede toward each other across the 0.2-wide top frame, so each must stay
+	// under 0.1 (0.08 leaves a 0.04 margin). r=0.15 self-intersected but only faceting hid it.
+	res, err := ops.FilletEdges(faceted, topRimEdges(faceted), 0.08)
 	if err != nil {
 		t.Fatalf("rim fillet on faceted tray failed: %v", err)
 	}

--- a/kernel/ops/fillet.go
+++ b/kernel/ops/fillet.go
@@ -124,8 +124,14 @@ func filletEdgesCornerRec(body *topo.Body, picks []EdgeFilletRadii, corner Corne
 	if arc := loneArcPick(body, picks); arc != nil {
 		return FilletCylinderArc(body, arc.Key, arc.R0) // a cylinder/cap arc → torus + setback end-caps
 	}
-	if chain, r, ok := closedCurvedTangentStripe(body, picks); ok {
-		return filletTangentStripe(body, chain, true, r) // #1797: a closed mixed tangent loop → one stripe
+	if chain, r, wholeClosed, ok := curvedTangentChain(body, picks); ok {
+		if wholeClosed {
+			return filletTangentStripe(body, chain, true, r) // #1797: a closed mixed tangent loop → one stripe
+		}
+		// A partial or OPEN curved tangent chain needs setback end-caps (ChFi3d corner processing) we do
+		// not build yet; report it honestly (ADR-0050 P6 partial-result) instead of the misleading miter
+		// error the per-edge corner solver emitted on the curved arm.
+		return nil, fmt.Errorf("fillet: an OPEN tangent chain crossing a curved face is not yet supported — select the whole closed loop, or fillet those edges one at a time")
 	}
 	edges, err := resolveFilletPicks(body, picks)
 	if err != nil {

--- a/kernel/ops/fillet.go
+++ b/kernel/ops/fillet.go
@@ -124,14 +124,10 @@ func filletEdgesCornerRec(body *topo.Body, picks []EdgeFilletRadii, corner Corne
 	if arc := loneArcPick(body, picks); arc != nil {
 		return FilletCylinderArc(body, arc.Key, arc.R0) // a cylinder/cap arc → torus + setback end-caps
 	}
-	if chain, r, wholeClosed, ok := curvedTangentChain(body, picks); ok {
-		if wholeClosed {
-			return filletTangentStripe(body, chain, true, r) // #1797: a closed mixed tangent loop → one stripe
-		}
-		// A partial or OPEN curved tangent chain needs setback end-caps (ChFi3d corner processing) we do
-		// not build yet; report it honestly (ADR-0050 P6 partial-result) instead of the misleading miter
-		// error the per-edge corner solver emitted on the curved arm.
-		return nil, fmt.Errorf("fillet: an OPEN tangent chain crossing a curved face is not yet supported — select the whole closed loop, or fillet those edges one at a time")
+	if chain, r, closed, ok := curvedTangentChain(body, picks); ok {
+		// A closed mixed tangent loop (#1797) rounds as one continuous stripe; a contiguous open run
+		// (ADR-0050 P6) rounds the same way but terminates in a flat setback cap at each end.
+		return filletTangentStripe(body, chain, closed, r)
 	}
 	edges, err := resolveFilletPicks(body, picks)
 	if err != nil {

--- a/kernel/ops/fillet.go
+++ b/kernel/ops/fillet.go
@@ -141,6 +141,9 @@ func filletEdgesCornerRec(body *topo.Body, picks []EdgeFilletRadii, corner Corne
 // assembles the validated result body. Round/setback corners have already been reduced to 3-edge
 // sphere blends by augmenting the third edge, so the corner solver only ever sees miters and blends.
 func filletResolvedEdges(body *topo.Body, edges []filletPick, concave ConcaveFill, rec *diag.Recorder) (*topo.Body, error) {
+	if err := validateFilletRadii(edges); err != nil {
+		return nil, err // #1800: reject an over-large radius before it self-intersects
+	}
 	blends, miters, err := computeCorners(edges)
 	if err != nil {
 		return nil, err

--- a/kernel/ops/fillet.go
+++ b/kernel/ops/fillet.go
@@ -124,6 +124,9 @@ func filletEdgesCornerRec(body *topo.Body, picks []EdgeFilletRadii, corner Corne
 	if arc := loneArcPick(body, picks); arc != nil {
 		return FilletCylinderArc(body, arc.Key, arc.R0) // a cylinder/cap arc → torus + setback end-caps
 	}
+	if chain, r, ok := closedCurvedTangentStripe(body, picks); ok {
+		return filletTangentStripe(body, chain, true, r) // #1797: a closed mixed tangent loop → one stripe
+	}
 	edges, err := resolveFilletPicks(body, picks)
 	if err != nil {
 		return nil, err

--- a/kernel/ops/fillet_stripe.go
+++ b/kernel/ops/fillet_stripe.go
@@ -43,34 +43,58 @@ type tangentStripe struct {
 	down     []*topo.Edge   // down[j] = the vertical smooth edge below junction[j], split at depth r
 }
 
-// closedCurvedTangentStripe reports whether the picks are exactly a closed, constant-radius tangent
-// chain at least one of whose edges borders a curved (cylinder) face — the tangent-stripe trigger
-// (#1797's top perimeter). It returns the ordered chain edges and the radius. An all-planar closed
-// chain (no curved neighbour) is left to the existing planar corner path so nothing there regresses.
-func closedCurvedTangentStripe(body *topo.Body, picks []EdgeFilletRadii) ([]*topo.Edge, float64, bool) {
-	if len(picks) < 3 || !uniformConstRadius(picks) {
-		return nil, 0, false
+// curvedTangentChain reports whether the picks are exactly a constant-radius tangent chain at least
+// one of whose edges borders a curved (cylinder) face, returning the ordered edges, the radius, and
+// whether the chain closes a loop. ok=false leaves the selection to the existing paths (an all-planar
+// chain, a non-uniform radius, or a set that is not one whole tangent run) — so nothing there
+// regresses. The caller routes a CLOSED chain to the stripe assembler and an OPEN one to an honest
+// partial-result error (its setback end-caps are future work).
+func curvedTangentChain(body *topo.Body, picks []EdgeFilletRadii) (edges []*topo.Edge, r float64, wholeClosed, ok bool) {
+	if len(picks) < 2 || !uniformConstRadius(picks) {
+		return nil, 0, false, false
 	}
-	keys, closed, err := TangentEdgeChain(body, picks[0].Key, DefaultTangentChainAngle)
-	if err != nil || !closed || len(keys) != len(picks) || !sameKeySet(keys, picks) {
-		return nil, 0, false
+	maxKeys, isClosed, err := TangentEdgeChain(body, picks[0].Key, DefaultTangentChainAngle)
+	if err != nil || !picksWithinChain(picks, maxKeys) || !anyCurvedAdjacent(body, picks) {
+		return nil, 0, false, false
 	}
-	edges := make([]*topo.Edge, len(keys))
-	curved := false
-	for i, k := range keys {
-		e, ok := body.FindEdgeByKey(k)
-		if !ok {
-			return nil, 0, false
+	// The whole closed loop is exactly buildable as a stripe; a proper subset or an open run is not
+	// (its setback end-caps are future work) — the caller turns that into an honest error.
+	if isClosed && len(picks) == len(maxKeys) && sameKeySet(maxKeys, picks) {
+		es := make([]*topo.Edge, len(maxKeys))
+		for i, k := range maxKeys {
+			es[i], _ = body.FindEdgeByKey(k)
 		}
-		edges[i] = e
-		if _, _, isCP := cylinderPlaneEdge(e); isCP {
-			curved = true
+		return es, picks[0].R0, true, true
+	}
+	return nil, picks[0].R0, false, true
+}
+
+// picksWithinChain reports whether every pick key lies on the maximal tangent chain — i.e. the picks
+// are one tangent run (or a contiguous part of one), not an unrelated scatter of edges.
+func picksWithinChain(picks []EdgeFilletRadii, chainKeys [][]byte) bool {
+	on := make(map[string]bool, len(chainKeys))
+	for _, k := range chainKeys {
+		on[string(k)] = true
+	}
+	for _, p := range picks {
+		if !on[string(p.Key)] {
+			return false
 		}
 	}
-	if !curved {
-		return nil, 0, false
+	return true
+}
+
+// anyCurvedAdjacent reports whether any pick borders a curved (cylinder) face — the trigger that
+// distinguishes a stripe/partial-result case from the all-planar chains the existing path handles.
+func anyCurvedAdjacent(body *topo.Body, picks []EdgeFilletRadii) bool {
+	for _, p := range picks {
+		if e, ok := body.FindEdgeByKey(p.Key); ok {
+			if _, _, isCP := cylinderPlaneEdge(e); isCP {
+				return true
+			}
+		}
 	}
-	return edges, picks[0].R0, true
+	return false
 }
 
 // uniformConstRadius reports whether every pick is the same constant radius with a plain arc section

--- a/kernel/ops/fillet_stripe.go
+++ b/kernel/ops/fillet_stripe.go
@@ -212,11 +212,14 @@ func solveTangentStripe(body *topo.Body, edges []*topo.Edge, closed bool, r floa
 }
 
 // marchSegments runs the blend engine over the spine and maps each returned segment onto the shared
-// face / wall roles, filling st.segs. It errors on a partial-result status (OCCT's contract).
+// face / wall roles, filling st.segs. On a partial-result status it localizes the failure to the segment
+// the marcher stopped on and the guide point there (OCCT's per-SurfData ChFiDS_ErrorStatus contract),
+// so the caller can name the faulty entity rather than fail globally.
 func (st *tangentStripe) marchSegments(sp *blend.Spine, m *blend.Marcher, r float64) error {
 	run := m.March(sp, blend.ConstRadiusFillet{R: r})
 	if run.Status != blend.StatusOk {
-		return fmt.Errorf("fillet: blend marcher failed on the tangent chain: %v", run.Status)
+		return fmt.Errorf("fillet: blend %v at chain segment %d (near %s) — radius %g exceeds the local bound there",
+			run.Status, len(run.Segments), spineFailPoint(sp, len(run.Segments)), r)
 	}
 	for _, bs := range run.Segments {
 		seg, err := stripeSegOf(bs, st.shared)
@@ -226,6 +229,17 @@ func (st *tangentStripe) marchSegments(sp *blend.Spine, m *blend.Marcher, r floa
 		st.segs = append(st.segs, seg)
 	}
 	return nil
+}
+
+// spineFailPoint describes the guide location of the segment the marcher stopped on, for a localized
+// error message. It clamps to the last edge when the failure is at the run's very end.
+func spineFailPoint(sp *blend.Spine, seg int) string {
+	if seg >= sp.NbEdges() {
+		seg = sp.NbEdges() - 1
+	}
+	first, last := sp.EdgeSpineRange(seg)
+	p := sp.PointAt((first + last) / 2)
+	return fmt.Sprintf("(%.3f, %.3f, %.3f)", p.X, p.Y, p.Z)
 }
 
 // reseatSurfaces re-anchors each blend surface's angular reference so its EXPOSED patch sits in the

--- a/kernel/ops/fillet_stripe.go
+++ b/kernel/ops/fillet_stripe.go
@@ -1,0 +1,320 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/blend"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Tangent-stripe fillet (ADR-0050 P4b, #1797) — filleting a tangent CHAIN whose segments do not all
+// share the same support pair, e.g. the top perimeter of a box whose vertical edges are already
+// rounded: a closed loop of 4 straight top∩side edges (plane∩plane → cylinder blend) and 4 arc
+// top∩cylinder edges (plane∩cylinder → torus blend). The whole loop shares ONE face (the top plane),
+// so it builds as a single continuous stripe: the blend engine (blend.Marcher) supplies every segment
+// surface + its two support contacts, consecutive segments meet along a shared section circle (they
+// sample the same spine abscissa, so their end sections coincide to machine precision — a G1 junction,
+// not a miter), and the stripe is stitched here. Mirrors OCCT ChFi3d_Builder over a ChFiDS_Spine.
+
+// stripeSeg is one solved segment of the stripe: its blend surface and the two support contacts
+// (shared side = the common face, wall side = the segment's other support), with the section
+// endpoints the marcher trimmed. topA/wallA are the segment's entry section feet, ...B the exit.
+type stripeSeg struct {
+	wall         *topo.Face
+	surf         geom.Surface
+	topContact   geom.Curve3 // on the shared face, topA → topB
+	wallContact  geom.Curve3 // on the wall, wallA → wallB
+	topA, topB   math.Point3
+	wallA, wallB math.Point3
+}
+
+// tangentStripe is a solved continuous blend over a closed tangent chain sharing one face.
+type tangentStripe struct {
+	shared   *topo.Face
+	r        float64
+	edges    []*topo.Edge   // the chain edges, ordered; edges[i] is segment i's guide
+	segs     []stripeSeg    // one per chain edge
+	apex     []math.Point3  // apex[j] = tube apex of the section circle at junction j (entry of seg j)
+	junction []*topo.Vertex // junction[j] = the original top vertex where segs[j-1] meets segs[j]
+	down     []*topo.Edge   // down[j] = the vertical smooth edge below junction[j], split at depth r
+}
+
+// closedCurvedTangentStripe reports whether the picks are exactly a closed, constant-radius tangent
+// chain at least one of whose edges borders a curved (cylinder) face — the tangent-stripe trigger
+// (#1797's top perimeter). It returns the ordered chain edges and the radius. An all-planar closed
+// chain (no curved neighbour) is left to the existing planar corner path so nothing there regresses.
+func closedCurvedTangentStripe(body *topo.Body, picks []EdgeFilletRadii) ([]*topo.Edge, float64, bool) {
+	if len(picks) < 3 || !uniformConstRadius(picks) {
+		return nil, 0, false
+	}
+	keys, closed, err := TangentEdgeChain(body, picks[0].Key, DefaultTangentChainAngle)
+	if err != nil || !closed || len(keys) != len(picks) || !sameKeySet(keys, picks) {
+		return nil, 0, false
+	}
+	edges := make([]*topo.Edge, len(keys))
+	curved := false
+	for i, k := range keys {
+		e, ok := body.FindEdgeByKey(k)
+		if !ok {
+			return nil, 0, false
+		}
+		edges[i] = e
+		if _, _, isCP := cylinderPlaneEdge(e); isCP {
+			curved = true
+		}
+	}
+	if !curved {
+		return nil, 0, false
+	}
+	return edges, picks[0].R0, true
+}
+
+// uniformConstRadius reports whether every pick is the same constant radius with a plain arc section
+// (no per-end taper, intermediate point, or conic/G2 cross-section) — the stripe's constant-r regime.
+func uniformConstRadius(picks []EdgeFilletRadii) bool {
+	r := picks[0].R0
+	for _, p := range picks {
+		if p.R0 != p.R1 || p.R0 != r || len(p.Mids) > 0 || !p.Cross.IsArc() {
+			return false
+		}
+	}
+	return true
+}
+
+// sameKeySet reports whether the ordered chain keys and the pick set are the same edges (the user
+// selected exactly the tangent loop, not a subset or superset of it).
+func sameKeySet(keys [][]byte, picks []EdgeFilletRadii) bool {
+	seen := make(map[string]bool, len(keys))
+	for _, k := range keys {
+		seen[string(k)] = true
+	}
+	for _, p := range picks {
+		if !seen[string(p.Key)] {
+			return false
+		}
+	}
+	return len(keys) == len(picks)
+}
+
+// solveTangentStripe drives the blend engine over the chain and assembles the per-segment contacts +
+// the junction section apices. It handles the closed, single-shared-face case (the #1797 acceptance);
+// it errors clearly on the cases it does not yet cover (open chain, no common face) rather than
+// producing a wrong body — OCCT's localized partial-result contract.
+func solveTangentStripe(body *topo.Body, edges []*topo.Edge, closed bool, r float64) (*tangentStripe, error) {
+	if !closed {
+		return nil, fmt.Errorf("fillet: open tangent chains are not yet supported (a closed loop or a single edge is)")
+	}
+	shared := commonFaceOfAll(edges)
+	if shared == nil {
+		return nil, fmt.Errorf("fillet: tangent-chain segments do not share a common face (general stripes are future work)")
+	}
+	sp, err := blend.NewSpine(edges, closed)
+	if err != nil {
+		return nil, err
+	}
+	m := &blend.Marcher{Inside: func(p math.Point3) bool { return PointInsideBody(body, p) },
+		Res: geom.ResolutionForBox(body.RangeBox())}
+	st := &tangentStripe{shared: shared, r: r, edges: edges}
+	if err := st.marchSegments(sp, m, r); err != nil {
+		return nil, err
+	}
+	if err := st.solveApices(sp, m, r); err != nil {
+		return nil, err
+	}
+	st.reseatSurfaces()
+	if err := st.solveJunctions(); err != nil {
+		return nil, err
+	}
+	return st, nil
+}
+
+// marchSegments runs the blend engine over the spine and maps each returned segment onto the shared
+// face / wall roles, filling st.segs. It errors on a partial-result status (OCCT's contract).
+func (st *tangentStripe) marchSegments(sp *blend.Spine, m *blend.Marcher, r float64) error {
+	run := m.March(sp, blend.ConstRadiusFillet{R: r})
+	if run.Status != blend.StatusOk {
+		return fmt.Errorf("fillet: blend marcher failed on the tangent chain: %v", run.Status)
+	}
+	for _, bs := range run.Segments {
+		seg, err := stripeSegOf(bs, st.shared)
+		if err != nil {
+			return err
+		}
+		st.segs = append(st.segs, seg)
+	}
+	return nil
+}
+
+// reseatSurfaces re-anchors each blend surface's angular reference so its EXPOSED patch sits in the
+// middle of the periodic (u) domain, never straddling the 0/2π seam. The marcher builds the surface
+// with an arbitrary Ref; a seam-crossing trim loop defeats the curved-face tessellator (which meshes
+// the whole band instead of the exposed quarter — a documented tessellation limitation), so the fillet
+// would read as material on the wrong side. This mirrors the arc-fillet catalog's Ref choice.
+func (st *tangentStripe) reseatSurfaces() {
+	for i := range st.segs {
+		st.segs[i].surf = reseatBlendSurface(st.segs[i].surf, st.apex[i], st.segs[i].wallA)
+	}
+}
+
+// reseatBlendSurface rebuilds a cylinder/torus blend with its angular origin placed so the exposed
+// patch is centred away from the seam: a cylinder gets Ref opposite the apex (apex at u=π); a torus
+// gets Ref at the segment's entry radial (its 90° major arc runs u∈[0,π/2]). Non-primitive surfaces
+// (a fitted B-spline) are returned unchanged — their trim is metric, not periodic.
+func reseatBlendSurface(surf geom.Surface, apex, entryWall math.Point3) geom.Surface {
+	switch s := surf.(type) {
+	case geom.Cylinder:
+		// Place the exposed apex at u=±π/2 (mid-quadrant): with ParamAt ranging (−π,π] BOTH 0 and π are
+		// seams, so Ref must be PERPENDICULAR to the apex radial (= axis × apexDir) to keep the 90° exposed
+		// arc, u∈[π/4,3π/4], clear of both.
+		apexRadial := perpComponent(s.Origin.VectorTo(apex), s.AxisDir)
+		ref := apexRadial.Cross(s.AxisDir.AsVector()) // sign puts the apex at u=+π/2, the exposed arc in [π/4,3π/4]
+		if c, err := geom.NewCylinderWithRef(s.Origin, s.AxisDir.AsVector(), ref, s.Radius); err == nil {
+			return c
+		}
+	case geom.Torus:
+		ref := perpComponent(s.Center.VectorTo(entryWall), s.AxisDir)
+		if t, err := geom.NewTorusWithRef(s.Center, s.AxisDir.AsVector(), ref, s.MajorRadius, s.MinorRadius); err == nil {
+			return t
+		}
+	}
+	return surf
+}
+
+// solveJunctions records, per junction, the original top vertex two consecutive chain edges share and
+// the single vertical smooth edge descending from it — the edge the stripe splits at depth r (its
+// upper part is consumed by the blend, its lower part survives as the shortened walls' side).
+func (st *tangentStripe) solveJunctions() error {
+	n := len(st.edges)
+	st.junction = make([]*topo.Vertex, n)
+	st.down = make([]*topo.Edge, n)
+	for j := 0; j < n; j++ {
+		prev := st.edges[(j-1+n)%n]
+		v := sharedVertex(prev, st.edges[j])
+		if v == nil {
+			return fmt.Errorf("fillet: stripe chain edges %d and %d do not meet at a vertex", (j-1+n)%n, j)
+		}
+		d := descendingEdge(v, prev, st.edges[j])
+		if d == nil {
+			return fmt.Errorf("fillet: stripe junction %d has no single descending edge to split", j)
+		}
+		st.junction[j], st.down[j] = v, d
+	}
+	return nil
+}
+
+// sharedVertex returns the vertex shared by two edges, or nil when they meet at none.
+func sharedVertex(e1, e2 *topo.Edge) *topo.Vertex {
+	for _, a := range []*topo.Vertex{e1.StartVertex(), e1.EndVertex()} {
+		for _, b := range []*topo.Vertex{e2.StartVertex(), e2.EndVertex()} {
+			if a == b {
+				return a
+			}
+		}
+	}
+	return nil
+}
+
+// descendingEdge returns the one edge at v that is neither of the two chain edges — the vertical
+// smooth tangent line the two walls share below the junction. nil unless exactly one such edge exists.
+func descendingEdge(v *topo.Vertex, e1, e2 *topo.Edge) *topo.Edge {
+	var found *topo.Edge
+	for _, e := range v.Edges() {
+		if e == e1 || e == e2 {
+			continue
+		}
+		if found != nil {
+			return nil // ambiguous
+		}
+		found = e
+	}
+	return found
+}
+
+// stripeSegOf maps a marcher BlendSegment onto a stripeSeg by identifying which support is the shared
+// face (its contact runs on the top) and which is the wall.
+func stripeSegOf(bs blend.BlendSegment, shared *topo.Face) (stripeSeg, error) {
+	if bs.OnS1.Face == shared {
+		return stripeSeg{wall: bs.OnS2.Face, surf: bs.Surface,
+			topContact: bs.OnS1.Curve, wallContact: bs.OnS2.Curve,
+			topA: bs.Start1.Point, topB: bs.End1.Point, wallA: bs.Start2.Point, wallB: bs.End2.Point}, nil
+	}
+	if bs.OnS2.Face == shared {
+		return stripeSeg{wall: bs.OnS1.Face, surf: bs.Surface,
+			topContact: bs.OnS2.Curve, wallContact: bs.OnS1.Curve,
+			topA: bs.Start2.Point, topB: bs.End2.Point, wallA: bs.Start1.Point, wallB: bs.End1.Point}, nil
+	}
+	return stripeSeg{}, fmt.Errorf("fillet: a stripe segment does not border the shared face")
+}
+
+// solveApices computes each junction's tube apex — the exposed midpoint of the section circle the two
+// consecutive blend faces share — via the engine's ball centre + section at the junction guide point.
+func (st *tangentStripe) solveApices(sp *blend.Spine, m *blend.Marcher, r float64) error {
+	n := len(st.segs)
+	st.apex = make([]math.Point3, n)
+	for j := 0; j < n; j++ {
+		first, _ := sp.EdgeSpineRange(j) // entry of segment j = junction j
+		sharedS, wallS := st.shared.Geometry(), st.segs[j].wall.Geometry()
+		c, ok := m.BallCentre(sp.PointAt(first), sharedS, wallS, r)
+		if !ok {
+			return fmt.Errorf("fillet: no section at stripe junction %d", j)
+		}
+		st.apex[j] = exposedApex(c, st.segs[j].topA, st.segs[j].wallA, r)
+	}
+	return nil
+}
+
+// exposedApex is the tube apex of the section circle: the point on the arc between the two contacts
+// (topA on the shared face, wallA on the wall) on the CORNER side — centre + r along the bisector of
+// the two contact directions. We compute it geometrically rather than via the engine's exposed-arc
+// test, because that test reads "outside the solid", and a convex edge's corner is still MATERIAL on
+// the pre-fillet body being cut, so the inside-test would pick the wrong (material-side) half.
+func exposedApex(centre, topA, wallA math.Point3, r float64) math.Point3 {
+	u1, e1 := math.UnitVector3FromVector(centre.VectorTo(topA))
+	u2, e2 := math.UnitVector3FromVector(centre.VectorTo(wallA))
+	if e1 != nil || e2 != nil {
+		return centre
+	}
+	bis, err := math.UnitVector3FromVector(u1.AsVector().Add(u2.AsVector()))
+	if err != nil {
+		return centre
+	}
+	return centre.TranslateBy(bis.AsVector().Scale(math.Scalar(r)))
+}
+
+// commonFaceOfAll returns the face bounding every edge in the run, or nil when no single face is
+// shared by all of them (the tangent chain does not ride one common support).
+func commonFaceOfAll(edges []*topo.Edge) *topo.Face {
+	if len(edges) == 0 {
+		return nil
+	}
+	for _, f := range edges[0].Faces() {
+		if faceBoundsAll(f, edges) {
+			return f
+		}
+	}
+	return nil
+}
+
+// faceBoundsAll reports whether face f is one of the two bounding faces of every edge in the run.
+func faceBoundsAll(f *topo.Face, edges []*topo.Edge) bool {
+	for _, e := range edges {
+		if !edgeHasFace(e, f) {
+			return false
+		}
+	}
+	return true
+}
+
+// edgeHasFace reports whether f bounds e.
+func edgeHasFace(e *topo.Edge, f *topo.Face) bool {
+	for _, ef := range e.Faces() {
+		if ef == f {
+			return true
+		}
+	}
+	return false
+}

--- a/kernel/ops/fillet_stripe.go
+++ b/kernel/ops/fillet_stripe.go
@@ -36,20 +36,33 @@ type stripeSeg struct {
 type tangentStripe struct {
 	shared   *topo.Face
 	r        float64
+	closed   bool           // a closed loop (no terminals) vs an open run (two flat setback caps)
 	edges    []*topo.Edge   // the chain edges, ordered; edges[i] is segment i's guide
 	segs     []stripeSeg    // one per chain edge
 	apex     []math.Point3  // apex[j] = tube apex of the section circle at junction j (entry of seg j)
-	junction []*topo.Vertex // junction[j] = the original top vertex where segs[j-1] meets segs[j]
-	down     []*topo.Edge   // down[j] = the vertical smooth edge below junction[j], split at depth r
+	junction []*topo.Vertex // junction[j] = the original top vertex where segs[j-1] meets segs[j]; nil at an open terminal
+	down     []*topo.Edge   // down[j] = the vertical smooth edge below junction[j], split at depth r; nil at a terminal
+	term     [2]stripeTerm  // (open only) the two run-out terminals: [0]=entry of seg 0, [1]=exit of the last seg
 }
 
-// curvedTangentChain reports whether the picks are exactly a constant-radius tangent chain at least
-// one of whose edges borders a curved (cylinder) face, returning the ordered edges, the radius, and
-// whether the chain closes a loop. ok=false leaves the selection to the existing paths (an all-planar
-// chain, a non-uniform radius, or a set that is not one whole tangent run) — so nothing there
-// regresses. The caller routes a CLOSED chain to the stripe assembler and an OPEN one to an honest
-// partial-result error (its setback end-caps are future work).
-func curvedTangentChain(body *topo.Body, picks []EdgeFilletRadii) (edges []*topo.Edge, r float64, wholeClosed, ok bool) {
+// stripeTerm is one run-out end of an OPEN stripe — the tube's flat setback cap. The cap is the quarter
+// disk bounded by the end section arc (topA→apex→wallA) and the two lines back to the surviving corner
+// vertex; it lies in the section plane ⊥ the spine, so it never intrudes on the neighbouring geometry.
+// Mirrors OCCT's free-end ChFi3d_CoupeParPlan planar cut and our own arc-fillet setback end-cap.
+type stripeTerm struct {
+	vertex      *topo.Vertex // the original corner vertex the tube ends at (survives; the cap's apex-of-triangle)
+	apex        math.Point3  // the section arc's exposed midpoint
+	topA, wallA math.Point3  // the section feet on the shared face and the wall
+	seg         int          // the segment this terminal ends
+}
+
+// curvedTangentChain reports whether the picks are a constant-radius tangent chain at least one of
+// whose edges borders a curved (cylinder) face, returning the ordered edges, the radius, and whether
+// the run closes a loop (closed=true) or is a single contiguous open sub-run (closed=false). ok=false
+// leaves the selection to the existing paths (an all-planar chain, a non-uniform radius, or a gapped /
+// scattered subset) — so nothing there regresses. The caller routes both a closed loop and a
+// contiguous open run to the stripe assembler; the open run terminates in flat setback caps.
+func curvedTangentChain(body *topo.Body, picks []EdgeFilletRadii) (edges []*topo.Edge, r float64, closed, ok bool) {
 	if len(picks) < 2 || !uniformConstRadius(picks) {
 		return nil, 0, false, false
 	}
@@ -57,16 +70,76 @@ func curvedTangentChain(body *topo.Body, picks []EdgeFilletRadii) (edges []*topo
 	if err != nil || !picksWithinChain(picks, maxKeys) || !anyCurvedAdjacent(body, picks) {
 		return nil, 0, false, false
 	}
-	// The whole closed loop is exactly buildable as a stripe; a proper subset or an open run is not
-	// (its setback end-caps are future work) — the caller turns that into an honest error.
-	if isClosed && len(picks) == len(maxKeys) && sameKeySet(maxKeys, picks) {
-		es := make([]*topo.Edge, len(maxKeys))
-		for i, k := range maxKeys {
-			es[i], _ = body.FindEdgeByKey(k)
-		}
-		return es, picks[0].R0, true, true
+	edges, closed, ok = orderPicksOnChain(body, picks, maxKeys, isClosed)
+	if !ok {
+		return nil, 0, false, false
 	}
-	return nil, picks[0].R0, false, true
+	return edges, picks[0].R0, closed, true
+}
+
+// orderPicksOnChain orders the picked edges along the maximal tangent chain and reports whether they
+// are the whole closed loop (closed=true) or a single CONTIGUOUS open run (closed=false). maxKeys is
+// already chain-ordered (consecutive keys share a vertex), so a valid selection is either every key
+// (closed loop) or one unbroken stretch of them; a gapped or scattered subset returns ok=false.
+func orderPicksOnChain(body *topo.Body, picks []EdgeFilletRadii, maxKeys [][]byte, isClosed bool) (edges []*topo.Edge, closed, ok bool) {
+	if isClosed && len(picks) == len(maxKeys) {
+		return edgesForKeys(body, maxKeys), true, true
+	}
+	picked := make(map[string]bool, len(picks))
+	for _, p := range picks {
+		picked[string(p.Key)] = true
+	}
+	run, runOk := contiguousRun(maxKeys, picked, isClosed)
+	if !runOk {
+		return nil, false, false
+	}
+	return edgesForKeys(body, run), false, true
+}
+
+// contiguousRun returns the picked keys as one unbroken stretch of the chain order, or ok=false when
+// the picks break into more than one run. On a closed chain the single run may wrap the seam (a
+// prefix + suffix that are adjacent through the loop closure); on an open chain no wrap is allowed.
+func contiguousRun(maxKeys [][]byte, picked map[string]bool, isClosed bool) ([][]byte, bool) {
+	var idx []int
+	for i, k := range maxKeys {
+		if picked[string(k)] {
+			idx = append(idx, i)
+		}
+	}
+	if len(idx) == 0 {
+		return nil, false
+	}
+	gapAt, gaps := 0, 0
+	for i := 1; i < len(idx); i++ {
+		if idx[i] != idx[i-1]+1 {
+			gaps, gapAt = gaps+1, i
+		}
+	}
+	if gaps == 0 {
+		return keysAtIndices(maxKeys, idx), true // one linear stretch
+	}
+	if gaps == 1 && isClosed {
+		return keysAtIndices(maxKeys, append(idx[gapAt:], idx[:gapAt]...)), true // wraps the seam
+	}
+	return nil, false
+}
+
+// keysAtIndices gathers maxKeys at the given (chain-ordered) positions.
+func keysAtIndices(maxKeys [][]byte, idx []int) [][]byte {
+	out := make([][]byte, len(idx))
+	for i, j := range idx {
+		out[i] = maxKeys[j]
+	}
+	return out
+}
+
+// edgesForKeys resolves chain keys to their edges in body order.
+func edgesForKeys(body *topo.Body, keys [][]byte) []*topo.Edge {
+	es := make([]*topo.Edge, len(keys))
+	for i, k := range keys {
+		es[i], _ = body.FindEdgeByKey(k)
+	}
+	return es
 }
 
 // picksWithinChain reports whether every pick key lies on the maximal tangent chain — i.e. the picks
@@ -109,29 +182,11 @@ func uniformConstRadius(picks []EdgeFilletRadii) bool {
 	return true
 }
 
-// sameKeySet reports whether the ordered chain keys and the pick set are the same edges (the user
-// selected exactly the tangent loop, not a subset or superset of it).
-func sameKeySet(keys [][]byte, picks []EdgeFilletRadii) bool {
-	seen := make(map[string]bool, len(keys))
-	for _, k := range keys {
-		seen[string(k)] = true
-	}
-	for _, p := range picks {
-		if !seen[string(p.Key)] {
-			return false
-		}
-	}
-	return len(keys) == len(picks)
-}
-
-// solveTangentStripe drives the blend engine over the chain and assembles the per-segment contacts +
-// the junction section apices. It handles the closed, single-shared-face case (the #1797 acceptance);
-// it errors clearly on the cases it does not yet cover (open chain, no common face) rather than
-// producing a wrong body — OCCT's localized partial-result contract.
+// solveTangentStripe drives the blend engine over the chain and assembles the per-segment contacts,
+// the interior junction section apices, and (for an open run) the two flat setback terminals. It errors
+// clearly on the cases it does not cover (no common face) rather than producing a wrong body — OCCT's
+// localized partial-result contract.
 func solveTangentStripe(body *topo.Body, edges []*topo.Edge, closed bool, r float64) (*tangentStripe, error) {
-	if !closed {
-		return nil, fmt.Errorf("fillet: open tangent chains are not yet supported (a closed loop or a single edge is)")
-	}
 	shared := commonFaceOfAll(edges)
 	if shared == nil {
 		return nil, fmt.Errorf("fillet: tangent-chain segments do not share a common face (general stripes are future work)")
@@ -142,7 +197,7 @@ func solveTangentStripe(body *topo.Body, edges []*topo.Edge, closed bool, r floa
 	}
 	m := &blend.Marcher{Inside: func(p math.Point3) bool { return PointInsideBody(body, p) },
 		Res: geom.ResolutionForBox(body.RangeBox())}
-	st := &tangentStripe{shared: shared, r: r, edges: edges}
+	st := &tangentStripe{shared: shared, r: r, closed: closed, edges: edges}
 	if err := st.marchSegments(sp, m, r); err != nil {
 		return nil, err
 	}
@@ -208,14 +263,22 @@ func reseatBlendSurface(surf geom.Surface, apex, entryWall math.Point3) geom.Sur
 	return surf
 }
 
-// solveJunctions records, per junction, the original top vertex two consecutive chain edges share and
-// the single vertical smooth edge descending from it — the edge the stripe splits at depth r (its
-// upper part is consumed by the blend, its lower part survives as the shortened walls' side).
+// solveJunctions records, per INTERIOR junction, the original top vertex two consecutive chain edges
+// share and the single vertical smooth edge descending from it — the edge the stripe splits at depth r
+// (its upper part consumed by the blend, its lower part surviving). A closed loop has n such junctions
+// (the wrap included); an open run has n−1 (its two ends are terminals, resolved separately).
 func (st *tangentStripe) solveJunctions() error {
 	n := len(st.edges)
 	st.junction = make([]*topo.Vertex, n)
 	st.down = make([]*topo.Edge, n)
-	for j := 0; j < n; j++ {
+	first := 0
+	if !st.closed {
+		if err := st.solveTerminalVertices(); err != nil {
+			return err
+		}
+		first = 1 // seg 0's entry is a terminal, not a junction
+	}
+	for j := first; j < n; j++ {
 		prev := st.edges[(j-1+n)%n]
 		v := sharedVertex(prev, st.edges[j])
 		if v == nil {
@@ -228,6 +291,28 @@ func (st *tangentStripe) solveJunctions() error {
 		st.junction[j], st.down[j] = v, d
 	}
 	return nil
+}
+
+// solveTerminalVertices sets the surviving corner vertex at each end of an open run: the guide edge's
+// endpoint NOT shared with its inner neighbour (the run-out corner the flat cap folds back to).
+func (st *tangentStripe) solveTerminalVertices() error {
+	n := len(st.edges)
+	v0 := freeEndVertex(st.edges[0], st.edges[1])
+	vn := freeEndVertex(st.edges[n-1], st.edges[n-2])
+	if v0 == nil || vn == nil {
+		return fmt.Errorf("fillet: open stripe terminal has no free end vertex")
+	}
+	st.term[0].vertex, st.term[1].vertex = v0, vn
+	return nil
+}
+
+// freeEndVertex returns e's vertex that is NOT the one it shares with neighbour nb — the run-out end.
+func freeEndVertex(e, nb *topo.Edge) *topo.Vertex {
+	shared := sharedVertex(e, nb)
+	if e.StartVertex() != shared {
+		return e.StartVertex()
+	}
+	return e.EndVertex()
 }
 
 // sharedVertex returns the vertex shared by two edges, or nil when they meet at none.
@@ -274,20 +359,48 @@ func stripeSegOf(bs blend.BlendSegment, shared *topo.Face) (stripeSeg, error) {
 	return stripeSeg{}, fmt.Errorf("fillet: a stripe segment does not border the shared face")
 }
 
-// solveApices computes each junction's tube apex — the exposed midpoint of the section circle the two
-// consecutive blend faces share — via the engine's ball centre + section at the junction guide point.
+// solveApices computes each segment ENTRY's tube apex — the exposed midpoint of the section circle two
+// consecutive blend faces share — via the engine's ball centre + section at the entry guide point. For
+// an open run it then resolves the two run-out terminals (the entry of seg 0 and the exit of the last).
 func (st *tangentStripe) solveApices(sp *blend.Spine, m *blend.Marcher, r float64) error {
 	n := len(st.segs)
 	st.apex = make([]math.Point3, n)
 	for j := 0; j < n; j++ {
-		first, _ := sp.EdgeSpineRange(j) // entry of segment j = junction j
-		sharedS, wallS := st.shared.Geometry(), st.segs[j].wall.Geometry()
-		c, ok := m.BallCentre(sp.PointAt(first), sharedS, wallS, r)
+		a, ok := st.entryApex(sp, m, r, j)
 		if !ok {
 			return fmt.Errorf("fillet: no section at stripe junction %d", j)
 		}
-		st.apex[j] = exposedApex(c, st.segs[j].topA, st.segs[j].wallA, r)
+		st.apex[j] = a
 	}
+	if st.closed {
+		return nil
+	}
+	return st.solveTerminalApices(sp, m, r)
+}
+
+// entryApex is the exposed section apex at segment j's entry (the spine's first abscissa on edge j).
+func (st *tangentStripe) entryApex(sp *blend.Spine, m *blend.Marcher, r float64, j int) (math.Point3, bool) {
+	first, _ := sp.EdgeSpineRange(j)
+	c, ok := m.BallCentre(sp.PointAt(first), st.shared.Geometry(), st.segs[j].wall.Geometry(), r)
+	if !ok {
+		return math.Point3{}, false
+	}
+	return exposedApex(c, st.segs[j].topA, st.segs[j].wallA, r), true
+}
+
+// solveTerminalApices fills the two open-run terminals' cap geometry: terminal 0 reuses seg 0's entry
+// section; terminal 1 is seg (n−1)'s EXIT section (spine's last abscissa there). The surviving vertices
+// are set later in solveTerminalVertices.
+func (st *tangentStripe) solveTerminalApices(sp *blend.Spine, m *blend.Marcher, r float64) error {
+	n := len(st.segs)
+	st.term[0].apex, st.term[0].topA, st.term[0].wallA, st.term[0].seg = st.apex[0], st.segs[0].topA, st.segs[0].wallA, 0
+	_, last := sp.EdgeSpineRange(n - 1)
+	c, ok := m.BallCentre(sp.PointAt(last), st.shared.Geometry(), st.segs[n-1].wall.Geometry(), r)
+	if !ok {
+		return fmt.Errorf("fillet: no section at the open stripe's end terminal")
+	}
+	st.term[1] = stripeTerm{apex: exposedApex(c, st.segs[n-1].topB, st.segs[n-1].wallB, r),
+		topA: st.segs[n-1].topB, wallA: st.segs[n-1].wallB, seg: n - 1}
 	return nil
 }
 

--- a/kernel/ops/fillet_stripe_build.go
+++ b/kernel/ops/fillet_stripe_build.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// rebuildWithStripe reconstructs the body with the tangent stripe rounded in: the shared face and the
+// walls are re-trimmed onto the blend's contact curves, the vertical smooth edge below each junction
+// is split at the tube depth (its upper part consumed), and one blend face per segment is added,
+// consecutive faces sharing a junction section circle. Mirrors the topological half of OCCT
+// ChFi3d_Builder — the geometry came from the blend engine (fillet_stripe.go). See ADR-0050 P4b.
+func rebuildWithStripe(b *topo.Body, st *tangentStripe) (*topo.Body, error) {
+	g := &stripeBuild{
+		st: st, bld: topo.NewBuilder(b.IsSolid(), b.Lineage()),
+		verts: map[*topo.Vertex]*topo.Vertex{}, edges: map[*topo.Edge]*topo.Edge{},
+		reRev: map[*topo.Edge]bool{}, chainIdx: map[*topo.Edge]int{}, downIdx: map[*topo.Edge]int{},
+		junIdx: map[*topo.Vertex]int{},
+	}
+	g.index()
+	for _, v := range b.Vertices() {
+		if _, gone := g.junIdx[v]; !gone {
+			g.verts[v] = g.bld.AddVertex(v.Point(), v.Lineage())
+		}
+	}
+	if err := g.addNewVertsAndEdges(); err != nil {
+		return nil, err
+	}
+	for _, e := range b.Edges() {
+		if _, chain := g.chainIdx[e]; chain {
+			continue
+		}
+		if _, down := g.downIdx[e]; down {
+			continue
+		}
+		g.edges[e] = g.bld.AddEdge(e.Geometry(), g.verts[e.StartVertex()], g.verts[e.EndVertex()], e.Lineage())
+	}
+	for _, f := range b.Faces() {
+		g.copyFace(f)
+	}
+	g.addBlendFaces()
+	return g.bld.Build(), nil
+}
+
+type stripeBuild struct {
+	st       *tangentStripe
+	bld      *topo.Builder
+	verts    map[*topo.Vertex]*topo.Vertex
+	edges    map[*topo.Edge]*topo.Edge
+	reRev    map[*topo.Edge]bool // how a re-trimmed face used each new stripe edge (blend uses the opposite)
+	chainIdx map[*topo.Edge]int  // chain edge → segment index
+	downIdx  map[*topo.Edge]int  // vertical smooth edge → junction index
+	junIdx   map[*topo.Vertex]int
+	vS1, vW  []*topo.Vertex // per junction: shared-side foot, wall-side foot
+	topE     []*topo.Edge   // per segment: shared-face contact
+	wallE    []*topo.Edge   // per segment: wall contact
+	section  []*topo.Edge   // per junction: tube section circle vS1[j]→vW[j]
+	lowerE   []*topo.Edge   // per junction: surviving lower part of the split vertical edge
+}
+
+// index builds the lookup maps from the solved stripe: chain edges → segment, down edges → junction,
+// junction vertices → index.
+func (g *stripeBuild) index() {
+	for i, e := range g.st.edges {
+		g.chainIdx[e] = i
+	}
+	for j, d := range g.st.down {
+		g.downIdx[d] = j
+		g.junIdx[g.st.junction[j]] = j
+	}
+}
+
+// addNewVertsAndEdges creates the stripe's new vertices (the shared-side and wall-side section feet at
+// every junction) and its new edges (the two contacts per segment, the section circle and the lower
+// split-edge remnant per junction).
+func (g *stripeBuild) addNewVertsAndEdges() error {
+	n := len(g.st.segs)
+	lin := func(role string, i int) topo.Lineage { return topo.NewLineage(topo.Tok("stripe", role, i)) }
+	g.vS1, g.vW = make([]*topo.Vertex, n), make([]*topo.Vertex, n)
+	for j := 0; j < n; j++ {
+		g.vS1[j] = g.bld.AddVertex(g.st.segs[j].topA, lin("s1", j))
+		g.vW[j] = g.bld.AddVertex(g.st.segs[j].wallA, lin("w", j))
+	}
+	g.topE, g.wallE = make([]*topo.Edge, n), make([]*topo.Edge, n)
+	for i := 0; i < n; i++ {
+		k := (i + 1) % n
+		g.topE[i] = g.bld.AddEdge(g.st.segs[i].topContact, g.vS1[i], g.vS1[k], lin("top", i))
+		g.wallE[i] = g.bld.AddEdge(g.st.segs[i].wallContact, g.vW[i], g.vW[k], lin("wall", i))
+	}
+	return g.addSectionsAndRemnants(lin)
+}
+
+// addSectionsAndRemnants adds, per junction, the tube section circle two blend faces share and the
+// surviving lower part of the split vertical smooth edge.
+func (g *stripeBuild) addSectionsAndRemnants(lin func(string, int) topo.Lineage) error {
+	n := len(g.st.segs)
+	g.section, g.lowerE = make([]*topo.Edge, n), make([]*topo.Edge, n)
+	for j := 0; j < n; j++ {
+		arc, err := geom.Arc3dByThreePoints(g.st.segs[j].topA, g.st.apex[j], g.st.segs[j].wallA)
+		if err != nil {
+			return fmt.Errorf("fillet: cannot build the section circle at stripe junction %d: %w", j, err)
+		}
+		g.section[j] = g.bld.AddEdge(arc, g.vS1[j], g.vW[j], lin("sec", j))
+		bottom := otherVertex(g.st.down[j], g.st.junction[j])
+		g.lowerE[j] = g.bld.AddEdge(geom.NewLineSegment(g.st.segs[j].wallA, bottom.Point()),
+			g.vW[j], g.verts[bottom], lin("lower", j))
+	}
+	return nil
+}
+
+// copyFace copies a face, re-trimming the shared face (chain edge → shared contact) and the walls
+// (chain edge → wall contact, vertical edge → lower remnant); others copied verbatim.
+func (g *stripeBuild) copyFace(f *topo.Face) {
+	specs := make([]topo.LoopSpec, 0, len(f.Loops()))
+	for _, l := range f.Loops() {
+		uses := make([]topo.Use, 0, len(l.EdgeUses()))
+		for _, u := range l.EdgeUses() {
+			mu := g.mapUse(f, u)
+			g.reRev[mu.Edge] = mu.Reversed
+			uses = append(uses, mu)
+		}
+		if l.IsOuter() {
+			specs = append(specs, topo.OuterLoop(uses...))
+		} else {
+			specs = append(specs, topo.InnerLoop(uses...))
+		}
+	}
+	if f.Reversed() {
+		g.bld.AddReversedFace(f.Geometry(), f.Lineage(), specs...)
+		return
+	}
+	g.bld.AddFace(f.Geometry(), f.Lineage(), specs...)
+}
+
+// mapUse substitutes a removed edge's use with its stripe replacement, orienting the new edge so it
+// runs the same way the original use did (matched by the use's from-vertex, mapped onto the new feet).
+func (g *stripeBuild) mapUse(f *topo.Face, u *topo.EdgeUse) topo.Use {
+	from := useFromVertex(u)
+	if i, ok := g.chainIdx[u.Edge()]; ok {
+		if f == g.st.shared {
+			return dirUse(g.topE[i], g.vS1[g.junIdx[from]])
+		}
+		return dirUse(g.wallE[i], g.vW[g.junIdx[from]])
+	}
+	if j, ok := g.downIdx[u.Edge()]; ok {
+		fromV := g.verts[from]
+		if from == g.st.junction[j] {
+			fromV = g.vW[j]
+		}
+		return dirUse(g.lowerE[j], fromV)
+	}
+	return topo.Use{Edge: g.edges[u.Edge()], Reversed: u.Reversed()}
+}
+
+// dirUse returns the use of edge e that starts at from (reversed when from is e's end vertex).
+func dirUse(e *topo.Edge, from *topo.Vertex) topo.Use {
+	return topo.Use{Edge: e, Reversed: e.StartVertex() != from}
+}
+
+// addBlendFaces adds one blend face per segment: the quad topE[i] · section[i+1] · wallE[i] · section[i],
+// wound so the loop normal matches the blend surface's outward radial (a convex fillet's surface faces
+// AWAY from the material, toward the rounded-off corner). A purely topological anchor is not enough —
+// it keeps every edge used twice but can still leave the surface geometrically inside-out, which the
+// mass-properties integral then reads as material on the wrong side of the tube.
+func (g *stripeBuild) addBlendFaces() {
+	n := len(g.st.segs)
+	lin := func(i int) topo.Lineage { return topo.NewLineage(topo.Tok("stripe", "blend", i)) }
+	for i := 0; i < n; i++ {
+		k := (i + 1) % n
+		ring := []math.Point3{g.vS1[i].Point(), g.vS1[k].Point(), g.vW[k].Point(), g.vW[i].Point()}
+		loop := []topo.Use{
+			dirUse(g.topE[i], g.vS1[i]),
+			dirUse(g.section[k], g.vS1[k]),
+			dirUse(g.wallE[i], g.vW[k]),
+			dirUse(g.section[i], g.vW[i]),
+		}
+		if blendRingFlipped(g.st.segs[i].surf, ring) {
+			loop = reverseLoop(loop)
+		}
+		g.bld.AddFace(g.st.segs[i].surf, lin(i), topo.OuterLoop(loop...))
+	}
+}
+
+// blendRingFlipped reports whether the quad ring winds against the blend surface's outward normal —
+// the triangle from three ring corners has a normal opposing surf.NormalAt at the ring centroid.
+func blendRingFlipped(surf geom.Surface, ring []math.Point3) bool {
+	nrm := ring[0].VectorTo(ring[1]).Cross(ring[0].VectorTo(ring[2]))
+	u, v := surf.ParamAt(centroidPts(ring))
+	return float64(nrm.Dot(surf.NormalAt(u, v))) < 0
+}
+
+// filletTangentStripe rounds a closed tangent chain (mixed straight/arc segments sharing one face) as
+// one continuous blend stripe — the #1797 top-perimeter case the per-edge miter path could not build.
+func filletTangentStripe(body *topo.Body, edges []*topo.Edge, closed bool, r float64) (*topo.Body, error) {
+	st, err := solveTangentStripe(body, edges, closed, r)
+	if err != nil {
+		return nil, err
+	}
+	res, err := rebuildWithStripe(body, st)
+	if err != nil {
+		return nil, err
+	}
+	if rep := Validate(res); !rep.Valid || !res.IsSolid() {
+		return nil, fmt.Errorf("fillet: tangent-stripe result is not a valid solid %v", rep.Issues)
+	}
+	return res, nil
+}

--- a/kernel/ops/fillet_stripe_build.go
+++ b/kernel/ops/fillet_stripe_build.go
@@ -19,18 +19,38 @@ func rebuildWithStripe(b *topo.Body, st *tangentStripe) (*topo.Body, error) {
 	g := &stripeBuild{
 		st: st, bld: topo.NewBuilder(b.IsSolid(), b.Lineage()),
 		verts: map[*topo.Vertex]*topo.Vertex{}, edges: map[*topo.Edge]*topo.Edge{},
-		reRev: map[*topo.Edge]bool{}, chainIdx: map[*topo.Edge]int{}, downIdx: map[*topo.Edge]int{},
+		chainIdx: map[*topo.Edge]int{}, downIdx: map[*topo.Edge]int{},
 		junIdx: map[*topo.Vertex]int{},
 	}
 	g.index()
+	g.copySurvivingVertices(b)
+	if err := g.addNewVertsAndEdges(); err != nil {
+		return nil, err
+	}
+	g.copySurvivingEdges(b)
+	for _, f := range b.Faces() {
+		g.copyFace(f)
+	}
+	g.addBlendFaces()
+	if !st.closed {
+		g.addCapFaces()
+	}
+	return g.bld.Build(), nil
+}
+
+// copySurvivingVertices carries over every original vertex except the interior junction corners the
+// stripe consumes (replaced by section feet). Open-run terminal corners survive and are copied here.
+func (g *stripeBuild) copySurvivingVertices(b *topo.Body) {
 	for _, v := range b.Vertices() {
 		if _, gone := g.junIdx[v]; !gone {
 			g.verts[v] = g.bld.AddVertex(v.Point(), v.Lineage())
 		}
 	}
-	if err := g.addNewVertsAndEdges(); err != nil {
-		return nil, err
-	}
+}
+
+// copySurvivingEdges carries over every original edge except the chain guides (replaced by contacts) and
+// the split vertical edges (replaced by lower remnants); both are re-trimmed by copyFace instead.
+func (g *stripeBuild) copySurvivingEdges(b *topo.Body) {
 	for _, e := range b.Edges() {
 		if _, chain := g.chainIdx[e]; chain {
 			continue
@@ -40,11 +60,6 @@ func rebuildWithStripe(b *topo.Body, st *tangentStripe) (*topo.Body, error) {
 		}
 		g.edges[e] = g.bld.AddEdge(e.Geometry(), g.verts[e.StartVertex()], g.verts[e.EndVertex()], e.Lineage())
 	}
-	for _, f := range b.Faces() {
-		g.copyFace(f)
-	}
-	g.addBlendFaces()
-	return g.bld.Build(), nil
 }
 
 type stripeBuild struct {
@@ -52,32 +67,42 @@ type stripeBuild struct {
 	bld      *topo.Builder
 	verts    map[*topo.Vertex]*topo.Vertex
 	edges    map[*topo.Edge]*topo.Edge
-	reRev    map[*topo.Edge]bool // how a re-trimmed face used each new stripe edge (blend uses the opposite)
-	chainIdx map[*topo.Edge]int  // chain edge → segment index
-	downIdx  map[*topo.Edge]int  // vertical smooth edge → junction index
+	chainIdx map[*topo.Edge]int // chain edge → segment index
+	downIdx  map[*topo.Edge]int // vertical smooth edge → junction index
 	junIdx   map[*topo.Vertex]int
-	vS1, vW  []*topo.Vertex // per junction: shared-side foot, wall-side foot
+	vS1, vW  []*topo.Vertex // per segment ENTRY: shared-side foot, wall-side foot
 	topE     []*topo.Edge   // per segment: shared-face contact
 	wallE    []*topo.Edge   // per segment: wall contact
-	section  []*topo.Edge   // per junction: tube section circle vS1[j]→vW[j]
-	lowerE   []*topo.Edge   // per junction: surviving lower part of the split vertical edge
+	section  []*topo.Edge   // per interior junction: tube section circle vS1[j]→vW[j]
+	lowerE   []*topo.Edge   // per interior junction: surviving lower part of the split vertical edge
+	// open-run terminals only: the last segment's EXIT feet, the two flat cap arcs, and the connectors
+	// folding each cap back to its surviving corner vertex (on the shared face and the wall).
+	vEndS1, vEndW *topo.Vertex
+	cap           [2]*topo.Edge // [0]=start terminal cap arc, [1]=end terminal cap arc
+	connTop       [2]*topo.Edge // corner vertex → shared-face foot
+	connWall      [2]*topo.Edge // corner vertex → wall foot
 }
 
 // index builds the lookup maps from the solved stripe: chain edges → segment, down edges → junction,
-// junction vertices → index.
+// junction vertices → index. An open run's terminal slots are nil (its ends survive, not consumed) and
+// are skipped, so a terminal vertex is copied verbatim rather than replaced by section feet.
 func (g *stripeBuild) index() {
 	for i, e := range g.st.edges {
 		g.chainIdx[e] = i
 	}
 	for j, d := range g.st.down {
+		if d == nil { // an open-run terminal: nothing consumed here
+			continue
+		}
 		g.downIdx[d] = j
 		g.junIdx[g.st.junction[j]] = j
 	}
 }
 
 // addNewVertsAndEdges creates the stripe's new vertices (the shared-side and wall-side section feet at
-// every junction) and its new edges (the two contacts per segment, the section circle and the lower
-// split-edge remnant per junction).
+// every segment entry, plus an open run's terminal-exit feet) and its new edges (the two contacts per
+// segment, the section circle + lower split-edge remnant per interior junction, and — for an open run —
+// the two flat cap arcs and their corner connectors).
 func (g *stripeBuild) addNewVertsAndEdges() error {
 	n := len(g.st.segs)
 	lin := func(role string, i int) topo.Lineage { return topo.NewLineage(topo.Tok("stripe", role, i)) }
@@ -86,21 +111,31 @@ func (g *stripeBuild) addNewVertsAndEdges() error {
 		g.vS1[j] = g.bld.AddVertex(g.st.segs[j].topA, lin("s1", j))
 		g.vW[j] = g.bld.AddVertex(g.st.segs[j].wallA, lin("w", j))
 	}
+	if !g.st.closed {
+		g.vEndS1 = g.bld.AddVertex(g.st.segs[n-1].topB, lin("s1", n))
+		g.vEndW = g.bld.AddVertex(g.st.segs[n-1].wallB, lin("w", n))
+	}
 	g.topE, g.wallE = make([]*topo.Edge, n), make([]*topo.Edge, n)
 	for i := 0; i < n; i++ {
-		k := (i + 1) % n
-		g.topE[i] = g.bld.AddEdge(g.st.segs[i].topContact, g.vS1[i], g.vS1[k], lin("top", i))
-		g.wallE[i] = g.bld.AddEdge(g.st.segs[i].wallContact, g.vW[i], g.vW[k], lin("wall", i))
+		g.topE[i] = g.bld.AddEdge(g.st.segs[i].topContact, g.vS1[i], g.exitFootS1(i), lin("top", i))
+		g.wallE[i] = g.bld.AddEdge(g.st.segs[i].wallContact, g.vW[i], g.exitFootW(i), lin("wall", i))
 	}
-	return g.addSectionsAndRemnants(lin)
+	if err := g.addSectionsAndRemnants(lin); err != nil {
+		return err
+	}
+	return g.addTerminalEdges(lin)
 }
 
-// addSectionsAndRemnants adds, per junction, the tube section circle two blend faces share and the
-// surviving lower part of the split vertical smooth edge.
+// addSectionsAndRemnants adds, per INTERIOR junction, the tube section circle two blend faces share and
+// the surviving lower part of the split vertical smooth edge. An open run's terminal slots are nil (no
+// section circle, no split there) and are skipped — their flat cap arcs are added in addTerminalEdges.
 func (g *stripeBuild) addSectionsAndRemnants(lin func(string, int) topo.Lineage) error {
 	n := len(g.st.segs)
 	g.section, g.lowerE = make([]*topo.Edge, n), make([]*topo.Edge, n)
 	for j := 0; j < n; j++ {
+		if g.st.junction[j] == nil { // an open-run terminal
+			continue
+		}
 		arc, err := geom.Arc3dByThreePoints(g.st.segs[j].topA, g.st.apex[j], g.st.segs[j].wallA)
 		if err != nil {
 			return fmt.Errorf("fillet: cannot build the section circle at stripe junction %d: %w", j, err)
@@ -113,16 +148,54 @@ func (g *stripeBuild) addSectionsAndRemnants(lin func(string, int) topo.Lineage)
 	return nil
 }
 
+// addTerminalEdges builds an open run's two flat cap arcs (shared foot → apex → wall foot) and the two
+// corner connectors per terminal — the lines folding the cap back to its surviving vertex on the shared
+// face and on the wall. A closed loop has no terminals, so this is a no-op.
+func (g *stripeBuild) addTerminalEdges(lin func(string, int) topo.Lineage) error {
+	if g.st.closed {
+		return nil
+	}
+	feet := [2][2]*topo.Vertex{{g.vS1[0], g.vW[0]}, {g.vEndS1, g.vEndW}}
+	for t := 0; t < 2; t++ {
+		tm := g.st.term[t]
+		arc, err := geom.Arc3dByThreePoints(tm.topA, tm.apex, tm.wallA)
+		if err != nil {
+			return fmt.Errorf("fillet: cannot build the flat cap arc at open stripe terminal %d: %w", t, err)
+		}
+		g.cap[t] = g.bld.AddEdge(arc, feet[t][0], feet[t][1], lin("cap", t))
+		vtx := g.verts[tm.vertex]
+		g.connTop[t] = g.bld.AddEdge(geom.NewLineSegment(tm.vertex.Point(), tm.topA), vtx, feet[t][0], lin("ctop", t))
+		g.connWall[t] = g.bld.AddEdge(geom.NewLineSegment(tm.vertex.Point(), tm.wallA), vtx, feet[t][1], lin("cwall", t))
+	}
+	return nil
+}
+
+// exitFootS1 / exitFootW return segment i's EXIT feet on the shared face / wall: an interior segment
+// exits into the next segment's entry feet; an open run's last segment exits into its terminal feet.
+func (g *stripeBuild) exitFootS1(i int) *topo.Vertex {
+	if n := len(g.st.segs); !g.st.closed && i == n-1 {
+		return g.vEndS1
+	}
+	return g.vS1[(i+1)%len(g.st.segs)]
+}
+
+func (g *stripeBuild) exitFootW(i int) *topo.Vertex {
+	if n := len(g.st.segs); !g.st.closed && i == n-1 {
+		return g.vEndW
+	}
+	return g.vW[(i+1)%len(g.st.segs)]
+}
+
 // copyFace copies a face, re-trimming the shared face (chain edge → shared contact) and the walls
-// (chain edge → wall contact, vertical edge → lower remnant); others copied verbatim.
+// (chain edge → wall contact, vertical edge → lower remnant); others copied verbatim. A chain-edge use
+// may expand to several new edges (an open-run terminal inserts a corner connector), so mapUse returns
+// an ordered list.
 func (g *stripeBuild) copyFace(f *topo.Face) {
 	specs := make([]topo.LoopSpec, 0, len(f.Loops()))
 	for _, l := range f.Loops() {
 		uses := make([]topo.Use, 0, len(l.EdgeUses()))
 		for _, u := range l.EdgeUses() {
-			mu := g.mapUse(f, u)
-			g.reRev[mu.Edge] = mu.Reversed
-			uses = append(uses, mu)
+			uses = append(uses, g.mapUse(f, u)...)
 		}
 		if l.IsOuter() {
 			specs = append(specs, topo.OuterLoop(uses...))
@@ -137,24 +210,79 @@ func (g *stripeBuild) copyFace(f *topo.Face) {
 	g.bld.AddFace(f.Geometry(), f.Lineage(), specs...)
 }
 
-// mapUse substitutes a removed edge's use with its stripe replacement, orienting the new edge so it
-// runs the same way the original use did (matched by the use's from-vertex, mapped onto the new feet).
-func (g *stripeBuild) mapUse(f *topo.Face, u *topo.EdgeUse) topo.Use {
-	from := useFromVertex(u)
+// mapUse substitutes a removed edge's use with its stripe replacement(s), orienting each new edge so the
+// path runs the same way the original use did. A chain edge maps to its contact (plus a terminal corner
+// connector at an open-run end); a split vertical edge maps to its lower remnant; anything else copies.
+func (g *stripeBuild) mapUse(f *topo.Face, u *topo.EdgeUse) []topo.Use {
 	if i, ok := g.chainIdx[u.Edge()]; ok {
-		if f == g.st.shared {
-			return dirUse(g.topE[i], g.vS1[g.junIdx[from]])
-		}
-		return dirUse(g.wallE[i], g.vW[g.junIdx[from]])
+		return g.mapChainUse(f, u, i)
 	}
+	from := useFromVertex(u)
 	if j, ok := g.downIdx[u.Edge()]; ok {
 		fromV := g.verts[from]
 		if from == g.st.junction[j] {
 			fromV = g.vW[j]
 		}
-		return dirUse(g.lowerE[j], fromV)
+		return []topo.Use{dirUse(g.lowerE[j], fromV)}
 	}
-	return topo.Use{Edge: g.edges[u.Edge()], Reversed: u.Reversed()}
+	return []topo.Use{{Edge: g.edges[u.Edge()], Reversed: u.Reversed()}}
+}
+
+// mapChainUse replaces a chain edge's use on the shared face or a wall with its re-trimmed contact,
+// inserting the flat cap's corner connector when this segment's entry (i==0) or exit (i==n−1) is an
+// open-run terminal. The pieces are built entry→exit and emitted reversed when the use runs exit→entry.
+func (g *stripeBuild) mapChainUse(f *topo.Face, u *topo.EdgeUse, i int) []topo.Use {
+	contact, entryFoot, exitFoot := g.topE[i], g.vS1[i], g.exitFootS1(i)
+	startConn, endConn := g.connTop[0], g.connTop[1]
+	if f != g.st.shared {
+		contact, entryFoot, exitFoot = g.wallE[i], g.vW[i], g.exitFootW(i)
+		startConn, endConn = g.connWall[0], g.connWall[1]
+	}
+	fwd := []dirPiece{{contact, entryFoot, exitFoot}}
+	n := len(g.st.segs)
+	if !g.st.closed && i == 0 {
+		fwd = append([]dirPiece{{startConn, g.verts[g.st.term[0].vertex], entryFoot}}, fwd...)
+	}
+	if !g.st.closed && i == n-1 {
+		fwd = append(fwd, dirPiece{endConn, exitFoot, g.verts[g.st.term[1].vertex]})
+	}
+	if useFromVertex(u) == g.entryVertex(i) {
+		return forwardPieces(fwd)
+	}
+	return reversePieces(fwd)
+}
+
+// entryVertex is the original body vertex at segment i's entry (spine-first) end — an interior junction,
+// or the open run's start terminal for the first segment.
+func (g *stripeBuild) entryVertex(i int) *topo.Vertex {
+	if !g.st.closed && i == 0 {
+		return g.st.term[0].vertex
+	}
+	return g.st.junction[i]
+}
+
+// dirPiece is one directed edge of a chain-use replacement path, a→b in the segment's entry→exit sense.
+type dirPiece struct {
+	e    *topo.Edge
+	a, b *topo.Vertex
+}
+
+// forwardPieces emits the path entry→exit (each piece used from its a vertex).
+func forwardPieces(fwd []dirPiece) []topo.Use {
+	out := make([]topo.Use, len(fwd))
+	for i, p := range fwd {
+		out[i] = dirUse(p.e, p.a)
+	}
+	return out
+}
+
+// reversePieces emits the path exit→entry (order reversed, each piece used from its b vertex).
+func reversePieces(fwd []dirPiece) []topo.Use {
+	out := make([]topo.Use, len(fwd))
+	for i, p := range fwd {
+		out[len(fwd)-1-i] = dirUse(p.e, p.b)
+	}
+	return out
 }
 
 // dirUse returns the use of edge e that starts at from (reversed when from is e's end vertex).
@@ -162,28 +290,45 @@ func dirUse(e *topo.Edge, from *topo.Vertex) topo.Use {
 	return topo.Use{Edge: e, Reversed: e.StartVertex() != from}
 }
 
-// addBlendFaces adds one blend face per segment: the quad topE[i] · section[i+1] · wallE[i] · section[i],
+// addBlendFaces adds one blend face per segment: the quad topE[i] · exitSection · wallE[i] · entrySection,
 // wound so the loop normal matches the blend surface's outward radial (a convex fillet's surface faces
 // AWAY from the material, toward the rounded-off corner). A purely topological anchor is not enough —
 // it keeps every edge used twice but can still leave the surface geometrically inside-out, which the
-// mass-properties integral then reads as material on the wrong side of the tube.
+// mass-properties integral then reads as material on the wrong side of the tube. An interior boundary is
+// a junction section circle; an open run's two ends are terminal cap arcs (see entry/exitSecEdge).
 func (g *stripeBuild) addBlendFaces() {
 	n := len(g.st.segs)
 	lin := func(i int) topo.Lineage { return topo.NewLineage(topo.Tok("stripe", "blend", i)) }
 	for i := 0; i < n; i++ {
-		k := (i + 1) % n
-		ring := []math.Point3{g.vS1[i].Point(), g.vS1[k].Point(), g.vW[k].Point(), g.vW[i].Point()}
+		es1, ew := g.exitFootS1(i), g.exitFootW(i)
+		ring := []math.Point3{g.vS1[i].Point(), es1.Point(), ew.Point(), g.vW[i].Point()}
 		loop := []topo.Use{
 			dirUse(g.topE[i], g.vS1[i]),
-			dirUse(g.section[k], g.vS1[k]),
-			dirUse(g.wallE[i], g.vW[k]),
-			dirUse(g.section[i], g.vW[i]),
+			dirUse(g.exitSecEdge(i), es1),
+			dirUse(g.wallE[i], ew),
+			dirUse(g.entrySecEdge(i), g.vW[i]),
 		}
 		if blendRingFlipped(g.st.segs[i].surf, ring) {
 			loop = reverseLoop(loop)
 		}
 		g.bld.AddFace(g.st.segs[i].surf, lin(i), topo.OuterLoop(loop...))
 	}
+}
+
+// entrySecEdge / exitSecEdge return the section arc bounding segment i at its entry / exit — an interior
+// junction's section circle, or (for an open run's first/last segment) the flat terminal cap arc.
+func (g *stripeBuild) entrySecEdge(i int) *topo.Edge {
+	if !g.st.closed && i == 0 {
+		return g.cap[0]
+	}
+	return g.section[i]
+}
+
+func (g *stripeBuild) exitSecEdge(i int) *topo.Edge {
+	if n := len(g.st.segs); !g.st.closed && i == n-1 {
+		return g.cap[1]
+	}
+	return g.section[(i+1)%len(g.st.segs)]
 }
 
 // blendRingFlipped reports whether the quad ring winds against the blend surface's outward normal —

--- a/kernel/ops/fillet_stripe_caps.go
+++ b/kernel/ops/fillet_stripe_caps.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Open-run terminal caps (ADR-0050 P6). Filleting a CONTIGUOUS OPEN sub-run of a tangent chain (e.g.
+// three of the eight top-rim edges of a box whose vertical edges are already rounded) rounds the run as
+// a stripe exactly like the closed loop, but each end must be closed off. The tube ends in a flat
+// quarter-disk cap lying in the section plane ⊥ the spine: the corner tip survives (it is at distance
+// r·√2 > r from the ball centre, outside the bite, so material remains there), and the cap is the real
+// face bridging the end section arc back to that tip. This mirrors OCCT's free-end ChFi3d_CoupeParPlan
+// (a planar cut of the fillet surface) and reuses the same idiom as our arc-fillet setback end-caps.
+
+// addCapFaces adds the two flat setback cap faces of an open run — the quarter-disk pocket between each
+// end section arc (topFoot→apex→wallFoot) and the surviving corner vertex. It is wound to face OUTWARD
+// along the tube axis (away from the tube interior), the same geometric-winding discipline addBlendFaces
+// uses, so the mass-properties integral reads material on the correct side.
+func (g *stripeBuild) addCapFaces() {
+	feet := [2][2]*topo.Vertex{{g.vS1[0], g.vW[0]}, {g.vEndS1, g.vEndW}}
+	lin := func(t int) topo.Lineage { return topo.NewLineage(topo.Tok("stripe", "cap", t)) }
+	for t := 0; t < 2; t++ {
+		tm := g.st.term[t]
+		vtx := g.verts[tm.vertex]
+		out := g.capOutward(t)
+		plane, err := geom.NewPlane(tm.vertex.Point(), out)
+		if err != nil {
+			continue // a degenerate section plane; Validate rejects the incomplete solid downstream
+		}
+		loop := []topo.Use{
+			dirUse(g.connTop[t], vtx),         // corner → shared-face foot
+			dirUse(g.cap[t], feet[t][0]),      // shared-face foot → wall foot (the section arc)
+			dirUse(g.connWall[t], feet[t][1]), // wall foot → corner
+		}
+		if capFaceFlipped([]math.Point3{tm.vertex.Point(), tm.topA, tm.wallA}, out) {
+			loop = reverseLoop(loop)
+		}
+		g.bld.AddFace(plane, lin(t), topo.OuterLoop(loop...))
+	}
+}
+
+// capOutward is terminal t's cap-face outward normal — the spine-axis direction that makes the flat cap
+// bound the solid correctly (it opposes the tube on their shared section arc, the manifold requirement
+// two outward faces satisfy). It points from the run-out end back toward the tube body: the little
+// material pocket the ball leaves at the corner tip sits ON the cap, so the solid is on the tube side.
+// Terminal 0 caps segment 0's entry (its interior is that segment's exit); terminal 1 caps the last
+// segment's exit (its interior is that segment's entry).
+func (g *stripeBuild) capOutward(t int) math.Vector3 {
+	tm := g.st.term[t]
+	termMid := midpointOf(tm.topA, tm.wallA)
+	interiorMid := midpointOf(g.exitFootS1(0).Point(), g.exitFootW(0).Point())
+	if t == 1 {
+		s := g.st.segs[tm.seg]
+		interiorMid = midpointOf(s.topA, s.wallA)
+	}
+	return termMid.VectorTo(interiorMid)
+}
+
+// capFaceFlipped reports whether the triangular cap ring (corner, shared foot, wall foot) winds against
+// the desired outward normal — matching blendRingFlipped's convention so both faces orient consistently.
+func capFaceFlipped(ring []math.Point3, out math.Vector3) bool {
+	nrm := ring[0].VectorTo(ring[1]).Cross(ring[0].VectorTo(ring[2]))
+	return float64(nrm.Dot(out)) < 0
+}
+
+// midpointOf is the midpoint of two points.
+func midpointOf(a, b math.Point3) math.Point3 {
+	return centroidPts([]math.Point3{a, b})
+}

--- a/kernel/ops/fillet_stripe_open_test.go
+++ b/kernel/ops/fillet_stripe_open_test.go
@@ -100,6 +100,50 @@ func notchCentroidOffset(r float64) float64 {
 	return num / (r * r * (1 - math.Pi/4))
 }
 
+// TestFilletSingleVerticalOpenChain fillets a genuinely OPEN maximal tangent chain: a box with ONE
+// vertical edge rounded (r=0.5) has a top rim whose tangent run is straight–arc–straight, terminating at
+// two sharp 90° corners (not a closed loop). Filleting it (r=0.25) builds the open stripe with a flat
+// setback cap at each sharp-corner run-out. The removed volume is checked against a locally-built OCCT
+// BRepFilletAPI_MakeFillet oracle (0.103246) — confirming our flat cap matches OCCT's intersection-at-end
+// for a right-angle terminal, to tessellation tolerance.
+func TestFilletSingleVerticalOpenChain(t *testing.T) {
+	box := csgBox(gmath.P3(0, 0, 0), 4, 4, 4)
+	var one [][]byte
+	for _, e := range box.Edges() {
+		if a, c := e.StartVertex().Point(), e.EndVertex().Point(); a.X == c.X && a.Y == c.Y {
+			one = append(one, e.ReferenceKey())
+			break
+		}
+	}
+	f, err := ops.FilletEdges(box, one, 0.5)
+	if err != nil {
+		t.Fatalf("single vertical fillet: %v", err)
+	}
+	before := ops.BodyGeometryProperties(f, ops.DefaultQuality()).Volume
+
+	chain, closed, err := ops.TangentEdgeChain(f, firstStraightTopEdge(t, f), ops.DefaultTangentChainAngle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if closed || len(chain) != 3 {
+		t.Fatalf("expected an OPEN 3-edge (straight–arc–straight) chain, got closed=%v len=%d", closed, len(chain))
+	}
+	res, err := ops.FilletEdges(f, chain, 0.25)
+	if err != nil {
+		t.Fatalf("open sas-chain fillet failed: %v", err)
+	}
+	rep := ops.Validate(res)
+	if !rep.Valid || !res.IsSolid() || rep.EulerCharacteristic != 2 {
+		t.Fatalf("open sas result invalid: valid=%v solid=%v chi=%d issues=%v",
+			rep.Valid, res.IsSolid(), rep.EulerCharacteristic, rep.Issues)
+	}
+	after := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	const occt = 0.103246
+	if removed := before - after; math.Abs(removed-occt) > 0.05*occt {
+		t.Errorf("removed volume = %g, want ≈%g (OCCT oracle)", removed, occt)
+	}
+}
+
 // TestFilletStripeUnbuildableIsLocalized is the ADR-0050 P6 partial-result contract: a radius that
 // cannot seat on the tangent chain (here r=0.5 equals the vertical-fillet radius, so the rolling-ball
 // centre curve collapses on the arc segments) fails with a localized, actionable error naming the faulty

--- a/kernel/ops/fillet_stripe_open_test.go
+++ b/kernel/ops/fillet_stripe_open_test.go
@@ -4,6 +4,7 @@ package ops_test
 
 import (
 	"math"
+	"strings"
 	"testing"
 
 	"oblikovati.org/kernel/geom"
@@ -97,6 +98,28 @@ func notchCentroidOffset(r float64) float64 {
 	// square centroid at r/2, area r²; quarter-disc centroid at 4r/3π from the corner, area πr²/4.
 	num := r*r*(r/2) - (math.Pi/4)*r*r*(4*r/(3*math.Pi))
 	return num / (r * r * (1 - math.Pi/4))
+}
+
+// TestFilletStripeUnbuildableIsLocalized is the ADR-0050 P6 partial-result contract: a radius that
+// cannot seat on the tangent chain (here r=0.5 equals the vertical-fillet radius, so the rolling-ball
+// centre curve collapses on the arc segments) fails with a localized, actionable error naming the faulty
+// segment and guide point — not a panic, not a silently wrong body. Mirrors OCCT ChFiDS_ErrorStatus.
+func TestFilletStripeUnbuildableIsLocalized(t *testing.T) {
+	filleted := boxWithRoundedVerticals(t, 4, 0.5)
+	top := topPerimeterKeys(t, filleted)
+
+	res, err := ops.FilletEdges(filleted, top, 0.5) // r == arc radius ⇒ no rolling-ball fit on the arcs
+	if err == nil {
+		t.Fatal("expected a localized partial-result error for the unbuildable radius, got a body")
+	}
+	if res != nil {
+		t.Errorf("unbuildable stripe must return no body, got %d faces", len(res.Faces()))
+	}
+	for _, want := range []string{"chain segment", "near ("} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should localize the failure (contain %q)", err.Error(), want)
+		}
+	}
 }
 
 // boxWithRoundedVerticals builds a box of the given side with its four vertical edges filleted at vr.

--- a/kernel/ops/fillet_stripe_open_test.go
+++ b/kernel/ops/fillet_stripe_open_test.go
@@ -3,60 +3,135 @@
 package ops_test
 
 import (
-	"strings"
+	"math"
 	"testing"
 
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
-	"oblikovati.org/math"
+	"oblikovati.org/kernel/topo"
+	gmath "oblikovati.org/math"
 )
 
-// TestFilletOpenCurvedTangentChainErrors is the ADR-0050 P6 partial-result contract: filleting an
-// OPEN tangent chain that crosses a curved face (a straight-arc-straight sub-selection of the top
-// rim) is not yet buildable — its setback end-caps are future work. It must fail with an ACTIONABLE
-// message (select the whole loop, or one edge at a time), not the misleading "miter corner's outer
-// face must be planar" the per-edge path emitted, and not a silently wrong body.
-func TestFilletOpenCurvedTangentChainErrors(t *testing.T) {
-	box := csgBox(math.P3(0, 0, 0), 4, 4, 4)
+// countPlanes counts a body's planar faces.
+func countPlanes(b *topo.Body) int {
+	n := 0
+	for _, f := range b.Faces() {
+		if _, ok := f.Geometry().(geom.Plane); ok {
+			n++
+		}
+	}
+	return n
+}
+
+// TestFilletOpenCurvedTangentStripe is the ADR-0050 P6 open-run acceptance: filleting a CONTIGUOUS OPEN
+// sub-run of a curved tangent chain (a straight–arc–straight stretch of the top rim of a box whose
+// vertical edges are already rounded) rounds the run as one stripe and closes each end with a flat
+// setback cap (OCCT's free-end ChFi3d_CoupeParPlan). The result is a valid closed manifold solid with
+// two new planar cap faces, and the removed volume matches the exact rolling-ball notch integral (the
+// ground truth OCCT approximates) — verifying the caps orient the tube outward, not inside-out.
+func TestFilletOpenCurvedTangentStripe(t *testing.T) {
+	filleted := boxWithRoundedVerticals(t, 4, 0.5)
+	before := ops.BodyGeometryProperties(filleted, ops.DefaultQuality()).Volume
+	planesBefore := countPlanes(filleted)
+
+	seed := firstStraightTopEdge(t, filleted)
+	chain, _, err := ops.TangentEdgeChain(filleted, seed, ops.DefaultTangentChainAngle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	open := chain[:3] // straight, arc, straight — a contiguous open sub-run of the closed loop
+	const r = 0.25
+
+	res, err := ops.FilletEdges(filleted, open, r)
+	if err != nil {
+		t.Fatalf("open curved tangent-stripe fillet failed: %v", err)
+	}
+	rep := ops.Validate(res)
+	if !rep.Valid || !res.IsSolid() || !rep.Manifold || !rep.Closed || !rep.OrientationOK {
+		t.Fatalf("open-stripe result invalid: valid=%v solid=%v manifold=%v closed=%v orient=%v issues=%v",
+			rep.Valid, res.IsSolid(), rep.Manifold, rep.Closed, rep.OrientationOK, rep.Issues)
+	}
+	if rep.EulerCharacteristic != 2 {
+		t.Errorf("Euler characteristic = %d, want 2 (genus-0 solid)", rep.EulerCharacteristic)
+	}
+	// Two flat run-out caps: the open run adds exactly two new planar faces over the closed body.
+	if got := countPlanes(res) - planesBefore; got != 2 {
+		t.Errorf("new planar faces = %d, want 2 (one flat setback cap per open end)", got)
+	}
+	// One torus over the single arc segment, two cylinders over the two straight segments (plus the four
+	// pre-existing vertical-edge cylinders).
+	if tori := countTorus(res); tori != 1 {
+		t.Errorf("torus faces = %d, want 1 (the single arc segment)", tori)
+	}
+	after := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	removed := before - after
+	want := openStripeRemovedVolume(r)
+	// Cross-check against OCCT: BRepFilletAPI_MakeFillet removes 0.198382 over the WHOLE 15.14-long
+	// tangent loop (it propagates); the same per-unit cross-section over just this 6.79-long run scales
+	// to ≈0.089, matching both `want` (the exact analytic) and our tessellated 0.0919 to a few percent.
+	if math.Abs(removed-want) > 0.1*want {
+		t.Errorf("removed volume = %g, want ≈%g (rolling-ball notch over straight–arc–straight)", removed, want)
+	}
+}
+
+// openStripeRemovedVolume is the EXACT material a radius-r rolling-ball fillet removes over the
+// straight–arc–straight run of the top rim (box side 4, vertical fillets 0.5). Each 90° convex edge
+// removes the notch area r²(1−π/4) per unit length; the straight tops are length (4−2·0.5)=3 each, and
+// the arc is a quarter turn of radius R=0.5 whose swept volume follows Pappus about the corner axis.
+// This is the ground truth OCCT's BRepFilletAPI_MakeFillet converges to.
+func openStripeRemovedVolume(r float64) float64 {
+	const R, side, vfil = 0.5, 4.0, 0.5
+	notch := r * r * (1 - math.Pi/4)
+	straightLen := side - 2*vfil // 3
+	straight := 2 * notch * straightLen
+	// Pappus: the notch centroid rides at radius R − cx from the corner axis, where cx is the notch's
+	// own centroid offset from the rim; swept through a quarter turn (π/2).
+	cx := notchCentroidOffset(r)
+	arc := notch * (math.Pi / 2) * (R - cx)
+	return straight + arc
+}
+
+// notchCentroidOffset is the inward distance from the convex edge to the centroid of the corner notch
+// (the r×r square minus its quarter disc), = r·(2/3)/(4−π) along each leg by symmetry.
+func notchCentroidOffset(r float64) float64 {
+	// square centroid at r/2, area r²; quarter-disc centroid at 4r/3π from the corner, area πr²/4.
+	num := r*r*(r/2) - (math.Pi/4)*r*r*(4*r/(3*math.Pi))
+	return num / (r * r * (1 - math.Pi/4))
+}
+
+// boxWithRoundedVerticals builds a box of the given side with its four vertical edges filleted at vr.
+func boxWithRoundedVerticals(t *testing.T, side, vr float64) *topo.Body {
+	t.Helper()
+	box := csgBox(gmath.P3(0, 0, 0), side, side, side)
 	var verts [][]byte
 	for _, e := range box.Edges() {
 		if a, c := e.StartVertex().Point(), e.EndVertex().Point(); a.X == c.X && a.Y == c.Y {
 			verts = append(verts, e.ReferenceKey())
 		}
 	}
-	filleted, err := ops.FilletEdges(box, verts, 0.5)
+	filleted, err := ops.FilletEdges(box, verts, vr)
 	if err != nil {
 		t.Fatalf("vertical fillet setup: %v", err)
 	}
-	var seed []byte
+	return filleted
+}
+
+// firstStraightTopEdge returns a top-rim straight edge (a line, not an arc) to seed the tangent chain.
+func firstStraightTopEdge(t *testing.T, b *topo.Body) []byte {
+	t.Helper()
 	maxZ := 0.0
-	for _, v := range filleted.Vertices() {
+	for _, v := range b.Vertices() {
 		if v.Point().Z > maxZ {
 			maxZ = v.Point().Z
 		}
 	}
-	for _, e := range filleted.Edges() {
+	for _, e := range b.Edges() {
 		if e.StartVertex().Point().Z >= maxZ-1e-9 && e.EndVertex().Point().Z >= maxZ-1e-9 {
 			if _, isArc := e.Geometry().(geom.Arc3d); !isArc {
-				seed = e.ReferenceKey()
-				break
+				return e.ReferenceKey()
 			}
 		}
 	}
-	chain, _, err := ops.TangentEdgeChain(filleted, seed, ops.DefaultTangentChainAngle)
-	if err != nil {
-		t.Fatal(err)
-	}
-	open := chain[:3] // straight, arc, straight — an open sub-run of the closed loop
-
-	_, err = ops.FilletEdges(filleted, open, 0.25)
-	if err == nil {
-		t.Fatal("open curved tangent chain must fail (end-caps unimplemented), got a body")
-	}
-	if strings.Contains(err.Error(), "miter") {
-		t.Errorf("open-chain error should be actionable, not the miter message: %v", err)
-	}
-	if !strings.Contains(err.Error(), "OPEN tangent chain") {
-		t.Errorf("expected an actionable open-chain message, got: %v", err)
-	}
+	t.Fatal("no straight top-rim edge found")
+	return nil
 }

--- a/kernel/ops/fillet_stripe_open_test.go
+++ b/kernel/ops/fillet_stripe_open_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+)
+
+// TestFilletOpenCurvedTangentChainErrors is the ADR-0050 P6 partial-result contract: filleting an
+// OPEN tangent chain that crosses a curved face (a straight-arc-straight sub-selection of the top
+// rim) is not yet buildable — its setback end-caps are future work. It must fail with an ACTIONABLE
+// message (select the whole loop, or one edge at a time), not the misleading "miter corner's outer
+// face must be planar" the per-edge path emitted, and not a silently wrong body.
+func TestFilletOpenCurvedTangentChainErrors(t *testing.T) {
+	box := csgBox(math.P3(0, 0, 0), 4, 4, 4)
+	var verts [][]byte
+	for _, e := range box.Edges() {
+		if a, c := e.StartVertex().Point(), e.EndVertex().Point(); a.X == c.X && a.Y == c.Y {
+			verts = append(verts, e.ReferenceKey())
+		}
+	}
+	filleted, err := ops.FilletEdges(box, verts, 0.5)
+	if err != nil {
+		t.Fatalf("vertical fillet setup: %v", err)
+	}
+	var seed []byte
+	maxZ := 0.0
+	for _, v := range filleted.Vertices() {
+		if v.Point().Z > maxZ {
+			maxZ = v.Point().Z
+		}
+	}
+	for _, e := range filleted.Edges() {
+		if e.StartVertex().Point().Z >= maxZ-1e-9 && e.EndVertex().Point().Z >= maxZ-1e-9 {
+			if _, isArc := e.Geometry().(geom.Arc3d); !isArc {
+				seed = e.ReferenceKey()
+				break
+			}
+		}
+	}
+	chain, _, err := ops.TangentEdgeChain(filleted, seed, ops.DefaultTangentChainAngle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	open := chain[:3] // straight, arc, straight — an open sub-run of the closed loop
+
+	_, err = ops.FilletEdges(filleted, open, 0.25)
+	if err == nil {
+		t.Fatal("open curved tangent chain must fail (end-caps unimplemented), got a body")
+	}
+	if strings.Contains(err.Error(), "miter") {
+		t.Errorf("open-chain error should be actionable, not the miter message: %v", err)
+	}
+	if !strings.Contains(err.Error(), "OPEN tangent chain") {
+		t.Errorf("expected an actionable open-chain message, got: %v", err)
+	}
+}

--- a/kernel/ops/fillet_stripe_test.go
+++ b/kernel/ops/fillet_stripe_test.go
@@ -65,9 +65,11 @@ func TestFilletTangentStripeTopPerimeter(t *testing.T) {
 		t.Errorf("cylinder faces = %d, want 8 (4 vertical + 4 straight blends)", cyls)
 	}
 	after := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
-	if removed := before - after; removed < 0.15 || removed > 0.26 {
-		// ≈ filletNotch(0.25)·perimeter(≈15.1) with a curvature correction on the four arcs.
-		t.Errorf("removed volume = %g, want ≈0.20 (a thin fillet tube around the top rim)", removed)
+	if removed := before - after; removed < 0.18 || removed > 0.22 {
+		// OCCT BRepFilletAPI_MakeFillet oracle removes 0.198382 for this exact fixture; we read 0.2027
+		// — a ~2% tessellation overshoot on the curved blend faces at DefaultQuality (verified against a
+		// locally-built OCCT TKFillet). The tolerance brackets that agreement.
+		t.Errorf("removed volume = %g, want ≈0.198 (OCCT oracle for the top-rim stripe)", removed)
 	}
 }
 

--- a/kernel/ops/fillet_stripe_test.go
+++ b/kernel/ops/fillet_stripe_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// countTorus counts a body's toroidal faces.
+func countTorus(b *topo.Body) int {
+	n := 0
+	for _, f := range b.Faces() {
+		if _, ok := f.Geometry().(geom.Torus); ok {
+			n++
+		}
+	}
+	return n
+}
+
+// TestFilletTangentStripeTopPerimeter is the #1797 acceptance: filleting the whole top perimeter of a
+// box whose vertical edges are already rounded — a closed tangent chain of 4 straight (plane∩plane)
+// and 4 arc (plane∩cylinder) edges — builds ONE continuous blend stripe (4 cylinder + 4 torus faces
+// meeting at shared section circles), a valid closed manifold solid. Before P4b this failed in the
+// miter corner solver ("outer face must be planar"); the tangent junctions are G1, not miters.
+func TestFilletTangentStripeTopPerimeter(t *testing.T) {
+	box := csgBox(math.P3(0, 0, 0), 4, 4, 4)
+	var verts [][]byte
+	for _, e := range box.Edges() {
+		if a, c := e.StartVertex().Point(), e.EndVertex().Point(); a.X == c.X && a.Y == c.Y {
+			verts = append(verts, e.ReferenceKey())
+		}
+	}
+	filleted, err := ops.FilletEdges(box, verts, 0.5)
+	if err != nil {
+		t.Fatalf("vertical fillet setup: %v", err)
+	}
+	before := ops.BodyGeometryProperties(filleted, ops.DefaultQuality()).Volume
+
+	top := topPerimeterKeys(t, filleted)
+	if len(top) != 8 {
+		t.Fatalf("expected 8 top-perimeter edges, got %d", len(top))
+	}
+
+	res, err := ops.FilletEdges(filleted, top, 0.25)
+	if err != nil {
+		t.Fatalf("tangent-stripe top-perimeter fillet failed: %v", err)
+	}
+	rep := ops.Validate(res)
+	if !rep.Valid || !res.IsSolid() || !rep.Manifold || !rep.Closed || !rep.OrientationOK {
+		t.Fatalf("stripe result invalid: valid=%v solid=%v manifold=%v closed=%v orient=%v issues=%v",
+			rep.Valid, res.IsSolid(), rep.Manifold, rep.Closed, rep.OrientationOK, rep.Issues)
+	}
+	if rep.EulerCharacteristic != 2 {
+		t.Errorf("Euler characteristic = %d, want 2 (genus-0 solid)", rep.EulerCharacteristic)
+	}
+	if tori := countTorus(res); tori != 4 {
+		t.Errorf("torus faces = %d, want 4 (one per arc segment)", tori)
+	}
+	if cyls := hasCylinderFaces(res); cyls != 8 {
+		t.Errorf("cylinder faces = %d, want 8 (4 vertical + 4 straight blends)", cyls)
+	}
+	after := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	if removed := before - after; removed < 0.15 || removed > 0.26 {
+		// ≈ filletNotch(0.25)·perimeter(≈15.1) with a curvature correction on the four arcs.
+		t.Errorf("removed volume = %g, want ≈0.20 (a thin fillet tube around the top rim)", removed)
+	}
+}
+
+// topPerimeterKeys returns the reference keys of every edge lying entirely on the body's top plane.
+func topPerimeterKeys(t *testing.T, b *topo.Body) [][]byte {
+	t.Helper()
+	maxZ := 0.0
+	for _, v := range b.Vertices() {
+		if v.Point().Z > maxZ {
+			maxZ = v.Point().Z
+		}
+	}
+	var keys [][]byte
+	for _, e := range b.Edges() {
+		if e.StartVertex().Point().Z >= maxZ-1e-9 && e.EndVertex().Point().Z >= maxZ-1e-9 {
+			keys = append(keys, e.ReferenceKey())
+		}
+	}
+	return keys
+}

--- a/kernel/ops/fillet_validity.go
+++ b/kernel/ops/fillet_validity.go
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// filletFitEps guards the two direction-cosine degeneracies of the recession formula: near-flat
+// faces (1−c→0, the edge is barely a crease) and razor edges (1+c→0, anti-parallel faces). These
+// are absolute because c=nA·nB is a dimensionless cosine, not a length (ADR-0050 P2 / #1800).
+const filletFitEps = 1e-9
+
+// validateFilletRadii rejects picks whose radius exceeds the geometric maximum the local planar
+// geometry admits — the closed-form planar specialization of OCCT's seed-section solvability
+// (ChFiDS_StartsolFailure): past r_max the rolling-ball tangent band overruns the finite face and
+// the fillet self-intersects, which the topological Validate cannot catch (#1800). Only edges
+// between two planar faces are bounded here; curved-neighbour edges get their r_max from the
+// marcher's seed solve in Phase 4. Radii are unchanged — this fails honestly, it does not clamp.
+func validateFilletRadii(picks []filletPick) error {
+	for _, p := range picks {
+		a, b, nA, nB, err := edgePlanarFaces(p.edge)
+		if err != nil {
+			continue // non-planar edge: not on the analytic planar path
+		}
+		rMax, bindingFace, bindingW, ok := maxFilletRadius(p, a, b, nA, nB, picks)
+		if !ok {
+			continue // degenerate dihedral: leave to the assembly's own validity gate
+		}
+		if r := p.maxRadius(); r > rMax*(1+1e-6) {
+			phi := stdmath.Acos(-clampUnit(float64(nA.Dot(nB)))) * 180 / stdmath.Pi
+			return fmt.Errorf(
+				"fillet: radius %g exceeds geometric maximum %g on edge %d (available in-face width %g on face %d, dihedral %.1f°); reduce the radius or use a smaller value",
+				r, rMax, p.edge.ID(), bindingW, bindingFace, phi)
+		}
+	}
+	return nil
+}
+
+// maxFilletRadius returns the largest constant radius that fits between the two planar faces of
+// pick p, r_max = cot(α/2)·min(W_A,W_B), with W the available in-face width toward the nearest
+// competing boundary (reduced by any co-filleted neighbour's own band). ok=false on a degenerate
+// dihedral (near-flat or razor faces). Mirrors the derivation in ADR-0050 Phase 2.
+func maxFilletRadius(p filletPick, a, b *topo.Face, nA, nB math.Vector3, all []filletPick) (rMax float64, bindingFace uint64, bindingW float64, ok bool) {
+	c := float64(nA.Dot(nB))
+	if 1-c < filletFitEps || 1+c < filletFitEps {
+		return 0, 0, 0, false
+	}
+	offDir := nA.Add(nB).Scale(math.Scalar(-1 / (1 + c)))
+	k := stdmath.Sqrt((1 + c) / (1 - c)) // cot(α/2): r_max = k · W
+	wA := availableWidth(p.edge, a, nA, offDir, all)
+	wB := availableWidth(p.edge, b, nB, offDir, all)
+	if wA <= wB {
+		return k * wA, a.ID(), wA, true
+	}
+	return k * wB, b.ID(), wB, true
+}
+
+// availableWidth is the smallest in-face clearance from edge e into face F perpendicular to e,
+// found by casting rays from samples along e toward the tangent-recession direction and taking
+// the nearest boundary hit. When the nearest boundary is itself a filleted edge, its own band is
+// subtracted so the two bands do not collide (constraint (b) of the ADR-0050 P2 derivation).
+func availableWidth(e *topo.Edge, f *topo.Face, nF, offDir math.Vector3, all []filletPick) float64 {
+	mF := offDir.Add(nF) // = tangent-recession direction, already in F's plane (offDir·nF = −1)
+	if l := float64(mF.Length()); l > 0 {
+		mF = mF.Scale(math.Scalar(1 / l))
+	}
+	yAxis := nF.Cross(mF) // in-plane, ⟂ to the ray
+	best := stdmath.Inf(1)
+	for _, p := range edgeSamples(e, 5) {
+		for _, g := range f.Edges() {
+			if g == e {
+				continue
+			}
+			s, hit := rayClearance(p, mF, yAxis, g.StartVertex().Point(), g.EndVertex().Point())
+			if hit {
+				best = stdmath.Min(best, s-neighbourBand(g, all))
+			}
+		}
+	}
+	return stdmath.Max(best, 0)
+}
+
+// rayClearance returns the distance s>0 at which the in-plane ray from origin O along xAxis
+// crosses segment [Q0,Q1] (coordinates taken in the (xAxis,yAxis) plane basis), or ok=false when
+// the segment does not straddle the ray on the forward side.
+func rayClearance(origin math.Point3, xAxis, yAxis math.Vector3, q0, q1 math.Point3) (float64, bool) {
+	y0 := float64(origin.VectorTo(q0).Dot(yAxis))
+	y1 := float64(origin.VectorTo(q1).Dot(yAxis))
+	if (y0 > 0) == (y1 > 0) {
+		return 0, false // both endpoints on the same side ⇒ no crossing of the y=0 ray line
+	}
+	u := y0 / (y0 - y1) // parameter along the segment where y=0
+	x0 := float64(origin.VectorTo(q0).Dot(xAxis))
+	x1 := float64(origin.VectorTo(q1).Dot(xAxis))
+	x := x0 + u*(x1-x0)
+	if x <= 0 {
+		return 0, false // crossing is behind the ray origin
+	}
+	return x, true
+}
+
+// neighbourBand is the in-face recession of edge g's own fillet when g is one of the picks, else
+// 0 — how far g's band eats into the shared face, subtracted from the clearance.
+func neighbourBand(g *topo.Edge, all []filletPick) float64 {
+	for _, p := range all {
+		if p.edge != g {
+			continue
+		}
+		_, _, nA, nB, err := edgePlanarFaces(g)
+		if err != nil {
+			return 0
+		}
+		c := float64(nA.Dot(nB))
+		if 1+c < filletFitEps {
+			return 0
+		}
+		return p.maxRadius() * stdmath.Sqrt((1-c)/(1+c)) // d(r) = r·√((1−c)/(1+c))
+	}
+	return 0
+}
+
+// edgeSamples returns n points spread evenly along a straight edge (planar-face edges are lines).
+func edgeSamples(e *topo.Edge, n int) []math.Point3 {
+	s, t := e.StartVertex().Point(), e.EndVertex().Point()
+	pts := make([]math.Point3, n)
+	for i := 0; i < n; i++ {
+		pts[i] = s.TranslateBy(s.VectorTo(t).Scale(math.Scalar(float64(i) / float64(n-1))))
+	}
+	return pts
+}
+
+// maxRadius is the largest radius applied along a pick (both ends plus any intermediate stops) —
+// the recession is deepest there, so the fit bound is checked against it.
+func (p filletPick) maxRadius() float64 {
+	m := stdmath.Max(p.r0, p.r1)
+	for _, rp := range p.mids {
+		m = stdmath.Max(m, rp.R)
+	}
+	return m
+}
+
+// clampUnit constrains x to [-1,1] so Acos of a rounded dot product never yields NaN.
+func clampUnit(x float64) float64 {
+	if x < -1 {
+		return -1
+	}
+	if x > 1 {
+		return 1
+	}
+	return x
+}

--- a/kernel/ops/fillet_validity_test.go
+++ b/kernel/ops/fillet_validity_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// TestFilletRejectsOverLargeRadius is the #1800 regression: a radius far larger than the feature
+// (r=20 on a 2×2×2 box, whose faces admit at most r=2) must fail honestly — surfacing the
+// offending radius and the computed geometric maximum — instead of shipping self-intersecting
+// geometry that only passes topological validation. A radius within the bound still succeeds.
+func TestFilletRejectsOverLargeRadius(t *testing.T) {
+	box := csgBox(math.P3(0, 0, 0), 2, 2, 2)
+	edge := verticalEdgeKey(t, box)
+
+	_, err := ops.FilletEdges(box, [][]byte{edge}, 20)
+	if err == nil {
+		t.Fatal("fillet with r=20 on a 2×2×2 box must be rejected, not shipped")
+	}
+	if !strings.Contains(err.Error(), "geometric maximum") {
+		t.Errorf("error should report the geometric maximum, got: %v", err)
+	}
+
+	if _, err := ops.FilletEdges(box, [][]byte{edge}, 0.5); err != nil {
+		t.Fatalf("a radius within the bound (0.5) must still succeed: %v", err)
+	}
+}
+
+// TestFilletRejectsCollidingNeighbours exercises constraint (b): two adjacent vertical edges
+// sharing a 2-wide side face, each filleted, whose bands recede toward each other. r=1.5 each
+// overshoots (1.5+1.5 > 2) and is rejected; r=0.8 each (1.6 < 2) fits.
+func TestFilletRejectsCollidingNeighbours(t *testing.T) {
+	box := csgBox(math.P3(0, 0, 0), 2, 2, 2)
+	a, b := adjacentVerticalEdges(t, box)
+
+	if _, err := ops.FilletEdges(box, [][]byte{a, b}, 1.5); err == nil {
+		t.Error("two r=1.5 fillets on a shared 2-wide face collide and must be rejected")
+	}
+	if _, err := ops.FilletEdges(box, [][]byte{a, b}, 0.8); err != nil {
+		t.Errorf("two r=0.8 fillets fit within the shared face and must succeed: %v", err)
+	}
+}
+
+// adjacentVerticalEdges returns the keys of two vertical box edges that share a side face.
+func adjacentVerticalEdges(t *testing.T, b *topo.Body) ([]byte, []byte) {
+	t.Helper()
+	var verts []*topo.Edge
+	for _, e := range b.Edges() {
+		if p, q := e.StartVertex().Point(), e.EndVertex().Point(); p.X == q.X && p.Y == q.Y {
+			verts = append(verts, e)
+		}
+	}
+	for i := range verts {
+		for j := i + 1; j < len(verts); j++ {
+			if sharesFace(verts[i], verts[j]) {
+				return verts[i].ReferenceKey(), verts[j].ReferenceKey()
+			}
+		}
+	}
+	t.Fatal("no two vertical edges sharing a face")
+	return nil, nil
+}
+
+// sharesFace reports whether two edges bound a common face.
+func sharesFace(a, b *topo.Edge) bool {
+	for _, fa := range a.Faces() {
+		for _, fb := range b.Faces() {
+			if fa == fb {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/kernel/ops/modify_visitor.go
+++ b/kernel/ops/modify_visitor.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Modification is the geometry-replacement visitor a local B-rep edit supplies — our
+// BRepTools_Modification (ADR-0050 P7). For each face/edge/vertex it returns replacement geometry
+// and true, or false to keep the original verbatim. It is what makes draft (and later shell,
+// move-face, replace-face) work on CURVED bodies: the modifier re-intersects neighbours instead of
+// casting every face to a plane (the rebuildWithPlanes limitation behind the #1802 crash).
+type Modification interface {
+	NewSurface(f *topo.Face) (geom.Surface, bool)
+	NewCurve(e *topo.Edge) (geom.Curve3, bool)
+	NewPoint(v *topo.Vertex) (math.Point3, bool)
+}
+
+// modifyBody rebuilds solid applying mod: each vertex, edge and face takes mod's replacement
+// geometry when offered and is otherwise copied verbatim, while the combinatorial structure (loops,
+// edge-uses, orientation) and the per-entity lineage are preserved (ADR-0043 — a selection on a
+// modified face survives). Mirrors BRepTools_Modifier::Perform. tag names the rebuild's body token.
+func modifyBody(solid *topo.Body, mod Modification, tag string) *topo.Body {
+	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok(tag, "body", 0)))
+	nv := modifiedVertices(bld, solid, mod, tag)
+	ne := modifiedEdges(bld, solid, mod, nv, tag)
+	modifiedFaces(bld, solid, mod, ne, tag)
+	return bld.Build()
+}
+
+// modifiedVertices adds each vertex at its relocated point (NewPoint) or original position.
+func modifiedVertices(bld *topo.Builder, solid *topo.Body, mod Modification, tag string) map[uint64]*topo.Vertex {
+	nv := make(map[uint64]*topo.Vertex, len(solid.Vertices()))
+	for i, v := range solid.Vertices() {
+		p := v.Point()
+		if np, ok := mod.NewPoint(v); ok {
+			p = np
+		}
+		nv[v.ID()] = bld.AddVertex(p, cloneName(true, v.Lineage(), tag, "v", i))
+	}
+	return nv
+}
+
+// modifiedEdges adds each edge with its re-intersected curve (NewCurve) or, unchanged, its original
+// curve — its endpoints did not move, which the modification guarantees.
+func modifiedEdges(bld *topo.Builder, solid *topo.Body, mod Modification, nv map[uint64]*topo.Vertex, tag string) map[uint64]*topo.Edge {
+	ne := make(map[uint64]*topo.Edge, len(solid.Edges()))
+	for i, e := range solid.Edges() {
+		crv, ok := mod.NewCurve(e)
+		if !ok {
+			crv = e.Geometry()
+		}
+		a, b := nv[e.StartVertex().ID()], nv[e.EndVertex().ID()]
+		ne[e.ID()] = bld.AddEdge(crv, a, b, cloneName(true, e.Lineage(), tag, "e", i))
+	}
+	return ne
+}
+
+// modifiedFaces adds each face with its replacement surface (NewSurface) or original, preserving
+// the loop structure against the rebuilt edges.
+func modifiedFaces(bld *topo.Builder, solid *topo.Body, mod Modification, ne map[uint64]*topo.Edge, tag string) {
+	for i, f := range solid.Faces() {
+		s, ok := mod.NewSurface(f)
+		if !ok {
+			s = f.Geometry()
+		}
+		bld.AddFace(s, cloneName(true, f.Lineage(), tag, "f", i), cloneLoops(f, ne)...)
+	}
+}

--- a/kernel/ops/retopo.go
+++ b/kernel/ops/retopo.go
@@ -3,32 +3,10 @@
 package ops
 
 import (
-	"fmt"
-
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 )
-
-// requirePlanarBody guards the plane-only rebuild engine ([rebuildWithPlanes]): it rejects a
-// body carrying any non-planar face — a cylinder/sphere/torus/cone/NURBS left by a prior
-// fillet, chamfer or curved boolean — that the engine cannot represent. rebuildWithPlanes casts
-// every face to geom.Plane, so on a curved face the assertion panics (draft.go before this
-// guard: the draft-after-fillet crash, #1802). op names the operation for the message.
-//
-// This is the Phase-0 stopgap of the ADR-0050 blend milestone (#1804): the curved-capable
-// modifier-visitor (Phase 7, #1809) supersedes it for draft; standard CAD practice is to
-// draft BEFORE filleting anyway. Example: requirePlanarBody(solid, "draft").
-func requirePlanarBody(solid *topo.Body, op string) error {
-	for _, f := range solid.Faces() {
-		if _, ok := f.Geometry().(geom.Plane); !ok {
-			return fmt.Errorf(
-				"%s requires an all-planar body: face %d is %T, not a geom.Plane — apply %s before fillets/chamfers",
-				op, f.ID(), f.Geometry(), op)
-		}
-	}
-	return nil
-}
 
 // rebuildWithPlanes clones a planar solid's topology, replacing each face's surface with
 // planeOf(f) and moving each vertex to the meeting point of its adjacent faces' new planes

--- a/kernel/ops/retopo.go
+++ b/kernel/ops/retopo.go
@@ -3,10 +3,32 @@
 package ops
 
 import (
+	"fmt"
+
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 )
+
+// requirePlanarBody guards the plane-only rebuild engine ([rebuildWithPlanes]): it rejects a
+// body carrying any non-planar face — a cylinder/sphere/torus/cone/NURBS left by a prior
+// fillet, chamfer or curved boolean — that the engine cannot represent. rebuildWithPlanes casts
+// every face to geom.Plane, so on a curved face the assertion panics (draft.go before this
+// guard: the draft-after-fillet crash, #1802). op names the operation for the message.
+//
+// This is the Phase-0 stopgap of the ADR-0050 blend milestone (#1804): the curved-capable
+// modifier-visitor (Phase 7, #1809) supersedes it for draft; standard CAD practice is to
+// draft BEFORE filleting anyway. Example: requirePlanarBody(solid, "draft").
+func requirePlanarBody(solid *topo.Body, op string) error {
+	for _, f := range solid.Faces() {
+		if _, ok := f.Geometry().(geom.Plane); !ok {
+			return fmt.Errorf(
+				"%s requires an all-planar body: face %d is %T, not a geom.Plane — apply %s before fillets/chamfers",
+				op, f.ID(), f.Geometry(), op)
+		}
+	}
+	return nil
+}
 
 // rebuildWithPlanes clones a planar solid's topology, replacing each face's surface with
 // planeOf(f) and moving each vertex to the meeting point of its adjacent faces' new planes

--- a/kernel/ops/tangent_chain.go
+++ b/kernel/ops/tangent_chain.go
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// DefaultTangentChainAngle is the angular band (radians, ~1°) within which two edges meeting
+// at a vertex are treated as G1-tangent for chain propagation. A real crease (a 90° box edge
+// sits π/2 from the antiparallel threshold) is far outside it, so the walk stops there; a
+// clean line↔arc junction on a rounded rim matches to machine precision and passes.
+const DefaultTangentChainAngle = stdmath.Pi / 180
+
+// TangentEdgeChain expands a single seed edge into the maximal run of tangent-continuous edges —
+// the "select tangent chain / loop" selection behind fillet/chamfer (Oblikovati/Oblikovati#1798).
+// From the seed it walks both endpoint vertices, at each step onto the one neighbour edge that
+// (a) is itself a fillet-able crease of the SAME convexity as the seed, (b) meets the current
+// edge G1-tangentially at the shared vertex (their away-from-vertex tangents are antiparallel
+// within angTol), and (c) is the only other crease at that vertex — every other incident edge is
+// a smooth (tangent) edge, so the two supporting faces continue across the junction. This mirrors
+// OCCT ChFi3d_Builder::PerformElement + ChFi3d_Builder::FaceTangency ("opposing faces must be
+// tangent"). It returns the ordered edge keys (seed included) and whether the run closes a loop.
+//
+// Example: one click on a straight edge of a rounded-rectangle rim yields all 8 edges
+// (4 lines + 4 G1 corner arcs) with closed=true.
+func TangentEdgeChain(body *topo.Body, seedKey []byte, angTol float64) ([][]byte, bool, error) {
+	seed, ok := body.FindEdgeByKey(seedKey)
+	if !ok {
+		return nil, false, fmt.Errorf("tangent chain: seed edge key not found in body of %d edges", len(body.Edges()))
+	}
+	conv := ClassifyEdgeConvexity(seed)
+	if conv != EdgeConvex && conv != EdgeConcave {
+		return [][]byte{seedKey}, false, nil // a smooth/boundary seed cannot anchor a fillet chain
+	}
+	if seed.StartVertex() == seed.EndVertex() {
+		return [][]byte{seedKey}, true, nil // a lone closed edge (e.g. a cylinder rim)
+	}
+	c := newEdgeChain(seed)
+	closed := c.grow(seed, seed.EndVertex(), seed.StartVertex(), conv, angTol, c.appendEdge)
+	if !closed {
+		c.grow(seed, seed.StartVertex(), seed.EndVertex(), conv, angTol, c.prependEdge)
+	}
+	return c.keys(), closed, nil
+}
+
+// edgeChain accumulates the ordered run of chained edges and the set already taken (so the walk
+// never revisits an edge or steps back onto the seed).
+type edgeChain struct {
+	edges   []*topo.Edge
+	visited map[uint64]bool
+}
+
+func newEdgeChain(seed *topo.Edge) *edgeChain {
+	return &edgeChain{edges: []*topo.Edge{seed}, visited: map[uint64]bool{seed.ID(): true}}
+}
+
+func (c *edgeChain) appendEdge(e *topo.Edge) { c.edges = append(c.edges, e); c.visited[e.ID()] = true }
+func (c *edgeChain) prependEdge(e *topo.Edge) {
+	c.edges = append([]*topo.Edge{e}, c.edges...)
+	c.visited[e.ID()] = true
+}
+
+func (c *edgeChain) keys() [][]byte {
+	keys := make([][]byte, len(c.edges))
+	for i, e := range c.edges {
+		keys[i] = e.ReferenceKey()
+	}
+	return keys
+}
+
+// grow walks from cur across frontier onto tangent neighbours until the run dies or reaches
+// target (closing a loop). add places each new edge at the correct end (append downstream,
+// prepend upstream). Returns true when the run closed back onto target.
+func (c *edgeChain) grow(cur *topo.Edge, frontier, target *topo.Vertex, conv EdgeConvexity, angTol float64, add func(*topo.Edge)) bool {
+	for {
+		next := c.pickContinuation(cur, frontier, conv, angTol)
+		if next == nil {
+			return false
+		}
+		nv := otherVertex(next, frontier)
+		add(next)
+		if nv == target {
+			return true
+		}
+		cur, frontier = next, nv
+	}
+}
+
+// pickContinuation returns the unvisited crease edge at frontier that best continues cur's
+// guideline (most antiparallel away-from-vertex tangents, within angTol of straight-through),
+// or nil when none qualifies.
+func (c *edgeChain) pickContinuation(cur *topo.Edge, frontier *topo.Vertex, conv EdgeConvexity, angTol float64) *topo.Edge {
+	tCur := unitTangentAwayFromVertex(cur, frontier)
+	var best *topo.Edge
+	bestAng := stdmath.Pi - angTol
+	for _, cand := range frontier.Edges() {
+		if cand == cur || c.visited[cand.ID()] || ClassifyEdgeConvexity(cand) != conv {
+			continue
+		}
+		if !onlyCreasesAtVertex(frontier, cur, cand) {
+			continue
+		}
+		if ang := float64(tCur.AngleTo(unitTangentAwayFromVertex(cand, frontier))); ang > bestAng {
+			best, bestAng = cand, ang
+		}
+	}
+	return best
+}
+
+// onlyCreasesAtVertex reports whether cur and cand are the sole fillet-able creases meeting at v
+// — every other incident edge is smooth (tangent) or a boundary. This is OCCT FaceTangency's
+// invariant: with no third crease, the two supporting faces pass tangentially through the
+// junction, so the blend guideline continues from cur onto cand.
+func onlyCreasesAtVertex(v *topo.Vertex, cur, cand *topo.Edge) bool {
+	for _, e := range v.Edges() {
+		if e == cur || e == cand {
+			continue
+		}
+		if k := ClassifyEdgeConvexity(e); k == EdgeConvex || k == EdgeConcave {
+			return false
+		}
+	}
+	return true
+}
+
+// unitTangentAwayFromVertex is e's unit tangent pointing away from v along the edge (toward its
+// other vertex). Two edges continue G1 through v when these point in opposite directions.
+func unitTangentAwayFromVertex(e *topo.Edge, v *topo.Vertex) math.Vector3 {
+	crv := e.Geometry()
+	lo, hi := crv.Domain()
+	t := crv.TangentAt(lo)
+	if e.EndVertex() == v && e.StartVertex() != v {
+		t = crv.TangentAt(hi).Negate()
+	}
+	if l := float64(t.Length()); l > 0 {
+		t = t.Scale(math.Scalar(1 / l))
+	}
+	return t
+}
+
+// otherVertex returns the endpoint of e that is not v.
+func otherVertex(e *topo.Edge, v *topo.Vertex) *topo.Vertex {
+	if e.StartVertex() == v {
+		return e.EndVertex()
+	}
+	return e.StartVertex()
+}

--- a/kernel/ops/tangent_chain_test.go
+++ b/kernel/ops/tangent_chain_test.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// TestTangentChainBoxHasNoPropagation: every edge of a plain box is an isolated 90° crease, so
+// seeding any one yields just that edge and no loop closure.
+func TestTangentChainBoxHasNoPropagation(t *testing.T) {
+	box := csgBox(math.P3(0, 0, 0), 2, 2, 2)
+	keys, closed, err := ops.TangentEdgeChain(box, verticalEdgeKey(t, box), ops.DefaultTangentChainAngle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(keys) != 1 || closed {
+		t.Fatalf("box edge chained to %d edges (closed=%v), want 1 and open", len(keys), closed)
+	}
+}
+
+// TestTangentChainRoundedRimIsClosedLoop is the #1798 repro: filleting the four vertical edges of
+// a box rounds the top rim into a tangent-continuous loop of 8 edges (4 straight sides G1 to 4
+// corner arcs). Seeding ONE straight side must propagate the whole rim and report closure — the
+// "pick one edge → select tangent chain" the chamfer/fillet tools were missing.
+func TestTangentChainRoundedRimIsClosedLoop(t *testing.T) {
+	box := csgBox(math.P3(0, 0, 0), 2, 2, 2)
+	rounded, err := ops.FilletEdges(box, verticalEdgeKeys(t, box), 0.5)
+	if err != nil {
+		t.Fatalf("fillet setup: %v", err)
+	}
+	seed := longestTopRimEdge(t, rounded, 2.0)
+	keys, closed, err := ops.TangentEdgeChain(rounded, seed, ops.DefaultTangentChainAngle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !closed {
+		t.Error("rounded top rim is a loop but chain reported open")
+	}
+	if len(keys) != 8 {
+		t.Fatalf("rounded rim chain = %d edges, want 8 (4 sides + 4 arcs)", len(keys))
+	}
+}
+
+// TestTangentChainCylinderRimClosesOnOneEdge: a cylinder's rim is a single closed circular edge,
+// so it is its own loop — the chain is one edge, closed.
+func TestTangentChainCylinderRimClosesOnOneEdge(t *testing.T) {
+	cyl, err := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 1, 2)
+	if err != nil {
+		t.Fatalf("SolidCylinder: %v", err)
+	}
+	rim := convexEdgeKey(t, cyl)
+	keys, closed, err := ops.TangentEdgeChain(cyl, rim, ops.DefaultTangentChainAngle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !closed || len(keys) < 1 {
+		t.Fatalf("cylinder rim chain = %d edges (closed=%v), want a closed loop", len(keys), closed)
+	}
+}
+
+// verticalEdgeKeys returns every vertical edge (start/end share X,Y) of a box.
+func verticalEdgeKeys(t *testing.T, b *topo.Body) [][]byte {
+	t.Helper()
+	var keys [][]byte
+	for _, e := range b.Edges() {
+		if a, c := e.StartVertex().Point(), e.EndVertex().Point(); a.X == c.X && a.Y == c.Y {
+			keys = append(keys, e.ReferenceKey())
+		}
+	}
+	if len(keys) != 4 {
+		t.Fatalf("expected 4 vertical box edges, found %d", len(keys))
+	}
+	return keys
+}
+
+// longestTopRimEdge returns the longest edge whose endpoints both sit at z≈top — a straight
+// side of the rounded rim (the straight sides are longer than the quarter-circle corner arcs).
+func longestTopRimEdge(t *testing.T, b *topo.Body, top float64) []byte {
+	t.Helper()
+	var best []byte
+	bestLen := 0.0
+	for _, e := range b.Edges() {
+		a, c := e.StartVertex().Point(), e.EndVertex().Point()
+		if stdmath.Abs(float64(a.Z)-top) > 1e-6 || stdmath.Abs(float64(c.Z)-top) > 1e-6 {
+			continue
+		}
+		if l := float64(a.DistanceTo(c)); l > bestLen {
+			best, bestLen = e.ReferenceKey(), l
+		}
+	}
+	if best == nil {
+		t.Fatalf("no top-rim edge at z=%g", top)
+	}
+	return best
+}
+
+// convexEdgeKey returns the key of the first convex edge of b.
+func convexEdgeKey(t *testing.T, b *topo.Body) []byte {
+	t.Helper()
+	for _, e := range b.Edges() {
+		if ops.ClassifyEdgeConvexity(e) == ops.EdgeConvex {
+			return e.ReferenceKey()
+		}
+	}
+	t.Fatal("no convex edge")
+	return nil
+}


### PR DESCRIPTION
## What

Replaces the faceted rolling-ball fillet fallback and the plane-only draft
retopo with a general, OCCT-parity **blend engine** (`kernel/blend/`) plus a
surface-agnostic **modifier-visitor** for draft — the whole ADR-0050 milestone
(#43), phases P0–P7.

- **Tangent-chain fillets** build as one continuous **stripe** (cylinder/torus
  blend segments meeting at G1 section circles) instead of a faceted octagon;
  open sub-runs terminate in flat setback caps.
- **General constant/variable-radius marcher** (`marcher.go`): the rolling-ball
  centre curve is the intersection of the two support offsets; the blend is the
  canal of radius r about it, exact for primitive pairs (line→cylinder,
  circle→torus) and B-spline-fit otherwise.
- **Geometric max-radius validity** rejects an over-large radius honestly
  instead of shipping self-intersecting geometry.
- **Curved-draft modifier-visitor** (`modify_visitor.go`, `draft_mod.go`) tilts
  changed faces and re-intersects neighbours — draft on a face adjacent to
  fillets now tapers to a valid solid instead of panicking.
- Localized partial-result status (ChFiDS_ErrorStatus-equivalent) names the
  faulty segment/vertex rather than failing globally.

## Why

The fillet/chamfer/draft bugs rampam reported in Discord `#bug-tracker` are all
symptoms of one gap: we lacked OCCT's general blend walking engine and its
local-modification framework. This lands that engine, grounded line-by-line in
the checked-out OCCT `ChFi3d`/`BRepBlend`/`Draft_Modification` sources.

## Verification

- Grounded and checked against a locally-built OCCT `TKFillet` oracle: the
  closed top-rim stripe removes 0.2027 vs OCCT `BRepFilletAPI_MakeFillet`
  0.198382 (~2% tessellation); a genuinely-open straight–arc–straight chain
  removes 0.1056 vs OCCT 0.103246 (~2%).
- Live offscreen render on the Vulkan head confirms a watertight rounded rim
  flowing through the corners; back edges stay sharp on partial selections.
- Full suite + `golangci-lint` green locally.

Closes #1797
Closes #1798
Closes #1800
Closes #1802
Closes #1804
Closes #1805
Closes #1806
Closes #1807
Closes #1808
Closes #1809

🤖 Generated with [Claude Code](https://claude.com/claude-code)