### PR TITLE
fix(fillet): honest fillet-into-round rejection (#1797) + concave max-radius bound (#1800)

### DIFF
--- a/app/fillet_allaround_rampam_test.go
+++ b/app/fillet_allaround_rampam_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+)
+
+// filletVerticalsOf rounds the four vertical edges of the session's active block via the Fillet
+// TOOL (the real interactive path), leaving a body whose top rim is a tangent loop of 4 straight
+// sides + 4 corner arcs — the state rampam is in before trying to fillet "all around".
+func filletVerticalsOf(t *testing.T, s *Session, block *topo.Body) *topo.Body {
+	t.Helper()
+	f := NewFilletTool()
+	s.StartTool(f)
+	for _, e := range block.Edges() {
+		a, c := e.StartVertex().Point(), e.EndVertex().Point()
+		if a.X == c.X && a.Y == c.Y {
+			f.Pick(s, EdgeHandle{Edge: e})
+		}
+	}
+	f.SetRadius(0.5)
+	if err := s.OK(); err != nil {
+		t.Fatalf("vertical fillet: %v", err)
+	}
+	return activePartDef(t, s).SurfaceBodies().Item(0)
+}
+
+// oneTopRimEdge returns one edge handle lying on the body's top plane (z≈max).
+func oneTopRimEdge(t *testing.T, b *topo.Body) EdgeHandle {
+	t.Helper()
+	maxZ := 0.0
+	for _, v := range b.Vertices() {
+		if v.Point().Z > maxZ {
+			maxZ = v.Point().Z
+		}
+	}
+	for _, e := range b.Edges() {
+		if e.StartVertex().Point().Z >= maxZ-1e-9 && e.EndVertex().Point().Z >= maxZ-1e-9 {
+			return EdgeHandle{Edge: e}
+		}
+	}
+	t.Fatal("no top-rim edge")
+	return EdgeHandle{}
+}
+
+func toriOf(b *topo.Body) int {
+	n := 0
+	for _, f := range b.Faces() {
+		if _, ok := f.Geometry().(geom.Torus); ok {
+			n++
+		}
+	}
+	return n
+}
+
+// TestFilletAllAroundShiftClickExpandsTangentLoop is the intended #1798 gesture, end-to-end through
+// the TOOL: after rounding the verticals, ONE Shift+click on a top-rim edge must expand to the whole
+// 8-edge tangent loop and fillet all around, yielding a valid solid with 4 torus corners.
+func TestFilletAllAroundShiftClickExpandsTangentLoop(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	rounded := filletVerticalsOf(t, s, block)
+
+	f := NewFilletTool()
+	s.StartTool(f)
+	f.PickWithMods(s, oneTopRimEdge(t, rounded), ShiftMod)
+	if n := len(f.Edges()); n != 8 {
+		t.Fatalf("Shift+click on the rounded rim selected %d edges, want 8 (the whole tangent loop)", n)
+	}
+	f.SetRadius(0.25)
+	if err := s.OK(); err != nil {
+		t.Fatalf("all-around fillet OK: %v", err)
+	}
+	body := activePartDef(t, s).SurfaceBodies().Item(0)
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("all-around fillet body invalid: %+v", r)
+	}
+	if tori := toriOf(body); tori != 4 {
+		t.Errorf("all-around fillet tori = %d, want 4", tori)
+	}
+}
+
+// TestFilletAllAroundPlainClickIsSingleEdge documents rampam's likely experience (#1 "unable to
+// fillet all around, it does not detect tangency"): a PLAIN click selects only the one clicked edge,
+// so a user who does not know the (undiscoverable) Shift+click gets a single-edge fillet, not an
+// all-around one. This is the interaction gap — the kernel/feature layers are correct (they round
+// all 8 when handed them), but nothing surfaces the tangent loop on a normal click.
+func TestFilletAllAroundPlainClickIsSingleEdge(t *testing.T) {
+	s, block := newPartWithBlock(t, 2)
+	rounded := filletVerticalsOf(t, s, block)
+
+	f := NewFilletTool()
+	s.StartTool(f)
+	f.Pick(s, oneTopRimEdge(t, rounded)) // plain click — no modifier
+	if n := len(f.Edges()); n != 1 {
+		t.Fatalf("plain click selected %d edges, want 1 (no tangent-chain on a normal click)", n)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.142.0
+	oblikovati.org/api v0.142.1
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.142.0
+	oblikovati.org/api v0.142.1
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/kernel/ops/fillet.go
+++ b/kernel/ops/fillet.go
@@ -146,7 +146,7 @@ func filletEdgesCornerRec(body *topo.Body, picks []EdgeFilletRadii, corner Corne
 // assembles the validated result body. Round/setback corners have already been reduced to 3-edge
 // sphere blends by augmenting the third edge, so the corner solver only ever sees miters and blends.
 func filletResolvedEdges(body *topo.Body, edges []filletPick, concave ConcaveFill, rec *diag.Recorder) (*topo.Body, error) {
-	if err := validateFilletRadii(edges); err != nil {
+	if err := validateFilletRadii(edges, concave); err != nil {
 		return nil, err // #1800: reject an over-large radius before it self-intersects
 	}
 	blends, miters, err := computeCorners(edges)

--- a/kernel/ops/fillet.go
+++ b/kernel/ops/fillet.go
@@ -153,9 +153,13 @@ func filletResolvedEdges(body *topo.Body, edges []filletPick, concave ConcaveFil
 	if err != nil {
 		return nil, err
 	}
+	picked := make(map[uint64]bool, len(edges))
+	for _, p := range edges {
+		picked[p.edge.ID()] = true
+	}
 	fils := make([]edgeFillet, 0, len(edges))
 	for _, p := range edges {
-		ef, err := computeEdgeFillet(body, p, blends, miters, concave)
+		ef, err := computeEdgeFillet(body, p, blends, miters, concave, picked)
 		if err != nil {
 			return nil, err
 		}
@@ -259,13 +263,16 @@ type edgeFillet struct {
 // computeEdgeFillet solves the rolling-ball geometry for one convex straight edge, using a
 // corner blend at either endpoint that is a shared corner. A varying pick gets its end arcs
 // sampled as chords (shared by the ruling strips and the end faces).
-func computeEdgeFillet(body *topo.Body, p filletPick, blends map[uint64]*cornerBlend, miters map[uint64]*cornerMiter, concave ConcaveFill) (edgeFillet, error) {
+func computeEdgeFillet(body *topo.Body, p filletPick, blends map[uint64]*cornerBlend, miters map[uint64]*cornerMiter, concave ConcaveFill, picked map[uint64]bool) (edgeFillet, error) {
 	e := p.edge
 	if cyl, pl, ok := cylinderPlaneEdge(e); ok {
 		return edgeFillet{}, curvedFilletError(e, cyl, pl) // fillet of a fillet — Phase A: classify & report
 	}
 	if err := curvedAdjacentError(e); err != nil {
 		return edgeFillet{}, err // any other curved neighbour (cyl∩cyl miter seam, torus, sphere)
+	}
+	if err := curvedEndpointError(e, picked); err != nil {
+		return edgeFillet{}, err // planar edge whose END runs into a PRIOR round (#1797 fillet-into-fillet)
 	}
 	a, b, nA, nB, err := edgePlanarFaces(e)
 	if err != nil {

--- a/kernel/ops/fillet_concave_maxradius_test.go
+++ b/kernel/ops/fillet_concave_maxradius_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"strings"
+	"testing"
+
+	m "oblikovati.org/math"
+)
+
+// TestConcaveFilletOverRadiusRejected is the #1800 concave gap (rampam item 4): the max-radius guard
+// only bounded convex edges — a concave (pocket-fill) fillet whose radius overruns the finite walls
+// passed Validate and shipped self-intersecting geometry. This L-prism has a 2-unit-deep pocket at
+// the reflex edge (2,2) with a 90° dihedral (k=1), so r_max ≈ 2: a small radius fits, an over-large
+// one is rejected with an honest max-radius message (not silently accepted).
+func TestConcaveFilletOverRadiusRejected(t *testing.T) {
+	b := zPrism([]m.Point2{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 2}, {X: 2, Y: 2}, {X: 2, Y: 4}, {X: 0, Y: 4}}, 0, 4, "L")
+	var key []byte
+	for _, e := range b.Edges() {
+		a, c := e.StartVertex().Point(), e.EndVertex().Point()
+		if a.X == c.X && a.Y == c.Y && ClassifyEdgeConvexity(e) == EdgeConcave {
+			key = e.ReferenceKey()
+			break
+		}
+	}
+	if key == nil {
+		t.Fatal("no concave vertical edge on the L-prism")
+	}
+
+	for _, r := range []float64{1.0, 1.9} {
+		if _, err := FilletEdges(b, [][]byte{key}, r); err != nil {
+			t.Errorf("concave fillet r=%.1f should fit the 2-deep pocket, got: %v", r, err)
+		}
+	}
+	for _, r := range []float64{3.0, 10.0, 20.0} {
+		_, err := FilletEdges(b, [][]byte{key}, r)
+		if err == nil {
+			t.Errorf("concave fillet r=%.0f overruns the 2-deep pocket but was accepted (self-intersects)", r)
+			continue
+		}
+		if !strings.Contains(err.Error(), "geometric maximum") {
+			t.Errorf("concave over-radius should fail with the max-radius message, got: %v", err)
+		}
+	}
+}

--- a/kernel/ops/fillet_curved.go
+++ b/kernel/ops/fillet_curved.go
@@ -64,6 +64,50 @@ func curvedAdjacentError(e *topo.Edge) error {
 	return nil
 }
 
+// curvedEndpointError rejects a planar-flanked edge whose ENDPOINT runs into a curved (non-planar)
+// face left by a PRIOR round — the fillet-meets-fillet corner rampam hit (#1797): fillet a cube's
+// top rim, then its verticals, and each vertical is plane∩plane (so curvedAdjacentError passes) but
+// its top vertex touches the top-rim cylinders. The rolling-ball cylinder cannot terminate cleanly
+// into that existing round, so assembleBody produced an invalid solid — the misleading "not a valid
+// solid" (and, on older builds, a facet-cage). Reject here with an actionable reason instead. The
+// guard fires ONLY on a curved face that already exists on the body; edges filleted TOGETHER don't
+// trip it, since their rounds aren't built yet when this runs. picked holds the edges being filleted
+// in this op — a curved face touching the endpoint that belongs to one of those picks is this op's
+// own in-progress corner (handled by the corner solver), not a prior round, so it is ignored.
+func curvedEndpointError(e *topo.Edge, picked map[uint64]bool) error {
+	own := map[uint64]bool{}
+	for _, f := range e.Faces() {
+		own[f.ID()] = true
+	}
+	for _, v := range e.Vertices() {
+		for _, f := range facesAtVertex(v) {
+			if own[f.ID()] {
+				continue // one of the edge's own two (planar) walls
+			}
+			if _, planar := f.Geometry().(geom.Plane); planar {
+				continue
+			}
+			if faceBordersAnyPick(f, picked) {
+				continue // this op's own adjacent-edge round, not a pre-existing one
+			}
+			return fmt.Errorf("fillet: cannot round edge %d — it runs into an existing rounded (%s) face at its end; "+
+				"fillet these edges BEFORE the adjacent rounds, or select them together", e.ID(), surfaceKind(f.Geometry()))
+		}
+	}
+	return nil
+}
+
+// faceBordersAnyPick reports whether face f is bounded by an edge that is one of the ops's picks —
+// i.e. f is a round this same op is about to build, not a pre-existing curved neighbour.
+func faceBordersAnyPick(f *topo.Face, picked map[uint64]bool) bool {
+	for _, e := range f.Edges() {
+		if picked[e.ID()] {
+			return true
+		}
+	}
+	return false
+}
+
 // surfaceKind names a surface for an error message (its concrete geometry type), e.g. "cylinder".
 func surfaceKind(s geom.Surface) string {
 	switch s.(type) {

--- a/kernel/ops/fillet_endpoint_curved_test.go
+++ b/kernel/ops/fillet_endpoint_curved_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+)
+
+// TestFilletIntoExistingRoundRejectedHonestly_1797 pins the kernel guard for Discord #1797: round a
+// box's top rim (leaving cylinder faces), then fillet the four verticals — each is plane∩plane but
+// its TOP vertex runs into the top-rim cylinders, a fillet-meets-fillet corner the planar blend can't
+// close. It must fail with an actionable, rounded-cause message — never the misleading "not a valid
+// solid" that shipped a facet-cage octagon.
+func TestFilletIntoExistingRoundRejectedHonestly_1797(t *testing.T) {
+	box := csgBox(math.P3(0, 0, 0), 4, 4, 4)
+	rounded, err := ops.FilletEdges(box, topPerimeterKeys(t, box), 0.5)
+	if err != nil {
+		t.Fatalf("top-rim fillet setup: %v", err)
+	}
+
+	_, err = ops.FilletEdges(rounded, verticalEdgeKeys(t, rounded), 0.5)
+	if err == nil {
+		t.Fatal("filleting an edge that runs into an existing round must be rejected, got nil error")
+	}
+	if strings.Contains(err.Error(), "not a valid solid") {
+		t.Errorf("misleading message — should name the rounded cause, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "rounded") {
+		t.Errorf("message should name the rounded cause (so the user knows to fillet these first), got: %v", err)
+	}
+}
+
+// TestFilletAdjacentEdgesTogetherNotRejected guards against over-rejection: filleting two adjacent
+// edges in ONE op (their shared corner) must NOT trip the endpoint guard — the adjacent round does
+// not exist yet, so it is this op's own corner, solved normally.
+func TestFilletAdjacentEdgesTogetherNotRejected(t *testing.T) {
+	box := csgBox(math.P3(0, 0, 0), 4, 4, 4)
+	top := topPerimeterKeys(t, box)
+	if len(top) < 2 {
+		t.Fatalf("plain box top edges = %d, want ≥2", len(top))
+	}
+	if _, err := ops.FilletEdges(box, top[:2], 0.5); err != nil {
+		t.Fatalf("filleting two adjacent edges together must succeed, got: %v", err)
+	}
+}

--- a/kernel/ops/fillet_validity.go
+++ b/kernel/ops/fillet_validity.go
@@ -21,13 +21,24 @@ const filletFitEps = 1e-9
 // the fillet self-intersects, which the topological Validate cannot catch (#1800). Only edges
 // between two planar faces are bounded here; curved-neighbour edges get their r_max from the
 // marcher's seed solve in Phase 4. Radii are unchanged — this fails honestly, it does not clamp.
-func validateFilletRadii(picks []filletPick) error {
+func validateFilletRadii(picks []filletPick, concave ConcaveFill) error {
 	for _, p := range picks {
 		a, b, nA, nB, err := edgePlanarFaces(p.edge)
 		if err != nil {
 			continue // non-planar edge: not on the analytic planar path
 		}
-		rMax, bindingFace, bindingW, ok := maxFilletRadius(p, a, b, nA, nB, picks)
+		// The rolling ball recedes INTO each finite wall. For a convex edge that recession points
+		// into the face; for a concave OUTWARD fill (the default pocket fill) the frame negates the
+		// normals/offset (see filletFrame), so the width must be measured in that negated direction —
+		// otherwise the ray escapes the face and the bound is +Inf, letting an over-large concave
+		// radius overrun the pocket (rampam #1800 concave gap). A concave INWARD recess lands its
+		// tangent points off the bounded faces by design, so it is left to the assembly's validity
+		// gate rather than bounded here.
+		concaveOutward := ClassifyEdgeConvexity(p.edge) == EdgeConcave && concave == FillConcaveOutward
+		if ClassifyEdgeConvexity(p.edge) == EdgeConcave && !concaveOutward {
+			continue
+		}
+		rMax, bindingFace, bindingW, ok := maxFilletRadius(p, a, b, nA, nB, picks, concaveOutward)
 		if !ok {
 			continue // degenerate dihedral: leave to the assembly's own validity gate
 		}
@@ -45,12 +56,18 @@ func validateFilletRadii(picks []filletPick) error {
 // pick p, r_max = cot(α/2)·min(W_A,W_B), with W the available in-face width toward the nearest
 // competing boundary (reduced by any co-filleted neighbour's own band). ok=false on a degenerate
 // dihedral (near-flat or razor faces). Mirrors the derivation in ADR-0050 Phase 2.
-func maxFilletRadius(p filletPick, a, b *topo.Face, nA, nB math.Vector3, all []filletPick) (rMax float64, bindingFace uint64, bindingW float64, ok bool) {
+func maxFilletRadius(p filletPick, a, b *topo.Face, nA, nB math.Vector3, all []filletPick, concaveOutward bool) (rMax float64, bindingFace uint64, bindingW float64, ok bool) {
 	c := float64(nA.Dot(nB))
 	if 1-c < filletFitEps || 1+c < filletFitEps {
 		return 0, 0, 0, false
 	}
 	offDir := nA.Add(nB).Scale(math.Scalar(-1 / (1 + c)))
+	if concaveOutward {
+		// Match the outward-fill frame (filletFrame): the ball sits in the void, so the recession
+		// runs the other way — negate the offset and the wall normals so availableWidth casts INTO
+		// the pocket walls. c (and thus k) is unchanged: (−nA)·(−nB) = nA·nB.
+		offDir, nA, nB = offDir.Scale(-1), nA.Scale(-1), nB.Scale(-1)
+	}
 	k := stdmath.Sqrt((1 + c) / (1 - c)) // cot(α/2): r_max = k · W
 	wA := availableWidth(p.edge, a, nA, offDir, all)
 	wB := availableWidth(p.edge, b, nB, offDir, all)

--- a/model/feature/fillet_facetcage_repro_test.go
+++ b/model/feature/fillet_facetcage_repro_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// faceMix reports a body's face-geometry composition — the signature that tells a clean analytic
+// blend (few planes + cylinders/tori) from a facet-cage (a plane explosion).
+func faceMix(b *topo.Body) (planes, cyls, tori, other int) {
+	for _, f := range b.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Plane:
+			planes++
+		case geom.Cylinder:
+			cyls++
+		case geom.Torus:
+			tori++
+		default:
+			other++
+		}
+	}
+	return
+}
+
+// TestFilletIntoExistingRoundIsHonest_Rampam1 is the regression for Discord item #1 (#1797) as
+// rampam's screenshots show it: fillet the top rim of a cube (rounds it — the body now carries
+// cylinder faces), THEN fillet the four vertical edges. Each vertical edge is planar-flanked but its
+// TOP vertex runs into the top-rim cylinders — a fillet-meets-fillet corner the planar rolling-ball
+// blend cannot close. This must be REJECTED with an honest, actionable reason that names the rounded
+// cause — NOT the misleading "result is not a valid solid" (which shipped a facet-cage octagon on the
+// nightly rampam tested), and it must leave the good top-rim fillet intact (no mutation).
+func TestFilletIntoExistingRoundIsHonest_Rampam1(t *testing.T) {
+	box := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}},
+		sketch.XYPlane(), span{near: 0, far: 4}, 0, "box")
+	fs := NewPartFeatures(nil)
+	NewBaseFeatures(fs).AddBase(box)
+
+	top := topPerimeterKeysF(box)
+	if len(top) != 4 {
+		t.Fatalf("plain cube top edges = %d, want 4", len(top))
+	}
+	f1 := NewDressUpFeatures(fs).AddFillet(top, func() float64 { return 0.5 })
+	fs.Recompute()
+	if !f1.Health().OK() {
+		t.Fatalf("top-rim fillet sick: %+v", f1.Health())
+	}
+	goodP, goodC, goodTr, _ := faceMix(fs.Result()[0]) // the intact rounded-top body
+
+	vert := verticalEdgeKeysF(fs.Result()[0])
+	if len(vert) != 4 {
+		t.Fatalf("vertical edges on rounded body = %d, want 4", len(vert))
+	}
+	f2 := NewDressUpFeatures(fs).AddFillet(vert, func() float64 { return 0.5 })
+	fs.Recompute()
+
+	// It must not silently "succeed" into a bad solid.
+	if f2.Health().OK() {
+		t.Fatalf("filleting an edge that runs into an existing round must be rejected, but it reported healthy")
+	}
+	reason := f2.Health().Reason
+	if strings.Contains(reason, "not a valid solid") {
+		t.Errorf("misleading reason — should name the rounded/curved cause, got: %q", reason)
+	}
+	if !strings.Contains(strings.ToLower(reason), "round") && !strings.Contains(strings.ToLower(reason), "curved") {
+		t.Errorf("reason should name the rounded/curved cause (so the user knows to fillet these first), got: %q", reason)
+	}
+
+	// The prior good fillet is preserved and valid — no facet-cage, no mutation.
+	res := fs.Result()[0]
+	if rep := ops.Validate(res); !rep.Valid || !res.IsSolid() {
+		t.Fatalf("rejected fillet mutated the body into an invalid solid: %+v", rep)
+	}
+	if p, c, tr, _ := faceMix(res); p != goodP || c != goodC || tr != goodTr {
+		t.Errorf("rejected fillet changed the body: faces planes/cyl/tori = %d/%d/%d, want %d/%d/%d (unchanged)",
+			p, c, tr, goodP, goodC, goodTr)
+	}
+}

--- a/model/feature/fillet_rampam1797_test.go
+++ b/model/feature/fillet_rampam1797_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// verticalEdgeKeysF returns the keys of a prism's vertical edges (Z varies, X/Y fixed).
+func verticalEdgeKeysF(b *topo.Body) [][]byte {
+	var keys [][]byte
+	for _, e := range b.Edges() {
+		a, c := e.StartVertex().Point(), e.EndVertex().Point()
+		if a.X == c.X && a.Y == c.Y {
+			keys = append(keys, e.ReferenceKey())
+		}
+	}
+	return keys
+}
+
+// topPerimeterKeysF returns the keys of every edge lying entirely on the body's top plane.
+func topPerimeterKeysF(b *topo.Body) [][]byte {
+	maxZ := 0.0
+	for _, v := range b.Vertices() {
+		if v.Point().Z > maxZ {
+			maxZ = v.Point().Z
+		}
+	}
+	var keys [][]byte
+	for _, e := range b.Edges() {
+		if e.StartVertex().Point().Z >= maxZ-1e-9 && e.EndVertex().Point().Z >= maxZ-1e-9 {
+			keys = append(keys, e.ReferenceKey())
+		}
+	}
+	return keys
+}
+
+func countTorusF(b *topo.Body) int {
+	n := 0
+	for _, f := range b.Faces() {
+		if _, ok := f.Geometry().(geom.Torus); ok {
+			n++
+		}
+	}
+	return n
+}
+
+// TestFilletAllAroundTopRimThroughFeaturePath is the MISSING regression for Discord item #1 (#1797):
+// rampam's exact interactive workflow, driven through the real FEATURE path (AddFillet + Recompute),
+// NOT the raw ops.FilletEdges call the kernel test uses. Round the 4 vertical edges of a cube, then
+// fillet the whole top perimeter (a closed tangent chain of 4 straight + 4 arc edges) — it must build
+// ONE continuous rounded stripe (4 torus + straight-blend cylinders), a valid closed manifold solid,
+// not a faceted/distorted cage. If this fails, the feature layer diverges from the green kernel test.
+func TestFilletAllAroundTopRimThroughFeaturePath(t *testing.T) {
+	box := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 4, Y: 0}, {X: 4, Y: 4}, {X: 0, Y: 4}},
+		sketch.XYPlane(), span{near: 0, far: 4}, 0, "box")
+
+	fs := NewPartFeatures(nil)
+	NewBaseFeatures(fs).AddBase(box)
+
+	vert := verticalEdgeKeysF(box)
+	if len(vert) != 4 {
+		t.Fatalf("expected 4 vertical edges on the cube, got %d", len(vert))
+	}
+	f1 := NewDressUpFeatures(fs).AddFillet(vert, func() float64 { return 0.5 })
+	fs.Recompute()
+	if !f1.Health().OK() {
+		t.Fatalf("vertical-edge fillet sick: %+v", f1.Health())
+	}
+
+	top := topPerimeterKeysF(fs.Result()[0])
+	if len(top) != 8 {
+		t.Fatalf("expected 8 top-perimeter edges after vertical fillet, got %d", len(top))
+	}
+	f2 := NewDressUpFeatures(fs).AddFillet(top, func() float64 { return 0.25 })
+	fs.Recompute()
+	if !f2.Health().OK() {
+		t.Fatalf("all-around top-rim fillet sick (rampam #1): %+v", f2.Health())
+	}
+
+	res := fs.Result()[0]
+	rep := ops.Validate(res)
+	if !rep.Valid || !res.IsSolid() || !rep.Manifold || !rep.Closed {
+		t.Fatalf("top-rim fillet result invalid: valid=%v solid=%v manifold=%v closed=%v issues=%v",
+			rep.Valid, res.IsSolid(), rep.Manifold, rep.Closed, rep.Issues)
+	}
+	if tori := countTorusF(res); tori != 4 {
+		t.Errorf("torus faces = %d, want 4 (one per rounded corner) — a faceted/distorted result", tori)
+	}
+}


### PR DESCRIPTION
## What & why

rampam retested the closed fillet items on nightly `26071003` and reported 1–4 still failing (Discord #bug-tracker). Investigation showed the #1797/#1800 fixes **were** in that build but had been validated only on clean/convex geometry — their regressions call `ops.FilletEdges` directly and even the `stripe1797shot` "live capture" builds the body from raw ops, so nothing exercised the real feature/tool path or the messy cases in rampam's screenshots. This PR closes the two genuine defects that exposed.

### Item 1 — fillet that runs into an existing round (#1797)
Filleting the rim of an already-rounded body (round a cube's top rim, then its verticals) drives each vertical edge — plane-flanked, so the existing curved-adjacent guard passes — whose **top vertex runs into the top-rim cylinders**. That fillet-meets-fillet corner can't be closed by the planar rolling-ball blend, so `assembleBody` produced an invalid solid reported as the misleading `"result is not a valid solid"` (and, on rampam's nightly, a shipped facet-cage octagon).

`curvedEndpointError` now rejects a planar edge whose endpoint touches a **pre-existing** curved face with an actionable, rounded-cause message (fillet these first, or select them together). Curved faces bordered by this op's own picks are ignored, so adjacent edges filleted *together* are unaffected.

*Out of scope:* actually **building** the fillet-into-fillet corner blend — a larger geometry effort left as a follow-up on #1797.

### Item 4 — over-large concave (pocket-fill) fillet (#1800)
The #1800 max-radius guard only bounded convex edges: `availableWidth` casts clearance rays along the convex recession direction, which for a reflex edge points **out** of the finite wall → `r_max = +Inf`, so an over-large concave fillet passed `Validate` and shipped self-intersecting geometry (rampam: r=20 on a small pocket).

`validateFilletRadii` now receives the concave-fill strategy and, for an outward pocket fill, measures wall width along the negated recession direction matching `filletFrame`'s outward frame. `k = cot(alpha/2)` is unchanged; **convex bounding is byte-identical** (`concaveOutward=false`). Concave *inward* recess lands its tangent points off the bounded faces by design and is left to the assembly gate.

## Tests
- `test(fillet)`: the missing coverage — feature-path (`AddFillet`+`Recompute`) and tool-path (Shift+click tangent-loop expansion) for the all-around workflow.
- `TestFilletIntoExistingRoundIsHonest_Rampam1` / `TestFilletIntoExistingRoundRejectedHonestly_1797` / `TestFilletAdjacentEdgesTogetherNotRejected`
- `TestConcaveFilletOverRadiusRejected`
- Full core (`CGO_ENABLED=0 go test ./...`) green; `kernel/ops` + `model/feature` + `app` green; root-module `golangci-lint` 0 issues; `gofmt`/`vet` clean. No `head/` changes.

## Follow-ups (tracked, not in this PR)
- #1797: full fillet-into-fillet corner *support*.
- #1798: a discoverable "select tangent chain" affordance (the gesture works via Shift+click but isn't surfaced).
- #1799: awaits rampam's retest on the next nightly (#1943 landed after `26071003`).

Closes #1797
Closes #1800
