### PR TITLE
surface: Delete Face heal + Thicken options + Replace Face onto planes (#1884, #1876, #1886)

### DIFF
--- a/addin/opregistry/apply_success_test.go
+++ b/addin/opregistry/apply_success_test.go
@@ -42,6 +42,18 @@ func TestAdditiveOperations(t *testing.T) {
 	}
 }
 
+// TestThickenOptionErrors covers the #1876 router parse branches: an unknown direction or
+// operation is rejected with a descriptive error rather than silently defaulting.
+func TestThickenOptionErrors(t *testing.T) {
+	s, _, _ := extrudedSolid(t)
+	if _, err := apply(t, s, "thicken", `{"thickness":"1 mm","direction":"sideways"}`); err == nil {
+		t.Error("unknown thicken direction should error")
+	}
+	if _, err := apply(t, s, "thicken", `{"thickness":"1 mm","operation":"weld"}`); err == nil {
+		t.Error("unknown thicken operation should error")
+	}
+}
+
 // TestModifyAndPatternOperations drives the body-modifying, boolean, pattern, and mirror
 // operations against a solid. They must return a result or a descriptive error (some need
 // geometry the seeded box lacks), never panic — exercising decode/resolve/build.

--- a/addin/opregistry/apply_success_test.go
+++ b/addin/opregistry/apply_success_test.go
@@ -3,6 +3,7 @@
 package opregistry
 
 import (
+	"encoding/json"
 	"testing"
 
 	"oblikovati.org/app"
@@ -51,6 +52,21 @@ func TestThickenOptionErrors(t *testing.T) {
 	}
 	if _, err := apply(t, s, "thicken", `{"thickness":"1 mm","operation":"weld"}`); err == nil {
 		t.Error("unknown thicken operation should error")
+	}
+}
+
+// TestReplaceFaceNewFaceRefs covers the #1886 router path: replacing a face with a new-face set
+// (here the face's own key) resolves through the plane target and rebuilds without error, and an
+// empty new-face/target set is rejected.
+func TestReplaceFaceNewFaceRefs(t *testing.T) {
+	s, _, face := extrudedSolid(t)
+	ok, _ := json.Marshal(map[string]any{"faceRefs": []string{face}, "newFaceRefs": []string{face}})
+	if _, err := apply(t, s, "replaceFace", string(ok)); err != nil {
+		t.Fatalf("replaceFace newFaceRefs: %v", err)
+	}
+	bad, _ := json.Marshal(map[string]any{"faceRefs": []string{face}})
+	if _, err := apply(t, s, "replaceFace", string(bad)); err == nil {
+		t.Error("replaceFace with neither newFaceRefs nor targetRef should error")
 	}
 }
 

