### PR TITLE
feat(sketch): project cut edges + silhouette to sketch (#1873)

### DIFF
--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -420,6 +420,8 @@ func (r *Router) registerSketchAuthoringHandlers() {
 	r.readOnly(wire.MethodSketchGetText, typedPart(getText))
 	r.readOnly(wire.MethodSketchAutoDimension, typedPart(autoDimensionSketch))
 	r.mutating(wire.MethodSketchProject, "Project Geometry", typedPart(projectGeometry))
+	r.mutating(wire.MethodSketchProjectCutEdges, "Project Cut Edges", typedPart(projectCutEdges))
+	r.mutating(wire.MethodSketchProjectSilhouette, "Project Silhouette", typedPart(projectSilhouette))
 }
 
 // registerCommandHandlers wires the command and ribbon methods — the add-in UI surface

--- a/addin/router/sketch_project.go
+++ b/addin/router/sketch_project.go
@@ -3,6 +3,8 @@
 package router
 
 import (
+	"fmt"
+
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
 	"oblikovati.org/model/compdef"
@@ -62,4 +64,41 @@ func projectRef(part *compdef.PartComponentDefinition, sk *sketch.Sketch, ref st
 		return sk.ProjectCurve(compdef.NewWorkPlaneRefSource(part, feature.WorkRef(ref), sk.Plane())), true
 	}
 	return nil, false
+}
+
+// projectCutEdges projects the section curves where the sketch plane cuts the part solid as
+// associative reference geometry — one projected curve per section loop (#1873).
+func projectCutEdges(_ *app.Session, part *compdef.PartComponentDefinition, in wire.ProjectCutEdgesArgs) (wire.ProjectGeometryResult, error) {
+	sk, err := sketchAtIndex(part, in.SketchIndex)
+	if err != nil {
+		return wire.ProjectGeometryResult{}, err
+	}
+	sources := part.CutEdgeSources(sk.Plane())
+	if len(sources) == 0 {
+		return wire.ProjectGeometryResult{}, fmt.Errorf("sketch.projectCutEdges: the sketch plane cuts no solid body")
+	}
+	created := make([]uint64, 0, len(sources))
+	for _, c := range sk.ProjectCutEdges(sources) {
+		created = append(created, uint64(c.EntityID()))
+	}
+	return wire.ProjectGeometryResult{Created: created, Healthy: true}, nil
+}
+
+// projectSilhouette projects the referenced face's silhouette onto the sketch plane as an
+// associative reference curve, choosing the loop nearest the proximity point (#1873).
+func projectSilhouette(_ *app.Session, part *compdef.PartComponentDefinition, in wire.ProjectSilhouetteArgs) (wire.ProjectGeometryResult, error) {
+	sk, err := sketchAtIndex(part, in.SketchIndex)
+	if err != nil {
+		return wire.ProjectGeometryResult{}, err
+	}
+	prox, err := xyzPoint(in.ProximityPoint, "sketch.projectSilhouette: proximityPoint")
+	if err != nil {
+		return wire.ProjectGeometryResult{}, err
+	}
+	src, ok := part.SilhouetteSource(in.FaceRef, sk.Plane(), prox, in.IncludeBoundary)
+	if !ok {
+		return wire.ProjectGeometryResult{}, fmt.Errorf("sketch.projectSilhouette: face %q has no silhouette on the sketch plane", in.FaceRef)
+	}
+	c := sk.ProjectCurve(src)
+	return wire.ProjectGeometryResult{Created: []uint64{uint64(c.EntityID())}, Healthy: true}, nil
 }

--- a/addin/router/sketch_project_derived_test.go
+++ b/addin/router/sketch_project_derived_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"testing"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/kernel/geom"
+)
+
+// curvedFaceRef extrudes a cylinder and returns a reference key for its curved side face.
+func curvedFaceRef(t *testing.T, r *Router, s *app.Session) string {
+	t.Helper()
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"circle","points":[[0,0]],"radius":"20 mm"}`, &struct{}{})
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":0,"profileIndex":0,"distance":"50 mm"}}`, &struct{}{})
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range part.SurfaceBodies().All()[0].Faces() {
+		if _, planar := f.Geometry().(geom.Plane); !planar {
+			return string(f.ReferenceKey())
+		}
+	}
+	t.Fatal("extruded cylinder has no curved face")
+	return ""
+}
+
+// TestProjectCutEdgesOverWire extrudes a block, then projects the section curves where an XZ sketch
+// cuts it — one associative projected curve per section loop (#1873).
+func TestProjectCutEdgesOverWire(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	// A profile centred on the origin, so the canonical XZ plane (y=0) cuts the block's interior.
+	for _, seg := range []string{
+		`[[-2,-1.5],[2,-1.5]]`, `[[2,-1.5],[2,1.5]]`, `[[2,1.5],[-2,1.5]]`, `[[-2,1.5],[-2,-1.5]]`,
+	} {
+		call(t, r, s, "sketch.addEntity", `{"sketchIndex":0,"kind":"line","points":`+seg+`}`, &struct{}{})
+	}
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":0,"profileIndex":0,"distance":"50 mm"}}`, &struct{}{})
+
+	call(t, r, s, "sketch.create", `{"plane":"XZ"}`, &wire.CreateSketchResult{}) // sketch 1 cuts the block
+	var proj wire.ProjectGeometryResult
+	call(t, r, s, "sketch.projectCutEdges", `{"sketchIndex":1}`, &proj)
+	if len(proj.Created) == 0 || !proj.Healthy {
+		t.Fatalf("projectCutEdges = %+v, want at least one created / healthy", proj)
+	}
+	var ents wire.EnumerateEntitiesResult
+	call(t, r, s, "sketch.entities", `{"sketchIndex":1}`, &ents)
+	if got := countKind(ents.Entities, "projectedCurve"); got != len(proj.Created) {
+		t.Errorf("enumerated %d projectedCurve, want %d", got, len(proj.Created))
+	}
+}
+
+// TestProjectCutEdgesNoSolidErrors: with no solid to cut, the op errors rather than creating a
+// dead, geometry-less reference.
+func TestProjectCutEdgesNoSolidErrors(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	if err := tryCall(t, r, s, "sketch.projectCutEdges", `{"sketchIndex":0}`); err == nil {
+		t.Error("projectCutEdges with no solid body should error")
+	}
+}
+
+// TestProjectSilhouetteOverWire projects a cylinder side face's silhouette onto a YZ sketch,
+// selecting the +Y ruling by proximity (#1873).
+func TestProjectSilhouetteOverWire(t *testing.T) {
+	r, s := emptyPartSession(t)
+	faceRef := curvedFaceRef(t, r, s)
+	call(t, r, s, "sketch.create", `{"plane":"YZ"}`, &wire.CreateSketchResult{}) // sketch 1, normal +X
+
+	var proj wire.ProjectGeometryResult
+	args, err := json.Marshal(wire.ProjectSilhouetteArgs{
+		SketchIndex: 1, FaceRef: faceRef, ProximityPoint: []float64{0, 2, 2.5}, IncludeBoundary: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	call(t, r, s, "sketch.projectSilhouette", string(args), &proj)
+	if len(proj.Created) != 1 || !proj.Healthy {
+		t.Fatalf("projectSilhouette = %+v, want 1 created / healthy", proj)
+	}
+	var ents wire.EnumerateEntitiesResult
+	call(t, r, s, "sketch.entities", `{"sketchIndex":1}`, &ents)
+	if got := countKind(ents.Entities, "projectedCurve"); got != 1 {
+		t.Errorf("enumerated %d projectedCurve, want 1 silhouette", got)
+	}
+}
+
+// TestProjectSilhouetteUnknownFaceErrors: an unresolved face reference is a clean error.
+func TestProjectSilhouetteUnknownFaceErrors(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	args, _ := json.Marshal(wire.ProjectSilhouetteArgs{
+		SketchIndex: 0, FaceRef: "no-such-face", ProximityPoint: []float64{0, 0, 0},
+	})
+	if err := tryCall(t, r, s, "sketch.projectSilhouette", string(args)); err == nil {
+		t.Error("projectSilhouette with an unknown face should error")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.133.0
+	oblikovati.org/api v0.134.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.133.0
+	oblikovati.org/api v0.134.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/compdef/section_reference_source.go
+++ b/model/compdef/section_reference_source.go
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"fmt"
+	stdmath "math"
+	"strconv"
+	"strings"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// Two more associative sketch-curve sources (#1873), alongside the edge/vertex/work-datum sources
+// (reference_source.go / work_reference_source.go): the section curves where the sketch plane cuts
+// a solid ("project cut edges") and a face's silhouette on the sketch plane ("project silhouette").
+// Both re-run their kernel op against the part's current bodies on every read, so they recompute
+// with the model like every other projected reference, and both bind to one sketch plane fixed at
+// construction — matching model/sketch projection.go and WorkPlaneRefSource.
+
+// CutEdgeRefSource adapts one section loop (the sketch plane × a part body) to a sketch curve
+// source, keyed by body index + loop index so it re-associates to the same loop after recompute.
+type CutEdgeRefSource struct {
+	bodies    func() []*topo.Body
+	plane     sketch.Plane
+	bodyIndex int
+	wireIndex int
+}
+
+// NewCutEdgeRefSource binds an associative curve source to the wireIndex-th section loop of the
+// bodyIndex-th body cut by the sketch plane.
+func NewCutEdgeRefSource(part *PartComponentDefinition, plane sketch.Plane, bodyIndex, wireIndex int) CutEdgeRefSource {
+	return CutEdgeRefSource{
+		bodies: func() []*topo.Body { return part.SurfaceBodies().All() },
+		plane:  plane, bodyIndex: bodyIndex, wireIndex: wireIndex,
+	}
+}
+
+// SourceID encodes the (body, loop) indices this source re-sections to.
+func (s CutEdgeRefSource) SourceID() string { return fmt.Sprintf("%d:%d", s.bodyIndex, s.wireIndex) }
+
+// SourceKind tags this as a cut-edge reference for projection persistence/rebind (#1873).
+func (s CutEdgeRefSource) SourceKind() string { return "cutEdge" }
+
+// SamplePoints re-sections the body by the sketch plane and samples the loop; ok=false when the
+// body or loop is gone (the plane no longer cuts it there), which freezes the projection.
+func (s CutEdgeRefSource) SamplePoints() ([]math.Point3, bool) {
+	bodies := s.bodies()
+	if s.bodyIndex < 0 || s.bodyIndex >= len(bodies) {
+		return nil, false
+	}
+	wires, ok := sectionWires(bodies[s.bodyIndex], s.plane)
+	if !ok || s.wireIndex < 0 || s.wireIndex >= len(wires) {
+		return nil, false
+	}
+	return sampleWireCurve(wires[s.wireIndex]), true
+}
+
+// CutEdgeSources sections every part body by the sketch plane and returns one associative curve
+// source per section loop, in body-then-loop order — the supply for [sketch.Sketch.ProjectCutEdges]
+// (#1873). Empty when the plane misses every body.
+func (d *PartComponentDefinition) CutEdgeSources(plane sketch.Plane) []sketch.CurveSource {
+	var out []sketch.CurveSource
+	for bi, b := range d.SurfaceBodies().All() {
+		wires, ok := sectionWires(b, plane)
+		if !ok {
+			continue
+		}
+		for wi := range wires {
+			out = append(out, NewCutEdgeRefSource(d, plane, bi, wi))
+		}
+	}
+	return out
+}
+
+// sectionWires sections one body by the sketch plane and returns its section wires; ok=false when
+// the plane misses the body or the section is degenerate.
+func sectionWires(b *topo.Body, plane sketch.Plane) ([]*topo.Wire, bool) {
+	sec, err := ops.SectionWithPlane(b, plane.Origin(), plane.Normal().AsVector(), ops.DefaultQuality())
+	if err != nil {
+		return nil, false
+	}
+	return sec.Wires(), true
+}
+
+// SilhouetteRefSource adapts a face's silhouette on the sketch plane to a curve source: it
+// re-resolves the face by reference key, re-traces its silhouette along the plane normal, and
+// returns the loop nearest the proximity point.
+type SilhouetteRefSource struct {
+	ref             string
+	bodies          func() []*topo.Body
+	plane           sketch.Plane
+	proximity       math.Point3
+	includeBoundary bool
+}
+
+// NewSilhouetteRefSource binds an associative curve source to the silhouette of the face with
+// reference key ref, viewed along plane's normal; proximity selects the loop when several exist.
+func NewSilhouetteRefSource(part *PartComponentDefinition, ref string, plane sketch.Plane, proximity math.Point3, includeBoundary bool) SilhouetteRefSource {
+	return SilhouetteRefSource{
+		ref:    ref,
+		bodies: func() []*topo.Body { return part.SurfaceBodies().All() },
+		plane:  plane, proximity: proximity, includeBoundary: includeBoundary,
+	}
+}
+
+// SourceKind tags this as a silhouette reference for projection persistence/rebind (#1873).
+func (s SilhouetteRefSource) SourceKind() string { return "silhouette" }
+
+// SourceID packs everything needed to rebuild the source after a reload: the include-boundary
+// flag, the proximity point, and the face key last — so a key containing the '|' delimiter
+// survives a SplitN.
+func (s SilhouetteRefSource) SourceID() string {
+	return fmt.Sprintf("%t|%g|%g|%g|%s", s.includeBoundary,
+		float64(s.proximity.X), float64(s.proximity.Y), float64(s.proximity.Z), s.ref)
+}
+
+// SamplePoints re-resolves the face, re-traces its silhouette along the sketch-plane normal and
+// samples the loop nearest the proximity point; ok=false when the face or its silhouette is gone.
+func (s SilhouetteRefSource) SamplePoints() ([]math.Point3, bool) {
+	face, ok := s.face()
+	if !ok {
+		return nil, false
+	}
+	sil, err := ops.FaceSilhouetteWires(face, s.plane.Normal().AsVector(), s.includeBoundary, ops.DefaultQuality())
+	if err != nil {
+		return nil, false
+	}
+	w := nearestWire(sil.Wires(), s.proximity)
+	if w == nil {
+		return nil, false
+	}
+	return sampleWireCurve(w), true
+}
+
+// face re-resolves the silhouette's face by reference key among the part's current bodies.
+func (s SilhouetteRefSource) face() (*topo.Face, bool) {
+	key := []byte(s.ref)
+	for _, b := range s.bodies() {
+		if f, ok := feature.FindOrRecoverFace(b, key); ok {
+			return f, true
+		}
+	}
+	return nil, false
+}
+
+// SilhouetteSource builds the associative silhouette curve source for the face with reference key
+// faceRef and reports whether it currently yields geometry (the face resolves and has a silhouette
+// on this plane), so the router can reject a dead pick cleanly (#1873).
+func (d *PartComponentDefinition) SilhouetteSource(faceRef string, plane sketch.Plane, proximity math.Point3, includeBoundary bool) (sketch.CurveSource, bool) {
+	src := NewSilhouetteRefSource(d, faceRef, plane, proximity, includeBoundary)
+	_, ok := src.SamplePoints()
+	return src, ok
+}
+
+// sampleWireCurve samples every edge of a section/silhouette wire into a single model-space
+// polyline (mirrors the router's wire-payload sampling, but yields points for projection).
+func sampleWireCurve(w *topo.Wire) []math.Point3 {
+	var pts []math.Point3
+	for _, u := range w.Uses() {
+		pts = append(pts, sampleUseCurve(u)...)
+	}
+	return pts
+}
+
+// sampleUseCurve samples one edge use over its domain into referenceSampleSteps+1 points,
+// honouring the use's direction so consecutive edges chain head-to-tail.
+func sampleUseCurve(u topo.Use) []math.Point3 {
+	c := u.Edge.Geometry()
+	lo, hi := c.Domain()
+	out := make([]math.Point3, referenceSampleSteps+1)
+	for i := range out {
+		t := float64(i) / float64(referenceSampleSteps)
+		if u.Reversed {
+			t = 1 - t
+		}
+		out[i] = c.PointAt(lo + (hi-lo)*t)
+	}
+	return out
+}
+
+// nearestWire returns the wire whose sampled polyline passes closest to p — how a silhouette pick
+// selects among several loops (Inventor's ProximityPoint). nil for an empty set.
+func nearestWire(wires []*topo.Wire, p math.Point3) *topo.Wire {
+	var best *topo.Wire
+	bestD := stdmath.Inf(1)
+	for _, w := range wires {
+		if d := wireDistanceTo(w, p); d < bestD {
+			best, bestD = w, d
+		}
+	}
+	return best
+}
+
+// wireDistanceTo returns the minimum distance from p to the wire's sampled polyline.
+func wireDistanceTo(w *topo.Wire, p math.Point3) float64 {
+	best := stdmath.Inf(1)
+	for _, q := range sampleWireCurve(w) {
+		if d := float64(p.DistanceTo(q)); d < best {
+			best = d
+		}
+	}
+	return best
+}
+
+// parseCutEdgeSourceID splits a cut-edge SourceID ("<body>:<loop>") back into its indices.
+func parseCutEdgeSourceID(id string) (bodyIndex, wireIndex int, ok bool) {
+	parts := strings.SplitN(id, ":", 2)
+	if len(parts) != 2 {
+		return 0, 0, false
+	}
+	bi, err1 := strconv.Atoi(parts[0])
+	wi, err2 := strconv.Atoi(parts[1])
+	if err1 != nil || err2 != nil {
+		return 0, 0, false
+	}
+	return bi, wi, true
+}
+
+// parseSilhouetteSourceID unpacks a silhouette SourceID ("<incl>|<px>|<py>|<pz>|<faceKey>").
+func parseSilhouetteSourceID(id string) (faceRef string, proximity math.Point3, includeBoundary, ok bool) {
+	parts := strings.SplitN(id, "|", 5)
+	if len(parts) != 5 {
+		return "", math.Point3{}, false, false
+	}
+	incl, err0 := strconv.ParseBool(parts[0])
+	x, err1 := strconv.ParseFloat(parts[1], 64)
+	y, err2 := strconv.ParseFloat(parts[2], 64)
+	z, err3 := strconv.ParseFloat(parts[3], 64)
+	if err0 != nil || err1 != nil || err2 != nil || err3 != nil {
+		return "", math.Point3{}, false, false
+	}
+	return parts[4], math.P3(math.Scalar(x), math.Scalar(y), math.Scalar(z)), incl, true
+}

--- a/model/compdef/section_reference_source_test.go
+++ b/model/compdef/section_reference_source_test.go
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// extrudeBlock builds a 4×3×5 block from a rectangle profile sketch and a distance extrude, so the
+// resulting body is feature-backed (it survives Recompute and a recipe round-trip, unlike an
+// injected body). Returns the part with one solid body after recompute.
+func extrudeBlock(t *testing.T) *compdef.PartComponentDefinition {
+	t.Helper()
+	def := compdef.NewPartComponentDefinition()
+	sk := def.Sketches().Add(sketch.XYPlane())
+	c0 := sk.Points().Add(math.P2(0, 0))
+	c1 := sk.Points().Add(math.P2(4, 0))
+	c2 := sk.Points().Add(math.P2(4, 3))
+	c3 := sk.Points().Add(math.P2(0, 3))
+	sk.Lines().Add(c0, c1)
+	sk.Lines().Add(c1, c2)
+	sk.Lines().Add(c2, c3)
+	sk.Lines().Add(c3, c0)
+	feature.NewExtrudeFeatures(def.Features()).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return 5 })
+	def.Recompute()
+	if def.SurfaceBodies().Count() != 1 {
+		t.Fatalf("extrude produced %d bodies, want 1", def.SurfaceBodies().Count())
+	}
+	return def
+}
+
+// midHeightSketch adds a sketch on the XY plane at z=2.5, cutting the extruded block mid-height.
+func midHeightSketch(t *testing.T, def *compdef.PartComponentDefinition) *sketch.Sketch {
+	t.Helper()
+	xy := sketch.XYPlane()
+	plane, err := sketch.NewPlane(math.P3(0, 0, 2.5), xy.XAxis(), xy.YAxis())
+	if err != nil {
+		t.Fatalf("NewPlane: %v", err)
+	}
+	return def.Sketches().Add(plane)
+}
+
+// curvedFaceKey returns the reference key of the body's first non-planar face (a cylinder's side).
+func curvedFaceKey(t *testing.T, b *topo.Body) string {
+	t.Helper()
+	for _, f := range b.Faces() {
+		if _, planar := f.Geometry().(geom.Plane); !planar {
+			return string(f.ReferenceKey())
+		}
+	}
+	t.Fatal("body has no curved face")
+	return ""
+}
+
+// projectedBounds returns the min/max 2D corner over every projected curve's polyline.
+func projectedBounds(curves []*sketch.ProjectedCurve) (lo, hi math.Point2) {
+	lo = math.P2(stdmath.Inf(1), stdmath.Inf(1))
+	hi = math.P2(stdmath.Inf(-1), stdmath.Inf(-1))
+	for _, c := range curves {
+		for _, p := range c.Points() {
+			lo = math.P2(math.Scalar(stdmath.Min(float64(lo.X), float64(p.X))), math.Scalar(stdmath.Min(float64(lo.Y), float64(p.Y))))
+			hi = math.P2(math.Scalar(stdmath.Max(float64(hi.X), float64(p.X))), math.Scalar(stdmath.Max(float64(hi.Y), float64(p.Y))))
+		}
+	}
+	return lo, hi
+}
+
+// TestCutEdgeSourcesSectionBoxIntoUnitSquare: the z=0 section of a [-1,1]³ box is the unit square,
+// projected onto the XY sketch as associative reference geometry (#1873 AC1).
+func TestCutEdgeSourcesSectionBoxIntoUnitSquare(t *testing.T) {
+	def := compdef.NewPartComponentDefinition()
+	box, err := brep.SolidBlock(math.P3(-1, -1, -1), math.P3(1, 1, 1), "box")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	def.SurfaceBodies().Add(box)
+	sk := def.Sketches().Add(sketch.XYPlane())
+
+	sources := def.CutEdgeSources(sk.Plane())
+	if len(sources) == 0 {
+		t.Fatal("cut-edge sources = 0, want the box's mid section loop")
+	}
+	curves := sk.ProjectCutEdges(sources)
+	if len(curves) == 0 {
+		t.Fatal("projected no cut-edge curves")
+	}
+	for _, c := range curves {
+		if !c.Linked() {
+			t.Error("a projected cut edge must be associative (linked)")
+		}
+	}
+	lo, hi := projectedBounds(curves)
+	if !lo.IsEqualTo(math.P2(-1, -1), 1e-6) || !hi.IsEqualTo(math.P2(1, 1), 1e-6) {
+		t.Errorf("section bounds = %v..%v, want (-1,-1)..(1,1)", lo, hi)
+	}
+}
+
+// TestCutEdgeSourcesEmptyWhenPlaneMissesBody: a sketch plane clear of the solid yields no cut edges.
+func TestCutEdgeSourcesEmptyWhenPlaneMissesBody(t *testing.T) {
+	def := compdef.NewPartComponentDefinition()
+	box, _ := brep.SolidBlock(math.P3(-1, -1, -1), math.P3(1, 1, 1), "box")
+	def.SurfaceBodies().Add(box)
+	xy := sketch.XYPlane()
+	far, _ := sketch.NewPlane(math.P3(0, 0, 100), xy.XAxis(), xy.YAxis()) // parallel to XY, well above the box
+
+	if got := def.CutEdgeSources(far); len(got) != 0 {
+		t.Errorf("cut-edge sources for a plane clear of the body = %d, want 0", len(got))
+	}
+}
+
+// TestSilhouetteSourceProjectsCylinderRuling: the side of a Z-axis cylinder, viewed along +X (a YZ
+// sketch normal), has silhouette rulings; the one nearest the proximity point projects as an
+// associative reference curve (#1873 AC2).
+func TestSilhouetteSourceProjectsCylinderRuling(t *testing.T) {
+	def := compdef.NewPartComponentDefinition()
+	cyl, err := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2, 5)
+	if err != nil {
+		t.Fatalf("SolidCylinder: %v", err)
+	}
+	def.SurfaceBodies().Add(cyl)
+	sk := def.Sketches().Add(sketch.YZPlane()) // normal +X
+
+	src, ok := def.SilhouetteSource(curvedFaceKey(t, cyl), sk.Plane(), math.P3(0, 2, 2.5), true)
+	if !ok {
+		t.Fatal("silhouette source reports no geometry, want the +Y ruling")
+	}
+	c := sk.ProjectCurve(src)
+	if !c.Linked() || len(c.Points()) == 0 {
+		t.Errorf("projected silhouette linked=%v points=%d, want linked with a polyline", c.Linked(), len(c.Points()))
+	}
+}
+
+// TestSilhouetteSourceLostFaceReportsNoGeometry: an unknown face key yields no source geometry.
+func TestSilhouetteSourceLostFaceReportsNoGeometry(t *testing.T) {
+	def := compdef.NewPartComponentDefinition()
+	cyl, _ := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 2, 5)
+	def.SurfaceBodies().Add(cyl)
+	sk := def.Sketches().Add(sketch.YZPlane())
+
+	if _, ok := def.SilhouetteSource("no-such-face", sk.Plane(), math.P3(0, 2, 2.5), true); ok {
+		t.Error("silhouette of a non-resolving face should report no geometry")
+	}
+}
+
+// TestProjectedCutEdgesRebindOnReload: projected cut edges of a feature-backed solid round-trip and
+// re-link (associative) after a save/reload — the extrude rebuilds on recompute and the "cutEdge"
+// resolver case re-sections it, so the projections stay live (#1873 AC3).
+func TestProjectedCutEdgesRebindOnReload(t *testing.T) {
+	def := extrudeBlock(t)
+	sk := midHeightSketch(t, def)
+	before := sk.ProjectCutEdges(def.CutEdgeSources(sk.Plane()))
+	if len(before) == 0 {
+		t.Fatal("no cut edges projected to round-trip")
+	}
+
+	recipe, err := def.MarshalRecipe()
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	got := compdef.NewPartComponentDefinition()
+	if err := got.ApplyRecipe(recipe); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+
+	var restored int
+	for _, e := range got.Sketches().Item(1).Entities() { // sketch 0 is the profile; 1 is the cut
+		if c, ok := e.(*sketch.ProjectedCurve); ok {
+			restored++
+			if !c.Linked() {
+				t.Error("restored cut edge should re-link (rebind + recompute re-section the solid)")
+			}
+		}
+	}
+	if restored != len(before) {
+		t.Errorf("restored %d projected cut edges, want %d", restored, len(before))
+	}
+}
+
+// TestSilhouetteSourceIDRoundTripsThroughResolver: the silhouette descriptor survives encode →
+// resolver rebuild, even when the face key contains the '|' field delimiter (#1873).
+func TestSilhouetteSourceIDRoundTripsThroughResolver(t *testing.T) {
+	def := compdef.NewPartComponentDefinition()
+	plane := sketch.YZPlane()
+	orig := compdef.NewSilhouetteRefSource(def, "face|with|pipes", plane, math.P3(1.5, -2, 3.25), true)
+
+	rebuilt, ok := def.CurveProjectionSource(orig.SourceKind(), orig.SourceID(), plane)
+	if !ok {
+		t.Fatal("resolver did not rebuild the silhouette source")
+	}
+	if rebuilt.SourceID() != orig.SourceID() {
+		t.Errorf("rebuilt SourceID = %q, want %q", rebuilt.SourceID(), orig.SourceID())
+	}
+}

