### PR TITLE
fix(tessellate): re-cut a drilled wall's seam clear of its holes (#2038)

### DIFF
--- a/kernel/ops/holed_cylinder_wall.go
+++ b/kernel/ops/holed_cylinder_wall.go
@@ -25,8 +25,9 @@ import (
 
 // holedConicWallMesh meshes a full-period cylinder or cone side carrying holes by unrolling it to a
 // contiguous (u,v) rectangle and delegating to the metric-scaled CDT. ok=false unless the surface is a
-// developable side (cylinder/cone) with at least one hole and a genuinely seam-wrapping outer loop (a hole
-// straddling the seam also defers — the builder seams the wall clear of its holes, so that should not arise).
+// developable side (cylinder/cone) with at least one hole and a genuinely seam-wrapping outer loop.
+// A hole straddling the wall's own seam no longer defers: the seam is re-cut clear of the holes
+// (wall_seam_recut.go), because no builder can be relied on to have placed it clear (#2038).
 func holedConicWallMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3, q Quality) (*Mesh, bool) {
 	if !isDevelopableSide(s) {
 		return nil, false // only a cylinder/cone unrolls (developable: zero Gaussian curvature)
@@ -34,15 +35,34 @@ func holedConicWallMesh(s geom.Surface, outer3D []math.Point3, holes3D [][]math.
 	if len(holes3D) == 0 || isPeriodic(s.UDomain()) == isPeriodic(s.VDomain()) {
 		return nil, false // need a holed, singly-periodic side
 	}
-	outerUV, umin, umax, ok := wrappedWallUV(s, outer3D)
+	br, holesUV, ok := wallBranchClearOfHoles(s, outer3D, holes3D)
 	if !ok {
 		return nil, false
 	}
-	holesUV, ok := holesIntoBranch(s, holes3D, umin, umax)
+	return unrolledWallCDT(s, q, br.loop, holes3D, br.uv, holesUV), true
+}
+
+// wallBranchClearOfHoles unrolls the wall into a branch every hole fits inside, with the holes already
+// mapped into it. It tries the branch the wall's OWN seam defines first, and only when a hole straddles
+// that seam — so no whole-period shift brings it inside — re-cuts the seam into the widest hole-free
+// gap and unrolls again (#2038).
+func wallBranchClearOfHoles(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3) (wallBranch, [][]math.Point2, bool) {
+	br, ok := unrollWall(s, outer3D)
 	if !ok {
-		return nil, false
+		return wallBranch{}, nil, false
 	}
-	return unrolledWallCDT(s, q, outer3D, holes3D, outerUV, holesUV), true
+	if holesUV, fits := holesIntoBranch(s, holes3D, br.umin, br.umax); fits {
+		return br, holesUV, true
+	}
+	wrap, ok := rebridgedWallLoop(s, outer3D, holes3D)
+	if !ok {
+		return wallBranch{}, nil, false
+	}
+	if br, ok = unrollWall(s, wrap); !ok {
+		return wallBranch{}, nil, false
+	}
+	holesUV, fits := holesIntoBranch(s, holes3D, br.umin, br.umax)
+	return br, holesUV, fits
 }
 
 // isDevelopableSide reports whether the surface is a cylinder (circular or elliptical) or a cone — the

--- a/kernel/ops/tessellate_trim.go
+++ b/kernel/ops/tessellate_trim.go
@@ -180,7 +180,9 @@ func meshSeamCrossingFace(f *topo.Face, s geom.Surface, outer3D []math.Point3, h
 		return fullDomainGridMesh(s, q) // shouldn't reach: a doubly-periodic band that isn't two circles + a seam
 	}
 	if isPeriodic(s.UDomain()) != isPeriodic(s.VDomain()) {
-		return trimmedPatchMesh(s, outer3D, holes3D) // sphere cap on the pole: CDT in the best-fit plane
+		m := trimmedPatchMesh(s, outer3D, holes3D) // sphere cap on the pole: CDT in the best-fit plane
+		recordUnmeshedWallWrap(m, s, outer3D, len(holes3D))
+		return m
 	}
 	return fullDomainGridMesh(s, q) // doubly-periodic / aperiodic seam face we can't reduce
 }

--- a/kernel/ops/wall_seam_recut.go
+++ b/kernel/ops/wall_seam_recut.go
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// Re-cutting a drilled wall's seam clear of its holes (Oblikovati/Oblikovati#2038).
+//
+// holedConicWallMesh unrolls a full-wrap developable wall into the (u,v) branch the wall's OWN seam
+// defines, then shifts each lens hole by whole periods into that branch. A lens that STRADDLES the
+// seam fits no branch at all, so holesIntoBranch declined and the face fell through to the flat
+// best-fit-plane CDT — which collapses a full wrap and covers only half of it. The B-rep stays valid
+// and ops.Validate stays clean, so the damage surfaces only in the integrated quantities: a Ø3 mm
+// bore through a Ø100 × 4 mm disk reported 7.1 cm³ against an analytic 30.7 (−77%), silently.
+//
+// Whether a lens straddles is an accident of where the operand cylinder's angle-0 happens to point —
+// brep.SolidCylinder takes it from axisFrame (+Y for a +Z axis), an extruded circle from its sketch
+// +X (extrude_analytic.go) — so the "the builder places the seam clear of its holes" precondition
+// holesIntoBranch documented cannot be relied on. The seam of a periodic wall is arbitrary, so cut it
+// SOMEWHERE ELSE: split the loop back into the two rims it bridges and re-bridge them at the widest
+// lens-free angle, through the same bridgeRimsAtSeam the two-rim band uses (two_rim_holed_band.go).
+
+// wallBranch is a wall's unrolled outer loop: the 3D loop, its (u,v) image, and the u-range it spans.
+type wallBranch struct {
+	loop       []math.Point3
+	uv         []math.Point2
+	umin, umax float64
+}
+
+// unrollWall unrolls a wrapping wall loop into its own branch. ok=false unless the loop wraps a full
+// period.
+func unrollWall(s geom.Surface, loop []math.Point3) (wallBranch, bool) {
+	uv, umin, umax, ok := wrappedWallUV(s, loop)
+	if !ok {
+		return wallBranch{}, false
+	}
+	return wallBranch{loop: loop, uv: uv, umin: umin, umax: umax}, true
+}
+
+// rebridgedWallLoop re-cuts outer3D's seam into the widest gap clear of the lens holes, returning the
+// re-bridged wrapping loop. ok=false when the loop is not a two-rim seam-bridged wall, or when a hole
+// itself wraps the period — that is a rim mis-demoted to a hole, twoRimHoledBandMesh's case, and no
+// choice of seam angle helps.
+func rebridgedWallLoop(s geom.Surface, outer3D []math.Point3, holes3D [][]math.Point3) ([]math.Point3, bool) {
+	rims, lenses := splitWrappingHoles(s, holes3D)
+	if len(rims) > 0 || len(lenses) == 0 {
+		return nil, false
+	}
+	top, bot, ok := splitSeamBridgedRims(s, outer3D)
+	if !ok {
+		return nil, false
+	}
+	return bridgeRimsAtSeam(s, top, bot, lenses)
+}
+
+// splitSeamBridgedRims splits a wall's seam-bridged outer loop back into its two rim rings. The loop
+// runs one rim from the seam all the way around, crosses to the other rim at the branch edge, and runs
+// back — so the points sitting at the lift's two extremes ARE the seam, and the two runs between them
+// are the rims. top is the ring with the greater mean v. ok=false when the loop is not that shape.
+func splitSeamBridgedRims(s geom.Surface, outer3D []math.Point3) (top, bot []math.Point3, ok bool) {
+	onSeam, ok := seamEndMask(s, outer3D)
+	if !ok {
+		return nil, nil, false
+	}
+	a, b, ok := ringsBetweenSeams(outer3D, onSeam)
+	if !ok {
+		return nil, nil, false
+	}
+	if meanVParam(s, a) < meanVParam(s, b) {
+		a, b = b, a
+	}
+	return a, b, true
+}
+
+// seamEndMask marks the loop points sitting at one of the unrolled lift's two extremes — the wall's
+// seam, which the loop traverses once at each end of the branch. ok=false unless the loop wraps a
+// full period.
+func seamEndMask(s geom.Surface, outer3D []math.Point3) ([]bool, bool) {
+	us := make([]float64, len(outer3D))
+	for i, p := range outer3D {
+		us[i], _ = s.ParamAt(p)
+	}
+	cu := cumulativeUnwrap(us)
+	umin, umax := minMax(cu)
+	if umax-umin < 2*stdmath.Pi-0.5 {
+		return nil, false // not a full wrap: nothing to re-cut
+	}
+	mask := make([]bool, len(cu))
+	for i, u := range cu {
+		mask[i] = u-umin <= seamAngularTol || umax-u <= seamAngularTol
+	}
+	return mask, true
+}
+
+// ringsBetweenSeams walks the cyclic loop and splits it at the seam into the two rim rings. A seam
+// run's FIRST point closes the ring being walked and its LAST point opens the next — those two are
+// the rim vertices the seam joins — and any point between them is seam interior, dropped because the
+// re-bridge lays down its own. ok=false unless the loop has exactly the two seam runs a bridged wall
+// has.
+func ringsBetweenSeams(pts []math.Point3, onSeam []bool) (a, b []math.Point3, ok bool) {
+	start := indexOfFalse(onSeam)
+	if start < 0 || countSeamRuns(onSeam) != 2 {
+		return nil, nil, false
+	}
+	var rings [2][]math.Point3
+	cur, n := 0, len(pts)
+	for k := 0; k < n; {
+		i := (start + k) % n
+		if !onSeam[i] {
+			rings[cur] = append(rings[cur], pts[i])
+			k++
+			continue
+		}
+		run := seamRunLength(onSeam, i)
+		rings[cur] = append(rings[cur], pts[i]) // closes this rim
+		cur = 1 - cur
+		rings[cur] = append(rings[cur], pts[(i+run-1)%n]) // opens the other
+		k += run
+	}
+	a, b = dropCyclicDuplicates(rings[0]), dropCyclicDuplicates(rings[1])
+	return a, b, len(a) >= 3 && len(b) >= 3
+}
+
+// indexOfFalse returns the first index whose mask entry is false, or −1 when every entry is true.
+func indexOfFalse(mask []bool) int {
+	for i, m := range mask {
+		if !m {
+			return i
+		}
+	}
+	return -1
+}
+
+// countSeamRuns counts the maximal cyclic runs of true in mask — a seam-bridged wall has exactly two,
+// one at each end of the branch.
+func countSeamRuns(mask []bool) int {
+	n, runs := len(mask), 0
+	for i, m := range mask {
+		if m && !mask[(i-1+n)%n] {
+			runs++
+		}
+	}
+	return runs
+}
+
+// seamRunLength returns the length of the maximal cyclic run of true in mask starting at i.
+func seamRunLength(mask []bool, i int) int {
+	n := len(mask)
+	for k := 1; k <= n; k++ {
+		if !mask[(i+k)%n] {
+			return k
+		}
+	}
+	return n
+}
+
+// dropCyclicDuplicates removes the repeat of the seam vertex: each rim is walked from the seam all
+// the way around and back to it, so the vertex the seam is cut at appears twice — as the last two
+// points, or as the last and the first.
+func dropCyclicDuplicates(ring []math.Point3) []math.Point3 {
+	tol := ringCoincidenceTol(ring)
+	out := make([]math.Point3, 0, len(ring))
+	for _, p := range ring {
+		if len(out) > 0 && float64(p.DistanceTo(out[len(out)-1])) <= tol {
+			continue
+		}
+		out = append(out, p)
+	}
+	for len(out) > 1 && float64(out[len(out)-1].DistanceTo(out[0])) <= tol {
+		out = out[:len(out)-1]
+	}
+	return out
+}
+
+// ringCoincidenceTol is the distance below which two ring points are the same place: a small fraction
+// of the ring's own mean chord, so the test scales with the model instead of fixing an absolute
+// epsilon (ADR-0042).
+func ringCoincidenceTol(ring []math.Point3) float64 {
+	if len(ring) < 2 {
+		return 0
+	}
+	var sum float64
+	for i := 1; i < len(ring); i++ {
+		sum += float64(ring[i-1].DistanceTo(ring[i]))
+	}
+	return 1e-6 * sum / float64(len(ring)-1)
+}
+
+// meanVParam is a ring's mean non-periodic parameter — which of a wall's two rims is the "top".
+func meanVParam(s geom.Surface, ring []math.Point3) float64 {
+	var sum float64
+	for _, p := range ring {
+		sum += vParam(s, p)
+	}
+	return sum / float64(len(ring))
+}

--- a/kernel/ops/wall_seam_recut_test.go
+++ b/kernel/ops/wall_seam_recut_test.go
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// #2038: a drilled wall's seam sits wherever its builder's angle-0 happened to point, so a lens hole
+// can straddle it. holesIntoBranch then fits the lens into no branch, holedConicWallMesh declined, and
+// the face fell through to the flat best-fit-plane CDT — which covers only half a full wrap. These
+// tests pin the re-cut (wall_seam_recut.go) that removes the dependence on where the seam landed.
+
+// bridgedWallLoop builds the seam-bridged outer loop of a full-wrap wall between v=vBot and v=vTop:
+// the seam's bottom vertex, the top rim all the way round, then the bottom rim back — the shape the
+// curved boolean hands the tessellator for a drilled cylinder wall.
+func bridgedWallLoop(s geom.Surface, vBot, vTop float64, n int) []math.Point3 {
+	step := 2 * stdmath.Pi / float64(n)
+	out := []math.Point3{s.PointAt(0, vBot)}
+	for k := 0; k <= n; k++ { // top rim, θ: 0 → −2π (closing on its own start)
+		out = append(out, s.PointAt(-step*float64(k), vTop))
+	}
+	for k := n; k > 0; k-- { // bottom rim back, θ: −2π → 0 (exclusive: index 0 already holds it)
+		out = append(out, s.PointAt(-step*float64(k), vBot))
+	}
+	return out
+}
+
+// TestHoledWallMeshesLensStraddlingTheSeam is the #2038 regression: the wall must mesh to its full
+// curved area whether the lens sits ON the seam or clear of it. Before the re-cut the straddling case
+// declined here and the caller's flat-CDT fallback covered ~half the wrap.
+func TestHoledWallMeshesLensStraddlingTheSeam(t *testing.T) {
+	s := bandCylinder(10)
+	q := Quality{ChordTolerance: 0.005, AngleTolerance: 2 * stdmath.Pi / 180}
+	full := 2 * stdmath.Pi * 3 * 10 // 2πRh = 188.50, minus one small lens
+	for _, tc := range []struct {
+		name  string
+		theta float64
+	}{
+		{"lens clear of the seam", stdmath.Pi},
+		{"lens straddling the seam", 0},
+		{"lens just inside the seam", 0.05},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			outer := bridgedWallLoop(s, 0, 10, 96)
+			lens := lensLoop(s, tc.theta, 5, 0.12, 0.35, 40)
+			m, ok := holedConicWallMesh(s, outer, [][]math.Point3{lens}, q)
+			if !ok {
+				t.Fatal("holedConicWallMesh declined a drilled wall; the flat CDT fallback covers half the wrap (#2038)")
+			}
+			if area := meshArea(m); area < full-3 || area > full+0.5 {
+				t.Errorf("wall area %.3f, want ≈%.3f (full wrap minus a small lens) — half-covered wrap?", area, full)
+			}
+		})
+	}
+}
+
+// TestSplitSeamBridgedRimsRecoversBothRims: the split must hand back the two rims intact — every
+// sampled vertex, each exactly once (the seam vertex is walked twice and must not come back doubled),
+// and separated by their v level.
+func TestSplitSeamBridgedRimsRecoversBothRims(t *testing.T) {
+	s := bandCylinder(10)
+	top, bot, ok := splitSeamBridgedRims(s, bridgedWallLoop(s, 0, 10, 96))
+	if !ok {
+		t.Fatal("splitSeamBridgedRims declined a seam-bridged wall loop")
+	}
+	if len(top) != 96 || len(bot) != 96 {
+		t.Errorf("rims came back with %d and %d points, want 96 each (a doubled seam vertex?)", len(top), len(bot))
+	}
+	if v := meanVParam(s, top); stdmath.Abs(v-10) > 1e-9 {
+		t.Errorf("top rim mean v = %v, want 10 — the rims are swapped or mixed", v)
+	}
+	if v := meanVParam(s, bot); stdmath.Abs(v) > 1e-9 {
+		t.Errorf("bottom rim mean v = %v, want 0 — the rims are swapped or mixed", v)
+	}
+}
+
+// TestSplitSeamBridgedRimsDeclinesNonWrappingLoop: a loop that does not wrap the period is not a
+// bridged wall, so the split must defer rather than invent rims.
+func TestSplitSeamBridgedRimsDeclinesNonWrappingLoop(t *testing.T) {
+	s := bandCylinder(10)
+	quarter := []math.Point3{s.PointAt(0, 0), s.PointAt(1, 0), s.PointAt(1, 10), s.PointAt(0, 10)}
+	if _, _, ok := splitSeamBridgedRims(s, quarter); ok {
+		t.Error("splitSeamBridgedRims accepted a quarter-wall loop")
+	}
+}
+
+// TestCrossingCylinderCutIsSeamIndependent is the invariant the defect broke: the volume of a bored
+// disk must not depend on the ANGLE the bore happens to make with the disk's angle-0 seam. The disk's
+// seam is where axisFrame put it (+Y for a +Z axis), so the φ=90°/270° rods drill straight through it.
+// Before the re-cut those two read ~10.07 cm³ against an analytic 30.71 — a −67% error on a valid,
+// Validate-clean solid with no diagnostics.
+func TestCrossingCylinderCutIsSeamIndependent(t *testing.T) {
+	want := stdmath.Pi*25*0.4 - stdmath.Pi*0.15*0.15*10 // disk − tunnel = 30.709068
+	for _, deg := range []float64{0, 45, 90, 135, 180, 270} {
+		body := boredDiskAtAzimuth(t, deg)
+		if r := Validate(body); !r.Valid || !body.IsSolid() {
+			t.Fatalf("φ=%g°: not a valid solid: %+v", deg, r.Issues)
+		}
+		got := BodyGeometryProperties(body, PropertyQuality()).Volume
+		if rel := stdmath.Abs(got-want) / want; rel > 1e-3 {
+			t.Errorf("φ=%g°: volume %.6f, want %.6f (rel %+.4f) — the bore straddles the disk's seam (#2038)",
+				deg, got, want, (got-want)/want)
+		}
+	}
+}
+
+// boredDiskAtAzimuth cuts a Ø0.3 rod clean through a R=5 × 0.4 disk along the azimuth deg (degrees
+// from the +X axis, in the disk's mid-plane), through the exact analytic crossing-cylinder path.
+func boredDiskAtAzimuth(t *testing.T, deg float64) *topo.Body {
+	t.Helper()
+	disk, err := brep.SolidCylinder(math.P3(0, 0, -0.2), math.V3(0, 0, 1), 5, 0.4)
+	if err != nil {
+		t.Fatalf("disk: %v", err)
+	}
+	rad := deg * stdmath.Pi / 180
+	axis := math.V3(math.Scalar(stdmath.Cos(rad)), math.Scalar(stdmath.Sin(rad)), 0)
+	rod, err := brep.SolidCylinder(math.P3(0, 0, 0).TranslateBy(axis.Scale(-6)), axis, 0.15, 12)
+	if err != nil {
+		t.Fatalf("rod: %v", err)
+	}
+	body, ok := CurvedBoolean(Cut, disk, rod)
+	if !ok {
+		t.Fatalf("φ=%g°: the exact crossing-cylinder path declined", deg)
+	}
+	return body
+}
+
+// TestCrossingCylinderBooleanStaysExactAtScale covers #2038's "adjacent finding at scale". Going
+// through the full Boolean entry, the seam-straddling wall's bad mesh made the Requicha volume guard
+// (curvedExactGuarded) REJECT a perfectly good analytic result, so the cut fell back to triangle-soup
+// CSG: 408 all-planar faces at k=1 and a NON-MANIFOLD body from k=5 up. With the wall meshed correctly
+// the analytic result is accepted, so the cut stays exact — and valid — at every scale.
+func TestCrossingCylinderBooleanStaysExactAtScale(t *testing.T) {
+	for _, k := range []float64{1, 5, 20} {
+		disk, err := brep.SolidCylinder(math.P3(0, 0, math.Scalar(-0.2*k)), math.V3(0, 0, 1), 5*k, 0.4*k)
+		if err != nil {
+			t.Fatalf("k=%v disk: %v", k, err)
+		}
+		rod, err := brep.SolidCylinder(math.P3(0, math.Scalar(-6*k), 0), math.V3(0, 1, 0), 0.15*k, 12*k)
+		if err != nil {
+			t.Fatalf("k=%v rod: %v", k, err)
+		}
+		body, err := Boolean(Cut, disk, rod)
+		if err != nil {
+			t.Fatalf("k=%v: %v", k, err)
+		}
+		if r := Validate(body); !r.Valid || !body.IsSolid() {
+			t.Fatalf("k=%v: not a valid solid (%d issues, first %v) — CSG fallback?", k, len(r.Issues), r.Issues[0])
+		}
+		if n := analyticCylinderFaceCount(body); n != 2 {
+			t.Errorf("k=%v: %d cylindrical faces on a %d-face body, want 2 (rim + bore) — the cut was faceted",
+				k, n, len(body.Faces()))
+		}
+		want := stdmath.Pi*25*k*k*0.4*k - stdmath.Pi*0.15*0.15*k*k*10*k
+		got := BodyGeometryProperties(body, PropertyQuality()).Volume
+		if rel := stdmath.Abs(got-want) / want; rel > 1e-3 {
+			t.Errorf("k=%v: volume %.6f, want %.6f (rel %+.4f)", k, got, want, (got-want)/want)
+		}
+	}
+}
+
+// analyticCylinderFaceCount tallies the body's true cylindrical faces — zero means the boolean
+// abandoned the analytic surfaces for facets.
+func analyticCylinderFaceCount(b *topo.Body) int {
+	n := 0
+	for _, f := range b.Faces() {
+		if _, ok := f.Geometry().(geom.Cylinder); ok {
+			n++
+		}
+	}
+	return n
+}