--- a/addin/opregistry/feature_advanced.go
+++ b/addin/opregistry/feature_advanced.go
@@ -11,6 +11,7 @@ import (
 	"oblikovati.org/api/types"
 	"oblikovati.org/api/wire/featureargs"
 	"oblikovati.org/app"
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
@@ -443,13 +444,14 @@ const replaceFaceSchema = `{
   "type": "object",
   "properties": {
     "faceRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Reference keys of the faces to replace (get_reference_keys)."},
-    "targetRef": {"type": "string", "description": "Reference key of the face whose surface replaces them."}
+    "newFaceRefs": {"type": "array", "items": {"type": "string"}, "description": "Replacement geometry: planar face keys and/or work planes (\"plane/N\", \"origin/plane/xy\"); faces may be from other bodies. Each picked face retrims onto its nearest new face."},
+    "targetRef": {"type": "string", "description": "Legacy single same-body target face (associative). newFaceRefs takes precedence."}
   },
-  "required": ["faceRefs", "targetRef"]
+  "required": ["faceRefs"]
 }`
 
 func replaceFaceDescriptor() *OperationDescriptor {
-	return &OperationDescriptor{Name: featureargs.KindReplaceFace, Summary: "Replace picked faces with another face's surface (direct edit).", Schema: json.RawMessage(replaceFaceSchema), Apply: applyReplaceFace}
+	return &OperationDescriptor{Name: featureargs.KindReplaceFace, Summary: "Replace picked faces with new faces / a work plane (direct edit).", Schema: json.RawMessage(replaceFaceSchema), Apply: applyReplaceFace}
 }
 
 func applyReplaceFace(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
@@ -457,11 +459,40 @@ func applyReplaceFace(s *app.Session, raw json.RawMessage) (json.RawMessage, err
 	if err != nil {
 		return nil, err
 	}
-	if len(in.FaceRefs) == 0 || in.TargetRef == "" {
-		return nil, errors.New("replaceFace: faceRefs and targetRef are required")
+	if len(in.FaceRefs) == 0 {
+		return nil, errors.New("replaceFace: faceRefs is required")
+	}
+	if len(in.NewFaceRefs) > 0 {
+		planes, err := replaceFacePlanes(part, in.NewFaceRefs)
+		if err != nil {
+			return nil, err
+		}
+		pf := feature.NewModifyFeatures(part.Features()).AddReplaceFacePlanes(refKeys(in.FaceRefs), planes)
+		return recomputeResult(part, pf)
+	}
+	if in.TargetRef == "" {
+		return nil, errors.New("replaceFace: newFaceRefs or targetRef is required")
 	}
 	pf := feature.NewModifyFeatures(part.Features()).AddReplaceFace(refKeys(in.FaceRefs), []byte(in.TargetRef))
 	return recomputeResult(part, pf)
+}
+
+// replaceFacePlanes resolves each new-face reference (a planar face key or a work plane) to a
+// frozen plane the replace-face feature retrims onto (#1886).
+func replaceFacePlanes(part *compdef.PartComponentDefinition, refs []string) ([]geom.Plane, error) {
+	planes := make([]geom.Plane, 0, len(refs))
+	for _, ref := range refs {
+		wp, err := part.WorkGeometry().PlaneTargetFromRef(ref)
+		if err != nil {
+			return nil, fmt.Errorf("replaceFace: new face %q: %w", ref, err)
+		}
+		pl, err := geom.NewPlane(wp.Plane().Origin(), wp.Plane().Normal().AsVector())
+		if err != nil {
+			return nil, fmt.Errorf("replaceFace: new face %q: %w", ref, err)
+		}
+		planes = append(planes, pl)
+	}
+	return planes, nil
 }
 
 // --- core/cavity -----------------------------------------------------------

--- a/addin/opregistry/feature_modify.go
+++ b/addin/opregistry/feature_modify.go
@@ -10,6 +10,7 @@ import (
 	"oblikovati.org/api/types"
 	"oblikovati.org/api/wire/featureargs"
 	"oblikovati.org/app"
+	"oblikovati.org/kernel/ops"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
 )
@@ -52,7 +53,13 @@ func applyCombine(s *app.Session, raw json.RawMessage) (json.RawMessage, error) 
 const thickenSchema = `{
   "type": "object",
   "properties": {
-    "thickness": {"type": "string", "description": "Wall thickness to add to the surface body, e.g. \"2 mm\"."},
+    "thickness": {"type": "string", "description": "Wall thickness to add to the surface body, e.g. \"2 mm\" (0 allowed for operation surface = a copy)."},
+    "direction": {"type": "string", "enum": ["positive", "negative", "symmetric"], "default": "positive", "description": "Offset side: +normal, -normal, or half each way."},
+    "operation": {"type": "string", "enum": ["join", "cut", "intersect", "surface"], "default": "join", "description": "join solidifies; cut/intersect boolean the solid into the running solid; surface offsets as a surface body."},
+    "faceRefs": {"type": "array", "items": {"type": "string"}, "description": "Reference keys of a face subset to thicken (get_reference_keys); empty = whole body."},
+    "createVerticalSurfaces": {"type": "boolean", "default": true, "description": "Close subset-boundary edges with side walls."},
+    "automaticFaceChain": {"type": "boolean", "default": false, "description": "Accepted for parity; selection is explicit, so not applied."},
+    "automaticBlending": {"type": "boolean", "default": false, "description": "Accepted for parity; not geometrically applied."},
     "approximation": {"type": "string", "enum": ["none", "mean", "neverTooThick", "neverTooThin"], "description": "Accepted approximation (#331 parity); the kernel computes the exact offset, which satisfies every bound."}
   },
   "required": ["thickness"]
@@ -75,10 +82,40 @@ func applyThicken(s *app.Session, raw json.RawMessage) (json.RawMessage, error) 
 	if err != nil {
 		return nil, err
 	}
+	dir, ok := ops.ParseThickenDirection(in.Direction)
+	if !ok {
+		return nil, fmt.Errorf("thicken: unknown direction %q (want positive/negative/symmetric)", in.Direction)
+	}
+	op, asSurface, err := parseThickenOperation(in.Operation)
+	if err != nil {
+		return nil, err
+	}
 	pf := feature.NewModifyFeatures(part.Features()).AddThickenFn(th)
-	pf.Definition().(*feature.ThickenFeature).SetApproximation(approx)
+	tf := pf.Definition().(*feature.ThickenFeature)
+	tf.SetApproximation(approx)
+	tf.SetThickenOptions(dir, op, asSurface, refKeys(in.FaceRefs), boolOrTrue(in.CreateVerticalSurfaces), in.AutomaticFaceChain, in.AutomaticBlending)
 	return recomputeResult(part, pf)
 }
+
+// parseThickenOperation maps the thicken output mode to (operation, asSurface). "" defaults to
+// join; "surface" is the offset-surface path; cut/intersect boolean into the running solid.
+func parseThickenOperation(name string) (ops.PartFeatureOperation, bool, error) {
+	switch name {
+	case "", "join":
+		return ops.Join, false, nil
+	case "cut":
+		return ops.Cut, false, nil
+	case "intersect":
+		return ops.Intersect, false, nil
+	case "surface":
+		return ops.Join, true, nil
+	default:
+		return ops.Join, false, fmt.Errorf("thicken: unknown operation %q (want join/cut/intersect/surface)", name)
+	}
+}
+
+// boolOrTrue defaults an omitted *bool to true (Inventor's CreateVerticalSurfaces default).
+func boolOrTrue(b *bool) bool { return b == nil || *b }
 
 // approximationArg parses the optional #331 approximation spelling (empty = none/exact).
 func approximationArg(s, op string) (types.FeatureApproximationType, error) {

--- a/addin/opregistry/feature_modify.go
+++ b/addin/opregistry/feature_modify.go
@@ -151,7 +151,10 @@ const faceOffsetSchema = `{
 
 const deleteFaceSchema = `{
   "type": "object",
-  "properties": {"faceRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Reference keys of the faces to delete (get_reference_keys)."}},
+  "properties": {
+    "faceRefs": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Reference keys of the faces to delete (get_reference_keys). Faces on an internal void shell delete that void and restore mass."},
+    "heal": {"type": "boolean", "default": false, "description": "Extend the neighbouring faces to close the opening. Default false (Inventor parity) leaves the body open (a surface)."}
+  },
   "required": ["faceRefs"]
 }`
 
@@ -170,7 +173,7 @@ func faceOffsetDescriptor() *OperationDescriptor {
 }
 
 func deleteFaceDescriptor() *OperationDescriptor {
-	return &OperationDescriptor{Name: featureargs.KindDeleteFace, Summary: "Delete picked faces, healing the body (direct edit).", Schema: json.RawMessage(deleteFaceSchema), Apply: applyDeleteFace}
+	return &OperationDescriptor{Name: featureargs.KindDeleteFace, Summary: "Delete picked faces (heal to close, or leave open); a void selection removes the void (direct edit).", Schema: json.RawMessage(deleteFaceSchema), Apply: applyDeleteFace}
 }
 
 func splitFaceDescriptor() *OperationDescriptor {
@@ -242,7 +245,7 @@ func applyDeleteFace(s *app.Session, raw json.RawMessage) (json.RawMessage, erro
 	if len(in.FaceRefs) == 0 {
 		return nil, errors.New("deleteFace: faceRefs is empty")
 	}
-	pf := feature.NewModifyFeatures(part.Features()).AddDeleteFace(refKeys(in.FaceRefs))
+	pf := feature.NewModifyFeatures(part.Features()).AddDeleteFace(refKeys(in.FaceRefs), in.Heal)
 	return recomputeResult(part, pf)
 }
 

--- a/app/delete_face_tool.go
+++ b/app/delete_face_tool.go
@@ -73,7 +73,7 @@ func (t *DeleteFaceTool) Commit(s *Session) error {
 
 // addDeleteFace builds the delete-face feature into engine fs — shared by Commit and preview.
 func (t *DeleteFaceTool) addDeleteFace(fs *feature.PartFeatures) *feature.PartFeature {
-	return feature.NewModifyFeatures(fs).AddDeleteFace(faceKeys(t.faces))
+	return feature.NewModifyFeatures(fs).AddDeleteFace(faceKeys(t.faces), true) // interactive Delete Face heals (#1884)
 }
 
 // AddedFeature returns the feature created on commit (for inspection/tests).

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.142.0
+	oblikovati.org/api v0.142.1
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.142.0
+	oblikovati.org/api v0.142.1
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/kernel/ops/delete_void.go
+++ b/kernel/ops/delete_void.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"bytes"
+	"fmt"
+
+	"oblikovati.org/kernel/topo"
+)
+
+// The FaceShell arm of Delete Face (#1884): selecting a face that lies on an internal void
+// (cavity) shell deletes that whole void and restores the enclosed mass, mirroring Inventor's
+// DeleteFaceFeatures.Add(FaceShell). This is distinct from deleting outer-shell faces (which
+// heals or opens the body — see delete_face.go / drop_faces.go); the feature dispatches on
+// whether the selection sits on a void shell.
+
+// FacesOnVoidShell reports whether every selected face lies on an internal void shell — the
+// signal the Delete Face feature uses to route to void removal rather than a face delete.
+// An empty selection, a lost key, or any face on the outer shell reports false.
+func FacesOnVoidShell(b *topo.Body, faceKeys [][]byte, q Quality) bool {
+	if len(faceKeys) == 0 {
+		return false
+	}
+	for _, k := range faceKeys {
+		sh := shellOfFaceKey(b, k)
+		if sh == nil || !ShellIsVoid(sh, q) {
+			return false
+		}
+	}
+	return true
+}
+
+// RemoveVoidShellByFaces drops every internal void shell that a selected face belongs to,
+// restoring the enclosed mass. It errors when a selected face reference is lost or names a face
+// that is not on an internal void shell, so the feature goes Sick rather than mangle the body.
+func RemoveVoidShellByFaces(b *topo.Body, faceKeys [][]byte, q Quality) (*topo.Body, error) {
+	drop := map[*topo.Shell]bool{}
+	for _, k := range faceKeys {
+		sh := shellOfFaceKey(b, k)
+		if sh == nil {
+			return nil, fmt.Errorf("delete-face void: face reference %q lost", k)
+		}
+		if !ShellIsVoid(sh, q) {
+			return nil, fmt.Errorf("delete-face void: face %q is not on an internal void shell", k)
+		}
+		drop[sh] = true
+	}
+	kept := make([]*topo.Shell, 0, len(b.Shells()))
+	for _, sh := range b.Shells() {
+		if !drop[sh] {
+			kept = append(kept, sh)
+		}
+	}
+	return topo.BodyFromShells(b.Lineage(), b.IsSolid(), kept...), nil
+}
+
+// shellOfFaceKey returns the shell carrying the face whose reference key equals key, or nil.
+func shellOfFaceKey(b *topo.Body, key []byte) *topo.Shell {
+	for _, sh := range b.Shells() {
+		for _, f := range sh.Faces() {
+			if bytes.Equal(f.ReferenceKey(), key) {
+				return sh
+			}
+		}
+	}
+	return nil
+}

--- a/kernel/ops/delete_void_test.go
+++ b/kernel/ops/delete_void_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/subd"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// distinctCavityBody is cavityBody with the outer and inner boxes carrying DISTINCT lineages, so
+// the two shells' faces have globally-unique reference keys (as real feature bodies do — the shared
+// cavityBody fixture reuses one "box" token, which is fine for its volume tests but breaks key→shell
+// lookup). 4³ block centred at origin minus a 2³ cavity centred at (1,1,1).
+func distinctCavityBody(t *testing.T, outer, inner string) *topo.Body {
+	t.Helper()
+	box := func(p math.Point3, s float64, name string) *topo.Body {
+		m := subd.Box(s, s, s)
+		for i := range m.Verts {
+			m.Verts[i] = m.Verts[i].TranslateBy(p.AsVector())
+		}
+		return subd.ToBody(m, name)
+	}
+	res, err := Boolean(Cut, box(math.P3(0, 0, 0), 4, outer), box(math.P3(1, 1, 1), 2, inner))
+	if err != nil {
+		t.Fatalf("cavity cut: %v", err)
+	}
+	return res
+}
+
+// voidFaceKey returns the reference key of one face on the body's internal void shell.
+func voidFaceKey(t *testing.T, b *topo.Body) []byte {
+	t.Helper()
+	for _, sh := range b.Shells() {
+		if ShellIsVoid(sh, DefaultQuality()) {
+			return sh.Faces()[0].ReferenceKey()
+		}
+	}
+	t.Fatal("body has no void shell")
+	return nil
+}
+
+// outerFaceKey returns the reference key of one face on the body's outer (non-void) shell.
+func outerFaceKey(t *testing.T, b *topo.Body) []byte {
+	t.Helper()
+	for _, sh := range b.Shells() {
+		if !ShellIsVoid(sh, DefaultQuality()) {
+			return sh.Faces()[0].ReferenceKey()
+		}
+	}
+	t.Fatal("body has no outer shell")
+	return nil
+}
+
+// TestRemoveVoidShellRestoresMass is the FaceShell arm of Delete Face (#1884): selecting a face on
+// the 4³−2³ cavity's void shell removes the void, restoring the 64 solid volume.
+func TestRemoveVoidShellRestoresMass(t *testing.T) {
+	body := distinctCavityBody(t, "outer", "inner")
+	if v := BodyGeometryProperties(body, DefaultQuality()).Volume; stdmath.Abs(v-56) > 0.1 {
+		t.Fatalf("fixture volume = %g, want 56 (4³ minus 2³ cavity)", v)
+	}
+	key := voidFaceKey(t, body)
+	if !FacesOnVoidShell(body, [][]byte{key}, DefaultQuality()) {
+		t.Fatal("a void-shell face should report FacesOnVoidShell true")
+	}
+	solid, err := RemoveVoidShellByFaces(body, [][]byte{key}, DefaultQuality())
+	if err != nil {
+		t.Fatalf("RemoveVoidShellByFaces: %v", err)
+	}
+	if got := len(solid.Shells()); got != 1 {
+		t.Fatalf("result has %d shells, want 1 (void removed)", got)
+	}
+	if v := BodyGeometryProperties(solid, DefaultQuality()).Volume; stdmath.Abs(v-64) > 0.1 {
+		t.Errorf("result volume = %g, want 64 (void filled)", v)
+	}
+	if r := Validate(solid); !r.Valid {
+		t.Errorf("result invalid: %v", r.Issues)
+	}
+}
+
+// TestFacesOnVoidShellRejectsOuterFace: an outer-shell face is not a void selection, so the feature
+// routes to an ordinary face delete instead.
+func TestFacesOnVoidShellRejectsOuterFace(t *testing.T) {
+	body := distinctCavityBody(t, "outer", "inner")
+	if FacesOnVoidShell(body, [][]byte{outerFaceKey(t, body)}, DefaultQuality()) {
+		t.Error("an outer-shell face should report FacesOnVoidShell false")
+	}
+	if FacesOnVoidShell(body, nil, DefaultQuality()) {
+		t.Error("an empty selection should report FacesOnVoidShell false")
+	}
+}
+
+// TestRemoveVoidShellErrorsOnNonVoid: RemoveVoidShellByFaces refuses an outer/lost face so the
+// feature goes Sick rather than mangle the body.
+func TestRemoveVoidShellErrorsOnNonVoid(t *testing.T) {
+	body := distinctCavityBody(t, "outer", "inner")
+	if _, err := RemoveVoidShellByFaces(body, [][]byte{outerFaceKey(t, body)}, DefaultQuality()); err == nil {
+		t.Error("removing a void by an outer-shell face should error")
+	}
+	if _, err := RemoveVoidShellByFaces(body, [][]byte{[]byte("ghost")}, DefaultQuality()); err == nil {
+		t.Error("a lost face key should error")
+	}
+}
+
+// TestDropFacesLeavesOpenSurface pins the heal=false arm at the kernel level: dropping a box face
+// leaves an open (non-solid) surface body with one fewer face.
+func TestDropFacesLeavesOpenSurface(t *testing.T) {
+	block, err := brep.SolidBlock(math.P3(0, 0, 0), math.P3(2, 2, 2), "b")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	key := block.Faces()[0].ReferenceKey()
+	open, err := DropFaces(block, [][]byte{key}, false)
+	if err != nil {
+		t.Fatalf("DropFaces: %v", err)
+	}
+	if open.IsSolid() {
+		t.Error("dropping a face should leave an open (non-solid) surface body")
+	}
+	if got, want := len(open.Faces()), len(block.Faces())-1; got != want {
+		t.Errorf("open body has %d faces, want %d", got, want)
+	}
+}

--- a/kernel/ops/replace_face.go
+++ b/kernel/ops/replace_face.go
@@ -3,8 +3,12 @@
 package ops
 
 import (
+	"fmt"
+	stdmath "math"
+
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
 )
 
 // ReplaceFaces replaces the surface of each selected face with the target plane and retrims
@@ -23,6 +27,44 @@ func ReplaceFaces(solid *topo.Body, faceKeys [][]byte, target geom.Plane) (*topo
 		}
 		return f.Geometry().(geom.Plane)
 	}), nil
+}
+
+// ReplaceFacesMulti replaces each selected face with the target plane it best matches — the
+// nearest by its centroid's distance to the plane — and retrims the neighbours. With a single
+// target it is exactly [ReplaceFaces]; with several it lets one Replace Face flatten different
+// picked faces onto different new faces / work planes (#1886). It errors on a lost pick or an
+// empty target set.
+func ReplaceFacesMulti(solid *topo.Body, faceKeys [][]byte, targets []geom.Plane) (*topo.Body, error) {
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("replace-face: no new faces")
+	}
+	sel, err := resolveFaceSet(solid, faceKeys)
+	if err != nil {
+		return nil, err
+	}
+	assign := make(map[uint64]geom.Plane, len(sel))
+	for _, f := range solid.Faces() {
+		if sel[f.ID()] {
+			assign[f.ID()] = nearestPlane(centroidPts(facePolygon(f)), targets)
+		}
+	}
+	return rebuildWithPlanes(solid, "replace-face", true, func(f *topo.Face) geom.Plane {
+		if pl, ok := assign[f.ID()]; ok {
+			return pl
+		}
+		return f.Geometry().(geom.Plane)
+	}), nil
+}
+
+// nearestPlane returns the target plane p minimizes |n·(c − origin)| for — the one c sits closest to.
+func nearestPlane(c math.Point3, targets []geom.Plane) geom.Plane {
+	best, bestD := targets[0], stdmath.Inf(1)
+	for _, pl := range targets {
+		if d := stdmath.Abs(float64(pl.Normal().Dot(pl.Origin.VectorTo(c)))); d < bestD {
+			best, bestD = pl, d
+		}
+	}
+	return best
 }
 
 // PlaneOfFace returns the plane of a face by its reference key (the target source for a

--- a/kernel/ops/replace_face_test.go
+++ b/kernel/ops/replace_face_test.go
@@ -51,6 +51,33 @@ func TestReplaceFaceLostKeyErrors(t *testing.T) {
 	}
 }
 
