### PR TITLE
surface: Sculpt per-surface direction / affected body / selection (#1881)

### DIFF
--- a/addin/opregistry/apply_success_test.go
+++ b/addin/opregistry/apply_success_test.go
@@ -153,6 +153,20 @@ func TestMidSurfaceFacePairs(t *testing.T) {
 	}
 }
 
+// TestSculptSurfaces covers the #1881 router path: bounding surfaces with per-surface directions
+// and an affected-body index parse and dispatch (result or a descriptive error, never a panic).
+func TestSculptSurfaces(t *testing.T) {
+	s, _, _ := extrudedSolid(t)
+	args, _ := json.Marshal(map[string]any{
+		"operation":         "new",
+		"surfaces":          []map[string]any{{"bodyIndex": 0, "direction": "positive"}},
+		"affectedBodyIndex": 0,
+	})
+	if _, err := apply(t, s, "sculpt", string(args)); err != nil && err.Error() == "" {
+		t.Error("sculpt surfaces returned an empty error")
+	}
+}
+
 // TestTrimCuttingTools covers the #1880 trim tool resolution: a work-plane tool and a sketch-line
 // tool resolve to a cutting plane (result or a descriptive error, never a resolution panic); a
 // multi-plane surface-body tool and an empty request error clearly.

--- a/addin/opregistry/feature_surface.go
+++ b/addin/opregistry/feature_surface.go
@@ -142,7 +142,9 @@ const sculptSchema = `{
   "type": "object",
   "properties": {
     "operation": {"type": "string", "enum": ["new", "join", "cut"], "default": "new"},
-    "tolerance": {"type": "string", "description": "Sculpt tolerance, e.g. \"0.1 mm\".", "default": "0.1 mm"}
+    "tolerance": {"type": "string", "description": "Sculpt tolerance, e.g. \"0.1 mm\".", "default": "0.1 mm"},
+    "surfaces": {"type": "array", "items": {"type": "object", "properties": {"bodyIndex": {"type": "integer", "minimum": 0}, "direction": {"type": "string", "enum": ["positive", "negative"]}}, "required": ["bodyIndex"]}, "description": "Bounding surfaces with the side (direction) facing the volume; omit to weld all running surfaces (a closed quilt)."},
+    "affectedBodyIndex": {"type": "integer", "minimum": 0, "description": "Body join/cut targets (default the last solid)."}
   }
 }`
 
