### PR TITLE
#1799: route in-sketch clicks to Sketch Fillet/Chamfer (Offset/Mirror)

### DIFF
--- a/app/sketch_create_tools.go
+++ b/app/sketch_create_tools.go
@@ -31,10 +31,17 @@ func NewSketchChamferTool(distance float64) *SketchChamferTool {
 
 func (t *SketchChamferTool) Name() string                  { return "Chamfer" }
 func (t *SketchChamferTool) Pick(_ *Session, s Selectable) { t.take(s) }
-func (t *SketchChamferTool) CanCommit() bool               { return t.ready() }
-func (t *SketchChamferTool) AutoCommitOnPick() bool        { return true }
-func (t *SketchChamferTool) Cancel(*Session)               { t.reset() }
-func (t *SketchChamferTool) Prompt(*Session) string        { return "Pick two lines to chamfer." }
+
+// Accepts highlights the lines a chamfer can bevel (the hover-candidate cue).
+func (t *SketchChamferTool) Accepts(e sketch.Entity) bool { return entityKindIs(e, sketch.LineKind) }
+
+// Chamfer must satisfy SketchEntityTool so in-sketch clicks reach it (#1799).
+var _ SketchEntityTool = (*SketchChamferTool)(nil)
+
+func (t *SketchChamferTool) CanCommit() bool        { return t.ready() }
+func (t *SketchChamferTool) AutoCommitOnPick() bool { return true }
+func (t *SketchChamferTool) Cancel(*Session)        { t.reset() }
+func (t *SketchChamferTool) Prompt(*Session) string { return "Pick two lines to chamfer." }
 
 // SetDistance sets the chamfer setback.
 func (t *SketchChamferTool) SetDistance(d float64) { t.distance = math.Scalar(d) }

--- a/app/sketch_create_tools_test.go
+++ b/app/sketch_create_tools_test.go
@@ -30,6 +30,31 @@ func TestSketchChamferTool(t *testing.T) {
 	}
 }
 
