### PR TITLE
feat(head): render PanelTree + PanelTable panel controls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.132.0
+	oblikovati.org/api v0.133.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.132.0
+	oblikovati.org/api v0.133.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -122,10 +122,11 @@ void obk_ig_center_next_window(void);
 void obk_ig_set_next_window_size(float w, float h);
 void obk_ig_set_next_window_size_first_use(float w, float h);
 
-// Table verbs (the Parameters dialog grid). begin_table opens a bordered, row-striped,
-// vertically scrolling table of `columns` columns; pair with end_table only when it
-// returned non-zero. setup_column/setup_scroll_freeze/headers_row define the header;
-// next_row/next_column advance the cursor (next_column returns visibility). push_id_int/
+// Table verbs (the Parameters dialog grid, the content-center member table, …). begin_table
+// opens a bordered, row-striped, vertically scrolling table of `columns` columns; begin_table_scrollx
+// is the same but also scrolls horizontally (a wide grid in a narrow docked panel). Pair either with
+// end_table only when it returned non-zero. setup_column/setup_scroll_freeze/headers_row define the
+// header; next_row/next_column advance the cursor (next_column returns visibility). push_id_int/
 // pop_id scope per-row widget ids so identical cell labels don't collide.
 int  obk_ig_begin_table(const char* id, int columns, float outer_w, float outer_h);
 int  obk_ig_begin_table_scrollx(const char* id, int columns, float outer_w, float outer_h);

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -128,6 +128,7 @@ void obk_ig_set_next_window_size_first_use(float w, float h);
 // next_row/next_column advance the cursor (next_column returns visibility). push_id_int/
 // pop_id scope per-row widget ids so identical cell labels don't collide.
 int  obk_ig_begin_table(const char* id, int columns, float outer_w, float outer_h);
+int  obk_ig_begin_table_scrollx(const char* id, int columns, float outer_w, float outer_h);
 void obk_ig_table_setup_column(const char* label);
 void obk_ig_table_setup_scroll_freeze(int cols, int rows);
 void obk_ig_table_headers_row(void);
@@ -606,6 +607,14 @@ func BeginTable(id string, columns int, w, h float32) bool {
 	return C.obk_ig_begin_table(c, C.int(columns), C.float(w), C.float(h)) != 0
 }
 func EndTable() { C.obk_ig_end_table() }
+
+// BeginTableScrollX is BeginTable plus horizontal scrolling — for a wide grid (many columns) in a
+// narrow docked panel. Pair every true return with EndTable.
+func BeginTableScrollX(id string, columns int, w, h float32) bool {
+	c, free := cstr(id)
+	defer free()
+	return C.obk_ig_begin_table_scrollx(c, C.int(columns), C.float(w), C.float(h)) != 0
+}
 
 // TableSetupColumn declares the next header column; TableSetupScrollFreeze keeps the
 // first cols columns / rows rows pinned while scrolling; TableHeadersRow emits the

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -522,6 +522,15 @@ int  obk_ig_begin_table(const char* id, int columns, float outer_w, float outer_
                             ImGuiTableFlags_Resizable | ImGuiTableFlags_ScrollY;
     return ImGui::BeginTable(id, columns, flags, ImVec2(outer_w, outer_h)) ? 1 : 0;
 }
+// begin_table_scrollx is begin_table plus horizontal scrolling, for wide data grids in a narrow
+// dock (a content-center member table). Kept separate from begin_table because ScrollX changes
+// column auto-sizing and the existing tables rely on the stretch default.
+int obk_ig_begin_table_scrollx(const char* id, int columns, float outer_w, float outer_h) {
+    ImGuiTableFlags flags = ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
+                            ImGuiTableFlags_Resizable | ImGuiTableFlags_ScrollY |
+                            ImGuiTableFlags_ScrollX;
+    return ImGui::BeginTable(id, columns, flags, ImVec2(outer_w, outer_h)) ? 1 : 0;
+}
 void obk_ig_table_setup_column(const char* label)      { ImGui::TableSetupColumn(label); }
 void obk_ig_table_setup_scroll_freeze(int cols, int rows) { ImGui::TableSetupScrollFreeze(cols, rows); }
 void obk_ig_table_headers_row(void)                    { ImGui::TableHeadersRow(); }

