### PR TITLE
fix(head): visible Content Center table selection + equal-width columns

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.134.0
+	oblikovati.org/api v0.142.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.134.0
+	oblikovati.org/api v0.142.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -30,6 +30,7 @@ int  obk_ig_begin_tab_bar(const char* id);
 int  obk_ig_begin_tab_item_ex(const char* label, int setSelected);
 int  obk_ig_begin_tab_item_closable(const char* label, int setSelected, int* open);
 int  obk_ig_selectable(const char* label, int selected);
+int  obk_ig_selectable_span_all_columns(const char* label, int selected);
 int  obk_ig_begin_drag_drop_source(void);
 void obk_ig_set_drag_drop_payload_int(const char* type, int v);
 void obk_ig_end_drag_drop_source(void);
@@ -123,13 +124,15 @@ void obk_ig_set_next_window_size(float w, float h);
 void obk_ig_set_next_window_size_first_use(float w, float h);
 
 // Table verbs (the Parameters dialog grid, the content-center member table, …). begin_table
-// opens a bordered, row-striped, vertically scrolling table of `columns` columns; begin_table_scrollx
-// is the same but also scrolls horizontally (a wide grid in a narrow docked panel). Pair either with
-// end_table only when it returned non-zero. setup_column/setup_scroll_freeze/headers_row define the
-// header; next_row/next_column advance the cursor (next_column returns visibility). push_id_int/
-// pop_id scope per-row widget ids so identical cell labels don't collide.
+// opens a bordered, row-striped, vertically scrolling table of `columns` columns; begin_table_stretch
+// is the same but sizes every column to an equal share of the table width (a member grid that fills a
+// wide docked panel). Pair either with end_table only when it returned non-zero. setup_column/
+// setup_scroll_freeze/headers_row define the header; next_row/next_column advance the cursor
+// (next_column returns visibility). push_id_int/pop_id scope per-row widget ids so identical cell
+// labels don't collide.
 int  obk_ig_begin_table(const char* id, int columns, float outer_w, float outer_h);
-int  obk_ig_begin_table_scrollx(const char* id, int columns, float outer_w, float outer_h);
+int  obk_ig_begin_table_stretch(const char* id, int columns, float outer_w, float outer_h);
+void obk_ig_table_set_row_bg(float r, float g, float b, float a);
 void obk_ig_table_setup_column(const char* label);
 void obk_ig_table_setup_scroll_freeze(int cols, int rows);
 void obk_ig_table_headers_row(void);
@@ -609,12 +612,21 @@ func BeginTable(id string, columns int, w, h float32) bool {
 }
 func EndTable() { C.obk_ig_end_table() }
 
