### PR TITLE
Fix camera-orbit FPS (curved-face pick memo) + analytic curved revolve & grooved-conical washer

### DIFF
--- a/app/raypicker_perf_test.go
+++ b/app/raypicker_perf_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/scene"
+)
+
+// TestRayPickerCurvedSceneStaysCheapPerFrame is the integration-level fence for the recurring
+// hover-pick starvation: the viewport runs RayPicker.Pick EVERY frame while orbiting, and a scene of
+// curved (analytic-sphere) bodies — the self-aligning bearing's 16 balls — must not re-tessellate
+// every face every frame. This drives the whole pick chain (Pick → nearestFace → RayCastFaces), so a
+// regression that bypasses the face pick-tessellation memo (in the picker, not just kernel/ops) also
+// trips it. A re-tessellating pick allocates ~150/op PER curved body; the memoized path is bounded.
+func TestRayPickerCurvedSceneStaysCheapPerFrame(t *testing.T) {
+	const balls = 16
+	bodies := make([]*topo.Body, 0, balls)
+	for i := 0; i < balls; i++ {
+		// Stagger the balls along x so several sit under the pick ray's neighbourhood, like the
+		// bearing's ball complement — the picker still ray-tests them all every frame.
+		b, err := brep.SolidSphere(math.V3(float64(i)*0.1, 0, 0).AsPoint(), 1.0, "ball")
+		if err != nil {
+			t.Fatalf("ball %d: %v", i, err)
+		}
+		bodies = append(bodies, b)
+	}
+	cam := scene.NewCamera(400, 400)
+	cam.Eye = math.P3(0, 0, 20)
+	cam.Target = math.P3(0, 0, 0)
+	cam.Up = math.V3(0, 1, 0)
+	picker := NewRayPicker(cam, func() []*topo.Body { return bodies })
+	filter := NewSelectionFilter(SelectFace)
+
+	// Warm every ball's memo (one orbit frame), then measure the steady-state per-frame pick cost.
+	if _, ok := picker.Pick(200, 200, filter); !ok {
+		t.Fatal("warm-up pick missed the ball complement")
+	}
+	const ceiling = 64 // memoized: small per-body slices; re-tessellation would be ~150 × curved bodies
+	avg := testing.AllocsPerRun(100, func() {
+		picker.Pick(200, 200, filter)
+	})
+	if avg > ceiling {
+		t.Fatalf("RayPicker.Pick over %d curved bodies allocates %.0f/op after warm-up (ceiling %d): the "+
+			"pick-tessellation memo is not holding — every orbit frame re-tessellates the balls", balls, avg, ceiling)
+	}
+}

