### PR TITLE
fix(diag): route the tessellator's report to the feature reply

### DIFF
--- a/addin/opregistry/tessellation_diagnostics_test.go
+++ b/addin/opregistry/tessellation_diagnostics_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"encoding/json"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/test-utilities/degenerate"
+
+	"oblikovati.org/app"
+)
+
+// crossedTrimFeature is a feature whose result is deliberately BAD INPUT for the tessellator — a
+// self-crossing trim boundary no triangulation can cover (test-utilities/degenerate). It is a fake
+// on purpose: a body the kernel builds and then meshes badly is a tessellation bug to fix, so there
+// is no shipping feature that reliably degrades, and enshrining one as a fixture would mean shipping
+// the bug it depends on.
+type crossedTrimFeature struct{}
+
+func (crossedTrimFeature) Kind() string { return "crossed-trim" }
+
+func (crossedTrimFeature) Recompute(feature.Input) (feature.Output, error) {
+	return feature.Output{Bodies: []*topo.Body{degenerate.CrossedTrimBody()}}, nil
+}
+
+// TestFeatureReplyCarriesTessellationDiagnostics is the #2058 wire-level regression: the reply an
+// add-in reads must carry what the tessellator recorded, keyed on the tessellation code. This is the
+// assertion #2038 would have failed — there the rim wall meshed to half its area, the body's volume
+// came back 77% low, and `diagnostics` was an empty array.
+func TestFeatureReplyCarriesTessellationDiagnostics(t *testing.T) {
+	def := emptyPart(t)
+	pf := def.Features().Add(crossedTrimFeature{})
+	out, err := recomputeResult(def, pf)
+	if err != nil {
+		t.Fatalf("recomputeResult: %v", err)
+	}
+	var r struct {
+		Diagnostics []struct {
+			Code     string `json:"code"`
+			Severity string `json:"severity"`
+			Detail   string `json:"detail"`
+		} `json:"diagnostics"`
+	}
+	if err := json.Unmarshal(out, &r); err != nil {
+		t.Fatalf("unmarshal reply: %v", err)
+	}
+	for _, d := range r.Diagnostics {
+		if d.Code == string(ops.CodePatchCoverage) && d.Severity == "defect" {
+			return
+		}
+	}
+	t.Errorf("feature reply carries no %q defect; got %s", ops.CodePatchCoverage, out)
+}
+
+// emptyPart seeds a session with one empty part document.
+func emptyPart(t *testing.T) *compdef.PartComponentDefinition {
+	t.Helper()
+	s := app.NewSession()
+	d, err := s.Workspace().Add(doc.Part, "tessdiag.obk", true)
+	if err != nil {
+		t.Fatalf("add document: %v", err)
+	}
+	def := compdef.NewPartComponentDefinition()
+	d.SetContent(def)
+	return def
+}

--- a/kernel/ops/body_mesh_diagnostics.go
+++ b/kernel/ops/body_mesh_diagnostics.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/topo"
+)
+
+// BodyMeshDiagnostics tessellates b at q and returns what the tessellator recorded while meshing its
+// faces, collapsed to one entry per code.
+//
+// The mesher already records its degradations — a saturated interior cap, an uncovered CDT domain, a
+// wall wrap that fell to the flat patch — onto the [Mesh] it returns (see [Mesh.Diagnose]). But a mesh
+// is a value most callers throw away, so until Oblikovati/Oblikovati#2058 every one of those records
+// died at this package's boundary: an add-in saw an empty diagnostics array while the tessellator knew
+// the mesh did not cover its own face (#2038, where that cost 77% of a body's volume, silently). This
+// is the harvest a caller holding a [diag.Recorder] forwards into it, the way
+// [BooleanWithDiagnostics] reports a fallback.
+//
+// It meshes FACES only (edge polylines carry no diagnostics) and is a pure query — nothing is cached
+// and the mesh is discarded, so the cost is one tessellation. A nil body yields nil.
+//
+// Example:
+//
+//	for _, d := range ops.BodyMeshDiagnostics(body, ops.DefaultQuality()) {
+//		rec.Record(d)
+//	}
+func BodyMeshDiagnostics(b *topo.Body, q Quality) []diag.Diagnostic {
+	if b == nil {
+		return nil
+	}
+	_, meshes := tessellateBodyFaces(b, q)
+	tallies := newMeshDiagTallies()
+	for _, m := range meshes {
+		tallies.addMesh(m)
+	}
+	return tallies.collapsed()
+}
+
+// meshDiagTally is one code's running total: the first record seen (its Detail names that face's own
+// numbers) raised to the worst severity any face reported it at, plus how many faces reported it.
+type meshDiagTally struct {
+	first diag.Diagnostic
+	count int
+}
+
+// meshDiagTallies accumulates per-face records by code while preserving first-appearance order, so a
+// body's report reads in meshing order rather than in map order.
+type meshDiagTallies struct {
+	order  []diag.Code
+	byCode map[diag.Code]*meshDiagTally
+}
+
+func newMeshDiagTallies() *meshDiagTallies {
+	return &meshDiagTallies{byCode: map[diag.Code]*meshDiagTally{}}
+}
+
+// addMesh folds one face mesh's records in. A nil mesh (a face the mesher declined) contributes none.
+func (ts *meshDiagTallies) addMesh(m *Mesh) {
+	if m == nil {
+		return
+	}
+	for _, d := range m.Diagnostics {
+		ts.add(d)
+	}
+}
+
+func (ts *meshDiagTallies) add(d diag.Diagnostic) {
+	t, seen := ts.byCode[d.Code]
+	if !seen {
+		t = &meshDiagTally{first: d}
+		ts.byCode[d.Code], ts.order = t, append(ts.order, d.Code)
+	}
+	t.count++
+	if d.Severity > t.first.Severity {
+		t.first.Severity = d.Severity // the worst face wins; a body is as degraded as its worst face
+	}
+}
+
+// collapsed renders one diagnostic per code. Collapsing is not cosmetic: one malformed trim usually
+// repeats on every face that shares it — a whole imported wall, every instance of a pattern — and a
+// few hundred identical lines on a feature reply hide the report instead of being it.
+func (ts *meshDiagTallies) collapsed() []diag.Diagnostic {
+	if len(ts.order) == 0 {
+		return nil
+	}
+	out := make([]diag.Diagnostic, 0, len(ts.order))
+	for _, code := range ts.order {
+		out = append(out, ts.byCode[code].rendered())
+	}
+	return out
+}
+
+// rendered is the tally as one diagnostic: the first face's Detail verbatim when only that face hit
+// it, with the face count appended when more did.
+func (t *meshDiagTally) rendered() diag.Diagnostic {
+	if t.count == 1 {
+		return t.first
+	}
+	d := t.first
+	d.Detail = fmt.Sprintf("%s [recorded while meshing %d of the body's faces]", d.Detail, t.count)
+	return d
+}

