### PR TITLE
fix(sketch): author elliptical arcs by Inventor's true angle (#1829)

### DIFF
--- a/addin/router/sketch_add_entity.go
+++ b/addin/router/sketch_add_entity.go
@@ -449,7 +449,9 @@ func buildEllipse(part *compdef.PartComponentDefinition, sk *sketch.Sketch, in w
 	return e, []uint64{uint64(e.Center.EntityID())}, nil
 }
 
-// buildEllipticalArc creates an elliptical arc bounded by parametric start/end angles.
+// buildEllipticalArc creates an elliptical arc bounded by TRUE geometric start/end angles (Inventor's
+// SketchEllipticalArc convention, #1829); EllipticalArcs.Add converts them to the internal parametric
+// angles.
 func buildEllipticalArc(part *compdef.PartComponentDefinition, sk *sketch.Sketch, in wire.AddSketchEntityArgs, pts []math.Point2) (sketch.Entity, []uint64, error) {
 	if err := wantPoints("ellipticalArc", pts, 1); err != nil {
 		return nil, nil, err

--- a/model/exchange/sketch_from_drawing.go
+++ b/model/exchange/sketch_from_drawing.go
@@ -124,11 +124,13 @@ func add2DEntity(sk *sketch.Sketch, e drawing.Entity) bool {
 		majorR := math.Hypot(g.MajorAxis[0], g.MajorAxis[1])
 		axis := gmath.V2(g.MajorAxis[0], g.MajorAxis[1])
 		// A partial ellipse (start/end parametric angles) is an elliptical arc; importing
-		// those as a full ellipse drew giant closed ovals over the drawing.
+		// those as a full ellipse drew giant closed ovals over the drawing. DXF ELLIPSE start/end
+		// params are eccentric-anomaly (parametric), so add them verbatim — NOT through the
+		// true-angle EllipticalArcs.Add, which would re-interpret and mis-place the arc (#1829).
 		if isFullEllipse(g.StartAngle, g.EndAngle) {
 			sk.Ellipses().Add(p2(g.Center), axis, majorR, majorR*g.AxisRatio)
 		} else {
-			sk.EllipticalArcs().Add(p2(g.Center), axis, majorR, majorR*g.AxisRatio, g.StartAngle, g.EndAngle)
+			sk.EllipticalArcs().AddParametric(p2(g.Center), axis, majorR, majorR*g.AxisRatio, g.StartAngle, g.EndAngle)
 		}
 	case *drawing.Spline:
 		add2DSpline(sk, g)

--- a/model/sketch/conics_test.go
+++ b/model/sketch/conics_test.go
@@ -30,7 +30,9 @@ func TestEllipticalArcSamplesEndpoints(t *testing.T) {
 func TestEllipticalArcRoundTrips(t *testing.T) {
 	sc := NewSketches()
 	s := sc.Add(XYPlane())
-	s.EllipticalArcs().Add(gmath.P2(1, 1), gmath.V2(0, 1), 3, 2, 0.1, 1.2)
+	// AddParametric stores the angles verbatim, so this checks pure serialization fidelity of the
+	// stored (parametric) representation, independent of the true-angle authoring conversion (#1829).
+	s.EllipticalArcs().AddParametric(gmath.P2(1, 1), gmath.V2(0, 1), 3, 2, 0.1, 1.2)
 
 	out := roundTrip(t, sc)
 	if got := out.EllipticalArcs().Count(); got != 1 {

--- a/model/sketch/ellipse_angle.go
+++ b/model/sketch/ellipse_angle.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import stdmath "math"
+
+// Elliptical-arc angle convention (#1829). An elliptical arc is authored with Autodesk Inventor's
+// convention — the TRUE geometric angle θ, the angle at the centre from the major axis to the ray
+// through an endpoint — but stored and sampled with the PARAMETRIC (eccentric-anomaly) angle a,
+// where the point is P(a) = C + Rmaj·cos(a)·û + Rmin·sin(a)·v̂. For a non-circular ellipse θ ≠ a; they
+// relate by a = atan2(Rmaj·sinθ, Rmin·cosθ). The authoring boundary (EllipticalArcs.Add, reached by
+// the wire and GUI) converts θ→a here; importers that already supply the parametric angle (DXF/DWG
+// ELLIPSE params are eccentric-anomaly) use AddParametric and skip the conversion.
+
+// trueToParamAngle maps a true geometric angle θ to the parametric angle a for an ellipse with the
+// given semi-axes. Rmin ≤ 0 (a degenerate/circle-authored arc) falls back to θ unchanged.
+func trueToParamAngle(theta, majorR, minorR float64) float64 {
+	if minorR <= 0 || majorR <= 0 {
+		return theta
+	}
+	return stdmath.Atan2(majorR*stdmath.Sin(theta), minorR*stdmath.Cos(theta))
+}
+
+// paramArcFromTrue converts an elliptical arc given by TRUE start/end angles into the parametric
+// start/end angles the arc stores, preserving the sweep's direction AND magnitude across the atan2
+// branch cut. θ→a is a continuous, monotonically increasing reparametrisation (mod 2π), so the
+// parametric sweep has the same sign as the true sweep; this only unwraps it back into that
+// revolution when atan2 wrapped an endpoint to the other branch.
+func paramArcFromTrue(startTrue, endTrue, majorR, minorR float64) (startParam, endParam float64) {
+	aStart := trueToParamAngle(startTrue, majorR, minorR)
+	aEnd := trueToParamAngle(endTrue, majorR, minorR)
+	sweepTrue := endTrue - startTrue
+	sweepParam := aEnd - aStart
+	for sweepTrue > 0 && sweepParam <= 0 {
+		sweepParam += 2 * stdmath.Pi
+	}
+	for sweepTrue < 0 && sweepParam >= 0 {
+		sweepParam -= 2 * stdmath.Pi
+	}
+	return aStart, aStart + sweepParam
+}

--- a/model/sketch/ellipse_angle_test.go
+++ b/model/sketch/ellipse_angle_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// trueAngleOf returns the geometric angle of point p about the origin in the +X/+Y frame.
+func trueAngleOf(p math.Point2) float64 { return stdmath.Atan2(float64(p.Y), float64(p.X)) }
+
+// TestEllipticalArcAddUsesTrueAngle is the #1829 regression: EllipticalArcs.Add interprets its
+// start/end as Inventor's TRUE geometric angle θ, not the parametric (eccentric-anomaly) angle. On a
+// 2:1 ellipse (major axis +X) an arc authored from θ=45° must actually START on the 45° ray — the
+// parametric interpretation would place it at ~26.57°.
+func TestEllipticalArcAddUsesTrueAngle(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	e := s.EllipticalArcs().Add(math.P2(0, 0), math.V2(1, 0), 2, 1, stdmath.Pi/4, stdmath.Pi/2)
+
+	pts := sampleEllipticalArcEntityN(e, 64)
+	if got := trueAngleOf(pts[0]); stdmath.Abs(got-stdmath.Pi/4) > 1e-9 {
+		t.Errorf("arc start true angle = %.6f rad (%.3f°), want π/4 (45°) — Add must interpret θ as the true angle (#1829)",
+			got, got*180/stdmath.Pi)
+	}
+	// θ=90° is on the minor axis where θ=a, so the end is exactly (0, minorR)=(0,1).
+	end := pts[len(pts)-1]
+	if stdmath.Abs(float64(end.X)) > 1e-9 || stdmath.Abs(float64(end.Y)-1) > 1e-9 {
+		t.Errorf("arc end = %v, want (0,1)", end)
+	}
+}
+
+// TestEllipticalArcAddParametricIsVerbatim: AddParametric stores the eccentric-anomaly angle directly
+// (the DXF/restore path), so its start point is the parametric point P(a), not the true-angle point.
+func TestEllipticalArcAddParametricIsVerbatim(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	const a = stdmath.Pi / 4 // parametric
+	e := s.EllipticalArcs().AddParametric(math.P2(0, 0), math.V2(1, 0), 2, 1, a, stdmath.Pi/2)
+
+	pts := sampleEllipticalArcEntityN(e, 64)
+	// P(a) = (Rmaj·cos a, Rmin·sin a) = (2·√2/2, 1·√2/2) = (√2, √2/2).
+	wantX, wantY := stdmath.Sqrt2, stdmath.Sqrt2/2
+	if stdmath.Abs(float64(pts[0].X)-wantX) > 1e-9 || stdmath.Abs(float64(pts[0].Y)-wantY) > 1e-9 {
+		t.Errorf("AddParametric start = %v, want (%.4f,%.4f) — must NOT convert", pts[0], wantX, wantY)
+	}
+}
+
+// TestParamArcFromTruePreservesSweep: the θ→a conversion keeps the sweep direction and keeps both
+// endpoints on their true rays, including a CW arc and one crossing the atan2 branch.
+func TestParamArcFromTrue(t *testing.T) {
+	const rMaj, rMin = 3.0, 1.0
+	cases := []struct{ startTrue, endTrue float64 }{
+		{stdmath.Pi / 6, 2 * stdmath.Pi / 3},     // CCW, off-axis
+		{2 * stdmath.Pi / 3, stdmath.Pi / 6},     // CW
+		{5 * stdmath.Pi / 6, 7 * stdmath.Pi / 6}, // crosses θ=π
+	}
+	for _, c := range cases {
+		aS, aE := paramArcFromTrue(c.startTrue, c.endTrue, rMaj, rMin)
+		// Each parametric endpoint must sit on its true-angle ray.
+		if got := paramPointTrueAngle(aS, rMaj, rMin); angleDiff(got, c.startTrue) > 1e-9 {
+			t.Errorf("start: param a=%.4f lands at true %.4f, want %.4f", aS, got, c.startTrue)
+		}
+		if got := paramPointTrueAngle(aE, rMaj, rMin); angleDiff(got, c.endTrue) > 1e-9 {
+			t.Errorf("end: param a=%.4f lands at true %.4f, want %.4f", aE, got, c.endTrue)
+		}
+		// Sweep sign preserved.
+		if (c.endTrue-c.startTrue > 0) != (aE-aS > 0) {
+			t.Errorf("sweep sign flipped: true %.4f→%.4f gave param %.4f→%.4f", c.startTrue, c.endTrue, aS, aE)
+		}
+	}
+}
+
+// paramPointTrueAngle is the true geometric angle of the parametric point P(a).
+func paramPointTrueAngle(a, rMaj, rMin float64) float64 {
+	return stdmath.Atan2(rMin*stdmath.Sin(a), rMaj*stdmath.Cos(a))
+}
+
+// angleDiff is the absolute smallest difference between two angles (mod 2π).
+func angleDiff(x, y float64) float64 {
+	d := stdmath.Mod(x-y, 2*stdmath.Pi)
+	if d > stdmath.Pi {
+		d -= 2 * stdmath.Pi
+	}
+	if d < -stdmath.Pi {
+		d += 2 * stdmath.Pi
+	}
+	return stdmath.Abs(d)
+}

--- a/model/sketch/entity_collections.go
+++ b/model/sketch/entity_collections.go
@@ -139,9 +139,21 @@ type EllipticalArcs struct {
 	entityList[*EllipticalArc]
 }
 
-// Add creates an elliptical arc from a center, major-axis direction, the two radii, and
-// the parametric start/end angles (radians, in the major/minor frame).
-func (c *EllipticalArcs) Add(center math.Point2, majorAxis math.Vector2, majorR, minorR, start, end math.Scalar) *EllipticalArc {
+// Add creates an elliptical arc from a center, major-axis direction, the two radii, and the TRUE
+// geometric start/end angles (radians, Inventor's convention — the angle at the centre from the
+// major axis to the ray through each endpoint, #1829). They are converted to the internal parametric
+// (eccentric-anomaly) angles the arc stores. An importer that already supplies parametric angles
+// (DXF/DWG) uses [EllipticalArcs.AddParametric] instead.
+func (c *EllipticalArcs) Add(center math.Point2, majorAxis math.Vector2, majorR, minorR, startTrue, endTrue math.Scalar) *EllipticalArc {
+	aStart, aEnd := paramArcFromTrue(float64(startTrue), float64(endTrue), float64(majorR), float64(minorR))
+	return c.AddWithCenter(c.s.newPoint(center), majorAxis, majorR, minorR, math.Scalar(aStart), math.Scalar(aEnd))
+}
+
+// AddParametric creates an elliptical arc from PARAMETRIC (eccentric-anomaly) start/end angles — the
+// arc's verbatim internal representation, no true-angle conversion. For callers that already hold the
+// parametric angle: DXF/DWG ELLIPSE start/end params are eccentric-anomaly, so importing them through
+// the true-angle [EllipticalArcs.Add] would mis-place the arc.
+func (c *EllipticalArcs) AddParametric(center math.Point2, majorAxis math.Vector2, majorR, minorR, start, end math.Scalar) *EllipticalArc {
 	return c.AddWithCenter(c.s.newPoint(center), majorAxis, majorR, minorR, start, end)
 }
 


### PR DESCRIPTION
Fixes #1829.

## What

An elliptical arc's `StartAngle`/`EndAngle` were interpreted as the **parametric** (eccentric-anomaly) angle `a`; Autodesk Inventor's `SketchEllipticalArc` uses the **true geometric** angle θ. For a non-circular ellipse θ≠a and the gap grows with eccentricity, so an arc authored with Inventor's angle landed several degrees of parameter off — past the sketch node-merge tolerance (1e-6 cm), leaving the profile loop **open**.

## How

Adopt Inventor's convention at the **authoring boundary**: `EllipticalArcs.Add` now takes **true** angles and converts to the internal parametric angle via `a = atan2(Rmaj·sinθ, Rmin·cosθ)`, preserving the sweep direction across the atan2 branch (`paramArcFromTrue`). The wire `ellipticalArc` path reaches `Add`, so external authors (the Inventor exporter, MCP) now speak Inventor's convention.

The internal representation, sampler, and **persistence stay parametric — no recipe migration**. Callers that already hold the parametric angle keep it verbatim:
- restore/clone use the existing `AddWithCenter`;
- DXF/DWG import (whose ELLIPSE params **are** eccentric-anomaly) now uses the new `AddParametric`, so it is not re-interpreted.

## Tests

- `TestEllipticalArcAddUsesTrueAngle`: an arc from θ=45° on a 2:1 ellipse now starts on the 45° ray (parametric would place it at ~26.57°).
- `TestEllipticalArcAddParametricIsVerbatim`: `AddParametric` stays verbatim.
- `TestParamArcFromTrue`: both endpoints land on their true rays and the sweep sign is preserved (incl. a CW arc and a branch-crossing arc).
- The serialization round-trip test uses `AddParametric` to stay a pure codec check; `model/sketch`, `addin/router`, `model/exchange` suites green.

## Downstream

Validated live: the Inventor exporter's `ST3215Bracket` elliptical-arc base loop now **closes** (the exporter drops its endpoint-derived parametric workaround and passes Inventor's `StartAngle`/`SweepAngle` straight through). Only one corpus part has elliptical arcs, so nothing else is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)