### PR TITLE
feat(work-features): occurrence-qualified datum references (#1857)

### DIFF
--- a/addin/router/work_axes.go
+++ b/addin/router/work_axes.go
@@ -21,6 +21,9 @@ import (
 // with their current geometry and health. Construction axes are hidden unless the request opts
 // in with IncludeConstruction (#1849).
 func listWorkAxes(_ *app.Session, host workHost, in wire.ListWorkAxesArgs) (wire.ListWorkAxesResult, error) {
+	if len(in.Occurrence) > 0 {
+		return listWorkAxesInOccurrence(host, in.Occurrence, in.IncludeConstruction)
+	}
 	axes := projectListedDatums(host.WorkAxes(), in.IncludeConstruction, workAxisInfo)
 	return wire.ListWorkAxesResult{Axes: axes}, nil
 }
@@ -46,6 +49,9 @@ func workAxisInfo(index int, wa *feature.WorkAxis) wire.WorkAxisInfo {
 // points) with their position, kind, origin flag, visibility, and health (#1842). Construction
 // points are hidden unless the request opts in with IncludeConstruction (#1849).
 func listWorkPoints(_ *app.Session, host workHost, in wire.ListWorkPointsArgs) (wire.ListWorkPointsResult, error) {
+	if len(in.Occurrence) > 0 {
+		return listWorkPointsInOccurrence(host, in.Occurrence, in.IncludeConstruction)
+	}
 	points := projectListedDatums(host.WorkPoints(), in.IncludeConstruction, workPointInfo)
 	return wire.ListWorkPointsResult{Points: points}, nil
 }

--- a/addin/router/work_occurrence_list.go
+++ b/addin/router/work_occurrence_list.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+)
+
+// Occurrence-qualified datum listing (#1857): when a workPlanes/Axes/Points.list request carries an
+// Occurrence path, it lists that sub-component's datums instead of the active host's own — each
+// returned as an occurrence-qualified ref ("occ/<path>/plane|axis|point/N") with its geometry
+// transformed into the assembly's space. The returned rows are read-only proxies (no editable
+// scalars/slots): a proxy is a projection of the native datum, redefined only in its own component.
+
+// occurrenceContext resolves the active assembly host + occurrence path to the composed transform
+// and the target component's work geometry, erroring when the host is not an assembly or the path
+// names no part.
+func occurrenceContext(host workHost, path []string, method string) (math.Matrix4, *feature.WorkGeometry, error) {
+	asm, ok := host.(*compdef.AssemblyComponentDefinition)
+	if !ok {
+		return math.Identity4(), nil, fmt.Errorf("%s: an occurrence path is only valid in an assembly context", method)
+	}
+	transform, work, ok := asm.ResolveOccurrenceContext(path)
+	if !ok {
+		return math.Identity4(), nil, fmt.Errorf("%s: occurrence path %v resolves to no part component", method, path)
+	}
+	return transform, work, nil
+}
+
+// listWorkPlanesInOccurrence lists a sub-component's datum planes as occurrence-qualified refs (#1857).
+func listWorkPlanesInOccurrence(host workHost, path []string, includeConstruction bool) (wire.ListWorkPlanesResult, error) {
+	xf, work, err := occurrenceContext(host, path, wire.MethodWorkPlanesList)
+	if err != nil {
+		return wire.ListWorkPlanesResult{}, err
+	}
+	planes := projectListedDatums(work.WorkPlanes(), includeConstruction, func(i int, wp *feature.WorkPlane) wire.WorkPlaneInfo {
+		pl := wp.Plane()
+		return wire.WorkPlaneInfo{
+			Index:        i,
+			Name:         wp.Name(),
+			Ref:          string(feature.EncodeOccurrenceRef(path, wp.Key())),
+			Origin:       point3Slice(xf.TransformPoint(pl.Origin())),
+			Normal:       vector3Slice(xf.TransformVector(pl.Normal().AsVector())),
+			IsOrigin:     wp.IsCoordinateSystemElement(),
+			Construction: wp.Construction(),
+			Healthy:      wp.Health().OK(),
+			Reason:       wp.Health().Reason,
+			Kind:         wp.Kind(),
+		}
+	})
+	return wire.ListWorkPlanesResult{Planes: planes}, nil
+}
+
+// listWorkAxesInOccurrence lists a sub-component's datum axes as occurrence-qualified refs (#1857).
+func listWorkAxesInOccurrence(host workHost, path []string, includeConstruction bool) (wire.ListWorkAxesResult, error) {
+	xf, work, err := occurrenceContext(host, path, wire.MethodWorkAxesList)
+	if err != nil {
+		return wire.ListWorkAxesResult{}, err
+	}
+	axes := projectListedDatums(work.WorkAxes(), includeConstruction, func(i int, wa *feature.WorkAxis) wire.WorkAxisInfo {
+		dir, derr := xf.TransformUnitVector(wa.Direction())
+		if derr != nil {
+			dir = wa.Direction()
+		}
+		return wire.WorkAxisInfo{
+			Index:        i,
+			Name:         wa.Name(),
+			Ref:          string(feature.EncodeOccurrenceRef(path, wa.Key())),
+			Kind:         wa.Kind(),
+			Origin:       point3Slice(xf.TransformPoint(wa.Origin())),
+			Direction:    vector3Slice(dir.AsVector()),
+			IsOrigin:     wa.IsCoordinateSystemElement(),
+			Construction: wa.Construction(),
+			Healthy:      wa.Health().OK(),
+			Reason:       wa.Health().Reason,
+		}
+	})
+	return wire.ListWorkAxesResult{Axes: axes}, nil
+}
+
+// listWorkPointsInOccurrence lists a sub-component's datum points as occurrence-qualified refs (#1857).
+func listWorkPointsInOccurrence(host workHost, path []string, includeConstruction bool) (wire.ListWorkPointsResult, error) {
+	xf, work, err := occurrenceContext(host, path, wire.MethodWorkPointsList)
+	if err != nil {
+		return wire.ListWorkPointsResult{}, err
+	}
+	points := projectListedDatums(work.WorkPoints(), includeConstruction, func(i int, wp *feature.WorkPoint) wire.WorkPointInfo {
+		return wire.WorkPointInfo{
+			Index:        i,
+			Name:         wp.Name(),
+			Ref:          string(feature.EncodeOccurrenceRef(path, wp.Key())),
+			Position:     point3Slice(xf.TransformPoint(wp.Point())),
+			IsOrigin:     wp.IsCoordinateSystemElement(),
+			Visible:      wp.Visible(),
+			Construction: wp.Construction(),
+			Healthy:      wp.Health().OK(),
+			Reason:       wp.Health().Reason,
+			Kind:         wp.Kind(),
+		}
+	})
+	return wire.ListWorkPointsResult{Points: points}, nil
+}

--- a/addin/router/work_occurrence_list_test.go
+++ b/addin/router/work_occurrence_list_test.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"fmt"
+	stdmath "math"
+	"strings"
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+)
+
+// TestOccurrenceDatumListAndInput drives #1857 over the wire: a placed sub-component's datum plane is
+// surfaced by workPlanes.list (occurrence path) as an occurrence-qualified ref with its geometry
+// transformed into the assembly, and that ref is then accepted as a plane input to an assembly
+// work-plane create (AC1–AC3).
+func TestOccurrenceDatumListAndInput(t *testing.T) {
+	r, s := emptyAssemblySession(t)
+	asm := s.ActiveDocument().Content().(*compdef.AssemblyComponentDefinition)
+	part := compdef.NewPartComponentDefinition()
+	part.WorkPlanes().AddByPlaneAndOffset(feature.OriginXYPlane, func() float64 { return 5 }) // z = 5 in part space
+	zdir, _ := math.UnitVector3FromVector(math.V3(0, 0, 1))
+	part.WorkAxes().AddByLine(math.P3(0, 0, 0), zdir)
+	part.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(1, 2, 3) })
+	part.Recompute()
+	asm.Place("sub:1", part, math.Translation4(math.V3(10, 0, 0))) // placed +10 along X
+
+	// Axes and points also list as occurrence-qualified refs, transformed.
+	var axes wire.ListWorkAxesResult
+	call(t, r, s, "workAxes.list", `{"occurrence":["sub:1"]}`, &axes)
+	foundAxis := false
+	for _, a := range axes.Axes {
+		if strings.HasPrefix(a.Ref, "occ/") && !a.IsOrigin {
+			foundAxis = true
+		}
+	}
+	if !foundAxis {
+		t.Error("expected an occurrence-qualified axis in the assembly-context list")
+	}
+	var points wire.ListWorkPointsResult
+	call(t, r, s, "workPoints.list", `{"occurrence":["sub:1"]}`, &points)
+	for _, p := range points.Points {
+		if strings.HasPrefix(p.Ref, "occ/") && !p.IsOrigin {
+			if stdmath.Abs(p.Position[0]-11) > 1e-9 { // (1,2,3) placed +10 X → (11,2,3)
+				t.Errorf("occurrence point position = %v, want x=11", p.Position)
+			}
+		}
+	}
+
+	// AC1+AC2: list the sub-component's datum planes as occurrence-qualified refs.
+	var planes wire.ListWorkPlanesResult
+	call(t, r, s, "workPlanes.list", `{"occurrence":["sub:1"]}`, &planes)
+	occRef := ""
+	for _, p := range planes.Planes {
+		if p.IsOrigin || !strings.HasPrefix(p.Ref, "occ/") {
+			continue
+		}
+		occRef = p.Ref
+		if len(p.Origin) != 3 || stdmath.Abs(p.Origin[0]-10) > 1e-9 || stdmath.Abs(p.Origin[2]-5) > 1e-9 {
+			t.Errorf("occurrence plane origin = %v, want x=10 z=5 (part z=5 placed +10 X)", p.Origin)
+		}
+	}
+	if occRef == "" {
+		t.Fatal("expected an occurrence-qualified user plane in the assembly-context list")
+	}
+
+	// AC3: the occurrence-qualified ref is accepted as a plane input to an assembly work-plane create.
+	var res wire.CreateWorkPlaneResult
+	call(t, r, s, "workPlanes.create", fmt.Sprintf(`{"kind":"plane-offset","refs":["%s"],"offset":"2 mm"}`, occRef), &res)
+	if !res.Healthy {
+		t.Errorf("an assembly work plane offset from an occurrence plane should be healthy: %+v", res)
+	}
+}
+
+// TestOccurrenceListErrors: an occurrence path on a part (no occurrences), and an unknown path on an
+// assembly, both error cleanly (#1857).
+func TestOccurrenceListErrors(t *testing.T) {
+	rp, sp := emptyPartSession(t)
+	if _, err := rp.Handle(sp, "workPlanes.list", []byte(`{"occurrence":["sub:1"]}`)); err == nil {
+		t.Error("an occurrence path on a part should error (no occurrences)")
+	}
+	ra, sa := emptyAssemblySession(t)
+	if _, err := ra.Handle(sa, "workAxes.list", []byte(`{"occurrence":["missing:1"]}`)); err == nil {
+		t.Error("an unknown occurrence path should error")
+	}
+}

