### PR TITLE
Analytic watertight near-pinch crossing-cylinder intersect, cut & join (#1818)

### DIFF
--- a/kernel/brep/curved_crossing_imprint.go
+++ b/kernel/brep/curved_crossing_imprint.go
@@ -62,12 +62,13 @@ func keepImprintLoops(tr geom.SurfaceIntersection, res geom.Resolution, rec *dia
 	return closedTraceLoops(tr.Curves, res, rec)
 }
 
-// crossingCylinderImprint returns the intersection loops of two bare cylinder bodies as closed polylines,
-// or ok=false when either body is not a bare cylinder or no closed loop is traced. The trace window spans
-// the first body's axial extent (the cylinders cross within it), and the periodic angular direction is
-// resolved by the tracer automatically. A non-nil rec receives a diagnostic for any traced chain that
-// failed to close (#1404).
-func crossingCylinderImprint(a, b *topo.Body, rec *diag.Recorder) ([]geom.Polyline, bool) {
+// crossingCylinderLoops traces the intersection loops of two bare cylinder bodies as closed polylines,
+// declining (silently) only below the Steinmetz snap ceiling where the exact bicylinder constructor takes
+// over (#1780). Unlike crossingCylinderImprint it does NOT decline the near-pinch band — the intersect driver
+// (crossingCylinderIntersectGeneral) resolves that band robustly by trimming the fat wall per loop (#1818),
+// so it needs the raw loops. Callers that cannot yet handle the near-pinch band (cut/join, cap-crossing) use
+// crossingCylinderImprint, which adds the near-pinch decline.
+func crossingCylinderLoops(a, b *topo.Body, rec *diag.Recorder) ([]geom.Polyline, bool) {
 	ca, baseA, heightA, okA := cylinderSolidParams(facesOfAny(a))
 	cb, _, _, okB := cylinderSolidParams(facesOfAny(b))
 	if !okA || !okB {
@@ -84,19 +85,36 @@ func crossingCylinderImprint(a, b *topo.Body, rec *diag.Recorder) ([]geom.Polyli
 	if len(loops) == 0 {
 		return nil, false
 	}
-	// Above the snap ceiling the two loops are genuine, resolvable geometry — but where their mutual
-	// closest approach (the neck) is narrow relative to the imprint's own chord, the two lens loops' faceted
-	// cusps interpenetrate: the (u,v) arrangement fabricates a spurious neck crossing and fuses the two
-	// lenses into one mis-classified face (a conditioning wall, δ~√Δr vs facet error ~h²/√Δr — #1781). The
-	// analytic result is watertight ONLY on the well-separated side of that wall; on the near-pinch side we
-	// decline to the deterministic faceted route and record the degradation. Resolving that residual band
-	// analytically needs the near-pinch analytic-tip split (Oblikovati#1818), not a finer imprint.
-	if ca.Radius != cb.Radius && nearPinchLoops(loops) {
+	return loops, true
+}
+
+// crossingCylinderImprint returns the crossing-cylinder loops for callers that decline the near-pinch band to
+// their CSG fallback (cut/join, cap-crossing). It is crossingCylinderLoops plus the near-pinch gate: where the
+// two loops' neck is narrow relative to the imprint chord, the fat wall's holed-wall trim would fuse the two
+// lens holes (a conditioning wall, δ~√Δr vs facet error ~h²/√Δr — #1781), so it records the degradation and
+// declines. The INTERSECT driver bypasses this (per-loop fat trim handles the band, #1818); folding cut/join
+// onto the analytic path (the holed-wall neck bridge) is the remaining #1818 work.
+func crossingCylinderImprint(a, b *topo.Body, rec *diag.Recorder) ([]geom.Polyline, bool) {
+	loops, ok := crossingCylinderLoops(a, b, rec)
+	if !ok {
+		return nil, false
+	}
+	// Equal-radius loops touch at the Steinmetz pinches (neck 0) — that is the exact bicylinder, handled by
+	// steinmetzGeneral, NOT a near-pinch decline. Only the UNEQUAL near-pinch band declines here.
+	if unequalRadiusCrossing(a, b) && nearPinchLoops(loops) {
 		rec.Recordf(CodeImprintNearPinchDeclined, diag.Defect,
 			"crossing cylinders with a narrow imprint neck (gap/chord = %.2g) decline the analytic imprint: near-pinch lens fusion, falling back", loopGapChordRatio(loops))
 		return nil, false
 	}
 	return loops, true
+}
+
+// unequalRadiusCrossing reports whether two bare cylinder bodies have different radii — the near-pinch decline
+// applies only to the UNEQUAL band; equal radii are the exact Steinmetz pinch handled by steinmetzGeneral.
+func unequalRadiusCrossing(a, b *topo.Body) bool {
+	ca, _, _, okA := cylinderSolidParams(facesOfAny(a))
+	cb, _, _, okB := cylinderSolidParams(facesOfAny(b))
+	return okA && okB && ca.Radius != cb.Radius
 }
 
 // nearPinchLoops reports whether a pair of imprint loops is in the near-pinch band the (u,v) arrangement

--- a/kernel/brep/curved_crossing_imprint_nearpinch_test.go
+++ b/kernel/brep/curved_crossing_imprint_nearpinch_test.go
@@ -80,3 +80,31 @@ func TestCrossingCylinderImprintRecoveredBand(t *testing.T) {
 		t.Errorf("recovered-band intersect has %d faces, want 3 (rod band + two lens caps)", n)
 	}
 }
+
+// TestCrossingCylinderIntersectNearPinchPerLoop exercises the #1818 per-loop fat-wall trim directly: a crossing
+// DEEP in the near-pinch band (below the #1781 gate) — which the cut/join path would decline — still builds the
+// exact three-face intersect, because the fat wall is trimmed one lens loop at a time (cylinderLensSplit).
+func TestCrossingCylinderIntersectNearPinchPerLoop(t *testing.T) {
+	const r = 3.0
+	thin, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), r, 12)
+	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), r+5e-5, 12) // deep near-pinch (gap/chord < gate)
+	body, ok := crossingCylinderIntersectGeneral(thin, fat, nil)
+	if !ok {
+		t.Fatal("near-pinch crossing intersect declined; #1818 per-loop path must build it")
+	}
+	if n := len(body.Faces()); n != 3 {
+		t.Errorf("near-pinch intersect has %d faces, want 3 (rod band + two lens caps)", n)
+	}
+}
+
+func TestUnequalRadiusCrossing(t *testing.T) {
+	eqA, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 3, 12)
+	eqB, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12)
+	if unequalRadiusCrossing(eqA, eqB) {
+		t.Error("equal radii reported unequal (would wrongly decline the Steinmetz pinch)")
+	}
+	neB, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3.001, 12)
+	if !unequalRadiusCrossing(eqA, neB) {
+		t.Error("unequal radii reported equal")
+	}
+}

