### PR TITLE
feat(work-planes): FlipNormal + size/grounded/autoResize + tangent/bisector solution selection (#1851, #1844)

### DIFF
--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -199,6 +199,7 @@ func (r *Router) registerStandardHandlers() {
 	r.readOnly(wire.MethodWorkPlanesList, ctxQuery(activeWorkHost, listWorkPlanes))
 	r.mutating(wire.MethodWorkPlanesCreate, "Create Work Plane", typedCtx(activeWorkHost, createWorkPlanes))
 	r.mutating(wire.MethodWorkPlanesRedefine, "Redefine Work Plane", typedCtx(activeWorkHost, redefineWorkPlane))
+	r.mutating(wire.MethodWorkPlanesFlipNormal, "Flip Work Plane Normal", typedCtx(activeWorkHost, flipWorkPlaneNormal))
 	r.readOnly(wire.MethodWorkPointsList, ctxQuery(activeWorkHost, listWorkPoints))
 	r.mutating(wire.MethodWorkPointsCreate, "Create Work Point", typedCtx(activeWorkHost, createWorkPoint))
 	r.readOnly(wire.MethodWorkAxesList, ctxQuery(activeWorkHost, listWorkAxes))

--- a/addin/router/work_plane_flip_solution_test.go
+++ b/addin/router/work_plane_flip_solution_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// TestFlipWorkPlaneNormal flips a user plane's normal over the wire and confirms it reverses (and a
+// second flip restores it); an origin plane and a bad index are clean errors (#1851).
+func TestFlipWorkPlaneNormal(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var pl wire.CreateWorkPlaneResult
+	call(t, r, s, "workPlanes.create", `{"kind":"plane-offset","refs":["origin/plane/xy"],"offset":"10 mm"}`, &pl)
+
+	var flip1, flip2 wire.FlipWorkPlaneResult
+	call(t, r, s, "workPlanes.flipNormal", `{"index":`+itoaInt(pl.Index)+`}`, &flip1)
+	call(t, r, s, "workPlanes.flipNormal", `{"index":`+itoaInt(pl.Index)+`}`, &flip2)
+	if dot3(flip1.Plane.Normal, flip2.Plane.Normal) > -0.999 {
+		t.Errorf("two flips should give opposite normals, got %v then %v", flip1.Plane.Normal, flip2.Plane.Normal)
+	}
+
+	if _, err := r.Handle(s, "workPlanes.flipNormal", []byte(`{"index":0}`)); err == nil {
+		t.Error("flipping an origin plane should error")
+	}
+	if _, err := r.Handle(s, "workPlanes.flipNormal", []byte(`{"index":99}`)); err == nil {
+		t.Error("a bad index should error")
+	}
+}
+
+// TestRedefineWorkPlaneDisplay sets grounded / auto-resize / explicit size via redefine and confirms
+// the list reports them back (#1851).
+func TestRedefineWorkPlaneDisplay(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var pl wire.CreateWorkPlaneResult
+	call(t, r, s, "workPlanes.create", `{"kind":"plane-offset","refs":["origin/plane/xy"],"offset":"10 mm"}`, &pl)
+
+	var res wire.RedefineWorkPlaneResult
+	call(t, r, s, "workPlanes.redefine",
+		`{"index":`+itoaInt(pl.Index)+`,"grounded":true,"autoResize":true,"size":[[1,2,0],[3,4,0]]}`, &res)
+	// SetSize turns auto-resize back off; grounded stays on.
+	if !res.Plane.Grounded {
+		t.Error("plane should report grounded=true")
+	}
+	if res.Plane.AutoResize {
+		t.Error("explicit size should turn off auto-resize")
+	}
+	if len(res.Plane.Size) != 2 || res.Plane.Size[0][0] != 1 || res.Plane.Size[1][1] != 4 {
+		t.Errorf("plane should report the explicit size corners, got %v", res.Plane.Size)
+	}
+}
+
+// TestRedefineWorkPlaneSizeBadArity: a size that is not two corners is a clean error (#1851).
+func TestRedefineWorkPlaneSizeBadArity(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var pl wire.CreateWorkPlaneResult
+	call(t, r, s, "workPlanes.create", `{"kind":"plane-offset","refs":["origin/plane/xy"],"offset":"10 mm"}`, &pl)
+	if _, err := r.Handle(s, "workPlanes.redefine", []byte(`{"index":`+itoaInt(pl.Index)+`,"size":[[1,2,0]]}`)); err == nil {
+		t.Error("a one-corner size should error")
+	}
+}
+
+// TestCreateTwoPlanesWithQuadrant: the quadrant point routes to the ...Toward constructor, and
+// opposite quadrant points give different (perpendicular) bisector normals (#1844).
+func TestCreateTwoPlanesWithQuadrant(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var a, b wire.CreateWorkPlaneResult
+	call(t, r, s, "workPlanes.create", `{"kind":"two-planes","refs":["origin/plane/xy","origin/plane/xz"],"quadrant":[0,-1,1]}`, &a)
+	call(t, r, s, "workPlanes.create", `{"kind":"two-planes","refs":["origin/plane/xy","origin/plane/xz"],"quadrant":[0,1,1]}`, &b)
+	if !a.Healthy || !b.Healthy {
+		t.Fatalf("both bisectors should be healthy: %+v %+v", a, b)
+	}
+	var list wire.ListWorkPlanesResult
+	call(t, r, s, "workPlanes.list", "{}", &list)
+	na, nb := findPlane(list.Planes, a.Ref).Normal, findPlane(list.Planes, b.Ref).Normal
+	if dot3(na, nb) > 1e-6 || dot3(na, nb) < -1e-6 {
+		t.Errorf("opposite quadrant points should give perpendicular bisectors, dot = %v", dot3(na, nb))
+	}
+}
+
+// TestCreateSolutionPlaneWrongRefCount: a quadrant point with the wrong reference count errors from
+// the solution dispatcher (#1844).
+func TestCreateSolutionPlaneWrongRefCount(t *testing.T) {
+	r, s := emptyPartSession(t)
+	if _, err := r.Handle(s, "workPlanes.create", []byte(`{"kind":"two-planes","refs":["origin/plane/xy"],"quadrant":[0,1,1]}`)); err == nil {
+		t.Error("two-planes with one reference should error")
+	}
+}
+
+func dot3(a, b []float64) float64 {
+	if len(a) != 3 || len(b) != 3 {
+		return 0
+	}
+	return a[0]*b[0] + a[1]*b[1] + a[2]*b[2]
+}

--- a/addin/router/work_planes.go
+++ b/addin/router/work_planes.go
@@ -73,12 +73,21 @@ func workPlaneInfo(host workHost, wp *feature.WorkPlane, index int) wire.WorkPla
 		IsOrigin:     wp.IsCoordinateSystemElement(),
 		Visible:      wp.Visible(),
 		Construction: wp.Construction(),
+		AutoResize:   wp.AutoResize(),
+		Grounded:     wp.Grounded(),
+		Size:         planeSizeCorners(wp),
 		Healthy:      wp.Health().OK(),
 		Reason:       wp.Health().Reason, // empty when healthy
 		Kind:         wp.Kind(),
 		Scalars:      workPlaneScalars(host, wp),
 		Slots:        workPlaneSlots(wp),
 	}
+}
+
+// planeSizeCorners renders the plane's displayed rectangle as its two opposite corners (#1851).
+func planeSizeCorners(wp *feature.WorkPlane) [][]float64 {
+	c1, c2 := wp.Size()
+	return [][]float64{point3Slice(c1), point3Slice(c2)}
 }
 
 // workPlaneScalars renders the plane's editable scalars with their value in the document's
@@ -131,8 +140,54 @@ func redefineWorkPlane(_ *app.Session, host workHost, in wire.RedefineWorkPlaneA
 		restore()
 		return wire.RedefineWorkPlaneResult{}, err
 	}