+// TestSketchChamferToolInSketchClickRoutes is the #1799 regression for chamfer: it drives
+// the REAL in-sketch pick route (Session.Click → sketchEntityPointer). Before the fix the
+// tool did not satisfy SketchEntityTool, so in-sketch clicks were silently dropped.
+func TestSketchChamferToolInSketchClickRoutes(t *testing.T) {
+	s, sk := sketchSession(t)
+	corner := sk.Points().Add(gmath.P2(0, 0)) // origin ↔ pixel (100,100)
+	farA, _ := screenToSketch(s, 170, 100)
+	farB, _ := screenToSketch(s, 100, 170)
+	sk.Lines().Add(corner, sk.Points().Add(farA))
+	sk.Lines().Add(corner, sk.Points().Add(farB))
+	before := sk.Lines().Count()
+
+	tool := NewSketchChamferTool(1)
+	s.StartTool(tool)
+	s.Click(135, 100)
+	s.Click(100, 135) // second pick auto-commits
+
+	if s.ActiveTool() != nil {
+		t.Fatal("chamfer tool still active — in-sketch clicks did not reach it (#1799)")
+	}
+	if sk.Lines().Count() != before+1 {
+		t.Fatalf("lines after in-sketch chamfer = %d, want %d (clicks were dropped)", sk.Lines().Count(), before+1)
+	}
+}
+
 // Slot draws a straight slot from two centre clicks (two lines + two arc caps).
 func TestSketchSlotTool(t *testing.T) {
 	s, sk := sketchSession(t)

--- a/app/sketch_modify_tools.go
+++ b/app/sketch_modify_tools.go
@@ -17,15 +17,45 @@ type pickCollector struct {
 	want  int
 }
 
+// take is the 3D-viewport pick route (Tool.Pick); PickSnap is the in-sketch route. Both
+// funnel through takeEntity so the two entry points share the dedup / capacity rule.
 func (c *pickCollector) take(sel Selectable) {
-	if h, ok := sel.(SketchEntityHandle); ok && len(c.picks) < c.want {
-		c.picks = append(c.picks, h.Entity)
+	if h, ok := sel.(SketchEntityHandle); ok {
+		c.takeEntity(h.Entity)
 	}
+}
+
+// PickSnap implements the entity-pick half of [SketchEntityTool]: inside a 2D sketch,
+// Session.sketchEntityPointer delivers every entity click HERE, not through Pick. A modify
+// tool that had only Pick therefore had its in-sketch clicks silently dropped, so Fillet/
+// Chamfer/Offset/Mirror did nothing (#1799). The snap carries nothing a corner blend,
+// offset, or mirror needs.
+func (c *pickCollector) PickSnap(ent sketch.Entity, _ SnapResult) { c.takeEntity(ent) }
+
+// takeEntity records one entity pick, ignoring a nil, a repeat of an already-picked entity
+// (a corner needs two DISTINCT lines), and any pick past `want`.
+func (c *pickCollector) takeEntity(ent sketch.Entity) {
+	if ent == nil || len(c.picks) >= c.want {
+		return
+	}
+	for _, p := range c.picks {
+		if p == ent {
+			return
+		}
+	}
+	c.picks = append(c.picks, ent)
 }
 
 func (c *pickCollector) ready() bool             { return len(c.picks) == c.want }
 func (c *pickCollector) reset()                  { c.picks = nil }
 func (c *pickCollector) Picked() []sketch.Entity { return c.picks }
+
+// The modify tools must satisfy SketchEntityTool so in-sketch clicks route to them (#1799).
+var (
+	_ SketchEntityTool = (*SketchFilletTool)(nil)
+	_ SketchEntityTool = (*SketchOffsetTool)(nil)
+	_ SketchEntityTool = (*SketchMirrorTool)(nil)
+)
 
 // SketchFilletTool rounds the corner between two picked lines with a tangent arc.
 type SketchFilletTool struct {
@@ -41,10 +71,13 @@ func NewSketchFilletTool(radius float64) *SketchFilletTool {
 
 func (t *SketchFilletTool) Name() string                  { return "Sketch Fillet" }
 func (t *SketchFilletTool) Pick(_ *Session, s Selectable) { t.take(s) }
-func (t *SketchFilletTool) CanCommit() bool               { return t.ready() }
-func (t *SketchFilletTool) AutoCommitOnPick() bool        { return true }
-func (t *SketchFilletTool) Cancel(*Session)               { t.reset() }
-func (t *SketchFilletTool) Prompt(*Session) string        { return "Pick two lines to fillet." }
+
+// Accepts highlights the lines a fillet can blend (the hover-candidate cue).
+func (t *SketchFilletTool) Accepts(e sketch.Entity) bool { return entityKindIs(e, sketch.LineKind) }
+func (t *SketchFilletTool) CanCommit() bool              { return t.ready() }
+func (t *SketchFilletTool) AutoCommitOnPick() bool       { return true }
+func (t *SketchFilletTool) Cancel(*Session)              { t.reset() }
+func (t *SketchFilletTool) Prompt(*Session) string       { return "Pick two lines to fillet." }
 
 // SetRadius sets the fillet radius.
 func (t *SketchFilletTool) SetRadius(r float64) { t.radius = math.Scalar(r) }
@@ -82,10 +115,16 @@ func NewSketchOffsetTool(distance float64) *SketchOffsetTool {
 
 func (t *SketchOffsetTool) Name() string                  { return "Offset" }
 func (t *SketchOffsetTool) Pick(_ *Session, s Selectable) { t.take(s) }
-func (t *SketchOffsetTool) CanCommit() bool               { return t.ready() }
-func (t *SketchOffsetTool) AutoCommitOnPick() bool        { return true }
-func (t *SketchOffsetTool) Cancel(*Session)               { t.reset() }
-func (t *SketchOffsetTool) Prompt(*Session) string        { return "Pick a curve to offset." }
+
+// Accepts highlights the curves OffsetEntity handles: line, circle, arc. Uses the entity's
+// Kind() capability via entityKindIs, not a type switch, per the sketch-entity seam (#1624).
+func (t *SketchOffsetTool) Accepts(e sketch.Entity) bool {
+	return entityKindIs(e, sketch.LineKind, sketch.CircleKind, sketch.ArcKind)
+}
+func (t *SketchOffsetTool) CanCommit() bool        { return t.ready() }
+func (t *SketchOffsetTool) AutoCommitOnPick() bool { return true }
+func (t *SketchOffsetTool) Cancel(*Session)        { t.reset() }
+func (t *SketchOffsetTool) Prompt(*Session) string { return "Pick a curve to offset." }
 
 // SetDistance sets the offset distance.
 func (t *SketchOffsetTool) SetDistance(d float64) { t.distance = math.Scalar(d) }
@@ -118,10 +157,14 @@ func NewSketchMirrorTool() *SketchMirrorTool {
 
 func (t *SketchMirrorTool) Name() string                  { return "Mirror" }
 func (t *SketchMirrorTool) Pick(_ *Session, s Selectable) { t.take(s) }
-func (t *SketchMirrorTool) CanCommit() bool               { return t.ready() }
-func (t *SketchMirrorTool) AutoCommitOnPick() bool        { return true }
-func (t *SketchMirrorTool) Cancel(*Session)               { t.reset() }
-func (t *SketchMirrorTool) Prompt(*Session) string        { return "Pick geometry, then a mirror line." }
+
+// Accepts highlights any geometry as a mirror candidate — the first pick is the geometry
+// to copy, the second the mirror line (Commit validates the second is a line).
+func (t *SketchMirrorTool) Accepts(e sketch.Entity) bool { return e != nil }
+func (t *SketchMirrorTool) CanCommit() bool              { return t.ready() }
+func (t *SketchMirrorTool) AutoCommitOnPick() bool       { return true }
+func (t *SketchMirrorTool) Cancel(*Session)              { t.reset() }
+func (t *SketchMirrorTool) Prompt(*Session) string       { return "Pick geometry, then a mirror line." }
 
 // Commit mirrors the first picked entity across the second picked line.
 func (t *SketchMirrorTool) Commit(s *Session) error {

--- a/app/sketch_modify_tools_test.go
+++ b/app/sketch_modify_tools_test.go
@@ -10,6 +10,92 @@ import (
 	"oblikovati.org/model/sketch"
 )
 
+// TestSketchFilletToolInSketchClickRoutes is the #1799 regression: it drives the REAL
+// in-sketch pick route (Session.Click → sketchEntityPointer), not feedPick. Before the fix
+// the fillet tool did not satisfy SketchEntityTool, so the type assertion in
+// sketchEntityPointer failed and the clicks were silently dropped — no arc, no error.
+func TestSketchFilletToolInSketchClickRoutes(t *testing.T) {
+	s, sk := sketchSession(t)
+	corner := sk.Points().Add(math.P2(0, 0)) // origin ↔ pixel (100,100)
+	farA, _ := screenToSketch(s, 170, 100)   // a point out along +X
+	farB, _ := screenToSketch(s, 100, 170)   // a point out along +Y
+	sk.Lines().Add(corner, sk.Points().Add(farA))
+	sk.Lines().Add(corner, sk.Points().Add(farB))
+
+	tool := NewSketchFilletTool(1)
+	s.StartTool(tool)
+	s.Click(135, 100) // lands on the horizontal line (not on an endpoint)
+	s.Click(100, 135) // lands on the vertical line → second pick auto-commits
+
+	if s.ActiveTool() != nil {
+		t.Fatal("fillet tool still active — the in-sketch clicks did not reach it (#1799)")
+	}
+	if sk.Arcs().Count() != 1 {
+		t.Fatalf("arcs after in-sketch fillet = %d, want 1 (clicks were dropped)", sk.Arcs().Count())
+	}
+}
+
+// TestSketchModifyToolsAcceptedKinds covers each tool's Accepts hover-candidate filter
+// (#1799): fillet/chamfer accept only lines, offset accepts line/circle/arc, mirror accepts
+// any geometry but not nil.
+func TestSketchModifyToolsAcceptedKinds(t *testing.T) {
+	_, sk := sketchSession(t)
+	line := sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(1, 0))
+	circle := sk.Circles().AddByCenterRadius(math.P2(0, 0), 1)
+	arc := sk.Arcs().AddByCenterStartEnd(math.P2(0, 0), math.P2(1, 0), math.P2(0, 1), true)
+	point := sk.Points().Add(math.P2(2, 2))
+
+	fillet := NewSketchFilletTool(1)
+	chamfer := NewSketchChamferTool(1)
+	offset := NewSketchOffsetTool(1)
+	mirror := NewSketchMirrorTool()
+
+	cases := []struct {
+		name   string
+		accept func(sketch.Entity) bool
+		yes    []sketch.Entity
+		no     []sketch.Entity
+	}{
+		{"fillet", fillet.Accepts, []sketch.Entity{line}, []sketch.Entity{circle, arc, point, nil}},
+		{"chamfer", chamfer.Accepts, []sketch.Entity{line}, []sketch.Entity{circle, arc, point, nil}},
+		{"offset", offset.Accepts, []sketch.Entity{line, circle, arc}, []sketch.Entity{point, nil}},
+		{"mirror", mirror.Accepts, []sketch.Entity{line, circle, arc, point}, []sketch.Entity{nil}},
+	}
+	for _, c := range cases {
+		for _, e := range c.yes {
+			if !c.accept(e) {
+				t.Errorf("%s.Accepts(%T) = false, want true", c.name, e)
+			}
+		}
+		for _, e := range c.no {
+			if c.accept(e) {
+				t.Errorf("%s.Accepts(%T) = true, want false", c.name, e)
+			}
+		}
+	}
+}
+
+// TestPickCollectorIgnoresRepeatPick covers the dedup guard: clicking the same line twice
+// leaves the tool waiting for a distinct second line, so it does not auto-commit.
+func TestPickCollectorIgnoresRepeatPick(t *testing.T) {
+	s, sk := sketchSession(t)
+	corner := sk.Points().Add(math.P2(0, 0))
+	farA, _ := screenToSketch(s, 170, 100)
+	sk.Lines().Add(corner, sk.Points().Add(farA))
+
+	tool := NewSketchFilletTool(1)
+	s.StartTool(tool)
+	s.Click(135, 100)
+	s.Click(135, 100) // same line again — must be ignored, no second distinct pick
+
+	if s.ActiveTool() == nil {
+		t.Fatal("fillet committed on a duplicate pick — dedup guard failed")
+	}
+	if got := len(tool.Picked()); got != 1 {
+		t.Errorf("picks after duplicate click = %d, want 1", got)
+	}
+}
+
 func TestSketchFilletToolRoundsCorner(t *testing.T) {
 	s, sk := sketchSession(t)
 	corner := sk.Points().Add(math.P2(0, 0))


### PR DESCRIPTION
## What

In a 2D sketch, picking two corner lines and invoking **Sketch ▸ Fillet** (or
**Chamfer**) did **nothing** — no arc/bevel, no error. Reported by **rampam** in
Discord `#bug-tracker`.

## Root cause

In-sketch clicks route through `Session.sketchEntityPointer`, which only
delivers a pick to the active tool if it implements `SketchEntityTool`
(`Accepts` + `Picked` + `PickSnap`). `SketchFilletTool` / `SketchChamferTool`
(and `SketchOffsetTool` / `SketchMirrorTool`, the same latent bug) had only
`Pick(*Session, Selectable)` + `pickCollector`, so the type assertion failed and
every in-sketch click was silently discarded. `pickCollector.take` was never
called → `ready()` stayed false → auto-commit never fired.

The model layer (`sketch.AddFillet`/`AddChamfer`/`sharedCorner`) was correct and
reachable all along; only the pick wiring was missing.

## Fix

At the shared root — `pickCollector`:
- adds `PickSnap` (the in-sketch route) and `takeEntity`, so the 3D-viewport
  route (`take`) and the in-sketch route funnel through one dedup/capacity rule;
- each tool declares `Accepts` for its hover-candidate kinds (lines for
  fillet/chamfer; line/circle/arc for offset; any geometry for mirror);
- compile-time assertions pin all four to `SketchEntityTool`.

Commit errors already surface through `Session.OK → s.notice` once picks arrive,
so a genuinely non-adjacent selection now reports *"the two lines do not share a
corner"* in the status bar instead of failing silently.

## Tests (bad premise fixed)

The existing tests passed on a bad premise — they drove `tool.Pick` directly
(the 3D-viewport route), never the in-sketch route the sketch UI uses. Added
regressions that drive the **real** route (`Session.Click → sketchEntityPointer`)
for fillet and chamfer. Verified both **fail without the fix** (tool stays
active, clicks dropped) and pass with it. Full `app` suite + lint green.

Closes #1799

🤖 Generated with [Claude Code](https://claude.com/claude-code)