### PR TITLE
feat(thread): partial-length cosmetic & cut threads (offset/length)

### DIFF
--- a/addin/opregistry/feature_extras.go
+++ b/addin/opregistry/feature_extras.go
@@ -58,7 +58,9 @@ const threadSchema = `{
     "cut": {"type": "boolean", "default": false, "description": "false = cosmetic thread (display only); true = model a real cut thread (the face becomes a threaded surface)."},
     "class": {"type": "string", "description": "Tolerance class recorded on the spec, e.g. \"6H\" (enumerable via threads.tableQuery)."},
     "tapered": {"type": "boolean", "default": false, "description": "Pipe-thread (tapered) data; a cut tapered thread is rejected — model it cosmetic."},
-    "modelDiameter": {"type": "string", "enum": ["major", "minor", "pitch", "tapDrill"], "description": "Which thread diameter the modeled face represents (default major)."}
+    "modelDiameter": {"type": "string", "enum": ["major", "minor", "pitch", "tapDrill"], "description": "Which thread diameter the modeled face represents (default major)."},
+    "length": {"type": "string", "description": "Threaded run along the axis (distance expression) from the face's start edge + offset; empty = full length (Inventor FullDepth)."},
+    "offset": {"type": "string", "description": "Distance expression from the face's start edge to where the thread begins; empty = 0. Thread the two ends of a stud with two features on one face."}
   },
   "required": ["faceRef", "designation"]
 }`
@@ -82,9 +84,18 @@ func applyThread(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 			return nil, fmt.Errorf("thread: unknown modelDiameter %q (want major/minor/pitch/tapDrill)", in.ModelDiameter)
 		}
 	}
+	offset, err := optionalLengthClosure(part, in.Offset, "thread: offset")
+	if err != nil {
+		return nil, err
+	}
+	length, err := optionalLengthClosure(part, in.Length, "thread: length")
+	if err != nil {
+		return nil, err
+	}
 	pf := feature.NewDressUpFeatures(part.Features()).AddThreadDef(&feature.ThreadDefinition{
 		FaceKey: []byte(in.FaceRef), Designation: in.Designation, Cut: in.Cut,
 		Class: in.Class, Tapered: in.Tapered, ModelDiameter: md,
+		Offset: offset, Length: length,
 	})
 	return recomputeResult(part, pf)
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.111.0
+	oblikovati.org/api v0.113.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.111.0
+	oblikovati.org/api v0.113.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/feature/dressup.go
+++ b/model/feature/dressup.go
@@ -232,6 +232,12 @@ type ThreadDefinition struct {
 	Class         string
 	Tapered       bool
 	ModelDiameter types.ModelDiameterFromThread
+	// Offset and Length limit the thread to a sub-span of the face along its axis (Inventor's
+	// ThreadOffset / ThreadDepth): the thread runs from the face's min axial extent + Offset for
+	// Length (cm). A nil Offset ⇒ 0; a nil or zero Length ⇒ the full face (Inventor's FullDepth).
+	// A double-ended stud threads only its two ends by giving each thread its own Offset+Length.
+	Offset func() float64
+	Length func() float64
 	// FaceAnchors maps FaceKey to its mint-time centroid for the geometric recovery tier
 	// (ADR-0043 P6 / #1579); see FilletDefinition.EdgeAnchors.
 	FaceAnchors map[string]math.Point3
@@ -280,14 +286,16 @@ func (t *ThreadFeature) Recompute(in Input) (Output, error) {
 	if !ok {
 		return Output{}, fmt.Errorf("thread %q: face is not cylindrical (%T)", t.def.Designation, face.Geometry())
 	}
-	vMin, vMax := axialExtent(face.RangeBox(), cyl)
+	vFaceMin, vFaceMax := axialExtent(face.RangeBox(), cyl)
+	vMin, vMax := resolveThreadSpan(vFaceMin, vFaceMax, t.def.Offset, t.def.Length)
 	spec.Internal = bodyHasMaterialOutside(body, cyl, (vMin+vMax)/2, (spec.MajorDiameter-spec.MinorDiameter)/2/10)
 	t.spec = &spec
 	if !t.def.Cut {
 		return Output{Bodies: in.Bodies, Heals: faceHeal(t.def.FaceKey, mt)}, nil // cosmetic: solid unchanged
 	}
 	// Modeled (cut) thread: retype the cylindrical face to a threaded surface — O(1), no
-	// boolean — so it tessellates and measures as real threaded geometry.
+	// boolean — so it tessellates and measures as real threaded geometry. The span honours the
+	// thread's offset/length so a partial cut thread grooves only its run.
 	threaded := geom.ThreadedCylinder{
 		Cylinder: cyl, Pitch: spec.Pitch / 10, Depth: (spec.MajorDiameter - spec.MinorDiameter) / 2 / 10,
 		Internal: spec.Internal, RightHanded: spec.RightHanded, VMin: vMin, VMax: vMax,

--- a/model/feature/serialize_codecs_solid.go
+++ b/model/feature/serialize_codecs_solid.go
@@ -159,6 +159,7 @@ func (r featureCodecSet) registerSolidCodecs() {
 			t := f.(*ThreadFeature)
 			fd.Thread = &ThreadData{Face: encodeKey(t.def.FaceKey), Designation: t.def.Designation, Cut: t.def.Cut,
 				Class: t.def.Class, Tapered: t.def.Tapered, ModelDiameter: threadModelDiameterName(t.def.ModelDiameter),
+				Offset: evalFloat(t.def.Offset), Length: evalFloat(t.def.Length),
 				FaceAnchors: encodeFaceAnchors(t.def.FaceAnchors)}
 			return nil
 		},
@@ -248,7 +249,8 @@ func decodeThread(rc *restoreContext, fd FeatureData) (*PartFeature, error) {
 		return nil, err
 	}
 	return NewDressUpFeatures(rc.fs).addThreadDef(&ThreadDefinition{FaceKey: key, Designation: fd.Thread.Designation,
-		Cut: fd.Thread.Cut, Class: fd.Thread.Class, Tapered: fd.Thread.Tapered, ModelDiameter: md, FaceAnchors: anchors}), nil
+		Cut: fd.Thread.Cut, Class: fd.Thread.Class, Tapered: fd.Thread.Tapered, ModelDiameter: md,
+		Offset: constFloat(fd.Thread.Offset), Length: constFloat(fd.Thread.Length), FaceAnchors: anchors}), nil
 }
 
 // decodeSnapFit rebuilds a cantilever snap-fit from its persisted dimensions.

