### PR TITLE
feat(opregistry): geometric selectors for hole placement and dress-up edges/faces (api v0.109.0)

### DIFF
--- a/addin/opregistry/dressup.go
+++ b/addin/opregistry/dressup.go
@@ -39,7 +39,8 @@ const filletSchema = `{
     "cornerType": {"type": "string", "enum": ["miter", "setback", "round"], "default": "miter", "description": "How a vertex where two filleted edges meet (third edge sharp) is treated: miter (exact crease), round (fillets the third edge into a smooth sphere). setback is reserved."},
     "crossSection": {"type": "string", "enum": ["arc", "g2", "conic"], "default": "arc", "description": "Blend cross-section shape (#1284): arc = circular rolling-ball (G1, default), g2 = curvature-continuous (no highlight break at the tangency lines), conic = rho-controlled. G2/conic apply to planar-walled edge fillets."},
     "rho": {"type": "number", "minimum": 0.1, "maximum": 0.9, "description": "Conic fullness when crossSection=conic: 0.5 = parabola, lower = flatter, higher = fuller."},
-    "concaveStrategy": {"type": "string", "enum": ["outward", "inward"], "default": "outward", "description": "Concave (internal) edge handling: outward fills the inside corner with an exact rolling-ball cylinder (default). inward rounds a recess into the corner and is only valid where the faces extend into the material (e.g. a pocket). Convex edges ignore this."}
+    "concaveStrategy": {"type": "string", "enum": ["outward", "inward"], "default": "outward", "description": "Concave (internal) edge handling: outward fills the inside corner with an exact rolling-ball cylinder (default). inward rounds a recess into the corner and is only valid where the faces extend into the material (e.g. a pocket). Convex edges ignore this."},
+    "edgesGeom": {"type": "array", "description": "Select the rounded edges by GEOMETRY instead of edgeRefs, so the binding survives recompute (for an external author that cannot mint stable keys). Give either this + radius, edgeRefs, or edgeSets.", "items": {"type": "object", "properties": {"midpoint": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Edge midpoint [x,y,z] cm."}, "direction": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Unit tangent [x,y,z]."}}, "required": ["midpoint", "direction"]}}
   }
 }`
 