--- a/addin/router/work_planes.go
+++ b/addin/router/work_planes.go
@@ -55,6 +55,9 @@ func activeWorkHost(s *app.Session) (workHost, error) {
 // user planes) with their current geometry and health. Construction planes are hidden unless the
 // request opts in with IncludeConstruction (#1849).
 func listWorkPlanes(_ *app.Session, host workHost, in wire.ListWorkPlanesArgs) (wire.ListWorkPlanesResult, error) {
+	if len(in.Occurrence) > 0 {
+		return listWorkPlanesInOccurrence(host, in.Occurrence, in.IncludeConstruction)
+	}
 	planes := projectListedDatums(host.WorkPlanes(), in.IncludeConstruction, func(i int, wp *feature.WorkPlane) wire.WorkPlaneInfo {
 		return workPlaneInfo(host, wp, i)
 	})

--- a/model/compdef/assembly.go
+++ b/model/compdef/assembly.go
@@ -82,6 +82,9 @@ func NewAssemblyComponentDefinition() *AssemblyComponentDefinition {
 	a.dsJoints = assembly.NewDSJointSet()
 	a.representations = assembly.NewRepresentations(occ, a.constraints, a.joints)
 	a.contacts = assembly.NewContactSolver()
+	// Accept occurrence-qualified datum refs ("occ/<path>/plane/N") as inputs to the assembly's
+	// own sketch/feature tools, resolved through the occurrence tree + transform (#1857).
+	a.work.SetExternalDatumResolver(occurrenceDatumResolver{asm: a})
 	return a
 }
 

--- a/model/compdef/occurrence_datum_resolver.go
+++ b/model/compdef/occurrence_datum_resolver.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/occurrence"
+	"oblikovati.org/model/sketch"
+)
+
+// Occurrence-qualified work-feature references (#1857): an assembly names a datum inside a
+// sub-component occurrence with "occ/<path>/plane|axis|point/N". This file resolves such a
+// reference to its geometry in the assembly's space — used both to accept the ref as a datum input
+// (the ExternalDatumResolver the assembly installs on its WorkGeometry) and to list a component's
+// datums as occurrence-qualified refs (ResolveOccurrenceContext, for the wire list).
+
+// ResolveOccurrenceContext resolves an occurrence path (instance names, top-down) to the composed
+// occurrence-to-assembly transform and the target component's work geometry. ok is false when the
+// path names no occurrence, or the leaf occurrence is not a part (a sub-assembly has no datums to
+// surface here).
+func (a *AssemblyComponentDefinition) ResolveOccurrenceContext(pathNames []string) (math.Matrix4, *feature.WorkGeometry, bool) {
+	chain, ok := a.Occurrences().ResolveChain(occurrence.OccurrencePath(pathNames))
+	if !ok {
+		return math.Identity4(), nil, false
+	}
+	transform := math.Identity4()
+	for _, o := range chain {
+		transform = transform.Mul(o.Transform()) // world = parent · child (assembly_derive.go)
+	}
+	part, ok := chain[len(chain)-1].Definition().(*PartComponentDefinition)
+	if !ok {
+		return math.Identity4(), nil, false
+	}
+	return transform, part.WorkGeometry(), true
+}
+
+// occurrenceDatumResolver adapts an assembly to feature.ExternalDatumResolver: it resolves an
+// occurrence-qualified ref to a sub-component datum, transformed into the assembly's space (#1857).
+type occurrenceDatumResolver struct{ asm *AssemblyComponentDefinition }
+
+// context decodes ref and resolves its occurrence path to (transform, component work geometry,
+// component-local native ref).
+func (r occurrenceDatumResolver) context(ref feature.WorkRef) (math.Matrix4, *feature.WorkGeometry, feature.WorkRef, bool) {
+	path, native, ok := feature.ParseOccurrenceRef(ref)
+	if !ok {
+		return math.Identity4(), nil, "", false
+	}
+	transform, work, ok := r.asm.ResolveOccurrenceContext(path)
+	if !ok {
+		return math.Identity4(), nil, "", false
+	}
+	return transform, work, native, true
+}
+
+// OccurrencePlane resolves an occurrence-qualified plane ref, transformed into assembly space.
+func (r occurrenceDatumResolver) OccurrencePlane(ref feature.WorkRef) (sketch.Plane, bool) {
+	transform, work, native, ok := r.context(ref)
+	if !ok {
+		return sketch.Plane{}, false
+	}
+	pl, err := work.ResolvePlaneRef(native)
+	if err != nil {
+		return sketch.Plane{}, false
+	}
+	return transformPlane(transform, pl)
+}
+
+// OccurrenceAxisLine resolves an occurrence-qualified axis ref to its origin + unit direction in
+// assembly space.
+func (r occurrenceDatumResolver) OccurrenceAxisLine(ref feature.WorkRef) (math.Point3, math.UnitVector3, bool) {
+	transform, work, native, ok := r.context(ref)
+	if !ok {
+		return math.Point3{}, math.UnitVector3{}, false
+	}
+	wa, ok := work.AxisByRef(native)
+	if !ok {
+		return math.Point3{}, math.UnitVector3{}, false
+	}
+	dir, err := transform.TransformUnitVector(wa.Direction())
+	if err != nil {
+		return math.Point3{}, math.UnitVector3{}, false
+	}
+	return transform.TransformPoint(wa.Origin()), dir, true
+}
+
+// OccurrencePoint resolves an occurrence-qualified point ref, transformed into assembly space.
+func (r occurrenceDatumResolver) OccurrencePoint(ref feature.WorkRef) (math.Point3, bool) {
+	transform, work, native, ok := r.context(ref)
+	if !ok {
+		return math.Point3{}, false
+	}
+	p, err := work.ResolvePointRef(native)
+	if err != nil {
+		return math.Point3{}, false
+	}
+	return transform.TransformPoint(p), true
+}
+
+// transformPlane maps a sketch plane through a rigid occurrence transform: its origin and in-plane
+// axes are transformed, preserving normal = XAxis × YAxis. ok is false if the transform degenerates
+// an axis (a zero-scale placement).
+func transformPlane(m math.Matrix4, pl sketch.Plane) (sketch.Plane, bool) {
+	x, err := m.TransformUnitVector(pl.XAxis())
+	if err != nil {
+		return sketch.Plane{}, false
+	}
+	y, err := m.TransformUnitVector(pl.YAxis())
+	if err != nil {
+		return sketch.Plane{}, false
+	}
+	out, err := sketch.NewPlane(m.TransformPoint(pl.Origin()), x, y)
+	if err != nil {
+		return sketch.Plane{}, false
+	}
+	return out, true
+}

--- a/model/compdef/occurrence_datum_resolver_test.go
+++ b/model/compdef/occurrence_datum_resolver_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+)
+
+// TestOccurrenceDatumTransform: a sub-component's datums, named through an occurrence-qualified ref,
+// resolve into the assembly's space with the occurrence's placement transform applied — the core of
+// #1857 (both the AC3 input path via ResolvePlaneRef/ResolvePointRef, and the AC1 context helper).
+func TestOccurrenceDatumTransform(t *testing.T) {
+	asm := NewAssemblyComponentDefinition()
+	part := NewPartComponentDefinition()
+	wp := part.WorkPlanes().AddByPlaneAndOffset(feature.OriginXYPlane, func() float64 { return 5 }) // z = 5 in part space
+	pt := part.WorkPoints().AddByPosition(func() math.Point3 { return math.P3(1, 2, 3) })
+	part.Recompute()
+	asm.Place("sub:1", part, math.Translation4(math.V3(10, 0, 0))) // placed +10 along X
+
+	xf, work, ok := asm.ResolveOccurrenceContext([]string{"sub:1"})
+	if !ok || work == nil {
+		t.Fatal("occurrence context should resolve to the placed part's work geometry")
+	}
+	if !xf.TransformPoint(math.P3(0, 0, 0)).IsEqualTo(math.P3(10, 0, 0), 1e-9) {
+		t.Errorf("occurrence transform of origin = %v, want (10,0,0)", xf.TransformPoint(math.P3(0, 0, 0)))
+	}
+
+	// AC3: the assembly's own resolver accepts the occ-qualified ref as a datum input, transformed.
+	planeRef := feature.EncodeOccurrenceRef([]string{"sub:1"}, wp.Key())
+	pl, err := asm.WorkGeometry().ResolvePlaneRef(planeRef)
+	if err != nil {
+		t.Fatalf("resolve occurrence plane: %v", err)
+	}
+	if !pl.Origin().IsEqualTo(math.P3(10, 0, 5), 1e-9) {
+		t.Errorf("occurrence plane origin = %v, want (10,0,5)", pl.Origin())
+	}
+	if !pl.Normal().AsVector().IsEqualTo(math.V3(0, 0, 1), 1e-9) {
+		t.Errorf("occurrence plane normal = %v, want +Z (rigid translation preserves it)", pl.Normal())
+	}
+
+	pointRef := feature.EncodeOccurrenceRef([]string{"sub:1"}, pt.Key())
+	p, err := asm.WorkGeometry().ResolvePointRef(pointRef)
+	if err != nil {
+		t.Fatalf("resolve occurrence point: %v", err)
+	}
+	if !p.IsEqualTo(math.P3(11, 2, 3), 1e-9) {
+		t.Errorf("occurrence point = %v, want (11,2,3)", p)
+	}
+
+	// The axis resolver transforms origin + direction into assembly space (feeds WorkGeometry.axis()).
+	dir, _ := math.UnitVector3FromVector(math.V3(1, 0, 0))
+	ax := part.WorkAxes().AddByLine(math.P3(0, 0, 0), dir)
+	part.Recompute()
+	o, d, ok := occurrenceDatumResolver{asm: asm}.OccurrenceAxisLine(feature.EncodeOccurrenceRef([]string{"sub:1"}, ax.Key()))
+	if !ok || !o.IsEqualTo(math.P3(10, 0, 0), 1e-9) || !d.AsVector().IsEqualTo(math.V3(1, 0, 0), 1e-9) {
+		t.Errorf("occurrence axis = origin %v dir %v ok %v, want (10,0,0)/+X", o, d, ok)
+	}
+	if _, _, ok := (occurrenceDatumResolver{asm: asm}).OccurrenceAxisLine("plane/3"); ok {
+		t.Error("a non-occurrence ref must not resolve as an occurrence axis")
+	}
+}
+
+// TestOccurrenceContextUnresolvable: an unknown occurrence path, and a ref whose leaf is not a part,
+// both fail cleanly rather than panicking (#1857).
+func TestOccurrenceContextUnresolvable(t *testing.T) {
+	asm := NewAssemblyComponentDefinition()
+	if _, _, ok := asm.ResolveOccurrenceContext([]string{"missing:1"}); ok {
+		t.Error("an unknown occurrence path should not resolve")
+	}
+	if _, err := asm.WorkGeometry().ResolvePlaneRef(feature.EncodeOccurrenceRef([]string{"missing:1"}, "plane/3")); err == nil {
+		t.Error("an occurrence plane through an unknown path should error")
+	}
+}

