### PR TITLE
feat(sketch3d): arc-length wrap projection onto a surface (#1841 part 2)

### DIFF
--- a/addin/router/sketch3d_project_alongvector_test.go
+++ b/addin/router/sketch3d_project_alongvector_test.go
@@ -38,8 +38,25 @@ func TestSketch3DProjectAlongVectorOverWire(t *testing.T) {
 	}
 }
 
-// TestSketch3DProjectWrapNotYetSupported: wrap is deferred to #1841 part 2 and errors cleanly.
-func TestSketch3DProjectWrapNotYetSupported(t *testing.T) {
+// TestSketch3DProjectWrapOverWire wraps a source curve onto a face through an origin work plane as
+// the flattening frame (#1841 part 2).
+func TestSketch3DProjectWrapOverWire(t *testing.T) {
+	r, s := emptyPartSession(t)
+	faceRef, source := projectSourceOverBlock(t, r, s)
+
+	var res wire.AddSketch3DSurfaceCurveResult
+	args, _ := json.Marshal(wire.AddSketch3DSurfaceCurveArgs{
+		SketchIndex: 0, Kind: "projectToSurface", FaceRefs: []string{faceRef},
+		SourceEntityID: source, ProjectionType: "wrap", WrapPlaneRef: "origin/plane/xy",
+	})
+	call(t, r, s, "sketch3d.addSurfaceCurve", string(args), &res)
+	if !res.Healthy || res.EntityID == 0 {
+		t.Fatalf("wrap projection = %+v, want healthy with an entity id", res)
+	}
+}
+
+// TestSketch3DProjectWrapNeedsPlaneRef: wrap without a wrapPlaneRef errors (no flattening frame).
+func TestSketch3DProjectWrapNeedsPlaneRef(t *testing.T) {
 	r, s := emptyPartSession(t)
 	faceRef, source := projectSourceOverBlock(t, r, s)
 
@@ -48,7 +65,7 @@ func TestSketch3DProjectWrapNotYetSupported(t *testing.T) {
 		SourceEntityID: source, ProjectionType: "wrap",
 	})
 	if err := tryCall(t, r, s, "sketch3d.addSurfaceCurve", string(args)); err == nil {
-		t.Error("wrap projection should error until #1841 part 2")
+		t.Error("wrap projection without wrapPlaneRef should error")
 	}
 }
 

--- a/addin/router/sketch3d_surface_curves.go
+++ b/addin/router/sketch3d_surface_curves.go
@@ -64,16 +64,16 @@ func projectToSurfaceCurve3D(part *compdef.PartComponentDefinition, sk *sketch.S
 	if !part.FaceKeyResolves(in.FaceRefs[0]) {
 		return surfaceCurveUnhealthy(in.Kind)
 	}
-	c, err := addProjectToSurface3D(sk, src, compdef.NewFaceRefSource(part, in.FaceRefs[0]), in)
+	c, err := addProjectToSurface3D(part, sk, src, compdef.NewFaceRefSource(part, in.FaceRefs[0]), in)
 	if err != nil {
 		return nil, err
 	}
 	return surfaceCurveResult(c.EntityID(), in.Kind)
 }
 
