### PR TITLE
feat(head): Windows in-process .dll add-in loader (parity with dlopen)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,10 +253,17 @@ jobs:
       # LoadLibrary/GetProcAddress) is exercised ONLY on Windows — the ubuntu `head`
       # job covers the dlopen path and this job otherwise just compiles. Run the
       # loader/automation/reload/tree/gate suite so the Win32 trampoline stays at
-      # parity on every PR (it builds real c-shared .dll fixtures via mingw gcc).
+      # parity on every PR (it builds real c-shared .dll fixtures via mingw gcc), and
+      # emit a coverprofile so SonarCloud actually measures dl_windows.go's coverage.
       - name: Test head add-in loader (Windows .dll)
         working-directory: head
-        run: CGO_ENABLED=1 go test ./internal/addinhost/...
+        run: CGO_ENABLED=1 go test -coverprofile=coverage-windows.out -covermode=count ./internal/addinhost/...
+      # Windows-only .dll loader coverage (dl_windows.go) for the SonarCloud `sonar` job —
+      # the ubuntu `head` job's Linux profile never contains dl_windows.go (build-tagged out).
+      - uses: actions/upload-artifact@v6
+        with:
+          name: coverage-head-windows
+          path: head/coverage-windows.out
 
   # Confirm the cgo-free core cross-compiles for every shipping target.
   build:
@@ -282,11 +289,11 @@ jobs:
 
   # Upload Go coverage to SonarCloud so it can measure coverage on new code (Automatic
   # Analysis cannot import Go coverage — sonar-project.properties has the one-time
-  # setup). Reuses the coverage profiles produced by the `test` (root) and `head` jobs,
-  # so it adds no extra test runs. The scan is SKIPPED until SONAR_TOKEN is set, so the
-  # job is green meanwhile.
+  # setup). Reuses the coverage profiles produced by the `test` (root), `head` (Linux),
+  # and `head-windows` (Windows .dll loader) jobs, so it adds no extra test runs. The
+  # scan is SKIPPED until SONAR_TOKEN is set, so the job is green meanwhile.
   sonar:
-    needs: [test, head]
+    needs: [test, head, head-windows]
     runs-on: ubuntu-latest
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -301,6 +308,10 @@ jobs:
       - uses: actions/download-artifact@v7
         with:
           name: coverage-head
+          path: head
+      - uses: actions/download-artifact@v7
+        with:
+          name: coverage-head-windows
           path: head
       - name: SonarCloud scan (coverage upload)
         if: env.SONAR_TOKEN != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,14 @@ jobs:
       - name: Build head
         working-directory: head
         run: CGO_ENABLED=1 go build ./...
+      # The in-process .dll add-in loader (internal/addinhost, dl_windows.go:
+      # LoadLibrary/GetProcAddress) is exercised ONLY on Windows — the ubuntu `head`
+      # job covers the dlopen path and this job otherwise just compiles. Run the
+      # loader/automation/reload/tree/gate suite so the Win32 trampoline stays at
+      # parity on every PR (it builds real c-shared .dll fixtures via mingw gcc).
+      - name: Test head add-in loader (Windows .dll)
+        working-directory: head
+        run: CGO_ENABLED=1 go test ./internal/addinhost/...
 
   # Confirm the cgo-free core cross-compiles for every shipping target.
   build:

--- a/head/internal/addinhost/automation_test.go
+++ b/head/internal/addinhost/automation_test.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build linux || darwin || windows
 
 // SPDX-License-Identifier: GPL-2.0-only
 

--- a/head/internal/addinhost/dl_shared.go
+++ b/head/internal/addinhost/dl_shared.go
@@ -41,6 +41,55 @@ type sharedLib struct {
 	path     string
 }
 
+// openLibrary loads the shared library at path and resolves the required ObkAddIn*
+// exports, returning a ready sharedLib. The orchestration — required-symbol list,
+// resolve loop, optional-symbol resolution, and struct assembly — is identical on
+// every OS and lives here once; each platform (dl_unix.go / dl_windows.go) supplies
+// only its irreducible primitives (openNativeLibrary / lookupSymbol /
+// lookupOptionalSymbol / closeNativeLibrary).
+func openLibrary(path string) (addInLib, error) {
+	h, err := openNativeLibrary(path)
+	if err != nil {
+		return nil, err
+	}
+	l := &sharedLib{handle: h, path: path}
+	required := []struct {
+		name string
+		dst  *unsafe.Pointer
+	}{
+		{"ObkAddInId", &l.idSym},
+		{"ObkAddInManifest", &l.manSym},
+		{"ObkAddInActivate", &l.actSym},
+		{"ObkAddInDeactivate", &l.deactSym},
+		{"ObkAddInNotify", &l.notifSym},
+		{"ObkFree", &l.freeSym},
+	}
+	for _, s := range required {
+		if *s.dst, err = lookupSymbol(h, s.name); err != nil {
+			_ = closeNativeLibrary(h) // unwind the partial load (a no-op on Windows)
+			return nil, err
+		}
+	}
+	// Automation is an optional export: absence just means hasAutomation() is false.
+	l.autoSym = lookupOptionalSymbol(h, "ObkAddInAutomation")
+	// The version exports are resolved leniently so a missing one does not abort the
+	// whole load; the compatibility gate (loader.go) turns their absence into a clear
+	// "cannot verify compatibility" skip rather than a symbol-lookup error.
+	l.majorSym = lookupOptionalSymbol(h, "ObkAddInApiMajor")
+	l.minorSym = lookupOptionalSymbol(h, "ObkAddInApiMinor")
+	return l, nil
+}
+
+// close unloads the library through the platform primitive, tagging the path onto any
+// failure. On Unix this dlcloses; on Windows closeNativeLibrary deliberately leaves the
+// module resident (see dl_windows.go), so this returns nil there.
+func (l *sharedLib) close() error {
+	if err := closeNativeLibrary(l.handle); err != nil {
+		return fmt.Errorf("addinhost: closing %q: %w", l.path, err)
+	}
+	return nil
+}
+
 func (l *sharedLib) id() string       { return C.GoString(C.call_str(l.idSym)) }
 func (l *sharedLib) manifest() string { return C.GoString(C.call_str(l.manSym)) }
 

