### PR TITLE
feat(work-features): line-point plane, visibility, relational axis/point ctors + list (#1843, #1856, #1840, #1842)

### DIFF
--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -199,6 +199,7 @@ func (r *Router) registerStandardHandlers() {
 	r.readOnly(wire.MethodWorkPlanesList, ctxQuery(activeWorkHost, listWorkPlanes))
 	r.mutating(wire.MethodWorkPlanesCreate, "Create Work Plane", typedCtx(activeWorkHost, createWorkPlanes))
 	r.mutating(wire.MethodWorkPlanesRedefine, "Redefine Work Plane", typedCtx(activeWorkHost, redefineWorkPlane))
+	r.readOnly(wire.MethodWorkPointsList, ctxQuery(activeWorkHost, listWorkPoints))
 	r.mutating(wire.MethodWorkPointsCreate, "Create Work Point", typedCtx(activeWorkHost, createWorkPoint))
 	r.readOnly(wire.MethodWorkAxesList, ctxQuery(activeWorkHost, listWorkAxes))
 	r.mutating(wire.MethodWorkAxesCreate, "Create Work Axis", typedCtx(activeWorkHost, createWorkAxis))

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -201,6 +201,7 @@ func (r *Router) registerStandardHandlers() {
 	r.mutating(wire.MethodWorkPointsCreate, "Create Work Point", typedCtx(activeWorkHost, createWorkPoint))
 	r.readOnly(wire.MethodWorkAxesList, ctxQuery(activeWorkHost, listWorkAxes))
 	r.mutating(wire.MethodWorkAxesCreate, "Create Work Axis", typedCtx(activeWorkHost, createWorkAxis))
+	r.mutating(wire.MethodWorkFeaturesSetVisible, "Set Work Feature Visibility", typedCtx(activeWorkHost, setWorkFeatureVisible))
 
 	r.readOnly(wire.MethodWorkSurfacesList, partQuery(listWorkSurfaces))
 	r.readOnly(wire.MethodWorkSurfacesGet, typedPart(getWorkSurface))

--- a/addin/router/work_axes.go
+++ b/addin/router/work_axes.go
@@ -40,6 +40,28 @@ func workAxisInfo(index int, wa *feature.WorkAxis) wire.WorkAxisInfo {
 	}
 }
 
+// listWorkPoints enumerates the active model's datum points (origin centre first, then user
+// points) with their position, kind, origin flag, visibility, and health (#1842).
+func listWorkPoints(_ *app.Session, host workHost) (wire.ListWorkPointsResult, error) {
+	points := projectAll(host.WorkPoints(), workPointInfo)
+	return wire.ListWorkPointsResult{Points: points}, nil
+}
+
+// workPointInfo renders one datum point as the wire DTO.
+func workPointInfo(index int, wp *feature.WorkPoint) wire.WorkPointInfo {
+	return wire.WorkPointInfo{
+		Index:    index,
+		Name:     wp.Name(),
+		Ref:      string(wp.Key()),
+		Position: point3Slice(wp.Point()),
+		IsOrigin: wp.IsCoordinateSystemElement(),
+		Visible:  wp.Visible(),
+		Healthy:  wp.Health().OK(),
+		Reason:   wp.Health().Reason, // empty when healthy
+		Kind:     wp.Kind(),
+	}
+}
+
 // buildWorkAxis dispatches a create request to the matching model constructor.
 func buildWorkAxis(host workHost, in wire.CreateWorkAxisArgs) (*feature.WorkAxis, error) {
 	axes := host.WorkAxes()
@@ -50,6 +72,12 @@ func buildWorkAxis(host workHost, in wire.CreateWorkAxisArgs) (*feature.WorkAxis
 		return addRefAxis(in, "two-points", axes.AddByTwoPoints)
 	case types.WorkAxisPlaneIntersection:
 		return addRefAxis(in, "plane-intersection", axes.AddByPlaneIntersection)
+	case types.WorkAxisPointAndPlane:
+		return addRefAxis(in, "point-and-plane", axes.AddByPointAndPlane)
+	case types.WorkAxisLineAndPoint:
+		return addRefAxis(in, "line-and-point", axes.AddByLineAndPoint)
+	case types.WorkAxisLineAndPlane:
+		return addRefAxis(in, "line-and-plane", axes.AddByLineAndPlane)
 	default:
 		return nil, fmt.Errorf("workAxes.create: unknown kind %q (see api/types WorkAxis*)", in.Kind)
 	}

--- a/addin/router/work_features.go
+++ b/addin/router/work_features.go
@@ -12,8 +12,11 @@ import (
 
 // setWorkFeatureVisible shows or hides the datum work plane, axis, or point named by the request's
 // ref — the post-create visibility toggle Inventor exposes on every work feature (#1856). It
-// resolves the ref against the active model's work geometry (origin frame + user datums) and
-// recomputes so subscribers see the change; an unknown ref is a clean error.
+// resolves the ref against the active model's work geometry (origin frame + user datums); an
+// unknown ref is a clean error. Visibility is a display-only attribute (it changes no geometry and
+// drives no dependents), so this touches only the datum's flag — no recompute — and the mutating
+// router seam records the single undo step / edit broadcast (#1612 keeps the recompute seam out of
+// the handler).
 func setWorkFeatureVisible(_ *app.Session, host workHost, in wire.SetWorkFeatureVisibleArgs) (wire.OKResult, error) {
 	g := host.WorkGeometry()
 	ref := feature.ParseWorkRef(in.Ref)
@@ -21,7 +24,6 @@ func setWorkFeatureVisible(_ *app.Session, host workHost, in wire.SetWorkFeature
 	case setPlaneVisible(g, ref, in.Visible),
 		setAxisVisible(g, ref, in.Visible),
 		setPointVisible(g, ref, in.Visible):
-		host.Recompute()
 		return wire.OKResult{OK: true}, nil
 	default:
 		return wire.OKResult{}, fmt.Errorf("workFeatures.setVisible: no work plane, axis, or point named %q", in.Ref)

--- a/addin/router/work_features.go
+++ b/addin/router/work_features.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/feature"
+)
+
+// setWorkFeatureVisible shows or hides the datum work plane, axis, or point named by the request's
+// ref — the post-create visibility toggle Inventor exposes on every work feature (#1856). It
+// resolves the ref against the active model's work geometry (origin frame + user datums) and
+// recomputes so subscribers see the change; an unknown ref is a clean error.
+func setWorkFeatureVisible(_ *app.Session, host workHost, in wire.SetWorkFeatureVisibleArgs) (wire.OKResult, error) {
+	g := host.WorkGeometry()
+	ref := feature.ParseWorkRef(in.Ref)
+	switch {
+	case setPlaneVisible(g, ref, in.Visible),
+		setAxisVisible(g, ref, in.Visible),
+		setPointVisible(g, ref, in.Visible):
+		host.Recompute()
+		return wire.OKResult{OK: true}, nil
+	default:
+		return wire.OKResult{}, fmt.Errorf("workFeatures.setVisible: no work plane, axis, or point named %q", in.Ref)
+	}
+}
+
+// setPlaneVisible sets a datum plane's visibility, reporting whether the ref named one.
+func setPlaneVisible(g *feature.WorkGeometry, ref feature.WorkRef, visible bool) bool {
+	wp, err := g.WorkPlaneByRef(ref)
+	if err != nil {
+		return false
+	}
+	wp.SetVisible(visible)
+	return true
+}
+
+// setAxisVisible sets a datum axis's visibility, reporting whether the ref named one.
+func setAxisVisible(g *feature.WorkGeometry, ref feature.WorkRef, visible bool) bool {
+	wa, ok := g.AxisByRef(ref)
+	if ok {
+		wa.SetVisible(visible)
+	}
+	return ok
+}
+
+// setPointVisible sets a datum point's visibility, reporting whether the ref named one.
+func setPointVisible(g *feature.WorkGeometry, ref feature.WorkRef, visible bool) bool {
+	wp, ok := g.WorkPointByRef(ref)
+	if ok {
+		wp.SetVisible(visible)
+	}
+	return ok
+}

--- a/addin/router/work_features_test.go
+++ b/addin/router/work_features_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/model/compdef"
+)
+
+// TestWorkPlaneLineAndPoint creates the line-and-point plane over the wire: the origin X axis and a
+// point at (0,5,0) define the XY plane — a healthy datum (#1843).
+func TestWorkPlaneLineAndPoint(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var p wire.CreateWorkPointResult
+	call(t, r, s, "workPoints.create", `{"at":[0,5,0]}`, &p)
+
+	var res wire.CreateWorkPlaneResult
+	call(t, r, s, "workPlanes.create", `{"kind":"line-point","refs":["origin/axis/x","`+p.Ref+`"]}`, &res)
+	if !res.Healthy {
+		t.Fatalf("line-point plane not healthy: %+v", res)
+	}
+}
+
+// TestWorkPlaneLineAndPointWrongRefCount: line-point needs exactly two references.
+func TestWorkPlaneLineAndPointWrongRefCount(t *testing.T) {
+	r, s := emptyPartSession(t)
+	if _, err := r.Handle(s, "workPlanes.create", []byte(`{"kind":"line-point","refs":["origin/axis/x"]}`)); err == nil {
+		t.Error("line-point with one reference should error")
+	}
+}
+
+// TestSetWorkFeatureVisible hides a datum plane, axis, and point by ref and confirms each — the
+// plane via its list Visible flag, the axis and point via the model (#1856).
+func TestSetWorkFeatureVisible(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var pl wire.CreateWorkPlaneResult
+	call(t, r, s, "workPlanes.create", `{"kind":"plane-offset","refs":["origin/plane/xy"],"offset":"10 mm"}`, &pl)
+	var res wire.OKResult
+	call(t, r, s, "workFeatures.setVisible", `{"ref":"`+pl.Ref+`","visible":false}`, &res)
+	if !res.OK {
+		t.Fatal("setVisible did not report OK")
+	}
+	var list wire.ListWorkPlanesResult
+	call(t, r, s, "workPlanes.list", "{}", &list)
+	for _, p := range list.Planes {
+		if p.Ref == pl.Ref && p.Visible {
+			t.Error("plane should be hidden after setVisible false")
+		}
+	}
+
+	var ax wire.CreateWorkAxisResult
+	call(t, r, s, "workAxes.create", `{"kind":"line","origin":[0,0,0],"direction":[0,0,1]}`, &ax)
+	call(t, r, s, "workFeatures.setVisible", `{"ref":"`+ax.Ref+`","visible":false}`, &res)
+
+	var pt wire.CreateWorkPointResult
+	call(t, r, s, "workPoints.create", `{"at":[1,2,3]}`, &pt)
+	call(t, r, s, "workFeatures.setVisible", `{"ref":"`+pt.Ref+`","visible":false}`, &res)
+
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	if def.WorkAxes().Item(ax.Index).Visible() {
+		t.Error("axis should be hidden")
+	}
+	if def.WorkPoints().Item(pt.Index).Visible() {
+		t.Error("point should be hidden")
+	}
+}
+
+// TestSetWorkFeatureVisibleUnknownRef: a ref naming no datum is a clean error.
+func TestSetWorkFeatureVisibleUnknownRef(t *testing.T) {
+	r, s := emptyPartSession(t)
+	if _, err := r.Handle(s, "workFeatures.setVisible", []byte(`{"ref":"plane/99","visible":false}`)); err == nil {
+		t.Error("an unknown ref should error")
+	}
+}

--- a/addin/router/work_planes.go
+++ b/addin/router/work_planes.go
@@ -30,6 +30,7 @@ type workHost interface {
 	WorkPlanes() *feature.WorkPlanes
 	WorkPoints() *feature.WorkPoints
 	WorkAxes() *feature.WorkAxes
+	WorkGeometry() *feature.WorkGeometry
 	Units() param.UnitsOfMeasure
 	Parameters() *param.Parameters
 	Recompute()
@@ -290,6 +291,9 @@ var refPlaneCtors = map[types.WorkPlaneKind]refPlaneCtor{
 	}},
 	types.WorkPlaneTwoLines: {2, func(p *feature.WorkPlanes, r []feature.WorkRef) *feature.WorkPlane {
 		return p.AddByTwoLines(r[0], r[1])
+	}},
+	types.WorkPlaneLineAndPoint: {2, func(p *feature.WorkPlanes, r []feature.WorkRef) *feature.WorkPlane {
+		return p.AddByLineAndPoint(r[0], r[1])
 	}},
 	types.WorkPlaneNormalToCurve: {2, func(p *feature.WorkPlanes, r []feature.WorkRef) *feature.WorkPlane {
 		return p.AddByNormalToCurve(r[0], r[1])

--- a/addin/router/work_planes.go
+++ b/addin/router/work_planes.go
@@ -223,14 +223,31 @@ func createWorkPoint(_ *app.Session, host workHost, in wire.CreateWorkPointArgs)
 // buildWorkPoint dispatches a create request to the matching model constructor. An empty kind is
 // the position constructor, so the original position-only request (just "at") is unchanged.
 func buildWorkPoint(host workHost, in wire.CreateWorkPointArgs) (*feature.WorkPoint, error) {
+	pts := host.WorkPoints()
 	switch types.WorkPointKind(in.Kind) {
 	case "", types.WorkPointPosition:
 		return addPositionPoint(host, in)
 	case types.WorkPointPlaneAxisIntersection:
 		return addPlaneAxisPoint(host, in)
+	case types.WorkPointOnPoint:
+		return refPoint(in, 1, func(r []feature.WorkRef) *feature.WorkPoint { return pts.AddByPoint(r[0]) })
+	case types.WorkPointTwoLines:
+		return refPoint(in, 2, func(r []feature.WorkRef) *feature.WorkPoint { return pts.AddByTwoLines(r[0], r[1]) })
+	case types.WorkPointThreePlanes:
+		return refPoint(in, 3, func(r []feature.WorkRef) *feature.WorkPoint { return pts.AddByThreePlanes(r[0], r[1], r[2]) })
 	default:
 		return nil, fmt.Errorf("workPoints.create: unknown kind %q (see api/types WorkPoint*)", in.Kind)
 	}
+}
+
+// refPoint builds a reference-model work point from exactly n references, erroring on the wrong
+// count — the shared arity guard for the on-point / two-lines / three-planes kinds.
+func refPoint(in wire.CreateWorkPointArgs, n int, build func([]feature.WorkRef) *feature.WorkPoint) (*feature.WorkPoint, error) {
+	refs := toWorkRefs(in.Refs)
+	if len(refs) != n {
+		return nil, fmt.Errorf("workPoints.create: %q needs %d references, got %d", in.Kind, n, len(refs))
+	}
+	return build(refs), nil
 }
 
 // addPositionPoint builds the fixed-position point from its [x, y, z] coordinate.

--- a/addin/router/work_relational_test.go
+++ b/addin/router/work_relational_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// Relational work-axis (#1840) and work-point (#1842) constructors over the wire, plus
+// workPoints.list enumeration.
+
+func TestWorkAxisRelationalKinds(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var pt wire.CreateWorkPointResult
+	call(t, r, s, "workPoints.create", `{"at":[0,0,5]}`, &pt)
+
+	cases := []struct{ name, args string }{
+		{"point-and-plane", `{"kind":"point-and-plane","refs":["` + pt.Ref + `","origin/plane/xy"]}`},
+		{"line-and-point", `{"kind":"line-and-point","refs":["origin/axis/x","` + pt.Ref + `"]}`},
+		{"line-and-plane", `{"kind":"line-and-plane","refs":["origin/axis/x","origin/plane/xy"]}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var res wire.CreateWorkAxisResult
+			call(t, r, s, "workAxes.create", c.args, &res)
+			if !res.Healthy {
+				t.Errorf("%s axis not healthy: %+v", c.name, res)
+			}
+		})
+	}
+}
+
+func TestWorkPointRelationalKinds(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var src wire.CreateWorkPointResult
+	call(t, r, s, "workPoints.create", `{"at":[1,2,3]}`, &src)
+
+	cases := []struct{ name, args string }{
+		{"point", `{"kind":"point","refs":["` + src.Ref + `"]}`},
+		{"two-lines", `{"kind":"two-lines","refs":["origin/axis/x","origin/axis/y"]}`},
+		{"three-planes", `{"kind":"three-planes","refs":["origin/plane/xy","origin/plane/xz","origin/plane/yz"]}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var res wire.CreateWorkPointResult
+			call(t, r, s, "workPoints.create", c.args, &res)
+			if !res.Healthy {
+				t.Errorf("%s point not healthy: %+v", c.name, res)
+			}
+		})
+	}
+}
+
+func TestWorkPointRelationalWrongRefCount(t *testing.T) {
+	r, s := emptyPartSession(t)
+	if _, err := r.Handle(s, "workPoints.create", []byte(`{"kind":"three-planes","refs":["origin/plane/xy"]}`)); err == nil {
+		t.Error("three-planes with one ref should error")
+	}
+}
+
+// TestWorkPointsList enumerates points and confirms position/kind/origin read-back (#1842).
+func TestWorkPointsList(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "workPoints.create", `{"at":[1,2,3]}`, &wire.CreateWorkPointResult{})
+	call(t, r, s, "workPoints.create", `{"kind":"two-lines","refs":["origin/axis/x","origin/axis/y"]}`, &wire.CreateWorkPointResult{})
+
+	var list wire.ListWorkPointsResult
+	call(t, r, s, "workPoints.list", "{}", &list)
+	// origin centre + 2 user points.
+	if len(list.Points) < 3 {
+		t.Fatalf("listed %d points, want at least 3 (origin + 2)", len(list.Points))
+	}
+	var origin, twoLines *wire.WorkPointInfo
+	for i := range list.Points {
+		p := &list.Points[i]
+		if p.IsOrigin {
+			origin = p
+		}
+		if p.Kind == "two-lines" {
+			twoLines = p
+		}
+	}
+	if origin == nil {
+		t.Error("list should include the origin centre point")
+	}
+	if twoLines == nil {
+		t.Fatal("list should include the two-lines point")
+	}
+	if p := twoLines.Position; len(p) != 3 || p[0] != 0 || p[1] != 0 || p[2] != 0 {
+		t.Errorf("two-lines point position = %v, want the origin (0,0,0)", twoLines.Position)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.120.0
+	oblikovati.org/api v0.122.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.122.0
+	oblikovati.org/api v0.123.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.122.0
+	oblikovati.org/api v0.123.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.121.0
+	oblikovati.org/api v0.122.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/feature/serialize_work.go
+++ b/model/feature/serialize_work.go
@@ -93,7 +93,7 @@ func serializePlaneDef(def planeDefinition) (WorkFeatureData, error) {
 	case *linePlaneAnglePlaneDef:
 		d.Angle = v.angle()
 	case *threePointPlaneDef, *planeAndPointPlaneDef, *twoPlanesPlaneDef, *twoLinesPlaneDef,
-		*normalToCurvePlaneDef, *torusMidPlaneDef, *pointAndTangentPlaneDef,
+		*lineAndPointPlaneDef, *normalToCurvePlaneDef, *torusMidPlaneDef, *pointAndTangentPlaneDef,
 		*planeAndTangentPlaneDef, *lineAndTangentPlaneDef:
 		// references only
 	default:
@@ -201,6 +201,8 @@ func restorePlaneFeature(c *WorkPlanes, d WorkFeatureData) error {
 		})
 	case "two-lines":
 		return restoreRefPlane(d, 2, func(r []WorkRef) { c.AddByTwoLines(r[0], r[1]) })
+	case "line-point":
+		return restoreRefPlane(d, 2, func(r []WorkRef) { c.AddByLineAndPoint(r[0], r[1]) })
 	case "normal-to-curve":
 		return restoreRefPlane(d, 2, func(r []WorkRef) { c.AddByNormalToCurve(r[0], r[1]) })
 	case "torus-midplane":

--- a/model/feature/serialize_work.go
+++ b/model/feature/serialize_work.go
@@ -110,7 +110,8 @@ func serializeAxisDef(def axisDefinition) (WorkFeatureData, error) {
 			Collection: "axis", Kind: def.kindName(),
 			Position: []float64{float64(p.X), float64(p.Y), float64(p.Z)}, XAxis: unitSlice(v.dir),
 		}, nil
-	case twoPointsAxisDef, planeIntersectionAxisDef:
+	case twoPointsAxisDef, planeIntersectionAxisDef,
+		pointAndPlaneAxisDef, lineAndPointAxisDef, lineAndPlaneAxisDef:
 		return WorkFeatureData{Collection: "axis", Kind: def.kindName(), Refs: refStrings(def.refs())}, nil
 	default:
 		return WorkFeatureData{}, fmt.Errorf("no codec for work axis definition %q", def.kindName())
@@ -127,7 +128,7 @@ func serializePointDef(def pointDefinition) (WorkFeatureData, error) {
 		p := v.FrozenPosition() // last good model position; the source re-derives it after relink (#645)
 		d.CloudID = v.cloudID
 		d.Position = []float64{float64(p.X), float64(p.Y), float64(p.Z)}
-	case planeAxisPointDef:
+	case planeAxisPointDef, pointRefPointDef, twoLinesPointDef, threePlanesPointDef:
 		// references only
 	default:
 		return WorkFeatureData{}, fmt.Errorf("no codec for work point definition %q", def.kindName())
@@ -280,6 +281,12 @@ func restoreAxisFeature(c *WorkAxes, d WorkFeatureData) error {
 		c.AddByTwoPoints(r[0], r[1])
 	case "plane-intersection":
 		c.AddByPlaneIntersection(r[0], r[1])
+	case "point-and-plane":
+		c.AddByPointAndPlane(r[0], r[1])
+	case "line-and-point":
+		c.AddByLineAndPoint(r[0], r[1])
+	case "line-and-plane":
+		c.AddByLineAndPlane(r[0], r[1])
 	default:
 		return fmt.Errorf("no restore codec for work axis kind %q", d.Kind)
 	}
@@ -324,6 +331,27 @@ func restorePointFeature(c *WorkPoints, d WorkFeatureData) error {
 			return err
 		}
 		c.AddByPlaneAndAxisIntersection(r[0], r[1])
+		return nil
+	case "point":
+		r, err := workRefs(d.Refs, 1)
+		if err != nil {
+			return err
+		}
+		c.AddByPoint(r[0])
+		return nil
+	case "two-lines":
+		r, err := workRefs(d.Refs, 2)
+		if err != nil {
+			return err
+		}
+		c.AddByTwoLines(r[0], r[1])
+		return nil
+	case "three-planes":
+		r, err := workRefs(d.Refs, 3)
+		if err != nil {
+			return err
+		}
+		c.AddByThreePlanes(r[0], r[1], r[2])
 		return nil
 	default:
 		return fmt.Errorf("no restore codec for work point kind %q", d.Kind)

--- a/model/feature/work_axis_point.go
+++ b/model/feature/work_axis_point.go
@@ -234,6 +234,7 @@ type WorkPoint struct {
 	health           health.Health
 	coordinateSystem bool
 	grounded         bool
+	visible          bool
 	seq              uint64 // global creation stamp (0 for the origin frame); see model/seq
 }
 
@@ -246,6 +247,11 @@ func (w *WorkPoint) Health() health.Health           { return w.health }
 func (w *WorkPoint) Point() math.Point3              { return w.point }
 func (w *WorkPoint) IsCoordinateSystemElement() bool { return w.coordinateSystem }
 func (w *WorkPoint) Grounded() bool                  { return w.grounded }
+
+// Visible reports whether the datum point is shown; SetVisible toggles it (#1856), matching the
+// visibility a WorkPlane / WorkAxis already carries.
+func (w *WorkPoint) Visible() bool     { return w.visible }
+func (w *WorkPoint) SetVisible(v bool) { w.visible = v }
 
 // recompute re-derives the point.
 func (w *WorkPoint) recompute(r workResolver) {
@@ -289,7 +295,7 @@ func (c *WorkPoints) AddByPlaneAndAxisIntersection(plane, axis WorkRef) *WorkPoi
 }
 
 func (c *WorkPoints) addUser(def pointDefinition) *WorkPoint {
-	w := &WorkPoint{id: nextID(), key: userRef("point", len(c.items)), name: "WorkPoint", def: def, seq: seq.Next()}
+	w := &WorkPoint{id: nextID(), key: userRef("point", len(c.items)), name: "WorkPoint", def: def, visible: true, seq: seq.Next()}
 	c.track(w)
 	c.g.recordUser("point", len(c.items)-1)
 	return w

--- a/model/feature/work_axis_point.go
+++ b/model/feature/work_axis_point.go
@@ -248,6 +248,10 @@ func (w *WorkPoint) Point() math.Point3              { return w.point }
 func (w *WorkPoint) IsCoordinateSystemElement() bool { return w.coordinateSystem }
 func (w *WorkPoint) Grounded() bool                  { return w.grounded }
 
+// Kind returns the point's constructor name (its definition's kind: "position", "two-lines",
+// "three-planes", …) — the vocabulary workPoints.list reports.
+func (w *WorkPoint) Kind() string { return w.def.kindName() }
+
 // Visible reports whether the datum point is shown; SetVisible toggles it (#1856), matching the
 // visibility a WorkPlane / WorkAxis already carries.
 func (w *WorkPoint) Visible() bool     { return w.visible }

--- a/model/feature/work_plane_defs.go
+++ b/model/feature/work_plane_defs.go
@@ -142,6 +142,45 @@ func (d *normalToCurvePlaneDef) eval(r workResolver) (sketch.Plane, error) {
 	return planeFromOriginNormal(p, axis.Direction())
 }
 
+// lineAndPointPlaneDef builds a plane that contains a line and passes through a point (Inventor's
+// AddByLineAndPoint): the line direction is the X axis and the normal is line × (point − lineOrigin),
+// so the plane holds both the line and the point. It is degenerate — no unique plane — when the
+// point lies on the line.
+type lineAndPointPlaneDef struct {
+	line  WorkRef
+	point WorkRef
+}
+
+func (d *lineAndPointPlaneDef) kindName() string { return "line-point" }
+func (d *lineAndPointPlaneDef) refs() []WorkRef  { return []WorkRef{d.line, d.point} }
+func (d *lineAndPointPlaneDef) eval(r workResolver) (sketch.Plane, error) {
+	line, err := r.axis(d.line)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	p, err := r.point(d.point)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	x := line.Direction()
+	normal, err := math.UnitVector3FromVector(x.AsVector().Cross(line.Origin().VectorTo(p)))
+	if err != nil {
+		return sketch.Plane{}, errors.New("the point lies on the line, so no plane is defined")
+	}
+	y, err := math.UnitVector3FromVector(normal.AsVector().Cross(x.AsVector()))
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	return sketch.NewPlane(line.Origin(), x, y)
+}
+
+// AddByLineAndPoint creates a plane that contains line and passes through point (#1843).
+//
+//	wp := planes.AddByLineAndPoint(feature.OriginXAxis, hole.Key())
+func (c *WorkPlanes) AddByLineAndPoint(line, point WorkRef) *WorkPlane {
+	return c.addUser(&lineAndPointPlaneDef{line: line, point: point})
+}
+
 // AddFixed creates a user plane fixed at origin with the given in-plane axes.
 //
 //	x, _ := math.NewUnitVector3(1, 0, 0)

--- a/model/feature/work_plane_line_point_test.go
+++ b/model/feature/work_plane_line_point_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// AddByLineAndPoint (#1843): the plane contains the line and passes through the point; it is
+// degenerate (unhealthy) when the point lies on the line.
+
+// TestAddByLineAndPointBuildsPlane: a plane through the origin X axis and the point (0,5,0) is the
+// XY plane — normal ±Z, containing both the axis origin and the point.
+func TestAddByLineAndPointBuildsPlane(t *testing.T) {
+	g := NewWorkGeometry()
+	pt := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 5, 0) })
+	wp := g.WorkPlanes().AddByLineAndPoint(OriginXAxis, pt.Key())
+	if !wp.Health().OK() {
+		t.Fatalf("line-and-point plane sick: %+v", wp.Health())
+	}
+	if !wp.Plane().Normal().AsVector().IsParallelTo(math.V3(0, 0, 1), wtol) {
+		t.Errorf("normal = %v, want parallel to +Z (the XY plane)", wp.Plane().Normal())
+	}
+	// The plane must contain the through-point: its signed distance to the plane is ~0.
+	n := wp.Plane().Normal().AsVector()
+	if d := n.Dot(wp.Plane().Origin().VectorTo(math.P3(0, 5, 0))); d > wtol || d < -wtol {
+		t.Errorf("through-point off the plane by %v", d)
+	}
+}
+
+// TestAddByLineAndPointDegenerate: a point on the line gives no unique plane (unhealthy).
+func TestAddByLineAndPointDegenerate(t *testing.T) {
+	g := NewWorkGeometry()
+	pt := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(3, 0, 0) }) // on the X axis
+	wp := g.WorkPlanes().AddByLineAndPoint(OriginXAxis, pt.Key())
+	if wp.Health().OK() {
+		t.Error("a point lying on the line should make the plane degenerate/unhealthy")
+	}
+}
+
+// TestWorkPointVisibility: a new work point defaults visible and SetVisible toggles it (#1856).
+func TestWorkPointVisibility(t *testing.T) {
+	g := NewWorkGeometry()
+	pt := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(1, 2, 3) })
+	if !pt.Visible() {
+		t.Error("a new work point should default visible")
+	}
+	pt.SetVisible(false)
+	if pt.Visible() {
+		t.Error("SetVisible(false) should hide the work point")
+	}
+}

--- a/model/feature/work_plane_redefine.go
+++ b/model/feature/work_plane_redefine.go
@@ -193,6 +193,16 @@ func (d *twoLinesPlaneDef) redefineSlots(w *WorkPlane) []WorkRefSlot {
 func (d *twoLinesPlaneDef) editableScalars() []EditableParam { return nil }
 func (d *twoLinesPlaneDef) snapshotState() func()            { return snapshotPointee(d) }
 
+// lineAndPointPlaneDef: the line and the through-point slots (#1843).
+func (d *lineAndPointPlaneDef) redefineSlots(w *WorkPlane) []WorkRefSlot {
+	return []WorkRefSlot{
+		w.slot("Line", WorkRefAxis, func(r WorkRef) { d.line = r }),
+		w.slot("Through point", WorkRefPoint, func(r WorkRef) { d.point = r }),
+	}
+}
+func (d *lineAndPointPlaneDef) editableScalars() []EditableParam { return nil }
+func (d *lineAndPointPlaneDef) snapshotState() func()            { return snapshotPointee(d) }
+
 // normalToCurvePlaneDef: curve + point slots.
 func (d *normalToCurvePlaneDef) redefineSlots(w *WorkPlane) []WorkRefSlot {
 	return []WorkRefSlot{

--- a/model/feature/work_relational_defs.go
+++ b/model/feature/work_relational_defs.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"errors"
+
+	"oblikovati.org/math"
+)
+
+// Relational datum-axis and datum-point constructors built purely on work-feature references
+// (points / lines / planes) — the reference-model half of Inventor's WorkAxes / WorkPoints
+// constructor sets (#1840, #1842). The face/edge-topology constructors (revolved-face,
+// analytic-edge, torus/sphere centre, curve∩surface) need ADR-0040 geometric selectors and are a
+// follow-up. Each captures its references so it round-trips and re-derives on recompute, and
+// reports an error (→ healthy=false) on degenerate input rather than producing garbage.
+
+// --- work axes -------------------------------------------------------------
+
+// pointAndPlaneAxisDef is the axis through a point, normal to a plane (Inventor AddByPointAndPlane).
+type pointAndPlaneAxisDef struct {
+	point WorkRef
+	plane WorkRef
+}
+
+func (d pointAndPlaneAxisDef) kindName() string { return "point-and-plane" }
+func (d pointAndPlaneAxisDef) refs() []WorkRef  { return []WorkRef{d.point, d.plane} }
+func (d pointAndPlaneAxisDef) eval(r workResolver) (math.Point3, math.UnitVector3, error) {
+	pt, err := r.point(d.point)
+	if err != nil {
+		return math.Point3{}, math.UnitVector3{}, err
+	}
+	pl, err := r.plane(d.plane)
+	if err != nil {
+		return math.Point3{}, math.UnitVector3{}, err
+	}
+	return pt, pl.Normal(), nil
+}
+
+// lineAndPointAxisDef is the axis through a point, parallel to a line (Inventor AddByLineAndPoint).
+type lineAndPointAxisDef struct {
+	line  WorkRef
+	point WorkRef
+}
+
+func (d lineAndPointAxisDef) kindName() string { return "line-and-point" }
+func (d lineAndPointAxisDef) refs() []WorkRef  { return []WorkRef{d.line, d.point} }
+func (d lineAndPointAxisDef) eval(r workResolver) (math.Point3, math.UnitVector3, error) {
+	line, err := r.axis(d.line)
+	if err != nil {
+		return math.Point3{}, math.UnitVector3{}, err
+	}
+	pt, err := r.point(d.point)
+	if err != nil {
+		return math.Point3{}, math.UnitVector3{}, err
+	}
+	return pt, line.dir, nil
+}
+
+// lineAndPlaneAxisDef is the input line projected onto a plane along the plane normal (Inventor
+// AddByLineAndPlane). Degenerate when the line is perpendicular to the plane (its projection is a
+// point, not a line).
+type lineAndPlaneAxisDef struct {
+	line  WorkRef
+	plane WorkRef
+}
+
+func (d lineAndPlaneAxisDef) kindName() string { return "line-and-plane" }
+func (d lineAndPlaneAxisDef) refs() []WorkRef  { return []WorkRef{d.line, d.plane} }
+func (d lineAndPlaneAxisDef) eval(r workResolver) (math.Point3, math.UnitVector3, error) {
+	line, err := r.axis(d.line)
+	if err != nil {
+		return math.Point3{}, math.UnitVector3{}, err
+	}
+	pl, err := r.plane(d.plane)
+	if err != nil {
+		return math.Point3{}, math.UnitVector3{}, err
+	}
+	n := pl.Normal().AsVector()
+	ld := line.dir.AsVector()
+	dir, err := math.UnitVector3FromVector(ld.Sub(n.Scale(ld.Dot(n)))) // drop the out-of-plane component
+	if err != nil {
+		return math.Point3{}, math.UnitVector3{}, errors.New("the line is perpendicular to the plane, so its projection is a point")
+	}
+	origin := projectPointOntoPlane(line.origin, pl.Origin(), n)
+	return origin, dir, nil
+}
+
+// projectPointOntoPlane drops p onto the plane through planeOrigin with unit normal n.
+func projectPointOntoPlane(p, planeOrigin math.Point3, n math.Vector3) math.Point3 {
+	return p.TranslateBy(n.Scale(p.VectorTo(planeOrigin).Dot(n)))
+}
+
+// AddByPointAndPlane creates the axis through a point, normal to a plane (#1840).
+func (c *WorkAxes) AddByPointAndPlane(point, plane WorkRef) *WorkAxis {
+	return c.addUser(pointAndPlaneAxisDef{point: point, plane: plane})
+}
+
+// AddByLineAndPoint creates the axis through a point, parallel to a line (#1840).
+func (c *WorkAxes) AddByLineAndPoint(line, point WorkRef) *WorkAxis {
+	return c.addUser(lineAndPointAxisDef{line: line, point: point})
+}
+
+// AddByLineAndPlane creates the axis of the input line projected onto a plane (#1840).
+func (c *WorkAxes) AddByLineAndPlane(line, plane WorkRef) *WorkAxis {
+	return c.addUser(lineAndPlaneAxisDef{line: line, plane: plane})
+}
+
+// --- work points -----------------------------------------------------------
+
+// pointRefPointDef is a datum point coincident with a referenced point/vertex (Inventor AddByPoint).
+type pointRefPointDef struct{ point WorkRef }
+
+func (d pointRefPointDef) kindName() string                         { return "point" }
+func (d pointRefPointDef) refs() []WorkRef                          { return []WorkRef{d.point} }
+func (d pointRefPointDef) eval(r workResolver) (math.Point3, error) { return r.point(d.point) }
+
+// twoLinesPointDef is the intersection of two lines (Inventor AddByTwoLines). Degenerate when the
+// lines are parallel or skew (do not meet).
+type twoLinesPointDef struct{ l1, l2 WorkRef }
+
+func (d twoLinesPointDef) kindName() string { return "two-lines" }
+func (d twoLinesPointDef) refs() []WorkRef  { return []WorkRef{d.l1, d.l2} }
+func (d twoLinesPointDef) eval(r workResolver) (math.Point3, error) {
+	l1, err := r.axis(d.l1)
+	if err != nil {
+		return math.Point3{}, err
+	}
+	l2, err := r.axis(d.l2)
+	if err != nil {
+		return math.Point3{}, err
+	}
+	return lineLineIntersection(l1.origin, l1.dir.AsVector(), l2.origin, l2.dir.AsVector())
+}
+
+// lineLineIntersection returns the point where two lines meet, or an error when they are parallel
+// (no cross product) or skew (their closest points do not coincide).
+func lineLineIntersection(o1 math.Point3, d1 math.Vector3, o2 math.Point3, d2 math.Vector3) (math.Point3, error) {
+	cross := d1.Cross(d2)
+	denom := cross.LengthSquared()
+	if math.IsNearZero(denom, math.DefaultTolerance) {
+		return math.Point3{}, errors.New("the two lines are parallel")
+	}
+	r := o1.VectorTo(o2)
+	p1 := o1.TranslateBy(d1.Scale(r.Cross(d2).Dot(cross) / denom))
+	p2 := o2.TranslateBy(d2.Scale(r.Cross(d1).Dot(cross) / denom))
+	if p1.VectorTo(p2).LengthSquared() > math.DefaultTolerance {
+		return math.Point3{}, errors.New("the two lines are skew and do not intersect")
+	}
+	return p1, nil
+}
+
+// threePlanesPointDef is the intersection point of three planes (Inventor AddByThreePlanes) — the
+// line where the first two meet, intersected with the third. Degenerate when any two are parallel
+// or the third is parallel to that line (no unique point).
+type threePlanesPointDef struct{ p1, p2, p3 WorkRef }
+
+func (d threePlanesPointDef) kindName() string { return "three-planes" }
+func (d threePlanesPointDef) refs() []WorkRef  { return []WorkRef{d.p1, d.p2, d.p3} }
+func (d threePlanesPointDef) eval(r workResolver) (math.Point3, error) {
+	p1, err := r.plane(d.p1)
+	if err != nil {
+		return math.Point3{}, err
+	}
+	p2, err := r.plane(d.p2)
+	if err != nil {
+		return math.Point3{}, err
+	}
+	p3, err := r.plane(d.p3)
+	if err != nil {
+		return math.Point3{}, err
+	}
+	o, dir, err := planeIntersectionLine(p1, p2)
+	if err != nil {
+		return math.Point3{}, errors.New("the first two planes are parallel")
+	}
+	n3 := p3.Normal().AsVector()
+	denom := dir.AsVector().Dot(n3)
+	if math.IsNearZero(denom, math.DefaultTolerance) {
+		return math.Point3{}, errors.New("the three planes do not meet at a single point")
+	}
+	return o.TranslateBy(dir.AsVector().Scale(o.VectorTo(p3.Origin()).Dot(n3) / denom)), nil
+}
+
+// AddByPoint creates a datum point coincident with a referenced point (#1842).
+func (c *WorkPoints) AddByPoint(point WorkRef) *WorkPoint {
+	return c.addUser(pointRefPointDef{point: point})
+}
+
+// AddByTwoLines creates a datum point where two lines intersect (#1842).
+func (c *WorkPoints) AddByTwoLines(l1, l2 WorkRef) *WorkPoint {
+	return c.addUser(twoLinesPointDef{l1: l1, l2: l2})
+}
+
+// AddByThreePlanes creates a datum point at the intersection of three planes (#1842).
+func (c *WorkPoints) AddByThreePlanes(p1, p2, p3 WorkRef) *WorkPoint {
+	return c.addUser(threePlanesPointDef{p1: p1, p2: p2, p3: p3})
+}

--- a/model/feature/work_relational_defs_test.go
+++ b/model/feature/work_relational_defs_test.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// Relational datum-axis (#1840) and datum-point (#1842) constructors: analytic checks that each
+// builds the expected geometry and reports degenerate input as unhealthy.
+
+func TestAxisPointAndPlane(t *testing.T) {
+	g := NewWorkGeometry()
+	pt := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 0, 5) })
+	wa := g.WorkAxes().AddByPointAndPlane(pt.Key(), OriginXYPlane)
+	if !wa.Health().OK() {
+		t.Fatalf("point-and-plane axis sick: %+v", wa.Health())
+	}
+	if !wa.Origin().IsEqualTo(math.P3(0, 0, 5), wtol) {
+		t.Errorf("origin = %v, want (0,0,5)", wa.Origin())
+	}
+	if !wa.Direction().AsVector().IsParallelTo(math.V3(0, 0, 1), wtol) {
+		t.Errorf("direction = %v, want +Z (the XY normal)", wa.Direction())
+	}
+}
+
+func TestAxisLineAndPoint(t *testing.T) {
+	g := NewWorkGeometry()
+	pt := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 5, 0) })
+	wa := g.WorkAxes().AddByLineAndPoint(OriginXAxis, pt.Key())
+	if !wa.Health().OK() {
+		t.Fatalf("line-and-point axis sick: %+v", wa.Health())
+	}
+	if !wa.Origin().IsEqualTo(math.P3(0, 5, 0), wtol) || !wa.Direction().AsVector().IsParallelTo(math.V3(1, 0, 0), wtol) {
+		t.Errorf("axis = %v dir %v, want through (0,5,0) parallel to X", wa.Origin(), wa.Direction())
+	}
+}
+
+func TestAxisLineAndPlane(t *testing.T) {
+	g := NewWorkGeometry()
+	// A grounded line at 45° in the XZ plane, projected onto XY, becomes the X axis.
+	diag, _ := math.NewUnitVector3(1, 0, 1)
+	line := g.WorkAxes().AddByLine(math.P3(0, 0, 2), diag)
+	wa := g.WorkAxes().AddByLineAndPlane(line.Key(), OriginXYPlane)
+	if !wa.Health().OK() {
+		t.Fatalf("line-and-plane axis sick: %+v", wa.Health())
+	}
+	if !wa.Direction().AsVector().IsParallelTo(math.V3(1, 0, 0), wtol) {
+		t.Errorf("projected direction = %v, want +X", wa.Direction())
+	}
+	if o := wa.Origin(); o.Z > wtol || o.Z < -wtol {
+		t.Errorf("projected origin Z = %v, want on the XY plane (0)", o.Z)
+	}
+}
+
+func TestAxisLineAndPlanePerpendicularIsDegenerate(t *testing.T) {
+	g := NewWorkGeometry()
+	line := g.WorkAxes().AddByLine(math.P3(0, 0, 3), mustUnit(0, 0, 1)) // ⟂ to XY
+	wa := g.WorkAxes().AddByLineAndPlane(line.Key(), OriginXYPlane)
+	if wa.Health().OK() {
+		t.Error("a line perpendicular to the plane should be degenerate")
+	}
+}
+
+func TestPointByPoint(t *testing.T) {
+	g := NewWorkGeometry()
+	src := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(1, 2, 3) })
+	wp := g.WorkPoints().AddByPoint(src.Key())
+	if !wp.Point().IsEqualTo(math.P3(1, 2, 3), wtol) {
+		t.Errorf("point = %v, want (1,2,3)", wp.Point())
+	}
+}
+
+func TestPointTwoLinesIntersectAtOrigin(t *testing.T) {
+	g := NewWorkGeometry()
+	wp := g.WorkPoints().AddByTwoLines(OriginXAxis, OriginYAxis)
+	if !wp.Health().OK() {
+		t.Fatalf("two-lines point sick: %+v", wp.Health())
+	}
+	if !wp.Point().IsEqualTo(math.P3(0, 0, 0), wtol) {
+		t.Errorf("X∩Y = %v, want the origin", wp.Point())
+	}
+}
+
+func TestPointTwoLinesSkewIsDegenerate(t *testing.T) {
+	g := NewWorkGeometry()
+	// The X axis and a Y-parallel line lifted to z=5 never meet.
+	skew := g.WorkAxes().AddByLine(math.P3(0, 0, 5), mustUnit(0, 1, 0))
+	wp := g.WorkPoints().AddByTwoLines(OriginXAxis, skew.Key())
+	if wp.Health().OK() {
+		t.Error("skew lines should be degenerate")
+	}
+}
+
+func TestPointThreePlanesAtOrigin(t *testing.T) {
+	g := NewWorkGeometry()
+	wp := g.WorkPoints().AddByThreePlanes(OriginXYPlane, OriginXZPlane, OriginYZPlane)
+	if !wp.Health().OK() {
+		t.Fatalf("three-planes point sick: %+v", wp.Health())
+	}
+	if !wp.Point().IsEqualTo(math.P3(0, 0, 0), wtol) {
+		t.Errorf("XY∩XZ∩YZ = %v, want the origin", wp.Point())
+	}
+}
+
+func TestPointThreePlanesParallelIsDegenerate(t *testing.T) {
+	g := NewWorkGeometry()
+	off := g.WorkPlanes().AddByPlaneAndOffset(OriginXYPlane, func() float64 { return 5 }) // parallel to XY
+	wp := g.WorkPoints().AddByThreePlanes(OriginXYPlane, off.Key(), OriginXZPlane)
+	if wp.Health().OK() {
+		t.Error("two parallel planes should make the three-plane point degenerate")
+	}
+}

