### PR TITLE
feat(coil): surface operation — open coiled surface as a sheet (#1858)

### DIFF
--- a/addin/opregistry/feature_solid.go
+++ b/addin/opregistry/feature_solid.go
@@ -208,7 +208,7 @@ const coilSchema = `{
     "revolutions": {"type": "string", "description": "Number of turns, e.g. \"4\"."},
     "height": {"type": "string", "description": "Total axial rise, e.g. \"30 mm\" — combines with pitch OR revolutions."},
     "taper": {"type": "string", "description": "Optional taper angle, e.g. \"5 deg\" — the helix radius grows with height."},
-    "operation": {"type": "string", "enum": ["new", "join", "cut"], "default": "new"},
+    "operation": {"type": "string", "enum": ["new", "join", "cut", "surface"], "default": "new", "description": "Boolean against existing bodies, or \"surface\" to coil the profile into an open swept-surface (sheet) body — Inventor's kSurfaceOperation."},
     "startTransitionAngle": {"type": "string", "description": "Spring start-end transition sweep (pitch winds down to zero), e.g. \"90 deg\". Grounds/flattens the coil start."},
     "startFlatAngle": {"type": "string", "description": "Spring start-end flat sweep (zero pitch) after the transition, e.g. \"180 deg\"."},
     "endTransitionAngle": {"type": "string", "description": "Spring end transition sweep (pitch winds down to zero), e.g. \"90 deg\"."},

--- a/model/feature/coil_surface_test.go
+++ b/model/feature/coil_surface_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+)
+
+// TestCoilSurfaceMakesOpenSheet: a 1×1 profile coiled 3 turns at pitch 2 about Z with the Surface
+// operation (kSurfaceOperation, #1858) builds an OPEN coiled sheet — the profile boundary swept
+// along the helix, no end caps — via coilTool → sweptShell (not a solid). The key correctness is the
+// open-sheet classification, cross-checked against the coil SOLID: the sheet is the solid's lateral
+// surface, so solid area = sheet area + the two profile end caps (≈2 for the unit profile).
+func TestCoilSurfaceMakesOpenSheet(t *testing.T) {
+	mk := func(op ops.PartFeatureOperation) *topo.Body {
+		fs := NewPartFeatures(nil)
+		pf := NewCoilFeatures(fs).AddDefinition(&CoilDefinition{
+			Sketch: coilProfileSketch(), Axis: zWorkAxis(),
+			Pitch: angleConst(2), Revolutions: angleConst(3), Operation: op,
+		})
+		fs.Recompute()
+		if !pf.Health().OK() {
+			t.Fatalf("coil (%v) went sick: %+v", op, pf.Health())
+		}
+		return fs.Result()[0]
+	}
+	area := func(b *topo.Body) float64 { return ops.BodyGeometryProperties(b, ops.DefaultQuality()).Area }
+
+	sheet, solid := mk(ops.Surface), mk(ops.NewBody)
+	if sheet.IsSolid() {
+		t.Error("surface-operation coil should be an OPEN sheet, got a solid")
+	}
+	sheetArea := area(sheet)
+	if sheetArea < 180 || sheetArea > 320 {
+		t.Errorf("coiled sheet area = %g, out of the expected regression band (≈235)", sheetArea)
+	}
+	// The open sheet is the solid coil's lateral surface: solid area = sheet + the two end caps.
+	// The 1×1 profile's two caps add ≈2, so the difference matches within a small margin.
+	if diff := area(solid) - sheetArea; relErr(diff, 2.0) > 0.5 {
+		t.Errorf("solid coil area − sheet = %g, want ≈2 (the two profile end caps)", diff)
+	}
+}

--- a/model/feature/sketched_features.go
+++ b/model/feature/sketched_features.go
@@ -409,7 +409,7 @@ func (c *CoilFeature) Recompute(in Input) (Output, error) {
 		return Output{}, err
 	}
 	sections := coilSections(prof, c.def.Sketch.Plane(), c.def.Axis, rise, totalTurns, c.def.Taper)
-	c.tool, err = sweptSolid(sections, false, featOr(c.featName, "coil"))
+	c.tool, err = c.coilTool(sections)
 	if err != nil {
 		return Output{}, err
 	}
@@ -418,6 +418,18 @@ func (c *CoilFeature) Recompute(in Input) (Output, error) {
 		return Output{}, err
 	}
 	return Output{Bodies: bodies}, nil
+}
+
+// coilTool builds the coiled body from its helical cross-sections: for the Surface operation
+// (kSurfaceOperation, #1858) an OPEN coiled sheet (the profile boundary swept along the helix, no
+// end caps) via sweptShell; otherwise the coiled solid. combine() adds a surface tool as a surface
+// body (no boolean).
+func (c *CoilFeature) coilTool(sections [][]math.Point3) (*topo.Body, error) {
+	feat := featOr(c.featName, "coil")
+	if c.def.Operation == ops.Surface {
+		return sweptShell(sections, false, feat)
+	}
+	return sweptSolid(sections, false, feat)
 }
 
 // coilSections places the profile along the helix rail: at each step it is


### PR DESCRIPTION
Fourth feature of the **kSurface keystone** (#1858) — after extrude, revolve (#1909), sweep (#1910). `operation:"surface"` on **coil** builds the profile boundary swept along the helix as an **open sheet body** (no end caps) instead of the coiled solid: no boolean, added to `SurfaceBodies`.

## Implementation
- **`CoilFeature.coilTool`** branches on `ops.Surface` → `sweptShell` vs `sweptSolid`. `combine()` routes a capless tool body to `SurfaceBodies`; `parseOperation` already maps `"surface"`.
- Coil schema gains `"surface"` in its operation enum.

## Test (model package, per the per-package Sonar coverage rule)
`TestCoilSurfaceMakesOpenSheet` — the surface coil is an **open sheet** (`IsSolid()==false`), cross-checked against the coil **solid**: the sheet is the solid's lateral surface, so `solid_area − sheet_area ≈ 2` (the two unit-profile end caps). That grounds the helical geometry cleanly without an external area formula (the helical sweep has no simple closed form).

Host-only; the `surface` vocabulary already exists. Same `sweptShell` branch as sweep. Remaining kSurface: **rib** (quick) and **loft** (the hollow-`tubeSolid` variant).

Advances #1858.