### PR TITLE
feat(addin): work axis create/list, hole center, draft pull, sweep path (api v0.108.0)

### DIFF
--- a/addin/opregistry/dressup.go
+++ b/addin/opregistry/dressup.go
@@ -408,7 +408,8 @@ const draftSchema = `{
   "type": "object",
   "properties": {
     "faceRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Reference keys of the faces to draft (from get_reference_keys)."},
-    "angle": {"type": "string", "description": "Draft angle with units, e.g. \"3 deg\"."}
+    "angle": {"type": "string", "description": "Draft angle with units, e.g. \"3 deg\"."},
+    "pullDirection": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Explicit pull/parting direction [dx,dy,dz] (only its orientation matters). Omit to let the host infer it from the neutral faces."}
   },
   "required": ["faceRefs", "angle"]
 }`
@@ -449,8 +450,25 @@ func applyDraft(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	pf := feature.NewDressUpFeatures(part.Features()).AddDraft(refKeys(in.FaceRefs), a)
+	pf, err := buildDraft(part, in, a)
+	if err != nil {
+		return nil, err
+	}
 	return recomputeResult(part, pf)
+}
+
+// buildDraft adds the draft feature: with an explicit pull direction when pullDirection is given
+// (AddDraftPull), otherwise the host's inferred pull (AddDraft, default +Z).
+func buildDraft(part *compdef.PartComponentDefinition, in featureargs.Draft, angle func() float64) (*feature.PartFeature, error) {
+	du := feature.NewDressUpFeatures(part.Features())
+	if len(in.PullDirection) == 0 {
+		return du.AddDraft(refKeys(in.FaceRefs), angle), nil
+	}
+	pull, err := vec3(in.PullDirection, "draft: pullDirection")
+	if err != nil {
+		return nil, err
+	}
+	return du.AddDraftPull(refKeys(in.FaceRefs), pull, angle), nil
 }
 
 // --- lip / groove (M20-F10) ------------------------------------------------

--- a/addin/opregistry/dressup_pull_test.go
+++ b/addin/opregistry/dressup_pull_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire/featureargs"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+)
+
+// draftPullDir builds a draft feature via buildDraft and returns its resolved pull direction.
+func draftPullDir(t *testing.T, in featureargs.Draft) math.Vector3 {
+	t.Helper()
+	s, _, _ := extrudedSolid(t)
+	part := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	pf, err := buildDraft(part, in, func() float64 { return 0.05 })
+	if err != nil {
+		t.Fatalf("buildDraft(%+v): %v", in, err)
+	}
+	return pf.Definition().(*feature.FaceDraftFeature).Definition().PullDir
+}
+
+// TestDraftDefaultPullDirection: without pullDirection, the draft uses the host's default +Z pull.
+func TestDraftDefaultPullDirection(t *testing.T) {
+	got := draftPullDir(t, featureargs.Draft{FaceRefs: []string{"f"}})
+	if got != math.V3(0, 0, 1) {
+		t.Errorf("default pull = %v, want +Z", got)
+	}
+}
+
+// TestDraftExplicitPullDirection: an explicit pullDirection maps straight onto the model's
+// AddDraftPull, so the feature's pull direction is exactly the vector supplied over the wire.
+func TestDraftExplicitPullDirection(t *testing.T) {
+	got := draftPullDir(t, featureargs.Draft{FaceRefs: []string{"f"}, PullDirection: []float64{1, 0, 0}})
+	if got != math.V3(1, 0, 0) {
+		t.Errorf("explicit pull = %v, want +X", got)
+	}
+}
+
+// TestDraftPullDirectionThroughRegistry: the full applyDraft path accepts a pullDirection on a
+// real face and builds a feature (recomputeResult never errors for a well-formed request).
+func TestDraftPullDirectionThroughRegistry(t *testing.T) {
+	s, _, face := extrudedSolid(t)
+	args := map[string]any{"faceRefs": []string{face}, "angle": "3 deg", "pullDirection": []float64{0, 0, 1}}
+	if _, err := applyMap(t, s, "draft", args); err != nil {
+		t.Fatalf("draft with pullDirection: %v", err)
+	}
+}
+
+// TestDraftRejectsBadPullDirection: a pullDirection that is not a 3-vector is a clean error.
+func TestDraftRejectsBadPullDirection(t *testing.T) {
+	s, _, face := extrudedSolid(t)
+	args := map[string]any{"faceRefs": []string{face}, "angle": "3 deg", "pullDirection": []float64{1, 0}}
+	if _, err := applyMap(t, s, "draft", args); err == nil {
+		t.Error("draft with a 2-component pullDirection should error")
+	}
+}

