### PR TITLE
fix(extrude): degrade an unresolvable to-face target gracefully

### DIFF
--- a/addin/opregistry/extrude.go
+++ b/addin/opregistry/extrude.go
@@ -148,33 +148,36 @@ const toFaceGeomBindTol = 1e-3
 func withToFaceGeom(part *compdef.PartComponentDefinition, ext feature.Extent, sel featureargs.GeomFaceSel) (feature.Extent, error) {
 	ref, err := geomFaceRef(sel)
 	if err != nil {
-		return feature.Extent{}, err
+		return feature.Extent{}, err // a malformed selector is a caller error, not a resolution miss
 	}
-	wp, err := toFaceGeomPlane(part, ref)
-	if err != nil {
-		return feature.Extent{}, err
-	}
-	ext.ToPlane = wp
+	// A target that matches no face leaves ToPlane nil; the to-face extent then recomputes UNHEALTHY
+	// (see toFaceGeomPlane) rather than erroring the whole apply, so a batch author (the exporter,
+	// reading an under-built base) flags the feature and keeps going instead of aborting the part.
+	ext.ToPlane, _ = toFaceGeomPlane(part, ref)
 	return ext, nil
 }
 
-// toFaceGeomPlane finds the planar body face matching the geometric descriptor and returns its
-// frozen plane. It tries an exact centroid+normal match first, then a plane-through-centroid match
-// (a large/annular stop face whose centroid sits off the recorded point still binds by its plane).
-func toFaceGeomPlane(part *compdef.PartComponentDefinition, ref topo.GeometricFaceRef) (*feature.WorkPlane, error) {
+// toFaceGeomPlane finds the planar body face matching the geometric descriptor and freezes its
+// plane. It tries an exact centroid+normal match first, then a plane-through-centroid match (a
+// large/annular stop face whose centroid sits off the recorded point still binds by its plane).
+// ok is false when no planar face matches — the caller leaves the extent unresolved so it degrades
+// to an unhealthy recompute (the hole's lost-placement-face pattern) rather than a hard error.
+func toFaceGeomPlane(part *compdef.PartComponentDefinition, ref topo.GeometricFaceRef) (*feature.WorkPlane, bool) {
 	for _, b := range part.SurfaceBodies().All() {
 		if f, ok := b.FindFaceByGeometry(ref, toFaceGeomBindTol); ok {
-			return fixedPlaneOfFace(f)
+			if wp, err := fixedPlaneOfFace(f); err == nil {
+				return wp, true
+			}
 		}
 	}
 	for _, b := range part.SurfaceBodies().All() {
 		if f, ok := b.FindPlanarFaceThrough(ref.Centroid, ref.Normal, toFaceGeomBindTol*10); ok {
-			return fixedPlaneOfFace(f)
+			if wp, err := fixedPlaneOfFace(f); err == nil {
+				return wp, true
+			}
 		}
 	}
-	return nil, fmt.Errorf(
-		"extrude: to-face geometric target (centroid %v, normal %v) matched no planar face on the current body",
-		ref.Centroid, ref.Normal)
+	return nil, false
 }
 
 // fixedPlaneOfFace freezes a planar face's surface as a transient work plane usable as an extent

--- a/addin/opregistry/extrude_toface_geom_test.go
+++ b/addin/opregistry/extrude_toface_geom_test.go
@@ -102,6 +102,39 @@ func TestExtrudeToFaceGeomNoMatchDegradesGracefully(t *testing.T) {
 	}
 }
 
+// TestExtrudeToFaceGeomBindsByPlaneThrough covers the plane-through fallback: a target whose recorded
+// point lies ON the stop face's plane but OFF its centroid (the common case — an exporter records a
+// point-on-face, not the running-body centroid) misses the exact centroid match and binds via
+// FindPlanarFaceThrough instead, still terminating the extrude at that plane.
+func TestExtrudeToFaceGeomBindsByPlaneThrough(t *testing.T) {
+	byGeom := seedToFaceVolume(t)
+	def := byGeom.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	g := topo.DescribeFace(topFaceOfBody(def.SurfaceBodies().Item(0)))
+	// Shift the recorded centroid 1 cm along +X: still on the top face's plane and inside its 4×3
+	// boundary, but far past the 1e-3 exact-centroid tolerance, so only the plane-through path binds.
+	args, _ := json.Marshal(map[string]any{
+		"sketchIndex": 1, "profileIndex": 0, "extent": "to-face", "operation": "new",
+		"toFaceGeom": map[string]any{
+			"centroid": []float64{float64(g.Centroid.X) + 1, float64(g.Centroid.Y), float64(g.Centroid.Z)},
+			"normal":   []float64{float64(g.Normal.X), float64(g.Normal.Y), float64(g.Normal.Z)},
+		},
+	})
+	out, err := apply(t, byGeom, "extrude", string(args))
+	if err != nil {
+		t.Fatalf("plane-through to-face-geom: %v", err)
+	}
+	var res struct {
+		Bodies  int  `json:"bodies"`
+		Healthy bool `json:"healthy"`
+	}
+	if err := json.Unmarshal(out, &res); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !res.Healthy || res.Bodies != 2 {
+		t.Fatalf("plane-through to-face result = %+v, want healthy with 2 bodies", res)
+	}
+}
+
 // seedToFaceVolume builds the base body a to-face extrude terminates against (a 10 mm prism), the
 // shared fixture for the geometric to-face tests.
 func seedToFaceVolume(t *testing.T) *app.Session {

--- a/addin/opregistry/extrude_toface_geom_test.go
+++ b/addin/opregistry/extrude_toface_geom_test.go
@@ -75,16 +75,30 @@ func TestExtrudeToFaceGeomFlippedNormalBinds(t *testing.T) {
 	}
 }
 