--- a/kernel/ops/wall_wrap_unmeshed.go
+++ b/kernel/ops/wall_wrap_unmeshed.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// The last-resort signal for a wall the wrapping meshers all declined (Oblikovati/Oblikovati#2038).
+// meshSeamCrossingFace ends at the flat best-fit-plane CDT, which is right for a sphere cap over its
+// pole but cannot cover a full-wrap developable wall: it comes back open, and the body's volume and
+// mass properties are quietly low. So a wall reaching it is flagged.
+
+// CodeWallWrapUnmeshed marks a full-wrap developable side — a cylinder or cone WALL — that no
+// wrapping mesher accepted and that therefore fell to the flat best-fit-plane CDT. Flattening a full
+// wrap cannot cover it: the mesh comes back open and every integrated quantity (face area, body
+// volume, mass properties) is under-reported, which is exactly how #2038 shipped a −77% volume on a
+// Validate-clean solid. The mesh still ships — a flagged partial covering beats a missing face — but
+// the degradation is recorded rather than silent.
+const CodeWallWrapUnmeshed diag.Code = "tessellate.wall-wrap-unmeshed"
+
+// recordUnmeshedWallWrap flags a developable side whose outer loop wraps the full period reaching the
+// FLAT patch CDT. A sphere cap straddling its pole legitimately lands there — it is not developable —
+// so the check is gated on the surface being a cylinder/cone side, where a flattened wrap is always
+// wrong.
+func recordUnmeshedWallWrap(m *Mesh, s geom.Surface, outer3D []math.Point3, holes int) {
+	if m == nil || !isDevelopableSide(s) {
+		return
+	}
+	if _, _, _, wraps := wrappedWallUV(s, outer3D); !wraps {
+		return
+	}
+	m.Diagnose(diag.Diagnostic{
+		Code:     CodeWallWrapUnmeshed,
+		Severity: diag.Defect,
+		Detail: fmt.Sprintf("a full-wrap %T wall carrying %d hole(s) fell to the flat patch CDT; "+
+			"the flattened wrap covers only part of the wall, so its area and the body's volume are low", s, holes),
+	})
+}

