### PR TITLE
#1803: Combine 'Operation' as a named dropdown (fix overflow/garble)

### DIFF
--- a/app/feature_modify_tools.go
+++ b/app/feature_modify_tools.go
@@ -203,9 +203,15 @@ func (t *CombineTool) DraftFeature(s *Session) (feature.Feature, bool) {
 // SetOperation chooses Join (0), Cut (1) or Intersect (2).
 func (t *CombineTool) SetOperation(op ops.PartFeatureOperation) { t.op = op }
 
+// Params exposes the boolean operation as a named dropdown. It was an IntParam whose long
+// self-documenting label ("Operation (0=Join 1=Cut 2=Intersect)") overflowed the 95px label
+// column and collided with the InputInt steppers, rendering as illegible garble (#1803). A
+// ChoiceParam puts the short label in the column and the named options in the control.
 func (t *CombineTool) Params() ToolParams {
-	return ToolParams{Ints: []IntParam{
-		{"Operation (0=Join 1=Cut 2=Intersect)", func() int { return int(t.op) }, func(n int) { t.op = ops.PartFeatureOperation(n) }},
+	return ToolParams{Choices: []ChoiceParam{
+		{Label: "Operation", Options: []string{"Join", "Cut", "Intersect"},
+			Get: func() int { return int(t.op) },
+			Set: func(n int) { t.op = ops.PartFeatureOperation(n) }},
 	}}
 }
 

--- a/app/feature_modify_tools_test.go
+++ b/app/feature_modify_tools_test.go
@@ -61,6 +61,33 @@ func TestCombineTool(t *testing.T) {
 	}
 }
 
+// TestCombineToolOperationIsChoice is the #1803 regression: the Combine "Operation" input
+// must be a ChoiceParam (a named dropdown), NOT an IntParam whose long self-documenting
+// label overflowed the 95px column and collided with the InputInt steppers into garble. It
+// asserts a short "Operation" label, the three named options in enum order, and that Set
+// routes into the tool's operation.
+func TestCombineToolOperationIsChoice(t *testing.T) {
+	tool := NewCombineTool()
+	p := tool.Params()
+	if len(p.Ints) != 0 {
+		t.Errorf("Combine still exposes %d IntParam(s) — the long-label overflow (#1803) is back", len(p.Ints))
+	}
+	if len(p.Choices) != 1 {
+		t.Fatalf("Combine Choices = %d, want 1 (the Operation dropdown)", len(p.Choices))
+	}
+	op := p.Choices[0]
+	if op.Label != "Operation" {
+		t.Errorf("Operation label = %q, want the short %q", op.Label, "Operation")
+	}
+	if want := []string{"Join", "Cut", "Intersect"}; !equalStrings(op.Options, want) {
+		t.Errorf("Operation options = %v, want %v (enum order Join=0/Cut=1/Intersect=2)", op.Options, want)
+	}
+	op.Set(int(ops.Intersect))
+	if op.Get() != int(ops.Intersect) {
+		t.Errorf("after Set(Intersect) Get = %d, want %d", op.Get(), int(ops.Intersect))
+	}
+}
+
 // Moving a body translates it.
 func TestMoveBodyTool(t *testing.T) {
 	s, def, _ := extrudedPart(t)


### PR DESCRIPTION
## What

The Boolean **Combine** dialog's "Operation" row rendered its long label and a
numeric input-with-steppers **on top of each other**, so the text was illegible
garble (`Operation (0=J…t -,li + sect)`). Reported by **rampam** in Discord
`#bug-tracker` ("Part design issues", item 7).

## Root cause

`CombineTool.Params()` exposed the boolean op as an `IntParam` labelled
`"Operation (0=Join 1=Cut 2=Intersect)"` (~250px). `propertyRow` draws the full
label then unconditionally moves the control cursor to `x + 95px`
(`propertyLabelWidth`), so the `InputInt` field (plus its `-`/`+` steppers) landed
in the middle of the still-visible label. Combine was the only tool stuffing an
enum into an `IntParam` instead of the `ChoiceParam` pattern every other
enum-bearing dialog uses.

## Fix

Replace the `IntParam` with a `ChoiceParam` — the short "Operation" label fits the
column and `drawToolChoice` renders a clean named dropdown (Join/Cut/Intersect in
enum order Join=0/Cut=1/Intersect=2), with no overflow, no stepper, and no need
for the `(0=…)` hint.

## Verification

- `TestCombineToolOperationIsChoice`: Combine exposes the Operation `Choice` (not
  an `Int`), the short label, the three named options in enum order, and `Set`
  routes into the tool's op.
- Full module suite (incl. archguard) + app lint green.
- **Live on the Vulkan head via the MCP bridge**: built two bodies, opened
  Combine, captured the window — the row now shows a clean **Join ▾** dropdown,
  garble gone.

Closes #1803

🤖 Generated with [Claude Code](https://claude.com/claude-code)