--- a/model/feature/serialize_dressup.go
+++ b/model/feature/serialize_dressup.go
@@ -269,13 +269,17 @@ type SnapFitData struct {
 // the #325 parity fields: the tolerance class, the tapered (pipe) flag, and which thread
 // diameter the modeled face represents (wire spelling; absent = major).
 type ThreadData struct {
-	Face          string           `yaml:"face"`
-	Designation   string           `yaml:"designation"`
-	Cut           bool             `yaml:"cut,omitempty"`
-	Class         string           `yaml:"class,omitempty"`
-	Tapered       bool             `yaml:"tapered,omitempty"`
-	ModelDiameter string           `yaml:"modelDiameter,omitempty"`
-	FaceAnchors   []FaceAnchorData `yaml:"faceAnchors,omitempty"`
+	Face          string `yaml:"face"`
+	Designation   string `yaml:"designation"`
+	Cut           bool   `yaml:"cut,omitempty"`
+	Class         string `yaml:"class,omitempty"`
+	Tapered       bool   `yaml:"tapered,omitempty"`
+	ModelDiameter string `yaml:"modelDiameter,omitempty"`
+	// Offset and Length are the thread's axial window on the face (cm), resolved at save time
+	// (Inventor ThreadOffset / ThreadDepth). Absent/0 length ⇒ the thread runs the full face.
+	Offset      float64          `yaml:"offset,omitempty"`
+	Length      float64          `yaml:"length,omitempty"`
+	FaceAnchors []FaceAnchorData `yaml:"faceAnchors,omitempty"`
 }
 
 // dressInputs is the decoded (keys, value) pair shared by edge/face dress-ups, plus any

--- a/model/feature/thread_display.go
+++ b/model/feature/thread_display.go
@@ -28,7 +28,7 @@ func ThreadDisplayCurves(fs *PartFeatures) [][]math.Point3 {
 			if !ok {
 				continue
 			}
-			if h := threadHelix(f, tf.spec); len(h) > 1 {
+			if h := threadHelix(f, tf.spec, tf.def); len(h) > 1 {
 				out = append(out, h)
 			}
 			break
@@ -37,15 +37,17 @@ func ThreadDisplayCurves(fs *PartFeatures) [][]math.Point3 {
 	return out
 }
 
-// threadHelix samples a helix on the face's cylinder over the face's axial extent, spiralling
+// threadHelix samples a helix on the face's cylinder over the thread's axial span, spiralling
 // once per thread pitch (left-handed reverses the spin). The line sits on the surface so it
-// reads as the thread groove.
-func threadHelix(face *topo.Face, spec *ThreadSpec) []math.Point3 {
+// reads as the thread groove. The span is the def's offset/length window clamped to the face
+// (full face when unset), so a double-ended stud's end threads draw only over their runs.
+func threadHelix(face *topo.Face, spec *ThreadSpec, def *ThreadDefinition) []math.Point3 {
 	cyl, ok := face.Geometry().(geom.Cylinder)
 	if !ok {
 		return nil
 	}
-	vMin, vMax := axialExtent(face.RangeBox(), cyl)
+	vFaceMin, vFaceMax := axialExtent(face.RangeBox(), cyl)
+	vMin, vMax := resolveThreadSpan(vFaceMin, vFaceMax, def.Offset, def.Length)
 	length := vMax - vMin
 	pitch := spec.Pitch / 10 // designation pitch is mm; the model is cm
 	if pitch <= 0 || length <= 0 {
@@ -63,6 +65,38 @@ func threadHelix(face *topo.Face, spec *ThreadSpec) []math.Point3 {
 		pts[i] = cyl.PointAt(sign*t*turns*2*stdmath.Pi, vMin+t*length)
 	}
 	return pts
+}
+
+// resolveThreadSpan clamps a thread's [offset, offset+length] window to the face's axial extent
+// [vFaceMin, vFaceMax]. offset is measured from vFaceMin; a nil offset ⇒ 0. A nil or non-positive
+// length (Inventor's FullDepth) runs to vFaceMax. The result is always ordered and within the
+// face, so a bad offset/length degrades to a shorter thread rather than an inverted or overhanging
+// one.
+func resolveThreadSpan(vFaceMin, vFaceMax float64, offset, length func() float64) (float64, float64) {
+	start := vFaceMin
+	if offset != nil {
+		start = vFaceMin + offset()
+	}
+	start = clampAxial(start, vFaceMin, vFaceMax)
+	end := vFaceMax
+	if length != nil {
+		if l := length(); l > 0 {
+			end = start + l
+		}
+	}
+	end = clampAxial(end, start, vFaceMax)
+	return start, end
+}
+
+// clampAxial bounds v to [lo, hi].
+func clampAxial(v, lo, hi float64) float64 {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
 }
 
 // axialExtent projects a face's range-box corners onto the cylinder axis to bound the threaded

--- a/model/feature/thread_test.go
+++ b/model/feature/thread_test.go
@@ -127,6 +127,32 @@ func TestThreadDisplayHelixOnSurface(t *testing.T) {
 	}
 }
 
+// TestThreadDisplayPartialSpan checks a cosmetic thread limited by Offset/Length draws its helix
+// only over that axial window (Inventor's ThreadOffset/ThreadDepth) — the double-ended-stud case,
+// where the two end threads must not spill into the plain middle.
+func TestThreadDisplayPartialSpan(t *testing.T) {
+	cyl, _ := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 0.4, 3.0)
+	fs := NewPartFeatures(nil)
+	NewBaseFeatures(fs).AddBase(cyl)
+	NewDressUpFeatures(fs).AddThreadDef(&ThreadDefinition{
+		FaceKey:     cylinderFaceKey(t, cyl),
+		Designation: "M8x1.25",
+		Offset:      constFloat(2.0), // start 2 cm up the 3 cm cylinder
+		Length:      constFloat(0.5), // run 0.5 cm — the nut-end band
+	})
+	fs.Recompute()
+
+	curves := ThreadDisplayCurves(fs)
+	if len(curves) != 1 {
+		t.Fatalf("got %d thread display curves, want 1", len(curves))
+	}
+	for _, p := range curves[0] {
+		if z := float64(p.Z); z < 2.0-1e-6 || z > 2.5+1e-6 {
+			t.Errorf("helix point outside the [2.0,2.5] thread span: z=%.5f", z)
+		}
+	}
+}
+
 // TestThreadCutModelsRealThreadFast checks the modeled (cut) thread retypes the face to a
 // threaded surface in O(1) — microseconds, no boolean — giving a valid solid whose volume
 // drops (the grooves are real geometry).


### PR DESCRIPTION
## What

Implements the host side of **partial-length threads** for the new `api` `Thread.Offset` / `Thread.Length` fields (Apache-2.0 side merged as Oblikovati.API v0.113.0). A thread now runs from the face's min axial extent **+ Offset** for **Length** (clamped to the face); empty/zero length keeps the **full-length** default, so every existing thread is unchanged.

- `ThreadDefinition` carries `Offset`/`Length` value closures (mirroring `Extent.Distance`), so the span re-drives with its driving parameters.
- `resolveThreadSpan` bounds the `[offset, offset+length]` window to the face; `threadHelix` draws the cosmetic display helix over it, and the cut-thread `ThreadedCylinder` grooves only its run.
- The resolved span persists on `ThreadData` via `evalFloat`/`constFloat`, exactly like every other feature distance, so it round-trips.

Pins `api v0.113.0` (resolved via the go.work replace / CI sibling checkout).

## Why

Oblikovati's cosmetic thread could only thread a whole face — a gap vs the Inventor API (`ThreadFeatures.Add` has `FullDepth`/`ThreadDepth`/`ThreadOffset`). The first consumer is the PartDesigner Content Center **double-ended stud** (DIN 939): one analytic-cylinder rod threaded only at its two ends (`b1` metal end, `b2` nut end), plain shank between. Building it as joined coaxial segments is not viable — a boolean union of coaxial same-radius cylinders re-facets them and destroys the analytic face a thread binds to (separate kernel issue).

## Verification

- `go test ./model/feature/ ./addin/opregistry/` green; new `TestThreadDisplayPartialSpan` asserts a thread limited to `[2.0, 2.5]` draws its helix only over that window. Existing full-length thread tests unchanged (back-compat).
- `golangci-lint` clean on the touched packages; SPDX clean.
- Live-verified over the MCP bridge with the PartDesigner add-in: the DIN 939 stud renders `[extrude, thread, thread]` with thread only at the two ends and a bare middle; the DIN 976 rod stays a full-length `[extrude, thread]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)