### PR TITLE
feat(sketch): driven/textPoint/linearDiameter at dimension create (#1875)

### DIFF
--- a/addin/router/sketch_dimension_create_options_test.go
+++ b/addin/router/sketch_dimension_create_options_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// offsetDimSketch adds a line (0,0)-(4,0) and a point (2,3) to sketch 0 and returns the point id
+// and line id — the operands of an offset dimension whose perpendicular distance is 3.
+func offsetDimSketch(t *testing.T, r *Router, s *app.Session) (point, line uint64) {
+	t.Helper()
+	var l, p wire.AddSketchEntityResult
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"line","points":[[0,0],[4,0]]}`, &l)
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"point","points":[[2,3]]}`, &p)
+	return p.EntityID, l.EntityID
+}
+
+// TestSketchDimensionDrivenAtCreate creates a driven (reference) offset dimension in one call and
+// verifies it neither constrains (DOF unchanged) nor enumerates as driving (#1875).
+func TestSketchDimensionDrivenAtCreate(t *testing.T) {
+	r, s := seededSession(t)
+	p, l := offsetDimSketch(t, r, s)
+
+	var free wire.SolveSketchResult
+	call(t, r, s, "sketch.solve", `{"sketchIndex":0}`, &free)
+
+	var res wire.AddDimensionResult
+	call(t, r, s, "sketch.addDimension", mustJSON(t, wire.AddDimensionArgs{
+		SketchIndex: 0, Kind: "offsetDim", Entities: []uint64{p, l}, Expression: "1 cm", Driven: true,
+	}), &res)
+	if res.DOF != free.DOF {
+		t.Errorf("driven dimension changed DOF %d→%d; a reference dim must not constrain", free.DOF, res.DOF)
+	}
+
+	var list wire.ListDimensionsResult
+	call(t, r, s, "sketch.dimensions", `{"sketchIndex":0}`, &list)
+	if len(list.Dimensions) != 1 || !list.Dimensions[0].Driven {
+		t.Errorf("enumerated dims = %+v, want one driven dim", list.Dimensions)
+	}
+}
+
+// TestSketchDimensionLinearDiameterDoublesValue creates an offset dimension with LinearDiameter and
+// verifies the reported value is twice the 3-unit perpendicular distance, and that enumeration
+// echoes the flag (#1875).
+func TestSketchDimensionLinearDiameterDoublesValue(t *testing.T) {
+	r, s := seededSession(t)
+	p, l := offsetDimSketch(t, r, s)
+
+	var res wire.AddDimensionResult
+	call(t, r, s, "sketch.addDimension", mustJSON(t, wire.AddDimensionArgs{
+		SketchIndex: 0, Kind: "offsetDim", Entities: []uint64{p, l}, Expression: "1 cm", LinearDiameter: true,
+	}), &res)
+	if math.Abs(res.Value-6) > 1e-9 {
+		t.Errorf("linear-diameter offset value = %g, want 6 (2× the 3-unit distance)", res.Value)
+	}
+
+	var list wire.ListDimensionsResult
+	call(t, r, s, "sketch.dimensions", `{"sketchIndex":0}`, &list)
+	if len(list.Dimensions) != 1 || !list.Dimensions[0].LinearDiameter {
+		t.Errorf("enumerated dims = %+v, want one linearDiameter dim", list.Dimensions)
+	}
+}
+
+// TestSketchDimensionTextPointRoundTrips stores a text placement at create and reads it back from
+// enumeration; a malformed textPoint is a clean error (#1875).
+func TestSketchDimensionTextPointRoundTrips(t *testing.T) {
+	r, s := seededSession(t)
+	p, l := offsetDimSketch(t, r, s)
+
+	call(t, r, s, "sketch.addDimension", mustJSON(t, wire.AddDimensionArgs{
+		SketchIndex: 0, Kind: "offsetDim", Entities: []uint64{p, l}, Expression: "3 cm", TextPoint: []float64{1.5, 2},
+	}), &wire.AddDimensionResult{})
+
+	var list wire.ListDimensionsResult
+	call(t, r, s, "sketch.dimensions", `{"sketchIndex":0}`, &list)
+	if len(list.Dimensions) != 1 || len(list.Dimensions[0].TextPoint) != 2 ||
+		list.Dimensions[0].TextPoint[0] != 1.5 || list.Dimensions[0].TextPoint[1] != 2 {
+		t.Errorf("enumerated textPoint = %+v, want [1.5,2]", list.Dimensions)
+	}
+
+	if err := tryCall(t, r, s, "sketch.addDimension", mustJSON(t, wire.AddDimensionArgs{
+		SketchIndex: 0, Kind: "offsetDim", Entities: []uint64{p, l}, Expression: "3 cm", TextPoint: []float64{1},
+	})); err == nil {
+		t.Error("a one-element textPoint should error")
+	}
+}