--- a/head/ui/addin_panels.go
+++ b/head/ui/addin_panels.go
@@ -180,6 +180,8 @@ func drawEditableControl(s *app.Session, windowID string, control wire.PanelCont
 		drawPanelSlider(s, windowID, control)
 	case types.PanelReferenceList:
 		drawPanelReferenceList(s, windowID, control)
+	case types.PanelTree:
+		drawPanelTree(s, windowID, control)
 	default:
 		return false
 	}

--- a/head/ui/addin_panels.go
+++ b/head/ui/addin_panels.go
@@ -182,6 +182,8 @@ func drawEditableControl(s *app.Session, windowID string, control wire.PanelCont
 		drawPanelReferenceList(s, windowID, control)
 	case types.PanelTree:
 		drawPanelTree(s, windowID, control)
+	case types.PanelTable:
+		drawPanelTable(s, windowID, control)
 	default:
 		return false
 	}

--- a/head/ui/addin_panels.go
+++ b/head/ui/addin_panels.go
@@ -164,16 +164,9 @@ func drawAddInPanelControl(s *app.Session, windowID string, index int, control w
 func drawEditableControl(s *app.Session, windowID string, control wire.PanelControlSpec) bool {
 	switch control.Kind {
 	case types.PanelTextBox, types.PanelValueEditor, types.PanelComboBox:
-		buf := panelBuffer(windowID+"/"+control.ID, control.Value)
-		panelFieldLabel(control.Text)
-		if native.InputText("##field", buf) {
-			s.PanelValueChanged(windowID, control.ID, bufString(buf))
-		}
+		drawPanelTextField(s, windowID, control)
 	case types.PanelCheckBox:
-		checked := control.Value == "true"
-		if native.Checkbox(control.Text, &checked) {
-			s.PanelValueChanged(windowID, control.ID, strconv.FormatBool(checked))
-		}
+		drawPanelCheckBox(s, windowID, control)
 	case types.PanelDropdown:
 		drawPanelDropdown(s, windowID, control)
 	case types.PanelSlider:
@@ -188,6 +181,25 @@ func drawEditableControl(s *app.Session, windowID string, control wire.PanelCont
 		return false
 	}
 	return true
+}
+
+// drawPanelTextField renders a stacked-caption text/combo input (#1490), pushing the new value to
+// the add-in on change. Split out of drawEditableControl to keep the dispatch switch's statement
+// count under the funlen gate as more control kinds land.
+func drawPanelTextField(s *app.Session, windowID string, control wire.PanelControlSpec) {
+	buf := panelBuffer(windowID+"/"+control.ID, control.Value)
+	panelFieldLabel(control.Text)
+	if native.InputText("##field", buf) {
+		s.PanelValueChanged(windowID, control.ID, bufString(buf))
+	}
+}
+
+// drawPanelCheckBox renders a checkbox control, pushing the new state to the add-in on toggle.
+func drawPanelCheckBox(s *app.Session, windowID string, control wire.PanelControlSpec) {
+	checked := control.Value == "true"
+	if native.Checkbox(control.Text, &checked) {
+		s.PanelValueChanged(windowID, control.ID, strconv.FormatBool(checked))
+	}
 }
 
 // drawPanelSlider renders a bounded numeric slider with its caption stacked above (#1490),

--- a/head/ui/addin_panels.go
+++ b/head/ui/addin_panels.go
@@ -158,6 +158,15 @@ func drawAddInPanelControl(s *app.Session, windowID string, index int, control w
 	}
 }
 
+// panelEditSession is the ≤1-method view of the session an editable panel widget needs (audit I5,
+// the arrowSession pattern): just the sink that reports a user edit back to the owning add-in, so
+// tree/table/field widgets don't couple to the whole *app.Session. *app.Session satisfies it.
+type panelEditSession interface {
+	PanelValueChanged(windowID, controlID, value string)
+}
+
+var _ panelEditSession = (*app.Session)(nil)
+
 // drawEditableControl renders the editable control kinds with the stacked-caption layout
 // (#1490) and reports whether control was one, keeping the leaf dispatch small. Edits push back
 // through Session.PanelValueChanged.
@@ -186,7 +195,7 @@ func drawEditableControl(s *app.Session, windowID string, control wire.PanelCont
 // drawPanelTextField renders a stacked-caption text/combo input (#1490), pushing the new value to
 // the add-in on change. Split out of drawEditableControl to keep the dispatch switch's statement
 // count under the funlen gate as more control kinds land.
-func drawPanelTextField(s *app.Session, windowID string, control wire.PanelControlSpec) {
+func drawPanelTextField(s panelEditSession, windowID string, control wire.PanelControlSpec) {
 	buf := panelBuffer(windowID+"/"+control.ID, control.Value)
 	panelFieldLabel(control.Text)
 	if native.InputText("##field", buf) {
@@ -195,7 +204,7 @@ func drawPanelTextField(s *app.Session, windowID string, control wire.PanelContr
 }
 
 // drawPanelCheckBox renders a checkbox control, pushing the new state to the add-in on toggle.
-func drawPanelCheckBox(s *app.Session, windowID string, control wire.PanelControlSpec) {
+func drawPanelCheckBox(s panelEditSession, windowID string, control wire.PanelControlSpec) {
 	checked := control.Value == "true"
 	if native.Checkbox(control.Text, &checked) {
 		s.PanelValueChanged(windowID, control.ID, strconv.FormatBool(checked))

--- a/head/ui/addin_table.go
+++ b/head/ui/addin_table.go
@@ -4,7 +4,6 @@ package ui
 
 import (
 	"oblikovati.org/api/wire"
-	"oblikovati.org/app"
 	"oblikovati.org/head/internal/native"
 )
 
@@ -32,7 +31,7 @@ func cellAt(row wire.TableRow, col int) string {
 // drawPanelTable renders a PanelTable: a scrolling, horizontally-scrolling data grid with a pinned
 // header. A row click pushes the row Key to the add-in (which arms Place). No per-frame allocation:
 // the spec's strings are drawn as-is.
-func drawPanelTable(s *app.Session, windowID string, control wire.PanelControlSpec) {
+func drawPanelTable(s panelEditSession, windowID string, control wire.PanelControlSpec) {
 	cols := len(control.TableColumns)
 	if cols == 0 {
 		return
@@ -54,7 +53,7 @@ func drawPanelTable(s *app.Session, windowID string, control wire.PanelControlSp
 
 // drawTableRow draws one selectable row spanning all columns; the first column carries a
 // row-spanning Selectable so a click anywhere on the row selects it.
-func drawTableRow(s *app.Session, windowID string, control wire.PanelControlSpec, i int) {
+func drawTableRow(s panelEditSession, windowID string, control wire.PanelControlSpec, i int) {
 	row := control.TableRows[i]
 	native.PushIDInt(i)
 	defer native.PopID()

--- a/head/ui/addin_table.go
+++ b/head/ui/addin_table.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// addInTableRows caps the member table's height so it shares the docked panel with the tree above
+// and the Place button below; the table scrolls internally past this many rows.
+const addInTableRows = 8
+
+// rowHeight is one table row's pixel height: the font's line height plus a small padding margin.
+// No table-sizing helper existed outside the Parameters dialog's own paramTableHeight (which bakes
+// in a fixed row px and an 8-row cap tuned for that grid), so PanelTable gets its own — this stays
+// proportional to the active font instead of a hardcoded pixel count.
+func rowHeight() float32 {
+	return native.TextLineHeight() + 6
+}
+
+// cellAt returns row's cell for column col, or "" when the row is shorter than the header (a
+// ragged catalog row must not panic the render loop).
+func cellAt(row wire.TableRow, col int) string {
+	if col < 0 || col >= len(row.Cells) {
+		return ""
+	}
+	return row.Cells[col]
+}
+
+// drawPanelTable renders a PanelTable: a scrolling, horizontally-scrolling data grid with a pinned
+// header. A row click pushes the row Key to the add-in (which arms Place). No per-frame allocation:
+// the spec's strings are drawn as-is.
+func drawPanelTable(s *app.Session, windowID string, control wire.PanelControlSpec) {
+	cols := len(control.TableColumns)
+	if cols == 0 {
+		return
+	}
+	h := rowHeight() * addInTableRows
+	if !native.BeginTableScrollX("##"+control.ID, cols, -1, h) {
+		return
+	}
+	defer native.EndTable()
+	for _, name := range control.TableColumns {
+		native.TableSetupColumn(name)
+	}
+	native.TableSetupScrollFreeze(0, 1)
+	native.TableHeadersRow()
+	for i := range control.TableRows {
+		drawTableRow(s, windowID, control, i)
+	}
+}
+
+// drawTableRow draws one selectable row spanning all columns; the first column carries a
+// row-spanning Selectable so a click anywhere on the row selects it.
+func drawTableRow(s *app.Session, windowID string, control wire.PanelControlSpec, i int) {
+	row := control.TableRows[i]
+	native.PushIDInt(i)
+	defer native.PopID()
+	native.TableNextRow()
+	for c := 0; c < len(control.TableColumns); c++ {
+		if !native.TableNextColumn() {
+			continue
+		}
+		if c == 0 {
+			if native.Selectable(cellAt(row, 0), row.Key == control.Value) {
+				s.PanelValueChanged(windowID, control.ID, row.Key)
+			}
+			continue
+		}
+		native.Text(cellAt(row, c))
+	}
+}

--- a/head/ui/addin_table_test.go
+++ b/head/ui/addin_table_test.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// cellAt must tolerate a row shorter than the column count (a ragged member row) by returning ""
+// rather than panicking, so a malformed catalog row can't crash the head.
+func TestCellAt(t *testing.T) {
+	row := wire.TableRow{Key: "k", Cells: []string{"10", "30"}}
+	if got := cellAt(row, 1); got != "30" {
+		t.Fatalf("cellAt col1 = %q, want 30", got)
+	}
+	if got := cellAt(row, 5); got != "" {
+		t.Fatalf("cellAt out-of-range = %q, want empty", got)
+	}
+}

--- a/head/ui/addin_tree.go
+++ b/head/ui/addin_tree.go
@@ -4,7 +4,6 @@ package ui
 
 import (
 	"oblikovati.org/api/wire"
-	"oblikovati.org/app"
 	"oblikovati.org/head/internal/native"
 )
 
@@ -25,7 +24,7 @@ func treeFirstUse(key string) bool {
 // drawPanelTree renders a PanelTree: a hierarchy of selectable, expandable nodes. The disclosure
 // arrow toggles a node (host-side, no event); a click on a node's label selects it and pushes the
 // node ID to the add-in, which re-sends the spec (e.g. to populate a members table).
-func drawPanelTree(s *app.Session, windowID string, control wire.PanelControlSpec) {
+func drawPanelTree(s panelEditSession, windowID string, control wire.PanelControlSpec) {
 	firstUse := treeFirstUse(windowID + "/" + control.ID)
 	for i := range control.Nodes {
 		drawTreeNode(s, windowID, control.ID, control.Value, control.Nodes[i], firstUse)
@@ -35,7 +34,7 @@ func drawPanelTree(s *app.Session, windowID string, control wire.PanelControlSpe
 // drawTreeNode renders one node and recurses into its children. selected is the currently-selected
 // node ID (for highlight). A leaf uses Selectable; a branch uses TreeNodeSelectable so the arrow
 // expands while a label click selects.
-func drawTreeNode(s *app.Session, windowID, controlID, selected string, node wire.TreeNode, firstUse bool) {
+func drawTreeNode(s panelEditSession, windowID, controlID, selected string, node wire.TreeNode, firstUse bool) {
 	if len(node.Children) == 0 {
 		if native.Selectable(node.Label, node.ID == selected) {
 			s.PanelValueChanged(windowID, controlID, node.ID)

--- a/head/ui/addin_tree.go
+++ b/head/ui/addin_tree.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// treeSeeded tracks which tree controls have rendered once, so a node's Expanded flag seeds the
+// disclosure state only on first render; afterwards imgui owns open/collapsed (a re-sent spec must
+// not re-collapse what the user opened). Keyed windowID+"/"+controlID.
+var treeSeeded = map[string]bool{}
+
+// treeFirstUse reports (and records) whether key is rendering for the first time.
+func treeFirstUse(key string) bool {
+	if treeSeeded[key] {
+		return false
+	}
+	treeSeeded[key] = true
+	return true
+}
+
+// drawPanelTree renders a PanelTree: a hierarchy of selectable, expandable nodes. The disclosure
+// arrow toggles a node (host-side, no event); a click on a node's label selects it and pushes the
+// node ID to the add-in, which re-sends the spec (e.g. to populate a members table).
+func drawPanelTree(s *app.Session, windowID string, control wire.PanelControlSpec) {
+	firstUse := treeFirstUse(windowID + "/" + control.ID)
+	for i := range control.Nodes {
+		drawTreeNode(s, windowID, control.ID, control.Value, control.Nodes[i], firstUse)
+	}
+}
+
+// drawTreeNode renders one node and recurses into its children. selected is the currently-selected
+// node ID (for highlight). A leaf uses Selectable; a branch uses TreeNodeSelectable so the arrow
+// expands while a label click selects.
+func drawTreeNode(s *app.Session, windowID, controlID, selected string, node wire.TreeNode, firstUse bool) {
+	if len(node.Children) == 0 {
+		if native.Selectable(node.Label, node.ID == selected) {
+			s.PanelValueChanged(windowID, controlID, node.ID)
+		}
+		return
+	}
+	if firstUse {
+		native.SetNextItemOpen(node.Expanded, true)
+	}
+	open := native.TreeNodeSelectable(node.Label, node.ID == selected)
+	if native.IsItemClicked(0) {
+		s.PanelValueChanged(windowID, controlID, node.ID)
+	}
+	if !open {
+		return
+	}
+	for i := range node.Children {
+		drawTreeNode(s, windowID, controlID, selected, node.Children[i], firstUse)
+	}
+	native.TreePop()
+}

--- a/head/ui/addin_tree_test.go
+++ b/head/ui/addin_tree_test.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import "testing"
+
+// treeFirstUse must report true the first time a control id is seen and false thereafter, so the
+// Expanded seed only applies on first render (afterwards imgui owns open/closed state).
+func TestTreeFirstUse(t *testing.T) {
+	delete(treeSeeded, "w/catalog")
+	if !treeFirstUse("w/catalog") {
+		t.Fatal("first call = false, want true")
+	}
+	if treeFirstUse("w/catalog") {
+		t.Fatal("second call = true, want false")
+	}
+}


### PR DESCRIPTION
Renders the two new API panel-control kinds (Oblikovati.API v0.132.0) natively in the docked-panel UI via the Dear-ImGui wrapper:

- `drawPanelTree` (ui/addin_tree.go): recursive nodes; a branch uses `TreeNodeSelectable` (arrow toggles open, label-click selects → emits node ID); leaves use `Selectable`; `Expanded` seeds `SetNextItemOpen` only on first render (`treeFirstUse`), so a re-sent spec never re-collapses the user's open nodes.
- `drawPanelTable` (ui/addin_table.go): header + selectable rows via a new `BeginTableScrollX` cgo shim (adds `ImGuiTableFlags_ScrollX` for wide grids in a narrow dock — a NEW variant, leaving the shared `obk_ig_begin_table` untouched so the six existing table callers are unaffected), pinned header, per-row Key emit; `cellAt` tolerates ragged rows.

Both wired into the panel dispatch. Verified live: the tree renders the PartDesigner catalog, the member table populates + scrolls, and Place produces a correct DOF-0 bearing.

Part of Oblikovati.AddIns.PartDesigner#48.