### PR TITLE
feat(head): headless add-in host (GUI-free bridge endpoint)

### DIFF
--- a/head/cmd/oblikovati-addinhost/main.go
+++ b/head/cmd/oblikovati-addinhost/main.go
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Command oblikovati-addinhost is a headless (no Vulkan/GUI) host for shared-library
+// add-ins. It replicates the add-in wiring of cmd/oblikovati-head/addins.go — install
+// the router as the host-call handler, load and activate every add-in in a directory,
+// and drain the dispatch queue on this single "session goroutine" forever — but without
+// a renderer. It brings an add-in's endpoint up on a machine (or CI) that cannot build
+// the cgo head, and proves the loader → c-shared → live-kernel chain end to end. Its
+// intended use is a GUI-free bridge endpoint for CI, automation, and external clients
+// such as the Inventor exporter.
+//
+// Environment:
+//
+//	OBK_ADDINS_DIR  directory holding each add-in's shared library (.dll/.so/.dylib) and
+//	                its manifest.json. Defaults to an "addins" folder beside the exe.
+//	OBK_MCP_ADDR    read by the MCP bridge add-in (not by this host) to choose the
+//	                address it serves on, e.g. 127.0.0.1:7800.
+//
+// Example (serve the MCP bridge add-in, then drive it):
+//
+//	OBK_ADDINS_DIR=/path/to/bridge OBK_MCP_ADDR=127.0.0.1:7800 ./oblikovati-addinhost &
+//	go run ./cmd/mcpcheck --url http://127.0.0.1:7800/mcp   # mcpcheck ships with the bridge add-in
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"oblikovati.org/addin/dispatch"
+	"oblikovati.org/addin/opregistry"
+	"oblikovati.org/addin/router"
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/addinhost"
+	"oblikovati.org/persistence"
+)
+
+// hostCallTimeout caps how long an add-in's host call waits to be drained. The drain
+// loop runs every drainInterval, so normal latency is sub-millisecond; the timeout only
+// guards a stalled loop.
+const hostCallTimeout = 10 * time.Second
+
+// drainInterval is how often the session goroutine services queued add-in calls. A few
+// milliseconds keeps MCP round-trips snappy without busy-spinning the CPU.
+const drainInterval = 3 * time.Millisecond
+
+// drainPerTick bounds how many queued add-in calls run per tick, so a burst of requests
+// cannot monopolize the loop.
+const drainPerTick = 32
+
+// dispatchCapacity is the depth of the add-in→host work queue before Submit blocks for
+// backpressure; matches the head's frame-loop dispatcher (cmd/oblikovati-head/addins.go).
+const dispatchCapacity = 64
+
+func main() {
+	session, err := newHostSession()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "oblikovati-addinhost: %v\n", err)
+		os.Exit(1)
+	}
+	d := dispatch.New(dispatchCapacity)
+	installHost(session, d)
+	startAddIns(session, addInsDir())
+	runDrainLoop(d)
+}
+
+// newHostSession builds a session with a real file-backed store (so save_document /
+// documents.saveAs actually write .obk files, as the CLI does) and the standard command
+// set registered — the same baseline the head starts from.
+func newHostSession() (*app.Session, error) {
+	session := app.NewSessionWithStore(persistence.NewPackageStore())
+	if err := app.RegisterStandardCommands(session); err != nil {
+		return nil, fmt.Errorf("register standard commands: %w", err)
+	}
+	return session, nil
+}
+
+// newRouterHandler returns the host-call handler that routes every add-in request
+// through the router over session. It runs on the session goroutine (inside
+// Dispatcher.Drain), so it may touch the non-thread-safe model.
+func newRouterHandler(session *app.Session) addinhost.Handler {
+	rtr := router.New(opregistry.Default())
+	return func(method string, req []byte) ([]byte, error) {
+		return rtr.Handle(session, method, req)
+	}
+}
+
+// installHost wires the dispatcher + router handler as the C-ABI host, so every add-in
+// host call serializes onto the dispatcher the drain loop services. Call once before
+// activating any add-in.
+func installHost(session *app.Session, d *dispatch.Dispatcher) {
+	addinhost.SetHost(d, newRouterHandler(session), hostCallTimeout)
+}
+
+// startAddIns loads, registers, and activates every add-in in dir, reporting load
+// errors, version-skips, and per-add-in failures on stderr, and returns the ids it
+// activated. The host must already be installed (installHost); the caller must start
+// draining right after, because an add-in's Activate may make blocking host calls.
+func startAddIns(session *app.Session, dir string) []string {
+	fmt.Fprintf(os.Stderr, "oblikovati-addinhost: scanning add-ins in %q\n", dir)
+	libs, skipped, err := addinhost.LoadDir(dir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "oblikovati-addinhost: load add-ins in %q: %v\n", dir, err)
+	}
+	for _, sk := range skipped {
+		fmt.Fprintf(os.Stderr, "oblikovati-addinhost: add-in %q skipped (incompatible): %s\n", sk.ID, sk.Reason)
+	}
+	activated, failures := activateEach(session, libs)
+	for _, f := range failures {
+		fmt.Fprintf(os.Stderr, "oblikovati-addinhost: %v\n", f)
+	}
+	fmt.Fprintf(os.Stderr, "oblikovati-addinhost: %d add-in(s) activated, %d skipped, %d failed\n",
+		len(activated), len(skipped), len(failures))
+	return activated
+}
+
+// activateEach registers and activates every add-in in libs, returning the ids it
+// activated and any per-add-in failures. A bad add-in is skipped, never fatal, so one
+// broken add-in cannot stop the others' endpoints from coming up.
+func activateEach(session *app.Session, libs []*addinhost.LoadedAddIn) (activated []string, failures []error) {
+	for _, lib := range libs {
+		if err := registerAndActivate(session, lib); err != nil {
+			failures = append(failures, err)
+			continue
+		}
+		activated = append(activated, lib.ID())
+	}
+	return activated, failures
+}
+
+// registerAndActivate registers one loaded add-in and activates it. Activation runs the
+// add-in's ObkAddInActivate (which starts its MCP server and may make host calls), so the
+// caller must be draining the dispatcher. Errors carry the offending add-in id.
+func registerAndActivate(session *app.Session, lib *addinhost.LoadedAddIn) error {
+	if err := session.AddIns().Register(lib); err != nil {
+		return fmt.Errorf("register add-in %q: %w", lib.ID(), err)
+	}
+	if err := session.AddIns().Activate(session, lib.ID()); err != nil {
+		return fmt.Errorf("activate add-in %q: %w", lib.ID(), err)
+	}
+	return nil
+}
+
+// runDrainLoop services queued add-in calls on this (the session) goroutine until
+// SIGINT/SIGTERM. The model is not thread-safe, so ALL draining happens here; an add-in's
+// HTTP server runs in its own runtime and submits work onto the dispatcher this loop drains.
+func runDrainLoop(d *dispatch.Dispatcher) {
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+	drainUntil(d, stop)
+}
+
+// drainUntil ticks every drainInterval, draining the dispatcher, until stop delivers a
+// signal. Split from runDrainLoop's signal setup so the ticking loop is unit-testable
+// (feed it a stop channel) while only the os/signal wait in runDrainLoop stays uncovered.
+func drainUntil(d *dispatch.Dispatcher, stop <-chan os.Signal) {
+	ticker := time.NewTicker(drainInterval)
+	defer ticker.Stop()
+	fmt.Fprintln(os.Stderr, "oblikovati-addinhost: draining (Ctrl-C to stop)")
+	for {
+		select {
+		case <-stop:
+			fmt.Fprintln(os.Stderr, "oblikovati-addinhost: shutting down")
+			return
+		case <-ticker.C:
+			drainTick(d)
+		}
+	}
+}
+
+// drainTick services up to drainPerTick queued add-in calls and reports how many ran.
+// Factored out of runDrainLoop's blocking select so the drain step is unit-testable.
+func drainTick(d *dispatch.Dispatcher) int {
+	return d.Drain(drainPerTick)
+}
+
+// addInsDir is the directory scanned for shared-library add-ins: OBK_ADDINS_DIR if set,
+// else an "addins" folder beside the executable.
+func addInsDir() string {
+	if dir := os.Getenv("OBK_ADDINS_DIR"); dir != "" {
+		return dir
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return "addins"
+	}
+	return filepath.Join(filepath.Dir(exe), "addins")
+}

