### PR TITLE
feat(work-points): plane-axis-intersection create kind (#1842)

### DIFF
--- a/addin/router/work_planes.go
+++ b/addin/router/work_planes.go
@@ -199,22 +199,56 @@ func createWorkPlanes(_ *app.Session, host workHost, in wire.CreateWorkPlaneArgs
 	}, nil
 }
 
-// createWorkPoint adds a datum point fixed at the requested position to the active model and
-// recomputes, returning its index and reference (usable as a point input to a work plane or a
-// redefine re-pick).
+// createWorkPoint adds a datum point of the requested kind (fixed position, or the point where an
+// axis pierces a plane — built by buildWorkPoint) to the active model and recomputes, returning its
+// index, reference (usable as a point input to a work plane or a redefine re-pick), name, and
+// health. A well-formed but unsatisfiable definition (an axis parallel to the plane) still creates
+// the point, reported healthy=false; the call only fails on bad arguments.
 func createWorkPoint(_ *app.Session, host workHost, in wire.CreateWorkPointArgs) (wire.CreateWorkPointResult, error) {
-	at, err := parseCoords(in.At, "workPoints.create: at")
+	wp, err := buildWorkPoint(host, in)
 	if err != nil {
 		return wire.CreateWorkPointResult{}, err
 	}
-	p := math.P3(at[0], at[1], at[2])
-	wp := host.WorkPoints().AddByPosition(func() math.Point3 { return p })
 	host.Recompute()
 	return wire.CreateWorkPointResult{
-		Index: host.WorkPoints().Count() - 1,
-		Ref:   string(wp.Key()),
-		Name:  wp.Name(),
+		Index:   host.WorkPoints().Count() - 1,
+		Ref:     string(wp.Key()),
+		Name:    wp.Name(),
+		Healthy: wp.Health().OK(),
+		Reason:  wp.Health().Reason, // empty when healthy
 	}, nil
+}
+
+// buildWorkPoint dispatches a create request to the matching model constructor. An empty kind is
+// the position constructor, so the original position-only request (just "at") is unchanged.
+func buildWorkPoint(host workHost, in wire.CreateWorkPointArgs) (*feature.WorkPoint, error) {
+	switch types.WorkPointKind(in.Kind) {
+	case "", types.WorkPointPosition:
+		return addPositionPoint(host, in)
+	case types.WorkPointPlaneAxisIntersection:
+		return addPlaneAxisPoint(host, in)
+	default:
+		return nil, fmt.Errorf("workPoints.create: unknown kind %q (see api/types WorkPoint*)", in.Kind)
+	}
+}
+
+// addPositionPoint builds the fixed-position point from its [x, y, z] coordinate.
+func addPositionPoint(host workHost, in wire.CreateWorkPointArgs) (*feature.WorkPoint, error) {
+	at, err := parseCoords(in.At, "workPoints.create: at")
+	if err != nil {
+		return nil, err
+	}
+	p := math.P3(at[0], at[1], at[2])
+	return host.WorkPoints().AddByPosition(func() math.Point3 { return p }), nil
+}
+
+// addPlaneAxisPoint builds the plane∩axis point from exactly two references [plane, axis].
+func addPlaneAxisPoint(host workHost, in wire.CreateWorkPointArgs) (*feature.WorkPoint, error) {
+	refs := toWorkRefs(in.Refs)
+	if len(refs) != 2 {
+		return nil, fmt.Errorf("workPoints.create: plane-axis-intersection needs 2 references [plane, axis], got %d", len(refs))
+	}
+	return host.WorkPoints().AddByPlaneAndAxisIntersection(refs[0], refs[1]), nil
 }
 
 // createWorkAxis adds a datum axis of the requested kind (line / two-points / plane-intersection,

--- a/addin/router/work_points_test.go
+++ b/addin/router/work_points_test.go
@@ -2,11 +2,74 @@
 
 package router
 