--- a/kernel/ops/wall_wrap_unmeshed_test.go
+++ b/kernel/ops/wall_wrap_unmeshed_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// TestUnmeshedWallWrapIsFlagged: if a full-wrap wall ever reaches the flat patch CDT again, the
+// half-covered mesh it produces must ship as a Defect, not silently (#2038's third acceptance).
+func TestUnmeshedWallWrapIsFlagged(t *testing.T) {
+	s := bandCylinder(10)
+	wrapping := bridgedWallLoop(s, 0, 10, 96)
+	m := &Mesh{}
+	recordUnmeshedWallWrap(m, s, wrapping, 1)
+	if len(m.Diagnostics) != 1 || m.Diagnostics[0].Code != CodeWallWrapUnmeshed {
+		t.Fatalf("a full-wrap cylinder wall on the flat CDT recorded %v, want one %s defect",
+			m.Diagnostics, CodeWallWrapUnmeshed)
+	}
+	if m.Diagnostics[0].Severity != diag.Defect {
+		t.Errorf("severity %v, want Defect — a half-covered wall is not advisory", m.Diagnostics[0].Severity)
+	}
+}
+
+// TestUnmeshedWallWrapIgnoresLegitimateFlatPatches: a sphere cap straddling its pole belongs on the
+// flat CDT, and so does a wall patch that does not wrap, so neither may be flagged.
+func TestUnmeshedWallWrapIgnoresLegitimateFlatPatches(t *testing.T) {
+	sph, err := geom.NewSphere(math.P3(0, 0, 0), 3)
+	if err != nil {
+		t.Fatalf("sphere: %v", err)
+	}
+	cyl := bandCylinder(10)
+	for _, tc := range []struct {
+		name string
+		s    geom.Surface
+		loop []math.Point3
+	}{
+		{"sphere cap over the pole", sph, bridgedWallLoop(sph, 0.4, 1.0, 48)},
+		{"cylinder patch that does not wrap", cyl,
+			[]math.Point3{cyl.PointAt(0, 0), cyl.PointAt(1, 0), cyl.PointAt(1, 10), cyl.PointAt(0, 10)}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &Mesh{}
+			recordUnmeshedWallWrap(m, tc.s, tc.loop, 0)
+			if len(m.Diagnostics) != 0 {
+				t.Errorf("flagged a legitimate flat patch: %v", m.Diagnostics)
+			}
+		})
+	}
+}

