### PR TITLE
feat(work-features): ADR-0040 edge resolver + analytic-edge/line-by-entity axis + edge-midpoint point (#1840, #1842)

### DIFF
--- a/addin/router/work_axes.go
+++ b/addin/router/work_axes.go
@@ -64,37 +64,50 @@ func workPointInfo(index int, wp *feature.WorkPoint) wire.WorkPointInfo {
 	}
 }
 
+// axisRefCtor builds a reference-model axis from exactly its references; axisRefCtors is the table
+// of the kinds dispatched purely by reference count, keeping buildWorkAxis's body small (the
+// grounded "line" kind, which reads scalar origin/direction, stays a special case). Mirrors
+// refPlaneCtors.
+type axisRefCtor struct {
+	arity int
+	build func(*feature.WorkAxes, []feature.WorkRef) *feature.WorkAxis
+}
+
+var axisRefCtors = map[types.WorkAxisKind]axisRefCtor{
+	types.WorkAxisTwoPoints: {2, func(a *feature.WorkAxes, r []feature.WorkRef) *feature.WorkAxis { return a.AddByTwoPoints(r[0], r[1]) }},
+	types.WorkAxisPlaneIntersection: {2, func(a *feature.WorkAxes, r []feature.WorkRef) *feature.WorkAxis {
+		return a.AddByPlaneIntersection(r[0], r[1])
+	}},
+	types.WorkAxisPointAndPlane: {2, func(a *feature.WorkAxes, r []feature.WorkRef) *feature.WorkAxis {
+		return a.AddByPointAndPlane(r[0], r[1])
+	}},
+	types.WorkAxisLineAndPoint: {2, func(a *feature.WorkAxes, r []feature.WorkRef) *feature.WorkAxis {
+		return a.AddByLineAndPoint(r[0], r[1])
+	}},
+	types.WorkAxisLineAndPlane: {2, func(a *feature.WorkAxes, r []feature.WorkRef) *feature.WorkAxis {
+		return a.AddByLineAndPlane(r[0], r[1])
+	}},
+	types.WorkAxisRevolvedFace: {1, func(a *feature.WorkAxes, r []feature.WorkRef) *feature.WorkAxis { return a.AddByRevolvedFace(r[0]) }},
+	types.WorkAxisAnalyticEdge: {1, func(a *feature.WorkAxes, r []feature.WorkRef) *feature.WorkAxis { return a.AddByAnalyticEdge(r[0]) }},
+	types.WorkAxisLineByEntity: {1, func(a *feature.WorkAxes, r []feature.WorkRef) *feature.WorkAxis { return a.AddByLineByEntity(r[0]) }},
+}
+
 // buildWorkAxis dispatches a create request to the matching model constructor.
 func buildWorkAxis(host workHost, in wire.CreateWorkAxisArgs) (*feature.WorkAxis, error) {
 	axes := host.WorkAxes()
-	switch types.WorkAxisKind(in.Kind) {
-	case types.WorkAxisLine:
+	kind := types.WorkAxisKind(in.Kind)
+	if kind == types.WorkAxisLine {
 		return addLineAxis(axes, in)
-	case types.WorkAxisTwoPoints:
-		return addRefAxis(in, "two-points", axes.AddByTwoPoints)
-	case types.WorkAxisPlaneIntersection:
-		return addRefAxis(in, "plane-intersection", axes.AddByPlaneIntersection)
-	case types.WorkAxisPointAndPlane:
-		return addRefAxis(in, "point-and-plane", axes.AddByPointAndPlane)
-	case types.WorkAxisLineAndPoint:
-		return addRefAxis(in, "line-and-point", axes.AddByLineAndPoint)
-	case types.WorkAxisLineAndPlane:
-		return addRefAxis(in, "line-and-plane", axes.AddByLineAndPlane)
-	case types.WorkAxisRevolvedFace:
-		return addFaceAxis(in, axes.AddByRevolvedFace)
-	default:
+	}
+	c, ok := axisRefCtors[kind]
+	if !ok {
 		return nil, fmt.Errorf("workAxes.create: unknown kind %q (see api/types WorkAxis*)", in.Kind)
 	}
-}
-
-// addFaceAxis builds a single-face axis kind (revolved-face) from exactly one face reference,
-// erroring on the wrong count (#1840).
-func addFaceAxis(in wire.CreateWorkAxisArgs, build func(feature.WorkRef) *feature.WorkAxis) (*feature.WorkAxis, error) {
 	refs := toWorkRefs(in.Refs)
-	if len(refs) != 1 {
-		return nil, fmt.Errorf("workAxes.create: revolved-face needs 1 reference (a face), got %d", len(refs))
+	if len(refs) != c.arity {
+		return nil, fmt.Errorf("workAxes.create: %s needs %d references, got %d", in.Kind, c.arity, len(refs))
 	}
-	return build(refs[0]), nil
+	return c.build(axes, refs), nil
 }
 
 // addLineAxis builds the grounded "line" axis from its origin point and direction vector.
@@ -108,14 +121,4 @@ func addLineAxis(axes *feature.WorkAxes, in wire.CreateWorkAxisArgs) (*feature.W
 		return nil, err
 	}
 	return axes.AddByLine(math.P3(origin[0], origin[1], origin[2]), dir), nil
-}
-
-// addRefAxis builds a two-reference axis kind (two-points / plane-intersection) from exactly two
-// work references, erroring on the wrong count.
-func addRefAxis(in wire.CreateWorkAxisArgs, kind string, build func(a, b feature.WorkRef) *feature.WorkAxis) (*feature.WorkAxis, error) {
-	refs := toWorkRefs(in.Refs)
-	if len(refs) != 2 {
-		return nil, fmt.Errorf("workAxes.create: %s needs 2 references, got %d", kind, len(refs))
-	}
-	return build(refs[0], refs[1]), nil
 }

--- a/addin/router/work_edge_datums_test.go
+++ b/addin/router/work_edge_datums_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+)
+
+// TestCreateEdgeAxes dispatches analytic-edge and line-by-entity axes over the wire. With no body
+// the edge reference does not resolve, so each is created but reports healthy=false — exercising the
+// edge dispatch (#1840).
+func TestCreateEdgeAxes(t *testing.T) {
+	r, s := emptyPartSession(t)
+	for _, kind := range []string{"analytic-edge", "line-by-entity"} {
+		var res wire.CreateWorkAxisResult
+		call(t, r, s, "workAxes.create", `{"kind":"`+kind+`","refs":["edge/AAAA"]}`, &res)
+		if res.Ref == "" {
+			t.Errorf("%s axis should be created even when its edge is unresolved", kind)
+		}
+		if res.Healthy {
+			t.Errorf("%s: with no body the edge is unresolved, so healthy should be false", kind)
+		}
+	}
+}
+
+// TestCreateEdgeAxisGeometricRef dispatches an analytic-edge axis whose reference is an ADR-0040
+// geometric descriptor string — the external-author form routes through the same create (#1840).
+func TestCreateEdgeAxisGeometricRef(t *testing.T) {
+	r, s := emptyPartSession(t)
+	ref := types.GeometricEdgeRef{Midpoint: [3]float64{1, 2, 3}, Direction: [3]float64{1, 0, 0}}.Ref()
+	var res wire.CreateWorkAxisResult
+	call(t, r, s, "workAxes.create", `{"kind":"analytic-edge","refs":["`+ref+`"]}`, &res)
+	if res.Ref == "" {
+		t.Error("a geometric-edge-ref axis should be created (unresolved without a body)")
+	}
+}
+
+// TestCreateEdgeMidpointPoint dispatches an edge-midpoint point over the wire (#1842).
+func TestCreateEdgeMidpointPoint(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var res wire.CreateWorkPointResult
+	call(t, r, s, "workPoints.create", `{"kind":"edge-midpoint","refs":["edge/AAAA"]}`, &res)
+	if res.Ref == "" || res.Healthy {
+		t.Errorf("edge-midpoint should be created but unresolved (healthy=false): %+v", res)
+	}
+}
+
+// TestCreateEdgeAxisWrongRefCount: an edge axis needs exactly one edge reference (#1840).
+func TestCreateEdgeAxisWrongRefCount(t *testing.T) {
+	r, s := emptyPartSession(t)
+	if _, err := r.Handle(s, "workAxes.create", []byte(`{"kind":"analytic-edge","refs":["a","b"]}`)); err == nil {
+		t.Error("analytic-edge with two references should error")
+	}
+	if _, err := r.Handle(s, "workPoints.create", []byte(`{"kind":"edge-midpoint"}`)); err == nil {
+		t.Error("edge-midpoint with no reference should error")
+	}
+}