@@ -51,9 +52,10 @@ const chamferSchema = `{
     "chamferType": {"type": "string", "enum": ["distance", "distanceAndAngle", "twoDistances"], "default": "distance", "description": "Setback mode."},
     "distance2": {"type": "string", "description": "twoDistances: setback on the second face, e.g. \"4 mm\"."},
     "angle": {"type": "string", "description": "distanceAndAngle: chamfer-face angle, e.g. \"30 deg\"."},
-    "concaveStrategy": {"type": "string", "enum": ["outward", "inward"], "default": "outward", "description": "Concave (internal) edge handling: outward fills the inside corner with material (default), inward cuts a recessed relief groove. Convex edges ignore this."}
+    "concaveStrategy": {"type": "string", "enum": ["outward", "inward"], "default": "outward", "description": "Concave (internal) edge handling: outward fills the inside corner with material (default), inward cuts a recessed relief groove. Convex edges ignore this."},
+    "edgesGeom": {"type": "array", "description": "Select the bevelled edges by GEOMETRY instead of edgeRefs, so the binding survives recompute. Give either this or edgeRefs.", "items": {"type": "object", "properties": {"midpoint": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Edge midpoint [x,y,z] cm."}, "direction": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Unit tangent [x,y,z]."}}, "required": ["midpoint", "direction"]}}
   },
-  "required": ["edgeRefs", "distance"]
+  "required": ["distance"]
 }`
 
 func filletDescriptor() *OperationDescriptor {
@@ -198,16 +200,33 @@ func applyFaceFillet(part *compdef.PartComponentDefinition, in featureargs.Fille
 // applyFilletFlat builds the flat (edgeRefs + single radius) fillet with the chosen corner
 // treatment and concave-edge strategy.
 func applyFilletFlat(part *compdef.PartComponentDefinition, in featureargs.Fillet, corner types.FilletCornerType, cs types.FilletConcaveStrategy, prof blendProfileArgs) (json.RawMessage, error) {
-	if len(in.EdgeRefs) == 0 {
-		return nil, errors.New("fillet: edgeRefs is empty (give edgeRefs+radius or edgeSets)")
+	if len(in.EdgeRefs) == 0 && len(in.EdgesGeom) == 0 {
+		return nil, errors.New("fillet: edgeRefs is empty (give edgeRefs+radius, edgesGeom, or edgeSets)")
 	}
 	r, err := lengthClosure(part, in.Radius, fieldFilletRadius)
 	if err != nil {
 		return nil, err
 	}
 	pf := feature.NewDressUpFeatures(part.Features()).AddFilletCorner(refKeys(in.EdgeRefs), r, corner)
+	if err := setFilletGeomEdges(pf, in.EdgesGeom); err != nil {
+		return nil, err
+	}
 	applyDressProfile(pf, cs, prof)
 	return recomputeResult(part, pf)
+}
+
+// setFilletGeomEdges binds the fillet's edges by geometry when edgesGeom is given, so an external
+// author's edge selection survives recompute (bindGeomEdges folds them into the edge list).
+func setFilletGeomEdges(pf *feature.PartFeature, sels []featureargs.GeomEdgeSel) error {
+	if len(sels) == 0 {
+		return nil
+	}
+	refs, err := geomEdgeRefs(sels)
+	if err != nil {
+		return err
+	}
+	pf.Definition().(*feature.FilletFeature).Definition().GeomEdges = refs
+	return nil
 }
 
 // applyFilletSets decodes the edge-set form and adds the fillet with the chosen corner treatment,
@@ -316,8 +335,8 @@ func applyChamfer(s *app.Session, raw json.RawMessage) (json.RawMessage, error) 
 	if err != nil {
 		return nil, err
 	}
-	if len(in.EdgeRefs) == 0 {
-		return nil, errors.New("chamfer: edgeRefs is empty")
+	if len(in.EdgeRefs) == 0 && len(in.EdgesGeom) == 0 {
+		return nil, errors.New("chamfer: edgeRefs is empty (give edgeRefs or edgesGeom)")
 	}
 	pf, err := buildChamfer(part, in)
 	if err != nil {
@@ -345,7 +364,16 @@ func buildChamfer(part *compdef.PartComponentDefinition, in featureargs.Chamfer)
 	if err != nil {
 		return nil, err
 	}
-	pf.Definition().(*feature.ChamferFeature).Definition().ConcaveStrategy = cs
+	def := pf.Definition().(*feature.ChamferFeature).Definition()
+	def.ConcaveStrategy = cs
+	if len(in.EdgesGeom) > 0 {
+		// Bind the chamfered edges by geometry when authored geometrically (survives recompute).
+		refs, err := geomEdgeRefs(in.EdgesGeom)
+		if err != nil {
+			return nil, err
+		}
+		def.GeomEdges = refs
+	}
 	return pf, nil
 }
 
@@ -399,9 +427,10 @@ const shellSchema = `{
   "type": "object",
   "properties": {
     "faceRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Reference keys of the faces to remove, hollowing the body (from get_reference_keys)."},
-    "thickness": {"type": "string", "description": "Remaining wall thickness with units, e.g. \"1 mm\"."}
+    "thickness": {"type": "string", "description": "Remaining wall thickness with units, e.g. \"1 mm\"."},
+    "facesGeom": {"type": "array", "description": "Select the removed faces by GEOMETRY instead of faceRefs, so the binding survives recompute. Give either this or faceRefs.", "items": {"type": "object", "properties": {"centroid": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Face centroid [x,y,z] cm."}, "normal": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Outward unit normal [x,y,z]."}}, "required": ["centroid", "normal"]}}
   },
-  "required": ["faceRefs", "thickness"]
+  "required": ["thickness"]
 }`
 
 const draftSchema = `{
@@ -409,9 +438,10 @@ const draftSchema = `{
   "properties": {
     "faceRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Reference keys of the faces to draft (from get_reference_keys)."},
     "angle": {"type": "string", "description": "Draft angle with units, e.g. \"3 deg\"."},
-    "pullDirection": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Explicit pull/parting direction [dx,dy,dz] (only its orientation matters). Omit to let the host infer it from the neutral faces."}
+    "pullDirection": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Explicit pull/parting direction [dx,dy,dz] (only its orientation matters). Omit to let the host infer it from the neutral faces."},
+    "facesGeom": {"type": "array", "description": "Select the drafted faces by GEOMETRY instead of faceRefs, so the binding survives recompute. Give either this or faceRefs.", "items": {"type": "object", "properties": {"centroid": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Face centroid [x,y,z] cm."}, "normal": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Outward unit normal [x,y,z]."}}, "required": ["centroid", "normal"]}}
   },
-  "required": ["faceRefs", "angle"]
+  "required": ["angle"]
 }`
 
 func shellDescriptor() *OperationDescriptor {
@@ -427,14 +457,22 @@ func applyShell(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(in.FaceRefs) == 0 {
-		return nil, errors.New("shell: faceRefs is empty")
+	if len(in.FaceRefs) == 0 && len(in.FacesGeom) == 0 {
+		return nil, errors.New("shell: faceRefs is empty (give faceRefs or facesGeom)")
 	}
 	th, err := lengthClosure(part, in.Thickness, "shell: thickness")
 	if err != nil {
 		return nil, err
 	}
 	pf := feature.NewDressUpFeatures(part.Features()).AddShell(refKeys(in.FaceRefs), th)
+	if len(in.FacesGeom) > 0 {
+		// Bind the removed faces by geometry when authored geometrically (survives recompute).
+		refs, err := geomFaceRefs(in.FacesGeom)
+		if err != nil {
+			return nil, err
+		}
+		pf.Definition().(*feature.ShellFeature).Definition().GeomFaces = refs
+	}
 	return recomputeResult(part, pf)
 }
 
@@ -443,8 +481,8 @@ func applyDraft(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(in.FaceRefs) == 0 {
-		return nil, errors.New("draft: faceRefs is empty")
+	if len(in.FaceRefs) == 0 && len(in.FacesGeom) == 0 {
+		return nil, errors.New("draft: faceRefs is empty (give faceRefs or facesGeom)")
 	}
 	a, err := angleClosure(part, in.Angle, "draft: angle")
 	if err != nil {
@@ -453,6 +491,14 @@ func applyDraft(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	pf, err := buildDraft(part, in, a)
 	if err != nil {
 		return nil, err
+	}
+	if len(in.FacesGeom) > 0 {
+		// Bind the drafted faces by geometry when authored geometrically (survives recompute).
+		refs, err := geomFaceRefs(in.FacesGeom)
+		if err != nil {
+			return nil, err
+		}
+		pf.Definition().(*feature.FaceDraftFeature).Definition().GeomFaces = refs
 	}
 	return recomputeResult(part, pf)
 }

--- a/addin/opregistry/geom_selectors.go
+++ b/addin/opregistry/geom_selectors.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"oblikovati.org/api/wire/featureargs"
+	"oblikovati.org/kernel/topo"
+)
+
+// This file wires the wire-level geometric selectors (featureargs.GeomFaceSel / GeomEdgeSel) to
+// the kernel's geometric references (topo.GeometricFaceRef / GeometricEdgeRef). An external author
+// cannot mint lineage reference keys and a located key does not survive the feature's recompute, so
+// a hole/fillet/chamfer/shell/draft it authors selects its faces/edges by GEOMETRY; the feature
+// rebinds them to body topology every recompute (ADR-0040, model bindGeomFaces/bindGeomEdges).
+
+// geomFaceRef converts one wire face selector to a kernel geometric face reference.
+func geomFaceRef(sel featureargs.GeomFaceSel) (topo.GeometricFaceRef, error) {
+	centroid, err := point3(sel.Centroid, "geometric face: centroid")
+	if err != nil {
+		return topo.GeometricFaceRef{}, err
+	}
+	normal, err := vec3(sel.Normal, "geometric face: normal")
+	if err != nil {
+		return topo.GeometricFaceRef{}, err
+	}
+	return topo.GeometricFaceRef{Centroid: centroid, Normal: normal}, nil
+}
+
+// geomFaceRefs converts a list of wire face selectors to kernel geometric face references.
+func geomFaceRefs(sels []featureargs.GeomFaceSel) ([]topo.GeometricFaceRef, error) {
+	refs := make([]topo.GeometricFaceRef, len(sels))
+	for i, sel := range sels {
+		ref, err := geomFaceRef(sel)
+		if err != nil {
+			return nil, err
+		}
+		refs[i] = ref
+	}
+	return refs, nil
+}
+
+// geomEdgeRefs converts a list of wire edge selectors to kernel geometric edge references.
+func geomEdgeRefs(sels []featureargs.GeomEdgeSel) ([]topo.GeometricEdgeRef, error) {
+	refs := make([]topo.GeometricEdgeRef, len(sels))
+	for i, sel := range sels {
+		midpoint, err := point3(sel.Midpoint, "geometric edge: midpoint")
+		if err != nil {
+			return nil, err
+		}
+		direction, err := vec3(sel.Direction, "geometric edge: direction")
+		if err != nil {
+			return nil, err
+		}
+		refs[i] = topo.GeometricEdgeRef{Midpoint: midpoint, Direction: direction}
+	}
+	return refs, nil
+}

--- a/addin/opregistry/geom_selectors_test.go
+++ b/addin/opregistry/geom_selectors_test.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// These tests cover the geometric-selector path (placementFaceGeom / edgesGeom / facesGeom): an
+// external author selects a hole/dress-up's faces and edges by GEOMETRY (centroid+normal,
+// midpoint+direction) instead of a reference key it cannot mint, and the host binds them to the
+// body. Each geometric selection must build the SAME solid the equivalent reference-key selection
+// does, since both name the same topology.
+
+func xyz(p math.Point3) []float64   { return []float64{float64(p.X), float64(p.Y), float64(p.Z)} }
+func dxyz(v math.Vector3) []float64 { return []float64{float64(v.X), float64(v.Y), float64(v.Z)} }
+
+// topFaceOf returns the extruded box's uppermost face object (the natural hole placement face).
+func topFaceOf(t *testing.T, s *app.Session) *topo.Face {
+	t.Helper()
+	b := activePartBody(t, s)
+	var top *topo.Face
+	for _, f := range b.Faces() {
+		if top == nil || faceVertexMean(f).Z > faceVertexMean(top).Z {
+			top = f
+		}
+	}
+	if top == nil {
+		t.Fatal("box has no faces")
+	}
+	return top
+}
+
+// TestHoleGeomFaceMatchesFaceRef: drilling by placementFaceGeom removes the same material as
+// drilling by faceRef on the same top face — proof the geometric placement binds the right face
+// (the failure this whole path fixes was a lost key leaving the hole cutting nothing).
+func TestHoleGeomFaceMatchesFaceRef(t *testing.T) {
+	byRef, _, _ := extrudedSolid(t)
+	refKey, _ := boxTopFace(t, byRef)
+	if _, err := applyMap(t, byRef, "hole", map[string]any{"faceRef": refKey, "diameter": "3 mm", "depth": "5 mm"}); err != nil {
+		t.Fatalf("drill by faceRef: %v", err)
+	}
+
+	byGeom, _, _ := extrudedSolid(t)
+	g := topo.DescribeFace(topFaceOf(t, byGeom))
+	args := map[string]any{"diameter": "3 mm", "depth": "5 mm",
+		"placementFaceGeom": map[string]any{"centroid": xyz(g.Centroid), "normal": dxyz(g.Normal)}}
+	if _, err := applyMap(t, byGeom, "hole", args); err != nil {
+		t.Fatalf("drill by placementFaceGeom: %v", err)
+	}
+
+	if vr, vg := bodyVolume(t, byRef), bodyVolume(t, byGeom); stdmath.Abs(vr-vg) > 1e-6 {
+		t.Errorf("geom-face hole volume = %v, faceRef hole = %v, want equal", vg, vr)
+	}
+}
+
+// TestHoleNeedsFaceRefOrGeom: a hole with neither faceRef nor placementFaceGeom is a clean error.
+func TestHoleNeedsFaceRefOrGeom(t *testing.T) {
+	s, _, _ := extrudedSolid(t)
+	if _, err := applyMap(t, s, "hole", map[string]any{"diameter": "3 mm", "depth": "5 mm"}); err == nil {
+		t.Error("hole with neither faceRef nor placementFaceGeom should error")
+	}
+}
+
+// TestFilletGeomEdgesMatchesEdgeRefs: rounding an edge by edgesGeom removes the same material as
+// rounding it by edgeRefs (same edge, same radius).
+func TestFilletGeomEdgesMatchesEdgeRefs(t *testing.T) {
+	byRef, edgeKey, _ := extrudedSolid(t)
+	if _, err := applyMap(t, byRef, "fillet", map[string]any{"edgeRefs": []string{edgeKey}, "radius": "1 mm"}); err != nil {
+		t.Fatalf("fillet by edgeRefs: %v", err)
+	}
+
+	byGeom, _, _ := extrudedSolid(t)
+	g := topo.DescribeEdge(activePartBody(t, byGeom).Edges()[0])
+	args := map[string]any{"radius": "1 mm",
+		"edgesGeom": []any{map[string]any{"midpoint": xyz(g.Midpoint), "direction": dxyz(g.Direction)}}}
+	if _, err := applyMap(t, byGeom, "fillet", args); err != nil {
+		t.Fatalf("fillet by edgesGeom: %v", err)
+	}
+
+	if vr, vg := bodyVolume(t, byRef), bodyVolume(t, byGeom); stdmath.Abs(vr-vg) > 1e-6 {
+		t.Errorf("geom-edge fillet volume = %v, edgeRefs fillet = %v, want equal", vg, vr)
+	}
+}
+
+// TestChamferGeomEdgesMatchesEdgeRefs: bevelling an edge by edgesGeom matches edgeRefs.
+func TestChamferGeomEdgesMatchesEdgeRefs(t *testing.T) {
+	byRef, edgeKey, _ := extrudedSolid(t)
+	if _, err := applyMap(t, byRef, "chamfer", map[string]any{"edgeRefs": []string{edgeKey}, "distance": "1 mm"}); err != nil {
+		t.Fatalf("chamfer by edgeRefs: %v", err)
+	}
+
+	byGeom, _, _ := extrudedSolid(t)
+	g := topo.DescribeEdge(activePartBody(t, byGeom).Edges()[0])
+	args := map[string]any{"distance": "1 mm",
+		"edgesGeom": []any{map[string]any{"midpoint": xyz(g.Midpoint), "direction": dxyz(g.Direction)}}}
+	if _, err := applyMap(t, byGeom, "chamfer", args); err != nil {
+		t.Fatalf("chamfer by edgesGeom: %v", err)
+	}
+
+	if vr, vg := bodyVolume(t, byRef), bodyVolume(t, byGeom); stdmath.Abs(vr-vg) > 1e-6 {
+		t.Errorf("geom-edge chamfer volume = %v, edgeRefs chamfer = %v, want equal", vg, vr)
+	}
+}
+
+// TestShellGeomFacesMatchesFaceRefs: hollowing while removing a face by facesGeom matches faceRefs.
+func TestShellGeomFacesMatchesFaceRefs(t *testing.T) {
+	byRef, _, faceKey := extrudedSolid(t)
+	if _, err := applyMap(t, byRef, "shell", map[string]any{"faceRefs": []string{faceKey}, "thickness": "1 mm"}); err != nil {
+		t.Fatalf("shell by faceRefs: %v", err)
+	}
+
+	byGeom, _, _ := extrudedSolid(t)
+	g := topo.DescribeFace(activePartBody(t, byGeom).Faces()[0])
+	args := map[string]any{"thickness": "1 mm",
+		"facesGeom": []any{map[string]any{"centroid": xyz(g.Centroid), "normal": dxyz(g.Normal)}}}
+	if _, err := applyMap(t, byGeom, "shell", args); err != nil {
+		t.Fatalf("shell by facesGeom: %v", err)
+	}
+
+	if vr, vg := bodyVolume(t, byRef), bodyVolume(t, byGeom); stdmath.Abs(vr-vg) > 1e-6 {
+		t.Errorf("geom-face shell volume = %v, faceRefs shell = %v, want equal", vg, vr)
+	}
+}
+
+// TestDraftGeomFacesMatchesFaceRefs: drafting a face by facesGeom matches faceRefs.
+func TestDraftGeomFacesMatchesFaceRefs(t *testing.T) {
+	byRef, _, faceKey := extrudedSolid(t)
+	if _, err := applyMap(t, byRef, "draft", map[string]any{"faceRefs": []string{faceKey}, "angle": "3 deg"}); err != nil {
+		t.Fatalf("draft by faceRefs: %v", err)
+	}
+
+	byGeom, _, _ := extrudedSolid(t)
+	g := topo.DescribeFace(activePartBody(t, byGeom).Faces()[0])
+	args := map[string]any{"angle": "3 deg",
+		"facesGeom": []any{map[string]any{"centroid": xyz(g.Centroid), "normal": dxyz(g.Normal)}}}
+	if _, err := applyMap(t, byGeom, "draft", args); err != nil {
+		t.Fatalf("draft by facesGeom: %v", err)
+	}
+
+	if vr, vg := bodyVolume(t, byRef), bodyVolume(t, byGeom); stdmath.Abs(vr-vg) > 1e-6 {
+		t.Errorf("geom-face draft volume = %v, faceRefs draft = %v, want equal", vg, vr)
+	}
+}
+
+// TestGeomSelectorBadVectorErrors: a geometric selector whose centroid/normal/midpoint is not a
+// 3-vector is a clean error, not a panic (covers the conversion error paths).
+func TestGeomSelectorBadVectorErrors(t *testing.T) {
+	s, _, _ := extrudedSolid(t)
+	badFace := map[string]any{"diameter": "3 mm", "depth": "5 mm",
+		"placementFaceGeom": map[string]any{"centroid": []float64{1, 2}, "normal": []float64{0, 0, 1}}}
+	if _, err := applyMap(t, s, "hole", badFace); err == nil {
+		t.Error("placementFaceGeom with a 2-vector centroid should error")
+	}
+
+	s2, _, _ := extrudedSolid(t)
+	badEdge := map[string]any{"radius": "1 mm",
+		"edgesGeom": []any{map[string]any{"midpoint": []float64{1, 2, 3}, "direction": []float64{0, 1}}}}
+	if _, err := applyMap(t, s2, "fillet", badEdge); err == nil {
+		t.Error("edgesGeom with a 2-vector direction should error")
+	}
+}

--- a/addin/opregistry/hole.go
+++ b/addin/opregistry/hole.go
@@ -31,9 +31,10 @@ const holeSchema = `{
     "includedAngle": {"type": "string", "description": "Countersink included angle, e.g. \"90 deg\" (type=countersink)."},
     "designation": {"type": "string", "description": "Thread designation, e.g. \"M5x0.8\" (type=tapped)."},
     "center": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Explicit drill point [x,y,z] in model-space cm (projected onto the picked face). Omit to drill at the face centroid. Needed to place more than one hole on a face."},
-    "centerExpr": {"type": "array", "items": {"type": "string"}, "minItems": 3, "maxItems": 3, "description": "Parameter-expression form of center: [x,y,z] each an expression with units (e.g. \"L/2\"). Overrides center when present."}
+    "centerExpr": {"type": "array", "items": {"type": "string"}, "minItems": 3, "maxItems": 3, "description": "Parameter-expression form of center: [x,y,z] each an expression with units (e.g. \"L/2\"). Overrides center when present."},
+    "placementFaceGeom": {"type": "object", "description": "Select the placement face by GEOMETRY instead of faceRef, so the binding survives recompute (for an external author that cannot mint a stable key). Give either this or faceRef.", "properties": {"centroid": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Face centroid [x,y,z] cm."}, "normal": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Outward unit normal [x,y,z]."}}, "required": ["centroid", "normal"]}
   },
-  "required": ["faceRef", "diameter"]
+  "required": ["diameter"]
 }`
 
 func holeDescriptor() *OperationDescriptor {
@@ -45,8 +46,8 @@ func applyHole(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	if in.FaceRef == "" {
-		return nil, errors.New("hole: faceRef is empty")
+	if in.FaceRef == "" && in.PlacementFaceGeom == nil {
+		return nil, errors.New("hole: needs faceRef or placementFaceGeom")
 	}
 	dia, err := lengthClosure(part, in.Diameter, "hole: diameter")
 	if err != nil {
@@ -59,7 +60,25 @@ func applyHole(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err := applyHoleCenter(part, pf, in); err != nil {
 		return nil, err
 	}
+	if err := applyHolePlacementGeom(pf, in); err != nil {
+		return nil, err
+	}
 	return recomputeResult(part, pf)
+}
+
+// applyHolePlacementGeom binds the hole's placement face by GEOMETRY (centroid + normal) when
+// PlacementFaceGeom is given, so an external author's face selection survives recompute — the
+// hole re-resolves it against the running body each time (see resolveHoleFace / GeomFace).
+func applyHolePlacementGeom(pf *feature.PartFeature, in featureargs.Hole) error {
+	if in.PlacementFaceGeom == nil {
+		return nil
+	}
+	ref, err := geomFaceRef(*in.PlacementFaceGeom)
+	if err != nil {
+		return err
+	}
+	pf.Definition().(*feature.HoleFeature).Definition().GeomFace = &ref
+	return nil
 }
 
 // applyHoleCenter sets the hole's explicit drill center from the args (centerExpr wins over the

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.108.0
+	oblikovati.org/api v0.109.0
 )
 
 require (

--- a/head/cmd/oblikovati-addinhost/main.go
+++ b/head/cmd/oblikovati-addinhost/main.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -38,10 +39,26 @@ import (
 	"oblikovati.org/persistence"
 )
 
-// hostCallTimeout caps how long an add-in's host call waits to be drained. The drain
-// loop runs every drainInterval, so normal latency is sub-millisecond; the timeout only
-// guards a stalled loop.
-const hostCallTimeout = 10 * time.Second
+// defaultHostCallTimeout caps how long an add-in's host call waits to be drained. The
+// drain loop runs every drainInterval, so normal latency is sub-millisecond; the timeout
+// only guards a stalled loop. Batch/automation runs that recompute heavy features (a
+// boolean on a large body) can exceed it, so OBK_HOST_CALL_TIMEOUT overrides it (seconds).
+const defaultHostCallTimeout = 10 * time.Second
+
+// hostCallTimeout is defaultHostCallTimeout unless OBK_HOST_CALL_TIMEOUT (a positive number
+// of seconds) overrides it; a malformed or non-positive value keeps the default.
+func hostCallTimeout() time.Duration {
+	raw := os.Getenv("OBK_HOST_CALL_TIMEOUT")
+	if raw == "" {
+		return defaultHostCallTimeout
+	}
+	secs, err := strconv.ParseFloat(raw, 64)
+	if err != nil || secs <= 0 {
+		fmt.Fprintf(os.Stderr, "oblikovati-addinhost: ignoring invalid OBK_HOST_CALL_TIMEOUT %q; using %s\n", raw, defaultHostCallTimeout)
+		return defaultHostCallTimeout
+	}
+	return time.Duration(secs * float64(time.Second))
+}
 
 // drainInterval is how often the session goroutine services queued add-in calls. A few
 // milliseconds keeps MCP round-trips snappy without busy-spinning the CPU.
@@ -92,7 +109,7 @@ func newRouterHandler(session *app.Session) addinhost.Handler {
 // host call serializes onto the dispatcher the drain loop services. Call once before
 // activating any add-in.
 func installHost(session *app.Session, d *dispatch.Dispatcher) {
-	addinhost.SetHost(d, newRouterHandler(session), hostCallTimeout)
+	addinhost.SetHost(d, newRouterHandler(session), hostCallTimeout())
 }
 
 // startAddIns loads, registers, and activates every add-in in dir, reporting load

--- a/head/cmd/oblikovati-addinhost/main_test.go
+++ b/head/cmd/oblikovati-addinhost/main_test.go
@@ -139,6 +139,33 @@ func TestAddInsDirDefaultsBesideExe(t *testing.T) {
 	}
 }
 
+// TestHostCallTimeoutDefault: with OBK_HOST_CALL_TIMEOUT unset, the default applies.
+func TestHostCallTimeoutDefault(t *testing.T) {
+	t.Setenv("OBK_HOST_CALL_TIMEOUT", "")
+	if got := hostCallTimeout(); got != defaultHostCallTimeout {
+		t.Errorf("hostCallTimeout() = %v, want the default %v", got, defaultHostCallTimeout)
+	}
+}
+
+// TestHostCallTimeoutOverride: a positive OBK_HOST_CALL_TIMEOUT (seconds) overrides the default —
+// batch runs that recompute heavy features need a longer window than the 10s default.
+func TestHostCallTimeoutOverride(t *testing.T) {
+	t.Setenv("OBK_HOST_CALL_TIMEOUT", "120")
+	if got := hostCallTimeout(); got != 120*time.Second {
+		t.Errorf("hostCallTimeout() = %v, want 120s", got)
+	}
+}
+
+// TestHostCallTimeoutInvalidKeepsDefault: a malformed or non-positive value is ignored (default).
+func TestHostCallTimeoutInvalidKeepsDefault(t *testing.T) {
+	for _, bad := range []string{"nope", "0", "-5"} {
+		t.Setenv("OBK_HOST_CALL_TIMEOUT", bad)
+		if got := hostCallTimeout(); got != defaultHostCallTimeout {
+			t.Errorf("hostCallTimeout() with %q = %v, want the default %v", bad, got, defaultHostCallTimeout)
+		}
+	}
+}
+
 // TestStartAddInsActivatesFixture is the end-to-end proof without the real bridge: it
 // loads the echo c-shared fixture, and startAddIns registers + activates it, round-tripping
 // the fixture's Activate host call through the dispatcher (drained concurrently, since

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.108.0
+	oblikovati.org/api v0.109.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)


### PR DESCRIPTION
## Why

The Inventor exporter drives the live model over the MCP bridge. It cannot mint the host's lineage reference keys, and a key it obtains from `body_locate_using_point` at author time **does not survive the feature's own recompute** — the base solid re-mints lineage, so a `faceRef`/`edgeRefs` key goes stale and the feature silently binds nothing: a hole that removes no material (`"placement face reference lost"`), a fillet that rounds no edge. Observed live across the ReelToReel corpus (e.g. CapstonMotorMachinedHolder: all four holes reported unhealthy, +152% over the Inventor oracle).

The model already binds by **geometry** every recompute (ADR-0040: `HoleDefinition.GeomFace`, dress-up `GeomEdges`/`GeomFaces`, resolved by `bindGeomEdges`/`bindGeomFaces`), and the `InventorEdgeDescriptor` design note says exactly this: *"an external author cannot mint Oblikovati lineage keys, so it ships geometry."* But no wire arg or router path exposed the geometric binding. [api#235](https://github.com/Oblikovati/Oblikovati.API/pull/235) added the wire selectors (released as **v0.109.0**); this wires them into the host.

## What

- **hole**: `placementFaceGeom` → `HoleDefinition.GeomFace`; `faceRef` now optional
- **fillet / chamfer**: `edgesGeom` → `{Fillet,Chamfer}Definition.GeomEdges`; `edgeRefs` optional
- **shell / draft**: `facesGeom` → `{Shell,FaceDraft}Definition.GeomFaces`; `faceRefs` optional
- `geom_selectors.go` maps wire `GeomFaceSel`/`GeomEdgeSel` → kernel `topo.GeometricFaceRef`/`GeometricEdgeRef`
- schemas document the new geom fields and drop the key field from each `required` list (geometry is the alternative)
- go.mod / head/go.mod pinned to `oblikovati.org/api v0.109.0`

No kernel/model change — the binding machinery already existed; this exposes it.

### Tests
`geom_selectors_test.go`: for hole, fillet, chamfer, shell, and draft, a geometric selection builds the **same solid** (equal volume) its reference-key form does; plus the "neither ref nor geom" and bad-vector error paths. Parity guards + archguard green.

Also makes the headless add-in host's host-call timeout configurable via `OBK_HOST_CALL_TIMEOUT` (seconds; default 10s) so a batch exporter run that recomputes heavy features isn't cut off at 10s (covered by `main_test.go`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)