-// addProjectToSurface3D builds the projection in the requested mode: closest-point (default) or
-// along a direction vector; wrap is deferred to #1841 part 2 (#1841).
-func addProjectToSurface3D(sk *sketch.Sketch3D, src geom.Curve3, surface sketch.SurfaceSource, in wire.AddSketch3DSurfaceCurveArgs) (*sketch.ProjectToSurfaceCurve3D, error) {
+// addProjectToSurface3D builds the projection in the requested mode: closest-point (default),
+// along a direction vector, or an arc-length wrap through a work-plane flattening frame (#1841).
+func addProjectToSurface3D(part *compdef.PartComponentDefinition, sk *sketch.Sketch3D, src geom.Curve3, surface sketch.SurfaceSource, in wire.AddSketch3DSurfaceCurveArgs) (*sketch.ProjectToSurfaceCurve3D, error) {
 	proj, ok := types.ParseProjectCurveToSurfaceType(in.ProjectionType)
 	if !ok {
 		return nil, fmt.Errorf("sketch3d.addSurfaceCurve: unknown projectionType %q (want closestPoint|alongVector|wrap)", in.ProjectionType)
@@ -86,10 +86,28 @@ func addProjectToSurface3D(sk *sketch.Sketch3D, src geom.Curve3, surface sketch.
 		}
 		return sk.AddProjectToSurfaceCurve3DAlongVector(src, surface, dir), nil
 	case types.ProjectWrapToSurface:
-		return nil, fmt.Errorf("sketch3d.addSurfaceCurve: wrap projection is not yet supported (#1841 part 2)")
+		frame, err := wrapFrameFromRef(part, in.WrapPlaneRef)
+		if err != nil {
+			return nil, err
+		}
+		return sk.AddProjectToSurfaceCurve3DWrap(src, surface, frame), nil
 	default:
 		return sk.AddProjectToSurfaceCurve3DRef(src, surface), nil
 	}
+}
+
+// wrapFrameFromRef resolves the flattening frame for a wrap projection from a work-plane reference:
+// the plane's origin and in-plane X/Y axes become the frame's origin and U/V axes (#1841).
+func wrapFrameFromRef(part *compdef.PartComponentDefinition, ref string) (geom.WrapFrame, error) {
+	if ref == "" {
+		return geom.WrapFrame{}, fmt.Errorf("sketch3d.addSurfaceCurve: wrap projection needs wrapPlaneRef (the flattening plane)")
+	}
+	wp, err := part.WorkGeometry().WorkPlaneByRef(feature.WorkRef(ref))
+	if err != nil {
+		return geom.WrapFrame{}, fmt.Errorf("sketch3d.addSurfaceCurve: wrap wrapPlaneRef %q: %w", ref, err)
+	}
+	pl := wp.Plane()
+	return geom.WrapFrame{Origin: pl.Origin(), U: pl.XAxis().AsVector(), V: pl.YAxis().AsVector()}, nil
 }
 
 // offsetCurve3 resolves an in-sketch source curve and adds its offset by OffsetDistance in

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.139.0
+	oblikovati.org/api v0.140.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.139.0
+	oblikovati.org/api v0.140.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/kernel/geom/wrap_curve.go
+++ b/kernel/geom/wrap_curve.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// wrapArcLengthSteps is the substep count for inverting arc length to a surface parameter by
+// integrating the metric speed. Constant-speed directions (a plane axis, a cylinder's
+// circumference/axis, a cone's/sphere's iso-circles) are exact at any count; directions whose
+// speed varies along the walk (a general NURBS meridian) converge with the midpoint rule at
+// this resolution.
+const wrapArcLengthSteps = 128
+
+// WrapFrame is a source curve's planar frame for a wrap projection: the plane Origin plus the
+// in-plane axes U and V (unit, orthogonal). A source point p flattens to planar coordinates
+// (a, b) = ((p−Origin)·U, (p−Origin)·V). The caller orients U toward the surface's u-parameter
+// direction and V toward its v-parameter direction (e.g. U circumferential, V axial for a
+// cylinder), so wrap maps a to arc length along u and b to arc length along v.
+type WrapFrame struct {
+	Origin math.Point3
+	U, V   math.Vector3
+}
+
+// flatten returns p's coordinates (a, b) in the frame — the signed U and V components of p−Origin.
+func (f WrapFrame) flatten(p math.Point3) (a, b float64) {
+	d := f.Origin.VectorTo(p)
+	return float64(d.Dot(f.U)), float64(d.Dot(f.V))
+}
+
+// WrapCurveOntoSurface maps the sampled source curve onto surface, preserving arc length from
+// the anchor — the surface parameters where Frame.Origin projects (surface.ParamAt). Each source
+// point flattens to (a, b) in frame and maps to the surface point reached by travelling arc
+// length b along the v-parameter, then a along the u-parameter, so an in-plane displacement
+// becomes an equal on-surface arc length along each parameter direction. This is Inventor's
+// kWrapToSurfaceType / MapPointCurve (#1841): an isometry for developable surfaces (cylinder,
+// cone) — e.g. a cylinder of radius R maps planar x to angle u = x/R — and the closest
+// arc-length-along-parameters map otherwise. Returns nil for a nil surface/source or samples < 1.
+func WrapCurveOntoSurface(surface Surface, source Curve3, frame WrapFrame, samples int) []math.Point3 {
+	if surface == nil || source == nil || samples < 1 {
+		return nil
+	}
+	u0, v0 := surface.ParamAt(frame.Origin)
+	lo, hi := source.Domain()
+	out := make([]math.Point3, samples+1)
+	for i := range out {
+		t := lo + (hi-lo)*float64(i)/float64(samples)
+		a, b := frame.flatten(source.PointAt(t))
+		v := arcLengthParam(v0, b, func(vv float64) float64 { return vDirSpeed(surface, u0, vv) })
+		u := arcLengthParam(u0, a, func(uu float64) float64 { return uDirSpeed(surface, uu, v) })
+		out[i] = surface.PointAt(u, v)
+	}
+	return out
+}
+
+// uDirSpeed / vDirSpeed are the surface's metric speeds |∂S/∂u| and |∂S/∂v| — the local
+// arc-length gained per unit of each parameter.
+func uDirSpeed(s Surface, u, v float64) float64 {
+	du, _ := s.DerivativesAt(u, v)
+	return float64(du.Length())
+}
+
+func vDirSpeed(s Surface, u, v float64) float64 {
+	_, dv := s.DerivativesAt(u, v)
+	return float64(dv.Length())
+}
+
+// arcLengthParam returns the parameter reached by travelling signed arc length target from
+// param0 along a 1-D path whose metric speed |dP/dparam| is speed(param). It marches in
+// wrapArcLengthSteps substeps, each sized to cover an equal share of the remaining arc length so
+// curvature is resolved, integrates with the midpoint speed, and finishes the last partial step
+// linearly. A constant speed yields the exact param0 + target/speed. speed must be > 0 on the
+// range (a regular surface direction); a degenerate (≤0) speed stops the march.
+func arcLengthParam(param0, target float64, speed func(float64) float64) float64 {
+	if target == 0 {
+		return param0
+	}
+	dir, remaining, param := stdmath.Copysign(1, target), stdmath.Abs(target), param0
+	for i := 0; i < wrapArcLengthSteps && remaining > 0; i++ {
+		sp := speed(param)
+		if sp <= 0 {
+			break
+		}
+		dParam := dir * (remaining / float64(wrapArcLengthSteps-i)) / sp
+		mid := speed(param + dParam/2)
+		if mid <= 0 {
+			mid = sp
+		}
+		step := stdmath.Abs(dParam) * mid
+		if step >= remaining {
+			return param + dir*(remaining/mid) // finish within this step
+		}
+		remaining -= step
+		param += dParam
+	}
+	return param
+}

--- a/kernel/geom/wrap_curve_test.go
+++ b/kernel/geom/wrap_curve_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestArcLengthParamVariableSpeed validates the metric-integration inverse on a NON-constant
+// speed — the genuinely numerical core of the wrap. With speed(p)=1+p the arc length from 0 to X
+// is ∫₀ˣ(1+p)dp = X + X²/2, so reaching arc length T lands at X = √(1+2T) − 1. The midpoint
+// integrator must recover that (constant-speed surfaces would never exercise this).
+func TestArcLengthParamVariableSpeed(t *testing.T) {
+	speed := func(p float64) float64 { return 1 + p }
+	for _, target := range []float64{0.5, 2, 5, 12} {
+		want := stdmath.Sqrt(1+2*target) - 1
+		got := arcLengthParam(0, target, speed)
+		if stdmath.Abs(got-want) > 1e-4 {
+			t.Errorf("arcLengthParam(0, %v) = %v, want %v (√(1+2T)−1)", target, got, want)
+		}
+	}
+}
+
+// TestArcLengthParamConstantSpeedExact: a constant speed inverts exactly (param0 + target/speed),
+// in both directions — the cylinder/plane case must carry no integration error.
+func TestArcLengthParamConstantSpeedExact(t *testing.T) {
+	speed := func(float64) float64 { return 2 }
+	if got := arcLengthParam(1, 6, speed); stdmath.Abs(got-4) > 1e-12 {
+		t.Errorf("forward: got %v, want 4 (1 + 6/2)", got)
+	}
+	if got := arcLengthParam(1, -6, speed); stdmath.Abs(got-(-2)) > 1e-12 {
+		t.Errorf("backward: got %v, want -2 (1 − 6/2)", got)
+	}
+}
+
+// TestWrapCurveOntoCylinderIsArcLengthUnwrap is the headline analytic check: wrapping a planar
+// source line onto a cylinder of radius R maps planar x to angle u = x/R (the cylinder unwrap),
+// preserving arc length. The source runs along the frame's U axis (circumferential) from the
+// anchor, so each point maps onto the cylinder's equator by exactly its planar arc length.
+func TestWrapCurveOntoCylinderIsArcLengthUnwrap(t *testing.T) {
+	const r = 2.0
+	cyl, err := NewCylinderWithRef(math.P3(0, 0, 0), math.V3(0, 0, 1), math.V3(1, 0, 0), r)
+	if err != nil {
+		t.Fatalf("NewCylinderWithRef: %v", err)
+	}
+	// Anchor (R,0,0) → (u,v)=(0,0); U circumferential (0,1,0); V axial (0,0,1).
+	frame := WrapFrame{Origin: math.P3(r, 0, 0), U: math.V3(0, 1, 0), V: math.V3(0, 0, 1)}
+	// Planar source from a=0 to a=π·R/2 (a quarter of the way around), all in the tangent plane.
+	arc := stdmath.Pi * r / 2
+	src := NewLineSegment(math.P3(r, 0, 0), math.P3(r, arc, 0))
+
+	pts := WrapCurveOntoSurface(cyl, src, frame, 32)
+	if len(pts) != 33 {
+		t.Fatalf("got %d points, want 33", len(pts))
+	}
+	for i, p := range pts {
+		a := arc * float64(i) / 32 // planar arc length of this sample
+		want := math.P3(math.Scalar(r*stdmath.Cos(a/r)), math.Scalar(r*stdmath.Sin(a/r)), 0)
+		if !p.IsEqualTo(want, 1e-6) {
+			t.Fatalf("sample %d (a=%.4f): got %v, want %v — u must equal a/R", i, a, p, want)
+		}
+	}
+	// End point: a quarter turn lands at (0, R, 0).
+	if !pts[len(pts)-1].IsEqualTo(math.P3(0, r, 0), 1e-6) {
+		t.Errorf("quarter-turn end = %v, want (0,2,0)", pts[len(pts)-1])
+	}
+}
+
+// TestWrapCurveOntoCylinderAxialOffsetIsIndependent: a planar V displacement (b) maps to axial
+// height v = b, independent of the circumferential wrap — confirms the two parameter directions
+// are decoupled on the cylinder (diagonal metric).
+func TestWrapCurveOntoCylinderAxialOffsetIsIndependent(t *testing.T) {
+	const r = 3.0
+	cyl, _ := NewCylinderWithRef(math.P3(0, 0, 0), math.V3(0, 0, 1), math.V3(1, 0, 0), r)
+	frame := WrapFrame{Origin: math.P3(r, 0, 0), U: math.V3(0, 1, 0), V: math.V3(0, 0, 1)}
+	// A single-point-thick source at planar (a=π·R, b=5): half a turn around, 5 up the axis.
+	a := stdmath.Pi * r
+	src := NewLineSegment(math.P3(r, a, 5), math.P3(r, a, 5))
+
+	pts := WrapCurveOntoSurface(cyl, src, frame, 4)
+	// u = a/R = π → (−R, 0, ·); v = b = 5.
+	if !pts[0].IsEqualTo(math.P3(-r, 0, 5), 1e-6) {
+		t.Errorf("got %v, want (-3,0,5) — half turn at axial height 5", pts[0])
+	}
+}
+
+// TestWrapCurveOntoPlaneReconstructsSource: wrapping onto a plane whose frame matches the source
+// frame is the identity — every planar point maps back to itself (the degenerate flat case).
+func TestWrapCurveOntoPlaneReconstructsSource(t *testing.T) {
+	plane, err := NewPlaneFromAxes(math.P3(0, 0, 0), math.V3(1, 0, 0), math.V3(0, 1, 0))
+	if err != nil {
+		t.Fatalf("NewPlaneFromAxes: %v", err)
+	}
+	frame := WrapFrame{Origin: math.P3(0, 0, 0), U: math.V3(1, 0, 0), V: math.V3(0, 1, 0)}
+	src := NewLineSegment(math.P3(1, 2, 0), math.P3(4, 6, 0))
+
+	pts := WrapCurveOntoSurface(plane, src, frame, 8)
+	for i, p := range pts {
+		want := src.PointAt(float64(i) / 8)
+		if !p.IsEqualTo(want, 1e-9) {
+			t.Errorf("sample %d: got %v, want %v (identity on a matching plane)", i, p, want)
+		}
+	}
+}
+
+// TestWrapCurveOntoSurfaceNilInputs guards the degenerate inputs (nil surface/curve, no samples).
+func TestWrapCurveOntoSurfaceNilInputs(t *testing.T) {
+	plane, _ := NewPlaneFromAxes(math.P3(0, 0, 0), math.V3(1, 0, 0), math.V3(0, 1, 0))
+	src := NewLineSegment(math.P3(0, 0, 0), math.P3(1, 0, 0))
+	frame := WrapFrame{Origin: math.P3(0, 0, 0), U: math.V3(1, 0, 0), V: math.V3(0, 1, 0)}
+	if pts := WrapCurveOntoSurface(nil, src, frame, 4); pts != nil {
+		t.Errorf("nil surface: got %v, want nil", pts)
+	}
+	if pts := WrapCurveOntoSurface(plane, nil, frame, 4); pts != nil {
+		t.Errorf("nil source: got %v, want nil", pts)
+	}
+	if pts := WrapCurveOntoSurface(plane, src, frame, 0); pts != nil {
+		t.Errorf("zero samples: got %v, want nil", pts)
+	}
+}

--- a/model/sketch/surface_curves_3d.go
+++ b/model/sketch/surface_curves_3d.go
@@ -93,25 +93,31 @@ func (c *SilhouetteCurve3D) Evaluate() [][]math.Point3 {
 }
 
 // ProjectToSurfaceCurve3D is a source curve projected onto a referenced surface. Projection is
-// either the perpendicular foot of each sample (closest point, the default) or the nearest point
-// where a ray from the sample along Direction pierces the surface (alongVector, #1841).
+// the perpendicular foot of each sample (closest point, the default), the nearest point where a
+// ray from the sample along Direction pierces the surface (alongVector), or the arc-length wrap of
+// the source curve onto the surface through Frame (wrap — Inventor's MapPointCurve, #1841).
 type ProjectToSurfaceCurve3D struct {
 	entityBase
 	Source     geom.Curve3
 	Surface    SurfaceSource
 	Samples    int
 	Projection types.ProjectCurveToSurfaceType
-	Direction  math.Vector3 // ray direction for the alongVector projection
+	Direction  math.Vector3   // ray direction for the alongVector projection
+	Frame      geom.WrapFrame // source's planar frame for the wrap projection
 }
 
-// Evaluate samples the source curve and projects each point onto the surface; a lost reference
-// (nil surface) yields no geometry.
+// Evaluate samples the source curve and projects each point onto the surface (or, for the wrap
+// projection, maps the whole curve preserving arc length); a lost reference (nil surface) yields
+// no geometry.
 func (c *ProjectToSurfaceCurve3D) Evaluate() []math.Point3 {
 	surface := c.Surface.Surface()
 	if surface == nil {
 		return nil
 	}
 	n := samplesOr(c.Samples)
+	if c.Projection == types.ProjectWrapToSurface {
+		return geom.WrapCurveOntoSurface(surface, c.Source, c.Frame, n)
+	}
 	lo, hi := c.Source.Domain()
 	out := make([]math.Point3, n+1)
 	for i := range out {
@@ -261,6 +267,16 @@ func (s *Sketch3D) AddProjectToSurfaceCurve3DRef(source geom.Curve3, surface Sur
 // each sample maps to the nearest point where the ray from it along dir pierces the surface (#1841).
 func (s *Sketch3D) AddProjectToSurfaceCurve3DAlongVector(source geom.Curve3, surface SurfaceSource, dir math.Vector3) *ProjectToSurfaceCurve3D {
 	c := &ProjectToSurfaceCurve3D{entityBase: newEntity(), Source: source, Surface: surface, Projection: types.ProjectAlongVector, Direction: dir}
+	s.addEntity3D(c)
+	return c
+}
+
+// AddProjectToSurfaceCurve3DWrap wraps a source curve onto a surface source, preserving arc length
+// from frame's origin anchor: each source point's planar U/V displacement becomes an equal
+// on-surface arc length along the surface's u/v parameters (Inventor kWrapToSurfaceType, #1841).
+// frame is the source curve's planar frame (origin + in-plane axes); the surface is associative.
+func (s *Sketch3D) AddProjectToSurfaceCurve3DWrap(source geom.Curve3, surface SurfaceSource, frame geom.WrapFrame) *ProjectToSurfaceCurve3D {
+	c := &ProjectToSurfaceCurve3D{entityBase: newEntity(), Source: source, Surface: surface, Projection: types.ProjectWrapToSurface, Frame: frame}
 	s.addEntity3D(c)
 	return c
 }

--- a/model/sketch/surface_curves_3d_project_test.go
+++ b/model/sketch/surface_curves_3d_project_test.go
@@ -41,6 +41,37 @@ func TestProjectToSurface3DAlongVectorPiercesAtDirection(t *testing.T) {
 	}
 }
 
+// TestProjectToSurface3DWrapUnwrapsOntoCylinder: the wrap projection maps a planar source line onto
+// a cylinder preserving arc length — planar x becomes angle u = x/R (#1841). Exercised through the
+// model entity so the sketch wiring (Frame field + wrap branch of Evaluate) is covered.
+func TestProjectToSurface3DWrapUnwrapsOntoCylinder(t *testing.T) {
+	const r = 2.0
+	s := NewSketches3D().Add()
+	cyl, err := geom.NewCylinderWithRef(gmath.P3(0, 0, 0), gmath.V3(0, 0, 1), gmath.V3(1, 0, 0), r)
+	if err != nil {
+		t.Fatalf("NewCylinderWithRef: %v", err)
+	}
+	arc := stdmath.Pi * r / 2
+	src := geom.NewLineSegment(gmath.P3(r, 0, 0), gmath.P3(r, arc, 0))
+	frame := geom.WrapFrame{Origin: gmath.P3(r, 0, 0), U: gmath.V3(0, 1, 0), V: gmath.V3(0, 0, 1)}
+
+	c := s.AddProjectToSurfaceCurve3DWrap(src, StaticSurface(cyl), frame)
+	if c.Projection != types.ProjectWrapToSurface {
+		t.Errorf("Projection = %v, want wrap", c.Projection)
+	}
+	pts := c.Evaluate()
+	if len(pts) == 0 {
+		t.Fatal("wrap projection produced no points")
+	}
+	if !pts[0].IsEqualTo(gmath.P3(r, 0, 0), 1e-6) {
+		t.Errorf("wrap start = %v, want the anchor (2,0,0)", pts[0])
+	}
+	// A quarter-turn's worth of planar length lands at (0, R, 0), a quarter around the cylinder.
+	if !pts[len(pts)-1].IsEqualTo(gmath.P3(0, r, 0), 1e-6) {
+		t.Errorf("wrap end = %v, want (0,2,0)", pts[len(pts)-1])
+	}
+}
+
 // TestProjectToSurface3DClosestPointUnchanged: the default projection still drops each sample to its
 // perpendicular foot (#1841 — no behaviour change for existing callers).
 func TestProjectToSurface3DClosestPointUnchanged(t *testing.T) {


### PR DESCRIPTION
## What

Implements the **wrap** projection (`kWrapToSurfaceType` / MapPointCurve) for 3D-sketch project-to-surface curves — the final mode of #1841, after part 1 landed `closestPoint`/`alongVector` ([#1938](https://github.com/Oblikovati/Oblikovati/pull/1938)).

### Kernel — `geom.WrapCurveOntoSurface` (new op)
Maps a planar source curve onto a surface **preserving arc length** through a `WrapFrame` (origin + in-plane U/V axes):
- each source point flattens to `(a, b) = ((p−Origin)·U, (p−Origin)·V)`;
- the **anchor** is `surface.ParamAt(Origin)`;
- `b` maps to arc length along the surface's **v**-parameter, `a` along its **u**-parameter, by integrating the surface metric (`|∂S/∂u|`, `|∂S/∂v|`) and inverting arc-length → parameter (midpoint march, exact for constant-speed directions).

This is an **isometry for developable surfaces**: a cylinder of radius R maps planar `x` to angle `u = x/R`.

### Model / router
- `ProjectToSurfaceCurve3D` gains a `Frame`; `Evaluate` routes the wrap projection to the kernel op; `AddProjectToSurfaceCurve3DWrap`.
- The router `wrap` branch resolves the flattening frame from a **work-plane reference** (`WrapPlaneRef` → origin + X/Y axes) — associative and consistent with the other surface-curve operands.

## Correctness (CLAUDE.md bar: validate against analytic cases)
- `TestWrapCurveOntoCylinderIsArcLengthUnwrap` — every sample matches `(R·cos(a/R), R·sin(a/R), 0)`, i.e. `u = a/R = x/radius`.
- `TestArcLengthParamVariableSpeed` — the metric inverse on a non-constant speed `1+p`, checked against the exact `√(1+2T)−1`.
- `TestWrapCurveOntoCylinderAxialOffsetIsIndependent`, `TestWrapCurveOntoPlaneReconstructsSource` (identity), nil-input guards; model + router (over-wire) coverage.

## API
Pins `oblikovati.org/api v0.140.0` (contract PR [Oblikovati.API#265](https://github.com/Oblikovati/Oblikovati.API/pull/265): `WrapPlaneRef` + `AddProjectToSurfaceCurveWrap`).

Default projection stays `closestPoint` — no behaviour change for existing callers. Closes #1841.

🤖 Generated with [Claude Code](https://claude.com/claude-code)