--- a/addin/opregistry/feature_advanced.go
+++ b/addin/opregistry/feature_advanced.go
@@ -28,8 +28,9 @@ const sweepSchema = `{
   "properties": {
     "sketchIndex": {"type": "integer", "minimum": 0, "description": "Sketch holding the profile to sweep (omit for definitionType \"solid\")."},
     "profileIndex": {"type": "integer", "minimum": 0, "default": 0},
-    "pathSketchIndex": {"type": "integer", "minimum": 0, "description": "Sketch holding the open path (rail) to sweep along."},
+    "pathSketchIndex": {"type": "integer", "minimum": 0, "description": "Sketch holding the open path (rail) to sweep along (used when pathPoints is absent)."},
     "pathIndex": {"type": "integer", "minimum": 0, "default": 0, "description": "Which open path of the path sketch (see list_sketch_profiles / the sketch's chains)."},
+    "pathPoints": {"type": "array", "items": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3}, "minItems": 2, "description": "Explicit 3D polyline path in cm (each entry [x,y,z]), mirroring how a loft rail's points override its sketch path. When given, the sketch path (pathSketchIndex/pathIndex) is ignored."},
     "definitionType": {"type": "string", "enum": ["path", "pathAndGuideRail", "pathAndGuideSurface", "pathAndSectionTwists", "solid"], "default": "path", "description": "The sweep definition union discriminator."},
     "orientation": {"type": "string", "enum": ["normalToPath", "parallelToOriginalProfile", "alignToVector"], "default": "normalToPath"},
     "alignVector": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Fixed profile normal for orientation alignToVector."},
@@ -42,8 +43,7 @@ const sweepSchema = `{
     "guideFaceKey": {"type": "string", "description": "Reference key of the guide face (pathAndGuideSurface)."},
     "toolBodyIndex": {"type": "integer", "minimum": 0, "description": "Running-body index of the tool to drag (definitionType \"solid\")."},
     "operation": {"type": "string", "enum": ["new", "join", "cut"], "default": "new"}
-  },
-  "required": ["pathSketchIndex"]
+  }
 }`
 
 func sweepDescriptor() *OperationDescriptor {
@@ -66,30 +66,62 @@ func applySweep(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 // sweepDefinitionFromArgs builds the union definition from the wire args,
 // validating the discriminator's required fields.
 func sweepDefinitionFromArgs(part *compdef.PartComponentDefinition, in featureargs.Sweep) (*feature.SweepDefinition, error) {
-	// Validate the path once up front, then hand the feature a live provider that
-	// re-derives it from the path sketch each recompute, so a parameter driving the
-	// rail reshapes the sweep (a snapshot would freeze it at apply time).
-	if _, err := pathFromSketch(part, in.PathSketchIndex, in.PathIndex); err != nil {
-		return nil, err
-	}
-	pathSk, err := sketchAt(part, in.PathSketchIndex)
+	path, pathSk, err := sweepPath(part, in)
 	if err != nil {
 		return nil, err
 	}
 	def := &feature.SweepDefinition{
 		ProfileIndex: in.ProfileIndex,
-		Path: func() *sketch.Path3D {
-			p, _ := pathFromSketch(part, in.PathSketchIndex, in.PathIndex)
-			return p
-		},
+		Path:         path,
 		// Attribute the live path to its sketch so a parameter driving the rail re-sweeps the
-		// body (#1414 tail invalidation; Oblikovati#1693).
+		// body (#1414 tail invalidation; Oblikovati#1693). An explicit pathPoints polyline has no
+		// sketch, so PathSketch is nil.
 		PathSketch: pathSk,
 	}
 	if err := sweepScalars(part, in, def); err != nil {
 		return nil, err
 	}
 	return def, sweepVariantFields(part, in, def)
+}
+
+// sweepPath resolves the sweep's path: an explicit pathPoints polyline (a static path, no sketch)
+// when given, otherwise a live provider re-derived from the path sketch each recompute (so a
+// parameter driving the rail reshapes the sweep; a snapshot would freeze it at apply time).
+func sweepPath(part *compdef.PartComponentDefinition, in featureargs.Sweep) (func() *sketch.Path3D, *sketch.Sketch, error) {
+	if len(in.PathPoints) > 0 {
+		p, err := path3DFromPoints(in.PathPoints)
+		if err != nil {
+			return nil, nil, err
+		}
+		return func() *sketch.Path3D { return p }, nil, nil
+	}
+	if _, err := pathFromSketch(part, in.PathSketchIndex, in.PathIndex); err != nil {
+		return nil, nil, err
+	}
+	pathSk, err := sketchAt(part, in.PathSketchIndex)
+	if err != nil {
+		return nil, nil, err
+	}
+	return func() *sketch.Path3D {
+		p, _ := pathFromSketch(part, in.PathSketchIndex, in.PathIndex)
+		return p
+	}, pathSk, nil
+}
+
+// path3DFromPoints builds an open 3D path from an [x,y,z] polyline (cm), mirroring how a loft
+// rail consumes its explicit Points. Needs at least two points.
+func path3DFromPoints(pts [][]float64) (*sketch.Path3D, error) {
+	if len(pts) < 2 {
+		return nil, fmt.Errorf("sweep: pathPoints needs at least 2 points, got %d", len(pts))
+	}
+	out := make([]*sketch.Point3D, len(pts))
+	for i, p := range pts {
+		if len(p) != 3 {
+			return nil, fmt.Errorf("sweep: pathPoints[%d] needs [x,y,z], got %v", i, p)
+		}
+		out[i] = sketch.NewPoint3D(math.P3(p[0], p[1], p[2]))
+	}
+	return sketch.NewPath3D(out, false), nil
 }
 
 // sweepScalars resolves the profile sketch, twist, taper, orientation and

--- a/addin/opregistry/hole.go
+++ b/addin/opregistry/hole.go
@@ -9,6 +9,7 @@ import (
 
 	"oblikovati.org/api/wire/featureargs"
 	"oblikovati.org/app"
+	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
 )
@@ -28,7 +29,9 @@ const holeSchema = `{
     "counterDepth": {"type": "string", "description": "Counterbore depth (type=counterbore)."},
     "sinkDiameter": {"type": "string", "description": "Countersink top diameter (type=countersink)."},
     "includedAngle": {"type": "string", "description": "Countersink included angle, e.g. \"90 deg\" (type=countersink)."},
-    "designation": {"type": "string", "description": "Thread designation, e.g. \"M5x0.8\" (type=tapped)."}
+    "designation": {"type": "string", "description": "Thread designation, e.g. \"M5x0.8\" (type=tapped)."},
+    "center": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Explicit drill point [x,y,z] in model-space cm (projected onto the picked face). Omit to drill at the face centroid. Needed to place more than one hole on a face."},
+    "centerExpr": {"type": "array", "items": {"type": "string"}, "minItems": 3, "maxItems": 3, "description": "Parameter-expression form of center: [x,y,z] each an expression with units (e.g. \"L/2\"). Overrides center when present."}
   },
   "required": ["faceRef", "diameter"]
 }`
@@ -53,7 +56,54 @@ func applyHole(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := applyHoleCenter(part, pf, in); err != nil {
+		return nil, err
+	}
 	return recomputeResult(part, pf)
+}
+
+// applyHoleCenter sets the hole's explicit drill center from the args (centerExpr wins over the
+// literal center); absent both, the definition keeps its face-centroid default (Center stays nil).
+func applyHoleCenter(part *compdef.PartComponentDefinition, pf *feature.PartFeature, in featureargs.Hole) error {
+	center, err := holeCenterPoint(part, in)
+	if err != nil || center == nil {
+		return err
+	}
+	pf.Definition().(*feature.HoleFeature).Definition().Center = center
+	return nil
+}
+
+// holeCenterPoint resolves the explicit drill center: centerExpr (three unit-bearing expressions,
+// resolved to model cm) when present, else the literal center [x,y,z]; nil when neither is given.
+func holeCenterPoint(part *compdef.PartComponentDefinition, in featureargs.Hole) (*math.Point3, error) {
+	if len(in.CenterExpr) > 0 {
+		return centerFromExprs(part, in.CenterExpr)
+	}
+	if len(in.Center) == 0 {
+		return nil, nil
+	}
+	p, err := point3(in.Center, "hole: center")
+	if err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+// centerFromExprs resolves the three coordinate expressions of centerExpr into a model-space point.
+func centerFromExprs(part *compdef.PartComponentDefinition, exprs []string) (*math.Point3, error) {
+	if len(exprs) != 3 {
+		return nil, fmt.Errorf("hole: centerExpr needs 3 expressions [x,y,z], got %d", len(exprs))
+	}
+	var c [3]float64
+	for i, e := range exprs {
+		v, err := lengthClosure(part, e, "hole: centerExpr")
+		if err != nil {
+			return nil, err
+		}
+		c[i] = v()
+	}
+	p := math.P3(c[0], c[1], c[2])
+	return &p, nil
 }
 
 // buildHole dispatches on the hole type, resolving the extra dimensions each variant needs.

--- a/addin/opregistry/hole_center_test.go
+++ b/addin/opregistry/hole_center_test.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+)
+
+// activePartBody returns the active part's first running solid body.
+func activePartBody(t *testing.T, s *app.Session) *topo.Body {
+	t.Helper()
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	if def.SurfaceBodies().Count() == 0 {
+		t.Fatal("part has no body")
+	}
+	return def.SurfaceBodies().Item(0)
+}
+
+// faceVertexMean averages a face's vertices — the point the hole op drills at by default (it
+// mirrors the model's centroidOf(faceVertexPoints)).
+func faceVertexMean(f *topo.Face) math.Point3 {
+	vs := f.Vertices()
+	var sx, sy, sz float64
+	for _, v := range vs {
+		p := v.Point()
+		sx, sy, sz = sx+float64(p.X), sy+float64(p.Y), sz+float64(p.Z)
+	}
+	n := float64(len(vs))
+	return math.P3(sx/n, sy/n, sz/n)
+}
+
+// boxTopFace returns the extruded box's uppermost (max-Z) face reference key and its vertex
+// centroid.
+func boxTopFace(t *testing.T, s *app.Session) (string, math.Point3) {
+	t.Helper()
+	b := activePartBody(t, s)
+	var top *topo.Face
+	for _, f := range b.Faces() {
+		if top == nil || faceVertexMean(f).Z > faceVertexMean(top).Z {
+			top = f
+		}
+	}
+	if top == nil {
+		t.Fatal("box has no faces")
+	}
+	return string(top.ReferenceKey()), faceVertexMean(top)
+}
+
+// bodyVolume returns the active part body's volume.
+func bodyVolume(t *testing.T, s *app.Session) float64 {
+	t.Helper()
+	return ops.BodyGeometryProperties(activePartBody(t, s), ops.DefaultQuality()).Volume
+}
+
+// bodyCentroidX returns the active part body's center-of-mass X coordinate.
+func bodyCentroidX(t *testing.T, s *app.Session) float64 {
+	t.Helper()
+	return float64(ops.BodyGeometryProperties(activePartBody(t, s), ops.DefaultQuality()).Centroid.X)
+}
+
+// drilledBox seeds a fresh 4×3×1 cm box and drills a blind hole on its top face; center is the
+// optional explicit drill point (nil ⇒ the face centroid). It returns the session after the drill.
+func drilledBox(t *testing.T, center []float64) *app.Session {
+	t.Helper()
+	s, _, _ := extrudedSolid(t)
+	faceKey, _ := boxTopFace(t, s)
+	args := map[string]any{"faceRef": faceKey, "diameter": "3 mm", "depth": "5 mm"}
+	if center != nil {
+		args["center"] = center
+	}
+	if _, err := applyMap(t, s, "hole", args); err != nil {
+		t.Fatalf("drill hole (center=%v): %v", center, err)
+	}
+	return s
+}
+
+// TestHoleCenterAtCentroidMatchesDefault: an explicit center equal to the face centroid drills
+// the same hole as the centroid default — same volume, same center of mass (no regression when
+// Center is supplied redundantly).
+func TestHoleCenterAtCentroidMatchesDefault(t *testing.T) {
+	def := drilledBox(t, nil)
+	seed := profiledPart(t) // recompute the centroid on an identical fresh box
+	if _, err := apply(t, seed, "extrude", `{"sketchIndex":0,"distance":"10 mm"}`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	_, c := boxTopFace(t, seed)
+	centered := drilledBox(t, []float64{float64(c.X), float64(c.Y), float64(c.Z)})
+
+	if vd, vc := bodyVolume(t, def), bodyVolume(t, centered); stdmath.Abs(vd-vc) > 1e-6 {
+		t.Errorf("centered-hole volume = %v, default-hole volume = %v, want equal", vc, vd)
+	}
+	if xd, xc := bodyCentroidX(t, def), bodyCentroidX(t, centered); stdmath.Abs(xd-xc) > 1e-6 {
+		t.Errorf("centered-hole centroid.X = %v, default = %v, want equal", xc, xd)
+	}
+}
+
+// TestHoleOffsetCenterShiftsBore: drilling at an offset center removes the same cylinder volume
+// but at a different location, so the remaining body's center of mass shifts along the offset.
+func TestHoleOffsetCenterShiftsBore(t *testing.T) {
+	// Centroid of the 4×3 face is (2,1.5); offset +0.8 cm in X keeps the Ø3 mm bore well inside.
+	centered := drilledBox(t, []float64{2, 1.5, 1})
+	offset := drilledBox(t, []float64{2.8, 1.5, 1})
+
+	if vc, vo := bodyVolume(t, centered), bodyVolume(t, offset); stdmath.Abs(vc-vo) > 1e-6 {
+		t.Errorf("offset-hole volume = %v, centered = %v, want equal (same bore removed)", vo, vc)
+	}
+	xc, xo := bodyCentroidX(t, centered), bodyCentroidX(t, offset)
+	if stdmath.Abs(xc-xo) < 1e-4 {
+		t.Errorf("offset-hole centroid.X = %v, centered = %v, want a detectable shift", xo, xc)
+	}
+}
+
+// TestHoleCenterExprResolves: the centerExpr form resolves per-coordinate expressions to the
+// same drill point as the literal center.
+func TestHoleCenterExprResolves(t *testing.T) {
+	s, _, _ := extrudedSolid(t)
+	faceKey, _ := boxTopFace(t, s)
+	args := map[string]any{"faceRef": faceKey, "diameter": "3 mm", "depth": "5 mm",
+		"centerExpr": []string{"2.8 cm", "1.5 cm", "1 cm"}}
+	if _, err := applyMap(t, s, "hole", args); err != nil {
+		t.Fatalf("drill hole with centerExpr: %v", err)
+	}
+	literal := drilledBox(t, []float64{2.8, 1.5, 1})
+	if xe, xl := bodyCentroidX(t, s), bodyCentroidX(t, literal); stdmath.Abs(xe-xl) > 1e-6 {
+		t.Errorf("centerExpr centroid.X = %v, literal center = %v, want equal", xe, xl)
+	}
+}
+
+// TestHoleCenterWrongCount: a literal center that is not a 3-vector is a clean error.
+func TestHoleCenterWrongCount(t *testing.T) {
+	s, _, _ := extrudedSolid(t)
+	faceKey, _ := boxTopFace(t, s)
+	args := map[string]any{"faceRef": faceKey, "diameter": "3 mm", "depth": "5 mm", "center": []float64{2, 1}}
+	if _, err := applyMap(t, s, "hole", args); err == nil {
+		t.Error("center with 2 coordinates should error")
+	}
+}
+
+// TestHoleCenterExprBadExpression: an unparseable centerExpr coordinate is a clean error.
+func TestHoleCenterExprBadExpression(t *testing.T) {
+	s, _, _ := extrudedSolid(t)
+	faceKey, _ := boxTopFace(t, s)
+	args := map[string]any{"faceRef": faceKey, "diameter": "3 mm", "depth": "5 mm",
+		"centerExpr": []string{"2 cm", "nonsense", "1 cm"}}
+	if _, err := applyMap(t, s, "hole", args); err == nil {
+		t.Error("an unparseable centerExpr coordinate should error")
+	}
+}
+
+// TestHoleCenterExprWrongCount: centerExpr with the wrong number of coordinates is a clean error.
+func TestHoleCenterExprWrongCount(t *testing.T) {
+	s, _, _ := extrudedSolid(t)
+	faceKey, _ := boxTopFace(t, s)
+	args := map[string]any{"faceRef": faceKey, "diameter": "3 mm", "depth": "5 mm",
+		"centerExpr": []string{"2 cm", "1 cm"}}
+	if _, err := applyMap(t, s, "hole", args); err == nil {
+		t.Error("centerExpr with 2 coordinates should error")
+	}
+}

--- a/addin/opregistry/sweep_path_test.go
+++ b/addin/opregistry/sweep_path_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestPath3DFromPoints covers the polyline→path helper: a valid chain builds an open path; too
+// few points or a malformed point is a clean error.
+func TestPath3DFromPoints(t *testing.T) {
+	p, err := path3DFromPoints([][]float64{{0, 0, 0}, {0, 0, 2}, {0, 0, 5}})
+	if err != nil {
+		t.Fatalf("valid polyline: %v", err)
+	}
+	if p.Count() != 3 || p.IsClosed() {
+		t.Errorf("path = %d points closed=%v, want 3 open", p.Count(), p.IsClosed())
+	}
+	if _, err := path3DFromPoints([][]float64{{0, 0, 0}}); err == nil {
+		t.Error("a single-point polyline should error")
+	}
+	if _, err := path3DFromPoints([][]float64{{0, 0, 0}, {1, 2}}); err == nil {
+		t.Error("a 2-component point should error")
+	}
+}
+
+// TestSweepAlongPathPoints sweeps the profile along an explicit 3D polyline (no path sketch),
+// mirroring how a loft rail consumes explicit points; it must build a healthy solid body.
+func TestSweepAlongPathPoints(t *testing.T) {
+	s := profiledPart(t)
+	// The profile sits on XY; a straight polyline up +Z sweeps it into a prism (no pathSketchIndex).
+	args := map[string]any{
+		"sketchIndex": 0, "profileIndex": 0,
+		"pathPoints": [][]float64{{0, 0, 0}, {0, 0, 5}},
+	}
+	raw, err := applyMap(t, s, "sweep", args)
+	if err != nil {
+		t.Fatalf("sweep along pathPoints: %v", err)
+	}
+	var res struct {
+		Bodies  int  `json:"bodies"`
+		Healthy bool `json:"healthy"`
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if !res.Healthy || res.Bodies < 1 {
+		t.Errorf("sweep result = %+v, want a healthy body from the polyline path", res)
+	}
+}
+
+// TestSweepPathPointsOverrideSketch: pathPoints takes precedence, so a valid polyline sweeps even
+// when the pathSketchIndex would be out of range (the sketch path is not consulted).
+func TestSweepPathPointsOverridesSketch(t *testing.T) {
+	s := profiledPart(t)
+	args := map[string]any{
+		"sketchIndex": 0, "profileIndex": 0, "pathSketchIndex": 99,
+		"pathPoints": [][]float64{{0, 0, 0}, {0, 0, 5}},
+	}
+	if _, err := applyMap(t, s, "sweep", args); err != nil {
+		t.Fatalf("pathPoints should override the (invalid) sketch path: %v", err)
+	}
+}
+
+// TestSweepPathPointsTooFew: a polyline with fewer than two points is a clean error.
+func TestSweepPathPointsTooFew(t *testing.T) {
+	s := profiledPart(t)
+	args := map[string]any{
+		"sketchIndex": 0, "profileIndex": 0,
+		"pathPoints": [][]float64{{0, 0, 0}},
+	}
+	if _, err := applyMap(t, s, "sweep", args); err == nil {
+		t.Error("a single-point pathPoints should error")
+	}
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -198,6 +198,8 @@ func (r *Router) registerStandardHandlers() {
 	r.mutating(wire.MethodWorkPlanesCreate, "Create Work Plane", typedCtx(activeWorkHost, createWorkPlanes))
 	r.mutating(wire.MethodWorkPlanesRedefine, "Redefine Work Plane", typedCtx(activeWorkHost, redefineWorkPlane))
 	r.mutating(wire.MethodWorkPointsCreate, "Create Work Point", typedCtx(activeWorkHost, createWorkPoint))
+	r.readOnly(wire.MethodWorkAxesList, ctxQuery(activeWorkHost, listWorkAxes))
+	r.mutating(wire.MethodWorkAxesCreate, "Create Work Axis", typedCtx(activeWorkHost, createWorkAxis))
 
 	r.readOnly(wire.MethodWorkSurfacesList, partQuery(listWorkSurfaces))
 	r.readOnly(wire.MethodWorkSurfacesGet, typedPart(getWorkSurface))

--- a/addin/router/work_axes.go
+++ b/addin/router/work_axes.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+)
+
+// The work-axis wire surface (workAxes.create / workAxes.list), mirroring work_planes.go: a
+// datum axis is a grounded "line" (origin + direction), an axis through two points, or the axis
+// where two planes meet. An unsatisfiable-but-well-formed definition still creates the axis
+// (reported healthy=false); the call only fails on bad arguments.
+
+// listWorkAxes enumerates the active model's datum axes (origin frame first, then user axes)
+// with their current geometry and health.
+func listWorkAxes(_ *app.Session, host workHost) (wire.ListWorkAxesResult, error) {
+	axes := projectAll(host.WorkAxes(), workAxisInfo)
+	return wire.ListWorkAxesResult{Axes: axes}, nil
+}
+
+// workAxisInfo renders one axis as the wire DTO: its identity, current origin + unit direction,
+// whether it is one of the origin coordinate axes, health, and constructor kind.
+func workAxisInfo(index int, wa *feature.WorkAxis) wire.WorkAxisInfo {
+	return wire.WorkAxisInfo{
+		Index:     index,
+		Name:      wa.Name(),
+		Ref:       string(wa.Key()),
+		Kind:      wa.Kind(),
+		Origin:    point3Slice(wa.Origin()),
+		Direction: vector3Slice(wa.Direction().AsVector()),
+		IsOrigin:  wa.IsCoordinateSystemElement(),
+		Healthy:   wa.Health().OK(),
+		Reason:    wa.Health().Reason, // empty when healthy
+	}
+}
+
+// buildWorkAxis dispatches a create request to the matching model constructor.
+func buildWorkAxis(host workHost, in wire.CreateWorkAxisArgs) (*feature.WorkAxis, error) {
+	axes := host.WorkAxes()
+	switch types.WorkAxisKind(in.Kind) {
+	case types.WorkAxisLine:
+		return addLineAxis(axes, in)
+	case types.WorkAxisTwoPoints:
+		return addRefAxis(in, "two-points", axes.AddByTwoPoints)
+	case types.WorkAxisPlaneIntersection:
+		return addRefAxis(in, "plane-intersection", axes.AddByPlaneIntersection)
+	default:
+		return nil, fmt.Errorf("workAxes.create: unknown kind %q (see api/types WorkAxis*)", in.Kind)
+	}
+}
+
+// addLineAxis builds the grounded "line" axis from its origin point and direction vector.
+func addLineAxis(axes *feature.WorkAxes, in wire.CreateWorkAxisArgs) (*feature.WorkAxis, error) {
+	origin, err := parseCoords(in.Origin, "workAxes.create: origin")
+	if err != nil {
+		return nil, err
+	}
+	dir, err := parseAxisVector(in.Direction, "workAxes.create: direction")
+	if err != nil {
+		return nil, err
+	}
+	return axes.AddByLine(math.P3(origin[0], origin[1], origin[2]), dir), nil
+}
+
+// addRefAxis builds a two-reference axis kind (two-points / plane-intersection) from exactly two
+// work references, erroring on the wrong count.
+func addRefAxis(in wire.CreateWorkAxisArgs, kind string, build func(a, b feature.WorkRef) *feature.WorkAxis) (*feature.WorkAxis, error) {
+	refs := toWorkRefs(in.Refs)
+	if len(refs) != 2 {
+		return nil, fmt.Errorf("workAxes.create: %s needs 2 references, got %d", kind, len(refs))
+	}
+	return build(refs[0], refs[1]), nil
+}

--- a/addin/router/work_axes_test.go
+++ b/addin/router/work_axes_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+func TestWorkAxesListIncludesOriginFrame(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var list wire.ListWorkAxesResult
+	call(t, r, s, "workAxes.list", "{}", &list)
+	if len(list.Axes) != 3 {
+		t.Fatalf("fresh part has %d work axes, want 3 origin axes", len(list.Axes))
+	}
+	for _, a := range list.Axes {
+		if !a.IsOrigin || !a.Healthy || a.Kind != "line" {
+			t.Errorf("origin axis %q: isOrigin=%v healthy=%v kind=%q, want origin+healthy+line", a.Name, a.IsOrigin, a.Healthy, a.Kind)
+		}
+	}
+}
+
+func TestWorkAxesCreateLineThenList(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var res wire.CreateWorkAxisResult
+	call(t, r, s, "workAxes.create", `{"kind":"line","origin":[1,2,3],"direction":[0,0,1]}`, &res)
+	if !res.Healthy {
+		t.Fatalf("line axis not healthy: %+v", res)
+	}
+	if res.Index != 3 { // after the 3 origin axes
+		t.Errorf("new axis index = %d, want 3", res.Index)
+	}
+	var list wire.ListWorkAxesResult
+	call(t, r, s, "workAxes.list", "{}", &list)
+	if len(list.Axes) != 4 {
+		t.Fatalf("after create, %d axes, want 4", len(list.Axes))
+	}
+	created := list.Axes[3]
+	if created.IsOrigin || created.Kind != "line" {
+		t.Errorf("created axis = %+v, want a user line axis", created)
+	}
+	if created.Origin[0] != 1 || created.Origin[1] != 2 || created.Origin[2] != 3 {
+		t.Errorf("created axis origin = %v, want (1,2,3)", created.Origin)
+	}
+	if created.Direction[2] != 1 || created.Direction[0] != 0 || created.Direction[1] != 0 {
+		t.Errorf("created axis direction = %v, want +Z", created.Direction)
+	}
+}
+
+func TestWorkAxesCreateTwoPoints(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var p0, p1 wire.CreateWorkPointResult
+	call(t, r, s, "workPoints.create", `{"at":[0,0,0]}`, &p0)
+	call(t, r, s, "workPoints.create", `{"at":[0,0,5]}`, &p1)
+	var res wire.CreateWorkAxisResult
+	call(t, r, s, "workAxes.create",
+		`{"kind":"two-points","refs":["`+p0.Ref+`","`+p1.Ref+`"]}`, &res)
+	if !res.Healthy {
+		t.Fatalf("two-points axis not healthy (user point refs must resolve): %+v", res)
+	}
+	var list wire.ListWorkAxesResult
+	call(t, r, s, "workAxes.list", "{}", &list)
+	created := list.Axes[res.Index]
+	if created.Kind != "two-points" || created.Direction[2] != 1 {
+		t.Errorf("two-points axis = %+v, want kind two-points along +Z", created)
+	}
+}
+
+func TestWorkAxesCreatePlaneIntersection(t *testing.T) {
+	r, s := emptyPartSession(t)
+	// XY ∩ XZ = the X axis.
+	var res wire.CreateWorkAxisResult
+	call(t, r, s, "workAxes.create",
+		`{"kind":"plane-intersection","refs":["origin/plane/xy","origin/plane/xz"]}`, &res)
+	if !res.Healthy {
+		t.Fatalf("plane-intersection axis not healthy: %+v", res)
+	}
+	var list wire.ListWorkAxesResult
+	call(t, r, s, "workAxes.list", "{}", &list)
+	created := list.Axes[res.Index]
+	if created.Kind != "plane-intersection" {
+		t.Errorf("kind = %q, want plane-intersection", created.Kind)
+	}
+	// The X axis: direction has no Y/Z component.
+	if created.Direction[1] != 0 || created.Direction[2] != 0 {
+		t.Errorf("XY∩XZ axis direction = %v, want parallel to X", created.Direction)
+	}
+}
+
+func TestWorkAxesCreateUnknownKind(t *testing.T) {
+	r, s := emptyPartSession(t)
+	if _, err := r.Handle(s, "workAxes.create", []byte(`{"kind":"no-such-kind"}`)); err == nil {
+		t.Error("expected error for unknown work-axis kind")
+	}
+}
+
+func TestWorkAxesCreateWrongReferenceCount(t *testing.T) {
+	r, s := emptyPartSession(t)
+	// two-points needs 2 references; supplying 1 is a bad request.
+	if _, err := r.Handle(s, "workAxes.create",
+		[]byte(`{"kind":"two-points","refs":["origin/point/center"]}`)); err == nil {
+		t.Error("expected error for wrong reference count")
+	}
+}
+
+func TestWorkAxesCreateLineBadDirection(t *testing.T) {
+	r, s := emptyPartSession(t)
+	// A zero direction vector cannot be normalized to a unit axis direction.
+	if _, err := r.Handle(s, "workAxes.create",
+		[]byte(`{"kind":"line","origin":[0,0,0],"direction":[0,0,0]}`)); err == nil {
+		t.Error("expected error for a zero direction vector")
+	}
+}

--- a/addin/router/work_planes.go
+++ b/addin/router/work_planes.go
@@ -29,6 +29,7 @@ var (
 type workHost interface {
 	WorkPlanes() *feature.WorkPlanes
 	WorkPoints() *feature.WorkPoints
+	WorkAxes() *feature.WorkAxes
 	Units() param.UnitsOfMeasure
 	Parameters() *param.Parameters
 	Recompute()
@@ -209,6 +210,25 @@ func createWorkPoint(_ *app.Session, host workHost, in wire.CreateWorkPointArgs)
 		Index: host.WorkPoints().Count() - 1,
 		Ref:   string(wp.Key()),
 		Name:  wp.Name(),
+	}, nil
+}
+
+// createWorkAxis adds a datum axis of the requested kind (line / two-points / plane-intersection,
+// built by buildWorkAxis in work_axes.go) to the active model and recomputes, returning its index,
+// reference (usable to build further datums or as a revolve axis), name, and health. It lives here
+// beside createWorkPoint because it self-orchestrates the work-geometry recompute (audit B1).
+func createWorkAxis(_ *app.Session, host workHost, in wire.CreateWorkAxisArgs) (wire.CreateWorkAxisResult, error) {
+	wa, err := buildWorkAxis(host, in)
+	if err != nil {
+		return wire.CreateWorkAxisResult{}, err
+	}
+	host.Recompute()
+	return wire.CreateWorkAxisResult{
+		Index:   host.WorkAxes().Count() - 1,
+		Ref:     string(wa.Key()),
+		Name:    wa.Name(),
+		Healthy: wa.Health().OK(),
+		Reason:  wa.Health().Reason,
 	}, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.107.0
+	oblikovati.org/api v0.108.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.107.0
+	oblikovati.org/api v0.108.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/feature/serialize_work.go
+++ b/model/feature/serialize_work.go
@@ -103,7 +103,13 @@ func serializePlaneDef(def planeDefinition) (WorkFeatureData, error) {
 }
 
 func serializeAxisDef(def axisDefinition) (WorkFeatureData, error) {
-	switch def.(type) {
+	switch v := def.(type) {
+	case fixedAxisDef: // grounded "line" axis: persist its origin + direction (no references)
+		p := v.origin
+		return WorkFeatureData{
+			Collection: "axis", Kind: def.kindName(),
+			Position: []float64{float64(p.X), float64(p.Y), float64(p.Z)}, XAxis: unitSlice(v.dir),
+		}, nil
 	case twoPointsAxisDef, planeIntersectionAxisDef:
 		return WorkFeatureData{Collection: "axis", Kind: def.kindName(), Refs: refStrings(def.refs())}, nil
 	default:
@@ -260,6 +266,9 @@ func restorePointCloudFit(c *WorkPlanes, d WorkFeatureData) error {
 }
 
 func restoreAxisFeature(c *WorkAxes, d WorkFeatureData) error {
+	if d.Kind == "line" { // grounded axis: rebuilt from its origin + direction, no references
+		return restoreLineAxis(c, d)
+	}
 	r, err := workRefs(d.Refs, 2)
 	if err != nil {
 		return err
@@ -272,6 +281,20 @@ func restoreAxisFeature(c *WorkAxes, d WorkFeatureData) error {
 	default:
 		return fmt.Errorf("no restore codec for work axis kind %q", d.Kind)
 	}
+	return nil
+}
+
+// restoreLineAxis rebuilds a grounded "line" axis from its persisted origin + direction.
+func restoreLineAxis(c *WorkAxes, d WorkFeatureData) error {
+	o, err := point3From(d.Position, "line axis origin")
+	if err != nil {
+		return err
+	}
+	dir, err := unit3From(d.XAxis, "line axis direction")
+	if err != nil {
+		return err
+	}
+	c.AddByLine(o, dir)
 	return nil
 }
 

--- a/model/feature/work_axis_point.go
+++ b/model/feature/work_axis_point.go
@@ -24,7 +24,10 @@ type fixedAxisDef struct {
 	dir    math.UnitVector3
 }
 
-func (d fixedAxisDef) kindName() string { return "fixed" }
+// kindName reports the grounded axis as "line" (types.WorkAxisLine): a raw origin + direction
+// axis. The origin coordinate axes and a user AddByLine axis share this fixedAxisDef, so both
+// list as the "line" kind (the origin ones additionally report IsCoordinateSystemElement).
+func (d fixedAxisDef) kindName() string { return "line" }
 func (d fixedAxisDef) refs() []WorkRef  { return nil }
 func (d fixedAxisDef) eval(workResolver) (math.Point3, math.UnitVector3, error) {
 	return d.origin, d.dir, nil
@@ -91,6 +94,10 @@ func (w *WorkAxis) Direction() math.UnitVector3     { return w.dir }
 func (w *WorkAxis) IsCoordinateSystemElement() bool { return w.coordinateSystem }
 func (w *WorkAxis) Grounded() bool                  { return w.grounded }
 
+// Kind reports the axis's constructor name (a types.WorkAxisKind value: "line", "two-points",
+// "plane-intersection"), as workAxes.list surfaces it. Mirrors WorkPlane.Kind.
+func (w *WorkAxis) Kind() string { return w.def.kindName() }
+
 // Visible reports whether the datum axis is drawn in the viewport.
 func (w *WorkAxis) Visible() bool { return w.visible }
 
@@ -132,6 +139,14 @@ func (c *WorkAxes) addOrigin(key WorkRef, name string, origin math.Point3, dir m
 		coordinateSystem: true, grounded: true,
 	}
 	c.track(w)
+}
+
+// AddByLine creates a grounded user axis at a fixed origin and direction — the raw axis a
+// revolve or sweep spins about when it is not one of the origin axes (e.g. an axis matching a
+// sketch line, authored over the wire by an exporter, #735). Mirrors AddByTwoPoints for the
+// grounded (fixedAxisDef) kind; the tracked axis is persisted by its origin+direction.
+func (c *WorkAxes) AddByLine(origin math.Point3, dir math.UnitVector3) *WorkAxis {
+	return c.addUser(fixedAxisDef{origin: origin, dir: dir})
 }
 
 // AddByTwoPoints creates a user axis through two referenced points.

--- a/model/feature/work_features_test.go
+++ b/model/feature/work_features_test.go
@@ -133,6 +133,51 @@ func TestWorkAxisByTwoPointsAndPlaneIntersection(t *testing.T) {
 	}
 }
 
+// TestWorkAxisByLine covers the grounded "line" axis: a fixed origin + direction, tracked as a
+// user axis that lists as the "line" kind (not an origin coordinate-system element).
+func TestWorkAxisByLine(t *testing.T) {
+	g := NewWorkGeometry()
+	before := g.WorkAxes().Count()
+	ax := g.WorkAxes().AddByLine(math.P3(1, 2, 3), mustUnit(0, 0, 1))
+	if g.WorkAxes().Count() != before+1 {
+		t.Fatalf("axis count = %d, want %d", g.WorkAxes().Count(), before+1)
+	}
+	if !ax.Health().OK() {
+		t.Fatalf("line axis sick: %+v", ax.Health())
+	}
+	if !ax.Origin().IsEqualTo(math.P3(1, 2, 3), wtol) {
+		t.Errorf("line axis origin = %v, want (1,2,3)", ax.Origin())
+	}
+	if !ax.Direction().AsVector().IsEqualTo(math.V3(0, 0, 1), wtol) {
+		t.Errorf("line axis dir = %v, want +Z", ax.Direction())
+	}
+	if ax.Kind() != "line" || ax.IsCoordinateSystemElement() {
+		t.Errorf("line axis Kind=%q origin=%v, want kind=line and not an origin element", ax.Kind(), ax.IsCoordinateSystemElement())
+	}
+}
+
+// TestWorkAxisLineSerializeRoundTrip pins that a grounded line axis persists by its origin +
+// direction and restores to the same geometry (serializeAxisDef / restoreLineAxis).
+func TestWorkAxisLineSerializeRoundTrip(t *testing.T) {
+	g := NewWorkGeometry()
+	g.WorkAxes().AddByLine(math.P3(1, 2, 3), mustUnit(0, 1, 0))
+	d, err := serializeAxisDef(fixedAxisDef{origin: math.P3(1, 2, 3), dir: mustUnit(0, 1, 0)})
+	if err != nil {
+		t.Fatalf("serialize line axis: %v", err)
+	}
+	if d.Kind != "line" || len(d.Position) != 3 || len(d.XAxis) != 3 {
+		t.Fatalf("serialized line axis = %+v, want kind=line with a position and direction", d)
+	}
+	restored := NewWorkGeometry()
+	if err := restoreAxisFeature(restored.WorkAxes(), d); err != nil {
+		t.Fatalf("restore line axis: %v", err)
+	}
+	ax := restored.WorkAxes().Item(restored.WorkAxes().Count() - 1)
+	if !ax.Origin().IsEqualTo(math.P3(1, 2, 3), wtol) || !ax.Direction().AsVector().IsEqualTo(math.V3(0, 1, 0), wtol) {
+		t.Errorf("restored line axis = origin %v dir %v, want (1,2,3) / +Y", ax.Origin(), ax.Direction())
+	}
+}
+
 func TestWorkPointPiercesPlane(t *testing.T) {
 	g := NewWorkGeometry()
 	wp := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(2, 3, 4) })


### PR DESCRIPTION
Implements the **host side** of the API gaps whose contract shipped in `oblikovati.org/api@v0.108.0` (bumped in `go.mod`; resolved locally via `go.work` to the sibling `../Oblikovati.API` at develop). Four wire handlers plus the one missing model constructor.

## Handlers

| Area | Handler(s) | Category |
|------|-----------|----------|
| **A. Work axis** | `workAxes.create` + `workAxes.list` | **corpus blocker** |
| **B. Hole placement center** | `hole` op `center` / `centerExpr` | **corpus blocker** |
| C. Draft pull direction | `draft` op `pullDirection` | parity |
| D. Sweep explicit path points | `sweep` op `pathPoints` | parity |

### A. Work axis (blocker) — model + router
- **Model** (`model/feature/work_axis_point.go`): new public grounded constructor `WorkAxes.AddByLine(origin math.Point3, dir math.UnitVector3) *WorkAxis` wrapping `fixedAxisDef`, mirroring `AddByTwoPoints`; added `WorkAxis.Kind()`; the grounded def now names itself `"line"` (matches `types.WorkAxisLine`). Serialize/restore support for the line axis (`serialize_work.go`) so an exporter-authored axis round-trips.
- **Router**: new `addin/router/work_axes.go` holds the read-only `listWorkAxes` + pure `buildWorkAxis` dispatch (`line` → `AddByLine`, `two-points` → `AddByTwoPoints`, `plane-intersection` → `AddByPlaneIntersection`). The recompute-orchestrating `createWorkAxis` sits in the already-allowlisted `work_planes.go` beside `createWorkPoint` (archguard B1 seam rule — no new self-orchestration file). Both registered next to the work-plane methods in `router.go`.

### B. Hole placement center (blocker) — opregistry
- `hole.go` schema gains `center` (model-space cm) and `centerExpr` (per-coordinate expressions). The apply path sets `HoleDefinition.Center` (the model already supported it); when absent, today's face-centroid behavior is unchanged (verified: a redundant explicit centroid yields identical volume + center of mass).

### C. Draft pull direction (parity) — opregistry
- `dressup.go` draft schema gains `pullDirection`; dispatches to the model's **existing** `AddDraftPull` when supplied, else the inferred +Z default. No model rework needed.

### D. Sweep explicit path points (parity) — opregistry
- `feature_advanced.go` sweep schema gains `pathPoints`; builds a static `sketch.Path3D` polyline (mirroring how a loft rail consumes explicit `Points`) that overrides the sketch path when present.

**No C/D limitations** — both the draft pull direction and the sweep polyline path are fully applied to the kernel (the model already had `AddDraftPull`; the sweep definition already accepts a `Path3D` provider). Neither required kernel work.

## Tests & CI
- Every new function has a test: model `AddByLine` + serialize round-trip; router create/list for all three axis kinds + error paths; hole center (centroid-equivalence, offset-shifts-bore, `centerExpr`, error paths); draft pull mapping + registry path; sweep `pathPoints` build + override + error paths.
- `go build ./...` and `go test ./...` (root module) green, including the `archguard` mutation-seam guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)