### PR TITLE
fix(step): give the exported file a product structure so readers find it

### DIFF
--- a/kernel/exchange/step/writer_facade.go
+++ b/kernel/exchange/step/writer_facade.go
@@ -36,22 +36,44 @@ func (Writer) ExportSolids(bodies []*topo.Body, opts exchange.TranslationOptions
 	}
 	w := part21.NewWriter()
 	emit := geommap.NewEmitter(w, opts.ExportScale()) // database-unit (cm) → file unit
-	emitUnitContext(w, opts.FileUnit)
+	// The product structure comes first so the file reads top-down, and because the geometric
+	// representation context it emits carries the unit declaration the geometry is expressed in.
+	ps := emitProductStructure(w, opts.Name, opts.FileUnit)
+	shapes := make([]int, 0, len(bodies))
+	solids := true
 	for _, body := range bodies {
-		if _, err := topomap.BodyToStep(emit, body); err != nil {
+		id, err := topomap.BodyToStep(emit, body)
+		if err != nil {
 			return nil, nil, err
 		}
+		shapes = append(shapes, id)
+		solids = solids && body.IsSolid()
 	}
-	return w.Emit(ap203Header()), nil, nil
+	// Without this the DATA section is unreachable geometry: a conformant reader enters at
+	// SHAPE_DEFINITION_REPRESENTATION and would find nothing to show (#2055).
+	emitShapeRepresentation(w, ps, shapes, solids)
+	return w.Emit(ap203Header()), mixedBodyWarnings(bodies), nil
 }
 