+	if err := applyDisplayEdits(wp, in); err != nil {
+		restore()
+		return wire.RedefineWorkPlaneResult{}, err
+	}
 	host.Recompute()
 	return wire.RedefineWorkPlaneResult{Plane: workPlaneInfo(host, wp, in.Index)}, nil
+}
+
+// applyDisplayEdits applies the redefine's display/associativity edits — auto-resize, grounded, and
+// the fixed displayed size (two corners) — to a user work plane; SetSize turns off auto-resize
+// (#1851).
+func applyDisplayEdits(wp *feature.WorkPlane, in wire.RedefineWorkPlaneArgs) error {
+	if in.AutoResize != nil {
+		wp.SetAutoResize(*in.AutoResize)
+	}
+	if in.Grounded != nil {
+		wp.SetGrounded(*in.Grounded)
+	}
+	if len(in.Size) == 0 {
+		return nil
+	}
+	if len(in.Size) != 2 {
+		return fmt.Errorf("workPlanes.redefine: size needs 2 corner points, got %d", len(in.Size))
+	}
+	c1, err := parseCoords(in.Size[0], "workPlanes.redefine: size corner 1")
+	if err != nil {
+		return err
+	}
+	c2, err := parseCoords(in.Size[1], "workPlanes.redefine: size corner 2")
+	if err != nil {
+		return err
+	}
+	wp.SetSize(math.P3(c1[0], c1[1], c1[2]), math.P3(c2[0], c2[1], c2[2]))
+	return nil
+}
+
+// flipWorkPlaneNormal reverses the normal of a placed user work plane by its index and recomputes;
+// the flip is recorded on the datum and persists. It fails on a bad index or an origin plane. Like
+// createWorkPlanes it self-orchestrates the work-geometry recompute (audit B1); the mutating router
+// seam records the undo step / edit broadcast (#1851).
+func flipWorkPlaneNormal(_ *app.Session, host workHost, in wire.FlipWorkPlaneArgs) (wire.FlipWorkPlaneResult, error) {
+	wp, err := userWorkPlane(host, in.Index)
+	if err != nil {
+		return wire.FlipWorkPlaneResult{}, err
+	}
+	wp.FlipNormal()
+	host.Recompute()
+	return wire.FlipWorkPlaneResult{Plane: workPlaneInfo(host, wp, in.Index)}, nil
 }
 
 // userWorkPlane resolves a redefine index to a user (non-origin) work plane.
