### PR TITLE
sketch: make filleted corners reach DOF 0

### DIFF
--- a/model/sketch/corner_blend.go
+++ b/model/sketch/corner_blend.go
@@ -10,11 +10,20 @@ import (
 )
 
 // AddFillet rounds the corner where two lines meet with a tangent arc of the given
-// radius: it trims each line back to its tangent point and inserts the arc between them.
+// radius: it trims each line back to its tangent point, inserts the arc between them, drops
+// the now-orphaned corner vertex, and pins the arc tangent to each edge. The tangency +
+// corner removal make a filleted corner reach DOF 0 with only a radius dimension added by the
+// caller — the pre-#69 AddFillet left the corner point floating (+2 DOF) and added no tangency,
+// so a filleted sketch could never fully constrain (Oblikovati.AddIns.PartDesigner#69). Apply
+// the fillet before other constraints reference the corner, as the corner vertex is consumed.
 // It errors when the lines do not share a corner or are (anti)parallel.
 //
 //	arc, err := sk.AddFillet(l1, l2, 0.5)
 func (s *Sketch) AddFillet(l1, l2 *Line, radius math.Scalar) (*Arc, error) {
+	cornerA, far1, cornerB, far2, ok := sharedCorner(l1, l2)
+	if !ok {
+		return nil, fmt.Errorf("fillet: the two lines do not share a corner")
+	}
 	corner, dir1, dir2, half, err := cornerFrame("fillet", l1, l2)
 	if err != nil {
 		return nil, err
@@ -27,7 +36,74 @@ func (s *Sketch) AddFillet(l1, l2 *Line, radius math.Scalar) (*Arc, error) {
 	trimTo(l1, l2, corner, t1, t2)
 	c := s.newPoint(center)
 	ccw := center.VectorTo(t1.Position()).Cross(center.VectorTo(t2.Position())) > 0
-	return s.arcs.Add(c, t1, t2, ccw), nil
+	arc := s.arcs.Add(c, t1, t2, ccw)
+	arc.filletTangents = []*filletTangencyConstraint{
+		newFilletTangency(c, t1, far1), // tangent to l1 at t1
+		newFilletTangency(c, t2, far2), // tangent to l2 at t2
+	}
+	s.dropOrphanCorner(cornerA)
+	if cornerB != cornerA {
+		s.dropOrphanCorner(cornerB)
+	}
+	return arc, nil
+}
+
+// dropOrphanCorner removes a corner vertex the fillet trimmed away, once nothing else references
+// it. A corner still used by another edge or a user constraint is left in place (the caller
+// filleted a shared/constrained corner); only a truly orphaned vertex is removed.
+func (s *Sketch) dropOrphanCorner(p *Point) {
+	if s.pointReferenced(p) {
+		return
+	}
+	s.removePoint(p)
+}
+
+// pointReferenced reports whether any surviving entity, geometric constraint, or dimension still
+// uses point p — the guard [Sketch.dropOrphanCorner] uses before discarding a filleted corner.
+func (s *Sketch) pointReferenced(p *Point) bool {
+	for _, e := range s.ents {
+		if e != Entity(p) && entityRefsPoint(e, p) {
+			return true
+		}
+	}
+	for _, c := range s.geomCons.All() {
+		if kc, ok := c.(KindedConstraint); ok && refsPoint(kc.RelatedEntities(), p) {
+			return true
+		}
+	}
+	for _, d := range s.dimCons.items {
+		if refsPoint(d.Refs(), p) {
+			return true
+		}
+	}
+	return false
+}
+
+// refsPoint reports whether any entity in ents is, or is defined by, point p.
+func refsPoint(ents []Entity, p *Point) bool {
+	for _, e := range ents {
+		if entityRefsPoint(e, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// entityRefsPoint reports whether entity e is point p or has p among its defining points.
+func entityRefsPoint(e Entity, p *Point) bool {
+	if e == Entity(p) {
+		return true
+	}
+	pd, ok := e.(pointDefined)
+	if !ok {
+		return false
+	}
+	for _, dp := range pd.definingPoints() {
+		if dp == p {
+			return true
+		}
+	}
+	return false
 }
 
 // AddChamfer bevels the corner where two lines meet with a straight line, trimming each

--- a/model/sketch/corner_blend_test.go
+++ b/model/sketch/corner_blend_test.go
@@ -70,6 +70,45 @@ func TestFilletDropsOrphanCorner(t *testing.T) {
 	}
 }
 
+// TestFilletKeepsCornerStillInUse: the fillet must NOT drop the shared corner when anything else
+// still references it — a third edge, a geometric constraint, or a dimension. Only a truly
+// orphaned vertex is removed (#69). Each keep-reason exercises a branch of pointReferenced.
+func TestFilletKeepsCornerStillInUse(t *testing.T) {
+	keepBy := map[string]func(s *Sketch, corner *Point){
+		"third edge": func(s *Sketch, c *Point) { s.Lines().Add(c, s.newPoint(gmath.P2(-4, 0))) },
+		"constraint": func(s *Sketch, c *Point) { s.GeometricConstraints().AddFix(c) },
+		"dimension": func(s *Sketch, c *Point) {
+			_, _ = s.DimensionConstraints().AddDistance(c, s.newPoint(gmath.P2(0, -3)), "3 cm")
+		},
+	}
+	for reason, keep := range keepBy {
+		s := NewSketches().Add(XYPlane())
+		corner := s.newPoint(gmath.P2(0, 0))
+		l1 := s.Lines().Add(corner, s.newPoint(gmath.P2(4, 0)))
+		l2 := s.Lines().Add(corner, s.newPoint(gmath.P2(0, 4)))
+		keep(s, corner)
+		arc, err := s.AddFillet(l1, l2, 1)
+		if err != nil {
+			t.Fatalf("[%s] AddFillet: %v", reason, err)
+		}
+		found := false
+		for _, p := range s.AllPoints() {
+			if p == corner {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("[%s] corner still in use was wrongly removed", reason)
+		}
+		// The tangency records are structural: they cannot be deleted on their own.
+		for _, ft := range arc.filletTangents {
+			if ft.Deletable() {
+				t.Errorf("[%s] fillet tangency constraint should be non-deletable", reason)
+			}
+		}
+	}
+}
+
 // TestFilletedSlopedCornerReachesDOF0 is the #69 regression: a fillet on a SLOPED corner (a
 // tapered flange's root) reaches DOF 0 with only the caller's edge directions + a radius
 // dimension, because AddFillet now drops the orphan corner and pins tangency non-degenerately.

--- a/model/sketch/corner_blend_test.go
+++ b/model/sketch/corner_blend_test.go
@@ -50,6 +50,90 @@ func TestAddChamferInsertsBevelLine(t *testing.T) {
 	}
 }
 
+// TestFilletDropsOrphanCorner: the fillet consumes the shared corner vertex, so it no longer
+// floats in the sketch as a free (+2 DOF) point (#69).
+func TestFilletDropsOrphanCorner(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	l1, l2 := cornerLines(s)
+	before := len(s.AllPoints())
+	if _, err := s.AddFillet(l1, l2, 1); err != nil {
+		t.Fatalf("AddFillet: %v", err)
+	}
+	// Net points: −1 corner (removed) +2 tangent +1 centre = +2.
+	if got := len(s.AllPoints()); got != before+2 {
+		t.Errorf("point count %d after fillet, want %d (orphan corner dropped, 2 tangents + centre added)", got, before+2)
+	}
+	for _, p := range s.AllPoints() {
+		if p.Position().IsEqualTo(gmath.P2(0, 0), 1e-9) {
+			t.Error("the orphaned corner vertex at (0,0) still lingers in the sketch")
+		}
+	}
+}
+
+// TestFilletedSlopedCornerReachesDOF0 is the #69 regression: a fillet on a SLOPED corner (a
+// tapered flange's root) reaches DOF 0 with only the caller's edge directions + a radius
+// dimension, because AddFillet now drops the orphan corner and pins tangency non-degenerately.
+func TestFilletedSlopedCornerReachesDOF0(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	g := s.GeometricConstraints()
+
+	// Fixed 8% reference so the sloped edge's direction is pinned independent of its endpoints.
+	rA, rB := s.Points().Add(gmath.P2(-5, 0)), s.Points().Add(gmath.P2(5, 0.8))
+	ref := s.Lines().Add(rA, rB)
+	g.AddFix(rA)
+	g.AddFix(rB)
+
+	vFar := s.Points().Add(gmath.P2(0, 0))    // web-front bottom
+	corner := s.Points().Add(gmath.P2(0, 5))  // root corner
+	sFar := s.Points().Add(gmath.P2(8, 5.64)) // flange toe, on the 8% slope through the corner
+	v := s.Lines().Add(vFar, corner)
+	sLine := s.Lines().Add(corner, sFar)
+
+	arc, err := s.AddFillet(v, sLine, 1)
+	if err != nil {
+		t.Fatalf("AddFillet: %v", err)
+	}
+	g.AddFix(vFar)
+	g.AddFix(sFar)
+	g.AddVertical(vFar, v.B)  // v trimmed to vFar->t1
+	g.AddParallel(sLine, ref) // sLine trimmed to t2->sFar, pinned to the 8% slope
+	if _, err := s.DimensionConstraints().AddRadius(arc, "1 cm"); err != nil {
+		t.Fatalf("AddRadius: %v", err)
+	}
+
+	if dof := s.DegreesOfFreedom(); dof != 0 {
+		t.Errorf("filleted sloped corner DOF = %d, want 0", dof)
+	}
+	r := s.Solve()
+	if !r.Converged {
+		t.Fatalf("filleted sloped corner did not converge (residual %g)", r.Residual)
+	}
+	// Tangent to both edges at unit radius, and the flange slope held at 8%.
+	if got := float64(arc.Radius()); math.Abs(got-1) > 1e-6 {
+		t.Errorf("arc radius %v, want 1", got)
+	}
+	if dv := perpFromCenter(arc, v); math.Abs(dv-1) > 1e-6 {
+		t.Errorf("arc not tangent to the vertical edge (perp dist %v)", dv)
+	}
+	if ds := perpFromCenter(arc, sLine); math.Abs(ds-1) > 1e-6 {
+		t.Errorf("arc not tangent to the sloped edge (perp dist %v)", ds)
+	}
+	d := sLine.A.Position().VectorTo(sLine.B.Position())
+	if slope := float64(d.Y) / float64(d.X); math.Abs(slope-0.08) > 1e-6 {
+		t.Errorf("flange slope %v, want 0.08", slope)
+	}
+}
+
+// perpFromCenter is the perpendicular distance from an arc's centre to a line's supporting line.
+func perpFromCenter(arc *Arc, l *Line) float64 {
+	dir := l.A.Position().VectorTo(l.B.Position())
+	length := dir.Length()
+	if length == 0 {
+		return 0
+	}
+	return math.Abs(float64(dir.Cross(l.A.Position().VectorTo(arc.Center.Position())))) / float64(length)
+}
+
 func TestAddFilletRejectsParallelLines(t *testing.T) {
 	s := NewSketches().Add(XYPlane())
 	shared := s.newPoint(gmath.P2(0, 0))

--- a/model/sketch/entities.go
+++ b/model/sketch/entities.go
@@ -105,7 +105,8 @@ type Arc struct {
 	Start            *Point
 	End              *Point
 	CounterClockwise bool
-	circularity      *arcCircularityConstraint // system-owned; keeps End at the arc radius
+	circularity      *arcCircularityConstraint  // system-owned; keeps End at the arc radius
+	filletTangents   []*filletTangencyConstraint // system-owned; tangency to the blended edges (#69)
 }
 
 // Radius returns the current center-to-start distance.

--- a/model/sketch/entities.go
+++ b/model/sketch/entities.go
@@ -105,7 +105,7 @@ type Arc struct {
 	Start            *Point
 	End              *Point
 	CounterClockwise bool
-	circularity      *arcCircularityConstraint  // system-owned; keeps End at the arc radius
+	circularity      *arcCircularityConstraint   // system-owned; keeps End at the arc radius
 	filletTangents   []*filletTangencyConstraint // system-owned; tangency to the blended edges (#69)
 }
 

--- a/model/sketch/fillet_tangency.go
+++ b/model/sketch/fillet_tangency.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"oblikovati.org/math"
+	"oblikovati.org/solve/ad"
+)
+
+// filletTangencyConstraint is the internal, system-owned constraint that keeps a fillet arc
+// tangent to one of the two edges it blends, at their shared point. It is created with the
+// fillet (see [Sketch.AddFillet]), lives and dies with the arc, and is never user-visible or
+// deletable.
+//
+// Tangency is expressed as the radius being perpendicular to the edge at the tangent point —
+// (shared − center) · (far − shared) = 0 — NOT as the usual line-to-circle "perpendicular
+// distance == radius" residual ([TangentConstraint]). That residual DEGENERATES for a fillet:
+// the arc's endpoint is the tangent point and lies on the line, so ∂(perp-dist)/∂center and
+// ∂(radius)/∂center are the same direction and the gradient vanishes at tangency, leaving the
+// fillet arc under-ranked (never reaching DOF 0). The radius-perpendicular form stays full-rank
+// there, so a filleted corner constrains cleanly (Oblikovati.AddIns.PartDesigner#69).
+type filletTangencyConstraint struct {
+	constraintBase
+	center, shared, far *Point
+}
+
+// newFilletTangency builds the tangency constraint for a fillet arc against one edge: shared is
+// the arc endpoint that lies on the edge (its tangent point), far the edge's other endpoint.
+func newFilletTangency(center, shared, far *Point) *filletTangencyConstraint {
+	return &filletTangencyConstraint{constraintBase: newConstraint(), center: center, shared: shared, far: far}
+}
+
+// residualAD: v = [center.X, center.Y, shared.X, shared.Y, far.X, far.Y]. The radius vector
+// (shared − center) is perpendicular to the edge direction (far − shared) at tangency, so their
+// dot product is zero.
+func (c *filletTangencyConstraint) residualAD(v []ad.Number) []ad.Number {
+	center := ad.V2(v[0], v[1])
+	shared := ad.V2(v[2], v[3])
+	far := ad.V2(v[4], v[5])
+	radial := shared.Sub(center)
+	edge := far.Sub(shared)
+	return []ad.Number{radial.Dot(edge)}
+}
+
+func (c *filletTangencyConstraint) Residuals() []float64 {
+	return adResiduals(c.Variables(), c.residualAD)
+}
+func (c *filletTangencyConstraint) Partials() [][]float64 {
+	return adPartials(c.Variables(), c.residualAD)
+}
+
+func (c *filletTangencyConstraint) Variables() []*math.Scalar {
+	return []*math.Scalar{
+		&c.center.X, &c.center.Y,
+		&c.shared.X, &c.shared.Y,
+		&c.far.X, &c.far.Y,
+	}
+}
+
+// Deletable implements [NonDeletable]: fillet tangency is structural to the blend and cannot be
+// removed on its own — it is dropped when its arc is.
+func (c *filletTangencyConstraint) Deletable() bool { return false }

--- a/model/sketch/sketch.go
+++ b/model/sketch/sketch.go
@@ -360,6 +360,9 @@ func (s *Sketch) Constraints() []Constraint {
 	// (#1419); the solver consumes it like any other, but it is not a user-facing relation.
 	for _, a := range s.arcs.items {
 		out = append(out, a.circularity)
+		for _, ft := range a.filletTangents {
+			out = append(out, ft) // fillet tangency to each blended edge (#69)
+		}
 	}
 	for _, d := range s.dimCons.items {
 		if !d.driven {


### PR DESCRIPTION
## Why

A sketch fillet could never fully constrain, which blocks any generated part needing fillets on a sloped edge — the tapered-flange channel fillets in **Oblikovati.AddIns.PartDesigner#69**. Two root causes, both found by probing the solver:

1. **`AddFillet` orphaned the shared corner vertex** — it repoints both edges to new tangent points but left the old corner floating as a free (+2 DOF) point.
2. **The line-arc `Tangent` residual is degenerate for a fillet** — the residual is `|perp-dist(C, line)| − R` with `R = |C − arc.Start|`, and in a fillet the arc's start *is* the tangent point *on* the line, so ∂(perp-dist)/∂C and ∂R/∂C are the same direction and the gradient vanishes at tangency. (It is fine for a full circle, whose radius is an independent variable.)

So a filleted profile stayed under-constrained even after dimensioning.

## What

`AddFillet` now:
- **drops the orphaned corner** — guarded by `pointReferenced`, so a corner still used by another edge or a user constraint is left in place;
- **pins the arc tangent to each edge** with a new system-owned, non-serialized `filletTangencyConstraint` that expresses tangency as **radius ⊥ edge at the tangent point** (`(shared − center) · (far − shared) = 0`) — full-rank there, unlike the perp-distance form. It's hung off the `Arc` like the existing `arcCircularityConstraint` and gathered by `Sketch.Constraints()`.

A filleted corner then reaches **DOF 0** with only a caller-supplied radius dimension + the edge directions, at **any** corner angle (verified on a sloped/tapered-flange corner).

No API/wire surface change — the `sketch.addEntity` `fillet` kind and `Dimension.Radius` already exist.

## Tests
- `TestFilletDropsOrphanCorner` — the corner vertex is consumed (net +2 points: −corner, +2 tangents, +centre).
- `TestFilletedSlopedCornerReachesDOF0` — a fillet on an 8%-sloped corner reaches DOF 0, converges, and is exactly tangent to both edges with the slope held.
- Existing fillet/chamfer/arc-circularity/serialization tests still pass; full `./model/...`, `./persistence/...`, `./addin/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)