### PR TITLE
fix(boolean): keep coaxial equal-radius cylinder joins analytic (#1831)

### DIFF
--- a/kernel/brep/curved_coaxial_cylinder.go
+++ b/kernel/brep/curved_coaxial_cylinder.go
@@ -49,6 +49,19 @@ func CoaxialCylinderUnion(a, b *topo.Body) (*topo.Body, bool) {
 	return union, true
 }
 
+// CoaxialEqualCylinders reports whether a and b are each a BARE analytic cylinder (one geom.Cylinder
+// side + two planar caps) sharing the same axis line and radius — the precondition CoaxialCylinderUnion
+// unions into a single analytic cylinder. The model boolean gate (model/feature.combine) uses it to
+// route such a JOIN to the curved boolean, which keeps the analytic cylinder, instead of faceting both
+// operands into prisms first and shattering the wall into planar facets (#1831). It does NOT apply the
+// axial-gap test — a gapped pair still passes here but CoaxialCylinderUnion then returns ok=false, so
+// the caller cleanly falls back to the planar path.
+func CoaxialEqualCylinders(a, b *topo.Body) bool {
+	ca, baseA, _, okA := cylinderSolidParams(facesOfAny(a))
+	cb, baseB, _, okB := cylinderSolidParams(facesOfAny(b))
+	return okA && okB && coaxialEqualRadius(ca, baseA, cb, baseB)
+}
+
 // coaxialEqualRadius reports whether two cylinders share the same axis line (parallel directions, each
 // base on the other's axis) and the same radius — the precondition for their side faces to be coincident.
 func coaxialEqualRadius(ca geom.Cylinder, baseA math.Point3, cb geom.Cylinder, baseB math.Point3) bool {

--- a/kernel/brep/curved_coaxial_cylinder_test.go
+++ b/kernel/brep/curved_coaxial_cylinder_test.go
@@ -43,6 +43,26 @@ func TestCoaxialCylinderUnionAbut(t *testing.T) {
 	}
 }
 
+// TestCoaxialEqualCylinders covers the predicate the model boolean gate uses (#1831): true for a
+// coaxial equal-radius bare-cylinder pair (overlap or abut), false for a different radius, an offset
+// axis, or a non-cylinder body — so a JOIN is routed to the analytic path only when it applies.
+func TestCoaxialEqualCylinders(t *testing.T) {
+	base, _ := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2, 4)
+	abut, _ := SolidCylinder(math.P3(0, 0, 4), math.V3(0, 0, 1), 2, 4)
+	overlap, _ := SolidCylinder(math.P3(0, 0, 3), math.V3(0, 0, 1), 2, 4)
+	if !CoaxialEqualCylinders(base, abut) || !CoaxialEqualCylinders(base, overlap) {
+		t.Error("coaxial equal-radius cylinders (abut/overlap) should report true")
+	}
+	bigR, _ := SolidCylinder(math.P3(0, 0, 4), math.V3(0, 0, 1), 3, 4)
+	offset, _ := SolidCylinder(math.P3(5, 0, 4), math.V3(0, 0, 1), 2, 4)
+	block, _ := SolidBlock(math.P3(0, 0, 0), math.P3(2, 2, 2), "b")
+	for name, other := range map[string]*topo.Body{"bigger radius": bigR, "offset axis": offset, "block": block} {
+		if CoaxialEqualCylinders(base, other) {
+			t.Errorf("%s should NOT report as a coaxial equal-radius cylinder pair", name)
+		}
+	}
+}
+
 // TestCoaxialCylinderUnionOrderIndependent: union resolves whichever cylinder is passed first.
 func TestCoaxialCylinderUnionOrderIndependent(t *testing.T) {
 	a, _ := SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2, 4)

