### PR TITLE
Fix frame-loop deadlock from per-frame hover-pick triangulating degenerate planar faces

### DIFF
--- a/kernel/brep/pick_planar_test.go
+++ b/kernel/brep/pick_planar_test.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep_test
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+)
+
+// TestRayCastPlanarCapHitMiss covers the point-in-polygon planar-face pick path (ops.rayCastFace):
+// a planar face is now hit-tested by ray–plane intersection + point-in-polygon on its boundary
+// rather than by triangulating it, so the per-frame hover pick never runs the exact-predicate
+// ear-clipper (the O(m³) big.Rat freeze that deadlocked add-in placement). This verifies the new
+// path still reports the correct nearest face: a ray down the axis hits the top cap, an off-axis
+// ray misses the solid entirely.
+func TestRayCastPlanarCapHitMiss(t *testing.T) {
+	const r, h = 5.0, 8.0
+	mer := []math.Point2{math.P2(0, 0), math.P2(r, 0), math.P2(r, h), math.P2(0, h)}
+	body, err := brep.SolidOfRevolution(math.P3(0, 0, 0), math.V3(0, 0, 1), mer, "cyl")
+	if err != nil || body == nil {
+		t.Fatalf("SolidOfRevolution = %v, %v", body, err)
+	}
+	q := ops.DefaultQuality()
+
+	// Straight down the axis from above the top cap (z=h): must hit a face at ~ (100-h).
+	_, dist, ok := ops.RayCastFaces(body, math.P3(0, 0, 100), math.V3(0, 0, -1), q)
+	if !ok {
+		t.Fatal("axis ray missed the cylinder; want a hit on the top cap")
+	}
+	if want := 100.0 - h; dist < want-1e-6 || dist > want+1e-6 {
+		t.Errorf("axis-ray hit distance = %g, want %g (top cap at z=%g)", dist, want, h)
+	}
+
+	// A ray parallel to the axis but well outside the radius must miss every face.
+	if _, _, ok := ops.RayCastFaces(body, math.P3(3*r, 0, 100), math.V3(0, 0, -1), q); ok {
+		t.Error("off-axis ray hit the cylinder; want a miss (outside every face's boundary)")
+	}
+}

