### PR TITLE
feat(parameters): BuiltIn/Renamed/DisabledActionTypes introspection (#1853)

### DIFF
--- a/addin/router/parameters_detail.go
+++ b/addin/router/parameters_detail.go
@@ -27,6 +27,8 @@ func paramDetail(holder compdef.ParameterHolder, p *param.Parameter) wire.Parame
 		Comment:       p.Comment, IsKey: p.IsKey, Visible: p.Visible,
 		InUse: ps.InUse(p.ID()), Precision: p.Precision,
 		DisplayFormat: p.DisplayFormat.String(), ExposedAsProperty: p.ExposedAsProperty,
+		BuiltIn: p.BuiltIn(), Renamed: p.Renamed(),
+		DisabledActionTypes:  p.DisabledActionTypes().Names(),
 		ModelValueType:       p.ModelValueType().String(),
 		CustomPropertyFormat: customPropertyInfo(p.CustomProperty),
 		DrivenBy:             paramNames(ps, ps.DrivenBy(p.ID())),
@@ -124,6 +126,15 @@ func applyParameterUpdate(p *param.Parameter, in wire.ParameterUpdateArgs) error
 	setIfPresent(in.Visible, &p.Visible)
 	setIfPresent(in.Precision, &p.Precision)
 	setIfPresent(in.ExposedAsProperty, &p.ExposedAsProperty)
+	if err := applyParameterEnums(p, in); err != nil {
+		return err
+	}
+	return applyCustomPropertyUpdate(p, in.CustomPropertyFormat)
+}
+
+// applyParameterEnums applies the update's enum-valued fields (display format,
+// model-value selection, disabled-action mask), validating each spelling.
+func applyParameterEnums(p *param.Parameter, in wire.ParameterUpdateArgs) error {
 	if in.DisplayFormat != nil {
 		f, ok := types.ParseParameterDisplayFormat(*in.DisplayFormat)
 		if !ok {
@@ -140,7 +151,14 @@ func applyParameterUpdate(p *param.Parameter, in wire.ParameterUpdateArgs) error
 			return err
 		}
 	}
-	return applyCustomPropertyUpdate(p, in.CustomPropertyFormat)
+	if in.DisabledActionTypes != nil {
+		mask, ok := types.ActionTypeMask(*in.DisabledActionTypes)
+		if !ok {
+			return fmt.Errorf("parameters.update: unknown disabled action type in %v (want edit|rename|delete)", *in.DisabledActionTypes)
+		}
+		p.SetDisabledActionTypes(mask)
+	}
+	return nil
 }
 
 // setIfPresent copies a pointer-optional update field when it was sent.

--- a/addin/router/parameters_detail_test.go
+++ b/addin/router/parameters_detail_test.go
@@ -111,6 +111,45 @@ func TestParameterUpdateRejectsUnknownSpellings(t *testing.T) {
 	}
 }
 