--- a/model/feature/coaxial_join_analytic_test.go
+++ b/model/feature/coaxial_join_analytic_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// circleSketchOnPlaneZ builds a one-circle sketch on the XY-oriented plane offset to z, so an
+// extrude from it stacks coaxially above one from the base XY plane.
+func circleSketchOnPlaneZ(z, cx, cy, r float64) *sketch.Sketch {
+	ux, _ := math.UnitVector3FromVector(math.V3(1, 0, 0))
+	uy, _ := math.UnitVector3FromVector(math.V3(0, 1, 0))
+	pl, _ := sketch.NewPlane(math.P3(0, 0, z), ux, uy)
+	s := sketch.NewSketches().Add(pl)
+	s.Circles().AddByCenterRadius(math.P2(cx, cy), r)
+	return s
+}
+
+// TestCoaxialCylinderJoinKeepsAnalyticFace is the #1831 regression: joining two coaxial, equal-radius
+// cylinders (a stacked/stepped shaft — extrude Ø4 z[0,4] then JOIN Ø4 z[4,7]) must yield ONE analytic
+// geom.Cylinder face spanning the merged extent with the exact πr²h volume, not a shattered stack of
+// planar facets. The bug: combine()'s curved-boolean gate (exactlyOneCurvedPrimitive) rejected the
+// both-operands-cylinder case, so it faceted BOTH cylinders into 24-gon prisms before the union —
+// losing analyticity (74 planar faces, 0 cylinders) and under-reporting the volume.
+func TestCoaxialCylinderJoinKeepsAnalyticFace(t *testing.T) {
+	const r, h1, h2 = 2.0, 4.0, 3.0
+	fs := NewPartFeatures(nil)
+	ex := NewExtrudeFeatures(fs)
+	ex.AddByDistanceExtent(circleSketchAt(0, 0, r), 0, ops.NewBody, func() float64 { return h1 })        // z[0,4]
+	ex.AddByDistanceExtent(circleSketchOnPlaneZ(h1, 0, 0, r), 0, ops.Join, func() float64 { return h2 }) // z[4,7]
+	fs.Recompute()
+
+	if n := len(fs.Result()); n != 1 {
+		t.Fatalf("coaxial join = %d bodies, want 1", n)
+	}
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("coaxial-join body not a valid solid: %+v", r)
+	}
+	if got := cylinderFaceCount(body); got != 1 {
+		t.Errorf("coaxial-join analytic cylinder faces = %d, want 1 (the union re-faceted the wall — #1831)", got)
+	}
+	// 5e-4 discriminates the analytic union (~−0.01% at PropertyQuality) from a shattered 24-gon
+	// prism (~−1.1%): only the analytic cylinder passes.
+	analytic := stdmath.Pi * r * r * (h1 + h2)
+	if v := ops.BodyGeometryProperties(body, ops.PropertyQuality()).Volume; relErr(v, analytic) > 5e-4 {
+		t.Errorf("coaxial-join volume = %g, want %g (πr²·%g) — faceted, not the analytic union", v, analytic, h1+h2)
+	}
+}
+
+// TestUnequalCoaxialCylinderJoinStillFacets guards the gate's precision: a coaxial join of DIFFERENT
+// radii (a shoulder — Ø4 over Ø6) is NOT the single-cylinder case, so it must NOT take the analytic
+// coaxial path; it stays a valid solid of the correct volume (whether or not it keeps analytic faces).
+func TestUnequalCoaxialCylinderJoinStillFacets(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	ex := NewExtrudeFeatures(fs)
+	ex.AddByDistanceExtent(circleSketchAt(0, 0, 3), 0, ops.NewBody, func() float64 { return 4 })       // Ø6 z[0,4]
+	ex.AddByDistanceExtent(circleSketchOnPlaneZ(4, 0, 0, 2), 0, ops.Join, func() float64 { return 3 }) // Ø4 z[4,7]
+	fs.Recompute()
+
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("shoulder body not a valid solid: %+v", r)
+	}
+	// The shoulder is not a single cylinder, so it stays on the faceted planar path (24-gon prism,
+	// ~−1.1% under the analytic value) — a wide bound just confirms it is a sane solid, not the
+	// analytic union.
+	analytic := stdmath.Pi*3*3*4 + stdmath.Pi*2*2*3
+	if v := ops.BodyGeometryProperties(body, ops.PropertyQuality()).Volume; relErr(v, analytic) > 2e-2 {
+		t.Errorf("shoulder volume = %g, want ~%g", v, analytic)
+	}
+}