--- a/model/feature/work_relational_defs_test.go
+++ b/model/feature/work_relational_defs_test.go
@@ -3,13 +3,93 @@
 package feature
 
 import (
+	"reflect"
 	"testing"
 
 	"oblikovati.org/math"
 )
 
+// TestRelationalWorkFeaturesRoundTrip marshals a part holding every new relational axis/point kind
+// and restores it, asserting the recipe is stable — exercising each definition's kindName/refs and
+// the .obk encode/decode codecs (#1840, #1842).
+func TestRelationalWorkFeaturesRoundTrip(t *testing.T) {
+	g := NewWorkGeometry()
+	pt := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 0, 5) })
+	g.WorkAxes().AddByPointAndPlane(pt.Key(), OriginXYPlane)
+	g.WorkAxes().AddByLineAndPoint(OriginXAxis, pt.Key())
+	g.WorkAxes().AddByLineAndPlane(OriginXAxis, OriginXYPlane)
+	g.WorkPoints().AddByPoint(pt.Key())
+	g.WorkPoints().AddByTwoLines(OriginXAxis, OriginYAxis)
+	g.WorkPoints().AddByThreePlanes(OriginXYPlane, OriginXZPlane, OriginYZPlane)
+
+	data, err := MarshalWork(g)
+	if err != nil {
+		t.Fatalf("MarshalWork: %v", err)
+	}
+	restored := NewWorkGeometry()
+	if err := ApplyWork(restored, data); err != nil {
+		t.Fatalf("ApplyWork: %v", err)
+	}
+	again, err := MarshalWork(restored)
+	if err != nil {
+		t.Fatalf("re-MarshalWork: %v", err)
+	}
+	if !reflect.DeepEqual(data, again) {
+		t.Errorf("relational work features did not round-trip:\n first=%+v\n again=%+v", data, again)
+	}
+	// The restored kinds and health match the originals.
+	if a := restored.WorkAxes(); a.Item(a.Count()-1).Kind() != "line-and-plane" {
+		t.Errorf("last restored axis kind = %q, want line-and-plane", a.Item(a.Count()-1).Kind())
+	}
+	if p := restored.WorkPoints(); p.Item(p.Count()-1).Kind() != "three-planes" || !p.Item(p.Count()-1).Health().OK() {
+		t.Errorf("last restored point = kind %q healthy %v, want three-planes healthy", p.Item(p.Count()-1).Kind(), p.Item(p.Count()-1).Health().OK())
+	}
+}
+
 // Relational datum-axis (#1840) and datum-point (#1842) constructors: analytic checks that each
 // builds the expected geometry and reports degenerate input as unhealthy.