--- a/addin/router/work_planes.go
+++ b/addin/router/work_planes.go
@@ -295,6 +295,8 @@ func buildWorkPoint(host workHost, in wire.CreateWorkPointArgs) (*feature.WorkPo
 		return refPoint(in, 3, func(r []feature.WorkRef) *feature.WorkPoint { return pts.AddByThreePlanes(r[0], r[1], r[2]) })
 	case types.WorkPointFaceCenter:
 		return refPoint(in, 1, func(r []feature.WorkRef) *feature.WorkPoint { return pts.AddByFaceCenter(r[0]) })
+	case types.WorkPointMidpointOfEdge:
+		return refPoint(in, 1, func(r []feature.WorkRef) *feature.WorkPoint { return pts.AddByMidpointOfEdge(r[0]) })
 	default:
 		return nil, fmt.Errorf("workPoints.create: unknown kind %q (see api/types WorkPoint*)", in.Kind)
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.126.0
+	oblikovati.org/api v0.127.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.126.0
+	oblikovati.org/api v0.127.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/feature/serialize_work.go
+++ b/model/feature/serialize_work.go
@@ -137,7 +137,7 @@ func serializeAxisDef(def axisDefinition) (WorkFeatureData, error) {
 			Position: []float64{float64(p.X), float64(p.Y), float64(p.Z)}, XAxis: unitSlice(v.dir),
 		}, nil
 	case twoPointsAxisDef, planeIntersectionAxisDef,
-		pointAndPlaneAxisDef, lineAndPointAxisDef, lineAndPlaneAxisDef, revolvedFaceAxisDef:
+		pointAndPlaneAxisDef, lineAndPointAxisDef, lineAndPlaneAxisDef, revolvedFaceAxisDef, edgeAxisDef:
 		return WorkFeatureData{Collection: "axis", Kind: def.kindName(), Refs: refStrings(def.refs())}, nil
 	default:
 		return WorkFeatureData{}, fmt.Errorf("no codec for work axis definition %q", def.kindName())
@@ -154,7 +154,8 @@ func serializePointDef(def pointDefinition) (WorkFeatureData, error) {
 		p := v.FrozenPosition() // last good model position; the source re-derives it after relink (#645)
 		d.CloudID = v.cloudID
 		d.Position = []float64{float64(p.X), float64(p.Y), float64(p.Z)}
-	case planeAxisPointDef, pointRefPointDef, twoLinesPointDef, threePlanesPointDef, faceCenterPointDef:
+	case planeAxisPointDef, pointRefPointDef, twoLinesPointDef, threePlanesPointDef, faceCenterPointDef,
+		edgeMidpointPointDef:
 		// references only
 	default:
 		return WorkFeatureData{}, fmt.Errorf("no codec for work point definition %q", def.kindName())
@@ -345,12 +346,20 @@ func restoreAxisFeature(c *WorkAxes, d WorkFeatureData) error {
 	if d.Kind == "line" { // grounded axis: rebuilt from its origin + direction, no references
 		return restoreLineAxis(c, d)
 	}
-	if d.Kind == "revolved-face" { // single face reference (#1840)
+	switch d.Kind { // single-reference axis kinds (a face or an edge) — #1840
+	case "revolved-face", "analytic-edge", "line-by-entity":
 		r, err := workRefs(d.Refs, 1)
 		if err != nil {
 			return err
 		}
-		c.AddByRevolvedFace(r[0])
+		switch d.Kind {
+		case "revolved-face":
+			c.AddByRevolvedFace(r[0])
+		case "analytic-edge":
+			c.AddByAnalyticEdge(r[0])
+		case "line-by-entity":
+			c.AddByLineByEntity(r[0])
+		}
 		return nil
 	}
 	r, err := workRefs(d.Refs, 2)
@@ -440,6 +449,13 @@ func restorePointFeature(c *WorkPoints, d WorkFeatureData) error {
 			return err
 		}
 		c.AddByFaceCenter(r[0])
+		return nil
+	case "edge-midpoint":
+		r, err := workRefs(d.Refs, 1)
+		if err != nil {
+			return err
+		}
+		c.AddByMidpointOfEdge(r[0])
 		return nil
 	default:
 		return fmt.Errorf("no restore codec for work point kind %q", d.Kind)

--- a/model/feature/work_edge_datums.go
+++ b/model/feature/work_edge_datums.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Edge-derived datums build on a B-rep edge resolved through the edge resolver (work_edge_ref.go):
+// an axis along a straight edge, or a point at an edge's midpoint (#1840, #1842).
+
+// edgeAxisDef is an axis lying along a straight B-rep edge. The two Inventor constructors that land
+// here — AddByEdge ("analytic-edge") and AddByLine on an edge ("line-by-entity") — share this
+// definition; the kind field preserves which one authored the datum. A non-linear edge goes sick.
+type edgeAxisDef struct {
+	edge WorkRef
+	kind string
+}
+
+func (d edgeAxisDef) kindName() string { return d.kind }
+func (d edgeAxisDef) refs() []WorkRef  { return []WorkRef{d.edge} }
+func (d edgeAxisDef) eval(r workResolver) (math.Point3, math.UnitVector3, error) {
+	e, err := r.edge(d.edge)
+	if err != nil {
+		return math.Point3{}, math.UnitVector3{}, err
+	}
+	return edgeLine(e)
+}
+
+// edgeLine returns the origin and unit direction of a straight edge; a non-linear edge is an error.
+func edgeLine(e *topo.Edge) (math.Point3, math.UnitVector3, error) {
+	switch c := e.Geometry().(type) {
+	case geom.Line:
+		return c.Origin, c.Dir, nil
+	case geom.LineSegment:
+		dir, err := math.UnitVector3FromVector(c.StartPoint.VectorTo(c.EndPoint))
+		if err != nil {
+			return math.Point3{}, math.UnitVector3{}, err
+		}
+		return c.StartPoint, dir, nil
+	default:
+		return math.Point3{}, math.UnitVector3{}, fmt.Errorf("edge is not linear (%T); no axis", c)
+	}
+}
+
+// AddByAnalyticEdge creates the axis coincident with a straight edge (Inventor's AddByEdge, #1840).
+func (c *WorkAxes) AddByAnalyticEdge(edge WorkRef) *WorkAxis {
+	return c.addUser(edgeAxisDef{edge: edge, kind: "analytic-edge"})
+}
+
+// AddByLineByEntity creates the axis along a linear edge (Inventor's AddByLine on an edge, #1840) —
+// same geometry as AddByAnalyticEdge; the distinct kind preserves the authoring constructor.
+func (c *WorkAxes) AddByLineByEntity(edge WorkRef) *WorkAxis {
+	return c.addUser(edgeAxisDef{edge: edge, kind: "line-by-entity"})
+}
+
+// edgeMidpointPointDef is the midpoint of a B-rep edge (Inventor's AddByMidpoint, #1842): the
+// average of the edge's trimmed endpoints — exact for a straight edge, the chord midpoint for a
+// curved one (the linear case is what this targets).
+type edgeMidpointPointDef struct{ edge WorkRef }
+
+func (d edgeMidpointPointDef) kindName() string { return "edge-midpoint" }
+func (d edgeMidpointPointDef) refs() []WorkRef  { return []WorkRef{d.edge} }
+func (d edgeMidpointPointDef) eval(r workResolver) (math.Point3, error) {
+	e, err := r.edge(d.edge)
+	if err != nil {
+		return math.Point3{}, err
+	}
+	return edgeChordMidpoint(e), nil
+}
+
+// edgeChordMidpoint returns the midpoint of an edge's trimmed span (the average of its two vertices,
+// computed via point/vector ops so it works for any coordinate scalar type).
+func edgeChordMidpoint(e *topo.Edge) math.Point3 {
+	a, b := e.StartVertex().Point(), e.EndVertex().Point()
+	return a.TranslateBy(a.VectorTo(b).Scale(0.5))
+}
+
+// AddByMidpointOfEdge creates the datum point at an edge's midpoint (#1842).
+func (c *WorkPoints) AddByMidpointOfEdge(edge WorkRef) *WorkPoint {
+	return c.addUser(edgeMidpointPointDef{edge: edge})
+}

--- a/model/feature/work_edge_datums_test.go
+++ b/model/feature/work_edge_datums_test.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// lineEdgeBody builds a one-face triangular body and returns it plus its first edge (start→end),
+// so a work axis/point can be built on a real B-rep edge with a reference key.
+func lineEdgeBody(t *testing.T, start, end math.Point3) (*topo.Body, *topo.Edge) {
+	t.Helper()
+	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok("f", "body", 0)))
+	a := bld.AddVertex(start, topo.NewLineage(topo.Tok("f", "vertex", 0)))
+	b := bld.AddVertex(end, topo.NewLineage(topo.Tok("f", "vertex", 1)))
+	c := bld.AddVertex(math.P3(0, 3, 0), topo.NewLineage(topo.Tok("f", "vertex", 2)))
+	seg := func(p, q *topo.Vertex) geom.LineSegment { return geom.NewLineSegment(p.Point(), q.Point()) }
+	ab := bld.AddEdge(seg(a, b), a, b, topo.NewLineage(topo.Tok("f", "edge", 0)))
+	bc := bld.AddEdge(seg(b, c), b, c, topo.NewLineage(topo.Tok("f", "edge", 1)))
+	ca := bld.AddEdge(seg(c, a), c, a, topo.NewLineage(topo.Tok("f", "edge", 2)))
+	pl, err := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bld.AddFace(pl, topo.NewLineage(topo.Tok("f", "face", 0)), topo.OuterLoop(topo.Fwd(ab), topo.Fwd(bc), topo.Fwd(ca)))
+	return bld.Build(), ab
+}
+
+// TestAnalyticEdgeAxisFromLineageKey: an axis built on a lineage-key edge reference lies along the
+// edge (#1840).
+func TestAnalyticEdgeAxisFromLineageKey(t *testing.T) {
+	g := NewWorkGeometry()
+	body, e := lineEdgeBody(t, math.P3(0, 0, 0), math.P3(4, 0, 0)) // edge along +X
+	wa := g.WorkAxes().AddByAnalyticEdge(EdgeRef(e.ReferenceKey()))
+	g.Recompute([]*topo.Body{body})
+	if !wa.Health().OK() {
+		t.Fatalf("analytic-edge axis sick: %+v", wa.Health())
+	}
+	if !wa.Direction().AsVector().IsParallelTo(math.V3(1, 0, 0), wtol) {
+		t.Errorf("axis direction = %v, want +X", wa.Direction())
+	}
+	if wa.Kind() != "analytic-edge" {
+		t.Errorf("kind = %q, want analytic-edge", wa.Kind())
+	}
+}
+
+// TestLineByEntityAxisKind: the line-by-entity constructor shares the geometry but keeps its own
+// kind name (#1840).
+func TestLineByEntityAxisKind(t *testing.T) {
+	g := NewWorkGeometry()
+	body, e := lineEdgeBody(t, math.P3(0, 0, 0), math.P3(0, 4, 0)) // edge along +Y
+	wa := g.WorkAxes().AddByLineByEntity(EdgeRef(e.ReferenceKey()))
+	g.Recompute([]*topo.Body{body})
+	if !wa.Health().OK() || wa.Kind() != "line-by-entity" {
+		t.Fatalf("line-by-entity axis: kind %q healthy %v", wa.Kind(), wa.Health().OK())
+	}
+	if !wa.Direction().AsVector().IsParallelTo(math.V3(0, 1, 0), wtol) {
+		t.Errorf("axis direction = %v, want +Y", wa.Direction())
+	}
+}
+
+// TestAnalyticEdgeAxisFromGeometricRef: the ADR-0040 geometric edge reference (midpoint+direction)
+// binds the matching edge on the running body — the external-author path (#1840).
+func TestAnalyticEdgeAxisFromGeometricRef(t *testing.T) {
+	g := NewWorkGeometry()
+	body, _ := lineEdgeBody(t, math.P3(0, 0, 0), math.P3(4, 0, 0)) // edge along +X, midpoint (2,0,0)
+	ref := types.GeometricEdgeRef{Midpoint: [3]float64{2, 0, 0}, Direction: [3]float64{1, 0, 0}}.Ref()
+	wa := g.WorkAxes().AddByAnalyticEdge(WorkRef(ref))
+	g.Recompute([]*topo.Body{body})
+	if !wa.Health().OK() {
+		t.Fatalf("geometric-ref axis sick: %+v", wa.Health())
+	}
+	if !wa.Direction().AsVector().IsParallelTo(math.V3(1, 0, 0), wtol) {
+		t.Errorf("axis direction = %v, want +X", wa.Direction())
+	}
+}
+
+// TestGeometricEdgeRefMissesHonestly: a descriptor far from any edge binds nothing, so the datum
+// goes sick rather than binding the wrong edge (#1840).
+func TestGeometricEdgeRefMissesHonestly(t *testing.T) {
+	g := NewWorkGeometry()
+	body, _ := lineEdgeBody(t, math.P3(0, 0, 0), math.P3(4, 0, 0))
+	ref := types.GeometricEdgeRef{Midpoint: [3]float64{100, 100, 100}, Direction: [3]float64{1, 0, 0}}.Ref()
+	wa := g.WorkAxes().AddByAnalyticEdge(WorkRef(ref))
+	g.Recompute([]*topo.Body{body})
+	if wa.Health().OK() {
+		t.Error("a far-away geometric edge reference should bind nothing (sick), not the wrong edge")
+	}
+}
+
+// TestMidpointOfEdge: the edge-midpoint point sits at the edge midpoint (#1842).
+func TestMidpointOfEdge(t *testing.T) {
+	g := NewWorkGeometry()
+	body, e := lineEdgeBody(t, math.P3(0, 0, 0), math.P3(4, 0, 0)) // midpoint (2,0,0)
+	wp := g.WorkPoints().AddByMidpointOfEdge(EdgeRef(e.ReferenceKey()))
+	g.Recompute([]*topo.Body{body})
+	if !wp.Health().OK() {
+		t.Fatalf("edge-midpoint sick: %+v", wp.Health())
+	}
+	if !wp.Point().IsEqualTo(math.P3(2, 0, 0), wtol) {
+		t.Errorf("edge midpoint = %v, want (2,0,0)", wp.Point())
+	}
+	if wp.Kind() != "edge-midpoint" {
+		t.Errorf("kind = %q, want edge-midpoint", wp.Kind())
+	}
+}
+
+// TestEdgeDatumsRoundTrip: an analytic-edge axis and an edge-midpoint point restore from the recipe
+// and re-bind against the body (#1840, #1842).
+func TestEdgeDatumsRoundTrip(t *testing.T) {
+	g := NewWorkGeometry()
+	body, e := lineEdgeBody(t, math.P3(0, 0, 0), math.P3(4, 0, 0))
+	g.WorkAxes().AddByAnalyticEdge(EdgeRef(e.ReferenceKey()))
+	g.WorkPoints().AddByMidpointOfEdge(EdgeRef(e.ReferenceKey()))
+	g.Recompute([]*topo.Body{body})
+
+	data, err := MarshalWork(g)
+	if err != nil {
+		t.Fatalf("MarshalWork: %v", err)
+	}
+	restored := NewWorkGeometry()
+	if err := ApplyWork(restored, data); err != nil {
+		t.Fatalf("ApplyWork: %v", err)
+	}
+	restored.Recompute([]*topo.Body{body})
+	ra := restored.WorkAxes().Item(restored.WorkAxes().Count() - 1)
+	rp := restored.WorkPoints().Item(restored.WorkPoints().Count() - 1)
+	if ra.Kind() != "analytic-edge" || !ra.Health().OK() {
+		t.Errorf("restored axis kind %q healthy %v", ra.Kind(), ra.Health().OK())
+	}
+	if rp.Kind() != "edge-midpoint" || !rp.Point().IsEqualTo(math.P3(2, 0, 0), wtol) {
+		t.Errorf("restored point kind %q at %v, want edge-midpoint at (2,0,0)", rp.Kind(), rp.Point())
+	}
+}
+
+// TestEdgeRefErrors: a non-edge ref and an edge ref with no body both fail to resolve (#1840).
+func TestEdgeRefErrors(t *testing.T) {
+	g := NewWorkGeometry()
+	if _, err := g.edge(WorkRef("plane/3")); err == nil {
+		t.Error("a non-edge ref should not resolve as an edge")
+	}
+	if _, err := g.edge(EdgeRef([]byte("k"))); err == nil {
+		t.Error("with no body an edge ref should not resolve")
+	}
+}

--- a/model/feature/work_edge_ref.go
+++ b/model/feature/work_edge_ref.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// A work feature can be built on a B-rep EDGE (an axis along a straight edge, a point at an edge
+// midpoint). Like a face, an edge is addressed by a single [WorkRef], re-bound to the running body
+// each recompute so the datum follows the edge through upstream edits. Two reference forms resolve
+// through the one edge resolver (ADR-0040):
+//   - a lineage-key form "edge/<key>" — an interactive pick, re-bound by exact key via FindEdgeByKey,
+//     the edge mirror of the face/vertex forms;
+//   - a geometric form "edge-geom/<descriptor>" — authored from geometry by an external author (an
+//     exporter) that has no Oblikovati lineage, re-bound by nearness via FindEdgeByGeometry.
+
+const edgeRefPrefix = "edge/"
+
+// edgeRef encodes a B-rep edge reference key as a WorkRef (the lineage-key form), mirroring faceRef.
+func edgeRef(key []byte) WorkRef {
+	return WorkRef(edgeRefPrefix + base64.RawURLEncoding.EncodeToString(key))
+}
+
+// EdgeRef is the exported edge-key encoder for the selection layer (a picked edge → a work-feature
+// edge reference), the edge mirror of [FaceRef]/[VertexRef].
+func EdgeRef(key []byte) WorkRef { return edgeRef(key) }
+
+// EdgeRefKey decodes a lineage-key edge WorkRef back to its reference key, reporting ok=false for a
+// ref that is not a lineage-key edge reference.
+func EdgeRefKey(ref WorkRef) ([]byte, bool) { return decodeRefKey(string(ref), edgeRefPrefix) }
+
+// edge resolves an edge WorkRef to its B-rep edge against the running body. It accepts both the
+// lineage-key "edge/<key>" form and the ADR-0040 geometric "edge-geom/<descriptor>" form. It errors
+// when ref is not an edge reference, when no body has been built yet, or when the reference no
+// longer binds (the work feature then goes Sick) — #1840, #1842.
+func (g *WorkGeometry) edge(ref WorkRef) (*topo.Edge, error) {
+	if desc, ok := types.ParseGeometricEdgeRef(string(ref)); ok {
+		return g.edgeByGeometry(desc, ref)
+	}
+	key, ok := decodeRefKey(string(ref), edgeRefPrefix)
+	if !ok {
+		return nil, fmt.Errorf("work geometry: %q is not an edge reference", ref)
+	}
+	if len(g.bodies) == 0 {
+		return nil, fmt.Errorf("work geometry: no body yet to resolve edge %q", ref)
+	}
+	for _, b := range g.bodies {
+		if e, ok := b.FindEdgeByKey(key); ok {
+			return e, nil
+		}
+	}
+	return nil, fmt.Errorf("work geometry: edge reference %q is lost", ref)
+}
+
+// edgeByGeometry binds an ADR-0040 geometric edge descriptor to an edge on the running body by
+// nearness (FindEdgeByGeometry), returning it only when the binder finds it unambiguously.
+func (g *WorkGeometry) edgeByGeometry(desc types.GeometricEdgeRef, ref WorkRef) (*topo.Edge, error) {
+	if len(g.bodies) == 0 {
+		return nil, fmt.Errorf("work geometry: no body yet to resolve edge %q", ref)
+	}
+	gr := topo.GeometricEdgeRef{
+		Midpoint:  math.P3(desc.Midpoint[0], desc.Midpoint[1], desc.Midpoint[2]),
+		Direction: math.V3(desc.Direction[0], desc.Direction[1], desc.Direction[2]),
+	}
+	for _, b := range g.bodies {
+		if e, ok := b.FindEdgeByGeometry(gr, geomEdgeBindTol); ok {
+			return e, nil
+		}
+	}
+	return nil, fmt.Errorf("work geometry: geometric edge reference %q binds no edge", ref)
+}

--- a/model/feature/work_geometry.go
+++ b/model/feature/work_geometry.go
@@ -46,6 +46,7 @@ type workResolver interface {
 	axis(WorkRef) (*WorkAxis, error)
 	point(WorkRef) (math.Point3, error)
 	surface(WorkRef) (geom.Surface, error)
+	edge(WorkRef) (*topo.Edge, error)
 }
 
 // WorkGeometry is a part's construction-geometry frame: the static origin coordinate


### PR DESCRIPTION
The **ADR-0040 edge-resolver wiring** for work features (host side; pairs with API v0.127.0, PR Oblikovati.API#252). Closes **#1840** (all 7 axis constructors now present) and advances **#1842**.

## What
Adds `edge(WorkRef)` to `workResolver`, resolving an edge reference in **either** form:
- a **lineage-key** `edge/<key>` ref — an interactive pick, re-bound by exact key via `topo.FindEdgeByKey` (the edge mirror of the existing `face/…` / `vertex/…` forms);
- an **ADR-0040 geometric** `edge-geom/<descriptor>` ref — an external author (an exporter) with geometry but no Oblikovati lineage, re-bound by nearness via `topo.FindEdgeByGeometry`. A far-away descriptor **misses honestly** (no bind → the datum goes sick) rather than binding the wrong edge.

Constructors:
- `AddByAnalyticEdge` / `AddByLineByEntity` — axis along a straight edge (a non-linear edge goes sick).
- `AddByMidpointOfEdge` — point at the edge midpoint.

Serialized as refs-only kinds at arity 1; **no new wire method** (they ride `workAxes.create` / `workPoints.create`).

## Notes
- `buildWorkAxis` refactored to an `axisRefCtor` table (mirrors `refPlaneCtors`) so the added single-ref kinds keep it under golangci-lint's `funlen` limit — **verified with golangci-lint v2.1.0 locally before pushing**.
- `workResolver` interface gained `edge()`; only `WorkGeometry` implements it.

## Tests
Model: analytic-edge / line-by-entity axis from a lineage-key ref, **from an ADR-0040 geometric ref**, honest-miss (far descriptor → sick), edge-midpoint, recipe round-trips, and resolver error paths. Router: create dispatch for all three kinds (incl. the geometric-ref string form) + arity guards.

## Scope
This is the first **work-feature** consumer of ADR-0040's edge geometric reference over the public API. The dress-up consumers (fillet/hole_boss) already used the kernel binder; the remaining M8 items (exporter Tier-B emission, oracle tests) are separate follow-ups.