+// TestReplaceFacesMultiPicksNearest replaces the box's top face against two candidate target
+// planes (z=3 near, z=100 far): the top face binds to the nearer plane, growing the box to vol 12
+// (#1886).
+func TestReplaceFacesMultiPicksNearest(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	near, _ := geom.NewPlane(math.P3(0, 0, 3), math.V3(0, 0, 1))
+	far, _ := geom.NewPlane(math.P3(0, 0, 100), math.V3(0, 0, 1))
+	res, err := ops.ReplaceFacesMulti(box, [][]byte{topFaceKey(t, box)}, []geom.Plane{far, near})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := ops.Validate(res); !r.Valid || !res.IsSolid() {
+		t.Fatalf("multi replace not a valid solid: %+v", r)
+	}
+	if got := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Volume; stdmath.Abs(got-12) > 1e-6 {
+		t.Errorf("multi replace volume = %g, want 12 (bound to nearer z=3 plane)", got)
+	}
+}
+
+// TestReplaceFacesMultiEmptyErrors: no target planes is a caller error (feature goes Sick).
+func TestReplaceFacesMultiEmptyErrors(t *testing.T) {
+	box := shellBox(2, 2, 2)
+	if _, err := ops.ReplaceFacesMulti(box, [][]byte{topFaceKey(t, box)}, nil); err == nil {
+		t.Error("ReplaceFacesMulti with no targets should error")
+	}
+}
+
 // TestPlaneOfFace resolves a planar face's plane by reference key, and reports a miss for an
 // unknown key.
 func TestPlaneOfFace(t *testing.T) {

--- a/kernel/ops/thicken.go
+++ b/kernel/ops/thicken.go
@@ -3,27 +3,97 @@
 package ops
 
 import (
+	"bytes"
 	"fmt"
 
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 )
 
-// Thicken turns a planar surface (sheet) body into a solid of wall thickness t: each face is
-// copied to both sides (offset ±t/2 along its normal) and the free-boundary edges (used by a
-// single face) are closed with side walls. A single planar patch becomes a slab; a connected
-// planar sheet becomes a thick shell. Curved or creased sheets (where per-face offsets don't
-// meet) are a follow-up. It errors when the result is not a valid solid.
+// ThickenDirection is the side(s) a Thicken offsets a surface toward (Inventor's
+// PartFeatureExtentDirection for Thicken): the +normal side, the −normal side, or half the
+// thickness each way (#1876).
+type ThickenDirection int
+
+const (
+	// ThickenSymmetric offsets ±t/2, keeping the surface centred (the pre-#1876 behaviour).
+	ThickenSymmetric ThickenDirection = iota
+	// ThickenPositive offsets 0…+t (all material on the +normal side).
+	ThickenPositive
+	// ThickenNegative offsets −t…0 (all material on the −normal side).
+	ThickenNegative
+)
+
+// String returns the stable wire/serialization spelling of a thicken direction.
+func (d ThickenDirection) String() string {
+	switch d {
+	case ThickenPositive:
+		return "positive"
+	case ThickenNegative:
+		return "negative"
+	default:
+		return "symmetric"
+	}
+}
+
+// ParseThickenDirection maps the wire spelling to a direction; "" defaults to positive (Inventor's
+// kPositive default for Thicken). It reports false for an unknown spelling.
+func ParseThickenDirection(s string) (ThickenDirection, bool) {
+	switch s {
+	case "", "positive":
+		return ThickenPositive, true
+	case "negative":
+		return ThickenNegative, true
+	case "symmetric":
+		return ThickenSymmetric, true
+	default:
+		return ThickenSymmetric, false
+	}
+}
+
+// slabOffsets returns the top/bottom offset distances for a direction and thickness.
+func (d ThickenDirection) slabOffsets(t float64) (top, bottom float64) {
+	switch d {
+	case ThickenPositive:
+		return t, 0
+	case ThickenNegative:
+		return 0, -t
+	default:
+		return t / 2, -t / 2
+	}
+}
+
+// Thicken turns a planar surface (sheet) body into a solid of wall thickness t, symmetric about
+// the surface — the whole-body default (see ThickenSolid for the directed / face-subset form).
 func Thicken(surface *topo.Body, t float64) (*topo.Body, error) {
+	return ThickenSolid(surface, t, ThickenSymmetric, nil, true)
+}
+
+// ThickenSolid turns (a subset of) a planar surface body into a solid of wall thickness t. Each
+// selected face is copied to both offset sides (per dir) and the subset-boundary edges — those
+// used by exactly one selected face — are closed with side walls when walls is true
+// (Inventor's CreateVerticalSurfaces). A nil/empty faceKeys thickens every face. Curved or creased
+// sheets (where per-face offsets don't meet) are a follow-up; it errors when the result is not a
+// valid solid.
+func ThickenSolid(surface *topo.Body, t float64, dir ThickenDirection, faceKeys [][]byte, walls bool) (*topo.Body, error) {
 	if t <= 0 {
 		return nil, fmt.Errorf("thicken: thickness %g must be > 0", t)
 	}
-	half := t / 2
+	selected := selectedFaceSet(surface, faceKeys)
+	if len(selected) == 0 {
+		return nil, fmt.Errorf("thicken: no faces selected")
+	}
+	top, bottom := dir.slabOffsets(t)
 	var loops []ploop
 	for _, f := range surface.Faces() {
+		if !selected[f.ID()] {
+			continue
+		}
 		n := f.Geometry().NormalAt(0, 0)
-		loops = append(loops, slabCaps(f, n, half)...)
-		loops = append(loops, slabWalls(f, n, half)...)
+		loops = append(loops, slabCaps(f, n, top, bottom)...)
+		if walls {
+			loops = append(loops, slabWalls(f, n, top, bottom, selected)...)
+		}
 	}
 	body := buildSolidFromLoops(loops)
 	if r := Validate(body); !r.Valid || !body.IsSolid() {
@@ -32,36 +102,66 @@ func Thicken(surface *topo.Body, t float64) (*topo.Body, error) {
 	return body, nil
 }
 
-// slabCaps returns the top (offset +half, same winding) and bottom (offset −half, reversed)
-// copies of a face — the two outer skins of the slab.
-func slabCaps(f *topo.Face, n math.Vector3, half float64) []ploop {
-	top := ploop{normal: n}
-	bottom := ploop{normal: n.Scale(-1)}
-	for _, l := range f.Loops() {
-		pts := loopPoints3(l)
-		top.rings = append(top.rings, offsetRing(pts, n, half))
-		bottom.rings = append(bottom.rings, reverse3(offsetRing(pts, n, -half)))
+// selectedFaceSet maps the chosen face ids (all faces when faceKeys is empty).
+func selectedFaceSet(surface *topo.Body, faceKeys [][]byte) map[uint64]bool {
+	set := map[uint64]bool{}
+	if len(faceKeys) == 0 {
+		for _, f := range surface.Faces() {
+			set[f.ID()] = true
+		}
+		return set
 	}
-	return []ploop{top, bottom}
+	for _, f := range surface.Faces() {
+		for _, k := range faceKeys {
+			if bytes.Equal(f.ReferenceKey(), k) {
+				set[f.ID()] = true
+			}
+		}
+	}
+	return set
 }
 
-// slabWalls returns a side-wall quad for each free-boundary edge of the face (an edge used by
-// a single face), connecting the top and bottom skins.
-func slabWalls(f *topo.Face, n math.Vector3, half float64) []ploop {
+// slabCaps returns the top (offset +top, same winding) and bottom (offset +bottom, reversed)
+// copies of a face — the two outer skins of the slab.
+func slabCaps(f *topo.Face, n math.Vector3, top, bottom float64) []ploop {
+	tc := ploop{normal: n}
+	bc := ploop{normal: n.Scale(-1)}
+	for _, l := range f.Loops() {
+		pts := loopPoints3(l)
+		tc.rings = append(tc.rings, offsetRing(pts, n, top))
+		bc.rings = append(bc.rings, reverse3(offsetRing(pts, n, bottom)))
+	}
+	return []ploop{tc, bc}
+}
+
+// slabWalls returns a side-wall quad for each subset-boundary edge of the face — an edge with
+// exactly one use on a selected face — connecting the top and bottom skins.
+func slabWalls(f *topo.Face, n math.Vector3, top, bottom float64, selected map[uint64]bool) []ploop {
 	var walls []ploop
 	for _, l := range f.Loops() {
 		for _, u := range l.EdgeUses() {
-			if len(u.Edge().Uses()) != 1 {
-				continue // shared (interior) edge — the offset skins already meet here
+			if selectedUses(u.Edge(), selected) != 1 {
+				continue // interior to the selected subset — the offset skins already meet here
 			}
 			a, b := useEndpoints(u)
-			at, ab := a.TranslateBy(n.Scale(half)), a.TranslateBy(n.Scale(-half))
-			bt, bb := b.TranslateBy(n.Scale(half)), b.TranslateBy(n.Scale(-half))
+			at, ab := a.TranslateBy(n.Scale(top)), a.TranslateBy(n.Scale(bottom))
+			bt, bb := b.TranslateBy(n.Scale(top)), b.TranslateBy(n.Scale(bottom))
 			wn := outwardWall(a.VectorTo(b), n)
 			walls = append(walls, ploop{normal: wn, rings: [][]math.Point3{{at, ab, bb, bt}}})
 		}
 	}
 	return walls
+}
+
+// selectedUses counts how many of an edge's uses belong to a selected face.
+func selectedUses(e *topo.Edge, selected map[uint64]bool) int {
+	n := 0
+	for _, u := range e.Uses() {
+		if f := u.Loop().Face(); f != nil && selected[f.ID()] {
+			n++
+		}
+	}
+	return n
 }
 
 // useEndpoints returns an edge use's start and end points in its traversal direction.

--- a/kernel/ops/thicken_test.go
+++ b/kernel/ops/thicken_test.go
@@ -58,3 +58,75 @@ func TestThickenThicknessMustBePositive(t *testing.T) {
 		t.Error("zero thickness should error")
 	}
 }
+
+// twoFaceSheet builds a flat two-face surface: rectangles [0,w]×[0,h] and [w,2w]×[0,h] in z=0,
+// sharing the x=w edge, each with its own lineage so the faces have distinct reference keys.
+func twoFaceSheet(t *testing.T, w, h float64) (*topo.Body, [][]byte) {
+	t.Helper()
+	lin := topo.NewLineage(topo.Tok("test", "sheet", 0))
+	bld := topo.NewBuilder(false, lin)
+	plane, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	var keys [][]byte
+	quad := func(x0 float64, tag int) {
+		p := []math.Point3{{X: x0, Y: 0}, {X: x0 + w, Y: 0}, {X: x0 + w, Y: h}, {X: x0, Y: h}}
+		fl := topo.NewLineage(topo.Tok("test", "face", tag))
+		v := make([]*topo.Vertex, 4)
+		for i, q := range p {
+			v[i] = bld.AddVertex(q, fl)
+		}
+		uses := make([]topo.Use, 4)
+		for i := range p {
+			e := bld.AddEdge(geom.NewLineSegment(p[i], p[(i+1)%4]), v[i], v[(i+1)%4], fl)
+			uses[i] = topo.Use{Edge: e}
+		}
+		f := bld.AddFace(plane, fl, topo.OuterLoop(uses...))
+		keys = append(keys, f.ReferenceKey())
+	}
+	quad(0, 1)
+	quad(w, 2)
+	return bld.Build(), keys
+}
+
+// TestThickenDirectionPlacesSlab pins the #1876 direction: a 2×2 patch thickened 0.5 lands on the
+// +normal side (centroid z +t/2), the −normal side, or centred (symmetric) — all volume 2.
+func TestThickenDirectionPlacesSlab(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		dir    ops.ThickenDirection
+		wantCZ float64
+	}{
+		{"positive", ops.ThickenPositive, 0.25},
+		{"negative", ops.ThickenNegative, -0.25},
+		{"symmetric", ops.ThickenSymmetric, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			slab, err := ops.ThickenSolid(planarPatch(t, 2, 2), 0.5, tc.dir, nil, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			p := ops.BodyGeometryProperties(slab, ops.DefaultQuality())
+			if stdmath.Abs(p.Volume-2) > 1e-6 {
+				t.Errorf("volume = %g, want 2", p.Volume)
+			}
+			if stdmath.Abs(float64(p.Centroid.Z)-tc.wantCZ) > 1e-6 {
+				t.Errorf("centroid z = %g, want %g", p.Centroid.Z, tc.wantCZ)
+			}
+		})
+	}
+}
+
+// TestThickenFaceSubset thickens only one face of a two-face sheet: the result is a valid solid of
+// just that face's volume (1·2·0.5 = 1), the shared edge closed by a vertical surface (#1876).
+func TestThickenFaceSubset(t *testing.T) {
+	sheet, keys := twoFaceSheet(t, 1, 2)
+	solid, err := ops.ThickenSolid(sheet, 0.5, ops.ThickenPositive, [][]byte{keys[0]}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := ops.Validate(solid); !r.Valid || !solid.IsSolid() {
+		t.Fatalf("subset thicken not a valid solid: %+v", r)
+	}
+	if got := ops.BodyGeometryProperties(solid, ops.DefaultQuality()).Volume; stdmath.Abs(got-1) > 1e-6 {
+		t.Errorf("subset volume = %g, want 1 (one 1×2 face × 0.5)", got)
+	}
+}

--- a/model/feature/modify.go
+++ b/model/feature/modify.go
@@ -136,13 +136,40 @@ func (f *ReplaceFaceFeature) Recompute(in Input) (Output, error) {
 	})
 }
 
-// DeleteFaceFeature removes the picked faces and heals the openings (extends neighbours).
-type DeleteFaceFeature struct{ faceEditFeature }
+// DeleteFaceFeature removes the picked faces. Heal (default false, Inventor parity #1884) extends
+// the neighbouring faces to close the opening; heal=false leaves the body open (a surface). If the
+// picked faces sit on an internal void shell instead, the whole void is removed (mass restored).
+type DeleteFaceFeature struct {
+	faceEditFeature
+	heal bool
+}
 
-// Recompute deletes the picked faces from the running body and heals it (see
-// kernel/ops/delete_face.go); a non-healable selection makes the feature go Sick.
+// Heal reports whether the openings are closed by extending neighbours (for serialization).
+func (f *DeleteFaceFeature) Heal() bool { return f.heal }
+
+// Recompute deletes the picked faces from the running body. Faces on an internal void shell drop
+// that void (restoring mass, see kernel/ops/delete_void.go); otherwise heal extends neighbours to
+// close the gap (kernel/ops/delete_face.go) and heal=false leaves it open (kernel/ops/drop_faces.go).
+// A non-healable selection or lost key makes the feature go Sick.
 func (f *DeleteFaceFeature) Recompute(in Input) (Output, error) {
-	return retopoFacesBody(in, f.faceKeys, f.kind, ops.DeleteFaces)
+	body, err := runningBody(in)
+	if err != nil {
+		return Output{}, err
+	}
+	q := ops.DefaultQuality()
+	var result *topo.Body
+	switch {
+	case ops.FacesOnVoidShell(body, f.faceKeys, q):
+		result, err = ops.RemoveVoidShellByFaces(body, f.faceKeys, q)
+	case f.heal:
+		result, err = ops.DeleteFaces(body, f.faceKeys)
+	default:
+		result, err = ops.DropFaces(body, f.faceKeys, false)
+	}
+	if err != nil {
+		return Output{}, fmt.Errorf("%s: %w", f.kind, err)
+	}
+	return Output{Bodies: replaceBody(in.Bodies, body, result)}, nil
 }
 
 // MoveFaceFeature translates the picked faces by a vector — or, in rotate mode (#331),
@@ -266,8 +293,10 @@ func (c *ModifyFeatures) AddFaceOffsetApprox(faceKeys [][]byte, distance func() 
 	})
 }
 
-func (c *ModifyFeatures) AddDeleteFace(faceKeys [][]byte) *PartFeature {
-	return c.engine.Add(&DeleteFaceFeature{faceEditFeature{kind: "delete-face", faceKeys: faceKeys}})
+// AddDeleteFace deletes the picked faces. heal=true extends the neighbouring faces to close the
+// opening; heal=false leaves the body open. Faces on an internal void shell drop that void (#1884).
+func (c *ModifyFeatures) AddDeleteFace(faceKeys [][]byte, heal bool) *PartFeature {
+	return c.engine.Add(&DeleteFaceFeature{faceEditFeature: faceEditFeature{kind: "delete-face", faceKeys: faceKeys}, heal: heal})
 }
 
 func (c *ModifyFeatures) AddReplaceFace(faceKeys [][]byte, targetKey []byte) *PartFeature {

--- a/model/feature/modify.go
+++ b/model/feature/modify.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -115,7 +116,7 @@ func (f *ThickenFeature) SetApproximation(a types.FeatureApproximationType) { f.
 
 // Direction / Operation / AsSurface / FaceKeys / Walls / ChainBlend expose the #1876 options
 // for serialization.
-func (f *ThickenFeature) Direction() ops.ThickenDirection    { return f.direction }
+func (f *ThickenFeature) Direction() ops.ThickenDirection     { return f.direction }
 func (f *ThickenFeature) Operation() ops.PartFeatureOperation { return f.operation }
 func (f *ThickenFeature) AsSurface() bool                     { return f.asSurface }
 func (f *ThickenFeature) FaceKeys() [][]byte                  { return f.faceKeys }
@@ -209,16 +210,25 @@ func lastSolidExcept(bodies []*topo.Body, skip *topo.Body) *topo.Body {
 // ReplaceFaceFeature replaces the picked faces' surface with that of a target face.
 type ReplaceFaceFeature struct {
 	faceEditFeature
-	targetKey []byte
+	targetKey    []byte       // legacy: a same-body face key, re-resolved each recompute (associative)
+	targetPlanes []geom.Plane // #1886: frozen new-face / work-plane target planes (from the router)
 }
 
-// TargetKey returns the reference key of the face whose plane replaces the picked faces.
+// TargetKey returns the reference key of the legacy single same-body target face.
 func (f *ReplaceFaceFeature) TargetKey() []byte { return f.targetKey }
 
-// Recompute replaces the picked faces with the target face's plane on the running body (see
-// kernel/ops/replace_face.go); a lost picked or target face makes the feature go Sick.
+// TargetPlanes returns the frozen new-face target planes (#1886), empty for the legacy path.
+func (f *ReplaceFaceFeature) TargetPlanes() []geom.Plane { return f.targetPlanes }
+
+// Recompute replaces the picked faces with their target plane(s) on the running body (see
+// kernel/ops/replace_face.go). The #1886 targetPlanes path assigns each picked face to its nearest
+// frozen target (work plane or new face, possibly cross-body); the legacy path re-resolves a single
+// same-body target face each recompute. A lost picked or target face makes the feature go Sick.
 func (f *ReplaceFaceFeature) Recompute(in Input) (Output, error) {
 	return retopoFacesBody(in, f.faceKeys, f.kind, func(b *topo.Body, keys [][]byte) (*topo.Body, error) {
+		if len(f.targetPlanes) > 0 {
+			return ops.ReplaceFacesMulti(b, keys, f.targetPlanes)
+		}
 		target, ok := ops.PlaneOfFace(b, f.targetKey)
 		if !ok {
 			return nil, fmt.Errorf("replace-face: target face reference lost")
@@ -392,6 +402,13 @@ func (c *ModifyFeatures) AddDeleteFace(faceKeys [][]byte, heal bool) *PartFeatur
 
 func (c *ModifyFeatures) AddReplaceFace(faceKeys [][]byte, targetKey []byte) *PartFeature {
 	return c.engine.Add(&ReplaceFaceFeature{faceEditFeature: faceEditFeature{kind: "replace-face", faceKeys: faceKeys}, targetKey: targetKey})
+}
+
+// AddReplaceFacePlanes replaces the picked faces with a set of frozen target planes (#1886) — work
+// planes and/or new faces, possibly from other bodies. Each picked face is assigned to its nearest
+// target at recompute.
+func (c *ModifyFeatures) AddReplaceFacePlanes(faceKeys [][]byte, targets []geom.Plane) *PartFeature {
+	return c.engine.Add(&ReplaceFaceFeature{faceEditFeature: faceEditFeature{kind: "replace-face", faceKeys: faceKeys}, targetPlanes: targets})
 }
 
 // AddThicken thickens the running surface body into a solid of the given wall thickness.

--- a/model/feature/modify.go
+++ b/model/feature/modify.go
@@ -82,11 +82,23 @@ func (f *faceEditFeature) FaceKeys() [][]byte { return f.faceKeys }
 // SplitFeature is the direct edit whose geometry still defers (phase C).
 type SplitFeature struct{ faceEditFeature }
 
-// ThickenFeature turns the running surface (sheet) body into a solid of a wall thickness.
-// Approximation mirrors FaceOffsetFeature's (#331): carried, exact path computed.
+// ThickenFeature turns the running surface (sheet) body into a solid of a wall thickness, or —
+// with operation surface — an offset surface (#1876). Direction picks the side(s) offset;
+// faceKeys thickens a subset (empty = whole body); walls is Inventor's CreateVerticalSurfaces.
+// operation join solidifies; cut/intersect boolean the thickened solid into the running solid.
+// Approximation mirrors FaceOffsetFeature's (#331): carried, exact path computed. autoChain /
+// autoBlend are accepted for parity but not geometrically applied (selection is explicit).
 type ThickenFeature struct {
 	thickness     func() float64
 	approximation types.FeatureApproximationType
+	featName      string
+	direction     ops.ThickenDirection
+	operation     ops.PartFeatureOperation
+	asSurface     bool
+	faceKeys      [][]byte
+	walls         bool
+	autoChain     bool
+	autoBlend     bool
 }
 
 // Kind implements [Feature].
@@ -101,18 +113,97 @@ func (f *ThickenFeature) Approximation() types.FeatureApproximationType { return
 // SetApproximation records the approximation request (the kernel still computes exact).
 func (f *ThickenFeature) SetApproximation(a types.FeatureApproximationType) { f.approximation = a }
 
-// Recompute thickens the running surface body into a solid (see kernel/ops/thicken.go); a
-// non-surface or non-thickenable body makes the feature go Sick.
+// Direction / Operation / AsSurface / FaceKeys / Walls / ChainBlend expose the #1876 options
+// for serialization.
+func (f *ThickenFeature) Direction() ops.ThickenDirection    { return f.direction }
+func (f *ThickenFeature) Operation() ops.PartFeatureOperation { return f.operation }
+func (f *ThickenFeature) AsSurface() bool                     { return f.asSurface }
+func (f *ThickenFeature) FaceKeys() [][]byte                  { return f.faceKeys }
+func (f *ThickenFeature) Walls() bool                         { return f.walls }
+func (f *ThickenFeature) ChainBlend() (chain, blend bool)     { return f.autoChain, f.autoBlend }
+
+// SetThickenOptions records the #1876 options on a thicken feature (direction, operation,
+// as-surface, face subset, vertical surfaces, and the carried chain/blend flags).
+func (f *ThickenFeature) SetThickenOptions(dir ops.ThickenDirection, op ops.PartFeatureOperation, asSurface bool, faceKeys [][]byte, walls, chain, blend bool) {
+	f.direction, f.operation, f.asSurface = dir, op, asSurface
+	f.faceKeys, f.walls, f.autoChain, f.autoBlend = faceKeys, walls, chain, blend
+}
+
+// Recompute thickens the running surface into a solid (or offsets it as a surface); operation
+// cut/intersect boolean the solid into the running solid body. See kernel/ops/thicken.go. A
+// non-surface / non-thickenable body or a missing boolean target makes the feature go Sick.
 func (f *ThickenFeature) Recompute(in Input) (Output, error) {
-	body, err := runningBody(in)
+	surface, err := runningBody(in)
 	if err != nil {
 		return Output{}, err
 	}
-	result, err := ops.Thicken(body, f.thickness())
+	if f.asSurface {
+		return f.recomputeAsSurface(in, surface)
+	}
+	solid, err := ops.ThickenSolid(surface, f.thickness(), f.direction, f.faceKeys, f.walls)
 	if err != nil {
 		return Output{}, fmt.Errorf("thicken: %w", err)
 	}
-	return Output{Bodies: replaceBody(in.Bodies, body, result)}, nil
+	if f.operation == ops.Cut || f.operation == ops.Intersect {
+		return thickenBoolean(in, surface, solid, f.operation)
+	}
+	return Output{Bodies: replaceBody(in.Bodies, surface, solid)}, nil
+}
+
+// recomputeAsSurface offsets the (optionally subset) surface into a parallel surface body; a zero
+// distance yields a copy (Inventor's Thicken surface, Distance 0).
+func (f *ThickenFeature) recomputeAsSurface(in Input, surface *topo.Body) (Output, error) {
+	src := surface
+	if len(f.faceKeys) > 0 {
+		kept, err := ops.DropFaces(surface, f.faceKeys, true)
+		if err != nil {
+			return Output{}, fmt.Errorf("thicken surface: %w", err)
+		}
+		src = kept
+	}
+	d := f.thickness()
+	if f.direction == ops.ThickenNegative {
+		d = -d
+	}
+	result, err := ops.OffsetSurface(src, d, f.featName)
+	if err != nil {
+		return Output{}, fmt.Errorf("thicken surface: %w", err)
+	}
+	return Output{Bodies: replaceBody(in.Bodies, surface, result)}, nil
+}
+
+// thickenBoolean cuts/intersects the thickened solid into the most recent running solid body
+// (the surface is consumed). A missing target solid makes the feature go Sick.
+func thickenBoolean(in Input, surface, solid *topo.Body, op ops.PartFeatureOperation) (Output, error) {
+	target := lastSolidExcept(in.Bodies, surface)
+	if target == nil {
+		return Output{}, fmt.Errorf("thicken %s: no solid body to modify", op)
+	}
+	result, err := ops.Boolean(op, target, solid)
+	if err != nil {
+		return Output{}, fmt.Errorf("thicken %s: %w", op, err)
+	}
+	bodies := make([]*topo.Body, 0, len(in.Bodies))
+	for _, b := range in.Bodies {
+		switch b {
+		case surface: // consumed by the thicken
+		case target:
+			bodies = append(bodies, result)
+		default:
+			bodies = append(bodies, b)
+		}
+	}
+	return Output{Bodies: bodies}, nil
+}
+
+// lastSolidExcept returns the most recent solid body that is not skip, or nil.
+func lastSolidExcept(bodies []*topo.Body, skip *topo.Body) *topo.Body {
+	for i := len(bodies) - 1; i >= 0; i-- {
+		if bodies[i] != skip && bodies[i].IsSolid() {
+			return bodies[i]
+		}
+	}
+	return nil
 }
 
 // ReplaceFaceFeature replaces the picked faces' surface with that of a target face.
@@ -308,7 +399,11 @@ func (c *ModifyFeatures) AddThicken(thickness float64) *PartFeature {
 	return c.AddThickenFn(constFloat(thickness))
 }
 
-// AddThickenFn is AddThicken with a live (parameter-driven) thickness.
+// AddThickenFn is AddThicken with a live (parameter-driven) thickness. Options default to the
+// whole-body, symmetric, join, walls-on thicken; the router/UI refine them via SetThickenOptions.
 func (c *ModifyFeatures) AddThickenFn(thickness func() float64) *PartFeature {
-	return c.engine.Add(&ThickenFeature{thickness: thickness})
+	tf := &ThickenFeature{thickness: thickness, walls: true, featName: "Thicken"}
+	pf := c.engine.Add(tf)
+	tf.featName = pf.name
+	return pf
 }

--- a/model/feature/modify_test.go
+++ b/model/feature/modify_test.go
@@ -213,6 +213,99 @@ func TestThickenSurfaceToSlab(t *testing.T) {
 	}
 }
 
+// TestThickenAsSurfaceOffset is the operation=surface arm (#1876): a 2×3 patch offset +1 stays an
+// open surface of the same area (6) at z=1; a zero distance is a copy (area 6 at z=0).
+func TestThickenAsSurfaceOffset(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		dist  float64
+		wantZ float64
+	}{
+		{"offset", 1, 1},
+		{"copy", 0, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := NewPartFeatures(nil)
+			NewBaseFeatures(fs).AddBase(patchSurfaceBody(2, 3))
+			th := NewModifyFeatures(fs).AddThickenFn(constFloat(tc.dist))
+			th.Definition().(*ThickenFeature).SetThickenOptions(ops.ThickenPositive, ops.Join, true, nil, true, false, false)
+			fs.Recompute()
+			if !th.Health().OK() {
+				t.Fatalf("thicken surface sick: %+v", th.Health())
+			}
+			res := fs.Result()[0]
+			if res.IsSolid() {
+				t.Error("operation surface should leave a non-solid surface body")
+			}
+			if a := ops.BodyGeometryProperties(res, ops.DefaultQuality()).Area; relErr(a, 6) > 1e-6 {
+				t.Errorf("surface area = %g, want 6", a)
+			}
+			// Centroid is ill-defined for a zero-volume sheet, so check the offset via vertex z.
+			for _, v := range res.Vertices() {
+				if stdmath.Abs(float64(v.Point().Z)-tc.wantZ) > 1e-9 {
+					t.Errorf("surface vertex z = %g, want %g", v.Point().Z, tc.wantZ)
+				}
+			}
+		})
+	}
+}
+
+// TestThickenCutIntoSolid is the operation=cut arm (#1876): thickening the box's bottom face 0.5
+// into the +z side and cutting removes that slab (2·2·0.5 = 2) from the vol-8 box, leaving 6.
+func TestThickenCutIntoSolid(t *testing.T) {
+	box := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 2, Y: 0}, {X: 2, Y: 2}, {X: 0, Y: 2}}, sketch.XYPlane(), span{near: 0, far: 2}, 0, "box")
+	fs := NewPartFeatures(nil)
+	NewBaseFeatures(fs).AddBase(box)
+	NewBaseFeatures(fs).AddBase(patchSurfaceBody(2, 2)) // coincident with the box's z=0 face
+	th := NewModifyFeatures(fs).AddThickenFn(constFloat(0.5))
+	th.Definition().(*ThickenFeature).SetThickenOptions(ops.ThickenPositive, ops.Cut, false, nil, true, false, false)
+	fs.Recompute()
+	if !th.Health().OK() {
+		t.Fatalf("thicken cut sick: %+v", th.Health())
+	}
+	res := fs.Result()
+	if len(res) != 1 {
+		t.Fatalf("after cut there are %d bodies, want 1 (surface consumed)", len(res))
+	}
+	if got := ops.BodyGeometryProperties(res[0], ops.DefaultQuality()).Volume; relErr(got, 6) > 1e-3 {
+		t.Errorf("cut volume = %g, want 6 (8 minus a 2×2×0.5 slab)", got)
+	}
+}
+
+// TestThickenOptionsRoundTrip pins #1876 serialization: direction/operation/faces/vertical-surfaces
+// and the carried chain/blend flags survive the recipe codec, and a legacy thicken restores
+// symmetric/join/walls-on.
+func TestThickenOptionsRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	pf := NewModifyFeatures(fs).AddThicken(0.2)
+	pf.Definition().(*ThickenFeature).SetThickenOptions(ops.ThickenNegative, ops.Cut, false, [][]byte{[]byte("f-a")}, false, true, true)
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	d := data[0].Thicken
+	if d.Direction != "negative" || d.Operation != "cut" || !d.NoWalls || !d.AutoChain || !d.AutoBlend || len(d.Faces) != 1 {
+		t.Fatalf("serialized thicken options = %+v", d)
+	}
+	fresh := NewPartFeatures(nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	tf := fresh.Item(0).Definition().(*ThickenFeature)
+	if tf.Direction() != ops.ThickenNegative || tf.Operation() != ops.Cut || tf.Walls() || len(tf.FaceKeys()) != 1 {
+		t.Errorf("restored options = dir %v op %v walls %v faces %d", tf.Direction(), tf.Operation(), tf.Walls(), len(tf.FaceKeys()))
+	}
+	// A legacy recipe (no #1876 fields) restores symmetric / join / walls-on.
+	legacy := NewPartFeatures(nil)
+	if err := legacy.ApplyRecipe([]FeatureData{{Kind: "thicken", Thicken: &ThickenData{Value: 0.3}}}, oneSketch{}, nil); err != nil {
+		t.Fatalf("legacy ApplyRecipe: %v", err)
+	}
+	lt := legacy.Item(0).Definition().(*ThickenFeature)
+	if lt.Direction() != ops.ThickenSymmetric || lt.Operation() != ops.Join || !lt.Walls() || lt.AsSurface() {
+		t.Errorf("legacy restore = dir %v op %v walls %v asSurface %v, want symmetric/join/walls/solid", lt.Direction(), lt.Operation(), lt.Walls(), lt.AsSurface())
+	}
+}
+
 // patchSurfaceBody builds a one-face planar surface (non-solid) body [0,w]×[0,h] at z=0.
 func patchSurfaceBody(w, h float64) *topo.Body {
 	lin := topo.NewLineage(topo.Tok("test", "patch", 0))

--- a/model/feature/modify_test.go
+++ b/model/feature/modify_test.go
@@ -306,6 +306,52 @@ func TestThickenOptionsRoundTrip(t *testing.T) {
 	}
 }
 
+// TestReplaceFacePlanesFlattens is the #1886 frozen-target arm: replacing a 2×2×2 box's top face
+// with a work-plane-style target at z=3 grows the box to vol 12, and the target planes survive the
+// recipe codec.
+func TestReplaceFacePlanesFlattens(t *testing.T) {
+	box := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 2, Y: 0}, {X: 2, Y: 2}, {X: 0, Y: 2}}, sketch.XYPlane(), span{near: 0, far: 2}, 0, "box")
+	var top []byte
+	for _, f := range box.Faces() {
+		if f.Geometry().NormalAt(0, 0).Z > 0.99 {
+			top = f.ReferenceKey()
+		}
+	}
+	target, _ := geom.NewPlane(math.P3(0, 0, 3), math.V3(0, 0, 1))
+	fs := NewPartFeatures(nil)
+	NewBaseFeatures(fs).AddBase(box)
+	rf := NewModifyFeatures(fs).AddReplaceFacePlanes([][]byte{top}, []geom.Plane{target})
+	fs.Recompute()
+	if !rf.Health().OK() {
+		t.Fatalf("replace-face (planes) sick: %+v", rf.Health())
+	}
+	if got := ops.BodyGeometryProperties(fs.Result()[0], ops.DefaultQuality()).Volume; relErr(got, 12) > 1e-6 {
+		t.Errorf("replaced volume = %g, want 12 (top raised to z=3)", got)
+	}
+}
+
+// TestReplaceFacePlanesRoundTrip pins #1886's frozen-plane serialization: a replace-face carrying
+// target planes survives the recipe codec.
+func TestReplaceFacePlanesRoundTrip(t *testing.T) {
+	target, _ := geom.NewPlane(math.P3(0, 0, 3), math.V3(0, 0, 1))
+	fs := NewPartFeatures(nil)
+	NewModifyFeatures(fs).AddReplaceFacePlanes([][]byte{[]byte("f-top")}, []geom.Plane{target})
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	if n := len(data[0].FaceEdit.NewFaces); n != 1 {
+		t.Fatalf("serialized newFaces = %d, want 1", n)
+	}
+	fresh := NewPartFeatures(nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	if got := fresh.Item(0).Definition().(*ReplaceFaceFeature).TargetPlanes(); len(got) != 1 || stdmath.Abs(float64(got[0].Origin.Z)-3) > 1e-9 {
+		t.Errorf("restored target planes = %+v, want one plane at z=3", got)
+	}
+}
+
 // patchSurfaceBody builds a one-face planar surface (non-solid) body [0,w]×[0,h] at z=0.
 func patchSurfaceBody(w, h float64) *topo.Body {
 	lin := topo.NewLineage(topo.Tok("test", "patch", 0))

--- a/model/feature/modify_test.go
+++ b/model/feature/modify_test.go
@@ -133,13 +133,39 @@ func TestDeleteFaceHealsInModel(t *testing.T) {
 			chamfer = f.ReferenceKey()
 		}
 	}
-	del := NewModifyFeatures(fs).AddDeleteFace([][]byte{chamfer})
+	del := NewModifyFeatures(fs).AddDeleteFace([][]byte{chamfer}, true)
 	fs.Recompute()
 	if !del.Health().OK() {
 		t.Fatalf("delete-face sick: %+v", del.Health())
 	}
 	if got := ops.BodyGeometryProperties(fs.Result()[0], ops.DefaultQuality()).Volume; relErr(got, 8) > 1e-6 {
 		t.Errorf("healed volume = %g, want 8", got)
+	}
+}
+
+// TestDeleteFaceOpenLeavesSurface is the heal=false arm (#1884): deleting the top face without
+// healing leaves an open, non-solid surface body of five faces.
+func TestDeleteFaceOpenLeavesSurface(t *testing.T) {
+	box := buildPrism([]math.Point2{{X: 0, Y: 0}, {X: 2, Y: 0}, {X: 2, Y: 2}, {X: 0, Y: 2}}, sketch.XYPlane(), span{near: 0, far: 2}, 0, "box")
+	var top []byte
+	for _, f := range box.Faces() {
+		if f.Geometry().NormalAt(0, 0).Z > 0.99 {
+			top = f.ReferenceKey()
+		}
+	}
+	fs := NewPartFeatures(nil)
+	NewBaseFeatures(fs).AddBase(box)
+	del := NewModifyFeatures(fs).AddDeleteFace([][]byte{top}, false)
+	fs.Recompute()
+	if !del.Health().OK() {
+		t.Fatalf("delete-face (open) sick: %+v", del.Health())
+	}
+	body := fs.Result()[0]
+	if body.IsSolid() {
+		t.Error("heal=false should leave an open (non-solid) surface body")
+	}
+	if got := len(body.Faces()); got != 5 {
+		t.Errorf("open body has %d faces, want 5 (6 minus the deleted top)", got)
 	}
 }
 

--- a/model/feature/serialize_codecs_faceedit.go
+++ b/model/feature/serialize_codecs_faceedit.go
@@ -39,15 +39,22 @@ func (r featureCodecSet) registerFaceEditCodecs() {
 		},
 		decode: decodeFaceEdit,
 	})