--- a/kernel/brep/curved_general_boolean.go
+++ b/kernel/brep/curved_general_boolean.go
@@ -254,7 +254,7 @@ func CrossingCylinderIntersectGeneral(a, b *topo.Body, rec *diag.Recorder) (*top
 // (no rod/fat split): the rod-wall band inside the fat plus the two fat-wall lens caps fall out of the same
 // two-sided trim. ok=false when the pair is not a cylinder-through-cylinder crossing.
 func crossingCylinderIntersectGeneral(a, b *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
-	loops, ok := crossingCylinderImprint(a, b, rec)
+	loops, ok := crossingCylinderLoops(a, b, rec)
 	if !ok || len(loops) == 0 {
 		return nil, false
 	}
@@ -265,13 +265,38 @@ func crossingCylinderIntersectGeneral(a, b *topo.Body, rec *diag.Recorder) (*top
 	if !okA || !okB || !okMA || !okMB {
 		return nil, false
 	}
-	imprint := polylineCurves(loops)
-	keptA, okKA := keptOrNone(cylinderSideSolidSplit(fA, cylA, bandA, imprint, Intersection, false, insideB))
-	keptB, okKB := keptOrNone(cylinderSideSolidSplit(fB, cylB, bandB, imprint, Intersection, true, insideA))
-	if !okKA || !okKB {
+	// Near-pinch (#1818): the two loops project to the LARGER-radius (fat) wall as two lens ovals whose tips
+	// nearly touch at the necks; a single (u,v) arrangement carrying both fuses them, so the fat wall is
+	// trimmed one loop at a time — each oval alone in its own arrangement, which is well-conditioned. The
+	// smaller (thin) wall carries the two loops as a single full-azimuth band bounded by both, so it keeps the
+	// both-loops trim. Away from the near-pinch band both sides take the both-loops trim unchanged.
+	nearPinch := nearPinchLoops(loops)
+	keptA, okA2 := keptOrNone(cylinderLensSplit(nearPinch && cylA.Radius > cylB.Radius, fA, cylA, bandA, loops, false, insideB))
+	keptB, okB2 := keptOrNone(cylinderLensSplit(nearPinch && cylB.Radius > cylA.Radius, fB, cylB, bandB, loops, true, insideA))
+	if !okA2 || !okB2 {
 		return nil, false
 	}
 	return curvedStitch(append(keptA, keptB...)), true
+}
+
+// cylinderLensSplit trims a cylinder side by the intersection imprint. perLoop trims each loop in a SEPARATE
+// arrangement — the #1818 near-pinch fat wall, whose two lens caps sit tip-to-tip at the necks and would fuse
+// in a shared arrangement — and concatenates the resulting caps; otherwise it trims by both loops at once (the
+// thin wall's single band bounded by both loops, and every non-near-pinch crossing). Each single-loop
+// arrangement keeps the loop's clear azimuth gap, so its seam auto-places cleanly with no pinched handling.
+func cylinderLensSplit(perLoop bool, f curvedFace, cyl geom.Cylinder, band coneSideBand_, loops []geom.Polyline, isB bool, inside func(math.Point3) bool) ([]curvedFace, []loopEdge, error) {
+	if !perLoop {
+		return cylinderSideSolidSplit(f, cyl, band, polylineCurves(loops), Intersection, isB, inside)
+	}
+	var caps []curvedFace
+	for i := range loops {
+		lens, _, err := cylinderSideSolidSplit(f, cyl, band, polylineCurves(loops[i:i+1]), Intersection, isB, inside)
+		if err != nil {
+			return nil, nil, err
+		}
+		caps = append(caps, lens...)
+	}
+	return caps, nil, nil
 }
 
 // ConeCylinderIntersectGeneral is the exported entry kernel/ops routes cone∩cylinder intersect through: the

--- a/kernel/brep/curved_general_ruled_cutjoin.go
+++ b/kernel/brep/curved_general_ruled_cutjoin.go
@@ -204,12 +204,18 @@ func ruledPairGeneral(a, b *topo.Body, rec *diag.Recorder,
 // a fat cylinder drilled by a rod (one solid) or a rod sliced by a fat (two stubs). ok=false outside the
 // wired clean-side-breach crossing so kernel/ops keeps its CSG fallback.
 func CrossingCylinderCutGeneral(target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	if body, ok := nearPinchCrossingCut(target, tool, rec); ok { // #1818 near-pinch band (raw whole-loop faces)
+		return body, true
+	}
 	return ruledPairGeneral(target, tool, rec, crossingCylinderImprint, cylinderOperand, ruledCutGeneral)
 }
 
 // CrossingCylinderJoinGeneral routes crossing-cylinder JOIN through the general ruled join (#1403/#1476):
 // a fat cylinder side-breached by a rod, welded into one solid (keyhole holed wall + two stubs + whole caps).
 func CrossingCylinderJoinGeneral(a, b *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	if body, ok := nearPinchCrossingJoin(a, b, rec); ok { // #1818 near-pinch band (raw whole-loop faces)
+		return body, true
+	}
 	return ruledPairGeneral(a, b, rec, crossingCylinderImprint, cylinderOperand, ruledJoinGeneral)
 }
 
@@ -245,11 +251,14 @@ func ConeCylinderJoinGeneral(a, b *topo.Body, rec *diag.Recorder) (*topo.Body, b
 // must be traced ROD-first (its window leaves one loop); tracing fat-first windows the full crossing and
 // returns two loops. Which body is the rod is unknown, so both orderings are tried, accepting the one that
 // yields exactly one loop. ok=false for a full crossing (two loops either way) or no intersection (#1403).
+// It reads the RAW loops (crossingCylinderLoops), not crossingCylinderImprint: a near-pinch FULL crossing is
+// not a partial penetration, so it must fall through here WITHOUT recording a near-pinch decline — that band
+// is now shipped analytically by nearPinchCrossingCut/Join, and a spurious decline would misreport it (#1818).
 func partialImprint(a, b *topo.Body, rec *diag.Recorder) ([]geom.Polyline, bool) {
-	if l, ok := crossingCylinderImprint(a, b, rec); ok && len(l) == 1 {
+	if l, ok := crossingCylinderLoops(a, b, rec); ok && len(l) == 1 {
 		return l, true
 	}
-	if l, ok := crossingCylinderImprint(b, a, rec); ok && len(l) == 1 {
+	if l, ok := crossingCylinderLoops(b, a, rec); ok && len(l) == 1 {
 		return l, true
 	}
 	return nil, false

--- a/kernel/brep/curved_near_pinch_cutjoin.go
+++ b/kernel/brep/curved_near_pinch_cutjoin.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Near-pinch crossing-cylinder CUT and JOIN (#1818). The near-pinch intersect trims the fat wall per lens loop
+// so the two ovals never fuse in one arrangement (curved_general_boolean.go). Cut and join are harder: the fat
+// wall's OUTSIDE-keep complement is a holed tube whose two lens holes near-touch at the neck, and the near-pinch
+// (u,v) arrangement both fuses those holes AND emits their loops as sub-arcs that will not weld to the thin
+// wall's faces. The fix builds EVERY near-pinch face from the RAW whole imprint loops, so a shared loop is one
+// closed edge that welds as a single topo edge (shared discretization):
+//
+//   - the fat wall is the keyhole holed tube (crossingHoledTubeFace) with the two whole loops as separate holes
+//     — its neck BRIDGE is meshed watertight by the corridor-seeding in kernel/ops (neckCorridorNodes), which
+//     stops the wall from chording hole-to-hole across the neck (those chords would double the thin band's
+//     matching pinch chords into non-manifold edges);
+//   - the thin wall keeps the arrangement tunnel band when it stays INSIDE (already welds to whole loops), or
+//     is built as raw two-rim stubs (rawStubBands) when it protrudes/severs OUTSIDE, where the arrangement
+//     would fuse the near-severed stubs at the neck.
+//
+// A global curvedReorient then makes the mixed-source shell consistently oriented. The whole band down to the
+// Steinmetz snap ceiling ships watertight (there is no conditioning floor above it — the surfaces stay > weld
+// tol apart by Δr); the caller's validBooleanSolid gate is the fail-safe for any unforeseen degenerate case.
+
+// keepsInside reports whether an operand under (op, isB) keeps the part of its wall INSIDE the other solid
+// (the lens caps) rather than OUTSIDE it (the holed tube): true for an intersect, and for the tool of a cut.
+func keepsInside(op Op, isB bool) bool {
+	return op == Intersection || (op == Difference && isB)
+}
+
+// fatNearPinchWall builds the fat operand's near-pinch wall: its two lens caps (per loop) when it keeps the
+// inside, or the holed tube when it keeps the outside — both from the loops kept separate, so the two ovals
+// never share an arrangement (#1818). ok=false when the fat side or its holed tube cannot be resolved.
+func fatNearPinchWall(fat ruledOperand, loops []geom.Polyline, op Op, isB bool, other func(math.Point3) bool) ([]curvedFace, bool) {
+	f, cyl, band, ok := cylinderSideFace(fat.body)
+	if !ok {
+		return nil, false
+	}
+	if keepsInside(op, isB) {
+		return keptOrNone(cylinderLensSplit(true, f, cyl, band, loops, isB, other))
+	}
+	tube, ok := crossingHoledTubeFace(f, cyl, band, loops, op, isB, other)
+	if !ok {
+		return nil, false
+	}
+	return []curvedFace{tube}, true
+}
+
+// crossingHoledTubeFace builds the fat wall's OUTSIDE-keep holed tube directly: the band's two rims bridged
+// into a keyhole outer loop, with the two imprint loops supplied as SEPARATE holes (#1818). Bypassing the
+// arrangement is what keeps the two near-touching lens holes from fusing; the holes reuse the shared imprint
+// polylines (so they weld to the rod band exactly) with their winding reversed to the outer's sense.
+func crossingHoledTubeFace(f curvedFace, cyl geom.Cylinder, band coneSideBand_, loops []geom.Polyline, op Op, isB bool, other func(math.Point3) bool) (curvedFace, bool) {
+	c := newCylinderUVSolid(cyl, band, op, isB, other)
+	holes := make([]curvedLoop, 0, len(loops))
+	for i := range loops {
+		holes = append(holes, curvedLoop{edges: []loopEdge{{curve: &loops[i], t0: 1, t1: 0}}}) // reversed for a hole
+	}
+	all := append([]curvedLoop{{edges: c.keyholeOuter()}}, holes...)
+	return curvedFace{surface: cyl, reversed: f.reversed, lineage: f.lineage, loops: all}, true
+}
+
+// rawStubBands builds a thin operand's OUTSIDE-keep protruding/severed stubs directly as raw two-closed-rim
+// bands — one per imprint loop, each bounded by the thin cap on that loop's axial side and the WHOLE raw loop
+// (#1818). Bypassing the (u,v) arrangement matters twice over: near the neck the two stubs nearly meet (a
+// near-severed rod) and the arrangement fuses/degrades there; and its OUTSIDE emission splits the loop into
+// sub-arcs that do NOT weld to the fat wall's whole-loop holes. A whole-loop closed edge welds to the fat
+// wall's matching hole as ONE topo edge, so the discretization is shared and the stub closes watertight.
+func rawStubBands(thin ruledOperand, loops []geom.Polyline) ([]curvedFace, bool) {
+	if len(loops) != 2 {
+		return nil, false
+	}
+	_, cyl, _, ok := cylinderSideFace(thin.body)
+	if !ok {
+		return nil, false
+	}
+	axis := cyl.AxisDir.AsVector()
+	lc := [2]float64{loopCentroidAxial(loops[0], cyl.Origin, axis), loopCentroidAxial(loops[1], cyl.Origin, axis)}
+	out := make([]curvedFace, 0, 2)
+	for i := range loops {
+		// A stub extends AWAY from the other loop: it is capped by the cap on the far side of this loop's
+		// centroid from the other loop's. wantHigh selects the higher-axial cap for the higher-centroid loop.
+		capCirc, okC := capOnAxialSide(planarCapFaces(thin.body), cyl, lc[i] >= lc[1-i])
+		if !okC {
+			return nil, false
+		}
+		// Winding is left to the global orientation pass (curvedReorient) — the stub's two rims are emitted in
+		// their native sense and the flood-fill flips whichever faces a consistent shell needs.
+		out = append(out, curvedFace{
+			surface: cyl, lineage: thin.face.lineage,
+			loops: []curvedLoop{
+				{edges: []loopEdge{{curve: capCirc, t0: 0, t1: 1}}},
+				{edges: []loopEdge{{curve: &loops[i], t0: 0, t1: 1}}},
+			},
+		})
+	}
+	return out, true
+}
+
+// capOnAxialSide returns the planar cap circle at the higher (wantHigh) or lower axial end of the cylinder —
+// the cap that closes a stub extending toward that end. ok=false if no planar cap circle is found.
+func capOnAxialSide(caps []curvedFace, cyl geom.Cylinder, wantHigh bool) (geom.Circle, bool) {
+	axis := cyl.AxisDir.AsVector()
+	best, bestAxial, found := geom.Circle{}, 0.0, false
+	for _, c := range caps {
+		circ, ok := capCircleOf(c)
+		if !ok {
+			continue
+		}
+		a := float64(cyl.Origin.VectorTo(circ.Center).Dot(axis))
+		if !found || (wantHigh && a > bestAxial) || (!wantHigh && a < bestAxial) {
+			best, bestAxial, found = circ, a, true
+		}
+	}
+	return best, found
+}
+
+// capCircleOf extracts the bounding circle of a planar cap face, or ok=false when the cap is not a single
+// full-circle loop.
+func capCircleOf(cap curvedFace) (geom.Circle, bool) {
+	if len(cap.loops) == 0 || len(cap.loops[0].edges) != 1 {
+		return geom.Circle{}, false
+	}
+	c, ok := cap.loops[0].edges[0].curve.(geom.Circle)
+	return c, ok
+}
+
+// loopCentroidAxial is a loop's mean axial coordinate (distance along the cylinder axis from its origin).
+func loopCentroidAxial(loop geom.Polyline, origin math.Point3, axis math.Vector3) float64 {
+	var sum float64
+	for _, p := range loop.Vertices {
+		sum += float64(origin.VectorTo(p).Dot(axis))
+	}
+	return sum / float64(len(loop.Vertices))
+}
+
+// fatterOperand returns the two operands ordered (fat, thin) by side-cylinder radius, or ok=false when a
+// side radius cannot be resolved — the near-pinch fat wall is the LARGER-radius wall (its two lens ovals
+// nearly touch), the thin wall being the well-separated full-wrap band.
+func fatterOperand(a, b ruledOperand) (fat, thin ruledOperand, aIsFat, ok bool) {
+	_, ca, _, okA := cylinderSideFace(a.body)
+	_, cb, _, okB := cylinderSideFace(b.body)
+	if !okA || !okB {
+		return ruledOperand{}, ruledOperand{}, false, false
+	}
+	if ca.Radius >= cb.Radius {
+		return a, b, true, true
+	}
+	return b, a, false, true
+}
+
+// nearPinchGate resolves a crossing to its two operands and imprint loops ONLY when it is the unequal-radius
+// near-pinch band this file handles: two loops, radii unequal (equal is the Steinmetz constructor's), a narrow
+// neck (nearPinchLoops), and the breach clear of BOTH operands' caps (so every cap survives whole, as the
+// ordinary ruled cut/join require). ok=false otherwise, so the caller falls through to the ordinary pipeline.
+func nearPinchGate(a, b *topo.Body, rec *diag.Recorder) (fat, thin ruledOperand, aIsFat bool, loops []geom.Polyline, ok bool) {
+	loops, okL := crossingCylinderLoops(a, b, rec)
+	if !okL || len(loops) != 2 || !unequalRadiusCrossing(a, b) || !nearPinchLoops(loops) {
+		return ruledOperand{}, ruledOperand{}, false, nil, false
+	}
+	oa, okA := cylinderOperand(a)
+	ob, okB := cylinderOperand(b)
+	if !okA || !okB {
+		return ruledOperand{}, ruledOperand{}, false, nil, false
+	}
+	fat, thin, aIsFat, okF := fatterOperand(oa, ob)
+	if !okF || !loopsClearOfCaps(fat.newUV(Difference, false, thin.inside), loops) ||
+		!loopsClearOfCaps(thin.newUV(Difference, false, fat.inside), loops) {
+		return ruledOperand{}, ruledOperand{}, false, nil, false
+	}
+	return fat, thin, aIsFat, loops, true
+}
+
+// nearPinchCrossingCut builds target − tool for an unequal-radius NEAR-PINCH crossing (below the #1781 gate),
+// where the ordinary (u,v) arrangement fuses the two lens holes. Every near-pinch face is built from the raw
+// whole imprint loops so each shared loop welds as ONE topo edge: the fat wall is the corridor-seeded keyhole
+// holed tube (fat − thin) or its two per-loop lens caps (thin − fat), and the thin wall is the arrangement
+// tunnel band (which already welds to whole loops) or the raw two-rim stubs. A global curvedReorient fixes the
+// mixed-source winding. ok=false when the pair is not the near-pinch band (the ordinary path then runs). The
+// caller's validBooleanSolid gate is the fail-safe: an unforeseen degenerate result declines to CSG (#1818).
+func nearPinchCrossingCut(target, tool *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	fat, thin, _, loops, ok := nearPinchGate(target, tool, rec)
+	if !ok {
+		return nil, false
+	}
+	tgt, tl := fat, thin
+	if fat.body != target {
+		tgt, tl = thin, fat
+	}
+	imprint := polylineCurves(loops)
+	var keptT, keptL []curvedFace
+	var okT, okL bool
+	if tgt.body == fat.body { // fat − thin: keyhole holed fat wall + reversed thin tunnel band
+		keptT, okT = fatNearPinchWall(fat, loops, Difference, false, tl.inside)
+		keptL, okL = tl.split(imprint, Difference, true, tgt.inside)
+	} else { // thin − fat: raw thin stubs + reversed fat lens caps
+		keptT, okT = rawStubBands(tgt, loops)
+		keptL, okL = fatNearPinchWall(fat, loops, Difference, true, tgt.inside)
+	}
+	if !okT || !okL {
+		return nil, false
+	}
+	return curvedStitch(curvedReorient(cutFaces(tgt, keptT, tl, keptL))), true
+}
+
+// nearPinchCrossingJoin builds a ∪ b for an unequal-radius near-pinch crossing: the corridor-seeded keyhole
+// holed fat wall + the two raw thin stubs + every cap, no reversal (a union keeps all walls facing out). Same
+// raw-whole-loop construction and reorient as the cut. ok=false outside the near-pinch band (#1818).
+func nearPinchCrossingJoin(a, b *topo.Body, rec *diag.Recorder) (*topo.Body, bool) {
+	fat, thin, aIsFat, loops, ok := nearPinchGate(a, b, rec)
+	if !ok {
+		return nil, false
+	}
+	wallFat, okWF := fatNearPinchWall(fat, loops, Union, !aIsFat, thin.inside)
+	wallThin, okWT := rawStubBands(thin, loops)
+	if !okWF || !okWT {
+		return nil, false
+	}
+	return curvedStitch(curvedReorient(joinFaces(fat, wallFat, thin, wallThin))), true
+}

--- a/kernel/brep/curved_near_pinch_cutjoin_test.go
+++ b/kernel/brep/curved_near_pinch_cutjoin_test.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+func TestKeepsInside(t *testing.T) {
+	cases := []struct {
+		op   Op
+		isB  bool
+		want bool
+	}{
+		{Intersection, false, true}, // intersect always keeps inside (the lens caps)
+		{Intersection, true, true},  //
+		{Difference, true, true},    // the TOOL of a cut keeps its inside (the tunnel)
+		{Difference, false, false},  // the TARGET of a cut keeps its outside (the holed wall)
+		{Union, false, false},       // a union keeps every wall outside
+		{Union, true, false},        //
+	}
+	for _, c := range cases {
+		if got := keepsInside(c.op, c.isB); got != c.want {
+			t.Errorf("keepsInside(%v, isB=%v) = %v, want %v", c.op, c.isB, got, c.want)
+		}
+	}
+}
+
+func TestFatterOperand(t *testing.T) {
+	thin, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 3, 12)
+	fatB, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3.5, 12)
+	oThin, _ := cylinderOperand(thin)
+	oFat, _ := cylinderOperand(fatB)
+	// The fatter is returned first regardless of argument order, with aIsFat tracking whether a was the fat one.
+	fat, thinOp, aIsFat, ok := fatterOperand(oThin, oFat)
+	if !ok || fat.body != fatB || thinOp.body != thin || aIsFat {
+		t.Errorf("fatterOperand(thin, fat): fat=%v thin=%v aIsFat=%v ok=%v, want fat=fatB thin=thin aIsFat=false", fat.body == fatB, thinOp.body == thin, aIsFat, ok)
+	}
+	fat2, _, aIsFat2, _ := fatterOperand(oFat, oThin)
+	if fat2.body != fatB || !aIsFat2 {
+		t.Errorf("fatterOperand(fat, thin): fat=fatB=%v aIsFat=%v, want true,true", fat2.body == fatB, aIsFat2)
+	}
+}
+
+func TestCapCircleOfAndAxialSide(t *testing.T) {
+	body, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 3, 12) // axis +x, caps at x=-6 and x=+6
+	_, cyl, _, _ := cylinderSideFace(body)
+	caps := planarCapFaces(body)
+	if len(caps) != 2 {
+		t.Fatalf("cylinder has %d planar caps, want 2", len(caps))
+	}
+	if _, ok := capCircleOf(caps[0]); !ok {
+		t.Error("capCircleOf failed on a planar cap face")
+	}
+	high, okH := capOnAxialSide(caps, cyl, true)
+	low, okL := capOnAxialSide(caps, cyl, false)
+	if !okH || !okL {
+		t.Fatal("capOnAxialSide could not resolve a cap")
+	}
+	axis := cyl.AxisDir.AsVector()
+	aHigh := float64(cyl.Origin.VectorTo(high.Center).Dot(axis))
+	aLow := float64(cyl.Origin.VectorTo(low.Center).Dot(axis))
+	if aHigh <= aLow {
+		t.Errorf("high cap axial %.2f not above low cap axial %.2f", aHigh, aLow)
+	}
+}
+
+func TestLoopCentroidAxial(t *testing.T) {
+	// A square loop centred at x=5 on the x-axis: its axial centroid (along +x from the origin) is 5.
+	pl, _ := geom.NewPolyline([]math.Point3{
+		math.P3(4, 0, 0), math.P3(6, 0, 0), math.P3(6, 1, 0), math.P3(4, 1, 0), math.P3(4, 0, 0),
+	})
+	got := loopCentroidAxial(pl, math.P3(0, 0, 0), math.V3(1, 0, 0))
+	if stdmath.Abs(got-4.8) > 1e-9 { // mean of {4,6,6,4,4} = 4.8
+		t.Errorf("loopCentroidAxial = %g, want 4.8", got)
+	}
+}
+
+// TestRawStubBands checks the near-severed rod's OUTSIDE stubs are built as two two-rim bands, one per loop,
+// each pairing the loop with the cap on the far axial side (so the stub extends away from the other loop).
+func TestRawStubBands(t *testing.T) {
+	thin, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 3, 12)
+	fat, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3.00006, 12)
+	loops, ok := crossingCylinderLoops(thin, fat, nil)
+	if !ok || len(loops) != 2 {
+		t.Fatalf("expected 2 crossing loops, got ok=%v n=%d", ok, len(loops))
+	}
+	op, _ := cylinderOperand(thin)
+	stubs, okS := rawStubBands(op, loops)
+	if !okS || len(stubs) != 2 {
+		t.Fatalf("rawStubBands: ok=%v n=%d, want 2 stub bands", okS, len(stubs))
+	}
+	for i, s := range stubs {
+		if len(s.loops) != 2 { // a two-rim band: cap circle + imprint loop
+			t.Errorf("stub %d has %d loops, want 2 (cap rim + imprint loop)", i, len(s.loops))
+		}
+	}
+}
+
+// TestCurvedReorientFlipsInconsistent builds two faces that share an edge traversed the SAME way by both
+// (an inconsistent shell) and checks curvedReorient flips exactly one so the shared edge is opposed.
+func TestCurvedReorientFlipsInconsistent(t *testing.T) {
+	seg := geom.NewLineSegment(math.P3(0, 0, 0), math.P3(1, 0, 0))
+	pl, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	// Both faces traverse the shared segment 0→1 (same direction) — inconsistent.
+	f0 := curvedFace{surface: pl, loops: []curvedLoop{{edges: []loopEdge{{curve: seg, t0: 0, t1: 1}}}}}
+	f1 := curvedFace{surface: pl, loops: []curvedLoop{{edges: []loopEdge{{curve: seg, t0: 0, t1: 1}}}}}
+	out := curvedReorient([]curvedFace{f0, f1})
+	d0 := out[0].loops[0].edges[0].t1 > out[0].loops[0].edges[0].t0
+	d1 := out[1].loops[0].edges[0].t1 > out[1].loops[0].edges[0].t0
+	if d0 == d1 {
+		t.Errorf("curvedReorient left the shared edge traversed the same way (d0=%v d1=%v); want opposed", d0, d1)
+	}
+}

--- a/kernel/brep/curved_near_pinch_cutjoin_test.go
+++ b/kernel/brep/curved_near_pinch_cutjoin_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 )
 
@@ -56,6 +57,15 @@ func TestCapCircleOfAndAxialSide(t *testing.T) {
 	if _, ok := capCircleOf(caps[0]); !ok {
 		t.Error("capCircleOf failed on a planar cap face")
 	}
+	// A face with no loops, and one whose edge is not a circle, are not cap circles.
+	if _, ok := capCircleOf(curvedFace{}); ok {
+		t.Error("capCircleOf accepted a loopless face")
+	}
+	seg := geom.NewLineSegment(math.P3(0, 0, 0), math.P3(1, 0, 0))
+	notCirc := curvedFace{loops: []curvedLoop{{edges: []loopEdge{{curve: seg, t0: 0, t1: 1}}}}}
+	if _, ok := capCircleOf(notCirc); ok {
+		t.Error("capCircleOf accepted a non-circle edge")
+	}
 	high, okH := capOnAxialSide(caps, cyl, true)
 	low, okL := capOnAxialSide(caps, cyl, false)
 	if !okH || !okL {
@@ -98,6 +108,67 @@ func TestRawStubBands(t *testing.T) {
 		if len(s.loops) != 2 { // a two-rim band: cap circle + imprint loop
 			t.Errorf("stub %d has %d loops, want 2 (cap rim + imprint loop)", i, len(s.loops))
 		}
+	}
+}
+
+// nearPinchPair builds a thin (radius r, axis x) and a fat (radius r+dr, axis z) crossing cylinder — the
+// unequal-radius near-pinch pair the cut/join constructors handle.
+func nearPinchPair(t *testing.T, r, dr float64) (thin, fat *topo.Body) {
+	t.Helper()
+	var err error
+	if thin, err = SolidCylinder(math.P3(-2*r, 0, 0), math.V3(1, 0, 0), r, 4*r); err != nil {
+		t.Fatalf("SolidCylinder thin: %v", err)
+	}
+	if fat, err = SolidCylinder(math.P3(0, 0, -2*r), math.V3(0, 0, 1), r+dr, 4*r); err != nil {
+		t.Fatalf("SolidCylinder fat: %v", err)
+	}
+	return thin, fat
+}
+
+// TestNearPinchCrossingCutJoinBuild covers the near-pinch constructors at the brep level (the ops watertight
+// sweep drives them via dispatch, but per-package coverage needs a direct brep caller): both cut directions
+// (fat−thin drill = 4 faces, thin−fat sever = 6 faces), the join (7 faces), and that each builds a valid
+// closed manifold solid.
+func TestNearPinchCrossingCutJoinBuild(t *testing.T) {
+	thin, fat := nearPinchPair(t, 3.0, 6e-5)
+	cases := []struct {
+		name      string
+		build     func() (*topo.Body, bool)
+		wantFaces int
+	}{
+		{"drill fat−thin", func() (*topo.Body, bool) { return nearPinchCrossingCut(fat, thin, nil) }, 4},
+		{"sever thin−fat", func() (*topo.Body, bool) { return nearPinchCrossingCut(thin, fat, nil) }, 6},
+		{"join", func() (*topo.Body, bool) { return nearPinchCrossingJoin(thin, fat, nil) }, 7},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			body, ok := c.build()
+			if !ok || body == nil {
+				t.Fatal("near-pinch constructor declined; want an analytic solid")
+			}
+			if n := len(body.Faces()); n != c.wantFaces {
+				t.Errorf("%s built %d faces, want %d", c.name, n, c.wantFaces)
+			}
+		})
+	}
+}
+
+// TestNearPinchGateDeclinesNonNearPinch pins that the gate — and thus the cut/join constructors — decline a
+// crossing that is NOT the unequal narrow-neck band, so those pairs fall through to the ordinary pipeline: an
+// EQUAL-radius Steinmetz pair (its own constructor owns it) and a WELL-SEPARATED thin-rod crossing.
+func TestNearPinchGateDeclinesNonNearPinch(t *testing.T) {
+	eqA, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 3, 12)
+	eqB, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12) // equal radii
+	if _, ok := nearPinchCrossingCut(eqA, eqB, nil); ok {
+		t.Error("near-pinch cut accepted an equal-radius Steinmetz pair; want decline")
+	}
+	if _, ok := nearPinchCrossingJoin(eqA, eqB, nil); ok {
+		t.Error("near-pinch join accepted an equal-radius Steinmetz pair; want decline")
+	}
+	thinRod, _ := SolidCylinder(math.P3(-6, 0, 0), math.V3(1, 0, 0), 1, 12)
+	fatCyl, _ := SolidCylinder(math.P3(0, 0, -6), math.V3(0, 0, 1), 3, 12) // well separated (r 1 vs 3)
+	if _, ok := nearPinchCrossingCut(thinRod, fatCyl, nil); ok {
+		t.Error("near-pinch cut accepted a well-separated crossing; want decline")
 	}
 }
 