--- a/head/internal/addinhost/dl_shared.go
+++ b/head/internal/addinhost/dl_shared.go
@@ -1,0 +1,109 @@
+//go:build linux || darwin || windows
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package addinhost
+
+/*
+#cgo CFLAGS: -I${SRCDIR}/include
+#include <stdlib.h>
+#include <stdint.h>
+#include "addin_trampolines.h"
+*/
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+// sharedLib is a loaded shared-library add-in with its resolved C entry points. The
+// handle and symbol pointers are opaque void* (a dlopen handle + dlsym results on
+// Unix, an HMODULE + GetProcAddress results on Windows); the OS-specific loader
+// primitives that populate them live in dl_unix.go / dl_windows.go, while every
+// export invocation below is platform-independent — it goes through the call_*
+// trampolines in include/addin_trampolines.h, so it is written once here.
+//
+// autoSym is the OPTIONAL ObkAddInAutomation export (nil when the add-in has no
+// automation surface, M05-F01 #252); freeSym is the add-in's ObkFree, which releases
+// the buffers automation hands back across the runtime boundary.
+type sharedLib struct {
+	handle   unsafe.Pointer
+	idSym    unsafe.Pointer
+	manSym   unsafe.Pointer
+	majorSym unsafe.Pointer
+	minorSym unsafe.Pointer
+	actSym   unsafe.Pointer
+	deactSym unsafe.Pointer
+	notifSym unsafe.Pointer
+	freeSym  unsafe.Pointer
+	autoSym  unsafe.Pointer
+	path     string
+}
+
+func (l *sharedLib) id() string       { return C.GoString(C.call_str(l.idSym)) }
+func (l *sharedLib) manifest() string { return C.GoString(C.call_str(l.manSym)) }
+
+// apiVersion reports the oblikovati.org/api major/minor the add-in was compiled
+// against (ObkAddInApiMajor/ObkAddInApiMinor). present is false when the add-in omits
+// either export, which the loader's gate treats as incompatible.
+func (l *sharedLib) apiVersion() (major, minor int, present bool) {
+	if l.majorSym == nil || l.minorSym == nil {
+		return 0, 0, false
+	}
+	return int(C.call_int(l.majorSym)), int(C.call_int(l.minorSym)), true
+}
+
+func (l *sharedLib) activate() error {
+	if rc := C.call_activate(l.actSym); rc != C.int(C.OBK_OK) {
+		return fmt.Errorf("addinhost: ObkAddInActivate %q returned %d", l.path, int(rc))
+	}
+	return nil
+}
+
+func (l *sharedLib) deactivate() error {
+	if rc := C.call_void(l.deactSym); rc != C.int(C.OBK_OK) {
+		return fmt.Errorf("addinhost: ObkAddInDeactivate %q returned %d", l.path, int(rc))
+	}
+	return nil
+}
+
+func (l *sharedLib) notify(b []byte) error {
+	var p *C.uint8_t
+	if len(b) > 0 {
+		p = (*C.uint8_t)(unsafe.Pointer(&b[0]))
+	}
+	if rc := C.call_notify(l.notifSym, p, C.int(len(b))); rc != C.int(C.OBK_OK) {
+		return fmt.Errorf("addinhost: ObkAddInNotify %q returned %d", l.path, int(rc))
+	}
+	return nil
+}
+
+func (l *sharedLib) hasAutomation() bool { return l.autoSym != nil }
+
+// automation invokes the add-in's optional ObkAddInAutomation export. The reply
+// buffer is allocated by the add-in's runtime, so it is copied out and released
+// through the add-in's own ObkFree (the cross-runtime ownership rule of the header).
+func (l *sharedLib) automation(method string, req []byte) ([]byte, error) {
+	if l.autoSym == nil {
+		return nil, fmt.Errorf("addinhost: add-in %q exports no ObkAddInAutomation", l.path)
+	}
+	cm := C.CString(method)
+	defer C.free(unsafe.Pointer(cm))
+	var reqPtr *C.uint8_t
+	if len(req) > 0 {
+		reqPtr = (*C.uint8_t)(unsafe.Pointer(&req[0]))
+	}
+	var resp *C.uint8_t
+	var respLen C.int
+	rc := C.call_automation(l.autoSym, cm, reqPtr, C.int(len(req)), &resp, &respLen) //nolint:gocritic // dupSubExpr false positive from cgo's generated call site
+	var out []byte
+	if resp != nil {
+		out = C.GoBytes(unsafe.Pointer(resp), respLen)
+		C.call_addin_free(l.freeSym, resp)
+	}
+	if rc != C.int(C.OBK_OK) {
+		return nil, fmt.Errorf("addinhost: automation %q on %q failed: %s", method, l.path, string(out))
+	}
+	return out, nil
+}

--- a/head/internal/addinhost/dl_unix.go
+++ b/head/internal/addinhost/dl_unix.go
@@ -5,36 +5,9 @@
 package addinhost
 
 /*
-#cgo CFLAGS: -I${SRCDIR}/include
 #cgo LDFLAGS: -ldl
 #include <dlfcn.h>
 #include <stdlib.h>
-#include <stdint.h>
-#include "oblikovati_addin.h"
-
-// The host's C-ABI callbacks (defined via //export in hostcall.go). Declared with
-// non-const params to match cgo's generated prototypes; the casts below adapt them
-// to the (const-qualified) ObkHostCall/ObkHostFree typedefs.
-extern int  ObkHostDispatch(char* method, uint8_t* req, int reqLen, uint8_t** resp, int* respLen);
-extern void ObkHostReleaseBuf(uint8_t* p);
-
-// Function-pointer trampolines: cgo cannot call a Go-held C pointer directly, so we
-// cast each dlsym result to its typedef and invoke it from C.
-typedef const char* (*strFn)(void);
-typedef int  (*intFn)(void);
-typedef int  (*activateFn)(ObkHostCall, ObkHostFree);
-typedef int  (*voidFn)(void);
-typedef int  (*notifyFn)(const uint8_t*, int);
-typedef int  (*automationFn)(const char*, const uint8_t*, int, uint8_t**, int*);
-typedef void (*freeFn)(uint8_t*);
-
-static const char* call_str(void* fn)               { return ((strFn)fn)(); }
-static int  call_int(void* fn)                       { return ((intFn)fn)(); }
-static int  call_activate(void* fn)                  { return ((activateFn)fn)((ObkHostCall)ObkHostDispatch, (ObkHostFree)ObkHostReleaseBuf); }
-static int  call_void(void* fn)                      { return ((voidFn)fn)(); }
-static int  call_notify(void* fn, const uint8_t* ev, int n) { return ((notifyFn)fn)(ev, n); }
-static int  call_automation(void* fn, const char* method, const uint8_t* req, int n, uint8_t** resp, int* respLen) { return ((automationFn)fn)(method, req, n, resp, respLen); }
-static void call_addin_free(void* fn, uint8_t* p)    { ((freeFn)fn)(p); }
 */
 import "C"
 
@@ -43,25 +16,9 @@ import (
 	"unsafe"
 )
 
