### PR TITLE
feat(sketch): ellipse-orientation solver DOF — horizontal/vertical of an ellipse axis (#1879 AC2)

### DIFF
--- a/addin/router/sketch_constraint_refs.go
+++ b/addin/router/sketch_constraint_refs.go
@@ -62,6 +62,20 @@ func singleLineOrAlign(sk *sketch.Sketch, refs []uint64, addLine func(*sketch.Li
 	}
 }
 
+// singleEntityHVOrAlign routes horizontal/vertical by operand: a single ellipse ref rotates that
+// ellipse's axis to horizontal/vertical (major/minor per the flag), otherwise it falls to the
+// line-or-align form (#1879 AC2, #1871).
+func singleEntityHVOrAlign(sk *sketch.Sketch, refs []uint64, major bool, addEllipse func(sketch.AxisOperand) sketch.Constraint, addLine func(*sketch.Line) sketch.Constraint, addAlign func(a, b *sketch.Point) sketch.Constraint) (sketch.Constraint, bool, error) {
+	if len(refs) == 1 && isEllipseRef(sk, refs[0]) {
+		op, err := axisOperandRef(sk, refs[0], major)
+		if err != nil {
+			return nil, true, err
+		}
+		return addEllipse(op), true, nil
+	}
+	return singleLineOrAlign(sk, refs, addLine, addAlign)
+}
+
 // axisOrLineRelation applies an ellipse-axis relation when either operand is an ellipse
 // (per-operand major/minor from the flags), else the plain two-line relation (#1879).
 func axisOrLineRelation(sk *sketch.Sketch, refs []uint64, flags axisFlags, addAxis func(a, b sketch.AxisOperand) sketch.Constraint, addLine func(a, b *sketch.Line) sketch.Constraint) (sketch.Constraint, bool, error) {

--- a/addin/router/sketch_constraints.go
+++ b/addin/router/sketch_constraints.go
@@ -72,15 +72,17 @@ func addCustomConstraint(sk *sketch.Sketch, in wire.AddConstraintArgs) error {
 	return err
 }
 
-// axisFlags carries the per-operand ellipse major/minor-axis selectors of a parallel/
-// perpendicular/collinear relation (#1879), defaulted to the major axis (Inventor's default)
-// when the request omits them.
-type axisFlags struct{ one, two bool }
+// axisFlags carries the ellipse major/minor-axis selectors of a constraint request (#1879):
+// one/two are the first/second operand of a parallel/perpendicular/collinear relation; major is
+// the single-operand horizontal/vertical form (#1879 AC2). All default to the major axis
+// (Inventor's default) when the request omits them.
+type axisFlags struct{ one, two, major bool }
 
 func axisFlagsFrom(in wire.AddConstraintArgs) axisFlags {
 	return axisFlags{
-		one: boolOrTrue(in.UseEllipseOneMajorAxis),
-		two: boolOrTrue(in.UseEllipseTwoMajorAxis),
+		one:   boolOrTrue(in.UseEllipseOneMajorAxis),
+		two:   boolOrTrue(in.UseEllipseTwoMajorAxis),
+		major: boolOrTrue(in.UseEllipseMajorAxis),
 	}
 }
 
@@ -94,7 +96,7 @@ func buildGeometricConstraint(sk *sketch.Sketch, kind types.GeometricConstraintK
 	if c, ok, err := pointPairConstraint(sk, kind, refs); ok {
 		return c, err
 	}
-	if c, ok, err := horizontalVerticalConstraint(sk, kind, refs); ok {
+	if c, ok, err := horizontalVerticalConstraint(sk, kind, refs, flags); ok {
 		return c, err
 	}
 	if c, ok, err := lineConstraint(sk, kind, refs, flags); ok {
@@ -170,19 +172,22 @@ func pointPairConstraint(sk *sketch.Sketch, kind types.GeometricConstraintKind, 
 	}
 }
 
-// horizontalVerticalConstraint routes the horizontal/vertical family (#1871): the plain
-// horizontal/vertical make a single line horizontal/vertical (one line ref) or level two
-// points (the align form, two point refs); horizontalAlign/verticalAlign are the explicit
-// two-point align kinds.
-func horizontalVerticalConstraint(sk *sketch.Sketch, kind types.GeometricConstraintKind, refs []uint64) (sketch.Constraint, bool, error) {
+// horizontalVerticalConstraint routes the horizontal/vertical family (#1871, #1879 AC2): the plain
+// horizontal/vertical make a single line horizontal/vertical (one line ref), rotate a single
+// ellipse's axis to horizontal/vertical (one ellipse ref, major/minor per UseEllipseMajorAxis), or
+// level two points (the align form, two point refs); horizontalAlign/verticalAlign are the
+// explicit two-point align kinds.
+func horizontalVerticalConstraint(sk *sketch.Sketch, kind types.GeometricConstraintKind, refs []uint64, flags axisFlags) (sketch.Constraint, bool, error) {
 	g := sk.GeometricConstraints()
 	switch kind {
 	case types.GeoConstraintHorizontal:
-		return singleLineOrAlign(sk, refs,
+		return singleEntityHVOrAlign(sk, refs, flags.major,
+			func(e sketch.AxisOperand) sketch.Constraint { return g.AddEllipseHorizontal(e) },
 			func(l *sketch.Line) sketch.Constraint { return g.AddLineHorizontal(l) },
 			func(a, b *sketch.Point) sketch.Constraint { return g.AddHorizontal(a, b) })
 	case types.GeoConstraintVertical:
-		return singleLineOrAlign(sk, refs,
+		return singleEntityHVOrAlign(sk, refs, flags.major,
+			func(e sketch.AxisOperand) sketch.Constraint { return g.AddEllipseVertical(e) },
 			func(l *sketch.Line) sketch.Constraint { return g.AddLineVertical(l) },
 			func(a, b *sketch.Point) sketch.Constraint { return g.AddVertical(a, b) })
 	case types.GeoConstraintHorizontalAlign:

--- a/addin/router/sketch_ellipse_axis_test.go
+++ b/addin/router/sketch_ellipse_axis_test.go
@@ -26,6 +26,16 @@ func solveAndLineDir(t *testing.T, r *Router, s *app.Session) (float64, float64)
 
 func nearlyZero(v float64) bool { return v < 1e-6 && v > -1e-6 }
 
+// pinEllipseHorizontal fixes an axis-aligned ellipse's orientation DOF (its axis is already +X, so
+// this only removes the rotational freedom) so a following relation moves the LINE, not the ellipse
+// (#1879 AC2).
+func pinEllipseHorizontal(t *testing.T, r *Router, s *app.Session, ellID uint64) {
+	t.Helper()
+	call(t, r, s, "sketch.addConstraint", mustJSON(t, wire.AddConstraintArgs{
+		SketchIndex: 0, Kind: "horizontal", Entities: []uint64{ellID},
+	}), &wire.AddConstraintResult{})
+}
+
 // TestEllipseParallelOverWire: parallel with an ellipse operand aligns the line to the ellipse's
 // major axis and enumerates as "parallel" (#1879).
 func TestEllipseParallelOverWire(t *testing.T) {
@@ -33,6 +43,7 @@ func TestEllipseParallelOverWire(t *testing.T) {
 	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
 	call(t, r, s, "sketch.setInferenceOptions", `{"inferEnabled":false}`, &wire.InferenceOptionsView{})
 	ell := addEnt(t, r, s, `{"sketchIndex":0,"kind":"ellipse","points":[[0,0]],"axis":[1,0],"majorRadius":"3 cm","minorRadius":"1 cm"}`)
+	pinEllipseHorizontal(t, r, s, ell.EntityID) // the ellipse's orientation is a DOF now (#1879 AC2)
 	l := addEnt(t, r, s, `{"sketchIndex":0,"kind":"line","points":[[0,0],[4,1]]}`)
 
 	var res wire.AddConstraintResult
@@ -55,6 +66,7 @@ func TestEllipseParallelMinorAxisOverWire(t *testing.T) {
 	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
 	call(t, r, s, "sketch.setInferenceOptions", `{"inferEnabled":false}`, &wire.InferenceOptionsView{})
 	ell := addEnt(t, r, s, `{"sketchIndex":0,"kind":"ellipse","points":[[0,0]],"axis":[1,0],"majorRadius":"3 cm","minorRadius":"1 cm"}`)
+	pinEllipseHorizontal(t, r, s, ell.EntityID) // pin the ellipse's rotation DOF (#1879 AC2)
 	l := addEnt(t, r, s, `{"sketchIndex":0,"kind":"line","points":[[0,0],[1,4]]}`)
 
 	no := false
@@ -76,6 +88,7 @@ func TestEllipsePerpendicularOverWire(t *testing.T) {
 	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
 	call(t, r, s, "sketch.setInferenceOptions", `{"inferEnabled":false}`, &wire.InferenceOptionsView{})
 	ell := addEnt(t, r, s, `{"sketchIndex":0,"kind":"ellipse","points":[[0,0]],"axis":[1,0],"majorRadius":"3 cm","minorRadius":"1 cm"}`)
+	pinEllipseHorizontal(t, r, s, ell.EntityID) // pin the ellipse's rotation DOF (#1879 AC2)
 	l := addEnt(t, r, s, `{"sketchIndex":0,"kind":"line","points":[[0,0],[1,4]]}`)
 	var res wire.AddConstraintResult
 	call(t, r, s, "sketch.addConstraint", mustJSON(t, wire.AddConstraintArgs{
@@ -88,6 +101,82 @@ func TestEllipsePerpendicularOverWire(t *testing.T) {
 	if !nearlyZero(dx) || nearlyZero(dy) {
 		t.Errorf("line direction = (%v,%v), want vertical", dx, dy)
 	}
+}
+
+// ellipseHVSession builds an inference-free sketch with a single 45° ellipse and returns its id.
+func ellipseHVSession(t *testing.T) (*Router, *app.Session, uint64) {
+	t.Helper()
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.setInferenceOptions", `{"inferEnabled":false}`, &wire.InferenceOptionsView{})
+	ell := addEnt(t, r, s, `{"sketchIndex":0,"kind":"ellipse","points":[[0,0]],"axis":[1,1],"majorRadius":"3 cm","minorRadius":"1 cm"}`)
+	return r, s, ell.EntityID
+}
+
+// assertHVRelatesEllipse checks a single constraint of the given kind is enumerated and relates
+// exactly the ellipse.
+func assertHVRelatesEllipse(t *testing.T, r *Router, s *app.Session, kind string, ellID uint64) {
+	t.Helper()
+	for _, c := range enumerated(t, r, s) {
+		if c.Kind == kind {
+			if len(c.Entities) != 1 || c.Entities[0] != ellID {
+				t.Fatalf("%s relates %v, want just the ellipse %d", kind, c.Entities, ellID)
+			}
+			return
+		}
+	}
+	t.Fatalf("no %s constraint enumerated after ellipse %s", kind, kind)
+}
+
+// TestEllipseHorizontalOverWire: kind=horizontal with a single ellipse ref rotates the ellipse's
+// major axis to horizontal, reports and enumerates as "horizontal", and relates the ellipse
+// (#1879 AC2).
+func TestEllipseHorizontalOverWire(t *testing.T) {
+	r, s, ell := ellipseHVSession(t)
+	var res wire.AddConstraintResult
+	call(t, r, s, "sketch.addConstraint", mustJSON(t, wire.AddConstraintArgs{
+		SketchIndex: 0, Kind: "horizontal", Entities: []uint64{ell},
+	}), &res)
+	if res.Kind != "horizontal" {
+		t.Fatalf("ellipse horizontal result kind = %q, want horizontal", res.Kind)
+	}
+	assertHVRelatesEllipse(t, r, s, "horizontal", ell)
+	var sr wire.SolveSketchResult
+	call(t, r, s, "sketch.solve", `{"sketchIndex":0}`, &sr)
+	if !sr.Converged {
+		t.Errorf("solve did not converge after ellipse horizontal: %+v", sr)
+	}
+}
+
+// TestEllipseVerticalOverWire: kind=vertical with a single ellipse ref makes the ellipse's axis
+// vertical, enumerating as "vertical" (#1879 AC2).
+func TestEllipseVerticalOverWire(t *testing.T) {
+	r, s, ell := ellipseHVSession(t)
+	var res wire.AddConstraintResult
+	call(t, r, s, "sketch.addConstraint", mustJSON(t, wire.AddConstraintArgs{
+		SketchIndex: 0, Kind: "vertical", Entities: []uint64{ell},
+	}), &res)
+	if res.Kind != "vertical" {
+		t.Fatalf("ellipse vertical result kind = %q, want vertical", res.Kind)
+	}
+	assertHVRelatesEllipse(t, r, s, "vertical", ell)
+}
+
+// TestEllipseHorizontalMinorAxisOverWire: UseEllipseMajorAxis=false selects the minor axis for the
+// single-operand horizontal form; it still creates and enumerates a horizontal constraint (#1879
+// AC2). The major/minor distinction is geometric (not wire-observable), so the geometry is covered
+// by the model-level tests.
+func TestEllipseHorizontalMinorAxisOverWire(t *testing.T) {
+	r, s, ell := ellipseHVSession(t)
+	no := false
+	var res wire.AddConstraintResult
+	call(t, r, s, "sketch.addConstraint", mustJSON(t, wire.AddConstraintArgs{
+		SketchIndex: 0, Kind: "horizontal", Entities: []uint64{ell}, UseEllipseMajorAxis: &no,
+	}), &res)
+	if res.Kind != "horizontal" {
+		t.Fatalf("ellipse minor horizontal result kind = %q, want horizontal", res.Kind)
+	}
+	assertHVRelatesEllipse(t, r, s, "horizontal", ell)
 }
 
 // TestTwoLineParallelStillWorks: with no ellipse operand, parallel is the plain two-line

--- a/addin/router/sketch_enumerate.go
+++ b/addin/router/sketch_enumerate.go
@@ -223,10 +223,13 @@ var wireConstraintKinds = map[sketch.ConstraintKind]types.GeometricConstraintKin
 	sketch.LineSymmetryKind:         types.GeoConstraintSymmetry,
 	sketch.CircularSymmetryKind:     types.GeoConstraintSymmetry,
 	sketch.ArcMidpointKind:          types.GeoConstraintMidpoint,
-	// Ellipse-axis relations enumerate as their plain wire relation (#1879).
+	// Ellipse-axis relations enumerate as their plain wire relation (#1879); the horizontal/
+	// vertical forms enumerate as the single-operand horizontal/vertical (#1879 AC2).
 	sketch.EllipseParallelKind:      types.GeoConstraintParallel,
 	sketch.EllipsePerpendicularKind: types.GeoConstraintPerpendicular,
 	sketch.EllipseCollinearKind:     types.GeoConstraintCollinear,
+	sketch.EllipseHorizontalKind:    types.GeoConstraintHorizontal,
+	sketch.EllipseVerticalKind:      types.GeoConstraintVertical,
 	sketch.FixKind:                  types.GeoConstraintFix,
 	sketch.ParallelKind:             types.GeoConstraintParallel,
 	sketch.PerpendicularKind:        types.GeoConstraintPerpendicular,

--- a/model/sketch/constraint_kind.go
+++ b/model/sketch/constraint_kind.go
@@ -46,13 +46,18 @@ const (
 	EllipseParallelKind      ConstraintKind = "ellipseParallel"
 	EllipsePerpendicularKind ConstraintKind = "ellipsePerpendicular"
 	EllipseCollinearKind     ConstraintKind = "ellipseCollinear"
-	FixKind                  ConstraintKind = "fix"
-	SmoothKind               ConstraintKind = "smooth"
-	GroundKind               ConstraintKind = "ground"
-	OffsetKind               ConstraintKind = "offset"
-	PatternLinkKind          ConstraintKind = "patternLink"
-	TextBoxAnchorKind        ConstraintKind = "textBox"
-	CustomKind               ConstraintKind = "custom"
+	// Horizontal/vertical of an ellipse axis (#1879 AC2): the ellipse rotates until its axis is
+	// parallel to world X/Y. They enumerate as the wire horizontal/vertical (a single-operand form)
+	// but persist distinctly (they carry the ellipse's major/minor flag).
+	EllipseHorizontalKind ConstraintKind = "ellipseHorizontal"
+	EllipseVerticalKind   ConstraintKind = "ellipseVertical"
+	FixKind               ConstraintKind = "fix"
+	SmoothKind            ConstraintKind = "smooth"
+	GroundKind            ConstraintKind = "ground"
+	OffsetKind            ConstraintKind = "offset"
+	PatternLinkKind       ConstraintKind = "patternLink"
+	TextBoxAnchorKind     ConstraintKind = "textBox"
+	CustomKind            ConstraintKind = "custom"
 )
 
 // KindedConstraint is the capability the serializer and the router enumerate

--- a/model/sketch/constraints_ellipse_axis.go
+++ b/model/sketch/constraints_ellipse_axis.go
@@ -3,48 +3,38 @@
 package sketch
 
 import (
+	stdmath "math"
+
 	"oblikovati.org/math"
 	"oblikovati.org/solve/ad"
 )
 
 // Ellipse-axis operands (#1879): Inventor's parallel/perpendicular/collinear and horizontal/
 // vertical accept an ellipse (or elliptical arc) operand, its constrained direction being the
-// ellipse's major or minor axis (UseEllipse*MajorAxis). An ellipse's axis direction is a fixed
-// reference (the major-axis direction is not a solver DOF — see solve_sketch.go's variable
-// universe), so an ellipse operand contributes a constant direction anchored at its centre; the
-// line operand adjusts. This is a direction-alignment relation, not a branch-selection one, so
-// the residuals reuse the existing scale-invariant angle/perp-distance primitives.
+// ellipse's major or minor axis (UseEllipse*MajorAxis). An ellipse's orientation IS a solver DOF
+// (#1879 AC2 — see solve_sketch.go and ellipse_orientation.go): the operand's direction is a live
+// function of the ellipse's orientation angle, so the solver can rotate the ellipse to satisfy the
+// relation (this is what makes horizontal/vertical of an ellipse axis solvable — the ellipse turns
+// to align to the fixed world axis). The residuals reuse the scale-invariant angle/perp-distance
+// primitives, so the unit-length axis direction is fine.
 
-// ellipseAxisSource is an ellipse-like entity that offers a centre and a major-axis direction —
+// ellipseAxisSource is an ellipse-like entity that offers a centre and an orientation-angle DOF —
 // satisfied by both Ellipse and EllipticalArc (#1879).
 type ellipseAxisSource interface {
 	Entity
 	axisCentre() *Point
-	// axisVector returns the (unnormalised) major or minor axis direction; adSineAngle/
-	// adCosAngle normalise, so a raw vector is fine.
-	axisVector(major bool) math.Vector2
+	// axisAngle is the ellipse's major-axis orientation DOF; the operand builds its direction
+	// from it so the solver can rotate the ellipse.
+	axisAngle() *math.Scalar
 }
 
-func (e *Ellipse) axisCentre() *Point { return e.Center }
-func (e *Ellipse) axisVector(major bool) math.Vector2 {
-	return ellipseAxisVector(e.MajorAxis, major)
-}
+func (e *Ellipse) axisCentre() *Point       { return e.Center }
 func (e *EllipticalArc) axisCentre() *Point { return e.Center }
-func (e *EllipticalArc) axisVector(major bool) math.Vector2 {
-	return ellipseAxisVector(e.MajorAxis, major)
-}
-
-// ellipseAxisVector returns the major axis as-is, or the minor axis as its left perpendicular.
-func ellipseAxisVector(major math.Vector2, useMajor bool) math.Vector2 {
-	if useMajor {
-		return major
-	}
-	return math.V2(-major.Y, major.X)
-}
 
 // AxisOperand is a direction operand of an axis-relation constraint: a line (direction from its
-// endpoints, DOFs) or an ellipse axis (a fixed direction anchored at the ellipse centre). The
-// interface is sealed (its methods are unexported); construct one with LineAxis or EllipseAxisOf.
+// endpoints, DOFs), an ellipse axis (direction from the ellipse's orientation DOF, anchored at its
+// centre), or a fixed world axis (a constant direction). The interface is sealed (its methods are
+// unexported); construct one with LineAxis, EllipseAxisOf, or the horizontal/vertical factories.
 type AxisOperand interface {
 	dirVars() []*math.Scalar
 	// readDir reads the operand's direction and anchor point from the seeded row starting at
@@ -101,13 +91,17 @@ func EllipseAxisOf(e Entity, major bool) (AxisOperand, bool) {
 
 func (o ellipseAxisOperand) dirVars() []*math.Scalar {
 	c := o.E.axisCentre()
-	return []*math.Scalar{&c.X, &c.Y}
+	return []*math.Scalar{&c.X, &c.Y, o.E.axisAngle()}
 }
 func (o ellipseAxisOperand) readDir(v []ad.Number, off int) (ad.Vec2, ad.Vec2, int) {
-	// The centre is a DOF (the anchor for collinear); the axis direction is a live constant.
+	// The centre is the anchor DOF (used by collinear); the direction is (cosθ, sinθ) of the
+	// orientation DOF, so the solver can rotate the ellipse. The minor axis is a quarter turn on.
 	centre := ad.V2(v[off], v[off+1])
-	d := o.E.axisVector(o.major)
-	return ad.V2(ad.Const(float64(d.X)), ad.Const(float64(d.Y))), centre, 2
+	angle := v[off+2]
+	if !o.major {
+		angle = angle.AddConst(stdmath.Pi / 2)
+	}
+	return ad.V2(angle.Cos(), angle.Sin()), centre, 3
 }
 func (o ellipseAxisOperand) operandEntity() Entity { return o.E }
 func (o ellipseAxisOperand) axisMajor() bool       { return o.major }
@@ -118,6 +112,20 @@ func (o ellipseAxisOperand) remap(m *cloneMap) (AxisOperand, bool) {
 	}
 	return EllipseAxisOf(ne, o.major)
 }
+
+// worldAxisOperand is a fixed world direction (the +X horizontal or +Y vertical reference) — the
+// immovable operand of an ellipse horizontal/vertical constraint. It contributes no DOF, names no
+// entity, and always remaps (it survives any copy) (#1879 AC2).
+type worldAxisOperand struct{ dir math.Vector2 }
+
+func (o worldAxisOperand) dirVars() []*math.Scalar { return nil }
+func (o worldAxisOperand) readDir(_ []ad.Number, _ int) (ad.Vec2, ad.Vec2, int) {
+	d := ad.V2(ad.Const(float64(o.dir.X)), ad.Const(float64(o.dir.Y)))
+	return d, ad.V2(ad.Const(0), ad.Const(0)), 0
+}
+func (o worldAxisOperand) operandEntity() Entity               { return nil }
+func (o worldAxisOperand) axisMajor() bool                     { return false }
+func (o worldAxisOperand) remap(*cloneMap) (AxisOperand, bool) { return o, true }
 
 // axisRelation is the geometric relation an [AxisRelationConstraint] enforces between its two
 // operand directions.
@@ -130,9 +138,10 @@ const (
 )
 
 // AxisRelationConstraint aligns two direction operands — at least one an ellipse axis — parallel,
-// perpendicular, or collinear (#1879). An ellipse operand is a fixed directional reference (its
-// orientation is not a solver DOF), so it is the line operand that the solver moves to satisfy
-// the relation; two fixed ellipse axes only hold when already so related.
+// perpendicular, or collinear, or aligns one ellipse axis to a fixed world axis (horizontal/
+// vertical, #1879). Every ellipse operand's direction tracks the ellipse's orientation DOF, so the
+// solver satisfies the relation by rotating whichever operand is free (the ellipse for a world-axis
+// relation; either an ellipse or a line for an ellipse-line relation).
 type AxisRelationConstraint struct {
 	constraintBase
 	a, b     AxisOperand
@@ -150,6 +159,19 @@ func (g *GeometricConstraints) AddEllipsePerpendicular(a, b AxisOperand) *AxisRe
 }
 func (g *GeometricConstraints) AddEllipseCollinear(a, b AxisOperand) *AxisRelationConstraint {
 	return g.addAxisRelation(a, b, axisCollinear, EllipseCollinearKind)
+}
+
+// AddEllipseHorizontal / AddEllipseVertical make an ellipse's chosen axis horizontal / vertical by
+// rotating the ellipse until that axis is parallel to the fixed world +X / +Y direction (#1879
+// AC2). The ellipse operand is the free (rotatable) side; the world axis is the datum. Like the
+// existing parallel/perpendicular constraints, an operand sitting EXACTLY perpendicular to the
+// target starts at the angular residual's zero-gradient dead point and will not rotate — a
+// measure-zero configuration real geometry does not hit.
+func (g *GeometricConstraints) AddEllipseHorizontal(e AxisOperand) *AxisRelationConstraint {
+	return g.addAxisRelation(e, worldAxisOperand{dir: math.V2(1, 0)}, axisParallel, EllipseHorizontalKind)
+}
+func (g *GeometricConstraints) AddEllipseVertical(e AxisOperand) *AxisRelationConstraint {
+	return g.addAxisRelation(e, worldAxisOperand{dir: math.V2(0, 1)}, axisParallel, EllipseVerticalKind)
 }
 
 func (g *GeometricConstraints) addAxisRelation(a, b AxisOperand, rel axisRelation, kind ConstraintKind) *AxisRelationConstraint {

--- a/model/sketch/constraints_ellipse_axis_test.go
+++ b/model/sketch/constraints_ellipse_axis_test.go
@@ -12,7 +12,12 @@ import (
 // product).
 func dirParallelTo(l *Line, vx, vy, tol float64) bool {
 	d := l.Direction()
-	cross := float64(d.X)*vy - float64(d.Y)*vx
+	return vecParallelTo(d, vx, vy, tol)
+}
+
+// vecParallelTo reports whether v is parallel to (vx,vy) within tol (zero cross product).
+func vecParallelTo(v math.Vector2, vx, vy, tol float64) bool {
+	cross := float64(v.X)*vy - float64(v.Y)*vx
 	return cross < tol && cross > -tol
 }
 
@@ -26,7 +31,8 @@ func mustEllipseOp(t *testing.T, e *Ellipse, major bool) AxisOperand {
 }
 
 // TestEllipseParallelAlignsLineToMajorAxis: parallel(line, ellipse-major) rotates the line to
-// the ellipse's major-axis direction; the minor selector uses the perpendicular axis (#1879).
+// the ellipse's major-axis direction; the minor selector uses the perpendicular axis (#1879). The
+// ellipse's own rotation DOF is pinned horizontal so it is the LINE that moves (#1879 AC2).
 func TestEllipseParallelAlignsLineToMajorAxis(t *testing.T) {
 	for _, tc := range []struct {
 		name         string
@@ -40,6 +46,7 @@ func TestEllipseParallelAlignsLineToMajorAxis(t *testing.T) {
 			s := NewSketches().Add(XYPlane())
 			g := s.GeometricConstraints()
 			ell := s.Ellipses().Add(math.P2(0, 0), math.V2(1, 0), 3, 1)
+			g.AddEllipseHorizontal(mustEllipseOp(t, ell, true))         // pin the ellipse's rotation
 			l := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 1)) // slanted
 			g.AddEllipseParallel(LineAxis(l), mustEllipseOp(t, ell, tc.major))
 			g.AddFix(l.A)
@@ -54,11 +61,12 @@ func TestEllipseParallelAlignsLineToMajorAxis(t *testing.T) {
 }
 
 // TestEllipsePerpendicularAlignsLine: perpendicular(line, ellipse-major) makes the line
-// perpendicular to the major axis (#1879).
+// perpendicular to the major axis, with the ellipse's rotation pinned horizontal (#1879).
 func TestEllipsePerpendicularAlignsLine(t *testing.T) {
 	s := NewSketches().Add(XYPlane())
 	g := s.GeometricConstraints()
 	ell := s.Ellipses().Add(math.P2(0, 0), math.V2(1, 0), 3, 1)
+	g.AddEllipseHorizontal(mustEllipseOp(t, ell, true))
 	l := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 1))
 	g.AddEllipsePerpendicular(LineAxis(l), mustEllipseOp(t, ell, true))
 	g.AddFix(l.A)
@@ -72,12 +80,18 @@ func TestEllipsePerpendicularAlignsLine(t *testing.T) {
 }
 
 // TestEllipseParallelRotatedEllipse grounds the axis direction against a rotated ellipse (major
-// axis at 45°), so the residual is not accidentally satisfied by an axis-aligned ellipse (#1879).
+// axis at 45°): a fixed 45° reference line pins the ellipse there (its orientation is now a DOF),
+// then a slanted line aligns to that rotated axis — proving the operand reads the ellipse's actual
+// direction, not an axis-aligned accident (#1879).
 func TestEllipseParallelRotatedEllipse(t *testing.T) {
 	s := NewSketches().Add(XYPlane())
 	g := s.GeometricConstraints()
 	ell := s.Ellipses().Add(math.P2(0, 0), math.V2(1, 1), 3, 1) // major axis along (1,1)
-	l := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0)) // horizontal
+	ref := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(1, 1))
+	g.AddFix(ref.A)
+	g.AddFix(ref.B)                                                  // ref is a fixed 45° datum
+	g.AddEllipseParallel(LineAxis(ref), mustEllipseOp(t, ell, true)) // pin the ellipse at 45°
+	l := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0))      // horizontal, to be moved
 	g.AddEllipseParallel(LineAxis(l), mustEllipseOp(t, ell, true))
 	g.AddFix(l.A)
 	if r := s.Solve(); !r.Converged {
@@ -89,14 +103,15 @@ func TestEllipseParallelRotatedEllipse(t *testing.T) {
 }
 
 // TestEllipseCollinearThroughCentre: collinear(line, ellipse-major) makes the line parallel to
-// the major axis AND pass through the ellipse centre (#1879).
+// the major axis AND pass through the ellipse centre, with the ellipse pinned (#1879).
 func TestEllipseCollinearThroughCentre(t *testing.T) {
 	s := NewSketches().Add(XYPlane())
 	g := s.GeometricConstraints()
 	ell := s.Ellipses().Add(math.P2(0, 0), math.V2(1, 0), 3, 1)
+	g.AddEllipseHorizontal(mustEllipseOp(t, ell, true))         // pin the ellipse's rotation
 	l := s.Lines().AddByTwoPoints(math.P2(0, 2), math.P2(4, 3)) // off the X axis, slanted
 	g.AddEllipseCollinear(LineAxis(l), mustEllipseOp(t, ell, true))
-	g.AddFix(ell.Center) // pin the ellipse (its centre is a DOF) so the line is what moves
+	g.AddFix(ell.Center) // pin the centre (a DOF) so the line is what moves
 	if r := s.Solve(); !r.Converged {
 		t.Fatalf("solve did not converge: %+v", r)
 	}
@@ -107,6 +122,79 @@ func TestEllipseCollinearThroughCentre(t *testing.T) {
 	if y0, y1 := float64(l.A.Position().Y), float64(l.B.Position().Y); y0 > solveTol || y0 < -solveTol || y1 > solveTol || y1 < -solveTol {
 		t.Errorf("collinear endpoints Y = %v, %v, want on the X axis (0)", y0, y1)
 	}
+}
+
+// TestEllipseHorizontalRotatesMajorAxis: horizontal(ellipse-major) rotates a 45°-oriented ellipse
+// until its major axis is horizontal — the core of #1879 AC2 (the ellipse turns, since the world
+// axis is fixed). The minor selector makes the MINOR axis horizontal instead.
+func TestEllipseHorizontalRotatesMajorAxis(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		major        bool
+		wantX, wantY float64
+	}{
+		{"major", true, 1, 0},  // major axis becomes horizontal
+		{"minor", false, 1, 0}, // minor axis becomes horizontal ⇒ major becomes vertical
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewSketches().Add(XYPlane())
+			g := s.GeometricConstraints()
+			ell := s.Ellipses().Add(math.P2(0, 0), math.V2(1, 1), 3, 1) // 45°
+			g.AddEllipseHorizontal(mustEllipseOp(t, ell, tc.major))
+			if r := s.Solve(); !r.Converged {
+				t.Fatalf("solve did not converge: %+v", r)
+			}
+			axis := ellipseAxisVectorFor(ell, tc.major)
+			if !vecParallelTo(axis, tc.wantX, tc.wantY, solveTol) {
+				t.Errorf("selected axis = %v, want horizontal (%v,%v)", axis, tc.wantX, tc.wantY)
+			}
+		})
+	}
+}
+
+// TestEllipseVerticalRotatesMajorAxis: vertical(ellipse-major) rotates the ellipse until its major
+// axis is vertical (#1879 AC2). The ellipse starts at 45° (a non-degenerate angle): an ellipse
+// EXACTLY perpendicular to the target sits at the sine residual's zero-gradient dead point, which
+// the iterative solver cannot escape — the same limitation the existing perpendicular/parallel
+// constraints have on exactly-parallel lines, and which real (non-exact) geometry never hits.
+func TestEllipseVerticalRotatesMajorAxis(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	g := s.GeometricConstraints()
+	ell := s.Ellipses().Add(math.P2(0, 0), math.V2(1, 1), 3, 1) // 45°, off the dead point
+	g.AddEllipseVertical(mustEllipseOp(t, ell, true))
+	if r := s.Solve(); !r.Converged {
+		t.Fatalf("solve did not converge: %+v", r)
+	}
+	if !vecParallelTo(ell.MajorAxis, 0, 1, solveTol) {
+		t.Errorf("major axis = %v, want vertical (0,1)", ell.MajorAxis)
+	}
+}
+
+// TestEllipticalArcHorizontal: an elliptical arc is an ellipse-axis source too, so its axis can be
+// made horizontal by rotation (#1879 AC2).
+func TestEllipticalArcHorizontal(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	g := s.GeometricConstraints()
+	ea := s.EllipticalArcs().Add(math.P2(0, 0), math.V2(1, 1), 3, 1, 0, 1) // 45°
+	op, ok := EllipseAxisOf(ea, true)
+	if !ok {
+		t.Fatal("elliptical arc is not an axis source")
+	}
+	g.AddEllipseHorizontal(op)
+	if r := s.Solve(); !r.Converged {
+		t.Fatalf("solve did not converge: %+v", r)
+	}
+	if !vecParallelTo(ea.MajorAxis, 1, 0, solveTol) {
+		t.Errorf("arc major axis = %v, want horizontal (1,0)", ea.MajorAxis)
+	}
+}
+
+// ellipseAxisVectorFor returns the ellipse's major axis, or its minor axis (a quarter turn on).
+func ellipseAxisVectorFor(e *Ellipse, major bool) math.Vector2 {
+	if major {
+		return e.MajorAxis
+	}
+	return math.V2(-e.MajorAxis.Y, e.MajorAxis.X)
 }
 
 // TestEllipseAxisOfRejectsNonEllipse: a line is not an ellipse-axis source (#1879).

--- a/model/sketch/copy_constraints_registry.go
+++ b/model/sketch/copy_constraints_registry.go
@@ -58,6 +58,8 @@ var constraintCarriers2D = map[ConstraintKind]constraintCarrier{
 	EllipseParallelKind:      carrier(carryEllipseAxis),
 	EllipsePerpendicularKind: carrier(carryEllipseAxis),
 	EllipseCollinearKind:     carrier(carryEllipseAxis),
+	EllipseHorizontalKind:    carrier(carryEllipseAxis),
+	EllipseVerticalKind:      carrier(carryEllipseAxis),
 	FixKind:                  carrier(carryFixKind),
 	SmoothKind:               carrier(carrySmooth),
 	GroundKind:               carrier(carryGround),

--- a/model/sketch/copy_constraints_test.go
+++ b/model/sketch/copy_constraints_test.go
@@ -128,6 +128,8 @@ func TestCopyCarriesEveryConstraintAndDimensionKind(t *testing.T) {
 	g.AddEllipseParallel(eop(true), LineAxis(l1))
 	g.AddEllipsePerpendicular(eop(false), LineAxis(l2))
 	g.AddEllipseCollinear(eop(true), LineAxis(l3))
+	g.AddEllipseHorizontal(eop(true)) // ellipse H/V carry the world-axis operand (#1879 AC2)
+	g.AddEllipseVertical(eop(false))
 	g.AddFix(pa)
 
 	// The six kinds the pre-#1637 switch silently dropped (TextBoxAnchor is the

--- a/model/sketch/drag.go
+++ b/model/sketch/drag.go
@@ -32,7 +32,9 @@ func (s *Sketch) DragSolve(pins []PinTarget) SolveResult {
 	for _, pt := range pins {
 		cons = append(cons, dragFix(pt.P, pt.Target))
 	}
-	return Solve(cons, s.variables(), Options{})
+	r := Solve(cons, s.variables(), Options{})
+	s.syncEllipseAxes()
+	return r
 }
 
 // pointDefined is an entity that can name its constrainable points (each entity declares its own

--- a/model/sketch/ellipse_orientation.go
+++ b/model/sketch/ellipse_orientation.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// Ellipse orientation as a solver DOF (#1879 AC2). An ellipse's major-axis direction is a
+// genuine rotational degree of freedom — a sketched ellipse can spin about its centre until
+// constrained — so making its axis horizontal/vertical (or aligning it to a line) requires the
+// solver to rotate it. We model that one DOF as a scalar angle (orientation) rather than the two
+// components of MajorAxis: two free components would spuriously add a magnitude DOF and let the
+// solver collapse the axis to a degenerate zero vector. MajorAxis stays the authoritative
+// direction outside a solve; variables() seeds orientation from it and Solve writes it back, so
+// every existing MajorAxis reader/writer is untouched.
+
+// axisAngle exposes the orientation DOF pointer for the constraint solver (Ellipse and
+// EllipticalArc both carry one).
+func (e *Ellipse) axisAngle() *math.Scalar       { return &e.orientation }
+func (e *EllipticalArc) axisAngle() *math.Scalar { return &e.orientation }
+
+// seedOrientation refreshes the orientation angle from the current MajorAxis, so the DOF the
+// solver reads always matches the authoritative direction (idempotent).
+func (e *Ellipse) seedOrientation()       { e.orientation = axisToAngle(e.MajorAxis) }
+func (e *EllipticalArc) seedOrientation() { e.orientation = axisToAngle(e.MajorAxis) }
+
+// syncAxisFromOrientation rewrites MajorAxis from the (possibly solver-moved) orientation,
+// preserving the vector's length so only its direction changes.
+func (e *Ellipse) syncAxisFromOrientation() { e.MajorAxis = angleToAxis(e.orientation, e.MajorAxis) }
+func (e *EllipticalArc) syncAxisFromOrientation() {
+	e.MajorAxis = angleToAxis(e.orientation, e.MajorAxis)
+}
+
+// axisToAngle is the major-axis direction's angle from +X (0 for a degenerate zero axis).
+func axisToAngle(axis math.Vector2) math.Scalar {
+	return stdmath.Atan2(float64(axis.Y), float64(axis.X))
+}
+
+// angleToAxis rebuilds an axis vector at the given angle, keeping the reference vector's length
+// (a zero-length reference is left as a unit vector rather than collapsing to the origin).
+func angleToAxis(angle math.Scalar, ref math.Vector2) math.Vector2 {
+	length := ref.Length()
+	if length == 0 {
+		length = 1
+	}
+	return math.V2(length*stdmath.Cos(float64(angle)), length*stdmath.Sin(float64(angle)))
+}

--- a/model/sketch/entities.go
+++ b/model/sketch/entities.go
@@ -146,17 +146,23 @@ func (a *Arc) circularVars() []*math.Scalar {
 }
 
 // Ellipse is a full ellipse: a center, a major-axis direction, and the two radii.
+// orientation is the solver's rotational DOF — the major-axis angle from +X in radians
+// (#1879). MajorAxis is the authoritative direction outside a solve; the solver seeds
+// orientation from it and writes it back rotated (see solve_sketch.go), so callers keep
+// reading MajorAxis and never touch orientation directly.
 type Ellipse struct {
 	entityBase
 	Center      *Point
 	MajorAxis   math.Vector2
 	MajorRadius math.Scalar
 	MinorRadius math.Scalar
+	orientation math.Scalar
 }
 
 // EllipticalArc is an ellipse restricted to a parametric-angle range [StartAngle,
 // EndAngle] (radians, measured in the major/minor frame). It shares the ellipse's
-// center, major-axis direction, and two radii.
+// center, major-axis direction, and two radii. orientation is its rotational DOF
+// (see [Ellipse], #1879).
 type EllipticalArc struct {
 	entityBase
 	Center      *Point
@@ -165,6 +171,7 @@ type EllipticalArc struct {
 	MinorRadius math.Scalar
 	StartAngle  math.Scalar
 	EndAngle    math.Scalar
+	orientation math.Scalar
 }
 
 // SplineFitMethod aliases the public fit-method enum (M06-F11,

--- a/model/sketch/serialize_codecs_ellipse_axis.go
+++ b/model/sketch/serialize_codecs_ellipse_axis.go
@@ -21,6 +21,29 @@ func registerEllipseAxisConstraintCodecs() {
 	registerConstraintCodec(EllipseCollinearKind, axisRelationCodec(func(g *GeometricConstraints, a, b AxisOperand) {
 		g.AddEllipseCollinear(a, b)
 	}))
+	registerConstraintCodec(EllipseHorizontalKind, ellipseWorldAxisCodec(func(g *GeometricConstraints, e AxisOperand) {
+		g.AddEllipseHorizontal(e)
+	}))
+	registerConstraintCodec(EllipseVerticalKind, ellipseWorldAxisCodec(func(g *GeometricConstraints, e AxisOperand) {
+		g.AddEllipseVertical(e)
+	}))
+}
+
+// ellipseWorldAxisCodec pairs a horizontal/vertical ellipse-axis relation with its factory: only
+// the ellipse operand is stored (the world axis is implied by the kind), so decode resolves the
+// single stored operand and the factory supplies the world axis (#1879 AC2).
+func ellipseWorldAxisCodec(add func(*GeometricConstraints, AxisOperand)) constraintCodec {
+	return constraintCodec{
+		encode: encodeAxisOperands,
+		decode: func(r *sketchRestorer, cd ConstraintData) error {
+			e, err := r.axisOperand(cd, 0)
+			if err != nil {
+				return err
+			}
+			add(r.s.geomCons, e)
+			return nil
+		},
+	}
 }
 
 // encodeAxisOperands stores each real operand's entity id + major flag (a world axis names no

--- a/model/sketch/serialize_constraint_registry_test.go
+++ b/model/sketch/serialize_constraint_registry_test.go
@@ -30,6 +30,7 @@ var (
 		ConcentricKind, EqualRadiusKind, CircularTangentKind, TangentKind,
 		SymmetryKind, LineSymmetryKind, CircularSymmetryKind, ArcMidpointKind,
 		EllipseParallelKind, EllipsePerpendicularKind, EllipseCollinearKind,
+		EllipseHorizontalKind, EllipseVerticalKind,
 		FixKind, SmoothKind,
 		GroundKind, OffsetKind, PatternLinkKind, TextBoxAnchorKind, CustomKind,
 	}
@@ -159,6 +160,8 @@ func populateEvery2DConstraintKind(s *Sketch) {
 	g.AddEllipseParallel(ellOp(true), LineAxis(l1))
 	g.AddEllipsePerpendicular(ellOp(false), LineAxis(l2))
 	g.AddEllipseCollinear(ellOp(true), LineAxis(l1))
+	g.AddEllipseHorizontal(ellOp(true))
+	g.AddEllipseVertical(ellOp(false))
 	g.AddFix(l1.A)
 	g.AddSmooth(l1, arc, l1.B, arc.Start)
 	g.AddGroundPoints(l2.A, l2.B)

--- a/model/sketch/solve_sketch.go
+++ b/model/sketch/solve_sketch.go
@@ -8,10 +8,12 @@ import (
 	"oblikovati.org/solve"
 )
 
-// variables returns the full DOF universe of the planar sketch: every point's X,Y
-// plus circle and ellipse radii. The solver needs the whole universe (not just
-// constraint-referenced variables) so that free, unconstrained geometry is counted
-// in the DOF total.
+// variables returns the full DOF universe of the planar sketch: every point's X,Y, circle and
+// ellipse radii, and each ellipse's orientation angle. The solver needs the whole universe (not
+// just constraint-referenced variables) so that free, unconstrained geometry is counted in the
+// DOF total — an unconstrained ellipse genuinely has a rotational DOF (#1879 AC2). Each ellipse's
+// orientation is re-seeded from its authoritative MajorAxis here, so every solve/analyze path
+// starts consistent regardless of who last moved the axis.
 func (s *Sketch) variables() []*math.Scalar {
 	vars := make([]*math.Scalar, 0, len(s.pts)*2)
 	for _, p := range s.pts {
@@ -21,9 +23,28 @@ func (s *Sketch) variables() []*math.Scalar {
 		vars = append(vars, &c.Radius)
 	}
 	for _, e := range s.ellipses.items {
-		vars = append(vars, &e.MajorRadius, &e.MinorRadius)
+		e.seedOrientation()
+		vars = append(vars, &e.MajorRadius, &e.MinorRadius, e.axisAngle())
+	}
+	// Elliptical arcs contribute only their orientation DOF here; their radii were never in the
+	// DOF universe (an arc's extent is authored, not solved), and this change keeps that scope.
+	for _, e := range s.ellArcs.items {
+		e.seedOrientation()
+		vars = append(vars, e.axisAngle())
 	}
 	return vars
+}
+
+// syncEllipseAxes rewrites every ellipse's MajorAxis from its solver-moved orientation, restoring
+// the authoritative direction after a geometry-mutating solve (#1879 AC2). Analyze-only paths that
+// build variables() but never move geometry skip this — orientation was only seeded, not changed.
+func (s *Sketch) syncEllipseAxes() {
+	for _, e := range s.ellipses.items {
+		e.syncAxisFromOrientation()
+	}
+	for _, e := range s.ellArcs.items {
+		e.syncAxisFromOrientation()
+	}
 }
 
 // Solve resolves the sketch from its constraints, updating geometry in place and
@@ -32,6 +53,7 @@ func (s *Sketch) variables() []*math.Scalar {
 // warning; otherwise it is healthy. Returns the full [SolveResult].
 func (s *Sketch) Solve() SolveResult {
 	result := Solve(s.Constraints(), s.variables(), Options{})
+	s.syncEllipseAxes()
 	s.health = healthFromSolve(result)
 	return result
 }
@@ -48,6 +70,7 @@ func (s *Sketch) AnalyzeConstraints() DOFAnalysis {
 func (s *Sketch) ConflictingConstraints() []Constraint {
 	cons := s.Constraints()
 	r := Solve(cons, s.variables(), Options{})
+	s.syncEllipseAxes()
 	if len(r.Conflicts) == 0 {
 		return nil
 	}

--- a/model/sketch/solver_test.go
+++ b/model/sketch/solver_test.go
@@ -164,9 +164,11 @@ func TestSolveStatusStrings(t *testing.T) {
 
 func TestEllipseRadiiAreDegreesOfFreedom(t *testing.T) {
 	s := NewSketches().Add(XYPlane())
-	s.Ellipses().Add(math.P2(0, 0), math.V2(1, 0), 4, 2) // center(2) + 2 radii = 4 free vars
+	// center(2) + 2 radii + orientation angle = 5 free vars; the orientation DOF (#1879 AC2) lets
+	// the ellipse rotate until a constraint pins its axis.
+	s.Ellipses().Add(math.P2(0, 0), math.V2(1, 0), 4, 2)
 	a := s.AnalyzeConstraints()
-	if a.Variables != 4 || a.DOF != 4 {
-		t.Errorf("ellipse DOF universe = %d vars / %d DOF, want 4 / 4", a.Variables, a.DOF)
+	if a.Variables != 5 || a.DOF != 5 {
+		t.Errorf("ellipse DOF universe = %d vars / %d DOF, want 5 / 5", a.Variables, a.DOF)
 	}
 }


### PR DESCRIPTION
Completes the deferred remainder of #1879: **horizontal/vertical of an ellipse axis** (acceptance criterion AC2), which the parallel/perpendicular/collinear PR (#1925) left open because it needs an ellipse-orientation solver DOF.

## What changed

An ellipse's major-axis direction is now a genuine solver **degree of freedom** — a single `orientation` angle per ellipse / elliptical arc — so the solver can **rotate** an ellipse to satisfy a constraint. `horizontal`/`vertical` of an ellipse axis becomes solvable: the ellipse turns until its chosen axis is parallel to the fixed world X/Y datum.

### Model (`model/sketch`)
- `Ellipse`/`EllipticalArc` gain an `orientation` DOF. `MajorAxis` stays the **authoritative** direction outside a solve; `variables()` re-seeds `orientation` from it (every solve/analyze path starts consistent), and the geometry-mutating solve paths (`Solve`/`DragSolve`/`ConflictingConstraints`) write `MajorAxis` back from the moved orientation, length-preserving. No construction/transform site needs touching.
- The ellipse-axis operand is now **DOF-driven**: its direction is `(cosθ, sinθ)` of the orientation, so parallel/perpendicular/collinear can move either operand, and horizontal/vertical can rotate the ellipse.
- New world-axis operand + `AddEllipseHorizontal`/`AddEllipseVertical` + `EllipseHorizontalKind`/`EllipseVerticalKind`, with full registration (codec, copy carrier, persisted vocabulary, round-trip + copy coverage).

### Router (`addin/router`)
- `horizontal`/`vertical` with a **single ellipse ref** rotates that ellipse's axis (major/minor per `UseEllipseMajorAxis`); the two kinds enumerate as the wire `horizontal`/`vertical`.

## Notes
- **API is unchanged** — the wire contract already anticipated this (its doc says "ONE line id (or one ellipse id)" and `UseEllipseMajorAxis` "applies to the single-operand horizontal/vertical form"). Host-only PR.
- A lone ellipse now reports **5 DOF** (centre + 2 radii + orientation) — geometrically correct: it can spin until constrained. Updated the one DOF assertion accordingly.
- **Honest limitation (documented):** an operand sitting *exactly* perpendicular to the target starts at the angular residual's zero-gradient dead point and will not rotate — the same measure-zero case the existing perpendicular/parallel constraints already have on exactly-parallel lines.

## Tests
- Model: ellipse & elliptical-arc rotate to horizontal/vertical (major & minor), 45° grounding; existing parallel/perp/collinear tests pin the ellipse's new rotational DOF so the line still moves.
- Router: single-ellipse horizontal/vertical dispatch, enumeration, minor-axis flag; existing ellipse-line relation tests pin the ellipse.
- Full suite green (109 packages); gofmt + golangci-lint clean (only the known CRLF `goimports` false positives).

Closes #1879.

🤖 Generated with [Claude Code](https://claude.com/claude-code)