### PR TITLE
model/feature: resolve profile seeds at recompute, not at load

### DIFF
--- a/model/feature/extrude.go
+++ b/model/feature/extrude.go
@@ -21,9 +21,15 @@ import (
 type ExtrudeDefinition struct {
 	Sketch         *sketch.Sketch
 	ProfileIndices []int // one or more sketch regions, extruded together into one feature
-	Operation      ops.PartFeatureOperation
-	Extent         Extent
-	Taper          float64 // draft angle (radians); 0 in phase A (planar sides)
+	// ProfileSeeds are interior seed points (sketch 2-D, cm) selecting the regions by
+	// containment. When present they are resolved to region indices EVERY recompute, so an
+	// externally-authored selection survives the sketch being re-solved between load and
+	// recompute (which reorders the DCEL regions and would otherwise strand ProfileIndices on
+	// the wrong cells — #region-seed). Empty ⇒ ProfileIndices is used directly.
+	ProfileSeeds [][]float64
+	Operation    ops.PartFeatureOperation
+	Extent       Extent
+	Taper        float64 // draft angle (radians); 0 in phase A (planar sides)
 }
 
 // ExtrudeFeature turns a profile into a prism and combines it with the running
@@ -111,9 +117,15 @@ func outerPolygons(profiles []*sketch.Profile) [][]math.Point2 {
 }
 
 // resolveProfiles re-derives the selected closed regions from the sketch (the shared
-// resolver), erroring (→ sick) when one is missing or open, or when none is selected.
+// resolver), erroring (→ sick) when one is missing or open, or when none is selected. Seed
+// points, when present, are resolved to indices against the CURRENT regions each recompute so
+// the selection tracks a re-solved sketch (region ordering is a DCEL artifact — #region-seed).
 func (e *ExtrudeFeature) resolveProfiles() ([]*sketch.Profile, error) {
-	return resolveClosedProfiles(e.def.Sketch, e.def.ProfileIndices, "extrude")
+	indices := e.def.ProfileIndices
+	if len(e.def.ProfileSeeds) > 0 {
+		indices = resolveSeeds(e.def.Sketch, e.def.ProfileSeeds, e.def.ProfileIndices)
+	}
+	return resolveClosedProfiles(e.def.Sketch, indices, "extrude")
 }
 
 // ExtrudeFeatures is the collection of extrude features, adding into the engine.

--- a/model/feature/revolve_test.go
+++ b/model/feature/revolve_test.go
@@ -12,6 +12,44 @@ import (
 	"oblikovati.org/model/sketch"
 )
 
+// TestRevolveSeedResolvesAtRecomputeNotStaleIndex is the #region-seed regression for revolve:
+// a seed on the definition must re-resolve the region at recompute, so a stale ProfileIndex
+// (as if the sketch re-solved and its DCEL regions reordered after load) does not spin the
+// wrong region. Two disjoint rectangles about the Y-axis centerline revolve to different
+// washers; the index points at the far (large) one while the seed points at the near (small)
+// one — the seed must win.
+func TestRevolveSeedResolvesAtRecomputeNotStaleIndex(t *testing.T) {
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	l := sk.Lines()
+	cl := l.AddByTwoPoints(math.P2(0, 0), math.P2(0, 1)) // Y-axis centerline
+	cl.SetCenterline(true)
+	// near region x∈[1,2] and far region x∈[3,5], each y∈[0,1] (areas 1 and 2).
+	for _, r := range [][2]float64{{1, 2}, {3, 5}} {
+		l.AddByTwoPoints(math.P2(r[0], 0), math.P2(r[1], 0))
+		l.AddByTwoPoints(math.P2(r[1], 0), math.P2(r[1], 1))
+		l.AddByTwoPoints(math.P2(r[1], 1), math.P2(r[0], 1))
+		l.AddByTwoPoints(math.P2(r[0], 1), math.P2(r[0], 0))
+	}
+	far := regionIndexOfArea(sk, 2) // the WRONG cell the stale index points at
+	if far < 0 {
+		t.Fatal("setup: no area-2 (far) region")
+	}
+
+	fs := NewPartFeatures(nil)
+	pf := NewRevolveFeatures(fs).AddAboutCenterline(sk, far, nil, ops.NewBody)
+	withProfileSeed(pf, []float64{1.5, 0.5}) // seed → the NEAR (small) region
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("seeded revolve sick: %+v", pf.Health())
+	}
+
+	want := stdmath.Pi * (2*2 - 1*1) * 1 // near washer: π(R²−r²)·h = 3π
+	got := ops.BodyGeometryProperties(fs.Result()[0], ops.DefaultQuality()).Volume
+	if relErr(got, want) > 0.02 {
+		t.Errorf("seeded revolve volume = %g, want ≈%g (3π, the NEAR region the seed selects, not the far index's 16π)", got, want)
+	}
+}
+
 // TestRevolveAboutSketchCenterline spins a profile about the sketch's own centerline (Inventor's
 // common flow), producing the same washer as revolving about an explicit Y work axis.
 func TestRevolveAboutSketchCenterline(t *testing.T) {

--- a/model/feature/serialize_extrude.go
+++ b/model/feature/serialize_extrude.go
@@ -105,15 +105,52 @@ func restoreExtrude(fs *PartFeatures, ed *ExtrudeData, sk SketchIndexer, work *W
 	if err != nil {
 		return nil, err
 	}
-	profiles := resolveSeeds(skt, ed.ProfilePoints, ed.extrudeProfiles())
-	return NewExtrudeFeatures(fs).AddExtrude(skt, profiles, op, extent, ed.Taper), nil
+	// Carry the seed points onto the feature (not a baked index list): the sketch is re-solved
+	// between here and the first recompute, reordering its DCEL regions, so a baked index would
+	// select the wrong cell. resolveProfiles resolves the seeds against the current regions each
+	// recompute instead (#region-seed). ProfileIndices holds a per-seed load-time fallback used
+	// only when a seed later misses every region.
+	return NewExtrudeFeatures(fs).AddExtrudeFeature(&ExtrudeDefinition{
+		Sketch: skt, ProfileIndices: seedFallback(skt, ed.ProfilePoints, ed.extrudeProfiles()),
+		ProfileSeeds: ed.ProfilePoints, Operation: op, Extent: extent, Taper: ed.Taper,
+	}), nil
+}
+
+// seedFallback builds the per-seed load-time fallback index list aligned to seeds: each seed's
+// smallest containing region now, or the recipe's first index when it hits none. With no seeds it
+// is the recipe index list unchanged. Used as the resolveSeeds fallback so a seed that later
+// misses (its cell shifted under a re-solve) reverts to its load-time cell, not the whole body.
+func seedFallback(skt *sketch.Sketch, seeds [][]float64, recipe []int) []int {
+	if len(seeds) == 0 {
+		return recipe
+	}
+	def0 := 0
+	if len(recipe) > 0 {
+		def0 = recipe[0]
+	}
+	profs := skt.Profiles()
+	out := make([]int, len(seeds))
+	for i, s := range seeds {
+		b := -1
+		if len(s) == 2 {
+			b = smallestContainingRegion(profs, math.P2(s[0], s[1]))
+		}
+		if b < 0 {
+			b = def0
+		}
+		out[i] = b
+	}
+	return out
 }
 
 // resolveSeeds maps each interior seed point to the smallest closed region that contains it,
-// falling back to the explicit index list when no seeds are given or none resolve. Region
-// ordering is a DCEL-walk artifact (regions.go), so an author that knows only the region
-// geometry must select by containment, not index. It never returns empty (an empty selection
-// would extrude the whole body).
+// resolved against the CURRENT regions (so it tracks a re-solved sketch — #region-seed). Region
+// ordering is a DCEL-walk artifact (regions.go), so an author that knows only the region geometry
+// must select by containment, not index. A seed that hits no region is dropped as long as ANY seed
+// resolves (a stray stale seed shouldn't add a wrong region — IOPlate); only when NONE resolves is
+// the fallback list returned whole (seedFallback's load-time cells, so an all-missed selection
+// reverts to load rather than the raw recipe index that could span the body — WheelSlider). It
+// never returns empty (an empty selection would extrude the whole body).
 func resolveSeeds(skt *sketch.Sketch, seeds [][]float64, fallback []int) []int {
 	if len(seeds) == 0 {
 		return fallback
@@ -124,15 +161,7 @@ func resolveSeeds(skt *sketch.Sketch, seeds [][]float64, fallback []int) []int {
 		if len(s) != 2 {
 			continue
 		}
-		q := math.P2(s[0], s[1])
-		best, bestArea := -1, stdmath.Inf(1)
-		for i := 0; i < profs.Count(); i++ {
-			p := profs.Item(i)
-			if p.IsClosed() && p.Contains(q) && p.Area() < bestArea {
-				best, bestArea = i, p.Area()
-			}
-		}
-		if best >= 0 {
+		if best := smallestContainingRegion(profs, math.P2(s[0], s[1])); best >= 0 {
 			idx = append(idx, best)
 		}
 	}
@@ -140,6 +169,19 @@ func resolveSeeds(skt *sketch.Sketch, seeds [][]float64, fallback []int) []int {
 		return fallback
 	}
 	return idx
+}
+
+// smallestContainingRegion returns the index of the smallest-area closed profile that contains q,
+// or -1 when none does. Smallest wins so a disk drawn inside an annulus is selectable (#1526).
+func smallestContainingRegion(profs *sketch.Profiles, q math.Point2) int {
+	best, bestArea := -1, stdmath.Inf(1)
+	for i := 0; i < profs.Count(); i++ {
+		p := profs.Item(i)
+		if p.IsClosed() && p.Contains(q) && p.Area() < bestArea {
+			best, bestArea = i, p.Area()
+		}
+	}
+	return best
 }
 
 // resolveSeed maps a single interior seed point to the region that contains it, falling back to

--- a/model/feature/serialize_extrude_seeds_test.go
+++ b/model/feature/serialize_extrude_seeds_test.go
@@ -43,6 +43,46 @@ func TestResolveSeedsSelectsRegionByContainment(t *testing.T) {
 	}
 }
 
+// regionIndexOfArea returns the profile index whose area matches want (within tol).
+func regionIndexOfArea(sk *sketch.Sketch, want float64) int {
+	ps := sk.Profiles()
+	for i := 0; i < ps.Count(); i++ {
+		if stdmath.Abs(ps.Item(i).Area()-want) < 1e-6 {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestExtrudeSeedResolvesAtRecomputeNotStaleIndex is the #region-seed regression: a feature
+// that carries a seed must re-resolve its region from the seed at recompute, so a stale
+// ProfileIndices (as if the sketch was re-solved and the DCEL regions reordered after load)
+// does NOT strand the extrude on the wrong cell. Here the index deliberately points at the
+// large region while the seed points at the small one — the seed must win.
+func TestExtrudeSeedResolvesAtRecomputeNotStaleIndex(t *testing.T) {
+	sk := splitRectSketch()
+	large := regionIndexOfArea(sk, 6) // the WRONG cell the stale index points at
+	if large < 0 {
+		t.Fatal("setup: no area-6 region")
+	}
+
+	e := &ExtrudeFeature{def: &ExtrudeDefinition{
+		Sketch:         sk,
+		ProfileIndices: []int{large},          // stale index → the area-6 region
+		ProfileSeeds:   [][]float64{{0.5, 1}}, // seed → the area-2 region
+	}}
+	profs, err := e.resolveProfiles()
+	if err != nil {
+		t.Fatalf("resolveProfiles: %v", err)
+	}
+	if len(profs) != 1 {
+		t.Fatalf("want 1 resolved profile, got %d", len(profs))
+	}
+	if a := profs[0].Area(); stdmath.Abs(a-2) > 1e-6 {
+		t.Errorf("resolved region area %v, want the area-2 region the SEED selects (not the stale index's 6)", a)
+	}
+}
+
 func TestResolveSeedsFallsBack(t *testing.T) {
 	sk := splitRectSketch()
 

--- a/model/feature/serialize_extrude_seeds_test.go
+++ b/model/feature/serialize_extrude_seeds_test.go
@@ -83,6 +83,43 @@ func TestExtrudeSeedResolvesAtRecomputeNotStaleIndex(t *testing.T) {
 	}
 }
 
+// TestResolveSeedsDropsMissingWhenSomeHit confirms a seed that hits no region is dropped as
+// long as another seed resolves — a stray stale seed must not add a wrong (fallback) region.
+func TestResolveSeedsDropsMissingWhenSomeHit(t *testing.T) {
+	sk := splitRectSketch()
+	// First seed hits the area-2 region; second seed is off the sheet (misses).
+	got := resolveSeeds(sk, [][]float64{{0.5, 1}, {99, 99}}, []int{7, 7})
+	if len(got) != 1 {
+		t.Fatalf("want only the hit region (missed seed dropped), got %v", got)
+	}
+	if a := sk.Profiles().Item(got[0]).Area(); stdmath.Abs(a-2) > 1e-6 {
+		t.Errorf("kept region area %v, want the area-2 region the first seed hit", a)
+	}
+}
+
+// TestSeedFallbackAlignsToSeeds confirms seedFallback yields one load-time cell per seed, using
+// the recipe's first index when a seed hits nothing, and the recipe list unchanged with no seeds.
+func TestSeedFallbackAlignsToSeeds(t *testing.T) {
+	sk := splitRectSketch()
+	small, large := regionIndexOfArea(sk, 2), regionIndexOfArea(sk, 6)
+
+	fb := seedFallback(sk, [][]float64{{0.5, 1}, {2.5, 1}}, []int{9})
+	if len(fb) != 2 || fb[0] != small || fb[1] != large {
+		t.Errorf("aligned fallback = %v, want [%d %d] (the two hit cells)", fb, small, large)
+	}
+
+	// A missing seed takes the recipe's first index (def0 = 9).
+	miss := seedFallback(sk, [][]float64{{99, 99}}, []int{9})
+	if len(miss) != 1 || miss[0] != 9 {
+		t.Errorf("missed-seed fallback = %v, want [9] (recipe default)", miss)
+	}
+
+	// No seeds ⇒ the recipe index list unchanged.
+	if none := seedFallback(sk, nil, []int{3, 4}); len(none) != 2 || none[0] != 3 || none[1] != 4 {
+		t.Errorf("no-seed fallback = %v, want [3 4] (recipe unchanged)", none)
+	}
+}
+
 func TestResolveSeedsFallsBack(t *testing.T) {
 	sk := splitRectSketch()
 

--- a/model/feature/serialize_work.go
+++ b/model/feature/serialize_work.go
@@ -369,6 +369,9 @@ func restoreRevolve(fs *PartFeatures, d *RevolveData, sk SketchIndexer, work *Wo
 		return nil, err
 	}
 	angle := d.Angle
+	// resolveSeed gives the fallback index; the seed is ALSO kept on the definition
+	// (withProfileSeed) so it re-resolves against the current regions every recompute — the
+	// sketch re-solves between load and recompute and reorders its regions (#region-seed).
 	profile := resolveSeed(skt, d.ProfilePoint, d.Profile)
 	if d.AxisSketch > 0 { // a specific centerline (1-based index)
 		axisSk, ok := sk.At(d.AxisSketch - 1)
@@ -379,11 +382,11 @@ func restoreRevolve(fs *PartFeatures, d *RevolveData, sk SketchIndexer, work *Wo
 			return nil, fmt.Errorf("revolve axis centerline references line %d out of range", d.AxisLine)
 		}
 		pf := NewRevolveFeatures(fs).AddAboutCenterlineLine(skt, profile, axisSk, axisSk.Lines().Item(d.AxisLine), func() float64 { return angle }, op)
-		return restoreSecondAngle(pf, d.Angle2), nil
+		return withProfileSeed(restoreSecondAngle(pf, d.Angle2), d.ProfilePoint), nil
 	}
 	if d.Axis == "" { // revolve about the profile sketch's own (single) centerline
 		pf := NewRevolveFeatures(fs).AddAboutCenterline(skt, profile, func() float64 { return angle }, op)
-		return restoreSecondAngle(pf, d.Angle2), nil
+		return withProfileSeed(restoreSecondAngle(pf, d.Angle2), d.ProfilePoint), nil
 	}
 	if work == nil {
 		return nil, fmt.Errorf("revolve needs the part's work geometry to resolve its axis")
@@ -394,10 +397,21 @@ func restoreRevolve(fs *PartFeatures, d *RevolveData, sk SketchIndexer, work *Wo
 	}
 	if d.Angle2 > 0 {
 		angle2 := d.Angle2
-		return NewRevolveFeatures(fs).AddTwoDirectional(skt, profile, axis,
-			func() float64 { return angle }, func() float64 { return angle2 }, op), nil
+		return withProfileSeed(NewRevolveFeatures(fs).AddTwoDirectional(skt, profile, axis,
+			func() float64 { return angle }, func() float64 { return angle2 }, op), d.ProfilePoint), nil
 	}
-	return NewRevolveFeatures(fs).Add(skt, profile, axis, func() float64 { return angle }, op), nil
+	return withProfileSeed(NewRevolveFeatures(fs).Add(skt, profile, axis, func() float64 { return angle }, op), d.ProfilePoint), nil
+}
+
+// withProfileSeed records the interior seed point on a restored revolve so its region is
+// re-resolved by containment each recompute (survives the sketch re-solving — #region-seed).
+func withProfileSeed(pf *PartFeature, seed []float64) *PartFeature {
+	if len(seed) > 0 {
+		if rf, ok := pf.feature.(*RevolveFeature); ok {
+			rf.def.ProfileSeed = append([]float64(nil), seed...)
+		}
+	}
+	return pf
 }
 
 // restoreSecondAngle re-applies a persisted second-direction sweep onto a

--- a/model/feature/sketched_features.go
+++ b/model/feature/sketched_features.go
@@ -28,8 +28,13 @@ const revolveSegments = 64
 // precedence: an explicit work axis; else a specific centerline (AxisCenterline on its sketch);
 // else the profile sketch's single centerline (auto).
 type RevolveDefinition struct {
-	Sketch               *sketch.Sketch
-	ProfileIndex         int
+	Sketch       *sketch.Sketch
+	ProfileIndex int
+	// ProfileSeed is an interior seed point (sketch 2-D, cm) selecting the region by
+	// containment. When set it is resolved to a region index EVERY recompute so the selection
+	// survives the sketch being re-solved between load and recompute (which reorders the DCEL
+	// regions, stranding ProfileIndex on the wrong cell — #region-seed). nil ⇒ use ProfileIndex.
+	ProfileSeed          []float64
 	Axis                 *WorkAxis
 	AxisCenterline       *sketch.Line   // a specific centerline to revolve about
 	AxisCenterlineSketch *sketch.Sketch // the centerline's sketch (for its plane)
@@ -58,7 +63,13 @@ func (r *RevolveFeature) ToolBody() *topo.Body                { return r.tool }
 // Recompute resolves the profile, spins it about the axis into a faceted solid of
 // revolution, and applies the operation against the running bodies.
 func (r *RevolveFeature) Recompute(in Input) (Output, error) {
-	prof, err := resolveSingleProfile(r.def.Sketch, r.def.ProfileIndex, "revolve")
+	// Resolve the seed against the CURRENT regions each recompute (region ordering is a DCEL
+	// artifact that shifts when the sketch re-solves — #region-seed); fall back to the index.
+	profileIndex := r.def.ProfileIndex
+	if len(r.def.ProfileSeed) > 0 {
+		profileIndex = resolveSeed(r.def.Sketch, r.def.ProfileSeed, r.def.ProfileIndex)
+	}
+	prof, err := resolveSingleProfile(r.def.Sketch, profileIndex, "revolve")
 	if err != nil {
 		return Output{}, err
 	}


### PR DESCRIPTION
## The bug
An externally-authored extrude/revolve selects its sketch region by an interior **seed point** (the reader's DCEL region *ordering* isn't predictable from outside). `restoreExtrude`/`restoreRevolve` resolved that seed to a region **index** once, at load, and baked the index onto the feature.

But the sketch is **re-solved between load and the first recompute**, which reorders its regions — so the baked index then selected a *different* cell than the seed intended, and the feature extruded/cut the wrong (often far larger) region.

**TapePath** recomputed to **+1090%** of the Inventor oracle for exactly this reason: its base extrude's seeds each resolved to a small region at load, but the baked indices pointed at a **7 cm²** cell at recompute (proven by instrumenting `resolveSeeds` vs `buildProfilePrisms`).

## The fix
Carry the seed points onto `ExtrudeDefinition.ProfileSeeds` / `RevolveDefinition.ProfileSeed` and resolve them against the **current** regions every recompute (the regions the feature actually builds against are stable post-load).

- `ProfileIndices` now holds a per-seed **load-time fallback** (`seedFallback`), used only when a seed later misses every region — so an all-missed selection reverts to its load cells rather than the raw recipe index that could span the whole body.
- A seed that misses while others hit is **dropped** (a stray stale seed must not add a wrong region — this keeps IOPlate at −0.7%).

## Live result (ReelToReel corpus, 51 parts)
| Part | before | after |
|------|--------|-------|
| **TapePath** | **+1090.5%** | **−15.6%** |
| BigChunkyPlate | +23.9% | +22.1% |
| MainFrameSingleHeadBlock | +3.9% | +1.9% |

**No oracle-passing part regresses.** WheelSlider (already failing at −49.8%) worsens to −99.7%: its seeds land in a spurious ~0.1 cm² **sliver** region post-load — a separate region-detection / seed-quality issue, *not* the stale-index bug fixed here.

## Tests
- `TestExtrudeSeedResolvesAtRecomputeNotStaleIndex`
- `TestRevolveSeedResolvesAtRecomputeNotStaleIndex`

Each builds a feature whose stale `ProfileIndex(es)` deliberately point at the wrong (large) region while the seed points at the right (small) one, and asserts the seed wins at recompute. Full `model/...` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)