### PR TITLE
feat(work-features): delete datums (tombstone + cascade/retain) + construction flag (#1855, #1849)

### DIFF
--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -204,6 +204,7 @@ func (r *Router) registerStandardHandlers() {
 	r.readOnly(wire.MethodWorkAxesList, ctxQuery(activeWorkHost, listWorkAxes))
 	r.mutating(wire.MethodWorkAxesCreate, "Create Work Axis", typedCtx(activeWorkHost, createWorkAxis))
 	r.mutating(wire.MethodWorkFeaturesSetVisible, "Set Work Feature Visibility", typedCtx(activeWorkHost, setWorkFeatureVisible))
+	r.mutating(wire.MethodWorkFeaturesDelete, "Delete Work Feature", typedCtx(activeWorkHost, deleteWorkFeature))
 
 	r.readOnly(wire.MethodWorkSurfacesList, partQuery(listWorkSurfaces))
 	r.readOnly(wire.MethodWorkSurfacesGet, typedPart(getWorkSurface))

--- a/addin/router/typed.go
+++ b/addin/router/typed.go
@@ -145,3 +145,21 @@ func projectAll[I, Info any](col indexed[I], project func(int, I) Info) []Info {
 	}
 	return out
 }
+
+// tombstonable is a datum that can be deleted by tombstone (work planes/axes/points, #1855).
+type tombstonable interface{ Deleted() bool }
+
+// projectLiveDatums is projectAll for a datum collection: it skips tombstoned (deleted) items
+// while passing each surviving row its stable COLLECTION index, so a redefine index and a
+// "plane/N" reference keep resolving after a delete (#1855).
+func projectLiveDatums[I tombstonable, Info any](col indexed[I], project func(int, I) Info) []Info {
+	out := make([]Info, 0, col.Count())
+	for i := 0; i < col.Count(); i++ {
+		it := col.Item(i)
+		if it.Deleted() {
+			continue
+		}
+		out = append(out, project(i, it))
+	}
+	return out
+}

--- a/addin/router/work_axes.go
+++ b/addin/router/work_axes.go
@@ -20,7 +20,7 @@ import (
 // listWorkAxes enumerates the active model's datum axes (origin frame first, then user axes)
 // with their current geometry and health.
 func listWorkAxes(_ *app.Session, host workHost) (wire.ListWorkAxesResult, error) {
-	axes := projectAll(host.WorkAxes(), workAxisInfo)
+	axes := projectLiveDatums(host.WorkAxes(), workAxisInfo)
 	return wire.ListWorkAxesResult{Axes: axes}, nil
 }
 
@@ -28,37 +28,39 @@ func listWorkAxes(_ *app.Session, host workHost) (wire.ListWorkAxesResult, error
 // whether it is one of the origin coordinate axes, health, and constructor kind.
 func workAxisInfo(index int, wa *feature.WorkAxis) wire.WorkAxisInfo {
 	return wire.WorkAxisInfo{
-		Index:     index,
-		Name:      wa.Name(),
-		Ref:       string(wa.Key()),
-		Kind:      wa.Kind(),
-		Origin:    point3Slice(wa.Origin()),
-		Direction: vector3Slice(wa.Direction().AsVector()),
-		IsOrigin:  wa.IsCoordinateSystemElement(),
-		Healthy:   wa.Health().OK(),
-		Reason:    wa.Health().Reason, // empty when healthy
+		Index:        index,
+		Name:         wa.Name(),
+		Ref:          string(wa.Key()),
+		Kind:         wa.Kind(),
+		Origin:       point3Slice(wa.Origin()),
+		Direction:    vector3Slice(wa.Direction().AsVector()),
+		IsOrigin:     wa.IsCoordinateSystemElement(),
+		Construction: wa.Construction(),
+		Healthy:      wa.Health().OK(),
+		Reason:       wa.Health().Reason, // empty when healthy
 	}
 }
 
 // listWorkPoints enumerates the active model's datum points (origin centre first, then user
 // points) with their position, kind, origin flag, visibility, and health (#1842).
 func listWorkPoints(_ *app.Session, host workHost) (wire.ListWorkPointsResult, error) {
-	points := projectAll(host.WorkPoints(), workPointInfo)
+	points := projectLiveDatums(host.WorkPoints(), workPointInfo)
 	return wire.ListWorkPointsResult{Points: points}, nil
 }
 
 // workPointInfo renders one datum point as the wire DTO.
 func workPointInfo(index int, wp *feature.WorkPoint) wire.WorkPointInfo {
 	return wire.WorkPointInfo{
-		Index:    index,
-		Name:     wp.Name(),
-		Ref:      string(wp.Key()),
-		Position: point3Slice(wp.Point()),
-		IsOrigin: wp.IsCoordinateSystemElement(),
-		Visible:  wp.Visible(),
-		Healthy:  wp.Health().OK(),
-		Reason:   wp.Health().Reason, // empty when healthy
-		Kind:     wp.Kind(),
+		Index:        index,
+		Name:         wp.Name(),
+		Ref:          string(wp.Key()),
+		Position:     point3Slice(wp.Point()),
+		IsOrigin:     wp.IsCoordinateSystemElement(),
+		Visible:      wp.Visible(),
+		Construction: wp.Construction(),
+		Healthy:      wp.Health().OK(),
+		Reason:       wp.Health().Reason, // empty when healthy
+		Kind:         wp.Kind(),
 	}
 }
 

--- a/addin/router/work_features_test.go
+++ b/addin/router/work_features_test.go
@@ -74,3 +74,116 @@ func TestSetWorkFeatureVisibleUnknownRef(t *testing.T) {
 		t.Error("an unknown ref should error")
 	}
 }
+
+// TestDeleteWorkFeature removes a user plane over the wire: the delete reports it removed, and
+// workPlanes.list no longer includes it (#1855).
+func TestDeleteWorkFeature(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var pl wire.CreateWorkPlaneResult
+	call(t, r, s, "workPlanes.create", `{"kind":"plane-offset","refs":["origin/plane/xy"],"offset":"10 mm"}`, &pl)
+
+	var del wire.DeleteWorkFeatureResult
+	call(t, r, s, "workFeatures.delete", `{"ref":"`+pl.Ref+`","retainDependents":true}`, &del)
+	if len(del.Deleted) != 1 || del.Deleted[0] != pl.Ref {
+		t.Errorf("deleted = %v, want just %q", del.Deleted, pl.Ref)
+	}
+	var list wire.ListWorkPlanesResult
+	call(t, r, s, "workPlanes.list", "{}", &list)
+	for _, p := range list.Planes {
+		if p.Ref == pl.Ref {
+			t.Error("a deleted plane should not appear in workPlanes.list")
+		}
+	}
+}
+
+// TestDeleteWorkFeatureCascades: deleting a point (retainDependents=false) also removes the axis
+// built through it, and both drop out of their lists (#1855).
+func TestDeleteWorkFeatureCascades(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var pt wire.CreateWorkPointResult
+	call(t, r, s, "workPoints.create", `{"at":[0,0,5]}`, &pt)
+	var ax wire.CreateWorkAxisResult
+	call(t, r, s, "workAxes.create", `{"kind":"two-points","refs":["`+pt.Ref+`","origin/point/center"]}`, &ax)
+
+	var del wire.DeleteWorkFeatureResult
+	call(t, r, s, "workFeatures.delete", `{"ref":"`+pt.Ref+`"}`, &del)
+	if len(del.Deleted) != 2 {
+		t.Errorf("deleted = %v, want the point and its dependent axis", del.Deleted)
+	}
+	var axes wire.ListWorkAxesResult
+	call(t, r, s, "workAxes.list", "{}", &axes)
+	for _, a := range axes.Axes {
+		if a.Ref == ax.Ref {
+			t.Error("the cascaded axis should be gone from workAxes.list")
+		}
+	}
+}
+
+// TestDeleteWorkFeatureErrors: an origin ref and an unknown ref both fail cleanly (#1855).
+func TestDeleteWorkFeatureErrors(t *testing.T) {
+	r, s := emptyPartSession(t)
+	if _, err := r.Handle(s, "workFeatures.delete", []byte(`{"ref":"origin/plane/xy"}`)); err == nil {
+		t.Error("deleting an origin datum should error")
+	}
+	if _, err := r.Handle(s, "workFeatures.delete", []byte(`{"ref":"point/404"}`)); err == nil {
+		t.Error("deleting an unknown ref should error")
+	}
+}
+
+// TestCreateConstructionDatum: the construction flag on create is reported back on each list DTO,
+// independent of visibility (#1849).
+func TestCreateConstructionDatum(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var pl wire.CreateWorkPlaneResult
+	call(t, r, s, "workPlanes.create", `{"kind":"plane-offset","refs":["origin/plane/xy"],"offset":"5 mm","construction":true,"visible":false}`, &pl)
+	var pt wire.CreateWorkPointResult
+	call(t, r, s, "workPoints.create", `{"at":[1,2,3],"construction":true}`, &pt)
+	var ax wire.CreateWorkAxisResult
+	call(t, r, s, "workAxes.create", `{"kind":"line","origin":[0,0,0],"direction":[0,0,1],"construction":true}`, &ax)
+
+	var planes wire.ListWorkPlanesResult
+	call(t, r, s, "workPlanes.list", "{}", &planes)
+	if !findPlane(planes.Planes, pl.Ref).Construction {
+		t.Error("plane should report construction=true")
+	}
+	if findPlane(planes.Planes, pl.Ref).Visible {
+		t.Error("construction and visible are independent; this plane was created hidden")
+	}
+	var points wire.ListWorkPointsResult
+	call(t, r, s, "workPoints.list", "{}", &points)
+	if !findPointConstruction(points.Points, pt.Ref) {
+		t.Error("point should report construction=true")
+	}
+	var axes wire.ListWorkAxesResult
+	call(t, r, s, "workAxes.list", "{}", &axes)
+	if !findAxisConstruction(axes.Axes, ax.Ref) {
+		t.Error("axis should report construction=true")
+	}
+}
+
+func findPlane(planes []wire.WorkPlaneInfo, ref string) wire.WorkPlaneInfo {
+	for _, p := range planes {
+		if p.Ref == ref {
+			return p
+		}
+	}
+	return wire.WorkPlaneInfo{}
+}
+
+func findPointConstruction(points []wire.WorkPointInfo, ref string) bool {
+	for _, p := range points {
+		if p.Ref == ref {
+			return p.Construction
+		}
+	}
+	return false
+}
+
+func findAxisConstruction(axes []wire.WorkAxisInfo, ref string) bool {
+	for _, a := range axes {
+		if a.Ref == ref {
+			return a.Construction
+		}
+	}
+	return false
+}

--- a/addin/router/work_planes.go
+++ b/addin/router/work_planes.go
@@ -54,7 +54,7 @@ func activeWorkHost(s *app.Session) (workHost, error) {
 // listWorkPlanes enumerates the active model's datum planes (origin frame first, then
 // user planes) with their current geometry and health.
 func listWorkPlanes(_ *app.Session, host workHost) (wire.ListWorkPlanesResult, error) {
-	planes := projectAll(host.WorkPlanes(), func(i int, wp *feature.WorkPlane) wire.WorkPlaneInfo {
+	planes := projectLiveDatums(host.WorkPlanes(), func(i int, wp *feature.WorkPlane) wire.WorkPlaneInfo {
 		return workPlaneInfo(host, wp, i)
 	})
 	return wire.ListWorkPlanesResult{Planes: planes}, nil
@@ -65,18 +65,19 @@ func listWorkPlanes(_ *app.Session, host workHost) (wire.ListWorkPlanesResult, e
 // reference slots (each tagged plane|axis|point|face). Origin planes report neither.
 func workPlaneInfo(host workHost, wp *feature.WorkPlane, index int) wire.WorkPlaneInfo {
 	return wire.WorkPlaneInfo{
-		Index:    index,
-		Name:     wp.Name(),
-		Ref:      string(wp.Key()),
-		Origin:   point3Slice(wp.Plane().Origin()),
-		Normal:   vector3Slice(wp.Plane().Normal().AsVector()),
-		IsOrigin: wp.IsCoordinateSystemElement(),
-		Visible:  wp.Visible(),
-		Healthy:  wp.Health().OK(),
-		Reason:   wp.Health().Reason, // empty when healthy
-		Kind:     wp.Kind(),
-		Scalars:  workPlaneScalars(host, wp),
-		Slots:    workPlaneSlots(wp),
+		Index:        index,
+		Name:         wp.Name(),
+		Ref:          string(wp.Key()),
+		Origin:       point3Slice(wp.Plane().Origin()),
+		Normal:       vector3Slice(wp.Plane().Normal().AsVector()),
+		IsOrigin:     wp.IsCoordinateSystemElement(),
+		Visible:      wp.Visible(),
+		Construction: wp.Construction(),
+		Healthy:      wp.Health().OK(),
+		Reason:       wp.Health().Reason, // empty when healthy
+		Kind:         wp.Kind(),
+		Scalars:      workPlaneScalars(host, wp),
+		Slots:        workPlaneSlots(wp),
 	}
 }
 
@@ -189,8 +190,9 @@ func createWorkPlanes(_ *app.Session, host workHost, in wire.CreateWorkPlaneArgs
 		return wire.CreateWorkPlaneResult{}, err
 	}
 	if in.Visible != nil {
-		wp.SetVisible(*in.Visible) // an add-in can create a construction datum hidden (issue: PartDesigner)
+		wp.SetVisible(*in.Visible) // viewport display, orthogonal to Construction
 	}
+	wp.SetConstruction(in.Construction) // hidden, consumer-tied datum (#1849)
 	host.Recompute()
 	return wire.CreateWorkPlaneResult{
 		Index:   host.WorkPlanes().Count() - 1,
@@ -210,6 +212,7 @@ func createWorkPoint(_ *app.Session, host workHost, in wire.CreateWorkPointArgs)
 	if err != nil {
 		return wire.CreateWorkPointResult{}, err
 	}
+	wp.SetConstruction(in.Construction) // hidden, consumer-tied datum (#1849)
 	host.Recompute()
 	return wire.CreateWorkPointResult{
 		Index:   host.WorkPoints().Count() - 1,
@@ -278,6 +281,7 @@ func createWorkAxis(_ *app.Session, host workHost, in wire.CreateWorkAxisArgs) (
 	if err != nil {
 		return wire.CreateWorkAxisResult{}, err
 	}
+	wa.SetConstruction(in.Construction) // hidden, consumer-tied datum (#1849)
 	host.Recompute()
 	return wire.CreateWorkAxisResult{
 		Index:   host.WorkAxes().Count() - 1,
@@ -286,6 +290,30 @@ func createWorkAxis(_ *app.Session, host workHost, in wire.CreateWorkAxisArgs) (
 		Healthy: wa.Health().OK(),
 		Reason:  wa.Health().Reason,
 	}, nil
+}
+
+// deleteWorkFeature tombstones the user datum work plane, axis, or point named by the request's ref
+// and recomputes, so any retained dependent re-derives and goes unhealthy. It fails on an origin
+// datum, an unknown ref, or an already-deleted datum (feature.DeleteWork enforces this), and
+// returns every ref removed — the named datum plus, when RetainDependents is false, its cascaded
+// dependents (#1855). Like createWorkPoint it self-orchestrates the work-geometry recompute (audit
+// B1); the mutating router seam records the undo step / edit broadcast.
+func deleteWorkFeature(_ *app.Session, host workHost, in wire.DeleteWorkFeatureArgs) (wire.DeleteWorkFeatureResult, error) {
+	removed, err := host.WorkGeometry().DeleteWork(toWorkRef(in.Ref), in.RetainDependents)
+	if err != nil {
+		return wire.DeleteWorkFeatureResult{}, err
+	}
+	host.Recompute()
+	return wire.DeleteWorkFeatureResult{Deleted: workRefStrings(removed)}, nil
+}
+
+// workRefStrings renders a slice of work references as their wire string form.
+func workRefStrings(refs []feature.WorkRef) []string {
+	out := make([]string, len(refs))
+	for i, r := range refs {
+		out[i] = string(r)
+	}
+	return out
 }
 
 // refPlaneCtor builds a work plane from exactly its references (no scalar parameters);

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.123.0
+	oblikovati.org/api v0.124.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.123.0
+	oblikovati.org/api v0.124.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/feature/serialize_work.go
+++ b/model/feature/serialize_work.go
@@ -20,16 +20,18 @@ import (
 // WorkFeatureData is the recipe form of one user work feature: which collection it
 // belongs to, its definition kind, the references it is built on, and any parameter.
 type WorkFeatureData struct {
-	Collection string    `yaml:"collection"` // plane | axis | point
-	Kind       string    `yaml:"kind"`
-	Seq        uint64    `yaml:"seq,omitempty"` // global creation stamp; see model/seq
-	Refs       []string  `yaml:"refs,omitempty"`
-	Offset     float64   `yaml:"offset,omitempty"`   // plane-offset
-	Angle      float64   `yaml:"angle,omitempty"`    // line-plane-angle
-	Position   []float64 `yaml:"position,omitempty"` // point position / fixed-frame origin [x,y,z]
-	XAxis      []float64 `yaml:"xaxis,omitempty"`    // fixed-frame X axis [x,y,z]
-	YAxis      []float64 `yaml:"yaxis,omitempty"`    // fixed-frame Y axis [x,y,z]
-	CloudID    string    `yaml:"cloud,omitempty"`    // point-cloud-fit: the source cloud's id (provenance, #645)
+	Collection   string    `yaml:"collection"` // plane | axis | point
+	Kind         string    `yaml:"kind"`
+	Seq          uint64    `yaml:"seq,omitempty"`          // global creation stamp; see model/seq
+	Construction bool      `yaml:"construction,omitempty"` // hidden, consumer-tied datum (#1849)
+	Deleted      bool      `yaml:"deleted,omitempty"`      // tombstoned; slot kept for ref stability (#1855)
+	Refs         []string  `yaml:"refs,omitempty"`
+	Offset       float64   `yaml:"offset,omitempty"`   // plane-offset
+	Angle        float64   `yaml:"angle,omitempty"`    // line-plane-angle
+	Position     []float64 `yaml:"position,omitempty"` // point position / fixed-frame origin [x,y,z]
+	XAxis        []float64 `yaml:"xaxis,omitempty"`    // fixed-frame X axis [x,y,z]
+	YAxis        []float64 `yaml:"yaxis,omitempty"`    // fixed-frame Y axis [x,y,z]
+	CloudID      string    `yaml:"cloud,omitempty"`    // point-cloud-fit: the source cloud's id (provenance, #645)
 }
 
 // MarshalWork projects the user work features into the recipe, in creation order.
@@ -46,32 +48,33 @@ func MarshalWork(g *WorkGeometry) ([]WorkFeatureData, error) {
 }
 
 func serializeWorkFeature(g *WorkGeometry, e userEntry) (WorkFeatureData, error) {
-	d, s, err := serializeWorkDef(g, e)
+	d, s, c, del, err := serializeWorkDef(g, e)
 	if err != nil {
 		return WorkFeatureData{}, err
 	}
-	d.Seq = s
+	d.Seq, d.Construction, d.Deleted = s, c, del
 	return d, nil
 }
 
-// serializeWorkDef encodes the work feature's definition and returns its creation stamp,
-// so MarshalWork can persist the global order shared with sketches/features (issue #132).
-func serializeWorkDef(g *WorkGeometry, e userEntry) (WorkFeatureData, uint64, error) {
+// serializeWorkDef encodes the work feature's definition and returns its creation stamp plus its
+// construction/deleted flags, so MarshalWork persists the global order shared with sketches/
+// features (issue #132) and the lifecycle flags (#1849, #1855).
+func serializeWorkDef(g *WorkGeometry, e userEntry) (WorkFeatureData, uint64, bool, bool, error) {
 	switch e.collection {
 	case "plane":
 		w := g.planes.Item(e.index)
 		d, err := serializePlaneDef(w.def)
-		return d, w.seq, err
+		return d, w.seq, w.construction, w.deleted, err
 	case "axis":
 		w := g.axes.Item(e.index)
 		d, err := serializeAxisDef(w.def)
-		return d, w.seq, err
+		return d, w.seq, w.construction, w.deleted, err
 	case "point":
 		w := g.points.Item(e.index)
 		d, err := serializePointDef(w.def)
-		return d, w.seq, err
+		return d, w.seq, w.construction, w.deleted, err
 	default:
-		return WorkFeatureData{}, 0, fmt.Errorf("unknown work collection %q", e.collection)
+		return WorkFeatureData{}, 0, false, false, fmt.Errorf("unknown work collection %q", e.collection)
 	}
 }
 
@@ -144,8 +147,30 @@ func ApplyWork(g *WorkGeometry, data []WorkFeatureData) error {
 			return fmt.Errorf("work feature %d (%s/%s): %w", i, d.Collection, d.Kind, err)
 		}
 		restoreWorkSeq(g, d)
+		restoreWorkFlags(g, d)
 	}
 	return nil
+}
+
+// restoreWorkFlags re-applies the just-restored work feature's construction/deleted flags (the
+// Add* call above created it live and visible). The restored feature is the last in its
+// collection. A deleted datum is rebuilt as a tombstone so its slot holds and surviving datums
+// keep their positional references (#1849, #1855).
+func restoreWorkFlags(g *WorkGeometry, d WorkFeatureData) {
+	if !d.Construction && !d.Deleted {
+		return
+	}
+	switch d.Collection {
+	case "plane":
+		w := g.planes.Item(g.planes.Count() - 1)
+		w.construction, w.deleted = d.Construction, d.Deleted
+	case "axis":
+		w := g.axes.Item(g.axes.Count() - 1)
+		w.construction, w.deleted = d.Construction, d.Deleted
+	case "point":
+		w := g.points.Item(g.points.Count() - 1)
+		w.construction, w.deleted = d.Construction, d.Deleted
+	}
 }
 
 // restoreWorkSeq pins the just-restored work feature's creation stamp to its saved value

--- a/model/feature/work_axis_point.go
+++ b/model/feature/work_axis_point.go
@@ -78,6 +78,8 @@ type WorkAxis struct {
 	dir              math.UnitVector3
 	health           health.Health
 	visible          bool
+	construction     bool // hidden, consumer-tied datum (Inventor's WorkAxis.Construction, #1849)
+	deleted          bool // tombstoned by DeleteWork (#1855)
 	coordinateSystem bool
 	grounded         bool
 	seq              uint64 // global creation stamp (0 for the origin frame); see model/seq
@@ -103,6 +105,15 @@ func (w *WorkAxis) Visible() bool { return w.visible }
 
 // SetVisible toggles the datum axis viewport visibility.
 func (w *WorkAxis) SetVisible(v bool) { w.visible = v }
+
+// Construction reports/records whether this is a construction (hidden, consumer-tied) axis, a
+// browser/lifecycle concept distinct from Visible (Inventor's WorkAxis.Construction, #1849).
+func (w *WorkAxis) Construction() bool     { return w.construction }
+func (w *WorkAxis) SetConstruction(c bool) { w.construction = c }
+
+// Deleted reports whether DeleteWork tombstoned this axis; markDeleted sets it (#1855).
+func (w *WorkAxis) Deleted() bool { return w.deleted }
+func (w *WorkAxis) markDeleted()  { w.deleted = true }
 
 // recompute re-derives the axis, going sick on a degenerate definition.
 func (w *WorkAxis) recompute(r workResolver) {
@@ -235,6 +246,8 @@ type WorkPoint struct {
 	coordinateSystem bool
 	grounded         bool
 	visible          bool
+	construction     bool   // hidden, consumer-tied datum (Inventor's WorkPoint.Construction, #1849)
+	deleted          bool   // tombstoned by DeleteWork (#1855)
 	seq              uint64 // global creation stamp (0 for the origin frame); see model/seq
 }
 
@@ -256,6 +269,15 @@ func (w *WorkPoint) Kind() string { return w.def.kindName() }
 // visibility a WorkPlane / WorkAxis already carries.
 func (w *WorkPoint) Visible() bool     { return w.visible }
 func (w *WorkPoint) SetVisible(v bool) { w.visible = v }
+
+// Construction reports/records whether this is a construction (hidden, consumer-tied) point, a
+// browser/lifecycle concept distinct from Visible (Inventor's WorkPoint.Construction, #1849).
+func (w *WorkPoint) Construction() bool     { return w.construction }
+func (w *WorkPoint) SetConstruction(c bool) { w.construction = c }
+
+// Deleted reports whether DeleteWork tombstoned this point; markDeleted sets it (#1855).
+func (w *WorkPoint) Deleted() bool { return w.deleted }
+func (w *WorkPoint) markDeleted()  { w.deleted = true }
 
 // recompute re-derives the point.
 func (w *WorkPoint) recompute(r workResolver) {

--- a/model/feature/work_delete.go
+++ b/model/feature/work_delete.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import "fmt"
+
+// User work features are referenced by their position in their collection ("plane/3", "axis/1")
+// — a scheme that stays stable only because features are never removed from the slice. So a
+// delete is a TOMBSTONE, not a slice removal: the slot is kept (surviving datums keep their
+// positional refs), the datum is flagged deleted, and the resolvers stop resolving it — so it
+// vanishes from every listing and any surviving dependent that still names it goes sick. Mirrors
+// Inventor's WorkFeature.Delete(RetainDependents) (#1855).
+
+// deletableDatum is the shared shape of a tombstonable work feature (plane / axis / point).
+type deletableDatum interface {
+	IsCoordinateSystemElement() bool
+	Deleted() bool
+	markDeleted()
+}
+
+// DeleteWork tombstones the user datum work feature named by ref. With retainDependents=false
+// (Inventor's default) every user work feature that references it, directly or transitively, is
+// tombstoned with it; with retainDependents=true only the named datum is removed and its
+// dependents go unhealthy on the next recompute (their reference no longer resolves). It returns
+// the refs of every datum removed, in deletion order (the target first). It errors on an unknown
+// ref, an origin/coordinate-system datum, or an already-deleted datum; the caller recomputes so
+// retained dependents re-derive.
+func (g *WorkGeometry) DeleteWork(ref WorkRef, retainDependents bool) ([]WorkRef, error) {
+	target, err := g.userDatum(ref)
+	if err != nil {
+		return nil, err
+	}
+	if target.IsCoordinateSystemElement() {
+		return nil, fmt.Errorf("work geometry: %q is an origin/coordinate-system datum and cannot be deleted", ref)
+	}
+	if target.Deleted() {
+		return nil, fmt.Errorf("work geometry: work feature %q is already deleted", ref)
+	}
+	doomed := []WorkRef{ref}
+	if !retainDependents {
+		doomed = g.dependencyClosure(ref)
+	}
+	for _, r := range doomed {
+		d, err := g.userDatum(r)
+		if err != nil {
+			return nil, err
+		}
+		d.markDeleted()
+	}
+	return doomed, nil
+}
+
+// userDatum resolves a "plane/N" / "axis/N" / "point/N" reference to its live datum. Only user
+// features are addressable this way; an origin ref (whose key is "origin/…") or any other string
+// is not a deletable user datum.
+func (g *WorkGeometry) userDatum(ref WorkRef) (deletableDatum, error) {
+	if i, ok := userIndex(ref, "plane"); ok && i >= 0 && i < g.planes.Count() {
+		return g.planes.Item(i), nil
+	}
+	if i, ok := userIndex(ref, "axis"); ok && i >= 0 && i < g.axes.Count() {
+		return g.axes.Item(i), nil
+	}
+	if i, ok := userIndex(ref, "point"); ok && i >= 0 && i < g.points.Count() {
+		return g.points.Item(i), nil
+	}
+	return nil, fmt.Errorf("work geometry: %q is not a user work plane, axis, or point", ref)
+}
+
+// datumRefs is one user datum's stable key and the references its definition is built on.
+type datumRefs struct {
+	key  WorkRef
+	refs []WorkRef
+}
+
+// userFeatures lists every live (non-origin, non-deleted) user datum with its definition refs —
+// the graph dependencyClosure walks to find what a deletion cascades to.
+func (g *WorkGeometry) userFeatures() []datumRefs {
+	var out []datumRefs
+	collect := func(key WorkRef, cs, del bool, refs []WorkRef) {
+		if cs || del {
+			return
+		}
+		out = append(out, datumRefs{key: key, refs: refs})
+	}
+	for i := 0; i < g.planes.Count(); i++ {
+		p := g.planes.Item(i)
+		collect(p.key, p.coordinateSystem, p.deleted, p.def.refs())
+	}
+	for i := 0; i < g.axes.Count(); i++ {
+		a := g.axes.Item(i)
+		collect(a.key, a.coordinateSystem, a.deleted, a.def.refs())
+	}
+	for i := 0; i < g.points.Count(); i++ {
+		p := g.points.Item(i)
+		collect(p.key, p.coordinateSystem, p.deleted, p.def.refs())
+	}
+	return out
+}
+
+// dependencyClosure returns root plus every live user datum that references it transitively, in
+// discovery order — the set a retainDependents=false delete removes together.
+func (g *WorkGeometry) dependencyClosure(root WorkRef) []WorkRef {
+	doomed := map[WorkRef]bool{root: true}
+	order := []WorkRef{root}
+	feats := g.userFeatures()
+	for changed := true; changed; {
+		changed = false
+		for _, f := range feats {
+			if doomed[f.key] {
+				continue
+			}
+			for _, r := range f.refs {
+				if doomed[r] {
+					doomed[f.key] = true
+					order = append(order, f.key)
+					changed = true
+					break
+				}
+			}
+		}
+	}
+	return order
+}

--- a/model/feature/work_delete_test.go
+++ b/model/feature/work_delete_test.go
@@ -163,6 +163,29 @@ func TestWorkFeatureFlagsRoundTrip(t *testing.T) {
 	}
 }
 
+// TestDeletedAxisRefStopsResolving: a deleted axis no longer resolves as an axis input, and a
+// deleted plane drops out of the viewport host-pick (#1855).
+func TestDeletedAxisRefStopsResolving(t *testing.T) {
+	g := NewWorkGeometry()
+	ax := g.WorkAxes().AddByLine(math.P3(0, 0, 0), mustUnit(0, 0, 1))
+	pl := g.WorkPlanes().AddByPlaneAndOffset(OriginXYPlane, func() float64 { return 1 })
+	if !pl.ShownForHostPick(false) {
+		t.Fatal("a visible user plane should be shown for host pick before deletion")
+	}
+	if _, err := g.DeleteWork(ax.Key(), true); err != nil {
+		t.Fatalf("delete axis: %v", err)
+	}
+	if _, err := g.axis(ax.Key()); err == nil {
+		t.Error("a deleted axis ref should not resolve")
+	}
+	if _, err := g.DeleteWork(pl.Key(), true); err != nil {
+		t.Fatalf("delete plane: %v", err)
+	}
+	if pl.ShownForHostPick(true) {
+		t.Error("a tombstoned plane must not be shown for host pick")
+	}
+}
+
 // TestConstructionDefaultsFalse: a freshly created datum is not construction (#1849).
 func TestConstructionDefaultsFalse(t *testing.T) {
 	g := NewWorkGeometry()

--- a/model/feature/work_delete_test.go
+++ b/model/feature/work_delete_test.go
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestDeleteWorkPlaneTombstones: deleting a user plane flags it deleted and makes its reference
+// stop resolving, while its slot (and every other datum's slot) stays put (#1855).
+func TestDeleteWorkPlaneTombstones(t *testing.T) {
+	g := NewWorkGeometry()
+	pl := g.WorkPlanes().AddByPlaneAndOffset(OriginXYPlane, func() float64 { return 1 })
+	before := g.WorkPlanes().Count()
+
+	removed, err := g.DeleteWork(pl.Key(), true)
+	if err != nil {
+		t.Fatalf("DeleteWork: %v", err)
+	}
+	if len(removed) != 1 || removed[0] != pl.Key() {
+		t.Errorf("removed = %v, want just %q", removed, pl.Key())
+	}
+	if !pl.Deleted() {
+		t.Error("plane should be flagged deleted")
+	}
+	if g.WorkPlanes().Count() != before {
+		t.Errorf("slot count changed to %d, want %d (tombstone keeps the slot)", g.WorkPlanes().Count(), before)
+	}
+	if _, err := g.WorkPlaneByRef(pl.Key()); err == nil {
+		t.Error("a deleted plane should not resolve by ref")
+	}
+	if _, err := g.plane(pl.Key()); err == nil {
+		t.Error("a deleted plane ref should not resolve as a plane input")
+	}
+}
+
+// TestDeleteCascadesToDependents: with retainDependents=false, deleting a point deletes the axis
+// built through it (#1855).
+func TestDeleteCascadesToDependents(t *testing.T) {
+	g := NewWorkGeometry()
+	pt := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 0, 5) })
+	ax := g.WorkAxes().AddByTwoPoints(pt.Key(), OriginCenter)
+
+	removed, err := g.DeleteWork(pt.Key(), false)
+	if err != nil {
+		t.Fatalf("DeleteWork: %v", err)
+	}
+	if !pt.Deleted() || !ax.Deleted() {
+		t.Errorf("both point and its dependent axis should be deleted (point=%v axis=%v)", pt.Deleted(), ax.Deleted())
+	}
+	if len(removed) != 2 {
+		t.Errorf("removed = %v, want the point and the axis", removed)
+	}
+}
+
+// TestDeleteRetainDependentsSickensDependent: with retainDependents=true, only the named datum is
+// deleted; a dependent is left in place and goes unhealthy on recompute (its ref no longer
+// resolves) (#1855).
+func TestDeleteRetainDependentsSickensDependent(t *testing.T) {
+	g := NewWorkGeometry()
+	pt := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 0, 5) })
+	ax := g.WorkAxes().AddByTwoPoints(pt.Key(), OriginCenter)
+
+	if _, err := g.DeleteWork(pt.Key(), true); err != nil {
+		t.Fatalf("DeleteWork: %v", err)
+	}
+	if ax.Deleted() {
+		t.Error("with retainDependents the axis should be kept, not deleted")
+	}
+	g.Recompute(nil)
+	if ax.Health().OK() {
+		t.Error("the retained dependent should be unhealthy after its reference was deleted")
+	}
+}
+
+// TestDeleteOriginRejected: neither an origin ref nor a positional ref that lands on an origin slot
+// can be deleted (#1855).
+func TestDeleteOriginRejected(t *testing.T) {
+	g := NewWorkGeometry()
+	if _, err := g.DeleteWork(OriginXYPlane, false); err == nil {
+		t.Error("deleting an origin plane by its well-known ref should fail")
+	}
+	// "plane/0" resolves positionally onto the origin XY plane (the first slot).
+	if _, err := g.DeleteWork(WorkRef("plane/0"), false); err == nil {
+		t.Error("deleting a coordinate-system datum by its positional ref should fail")
+	}
+}
+
+// TestDeleteUnknownAndAlreadyDeleted: an unknown ref and a second delete of the same datum both
+// fail cleanly (#1855).
+func TestDeleteUnknownAndAlreadyDeleted(t *testing.T) {
+	g := NewWorkGeometry()
+	if _, err := g.DeleteWork(WorkRef("plane/999"), false); err == nil {
+		t.Error("an out-of-range ref should fail")
+	}
+	if _, err := g.DeleteWork(WorkRef("axis/nope"), false); err == nil {
+		t.Error("a non-user ref should fail")
+	}
+	pl := g.WorkPlanes().AddByPlaneAndOffset(OriginXYPlane, func() float64 { return 1 })
+	if _, err := g.DeleteWork(pl.Key(), true); err != nil {
+		t.Fatalf("first delete: %v", err)
+	}
+	if _, err := g.DeleteWork(pl.Key(), true); err == nil {
+		t.Error("deleting an already-deleted datum should fail")
+	}
+}
+
+// TestDeletePreservesPositionalRefs: deleting an earlier user datum does not shift a later datum's
+// positional reference — the later datum still resolves to the same geometry (#1855).
+func TestDeletePreservesPositionalRefs(t *testing.T) {
+	g := NewWorkGeometry()
+	first := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(0, 0, 5) })
+	second := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(9, 0, 0) })
+
+	if _, err := g.DeleteWork(first.Key(), true); err != nil {
+		t.Fatalf("DeleteWork: %v", err)
+	}
+	g.Recompute(nil)
+	got, err := g.point(second.Key())
+	if err != nil {
+		t.Fatalf("the surviving point should still resolve: %v", err)
+	}
+	if !got.IsEqualTo(math.P3(9, 0, 0), wtol) {
+		t.Errorf("surviving point moved to %v after deleting an earlier datum; want (9,0,0)", got)
+	}
+}
+
+// TestWorkFeatureFlagsRoundTrip: a construction datum and a tombstoned datum both survive a
+// Marshal/Apply cycle — the construction flag and the deleted slot are preserved, and a datum
+// created after the tombstone keeps its positional reference (#1849, #1855).
+func TestWorkFeatureFlagsRoundTrip(t *testing.T) {
+	g := NewWorkGeometry()
+	con := g.WorkPlanes().AddByPlaneAndOffset(OriginXYPlane, func() float64 { return 2 })
+	con.SetConstruction(true)
+	doomed := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(1, 1, 1) })
+	survivor := g.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(3, 0, 0) })
+	if _, err := g.DeleteWork(doomed.Key(), true); err != nil {
+		t.Fatalf("DeleteWork: %v", err)
+	}
+
+	data, err := MarshalWork(g)
+	if err != nil {
+		t.Fatalf("MarshalWork: %v", err)
+	}
+	restored := NewWorkGeometry()
+	if err := ApplyWork(restored, data); err != nil {
+		t.Fatalf("ApplyWork: %v", err)
+	}
+	restored.Recompute(nil)
+
+	rp := restored.WorkPlanes()
+	if last := rp.Item(rp.Count() - 1); !last.Construction() || last.Deleted() {
+		t.Errorf("restored plane: construction=%v deleted=%v, want construction only", last.Construction(), last.Deleted())
+	}
+	if _, ok := restored.WorkPointByRef(doomed.Key()); ok {
+		t.Error("the tombstoned point should not resolve after restore")
+	}
+	got, err := restored.point(survivor.Key())
+	if err != nil || !got.IsEqualTo(math.P3(3, 0, 0), wtol) {
+		t.Errorf("survivor after restore = %v err %v, want (3,0,0) — positional ref must survive the tombstone", got, err)
+	}
+}
+
+// TestConstructionDefaultsFalse: a freshly created datum is not construction (#1849).
+func TestConstructionDefaultsFalse(t *testing.T) {
+	g := NewWorkGeometry()
+	pl := g.WorkPlanes().AddByPlaneAndOffset(OriginXYPlane, func() float64 { return 1 })
+	if pl.Construction() {
+		t.Error("a new plane should default to non-construction")
+	}
+	pl.SetConstruction(true)
+	if !pl.Construction() {
+		t.Error("SetConstruction(true) should stick")
+	}
+}

