### PR TITLE
feat(sketch3d): project-to-surface along a direction vector (#1841 part 1)

### DIFF
--- a/addin/router/sketch3d_project_alongvector_test.go
+++ b/addin/router/sketch3d_project_alongvector_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"encoding/json"
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// projectSourceOverBlock extrudes a block and adds a 3D source line, returning a face key and the
+// source line's entity id — the operands of a project-to-surface curve.
+func projectSourceOverBlock(t *testing.T, r *Router, s *app.Session) (faceRef string, source uint64) {
+	t.Helper()
+	faceRef = blockFaceRef(t, r, s)
+	call(t, r, s, "sketch3d.create", `{}`, &wire.CreateSketch3DResult{})
+	var line wire.AddSketch3DEntityResult
+	call(t, r, s, "sketch3d.addEntity", `{"sketchIndex":0,"kind":"line","points":[[0,0,20],[2,0,20]]}`, &line)
+	return faceRef, line.EntityID
+}
+
+// TestSketch3DProjectAlongVectorOverWire projects a source curve onto a face along a direction
+// (#1841).
+func TestSketch3DProjectAlongVectorOverWire(t *testing.T) {
+	r, s := emptyPartSession(t)
+	faceRef, source := projectSourceOverBlock(t, r, s)
+
+	var res wire.AddSketch3DSurfaceCurveResult
+	args, _ := json.Marshal(wire.AddSketch3DSurfaceCurveArgs{
+		SketchIndex: 0, Kind: "projectToSurface", FaceRefs: []string{faceRef},
+		SourceEntityID: source, ProjectionType: "alongVector", ProjectDirection: []float64{0, 0, -1},
+	})
+	call(t, r, s, "sketch3d.addSurfaceCurve", string(args), &res)
+	if !res.Healthy || res.EntityID == 0 {
+		t.Fatalf("alongVector projection = %+v, want healthy with an entity id", res)
+	}
+}
+
+// TestSketch3DProjectWrapNotYetSupported: wrap is deferred to #1841 part 2 and errors cleanly.
+func TestSketch3DProjectWrapNotYetSupported(t *testing.T) {
+	r, s := emptyPartSession(t)
+	faceRef, source := projectSourceOverBlock(t, r, s)
+
+	args, _ := json.Marshal(wire.AddSketch3DSurfaceCurveArgs{
+		SketchIndex: 0, Kind: "projectToSurface", FaceRefs: []string{faceRef},
+		SourceEntityID: source, ProjectionType: "wrap",
+	})
+	if err := tryCall(t, r, s, "sketch3d.addSurfaceCurve", string(args)); err == nil {
+		t.Error("wrap projection should error until #1841 part 2")
+	}
+}
+
+// TestSketch3DProjectUnknownTypeErrors rejects an unknown projection type (#1841).
+func TestSketch3DProjectUnknownTypeErrors(t *testing.T) {
+	r, s := emptyPartSession(t)
+	faceRef, source := projectSourceOverBlock(t, r, s)
+
+	args, _ := json.Marshal(wire.AddSketch3DSurfaceCurveArgs{
+		SketchIndex: 0, Kind: "projectToSurface", FaceRefs: []string{faceRef},
+		SourceEntityID: source, ProjectionType: "sideways",
+	})
+	if err := tryCall(t, r, s, "sketch3d.addSurfaceCurve", string(args)); err == nil {
+		t.Error("an unknown projectionType should error")
+	}
+}

--- a/addin/router/sketch3d_surface_curves.go
+++ b/addin/router/sketch3d_surface_curves.go
@@ -64,8 +64,32 @@ func projectToSurfaceCurve3D(part *compdef.PartComponentDefinition, sk *sketch.S
 	if !part.FaceKeyResolves(in.FaceRefs[0]) {
 		return surfaceCurveUnhealthy(in.Kind)
 	}
-	c := sk.AddProjectToSurfaceCurve3DRef(src, compdef.NewFaceRefSource(part, in.FaceRefs[0]))
+	c, err := addProjectToSurface3D(sk, src, compdef.NewFaceRefSource(part, in.FaceRefs[0]), in)
+	if err != nil {
+		return nil, err
+	}
 	return surfaceCurveResult(c.EntityID(), in.Kind)
+}
+
+// addProjectToSurface3D builds the projection in the requested mode: closest-point (default) or
+// along a direction vector; wrap is deferred to #1841 part 2 (#1841).
+func addProjectToSurface3D(sk *sketch.Sketch3D, src geom.Curve3, surface sketch.SurfaceSource, in wire.AddSketch3DSurfaceCurveArgs) (*sketch.ProjectToSurfaceCurve3D, error) {
+	proj, ok := types.ParseProjectCurveToSurfaceType(in.ProjectionType)
+	if !ok {
+		return nil, fmt.Errorf("sketch3d.addSurfaceCurve: unknown projectionType %q (want closestPoint|alongVector|wrap)", in.ProjectionType)
+	}
+	switch proj {
+	case types.ProjectAlongVector:
+		dir, err := vector3Arg(in.ProjectDirection)
+		if err != nil {
+			return nil, fmt.Errorf("sketch3d.addSurfaceCurve: alongVector projectDirection: %w", err)
+		}
+		return sk.AddProjectToSurfaceCurve3DAlongVector(src, surface, dir), nil
+	case types.ProjectWrapToSurface:
+		return nil, fmt.Errorf("sketch3d.addSurfaceCurve: wrap projection is not yet supported (#1841 part 2)")
+	default:
+		return sk.AddProjectToSurfaceCurve3DRef(src, surface), nil
+	}
 }
 
 // offsetCurve3 resolves an in-sketch source curve and adds its offset by OffsetDistance in

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.138.0
+	oblikovati.org/api v0.139.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.138.0
+	oblikovati.org/api v0.139.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/sketch/surface_curves_3d.go
+++ b/model/sketch/surface_curves_3d.go
@@ -5,6 +5,7 @@ package sketch
 import (
 	"fmt"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/math"
 )
@@ -91,27 +92,70 @@ func (c *SilhouetteCurve3D) Evaluate() [][]math.Point3 {
 	return geom.Silhouette(surface, c.ViewDir, c.Grid)
 }
 
-// ProjectToSurfaceCurve3D is a source curve projected onto a referenced surface (the
-// perpendicular foot of each sampled point).
+// ProjectToSurfaceCurve3D is a source curve projected onto a referenced surface. Projection is
+// either the perpendicular foot of each sample (closest point, the default) or the nearest point
+// where a ray from the sample along Direction pierces the surface (alongVector, #1841).
 type ProjectToSurfaceCurve3D struct {
 	entityBase
-	Source  geom.Curve3
-	Surface SurfaceSource
-	Samples int
+	Source     geom.Curve3
+	Surface    SurfaceSource
+	Samples    int
+	Projection types.ProjectCurveToSurfaceType
+	Direction  math.Vector3 // ray direction for the alongVector projection
 }
 
-// Evaluate samples the source curve and projects each point onto the surface.
+// Evaluate samples the source curve and projects each point onto the surface; a lost reference
+// (nil surface) yields no geometry.
 func (c *ProjectToSurfaceCurve3D) Evaluate() []math.Point3 {
 	surface := c.Surface.Surface()
+	if surface == nil {
+		return nil
+	}
 	n := samplesOr(c.Samples)
 	lo, hi := c.Source.Domain()
 	out := make([]math.Point3, n+1)
 	for i := range out {
 		t := lo + (hi-lo)*float64(i)/float64(n)
-		_, _, foot := geom.ClosestPointOnSurface(surface, c.Source.PointAt(t))
-		out[i] = foot
+		out[i] = c.projectSample(surface, c.Source.PointAt(t))
 	}
 	return out
+}
+
+// projectSample maps one source point onto the surface: along Direction (the nearest ray pierce)
+// for the alongVector projection, otherwise the perpendicular foot (#1841).
+func (c *ProjectToSurfaceCurve3D) projectSample(surface geom.Surface, p math.Point3) math.Point3 {
+	_, _, foot := geom.ClosestPointOnSurface(surface, p)
+	if c.Projection != types.ProjectAlongVector {
+		return foot
+	}
+	if pierce, ok := rayPierceSurface(surface, p, c.Direction, foot); ok {
+		return pierce
+	}
+	return foot // the ray missed the surface: keep the closest foot
+}
+
+// rayPierceSurface returns the point nearest p where the line through p along dir pierces the
+// surface; ok=false when the ray misses or dir is degenerate (#1841). The probe segment is sized
+// from p's distance to the surface so it reaches across without a runaway length.
+func rayPierceSurface(surface geom.Surface, p math.Point3, dir math.Vector3, foot math.Point3) (math.Point3, bool) {
+	length := float64(dir.Length())
+	if length == 0 {
+		return math.Point3{}, false
+	}
+	unit := dir.Scale(math.Scalar(1 / length))
+	span := math.Scalar(10*float64(p.DistanceTo(foot)) + 1)
+	seg := geom.NewLineSegment(p.TranslateBy(unit.Scale(-span)), p.TranslateBy(unit.Scale(span)))
+	hits := geom.IntersectCurveSurface(seg, surface)
+	if len(hits) == 0 {
+		return math.Point3{}, false
+	}
+	best, bestD := hits[0], p.DistanceTo(hits[0])
+	for _, h := range hits[1:] {
+		if d := p.DistanceTo(h); d < bestD {
+			best, bestD = h, d
+		}
+	}
+	return best, true
 }
 
 // OnFaceCurve3D is a curve drawn in a referenced surface's parameter space, mapped to 3D
@@ -205,10 +249,18 @@ func (s *Sketch3D) AddProjectToSurfaceCurve3D(source geom.Curve3, surface geom.S
 	return s.AddProjectToSurfaceCurve3DRef(source, StaticSurface(surface))
 }
 
-// AddProjectToSurfaceCurve3DRef projects a source curve onto a surface source (the surface
-// is associative and rebinds on recompute; the source curve is a fixed snapshot).
+// AddProjectToSurfaceCurve3DRef projects a source curve onto a surface source to its closest point
+// (the surface is associative and rebinds on recompute; the source curve is a fixed snapshot).
 func (s *Sketch3D) AddProjectToSurfaceCurve3DRef(source geom.Curve3, surface SurfaceSource) *ProjectToSurfaceCurve3D {
-	c := &ProjectToSurfaceCurve3D{entityBase: newEntity(), Source: source, Surface: surface}
+	c := &ProjectToSurfaceCurve3D{entityBase: newEntity(), Source: source, Surface: surface, Projection: types.ProjectToClosestPoint}
+	s.addEntity3D(c)
+	return c
+}
+
+// AddProjectToSurfaceCurve3DAlongVector projects a source curve onto a surface source along dir:
+// each sample maps to the nearest point where the ray from it along dir pierces the surface (#1841).
+func (s *Sketch3D) AddProjectToSurfaceCurve3DAlongVector(source geom.Curve3, surface SurfaceSource, dir math.Vector3) *ProjectToSurfaceCurve3D {
+	c := &ProjectToSurfaceCurve3D{entityBase: newEntity(), Source: source, Surface: surface, Projection: types.ProjectAlongVector, Direction: dir}
 	s.addEntity3D(c)
 	return c
 }

--- a/model/sketch/surface_curves_3d_project_test.go
+++ b/model/sketch/surface_curves_3d_project_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/geom"
+	gmath "oblikovati.org/math"
+)
+
+// TestProjectToSurface3DAlongVectorPiercesAtDirection: a source line at z=5 projected onto the z=0
+// plane along (1,0,-1) lands where each ray pierces the plane — shifted +x by the drop height, NOT
+// the perpendicular foot directly below (#1841).
+func TestProjectToSurface3DAlongVectorPiercesAtDirection(t *testing.T) {
+	s := NewSketches3D().Add()
+	src := geom.NewLineSegment(gmath.P3(0, 0, 5), gmath.P3(2, 0, 5))
+	plane, err := geom.NewPlane(gmath.P3(0, 0, 0), gmath.V3(0, 0, 1))
+	if err != nil {
+		t.Fatalf("NewPlane: %v", err)
+	}
+	c := s.AddProjectToSurfaceCurve3DAlongVector(src, StaticSurface(plane), gmath.V3(1, 0, -1))
+	if c.Projection != types.ProjectAlongVector {
+		t.Errorf("Projection = %v, want alongVector", c.Projection)
+	}
+
+	pts := c.Evaluate()
+	if len(pts) == 0 {
+		t.Fatal("alongVector projection produced no points")
+	}
+	// Sample at the source start (0,0,5): the ray (1,0,-1) pierces z=0 at (5,0,0).
+	if !pts[0].IsEqualTo(gmath.P3(5, 0, 0), 1e-6) {
+		t.Errorf("first pierce = %v, want (5,0,0) — along the ray, not the foot (0,0,0)", pts[0])
+	}
+	for _, p := range pts {
+		if stdmath.Abs(float64(p.Z)) > 1e-6 {
+			t.Errorf("pierce %v not on the z=0 plane", p)
+		}
+	}
+}
+
+// TestProjectToSurface3DClosestPointUnchanged: the default projection still drops each sample to its
+// perpendicular foot (#1841 — no behaviour change for existing callers).
+func TestProjectToSurface3DClosestPointUnchanged(t *testing.T) {
+	s := NewSketches3D().Add()
+	src := geom.NewLineSegment(gmath.P3(1, 2, 5), gmath.P3(3, 2, 5))
+	plane, _ := geom.NewPlane(gmath.P3(0, 0, 0), gmath.V3(0, 0, 1))
+	c := s.AddProjectToSurfaceCurve3DRef(src, StaticSurface(plane))
+
+	pts := c.Evaluate()
+	// The foot of (1,2,5) on z=0 is (1,2,0) — directly below.
+	if !pts[0].IsEqualTo(gmath.P3(1, 2, 0), 1e-6) {
+		t.Errorf("closest-point foot = %v, want (1,2,0)", pts[0])
+	}
+}


