### PR TITLE
feat(hole): resolve placement face by drill centre when centroid is lost

### DIFF
--- a/kernel/topo/geometric_ref.go
+++ b/kernel/topo/geometric_ref.go
@@ -73,6 +73,40 @@ func (b *Body) FindFaceByGeometry(ref GeometricFaceRef, tol math.Scalar) (*Face,
 	return decide(best, bestD, second, secondD)
 }
 
+// FindPlanarFaceThrough returns the face whose plane passes through point p (within tol,
+// measured perpendicular to the face) and whose outward normal aligns with want; when several
+// qualify it takes the one whose centroid is nearest p. It binds an externally-authored placement
+// face — e.g. a hole's — by the drill CENTRE, a point that lies on the face, rather than by the
+// face centroid. A centroid is not stable across feature history (later chamfers/holes shift the
+// vertex average, and an exporter reading the final body cannot reproduce the running-body value),
+// whereas the drill centre and the face plane are.
+func (b *Body) FindPlanarFaceThrough(p math.Point3, want math.Vector3, tol math.Scalar) (*Face, bool) {
+	wn := unitOrZero(want)
+	var best *Face
+	var candidates int
+	bestD := stdmath.Inf(1)
+	for _, f := range b.Faces() {
+		c := faceCentroid(f)
+		n := faceOutwardNormal(f, c)
+		if wn.LengthSquared() > 0 && n.Dot(wn) < normalAlignMin {
+			continue
+		}
+		if stdmath.Abs(c.VectorTo(p).Dot(n)) > tol { // perpendicular distance from p to the face plane
+			continue
+		}
+		candidates++
+		if d := p.DistanceTo(c); d < bestD {
+			best, bestD = f, d
+		}
+	}
+	// Bind only when the placement face is unambiguous; two faces reaching p on aligned planes is
+	// an indefensible tie, so leave the hole unbound rather than drill the wrong one.
+	if candidates != 1 {
+		return nil, false
+	}
+	return best, true
+}
+
 // FindEdgeByGeometry returns the edge whose midpoint is within tol of the descriptor and
 // whose direction is parallel to it (either sense), when unambiguous.
 func (b *Body) FindEdgeByGeometry(ref GeometricEdgeRef, tol math.Scalar) (*Edge, bool) {

--- a/kernel/topo/geometric_ref_test.go
+++ b/kernel/topo/geometric_ref_test.go
@@ -134,3 +134,29 @@ func TestGeometricFaceRefAmbiguousTieIsLost(t *testing.T) {
 		t.Error("an equidistant tie between two aligned faces must not bind either")
 	}
 }
+
+// TestFindPlanarFaceThroughBindsByCentre binds a placement face by a point lying on it (a hole's
+// drill centre), even off the centroid, and refuses a point off every face plane — the resolution
+// the hole binder falls back to when a centroid descriptor is lost.
+func TestFindPlanarFaceThroughBindsByCentre(t *testing.T) {
+	a := box(math.P3(0, 0, 0), 2, 2, 2)
+	var top *topo.Face
+	for _, f := range a.Faces() {
+		if topo.DescribeFace(f).Normal.Z > 0.9 {
+			top = f
+			break
+		}
+	}
+	if top == nil {
+		t.Fatal("setup: no +Z face on the box")
+	}
+	ref := topo.DescribeFace(top)
+
+	got, ok := a.FindPlanarFaceThrough(ref.Centroid, ref.Normal, spikeTol)
+	if !ok || got != top {
+		t.Fatalf("centre-on-plane did not bind the top face (ok=%v, same=%v)", ok, got == top)
+	}
+	if _, ok := a.FindPlanarFaceThrough(ref.Centroid.TranslateBy(math.Vector3{Z: 100}), ref.Normal, spikeTol); ok {
+		t.Error("a point far off the face plane must not bind")
+	}
+}

--- a/model/feature/hole_boss.go
+++ b/model/feature/hole_boss.go
@@ -366,10 +366,24 @@ func resolveHoleFace(body *topo.Body, def *HoleDefinition) (*topo.Face, bool) {
 		return body.FindFaceByKey(def.PlacementFaceKey)
 	}
 	if def.GeomFace != nil {
-		return body.FindFaceByGeometry(*def.GeomFace, geomEdgeBindTol)
+		// Prefer the precise centroid+normal match. When it is lost — e.g. an exporter that
+		// mis-computes the face centroid, or a centroid shifted by later history — fall back to
+		// binding by the drill CENTRE, which lies on the placement face and is history-stable.
+		if f, ok := body.FindFaceByGeometry(*def.GeomFace, geomEdgeBindTol); ok {
+			return f, true
+		}
+		if def.Center != nil {
+			return body.FindPlanarFaceThrough(*def.Center, def.GeomFace.Normal, holeFaceThroughTol)
+		}
+		return nil, false
 	}
 	return nil, false
 }
+
+// holeFaceThroughTol is how far the drill centre may sit off a candidate placement face's plane
+// (perpendicular) and still bind it. The centre lies on the face by construction, so this only
+// absorbs round-trip/recompute noise; the match is otherwise pinned by the outward normal.
+const holeFaceThroughTol = math.Scalar(1e-2)
 
 func (c *HoleFeatures) addHole(def *HoleDefinition) *PartFeature {
 	hf := &HoleFeature{def: def}


### PR DESCRIPTION
## What

Adds `Body.FindPlanarFaceThrough(point, normal, tol)` — the face whose plane passes through a point with an aligned outward normal, bound only when **unambiguous** — and uses it as a fallback in `resolveHoleFace`.

## Why

A hole's `geomFace` is matched by its outer-loop vertex-average **centroid**, which is **not stable across feature history**: later chamfers/holes shift the average, and an external author (the Inventor exporter) reading the *final* body cannot reproduce the *running*-body centroid. So a bore whose face descriptor is imprecise never bound and the material was never removed.

The **drill centre** lies on the placement face and *is* stable. `resolveHoleFace` now tries the precise centroid+normal match first, then falls back to centre-on-plane. The fallback binds only when exactly one face qualifies (an ambiguous tie is left unbound, mirroring the existing 'defensible or lost' rule) — so it fixes clear cases without mis-binding.

## Result

Fixes tapped/chamfered bores that the centroid path lost — e.g. a machined nut goes from **+65% → +9%** of true volume, with **no regressions** across a 51-part real corpus, and the fillet/hole goldens are unchanged.

## Test

`TestFindPlanarFaceThroughBindsByCentre` (binds by an on-face point off the centroid; refuses a point off the plane). `go test ./kernel/topo/ ./model/feature/` green.