### PR TITLE
feat(opregistry): draft neutral plane, coil end conditions, hole drill point (#1866, #1883, #1863)

### DIFF
--- a/addin/opregistry/draft_coil_hole_unreachable_test.go
+++ b/addin/opregistry/draft_coil_hole_unreachable_test.go
@@ -49,6 +49,77 @@ func TestDraftNeutralPlaneBadRef(t *testing.T) {
 	}
 }
 
+// TestDraftNeutralPlanePullDirection: a neutral-plane draft accepts an explicit pull direction
+// (the override branch), overriding the plane-normal default. #1866.
+func TestDraftNeutralPlanePullDirection(t *testing.T) {
+	s, _, _ := extrudedSolid(t)
+	if _, err := applyMap(t, s, "draft", map[string]any{
+		"faceRefs": []string{sideFaceKey(t, s)}, "angle": "3 deg",
+		"neutralPlane": "origin/plane/xy", "pullDirection": []float64{0, 0, 1},
+	}); err != nil {
+		t.Fatalf("neutral-plane draft with pullDirection: %v", err)
+	}
+}
+
+// TestDraftNeutralPlaneBadPullDirection: a malformed pull direction on a neutral-plane draft is a
+// clean error (a 2-component vector cannot be a [dx,dy,dz]).
+func TestDraftNeutralPlaneBadPullDirection(t *testing.T) {
+	s, _, face := extrudedSolid(t)
+	if _, err := applyMap(t, s, "draft", map[string]any{
+		"faceRefs": []string{face}, "angle": "3 deg",
+		"neutralPlane": "origin/plane/xy", "pullDirection": []float64{0, 1},
+	}); err == nil {
+		t.Error("a 2-component pullDirection should error")
+	}
+}
+
+// TestHoleDrillPointErrors: an unknown drillPoint value and an angled point with an unparseable
+// tipAngle are both clean errors, not silent successes. #1863.
+func TestHoleDrillPointErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		extra map[string]any
+	}{
+		{"unknown drillPoint", map[string]any{"drillPoint": "banana"}},
+		{"angled bad tipAngle", map[string]any{"drillPoint": "angled", "tipAngle": "banana"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, _, face := extrudedSolid(t)
+			args := map[string]any{"faceRef": face, "diameter": "4 mm", "depth": "5 mm"}
+			for k, v := range tc.extra {
+				args[k] = v
+			}
+			if _, err := applyMap(t, s, "hole", args); err == nil {
+				t.Errorf("%s should error", tc.name)
+			}
+		})
+	}
+}
+
+// TestCoilEndConditionErrors: an unparseable transition or flat angle on either spring end is a
+// clean error. #1883.
+func TestCoilEndConditionErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		extra map[string]any
+	}{
+		{"bad startTransitionAngle", map[string]any{"startTransitionAngle": "banana"}},
+		{"bad startFlatAngle", map[string]any{"startFlatAngle": "banana"}},
+		{"bad endTransitionAngle", map[string]any{"endTransitionAngle": "banana"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := profiledPart(t)
+			args := map[string]any{"sketchIndex": 0, "pitch": "5 mm", "revolutions": "3"}
+			for k, v := range tc.extra {
+				args[k] = v
+			}
+			if _, err := applyMap(t, s, "coil", args); err == nil {
+				t.Errorf("%s should error", tc.name)
+			}
+		})
+	}
+}
+
 // TestCoilEndConditions: start/end transition + flat sweeps are accepted and build a healthy coil
 // with more geometry (the flat/transition turns) than the plain helix (#1883).
 func TestCoilEndConditions(t *testing.T) {

--- a/addin/opregistry/draft_coil_hole_unreachable_test.go
+++ b/addin/opregistry/draft_coil_hole_unreachable_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/kernel/topo"
+)
+
+// Unreachable-API quick-wins from the M33 audit: draft neutral plane (#1866), coil end conditions
+// (#1883) and hole angled drill point (#1863) — wiring model capability that had no authoring
+// surface.
+
+// sideFaceKey returns the reference key of a vertical side face (normal ⟂ Z) of the active body —
+// one that actually meets the XY neutral plane in a line (a face parallel to it would not draft).
+func sideFaceKey(t *testing.T, s *app.Session) string {
+	t.Helper()
+	for _, f := range activePartBody(t, s).Faces() {
+		if n := topo.DescribeFace(f).Normal; math.Abs(n.Z) < 0.5 {
+			return string(f.ReferenceKey())
+		}
+	}
+	t.Fatal("no vertical side face found")
+	return ""
+}
+
+// TestDraftNeutralPlane: a fixed-plane draft about origin/plane/xy is accepted and healthy — the
+// faces pivot on their intersection with the neutral plane (#1866).
+func TestDraftNeutralPlane(t *testing.T) {
+	s, _, _ := extrudedSolid(t)
+	if _, err := applyMap(t, s, "draft", map[string]any{
+		"faceRefs": []string{sideFaceKey(t, s)}, "angle": "3 deg", "neutralPlane": "origin/plane/xy",
+	}); err != nil {
+		t.Fatalf("neutral-plane draft: %v", err)
+	}
+}
+
+// TestDraftNeutralPlaneBadRef: an unresolvable neutralPlane is a clean error.
+func TestDraftNeutralPlaneBadRef(t *testing.T) {
+	s, _, face := extrudedSolid(t)
+	if _, err := applyMap(t, s, "draft", map[string]any{
+		"faceRefs": []string{face}, "angle": "3 deg", "neutralPlane": "origin/plane/nope",
+	}); err == nil {
+		t.Error("bad neutralPlane ref should error")
+	}
+}
+
+// TestCoilEndConditions: start/end transition + flat sweeps are accepted and build a healthy coil
+// with more geometry (the flat/transition turns) than the plain helix (#1883).
+func TestCoilEndConditions(t *testing.T) {
+	plain := coilVolume(t, nil)
+	ground := coilVolume(t, map[string]any{
+		"startTransitionAngle": "90 deg", "startFlatAngle": "180 deg",
+		"endTransitionAngle": "90 deg", "endFlatAngle": "180 deg",
+	})
+	if ground <= plain {
+		t.Errorf("ground-ended coil volume %g should exceed plain %g (added flat/transition turns)", ground, plain)
+	}
+}
+
+func coilVolume(t *testing.T, extra map[string]any) float64 {
+	t.Helper()
+	s := profiledPart(t)
+	args := map[string]any{"sketchIndex": 0, "pitch": "5 mm", "revolutions": "3"}
+	for k, v := range extra {
+		args[k] = v
+	}
+	raw, err := applyMap(t, s, "coil", args)
+	if err != nil {
+		t.Fatalf("coil %v: %v", extra, err)
+	}
+	var res struct {
+		Healthy bool `json:"healthy"`
+	}
+	if err := json.Unmarshal(raw, &res); err != nil || !res.Healthy {
+		t.Fatalf("coil %v not healthy: %s", extra, raw)
+	}
+	return bodyVolume(t, s)
+}
+
+// TestHoleAngledDrillPointChangesVolume: an angled drill point produces a different blind-hole
+// volume than a flat bottom — proving drillPoint/tipAngle reach the model's PointAngle (#1863).
+func TestHoleAngledDrillPointChangesVolume(t *testing.T) {
+	vFlat := blindHoleVolume(t, nil)
+	vAngled := blindHoleVolume(t, map[string]any{"drillPoint": "angled"})
+	if math.Abs(vAngled-vFlat) < 1e-6*vFlat {
+		t.Errorf("angled drill-point volume %g == flat %g; drillPoint did not take effect", vAngled, vFlat)
+	}
+}
+
+func blindHoleVolume(t *testing.T, extra map[string]any) float64 {
+	t.Helper()
+	s, _, face := extrudedSolid(t)
+	args := map[string]any{"faceRef": face, "diameter": "4 mm", "depth": "5 mm"}
+	for k, v := range extra {
+		args[k] = v
+	}
+	if _, err := applyMap(t, s, "hole", args); err != nil {
+		t.Fatalf("drill hole %v: %v", extra, err)
+	}
+	return bodyVolume(t, s)
+}

