### PR TITLE
feat(sketch): distance-dimension orientation (aligned/horizontal/vertical) (#1869)

### DIFF
--- a/addin/router/sketch_dimension_orientation_test.go
+++ b/addin/router/sketch_dimension_orientation_test.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// TestSketchDistanceDimensionOrientation drives sketch.addDimension with a horizontal orientation
+// over two points at (0,0) and (3,4): the measured value is 3 (|Δx|), not the Euclidean 5, and
+// sketch.dimensions reports the orientation. An unknown orientation is a clean error. #1869.
+func TestSketchDistanceDimensionOrientation(t *testing.T) {
+	r, s := seededSession(t)
+	var l wire.AddSketchEntityResult
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"line","points":[[0,0],[3,4]]}`, &l)
+
+	var res wire.AddDimensionResult
+	call(t, r, s, "sketch.addDimension", mustJSON(t, wire.AddDimensionArgs{
+		SketchIndex: 0, Kind: "distance", Orientation: "horizontal", Entities: l.PointIDs, Expression: "1 cm",
+	}), &res)
+	if math.Abs(res.Value-3) > 1e-9 {
+		t.Errorf("horizontal distance measured = %g, want 3 (|Δx|, not the Euclidean 5)", res.Value)
+	}
+
+	var list wire.ListDimensionsResult
+	call(t, r, s, "sketch.dimensions", `{"sketchIndex":0}`, &list)
+	if len(list.Dimensions) != 1 || list.Dimensions[0].Orientation != "horizontal" {
+		t.Errorf("enumerated orientation = %+v, want one horizontal dim", list.Dimensions)
+	}
+
+	if err := tryCall(t, r, s, "sketch.addDimension", mustJSON(t, wire.AddDimensionArgs{
+		SketchIndex: 0, Kind: "distance", Orientation: "diagonal", Entities: l.PointIDs, Expression: "1 cm",
+	})); err == nil {
+		t.Error("an unknown orientation should error")
+	}
+}

--- a/addin/router/sketch_dimensions.go
+++ b/addin/router/sketch_dimensions.go
@@ -20,7 +20,11 @@ func addDimension(_ *app.Session, part *compdef.PartComponentDefinition, in wire
 	if err != nil {
 		return wire.AddDimensionResult{}, err
 	}
-	dim, err := buildDimension(sk, types.DimensionConstraintKind(in.Kind), in.Entities, in.Expression, in.FarSide)
+	orientation, ok := sketch.ParseDistanceOrientation(in.Orientation)
+	if !ok {
+		return wire.AddDimensionResult{}, fmt.Errorf("sketch.addDimension: unknown orientation %q (want aligned|horizontal|vertical)", in.Orientation)
+	}
+	dim, err := buildDimension(sk, types.DimensionConstraintKind(in.Kind), in.Entities, in.Expression, in.FarSide, orientation)
 	if err != nil {
 		return wire.AddDimensionResult{}, err
 	}
@@ -60,8 +64,9 @@ func applyDimensionEdit(part *compdef.PartComponentDefinition, dim *sketch.Dimen
 	return wire.OKResult{OK: true}, nil
 }
 
-// buildDimension resolves references and applies the matching model dimension factory.
-func buildDimension(sk *sketch.Sketch, kind types.DimensionConstraintKind, refs []uint64, expr string, farSide bool) (*sketch.DimensionConstraint, error) {
+// buildDimension resolves references and applies the matching model dimension factory. orientation
+// applies only to the distance kind (aligned/horizontal/vertical); other kinds ignore it.
+func buildDimension(sk *sketch.Sketch, kind types.DimensionConstraintKind, refs []uint64, expr string, farSide bool, orientation sketch.DistanceOrientation) (*sketch.DimensionConstraint, error) {
 	dc := sk.DimensionConstraints()
 	switch kind {
 	case types.DimConstraintDistance:
@@ -69,7 +74,7 @@ func buildDimension(sk *sketch.Sketch, kind types.DimensionConstraintKind, refs 
 		if err != nil {
 			return nil, err
 		}
-		return dc.AddDistance(a, b, expr)
+		return dc.AddDistanceOriented(a, b, expr, orientation)
 	case types.DimConstraintAngle:
 		a, b, err := twoLineRefs(sk, refs)
 		if err != nil {

--- a/addin/router/sketch_enumerate.go
+++ b/addin/router/sketch_enumerate.go
@@ -86,10 +86,11 @@ func enumerateDimensions(_ *app.Session, part *compdef.PartComponentDefinition, 
 // dimensionInfo renders one dimensional constraint as its wire summary.
 func dimensionInfo(index int, d *sketch.DimensionConstraint) wire.DimensionInfo {
 	info := wire.DimensionInfo{
-		Index:  index,
-		Kind:   string(dimensionKind(d.Kind())),
-		Value:  d.Measured(),
-		Driven: d.Driven(),
+		Index:       index,
+		Kind:        string(dimensionKind(d.Kind())),
+		Value:       d.Measured(),
+		Driven:      d.Driven(),
+		Orientation: sketch.DistanceOrientationName(d.Orientation()),
 	}
 	if p := d.Parameter(); p != nil {
 		info.Name = p.Name()

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.119.0
+	oblikovati.org/api v0.120.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.119.0
+	oblikovati.org/api v0.120.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/sketch/copy_constraints.go
+++ b/model/sketch/copy_constraints.go
@@ -244,7 +244,7 @@ func (target *Sketch) recreateCoreDimension(d *DimensionConstraint, m *cloneMap)
 	switch d.kind {
 	case DistanceDim:
 		if a, b, ok := m.refPoints2(d.refs); ok {
-			return added(dc.AddDistance(a, b, expr))
+			return added(dc.AddDistanceOriented(a, b, expr, d.orientation))
 		}
 	case AngleDim:
 		if l1, l2, ok := m.refLines2(d.refs); ok {

--- a/model/sketch/dimension.go
+++ b/model/sketch/dimension.go
@@ -62,14 +62,60 @@ func (l ConstraintLimits) clamp(v float64) float64 {
 // the parameter's value (modeling/00).
 type DimensionConstraint struct {
 	constraintBase
-	kind      DimKind
-	driven    bool
-	param     *param.Parameter
-	limits    ConstraintLimits
-	measureAD adFunc1 // the measured quantity over duals; the float measure derives from it
-	vars      []*math.Scalar
-	refs      []Entity // the dimensioned geometry (points/lines/arcs), for editing + serialization
-	farSide   bool     // tangentDistance only: dimension to the far tangent point (#152)
+	kind        DimKind
+	driven      bool
+	param       *param.Parameter
+	limits      ConstraintLimits
+	measureAD   adFunc1 // the measured quantity over duals; the float measure derives from it
+	vars        []*math.Scalar
+	refs        []Entity            // the dimensioned geometry (points/lines/arcs), for editing + serialization
+	farSide     bool                // tangentDistance only: dimension to the far tangent point (#152)
+	orientation DistanceOrientation // distance only: aligned (Euclidean) / horizontal (Δx) / vertical (Δy) (#1869)
+}
+
+// DistanceOrientation selects what a two-point distance dimension measures — Inventor's
+// DimensionOrientationEnum.
+type DistanceOrientation uint8
+
+const (
+	// AlignedDistance measures the Euclidean distance |P2 − P1| (the default).
+	AlignedDistance DistanceOrientation = iota
+	// HorizontalDistance measures only the X separation |P2.x − P1.x| (the pair stays free to
+	// slide vertically).
+	HorizontalDistance
+	// VerticalDistance measures only the Y separation |P2.y − P1.y|.
+	VerticalDistance
+)
+
+// Orientation reports what a distance dimension measures (aligned for every non-distance kind).
+func (d *DimensionConstraint) Orientation() DistanceOrientation { return d.orientation }
+
+// DistanceOrientationName renders an orientation as its stable name ("" for the aligned default, so
+// the common case serializes nothing) — the vocabulary shared by the wire router and the codec.
+func DistanceOrientationName(o DistanceOrientation) string {
+	switch o {
+	case HorizontalDistance:
+		return "horizontal"
+	case VerticalDistance:
+		return "vertical"
+	default:
+		return ""
+	}
+}
+
+// ParseDistanceOrientation maps a name ("aligned"/"horizontal"/"vertical", empty ⇒ aligned) to its
+// orientation; ok is false for an unknown name.
+func ParseDistanceOrientation(name string) (DistanceOrientation, bool) {
+	switch name {
+	case "", "aligned":
+		return AlignedDistance, true
+	case "horizontal":
+		return HorizontalDistance, true
+	case "vertical":
+		return VerticalDistance, true
+	default:
+		return AlignedDistance, false
+	}
 }
 
 // FarSide reports whether a tangent-distance dimension measures to the far tangent point
@@ -174,11 +220,36 @@ func (dc *DimensionConstraints) Delete(d *DimensionConstraint) bool {
 	return false
 }
 
-// AddDistance dimensions the distance between two points to expression (e.g. "25 mm").
+// AddDistance dimensions the aligned (Euclidean) distance between two points to expression
+// (e.g. "25 mm").
 func (dc *DimensionConstraints) AddDistance(a, b *Point, expression string) (*DimensionConstraint, error) {
-	measure := func(v []ad.Number) ad.Number { return ad.V2(v[0], v[1]).Sub(ad.V2(v[2], v[3])).Length() }
+	return dc.AddDistanceOriented(a, b, expression, AlignedDistance)
+}
+
+// AddDistanceOriented dimensions the distance between two points along the chosen orientation:
+// aligned = Euclidean |P2 − P1|, horizontal = |Δx| (leaves the Y separation free), vertical = |Δy|
+// (Inventor's DimensionOrientationEnum, #1869).
+func (dc *DimensionConstraints) AddDistanceOriented(a, b *Point, expression string, o DistanceOrientation) (*DimensionConstraint, error) {
 	vars := []*math.Scalar{&a.X, &a.Y, &b.X, &b.Y}
-	return dc.create(DistanceDim, expression, []Entity{a, b}, measure, vars)
+	d, err := dc.create(DistanceDim, expression, []Entity{a, b}, distanceMeasure(o), vars)
+	if err != nil {
+		return nil, err
+	}
+	d.orientation = o
+	return d, nil
+}
+
+// distanceMeasure is the autodiff measure for a two-point distance dimension of orientation o over
+// the packed vars [a.X, a.Y, b.X, b.Y]; the solver's Jacobian follows from it automatically.
+func distanceMeasure(o DistanceOrientation) adFunc1 {
+	switch o {
+	case HorizontalDistance:
+		return func(v []ad.Number) ad.Number { return v[0].Sub(v[2]).Abs() }
+	case VerticalDistance:
+		return func(v []ad.Number) ad.Number { return v[1].Sub(v[3]).Abs() }
+	default:
+		return func(v []ad.Number) ad.Number { return ad.V2(v[0], v[1]).Sub(ad.V2(v[2], v[3])).Length() }
+	}
 }
 
 // AddRadius dimensions the radius of a circle or an arc (Inventor allows both). For

--- a/model/sketch/dimension_orientation_test.go
+++ b/model/sketch/dimension_orientation_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"math"
+	"testing"
+
+	obmath "oblikovati.org/math"
+)
+
+// Two-point distance dimension orientation — Inventor's DimensionOrientationEnum (#1869): aligned
+// measures the Euclidean distance, horizontal the X separation only, vertical the Y separation.
+
+// TestDistanceOrientationMeasuresComponent: for the points (0,0) and (3,4) the aligned dim measures
+// 5, the horizontal dim 3 (|Δx|), the vertical dim 4 (|Δy|) — proof each orientation constrains its
+// own component. Each also reports its orientation.
+func TestDistanceOrientationMeasuresComponent(t *testing.T) {
+	for _, tc := range []struct {
+		o    DistanceOrientation
+		want float64
+	}{
+		{AlignedDistance, 5},
+		{HorizontalDistance, 3},
+		{VerticalDistance, 4},
+	} {
+		s := NewSketches().Add(XYPlane())
+		a, b := s.NewPoint(obmath.P2(0, 0)), s.NewPoint(obmath.P2(3, 4))
+		d, err := s.DimensionConstraints().AddDistanceOriented(a, b, "1 cm", tc.o)
+		if err != nil {
+			t.Fatalf("orientation %d: %v", tc.o, err)
+		}
+		if got := d.Measured(); math.Abs(got-tc.want) > 1e-9 {
+			t.Errorf("orientation %d measured = %g, want %g", tc.o, got, tc.want)
+		}
+		if d.Orientation() != tc.o {
+			t.Errorf("Orientation() = %d, want %d", d.Orientation(), tc.o)
+		}
+	}
+}
+
+// TestHorizontalDistanceSolvesXLeavesY: with point a grounded at the origin and b free, a
+// horizontal "3 cm" dim drives |b.x − a.x| to 3 while leaving b.y at its initial value — the pair
+// keeps a translational DOF along Y (AC #1869).
+func TestHorizontalDistanceSolvesXLeavesY(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	a, b := s.NewPoint(obmath.P2(0, 0)), s.NewPoint(obmath.P2(10, 7))
+	s.GeometricConstraints().AddGround(a)
+	if _, err := s.DimensionConstraints().AddDistanceOriented(a, b, "3 cm", HorizontalDistance); err != nil {
+		t.Fatal(err)
+	}
+	if r := s.Solve(); !r.Converged {
+		t.Fatalf("solve did not converge: %+v", r)
+	}
+	if dx := math.Abs(float64(b.X) - float64(a.X)); math.Abs(dx-3) > 1e-6 {
+		t.Errorf("|Δx| after solve = %g, want 3", dx)
+	}
+	if math.Abs(float64(b.Y)-7) > 1e-6 {
+		t.Errorf("b.y = %g, want 7 (Y left free/unmoved by a horizontal dim)", float64(b.Y))
+	}
+}
+
+// TestDistanceDimensionRemovesOneDOF: any single distance dim (here horizontal) removes exactly one
+// degree of freedom from the two otherwise-free points (4 → 3).
+func TestDistanceDimensionRemovesOneDOF(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	a, b := s.NewPoint(obmath.P2(0, 0)), s.NewPoint(obmath.P2(3, 4))
+	before := s.DegreesOfFreedom()
+	if _, err := s.DimensionConstraints().AddDistanceOriented(a, b, "3 cm", HorizontalDistance); err != nil {
+		t.Fatal(err)
+	}
+	if after := s.DegreesOfFreedom(); after != before-1 {
+		t.Errorf("DOF %d → %d, want one fewer (a horizontal dim is a single scalar constraint)", before, after)
+	}
+}
+
+// TestDistanceOrientationSurvivesRoundTrip: a horizontal distance dim keeps its orientation across
+// a serialize/restore (the default aligned serializes nothing, so a directed dim exercises the
+// codec). #1869.
+func TestDistanceOrientationSurvivesRoundTrip(t *testing.T) {
+	sc := NewSketches()
+	s := sc.Add(XYPlane())
+	a, b := s.NewPoint(obmath.P2(0, 0)), s.NewPoint(obmath.P2(3, 4))
+	if _, err := s.DimensionConstraints().AddDistanceOriented(a, b, "3 cm", HorizontalDistance); err != nil {
+		t.Fatal(err)
+	}
+	out := roundTrip(t, sc)
+	dims := out.DimensionConstraints().All()
+	if len(dims) != 1 {
+		t.Fatalf("restored dimension count = %d, want 1", len(dims))
+	}
+	if got := dims[0].Orientation(); got != HorizontalDistance {
+		t.Errorf("restored orientation = %d, want HorizontalDistance (%d)", got, HorizontalDistance)
+	}
+}
+
+// TestDistanceOrientationUnknownName guards the name parser.
+func TestDistanceOrientationUnknownName(t *testing.T) {
+	if _, ok := ParseDistanceOrientation("diagonal"); ok {
+		t.Error("unknown orientation name should not parse")
+	}
+	for _, n := range []string{"", "aligned", "horizontal", "vertical"} {
+		if _, ok := ParseDistanceOrientation(n); !ok {
+			t.Errorf("orientation %q should parse", n)
+		}
+	}
+}

--- a/model/sketch/serialize.go
+++ b/model/sketch/serialize.go
@@ -145,13 +145,14 @@ type ConstraintData struct {
 // DimensionData is one dimensional constraint: its kind, operand ids, the value
 // expression, and driving/limit state.
 type DimensionData struct {
-	Kind       string      `yaml:"kind"`
-	Points     []int       `yaml:"points,omitempty"`
-	Curves     []int       `yaml:"curves,omitempty"`
-	Expression string      `yaml:"expression"`
-	Driven     bool        `yaml:"driven,omitempty"`
-	FarSide    bool        `yaml:"farSide,omitempty"` // tangentDistance only (#152)
-	Limits     *LimitsData `yaml:"limits,omitempty"`
+	Kind        string      `yaml:"kind"`
+	Points      []int       `yaml:"points,omitempty"`
+	Curves      []int       `yaml:"curves,omitempty"`
+	Expression  string      `yaml:"expression"`
+	Driven      bool        `yaml:"driven,omitempty"`
+	FarSide     bool        `yaml:"farSide,omitempty"`     // tangentDistance only (#152)
+	Orientation string      `yaml:"orientation,omitempty"` // distance only: horizontal/vertical (absent ⇒ aligned) (#1869)
+	Limits      *LimitsData `yaml:"limits,omitempty"`
 }
 
 // LimitsData carries a dimension's drive limits when enabled.
@@ -337,7 +338,7 @@ func serializeSplineHandles(sp *Spline) []SplineHandleData {
 }
 
 func serializeDimension(d *DimensionConstraint) (DimensionData, error) {
-	dd := DimensionData{Expression: d.param.Expression(), Driven: d.driven, FarSide: d.farSide}
+	dd := DimensionData{Expression: d.param.Expression(), Driven: d.driven, FarSide: d.farSide, Orientation: DistanceOrientationName(d.orientation)}
 	if d.limits.Enabled {
 		dd.Limits = &LimitsData{Min: d.limits.Min, Max: d.limits.Max}
 	}

--- a/model/sketch/serialize_restore.go
+++ b/model/sketch/serialize_restore.go
@@ -272,7 +272,11 @@ func (r *sketchRestorer) restoreDimension(dd DimensionData) (*DimensionConstrain
 		if err != nil {
 			return nil, err
 		}
-		return dc.AddDistance(a, b, dd.Expression)
+		o, ok := ParseDistanceOrientation(dd.Orientation)
+		if !ok {
+			return nil, fmt.Errorf("distance dimension: unknown orientation %q", dd.Orientation)
+		}
+		return dc.AddDistanceOriented(a, b, dd.Expression, o)
 	case "radius":
 		// AddRadius accepts any CircularCurve (circle or arc) — an arc radius/diameter
 		// dimension is common (esp. from CAD imports), so resolve as a circular curve,


### PR DESCRIPTION
Part of milestone #44 (M33 Inventor-API parity), Wave C. Host side of Oblikovati.API#245 (released as v0.120.0). Closes #1869.

A two-point distance dimension can now measure the **X separation** (horizontal) or **Y separation** (vertical) only, not just the Euclidean distance (aligned) — Inventor's `DimensionOrientationEnum`, the most common driving dimension in real part sketches and imported DWG/DXF.

## Clean because the solver is autodiff
The sketch dimension is defined by a `measure` closure over dual numbers, so the constraint Jacobian is automatic:
- `aligned` → `|P2 − P1|` (today)
- `horizontal` → `|Δx|`  · `vertical` → `|Δy|`

The orientation rides on `DimensionConstraint` (like the existing `farSide` flag), so the kind stays `DistanceDim` and the copy/serialize/enumerate switches need **no new cases** — only the single distance case in each is touched. Persisted in the `.obk` codec (absent ⇒ aligned) and reported on enumeration, via the shared `ParseDistanceOrientation` / `DistanceOrientationName` vocabulary.

- Router: `sketch.addDimension` gains `orientation`; `sketch.dimensions` reports it.

## Tests
- Each orientation measures its own component: aligned 5 / horizontal 3 / vertical 4 for (0,0)–(3,4).
- **AC (DOF):** with point a grounded, a horizontal `3 cm` dim drives `|Δx|→3` and leaves `b.y` free (the translational DOF).
- A single distance dim removes exactly one DOF.
- Horizontal orientation survives a serialize round-trip; unknown names error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)