### PR TITLE
Analytic spherical-cap revolve + revolve about the sketch centerline

### DIFF
--- a/addin/opregistry/feature_solid.go
+++ b/addin/opregistry/feature_solid.go
@@ -27,6 +27,7 @@ const revolveSchema = `{
     "sketchIndex": {"type": "integer", "minimum": 0},
     "profileIndex": {"type": "integer", "minimum": 0, "default": 0},
     "axisRef": {"type": "string", "description": "Work-axis reference to revolve about, e.g. \"origin/axis/y\" (default). See get_reference_keys / list_work_planes."},
+    "aboutCenterline": {"type": "boolean", "default": false, "description": "Revolve about the sketch's single centerline (an internal, tilted axis) instead of axisRef; the sketch must have exactly one centerline."},
     "angle": {"type": "string", "description": "Revolve angle with units, e.g. \"360 deg\"."},
     "angle2": {"type": "string", "description": "Optional second-direction sweep (opposite sense), e.g. \"30 deg\" — the two-directional revolve."},
     "operation": {"type": "string", "enum": ["new", "join", "cut", "intersect", "surface"], "default": "new", "description": "Boolean against existing bodies, or \"surface\" to revolve the profile into an open surface-of-revolution (sheet) body — Inventor's kSurfaceOperation."},
@@ -48,15 +49,23 @@ func applyRevolve(s *app.Session, raw json.RawMessage) (json.RawMessage, error) 
 	if err != nil {
 		return nil, err
 	}
-	axis, err := axisFromRef(part, in.AxisRef)
-	if err != nil {
-		return nil, err
-	}
 	angle, err := angleClosure(part, in.Angle, "revolve: angle")
 	if err != nil {
 		return nil, err
 	}
 	op, err := parseOperation(in.Operation)
+	if err != nil {
+		return nil, err
+	}
+	if in.AboutCenterline {
+		if in.Angle2 != "" {
+			return nil, errors.New("revolve: aboutCenterline does not support a second-direction angle2")
+		}
+		pf := feature.NewRevolveFeatures(part.Features()).AddAboutCenterline(sk, in.ProfileIndex, angle, op)
+		setRevolveProfileSeed(pf, in.ProfileSeed)
+		return recomputeResult(part, pf)
+	}
+	axis, err := axisFromRef(part, in.AxisRef)
 	if err != nil {
 		return nil, err
 	}

--- a/addin/router/sketch_add_entity.go
+++ b/addin/router/sketch_add_entity.go
@@ -29,6 +29,7 @@ func addSketchEntity(s *app.Session, part *compdef.PartComponentDefinition, in w
 		return wire.AddSketchEntityResult{}, err
 	}
 	applyConstruction(ent, in.Construction)
+	applyCenterline(ent, in.Centerline)
 	out := wire.AddSketchEntityResult{
 		EntityID: uint64(ent.EntityID()), Kind: in.Kind, PointIDs: pointIDs,
 	}
@@ -572,5 +573,18 @@ func wantPoints(what string, pts []math.Point2, n int) error {
 func applyConstruction(e sketch.Entity, construction bool) {
 	if c, ok := e.(interface{ SetConstruction(bool) }); ok {
 		c.SetConstruction(construction)
+	}
+}
+
+// applyCenterline marks a line as the sketch's axis of revolution (Inventor's "revolve about the
+// sketch centerline"). Only line-like entities carry it; IsConstruction already treats a
+// centerline as construction, so no separate construction flag is needed. Lets a revolve with no
+// explicit axis spin about this line — see wire.AddSketchEntityArgs.Centerline (PartDesigner #54).
+func applyCenterline(e sketch.Entity, centerline bool) {
+	if !centerline {
+		return
+	}
+	if c, ok := e.(interface{ SetCenterline(bool) }); ok {
+		c.SetCenterline(centerline)
 	}
 }

--- a/addin/router/sketch_add_entity_coverage_test.go
+++ b/addin/router/sketch_add_entity_coverage_test.go
@@ -8,6 +8,7 @@ import (
 
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
 )
 
 // tryCall invokes a method and returns its error (for paths where a clean error on
@@ -78,5 +79,60 @@ func TestSketchAddEntityErrors(t *testing.T) {
 				t.Errorf("expected an error for %s", args)
 			}
 		})
+	}
+}
+
+// TestSketchAddCenterlineMarksAxisOfRevolution is the regression for the centerline flag
+// (PartDesigner #54): a line added with centerline:true becomes the sketch's single centerline,
+// so a revolve with no explicit axis resolves it. A plain construction line does NOT.
+func TestSketchAddCenterlineMarksAxisOfRevolution(t *testing.T) {
+	r, s := seededSession(t)
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	sk := def.Sketches().Item(0)
+	if n := len(sk.Centerlines()); n != 0 {
+		t.Fatalf("seeded sketch already has %d centerlines, want 0", n)
+	}
+	if err := tryCall(t, r, s, "sketch.addEntity",
+		`{"sketchIndex":0,"kind":"line","points":[[0,0],[0,5]],"centerline":true}`); err != nil {
+		t.Fatalf("add centerline: %v", err)
+	}
+	if n := len(sk.Centerlines()); n != 1 {
+		t.Fatalf("Centerlines() = %d, want 1 after centerline:true", n)
+	}
+	if err := tryCall(t, r, s, "sketch.addEntity",
+		`{"sketchIndex":0,"kind":"line","points":[[1,0],[1,5]],"construction":true}`); err != nil {
+		t.Fatalf("add construction line: %v", err)
+	}
+	if n := len(sk.Centerlines()); n != 1 {
+		t.Fatalf("Centerlines() = %d after a plain construction line, want still 1", n)
+	}
+}
+
+// TestRevolveAboutCenterlineOverWire is the e2e regression for the whole PartDesigner #54 axis
+// path: author an offset profile + a centerline through sketch.addEntity, then features.add a
+// revolve with aboutCenterline:true. It must spin about the sketch centerline (not the default Y
+// work axis) and yield the 24π-cm³ washer — proving the centerline flag and the revolve flag
+// resolve together, as a procedural add-in revolving a tilted roller about its own axis relies on.
+func TestRevolveAboutCenterlineOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.addEntity",
+		`{"sketchIndex":1,"kind":"polyline","points":[[2,0],[4,0],[4,2],[2,2]],"closed":true}`,
+		&wire.AddSketchEntityResult{})
+	call(t, r, s, "sketch.addEntity",
+		`{"sketchIndex":1,"kind":"line","points":[[0,0],[0,2]],"centerline":true}`,
+		&wire.AddSketchEntityResult{})
+	var res struct {
+		Name string `json:"name"`
+	}
+	call(t, r, s, "features.add",
+		`{"kind":"revolve","args":{"sketchIndex":1,"profileIndex":0,"aboutCenterline":true,"angle":"360 deg","operation":"new"}}`,
+		&res)
+
+	var mp wire.MassPropertiesResult
+	call(t, r, s, "body.physicalProperties", `{"bodyIndex":0}`, &mp)
+	const wantMm3 = 24 * 3.14159265 * 1000 // 24π cm³ washer → mm³ (outer R4, inner R2, height 2 cm)
+	if mp.VolumeMm3 < wantMm3*0.97 || mp.VolumeMm3 > wantMm3*1.03 {
+		t.Fatalf("centerline-revolved volume = %g mm³, want ≈%g (24π cm³); the revolve did not use the centerline", mp.VolumeMm3, wantMm3)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.128.0
+	oblikovati.org/api v0.129.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.128.0
+	oblikovati.org/api v0.129.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/kernel/brep/revolution.go
+++ b/kernel/brep/revolution.go
@@ -56,9 +56,13 @@ type RevolveVertex struct {
 }
 
 // SolidOfRevolutionMeridian is the general builder: it revolves a meridian whose edges may be lines
-// OR arcs 360° about the axis. The meridian must be wound counter-clockwise in (r,z) (positive area)
-// so each face's right-hand normal points out of the solid; arc edges are assumed convex (a fillet).
-// Returns (nil,nil) for fewer than 3 vertices.
+// OR arcs 360° about the axis. An arc edge whose centre is OFF the axis revolves to a geom.Torus
+// (a fillet); an arc whose centre is ON the axis and that runs from a rim circle to the pole (one
+// endpoint on the axis) revolves to a spherical CAP (a domed end). The meridian is auto-oriented to
+// counter-clockwise in (r,z) so each face's right-hand normal points out of the solid. Returns
+// (nil,nil) for fewer than 3 vertices OR when an arc revolves to a surface not yet built analytically
+// (a sphere ZONE with both endpoints off-axis, or a pole-to-pole meridian) — the caller then keeps the
+// faceted revolve.
 func SolidOfRevolutionMeridian(axisOrigin math.Point3, axisDir math.Vector3, verts []RevolveVertex, feat string) (*topo.Body, error) {
 	if len(verts) < 3 {
 		return nil, nil
@@ -70,6 +74,10 @@ func SolidOfRevolutionMeridian(axisOrigin math.Point3, axisDir math.Vector3, ver
 	refCircle, err := geom.NewCircle(axisOrigin, a.AsVector(), 1) // borrow geom's angle-0 frame
 	if err != nil {
 		return nil, err
+	}
+	verts = ccwMeridianVerts(verts) // right-hand face normals must point out of the solid
+	if !revolveArcsAnalytic(verts, revolveResolution(verts).Plane()) {
+		return nil, nil // an arc revolves to a surface we don't build analytically: fall back to faceted
 	}
 	return buildRevolution(axisOrigin, a, refCircle.RefDir, verts, feat), nil
 }
@@ -97,6 +105,55 @@ func signedArea2(p []math.Point2) float64 {
 	return sum / 2
 }
 
+// ccwMeridianVerts returns the meridian vertices wound counter-clockwise in (r,z) so a face's
+// right-hand normal points OUT of the solid. Arc info lives on an edge's END vertex, so reversing the
+// ring must re-key every ArcCenter: the reversed edge k is old edge (n−1−k) traversed backwards, and
+// its new end is that old edge's START vertex — the vertex ONE slot back around the original ring.
+func ccwMeridianVerts(verts []RevolveVertex) []RevolveVertex {
+	pts := make([]math.Point2, len(verts))
+	for i, v := range verts {
+		pts[i] = v.P
+	}
+	if signedArea2(pts) >= 0 {
+		return verts
+	}
+	n := len(verts)
+	out := make([]RevolveVertex, n)
+	for k := 0; k < n; k++ {
+		oldEdge := n - 1 - k
+		out[k] = RevolveVertex{P: verts[(oldEdge-1+n)%n].P, ArcCenter: verts[oldEdge].ArcCenter}
+	}
+	return out
+}
+
+// arcCenterOnAxis reports whether an arc centre (in (r,z)) sits on the axis of revolution — its radial
+// coordinate is below the meridian's own coincidence resolution. An on-axis centre revolves the arc to
+// a SPHERE (the arc traces a meridian of that sphere); an off-axis centre gives a torus.
+func arcCenterOnAxis(center math.Point2, axisTol float64) bool {
+	return stdmath.Abs(float64(center.X)) <= axisTol
+}
+
+// revolveArcsAnalytic reports whether every ARC edge of the meridian revolves to a surface this
+// builder emits analytically: a torus (centre off-axis) or a spherical CAP (centre on-axis with
+// EXACTLY one endpoint on the axis, i.e. the arc runs from a rim latitude to the pole). A sphere ZONE
+// (centre on-axis, both endpoints off-axis) needs a framed sphere parameterization we do not yet
+// build, and a pole-to-pole meridian is degenerate; both return false so the caller keeps the faceted
+// revolve (no regression — today every curved-meridian revolve facets).
+func revolveArcsAnalytic(verts []RevolveVertex, axisTol float64) bool {
+	n := len(verts)
+	for i := range verts {
+		if verts[i].ArcCenter == nil || !arcCenterOnAxis(*verts[i].ArcCenter, axisTol) {
+			continue // a straight edge or an off-axis (torus) arc — both handled
+		}
+		onPrev := float64(verts[(i-1+n)%n].P.X) <= axisTol
+		onCur := float64(verts[i].P.X) <= axisTol
+		if onPrev == onCur {
+			return false // zone (neither endpoint on-axis) or pole-to-pole (both): not analytic yet
+		}
+	}
+	return true
+}
+
 // revNode is one meridian vertex realized in 3D: the circle of revolution it traces (nil when the
 // vertex sits on the axis, r=0) and the seam/apex vertex at angle 0.
 type revNode struct {
@@ -108,7 +165,7 @@ type revNode struct {
 
 // buildRevolution assembles the body: one circle per off-axis vertex, then one face per meridian
 // edge (cylinder for axis-parallel, disk/annulus for axis-perpendicular, cone for oblique, torus for
-// an arc; on-axis line edges skipped).
+// an off-axis arc, spherical cap for an on-axis arc closing at the pole; on-axis line edges skipped).
 func buildRevolution(axisOrigin math.Point3, a, ref math.UnitVector3, verts []RevolveVertex, feat string) *topo.Body {
 	bld := topo.NewBuilder(true, revLin(feat, "body", 0))
 	res := revolveResolution(verts)
@@ -119,7 +176,11 @@ func buildRevolution(axisOrigin math.Point3, a, ref math.UnitVector3, verts []Re
 	for i := range verts {
 		j := (i + 1) % len(verts)
 		if verts[j].ArcCenter != nil {
-			addRevolutionTorus(bld, nodes[i], nodes[j], *verts[j].ArcCenter, axisOrigin, a, ref, feat, i)
+			if arcCenterOnAxis(*verts[j].ArcCenter, res.Plane()) {
+				addRevolutionSphereCap(bld, nodes[i], nodes[j], *verts[j].ArcCenter, axisOrigin, a, feat, i)
+			} else {
+				addRevolutionTorus(bld, nodes[i], nodes[j], *verts[j].ArcCenter, axisOrigin, a, ref, feat, i)
+			}
 			continue
 		}
 		addRevolutionFace(bld, nodes[i], nodes[j], a, ref, res.Weld(), feat, i)
@@ -277,6 +338,33 @@ func addRevolutionTorus(bld *topo.Builder, ni, nj revNode, arcCenter math.Point2
 		return
 	}
 	bld.AddReversedFace(torus, revLin(feat, "fillet", i), loop)
+}
+
+// addRevolutionSphereCap adds the analytic spherical-cap face for an ARC meridian edge whose centre
+// lies ON the axis: the arc runs from a rim latitude circle to the pole on the axis, so it revolves to
+// the polar zone of a sphere centred at the revolved arc centre (radius = the arc radius). Following
+// the cone-apex idiom (coneLoop) and the full disk (addRevolutionPlane), the face is bounded by the
+// SINGLE rim circle with the pole left IMPLICIT — the sphere's geometric tip, not a topology vertex —
+// so the trimmed-face tessellator routes it to sphereCapFan (true spherical bulge). A seamed pole loop
+// would carry the off-plane pole in its boundary and fall to the flat best-fit-plane CDT instead
+// (a flat lid, zero cap volume — the #1334 bug). One endpoint is the pole (circle==nil).
+func addRevolutionSphereCap(bld *topo.Builder, ni, nj revNode, arcCenter math.Point2, axisOrigin math.Point3, a math.UnitVector3, feat string, i int) {
+	center := axisOrigin.TranslateBy(a.AsVector().Scale(math.Scalar(arcCenter.Y)))
+	rim, use := ni, topo.Fwd(ni.circle)
+	if ni.circle == nil { // pole at i, rim at j — mirror coneLoop's apex-at-i collapse (Rev of the far circle)
+		rim, use = nj, topo.Rev(nj.circle)
+	}
+	radius := float64(center.VectorTo(rim.v.Point()).Length()) // sphere radius = |centre → rim|
+	sph, err := geom.NewSphere(center, radius)
+	if err != nil {
+		return
+	}
+	loop := topo.OuterLoop(use)
+	if axialGap(ni, nj, a) > 0 { // dz>0: convex cap faces outward (AddFace), like cylinder/cone/torus
+		bld.AddFace(sph, revLin(feat, "cap", i), loop)
+		return
+	}
+	bld.AddReversedFace(sph, revLin(feat, "cap", i), loop)
 }
 
 // arcMidpoint returns the 3D point at the middle of the meridian arc (centre (rc,zc) in (r,z),

--- a/kernel/brep/revolution_sphere_test.go
+++ b/kernel/brep/revolution_sphere_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// sphereFaces tallies the analytic geom.Sphere faces of a body.
+func sphereFaces(b *topo.Body) int {
+	n := 0
+	for _, f := range b.Faces() {
+		if _, ok := f.Geometry().(geom.Sphere); ok {
+			n++
+		}
+	}
+	return n
+}
+
+// hemisphereCappedMeridian is the (r,z) meridian of a cylinder (radius r, height h) closed at the top
+// by a hemispherical cap: a bottom disk, a cylinder wall, then a 90° arc from the rim (r,h) to the pole
+// (0, h+r) about the on-axis centre (0,h). Revolved, that arc is a spherical cap — the canonical on-apex
+// domed end (a tapered roller's big end).
+func hemisphereCappedMeridian(r, h float64) []brep.RevolveVertex {
+	c := math.P2(0, h)
+	return []brep.RevolveVertex{
+		{P: math.P2(0, 0)},
+		{P: math.P2(r, 0)},
+		{P: math.P2(r, h)},
+		{P: math.P2(0, h+r), ArcCenter: &c}, // the arc edge (r,h)→(0,h+r) about the on-axis centre (0,h)
+	}
+}
+
+// TestSolidOfRevolutionSphereCap is the #129 curved-meridian follow-up (sphere case, the tapered-roller
+// domed end): an on-axis arc closing at the pole revolves to ONE analytic geom.Sphere cap face — not the
+// hundreds of cone slivers the faceted swept solid leaves — so the mesh carries true curvature and the
+// per-frame hover-pick stays cheap. The body is a cylinder (r=2,h=5) topped by a hemisphere.
+func TestSolidOfRevolutionSphereCap(t *testing.T) {
+	r, h := 2.0, 5.0
+	body, err := brep.SolidOfRevolutionMeridian(math.P3(0, 0, 0), math.V3(0, 0, 1), hemisphereCappedMeridian(r, h), "capped")
+	if err != nil || body == nil {
+		t.Fatalf("SolidOfRevolutionMeridian(hemisphere-capped cylinder) = (%v, %v), want a body", body, err)
+	}
+	if res := ops.Validate(body); !res.Valid || !body.IsSolid() {
+		t.Fatalf("hemisphere-capped cylinder is not a valid solid: %+v", res.Issues)
+	}
+	if got := sphereFaces(body); got != 1 {
+		t.Fatalf("hemisphere-capped cylinder has %d sphere faces, want exactly 1 (got %d total faces)", got, len(body.Faces()))
+	}
+	if got := len(body.Faces()); got != 3 {
+		t.Fatalf("hemisphere-capped cylinder has %d faces, want 3 (bottom disk + wall + cap)", got)
+	}
+	want := stdmath.Pi*r*r*h + 2.0/3.0*stdmath.Pi*r*r*r // cylinder + hemisphere
+	if got := vol(body); relErrF(got, want) > 0.02 {
+		t.Errorf("hemisphere-capped cylinder volume = %g, want ≈%g (πr²h + ⅔πr³)", got, want)
+	}
+}
+
+// TestSolidOfRevolutionSphereCapAutoOrients feeds the SAME meridian wound CLOCKWISE (negative area): the
+// builder must re-wind it to CCW AND re-key the arc centre onto the reversed edge's new end vertex
+// (ccwMeridianVerts), so a caller need not know the projected winding. The result is the identical valid
+// hemisphere-capped solid.
+func TestSolidOfRevolutionSphereCapAutoOrients(t *testing.T) {
+	r, h := 2.0, 5.0
+	c := math.P2(0, h)
+	// Clockwise traversal: (0,0) → pole (0,h+r) → rim (r,h) → (r,0). The arc edge is (0,h+r)→(r,h)
+	// about (0,h), so its centre rides the rim vertex (r,h) — the END of that CW edge.
+	cw := []brep.RevolveVertex{
+		{P: math.P2(0, 0)},
+		{P: math.P2(0, h+r)},
+		{P: math.P2(r, h), ArcCenter: &c},
+		{P: math.P2(r, 0)},
+	}
+	body, err := brep.SolidOfRevolutionMeridian(math.P3(0, 0, 0), math.V3(0, 0, 1), cw, "capped-cw")
+	if err != nil || body == nil {
+		t.Fatalf("SolidOfRevolutionMeridian(CW hemisphere) = (%v, %v), want a body", body, err)
+	}
+	if res := ops.Validate(body); !res.Valid || !body.IsSolid() {
+		t.Fatalf("CW hemisphere-capped cylinder is not a valid solid: %+v", res.Issues)
+	}
+	if got := sphereFaces(body); got != 1 {
+		t.Fatalf("CW hemisphere cap has %d sphere faces, want 1", got)
+	}
+	want := stdmath.Pi*r*r*h + 2.0/3.0*stdmath.Pi*r*r*r
+	if got := vol(body); relErrF(got, want) > 0.02 {
+		t.Errorf("CW hemisphere-capped volume = %g, want ≈%g", got, want)
+	}
+}
+
+// TestSolidOfRevolutionSphereZoneFallsBack pins the analytic boundary: an on-axis arc whose BOTH
+// endpoints are off the axis revolves to a sphere ZONE (a barrel), which needs a framed sphere
+// parameterization not yet built, so the builder returns (nil,nil) — the signal for the caller to keep
+// the faceted revolve. r0=2, H=4, centre (0,2) radius √8.
+func TestSolidOfRevolutionSphereZoneFallsBack(t *testing.T) {
+	c := math.P2(0, 2) // on the axis, but both arc endpoints are at r=2 (off-axis) → a zone, not a cap
+	zone := []brep.RevolveVertex{
+		{P: math.P2(0, 0)},
+		{P: math.P2(2, 0)},
+		{P: math.P2(2, 4), ArcCenter: &c},
+		{P: math.P2(0, 4)},
+	}
+	body, err := brep.SolidOfRevolutionMeridian(math.P3(0, 0, 0), math.V3(0, 0, 1), zone, "zone")
+	if err != nil {
+		t.Fatalf("SolidOfRevolutionMeridian(zone) error = %v, want nil (a clean fallback signal)", err)
+	}
+	if body != nil {
+		t.Fatalf("SolidOfRevolutionMeridian(sphere zone) built %d faces, want nil (fall back to faceted)", len(body.Faces()))
+	}
+}
+
+// relErrF is the relative error between got and want (want ≠ 0).
+func relErrF(got, want float64) float64 { return stdmath.Abs(got-want) / stdmath.Abs(want) }

--- a/model/feature/revolve_analytic_test.go
+++ b/model/feature/revolve_analytic_test.go
@@ -53,10 +53,12 @@ func TestAnalyticRevolveHasCylinderWalls(t *testing.T) {
 	}
 }
 
-// TestArcProfileRevolveStaysFaceted pins the analytic boundary: a profile with a CURVED edge (a
-// half-disc → sphere) is NOT made analytic — its sampled chords would shatter into tiny cone facets,
-// worse than the faceted swept solid — so it revolves to a valid faceted sphere with no analytic
-// cylinder/cone faces (the isStraightLoop guard; curved meridian edges remain a follow-up).
+// TestArcProfileRevolveStaysFaceted pins the analytic boundary at a FULL sphere: a half-disc whose arc
+// runs pole-to-pole (both endpoints on the axis, its centre on the axis) is a two-edge meridian, which
+// SolidOfRevolutionMeridian declines (a pole-to-pole meridian is not built as a boundary-less sphere
+// here — SolidSphere is that route), so it revolves to a valid faceted sphere with no analytic
+// cylinder/cone faces. A PARTIAL dome (an arc from a rim to a single pole) IS analytic — see
+// TestDomedRevolveMakesAnalyticSphereCap.
 func TestArcProfileRevolveStaysFaceted(t *testing.T) {
 	s := sketch.NewSketches().Add(sketch.XYPlane())
 	top := s.Points().Add(math.P2(0, 2))
@@ -134,6 +136,52 @@ func torusFaceCount(b *topo.Body) int {
 		}
 	}
 	return n
+}
+
+// sphereFaceCount tallies geom.Sphere faces.
+func sphereFaceCount(b *topo.Body) int {
+	n := 0
+	for _, f := range b.Faces() {
+		if _, ok := f.Geometry().(geom.Sphere); ok {
+			n++
+		}
+	}
+	return n
+}
+
+// TestDomedRevolveMakesAnalyticSphereCap proves the #129 curved-meridian follow-up (sphere-cap case)
+// end-to-end through the revolve FEATURE: a meridian of a cylinder (r=2, h=5) topped by a 90° dome arc
+// from the rim to the on-axis pole revolves to ONE analytic geom.Sphere cap face — not the 48-facets-
+// per-arc swept solid that shattered the tapered roller into ~1700 sliver faces and starved the
+// frame-loop hover-pick. This is the fix behind the tapered-roller domed big end (#54).
+func TestDomedRevolveMakesAnalyticSphereCap(t *testing.T) {
+	r, h := 2.0, 5.0
+	s := sketch.NewSketches().Add(sketch.XYPlane())
+	s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(r, 0))                            // bottom disk
+	s.Lines().AddByTwoPoints(math.P2(r, 0), math.P2(r, h))                            // cylinder wall
+	s.Arcs().AddByCenterStartEnd(math.P2(0, h), math.P2(r, h), math.P2(0, h+r), true) // dome to the pole
+	s.Lines().AddByTwoPoints(math.P2(0, h+r), math.P2(0, 0))                          // close along the axis
+	cl := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(0, h+r))
+	cl.SetCenterline(true)
+	cl.SetConstruction(true)
+
+	fs := NewPartFeatures(nil)
+	NewRevolveFeatures(fs).AddAboutCenterline(s, 0, nil, ops.NewBody)
+	fs.Recompute()
+	body := fs.Result()[0]
+	if res := ops.Validate(body); !res.Valid || !body.IsSolid() {
+		t.Fatalf("domed revolve is not a valid solid: %+v", res.Issues)
+	}
+	if got := sphereFaceCount(body); got != 1 {
+		t.Fatalf("domed revolve has %d sphere faces, want exactly 1 analytic cap (%d total faces)", got, len(body.Faces()))
+	}
+	if got := len(body.Faces()); got != 3 {
+		t.Fatalf("domed revolve has %d faces, want 3 (bottom disk + cylinder wall + sphere cap)", got)
+	}
+	want := stdmath.Pi*r*r*h + 2.0/3.0*stdmath.Pi*r*r*r // cylinder + hemisphere
+	if got := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; relErr(got, want) > 0.02 {
+		t.Errorf("domed revolve volume = %g, want ≈%g (πr²h + ⅔πr³)", got, want)
+	}
 }
 
 // TestCircleRevolveMakesAnalyticTorus proves the #129 curved-meridian follow-up (torus case): a single

--- a/model/feature/sketched_features.go
+++ b/model/feature/sketched_features.go
@@ -110,23 +110,21 @@ func buildRevolveSheet(prof *sketch.Profile, plane sketch.Plane, axis *WorkAxis,
 }
 
 // buildRevolveSolid revolves a profile (already projected onto plane) about axis over the
-// swept angle starting at start. Behind OBK_ANALYTIC_CURVES a full 360° revolve of a
-// rectilinear profile becomes a TRUE analytic solid (cylinder walls + disk/annulus caps) so
-// thread/chamfer/fillet attach to its revolved cylindrical faces (#129); every other case
-// (partial angle, an oblique/curved profile edge, or the gate off) keeps the faceted swept
-// solid. Booleans re-facet an analytic revolve body on demand (combine → planarized).
+// swept angle starting at start. A full 360° revolve becomes a TRUE analytic solid whenever every
+// profile edge revolves to an exact surface — straight edges → cylinder/cone/plane faces, an off-axis
+// arc → a torus, and an on-axis arc closing at the pole → a spherical cap (the domed end of a tapered
+// roller, #129) — so thread/chamfer/fillet attach to its revolved faces and the mesh carries true
+// curvature (not the 48-facet-per-arc swept solid that starves the frame-loop pick). Every other case
+// (partial angle, a spline edge, a sphere zone we do not build analytically) keeps the faceted swept
+// solid; SolidOfRevolutionMeridian returns nil to signal that fallback. Booleans re-facet an analytic
+// revolve body on demand (combine → planarized).
 func buildRevolveSolid(prof *sketch.Profile, plane sketch.Plane, axis *WorkAxis, angle, start float64, feat string) (*topo.Body, error) {
-	// Analytic only for a full revolve of a STRAIGHT-edged profile: those edges revolve to exact
-	// cylinder/cone/plane faces. A profile with an arc/spline (e.g. a sphere) would have its sampled
-	// chords turn into many tiny cone facets — worse than the faceted swept solid — so it stays
-	// faceted until curved meridian edges (torus, #129 follow-up) are supported.
 	if fullRevolution(angle) {
 		if body, ok := circleProfileTorus(prof, plane, axis, feat); ok {
 			return body, nil // a circle clear of the axis revolves to an analytic torus (#129 follow-up)
 		}
-		if isStraightLoop(prof.OuterLoop()) {
-			mer := meridianFromProfile(prof, plane, axis)
-			if body, err := brep.SolidOfRevolution(axis.Origin(), axis.Direction().AsVector(), mer, feat); err == nil && body != nil {
+		if verts, ok := meridianVertsFromProfile(prof, plane, axis); ok {
+			if body, err := brep.SolidOfRevolutionMeridian(axis.Origin(), axis.Direction().AsVector(), verts, feat); err == nil && body != nil {
 				return body, nil
 			}
 		}
@@ -183,34 +181,62 @@ func revolveSpan(def *RevolveDefinition) (total, start float64) {
 	return a1 + a2, -a2
 }
 
-// isStraightLoop reports whether every entity of a profile loop is a straight line segment (so its
-// revolution is an exact cylinder/cone/plane), as opposed to an arc/spline/circle.
-func isStraightLoop(l sketch.Loop) bool {
-	for _, pe := range l.Entities() {
-		if _, ok := pe.Entity.(*sketch.Line); !ok {
-			return false
-		}
-	}
-	return len(l.Entities()) > 0
-}
-
 // fullRevolution reports whether an angle is a complete turn (0 ⇒ full, like revolveSections).
 func fullRevolution(angle float64) bool { return angle <= 0 || angle >= 2*stdmath.Pi-1e-9 }
 
-// meridianFromProfile projects the profile's outer loop into the axis's (radius, height) half-plane
-// — radius = perpendicular distance from the axis, height = signed distance along it — the
-// cross-section brep.SolidOfRevolution revolves.
-func meridianFromProfile(prof *sketch.Profile, plane sketch.Plane, axis *WorkAxis) []math.Point2 {
+// meridianVertsFromProfile walks the profile's outer loop into brep.RevolveVertex meridian vertices
+// in the axis's (radius, height) half-plane — radius = perpendicular distance from the axis, height =
+// signed distance along it — one vertex per edge END, carrying the arc CENTRE when that edge is a
+// circular arc (so it revolves to a torus/sphere face, not chorded cone facets). ok is false when the
+// loop holds an entity that is neither a line nor an arc (a spline): the caller keeps the faceted
+// revolve. brep.SolidOfRevolutionMeridian orients the meridian and rejects arcs it cannot build
+// analytically (returning nil), so a mixed profile still falls back cleanly.
+func meridianVertsFromProfile(prof *sketch.Profile, plane sketch.Plane, axis *WorkAxis) ([]brep.RevolveVertex, bool) {
 	o, a := axis.Origin(), axis.Direction().AsVector()
-	poly := modelPolygon(prof, plane)
-	out := make([]math.Point2, len(poly))
-	for i, p := range poly {
-		v := o.VectorTo(p)
+	toRZ := func(p2 math.Point2) math.Point2 {
+		v := o.VectorTo(plane.ToModel(p2))
 		z := v.Dot(a)
-		radial := v.Sub(a.Scale(z))
-		out[i] = math.P2(radial.Length(), z)
+		return math.P2(v.Sub(a.Scale(z)).Length(), z)
 	}
-	return out
+	ents := prof.OuterLoop().Entities()
+	verts := make([]brep.RevolveVertex, 0, len(ents))
+	for _, pe := range ents {
+		end, center, ok := entityEndAndArcCenter(pe)
+		if !ok {
+			return nil, false
+		}
+		rv := brep.RevolveVertex{P: toRZ(end)}
+		if center != nil {
+			c := toRZ(*center)
+			rv.ArcCenter = &c
+		}
+		verts = append(verts, rv)
+	}
+	if len(verts) < 3 {
+		return nil, false
+	}
+	return verts, true
+}
+
+// entityEndAndArcCenter returns a loop entity's traversal END point (sketch 2-D) and, for an arc, its
+// centre; ok is false for anything but a line or arc (a spline keeps the profile on the faceted path).
+func entityEndAndArcCenter(pe sketch.ProfileEntity) (end math.Point2, center *math.Point2, ok bool) {
+	switch e := pe.Entity.(type) {
+	case *sketch.Line:
+		end = e.EndPoint().Position()
+		if pe.Reversed() {
+			end = e.StartPoint().Position()
+		}
+		return end, nil, true
+	case *sketch.Arc:
+		end = e.End.Position()
+		if pe.Reversed() {
+			end = e.Start.Position()
+		}
+		c := e.Center.Position()
+		return end, &c, true
+	}
+	return math.Point2{}, nil, false
 }
 
 // revolveAxis resolves the axis of revolution: an explicit work axis if set, otherwise the


### PR DESCRIPTION
Two related changes that give the PartDesigner tapered-roller **domed big end** (#54, Method C) a correct, smooth, and cheap implementation. The API half shipped in oblikovati.org/api **v0.129.0**.

## 1. Kernel: analytic spherical-cap surface of revolution
A full revolve of a profile with an **arc edge whose centre lies on the axis** and that closes at the pole now builds a true `geom.Sphere` cap face instead of the faceted swept solid.

- Grounded in OCCT's canonical recogniser (`GeomConvert_SurfToAnaSurf::TryTorusSphere`): a revolved arc is a sphere exactly when its iso-circle centres collapse onto the axis, else a torus. We know the centre analytically, so we test it directly (SolveSpace collapses sweep control points at the pole; SHAPER delegates to OCCT).
- The cap is bounded by the single rim circle with the pole left **implicit** (like the cone apex / full disk), so the trimmed-face tessellator routes it to `sphereCapFan` and it carries true spherical curvature — a seamed pole loop would fall to the flat best-fit-plane CDT (zero cap volume, the #1334 bug).
- `SolidOfRevolutionMeridian` now auto-orients the meridian to CCW (re-keying arc centres across the reversal) and falls back to faceted (returns nil) for arcs not yet analytic (a sphere zone, a pole-to-pole meridian). The revolve feature walks profile loop entities into arc-aware meridian vertices; splines still facet.

**Why:** each tapered roller is revolved about its own tilted axis; the dome arc forced the faceted path, so one roller became ~1700 sliver faces and 16 of them **starved the per-frame hover-pick render loop — the camera froze on placement**. The analytic cap drops the roller to **3 faces** and the pick cost **~9× (1.45 ms → 0.16 ms)**.

## 2. Router: revolve about the sketch centerline
Host side of the api v0.129.0 centerline flag: mark a sketch line as the axis of revolution and revolve a profile about it, with no external work axis (`aboutCenterline`). e2e coverage over the wire.

## Verification
- kernel/brep, kernel/ops, model/feature, addin/router, addin/opregistry green; build/vet/lint/SPDX clean; 4 new kernel regression tests (sphere-cap, CW auto-orient, zone-fallback, feature-level dome).
- **Live** (30206 bearing via the PartDesigner add-in): volume matches analytic to **0.035%**, 16 smooth domed rollers render with no faceting, camera reorientation ~250 ms with no freeze.

Refs #54, #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)