@@ -360,6 +415,9 @@ func buildWorkPlane(host workHost, in wire.CreateWorkPlaneArgs) (*feature.WorkPl
 	planes := host.WorkPlanes()
 	refs := toWorkRefs(in.Refs)
 	kind := types.WorkPlaneKind(in.Kind)
+	if wp, handled, err := addSolutionPlane(planes, kind, refs, in); handled {
+		return wp, err
+	}
 	if c, ok := refPlaneCtors[kind]; ok {
 		if len(refs) != c.arity {
 			return nil, fmt.Errorf("workPlanes.create: %s needs %d references, got %d", in.Kind, c.arity, len(refs))
@@ -375,6 +433,41 @@ func buildWorkPlane(host workHost, in wire.CreateWorkPlaneArgs) (*feature.WorkPl
 		return addFixedWorkPlane(host.WorkPlanes(), in)
 	default:
 		return nil, fmt.Errorf("workPlanes.create: unknown kind %q (see api/types WorkPlane*)", in.Kind)
+	}
+}
+
+// addSolutionPlane handles the tangent/bisector kinds when a proximity (tangent) or quadrant
+// (two-planes) point is supplied, threading it to the ...Toward constructor so the chosen side is
+// recorded. It returns handled=false — so buildWorkPlane falls through to the default constructor —
+// for any other kind or when no solution point is given (#1844).
+func addSolutionPlane(planes *feature.WorkPlanes, kind types.WorkPlaneKind, refs []feature.WorkRef, in wire.CreateWorkPlaneArgs) (*feature.WorkPlane, bool, error) {
+	var raw []float64
+	switch kind {
+	case types.WorkPlaneTwoPlanes:
+		raw = in.Quadrant
+	case types.WorkPlanePlaneAndTangent, types.WorkPlaneLineAndTangent:
+		raw = in.Proximity
+	default:
+		return nil, false, nil
+	}
+	if len(raw) == 0 {
+		return nil, false, nil // no solution point → default constructor
+	}
+	coords, err := parseCoords(raw, fmt.Sprintf("workPlanes.create: %s solution point", kind))
+	if err != nil {
+		return nil, true, err
+	}
+	if len(refs) != 2 {
+		return nil, true, fmt.Errorf("workPlanes.create: %s needs 2 references, got %d", kind, len(refs))
+	}
+	p := math.P3(coords[0], coords[1], coords[2])
+	switch kind {
+	case types.WorkPlaneTwoPlanes:
+		return planes.AddByTwoPlanesToward(refs[0], refs[1], p), true, nil
+	case types.WorkPlanePlaneAndTangent:
+		return planes.AddByPlaneAndTangentToward(refs[0], refs[1], p), true, nil
+	default: // WorkPlaneLineAndTangent
+		return planes.AddByLineAndTangentToward(refs[0], refs[1], p), true, nil
 	}
 }
 

--- a/addin/router/work_planes.go
+++ b/addin/router/work_planes.go
@@ -441,17 +441,9 @@ func buildWorkPlane(host workHost, in wire.CreateWorkPlaneArgs) (*feature.WorkPl
 // recorded. It returns handled=false — so buildWorkPlane falls through to the default constructor —
 // for any other kind or when no solution point is given (#1844).
 func addSolutionPlane(planes *feature.WorkPlanes, kind types.WorkPlaneKind, refs []feature.WorkRef, in wire.CreateWorkPlaneArgs) (*feature.WorkPlane, bool, error) {
-	var raw []float64
-	switch kind {
-	case types.WorkPlaneTwoPlanes:
-		raw = in.Quadrant
-	case types.WorkPlanePlaneAndTangent, types.WorkPlaneLineAndTangent:
-		raw = in.Proximity
-	default:
-		return nil, false, nil
-	}
-	if len(raw) == 0 {
-		return nil, false, nil // no solution point → default constructor
+	raw, ok := solutionPointArg(kind, in)
+	if !ok {
+		return nil, false, nil // not a solution kind, or no point given → default constructor
 	}
 	coords, err := parseCoords(raw, fmt.Sprintf("workPlanes.create: %s solution point", kind))
 	if err != nil {
@@ -460,14 +452,34 @@ func addSolutionPlane(planes *feature.WorkPlanes, kind types.WorkPlaneKind, refs
 	if len(refs) != 2 {
 		return nil, true, fmt.Errorf("workPlanes.create: %s needs 2 references, got %d", kind, len(refs))
 	}
-	p := math.P3(coords[0], coords[1], coords[2])
+	return buildSolutionPlane(planes, kind, refs, math.P3(coords[0], coords[1], coords[2])), true, nil
+}
+
+// solutionPointArg returns the solution-selection point a tangent/bisector kind was given — the
+// quadrant point for two-planes, the proximity point for the tangent kinds — and false when the
+// kind takes none or none was supplied.
+func solutionPointArg(kind types.WorkPlaneKind, in wire.CreateWorkPlaneArgs) ([]float64, bool) {
+	var raw []float64
 	switch kind {
 	case types.WorkPlaneTwoPlanes:
-		return planes.AddByTwoPlanesToward(refs[0], refs[1], p), true, nil
+		raw = in.Quadrant
+	case types.WorkPlanePlaneAndTangent, types.WorkPlaneLineAndTangent:
+		raw = in.Proximity
+	default:
+		return nil, false
+	}
+	return raw, len(raw) > 0
+}
+
+// buildSolutionPlane calls the ...Toward constructor for the given tangent/bisector kind.
+func buildSolutionPlane(planes *feature.WorkPlanes, kind types.WorkPlaneKind, refs []feature.WorkRef, p math.Point3) *feature.WorkPlane {
+	switch kind {
+	case types.WorkPlaneTwoPlanes:
+		return planes.AddByTwoPlanesToward(refs[0], refs[1], p)
 	case types.WorkPlanePlaneAndTangent:
-		return planes.AddByPlaneAndTangentToward(refs[0], refs[1], p), true, nil
+		return planes.AddByPlaneAndTangentToward(refs[0], refs[1], p)
 	default: // WorkPlaneLineAndTangent
-		return planes.AddByLineAndTangentToward(refs[0], refs[1], p), true, nil
+		return planes.AddByLineAndTangentToward(refs[0], refs[1], p)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.125.0
+	oblikovati.org/api v0.126.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.124.0
+	oblikovati.org/api v0.125.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.124.0
+	oblikovati.org/api v0.125.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.125.0
+	oblikovati.org/api v0.126.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/feature/serialize_work.go
+++ b/model/feature/serialize_work.go
@@ -20,18 +20,23 @@ import (
 // WorkFeatureData is the recipe form of one user work feature: which collection it
 // belongs to, its definition kind, the references it is built on, and any parameter.
 type WorkFeatureData struct {
-	Collection   string    `yaml:"collection"` // plane | axis | point
-	Kind         string    `yaml:"kind"`
-	Seq          uint64    `yaml:"seq,omitempty"`          // global creation stamp; see model/seq
-	Construction bool      `yaml:"construction,omitempty"` // hidden, consumer-tied datum (#1849)
-	Deleted      bool      `yaml:"deleted,omitempty"`      // tombstoned; slot kept for ref stability (#1855)
-	Refs         []string  `yaml:"refs,omitempty"`
-	Offset       float64   `yaml:"offset,omitempty"`   // plane-offset
-	Angle        float64   `yaml:"angle,omitempty"`    // line-plane-angle
-	Position     []float64 `yaml:"position,omitempty"` // point position / fixed-frame origin [x,y,z]
-	XAxis        []float64 `yaml:"xaxis,omitempty"`    // fixed-frame X axis [x,y,z]
-	YAxis        []float64 `yaml:"yaxis,omitempty"`    // fixed-frame Y axis [x,y,z]
-	CloudID      string    `yaml:"cloud,omitempty"`    // point-cloud-fit: the source cloud's id (provenance, #645)
+	Collection   string      `yaml:"collection"` // plane | axis | point
+	Kind         string      `yaml:"kind"`
+	Seq          uint64      `yaml:"seq,omitempty"`          // global creation stamp; see model/seq
+	Construction bool        `yaml:"construction,omitempty"` // hidden, consumer-tied datum (#1849)
+	Deleted      bool        `yaml:"deleted,omitempty"`      // tombstoned; slot kept for ref stability (#1855)
+	Flipped      bool        `yaml:"flipped,omitempty"`      // plane normal reversed by FlipNormal (#1851)
+	AutoResize   bool        `yaml:"autoResize,omitempty"`   // plane displayed size tracks the component box (#1851)
+	Grounded     bool        `yaml:"grounded,omitempty"`     // plane grounded flag (#1851)
+	SizeCorners  [][]float64 `yaml:"sizeCorners,omitempty"`  // explicit displayed-rectangle corners [x,y,z] (#1851)
+	Solution     []float64   `yaml:"solution,omitempty"`     // tangent/bisector proximity/quadrant point [x,y,z] (#1844)
+	Refs         []string    `yaml:"refs,omitempty"`
+	Offset       float64     `yaml:"offset,omitempty"`   // plane-offset
+	Angle        float64     `yaml:"angle,omitempty"`    // line-plane-angle
+	Position     []float64   `yaml:"position,omitempty"` // point position / fixed-frame origin [x,y,z]
+	XAxis        []float64   `yaml:"xaxis,omitempty"`    // fixed-frame X axis [x,y,z]
+	YAxis        []float64   `yaml:"yaxis,omitempty"`    // fixed-frame Y axis [x,y,z]
+	CloudID      string      `yaml:"cloud,omitempty"`    // point-cloud-fit: the source cloud's id (provenance, #645)
 }
 
 // MarshalWork projects the user work features into the recipe, in creation order.
@@ -47,34 +52,41 @@ func MarshalWork(g *WorkGeometry) ([]WorkFeatureData, error) {
 	return out, nil
 }
 
+// serializeWorkFeature encodes one user work feature: its definition (references, scalars, solution
+// point) plus the creation stamp and lifecycle/display flags shared across collections (#132, #1849,
+// #1855) and — for a plane — its flip/auto-resize/grounded/size display state (#1851).
 func serializeWorkFeature(g *WorkGeometry, e userEntry) (WorkFeatureData, error) {
-	d, s, c, del, err := serializeWorkDef(g, e)
-	if err != nil {
-		return WorkFeatureData{}, err
-	}
-	d.Seq, d.Construction, d.Deleted = s, c, del
-	return d, nil
-}
-
-// serializeWorkDef encodes the work feature's definition and returns its creation stamp plus its
-// construction/deleted flags, so MarshalWork persists the global order shared with sketches/
-// features (issue #132) and the lifecycle flags (#1849, #1855).
-func serializeWorkDef(g *WorkGeometry, e userEntry) (WorkFeatureData, uint64, bool, bool, error) {
 	switch e.collection {
 	case "plane":
 		w := g.planes.Item(e.index)
 		d, err := serializePlaneDef(w.def)
-		return d, w.seq, w.construction, w.deleted, err
+		if err != nil {
+			return WorkFeatureData{}, err
+		}
+		d.Seq, d.Construction, d.Deleted = w.seq, w.construction, w.deleted
+		d.Flipped, d.AutoResize, d.Grounded = w.flipped, w.autoResize, w.grounded
+		if w.hasSize {
+			d.SizeCorners = [][]float64{p3Slice(w.sizeC1), p3Slice(w.sizeC2)}
+		}
+		return d, nil
 	case "axis":
 		w := g.axes.Item(e.index)
 		d, err := serializeAxisDef(w.def)
-		return d, w.seq, w.construction, w.deleted, err
+		if err != nil {
+			return WorkFeatureData{}, err
+		}
+		d.Seq, d.Construction, d.Deleted = w.seq, w.construction, w.deleted
+		return d, nil
 	case "point":
 		w := g.points.Item(e.index)
 		d, err := serializePointDef(w.def)
-		return d, w.seq, w.construction, w.deleted, err
+		if err != nil {
+			return WorkFeatureData{}, err
+		}
+		d.Seq, d.Construction, d.Deleted = w.seq, w.construction, w.deleted
+		return d, nil
 	default:
-		return WorkFeatureData{}, 0, false, false, fmt.Errorf("unknown work collection %q", e.collection)
+		return WorkFeatureData{}, fmt.Errorf("unknown work collection %q", e.collection)
 	}
 }
 
@@ -95,9 +107,20 @@ func serializePlaneDef(def planeDefinition) (WorkFeatureData, error) {
 		d.XAxis, d.YAxis = unitSlice(v.x), unitSlice(v.y)
 	case *linePlaneAnglePlaneDef:
 		d.Angle = v.angle()
-	case *threePointPlaneDef, *planeAndPointPlaneDef, *twoPlanesPlaneDef, *twoLinesPlaneDef,
-		*lineAndPointPlaneDef, *normalToCurvePlaneDef, *torusMidPlaneDef, *pointAndTangentPlaneDef,
-		*planeAndTangentPlaneDef, *lineAndTangentPlaneDef:
+	case *twoPlanesPlaneDef:
+		if v.quadrant != nil { // persist the chosen bisector quadrant (#1844)
+			d.Solution = p3Slice(*v.quadrant)
+		}
+	case *planeAndTangentPlaneDef:
+		if v.proximity != nil { // persist the chosen tangent side (#1844)
+			d.Solution = p3Slice(*v.proximity)
+		}
+	case *lineAndTangentPlaneDef:
+		if v.proximity != nil {
+			d.Solution = p3Slice(*v.proximity)
+		}
+	case *threePointPlaneDef, *planeAndPointPlaneDef, *twoLinesPlaneDef,
+		*lineAndPointPlaneDef, *normalToCurvePlaneDef, *torusMidPlaneDef, *pointAndTangentPlaneDef:
 		// references only
 	default:
 		return WorkFeatureData{}, fmt.Errorf("no codec for work plane definition %q", def.kindName())
@@ -152,18 +175,25 @@ func ApplyWork(g *WorkGeometry, data []WorkFeatureData) error {
 	return nil
 }
 
-// restoreWorkFlags re-applies the just-restored work feature's construction/deleted flags (the
-// Add* call above created it live and visible). The restored feature is the last in its
-// collection. A deleted datum is rebuilt as a tombstone so its slot holds and surviving datums
-// keep their positional references (#1849, #1855).
+// restoreWorkFlags re-applies the just-restored work feature's lifecycle flags (construction/
+// deleted) — the Add* call above created it live and visible — and, for a plane, its flip/
+// auto-resize/grounded/size display state. The restored feature is the last in its collection. A
+// deleted datum is rebuilt as a tombstone so its slot holds and surviving datums keep their
+// positional references; a flipped plane re-applies its normal flip on the next recompute (#1849,
+// #1855, #1851).
 func restoreWorkFlags(g *WorkGeometry, d WorkFeatureData) {
-	if !d.Construction && !d.Deleted {
-		return
-	}
 	switch d.Collection {
 	case "plane":
 		w := g.planes.Item(g.planes.Count() - 1)
 		w.construction, w.deleted = d.Construction, d.Deleted
+		w.flipped, w.autoResize, w.grounded = d.Flipped, d.AutoResize, d.Grounded
+		if len(d.SizeCorners) == 2 {
+			if c1, err := point3From(d.SizeCorners[0], "plane size corner 1"); err == nil {
+				if c2, err := point3From(d.SizeCorners[1], "plane size corner 2"); err == nil {
+					w.sizeC1, w.sizeC2, w.hasSize = c1, c2, true
+				}
+			}
+		}
 	case "axis":
 		w := g.axes.Item(g.axes.Count() - 1)
 		w.construction, w.deleted = d.Construction, d.Deleted
@@ -219,7 +249,13 @@ func restorePlaneFeature(c *WorkPlanes, d WorkFeatureData) error {
 	case "plane-point":
 		return restoreRefPlane(d, 2, func(r []WorkRef) { c.AddByPlaneAndPoint(r[0], r[1]) })
 	case "two-planes":
-		return restoreRefPlane(d, 2, func(r []WorkRef) { c.AddByTwoPlanes(r[0], r[1]) })
+		return restoreRefPlane(d, 2, func(r []WorkRef) {
+			if pt, ok := solutionPoint(d); ok {
+				c.AddByTwoPlanesToward(r[0], r[1], pt)
+				return
+			}
+			c.AddByTwoPlanes(r[0], r[1])
+		})
 	case "line-plane-angle":
 		return restoreRefPlane(d, 2, func(r []WorkRef) {
 			ang := d.Angle
@@ -236,9 +272,21 @@ func restorePlaneFeature(c *WorkPlanes, d WorkFeatureData) error {
 	case "point-tangent":
 		return restoreRefPlane(d, 2, func(r []WorkRef) { c.AddByPointAndTangent(r[0], r[1]) })
 	case "plane-tangent":
-		return restoreRefPlane(d, 2, func(r []WorkRef) { c.AddByPlaneAndTangent(r[0], r[1]) })
+		return restoreRefPlane(d, 2, func(r []WorkRef) {
+			if pt, ok := solutionPoint(d); ok {
+				c.AddByPlaneAndTangentToward(r[0], r[1], pt)
+				return
+			}
+			c.AddByPlaneAndTangent(r[0], r[1])
+		})
 	case "line-tangent":
-		return restoreRefPlane(d, 2, func(r []WorkRef) { c.AddByLineAndTangent(r[0], r[1]) })
+		return restoreRefPlane(d, 2, func(r []WorkRef) {
+			if pt, ok := solutionPoint(d); ok {
+				c.AddByLineAndTangentToward(r[0], r[1], pt)
+				return
+			}
+			c.AddByLineAndTangent(r[0], r[1])
+		})
 	default:
 		return fmt.Errorf("no restore codec for work plane kind %q", d.Kind)
 	}
@@ -635,6 +683,20 @@ func workRefs(refs []string, n int) ([]WorkRef, error) {
 func unitSlice(u math.UnitVector3) []float64 {
 	v := u.AsVector()
 	return []float64{float64(v.X), float64(v.Y), float64(v.Z)}
+}
+
+// p3Slice renders a point as its [x,y,z] components for YAML.
+func p3Slice(p math.Point3) []float64 {
+	return []float64{float64(p.X), float64(p.Y), float64(p.Z)}
+}
+
+// solutionPoint returns the recipe's tangent/bisector proximity/quadrant point (and true) when one
+// was recorded, so restore rebuilds the plane with the same solution side (#1844).
+func solutionPoint(d WorkFeatureData) (math.Point3, bool) {
+	if len(d.Solution) != 3 {
+		return math.Point3{}, false
+	}
+	return math.P3(d.Solution[0], d.Solution[1], d.Solution[2]), true
 }
 
 // point3From reads a 3-component coordinate slice into a point, naming what for errors.

--- a/model/feature/work_plane.go
+++ b/model/feature/work_plane.go
@@ -117,9 +117,13 @@ type WorkPlane struct {
 	coordinateSystem bool
 	grounded         bool
 	visible          bool
-	construction     bool   // hidden, consumer-tied datum (Inventor's WorkPlane.Construction, #1849)
-	deleted          bool   // tombstoned by DeleteWork: slot kept for ref stability, excluded from lists (#1855)
-	seq              uint64 // global creation stamp (0 for the origin frame); see model/seq
+	construction     bool        // hidden, consumer-tied datum (Inventor's WorkPlane.Construction, #1849)
+	deleted          bool        // tombstoned by DeleteWork: slot kept for ref stability, excluded from lists (#1855)
+	flipped          bool        // normal reversed by FlipNormal; re-applied each recompute, serialized (#1851)
+	autoResize       bool        // displayed size tracks the component box (#1851)
+	sizeC1, sizeC2   math.Point3 // explicit displayed-rectangle corners when hasSize is set (#1851)
+	hasSize          bool        // SetSize fixed the extents (overrides the displaySize square)
+	seq              uint64      // global creation stamp (0 for the origin frame); see model/seq
 
 	// paramFootprint is the dependency footprint this plane's last recompute read — for an
 	// offset/angle plane, the parameter driving its distance (its offset closure reads it
@@ -166,6 +170,41 @@ func (w *WorkPlane) Kind() string { return w.def.kindName() }
 func (w *WorkPlane) IsCoordinateSystemElement() bool { return w.coordinateSystem }
 func (w *WorkPlane) Grounded() bool                  { return w.grounded }
 
+// SetGrounded sets the datum's grounded flag (Inventor's WorkPlane.Grounded, #1851). It is a
+// user-settable associativity attribute, not the coordinate-system membership above.
+func (w *WorkPlane) SetGrounded(g bool) { w.grounded = g }
+
+// AutoResize reports/records whether the displayed size tracks the component bounding box; SetSize
+// turns it off (Inventor's WorkPlane.AutoResize, #1851).
+func (w *WorkPlane) AutoResize() bool     { return w.autoResize }
+func (w *WorkPlane) SetAutoResize(a bool) { w.autoResize = a }
+
+// FlipNormal reverses the plane's normal (Inventor's WorkPlane.FlipNormal). The flip is recorded
+// on the datum and re-applied on every recompute (see recompute), and serialized, so it survives a
+// recompute and a save/reload — the previous transient-flag attempt did not. The plane does not
+// move; only its normal reverses. #1851.
+func (w *WorkPlane) FlipNormal() { w.flipped = !w.flipped }
+
+// Flipped reports whether FlipNormal has reversed this plane's normal (#1851).
+func (w *WorkPlane) Flipped() bool { return w.flipped }
+
+// SetSize fixes the displayed rectangle to the two opposite corners c1, c2 (model cm), turning off
+// AutoResize; Size returns the current corners — the explicit pair, or a square derived from the
+// display size centred on the plane origin (Inventor's WorkPlane.Set/GetSize, #1851).
+func (w *WorkPlane) SetSize(c1, c2 math.Point3) {
+	w.sizeC1, w.sizeC2, w.hasSize, w.autoResize = c1, c2, true, false
+}
+
+// Size returns the two opposite corners of the displayed rectangle (model cm) — the explicit pair
+// set by SetSize, or the displaySize square centred on the plane origin (#1851).
+func (w *WorkPlane) Size() (math.Point3, math.Point3) {
+	if w.hasSize {
+		return w.sizeC1, w.sizeC2
+	}
+	diag := w.plane.XAxis().AsVector().Add(w.plane.YAxis().AsVector()).Scale(w.displaySize)
+	return w.plane.Origin().TranslateBy(diag.Scale(-1)), w.plane.Origin().TranslateBy(diag)
+}
+
 // Visible reports whether the datum is drawn in the viewport; SetVisible toggles it
 // (Inventor's per-work-feature Visibility). User planes are visible by default.
 func (w *WorkPlane) Visible() bool     { return w.visible }
@@ -203,7 +242,24 @@ func (w *WorkPlane) recompute(r workResolver) {
 		w.health = health.Sicken("work plane: " + err.Error())
 		return
 	}
+	if w.flipped { // re-apply the persisted normal flip every recompute (#1851)
+		p, err = flipPlaneNormal(p)
+		if err != nil {
+			w.health = health.Sicken("work plane: flip normal: " + err.Error())
+			return
+		}
+	}
 	w.plane, w.health = p, health.Healthy
+}
+
+// flipPlaneNormal returns p with its normal reversed and origin unchanged: negating the Y axis
+// flips normal = X×Y while keeping the frame right-handed (#1851).
+func flipPlaneNormal(p sketch.Plane) (sketch.Plane, error) {
+	negY, err := math.UnitVector3FromVector(p.YAxis().AsVector().Scale(-1))
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	return sketch.NewPlane(p.Origin(), p.XAxis(), negY)
 }
 
 // WorkPlanes is the part's collection of datum planes (origin first, then user). It

--- a/model/feature/work_plane_defs.go
+++ b/model/feature/work_plane_defs.go
@@ -53,7 +53,10 @@ func (d *planeAndPointPlaneDef) eval(r workResolver) (sketch.Plane, error) {
 
 // twoPlanesPlaneDef bisects two planes (Inventor's AddByTwoPlanes): the dihedral-angle
 // bisector through their intersection line, or the mid-plane when they are parallel.
-type twoPlanesPlaneDef struct{ p1, p2 WorkRef }
+type twoPlanesPlaneDef struct {
+	p1, p2   WorkRef
+	quadrant *math.Point3 // solution-selection point: pick the bisector quadrant nearest it (#1844)
+}
 
 func (d *twoPlanesPlaneDef) kindName() string { return "two-planes" }
 func (d *twoPlanesPlaneDef) refs() []WorkRef  { return []WorkRef{d.p1, d.p2} }
@@ -66,7 +69,7 @@ func (d *twoPlanesPlaneDef) eval(r workResolver) (sketch.Plane, error) {
 	if err != nil {
 		return sketch.Plane{}, err
 	}
-	return bisectingPlane(p1, p2)
+	return bisectingPlane(p1, p2, d.quadrant)
 }
 
 // linePlaneAnglePlaneDef passes through a line at a given angle from a plane, swung
@@ -204,6 +207,15 @@ func (c *WorkPlanes) AddByTwoPlanes(p1, p2 WorkRef) *WorkPlane {
 	return c.addUser(&twoPlanesPlaneDef{p1: p1, p2: p2})
 }
 
+// AddByTwoPlanesToward is AddByTwoPlanes with a quadrant point selecting which of the two bisector
+// solutions (the two perpendicular dihedral bisectors) the plane lies in — the one nearest the
+// point. The choice is recorded so recompute is stable; ignored when the planes are parallel
+// (a single mid-plane). (#1844)
+func (c *WorkPlanes) AddByTwoPlanesToward(p1, p2 WorkRef, quadrant math.Point3) *WorkPlane {
+	q := quadrant
+	return c.addUser(&twoPlanesPlaneDef{p1: p1, p2: p2, quadrant: &q})
+}
+
 // AddByLinePlaneAndAngle creates a plane through line at angle (radians) from base.
 //
 //	wp := planes.AddByLinePlaneAndAngle(feature.OriginXAxis, feature.OriginXYPlane,
@@ -229,19 +241,41 @@ func (c *WorkPlanes) AddByNormalToCurve(curve, point WorkRef) *WorkPlane {
 // bisectingPlane returns the plane that bisects p1 and p2. Intersecting planes give the
 // dihedral bisector (normal n1+n2) through a point on their intersection line; parallel
 // planes give the mid-plane, parallel to both and halfway between them.
-func bisectingPlane(p1, p2 sketch.Plane) (sketch.Plane, error) {
+func bisectingPlane(p1, p2 sketch.Plane, quadrant *math.Point3) (sketch.Plane, error) {
 	origin, _, err := planeIntersectionLine(p1, p2)
 	if err != nil {
 		n1 := p1.Normal().AsVector()
 		dist := n1.Dot(p1.Origin().VectorTo(p2.Origin()))
 		mid := p1.Origin().TranslateBy(n1.Scale(dist / 2))
-		return sketch.NewPlane(mid, p1.XAxis(), p1.YAxis())
+		return sketch.NewPlane(mid, p1.XAxis(), p1.YAxis()) // parallel: single mid-plane, quadrant ignored
 	}
-	normal, err := math.UnitVector3FromVector(p1.Normal().AsVector().Add(p2.Normal().AsVector()))
-	if err != nil {
-		return sketch.Plane{}, err
+	// Intersecting planes have two perpendicular bisectors (normals n1+n2 and n1-n2). Default to the
+	// sum bisector; a quadrant point picks whichever bisector plane it lies nearest — #1844.
+	n := bisectorNormal(p1.Normal().AsVector(), p2.Normal().AsVector(), origin, quadrant)
+	return planeFromOriginNormal(origin, n)
+}
+
+// bisectorNormal returns the normal of the chosen dihedral bisector through origin: the sum
+// bisector (n1+n2) by default, or — when a quadrant point is given — whichever of the two
+// perpendicular bisectors (n1±n2) that point lies nearest (smaller point-to-plane distance) (#1844).
+func bisectorNormal(n1, n2 math.Vector3, origin math.Point3, quadrant *math.Point3) math.UnitVector3 {
+	sum, sumErr := math.UnitVector3FromVector(n1.Add(n2))
+	diff, diffErr := math.UnitVector3FromVector(n1.Sub(n2))
+	if quadrant == nil || sumErr != nil {
+		if sumErr != nil && diffErr == nil {
+			return diff
+		}
+		return sum
 	}
-	return planeFromOriginNormal(origin, normal)
+	if diffErr != nil {
+		return sum
+	}
+	rel := origin.VectorTo(*quadrant)
+	dDiff, dSum := rel.Dot(diff.AsVector()), rel.Dot(sum.AsVector())
+	if dDiff*dDiff < dSum*dSum { // |rel·diff| < |rel·sum|: the point is nearer the diff-bisector plane
+		return diff
+	}
+	return sum
 }
 
 // planeThroughLineAtAngle returns the plane that holds line and is rotated about it by

--- a/model/feature/work_plane_flip_solution_test.go
+++ b/model/feature/work_plane_flip_solution_test.go
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// TestFlipNormalReversesAndPersists: FlipNormal reverses the plane normal, the plane does not move,
+// the flip survives a recompute, and a second flip restores the original (#1851).
+func TestFlipNormalReversesAndPersists(t *testing.T) {
+	g := NewWorkGeometry()
+	pl := g.WorkPlanes().AddByPlaneAndOffset(OriginXYPlane, func() float64 { return 3 })
+	g.Recompute(nil)
+	before, origin := pl.Plane().Normal(), pl.Plane().Origin()
+
+	pl.FlipNormal()
+	g.Recompute(nil) // the flip must re-apply on recompute, not just at the toggle
+	if d := pl.Plane().Normal().AsVector().Dot(before.AsVector()); d > -1+wtol {
+		t.Errorf("flip should reverse the normal (dot ≈ -1), got %v", d)
+	}
+	if !pl.Plane().Origin().IsEqualTo(origin, wtol) {
+		t.Errorf("flip must not move the plane: origin %v, want %v", pl.Plane().Origin(), origin)
+	}
+	pl.FlipNormal()
+	g.Recompute(nil)
+	if d := pl.Plane().Normal().AsVector().Dot(before.AsVector()); d < 1-wtol {
+		t.Errorf("a second flip should restore the original normal (dot ≈ 1), got %v", d)
+	}
+}
+
+// TestFlipNormalRoundTrips: a flipped plane keeps its reversed normal across Marshal/Apply/recompute
+// — the flip lives on the recipe, not just the live object (the fix for the earlier revert) (#1851).
+func TestFlipNormalRoundTrips(t *testing.T) {
+	g := NewWorkGeometry()
+	pl := g.WorkPlanes().AddByPlaneAndOffset(OriginXYPlane, func() float64 { return 2 })
+	pl.FlipNormal()
+	g.Recompute(nil)
+	flipped := pl.Plane().Normal()
+
+	data, err := MarshalWork(g)
+	if err != nil {
+		t.Fatalf("MarshalWork: %v", err)
+	}
+	restored := NewWorkGeometry()
+	if err := ApplyWork(restored, data); err != nil {
+		t.Fatalf("ApplyWork: %v", err)
+	}
+	restored.Recompute(nil)
+	rp := restored.WorkPlanes().Item(restored.WorkPlanes().Count() - 1)
+	if !rp.Flipped() {
+		t.Error("flip flag should survive the round-trip")
+	}
+	if d := rp.Plane().Normal().AsVector().Dot(flipped.AsVector()); d < 1-wtol {
+		t.Errorf("restored normal should match the flipped normal (dot ≈ 1), got %v", d)
+	}
+}
+
+// TestWorkPlaneDisplayStateRoundTrips: grounded / auto-resize / explicit size are gettable, settable,
+// and survive a round-trip; SetSize turns off auto-resize (#1851).
+func TestWorkPlaneDisplayStateRoundTrips(t *testing.T) {
+	g := NewWorkGeometry()
+	pl := g.WorkPlanes().AddByPlaneAndOffset(OriginXYPlane, func() float64 { return 1 })
+	g.Recompute(nil)
+	if pl.AutoResize() || pl.Grounded() {
+		t.Fatal("a new user plane should default to auto-resize=false, grounded=false")
+	}
+	// The derived (unset) size is a square centred on the plane origin.
+	c1, c2 := pl.Size()
+	mid := math.P3((c1.X+c2.X)/2, (c1.Y+c2.Y)/2, (c1.Z+c2.Z)/2)
+	if !mid.IsEqualTo(pl.Plane().Origin(), wtol) {
+		t.Errorf("derived size should centre on the plane origin, got midpoint %v", mid)
+	}
+
+	pl.SetAutoResize(true)
+	pl.SetGrounded(true)
+	pl.SetSize(math.P3(1, 2, 0), math.P3(3, 4, 0))
+	if pl.AutoResize() {
+		t.Error("SetSize should turn off auto-resize")
+	}
+	gc1, gc2 := pl.Size()
+	if !gc1.IsEqualTo(math.P3(1, 2, 0), wtol) || !gc2.IsEqualTo(math.P3(3, 4, 0), wtol) {
+		t.Errorf("explicit size not stored: %v %v", gc1, gc2)
+	}
+
+	data, err := MarshalWork(g)
+	if err != nil {
+		t.Fatalf("MarshalWork: %v", err)
+	}
+	restored := NewWorkGeometry()
+	if err := ApplyWork(restored, data); err != nil {
+		t.Fatalf("ApplyWork: %v", err)
+	}
+	restored.Recompute(nil)
+	rp := restored.WorkPlanes().Item(restored.WorkPlanes().Count() - 1)
+	if !rp.Grounded() {
+		t.Error("grounded should survive the round-trip")
+	}
+	rc1, rc2 := rp.Size()
+	if !rc1.IsEqualTo(math.P3(1, 2, 0), wtol) || !rc2.IsEqualTo(math.P3(3, 4, 0), wtol) {
+		t.Errorf("explicit size should survive the round-trip: %v %v", rc1, rc2)
+	}
+}
+
+// TestWorkPlaneAutoResizeRoundTrips: an auto-resize flag with no explicit size survives (#1851).
+func TestWorkPlaneAutoResizeRoundTrips(t *testing.T) {
+	g := NewWorkGeometry()
+	pl := g.WorkPlanes().AddByPlaneAndOffset(OriginXYPlane, func() float64 { return 1 })
+	pl.SetAutoResize(true)
+	data, _ := MarshalWork(g)
+	restored := NewWorkGeometry()
+	if err := ApplyWork(restored, data); err != nil {
+		t.Fatalf("ApplyWork: %v", err)
+	}
+	if !restored.WorkPlanes().Item(restored.WorkPlanes().Count() - 1).AutoResize() {
+		t.Error("auto-resize should survive the round-trip")
+	}
+}
+
+// TestPlaneParallelTangentProximitySelectsSide: for a plane-parallel tangent on a cylinder, a
+// proximity point on either side of the axis selects the tangent on that side (#1844).
+func TestPlaneParallelTangentProximitySelectsSide(t *testing.T) {
+	cyl, err := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2) // axis +Z, radius 2
+	if err != nil {
+		t.Fatal(err)
+	}
+	base, err := sketch.NewPlane(math.P3(0, 0, 0), mustUnit(0, 1, 0), mustUnit(0, 0, 1)) // normal +X
+	if err != nil {
+		t.Fatal(err)
+	}
+	plus, minus := math.P3(5, 0, 0), math.P3(-5, 0, 0)
+	pPlus, err := planeParallelTangent(base, cyl, &plus)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pMinus, err := planeParallelTangent(base, cyl, &minus)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pPlus.Origin().X < 1.9 {
+		t.Errorf("proximity +X should land the tangent at x≈+2, got %v", pPlus.Origin())
+	}
+	if pMinus.Origin().X > -1.9 {
+		t.Errorf("proximity -X should land the tangent at x≈-2, got %v", pMinus.Origin())
+	}
+	// No proximity → the deterministic default (+n side).
+	def, err := planeParallelTangent(base, cyl, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if def.Origin().X < 1.9 {
+		t.Errorf("default tangent should be the +n side (x≈+2), got %v", def.Origin())
+	}
+}
+
+// TestLineTangentProximitySelectsSide: for a through-line tangent on a cylinder, a proximity point
+// selects which of the two tangent solutions is built (#1844).
+func TestLineTangentProximitySelectsSide(t *testing.T) {
+	cyl, err := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := NewDatumAxis(math.P3(5, 0, 0), mustUnit(0, 0, 1)) // parallel to the axis, outside
+	pPos, pNeg := math.P3(0, 5, 0), math.P3(0, -5, 0)
+	planePos, err := planeThroughLineTangent(line, cyl, &pPos)
+	if err != nil {
+		t.Fatal(err)
+	}
+	planeNeg, err := planeThroughLineTangent(line, cyl, &pNeg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if planePos.Normal().AsVector().Y <= 0 {
+		t.Errorf("proximity +Y should pick the +Y tangent normal, got %v", planePos.Normal())
+	}
+	if planeNeg.Normal().AsVector().Y >= 0 {
+		t.Errorf("proximity -Y should pick the -Y tangent normal, got %v", planeNeg.Normal())
+	}
+}
+
+// TestBisectorQuadrantSelectsSolution: for two intersecting planes, the quadrant point picks between
+// the two perpendicular bisector solutions (#1844).
+func TestBisectorQuadrantSelectsSolution(t *testing.T) {
+	xy, xz := sketch.XYPlane(), sketch.XZPlane() // intersect on the X axis
+	qSum, qDiff := math.P3(0, -1, 1), math.P3(0, 1, 1)
+	pSum, err := bisectingPlane(xy, xz, &qSum)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pDiff, err := bisectingPlane(xy, xz, &qDiff)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d := pSum.Normal().AsVector().Dot(pDiff.Normal().AsVector()); !math.IsNearZero(d, 1e-6) {
+		t.Errorf("the two selected bisectors should be perpendicular, dot = %v", d)
+	}
+}
+
+// TestTwoPlanesTowardRoundTrips: the chosen bisector quadrant is recorded on the definition and
+// survives a Marshal/Apply cycle (#1844).
+func TestTwoPlanesTowardRoundTrips(t *testing.T) {
+	g := NewWorkGeometry()
+	pl := g.WorkPlanes().AddByTwoPlanesToward(OriginXYPlane, OriginXZPlane, math.P3(0, 1, 1))
+	g.Recompute(nil)
+	want := pl.Plane().Normal()
+
+	data, err := MarshalWork(g)
+	if err != nil {
+		t.Fatalf("MarshalWork: %v", err)
+	}
+	restored := NewWorkGeometry()
+	if err := ApplyWork(restored, data); err != nil {
+		t.Fatalf("ApplyWork: %v", err)
+	}
+	restored.Recompute(nil)
+	rp := restored.WorkPlanes().Item(restored.WorkPlanes().Count() - 1)
+	if d := rp.Plane().Normal().AsVector().Dot(want.AsVector()); d < 1-wtol {
+		t.Errorf("bisector solution not preserved across round-trip: want %v got %v (dot %v)", want, rp.Plane().Normal(), d)
+	}
+}

--- a/model/feature/work_plane_tangent.go
+++ b/model/feature/work_plane_tangent.go
@@ -63,7 +63,10 @@ func (d *pointAndTangentPlaneDef) eval(r workResolver) (sketch.Plane, error) {
 // planeAndTangentPlaneDef is parallel to a reference plane and tangent to the surface
 // (Inventor's AddByPlaneAndTangent). Closed-form for cylinders and spheres; other
 // surfaces report a Sick reason.
-type planeAndTangentPlaneDef struct{ base, face WorkRef }
+type planeAndTangentPlaneDef struct {
+	base, face WorkRef
+	proximity  *math.Point3 // solution-selection point: pick the tangent side nearest it (#1844)
+}
 
 func (d *planeAndTangentPlaneDef) kindName() string { return "plane-tangent" }
 func (d *planeAndTangentPlaneDef) refs() []WorkRef  { return []WorkRef{d.base, d.face} }
@@ -76,14 +79,17 @@ func (d *planeAndTangentPlaneDef) eval(r workResolver) (sketch.Plane, error) {
 	if err != nil {
 		return sketch.Plane{}, err
 	}
-	return planeParallelTangent(base, s)
+	return planeParallelTangent(base, s, d.proximity)
 }
 
 // lineAndTangentPlaneDef holds a line and is tangent to the surface (Inventor's
 // AddByLineAndTangent). Closed-form for a cylindrical face whose axis is parallel to the
 // line (the canonical case — a datum through an edge, tangent to a round); other
 // configurations report a Sick reason.
-type lineAndTangentPlaneDef struct{ line, face WorkRef }
+type lineAndTangentPlaneDef struct {
+	line, face WorkRef
+	proximity  *math.Point3 // solution-selection point: pick the tangent side nearest it (#1844)
+}
 
 func (d *lineAndTangentPlaneDef) kindName() string { return "line-tangent" }
 func (d *lineAndTangentPlaneDef) refs() []WorkRef  { return []WorkRef{d.line, d.face} }
@@ -96,7 +102,7 @@ func (d *lineAndTangentPlaneDef) eval(r workResolver) (sketch.Plane, error) {
 	if err != nil {
 		return sketch.Plane{}, err
 	}
-	return planeThroughLineTangent(line, s)
+	return planeThroughLineTangent(line, s, d.proximity)
 }
 
 // AddByTorusMidPlane creates the mid-plane of the torus face.
@@ -121,12 +127,28 @@ func (c *WorkPlanes) AddByPlaneAndTangent(base, face WorkRef) *WorkPlane {
 	return c.addUser(&planeAndTangentPlaneDef{base: base, face: face})
 }
 
+// AddByPlaneAndTangentToward is AddByPlaneAndTangent with a proximity point selecting which of the
+// two tangent solutions (which side of the cylinder/sphere) the plane sits on — the side nearest the
+// point. The choice is recorded on the definition so recompute is stable (#1844).
+func (c *WorkPlanes) AddByPlaneAndTangentToward(base, face WorkRef, proximity math.Point3) *WorkPlane {
+	p := proximity
+	return c.addUser(&planeAndTangentPlaneDef{base: base, face: face, proximity: &p})
+}
+
 // AddByLineAndTangent creates a plane through line and tangent to the surface (a
 // cylinder whose axis is parallel to the line).
 //
 //	wp := planes.AddByLineAndTangent(edgeAxis.Key(), feature.FaceRef(cylKey))
 func (c *WorkPlanes) AddByLineAndTangent(line, face WorkRef) *WorkPlane {
 	return c.addUser(&lineAndTangentPlaneDef{line: line, face: face})
+}
+
+// AddByLineAndTangentToward is AddByLineAndTangent with a proximity point selecting which of the two
+// tangent solutions the plane sits on — the side whose contact line is nearest the point. The choice
+// is recorded on the definition so recompute is stable (#1844).
+func (c *WorkPlanes) AddByLineAndTangentToward(line, face WorkRef, proximity math.Point3) *WorkPlane {
+	p := proximity
+	return c.addUser(&lineAndTangentPlaneDef{line: line, face: face, proximity: &p})
 }
 
 // FaceRef encodes a B-rep face's persistent reference key as a WorkRef, for the
@@ -188,28 +210,59 @@ func torusNormalAtPoint(t geom.Torus, p math.Point3) (math.UnitVector3, error) {
 // to the surface. For a cylinder the reference normal must be perpendicular to the axis
 // (otherwise no parallel plane is tangent along a line); the tangent point is on the +N
 // side of the axis/centre (the opposite tangent is the −N plane).
-func planeParallelTangent(base sketch.Plane, s geom.Surface) (sketch.Plane, error) {
+func planeParallelTangent(base sketch.Plane, s geom.Surface, proximity *math.Point3) (sketch.Plane, error) {
 	n := base.Normal().AsVector()
+	var center math.Point3
 	switch g := s.(type) {
 	case geom.Cylinder:
 		if !math.IsNearZero(n.Dot(g.AxisDir.AsVector()), math.DefaultTolerance) {
 			return sketch.Plane{}, fmt.Errorf("reference plane is not parallel to the cylinder axis")
 		}
-		origin := g.Origin.TranslateBy(n.Scale(g.Radius))
-		return sketch.NewPlane(origin, base.XAxis(), base.YAxis())
+		center = g.Origin
 	case geom.Sphere:
-		origin := g.Center.TranslateBy(n.Scale(g.Radius))
-		return sketch.NewPlane(origin, base.XAxis(), base.YAxis())
+		center = g.Center
 	default:
 		return sketch.Plane{}, fmt.Errorf("plane tangent to a %T is supported for cylinders and spheres only", s)
 	}
+	radius := surfaceRadius(s)
+	// Two tangent solutions, at center ± n·radius; pick the one whose tangent point is nearest the
+	// proximity point (default +n·radius when none is given) — #1844.
+	sign := tangentSideSign(center, n, radius, proximity)
+	origin := center.TranslateBy(n.Scale(sign * radius))
+	return sketch.NewPlane(origin, base.XAxis(), base.YAxis())
+}
+
+// surfaceRadius returns the radius of a cylinder or sphere surface.
+func surfaceRadius(s geom.Surface) float64 {
+	switch g := s.(type) {
+	case geom.Cylinder:
+		return g.Radius
+	case geom.Sphere:
+		return g.Radius
+	default:
+		return 0
+	}
+}
+
+// tangentSideSign returns +1 or -1 for the tangent point (center ± dir·radius) nearest proximity;
+// +1 (Inventor's arbitrary default) when no proximity point is supplied (#1844).
+func tangentSideSign(center math.Point3, dir math.Vector3, radius float64, proximity *math.Point3) float64 {
+	if proximity == nil {
+		return 1
+	}
+	plus := center.TranslateBy(dir.Scale(radius))
+	minus := center.TranslateBy(dir.Scale(-radius))
+	if proximity.VectorTo(minus).LengthSquared() < proximity.VectorTo(plus).LengthSquared() {
+		return -1
+	}
+	return 1
 }
 
 // planeThroughLineTangent returns the plane that holds the line and is tangent to the
 // surface. Supported for a cylinder whose axis is parallel to the line; the tangent is
 // solved in the cross-section (a tangent line from the line's projection to the radius
 // circle), so the line must lie outside the cylinder.
-func planeThroughLineTangent(line *WorkAxis, s geom.Surface) (sketch.Plane, error) {
+func planeThroughLineTangent(line *WorkAxis, s geom.Surface, proximity *math.Point3) (sketch.Plane, error) {
 	g, ok := s.(geom.Cylinder)
 	if !ok {
 		return sketch.Plane{}, fmt.Errorf("tangent-to-line work plane supports cylindrical faces only, got %T", s)
@@ -218,29 +271,55 @@ func planeThroughLineTangent(line *WorkAxis, s geom.Surface) (sketch.Plane, erro
 		return sketch.Plane{}, fmt.Errorf("the line must be parallel to the cylinder axis")
 	}
 	a := line.Origin()
-	normal, err := cylinderTangentNormal(a, g)
+	m1, m2, err := cylinderTangentNormals(a, g)
 	if err != nil {
 		return sketch.Plane{}, err
+	}
+	// The two tangent solutions touch the cylinder at axisFoot + R·m; pick the contact nearest the
+	// proximity point (default m1 when none is given) — #1844.
+	foot := cylinderAxisFoot(a, g)
+	normal := m1
+	if proximity != nil {
+		t1 := foot.TranslateBy(m1.AsVector().Scale(g.Radius))
+		t2 := foot.TranslateBy(m2.AsVector().Scale(g.Radius))
+		if proximity.VectorTo(t2).LengthSquared() < proximity.VectorTo(t1).LengthSquared() {
+			normal = m2
+		}
 	}
 	return planeFromOriginNormal(a, normal)
 }
 
-// cylinderTangentNormal returns the normal of the plane that holds the axis-parallel line
-// through a and is tangent to the cylinder — solved in the cross-section as a tangent line
-// from a's projection to the radius circle (the line must lie outside the cylinder).
-func cylinderTangentNormal(a math.Point3, g geom.Cylinder) (math.UnitVector3, error) {
+// cylinderAxisFoot returns the point on the cylinder axis level with a (a projected onto the axis).
+func cylinderAxisFoot(a math.Point3, g geom.Cylinder) math.Point3 {
+	rel := g.Origin.VectorTo(a)
+	return g.Origin.TranslateBy(g.AxisDir.AsVector().Scale(rel.Dot(g.AxisDir.AsVector())))
+}
+
+// cylinderTangentNormals returns the two normals of the planes that hold the axis-parallel line
+// through a and are tangent to the cylinder — solved in the cross-section as the two tangent lines
+// from a's projection to the radius circle (the line must lie outside the cylinder). They are
+// symmetric about the a-direction: u·cosA ± w·sinA.
+func cylinderTangentNormals(a math.Point3, g geom.Cylinder) (math.UnitVector3, math.UnitVector3, error) {
 	rel := g.Origin.VectorTo(a)
 	perp := rel.Sub(g.AxisDir.AsVector().Scale(rel.Dot(g.AxisDir.AsVector())))
 	d := perp.Length()
 	if d < g.Radius-math.DefaultTolerance {
-		return math.UnitVector3{}, fmt.Errorf("the line is inside the cylinder (offset %g < radius %g); no tangent plane", d, g.Radius)
+		return math.UnitVector3{}, math.UnitVector3{}, fmt.Errorf("the line is inside the cylinder (offset %g < radius %g); no tangent plane", d, g.Radius)
 	}
 	u, err := math.UnitVector3FromVector(perp)
 	if err != nil {
-		return math.UnitVector3{}, fmt.Errorf("the line is on the cylinder axis; the tangent plane is undefined")
+		return math.UnitVector3{}, math.UnitVector3{}, fmt.Errorf("the line is on the cylinder axis; the tangent plane is undefined")
 	}
 	w := g.AxisDir.Cross(u)
 	cosA := g.Radius / d
 	sinA := stdmath.Sqrt(stdmath.Max(0, 1-cosA*cosA))
-	return math.UnitVector3FromVector(u.AsVector().Scale(cosA).Add(w.Scale(sinA)))
+	m1, err := math.UnitVector3FromVector(u.AsVector().Scale(cosA).Add(w.Scale(sinA)))
+	if err != nil {
+		return math.UnitVector3{}, math.UnitVector3{}, err
+	}
+	m2, err := math.UnitVector3FromVector(u.AsVector().Scale(cosA).Sub(w.Scale(sinA)))
+	if err != nil {
+		return math.UnitVector3{}, math.UnitVector3{}, err
+	}
+	return m1, m2, nil
 }


### PR DESCRIPTION
Host implementation for two [Work Features] parity gaps (M33 #44). Pairs with API PR Oblikovati.API#250 → **v0.125.0** (pinned here).

## #1851 — WorkPlane display & orientation controls
- **`workPlanes.flipNormal`**: a `flipped` flag on the plane, **re-applied every recompute** (negate the Y axis → reverse `normal = X×Y`, keeping the frame right-handed) and **serialized** in the recipe.
  - This is the correct fix for the earlier transient-flag revert: I confirmed the part recomputes work geometry **in place** (`compdef/part.go` recomputeGeometry), so a live flag survives a recompute, and the recipe field carries it across save/reload. The plane does not move; only its normal reverses.
- **`autoResize` / `grounded`** get/set, **`size`** (two corner points) get/set via `RedefineWorkPlaneArgs`; `WorkPlaneInfo` reports all three. `SetSize` turns off auto-resize; unset size derives a square from the display size.

## #1844 — tangent & bisector solution selection
- `plane-tangent` / `line-tangent` accept a **proximity** point, `two-planes` a **quadrant** point — recorded on the definition (nil = today's deterministic default) and **serialized**, so the chosen side is stable across recompute.
- Each geometry helper now computes **both** solutions and picks the one nearest the point: `planeParallelTangent` (center ± n·r), `cylinderTangentNormals` (u·cosA ± w·sinA), `bisectorNormal` (n1±n2). Routed via `addSolutionPlane`, which falls through to the default constructor when no point is supplied.

## Architecture / guards
- Flip handler + redefine display edits live in `work_planes.go` (already grandfathered in archguard's mutation-seam allowlist, like create/redefine) — no new archguard offender.
- Deletion/flip/construction flags all round-trip through `WorkFeatureData`.

## Tests
Model: flip reverse/persist/**round-trip**, display-state get/set/round-trip, proximity selection on a cylinder (both sides + default), line-tangent proximity, bisector quadrant perpendicularity, two-planes-toward round-trip. Router: flip over the wire (+ origin/bad-index errors), redefine grounded/auto-resize/size read-back (+ bad-arity), two-planes-with-quadrant dispatch (+ wrong-ref-count error).

## Scope note
WorkPlane surface (the issue's primary target). Axis auto-resize/size setters are a noted follow-up.

Closes #1851, #1844.