### PR TITLE
feat(revolve): surface operation — surface of revolution as an open sheet (#1858)

### DIFF
--- a/addin/opregistry/feature_solid.go
+++ b/addin/opregistry/feature_solid.go
@@ -29,7 +29,7 @@ const revolveSchema = `{
     "axisRef": {"type": "string", "description": "Work-axis reference to revolve about, e.g. \"origin/axis/y\" (default). See get_reference_keys / list_work_planes."},
     "angle": {"type": "string", "description": "Revolve angle with units, e.g. \"360 deg\"."},
     "angle2": {"type": "string", "description": "Optional second-direction sweep (opposite sense), e.g. \"30 deg\" — the two-directional revolve."},
-    "operation": {"type": "string", "enum": ["new", "join", "cut", "intersect"], "default": "new"},
+    "operation": {"type": "string", "enum": ["new", "join", "cut", "intersect", "surface"], "default": "new", "description": "Boolean against existing bodies, or \"surface\" to revolve the profile into an open surface-of-revolution (sheet) body — Inventor's kSurfaceOperation."},
     "profileSeed": {"type": "array", "items": {"type": "number"}, "minItems": 2, "maxItems": 2, "description": "Select the revolved region by an interior seed point [x,y] (sketch 2-D cm) instead of profileIndex — resolved by containment on the solved sketch every recompute; wins over profileIndex."}
   },
   "required": ["sketchIndex", "angle"]

--- a/addin/opregistry/revolve_surface_test.go
+++ b/addin/opregistry/revolve_surface_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/kernel/ops"
+	omath "oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/sketch"
+)
+
+// revolveReadyPart builds a part with a rectangle clear of the axis (radius 2..4, height 0..3 on
+// XY), so it can be revolved about the origin Y axis without collapsing onto a pole.
+func revolveReadyPart(t *testing.T) *app.Session {
+	t.Helper()
+	s := app.NewSession()
+	d, err := s.Workspace().Add(doc.Part, "t.obk", true)
+	if err != nil {
+		t.Fatalf("add document: %v", err)
+	}
+	def := compdef.NewPartComponentDefinition()
+	d.SetContent(def)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	at := func(x, y float64) *sketch.Point { return sk.Points().Add(omath.P2(x, y)) }
+	corners := []*sketch.Point{at(2, 0), at(4, 0), at(4, 3), at(2, 3)}
+	for i, c := range corners {
+		sk.Lines().Add(c, corners[(i+1)%len(corners)])
+	}
+	def.Recompute()
+	return s
+}
+
+// TestRevolveSurfaceOperation drives the revolve tool with operation:"surface" (Inventor's
+// kSurfaceOperation, #1858): a rectangle (radius 2..4, height 3) revolved 180° about the Y axis
+// builds one healthy OPEN sheet body — the surface of revolution, no start/end profile caps, not
+// booleaned. Its area matches the analytic surface-of-revolution area θ·h·(r1+r2)+θ(r2²−r1²)
+// (verified against the OCCT oracle), within the tessellation tolerance.
+func TestRevolveSurfaceOperation(t *testing.T) {
+	s := revolveReadyPart(t)
+	raw, err := applyMap(t, s, "revolve", map[string]any{
+		"sketchIndex": 0, "angle": "180 deg", "axisRef": "origin/axis/y", "operation": "surface",
+	})
+	if err != nil {
+		t.Fatalf("surface revolve: %v", err)
+	}
+	var res struct {
+		Bodies  int  `json:"bodies"`
+		Healthy bool `json:"healthy"`
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if !res.Healthy || res.Bodies != 1 {
+		t.Fatalf("surface revolve result = %+v, want one healthy body", res)
+	}
+	b := s.ActiveDocument().Content().(*compdef.PartComponentDefinition).SurfaceBodies().Item(0)
+	if b.IsSolid() {
+		t.Error("surface-operation revolve produced a SOLID body, want an open sheet")
+	}
+
+	const r1, r2, h, theta = 2.0, 4.0, 3.0, math.Pi // 180°
+	want := theta*h*(r1+r2) + theta*(r2*r2-r1*r1)   // 30π ≈ 94.25 (OCCT-confirmed formula)
+	got := ops.BodyGeometryProperties(b, ops.DefaultQuality()).Area
+	if got < 0.90*want || got > 1.02*want {
+		t.Errorf("surface-of-revolution area = %.4f, want ≈ %.4f (analytic; faceted within tolerance)", got, want)
+	}
+}
+
+// TestRevolveSurfaceUnknownOperationErrors: an unknown operation is still a clean error after
+// adding "surface" to the revolve enum.
+func TestRevolveSurfaceUnknownOperationErrors(t *testing.T) {
+	s := revolveReadyPart(t)
+	if _, err := applyMap(t, s, "revolve", map[string]any{"sketchIndex": 0, "angle": "90 deg", "operation": "bogus"}); err == nil {
+		t.Error("unknown operation should error")
+	}
+}

--- a/model/feature/revolve_surface_test.go
+++ b/model/feature/revolve_surface_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+)
+
+// TestRevolveSurfacePartialOpenSheet: a 90° Surface-operation revolve of the square (r 2..4, h 2)
+// builds an OPEN surface of revolution — no start/end profile caps — via buildRevolveSheet →
+// sweptShell. Its area is the analytic θ·h·(r1+r2)+θ·(r2²−r1²) = 12π (the OCCT-grounded
+// surface-of-revolution formula), within the tessellation tolerance (#1858).
+func TestRevolveSurfacePartialOpenSheet(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	pf := NewRevolveFeatures(fs).Add(offsetSquareSketch(2, 2), 0, yAxis(),
+		func() float64 { return stdmath.Pi / 2 }, ops.Surface)
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("surface revolve went sick: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	if body.IsSolid() {
+		t.Error("partial surface-operation revolve should be an OPEN sheet, got a solid")
+	}
+	want := stdmath.Pi/2*2*(2+4) + stdmath.Pi/2*(4*4-2*2) // 12π
+	if got := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Area; relErr(got, want) > 0.03 {
+		t.Errorf("open surface-of-revolution area = %g, want ≈%g (12π) within 3%%", got, want)
+	}
+}
+
+// TestRevolveSurfaceFullClosedSheet: a full 360° Surface revolve of the square boundary builds the
+// closed surface of revolution (a watertight sheet), exercising sweptShell's closed-shell outward
+// orientation flip. Area = 2π·h·(r1+r2)+2π·(r2²−r1²) = 48π (#1858).
+func TestRevolveSurfaceFullClosedSheet(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	pf := NewRevolveFeatures(fs).Add(offsetSquareSketch(2, 2), 0, yAxis(), nil, ops.Surface)
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("full surface revolve went sick: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	want := 2*stdmath.Pi*2*(2+4) + 2*stdmath.Pi*(4*4-2*2) // 48π
+	if got := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Area; relErr(got, want) > 0.03 {
+		t.Errorf("closed surface-of-revolution area = %g, want ≈%g (48π) within 3%%", got, want)
+	}
+}

--- a/model/feature/sketched_features.go
+++ b/model/feature/sketched_features.go
@@ -88,12 +88,25 @@ func (r *RevolveFeature) Recompute(in Input) (Output, error) {
 	return Output{Bodies: bodies}, nil
 }
 
-// buildRevolveTool spins the profile into the solid of revolution, resolving the swept
-// span from the definition. The actual revolution is the shared [buildRevolveSolid] (the
-// assembly-context revolve, #735, reuses it on an assembly-space profile).
+// buildRevolveTool spins the profile into the tool body, resolving the swept span from the
+// definition. For the Surface operation (kSurfaceOperation, #1858) it revolves the profile
+// boundary into an OPEN surface of revolution (a sheet); otherwise it builds the solid of
+// revolution via the shared [buildRevolveSolid] (the assembly-context revolve, #735, reuses it).
 func (r *RevolveFeature) buildRevolveTool(prof *sketch.Profile, axis *WorkAxis) (*topo.Body, error) {
 	angle, start := revolveSpan(r.def)
-	return buildRevolveSolid(prof, r.def.Sketch.Plane(), axis, angle, start, featOr(r.featName, "revolve"))
+	plane, feat := r.def.Sketch.Plane(), featOr(r.featName, "revolve")
+	if r.def.Operation == ops.Surface {
+		return buildRevolveSheet(prof, plane, axis, angle, start, feat)
+	}
+	return buildRevolveSolid(prof, plane, axis, angle, start, feat)
+}
+
+// buildRevolveSheet revolves the profile boundary into an open surface of revolution (no caps) —
+// Inventor's Surface-operation revolve (kSurfaceOperation, #1858). Uses the faceted section sweep
+// (sweptShell), matching the faceted swept-solid path; combine() adds the result as a surface body.
+func buildRevolveSheet(prof *sketch.Profile, plane sketch.Plane, axis *WorkAxis, angle, start float64, feat string) (*topo.Body, error) {
+	sections, closed := revolveSectionsFrom(prof, plane, axis, angle, start)
+	return sweptShell(sections, closed, feat)
 }
 
 // buildRevolveSolid revolves a profile (already projected onto plane) about axis over the

--- a/model/feature/swept.go
+++ b/model/feature/swept.go
@@ -36,6 +36,55 @@ func sweptSolid(sections [][]math.Point3, closedLoop bool, feat string) (*topo.B
 	return body, nil
 }
 
+// sweptShell builds an OPEN surface shell — the side walls only, with NO start/end caps — from a
+// sequence of cross-section loops, the surface-of-revolution / swept sheet for the kSurface
+// operation (#1858). For a full revolution (closedLoop) the side walls already close into a
+// watertight sheet; for a partial sweep the result is an open sheet with boundary edges at the
+// start and end sections. combine() adds it to the model as a surface body (no boolean). It shares
+// sweptSolid's cage→B-rep path but omits the cap rows, so downstream sees an open (non-solid) body.
+func sweptShell(sections [][]math.Point3, closedLoop bool, feat string) (*topo.Body, error) {
+	if err := validateSections(sections, closedLoop); err != nil {
+		return nil, err
+	}
+	mesh := sectionSideMesh(sections, closedLoop, closureShift(sections, closedLoop))
+	body := subd.ToBody(mesh, feat)
+	// A full-revolution shell is closed, so orient it outward like a solid; an open sheet's signed
+	// volume is ~0 and the flip is a harmless no-op.
+	if ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume < 0 {
+		body = subd.ToBody(reverseFaces(mesh), feat)
+	}
+	return body, nil
+}
+
+// sectionSideMesh is sectionMesh's cage WITHOUT the start/end cap rows — the side walls only, for
+// the open surface shell sweptShell builds (#1858).
+func sectionSideMesh(sections [][]math.Point3, closedLoop bool, wrapShift int) subd.Mesh {
+	k, n := len(sections), len(sections[0])
+	verts := make([]math.Point3, 0, k*n)
+	for _, s := range sections {
+		verts = append(verts, s...)
+	}
+	segs := k - 1
+	if closedLoop {
+		segs = k
+	}
+	var faces [][]int
+	for s := 0; s < segs; s++ {
+		ns := (s + 1) % k
+		shift := 0
+		if closedLoop && ns == 0 {
+			shift = wrapShift
+		}
+		for i := 0; i < n; i++ {
+			j := (i + 1) % n
+			a, b := s*n+i, s*n+j
+			c, d := ns*n+(j+shift)%n, ns*n+(i+shift)%n
+			faces = append(faces, sideQuad(verts, a, b, c, d)...)
+		}
+	}
+	return subd.Mesh{Verts: verts, Faces: faces}
+}
+
 // validateSections rejects inputs that cannot form a solid: fewer than two sections
 // (or three for a closed loop), a degenerate cross-section, or ragged section sizes.
 func validateSections(sections [][]math.Point3, closedLoop bool) error {

--- a/model/feature/swept.go
+++ b/model/feature/swept.go
@@ -26,7 +26,7 @@ func sweptSolid(sections [][]math.Point3, closedLoop bool, feat string) (*topo.B
 	if err := validateSections(sections, closedLoop); err != nil {
 		return nil, err
 	}
-	mesh := sectionMesh(sections, closedLoop, closureShift(sections, closedLoop))
+	mesh := sectionMesh(sections, closedLoop, true, closureShift(sections, closedLoop))
 	body := subd.ToBody(mesh, feat)
 	// A consistently-wound cage is either all-outward or all-inward; if the signed
 	// volume came out negative the cage is inside-out, so rebuild it face-reversed.
@@ -46,7 +46,7 @@ func sweptShell(sections [][]math.Point3, closedLoop bool, feat string) (*topo.B
 	if err := validateSections(sections, closedLoop); err != nil {
 		return nil, err
 	}
-	mesh := sectionSideMesh(sections, closedLoop, closureShift(sections, closedLoop))
+	mesh := sectionMesh(sections, closedLoop, false, closureShift(sections, closedLoop))
 	body := subd.ToBody(mesh, feat)
 	// A full-revolution shell is closed, so orient it outward like a solid; an open sheet's signed
 	// volume is ~0 and the flip is a harmless no-op.
@@ -54,35 +54,6 @@ func sweptShell(sections [][]math.Point3, closedLoop bool, feat string) (*topo.B
 		body = subd.ToBody(reverseFaces(mesh), feat)
 	}
 	return body, nil
-}
-
-// sectionSideMesh is sectionMesh's cage WITHOUT the start/end cap rows — the side walls only, for
-// the open surface shell sweptShell builds (#1858).
-func sectionSideMesh(sections [][]math.Point3, closedLoop bool, wrapShift int) subd.Mesh {
-	k, n := len(sections), len(sections[0])
-	verts := make([]math.Point3, 0, k*n)
-	for _, s := range sections {
-		verts = append(verts, s...)
-	}
-	segs := k - 1
-	if closedLoop {
-		segs = k
-	}
-	var faces [][]int
-	for s := 0; s < segs; s++ {
-		ns := (s + 1) % k
-		shift := 0
-		if closedLoop && ns == 0 {
-			shift = wrapShift
-		}
-		for i := 0; i < n; i++ {
-			j := (i + 1) % n
-			a, b := s*n+i, s*n+j
-			c, d := ns*n+(j+shift)%n, ns*n+(i+shift)%n
-			faces = append(faces, sideQuad(verts, a, b, c, d)...)
-		}
-	}
-	return subd.Mesh{Verts: verts, Faces: faces}
 }
 
 // validateSections rejects inputs that cannot form a solid: fewer than two sections
@@ -108,10 +79,12 @@ func validateSections(sections [][]math.Point3, closedLoop bool) error {
 }
 
 // sectionMesh assembles the cage: vertex (s,i) at index s*n+i, a quad per (segment,
-// cross-section edge), and start/end caps unless the sweep is a closed loop. wrapShift offsets
-// the cross-section index across the CLOSING segment only, so a twisted closed loft (a Möbius
-// band) joins corresponding points across the seam instead of pairing them off by the monodromy.
-func sectionMesh(sections [][]math.Point3, closedLoop bool, wrapShift int) subd.Mesh {
+// cross-section edge), and — when caps is set — start/end caps unless the sweep is a closed loop.
+// The kSurface surface-of-revolution / swept-sheet path passes caps=false for an OPEN shell (side
+// walls only); the solid path passes caps=true (#1858). wrapShift offsets the cross-section index
+// across the CLOSING segment only, so a twisted closed loft (a Möbius band) joins corresponding
+// points across the seam instead of pairing them off by the monodromy.
+func sectionMesh(sections [][]math.Point3, closedLoop, caps bool, wrapShift int) subd.Mesh {
 	k, n := len(sections), len(sections[0])
 	verts := make([]math.Point3, 0, k*n)
 	for _, s := range sections {
@@ -135,7 +108,7 @@ func sectionMesh(sections [][]math.Point3, closedLoop bool, wrapShift int) subd.
 			faces = append(faces, sideQuad(verts, a, b, c, d)...)
 		}
 	}
-	if !closedLoop {
+	if caps && !closedLoop {
 		faces = append(faces, reversedRow(0, n), row(k-1, n))
 	}
 	return subd.Mesh{Verts: verts, Faces: faces}


### PR DESCRIPTION
Second feature of the **kSurface keystone** (#1858) — extrude already had it. `operation:"surface"` on **revolve** builds the profile boundary revolved into an **open surface of revolution** (a sheet body) instead of the solid of revolution: no boolean, added to `SurfaceBodies`.

## Implementation
- **`sweptShell`** (`model/feature/swept.go`): `sweptSolid`'s cage **without the start/end cap rows** — side walls only. A full revolution closes into a watertight sheet; a partial sweep is an open sheet with boundary edges. Reuses the section-sweep + outward-orientation path.
- **`buildRevolveTool`** branches on `ops.Surface` → `buildRevolveSheet`. `combine()` already routes any capless tool body to `SurfaceBodies` (from the extrude surface work), so no boolean runs.
- Revolve schema gains `"surface"` in its operation enum (`parseOperation` already maps it — shared with extrude).

## Oracle-grounded
A rectangle (radius 2..4, height 3) revolved 180° about Y yields a sheet whose area matches the analytic surface-of-revolution formula `θ·h·(r1+r2)+θ(r2²−r1²) = 30π ≈ 94.2478`. **Confirmed against OpenCASCADE** (`BRepPrimAPI_MakeRevol` of the same wire → area `94.247780`, 6 dp) via the `_oracles` harness — the new-kernel-surface grounding practice applied.

## Tests
`TestRevolveSurfaceOperation` (open sheet, healthy, area within tessellation tolerance of the oracle value) + `TestRevolveSurfaceUnknownOperationErrors`.

## Scope
Host-only; the `surface` operation vocabulary already exists (extrude). Remaining kSurface features (loft, sweep, coil, rib) are follow-ups — each needs its own sheet-generation path; this establishes the pattern (`sweptShell`) they'll reuse. Note: a *full-360* revolve of a *closed* profile yields a topologically closed shell (classified solid by topology); partial angles are cleanly open — the closed-360 surface-body classification is a noted follow-up.

Advances #1858.