+// TestParameterIntrospectionOverWire: getDetail reports builtIn/renamed, update
+// round-trips disabledActionTypes, and a rename of a model parameter flips
+// renamed to true (#1853).
+func TestParameterIntrospectionOverWire(t *testing.T) {
+	r, s := seededSession(t)
+	// A user parameter is neither built-in nor renamed, with no disabled actions.
+	if d := getDetail(t, r, s, "width"); d.BuiltIn || d.Renamed || len(d.DisabledActionTypes) != 0 {
+		t.Errorf("user param introspection = builtIn=%v renamed=%v disabled=%v, want all clear", d.BuiltIn, d.Renamed, d.DisabledActionTypes)
+	}
+	// disabledActionTypes replaces the whole mask and reads back in emission order.
+	var d wire.ParameterDetail
+	call(t, r, s, "parameters.update", `{"name":"width","disabledActionTypes":["rename","delete"]}`, &d)
+	if !slices.Equal(d.DisabledActionTypes, []string{"rename", "delete"}) {
+		t.Errorf("disabledActionTypes = %v, want [rename delete]", d.DisabledActionTypes)
+	}
+	// An empty list clears it. Read back through a fresh getDetail: the omitempty
+	// response field would otherwise leave the reused struct's stale value.
+	call(t, r, s, "parameters.update", `{"name":"width","disabledActionTypes":[]}`, nil)
+	if cleared := getDetail(t, r, s, "width"); len(cleared.DisabledActionTypes) != 0 {
+		t.Errorf("cleared disabledActionTypes = %v, want empty", cleared.DisabledActionTypes)
+	}
+	// Renaming a model parameter raises renamed.
+	call(t, r, s, "parameters.add", `{"name":"d0","kind":"model","expression":"5 mm"}`, nil)
+	call(t, r, s, "parameters.rename", `{"name":"d0","newName":"thickness"}`, nil)
+	if d := getDetail(t, r, s, "thickness"); !d.Renamed {
+		t.Errorf("renamed model param reports renamed=%v, want true", d.Renamed)
+	}
+}
+
+// TestParameterUpdateRejectsUnknownAction: an unrecognised disabled-action
+// spelling is refused, naming the offender (#1853).
+func TestParameterUpdateRejectsUnknownAction(t *testing.T) {
+	r, s := seededSession(t)
+	_, err := r.Handle(s, "parameters.update", []byte(`{"name":"width","disabledActionTypes":["suppress"]}`))
+	if err == nil || !strings.Contains(err.Error(), "disabled action type") {
+		t.Errorf("update with unknown action err = %v, want it to mention the disabled action type", err)
+	}
+}
+
 func TestParameterToleranceModesOverWire(t *testing.T) {
 	r, s := seededSession(t)
 	// Each mutation's response is checked through a fresh getDetail: omitempty

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.140.0
+	oblikovati.org/api v0.141.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.140.0
+	oblikovati.org/api v0.141.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/compdef/param_introspection_serialize_internal_test.go
+++ b/model/compdef/param_introspection_serialize_internal_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"testing"
+
+	"oblikovati.org/model/param"
+)
+
+// TestParameterIntrospectionRoundTrip: a renamed model parameter and a disabled-action
+// mask survive the parameter recipe round-trip (#1853). Without the recipe fields a
+// reopened model parameter would lose Renamed (re-added under its stored name) and its
+// DisabledActionTypes would reset to none.
+func TestParameterIntrospectionRoundTrip(t *testing.T) {
+	src := param.NewParameters()
+	m, err := src.AddModelParameter("d0", "5 mm")
+	if err != nil {
+		t.Fatalf("AddModelParameter: %v", err)
+	}
+	if err := src.Rename(m.ID(), "thickness"); err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+	m.SetDisabledActionTypes(param.ActionRename | param.ActionDelete)
+
+	recs := parametersRecipeOf(src)
+	dst := param.NewParameters()
+	if err := applyParametersTo(dst, nil, recs); err != nil {
+		t.Fatalf("applyParametersTo: %v", err)
+	}
+
+	got, ok := dst.ByName("thickness")
+	if !ok {
+		t.Fatalf("thickness missing after round-trip")
+	}
+	if !got.Renamed() {
+		t.Error("restored parameter lost Renamed()")
+	}
+	if got.DisabledActionTypes() != param.ActionRename|param.ActionDelete {
+		t.Errorf("restored mask = %v, want rename|delete", got.DisabledActionTypes())
+	}
+}

--- a/model/compdef/param_recipe.go
+++ b/model/compdef/param_recipe.go
@@ -72,6 +72,8 @@ func recordParameterPresentation(pr *parameterRecipe, p *param.Parameter) {
 		pr.SortedValueList = !p.CustomOrder()
 	}
 	pr.Hidden = !p.Visible
+	pr.Renamed = p.Renamed()
+	pr.DisabledActions = p.DisabledActionTypes().Names()
 	if p.DisplayFormat != param.DisplayFormatDecimal {
 		pr.DisplayFormat = p.DisplayFormat.String()
 	}