--- a/head/cmd/perfbench/main.go
+++ b/head/cmd/perfbench/main.go
@@ -22,6 +22,7 @@ import (
 
 	"oblikovati.org/app"
 	"oblikovati.org/head/internal/native"
+	"oblikovati.org/kernel/topo"
 	"oblikovati.org/model/benchgen"
 	"oblikovati.org/model/doc"
 	"oblikovati.org/perf/benchprof"
@@ -47,14 +48,16 @@ func main() {
 	png := flag.String("png", "", "save a viewport PNG after the orbit (visual confirmation)")
 	frames := flag.Int("frames", 120, "frames in the 360° orbit scenario")
 	uiIters := flag.Int("ui-iters", 200, "model-tree builds in the UI stress scenario")
+	hoverpick := flag.Bool("hoverpick", false, "fire a viewport-centre hover-pick each orbit frame — the "+
+		"interactive per-frame cost the live head pays (guards the pick-tessellation memo against regression)")
 	flag.Parse()
-	if err := run(*profileName, *assembly, *out, *png, *frames, *uiIters); err != nil {
+	if err := run(*profileName, *assembly, *out, *png, *frames, *uiIters, *hoverpick); err != nil {
 		fmt.Fprintln(os.Stderr, "perfbench:", err)
 		os.Exit(1)
 	}
 }
 
-func run(profileName, assembly, out, png string, frames, uiIters int) error {
+func run(profileName, assembly, out, png string, frames, uiIters int, hoverpick bool) error {
 	s := app.NewSessionWithStore(persistence.NewPackageStore())
 	res := Result{Profile: profileName, Source: "generated"}
 	cold, err := loadOrGenerate(s, profileName, assembly, &res)
@@ -71,11 +74,7 @@ func run(profileName, assembly, out, png string, frames, uiIters int) error {
 	win.InitViewport()
 	res.ColdLoad.FirstFrameMs = firstFrameUpload(win, s)
 
-	s.FitView()
-	res.Orbit = orbitScenario(win, s, frames)
-	res.UIStress = uiStressScenario(s, uiIters)
-	res.Propagation = propagationScenario(s)
-
+	runScenarios(win, s, &res, frames, uiIters, hoverpick)
 	if png != "" {
 		drawFrame(win, s)
 		if err := win.SaveViewportPNG(png); err != nil {
@@ -84,6 +83,18 @@ func run(profileName, assembly, out, png string, frames, uiIters int) error {
 		fmt.Println("wrote", png)
 	}
 	return report(res, out)
+}
+
+// runScenarios frames the scene and runs the three timed scenarios into res. With hoverpick set it
+// installs the ray picker first so the orbit pays the live head's per-frame hover-pick cost.
+func runScenarios(win *native.Window, s *app.Session, res *Result, frames, uiIters int, hoverpick bool) {
+	s.FitView()
+	if hoverpick {
+		installBenchPicker(s)
+	}
+	res.Orbit = orbitScenario(win, s, frames, hoverpick)
+	res.UIStress = uiStressScenario(s, uiIters)
+	res.Propagation = propagationScenario(s)
 }
 
 // loadOrGenerate fills the session with the assembly — opening the saved root (the true
@@ -122,6 +133,16 @@ func fillSession(s *app.Session, profileName, assembly string, res *Result) (*do
 	}
 	root, _, err := benchgen.Generate(s.Workspace(), "perfbench", profile)
 	return root, err
+}
+
+// installBenchPicker gives the session the same ray picker the live head uses (minus the sketch/
+// work-geometry providers a static orbit never queries), so orbitScenario can pay the real per-frame
+// hover-pick cost. The assembly BVH (RayPickBodies) supplies candidates; the base body list is the
+// part-only fallback, unused for the generated assembly. SetCamera (called each orbit frame) keeps
+// the picker's view current.
+func installBenchPicker(s *app.Session) {
+	s.SetPicker(app.NewRayPicker(s.Camera(), func() []*topo.Body { return nil }).
+		WithRayBodies(s.RayPickBodies))
 }
 
 // firstFrameUpload times the first rendered frame — the cold vertex/index/instance

--- a/head/cmd/perfbench/scenarios.go
+++ b/head/cmd/perfbench/scenarios.go
@@ -62,7 +62,7 @@ type OrbitResult struct {
 // frame per step through the real DrawChrome path and recording each frame's wall time —
 // the ViewCube-orbit stress that exercises command-buffer recording and per-instance frustum
 // culling (M34-F1: as the view turns, the off-screen part of the car is dropped before upload).
-func orbitScenario(win *native.Window, s *app.Session, frames int) OrbitResult {
+func orbitScenario(win *native.Window, s *app.Session, frames int, hoverpick bool) OrbitResult {
 	if frames < 2 {
 		frames = 2
 	}
@@ -73,10 +73,25 @@ func orbitScenario(win *native.Window, s *app.Session, frames int) OrbitResult {
 		s.SetCamera(s.Camera().Orbit(yaw, 0))
 		t0 := time.Now()
 		drawFrame(win, s)
+		if hoverpick {
+			frameHoverPick(s) // the live head's per-frame viewport-centre hover-pick (RayCastFaces over the scene)
+		}
 		times = append(times, msSince(t0))
 	}
 	sum, _ := prof.Stop()
 	return orbitStats(times, sum)
+}
+
+// frameHoverPick reproduces the live head's per-frame hover-pick: a ray through the viewport centre
+// against the scene. It is what turns an orbit slow when picking re-tessellates curved faces every
+// frame; measured here it guards the pick-tessellation memo (ops.pickFaceMesh) at scene scale. The
+// camera pixel size is set by DrawChrome's updateViewportCamera on the frame just drawn.
+func frameHoverPick(s *app.Session) {
+	cam := s.Camera()
+	if cam.Width <= 0 || cam.Height <= 0 {
+		return
+	}
+	s.PickAt(float64(cam.Width)/2, float64(cam.Height)/2, app.NewSelectionFilter())
 }
 
 // uiStressScenario measures the per-frame model-browser tree the UI rebuilds every frame

--- a/kernel/brep/revolution.go
+++ b/kernel/brep/revolution.go
@@ -134,24 +134,49 @@ func arcCenterOnAxis(center math.Point2, axisTol float64) bool {
 }
 
 // revolveArcsAnalytic reports whether every ARC edge of the meridian revolves to a surface this
-// builder emits analytically: a torus (centre off-axis) or a spherical CAP (centre on-axis with
-// EXACTLY one endpoint on the axis, i.e. the arc runs from a rim latitude to the pole). A sphere ZONE
-// (centre on-axis, both endpoints off-axis) needs a framed sphere parameterization we do not yet
-// build, and a pole-to-pole meridian is degenerate; both return false so the caller keeps the faceted
-// revolve (no regression — today every curved-meridian revolve facets).
+// builder emits analytically: a torus (centre off-axis), a spherical CAP (centre on-axis, EXACTLY one
+// endpoint on the axis — a rim latitude to the pole), or a spherical ZONE (centre on-axis, BOTH
+// endpoints off-axis on the same side of the equator — a latitude band, addRevolutionSphereZone). It
+// still declines two on-axis cases that have no single-sphere-patch parameterization: a pole-to-pole
+// meridian (both endpoints on the axis — a whole sphere; SolidSphere is that route) and a zone whose
+// endpoints STRADDLE the equator (r not monotone in colatitude); both return false so the caller keeps
+// the faceted revolve.
 func revolveArcsAnalytic(verts []RevolveVertex, axisTol float64) bool {
 	n := len(verts)
 	for i := range verts {
 		if verts[i].ArcCenter == nil || !arcCenterOnAxis(*verts[i].ArcCenter, axisTol) {
 			continue // a straight edge or an off-axis (torus) arc — both handled
 		}
-		onPrev := float64(verts[(i-1+n)%n].P.X) <= axisTol
-		onCur := float64(verts[i].P.X) <= axisTol
-		if onPrev == onCur {
-			return false // zone (neither endpoint on-axis) or pole-to-pole (both): not analytic yet
+		prev := verts[(i-1+n)%n].P
+		cur := verts[i].P
+		onPrev := float64(prev.X) <= axisTol
+		onCur := float64(cur.X) <= axisTol
+		if onPrev != onCur {
+			continue // exactly one endpoint on the axis: a spherical cap — handled
+		}
+		if onPrev { // both endpoints on the axis: a pole-to-pole meridian — a whole sphere, declined here
+			return false
+		}
+		if !sphereZoneAnalytic(prev, cur, *verts[i].ArcCenter, axisTol) {
+			return false // an equator-straddling zone: not a single monotone-colatitude band yet
 		}
 	}
 	return true
+}
+
+// sphereZoneAnalytic reports whether an on-axis-centre arc between two OFF-axis endpoints revolves to a
+// single analytic spherical ZONE the builder emits (addRevolutionSphereZone). The zone is well defined
+// only when both rims sit on the SAME side of the equator (the latitude plane z=centre.Y): colatitude is
+// then monotone along the arc and each rim is a proper latitude circle. Endpoints straddling the equator
+// (opposite signs) or a rim ON it (|Δz| ≤ axisTol, radius = sphere radius, a tangent equator) fall back to
+// the faceted revolve. axisTol is the meridian-relative coincidence scale (res.Plane()).
+func sphereZoneAnalytic(prev, cur, center math.Point2, axisTol float64) bool {
+	dzPrev := float64(prev.Y - center.Y)
+	dzCur := float64(cur.Y - center.Y)
+	if stdmath.Abs(dzPrev) <= axisTol || stdmath.Abs(dzCur) <= axisTol {
+		return false // a rim on the equator: tangent to the neighbouring cylinder, degenerate latitude
+	}
+	return (dzPrev > 0) == (dzCur > 0) // both above OR both below the equator: same-side band
 }
 
 // revNode is one meridian vertex realized in 3D: the circle of revolution it traces (nil when the
@@ -176,10 +201,13 @@ func buildRevolution(axisOrigin math.Point3, a, ref math.UnitVector3, verts []Re
 	for i := range verts {
 		j := (i + 1) % len(verts)
 		if verts[j].ArcCenter != nil {
-			if arcCenterOnAxis(*verts[j].ArcCenter, res.Plane()) {
-				addRevolutionSphereCap(bld, nodes[i], nodes[j], *verts[j].ArcCenter, axisOrigin, a, feat, i)
-			} else {
+			switch {
+			case !arcCenterOnAxis(*verts[j].ArcCenter, res.Plane()):
 				addRevolutionTorus(bld, nodes[i], nodes[j], *verts[j].ArcCenter, axisOrigin, a, ref, feat, i)
+			case nodes[i].circle == nil || nodes[j].circle == nil:
+				addRevolutionSphereCap(bld, nodes[i], nodes[j], *verts[j].ArcCenter, axisOrigin, a, feat, i)
+			default:
+				addRevolutionSphereZone(bld, nodes[i], nodes[j], *verts[j].ArcCenter, axisOrigin, a, ref, feat, i)
 			}
 			continue
 		}
@@ -365,6 +393,37 @@ func addRevolutionSphereCap(bld *topo.Builder, ni, nj revNode, arcCenter math.Po
 		return
 	}
 	bld.AddReversedFace(sph, revLin(feat, "cap", i), loop)
+}
+
+// addRevolutionSphereZone adds the analytic spherical ZONE face for an ARC meridian edge whose centre
+// lies ON the axis but whose BOTH endpoints are OFF the axis: the arc is a latitude band of the sphere
+// centred at the revolved arc centre (radius = the arc radius). Topologically it is the torus case — two
+// shared rim circles bridged by the arc seam traversed twice — but on a geom.Sphere, so the sphere-zone
+// tessellator sweeps latitude rings between the two rims with the sphere's true bulge. This is the sphere
+// analogue of addRevolutionTorus; caller guarantees a same-side (non-equator-crossing) zone via
+// sphereZoneAnalytic. (self-aligning thrust seat #54; #129 curved-meridian follow-up.)
+func addRevolutionSphereZone(bld *topo.Builder, ni, nj revNode, arcCenter math.Point2, axisOrigin math.Point3, a, ref math.UnitVector3, feat string, i int) {
+	rc, zc := float64(arcCenter.X), float64(arcCenter.Y)
+	zi := float64(axisOrigin.VectorTo(ni.center).Dot(a.AsVector()))
+	zj := float64(axisOrigin.VectorTo(nj.center).Dot(a.AsVector()))
+	radius := stdmath.Hypot(ni.r-rc, zi-zc) // sphere radius = arc radius (centre → rim, in (r,z))
+	center := axisOrigin.TranslateBy(a.AsVector().Scale(math.Scalar(zc)))
+	sph, err := geom.NewSphere(center, radius)
+	if err != nil {
+		return
+	}
+	mid := arcMidpoint(axisOrigin, a, ref, arcCenter, radius, ni.r, zi, nj.r, zj)
+	seamArc, err := geom.Arc3dByThreePoints(ni.v.Point(), mid, nj.v.Point())
+	if err != nil {
+		return
+	}
+	seam := bld.AddEdge(seamArc, ni.v, nj.v, revLin(feat, "zone-seam", i))
+	loop := topo.OuterLoop(topo.Fwd(ni.circle), topo.Fwd(seam), topo.Rev(nj.circle), topo.Rev(seam))
+	if axialGap(ni, nj, a) > 0 { // dz>0: convex band faces outward (AddFace), like cylinder/cone/torus
+		bld.AddFace(sph, revLin(feat, "zone", i), loop)
+		return
+	}
+	bld.AddReversedFace(sph, revLin(feat, "zone", i), loop)
 }
 
 // arcMidpoint returns the 3D point at the middle of the meridian arc (centre (rc,zc) in (r,z),

--- a/kernel/brep/revolution_sphere_test.go
+++ b/kernel/brep/revolution_sphere_test.go
@@ -115,5 +115,105 @@ func TestSolidOfRevolutionSphereZoneFallsBack(t *testing.T) {
 	}
 }
 
+// TestSolidOfRevolutionSphereZoneConvex is the same-side spherical ZONE the self-aligning thrust seat
+// (#54) needs: an on-axis-centre arc whose BOTH endpoints are off the axis and on the SAME side of the
+// equator revolves to ONE analytic geom.Sphere band (addRevolutionSphereZone) — NOT the equator-
+// straddling zone that still falls back (TestSolidOfRevolutionSphereZoneFallsBack). Sphere centre (0,0)
+// radius 5; the band runs z∈[1,3] (both above the equator), so the arc bulges OUTWARD (dz>0 ⇒ AddFace).
+// The revolved region is {0≤r≤√(25−z²), 1≤z≤3}, volume π∫₁³(25−z²)dz.
+func TestSolidOfRevolutionSphereZoneConvex(t *testing.T) {
+	c := math.P2(0, 0) // sphere centre on the axis; both rims (z=1,z=3) sit above the equator z=0
+	rLo := stdmath.Sqrt(24)
+	zone := []brep.RevolveVertex{
+		{P: math.P2(0, 1)},
+		{P: math.P2(rLo, 1)},
+		{P: math.P2(4, 3), ArcCenter: &c}, // arc edge (√24,1)→(4,3) about (0,0): the outward-bulging band
+		{P: math.P2(0, 3)},
+	}
+	body, err := brep.SolidOfRevolutionMeridian(math.P3(0, 0, 0), math.V3(0, 0, 1), zone, "zone-convex")
+	if err != nil || body == nil {
+		t.Fatalf("SolidOfRevolutionMeridian(convex same-side zone) = (%v, %v), want an analytic body", body, err)
+	}
+	if res := ops.Validate(body); !res.Valid || !body.IsSolid() {
+		t.Fatalf("convex sphere-zone body is not a valid solid: %+v", res.Issues)
+	}
+	if got := sphereFaces(body); got != 1 {
+		t.Fatalf("convex sphere zone has %d sphere faces, want exactly 1 (of %d total)", got, len(body.Faces()))
+	}
+	want := stdmath.Pi * (25*3 - 27.0/3 - (25*1 - 1.0/3)) // π∫₁³(25−z²)dz
+	if got := vol(body); relErrF(got, want) > 0.02 {
+		t.Errorf("convex sphere-zone volume = %g, want ≈%g (π∫₁³(25−z²)dz)", got, want)
+	}
+}
+
+// TestSolidOfRevolutionSphereZoneConcave is the CONCAVE seat orientation: the sphere band is the INNER
+// wall of an annulus (material OUTSIDE the sphere), so the arc edge descends in z (dz<0 ⇒ AddReversedFace)
+// — the housing washer's outboard spherical seat. Same sphere (centre (0,0), R=5), band z∈[1,3], wrapped
+// by an r=6 cylinder. Revolved region {√(25−z²)≤r≤6, 1≤z≤3}, volume π∫₁³(36−(25−z²))dz = π∫₁³(11+z²)dz.
+func TestSolidOfRevolutionSphereZoneConcave(t *testing.T) {
+	c := math.P2(0, 0)
+	rLo := stdmath.Sqrt(24)
+	annulus := []brep.RevolveVertex{
+		{P: math.P2(rLo, 1), ArcCenter: &c}, // arc edge (4,3)→(√24,1) about (0,0): the inward-facing seat band
+		{P: math.P2(6, 1)},
+		{P: math.P2(6, 3)},
+		{P: math.P2(4, 3)},
+	}
+	body, err := brep.SolidOfRevolutionMeridian(math.P3(0, 0, 0), math.V3(0, 0, 1), annulus, "zone-concave")
+	if err != nil || body == nil {
+		t.Fatalf("SolidOfRevolutionMeridian(concave zone annulus) = (%v, %v), want an analytic body", body, err)
+	}
+	if res := ops.Validate(body); !res.Valid || !body.IsSolid() {
+		t.Fatalf("concave sphere-zone annulus is not a valid solid: %+v", res.Issues)
+	}
+	if got := sphereFaces(body); got != 1 {
+		t.Fatalf("concave sphere-zone annulus has %d sphere faces, want exactly 1 (of %d total)", got, len(body.Faces()))
+	}
+	want := stdmath.Pi * (11*3 + 27.0/3 - (11*1 + 1.0/3)) // π∫₁³(11+z²)dz
+	if got := vol(body); relErrF(got, want) > 0.02 {
+		t.Errorf("concave sphere-zone volume = %g, want ≈%g (π∫₁³(11+z²)dz)", got, want)
+	}
+}
+
+// TestSolidOfRevolutionPoleToPoleArcFallsBack pins the other declined on-axis case: an arc whose BOTH
+// endpoints lie ON the axis is a pole-to-pole meridian — a WHOLE sphere, which has no single-patch zone
+// parameterization here (SolidSphere is that route), so revolveArcsAnalytic returns false and the builder
+// falls back (nil,nil). Half-disc: axis segment (0,0)→(0,4) closed by the 180° arc back about (0,2).
+func TestSolidOfRevolutionPoleToPoleArcFallsBack(t *testing.T) {
+	c := math.P2(0, 2) // on the axis; the arc's two endpoints (0,0) and (0,4) are on the axis too
+	halfDisc := []brep.RevolveVertex{
+		{P: math.P2(0, 0)},
+		{P: math.P2(0, 4), ArcCenter: &c},
+	}
+	body, err := brep.SolidOfRevolutionMeridian(math.P3(0, 0, 0), math.V3(0, 0, 1), halfDisc, "pole-to-pole")
+	if err != nil {
+		t.Fatalf("SolidOfRevolutionMeridian(pole-to-pole arc) error = %v, want nil (clean fallback)", err)
+	}
+	if body != nil {
+		t.Fatalf("pole-to-pole arc built %d faces, want nil (a whole sphere ⇒ fall back)", len(body.Faces()))
+	}
+}
+
+// TestSolidOfRevolutionSphereZoneEquatorRimFallsBack covers the degenerate zone where one rim sits ON the
+// equator (|Δz|≈0): that rim's latitude circle is the sphere's own equator, tangent to the neighbouring
+// band, so sphereZoneAnalytic declines it and the builder falls back. Centre (0,2), rims (2,2) [on the
+// equator z=2] and (√3,3).
+func TestSolidOfRevolutionSphereZoneEquatorRimFallsBack(t *testing.T) {
+	c := math.P2(0, 2)
+	zone := []brep.RevolveVertex{
+		{P: math.P2(0, 2)},
+		{P: math.P2(2, 2)}, // rim on the equator plane z=2 (Δz from centre = 0)
+		{P: math.P2(stdmath.Sqrt(3), 3), ArcCenter: &c}, // arc (2,2)→(√3,3) about (0,2)
+		{P: math.P2(0, 3)},
+	}
+	body, err := brep.SolidOfRevolutionMeridian(math.P3(0, 0, 0), math.V3(0, 0, 1), zone, "equator-rim")
+	if err != nil {
+		t.Fatalf("SolidOfRevolutionMeridian(equator-rim zone) error = %v, want nil (clean fallback)", err)
+	}
+	if body != nil {
+		t.Fatalf("equator-rim zone built %d faces, want nil (degenerate latitude ⇒ fall back)", len(body.Faces()))
+	}
+}
+
 // relErrF is the relative error between got and want (want ≠ 0).
 func relErrF(got, want float64) float64 { return stdmath.Abs(got-want) / stdmath.Abs(want) }

--- a/kernel/ops/pick.go
+++ b/kernel/ops/pick.go
@@ -37,7 +37,30 @@ func rayCastFace(f *topo.Face, origin math.Point3, dir math.Vector3, q Quality) 
 	if _, ok := f.Geometry().(geom.Plane); ok {
 		return rayCastPlanarFace(f, origin, dir, q)
 	}
-	return rayCastMesh(TessellateFace(f, q), origin, dir)
+	return rayCastMesh(pickFaceMesh(f, q), origin, dir)
+}
+
+// facePickTess is the ops-owned payload of topo.Face.pickTess: the mesh a curved face was last
+// tessellated to for picking, plus the quality it was built at (picking always uses DefaultQuality,
+// but the quality guard rebuilds correctly if a caller ever passes another).
+type facePickTess struct {
+	mesh *Mesh
+	q    Quality
+}
+
+// pickFaceMesh returns the curved face's tessellation for ray-casting, tessellating it once and
+// memoizing on the face. Without this the synchronous hover-pick re-tessellated every curved face
+// EVERY frame while merely orbiting — 151 µs and 151 allocs per analytic-sphere ball, ×16 balls, is
+// the self-aligning bearing's orbit stutter (and the general recurring pick-starvation class). The
+// face is immutable once its body is finalized, so the memo is valid until the face is replaced by a
+// recompute (which yields a fresh face with an empty memo — no stale geometry, no leak).
+func pickFaceMesh(f *topo.Face, q Quality) *Mesh {
+	if c, ok := f.PickTess().(facePickTess); ok && c.q == q {
+		return c.mesh
+	}
+	m := TessellateFace(f, q)
+	f.SetPickTess(facePickTess{mesh: m, q: q})
+	return m
 }
 
 // rayCastPlanarFace intersects the ray with the face's plane, then tests the hit point against the

--- a/kernel/ops/pick_bench_test.go
+++ b/kernel/ops/pick_bench_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// sphereBallBody is a single analytic-sphere body — one ball of the self-aligning thrust bearing,
+// whose 16 copies the viewport hover-pick ray-tests EVERY frame during an orbit.
+func sphereBallBody(t testing.TB) *topo.Body {
+	body, err := brep.SolidSphere(math.V3(0, 0, 0).AsPoint(), 1.0, "ball")
+	if err != nil {
+		t.Fatalf("SolidSphere: %v", err)
+	}
+	return body
+}
+
+// BenchmarkRayCastFacesSphere measures the per-ray cost of picking one analytic-sphere body. The
+// hovered-plane pick runs RayCastFaces on every body every frame during an orbit; without the
+// face-lifetime pick-tessellation memo this re-tessellated the sphere per ray (~151 µs, 151 allocs),
+// and 16 balls per frame starved 60 fps. With the memo the repeat cost is ray-vs-cached-mesh only.
+func BenchmarkRayCastFacesSphere(b *testing.B) {
+	body := sphereBallBody(b)
+	origin := math.V3(0, 0, 5).AsPoint()
+	dir := math.V3(0, 0, -1)
+	q := ops.DefaultQuality()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, _, ok := ops.RayCastFaces(body, origin, dir, q); !ok {
+			b.Fatal("ray missed the sphere it is aimed at")
+		}
+	}
+}
+
+// TestRayCastFacesCurvedDoesNotRetessellatePerCall is the regression fence the recurring pick
+// starvation keeps needing (planar #1913, then the analytic-sphere balls): once a curved face has
+// been picked, subsequent rays MUST reuse the memoized tessellation, not rebuild it. A rebuild shows
+// up as ~150 allocations/op (a fresh sphere Mesh); the memoized path is a handful. We assert a low
+// per-call allocation ceiling so deleting or breaking the cache fails CI loudly.
+func TestRayCastFacesCurvedDoesNotRetessellatePerCall(t *testing.T) {
+	body := sphereBallBody(t)
+	origin := math.V3(0, 0, 5).AsPoint()
+	dir := math.V3(0, 0, -1)
+	q := ops.DefaultQuality()
+	// Warm the memo, then measure the steady-state (orbit) cost of repeated picks.
+	if _, _, ok := ops.RayCastFaces(body, origin, dir, q); !ok {
+		t.Fatal("warm-up ray missed the sphere")
+	}
+	const ceiling = 16 // memoized: a couple of small slices; re-tessellation would be ~150
+	avg := testing.AllocsPerRun(200, func() {
+		if _, _, ok := ops.RayCastFaces(body, origin, dir, q); !ok {
+			t.Fatal("steady-state ray missed the sphere")
+		}
+	})
+	if avg > ceiling {
+		t.Fatalf("RayCastFaces on a curved face allocates %.0f/op after warm-up (ceiling %d): the "+
+			"pick-tessellation memo is not being reused — every orbit frame re-tessellates the face", avg, ceiling)
+	}
+}
+
+// TestPickTessMemoMatchesFreshTessellation guards correctness: the memoized pick must return the same
+// hit as a cold pick. A stale or wrong memo would silently mispick — worse than being slow.
+func TestPickTessMemoMatchesFreshTessellation(t *testing.T) {
+	origin := math.V3(0, 0, 5).AsPoint()
+	dir := math.V3(0, 0, -1)
+	q := ops.DefaultQuality()
+
+	cold := sphereBallBody(t) // never picked before → cold tessellation
+	_, tCold, okCold := ops.RayCastFaces(cold, origin, dir, q)
+
+	warm := sphereBallBody(t)
+	ops.RayCastFaces(warm, origin, dir, q) // prime the memo
+	_, tWarm, okWarm := ops.RayCastFaces(warm, origin, dir, q)
+
+	if !okCold || !okWarm {
+		t.Fatalf("expected both picks to hit the sphere (cold=%v warm=%v)", okCold, okWarm)
+	}
+	if diff := tCold - tWarm; diff > 1e-9 || diff < -1e-9 {
+		t.Fatalf("memoized pick distance %v differs from cold %v (Δ=%g): the memo changed the hit", tWarm, tCold, diff)
+	}
+	// The near hit of a unit sphere centred at the origin, from z=5 toward −z, is at z=1 → distance 4.
+	if tWarm < 3.9 || tWarm > 4.1 {
+		t.Fatalf("sphere near-hit distance %v, want ≈4 (origin z=5, radius 1)", tWarm)
+	}
+}

--- a/kernel/topo/pick_tess_test.go
+++ b/kernel/topo/pick_tess_test.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package topo
+
+import "testing"
+
+// TestFacePickTessRoundTrip fences the opaque pick-tessellation memo on a Face: it starts nil, stores
+// whatever ops hands it, and reads it back unchanged. The ops package holds the payload type and the
+// hover-pick reuse logic (kernel/ops/pick.go); topo only owns the field's lifetime, so this test lives
+// here to credit the accessors' coverage in package topo (a cross-package ops_test does not). The memo
+// exists so orbiting a curved model does not re-tessellate every face every frame — see PickTess.
+func TestFacePickTessRoundTrip(t *testing.T) {
+	face := buildTetra().Faces()[0]
+	if got := face.PickTess(); got != nil {
+		t.Fatalf("a fresh face's PickTess = %v, want nil (memo empty until the first hover-pick)", got)
+	}
+	type stubMesh struct{ triangles int }
+	memo := stubMesh{triangles: 42}
+	face.SetPickTess(memo)
+	got, ok := face.PickTess().(stubMesh)
+	if !ok || got != memo {
+		t.Fatalf("PickTess after SetPickTess = %v (ok=%v), want %v", got, ok, memo)
+	}
+}

--- a/kernel/topo/topology.go
+++ b/kernel/topo/topology.go
@@ -212,6 +212,13 @@ type Face struct {
 	derived        bool
 	cachedEdges    []*Edge
 	cachedVertices []*Vertex
+	// pickTess memoizes the ops-tessellated mesh the synchronous hover-pick ray-tests a CURVED face
+	// against, so an orbit does not re-tessellate every curved face EVERY frame (the recurring pick
+	// starvation: #1913 was a planar face triangulated per frame; the analytic-sphere balls then hit
+	// the same trap on the curved path). Face-lifetime (dies with the face on recompute, so no leak
+	// and no stale geometry) and opaque to topo — the ops package owns the payload type and only the
+	// single-threaded pick path writes it (mirrors the render loop's bodyGeometryCache assumption).
+	pickTess any
 }
 
 func (f *Face) ID() uint64           { return f.id }
@@ -221,6 +228,16 @@ func (f *Face) ReferenceKey() []byte { return referenceKey(KindFace, f.lineage) 
 
 // Geometry returns the face's underlying transient surface (a Plane/Cylinder…).
 func (f *Face) Geometry() geom.Surface { return f.surface }
+
+// PickTess returns the opaque, ops-owned pick-tessellation memo (nil until the hover-pick first
+// tessellates this curved face). See the pickTess field: it exists so orbiting a curved model does
+// not re-tessellate every face every frame. Written only by the single-threaded pick path.
+func (f *Face) PickTess() any { return f.pickTess }
+
+// SetPickTess stores the ops-owned pick-tessellation memo for this face. The payload is opaque to
+// topo (the ops package defines and type-asserts it), keeping the tessellator out of the topology
+// layer while giving the memo the face's lifetime.
+func (f *Face) SetPickTess(v any) { f.pickTess = v }
 
 // Reversed reports whether the face's outward (material) side is OPPOSITE its surface
 // normal — true for the cut wall a Difference carves, where the surface (e.g. a cylinder's

--- a/model/feature/revolve_analytic_test.go
+++ b/model/feature/revolve_analytic_test.go
@@ -53,13 +53,13 @@ func TestAnalyticRevolveHasCylinderWalls(t *testing.T) {
 	}
 }
 
-// TestArcProfileRevolveStaysFaceted pins the analytic boundary at a FULL sphere: a half-disc whose arc
-// runs pole-to-pole (both endpoints on the axis, its centre on the axis) is a two-edge meridian, which
-// SolidOfRevolutionMeridian declines (a pole-to-pole meridian is not built as a boundary-less sphere
-// here — SolidSphere is that route), so it revolves to a valid faceted sphere with no analytic
-// cylinder/cone faces. A PARTIAL dome (an arc from a rim to a single pole) IS analytic — see
-// TestDomedRevolveMakesAnalyticSphereCap.
-func TestArcProfileRevolveStaysFaceted(t *testing.T) {
+// TestArcProfileRevolveMakesAnalyticSphere proves the #129 curved-meridian follow-up (FULL-sphere case):
+// a half-disc whose arc runs pole-to-pole (both endpoints AND centre on the axis), closed by a straight
+// side along the axis, revolves to ONE boundary-less analytic geom.Sphere face — not the ~1600-facet UV
+// sphere that shattered every representational bearing ball into sliver faces and starved the frame-loop
+// hover-pick. A PARTIAL dome (rim to a single pole) is a cap (TestDomedRevolveMakesAnalyticSphereCap); a
+// latitude band is a zone (TestSphereZoneRevolveMakesAnalyticSphere).
+func TestArcProfileRevolveMakesAnalyticSphere(t *testing.T) {
 	s := sketch.NewSketches().Add(sketch.XYPlane())
 	top := s.Points().Add(math.P2(0, 2))
 	bot := s.Points().Add(math.P2(0, -2))
@@ -71,14 +71,17 @@ func TestArcProfileRevolveStaysFaceted(t *testing.T) {
 	fs.Recompute()
 	body := fs.Result()[0]
 	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
-		t.Fatalf("faceted sphere revolve is not a valid solid: %+v", r.Issues)
+		t.Fatalf("sphere revolve is not a valid solid: %+v", r.Issues)
+	}
+	if got := sphereFaceCount(body); got != 1 {
+		t.Fatalf("pole-to-pole revolve has %d sphere faces, want exactly 1 analytic sphere (%d total faces)", got, len(body.Faces()))
 	}
 	if c, k := cylinderFaceCount(body), bodyConeCount(body); c != 0 || k != 0 {
-		t.Fatalf("arc-profile revolve has %d cylinder + %d cone faces, want 0 (faceted sphere)", c, k)
+		t.Fatalf("sphere revolve has %d cylinder + %d cone faces, want 0", c, k)
 	}
 	want := 4.0 / 3.0 * stdmath.Pi * 8 // (4/3)πR³, R=2
 	if got := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; relErr(got, want) > 0.03 {
-		t.Errorf("faceted sphere volume = %g, want ≈%g", got, want)
+		t.Errorf("analytic sphere volume = %g, want ≈%g", got, want)
 	}
 }
 
@@ -182,6 +185,55 @@ func TestDomedRevolveMakesAnalyticSphereCap(t *testing.T) {
 	if got := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; relErr(got, want) > 0.02 {
 		t.Errorf("domed revolve volume = %g, want ≈%g (πr²h + ⅔πr³)", got, want)
 	}
+}
+
+// TestSphereZoneRevolveMakesAnalyticSphere proves the #129 curved-meridian follow-up (sphere-ZONE case):
+// a dished-annulus meridian whose concave back is an arc with its centre ON the axis but BOTH endpoints
+// OFF the axis (a latitude band, neither a cap nor pole-to-pole) revolves to ONE analytic geom.Sphere
+// zone face — not the ~1600-facet swept band that starves the frame-loop hover-pick. This is the fix
+// behind the self-aligning thrust seat (#54): its housing/seat washers carry exactly such a zone back.
+func TestSphereZoneRevolveMakesAnalyticSphere(t *testing.T) {
+	const rIn, rOut, radius, zc = 2.0, 4.0, 10.0, 10.0
+	zOut := zc - stdmath.Sqrt(radius*radius-rOut*rOut) // 0.8348
+	zIn := zc - stdmath.Sqrt(radius*radius-rIn*rIn)    // 0.2020
+	s := sketch.NewSketches().Add(sketch.XYPlane())
+	s.Lines().AddByTwoPoints(math.P2(rIn, 0), math.P2(rOut, 0))                                 // bottom annulus
+	s.Lines().AddByTwoPoints(math.P2(rOut, 0), math.P2(rOut, zOut))                             // OD edge
+	s.Arcs().AddByCenterStartEnd(math.P2(0, zc), math.P2(rOut, zOut), math.P2(rIn, zIn), false) // concave zone back
+	s.Lines().AddByTwoPoints(math.P2(rIn, zIn), math.P2(rIn, 0))                                // bore edge
+	cl := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(0, zc))
+	cl.SetCenterline(true)
+	cl.SetConstruction(true)
+
+	fs := NewPartFeatures(nil)
+	NewRevolveFeatures(fs).AddAboutCenterline(s, 0, nil, ops.NewBody)
+	fs.Recompute()
+	body := fs.Result()[0]
+	if res := ops.Validate(body); !res.Valid || !body.IsSolid() {
+		t.Fatalf("sphere-zone revolve is not a valid solid: %+v", res.Issues)
+	}
+	if got := sphereFaceCount(body); got != 1 {
+		t.Fatalf("sphere-zone revolve has %d sphere faces, want exactly 1 analytic zone (%d total faces)", got, len(body.Faces()))
+	}
+	if got := len(body.Faces()); got != 4 {
+		t.Fatalf("sphere-zone revolve has %d faces, want 4 (bottom annulus + bore + OD + sphere zone)", got)
+	}
+	want := sphereZoneShellVolume(rIn, rOut, radius, zc)
+	if got := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; relErr(got, want) > 0.02 {
+		t.Errorf("sphere-zone revolve volume = %g, want ≈%g", got, want)
+	}
+}
+
+// sphereZoneShellVolume integrates the dished annulus V = ∫ 2πr·(zc−√(R²−r²)) dr by shells, the
+// reference the analytic sphere-zone revolve must match.
+func sphereZoneShellVolume(rIn, rOut, radius, zc float64) float64 {
+	const n = 20000
+	acc, dr := 0.0, (rOut-rIn)/n
+	for i := 0; i < n; i++ {
+		r := rIn + (float64(i)+0.5)*dr
+		acc += r * (zc - stdmath.Sqrt(radius*radius-r*r))
+	}
+	return 2 * stdmath.Pi * acc * dr
 }
 
 // TestCircleRevolveMakesAnalyticTorus proves the #129 curved-meridian follow-up (torus case): a single

--- a/model/feature/revolve_grooved_conical_test.go
+++ b/model/feature/revolve_grooved_conical_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// housingMeridian builds the 532xx self-aligning HOUSING washer meridian (cm, radius=x, axial=y): a
+// grooved ball-facing front (inner land, a groove arc cradling the ball, outer land) closed by a bore
+// edge, an OD edge, and a CONICAL back (a straight oblique edge, OD-high to bore-low). These are the
+// solved coordinates the live add-in produces. When backHi==backLo the back is FLAT (the 511xx shaft
+// washer) — the control. The mixed line/arc loop is exactly the shape whose region-extractor Reversed
+// flags were inconsistent, mis-placing the groove arc and collapsing the revolved volume (#54).
+func housingMeridian(backHi, backLo float64) *sketch.Sketch {
+	const bore, od, pit, land = 1.5, 2.35, 1.925, 0.1836
+	w := 0.1874 // half the groove-arc chord in x (pit±w are the groove/land junctions)
+	s := sketch.NewSketches().Add(sketch.XYPlane())
+	pBoreBack := s.Points().Add(math.P2(bore, backLo))
+	pBoreFront := s.Points().Add(math.P2(bore, land))
+	pGrooveIn := s.Points().Add(math.P2(pit-w, land))
+	pGrooveOut := s.Points().Add(math.P2(pit+w, land))
+	pOdFront := s.Points().Add(math.P2(od, land))
+	pOdBack := s.Points().Add(math.P2(od, backHi))
+	center := s.Points().Add(math.P2(pit, 0))
+	s.Lines().Add(pBoreBack, pBoreFront)              // bore edge
+	s.Lines().Add(pBoreFront, pGrooveIn)              // inner land
+	s.Arcs().Add(center, pGrooveOut, pGrooveIn, true) // groove arc (apex toward +y, into the washer)
+	s.Lines().Add(pGrooveOut, pOdFront)               // outer land
+	s.Lines().Add(pOdFront, pOdBack)                  // OD edge
+	s.Lines().Add(pOdBack, pBoreBack)                 // back edge (conical when backHi≠backLo, else flat)
+	return s
+}
+
+// pappusVolume is the true solid-of-revolution volume of a meridian profile by Pappus: V = 2π·A·R̄,
+// with the profile's area A and centroid radius R̄ from the loop polygon (shoelace). An independent
+// oracle for the revolved mesh volume — insensitive to how the kernel tessellates, so a mesh whose
+// groove torus was built on the wrong span (inverted/cancelling triangles) fails against it.
+func pappusVolume(p *sketch.Profile) float64 {
+	poly := p.OuterLoop().Polygon()
+	var a2, cx float64
+	for i := 0; i < len(poly); i++ {
+		j := (i + 1) % len(poly)
+		cross := float64(poly[i].X*poly[j].Y - poly[j].X*poly[i].Y)
+		a2 += cross
+		cx += (float64(poly[i].X) + float64(poly[j].X)) * cross
+	}
+	return 2 * stdmath.Pi * (stdmath.Abs(a2) / 2) * stdmath.Abs(cx/3/a2)
+}
+
+func revolvedGroovedWasherVolumes(t *testing.T, sk *sketch.Sketch) (mesh, pappus float64) {
+	t.Helper()
+	fs := NewPartFeatures(nil)
+	NewRevolveFeatures(fs).Add(sk, 0, yAxis(), nil, ops.NewBody)
+	fs.Recompute()
+	res := fs.Result()
+	if len(res) != 1 {
+		t.Fatalf("revolve produced %d bodies, want 1", len(res))
+	}
+	prof, err := resolveSingleProfile(sk, 0, "test")
+	if err != nil {
+		t.Fatalf("resolve profile: %v", err)
+	}
+	return ops.BodyGeometryProperties(res[0], ops.PropertyQuality()).Volume, pappusVolume(prof)
+}
+
+// TestGroovedFlatBackWasherVolume is the CONTROL: the 511xx grooved shaft washer (FLAT back) revolves
+// to a mesh whose volume matches Pappus.
+func TestGroovedFlatBackWasherVolume(t *testing.T) {
+	mesh, pappus := revolvedGroovedWasherVolumes(t, housingMeridian(0.55, 0.55))
+	if relErr(mesh, pappus) > 0.02 {
+		t.Fatalf("flat-back grooved washer mesh volume %.4f vs Pappus %.4f (%.1f%%)", mesh, pappus, relErr(mesh, pappus)*100)
+	}
+}
+
+// TestGroovedConicalBackWasherVolume guards the #54 self-aligning HOUSING fix: the grooved washer with
+// a CONICAL back must revolve to a mesh whose volume matches Pappus. Before the fix meridianVertsFromProfile
+// trusted the loop's Reversed flags — which the region extractor set inconsistently for this mixed
+// line/arc loop — so the groove torus was built on the inner-land span (minor radius 0.463 instead of
+// 0.262) and the mesh volume collapsed to ~28% of true. Chaining by shared endpoints holds it exact.
+func TestGroovedConicalBackWasherVolume(t *testing.T) {
+	mesh, pappus := revolvedGroovedWasherVolumes(t, housingMeridian(0.55, 0.3819))
+	if relErr(mesh, pappus) > 0.02 {
+		t.Fatalf("conical-back grooved washer mesh volume %.4f vs Pappus %.4f (%.1f%%) — the groove torus "+
+			"was built on the wrong span", mesh, pappus, relErr(mesh, pappus)*100)
+	}
+}

--- a/model/feature/sketched_features.go
+++ b/model/feature/sketched_features.go
@@ -120,6 +120,9 @@ func buildRevolveSheet(prof *sketch.Profile, plane sketch.Plane, axis *WorkAxis,
 // revolve body on demand (combine → planarized).
 func buildRevolveSolid(prof *sketch.Profile, plane sketch.Plane, axis *WorkAxis, angle, start float64, feat string) (*topo.Body, error) {
 	if fullRevolution(angle) {
+		if body, ok := sphereProfileSolid(prof, plane, axis, feat); ok {
+			return body, nil // a pole-to-pole semicircle on the axis revolves to an analytic sphere (#129 follow-up)
+		}
 		if body, ok := circleProfileTorus(prof, plane, axis, feat); ok {
 			return body, nil // a circle clear of the axis revolves to an analytic torus (#129 follow-up)
 		}
@@ -163,6 +166,66 @@ func circleProfileTorus(prof *sketch.Profile, plane sketch.Plane, axis *WorkAxis
 	return body, true
 }
 
+// sphereProfileSolid builds an analytic geom.Sphere (one boundary-less face, brep.SolidSphere) when the
+// profile is a pole-to-pole semicircle on the axis: an ARC whose centre AND both endpoints lie on the
+// revolve axis, closed by a straight LINE along the axis (the flat side of a half-disc). Revolving it a
+// full turn is a whole sphere centred at the arc centre with the arc radius. This is the #129 curved-
+// meridian follow-up for the FULL-sphere case — otherwise the half-disc facets into a ~1600-face UV
+// sphere that shatters the frame-loop hover-pick (e.g. every representational bearing ball). ok=false for
+// any other profile (the caller keeps the meridian/faceted path), including an off-axis arc (that is the
+// torus/zone case) or an arc that does not close pole-to-pole.
+func sphereProfileSolid(prof *sketch.Profile, plane sketch.Plane, axis *WorkAxis, feat string) (*topo.Body, bool) {
+	ents := prof.OuterLoop().Entities()
+	if len(ents) != 2 {
+		return nil, false
+	}
+	arc, line := arcAndLine(ents[0].Entity, ents[1].Entity)
+	if arc == nil || line == nil {
+		return nil, false
+	}
+	o, a := axis.Origin(), axis.Direction().AsVector()
+	radius := float64(arc.CurveRadius())
+	if radius <= 0 {
+		return nil, false
+	}
+	onAxis := func(p2 math.Point2) bool { // perpendicular distance from the revolve axis, relative to the sphere radius
+		v := o.VectorTo(plane.ToModel(p2))
+		return float64(v.Sub(a.Scale(v.Dot(a))).Length()) <= 1e-7*radius
+	}
+	if !halfDiscPolesOnAxis(arc, line, onAxis) {
+		return nil, false // centre/pole or the closing side off the axis: not a full sphere (torus/zone/cap case)
+	}
+	body, err := brep.SolidSphere(plane.ToModel(arc.CenterPoint().Position()), radius, feat)
+	if err != nil {
+		return nil, false
+	}
+	return body, true
+}
+
+// halfDiscPolesOnAxis reports whether the half-disc's arc centre, both arc poles, and both endpoints
+// of the closing line all lie on the revolve axis — the full-sphere signature (a pole/centre off the
+// axis is instead the torus/zone/cap case).
+func halfDiscPolesOnAxis(arc *sketch.Arc, line *sketch.Line, onAxis func(math.Point2) bool) bool {
+	return onAxis(arc.CenterPoint().Position()) && onAxis(arc.Start.Position()) && onAxis(arc.End.Position()) &&
+		onAxis(line.StartPoint().Position()) && onAxis(line.EndPoint().Position())
+}
+
+// arcAndLine returns (arc, line) from an unordered pair of profile entities, or (nil, nil) unless the
+// pair is exactly one arc and one line — the half-disc signature sphereProfileSolid recognizes.
+func arcAndLine(e0, e1 sketch.Entity) (*sketch.Arc, *sketch.Line) {
+	if a, ok := e0.(*sketch.Arc); ok {
+		if l, ok := e1.(*sketch.Line); ok {
+			return a, l
+		}
+	}
+	if a, ok := e1.(*sketch.Arc); ok {
+		if l, ok := e0.(*sketch.Line); ok {
+			return a, l
+		}
+	}
+	return nil, nil
+}
+
 // revolveSpan resolves the total swept angle and its start offset: a
 // two-directional revolve spans [-angle2, +angle1]. A combined span reaching a
 // full turn collapses to the full revolution (start irrelevant — the solid is
@@ -184,13 +247,19 @@ func revolveSpan(def *RevolveDefinition) (total, start float64) {
 // fullRevolution reports whether an angle is a complete turn (0 ⇒ full, like revolveSections).
 func fullRevolution(angle float64) bool { return angle <= 0 || angle >= 2*stdmath.Pi-1e-9 }
 
-// meridianVertsFromProfile walks the profile's outer loop into brep.RevolveVertex meridian vertices
-// in the axis's (radius, height) half-plane — radius = perpendicular distance from the axis, height =
-// signed distance along it — one vertex per edge END, carrying the arc CENTRE when that edge is a
-// circular arc (so it revolves to a torus/sphere face, not chorded cone facets). ok is false when the
-// loop holds an entity that is neither a line nor an arc (a spline): the caller keeps the faceted
-// revolve. brep.SolidOfRevolutionMeridian orients the meridian and rejects arcs it cannot build
-// analytically (returning nil), so a mixed profile still falls back cleanly.
+// meridianVertsFromProfile walks the profile's outer loop into brep.RevolveVertex meridian vertices in
+// the axis's (radius, height) half-plane — radius = perpendicular distance from the axis, height =
+// signed distance along it — one vertex per edge, at the point that edge SHARES with the next, carrying
+// the arc CENTRE when the edge is a circular arc (so it revolves to a torus/sphere face, not chorded
+// cone facets). ok is false when the loop holds a non-line/arc entity (a spline) or is not a contiguous
+// chain: the caller keeps the faceted revolve.
+//
+// The ring is built from the entities' GEOMETRY (their shared endpoints), NOT from each entity's loop
+// Reversed flag: the region extractor does not always set those flags as a consistent directed
+// traversal for a mixed line/arc loop, and a wrong flag put the groove arc's endpoints on the wrong
+// span — the revolve then built the groove torus with the wrong minor radius and the 532xx housing
+// washer's mesh volume collapsed to ~28% (Oblikovati.AddIns.PartDesigner #54). Chaining by shared
+// points is flag-independent, matching how the loop's polygon is already assembled.
 func meridianVertsFromProfile(prof *sketch.Profile, plane sketch.Plane, axis *WorkAxis) ([]brep.RevolveVertex, bool) {
 	o, a := axis.Origin(), axis.Direction().AsVector()
 	toRZ := func(p2 math.Point2) math.Point2 {
@@ -198,60 +267,102 @@ func meridianVertsFromProfile(prof *sketch.Profile, plane sketch.Plane, axis *Wo
 		z := v.Dot(a)
 		return math.P2(v.Sub(a.Scale(z)).Length(), z)
 	}
-	ents := prof.OuterLoop().Entities()
-	verts := make([]brep.RevolveVertex, 0, len(ents))
-	for _, pe := range ents {
-		end, center, ok := entityEndAndArcCenter(pe)
+	shapes, ok := loopEntityShapes(prof.OuterLoop().Entities())
+	if !ok {
+		return nil, false
+	}
+	tol := loopChainTolerance(shapes)
+	verts := make([]brep.RevolveVertex, len(shapes))
+	for k := range shapes {
+		end, ok := sharedEndpoint(shapes[k], shapes[(k+1)%len(shapes)], tol)
 		if !ok {
-			return nil, false
+			return nil, false // entities do not chain end-to-end: not a simple ring, keep faceted
 		}
 		rv := brep.RevolveVertex{P: toRZ(end)}
-		if center != nil {
-			c := toRZ(*center)
+		if shapes[k].center != nil {
+			c := toRZ(*shapes[k].center)
 			rv.ArcCenter = &c
 		}
-		verts = append(verts, rv)
-	}
-	if len(verts) < 3 {
-		return nil, false
+		verts[k] = rv
 	}
 	return verts, true
 }
 
-// entityEndAndArcCenter returns a loop entity's traversal END point (sketch 2-D) and, for an arc, its
-// centre; ok is false for anything but a line or arc (a spline keeps the profile on the faceted path).
-// It reads the entity through the ShapedEntity capability (Kind + ShapePoints) rather than switching
-// on concrete types, per the sketch-entity type-switch ban (#1624, audit I1): ShapePoints yields
-// [start, end] for a line and [centre, start, end] for an arc.
-func entityEndAndArcCenter(pe sketch.ProfileEntity) (end math.Point2, center *math.Point2, ok bool) {
+// loopEntityShape is a line/arc loop entity reduced to what the meridian ring needs: its two endpoints
+// (a, b — undirected) and, for an arc, its centre. Reading the endpoints geometrically keeps the
+// entity's stored direction and the loop Reversed flag out of the ring construction.
+type loopEntityShape struct {
+	a, b   math.Point2
+	center *math.Point2
+}
+
+// loopEntityShapes reduces the loop's entities to their shapes; ok is false when the loop is shorter
+// than a triangle or holds a non-line/arc entity (a spline), so the caller keeps the faceted revolve.
+func loopEntityShapes(ents []sketch.ProfileEntity) ([]loopEntityShape, bool) {
+	if len(ents) < 3 {
+		return nil, false
+	}
+	shapes := make([]loopEntityShape, len(ents))
+	for i, pe := range ents {
+		s, ok := shapeOfLoopEntity(pe)
+		if !ok {
+			return nil, false
+		}
+		shapes[i] = s
+	}
+	return shapes, true
+}
+
+// shapeOfLoopEntity reads a line/arc loop entity through the ShapedEntity capability (Kind +
+// ShapePoints — [start, end] for a line, [centre, start, end] for an arc), per the sketch-entity
+// type-switch ban (#1624, audit I1). ok is false for a spline (keeps the profile on the faceted path).
+func shapeOfLoopEntity(pe sketch.ProfileEntity) (loopEntityShape, bool) {
 	shaped, isShaped := pe.Entity.(sketch.ShapedEntity)
 	if !isShaped {
-		return math.Point2{}, nil, false
+		return loopEntityShape{}, false
 	}
 	pts := shaped.ShapePoints()
 	switch shaped.Kind() {
 	case sketch.LineKind:
 		if len(pts) < 2 {
-			return math.Point2{}, nil, false
+			return loopEntityShape{}, false
 		}
-		return orientedEnd(pts[0], pts[1], pe.Reversed()), nil, true
+		return loopEntityShape{a: pts[0], b: pts[1]}, true
 	case sketch.ArcKind:
 		if len(pts) < 3 {
-			return math.Point2{}, nil, false
+			return loopEntityShape{}, false
 		}
 		c := pts[0]
-		return orientedEnd(pts[1], pts[2], pe.Reversed()), &c, true
+		return loopEntityShape{a: pts[1], b: pts[2], center: &c}, true
 	}
-	return math.Point2{}, nil, false
+	return loopEntityShape{}, false
 }
 
-// orientedEnd returns the traversal END of an edge whose forward direction runs start→end, flipped
-// to start when the edge is reversed within the loop.
-func orientedEnd(start, end math.Point2, reversed bool) math.Point2 {
-	if reversed {
-		return start
+// sharedEndpoint returns the point entity s shares with the next entity t — s's END in the ring,
+// derived from geometry rather than a direction flag. ok is false when they do not touch (the loop is
+// not a contiguous chain).
+func sharedEndpoint(s, t loopEntityShape, tol float64) (math.Point2, bool) {
+	for _, p := range [2]math.Point2{s.a, s.b} {
+		if near2D(p, t.a, tol) || near2D(p, t.b, tol) {
+			return p, true
+		}
 	}
-	return end
+	return math.Point2{}, false
+}
+
+// near2D reports whether two sketch points coincide within tol.
+func near2D(p, q math.Point2, tol float64) bool {
+	return stdmath.Hypot(float64(p.X-q.X), float64(p.Y-q.Y)) <= tol
+}
+
+// loopChainTolerance is the endpoint-coincidence tolerance for chaining, scaled to the loop's extent so
+// it holds across model scales (ADR-0042) instead of a cm-anchored constant.
+func loopChainTolerance(shapes []loopEntityShape) float64 {
+	ext := 1.0
+	for _, s := range shapes {
+		ext = stdmath.Max(ext, stdmath.Max(stdmath.Abs(float64(s.a.X)), stdmath.Abs(float64(s.a.Y))))
+	}
+	return ext * 1e-6
 }
 
 // revolveAxis resolves the axis of revolution: an explicit work axis if set, otherwise the


### PR DESCRIPTION
## What & why

Two intertwined fixes that emerged from a *\"camera orbit feels slow\"* report on a placed self-aligning thrust ball bearing (16 balls + grooved washers).

### 1. Camera-orbit FPS — curved-face pick tessellation memo
The synchronous viewport hover-pick (`hoveredPlane → PickAt → RayCastFaces`) runs **every frame the cursor is over the viewport**, including mid-orbit. `rayCastFace` re-tessellated **every curved face on every ray** with no cache. After analytic-sphere balls became single curved faces, they moved off the fast O(m) planar-pick path onto this one: **151 µs + 151 allocs per ball × 16 = 2.4 ms + 2400 allocs/frame** of GC churn — the stutter.

**Fix:** memoize the pick tessellation on `topo.Face` itself (opaque, `ops`-owned payload; face-lifetime, so it dies with the face on recompute — no leak, no staleness).
- **151 µs → 4.7 µs (32×), 151 → 1 alloc.**
- Live: **60–63 fps sustained** with a forced center hover-pick every frame (was stutter).

### 2. Analytic sphere/zone revolve + shared-endpoint meridian chaining
- Curved-arc meridians build **true analytic faces** (a pole-to-pole half-disc → one `geom.Sphere`; an on-axis-centre same-side arc → a sphere zone) instead of ~1600-facet UV spheres. #129 follow-up.
- **Collapsed grooved-conical washer fix:** `meridianVertsFromProfile` trusted each `ProfileEntity.Reversed` flag, which the region extractor sets **inconsistently** for a mixed line/arc loop — a wrong flag put the groove arc on the wrong span, so the revolve built its torus with the wrong minor radius (inverted, cancelling triangles → mesh volume **~28% of true**). The ring is now chained by the entities' **shared endpoints** (flag-independent). Live bearing volume error **14.9% → 0.010%**.

## Regression fences (the pick-perf class keeps recurring)
- `kernel/ops`: `TestRayCastFacesCurvedDoesNotRetessellatePerCall` (alloc ceiling) + memo-correctness test + benchmark.
- `app`: `TestRayPickerCurvedSceneStaysCheapPerFrame` (full pick chain over 16 curved bodies).
- `model/feature`: `TestGroovedConicalBackWasherVolume` + flat-back control vs a Pappus oracle (both failed before the fix).
- `head/cmd/perfbench -hoverpick`: durable orbit-with-pick measurement harness.

## Verification
Rebased on latest `develop`. `kernel/{ops,topo,brep}`, `model/feature`, `app` suites green; `gofmt`/`goimports` clean; golangci-lint clean on touched packages; live self-aligning bearing renders correctly and re-drives, orbit ≥60 fps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)