### PR TITLE
feat(fillet/chamfer): discoverable 'Tangent chain' selection toggle (#1947, follow-up to #1798)

### DIFF
--- a/app/chamfer_tool.go
+++ b/app/chamfer_tool.go
@@ -19,6 +19,7 @@ type ChamferTool struct {
 	distance        float64
 	flatCorners     bool
 	concaveStrategy types.ChamferConcaveStrategy // concave edges: outward fill (default) or inward relief
+	tangentChain    bool                         // a plain pick selects the whole tangent chain (#1947)
 	added           *feature.PartFeature
 }
 
@@ -36,7 +37,13 @@ func (t *ChamferTool) Name() string { return "Chamfer" }
 func (t *ChamferTool) Start(s *Session) {
 	t.flatCorners = s.ChamferFlatCorners()
 	t.concaveStrategy = s.ChamferConcaveStrategy()
+	t.tangentChain = s.TangentChainSelect()
 }
+
+// SetTangentChain/TangentChain choose whether a plain pick selects the whole tangent chain through
+// the clicked edge (Inventor's tangent propagation) or just that edge. Shift+click always expands.
+func (t *ChamferTool) SetTangentChain(on bool) { t.tangentChain = on }
+func (t *ChamferTool) TangentChain() bool      { return t.tangentChain }
 
 // AcceptedKinds declares chamfer picks edges (the edges to bevel).
 func (t *ChamferTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectEdge} }
@@ -80,17 +87,18 @@ func (t *ChamferTool) Pick(_ *Session, sel Selectable) {
 	}
 }
 
-// PickWithMods adds the whole tangent chain through the clicked edge on Shift+click — the
-// "select tangent chain / loop" selection (#1798); a plain click adds the single edge.
+// PickWithMods adds the whole tangent chain through the clicked edge when tangent-chain mode is on
+// (the default, Inventor's tangent propagation) or on Shift+click — the "select tangent chain /
+// loop" selection (#1798/#1947); otherwise a plain click adds the single edge. Shift always expands.
 func (t *ChamferTool) PickWithMods(s *Session, sel Selectable, mods Modifier) {
 	e, ok := sel.(EdgeHandle)
-	if !ok || !mods.Has(ShiftMod) {
-		t.Pick(s, sel)
+	if ok && (t.tangentChain || mods.Has(ShiftMod)) {
+		for _, h := range s.tangentChainHandles(e) {
+			t.addEdge(h)
+		}
 		return
 	}
-	for _, h := range s.tangentChainHandles(e) {
-		t.addEdge(h)
-	}
+	t.Pick(s, sel)
 }
 
 // addEdge appends an edge unless it is already selected.

--- a/app/fillet_allaround_rampam_test.go
+++ b/app/fillet_allaround_rampam_test.go
@@ -84,19 +84,36 @@ func TestFilletAllAroundShiftClickExpandsTangentLoop(t *testing.T) {
 	}
 }
 