--- a/kernel/brep/curved_reorient.go
+++ b/kernel/brep/curved_reorient.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import "oblikovati.org/kernel/geom"
+
+// Curved-shell orientation repair (#1818). The near-pinch cut/join assembles a shell from faces built by
+// DIFFERENT machinery: the (u,v) arrangement (self-consistent by construction) and the raw whole-loop
+// constructors (keyhole holed wall, two-rim stubs, lens caps), each wound independently. A mixed shell can
+// therefore be manifold and watertight yet have some shared edges traversed the SAME way by both faces —
+// the orientation inconsistency Validate flags. This pass two-colours the face-adjacency graph over shared
+// edges (BFS per shell) and flips the marked faces so every shared edge is traversed oppositely, mirroring
+// the planar boolean's reorientFaces but on curvedFaces. The outward sense is fixed downstream by the mesh
+// pass (orientFacesOutward); this only makes the B-rep edge-uses consistent.
+
+// curvedReorient returns the faces re-wound to a globally consistent orientation (each shared edge traversed
+// oppositely by its two faces). Already-consistent input is returned unchanged (the flood fill flips nothing).
+func curvedReorient(faces []curvedFace) []curvedFace {
+	pw := newWelder3(geom.ResolutionForBox(curvedFaceBox(faces)).Stitch())
+	flip := curvedOrientationFlips(faces, pw)
+	out := make([]curvedFace, len(faces))
+	for i, f := range faces {
+		if flip[i] {
+			f.reversed = !f.reversed
+			loops := make([]curvedLoop, len(f.loops))
+			for j, lp := range f.loops {
+				loops[j] = reverseCurvedLoop(lp)
+			}
+			f.loops = loops
+		}
+		out[i] = f
+	}
+	return out
+}
+
+// curvedOrientationFlips two-colours the face-adjacency graph (BFS over each connected shell) so that, after
+// flipping the marked faces, every shared edge is traversed in opposite directions by its two faces.
+func curvedOrientationFlips(faces []curvedFace, pw *welder3) []bool {
+	adj := curvedFaceAdjacency(faces, pw)
+	flip := make([]bool, len(faces))
+	seen := make([]bool, len(faces))
+	for s := range faces {
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		for q := []int{s}; len(q) > 0; {
+			f := q[0]
+			q = q[1:]
+			for _, e := range adj[f] {
+				if seen[e.face] {
+					continue
+				}
+				seen[e.face] = true
+				flip[e.face] = flip[f] != e.sameDir // flip[nbr] = flip[f] XOR sameDir
+				q = append(q, e.face)
+			}
+		}
+	}
+	return flip
+}
+
+// curvedFaceAdjacency lists, per face, the faces it shares a manifold edge with and whether that edge is
+// traversed the SAME direction by both (so one of them must be flipped for a consistent orientation). Edges
+// used other than exactly twice are skipped (they are resolved by the weld/stitch, not orientation).
+func curvedFaceAdjacency(faces []curvedFace, pw *welder3) [][]orientFlipNeighbour {
+	type useRec struct {
+		face int
+		dir  bool
+	}
+	uses := map[[3]int][]useRec{}
+	for fi := range faces {
+		for _, lp := range faces[fi].loops {
+			for _, le := range lp.edges {
+				key, dir := reorientEdgeKey(pw, le)
+				uses[key] = append(uses[key], useRec{fi, dir})
+			}
+		}
+	}
+	adj := make([][]orientFlipNeighbour, len(faces))
+	for _, us := range uses {
+		if len(us) != 2 {
+			continue
+		}
+		same := us[0].dir == us[1].dir
+		adj[us[0].face] = append(adj[us[0].face], orientFlipNeighbour{us[1].face, same})
+		adj[us[1].face] = append(adj[us[1].face], orientFlipNeighbour{us[0].face, same})
+	}
+	return adj
+}
+
+// reorientEdgeKey returns a loop edge's weld-canonical key (welded endpoints + midpoint, matching curveWelder)
+// and its traversal direction: for a CLOSED edge (a whole seam circle/loop) the sweep sign (t1 < t0); for an
+// OPEN edge whether it runs from the lower-keyed endpoint to the higher. Two faces sharing a key with equal
+// direction traverse it the same way, so one must be flipped.
+func reorientEdgeKey(pw *welder3, le loopEdge) ([3]int, bool) {
+	ka, kb := pw.add(le.start()), pw.add(le.end())
+	kmid := pw.add(le.curve.PointAt((le.t0 + le.t1) / 2))
+	if ka == kb { // closed: oriented by sweep sign, as curveWelder does
+		return [3]int{ka, kb, kmid}, le.t1 < le.t0
+	}
+	if ka > kb {
+		return [3]int{kb, ka, kmid}, false // runs high→low
+	}
+	return [3]int{ka, kb, kmid}, true // runs low→high
+}

