### PR TITLE
feat(sketch): offset-spline dimension drives the offset distance (#1874)

### DIFF
--- a/addin/router/sketch_dimensions.go
+++ b/addin/router/sketch_dimensions.go
@@ -135,9 +135,27 @@ func buildAdvancedDimension(sk *sketch.Sketch, kind types.DimensionConstraintKin
 			return nil, err
 		}
 		return dc.AddEllipseRadius(e, expr)
+	case types.DimConstraintOffsetSpline:
+		return offsetSplineDimension(sk, refs, expr)
 	default:
 		return nil, fmt.Errorf("sketch.addDimension: unsupported kind %q", kind)
 	}
+}
+
+// offsetSplineDimension resolves a single offset-spline ref and drives its offset distance (#1874).
+func offsetSplineDimension(sk *sketch.Sketch, refs []uint64, expr string) (*sketch.DimensionConstraint, error) {
+	if len(refs) != 1 {
+		return nil, fmt.Errorf("sketch.addDimension: offsetSplineDim needs 1 offset-spline ref, got %d", len(refs))
+	}
+	e, ok := sk.EntityByID(sketch.ID(refs[0]))
+	if !ok {
+		return nil, fmt.Errorf("sketch.addDimension: no entity with id %d", refs[0])
+	}
+	o, ok := e.(*sketch.OffsetSpline)
+	if !ok {
+		return nil, fmt.Errorf("sketch.addDimension: entity %d is %T, want an offset spline", refs[0], e)
+	}
+	return sk.DimensionConstraints().AddOffsetSplineDim(o, expr)
 }
 
 // tangentDistanceDimension resolves a line + circle/arc ref and dimensions the distance from

--- a/addin/router/sketch_enumerate.go
+++ b/addin/router/sketch_enumerate.go
@@ -280,6 +280,8 @@ func advancedDimensionKind(k sketch.DimKind) types.DimensionConstraintKind {
 		return types.DimConstraintEllipseRadius
 	case sketch.TangentDistanceDim:
 		return types.DimConstraintTangentDistance
+	case sketch.OffsetSplineDim:
+		return types.DimConstraintOffsetSpline
 	default:
 		return types.DimConstraintUnknown
 	}

--- a/addin/router/sketch_offset_spline_dimension_test.go
+++ b/addin/router/sketch_offset_spline_dimension_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// TestSketchOffsetSplineDimensionOverWire creates a spline, offsets it, dimensions the offset via
+// sketch.addDimension kind=offsetSplineDim, and confirms the driven value and enumeration (#1874).
+func TestSketchOffsetSplineDimensionOverWire(t *testing.T) {
+	r, s := seededSession(t)
+
+	var sp wire.AddSketchEntityResult
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"spline","points":[[0,0],[1,1],[2,0]]}`, &sp)
+	var off wire.AddSketchEntityResult
+	call(t, r, s, "sketch.addEntity", mustJSON(t, wire.AddSketchEntityArgs{
+		SketchIndex: 0, Kind: "offsetSpline", EntityRefs: []uint64{sp.EntityID}, Radius: "2 cm",
+	}), &off)
+
+	var res wire.AddDimensionResult
+	call(t, r, s, "sketch.addDimension", mustJSON(t, wire.AddDimensionArgs{
+		SketchIndex: 0, Kind: "offsetSplineDim", Entities: []uint64{off.EntityID}, Expression: "5 mm",
+	}), &res)
+	if res.Kind != "offsetSplineDim" {
+		t.Errorf("created dim kind = %q, want offsetSplineDim", res.Kind)
+	}
+
+	call(t, r, s, "sketch.solve", `{"sketchIndex":0}`, &wire.SolveSketchResult{})
+	var list wire.ListDimensionsResult
+	call(t, r, s, "sketch.dimensions", `{"sketchIndex":0}`, &list)
+	if len(list.Dimensions) != 1 || list.Dimensions[0].Kind != "offsetSplineDim" {
+		t.Fatalf("enumerated dims = %+v, want one offsetSplineDim", list.Dimensions)
+	}
+	if math.Abs(list.Dimensions[0].Value-0.5) > 1e-6 {
+		t.Errorf("driven offset value = %g cm, want 0.5 (5 mm)", list.Dimensions[0].Value)
+	}
+}
+
+// TestSketchOffsetSplineDimensionRejectsNonOffsetSpline: pointing the dimension at a plain spline is
+// a clean error (#1874).
+func TestSketchOffsetSplineDimensionRejectsNonOffsetSpline(t *testing.T) {
+	r, s := seededSession(t)
+	var sp wire.AddSketchEntityResult
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"spline","points":[[0,0],[1,1],[2,0]]}`, &sp)
+
+	if err := tryCall(t, r, s, "sketch.addDimension", mustJSON(t, wire.AddDimensionArgs{
+		SketchIndex: 0, Kind: "offsetSplineDim", Entities: []uint64{sp.EntityID}, Expression: "5 mm",
+	})); err == nil {
+		t.Error("dimensioning a plain spline as an offset spline should error")
+	}
+}