--- a/model/feature/extrude_bore_seam_test.go
+++ b/model/feature/extrude_bore_seam_test.go
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// The squat-rim bore (Oblikovati/Oblikovati#2038): a Ø0.3 rod bored clean through a R=5 × 0.4 disk.
+// An extruded circle's analytic cylinder pins angle-0 to its sketch +X (extrude_analytic.go), so an
+// XY-sketched disk carries its seam at +X — and a bore sketched on YZ runs straight through it. The
+// wall's lens holes then straddled the seam, the tessellator fell back to a flat CDT that covers half
+// the wrap, and the part reported 7.1 cm³ against an analytic 30.7 with a valid solid and no
+// diagnostic. See kernel/ops/wall_seam_recut.go.
+
+// boredDiskVolume is the analytic volume of the disk minus the full tunnel.
+func boredDiskVolume() float64 { return stdmath.Pi*25*0.4 - stdmath.Pi*0.15*0.15*10 }
+
+// boredDisk builds the disk on XY and cuts the bore from borePlane under the given extent direction.
+func boredDisk(t *testing.T, borePlane sketch.Plane, dir ExtentDirection) *PartFeatures {
+	t.Helper()
+	fs := NewPartFeatures(nil)
+	disk := sketch.NewSketches().Add(sketch.XYPlane())
+	disk.Circles().AddByCenterRadius(math.P2(0, 0), 5)
+	NewExtrudeFeatures(fs).AddExtrude(disk, []int{0}, ops.NewBody,
+		Extent{Type: DistanceExtent, Direction: SymmetricDir, Distance: func() float64 { return 0.4 }}, 0)
+	bore := sketch.NewSketches().Add(borePlane)
+	bore.Circles().AddByCenterRadius(math.P2(0, 0), 0.15)
+	NewExtrudeFeatures(fs).AddExtrude(bore, []int{0}, ops.Cut, Extent{Type: ThroughAllExtent, Direction: dir}, 0)
+	fs.Recompute()
+	if n := len(fs.Result()); n != 1 {
+		t.Fatalf("recompute gave %d bodies, want 1", n)
+	}
+	return fs
+}
+
+// TestBoredDiskVolumeIsIndependentOfTheBoreAxis: the same part must measure the same whether the bore
+// runs along Y (clear of the disk's +X seam) or along X (straight through it). #2038 read the second
+// 77% low.
+func TestBoredDiskVolumeIsIndependentOfTheBoreAxis(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		plane sketch.Plane
+	}{
+		{"bore along Y, clear of the seam", sketch.XZPlane()},
+		{"bore along X, through the seam", sketch.YZPlane()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := boredDisk(t, tc.plane, SymmetricDir).Result()[0]
+			if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+				t.Fatalf("not a valid solid: %+v", r.Issues)
+			}
+			want := boredDiskVolume()
+			got := ops.BodyGeometryProperties(body, ops.PropertyQuality()).Volume
+			if rel := stdmath.Abs(got-want) / want; rel > 1e-3 {
+				t.Errorf("volume %.6f, want %.6f (rel %+.4f) — half-covered wall mesh? (#2038)",
+					got, want, (got-want)/want)
+			}
+		})
+	}
+}
+
+// TestSymmetricThroughAllBoreIsOpenAlongItsWholeLength probes the bore axis at several stations rather
+// than trusting a volume band: a volume check alone passes a solid that is missing an end of the
+// tunnel by less than its tolerance (#2038's acceptance).
+func TestSymmetricThroughAllBoreIsOpenAlongItsWholeLength(t *testing.T) {
+	body := boredDisk(t, sketch.XZPlane(), SymmetricDir).Result()[0]
+	for _, y := range []float64{-4.5, -3, -1.5, -0.5, 0.5, 1.5, 3, 4.5} {
+		p := math.P3(0, math.Scalar(y), 0)
+		if c := ops.BodyContainment(body, p, ops.PropertyQuality(), 1e-7); c != ops.ContainOutside {
+			t.Errorf("y=%+.1f inside the bore reads %v, want outside — the tunnel is filled there", y, c)
+		}
+	}
+}
+
+// TestPositiveThroughAllBoreCutsOneSideOnly locks the Inventor semantics #2038 misread as a bug: a
+// through-all extent takes a DIRECTION (ExtrudeDefinition.SetThroughAllExtent), and
+// kPositiveExtentDirection cuts only the side of the sketch plane the normal points to. The XZ plane's
+// normal is −Y, so the material at +Y must survive and the −Y half must go.
+func TestPositiveThroughAllBoreCutsOneSideOnly(t *testing.T) {
+	body := boredDisk(t, sketch.XZPlane(), PositiveDir).Result()[0]
+	for _, tc := range []struct {
+		y    float64
+		want ops.PointContainment
+	}{{-4, ops.ContainOutside}, {-2, ops.ContainOutside}, {2, ops.ContainInside}, {4, ops.ContainInside}} {
+		p := math.P3(0, math.Scalar(tc.y), 0)
+		if c := ops.BodyContainment(body, p, ops.PropertyQuality(), 1e-7); c != tc.want {
+			t.Errorf("y=%+.1f reads %v, want %v — a one-direction through-all must not cut both ways",
+				tc.y, c, tc.want)
+		}
+	}
+	// Exactly half the tunnel, so a caller measuring against the full tunnel is measuring the wrong thing.
+	want := stdmath.Pi*25*0.4 - stdmath.Pi*0.15*0.15*5
+	got := ops.BodyGeometryProperties(body, ops.PropertyQuality()).Volume
+	if rel := stdmath.Abs(got-want) / want; rel > 2e-3 {
+		t.Errorf("volume %.6f, want %.6f (disk minus HALF the tunnel)", got, want)
+	}
+}


