### PR TITLE
surface: Boundary patch over a 3D edge loop with G1/G2 blend (#1867)

### DIFF
--- a/addin/opregistry/apply_success_test.go
+++ b/addin/opregistry/apply_success_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"oblikovati.org/app"
+	"oblikovati.org/model/feature"
 )
 
 // twoBodyPart extrudes two separate new bodies so the boolean/combine ops have a target
@@ -115,7 +116,9 @@ func TestModifyAndPatternOperations(t *testing.T) {
 		{"surfaceOffset", withSolid(func(e, f string) map[string]any { return map[string]any{"faceRefs": []string{f}, "distance": "1 mm"} })},
 		{"midSurface", withSolid(func(e, f string) map[string]any { return map[string]any{"faceRefs": []string{f}} })},
 		{"ruledSurface", withSolid(func(e, f string) map[string]any { return map[string]any{"edgeRefs": []string{e}, "distance": "2 mm"} })},
-		{"boundaryPatch", withSolid(func(e, f string) map[string]any { return map[string]any{"edgeRefs": []string{e}} })},
+		{"boundaryPatch", withSolid(func(e, f string) map[string]any {
+			return map[string]any{"edgeLoopRefs": []string{e}, "condition": "curvature"}
+		})},
 		{"extend", withSolid(func(e, f string) map[string]any { return map[string]any{"edgeRefs": []string{e}, "distance": "1 mm"} })},
 		{"stitch", withSolid(func(e, f string) map[string]any { return map[string]any{"faceRefs": []string{f}} })},
 		{"patternRectangular", withSolid(func(e, f string) map[string]any {
@@ -153,6 +156,26 @@ func TestRuledSurfaceSweepOptions(t *testing.T) {
 	}
 	if _, err := apply(t, profiledPart(t), "ruledSurface", `{"sketchIndex":0,"distance":"3 mm","type":"sweep"}`); err == nil {
 		t.Error("sweep with no direction should error")
+	}
+}
+
+// TestBoundaryPatchConditionMapping covers the #1867 router condition parse: free/tangent/curvature/
+// continuous map to G0/G1/G2, and an edge-loop request dispatches to the 3D fill (a solid's lone edge
+// cannot close a loop, so a descriptive error — never a panic — is acceptable).
+func TestBoundaryPatchConditionMapping(t *testing.T) {
+	cases := map[string]feature.PatchCondition{
+		"free": feature.PatchFree, "tangent": feature.PatchTangent,
+		"curvature": feature.PatchCurvature, "continuous": feature.PatchCurvature, "": feature.PatchFree,
+	}
+	for name, want := range cases {
+		if got := patchCondition(name); got != want {
+			t.Errorf("patchCondition(%q) = %v, want %v", name, got, want)
+		}
+	}
+	s, edge, _ := extrudedSolid(t)
+	loop, _ := json.Marshal(map[string]any{"edgeLoopRefs": []string{edge}, "condition": "curvature"})
+	if _, err := apply(t, s, "boundaryPatch", string(loop)); err != nil && err.Error() == "" {
+		t.Error("boundaryPatch edge-loop returned an empty error")
 	}
 }
 

--- a/addin/opregistry/feature_surface.go
+++ b/addin/opregistry/feature_surface.go
@@ -28,15 +28,17 @@ import (
 const boundaryPatchSchema = `{
   "type": "object",
   "properties": {
-    "sketchIndex": {"type": "integer", "minimum": 0},
+    "sketchIndex": {"type": "integer", "minimum": 0, "description": "Planar sketch loop to fill (omit when edgeLoopRefs is given)."},
     "profileIndex": {"type": "integer", "minimum": 0, "default": 0},
-    "condition": {"type": "string", "enum": ["free", "tangent"], "default": "free", "description": "Edge continuity to neighbouring faces."}
-  },
-  "required": ["sketchIndex"]
+    "condition": {"type": "string", "enum": ["free", "tangent", "curvature", "continuous"], "default": "free", "description": "Edge continuity to the adjacent faces: free (G0), tangent (G1), curvature/continuous (G2)."},
+    "edgeLoopRefs": {"type": "array", "items": {"type": "string"}, "description": "Reference keys of surface-body boundary edges forming a (possibly non-planar) loop to fill with a NURBS patch (get_reference_keys)."},
+    "guideRailRefs": {"type": "array", "items": {"type": "string"}, "description": "Interior guide-rail curves the patch interpolates (reserved)."},
+    "tangentWeight": {"type": "number", "description": "Tangent-pull magnitude for tangent/curvature blends (reserved)."}
+  }
 }`
 
 func boundaryPatchDescriptor() *OperationDescriptor {
-	return &OperationDescriptor{Name: featureargs.KindBoundaryPatch, Summary: "Fill a closed sketch loop with a surface patch.", Schema: json.RawMessage(boundaryPatchSchema), Apply: applyBoundaryPatch}
+	return &OperationDescriptor{Name: featureargs.KindBoundaryPatch, Summary: "Fill a closed sketch loop or 3D edge loop with a surface patch.", Schema: json.RawMessage(boundaryPatchSchema), Apply: applyBoundaryPatch}
 }
 
 func applyBoundaryPatch(s *app.Session, raw json.RawMessage) (json.RawMessage, error) {
@@ -44,16 +46,30 @@ func applyBoundaryPatch(s *app.Session, raw json.RawMessage) (json.RawMessage, e
 	if err != nil {
 		return nil, err
 	}
+	patches := feature.NewBoundaryPatchFeatures(part.Features())
+	if len(in.EdgeLoopRefs) > 0 {
+		pf := patches.AddEdgeLoop(refKeys(in.EdgeLoopRefs), patchCondition(in.Condition), refKeys(in.GuideRailRefs), in.TangentWeight)
+		return recomputeResult(part, pf)
+	}
 	sk, err := sketchAt(part, in.SketchIndex)
 	if err != nil {
 		return nil, err
 	}
-	cond := feature.PatchFree
-	if strings.EqualFold(in.Condition, "tangent") {
-		cond = feature.PatchTangent
-	}
-	pf := feature.NewBoundaryPatchFeatures(part.Features()).Add(sk, in.ProfileIndex, cond)
+	pf := patches.Add(sk, in.ProfileIndex, patchCondition(in.Condition))
 	return recomputeResult(part, pf)
+}
+
+// patchCondition maps the wire continuity name to the model's PatchCondition: tangent → G1,
+// curvature/continuous → G2, anything else (incl. "free") → G0.
+func patchCondition(name string) feature.PatchCondition {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "tangent":
+		return feature.PatchTangent
+	case "curvature", "continuous":
+		return feature.PatchCurvature
+	default:
+		return feature.PatchFree
+	}
 }
 
 // --- ruled surface ---------------------------------------------------------

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.143.0
+	oblikovati.org/api v0.144.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.143.0
+	oblikovati.org/api v0.144.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/kernel/ops/fill_edge_loop.go
+++ b/kernel/ops/fill_edge_loop.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+)
+
+// Boundary-patch fill over an explicit 3D edge loop (#1867). Where FillNSided derives its bounding
+// edges from whole neighbour bodies (their inner iso-edges), a boundary patch is handed the loop
+// directly — a set of surface-body boundary edges, possibly non-planar. Each edge contributes its
+// curve and, when it borders a NURBS face, that face for the tangent/curvature (G1/G2) match; the
+// loop then feeds the same Coons + MatchSurface fill as the N-sided opening (fillFromBoundaryEdges).
+
+// FillEdgeLoop fills the closed loop of surface-body edges with one NURBS at the requested continuity
+// order (0=G0…2=G2), matching to each edge's adjacent surface face where it borders a NURBS surface.
+// An edge bordering only a planar/other face fills position-only (G0) on its side. It errors when the
+// edges do not chain into a single closed loop.
+func FillEdgeLoop(edges []*topo.Edge, order int) (*topo.Body, error) {
+	if len(edges) < 3 {
+		return nil, fmt.Errorf("ops.FillEdgeLoop: needs at least 3 boundary edges, have %d", len(edges))
+	}
+	bes := make([]boundaryEdge, len(edges))
+	for i, e := range edges {
+		bes[i] = boundaryFromEdge(e)
+	}
+	return fillFromBoundaryEdges(bes, order)
+}
+
+// boundaryFromEdge builds the fill boundary for a topo edge: its curve, and — when the edge borders a
+// NURBS surface face — that surface plus the nearest of its four iso-boundaries (so MatchSurface can
+// impose tangent/curvature on that side). An edge bordering only planar/other faces fills G0.
+func boundaryFromEdge(e *topo.Edge) boundaryEdge {
+	curve := curveAsBSpline(e.Geometry())
+	lo, hi := curve.Domain()
+	mid := curve.PointAt((lo + hi) / 2)
+	for _, f := range e.Faces() {
+		if bs, ok := f.Geometry().(geom.BSplineSurface); ok {
+			return boundaryEdge{curve: curve, surface: bs, edge: innerEdge(bs, mid), nurbs: true}
+		}
+	}
+	return boundaryEdge{curve: curve}
+}
+
+// fillFromBoundaryEdges fills the opening bounded by the given inner boundary edges (each already
+// carrying its adjacent surface for the continuity match) with one NURBS: chain into a loop, map onto
+// four compatible quad sides (splitting when <4, merging when >4), then Coons + MatchSurface. It is
+// the shared tail of both the N-sided-opening fill and the edge-loop boundary patch.
+func fillFromBoundaryEdges(edges []boundaryEdge, order int) (*topo.Body, error) {
+	loop, err := orderLoop(edges)
+	if err != nil {
+		return nil, err
+	}
+	for len(loop) < 4 {
+		loop = splitLongestEdge(loop)
+	}
+	c0, c1, d0, d1, err := chainLoop(groupToFourSides(loop))
+	if err != nil {
+		return nil, fmt.Errorf("ops.fillFromBoundaryEdges: %w", err)
+	}
+	if err = makeSidesCompatible(&c0, &c1, &d0, &d1); err != nil {
+		return nil, fmt.Errorf("ops.fillFromBoundaryEdges: %w", err)
+	}
+	sides := [4]geom.FillSide{fillSide(c0, order), fillSide(c1, order), fillSide(d0, order), fillSide(d1, order)}
+	fill, err := geom.FillSurface(c0.curve, c1.curve, d0.curve, d1.curve, sides)
+	if err != nil {
+		return nil, fmt.Errorf("ops.fillFromBoundaryEdges: %w", err)
+	}
+	return fullDomainBody(fill, "fill"), nil
+}

--- a/kernel/ops/fill_edge_loop_test.go
+++ b/kernel/ops/fill_edge_loop_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// nearestBoundaryEdge returns the body face's boundary edge whose midpoint is closest to center — the
+// inner edge of a neighbour facing the opening, as a *topo.Edge for FillEdgeLoop.
+func nearestBoundaryEdge(t *testing.T, b *topo.Body, center math.Point3) *topo.Edge {
+	t.Helper()
+	var best *topo.Edge
+	bestD := stdmath.Inf(1)
+	for _, f := range b.Faces() {
+		for _, l := range f.Loops() {
+			for _, u := range l.EdgeUses() {
+				e := u.Edge()
+				c := e.Geometry()
+				lo, hi := c.Domain()
+				if d := float64(c.PointAt((lo + hi) / 2).DistanceTo(center)); d < bestD {
+					best, bestD = e, d
+				}
+			}
+		}
+	}
+	if best == nil {
+		t.Fatal("no boundary edge found")
+	}
+	return best
+}
+
+// innerLoopEdges collects each neighbour's inner boundary edge (facing the origin) into a loop.
+func innerLoopEdges(t *testing.T, bodies []*topo.Body) []*topo.Edge {
+	t.Helper()
+	edges := make([]*topo.Edge, len(bodies))
+	for i, b := range bodies {
+		edges[i] = nearestBoundaryEdge(t, b, math.P3(0, 0, 0))
+	}
+	return edges
+}
+
+// TestFillEdgeLoopClosesFourSided fills the square opening from an explicit loop of four surface-body
+// edges (the #1867 3D-edge-loop input) and checks it interpolates the loop corners (G0 closure).
+func TestFillEdgeLoopClosesFourSided(t *testing.T) {
+	bodies, verts := polygonNeighbours(t, 4, 1, flat)
+	out, err := ops.FillEdgeLoop(innerLoopEdges(t, bodies), 1)
+	if err != nil {
+		t.Fatalf("FillEdgeLoop(4): %v", err)
+	}
+	fill, ok := out.Faces()[0].Geometry().(geom.BSplineSurface)
+	if !ok {
+		t.Fatalf("fill face is %T, want BSplineSurface", out.Faces()[0].Geometry())
+	}
+	fillInterpolatesVertices(t, fill, verts)
+}
+
+// TestFillEdgeLoopNonPlanar fills a NON-planar five-edge loop (alternating corner heights) — the
+// headline #1867 case: a boundary patch over a 3D edge loop, not just a planar sketch profile.
+func TestFillEdgeLoopNonPlanar(t *testing.T) {
+	z := func(i int) float64 {
+		if i%2 == 0 {
+			return 0.3
+		}
+		return -0.3
+	}
+	bodies, verts := polygonNeighbours(t, 5, 1, z)
+	out, err := ops.FillEdgeLoop(innerLoopEdges(t, bodies), 2)
+	if err != nil {
+		t.Fatalf("FillEdgeLoop(non-planar 5): %v", err)
+	}
+	fill, ok := out.Faces()[0].Geometry().(geom.BSplineSurface)
+	if !ok {
+		t.Fatalf("fill face is %T, want BSplineSurface", out.Faces()[0].Geometry())
+	}
+	fillInterpolatesVertices(t, fill, verts)
+	// The loop is genuinely non-planar: at least one corner sits off z=0.
+	off := false
+	for _, v := range verts {
+		if stdmath.Abs(float64(v.Z)) > 1e-6 {
+			off = true
+		}
+	}
+	if !off {
+		t.Fatal("test setup error: the loop is planar")
+	}
+}
+
+// TestFillEdgeLoopTooFew: fewer than three edges cannot bound an opening.
+func TestFillEdgeLoopTooFew(t *testing.T) {
+	bodies, _ := polygonNeighbours(t, 4, 1, flat)
+	edges := innerLoopEdges(t, bodies)
+	if _, err := ops.FillEdgeLoop(edges[:2], 1); err == nil {
+		t.Error("FillEdgeLoop with 2 edges should error")
+	}
+}

--- a/kernel/ops/fill_nsided.go
+++ b/kernel/ops/fill_nsided.go
@@ -21,7 +21,8 @@ import (
 // N-sided G2 convergence limit.
 
 // FillNSided fills the opening bounded by neighbours (3 or more single-face surface bodies) with one
-// NURBS at the requested continuity order. With exactly four neighbours it is the four-sided fill.
+// NURBS at the requested continuity order. With exactly four neighbours it is the four-sided fill;
+// otherwise the N inner edges chain onto four compatible quad sides via the shared edge-loop fill.
 func FillNSided(neighbours []*topo.Body, order int) (*topo.Body, error) {
 	if len(neighbours) < 3 {
 		return nil, fmt.Errorf("ops.FillNSided: needs at least 3 bounding surfaces, have %d", len(neighbours))
@@ -29,40 +30,11 @@ func FillNSided(neighbours []*topo.Body, order int) (*topo.Body, error) {
 	if len(neighbours) == 4 {
 		return FillFourSided([4]*topo.Body{neighbours[0], neighbours[1], neighbours[2], neighbours[3]}, order)
 	}
-	c0, c1, d0, d1, err := quadSidesFromOpening(neighbours)
+	edges, err := openingEdgesN(neighbours)
 	if err != nil {
 		return nil, err
 	}
-	sides := [4]geom.FillSide{fillSide(c0, order), fillSide(c1, order), fillSide(d0, order), fillSide(d1, order)}
-	fill, err := geom.FillSurface(c0.curve, c1.curve, d0.curve, d1.curve, sides)
-	if err != nil {
-		return nil, fmt.Errorf("ops.FillNSided: %w", err)
-	}
-	return fullDomainBody(fill, "fill"), nil
-}
-
-// quadSidesFromOpening maps the N inner edges of the opening onto the four compatible, oriented quad
-// sides (chain → quad-ify by splitting → group into four → make opposite pairs knot-compatible).
-func quadSidesFromOpening(neighbours []*topo.Body) (c0, c1, d0, d1 boundaryEdge, err error) {
-	edges, err := openingEdgesN(neighbours)
-	if err != nil {
-		return c0, c1, d0, d1, err
-	}
-	loop, err := orderLoop(edges)
-	if err != nil {
-		return c0, c1, d0, d1, err
-	}
-	for len(loop) < 4 {
-		loop = splitLongestEdge(loop)
-	}
-	c0, c1, d0, d1, err = chainLoop(groupToFourSides(loop))
-	if err != nil {
-		return c0, c1, d0, d1, fmt.Errorf("ops.FillNSided: %w", err)
-	}
-	if err = makeSidesCompatible(&c0, &c1, &d0, &d1); err != nil {
-		return c0, c1, d0, d1, fmt.Errorf("ops.FillNSided: %w", err)
-	}
-	return c0, c1, d0, d1, nil
+	return fillFromBoundaryEdges(edges, order)
 }
 
 // makeSidesCompatible refines the two opposite side pairs (c0/c1 in u, d0/d1 in v) to share degree

--- a/model/feature/serialize_surface.go
+++ b/model/feature/serialize_surface.go
@@ -13,9 +13,15 @@ import (
 // distance). Like extrude, they reference their input sketch by index via the
 // SketchIndexer.
 
-// BoundaryPatchData is a boundary patch's recipe: the closed sketch loops it fills.
+// BoundaryPatchData is a boundary patch's recipe: either the closed sketch loops it fills, or (the
+// #1867 3D form) the surface-body boundary-edge keys, the fill continuity, and the reserved
+// guide-rail keys / tangent weight.
 type BoundaryPatchData struct {
-	Loops []PatchLoopData `yaml:"loops"`
+	Loops         []PatchLoopData `yaml:"loops,omitempty"`
+	EdgeKeys      []string        `yaml:"edgeKeys,omitempty"`
+	Condition     string          `yaml:"condition,omitempty"`
+	GuideRailKeys []string        `yaml:"guideRailKeys,omitempty"`
+	TangentWeight float64         `yaml:"tangentWeight,omitempty"`
 }
 
 // PatchLoopData is one boundary loop: a sketch profile and its continuity condition.
@@ -38,6 +44,16 @@ type RuledSurfaceData struct {
 }
 
 func serializeBoundaryPatch(def *BoundaryPatchDefinition, sk SketchIndexer) (*BoundaryPatchData, error) {
+	if len(def.EdgeKeys) > 0 {
+		cond, err := patchConditionName(def.Condition)
+		if err != nil {
+			return nil, err
+		}
+		return &BoundaryPatchData{
+			EdgeKeys: encodeKeys(def.EdgeKeys), Condition: cond,
+			GuideRailKeys: encodeKeys(def.GuideRailKeys), TangentWeight: def.TangentWeight,
+		}, nil
+	}
 	if def.Loops == nil || def.Loops.Count() == 0 {
 		return nil, fmt.Errorf("boundary patch has no loops")
 	}
@@ -58,7 +74,13 @@ func serializeBoundaryPatch(def *BoundaryPatchDefinition, sk SketchIndexer) (*Bo
 }
 
 func restoreBoundaryPatch(fs *PartFeatures, d *BoundaryPatchData, sk SketchIndexer) (*PartFeature, error) {
-	if d == nil || len(d.Loops) == 0 {
+	if d == nil {
+		return nil, fmt.Errorf("boundary-patch feature is missing its payload")
+	}
+	if len(d.EdgeKeys) > 0 {
+		return restoreEdgeLoopPatch(fs, d)
+	}
+	if len(d.Loops) == 0 {
 		return nil, fmt.Errorf("boundary-patch feature is missing its loops")
 	}
 	first, err := resolvePatchLoop(d.Loops[0], sk)
@@ -75,6 +97,24 @@ func restoreBoundaryPatch(fs *PartFeatures, d *BoundaryPatchData, sk SketchIndex
 		pf.feature.(*BoundaryPatchFeature).def.Loops.Add(more.skt, more.profile, more.cond)
 	}
 	return pf, nil
+}
+
+// restoreEdgeLoopPatch restores the #1867 3D edge-loop boundary patch: decode the boundary-edge keys,
+// continuity, and reserved guide-rail keys / tangent weight.
+func restoreEdgeLoopPatch(fs *PartFeatures, d *BoundaryPatchData) (*PartFeature, error) {
+	edges, err := decodeKeys(d.EdgeKeys)
+	if err != nil {
+		return nil, fmt.Errorf("boundary-patch edge keys: %w", err)
+	}
+	rails, err := decodeKeys(d.GuideRailKeys)
+	if err != nil {
+		return nil, fmt.Errorf("boundary-patch guide-rail keys: %w", err)
+	}
+	cond, err := parsePatchCondition(d.Condition)
+	if err != nil {
+		return nil, err
+	}
+	return NewBoundaryPatchFeatures(fs).AddEdgeLoop(edges, cond, rails, d.TangentWeight), nil
 }
 
 // patchLoopInputs is the resolved (sketch, profile, condition) of one loop.

--- a/model/feature/surface.go
+++ b/model/feature/surface.go
@@ -9,6 +9,7 @@ import (
 	stdmath "math"
 
 	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 	"oblikovati.org/model/sketch"
@@ -58,10 +59,17 @@ func (ls *BoundaryPatchLoops) Add(skt *sketch.Sketch, profileIndex int, cond Pat
 func (ls *BoundaryPatchLoops) Count() int                    { return len(ls.items) }
 func (ls *BoundaryPatchLoops) Item(i int) *BoundaryPatchLoop { return ls.items[i] }
 
-// BoundaryPatchDefinition is the recipe for a boundary patch: the boundary loops it
-// fills. Phase A fills the first closed planar loop (with the others as holes).
+// BoundaryPatchDefinition is the recipe for a boundary patch. Loops is the planar-sketch form (the
+// first closed loop is filled, the others cut as holes). EdgeKeys is the non-planar 3D edge-loop form
+// (#1867): reference keys of surface-body boundary edges filled with a NURBS that blends to their
+// adjacent faces at Condition continuity (free/tangent/curvature → G0/G1/G2). GuideRailKeys and
+// TangentWeight are recorded for the interior-interpolation phase (accepted, not yet honoured).
 type BoundaryPatchDefinition struct {
-	Loops *BoundaryPatchLoops
+	Loops         *BoundaryPatchLoops
+	EdgeKeys      [][]byte
+	Condition     PatchCondition
+	GuideRailKeys [][]byte
+	TangentWeight float64
 }
 
 // BoundaryPatchFeature fills a closed boundary with a trimmed surface patch.
@@ -81,6 +89,9 @@ func (b *BoundaryPatchFeature) Kind() string { return "boundary-patch" }
 // planar loop satisfies any condition vacuously (there is no adjacent face to blend
 // to). Patching a non-planar 3D boundary is the NURBS phase-B case (deferred).
 func (b *BoundaryPatchFeature) Recompute(in Input) (Output, error) {
+	if len(b.def.EdgeKeys) > 0 {
+		return b.fillEdgeLoop(in)
+	}
 	if b.def.Loops == nil || b.def.Loops.Count() == 0 {
 		return Output{}, errors.New("boundary patch: no boundary loops")
 	}
@@ -91,6 +102,56 @@ func (b *BoundaryPatchFeature) Recompute(in Input) (Output, error) {
 	}
 	patch := buildPlanarPatch(profile, loop.Sketch.Plane(), b.featName)
 	return Output{Bodies: appendBody(in.Bodies, patch)}, nil
+}
+
+// fillEdgeLoop fills a non-planar 3D edge loop taken from surface-body boundary edges with a NURBS
+// patch that blends to the adjacent faces at the definition's continuity (#1867).
+func (b *BoundaryPatchFeature) fillEdgeLoop(in Input) (Output, error) {
+	edges, err := resolveLoopEdges(in.Bodies, b.def.EdgeKeys)
+	if err != nil {
+		return Output{}, err
+	}
+	patch, err := ops.FillEdgeLoop(edges, patchContinuityOrder(b.def.Condition))
+	if err != nil {
+		return Output{}, fmt.Errorf("boundary patch: %w", err)
+	}
+	return Output{Bodies: appendBody(in.Bodies, patch)}, nil
+}
+
+// resolveLoopEdges resolves each boundary-edge reference key against the running bodies.
+func resolveLoopEdges(bodies []*topo.Body, keys [][]byte) ([]*topo.Edge, error) {
+	edges := make([]*topo.Edge, 0, len(keys))
+	for _, k := range keys {
+		e, ok := findEdgeByKey(bodies, k)
+		if !ok {
+			return nil, fmt.Errorf("boundary patch: edge %x not found in the model", k)
+		}
+		edges = append(edges, e)
+	}
+	return edges, nil
+}
+
+// findEdgeByKey looks a reference key up across all running bodies.
+func findEdgeByKey(bodies []*topo.Body, key []byte) (*topo.Edge, bool) {
+	for _, bd := range bodies {
+		if e, ok := bd.FindEdgeByKey(key); ok {
+			return e, true
+		}
+	}
+	return nil, false
+}
+
+// patchContinuityOrder maps a patch condition to the fill's NURBS continuity order (free→G0,
+// tangent→G1, curvature→G2).
+func patchContinuityOrder(c PatchCondition) int {
+	switch c {
+	case PatchTangent:
+		return 1
+	case PatchCurvature:
+		return 2
+	default:
+		return 0
+	}
 }
 
 // BoundaryPatchFeatures adds boundary patches into the engine.
@@ -105,7 +166,19 @@ func NewBoundaryPatchFeatures(engine *PartFeatures) *BoundaryPatchFeatures {
 func (c *BoundaryPatchFeatures) Add(skt *sketch.Sketch, profileIndex int, cond PatchCondition) *PartFeature {
 	loops := &BoundaryPatchLoops{}
 	loops.Add(skt, profileIndex, cond)
-	bf := &BoundaryPatchFeature{def: &BoundaryPatchDefinition{Loops: loops}, featName: "BoundaryPatch"}
+	return c.add(&BoundaryPatchDefinition{Loops: loops})
+}
+
+// AddEdgeLoop fills a non-planar loop of surface-body boundary edges (reference keys) with a NURBS
+// patch at the given continuity, blending to the loop's adjacent faces (#1867). guideRails and
+// tangentWeight are recorded for a later interior-interpolation phase.
+func (c *BoundaryPatchFeatures) AddEdgeLoop(edgeKeys [][]byte, cond PatchCondition, guideRails [][]byte, tangentWeight float64) *PartFeature {
+	return c.add(&BoundaryPatchDefinition{EdgeKeys: edgeKeys, Condition: cond, GuideRailKeys: guideRails, TangentWeight: tangentWeight})
+}
+
+// add registers a boundary-patch feature from its definition and back-fills the feature name.
+func (c *BoundaryPatchFeatures) add(def *BoundaryPatchDefinition) *PartFeature {
+	bf := &BoundaryPatchFeature{def: def, featName: "BoundaryPatch"}
 	pf := c.engine.Add(bf)
 	bf.featName = pf.name
 	return pf

--- a/model/feature/surface_test.go
+++ b/model/feature/surface_test.go
@@ -129,6 +129,37 @@ func TestBoundaryPatchGoesSickOnOpenProfile(t *testing.T) {
 	}
 }
 
+// TestBoundaryPatchEdgeLoopRoundTrip: the #1867 3D edge-loop patch (edge keys, curvature continuity,
+// guide-rail keys, tangent weight) survives marshal→restore.
+func TestBoundaryPatchEdgeLoopRoundTrip(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	NewBoundaryPatchFeatures(fs).AddEdgeLoop([][]byte{{1, 2}, {3, 4}, {5, 6}}, PatchCurvature, [][]byte{{9, 9}}, 0.75)
+	data, err := fs.MarshalRecipe(oneSketch{})
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil)
+	if err := fresh.ApplyRecipe(data, oneSketch{}, nil); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	d := fresh.Item(0).Definition().(*BoundaryPatchFeature).Definition()
+	if len(d.EdgeKeys) != 3 || d.Condition != PatchCurvature {
+		t.Errorf("restored patch = {edges:%d cond:%v}, want {3 PatchCurvature}", len(d.EdgeKeys), d.Condition)
+	}
+	if len(d.GuideRailKeys) != 1 || d.TangentWeight != 0.75 {
+		t.Errorf("restored rails/weight = {%d %v}, want {1 0.75}", len(d.GuideRailKeys), d.TangentWeight)
+	}
+}
+
+// TestPatchContinuityOrder maps free/tangent/curvature to the G0/G1/G2 fill order.
+func TestPatchContinuityOrder(t *testing.T) {
+	for c, want := range map[PatchCondition]int{PatchFree: 0, PatchTangent: 1, PatchCurvature: 2} {
+		if got := patchContinuityOrder(c); got != want {
+			t.Errorf("patchContinuityOrder(%v) = %d, want %d", c, got, want)
+		}
+	}
+}
+
 func TestRuledSurfaceBuildsBand(t *testing.T) {
 	fs := NewPartFeatures(nil)
 	pf := NewRuledSurfaceFeatures(fs).AddByDistance(squareSketch(2), 0, RuledNormal, func() float64 { return 3 })


### PR DESCRIPTION
Closes #1867 (the last of the 9 M44 Surfaces parity issues).

Broadens the boundary patch from a planar sketch loop to a **non-planar 3D loop of surface-body boundary edges**, filled with a NURBS that blends to the loop's adjacent faces at the requested continuity.

### Kernel
- `ops.FillEdgeLoop(edges []*topo.Edge, order int)` resolves each topo edge to its curve plus — where it borders a NURBS face — that surface and its nearest iso-boundary, then feeds the existing Coons + `MatchSurface` fill.
- Extracted `fillFromBoundaryEdges` from `FillNSided` so the N-sided-opening fill and the edge-loop patch share one tail (no duplication; `FillNSided`'s 4-neighbour path is untouched).
- A planar-bordered edge fills position-only (G0) on its side; a NURBS-bordered edge matches to G1/G2.

### Model / router
- `BoundaryPatchDefinition` gains `EdgeKeys` / `Condition` / `GuideRailKeys` / `TangentWeight`; `Recompute` routes an edge-loop patch through `FillEdgeLoop` at the condition's order (free/tangent/curvature → G0/G1/G2). Serialize codec carries the new fields (`omitempty` — planar sketch patches round-trip unchanged).
- Router `boundaryPatch` accepts `edgeLoopRefs`, `condition: curvature`/`continuous` (G2), `guideRailRefs`, `tangentWeight`.

### Acceptance criteria
- [x] `condition` accepts `curvature`/`continuous` (G2) alongside free/tangent.
- [x] Fills a **non-planar 3D edge loop** taken from surface-body edges (kernel `TestFillEdgeLoopNonPlanar`; live-verified).
- [x] tangent/curvature blend to the adjacent NURBS face (order-2 `MatchSurface` on bicubic neighbours; underlying G1/G2 proven by `match_surface_test.go`).
- [ ] **Guide rails + per-entity tangent weight** — accepted in the contract/model/router and recorded, but interior-curve interpolation is **not yet honoured**. Tracked as a follow-up (needs the Gordon/network-surface interior path). Filing a sub-issue.

### Live verification (oblikovati-head)
Capping the open top of a ruled 200 mm square tube via its **four top edges** took the surface area from `24000 mm²` (4 walls) to exactly `64000 mm²` — the `+40000` being the 200×200 mm NURBS cap over the 3D edge loop. Screenshot confirms the closed top.

### Tests
Kernel: four-edge + non-planar five-edge fill (interpolation), <3-edge error. Model: edge-loop serialize round-trip, continuity-order map. Router: condition mapping + edge-loop dispatch.

Pins `oblikovati.org/api` v0.144.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)