### PR TITLE
feat(revolve): select revolved region by interior seed point

### DIFF
--- a/model/feature/serialize_extrude.go
+++ b/model/feature/serialize_extrude.go
@@ -142,6 +142,15 @@ func resolveSeeds(skt *sketch.Sketch, seeds [][]float64, fallback []int) []int {
 	return idx
 }
 
+// resolveSeed maps a single interior seed point to the region that contains it, falling back to
+// the given index when the seed is absent or unresolved. The single-region form used by revolve.
+func resolveSeed(skt *sketch.Sketch, seed []float64, fallback int) int {
+	if idx := resolveSeeds(skt, [][]float64{seed}, []int{fallback}); len(idx) > 0 {
+		return idx[0]
+	}
+	return fallback
+}
+
 // restoreExtent rebuilds the extent from its recipe, resolving any work-plane targets.
 func restoreExtent(ed *ExtrudeData, work *WorkGeometry) (Extent, error) {
 	ext := Extent{Type: parseExtentName(ed.Extent), Direction: parseDirectionName(ed.Direction)}

--- a/model/feature/serialize_extrude_seeds_test.go
+++ b/model/feature/serialize_extrude_seeds_test.go
@@ -55,3 +55,19 @@ func TestResolveSeedsFallsBack(t *testing.T) {
 		t.Errorf("unmatched seed: want fallback [5], got %v", got)
 	}
 }
+
+func TestResolveSeedSingleRegion(t *testing.T) {
+	sk := splitRectSketch()
+	// a seed in the large region resolves to whichever index holds area 6
+	got := resolveSeed(sk, []float64{2.5, 1}, 0)
+	if a := sk.Profiles().Item(got).Area(); stdmath.Abs(a-6) > 1e-6 {
+		t.Errorf("seed (2.5,1) resolved to a region of area %v, want the area-6 region", a)
+	}
+	// no seed / unmatched seed -> the fallback index
+	if got := resolveSeed(sk, nil, 3); got != 3 {
+		t.Errorf("no seed: want fallback 3, got %d", got)
+	}
+	if got := resolveSeed(sk, []float64{99, 99}, 5); got != 5 {
+		t.Errorf("unmatched seed: want fallback 5, got %d", got)
+	}
+}

--- a/model/feature/serialize_work.go
+++ b/model/feature/serialize_work.go
@@ -317,6 +317,10 @@ type RevolveData struct {
 	Angle      float64 `yaml:"angle,omitempty"`      // 0 ⇒ full revolution
 	Angle2     float64 `yaml:"angle2,omitempty"`     // second-direction sweep (#313)
 	Operation  string  `yaml:"operation"`
+	// ProfilePoint selects the revolved region by an interior seed point (sketch 2-D cm) rather
+	// than by index, since an external author cannot predict the reader's region ordering. When
+	// present it wins over Profile; absent, the index is used unchanged.
+	ProfilePoint []float64 `yaml:"profilePoint,omitempty"`
 }
 
 func serializeRevolve(def *RevolveDefinition, sk SketchIndexer) (*RevolveData, error) {
@@ -365,6 +369,7 @@ func restoreRevolve(fs *PartFeatures, d *RevolveData, sk SketchIndexer, work *Wo
 		return nil, err
 	}
 	angle := d.Angle
+	profile := resolveSeed(skt, d.ProfilePoint, d.Profile)
 	if d.AxisSketch > 0 { // a specific centerline (1-based index)
 		axisSk, ok := sk.At(d.AxisSketch - 1)
 		if !ok {
@@ -373,11 +378,11 @@ func restoreRevolve(fs *PartFeatures, d *RevolveData, sk SketchIndexer, work *Wo
 		if d.AxisLine < 0 || d.AxisLine >= axisSk.Lines().Count() {
 			return nil, fmt.Errorf("revolve axis centerline references line %d out of range", d.AxisLine)
 		}
-		pf := NewRevolveFeatures(fs).AddAboutCenterlineLine(skt, d.Profile, axisSk, axisSk.Lines().Item(d.AxisLine), func() float64 { return angle }, op)
+		pf := NewRevolveFeatures(fs).AddAboutCenterlineLine(skt, profile, axisSk, axisSk.Lines().Item(d.AxisLine), func() float64 { return angle }, op)
 		return restoreSecondAngle(pf, d.Angle2), nil
 	}
 	if d.Axis == "" { // revolve about the profile sketch's own (single) centerline
-		pf := NewRevolveFeatures(fs).AddAboutCenterline(skt, d.Profile, func() float64 { return angle }, op)
+		pf := NewRevolveFeatures(fs).AddAboutCenterline(skt, profile, func() float64 { return angle }, op)
 		return restoreSecondAngle(pf, d.Angle2), nil
 	}
 	if work == nil {
@@ -389,10 +394,10 @@ func restoreRevolve(fs *PartFeatures, d *RevolveData, sk SketchIndexer, work *Wo
 	}
 	if d.Angle2 > 0 {
 		angle2 := d.Angle2
-		return NewRevolveFeatures(fs).AddTwoDirectional(skt, d.Profile, axis,
+		return NewRevolveFeatures(fs).AddTwoDirectional(skt, profile, axis,
 			func() float64 { return angle }, func() float64 { return angle2 }, op), nil
 	}
-	return NewRevolveFeatures(fs).Add(skt, d.Profile, axis, func() float64 { return angle }, op), nil
+	return NewRevolveFeatures(fs).Add(skt, profile, axis, func() float64 { return angle }, op), nil
 }
 
 // restoreSecondAngle re-applies a persisted second-direction sweep onto a


### PR DESCRIPTION
Mirrors the merged extrude `profilePoints` fix (#1810) for revolve: adds `RevolveData.profilePoint` (one interior seed, sketch 2-D cm), resolved to the containing region via `Profile.Contains`.

An external author (the Inventor exporter) cannot predict the reader's DCEL region ordering, so selecting a revolve's region by **index** picks the wrong region — often a sliver — and the revolve produces little or no solid. `resolveSeed` is the single-region form of `resolveSeeds`; it falls back to the profile index when no seed is present or none resolves. Fully back-compatible.

Measured with the paired exporter change: a revolved body part goes from **-99% → -71%** of true volume, no regressions. Test: `TestResolveSeedSingleRegion`. `go test ./model/feature/` green.