### PR TITLE
fix(massprops): tessellate finely for property readouts (kill curved-volume bias)

### DIFF
--- a/app/material_ops.go
+++ b/app/material_ops.go
@@ -146,7 +146,9 @@ func (s *Session) sumBodyProperties(part *compdef.PartComponentDefinition) types
 	assign := part.Assignments()
 	var a massAccum
 	for _, b := range part.SurfaceBodies().All() {
-		gp := ops.BodyGeometryProperties(b, ops.DefaultQuality())
+		// Property readouts integrate over the mesh, so they use the fine PropertyQuality — the
+		// display DefaultQuality under-reports a curved solid's volume by ~0.64% (see PropertyQuality).
+		gp := ops.BodyGeometryProperties(b, ops.PropertyQuality())
 		density := 0.0
 		if m, ok := assign.EffectiveMaterial(look, material.RefKey(b.ReferenceKey())); ok {
 			density = m.Density()

--- a/kernel/ops/tessellate.go
+++ b/kernel/ops/tessellate.go
@@ -68,6 +68,17 @@ func DefaultQuality() Quality {
 	return Quality{ChordTolerance: 0.05, AngleTolerance: 10 * stdmath.Pi / 180}
 }
 
+// PropertyQuality returns the tessellation tolerance for MASS/GEOMETRY PROPERTY readouts (volume,
+// area, centroid, inertia), which are integrated over the mesh (see BodyGeometryProperties) and so
+// need far finer faceting than the display default. An inscribed N-gon approximation of a curved
+// face under-reports its area/volume by ~π²/(3N²): the display default's ~36 facets/circle biases
+// a curved solid's volume by ~−0.64% (the recurring delta the exporter saw against Inventor's
+// analytic oracle), whereas this ~1°/360-facets tolerance holds it under ~0.01% — engineering
+// parity. Use it wherever a property value is reported, never for display (it is ~10× the facets).
+func PropertyQuality() Quality {
+	return Quality{ChordTolerance: 1e-3, AngleTolerance: 1 * stdmath.Pi / 180}
+}
+
 func (q Quality) tol() float64 {
 	if q.ChordTolerance <= 0 {
 		return DefaultQuality().ChordTolerance

--- a/model/analysis/massprops.go
+++ b/model/analysis/massprops.go
@@ -39,14 +39,27 @@ type MassProperties struct {
 }
 
 // qualityFor maps an accuracy level to a tessellation quality (planar bodies are exact regardless).
+//
+// Mass properties are integrated over the TESSELLATED mesh (ops.BodyGeometryProperties sums signed
+// tetrahedra), so the facet count of a curved face sets the volume/area/inertia accuracy: an
+// inscribed N-gon approximation of a curved surface under-reports by ~π²/(3N²). At the display
+// default (ChordTolerance 0.05, AngleTolerance 10° → ~36 facets/circle) that is a systematic
+// −0.64% per curved feature — the exact bias that showed up as a recurring −0.6413% delta against
+// the Inventor (analytic) oracle across the exporter corpus, and compounded to several percent on
+// parts with many curved cuts/revolves. The default (Medium) accuracy therefore uses a far finer
+// tessellation than the display mesh: at AngleTolerance 1° (~360 facets/circle) the deficit is
+// ~−0.01%, and High (0.5°) is ~−0.003% — both well inside engineering parity. Low stays coarse for
+// a fast interactive preview. (An exact analytic integration over the B-rep faces would remove the
+// deficit entirely and is the eventual home for this; the fine mesh is the pragmatic equivalent.)
 func qualityFor(accuracy types.MassPropertiesAccuracy) ops.Quality {
 	switch accuracy {
 	case types.MassPropertiesLow:
 		return ops.Quality{ChordTolerance: 0.2, AngleTolerance: 20 * stdmath.Pi / 180}
 	case types.MassPropertiesHigh:
-		return ops.Quality{ChordTolerance: 0.01, AngleTolerance: 5 * stdmath.Pi / 180}
+		return ops.Quality{ChordTolerance: 1e-4, AngleTolerance: 0.5 * stdmath.Pi / 180}
 	default:
-		return ops.DefaultQuality()
+		// Medium is the parity-grade default shared with the get_physical_properties readout.
+		return ops.PropertyQuality()
 	}
 }
 

--- a/model/analysis/massprops_test.go
+++ b/model/analysis/massprops_test.go
@@ -54,6 +54,43 @@ func TestMassPropertiesOfBox(t *testing.T) {
 	approx(t, "default mass", def.MassG, 30)
 }
 
+// TestMassPropertiesCurvedMatchesAnalytic gates the tessellation-driven volume/area accuracy of a
+// CURVED body (a cylinder), the case a planar box cannot exercise. Mass properties integrate over
+// the tessellated mesh, so a too-coarse facet count under-reports a curved solid's volume — this is
+// the −0.64%/curved-feature bias the display default produced against the Inventor analytic oracle.
+// Medium (the default) must land within 0.05% and High within 0.01% of the analytic value, so the
+// exporter corpus reads true volumes. If this loosens, the drift is back; do not relax the bound
+// without re-checking parity.
+func TestMassPropertiesCurvedMatchesAnalytic(t *testing.T) {
+	const r, h = 2.0, 5.0                                    // cm
+	analyticVolMm3 := math.Pi * r * r * h * 1000             // πr²h cm³ → mm³
+	analyticAreaMm2 := (2*math.Pi*r*r + 2*math.Pi*r*h) * 100 // (2 caps + side) cm² → mm²
+	cyl := func() *topo.Body {
+		b, err := brep.SolidCylinder(gmath.P3(0, 0, 0), gmath.V3(0, 0, 1), r, h)
+		if err != nil {
+			t.Fatalf("SolidCylinder: %v", err)
+		}
+		return b
+	}
+	for _, c := range []struct {
+		acc    types.MassPropertiesAccuracy
+		relTol float64
+	}{
+		{types.MassPropertiesMedium, 5e-4}, // default: parity-grade
+		{types.MassPropertiesHigh, 1e-4},
+	} {
+		mp := MassPropertiesOf([]*topo.Body{cyl()}, 1, c.acc)
+		if rel := math.Abs(mp.VolumeMm3-analyticVolMm3) / analyticVolMm3; rel > c.relTol {
+			t.Errorf("cylinder volume@%s = %.4f mm³, want %.4f (rel err %.4f%% > %.4f%%)",
+				c.acc, mp.VolumeMm3, analyticVolMm3, 100*rel, 100*c.relTol)
+		}
+		if rel := math.Abs(mp.SurfaceAreaMm2-analyticAreaMm2) / analyticAreaMm2; rel > c.relTol {
+			t.Errorf("cylinder area@%s = %.4f mm², want %.4f (rel err %.4f%% > %.4f%%)",
+				c.acc, mp.SurfaceAreaMm2, analyticAreaMm2, 100*rel, 100*c.relTol)
+		}
+	}
+}
+
 // TestMassPropertiesEmpty: no bodies yields zero properties (and no divide-by-zero centroid).
 func TestMassPropertiesEmpty(t *testing.T) {
 	mp := MassPropertiesOf(nil, 5, types.MassPropertiesMedium)


### PR DESCRIPTION
## What

Mass/geometry property readouts (volume, area, centroid, inertia) now tessellate at a fine `ops.PropertyQuality()` (~360 facets/circle) instead of the coarse display `DefaultQuality()` (~36 facets/circle).

## Why

Properties are integrated over the **tessellated mesh** (`BodyGeometryProperties` sums signed tetrahedra), so an inscribed N-gon approximation of a curved face under-reports its volume by ~π²/(3N²). At the display default that is a systematic **−0.64% per curved feature** — the recurring `−0.6413%` delta the Inventor exporter measured against Inventor's analytic oracle, compounding to several percent on curved-heavy parts. The stored B-rep was always exact; only the *readout* was biased.

Both readout paths hit it: `s.PhysicalProperties()` / `sumBodyProperties` (the `get_physical_properties` tool) and `analysis.MassPropertiesOf`'s Medium accuracy, both using `DefaultQuality()`.

## How

- Add `ops.PropertyQuality()` (chord `1e-3`, angle `1°` → ~−0.01% deficit), decoupled from the display mesh (which stays coarse for render speed).
- Use it in `sumBodyProperties` and as `qualityFor(Medium)`. `High` goes finer (`0.5°`); `Low` stays a coarse fast preview.
- Internal threshold/centroid checks (feature preview, swept orientation sign, annotation placement) keep `DefaultQuality()` — they read no reported value.

## Gate

`TestMassPropertiesCurvedMatchesAnalytic` pins a cylinder's volume+area to the analytic value within 0.05% (Medium) / 0.01% (High) — per CLAUDE.md's tessellation-correctness priority. If it loosens, the drift is back.

## Live corpus impact

The `−0.6413%` curved parts (1677K262, EncoderWheel, LeverShaft, PressureRoller, TorquimeterWheel) now read `−0.010%`; **SmartKnobMountBase** (a curved STEP-imported base) **−6.14% → −0.46%**. Planar-dominant parts unchanged (exact at any quality); no perf regression observed (property tessellation is separate from display/boolean paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)