--- a/addin/opregistry/dressup.go
+++ b/addin/opregistry/dressup.go
@@ -6,10 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"oblikovati.org/api/types"
 	"oblikovati.org/api/wire/featureargs"
 	"oblikovati.org/app"
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
 )
@@ -439,7 +441,8 @@ const draftSchema = `{
     "faceRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Reference keys of the faces to draft (from get_reference_keys)."},
     "angle": {"type": "string", "description": "Draft angle with units, e.g. \"3 deg\"."},
     "pullDirection": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Explicit pull/parting direction [dx,dy,dz] (only its orientation matters). Omit to let the host infer it from the neutral faces."},
-    "facesGeom": {"type": "array", "description": "Select the drafted faces by GEOMETRY instead of faceRefs, so the binding survives recompute. Give either this or faceRefs.", "items": {"type": "object", "properties": {"centroid": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Face centroid [x,y,z] cm."}, "normal": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Outward unit normal [x,y,z]."}}, "required": ["centroid", "normal"]}}
+    "facesGeom": {"type": "array", "description": "Select the drafted faces by GEOMETRY instead of faceRefs, so the binding survives recompute. Give either this or faceRefs.", "items": {"type": "object", "properties": {"centroid": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Face centroid [x,y,z] cm."}, "normal": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Outward unit normal [x,y,z]."}}, "required": ["centroid", "normal"]}},
+    "neutralPlane": {"type": "string", "description": "Fixed-plane draft: a planar face key, work plane (\"plane/N\"), or origin plane (\"origin/plane/xy\"). Faces pivot on their intersection with it (dimensions in the plane preserved); pull defaults to its normal. Inventor's kFixedPlaneFaceDraftDefinitionType."}
   },
   "required": ["angle"]
 }`