@@ -461,7 +463,12 @@ func applySculpt(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	pf := feature.NewSculptFeatures(part.Features()).Add(op, tol)
+	def := &feature.SculptDefinition{Operation: op, Tolerance: tol, AffectedIndex: in.AffectedBodyIndex}
+	for _, srf := range in.Surfaces {
+		def.BodyIndices = append(def.BodyIndices, srf.BodyIndex)
+		def.Directions = append(def.Directions, srf.Direction == "positive") // else keep the −normal side
+	}
+	pf := feature.NewSculptFeatures(part.Features()).AddSculpt(def)
 	return recomputeResult(part, pf)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.142.4
+	oblikovati.org/api v0.142.5
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.142.4
+	oblikovati.org/api v0.142.5
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/kernel/ops/sculpt_directed.go
+++ b/kernel/ops/sculpt_directed.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"errors"
+	"fmt"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// SculptDirected builds the solid enclosed by a set of PLANAR bounding surfaces, each with a
+// keep-side flag naming the direction that faces the volume — Inventor's directed sculpt, where a
+// per-surface direction disambiguates the enclosed region of OPEN bounding surfaces (#1881). It
+// starts from a bounding cube around the surfaces and cuts it by each surface's directed halfspace;
+// the intersection is the enclosed solid. keepPositive[i] keeps the surface's +normal side (its
+// −normal side otherwise). Curved or non-convex bounding surfaces are phase C.
+func SculptDirected(surfaces []*topo.Body, keepPositive []bool, feat string) (*topo.Body, error) {
+	if len(surfaces) < 2 || len(keepPositive) != len(surfaces) {
+		return nil, errors.New("sculpt: need at least two bounding surfaces, one direction each")
+	}
+	solid, err := boundingCube(surfaces, feat)
+	if err != nil {
+		return nil, err
+	}
+	for i, surf := range surfaces {
+		pl, ok := BodyPlane(surf)
+		if !ok {
+			return nil, fmt.Errorf("sculpt: bounding surface %d is not planar", i)
+		}
+		n := pl.Normal()
+		if keepPositive[i] {
+			n = n.Scale(-1) // HalfSpaceCut keeps the side OPPOSITE the plane normal
+		}
+		cut, err := geom.NewPlane(pl.Origin, n)
+		if err != nil {
+			return nil, fmt.Errorf("sculpt: bounding surface %d: %w", i, err)
+		}
+		if solid, err = brep.HalfSpaceCut(solid, cut); err != nil {
+			return nil, fmt.Errorf("sculpt: cut by surface %d: %w", i, err)
+		}
+	}
+	if r := Validate(solid); !r.Valid || !solid.IsSolid() {
+		return nil, fmt.Errorf("sculpt: directed surfaces do not bound a solid %v", r.Issues)
+	}
+	return solid, nil
+}
+
+// boundingCube returns a solid box enclosing all the surfaces with a margin, so the directed
+// halfspace cuts (not the box) bound the sculpted solid.
+func boundingCube(surfaces []*topo.Body, feat string) (*topo.Body, error) {
+	pts := make([]math.Point3, 0, 2*len(surfaces))
+	for _, s := range surfaces {
+		bb := s.RangeBox()
+		pts = append(pts, bb.Min, bb.Max)
+	}
+	box := math.BoxFromPoints(pts...)
+	m := float64(box.Diagonal().Length())*0.1 + 1
+	mv := math.V3(m, m, m)
+	return brep.SolidBlock(box.Min.TranslateBy(mv.Scale(-1)), box.Max.TranslateBy(mv), feat)
+}

--- a/kernel/ops/sculpt_directed_test.go
+++ b/kernel/ops/sculpt_directed_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+)
+
+// TestSculptDirectedFromBoxFaces closes the six outward-facing box planes (keep each −normal side,
+// the inside) into the solid box they bound — volume 32 for a 4×4×2 box (#1881).
+func TestSculptDirectedFromBoxFaces(t *testing.T) {
+	faces := boxFaces(4, 4, 2)
+	keep := make([]bool, len(faces)) // false = keep the −normal (inside) side of each outward face
+	solid, err := SculptDirected(faces, keep, "sc")
+	if err != nil {
+		t.Fatalf("SculptDirected: %v", err)
+	}
+	if !solid.IsSolid() {
+		t.Fatal("directed sculpt should yield a solid")
+	}
+	if v := BodyGeometryProperties(solid, DefaultQuality()).Volume; stdmath.Abs(v-32) > 0.1 {
+		t.Errorf("volume = %g, want 32 (the 4×4×2 box the planes bound)", v)
+	}
+}
+
+// TestSculptDirectedErrors: fewer than two surfaces, or a mismatched direction count, errors.
+func TestSculptDirectedErrors(t *testing.T) {
+	faces := boxFaces(2, 2, 2)
+	if _, err := SculptDirected(faces[:1], []bool{false}, "sc"); err == nil {
+		t.Error("a single bounding surface should error")
+	}
+	if _, err := SculptDirected(faces, []bool{false}, "sc"); err == nil {
+		t.Error("a direction count that does not match the surfaces should error")
+	}
+}