--- a/kernel/ops/cdt.go
+++ b/kernel/ops/cdt.go
@@ -65,6 +65,20 @@ type cdt struct {
 	// current segment's recovery completes (#1604): recovery alone leaves the corridor non-Delaunay,
 	// which both degrades triangle quality and invalidates the walk-based point location.
 	pendingLegal [][2]int
+	// recoverFlipWork counts flipOneCrossing invocations across ALL recoverByFlips calls, and
+	// recoverBudget caps it. recoverByFlips is the O(T) whole-mesh fallback taken only when the
+	// corridor march fails on a degeneracy; on a NON-SIMPLE (self-intersecting / overlapping /
+	// pinched) boundary — a transient partially-constrained face hover-picked mid-build — that
+	// degeneracy hits every constraint, so each spins its per-segment cap of O(T) scans and the
+	// face costs O(n·T²) (seconds on a ~250-vertex face). That is synchronous per-frame pick work,
+	// so it starves the frame-loop dispatcher an async add-in build depends on → hard deadlock.
+	// A GLOBAL budget stops the spin once a face proves thoroughly degenerate; overBudget then
+	// forces finalizeDomain to the deterministic earcut fallback. A valid face barely touches
+	// recoverByFlips (the march handles it, and splitConstraintAtVertices recovers the rare
+	// on-segment vertex even after a budget bail), so the budget is invisible to it.
+	recoverFlipWork int
+	recoverBudget   int
+	overBudget      bool
 }
 
 func conKey(a, b int) [2]int {
@@ -114,6 +128,12 @@ func newCDT(pts [][2]float64) *cdt {
 	m := &cdt{pts: all, con: map[[2]int]int{}, nsup: nsup}
 	m.tris = []cdtTri{{v: [3]int{nsup, nsup + 1, nsup + 2}, n: [3]int{-1, -1, -1}}}
 	m.dead = []bool{false}
+	// recoverByFlips is a rare legacy fallback: the corridor march (#1409) plus splitConstraintAtVertices
+	// recover every VALID face's constraints without it (the whole CDT/tessellation suite passes with this
+	// budget at 0). So a modest global budget lets a genuinely-hard segment still get a burst of flips while
+	// capping a malformed face — where every constraint falls back and each flipOneCrossing is an O(T) scan —
+	// at O(nsup) total scans instead of O(nsup²), the O(n·T²) freeze fixed here. See recoverFlipWork.
+	m.recoverBudget = 2*nsup + 64
 	return m
 }
 

--- a/kernel/ops/cdt_build.go
+++ b/kernel/ops/cdt_build.go
@@ -403,7 +403,10 @@ func (m *cdt) finalizeDomain(pts [][2]float64, loops [][]int) ([][3]int, [][2]in
 	if len(m.unrecovered) == 0 {
 		return ed, nil, false
 	}
-	if m.domainLeaked(ed, loops) {
+	// A budget bail means the boundary is non-simple: the extracted domain is untrustworthy (many
+	// unrecovered constraints), so take the deterministic, bounded earcut fallback unconditionally
+	// rather than probing domainLeaked on a mesh we already know is degenerate (see recoverFlipWork).
+	if m.overBudget || m.domainLeaked(ed, loops) {
 		return earcutFromLoops(pts, loops), m.unrecovered, true
 	}
 	return ed, m.unrecovered, false

--- a/kernel/ops/cdt_constraint.go
+++ b/kernel/ops/cdt_constraint.go
@@ -375,6 +375,15 @@ func (m *cdt) touch(t int) {
 // unrecovered for finalizeDomain) rather than spinning, exactly as before #1409.
 func (m *cdt) recoverByFlips(a, b int) bool {
 	for tries := 0; !m.hasEdge(a, b) && tries < 4*len(m.tris)+8; tries++ {
+		if m.recoverFlipWork >= m.recoverBudget {
+			// The face has spent its whole flip-recovery budget without realizing this edge: it is
+			// thoroughly degenerate (non-simple). Stop the O(n·T²) spin and let insertConstraint's
+			// splitConstraintAtVertices try (it recovers valid on-segment cases); the flag routes a
+			// genuinely-unrecoverable face to the deterministic earcut fallback in finalizeDomain.
+			m.overBudget = true
+			return false
+		}
+		m.recoverFlipWork++
 		if !m.flipOneCrossing(a, b) {
 			break
 		}

--- a/kernel/ops/pick.go
+++ b/kernel/ops/pick.go
@@ -5,23 +5,71 @@ package ops
 import (
 	stdmath "math"
 
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 )
 
 // RayCastFaces returns the nearest face of a body hit by a ray, with the hit
 // distance — the geometric core of viewport picking (the renderer's ID-buffer is an
-// optimization of the same query). Each face is tessellated and its triangles
-// tested; the closest hit wins. Pure Go, so the UI's hit-test is headless-testable.
+// optimization of the same query). The closest hit wins. Pure Go, so the UI's
+// hit-test is headless-testable.
 func RayCastFaces(b *topo.Body, origin math.Point3, dir math.Vector3, q Quality) (*topo.Face, float64, bool) {
 	var nearest *topo.Face
 	best := stdmath.Inf(1)
 	for _, f := range b.Faces() {
-		if t, ok := rayCastMesh(TessellateFace(f, q), origin, dir); ok && t < best {
+		if t, ok := rayCastFace(f, origin, dir, q); ok && t < best {
 			best, nearest = t, f
 		}
 	}
 	return nearest, best, nearest != nil
+}
+
+// rayCastFace returns the ray's forward hit distance to a face. A PLANAR face is hit-tested by
+// ray–plane intersection plus a point-in-polygon test on its boundary loops — O(m), no
+// triangulation — so the synchronous per-frame hover pick never triangulates a planar face. That
+// matters because tessellatePlanarFace runs the exact-predicate ear-clipper, which on a degenerate
+// (near-collinear) boundary escalates to O(m³) big.Rat arithmetic (seconds on a ~66-vertex face);
+// re-run every frame by the viewport's hovered-plane pick, it starved the frame-loop dispatcher an
+// async add-in build blocks on → a hard placement deadlock. A curved face still ray-tests its
+// tessellation (a bounded UV grid — no ear-clipping).
+func rayCastFace(f *topo.Face, origin math.Point3, dir math.Vector3, q Quality) (float64, bool) {
+	if _, ok := f.Geometry().(geom.Plane); ok {
+		return rayCastPlanarFace(f, origin, dir, q)
+	}
+	return rayCastMesh(TessellateFace(f, q), origin, dir)
+}
+
+// rayCastPlanarFace intersects the ray with the face's plane, then tests the hit point against the
+// face's boundary loops (inside the outer loop, outside every hole) — the same coverage a
+// triangulation of the face would give, since the boundary is discretized identically (loopBoundary),
+// but in O(m) with no ear-clipping.
+func rayCastPlanarFace(f *topo.Face, origin math.Point3, dir math.Vector3, q Quality) (float64, bool) {
+	outer3D := faceOuterBoundary(f, q)
+	if len(outer3D) < 3 {
+		return 0, false
+	}
+	normal := f.Geometry().NormalAt(0, 0)
+	denom := float64(dir.Dot(normal))
+	if stdmath.Abs(denom) < 1e-12 {
+		return 0, false // ray parallel to the face plane
+	}
+	t := float64(origin.VectorTo(outer3D[0]).Dot(normal)) / denom
+	if t <= 0 {
+		return 0, false // behind the ray origin
+	}
+	hit := origin.TranslateBy(dir.Scale(math.Scalar(t)))
+	flat := planeProjector(normal)
+	p := flat(hit)
+	if !pointInLoop2D(p, project2D(outer3D, flat)) {
+		return 0, false
+	}
+	for _, h := range faceHoleBoundaries(f, q) {
+		if pointInLoop2D(p, project2D(h, flat)) {
+			return 0, false // the ray passes through a hole
+		}
+	}
+	return t, true
 }
 
 // rayCastMesh returns the nearest positive hit distance of a ray against a mesh's

--- a/kernel/ops/planar_faithful.go
+++ b/kernel/ops/planar_faithful.go
@@ -47,7 +47,46 @@ func planarTris(outer2D []math.Point2, holes2D [][]math.Point2) [][3]int {
 	if planarAreaMatches(tris, outer2D, holes2D) {
 		return tris
 	}
+	// A self-intersecting (non-simple) boundary has no correct triangulation, and feeding it to the
+	// CDT makes every boundary constraint fall into the O(T) flip-recovery fallback — O(n·T²), seconds
+	// on a ~250-vertex face — which, on the synchronous per-frame pick path, starves the frame-loop
+	// dispatcher an async add-in build waits on (a transient partially-constrained face gets revolved
+	// and hover-picked mid-build). Such input only appears transiently; a bounded best-effort mesh is
+	// fine (the real geometry replaces it next frame). The CDT's own recoverFlipWork budget backstops
+	// the non-crossing degeneracies (collinear overlap, coincident vertices) this cheap check misses.
+	if loopsSelfCross(outer2D, holes2D) {
+		return tris
+	}
 	return planarCDT(outer2D, holes2D)
+}
+
+// loopsSelfCross reports whether any two boundary segments of the loops (outer + holes) PROPERLY
+// cross — the defining signature of a non-simple boundary. It reuses the exact-predicate segmentsCross,
+// which returns false for segments that merely share an endpoint (adjacent edges) or touch, so only a
+// genuine transversal crossing trips it (no false positive on a valid simple boundary, whose faceting
+// stays simple). O(n²) with early exit, run only on the already-off area-mismatch path where n is one
+// face's facet count (<~150) — a few milliseconds worst case, and typically an immediate hit.
+func loopsSelfCross(outer2D []math.Point2, holes2D [][]math.Point2) bool {
+	var segs [][2][2]float64
+	appendLoop := func(loop []math.Point2) {
+		n := len(loop)
+		for i := 0; i < n; i++ {
+			p, q := loop[i], loop[(i+1)%n]
+			segs = append(segs, [2][2]float64{{float64(p.X), float64(p.Y)}, {float64(q.X), float64(q.Y)}})
+		}
+	}
+	appendLoop(outer2D)
+	for _, h := range holes2D {
+		appendLoop(h)
+	}
+	for i := 0; i < len(segs); i++ {
+		for j := i + 1; j < len(segs); j++ {
+			if segmentsCross(segs[i][0], segs[i][1], segs[j][0], segs[j][1]) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // planarAreaMatches reports whether tris covers exactly the face area (|outer| − Σ|holes|). A clean

--- a/kernel/ops/planar_nonsimple_test.go
+++ b/kernel/ops/planar_nonsimple_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"testing"
+	"time"
+
+	"oblikovati.org/math"
+)
+
+// selfCrossingBand builds a NON-SIMPLE (self-intersecting) closed polygon of 2*n vertices: two
+// near-collinear rows joined into a crossed "bowtie band". It stands in for a transient,
+// partially-constrained sketch face that gets revolved into a malformed solid and hover-picked
+// mid add-in build — the input that used to drive planarTris' CDT flip-recovery to O(n·T²).
+func selfCrossingBand(n int) []math.Point2 {
+	pts := make([]math.Point2, 0, 2*n)
+	for i := 0; i < n; i++ {
+		pts = append(pts, math.P2(float64(i), 0.0001*float64(i%2)))
+	}
+	for i := n - 1; i >= 0; i-- {
+		pts = append(pts, math.P2(float64(n-1-i), 0.5+0.0001*float64(i%2)))
+	}
+	return pts
+}
+
+// TestPlanarTrisNonSimpleBounded is the regression for the pick-path frame-starvation freeze:
+// planarTris on a self-intersecting ~264-vertex face must return a bounded triangulation quickly.
+// Before the fix (loopsSelfCross fast-path + the CDT recoverFlipWork budget) this took ~5.2 s — a
+// single such face, hover-picked every frame, starved the frame-loop dispatcher an async add-in
+// build blocks on, deadlocking placement. The ceiling is ~40x the fixed cost and ~20x under the
+// pre-fix cost, so it distinguishes fixed from broken without flaking on a slow CI host.
+func TestPlanarTrisNonSimpleBounded(t *testing.T) {
+	poly := selfCrossingBand(132) // 264 vertices
+	start := time.Now()
+	tris := planarTris(poly, nil)
+	elapsed := time.Since(start)
+	if elapsed > 250*time.Millisecond {
+		t.Fatalf("planarTris on a 264-vertex self-intersecting face took %v; want < 250ms "+
+			"(the O(n·T²) CDT flip-recovery freeze regressed)", elapsed)
+	}
+	if len(tris) == 0 {
+		t.Fatal("planarTris returned no triangles for a non-simple face; want a bounded best-effort mesh")
+	}
+}
+
+// TestConstrainedDelaunayNonSimpleBounded exercises the CDT's own recoverFlipWork budget in
+// isolation — the backstop for every constrainedDelaunay caller (curved-surface (u,v) meshers,
+// conformance repair), not just planarTris' fast-path. Fed a non-simple boundary directly, the
+// triangulation must terminate quickly instead of spinning flip-recovery to O(n·T²).
+func TestConstrainedDelaunayNonSimpleBounded(t *testing.T) {
+	poly := selfCrossingBand(132) // 264 vertices
+	pts := make([][2]float64, len(poly))
+	for i, p := range poly {
+		pts[i] = [2]float64{float64(p.X), float64(p.Y)}
+	}
+	loops := [][]int{rangeIndices(0, len(poly))}
+	start := time.Now()
+	tris := constrainedDelaunay(pts, loops)
+	if elapsed := time.Since(start); elapsed > 250*time.Millisecond {
+		t.Fatalf("constrainedDelaunay on a 264-vertex non-simple boundary took %v; want < 250ms "+
+			"(flip-recovery budget regressed)", elapsed)
+	}
+	_ = tris // may be empty for a fully-degenerate domain; the point is bounded time, not coverage
+}
+
+// TestLoopsSelfCross checks the discriminator that routes a non-simple face past the CDT: it fires
+// on a genuine transversal crossing and stays silent on valid simple boundaries (a clean n-gon and a
+// holed face), so valid complex faces still reach the constrained Delaunay unchanged.
+func TestLoopsSelfCross(t *testing.T) {
+	if !loopsSelfCross(selfCrossingBand(20), nil) {
+		t.Error("loopsSelfCross missed a self-intersecting boundary")
+	}
+	if loopsSelfCross(ngon2D(0, 0, 10, 48), nil) {
+		t.Error("loopsSelfCross flagged a clean convex n-gon as non-simple")
+	}
+	outer := ngon2D(0, 0, 10, 32)
+	hole := ngon2D(0, 0, 3, 24)
+	if loopsSelfCross(outer, [][]math.Point2{hole}) {
+		t.Error("loopsSelfCross flagged a valid holed face as non-simple")
+	}
+}

--- a/kernel/ops/planar_nonsimple_test.go
+++ b/kernel/ops/planar_nonsimple_test.go
@@ -4,7 +4,6 @@ package ops
 
 import (
 	"testing"
-	"time"
 
 	"oblikovati.org/math"
 )
@@ -24,44 +23,65 @@ func selfCrossingBand(n int) []math.Point2 {
 	return pts
 }
 
-// TestPlanarTrisNonSimpleBounded is the regression for the pick-path frame-starvation freeze:
-// planarTris on a self-intersecting ~264-vertex face must return a bounded triangulation quickly.
-// Before the fix (loopsSelfCross fast-path + the CDT recoverFlipWork budget) this took ~5.2 s — a
-// single such face, hover-picked every frame, starved the frame-loop dispatcher an async add-in
-// build blocks on, deadlocking placement. The ceiling is ~40x the fixed cost and ~20x under the
-// pre-fix cost, so it distinguishes fixed from broken without flaking on a slow CI host.
-func TestPlanarTrisNonSimpleBounded(t *testing.T) {
+// TestPlanarTrisNonSimpleFastPath is the regression for the pick-path frame-starvation freeze:
+// planarTris on a self-intersecting ~264-vertex face must take the loopsSelfCross fast-path and
+// skip the constrained-Delaunay entirely, returning a bounded best-effort mesh. Before the fix a
+// single such face — hover-picked every frame while an async add-in build ran — drove the CDT flip
+// recovery to O(n·T²) (~5.2 s), starving the frame-loop dispatcher and deadlocking placement. Asserted
+// on the deterministic fast-path predicate rather than wall-clock time (repeatable on any CI host).
+func TestPlanarTrisNonSimpleFastPath(t *testing.T) {
 	poly := selfCrossingBand(132) // 264 vertices
-	start := time.Now()
-	tris := planarTris(poly, nil)
-	elapsed := time.Since(start)
-	if elapsed > 250*time.Millisecond {
-		t.Fatalf("planarTris on a 264-vertex self-intersecting face took %v; want < 250ms "+
-			"(the O(n·T²) CDT flip-recovery freeze regressed)", elapsed)
+	if !loopsSelfCross(poly, nil) {
+		t.Fatal("selfCrossingBand is not detected as non-simple; the fast-path would not engage")
 	}
-	if len(tris) == 0 {
+	if tris := planarTris(poly, nil); len(tris) == 0 {
 		t.Fatal("planarTris returned no triangles for a non-simple face; want a bounded best-effort mesh")
 	}
 }
 
-// TestConstrainedDelaunayNonSimpleBounded exercises the CDT's own recoverFlipWork budget in
-// isolation — the backstop for every constrainedDelaunay caller (curved-surface (u,v) meshers,
-// conformance repair), not just planarTris' fast-path. Fed a non-simple boundary directly, the
-// triangulation must terminate quickly instead of spinning flip-recovery to O(n·T²).
-func TestConstrainedDelaunayNonSimpleBounded(t *testing.T) {
+// TestConstrainedDelaunayNonSimpleBudget exercises the CDT's own recoverFlipWork budget in isolation
+// — the backstop for every constrainedDelaunay caller (curved-surface (u,v) meshers, conformance
+// repair), not just planarTris' fast-path. Fed a non-simple boundary directly, the flip-recovery
+// budget must engage (m.overBudget), which is what caps the O(n·T²) spin and routes to the earcut
+// fallback. This is deterministic (same input → same flip sequence), unlike a wall-clock bound.
+func TestConstrainedDelaunayNonSimpleBudget(t *testing.T) {
 	poly := selfCrossingBand(132) // 264 vertices
 	pts := make([][2]float64, len(poly))
 	for i, p := range poly {
 		pts[i] = [2]float64{float64(p.X), float64(p.Y)}
 	}
 	loops := [][]int{rangeIndices(0, len(poly))}
-	start := time.Now()
-	tris := constrainedDelaunay(pts, loops)
-	if elapsed := time.Since(start); elapsed > 250*time.Millisecond {
-		t.Fatalf("constrainedDelaunay on a 264-vertex non-simple boundary took %v; want < 250ms "+
-			"(flip-recovery budget regressed)", elapsed)
+
+	m := newCDT(pts)
+	for i := 0; i < m.nsup; i++ {
+		m.insert(i)
 	}
-	_ = tris // may be empty for a fully-degenerate domain; the point is bounded time, not coverage
+	m.constrain(loops)
+	if !m.overBudget {
+		t.Fatalf("flip-recovery budget (%d) did not engage on a 264-vertex non-simple boundary; "+
+			"the O(n·T²) freeze can regress (recoverFlipWork=%d)", m.recoverBudget, m.recoverFlipWork)
+	}
+	if m.recoverFlipWork > m.recoverBudget {
+		t.Fatalf("recoverFlipWork %d exceeded budget %d", m.recoverFlipWork, m.recoverBudget)
+	}
+	// A valid convex face never trips the budget (the corridor march recovers it without recoverByFlips).
+	vm := newCDT(cvtPts(ngon2D(0, 0, 10, 64)))
+	for i := 0; i < vm.nsup; i++ {
+		vm.insert(i)
+	}
+	vm.constrain([][]int{rangeIndices(0, 64)})
+	if vm.overBudget {
+		t.Error("flip-recovery budget engaged on a valid convex n-gon; it must be invisible to valid faces")
+	}
+}
+
+// cvtPts converts a Point2 loop to the CDT's [][2]float64 form.
+func cvtPts(loop []math.Point2) [][2]float64 {
+	pts := make([][2]float64, len(loop))
+	for i, p := range loop {
+		pts[i] = [2]float64{float64(p.X), float64(p.Y)}
+	}
+	return pts
 }
 
 // TestLoopsSelfCross checks the discriminator that routes a non-simple face past the CDT: it fires


### PR DESCRIPTION
## What & why
Placing a procedural part whose async build adds a sketch section (surfaced by the PartDesigner **thrust grooved washer**) could hang the build indefinitely while the app stayed responsive to MCP. A SIGQUIT goroutine dump pinned it:

```
pumpFrame → head/ui.hoveredPlane → RayPicker.Pick → nearestFace
  → ops.RayCastFaces → TessellateFace → tessellatePlanarFace → planarTris
  → bestSingleLoopTriangulation → earClip → findEar → anyInside
  → predicate.Orient2D → orient2DExact → math/big.(*Rat).Sub
```

The viewport's per-frame hovered-plane pick tessellates **every body face every frame** (no cache). On a **degenerate near-collinear planar face** — which appears transiently while an async build revolves a partially-constrained sketch — `earClip` is O(m³) and every `Orient2D` escalates to exact `big.Rat` arithmetic, taking seconds. Re-run every frame, the frame loop never completes, so the add-in dispatcher (drained once per frame) never drains and the build's next wire call blocks forever → **deadlock**.

## Fix (two commits)
1. **Pick planar faces by point-in-polygon, not triangulation** (`kernel/ops/pick.go`). A planar face is hit-tested by ray–plane intersection + point-in-polygon on its boundary loops — O(m), no ear-clipping. The boundary is discretized identically to the tessellation, so coverage and hit distance are unchanged; curved faces still ray-test their bounded UV-grid mesh. **This is the deadlock fix.**
2. **Bound the planar CDT on non-simple faces** (`kernel/ops/cdt*.go`, `planar_faithful.go`). Defensive hardening for the other path that went superlinear on a non-simple boundary: the constrained-Delaunay flip-recovery spun every unrecoverable constraint to its cap (O(n·T²), ~5.2s at 264 verts). A global flip-recovery work budget + a self-intersection fast-path route a degenerate face to the deterministic earcut fallback; a 264-vertex non-simple face drops to a few ms. The corridor-march + split path recover every *valid* face without touching `recoverByFlips`, so the budget is invisible to them (whole CDT/tessellation suite passes with the budget at 0).

## Tests
- `TestRayCastPlanarCapHitMiss` — planar-pick hit/miss correctness on a real revolved solid.
- `TestPlanarTrisNonSimpleBounded`, `TestConstrainedDelaunayNonSimpleBounded` — the O(n·T²) freeze regression (bounded time).
- `TestLoopsSelfCross` — the non-simple discriminator (fires on a crossing, silent on valid n-gon/holed faces).
- Full `go test ./...` green; golangci-lint clean.

## Live validation
Thrust grooved-washer placement (the case that deadlocked) now completes: two grooved washer races + 16 balls build, **volume 8040.7 mm³ vs analytic 8057 → 0.20%**, and it renders correctly.

Design of the CDT budget & degeneracy discriminator was pressure-tested with the geometry-math-advisor (a global work budget is complete where a self-intersection gate alone is not — transversal crossing is only 1 of 6 PSLG-violation classes).

Closes #1913

🤖 Generated with [Claude Code](https://claude.com/claude-code)