@@ -503,18 +506,45 @@ func applyDraft(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	return recomputeResult(part, pf)
 }
 
-// buildDraft adds the draft feature: with an explicit pull direction when pullDirection is given
-// (AddDraftPull), otherwise the host's inferred pull (AddDraft, default +Z).
+// buildDraft adds the draft feature: a fixed-plane (neutral) draft when neutralPlane is given,
+// else an explicit-pull draft (AddDraftPull) when pullDirection is given, else the host's inferred
+// pull (AddDraft, default +Z).
 func buildDraft(part *compdef.PartComponentDefinition, in featureargs.Draft, angle func() float64) (*feature.PartFeature, error) {
 	du := feature.NewDressUpFeatures(part.Features())
+	keys := refKeys(in.FaceRefs)
+	if strings.TrimSpace(in.NeutralPlane) != "" {
+		return buildNeutralDraft(part, du, in, keys, angle)
+	}
 	if len(in.PullDirection) == 0 {
-		return du.AddDraft(refKeys(in.FaceRefs), angle), nil
+		return du.AddDraft(keys, angle), nil
 	}
 	pull, err := vec3(in.PullDirection, "draft: pullDirection")
 	if err != nil {
 		return nil, err
 	}
-	return du.AddDraftPull(refKeys(in.FaceRefs), pull, angle), nil
+	return du.AddDraftPull(keys, pull, angle), nil
+}
+
+// buildNeutralDraft resolves the fixed neutral plane (a planar face key, "plane/N", or origin
+// plane) and drafts the faces pivoting on their intersection with it — Inventor's fixed-plane
+// draft. The pull defaults to the plane normal unless pullDirection overrides it. #1866.
+func buildNeutralDraft(part *compdef.PartComponentDefinition, du *feature.DressUpFeatures, in featureargs.Draft, keys [][]byte, angle func() float64) (*feature.PartFeature, error) {
+	wp, err := part.WorkGeometry().PlaneTargetFromRef(in.NeutralPlane)
+	if err != nil {
+		return nil, fmt.Errorf("draft: neutralPlane %q: %w", in.NeutralPlane, err)
+	}
+	pl := wp.Plane()
+	neutral, err := geom.NewPlane(pl.Origin(), pl.Normal().AsVector())
+	if err != nil {
+		return nil, fmt.Errorf("draft: neutralPlane %q: %w", in.NeutralPlane, err)
+	}
+	pull := pl.Normal().AsVector()
+	if len(in.PullDirection) > 0 {
+		if pull, err = vec3(in.PullDirection, "draft: pullDirection"); err != nil {
+			return nil, err
+		}
+	}
+	return du.AddDraftPullNeutral(keys, pull, &neutral, angle), nil
 }
 
 // --- lip / groove (M20-F10) ------------------------------------------------

