### PR TITLE
fix(brep): take a face's holes from the traced inner boundaries

### DIFF
--- a/kernel/brep/arrange2d_adjacent_holes_test.go
+++ b/kernel/brep/arrange2d_adjacent_holes_test.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// Regression for Oblikovati#2030: a face's holes must come from the arrangement's CLOCKWISE
+// (inner-boundary) cycles, not from re-nesting its counter-clockwise ones by containment. The two
+// agree only while the regions inside a face are pairwise disjoint; when two of them are ADJACENT,
+// containment nesting emits BOTH as holes and the boundary they share is written twice.
+
+// unitSquare returns the segments of an axis-aligned rectangle.
+func rectSegments(x0, y0, x1, y1 float64) [][2]math.Point2 {
+	c := []math.Point2{math.P2(math.Scalar(x0), math.Scalar(y0)), math.P2(math.Scalar(x1), math.Scalar(y0)),
+		math.P2(math.Scalar(x1), math.Scalar(y1)), math.P2(math.Scalar(x0), math.Scalar(y1))}
+	out := make([][2]math.Point2, 0, 4)
+	for i := range c {
+		out = append(out, [2]math.Point2{c[i], c[(i+1)%4]})
+	}
+	return out
+}
+
+// TestArrangeAdjacentRegionsFormOneHole is the reduced form of the defect. Inside a big outer
+// square sit two rectangles that SHARE an edge — the arrangement has three bounded regions (each
+// rectangle, and the outer frame around them). The frame's inner boundary is ONE loop running
+// around the pair; emitting the two rectangles as two separate holes would write their shared edge
+// twice, which downstream becomes an edge whose two uses lie on the same face.
+func TestArrangeAdjacentRegionsFormOneHole(t *testing.T) {
+	var segs [][2]math.Point2
+	segs = append(segs, rectSegments(0, 0, 10, 10)...) // outer frame
+	segs = append(segs, rectSegments(2, 2, 5, 6)...)   // left cell
+	segs = append(segs, rectSegments(5, 2, 8, 6)...)   // right cell, sharing the x=5 edge
+
+	frame := faceWithOuterArea(t, Arrange(segs), 100)
+	if len(frame.Holes) != 1 {
+		t.Fatalf("frame has %d holes, want 1 — two adjacent regions form ONE connected opening", len(frame.Holes))
+	}
+	// The single hole must run around the union (2..8 in x, 2..6 in y), not around one cell.
+	lo, hi := boundsOf(frame.Holes[0])
+	if lo.X != 2 || hi.X != 8 || lo.Y != 2 || hi.Y != 6 {
+		t.Errorf("hole spans [%v %v]..[%v %v], want [2 2]..[8 6] (the union of both cells)", lo.X, lo.Y, hi.X, hi.Y)
+	}
+	// The shared x=5 edge is interior to the opening, so it must not appear on the frame at all.
+	for _, p := range frame.Holes[0] {
+		if p.X == 5 && p.Y > 2 && p.Y < 6 {
+			t.Errorf("the shared edge at x=5 leaked onto the frame's boundary at %v", p)
+		}
+	}
+}
+
+// TestArrangeDisjointRegionsStayTwoHoles pins the other side: two regions that do NOT touch are
+// two separate openings, and must stay two holes.
+func TestArrangeDisjointRegionsStayTwoHoles(t *testing.T) {
+	var segs [][2]math.Point2
+	segs = append(segs, rectSegments(0, 0, 10, 10)...)
+	segs = append(segs, rectSegments(2, 2, 4, 6)...)
+	segs = append(segs, rectSegments(6, 2, 8, 6)...)
+
+	if frame := faceWithOuterArea(t, Arrange(segs), 100); len(frame.Holes) != 2 {
+		t.Errorf("frame has %d holes, want 2 — the cells are disjoint openings", len(frame.Holes))
+	}
+}
+
+// TestArrangeNestedFramesKeepTheirOwnHole pins multi-level nesting: three concentric squares give a
+// frame whose hole is the middle square, and a middle frame whose hole is the inner square — each
+// hole assigned to its DIRECT parent, not to the outermost face.
+func TestArrangeNestedFramesKeepTheirOwnHole(t *testing.T) {
+	var segs [][2]math.Point2
+	segs = append(segs, rectSegments(0, 0, 10, 10)...)
+	segs = append(segs, rectSegments(2, 2, 8, 8)...)
+	segs = append(segs, rectSegments(4, 4, 6, 6)...)
+	faces := Arrange(segs)
+
+	outer := faceWithOuterArea(t, faces, 100)
+	if len(outer.Holes) != 1 {
+		t.Fatalf("outer frame has %d holes, want 1", len(outer.Holes))
+	}
+	if lo, hi := boundsOf(outer.Holes[0]); lo.X != 2 || hi.X != 8 {
+		t.Errorf("outer frame's hole spans x %v..%v, want 2..8 (the middle square)", lo.X, hi.X)
+	}
+	middle := faceWithOuterArea(t, faces, 36)
+	if len(middle.Holes) != 1 {
+		t.Fatalf("middle frame has %d holes, want 1", len(middle.Holes))
+	}
+	if lo, hi := boundsOf(middle.Holes[0]); lo.X != 4 || hi.X != 6 {
+		t.Errorf("middle frame's hole spans x %v..%v, want 4..6 (the inner square)", lo.X, hi.X)
+	}
+}
+
+// faceWithOuterArea returns the arranged face whose outer loop encloses the given area.
+func faceWithOuterArea(t *testing.T, faces []Face2D, area float64) Face2D {
+	t.Helper()
+	for _, f := range faces {
+		if a := signedArea2D(f.Outer); a > area-1e-6 && a < area+1e-6 {
+			return f
+		}
+	}
+	t.Fatalf("no arranged face of area %v (got %d faces)", area, len(faces))
+	return Face2D{}
+}
+
+// boundsOf returns a loop's axis-aligned bounds.
+func boundsOf(loop []math.Point2) (lo, hi math.Point2) {
+	lo, hi = loop[0], loop[0]
+	for _, p := range loop {
+		lo = math.P2(min(lo.X, p.X), min(lo.Y, p.Y))
+		hi = math.P2(max(hi.X, p.X), max(hi.Y, p.Y))
+	}
+	return lo, hi
+}