-// unixLib is a dlopen'd add-in with its resolved C entry points. autoSym is the
-// OPTIONAL ObkAddInAutomation export (nil when the add-in has no automation
-// surface, M05-F01 #252); freeSym is the add-in's ObkFree, which releases the
-// buffers automation hands back across the runtime boundary.
-type unixLib struct {
-	handle   unsafe.Pointer
-	idSym    unsafe.Pointer
-	manSym   unsafe.Pointer
-	majorSym unsafe.Pointer
-	minorSym unsafe.Pointer
-	actSym   unsafe.Pointer
-	deactSym unsafe.Pointer
-	notifSym unsafe.Pointer
-	freeSym  unsafe.Pointer
-	autoSym  unsafe.Pointer
-	path     string
-}
-
-// openLibrary dlopens path and resolves the required ObkAddIn* exports.
+// openLibrary dlopens path and resolves the required ObkAddIn* exports into a
+// sharedLib (dl_shared.go holds the portable export-invocation code; this file holds
+// only the dlfcn loader primitives).
 func openLibrary(path string) (addInLib, error) {
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
@@ -69,7 +26,7 @@ func openLibrary(path string) (addInLib, error) {
 	if h == nil {
 		return nil, fmt.Errorf("addinhost: dlopen %q: %s", path, C.GoString(C.dlerror()))
 	}
-	l := &unixLib{handle: h, path: path}
+	l := &sharedLib{handle: h, path: path}
 	syms := []struct {
 		name string
 		dst  *unsafe.Pointer
@@ -117,74 +74,8 @@ func resolve(h unsafe.Pointer, name string) (unsafe.Pointer, error) {
 	return p, nil
 }
 
-func (l *unixLib) id() string       { return C.GoString(C.call_str(l.idSym)) }
-func (l *unixLib) manifest() string { return C.GoString(C.call_str(l.manSym)) }
-
-// apiVersion reports the oblikovati.org/api major/minor the add-in was compiled
-// against (ObkAddInApiMajor/ObkAddInApiMinor). present is false when the add-in omits
-// either export, which the loader's gate treats as incompatible.
-func (l *unixLib) apiVersion() (major, minor int, present bool) {
-	if l.majorSym == nil || l.minorSym == nil {
-		return 0, 0, false
-	}
-	return int(C.call_int(l.majorSym)), int(C.call_int(l.minorSym)), true
-}
-
-func (l *unixLib) activate() error {
-	if rc := C.call_activate(l.actSym); rc != C.int(C.OBK_OK) {
-		return fmt.Errorf("addinhost: ObkAddInActivate %q returned %d", l.path, int(rc))
-	}
-	return nil
-}
-
-func (l *unixLib) deactivate() error {
-	if rc := C.call_void(l.deactSym); rc != C.int(C.OBK_OK) {
-		return fmt.Errorf("addinhost: ObkAddInDeactivate %q returned %d", l.path, int(rc))
-	}
-	return nil
-}
-
-func (l *unixLib) notify(b []byte) error {
-	var p *C.uint8_t
-	if len(b) > 0 {
-		p = (*C.uint8_t)(unsafe.Pointer(&b[0]))
-	}
-	if rc := C.call_notify(l.notifSym, p, C.int(len(b))); rc != C.int(C.OBK_OK) {
-		return fmt.Errorf("addinhost: ObkAddInNotify %q returned %d", l.path, int(rc))
-	}
-	return nil
-}
-
-func (l *unixLib) hasAutomation() bool { return l.autoSym != nil }
-
-// automation invokes the add-in's optional ObkAddInAutomation export. The reply
-// buffer is allocated by the add-in's runtime, so it is copied out and released
-// through the add-in's own ObkFree (the cross-runtime ownership rule of the header).
-func (l *unixLib) automation(method string, req []byte) ([]byte, error) {
-	if l.autoSym == nil {
-		return nil, fmt.Errorf("addinhost: add-in %q exports no ObkAddInAutomation", l.path)
-	}
-	cm := C.CString(method)
-	defer C.free(unsafe.Pointer(cm))
-	var reqPtr *C.uint8_t
-	if len(req) > 0 {
-		reqPtr = (*C.uint8_t)(unsafe.Pointer(&req[0]))
-	}
-	var resp *C.uint8_t
-	var respLen C.int
-	rc := C.call_automation(l.autoSym, cm, reqPtr, C.int(len(req)), &resp, &respLen) //nolint:gocritic // dupSubExpr false positive from cgo's generated call site
-	var out []byte
-	if resp != nil {
-		out = C.GoBytes(unsafe.Pointer(resp), respLen)
-		C.call_addin_free(l.freeSym, resp)
-	}
-	if rc != C.int(C.OBK_OK) {
-		return nil, fmt.Errorf("addinhost: automation %q on %q failed: %s", method, l.path, string(out))
-	}
-	return out, nil
-}
-
-func (l *unixLib) close() error {
+// close unmaps the shared library (dlclose); a non-zero return is an error.
+func (l *sharedLib) close() error {
 	if rc := C.dlclose(l.handle); rc != 0 {
 		return fmt.Errorf("addinhost: dlclose %q: %s", l.path, C.GoString(C.dlerror()))
 	}

--- a/head/internal/addinhost/dl_unix.go
+++ b/head/internal/addinhost/dl_unix.go
@@ -16,68 +16,40 @@ import (
 	"unsafe"
 )
 
-// openLibrary dlopens path and resolves the required ObkAddIn* exports into a
-// sharedLib (dl_shared.go holds the portable export-invocation code; this file holds
-// only the dlfcn loader primitives).
-func openLibrary(path string) (addInLib, error) {
+// openNativeLibrary dlopens path — the dlfcn loader primitive behind the shared
+// openLibrary in dl_shared.go. RTLD_NOW surfaces missing symbols immediately;
+// RTLD_LOCAL keeps the add-in's symbols out of the global namespace.
+func openNativeLibrary(path string) (unsafe.Pointer, error) {
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
 	h := C.dlopen(cpath, C.RTLD_NOW|C.RTLD_LOCAL)
 	if h == nil {
 		return nil, fmt.Errorf("addinhost: dlopen %q: %s", path, C.GoString(C.dlerror()))
 	}
-	l := &sharedLib{handle: h, path: path}
-	syms := []struct {
-		name string
-		dst  *unsafe.Pointer
-	}{
-		{"ObkAddInId", &l.idSym},
-		{"ObkAddInManifest", &l.manSym},
-		{"ObkAddInActivate", &l.actSym},
-		{"ObkAddInDeactivate", &l.deactSym},
-		{"ObkAddInNotify", &l.notifSym},
-		{"ObkFree", &l.freeSym},
-	}
-	for _, s := range syms {
-		p, err := resolve(h, s.name)
-		if err != nil {
-			C.dlclose(h)
-			return nil, err
-		}
-		*s.dst = p
-	}
-	// Automation is an optional export: absence just means hasAutomation() is false.
-	l.autoSym = resolveOptional(h, "ObkAddInAutomation")
-	// The version exports are resolved leniently so a missing one does not abort the
-	// whole load; the compatibility gate (loader.go) turns their absence into a clear
-	// "cannot verify compatibility" skip rather than a dlsym error.
-	l.majorSym = resolveOptional(h, "ObkAddInApiMajor")
-	l.minorSym = resolveOptional(h, "ObkAddInApiMinor")
-	return l, nil
+	return h, nil
 }
 
-// resolveOptional looks up a symbol the contract marks optional; nil means absent.
-func resolveOptional(h unsafe.Pointer, name string) unsafe.Pointer {
+// lookupOptionalSymbol resolves a symbol the contract marks optional; nil means absent.
+func lookupOptionalSymbol(h unsafe.Pointer, name string) unsafe.Pointer {
 	cn := C.CString(name)
 	defer C.free(unsafe.Pointer(cn))
 	return C.dlsym(h, cn)
 }
 
-// resolve looks up a required symbol, returning a descriptive error if absent.
-func resolve(h unsafe.Pointer, name string) (unsafe.Pointer, error) {
-	cn := C.CString(name)
-	defer C.free(unsafe.Pointer(cn))
-	p := C.dlsym(h, cn)
-	if p == nil {
-		return nil, fmt.Errorf("addinhost: dlsym %q: %s", name, C.GoString(C.dlerror()))
+// lookupSymbol resolves a required symbol, returning an error naming the symbol and the
+// dlerror text if absent.
+func lookupSymbol(h unsafe.Pointer, name string) (unsafe.Pointer, error) {
+	if p := lookupOptionalSymbol(h, name); p != nil {
+		return p, nil
 	}
-	return p, nil
+	return nil, fmt.Errorf("addinhost: dlsym %q: %s", name, C.GoString(C.dlerror()))
 }
 
-// close unmaps the shared library (dlclose); a non-zero return is an error.
-func (l *sharedLib) close() error {
-	if rc := C.dlclose(l.handle); rc != 0 {
-		return fmt.Errorf("addinhost: dlclose %q: %s", l.path, C.GoString(C.dlerror()))
+// closeNativeLibrary dlcloses the handle; a non-zero return is an error (the shared
+// close() in dl_shared.go tags the add-in path onto it).
+func closeNativeLibrary(h unsafe.Pointer) error {
+	if rc := C.dlclose(h); rc != 0 {
+		return fmt.Errorf("dlclose: %s", C.GoString(C.dlerror()))
 	}
 	return nil
 }

--- a/head/internal/addinhost/dl_windows.go
+++ b/head/internal/addinhost/dl_windows.go
@@ -4,13 +4,137 @@
 
 package addinhost
 
-import "errors"
+/*
+#include <windows.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
 
-// openLibrary on Windows is a fast-follow: passing the host's //export'd callback
-// to a c-shared add-in via LoadLibrary/GetProcAddress needs its own trampoline
-// wiring. Until then loading errors out clearly rather than silently no-op'ing, so
-// the .dll story is explicit. (Linux/macOS .so/.dylib loading is implemented in
-// dl_unix.go.)
-func openLibrary(path string) (addInLib, error) {
-	return nil, errors.New("addinhost: shared-library add-ins are not yet supported on Windows (.dll loading is a fast-follow); path=" + path)
+// Windows loader primitives — the only OS-specific part of the add-in loader. The
+// resolved symbols are invoked through the portable trampolines in
+// include/addin_trampolines.h (shared with dl_unix.go, pulled in via dl_shared.go),
+// so only these Win32 calls differ from the dlopen/dlsym path.
+//
+// GetProcAddress returns FARPROC and LoadLibraryW an HMODULE; the (void*) casts to
+// the opaque handle the Go side stores happen here in C, where a function-pointer
+// <-> void* cast is the idiomatic Win32 pattern (mirroring how dlsym hands back a
+// void* on Unix). There is deliberately NO FreeLibrary wrapper: a loaded Go c-shared
+// add-in cannot be safely unmapped (see close() below).
+
+// obk_errbuf holds the last FormatMessage'd error text. It is process-static and
+// overwritten on each failure, so the Go caller reads it (into a Go error) right
+// after the failing call. Loads are serialized in practice; dlerror() on Unix has
+// the same single-buffer contract.
+static char obk_errbuf[512];
+
+static void obk_capture_error(void) {
+	unsigned long code = GetLastError();
+	DWORD n = FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+	                         NULL, code, 0, obk_errbuf, (DWORD)sizeof(obk_errbuf), NULL);
+	if (n == 0) {
+		snprintf(obk_errbuf, sizeof(obk_errbuf), "GetLastError=%lu", code);
+		return;
+	}
+	// FormatMessage appends a trailing CRLF; trim it so the Go error reads cleanly.
+	while (n > 0 && (obk_errbuf[n-1] == '\n' || obk_errbuf[n-1] == '\r')) obk_errbuf[--n] = 0;
 }
+
+static const char* obk_last_message(void) { return obk_errbuf; }
+
+static void* obk_load_library(const wchar_t* path) {
+	HMODULE h = LoadLibraryW(path);
+	if (h == NULL) obk_capture_error();
+	return (void*)h;
+}
+
+static void* obk_get_proc(void* h, const char* name) {
+	FARPROC p = GetProcAddress((HMODULE)h, name);
+	if (p == NULL) obk_capture_error();
+	return (void*)p;
+}
+*/
+import "C"
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+)
+
+// openLibrary LoadLibrary's path and resolves the required ObkAddIn* exports into a
+// sharedLib (dl_shared.go holds the portable export-invocation code; this file holds
+// only the Win32 loader primitives). The path is passed as UTF-16 via LoadLibraryW so
+// non-ASCII add-in paths load correctly.
+func openLibrary(path string) (addInLib, error) {
+	wpath, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, fmt.Errorf("addinhost: LoadLibrary path %q not encodable as UTF-16: %w", path, err)
+	}
+	h := C.obk_load_library((*C.wchar_t)(unsafe.Pointer(wpath)))
+	if h == nil {
+		return nil, fmt.Errorf("addinhost: LoadLibrary %q: %s", path, lastError())
+	}
+	l := &sharedLib{handle: h, path: path}
+	syms := []struct {
+		name string
+		dst  *unsafe.Pointer
+	}{
+		{"ObkAddInId", &l.idSym},
+		{"ObkAddInManifest", &l.manSym},
+		{"ObkAddInActivate", &l.actSym},
+		{"ObkAddInDeactivate", &l.deactSym},
+		{"ObkAddInNotify", &l.notifSym},
+		{"ObkFree", &l.freeSym},
+	}
+	for _, s := range syms {
+		p, err := resolve(h, s.name)
+		if err != nil {
+			// Deliberately do NOT FreeLibrary the partially-resolved module: once loaded,
+			// its Go runtime has already spawned threads, and unmapping it here would race
+			// them into a crash exactly as close() explains. A malformed add-in is rare;
+			// leaking its mapping is strictly safer than crashing the host.
+			return nil, err
+		}
+		*s.dst = p
+	}
+	// Automation is an optional export: absence just means hasAutomation() is false.
+	l.autoSym = resolveOptional(h, "ObkAddInAutomation")
+	// The version exports are resolved leniently so a missing one does not abort the
+	// whole load; the compatibility gate (loader.go) turns their absence into a clear
+	// "cannot verify compatibility" skip rather than a GetProcAddress error.
+	l.majorSym = resolveOptional(h, "ObkAddInApiMajor")
+	l.minorSym = resolveOptional(h, "ObkAddInApiMinor")
+	return l, nil
+}
+
+// resolveOptional looks up a symbol the contract marks optional; nil means absent.
+func resolveOptional(h unsafe.Pointer, name string) unsafe.Pointer {
+	cn := C.CString(name)
+	defer C.free(unsafe.Pointer(cn))
+	return C.obk_get_proc(h, cn)
+}
+
+// resolve looks up a required symbol, returning a descriptive error (naming the
+// symbol and the GetLastError text) if absent.
+func resolve(h unsafe.Pointer, name string) (unsafe.Pointer, error) {
+	p := resolveOptional(h, name)
+	if p == nil {
+		return nil, fmt.Errorf("addinhost: GetProcAddress %q: %s", name, lastError())
+	}
+	return p, nil
+}
+
+// close leaves the shared library RESIDENT — it does not FreeLibrary. This mirrors the
+// Unix host's own lifetime rule (cmd/oblikovati-head/addins.go stop(): "It does NOT
+// dlclose the libraries: a Go c-shared keeps runtime threads (sysmon/GC) alive, and
+// unmapping its code ... crashes the host"). On Windows that hazard is sharper: calling
+// FreeLibrary on a live Go c-shared DLL unmaps its code while its runtime's background
+// threads are still executing, which faults the process with an access violation
+// (0xc0000005). So the safe, production-matching behavior is to keep the module mapped
+// for the process lifetime; the OS reclaims it on exit. Reload therefore follows the
+// same copy-and-coexist strategy as Unix (a fresh LoadLibrary of a replacement copy),
+// never an in-process unload. Returns nil because there is nothing to fail.
+func (l *sharedLib) close() error { return nil }
+
+// lastError returns the text of the most recent Win32 loader failure captured in C.
+func lastError() string { return C.GoString(C.obk_last_message()) }

--- a/head/internal/addinhost/dl_windows.go
+++ b/head/internal/addinhost/dl_windows.go
@@ -13,13 +13,14 @@ package addinhost
 // Windows loader primitives — the only OS-specific part of the add-in loader. The
 // resolved symbols are invoked through the portable trampolines in
 // include/addin_trampolines.h (shared with dl_unix.go, pulled in via dl_shared.go),
-// so only these Win32 calls differ from the dlopen/dlsym path.
+// and the shared openLibrary orchestration lives in dl_shared.go; only these Win32
+// calls differ from the dlopen/dlsym path.
 //
 // GetProcAddress returns FARPROC and LoadLibraryW an HMODULE; the (void*) casts to
 // the opaque handle the Go side stores happen here in C, where a function-pointer
 // <-> void* cast is the idiomatic Win32 pattern (mirroring how dlsym hands back a
 // void* on Unix). There is deliberately NO FreeLibrary wrapper: a loaded Go c-shared
-// add-in cannot be safely unmapped (see close() below).
+// add-in cannot be safely unmapped (see closeNativeLibrary below).
 
 // obk_errbuf holds the last FormatMessage'd error text. It is process-static and
 // overwritten on each failure, so the Go caller reads it (into a Go error) right
@@ -61,11 +62,10 @@ import (
 	"unsafe"
 )
 
-// openLibrary LoadLibrary's path and resolves the required ObkAddIn* exports into a
-// sharedLib (dl_shared.go holds the portable export-invocation code; this file holds
-// only the Win32 loader primitives). The path is passed as UTF-16 via LoadLibraryW so
+// openNativeLibrary LoadLibrary's path — the Win32 loader primitive behind the shared
+// openLibrary in dl_shared.go. The path is passed as UTF-16 via LoadLibraryW so
 // non-ASCII add-in paths load correctly.
-func openLibrary(path string) (addInLib, error) {
+func openNativeLibrary(path string) (unsafe.Pointer, error) {
 	wpath, err := syscall.UTF16PtrFromString(path)
 	if err != nil {
 		return nil, fmt.Errorf("addinhost: LoadLibrary path %q not encodable as UTF-16: %w", path, err)
@@ -74,67 +74,36 @@ func openLibrary(path string) (addInLib, error) {
 	if h == nil {
 		return nil, fmt.Errorf("addinhost: LoadLibrary %q: %s", path, lastError())
 	}
-	l := &sharedLib{handle: h, path: path}
-	syms := []struct {
-		name string
-		dst  *unsafe.Pointer
-	}{
-		{"ObkAddInId", &l.idSym},
-		{"ObkAddInManifest", &l.manSym},
-		{"ObkAddInActivate", &l.actSym},
-		{"ObkAddInDeactivate", &l.deactSym},
-		{"ObkAddInNotify", &l.notifSym},
-		{"ObkFree", &l.freeSym},
-	}
-	for _, s := range syms {
-		p, err := resolve(h, s.name)
-		if err != nil {
-			// Deliberately do NOT FreeLibrary the partially-resolved module: once loaded,
-			// its Go runtime has already spawned threads, and unmapping it here would race
-			// them into a crash exactly as close() explains. A malformed add-in is rare;
-			// leaking its mapping is strictly safer than crashing the host.
-			return nil, err
-		}
-		*s.dst = p
-	}
-	// Automation is an optional export: absence just means hasAutomation() is false.
-	l.autoSym = resolveOptional(h, "ObkAddInAutomation")
-	// The version exports are resolved leniently so a missing one does not abort the
-	// whole load; the compatibility gate (loader.go) turns their absence into a clear
-	// "cannot verify compatibility" skip rather than a GetProcAddress error.
-	l.majorSym = resolveOptional(h, "ObkAddInApiMajor")
-	l.minorSym = resolveOptional(h, "ObkAddInApiMinor")
-	return l, nil
+	return h, nil
 }
 
-// resolveOptional looks up a symbol the contract marks optional; nil means absent.
-func resolveOptional(h unsafe.Pointer, name string) unsafe.Pointer {
+// lookupOptionalSymbol resolves a symbol the contract marks optional; nil means absent.
+func lookupOptionalSymbol(h unsafe.Pointer, name string) unsafe.Pointer {
 	cn := C.CString(name)
 	defer C.free(unsafe.Pointer(cn))
 	return C.obk_get_proc(h, cn)
 }
 
-// resolve looks up a required symbol, returning a descriptive error (naming the
-// symbol and the GetLastError text) if absent.
-func resolve(h unsafe.Pointer, name string) (unsafe.Pointer, error) {
-	p := resolveOptional(h, name)
-	if p == nil {
-		return nil, fmt.Errorf("addinhost: GetProcAddress %q: %s", name, lastError())
+// lookupSymbol resolves a required symbol, returning an error naming the symbol and the
+// GetLastError text if absent.
+func lookupSymbol(h unsafe.Pointer, name string) (unsafe.Pointer, error) {
+	if p := lookupOptionalSymbol(h, name); p != nil {
+		return p, nil
 	}
-	return p, nil
+	return nil, fmt.Errorf("addinhost: GetProcAddress %q: %s", name, lastError())
 }
 
-// close leaves the shared library RESIDENT — it does not FreeLibrary. This mirrors the
-// Unix host's own lifetime rule (cmd/oblikovati-head/addins.go stop(): "It does NOT
-// dlclose the libraries: a Go c-shared keeps runtime threads (sysmon/GC) alive, and
-// unmapping its code ... crashes the host"). On Windows that hazard is sharper: calling
-// FreeLibrary on a live Go c-shared DLL unmaps its code while its runtime's background
-// threads are still executing, which faults the process with an access violation
-// (0xc0000005). So the safe, production-matching behavior is to keep the module mapped
-// for the process lifetime; the OS reclaims it on exit. Reload therefore follows the
-// same copy-and-coexist strategy as Unix (a fresh LoadLibrary of a replacement copy),
-// never an in-process unload. Returns nil because there is nothing to fail.
-func (l *sharedLib) close() error { return nil }
+// closeNativeLibrary intentionally leaves the module RESIDENT — it does NOT call
+// FreeLibrary, so the shared close() in dl_shared.go returns nil on Windows. This
+// mirrors the Unix host's own lifetime rule (cmd/oblikovati-head/addins.go stop(): "It
+// does NOT dlclose the libraries: a Go c-shared keeps runtime threads (sysmon/GC)
+// alive, and unmapping its code ... crashes the host"). On Windows that hazard is
+// sharper: FreeLibrary on a live Go c-shared DLL unmaps its code while its runtime's
+// background threads are still executing, faulting the process with an access violation
+// (0xc0000005). Keeping the module mapped for the process lifetime (the OS reclaims it
+// on exit) is the safe, production-matching behavior; reload uses the same
+// copy-and-coexist strategy as Unix, never an in-process unload.
+func closeNativeLibrary(unsafe.Pointer) error { return nil }
 
 // lastError returns the text of the most recent Win32 loader failure captured in C.
 func lastError() string { return C.GoString(C.obk_last_message()) }

--- a/head/internal/addinhost/include/addin_trampolines.h
+++ b/head/internal/addinhost/include/addin_trampolines.h
@@ -1,0 +1,45 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * addin_trampolines.h — the portable C shared by the Unix (dl_unix.go) and Windows
+ * (dl_windows.go) add-in loaders. It holds everything that is NOT the OS-specific
+ * loader primitive (dlopen vs LoadLibrary, dlsym vs GetProcAddress, dlclose vs
+ * FreeLibrary): the host's C-ABI callback declarations, the function-pointer
+ * typedefs for the add-in's exports, and the call_* trampolines.
+ *
+ * WHY trampolines: cgo cannot call a Go-held C function pointer directly, so each
+ * platform resolves a symbol to a void* (dlsym / GetProcAddress) and invokes it here
+ * in C by casting to its typedef. The invoking code is then identical on both OSes
+ * (dl_shared.go), and only the ~3 loader primitives differ per platform — no
+ * duplication of the trampoline C (repo CLAUDE.md "no code duplication").
+ */
+#ifndef OBLIKOVATI_ADDIN_TRAMPOLINES_H
+#define OBLIKOVATI_ADDIN_TRAMPOLINES_H
+
+#include <stdint.h>
+#include <stdlib.h>
+#include "oblikovati_addin.h"
+
+/* The host's C-ABI callbacks (defined via //export in hostcall.go). Declared with
+ * non-const params to match cgo's generated prototypes; the casts below adapt them
+ * to the (const-qualified) ObkHostCall/ObkHostFree typedefs. */
+extern int  ObkHostDispatch(char* method, uint8_t* req, int reqLen, uint8_t** resp, int* respLen);
+extern void ObkHostReleaseBuf(uint8_t* p);
+
+/* Function-pointer typedefs for the add-in's ObkAddIn* exports. */
+typedef const char* (*strFn)(void);
+typedef int  (*intFn)(void);
+typedef int  (*activateFn)(ObkHostCall, ObkHostFree);
+typedef int  (*voidFn)(void);
+typedef int  (*notifyFn)(const uint8_t*, int);
+typedef int  (*automationFn)(const char*, const uint8_t*, int, uint8_t**, int*);
+typedef void (*freeFn)(uint8_t*);
+
+static const char* call_str(void* fn)               { return ((strFn)fn)(); }
+static int  call_int(void* fn)                       { return ((intFn)fn)(); }
+static int  call_activate(void* fn)                  { return ((activateFn)fn)((ObkHostCall)ObkHostDispatch, (ObkHostFree)ObkHostReleaseBuf); }
+static int  call_void(void* fn)                      { return ((voidFn)fn)(); }
+static int  call_notify(void* fn, const uint8_t* ev, int n) { return ((notifyFn)fn)(ev, n); }
+static int  call_automation(void* fn, const char* method, const uint8_t* req, int n, uint8_t** resp, int* respLen) { return ((automationFn)fn)(method, req, n, resp, respLen); }
+static void call_addin_free(void* fn, uint8_t* p)    { ((freeFn)fn)(p); }
+
+#endif /* OBLIKOVATI_ADDIN_TRAMPOLINES_H */

--- a/head/internal/addinhost/loader_test.go
+++ b/head/internal/addinhost/loader_test.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build linux || darwin || windows
 
 // SPDX-License-Identifier: GPL-2.0-only
 
@@ -24,11 +24,7 @@ import (
 // repo's go.work workspace (which does not `use` it) must not capture it.
 func buildFixture(t *testing.T, dirName string) string {
 	t.Helper()
-	ext := ".so"
-	if runtime.GOOS == "darwin" {
-		ext = ".dylib"
-	}
-	out := filepath.Join(t.TempDir(), dirName+ext)
+	out := filepath.Join(libDir(t), dirName+sharedLibExt())
 	_, thisFile, _, _ := runtime.Caller(0)
 	src := filepath.Join(filepath.Dir(thisFile), "testdata", dirName)
 
@@ -39,6 +35,37 @@ func buildFixture(t *testing.T, dirName string) string {
 		t.Fatalf("build fixture add-in %q: %v\n%s", dirName, err, combined)
 	}
 	return out
+}
+
+// sharedLibExt is the c-shared library extension for the host OS, so fixtures build
+// (and get copied) with the extension isSharedLib recognizes: .dll on Windows,
+// .dylib on macOS, .so elsewhere.
+func sharedLibExt() string {
+	switch runtime.GOOS {
+	case "windows":
+		return ".dll"
+	case "darwin":
+		return ".dylib"
+	default:
+		return ".so"
+	}
+}
+
+// libDir makes a temp directory for hosting c-shared fixtures with BEST-EFFORT
+// cleanup. On Windows a loaded add-in DLL stays resident for the process lifetime
+// (close() cannot FreeLibrary a live Go runtime — see dl_windows.go) and Windows locks
+// a mapped image file, so t.TempDir's strict RemoveAll would fail on the still-locked
+// .dll. This helper removes what it can and ignores the lock; the OS reclaims the rest
+// at process exit. On Unix it behaves like an ordinary temp dir. Used wherever a test
+// places a library it then loads.
+func libDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "addinhost-fixture-")
+	if err != nil {
+		t.Fatalf("make fixture temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
 }
 
 // TestLoadDirRoundTripsHostCall is the seam proof: load a real c-shared add-in,
@@ -97,7 +124,7 @@ func TestLoadDirRoundTripsHostCall(t *testing.T) {
 // c-shared add-in reporting a mismatched ObkAddInApiMajor is left unloaded while a
 // compatible one in the same directory still loads.
 func TestLoadDirSkipsIncompatibleAddIn(t *testing.T) {
-	dir := t.TempDir()
+	dir := libDir(t)
 	placeFixture(t, "echoaddin", dir)
 	placeFixture(t, "incompataddin", dir)
 

--- a/head/internal/addinhost/loader_tree_test.go
+++ b/head/internal/addinhost/loader_tree_test.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build linux || darwin || windows
 
 // SPDX-License-Identifier: GPL-2.0-only
 
@@ -27,7 +27,7 @@ func copyFile(t *testing.T, src, dst string) {
 // found and loaded, with its id resolved over the C ABI.
 func TestLoadInstalledTreeNested(t *testing.T) {
 	so := buildFixture(t, "echoaddin")
-	root := t.TempDir()
+	root := libDir(t)
 	nested := filepath.Join(root, "com.oblikovati.echo-fixture", "bundle")
 	if err := os.MkdirAll(nested, 0o755); err != nil {
 		t.Fatal(err)

--- a/head/internal/addinhost/reload_test.go
+++ b/head/internal/addinhost/reload_test.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build linux || darwin || windows
 
 // SPDX-License-Identifier: GPL-2.0-only
 
@@ -90,7 +90,7 @@ func copyTo(t *testing.T, src string) string {
 	if err != nil {
 		t.Fatalf("read %q: %v", src, err)
 	}
-	dst := filepath.Join(t.TempDir(), fmt.Sprintf("copy-%d.so", time.Now().UnixNano()))
+	dst := filepath.Join(libDir(t), fmt.Sprintf("copy-%d%s", time.Now().UnixNano(), sharedLibExt()))
 	if err := os.WriteFile(dst, data, 0o755); err != nil {
 		t.Fatalf("write %q: %v", dst, err)
 	}

--- a/head/internal/addinhost/uiaddin_test.go
+++ b/head/internal/addinhost/uiaddin_test.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build linux || darwin || windows
 
 // SPDX-License-Identifier: GPL-2.0-only
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -21,8 +21,9 @@ sonar.exclusions=head/third_party/**,_api/**
 # is unaffected. (SonarQube's own guidance recommends excluding tests from CPD.)
 sonar.cpd.exclusions=**/*_test.go
 
-# Go coverage profiles uploaded by the test (root module) and head (cgo module) jobs.
-sonar.go.coverage.reportPaths=coverage.out,head/coverage.out
+# Go coverage profiles uploaded by the test (root module), head (cgo module, Linux), and
+# head-windows (cgo module — the Windows .dll add-in loader) jobs.
+sonar.go.coverage.reportPaths=coverage.out,head/coverage.out,head/coverage-windows.out
 
 # Tests and fixtures are not production code that needs covering. The cgo binding layer
 # (head/internal/native: C/C++ wrappers + their thin Go shims) carries no Go unit coverage by
@@ -50,11 +51,4 @@ sonar.go.coverage.reportPaths=coverage.out,head/coverage.out
 # matrix, but coverage is uploaded only from the ubuntu job, so they show as uncovered here
 # despite being tested — same rationale as the native bindings and DWG decode above. The
 # Linux probes (sysinfo_linux.go, sysinfo_unix.go) run on ubuntu and stay counted.
-#
-# head/internal/addinhost/dl_windows.go is the Windows-only cgo FFI loader for c-shared
-# .dll add-ins (LoadLibraryW/GetProcAddress + the FreeLibrary-is-unsafe close). It is
-# exercised by the head-windows job's addinhost tests, but coverage is uploaded only from
-# the ubuntu job, so it shows as uncovered despite being tested — same rationale as the
-# native bindings and the Windows sysinfo probe. The portable orchestration (dl_shared.go)
-# and the Linux dlopen primitives (dl_unix.go) run on ubuntu and stay counted.
-sonar.coverage.exclusions=**/*_test.go,**/testdata/**,test-utilities/**,head/internal/native/**,head/cmd/*shot/**,head/cmd/perfbench/**,kernel/exchange/dwg/decompress.go,kernel/exchange/dwg/header_r2004.go,kernel/exchange/dwg/sectionmap.go,usagestats/sysinfo_darwin.go,usagestats/sysinfo_windows.go,head/internal/addinhost/dl_windows.go
+sonar.coverage.exclusions=**/*_test.go,**/testdata/**,test-utilities/**,head/internal/native/**,head/cmd/*shot/**,head/cmd/perfbench/**,kernel/exchange/dwg/decompress.go,kernel/exchange/dwg/header_r2004.go,kernel/exchange/dwg/sectionmap.go,usagestats/sysinfo_darwin.go,usagestats/sysinfo_windows.go

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -50,4 +50,11 @@ sonar.go.coverage.reportPaths=coverage.out,head/coverage.out
 # matrix, but coverage is uploaded only from the ubuntu job, so they show as uncovered here
 # despite being tested — same rationale as the native bindings and DWG decode above. The
 # Linux probes (sysinfo_linux.go, sysinfo_unix.go) run on ubuntu and stay counted.
-sonar.coverage.exclusions=**/*_test.go,**/testdata/**,test-utilities/**,head/internal/native/**,head/cmd/*shot/**,head/cmd/perfbench/**,kernel/exchange/dwg/decompress.go,kernel/exchange/dwg/header_r2004.go,kernel/exchange/dwg/sectionmap.go,usagestats/sysinfo_darwin.go,usagestats/sysinfo_windows.go
+#
+# head/internal/addinhost/dl_windows.go is the Windows-only cgo FFI loader for c-shared
+# .dll add-ins (LoadLibraryW/GetProcAddress + the FreeLibrary-is-unsafe close). It is
+# exercised by the head-windows job's addinhost tests, but coverage is uploaded only from
+# the ubuntu job, so it shows as uncovered despite being tested — same rationale as the
+# native bindings and the Windows sysinfo probe. The portable orchestration (dl_shared.go)
+# and the Linux dlopen primitives (dl_unix.go) run on ubuntu and stay counted.
+sonar.coverage.exclusions=**/*_test.go,**/testdata/**,test-utilities/**,head/internal/native/**,head/cmd/*shot/**,head/cmd/perfbench/**,kernel/exchange/dwg/decompress.go,kernel/exchange/dwg/header_r2004.go,kernel/exchange/dwg/sectionmap.go,usagestats/sysinfo_darwin.go,usagestats/sysinfo_windows.go,head/internal/addinhost/dl_windows.go


### PR DESCRIPTION
## What & why

`head/internal/addinhost/dl_windows.go` was a stub — `openLibrary` always
returned "shared-library add-ins are not yet supported on Windows (.dll
loading is a fast-follow)". So c-shared `.dll` add-ins (notably the MCP
bridge) could not be loaded by the Windows host. This brings the Windows
loader to full parity with the working Unix `dlopen` path (`dl_unix.go`),
using the Win32 loader (`LoadLibraryW`/`GetProcAddress`/`FreeLibrary`,
`GetLastError`/`FormatMessage`).

## Trampoline implementation — factored, not duplicated

Per CLAUDE.md's "no code duplication", the portable C is shared rather
than mirrored:

- **`include/addin_trampolines.h`** (new) holds the OS-independent C: the
  host-callback `extern`s (`ObkHostDispatch`/`ObkHostReleaseBuf`), the
  add-in-export function-pointer typedefs, and the `call_*` trampolines
  (cgo cannot call a Go-held C function pointer directly, so each resolved
  symbol is invoked through these).
- **`dl_shared.go`** (new, `linux || darwin || windows`) holds the
  `sharedLib` struct and every export-invocation method
  (`id`/`manifest`/`apiVersion`/`activate`/`deactivate`/`notify`/
  `hasAutomation`/`automation`) — written once, used by both OSes through
  the shared trampolines.
- **`dl_unix.go`** keeps only `dlopen`/`dlsym`/`dlclose`. Its Go logic is
  unchanged — a mechanical `unixLib`→`sharedLib` rename plus moving the
  now-shared C to the header. **No behavioral change to the Unix path.**
- **`dl_windows.go`** implements the three Win32 primitives: `LoadLibraryW`
  with a UTF-16 path (non-ASCII add-in paths load correctly),
  `GetProcAddress` (required symbols error with the symbol name +
  `FormatMessage` text; optional `ObkAddInAutomation`/`ObkAddInApiMajor`/
  `ObkAddInApiMinor` resolve leniently to nil), and the buffer ownership
  rule in `automation()` (copy out with `C.GoBytes`, release via the
  add-in's own `ObkFree`) is preserved exactly.

## `close()` on Windows is intentionally a no-op

A loaded Go `c-shared` DLL keeps its own Go runtime threads (sysmon/GC)
alive. Calling `FreeLibrary` on it unmaps the code while those threads are
still executing → an uncatchable access violation (`0xc0000005`).
Empirically this crashed the reload/tree tests intermittently (a race).

This is the **same** hazard the host already documents on Unix
(`cmd/oblikovati-head/addins.go` `stop()`: *"It does NOT dlclose the
libraries: a Go c-shared keeps runtime threads (sysmon/GC) alive, and
unmapping its code with dlclose crashes the host"*), and the host's
hot-reload strategy is already copy-and-coexist, never in-process unload
(`TestOpenCopiesCoexistWithoutClose`). Production never calls
`LoadedAddIn.Close()` during a session. So on Windows `close()` leaves the
library resident (the OS reclaims it at process exit) and returns nil. The
Unix `dlclose` path is unchanged.

## Tests

The loader/automation/reload/tree/uiaddin test files gain the `windows`
build tag; `buildFixture` emits `.dll` on Windows; and DLL-hosting temp
dirs use best-effort cleanup (a resident Windows DLL locks its image file,
so `t.TempDir`'s strict `RemoveAll` would fail on the still-locked `.dll`).

Run on Windows 11 with the MSYS2/MinGW64 toolchain (gcc 16.1.0, Go
1.26.4) — the same toolchain the `head-windows` CI job uses. Green across
5 consecutive full runs (no flakes):

```
$ CGO_ENABLED=1 go test -v ./internal/addinhost/
--- PASS: TestAutomationExportRoundTrips (1.85s)
--- PASS: TestAutomationAbsentIsReported (1.93s)
--- PASS: TestFixturesTrackAPIMajor (0.00s)
--- PASS: TestCheckCompatibility (0.00s)
--- PASS: TestLoadDirRoundTripsHostCall (1.83s)
--- PASS: TestLoadDirSkipsIncompatibleAddIn (3.72s)
--- PASS: TestLoadDirMissingDir (0.00s)
--- PASS: TestLoadInstalledTreeNested (1.85s)
--- PASS: TestLoadInstalledTreeMissingDirIsEmpty (0.00s)
--- PASS: TestFirstSharedLib (0.00s)
--- PASS: TestOpenReloadCycle (1.87s)
--- PASS: TestOpenCopiesCoexistWithoutClose (1.86s)
--- PASS: TestOpenMissing (0.00s)
--- PASS: TestAddInExtendsRibbonAndActsOnClick (1.99s)
PASS
ok  	oblikovati.org/head/internal/addinhost	17.816s
```

`go build ./...` (whole head module) and `go vet ./internal/addinhost/`
both clean on Windows.

## CI matrix note

The `head-windows` job previously ran **only** `go build ./...` — the
addinhost tests execute solely in the ubuntu `head` job (the dlopen
path). So the Windows loader would have been compile-checked but never
test-run in CI. This PR adds a targeted `go test ./internal/addinhost/...`
step to the `head-windows` job (mingw builds the real `.dll` fixtures),
so the Win32 trampoline is verified on every PR.

## Not verified on the author's machine

- **Linux/macOS compile of the refactored shared C.** No Linux/cross
  cgo toolchain was available here. The `dl_unix.go` change is mechanical
  (rename + moving unchanged C into an included header) and `dl_shared.go`
  compiles on Windows with the same header, but the Linux `head` CI job is
  the real confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
