### PR TITLE
feat: honor visible flag on workPlanes.create

### DIFF
--- a/addin/router/work_planes.go
+++ b/addin/router/work_planes.go
@@ -70,6 +70,7 @@ func workPlaneInfo(host workHost, wp *feature.WorkPlane, index int) wire.WorkPla
 		Origin:   point3Slice(wp.Plane().Origin()),
 		Normal:   vector3Slice(wp.Plane().Normal().AsVector()),
 		IsOrigin: wp.IsCoordinateSystemElement(),
+		Visible:  wp.Visible(),
 		Healthy:  wp.Health().OK(),
 		Reason:   wp.Health().Reason, // empty when healthy
 		Kind:     wp.Kind(),
@@ -185,6 +186,9 @@ func createWorkPlanes(_ *app.Session, host workHost, in wire.CreateWorkPlaneArgs
 	wp, err := buildWorkPlane(host, in)
 	if err != nil {
 		return wire.CreateWorkPlaneResult{}, err
+	}
+	if in.Visible != nil {
+		wp.SetVisible(*in.Visible) // an add-in can create a construction datum hidden (issue: PartDesigner)
 	}
 	host.Recompute()
 	return wire.CreateWorkPlaneResult{

--- a/addin/router/work_planes_test.go
+++ b/addin/router/work_planes_test.go
@@ -53,6 +53,27 @@ func TestWorkPlanesCreateOffsetThenList(t *testing.T) {
 	assertOffsetPlaneOnXY(t, r, s)
 }
 
+// TestWorkPlanesCreateHiddenPlane checks that a create request with visible:false lands a hidden
+// datum (list reports Visible=false) while an otherwise-identical default create stays visible —
+// the seam an add-in uses to keep construction datums out of a placed part.
+func TestWorkPlanesCreateHiddenPlane(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var hidden, shown wire.CreateWorkPlaneResult
+	call(t, r, s, "workPlanes.create",
+		`{"kind":"plane-offset","refs":["origin/plane/xy"],"offset":"5 mm","visible":false}`, &hidden)
+	call(t, r, s, "workPlanes.create",
+		`{"kind":"plane-offset","refs":["origin/plane/xy"],"offset":"9 mm"}`, &shown)
+
+	var list wire.ListWorkPlanesResult
+	call(t, r, s, "workPlanes.list", "{}", &list)
+	if list.Planes[hidden.Index].Visible {
+		t.Errorf("plane created with visible:false is Visible=true; want it hidden")
+	}
+	if !list.Planes[shown.Index].Visible {
+		t.Errorf("plane created without a visible flag is hidden; want the default (visible)")
+	}
+}
+
 func TestWorkPlanesCreateMidplane(t *testing.T) {
 	r, s := emptyPartSession(t)
 	var res wire.CreateWorkPlaneResult

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.110.0
+	oblikovati.org/api v0.111.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.110.0
+	oblikovati.org/api v0.111.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)


### PR DESCRIPTION
## What
Implements the host side of the api's new `workPlanes.create` visibility flag (Oblikovati.API v0.111.0):
- when a create request sets `visible`, apply it via the plane's `SetVisible`;
- report each plane's current visibility on `WorkPlaneInfo`, so `workPlanes.list` round-trips it.

## Why
An add-in that offsets a work plane only to sketch on it (e.g. `Oblikovati.AddIns.PartDesigner` building a socket-head cap screw's shank from the head-underside plane) can now create that construction datum hidden, keeping the placed standard part free of datum-plane clutter. The per-plane `SetVisible` already existed in the model; this wires it to the wire surface. Pairs with Oblikovati.API#237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)