### PR TITLE
feat(parameters): reachable text/boolean/model creation + rename (#1845, #1847)

### DIFF
--- a/addin/router/parameters.go
+++ b/addin/router/parameters.go
@@ -4,6 +4,9 @@ package router
 
 import (
 	"errors"
+	"fmt"
+	"strconv"
+	"strings"
 
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
@@ -17,12 +20,25 @@ import (
 func paramInfo(holder compdef.ParameterHolder, p *param.Parameter) wire.ParameterInfo {
 	info := wire.ParameterInfo{
 		Name: p.Name(), Kind: p.Kind().String(),
-		Expression: p.Expression(), Value: holder.Units().Format(p.Value()),
+		Expression: p.Expression(), Value: formatParamValue(holder, p),
 	}
 	if h := p.Health(); !h.OK() {
 		info.Health = h.Reason
 	}
 	return info
+}
+
+// formatParamValue renders a parameter's evaluated value for the wire: the literal string for a
+// text parameter, "true"/"false" for a boolean, and the unit-formatted quantity otherwise (#1845).
+func formatParamValue(holder compdef.ParameterHolder, p *param.Parameter) string {
+	switch {
+	case p.IsText():
+		return p.Text()
+	case p.IsBoolean():
+		return strconv.FormatBool(p.Bool())
+	default:
+		return holder.Units().Format(p.Value())
+	}
 }
 
 // listParameters returns the active part's or assembly's parameters.
@@ -44,16 +60,61 @@ func getParameter(_ *app.Session, holder compdef.ParameterHolder, in wire.Parame
 	return paramInfo(holder, p), nil
 }
 
-// addParameter adds a new user parameter from name + expression (e.g. "4 cm").
+// addParameter adds a new parameter. ValueType selects numeric (default) / text / boolean and
+// Kind selects the user (default) / model table — Inventor's non-numeric and model-parameter
+// creation (#1845). A numeric parameter takes a unit-bearing expression (e.g. "4 cm").
 func addParameter(_ *app.Session, holder compdef.ParameterHolder, in wire.ParameterSetArgs) (wire.ParameterInfo, error) {
-	if err := requireNameExpr(in); err != nil {
-		return wire.ParameterInfo{}, err
-	}
-	p, err := holder.Parameters().AddUserParameter(in.Name, in.Expression)
+	p, err := addParameterOfKind(holder, in)
 	if err != nil {
 		return wire.ParameterInfo{}, err
 	}
 	return paramInfo(holder, p), nil
+}
+
+// addParameterOfKind dispatches to the model's typed creators from the wire ValueType/Kind
+// discriminators. Text values may be empty; boolean values parse "true"/"false". #1845.
+func addParameterOfKind(holder compdef.ParameterHolder, in wire.ParameterSetArgs) (*param.Parameter, error) {
+	if in.Name == "" {
+		return nil, errors.New("parameters: name is required")
+	}
+	switch strings.ToLower(strings.TrimSpace(in.ValueType)) {
+	case "", "numeric":
+		if in.Expression == "" {
+			return nil, errors.New("parameters: expression is required for a numeric parameter")
+		}
+		if strings.EqualFold(strings.TrimSpace(in.Kind), "model") {
+			return holder.Parameters().AddModelParameter(in.Name, in.Expression)
+		}
+		return holder.Parameters().AddUserParameter(in.Name, in.Expression)
+	case "text":
+		return holder.Parameters().AddTextUserParameter(in.Name, in.Expression)
+	case "boolean", "bool":
+		b, err := strconv.ParseBool(strings.TrimSpace(in.Expression))
+		if err != nil {
+			return nil, fmt.Errorf("parameters: boolean parameter %q needs expression \"true\" or \"false\", got %q", in.Name, in.Expression)
+		}
+		return holder.Parameters().AddBooleanUserParameter(in.Name, b)
+	default:
+		return nil, fmt.Errorf("parameters: unknown valueType %q (want numeric|text|boolean)", in.ValueType)
+	}
+}
+
+// renameParameter renames a parameter, keeping its identity so dependent expressions stay bound
+// and are rewritten to the new name (#1847).
+func renameParameter(s *app.Session, holder compdef.ParameterHolder, in wire.ParameterRenameArgs) (wire.ParameterInfo, error) {
+	if in.Name == "" || in.NewName == "" {
+		return wire.ParameterInfo{}, errors.New("parameters.rename: name and newName are required")
+	}
+	p, ok := holder.Parameters().ByName(in.Name)
+	if !ok {
+		return wire.ParameterInfo{}, errors.New("parameters.rename: no parameter named " + in.Name)
+	}
+	if err := holder.Parameters().Rename(p.ID(), in.NewName); err != nil {
+		return wire.ParameterInfo{}, err
+	}
+	info := paramInfo(holder, p)
+	emitParameterChanged(s, info) // #148: relay the rename to subscribing add-ins
+	return info, nil
 }
 
 // setParameter changes an existing parameter's expression and recomputes so any

--- a/addin/router/parameters_create_rename_test.go
+++ b/addin/router/parameters_create_rename_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+)
+
+// wantErr asserts that a wire method call fails (the router surfaces model rejections as errors).
+func wantErr(t *testing.T, r *Router, s *app.Session, method, args string) {
+	t.Helper()
+	if _, err := r.Handle(s, method, []byte(args)); err == nil {
+		t.Errorf("%s(%s): want an error, got success", method, args)
+	}
+}
+
+// Non-numeric and model-kind parameter creation (#1845) and parameter rename (#1847) over the
+// wire — the previously-unreachable model capability (AddTextUserParameter /
+// AddBooleanUserParameter / AddModelParameter / Parameters.Rename).
+
+// TestAddTextParameter creates a text user parameter: the literal string is the value, no units.
+func TestAddTextParameter(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "parameters.add", `{"name":"finish","valueType":"text","expression":"anodized"}`, nil)
+	d := getDetail(t, r, s, "finish")
+	if d.Kind == "" || d.Value != "anodized" {
+		t.Fatalf("text param = kind=%q value=%q, want a text value \"anodized\"", d.Kind, d.Value)
+	}
+	if d.Tolerance != nil {
+		t.Errorf("text parameter should carry no tolerance, got %+v", d.Tolerance)
+	}
+}
+
+// TestAddBooleanParameter creates a true/false user parameter from "true"/"false".
+func TestAddBooleanParameter(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "parameters.add", `{"name":"vented","valueType":"boolean","expression":"true"}`, nil)
+	if d := getDetail(t, r, s, "vented"); d.Value != "true" && d.Value != "True" {
+		t.Fatalf("boolean param value = %q, want true", d.Value)
+	}
+}
+
+// TestAddBooleanParameterRejectsNonBool: a non-boolean expression is a clean error.
+func TestAddBooleanParameterRejectsNonBool(t *testing.T) {
+	r, s := seededSession(t)
+	wantErr(t, r, s, "parameters.add", `{"name":"bad","valueType":"boolean","expression":"3 cm"}`)
+}
+
+// TestAddModelParameter creates a numeric parameter in the MODEL table (Kind=model).
+func TestAddModelParameter(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "parameters.add", `{"name":"depth","kind":"model","expression":"5 mm"}`, nil)
+	if d := getDetail(t, r, s, "depth"); d.Kind == "" {
+		t.Fatalf("model param not created: %+v", d.ParameterInfo)
+	}
+}
+
+// TestAddParameterUnknownValueType: an unknown valueType is a clean error.
+func TestAddParameterUnknownValueType(t *testing.T) {
+	r, s := seededSession(t)
+	wantErr(t, r, s, "parameters.add", `{"name":"x","valueType":"vector","expression":"1"}`)
+}
+
+// TestRenameParameterRewritesDependents renames a driving parameter and confirms its identity is
+// kept and a dependent expression is rewritten to the new name (#1847).
+func TestRenameParameterRewritesDependents(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "parameters.add", `{"name":"half","expression":"width / 2"}`, nil)
+	call(t, r, s, "parameters.rename", `{"name":"width","newName":"span"}`, nil)
+
+	if d := getDetail(t, r, s, "span"); d.Name != "span" || d.Expression != "4 cm" {
+		t.Fatalf("renamed param = %+v, want span / 4 cm", d.ParameterInfo)
+	}
+	if d := getDetail(t, r, s, "half"); d.Expression != "span / 2" {
+		t.Errorf("dependent expression = %q, want it rewritten to \"span / 2\"", d.Expression)
+	}
+}
+
+// TestRenameParameterClashRejected: renaming onto an existing name is refused.
+func TestRenameParameterClashRejected(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "parameters.add", `{"name":"height","expression":"2 cm"}`, nil)
+	wantErr(t, r, s, "parameters.rename", `{"name":"height","newName":"width"}`)
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -181,6 +181,7 @@ func (r *Router) registerStandardHandlers() {
 	r.readOnly(wire.MethodParametersGet, typedHolder(getParameter))
 	r.mutating(wire.MethodParametersAdd, labelEditParameters, typedHolder(addParameter))
 	r.mutating(wire.MethodParametersSet, labelEditParameters, typedHolder(setParameter))
+	r.mutating(wire.MethodParametersRename, labelEditParameters, typedHolder(renameParameter))
 	r.registerParameterDetailHandlers()
 	r.readOnly(wire.MethodModelTree, partQuery(modelTree))
 	r.readOnly(wire.MethodModelSelection, modelSelection)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.114.0
+	oblikovati.org/api v0.115.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.114.0
+	oblikovati.org/api v0.115.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)


### PR DESCRIPTION
Two Parameters parity gaps from the M33 audit (#44), wiring previously-unreachable model capability. Pins the contract from Oblikovati.API#240 (v0.115.0).

## #1845 — non-numeric & model-kind creation
`add_parameter` now dispatches on `valueType` (`numeric` default / `text` / `boolean`) and `kind` (`user` default / `model`) to the model's existing `AddUserParameter` / `AddTextUserParameter` / `AddBooleanUserParameter` / `AddModelParameter`. Also fixes `paramInfo` to format a text parameter's literal string and a boolean's `true`/`false` (was numeric-only — text read `"0"`, boolean `"1"`).

## #1847 — rename
New `parameters.rename` handler resolves the parameter by name and calls `Parameters.Rename`, keeping identity and rewriting dependent expressions (`half = width/2` → `half = span/2` when `width`→`span`).

## Tests
`addin/router/parameters_create_rename_test.go`: text/boolean/model creation, boolean-parse and unknown-valueType errors, rename-rewrites-dependents, rename-clash-rejected. Full `addin/router` suite green.

Closes #1845, closes #1847.

🤖 Generated with [Claude Code](https://claude.com/claude-code)