### PR DESCRIPTION
Sketch3D parity **#1841 part 1** (milestone #44) — the `alongVector` projection mode for a project-to-surface curve. Pins API **v0.139.0** ([Oblikovati.API#264](https://github.com/Oblikovati/Oblikovati.API/pull/264)).

## What changed
`ProjectToSurfaceCurve3D` gains a `Projection` type + `Direction`. Each source sample maps to the **nearest point where the ray from it along `Direction` pierces the surface** (via the kernel's `IntersectCurveSurface`), falling back to the closest foot when the ray misses. `closestPoint` stays the default — no behaviour change for existing callers. The router parses `projectionType` + `projectDirection`.

## Staging
Per the agreed wrap-scope decision, `wrap` (the arc-length MapPointCurve mode) is **part 2** (a new kernel op + a flattening frame). It is rejected cleanly here (`wrap projection is not yet supported`).

## Acceptance criteria (this part)
- ✔ `add_sketch3d_surface_curve` accepts `projectionType` + `projectDirection` and produces the correct curve for `closestPoint` and `alongVector`.
- ✔ Default (omitted `projectionType`) stays closest-point.
- ⏳ Wrap → part 2.

## Tests
- Model: a source line at z=5 projected onto z=0 along (1,0,-1) pierces at (5,0,0) — the ray hit, **not** the perpendicular foot (0,0,0); closest-point unchanged.
- Router: alongVector over the wire is healthy; wrap errors (deferred); unknown projectionType errors.

Full model/sketch + router suites green; gofmt + golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)