-// BeginTableScrollX is BeginTable plus horizontal scrolling — for a wide grid (many columns) in a
-// narrow docked panel. Pair every true return with EndTable.
-func BeginTableScrollX(id string, columns int, w, h float32) bool {
+// BeginTableStretch is BeginTable with equal-width stretch sizing — every column takes the same
+// share of the table width, filling a wide docked panel instead of clustering narrow columns on the
+// left. Resizable still lets the user redistribute. Pair every true return with EndTable.
+func BeginTableStretch(id string, columns int, w, h float32) bool {
 	c, free := cstr(id)
 	defer free()
-	return C.obk_ig_begin_table_scrollx(c, C.int(columns), C.float(w), C.float(h)) != 0
+	return C.obk_ig_begin_table_stretch(c, C.int(columns), C.float(w), C.float(h)) != 0
+}
+
+// TableSetRowBg paints the current table row's whole-row background in an explicit RGBA color, a
+// clearly visible persistent highlight for a selected row (the theme's resting ImGuiCol_Header is
+// dark, so a Selectable's own selected fill is near-invisible). Pass the accent at full alpha. Call
+// this right after TableNextRow. Uses ImGui's RowBg1 selection-marking layer, drawn behind the text.
+func TableSetRowBg(r, g, b, a float32) {
+	C.obk_ig_table_set_row_bg(C.float(r), C.float(g), C.float(b), C.float(a))
 }
 
 // TableSetupColumn declares the next header column; TableSetupScrollFreeze keeps the
@@ -712,6 +724,15 @@ func Selectable(label string, selected bool) bool {
 	c, free := cstr(label)
 	defer free()
 	return C.obk_ig_selectable(c, cBool(selected)) != 0
+}
+
+// SelectableSpanAllColumns is Selectable whose click target and highlight fill span the whole table
+// row rather than just the current cell. Use it for the first cell of a table row so a selected row
+// shows a persistent, full-width highlight (a plain Selectable confines the fill to column 0).
+func SelectableSpanAllColumns(label string, selected bool) bool {
+	c, free := cstr(label)
+	defer free()
+	return C.obk_ig_selectable_span_all_columns(c, cBool(selected)) != 0
 }
 
 // BeginDragDropSource reports whether the last item is being dragged this frame; if so set a

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -129,6 +129,14 @@ void obk_ig_end_tab_item(void)               { ImGui::EndTabItem(); }
 int  obk_ig_selectable(const char* label, int selected) {
     return ImGui::Selectable(label, selected != 0) ? 1 : 0;
 }
+// selectable_span_all_columns is selectable whose click target AND highlight fill span the whole
+// table row (all columns), not just the current cell. Without SpanAllColumns a Selectable placed
+// in column 0 confines both its hover and its persistent `selected` fill to that one column, so a
+// selected member row shows no visible full-row highlight (the tree gets this via
+// TreeNodeFlags_SpanAvailWidth; a table needs SpanAllColumns to match).
+int  obk_ig_selectable_span_all_columns(const char* label, int selected) {
+    return ImGui::Selectable(label, selected != 0, ImGuiSelectableFlags_SpanAllColumns) ? 1 : 0;
+}
 
 // Drag-and-drop: reorder a list by dragging a row onto another (#1222). The payload is a single
 // int (the dragged row index); SetDragDropPayload copies it internally so a local is safe.
@@ -522,18 +530,28 @@ int  obk_ig_begin_table(const char* id, int columns, float outer_w, float outer_
                             ImGuiTableFlags_Resizable | ImGuiTableFlags_ScrollY;
     return ImGui::BeginTable(id, columns, flags, ImVec2(outer_w, outer_h)) ? 1 : 0;
 }
-// begin_table_scrollx is begin_table plus horizontal scrolling, for wide data grids in a narrow
-// dock (a content-center member table). Kept separate from begin_table because ScrollX changes
-// column auto-sizing and the existing tables rely on the stretch default.
-int obk_ig_begin_table_scrollx(const char* id, int columns, float outer_w, float outer_h) {
+// begin_table_stretch is begin_table with equal-width stretch sizing: SizingStretchSame gives every
+// column the same share of the table width instead of shrinking each to its content and leaving the
+// surplus width empty (the content-center member table in a wide dock). Resizable still lets the user
+// redistribute. No ScrollX: horizontal scroll and stretch sizing are mutually exclusive in ImGui —
+// ScrollX forces SizingFixedFit, which is exactly the narrow-columns-with-empty-space symptom.
+int obk_ig_begin_table_stretch(const char* id, int columns, float outer_w, float outer_h) {
     ImGuiTableFlags flags = ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
                             ImGuiTableFlags_Resizable | ImGuiTableFlags_ScrollY |
-                            ImGuiTableFlags_ScrollX;
+                            ImGuiTableFlags_SizingStretchSame;
     return ImGui::BeginTable(id, columns, flags, ImVec2(outer_w, outer_h)) ? 1 : 0;
 }
 void obk_ig_table_setup_column(const char* label)      { ImGui::TableSetupColumn(label); }
 void obk_ig_table_setup_scroll_freeze(int cols, int rows) { ImGui::TableSetupScrollFreeze(cols, rows); }
 void obk_ig_table_headers_row(void)                    { ImGui::TableHeadersRow(); }
+// table_set_row_bg fills the CURRENT row's whole-row background with an explicit RGBA color, drawn
+// behind the cell text (RowBg1 is ImGui's dedicated selection-marking layer). The caller passes the
+// chrome accent at full opacity for a selected row: this theme maps the resting ImGuiCol_Header (a
+// Selectable's own selected fill) to the DARK header background, near-invisible against the striped
+// grid, so the selection highlight must be painted explicitly. Call right after TableNextRow().
+void obk_ig_table_set_row_bg(float r, float g, float b, float a) {
+    ImGui::TableSetBgColor(ImGuiTableBgTarget_RowBg1, ImGui::GetColorU32(ImVec4(r, g, b, a)));
+}
 void obk_ig_table_next_row(void)                       { ImGui::TableNextRow(); }
 int  obk_ig_table_next_column(void)                    { return ImGui::TableNextColumn() ? 1 : 0; }
 void obk_ig_end_table(void)                            { ImGui::EndTable(); }

--- a/head/ui/addin_table.go
+++ b/head/ui/addin_table.go
@@ -28,16 +28,16 @@ func cellAt(row wire.TableRow, col int) string {
 	return row.Cells[col]
 }
 
-// drawPanelTable renders a PanelTable: a scrolling, horizontally-scrolling data grid with a pinned
-// header. A row click pushes the row Key to the add-in (which arms Place). No per-frame allocation:
-// the spec's strings are drawn as-is.
+// drawPanelTable renders a PanelTable: a vertically-scrolling data grid with a pinned header whose
+// columns stretch to equal widths filling the dock. A row click pushes the row Key to the add-in
+// (which arms Place). No per-frame allocation: the spec's strings are drawn as-is.
 func drawPanelTable(s panelEditSession, windowID string, control wire.PanelControlSpec) {
 	cols := len(control.TableColumns)
 	if cols == 0 {
 		return
 	}
 	h := rowHeight() * addInTableRows
-	if !native.BeginTableScrollX("##"+control.ID, cols, -1, h) {
+	if !native.BeginTableStretch("##"+control.ID, cols, -1, h) {
 		return
 	}
 	defer native.EndTable()
@@ -58,12 +58,22 @@ func drawTableRow(s panelEditSession, windowID string, control wire.PanelControl
 	native.PushIDInt(i)
 	defer native.PopID()
 	native.TableNextRow()
+	if row.Key == control.Value {
+		// Paint the whole selected row in the chrome accent (opaque) so the selection is unmistakable
+		// and PERSISTS after the click. A Selectable's own selected fill is the theme's dark resting
+		// Header color, near-invisible against the row stripes — hence the explicit accent RowBg here.
+		a := chromeTheme.accentColor
+		native.TableSetRowBg(a[0], a[1], a[2], 1)
+	}
 	for c := 0; c < len(control.TableColumns); c++ {
 		if !native.TableNextColumn() {
 			continue
 		}
 		if c == 0 {
-			if native.Selectable(cellAt(row, 0), row.Key == control.Value) {
+			// SpanAllColumns so hovering and clicking anywhere on the row (not just column 0) selects
+			// it; the persistent selected fill is drawn above via TableSetRowBg, so this Selectable
+			// is never itself "selected" (that fill would be the near-invisible dark Header).
+			if native.SelectableSpanAllColumns(cellAt(row, 0), false) {
 				s.PanelValueChanged(windowID, control.ID, row.Key)
 			}
 			continue


### PR DESCRIPTION
## What

Two UX defects in the add-in dockable **PanelTable** (the Content Center member browser), reported from direct user testing:

1. **Clicking a row left no visible selection.** Now the selected row is painted full-width in the opaque chrome accent (via imgui's `RowBg1` selection layer), and clicking/hovering anywhere on the row selects/highlights it (`SpanAllColumns`).
2. **Columns clustered narrow with dead space on the right, clipping content.** Switched the table from `ScrollX` (which forces `SizingFixedFit`) to `SizingStretchSame`, so columns fill the panel equally (still resizable).

## Why

The resting selected color (`ImGuiCol_Header`) is themed to the dark header background — near-invisible against the row stripes — so a standard Selectable selection was effectively invisible; only the accent hover showed. `ScrollX` forced content-width columns and left the surplus panel width empty.

## Verification

- Built + full `ui`/`native` tests pass; lint clean on changed files.
- Live-verified on a running head over the MCP bridge: selected row shows a bold full-row accent highlight that persists and tracks the selection; all columns distribute equally with no clipping (confirmed against imgui's internal column state: all `WidthStretch`, equal).
- New draw paths are covered by the existing in-window `TestAddInPanelTreeTableRender` (renders a selected row), credited by the xvfb head job.

Related (not closed): #1933 (auto-scroll a programmatically-selected row into view) is a separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)