### PR TITLE
feat(sketch3d): evaluate cylindrical/spherical equation curves (#1846)

### DIFF
--- a/addin/router/sketch3d_add_entity.go
+++ b/addin/router/sketch3d_add_entity.go
@@ -382,9 +382,14 @@ func buildFixedSpline3D(sk *sketch.Sketch3D, in wire.AddSketch3DEntityArgs) (jso
 	return entityResult(uint64(sp.EntityID()), in.Kind)
 }
 
-// buildEquationCurve3D builds a parametric x(t)/y(t)/z(t) curve.
+// buildEquationCurve3D builds a parametric curve whose three expressions are interpreted in the
+// requested coordinate system (cartesian by default, #1846).
 func buildEquationCurve3D(sk *sketch.Sketch3D, in wire.AddSketch3DEntityArgs) (json.RawMessage, error) {
-	e, err := sk.AddEquationCurve3D(in.XExpr, in.YExpr, in.ZExpr, in.T0, in.T1)
+	coord, ok := types.ParseCoordinateSystemType(in.CoordinateSystem)
+	if !ok {
+		return nil, fmt.Errorf("sketch3d.addEntity: unknown coordinate system %q (want cartesian|cylindrical|spherical)", in.CoordinateSystem)
+	}
+	e, err := sk.AddEquationCurve3DIn(coord, in.XExpr, in.YExpr, in.ZExpr, in.T0, in.T1)
 	if err != nil {
 		return nil, fmt.Errorf("sketch3d.addEntity: equation curve: %w", err)
 	}

--- a/addin/router/sketch3d_enumerate.go
+++ b/addin/router/sketch3d_enumerate.go
@@ -79,6 +79,9 @@ func entity3DInfo(index int, e sketch.Entity) wire.Sketch3DEntityInfo {
 	info.Points = point3sCoords(se.ShapePoints3D())
 	info.Radius = entityRadius(e)
 	info.Construction = isConstruction(e)
+	if eq, ok := e.(*sketch.EquationCurve3D); ok && eq.CoordinateSystem() != types.CoordinateSystemCartesian {
+		info.CoordinateSystem = eq.CoordinateSystem().String() // omit for cartesian (#1846)
+	}
 	return info
 }
 

--- a/addin/router/sketch3d_equation_coord_test.go
+++ b/addin/router/sketch3d_equation_coord_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// TestSketch3DEquationCurveCylindricalOverWire creates a cylindrical equation curve and checks
+// enumeration reports its coordinate system (#1846).
+func TestSketch3DEquationCurveCylindricalOverWire(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch3d.create", `{}`, &wire.CreateSketch3DResult{})
+	call(t, r, s, "sketch3d.addEntity",
+		`{"sketchIndex":0,"kind":"equationCurve","xExpr":"2","yExpr":"t","zExpr":"1","t0":0,"t1":6.28,"coordinateSystem":"cylindrical"}`,
+		&wire.AddSketch3DEntityResult{})
+
+	var ents wire.EnumerateEntities3DResult
+	call(t, r, s, "sketch3d.entities", `{"sketchIndex":0}`, &ents)
+	if len(ents.Entities) != 1 || ents.Entities[0].CoordinateSystem != "cylindrical" {
+		t.Fatalf("enumerated entities = %+v, want one cylindrical equation curve", ents.Entities)
+	}
+}
+
+// TestSketch3DEquationCurveDefaultOmitsCoordinateSystem: a Cartesian curve reports no coordinate
+// system (#1846 AC2).
+func TestSketch3DEquationCurveDefaultOmitsCoordinateSystem(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch3d.create", `{}`, &wire.CreateSketch3DResult{})
+	call(t, r, s, "sketch3d.addEntity",
+		`{"sketchIndex":0,"kind":"equationCurve","xExpr":"cos(t)","yExpr":"sin(t)","zExpr":"t","t0":0,"t1":6.28}`,
+		&wire.AddSketch3DEntityResult{})
+
+	var ents wire.EnumerateEntities3DResult
+	call(t, r, s, "sketch3d.entities", `{"sketchIndex":0}`, &ents)
+	if len(ents.Entities) != 1 || ents.Entities[0].CoordinateSystem != "" {
+		t.Errorf("cartesian curve reported coordinateSystem = %q, want empty", ents.Entities[0].CoordinateSystem)
+	}
+}
+
+// TestSketch3DEquationCurveUnknownCoordinateSystemErrors rejects a bad selector cleanly (#1846).
+func TestSketch3DEquationCurveUnknownCoordinateSystemErrors(t *testing.T) {
+	r, s := emptyPartSession(t)
+	call(t, r, s, "sketch3d.create", `{}`, &wire.CreateSketch3DResult{})
+	if err := tryCall(t, r, s, "sketch3d.addEntity",
+		`{"sketchIndex":0,"kind":"equationCurve","xExpr":"t","yExpr":"t","zExpr":"t","t0":0,"t1":1,"coordinateSystem":"toroidal"}`); err == nil {
+		t.Error("an unknown coordinate system should error")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.135.0
+	oblikovati.org/api v0.136.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.135.0
+	oblikovati.org/api v0.136.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/sketch/serialize_3d.go
+++ b/model/sketch/serialize_3d.go
@@ -95,6 +95,8 @@ type Entity3DData struct {
 	ZExpr  string    `yaml:"zExpr,omitempty"`
 	T0     float64   `yaml:"t0,omitempty"`
 	T1     float64   `yaml:"t1,omitempty"`
+	// CoordinateSystem is an equation curve's coordinate-system id (0 ⇒ cartesian; #1846).
+	CoordinateSystem int32 `yaml:"coordinateSystem,omitempty"`
 	// Spline only (M06-F11, #626): the active tangency handles.
 	Handles []SplineHandle3DData `yaml:"handles,omitempty"`
 	// Helical only (M06-F09, #624): the shape definition — kind spelling,

--- a/model/sketch/serialize_codecs_3d.go
+++ b/model/sketch/serialize_codecs_3d.go
@@ -5,6 +5,7 @@ package sketch
 import (
 	"fmt"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/math"
 )
 
@@ -158,11 +159,11 @@ func registerSpline3DCodecs() {
 			v := e.(*EquationCurve3D)
 			return Entity3DData{
 				ID: int(v.id), XExpr: v.XExpr, YExpr: v.YExpr, ZExpr: v.ZExpr,
-				T0: v.T0, T1: v.T1, Construction: v.construction,
+				T0: v.T0, T1: v.T1, CoordinateSystem: int32(v.coord), Construction: v.construction,
 			}, nil
 		},
 		decode: func(s *Sketch3D, ed Entity3DData, _ []*Point3D) (Entity, error) {
-			e, err := s.AddEquationCurve3D(ed.XExpr, ed.YExpr, ed.ZExpr, ed.T0, ed.T1)
+			e, err := s.AddEquationCurve3DIn(types.CoordinateSystemType(ed.CoordinateSystem), ed.XExpr, ed.YExpr, ed.ZExpr, ed.T0, ed.T1)
 			if err != nil {
 				return nil, fmt.Errorf("equationCurve entity: %w", err)
 			}

--- a/model/sketch/splines_3d.go
+++ b/model/sketch/splines_3d.go
@@ -3,6 +3,9 @@
 package sketch
 
 import (
+	stdmath "math"
+
+	"oblikovati.org/api/types"
 	"oblikovati.org/math"
 	"oblikovati.org/model/param"
 )
@@ -55,17 +58,42 @@ func (s *FixedSpline3D) Sample() []math.Point3 {
 	return sampleChain3D(append([]math.Point3(nil), s.Pts...), s.Closed, true)
 }
 
-// EquationCurve3D is a parametric 3D curve x(t)/y(t)/z(t) over t ∈ [T0, T1].
+// EquationCurve3D is a parametric 3D curve over t ∈ [T0, T1]. The three expressions are
+// interpreted by Coord (#1846): Cartesian x/y/z, cylindrical radius/theta/z, or spherical
+// radius/theta/phi.
 type EquationCurve3D struct {
 	entityBase
 	XExpr, YExpr, ZExpr string
 	T0, T1              float64
+	coord               types.CoordinateSystemType
 	xc, yc, zc          param.Expr
 }
 
-// At evaluates the curve at parameter t.
+// CoordinateSystem reports how the three expressions are interpreted (#1846).
+func (e *EquationCurve3D) CoordinateSystem() types.CoordinateSystemType { return e.coord }
+
+// At evaluates the curve at parameter t, mapping the three expression values to a Cartesian
+// point through the curve's coordinate system.
 func (e *EquationCurve3D) At(t float64) math.Point3 {
-	return math.P3(math.Scalar(evalT(e.xc, t)), math.Scalar(evalT(e.yc, t)), math.Scalar(evalT(e.zc, t)))
+	return equationCurvePoint(e.coord, evalT(e.xc, t), evalT(e.yc, t), evalT(e.zc, t))
+}
+
+// equationCurvePoint converts the three evaluated expressions to Cartesian per coordinate system
+// (#1846): cylindrical (r,θ,z)→(r·cosθ, r·sinθ, z); spherical (r,θ,φ)→(r·sinφ·cosθ, r·sinφ·sinθ,
+// r·cosφ). θ/φ are radians, r/z centimetres.
+func equationCurvePoint(coord types.CoordinateSystemType, a, b, c float64) math.Point3 {
+	switch coord {
+	case types.CoordinateSystemCylindrical:
+		return math.P3(math.Scalar(a*stdmath.Cos(b)), math.Scalar(a*stdmath.Sin(b)), math.Scalar(c))
+	case types.CoordinateSystemSpherical:
+		return math.P3(
+			math.Scalar(a*stdmath.Sin(c)*stdmath.Cos(b)),
+			math.Scalar(a*stdmath.Sin(c)*stdmath.Sin(b)),
+			math.Scalar(a*stdmath.Cos(c)),
+		)
+	default:
+		return math.P3(math.Scalar(a), math.Scalar(b), math.Scalar(c))
+	}
 }
 
 // Sample returns n+1 evenly-spaced points along the curve.
@@ -105,13 +133,19 @@ func (s *Sketch3D) AddFixedSpline3D(coords []math.Point3, closed bool) *FixedSpl
 // AddEquationCurve3D adds a parametric curve from x(t)/y(t)/z(t) expressions over [t0,t1],
 // erroring if any expression fails to parse/bind to t.
 func (s *Sketch3D) AddEquationCurve3D(xExpr, yExpr, zExpr string, t0, t1 float64) (*EquationCurve3D, error) {
+	return s.AddEquationCurve3DIn(types.CoordinateSystemCartesian, xExpr, yExpr, zExpr, t0, t1)
+}
+
+// AddEquationCurve3DIn adds a parametric curve whose three expressions are interpreted in the given
+// coordinate system (#1846); the Cartesian case is [Sketch3D.AddEquationCurve3D].
+func (s *Sketch3D) AddEquationCurve3DIn(coord types.CoordinateSystemType, xExpr, yExpr, zExpr string, t0, t1 float64) (*EquationCurve3D, error) {
 	xc, yc, zc, err := bindEquation3D(xExpr, yExpr, zExpr)
 	if err != nil {
 		return nil, err
 	}
 	e := &EquationCurve3D{
 		entityBase: newEntity(), XExpr: xExpr, YExpr: yExpr, ZExpr: zExpr,
-		T0: t0, T1: t1, xc: xc, yc: yc, zc: zc,
+		T0: t0, T1: t1, coord: coord, xc: xc, yc: yc, zc: zc,
 	}
 	s.addEntity3D(e)
 	return e, nil

--- a/model/sketch/splines_3d_coord_test.go
+++ b/model/sketch/splines_3d_coord_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/api/types"
+	gmath "oblikovati.org/math"
+)
+
+// TestEquationCurve3DCylindricalEvaluation: (r,θ,z)=(2,t,1) traces a radius-2 circle at z=1 (#1846).
+func TestEquationCurve3DCylindricalEvaluation(t *testing.T) {
+	s := NewSketches3D().Add()
+	e, err := s.AddEquationCurve3DIn(types.CoordinateSystemCylindrical, "2", "t", "1", 0, stdmath.Pi/2)
+	if err != nil {
+		t.Fatalf("AddEquationCurve3DIn: %v", err)
+	}
+	if e.CoordinateSystem() != types.CoordinateSystemCylindrical {
+		t.Errorf("CoordinateSystem() = %v, want cylindrical", e.CoordinateSystem())
+	}
+	if got := e.At(0); !got.IsEqualTo(gmath.P3(2, 0, 1), 1e-9) {
+		t.Errorf("at t=0 = %v, want (2,0,1)", got)
+	}
+	if got := e.At(stdmath.Pi / 2); !got.IsEqualTo(gmath.P3(0, 2, 1), 1e-9) {
+		t.Errorf("at t=π/2 = %v, want (0,2,1)", got)
+	}
+}
+
+// TestEquationCurve3DSphericalEvaluation: (r,θ,φ)=(1,0,t) sweeps the prime meridian from +Z to −Z
+// through +X (#1846).
+func TestEquationCurve3DSphericalEvaluation(t *testing.T) {
+	s := NewSketches3D().Add()
+	e, err := s.AddEquationCurve3DIn(types.CoordinateSystemSpherical, "1", "0", "t", 0, stdmath.Pi)
+	if err != nil {
+		t.Fatalf("AddEquationCurve3DIn: %v", err)
+	}
+	cases := []struct {
+		t    float64
+		want gmath.Point3
+	}{
+		{0, gmath.P3(0, 0, 1)},
+		{stdmath.Pi / 2, gmath.P3(1, 0, 0)},
+		{stdmath.Pi, gmath.P3(0, 0, -1)},
+	}
+	for _, c := range cases {
+		if got := e.At(c.t); !got.IsEqualTo(c.want, 1e-9) {
+			t.Errorf("spherical at t=%g = %v, want %v", c.t, got, c.want)
+		}
+	}
+}
+
+// TestEquationCurve3DDefaultIsCartesian: the plain factory keeps x/y/z (#1846 AC2).
+func TestEquationCurve3DDefaultIsCartesian(t *testing.T) {
+	s := NewSketches3D().Add()
+	e, _ := s.AddEquationCurve3D("t", "2", "3", 0, 1)
+	if e.CoordinateSystem() != types.CoordinateSystemCartesian {
+		t.Errorf("default coordinate system = %v, want cartesian", e.CoordinateSystem())
+	}
+	if got := e.At(0.5); !got.IsEqualTo(gmath.P3(0.5, 2, 3), 1e-9) {
+		t.Errorf("cartesian at t=0.5 = %v, want (0.5,2,3)", got)
+	}
+}
+
+// TestEquationCurve3DCoordinateSystemRoundTrips: the coordinate system survives marshal→apply so a
+// saved cylindrical/spherical curve reloads with the same geometry (#1846 AC3).
+func TestEquationCurve3DCoordinateSystemRoundTrips(t *testing.T) {
+	src := NewSketches3D()
+	s := src.Add()
+	if _, err := s.AddEquationCurve3DIn(types.CoordinateSystemSpherical, "1", "0", "t", 0, stdmath.Pi); err != nil {
+		t.Fatalf("AddEquationCurve3DIn: %v", err)
+	}
+
+	data, err := src.MarshalRecipe3D()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	dst := NewSketches3D()
+	if err := dst.ApplyRecipe3D(data); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	ents := dst.Item(0).Entities()
+	eq, ok := ents[0].(*EquationCurve3D)
+	if !ok || eq.CoordinateSystem() != types.CoordinateSystemSpherical {
+		t.Fatalf("restored entity = %+v, want a spherical equation curve", ents[0])
+	}
+	if got := eq.At(stdmath.Pi / 2); !got.IsEqualTo(gmath.P3(1, 0, 0), 1e-9) {
+		t.Errorf("restored spherical curve at t=π/2 = %v, want (1,0,0)", got)
+	}
+}


### PR DESCRIPTION
Closes #1846. Implements the coordinate-system selector for the 3D equation curve (M42 Sketch3D parity, milestone #44). Pins API **v0.136.0** ([Oblikovati.API#261](https://github.com/Oblikovati/Oblikovati.API/pull/261)).

## What changed
- `AddEquationCurve3DIn(coord, …)` interprets the three expressions as radius/theta/z (cylindrical) or radius/theta/phi (spherical), converting to Cartesian in `At()` — cylindrical `(r,θ,z)→(r·cosθ, r·sinθ, z)`, spherical `(r,θ,φ)→(r·sinφ·cosθ, r·sinφ·sinθ, r·cosφ)`. The plain `AddEquationCurve3D` stays Cartesian.
- Coordinate system persists in `Entity3DData` and is reported on enumeration (`Sketch3DEntityInfo.CoordinateSystem`), omitted for Cartesian.
- Router parses the selector (empty ⇒ cartesian; unknown ⇒ clean error).

## Acceptance criteria
- ✔ `equationCurve` accepts `coordinateSystem` and evaluates cylindrical/spherical correctly (exact sample-point tests).
- ✔ Omitted `coordinateSystem` behaves as Cartesian — no change for existing callers.
- ✔ Enumeration reports the coordinate system; marshal→apply round-trip preserves it.

## Tests
- Model: exact cylindrical (radius-2 circle) + spherical (prime meridian) sample points; default-Cartesian; marshal/apply round-trip.
- Router: cylindrical over the wire enumerates its coordinate system; Cartesian omits it; unknown selector errors.

Full model/sketch + router suites green; gofmt + golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)