--- a/model/feature/occurrence_ref.go
+++ b/model/feature/occurrence_ref.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"encoding/base64"
+	"strings"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/health"
+	"oblikovati.org/model/sketch"
+)
+
+// Occurrence-qualified work-feature references name a datum that lives inside a sub-component
+// occurrence, reached from an assembly context — the wire counterpart of Inventor's
+// WorkPlane/Axis/PointProxy (NativeObject + ContainingOccurrence, #1857). The encoding is
+// "occ/<b64path>/<native>" where b64path is the URL-safe base64 of the NUL-joined occurrence path
+// (instance names, top-down) and native is the component-local datum ref ("plane/3", "axis/1",
+// "point/0"). URL-safe base64 never contains '/', so the native ref (which does) is unambiguous.
+
+const occurrenceRefPrefix = "occ/"
+
+// EncodeOccurrenceRef builds the occurrence-qualified reference for a component-local datum named
+// through the given occurrence path.
+func EncodeOccurrenceRef(path []string, native WorkRef) WorkRef {
+	b64 := base64.RawURLEncoding.EncodeToString([]byte(strings.Join(path, "\x00")))
+	return WorkRef(occurrenceRefPrefix + b64 + "/" + string(native))
+}
+
+// ParseOccurrenceRef decodes an occurrence-qualified reference into its occurrence path (instance
+// names) and the component-local native datum ref. ok is false for any other reference.
+func ParseOccurrenceRef(ref WorkRef) (path []string, native WorkRef, ok bool) {
+	s := string(ref)
+	if !strings.HasPrefix(s, occurrenceRefPrefix) {
+		return nil, "", false
+	}
+	rest := s[len(occurrenceRefPrefix):]
+	slash := strings.IndexByte(rest, '/')
+	if slash < 0 {
+		return nil, "", false
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(rest[:slash])
+	if err != nil {
+		return nil, "", false
+	}
+	nativeRef := rest[slash+1:]
+	if nativeRef == "" {
+		return nil, "", false
+	}
+	names := strings.Split(string(raw), "\x00")
+	return names, WorkRef(nativeRef), true
+}
+
+// isOccurrenceRef reports whether ref is an occurrence-qualified reference.
+func isOccurrenceRef(ref WorkRef) bool { return strings.HasPrefix(string(ref), occurrenceRefPrefix) }
+
+// ExternalDatumResolver resolves occurrence-qualified references (which name a datum in another
+// component, reached through an occurrence) to their geometry in the resolving context's space. An
+// assembly injects one into its WorkGeometry so occurrence-qualified refs are accepted as datum
+// inputs to assembly sketch/feature tools (#1857). Each method returns ok=false when the reference
+// does not resolve (a lost occurrence, a deleted datum), so the consuming feature goes unhealthy.
+type ExternalDatumResolver interface {
+	OccurrencePlane(ref WorkRef) (sketch.Plane, bool)
+	OccurrenceAxisLine(ref WorkRef) (origin math.Point3, dir math.UnitVector3, ok bool)
+	OccurrencePoint(ref WorkRef) (math.Point3, bool)
+}
+
+// SetExternalDatumResolver installs the resolver for occurrence-qualified references. Nil (the
+// default) means occurrence refs do not resolve — a plain part has no occurrences.
+func (g *WorkGeometry) SetExternalDatumResolver(r ExternalDatumResolver) { g.external = r }
+
+// newOccurrenceAxis wraps a resolved occurrence axis line as a transient grounded WorkAxis (not part
+// of any collection) so it can be returned from axis() like a local datum axis.
+func newOccurrenceAxis(ref WorkRef, origin math.Point3, dir math.UnitVector3) *WorkAxis {
+	return &WorkAxis{
+		key:      ref,
+		name:     "Occurrence Axis",
+		def:      fixedAxisDef{origin: origin, dir: dir},
+		origin:   origin,
+		dir:      dir,
+		grounded: true,
+		health:   health.Healthy,
+	}
+}

--- a/model/feature/occurrence_ref_test.go
+++ b/model/feature/occurrence_ref_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// TestOccurrenceRefRoundTrip: an occurrence-qualified ref encodes an occurrence path (even with
+// names containing slashes or spaces) and its native datum ref, and decodes back exactly (#1857).
+func TestOccurrenceRefRoundTrip(t *testing.T) {
+	path := []string{"gear:1", "sub/assembly:2", "shaft x:3"}
+	ref := EncodeOccurrenceRef(path, "axis/0")
+	gotPath, native, ok := ParseOccurrenceRef(ref)
+	if !ok || native != "axis/0" || len(gotPath) != 3 {
+		t.Fatalf("decode = path %v native %q ok %v", gotPath, native, ok)
+	}
+	for i := range path {
+		if gotPath[i] != path[i] {
+			t.Errorf("path[%d] = %q, want %q", i, gotPath[i], path[i])
+		}
+	}
+	if _, _, ok := ParseOccurrenceRef("plane/3"); ok {
+		t.Error("a plain datum ref must not decode as an occurrence ref")
+	}
+	if _, _, ok := ParseOccurrenceRef("occ/notbase64!/plane/3"); ok {
+		t.Error("a bad base64 path must not decode")
+	}
+}
+
+type fakeExternalResolver struct {
+	pl sketch.Plane
+	o  math.Point3
+	d  math.UnitVector3
+	pt math.Point3
+}
+
+func (f fakeExternalResolver) OccurrencePlane(WorkRef) (sketch.Plane, bool) { return f.pl, true }
+func (f fakeExternalResolver) OccurrenceAxisLine(WorkRef) (math.Point3, math.UnitVector3, bool) {
+	return f.o, f.d, true
+}
+func (f fakeExternalResolver) OccurrencePoint(WorkRef) (math.Point3, bool) { return f.pt, true }
+
+// TestExternalResolverInterceptsOccurrenceRefs: with an external resolver installed, the plane/axis/
+// point resolvers delegate occurrence-qualified refs to it; without one, an occ ref errors (#1857).
+func TestExternalResolverInterceptsOccurrenceRefs(t *testing.T) {
+	g := NewWorkGeometry()
+	occ := EncodeOccurrenceRef([]string{"sub:1"}, "plane/3")
+	if _, err := g.plane(occ); err == nil {
+		t.Error("an occurrence ref without an external resolver should error")
+	}
+
+	g.SetExternalDatumResolver(fakeExternalResolver{pl: sketch.XYPlane(), o: math.P3(1, 2, 3), d: mustUnit(0, 0, 1), pt: math.P3(4, 5, 6)})
+	if pl, err := g.plane(occ); err != nil || !pl.Origin().IsEqualTo(math.P3(0, 0, 0), wtol) {
+		t.Errorf("plane occ ref = %v (err %v), want the XY plane", pl.Origin(), err)
+	}
+	ax, err := g.axis(EncodeOccurrenceRef([]string{"sub:1"}, "axis/0"))
+	if err != nil || !ax.Origin().IsEqualTo(math.P3(1, 2, 3), wtol) {
+		t.Errorf("axis occ ref = %v (err %v), want origin (1,2,3)", ax, err)
+	}
+	if !ax.Direction().AsVector().IsEqualTo(math.V3(0, 0, 1), wtol) {
+		t.Errorf("axis dir = %v, want +Z", ax.Direction())
+	}
+	if p, err := g.point(EncodeOccurrenceRef([]string{"sub:1"}, "point/0")); err != nil || !p.IsEqualTo(math.P3(4, 5, 6), wtol) {
+		t.Errorf("point occ ref = %v (err %v), want (4,5,6)", p, err)
+	}
+}

--- a/model/feature/work_geometry.go
+++ b/model/feature/work_geometry.go
@@ -62,6 +62,9 @@ type WorkGeometry struct {
 	bodies  []*topo.Body // the running solid result, so surface-tangent work planes can
 	// resolve a picked B-rep face's reference key to its surface (set each Recompute).
 	tracker FootprintTracker // captures each plane's parameter footprint (set by the part); nil ⇒ no capture
+	// external resolves occurrence-qualified references (a datum in another component reached
+	// through an occurrence) — set by an assembly, nil for a plain part (#1857).
+	external ExternalDatumResolver
 }
 
 // FootprintTracker captures the dependency keys read while fn runs — satisfied by
@@ -168,6 +171,12 @@ func (g *WorkGeometry) seedOrigin() {
 
 // plane/axis/point implement workResolver, resolving a ref to its current geometry.
 func (g *WorkGeometry) plane(ref WorkRef) (sketch.Plane, error) {
+	if g.external != nil && isOccurrenceRef(ref) {
+		if pl, ok := g.external.OccurrencePlane(ref); ok {
+			return pl, nil
+		}
+		return sketch.Plane{}, fmt.Errorf("work geometry: occurrence plane %q does not resolve", ref)
+	}
 	if pl, isFace, err := g.facePlane(ref); isFace {
 		return pl, err // a planar B-rep face used as a plane input (offset-from-face, etc.)
 	}
@@ -194,6 +203,10 @@ func (g *WorkGeometry) plane(ref WorkRef) (sketch.Plane, error) {
 // mirror's plane; errors when the ref names no resolvable plane.
 func (g *WorkGeometry) ResolvePlaneRef(ref WorkRef) (sketch.Plane, error) { return g.plane(ref) }
 
+// ResolvePointRef resolves a WorkRef to its model-space point (origin/user datum point or a
+// vertex) — exported so an assembly can read a sub-component's datum point through an occurrence.
+func (g *WorkGeometry) ResolvePointRef(ref WorkRef) (math.Point3, error) { return g.point(ref) }
+
 // WorkPlaneByRef resolves a WorkRef to its *WorkPlane (origin or user) — for features
 // that reference a datum plane, e.g. an extrude's to-face / from-to target.
 func (g *WorkGeometry) WorkPlaneByRef(ref WorkRef) (*WorkPlane, error) {
@@ -215,6 +228,12 @@ func (g *WorkGeometry) WorkPlaneByRef(ref WorkRef) (*WorkPlane, error) {
 }
 
 func (g *WorkGeometry) axis(ref WorkRef) (*WorkAxis, error) {
+	if g.external != nil && isOccurrenceRef(ref) {
+		if o, d, ok := g.external.OccurrenceAxisLine(ref); ok {
+			return newOccurrenceAxis(ref, o, d), nil
+		}
+		return nil, fmt.Errorf("work geometry: occurrence axis %q does not resolve", ref)
+	}
 	if i, ok := userIndex(ref, "axis"); ok {
 		if i < 0 || i >= g.axes.Count() {
 			return nil, fmt.Errorf("work geometry: no work axis %q", ref)
@@ -263,6 +282,12 @@ func (g *WorkGeometry) WorkPointByRef(ref WorkRef) (*WorkPoint, bool) {
 }
 
 func (g *WorkGeometry) point(ref WorkRef) (math.Point3, error) {
+	if g.external != nil && isOccurrenceRef(ref) {
+		if p, ok := g.external.OccurrencePoint(ref); ok {
+			return p, nil
+		}
+		return math.Point3{}, fmt.Errorf("work geometry: occurrence point %q does not resolve", ref)
+	}
 	if p, isVertex, err := g.vertexPoint(ref); isVertex {
 		return p, err
 	}

--- a/model/feature/work_ref_parse.go
+++ b/model/feature/work_ref_parse.go
@@ -5,11 +5,12 @@ package feature
 import "strings"
 
 // workFeatureRefPrefixes are the reference-string prefixes that name a work feature — an origin
-// datum, a user plane/axis/point, a UCS, a model vertex, or a B-rep edge (a lineage-key "edge/…" or
-// an ADR-0040 geometric "edge-geom/…" descriptor) — rather than a raw B-rep face key. The two edge
-// forms are kept verbatim so the edge resolver (work_edge_ref.go) can bind them; without this a
-// wire edge ref was mis-wrapped as a face key and every edge-based datum went unhealthy (#1840, #1842).
-var workFeatureRefPrefixes = []string{"origin/", "plane/", "axis/", "point/", "ucs/", "vertex/", "edge/", "edge-geom/"}
+// datum, a user plane/axis/point, a UCS, a model vertex, a B-rep edge (a lineage-key "edge/…" or an
+// ADR-0040 geometric "edge-geom/…" descriptor), or an occurrence-qualified datum ("occ/…", a datum
+// inside a sub-component reached through an occurrence) — rather than a raw B-rep face key. Each is
+// kept verbatim so its resolver (work_edge_ref.go / occurrence_ref.go) can bind it; without this a
+// wire ref was mis-wrapped as a face key and the datum went unhealthy (#1840, #1842, #1857).
+var workFeatureRefPrefixes = []string{"origin/", "plane/", "axis/", "point/", "ucs/", "vertex/", "edge/", "edge-geom/", "occ/"}
 
 // ParseWorkRef classifies a raw reference string from the wire: a work-feature reference is kept
 // verbatim; any other string is treated as a raw B-rep face key and wrapped as a face ref. It is


### PR DESCRIPTION
Closes **#1857** — the last Work Features gap. The wire counterpart of Inventor's WorkPlane/Axis/PointProxy (`NativeObject` + `ContainingOccurrence`): name a datum inside a sub-component occurrence from an assembly context, resolved through the occurrence transform. **Host-only** (the `Occurrence` list field shipped in v0.128.0).

## Ref vocabulary
`occ/<b64path>/plane|axis|point/N` — URL-safe base64 of the NUL-joined occurrence path (never contains `/`) + the component-local native ref. `ParseWorkRef` now keeps `occ/` verbatim (same class of fix as edge refs — without it the ref was mis-wrapped as a face key; #1840/#1842/#1857).

## AC1+AC2 — list in occurrence context
`workPlanes/Axes/Points.list` with an `Occurrence` path lists that sub-component's datums, geometry transformed into the assembly (composed `ResolveChain` transform), each as an occurrence-qualified ref. Rows are **read-only proxies** (no editable scalars/slots) — a proxy is a projection redefined only in its own component.

## AC3 — input acceptance
An assembly installs an `ExternalDatumResolver` on its `WorkGeometry`; the plane/axis/point resolvers intercept `occ/…` refs and resolve them through the occurrence tree + transform — so an occurrence-qualified ref is accepted as a datum input to the assembly's own sketch/feature tools.

## Tests
- encode/decode round-trip (incl. names with `/` and spaces); bad-base64 rejection
- external-resolver interception (plane/axis/point delegate; no resolver → error)
- occurrence transform: part z=5 placed +10 X → plane origin (10,0,5) normal +Z preserved; point (1,2,3)→(11,2,3); axis origin+dir transformed
- wire round trip: list a placed part's datums as occ refs → accept one as a plane-offset input (healthy)
- error paths: occurrence path on a part, unknown path

🤖 Generated with [Claude Code](https://claude.com/claude-code)