+
+// TestRelationalUnresolvedRefsAreUnhealthy: every relational constructor goes unhealthy when a
+// reference cannot resolve, exercising each definition's ref-resolution error path.
+func TestRelationalUnresolvedRefsAreUnhealthy(t *testing.T) {
+	const bad = WorkRef("plane/999") // resolves as no axis / no plane / no point
+	build := []struct {
+		name    string
+		healthy func(*WorkGeometry) bool
+	}{
+		{"axis point-and-plane", func(g *WorkGeometry) bool { return g.WorkAxes().AddByPointAndPlane(bad, OriginXYPlane).Health().OK() }},
+		{"axis point-and-plane bad plane", func(g *WorkGeometry) bool {
+			return g.WorkAxes().AddByPointAndPlane(OriginCenter, bad).Health().OK()
+		}},
+		{"axis line-and-point", func(g *WorkGeometry) bool { return g.WorkAxes().AddByLineAndPoint(bad, OriginCenter).Health().OK() }},
+		{"axis line-and-point bad point", func(g *WorkGeometry) bool {
+			return g.WorkAxes().AddByLineAndPoint(OriginXAxis, bad).Health().OK()
+		}},
+		{"axis line-and-plane", func(g *WorkGeometry) bool { return g.WorkAxes().AddByLineAndPlane(bad, OriginXYPlane).Health().OK() }},
+		{"axis line-and-plane bad plane", func(g *WorkGeometry) bool {
+			return g.WorkAxes().AddByLineAndPlane(OriginXAxis, bad).Health().OK()
+		}},
+		{"point on-point", func(g *WorkGeometry) bool { return g.WorkPoints().AddByPoint(bad).Health().OK() }},
+		{"point two-lines", func(g *WorkGeometry) bool { return g.WorkPoints().AddByTwoLines(bad, OriginYAxis).Health().OK() }},
+		{"point two-lines second", func(g *WorkGeometry) bool {
+			return g.WorkPoints().AddByTwoLines(OriginXAxis, bad).Health().OK()
+		}},
+		{"point three-planes", func(g *WorkGeometry) bool {
+			return g.WorkPoints().AddByThreePlanes(bad, OriginXZPlane, OriginYZPlane).Health().OK()
+		}},
+		{"point three-planes second", func(g *WorkGeometry) bool {
+			return g.WorkPoints().AddByThreePlanes(OriginXYPlane, bad, OriginYZPlane).Health().OK()
+		}},
+		{"point three-planes third", func(g *WorkGeometry) bool {
+			return g.WorkPoints().AddByThreePlanes(OriginXYPlane, OriginXZPlane, bad).Health().OK()
+		}},
+	}
+	for _, b := range build {
+		if b.healthy(NewWorkGeometry()) {
+			t.Errorf("%s with an unresolvable reference should be unhealthy", b.name)
+		}
+	}
+}
 
 func TestAxisPointAndPlane(t *testing.T) {
 	g := NewWorkGeometry()


### PR DESCRIPTION
Part of milestone #44 (M33 Inventor-API parity), Wave C — Work Features. Host side of Oblikovati.API#247 (v0.122.0) + #248 (v0.123.0). Four Work-Features issues batched (the relational ctors folded in because the v0.123.0 API's new `workPoints.list` method requires a router handler here — the parity guard fails otherwise).

## #1843 — line-and-point work plane (completes WorkPlanes 13/13)
`WorkPlanes.AddByLineAndPoint(line, point)` — contains the line, passes through the point; degenerate when the point is on the line.

## #1856 — datum visibility toggle
`WorkPoint.Visible` + `workFeatures.setVisible{ref, visible}` resolving plane/axis/point refs. Display-only (no recompute — satisfies the router-mutation-seam archguard).

## #1840 — WorkAxes: 3 relational constructors
`point-and-plane`, `line-and-point`, `line-and-plane` (line projected onto plane).

## #1842 — WorkPoints: 3 relational constructors + enumeration
`point`, `two-lines`, `three-planes`, and **`workPoints.list`**.

## Tests
Analytic geometry at the model layer (two-lines/three-planes → origin, projections, all degenerate cases) + router dispatch, enumeration read-back, archguard, and wire-parity. Each new datum round-trips through the `.obk` codec.

## Deferred
Face/edge-topology constructors (revolved-face, analytic-edge, normal-to-surface, torus/sphere centre, curve∩surface, midpoint-of-edge) need ADR-0040 selectors — remain on #1840/#1842. flipNormal/autoResize/etc. remain on #1851.

🤖 Generated with [Claude Code](https://claude.com/claude-code)