### PR TITLE
fix(kernel): exact analytic boolean for a coaxial sphere and cylinder (#2036)

### DIFF
--- a/architecture/decisions/ADR-0045-curved-boolean-kind-taxonomy.md
+++ b/architecture/decisions/ADR-0045-curved-boolean-kind-taxonomy.md
@@ -64,6 +64,7 @@ arrangement. The taxonomy is the deliverable, not a forced merge into one functi
 | **Curved-on-planar (interior)** | one closed conic **strictly inside** a planar face, added as an inner loop | degenerate (no band to subdivide) | build the pierced face + wall + cap and `curvedStitch` | drill through-hole, cylinder boss |
 | **Curved-on-planar (partial)** | the imprint conic **CLIPS** the planar face boundary (pierced but not clean) | degenerate | trim the pierced face(s) through a bounded non-periodic `planeUV` `(u,v)` arrangement + assemble the partial wall/cap (ADR-0049) | edge scallop (partial drill), straddling boss |
 | **Degenerate overlap** | 2-D region of **coincident** surfaces | no | simplify to the merged analytic solid | coaxial cylinder union |
+| **Transversal, split by construction** | 1-D curve that is one **planar conic bisecting a closed surface** — the surface has no rims or seam to subdivide | yes, in closed form | name which of the two regions survives and `curvedStitch` | coaxial ball ∪/−/∩ rod (the ball stud), ADR-0045 addendum below |
 
 Concretely:
 
@@ -110,3 +111,41 @@ Concretely:
 - **A heavyweight `classifyContact` pre-classifier replacing the gated try-list.** Rejected: the
   gated list already declines cleanly and logs its CSG fallback; a classifier would be ceremony
   isolating no new invariant.
+
+## Addendum — 2026-08-06: a transversal crossing that is still not an arrangement (#2036)
+
+`ops.Boolean` had no entry for **sphere ∪ cylinder**, so a ball stud (a ball head on a coaxial shank)
+fell through to triangle-soup CSG and shipped an inscribed polyhedron 1.3% under volume. Closing that
+gap adds a row to the table above rather than bending an existing one, because the pair is transversal
+— the surfaces genuinely cross in a 1-D curve — yet the `(u,v)` arrangement still does not apply.
+
+The load-bearing invariant this ADR states is *"the `(u,v)` arrangement is for transversal crossings of
+**periodic** surfaces"*, and the emphasis is doing the work: `paramOf` reads `u` as an azimuth and `v`
+as axial distance **between two rim circles**. A sphere has no rims. It also has no meaningful seam —
+`geom.Sphere`'s is a parameterisation artefact fixed to world `+Z`, unrelated to where the rod enters.
+And when the rod is COAXIAL with the ball, the contact is a single **planar circle**, which splits a
+sphere into exactly two caps by construction. There is nothing for a cell classifier to decide: naming
+which cap survives *is* the split. So the handler is a direct assembly (three analytic faces) in
+`kernel/brep/curved_coaxial_sphere_rod*.go`, in the same spirit as the drill and the boss.
+
+Two consequences worth recording:
+
+- **The recognizer is a port, not an invention.** OCCT special-cases exactly this pair in
+  `IntAna_QuadQuadGeo::Perform(gp_Cylinder, gp_Sphere)`: an axis through the sphere centre yields
+  `IntAna_Circle` at ±√(R_s²−R_c²) along the axis, and every other configuration is
+  `IntAna_NoGeometricSolution` — handed to the numeric marcher. We decline the same three cases OCCT
+  declines (off-axis, ball no larger than the rod, equal radii). An off-axis sphere∩cylinder is a
+  quartic space curve and stays on the CSG fallback.
+- **Winding, not sense, names the region on a closed surface.** For a face bounded by one circle on a
+  sphere, the loop direction is what selects which cap survives, and `kernel/ops` reads exactly that
+  (`capAxis`, `sphere_cap_mesh.go`). The cylindrical band and the planar disc cover the same region
+  either way, so they take whatever direction the cap leaves them — that is how the assembly satisfies
+  `ops.Validate`'s anti-parallel edge-use invariant while still meshing the intended cap. Getting it
+  backwards costs nothing at build time and yields a closed, manifold solid of the RIGHT volume that
+  `Validate` rejects only on orientation.
+
+**Scope left open.** A rod passing right THROUGH the ball meets it in *two* circles, and the surviving
+ball face is then the belt between them — a spherical zone straddling the equator of its own band axis.
+`kernel/ops` has no analytic mesh for that shape (measured: ~75% of its area goes missing), which is why
+`revolution.go`'s `sphereZoneAnalytic` also gates equator-crossing zones out. That configuration keeps
+the faceted CSG fallback until the zone mesh exists.

--- a/kernel/brep/curved_coaxial_sphere_rod.go
+++ b/kernel/brep/curved_coaxial_sphere_rod.go
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Coaxial sphere ∩ cylinder — the ball-stud family (Oblikovati#2036). A rod whose axis passes through
+// a ball's centre meets it in a CIRCLE, and that is the one sphere∩cylinder configuration with a
+// closed-form answer: OCCT solves exactly this case analytically in
+// IntAna_QuadQuadGeo::Perform(const gp_Cylinder&, const gp_Sphere&) — axis through the centre gives
+// IntAna_Circle at ±√(R_s²−R_c²) along the axis — and returns IntAna_NoGeometricSolution for every
+// off-axis pair, handing those to the numeric marcher. This file ports that recognizer; the four
+// solids its single circle bounds are assembled in curved_coaxial_sphere_rod_build.go.
+//
+// KIND (ADR-0045): the contact is a 1-D curve, so this is TRANSVERSAL — but it does NOT ride the (u,v)
+// arrangement, for the same reason the drill and the boss don't. The arrangement earns its keep when an
+// imprint subdivides a periodic band non-trivially; here the imprint is one PLANAR circle and a sphere
+// is not a rim-bounded band at all. A circle on a sphere splits it into exactly two caps by
+// construction, so there is nothing for a cell classifier to decide: naming which cap survives IS the
+// split (compare DrillThroughHole, where "the circle is an inner loop" is likewise the whole answer).
+//
+// SCOPE — the ONE-CIRCLE configurations, where the rod has one cap strictly INSIDE the ball and one
+// strictly OUTSIDE it:
+//
+//	∪  ball + protruding stub          (the ball stud / rod end)
+//	−  ball − rod  = a blind spherical bore with a flat bottom (a socket)
+//	−  rod − ball  = the free stub with a spherical dimple in its base
+//	∩  the plug: the buried length of the rod, domed by the ball
+//
+// A rod that passes RIGHT THROUGH the ball (two circles) is deliberately NOT handled. Its result needs
+// a spherical ZONE face — the belt between the two circles — and that belt straddles the equator of its
+// own band axis, which is exactly the shape kernel/ops has no analytic mesh for (revolution.go's
+// sphereZoneAnalytic gates equator-crossing bands out for the same reason, so no revolve emits one
+// either): measured, such a face tessellates to a quarter of its true area. Declining keeps the
+// faceted-but-honest CSG fallback until that mesh path exists (#2036 follow-up).
+
+// coaxialSphereCircleOffset returns the axial distance from the sphere centre to each circle in which
+// an INFINITE cylinder cuts the sphere, when the cylinder's axis passes through that centre. It is the
+// port of OCCT IntAna_QuadQuadGeo::Perform(gp_Cylinder, gp_Sphere): the two circles sit at
+// centre ± √(R_s²−R_c²)·axis with radius R_c. ok=false reproduces OCCT's two declines — an off-axis
+// cylinder (IntAna_NoGeometricSolution: a quartic space curve, not a circle) and a sphere no larger
+// than the cylinder (IntAna_Empty) — plus the equal-radius case OCCT reports as a single circle, which
+// is an internal TANGENCY and so not a transversal boolean this file can build.
+//
+// Example: a Ø10 ball and a coaxial Ø6 rod give 4 — the seam circle sits 4 mm off the centre.
+func coaxialSphereCircleOffset(sph geom.Sphere, cyl geom.Cylinder) (float64, bool) {
+	tol := geom.ResolutionForSize(sph.Radius).Plane()
+	if pointAxisDistance(sph.Center, cyl.Origin, cyl.AxisDir.AsVector()) > tol {
+		return 0, false // OCCT: the axis misses the sphere centre → IntAna_NoGeometricSolution
+	}
+	if sph.Radius <= cyl.Radius {
+		return 0, false // OCCT: IntAna_Empty — the ball fits inside the rod, no intersection curve
+	}
+	d := stdmath.Sqrt(sph.Radius*sph.Radius - cyl.Radius*cyl.Radius)
+	if d <= tol {
+		return 0, false // the two circles have collapsed onto one: a tangential, non-transversal contact
+	}
+	return d, true
+}
+
+// pointAxisDistance is the perpendicular distance from p to the line through origin along unit dir.
+func pointAxisDistance(p, origin math.Point3, dir math.Vector3) float64 {
+	v := origin.VectorTo(p)
+	return float64(v.Sub(dir.Scale(v.Dot(dir))).Length())
+}
+
+// axialCoord is p's coordinate along dir measured from from — the axis parameter every extent test in
+// this file uses, with the sphere centre as the origin.
+func axialCoord(from, p math.Point3, dir math.Vector3) float64 {
+	return float64(from.VectorTo(p).Dot(dir))
+}
+
+// sphereSolidOf resolves a body as a bare ball: one boundary-less geom.Sphere face, which is what both
+// SolidSphere and a 360° revolve of an on-axis semicircle build. It returns the face's lineage too, so
+// the trimmed ball keeps its reference key across the boolean (ADR-0043 K1a). ok=false once the sphere
+// carries any boundary — an already-trimmed ball is a different, unhandled shape.
+func sphereSolidOf(b *topo.Body) (geom.Sphere, topo.Lineage, bool) {
+	faces := b.Faces()
+	if len(faces) != 1 || len(faces[0].Loops()) != 0 {
+		return geom.Sphere{}, topo.Lineage{}, false
+	}
+	sph, ok := faces[0].Geometry().(geom.Sphere)
+	return sph, faces[0].Lineage(), ok
+}
+
+// rodSolid is a bare SolidCylinder parsed once: its surface, its two cap centres, and each face's
+// lineage, so every face that survives the boolean whole keeps its reference key (ADR-0043 K1a).
+type rodSolid struct {
+	cyl       geom.Cylinder
+	base, top math.Point3 // cap centres, base the lower one along cyl.AxisDir
+	wall      topo.Lineage
+	baseCap   topo.Lineage
+	topCapLin topo.Lineage
+}
+
+// rodSolidOf parses a bare cylinder solid — one cylindrical side plus two planar caps — or declines.
+func rodSolidOf(b *topo.Body) (rodSolid, bool) {
+	faces := facesOfAny(b)
+	cyl, base, height, ok := cylinderSolidParams(faces)
+	if !ok {
+		return rodSolid{}, false
+	}
+	r := rodSolid{cyl: cyl, base: base, top: base.TranslateBy(cyl.AxisDir.AsVector().Scale(math.Scalar(height)))}
+	r.wall, r.baseCap, r.topCapLin = rodFaceLineages(faces, r.base)
+	return r, true
+}
+
+// rodFaceLineages splits the parsed faces' lineages into the side and the two caps, telling the caps
+// apart by which plane sits on the base centre. cylinderSolidParams has already guaranteed exactly one
+// cylinder and two planes, so the pair is complete by construction.
+func rodFaceLineages(faces []curvedFace, base math.Point3) (wall, baseCap, topCap topo.Lineage) {
+	var caps [2]struct {
+		lineage topo.Lineage
+		dist    float64
+	}
+	n := 0
+	for _, f := range faces {
+		pl, isPlane := f.surface.(geom.Plane)
+		if !isPlane {
+			wall = f.lineage
+			continue
+		}
+		caps[n].lineage, caps[n].dist = f.lineage, float64(base.VectorTo(pl.Origin).Length())
+		n++
+	}
+	if caps[0].dist <= caps[1].dist {
+		return wall, caps[0].lineage, caps[1].lineage
+	}
+	return wall, caps[1].lineage, caps[0].lineage
+}
+
+// coaxialRod is a recognised ball + coaxial rod whose surfaces meet in exactly ONE circle: the rod's
+// buried cap lies strictly inside the ball and its free cap strictly outside. Every assembly in
+// curved_coaxial_sphere_rod_build.go is three faces drawn from this one frame.
+type coaxialRod struct {
+	ball, rod *topo.Body
+	sph       geom.Sphere
+	cyl       geom.Cylinder
+	out       math.Vector3 // unit rod axis, buried cap → free cap
+	buried    geom.Circle  // the rod rim inside the ball
+	free      geom.Circle  // the rod rim outside the ball
+	seam      geom.Circle  // cylinder ∩ sphere — OCCT's IntAna_Circle
+	ballLin   topo.Lineage
+	wallLin   topo.Lineage
+	buriedLin topo.Lineage
+	freeLin   topo.Lineage
+}
+
+// coaxialRodOf resolves either argument order into a coaxialRod, so a caller never has to know which
+// operand is the ball. ok=false when the pair is not the single-circle coaxial family.
+func coaxialRodOf(a, b *topo.Body) (coaxialRod, bool) {
+	if r, ok := coaxialRodOrdered(a, b); ok {
+		return r, true
+	}
+	return coaxialRodOrdered(b, a)
+}
+
+// coaxialRodOrdered resolves ball as the sphere and rod as the cylinder, or declines.
+func coaxialRodOrdered(ball, rod *topo.Body) (coaxialRod, bool) {
+	sph, ballLin, okS := sphereSolidOf(ball)
+	rs, okR := rodSolidOf(rod)
+	if !okS || !okR {
+		return coaxialRod{}, false
+	}
+	d, okD := coaxialSphereCircleOffset(sph, rs.cyl)
+	if !okD {
+		return coaxialRod{}, false
+	}
+	return coaxialRodEnds(coaxialRod{ball: ball, rod: rod, sph: sph, cyl: rs.cyl, ballLin: ballLin,
+		wallLin: rs.wall}, rs, d)
+}
+
+// coaxialRodEnds picks which rod cap is buried and which is free, and declines every other extent. A
+// cap counts as BURIED only when its whole disc is inside the ball (|s| < d, since the disc's far edge
+// sits at √(s²+R_c²)) and FREE only when its whole disc is outside (|s| > R_s). A cap landing in the
+// band between — the rod stopping part way through the ball's shoulder — leaves an annular cap bounded
+// by a plane∩sphere circle, a different solid; a rod clearing BOTH sides is the two-circle case the
+// file header rules out.
+func coaxialRodEnds(r coaxialRod, rs rodSolid, d float64) (coaxialRod, bool) {
+	axis := rs.cyl.AxisDir.AsVector()
+	tol := geom.ResolutionForSize(r.sph.Radius).Plane()
+	sBase, sTop := axialCoord(r.sph.Center, rs.base, axis), axialCoord(r.sph.Center, rs.top, axis)
+	buried := func(s float64) bool { return stdmath.Abs(s) < d-tol }
+	free := func(s float64) bool { return stdmath.Abs(s) > r.sph.Radius+tol }
+	switch {
+	case buried(sBase) && free(sTop):
+		return r.withEnds(rs.base, rs.top, rs.baseCap, rs.topCapLin, d)
+	case buried(sTop) && free(sBase):
+		return r.withEnds(rs.top, rs.base, rs.topCapLin, rs.baseCap, d)
+	}
+	return coaxialRod{}, false
+}
+
+// withEnds completes the frame: the seam circle at OCCT's offset, and one circle per rod rim sharing
+// the seam's angle-0 reference direction so all three rims' PointAt(0) line up on a single ruling —
+// what lets the wall seams weld.
+func (r coaxialRod) withEnds(buried, free math.Point3, buriedLin, freeLin topo.Lineage, d float64) (coaxialRod, bool) {
+	r.out = unit(buried.VectorTo(free))
+	seam, err := geom.NewCircle(r.sph.Center.TranslateBy(r.out.Scale(math.Scalar(d))), r.out, r.cyl.Radius)
+	if err != nil {
+		return coaxialRod{}, false
+	}
+	r.seam, r.buried, r.free = seam, coaxialCircleAt(seam, buried), coaxialCircleAt(seam, free)
+	r.buriedLin, r.freeLin = buriedLin, freeLin
+	return r, true
+}
+
+// coaxialCircleAt copies a circle's whole frame (normal, angle-0 reference, radius) to another centre
+// on its axis, so both circles' PointAt(t) agree in azimuth.
+func coaxialCircleAt(base geom.Circle, center math.Point3) geom.Circle {
+	return geom.Circle{Center: center, Normal: base.Normal, RefDir: base.RefDir, Radius: base.Radius}
+}

--- a/kernel/brep/curved_coaxial_sphere_rod_build.go
+++ b/kernel/brep/curved_coaxial_sphere_rod_build.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// The four solids a coaxial ball-and-rod pair bounds (Oblikovati#2036). Every one of them is THREE
+// analytic faces off the frame curved_coaxial_sphere_rod.go recognised — a spherical cap, a
+// cylindrical band, and a planar disc — because the single seam circle splits each operand's surface
+// in two and the boolean is only a choice of which halves to keep:
+//
+//	           ball cap kept | rod band       | disc          | inverted faces
+//	∪ join     far  (−out)   | seam → free    | free,  +out   | none
+//	− ball−rod far  (−out)   | buried → seam  | buried, +out  | the band, turned into the bore
+//	− rod−ball near (+out)   | seam → free    | free,  +out   | the ball cap, turned into a dimple
+//	∩ intersect near (+out)  | buried → seam  | buried, −out  | none
+//
+// WINDING. The seam circle is shared by the ball cap and the band, and the rod rim by the band and the
+// disc, so one decision fixes all three: ops.Validate requires an edge's two uses to run opposite ways.
+// Only the ball cap's direction carries meaning — on a sphere the loop is what NAMES which cap survives
+// and the tessellator reads exactly that (capAxis) — while a cylindrical band and a planar disc cover
+// the same region either way. So the cap chooses, the other two follow, and which side holds material
+// is carried by the face sense alone. Getting this backwards costs nothing at build time and produces a
+// closed, manifold solid of the right volume that ops.Validate rejects on orientation.
+
+// CoaxialSphereRodJoin returns a ∪ b for a ball and a coaxial rod that ends inside it — the ball stud.
+// The result is the ball minus the cap the rod covers, the rod's free stub, and the stub's end cap.
+//
+// Example:
+//
+//	ball, _ := brep.SolidSphere(math.P3(0,0,0), 0.5, "ball")
+//	rod, _ := brep.SolidCylinder(math.P3(0,0,0), math.V3(0,1,0), 0.3, 1.5)
+//	stud, ok := brep.CoaxialSphereRodJoin(ball, rod) // ok: one solid, 3 analytic faces
+func CoaxialSphereRodJoin(a, b *topo.Body) (*topo.Body, bool) {
+	r, ok := coaxialRodOf(a, b)
+	if !ok {
+		return nil, false
+	}
+	return r.assemble(rodResult{keepNearCap: false, rim: r.free, rimLin: r.freeLin, outward: r.out})
+}
+
+// CoaxialSphereRodCut returns target − tool for a ball and a coaxial rod that ends inside it: a blind
+// spherical bore when the ball is the target, the dimpled free stub when the rod is.
+func CoaxialSphereRodCut(target, tool *topo.Body) (*topo.Body, bool) {
+	r, ok := coaxialRodOf(target, tool)
+	if !ok {
+		return nil, false
+	}
+	if r.ball == target {
+		// ball − rod: the ball's surface outside the rod, the rod's buried wall turned inward as the
+		// bore, and the rod's buried cap as the flat pocket bottom — whose outward normal points along
+		// +out, into the material that was removed.
+		return r.assemble(rodResult{rim: r.buried, rimLin: r.buriedLin, outward: r.out, bandInverted: true})
+	}
+	// rod − ball: the free stub, its base hollowed by the ball's own surface. The ball cap is the NEAR
+	// one and inverted — the material now sits outside the ball, so the sphere's outward radial normal
+	// points into the solid.
+	return r.assemble(rodResult{keepNearCap: true, capInverted: true,
+		rim: r.free, rimLin: r.freeLin, outward: r.out})
+}
+
+// CoaxialSphereRodIntersect returns a ∩ b: the plug, the buried length of the rod capped by the ball's
+// own dome. Unlike a full crossing's intersect it carries the rod's PLANAR buried cap, which lies
+// inside the ball and so survives into the common material.
+func CoaxialSphereRodIntersect(a, b *topo.Body) (*topo.Body, bool) {
+	r, ok := coaxialRodOf(a, b)
+	if !ok {
+		return nil, false
+	}
+	return r.assemble(rodResult{keepNearCap: true,
+		rim: r.buried, rimLin: r.buriedLin, outward: r.out.Scale(-1)})
+}
+
+// rodResult is one of the four results as a choice of halves: which ball cap survives, which rod rim
+// the band runs to, which way that rim's disc faces, and which of the two faces is inverted (its
+// material on the far side of its own surface).
+type rodResult struct {
+	keepNearCap  bool         // keep the small cap the stub protrudes toward, not the rest of the ball
+	capInverted  bool         // the ball cap is a dimple: material outside the ball
+	bandInverted bool         // the rod wall is a bore: material outside the cylinder
+	rim          geom.Circle  // the rod rim the band runs to from the seam
+	rimLin       topo.Lineage // that rim's cap face, so its reference key survives (ADR-0043 K1a)
+	outward      math.Vector3 // which way the disc closing rim faces out of the solid
+}
+
+// assemble welds the three faces. capForward is the pivot: it is the direction the ball cap walks the
+// seam circle, so the band must take the seam the other way (hence the near/far swap), and the disc
+// must in turn oppose the band on the rim — which lands on capForward again, since the band walks its
+// near circle forward and its far circle backward.
+func (r coaxialRod) assemble(res rodResult) (*topo.Body, bool) {
+	keep := r.out
+	if !res.keepNearCap {
+		keep = r.out.Scale(-1)
+	}
+	near, far := r.seam, res.rim
+	if res.keepNearCap { // the cap already walked the seam forward
+		near, far = res.rim, r.seam
+	}
+	disc, ok := discFace(res.rim, !res.keepNearCap, res.outward, res.rimLin)
+	if !ok {
+		return nil, false
+	}
+	return curvedStitch([]curvedFace{
+		sphereCapFace(r.sph, r.seam, keep, res.capInverted, r.ballLin),
+		cylinderBandFace(r.cyl, near, far, res.bandInverted, r.wallLin),
+		disc,
+	}), true
+}

--- a/kernel/brep/curved_coaxial_sphere_rod_test.go
+++ b/kernel/brep/curved_coaxial_sphere_rod_test.go
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Coaxial sphere ∩ cylinder — the ball-stud family (Oblikovati#2036), ported from OCCT's
+// IntAna_QuadQuadGeo::Perform(gp_Cylinder, gp_Sphere). These tests pin the recognizer: the closed-form
+// circle offset, the three configurations OCCT itself declines, and the rod extents that fall outside
+// the one-circle family this handler builds.
+
+// ballAndRod is the reference pair: a ball of radius R at the origin and a coaxial rod of radius rc
+// running along +Y from y=y0 to y=y0+length.
+func ballAndRod(t *testing.T, ballR, rodR, y0, length float64) (*topo.Body, *topo.Body) {
+	t.Helper()
+	ball, err := SolidSphere(math.P3(0, 0, 0), ballR, "ball")
+	if err != nil {
+		t.Fatalf("SolidSphere(R=%g): %v", ballR, err)
+	}
+	rod, err := SolidCylinder(math.P3(0, math.Scalar(y0), 0), math.V3(0, 1, 0), rodR, length)
+	if err != nil {
+		t.Fatalf("SolidCylinder(r=%g, y0=%g, L=%g): %v", rodR, y0, length, err)
+	}
+	return ball, rod
+}
+
+// TestCoaxialSphereCircleOffsetMatchesTheClosedForm pins the ported formula: the seam circles sit at
+// ±√(R_s²−R_c²) along the axis. A Ø10 ball on a Ø6 shank puts them 4 mm from the centre — the 3-4-5
+// triangle the NopSCADlib ball stud in #2036 is built on.
+func TestCoaxialSphereCircleOffsetMatchesTheClosedForm(t *testing.T) {
+	for _, c := range []struct{ ballR, rodR, want float64 }{
+		{5, 3, 4}, {0.5, 0.3, 0.4}, {13, 5, 12},
+	} {
+		sph, _ := geom.NewSphere(math.P3(0, 0, 0), c.ballR)
+		cyl, _ := geom.NewCylinder(math.P3(0, 0, 0), math.V3(0, 1, 0), c.rodR)
+		got, ok := coaxialSphereCircleOffset(sph, cyl)
+		if !ok {
+			t.Fatalf("ball R=%g, rod r=%g: declined; want an offset of %g", c.ballR, c.rodR, c.want)
+		}
+		if stdmath.Abs(got-c.want) > 1e-12*c.ballR {
+			t.Errorf("ball R=%g, rod r=%g: offset %g, want %g", c.ballR, c.rodR, got, c.want)
+		}
+	}
+}
+
+// TestCoaxialSphereCircleOffsetDeclinesWhatOCCTDeclines: the recognizer must refuse exactly the cases
+// OCCT reports as something other than a pair of circles — an axis missing the centre
+// (IntAna_NoGeometricSolution: a quartic space curve), a ball no bigger than the rod (IntAna_Empty),
+// and equal radii, which OCCT reports as ONE circle because the contact is an internal tangency.
+func TestCoaxialSphereCircleOffsetDeclinesWhatOCCTDeclines(t *testing.T) {
+	sph, _ := geom.NewSphere(math.P3(0, 0, 0), 5)
+	for _, c := range []struct {
+		name   string
+		origin math.Point3
+		rodR   float64
+	}{
+		{"axis offset from the centre", math.P3(1, 0, 0), 3},
+		{"ball smaller than the rod", math.P3(0, 0, 0), 6},
+		{"equal radii: an internal tangency", math.P3(0, 0, 0), 5},
+	} {
+		cyl, _ := geom.NewCylinder(c.origin, math.V3(0, 1, 0), c.rodR)
+		if d, ok := coaxialSphereCircleOffset(sph, cyl); ok {
+			t.Errorf("%s: accepted with offset %g, want a decline", c.name, d)
+		}
+	}
+}
+
+// TestCoaxialRodOfDeclinesOutOfScopeExtents guards the documented scope. Only a rod with ONE cap
+// strictly inside the ball and one strictly outside is built here; the others must decline so
+// kernel/ops keeps its guarded fallback rather than shipping a solid this file cannot describe.
+func TestCoaxialRodOfDeclinesOutOfScopeExtents(t *testing.T) {
+	for _, c := range []struct {
+		name        string
+		y0, length  float64
+		explanation string
+	}{
+		{"through rod", -1.5, 3, "clears both sides: two seam circles, needing a spherical zone face"},
+		{"shoulder stop", 0, 0.45, "the far cap lands between the seam plane and the pole"},
+		{"buried rod", -0.2, 0.4, "both caps inside: the union is the ball alone"},
+	} {
+		ball, rod := ballAndRod(t, 0.5, 0.3, c.y0, c.length)
+		if _, ok := coaxialRodOf(ball, rod); ok {
+			t.Errorf("%s accepted; want a decline (%s)", c.name, c.explanation)
+		}
+	}
+}
+
+// TestCoaxialRodOfAcceptsEitherArgumentOrder: a caller must not have to know which operand is the ball.
+func TestCoaxialRodOfAcceptsEitherArgumentOrder(t *testing.T) {
+	ball, rod := ballAndRod(t, 0.5, 0.3, 0, 1.5)
+	forward, okF := coaxialRodOf(ball, rod)
+	reverse, okR := coaxialRodOf(rod, ball)
+	if !okF || !okR {
+		t.Fatalf("ball-first ok=%v, rod-first ok=%v; want both", okF, okR)
+	}
+	if forward.seam.Center != reverse.seam.Center || forward.seam.Radius != reverse.seam.Radius {
+		t.Errorf("argument order changed the seam: %v vs %v", forward.seam, reverse.seam)
+	}
+}
+
+// TestCoaxialRodOfOrientsTheAxisFromTheBuriedEnd: `out` must run from the buried cap toward the free
+// one whichever way the rod was modelled, since every face's side is named against it.
+func TestCoaxialRodOfOrientsTheAxisFromTheBuriedEnd(t *testing.T) {
+	for _, c := range []struct {
+		name       string
+		y0, length float64
+		wantY      float64
+	}{
+		{"rod built along +Y", 0, 1.5, 1},
+		{"rod built along -Y", -1.5, 1.5, -1},
+	} {
+		ball, rod := ballAndRod(t, 0.5, 0.3, c.y0, c.length)
+		r, ok := coaxialRodOf(ball, rod)
+		if !ok {
+			t.Fatalf("%s: declined", c.name)
+		}
+		if got := float64(r.out.Y); stdmath.Abs(got-c.wantY) > 1e-12 {
+			t.Errorf("%s: out.Y = %g, want %g (buried cap → free cap)", c.name, got, c.wantY)
+		}
+		if float64(r.seam.Center.Y)*c.wantY <= 0 {
+			t.Errorf("%s: seam at y=%g is on the buried side", c.name, float64(r.seam.Center.Y))
+		}
+	}
+}
+
+// TestCoaxialSphereRodBuildersAssembleThreeAnalyticFaces walks the whole family at the builder level:
+// every result is one watertight solid of exactly one sphere, one cylinder and one plane. The volumes
+// are asserted where the boolean runs (kernel/ops, against the OCC oracle); what belongs here is the
+// SHAPE, because an assembly that keeps the wrong halves still stitches into a plausible-looking body.
+func TestCoaxialSphereRodBuildersAssembleThreeAnalyticFaces(t *testing.T) {
+	ball, rod := ballAndRod(t, 0.5, 0.3, 0, 1.5)
+	for _, c := range []struct {
+		name  string
+		build func() (*topo.Body, bool)
+	}{
+		{"ball ∪ rod", func() (*topo.Body, bool) { return CoaxialSphereRodJoin(ball, rod) }},
+		{"ball − rod", func() (*topo.Body, bool) { return CoaxialSphereRodCut(ball, rod) }},
+		{"rod − ball", func() (*topo.Body, bool) { return CoaxialSphereRodCut(rod, ball) }},
+		{"ball ∩ rod", func() (*topo.Body, bool) { return CoaxialSphereRodIntersect(ball, rod) }},
+	} {
+		res, ok := c.build()
+		if !ok {
+			t.Errorf("%s declined", c.name)
+			continue
+		}
+		assertWatertight(t, res)
+		kinds := map[string]int{}
+		for _, f := range res.Faces() {
+			kinds[surfaceKind(f)]++
+		}
+		if len(res.Faces()) != 3 || kinds["sphere"] != 1 || kinds["cylinder"] != 1 || kinds["plane"] != 1 {
+			t.Errorf("%s built %d faces %v, want one sphere + one cylinder + one plane",
+				c.name, len(res.Faces()), kinds)
+		}
+	}
+}
+
+// TestCoaxialSphereRodCutFacesTheRightWay: which operand is the target decides which cap survives and
+// which face is inverted, so the two directions must NOT come out the same body. rod − ball keeps the
+// small cap (as a dimple in the stub's base); ball − rod keeps the large one (the rest of the ball).
+func TestCoaxialSphereRodCutFacesTheRightWay(t *testing.T) {
+	ball, rod := ballAndRod(t, 0.5, 0.3, 0, 1.5)
+	bored, okB := CoaxialSphereRodCut(ball, rod)
+	stub, okS := CoaxialSphereRodCut(rod, ball)
+	if !okB || !okS {
+		t.Fatalf("ball−rod ok=%v, rod−ball ok=%v; want both", okB, okS)
+	}
+	if boredRev, stubRev := sphereFaceReversed(t, bored), sphereFaceReversed(t, stub); boredRev || !stubRev {
+		t.Errorf("sphere sense: ball−rod reversed=%v (want false, material inside the ball), "+
+			"rod−ball reversed=%v (want true, a dimple)", boredRev, stubRev)
+	}
+}
+
+// sphereFaceReversed reports whether the body's spherical face was added with its material on the far
+// side of the surface normal — the difference between a ball's own surface and a dimple cut into a rod.
+func sphereFaceReversed(t *testing.T, b *topo.Body) bool {
+	t.Helper()
+	for _, f := range b.Faces() {
+		if surfaceKind(f) == "sphere" {
+			return f.Reversed()
+		}
+	}
+	t.Fatal("body has no spherical face")
+	return false
+}
+
+// TestCoaxialSphereRodJoinKeepsOperandLineage: the ball stud's three faces all descend from an operand
+// face, so each must keep that face's key or a reference bound to the shank's end face (a chamfer, a
+// hole) would break on the join (ADR-0043 K1a).
+func TestCoaxialSphereRodJoinKeepsOperandLineage(t *testing.T) {
+	ball, rod := ballAndRod(t, 0.5, 0.3, 0, 1.5)
+	want := map[string]string{
+		"sphere":   soleFaceKey(t, ball, "sphere"),
+		"cylinder": soleFaceKey(t, rod, "cylinder"),
+		"plane":    capFaceKey(t, rod, 1.5), // the FREE cap, the only one the join keeps
+	}
+	res, ok := CoaxialSphereRodJoin(ball, rod)
+	if !ok {
+		t.Fatal("ball stud join declined")
+	}
+	for _, f := range res.Faces() {
+		kind := surfaceKind(f)
+		if got := f.Lineage().KeyString(); got != want[kind] {
+			t.Errorf("%s face lineage %q, want the operand's %q", kind, got, want[kind])
+		}
+	}
+}
+
+// soleFaceKey returns the lineage key of the body's only face of the given surface kind.
+func soleFaceKey(t *testing.T, b *topo.Body, kind string) string {
+	t.Helper()
+	for _, f := range b.Faces() {
+		if surfaceKind(f) == kind {
+			return f.Lineage().KeyString()
+		}
+	}
+	t.Fatalf("body has no %s face", kind)
+	return ""
+}
+
+// capFaceKey returns the lineage key of the rod's planar cap at height y along the +Y axis.
+func capFaceKey(t *testing.T, b *topo.Body, y float64) string {
+	t.Helper()
+	for _, f := range b.Faces() {
+		pl, ok := f.Geometry().(geom.Plane)
+		if ok && stdmath.Abs(float64(pl.Origin.Y)-y) < 1e-9 {
+			return f.Lineage().KeyString()
+		}
+	}
+	t.Fatalf("body has no planar cap at y=%g", y)
+	return ""
+}
+
+// surfaceKind names a face's analytic surface, so a result face can be matched to the operand face it
+// descends from.
+func surfaceKind(f *topo.Face) string {
+	switch f.Geometry().(type) {
+	case geom.Sphere:
+		return "sphere"
+	case geom.Cylinder:
+		return "cylinder"
+	default:
+		return "plane"
+	}
+}

--- a/kernel/brep/curved_cylinder_boss.go
+++ b/kernel/brep/curved_cylinder_boss.go
@@ -96,8 +96,12 @@ func assembleBoss(faces []curvedFace, seat int, near, far math.Point3, radius fl
 		}
 		out = append(out, f)
 	}
-	out = append(out, bossWallFace(near, axis, radius, nearCirc, farCirc), bossTopCapFace(far, axis, farCirc))
-	return curvedStitch(out)
+	wall, okW := bossWallFace(near, axis, radius, nearCirc, farCirc)
+	topCap, okC := discFace(farCirc, true, axis, topo.NewLineage(topo.Tok("brep", "bosscap", 0)))
+	if !okW || !okC {
+		return nil
+	}
+	return curvedStitch(append(out, wall, topCap))
 }
 
 // capWithHoleReversed appends the circle to a face as an inner loop wound REVERSED — opposite to
@@ -110,26 +114,14 @@ func capWithHoleReversed(f curvedFace, circ geom.Circle) curvedFace {
 }
 
 // bossWallFace builds the boss side as an OUTWARD cylinder face (material toward the axis, a solid boss —
-// AddFace, not the reversed hole wall) with the same seamed loop SolidCylinder's side uses (seam up, far
-// circle reversed, seam down, near circle forward), so it welds to the seat-face hole and the top cap
-// along the shared circle edges.
-func bossWallFace(baseCenter math.Point3, axis math.Vector3, radius float64, nearCirc, farCirc geom.Circle) curvedFace {
-	cyl, _ := geom.NewCylinder(baseCenter, axis, radius)
-	seam := geom.NewLineSegment(nearCirc.PointAt(0), farCirc.PointAt(0))
-	loop := curvedLoop{edges: []loopEdge{
-		{curve: seam, t0: 0, t1: 1},
-		{curve: farCirc, t0: 1, t1: 0},
-		{curve: seam, t0: 1, t1: 0},
-		{curve: nearCirc, t0: 0, t1: 1},
-	}}
-	return curvedFace{surface: cyl, reversed: false, loops: []curvedLoop{loop}, lineage: topo.NewLineage(topo.Tok("brep", "bosswall", 0))}
-}
-
-// bossTopCapFace builds the boss's outer cap disk (outward normal along the axis, away from the seat).
-func bossTopCapFace(center math.Point3, axis math.Vector3, farCirc geom.Circle) curvedFace {
-	pl, _ := geom.NewPlane(center, axis)
-	loop := curvedLoop{edges: []loopEdge{{curve: farCirc, t0: 0, t1: 1}}}
-	return curvedFace{surface: pl, reversed: false, loops: []curvedLoop{loop}, lineage: topo.NewLineage(topo.Tok("brep", "bosscap", 0))}
+// AddFace, not the reversed hole wall), so it welds to the seat-face hole and the top cap along the
+// shared circle edges.
+func bossWallFace(baseCenter math.Point3, axis math.Vector3, radius float64, nearCirc, farCirc geom.Circle) (curvedFace, bool) {
+	cyl, err := geom.NewCylinder(baseCenter, axis, radius)
+	if err != nil {
+		return curvedFace{}, false
+	}
+	return cylinderBandFace(cyl, nearCirc, farCirc, false, topo.NewLineage(topo.Tok("brep", "bosswall", 0))), true
 }
 
 // faceOutwardNormal returns a face's true outward normal: the plane normal, flipped when the face was

--- a/kernel/brep/curved_face_primitives.go
+++ b/kernel/brep/curved_face_primitives.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Analytic face constructors shared by the bespoke curved-boolean assemblers — the handlers that build
+// their result directly instead of running the (u,v) arrangement (the boss, the coaxial ball stud).
+// Each returns ONE curvedFace with its boundary already wound to the side that survives, because for
+// these KINDs naming the surviving region IS the split (ADR-0045).
+
+// cylinderBandFace builds a cylindrical wall between two coaxial circles as one seamed periodic loop —
+// seam up, far circle reversed, seam down, near circle forward — the same loop SolidCylinder's side
+// carries, so it welds to whatever bounds it at either rim. near and far must share a frame (see
+// coaxialCircleAt) with near the lower one along cyl.AxisDir; reversed turns the wall inward, which is
+// what a cut's bore needs.
+func cylinderBandFace(cyl geom.Cylinder, near, far geom.Circle, reversed bool, lin topo.Lineage) curvedFace {
+	seam := geom.NewLineSegment(near.PointAt(0), far.PointAt(0))
+	loop := curvedLoop{edges: []loopEdge{
+		{curve: seam, t0: 0, t1: 1},
+		{curve: far, t0: 1, t1: 0},
+		{curve: seam, t0: 1, t1: 0},
+		{curve: near, t0: 0, t1: 1},
+	}}
+	return curvedFace{surface: cyl, reversed: reversed, loops: []curvedLoop{loop}, lineage: lin}
+}
+
+// discFace builds the planar disc that a circle bounds. forward is the direction the loop must walk
+// the rim — the caller's neighbour on that same edge walks it the other way, which is the invariant
+// ops.Validate checks — and the plane's normal is taken to MATCH that walk, so the loop stays
+// counter-clockwise about its own surface normal. Which side holds material is then carried by the
+// face sense alone: reversed when outward disagrees with that normal.
+func discFace(rim geom.Circle, forward bool, outward math.Vector3, lin topo.Lineage) (curvedFace, bool) {
+	normal := rim.Normal.AsVector()
+	if !forward {
+		normal = normal.Scale(-1)
+	}
+	pl, err := geom.NewPlane(rim.Center, normal)
+	if err != nil {
+		return curvedFace{}, false
+	}
+	return curvedFace{surface: pl, reversed: normal.Dot(outward) < 0, lineage: lin,
+		loops: []curvedLoop{{edges: []loopEdge{orientedCircle(rim, normal)}}}}, true
+}
+
+// sphereCapFace builds the sphere face a circle on that sphere bounds, keeping the cap on the keep side
+// of the circle's plane. A circle splits a sphere into exactly two caps and the WINDING is what names
+// which one: kernel/ops reads the loop's direction against the outward radius to find the enclosed pole
+// (capAxis in sphere_cap_mesh.go), so a forward loop keeps the cap the circle's normal points into.
+// That makes this the one face in an assembly whose winding is NOT free — the neighbours have to take
+// the opposite direction from it, not the other way round. reversed additionally turns the cap inward —
+// a spherical dimple, where the material is outside the ball rather than inside it.
+func sphereCapFace(sph geom.Sphere, rim geom.Circle, keep math.Vector3, reversed bool, lin topo.Lineage) curvedFace {
+	return curvedFace{surface: sph, reversed: reversed, lineage: lin,
+		loops: []curvedLoop{{edges: []loopEdge{orientedCircle(rim, keep)}}}}
+}
+
+// orientedCircle walks a circle forward when its normal agrees with want, backward otherwise.
+func orientedCircle(c geom.Circle, want math.Vector3) loopEdge {
+	if c.Normal.AsVector().Dot(want) < 0 {
+		return loopEdge{curve: c, t0: 1, t1: 0}
+	}
+	return loopEdge{curve: c, t0: 0, t1: 1}
+}

--- a/kernel/ops/boolean.go
+++ b/kernel/ops/boolean.go
@@ -159,7 +159,10 @@ func booleanGeneral(op PartFeatureOperation, target, tool *topo.Body, lin topo.L
 //	  - two crossing cylinders ∩/−/∪ (rod band + fat-wall lens caps) (#1335);
 //	  - a cone crossing a cylinder, and a cone crossing a fatter cone, ∩/−/∪ (#1335);
 //	  - two EQUAL-radius perpendicular cylinders ∩/−/∪ (the Steinmetz bicylinder, imprint split at its pinches) (#1403);
-//	  - a thin rod ending inside a fatter solid ∩/−/∪ (a partial penetration: plug, blind hole, one-sided stub) (#1335).
+//	  - a thin rod ending inside a fatter solid ∩/−/∪ (a partial penetration: plug, blind hole, one-sided stub) (#1335);
+//	  - a rod COAXIAL with a ball, ending inside it ∩/−/∪ (the ball stud, its blind spherical bore, its plug) —
+//	    transversal, but the contact is one PLANAR circle and a sphere is not a rim-bounded band, so the split is
+//	    by construction and no arrangement runs; OCCT special-cases the same pair in closed form (#2036).
 //
 //	CURVED-ON-PLANAR (contact = one closed conic STRICTLY INSIDE a planar face, added as an inner loop; no
 //	SSI arrangement — the periodic (u,v) machinery does not apply to a flat bounded face, ADR-0045):
@@ -243,11 +246,11 @@ var curvedExactPaths = []func(PartFeatureOperation, *topo.Body, *topo.Body, *dia
 	// Intersect — all [T] transversal (curved∩convex-planar half-space, then ruled crossings).
 	curvedConvexIntersect, curvedConvexSubtract,
 	curvedCrossingIntersect, curvedSteinmetzIntersect, curvedConeCylinderIntersect, curvedConeConeIntersect,
-	curvedPartialIntersect,
+	curvedPartialIntersect, curvedBallRodIntersect,
 	// Cut — [P] the drill through-hole and the edge scallop (curved-on-planar), the rest [T] transversal.
-	curvedCylindricalHoleCut, curvedEdgeScallopCut, curvedFlatSubtract, curvedPartialCut, curvedSteinmetzCut, curvedConeCylinderCut, curvedConeConeCut, curvedCapCrossCut, curvedRimCrossCut, curvedTwoCapCrossCut, curvedConeCapCrossCut, curvedPartialRimCut, curvedPartialRimCornerCut, curvedCrossingCut,
+	curvedCylindricalHoleCut, curvedEdgeScallopCut, curvedFlatSubtract, curvedPartialCut, curvedSteinmetzCut, curvedConeCylinderCut, curvedConeConeCut, curvedCapCrossCut, curvedRimCrossCut, curvedTwoCapCrossCut, curvedConeCapCrossCut, curvedPartialRimCut, curvedPartialRimCornerCut, curvedCrossingCut, curvedBallRodCut,
 	// Join — [D] coaxial (degenerate overlap), [P] boss interior then straddling (curved-on-planar), the rest [T] transversal.
-	curvedCoaxialJoin, curvedCylinderBossJoin, curvedPartialBossJoin, curvedPartialJoin, curvedConeCylinderJoin, curvedConeConeJoin, curvedCrossingJoin, curvedSteinmetzJoin,
+	curvedCoaxialJoin, curvedCylinderBossJoin, curvedPartialBossJoin, curvedPartialJoin, curvedConeCylinderJoin, curvedConeConeJoin, curvedCrossingJoin, curvedSteinmetzJoin, curvedBallRodJoin,
 }
 
 func shouldFallbackBoolean(op PartFeatureOperation, target, tool, body *topo.Body) bool {

--- a/kernel/ops/boolean_ball_stud_test.go
+++ b/kernel/ops/boolean_ball_stud_test.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Coaxial ball ∪/−/∩ rod — the ball-stud family (Oblikovati#2036). Before this, no entry in
+// curvedExactPaths claimed a sphere (every ruled operand is a cylinder or a cone), so the union of a
+// ball and its shank fell through to triangle-soup CSG and shipped an INSCRIBED polyhedron: ~500
+// planar faces, no analytic surface left, and a volume 1.3% low that did NOT improve with tessellation
+// quality because the deficit was in the B-rep, not the mesh. These tests assert the opposite of each
+// of those symptoms — three analytic faces, and a volume AND area that match the closed form to the
+// tessellation's own noise floor.
+
+// ballStud is the reference model of #2036, in cm: a Ø10 ball at the origin and a coaxial Ø6 shank
+// running along +Y from the centre out to 15 mm.
+const (
+	ballStudR   = 0.5 // ball radius
+	ballStudRod = 0.3 // shank radius
+	ballStudLen = 1.5 // shank length, from the ball centre
+)
+
+// ballStudSeam is the axial offset of the seam circle: OCCT's √(R_s²−R_c²), here the 3-4-5 leg 0.4.
+var ballStudSeam = stdmath.Sqrt(ballStudR*ballStudR - ballStudRod*ballStudRod)
+
+func ballStudOperands(t *testing.T) (ball, rod *topo.Body) {
+	t.Helper()
+	ball, err := brep.SolidSphere(math.P3(0, 0, 0), ballStudR, "ball")
+	if err != nil {
+		t.Fatalf("SolidSphere: %v", err)
+	}
+	rod, err = brep.SolidCylinder(math.P3(0, 0, 0), math.V3(0, 1, 0), ballStudRod, ballStudLen)
+	if err != nil {
+		t.Fatalf("SolidCylinder: %v", err)
+	}
+	return ball, rod
+}
+
+// TestBallStudBooleansStayAnalytic is the #2036 regression. Each of the four results is measured
+// against its closed form in BOTH volume and area — volume alone would pass on a body whose spherical
+// face meshed as a flat lid, and area alone on one whose faces were assembled inside out.
+func TestBallStudBooleansStayAnalytic(t *testing.T) {
+	ball, rod := ballStudOperands(t)
+	R, rc, L, d := ballStudR, ballStudRod, ballStudLen, ballStudSeam
+	vBall := 4.0 / 3.0 * stdmath.Pi * R * R * R
+	vRod := stdmath.Pi * rc * rc * L
+	// the plug is the rod up to the seam plane plus the ball's cap above it (height R−d)
+	vPlug := stdmath.Pi*rc*rc*d + stdmath.Pi*(R-d)*(R-d)*(R-(R-d)/3)
+	nearCap, farCap := 2*stdmath.Pi*R*(R-d), 2*stdmath.Pi*R*(R+d) // spherical zone area = 2πR·height
+	disc := stdmath.Pi * rc * rc
+	band := func(length float64) float64 { return 2 * stdmath.Pi * rc * length }
+
+	for _, c := range []struct {
+		name              string
+		op                PartFeatureOperation
+		target, tool      *topo.Body
+		wantVol, wantArea float64
+	}{
+		{"ball ∪ rod", Join, ball, rod, vBall + vRod - vPlug, farCap + band(L-d) + disc},
+		{"rod ∪ ball", Join, rod, ball, vBall + vRod - vPlug, farCap + band(L-d) + disc},
+		{"ball − rod", Cut, ball, rod, vBall - vPlug, farCap + band(d) + disc},
+		{"rod − ball", Cut, rod, ball, vRod - vPlug, nearCap + band(L-d) + disc},
+		{"ball ∩ rod", Intersect, ball, rod, vPlug, nearCap + band(d) + disc},
+	} {
+		got, err := Boolean(c.op, c.target, c.tool)
+		if err != nil {
+			t.Errorf("%s: %v", c.name, err)
+			continue
+		}
+		assertBallStudSolid(t, c.name, got)
+		props := BodyGeometryProperties(got, PropertyQuality())
+		assertWithin(t, c.name+" volume", props.Volume, c.wantVol)
+		assertWithin(t, c.name+" area", props.Area, c.wantArea)
+	}
+}
+
+// ballStudBand is how far a measured value may sit off its closed form. It is a TESSELLATION budget,
+// not a modelling one: at PropertyQuality a sphere's facets under-measure by ~0.02%, and an exact
+// B-rep is the only way to land inside this. The CSG fallback this replaced missed by 1.3% and did not
+// improve with quality.
+const ballStudBand = 1e-3
+
+func assertWithin(t *testing.T, what string, got, want float64) {
+	t.Helper()
+	if rel := stdmath.Abs(got-want) / want; rel > ballStudBand {
+		t.Errorf("%s = %.6f, want %.6f (off by %.3f%%, budget %.2f%%)",
+			what, got, want, 100*rel, 100*ballStudBand)
+	}
+}
+
+// assertBallStudSolid pins the shape of every result in this family: a valid closed manifold solid of
+// exactly three ANALYTIC faces — one sphere, one cylinder, one plane. A CSG fallback shows up here as
+// hundreds of planar faces long before any volume check runs.
+func assertBallStudSolid(t *testing.T, name string, b *topo.Body) {
+	t.Helper()
+	if r := Validate(b); !r.Valid || !r.Closed || !r.Manifold || !b.IsSolid() {
+		t.Fatalf("%s: valid=%v closed=%v manifold=%v orientation=%v solid=%v: %v",
+			name, r.Valid, r.Closed, r.Manifold, r.OrientationOK, b.IsSolid(), r.Issues)
+	}
+	kinds := map[string]int{}
+	for _, f := range b.Faces() {
+		switch f.Geometry().(type) {
+		case geom.Sphere:
+			kinds["sphere"]++
+		case geom.Cylinder:
+			kinds["cylinder"]++
+		case geom.Plane:
+			kinds["plane"]++
+		default:
+			t.Errorf("%s: face surface %T is not analytic", name, f.Geometry())
+		}
+	}
+	if kinds["sphere"] != 1 || kinds["cylinder"] != 1 || kinds["plane"] != 1 || len(b.Faces()) != 3 {
+		t.Errorf("%s: %d faces %v, want one sphere + one cylinder + one plane", name, len(b.Faces()), kinds)
+	}
+}
+
+// TestBallStudVolumeConvergesWithQuality is the symptom test from #2036. The CSG fallback's deficit
+// was FLAT across tessellation quality — that is what proved the error lived in the B-rep — so an exact
+// result must instead CONVERGE as the facets get finer. A refinement that does not move the volume is
+// the fallback coming back.
+func TestBallStudVolumeConvergesWithQuality(t *testing.T) {
+	ball, rod := ballStudOperands(t)
+	stud, err := Boolean(Join, ball, rod)
+	if err != nil {
+		t.Fatalf("join: %v", err)
+	}
+	coarse := BodyGeometryProperties(stud, DefaultQuality()).Volume
+	fine := BodyGeometryProperties(stud, PropertyQuality()).Volume
+	if fine <= coarse {
+		t.Errorf("refining the mesh did not raise the volume (%.6f → %.6f); an inscribed polyhedron's "+
+			"deficit is in the B-rep and does not converge", coarse, fine)
+	}
+}
+
+// TestOffAxisRodDoesNotTakeTheCoaxialPath: the closed form is only valid when the rod's axis passes
+// through the ball's centre — off-axis, sphere ∩ cylinder is a quartic space curve, which OCCT itself
+// reports as IntAna_NoGeometricSolution. The handler must decline rather than build a circle that is
+// not there, leaving the (faceted, but honest) fallback to produce a valid solid.
+func TestOffAxisRodDoesNotTakeTheCoaxialPath(t *testing.T) {
+	ball, _ := brep.SolidSphere(math.P3(0, 0, 0), ballStudR, "ball")
+	rod, err := brep.SolidCylinder(math.P3(0.2, 0, 0), math.V3(0, 1, 0), ballStudRod, ballStudLen)
+	if err != nil {
+		t.Fatalf("SolidCylinder: %v", err)
+	}
+	if _, ok := CurvedBoolean(Join, ball, rod); ok {
+		t.Fatal("an off-axis rod was claimed by an exact analytic path; its seam is not a circle")
+	}
+	stud, err := Boolean(Join, ball, rod)
+	if err != nil {
+		t.Fatalf("join: %v", err)
+	}
+	if r := Validate(stud); !r.Valid {
+		t.Errorf("the fallback produced an invalid solid: %v", r.Issues)
+	}
+}

--- a/kernel/ops/boolean_crossing_cylinder.go
+++ b/kernel/ops/boolean_crossing_cylinder.go
@@ -52,11 +52,12 @@ func withoutRecorder(build func(target, tool *topo.Body) (*topo.Body, bool)) rul
 // handles. Most are the TRANSVERSAL-crossing KIND (ADR-0045): the general SSI→trim→classify→stitch pipeline
 // (#1403/#1476) builds every ruled pair, and the whole equal-radius Steinmetz family — intersect, cut AND
 // join — now rides it (#1403), its self-intersecting imprint split at the analytic pinches into four open
-// arcs so the arrangement never sees the crossing (brep.Steinmetz*General). The remaining three are the
-// other two KINDs, which are NOT transversal SSI and correctly do NOT ride the (u,v) arrangement: the drill
-// through-hole and the cylinder boss are CURVED-ON-PLANAR (a tool cylinder crossing a planar face in a
-// strictly-interior circle), and the coaxial union is a DEGENERATE OVERLAP (coincident side surfaces, no SSI
-// curve). See ADR-0045 for why each stays a distinct analytic handler rather than folding into the pipeline.
+// arcs so the arrangement never sees the crossing (brep.Steinmetz*General). The rest correctly do NOT ride
+// the (u,v) arrangement: the drill through-hole and the cylinder boss are CURVED-ON-PLANAR (a tool cylinder
+// crossing a planar face in a strictly-interior circle), the coaxial cylinder union is a DEGENERATE OVERLAP
+// (coincident side surfaces, no SSI curve), and the coaxial ball-and-rod family is transversal but meets in
+// one PLANAR circle on a surface that is not a rim-bounded band, so the split is by construction (#2036).
+// See ADR-0045 for why each stays a distinct analytic handler rather than folding into the pipeline.
 var (
 	// Intersect — the band of the thin operand plus the fat operand's two lens caps.
 	curvedCrossingIntersect     = gatedCurved(Intersect, brep.CrossingCylinderIntersectGeneral) // two crossing cylinders
@@ -64,6 +65,7 @@ var (
 	curvedConeCylinderIntersect = gatedCurved(Intersect, brep.ConeCylinderIntersectGeneral)     // cone ∩ cylinder
 	curvedConeConeIntersect     = gatedCurved(Intersect, brep.ConeConeIntersectGeneral)         // cone ∩ fatter cone
 	curvedPartialIntersect      = gatedCurved(Intersect, brep.PartialPenetrationIntersectGeneral)
+	curvedBallRodIntersect      = gatedCurved(Intersect, withoutRecorder(brep.CoaxialSphereRodIntersect)) // coaxial ball ∩ rod: the plug
 
 	// Cut — drilling the target with the tool (through, blind, or two stubs of tool − target).
 	curvedCylindricalHoleCut  = gatedCurved(Cut, withoutRecorder(brep.DrillThroughHole)) // straight cylinder through a planar slab, hole strictly interior
@@ -73,15 +75,17 @@ var (
 	curvedConeCylinderCut     = gatedCurved(Cut, brep.ConeCylinderCutGeneral)
 	curvedConeConeCut         = gatedCurved(Cut, brep.ConeConeCutGeneral)
 	curvedCrossingCut         = gatedCurved(Cut, brep.CrossingCylinderCutGeneral)
-	curvedCapCrossCut         = gatedCurved(Cut, brep.CapCrossingCutGeneral)      // oblique tool exits one cap, ellipse inside rim (#1724)
-	curvedRimCrossCut         = gatedCurved(Cut, brep.RimCrossingCutGeneral)      // oblique tool exits one cap, ellipse crosses rim (#1724 slice 2)
-	curvedTwoCapCrossCut      = gatedCurved(Cut, brep.TwoCapCrossingCutGeneral)   // steep tool exits BOTH caps, wall intact (#1724)
-	curvedConeCapCrossCut     = gatedCurved(Cut, brep.ConeCapCrossingCutGeneral)  // oblique CONE tool exits one cap, ellipse inside rim (#1724)
-	curvedPartialRimCut       = gatedCurved(Cut, brep.PartialRimCutGeneral)       // second cut on an already-notched cylinder side, disjoint from the notch (#1732)
-	curvedPartialRimCornerCut = gatedCurved(Cut, brep.PartialRimCornerCutGeneral) // second cut whose imprint CROSSES the notch — the coupled corner-junction (#1738, ADR-0048)
+	curvedCapCrossCut         = gatedCurved(Cut, brep.CapCrossingCutGeneral)                // oblique tool exits one cap, ellipse inside rim (#1724)
+	curvedRimCrossCut         = gatedCurved(Cut, brep.RimCrossingCutGeneral)                // oblique tool exits one cap, ellipse crosses rim (#1724 slice 2)
+	curvedTwoCapCrossCut      = gatedCurved(Cut, brep.TwoCapCrossingCutGeneral)             // steep tool exits BOTH caps, wall intact (#1724)
+	curvedConeCapCrossCut     = gatedCurved(Cut, brep.ConeCapCrossingCutGeneral)            // oblique CONE tool exits one cap, ellipse inside rim (#1724)
+	curvedPartialRimCut       = gatedCurved(Cut, brep.PartialRimCutGeneral)                 // second cut on an already-notched cylinder side, disjoint from the notch (#1732)
+	curvedPartialRimCornerCut = gatedCurved(Cut, brep.PartialRimCornerCutGeneral)           // second cut whose imprint CROSSES the notch — the coupled corner-junction (#1738, ADR-0048)
+	curvedBallRodCut          = gatedCurved(Cut, withoutRecorder(brep.CoaxialSphereRodCut)) // coaxial ball − rod (a blind spherical bore) and rod − ball (a dimpled stub), #2036
 
 	// Join — the union, keeping the analytic wall where the operands' faces are coincident or breached.
 	curvedCoaxialJoin      = gatedCurved(Join, withoutRecorder(brep.CoaxialCylinderUnion)) // coaxial equal-radius cylinders
+	curvedBallRodJoin      = gatedCurved(Join, withoutRecorder(brep.CoaxialSphereRodJoin)) // coaxial ball ∪ rod: the ball stud, #2036
 	curvedCylinderBossJoin = gatedCurved(Join, withoutRecorder(brep.JoinCylindricalBoss))  // cylinder seated flush on a face, base strictly interior
 	curvedPartialBossJoin  = gatedCurved(Join, withoutRecorder(brep.JoinPartialBoss))      // cylinder boss whose base circle straddles the seat edge (#1591)
 	curvedPartialJoin      = gatedCurved(Join, brep.PartialPenetrationJoinGeneral)         // fat + entry stub

--- a/kernel/ops/boolean_csg_demotion_test.go
+++ b/kernel/ops/boolean_csg_demotion_test.go
@@ -119,6 +119,10 @@ func curvedExactCases() []curvedExactCase {
 		{"cylinder boss ∪", ops.Join, func(t *testing.T) (*topo.Body, *topo.Body) {
 			return demoBlock(t, math.P3(-5, -5, 0), math.P3(5, 5, 2)), demoCyl(t, math.P3(0, 0, 2), math.V3(0, 0, 1), 1.5, 3)
 		}},
+		{"coaxial ball ∪ rod (ball stud)", ops.Join, demoBallAndRod},
+		{"coaxial ball − rod (blind spherical bore)", ops.Cut, demoBallAndRod},
+		{"coaxial rod − ball (dimpled stub)", ops.Cut, demoRodAndBall},
+		{"coaxial ball ∩ rod (plug)", ops.Intersect, demoBallAndRod},
 		{"cone ∩ box (axis-∥ flat)", ops.Intersect, coneFlatBox},
 		{"cone − box (axis-∥ flat)", ops.Cut, coneFlatBox},
 		{"cone ∩ box (vertex-inside flat)", ops.Intersect, coneVertexInsideFlatBox},
@@ -365,6 +369,29 @@ func demoCyl(t *testing.T, base math.Point3, axis math.Vector3, r, h float64) *t
 	b, err := brep.SolidCylinder(base, axis, r, h)
 	if err != nil {
 		t.Fatalf("SolidCylinder: %v", err)
+	}
+	return b
+}
+
+// demoBallAndRod is the #2036 ball stud: a Ø10 ball at the origin with a coaxial Ø6 shank running from
+// the centre out to 15 mm, so one shank cap is buried in the ball and the other clears it.
+func demoBallAndRod(t *testing.T) (*topo.Body, *topo.Body) {
+	t.Helper()
+	return demoSphere(t, math.P3(0, 0, 0), 5), demoCyl(t, math.P3(0, 0, 0), math.V3(0, 1, 0), 3, 15)
+}
+
+// demoRodAndBall is the same pair with the rod as the target, for rod − ball.
+func demoRodAndBall(t *testing.T) (*topo.Body, *topo.Body) {
+	t.Helper()
+	ball, rod := demoBallAndRod(t)
+	return rod, ball
+}
+
+func demoSphere(t *testing.T, center math.Point3, r float64) *topo.Body {
+	t.Helper()
+	b, err := brep.SolidSphere(center, r, "ball")
+	if err != nil {
+		t.Fatalf("SolidSphere: %v", err)
 	}
 	return b
 }

--- a/kernel/ops/testdata/occ_boolean_oracle.json
+++ b/kernel/ops/testdata/occ_boolean_oracle.json
@@ -11,6 +11,14 @@
   "partial penetration ∩": 20.52055473,
   "coaxial cylinders ∪": 87.9645943,
   "cylinder boss ∪": 221.2057504,
+  "cap-crossing cylinder − (exits top cap)": 266.6720995,
+  "rim-crossing cylinder − (exit ellipse crosses top rim)": 263.6617744,
+  "two-cap-exit cylinder − (steep tool exits both caps)": 266.3615948,
+  "cone-cap-crossing − (oblique cone tool exits top cap)": 271.6205285,
+  "coaxial ball ∪ rod (ball stud)": 819.955685,
+  "coaxial ball − rod (blind spherical bore)": 395.8406792,
+  "coaxial rod − ball (dimpled stub)": 296.3569065,
+  "coaxial ball ∩ rod (plug)": 127.758099,
   "cone ∩ box (axis-∥ flat)": 156.27698,
   "cone − box (axis-∥ flat)": 503.4574773,
   "cone ∩ box (vertex-inside flat)": 31.78157847,
@@ -46,9 +54,5 @@
   "torus − box (two oblique ovals)": 219.4483228,
   "torus ∩ box (oblique figure-eight)": 151.898735,
   "torus − box (oblique figure-eight)": 242.8854496,
-  "torus − box (axis-∥ near-pinch large oval)": 280.2555295,
-  "cap-crossing cylinder − (exits top cap)": 266.6720995,
-  "rim-crossing cylinder − (exit ellipse crosses top rim)": 263.6617744,
-  "two-cap-exit cylinder − (steep tool exits both caps)": 266.3615948,
-  "cone-cap-crossing − (oblique cone tool exits top cap)": 271.6205285
+  "torus − box (axis-∥ near-pinch large oval)": 280.2555295
 }


### PR DESCRIPTION
## What

`ops.Boolean` had no entry for **sphere ∪ cylinder**, so a ball stud — a spherical head on a coaxial shank — fell through to triangle-soup CSG. Measured on the NopSCADlib ball stud (Ø10 head, Ø6 shank out to 15 mm), driven through the normal sketch → extrude → revolve-join path:

| body | volume (cm³) | exact | error | faces |
|---|---|---|---|---|
| before | 0.809002 | 0.819956 | −1.336% | 513, all planar |
| after | 0.819838 | 0.819956 | **−0.014%** | **3: sphere + cylinder + plane** |

The old error did not move with tessellation quality — flat from a 4° to a 0.1° angular tolerance — which is what proved the deficit was in the B-rep, not the mesh. The new one is pure inscribed-facet deficit and converges.

## Why this pair, and why only this configuration

A rod whose axis passes through the ball's centre meets it in a **circle**, and that is the one sphere∩cylinder configuration with a closed-form answer. This is a port of OCCT's `IntAna_QuadQuadGeo::Perform(const gp_Cylinder&, const gp_Sphere&)`: an axis through the centre gives `IntAna_Circle` at ±√(R_s²−R_c²) along the axis; everything else is `IntAna_NoGeometricSolution`, a quartic space curve OCCT hands to its numeric marcher. We decline the same three cases OCCT declines — off-axis, ball no larger than the rod, equal radii (an internal tangency) — so an off-axis rod keeps the existing fallback rather than getting a circle that is not there.

Four results, three analytic faces each:

| | ball cap kept | rod band | disc | inverted |
|---|---|---|---|---|
| `∪` ball stud | far | seam → free | free, +out | — |
| `−` ball − rod (blind spherical bore) | far | buried → seam | buried, +out | the band, into the bore |
| `−` rod − ball (dimpled stub) | near | seam → free | free, +out | the ball cap, into a dimple |
| `∩` the plug | near | buried → seam | buried, −out | — |

## Where it sits in the taxonomy

Transversal (the surfaces genuinely cross in a 1-D curve) but **no `(u,v)` arrangement runs**, for the same reason the drill and the boss don't: the imprint is one *planar* circle and a sphere is not a rim-bounded band — it has no rims, and `geom.Sphere`'s seam is a parameterisation artefact fixed to world `+Z`. A circle splits a sphere into exactly two caps by construction, so naming which one survives *is* the split. ADR-0045 gains a row and an addendum recording that.

One consequence worth knowing: on a closed surface the loop **winding** is what names the region — `kernel/ops`' `capAxis` reads exactly that — so the cap's winding is fixed by geometry and the band and disc take the opposite direction. That is how the assembly satisfies `Validate`'s anti-parallel edge-use invariant while still meshing the intended cap. Getting it backwards costs nothing at build time and yields a closed, manifold solid of the *right* volume that `Validate` rejects only on orientation; the first cut of this did exactly that.

## Deliberately out of scope

A rod passing right **through** the ball meets it in *two* circles, and the surviving ball face is then the belt between them — a spherical zone straddling the equator of its own band axis. `kernel/ops` has no analytic mesh for that shape: measured, such a face tessellates to ~25% of its true area, which is why `revolution.go`'s `sphereZoneAnalytic` gates equator-crossing zones out too. That configuration keeps the faceted-but-honest CSG fallback, and the recognizer declines it explicitly rather than shipping a face that would mesh wrong. Follow-up filed.

## Validation

- **OpenCASCADE oracle.** The four cases join `curvedExactCases`, so they run under both `TestCurvedBooleansStayExact` and `TestCurvedBooleanVolumesMatchOCC`. OCC `getMass` agrees with the closed form to 8 significant figures (819.955685 vs 819.955683, and the same for the other three). The generator (`experiments/occ-boolean-oracle`) also regains the four #1724 cap-crossing cases that had been hand-appended to the committed JSON without an entry — a regeneration used to silently drop them; the regenerated values are byte-identical to the committed ones.
- **Closed-form volume AND area** at `PropertyQuality`, all within 0.02% (`TestBallStudBooleansStayAnalytic`). Volume alone would pass on a body whose spherical face meshed as a flat lid; area alone on one assembled inside out.
- **Every level mutation-proved.** Wrong seam offset, wrong cap side, dropped winding coupling, unregistered path, flipped face sense — each turns a specific test red.
- **Live**, against a running head over the MCP bridge (`mcplive --part ballstud`, new): all four results, 3 analytic faces each, volumes within 0.02%, plus a parametric head resize. Screenshots confirm smooth analytic surfaces and, on the socket, a silhouette flattened over exactly the bore diameter.

`go test ./...` green, `golangci-lint run ./...` 0 issues, markdownlint clean.

Closes #2036

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TBVMFbhWH7akseMqz5GM3