--- a/kernel/ops/body_mesh_diagnostics_test.go
+++ b/kernel/ops/body_mesh_diagnostics_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"strings"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/test-utilities/degenerate"
+)
+
+// TestBodyMeshDiagnosticsHarvestsTheTessellatorsReport is the #2058 kernel-side regression: what the
+// mesher recorded onto its Mesh must be readable from outside this package, or it reaches nobody.
+func TestBodyMeshDiagnosticsHarvestsTheTessellatorsReport(t *testing.T) {
+	got := BodyMeshDiagnostics(degenerate.CrossedTrimBody(), DefaultQuality())
+	if len(got) != 1 {
+		t.Fatalf("harvested %d diagnostics from a two-face self-crossing trim, want 1 collapsed entry: %v",
+			len(got), got)
+	}
+	if got[0].Code != CodePatchCoverage || got[0].Severity != diag.Defect {
+		t.Errorf("harvested %v, want a %s Defect", got[0], CodePatchCoverage)
+	}
+	// Both faces carry the flaw, so the collapsed entry must say so rather than imply a single face.
+	if !strings.Contains(got[0].Detail, "meshing 2 of the body's faces") {
+		t.Errorf("collapsed detail %q does not report the 2 affected faces", got[0].Detail)
+	}
+}
+
+// TestBodyMeshDiagnosticsStaysSilentOnCleanBodies guards the false-positive side: the ordinary
+// analytic corpus meshes cleanly, and a channel that cries on healthy geometry is one users learn to
+// ignore (#2058's third acceptance).
+func TestBodyMeshDiagnosticsStaysSilentOnCleanBodies(t *testing.T) {
+	for name, b := range cleanPrimitiveBodies(t) {
+		if got := BodyMeshDiagnostics(b, DefaultQuality()); len(got) != 0 {
+			t.Errorf("clean %s reported %v, want none", name, got)
+		}
+	}
+}
+
+// cleanPrimitiveBodies builds one of each analytic solid the mesher has an exact path for.
+func cleanPrimitiveBodies(t *testing.T) map[string]*topo.Body {
+	t.Helper()
+	cyl, err := brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 10)
+	if err != nil {
+		t.Fatalf("cylinder: %v", err)
+	}
+	sph, err := brep.SolidSphere(math.P3(0, 0, 0), 5, "s")
+	if err != nil {
+		t.Fatalf("sphere: %v", err)
+	}
+	tor, err := brep.SolidTorus(math.P3(0, 0, 0), math.V3(0, 0, 1), 5, 1.5, "t")
+	if err != nil {
+		t.Fatalf("torus: %v", err)
+	}
+	return map[string]*topo.Body{"cylinder": cyl, "sphere": sph, "torus": tor}
+}
+
+// TestBodyMeshDiagnosticsOnNilBodyIsEmpty: the harvest is called on whatever a feature returned, and
+// a nil body in that slice must not panic the recompute it is reporting on.
+func TestBodyMeshDiagnosticsOnNilBodyIsEmpty(t *testing.T) {
+	if got := BodyMeshDiagnostics(nil, DefaultQuality()); got != nil {
+		t.Errorf("nil body reported %v, want nil", got)
+	}
+}