-// emitUnitContext emits the file's SI (mm/cm/m) or conversion-based (in/ft) length
-// unit plus a unit-assigned context, so the file's lengths are unambiguous on
-// re-import. An empty unit defaults to millimetres. The reader locates the unit by
-// scanning for GLOBAL_UNIT_ASSIGNED_CONTEXT (units.go), so the context id needs no
-// further reference here.
-func emitUnitContext(w *part21.Writer, fileUnit string) {
-	w.Add("GLOBAL_UNIT_ASSIGNED_CONTEXT", part21.FormatList(part21.Ref(lengthUnitRef(w, fileUnit))))
+// mixedBodyWarnings reports a body set that mixes solids and open shells. One shape
+// representation cannot hold both — ADVANCED_BREP_SHAPE_REPRESENTATION takes solid b-reps and
+// MANIFOLD_SURFACE_SHAPE_REPRESENTATION takes surface models — so the file declares the surface
+// form, which readers accept for both, and the user is told the distinction was flattened.
+func mixedBodyWarnings(bodies []*topo.Body) []string {
+	solids, shells := 0, 0
+	for _, b := range bodies {
+		if b.IsSolid() {
+			solids++
+			continue
+		}
+		shells++
+	}
+	if solids > 0 && shells > 0 {
+		return []string{fmt.Sprintf(
+			"step export: %d solid and %d surface bodies share one shape representation; "+
+				"the file declares the surface form, which readers accept for both", solids, shells)}
+	}
+	return nil
 }
 
 // lengthUnitRef emits the LENGTH_UNIT entity for fileUnit and returns its id.

--- a/kernel/exchange/step/writer_product.go
+++ b/kernel/exchange/step/writer_product.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package step
+
+import (
+	"oblikovati.org/kernel/exchange/step/part21"
+)
+
+// The AP203 product structure and shape representation — the entry point every conformant STEP
+// reader walks to find geometry (#2055).
+//
+// The exported file used to be a DATA section of raw geometry ending at MANIFOLD_SOLID_BREP,
+// with no APPLICATION_CONTEXT, no PRODUCT and no shape representation. Our own reader scans for
+// the b-rep entity directly, so the round-trip test passed — but a reader that enters the file
+// the standard way, from SHAPE_DEFINITION_REPRESENTATION down, found nothing to display and
+// opened an empty model. That is the shape of "no geometry in the STEP file" (#2055).
+//
+// The chain a reader follows, and therefore the chain emitted here:
+//
+//	SHAPE_DEFINITION_REPRESENTATION
+//	  → PRODUCT_DEFINITION_SHAPE → PRODUCT_DEFINITION → … → PRODUCT
+//	  → ADVANCED_BREP_SHAPE_REPRESENTATION (in a GEOMETRIC_REPRESENTATION_CONTEXT)
+//	      → MANIFOLD_SOLID_BREP / SHELL_BASED_SURFACE_MODEL
+
+// productStructure holds the ids the shape representation needs to reference.
+type productStructure struct {
+	definitionShape int // PRODUCT_DEFINITION_SHAPE — what the representation is OF
+	context         int // the geometric representation context the shapes live in
+}
+
+// emitProductStructure writes the AP203 product/application context chain and the geometric
+// representation context, returning the ids the shape representation binds to. name labels the
+// product; an empty name becomes "Oblikovati part" so a reader's tree shows something.
+func emitProductStructure(w *part21.Writer, name, fileUnit string) productStructure {
+	if name == "" {
+		name = defaultProductName
+	}
+	appCtx := w.Add("APPLICATION_CONTEXT", part21.QuoteString(ap203ContextName))
+	w.Add("APPLICATION_PROTOCOL_DEFINITION", part21.QuoteString("international standard"),
+		part21.QuoteString("config_control_design"), "1994", part21.Ref(appCtx))
+
+	prodCtx := w.Add("PRODUCT_CONTEXT", part21.QuoteString(""), part21.Ref(appCtx),
+		part21.QuoteString("mechanical"))
+	product := w.Add("PRODUCT", part21.QuoteString(name), part21.QuoteString(name),
+		part21.QuoteString(""), part21.FormatList(part21.Ref(prodCtx)))
+	formation := w.Add("PRODUCT_DEFINITION_FORMATION_WITH_SPECIFIED_SOURCE",
+		part21.QuoteString(""), part21.QuoteString(""), part21.Ref(product), ".NOT_KNOWN.")
+	defCtx := w.Add("PRODUCT_DEFINITION_CONTEXT", part21.QuoteString("part definition"),
+		part21.Ref(appCtx), part21.QuoteString("design"))
+	definition := w.Add("PRODUCT_DEFINITION", part21.QuoteString("design"),
+		part21.QuoteString(""), part21.Ref(formation), part21.Ref(defCtx))
+	defShape := w.Add("PRODUCT_DEFINITION_SHAPE", part21.QuoteString(""),
+		part21.QuoteString(""), part21.Ref(definition))
+
+	return productStructure{definitionShape: defShape, context: emitGeometricContext(w, fileUnit)}
+}
+
+// emitShapeRepresentation binds the emitted b-rep entities to the product, so a reader that
+// starts at SHAPE_DEFINITION_REPRESENTATION reaches the geometry.
+//
+// solids selects ADVANCED_BREP_SHAPE_REPRESENTATION over MANIFOLD_SURFACE_SHAPE_REPRESENTATION:
+// the first is for MANIFOLD_SOLID_BREPs, the second for SHELL_BASED_SURFACE_MODELs, and a reader
+// rejects a representation whose items are of the wrong kind.
+func emitShapeRepresentation(w *part21.Writer, ps productStructure, shapeIDs []int, solids bool) int {
+	items := make([]string, 0, len(shapeIDs)+1)
+	items = append(items, part21.Ref(originPlacement(w))) // the part's own coordinate frame
+	for _, id := range shapeIDs {
+		items = append(items, part21.Ref(id))
+	}
+	keyword := "MANIFOLD_SURFACE_SHAPE_REPRESENTATION"
+	if solids {
+		keyword = "ADVANCED_BREP_SHAPE_REPRESENTATION"
+	}
+	rep := w.Add(keyword, part21.QuoteString(""), part21.FormatList(items...), part21.Ref(ps.context))
+	return w.Add("SHAPE_DEFINITION_REPRESENTATION", part21.Ref(ps.definitionShape), part21.Ref(rep))
+}
+
+// originPlacement emits the identity axis placement every shape representation carries as its
+// first item — the frame the geometry is expressed in.
+func originPlacement(w *part21.Writer) int {
+	origin := w.AddShared("CARTESIAN_POINT", part21.QuoteString(""), "(0.,0.,0.)")
+	z := w.AddShared("DIRECTION", part21.QuoteString(""), "(0.,0.,1.)")
+	x := w.AddShared("DIRECTION", part21.QuoteString(""), "(1.,0.,0.)")
+	return w.Add("AXIS2_PLACEMENT_3D", part21.QuoteString(""),
+		part21.Ref(origin), part21.Ref(z), part21.Ref(x))
+}
+
+// emitGeometricContext emits the combined representation context the shape representation lives
+// in: three dimensions, the length/angle/solid-angle units, and the modelling tolerance.
+//
+// It replaces the bare GLOBAL_UNIT_ASSIGNED_CONTEXT the writer used to emit. A representation
+// must sit in a GEOMETRIC_REPRESENTATION_CONTEXT that also assigns units and an uncertainty; a
+// standalone unit context satisfies neither the schema nor a reader. Our own reader already
+// handles both forms — it scans the complex instance's GLOBAL_UNIT_ASSIGNED_CONTEXT component
+// and picks the length-bearing unit out of the list (units.go) — so the round trip is unaffected.
+func emitGeometricContext(w *part21.Writer, fileUnit string) int {
+	length := lengthUnitRef(w, fileUnit)
+	angle := w.AddRaw("(NAMED_UNIT(*)PLANE_ANGLE_UNIT()SI_UNIT($,.RADIAN.))")
+	solid := w.AddRaw("(NAMED_UNIT(*)SI_UNIT($,.STERADIAN.)SOLID_ANGLE_UNIT())")
+	tol := w.AddRaw("UNCERTAINTY_MEASURE_WITH_UNIT(LENGTH_MEASURE(" +
+		part21.FormatReal(modelTolerance) + ")," + part21.Ref(length) +
+		",'distance_accuracy_value','confusion accuracy')")
+	return w.AddRaw("(GEOMETRIC_REPRESENTATION_CONTEXT(3)" +
+		"GLOBAL_UNCERTAINTY_ASSIGNED_CONTEXT((" + part21.Ref(tol) + "))" +
+		"GLOBAL_UNIT_ASSIGNED_CONTEXT((" + part21.Ref(length) + "," + part21.Ref(angle) +
+		"," + part21.Ref(solid) + "))REPRESENTATION_CONTEXT('',''))")
+}
+
+const (
+	// ap203ContextName is the APPLICATION_CONTEXT description AP203 prescribes.
+	ap203ContextName = "configuration controlled 3d designs of mechanical parts and assemblies"
+	// defaultProductName labels an exported part that carries no name of its own.
+	defaultProductName = "Oblikovati part"
+	// modelTolerance is the distance accuracy declared for the geometry, in FILE units. It is
+	// the conventional 1e-6 relative value readers expect rather than a kernel tolerance.
+	modelTolerance = 1e-6
+)

--- a/kernel/exchange/step/writer_product_test.go
+++ b/kernel/exchange/step/writer_product_test.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package step
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"oblikovati.org/kernel/exchange"
+	"oblikovati.org/kernel/topo"
+)
+
+// #2055: the exported file was a DATA section of raw geometry ending at MANIFOLD_SOLID_BREP,
+// with no APPLICATION_CONTEXT, no PRODUCT and no shape representation. Our own reader scans for
+// the b-rep entity directly so the round trip passed, but a reader that enters the standard way
+// — from SHAPE_DEFINITION_REPRESENTATION down — found nothing and opened an empty model.
+//
+// Verified against OCCT (an independent reader) while fixing: the pre-fix file yields NO shape
+// at all, the post-fix file yields SOLID/6 faces/12 edges/8 vertices. These tests encode the
+// structural invariant so CI holds it without OCCT.
+
+// stepEntities indexes a written file by entity id.
+func stepEntities(t *testing.T, data []byte) map[int]string {
+	t.Helper()
+	out := map[int]string{}
+	re := regexp.MustCompile(`^#(\d+)=(.*);$`)
+	for _, line := range strings.Split(string(data), "\n") {
+		if m := re.FindStringSubmatch(strings.TrimSpace(line)); m != nil {
+			id, _ := strconv.Atoi(m[1])
+			out[id] = m[2]
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("the exported file has no DATA entities at all")
+	}
+	return out
+}
+
+// findEntity returns the id of the single entity whose body starts with keyword.
+func findEntity(t *testing.T, ents map[int]string, keyword string) int {
+	t.Helper()
+	found := -1
+	for id, body := range ents {
+		if strings.HasPrefix(body, keyword+"(") {
+			if found >= 0 {
+				t.Fatalf("%s appears more than once (#%d and #%d)", keyword, found, id)
+			}
+			found = id
+		}
+	}
+	if found < 0 {
+		t.Fatalf("the exported file has no %s — a reader entering the standard way finds no "+
+			"geometry and opens an empty model (#2055)", keyword)
+	}
+	return found
+}
+
+// refsOf lists the #ids an entity body references.
+func refsOf(body string) []int {
+	var out []int
+	for _, m := range regexp.MustCompile(`#(\d+)`).FindAllStringSubmatch(body, -1) {
+		id, _ := strconv.Atoi(m[1])
+		out = append(out, id)
+	}
+	return out
+}
+
+// reachesKeyword walks references from start and reports whether any reachable entity's body
+// starts with keyword — the traversal a reader performs.
+func reachesKeyword(ents map[int]string, start int, keyword string) bool {
+	seen := map[int]bool{}
+	stack := []int{start}
+	for len(stack) > 0 {
+		id := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		body, ok := ents[id]
+		if !ok {
+			continue
+		}
+		if strings.HasPrefix(body, keyword+"(") {
+			return true
+		}
+		stack = append(stack, refsOf(body)...)
+	}
+	return false
+}
+
+// exportBox writes the cube fixture (or an open shell made from it) and returns the file bytes.
+func exportBox(t *testing.T, solid bool) []byte {
+	t.Helper()
+	data, _, err := Writer{}.ExportSolids([]*topo.Body{cubeOrShell(t, solid)},
+		exchange.TranslationOptions{})
+	if err != nil {
+		t.Fatalf("ExportSolids: %v", err)
+	}
+	return data
+}
+
+// cubeOrShell returns the imported cube, or an open-shell body over the same faces — the
+// surface-model case the writer must represent differently.
+func cubeOrShell(t *testing.T, solid bool) *topo.Body {
+	t.Helper()
+	body := importOneSolid(t, "cube.step")
+	if solid {
+		return body
+	}
+	return topo.BodyFromShells(body.Lineage(), false, body.Shells()...)
+}
+
+// TestExportedSolidIsReachableFromTheProductStructure walks the file the way a conformant reader
+// does — SHAPE_DEFINITION_REPRESENTATION down — and requires the b-rep to be reachable.
+func TestExportedSolidIsReachableFromTheProductStructure(t *testing.T) {
+	ents := stepEntities(t, exportBox(t, true))
+	sdr := findEntity(t, ents, "SHAPE_DEFINITION_REPRESENTATION")
+
+	for _, keyword := range []string{
+		"PRODUCT_DEFINITION_SHAPE",
+		"PRODUCT_DEFINITION",
+		"PRODUCT",
+		"APPLICATION_CONTEXT",
+		"ADVANCED_BREP_SHAPE_REPRESENTATION",
+		"MANIFOLD_SOLID_BREP",
+		"CLOSED_SHELL",
+		"ADVANCED_FACE",
+	} {
+		if !reachesKeyword(ents, sdr, keyword) {
+			t.Errorf("%s is not reachable from SHAPE_DEFINITION_REPRESENTATION — a reader "+
+				"walking the file cannot find it (#2055)", keyword)
+		}
+	}
+}
+
+// The representation must sit in a geometric context that assigns units and an uncertainty; a
+// bare GLOBAL_UNIT_ASSIGNED_CONTEXT satisfies neither the schema nor a reader.
+func TestExportedRepresentationHasAGeometricContext(t *testing.T) {
+	data := exportBox(t, true)
+	s := string(data)
+	for _, want := range []string{
+		"GEOMETRIC_REPRESENTATION_CONTEXT(3)",
+		"GLOBAL_UNCERTAINTY_ASSIGNED_CONTEXT",
+		"GLOBAL_UNIT_ASSIGNED_CONTEXT",
+		"UNCERTAINTY_MEASURE_WITH_UNIT",
+		"PLANE_ANGLE_UNIT",
+		"SOLID_ANGLE_UNIT",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("the exported file declares no %s", want)
+		}
+	}
+	// The representation's context reference must BE that combined instance.
+	ents := stepEntities(t, data)
+	rep := findEntity(t, ents, "ADVANCED_BREP_SHAPE_REPRESENTATION")
+	refs := refsOf(ents[rep])
+	ctx := refs[len(refs)-1] // the context is the representation's last parameter
+	if !strings.Contains(ents[ctx], "GEOMETRIC_REPRESENTATION_CONTEXT") {
+		t.Errorf("the representation's context #%d is %q, want the geometric context", ctx, ents[ctx])
+	}
+}
+
+// A surface body takes MANIFOLD_SURFACE_SHAPE_REPRESENTATION: a reader rejects a representation
+// whose items are of the wrong kind, so an open shell must not claim to be a solid b-rep.
+func TestExportedSurfaceBodyUsesTheSurfaceRepresentation(t *testing.T) {
+	s := string(exportBox(t, false))
+	if strings.Contains(s, "ADVANCED_BREP_SHAPE_REPRESENTATION") {
+		t.Error("an open shell was exported as a solid b-rep representation")
+	}
+	if !strings.Contains(s, "MANIFOLD_SURFACE_SHAPE_REPRESENTATION") {
+		t.Error("the surface body has no MANIFOLD_SURFACE_SHAPE_REPRESENTATION")
+	}
+	if !strings.Contains(s, "SHELL_BASED_SURFACE_MODEL") {
+		t.Error("the surface body has no SHELL_BASED_SURFACE_MODEL")
+	}
+}
+
+// The product carries the name the caller asked for, so a reader's model tree shows something
+// meaningful rather than a placeholder.
+func TestExportedProductCarriesTheName(t *testing.T) {
+	data, _, err := Writer{}.ExportSolids([]*topo.Body{cubeOrShell(t, true)},
+		exchange.TranslationOptions{Name: "bracket"})
+	if err != nil {
+		t.Fatalf("ExportSolids: %v", err)
+	}
+	if !strings.Contains(string(data), "PRODUCT('bracket','bracket'") {
+		t.Error("the exported product does not carry the requested name")
+	}
+	// With no name the writer falls back rather than emitting an empty product.
+	plain := string(exportBox(t, true))
+	if !strings.Contains(plain, "PRODUCT('"+defaultProductName+"'") {
+		t.Errorf("an unnamed export has no fallback product name")
+	}
+}
+
+// Mixing solids and shells in one file is reported rather than silently flattened.
+func TestMixedBodiesWarn(t *testing.T) {
+	_, warns, err := Writer{}.ExportSolids(
+		[]*topo.Body{cubeOrShell(t, true), cubeOrShell(t, false)}, exchange.TranslationOptions{})
+	if err != nil {
+		t.Fatalf("ExportSolids: %v", err)
+	}
+	if len(warns) != 1 || !strings.Contains(warns[0], "shape representation") {
+		t.Errorf("warnings = %v, want one about the shared shape representation", warns)
+	}
+	// A homogeneous export stays silent.
+	_, quiet, err := Writer{}.ExportSolids([]*topo.Body{cubeOrShell(t, true)}, exchange.TranslationOptions{})
+	if err != nil {
+		t.Fatalf("ExportSolids: %v", err)
+	}
+	if len(quiet) != 0 {
+		t.Errorf("a solids-only export warned: %v", quiet)
+	}
+}

