### PR TITLE
feat(parameters): type conversion (ConvertTo user/model/reference) (#1850)

### DIFF
--- a/addin/router/parameters.go
+++ b/addin/router/parameters.go
@@ -117,6 +117,44 @@ func renameParameter(s *app.Session, holder compdef.ParameterHolder, in wire.Par
 	return info, nil
 }
 
+// convertParameter changes a parameter's category (user/model/reference) in place, preserving its
+// identity, expression and dependency edges; converting to reference makes it read-only. A
+// built-in/auto or derived parameter is refused by the model (#1850).
+func convertParameter(s *app.Session, holder compdef.ParameterHolder, in wire.ParameterConvertArgs) (wire.ParameterInfo, error) {
+	if in.Name == "" {
+		return wire.ParameterInfo{}, errors.New("parameters.convert: name is required")
+	}
+	p, ok := holder.Parameters().ByName(in.Name)
+	if !ok {
+		return wire.ParameterInfo{}, errors.New("parameters.convert: no parameter named " + in.Name)
+	}
+	target, err := parseConvertKind(in.TargetKind)
+	if err != nil {
+		return wire.ParameterInfo{}, err
+	}
+	if err := holder.Parameters().Convert(p.ID(), target); err != nil {
+		return wire.ParameterInfo{}, err
+	}
+	info := paramInfo(holder, p)
+	emitParameterChanged(s, info) // relay the kind change to subscribing add-ins
+	return info, nil
+}
+
+// parseConvertKind maps the wire targetKind spelling to a model parameter kind — only the three
+// Inventor-convertible categories (ConvertTo{User,Model,Reference}) are accepted here.
+func parseConvertKind(kind string) (param.ParameterKind, error) {
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "user":
+		return param.UserParam, nil
+	case "model":
+		return param.ModelParam, nil
+	case "reference":
+		return param.ReferenceParam, nil
+	default:
+		return 0, fmt.Errorf("parameters.convert: unknown targetKind %q (want user|model|reference)", kind)
+	}
+}
+
 // setParameter changes an existing parameter's expression and recomputes so any
 // driven features update.
 func setParameter(s *app.Session, holder compdef.ParameterHolder, in wire.ParameterSetArgs) (wire.ParameterInfo, error) {

--- a/addin/router/parameters_convert_test.go
+++ b/addin/router/parameters_convert_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import "testing"
+
+// Parameter type conversion over the wire (#1850): parameters.convert changes a parameter's kind
+// (user/model/reference) in place, preserving identity and dependents; reference is read-only;
+// built-in/auto, derived, and unknown targets are refused.
+
+// TestConvertParameterUserModelRoundTrip converts the seeded "width" user→model and back, and
+// confirms a dependent expression stays bound across the conversion.
+func TestConvertParameterUserModelRoundTrip(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "parameters.add", `{"name":"half","expression":"width / 2"}`, nil)
+
+	call(t, r, s, "parameters.convert", `{"name":"width","targetKind":"model"}`, nil)
+	if d := getDetail(t, r, s, "width"); d.Kind != "model" {
+		t.Errorf("after convert, width kind = %q, want model", d.Kind)
+	}
+	if d := getDetail(t, r, s, "half"); d.Expression != "width / 2" {
+		t.Errorf("dependent expression = %q, want it still bound to width", d.Expression)
+	}
+
+	call(t, r, s, "parameters.convert", `{"name":"width","targetKind":"user"}`, nil)
+	if d := getDetail(t, r, s, "width"); d.Kind != "user" {
+		t.Errorf("after convert back, width kind = %q, want user", d.Kind)
+	}
+}
+
+// TestConvertParameterToReferenceIsReadOnly: a reference parameter refuses parameters.set.
+func TestConvertParameterToReferenceIsReadOnly(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "parameters.convert", `{"name":"width","targetKind":"reference"}`, nil)
+	if d := getDetail(t, r, s, "width"); d.Kind != "reference" {
+		t.Fatalf("width kind = %q, want reference", d.Kind)
+	}
+	wantErr(t, r, s, "parameters.set", `{"name":"width","expression":"6 cm"}`)
+}
+
+// TestConvertParameterErrors covers the guard rails: an unsupported target, an unknown parameter,
+// and an unknown targetKind spelling are all clean errors.
+func TestConvertParameterErrors(t *testing.T) {
+	r, s := seededSession(t)
+	wantErr(t, r, s, "parameters.convert", `{"name":"width","targetKind":"derived"}`)
+	wantErr(t, r, s, "parameters.convert", `{"name":"missing","targetKind":"model"}`)
+	wantErr(t, r, s, "parameters.convert", `{"name":"width","targetKind":"banana"}`)
+}

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -182,6 +182,7 @@ func (r *Router) registerStandardHandlers() {
 	r.mutating(wire.MethodParametersAdd, labelEditParameters, typedHolder(addParameter))
 	r.mutating(wire.MethodParametersSet, labelEditParameters, typedHolder(setParameter))
 	r.mutating(wire.MethodParametersRename, labelEditParameters, typedHolder(renameParameter))
+	r.mutating(wire.MethodParametersConvert, labelEditParameters, typedHolder(convertParameter))
 	r.registerParameterDetailHandlers()
 	r.readOnly(wire.MethodModelTree, partQuery(modelTree))
 	r.readOnly(wire.MethodModelSelection, modelSelection)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.120.0
+	oblikovati.org/api v0.121.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.120.0
+	oblikovati.org/api v0.121.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/param/convert_test.go
+++ b/model/param/convert_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package param
+
+import "testing"
+
+// Parameter type conversion (#1850): ConvertTo{User,Model,Reference} changes a parameter's
+// category in place, keeping its identity and dependency edges; a built-in/auto or derived
+// parameter, or an unsupported target, is refused.
+
+// TestConvertPreservesIdentityAndEdges: converting "od" user→model keeps its name and expression,
+// and a dependent "od/2" still tracks it (the edge binds by id, so re-kinding is transparent). It
+// converts back to user cleanly.
+func TestConvertPreservesIdentityAndEdges(t *testing.T) {
+	ps := NewParameters()
+	od, _ := ps.AddUserParameter("od", "10 cm")
+	half, _ := ps.AddUserParameter("half", "od / 2")
+
+	if err := ps.Convert(od.ID(), ModelParam); err != nil {
+		t.Fatalf("user→model: %v", err)
+	}
+	if od.Kind() != ModelParam || od.Name() != "od" || od.Expression() != "10 cm" {
+		t.Errorf("converted param lost identity: kind=%v name=%q expr=%q", od.Kind(), od.Name(), od.Expression())
+	}
+	// The dependent edge survived: driving od re-evaluates half.
+	if err := ps.SetExpression(od.ID(), "20 cm"); err != nil {
+		t.Fatalf("set od after convert: %v", err)
+	}
+	if got := half.Value().Value; got != 10 {
+		t.Errorf("dependent half = %g cm, want 10 (edge lost across conversion)", got)
+	}
+	if err := ps.Convert(od.ID(), UserParam); err != nil || od.Kind() != UserParam {
+		t.Errorf("model→user: err=%v kind=%v", err, od.Kind())
+	}
+}
+
+// TestConvertToReferenceIsReadOnly: converting to reference makes the parameter read-only (a later
+// SetExpression is refused); converting back to user restores editability.
+func TestConvertToReferenceIsReadOnly(t *testing.T) {
+	ps := NewParameters()
+	p, _ := ps.AddUserParameter("a", "5 cm")
+
+	if err := ps.Convert(p.ID(), ReferenceParam); err != nil {
+		t.Fatalf("user→reference: %v", err)
+	}
+	if p.Kind() != ReferenceParam {
+		t.Fatalf("kind = %v, want reference", p.Kind())
+	}
+	if err := p.SetExpression("6 cm"); err == nil {
+		t.Error("a reference parameter must refuse SetExpression")
+	}
+	if err := ps.Convert(p.ID(), UserParam); err != nil {
+		t.Fatalf("reference→user: %v", err)
+	}
+	if err := p.SetExpression("6 cm"); err != nil {
+		t.Errorf("a user parameter must accept SetExpression, got %v", err)
+	}
+}
+
+// TestConvertBuiltInRejected: an auto-generated model parameter (a feature-dimension backing param)
+// is built-in and refuses conversion.
+func TestConvertBuiltInRejected(t *testing.T) {
+	ps := NewParameters()
+	d, _ := ps.AddAutoModelParameter("3 cm")
+	if !d.BuiltIn() {
+		t.Fatal("AddAutoModelParameter should mint a built-in parameter")
+	}
+	if err := ps.Convert(d.ID(), UserParam); err == nil {
+		t.Error("a built-in/auto parameter must not convert")
+	}
+}
+
+// TestConvertDerivedAndBadTargetRejected: a derived (cross-document) parameter cannot convert, and
+// only user/model/reference are valid targets.
+func TestConvertDerivedAndBadTargetRejected(t *testing.T) {
+	ps := NewParameters()
+	d, _ := ps.AddDerivedParameter("x", Q(1, Length))
+	if err := ps.Convert(d.ID(), UserParam); err == nil {
+		t.Error("a derived parameter must not convert")
+	}
+	p, _ := ps.AddUserParameter("a", "5 cm")
+	if err := ps.Convert(p.ID(), DerivedParam); err == nil {
+		t.Error("derived is not a valid conversion target")
+	}
+	if err := ps.Convert(ID(9999), UserParam); err == nil {
+		t.Error("converting an unknown id should error")
+	}
+}

--- a/model/param/parameter.go
+++ b/model/param/parameter.go
@@ -55,15 +55,16 @@ func (h Health) OK() bool { return h.Status == Healthy }
 // quantity in database units; ModelValue applies the tolerance. Construct
 // parameters through a [Parameters] collection, never directly.
 type Parameter struct {
-	id     ID
-	owner  *Parameters // the collection that minted this parameter; nil for a bare test parameter
-	name   string
-	expr   Expr
-	value  Quantity
-	text   string // the value when this is a Text parameter (Unit == Text)
-	tol    Tolerance
-	kind   ParameterKind
-	health Health
+	id      ID
+	owner   *Parameters // the collection that minted this parameter; nil for a bare test parameter
+	name    string
+	expr    Expr
+	value   Quantity
+	text    string // the value when this is a Text parameter (Unit == Text)
+	tol     Tolerance
+	kind    ParameterKind
+	builtin bool // an auto-generated / system parameter (a feature-dimension backing param) — kind conversion is refused, matching Inventor's BuiltIn guard (#1850)
+	health  Health
 
 	exprList    []string // multi-value choices (empty ⇒ single-valued); see expression_list.go
 	allowCustom bool     // a value outside exprList is accepted (the one custom value)
@@ -90,6 +91,11 @@ func (p *Parameter) Name() string { return p.name }
 
 // Kind returns the parameter category.
 func (p *Parameter) Kind() ParameterKind { return p.kind }
+
+// BuiltIn reports whether this is an auto-generated / system parameter (a feature-dimension
+// backing param). A built-in parameter's kind cannot be converted — matching Inventor's BuiltIn
+// guard (#1850).
+func (p *Parameter) BuiltIn() bool { return p.builtin }
 
 // Unit returns the unit of the evaluated value.
 func (p *Parameter) Unit() Unit { return p.value.Unit }

--- a/model/param/parameters.go
+++ b/model/param/parameters.go
@@ -105,7 +105,14 @@ func (ps *Parameters) AddModelParameter(name, expression string) (*Parameter, er
 // revolve angle) so the argument joins the dependency graph and may itself
 // reference other parameters, exactly like a sketch dimension.
 func (ps *Parameters) AddAutoModelParameter(expression string) (*Parameter, error) {
-	return ps.AddModelParameter(ps.uniqueName("d"), expression)
+	p, err := ps.AddModelParameter(ps.uniqueName("d"), expression)
+	if err != nil {
+		return nil, err
+	}
+	// The feature owns this anonymous dimension backing param; flag it built-in so the generic
+	// convert API cannot re-kind it out from under its feature (Inventor's BuiltIn guard, #1850).
+	p.builtin = true
+	return p, nil
 }
 
 // uniqueName mints an unused parameter name with the given prefix.
@@ -214,6 +221,36 @@ func (ps *Parameters) add(name string, kind ParameterKind) (*Parameter, error) {
 
 // Rename changes a parameter's display name, rejecting a clash with another
 // parameter. Stable ids mean dependent expressions are unaffected.
+// convertibleKinds are the parameter categories a Convert may target — Inventor exposes
+// ConvertTo{User,Model,Reference}; a document link (Derived) or table membership is not a
+// conversion target here.
+var convertibleKinds = map[ParameterKind]bool{UserParam: true, ModelParam: true, ReferenceParam: true}
+
+// Convert changes a parameter's category in place, preserving its identity — name, expression,
+// value, tolerance, comment, and every dependency edge (edges bind by stable id, so re-kinding
+// touches nothing else). Converting to Reference makes the parameter read-only (its kind is no
+// longer Editable), so a later SetExpression is refused — the reference-parameter semantics.
+// It refuses to convert a built-in/auto parameter (a feature-dimension backing param), a derived
+// (cross-document) parameter, or a target outside user/model/reference (#1850, Inventor's
+// ModelParameter/UserParameter/ReferenceParameter.ConvertTo*).
+func (ps *Parameters) Convert(id ID, target ParameterKind) error {
+	p, ok := ps.byID[id]
+	if !ok {
+		return fmt.Errorf(errNoParameter, id)
+	}
+	if p.builtin {
+		return fmt.Errorf("param: built-in parameter %q cannot be converted", p.name)
+	}
+	if p.kind == DerivedParam {
+		return fmt.Errorf("param: derived parameter %q (linked from another document) cannot be converted", p.name)
+	}
+	if !convertibleKinds[target] {
+		return fmt.Errorf("param: cannot convert %q to %q (want user, model, or reference)", p.name, target)
+	}
+	p.kind = target
+	return nil
+}
+
 func (ps *Parameters) Rename(id ID, newName string) error {
 	p, ok := ps.byID[id]
 	if !ok {


### PR DESCRIPTION
Part of milestone #44 (M33 Inventor-API parity), Wave C — Parameters. Host side of Oblikovati.API#246 (released as v0.121.0). Closes #1850.

`parameters.convert` changes a parameter's category **in place** — Inventor's `ModelParameter`/`UserParameter`/`ReferenceParameter.ConvertTo*`.

## Clean because edges bind by id
`Parameters.Convert(id, target)` just swaps `p.kind`; dependency edges bind by stable id, so the name, expression, value, tolerance, comment **and every dependent** are preserved untouched. Read-only-on-reference is free: `ReferenceParam` isn't `Editable()`, so a later `SetExpression` is already refused.

## Guards (Inventor's ConvertTo* + BuiltIn)
- A **built-in/auto** parameter is refused. `AddAutoModelParameter` now flags its anonymous `d0` feature-dimension params built-in (they're system-managed).
- A **derived** (cross-document link) parameter is refused.
- Only `user`/`model`/`reference` are valid targets.

## Tests (model + router)
- `user↔model` round-trip keeps a dependent (`half = width/2`) bound across the conversion.
- Converting to `reference` makes `parameters.set` fail (read-only).
- Built-in/auto, derived, unknown parameter, and unknown targetKind all error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)