### PR TITLE
feat(sweep): surface operation — open swept surface as a sheet (#1858)

### DIFF
--- a/addin/opregistry/feature_advanced.go
+++ b/addin/opregistry/feature_advanced.go
@@ -42,7 +42,7 @@ const sweepSchema = `{
     "scaling": {"type": "string", "enum": ["xy", "x", "none"], "default": "xy", "description": "How the guide rail scales the profile."},
     "guideFaceKey": {"type": "string", "description": "Reference key of the guide face (pathAndGuideSurface)."},
     "toolBodyIndex": {"type": "integer", "minimum": 0, "description": "Running-body index of the tool to drag (definitionType \"solid\")."},
-    "operation": {"type": "string", "enum": ["new", "join", "cut", "intersect"], "default": "new", "description": "Boolean against existing bodies (Inventor's PartFeatureOperationEnum, minus the surface op)."}
+    "operation": {"type": "string", "enum": ["new", "join", "cut", "intersect", "surface"], "default": "new", "description": "Boolean against existing bodies, or \"surface\" to sweep the profile into an open swept-surface (sheet) body — Inventor's kSurfaceOperation."}
   }
 }`
 

--- a/addin/opregistry/sweep_path_test.go
+++ b/addin/opregistry/sweep_path_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"math"
 	"testing"
+
+	"oblikovati.org/model/compdef"
 )
 
 // TestPath3DFromPoints covers the polyline→path helper: a valid chain builds an open path; too
@@ -120,5 +122,33 @@ func TestSweepPathPointsTooFew(t *testing.T) {
 	}
 	if _, err := applyMap(t, s, "sweep", args); err == nil {
 		t.Error("a single-point pathPoints should error")
+	}
+}
+
+// TestSweepSurfaceOperation sweeps the profile with operation:"surface" (kSurfaceOperation, #1858):
+// the rectangle swept 5 up +Z builds one healthy OPEN sheet body (walls only, no end caps), not
+// booleaned against anything.
+func TestSweepSurfaceOperation(t *testing.T) {
+	s := profiledPart(t)
+	raw, err := applyMap(t, s, "sweep", map[string]any{
+		"sketchIndex": 0, "profileIndex": 0, "operation": "surface",
+		"pathPoints": [][]float64{{0, 0, 0}, {0, 0, 5}},
+	})
+	if err != nil {
+		t.Fatalf("surface sweep: %v", err)
+	}
+	var res struct {
+		Bodies  int  `json:"bodies"`
+		Healthy bool `json:"healthy"`
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if !res.Healthy || res.Bodies != 1 {
+		t.Fatalf("surface sweep result = %+v, want one healthy body", res)
+	}
+	b := s.ActiveDocument().Content().(*compdef.PartComponentDefinition).SurfaceBodies().Item(0)
+	if b.IsSolid() {
+		t.Error("surface-operation sweep produced a SOLID body, want an open sheet")
 	}
 }

--- a/model/feature/sweep_loft.go
+++ b/model/feature/sweep_loft.go
@@ -145,7 +145,7 @@ func (s *SweepFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	s.tool, err = sweptSolid(sections, path.IsClosed(), featOr(s.featName, "sweep"))
+	s.tool, err = s.sweepTool(sections, path.IsClosed())
 	if err != nil {
 		return Output{}, err
 	}
@@ -154,6 +154,18 @@ func (s *SweepFeature) Recompute(in Input) (Output, error) {
 		return Output{}, err
 	}
 	return Output{Bodies: bodies}, nil
+}
+
+// sweepTool builds the swept body from its cross-sections: for the Surface operation
+// (kSurfaceOperation, #1858) an OPEN swept sheet (the profile boundary swept, no end caps) via
+// sweptShell; otherwise the swept solid. combine() adds a surface tool as a surface body (no
+// boolean).
+func (s *SweepFeature) sweepTool(sections [][]math.Point3, closed bool) (*topo.Body, error) {
+	feat := featOr(s.featName, "sweep")
+	if s.def.Operation == ops.Surface {
+		return sweptShell(sections, closed, feat)
+	}
+	return sweptSolid(sections, closed, feat)
 }
 
 // pathTangents returns a unit tangent at each path point: the forward segment at the

--- a/model/feature/sweep_surface_test.go
+++ b/model/feature/sweep_surface_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// TestSweepSurfaceMakesOpenSheet: a 2×2 square (perimeter 8) swept along a straight 5-long path with
+// the Surface operation (kSurfaceOperation, #1858) builds an OPEN swept sheet — the profile boundary
+// swept, no end caps — via sweepTool → sweptShell. For a straight path the four side faces are exact
+// planes, so the area is perimeter × length = 40 exactly.
+func TestSweepSurfaceMakesOpenSheet(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	path := sketch.NewPath3D([]*sketch.Point3D{
+		sketch.NewPoint3D(math.P3(0, 0, 0)),
+		sketch.NewPoint3D(math.P3(0, 0, 5)),
+	}, false)
+	pf := NewSweepFeatures(fs).Add(centeredSquareOn(sketch.XYPlane(), 1), 0, path, nil, ops.Surface)
+	fs.Recompute()
+
+	if !pf.Health().OK() {
+		t.Fatalf("surface sweep went sick: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	if body.IsSolid() {
+		t.Error("surface-operation sweep should be an OPEN sheet, got a solid")
+	}
+	want := 8.0 * 5.0 // profile perimeter 8 × path length 5
+	if got := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Area; relErr(got, want) > 0.02 {
+		t.Errorf("swept sheet area = %g, want ≈%g (perimeter × length)", got, want)
+	}
+}


### PR DESCRIPTION
Third feature of the **kSurface keystone** (#1858) — after extrude + revolve (#1909). `operation:"surface"` on **sweep** builds the profile boundary swept along the path as an **open sheet body** (no end caps) instead of the swept solid: no boolean, added to `SurfaceBodies`.

## Implementation
- **`SweepFeature.sweepTool`** branches on `ops.Surface` → **`sweptShell`** (the capless shell from #1909) vs `sweptSolid`. `combine()` already routes a capless tool body to `SurfaceBodies`; `parseOperation` already maps `"surface"` (shared with extrude/revolve).
- Sweep schema gains `"surface"` in its operation enum.

## Tests (coverage-bearing test in the model package, per the per-package Sonar rule)
- **Model**: `TestSweepSurfaceMakesOpenSheet` — a 2×2 square (perimeter 8) swept 5 along a straight path yields an **open sheet** (`IsSolid()==false`) of area `perimeter × length = 40` (exact for planar side faces).
- **Router**: `TestSweepSurfaceOperation` — end-to-end via the registry, confirms the sheet body.

## Scope
Host-only; the `surface` operation vocabulary already exists. Same `sweptShell` pattern the remaining kSurface features (loft, coil, rib) will reuse.

Advances #1858.