-// TestFilletAllAroundPlainClickIsSingleEdge documents rampam's likely experience (#1 "unable to
-// fillet all around, it does not detect tangency"): a PLAIN click selects only the one clicked edge,
-// so a user who does not know the (undiscoverable) Shift+click gets a single-edge fillet, not an
-// all-around one. This is the interaction gap — the kernel/feature layers are correct (they round
-// all 8 when handed them), but nothing surfaces the tangent loop on a normal click.
-func TestFilletAllAroundPlainClickIsSingleEdge(t *testing.T) {
+// TestFilletAllAroundIsDiscoverableByDefault is the #1947 affordance for rampam's #1 ("does not
+// detect tangency"): with the "Tangent chain" toggle at its default (on), a PLAIN viewport click
+// (PickWithMods, no modifier) selects the whole 8-edge loop, so "fillet all around" works on the
+// first click with no hidden gesture. Toggling it off restores single-edge picking; the explicit
+// Pick API is always single (it is the deterministic per-edge entry the toggle does not touch).
+func TestFilletAllAroundIsDiscoverableByDefault(t *testing.T) {
 	s, block := newPartWithBlock(t, 2)
 	rounded := filletVerticalsOf(t, s, block)
+	seed := oneTopRimEdge(t, rounded)
 
-	f := NewFilletTool()
-	s.StartTool(f)
-	f.Pick(s, oneTopRimEdge(t, rounded)) // plain click — no modifier
-	if n := len(f.Edges()); n != 1 {
-		t.Fatalf("plain click selected %d edges, want 1 (no tangent-chain on a normal click)", n)
+	on := NewFilletTool()
+	s.StartTool(on) // seeds tangentChain from the session default (on)
+	on.PickWithMods(s, seed, 0)
+	if n := len(on.Edges()); n != 8 {
+		t.Fatalf("plain click with the Tangent-chain default (on) selected %d edges, want the 8-edge loop", n)
+	}
+
+	off := NewFilletTool()
+	s.StartTool(off)
+	off.SetTangentChain(false)
+	off.PickWithMods(s, seed, 0)
+	if n := len(off.Edges()); n != 1 {
+		t.Fatalf("plain click with Tangent chain off selected %d edges, want 1", n)
+	}
+
+	// The explicit single-edge Pick API is unaffected by the toggle.
+	exp := NewFilletTool()
+	s.StartTool(exp)
+	exp.Pick(s, seed)
+	if n := len(exp.Edges()); n != 1 {
+		t.Fatalf("explicit Pick selected %d edges, want 1", n)
 	}
 }

--- a/app/fillet_tool.go
+++ b/app/fillet_tool.go
@@ -25,6 +25,7 @@ type FilletTool struct {
 	concaveStrategy types.FilletConcaveStrategy // concave edges: outward fill (default) or inward recess
 	crossSection    feature.FilletCrossSection  // blend cross-section: arc (default), G2, or conic (#1284)
 	rho             float64                     // conic fullness (0<ρ<1, 0.5 = parabola)
+	tangentChain    bool                        // a plain pick selects the whole tangent chain (#1947)
 	added           *feature.PartFeature
 }
 
@@ -113,7 +114,12 @@ func (t *FilletTool) SetCornerTypeIndex(i int) {
 func (t *FilletTool) Name() string { return "Fillet" }
 
 // Start is a no-op; the engine installs the filter from AcceptedKinds.
-func (t *FilletTool) Start(*Session) {}
+func (t *FilletTool) Start(s *Session) { t.tangentChain = s.TangentChainSelect() }
+
+// SetTangentChain/TangentChain choose whether a plain pick selects the whole tangent chain through
+// the clicked edge (Inventor's tangent propagation) or just that edge. Shift+click always expands.
+func (t *FilletTool) SetTangentChain(on bool) { t.tangentChain = on }
+func (t *FilletTool) TangentChain() bool      { return t.tangentChain }
 
 // AcceptedKinds declares fillet picks edges (the edges to round).
 func (t *FilletTool) AcceptedKinds() []SelectionKind { return []SelectionKind{SelectEdge} }
@@ -128,17 +134,19 @@ func (t *FilletTool) Pick(_ *Session, sel Selectable) {
 	}
 }
 
-// PickWithMods adds the whole tangent chain through the clicked edge on Shift+click — the
-// "select tangent chain / loop" selection (#1798); a plain click adds the single edge.
+// PickWithMods adds the whole tangent chain through the clicked edge when tangent-chain mode is on
+// (the default, Inventor's tangent propagation) or on Shift+click — the "select tangent chain /
+// loop" selection (#1798/#1947); otherwise a plain click adds the single edge. Shift always expands,
+// so it still works even when the mode is toggled off.
 func (t *FilletTool) PickWithMods(s *Session, sel Selectable, mods Modifier) {
 	e, ok := sel.(EdgeHandle)
-	if !ok || !mods.Has(ShiftMod) {
-		t.Pick(s, sel)
+	if ok && (t.tangentChain || mods.Has(ShiftMod)) {
+		for _, h := range s.tangentChainHandles(e) {
+			t.addEdge(h)
+		}
 		return
 	}
-	for _, h := range s.tangentChainHandles(e) {
-		t.addEdge(h)
-	}
+	t.Pick(s, sel)
 }
 
 // addEdge appends an edge unless it is already selected.

--- a/app/options/options.go
+++ b/app/options/options.go
@@ -37,6 +37,10 @@ type Sketch struct {
 // Part is the part-modeling defaults, applied live to the session.
 type Part struct {
 	ChamferFlatCorners bool `yaml:"chamferFlatCorners"`
+	// TangentChainSelect makes a Fillet/Chamfer pick select the whole tangent chain through the
+	// clicked edge (Inventor's tangent propagation). Defaults true; Load merges over Defaults so a
+	// stored file missing the key keeps the default. See #1798 follow-up (#1947).
+	TangentChainSelect bool `yaml:"tangentChainSelect"`
 }
 
 // Save is the save policy (M03-F09, #610): thumbnail capture on save (read by
@@ -92,7 +96,7 @@ func Defaults() All {
 	return All{
 		General:   General{StartupAction: types.StartupNewPart},
 		Sketch:    Sketch{GridSpacingCm: 1, GridVisible: true, GridMajorEvery: 5, SnapToPoints: true, SnapToGrid: true, HeadsUpDisplay: true},
-		Part:      Part{ChamferFlatCorners: true},
+		Part:      Part{ChamferFlatCorners: true, TangentChainSelect: true},
 		Save:      Save{Thumbnail: types.ThumbnailNone},
 		Updates:   Updates{CheckOnStartup: true},
 		Telemetry: Telemetry{ShareUsageStatistics: true},

--- a/app/preferences.go
+++ b/app/preferences.go
@@ -79,6 +79,14 @@ func (s *Session) ChamferFlatCorners() bool { return s.chamferFlatCorners }
 // SetChamferFlatCorners sets the default corner treatment for new chamfers.
 func (s *Session) SetChamferFlatCorners(flat bool) { s.chamferFlatCorners = flat }
 
+// TangentChainSelect reports whether new Fillet/Chamfer tools select the whole tangent chain
+// through a clicked edge (Inventor's tangent propagation) rather than the single edge. Defaults
+// true; Shift+click always expands regardless. See #1947.
+func (s *Session) TangentChainSelect() bool { return s.tangentChainSelect }
+
+// SetTangentChainSelect sets the default tangent-chain selection mode for new fillets/chamfers.
+func (s *Session) SetTangentChainSelect(on bool) { s.tangentChainSelect = on }
+
 // ChamferConcaveStrategy reports the default concave-edge strategy new Chamfer tools start with:
 // outward fills the inside corner with material (the default), inward cuts a recessed relief.
 func (s *Session) ChamferConcaveStrategy() types.ChamferConcaveStrategy {

--- a/app/session.go
+++ b/app/session.go
@@ -140,6 +140,7 @@ type Session struct {
 	styles                    *style.Registry                   // document color styles + style-library cascade (M16-F02 #403/#408)
 	displayOptions            display.Options                   // app-level display options that parameterize the display modes (M16-F07 #643)
 	chamferFlatCorners        bool                              // default three-edge-corner treatment for new chamfers
+	tangentChainSelect        bool                              // default: a fillet/chamfer pick selects the whole tangent chain (#1947)
 	chamferConcaveOut         bool                              // default concave-edge strategy for new chamfers (true ⇒ outward fill)
 	paramsDialogOpen          bool                              // the Manage ▸ Parameters dialog is open
 	keymapEditorOpen          bool                              // the Tools ▸ Customize Keyboard panel is open (M05-F17)
@@ -233,6 +234,7 @@ func newSession(store doc.Store) *Session {
 		lightingStyle:           renderer.LightingThreePoint,
 		lighting:                renderer.SceneLightingFor(renderer.LightingThreePoint),
 		chamferFlatCorners:      true, // match Inventor's default flat three-edge-corner blend
+		tangentChainSelect:      true, // match Inventor's tangent propagation: a pick grabs the tangent chain
 		hudEnabled:              true, // dynamic-input HUD on by default, like Inventor (#790)
 		chamferConcaveOut:       true, // concave edges fill the inside corner by default (outward)
 		pointCloudRenderDensity: 100,

--- a/app/session_options.go
+++ b/app/session_options.go
@@ -29,6 +29,7 @@ func (s *Session) UseOptionsStore(store options.Store) error {
 	s.appOptions = loaded
 	s.applySketchOptions(loaded.Sketch)
 	s.chamferFlatCorners = loaded.Part.ChamferFlatCorners
+	s.tangentChainSelect = loaded.Part.TangentChainSelect
 	return nil
 }
 
@@ -52,6 +53,7 @@ func (s *Session) SetSketchOptions(o options.Sketch) error {
 func (s *Session) SetPartOptions(p options.Part) error {
 	s.appOptions.Part = p
 	s.chamferFlatCorners = p.ChamferFlatCorners
+	s.tangentChainSelect = p.TangentChainSelect
 	return s.saveOptions()
 }
 
@@ -69,7 +71,7 @@ func (s *Session) PersistLiveOptions() error {
 		HeadsUpDisplay: s.hudEnabled,
 		RelaxMode:      s.relaxMode,
 	}
-	s.appOptions.Part = options.Part{ChamferFlatCorners: s.chamferFlatCorners}
+	s.appOptions.Part = options.Part{ChamferFlatCorners: s.chamferFlatCorners, TangentChainSelect: s.tangentChainSelect}
 	return s.saveOptions()
 }
 

--- a/app/tangent_chain_pref_test.go
+++ b/app/tangent_chain_pref_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/app/options"
+)
+
+// TestTangentChainSelectDefaultsOn checks the session-level default that new Fillet/Chamfer tools
+// seed from is on out of the box (#1947), matching Inventor's tangent propagation.
+func TestTangentChainSelectDefaultsOn(t *testing.T) {
+	s := NewSession()
+	if !s.TangentChainSelect() {
+		t.Error("TangentChainSelect() should default to true (Inventor tangent propagation)")
+	}
+	f := NewFilletTool()
+	s.StartTool(f)
+	if !f.TangentChain() {
+		t.Error("a new Fillet tool should seed Tangent chain = on from the session default")
+	}
+	ch := NewChamferTool()
+	s.StartTool(ch)
+	if !ch.TangentChain() {
+		t.Error("a new Chamfer tool should seed Tangent chain = on from the session default")
+	}
+}
+
+// TestTangentChainSelectPreferenceSeedsNewTools verifies that flipping the session preference is
+// picked up by the next tool started (the preference is the seed, not a one-shot).
+func TestTangentChainSelectPreferenceSeedsNewTools(t *testing.T) {
+	s := NewSession()
+	s.SetTangentChainSelect(false)
+	f := NewFilletTool()
+	s.StartTool(f)
+	if f.TangentChain() {
+		t.Error("after SetTangentChainSelect(false), a new Fillet tool should start with Tangent chain off")
+	}
+}
+
+// TestTangentChainSelectPersists round-trips the preference through SetPartOptions (the persistence
+// path the Preferences window and options.* wire methods use), mirroring chamfer flat-corners.
+func TestTangentChainSelectPersists(t *testing.T) {
+	s := NewSession()
+	if err := s.SetPartOptions(options.Part{ChamferFlatCorners: true, TangentChainSelect: false}); err != nil {
+		t.Fatalf("SetPartOptions: %v", err)
+	}
+	if s.TangentChainSelect() {
+		t.Error("SetPartOptions{TangentChainSelect:false} should turn the session default off")
+	}
+	if got := s.Options().Part.TangentChainSelect; got {
+		t.Errorf("Options().Part.TangentChainSelect = %v, want false (persisted)", got)
+	}
+}
+
+// TestOptionsDefaultsTangentChainOn guards the on-disk defaults: a fresh options set (no stored
+// file) has tangent-chain selection enabled, so Load-over-Defaults keeps it on for files that
+// predate the key.
+func TestOptionsDefaultsTangentChainOn(t *testing.T) {
+	if !options.Defaults().Part.TangentChainSelect {
+		t.Error("options.Defaults().Part.TangentChainSelect should be true")
+	}
+}

--- a/app/tangent_chain_select_test.go
+++ b/app/tangent_chain_select_test.go
@@ -9,27 +9,37 @@ import (
 	"oblikovati.org/kernel/topo"
 )
 
-// TestChamferShiftClickSelectsTangentLoop is the #1798 acceptance at the UI seam: after rounding
-// a block's four vertical edges, Shift-clicking one straight edge of the resulting tangent top
-// rim selects the whole 8-edge loop in one gesture (4 sides + 4 corner arcs) — the "pick one
-// edge → select tangent chain" the Chamfer/Fillet tools were missing. A plain click still adds
-// only the clicked edge.
+// TestChamferShiftClickSelectsTangentLoop is the #1798/#1947 acceptance at the UI seam: after
+// rounding a block's four vertical edges, one click on a straight edge of the resulting tangent top
+// rim selects the whole 8-edge loop (4 sides + 4 corner arcs). With the "Tangent chain" toggle at
+// its default (on, Inventor's tangent propagation) a PLAIN click expands; toggling it off makes a
+// plain click select just the clicked edge; and Shift+click always expands regardless.
 func TestChamferShiftClickSelectsTangentLoop(t *testing.T) {
 	s, block := newPartWithBlock(t, 2)
 	roundVerticalEdges(t, s, block, 0.5)
 	rounded := activePartDef(t, s).SurfaceBodies().Item(0)
 	seed := longestTopRimEdgeHandle(t, rounded, 2.0)
 
-	ch := NewChamferTool()
-	s.StartTool(ch)
-	ch.PickWithMods(s, seed, 0) // plain click adds only the seed
-	if got := len(ch.Edges()); got != 1 {
-		t.Fatalf("plain click selected %d edges, want 1", got)
+	def := NewChamferTool()
+	s.StartTool(def) // seeds tangentChain from the session default (on)
+	def.PickWithMods(s, seed, 0)
+	if got := len(def.Edges()); got != 8 {
+		t.Fatalf("plain click with the Tangent-chain default (on) selected %d edges, want the 8-edge loop", got)
 	}
-	ch2 := NewChamferTool()
-	s.StartTool(ch2)
-	ch2.PickWithMods(s, seed, ShiftMod) // Shift-click expands to the tangent loop
-	if got := len(ch2.Edges()); got != 8 {
+
+	off := NewChamferTool()
+	s.StartTool(off)
+	off.SetTangentChain(false)
+	off.PickWithMods(s, seed, 0) // toggle off ⇒ plain click adds only the seed
+	if got := len(off.Edges()); got != 1 {
+		t.Fatalf("plain click with Tangent chain off selected %d edges, want 1", got)
+	}
+
+	shift := NewChamferTool()
+	s.StartTool(shift)
+	shift.SetTangentChain(false)
+	shift.PickWithMods(s, seed, ShiftMod) // Shift always expands, even with the toggle off
+	if got := len(shift.Edges()); got != 8 {
 		t.Fatalf("Shift-click selected %d edges, want the 8-edge tangent loop", got)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.142.1
+	oblikovati.org/api v0.142.2
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.142.2
+	oblikovati.org/api v0.142.3
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.142.2
+	oblikovati.org/api v0.142.3
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.142.1
+	oblikovati.org/api v0.142.2
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/head/ui/chamfer_dialog.go
+++ b/head/ui/chamfer_dialog.go
@@ -16,6 +16,7 @@ var chamferUI = struct {
 	distance     float32
 	flatCorners  bool
 	concaveIndex int              // concave-edge strategy combo: 0 outward (fill), 1 inward (relief)
+	tangentChain bool             // select the whole tangent chain on a plain pick (#1947)
 	seeded       *app.ChamferTool // the tool the fields were seeded from (nil = none)
 }{distance: 1, flatCorners: true}
 
@@ -28,21 +29,15 @@ func drawChamferDialog(s *app.Session) {
 		return
 	}
 	if chamferUI.seeded != c {
-		chamferUI.distance = float32(c.Distance())
-		chamferUI.flatCorners = c.FlatCorners()
-		chamferUI.concaveIndex = c.ConcaveStrategyIndex()
-		chamferUI.seeded = c
+		seedChamferUI(c)
 	}
 	dialogSizeOnce(340, 250)
 	if native.Begin("Chamfer") {
-		title := "Chamfer"
-		if name := c.EditingName(); name != "" {
-			title = name // re-editing a committed chamfer: the breadcrumb names it
-		}
-		drawFeatureBreadcrumb(title, "")
+		drawFeatureBreadcrumb(chamferTitle(c), "")
 		if propertySection("Input Geometry") {
 			drawPickChipRow("Edges", "chamfer-edges", countChipText(c.EdgeCount(), "Edge", "Select Edges"),
-				c.EdgeCount() > 0, "Click edges to bevel; Shift+click selects the whole tangent chain", c.ClearEdges)
+				c.EdgeCount() > 0, "Click edges to bevel; with Tangent chain on, a click selects the whole connected loop (Shift+click always does)", c.ClearEdges)
+			drawTangentChainRow("chamfer", &chamferUI.tangentChain, c.SetTangentChain)
 		}
 		if propertySection("Behavior") {
 			drawChamferBehaviorRows(s, c)
@@ -51,6 +46,25 @@ func drawChamferDialog(s *app.Session) {
 		drawCommitCancelButtons(s, c.CanCommit())
 	}
 	native.End()
+}
+
+// chamferTitle is the panel/breadcrumb title: a committed chamfer's name when re-editing, else
+// "Chamfer".
+func chamferTitle(c *app.ChamferTool) string {
+	if name := c.EditingName(); name != "" {
+		return name
+	}
+	return "Chamfer"
+}
+
+// seedChamferUI loads the panel buffers from the tool the first frame it appears (creation
+// defaults, or a committed chamfer's values in edit mode) — mirrors seedFilletUI.
+func seedChamferUI(c *app.ChamferTool) {
+	chamferUI.distance = float32(c.Distance())
+	chamferUI.flatCorners = c.FlatCorners()
+	chamferUI.concaveIndex = c.ConcaveStrategyIndex()
+	chamferUI.tangentChain = c.TangentChain()
+	chamferUI.seeded = c
 }
 
 // drawChamferBehaviorRows renders the setback distance, the concave-edge strategy combo, and the

--- a/head/ui/fillet_dialog.go
+++ b/head/ui/fillet_dialog.go
@@ -15,11 +15,12 @@ import (
 // (the reference panel schema) shows the picked-edges chip and the blend radius, then
 // OK/Cancel.
 var filletUI = struct {
-	radius      float32
-	startRadius float32
-	endRadius   float32
-	rho         float32         // conic cross-section fullness (#1284)
-	seeded      *app.FilletTool // the tool the fields were seeded from (nil = none)
+	radius       float32
+	startRadius  float32
+	endRadius    float32
+	rho          float32         // conic cross-section fullness (#1284)
+	tangentChain bool            // select the whole tangent chain on a plain pick (#1947)
+	seeded       *app.FilletTool // the tool the fields were seeded from (nil = none)
 }{radius: 1, startRadius: 1, endRadius: 1, rho: 0.5}
 
 // drawFilletDialog shows the Fillet property panel while the Fillet tool is active —
@@ -52,7 +53,8 @@ func drawFilletPanelBody(s *app.Session, f *app.FilletTool) {
 	drawFeatureBreadcrumb(title, "")
 	if propertySection("Input Geometry") {
 		drawPickChipRow("Edges", "fillet-edges", countChipText(f.EdgeCount(), "Edge", "Select Edges"),
-			f.EdgeCount() > 0, "Click convex edges to round; Shift+click selects the whole tangent chain", f.ClearEdges)
+			f.EdgeCount() > 0, "Click convex edges to round; with Tangent chain on, a click selects the whole connected loop (Shift+click always does)", f.ClearEdges)
+		drawTangentChainRow("fillet", &filletUI.tangentChain, f.SetTangentChain)
 	}
 	if propertySection("Behavior") {
 		drawFilletRadiusRows(s, f)
@@ -95,6 +97,7 @@ func seedFilletUI(f *app.FilletTool) {
 	filletUI.startRadius = float32(f.StartRadius())
 	filletUI.endRadius = float32(f.EndRadius())
 	filletUI.rho = float32(f.Rho())
+	filletUI.tangentChain = f.TangentChain()
 	filletUI.seeded = f
 }
 

--- a/head/ui/tangent_chain_row.go
+++ b/head/ui/tangent_chain_row.go
@@ -1,0 +1,20 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import "oblikovati.org/head/internal/native"
+
+// drawTangentChainRow renders the "Tangent chain" selection toggle shared by the Fillet and Chamfer
+// panels (#1947): when on — the default, matching Inventor's tangent propagation — a plain edge
+// click selects the whole tangent loop through it; when off, one edge per click. Shift+click always
+// selects the chain regardless. idScope keeps the imgui widget id unique per panel; set is the
+// tool's SetTangentChain, called only on an actual toggle so it never fights the seeded state.
+func drawTangentChainRow(idScope string, state *bool, set func(bool)) {
+	propertyRow("")
+	if native.Checkbox("Tangent chain##"+idScope, state) {
+		set(*state)
+	}
+	native.SetItemTooltip("On: a click selects the whole connected (tangent) loop of edges — e.g. a rounded rim all around. Off: one edge per click. Shift+click always selects the loop.")
+}


### PR DESCRIPTION
## What & why

Discoverability follow-up to #1798 (filed as #1947). The tangent-chain / loop selection existed but
was reachable only via an **undiscoverable Shift+click**, so rampam re-reported that Fillet/Chamfer
"all around" still doesn't work and "does not detect tangency". This surfaces it as a visible toggle.

## Change
- **`options.Part.TangentChainSelect`** — a session preference (persisted like chamfer flat-corners),
  **defaults on** to match Inventor's tangent propagation and the existing flat-corners precedent.
  `Load` merges over `Defaults`, so files predating the key keep the default.
- **`FilletTool` / `ChamferTool`** seed a `tangentChain` field from it and expand a pick to the whole
  tangent chain when it is **on OR on Shift+click** — so "all around" works on the first plain click,
  while **Shift+click always expands** even with the toggle off. The explicit single-edge `Pick` API
  is unchanged.
- **Head panels** get a **"Tangent chain" checkbox** in the Fillet and Chamfer Input-Geometry
  sections (shared `drawTangentChainRow`, plain values — no `*app.Session`, so the head/ui session
  coupling ratchet holds). Extracted `seedChamferUI`/`chamferTitle` to keep `drawChamferDialog`
  within funlen (also clears pre-existing debt). No API change.

## Verification
- **app**: session default on + tool seeding + preference persistence round-trip; Fillet/Chamfer
  plain click expands by default, single when toggled off, Shift always expands.
- **head/ui**: the existing dialog render test drives `drawFilletDialog`/`drawChamferDialog`, now
  exercising the new checkbox.
- **Live visual**: a one-plain-click on a rounded cube's rim selected all **8** rim edges and the
  panel shows the checked "Tangent chain" box — captured and eyeballed (rim highlighted all around).
- Full core suite (`CGO_ENABLED=0 go test ./...`, incl. the archguard coupling ratchet) green; head
  builds + `ui` render test green; root-module `golangci-lint` 0 issues; my head files add no lint.

## Out of scope (later)
Hover-preview highlighting the whole chain under the cursor; a "select mode: Edge / Loop / Feature"
selector.

Closes #1947