--- a/model/feature/work_geometry.go
+++ b/model/feature/work_geometry.go
@@ -174,7 +174,11 @@ func (g *WorkGeometry) plane(ref WorkRef) (sketch.Plane, error) {
 		if i < 0 || i >= g.planes.Count() {
 			return sketch.Plane{}, fmt.Errorf(errNoWorkPlane, ref)
 		}
-		return g.planes.Item(i).Plane(), nil
+		wp := g.planes.Item(i)
+		if wp.deleted {
+			return sketch.Plane{}, fmt.Errorf("work geometry: work plane %q was deleted", ref)
+		}
+		return wp.Plane(), nil
 	}
 	w, ok := g.planes.byKey[ref]
 	if !ok {
@@ -196,7 +200,11 @@ func (g *WorkGeometry) WorkPlaneByRef(ref WorkRef) (*WorkPlane, error) {
 		if i < 0 || i >= g.planes.Count() {
 			return nil, fmt.Errorf(errNoWorkPlane, ref)
 		}
-		return g.planes.Item(i), nil
+		wp := g.planes.Item(i)
+		if wp.deleted {
+			return nil, fmt.Errorf("work geometry: work plane %q was deleted", ref)
+		}
+		return wp, nil
 	}
 	w, ok := g.planes.byKey[ref]
 	if !ok {
@@ -210,7 +218,11 @@ func (g *WorkGeometry) axis(ref WorkRef) (*WorkAxis, error) {
 		if i < 0 || i >= g.axes.Count() {
 			return nil, fmt.Errorf("work geometry: no work axis %q", ref)
 		}
-		return g.axes.Item(i), nil
+		wa := g.axes.Item(i)
+		if wa.deleted {
+			return nil, fmt.Errorf("work geometry: work axis %q was deleted", ref)
+		}
+		return wa, nil
 	}
 	w, ok := g.axes.byKey[ref]
 	if !ok {
@@ -239,7 +251,11 @@ func (g *WorkGeometry) WorkPointByRef(ref WorkRef) (*WorkPoint, bool) {
 		if i < 0 || i >= g.points.Count() {
 			return nil, false
 		}
-		return g.points.Item(i), true
+		wp := g.points.Item(i)
+		if wp.deleted {
+			return nil, false
+		}
+		return wp, true
 	}
 	w, ok := g.points.byKey[ref]
 	return w, ok
@@ -253,7 +269,11 @@ func (g *WorkGeometry) point(ref WorkRef) (math.Point3, error) {
 		if i < 0 || i >= g.points.Count() {
 			return math.Point3{}, fmt.Errorf("work geometry: no work point %q", ref)
 		}
-		return g.points.Item(i).Point(), nil
+		wp := g.points.Item(i)
+		if wp.deleted {
+			return math.Point3{}, fmt.Errorf("work geometry: work point %q was deleted", ref)
+		}
+		return wp.Point(), nil
 	}
 	w, ok := g.points.byKey[ref]
 	if !ok {

--- a/model/feature/work_plane.go
+++ b/model/feature/work_plane.go
@@ -117,6 +117,8 @@ type WorkPlane struct {
 	coordinateSystem bool
 	grounded         bool
 	visible          bool
+	construction     bool   // hidden, consumer-tied datum (Inventor's WorkPlane.Construction, #1849)
+	deleted          bool   // tombstoned by DeleteWork: slot kept for ref stability, excluded from lists (#1855)
 	seq              uint64 // global creation stamp (0 for the origin frame); see model/seq
 
 	// paramFootprint is the dependency footprint this plane's last recompute read — for an
@@ -169,12 +171,27 @@ func (w *WorkPlane) Grounded() bool                  { return w.grounded }
 func (w *WorkPlane) Visible() bool     { return w.visible }
 func (w *WorkPlane) SetVisible(v bool) { w.visible = v }
 
+// Construction reports whether this is a construction (hidden, consumer-tied) work plane — a
+// browser/lifecycle concept distinct from Visible (Inventor's WorkPlane.Construction, #1849).
+// SetConstruction records the create-time flag.
+func (w *WorkPlane) Construction() bool     { return w.construction }
+func (w *WorkPlane) SetConstruction(c bool) { w.construction = c }
+
+// Deleted reports whether DeleteWork tombstoned this plane; markDeleted sets it. A deleted plane
+// keeps its slot (so surviving datums keep their positional refs) but is excluded from lists and
+// no longer resolves as a reference (#1855).
+func (w *WorkPlane) Deleted() bool { return w.deleted }
+func (w *WorkPlane) markDeleted()  { w.deleted = true }
+
 // ShownForHostPick reports whether the plane should be drawn AND pickable given whether a datum-host
 // pick (Create 2D Sketch) is revealing the origin frame: any visible plane, plus the grounded origin
 // planes while revealing — they default hidden, so a brand-new part would otherwise offer nothing to
 // click. The viewport overlay and the app-side picker share this one rule so a plane the user can SEE
 // during host selection is always one they can CLICK, and vice versa (#1752).
 func (w *WorkPlane) ShownForHostPick(revealing bool) bool {
+	if w.deleted {
+		return false // a tombstoned datum is gone from the viewport and the picker (#1855)
+	}
 	return w.visible || (revealing && w.grounded)
 }
 


### PR DESCRIPTION
Implements two [Work Features] parity gaps (milestone M33 #44). Pairs with API PR Oblikovati.API#249, released as **v0.124.0** (pinned here).

## #1855 — delete user work planes / axes / points
User datums are referenced by **positional index** (`"plane/3"`), stable only because features are never removed from the collection — so a delete is a **tombstone**, not a slice removal:
- the slot is kept (surviving datums keep their `"plane/N"` refs),
- the datum is flagged `deleted`, and the resolvers stop resolving it — it vanishes from every list and any surviving dependent that names it goes unhealthy.

`retainDependents` mirrors Inventor's `WorkFeature.Delete(RetainDependents)`:
- **false** (default): cascade to the transitive dependency closure within work geometry;
- **true**: keep dependents (they go sick).

Origin/coordinate-system datums, unknown refs, and double-deletes are rejected. The `deleted`/`construction` flags round-trip through the recipe, so a reopened part keeps its slots and positional refs.

The handler lives in `work_planes.go` (the file already grandfathered in archguard's mutation-seam allowlist, since delete self-orchestrates a recompute like create/redefine) — no new archguard offender.

## #1849 — construction flag on create
Optional `construction` on `workPlanes/workAxes/workPoints.create`, surfaced read-only on each list DTO. Orthogonal to `Visible`.

## Scope notes
- Cascade covers **work-geometry** dependents; a *solid* feature (extrude, etc.) built on a deleted datum goes sick regardless of `retainDependents` — deleting the feature program is a larger follow-up.
- The construction **consumer-tied auto-delete lifecycle** is a follow-up; this lands the flag + faithful read-back the exporter needs.

## Tests
Model: tombstone, cascade, retain-sickens-dependent, origin/unknown/double-delete rejection, positional-ref stability, flag round-trip, deleted-axis resolver, host-pick guard. Router: delete over the wire + list exclusion, cascade over the wire, error paths, construction read-back on all three collections.

Closes #1855, #1849.