### PR TITLE
feat(shell): direction inside/outside/both (#1864)

### DIFF
--- a/addin/opregistry/dressup.go
+++ b/addin/opregistry/dressup.go
@@ -430,7 +430,8 @@ const shellSchema = `{
   "properties": {
     "faceRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Reference keys of the faces to remove, hollowing the body (from get_reference_keys)."},
     "thickness": {"type": "string", "description": "Remaining wall thickness with units, e.g. \"1 mm\"."},
-    "facesGeom": {"type": "array", "description": "Select the removed faces by GEOMETRY instead of faceRefs, so the binding survives recompute. Give either this or faceRefs.", "items": {"type": "object", "properties": {"centroid": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Face centroid [x,y,z] cm."}, "normal": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Outward unit normal [x,y,z]."}}, "required": ["centroid", "normal"]}}
+    "facesGeom": {"type": "array", "description": "Select the removed faces by GEOMETRY instead of faceRefs, so the binding survives recompute. Give either this or faceRefs.", "items": {"type": "object", "properties": {"centroid": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Face centroid [x,y,z] cm."}, "normal": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Outward unit normal [x,y,z]."}}, "required": ["centroid", "normal"]}},
+    "direction": {"type": "string", "enum": ["inside", "outside", "both"], "default": "inside", "description": "Which side the wall grows onto: \"inside\" (outer dimensions kept), \"outside\" (outer dimensions grow by thickness), or \"both\" (wall centred on the faces). Inventor's ShellDirectionEnum."}
   },
   "required": ["thickness"]
 }`
@@ -467,14 +468,20 @@ func applyShell(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
+	dir, ok := feature.ParseShellDirection(strings.ToLower(strings.TrimSpace(in.Direction)))
+	if !ok {
+		return nil, fmt.Errorf("shell: unknown direction %q (want inside|outside|both)", in.Direction)
+	}
 	pf := feature.NewDressUpFeatures(part.Features()).AddShell(refKeys(in.FaceRefs), th)
+	def := pf.Definition().(*feature.ShellFeature).Definition()
+	def.Direction = dir
 	if len(in.FacesGeom) > 0 {
 		// Bind the removed faces by geometry when authored geometrically (survives recompute).
 		refs, err := geomFaceRefs(in.FacesGeom)
 		if err != nil {
 			return nil, err
 		}
-		pf.Definition().(*feature.ShellFeature).Definition().GeomFaces = refs
+		def.GeomFaces = refs
 	}
 	return recomputeResult(part, pf)
 }

--- a/addin/opregistry/shell_direction_test.go
+++ b/addin/opregistry/shell_direction_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"math"
+	"testing"
+)
+
+// Shell direction (inside/outside/both) — Inventor's ShellDirectionEnum, #1864. The kernel op
+// (ops.ShellDirected) carries the analytic-volume proofs; these check the wire reaches it with the
+// right direction, on a 4×3×1 cm box (12 cm³) shelled 0.2 cm with the top face removed.
+
+// TestShellDirectionVolumes: inside keeps the outer size (4.512 cm³), outside grows the wall
+// outward (5.952 cm³), both centres it (5.208 cm³) — three distinct, analytically-known solids.
+func TestShellDirectionVolumes(t *testing.T) {
+	for _, tc := range []struct {
+		dir  string
+		want float64
+	}{
+		{"inside", 12 - 3.6*2.6*0.8},        // 4.512
+		{"outside", 4.4*3.4*1.2 - 12},       // 5.952
+		{"both", 4.2*3.2*1.1 - 3.8*2.8*0.9}, // 5.208
+		{"", 12 - 3.6*2.6*0.8},              // empty ⇒ inside default
+	} {
+		t.Run(tc.dir, func(t *testing.T) {
+			got := shelledBoxVolume(t, tc.dir)
+			if math.Abs(got-tc.want) > 1e-6 {
+				t.Errorf("shell direction %q volume = %g, want %g", tc.dir, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestShellDirectionUnknown: an unknown direction is a clean error.
+func TestShellDirectionUnknown(t *testing.T) {
+	s, _, _ := extrudedSolid(t)
+	top, _ := boxTopFace(t, s)
+	if _, err := applyMap(t, s, "shell", map[string]any{
+		"faceRefs": []string{top}, "thickness": "2 mm", "direction": "sideways",
+	}); err == nil {
+		t.Error("unknown shell direction should error")
+	}
+}
+
+// shelledBoxVolume seeds a 4×3×1 box, shells it 2 mm with the given direction (top face removed),
+// and returns the resulting body volume.
+func shelledBoxVolume(t *testing.T, dir string) float64 {
+	t.Helper()
+	s, _, _ := extrudedSolid(t)
+	top, _ := boxTopFace(t, s)
+	args := map[string]any{"faceRefs": []string{top}, "thickness": "2 mm"}
+	if dir != "" {
+		args["direction"] = dir
+	}
+	if _, err := applyMap(t, s, "shell", args); err != nil {
+		t.Fatalf("shell %q: %v", dir, err)
+	}
+	return bodyVolume(t, s)
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.117.0
+	oblikovati.org/api v0.119.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.118.0
+	oblikovati.org/api v0.119.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/kernel/ops/shell.go
+++ b/kernel/ops/shell.go
@@ -9,12 +9,35 @@ import (
 	"oblikovati.org/kernel/topo"
 )
 
+// ShellDirection is which side of the original faces the wall grows onto — Inventor's
+// ShellDirectionEnum.
+type ShellDirection uint8
+
+const (
+	// ShellInside offsets the wall inward (the outer skin/dimensions are kept). Default.
+	ShellInside ShellDirection = iota
+	// ShellOutside grows the wall outward (outer dimensions increase by t); the original
+	// surface becomes the inner cavity.
+	ShellOutside
+	// ShellBoth centres the wall on the original faces (t/2 in, t/2 out).
+	ShellBoth
+)
+
 // Shell hollows a planar-faceted solid to wall thickness t, leaving the removed faces as
-// openings. It builds the inner cavity solid by offsetting every KEPT face inward by t
-// (via [rebuildWithPlanes]) while leaving the REMOVED faces in place — so the cavity stays
-// flush with them and the difference opens them (the coplanar B-rep rule) — then returns
-// solid − cavity. Inward shell only; outward/both-sides are a follow-up.
+// openings — the inward shell (outer skin kept). It is [ShellDirected] with [ShellInside].
 func Shell(solid *topo.Body, removedKeys [][]byte, t float64) (*topo.Body, error) {
+	return ShellDirected(solid, removedKeys, t, ShellInside)
+}
+
+// ShellDirected hollows a planar-faceted solid to wall thickness t on the chosen side of the
+// original faces, leaving the removed faces as openings. Every KEPT face is offset (a REMOVED
+// face stays in place, so the wall stays flush with it and the difference opens it — the
+// coplanar B-rep rule); the wall is then the region between the original solid and the offset
+// solid(s):
+//   - Inside:  solid − (kept faces offset inward t)               — outer skin kept.
+//   - Outside: (kept faces offset outward t) − solid              — outer dimensions grow by t.
+//   - Both:    (kept faces offset outward t/2) − (offset inward t/2) — wall centred on the faces.
+func ShellDirected(solid *topo.Body, removedKeys [][]byte, t float64, dir ShellDirection) (*topo.Body, error) {
 	if t <= 0 {
 		return nil, fmt.Errorf("shell: thickness %g must be > 0", t)
 	}
@@ -22,20 +45,34 @@ func Shell(solid *topo.Body, removedKeys [][]byte, t float64) (*topo.Body, error
 	if err != nil {
 		return nil, err
 	}
-	cavity := rebuildWithPlanes(solid, "shell-cavity", false, func(f *topo.Face) geom.Plane {
-		return shellFacePlane(f, removed, t)
-	})
-	return Boolean(Cut, solid, cavity)
+	switch dir {
+	case ShellInside:
+		return Boolean(Cut, solid, offsetShellSolid(solid, removed, -t))
+	case ShellOutside:
+		return Boolean(Cut, offsetShellSolid(solid, removed, t), solid)
+	case ShellBoth:
+		return Boolean(Cut, offsetShellSolid(solid, removed, t/2), offsetShellSolid(solid, removed, -t/2))
+	default:
+		return nil, fmt.Errorf("shell: unknown direction %d", dir)
+	}
 }
 
-// shellFacePlane returns a kept face's plane offset inward by t (origin moved along
-// −normal), or the unchanged plane for a removed face (so the cavity stays flush there).
-func shellFacePlane(f *topo.Face, removed map[uint64]bool, t float64) geom.Plane {
+// offsetShellSolid rebuilds the solid with every kept face's plane moved by d along its normal
+// (d<0 inward, d>0 outward); removed faces stay in place so the shell opens flush there.
+func offsetShellSolid(solid *topo.Body, removed map[uint64]bool, d float64) *topo.Body {
+	return rebuildWithPlanes(solid, "shell-offset", false, func(f *topo.Face) geom.Plane {
+		return shellFacePlane(f, removed, d)
+	})
+}
+
+// shellFacePlane returns a kept face's plane offset by d along its normal (origin moved along
+// +normal·d), or the unchanged plane for a removed face (so the shell stays flush there).
+func shellFacePlane(f *topo.Face, removed map[uint64]bool, d float64) geom.Plane {
 	pl := f.Geometry().(geom.Plane)
 	if removed[f.ID()] {
 		return pl
 	}
-	moved, _ := geom.NewPlaneFromAxes(pl.Origin.TranslateBy(pl.Normal().Scale(-t)), pl.UAxis.AsVector(), pl.VAxis.AsVector())
+	moved, _ := geom.NewPlaneFromAxes(pl.Origin.TranslateBy(pl.Normal().Scale(d)), pl.UAxis.AsVector(), pl.VAxis.AsVector())
 	return moved
 }
 

--- a/kernel/ops/shell_test.go
+++ b/kernel/ops/shell_test.go
@@ -46,6 +46,49 @@ func TestShellOpenTopBox(t *testing.T) {
 	}
 }
 
+// TestShellOutsideBox shells the same 4×4×4 open-top box OUTWARD by 0.5: the wall grows onto the
+// outside, so the outer solid [-0.5,4.5]×[-0.5,4.5]×[-0.5,4] (5·5·4.5 = 112.5) minus the original
+// 64 leaves a 48.5 wall, and the result must be a valid solid.
+func TestShellOutsideBox(t *testing.T) {
+	box := shellBox(4, 4, 4)
+	res, err := ops.ShellDirected(box, [][]byte{topFaceKey(t, box)}, 0.5, ops.ShellOutside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("outward-shelled box not a valid solid: %+v", r)
+	}
+	want := 5.0*5.0*4.5 - 64.0
+	if got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume; stdmath.Abs(got-want) > 1e-6 {
+		t.Errorf("outside shell volume = %g, want %g", got, want)
+	}
+}
+
+// TestShellBothBox centres a 0.5 wall on the faces of the 4×4×4 open-top box: outer offset +0.25
+// (4.5·4.5·4.25 = 86.0625) minus inner offset −0.25 (3.5·3.5·3.75 = 45.9375) = 40.125.
+func TestShellBothBox(t *testing.T) {
+	box := shellBox(4, 4, 4)
+	res, err := ops.ShellDirected(box, [][]byte{topFaceKey(t, box)}, 0.5, ops.ShellBoth)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("both-sides-shelled box not a valid solid: %+v", r)
+	}
+	want := 4.5*4.5*4.25 - 3.5*3.5*3.75
+	if got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume; stdmath.Abs(got-want) > 1e-6 {
+		t.Errorf("both-sides shell volume = %g, want %g", got, want)
+	}
+}
+
+// TestShellDirectedUnknownDirection guards the direction switch.
+func TestShellDirectedUnknownDirection(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	if _, err := ops.ShellDirected(box, [][]byte{topFaceKey(t, box)}, 0.2, ops.ShellDirection(9)); err == nil {
+		t.Error("unknown shell direction should error")
+	}
+}
+
 // TestShellLostFaceErrors checks a vanished removed-face key is reported (so the feature
 // can go Sick) rather than silently shelling a closed box.
 func TestShellLostFaceErrors(t *testing.T) {

--- a/model/feature/dressup.go
+++ b/model/feature/dressup.go
@@ -173,6 +173,7 @@ type ShellDefinition struct {
 	RemovedFaceKeys [][]byte
 	Thickness       func() float64
 	GeomFaces       []topo.GeometricFaceRef // externally-authored removed faces by geometric descriptor (ADR-0040)
+	Direction       ops.ShellDirection      // which side the wall grows onto (default ShellInside) — #1864
 }
 
 // ShellFeature hollows a solid.
@@ -191,7 +192,7 @@ func (s *ShellFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	return shellBody(in, keys, callOrZero(s.def.Thickness), featOr(s.featName, "shell"))
+	return shellBody(in, keys, callOrZero(s.def.Thickness), s.def.Direction, featOr(s.featName, "shell"))
 }
 
 // FaceDraftDefinition tapers selected faces by an angle about a pull direction. Neutral, when set, is

--- a/model/feature/serialize_codecs_dressup.go
+++ b/model/feature/serialize_codecs_dressup.go
@@ -67,7 +67,7 @@ func (r featureCodecSet) registerDressUpCodecs() {
 	r.register("shell", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			sf := f.(*ShellFeature)
-			fd.Shell = &FaceDressData{Faces: encodeKeys(sf.def.RemovedFaceKeys), Value: evalFloat(sf.def.Thickness), GeomFaces: encodeGeomFaces(sf.def.GeomFaces)}
+			fd.Shell = &FaceDressData{Faces: encodeKeys(sf.def.RemovedFaceKeys), Value: evalFloat(sf.def.Thickness), GeomFaces: encodeGeomFaces(sf.def.GeomFaces), ShellDirection: ShellDirectionName(sf.def.Direction)}
 			return nil
 		},
 		decode: decodeShell,
@@ -210,14 +210,18 @@ func decodeRuleFillet(rc *restoreContext, fd FeatureData) (*PartFeature, error) 
 	return NewDressUpFeatures(rc.fs).AddRuleFillet(rule, constFloat(fd.RuleFillet.Value)), nil
 }
 
-// decodeShell rebuilds a shell, re-binding its removed faces by key.
+// decodeShell rebuilds a shell, re-binding its removed faces by key and its wall direction.
 func decodeShell(rc *restoreContext, fd FeatureData) (*PartFeature, error) {
 	d, err := requireFaceDress(fd.Shell, "shell")
 	if err != nil {
 		return nil, err
 	}
+	dir, ok := ParseShellDirection(fd.Shell.ShellDirection)
+	if !ok {
+		return nil, fmt.Errorf("shell: unknown direction %q", fd.Shell.ShellDirection)
+	}
 	return NewDressUpFeatures(rc.fs).addShell(&ShellDefinition{
-		RemovedFaceKeys: d.keys, GeomFaces: d.geomFaces, Thickness: constFloat(d.value),
+		RemovedFaceKeys: d.keys, GeomFaces: d.geomFaces, Thickness: constFloat(d.value), Direction: dir,
 	}), nil
 }
 

--- a/model/feature/serialize_dressup.go
+++ b/model/feature/serialize_dressup.go
@@ -226,6 +226,9 @@ type FaceDressData struct {
 	// path the NX exporter uses since it cannot mint Oblikovati lineage keys. Empty for an
 	// Oblikovati-authored dress-up (which uses Faces).
 	GeomFaces []GeomFaceRefData `yaml:"geomFaces,omitempty"`
+	// ShellDirection is the wall side for a shell ("outside"/"both"; absent ⇒ inside). Unused by
+	// the other dress-ups. #1864.
+	ShellDirection string `yaml:"shellDirection,omitempty"`
 }
 
 // GeomFaceRefData is the serialized form of a geometric face descriptor: the face's

--- a/model/feature/serialize_test.go
+++ b/model/feature/serialize_test.go
@@ -91,6 +91,26 @@ func TestDressUpFeaturesRoundTrip(t *testing.T) {
 	}
 }
 
+// TestShellDirectionRoundTrip checks a non-default shell wall direction survives a marshal/restore
+// (the default inside serializes nothing; outside/both must persist). #1864.
+func TestShellDirectionRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	pf := NewDressUpFeatures(fs).AddShell([][]byte{[]byte("face-a")}, func() float64 { return 2 })
+	pf.Definition().(*ShellFeature).Definition().Direction = ops.ShellOutside
+
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	if got := fresh.Item(0).Definition().(*ShellFeature).Definition().Direction; got != ops.ShellOutside {
+		t.Errorf("restored shell direction = %d, want ShellOutside (%d)", got, ops.ShellOutside)
+	}
+}
+
 // TestDraftPullNeutralRoundTrip checks a draft's explicit pull direction and neutral (parting) plane
 // survive a recipe round trip (#1801).
 func TestDraftPullNeutralRoundTrip(t *testing.T) {

--- a/model/feature/shell.go
+++ b/model/feature/shell.go
@@ -8,10 +8,42 @@ import (
 	"oblikovati.org/kernel/ops"
 )
 
-// shellBody hollows the running body to a wall thickness, opening the removed faces, via
-// ops.Shell, and replaces it in the body list. A lost face key or non-positive thickness
-// is an error so the feature goes Sick. See kernel/ops/shell.go for the geometry.
-func shellBody(in Input, removedFaceKeys [][]byte, thickness float64, feat string) (Output, error) {
+// shellDirectionNames is the stable wire/serialization vocabulary for ops.ShellDirection —
+// the single source shared by the op registry (wire) and the .obk codec so they cannot drift.
+var shellDirectionNames = map[ops.ShellDirection]string{
+	ops.ShellInside:  "inside",
+	ops.ShellOutside: "outside",
+	ops.ShellBoth:    "both",
+}
+
+// ShellDirectionName renders a shell direction as its stable name ("" for the inside default, so
+// the common case serializes nothing).
+func ShellDirectionName(d ops.ShellDirection) string {
+	if d == ops.ShellInside {
+		return ""
+	}
+	return shellDirectionNames[d]
+}
+
+// ParseShellDirection maps a name ("inside"/"outside"/"both", empty ⇒ inside) to its direction;
+// ok is false for an unknown name.
+func ParseShellDirection(name string) (ops.ShellDirection, bool) {
+	switch name {
+	case "", "inside":
+		return ops.ShellInside, true
+	case "outside":
+		return ops.ShellOutside, true
+	case "both":
+		return ops.ShellBoth, true
+	default:
+		return ops.ShellInside, false
+	}
+}
+
+// shellBody hollows the running body to a wall thickness on the chosen side (inside/outside/both),
+// opening the removed faces, via ops.ShellDirected, and replaces it in the body list. A lost face
+// key or non-positive thickness is an error so the feature goes Sick. See kernel/ops/shell.go.
+func shellBody(in Input, removedFaceKeys [][]byte, thickness float64, dir ops.ShellDirection, feat string) (Output, error) {
 	body, err := runningBody(in)
 	if err != nil {
 		return Output{}, err
@@ -19,7 +51,7 @@ func shellBody(in Input, removedFaceKeys [][]byte, thickness float64, feat strin
 	if thickness <= 0 {
 		return Output{}, fmt.Errorf("%s: thickness %g must be > 0", feat, thickness)
 	}
-	result, err := ops.Shell(body, removedFaceKeys, thickness)
+	result, err := ops.ShellDirected(body, removedFaceKeys, thickness, dir)
 	if err != nil {
 		return Output{}, err
 	}


### PR DESCRIPTION
Part of milestone #44 (M33 Inventor-API parity), Wave C option depth. Host side of Oblikovati.API#244 (released as v0.119.0).

Wires Inventor's `ShellDirectionEnum` through the full stack so a shell can grow its wall **inside** (default), **outside**, or **both** — not just inward.

## Layers
- **kernel** (`kernel/ops/shell.go`) — `ops.ShellDirected(solid, removed, t, dir)`:
  - `inside` = `Cut(solid, inward-offset)` — outer skin/dimensions kept (current behaviour).
  - `outside` = `Cut(outward-offset, solid)` — outer dimensions grow by `t`; original surface becomes the inner cavity.
  - `both` = `Cut(outward t/2, inward t/2)` — wall centred on the original faces.
  - `ops.Shell` stays as the `inside` wrapper (no caller changes); `shellFacePlane` now takes a signed offset, so the inside path is byte-for-byte identical.
- **model** — `ShellDefinition.Direction` threaded through `shellBody`; persisted in the `.obk` codec (`shellDirection`, absent ⇒ inside) via the shared `ParseShellDirection` / `ShellDirectionName` vocabulary.
- **host** — the `shell` op gains `direction` (`inside|outside|both`).

## Tessellation-first: analytic-volume regression at every layer
- kernel: 4×4×4 open-top box shelled 0.5 → **48.5** (outside), **40.125** (both).
- host: 4×3×1 box shelled 2 mm → **4.512 / 5.952 / 5.208** (inside / outside / both); empty ⇒ inside; unknown ⇒ error.

## Scope
Direction only. Per-face unique thickness (`SetFaceThickness`, the other half of #1864) is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)