### PR TITLE
feat(sketch): honor AddWithOrientation — deterministic in-plane frame on create (#1920)

### DIFF
--- a/addin/router/sketch.go
+++ b/addin/router/sketch.go
@@ -39,16 +39,25 @@ type sketchHost interface {
 	Parameters() *param.Parameters
 	Units() param.UnitsOfMeasure
 	WorkPlanes() *feature.WorkPlanes
+	WorkGeometry() *feature.WorkGeometry // resolve orientation-axis refs (#1920)
 }
 
 // createSketch adds a sketch on an origin or work plane of the active sketch host (part
 // or assembly) and returns its index (for sketch.rectangle / features.add).
 func createSketch(_ *app.Session, host sketchHost, in wire.CreateSketchArgs) (wire.CreateSketchResult, error) {
-	plane, name, wp, err := sketchCreatePlane(host, in)
+	base, name, wp, err := sketchCreatePlane(host, in)
 	if err != nil {
 		return wire.CreateSketchResult{}, err
 	}
-	sk := host.Sketches().Add(plane)
+	// Validate the orientation up-front so a bad axis fails the create call, not a later
+	// recompute; then track the (re-)oriented plane so the frame survives plane motion.
+	if in.Orientation != nil {
+		if _, err := orientSketchPlane(host, base, in.Orientation); err != nil {
+			return wire.CreateSketchResult{}, err
+		}
+	}
+	planeOf := sketchPlaneFn(host, base, wp, in.Orientation)
+	sk := host.Sketches().Add(planeOf())
 	// Share the host's parameter DAG so dimension expressions can reference user
 	// parameters (e.g. "od/2") and the dimension's own d0,d1… parameters live in
 	// the host's table — the way Inventor sketch dimensions work. Without this the
@@ -59,10 +68,88 @@ func createSketch(_ *app.Session, host sketchHost, in wire.CreateSketchArgs) (wi
 	// plane's offset parameter into the sketch's footprint so an offset edit targets this
 	// sketch's features instead of forcing a wholesale rebuild (ADR-0044).
 	if wp != nil {
-		sk.SetPlaneHost(func() sketch.Plane { return wp.Plane() })
+		sk.SetPlaneHost(planeOf)
 		sk.SetHostFootprint(func() []depend.Key { return wp.ParameterFootprint() })
 	}
 	return wire.CreateSketchResult{SketchIndex: host.Sketches().Count() - 1, Plane: name}, nil
+}
+
+// sketchPlaneFn returns the source of a sketch's host plane on each recompute: the base
+// plane (or the live work plane when wp is set), reframed by an optional orientation. The
+// orientation is re-applied every recompute so the pinned frame follows the plane if it
+// moves; if the reframe later degenerates it falls back to the base frame (it was validated
+// at create time). See [orientSketchPlane] and #1920.
+func sketchPlaneFn(host sketchHost, base sketch.Plane, wp *feature.WorkPlane, o *wire.SketchOrientation) func() sketch.Plane {
+	basePlane := func() sketch.Plane {
+		if wp != nil {
+			return wp.Plane()
+		}
+		return base
+	}
+	if o == nil {
+		return basePlane
+	}
+	return func() sketch.Plane {
+		p, err := orientSketchPlane(host, basePlane(), o)
+		if err != nil {
+			return basePlane()
+		}
+		return p
+	}
+}
+
+// orientSketchPlane reframes a sketch plane so a reference axis (projected into the plane)
+// becomes its X or Y axis — Inventor's PlanarSketches.AddWithOrientation. The plane's origin
+// and normal are preserved (so the sketch faces the same way and normal = X×Y still holds);
+// only the in-plane rotation and, optionally, the origin change. Errors if the axis is
+// perpendicular to the plane (its in-plane projection is degenerate). See #1920.
+func orientSketchPlane(host sketchHost, base sketch.Plane, o *wire.SketchOrientation) (sketch.Plane, error) {
+	dir, err := orientationAxisDir(host, o.Axis)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	normal := base.Normal().AsVector()
+	chosen, err := math.UnitVector3FromVector(dir.Sub(normal.Scale(dir.Dot(normal))))
+	if err != nil {
+		return sketch.Plane{}, fmt.Errorf("sketch.create: orientation axis %q is perpendicular to the plane "+
+			"(normal %v); its in-plane projection is degenerate", o.Axis, normal)
+	}
+	if o.Reverse {
+		chosen, _ = math.UnitVector3FromVector(chosen.AsVector().Scale(-1))
+	}
+	origin := base.Origin()
+	if len(o.Origin) == 3 {
+		origin = math.P3(o.Origin[0], o.Origin[1], o.Origin[2])
+	}
+	x, y, err := orientedAxes(chosen, base.Normal(), o.AxisIsX)
+	if err != nil {
+		return sketch.Plane{}, err
+	}
+	return sketch.NewPlane(origin, x, y)
+}
+
+// orientedAxes completes an orthonormal in-plane frame from the chosen axis and the plane
+// normal: the chosen axis is X (then Y = normal×X) or Y (then X = Y×normal), each choice
+// giving normal = X×Y so the plane's facing is preserved.
+func orientedAxes(chosen, normal math.UnitVector3, axisIsX bool) (x, y math.UnitVector3, err error) {
+	if axisIsX {
+		x = chosen
+		y, err = math.UnitVector3FromVector(normal.Cross(x))
+		return x, y, err
+	}
+	y = chosen
+	x, err = math.UnitVector3FromVector(y.Cross(normal).Scale(-1)) // X = Y × normal
+	return x, y, err
+}
+
+// orientationAxisDir resolves an orientation-axis reference (an origin-axis constant, a work
+// axis, or a linear edge) to its unit direction in model space.
+func orientationAxisDir(host sketchHost, ref string) (math.Vector3, error) {
+	wa, ok := host.WorkGeometry().AxisByRef(feature.ParseWorkRef(ref))
+	if !ok {
+		return math.Vector3{}, fmt.Errorf("sketch.create: orientation axis %q not found", ref)
+	}
+	return wa.Direction().AsVector(), nil
 }
 
 // sketchCreatePlane resolves the plane a new sketch starts on: a user work plane (when

--- a/addin/router/sketch_orientation_test.go
+++ b/addin/router/sketch_orientation_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+)
+
+// sketchPlaneAt returns the host coordinate frame of the sketch at index i on the active part.
+func sketchPlaneAt(t *testing.T, s *app.Session, i int) (x, y, n math.UnitVector3) {
+	t.Helper()
+	part := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	pl := part.Sketches().Item(i).Plane()
+	return pl.XAxis(), pl.YAxis(), pl.Normal()
+}
+
+// TestSketchOrientationPinsFrameToAxis is the #1920 core: a sketch created on a plane built
+// through the Z axis at 30° to XZ, oriented with its Y pinned to +Z, must come out with
+// YAxis = +Z (axial) and XAxis radial (in-plane, perpendicular to Z) — so an add-in's ordinary
+// (radius, axial) meridian drops onto that tilted plane unchanged. Without orientation the
+// host-chosen frame is arbitrary (here X = −Z), which is what the feature fixes.
+func TestSketchOrientationPinsFrameToAxis(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var wp wire.CreateWorkPlaneResult
+	call(t, r, s, "workPlanes.create",
+		`{"kind":"line-plane-angle","refs":["origin/axis/z","origin/plane/xz"],"angle":"30 deg"}`, &wp)
+	if !wp.Healthy {
+		t.Fatalf("angled plane not healthy: %+v", wp)
+	}
+	var sk wire.CreateSketchResult
+	call(t, r, s, "sketch.create",
+		`{"workPlaneIndex":3,"orientation":{"axis":"origin/axis/z","axisIsX":false}}`, &sk)
+
+	x, y, n := sketchPlaneAt(t, s, sk.SketchIndex)
+	tol := math.Scalar(1e-9)
+	if !y.IsEqualTo(math.V3(0, 0, 1).AsUnit(), tol) {
+		t.Errorf("oriented sketch YAxis = %v, want +Z (axial)", y)
+	}
+	if zc := x.AsVector().Dot(math.V3(0, 0, 1)); stdmath.Abs(zc) > tol {
+		t.Errorf("oriented sketch XAxis = %v has Z component %g, want radial (⟂ Z)", x, zc)
+	}
+	// The plane's facing (normal) must be preserved: still horizontal (no Z), rotated 30° about Z.
+	if nz := n.AsVector().Dot(math.V3(0, 0, 1)); stdmath.Abs(nz) > tol {
+		t.Errorf("oriented sketch normal = %v gained a Z component %g, want the plane facing preserved", n, nz)
+	}
+}
+
+// TestSketchOrientationReverseFlipsAxis checks Reverse:true pins Y to −Z instead of +Z
+// (Inventor NaturalAxisDirection=false).
+func TestSketchOrientationReverseFlipsAxis(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var wp wire.CreateWorkPlaneResult
+	call(t, r, s, "workPlanes.create",
+		`{"kind":"line-plane-angle","refs":["origin/axis/z","origin/plane/xz"],"angle":"30 deg"}`, &wp)
+	var sk wire.CreateSketchResult
+	call(t, r, s, "sketch.create",
+		`{"workPlaneIndex":3,"orientation":{"axis":"origin/axis/z","axisIsX":false,"reverse":true}}`, &sk)
+	_, y, _ := sketchPlaneAt(t, s, sk.SketchIndex)
+	if !y.IsEqualTo(math.V3(0, 0, -1).AsUnit(), math.Scalar(1e-9)) {
+		t.Errorf("reversed sketch YAxis = %v, want -Z", y)
+	}
+}
+
+// TestSketchOrientationAxisIsXPinsX pins the projected axis as X instead of Y.
+func TestSketchOrientationAxisIsXPinsX(t *testing.T) {
+	r, s := emptyPartSession(t)
+	var wp wire.CreateWorkPlaneResult
+	call(t, r, s, "workPlanes.create",
+		`{"kind":"line-plane-angle","refs":["origin/axis/z","origin/plane/xz"],"angle":"30 deg"}`, &wp)
+	var sk wire.CreateSketchResult
+	call(t, r, s, "sketch.create",
+		`{"workPlaneIndex":3,"orientation":{"axis":"origin/axis/z","axisIsX":true}}`, &sk)
+	x, _, _ := sketchPlaneAt(t, s, sk.SketchIndex)
+	if !x.IsEqualTo(math.V3(0, 0, 1).AsUnit(), math.Scalar(1e-9)) {
+		t.Errorf("axisIsX sketch XAxis = %v, want +Z", x)
+	}
+}
+
+// TestSketchOrientationPerpendicularAxisErrors rejects an axis perpendicular to the plane:
+// the Z axis is normal to the XY plane, so its in-plane projection is degenerate and the
+// create must fail with a clear message rather than silently pick a frame.
+func TestSketchOrientationPerpendicularAxisErrors(t *testing.T) {
+	r, s := emptyPartSession(t)
+	_, err := r.Handle(s, "sketch.create",
+		[]byte(`{"plane":"XY","orientation":{"axis":"origin/axis/z","axisIsX":true}}`))
+	if err == nil {
+		t.Fatal("sketch.create with an axis perpendicular to the plane should error, got nil")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.129.0
+	oblikovati.org/api v0.130.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.129.0
+	oblikovati.org/api v0.130.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/feature/sketched_features.go
+++ b/model/feature/sketched_features.go
@@ -220,23 +220,38 @@ func meridianVertsFromProfile(prof *sketch.Profile, plane sketch.Plane, axis *Wo
 
 // entityEndAndArcCenter returns a loop entity's traversal END point (sketch 2-D) and, for an arc, its
 // centre; ok is false for anything but a line or arc (a spline keeps the profile on the faceted path).
+// It reads the entity through the ShapedEntity capability (Kind + ShapePoints) rather than switching
+// on concrete types, per the sketch-entity type-switch ban (#1624, audit I1): ShapePoints yields
+// [start, end] for a line and [centre, start, end] for an arc.
 func entityEndAndArcCenter(pe sketch.ProfileEntity) (end math.Point2, center *math.Point2, ok bool) {
-	switch e := pe.Entity.(type) {
-	case *sketch.Line:
-		end = e.EndPoint().Position()
-		if pe.Reversed() {
-			end = e.StartPoint().Position()
+	shaped, isShaped := pe.Entity.(sketch.ShapedEntity)
+	if !isShaped {
+		return math.Point2{}, nil, false
+	}
+	pts := shaped.ShapePoints()
+	switch shaped.Kind() {
+	case sketch.LineKind:
+		if len(pts) < 2 {
+			return math.Point2{}, nil, false
 		}
-		return end, nil, true
-	case *sketch.Arc:
-		end = e.End.Position()
-		if pe.Reversed() {
-			end = e.Start.Position()
+		return orientedEnd(pts[0], pts[1], pe.Reversed()), nil, true
+	case sketch.ArcKind:
+		if len(pts) < 3 {
+			return math.Point2{}, nil, false
 		}
-		c := e.Center.Position()
-		return end, &c, true
+		c := pts[0]
+		return orientedEnd(pts[1], pts[2], pe.Reversed()), &c, true
 	}
 	return math.Point2{}, nil, false
+}
+
+// orientedEnd returns the traversal END of an edge whose forward direction runs start→end, flipped
+// to start when the edge is reversed within the loop.
+func orientedEnd(start, end math.Point2, reversed bool) math.Point2 {
+	if reversed {
+		return start
+	}
+	return end
 }
 
 // revolveAxis resolves the axis of revolution: an explicit work axis if set, otherwise the


### PR DESCRIPTION
Closes #1920

## What
Resolve the new `wire.SketchOrientation` (api v0.130.0) in `createSketch`: project the reference axis into the sketch plane and pin it as the sketch X or Y axis (the other = normal × it), preserving the plane origin and facing. The reframe re-applies every recompute so a work-plane-hosted sketch keeps its pinned frame when the plane moves; a degenerate axis (⟂ the plane) fails the create with a clear message.

## Why
A sketch on a **non-origin plane** (e.g. `line-plane-angle`, a plane through an axis at an angle) otherwise gets a **host-chosen** in-plane frame (`perpendicularTo`), so an add-in linking only the public API cannot know which sketch direction is radial/axial and cannot place DOF-0 parametric geometry there. This is Inventor's `PlanarSketches.AddWithOrientation`. First consumer: the PartDesigner tapered-roller **cage** bars.

## Tests
`addin/router/sketch_orientation_test.go`: on a plane through Z at 30°, pinning Y to +Z yields YAxis=+Z, XAxis radial (⟂Z), normal preserved; `reverse` flips to −Z; `axisIsX` pins X; a perpendicular axis errors. Full `addin/...`, `model/sketch`, `model/feature` suites green; golangci-lint 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)