--- a/kernel/ops/boolean_curved_target_test.go
+++ b/kernel/ops/boolean_curved_target_test.go
@@ -76,16 +76,18 @@ func TestBooleanNearTangentCylindersStayManifold(t *testing.T) {
 		})
 	}
 
-	t.Run("recorded fallback in the residual lower band", func(t *testing.T) {
-		union, rec := nearTangentUnion(t, r, 5e-5) // |Δr|/r = 2.5e-5 — below the near-pinch gate
-		if !rec.Has(brep.CodeImprintNearPinchDeclined) {
-			t.Fatal("residual near-pinch decline must be RECORDED, not silent (#1598/#1781)")
+	t.Run("analytic path in the residual lower band", func(t *testing.T) {
+		// dr=5e-5 (|Δr|/r = 2.5e-5) is deep in the near-pinch band that #1781 declined; #1818 now ships it
+		// analytically (nearPinchCrossingJoin: raw whole-loop stubs + corridor-seeded keyhole wall).
+		union, rec := nearTangentUnion(t, r, 5e-5)
+		if res := ops.Validate(union); !res.Valid || !union.IsSolid() {
+			t.Fatalf("residual near-pinch union not a valid solid: %+v", res)
 		}
-		got := ops.BodyGeometryProperties(union, ops.DefaultQuality()).Volume
-		// The faceted fallback inscribes the cylinders, so it systematically under-measures
-		// by the facet sagitta — allow 3% where the general path gets 2%.
-		if stdmath.Abs(got-want) > 0.03*want {
-			t.Errorf("fallback union volume = %.4f, want ≈ %.4f — the faceted route must not lose material", got, want)
+		if rec.Has(brep.CodeImprintNearPinchDeclined) {
+			t.Fatalf("residual near-pinch union must ship the analytic path, not decline (#1818)")
+		}
+		if got := ops.BodyGeometryProperties(union, ops.DefaultQuality()).Volume; stdmath.Abs(got-want) > 0.02*want {
+			t.Errorf("union volume = %.4f, want ≈ %.4f (2·cyl − Steinmetz)", got, want)
 		}
 	})
 }

--- a/kernel/ops/boolean_near_pinch_test.go
+++ b/kernel/ops/boolean_near_pinch_test.go
@@ -96,32 +96,62 @@ func assertWatertightCrossing(t *testing.T, got *topo.Body, r, dr float64) {
 	}
 }
 
-// TestNearPinchCutJoinDeclineCleanly pins that CUT and JOIN still decline the near-pinch band to the recorded
-// faceted fallback: #1818 fixes the INTERSECT (per-loop fat-wall trim), but the cut/join fat wall keeps the
-// holed-wall complement whose two lens holes bridge at the neck — a harder construction not yet folded onto
-// the analytic path. The decline must be recorded (never a silent wrong result) and the fallback volume must
-// not collapse. Folding cut/join onto the analytic path is #1819-followup.
-func TestNearPinchCutJoinDeclineCleanly(t *testing.T) {
-	const r = 3.0
-	full := stdmath.Pi * r * r * (4 * r)
-	for _, op := range []PartFeatureOperation{Cut, Join} {
-		for _, dr := range []float64{4e-5, 6e-5, 8e-5} { // |Δr|/r ≈ 1.3e-5 .. 2.7e-5, above the snap ceiling
-			t.Run(fmt.Sprintf("%v/dr=%g", op, dr), func(t *testing.T) {
-				cx, cz := crossingCyls(t, r, dr)
-				rec := &diag.Recorder{}
-				got, err := BooleanWithDiagnostics(op, cx, cz, rec)
-				if err != nil {
-					t.Fatalf("Boolean(%v): %v", op, err)
-				}
-				if !rec.Has(brep.CodeImprintNearPinchDeclined) {
-					t.Fatalf("%v dr=%g (near-pinch) must record the decline, not ship a silent analytic result", op, dr)
-				}
-				// Sanity: the fallback bulk is on the order of a cylinder (cut ≲ full, join ≈ 2·full − lens),
-				// never a collapsed lump.
-				if vol := BodyGeometryProperties(got, DefaultQuality()).Volume; vol < 0.5*full {
-					t.Errorf("%v dr=%g fallback volume %.2f collapsed (< 0.5·cyl %.2f)", op, dr, vol, 0.5*full)
-				}
-			})
+// TestNearPinchCutJoinWatertight is the #1818 cut/join acceptance gate: an unequal-radius near-pinch crossing
+// (below the #1781 upper-band gate, down to just above the Steinmetz snap ceiling) must SUBTRACT and UNION to
+// an EXACT watertight analytic solid — a valid closed manifold, 0 free mesh edges, volume within the
+// DefaultQuality budget of the analytic oracle — and must NOT decline. Cut (cx−cz) severs the near-equal rod
+// into two stubs (rod − intersection); Join fuses both cylinders (fat + thin − intersection). Every near-pinch
+// face is built from the raw whole imprint loops so each shared loop welds as one topo edge (the drilled fat
+// wall is the corridor-seeded keyhole; the thin walls are raw two-rim stubs), a global reorient fixing the
+// winding. Swept at two model scales with |Δr| scaled by R, so the dimensionless near-pinch gate is exercised
+// identically at both.
+func TestNearPinchCutJoinWatertight(t *testing.T) {
+	for _, r := range []float64{3.0, 30.0} {
+		for _, op := range []PartFeatureOperation{Cut, Join} {
+			for _, k := range []float64{4e-5, 6e-5, 1.6e-4, 3.2e-4} {
+				dr := k * (r / 3.0)
+				t.Run(fmt.Sprintf("%v/R=%g/dr=%g", op, r, dr), func(t *testing.T) {
+					cx, cz := crossingCyls(t, r, dr)
+					rec := &diag.Recorder{}
+					got, err := BooleanWithDiagnostics(op, cx, cz, rec)
+					if err != nil {
+						t.Fatalf("Boolean(%v): %v", op, err)
+					}
+					if rec.Has(brep.CodeImprintNearPinchDeclined) {
+						t.Fatalf("%v R=%g dr=%g must ship the analytic near-pinch path, not decline (#1818)", op, r, dr)
+					}
+					assertWatertightSolid(t, got)
+					assertCutJoinVolume(t, op, got, r, dr)
+				})
+			}
 		}
+	}
+}
+
+// assertWatertightSolid pins a boolean result as a valid closed manifold whose mesh has zero free edges.
+func assertWatertightSolid(t *testing.T, got *topo.Body) {
+	t.Helper()
+	if v := Validate(got); !v.Valid || !v.Closed || !v.Manifold || !got.IsSolid() {
+		t.Fatalf("result not a valid closed manifold solid: %+v", v)
+	}
+	if m, _ := TessellateBody(got, DefaultQuality()); freeEdgeCount(m) != 0 {
+		t.Errorf("meshed with %d free edges; want 0 (watertight)", freeEdgeCount(m))
+	}
+}
+
+// assertCutJoinVolume checks the cut/join bulk against the analytic oracle: cx (rod, radius r) − cz (radius
+// r+Δr) is the rod minus the crossing intersection; the union adds both cylinders less that intersection.
+func assertCutJoinVolume(t *testing.T, op PartFeatureOperation, got *topo.Body, r, dr float64) {
+	t.Helper()
+	h := 4 * r
+	rod, fat := stdmath.Pi*r*r*h, stdmath.Pi*(r+dr)*(r+dr)*h
+	inter := nearPinchIntersectVolume(r, r+dr)
+	want := rod - inter
+	if op == Join {
+		want = rod + fat - inter
+	}
+	vol := BodyGeometryProperties(got, DefaultQuality()).Volume
+	if rel := stdmath.Abs(vol-want) / want; rel > 0.04 {
+		t.Errorf("%v R=%g dr=%g volume %.4f, want %.4f (analytic) — rel %.3f > 4%%", op, r, dr, vol, want, rel)
 	}
 }

--- a/kernel/ops/boolean_near_pinch_test.go
+++ b/kernel/ops/boolean_near_pinch_test.go
@@ -53,10 +53,13 @@ func crossingCyls(t *testing.T, r, dr float64) (cx, cz *topo.Body) {
 // (R=3 and R=30) with |Δr| scaled by R, so the dimensionless gate is exercised identically at both — the
 // scale-invariance the near-pinch ratio gate promises.
 func TestNearPinchRecoveredBandWatertight(t *testing.T) {
+	// The whole band down to just above the snap ceiling (|Δr|≈2e-5 at R=3): #1781 recovered the upper part
+	// (gap/chord ≥ the gate) and #1818 the residual near-pinch part (per-loop fat-wall trim). All must ship
+	// the exact three-face watertight solid; none may decline.
 	for _, r := range []float64{3.0, 30.0} {
-		for _, k := range []float64{1.2e-4, 1.6e-4, 2.4e-4, 4.0e-4, 6.0e-4} {
+		for _, k := range []float64{2e-5, 4e-5, 8e-5, 1.6e-4, 3.2e-4, 6.0e-4} {
 			dr := k * (r / 3.0) // scale |Δr| with R so |Δr|/R (hence the loop gap/chord ratio) matches
-			t.Run(fmt.Sprintf("recovered/R=%g/dr=%g", r, dr), func(t *testing.T) {
+			t.Run(fmt.Sprintf("R=%g/dr=%g", r, dr), func(t *testing.T) {
 				cx, cz := crossingCyls(t, r, dr)
 				rec := &diag.Recorder{}
 				got, err := BooleanWithDiagnostics(Intersect, cx, cz, rec)
@@ -64,7 +67,7 @@ func TestNearPinchRecoveredBandWatertight(t *testing.T) {
 					t.Fatalf("Boolean(Intersect): %v", err)
 				}
 				if rec.Has(brep.CodeImprintNearPinchDeclined) {
-					t.Fatalf("R=%g dr=%g must ship the analytic path, not decline (#1781)", r, dr)
+					t.Fatalf("R=%g dr=%g must ship the analytic per-loop path, not decline (#1818)", r, dr)
 				}
 				assertWatertightCrossing(t, got, r, dr)
 			})
@@ -93,30 +96,32 @@ func assertWatertightCrossing(t *testing.T, got *topo.Body, r, dr float64) {
 	}
 }
 
-// TestNearPinchResidualBandDeclinesCleanly pins the residual lower band (#1818): where the neck is below the
-// gate the boolean must DECLINE the analytic path (recorded, never silent) and take the faceted fallback,
-// whose VOLUME must not collapse (a user gets degraded-but-correct bulk, not a wrong tiny lump — the ~98%
-// collapse the analytic arrangement would produce here). The fallback is knowingly NON-watertight in this
-// band (the ~6300-face CSG has sliver edges, #1780) — making it watertight analytically is #1818; this test
-// pins only that the decline is recorded and the volume is preserved, so #1818's arrival is a clean upgrade.
-func TestNearPinchResidualBandDeclinesCleanly(t *testing.T) {
+// TestNearPinchCutJoinDeclineCleanly pins that CUT and JOIN still decline the near-pinch band to the recorded
+// faceted fallback: #1818 fixes the INTERSECT (per-loop fat-wall trim), but the cut/join fat wall keeps the
+// holed-wall complement whose two lens holes bridge at the neck — a harder construction not yet folded onto
+// the analytic path. The decline must be recorded (never a silent wrong result) and the fallback volume must
+// not collapse. Folding cut/join onto the analytic path is #1819-followup.
+func TestNearPinchCutJoinDeclineCleanly(t *testing.T) {
 	const r = 3.0
-	for _, dr := range []float64{4e-5, 6e-5, 8e-5} { // |Δr|/r ≈ 1.3e-5 .. 2.7e-5, above the snap ceiling
-		t.Run(fmt.Sprintf("residual/dr=%g", dr), func(t *testing.T) {
-			cx, cz := crossingCyls(t, r, dr)
-			rec := &diag.Recorder{}
-			got, err := BooleanWithDiagnostics(Intersect, cx, cz, rec)
-			if err != nil {
-				t.Fatalf("Boolean(Intersect): %v", err)
-			}
-			if !rec.Has(brep.CodeImprintNearPinchDeclined) {
-				t.Fatalf("dr=%g (below the near-pinch gate) must record the decline, not ship a silent analytic result", dr)
-			}
-			vol := BodyGeometryProperties(got, DefaultQuality()).Volume
-			want := nearPinchIntersectVolume(r, r+dr)
-			if rel := stdmath.Abs(vol-want) / want; rel > 0.05 {
-				t.Errorf("fallback volume %.4f collapsed vs analytic %.4f — rel %.3f > 5%% (the analytic arrangement would collapse it ~98%% here)", vol, want, rel)
-			}
-		})
+	full := stdmath.Pi * r * r * (4 * r)
+	for _, op := range []PartFeatureOperation{Cut, Join} {
+		for _, dr := range []float64{4e-5, 6e-5, 8e-5} { // |Δr|/r ≈ 1.3e-5 .. 2.7e-5, above the snap ceiling
+			t.Run(fmt.Sprintf("%v/dr=%g", op, dr), func(t *testing.T) {
+				cx, cz := crossingCyls(t, r, dr)
+				rec := &diag.Recorder{}
+				got, err := BooleanWithDiagnostics(op, cx, cz, rec)
+				if err != nil {
+					t.Fatalf("Boolean(%v): %v", op, err)
+				}
+				if !rec.Has(brep.CodeImprintNearPinchDeclined) {
+					t.Fatalf("%v dr=%g (near-pinch) must record the decline, not ship a silent analytic result", op, dr)
+				}
+				// Sanity: the fallback bulk is on the order of a cylinder (cut ≲ full, join ≈ 2·full − lens),
+				// never a collapsed lump.
+				if vol := BodyGeometryProperties(got, DefaultQuality()).Volume; vol < 0.5*full {
+					t.Errorf("%v dr=%g fallback volume %.2f collapsed (< 0.5·cyl %.2f)", op, dr, vol, 0.5*full)
+				}
+			})
+		}
 	}
 }

--- a/kernel/ops/holed_cylinder_wall.go
+++ b/kernel/ops/holed_cylinder_wall.go
@@ -74,11 +74,8 @@ func unrolledWallCDT(s geom.Surface, q Quality, outer3D []math.Point3, holes3D [
 	uv, pos, nrm, loops := patchLoops2D(s, outer3D, holes3D, outer2D, holes2D)
 	nFrontier := len(uv)
 	nodes, saturated := adaptiveInteriorNodes(s, outerUV, holesUV, q, 1, false)
-	for _, g := range nodes {
-		uv = append(uv, [2]float64{g[0] * su, g[1] * sv})
-		pos = append(pos, s.PointAt(g[0], g[1]))
-		nrm = append(nrm, s.NormalAt(g[0], g[1]))
-	}
+	nodes = append(nodes, neckCorridorNodes(holesUV)...) // #1818: seed the bridge between near-touching holes
+	uv, pos, nrm = appendInteriorNodes(s, nodes, su, sv, uv, pos, nrm)
 	tris, unrecovered, leaked := constrainedDelaunayRefinedChecked(uv, loops, nFrontier)
 	if len(tris) == 0 {
 		return boundaryPatchMesh(s, outer3D, holes3D)
@@ -88,6 +85,82 @@ func unrolledWallCDT(s geom.Surface, q Quality, outer3D []math.Point3, holes3D [
 	recordCapSaturation(m, saturated, q)
 	recordConstraintLeak(m, unrecovered, leaked) // #1410: surface non-recovery; never a silent boundary leak
 	return m
+}
+
+// neckCorridorNodes seeds Steiner nodes in the BRIDGE between two near-touching lens holes (the near-pinch
+// crossing neck, #1818). Where two holes come within a few chord lengths, the interior grid — kept a margin
+// clear of every hole — leaves the thin corridor between them EMPTY, so the CDT chords one hole rim straight
+// to the other; those chords coincide with the reversed tunnel band's own pinch chords (same shared loop
+// vertices) and weld into non-manifold deg-4 edges. Seeding the corridor midline forces the wall to mesh
+// hole→node→hole on the fat surface instead, breaking the coincidence. Only fires for exactly two holes that
+// actually near-touch, so an ordinary well-separated drilling is untouched.
+func neckCorridorNodes(holesUV [][]math.Point2) [][2]float64 {
+	if len(holesUV) != 2 {
+		return nil
+	}
+	gap := minCrossVertexDistance(holesUV[0], holesUV[1])
+	chord := meanLoopChord2D(holesUV[0])
+	if chord <= 0 || gap > nearNeckChords*chord {
+		return nil // holes well separated: no corridor to seed
+	}
+	var out [][2]float64
+	for _, a := range holesUV[0] {
+		b, d := nearestVertex2D(a, holesUV[1])
+		if d <= nearNeckChords*chord {
+			out = append(out, [2]float64{float64(a.X+b.X) / 2, float64(a.Y+b.Y) / 2})
+		}
+	}
+	return out
+}
+
+// nearNeckChords is how close (in hole-chord multiples) two holes must approach before the corridor between
+// them is seeded — a dimensionless, model-scale-free threshold (#1818).
+const nearNeckChords = 4.0
+
+// minCrossVertexDistance is the smallest distance between any vertex of loop a and any of loop b.
+func minCrossVertexDistance(a, b []math.Point2) float64 {
+	min := stdmath.Inf(1)
+	for _, pa := range a {
+		if _, d := nearestVertex2D(pa, b); d < min {
+			min = d
+		}
+	}
+	return min
+}
+
+// nearestVertex2D returns the vertex of loop nearest to p and its distance.
+func nearestVertex2D(p math.Point2, loop []math.Point2) (math.Point2, float64) {
+	best, bestD := math.Point2{}, stdmath.Inf(1)
+	for _, q := range loop {
+		if d := float64(p.DistanceTo(q)); d < bestD {
+			best, bestD = q, d
+		}
+	}
+	return best, bestD
+}
+
+// meanLoopChord2D is the mean consecutive-vertex spacing of a (u,v) loop — its own length scale, the neck
+// gap is measured against so the corridor gate is spacing-independent.
+func meanLoopChord2D(loop []math.Point2) float64 {
+	if len(loop) < 2 {
+		return 0
+	}
+	var sum float64
+	for i := 1; i < len(loop); i++ {
+		sum += float64(loop[i-1].DistanceTo(loop[i]))
+	}
+	return sum / float64(len(loop)-1)
+}
+
+// appendInteriorNodes lifts each interior (u,v) node onto the surface — its metric-scaled (u,v), 3D point,
+// and normal — appending them to the CDT's parallel uv/pos/nrm buffers.
+func appendInteriorNodes(s geom.Surface, nodes [][2]float64, su, sv float64, uv [][2]float64, pos []math.Point3, nrm []math.Vector3) ([][2]float64, []math.Point3, []math.Vector3) {
+	for _, g := range nodes {
+		uv = append(uv, [2]float64{g[0] * su, g[1] * sv})
+		pos = append(pos, s.PointAt(g[0], g[1]))
+		nrm = append(nrm, s.NormalAt(g[0], g[1]))
+	}
+	return uv, pos, nrm
 }
 
 // scaleUVLoop scales a (u,v) loop by the per-axis metric (su, sv) so the CDT runs in a space isometric to

--- a/kernel/ops/holed_cylinder_wall_test.go
+++ b/kernel/ops/holed_cylinder_wall_test.go
@@ -128,3 +128,42 @@ func TestHoledCylinderWallDeclinesNonWrappingOuter(t *testing.T) {
 		t.Error("a non-wrapping outer loop should defer from the holed-wall mesher")
 	}
 }
+
+// squareHoleUV is a closed unit square hole loop in (u,v) offset by (du,0) — a synthetic near-pinch hole.
+func squareHoleUV(du float64) []math.Point2 {
+	return []math.Point2{
+		math.P2(math.Scalar(du), 0), math.P2(math.Scalar(du+1), 0),
+		math.P2(math.Scalar(du+1), 1), math.P2(math.Scalar(du), 1), math.P2(math.Scalar(du), 0),
+	}
+}
+
+func TestMeanLoopChord2D(t *testing.T) {
+	if got := meanLoopChord2D(squareHoleUV(0)); stdmath.Abs(got-1) > 1e-9 { // every edge is a unit segment
+		t.Errorf("meanLoopChord2D = %g, want 1", got)
+	}
+	if got := meanLoopChord2D([]math.Point2{math.P2(0, 0)}); got != 0 {
+		t.Errorf("meanLoopChord2D(single) = %g, want 0", got)
+	}
+}
+
+func TestMinCrossVertexDistance(t *testing.T) {
+	// squares at u∈[0,1] and u∈[5,6]: nearest vertices are u=1 and u=5, gap 4.
+	if got := minCrossVertexDistance(squareHoleUV(0), squareHoleUV(5)); stdmath.Abs(got-4) > 1e-9 {
+		t.Errorf("minCrossVertexDistance = %g, want 4", got)
+	}
+}
+
+func TestNeckCorridorNodes(t *testing.T) {
+	// Two holes 0.2 apart (gap/chord = 0.2 < nearNeckChords): the corridor between them is seeded.
+	if got := neckCorridorNodes([][]math.Point2{squareHoleUV(0), squareHoleUV(1.2)}); len(got) == 0 {
+		t.Error("neckCorridorNodes seeded nothing for near-touching holes (gap 0.2)")
+	}
+	// Well-separated holes (gap 6 ≫ nearNeckChords·chord): no corridor seeding.
+	if got := neckCorridorNodes([][]math.Point2{squareHoleUV(0), squareHoleUV(7)}); len(got) != 0 {
+		t.Errorf("neckCorridorNodes seeded %d nodes for well-separated holes; want 0", len(got))
+	}
+	// Not exactly two holes: never seeds (an ordinary single-hole drilling is untouched).
+	if got := neckCorridorNodes([][]math.Point2{squareHoleUV(0)}); got != nil {
+		t.Errorf("neckCorridorNodes seeded for a single hole; want nil")
+	}
+}


### PR DESCRIPTION
## What

Closes #1818. Two perpendicular cylinders whose radii differ by only a hair (an unequal-radius crossing **below the #1781 upper-band gate**, down to the Steinmetz snap ceiling) now **intersect, subtract, and union to exact watertight analytic solids** instead of declining to the faceted CSG fallback.

- **Intersect** (`1cdfba81`): the fat wall is trimmed one lens loop at a time so the two ovals never fuse in a shared `(u,v)` arrangement (each oval is well-conditioned alone). Rod band + two lens caps.
- **Cut & Join** (`0b183737`): every near-pinch face is built from the **raw whole imprint loops**, so each shared loop welds as a single topo edge (shared discretisation):
  - the fat wall is the keyhole **holed tube** with the two whole loops as separate holes;
  - its **neck bridge** (the sliver of fat wall surviving between the two near-touching holes) is meshed watertight by seeding Steiner nodes in the otherwise-empty corridor between the holes — this stops the wall from chording hole-to-hole across the neck, whose chords would otherwise double the reversed thin band's matching pinch chords into non-manifold edges;
  - the thin wall keeps the arrangement tunnel band when it stays inside, or is built as **raw two-rim stubs** when it protrudes / severs outside (where the arrangement fuses the near-severed stubs).
  - A global `curvedReorient` (BFS shell orientation, mirroring the planar boolean's `reorientFaces`) makes the mixed-source shell consistently wound.

## Why

Below the near-pinch gate the two intersection loops separate as `O(√Δr)` while their faceted cusps deviate as `O(h²/√Δr)`, so a single arrangement carrying both loops fuses them and traces the two lenses as one figure-eight — no tolerance schedule survives it. The fix is **topological separation** (per-loop / raw whole-loop construction), not a tighter tolerance. There is **no conditioning floor above the snap ceiling**: the two surfaces stay farther apart than the weld tolerance by `Δr`, which the existing Steinmetz snap ceiling already gates; below that the exact equal-radius constructor takes over.

## Validation

`TestNearPinchCutJoinWatertight` and `TestNearPinchRecoveredBandWatertight` sweep the whole recovered band at **two model scales (R=3, R=30)** and assert, for intersect / cut / join: a **valid closed manifold** solid, **0 free mesh edges**, and **volume within 4 % of the analytic oracle** — and that none decline. The volume-vs-oracle check also certifies **outward** orientation (an inside-out solid fails it).

These sub-micron near-equal cases (Δr ≈ 0.6 µm at R=3) are visually indistinguishable from a plain cylinder, so — as documented for the #1781/#1819 upper band — the headless watertight + volume gate is the authoritative signal; a screenshot cannot resolve the neck. Full `go test ./...` green; `golangci-lint` clean; develop merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)