### PR TITLE
test(feature): wire OCCT oracle into analytic work-feature geometry tests (#1844, #1840)

### DIFF
--- a/model/feature/oracle_geometry_test.go
+++ b/model/feature/oracle_geometry_test.go
@@ -1,0 +1,126 @@
+//go:build oracle
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package feature's analytic work-feature geometry (tangent/axis) cross-checked against an
+// external CAD kernel oracle — OpenCASCADE via the _oracles/oracle_service.py JSON CLI (see
+// architecture/decisions or memory oracle-kernels-occt-solvespace). These tests are excluded from
+// the normal build (the `oracle` build tag; CI has no Python/OCCT) and skip unless the oracle env is
+// set. Run locally:
+//
+//	OBK_ORACLE_PY=/c/Users/vmiguel/miniforge3/envs/occ/python.exe \
+//	OBK_ORACLE_SVC=/c/Users/vmiguel/git/oblikovati-workspace/_oracles/oracle_service.py \
+//	go test -tags oracle -run Oracle ./model/feature/...
+//
+// The oracle is the source of truth for the golden constants frozen into the normal (CI-run)
+// geometry tests; these tests re-derive those values live and assert the Go kernel matches.
+package feature
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// oracleResult shells out to the OCCT oracle service for op(args) and returns its JSON object.
+func oracleResult(t *testing.T, op string, args ...string) map[string]any {
+	t.Helper()
+	py, svc := os.Getenv("OBK_ORACLE_PY"), os.Getenv("OBK_ORACLE_SVC")
+	if py == "" || svc == "" {
+		t.Skip("oracle cross-check: set OBK_ORACLE_PY (conda occ python) and OBK_ORACLE_SVC (_oracles/oracle_service.py)")
+	}
+	out, err := exec.Command(py, append([]string{svc, op}, args...)...).Output()
+	if err != nil {
+		t.Fatalf("oracle %s %v: %v", op, args, err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("oracle %s: bad JSON %q: %v", op, out, err)
+	}
+	return m
+}
+
+func ftoa(v float64) string { return strconv.FormatFloat(v, 'g', 17, 64) }
+
+// pairs2D reads a JSON [[x,y],[x,y]] value into a sorted [][2]float64 for order-independent compare.
+func pairs2D(t *testing.T, v any) [][2]float64 {
+	t.Helper()
+	rows := v.([]any)
+	out := make([][2]float64, len(rows))
+	for i, r := range rows {
+		xy := r.([]any)
+		out[i] = [2]float64{xy[0].(float64), xy[1].(float64)}
+	}
+	if len(out) == 2 && out[0][1] > out[1][1] { // sort by y (both share x here)
+		out[0], out[1] = out[1], out[0]
+	}
+	return out
+}
+
+// TestOracleCylinderTangentNormals cross-checks cylinderTangentNormals (#1844) against OCCT's
+// GccAna_Lin2d2Tan (line tangent to a circle): the two contact points of the axis-parallel tangent
+// lines from an external line must match to kernel tolerance.
+func TestOracleCylinderTangentNormals(t *testing.T) {
+	const R, dist = 2.0, 5.0
+	cyl, err := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), R)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m1, m2, err := cylinderTangentNormals(math.P3(dist, 0, 0), cyl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Contact point = axis foot (origin here) + R·m; the normal m is the contact radial.
+	got := [][2]float64{
+		{R * float64(m1.AsVector().X), R * float64(m1.AsVector().Y)},
+		{R * float64(m2.AsVector().X), R * float64(m2.AsVector().Y)},
+	}
+	if got[0][1] > got[1][1] {
+		got[0], got[1] = got[1], got[0]
+	}
+	want := pairs2D(t, oracleResult(t, "tangent", ftoa(R), ftoa(dist))["contacts"])
+	for i := range want {
+		if abs(got[i][0]-want[i][0]) > 1e-9 || abs(got[i][1]-want[i][1]) > 1e-9 {
+			t.Errorf("tangent contact %d: Go=%v OCCT=%v", i, got[i], want[i])
+		}
+	}
+}
+
+// TestOracleRevolvedFaceAxisCone cross-checks revolvedFaceAxis (#1840) against OCCT gp_Cone: the
+// axis direction matches and the apex OCCT reports is exactly on that axis (so using Apex as the
+// axis point is sound).
+func TestOracleRevolvedFaceAxisCone(t *testing.T) {
+	const halfAngle, refRadius = 0.5, 2.0
+	res := oracleResult(t, "revolved_axis", "cone", ftoa(halfAngle), ftoa(refRadius))
+	ap := res["apex"].([]any)
+	apex := math.P3(ap[0].(float64), ap[1].(float64), ap[2].(float64))
+	cone, err := geom.NewCone(apex, math.V3(0, 0, 1), halfAngle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	o, d, err := revolvedFaceAxis(cone)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !d.AsVector().IsParallelTo(math.V3(0, 0, 1), 1e-9) {
+		t.Errorf("cone axis dir = %v, want +Z (OCCT axis_dir %v)", d, res["axis_dir"])
+	}
+	if !o.IsEqualTo(apex, 1e-9) {
+		t.Errorf("cone axis origin = %v, want the OCCT apex %v", o, apex)
+	}
+	if res["apex_on_axis_dist"].(float64) > 1e-9 {
+		t.Errorf("OCCT reports apex off axis by %v", res["apex_on_axis_dist"])
+	}
+}
+
+func abs(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/model/feature/work_plane_flip_solution_test.go
+++ b/model/feature/work_plane_flip_solution_test.go
@@ -157,6 +157,40 @@ func TestPlaneParallelTangentProximitySelectsSide(t *testing.T) {
 	}
 }
 
+// TestCylinderTangentNormalsGolden pins cylinderTangentNormals (#1844) to values verified against
+// OpenCASCADE's GccAna_Lin2d2Tan (line tangent to a circle) via the oracle harness. Cylinder axis
+// +Z radius 2 at the origin; external axis-parallel line at (5,0,0): the two tangent contact points
+// are (0.8, ±1.833030277982336). The oracle-gated TestOracleCylinderTangentNormals (build tag
+// "oracle", _oracles/oracle_service.py) re-derives these live; this frozen copy guards them in CI.
+func TestCylinderTangentNormalsGolden(t *testing.T) {
+	const R = 2.0
+	cyl, err := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), R)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m1, m2, err := cylinderTangentNormals(math.P3(5, 0, 0), cyl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Contact point = axis foot (the origin here) + R·m, where the normal m is the contact radial.
+	got := [][2]float64{
+		{R * float64(m1.AsVector().X), R * float64(m1.AsVector().Y)},
+		{R * float64(m2.AsVector().X), R * float64(m2.AsVector().Y)},
+	}
+	if got[0][1] > got[1][1] {
+		got[0], got[1] = got[1], got[0]
+	}
+	want := [][2]float64{{0.8, -1.833030277982336}, {0.8, 1.833030277982336}} // OCCT GccAna_Lin2d2Tan
+	for i := range want {
+		if dx := got[i][0] - want[i][0]; dx > 1e-9 || dx < -1e-9 {
+			t.Errorf("contact %d x = %v, want %v (OCCT)", i, got[i][0], want[i][0])
+		}
+		if dy := got[i][1] - want[i][1]; dy > 1e-9 || dy < -1e-9 {
+			t.Errorf("contact %d y = %v, want %v (OCCT)", i, got[i][1], want[i][1])
+		}
+	}
+}
+
 // TestLineTangentProximitySelectsSide: for a through-line tangent on a cylinder, a proximity point
 // selects which of the two tangent solutions is built (#1844).
 func TestLineTangentProximitySelectsSide(t *testing.T) {


### PR DESCRIPTION
Wires the OpenCASCADE (OCCT) computational oracle into the kernel geometry tests, grounding this milestone's analytic work-feature geometry against a battle-tested kernel — two complementary ways:

## 1. CI-safe golden (always runs)
`TestCylinderTangentNormalsGolden` pins `cylinderTangentNormals` (#1844) to the exact contact points OCCT's `GccAna_Lin2d2Tan` (line tangent to a circle) reports — `(0.8, ±1.833030277982336)` — with a comment citing the oracle. A kernel regression fails CI.

## 2. Oracle-gated live cross-check (`-tags oracle`, excluded from CI)
`model/feature/oracle_geometry_test.go` (build tag `oracle`) shells out to `_oracles/oracle_service.py` (a JSON CLI over **pythonocc-core / OCCT**) and asserts the Go kernel's `cylinderTangentNormals` and `revolvedFaceAxis` (#1840) match OCCT ground truth live. It is:
- **excluded from the CI build** (the `oracle` build tag; CI has no Python/OCCT — verified: plain `go test` reports "no tests to run" and `go vet` is clean in both configs), and
- **skipped** unless `OBK_ORACLE_PY` (conda `occ` python) and `OBK_ORACLE_SVC` (the service script) are set.

Run locally:
```
OBK_ORACLE_PY=~/miniforge3/envs/occ/python.exe \
OBK_ORACLE_SVC=…/_oracles/oracle_service.py \
go test -tags oracle -run Oracle ./model/feature/...
```

## Why both
The oracle is the source of truth for the frozen golden constants (CI protects them); the gated test re-derives them live so a regression surfaces on demand and the golden values can be regenerated. Confirmed passing: the live cross-check matches OCCT to 1e-9, and the golden test is green in the normal build.

The oracle harness itself (OCCT via gmsh + pythonocc-core, SolveSpace via a MinGW-built `libslvs.dll`) lives outside the repo in `_oracles/` and is documented there; no new host/API runtime dependency.

Host-only; no API change.