--- a/head/cmd/oblikovati-addinhost/main_signal_test.go
+++ b/head/cmd/oblikovati-addinhost/main_signal_test.go
@@ -1,0 +1,35 @@
+//go:build linux || darwin
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package main
+
+import (
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestMainStopsOnSignal is the entrypoint's end-to-end shutdown proof: main() builds the
+// session, installs the host, scans for add-ins, and enters the drain loop, and a real
+// SIGTERM to this process unwinds it cleanly (runDrainLoop's os/signal wait returns and
+// main falls through). Unix-only — syscall.Kill has no Windows counterpart, and the head
+// coverage job (Linux) is where this path is measured; the loop body itself is also unit
+// tested platform-independently via drainUntil/drainTick.
+func TestMainStopsOnSignal(t *testing.T) {
+	done := make(chan struct{})
+	go func() { main(); close(done) }()
+
+	// runDrainLoop's signal.Notify is reached within main()'s first few statements (a
+	// session build + router construction, all sub-100ms); this wait leaves ample room so
+	// the SIGTERM lands on its channel, not the default terminate action.
+	time.Sleep(500 * time.Millisecond)
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGTERM); err != nil {
+		t.Fatalf("raise SIGTERM: %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("main did not return after SIGTERM")
+	}
+}

--- a/head/cmd/oblikovati-addinhost/main_test.go
+++ b/head/cmd/oblikovati-addinhost/main_test.go
@@ -1,0 +1,311 @@
+//go:build linux || darwin || windows
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"testing"
+	"time"
+
+	"oblikovati.org/addin/dispatch"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/head/internal/addinhost"
+)
+
+const echoFixtureID = "com.oblikovati.echo-fixture"
+
+// TestNewHostSessionRegistersCommands proves the session baseline builds without error —
+// a file-backed store plus the standard command set, the same baseline the head starts from.
+func TestNewHostSessionRegistersCommands(t *testing.T) {
+	session, err := newHostSession()
+	if err != nil {
+		t.Fatalf("newHostSession: %v", err)
+	}
+	if session == nil {
+		t.Fatal("newHostSession returned a nil session")
+	}
+}
+
+// TestNewRouterHandlerRoutesReadMethod checks the router handler wired over the session
+// answers a real read method (application.apiVersion) and rejects an unknown one — proving
+// the add-in host call reaches the router, not a stub.
+func TestNewRouterHandlerRoutesReadMethod(t *testing.T) {
+	session, err := newHostSession()
+	if err != nil {
+		t.Fatalf("newHostSession: %v", err)
+	}
+	handle := newRouterHandler(session)
+
+	out, err := handle(wire.MethodApplicationApiVersion, []byte("{}"))
+	if err != nil {
+		t.Fatalf("handle(%s): %v", wire.MethodApplicationApiVersion, err)
+	}
+	var got wire.ApplicationApiVersionResult
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal apiVersion result %s: %v", out, err)
+	}
+	if got.Version == "" {
+		t.Errorf("apiVersion result = %s, want a non-empty version", out)
+	}
+	if _, err := handle("no.such.method", []byte("{}")); err == nil {
+		t.Error("handle(no.such.method) err = nil, want an unknown-method error")
+	}
+}
+
+// TestInstallHostWiresRouter runs installHost (the C-ABI host wiring) and confirms the
+// same router handler it installs routes a real read method.
+func TestInstallHostWiresRouter(t *testing.T) {
+	session, err := newHostSession()
+	if err != nil {
+		t.Fatalf("newHostSession: %v", err)
+	}
+	d := dispatch.New(dispatchCapacity)
+	defer d.Close()
+	installHost(session, d)
+
+	if _, err := newRouterHandler(session)(wire.MethodApplicationApiVersion, []byte("{}")); err != nil {
+		t.Fatalf("router handler after installHost: %v", err)
+	}
+}
+
+// TestDrainTickRunsQueuedCall submits one job from another goroutine and confirms a single
+// drainTick runs it — the loop body runDrainLoop repeats on every ticker tick.
+func TestDrainTickRunsQueuedCall(t *testing.T) {
+	d := dispatch.New(dispatchCapacity)
+	defer d.Close()
+	go func() {
+		_, _ = d.Submit(context.Background(), func() ([]byte, error) { return []byte("ok"), nil })
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		if drainTick(d) == 1 {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("drainTick never ran the queued job")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
+// TestDrainUntilDrainsThenStops proves the ticking loop drains a queued call and then
+// returns when its stop channel delivers a signal — the whole of runDrainLoop except the
+// os/signal registration.
+func TestDrainUntilDrainsThenStops(t *testing.T) {
+	d := dispatch.New(dispatchCapacity)
+	defer d.Close()
+	stop := make(chan os.Signal, 1)
+	ran := make(chan []byte, 1)
+	go func() {
+		out, _ := d.Submit(context.Background(), func() ([]byte, error) { return []byte("x"), nil })
+		ran <- out              // Submit returns only after the loop drained the job...
+		stop <- syscall.SIGTERM // ...so asking to stop now cannot race ahead of the drain.
+	}()
+
+	drainUntil(d, stop)
+	select {
+	case <-ran:
+	default:
+		t.Fatal("drainUntil returned before draining the queued job")
+	}
+}
+
+// TestAddInsDirUsesEnv checks OBK_ADDINS_DIR overrides the default location.
+func TestAddInsDirUsesEnv(t *testing.T) {
+	t.Setenv("OBK_ADDINS_DIR", filepath.Join("some", "addins"))
+	if got := addInsDir(); got != filepath.Join("some", "addins") {
+		t.Errorf("addInsDir() = %q, want the OBK_ADDINS_DIR value", got)
+	}
+}
+
+// TestAddInsDirDefaultsBesideExe checks the fallback is an "addins" folder beside the exe
+// when OBK_ADDINS_DIR is unset.
+func TestAddInsDirDefaultsBesideExe(t *testing.T) {
+	t.Setenv("OBK_ADDINS_DIR", "")
+	if got := addInsDir(); filepath.Base(got) != "addins" {
+		t.Errorf("addInsDir() = %q, want a path ending in \"addins\"", got)
+	}
+}
+
+// TestStartAddInsActivatesFixture is the end-to-end proof without the real bridge: it
+// loads the echo c-shared fixture, and startAddIns registers + activates it, round-tripping
+// the fixture's Activate host call through the dispatcher (drained concurrently, since
+// Activate blocks). It returns the activated id.
+func TestStartAddInsActivatesFixture(t *testing.T) {
+	dir := fixtureDir(t)
+	buildFixtureInto(t, "echoaddin", dir)
+
+	session, err := newHostSession()
+	if err != nil {
+		t.Fatalf("newHostSession: %v", err)
+	}
+	d := dispatch.New(dispatchCapacity)
+	defer d.Close()
+	// The fixture's Activate calls the host "echo" method and expects "ping" back.
+	addinhost.SetHost(d, func(method string, req []byte) ([]byte, error) {
+		if method != "echo" {
+			return nil, fmt.Errorf("unexpected host method %q", method)
+		}
+		return req, nil
+	}, 2*time.Second)
+
+	ids := drainWhileActivating(t, d, func() []string { return startAddIns(session, dir) })
+	if len(ids) != 1 || ids[0] != echoFixtureID {
+		t.Fatalf("startAddIns activated %v, want [%s]", ids, echoFixtureID)
+	}
+}
+
+// TestStartAddInsReportsSkippedAndFailed drives both non-happy paths: the incompatible
+// fixture is skipped at load time, and the echo fixture's Activate fails because the host
+// rejects its call — so startAddIns activates nothing and both are surfaced (not fatal).
+func TestStartAddInsReportsSkippedAndFailed(t *testing.T) {
+	dir := fixtureDir(t)
+	buildFixtureInto(t, "echoaddin", dir)
+	buildFixtureInto(t, "incompataddin", dir)
+
+	session, err := newHostSession()
+	if err != nil {
+		t.Fatalf("newHostSession: %v", err)
+	}
+	d := dispatch.New(dispatchCapacity)
+	defer d.Close()
+	// Reject every host call, so the echo fixture's Activate returns an error → a failure.
+	addinhost.SetHost(d, func(method string, _ []byte) ([]byte, error) {
+		return nil, fmt.Errorf("host refuses %q", method)
+	}, 2*time.Second)
+
+	ids := drainWhileActivating(t, d, func() []string { return startAddIns(session, dir) })
+	if len(ids) != 0 {
+		t.Fatalf("startAddIns activated %v, want none (echo must fail, incompatible must skip)", ids)
+	}
+}
+
+// TestStartAddInsLoadError surfaces a hard load error: a path that exists but is a file,
+// not a directory, makes LoadDir's os.ReadDir fail with a non-"not exist" error, which
+// startAddIns reports while activating nothing.
+func TestStartAddInsLoadError(t *testing.T) {
+	notADir := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(notADir, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	session, err := newHostSession()
+	if err != nil {
+		t.Fatalf("newHostSession: %v", err)
+	}
+	if ids := startAddIns(session, notADir); len(ids) != 0 {
+		t.Fatalf("startAddIns(file) = %v, want none", ids)
+	}
+}
+
+// TestRegisterAndActivateRejectsDuplicate covers the register-failure path: registering an
+// add-in whose id is already registered fails before activation, and the error names the id.
+func TestRegisterAndActivateRejectsDuplicate(t *testing.T) {
+	dir := fixtureDir(t)
+	buildFixtureInto(t, "echoaddin", dir)
+	libs, _, err := addinhost.LoadDir(dir)
+	if err != nil || len(libs) != 1 {
+		t.Fatalf("LoadDir: libs=%d err=%v", len(libs), err)
+	}
+	lib := libs[0]
+	defer func() { _ = lib.Close() }()
+
+	session, err := newHostSession()
+	if err != nil {
+		t.Fatalf("newHostSession: %v", err)
+	}
+	if err := session.AddIns().Register(lib); err != nil {
+		t.Fatalf("first Register: %v", err)
+	}
+	if err := registerAndActivate(session, lib); err == nil {
+		t.Fatal("registerAndActivate on an already-registered id: err = nil, want a duplicate error")
+	}
+}
+
+// TestStartAddInsMissingDir treats an absent add-ins directory as "none installed": no
+// error, nothing activated.
+func TestStartAddInsMissingDir(t *testing.T) {
+	session, err := newHostSession()
+	if err != nil {
+		t.Fatalf("newHostSession: %v", err)
+	}
+	if ids := startAddIns(session, filepath.Join(t.TempDir(), "does-not-exist")); len(ids) != 0 {
+		t.Fatalf("startAddIns(missing) = %v, want none", ids)
+	}
+}
+
+// drainWhileActivating runs activate on a background goroutine and drains d on this one
+// until it returns, because a fixture's Activate blocks on a host call the drain services.
+func drainWhileActivating(t *testing.T, d *dispatch.Dispatcher, activate func() []string) []string {
+	t.Helper()
+	done := make(chan []string, 1)
+	go func() { done <- activate() }()
+	deadline := time.After(20 * time.Second)
+	for {
+		d.Drain(0)
+		select {
+		case ids := <-done:
+			return ids
+		case <-deadline:
+			t.Fatal("timed out draining while startAddIns activated add-ins")
+			return nil
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
+// buildFixtureInto compiles a testdata add-in fixture (shared by the addinhost package
+// tests) as a c-shared library into destDir. GOTOOLCHAIN=local keeps the build offline and
+// GOWORK=off builds the fixture against its own module, standing in for an external add-in.
+// Go test helpers cannot cross package/test-binary boundaries, so this mirrors the addinhost
+// package's buildFixture (sonar.cpd.exclusions covers _test.go for that reason).
+func buildFixtureInto(t *testing.T, name, destDir string) {
+	t.Helper()
+	_, thisFile, _, _ := runtime.Caller(0)
+	src := filepath.Join(filepath.Dir(thisFile), "..", "..", "internal", "addinhost", "testdata", name)
+	out := filepath.Join(destDir, name+sharedLibExt())
+
+	cmd := exec.Command("go", "build", "-buildmode=c-shared", "-o", out, ".")
+	cmd.Dir = src
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=1", "GOTOOLCHAIN=local", "GOWORK=off")
+	if combined, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build fixture %q: %v\n%s", name, err, combined)
+	}
+}
+
+// sharedLibExt is the c-shared extension isSharedLib recognizes on this OS.
+func sharedLibExt() string {
+	switch runtime.GOOS {
+	case "windows":
+		return ".dll"
+	case "darwin":
+		return ".dylib"
+	default:
+		return ".so"
+	}
+}
+
+// fixtureDir makes a temp directory for c-shared fixtures with BEST-EFFORT cleanup: on
+// Windows a loaded add-in DLL stays resident for the process lifetime and the image file
+// stays locked, so a strict RemoveAll would fail — the OS reclaims it at process exit.
+func fixtureDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "addinhost-cmd-fixture-")
+	if err != nil {
+		t.Fatalf("make fixture temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}


### PR DESCRIPTION
## What

Adds `head/cmd/oblikovati-addinhost`: a **headless (no Vulkan/GUI) host** for shared-library add-ins. It replicates the add-in wiring of `cmd/oblikovati-head/addins.go` — install the router as the C-ABI host-call handler, load and activate every add-in in a directory, and drain the dispatch queue on the single "session goroutine" forever — but **without a renderer**.

Environment:
- `OBK_ADDINS_DIR` — directory holding each add-in's shared library (`.dll`/`.so`/`.dylib`) and its `manifest.json` (defaults to an `addins` folder beside the exe).
- `OBK_MCP_ADDR` — read by the MCP bridge add-in (not by this host) to choose the address it serves on.

Example:
```
OBK_ADDINS_DIR=/path/to/bridge OBK_MCP_ADDR=127.0.0.1:7800 ./oblikovati-addinhost &
go run ./cmd/mcpcheck --url http://127.0.0.1:7800/mcp   # mcpcheck ships with the bridge add-in
```

## Why

A GUI-free endpoint for **CI, automation, and driving the bridge from external clients (the Inventor exporter)** on machines that cannot build the cgo head. It also proves the loader → c-shared → live-kernel chain end to end without a window.

Proven end to end: it loaded the real ~30 MB MCP bridge `.dll` via the merged Windows loader and served `127.0.0.1:7800/mcp` (586 tools); a `create → sketch → extrude → get_physical_properties` round trip returned volume **exactly 60 cm³**.

## Test approach

The wiring is factored into small, single-responsibility helpers so the loader → c-shared → live-kernel chain is unit tested **without the real bridge**, reusing the existing `internal/addinhost` fixtures (`echoaddin`, `incompataddin`):

- `newHostSession`, `newRouterHandler` / `installHost` — session + router host wiring; a real read method (`application.apiVersion`) round-trips and an unknown method is rejected.
- `startAddIns` / `activateEach` / `registerAndActivate` — load + register + activate a real c-shared fixture, round-tripping its `Activate` host call through the drained dispatcher; plus the skipped-incompatible, activate-failure, duplicate-register, load-error and missing-dir paths.
- `drainUntil` / `drainTick` — the drain-loop body, and a Unix `SIGTERM` entrypoint test drives `main()` through a clean shutdown.

Only `main()`'s error `os.Exit` and the two unforceable defensive branches (`RegisterStandardCommands` failure, `os.Executable` failure) remain outside direct assertions. New-code line coverage on the Linux gate job is ~92% of statements — no coverage exclusion was needed.

Local (Windows, MinGW) `go test ./cmd/oblikovati-addinhost/... ./internal/addinhost/...`: both packages green (the `main()` SIGTERM test is `linux || darwin` only and is build-excluded on Windows).

## CI note

`head-windows` deliberately does **not** smoke this — it would need the bridge `.dll`, which that job doesn't build; no flaky integration step is added. The new command compiles under the existing `head` and `head-windows` `go build ./...` steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)