--- a/model/sketch/derived_curves.go
+++ b/model/sketch/derived_curves.go
@@ -131,11 +131,12 @@ func (c *FixedSplines) Count() int              { return len(c.items) }
 func (c *FixedSplines) Item(i int) *FixedSpline { return c.items[i] }
 
 // OffsetSpline is the offset of a parent spline by a signed distance (left of the parent's
-// direction for a positive distance). Immutable; tracks the parent by reference.
+// direction for a positive distance). It tracks the parent by reference; Dist is a solver DOF, so
+// an offset-spline dimension can drive it (#1874) and an undriven offset is free to slide.
 type OffsetSpline struct {
 	entityBase
 	Parent *Spline
-	Dist   float64
+	Dist   math.Scalar
 }
 
 // OffsetSplines creates and tracks offset splines.

--- a/model/sketch/dimension.go
+++ b/model/sketch/dimension.go
@@ -30,6 +30,8 @@ const (
 	SplineLengthDimKind3D // a 3D spline's sampled arc length
 	// Appended for issue #152 (do not reorder).
 	TangentDistanceDim // distance from a line to a circle/arc's near/far tangent point
+	// Appended for issue #1874 (do not reorder).
+	OffsetSplineDim // an offset spline's offset distance from its parent
 )
 
 // ConstraintLimits bounds a dimension's value for drive/animation. When Enabled,

--- a/model/sketch/dimension_advanced.go
+++ b/model/sketch/dimension_advanced.go
@@ -44,3 +44,11 @@ func (dc *DimensionConstraints) AddEllipseRadius(e *Ellipse, expression string) 
 	measure := func(v []ad.Number) ad.Number { return v[0] }
 	return dc.create(EllipseRadiusDim, expression, []Entity{e}, measure, []*math.Scalar{&e.MajorRadius})
 }
+
+// AddOffsetSplineDim drives an offset spline's offset distance from its parent (#1874). The
+// measure is the magnitude of the signed offset, so a positive length expression preserves the
+// side the offset was created on while setting its distance.
+func (dc *DimensionConstraints) AddOffsetSplineDim(o *OffsetSpline, expression string) (*DimensionConstraint, error) {
+	measure := func(v []ad.Number) ad.Number { return v[0].Abs() }
+	return dc.create(OffsetSplineDim, expression, []Entity{o}, measure, []*math.Scalar{&o.Dist})
+}

