### PR TITLE
feat(rib): surface operation — open rib walls as a sheet; closes kSurface (#1858)

### DIFF
--- a/addin/opregistry/feature_solid.go
+++ b/addin/opregistry/feature_solid.go
@@ -93,7 +93,7 @@ const ribSchema = `{
     "thickness": {"type": "string", "description": "Rib wall thickness, e.g. \"2 mm\"."},
     "depth": {"type": "string", "description": "How far the rib grows toward the body, e.g. \"10 mm\" (sign picks the direction; omit with toNext)."},
     "toNext": {"type": "boolean", "default": false, "description": "Extend the wall until it fully lands on the existing material (the to-next rib)."},
-    "operation": {"type": "string", "enum": ["new", "join"], "default": "join"}
+    "operation": {"type": "string", "enum": ["new", "join", "surface"], "default": "join", "description": "Join the rib to existing material (default), a new body, or \"surface\" to build the rib walls as an open sheet — Inventor's kSurfaceOperation."}
   },
   "required": ["sketchIndex", "thickness"]
 }`

--- a/model/feature/rib_surface_test.go
+++ b/model/feature/rib_surface_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+)
+
+// TestRibSurfaceMakesOpenSheet: a rib built with the Surface operation (kSurfaceOperation, #1858)
+// produces the rib WALLS only — an open sheet, no end caps — via buildExtrusionShell(caps=false),
+// rather than the capped prism. The open sheet is the solid rib's side walls, so a solid rib of the
+// same band has strictly more area (its two band end caps).
+func TestRibSurfaceMakesOpenSheet(t *testing.T) {
+	mk := func(op ops.PartFeatureOperation) *topo.Body {
+		fs := NewPartFeatures(nil)
+		pf := NewRibFeatures(fs).AddDefinition(&RibDefinition{
+			Sketch: lineSketchOn(planeAtZ(3)), ProfileIndex: 0,
+			Thickness: angleConst(0.5), Depth: angleConst(2), Operation: op,
+		})
+		fs.Recompute()
+		if !pf.Health().OK() {
+			t.Fatalf("rib (%v) went sick: %+v", op, pf.Health())
+		}
+		return fs.Result()[0]
+	}
+	area := func(b *topo.Body) float64 { return ops.BodyGeometryProperties(b, ops.DefaultQuality()).Area }
+
+	sheet, solid := mk(ops.Surface), mk(ops.NewBody)
+	if sheet.IsSolid() {
+		t.Error("surface-operation rib should be an OPEN sheet, got a solid")
+	}
+	if s, so := area(sheet), area(solid); s <= 0 || so <= s {
+		t.Errorf("rib sheet area %g should be > 0 and less than the solid rib area %g (which adds the two band caps)", s, so)
+	}
+}

--- a/model/feature/sketched_features.go
+++ b/model/feature/sketched_features.go
@@ -550,7 +550,9 @@ func (r *RibFeature) Recompute(in Input) (Output, error) {
 		return Output{}, err
 	}
 	band := ensureCCW2(thickenPath(pts, t))
-	r.tool = buildPrism(band, r.def.Sketch.Plane(), orderedSpan(0, d), 0, "rib")
+	// The Surface operation (kSurfaceOperation, #1858) builds the rib walls only — an open sheet, no
+	// caps — rather than the capped prism; combine() adds it as a surface body (no boolean).
+	r.tool = buildExtrusionShell(band, r.def.Sketch.Plane(), orderedSpan(0, d), 0, "rib", r.def.Operation != ops.Surface)
 	bodies, err := combine(in, r.tool, r.def.Operation)
 	if err != nil {
 		return Output{}, err


### PR DESCRIPTION
**Sixth and final feature of the kSurface keystone** — after extrude, revolve (#1909), sweep (#1910), coil (#1911), loft (#1912). `operation:"surface"` on **rib** builds the rib **walls only** — an open sheet, no end caps — via `buildExtrusionShell(caps=false)` instead of the capped prism; `combine()` adds it as a surface body (no boolean).

A one-line tool swap (`buildPrism` → `buildExtrusionShell` with `caps = op != Surface`) plus the `"surface"` enum value on the rib schema.

## Test
`TestRibSurfaceMakesOpenSheet` cross-checks the open sheet against the **solid** rib: the sheet is the solid's side walls, so the solid — which additionally has the two band end caps — has strictly more area.

## Keystone complete
With rib, **every additive sketch feature accepts the Surface operation**: extrude, revolve, sweep, coil, loft, rib. The surfacing workflow's entry point — the audit's #1 highest-leverage gap, which previously blocked thicken/stitch/trim/offset from having any surface body to consume — is fully open.

Host-only; the `surface` vocabulary already exists. **Closes #1858.**