--- a/addin/opregistry/feature_solid.go
+++ b/addin/opregistry/feature_solid.go
@@ -208,7 +208,11 @@ const coilSchema = `{
     "revolutions": {"type": "string", "description": "Number of turns, e.g. \"4\"."},
     "height": {"type": "string", "description": "Total axial rise, e.g. \"30 mm\" — combines with pitch OR revolutions."},
     "taper": {"type": "string", "description": "Optional taper angle, e.g. \"5 deg\" — the helix radius grows with height."},
-    "operation": {"type": "string", "enum": ["new", "join", "cut"], "default": "new"}
+    "operation": {"type": "string", "enum": ["new", "join", "cut"], "default": "new"},
+    "startTransitionAngle": {"type": "string", "description": "Spring start-end transition sweep (pitch winds down to zero), e.g. \"90 deg\". Grounds/flattens the coil start."},
+    "startFlatAngle": {"type": "string", "description": "Spring start-end flat sweep (zero pitch) after the transition, e.g. \"180 deg\"."},
+    "endTransitionAngle": {"type": "string", "description": "Spring end transition sweep (pitch winds down to zero), e.g. \"90 deg\"."},
+    "endFlatAngle": {"type": "string", "description": "Spring end flat sweep (zero pitch) after the transition, e.g. \"180 deg\"."}
   },
   "required": ["sketchIndex"]
 }`
@@ -242,13 +246,40 @@ func applyCoil(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
+	startEnd, err := coilEndCondition(part, in.StartTransitionAngle, in.StartFlatAngle, "coil: start")
+	if err != nil {
+		return nil, err
+	}
+	endEnd, err := coilEndCondition(part, in.EndTransitionAngle, in.EndFlatAngle, "coil: end")
+	if err != nil {
+		return nil, err
+	}
 	def := &feature.CoilDefinition{
 		Sketch: sk, ProfileIndex: in.ProfileIndex, Axis: axis,
 		Pitch: pitch, Revolutions: revs, Height: height,
 		Taper: callOrZeroF(taper), Operation: op,
+		StartEnd: startEnd, EndEnd: endEnd,
 	}
 	pf := feature.NewCoilFeatures(part.Features()).AddDefinition(def)
 	return recomputeResult(part, pf)
+}
+
+// coilEndCondition parses one spring end's transition + flat sweep angles into a CoilEndCondition
+// (radians). It is active (Flat) only when at least one angle is given; the transition sweeps the
+// pitch down to zero and the flat sweep then holds zero pitch (a ground spring end). #1883.
+func coilEndCondition(part *compdef.PartComponentDefinition, transition, flat, ctx string) (feature.CoilEndCondition, error) {
+	if transition == "" && flat == "" {
+		return feature.CoilEndCondition{}, nil
+	}
+	tf, err := optionalAngleClosure(part, transition, ctx+": transitionAngle")
+	if err != nil {
+		return feature.CoilEndCondition{}, err
+	}
+	ff, err := optionalAngleClosure(part, flat, ctx+": flatAngle")
+	if err != nil {
+		return feature.CoilEndCondition{}, err
+	}
+	return feature.CoilEndCondition{Flat: true, TransitionAngle: callOrZeroF(tf), FlatAngle: callOrZeroF(ff)}, nil
 }
 
 // callOrZeroF evaluates an optional closure (nil ⇒ 0).

--- a/addin/opregistry/hole.go
+++ b/addin/opregistry/hole.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"oblikovati.org/api/wire/featureargs"
 	"oblikovati.org/app"
@@ -32,7 +33,9 @@ const holeSchema = `{
     "designation": {"type": "string", "description": "Thread designation, e.g. \"M5x0.8\" (type=tapped)."},
     "center": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Explicit drill point [x,y,z] in model-space cm (projected onto the picked face). Omit to drill at the face centroid. Needed to place more than one hole on a face."},
     "centerExpr": {"type": "array", "items": {"type": "string"}, "minItems": 3, "maxItems": 3, "description": "Parameter-expression form of center: [x,y,z] each an expression with units (e.g. \"L/2\"). Overrides center when present."},
-    "placementFaceGeom": {"type": "object", "description": "Select the placement face by GEOMETRY instead of faceRef, so the binding survives recompute (for an external author that cannot mint a stable key). Give either this or faceRef.", "properties": {"centroid": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Face centroid [x,y,z] cm."}, "normal": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Outward unit normal [x,y,z]."}}, "required": ["centroid", "normal"]}
+    "placementFaceGeom": {"type": "object", "description": "Select the placement face by GEOMETRY instead of faceRef, so the binding survives recompute (for an external author that cannot mint a stable key). Give either this or faceRef.", "properties": {"centroid": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Face centroid [x,y,z] cm."}, "normal": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Outward unit normal [x,y,z]."}}, "required": ["centroid", "normal"]},
+    "drillPoint": {"type": "string", "enum": ["flat", "angled"], "default": "flat", "description": "Blind-hole bottom: \"flat\" (disc) or \"angled\" (cone of tipAngle). Inventor's HoleDrillPointTypeEnum."},
+    "tipAngle": {"type": "string", "description": "Included angle of an \"angled\" drill point, e.g. \"118 deg\" (the default when omitted)."}
   },
   "required": ["diameter"]
 }`
