### PR TITLE
feat(extrude): surface operation (kSurfaceOperation) — open sheet output (#1858)

### DIFF
--- a/addin/opregistry/extrude.go
+++ b/addin/opregistry/extrude.go
@@ -26,7 +26,7 @@ const extrudeSchema = `{
     "sketchIndex": {"type": "integer", "minimum": 0, "description": "Index of the sketch to extrude (see model.tree)."},
     "profileIndex": {"type": "integer", "minimum": 0, "default": 0, "description": "Which closed profile of the sketch to extrude."},
     "distance": {"type": "string", "description": "Extrude depth with units, e.g. \"50 mm\" or \"5 cm\". Required for distance and distance-from-face extents."},
-    "operation": {"type": "string", "enum": ["new", "join", "cut", "intersect"], "default": "new", "description": "Boolean against existing bodies."},
+    "operation": {"type": "string", "enum": ["new", "join", "cut", "intersect", "surface"], "default": "new", "description": "Boolean against existing bodies, or \"surface\" to build an open sheet (surface) body — Inventor's kSurfaceOperation."},
     "extent": {"type": "string", "enum": ["distance", "through-all", "to-next", "to-face"], "default": "distance", "description": "How the extrude terminates."},
     "direction": {"type": "string", "enum": ["positive", "negative", "symmetric"], "default": "positive", "description": "Which side(s) of the sketch plane to grow."},
     "secondDistance": {"type": "string", "description": "Asymmetric two-direction depth on the negative side, e.g. \"10 mm\"."},
@@ -265,7 +265,8 @@ func sketchAt(part *compdef.PartComponentDefinition, i int) (*sketch.Sketch, err
 	return sks.Item(i), nil
 }
 
-// parseOperation maps an operation name to the boolean op (default new body).
+// parseOperation maps an operation name to the feature operation (default new body). "surface"
+// is Inventor's kSurfaceOperation — an open sheet body rather than a boolean (#1858).
 func parseOperation(name string) (ops.PartFeatureOperation, error) {
 	switch strings.ToLower(strings.TrimSpace(name)) {
 	case "", "new", "newbody", "new-body":
@@ -276,7 +277,9 @@ func parseOperation(name string) (ops.PartFeatureOperation, error) {
 		return ops.Cut, nil
 	case "intersect":
 		return ops.Intersect, nil
+	case "surface":
+		return ops.Surface, nil
 	default:
-		return 0, fmt.Errorf("extrude: unknown operation %q (want new|join|cut|intersect)", name)
+		return 0, fmt.Errorf("extrude: unknown operation %q (want new|join|cut|intersect|surface)", name)
 	}
 }

--- a/addin/opregistry/extrude_surface_test.go
+++ b/addin/opregistry/extrude_surface_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"testing"
+
+	"oblikovati.org/model/compdef"
+)
+
+// TestExtrudeSurfaceOperation drives the extrude tool with operation:"surface" (Inventor's
+// kSurfaceOperation) end-to-end through the registry: the result is one healthy OPEN sheet body —
+// non-solid, walls only (four side faces of the 4×3 rectangle, no start/end caps), and NOT
+// booleaned against anything. This is the surfacing workflow's entry point (#1858).
+func TestExtrudeSurfaceOperation(t *testing.T) {
+	s := profiledPart(t)
+	raw, err := applyMap(t, s, "extrude", map[string]any{
+		"sketchIndex": 0, "distance": "5 mm", "operation": "surface",
+	})
+	if err != nil {
+		t.Fatalf("surface extrude: %v", err)
+	}
+	var res struct {
+		Bodies  int  `json:"bodies"`
+		Healthy bool `json:"healthy"`
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if !res.Healthy || res.Bodies != 1 {
+		t.Fatalf("surface extrude result = %+v, want one healthy body", res)
+	}
+	b := s.ActiveDocument().Content().(*compdef.PartComponentDefinition).SurfaceBodies().Item(0)
+	if b.IsSolid() {
+		t.Error("surface-operation extrude produced a SOLID body, want an open sheet")
+	}
+	if got := len(b.Faces()); got != 4 {
+		t.Errorf("surface extrude has %d faces, want 4 walls (no caps)", got)
+	}
+}
+
+// TestExtrudeSurfaceThenJoinKeepsBodies: a surface extrude does not boolean, so a following
+// join extrude of the other profile leaves the sheet untouched and adds the solid alongside it —
+// two bodies, one sheet + one solid.
+func TestExtrudeSurfaceThenSolidCoexist(t *testing.T) {
+	s := profiledPart(t)
+	if _, err := applyMap(t, s, "extrude", map[string]any{"sketchIndex": 0, "distance": "5 mm", "operation": "surface"}); err != nil {
+		t.Fatalf("surface extrude: %v", err)
+	}
+	if _, err := applyMap(t, s, "extrude", map[string]any{"sketchIndex": 1, "distance": "5 mm", "operation": "new"}); err != nil {
+		t.Fatalf("solid extrude: %v", err)
+	}
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	if got := def.SurfaceBodies().Count(); got != 2 {
+		t.Fatalf("want 2 bodies (sheet + solid), got %d", got)
+	}
+	var sheets, solids int
+	for _, b := range def.SurfaceBodies().All() {
+		if b.IsSolid() {
+			solids++
+		} else {
+			sheets++
+		}
+	}
+	if sheets != 1 || solids != 1 {
+		t.Errorf("want 1 sheet + 1 solid, got %d sheet(s) + %d solid(s)", sheets, solids)
+	}
+}
+
+// TestExtrudeUnknownOperationErrors: an unknown operation name is still a clean error after
+// adding "surface" (guards the parseOperation switch's default).
+func TestExtrudeUnknownOperationErrors(t *testing.T) {
+	s := profiledPart(t)
+	if _, err := applyMap(t, s, "extrude", map[string]any{"sketchIndex": 0, "distance": "5 mm", "operation": "bogus"}); err == nil {
+		t.Error("unknown operation should error")
+	}
+}

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -22,6 +22,11 @@ const (
 	Intersect
 	// NewBody creates a separate body rather than combining.
 	NewBody
+	// Surface is NOT a boolean: it is Inventor's kSurfaceOperation. The feature builds an
+	// open sheet (surface) body — walls only, uncapped, non-solid — added alongside existing
+	// bodies with no boolean. Features must short-circuit on Surface before reaching Boolean;
+	// it never maps to a B-rep boolean (see toBrepOp). #1858.
+	Surface
 )
 
 // String returns a stable name for diagnostics.
@@ -33,6 +38,8 @@ func (op PartFeatureOperation) String() string {
 		return "cut"
 	case Intersect:
 		return "intersect"
+	case Surface:
+		return "surface"
 	default:
 		return "new-body"
 	}
@@ -296,8 +303,8 @@ func volumeOutOfBracket(op PartFeatureOperation, targetVol, toolVol, bodyVol, to
 // cheaply, while a huge body's CSG attempt is costly and seldom valid.
 const csgFallbackFaceLimit = 256
 
-// toBrepOp maps the feature-level operation to the B-rep boolean operation (NewBody has no
-// B-rep analogue — it is handled before this point).
+// toBrepOp maps the feature-level operation to the B-rep boolean operation (NewBody and
+// Surface have no B-rep analogue — both are handled before this point).
 func toBrepOp(op PartFeatureOperation) (brep.Op, bool) {
 	switch op {
 	case Join:

--- a/model/feature/extrude.go
+++ b/model/feature/extrude.go
@@ -4,6 +4,7 @@ package feature
 
 import (
 	"errors"
+	"fmt"
 	stdmath "math"
 
 	"oblikovati.org/kernel/brep"
@@ -104,6 +105,11 @@ func (e *ExtrudeFeature) Recompute(in Input) (Output, error) {
 // prisms into one body. The regions are distinct cells of the same sketch, so they never
 // overlap — a shell merge is exactly their union and avoids the intersecting Join.
 func (e *ExtrudeFeature) buildTool(profiles []*sketch.Profile, plane sketch.Plane, sp span, rec *diag.Recorder) *topo.Body {
+	// Surface (kSurfaceOperation): extrude the profile walls only — an open, uncapped sheet
+	// body — rather than a capped solid prism. #1858.
+	if e.def.Operation == ops.Surface {
+		return buildProfileSheets(profiles, plane, sp, e.def.Taper, e.featName, rec)
+	}
 	return buildProfilePrisms(profiles, plane, sp, e.def.Taper, e.featName, rec)
 }
 
@@ -186,7 +192,10 @@ func NewExtrudeFeature(def *ExtrudeDefinition) *ExtrudeFeature { return &Extrude
 // quality signal instead of shipping a silently faceted body (#1601).
 func combine(in Input, body *topo.Body, op ops.PartFeatureOperation) ([]*topo.Body, error) {
 	running := in.Bodies
-	if len(running) == 0 || op == ops.NewBody {
+	// Surface (kSurfaceOperation) and NewBody both skip the boolean: the tool body is added
+	// alongside the running bodies untouched. For Surface the tool is already an open sheet
+	// (buildTool built it uncapped/non-solid); it joins the model as a surface body. #1858.
+	if len(running) == 0 || op == ops.NewBody || op == ops.Surface {
 		return append(append([]*topo.Body(nil), running...), body), nil
 	}
 	target := running[len(running)-1]
@@ -235,6 +244,17 @@ func appendCombined(running []*topo.Body, res *topo.Body) []*topo.Body {
 // draft outward (positive) or inward (negative); the far cap stays perpendicular to the
 // normal, and each side stays a planar trapezoid.
 func buildPrism(poly []math.Point2, plane sketch.Plane, sp span, taper float64, feat string) *topo.Body {
+	return buildExtrusionShell(poly, plane, sp, taper, feat, true)
+}
+
+// buildExtrusionShell extrudes a closed polygon over the span (near→far offsets along the plane
+// normal). With caps=true it is a watertight SOLID prism: a near cap, a far cap, and one planar
+// side face per profile edge. With caps=false it is an OPEN, non-solid wall SHEET — the side
+// faces only, no caps — Inventor's Surface-operation extrude (kSurfaceOperation, #1858). A
+// non-zero taper offsets the far loop by depth·tan(taper) so the sides draft outward (positive)
+// or inward (negative); the far cap (when present) stays perpendicular to the normal, and each
+// side stays a planar trapezoid.
+func buildExtrusionShell(poly []math.Point2, plane sketch.Plane, sp span, taper float64, feat string, caps bool) *topo.Body {
 	// Normalise the cross-section to CCW: a CW input (a chamfer wedge whose edge frame happens to
 	// wind that way) previously produced a topologically INSIDE-OUT prism — outward face normals
 	// with loops traversed clockwise about them — which the orientation-faithful winding
@@ -247,7 +267,7 @@ func buildPrism(poly []math.Point2, plane sketch.Plane, sp span, taper float64, 
 	n := len(poly)
 	normal := plane.Normal().AsVector()
 	topPoly := taperedLoop(poly, sp.depth(), taper)
-	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok(feat, "body", 0)))
+	bld := topo.NewBuilder(caps, topo.NewLineage(topo.Tok(feat, "body", 0)))
 	bottom := make([]*topo.Vertex, n)
 	top := make([]*topo.Vertex, n)
 	for i := 0; i < n; i++ {
@@ -257,9 +277,43 @@ func buildPrism(poly []math.Point2, plane sketch.Plane, sp span, taper float64, 
 		top[i] = bld.AddVertex(t, topo.NewLineage(topo.Tok(feat, "vertex", n+i)))
 	}
 	be, te, ve := prismEdges(bld, bottom, top, feat)
-	addCaps(bld, bottom, top, be, te, normal, feat)
+	if caps {
+		addCaps(bld, bottom, top, be, te, normal, feat)
+	}
 	addSides(bld, bottom, top, be, te, ve, outwardSign(poly), feat)
 	return bld.Build()
+}
+
+// buildProfileSheets extrudes each selected profile into an open wall sheet (no caps), merging
+// them into one non-solid surface body — the tool for an extrude with the Surface operation
+// (kSurfaceOperation, #1858). There is no boolean; combine() adds the result as a surface body.
+func buildProfileSheets(profiles []*sketch.Profile, plane sketch.Plane, sp span, taper float64, feat string, _ *diag.Recorder) *topo.Body {
+	sheets := make([]*topo.Body, 0, len(profiles))
+	for i, p := range profiles {
+		name := feat
+		if len(profiles) > 1 {
+			name = fmt.Sprintf("%s/p%d", feat, i)
+		}
+		sheets = append(sheets, buildProfileSheet(p, plane, sp, taper, name))
+	}
+	if len(sheets) == 1 {
+		return sheets[0]
+	}
+	return topo.MergeBodies(topo.NewLineage(topo.Tok(feat, "merged", 0)), false, sheets...)
+}
+
+// buildProfileSheet builds one profile's open wall sheet: the outer loop plus each inner loop,
+// each as an uncapped tube, merged into a single non-solid body. Inner (hole) loops become their
+// own open tubes rather than being booleaned out (there is no solid to cut). #1858.
+func buildProfileSheet(p *sketch.Profile, plane sketch.Plane, sp span, taper float64, feat string) *topo.Body {
+	walls := []*topo.Body{buildExtrusionShell(p.OuterLoop().Polygon(), plane, sp, taper, feat, false)}
+	for j, loop := range p.InnerLoops() {
+		walls = append(walls, buildExtrusionShell(loop.Polygon(), plane, sp, taper, fmt.Sprintf("%s/hole%d", feat, j), false))
+	}
+	if len(walls) == 1 {
+		return walls[0]
+	}
+	return topo.MergeBodies(topo.NewLineage(topo.Tok(feat, "sheet", 0)), false, walls...)
 }
 
 // reversePoly returns the polygon with its winding reversed.

--- a/model/feature/extrude_surface_test.go
+++ b/model/feature/extrude_surface_test.go
@@ -5,7 +5,9 @@ package feature
 import (
 	"testing"
 
+	"oblikovati.org/kernel/ops"
 	"oblikovati.org/math"
+	"oblikovati.org/model/param"
 	"oblikovati.org/model/sketch"
 )
 
@@ -29,4 +31,75 @@ func TestBuildExtrusionShellSheetIsOpen(t *testing.T) {
 	if !solid.IsSolid() || len(solid.Faces()) != 6 {
 		t.Errorf("caps-on shell = solid?%v with %d faces, want a solid with 6", solid.IsSolid(), len(solid.Faces()))
 	}
+}
+
+// TestSurfaceExtrudeRingHasInnerAndOuterWalls drives a Surface-operation extrude of an annular
+// profile (a square with a square hole) through the feature engine: the open sheet is the ring's
+// 4 outer walls plus its 4 inner-loop walls — 8 side faces, no caps, non-solid. Exercises the
+// inner-loop tube of the sheet builder (#1858).
+func TestSurfaceExtrudeRingHasInnerAndOuterWalls(t *testing.T) {
+	fs := NewPartFeatures(param.NewParameters())
+	const side, hole, height = 4.0, 2.0, 3.0
+	sk := squareWithHoleSketch(side, hole)
+	ring := -1
+	for i := 0; i < sk.Profiles().Count(); i++ {
+		if len(sk.Profiles().Item(i).InnerLoops()) > 0 {
+			ring = i
+		}
+	}
+	if ring < 0 {
+		t.Fatal("no annular profile detected")
+	}
+	NewExtrudeFeatures(fs).AddExtrude(sk, []int{ring}, ops.Surface,
+		Extent{Type: DistanceExtent, Distance: func() float64 { return height }}, 0)
+	fs.Recompute()
+
+	bodies := fs.Result()
+	if len(bodies) != 1 || bodies[0].IsSolid() {
+		t.Fatalf("surface ring extrude = %d bodies (solid=%v), want 1 open sheet", len(bodies), len(bodies) == 1 && bodies[0].IsSolid())
+	}
+	if got := len(bodies[0].Faces()); got != 8 {
+		t.Errorf("ring sheet has %d faces, want 8 (4 outer + 4 inner walls, no caps)", got)
+	}
+}
+
+// TestSurfaceExtrudeMergesMultipleProfiles drives a Surface-operation extrude of TWO disjoint
+// square regions in one sketch: the open sheet merges both tubes (4 + 4 = 8 walls, no caps,
+// non-solid). Exercises the multi-profile merge of buildProfileSheets (#1858).
+func TestSurfaceExtrudeMergesMultipleProfiles(t *testing.T) {
+	fs := NewPartFeatures(param.NewParameters())
+	sk := twoSquaresSketch(2, 3) // two 2×2 squares, gap 3
+	if sk.Profiles().Count() != 2 {
+		t.Fatalf("two-squares sketch has %d regions, want 2", sk.Profiles().Count())
+	}
+	NewExtrudeFeatures(fs).AddExtrude(sk, []int{0, 1}, ops.Surface,
+		Extent{Type: DistanceExtent, Distance: func() float64 { return 3 }}, 0)
+	fs.Recompute()
+
+	bodies := fs.Result()
+	if len(bodies) != 1 || bodies[0].IsSolid() {
+		t.Fatalf("two-profile surface extrude = %d bodies (solid=%v), want 1 open sheet", len(bodies), len(bodies) == 1 && bodies[0].IsSolid())
+	}
+	if got := len(bodies[0].Faces()); got != 8 {
+		t.Errorf("merged sheet has %d faces, want 8 (two 4-wall tubes)", got)
+	}
+}
+
+// twoSquaresSketch draws two disjoint side×side squares separated by gap along +X, giving two
+// independent closed regions in one sketch.
+func twoSquaresSketch(side, gap float64) *sketch.Sketch {
+	s := sketch.NewSketches().Add(sketch.XYPlane())
+	addSquareAt := func(x0 float64) {
+		p0 := s.Points().Add(math.P2(x0, 0))
+		p1 := s.Points().Add(math.P2(x0+side, 0))
+		p2 := s.Points().Add(math.P2(x0+side, side))
+		p3 := s.Points().Add(math.P2(x0, side))
+		s.Lines().Add(p0, p1)
+		s.Lines().Add(p1, p2)
+		s.Lines().Add(p2, p3)
+		s.Lines().Add(p3, p0)
+	}
+	addSquareAt(0)
+	addSquareAt(side + gap)
+	return s
 }

--- a/model/feature/extrude_surface_test.go
+++ b/model/feature/extrude_surface_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// TestBuildExtrusionShellSheetIsOpen: with caps=false buildExtrusionShell builds an OPEN,
+// non-solid wall sheet — the four side walls of a 2×2 square, no start/end caps — the tool for a
+// Surface-operation extrude (Inventor kSurfaceOperation, #1858). The same profile with caps=true
+// is the pre-existing closed solid prism (6 faces), proving the refactor left the solid path
+// intact.
+func TestBuildExtrusionShellSheetIsOpen(t *testing.T) {
+	poly := []math.Point2{{X: 0, Y: 0}, {X: 2, Y: 0}, {X: 2, Y: 2}, {X: 0, Y: 2}}
+
+	sheet := buildExtrusionShell(poly, sketch.XYPlane(), span{near: 0, far: 3}, 0, "s", false)
+	if sheet.IsSolid() {
+		t.Error("caps-off shell is solid, want an open sheet")
+	}
+	if got := len(sheet.Faces()); got != 4 {
+		t.Errorf("sheet has %d faces, want 4 walls (no caps)", got)
+	}
+
+	solid := buildExtrusionShell(poly, sketch.XYPlane(), span{near: 0, far: 3}, 0, "s", true)
+	if !solid.IsSolid() || len(solid.Faces()) != 6 {
+		t.Errorf("caps-on shell = solid?%v with %d faces, want a solid with 6", solid.IsSolid(), len(solid.Faces()))
+	}
+}


### PR DESCRIPTION
Part of the M33 parity milestone (#44). Delivers the **keystone** surface-operation gap for **extrude**.

## What
`operation: "surface"` on the extrude tool now builds the profile walls as an **open, uncapped, non-solid sheet body** — Inventor's `PartFeatureOperationEnum.kSurfaceOperation` — added alongside existing bodies with **no boolean**. This is the entry point of the surfacing workflow (later thickened/stitched/trimmed).

## How
- **kernel/ops**: new `Surface` member on `PartFeatureOperation`. It is *not* a boolean — `toBrepOp` has no analogue and features short-circuit before `Boolean`.
- **model/feature**: `combine` treats `Surface` like `NewBody` (append, no boolean). Extrude's `buildTool` builds a walls-only sheet via `buildExtrusionShell(caps=false)`, a refactor of `buildPrism` that leaves the solid path byte-for-byte identical. Inner (hole) loops become their own open tubes.
- **addin/opregistry**: extrude schema `operation` enum + `parseOperation` accept `"surface"`.

Host-only — the wire `operation` field is already a free string, so no `Oblikovati.API` change.

## Tests
- End-to-end registry: healthy open sheet, 4 walls / no caps, non-solid, coexists with a solid body.
- Model-level builder unit: caps-off (open, 4 faces) vs caps-on (solid, 6 faces).
- Full `kernel/ops` + `model/feature` + `addin/opregistry` suites green (no regression from the `buildPrism` refactor).

## Scope / follow-up
Extrude only. Revolve/loft/sweep/coil surface output flow through the mesh/skin builder (`sweptSolid`), which needs a boundary-sweep / caps-off variant **with tessellation regression tests** — tracked as follow-ups on #1858. They are deliberately **not** added to their schemas yet, to avoid a silent no-op (accepting `"surface"` but emitting a solid).

Refs #1858.

🤖 Generated with [Claude Code](https://claude.com/claude-code)