--- a/kernel/exchange/translate.go
+++ b/kernel/exchange/translate.go
@@ -46,6 +46,9 @@ type TranslationOptions struct {
 	// "m", "in" or "ft". Empty ⇒ millimetres. It is ignored on import, where the
 	// unit is read from the file.
 	FileUnit string
+	// Name labels the exported product — what a reader shows in its model tree. Empty ⇒ the
+	// writer's own default. It is ignored on import, where the name is read from the file.
+	Name string
 	// ChordTolerance bounds curve/surface faceting used by validation/mass props.
 	ChordTolerance float64
 	// Progress, when non-nil, receives incremental progress and can cancel a long import (S13,

--- a/model/exchange/dispatch.go
+++ b/model/exchange/dispatch.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/exchange"
@@ -71,7 +72,7 @@ func Export(part *compdef.PartComponentDefinition, path string, format types.Exc
 	if !ok || route.exportBodies == nil {
 		return ExportResult{}, fmt.Errorf("export: unsupported format %q (want stl|obj|3mf|step)", format)
 	}
-	data, tris, warns, err := route.exportBodies(bodies, res, exportUnits(part))
+	data, tris, warns, err := route.exportBodies(bodies, res, exportOptions(part, path))
 	if err != nil {
 		return ExportResult{}, fmt.Errorf("export %q: %w", path, err)
 	}
@@ -79,6 +80,15 @@ func Export(part *compdef.PartComponentDefinition, path string, format types.Exc
 		return ExportResult{}, fmt.Errorf("export: write %q: %w", path, err)
 	}
 	return ExportResult{TriangleCount: tris, Warnings: warns}, nil
+}
+
+// exportOptions is exportUnits plus the product name a format that carries one writes. The name
+// comes from the destination file's base name — the part definition carries none, and a reader's
+// model tree showing "plate" beats a constant placeholder (#2055).
+func exportOptions(part *compdef.PartComponentDefinition, path string) exchange.TranslationOptions {
+	opts := exportUnits(part)
+	opts.Name = strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	return opts
 }
 
 // exportUnits builds the translation options for an export: the kernel works in


### PR DESCRIPTION
Closes #2055 — an exported STEP opened with no geometry in eDrawings.

## Root cause

The model was fine: the reporter's viewport screenshot shows a solid block, and
reproducing their exact document gives a valid 6-face solid of volume 60. The
defect is entirely in the writer.

The exported file was a DATA section of raw geometry that ended here:

```
#1=(LENGTH_UNIT()NAMED_UNIT(*)SI_UNIT(.MILLI.,.METRE.));
#2=GLOBAL_UNIT_ASSIGNED_CONTEXT((#1));
... geometry ...
#120=CLOSED_SHELL('',(#36,#66,#83,#96,#109,#119));
#121=MANIFOLD_SOLID_BREP('',#120);
ENDSEC;
```

No `APPLICATION_CONTEXT`, no `PRODUCT`, no shape representation — and a bare
`GLOBAL_UNIT_ASSIGNED_CONTEXT` where a `GEOMETRIC_REPRESENTATION_CONTEXT`
belongs. A conformant reader enters at `SHAPE_DEFINITION_REPRESENTATION` and
walks down through the product definition to the representation. With no entry
point there was nothing to walk to, so correct geometry was unreachable.

**Why no test caught it:** our own reader scans for the b-rep entity directly,
so the round-trip test passed throughout. A writer and reader from one codebase
agreeing with each other says nothing about interoperability — that is the trap
this sat behind, and it is why the fix is verified against a foreign reader.

## The fix

The writer emits the AP203 chain a reader actually follows:

```
SHAPE_DEFINITION_REPRESENTATION
  → PRODUCT_DEFINITION_SHAPE → PRODUCT_DEFINITION → … → PRODUCT → APPLICATION_CONTEXT
  → ADVANCED_BREP_SHAPE_REPRESENTATION  (in a GEOMETRIC_REPRESENTATION_CONTEXT
      with length/angle/solid-angle units and a declared uncertainty)
      → MANIFOLD_SOLID_BREP → CLOSED_SHELL → ADVANCED_FACE
```

An open shell takes `MANIFOLD_SURFACE_SHAPE_REPRESENTATION` over
`SHELL_BASED_SURFACE_MODEL` instead — a reader rejects a representation whose
items are of the wrong kind. A body set mixing solids and shells now warns
rather than silently flattening. The product takes its name from the output
file, so a reader's tree shows "bracket" rather than a placeholder.

The reader is unaffected: it already handled both the bare and the complex
context forms and picks the length-bearing unit out of the assigned list.

## Verification

**Against OCCT — an independent reader — before and after:**

| | OCCT `nbshapes` |
|---|---|
| before | *no shape at all* — the file produces no root |
| after | `SOLID: 1, SHELL: 1, FACE: 6, EDGE: 12, VERTEX: 8` |

That reproduces the reported symptom exactly and shows it resolved.

**Live test** through the app's own export path (not the CLI): build the
reported part in a real head over the MCP bridge, `documents.export` to STEP,
read the result with OCCT — 5/5 checks pass, solid with its 6 faces.

**Regression test** encodes the invariant by walking references from
`SHAPE_DEFINITION_REPRESENTATION` and requiring each link to be reachable, so
CI holds it without OCCT. Red-verified: disabling the emission fails with
*"the exported file has no SHAPE_DEFINITION_REPRESENTATION — a reader entering
the standard way finds no geometry and opens an empty model"*.

Full core + head suites green, `golangci-lint` 0 issues, SPDX clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TBVMFbhWH7akseMqz5GM3