--- a/model/sketch/dimension_offset_spline_test.go
+++ b/model/sketch/dimension_offset_spline_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// offsetSplineFixture builds a parent spline and an offset of it at the given signed distance.
+func offsetSplineFixture(s *Sketch, dist float64) *OffsetSpline {
+	parent := s.Splines().AddByPoints([]math.Point2{math.P2(0, 0), math.P2(1, 1), math.P2(2, 0)}, false)
+	return s.OffsetSplines().Add(parent, dist)
+}
+
+// TestOffsetSplineDistIsSolverDOF: adding an offset spline grows the DOF universe by exactly one —
+// its offset distance is a solver variable, so an offset-spline dimension can drive it (#1874).
+func TestOffsetSplineDistIsSolverDOF(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	parent := s.Splines().AddByPoints([]math.Point2{math.P2(0, 0), math.P2(1, 1), math.P2(2, 0)}, false)
+	before := s.AnalyzeConstraints().Variables
+	s.OffsetSplines().Add(parent, 2)
+	if after := s.AnalyzeConstraints().Variables; after != before+1 {
+		t.Errorf("offset spline changed the variable count by %d, want +1", after-before)
+	}
+}
+
+// TestAddOffsetSplineDimDrivesDistance drives the offset to a 5 mm target and checks the solved
+// distance is 0.5 cm on the same (positive) side it was created (#1874).
+func TestAddOffsetSplineDimDrivesDistance(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	off := offsetSplineFixture(s, 2) // starts at +2 cm
+
+	if _, err := s.DimensionConstraints().AddOffsetSplineDim(off, "5 mm"); err != nil {
+		t.Fatalf("AddOffsetSplineDim: %v", err)
+	}
+	if r := s.Solve(); !r.Converged {
+		t.Fatalf("solve did not converge: residual=%v", r.Residual)
+	}
+	if stdmath.Abs(float64(off.Dist)-0.5) > 1e-6 {
+		t.Errorf("solved offset = %v cm, want +0.5 (magnitude 5 mm, side preserved)", off.Dist)
+	}
+}
+
+// TestOffsetSplineDimPreservesNegativeSide: an offset created on the negative side keeps that side
+// when driven — the measure is the magnitude, so the sign is untouched (#1874).
+func TestOffsetSplineDimPreservesNegativeSide(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	off := offsetSplineFixture(s, -2)
+
+	if _, err := s.DimensionConstraints().AddOffsetSplineDim(off, "5 mm"); err != nil {
+		t.Fatalf("AddOffsetSplineDim: %v", err)
+	}
+	if r := s.Solve(); !r.Converged {
+		t.Fatalf("solve did not converge: residual=%v", r.Residual)
+	}
+	if stdmath.Abs(float64(off.Dist)+0.5) > 1e-6 {
+		t.Errorf("solved offset = %v cm, want -0.5 (negative side preserved)", off.Dist)
+	}
+}
+
+// TestOffsetSplineDimSurvivesRoundTrip serializes an offset-spline dimension and restores it (#1874).
+func TestOffsetSplineDimSurvivesRoundTrip(t *testing.T) {
+	sc := NewSketches()
+	s := sc.Add(XYPlane())
+	off := offsetSplineFixture(s, 1.5)
+	if _, err := s.DimensionConstraints().AddOffsetSplineDim(off, "1 cm"); err != nil {
+		t.Fatalf("AddOffsetSplineDim: %v", err)
+	}
+
+	out := roundTrip(t, sc)
+	dims := out.DimensionConstraints().All()
+	if len(dims) != 1 || dims[0].Kind() != OffsetSplineDim {
+		t.Fatalf("restored dims = %+v, want one offsetSplineDim", dims)
+	}
+	if len(dims[0].Refs()) != 1 {
+		t.Fatalf("restored offsetSplineDim refs = %d, want 1", len(dims[0].Refs()))
+	}
+	if _, ok := dims[0].Refs()[0].(*OffsetSpline); !ok {
+		t.Errorf("restored offsetSplineDim target = %T, want *OffsetSpline", dims[0].Refs()[0])
+	}
+}

--- a/model/sketch/serialize.go
+++ b/model/sketch/serialize.go
@@ -390,6 +390,8 @@ func dimKindName(k DimKind) (string, error) {
 		return "ellipseRadius", nil
 	case TangentDistanceDim:
 		return "tangentDistance", nil
+	case OffsetSplineDim:
+		return "offsetSplineDim", nil
 	default:
 		return "", fmt.Errorf("cannot serialize dimension of kind %d (no codec)", k)
 	}

