### PR TITLE
feat(sketch3d): OnFace constraint — pin a 3D point to a face (#1839)

### DIFF
--- a/addin/router/sketch3d_constraints.go
+++ b/addin/router/sketch3d_constraints.go
@@ -18,7 +18,7 @@ func addSketch3DConstraint(_ *app.Session, part *compdef.PartComponentDefinition
 	if err != nil {
 		return wire.AddSketch3DConstraintResult{}, err
 	}
-	c, err := buildSketch3DConstraint(sk, types.Geometric3DConstraintKind(in.Kind), in.Entities)
+	c, err := build3DConstraint(part, sk, in)
 	if err != nil {
 		return wire.AddSketch3DConstraintResult{}, err
 	}
@@ -26,6 +26,31 @@ func addSketch3DConstraint(_ *app.Session, part *compdef.PartComponentDefinition
 	return wire.AddSketch3DConstraintResult{
 		Index: sk.GeometricConstraints3D().Count() - 1, Kind: in.Kind, DOF: sk.DegreesOfFreedom(),
 	}, nil
+}
+
+// build3DConstraint dispatches the onFace kind (which resolves an external face ref and so needs
+// the part) and otherwise delegates to the entity-id-only factory (#1839).
+func build3DConstraint(part *compdef.PartComponentDefinition, sk *sketch.Sketch3D, in wire.AddSketch3DConstraintArgs) (sketch.Constraint, error) {
+	if types.Geometric3DConstraintKind(in.Kind) == types.Geo3DOnFace {
+		return onFaceConstraint3D(part, sk, in)
+	}
+	return buildSketch3DConstraint(sk, types.Geometric3DConstraintKind(in.Kind), in.Entities)
+}
+
+// onFaceConstraint3D resolves the point entity and the referenced face and pins the point onto the
+// face's surface (#1839).
+func onFaceConstraint3D(part *compdef.PartComponentDefinition, sk *sketch.Sketch3D, in wire.AddSketch3DConstraintArgs) (sketch.Constraint, error) {
+	if len(in.Entities) != 1 {
+		return nil, fmt.Errorf("sketch3d.addConstraint: onFace needs 1 point entity, got %d", len(in.Entities))
+	}
+	p, err := pointRef3D(sk, in.Entities[0])
+	if err != nil {
+		return nil, err
+	}
+	if !part.FaceKeyResolves(in.FaceRef) {
+		return nil, fmt.Errorf("sketch3d.addConstraint: onFace face %q does not resolve", in.FaceRef)
+	}
+	return sketch.NewOnFace3D(p, compdef.NewFaceRefSource(part, in.FaceRef), in.FaceRef), nil
 }
 
 // buildSketch3DConstraint resolves the operands and applies the matching constraint factory.

--- a/addin/router/sketch3d_constraints_coverage_test.go
+++ b/addin/router/sketch3d_constraints_coverage_test.go
@@ -138,6 +138,13 @@ var declared3DConstraintFixtures = map[types.Geometric3DConstraintKind]constrain
 // (#142 closed the gap; #143 added bend) — and kept so the next gap must be tracked.
 var trackedUnimplemented3DKinds = map[types.Geometric3DConstraintKind]string{}
 
+// dedicated3DConstraintKinds are implemented kinds the generic fixture harness cannot drive because
+// they take more than entity ids — onFace needs a face reference key + a real solid, so it has its
+// own end-to-end test (TestSketch3DOnFaceConstraintOverWire) instead of a fixture (#1839).
+var dedicated3DConstraintKinds = map[types.Geometric3DConstraintKind]string{
+	types.Geo3DOnFace: "TestSketch3DOnFaceConstraintOverWire",
+}
+
 // allDeclared3DConstraintKinds mirrors the const block in api/types/sketch3d.go
 // (Go cannot enumerate constants); keep in sync when the API grows.
 var allDeclared3DConstraintKinds = []types.Geometric3DConstraintKind{
@@ -146,7 +153,7 @@ var allDeclared3DConstraintKinds = []types.Geometric3DConstraintKind{
 	types.Geo3DMidpoint, types.Geo3DGround,
 	types.Geo3DParallelToXAxis, types.Geo3DParallelToYAxis, types.Geo3DParallelToZAxis,
 	types.Geo3DParallelToXYPlane, types.Geo3DParallelToXZPlane, types.Geo3DParallelToYZPlane,
-	types.Geo3DSplineFitPoints, types.Geo3DBend, types.Geo3DHelical,
+	types.Geo3DSplineFitPoints, types.Geo3DBend, types.Geo3DHelical, types.Geo3DOnFace,
 }
 
 // TestEvery3DConstraintKindAccepted drives sketch3d.addConstraint for every declared
@@ -179,12 +186,13 @@ func TestEvery3DConstraintKindAccepted(t *testing.T) {
 func TestDeclared3DConstraintKindsComplete(t *testing.T) {
 	for _, kind := range allDeclared3DConstraintKinds {
 		_, covered := declared3DConstraintFixtures[kind]
+		_, dedicated := dedicated3DConstraintKinds[kind]
 		issue, tracked := trackedUnimplemented3DKinds[kind]
 		switch {
 		case covered && tracked:
 			t.Errorf("kind %q is both covered and tracked-unimplemented (%s) — remove one", kind, issue)
-		case !covered && !tracked:
-			t.Errorf("kind %q is declared in api/types but has no fixture and no tracking issue", kind)
+		case !covered && !dedicated && !tracked:
+			t.Errorf("kind %q is declared in api/types but has no fixture, dedicated test, or tracking issue", kind)
 		}
 	}
 }

--- a/addin/router/sketch3d_onface_test.go
+++ b/addin/router/sketch3d_onface_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"testing"
+
+	"oblikovati.org/api/wire"
+)
+
+// TestSketch3DOnFaceConstraintOverWire pins a 3D sketch point onto a part face by reference key and
+// checks the constraint lands and enumerates as onFace (#1839). This is the dedicated end-to-end
+// test the coverage guard points at (onFace needs a face ref + a solid, unlike the fixture kinds).
+func TestSketch3DOnFaceConstraintOverWire(t *testing.T) {
+	r, s := emptyPartSession(t)
+	faceRef := blockFaceRef(t, r, s)
+	call(t, r, s, "sketch3d.create", `{}`, &wire.CreateSketch3DResult{})
+	var pt wire.AddSketch3DEntityResult
+	call(t, r, s, "sketch3d.addEntity", `{"sketchIndex":0,"kind":"point","points":[[10,0,0]]}`, &pt)
+
+	var res wire.AddSketch3DConstraintResult
+	args, _ := json.Marshal(wire.AddSketch3DConstraintArgs{
+		SketchIndex: 0, Kind: "onFace", Entities: []uint64{pt.EntityID}, FaceRef: faceRef,
+	})
+	call(t, r, s, "sketch3d.addConstraint", string(args), &res)
+	if res.Kind != "onFace" {
+		t.Errorf("addConstraint kind = %q, want onFace", res.Kind)
+	}
+
+	var cons wire.ListConstraints3DResult
+	call(t, r, s, "sketch3d.constraints", `{"sketchIndex":0}`, &cons)
+	if len(cons.Constraints) != 1 || cons.Constraints[0].Kind != "onFace" {
+		t.Errorf("enumerated constraints = %+v, want one onFace", cons.Constraints)
+	}
+}
+
+// TestSketch3DOnFaceUnresolvedFaceErrors: an onFace with a face reference that does not resolve is a
+// clean error (#1839).
+func TestSketch3DOnFaceUnresolvedFaceErrors(t *testing.T) {
+	r, s := emptyPartSession(t)
+	blockFaceRef(t, r, s) // a solid exists, but the ref below is not one of its faces
+	call(t, r, s, "sketch3d.create", `{}`, &wire.CreateSketch3DResult{})
+	var pt wire.AddSketch3DEntityResult
+	call(t, r, s, "sketch3d.addEntity", `{"sketchIndex":0,"kind":"point","points":[[10,0,0]]}`, &pt)
+
+	args, _ := json.Marshal(wire.AddSketch3DConstraintArgs{
+		SketchIndex: 0, Kind: "onFace", Entities: []uint64{pt.EntityID}, FaceRef: "no-such-face",
+	})
+	if err := tryCall(t, r, s, "sketch3d.addConstraint", string(args)); err == nil {
+		t.Error("onFace with an unresolved face should error")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.137.0
+	oblikovati.org/api v0.138.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.137.0
+	oblikovati.org/api v0.138.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/compdef/onface_constraint_rebind_test.go
+++ b/model/compdef/onface_constraint_rebind_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef_test
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/sketch"
+)
+
+// TestOnFace3DConstraintRebindsOnReload: an onFace constraint on a feature-backed solid round-trips
+// and re-binds its face source after a save/reload, so the point-on-face pin stays active and
+// associative — the constraint analogue of projected-geometry rebind (#1839 AC2).
+func TestOnFace3DConstraintRebindsOnReload(t *testing.T) {
+	def := extrudeBlock(t) // feature-backed block; its face keys survive recompute + reload
+	faceKey := string(def.SurfaceBodies().All()[0].Faces()[0].ReferenceKey())
+
+	sk := def.Sketches3D().Add()
+	p := sk.AddPoint3D(math.P3(10, 0, 0))
+	sk.GeometricConstraints3D().Add(sketch.NewOnFace3D(p, compdef.NewFaceRefSource(def, faceKey), faceKey))
+
+	recipe, err := def.MarshalRecipe()
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	got := compdef.NewPartComponentDefinition()
+	if err := got.ApplyRecipe(recipe); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+
+	var restored *sketch.OnFace3D
+	for _, c := range got.Sketches3D().Item(0).GeometricConstraints3D().All() {
+		if oc, ok := c.(*sketch.OnFace3D); ok {
+			restored = oc
+		}
+	}
+	if restored == nil {
+		t.Fatal("onFace constraint lost on reload")
+	}
+	if restored.SurfaceRef() != faceKey {
+		t.Errorf("restored SurfaceRef = %q, want %q", restored.SurfaceRef(), faceKey)
+	}
+	// Bound + the face resolves ⇒ the constraint is active again (contributes its point's DOFs).
+	if len(restored.Variables()) != 3 {
+		t.Errorf("restored onFace has %d variables, want 3 (rebound + active)", len(restored.Variables()))
+	}
+}

--- a/model/compdef/serialize.go
+++ b/model/compdef/serialize.go
@@ -284,7 +284,8 @@ func (d *PartComponentDefinition) applyRecipeStruct(r partRecipe) error {
 	if r.EndOfPart != nil {
 		d.SetEndOfPart(*r.EndOfPart)
 	}
-	d.rebindSketchProjections() // re-attach live sources to restored projections before recompute (#1268)
+	d.rebindSketchProjections()   // re-attach live sources to restored projections before recompute (#1268)
+	d.rebindSketch3DConstraints() // and to restored surface-bound 3D constraints (onFace, #1839)
 	d.Recompute()
 	return nil
 }

--- a/model/compdef/sketch_projection_rebind.go
+++ b/model/compdef/sketch_projection_rebind.go
@@ -24,6 +24,20 @@ func (d *PartComponentDefinition) rebindSketchProjections() {
 	}
 }
 
+// rebindSketch3DConstraints re-attaches a live face surface source to every restored surface-bound
+// 3D constraint (the onFace constraint) — the constraint analogue of rebindSketchProjections. A
+// saved onFace constraint carries only its face reference key; this rebuilds a self-resolving
+// FaceRefSource from it before Recompute, so the point-on-face pin becomes associative again (#1839).
+func (d *PartComponentDefinition) rebindSketch3DConstraints() {
+	for i := 0; i < d.sketches3D.Count(); i++ {
+		for _, c := range d.sketches3D.Item(i).GeometricConstraints3D().All() {
+			if bound, ok := c.(sketch.SurfaceBoundConstraint); ok {
+				bound.BindSurface(NewFaceRefSource(d, bound.SurfaceRef()))
+			}
+		}
+	}
+}
+
 // The part definition is the projection-source resolver: it owns the
 // vertices/edges/work geometry the persisted descriptors point at.
 var _ sketch.ProjectionSourceResolver = (*PartComponentDefinition)(nil)

--- a/model/sketch/constraint_kind_3d.go
+++ b/model/sketch/constraint_kind_3d.go
@@ -20,6 +20,9 @@ const (
 	// persisted spelling is the same "helical" in the constraint table.
 	HelicalJoinKind ConstraintKind = "helical"
 	BendKind        ConstraintKind = "bend"
+	// OnFaceKind holds a 3D sketch point on a referenced part face (#1839); the persisted spelling
+	// "onFace" matches the on-face curve EntityKind, in a different table.
+	OnFaceKind ConstraintKind = "onFace"
 )
 
 // ConstraintKind per 3D type. ParallelToAxis3D/ParallelToPlane3D derive their
@@ -58,6 +61,7 @@ func (c *Smooth3D) ConstraintKind() ConstraintKind          { return SmoothKind 
 func (c *SplineFitPoints3D) ConstraintKind() ConstraintKind { return SplineFitPointsKind }
 func (c *Helical3D) ConstraintKind() ConstraintKind         { return HelicalJoinKind }
 func (c *Bend3D) ConstraintKind() ConstraintKind            { return BendKind }
+func (c *OnFace3D) ConstraintKind() ConstraintKind          { return OnFaceKind }
 
 // RelatedEntities per 3D type, in API enumeration order.
 func (c *Coincident3D) RelatedEntities() []Entity    { return []Entity{c.A, c.B} }
@@ -84,21 +88,27 @@ func (c *Bend3D) RelatedEntities() []Entity {
 	return []Entity{c.Arc, c.L1, c.L2}
 }
 
+// OnFace3D relates only its constrained point; the held face is external geometry (a reference key),
+// not an in-sketch entity (#1839).
+func (c *OnFace3D) RelatedEntities() []Entity { return []Entity{c.P} }
+
 // Every 3D constraint carries the capability — a lost method fails the build.
 var (
-	_ KindedConstraint = (*Coincident3D)(nil)
-	_ KindedConstraint = (*Collinear3D)(nil)
-	_ KindedConstraint = (*Concentric3D)(nil)
-	_ KindedConstraint = (*Equal3D)(nil)
-	_ KindedConstraint = (*Parallel3D)(nil)
-	_ KindedConstraint = (*Perpendicular3D)(nil)
-	_ KindedConstraint = (*Midpoint3D)(nil)
-	_ KindedConstraint = (*Ground3D)(nil)
-	_ KindedConstraint = (*ParallelToAxis3D)(nil)
-	_ KindedConstraint = (*ParallelToPlane3D)(nil)
-	_ KindedConstraint = (*Tangent3D)(nil)
-	_ KindedConstraint = (*Smooth3D)(nil)
-	_ KindedConstraint = (*SplineFitPoints3D)(nil)
-	_ KindedConstraint = (*Helical3D)(nil)
-	_ KindedConstraint = (*Bend3D)(nil)
+	_ KindedConstraint       = (*Coincident3D)(nil)
+	_ KindedConstraint       = (*Collinear3D)(nil)
+	_ KindedConstraint       = (*Concentric3D)(nil)
+	_ KindedConstraint       = (*Equal3D)(nil)
+	_ KindedConstraint       = (*Parallel3D)(nil)
+	_ KindedConstraint       = (*Perpendicular3D)(nil)
+	_ KindedConstraint       = (*Midpoint3D)(nil)
+	_ KindedConstraint       = (*Ground3D)(nil)
+	_ KindedConstraint       = (*ParallelToAxis3D)(nil)
+	_ KindedConstraint       = (*ParallelToPlane3D)(nil)
+	_ KindedConstraint       = (*Tangent3D)(nil)
+	_ KindedConstraint       = (*Smooth3D)(nil)
+	_ KindedConstraint       = (*SplineFitPoints3D)(nil)
+	_ KindedConstraint       = (*Helical3D)(nil)
+	_ KindedConstraint       = (*Bend3D)(nil)
+	_ KindedConstraint       = (*OnFace3D)(nil)
+	_ SurfaceBoundConstraint = (*OnFace3D)(nil)
 )

--- a/model/sketch/constraints_3d_onface.go
+++ b/model/sketch/constraints_3d_onface.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// SurfaceBoundConstraint is a 3D geometric constraint bound to an external surface (a part face) by
+// reference key. Because model/sketch cannot resolve a face itself, such a constraint restores
+// frozen carrying only the key; a host rebinds a live surface source after a reload — exactly as
+// projected geometry rebinds (#1839). While unbound the constraint is inactive.
+type SurfaceBoundConstraint interface {
+	SurfaceRef() string
+	BindSurface(SurfaceSource)
+}
+
+// OnFace3D holds a 3D sketch point on a referenced surface (a part face): the solver drives the
+// point's signed distance to the surface to zero, removing one degree of freedom (Inventor
+// OnFaceConstraint3D, #1839). The surface is reached through the [SurfaceSource] seam so the
+// constraint tracks recompute. It contributes no equation while unbound (restored but not yet
+// rebound) or when the reference is lost, so a saved sketch loads without a dangling face pin.
+type OnFace3D struct {
+	constraintBase
+	P       *Point3D
+	surface SurfaceSource
+	ref     string // the face reference key, kept for serialize + rebind
+}
+
+// NewOnFace3D constrains point p onto the surface source; ref is the face reference key persisted
+// for a later [OnFace3D.BindSurface].
+//
+//	c := NewOnFace3D(p, compdef.NewFaceRefSource(part, key), key)
+func NewOnFace3D(p *Point3D, surface SurfaceSource, ref string) *OnFace3D {
+	return &OnFace3D{constraintBase: newConstraint(), P: p, surface: surface, ref: ref}
+}
+
+// SurfaceRef returns the constrained face's reference key (for serialize + rebind).
+func (c *OnFace3D) SurfaceRef() string { return c.ref }
+
+// BindSurface attaches a live surface source after a reload, reactivating the constraint.
+func (c *OnFace3D) BindSurface(s SurfaceSource) { c.surface = s }
+
+// Variables are the constrained point's three coordinate DOFs — none while inactive, so an unbound
+// or lost constraint drops out of the solve entirely (mirrors a driven dimension).
+func (c *OnFace3D) Variables() []*math.Scalar {
+	if c.activeSurface() == nil {
+		return nil
+	}
+	return []*math.Scalar{&c.P.X, &c.P.Y, &c.P.Z}
+}
+
+// Residuals is the point's signed distance to the surface, driven to zero; nil while inactive.
+func (c *OnFace3D) Residuals() []float64 {
+	surf := c.activeSurface()
+	if surf == nil {
+		return nil
+	}
+	p := c.P.Position()
+	u, v, foot := geom.ClosestPointOnSurface(surf, p)
+	return []float64{float64(foot.VectorTo(p).Dot(surf.NormalAt(u, v)))}
+}
+
+// Partials is the surface unit normal at the closest foot — the exact gradient of the point's
+// signed distance to the surface (∂d/∂p = n); nil while inactive.
+func (c *OnFace3D) Partials() [][]float64 {
+	surf := c.activeSurface()
+	if surf == nil {
+		return nil
+	}
+	u, v, _ := geom.ClosestPointOnSurface(surf, c.P.Position())
+	n := surf.NormalAt(u, v)
+	return [][]float64{{float64(n.X), float64(n.Y), float64(n.Z)}}
+}
+
+// activeSurface resolves the bound source's current surface, or nil when unbound/lost.
+func (c *OnFace3D) activeSurface() geom.Surface {
+	if c.surface == nil {
+		return nil
+	}
+	return c.surface.Surface()
+}

--- a/model/sketch/constraints_3d_onface_test.go
+++ b/model/sketch/constraints_3d_onface_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	gmath "oblikovati.org/math"
+)
+
+// TestOnFace3DPinsPointToSurface: a point off a radius-5 sphere, constrained on-face, loses one DOF
+// and solves onto the sphere (#1839).
+func TestOnFace3DPinsPointToSurface(t *testing.T) {
+	s := NewSketches3D().Add()
+	p := s.AddPoint3D(gmath.P3(10, 0, 0)) // 10 from the origin; the sphere has radius 5
+	sphere, err := geom.NewSphere(gmath.P3(0, 0, 0), 5)
+	if err != nil {
+		t.Fatalf("NewSphere: %v", err)
+	}
+	before := s.DegreesOfFreedom()
+	s.GeometricConstraints3D().Add(NewOnFace3D(p, StaticSurface(sphere), ""))
+	if after := s.DegreesOfFreedom(); after != before-1 {
+		t.Errorf("onFace removed %d DOF, want 1", before-after)
+	}
+
+	if r := s.Solve(); !r.Converged {
+		t.Fatalf("solve did not converge: residual=%v", r.Residual)
+	}
+	if d := float64(p.Position().DistanceTo(gmath.P3(0, 0, 0))); stdmath.Abs(d-5) > 1e-6 {
+		t.Errorf("solved point distance from centre = %v, want 5 (on the sphere)", d)
+	}
+}
+
+// TestOnFace3DUnboundIsInactive: a constraint with no live surface (restored, not yet rebound)
+// contributes no equation and keeps its face key for rebind (#1839).
+func TestOnFace3DUnboundIsInactive(t *testing.T) {
+	s := NewSketches3D().Add()
+	p := s.AddPoint3D(gmath.P3(1, 2, 3))
+	before := s.DegreesOfFreedom()
+	c := NewOnFace3D(p, nil, "face-key")
+	s.GeometricConstraints3D().Add(c)
+
+	if after := s.DegreesOfFreedom(); after != before {
+		t.Errorf("an unbound onFace removed %d DOF, want 0 (inactive)", before-after)
+	}
+	if c.SurfaceRef() != "face-key" {
+		t.Errorf("SurfaceRef() = %q, want the retained face key", c.SurfaceRef())
+	}
+	if c.Residuals() != nil || c.Variables() != nil {
+		t.Error("an unbound onFace should contribute no residual or variables")
+	}
+}

--- a/model/sketch/serialize_3d.go
+++ b/model/sketch/serialize_3d.go
@@ -140,6 +140,8 @@ type Constraint3DRow struct {
 	Curves []int   `yaml:"curves,omitempty"`
 	Index  int     `yaml:"index,omitempty"`
 	Radius float64 `yaml:"radius,omitempty"`
+	// FaceRef is the face reference key an onFace constraint holds its point on (#1839).
+	FaceRef string `yaml:"faceRef,omitempty"`
 }
 
 // MarshalRecipe3D projects every 3D sketch into its serializable form, in order.

--- a/model/sketch/serialize_codecs_constraints_3d.go
+++ b/model/sketch/serialize_codecs_constraints_3d.go
@@ -16,6 +16,26 @@ func init() {
 	registerLine3DConstraintCodecs()
 	registerOrientation3DConstraintCodecs()
 	registerCurveJoin3DConstraintCodecs()
+	registerOnFace3DConstraintCodec()
+}
+
+// registerOnFace3DConstraintCodec persists the point-on-face constraint (#1839): its point id plus
+// the face reference key. Decode restores it FROZEN (no live surface); the host rebinds a source
+// after load (compdef.rebindSketch3DConstraints), mirroring projected geometry.
+func registerOnFace3DConstraintCodec() {
+	registerConstraintCodec3D(OnFaceKind, constraintCodec3D{
+		encode: func(c Constraint) (Constraint3DRow, error) {
+			v := c.(*OnFace3D)
+			return Constraint3DRow{Points: []int{int(v.P.id)}, FaceRef: v.ref}, nil
+		},
+		decode: func(s *Sketch3D, cd Constraint3DRow, pts []*Point3D, _ map[int]Entity) error {
+			if len(pts) != 1 {
+				return fmt.Errorf("onFace needs 1 point, got %d", len(pts))
+			}
+			s.geomCons.add(NewOnFace3D(pts[0], nil, cd.FaceRef))
+			return nil
+		},
+	})
 }
 
 // point3DConstraintCodec pairs an all-points 3D constraint row with its factory.

--- a/model/sketch/serialize_constraint_registry_test.go
+++ b/model/sketch/serialize_constraint_registry_test.go
@@ -39,7 +39,7 @@ var (
 		ParallelKind, PerpendicularKind, MidpointKind, GroundKind,
 		ParallelToXAxisKind, ParallelToYAxisKind, ParallelToZAxisKind,
 		ParallelToXYKind, ParallelToXZKind, ParallelToYZKind,
-		TangentKind, SmoothKind, SplineFitPointsKind, HelicalJoinKind, BendKind,
+		TangentKind, SmoothKind, SplineFitPointsKind, HelicalJoinKind, BendKind, OnFaceKind,
 	}
 )
 
@@ -245,6 +245,9 @@ func populateEvery3DConstraintKind(t *testing.T, s *Sketch3D) {
 	if _, err := s.AddBend3D(s.AddLine3D(math.P3(6, 0, 0), math.P3(9, 0, 0)), s.AddLine3D(math.P3(9, 0, 0), math.P3(9, 3, 0)), 0.5); err != nil {
 		t.Fatalf("AddBend3D: %v", err)
 	}
+	// onFace carries only a point id + a face reference key; a nil surface serializes fine (the
+	// live source is a host-rebind concern, exercised in compdef, #1839).
+	g.Add(NewOnFace3D(c, nil, "face-ref"))
 }
 
 func addSplineFit3D(t *testing.T, g *GeometricConstraints, sp *Spline3D, p *Point3D) {


### PR DESCRIPTION
Closes #1839. Implements the 3D on-face constraint (Inventor `OnFaceConstraint3D`; M42 Sketch3D parity, milestone #44). Pins API **v0.138.0** ([Oblikovati.API#263](https://github.com/Oblikovati/Oblikovati.API/pull/263)).

## Solver
`OnFace3D`'s residual is the constrained point's **signed distance to the referenced surface** (driven to zero); its exact Jacobian row is the **surface unit normal at the closest foot** (∂d/∂p = n) — so the point is pinned onto the face, removing exactly one DOF. No autodiff needed; the normal is analytic.

## Associativity + rebind
The surface is reached through the `SurfaceSource` seam (`SurfaceBoundConstraint`), so the constraint tracks recompute. It is **inactive while unbound** (restored but not yet rebound) or when the reference is lost, so a saved sketch never carries a dangling face pin. New `compdef.rebindSketch3DConstraints` re-attaches a live `FaceRefSource` after reload — the constraint analogue of projection rebind.

## Registration surface
`OnFaceKind` + `ConstraintKind`/`RelatedEntities`/`KindedConstraint`; a codec storing the point id + face key; the persisted-vocabulary + round-trip closure; router `onFace` case (resolves point + face, needs the part); enumeration; coverage-guard dedicated-test entry (the generic fixture harness can't supply a `faceRef` + solid).

Scoped to a **point** operand (the associative common case); a curve-on-face is its per-point constraints.

## Acceptance criteria
- ✔ `onFace` constrains a 3D point to a referenced face and removes DOF (a point off a sphere solves onto it, −1 DOF).
- ✔ Round-trips through enumeration, serialize, and reference-key rebinding (feature-backed solid → save/reload → constraint re-links active).
- ✔ Coverage-guard test exercises the kind (dedicated end-to-end test).

## Tests
- Model: point pins to a sphere (−1 DOF, lands on surface); unbound constraint is inactive and keeps its key.
- compdef: onFace on a feature-backed block round-trips and re-binds active on reload.
- Router: onFace over the wire enumerates as `onFace`; unresolved face errors. Full serialize round-trip + coverage closure updated.

Full model/sketch, compdef, router, persistence suites green; gofmt + golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)