### PR TITLE
surface: multi-edge / to-plane / natural surface extend (#1878)

### DIFF
--- a/addin/opregistry/apply_success_test.go
+++ b/addin/opregistry/apply_success_test.go
@@ -139,6 +139,18 @@ func TestModifyAndPatternOperations(t *testing.T) {
 	}
 }
 
+// TestExtendRouterOptions covers the #1878 extend parse/resolve branches: no edges errors, and
+// extentType toPlane without a targetRef errors (the plane target cannot resolve).
+func TestExtendRouterOptions(t *testing.T) {
+	s, _, _ := extrudedSolid(t)
+	if _, err := apply(t, s, "extend", `{"distance":"1 mm"}`); err == nil {
+		t.Error("extend with no edges should error")
+	}
+	if _, err := apply(t, s, "extend", `{"edgeRefs":["e1"],"extentType":"toPlane"}`); err == nil {
+		t.Error("extend toPlane with no targetRef should error")
+	}
+}
+
 // TestCombineTwoBodies covers the boolean-combine path that needs a tool body.
 func TestCombineTwoBodies(t *testing.T) {
 	for _, op := range []string{"join", "cut", "intersect"} {

--- a/addin/opregistry/feature_surface.go
+++ b/addin/opregistry/feature_surface.go
@@ -11,6 +11,7 @@ import (
 	"oblikovati.org/api/types"
 	"oblikovati.org/api/wire/featureargs"
 	"oblikovati.org/app"
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
@@ -110,10 +111,13 @@ const surfaceOffsetSchema = `{
 const extendSchema = `{
   "type": "object",
   "properties": {
-    "edgeRef": {"type": "string", "description": "Reference key of the surface edge to extend (get_reference_keys)."},
-    "distance": {"type": "string", "description": "Extend distance, e.g. \"5 mm\"."}
-  },
-  "required": ["edgeRef", "distance"]
+    "edgeRefs": {"type": "array", "items": {"type": "string"}, "description": "Reference keys of the surface boundary edges to extend (get_reference_keys)."},
+    "edgeRef": {"type": "string", "description": "Legacy single edge (use edgeRefs)."},
+    "extentType": {"type": "string", "enum": ["distance", "toPlane", "toObject"], "default": "distance", "description": "distance grows by distance; toPlane/toObject grows each edge until it reaches targetRef."},
+    "distance": {"type": "string", "description": "Extend distance for extentType distance, e.g. \"5 mm\"."},
+    "targetRef": {"type": "string", "description": "Target plane/face for extentType toPlane (a planar face key, \"plane/N\", or \"origin/plane/xy\")."},
+    "extensionType": {"type": "string", "enum": ["stretched", "natural"], "default": "stretched", "description": "Continuity mode; coincides with stretched for planar faces."}
+  }
 }`
 
 const midSurfaceSchema = `{
@@ -347,15 +351,52 @@ func applyExtend(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	if in.EdgeRef == "" {
-		return nil, errors.New("extend: edgeRef is empty")
+	edges := extendEdgeKeys(in)
+	if len(edges) == 0 {
+		return nil, errors.New("extend: edgeRefs is empty")
 	}
-	d, err := lengthClosure(part, in.Distance, "extend: distance")
-	if err != nil {
+	def := &feature.ExtendDefinition{EdgeKeys: edges, Natural: in.ExtensionType == "natural"}
+	if err := resolveExtendExtent(part, in, def); err != nil {
 		return nil, err
 	}
-	pf := feature.NewExtendFeatures(part.Features()).Add([]byte(in.EdgeRef), d)
+	pf := feature.NewExtendFeatures(part.Features()).AddExtend(def)
 	return recomputeResult(part, pf)
+}
+
+// resolveExtendExtent fills the extend definition's extent: a target plane for extentType
+// toPlane/toObject (resolved from a work plane / planar face), else the distance closure (#1878).
+func resolveExtendExtent(part *compdef.PartComponentDefinition, in featureargs.Extend, def *feature.ExtendDefinition) error {
+	switch in.ExtentType {
+	case "toPlane", "toObject":
+		wp, err := part.WorkGeometry().PlaneTargetFromRef(in.TargetRef)
+		if err != nil {
+			return fmt.Errorf("extend: target %q: %w", in.TargetRef, err)
+		}
+		pl, err := geom.NewPlane(wp.Plane().Origin(), wp.Plane().Normal().AsVector())
+		if err != nil {
+			return fmt.Errorf("extend: target %q: %w", in.TargetRef, err)
+		}
+		def.TargetPlane = &pl
+		return nil
+	default:
+		d, err := lengthClosure(part, in.Distance, "extend: distance")
+		if err != nil {
+			return err
+		}
+		def.Distance = d
+		return nil
+	}
+}
+
+// extendEdgeKeys returns the extend edges: the multi-edge EdgeRefs, else the legacy single EdgeRef.
+func extendEdgeKeys(in featureargs.Extend) [][]byte {
+	if len(in.EdgeRefs) > 0 {
+		return refKeys(in.EdgeRefs)
+	}
+	if in.EdgeRef != "" {
+		return [][]byte{[]byte(in.EdgeRef)}
+	}
+	return nil
 }
 
 func applyMidSurface(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.142.1
+	oblikovati.org/api v0.142.2
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.142.1
+	oblikovati.org/api v0.142.2
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/kernel/ops/extend_edges.go
+++ b/kernel/ops/extend_edges.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"errors"
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Multi-edge and extend-to-plane surface extend (#1878). ExtendByEdge grows one boundary edge of a
+// planar face by a distance; these grow SEVERAL boundary edges of the same planar face in one
+// feature, and can grow each edge until it reaches a target plane (Inventor's extend-to-object).
+// A vertex shared by two extended edges takes both displacements. Multi-face / curved (NURBS)
+// surfaces remain phase C, exactly as ExtendByEdge.
+
+// ExtendEdgesByDistance extends each selected boundary edge of a single planar surface face
+// outward by distance, growing the face.
+func ExtendEdgesByDistance(body *topo.Body, edgeKeys [][]byte, distance float64, feat string) (*topo.Body, error) {
+	return extendEdges(body, edgeKeys, feat, func(pl geom.Plane, a, b, c math.Point3) (math.Vector3, math.Vector3) {
+		s := extendDir(pl.Normal(), a, b, c).Scale(distance)
+		return s, s
+	})
+}
+
+// ExtendEdgesToPlane extends each selected boundary edge until its endpoints reach target: each
+// endpoint slides along the in-plane extend direction to the plane. An endpoint whose extend
+// direction is parallel to the plane, or that would move backward to reach it, stays put.
+func ExtendEdgesToPlane(body *topo.Body, edgeKeys [][]byte, target geom.Plane, feat string) (*topo.Body, error) {
+	return extendEdges(body, edgeKeys, feat, func(pl geom.Plane, a, b, c math.Point3) (math.Vector3, math.Vector3) {
+		dir := extendDir(pl.Normal(), a, b, c)
+		return reachPlane(a, dir, target), reachPlane(b, dir, target)
+	})
+}
+
+// extendEdges resolves the selected boundary edges of one planar face, accumulates each edge's
+// endpoint displacement (from shift) at the face's polygon vertices, and rebuilds the grown sheet.
+func extendEdges(body *topo.Body, edgeKeys [][]byte, feat string, shift func(pl geom.Plane, a, b, c math.Point3) (math.Vector3, math.Vector3)) (*topo.Body, error) {
+	face, err := singleExtendFace(body, edgeKeys)
+	if err != nil {
+		return nil, err
+	}
+	pl := face.Geometry().(geom.Plane)
+	poly := facePolygon(face)
+	c := centroid(poly)
+	disp := make([]math.Vector3, len(poly))
+	for _, key := range edgeKeys {
+		edge, _ := body.FindEdgeByKey(key) // resolved in singleExtendFace
+		a, b := edge.StartVertex().Point(), edge.EndVertex().Point()
+		da, db := shift(pl, a, b, c)
+		addDispAt(poly, disp, a, da)
+		addDispAt(poly, disp, b, db)
+	}
+	moved := make([]math.Point3, len(poly))
+	for i, p := range poly {
+		moved[i] = p.TranslateBy(disp[i])
+	}
+	return buildSheet([]sheetPatch{{poly: moved, normal: pl.Normal()}}, feat), nil
+}
+
+// singleExtendFace resolves every edge key and returns the single planar face they all bound, or an
+// error (a lost key, a non-boundary/shared edge, edges on different faces, or a curved face — the
+// phase-C cases, matching ExtendByEdge).
+func singleExtendFace(body *topo.Body, edgeKeys [][]byte) (*topo.Face, error) {
+	if len(edgeKeys) == 0 {
+		return nil, errors.New("extend: no edges")
+	}
+	var face *topo.Face
+	for _, key := range edgeKeys {
+		edge, ok := body.FindEdgeByKey(key)
+		if !ok {
+			return nil, errors.New("extend: edge reference lost")
+		}
+		faces := edge.Faces()
+		if len(faces) != 1 {
+			return nil, errors.New("extend: edge is not a single-face boundary edge")
+		}
+		if face == nil {
+			face = faces[0]
+		} else if faces[0] != face {
+			return nil, errors.New("extend: edges lie on different faces")
+		}
+	}
+	if _, planar := face.Geometry().(geom.Plane); !planar {
+		return nil, errors.New("extend: curved surface not supported")
+	}
+	return face, nil
+}
+
+// addDispAt adds shift to the displacement of the polygon vertex coincident with p.
+func addDispAt(poly []math.Point3, disp []math.Vector3, p math.Point3, shift math.Vector3) {
+	for i, q := range poly {
+		if coincidentPt(q, p) {
+			disp[i] = disp[i].Add(shift)
+		}
+	}
+}
+
+// reachPlane returns the displacement that slides p along dir until it lies on target, or the zero
+// vector when dir is parallel to the plane or the plane is behind p (no forward reach).
+func reachPlane(p math.Point3, dir math.Vector3, target geom.Plane) math.Vector3 {
+	den := float64(dir.Dot(target.Normal()))
+	if stdmath.Abs(den) < 1e-12 {
+		return math.Vector3{}
+	}
+	t := float64(target.Normal().Dot(p.VectorTo(target.Origin))) / den
+	if t <= 0 {
+		return math.Vector3{}
+	}
+	return dir.Scale(t)
+}

--- a/kernel/ops/extend_edges_test.go
+++ b/kernel/ops/extend_edges_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// keyedPatch builds the [0,w]×[0,h] z=0 patch with each of its four boundary edges carrying its own
+// lineage (so FindEdgeByKey is unambiguous). Returns the body and the edge keys in order
+// bottom, right, top, left.
+func keyedPatch(t *testing.T, w, h float64) (*topo.Body, [][]byte) {
+	t.Helper()
+	lin := topo.NewLineage(topo.Tok("test", "patch", 0))
+	bld := topo.NewBuilder(false, lin)
+	p := []math.Point3{{X: 0, Y: 0}, {X: w, Y: 0}, {X: w, Y: h}, {X: 0, Y: h}}
+	v := make([]*topo.Vertex, 4)
+	for i, q := range p {
+		v[i] = bld.AddVertex(q, lin)
+	}
+	uses := make([]topo.Use, 4)
+	keys := make([][]byte, 4)
+	for i := range p {
+		e := bld.AddEdge(geom.NewLineSegment(p[i], p[(i+1)%4]), v[i], v[(i+1)%4], topo.NewLineage(topo.Tok("test", "edge", i)))
+		uses[i] = topo.Use{Edge: e}
+		keys[i] = e.ReferenceKey()
+	}
+	plane, _ := geom.NewPlane(math.P3(0, 0, 0), math.V3(0, 0, 1))
+	bld.AddFace(plane, lin, topo.OuterLoop(uses...))
+	return bld.Build(), keys
+}
+
+// TestExtendEdgesByDistanceGrows extends the right edge of a 2×3 patch (area 6) outward by 1: the
+// patch grows to 3×3 (area 9) (#1878).
+func TestExtendEdgesByDistanceGrows(t *testing.T) {
+	patch, keys := keyedPatch(t, 2, 3)
+	out, err := ops.ExtendEdgesByDistance(patch, [][]byte{keys[1]}, 1, "ext")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := ops.BodyGeometryProperties(out, ops.DefaultQuality()).Area; stdmath.Abs(got-9) > 1e-6 {
+		t.Errorf("area = %g, want 9 (2×3 grown to 3×3)", got)
+	}
+}
+
+// TestExtendEdgesMultiGrows extends both the left and right edges of a 2×3 patch by 1 each: width
+// grows to 4, area to 12 (#1878).
+func TestExtendEdgesMultiGrows(t *testing.T) {
+	patch, keys := keyedPatch(t, 2, 3)
+	out, err := ops.ExtendEdgesByDistance(patch, [][]byte{keys[1], keys[3]}, 1, "ext")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := ops.BodyGeometryProperties(out, ops.DefaultQuality()).Area; stdmath.Abs(got-12) > 1e-6 {
+		t.Errorf("area = %g, want 12 (both sides +1 ⇒ 4×3)", got)
+	}
+}
+
+// TestExtendEdgesToPlane extends the right edge of a 2×3 patch until it reaches the plane x=5: the
+// patch grows to 5×3 (area 15) (#1878).
+func TestExtendEdgesToPlane(t *testing.T) {
+	patch, keys := keyedPatch(t, 2, 3)
+	target, _ := geom.NewPlane(math.P3(5, 0, 0), math.V3(1, 0, 0))
+	out, err := ops.ExtendEdgesToPlane(patch, [][]byte{keys[1]}, target, "ext")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := ops.BodyGeometryProperties(out, ops.DefaultQuality()).Area; stdmath.Abs(got-15) > 1e-6 {
+		t.Errorf("area = %g, want 15 (right edge reached x=5 ⇒ 5×3)", got)
+	}
+}
+
+// TestExtendEdgesLostKeyErrors reports a vanished edge so the feature can go Sick.
+func TestExtendEdgesLostKeyErrors(t *testing.T) {
+	patch, _ := keyedPatch(t, 2, 3)
+	if _, err := ops.ExtendEdgesByDistance(patch, [][]byte{[]byte("ghost")}, 1, "ext"); err == nil {
+		t.Error("extend with a lost edge key should error")
+	}
+	if _, err := ops.ExtendEdgesByDistance(patch, nil, 1, "ext"); err == nil {
+		t.Error("extend with no edges should error")
+	}
+}

--- a/model/feature/serialize_missing_codecs_test.go
+++ b/model/feature/serialize_missing_codecs_test.go
@@ -31,8 +31,8 @@ func TestSurfaceEditCodecsRoundTrip(t *testing.T) {
 		t.Errorf("restored trim = %+v, want origin (1,2,3) normal (0,0,1) keepPositive", trim)
 	}
 	ext := featAt[*ExtendFeature](t, fresh, 1).Definition()
-	if string(ext.EdgeKey) != "edge-key-\x00\xff" || ext.Distance() != 2.5 {
-		t.Errorf("restored extend key=%q dist=%g, want the original key and 2.5", ext.EdgeKey, ext.Distance())
+	if len(ext.EdgeKeys) != 1 || string(ext.EdgeKeys[0]) != "edge-key-\x00\xff" || ext.Distance() != 2.5 {
+		t.Errorf("restored extend keys=%q dist=%g, want the original key and 2.5", ext.EdgeKeys, ext.Distance())
 	}
 	if off := featAt[*SurfaceOffsetFeature](t, fresh, 2).Definition(); off.Distance() != -1.25 {
 		t.Errorf("restored surface-offset distance = %g, want -1.25", off.Distance())

--- a/model/feature/serialize_surface_edits.go
+++ b/model/feature/serialize_surface_edits.go
@@ -2,7 +2,12 @@
 
 package feature
 
-import "fmt"
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
 
 // Serialized forms of the surface-editing features (M10-F01/F02): trim, extend, surface offset,
 // mid-surface, stitch, and sculpt. These kinds were creatable but carried no serialization codec,
@@ -29,26 +34,57 @@ func restoreTrim(fs *PartFeatures, d *TrimData) (*PartFeature, error) {
 	return NewTrimFeatures(fs).AddByPlane(decodePoint3(d.Origin), decodeVec3(d.Normal), d.KeepPositive), nil
 }
 
-// ExtendData is a surface extend's recipe: the boundary edge (base64 reference key) and the
-// outward distance.
+// ExtendData is a surface extend's recipe (#1878): the boundary edges (base64 reference keys), the
+// outward distance or a target plane (extend-to-plane), and the continuity mode. EdgeKey is the
+// legacy single-edge field, read when Edges is empty so pre-#1878 recipes restore unchanged.
 type ExtendData struct {
-	EdgeKey  string  `yaml:"edgeKey"`
-	Distance float64 `yaml:"distance"`
+	EdgeKey      string    `yaml:"edgeKey,omitempty"`
+	Edges        []string  `yaml:"edges,omitempty"`
+	Distance     float64   `yaml:"distance,omitempty"`
+	TargetOrigin []float64 `yaml:"targetOrigin,omitempty"` // extend-to-plane target (origin + normal)
+	TargetNormal []float64 `yaml:"targetNormal,omitempty"`
+	Natural      bool      `yaml:"natural,omitempty"`
 }
 
 func serializeExtend(def *ExtendDefinition) *ExtendData {
-	return &ExtendData{EdgeKey: encodeKey(def.EdgeKey), Distance: evalFloat(def.Distance)}
+	d := &ExtendData{Edges: encodeKeys(def.EdgeKeys), Distance: evalFloat(def.Distance), Natural: def.Natural}
+	if p := def.TargetPlane; p != nil {
+		o, n := p.Origin, p.Normal()
+		d.TargetOrigin = []float64{float64(o.X), float64(o.Y), float64(o.Z)}
+		d.TargetNormal = []float64{float64(n.X), float64(n.Y), float64(n.Z)}
+	}
+	return d
 }
 
 func restoreExtend(fs *PartFeatures, d *ExtendData) (*PartFeature, error) {
 	if d == nil {
 		return nil, fmt.Errorf("extend feature is missing its payload")
 	}
+	keys, err := extendEdgeKeys(d)
+	if err != nil {
+		return nil, err
+	}
+	def := &ExtendDefinition{EdgeKeys: keys, Distance: constFloat(d.Distance), Natural: d.Natural}
+	if len(d.TargetNormal) == 3 && len(d.TargetOrigin) == 3 {
+		pl, err := geom.NewPlane(math.P3(d.TargetOrigin[0], d.TargetOrigin[1], d.TargetOrigin[2]), math.V3(d.TargetNormal[0], d.TargetNormal[1], d.TargetNormal[2]))
+		if err != nil {
+			return nil, fmt.Errorf("extend feature target plane: %w", err)
+		}
+		def.TargetPlane = &pl
+	}
+	return NewExtendFeatures(fs).AddExtend(def), nil
+}
+
+// extendEdgeKeys decodes the multi-edge Edges list, falling back to the legacy single EdgeKey.
+func extendEdgeKeys(d *ExtendData) ([][]byte, error) {
+	if len(d.Edges) > 0 {
+		return decodeKeys(d.Edges)
+	}
 	key, err := decodeKey(d.EdgeKey)
 	if err != nil {
 		return nil, fmt.Errorf("extend feature edge key: %w", err)
 	}
-	return NewExtendFeatures(fs).Add(key, constFloat(d.Distance)), nil
+	return [][]byte{key}, nil
 }
 
 // SurfaceOffsetData is a surface offset's recipe: the offset distance along the face normal.

--- a/model/feature/surface_edit.go
+++ b/model/feature/surface_edit.go
@@ -5,6 +5,7 @@ package feature
 import (
 	"errors"
 
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
@@ -79,14 +80,19 @@ func (c *TrimFeatures) AddByPlane(origin math.Point3, normal math.Vector3, keepP
 	return pf
 }
 
-// ExtendDefinition is the recipe for extending a planar surface's boundary edge outward by a
-// distance (the edge held by reference key, re-resolved each recompute).
+// ExtendDefinition is the recipe for extending a planar surface's boundary edges outward — by a
+// distance, or until they reach a target plane (#1878). Edges are held by reference key and
+// re-resolved each recompute. Natural marks the continuity mode (natural vs stretched); for the
+// planar faces supported today both extend linearly, so it is carried for parity and only bites on
+// the curved (NURBS) extend that is phase C.
 type ExtendDefinition struct {
-	EdgeKey  []byte
-	Distance func() float64
+	EdgeKeys    [][]byte
+	Distance    func() float64
+	TargetPlane *geom.Plane // non-nil ⇒ extend-to-plane (Inventor's to-object) instead of by distance
+	Natural     bool
 }
 
-// ExtendFeature extends a planar surface body's boundary edge, growing the face (PBI-111).
+// ExtendFeature extends a planar surface body's boundary edges, growing the face (PBI-111, #1878).
 // Multi-face and curved-surface extension are the remaining phase-C (NURBS) work.
 type ExtendFeature struct {
 	def      *ExtendDefinition
@@ -99,13 +105,19 @@ func (e *ExtendFeature) Definition() *ExtendDefinition { return e.def }
 // Kind implements [Feature].
 func (e *ExtendFeature) Kind() string { return "extend" }
 
-// Recompute resolves the boundary edge and extends its face outward; a lost edge → Sick.
+// Recompute resolves the boundary edges and extends their face outward — to the target plane when
+// one is set, otherwise by the distance. A lost edge → Sick.
 func (e *ExtendFeature) Recompute(in Input) (Output, error) {
 	body, err := lastBody(in, "extend")
 	if err != nil {
 		return Output{}, err
 	}
-	extended, err := ops.ExtendByEdge(body, e.def.EdgeKey, callOrZero(e.def.Distance), e.featName)
+	var extended *topo.Body
+	if e.def.TargetPlane != nil {
+		extended, err = ops.ExtendEdgesToPlane(body, e.def.EdgeKeys, *e.def.TargetPlane, e.featName)
+	} else {
+		extended, err = ops.ExtendEdgesByDistance(body, e.def.EdgeKeys, callOrZero(e.def.Distance), e.featName)
+	}
 	if err != nil {
 		return Output{}, err
 	}
@@ -118,9 +130,14 @@ type ExtendFeatures struct{ engine *PartFeatures }
 // NewExtendFeatures binds the collection to a feature engine.
 func NewExtendFeatures(engine *PartFeatures) *ExtendFeatures { return &ExtendFeatures{engine: engine} }
 
-// Add extends the boundary edge (by reference key) outward by distance.
+// Add extends a single boundary edge outward by distance (the simple back-compatible form).
 func (c *ExtendFeatures) Add(edgeKey []byte, distance func() float64) *PartFeature {
-	ef := &ExtendFeature{def: &ExtendDefinition{EdgeKey: edgeKey, Distance: distance}, featName: "Extend"}
+	return c.AddExtend(&ExtendDefinition{EdgeKeys: [][]byte{edgeKey}, Distance: distance})
+}
+
+// AddExtend extends the definition's boundary edges — by distance or to a target plane (#1878).
+func (c *ExtendFeatures) AddExtend(def *ExtendDefinition) *PartFeature {
+	ef := &ExtendFeature{def: def, featName: "Extend"}
 	pf := c.engine.Add(ef)
 	ef.featName = pf.name
 	return pf

--- a/model/feature/surface_edit_test.go
+++ b/model/feature/surface_edit_test.go
@@ -5,6 +5,7 @@ package feature
 import (
 	"testing"
 
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/math"
 	"oblikovati.org/model/health"
@@ -61,6 +62,81 @@ func TestExtendFeatureGrowsSurface(t *testing.T) {
 	box := fs.Result()[0].RangeBox()
 	if !approxEq(box.Min.Y, -2) || !approxEq(box.Max.Y, 4) {
 		t.Errorf("extended y-span = [%v,%v], want [-2,4]", box.Min.Y, box.Max.Y)
+	}
+}
+
+// TestExtendFeatureMultiEdge extends the bottom (y=0) and top (y=4) edges of the 4×4 patch by 2
+// each in one feature: the y-span grows to [-2,6] (#1878).
+func TestExtendFeatureMultiEdge(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	patchSurface(fs)
+	fs.Recompute()
+	var bottom, top []byte
+	for _, e := range fs.Result()[0].Edges() {
+		a, b := e.StartVertex().Point(), e.EndVertex().Point()
+		if a.Y == 0 && b.Y == 0 {
+			bottom = e.ReferenceKey()
+		}
+		if approxEq(a.Y, 4) && approxEq(b.Y, 4) {
+			top = e.ReferenceKey()
+		}
+	}
+	pf := NewExtendFeatures(fs).AddExtend(&ExtendDefinition{EdgeKeys: [][]byte{bottom, top}, Distance: func() float64 { return 2 }})
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("multi-edge extend sick: %+v", pf.Health())
+	}
+	box := fs.Result()[0].RangeBox()
+	if !approxEq(box.Min.Y, -2) || !approxEq(box.Max.Y, 6) {
+		t.Errorf("extended y-span = [%v,%v], want [-2,6]", box.Min.Y, box.Max.Y)
+	}
+}
+
+// TestExtendFeatureToPlane extends the bottom edge of the 4×4 patch until it reaches the plane
+// y=-3: the y-span grows to [-3,4] (#1878).
+func TestExtendFeatureToPlane(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	patchSurface(fs)
+	fs.Recompute()
+	var bottom []byte
+	for _, e := range fs.Result()[0].Edges() {
+		if e.StartVertex().Point().Y == 0 && e.EndVertex().Point().Y == 0 {
+			bottom = e.ReferenceKey()
+		}
+	}
+	target, _ := geom.NewPlane(math.P3(0, -3, 0), math.V3(0, 1, 0))
+	pf := NewExtendFeatures(fs).AddExtend(&ExtendDefinition{EdgeKeys: [][]byte{bottom}, TargetPlane: &target})
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("extend-to-plane sick: %+v", pf.Health())
+	}
+	if box := fs.Result()[0].RangeBox(); !approxEq(box.Min.Y, -3) || !approxEq(box.Max.Y, 4) {
+		t.Errorf("extended y-span = [%v,%v], want [-3,4]", box.Min.Y, box.Max.Y)
+	}
+}
+
+// TestExtendOptionsRoundTrip pins #1878 serialization: multi-edge, extend-to-plane target, and the
+// natural flag survive the recipe codec; a legacy single-edge recipe still restores.
+func TestExtendOptionsRoundTrip(t *testing.T) {
+	target, _ := geom.NewPlane(math.P3(0, -3, 0), math.V3(0, 1, 0))
+	fs := NewPartFeatures(nil)
+	NewExtendFeatures(fs).AddExtend(&ExtendDefinition{
+		EdgeKeys: [][]byte{[]byte("e-a"), []byte("e-b")}, TargetPlane: &target, Natural: true,
+	})
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	if d := data[0].Extend; len(d.Edges) != 2 || len(d.TargetNormal) != 3 || !d.Natural {
+		t.Fatalf("serialized extend = %+v", d)
+	}
+	fresh := NewPartFeatures(nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	def := fresh.Item(0).Definition().(*ExtendFeature).Definition()
+	if len(def.EdgeKeys) != 2 || def.TargetPlane == nil || !def.Natural {
+		t.Errorf("restored extend = %d edges, target %v, natural %v", len(def.EdgeKeys), def.TargetPlane, def.Natural)
 	}
 }
 


### PR DESCRIPTION
#1878 (Surfaces parity, milestone #44). Pins oblikovati.org/api v0.142.2 (Oblikovati.API#269).

Extend now grows **several boundary edges** of a planar surface face in one feature (`edgeRefs`), and can grow each edge **until it reaches a target plane** (`extentType: toPlane`/`toObject`, `targetRef` = work plane or planar face) rather than by a fixed distance. `extensionType` natural|stretched is carried (they coincide for the planar faces supported today; natural bites on the curved-surface extend that is phase C — the previously-unreachable continuity order is now expressible).

New kernel `ops.ExtendEdgesByDistance` / `ExtendEdgesToPlane` accumulate each edge's endpoint displacement on the shared face polygon (a vertex on two extended edges takes both). The legacy single `edgeRef` path and pre-#1878 recipes still restore.

Kernel (analytic areas: 2×3 → 3×3 grow, both-sides → 4×3, to-plane x=5 → 5×3), model (multi-edge span, to-plane span, options round-trip) and router tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)