--- a/model/sketch/serialize_restore.go
+++ b/model/sketch/serialize_restore.go
@@ -356,6 +356,12 @@ func (r *sketchRestorer) restoreAdvancedDimension(dd DimensionData) (*DimensionC
 			return nil, err
 		}
 		return dc.AddTangentDistance(l, c, dd.FarSide, dd.LinearDiameter, dd.Expression)
+	case "offsetSplineDim":
+		o, err := r.offsetSpline(dd.Curves, 0)
+		if err != nil {
+			return nil, err
+		}
+		return dc.AddOffsetSplineDim(o, dd.Expression)
 	default:
 		return nil, fmt.Errorf("unknown dimension kind %q", dd.Kind)
 	}
@@ -371,6 +377,17 @@ func (r *sketchRestorer) ellipse(ids []int, i int) (*Ellipse, error) {
 		return nil, fmt.Errorf("entity %d is not an ellipse", ids[i])
 	}
 	return e, nil
+}
+
+func (r *sketchRestorer) offsetSpline(ids []int, i int) (*OffsetSpline, error) {
+	if i >= len(ids) {
+		return nil, fmt.Errorf("offset-spline operand %d missing", i)
+	}
+	o, ok := r.entityMap[ids[i]].(*OffsetSpline)
+	if !ok {
+		return nil, fmt.Errorf("entity %d is not an offset spline", ids[i])
+	}
+	return o, nil
 }
 
 // --- operand resolution -------------------------------------------------------------

--- a/model/sketch/solve_sketch.go
+++ b/model/sketch/solve_sketch.go
@@ -32,6 +32,11 @@ func (s *Sketch) variables() []*math.Scalar {
 		e.seedOrientation()
 		vars = append(vars, e.axisAngle())
 	}
+	// An offset spline's signed offset distance is a solver DOF, so an offset-spline dimension can
+	// drive it and an undriven offset is genuinely free (#1874).
+	for _, o := range s.offSpl.items {
+		vars = append(vars, &o.Dist)
+	}
 	return vars
 }
 


### PR DESCRIPTION
Closes #1874. Adds the `offsetSplineDim` dimension (Inventor `OffsetSplineDimConstraint` / `AddOffsetSpline`; M42 Sketch2D parity, milestone #44). Builds on API **v0.132.0** ([Oblikovati.API#257](https://github.com/Oblikovati/Oblikovati.API/pull/257)).

## Approach
An offset spline's signed offset distance becomes a **solver DOF** — mirroring how an ellipse's radius is a DOF — so a dimension drives it and an *undriven* offset is genuinely free to slide:
- `OffsetSpline.Dist` joins the solver variable universe (`solve_sketch.go` `variables()`).
- `AddOffsetSplineDim` measures the offset **magnitude**, so a positive length expression sets the distance while preserving the side the offset was created on (positive/negative).
- Full registration: `dimKindName` + restore case + offset-spline restorer resolver; router `buildAdvancedDimension` case + `offsetSplineDimension` helper; enumeration kind mapping.

## Acceptance criteria
- ✔ `add_sketch_dimension kind=offsetSplineDim` over an offset spline drives its offset distance by expression.
- ✔ Editing the expression re-solves the offset on next recompute (standard `Solve` path).
- ✔ Non-offset-spline refs error clearly.

## Note on copy
Offset splines are not clonable (they are derived curves), so `CopyEntitiesTo` drops an `offsetSplineDim` — the same behavior as any dimension whose operand is left behind. It is therefore intentionally absent from the copy-every-kind coverage test.

## Tests
- Model: offset `Dist` is counted as a DOF (+1); driving to 5 mm solves to 0.5 cm on the created side; negative side preserved; serialize round-trip.
- Router: create→drive→enumerate over the wire (value 0.5 cm); non-offset-spline ref errors.

Full model/sketch, router and persistence suites green; gofmt + golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)