@@ -146,6 +148,10 @@ func addReadOnlyParameterTo(pr parameterRecipe, add func(string, param.Quantity)
 func applyParameterState(p *param.Parameter, pr parameterRecipe) error {
 	p.Comment, p.IsKey, p.ExposedAsProperty, p.Precision = pr.Comment, pr.Key, pr.Export, pr.Precision
 	p.Visible = !pr.Hidden
+	p.SetRenamed(pr.Renamed)
+	if err := applyDisabledActions(p, pr); err != nil {
+		return err
+	}
 	if err := applyParameterFormats(p, pr); err != nil {
 		return err
 	}
@@ -153,6 +159,20 @@ func applyParameterState(p *param.Parameter, pr parameterRecipe) error {
 		return err
 	}
 	return applyParameterValueList(p, pr)
+}
+
+// applyDisabledActions restores the restricted-action mask from its persisted
+// spellings (#1853).
+func applyDisabledActions(p *param.Parameter, pr parameterRecipe) error {
+	if len(pr.DisabledActions) == 0 {
+		return nil
+	}
+	mask, ok := types.ActionTypeMask(pr.DisabledActions)
+	if !ok {
+		return fmt.Errorf("unknown disabled action type in %v (want edit|rename|delete)", pr.DisabledActions)
+	}
+	p.SetDisabledActionTypes(mask)
+	return nil
 }
 
 // applyParameterFormats restores the display format and custom-property format

--- a/model/compdef/serialize.go
+++ b/model/compdef/serialize.go
@@ -102,6 +102,11 @@ type parameterRecipe struct {
 	// DisplayFormat is the wire spelling; empty means decimal.
 	DisplayFormat  string                `yaml:"displayFormat,omitempty"`
 	CustomProperty *customPropertyRecipe `yaml:"customProperty,omitempty"`
+	// Renamed marks a model parameter renamed from its generated name; DisabledActions
+	// is the list of restricted edit-action spellings (types.ActionType.Names()). Both
+	// are sparse (omitted when default), the parameter-introspection state (#1853).
+	Renamed         bool     `yaml:"renamed,omitempty"`
+	DisabledActions []string `yaml:"disabledActions,omitempty"`
 }
 
 // toleranceRecipe is the persisted form of a non-zero engineering tolerance:

--- a/model/param/introspection_test.go
+++ b/model/param/introspection_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package param
+
+import "testing"
+
+// TestRenamedFlagOnlyForModelParameters: renaming a model parameter raises Renamed;
+// renaming a user parameter (whose name is authored, not generated) does not (#1853).
+func TestRenamedFlagOnlyForModelParameters(t *testing.T) {
+	ps := NewParameters()
+	m, _ := ps.AddModelParameter("d0", "1 cm")
+	u, _ := ps.AddUserParameter("width", "2 cm")
+	if m.Renamed() || u.Renamed() {
+		t.Fatalf("fresh parameters must not be renamed (model %v, user %v)", m.Renamed(), u.Renamed())
+	}
+	if err := ps.Rename(m.ID(), "length"); err != nil {
+		t.Fatalf("rename model: %v", err)
+	}
+	if err := ps.Rename(u.ID(), "breadth"); err != nil {
+		t.Fatalf("rename user: %v", err)
+	}
+	if !m.Renamed() {
+		t.Error("renamed model parameter should report Renamed() = true")
+	}
+	if u.Renamed() {
+		t.Error("renamed user parameter should stay Renamed() = false (authored name)")
+	}
+}
+
+// TestAutoModelParameterIsBuiltIn confirms BuiltIn distinguishes an auto-generated
+// feature-dimension backing param from a user-created one (#1853 acceptance).
+func TestAutoModelParameterIsBuiltIn(t *testing.T) {
+	ps := NewParameters()
+	auto, _ := ps.AddAutoModelParameter("3 cm")
+	user, _ := ps.AddUserParameter("w", "3 cm")
+	if !auto.BuiltIn() {
+		t.Error("auto model parameter should be BuiltIn() = true")
+	}
+	if user.BuiltIn() {
+		t.Error("user parameter should be BuiltIn() = false")
+	}
+}
+
+// TestDisabledActionTypesRoundTrip: the mask is settable and read back exactly.
+func TestDisabledActionTypesRoundTrip(t *testing.T) {
+	ps := NewParameters()
+	p, _ := ps.AddUserParameter("w", "3 cm")
+	if p.DisabledActionTypes() != ActionNone {
+		t.Fatalf("fresh parameter mask = %v, want ActionNone", p.DisabledActionTypes())
+	}
+	p.SetDisabledActionTypes(ActionRename | ActionDelete)
+	if got := p.DisabledActionTypes(); got != ActionRename|ActionDelete {
+		t.Errorf("mask = %v, want rename|delete", got)
+	}
+}

--- a/model/param/parameter.go
+++ b/model/param/parameter.go
@@ -23,6 +23,19 @@ const (
 	TableParam     = types.TableParam
 )
 
+// ActionType is the bitmask of edit actions restricted on a parameter
+// (Parameter.DisabledActionTypes). Defined once in the Apache-2.0 contract
+// ([types.ActionType]); aliased here so param call sites keep their spelling
+// (ADR-0018, #1853).
+type ActionType = types.ActionType
+
+const (
+	ActionNone   = types.ActionNone
+	ActionEdit   = types.ActionEdit
+	ActionRename = types.ActionRename
+	ActionDelete = types.ActionDelete
+)
+
 // ParameterHealth is a parameter's evaluation health: a simplified three-value status (current /
 // stale / errored). It is a DISTINCT concept from api/types.HealthStatus (the entity/feature/constraint
 // health, OK/Warning/Sick/Suppressed) — a parameter has no Suppressed state and OutOfDate has no entity
@@ -64,7 +77,11 @@ type Parameter struct {
 	tol     Tolerance
 	kind    ParameterKind
 	builtin bool // an auto-generated / system parameter (a feature-dimension backing param) — kind conversion is refused, matching Inventor's BuiltIn guard (#1850)
-	health  Health
+	renamed bool // a model parameter renamed from its generated name (Inventor's ModelParameter.Renamed, #1853)
+	// disabledActions is the mask of edit actions restricted on this parameter
+	// (Inventor's Parameter.DisabledActionTypes, #1853). Zero = nothing disabled.
+	disabledActions ActionType
+	health          Health
 
 	exprList    []string // multi-value choices (empty ⇒ single-valued); see expression_list.go
 	allowCustom bool     // a value outside exprList is accepted (the one custom value)
@@ -96,6 +113,22 @@ func (p *Parameter) Kind() ParameterKind { return p.kind }
 // backing param). A built-in parameter's kind cannot be converted — matching Inventor's BuiltIn
 // guard (#1850).
 func (p *Parameter) BuiltIn() bool { return p.builtin }
+
+// Renamed reports whether a model parameter was renamed away from its
+// auto-generated name (Inventor's ModelParameter.Renamed, #1853). It is only
+// ever true for model parameters; user parameters carry their authored name.
+func (p *Parameter) Renamed() bool { return p.renamed }
+
+// DisabledActionTypes returns the mask of edit actions restricted on this
+// parameter (Inventor's Parameter.DisabledActionTypes, #1853).
+func (p *Parameter) DisabledActionTypes() ActionType { return p.disabledActions }
+
+// SetDisabledActionTypes replaces the restricted-action mask.
+func (p *Parameter) SetDisabledActionTypes(mask ActionType) { p.disabledActions = mask }
+
+// SetRenamed restores the renamed flag on a deserialised parameter (#1853); the
+// flag is otherwise raised only by [Parameters.Rename]. Persistence-only.
+func (p *Parameter) SetRenamed(renamed bool) { p.renamed = renamed }
 
 // Unit returns the unit of the evaluated value.
 func (p *Parameter) Unit() Unit { return p.value.Unit }

--- a/model/param/parameters.go
+++ b/model/param/parameters.go
@@ -263,6 +263,12 @@ func (ps *Parameters) Rename(id ID, newName string) error {
 	delete(ps.byName, oldName)
 	ps.byName[newName] = id
 	p.name = newName
+	// A renamed model parameter no longer carries its generated name; Inventor
+	// surfaces this as ModelParameter.Renamed (#1853). User parameters own their
+	// authored name, so the flag is meaningless for them.
+	if p.kind == ModelParam {
+		p.renamed = true
+	}
 	// References stay bound by stable id; update dependents' display text so it
 	// tracks the rename (edges are untouched, so dependents still evaluate).
 	for dep := range ps.dependents[id] {


### PR DESCRIPTION
Closes #1853.

## What
Exposes the read-only parameter-introspection members and the settable disabled-action mask through the member-level detail view. Pins `api v0.141.0` (contract in Oblikovati.API#266).

- **`paramDetail`** reports `builtIn`, `renamed`, `disabledActionTypes`.
- **`parameters.update`** accepts `disabledActionTypes` (replaces the whole mask; empty list clears), validated against `types.ActionType`.
- **model**: `param.Parameter` gains `renamed` (raised by `Rename` **only for model parameters**, matching Inventor's `ModelParameter.Renamed`) and a `disabledActions` mask with accessors.
- **persistence**: `parameterRecipe` carries `renamed` + `disabledActions`, so both survive a `.obk` save/reopen — a restored model parameter is re-added under its already-renamed name, which would otherwise drop the flag.

`BuiltIn` already existed on the model (#1850); this surfaces it so a converter can distinguish auto-generated feature dimensions (`d0`,`d1`,…) from authored parameters.

## Acceptance criteria
- [x] `parameters_get_detail` reports `builtIn` and `renamed` for model/reference parameters.
- [x] `builtIn` true for auto-created feature-dimension params, false for API-added (`TestAutoModelParameterIsBuiltIn`).
- [x] `disabledActionTypes` readable and settable via `parameters_update`.

## Test
- `model/param/introspection_test.go` — Renamed-only-for-model, BuiltIn auto vs user, mask round-trip.
- `addin/router/parameters_detail_test.go` — over-wire detail/update/clear + unknown-action rejection.
- `model/compdef/…_internal_test.go` — renamed + mask survive the recipe round-trip.

All green; gofmt + golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)