### PR TITLE
kernel/topo: describe closed circular edges by centre + axis

### DIFF
--- a/kernel/topo/geometric_ref.go
+++ b/kernel/topo/geometric_ref.go
@@ -5,6 +5,7 @@ package topo
 import (
 	stdmath "math"
 
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/math"
 )
 
@@ -201,13 +202,35 @@ func faceOutwardNormal(f *Face, p math.Point3) math.Vector3 {
 	return unitOrZero(nrm)
 }
 
+// edgeMidpoint is the edge's representative point: for a closed circular edge (a bore/boss
+// rim, which has no distinct start/end vertex) it is the circle centre — stable under
+// recompute; for any other edge it is the chord midpoint of its two vertices.
 func edgeMidpoint(e *Edge) math.Point3 {
+	if c, ok := closedCircleOf(e); ok {
+		return c.Center
+	}
 	a, b := e.StartVertex().Point(), e.EndVertex().Point()
 	return math.P3((a.X+b.X)/2, (a.Y+b.Y)/2, (a.Z+b.Z)/2)
 }
 
+// edgeDirection is the edge's (sign-agnostic) direction: the circle axis for a closed
+// circular edge, else the chord direction between its vertices.
 func edgeDirection(e *Edge) math.Vector3 {
+	if c, ok := closedCircleOf(e); ok {
+		return c.Normal.AsVector()
+	}
 	return unitOrZero(e.StartVertex().Point().VectorTo(e.EndVertex().Point()))
+}
+
+// closedCircleOf reports the underlying circle when the edge is a full closed circle — the
+// case the vertex-based midpoint/direction can't describe (start == end, or no vertices).
+func closedCircleOf(e *Edge) (geom.Circle, bool) {
+	c, ok := e.Geometry().(geom.Circle)
+	if !ok {
+		return geom.Circle{}, false
+	}
+	return c, e.StartVertex() == nil || e.EndVertex() == nil ||
+		e.StartVertex().Point() == e.EndVertex().Point()
 }
 
 func unitOrZero(v math.Vector3) math.Vector3 {

--- a/kernel/topo/geometric_ref_test.go
+++ b/kernel/topo/geometric_ref_test.go
@@ -3,8 +3,11 @@
 package topo_test
 
 import (
+	stdmath "math"
 	"testing"
 
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/subd"
 	"oblikovati.org/kernel/topo"
@@ -70,6 +73,51 @@ func TestGeometricEdgeRefReboundsAcrossRebuild(t *testing.T) {
 		if topo.DescribeEdge(got).Midpoint.DistanceTo(ref.Midpoint) > spikeTol {
 			t.Errorf("edge %d: resolved an edge at the wrong midpoint", i)
 		}
+	}
+}
+
+// TestClosedCircularEdgeDescribedByCentreAndAxis captures a bore/boss rim — a closed
+// circular edge whose start and end are the same vertex, so the chord midpoint/direction
+// degenerate — and confirms it is described by the circle centre + axis and re-binds on a
+// geometrically identical rebuilt edge. This is what lets a fillet/chamfer on a circular
+// edge (the case DressUpExtractor emits) resolve at recompute.
+func TestClosedCircularEdgeDescribedByCentreAndAxis(t *testing.T) {
+	// A cylinder's cap rim is a closed circular edge: start == end vertex, so the chord
+	// midpoint/direction degenerate — it must be described by the circle centre + axis.
+	cyl := func() *topo.Body {
+		b, err := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2, 4)
+		if err != nil {
+			t.Fatalf("cylinder: %v", err)
+		}
+		return b
+	}
+	body := cyl()
+
+	var rim *topo.Edge
+	for _, e := range body.Edges() {
+		if _, ok := e.Geometry().(geom.Circle); ok {
+			rim = e
+			break
+		}
+	}
+	if rim == nil {
+		t.Fatal("setup: cylinder had no circular edge")
+	}
+
+	ref := topo.DescribeEdge(rim)
+	if ref.Midpoint.DistanceTo(math.P3(0, 0, 0)) > spikeTol &&
+		ref.Midpoint.DistanceTo(math.P3(0, 0, 4)) > spikeTol {
+		t.Errorf("circle rim midpoint = %v, want a cap centre (0,0,0) or (0,0,4)", ref.Midpoint)
+	}
+	if stdmath.Abs(ref.Direction.Dot(math.V3(0, 0, 1))) < 0.9999 {
+		t.Errorf("circle rim direction = %v, want the cylinder axis (0,0,1)", ref.Direction)
+	}
+
+	if self, ok := body.FindEdgeByGeometry(ref, spikeTol); !ok || self != rim {
+		t.Fatalf("circular edge did not self-resolve (ok=%v)", ok)
+	}
+	if _, ok := cyl().FindEdgeByGeometry(ref, spikeTol); !ok {
+		t.Error("closed circular edge descriptor did not re-bind on the rebuilt cylinder")
 	}
 }
 


### PR DESCRIPTION
## Problem
A closed circular edge — a bore/boss rim or a cylinder cap — has a single vertex acting as both start and end. The geometric edge descriptor (`edgeMidpoint`/`edgeDirection`) derived its representative point and direction from the two vertices, which degenerate to a point and a zero vector for a closed circle. So a fillet or chamfer selected on such an edge could not be named geometrically and was **lost at recompute**.

## Fix
`closedCircleOf(e)` detects the case (`Edge.Geometry().(geom.Circle)` with `start == end`) and describes the edge by:
- **midpoint** → the circle **centre** (stable representative point)
- **direction** → the circle **axis** (`Normal`, already sign-agnostic in `FindEdgeByGeometry`)

Both are stable under recompute, so `DescribeEdge`/`FindEdgeByGeometry` now round-trip a circular edge the same way they already do a straight one.

## Test
`TestClosedCircularEdgeDescribedByCentreAndAxis` builds a `brep.SolidCylinder`, confirms its cap rim is described by the cap centre + axis, self-resolves, and re-binds on an independently rebuilt cylinder.

## Pairs with
The Inventor exporter change emitting centre+axis descriptors for closed circular dress-up edges (previously dropped by `DressUpExtractor.AddEdges`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)