--- a/kernel/brep/arrange2d_trace.go
+++ b/kernel/brep/arrange2d_trace.go
@@ -77,38 +77,61 @@ func sortAround(pts []math.Point2, hes []halfEdge) (map[int][]int, []int) {
 	return outgoing, pos
 }
 
-// nestFaces keeps the counter-clockwise cycles as face outer loops and assigns each
-// directly-enclosing relationship: a CCW cycle nested one level inside another becomes a
-// hole of it (and remains a face in its own right — the arrangement of disjoint loops).
+// nestFaces turns the traced cycles into faces: every COUNTER-CLOCKWISE cycle bounds a face,
+// and every CLOCKWISE cycle is an INNER boundary — it becomes a hole of the face it encloses.
+//
+// The holes must come from the clockwise cycles, not from re-nesting the counter-clockwise ones by
+// containment (Oblikovati#2030). Both describe the same nesting only while the regions inside a
+// face are pairwise DISJOINT. When two of them are ADJACENT — they share an edge, so the
+// complement component they form is one connected region — containment nesting makes BOTH a hole
+// of the parent, and the boundary they share is then emitted twice, once per hole loop. Downstream
+// that lands as an edge whose two uses are on the SAME face: the face is no longer a disk-with-
+// holes, so its χ = V−E+2F−L is off by one per shared edge and the solid is rejected as
+// topologically inadmissible (a camera PCB whose mounting hole straddled the footprint of a block
+// joined on top of it: 31 doubled edges, χ = −31).
+//
+// The half-edge walk already answers this exactly. A face lies to the LEFT of every half-edge on
+// its boundary, so its outer boundary traces counter-clockwise and each of its inner boundaries
+// traces CLOCKWISE — and an inner boundary that runs around several adjacent regions is traced as
+// the ONE cycle it is. Taking the clockwise cycles as the holes therefore yields ∂(A∪B) once
+// instead of ∂A and ∂B twice, and is identical to the old behaviour on disjoint nesting.
 func nestFaces(cycles [][]math.Point2) []Face2D {
-	var ccw [][]math.Point2
+	var ccw, cw [][]math.Point2
 	for _, c := range cycles {
-		if len(c) >= 3 && signedArea2D(c) > arrTol {
+		switch a := signedArea2D(c); {
+		case len(c) < 3:
+		case a > arrTol:
 			ccw = append(ccw, c)
+		case a < -arrTol:
+			cw = append(cw, c)
 		}
 	}
 	faces := make([]Face2D, len(ccw))
 	for i, c := range ccw {
 		faces[i] = Face2D{Outer: c}
 	}
-	for i, inner := range ccw {
-		if p := smallestContainer(ccw, i); p >= 0 {
-			faces[p].Holes = append(faces[p].Holes, reversedLoop(inner))
+	for _, hole := range cw {
+		if p := enclosingFace(ccw, hole); p >= 0 {
+			faces[p].Holes = append(faces[p].Holes, hole)
 		}
 	}
 	return faces
 }
 
-// smallestContainer returns the index of the smallest CCW cycle strictly containing
-// cycle i (its direct parent in the nesting), or −1 if it is top-level. The probe sits
-// just inside cycle i's boundary (an edge midpoint nudged inward), so it is in cycle i's
-// own region — not at a shared-boundary vertex (ambiguous) and not near the centre where a
-// concentric inner cycle would swallow it (which made a frame look nested in its own hole).
-func smallestContainer(ccw [][]math.Point2, i int) int {
-	probe := probeJustInside(ccw[i])
+// enclosingFace returns the index of the smallest counter-clockwise cycle containing the clockwise
+// cycle `hole` — the face `hole` is an inner boundary of — or −1 when there is none (the
+// arrangement's outermost clockwise cycle, which bounds the unbounded region).
+//
+// The probe sits just to the LEFT of the hole's first edge. A face lies to the left of its boundary
+// half-edges, so for a clockwise inner boundary that is a point in the enclosing face itself —
+// OUTSIDE the area the hole encloses. That is what makes the containment test unambiguous: it never
+// samples a shared-boundary vertex, and never lands inside the hole where a nested cycle could
+// swallow it.
+func enclosingFace(ccw [][]math.Point2, hole []math.Point2) int {
+	probe := probeLeftOfFirstEdge(hole)
 	best, bestArea := -1, stdmath.Inf(1)
 	for j, c := range ccw {
-		if j == i || !pointInPolygon2D(probe, c) {
+		if !pointInPolygon2D(probe, c) {
 			continue
 		}
 		if a := signedArea2D(c); a < bestArea {
@@ -118,20 +141,13 @@ func smallestContainer(ccw [][]math.Point2, i int) int {
 	return best
 }
 
-// probeJustInside returns a point just inside a CCW loop near its first edge: the edge
-// midpoint nudged along the inward (left) normal by a small fraction of the edge length.
-func probeJustInside(loop []math.Point2) math.Point2 {
+// probeLeftOfFirstEdge returns a point just to the left of a loop's first edge: the edge midpoint
+// nudged along the left normal by a small fraction of the edge length. "Left" is the face side of
+// any boundary half-edge — the loop's interior for a CCW loop, its exterior for a CW one.
+func probeLeftOfFirstEdge(loop []math.Point2) math.Point2 {
 	a, b := loop[0], loop[1]
 	e := a.VectorTo(b)
 	mid := math.P2((a.X+b.X)/2, (a.Y+b.Y)/2)
-	left := math.V2(-e.Y, e.X)               // interior side of a CCW loop
+	left := math.V2(-e.Y, e.X)               // face side of a boundary half-edge
 	return mid.TranslateBy(left.Scale(1e-4)) // tol:calibrated — interior-probe nudge (see arrange2d arrTol)
-}
-
-func reversedLoop(loop []math.Point2) []math.Point2 {
-	out := make([]math.Point2, len(loop))
-	for i, p := range loop {
-		out[len(loop)-1-i] = p
-	}
-	return out
 }

--- a/kernel/ops/boolean_straddling_hole_test.go
+++ b/kernel/ops/boolean_straddling_hole_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Regression for Oblikovati#2030 at the solid level: joining a block onto a plate whose HOLE
+// straddles the block's footprint edge must leave a valid solid of the right genus.
+//
+// The plate's top plane then carries two openings that TOUCH — the block footprint and the hole —
+// so they bound one connected region. Nesting them as two separate hole loops wrote their shared
+// arcs twice, giving a face with edges whose two uses lay on that same face; χ = V−E+2F−L then
+// drifted by one per doubled edge. With one hole that landed on an EVEN χ and slipped through
+// [Validate]; with two it went odd and the solid was rejected outright (a Raspberry-Pi camera PCB
+// whose two mounting holes straddled the flex-connector block: χ = −31 across 31 doubled edges).
+
+// plateWithStraddledHole builds the configuration: a 2.5 × 2.4 × 0.1 plate whose top face is at
+// z = 0, drilled by one Ø0.21 hole centred at (0.2, 0.96), FACETED (as an upstream join would
+// leave it), then a block joined on top whose footprint edge at y = 1.05 crosses that hole — whose
+// far side reaches y = 1.065, so a thin crescent stays outside the block.
+func plateWithStraddledHole(t *testing.T, holeCenters ...math.Point2) *topo.Body {
+	t.Helper()
+	body, err := brep.SolidBlock(math.P3(-1.25, -1.2, -0.1), math.P3(1.25, 1.2, 0), "plate")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	for _, c := range holeCenters {
+		drill, err := brep.SolidCylinder(math.P3(c.X, c.Y, -0.2), math.V3(0, 0, 1), 0.105, 0.4)
+		if err != nil {
+			t.Fatalf("SolidCylinder: %v", err)
+		}
+		if body, err = Boolean(Cut, body, drill); err != nil {
+			t.Fatalf("drill at %v: %v", c, err)
+		}
+	}
+	// A curved operand forces the planar boolean's faceting fallback upstream of the join; do it
+	// explicitly so this test pins the planar path rather than whatever the fallback picks.
+	body = brep.UnifyCoplanarFaces(Facet(body, "facet"), "unify")
+
+	block, err := brep.SolidBlock(math.P3(-0.4, 0.55, 0), math.P3(0.4, 1.05, 0.1), "block")
+	if err != nil {
+		t.Fatalf("SolidBlock: %v", err)
+	}
+	joined, err := Boolean(Join, body, block)
+	if err != nil {
+		t.Fatalf("join: %v", err)
+	}
+	return joined
+}
+
+// sameFaceSeamEdges counts edges whose TWO uses lie on one face. A cylinder's seam is a legitimate
+// instance (the face is still a disk once cut along it); one on a PLANAR face is the doubled
+// boundary this regression guards against.
+func sameFaceSeamEdges(b *topo.Body) int {
+	n := 0
+	for _, e := range b.Edges() {
+		if us := e.Uses(); len(us) == 2 && us[0].Loop().Face() == us[1].Loop().Face() {
+			n++
+		}
+	}
+	return n
+}
+
+func TestJoinOverAStraddlingHoleKeepsOneOpening(t *testing.T) {
+	joined := plateWithStraddledHole(t, math.P2(0.2, 0.96))
+	if got := sameFaceSeamEdges(joined); got != 0 {
+		t.Errorf("%d edge(s) have both uses on one face — the shared boundary was written twice", got)
+	}
+	// One through-hole survives (the crescent keeps it open), so the solid is genus 1: χ = 2−2g = 0.
+	if got := joined.EulerCharacteristic(); got != 0 {
+		t.Errorf("χ = %d, want 0 (one through-hole ⇒ genus 1)", got)
+	}
+	if r := Validate(joined); !r.Valid {
+		t.Errorf("joined solid invalid: %v", r.Issues)
+	}
+}
+
+// TestTwoStraddlingHolesStayOnTheExactPath is the camera's own shape — TWO straddled holes — and
+// pins the COST of the defect rather than only its symptom. With both holes the doubled edges made
+// the planar result invalid, so [booleanGeneral]'s guard threw it away and adopted the triangle-soup
+// CSG fallback instead: a valid solid of the right genus, but 5726 faces where the exact planar
+// path gives 77. That silent 74× demotion is what shattered the camera into facets, and asserting
+// a low face count is what makes this a real guard — the χ and validity checks alone pass either
+// way, because the fallback rescues them.
+func TestTwoStraddlingHolesStayOnTheExactPath(t *testing.T) {
+	joined := plateWithStraddledHole(t, math.P2(0.2, 0.96), math.P2(-0.2, 0.96))
+	if got := len(joined.Faces()); got > 200 {
+		t.Errorf("join produced %d faces — the exact planar path was abandoned for triangle CSG", got)
+	}
+	if got := sameFaceSeamEdges(joined); got != 0 {
+		t.Errorf("%d edge(s) have both uses on one face", got)
+	}
+	// Two through-holes survive (each keeps a crescent open), so the solid is genus 2: χ = 2−2g.
+	if got := joined.EulerCharacteristic(); got != -2 {
+		t.Errorf("χ = %d, want -2 (two through-holes ⇒ genus 2)", got)
+	}
+	if r := Validate(joined); !r.Valid {
+		t.Errorf("joined solid invalid: %v", r.Issues)
+	}
+}


### PR DESCRIPTION
## What

A planar face's hole loops were rebuilt by re-nesting the 2D arrangement's **counter-clockwise**
cycles by containment. That matches the real nesting only while the regions inside a face are
pairwise **disjoint**. When two of them are **adjacent** — they share an edge, so the opening they
form is one connected region — both became holes of the parent and their shared boundary was
written **twice**.

Holes now come from the traced **clockwise** cycles instead. A face lies to the LEFT of every
half-edge on its boundary, so its outer boundary traces CCW and each of its inner boundaries traces
CW — and an inner boundary running around several adjacent regions is traced as the one cycle it
is. That yields `∂(A∪B)` once rather than `∂A` and `∂B` twice, and is identical to the previous
result on disjoint nesting.

## Why it mattered

A doubled boundary lands as an edge whose two uses are on the **same face**, so the face is no
longer a disk-with-holes and `χ = V−E+2F−L` drifts by one per doubled edge.

Joining a block onto a plate whose hole **straddles** the block's footprint hits it directly:

| | before | after |
|---|---|---|
| one straddled hole | 15 doubled edges, χ = −16 (want 0) | 0 doubled edges, χ = 0 |
| two straddled holes | χ odd → exact result discarded, **5726** faces via CSG | **77** faces, χ = −2 |

With one hole the drift landed on an *even* χ and passed `ops.Validate` silently. With two it went
odd — impossible for a closed orientable solid — so `booleanGeneral`'s guard threw the exact planar
result away and adopted the triangle-soup CSG fallback, shattering the body into facets. That is
what failed `TestNopRpiCameraV1` / `TestPTCameraAssembly` in Oblikovati.AddIns.MCPBridge, on a
Raspberry-Pi camera PCB whose two mounting holes straddled the flex-connector block: **χ = −31
across 31 doubled edges**.

## Tests

- `kernel/brep`: adjacent regions form ONE hole; disjoint regions stay TWO; concentric frames each
  keep their own direct hole (the two non-regression sides).
- `kernel/ops`: the straddled-hole join keeps a valid genus-1 solid with no same-face seam edge,
  and the two-hole case stays on the exact planar path (face-count ceiling).

Each guard was mutation-tested: restoring the old containment nesting fails the adjacent-region and
both solid-level tests, while the disjoint and nested guards keep passing.

Full suite green (110 packages), `golangci-lint run ./kernel/...` clean.

Closes #2030