--- a/model/feature/sculpt_stitch.go
+++ b/model/feature/sculpt_stitch.go
@@ -4,6 +4,7 @@ package feature
 
 import (
 	"errors"
+	"fmt"
 
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
@@ -70,15 +71,21 @@ type KnitFeatures = StitchFeatures
 // NewKnitFeatures binds a knit (alias of stitch) collection to an engine.
 func NewKnitFeatures(engine *PartFeatures) *KnitFeatures { return NewStitchFeatures(engine) }
 
-// SculptDefinition is the recipe for a sculpt: the operation against existing
-// material and the coincidence tolerance for closing the bounding surfaces.
+// SculptDefinition is the recipe for a sculpt: the operation against existing material, the
+// coincidence tolerance for closing the bounding surfaces, and the #1881 options. Directions gives
+// a per-bounding-surface keep-positive side (empty ⇒ closed-quilt stitch); BodyIndices selects the
+// bounding surfaces (empty ⇒ all running bodies); AffectedIndex targets a body for join/cut.
 type SculptDefinition struct {
-	Operation ops.PartFeatureOperation
-	Tolerance float64
+	Operation     ops.PartFeatureOperation
+	Tolerance     float64
+	Directions    []bool
+	BodyIndices   []int
+	AffectedIndex *int
 }
 
-// SculptFeature fills a volume bounded by the running surface bodies, producing a
-// solid (PBI-110). The bounding surfaces must enclose a closed cell.
+// SculptFeature fills a volume bounded by the running surface bodies, producing a solid (PBI-110).
+// Closed quilts weld into the solid; open bounding surfaces are closed by their per-surface
+// directions (#1881). new adds a body; join/cut boolean it into the affected solid.
 type SculptFeature struct {
 	def      *SculptDefinition
 	featName string
@@ -90,20 +97,91 @@ func (s *SculptFeature) Definition() *SculptDefinition { return s.def }
 // Kind implements [Feature].
 func (s *SculptFeature) Kind() string { return "sculpt" }
 
-// Recompute welds the bounding surfaces into a solid; if they do not enclose a
-// volume (the quilt is open) the feature goes sick — it cannot define a region.
+// Recompute builds the sculpted solid from the selected bounding surfaces (welding a closed quilt,
+// or intersecting the directed halfspaces of open surfaces) and combines it per the operation.
 func (s *SculptFeature) Recompute(in Input) (Output, error) {
 	if len(in.Bodies) == 0 {
 		return Output{}, errors.New("sculpt: no bounding surfaces in the running state")
 	}
-	solid, err := ops.Stitch(in.Bodies, s.def.Tolerance, false, s.featName)
+	surfaces, others := s.partition(in.Bodies)
+	if len(surfaces) == 0 {
+		return Output{}, errors.New("sculpt: no bounding surfaces selected")
+	}
+	solid, err := s.buildSolid(surfaces)
 	if err != nil {
 		return Output{}, err
 	}
-	if !solid.IsSolid() {
-		return Output{}, errors.New("sculpt: bounding surfaces do not enclose a volume")
+	if s.def.Operation == ops.Cut || s.def.Operation == ops.Join {
+		return sculptBoolean(others, solid, s.def.Operation, s.def.AffectedIndex)
 	}
-	return Output{Bodies: []*topo.Body{solid}}, nil
+	return Output{Bodies: append(others, solid)}, nil // new body
+}
+
+// partition splits the running bodies into the selected bounding surfaces and the rest (which carry
+// through and hold the affected body for join/cut). No selection ⇒ every body is a bounding surface.
+func (s *SculptFeature) partition(bodies []*topo.Body) (surfaces, others []*topo.Body) {
+	if len(s.def.BodyIndices) == 0 {
+		return bodies, nil
+	}
+	picked := map[int]bool{}
+	for _, i := range s.def.BodyIndices { // preserve the caller's order so Directions[i] aligns
+		if i >= 0 && i < len(bodies) {
+			surfaces = append(surfaces, bodies[i])
+			picked[i] = true
+		}
+	}
+	for i, b := range bodies {
+		if !picked[i] {
+			others = append(others, b)
+		}
+	}
+	return surfaces, others
+}
+
+// buildSolid welds a closed quilt into a solid, or — with per-surface directions — intersects the
+// directed halfspaces of the (possibly open) bounding surfaces.
+func (s *SculptFeature) buildSolid(surfaces []*topo.Body) (*topo.Body, error) {
+	if len(s.def.Directions) > 0 {
+		return ops.SculptDirected(surfaces, s.def.Directions, s.featName)
+	}
+	solid, err := ops.Stitch(surfaces, s.def.Tolerance, false, s.featName)
+	if err != nil {
+		return nil, err
+	}
+	if !solid.IsSolid() {
+		return nil, errors.New("sculpt: bounding surfaces do not enclose a volume")
+	}
+	return solid, nil
+}
+
+// sculptBoolean combines the sculpted solid into the affected body (index into the carried bodies,
+// default the last solid), leaving the other carried bodies untouched.
+func sculptBoolean(others []*topo.Body, solid *topo.Body, op ops.PartFeatureOperation, affected *int) (Output, error) {
+	target := sculptTarget(others, affected)
+	if target < 0 {
+		return Output{}, fmt.Errorf("sculpt %s: no solid body to modify", op)
+	}
+	result, err := ops.Boolean(op, others[target], solid)
+	if err != nil {
+		return Output{}, fmt.Errorf("sculpt %s: %w", op, err)
+	}
+	out := append([]*topo.Body(nil), others...)
+	out[target] = result
+	return Output{Bodies: out}, nil
+}
+
+// sculptTarget returns the index (into others) of the affected body: the given index if it is a
+// valid solid, else the most recent solid, or -1.
+func sculptTarget(others []*topo.Body, affected *int) int {
+	if affected != nil && *affected >= 0 && *affected < len(others) && others[*affected].IsSolid() {
+		return *affected
+	}
+	for i := len(others) - 1; i >= 0; i-- {
+		if others[i].IsSolid() {
+			return i
+		}
+	}
+	return -1
 }
 
 // SculptFeatures adds sculpt features into the engine.
@@ -112,9 +190,13 @@ type SculptFeatures struct{ engine *PartFeatures }
 // NewSculptFeatures binds the collection to a feature engine.
 func NewSculptFeatures(engine *PartFeatures) *SculptFeatures { return &SculptFeatures{engine: engine} }
 
-// Add fills the volume bounded by the running surfaces, combining via op.
+// Add fills the volume bounded by the running surfaces, combining via op (closed-quilt form).
 func (c *SculptFeatures) Add(op ops.PartFeatureOperation, tolerance float64) *PartFeature {
-	def := &SculptDefinition{Operation: op, Tolerance: tolerance}
+	return c.AddSculpt(&SculptDefinition{Operation: op, Tolerance: tolerance})
+}
+
+// AddSculpt fills the volume bounded by the (optionally directed / selected) surfaces per def (#1881).
+func (c *SculptFeatures) AddSculpt(def *SculptDefinition) *PartFeature {
 	sf := &SculptFeature{def: def, featName: "Sculpt"}
 	pf := c.engine.Add(sf)
 	sf.featName = pf.name

--- a/model/feature/sculpt_stitch_test.go
+++ b/model/feature/sculpt_stitch_test.go
@@ -10,6 +10,7 @@ import (
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 	"oblikovati.org/model/health"
+	"oblikovati.org/model/sketch"
 )
 
 // cubeFaceBody builds one outward-oriented quad surface body of the unit cube.
@@ -108,6 +109,66 @@ func TestSculptFillsBoundedVolume(t *testing.T) {
 	// The filled volume spans the unit cube.
 	if d := body.RangeBox().Diagonal(); !approxEq(d.X, 1) || !approxEq(d.Y, 1) || !approxEq(d.Z, 1) {
 		t.Errorf("sculpt box diagonal = %v, want (1,1,1)", d)
+	}
+}
+
+// TestSculptDirectedFillsVolume is #1881: with an explicit direction per bounding surface (keep the
+// inside of each outward cube face), sculpt intersects the directed halfspaces into the unit solid.
+func TestSculptDirectedFillsVolume(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	NewBaseFeatures(fs).AddBase(unitCubeFaces()...)
+	pf := NewSculptFeatures(fs).AddSculpt(&SculptDefinition{Operation: ops.NewBody, Directions: make([]bool, 6)})
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("directed sculpt went unhealthy: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	if !body.IsSolid() {
+		t.Fatal("directed sculpt should fill a solid")
+	}
+	if v := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; !approxEq(v, 1) {
+		t.Errorf("directed sculpt volume = %g, want 1 (unit cube)", v)
+	}
+}
+
+// TestSculptBodySelectionKeepsOthers is #1881: sculpting only the selected bounding surfaces leaves
+// an unselected body untouched alongside the new sculpted solid.
+func TestSculptBodySelectionKeepsOthers(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	NewBaseFeatures(fs).AddBase(unitCubeFaces()...)                                                          // bodies 0..5: cube faces
+	NewBaseFeatures(fs).AddBase(buildPrism(squarePoly(10), sketch.XYPlane(), span{near: 0, far: 1}, 0, "b")) // body 6: a far solid
+	pf := NewSculptFeatures(fs).AddSculpt(&SculptDefinition{Operation: ops.NewBody, BodyIndices: []int{0, 1, 2, 3, 4, 5}, Directions: make([]bool, 6)})
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("body-selected sculpt sick: %+v", pf.Health())
+	}
+	if got := len(fs.Result()); got != 2 {
+		t.Fatalf("result = %d bodies, want 2 (the far solid + the sculpted cube)", got)
+	}
+}
+
+// TestSculptOptionsRoundTrip pins #1881 serialization: directions, body selection, and the affected
+// index survive the recipe codec.
+func TestSculptOptionsRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	affected := 2
+	NewSculptFeatures(fs).AddSculpt(&SculptDefinition{
+		Operation: ops.Cut, Tolerance: 0.01, Directions: []bool{true, false, true}, BodyIndices: []int{0, 1, 3}, AffectedIndex: &affected,
+	})
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	if d := data[0].Sculpt; len(d.Directions) != 3 || len(d.BodyIndices) != 3 || d.AffectedIndex == nil || *d.AffectedIndex != 2 {
+		t.Fatalf("serialized sculpt = %+v", d)
+	}
+	fresh := NewPartFeatures(nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	def := fresh.Item(0).Definition().(*SculptFeature).Definition()
+	if len(def.Directions) != 3 || !def.Directions[0] || def.Directions[1] || len(def.BodyIndices) != 3 || def.AffectedIndex == nil || *def.AffectedIndex != 2 {
+		t.Errorf("restored sculpt = %+v", def)
 	}
 }
 

--- a/model/feature/serialize_surface_edits.go
+++ b/model/feature/serialize_surface_edits.go
@@ -175,8 +175,11 @@ func restoreStitch(fs *PartFeatures, d *StitchData) (*PartFeature, error) {
 // SculptData is a sculpt's recipe: the boolean operation against existing material and the
 // coincidence tolerance for closing the bounding surfaces.
 type SculptData struct {
-	Operation string  `yaml:"operation"`
-	Tolerance float64 `yaml:"tolerance"`
+	Operation     string  `yaml:"operation"`
+	Tolerance     float64 `yaml:"tolerance"`
+	Directions    []bool  `yaml:"directions,omitempty"`    // #1881: per-surface keep-positive
+	BodyIndices   []int   `yaml:"bodyIndices,omitempty"`   // #1881: bounding-surface selection
+	AffectedIndex *int    `yaml:"affectedIndex,omitempty"` // #1881: join/cut target
 }
 
 func serializeSculpt(def *SculptDefinition) (*SculptData, error) {
@@ -184,7 +187,10 @@ func serializeSculpt(def *SculptDefinition) (*SculptData, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &SculptData{Operation: op, Tolerance: def.Tolerance}, nil
+	return &SculptData{
+		Operation: op, Tolerance: def.Tolerance,
+		Directions: def.Directions, BodyIndices: def.BodyIndices, AffectedIndex: def.AffectedIndex,
+	}, nil
 }
 
 func restoreSculpt(fs *PartFeatures, d *SculptData) (*PartFeature, error) {
@@ -195,5 +201,8 @@ func restoreSculpt(fs *PartFeatures, d *SculptData) (*PartFeature, error) {
 	if err != nil {
 		return nil, fmt.Errorf("sculpt feature operation: %w", err)
 	}
-	return NewSculptFeatures(fs).Add(op, d.Tolerance), nil
+	return NewSculptFeatures(fs).AddSculpt(&SculptDefinition{
+		Operation: op, Tolerance: d.Tolerance,
+		Directions: d.Directions, BodyIndices: d.BodyIndices, AffectedIndex: d.AffectedIndex,
+	}), nil
 }


### PR DESCRIPTION
#1881 (Surfaces parity, milestone #44). Pins oblikovati.org/api v0.142.5 (Oblikovati.API#272).

Sculpt was operation-ignoring, whole-part, fixed-side. It now:
- **Applies the operation** — `new` adds a body; `join`/`cut` boolean the sculpted solid into the **affected body** (`affectedBodyIndex`, default the last solid), leaving other bodies untouched (the operation was previously stored but ignored).
- **Selects bounding surfaces** — `surfaces[].bodyIndex` picks which running surface bodies bound the volume; unselected bodies carry through.
- **Per-surface direction** — `surfaces[].direction` (positive|negative) names which side of each bounding surface faces the volume. New kernel `ops.SculptDirected` closes **open** planar bounding surfaces by intersecting their directed halfspaces (a bounding cube clipped by each surface's `brep.HalfSpaceCut`). Without directions it welds a closed quilt as before.

Curved / non-convex bounding surfaces remain phase C. Kernel (box faces → the vol-32 box they bound; unit cube → vol 1), model (directed fill, body selection keeps others, options round-trip), and router tests. Live-verified against the running head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)