### PR DESCRIPTION
## What

A bored disk reported **7.1 cm³ where the analytic answer is 30.7** — a 77% error on a closed,
`Validate`-clean solid with an empty diagnostics array. This makes the answer independent of where
the operand's angle-0 seam happened to land, and flags the fallback that caused it.

## Why

A full-wrap cylinder/cone **wall** carrying lens holes is meshed by unrolling it into the (u,v)
branch the wall's own seam defines (`holedConicWallMesh`), then shifting each hole by whole periods
into that branch. A hole that **straddles the seam** fits no branch, so the mesher declined on a
documented precondition — *"the builder is expected to place the wall's seam clear of its holes"* —
that nothing enforces and no builder can honour:

- `brep.SolidCylinder` takes angle-0 from `axisFrame` → **+Y** for a +Z axis;
- an extruded circle pins it to its **sketch +X** (`extrude_analytic.go`).

So whether a bore straddles the seam is an accident of geometry. On decline the face fell through to
the flat best-fit-plane CDT, which cannot cover a full wrap: **the rim wall meshed to 6.14 of its
12.43 area** — an open mesh, so the divergence-theorem volume is garbage. Nothing reported it.

**It is reachable through the ordinary app path**, not just the raw kernel API. An XY-sketched disk
seams at +X, so a bore sketched on **YZ** runs straight through it:

| bore axis | before | after | analytic |
|---|---|---|---|
| along Y (misses the seam) | 30.706170 | 30.706170 | 30.709068 |
| along X (through the seam) | **7.106490** | **30.706188** | 30.709068 |

## How

The seam of a periodic wall is arbitrary, so cut it somewhere else. `wall_seam_recut.go` splits the
loop back into the two rims it bridges and re-bridges them at the widest hole-free angle, through the
same `bridgeRimsAtSeam` the two-rim band already uses. That helper anchors on **existing** rim
vertices, so it introduces no point a neighbouring cap lacks, and reuses its seam interior on both
rectangle edges so they weld.

Second commit: a cylinder/cone side whose loop wraps the whole period now records a
`tessellate.wall-wrap-unmeshed` **Defect** if it ever reaches the flat CDT again. Note the reach —
`Mesh.Diagnostics` is consumed only inside `kernel/ops` today, so this makes the failure visible to
the kernel and its tests, not yet to the feature reply an add-in reads. Wiring that channel through
is its own piece of work (filed separately).

## Knock-on fix

The bad mesh also made the Requicha guard in `curvedExactGuarded` **reject a sound analytic result**,
so the cut fell back to triangle-soup CSG: 408 all-planar faces at k=1 and a **non-manifold** body
from k=5 up (#2038 reported this at k=20 as an "adjacent finding"). With the wall meshed correctly the
analytic result is accepted and the cut stays exact — 4 faces, 2 true cylinders, valid — at k=1…50.

## Note on the issue as filed

The reported symptom, *"through-all cut removes only half the tunnel"*, is **correct behaviour**. A
through-all extent takes a direction (`ExtrudeDefinition.SetThroughAllExtent`) and
`kPositiveExtentDirection` cuts only the side the sketch normal points to. The `squatrim` driver asked
for the default and asserted a both-directions volume; with `direction: symmetric` the host removes
0.706603 against an analytic tunnel of 0.706858 — **0.036%**. The "regression since July" was two
errors cancelling: that host faceted the whole body (51 planar faces) and its under-tessellated volume
happened to offset the missing half-tunnel. The driver fix and a new `seambore` stress are in
Oblikovati.AddIns.MCPBridge. `TestPositiveThroughAllBoreCutsOneSideOnly` now locks the semantics so it
is not "fixed" later.

## Verification

- **OCCT oracle** — `bcut` of the same two cylinders in DRAWEXE gives **30.7091**; we match to 4e-5 at
  every bore azimuth (0°/45°/90°/135°/180°/270°).
- **Mutation-proved tests** — disabling the re-cut turns the new tests red (φ=90° → 10.03, φ=270° →
  0.09, and the straddling wall declines).
- **Live** — `mcplive --part squatrim --part seambore` both PASS against a real head, at 1× and 20×;
  the app reports volume 30.706188 / area 178.892514. Isometric capture shows an unbroken rim wall
  with a clean bore exit.
- Full `go test ./...` green; `golangci-lint` clean.

Closes #2038

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TBVMFbhWH7akseMqz5GM3
