### PR TITLE
surface: Trim cutting tools — work plane / surface body / sketch line (#1880)

### DIFF
--- a/addin/opregistry/apply_success_test.go
+++ b/addin/opregistry/apply_success_test.go
@@ -153,6 +153,29 @@ func TestMidSurfaceFacePairs(t *testing.T) {
 	}
 }
 
+// TestTrimCuttingTools covers the #1880 trim tool resolution: a work-plane tool and a sketch-line
+// tool resolve to a cutting plane (result or a descriptive error, never a resolution panic); a
+// multi-plane surface-body tool and an empty request error clearly.
+func TestTrimCuttingTools(t *testing.T) {
+	// Fresh session per assertion — each trim mutates the running body.
+	s1, _, _ := extrudedSolid(t)
+	if _, err := apply(t, s1, "trim", `{"toolRef":"origin/plane/xy"}`); err != nil && err.Error() == "" {
+		t.Error("trim toolRef returned an empty error")
+	}
+	s2, _, _ := extrudedSolid(t)
+	if _, err := apply(t, s2, "trim", `{"toolSketchIndex":0,"toolLineIndex":0}`); err != nil && err.Error() == "" {
+		t.Error("trim sketch-line tool returned an empty error")
+	}
+	s3, _, _ := extrudedSolid(t)
+	if _, err := apply(t, s3, "trim", `{"toolBodyIndex":0}`); err == nil {
+		t.Error("trim with a multi-plane tool body should error")
+	}
+	s4, _, _ := extrudedSolid(t)
+	if _, err := apply(t, s4, "trim", `{}`); err == nil {
+		t.Error("trim with no cutting tool should error")
+	}
+}
+
 // TestExtendRouterOptions covers the #1878 extend parse/resolve branches: no edges errors, and
 // extentType toPlane without a targetRef errors (the plane target cannot resolve).
 func TestExtendRouterOptions(t *testing.T) {

--- a/addin/opregistry/feature_modify.go
+++ b/addin/opregistry/feature_modify.go
@@ -11,6 +11,7 @@ import (
 	"oblikovati.org/api/wire/featureargs"
 	"oblikovati.org/app"
 	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
 )
@@ -134,15 +135,18 @@ func approximationArg(s, op string) (types.FeatureApproximationType, error) {
 const trimSchema = `{
   "type": "object",
   "properties": {
-    "origin": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Cutting-plane origin [x,y,z] in cm."},
-    "normal": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Cutting-plane normal [x,y,z]."},
-    "keepPositive": {"type": "boolean", "default": true, "description": "Keep the half on the +normal side."}
-  },
-  "required": ["origin", "normal"]
+    "origin": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Explicit cutting-plane origin [x,y,z] in cm."},
+    "normal": {"type": "array", "items": {"type": "number"}, "minItems": 3, "maxItems": 3, "description": "Explicit cutting-plane normal [x,y,z]."},
+    "toolRef": {"type": "string", "description": "Cutting tool: a work plane or planar face (\"plane/N\", \"origin/plane/xy\", or a face key)."},
+    "toolBodyIndex": {"type": "integer", "minimum": 0, "description": "Cutting tool: a planar surface body by index (model.tree order)."},
+    "toolSketchIndex": {"type": "integer", "minimum": 0, "description": "Cutting tool: the sketch holding a straight cutting line (swept along the sketch normal)."},
+    "toolLineIndex": {"type": "integer", "minimum": 0, "default": 0, "description": "Which line of toolSketchIndex is the cutting line."},
+    "keepPositive": {"type": "boolean", "default": true, "description": "Keep the side on the +normal side of the cut."}
+  }
 }`
 
 func trimDescriptor() *OperationDescriptor {
-	return &OperationDescriptor{Name: featureargs.KindTrim, Summary: "Trim the body with a cutting plane, keeping one half.", Schema: json.RawMessage(trimSchema), Apply: applyTrim}
+	return &OperationDescriptor{Name: featureargs.KindTrim, Summary: "Trim a surface with a cutting tool (plane / work plane / surface body / sketch line), keeping one side.", Schema: json.RawMessage(trimSchema), Apply: applyTrim}
 }
 
 func applyTrim(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
@@ -150,16 +154,68 @@ func applyTrim(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	origin, err := point3(in.Origin, "trim: origin")
-	if err != nil {
-		return nil, err
-	}
-	normal, err := vec3(in.Normal, "trim: normal")
+	origin, normal, err := trimCuttingPlane(part, in)
 	if err != nil {
 		return nil, err
 	}
 	pf := feature.NewTrimFeatures(part.Features()).AddByPlane(origin, normal, in.KeepPositive)
 	return recomputeResult(part, pf)
+}
+
+// trimCuttingPlane resolves the trim's cutting tool to a plane (origin+normal): an explicit plane,
+// a work plane / planar face, a planar surface body, or a straight sketch line swept along its
+// sketch normal (#1880).
+func trimCuttingPlane(part *compdef.PartComponentDefinition, in featureargs.Trim) (math.Point3, math.Vector3, error) {
+	switch {
+	case in.ToolRef != "":
+		wp, err := part.WorkGeometry().PlaneTargetFromRef(in.ToolRef)
+		if err != nil {
+			return math.Point3{}, math.Vector3{}, fmt.Errorf("trim: tool %q: %w", in.ToolRef, err)
+		}
+		return wp.Plane().Origin(), wp.Plane().Normal().AsVector(), nil
+	case in.ToolBodyIndex != nil:
+		return trimBodyPlane(part, *in.ToolBodyIndex)
+	case in.ToolSketchIndex != nil:
+		return trimSketchLinePlane(part, *in.ToolSketchIndex, in.ToolLineIndex)
+	default:
+		origin, err := point3(in.Origin, "trim: origin")
+		if err != nil {
+			return math.Point3{}, math.Vector3{}, err
+		}
+		normal, err := vec3(in.Normal, "trim: normal")
+		return origin, normal, err
+	}
+}
+
+// trimBodyPlane extracts the plane of a planar surface body used as a cutting tool.
+func trimBodyPlane(part *compdef.PartComponentDefinition, index int) (math.Point3, math.Vector3, error) {
+	bodies := part.Features().Result()
+	if index < 0 || index >= len(bodies) {
+		return math.Point3{}, math.Vector3{}, fmt.Errorf("trim: tool body index %d out of range (have %d)", index, len(bodies))
+	}
+	pl, ok := ops.BodyPlane(bodies[index])
+	if !ok {
+		return math.Point3{}, math.Vector3{}, fmt.Errorf("trim: tool body %d is not a planar surface", index)
+	}
+	return pl.Origin, pl.Normal(), nil // geom.Plane.Normal() is already a Vector3
+}
+
+// trimSketchLinePlane derives the cutting plane of a straight sketch line: the plane containing the
+// line and the sketch normal (the line swept perpendicular to its sketch).
+func trimSketchLinePlane(part *compdef.PartComponentDefinition, sketchIndex, lineIndex int) (math.Point3, math.Vector3, error) {
+	sk, err := sketchAt(part, sketchIndex)
+	if err != nil {
+		return math.Point3{}, math.Vector3{}, err
+	}
+	if lineIndex < 0 || lineIndex >= sk.Lines().Count() {
+		return math.Point3{}, math.Vector3{}, fmt.Errorf("trim: line index %d out of range (sketch has %d lines)", lineIndex, sk.Lines().Count())
+	}
+	origin, dir := sk.Lines().Item(lineIndex).Axis3D(sk.Plane())
+	normal := dir.Cross(sk.Plane().Normal().AsVector())
+	if normal.LengthSquared() < 1e-18 {
+		return math.Point3{}, math.Vector3{}, fmt.Errorf("trim: cutting line is degenerate")
+	}
+	return origin, normal, nil
 }
 
 // --- face direct edits (move / offset / delete / split) --------------------

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.142.3
+	oblikovati.org/api v0.142.4
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.142.3
+	oblikovati.org/api v0.142.4
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/kernel/ops/surface_edit.go
+++ b/kernel/ops/surface_edit.go
@@ -171,6 +171,27 @@ func TrimByPlane(body *topo.Body, origin math.Point3, normal math.Vector3, keepP
 	return buildSheet(patches, feat), nil
 }
 
+// BodyPlane returns the common plane of a planar surface body (its faces' shared plane) — for use
+// as a Trim cutting tool (#1880). It reports false for an empty, non-planar, or multi-plane body
+// (a curved tool surface is phase C).
+func BodyPlane(body *topo.Body) (geom.Plane, bool) {
+	faces := body.Faces()
+	if len(faces) == 0 {
+		return geom.Plane{}, false
+	}
+	pl, ok := faces[0].Geometry().(geom.Plane)
+	if !ok {
+		return geom.Plane{}, false
+	}
+	for _, f := range faces[1:] {
+		other, ok := f.Geometry().(geom.Plane)
+		if !ok || !sameDirection(pl.Normal(), other.Normal()) || stdmath.Abs(float64(geom.SignedDistanceToPlane(pl, other.Origin))) > 1e-6 {
+			return geom.Plane{}, false // not a single coplanar tool surface
+		}
+	}
+	return pl, true
+}
+
 // clipHalfSpace clips a planar polygon against one half-space (Sutherland–Hodgman),
 // keeping vertices on the plane's keep side and inserting edge–plane intersections.
 func clipHalfSpace(poly []math.Point3, origin math.Point3, normal math.Vector3, keepPositive bool) []math.Point3 {

--- a/kernel/ops/surface_edit_test.go
+++ b/kernel/ops/surface_edit_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 )
@@ -148,6 +149,29 @@ func TestTrimByPlaneEmptyErrors(t *testing.T) {
 	// Keep the x ≥ 10 side — nothing remains.
 	if _, err := TrimByPlane(patch, math.P3(10, 0, 0), math.V3(1, 0, 0), true, "trim"); err == nil {
 		t.Error("trimming away the whole patch should error")
+	}
+}
+
+// TestBodyPlaneOfPlanarSurface returns the plane of a single-face (and a coplanar two-face) surface
+// body, and rejects a non-coplanar body — the Trim surface-body tool (#1880).
+func TestBodyPlaneOfPlanarSurface(t *testing.T) {
+	quad := quadBody("q", math.P3(0, 0, 5), math.P3(4, 0, 5), math.P3(4, 4, 5), math.P3(0, 4, 5)) // z=5 plane
+	pl, ok := BodyPlane(quad)
+	if !ok {
+		t.Fatal("BodyPlane should resolve a single planar face")
+	}
+	if n := pl.Normal(); !approx(float64(n.Z*n.Z), 1) {
+		t.Errorf("plane normal = %v, want ±Z", n)
+	}
+	if d := geom.SignedDistanceToPlane(pl, math.P3(0, 0, 5)); !approx(float64(d), 0) {
+		t.Errorf("z=5 point is %g off the plane, want 0", d)
+	}
+	if _, ok := BodyPlane(twoQuadSheet(t)); !ok {
+		t.Error("a coplanar quilt should resolve one plane")
+	}
+	box, _ := Stitch(boxFaces(2, 2, 2), 0, false, "box")
+	if _, ok := BodyPlane(box); ok {
+		t.Error("a multi-plane body should not resolve a single tool plane")
 	}
 }
 


### PR DESCRIPTION
#1880 (Surfaces parity, milestone #44). Pins oblikovati.org/api v0.142.4 (Oblikovati.API#271).

Trim's cutting tool was limited to an implicit plane. It now resolves any of:
- **`toolRef`** — a work plane or planar face (`"plane/N"`, `"origin/plane/xy"`, or a face key), via `PlaneTargetFromRef`.
- **`toolBodyIndex`** — a **planar surface body** as the tool (new kernel `ops.BodyPlane` extracts its plane; a multi-plane/curved tool errors cleanly).
- **`toolSketchIndex` + `toolLineIndex`** — a **straight sketch line**, swept along its sketch normal into the cutting plane (`Line.Axis3D` × sketch normal).

Each resolves to a cutting plane and reuses the existing `TrimFeature` / `ops.TrimByPlane`, so the model/serialize layers are unchanged. Curved tool surfaces, curved sketch curves, and multi-region selection (>2 pieces) remain phase C — documented on the issue.

Kernel `BodyPlane` test (single/coplanar → plane, multi-plane → false) + router tool-resolution tests. Live-verified against the running head (see issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)