### PR TITLE
feat(work-features): surface-derived datums — revolved-face axis + face-center point (#1840, #1842)

### DIFF
--- a/addin/router/work_axes.go
+++ b/addin/router/work_axes.go
@@ -80,9 +80,21 @@ func buildWorkAxis(host workHost, in wire.CreateWorkAxisArgs) (*feature.WorkAxis
 		return addRefAxis(in, "line-and-point", axes.AddByLineAndPoint)
 	case types.WorkAxisLineAndPlane:
 		return addRefAxis(in, "line-and-plane", axes.AddByLineAndPlane)
+	case types.WorkAxisRevolvedFace:
+		return addFaceAxis(in, axes.AddByRevolvedFace)
 	default:
 		return nil, fmt.Errorf("workAxes.create: unknown kind %q (see api/types WorkAxis*)", in.Kind)
 	}
+}
+
+// addFaceAxis builds a single-face axis kind (revolved-face) from exactly one face reference,
+// erroring on the wrong count (#1840).
+func addFaceAxis(in wire.CreateWorkAxisArgs, build func(feature.WorkRef) *feature.WorkAxis) (*feature.WorkAxis, error) {
+	refs := toWorkRefs(in.Refs)
+	if len(refs) != 1 {
+		return nil, fmt.Errorf("workAxes.create: revolved-face needs 1 reference (a face), got %d", len(refs))
+	}
+	return build(refs[0]), nil
 }
 
 // addLineAxis builds the grounded "line" axis from its origin point and direction vector.

--- a/addin/router/work_planes.go
+++ b/addin/router/work_planes.go
@@ -293,6 +293,8 @@ func buildWorkPoint(host workHost, in wire.CreateWorkPointArgs) (*feature.WorkPo
 		return refPoint(in, 2, func(r []feature.WorkRef) *feature.WorkPoint { return pts.AddByTwoLines(r[0], r[1]) })
 	case types.WorkPointThreePlanes:
 		return refPoint(in, 3, func(r []feature.WorkRef) *feature.WorkPoint { return pts.AddByThreePlanes(r[0], r[1], r[2]) })
+	case types.WorkPointFaceCenter:
+		return refPoint(in, 1, func(r []feature.WorkRef) *feature.WorkPoint { return pts.AddByFaceCenter(r[0]) })
 	default:
 		return nil, fmt.Errorf("workPoints.create: unknown kind %q (see api/types WorkPoint*)", in.Kind)
 	}

--- a/addin/router/work_surface_datums_test.go
+++ b/addin/router/work_surface_datums_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// TestCreateRevolvedFaceAxis dispatches a revolved-face axis over the wire. With no body the face
+// reference does not resolve, so the axis is created but reports healthy=false — exercising the
+// arity-1 dispatch without needing a B-rep body (#1840).
+func TestCreateRevolvedFaceAxis(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var res wire.CreateWorkAxisResult
+	call(t, r, s, "workAxes.create", `{"kind":"revolved-face","refs":["face/cyl-1"]}`, &res)
+	if res.Ref == "" {
+		t.Error("a revolved-face axis should be created (with a stable ref) even when its face is unresolved")
+	}
+	if res.Healthy {
+		t.Error("with no body the face is unresolved, so the axis should report healthy=false")
+	}
+}
+
+// TestCreateRevolvedFaceAxisWrongRefCount: revolved-face needs exactly one face reference (#1840).
+func TestCreateRevolvedFaceAxisWrongRefCount(t *testing.T) {
+	r, s := emptyPartSession(t)
+	if _, err := r.Handle(s, "workAxes.create", []byte(`{"kind":"revolved-face","refs":["a","b"]}`)); err == nil {
+		t.Error("revolved-face with two references should error")
+	}
+	if _, err := r.Handle(s, "workAxes.create", []byte(`{"kind":"revolved-face"}`)); err == nil {
+		t.Error("revolved-face with no reference should error")
+	}
+}
+
+// TestCreateFaceCenterPoint dispatches a face-center point over the wire (unresolved without a body,
+// so healthy=false) — exercising the arity-1 point dispatch (#1842).
+func TestCreateFaceCenterPoint(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var res wire.CreateWorkPointResult
+	call(t, r, s, "workPoints.create", `{"kind":"face-center","refs":["face/sph-1"]}`, &res)
+	if res.Ref == "" {
+		t.Error("a face-center point should be created even when its face is unresolved")
+	}
+	if res.Healthy {
+		t.Error("with no body the face is unresolved, so the point should report healthy=false")
+	}
+}
+
+// TestCreateFaceCenterWrongRefCount: face-center needs exactly one face reference (#1842).
+func TestCreateFaceCenterWrongRefCount(t *testing.T) {
+	r, s := emptyPartSession(t)
+	if _, err := r.Handle(s, "workPoints.create", []byte(`{"kind":"face-center","refs":["a","b"]}`)); err == nil {
+		t.Error("face-center with two references should error")
+	}
+}

