### PR TITLE
feat(sketch): ellipse-axis operand for parallel/perpendicular/collinear (#1879)

### DIFF
--- a/addin/router/sketch_constraint_refs.go
+++ b/addin/router/sketch_constraint_refs.go
@@ -62,6 +62,50 @@ func singleLineOrAlign(sk *sketch.Sketch, refs []uint64, addLine func(*sketch.Li
 	}
 }
 
+// axisOrLineRelation applies an ellipse-axis relation when either operand is an ellipse
+// (per-operand major/minor from the flags), else the plain two-line relation (#1879).
+func axisOrLineRelation(sk *sketch.Sketch, refs []uint64, flags axisFlags, addAxis func(a, b sketch.AxisOperand) sketch.Constraint, addLine func(a, b *sketch.Line) sketch.Constraint) (sketch.Constraint, bool, error) {
+	if len(refs) != 2 || (!isEllipseRef(sk, refs[0]) && !isEllipseRef(sk, refs[1])) {
+		return withTwoLines(sk, refs, addLine)
+	}
+	a, err := axisOperandRef(sk, refs[0], flags.one)
+	if err != nil {
+		return nil, true, err
+	}
+	b, err := axisOperandRef(sk, refs[1], flags.two)
+	if err != nil {
+		return nil, true, err
+	}
+	return addAxis(a, b), true, nil
+}
+
+// isEllipseRef reports whether an id resolves to an ellipse or elliptical arc.
+func isEllipseRef(sk *sketch.Sketch, ref uint64) bool {
+	e, ok := sk.EntityByID(sketch.ID(ref))
+	if !ok {
+		return false
+	}
+	_, ok = sketch.EllipseAxisOf(e, true)
+	return ok
+}
+
+// axisOperandRef resolves an id to an axis-relation operand: an ellipse's major/minor axis, or a
+// line's direction (a single typed pick, not a type switch — archguard I1).
+func axisOperandRef(sk *sketch.Sketch, ref uint64, major bool) (sketch.AxisOperand, error) {
+	e, ok := sk.EntityByID(sketch.ID(ref))
+	if !ok {
+		return nil, fmt.Errorf("sketch.addConstraint: no entity with id %d", ref)
+	}
+	if op, ok := sketch.EllipseAxisOf(e, major); ok {
+		return op, nil
+	}
+	l, ok := e.(*sketch.Line)
+	if !ok {
+		return nil, fmt.Errorf("sketch.addConstraint: entity %d (%T) is neither a line nor an ellipse", ref, e)
+	}
+	return sketch.LineAxis(l), nil
+}
+
 // withTwoPoints resolves two point refs and applies a two-point constraint factory.
 func withTwoPoints(sk *sketch.Sketch, refs []uint64, add func(a, b *sketch.Point) sketch.Constraint) (sketch.Constraint, bool, error) {
 	a, b, err := twoPointRefs(sk, refs)

--- a/addin/router/sketch_constraints.go
+++ b/addin/router/sketch_constraints.go
@@ -28,7 +28,7 @@ func addConstraint(_ *app.Session, part *compdef.PartComponentDefinition, in wir
 			return wire.AddConstraintResult{}, err
 		}
 	} else {
-		c, err := buildGeometricConstraint(sk, types.GeometricConstraintKind(in.Kind), in.Entities)
+		c, err := buildGeometricConstraint(sk, types.GeometricConstraintKind(in.Kind), in)
 		if err != nil {
 			return wire.AddConstraintResult{}, err
 		}
@@ -72,16 +72,32 @@ func addCustomConstraint(sk *sketch.Sketch, in wire.AddConstraintArgs) error {
 	return err
 }
 
+// axisFlags carries the per-operand ellipse major/minor-axis selectors of a parallel/
+// perpendicular/collinear relation (#1879), defaulted to the major axis (Inventor's default)
+// when the request omits them.
+type axisFlags struct{ one, two bool }
+
+func axisFlagsFrom(in wire.AddConstraintArgs) axisFlags {
+	return axisFlags{
+		one: boolOrTrue(in.UseEllipseOneMajorAxis),
+		two: boolOrTrue(in.UseEllipseTwoMajorAxis),
+	}
+}
+
+func boolOrTrue(p *bool) bool { return p == nil || *p }
+
 // buildGeometricConstraint resolves the references and applies the matching model
 // constraint. The kinds are split into small groups to keep each switch readable.
-func buildGeometricConstraint(sk *sketch.Sketch, kind types.GeometricConstraintKind, refs []uint64) (sketch.Constraint, error) {
+func buildGeometricConstraint(sk *sketch.Sketch, kind types.GeometricConstraintKind, in wire.AddConstraintArgs) (sketch.Constraint, error) {
+	refs := in.Entities
+	flags := axisFlagsFrom(in)
 	if c, ok, err := pointPairConstraint(sk, kind, refs); ok {
 		return c, err
 	}
 	if c, ok, err := horizontalVerticalConstraint(sk, kind, refs); ok {
 		return c, err
 	}
-	if c, ok, err := lineConstraint(sk, kind, refs); ok {
+	if c, ok, err := lineConstraint(sk, kind, refs, flags); ok {
 		return c, err
 	}
 	if c, ok, err := circularConstraint(sk, kind, refs); ok {
@@ -178,16 +194,23 @@ func horizontalVerticalConstraint(sk *sketch.Sketch, kind types.GeometricConstra
 	}
 }
 
-// lineConstraint handles the constraints between two lines.
-func lineConstraint(sk *sketch.Sketch, kind types.GeometricConstraintKind, refs []uint64) (sketch.Constraint, bool, error) {
+// lineConstraint handles the direction relations between two lines — or, when at least one
+// operand is an ellipse, between the two operands' axes (#1879).
+func lineConstraint(sk *sketch.Sketch, kind types.GeometricConstraintKind, refs []uint64, flags axisFlags) (sketch.Constraint, bool, error) {
 	g := sk.GeometricConstraints()
 	switch kind {
 	case types.GeoConstraintParallel:
-		return withTwoLines(sk, refs, func(a, b *sketch.Line) sketch.Constraint { return g.AddParallel(a, b) })
+		return axisOrLineRelation(sk, refs, flags,
+			func(a, b sketch.AxisOperand) sketch.Constraint { return g.AddEllipseParallel(a, b) },
+			func(a, b *sketch.Line) sketch.Constraint { return g.AddParallel(a, b) })
 	case types.GeoConstraintPerpendicular:
-		return withTwoLines(sk, refs, func(a, b *sketch.Line) sketch.Constraint { return g.AddPerpendicular(a, b) })
+		return axisOrLineRelation(sk, refs, flags,
+			func(a, b sketch.AxisOperand) sketch.Constraint { return g.AddEllipsePerpendicular(a, b) },
+			func(a, b *sketch.Line) sketch.Constraint { return g.AddPerpendicular(a, b) })
 	case types.GeoConstraintCollinear:
-		return withTwoLines(sk, refs, func(a, b *sketch.Line) sketch.Constraint { return g.AddCollinear(a, b) })
+		return axisOrLineRelation(sk, refs, flags,
+			func(a, b sketch.AxisOperand) sketch.Constraint { return g.AddEllipseCollinear(a, b) },
+			func(a, b *sketch.Line) sketch.Constraint { return g.AddCollinear(a, b) })
 	case types.GeoConstraintEqualLength:
 		return withTwoLines(sk, refs, func(a, b *sketch.Line) sketch.Constraint { return g.AddEqualLength(a, b) })
 	default:

--- a/addin/router/sketch_ellipse_axis_test.go
+++ b/addin/router/sketch_ellipse_axis_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// solveAndLineDir solves the sketch and returns the first line's direction components.
+func solveAndLineDir(t *testing.T, r *Router, s *app.Session) (float64, float64) {
+	t.Helper()
+	call(t, r, s, "sketch.solve", `{"sketchIndex":0}`, &wire.SolveSketchResult{})
+	var ents wire.EnumerateEntitiesResult
+	call(t, r, s, "sketch.entities", `{"sketchIndex":0}`, &ents)
+	for _, e := range ents.Entities {
+		if e.Kind == "line" && len(e.Points) == 2 {
+			return e.Points[1][0] - e.Points[0][0], e.Points[1][1] - e.Points[0][1]
+		}
+	}
+	t.Fatal("no line enumerated")
+	return 0, 0
+}
+
+func nearlyZero(v float64) bool { return v < 1e-6 && v > -1e-6 }
+
+// TestEllipseParallelOverWire: parallel with an ellipse operand aligns the line to the ellipse's
+// major axis and enumerates as "parallel" (#1879).
+func TestEllipseParallelOverWire(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.setInferenceOptions", `{"inferEnabled":false}`, &wire.InferenceOptionsView{})
+	ell := addEnt(t, r, s, `{"sketchIndex":0,"kind":"ellipse","points":[[0,0]],"axis":[1,0],"majorRadius":"3 cm","minorRadius":"1 cm"}`)
+	l := addEnt(t, r, s, `{"sketchIndex":0,"kind":"line","points":[[0,0],[4,1]]}`)
+
+	var res wire.AddConstraintResult
+	call(t, r, s, "sketch.addConstraint", mustJSON(t, wire.AddConstraintArgs{
+		SketchIndex: 0, Kind: "parallel", Entities: []uint64{l.EntityID, ell.EntityID},
+	}), &res)
+	if res.Kind != "parallel" {
+		t.Fatalf("result kind = %q, want parallel", res.Kind)
+	}
+	dx, dy := solveAndLineDir(t, r, s)
+	if !nearlyZero(dy) || nearlyZero(dx) {
+		t.Errorf("line direction = (%v,%v), want horizontal (parallel to the major axis)", dx, dy)
+	}
+}
+
+// TestEllipseParallelMinorAxisOverWire: UseEllipseTwoMajorAxis=false selects the minor axis, so
+// the line becomes vertical (#1879).
+func TestEllipseParallelMinorAxisOverWire(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.setInferenceOptions", `{"inferEnabled":false}`, &wire.InferenceOptionsView{})
+	ell := addEnt(t, r, s, `{"sketchIndex":0,"kind":"ellipse","points":[[0,0]],"axis":[1,0],"majorRadius":"3 cm","minorRadius":"1 cm"}`)
+	l := addEnt(t, r, s, `{"sketchIndex":0,"kind":"line","points":[[0,0],[1,4]]}`)
+
+	no := false
+	var res wire.AddConstraintResult
+	call(t, r, s, "sketch.addConstraint", mustJSON(t, wire.AddConstraintArgs{
+		SketchIndex: 0, Kind: "parallel", Entities: []uint64{l.EntityID, ell.EntityID},
+		UseEllipseTwoMajorAxis: &no,
+	}), &res)
+	dx, dy := solveAndLineDir(t, r, s)
+	if !nearlyZero(dx) || nearlyZero(dy) {
+		t.Errorf("line direction = (%v,%v), want vertical (parallel to the minor axis)", dx, dy)
+	}
+}
+
+// TestEllipsePerpendicularOverWire: perpendicular with an ellipse major-axis operand makes the
+// line vertical, enumerating as "perpendicular" (#1879).
+func TestEllipsePerpendicularOverWire(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.setInferenceOptions", `{"inferEnabled":false}`, &wire.InferenceOptionsView{})
+	ell := addEnt(t, r, s, `{"sketchIndex":0,"kind":"ellipse","points":[[0,0]],"axis":[1,0],"majorRadius":"3 cm","minorRadius":"1 cm"}`)
+	l := addEnt(t, r, s, `{"sketchIndex":0,"kind":"line","points":[[0,0],[1,4]]}`)
+	var res wire.AddConstraintResult
+	call(t, r, s, "sketch.addConstraint", mustJSON(t, wire.AddConstraintArgs{
+		SketchIndex: 0, Kind: "perpendicular", Entities: []uint64{l.EntityID, ell.EntityID},
+	}), &res)
+	if res.Kind != "perpendicular" {
+		t.Fatalf("result kind = %q, want perpendicular", res.Kind)
+	}
+	dx, dy := solveAndLineDir(t, r, s)
+	if !nearlyZero(dx) || nearlyZero(dy) {
+		t.Errorf("line direction = (%v,%v), want vertical", dx, dy)
+	}
+}
+
+// TestTwoLineParallelStillWorks: with no ellipse operand, parallel is the plain two-line
+// relation, unchanged by the ellipse-axis path (#1879).
+func TestTwoLineParallelStillWorks(t *testing.T) {
+	r, s := seededSession(t)
+	l1 := addEnt(t, r, s, `{"sketchIndex":0,"kind":"line","points":[[0,0],[2,0]]}`)
+	l2 := addEnt(t, r, s, `{"sketchIndex":0,"kind":"line","points":[[0,1],[3,2]]}`)
+	var res wire.AddConstraintResult
+	call(t, r, s, "sketch.addConstraint", mustJSON(t, wire.AddConstraintArgs{
+		SketchIndex: 0, Kind: "parallel", Entities: []uint64{l1.EntityID, l2.EntityID},
+	}), &res)
+	if res.Kind != "parallel" {
+		t.Errorf("two-line parallel kind = %q, want parallel", res.Kind)
+	}
+}

--- a/addin/router/sketch_enumerate.go
+++ b/addin/router/sketch_enumerate.go
@@ -223,6 +223,10 @@ var wireConstraintKinds = map[sketch.ConstraintKind]types.GeometricConstraintKin
 	sketch.LineSymmetryKind:         types.GeoConstraintSymmetry,
 	sketch.CircularSymmetryKind:     types.GeoConstraintSymmetry,
 	sketch.ArcMidpointKind:          types.GeoConstraintMidpoint,
+	// Ellipse-axis relations enumerate as their plain wire relation (#1879).
+	sketch.EllipseParallelKind:      types.GeoConstraintParallel,
+	sketch.EllipsePerpendicularKind: types.GeoConstraintPerpendicular,
+	sketch.EllipseCollinearKind:     types.GeoConstraintCollinear,
 	sketch.FixKind:                  types.GeoConstraintFix,
 	sketch.ParallelKind:             types.GeoConstraintParallel,
 	sketch.PerpendicularKind:        types.GeoConstraintPerpendicular,

--- a/model/sketch/constraint_kind.go
+++ b/model/sketch/constraint_kind.go
@@ -40,13 +40,19 @@ const (
 	LineSymmetryKind     ConstraintKind = "symmetryLine"
 	CircularSymmetryKind ConstraintKind = "symmetryCircular"
 	ArcMidpointKind      ConstraintKind = "midpointArc"
-	FixKind              ConstraintKind = "fix"
-	SmoothKind           ConstraintKind = "smooth"
-	GroundKind           ConstraintKind = "ground"
-	OffsetKind           ConstraintKind = "offset"
-	PatternLinkKind      ConstraintKind = "patternLink"
-	TextBoxAnchorKind    ConstraintKind = "textBox"
-	CustomKind           ConstraintKind = "custom"
+	// Ellipse-axis relations (#1879): parallel/perpendicular/collinear with an ellipse-axis
+	// operand. They enumerate as the wire parallel/perpendicular/collinear but persist distinctly
+	// (they carry per-operand major/minor flags a plain two-line constraint has no place for).
+	EllipseParallelKind      ConstraintKind = "ellipseParallel"
+	EllipsePerpendicularKind ConstraintKind = "ellipsePerpendicular"
+	EllipseCollinearKind     ConstraintKind = "ellipseCollinear"
+	FixKind                  ConstraintKind = "fix"
+	SmoothKind               ConstraintKind = "smooth"
+	GroundKind               ConstraintKind = "ground"
+	OffsetKind               ConstraintKind = "offset"
+	PatternLinkKind          ConstraintKind = "patternLink"
+	TextBoxAnchorKind        ConstraintKind = "textBox"
+	CustomKind               ConstraintKind = "custom"
 )
 
 // KindedConstraint is the capability the serializer and the router enumerate
@@ -91,7 +97,11 @@ func (c *LineSymmetryConstraint) ConstraintKind() ConstraintKind    { return Lin
 func (c *CircularSymmetryConstraint) ConstraintKind() ConstraintKind {
 	return CircularSymmetryKind
 }
-func (c *ArcMidpointConstraint) ConstraintKind() ConstraintKind   { return ArcMidpointKind }
+func (c *ArcMidpointConstraint) ConstraintKind() ConstraintKind { return ArcMidpointKind }
+
+// AxisRelationConstraint carries its persisted kind (one of the five ellipse-axis kinds) in a
+// field, since one Go type covers all five relations/orientations (#1879).
+func (c *AxisRelationConstraint) ConstraintKind() ConstraintKind  { return c.kind }
 func (c *FixConstraint) ConstraintKind() ConstraintKind           { return FixKind }
 func (c *SmoothConstraint) ConstraintKind() ConstraintKind        { return SmoothKind }
 func (c *GroundConstraint) ConstraintKind() ConstraintKind        { return GroundKind }
@@ -127,8 +137,20 @@ func (c *CircularSymmetryConstraint) RelatedEntities() []Entity {
 	return []Entity{c.C1, c.C2, c.About}
 }
 func (c *ArcMidpointConstraint) RelatedEntities() []Entity { return []Entity{c.P, c.A} }
-func (c *FixConstraint) RelatedEntities() []Entity         { return []Entity{c.P} }
-func (c *SmoothConstraint) RelatedEntities() []Entity      { return []Entity{c.C1, c.C2} }
+
+// RelatedEntities lists the operand entities, skipping the world axis of a horizontal/vertical
+// form (which names no entity).
+func (c *AxisRelationConstraint) RelatedEntities() []Entity {
+	out := make([]Entity, 0, 2)
+	for _, op := range []AxisOperand{c.a, c.b} {
+		if e := op.operandEntity(); e != nil {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+func (c *FixConstraint) RelatedEntities() []Entity    { return []Entity{c.P} }
+func (c *SmoothConstraint) RelatedEntities() []Entity { return []Entity{c.C1, c.C2} }
 func (c *GroundConstraint) RelatedEntities() []Entity {
 	pts := c.Points()
 	out := make([]Entity, len(pts))
@@ -166,6 +188,7 @@ var (
 	_ KindedConstraint = (*LineSymmetryConstraint)(nil)
 	_ KindedConstraint = (*CircularSymmetryConstraint)(nil)
 	_ KindedConstraint = (*ArcMidpointConstraint)(nil)
+	_ KindedConstraint = (*AxisRelationConstraint)(nil)
 	_ KindedConstraint = (*FixConstraint)(nil)
 	_ KindedConstraint = (*SmoothConstraint)(nil)
 	_ KindedConstraint = (*GroundConstraint)(nil)

--- a/model/sketch/constraints_ellipse_axis.go
+++ b/model/sketch/constraints_ellipse_axis.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"oblikovati.org/math"
+	"oblikovati.org/solve/ad"
+)
+
+// Ellipse-axis operands (#1879): Inventor's parallel/perpendicular/collinear and horizontal/
+// vertical accept an ellipse (or elliptical arc) operand, its constrained direction being the
+// ellipse's major or minor axis (UseEllipse*MajorAxis). An ellipse's axis direction is a fixed
+// reference (the major-axis direction is not a solver DOF — see solve_sketch.go's variable
+// universe), so an ellipse operand contributes a constant direction anchored at its centre; the
+// line operand adjusts. This is a direction-alignment relation, not a branch-selection one, so
+// the residuals reuse the existing scale-invariant angle/perp-distance primitives.
+
+// ellipseAxisSource is an ellipse-like entity that offers a centre and a major-axis direction —
+// satisfied by both Ellipse and EllipticalArc (#1879).
+type ellipseAxisSource interface {
+	Entity
+	axisCentre() *Point
+	// axisVector returns the (unnormalised) major or minor axis direction; adSineAngle/
+	// adCosAngle normalise, so a raw vector is fine.
+	axisVector(major bool) math.Vector2
+}
+
+func (e *Ellipse) axisCentre() *Point { return e.Center }
+func (e *Ellipse) axisVector(major bool) math.Vector2 {
+	return ellipseAxisVector(e.MajorAxis, major)
+}
+func (e *EllipticalArc) axisCentre() *Point { return e.Center }
+func (e *EllipticalArc) axisVector(major bool) math.Vector2 {
+	return ellipseAxisVector(e.MajorAxis, major)
+}
+
+// ellipseAxisVector returns the major axis as-is, or the minor axis as its left perpendicular.
+func ellipseAxisVector(major math.Vector2, useMajor bool) math.Vector2 {
+	if useMajor {
+		return major
+	}
+	return math.V2(-major.Y, major.X)
+}
+
+// AxisOperand is a direction operand of an axis-relation constraint: a line (direction from its
+// endpoints, DOFs) or an ellipse axis (a fixed direction anchored at the ellipse centre). The
+// interface is sealed (its methods are unexported); construct one with LineAxis or EllipseAxisOf.
+type AxisOperand interface {
+	dirVars() []*math.Scalar
+	// readDir reads the operand's direction and anchor point from the seeded row starting at
+	// off, returning the number of variables consumed.
+	readDir(v []ad.Number, off int) (dir, anchor ad.Vec2, consumed int)
+	// operandEntity is the entity the operand names for enumeration (nil for a world axis).
+	operandEntity() Entity
+	// axisMajor reports whether an ellipse operand uses its major axis (false for line/world
+	// operands); persisted so the major/minor choice survives a round trip (#1879).
+	axisMajor() bool
+	// remap rebuilds the operand against a sketch clone, reporting ok=false when its entity
+	// lies outside the copied set (a world axis always remaps).
+	remap(m *cloneMap) (AxisOperand, bool)
+}
+
+// lineAxisOperand is a line's direction operand.
+type lineAxisOperand struct{ L *Line }
+
+// LineAxis wraps a line as an axis-relation operand.
+func LineAxis(l *Line) AxisOperand { return lineAxisOperand{L: l} }
+
+func (o lineAxisOperand) dirVars() []*math.Scalar {
+	return []*math.Scalar{&o.L.A.X, &o.L.A.Y, &o.L.B.X, &o.L.B.Y}
+}
+func (o lineAxisOperand) readDir(v []ad.Number, off int) (ad.Vec2, ad.Vec2, int) {
+	a, b := ad.V2(v[off], v[off+1]), ad.V2(v[off+2], v[off+3])
+	return b.Sub(a), a, 4
+}
+func (o lineAxisOperand) operandEntity() Entity { return o.L }
+func (o lineAxisOperand) axisMajor() bool       { return false }
+func (o lineAxisOperand) remap(m *cloneMap) (AxisOperand, bool) {
+	nl, ok := m.line(o.L)
+	if !ok {
+		return nil, false
+	}
+	return LineAxis(nl), true
+}
+
+// ellipseAxisOperand is an ellipse's major/minor axis: a fixed direction anchored at the centre.
+type ellipseAxisOperand struct {
+	E     ellipseAxisSource
+	major bool
+}
+
+// EllipseAxisOf wraps an entity's major (or minor) axis as an operand, reporting ok=false when
+// the entity is not an ellipse or elliptical arc.
+func EllipseAxisOf(e Entity, major bool) (AxisOperand, bool) {
+	src, ok := e.(ellipseAxisSource)
+	if !ok {
+		return nil, false
+	}
+	return ellipseAxisOperand{E: src, major: major}, true
+}
+
+func (o ellipseAxisOperand) dirVars() []*math.Scalar {
+	c := o.E.axisCentre()
+	return []*math.Scalar{&c.X, &c.Y}
+}
+func (o ellipseAxisOperand) readDir(v []ad.Number, off int) (ad.Vec2, ad.Vec2, int) {
+	// The centre is a DOF (the anchor for collinear); the axis direction is a live constant.
+	centre := ad.V2(v[off], v[off+1])
+	d := o.E.axisVector(o.major)
+	return ad.V2(ad.Const(float64(d.X)), ad.Const(float64(d.Y))), centre, 2
+}
+func (o ellipseAxisOperand) operandEntity() Entity { return o.E }
+func (o ellipseAxisOperand) axisMajor() bool       { return o.major }
+func (o ellipseAxisOperand) remap(m *cloneMap) (AxisOperand, bool) {
+	ne, ok := m.entity(o.E)
+	if !ok {
+		return nil, false
+	}
+	return EllipseAxisOf(ne, o.major)
+}
+
+// axisRelation is the geometric relation an [AxisRelationConstraint] enforces between its two
+// operand directions.
+type axisRelation int
+
+const (
+	axisParallel axisRelation = iota
+	axisPerpendicular
+	axisCollinear
+)
+
+// AxisRelationConstraint aligns two direction operands — at least one an ellipse axis — parallel,
+// perpendicular, or collinear (#1879). An ellipse operand is a fixed directional reference (its
+// orientation is not a solver DOF), so it is the line operand that the solver moves to satisfy
+// the relation; two fixed ellipse axes only hold when already so related.
+type AxisRelationConstraint struct {
+	constraintBase
+	a, b     AxisOperand
+	relation axisRelation
+	kind     ConstraintKind
+}
+
+// AddEllipseParallel / AddEllipsePerpendicular / AddEllipseCollinear relate two operands, at
+// least one an ellipse axis (the other typically a line the solver aligns to it).
+func (g *GeometricConstraints) AddEllipseParallel(a, b AxisOperand) *AxisRelationConstraint {
+	return g.addAxisRelation(a, b, axisParallel, EllipseParallelKind)
+}
+func (g *GeometricConstraints) AddEllipsePerpendicular(a, b AxisOperand) *AxisRelationConstraint {
+	return g.addAxisRelation(a, b, axisPerpendicular, EllipsePerpendicularKind)
+}
+func (g *GeometricConstraints) AddEllipseCollinear(a, b AxisOperand) *AxisRelationConstraint {
+	return g.addAxisRelation(a, b, axisCollinear, EllipseCollinearKind)
+}
+
+func (g *GeometricConstraints) addAxisRelation(a, b AxisOperand, rel axisRelation, kind ConstraintKind) *AxisRelationConstraint {
+	c := &AxisRelationConstraint{constraintBase: newConstraint(), a: a, b: b, relation: rel, kind: kind}
+	g.add(c)
+	return c
+}
+
+// residualAD: the two operand directions are parallel (sine of the angle zero), perpendicular
+// (cosine zero), or collinear (parallel AND the second anchor on the first operand's line). All
+// three primitives are scale-invariant, so a fixed ellipse-axis direction of arbitrary length is
+// fine (#1418, #1879).
+func (c *AxisRelationConstraint) residualAD(v []ad.Number) []ad.Number {
+	da, aa, n := c.a.readDir(v, 0)
+	db, ab, _ := c.b.readDir(v, n)
+	switch c.relation {
+	case axisPerpendicular:
+		return []ad.Number{adCosAngle(da, db)}
+	case axisCollinear:
+		return []ad.Number{adSineAngle(da, db), adSignedPerpDistance(da, ab.Sub(aa))}
+	default: // axisParallel
+		return []ad.Number{adSineAngle(da, db)}
+	}
+}
+func (c *AxisRelationConstraint) Residuals() []float64 {
+	return adResiduals(c.Variables(), c.residualAD)
+}
+func (c *AxisRelationConstraint) Partials() [][]float64 {
+	return adPartials(c.Variables(), c.residualAD)
+}
+func (c *AxisRelationConstraint) Variables() []*math.Scalar {
+	return append(c.a.dirVars(), c.b.dirVars()...)
+}

--- a/model/sketch/constraints_ellipse_axis_test.go
+++ b/model/sketch/constraints_ellipse_axis_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// dirParallelTo reports whether line l's direction is parallel to (vx,vy) within tol (zero cross
+// product).
+func dirParallelTo(l *Line, vx, vy, tol float64) bool {
+	d := l.Direction()
+	cross := float64(d.X)*vy - float64(d.Y)*vx
+	return cross < tol && cross > -tol
+}
+
+func mustEllipseOp(t *testing.T, e *Ellipse, major bool) AxisOperand {
+	t.Helper()
+	op, ok := EllipseAxisOf(e, major)
+	if !ok {
+		t.Fatal("ellipse is not an axis source")
+	}
+	return op
+}
+
+// TestEllipseParallelAlignsLineToMajorAxis: parallel(line, ellipse-major) rotates the line to
+// the ellipse's major-axis direction; the minor selector uses the perpendicular axis (#1879).
+func TestEllipseParallelAlignsLineToMajorAxis(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		major        bool
+		wantX, wantY float64
+	}{
+		{"major", true, 1, 0},  // major axis along +X
+		{"minor", false, 0, 1}, // minor axis is its left perpendicular, +Y
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewSketches().Add(XYPlane())
+			g := s.GeometricConstraints()
+			ell := s.Ellipses().Add(math.P2(0, 0), math.V2(1, 0), 3, 1)
+			l := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 1)) // slanted
+			g.AddEllipseParallel(LineAxis(l), mustEllipseOp(t, ell, tc.major))
+			g.AddFix(l.A)
+			if r := s.Solve(); !r.Converged {
+				t.Fatalf("solve did not converge: %+v", r)
+			}
+			if !dirParallelTo(l, tc.wantX, tc.wantY, solveTol) {
+				t.Errorf("line direction = %v, want parallel to (%v,%v)", l.Direction(), tc.wantX, tc.wantY)
+			}
+		})
+	}
+}
+
+// TestEllipsePerpendicularAlignsLine: perpendicular(line, ellipse-major) makes the line
+// perpendicular to the major axis (#1879).
+func TestEllipsePerpendicularAlignsLine(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	g := s.GeometricConstraints()
+	ell := s.Ellipses().Add(math.P2(0, 0), math.V2(1, 0), 3, 1)
+	l := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 1))
+	g.AddEllipsePerpendicular(LineAxis(l), mustEllipseOp(t, ell, true))
+	g.AddFix(l.A)
+	if r := s.Solve(); !r.Converged {
+		t.Fatalf("solve did not converge: %+v", r)
+	}
+	// Perpendicular to +X major axis → the line is vertical, parallel to (0,1).
+	if !dirParallelTo(l, 0, 1, solveTol) {
+		t.Errorf("line direction = %v, want vertical (perpendicular to the major axis)", l.Direction())
+	}
+}
+
+// TestEllipseParallelRotatedEllipse grounds the axis direction against a rotated ellipse (major
+// axis at 45°), so the residual is not accidentally satisfied by an axis-aligned ellipse (#1879).
+func TestEllipseParallelRotatedEllipse(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	g := s.GeometricConstraints()
+	ell := s.Ellipses().Add(math.P2(0, 0), math.V2(1, 1), 3, 1) // major axis along (1,1)
+	l := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0)) // horizontal
+	g.AddEllipseParallel(LineAxis(l), mustEllipseOp(t, ell, true))
+	g.AddFix(l.A)
+	if r := s.Solve(); !r.Converged {
+		t.Fatalf("solve did not converge: %+v", r)
+	}
+	if !dirParallelTo(l, 1, 1, solveTol) {
+		t.Errorf("line direction = %v, want parallel to the 45° major axis (1,1)", l.Direction())
+	}
+}
+
+// TestEllipseCollinearThroughCentre: collinear(line, ellipse-major) makes the line parallel to
+// the major axis AND pass through the ellipse centre (#1879).
+func TestEllipseCollinearThroughCentre(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	g := s.GeometricConstraints()
+	ell := s.Ellipses().Add(math.P2(0, 0), math.V2(1, 0), 3, 1)
+	l := s.Lines().AddByTwoPoints(math.P2(0, 2), math.P2(4, 3)) // off the X axis, slanted
+	g.AddEllipseCollinear(LineAxis(l), mustEllipseOp(t, ell, true))
+	g.AddFix(ell.Center) // pin the ellipse (its centre is a DOF) so the line is what moves
+	if r := s.Solve(); !r.Converged {
+		t.Fatalf("solve did not converge: %+v", r)
+	}
+	if !dirParallelTo(l, 1, 0, solveTol) {
+		t.Errorf("collinear line direction = %v, want horizontal", l.Direction())
+	}
+	// On the major-axis line through the origin ⇒ both endpoints at Y≈0.
+	if y0, y1 := float64(l.A.Position().Y), float64(l.B.Position().Y); y0 > solveTol || y0 < -solveTol || y1 > solveTol || y1 < -solveTol {
+		t.Errorf("collinear endpoints Y = %v, %v, want on the X axis (0)", y0, y1)
+	}
+}
+
+// TestEllipseAxisOfRejectsNonEllipse: a line is not an ellipse-axis source (#1879).
+func TestEllipseAxisOfRejectsNonEllipse(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	l := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(1, 0))
+	if _, ok := EllipseAxisOf(l, true); ok {
+		t.Error("a line must not resolve as an ellipse-axis operand")
+	}
+}

--- a/model/sketch/copy_constraints.go
+++ b/model/sketch/copy_constraints.go
@@ -53,6 +53,13 @@ func (m *cloneMap) arc(a *Arc) (*Arc, bool) {
 	return na, ok
 }
 
+// entity resolves any source entity to its clone — the generic lookup an axis-relation operand
+// uses to remap a line or ellipse without knowing which it is (#1879).
+func (m *cloneMap) entity(e Entity) (Entity, bool) {
+	c, ok := m.entities[e]
+	return c, ok
+}
+
 func (m *cloneMap) ellipse(e *Ellipse) (*Ellipse, bool) {
 	c, ok := m.entities[e]
 	if !ok {

--- a/model/sketch/copy_constraints_registry.go
+++ b/model/sketch/copy_constraints_registry.go
@@ -55,6 +55,9 @@ var constraintCarriers2D = map[ConstraintKind]constraintCarrier{
 	LineSymmetryKind:         carrier(carryLineSymmetry),
 	CircularSymmetryKind:     carrier(carryCircularSymmetry),
 	ArcMidpointKind:          carrier(carryArcMidpoint),
+	EllipseParallelKind:      carrier(carryEllipseAxis),
+	EllipsePerpendicularKind: carrier(carryEllipseAxis),
+	EllipseCollinearKind:     carrier(carryEllipseAxis),
 	FixKind:                  carrier(carryFixKind),
 	SmoothKind:               carrier(carrySmooth),
 	GroundKind:               carrier(carryGround),
@@ -204,6 +207,18 @@ func carryCircularSymmetry(g *GeometricConstraints, v *CircularSymmetryConstrain
 		return false
 	}
 	g.AddCircularSymmetry(c1, c2, about)
+	return true
+}
+
+// carryEllipseAxis remaps both operands of an ellipse-axis relation and re-adds it preserving
+// the relation and kind (a world-axis operand of a horizontal/vertical form always remaps) (#1879).
+func carryEllipseAxis(g *GeometricConstraints, v *AxisRelationConstraint, m *cloneMap) bool {
+	a, ok1 := v.a.remap(m)
+	b, ok2 := v.b.remap(m)
+	if !ok1 || !ok2 {
+		return false
+	}
+	g.addAxisRelation(a, b, v.relation, v.kind)
 	return true
 }
 

--- a/model/sketch/copy_constraints_test.go
+++ b/model/sketch/copy_constraints_test.go
@@ -123,6 +123,11 @@ func TestCopyCarriesEveryConstraintAndDimensionKind(t *testing.T) {
 	g.AddCircularTangent(c1, c2)
 	g.AddTangent(l1, c1)
 	g.AddSymmetry(pa, pb, l3)
+	// Ellipse-axis relations (#1879): a line aligned to the ellipse's major/minor axis.
+	eop := func(major bool) AxisOperand { op, _ := EllipseAxisOf(ell, major); return op }
+	g.AddEllipseParallel(eop(true), LineAxis(l1))
+	g.AddEllipsePerpendicular(eop(false), LineAxis(l2))
+	g.AddEllipseCollinear(eop(true), LineAxis(l3))
 	g.AddFix(pa)
 
 	// The six kinds the pre-#1637 switch silently dropped (TextBoxAnchor is the

--- a/model/sketch/serialize.go
+++ b/model/sketch/serialize.go
@@ -137,6 +137,9 @@ type ConstraintData struct {
 	Points []int   `yaml:"points,omitempty"`
 	Curves []int   `yaml:"curves,omitempty"`
 	Value  float64 `yaml:"value,omitempty"` // offset constraint's signed distance
+	// AxisMajor is the per-operand major-axis flag of an ellipse-axis constraint (#1879), one
+	// entry per Curves operand; absent for every other kind.
+	AxisMajor []bool `yaml:"axisMajor,omitempty"`
 	// Custom (add-in tag) constraints carry their owner and record name
 	// (M06-F11, #626).
 	ClientID string `yaml:"clientId,omitempty"`

--- a/model/sketch/serialize_codecs_constraints.go
+++ b/model/sketch/serialize_codecs_constraints.go
@@ -15,6 +15,7 @@ func init() {
 	registerTwoCurveConstraintCodecs()
 	registerMixedConstraintCodecs()
 	registerEntitySymmetryConstraintCodecs()
+	registerEllipseAxisConstraintCodecs()
 	registerTagConstraintCodecs()
 }
 

--- a/model/sketch/serialize_codecs_ellipse_axis.go
+++ b/model/sketch/serialize_codecs_ellipse_axis.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import "fmt"
+
+// Codecs for the ellipse-axis relation constraints (#1879). Each stores its operand entity ids
+// in Curves and their per-operand major-axis flags in AxisMajor (whether an operand is an
+// ellipse is re-derived from the resolved entity's type); the horizontal/vertical forms store
+// only the ellipse operand — the world axis is implied by the kind.
+
+// registerEllipseAxisConstraintCodecs is called from the constraint-codec init() (not its own,
+// to keep registration off the import-linkage path — archguard B6/#1617).
+func registerEllipseAxisConstraintCodecs() {
+	registerConstraintCodec(EllipseParallelKind, axisRelationCodec(func(g *GeometricConstraints, a, b AxisOperand) {
+		g.AddEllipseParallel(a, b)
+	}))
+	registerConstraintCodec(EllipsePerpendicularKind, axisRelationCodec(func(g *GeometricConstraints, a, b AxisOperand) {
+		g.AddEllipsePerpendicular(a, b)
+	}))
+	registerConstraintCodec(EllipseCollinearKind, axisRelationCodec(func(g *GeometricConstraints, a, b AxisOperand) {
+		g.AddEllipseCollinear(a, b)
+	}))
+}
+
+// encodeAxisOperands stores each real operand's entity id + major flag (a world axis names no
+// entity and is skipped — the kind implies it).
+func encodeAxisOperands(c Constraint) (ConstraintData, error) {
+	v := c.(*AxisRelationConstraint)
+	var curves []int
+	var majors []bool
+	for _, op := range []AxisOperand{v.a, v.b} {
+		if e := op.operandEntity(); e != nil {
+			curves = append(curves, int(e.EntityID()))
+			majors = append(majors, op.axisMajor())
+		}
+	}
+	return ConstraintData{Curves: curves, AxisMajor: majors}, nil
+}
+
+// axisRelationCodec pairs a two-operand ellipse-axis relation with its factory.
+func axisRelationCodec(add func(*GeometricConstraints, AxisOperand, AxisOperand)) constraintCodec {
+	return constraintCodec{
+		encode: encodeAxisOperands,
+		decode: func(r *sketchRestorer, cd ConstraintData) error {
+			a, err := r.axisOperand(cd, 0)
+			if err != nil {
+				return err
+			}
+			b, err := r.axisOperand(cd, 1)
+			if err != nil {
+				return err
+			}
+			add(r.s.geomCons, a, b)
+			return nil
+		},
+	}
+}
+
+// axisOperand resolves the i-th stored operand back to a line or ellipse-axis operand, reading
+// its major flag from AxisMajor.
+func (r *sketchRestorer) axisOperand(cd ConstraintData, i int) (AxisOperand, error) {
+	e, err := r.entity(cd.Curves, i)
+	if err != nil {
+		return nil, err
+	}
+	major := i < len(cd.AxisMajor) && cd.AxisMajor[i]
+	if op, ok := EllipseAxisOf(e, major); ok {
+		return op, nil
+	}
+	l, ok := e.(*Line)
+	if !ok {
+		return nil, fmt.Errorf("axis-relation operand %d (%T) is neither a line nor an ellipse", i, e)
+	}
+	return LineAxis(l), nil
+}

--- a/model/sketch/serialize_constraint_registry_test.go
+++ b/model/sketch/serialize_constraint_registry_test.go
@@ -29,6 +29,7 @@ var (
 		ParallelKind, PerpendicularKind, CollinearKind, EqualLengthKind,
 		ConcentricKind, EqualRadiusKind, CircularTangentKind, TangentKind,
 		SymmetryKind, LineSymmetryKind, CircularSymmetryKind, ArcMidpointKind,
+		EllipseParallelKind, EllipsePerpendicularKind, EllipseCollinearKind,
 		FixKind, SmoothKind,
 		GroundKind, OffsetKind, PatternLinkKind, TextBoxAnchorKind, CustomKind,
 	}
@@ -152,6 +153,12 @@ func populateEvery2DConstraintKind(s *Sketch) {
 	g.AddLineSymmetry(sl1, sl2, axis)
 	g.AddCircularSymmetry(c1, c2, axis)
 	g.AddMidpointToArc(s.Points().Add(math.P2(0, 6)), arc)
+	// Ellipse-axis relations (#1879): one instance of each kind, mixing major/minor selectors.
+	ell := s.Ellipses().Add(math.P2(20, 0), math.V2(1, 0), 3, 1)
+	ellOp := func(major bool) AxisOperand { op, _ := EllipseAxisOf(ell, major); return op }
+	g.AddEllipseParallel(ellOp(true), LineAxis(l1))
+	g.AddEllipsePerpendicular(ellOp(false), LineAxis(l2))
+	g.AddEllipseCollinear(ellOp(true), LineAxis(l1))
 	g.AddFix(l1.A)
 	g.AddSmooth(l1, arc, l1.B, arc.Start)
 	g.AddGroundPoints(l2.A, l2.B)


### PR DESCRIPTION
Addresses #1879 (parallel/perpendicular/collinear). Final host PR of Sketch2D Batch A; uses API v0.131.0's `UseEllipse*MajorAxis` flags.

## What this does
`parallel` / `perpendicular` / `collinear` now accept an **ellipse** (or elliptical-arc) operand, its constrained direction being the **major** or **minor** axis, selected per operand by `UseEllipseOneMajorAxis` / `UseEllipseTwoMajorAxis` (default major — Inventor's default). This is the issue's primary case: e.g. `parallel(line, ellipse, useEllipseTwoMajorAxis=false)` aligns the line to the ellipse's minor axis.

An ellipse's axis is a **fixed directional reference** (its orientation is not a solver DOF — only centre + radii are, per `solve_sketch.go`), so the solver moves the **line** operand to align to it. A single `AxisRelationConstraint` with a small sealed `AxisOperand` abstraction (line direction from its endpoints; ellipse major/minor axis as a live constant anchored at the centre) covers all three relations; the direction math reuses the existing scale-invariant `adSineAngle`/`adCosAngle`/`adSignedPerpDistance` primitives.

## Persistence & plumbing
Three persisted kinds `ellipseParallel/Perpendicular/Collinear` enumerate as the plain wire `parallel/perpendicular/collinear`, with the per-operand major flags in a new additive `ConstraintData.axisMajor` (which operand is an ellipse is re-derived from the resolved entity type). Full codec + copy carrier + round-trip closure; the router detects an ellipse operand and threads the flags, falling back to the plain two-line relation otherwise. Codec registration is routed through the existing constraint `init()` (archguard B6).

## Scope note (AC2 deferred)
`horizontal`/`vertical` of an **ellipse axis** is **not** in this PR: making an ellipse's axis horizontal requires *rotating the ellipse*, i.e. an ellipse-orientation solver DOF the model does not yet expose (adding it changes the DOF count of every ellipse sketch — a separate, larger change). A constraint only satisfiable when the ellipse is already aligned would be worse than none, so it is left for a follow-up that introduces that DOF. #1879 should stay open for that remainder.

## Tests
- Model (oracle-grounded): a line aligns to the ellipse's major/minor axis under parallel; perpendicular makes it normal to the axis; a **rotated** (45°) ellipse grounds the direction so an axis-aligned ellipse can't pass by accident; collinear also pins the line onto the axis line through the centre.
- Router: parallel/perpendicular over the wire with an ellipse operand solve to the right direction; `UseEllipseTwoMajorAxis=false` selects the minor axis; two-line parallel is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)