-import "testing"
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+)
 
 func TestWorkPointsCreateRejectsBadPosition(t *testing.T) {
 	r, s := emptyPartSession(t)
 	if _, err := r.Handle(s, "workPoints.create", []byte(`{"at":[1,2]}`)); err == nil {
 		t.Error("a 2-component position must error")
 	}
+}
+
+// TestWorkPointsPlaneAxisIntersection: the Z axis pierces the XY plane at the origin. The created
+// point is healthy and lands at (0,0,0) — proving the plane-axis-intersection kind reaches the
+// model's AddByPlaneAndAxisIntersection (#1842).
+func TestWorkPointsPlaneAxisIntersection(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var res wire.CreateWorkPointResult
+	call(t, r, s, "workPoints.create",
+		`{"kind":"plane-axis-intersection","refs":["origin/plane/xy","origin/axis/z"]}`, &res)
+	if !res.Healthy {
+		t.Fatalf("Z∩XY point not healthy: %+v", res)
+	}
+	at := lastWorkPoint(t, s).Point()
+	if math.Abs(float64(at.X)) > 1e-9 || math.Abs(float64(at.Y)) > 1e-9 || math.Abs(float64(at.Z)) > 1e-9 {
+		t.Errorf("Z∩XY point at %v, want the origin", at)
+	}
+}
+
+// TestWorkPointsPlaneAxisParallelIsUnhealthy: an axis parallel to the plane (X axis, XY plane)
+// has no intersection — the point is still created, but reported healthy=false with a reason,
+// not a bare error.
+func TestWorkPointsPlaneAxisParallelIsUnhealthy(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var res wire.CreateWorkPointResult
+	call(t, r, s, "workPoints.create",
+		`{"kind":"plane-axis-intersection","refs":["origin/plane/xy","origin/axis/x"]}`, &res)
+	if res.Healthy || res.Reason == "" {
+		t.Errorf("X∥XY point should be unhealthy with a reason, got %+v", res)
+	}
+}
+
+func TestWorkPointsPlaneAxisWrongReferenceCount(t *testing.T) {
+	r, s := emptyPartSession(t)
+	if _, err := r.Handle(s, "workPoints.create",
+		[]byte(`{"kind":"plane-axis-intersection","refs":["origin/plane/xy"]}`)); err == nil {
+		t.Error("plane-axis-intersection with 1 reference must error")
+	}
+}
+
+func TestWorkPointsCreateUnknownKind(t *testing.T) {
+	r, s := emptyPartSession(t)
+	if _, err := r.Handle(s, "workPoints.create", []byte(`{"kind":"no-such-kind"}`)); err == nil {
+		t.Error("expected error for unknown work-point kind")
+	}
+}
+
+// lastWorkPoint returns the most recently created work point of the active part.
+func lastWorkPoint(t *testing.T, s *app.Session) *feature.WorkPoint {
+	t.Helper()
+	pts := s.ActiveDocument().Content().(*compdef.PartComponentDefinition).WorkPoints()
+	if pts.Count() == 0 {
+		t.Fatal("no work points")
+	}
+	return pts.Item(pts.Count() - 1)
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.115.0
+	oblikovati.org/api v0.117.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.115.0
+	oblikovati.org/api v0.117.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)


### PR DESCRIPTION
Part of milestone #44 (M33 Inventor-API parity), Wave B unreachable quick-wins. Host side of Oblikovati.API#242 (released as v0.117.0).

Wires the datum-point constructor **AddByPlaneAndAxisIntersection** — the point where an axis pierces a plane (Inventor `WorkPoint.AddByPlaneAndLine`). The model already implemented it; `workPoints.create` only exposed the fixed-position constructor.

## Changes
- `createWorkPoint` now dispatches on `WorkPointKind` via `buildWorkPoint` (mirrors `buildWorkAxis`): `addPositionPoint` (default, unchanged) and `addPlaneAxisPoint` (refs `[plane, axis]`).
- The result reports **health**, so an axis parallel to the plane returns `healthy=false` + reason instead of a bare error.
- Adopts `oblikovati.org/api v0.117.0`.

## Tests (`work_points_test.go`)
- `TestWorkPointsPlaneAxisIntersection` — Z ∩ XY lands at the origin (position verified against the model).
- `TestWorkPointsPlaneAxisParallelIsUnhealthy` — X ∥ XY → unhealthy + reason.
- `TestWorkPointsPlaneAxisWrongReferenceCount`, `TestWorkPointsCreateUnknownKind` — argument errors.

## Scope
Advances #1842 (the reachability half). `AddByCloudPoint` — the other unreachable ctor — stays deferred; it needs a point-cloud import surface that does not exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)