--- a/model/feature/serialize_work.go
+++ b/model/feature/serialize_work.go
@@ -137,7 +137,7 @@ func serializeAxisDef(def axisDefinition) (WorkFeatureData, error) {
 			Position: []float64{float64(p.X), float64(p.Y), float64(p.Z)}, XAxis: unitSlice(v.dir),
 		}, nil
 	case twoPointsAxisDef, planeIntersectionAxisDef,
-		pointAndPlaneAxisDef, lineAndPointAxisDef, lineAndPlaneAxisDef:
+		pointAndPlaneAxisDef, lineAndPointAxisDef, lineAndPlaneAxisDef, revolvedFaceAxisDef:
 		return WorkFeatureData{Collection: "axis", Kind: def.kindName(), Refs: refStrings(def.refs())}, nil
 	default:
 		return WorkFeatureData{}, fmt.Errorf("no codec for work axis definition %q", def.kindName())
@@ -154,7 +154,7 @@ func serializePointDef(def pointDefinition) (WorkFeatureData, error) {
 		p := v.FrozenPosition() // last good model position; the source re-derives it after relink (#645)
 		d.CloudID = v.cloudID
 		d.Position = []float64{float64(p.X), float64(p.Y), float64(p.Z)}
-	case planeAxisPointDef, pointRefPointDef, twoLinesPointDef, threePlanesPointDef:
+	case planeAxisPointDef, pointRefPointDef, twoLinesPointDef, threePlanesPointDef, faceCenterPointDef:
 		// references only
 	default:
 		return WorkFeatureData{}, fmt.Errorf("no codec for work point definition %q", def.kindName())
@@ -345,6 +345,14 @@ func restoreAxisFeature(c *WorkAxes, d WorkFeatureData) error {
 	if d.Kind == "line" { // grounded axis: rebuilt from its origin + direction, no references
 		return restoreLineAxis(c, d)
 	}
+	if d.Kind == "revolved-face" { // single face reference (#1840)
+		r, err := workRefs(d.Refs, 1)
+		if err != nil {
+			return err
+		}
+		c.AddByRevolvedFace(r[0])
+		return nil
+	}
 	r, err := workRefs(d.Refs, 2)
 	if err != nil {
 		return err
@@ -425,6 +433,13 @@ func restorePointFeature(c *WorkPoints, d WorkFeatureData) error {
 			return err
 		}
 		c.AddByThreePlanes(r[0], r[1], r[2])
+		return nil
+	case "face-center":
+		r, err := workRefs(d.Refs, 1)
+		if err != nil {
+			return err
+		}
+		c.AddByFaceCenter(r[0])
 		return nil
 	default:
 		return fmt.Errorf("no restore codec for work point kind %q", d.Kind)

--- a/model/feature/work_surface_datums.go
+++ b/model/feature/work_surface_datums.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Surface-derived datums read an analytic B-rep face (resolved through the work resolver's
+// surface() — the same path the tangent planes use) and extract a frame from it: the axis of a
+// surface of revolution, or the centre of a sphere/torus. They need no ADR-0040 edge selectors,
+// only the existing face→surface resolution (#1840, #1842).
+
+// revolvedFaceAxisDef is the axis of revolution of a cylindrical, conical, or toroidal face
+// (Inventor's WorkAxes.AddByRevolvedFace). A face with no axis of revolution (plane, sphere, NURBS)
+// goes sick rather than producing garbage. #1840.
+type revolvedFaceAxisDef struct{ face WorkRef }
+
+func (d revolvedFaceAxisDef) kindName() string { return "revolved-face" }
+func (d revolvedFaceAxisDef) refs() []WorkRef  { return []WorkRef{d.face} }
+func (d revolvedFaceAxisDef) eval(r workResolver) (math.Point3, math.UnitVector3, error) {
+	s, err := r.surface(d.face)
+	if err != nil {
+		return math.Point3{}, math.UnitVector3{}, err
+	}
+	return revolvedFaceAxis(s)
+}
+
+// revolvedFaceAxis returns an axis point and unit direction for a surface of revolution.
+func revolvedFaceAxis(s geom.Surface) (math.Point3, math.UnitVector3, error) {
+	switch g := s.(type) {
+	case geom.Cylinder:
+		return g.Origin, g.AxisDir, nil
+	case geom.Cone:
+		return g.Apex, g.AxisDir, nil
+	case geom.Torus:
+		return g.Center, g.AxisDir, nil
+	default:
+		return math.Point3{}, math.UnitVector3{}, fmt.Errorf("a %T face has no axis of revolution", s)
+	}
+}
+
+// AddByRevolvedFace creates the axis of revolution of a cylindrical/conical/toroidal face (#1840).
+func (c *WorkAxes) AddByRevolvedFace(face WorkRef) *WorkAxis {
+	return c.addUser(revolvedFaceAxisDef{face: face})
+}
+
+// faceCenterPointDef is the centre of a spherical or toroidal face (Inventor's
+// AddByCenterOfSphereFace / AddByCenterOfTorusFace). A face with no centre point goes sick. #1842.
+type faceCenterPointDef struct{ face WorkRef }
+
+func (d faceCenterPointDef) kindName() string { return "face-center" }
+func (d faceCenterPointDef) refs() []WorkRef  { return []WorkRef{d.face} }
+func (d faceCenterPointDef) eval(r workResolver) (math.Point3, error) {
+	s, err := r.surface(d.face)
+	if err != nil {
+		return math.Point3{}, err
+	}
+	return faceCenter(s)
+}
+
+// faceCenter returns the centre point of a sphere or torus surface.
+func faceCenter(s geom.Surface) (math.Point3, error) {
+	switch g := s.(type) {
+	case geom.Sphere:
+		return g.Center, nil
+	case geom.Torus:
+		return g.Center, nil
+	default:
+		return math.Point3{}, fmt.Errorf("a %T face has no centre point", s)
+	}
+}
+
+// AddByFaceCenter creates the datum point at the centre of a spherical/toroidal face (#1842).
+func (c *WorkPoints) AddByFaceCenter(face WorkRef) *WorkPoint {
+	return c.addUser(faceCenterPointDef{face: face})
+}

--- a/model/feature/work_surface_datums_test.go
+++ b/model/feature/work_surface_datums_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// TestRevolvedFaceAxisFromCylinder: the axis of a cylindrical face is its axis of revolution (#1840).
+func TestRevolvedFaceAxisFromCylinder(t *testing.T) {
+	g := NewWorkGeometry()
+	body, key := faceBody(t, mustCylinder(t)) // axis +Z at origin, radius 2
+	wa := g.WorkAxes().AddByRevolvedFace(FaceRef(key))
+	g.Recompute([]*topo.Body{body})
+	if !wa.Health().OK() {
+		t.Fatalf("revolved-face axis sick: %+v", wa.Health())
+	}
+	if !wa.Direction().AsVector().IsParallelTo(math.V3(0, 0, 1), wtol) {
+		t.Errorf("axis direction = %v, want +Z", wa.Direction())
+	}
+	if !wa.Origin().IsEqualTo(math.P3(0, 0, 0), wtol) {
+		t.Errorf("axis origin = %v, want the origin", wa.Origin())
+	}
+	if wa.Kind() != "revolved-face" {
+		t.Errorf("kind = %q, want revolved-face", wa.Kind())
+	}
+}
+
+// TestRevolvedFaceAxisConeAndTorus: cone and torus faces also yield their axis of revolution (#1840).
+func TestRevolvedFaceAxisConeAndTorus(t *testing.T) {
+	cone, err := geom.NewCone(math.P3(0, 0, 1), math.V3(0, 0, 1), 0.5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	o, d, err := revolvedFaceAxis(cone)
+	if err != nil || !o.IsEqualTo(math.P3(0, 0, 1), wtol) || !d.AsVector().IsParallelTo(math.V3(0, 0, 1), wtol) {
+		t.Errorf("cone axis = %v %v err %v, want apex (0,0,1) dir +Z", o, d, err)
+	}
+	tor, err := geom.NewTorus(math.P3(1, 2, 3), math.V3(0, 1, 0), 5, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	o, d, err = revolvedFaceAxis(tor)
+	if err != nil || !o.IsEqualTo(math.P3(1, 2, 3), wtol) || !d.AsVector().IsParallelTo(math.V3(0, 1, 0), wtol) {
+		t.Errorf("torus axis = %v %v err %v, want centre (1,2,3) dir +Y", o, d, err)
+	}
+}
+
+// TestRevolvedFaceAxisRejectsSphere: a sphere face has no axis of revolution (#1840).
+func TestRevolvedFaceAxisRejectsSphere(t *testing.T) {
+	sph, _ := geom.NewSphere(math.P3(0, 0, 0), 2)
+	if _, _, err := revolvedFaceAxis(sph); err == nil {
+		t.Error("a sphere face should have no axis of revolution")
+	}
+}
+
+// TestFaceCenterFromSphere: the centre of a spherical face is the sphere centre (#1842).
+func TestFaceCenterFromSphere(t *testing.T) {
+	g := NewWorkGeometry()
+	sph, _ := geom.NewSphere(math.P3(1, 2, 3), 2)
+	body, key := faceBody(t, sph)
+	wp := g.WorkPoints().AddByFaceCenter(FaceRef(key))
+	g.Recompute([]*topo.Body{body})
+	if !wp.Health().OK() {
+		t.Fatalf("face-center point sick: %+v", wp.Health())
+	}
+	if !wp.Point().IsEqualTo(math.P3(1, 2, 3), wtol) {
+		t.Errorf("sphere centre = %v, want (1,2,3)", wp.Point())
+	}
+	if wp.Kind() != "face-center" {
+		t.Errorf("kind = %q, want face-center", wp.Kind())
+	}
+}
+
+// TestFaceCenterTorusAndRejectsCylinder: a torus face yields its centre; a cylinder has none (#1842).
+func TestFaceCenterTorusAndRejectsCylinder(t *testing.T) {
+	tor, _ := geom.NewTorus(math.P3(4, 5, 6), math.V3(0, 0, 1), 5, 1)
+	c, err := faceCenter(tor)
+	if err != nil || !c.IsEqualTo(math.P3(4, 5, 6), wtol) {
+		t.Errorf("torus centre = %v err %v, want (4,5,6)", c, err)
+	}
+	if _, err := faceCenter(mustCylinder(t)); err == nil {
+		t.Error("a cylinder face should have no centre point")
+	}
+}
+
+// TestRevolvedFaceAxisRoundTrips: the revolved-face axis restores from the recipe and re-resolves
+// against the body (#1840).
+func TestRevolvedFaceAxisRoundTrips(t *testing.T) {
+	g := NewWorkGeometry()
+	body, key := faceBody(t, mustCylinder(t))
+	g.WorkAxes().AddByRevolvedFace(FaceRef(key))
+	g.Recompute([]*topo.Body{body})
+
+	data, err := MarshalWork(g)
+	if err != nil {
+		t.Fatalf("MarshalWork: %v", err)
+	}
+	restored := NewWorkGeometry()
+	if err := ApplyWork(restored, data); err != nil {
+		t.Fatalf("ApplyWork: %v", err)
+	}
+	restored.Recompute([]*topo.Body{body})
+	ra := restored.WorkAxes().Item(restored.WorkAxes().Count() - 1)
+	if ra.Kind() != "revolved-face" || !ra.Health().OK() {
+		t.Errorf("restored axis kind %q healthy %v, want revolved-face healthy", ra.Kind(), ra.Health().OK())
+	}
+	if !ra.Direction().AsVector().IsParallelTo(math.V3(0, 0, 1), wtol) {
+		t.Errorf("restored axis direction = %v, want +Z", ra.Direction())
+	}
+}
+
+// TestFaceCenterRoundTrips: the face-center point restores from the recipe and re-resolves (#1842).
+func TestFaceCenterRoundTrips(t *testing.T) {
+	g := NewWorkGeometry()
+	sph, _ := geom.NewSphere(math.P3(1, 2, 3), 2)
+	body, key := faceBody(t, sph)
+	g.WorkPoints().AddByFaceCenter(FaceRef(key))
+	g.Recompute([]*topo.Body{body})
+
+	data, err := MarshalWork(g)
+	if err != nil {
+		t.Fatalf("MarshalWork: %v", err)
+	}
+	restored := NewWorkGeometry()
+	if err := ApplyWork(restored, data); err != nil {
+		t.Fatalf("ApplyWork: %v", err)
+	}
+	restored.Recompute([]*topo.Body{body})
+	rp := restored.WorkPoints().Item(restored.WorkPoints().Count() - 1)
+	if rp.Kind() != "face-center" || !rp.Point().IsEqualTo(math.P3(1, 2, 3), wtol) {
+		t.Errorf("restored point kind %q at %v, want face-center at (1,2,3)", rp.Kind(), rp.Point())
+	}
+}


### PR DESCRIPTION
Host implementation for two surface-derived datum constructors (API already released as **v0.126.0**, PR Oblikovati.API#251 — develop already pins it).

Both read an analytic B-rep face through the **existing `surface()` resolver** (the same path the tangent planes use) — **no ADR-0040 edge selectors needed**:

- **`AddByRevolvedFace`** (`WorkAxisRevolvedFace` "revolved-face"): the axis of revolution of a cylindrical / conical / toroidal face — `Cylinder{Origin,AxisDir}` / `Cone{Apex,AxisDir}` / `Torus{Center,AxisDir}`. A plane / sphere / NURBS face goes sick.
- **`AddByFaceCenter`** (`WorkPointFaceCenter` "face-center"): the centre of a spherical or toroidal face — `Sphere.Center` / `Torus.Center`. A cylinder / plane face goes sick.

## Wiring
- **No new wire method** — both ride `workAxes.create` / `workPoints.create` (arity-1 face ref), so no wire-parity coupling.
- Serialized as refs-only kinds; `revolved-face` restores at arity 1 (handled before the arity-2 axis path).

## Tests
Model: analytic extraction for all four surface types + rejections (sphere→no axis, cylinder→no centre), `faceBody`-resolved create, and recipe round-trips (marshal → apply → recompute against the body). Router: create dispatch (unresolved-face → healthy=false) + arity guards.

Ran **golangci-lint v2.1.0 locally** before pushing (clean) — pre-empting the `funlen` class of failure.

## Scope
Advances #1840 (now 5/7 axis constructors — **analytic-edge** and **line-by-entity** remain, blocked on ADR-0040's unfinished edge-resolver wiring) and #1842. Those edge/curve constructors need the ADR-0040 M8 follow-up first.