### PR TITLE
#1801: Draft pull-direction + neutral-plane inputs

### DIFF
--- a/app/draft_tool.go
+++ b/app/draft_tool.go
@@ -6,20 +6,38 @@ import (
 	"errors"
 	stdmath "math"
 
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
 	"oblikovati.org/model/feature"
 )
 
 // degToRad converts the draft angle the UI takes in degrees to the radians the feature uses.
 const degToRad = stdmath.Pi / 180
 
-// DraftTool is the interactive Draft command: activate it, click one or more faces, set the
-// draft angle (degrees) in the property window, and OK to taper them about the +Z pull
-// direction (the mould-pull default). Negative angle leans the face in, positive out.
+// draftPickMode selects which slot the next viewport click fills: the faces to taper, the pull-
+// direction face (its normal), or the neutral (parting) plane face. Mirrors ReplaceFaceTool's mode.
+type draftPickMode int
+
+const (
+	pickDraftFaces draftPickMode = iota
+	pickDraftPull
+	pickDraftNeutral
+)
+
+// DraftTool is the interactive Draft command: activate it, click one or more faces, optionally set a
+// pull-direction face and a neutral (parting) plane face, set the draft angle (degrees), and OK to
+// taper. Pull defaults to +Z (the mould-pull default); with no neutral plane each face pivots on the
+// implicit lowest-vertex hinge. Negative angle leans the face in, positive out (#1801).
 type DraftTool struct {
 	featureEditMode // set ⇒ this panel re-edits a committed draft (see editDraftTool)
 	faces           []FaceHandle
 	seededFaceKeys  [][]byte // edit mode: the feature's existing face keys
 	angleDeg        float64
+	mode            draftPickMode
+	pull            *FaceHandle   // pull-direction face (its normal); nil ⇒ default/seeded
+	neutral         *FaceHandle   // neutral parting-plane face; nil ⇒ default/seeded
+	seededPull      *math.Vector3 // edit mode: the committed pull direction (kept if not re-picked)
+	seededNeutral   *geom.Plane   // edit mode: the committed neutral plane (kept if not re-picked)
 	added           *feature.PartFeature
 }
 
@@ -35,16 +53,91 @@ func (t *DraftTool) Start(*Session) {}
 // AcceptedKinds declares draft picks faces (the faces to taper).
 func (t *DraftTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectFace} }
 