-	// split and delete-face carry only their face keys, via the generic faceEditor interface (any
-	// feature exposing FaceKeys() that is not one of the explicit kinds above).
-	for _, kind := range []string{"split", "delete-face"} {
-		r.register(kind, featureCodec{
-			encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
-				fd.FaceEdit = &FaceEditData{Faces: encodeKeys(f.(faceEditor).FaceKeys())}
-				return nil
-			},
-			decode: decodeFaceEdit,
-		})
-	}
+	// delete-face carries its face keys plus the inverse-heal flag (#1884); Open is negated so a
+	// pre-#1884 recipe (no field) restores as healed.
+	r.register("delete-face", featureCodec{
+		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
+			df := f.(*DeleteFaceFeature)
+			fd.FaceEdit = &FaceEditData{Faces: encodeKeys(df.FaceKeys()), Open: !df.Heal()}
+			return nil
+		},
+		decode: decodeFaceEdit,
+	})
+	// split carries only its face keys, via the generic faceEditor interface.
+	r.register("split", featureCodec{
+		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
+			fd.FaceEdit = &FaceEditData{Faces: encodeKeys(f.(faceEditor).FaceKeys())}
+			return nil
+		},
+		decode: decodeFaceEdit,
+	})
 }

--- a/model/feature/serialize_codecs_faceedit.go
+++ b/model/feature/serialize_codecs_faceedit.go
@@ -34,7 +34,7 @@ func (r featureCodecSet) registerFaceEditCodecs() {
 	r.register("replace-face", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			rf := f.(*ReplaceFaceFeature)
-			fd.FaceEdit = &FaceEditData{Faces: encodeKeys(rf.FaceKeys()), Target: encodeKey(rf.TargetKey())}
+			fd.FaceEdit = &FaceEditData{Faces: encodeKeys(rf.FaceKeys()), Target: encodeKey(rf.TargetKey()), NewFaces: encodePlanes(rf.TargetPlanes())}
 			return nil
 		},
 		decode: decodeFaceEdit,

--- a/model/feature/serialize_codecs_solid.go
+++ b/model/feature/serialize_codecs_solid.go
@@ -179,7 +179,14 @@ func (r featureCodecSet) registerSolidCodecs() {
 	r.register("thicken", featureCodec{
 		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
 			t := f.(*ThickenFeature)
-			fd.Thicken = &ThickenData{Value: t.Thickness(), Approximation: approximationName(t.Approximation())}
+			chain, blend := t.ChainBlend()
+			fd.Thicken = &ThickenData{
+				Value: t.Thickness(), Approximation: approximationName(t.Approximation()),
+				Direction: thickenDirectionName(t.Direction()),
+				Operation: thickenOperationName(t.Operation(), t.AsSurface()),
+				Faces:     encodeKeys(t.FaceKeys()), NoWalls: !t.Walls(),
+				AutoChain: chain, AutoBlend: blend,
+			}
 			return nil
 		},
 		decode: decodeThicken,
@@ -264,16 +271,24 @@ func decodeSnapFit(rc *restoreContext, fd FeatureData) (*PartFeature, error) {
 		constFloat(d.CatchLength), constFloat(d.CatchHeight)), nil
 }
 
-// decodeThicken rebuilds a thicken, restoring the surface-offset approximation mode.
+// decodeThicken rebuilds a thicken, restoring the #331 approximation mode and #1876 options.
 func decodeThicken(rc *restoreContext, fd FeatureData) (*PartFeature, error) {
 	if fd.Thicken == nil {
 		return nil, fmt.Errorf("thicken feature is missing its payload")
 	}
-	approx, err := approximationOf(fd.Thicken.Approximation)
+	d := fd.Thicken
+	approx, err := approximationOf(d.Approximation)
 	if err != nil {
 		return nil, err
 	}
-	pf := NewModifyFeatures(rc.fs).AddThicken(fd.Thicken.Value)
-	pf.Definition().(*ThickenFeature).SetApproximation(approx)
+	keys, err := decodeKeys(d.Faces)
+	if err != nil {
+		return nil, err
+	}
+	pf := NewModifyFeatures(rc.fs).AddThicken(d.Value)
+	tf := pf.Definition().(*ThickenFeature)
+	tf.SetApproximation(approx)
+	op, asSurface := thickenOperationOf(d.Operation)
+	tf.SetThickenOptions(thickenDirectionOf(d.Direction), op, asSurface, keys, !d.NoWalls, d.AutoChain, d.AutoBlend)
 	return pf, nil
 }

--- a/model/feature/serialize_modify.go
+++ b/model/feature/serialize_modify.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/ops"
 )
 
 // This file holds the YAML codec for the direct face-edit features — split, move-face,
@@ -33,10 +34,66 @@ type FaceEditData struct {
 }
 
 // ThickenData is a thicken feature: the wall thickness applied to the running surface body,
-// plus the #331 approximation request (wire spelling; absent = none/exact).
+// plus the #331 approximation request (wire spelling; absent = none/exact) and the #1876 options.
+// The zero value of each new field restores the pre-#1876 behaviour: Direction "" = symmetric,
+// Operation "" = join, and NoWalls false = vertical surfaces on (stored negated so a legacy recipe,
+// which always built walls, restores unchanged).
 type ThickenData struct {
-	Value         float64 `yaml:"value"`
-	Approximation string  `yaml:"approximation,omitempty"`
+	Value         float64  `yaml:"value"`
+	Approximation string   `yaml:"approximation,omitempty"`
+	Direction     string   `yaml:"direction,omitempty"` // "" = symmetric (legacy)
+	Operation     string   `yaml:"operation,omitempty"` // "" = join; "surface" = offset surface
+	Faces         []string `yaml:"faces,omitempty"`     // face subset (empty = whole body)
+	NoWalls       bool     `yaml:"noWalls,omitempty"`   // inverse of createVerticalSurfaces
+	AutoChain     bool     `yaml:"autoChain,omitempty"`
+	AutoBlend     bool     `yaml:"autoBlend,omitempty"`
+}
+
+// thickenDirectionName / thickenDirectionOf map the direction enum to its serialized spelling;
+// symmetric encodes as "" so a legacy recipe (no field) and a new symmetric thicken both restore
+// symmetric.
+func thickenDirectionName(d ops.ThickenDirection) string {
+	if d == ops.ThickenSymmetric {
+		return ""
+	}
+	return d.String()
+}
+
+func thickenDirectionOf(s string) ops.ThickenDirection {
+	switch s {
+	case "positive":
+		return ops.ThickenPositive
+	case "negative":
+		return ops.ThickenNegative
+	default:
+		return ops.ThickenSymmetric // "" legacy / symmetric
+	}
+}
+
+// thickenOperationName encodes the thicken output mode: "surface" for the offset-surface path,
+// "cut"/"intersect" for the booleans, and "" for join (the legacy default, so it stays omitted).
+func thickenOperationName(op ops.PartFeatureOperation, asSurface bool) string {
+	if asSurface {
+		return "surface"
+	}
+	if op == ops.Join {
+		return ""
+	}
+	return op.String()
+}
+
+// thickenOperationOf decodes the mode back to (operation, asSurface). "" = join.
+func thickenOperationOf(s string) (ops.PartFeatureOperation, bool) {
+	switch s {
+	case "surface":
+		return ops.Join, true
+	case "cut":
+		return ops.Cut, false
+	case "intersect":
+		return ops.Intersect, false
+	default:
+		return ops.Join, false
+	}
 }
 
 // approximationName / approximationOf map the enum to its wire spelling (empty for the zero

--- a/model/feature/serialize_modify.go
+++ b/model/feature/serialize_modify.go
@@ -26,6 +26,10 @@ type FaceEditData struct {
 	Distance      float64   `yaml:"distance,omitempty"`      // face-offset
 	Approximation string    `yaml:"approximation,omitempty"` // face-offset (#331), wire spelling
 	Target        string    `yaml:"target,omitempty"`        // replace-face: source face key
+	// Open is delete-face's inverse-heal flag (#1884): stored as the negation so the zero value
+	// (absent field) restores the legacy healed behaviour — pre-#1884 recipes had no field and
+	// were always healed. Open=true means the delete left the body open (heal=false).
+	Open bool `yaml:"open,omitempty"`
 }
 
 // ThickenData is a thicken feature: the wall thickness applied to the running surface body,
@@ -97,7 +101,7 @@ func restoreFaceEdit(fs *PartFeatures, kind string, d *FaceEditData) (*PartFeatu
 		}
 		return m.AddFaceOffsetApprox(keys, constFloat(d.Distance), approx), nil
 	case "delete-face":
-		return m.AddDeleteFace(keys), nil
+		return m.AddDeleteFace(keys, !d.Open), nil // Open is stored negated (see FaceEditData.Open)
 	case "replace-face":
 		target, err := decodeKey(d.Target)
 		if err != nil {

--- a/model/feature/serialize_modify.go
+++ b/model/feature/serialize_modify.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 
 	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
 )
 
 // This file holds the YAML codec for the direct face-edit features — split, move-face,
@@ -26,11 +28,52 @@ type FaceEditData struct {
 	Angle         float64   `yaml:"angle,omitempty"`         // move-face rotate, radians
 	Distance      float64   `yaml:"distance,omitempty"`      // face-offset
 	Approximation string    `yaml:"approximation,omitempty"` // face-offset (#331), wire spelling
-	Target        string    `yaml:"target,omitempty"`        // replace-face: source face key
+	Target        string    `yaml:"target,omitempty"`        // replace-face: legacy same-body source face key
+	// NewFaces are replace-face's frozen target planes (#1886): work planes and/or new faces resolved
+	// to origin+normal by the router. Present only for the multi/work-plane path; the legacy Target
+	// (same-body face key) stays associative and is used when NewFaces is empty.
+	NewFaces []PlaneData `yaml:"newFaces,omitempty"`
 	// Open is delete-face's inverse-heal flag (#1884): stored as the negation so the zero value
 	// (absent field) restores the legacy healed behaviour — pre-#1884 recipes had no field and
 	// were always healed. Open=true means the delete left the body open (heal=false).
 	Open bool `yaml:"open,omitempty"`
+}
+
+// PlaneData is a frozen plane (origin + unit normal) — replace-face's #1886 target planes.
+type PlaneData struct {
+	Origin []float64 `yaml:"origin"`
+	Normal []float64 `yaml:"normal"`
+}
+
+// encodePlanes / decodePlanes convert between the frozen geom.Plane list and its serialized form.
+func encodePlanes(planes []geom.Plane) []PlaneData {
+	if len(planes) == 0 {
+		return nil
+	}
+	out := make([]PlaneData, len(planes))
+	for i, p := range planes {
+		o, n := p.Origin, p.Normal()
+		out[i] = PlaneData{Origin: []float64{float64(o.X), float64(o.Y), float64(o.Z)}, Normal: []float64{float64(n.X), float64(n.Y), float64(n.Z)}}
+	}
+	return out
+}
+
+func decodePlanes(data []PlaneData) ([]geom.Plane, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	out := make([]geom.Plane, len(data))
+	for i, d := range data {
+		if len(d.Origin) != 3 || len(d.Normal) != 3 {
+			return nil, fmt.Errorf("replace-face: target plane %d needs origin[3]+normal[3], got %v/%v", i, d.Origin, d.Normal)
+		}
+		pl, err := geom.NewPlane(math.P3(d.Origin[0], d.Origin[1], d.Origin[2]), math.V3(d.Normal[0], d.Normal[1], d.Normal[2]))
+		if err != nil {
+			return nil, fmt.Errorf("replace-face: target plane %d: %w", i, err)
+		}
+		out[i] = pl
+	}
+	return out, nil
 }
 
 // ThickenData is a thicken feature: the wall thickness applied to the running surface body,
@@ -160,6 +203,13 @@ func restoreFaceEdit(fs *PartFeatures, kind string, d *FaceEditData) (*PartFeatu
 	case "delete-face":
 		return m.AddDeleteFace(keys, !d.Open), nil // Open is stored negated (see FaceEditData.Open)
 	case "replace-face":
+		if len(d.NewFaces) > 0 {
+			planes, err := decodePlanes(d.NewFaces)
+			if err != nil {
+				return nil, err
+			}
+			return m.AddReplaceFacePlanes(keys, planes), nil
+		}
 		target, err := decodeKey(d.Target)
 		if err != nil {
 			return nil, err

--- a/model/feature/serialize_test.go
+++ b/model/feature/serialize_test.go
@@ -597,7 +597,7 @@ func TestFaceEditFeaturesRoundTrip(t *testing.T) {
 	m.AddSplit([][]byte{[]byte("f-split")})
 	m.AddMoveFace([][]byte{[]byte("f-move")}, math.V3(1, 2, 3))
 	m.AddFaceOffset([][]byte{[]byte("f-off")}, 0.5)
-	m.AddDeleteFace([][]byte{[]byte("f-del")})
+	m.AddDeleteFace([][]byte{[]byte("f-del")}, true)
 	m.AddReplaceFace([][]byte{[]byte("f-rep")}, []byte("f-target"))
 	m.AddThicken(0.5)
 
@@ -623,6 +623,31 @@ func TestFaceEditFeaturesRoundTrip(t *testing.T) {
 	split := fresh.Item(0).Definition().(faceEditor)
 	if len(split.FaceKeys()) != 1 || string(split.FaceKeys()[0]) != "f-split" {
 		t.Errorf("split face keys = %v, want [f-split]", split.FaceKeys())
+	}
+	// The delete-face heal flag survives (this recipe used heal=true).
+	if df := fresh.Item(3).Definition().(*DeleteFaceFeature); !df.Heal() {
+		t.Error("restored delete-face heal = false, want true")
+	}
+}
+
+// TestDeleteFaceHealFlagRoundTrip pins #1884's inverse-heal serialization: a heal=false delete
+// restores as heal=false (the `open` flag), while a recipe with no flag restores healed (legacy).
+func TestDeleteFaceHealFlagRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	NewModifyFeatures(fs).AddDeleteFace([][]byte{[]byte("f-open")}, false)
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	if !data[0].FaceEdit.Open {
+		t.Error("heal=false delete-face should serialize open=true")
+	}
+	fresh := NewPartFeatures(nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	if df := fresh.Item(0).Definition().(*DeleteFaceFeature); df.Heal() {
+		t.Error("restored heal = true, want false (open)")
 	}
 }
 


### PR DESCRIPTION
First Surfaces-parity batch (milestone #44). Pins oblikovati.org/api v0.142.1 (Oblikovati.API#268).

### #1884 — Delete Face heal toggle + void removal
- `heal` (default false, Inventor parity): false drops the picked faces leaving an open surface (`ops.DropFaces`); true extends neighbours to close the gap (`ops.DeleteFaces`, the prior always-on behaviour).
- Selecting a face on an **internal void shell** removes that void and restores mass (new `ops.RemoveVoidShellByFaces` / `FacesOnVoidShell`).
- Serialized as the inverse (`open`) so pre-#1884 recipes (always healed) restore unchanged.

### #1876 — Thicken direction / operation / face-subset
- `direction` positive|negative|symmetric (default positive; was symmetric-only).
- `operation` join|cut|intersect|surface — join solidifies; cut/intersect boolean the thickened solid into the running solid; surface offsets a sheet (distance 0 = copy).
- `faceRefs` subset with `createVerticalSurfaces` side walls at subset boundaries.
- `automaticFaceChain` / `automaticBlending` accepted for parity (not geometrically applied — selection is explicit).
- Kernel `Thicken` generalized to `ThickenSolid(dir, faceKeys, walls)`; legacy defaults (symmetric/join/walls) preserved on restore.

### #1886 — Replace Face onto work planes / multi-face sets
- `newFaceRefs`: replacement geometry may be a work plane and/or several faces (cross-body); each picked face retrims onto its nearest target (new `ops.ReplaceFacesMulti`). Legacy `targetRef` (associative same-body) retained.

All three have kernel + model + serialize + router tests (analytic volumes/areas; legacy-recipe restore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)