--- a/model/feature/extrude.go
+++ b/model/feature/extrude.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	stdmath "math"
 
+	"oblikovati.org/kernel/brep"
 	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
@@ -196,7 +197,12 @@ func combine(in Input, body *topo.Body, op ops.PartFeatureOperation) ([]*topo.Bo
 	// cylinder/cone tool, which previously fell through to faceting and shattered the hole rim into 24 straight
 	// segments (#1472). CurvedBoolean takes (target, tool) in feature order; each kernel path checks its own
 	// operand roles, so the same call serves both directions.
-	if exactlyOneCurvedPrimitive(target, body) {
+	// The curved boolean also keeps analyticity for a JOIN of two coaxial equal-radius cylinders (a
+	// stepped/stacked shaft) — brep.CoaxialCylinderUnion returns one cylinder spanning the merged
+	// extent. Without this the both-cylinder pair fails exactlyOneCurvedPrimitive (both are curved), so
+	// combine faceted BOTH into 24-gon prisms and shattered the wall into planar facets (#1831). On no
+	// match the curved boolean returns ok=false and we fall through to the planar path unchanged.
+	if exactlyOneCurvedPrimitive(target, body) || (op == ops.Join && brep.CoaxialEqualCylinders(target, body)) {
 		if res, ok := ops.CurvedBooleanWithDiagnostics(op, target, body, in.Diag); ok {
 			return appendCombined(running, res), nil
 		}


### PR DESCRIPTION
Fixes #1831.

## What

Joining two coaxial, same-radius cylinders (a stacked/stepped shaft) now keeps **one analytic `geom.Cylinder` face** spanning the merged extent, instead of shattering the wall into planar facets (74 planar faces, 0 cylinders) and under-reporting the volume by ~1%.

## Root cause — the model gate, not the kernel

`brep.CoaxialCylinderUnion` already unions coaxial equal cylinders (overlap **or** abut) into one analytic cylinder and is well tested — but it was **never reached** from the feature path. `combine()`'s curved-boolean gate `exactlyOneCurvedPrimitive` only fires when exactly one operand is curved and the other is planar. Two cylinders are **both** curved, so the gate rejected the pair and `combine` faceted **both** into 24-gon prisms (`planarizeSimpleCylinder`) *before* the union ran — the analytic surface was gone upstream.

## Fix

Widen the gate: also route a **JOIN of a coaxial equal-radius cylinder pair** to the curved boolean, which reaches `curvedCoaxialJoin` → `CoaxialCylinderUnion`. The precondition is exposed as `brep.CoaxialEqualCylinders`, reusing the exact `CoaxialCylinderUnion` detector so the gate and the handler cannot drift. On no match the curved boolean returns `ok=false` and `combine` falls through to the planar path unchanged, so unequal radii (a shoulder/washer) and non-join ops are untouched.

## Tests

- `TestCoaxialCylinderJoinKeepsAnalyticFace`: Ø4 z[0,4] + JOIN Ø4 z[4,7] → **1** `geom.Cylinder` face, exact πr²·7 volume (discriminates the analytic union at ~−0.01% from a shattered prism at ~−1.1%).
- `TestUnequalCoaxialCylinderJoinStillFacets`: an unequal Ø6/Ø4 shoulder stays a valid faceted solid (gate precision).
- Full `model/feature`, `kernel/brep`, `kernel/ops` suites green (incl. the washer-stays-faceted test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)