@@ -63,7 +66,42 @@ func applyHole(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err := applyHolePlacementGeom(pf, in); err != nil {
 		return nil, err
 	}
+	if err := applyHoleDrillPoint(part, pf, in); err != nil {
+		return nil, err
+	}
 	return recomputeResult(part, pf)
+}
+
+// applyHoleDrillPoint sets a blind hole's conical bottom from drillPoint/tipAngle, wiring the
+// featureargs to the model's HoleDefinition.PointAngle: "flat" (or empty) keeps the flat bottom;
+// "angled" sets the included cone angle, defaulting to the standard 118° twist-drill point. #1863.
+func applyHoleDrillPoint(part *compdef.PartComponentDefinition, pf *feature.PartFeature, in featureargs.Hole) error {
+	switch strings.ToLower(strings.TrimSpace(in.DrillPoint)) {
+	case "", "flat":
+		return nil
+	case "angled":
+		angle, err := holeTipAngle(part, in.TipAngle)
+		if err != nil {
+			return err
+		}
+		hf, ok := pf.Definition().(*feature.HoleFeature)
+		if !ok {
+			return errors.New("hole: drillPoint applies only to a drilled/tapped hole")
+		}
+		hf.Definition().PointAngle = angle
+		return nil
+	default:
+		return fmt.Errorf("hole: unknown drillPoint %q (want flat|angled)", in.DrillPoint)
+	}
+}
+
+// holeTipAngle parses the drill-point included angle, defaulting to 118° (the standard twist-drill
+// point) when omitted. #1863.
+func holeTipAngle(part *compdef.PartComponentDefinition, expr string) (func() float64, error) {
+	if strings.TrimSpace(expr) == "" {
+		expr = "118 deg"
+	}
+	return angleClosure(part, expr, "hole: tipAngle")
 }
 
 // applyHolePlacementGeom binds the hole's placement face by GEOMETRY (centroid + normal) when

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.115.0
+	oblikovati.org/api v0.116.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.116.0
+	oblikovati.org/api v0.115.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.116.0
+	oblikovati.org/api v0.117.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.115.0
+	oblikovati.org/api v0.116.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.116.0
+	oblikovati.org/api v0.117.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)


### PR DESCRIPTION
Wires three "unreachable API" gaps from the M33 audit (#44) to their existing model implementations. Pins the contract from Oblikovati.API#241 (**v0.116.0**).

> ⏳ **CI note:** the go.mod pin (`oblikovati.org/api v0.116.0`) depends on the API release, which is queued behind a congested Actions runner. CI will be red until v0.116.0 publishes; it needs a re-run then. Builds/tests pass locally via `go.work`.

## What
- **Draft `neutralPlane`** (#1866) — a fixed-plane face draft: resolves a plane ref (face key / `plane/N` / `origin/plane/xy`) and drafts via `AddDraftPullNeutral`, faces pivoting on their intersection with it; pull defaults to the plane normal.
- **Coil end conditions** (#1883) — `startTransitionAngle`/`startFlatAngle`/`endTransitionAngle`/`endFlatAngle` set `def.StartEnd`/`EndEnd` (`CoilEndCondition`) for ground/flat spring ends.
- **Hole drill point** (#1863) — `drillPoint:"angled"` + `tipAngle` (default 118°) set `HoleDefinition.PointAngle` for a conical blind bottom.

## Tests
`draft_coil_hole_unreachable_test.go`: neutral-plane draft healthy + bad-ref error; coil end conditions add geometry vs the plain helix; angled drill point changes the blind-hole volume.

## Scope
Advances but does **not** close #1866/#1883/#1863 — their remaining ACs are genuinely new features (parting-line/fixed-edge draft, coil handedness/spiral, hole to-face/from-to termination), not wiring, and stay tracked.

Refs #1866, #1883, #1863.

🤖 Generated with [Claude Code](https://claude.com/claude-code)