--- a/addin/router/sketch_dimensions.go
+++ b/addin/router/sketch_dimensions.go
@@ -8,6 +8,7 @@ import (
 	"oblikovati.org/api/types"
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
+	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/param"
 	"oblikovati.org/model/sketch"
@@ -24,8 +25,11 @@ func addDimension(_ *app.Session, part *compdef.PartComponentDefinition, in wire
 	if !ok {
 		return wire.AddDimensionResult{}, fmt.Errorf("sketch.addDimension: unknown orientation %q (want aligned|horizontal|vertical)", in.Orientation)
 	}
-	dim, err := buildDimension(sk, types.DimensionConstraintKind(in.Kind), in.Entities, in.Expression, in.FarSide, orientation)
+	dim, err := buildDimension(sk, types.DimensionConstraintKind(in.Kind), in.Entities, in.Expression, in.FarSide, in.LinearDiameter, orientation)
 	if err != nil {
+		return wire.AddDimensionResult{}, err
+	}
+	if err := applyCreateOptions(dim, in); err != nil {
 		return wire.AddDimensionResult{}, err
 	}
 	dc := sk.DimensionConstraints()
@@ -33,6 +37,23 @@ func addDimension(_ *app.Session, part *compdef.PartComponentDefinition, in wire
 		Index: dc.Count() - 1, Kind: in.Kind, Parameter: dim.Parameter().Name(),
 		Value: dim.Measured(), DOF: sk.DegreesOfFreedom(),
 	}, nil
+}
+
+// applyCreateOptions sets the driven flag and text placement at create (#1875), before the
+// result's DOF is read — so a driven dimension is already non-constraining and never transiently
+// over-constrains the sketch.
+func applyCreateOptions(dim *sketch.DimensionConstraint, in wire.AddDimensionArgs) error {
+	if in.Driven {
+		dim.SetDriven(true)
+	}
+	switch len(in.TextPoint) {
+	case 0:
+	case 2:
+		dim.SetTextPoint(math.P2(math.Scalar(in.TextPoint[0]), math.Scalar(in.TextPoint[1])))
+	default:
+		return fmt.Errorf("sketch.addDimension: textPoint needs [x,y], got %d values", len(in.TextPoint))
+	}
+	return nil
 }
 
 // driveDimension edits a dimension: its value (expression), driven flag, and/or limits.
@@ -66,7 +87,7 @@ func applyDimensionEdit(part *compdef.PartComponentDefinition, dim *sketch.Dimen
 
 // buildDimension resolves references and applies the matching model dimension factory. orientation
 // applies only to the distance kind (aligned/horizontal/vertical); other kinds ignore it.
-func buildDimension(sk *sketch.Sketch, kind types.DimensionConstraintKind, refs []uint64, expr string, farSide bool, orientation sketch.DistanceOrientation) (*sketch.DimensionConstraint, error) {
+func buildDimension(sk *sketch.Sketch, kind types.DimensionConstraintKind, refs []uint64, expr string, farSide, linearDiameter bool, orientation sketch.DistanceOrientation) (*sketch.DimensionConstraint, error) {
 	dc := sk.DimensionConstraints()
 	switch kind {
 	case types.DimConstraintDistance:
@@ -88,20 +109,20 @@ func buildDimension(sk *sketch.Sketch, kind types.DimensionConstraintKind, refs 
 	case types.DimConstraintArcLength:
 		return arcLengthDimension(sk, refs, expr)
 	default:
-		return buildAdvancedDimension(sk, kind, refs, expr, farSide)
+		return buildAdvancedDimension(sk, kind, refs, expr, farSide, linearDiameter)
 	}
 }
 
 // buildAdvancedDimension handles the M21 dimension kinds (offset/three-point-angle/
 // ellipse-radius) plus the tangent-distance dimension (#152); split out of buildDimension to
 // keep that switch small.
-func buildAdvancedDimension(sk *sketch.Sketch, kind types.DimensionConstraintKind, refs []uint64, expr string, farSide bool) (*sketch.DimensionConstraint, error) {
+func buildAdvancedDimension(sk *sketch.Sketch, kind types.DimensionConstraintKind, refs []uint64, expr string, farSide, linearDiameter bool) (*sketch.DimensionConstraint, error) {
 	dc := sk.DimensionConstraints()
 	switch kind {
 	case types.DimConstraintTangentDistance:
-		return tangentDistanceDimension(sk, refs, expr, farSide)
+		return tangentDistanceDimension(sk, refs, expr, farSide, linearDiameter)
 	case types.DimConstraintOffset:
-		return offsetDimension(sk, refs, expr)
+		return offsetDimension(sk, refs, expr, linearDiameter)
 	case types.DimConstraintThreePointAngle:
 		v, a, b, err := threePointRefs(sk, refs)
 		if err != nil {
@@ -121,7 +142,7 @@ func buildAdvancedDimension(sk *sketch.Sketch, kind types.DimensionConstraintKin
 
 // tangentDistanceDimension resolves a line + circle/arc ref and dimensions the distance from
 // the line to the curve's near (default) or far tangent point (#152).
-func tangentDistanceDimension(sk *sketch.Sketch, refs []uint64, expr string, farSide bool) (*sketch.DimensionConstraint, error) {
+func tangentDistanceDimension(sk *sketch.Sketch, refs []uint64, expr string, farSide, linearDiameter bool) (*sketch.DimensionConstraint, error) {
 	if len(refs) != 2 {
 		return nil, fmt.Errorf("sketch.addDimension: tangentDistance needs a line ref and a circle/arc ref, got %d", len(refs))
 	}
@@ -133,11 +154,11 @@ func tangentDistanceDimension(sk *sketch.Sketch, refs []uint64, expr string, far
 	if err != nil {
 		return nil, err
 	}
-	return sk.DimensionConstraints().AddTangentDistance(l, c, farSide, expr)
+	return sk.DimensionConstraints().AddTangentDistance(l, c, farSide, linearDiameter, expr)
 }
 
 // offsetDimension resolves a point + line ref and dimensions their perpendicular distance.
-func offsetDimension(sk *sketch.Sketch, refs []uint64, expr string) (*sketch.DimensionConstraint, error) {
+func offsetDimension(sk *sketch.Sketch, refs []uint64, expr string, linearDiameter bool) (*sketch.DimensionConstraint, error) {
 	if len(refs) != 2 {
 		return nil, fmt.Errorf("sketch.addDimension: offsetDim needs a point + line ref, got %d", len(refs))
 	}
@@ -149,7 +170,7 @@ func offsetDimension(sk *sketch.Sketch, refs []uint64, expr string) (*sketch.Dim
 	if err != nil {
 		return nil, err
 	}
-	return sk.DimensionConstraints().AddOffsetDim(p, l, expr)
+	return sk.DimensionConstraints().AddOffsetDim(p, l, linearDiameter, expr)
 }
 
 // threePointRefs resolves three point refs (vertex, a, b).

--- a/addin/router/sketch_enumerate.go
+++ b/addin/router/sketch_enumerate.go
@@ -86,15 +86,19 @@ func enumerateDimensions(_ *app.Session, part *compdef.PartComponentDefinition, 
 // dimensionInfo renders one dimensional constraint as its wire summary.
 func dimensionInfo(index int, d *sketch.DimensionConstraint) wire.DimensionInfo {
 	info := wire.DimensionInfo{
-		Index:       index,
-		Kind:        string(dimensionKind(d.Kind())),
-		Value:       d.Measured(),
-		Driven:      d.Driven(),
-		Orientation: sketch.DistanceOrientationName(d.Orientation()),
+		Index:          index,
+		Kind:           string(dimensionKind(d.Kind())),
+		Value:          d.Measured(),
+		Driven:         d.Driven(),
+		Orientation:    sketch.DistanceOrientationName(d.Orientation()),
+		LinearDiameter: d.LinearDiameter(),
 	}
 	if p := d.Parameter(); p != nil {
 		info.Name = p.Name()
 		info.Expression = p.Expression()
+	}
+	if tp, ok := d.TextPoint(); ok {
+		info.TextPoint = []float64{float64(tp.X), float64(tp.Y)}
 	}
 	return info
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.131.0
+	oblikovati.org/api v0.132.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.131.0
+	oblikovati.org/api v0.132.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/sketch/autodiff_test.go
+++ b/model/sketch/autodiff_test.go
@@ -220,10 +220,10 @@ func TestDimensionPartialsMatchFiniteDifference(t *testing.T) {
 		{"radius-arc", mk(d.AddRadius(arc, "2 cm"))},
 		{"diameter", mk(d.AddDiameter(c1, "4 cm"))},
 		{"angle", mk(d.AddAngle(l1, l2, "30 deg"))},
-		{"tangent-distance-near", mk(d.AddTangentDistance(l1, c1, false, "1 cm"))},
-		{"tangent-distance-far", mk(d.AddTangentDistance(l2, c1, true, "1 cm"))},
+		{"tangent-distance-near", mk(d.AddTangentDistance(l1, c1, false, false, "1 cm"))},
+		{"tangent-distance-far", mk(d.AddTangentDistance(l2, c1, true, false, "1 cm"))},
 		{"arc-length", mk(d.AddArcLength(arc, "3 cm"))},
-		{"offset", mk(d.AddOffsetDim(p, l1, "1 cm"))},
+		{"offset", mk(d.AddOffsetDim(p, l1, false, "1 cm"))},
 		{"three-point-angle", mk(d.AddThreePointAngle(vtx, p, q, "45 deg"))},
 		{"ellipse-radius", mk(d.AddEllipseRadius(ell, "3 cm"))},
 	}

--- a/model/sketch/copy_constraints.go
+++ b/model/sketch/copy_constraints.go
@@ -228,6 +228,9 @@ func (target *Sketch) carryDimension(d *DimensionConstraint, m *cloneMap) bool {
 	if d.limits.Enabled {
 		nd.SetLimits(d.limits.Min, d.limits.Max)
 	}
+	if tp, ok := d.TextPoint(); ok {
+		nd.SetTextPoint(tp)
+	}
 	return true
 }
 
@@ -281,7 +284,7 @@ func (target *Sketch) recreateAdvancedDimension(d *DimensionConstraint, m *clone
 	switch d.kind {
 	case OffsetDim:
 		if p, l, ok := m.refPointLine(d.refs); ok {
-			return added(dc.AddOffsetDim(p, l, expr))
+			return added(dc.AddOffsetDim(p, l, d.linearDiameter, expr))
 		}
 	case ThreePointAngleDim:
 		if vx, a, b, ok := m.refPoints3(d.refs); ok {
@@ -293,7 +296,7 @@ func (target *Sketch) recreateAdvancedDimension(d *DimensionConstraint, m *clone
 		}
 	case TangentDistanceDim:
 		if l, c, ok := m.refLineCurve(d.refs); ok {
-			return added(dc.AddTangentDistance(l, c, d.farSide, expr))
+			return added(dc.AddTangentDistance(l, c, d.farSide, d.linearDiameter, expr))
 		}
 	}
 	return nil, false

--- a/model/sketch/copy_constraints_test.go
+++ b/model/sketch/copy_constraints_test.go
@@ -160,10 +160,10 @@ func TestCopyCarriesEveryConstraintAndDimensionKind(t *testing.T) {
 	add(dc.AddRadius(c1, "1 mm"))
 	add(dc.AddDiameter(c2, "2 mm"))
 	add(dc.AddArcLength(arc, "1 mm"))
-	add(dc.AddOffsetDim(pa, l2, "1 mm"))
+	add(dc.AddOffsetDim(pa, l2, false, "1 mm"))
 	add(dc.AddThreePointAngle(pa, pb, l1.B, "45 deg"))
 	add(dc.AddEllipseRadius(ell, "2 mm"))
-	add(dc.AddTangentDistance(l1, c1, false, "1 mm"))
+	add(dc.AddTangentDistance(l1, c1, false, false, "1 mm"))
 
 	wantC, wantD := g.Count(), dc.Count()
 

--- a/model/sketch/dimension.go
+++ b/model/sketch/dimension.go
@@ -62,15 +62,17 @@ func (l ConstraintLimits) clamp(v float64) float64 {
 // the parameter's value (modeling/00).
 type DimensionConstraint struct {
 	constraintBase
-	kind        DimKind
-	driven      bool
-	param       *param.Parameter
-	limits      ConstraintLimits
-	measureAD   adFunc1 // the measured quantity over duals; the float measure derives from it
-	vars        []*math.Scalar
-	refs        []Entity            // the dimensioned geometry (points/lines/arcs), for editing + serialization
-	farSide     bool                // tangentDistance only: dimension to the far tangent point (#152)
-	orientation DistanceOrientation // distance only: aligned (Euclidean) / horizontal (Δx) / vertical (Δy) (#1869)
+	kind           DimKind
+	driven         bool
+	param          *param.Parameter
+	limits         ConstraintLimits
+	measureAD      adFunc1 // the measured quantity over duals; the float measure derives from it
+	vars           []*math.Scalar
+	refs           []Entity            // the dimensioned geometry (points/lines/arcs), for editing + serialization
+	farSide        bool                // tangentDistance only: dimension to the far tangent point (#152)
+	orientation    DistanceOrientation // distance only: aligned (Euclidean) / horizontal (Δx) / vertical (Δy) (#1869)
+	textPoint      *math.Point2        // annotation-text placement; nil ⇒ unset (Inventor TextPoint, #1875)
+	linearDiameter bool                // offset/tangentDistance only: value reads as a diameter, 2× the distance (#1875)
 }
 
 // DistanceOrientation selects what a two-point distance dimension measures — Inventor's
@@ -121,6 +123,22 @@ func ParseDistanceOrientation(name string) (DistanceOrientation, bool) {
 // FarSide reports whether a tangent-distance dimension measures to the far tangent point
 // (#152); false (the near side) for every other kind.
 func (d *DimensionConstraint) FarSide() bool { return d.farSide }
+
+// LinearDiameter reports whether an offset/tangent-distance dimension reads as a diameter —
+// its value is 2× the measured linear distance (Inventor bool LinearDiameter, #1875).
+func (d *DimensionConstraint) LinearDiameter() bool { return d.linearDiameter }
+
+// TextPoint returns the dimension's annotation-text placement and whether one is stored
+// (Inventor Point2d TextPoint, #1875).
+func (d *DimensionConstraint) TextPoint() (math.Point2, bool) {
+	if d.textPoint == nil {
+		return math.Point2{}, false
+	}
+	return *d.textPoint, true
+}
+
+// SetTextPoint records the dimension's annotation-text placement (#1875).
+func (d *DimensionConstraint) SetTextPoint(p math.Point2) { d.textPoint = &p }
 
 // Refs returns the geometry the dimension measures (points for a distance, the line
 // pair for an angle, the circle for a radius, …). It is what serialization records so
@@ -279,8 +297,8 @@ func (dc *DimensionConstraints) AddAngle(l1, l2 *Line, expression string) (*Dime
 // tangent point: |perpendicular distance from the center to the line| ∓ radius — the near
 // side (default) subtracts the radius, the far side adds it (#152). The solver drives the
 // line's endpoints and the curve's center/radius (circularVars) to satisfy the target.
-func (dc *DimensionConstraints) AddTangentDistance(l *Line, c CircularCurve, farSide bool, expression string) (*DimensionConstraint, error) {
-	measure := func(v []ad.Number) ad.Number {
+func (dc *DimensionConstraints) AddTangentDistance(l *Line, c CircularCurve, farSide, linearDiameter bool, expression string) (*DimensionConstraint, error) {
+	measure := diameterScaled(func(v []ad.Number) ad.Number {
 		a, b := ad.V2(v[0], v[1]), ad.V2(v[2], v[3])
 		center, radius, _ := c.circularFrameAD(v, 4)
 		dir := b.Sub(a)
@@ -293,14 +311,25 @@ func (dc *DimensionConstraints) AddTangentDistance(l *Line, c CircularCurve, far
 			return d.Add(radius)
 		}
 		return d.Sub(radius)
-	}
+	}, linearDiameter)
 	vars := append([]*math.Scalar{&l.A.X, &l.A.Y, &l.B.X, &l.B.Y}, c.circularVars()...)
 	d, err := dc.create(TangentDistanceDim, expression, []Entity{l, c}, measure, vars)
 	if err != nil {
 		return nil, err
 	}
-	d.farSide = farSide
+	d.farSide, d.linearDiameter = farSide, linearDiameter
 	return d, nil
+}
+
+// diameterScaled wraps a linear measure to read as a diameter — 2× the distance — when
+// linearDiameter is set, so an offset/tangent-distance dimension presents and drives a diameter
+// value (#1875). Doubling the measure keeps report and drive consistent: a target T solves to a
+// linear distance of T/2.
+func diameterScaled(measure adFunc1, linearDiameter bool) adFunc1 {
+	if !linearDiameter {
+		return measure
+	}
+	return func(v []ad.Number) ad.Number { return measure(v).Scale(2) }
 }
 
 // AddArcLength dimensions an arc's length (radius × swept angle).

--- a/model/sketch/dimension_advanced.go
+++ b/model/sketch/dimension_advanced.go
@@ -7,9 +7,10 @@ import (
 	"oblikovati.org/solve/ad"
 )
 
-// AddOffsetDim dimensions the perpendicular distance from point p to line l.
-func (dc *DimensionConstraints) AddOffsetDim(p *Point, l *Line, expression string) (*DimensionConstraint, error) {
-	measure := func(v []ad.Number) ad.Number {
+// AddOffsetDim dimensions the perpendicular distance from point p to line l. With linearDiameter
+// the value reads as a diameter — 2× that distance (Inventor's LinearDiameter, #1875).
+func (dc *DimensionConstraints) AddOffsetDim(p *Point, l *Line, linearDiameter bool, expression string) (*DimensionConstraint, error) {
+	measure := diameterScaled(func(v []ad.Number) ad.Number {
 		pt, a, b := ad.V2(v[0], v[1]), ad.V2(v[2], v[3]), ad.V2(v[4], v[5])
 		dir := b.Sub(a)
 		length := dir.Length()
@@ -17,9 +18,14 @@ func (dc *DimensionConstraints) AddOffsetDim(p *Point, l *Line, expression strin
 			return pt.Sub(a).Length() // degenerate line: distance to its point
 		}
 		return dir.Cross(pt.Sub(a)).Div(length).Abs()
-	}
+	}, linearDiameter)
 	vars := []*math.Scalar{&p.X, &p.Y, &l.A.X, &l.A.Y, &l.B.X, &l.B.Y}
-	return dc.create(OffsetDim, expression, []Entity{p, l}, measure, vars)
+	d, err := dc.create(OffsetDim, expression, []Entity{p, l}, measure, vars)
+	if err != nil {
+		return nil, err
+	}
+	d.linearDiameter = linearDiameter
+	return d, nil
 }
 
 // AddThreePointAngle dimensions the angle a–vertex–b (the included angle at vertex).

--- a/model/sketch/dimension_advanced_test.go
+++ b/model/sketch/dimension_advanced_test.go
@@ -13,7 +13,7 @@ func TestOffsetDimMeasuresPerpendicular(t *testing.T) {
 	s := NewSketches().Add(XYPlane())
 	l := s.Lines().AddByTwoPoints(gmath.P2(0, 0), gmath.P2(4, 0))
 	p := s.Points().Add(gmath.P2(2, 3))
-	d, err := s.DimensionConstraints().AddOffsetDim(p, l, "30 mm")
+	d, err := s.DimensionConstraints().AddOffsetDim(p, l, false, "30 mm")
 	if err != nil {
 		t.Fatalf("AddOffsetDim: %v", err)
 	}
@@ -58,7 +58,7 @@ func TestAdvancedDimsRoundTrip(t *testing.T) {
 	v := s.Points().Add(gmath.P2(5, 5))
 	a := s.Points().Add(gmath.P2(6, 5))
 	b := s.Points().Add(gmath.P2(5, 6))
-	if _, err := s.DimensionConstraints().AddOffsetDim(p, l, "30 mm"); err != nil {
+	if _, err := s.DimensionConstraints().AddOffsetDim(p, l, false, "30 mm"); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := s.DimensionConstraints().AddThreePointAngle(v, a, b, "90 deg"); err != nil {

--- a/model/sketch/dimension_create_options_test.go
+++ b/model/sketch/dimension_create_options_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestLinearDiameterDoublesOffsetMeasure: an offset dimension created with linearDiameter reports
+// twice the perpendicular distance, so it presents a diameter value (#1875).
+func TestLinearDiameterDoublesOffsetMeasure(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	l := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0))
+	p := s.Points().Add(math.P2(2, 3)) // perpendicular distance 3
+
+	d, err := s.DimensionConstraints().AddOffsetDim(p, l, true, "1 cm")
+	if err != nil {
+		t.Fatalf("AddOffsetDim: %v", err)
+	}
+	if !d.LinearDiameter() {
+		t.Error("LinearDiameter() = false, want true")
+	}
+	if got := d.Measured(); stdmath.Abs(got-6) > 1e-9 {
+		t.Errorf("linear-diameter offset measure = %v, want 6 (2×3)", got)
+	}
+}
+
+// TestLinearDiameterDrivesToHalfDistance: driving a linear-diameter offset dimension to "6 cm"
+// solves the perpendicular distance to 3 — the diameter target is met at half the linear distance,
+// proving report and drive stay consistent (#1875).
+func TestLinearDiameterDrivesToHalfDistance(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	l := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0))
+	p := s.Points().Add(math.P2(2, 5)) // starts at distance 5
+	g := s.GeometricConstraints()
+	g.AddFix(l.A)
+	g.AddFix(l.B)
+
+	if _, err := s.DimensionConstraints().AddOffsetDim(p, l, true, "6 cm"); err != nil {
+		t.Fatalf("AddOffsetDim: %v", err)
+	}
+	if r := s.Solve(); !r.Converged {
+		t.Fatalf("solve did not converge: residual=%v", r.Residual)
+	}
+	if got := stdmath.Abs(float64(p.Y)); stdmath.Abs(got-3) > 1e-6 {
+		t.Errorf("solved perpendicular distance = %v, want 3 (half the 6 cm diameter)", got)
+	}
+}
+
+// TestTextPointSetAndGet round-trips a text placement through the accessors (#1875).
+func TestTextPointSetAndGet(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	l := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0))
+	p := s.Points().Add(math.P2(2, 3))
+	d, _ := s.DimensionConstraints().AddOffsetDim(p, l, false, "3 cm")
+
+	if _, ok := d.TextPoint(); ok {
+		t.Error("a fresh dimension should have no text point")
+	}
+	d.SetTextPoint(math.P2(1.5, 2))
+	if tp, ok := d.TextPoint(); !ok || tp != math.P2(1.5, 2) {
+		t.Errorf("TextPoint() = (%v, %v), want (1.5,2), true", tp, ok)
+	}
+}
+
+// TestDimensionCreateOptionsSurviveRoundTrip serializes an offset dimension carrying both
+// linearDiameter and a text point, then restores it and checks both survived (#1875).
+func TestDimensionCreateOptionsSurviveRoundTrip(t *testing.T) {
+	sc := NewSketches()
+	s := sc.Add(XYPlane())
+	l := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0))
+	p := s.Points().Add(math.P2(2, 3))
+	d, _ := s.DimensionConstraints().AddOffsetDim(p, l, true, "6 cm")
+	d.SetTextPoint(math.P2(1.5, 2))
+
+	out := roundTrip(t, sc)
+	dims := out.DimensionConstraints().All()
+	if len(dims) != 1 {
+		t.Fatalf("restored dimension count = %d, want 1", len(dims))
+	}
+	got := dims[0]
+	if !got.LinearDiameter() {
+		t.Error("restored dim lost its linearDiameter flag")
+	}
+	if tp, ok := got.TextPoint(); !ok || tp != math.P2(1.5, 2) {
+		t.Errorf("restored textPoint = (%v, %v), want (1.5,2), true", tp, ok)
+	}
+	if v := got.Measured(); stdmath.Abs(v-6) > 1e-9 {
+		t.Errorf("restored linear-diameter measure = %v, want 6", v)
+	}
+}
+
+// TestCopyCarriesTextPointAndLinearDiameter copies an offset dimension carrying both attributes to
+// another sketch and checks they travel with it (#1875).
+func TestCopyCarriesTextPointAndLinearDiameter(t *testing.T) {
+	src := NewSketches().Add(XYPlane())
+	l := src.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0))
+	p := src.Points().Add(math.P2(2, 3))
+	d, _ := src.DimensionConstraints().AddOffsetDim(p, l, true, "6 cm")
+	d.SetTextPoint(math.P2(1.5, 2))
+
+	target := NewSketches().Add(XYPlane())
+	if _, warns := target.CopyEntitiesWithConstraints(src, src.Entities(), math.V2(10, 0)); len(warns) != 0 {
+		t.Fatalf("unexpected copy warnings: %v", warns)
+	}
+	dims := target.DimensionConstraints().All()
+	if len(dims) != 1 {
+		t.Fatalf("copied dimension count = %d, want 1", len(dims))
+	}
+	got := dims[0]
+	if !got.LinearDiameter() {
+		t.Error("copy dropped the linearDiameter flag")
+	}
+	if tp, ok := got.TextPoint(); !ok || tp != math.P2(1.5, 2) {
+		t.Errorf("copied textPoint = (%v, %v), want (1.5,2), true", tp, ok)
+	}
+}

--- a/model/sketch/serialize.go
+++ b/model/sketch/serialize.go
@@ -149,14 +149,16 @@ type ConstraintData struct {
 // DimensionData is one dimensional constraint: its kind, operand ids, the value
 // expression, and driving/limit state.
 type DimensionData struct {
-	Kind        string      `yaml:"kind"`
-	Points      []int       `yaml:"points,omitempty"`
-	Curves      []int       `yaml:"curves,omitempty"`
-	Expression  string      `yaml:"expression"`
-	Driven      bool        `yaml:"driven,omitempty"`
-	FarSide     bool        `yaml:"farSide,omitempty"`     // tangentDistance only (#152)
-	Orientation string      `yaml:"orientation,omitempty"` // distance only: horizontal/vertical (absent ⇒ aligned) (#1869)
-	Limits      *LimitsData `yaml:"limits,omitempty"`
+	Kind           string      `yaml:"kind"`
+	Points         []int       `yaml:"points,omitempty"`
+	Curves         []int       `yaml:"curves,omitempty"`
+	Expression     string      `yaml:"expression"`
+	Driven         bool        `yaml:"driven,omitempty"`
+	FarSide        bool        `yaml:"farSide,omitempty"`        // tangentDistance only (#152)
+	Orientation    string      `yaml:"orientation,omitempty"`    // distance only: horizontal/vertical (absent ⇒ aligned) (#1869)
+	LinearDiameter bool        `yaml:"linearDiameter,omitempty"` // offset/tangentDistance only: value reads as a diameter (#1875)
+	TextPoint      []float64   `yaml:"textPoint,omitempty"`      // [x,y] annotation placement, absent when unset (#1875)
+	Limits         *LimitsData `yaml:"limits,omitempty"`
 }
 
 // LimitsData carries a dimension's drive limits when enabled.
@@ -343,9 +345,12 @@ func serializeSplineHandles(sp *Spline) []SplineHandleData {
 }
 
 func serializeDimension(d *DimensionConstraint) (DimensionData, error) {
-	dd := DimensionData{Expression: d.param.Expression(), Driven: d.driven, FarSide: d.farSide, Orientation: DistanceOrientationName(d.orientation)}
+	dd := DimensionData{Expression: d.param.Expression(), Driven: d.driven, FarSide: d.farSide, Orientation: DistanceOrientationName(d.orientation), LinearDiameter: d.linearDiameter}
 	if d.limits.Enabled {
 		dd.Limits = &LimitsData{Min: d.limits.Min, Max: d.limits.Max}
+	}
+	if tp, ok := d.TextPoint(); ok {
+		dd.TextPoint = []float64{float64(tp.X), float64(tp.Y)}
 	}
 	kind, err := dimKindName(d.kind)
 	if err != nil {

--- a/model/sketch/serialize_dimensions_roundtrip_test.go
+++ b/model/sketch/serialize_dimensions_roundtrip_test.go
@@ -44,11 +44,11 @@ func TestAllDimensionKindsSurviveRoundTrip(t *testing.T) {
 	chk("arcLength", err)
 	_, err = dc.AddEllipseRadius(ell, "2 cm")
 	chk("ellipseRadius", err)
-	_, err = dc.AddOffsetDim(c, l1, "3 cm")
+	_, err = dc.AddOffsetDim(c, l1, false, "3 cm")
 	chk("offset", err)
 	_, err = dc.AddThreePointAngle(a, b, c, "45 deg")
 	chk("threePointAngle", err)
-	_, err = dc.AddTangentDistance(l1, circle, false, "1 cm")
+	_, err = dc.AddTangentDistance(l1, circle, false, false, "1 cm")
 	chk("tangentDistance", err)
 
 	wantDims := s.DimensionConstraints().Count()

--- a/model/sketch/serialize_restore.go
+++ b/model/sketch/serialize_restore.go
@@ -257,6 +257,9 @@ func (r *sketchRestorer) restoreDimensions(dims []DimensionData) error {
 		if dd.Limits != nil {
 			d.SetLimits(dd.Limits.Min, dd.Limits.Max)
 		}
+		if len(dd.TextPoint) == 2 {
+			d.SetTextPoint(math.P2(math.Scalar(dd.TextPoint[0]), math.Scalar(dd.TextPoint[1])))
+		}
 	}
 	return nil
 }
@@ -330,7 +333,7 @@ func (r *sketchRestorer) restoreAdvancedDimension(dd DimensionData) (*DimensionC
 		if err != nil {
 			return nil, err
 		}
-		return dc.AddOffsetDim(p, l, dd.Expression)
+		return dc.AddOffsetDim(p, l, dd.LinearDiameter, dd.Expression)
 	case "threePointAngle":
 		pts, err := r.points(dd.Points, 3)
 		if err != nil {
@@ -352,7 +355,7 @@ func (r *sketchRestorer) restoreAdvancedDimension(dd DimensionData) (*DimensionC
 		if err != nil {
 			return nil, err
 		}
-		return dc.AddTangentDistance(l, c, dd.FarSide, dd.Expression)
+		return dc.AddTangentDistance(l, c, dd.FarSide, dd.LinearDiameter, dd.Expression)
 	default:
 		return nil, fmt.Errorf("unknown dimension kind %q", dd.Kind)
 	}

--- a/model/sketch/sketch_gaps_test.go
+++ b/model/sketch/sketch_gaps_test.go
@@ -41,7 +41,7 @@ func TestTangentDistanceDimRoundTrip(t *testing.T) {
 	a, b := s.NewPoint(math.P2(0, 0)), s.NewPoint(math.P2(4, 0))
 	line := s.Lines().Add(a, b)
 	circle := s.Circles().Add(s.NewPoint(math.P2(0, 5)), 2)
-	d, err := s.DimensionConstraints().AddTangentDistance(line, circle, true, "1 cm")
+	d, err := s.DimensionConstraints().AddTangentDistance(line, circle, true, false, "1 cm")
 	if err != nil {
 		t.Fatalf("AddTangentDistance: %v", err)
 	}


### PR DESCRIPTION
Closes #1875. Brings `sketch.addDimension` up to Inventor's `Add*(…, Point2d TextPoint, bool? Driven, bool LinearDiameter)` call shape (M42 Sketch2D parity, milestone #44). Pins API **v0.132.0** ([Oblikovati.API#257](https://github.com/Oblikovati/Oblikovati.API/pull/257)).

## What changed
- **driven-at-create** — `addDimension` accepts `driven=true` and creates a reference dimension in one call. The router flips the flag *before* the result's DOF is read, so a driven dimension never transiently over-constrains (the old create-then-`SetDriven` path could). AC1 ✔
- **textPoint** — `DimensionConstraint` stores an optional annotation-text placement (`*math.Point2`, nil ⇒ unset). Set at create, round-tripped through serialize + copy, and reported on `sketch.dimensions`. AC2 ✔
- **linearDiameter** — offset/tangent-distance dims read as a diameter: the measure is doubled, so a target `T` solves to a linear distance of `T/2` (report and drive stay consistent). Threaded through `AddOffsetDim`/`AddTangentDistance`, serialize/restore, copy carry, enumeration. AC3 ✔

## Tests
- Model: `linearDiameter` doubles the offset measure; drives to half the distance; textPoint set/get; serialize round-trip carries both; copy carries both.
- Router: driven-at-create leaves DOF unchanged + enumerates driven; `linearDiameter` value doubled + echoed; `textPoint` round-trips through enumeration; malformed `textPoint` errors.

Full model/sketch, router and persistence suites green; gofmt + golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)