-// Picks reports the picked faces for the unified highlight.
-func (t *DraftTool) Picks() []Selectable { return selectables(t.faces) }
-
-// Pick appends the clicked face (ignoring a duplicate).
+// Pick routes the clicked face to the active slot: the pull-direction face, the neutral-plane face,
+// or (default) the faces to taper.
 func (t *DraftTool) Pick(_ *Session, sel Selectable) {
 	f, ok := sel.(FaceHandle)
-	if !ok || t.hasFace(f) {
+	if !ok {
 		return
 	}
-	t.faces = append(t.faces, f)
+	switch t.mode {
+	case pickDraftPull:
+		fc := f
+		t.pull = &fc
+	case pickDraftNeutral:
+		fc := f
+		t.neutral = &fc
+	default:
+		if !t.hasFace(f) {
+			t.faces = append(t.faces, f)
+		}
+	}
+}
+
+// Picks reports the tapered faces plus the pull and neutral faces for the unified highlight.
+func (t *DraftTool) Picks() []Selectable {
+	return appendPick(appendPick(selectables(t.faces), t.pull), t.neutral)
+}
+
+// SetPickMode / PickMode switch which slot the next viewport click fills.
+func (t *DraftTool) SetPickMode(m draftPickMode) { t.mode = m }
+func (t *DraftTool) PickMode() draftPickMode     { return t.mode }
+
+// PickingPull / PickingNeutral report the active pick slot (for the dialog's row highlight).
+func (t *DraftTool) PickingPull() bool    { return t.mode == pickDraftPull }
+func (t *DraftTool) PickingNeutral() bool { return t.mode == pickDraftNeutral }
+
+// SetPickingPull / SetPickingNeutral route the next viewport click to the pull-direction or
+// neutral-plane slot when enabled, or back to picking faces when disabled — the exported toggles
+// the head's dialog drives (mirrors ReplaceFaceTool.SetPickingTarget). Enabling one clears the
+// other so only one slot is armed at a time.
+func (t *DraftTool) SetPickingPull(on bool) {
+	if on {
+		t.mode = pickDraftPull
+		return
+	}
+	t.mode = pickDraftFaces
+}
+func (t *DraftTool) SetPickingNeutral(on bool) {
+	if on {
+		t.mode = pickDraftNeutral
+		return
+	}
+	t.mode = pickDraftFaces
+}
+
+// PullSet / NeutralSet report whether a pull face / neutral plane is in effect (picked or seeded).
+func (t *DraftTool) PullSet() bool    { return t.pull != nil || t.seededPull != nil }
+func (t *DraftTool) NeutralSet() bool { return t.neutral != nil || t.seededNeutral != nil }
+
+// ClearPull / ClearNeutral drop the pull / neutral input, reverting to the default (+Z / implicit
+// hinge), and return to picking faces.
+func (t *DraftTool) ClearPull()    { t.pull, t.seededPull, t.mode = nil, nil, pickDraftFaces }
+func (t *DraftTool) ClearNeutral() { t.neutral, t.seededNeutral, t.mode = nil, nil, pickDraftFaces }
+
+// pullVector resolves the pull direction: the picked face's normal, else the seeded (edit) direction,
+// else the +Z mould-pull default.
+func (t *DraftTool) pullVector() math.Vector3 {
+	if t.pull != nil {
+		if pl, ok := t.pull.Face.Geometry().(geom.Plane); ok {
+			return pl.Normal()
+		}
+	}
+	if t.seededPull != nil {
+		return *t.seededPull
+	}
+	return math.V3(0, 0, 1)
+}
+
+// neutralPlane resolves the neutral parting plane: the picked planar face, else the seeded (edit)
+// plane, else nil (the implicit lowest-vertex hinge).
+func (t *DraftTool) neutralPlane() *geom.Plane {
+	if t.neutral != nil {
+		if pl, ok := t.neutral.Face.Geometry().(geom.Plane); ok {
+			return &pl
+		}
+	}
+	return t.seededNeutral
 }
 
 func (t *DraftTool) hasFace(f FaceHandle) bool {
@@ -103,7 +196,7 @@ func (t *DraftTool) Commit(s *Session) error {
 // both Commit (the part's engine) and DraftFeature (a scratch engine).
 func (t *DraftTool) addDraft(dress *feature.DressUpFeatures) *feature.PartFeature {
 	rad := t.angleDeg * degToRad
-	return dress.AddDraft(t.selectedFaceKeys(), func() float64 { return rad })
+	return dress.AddDraftPullNeutral(t.selectedFaceKeys(), t.pullVector(), t.neutralPlane(), func() float64 { return rad })
 }
 
 // AddedFeature returns the feature created on commit (for inspection/tests).
@@ -142,6 +235,8 @@ func (t *DraftTool) commitEdit(s *Session) error {
 	def := t.target.Definition().(*feature.FaceDraftFeature).Definition()
 	def.FaceKeys = t.selectedFaceKeys()
 	def.Angle = konst(t.angleDeg * degToRad)
+	def.PullDir = t.pullVector()
+	def.Neutral = t.neutralPlane()
 	return commitFeatureEdit(s, t.target)
 }
 

--- a/app/draft_tool_test.go
+++ b/app/draft_tool_test.go
@@ -8,7 +8,20 @@ import (
 
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/feature"
 )
+
+// plusZFaceOf returns the body's +Z-facing planar face (the top of the block).
+func plusZFaceOf(t *testing.T, b *topo.Body) *topo.Face {
+	t.Helper()
+	for _, f := range b.Faces() {
+		if f.Geometry().NormalAt(0, 0).Z > 0.9 {
+			return f
+		}
+	}
+	t.Fatal("no +Z face found")
+	return nil
+}
 
 // plusXFaceOf returns the body's +X-facing planar face (a vertical side of the block).
 func plusXFaceOf(t *testing.T, b *topo.Body) *topo.Face {
@@ -74,6 +87,74 @@ func TestDraftViaRibbonCommand(t *testing.T) {
 	// The default angle is +3° (taper outward), so the volume changes from the 8 baseline.
 	if v := ops.BodyGeometryProperties(def.SurfaceBodies().Item(0), ops.DefaultQuality()).Volume; stdmath.Abs(v-8) < 1e-6 {
 		t.Errorf("draft did not change the body: volume %g, want ≠ 8", v)
+	}
+}
+
+// TestDraftToolPullAndNeutralPicks drives the pull-direction and neutral-plane pick slots: the
+// tool routes clicks by pick mode, and the committed draft carries the picked +X face normal as
+// its pull direction and the +Z (top) face as its neutral parting plane (#1801).
+func TestDraftToolPullAndNeutralPicks(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	sideX := FaceHandle{Face: plusXFaceOf(t, block), Body: block}
+	topZ := FaceHandle{Face: plusZFaceOf(t, block), Body: block}
+
+	d := NewDraftTool()
+	s.StartTool(d)
+	d.Pick(s, sideX) // faces to taper (default mode)
+
+	d.SetPickingPull(true)
+	if !d.PickingPull() {
+		t.Fatal("pull pick mode not armed")
+	}
+	d.Pick(s, sideX) // pull-direction face
+
+	d.SetPickingNeutral(true)
+	if !d.PickingNeutral() {
+		t.Fatal("neutral pick mode not armed")
+	}
+	d.Pick(s, topZ) // neutral parting plane
+	if !d.PullSet() || !d.NeutralSet() {
+		t.Fatalf("pull/neutral not registered: pull=%v neutral=%v", d.PullSet(), d.NeutralSet())
+	}
+
+	d.SetAngleDegrees(-stdmath.Atan(0.25) * 180 / stdmath.Pi)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+
+	def := d.AddedFeature().Definition().(*feature.FaceDraftFeature).Definition()
+	if def.PullDir.X < 0.9 {
+		t.Errorf("pull direction = %+v, want +X normal", def.PullDir)
+	}
+	if def.Neutral == nil {
+		t.Fatal("neutral plane not committed")
+	}
+	if nz := float64(def.Neutral.Normal().Z); stdmath.Abs(nz) < 0.9 {
+		t.Errorf("neutral normal Z = %g, want ±1 (the +Z top face)", nz)
+	}
+}
+
+// TestDraftToolClearPullNeutral checks the clear handlers drop the pull/neutral inputs and
+// return the tool to picking faces.
+func TestDraftToolClearPullNeutral(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	side := FaceHandle{Face: plusXFaceOf(t, block), Body: block}
+	top := FaceHandle{Face: plusZFaceOf(t, block), Body: block}
+
+	d := NewDraftTool()
+	s.StartTool(d)
+	d.SetPickingPull(true)
+	d.Pick(s, side)
+	d.SetPickingNeutral(true)
+	d.Pick(s, top)
+
+	d.ClearPull()
+	if d.PullSet() || d.PickingPull() {
+		t.Error("pull not cleared / mode not reset")
+	}
+	d.ClearNeutral()
+	if d.NeutralSet() || d.PickingNeutral() {
+		t.Error("neutral not cleared / mode not reset")
 	}
 }
 

--- a/app/feature_edit_mode.go
+++ b/app/feature_edit_mode.go
@@ -343,6 +343,9 @@ func editDraftTool(f *feature.PartFeature, d *feature.FaceDraftFeature) *DraftTo
 	t := NewDraftTool()
 	t.seededFaceKeys = cloneKeys(def.FaceKeys)
 	t.angleDeg = callOrZeroFn(def.Angle) / degToRad
+	pull := def.PullDir
+	t.seededPull = &pull
+	t.seededNeutral = def.Neutral
 	t.bindEdit(f, snapshotDraftDef(def))
 	return t
 }

--- a/head/ui/draft_dialog.go
+++ b/head/ui/draft_dialog.go
@@ -39,6 +39,8 @@ func drawDraftDialog(s *app.Session) {
 		if propertySection("Input Geometry") {
 			drawPickChipRow("Faces", "draft-faces", countChipText(d.FaceCount(), "Face", "Select Faces"),
 				d.FaceCount() > 0, "Click faces in the viewport to draft", d.ClearFaces)
+			drawDraftPullRow(d)
+			drawDraftNeutralRow(d)
 		}
 		if propertySection("Behavior") {
 			angleDegRowHint(s, "Angle", "draft-angle", " (+out / −in)", &draftUI.angle)
@@ -48,4 +50,28 @@ func drawDraftDialog(s *app.Session) {
 		drawCommitCancelButtons(s, d.CanCommit())
 	}
 	native.End()
+}
+
+// drawDraftPullRow shows the pull-direction chip (the face whose normal is the mould-pull axis,
+// defaulting to +Z when unset) and the toggle that routes the next viewport click to it.
+func drawDraftPullRow(d *app.DraftTool) {
+	drawPickChipRow("Pull direction", "draft-pull", pickChipText(d.PullSet(), "1 Face", "+Z (default)"),
+		d.PullSet(), "The face whose normal is the mould-pull direction", d.ClearPull)
+	propertyRow("")
+	pickPull := d.PickingPull()
+	if native.Checkbox("Pick pull face", &pickPull) {
+		d.SetPickingPull(pickPull)
+	}
+}
+
+// drawDraftNeutralRow shows the neutral (parting) plane chip and the toggle that routes the next
+// viewport click to it. With no neutral plane each face pivots on its implicit lowest-vertex hinge.
+func drawDraftNeutralRow(d *app.DraftTool) {
+	drawPickChipRow("Neutral plane", "draft-neutral", pickChipText(d.NeutralSet(), "1 Face", "None"),
+		d.NeutralSet(), "The parting plane the taper pivots about", d.ClearNeutral)
+	propertyRow("")
+	pickNeutral := d.PickingNeutral()
+	if native.Checkbox("Pick neutral plane", &pickNeutral) {
+		d.SetPickingNeutral(pickNeutral)
+	}
 }

--- a/kernel/ops/draft.go
+++ b/kernel/ops/draft.go
@@ -19,6 +19,15 @@ import (
 // material toward the far end); a POSITIVE angle leans it outward (adds material). See the
 // convention pinned by TestDraftTapersSideFace, which drafts inward with a negative angle.
 func DraftFaces(solid *topo.Body, faceKeys [][]byte, pull math.Vector3, angle float64) (*topo.Body, error) {
+	return DraftFacesNeutral(solid, faceKeys, pull, nil, angle)
+}
+
+// DraftFacesNeutral is DraftFaces with an explicit NEUTRAL PLANE — the fixed reference each drafted
+// face pivots about (mould-parting plane). When neutral is non-nil each hinge is the line where the
+// face meets it (OCCT BRepOffsetAPI_DraftAngle's neutral-plane construction); when nil the hinge
+// falls back to the implicit plane ⊥ pull through the face's lowest vertex (#1801). Faces parallel to
+// the neutral plane (no hinge) are left unchanged.
+func DraftFacesNeutral(solid *topo.Body, faceKeys [][]byte, pull math.Vector3, neutral *geom.Plane, angle float64) (*topo.Body, error) {
 	p, perr := math.UnitVector3FromVector(pull)
 	if perr != nil {
 		return nil, perr
@@ -26,23 +35,22 @@ func DraftFaces(solid *topo.Body, faceKeys [][]byte, pull math.Vector3, angle fl
 	// #1802 (ADR-0050 P7): the modifier-visitor tilts the drafted planar faces and re-intersects the
 	// neighbours — so a body carrying curved faces from a prior fillet drafts into a valid tapered
 	// solid (its fillet edges re-trimmed to arcs) instead of panicking in the plane-only rebuild.
-	mod, err := newDraftMod(solid, faceKeys, p, angle)
+	mod, err := newDraftMod(solid, faceKeys, p, neutral, angle)
 	if err != nil {
 		return nil, err
 	}
 	return modifyBody(solid, mod, "draft"), nil
 }
 
-// draftedPlane returns a face's plane rotated by angle about its hinge (pull × normal),
-// pivoting on the face's lowest vertex along pull. Returns the unchanged plane when the
-// face is perpendicular to pull (the hinge is undefined).
-func draftedPlane(f *topo.Face, pull math.UnitVector3, angle float64) geom.Plane {
+// draftedPlane returns a face's plane rotated by angle about its draft hinge, pivoting on a point of
+// that hinge. Returns the unchanged plane when the hinge is undefined (face parallel to pull, or to
+// the neutral plane).
+func draftedPlane(f *topo.Face, pull math.UnitVector3, neutral *geom.Plane, angle float64) geom.Plane {
 	pl := f.Geometry().(geom.Plane)
-	hinge, err := math.UnitVector3FromVector(pull.AsVector().Cross(pl.Normal()))
-	if err != nil {
-		return pl // face normal parallel to pull → no draft
+	hinge, pivot, ok := draftHinge(f, pl, pull, neutral)
+	if !ok {
+		return pl
 	}
-	pivot := lowestVertexAlong(f, pull)
 	rot := math.Rotation4(angle, hinge, pivot)
 	newN := rot.TransformVector(pl.Normal())
 	moved, perr := geom.NewPlane(pivot, newN)
@@ -50,6 +58,39 @@ func draftedPlane(f *topo.Face, pull math.UnitVector3, angle float64) geom.Plane
 		return pl
 	}
 	return moved
+}
+
+// draftHinge returns the rotation axis and a pivot point for drafting face pl: the line where pl meets
+// the neutral plane when one is given (the user-chosen parting reference), else the implicit hinge
+// pull × normal through the face's lowest vertex along pull. ok=false when no hinge exists.
+func draftHinge(f *topo.Face, pl geom.Plane, pull math.UnitVector3, neutral *geom.Plane) (math.UnitVector3, math.Point3, bool) {
+	if neutral != nil {
+		return neutralHinge(pl, *neutral)
+	}
+	hinge, err := math.UnitVector3FromVector(pull.AsVector().Cross(pl.Normal()))
+	if err != nil {
+		return math.UnitVector3{}, math.Point3{}, false // face normal parallel to pull → no draft
+	}
+	return hinge, lowestVertexAlong(f, pull), true
+}
+
+// neutralHinge is the intersection line of the face plane and the neutral plane — the fixed edge the
+// drafted face pivots about. Direction = n_face × n_neutral; the pivot is the closest point of that
+// line to the world origin (any point on the line is a valid rotation pivot). ok=false when the two
+// planes are parallel.
+func neutralHinge(face, neutral geom.Plane) (math.UnitVector3, math.Point3, bool) {
+	n1, n2 := face.Normal(), neutral.Normal()
+	dir, err := math.UnitVector3FromVector(n1.Cross(n2))
+	if err != nil {
+		return math.UnitVector3{}, math.Point3{}, false // parallel planes
+	}
+	c := float64(n1.Dot(n2))
+	d1 := float64(n1.Dot(face.Origin.AsVector()))
+	d2 := float64(n2.Dot(neutral.Origin.AsVector()))
+	denom := 1 - c*c
+	a, b := (d1-d2*c)/denom, (d2-d1*c)/denom
+	pivot := math.P3(0, 0, 0).TranslateBy(n1.Scale(math.Scalar(a))).TranslateBy(n2.Scale(math.Scalar(b)))
+	return dir, pivot, true
 }
 
 // lowestVertexAlong returns the face vertex with the smallest projection onto pull — a

--- a/kernel/ops/draft_mod.go
+++ b/kernel/ops/draft_mod.go
@@ -28,7 +28,7 @@ type draftMod struct {
 // tilted face to the meeting point of its adjacent (new) surfaces, and re-intersect every edge that
 // touches a relocated vertex. Errors if a selected face is not planar (curved-face draft is future
 // work — the plane-only tilt does not yet apply to a cylinder/cone selected face).
-func newDraftMod(solid *topo.Body, faceKeys [][]byte, pull math.UnitVector3, angle float64) (*draftMod, error) {
+func newDraftMod(solid *topo.Body, faceKeys [][]byte, pull math.UnitVector3, neutral *geom.Plane, angle float64) (*draftMod, error) {
 	sel, err := resolveFaceSet(solid, faceKeys)
 	if err != nil {
 		return nil, err
@@ -38,7 +38,7 @@ func newDraftMod(solid *topo.Body, faceKeys [][]byte, pull math.UnitVector3, ang
 		faceSurf: map[uint64]geom.Surface{}, newSurf: map[uint64]geom.Surface{},
 		newPoint: map[uint64]math.Point3{}, newCurve: map[uint64]geom.Curve3{},
 	}
-	if err := d.tiltSelectedFaces(solid, pull, angle); err != nil {
+	if err := d.tiltSelectedFaces(solid, pull, neutral, angle); err != nil {
 		return nil, err
 	}
 	moved := d.relocateVertices(solid)
@@ -50,7 +50,7 @@ func newDraftMod(solid *topo.Body, faceKeys [][]byte, pull math.UnitVector3, ang
 
 // tiltSelectedFaces rotates each selected planar face about its hinge and records both the tilted
 // surface (newSurf) and every face's effective surface (faceSurf) for the re-intersection.
-func (d *draftMod) tiltSelectedFaces(solid *topo.Body, pull math.UnitVector3, angle float64) error {
+func (d *draftMod) tiltSelectedFaces(solid *topo.Body, pull math.UnitVector3, neutral *geom.Plane, angle float64) error {
 	for _, f := range solid.Faces() {
 		if !d.selected[f.ID()] {
 			d.faceSurf[f.ID()] = f.Geometry()
@@ -59,7 +59,7 @@ func (d *draftMod) tiltSelectedFaces(solid *topo.Body, pull math.UnitVector3, an
 		if _, ok := f.Geometry().(geom.Plane); !ok {
 			return fmt.Errorf("draft: selected face %d is %T; only planar faces can be drafted (curved-face draft is future work)", f.ID(), f.Geometry())
 		}
-		tilted := draftedPlane(f, pull, angle)
+		tilted := draftedPlane(f, pull, neutral, angle)
 		d.faceSurf[f.ID()], d.newSurf[f.ID()] = tilted, tilted
 	}
 	return nil

--- a/kernel/ops/draft_neutral_internal_test.go
+++ b/kernel/ops/draft_neutral_internal_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// TestNeutralHingeIsPlaneIntersection checks the neutral-plane hinge (#1801): drafting the +X face
+// about a neutral plane at z=1 must pivot on the line x=2,z=1 (direction ±Y), not the face's lowest
+// vertex. Both the direction and a point on it are verified against the two planes exactly.
+func TestNeutralHingeIsPlaneIntersection(t *testing.T) {
+	face, _ := geom.NewPlane(math.P3(2, 0, 0), math.V3(1, 0, 0))    // +X face at x=2
+	neutral, _ := geom.NewPlane(math.P3(0, 0, 1), math.V3(0, 0, 1)) // z=1
+
+	dir, pivot, ok := neutralHinge(face, neutral)
+	if !ok {
+		t.Fatal("neutralHinge returned ok=false for two perpendicular planes")
+	}
+	// Direction is ±Y (perpendicular to both normals).
+	if stdmath.Abs(float64(dir.X())) > 1e-12 || stdmath.Abs(float64(dir.Z())) > 1e-12 ||
+		stdmath.Abs(stdmath.Abs(float64(dir.Y()))-1) > 1e-12 {
+		t.Errorf("hinge direction = %v, want ±Y", dir)
+	}
+	// Pivot lies on BOTH planes.
+	if d := geom.SignedDistanceToPlane(face, pivot); stdmath.Abs(d) > 1e-9 {
+		t.Errorf("pivot %v is %g off the face plane (x=2)", pivot, d)
+	}
+	if d := geom.SignedDistanceToPlane(neutral, pivot); stdmath.Abs(d) > 1e-9 {
+		t.Errorf("pivot %v is %g off the neutral plane (z=1)", pivot, d)
+	}
+}
+
+// TestNeutralHingeParallelPlanesNoHinge: a neutral plane parallel to the face has no intersection line.
+func TestNeutralHingeParallelPlanesNoHinge(t *testing.T) {
+	face, _ := geom.NewPlane(math.P3(2, 0, 0), math.V3(1, 0, 0))
+	neutral, _ := geom.NewPlane(math.P3(5, 0, 0), math.V3(1, 0, 0)) // parallel to the face
+	if _, _, ok := neutralHinge(face, neutral); ok {
+		t.Error("parallel planes must yield no hinge (ok=false)")
+	}
+}

--- a/kernel/ops/draft_neutral_test.go
+++ b/kernel/ops/draft_neutral_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// TestDraftFacesNeutralPivotsOnNeutralPlane is the #1801 acceptance for the neutral plane: drafting
+// the +X face of a box about a neutral plane at z=1 pivots the face on the line x=2,z=1 — so a point
+// on that line stays fixed, whereas the implicit (no-neutral) hinge would pin the bottom edge (z=0).
+// The result is a valid tapered solid.
+func TestDraftFacesNeutralPivotsOnNeutralPlane(t *testing.T) {
+	box := csgBox(math.P3(0, 0, 0), 2, 2, 2)
+	side := plusXFaceKey(t, box)
+	neutral, _ := geom.NewPlane(math.P3(0, 0, 1), math.V3(0, 0, 1)) // z=1, the mid-height parting plane
+
+	res, err := ops.DraftFacesNeutral(box, [][]byte{side}, math.V3(0, 0, 1), &neutral, stdmath.Atan(0.2))
+	if err != nil {
+		t.Fatalf("draft with neutral plane: %v", err)
+	}
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("neutral-plane draft is not a valid solid: %+v", r.Issues)
+	}
+	drafted := mostPlusXFace(res)
+	if drafted == nil {
+		t.Fatal("no drafted +X face in the result")
+	}
+	pl, ok := drafted.Geometry().(geom.Plane)
+	if !ok {
+		t.Fatalf("drafted face is %T, want a plane", drafted.Geometry())
+	}
+	// A point on the neutral∩face hinge (x=2, z=1) must remain on the drafted plane (unmoved pivot).
+	if d := geom.SignedDistanceToPlane(pl, math.P3(2, 1, 1)); stdmath.Abs(d) > 1e-6 {
+		t.Errorf("hinge point (2,1,1) is %g off the drafted plane — neutral plane is not the fixed pivot", d)
+	}
+}
+
+// plusXFaceKey returns the reference key of the box face whose outward normal is +X.
+func plusXFaceKey(t *testing.T, b *topo.Body) []byte {
+	t.Helper()
+	for _, f := range b.Faces() {
+		if n := f.Geometry().NormalAt(0, 0); stdmath.Abs(float64(n.X)-1) < 1e-9 {
+			return f.ReferenceKey()
+		}
+	}
+	t.Fatal("no +X face")
+	return nil
+}
+
+// mostPlusXFace returns the planar face whose normal has the largest +X component (the drafted wall).
+func mostPlusXFace(b *topo.Body) *topo.Face {
+	var best *topo.Face
+	bestX := 0.5
+	for _, f := range b.Faces() {
+		if _, ok := f.Geometry().(geom.Plane); !ok {
+			continue
+		}
+		if x := float64(f.Geometry().NormalAt(0, 0).X); x > bestX {
+			bestX, best = x, f
+		}
+	}
+	return best
+}

--- a/kernel/ops/draft_neutral_test.go
+++ b/kernel/ops/draft_neutral_test.go
@@ -42,6 +42,31 @@ func TestDraftFacesNeutralPivotsOnNeutralPlane(t *testing.T) {
 	}
 }
 
+// TestDraftFacesNeutralVolumeMatchesOCCT grounds the neutral-plane draft against OCCT
+// BRepOffsetAPI_DraftAngle (the oracle rule): drafting the +X face of a 2×2×2 box by 10°
+// about a neutral plane at z=0.5 removes/adds a wedge of exactly ½·|z-centroid asymmetry|.
+// OCCT reports 7.6473460386 for this case; the box is 8, so the wedge magnitude is
+// 0.352662. Our sign convention may lean the face the other way, so we compare |Δvol|.
+// Analytic: ∫₀²2·(z−0.5)·tan10° dz = tan10° = 0.1763269, ×2 = 0.3526538 (OCCT 0.3526540).
+func TestDraftFacesNeutralVolumeMatchesOCCT(t *testing.T) {
+	box := csgBox(math.P3(0, 0, 0), 2, 2, 2)
+	side := plusXFaceKey(t, box)
+	neutral, _ := geom.NewPlane(math.P3(0, 0, 0.5), math.V3(0, 0, 1))
+
+	res, err := ops.DraftFacesNeutral(box, [][]byte{side}, math.V3(0, 0, 1), &neutral, 10*stdmath.Pi/180)
+	if err != nil {
+		t.Fatalf("draft with neutral plane: %v", err)
+	}
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("neutral-plane draft is not a valid solid: %+v", r.Issues)
+	}
+	vol := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume
+	const occtWedge = 0.3526540 // 8 − 7.6473460386, from BRepOffsetAPI_DraftAngle
+	if got := stdmath.Abs(vol - 8); stdmath.Abs(got-occtWedge) > 1e-4 {
+		t.Errorf("neutral-draft wedge = %g (vol %g), OCCT oracle wants %g", got, vol, occtWedge)
+	}
+}
+
 // plusXFaceKey returns the reference key of the box face whose outward normal is +X.
 func plusXFaceKey(t *testing.T, b *topo.Body) []byte {
 	t.Helper()

--- a/model/feature/draft.go
+++ b/model/feature/draft.go
@@ -5,19 +5,21 @@ package feature
 import (
 	"fmt"
 
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/math"
 )
 
-// draftBody tapers the picked faces of the running body about the pull direction by angle
-// (via ops.DraftFaces) and replaces it; a lost face key (surfaced by the op) makes the
-// feature go Sick. See kernel/ops/draft.go for the geometry.
-func draftBody(in Input, faceKeys [][]byte, pull math.Vector3, angle float64, feat string) (Output, error) {
+// draftBody tapers the picked faces of the running body about the pull direction by angle (via
+// ops.DraftFacesNeutral) and replaces it; when neutral is non-nil each face pivots on the line where
+// it meets that parting plane (#1801), else on the implicit lowest-vertex hinge. A lost face key
+// (surfaced by the op) makes the feature go Sick. See kernel/ops/draft.go for the geometry.
+func draftBody(in Input, faceKeys [][]byte, pull math.Vector3, neutral *geom.Plane, angle float64, feat string) (Output, error) {
 	body, err := runningBody(in)
 	if err != nil {
 		return Output{}, err
 	}
-	result, err := ops.DraftFaces(body, faceKeys, pull, angle)
+	result, err := ops.DraftFacesNeutral(body, faceKeys, pull, neutral, angle)
 	if err != nil {
 		return Output{}, fmt.Errorf("%s: %w", feat, err)
 	}

--- a/model/feature/dressup.go
+++ b/model/feature/dressup.go
@@ -194,10 +194,12 @@ func (s *ShellFeature) Recompute(in Input) (Output, error) {
 	return shellBody(in, keys, callOrZero(s.def.Thickness), featOr(s.featName, "shell"))
 }
 
-// FaceDraftDefinition tapers selected faces by an angle about a pull direction.
+// FaceDraftDefinition tapers selected faces by an angle about a pull direction. Neutral, when set, is
+// the fixed parting plane each face pivots on (#1801); nil ⇒ the implicit lowest-vertex hinge.
 type FaceDraftDefinition struct {
 	FaceKeys  [][]byte
 	PullDir   math.Vector3
+	Neutral   *geom.Plane
 	Angle     func() float64
 	GeomFaces []topo.GeometricFaceRef // externally-authored drafted faces by geometric descriptor (ADR-0040)
 }
@@ -214,7 +216,7 @@ func (d *FaceDraftFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	return draftBody(in, keys, d.def.PullDir, callOrZero(d.def.Angle), "draft")
+	return draftBody(in, keys, d.def.PullDir, d.def.Neutral, callOrZero(d.def.Angle), "draft")
 }
 
 // ThreadDefinition applies thread data to a cylindrical face. Cut=false is a cosmetic thread
@@ -469,9 +471,15 @@ func (c *DressUpFeatures) AddDraft(faceKeys [][]byte, angle func() float64) *Par
 	return c.AddDraftPull(faceKeys, math.V3(0, 0, 1), angle)
 }
 
-// AddDraftPull tapers the given faces by angle about an explicit pull direction.
+// AddDraftPull tapers the given faces by angle about an explicit pull direction (implicit hinge).
 func (c *DressUpFeatures) AddDraftPull(faceKeys [][]byte, pull math.Vector3, angle func() float64) *PartFeature {
-	return c.engine.Add(&FaceDraftFeature{def: &FaceDraftDefinition{FaceKeys: faceKeys, PullDir: pull, Angle: angle}})
+	return c.AddDraftPullNeutral(faceKeys, pull, nil, angle)
+}
+
+// AddDraftPullNeutral tapers the given faces by angle about an explicit pull direction, pivoting each
+// face on the fixed neutral (parting) plane when one is given (#1801); nil ⇒ the implicit hinge.
+func (c *DressUpFeatures) AddDraftPullNeutral(faceKeys [][]byte, pull math.Vector3, neutral *geom.Plane, angle func() float64) *PartFeature {
+	return c.engine.Add(&FaceDraftFeature{def: &FaceDraftDefinition{FaceKeys: faceKeys, PullDir: pull, Neutral: neutral, Angle: angle}})
 }
 
 // addShell / addFaceDraft add a face dress-up from a fully-built definition (used by the

--- a/model/feature/serialize_codecs_dressup.go
+++ b/model/feature/serialize_codecs_dressup.go
@@ -76,7 +76,9 @@ func (r featureCodecSet) registerDressUpCodecs() {
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			df := f.(*FaceDraftFeature)
 			p := df.def.PullDir
-			fd.Draft = &FaceDressData{Faces: encodeKeys(df.def.FaceKeys), Value: evalFloat(df.def.Angle), Pull: []float64{p.X, p.Y, p.Z}, GeomFaces: encodeGeomFaces(df.def.GeomFaces)}
+			no, nn := neutralData(df.def.Neutral)
+			fd.Draft = &FaceDressData{Faces: encodeKeys(df.def.FaceKeys), Value: evalFloat(df.def.Angle),
+				Pull: []float64{p.X, p.Y, p.Z}, NeutralOrigin: no, NeutralNormal: nn, GeomFaces: encodeGeomFaces(df.def.GeomFaces)}
 			return nil
 		},
 		decode: decodeDraft,
@@ -226,6 +228,7 @@ func decodeDraft(rc *restoreContext, fd FeatureData) (*PartFeature, error) {
 		return nil, err
 	}
 	return NewDressUpFeatures(rc.fs).addFaceDraft(&FaceDraftDefinition{
-		FaceKeys: d.keys, GeomFaces: d.geomFaces, PullDir: draftPull(fd.Draft.Pull), Angle: constFloat(d.value),
+		FaceKeys: d.keys, GeomFaces: d.geomFaces, PullDir: draftPull(fd.Draft.Pull),
+		Neutral: draftNeutral(fd.Draft.NeutralOrigin, fd.Draft.NeutralNormal), Angle: constFloat(d.value),
 	}), nil
 }

--- a/model/feature/serialize_dressup.go
+++ b/model/feature/serialize_dressup.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 )
@@ -19,6 +20,29 @@ func draftPull(p []float64) math.Vector3 {
 		return math.V3(0, 0, 1)
 	}
 	return math.V3(p[0], p[1], p[2])
+}
+
+// draftNeutral reads a serialized draft neutral (parting) plane from its origin and normal, or nil when
+// absent/degenerate — the implicit lowest-vertex hinge (#1801).
+func draftNeutral(origin, normal []float64) *geom.Plane {
+	if len(origin) != 3 || len(normal) != 3 {
+		return nil
+	}
+	pl, err := geom.NewPlane(math.P3(origin[0], origin[1], origin[2]), math.V3(normal[0], normal[1], normal[2]))
+	if err != nil {
+		return nil
+	}
+	return &pl
+}
+
+// neutralData serializes a draft neutral plane to (origin, normal) float triples, or (nil, nil) when
+// no neutral plane is set.
+func neutralData(pl *geom.Plane) (origin, normal []float64) {
+	if pl == nil {
+		return nil, nil
+	}
+	n := pl.Normal()
+	return []float64{pl.Origin.X, pl.Origin.Y, pl.Origin.Z}, []float64{float64(n.X), float64(n.Y), float64(n.Z)}
 }
 
 // This file holds the YAML codecs for the dress-up family (fillet/chamfer/shell/draft/
@@ -193,9 +217,11 @@ func restoreRadiusPoints(pts []FilletRadiusPointData) []FilletRadiusPoint {
 // FaceDressData is a face-based dress-up (shell thickness / draft angle): the picked
 // faces as reference keys plus the scalar value, and (draft only) the pull direction.
 type FaceDressData struct {
-	Faces []string  `yaml:"faces"`
-	Value float64   `yaml:"value"`
-	Pull  []float64 `yaml:"pull,omitempty"` // draft pull direction (dx,dy,dz); absent ⇒ +Z
+	Faces         []string  `yaml:"faces"`
+	Value         float64   `yaml:"value"`
+	Pull          []float64 `yaml:"pull,omitempty"`          // draft pull direction (dx,dy,dz); absent ⇒ +Z
+	NeutralOrigin []float64 `yaml:"neutralOrigin,omitempty"` // draft neutral (parting) plane origin (x,y,z); absent ⇒ implicit hinge
+	NeutralNormal []float64 `yaml:"neutralNormal,omitempty"` // draft neutral plane normal (nx,ny,nz)
 	// GeomFaces are faces selected by a serialized GEOMETRIC descriptor (ADR-0040), the
 	// path the NX exporter uses since it cannot mint Oblikovati lineage keys. Empty for an
 	// Oblikovati-authored dress-up (which uses Faces).

--- a/model/feature/serialize_test.go
+++ b/model/feature/serialize_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/math"
 	"oblikovati.org/model/sketch"
@@ -87,6 +88,36 @@ func TestDressUpFeaturesRoundTrip(t *testing.T) {
 	thread := fresh.Item(4).Definition().(*ThreadFeature).Definition()
 	if string(thread.FaceKey) != "face-c" || thread.Designation != "M6x1" {
 		t.Errorf("thread = key %q designation %q, want face-c M6x1", thread.FaceKey, thread.Designation)
+	}
+}
+
+// TestDraftPullNeutralRoundTrip checks a draft's explicit pull direction and neutral (parting) plane
+// survive a recipe round trip (#1801).
+func TestDraftPullNeutralRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	neutral, _ := geom.NewPlane(math.P3(0, 0, 3), math.V3(0, 0, 1))
+	NewDressUpFeatures(fs).AddDraftPullNeutral([][]byte{[]byte("face-x")}, math.V3(1, 0, 0), &neutral, func() float64 { return 0.1 })
+
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	def := fresh.Item(0).Definition().(*FaceDraftFeature).Definition()
+	if def.PullDir != (math.V3(1, 0, 0)) {
+		t.Errorf("pull dir = %v, want (1,0,0)", def.PullDir)
+	}
+	if def.Neutral == nil {
+		t.Fatal("neutral plane lost in round trip")
+	}
+	if d := geom.SignedDistanceToPlane(*def.Neutral, math.P3(0, 0, 3)); d > 1e-9 || d < -1e-9 {
+		t.Errorf("neutral plane origin moved: (0,0,3) is %g off it", d)
+	}
+	if n := def.Neutral.Normal(); n.Z < 0.999 {
+		t.Errorf("neutral normal = %v, want +Z", n)
 	}
 }
 


### PR DESCRIPTION
## What

Give the **Draft** feature the two inputs it was missing (#1801): a **pull
direction** (previously hard-coded to +Z) and an optional **neutral parting
plane** (previously none — every face pivoted on its implicit lowest-vertex
hinge). Both are pickable in the viewport and drawn in the head's Draft dialog.

- **Kernel** (`kernel/ops/draft*.go`): `DraftFacesNeutral` computes the hinge
  as the exact `face ∩ neutral` plane-intersection line (closed-form, direction
  `n_face × n_neutral`, pivot on both planes). No neutral plane ⇒ the previous
  implicit lowest-vertex hinge (backward compatible).
- **Model** (`model/feature`): `FaceDraftDefinition.Neutral`, threaded through
  recompute and the recipe codec (round-trips as neutral origin+normal).
- **App** (`app/draft_tool.go`): the tool routes viewport clicks to three slots
  — faces / pull-direction face / neutral-plane face — via an exported pick-mode
  toggle mirroring `ReplaceFaceTool`. Edit mode seeds the committed pull/neutral.
- **Head** (`head/ui/draft_dialog.go`): "Pull direction" and "Neutral plane"
  pick-chip rows with pick-face checkboxes.

## Why

Closes the last open item in milestone **OCCT fillet/chamfer/draft parity
(ADR-0050)**. OCCT's `BRepOffsetAPI_DraftAngle` takes exactly these inputs
(pull direction + neutral plane per face); Oblikovati now matches that surface.

## Verification (OCCT-grounded)

- Numeric oracle: a 10° draft of a box +X face about a z=0.5 neutral plane
  removes a wedge of magnitude **0.352654**, matching OCCT
  `BRepOffsetAPI_DraftAngle` (`8 − 7.6473460386`) to <1e-4
  (`TestDraftFacesNeutralVolumeMatchesOCCT`).
- Invariant: the hinge point stays fixed on the drafted plane
  (`TestDraftFacesNeutralPivotsOnNeutralPlane`).
- App: tool routing + committed def carry the picked pull/neutral
  (`TestDraftToolPullAndNeutralPicks`, `TestDraftToolClearPullNeutral`).
- Recipe round-trip (`TestDraftPullNeutralRoundTrip`).
- Live: drove the head over the MCP bridge, opened the Draft command, and
  captured the dialog — it renders the new Pull-direction (+Z default) and
  Neutral-plane (None) rows with their pick toggles.

Public API/MCP exposure of pull+neutral is intentionally out of scope here (a
follow-up); this PR is the kernel/model/app/head path.

Closes #1801

🤖 Generated with [Claude Code](https://claude.com/claude-code)