--- a/model/compdef/sketch_projection_rebind.go
+++ b/model/compdef/sketch_projection_rebind.go
@@ -50,6 +50,16 @@ func (d *PartComponentDefinition) CurveProjectionSource(kind, id string, plane s
 		return NewWorkAxisRefSource(d, feature.WorkRef(id)), true
 	case "workPlane":
 		return NewWorkPlaneRefSource(d, feature.WorkRef(id), plane), true
+	case "cutEdge":
+		if bi, wi, ok := parseCutEdgeSourceID(id); ok {
+			return NewCutEdgeRefSource(d, plane, bi, wi), true
+		}
+		return nil, false
+	case "silhouette":
+		if faceRef, prox, incl, ok := parseSilhouetteSourceID(id); ok {
+			return NewSilhouetteRefSource(d, faceRef, plane, prox, incl), true
+		}
+		return nil, false
 	default:
 		return nil, false
 	}


### PR DESCRIPTION
Closes #1873. Wires the two associative projected-geometry variants (M42 Sketch2D parity, milestone #44) onto the existing projection machinery, reusing the mesh-accurate kernel ops. Pins API **v0.133.0** ([Oblikovati.API#259](https://github.com/Oblikovati/Oblikovati.API/pull/259)).

## Approach
The associative projection framework (`ProjectedCurve`, source-key rebind, recompute hook, codec) and both kernel primitives (`ops.SectionWithPlane`, `ops.FaceSilhouetteWires`) already existed — even `Sketch.ProjectCutEdges` was a stub awaiting sources. This PR adds the missing *sources*:

- **`CutEdgeRefSource`** — one section loop (sketch plane × a part body), keyed by `(bodyIndex, wireIndex)`.
- **`SilhouetteRefSource`** — a face's silhouette along the sketch-plane normal, choosing the loop nearest the proximity point.

Both mirror `WorkPlaneRefSource`: they bind one sketch plane at construction and re-run their kernel op against the part's **current** bodies on every read, so they recompute with the model and round-trip through the existing projected-curve codec. New resolver cases (`"cutEdge"` / `"silhouette"`) rebuild the live source on reload.

- **`sketch.projectCutEdges`** — `part.CutEdgeSources(plane)` → one projected curve per section loop; errors if the plane cuts no body.
- **`sketch.projectSilhouette`** — `part.SilhouetteSource(faceRef, plane, proximity, includeBoundary)`; errors on an unresolved face or a face with no silhouette on the plane.

## Acceptance criteria
- ✔ Project cut edges creates reference curves for the section, updating on recompute.
- ✔ Project silhouette creates the silhouette reference curve of a face + proximity point.
- ✔ Both are enumerable and heal/round-trip like existing projected refs.

## Tests
- **compdef (geometry + associativity):** box mid-section maps to the unit square; plane-misses-body → no sources; cylinder side silhouette projects a ruling; lost face → no geometry; **feature-backed extrude → projectCutEdges → save/reload → curves re-link** (proves recompute re-sections the rebuilt solid); silhouette SourceID round-trips through the resolver even with `|` in the face key.
- **router (end-to-end):** projectCutEdges over an extruded block (XZ cut) creates + enumerates projected curves; no-solid errors; projectSilhouette over an extruded cylinder selects the ruling by proximity; unknown face errors.

Raw section/silhouette geometry is already covered by `kernel/ops` tests; these verify the associative wiring and 2D mapping. Full compdef/router/sketch suites green; gofmt + golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)