-// TestExtrudeToFaceGeomNoMatchErrors: a geometric target that matches no face on the body is a
-// clear error, not a silent no-op — the same "defensible or lost" rule the geom selectors use.
-func TestExtrudeToFaceGeomNoMatchErrors(t *testing.T) {
+// TestExtrudeToFaceGeomNoMatchDegradesGracefully: a geometric target that matches no face on the
+// body degrades to an UNHEALTHY feature (healthy:false with a clear reason), NOT a hard error that
+// aborts the operation — the hole's lost-placement-face pattern. A batch author (the exporter,
+// reading an under-built base whose target face never formed) can then flag the feature and keep
+// emitting the rest of the part instead of failing the whole document.
+func TestExtrudeToFaceGeomNoMatchDegradesGracefully(t *testing.T) {
 	byGeom := seedToFaceVolume(t)
 	args, _ := json.Marshal(map[string]any{
 		"sketchIndex": 1, "profileIndex": 0, "extent": "to-face", "operation": "new",
 		"toFaceGeom": map[string]any{"centroid": []float64{999, 999, 999}, "normal": []float64{0, 0, 1}},
 	})
-	if _, err := apply(t, byGeom, "extrude", string(args)); err == nil {
-		t.Error("to-face-geom with an unmatchable target should error")
+	out, err := apply(t, byGeom, "extrude", string(args))
+	if err != nil {
+		t.Fatalf("unmatchable to-face-geom should degrade gracefully, not error: %v", err)
+	}
+	var res struct {
+		Healthy bool   `json:"healthy"`
+		Reason  string `json:"reason"`
+	}
+	if err := json.Unmarshal(out, &res); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if res.Healthy || res.Reason == "" {
+		t.Errorf("unmatchable to-face-geom result = %+v, want healthy:false with a reason", res)
 	}
 }
 

--- a/model/feature/extrude_extent.go
+++ b/model/feature/extrude_extent.go
@@ -83,8 +83,14 @@ func throughAllSpan(ex Extent, bodies []*topo.Body, plane sketch.Plane) (span, e
 	}
 }
 
-// toPlaneSpan extrudes from the sketch plane to the (parallel) target work plane.
+// toPlaneSpan extrudes from the sketch plane to the (parallel) target work plane. A nil target is
+// an unresolved to-face selector (its face is absent on the current body — e.g. a geometric target
+// naming a face an earlier feature under-built); it recomputes to a clear unhealthy reason rather
+// than a hard error, so the caller degrades gracefully.
 func toPlaneSpan(ex Extent, plane sketch.Plane) (span, error) {
+	if ex.ToPlane == nil {
+		return span{}, errors.New("extrude: to-face target face was not found on the current body")
+	}
 	d, err := signedDistanceToPlane(ex.ToPlane, plane, "to-face")
 	if err != nil {
 		return span{}, err

--- a/model/feature/extrude_modes_test.go
+++ b/model/feature/extrude_modes_test.go
@@ -86,6 +86,22 @@ func TestExtrudeToWorkPlane(t *testing.T) {
 	}
 }
 
+// TestExtrudeToFaceNilTargetIsUnhealthy: a to-face extent whose target plane never resolved (nil —
+// e.g. a geometric target whose stop face an earlier feature under-built) recomputes UNHEALTHY with
+// a clear reason, rather than panicking or erroring the apply. This is the graceful degradation the
+// exporter relies on so one unresolved feature does not abort the whole document.
+func TestExtrudeToFaceNilTargetIsUnhealthy(t *testing.T) {
+	fs := NewPartFeatures(param.NewParameters())
+	pf := NewExtrudeFeatures(fs).AddExtrude(squareSketch(2), []int{0}, ops.NewBody, Extent{Type: ToFaceExtent}, 0)
+	fs.Recompute()
+	if pf.Health().OK() {
+		t.Fatal("to-face extrude with a nil target plane should be unhealthy, not OK")
+	}
+	if pf.Health().Reason == "" {
+		t.Error("unhealthy to-face extrude should carry a reason")
+	}
+}
+
 func TestExtrudeModeRoundTrip(t *testing.T) {
 	sk := sketch.NewSketches().Add(sketch.XYPlane())
 	fs := NewPartFeatures(nil)


### PR DESCRIPTION
## What

A to-face extent whose **geometric** target (`toFaceGeom`) matches no planar face on the current body now degrades to an **unhealthy feature** (`healthy:false` with a clear reason) instead of returning a hard error.

## Why

The stop face legitimately goes missing when an earlier feature under-builds the base, so the target never forms. A hard error aborts the whole operation — and for a batch author (the Inventor exporter) it aborts the **entire document emit**: ST3215Bracket came back as an `ERROR` with no volume at all, rather than a flagged partial build. The hole feature already handles a lost placement face this way (recompute unhealthy, not error); this brings the to-face extent in line.

## How

On no match, `toFaceGeomPlane` reports `ok=false` and `withToFaceGeom` leaves the extent's `ToPlane` nil, so at recompute `toPlaneSpan` fails into feature Health with a clear reason ("to-face target face was not found on the current body") — captured as `healthy:false`, not an escaping error. A **malformed** selector (bad centroid/normal vector) is still a hard caller error; only a valid-but-unresolvable target degrades.

## Test

`TestExtrudeToFaceGeomNoMatchDegradesGracefully`: an unmatchable `toFaceGeom` now yields `healthy:false` + a reason, not an error (replaces the prior expect-error test). `opregistry` and `model/feature` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)