### PR TITLE
topo: bind a geometric face reference sign-agnostically and by containment

### DIFF
--- a/addin/opregistry/geom_selectors_test.go
+++ b/addin/opregistry/geom_selectors_test.go
@@ -59,6 +59,31 @@ func TestHoleGeomFaceMatchesFaceRef(t *testing.T) {
 	}
 }
 
+// TestHoleGeomFaceFlippedNormalStillBinds: an external author may record the placement face's
+// outward normal with the opposite sign convention (observed: Inventor vs Oblikovati disagree on
+// a revolve end face). The face identity does not depend on the normal sign, so a flipped-normal
+// descriptor must still bind the same face and remove the same material. Also uses an explicit
+// center so the drill point lies on the face.
+func TestHoleGeomFaceFlippedNormalStillBinds(t *testing.T) {
+	byRef, _, _ := extrudedSolid(t)
+	refKey, _ := boxTopFace(t, byRef)
+	if _, err := applyMap(t, byRef, "hole", map[string]any{"faceRef": refKey, "diameter": "3 mm", "depth": "5 mm", "center": []float64{2, 1.5, 1}}); err != nil {
+		t.Fatalf("drill by faceRef: %v", err)
+	}
+
+	byGeom, _, _ := extrudedSolid(t)
+	g := topo.DescribeFace(topFaceOf(t, byGeom))
+	flipped := []float64{-g.Normal.X, -g.Normal.Y, -g.Normal.Z}
+	args := map[string]any{"diameter": "3 mm", "depth": "5 mm", "center": []float64{2, 1.5, 1},
+		"placementFaceGeom": map[string]any{"centroid": xyz(g.Centroid), "normal": flipped}}
+	if _, err := applyMap(t, byGeom, "hole", args); err != nil {
+		t.Fatalf("drill by placementFaceGeom (flipped normal): %v", err)
+	}
+	if vr, vg := bodyVolume(t, byRef), bodyVolume(t, byGeom); stdmath.Abs(vr-vg) > 1e-6 {
+		t.Errorf("flipped-normal geom-face hole volume = %v, faceRef = %v, want equal", vg, vr)
+	}
+}
+
 // TestHoleNeedsFaceRefOrGeom: a hole with neither faceRef nor placementFaceGeom is a clean error.
 func TestHoleNeedsFaceRefOrGeom(t *testing.T) {
 	s, _, _ := extrudedSolid(t)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.111.0
+	oblikovati.org/api v0.113.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.111.0
+	oblikovati.org/api v0.113.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/kernel/topo/geometric_ref.go
+++ b/kernel/topo/geometric_ref.go
@@ -20,9 +20,13 @@ import (
 // identity); it only recovers a selection at recompute, and the caller maps a hit to
 // health.Warning (auto-healed, flagged), exactly like the M31 fallback tiers.
 
-// normalAlignMin is the minimum dot product (unit normals) for a candidate face's outward
-// normal to count as aligned with the descriptor's — ~25°, enough to reject the opposite
-// face of a thin feature while tolerating tessellation/curvature drift.
+// normalAlignMin is the minimum |dot product| (unit normals) for a candidate face's outward
+// normal to count as aligned with the descriptor's — ~25°, tolerating tessellation/curvature
+// drift. The match is on the normal AXIS, not its sign: an external author (e.g. an exporter)
+// can record a face's outward normal with the opposite sign convention, and a planar face's
+// identity does not depend on which way its normal is named. The opposite face of a thin
+// feature is still rejected by the point-on-plane / centroid-distance tests (its plane is a
+// thickness away), and FindPlanarFaceThrough only binds when a single candidate remains.
 const normalAlignMin = 0.9
 
 // GeometricFaceRef names a face by where it sits, not by lineage: a representative point
@@ -66,7 +70,7 @@ func (b *Body) FindFaceByGeometry(ref GeometricFaceRef, tol math.Scalar) (*Face,
 		if d > tol {
 			continue
 		}
-		if want.LengthSquared() > 0 && faceOutwardNormal(f, c).Dot(want) < normalAlignMin {
+		if want.LengthSquared() > 0 && stdmath.Abs(float64(faceOutwardNormal(f, c).Dot(want))) < normalAlignMin {
 			continue
 		}
 		best, bestD, second, secondD = rank(f, d, best, bestD, second, secondD)
@@ -83,29 +87,40 @@ func (b *Body) FindFaceByGeometry(ref GeometricFaceRef, tol math.Scalar) (*Face,
 // whereas the drill centre and the face plane are.
 func (b *Body) FindPlanarFaceThrough(p math.Point3, want math.Vector3, tol math.Scalar) (*Face, bool) {
 	wn := unitOrZero(want)
+	var planeCands []*Face
+	var containing []*Face
 	var best *Face
-	var candidates int
 	bestD := stdmath.Inf(1)
 	for _, f := range b.Faces() {
 		c := faceCentroid(f)
 		n := faceOutwardNormal(f, c)
-		if wn.LengthSquared() > 0 && n.Dot(wn) < normalAlignMin {
+		if wn.LengthSquared() > 0 && stdmath.Abs(float64(n.Dot(wn))) < normalAlignMin {
 			continue
 		}
 		if stdmath.Abs(c.VectorTo(p).Dot(n)) > tol { // perpendicular distance from p to the face plane
 			continue
 		}
-		candidates++
+		planeCands = append(planeCands, f)
+		if NewFaceEvaluator(f).Contains(p) {
+			containing = append(containing, f)
+		}
 		if d := p.DistanceTo(c); d < bestD {
 			best, bestD = f, d
 		}
 	}
-	// Bind only when the placement face is unambiguous; two faces reaching p on aligned planes is
-	// an indefensible tie, so leave the hole unbound rather than drill the wrong one.
-	if candidates != 1 {
-		return nil, false
+	// Prefer the face that actually CONTAINS p (inside its outer boundary, outside its holes):
+	// coplanar faces on aligned planes are common (a face split by a pattern/step), and only one
+	// contains the drill point, so this disambiguates them where a plane-only test would tie.
+	if len(containing) == 1 {
+		return containing[0], true
 	}
-	return best, true
+	// No unique containing face: fall back to a single plane-aligned candidate (p may sit just
+	// outside the boundary, e.g. a recorded centroid off an annular face). Two remain ⇒ an
+	// indefensible tie, so leave the hole unbound rather than drill the wrong one.
+	if len(planeCands) == 1 {
+		return best, true
+	}
+	return nil, false
 }
 
 // FindEdgeByGeometry returns the edge whose midpoint is within tol of the descriptor and

--- a/kernel/topo/geometric_ref.go
+++ b/kernel/topo/geometric_ref.go
@@ -92,19 +92,14 @@ func (b *Body) FindPlanarFaceThrough(p math.Point3, want math.Vector3, tol math.
 	var best *Face
 	bestD := stdmath.Inf(1)
 	for _, f := range b.Faces() {
-		c := faceCentroid(f)
-		n := faceOutwardNormal(f, c)
-		if wn.LengthSquared() > 0 && stdmath.Abs(float64(n.Dot(wn))) < normalAlignMin {
-			continue
-		}
-		if stdmath.Abs(c.VectorTo(p).Dot(n)) > tol { // perpendicular distance from p to the face plane
+		if !faceThroughPointAligned(f, p, wn, tol) {
 			continue
 		}
 		planeCands = append(planeCands, f)
 		if NewFaceEvaluator(f).Contains(p) {
 			containing = append(containing, f)
 		}
-		if d := p.DistanceTo(c); d < bestD {
+		if d := p.DistanceTo(faceCentroid(f)); d < bestD {
 			best, bestD = f, d
 		}
 	}
@@ -121,6 +116,18 @@ func (b *Body) FindPlanarFaceThrough(p math.Point3, want math.Vector3, tol math.
 		return best, true
 	}
 	return nil, false
+}
+
+// faceThroughPointAligned reports whether planar face f's plane passes through p (perpendicular
+// distance ≤ tol) with its outward normal aligned to want up to sign (see normalAlignMin). A zero
+// want skips the normal filter.
+func faceThroughPointAligned(f *Face, p math.Point3, want math.Vector3, tol math.Scalar) bool {
+	c := faceCentroid(f)
+	n := faceOutwardNormal(f, c)
+	if want.LengthSquared() > 0 && stdmath.Abs(float64(n.Dot(want))) < normalAlignMin {
+		return false
+	}
+	return stdmath.Abs(c.VectorTo(p).Dot(n)) <= tol
 }
 
 // FindEdgeByGeometry returns the edge whose midpoint is within tol of the descriptor and

--- a/kernel/topo/geometric_ref_test.go
+++ b/kernel/topo/geometric_ref_test.go
@@ -208,3 +208,37 @@ func TestFindPlanarFaceThroughBindsByCentre(t *testing.T) {
 		t.Error("a point far off the face plane must not bind")
 	}
 }
+
+// TestGeometricFaceRefNormalIsSignAgnostic: a face descriptor whose normal is recorded with the
+// opposite sign (an external author's outward-normal convention may differ) still binds the same
+// face — a planar face's identity does not depend on which way its normal is named.
+func TestGeometricFaceRefNormalIsSignAgnostic(t *testing.T) {
+	a := box(math.P3(0, 0, 0), 2, 2, 2)
+	f := a.Faces()[0]
+	ref := topo.DescribeFace(f)
+	ref.Normal = ref.Normal.Scale(-1) // flip the sign
+	if got, ok := a.FindFaceByGeometry(ref, spikeTol); !ok || got != f {
+		t.Errorf("flipped-normal descriptor did not resolve its face (ok=%v, same=%v)", ok, got == f)
+	}
+}
+
+// TestFindPlanarFaceThroughDisambiguatesCoplanarByContainment: two coplanar, same-normal faces
+// (two disjoint boxes joined share the Z=2 plane) no longer tie — the face that CONTAINS the
+// point binds, so a hole whose drill point lands inside one of several coplanar faces resolves.
+func TestFindPlanarFaceThroughDisambiguatesCoplanarByContainment(t *testing.T) {
+	a := box(math.P3(0, 0, 0), 2, 2, 2)
+	b := box(math.P3(6, 0, 0), 2, 2, 2) // disjoint, tops coplanar at Z=2
+	u, err := ops.Boolean(ops.Join, a, b)
+	if err != nil {
+		t.Fatalf("union: %v", err)
+	}
+	up := math.Vector3{X: 0, Y: 0, Z: 1}
+	p := math.P3(1, 1, 2) // inside the FIRST box's top face only
+	got, ok := u.FindPlanarFaceThrough(p, up, spikeTol)
+	if !ok {
+		t.Fatal("a point inside one of two coplanar faces should bind that face")
+	}
+	if c := topo.DescribeFace(got).Centroid; c.X > 3 {
+		t.Errorf("bound the wrong coplanar face (centroid X=%v, want the box at X~1)", c.X)
+	}
+}

--- a/model/feature/hole_boss.go
+++ b/model/feature/hole_boss.go
@@ -366,16 +366,24 @@ func resolveHoleFace(body *topo.Body, def *HoleDefinition) (*topo.Face, bool) {
 		return body.FindFaceByKey(def.PlacementFaceKey)
 	}
 	if def.GeomFace != nil {
-		// Prefer the precise centroid+normal match. When it is lost — e.g. an exporter that
-		// mis-computes the face centroid, or a centroid shifted by later history — fall back to
-		// binding by the drill CENTRE, which lies on the placement face and is history-stable.
+		// Prefer the precise centroid+normal match. When it drifts past geomEdgeBindTol (an exporter
+		// computing the centroid differently, a centroid shifted by later history, or an annular face
+		// whose vertex-mean sits off the material), fall back to binding by a point on the placement
+		// face's PLANE with the recorded normal. Try TWO such points, since either may miss:
+		//   - the drill CENTRE, which lies on the face for a well-placed hole — but can sit on an
+		//     adjacent curved face at a rim, off the target plane;
+		//   - the recorded face CENTROID, which is coplanar with the placement face even when it
+		//     falls just outside the face boundary (FindPlanarFaceThrough uses perpendicular distance
+		//     to the plane, so an in-plane offset does not matter).
 		if f, ok := body.FindFaceByGeometry(*def.GeomFace, geomEdgeBindTol); ok {
 			return f, true
 		}
 		if def.Center != nil {
-			return body.FindPlanarFaceThrough(*def.Center, def.GeomFace.Normal, holeFaceThroughTol)
+			if f, ok := body.FindPlanarFaceThrough(*def.Center, def.GeomFace.Normal, holeFaceThroughTol); ok {
+				return f, true
+			}
 		}
-		return nil, false
+		return body.FindPlanarFaceThrough(def.GeomFace.Centroid, def.GeomFace.Normal, holeFaceThroughTol)
 	}
 	return nil, false
 }


### PR DESCRIPTION
## Why

The Inventor exporter records a placement face's outward normal as a geometric descriptor (ADR-0040, `placementFaceGeom`). But an external author's outward-normal *convention* can differ from Oblikovati's — observed on a revolve end face where Inventor reports **−Z** and Oblikovati's outward normal is **+Z**. `FindFaceByGeometry` / `FindPlanarFaceThrough` rejected the antiparallel normal (signed `dot < normalAlignMin`), so the hole reported **"placement face reference lost"** even though the base solid was correct.

## What

1. **Sign-agnostic normal match.** A planar face's identity does not depend on which way its normal is named — `FindEdgeByGeometry` already matches edge direction sign-agnostically. Match faces on `|dot|` (parallel *or* antiparallel). The opposite face of a thin feature is still rejected by the point-on-plane / centroid-distance tests, and the ambiguous-tie guard still holds.

2. **Coplanar disambiguation by containment.** A placement plane often carries several coplanar faces (a face split by a pattern/step); `FindPlanarFaceThrough` refused to guess when more than one candidate reached the point. Now it prefers the face that actually **contains** the point (`FaceEvaluator.Contains`: on-plane, inside the outer loop, outside holes) — exactly one does — falling back to a single plane-aligned candidate otherwise.

3. **resolveHoleFace** tries both the drill **centre** and the recorded **centroid** as the through-point (either can miss: the centre can sit on an adjacent curved face at a rim; the centroid can fall just outside an annular face's boundary).

Pure host change, no API surface.

### Tests
`kernel/topo/geometric_ref_test.go`: sign-agnostic face match; coplanar disambiguation by containment (two joined boxes → coplanar tops, point inside one binds it); the pre-existing ambiguous-tie test still passes. `addin/opregistry`: flipped-normal placement drills the same solid.

### Live validation
SmartKnobFixedBase and WheelSlider holes now bind (were "reference lost") against real Inventor 2027 geometry over the MCP bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)