--- a/model/feature/engine.go
+++ b/model/feature/engine.go
@@ -26,11 +26,14 @@ const eopAll = -1
 // the clean prefix, isolates failures as feature health, and supports
 // reorder/rename/suppression and the end-of-part marker (ADR-0010).
 type PartFeatures struct {
-	items        []*PartFeature
-	byID         map[ID]*PartFeature
-	params       *param.Parameters
-	eop          int
-	result       []*topo.Body
+	items  []*PartFeature
+	byID   map[ID]*PartFeature
+	params *param.Parameters
+	eop    int
+	result []*topo.Body
+	// resultDiags is what each body in result CARRIES (its build report, its mesh report), kept
+	// keyed on body identity so an unchanged body is judged once and not re-meshed (#2058).
+	resultDiags  map[*topo.Body][]diag.Diagnostic
 	resources    ResourceStore
 	fonts        text.FontResolver
 	workingScale func() float64 // ADR-0042 Phase 2: live working scale (cm per working unit) for re-import
@@ -175,20 +178,26 @@ func (fs *PartFeatures) MarkAllDirty() {
 // aborts.
 func (fs *PartFeatures) Recompute() {
 	end := fs.effectiveEnd()
-	start := fs.earliestDirty(end)
-	if start < 0 {
+	if start := fs.earliestDirty(end); start < 0 {
 		// Nothing dirty: the result is the cached body state at the cutoff. Re-deriving
 		// it (rather than leaving fs.result untouched) keeps the result correct after a
 		// Remove that shortened the program — the deleted tail no longer contributes.
 		fs.result = fs.prefixBodies(end)
-		return
+	} else {
+		fs.result = fs.evaluateFrom(start, end)
 	}
+	fs.diagnoseResultBodies(end) // what the surviving bodies CARRY, not just what the calls reported (#2058)
+}
+
+// evaluateFrom replays the program from the first dirty feature to the cutoff, threading the running
+// body state through each and poisoning the dependents of any that sickens.
+func (fs *PartFeatures) evaluateFrom(start, end int) []*topo.Body {
 	bodies := fs.prefixBodies(start)
 	sick := fs.sickBefore(start)
 	for i := start; i < end; i++ {
 		bodies = fs.evaluate(fs.items[i], bodies, sick)
 	}
-	fs.result = bodies
+	return bodies
 }
 
 // PreviewResult evaluates a candidate feature as if it were appended at the end-of-part

--- a/model/feature/engine.go
+++ b/model/feature/engine.go
@@ -26,14 +26,11 @@ const eopAll = -1
 // the clean prefix, isolates failures as feature health, and supports
 // reorder/rename/suppression and the end-of-part marker (ADR-0010).
 type PartFeatures struct {
-	items  []*PartFeature
-	byID   map[ID]*PartFeature
-	params *param.Parameters
-	eop    int
-	result []*topo.Body
-	// resultDiags is what each body in result CARRIES (its build report, its mesh report), kept
-	// keyed on body identity so an unchanged body is judged once and not re-meshed (#2058).
-	resultDiags  map[*topo.Body][]diag.Diagnostic
+	items        []*PartFeature
+	byID         map[ID]*PartFeature
+	params       *param.Parameters
+	eop          int
+	result       []*topo.Body
 	resources    ResourceStore
 	fonts        text.FontResolver
 	workingScale func() float64 // ADR-0042 Phase 2: live working scale (cm per working unit) for re-import
@@ -186,7 +183,7 @@ func (fs *PartFeatures) Recompute() {
 	} else {
 		fs.result = fs.evaluateFrom(start, end)
 	}
-	fs.diagnoseResultBodies(end) // what the surviving bodies CARRY, not just what the calls reported (#2058)
+	fs.fileResultBodies(end) // whose body is whose, so Diagnostics() can report what it CARRIES (#2058)
 }
 
 // evaluateFrom replays the program from the first dirty feature to the cutoff, threading the running

--- a/model/feature/part_feature.go
+++ b/model/feature/part_feature.go
@@ -24,11 +24,13 @@ type PartFeature struct {
 	recomputes int
 	cached     []*topo.Body
 	diags      []diag.Diagnostic // kernel diagnostics the OPERATIONS reported last evaluation (#1601)
-	// resultDiags is what the body this feature produced CARRIES, as of the last recompute: the
-	// assembler's build report and the tessellator's. Held apart from diags because it is refreshed
-	// per recompute against the surviving result, not per evaluation (#2058).
-	resultDiags []diag.Diagnostic
-	seq         uint64 // global creation stamp; see model/seq
+	// resultBodies are the bodies this feature produced that survived into the current result, and
+	// resultDiags is what they CARRY (the assembler's build report, the tessellator's) — computed on
+	// first ask, because reading it means meshing them, and memoized until the bodies change (#2058).
+	resultBodies []*topo.Body
+	resultDiags  []diag.Diagnostic
+	resultRead   bool
+	seq          uint64 // global creation stamp; see model/seq
 
 	// paramReads is the model parameters this feature read DIRECTLY during its last
 	// evaluation — a sheet-metal thickness, a suppression condition (NOT the
@@ -58,11 +60,29 @@ func (f *PartFeature) Kind() string { return f.feature.Kind() }
 // what the OPERATIONS reported while it rebuilt (a boolean faceting analytic surfaces, a CSG fallback
 // — #1601), followed by what the body it produced CARRIES (the assembler's build report, the
 // tessellator's — #2058).
+//
+// The second half is computed HERE, on the first ask after a recompute, and memoized until the
+// feature's surviving bodies change: reading it means meshing them, which can cost far more than
+// building them, so the price falls on the caller who wants the answer rather than on every rebuild.
+// Call it from the goroutine that drives the model, like the rest of the recompute engine.
 func (f *PartFeature) Diagnostics() []diag.Diagnostic {
+	if !f.resultRead {
+		f.resultDiags, f.resultRead = bodyDegradations(f.resultBodies), true
+	}
 	if len(f.resultDiags) == 0 {
 		return f.diags
 	}
 	return append(append([]diag.Diagnostic(nil), f.diags...), f.resultDiags...)
+}
+
+// setResultBodies records the bodies this feature produced that survived the recompute, invalidating
+// the memoized report only when they actually changed — an unchanged body's verdict cannot have,
+// since a built body's geometry is immutable.
+func (f *PartFeature) setResultBodies(bodies []*topo.Body) {
+	if sameBodies(f.resultBodies, bodies) {
+		return
+	}
+	f.resultBodies, f.resultDiags, f.resultRead = bodies, nil, false
 }
 
 // Definition returns the wrapped feature recipe.

--- a/model/feature/part_feature.go
+++ b/model/feature/part_feature.go
@@ -23,8 +23,12 @@ type PartFeature struct {
 	dirty      bool
 	recomputes int
 	cached     []*topo.Body
-	diags      []diag.Diagnostic // kernel diagnostics from the last evaluation (#1601)
-	seq        uint64            // global creation stamp; see model/seq
+	diags      []diag.Diagnostic // kernel diagnostics the OPERATIONS reported last evaluation (#1601)
+	// resultDiags is what the body this feature produced CARRIES, as of the last recompute: the
+	// assembler's build report and the tessellator's. Held apart from diags because it is refreshed
+	// per recompute against the surviving result, not per evaluation (#2058).
+	resultDiags []diag.Diagnostic
+	seq         uint64 // global creation stamp; see model/seq
 
 	// paramReads is the model parameters this feature read DIRECTLY during its last
 	// evaluation — a sheet-metal thickness, a suppression condition (NOT the
@@ -49,10 +53,17 @@ func (f *PartFeature) SetName(n string) { f.name = n }
 // Kind returns the wrapped feature's type name.
 func (f *PartFeature) Kind() string { return f.feature.Kind() }
 
-// Diagnostics returns the kernel diagnostics recorded during this feature's last evaluation —
-// degradations that did not sicken it (a boolean faceting analytic surfaces, a CSG fallback) but
-// that users and add-ins must be able to SEE rather than discover downstream (#1601).
-func (f *PartFeature) Diagnostics() []diag.Diagnostic { return f.diags }
+// Diagnostics returns the kernel diagnostics for this feature's current state — degradations that did
+// not sicken it but that users and add-ins must be able to SEE rather than discover downstream. It is
+// what the OPERATIONS reported while it rebuilt (a boolean faceting analytic surfaces, a CSG fallback
+// — #1601), followed by what the body it produced CARRIES (the assembler's build report, the
+// tessellator's — #2058).
+func (f *PartFeature) Diagnostics() []diag.Diagnostic {
+	if len(f.resultDiags) == 0 {
+		return f.diags
+	}
+	return append(append([]diag.Diagnostic(nil), f.diags...), f.resultDiags...)
+}
 
 // Definition returns the wrapped feature recipe.
 func (f *PartFeature) Definition() Feature { return f.feature }

--- a/model/feature/result_diagnostics.go
+++ b/model/feature/result_diagnostics.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+)
+
+// The kernel reports a degradation two ways. An OPERATION-scoped report goes straight into the
+// [diag.Recorder] the caller threaded in — that is how ops.BooleanWithDiagnostics reaches a feature
+// reply. A RESULT-carried report instead rides on the value produced: [topo.Body.BuildDiagnostics]
+// for what the assembler could not do ideally, ops.Mesh.Diagnostics for what the tessellator could
+// not. Nothing outside kernel/ops ever read the second kind, so an add-in saw an empty diagnostics
+// array while the kernel knew the mesh did not cover its own face — which is how Oblikovati#2038
+// shipped a body reading 77% low on volume without a word. This file closes that gap (#2058).
+
+// diagnoseResultBodies drains the result-carried channels of the bodies the recompute left standing
+// and files each body's degradations on the feature that produced it. end is the evaluation cutoff.
+//
+// It reads the RESULT rather than every feature's output because a defect in an intermediate body
+// that a later feature cut away is not something the user has, and reporting it would be a false
+// alarm. A body still standing from the previous pass keeps its verdict — a built body's geometry is
+// immutable — so each body is meshed exactly once, and a recompute that changes nothing is free.
+//
+// It is not free in general: reporting at all costs one display-tolerance mesh of every body a
+// recompute produces (measured +7% on model/feature's suite, +25% on the fillet parity corpus, whose
+// bands are expensive to mesh relative to building them). There is no cheaper honest answer — the
+// reply is written before any consumer has meshed the body, so somebody has to. CLAUDE.md ranks
+// tessellation correctness above features, and a silent 77%-low body (#2038) is what the alternative
+// buys.
+func (fs *PartFeatures) diagnoseResultBodies(end int) {
+	settled := fs.resultDiags
+	fs.resultDiags = make(map[*topo.Body][]diag.Diagnostic, len(fs.result))
+	for _, b := range fs.result {
+		if b != nil {
+			fs.resultDiags[b] = bodyDegradations(settled, b)
+		}
+	}
+	fs.fileResultDiagnostics(end)
+}
+
+// bodyDegradations returns what b carries, reusing the previous pass's verdict when this exact body
+// was already judged (a two-value lookup, so a body known to be CLEAN is remembered as such and not
+// re-meshed).
+func bodyDegradations(settled map[*topo.Body][]diag.Diagnostic, b *topo.Body) []diag.Diagnostic {
+	if known, judged := settled[b]; judged {
+		return known
+	}
+	out := degradationsIn(b.BuildDiagnostics())
+	return append(out, degradationsIn(ops.BodyMeshDiagnostics(b, displayQuality()))...)
+}
+
+// degradationsIn keeps everything that DEGRADED, dropping [diag.Info].
+//
+// Info is defined as "a path was taken, nothing degraded" — e.g. the fillet edge catalog stamps every
+// body it assembles so a kernel corpus gate can tell "reported nothing" from "never ran". That marker
+// is meaningful to the corpus gate and pure noise on a feature reply, which exists to answer "did
+// anything about my feature come out worse than I asked for".
+func degradationsIn(ds []diag.Diagnostic) []diag.Diagnostic {
+	var out []diag.Diagnostic
+	for _, d := range ds {
+		if d.Severity != diag.Info {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// fileResultDiagnostics attributes each result body's degradations to the feature that produced it,
+// REPLACING the previous pass's attribution so repeated recomputes never accumulate duplicates.
+func (fs *PartFeatures) fileResultDiagnostics(end int) {
+	for _, pf := range fs.items {
+		pf.resultDiags = nil
+	}
+	for _, b := range fs.result {
+		producer := fs.producerOf(b, end)
+		if producer == nil || len(fs.resultDiags[b]) == 0 {
+			continue
+		}
+		producer.resultDiags = append(producer.resultDiags, fs.resultDiags[b]...)
+	}
+}
+
+// producerOf returns the feature that made b: the earliest one whose output holds this exact body,
+// since a feature that leaves a body alone hands back the same pointer. A body no feature claims
+// cannot arise from a recomputed result, but if one ever did the last evaluated feature owns it — a
+// report with nowhere to go would be exactly the silence this fixes.
+func (fs *PartFeatures) producerOf(b *topo.Body, end int) *PartFeature {
+	if b == nil || end == 0 {
+		return nil
+	}
+	for _, pf := range fs.items[:end] {
+		if holdsBody(pf.cached, b) {
+			return pf
+		}
+	}
+	return fs.items[end-1]
+}
+
+// holdsBody reports whether bodies contains this exact body (identity, not equality).
+func holdsBody(bodies []*topo.Body, b *topo.Body) bool {
+	for _, held := range bodies {
+		if held == b {
+			return true
+		}
+	}
+	return false
+}
+
+// displayQuality is the tolerance the result drain meshes at: the DISPLAY tolerance, because the mesh
+// whose defects the user is about to meet is the one the viewport draws. Reporting against
+// ops.PropertyQuality() instead would answer a question nobody asked and cost ~10x the facets.
+func displayQuality() ops.Quality { return ops.DefaultQuality() }

--- a/model/feature/result_diagnostics.go
+++ b/model/feature/result_diagnostics.go
@@ -16,70 +16,22 @@ import (
 // array while the kernel knew the mesh did not cover its own face — which is how Oblikovati#2038
 // shipped a body reading 77% low on volume without a word. This file closes that gap (#2058).
 
-// diagnoseResultBodies drains the result-carried channels of the bodies the recompute left standing
-// and files each body's degradations on the feature that produced it. end is the evaluation cutoff.
+// fileResultBodies records which of the bodies the recompute left standing each feature PRODUCED.
+// It is pointer bookkeeping only — no geometry is read — because it runs on every recompute and a
+// recompute must not pay for a report nobody asked for. The reading happens in
+// [PartFeature.Diagnostics].
 //
-// It reads the RESULT rather than every feature's output because a defect in an intermediate body
-// that a later feature cut away is not something the user has, and reporting it would be a false
-// alarm. A body still standing from the previous pass keeps its verdict — a built body's geometry is
-// immutable — so each body is meshed exactly once, and a recompute that changes nothing is free.
-//
-// It is not free in general: reporting at all costs one display-tolerance mesh of every body a
-// recompute produces (measured +7% on model/feature's suite, +25% on the fillet parity corpus, whose
-// bands are expensive to mesh relative to building them). There is no cheaper honest answer — the
-// reply is written before any consumer has meshed the body, so somebody has to. CLAUDE.md ranks
-// tessellation correctness above features, and a silent 77%-low body (#2038) is what the alternative
-// buys.
-func (fs *PartFeatures) diagnoseResultBodies(end int) {
-	settled := fs.resultDiags
-	fs.resultDiags = make(map[*topo.Body][]diag.Diagnostic, len(fs.result))
+// A feature whose set of surviving bodies is unchanged keeps its memoized report: a built body's
+// geometry is immutable, so its verdict cannot have changed.
+func (fs *PartFeatures) fileResultBodies(end int) {
+	produced := make(map[*PartFeature][]*topo.Body, end)
 	for _, b := range fs.result {
-		if b != nil {
-			fs.resultDiags[b] = bodyDegradations(settled, b)
+		if owner := fs.producerOf(b, end); owner != nil {
+			produced[owner] = append(produced[owner], b)
 		}
 	}
-	fs.fileResultDiagnostics(end)
-}
-
-// bodyDegradations returns what b carries, reusing the previous pass's verdict when this exact body
-// was already judged (a two-value lookup, so a body known to be CLEAN is remembered as such and not
-// re-meshed).
-func bodyDegradations(settled map[*topo.Body][]diag.Diagnostic, b *topo.Body) []diag.Diagnostic {
-	if known, judged := settled[b]; judged {
-		return known
-	}
-	out := degradationsIn(b.BuildDiagnostics())
-	return append(out, degradationsIn(ops.BodyMeshDiagnostics(b, displayQuality()))...)
-}
-
-// degradationsIn keeps everything that DEGRADED, dropping [diag.Info].
-//
-// Info is defined as "a path was taken, nothing degraded" — e.g. the fillet edge catalog stamps every
-// body it assembles so a kernel corpus gate can tell "reported nothing" from "never ran". That marker
-// is meaningful to the corpus gate and pure noise on a feature reply, which exists to answer "did
-// anything about my feature come out worse than I asked for".
-func degradationsIn(ds []diag.Diagnostic) []diag.Diagnostic {
-	var out []diag.Diagnostic
-	for _, d := range ds {
-		if d.Severity != diag.Info {
-			out = append(out, d)
-		}
-	}
-	return out
-}
-
-// fileResultDiagnostics attributes each result body's degradations to the feature that produced it,
-// REPLACING the previous pass's attribution so repeated recomputes never accumulate duplicates.
-func (fs *PartFeatures) fileResultDiagnostics(end int) {
 	for _, pf := range fs.items {
-		pf.resultDiags = nil
-	}
-	for _, b := range fs.result {
-		producer := fs.producerOf(b, end)
-		if producer == nil || len(fs.resultDiags[b]) == 0 {
-			continue
-		}
-		producer.resultDiags = append(producer.resultDiags, fs.resultDiags[b]...)
+		pf.setResultBodies(produced[pf])
 	}
 }
 
@@ -109,7 +61,55 @@ func holdsBody(bodies []*topo.Body, b *topo.Body) bool {
 	return false
 }
 
-// displayQuality is the tolerance the result drain meshes at: the DISPLAY tolerance, because the mesh
-// whose defects the user is about to meet is the one the viewport draws. Reporting against
+// sameBodies reports whether two body lists are the same bodies in the same order.
+func sameBodies(a, b []*topo.Body) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// bodyDegradations reads what the bodies carry: the assembler's build report, and what the
+// tessellator records while meshing them.
+//
+// This is the expensive half of #2058 and the reason it is not done during recompute. Meshing can
+// cost far more than building — a modeled thread retypes one face in ~400 µs and meshes as a
+// height-field grid in ~11 ms (thread_test.go's no-boolean budget) — so a recompute that paid for
+// this would make a fast path 27x slower for a report nobody had asked for yet.
+func bodyDegradations(bodies []*topo.Body) []diag.Diagnostic {
+	var out []diag.Diagnostic
+	for _, b := range bodies {
+		if b == nil {
+			continue
+		}
+		out = append(out, degradationsIn(b.BuildDiagnostics())...)
+		out = append(out, degradationsIn(ops.BodyMeshDiagnostics(b, displayQuality()))...)
+	}
+	return out
+}
+
+// degradationsIn keeps everything that DEGRADED, dropping [diag.Info].
+//
+// Info is defined as "a path was taken, nothing degraded" — e.g. the fillet edge catalog stamps every
+// body it assembles so a kernel corpus gate can tell "reported nothing" from "never ran". That marker
+// is meaningful to the corpus gate and pure noise on a feature reply, which exists to answer "did
+// anything about my feature come out worse than I asked for".
+func degradationsIn(ds []diag.Diagnostic) []diag.Diagnostic {
+	var out []diag.Diagnostic
+	for _, d := range ds {
+		if d.Severity != diag.Info {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// displayQuality is the tolerance the result report meshes at: the DISPLAY tolerance, because the
+// mesh whose defects the user is about to meet is the one the viewport draws. Reporting against
 // ops.PropertyQuality() instead would answer a question nobody asked and cost ~10x the facets.
 func displayQuality() ops.Quality { return ops.DefaultQuality() }

--- a/model/feature/result_diagnostics_test.go
+++ b/model/feature/result_diagnostics_test.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/test-utilities/degenerate"
+)
+
+// crossedTrimFeature is a fake feature whose result is deliberately BAD INPUT for the tessellator (a
+// self-crossing trim boundary, see test-utilities/degenerate). It stands in for the real thing —
+// malformed geometry arriving from an import or a degenerate sketch — because a body the kernel
+// itself meshes badly is a tessellation bug to fix, not a fixture to build a regression test on.
+type crossedTrimFeature struct{}
+
+func (crossedTrimFeature) Kind() string { return "crossed-trim" }
+
+func (crossedTrimFeature) Recompute(Input) (Output, error) {
+	return Output{Bodies: []*topo.Body{degenerate.CrossedTrimBody()}}, nil
+}
+
+// passThroughFeature returns the running bodies untouched — a suppressible marker, a work feature,
+// any feature that adds no geometry.
+type passThroughFeature struct{}
+
+func (passThroughFeature) Kind() string { return "pass-through" }
+
+func (passThroughFeature) Recompute(in Input) (Output, error) {
+	return Output{Bodies: in.Bodies}, nil
+}
+
+// discardBodiesFeature drops the running bodies — a delete-body feature, or any operation that
+// consumes what came before it.
+type discardBodiesFeature struct{}
+
+func (discardBodiesFeature) Kind() string { return "discard-bodies" }
+
+func (discardBodiesFeature) Recompute(Input) (Output, error) { return Output{}, nil }
+
+// markedBodyFeature produces a fresh, geometrically clean body carrying a planted build report, so
+// the routing of topo.Body.BuildDiagnostics can be tested independently of any tessellation.
+type markedBodyFeature struct {
+	marks []diag.Diagnostic
+}
+
+func (markedBodyFeature) Kind() string { return "marked-body" }
+
+func (m markedBodyFeature) Recompute(Input) (Output, error) {
+	bld := topo.NewBuilder(false, topo.NewLineage(topo.Tok("test", "marked", 0)))
+	for _, d := range m.marks {
+		bld.Diagnose(d)
+	}
+	return Output{Bodies: []*topo.Body{bld.Build()}}, nil
+}
+
+// TestFeatureReportsTheTessellatorsDefect is the #2058 engine-side regression: a feature whose result
+// does not mesh must say so. Before this, kernel/ops knew and the feature reply was clean — which is
+// how #2038's 77%-low body reached the user without a word.
+func TestFeatureReportsTheTessellatorsDefect(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	pf := fs.Add(crossedTrimFeature{})
+	fs.Recompute()
+	if !hasDiagCode(pf.Diagnostics(), ops.CodePatchCoverage) {
+		t.Fatalf("a feature whose body fails to mesh reports %v, want a %s defect",
+			pf.Diagnostics(), ops.CodePatchCoverage)
+	}
+}
+
+// TestDegradationIsFiledOnTheProducingFeature: a body's defect belongs to whoever MADE the body. A
+// feature that hands its input straight back returns the same *topo.Body, and blaming it would point
+// the user at the wrong row of the browser.
+func TestDegradationIsFiledOnTheProducingFeature(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	bad := fs.Add(crossedTrimFeature{})
+	quiet := fs.Add(passThroughFeature{})
+	fs.Recompute()
+	if !hasDiagCode(bad.Diagnostics(), ops.CodePatchCoverage) {
+		t.Fatalf("the producing feature lost its %s defect: %v", ops.CodePatchCoverage, bad.Diagnostics())
+	}
+	if n := len(quiet.Diagnostics()); n != 0 {
+		t.Errorf("the pass-through feature reports %d diagnostics, want 0: %v", n, quiet.Diagnostics())
+	}
+}
+
+// TestBuildReportReachesTheFeatureWithoutItsInfoMarkers: the assembler's report on the body is the
+// other result-carried channel nothing outside the kernel read. Its Warning/Defect entries must
+// arrive; its Info markers (e.g. "assembled through the fillet edge catalog", which a kernel corpus
+// gate reads) must not, or every fillet would ship noise on the wire.
+func TestBuildReportReachesTheFeatureWithoutItsInfoMarkers(t *testing.T) {
+	const marker, degradation diag.Code = "test.path-marker", "test.degradation"
+	fs := NewPartFeatures(nil)
+	pf := fs.Add(markedBodyFeature{marks: []diag.Diagnostic{
+		{Code: marker, Severity: diag.Info, Detail: "a path was taken"},
+		{Code: degradation, Severity: diag.Warning, Detail: "something came out worse than asked"},
+	}})
+	fs.Recompute()
+	if !hasDiagCode(pf.Diagnostics(), degradation) {
+		t.Errorf("the build report's Warning did not reach the feature: %v", pf.Diagnostics())
+	}
+	if hasDiagCode(pf.Diagnostics(), marker) {
+		t.Errorf("an Info path marker reached the feature reply: %v", pf.Diagnostics())
+	}
+}
+
+// TestRepeatedRecomputesDoNotAccumulateDiagnostics: the result drain re-files on every recompute, and
+// a report that grew a copy each time would turn one defect into a hundred over a session. It also
+// pins the memo — the second pass must reuse the verdict of a body it already judged, not re-mesh it.
+func TestRepeatedRecomputesDoNotAccumulateDiagnostics(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	pf := fs.Add(crossedTrimFeature{})
+	fs.Recompute()
+	first := len(pf.Diagnostics())
+	for i := 0; i < 3; i++ {
+		fs.Recompute()
+	}
+	if got := len(pf.Diagnostics()); got != first {
+		t.Errorf("after 4 recomputes the feature reports %d diagnostics, want the same %d: %v",
+			got, first, pf.Diagnostics())
+	}
+}
+
+// TestDeletedGeometryStopsBeingReported: the drain reads the RESULT, so a defect a later feature cut
+// away must disappear from the report — the model no longer has it, and a stale alarm is as bad as a
+// missing one.
+func TestDeletedGeometryStopsBeingReported(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	bad := fs.Add(crossedTrimFeature{})
+	fs.Add(discardBodiesFeature{})
+	fs.Recompute()
+	if n := len(bad.Diagnostics()); n != 0 {
+		t.Errorf("a feature whose body was removed downstream still reports %d diagnostics: %v",
+			n, bad.Diagnostics())
+	}
+}

--- a/model/feature/result_diagnostics_test.go
+++ b/model/feature/result_diagnostics_test.go
@@ -123,7 +123,29 @@ func TestRepeatedRecomputesDoNotAccumulateDiagnostics(t *testing.T) {
 	}
 }
 
-// TestDeletedGeometryStopsBeingReported: the drain reads the RESULT, so a defect a later feature cut
+// TestRecomputeDoesNotReadTheBodiesUntilAsked pins what the first cut of #2058 got wrong: reading a
+// body's report means MESHING it, which can cost far more than building it — the modeled thread
+// retypes one face in ~400 µs and meshes in ~11 ms, and doing that on every recompute made
+// TestThreadCutModelsRealThreadFast's no-boolean budget fail by 2x on CI. The price belongs to the
+// caller who wants the answer. The memo must also survive a recompute that changed nothing.
+func TestRecomputeDoesNotReadTheBodiesUntilAsked(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	pf := fs.Add(crossedTrimFeature{})
+	fs.Recompute()
+	if pf.resultRead {
+		t.Fatalf("recompute meshed the result body; the report must wait until it is asked for")
+	}
+	pf.Diagnostics()
+	if !pf.resultRead {
+		t.Fatalf("asking for the diagnostics did not read the body")
+	}
+	fs.Recompute() // nothing dirty: the same bodies survive, so the verdict cannot have changed
+	if !pf.resultRead {
+		t.Errorf("a recompute that changed nothing threw the memoized report away")
+	}
+}
+
+// TestDeletedGeometryStopsBeingReported: the report reads the RESULT, so a defect a later feature cut
 // away must disappear from the report — the model no longer has it, and a stale alarm is as bad as a
 // missing one.
 func TestDeletedGeometryStopsBeingReported(t *testing.T) {

--- a/test-utilities/degenerate/crossed_trim.go
+++ b/test-utilities/degenerate/crossed_trim.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package degenerate builds bodies that are deliberately BAD INPUT for the tessellator, so tests
+// that need a mesh degradation can produce one on purpose instead of hunting for a model where the
+// kernel happens to misbehave. That distinction matters: a body the kernel builds and then meshes
+// badly is a tessellation bug to fix (CLAUDE.md ranks those above features), never a fixture to
+// enshrine — whereas a self-crossing trim boundary is malformed geometry no triangulation can cover,
+// so the tessellator's only correct answer is to ship what it can AND say so.
+//
+// Used by the Oblikovati/Oblikovati#2058 regression tests, which assert that the diagnostic those
+// bodies raise reaches the feature reply instead of dying inside kernel/ops.
+package degenerate
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// crossedTrimUV is one bow-tie in (u,v): the loop visits the corners out of order, so edge 0→1
+// crosses edge 2→3. Its signed area is near zero and no triangulation of it covers a well-defined
+// region, which is exactly what the coverage gate is there to catch (kernel/ops/patch_acceptance.go).
+var crossedTrimUV = [][2]float64{{0, 0}, {0.6, 1.2}, {0.1, 4}, {0.7, 0.4}}
+
+// CrossedTrimBody returns an open body whose faces each carry a self-crossing trim boundary, so
+// tessellating it raises ops.CodePatchCoverage — one Defect per face. It has TWO such faces (the
+// same bow-tie at two heights on one elliptical cone) so a consumer that aggregates per-face
+// diagnostics is exercised on a repeat, not just on a single occurrence.
+//
+// The surface is an elliptical cone because it is the analytic surface whose trims go through the
+// best-fit-plane ear-clip that runs the coverage gate; a cylinder or sphere takes the metric-CDT
+// path, which reports the same malformed trim under a different code.
+//
+// Example:
+//
+//	m, _ := ops.TessellateBody(degenerate.CrossedTrimBody(), ops.DefaultQuality())
+//	// m.Diagnostics carries two tessellate.patch-coverage defects
+func CrossedTrimBody() *topo.Body {
+	cone, err := geom.NewEllipticalCone(math.P3(0, 0, 0), math.V3(0, 0, 1), math.V3(1, 0, 0), 0.5, 0.3)
+	if err != nil {
+		panic(fmt.Sprintf("degenerate: NewEllipticalCone(apex 0,0,0 axis +Z major +X, angles 0.5/0.3): %v", err))
+	}
+	bld := topo.NewBuilder(false, topo.NewLineage(topo.Tok("degenerate", "crossed-trim", 0)))
+	for i, vOffset := range []float64{0, 6} {
+		addCrossedTrimFace(bld, cone, vOffset, i)
+	}
+	return bld.Build()
+}
+
+// addCrossedTrimFace lays the bow-tie loop on s, shifted along v, as face number i of the body.
+func addCrossedTrimFace(bld *topo.Builder, s geom.Surface, vOffset float64, i int) {
+	pts := make([]math.Point3, len(crossedTrimUV))
+	for j, c := range crossedTrimUV {
+		pts[j] = s.PointAt(c[0], c[1]+vOffset)
+	}
+	uses := make([]topo.Use, len(pts))
+	verts := make([]*topo.Vertex, len(pts))
+	for j, p := range pts {
+		verts[j] = bld.AddVertex(p, topo.NewLineage(topo.Tok("degenerate", "v", i*len(pts)+j)))
+	}
+	for j := range pts {
+		k := (j + 1) % len(pts)
+		e := bld.AddEdge(geom.NewLineSegment(pts[j], pts[k]), verts[j], verts[k],
+			topo.NewLineage(topo.Tok("degenerate", "e", i*len(pts)+j)))
+		uses[j] = topo.Fwd(e)
+	}
+	bld.AddFace(s, topo.NewLineage(topo.Tok("degenerate", "f", i)), topo.OuterLoop(uses...))
+}

--- a/test-utilities/degenerate/crossed_trim_test.go
+++ b/test-utilities/degenerate/crossed_trim_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package degenerate
+
+import "testing"
+
+// TestCrossedTrimLoopActuallyCrosses guards the fixture's whole reason to exist. Every #2058 test
+// asserts that a diagnostic REACHES the caller; if this loop ever stopped crossing itself, the
+// tessellator would have nothing to report and those tests would go green for the wrong reason.
+func TestCrossedTrimLoopActuallyCrosses(t *testing.T) {
+	// Edge 0→1 against edge 2→3: the pair the out-of-order corner visit crosses.
+	if !segmentsCross(crossedTrimUV[0], crossedTrimUV[1], crossedTrimUV[2], crossedTrimUV[3]) {
+		t.Fatalf("crossedTrimUV %v is a simple polygon — it no longer degrades any triangulation",
+			crossedTrimUV)
+	}
+}
+
+// TestCrossedTrimBodyCarriesTwoFaces pins the repeat that lets a consumer's per-code aggregation be
+// tested on more than a single occurrence.
+func TestCrossedTrimBodyCarriesTwoFaces(t *testing.T) {
+	if n := len(CrossedTrimBody().Faces()); n != 2 {
+		t.Errorf("CrossedTrimBody has %d faces, want 2 (one bow-tie at each height)", n)
+	}
+}
+
+// segmentsCross reports whether the open segments a→b and c→d intersect, by the standard
+// opposite-orientation test on both endpoint pairs.
+func segmentsCross(a, b, c, d [2]float64) bool {
+	return orientation(a, b, c)*orientation(a, b, d) < 0 &&
+		orientation(c, d, a)*orientation(c, d, b) < 0
+}
+
+// orientation is the signed area of triangle p,q,r: positive counter-clockwise, negative clockwise.
+func orientation(p, q, r [2]float64) float64 {
+	return (q[0]-p[0])*(r[1]-p[1]) - (q[1]-p[1])*(r[0]-p[0])
+}


### PR DESCRIPTION
## What

`kernel/ops` records tessellation degradations onto the `Mesh` it returns — `tessellate.cdt-constraint-leak`, `patch-coverage`, `cap-saturated`, `domain-uncovered`, `wall-wrap-unmeshed`. **Nothing outside `kernel/ops` ever read `Mesh.Diagnostics`**, so every one of those codes was visible to the kernel and its own tests and to nobody else: an add-in calling `add_feature` got `diagnostics: []` while the mesher knew the mesh did not cover its own face.

The same was true of the second result-carried channel, `topo.Body.BuildDiagnostics` — the assembler's report, which `assemble.edge-curve-conflict` (Defect) and `edge-curve-nil-offer` (Warning) ride on.

This routes both into the `diag` stream the boolean already uses, so a degradation surfaces on the feature that produced the body — the way `boolean.csg-fallback` does.

## Why

This is the split-out of #2038, where it was the reason a catastrophic mesh defect shipped silently: the rim wall meshed to 6.14 of its 12.43 area, the body's volume came back **77% low**, and the feature reply was clean. It is also why `patch_acceptance_test`'s standing promise that a self-crossing trim is *"visible in feature diagnostics and over the wire"* was not actually true.

## How

- **`ops.BodyMeshDiagnostics(body, quality)`** — meshes a body's faces and returns what the tessellator recorded, collapsed to one entry per code. Collapsing is not cosmetic: one malformed trim repeats on every face that shares it, and a few hundred identical lines hide the report instead of being it.
- **`PartFeatures.fileResultBodies`** — at the end of each recompute, records which surviving bodies each feature produced. Pointer bookkeeping only; no geometry is read.
- **`PartFeature.Diagnostics()`** — returns what the **operations** reported (#1601) followed by what the **bodies carry** (#2058), reading the bodies on the first ask and memoizing until they change. The wire shape is unchanged.

Three design calls, each documented at the code:

1. **Lazy, not on every recompute.** Reading a body's report means *meshing* it, and meshing can cost far more than building — see the cost note below. The price belongs to the caller who wants the answer.
2. **Read the RESULT, not every feature's output.** A defect in an intermediate body a later feature cut away is not something the user has, and reporting it would be a false alarm.
3. **`Info` records are dropped.** Info means "a path was taken, nothing degraded" — e.g. the fillet edge catalog stamps every body it assembles so a kernel corpus gate can tell "reported nothing" from "never ran". Meaningful to the gate, pure noise on a feature reply.

Reporting is against the **display** tolerance, not `PropertyQuality` — the mesh whose defects the user is about to meet is the one the viewport draws.

### Cost — and the first design that was wrong about it

The first commit drained both channels eagerly at the end of every recompute. CI caught it: `TestThreadCutModelsRealThreadFast` asserts a modeled thread retypes one face with no boolean and stays under 50 ms, and it failed at **102 ms** on the Windows runner. Measured locally, that recompute went **408 µs → 11 ms (27×)** purely from the added mesh — a threaded face meshes as a fine height-field grid, far dearer than the O(1) retype that builds it.

The second commit makes the read lazy. **Recompute is byte-identical in cost to before this PR** (408 µs on the thread case); the mesh is paid once, by whoever asks, and memoized. That existing thread budget is now the standing guard against anyone making it eager again, alongside a new white-box test that a recompute leaves the report unread.

## Tests

The fixture is deliberately synthetic and the reason is worth stating: **a body the kernel builds and then meshes badly is a tessellation bug to fix, not a fixture to enshrine.** I swept spheres, tori, cones, hemispheres, bored solids and crossing cylinders — the tessellator is clean on all of them. So `test-utilities/degenerate` builds malformed *input* (a self-crossing trim boundary, which no triangulation can cover) — the case where shipping-what-it-can-and-saying-so is the tessellator's only correct answer.

- `kernel/ops` — the harvest surfaces a `patch-coverage` Defect, collapses two affected faces into one entry, stays silent on the clean analytic primitives, and survives a nil body.
- `model/feature` — the defect reaches the feature; it is filed on the **producing** feature, not on a pass-through; the build report's Warning arrives while its Info marker does not; a recompute does not read the bodies until asked, and keeps the memo when nothing changed; repeated recomputes do not accumulate; geometry deleted downstream stops being reported.
- `addin/opregistry` — the wire-level regression: the JSON reply carries the tessellation code. **This is the assertion #2038 would have failed.**
- `test-utilities/degenerate` — the fixture's own guard: if that loop ever stopped crossing itself, every test above would go green for the wrong reason.

Every level was mutation-proved (disable the routing → all fail; break the tally → the collapse assertion fails; make the read eager again → the laziness guard fails).

## Verification

- `go test ./...` green; `golangci-lint run ./...` 0 issues; `gofmt` clean.
- Live via MCPBridge (Oblikovati/Oblikovati.AddIns.MCPBridge#99, new `meshdiag` driver), re-run against a head built from the final commit: the positive control confirms the diagnostics array reaches the caller non-empty in the running app; the clean seam-bore model reports **0 diagnostics** on both features with volume 30.706188 (rel 1e-4) and 245653.06 at 20×, the 20× rebuild-and-measure taking 227 ms.
- `squatrim`, `seambore`, `facetdiag` all still PASS — no regression.
- Screenshots (iso/front/top) show an unbroken rim with a clean bore exit; volume/area identical to the values recorded when #2038 was closed.

Closes #2058

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TBVMFbhWH7akseMqz5GM3