### PR TITLE
feat(sketch3d): intersection curve accepts a work-plane operand (#1854)

### DIFF
--- a/addin/router/sketch3d_intersection_workplane_test.go
+++ b/addin/router/sketch3d_intersection_workplane_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"testing"
+
+	"oblikovati.org/addin/modelaccess"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// blockFaceRef extrudes a block and returns a reference key for one of its faces.
+func blockFaceRef(t *testing.T, r *Router, s *app.Session) string {
+	t.Helper()
+	call(t, r, s, "sketch.create", `{"plane":"XY"}`, &wire.CreateSketchResult{})
+	call(t, r, s, "sketch.rectangle", `{"sketchIndex":0,"width":"40 mm","height":"30 mm"}`, &wire.SketchRectangleResult{})
+	call(t, r, s, "features.add", `{"kind":"extrude","args":{"sketchIndex":0,"profileIndex":0,"distance":"50 mm"}}`, &struct{}{})
+	part, err := modelaccess.ActivePart(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bodies := part.SurfaceBodies().All()
+	if len(bodies) == 0 || len(bodies[0].Faces()) == 0 {
+		t.Fatal("extrude produced no faces")
+	}
+	return string(bodies[0].Faces()[0].ReferenceKey())
+}
+
+// TestSketch3DIntersectionFaceWorkPlaneOverWire intersects a part face with an origin work plane
+// (#1854).
+func TestSketch3DIntersectionFaceWorkPlaneOverWire(t *testing.T) {
+	r, s := emptyPartSession(t)
+	faceRef := blockFaceRef(t, r, s)
+	call(t, r, s, "sketch3d.create", `{}`, &wire.CreateSketch3DResult{})
+
+	var res wire.AddSketch3DSurfaceCurveResult
+	args, _ := json.Marshal(wire.AddSketch3DSurfaceCurveArgs{
+		SketchIndex: 0, Kind: "intersection", FaceRefs: []string{faceRef}, WorkRefs: []string{"origin/plane/xz"},
+	})
+	call(t, r, s, "sketch3d.addSurfaceCurve", string(args), &res)
+	if !res.Healthy || res.EntityID == 0 {
+		t.Fatalf("face ∩ work-plane intersection = %+v, want healthy with an entity id", res)
+	}
+}
+
+// TestSketch3DIntersectionWrongOperandCountErrors: fewer or more than two operands is a clean error
+// (#1854 AC2).
+func TestSketch3DIntersectionWrongOperandCountErrors(t *testing.T) {
+	r, s := emptyPartSession(t)
+	faceRef := blockFaceRef(t, r, s)
+	call(t, r, s, "sketch3d.create", `{}`, &wire.CreateSketch3DResult{})
+
+	args, _ := json.Marshal(wire.AddSketch3DSurfaceCurveArgs{
+		SketchIndex: 0, Kind: "intersection", FaceRefs: []string{faceRef}, // only one operand
+	})
+	if err := tryCall(t, r, s, "sketch3d.addSurfaceCurve", string(args)); err == nil {
+		t.Error("an intersection with one operand should error")
+	}
+}
+
+// TestSketch3DIntersectionUnresolvedWorkPlaneIsUnhealthy: an unresolved work-plane ref reports
+// unhealthy rather than erroring, matching the face path (#1854).
+func TestSketch3DIntersectionUnresolvedWorkPlaneIsUnhealthy(t *testing.T) {
+	r, s := emptyPartSession(t)
+	faceRef := blockFaceRef(t, r, s)
+	call(t, r, s, "sketch3d.create", `{}`, &wire.CreateSketch3DResult{})
+
+	var res wire.AddSketch3DSurfaceCurveResult
+	args, _ := json.Marshal(wire.AddSketch3DSurfaceCurveArgs{
+		SketchIndex: 0, Kind: "intersection", FaceRefs: []string{faceRef}, WorkRefs: []string{"origin/plane/bogus"},
+	})
+	call(t, r, s, "sketch3d.addSurfaceCurve", string(args), &res)
+	if res.Healthy {
+		t.Errorf("intersection with an unresolved work plane = %+v, want unhealthy", res)
+	}
+}

--- a/addin/router/sketch3d_surface_curves.go
+++ b/addin/router/sketch3d_surface_curves.go
@@ -13,6 +13,7 @@ import (
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
 	"oblikovati.org/model/sketch"
 )
 
@@ -111,15 +112,27 @@ func uvPairs(flat []float64) ([]math.Point2, error) {
 	return out, nil
 }
 
-// intersectionCurve3D resolves two face refs and adds their (associative) intersection.
+// intersectionCurve3D resolves the two operands — each a face or a work plane, in any mix — and
+// adds their (associative) intersection (#1854). Faces come first as the bounded base; a work
+// plane contributes its infinite plane surface.
 func intersectionCurve3D(part *compdef.PartComponentDefinition, sk *sketch.Sketch3D, in wire.AddSketch3DSurfaceCurveArgs) (json.RawMessage, error) {
-	if len(in.FaceRefs) != 2 {
-		return nil, fmt.Errorf("sketch3d.addSurfaceCurve: intersection needs 2 face refs, got %d", len(in.FaceRefs))
+	if len(in.FaceRefs)+len(in.WorkRefs) != 2 {
+		return nil, fmt.Errorf("sketch3d.addSurfaceCurve: intersection needs 2 operands (face and/or work-plane refs), got %d", len(in.FaceRefs)+len(in.WorkRefs))
 	}
-	if !part.FaceKeyResolves(in.FaceRefs[0]) || !part.FaceKeyResolves(in.FaceRefs[1]) {
-		return surfaceCurveUnhealthy(in.Kind)
+	sources := make([]sketch.SurfaceSource, 0, 2)
+	for _, f := range in.FaceRefs {
+		if !part.FaceKeyResolves(f) {
+			return surfaceCurveUnhealthy(in.Kind)
+		}
+		sources = append(sources, compdef.NewFaceRefSource(part, f))
 	}
-	c := sk.AddIntersectionCurve3DRef(compdef.NewFaceRefSource(part, in.FaceRefs[0]), compdef.NewFaceRefSource(part, in.FaceRefs[1]), gridFromArgs(in))
+	for _, w := range in.WorkRefs {
+		if !part.WorkPlaneKeyResolves(w) {
+			return surfaceCurveUnhealthy(in.Kind)
+		}
+		sources = append(sources, compdef.NewWorkPlaneSurfaceSource(part, feature.WorkRef(w)))
+	}
+	c := sk.AddIntersectionCurve3DRef(sources[0], sources[1], gridFromArgs(in))
 	return surfaceCurveResult(c.EntityID(), in.Kind)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.136.0
+	oblikovati.org/api v0.137.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.136.0
+	oblikovati.org/api v0.137.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/compdef/work_plane_surface_source_test.go
+++ b/model/compdef/work_plane_surface_source_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// TestWorkPlaneSurfaceSourceResolvesOriginPlane: the origin XY plane resolves to the z=0 surface
+// (#1854).
+func TestWorkPlaneSurfaceSourceResolvesOriginPlane(t *testing.T) {
+	def := compdef.NewPartComponentDefinition()
+	surf := compdef.NewWorkPlaneSurfaceSource(def, feature.OriginXYPlane).Surface()
+	if surf == nil {
+		t.Fatal("origin XY plane should resolve to a surface")
+	}
+	// Every point of the XY plane lies at z=0.
+	for _, uv := range [][2]float64{{0, 0}, {1, 2}, {-3, 4}} {
+		if p := surf.PointAt(uv[0], uv[1]); stdmath.Abs(float64(p.Z)) > 1e-9 {
+			t.Errorf("XY-plane point at (%g,%g) = %v, want z=0", uv[0], uv[1], p)
+		}
+	}
+}
+
+// TestWorkPlaneSurfaceSourceLostReferenceIsNil: an unknown work-plane ref yields no surface (#1854).
+func TestWorkPlaneSurfaceSourceLostReferenceIsNil(t *testing.T) {
+	def := compdef.NewPartComponentDefinition()
+	if surf := compdef.NewWorkPlaneSurfaceSource(def, feature.WorkRef("no-such-plane")).Surface(); surf != nil {
+		t.Error("an unresolved work plane should yield a nil surface")
+	}
+}
+
+// TestIntersectionCurveWithWorkPlaneOperand: a radius-5 sphere ∩ the origin XY plane is the z=0
+// great circle, proving a work plane works as an intersection operand (#1854 AC1).
+func TestIntersectionCurveWithWorkPlaneOperand(t *testing.T) {
+	def := compdef.NewPartComponentDefinition()
+	sphere, err := geom.NewSphere(math.P3(0, 0, 0), 5)
+	if err != nil {
+		t.Fatalf("NewSphere: %v", err)
+	}
+	s := sketch.NewSketches3D().Add()
+	c := s.AddIntersectionCurve3DRef(
+		sketch.StaticSurface(sphere),
+		compdef.NewWorkPlaneSurfaceSource(def, feature.OriginXYPlane),
+		geom.SurfaceGrid{},
+	)
+	polys := c.Evaluate()
+	if len(polys) == 0 {
+		t.Fatal("sphere ∩ work plane produced no section curve")
+	}
+	for _, poly := range polys {
+		for _, p := range poly {
+			if stdmath.Abs(float64(p.Z)) > 1e-2 {
+				t.Errorf("section point %v not on the z=0 plane", p)
+			}
+			if r := stdmath.Hypot(float64(p.X), float64(p.Y)); stdmath.Abs(r-5) > 1e-2 {
+				t.Errorf("section point radius = %g, want 5 (the great circle)", r)
+			}
+		}
+	}
+}

--- a/model/compdef/work_reference_source.go
+++ b/model/compdef/work_reference_source.go
@@ -3,6 +3,7 @@
 package compdef
 
 import (
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/math"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/sketch"
@@ -129,6 +130,39 @@ func (s WorkPlaneRefSource) SamplePoints() ([]math.Point3, bool) {
 	}
 	step := dir.AsVector().Scale(s.span())
 	return []math.Point3{at.TranslateBy(step.Scale(-1)), at.TranslateBy(step)}, true
+}
+
+// WorkPlaneSurfaceSource adapts a datum work plane (by WorkRef) to a sketch SURFACE source: it
+// re-resolves the plane through the part's work geometry and yields its infinite plane surface, so
+// a 3D intersection curve can take a work plane as an operand (#1854). It re-resolves on every read
+// (associative) and returns a nil surface — treated as no intersection by the kernel tracer — when
+// the reference is lost or the plane is degenerate. Structurally satisfies sketch.SurfaceSource
+// without this package importing that seam type.
+type WorkPlaneSurfaceSource struct {
+	ref  feature.WorkRef
+	work func() *feature.WorkGeometry
+}
+
+// NewWorkPlaneSurfaceSource binds an associative surface source to the datum plane with ref.
+func NewWorkPlaneSurfaceSource(part *PartComponentDefinition, ref feature.WorkRef) WorkPlaneSurfaceSource {
+	return WorkPlaneSurfaceSource{ref: ref, work: func() *feature.WorkGeometry { return part.WorkGeometry() }}
+}
+
+// SourceID returns the datum plane reference (its stable cross-recompute identity).
+func (s WorkPlaneSurfaceSource) SourceID() string { return string(s.ref) }
+
+// Surface re-resolves the work plane and returns its infinite plane surface, or nil when lost.
+func (s WorkPlaneSurfaceSource) Surface() geom.Surface {
+	wp, err := s.work().WorkPlaneByRef(s.ref)
+	if err != nil {
+		return nil
+	}
+	p := wp.Plane()
+	plane, err := geom.NewPlane(p.Origin(), p.Normal().AsVector())
+	if err != nil {
+		return nil
+	}
+	return plane
 }
 
 // referenceLineHalfSpan sizes a projected work-axis / plane-intersection reference line: half


### PR DESCRIPTION
Closes #1854. Generalizes the 3D intersection curve to take a work plane as an operand (Inventor `IntersectionCurves.Add` accepts any two entities; M42 Sketch3D parity, milestone #44). Pins API **v0.137.0** ([Oblikovati.API#262](https://github.com/Oblikovati/Oblikovati.API/pull/262)).

## Approach
The model's `IntersectionCurve3D` already takes two generic `SurfaceSource`s, so the gap was purely the missing work-plane source + router relaxation:
- **`compdef.WorkPlaneSurfaceSource`** — an associative `SurfaceSource` that re-resolves a datum work plane by `WorkRef` and yields its infinite plane surface (`geom.NewPlane` from `WorkPlane.Plane()`), nil when lost/degenerate.
- The router's `intersectionCurve3D` now builds its two operands from `FaceRefs` + `WorkRefs` in any mix (faces first as the bounded base), health-checking each. A face∩work-plane pair yields the section line where the plane cuts the face.

## Acceptance criteria
- ✔ `intersection` accepts a work-plane reference as one operand and produces the section curve.
- ✔ Operand resolution: wrong count errors clearly; an unresolved ref reports unhealthy (matching the existing face path).

## Tests
- compdef: `WorkPlaneSurfaceSource` resolves the origin XY plane (z=0) and is nil when lost; a radius-5 sphere ∩ the origin XY plane is the z=0 great circle (real geometry).
- Router: face ∩ origin work-plane over the wire is healthy with an entity id; one operand errors; an unresolved work plane is unhealthy.

Full compdef + router suites green (face∩face path unchanged); gofmt + golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)