### PR TITLE
Inventor .ipt translator: node-graph decode + machined-revolve solids

### DIFF
--- a/model/exchange/translators/inventor/cmd/batch-translate/main.go
+++ b/model/exchange/translators/inventor/cmd/batch-translate/main.go
@@ -158,7 +158,7 @@ func featureTags(data []byte) string {
 	if ipt.HasRevolve(seg) {
 		tags = append(tags, "rev")
 	}
-	if _, ok := ipt.DecodeHole(seg); ok {
+	if _, ok := ipt.DecodeHole(d); ok {
 		tags = append(tags, "hole")
 	}
 	if _, ok := ipt.DecodeSweep(seg); ok {

--- a/model/exchange/translators/inventor/ipt/ellipse_region_test.go
+++ b/model/exchange/translators/inventor/ipt/ellipse_region_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ipt
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestEllipseRegionResolves guards the ellipse-in-region decode: ST3215Bracket's base extrude names
+// a region whose boundary includes two trimmed elliptical arcs. Before regionEdgeOf/trimEllipseEdge
+// learned the ellipse edge kind, loopAt failed on that loop and regionOf returned nil for the whole
+// region — the base declined and the bracket built a 0.023x fragment. Now every extrude resolves its
+// region. Corpus-gated (the real part carries the ellipse boundary; no generated fixture does);
+// point IPT_CORPUS at the ReelToReel Mechanical directory to enable.
+func TestEllipseRegionResolves(t *testing.T) {
+	dir := os.Getenv("IPT_CORPUS")
+	if dir == "" {
+		dir = `P:\ReelToReel\Mechanical`
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "ST3215Bracket.ipt"))
+	if err != nil {
+		t.Skipf("corpus part not available (%v); set IPT_CORPUS", err)
+	}
+	d, err := Open(data)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	regions := ExtrudeRegions(d)
+	if len(regions) == 0 {
+		t.Fatal("no extrude regions decoded")
+	}
+	// The base (ext 0) region has an outer boundary + 5 holes + a second ellipse-bearing boundary.
+	if got := len(regions[0]); got == 0 {
+		t.Fatalf("base extrude region has 0 loops — the ellipse boundary edge was dropped")
+	}
+	// Every extrude must now resolve a non-empty region (the ellipse edges no longer void a loop).
+	for i, r := range regions {
+		if len(r) == 0 {
+			t.Errorf("extrude %d region is empty", i)
+		}
+	}
+}

--- a/model/exchange/translators/inventor/ipt/featuregraph.go
+++ b/model/exchange/translators/inventor/ipt/featuregraph.go
@@ -397,6 +397,52 @@ func profileOf(pay []byte, patchToSketch map[int]int) int {
 	return -1
 }
 
+// revolveAxisNodeType is the node a Revolution feature names at property 2 (propDirection), in
+// place of an extrude's DirectionAxis: its own axis/centreline reference. It is what tells a revolve
+// feature apart from an extrude (which names 0xCE52DF40 there) — verified on the ReelToReel revolve
+// parts, where every revolve's property 2 resolves to this type and no extrude's does.
+const revolveAxisNodeType = 0x8EF06C89
+
+// RevolveProfileSketch returns the GraphSketches index of the sketch the part's Revolution feature
+// consumes as its profile, resolved through the feature's BoundaryPatch property — the SAME
+// patch -> FaceBound -> Sketch2D chain ExtrudeProfiles uses. This replaces GUESSING the revolve base
+// (the first sketch that merely looks revolvable), which mis-picks a CUT profile on a multi-feature
+// machined part and revolves garbage. A revolve feature is a generic Fx feature that is not an
+// extrude (no depth) and names its axis at property 2 as a revolveAxisNodeType node. ok=false when
+// the part has no such feature or its profile patch can't be mapped, so callers keep their fallback.
+func RevolveProfileSketch(d *Document) (int, bool) {
+	nodes := dcNodes(d)
+	_, sketchIndex := sketchOrdinals(nodes)
+	patchToSketch := boundPatchSketches(nodes, sketchIndex)
+	for _, n := range nodes {
+		if n.typ != featureNodeType {
+			continue
+		}
+		if _, isExtrude := extrudeDepth(nodes, n.payload); isExtrude {
+			continue
+		}
+		props, ok := featureProperties(n.payload)
+		if !ok || len(props) <= propProfile || !isRevolveFeature(nodes, props) {
+			continue
+		}
+		if i, ok := patchToSketch[props[propProfile]]; ok {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// isRevolveFeature reports whether a feature's properties are a revolve's — property 2 (propDirection)
+// names a revolveAxisNodeType node, where an extrude names a DirectionAxis and a hole names its kind
+// at property 0.
+func isRevolveFeature(nodes []dcNode, props []int) bool {
+	if len(props) <= propDirection {
+		return false
+	}
+	ax, ok := nodeAt(nodes, props[propDirection])
+	return ok && ax.typ == revolveAxisNodeType
+}
+
 // boundPatchSketches maps each BoundaryPatch ordinal to the index of the sketch that bounds it,
 // by walking the FaceBound nodes that name the patch as their proxy.
 func boundPatchSketches(nodes []dcNode, sketchIndex map[int]int) map[int]int {

--- a/model/exchange/translators/inventor/ipt/featuregraph.go
+++ b/model/exchange/translators/inventor/ipt/featuregraph.go
@@ -68,14 +68,98 @@ type dcNode struct {
 }
 
 // dcNodes returns every node of the DC segment in walk order, so a reference r resolves to
-// nodes[r-1].
+// nodes[r-1]. Pre-2023 saves lack a 4-byte content-header gap this decoder (calibrated to Inventor
+// 2027) expects, so their entity fields sit 4 bytes earlier; such a segment is normalised once to
+// the 2027 layout (see olderContentHeader / padContentHeader) so every offset-34/38/42 decoder
+// reads it unchanged. The result is memoised because the whole feature/sketch decode re-walks it.
 func dcNodes(d *Document) []dcNode {
+	if d.dcCached {
+		return d.dcCache
+	}
 	var out []dcNode
 	d.walkSegment("PmDCSegment", func(typ uint32, pay []byte) bool {
 		out = append(out, dcNode{typ, pay})
 		return true
 	})
+	if olderContentHeader(out) {
+		for i := range out {
+			out[i].payload = padContentHeader(out[i].payload, out[i].typ)
+		}
+	}
+	d.dcCache, d.dcCached = out, true
 	return out
+}
+
+// contentHeaderGapFor returns where a pre-2023 node of the given type is missing the 4-byte
+// content-header gap 2027 adds. It is NODE-TYPE-DEPENDENT: a type's fields before the gap keep their
+// offset while everything after shifts +4, and types differ in how much header precedes the gap.
+//   - Most types (sketch entity, feature, FaceBound, FxAttrStyles) carry the gap at 22: a
+//     SketchPoint's sentinel sits at 26 on 2027 / 22 on older, so flags@30→34, owner@34→38,
+//     coords@38→42, a feature's property marker@30→34, a FaceBound's refs@26→30 all realign.
+//   - A Loop keeps its operation at 10 (unshifted) and carries the gap at 14, so its edge list
+//     realigns 14→18.
+//   - A SketchEntityRef carries the gap at 18, so its associative id realigns 18→22 (and its
+//     later point/sketch refs 30/42/50/51→34/46/54/55).
+// Inserting a uniform gap breaks this: at 22 the Loop/EntityRef fields below 22 never move (no
+// region resolves); lower than 14 shifts a Loop's operation off its correct offset.
+func contentHeaderGapFor(typ uint32) int {
+	switch typ {
+	case loopNodeType, loop3DNodeType:
+		return 14
+	case entityRefNodeType:
+		return 18
+	default:
+		return 22
+	}
+}
+
+// padContentHeader inserts the missing 4-byte content-header gap at this node type's position so a
+// pre-2023 node reads at the 2027 offsets. See contentHeaderGapFor.
+func padContentHeader(pay []byte, typ uint32) []byte {
+	at := contentHeaderGapFor(typ)
+	if len(pay) < at {
+		return pay
+	}
+	out := make([]byte, len(pay)+4)
+	copy(out, pay[:at])
+	copy(out[at+4:], pay[at:])
+	return out
+}
+
+// olderContentHeader reports whether the DC segment uses the pre-2023 layout, detected from the
+// property/point List2 marker (0x0002,0x3000) that a feature node carries: at offset 34 on a 2027
+// save, at 30 on an older one. Falls back to a line's edge-list marker (42 vs 38) when the part has
+// no feature nodes; defaults to 2027 (no normalisation) when neither is present, so a file this
+// heuristic can't classify is left exactly as today.
+func olderContentHeader(nodes []dcNode) bool {
+	newer, older := 0, 0
+	for _, n := range nodes {
+		switch n.typ {
+		case featureNodeType:
+			newer, older = tallyMarker(n.payload, featurePropListOffset, newer, older)
+		case line2DNodeType:
+			newer, older = tallyMarker(n.payload, edgePointsListOffset, newer, older)
+		}
+	}
+	return older > newer
+}
+
+// tallyMarker increments newer/older by whether the List2 marker sits at the 2027 offset off or the
+// 4-byte-earlier pre-2023 offset off-4.
+func tallyMarker(pay []byte, off, newer, older int) (int, int) {
+	if hasList2Marker(pay, off) {
+		newer++
+	} else if hasList2Marker(pay, off-4) {
+		older++
+	}
+	return newer, older
+}
+
+// hasList2Marker reports whether a List2 header (marker + owner) begins at off.
+func hasList2Marker(pay []byte, off int) bool {
+	return off >= 0 && off+4 <= len(pay) &&
+		binary.LittleEndian.Uint16(pay[off:]) == list2Marker &&
+		binary.LittleEndian.Uint16(pay[off+2:]) == list2Owner
 }
 
 // nodeAt resolves a 1-based reference; ok=false when it points outside the segment.

--- a/model/exchange/translators/inventor/ipt/featuregraph.go
+++ b/model/exchange/translators/inventor/ipt/featuregraph.go
@@ -100,6 +100,7 @@ func dcNodes(d *Document) []dcNode {
 //     realigns 14→18.
 //   - A SketchEntityRef carries the gap at 18, so its associative id realigns 18→22 (and its
 //     later point/sketch refs 30/42/50/51→34/46/54/55).
+//
 // Inserting a uniform gap breaks this: at 22 the Loop/EntityRef fields below 22 never move (no
 // region resolves); lower than 14 shifts a Loop's operation off its correct offset.
 func contentHeaderGapFor(typ uint32) int {
@@ -246,6 +247,29 @@ func featureBoolean(nodes []dcNode, props []int, i int) bool {
 	}
 	v, ok := booleanValue(n.payload)
 	return ok && v
+}
+
+// enumValueOf reads a node's 16-bit enum value (an operation, extent, or hole-kind enum), and whether
+// the payload is long enough to hold one.
+func enumValueOf(n dcNode) (uint16, bool) {
+	if len(n.payload) < enumValueOffset+2 {
+		return 0, false
+	}
+	return binary.LittleEndian.Uint16(n.payload[enumValueOffset:]), true
+}
+
+// featureEnum reads the enum value the feature's i-th property names, and whether that property
+// resolves to a node carrying one — the generic form of extrudeExtentEnum for any property slot
+// (a hole's extent sits at a different index than an extrude's).
+func featureEnum(nodes []dcNode, props []int, i int) (uint16, bool) {
+	if i >= len(props) {
+		return 0, false
+	}
+	n, ok := nodeAt(nodes, props[i])
+	if !ok {
+		return 0, false
+	}
+	return enumValueOf(n)
 }
 
 // extrudeDirection reads the unit direction the feature's DirectionAxis names, and whether it read

--- a/model/exchange/translators/inventor/ipt/hole.go
+++ b/model/exchange/translators/inventor/ipt/hole.go
@@ -8,11 +8,39 @@ import (
 	"unicode/utf16"
 )
 
-// Hole feature decoding from PmDCSegment. Inventor's HoleFeature stores many preset
-// dimensions (clearance/tap defaults) as model parameters; the hole TYPE is a kind-3 0x0C20
-// enum node (like the boolean operation's kind-5 node), and the extent (through vs blind) is
-// inferred geometrically. v1 reads the dimensions from the ordered model parameters:
-// [thickness, diameter, preset, counterDiameter, counterDepth, counterAngle, throughDefault].
+// Hole feature decoding from PmDCSegment. A HoleFeature is a generic Fx feature node
+// (featureNodeType) whose FIRST property is a 0x43CD7C11 "hole kind" node — that node's enum value
+// is the HoleType (0 drilled / 1 countersink / 2 counterbore), and the bore dimensions are the
+// feature's OWN referenced parameters, at stable property indices (verified on fixtures
+// 19/20/25/26/27 and the CapstainNut corpus part):
+//
+//	prop[1] diameter   prop[2] depth   prop[3] counterDiameter
+//	prop[4] counterDepth (counterbore)   prop[5] counterAngle (countersink, radians)
+//	prop[9] extent enum (0x92637D29): value 5 = Through All, else blind at prop[2]
+//
+// This replaced a v1 that read the ordered model-parameter list [thickness, diameter, preset, …]:
+// that order held only for the generated fixtures. On a real part with more parameters it picked the
+// wrong ones — CapstainNut's bore came out Ø0.55 (the extrude thickness) with depth π/4 (a chamfer
+// angle), building the nut with no bore (1.62x). The node's own refs are order-independent.
+
+// holeFeatureType is the "hole kind" node an Fx hole names as its first property; its enum value is
+// the HoleType. (InventorLoader Read_43CD7C11.)
+const holeFeatureType = 0x43CD7C11
+
+// Hole feature property indices within the Fx feature node.
+const (
+	holePropKind            = 0 // the 0x43CD7C11 node; its enum value is the HoleType
+	holePropDiameter        = 1
+	holePropDepth           = 2
+	holePropCounterDiameter = 3
+	holePropCounterDepth    = 4 // counterbore
+	holePropCounterAngle    = 5 // countersink, radians
+	holePropExtent          = 9 // 0x92637D29 PartFeatureExtentEnum
+)
+
+// holeThroughExtent is the extent enum's "All" value — the bore runs through the whole body, so its
+// blind depth is a stale leftover (the same 5 = kExtentAll an extrude uses).
+const holeThroughExtent = 5
 
 // HoleType is the hole geometry style, matching Inventor's HoleTypeEnum value.
 type HoleType int
@@ -39,41 +67,61 @@ type Hole struct {
 	Designation     string  // thread callout (e.g. "M6x1"), tapped holes only
 }
 
-// DecodeHole reports the part's hole, if present. v1: single hole — the ordered model
-// parameters are [thickness, diameter, preset, counterDiameter, counterDepth, counterAngle,
-// throughDefault]; the type is the kind-3 enum node; the bore is Through All when the last
-// parameter reaches the material thickness. Multi-hole, placement, and tap decode are future
-// work.
-func DecodeHole(seg []byte) (Hole, bool) {
-	if !containsUTF16(seg, "Hole1") {
-		return Hole{}, false
+// DecodeHole reports the part's hole, if present, reading its bore from the HoleFeature node's own
+// parameter references (see the layout above). v1: single hole — the first hole feature. Multi-hole
+// and placement are future work.
+//
+//	if h, ok := DecodeHole(d); ok { addHole(def, h, cx, cy, thickness) }
+func DecodeHole(d *Document) (Hole, bool) {
+	nodes := dcNodes(d)
+	for _, n := range nodes {
+		if n.typ != featureNodeType {
+			continue
+		}
+		props, ok := featureProperties(n.payload)
+		if !ok || len(props) <= holePropExtent {
+			continue
+		}
+		kind, ok := nodeAt(nodes, props[holePropKind])
+		if !ok || kind.typ != holeFeatureType {
+			continue
+		}
+		h := holeFromNode(nodes, props, kind)
+		if h.Diameter <= 0 {
+			return Hole{}, false // a hole node with no bore is malformed, not a hole to build
+		}
+		if seg, ok := d.Segment("PmDCSegment"); ok {
+			if des, ok := decodeTap(seg); ok {
+				h.Tapped, h.Designation = true, des
+			}
+		}
+		return h, true
 	}
-	mp := modelParamValues(seg)
-	if len(mp) < 2 {
-		return Hole{}, false
+	return Hole{}, false
+}
+
+// holeFromNode reads a hole's dimensions from its feature node's own property references. The kind
+// node's enum value gives the HoleType; the bore/depth/counter values are referenced parameters.
+func holeFromNode(nodes []dcNode, props []int, kind dcNode) Hole {
+	h := Hole{
+		Diameter: featureParameter(nodes, props, holePropDiameter),
+		Depth:    featureParameter(nodes, props, holePropDepth),
 	}
-	thickness, diameter, depth := mp[0], mp[1], mp[len(mp)-1]
-	if diameter <= 0 {
-		return Hole{}, false
+	if v, ok := enumValueOf(kind); ok {
+		h.Type = HoleType(v)
 	}
-	h := Hole{Diameter: diameter, Depth: depth, ThroughAll: depth >= thickness}
-	if kinds := enumNodeValues(seg, 3); len(kinds) > 0 {
-		h.Type = HoleType(kinds[0])
+	if v, ok := featureEnum(nodes, props, holePropExtent); ok {
+		h.ThroughAll = v == holeThroughExtent
 	}
 	switch h.Type {
 	case CounterboreHole:
-		if len(mp) >= 5 {
-			h.CounterDiameter, h.CounterDepth = mp[3], mp[4]
-		}
+		h.CounterDiameter = featureParameter(nodes, props, holePropCounterDiameter)
+		h.CounterDepth = featureParameter(nodes, props, holePropCounterDepth)
 	case CountersinkHole:
-		if len(mp) >= 6 {
-			h.CounterDiameter, h.CounterAngle = mp[3], mp[5]
-		}
+		h.CounterDiameter = featureParameter(nodes, props, holePropCounterDiameter)
+		h.CounterAngle = featureParameter(nodes, props, holePropCounterAngle)
 	}
-	if des, ok := decodeTap(seg); ok {
-		h.Tapped, h.Designation = true, des
-	}
-	return h, true
+	return h
 }
 
 // threadTypeKeywords mark a thread-type string (e.g. "ANSI Metric M Profile", "ANSI Unified

--- a/model/exchange/translators/inventor/ipt/hole.go
+++ b/model/exchange/translators/inventor/ipt/hole.go
@@ -35,6 +35,7 @@ const (
 	holePropCounterDiameter = 3
 	holePropCounterDepth    = 4 // counterbore
 	holePropCounterAngle    = 5 // countersink, radians
+	holePropPlacement       = 8 // 0x90874D18 Transformation: the drill point + axis in model space
 	holePropExtent          = 9 // 0x92637D29 PartFeatureExtentEnum
 )
 
@@ -65,6 +66,13 @@ type Hole struct {
 	CounterAngle    float64 // countersink, radians
 	Tapped          bool    // a threaded (tapped) hole — the bore is the tap-drill cylinder
 	Designation     string  // thread callout (e.g. "M6x1"), tapped holes only
+	// Center and Axis are the drill point and its axis in MODEL space, from the hole's own placement
+	// transform (prop[8]). Placed is false when the file states none this layout reads. Without it a
+	// hole on a non-XY face drilled in the wrong place — CapstainNut's bore sits at the origin with a
+	// +X axis, not on the assumed XY face.
+	Center [3]float64
+	Axis   [3]float64
+	Placed bool
 }
 
 // DecodeHole reports the part's hole, if present, reading its bore from the HoleFeature node's own
@@ -121,7 +129,33 @@ func holeFromNode(nodes []dcNode, props []int, kind dcNode) Hole {
 		h.CounterDiameter = featureParameter(nodes, props, holePropCounterDiameter)
 		h.CounterAngle = featureParameter(nodes, props, holePropCounterAngle)
 	}
+	if c, a, ok := holePlacement(nodes, props); ok {
+		h.Center, h.Axis, h.Placed = c, a, true
+	}
 	return h
+}
+
+// holePlacement reads the hole's drill point and axis from its placement transform (prop[8]): the
+// transform's translation is the point, and its Z axis (xAxis × yAxis) is the drill direction — the
+// outward normal of the face the hole is bored on. ok=false when the file states none this layout
+// reads, so the caller keeps the profile-centroid fallback.
+func holePlacement(nodes []dcNode, props []int) (center, axis [3]float64, ok bool) {
+	if holePropPlacement >= len(props) {
+		return center, axis, false
+	}
+	n, ok := nodeAt(nodes, props[holePropPlacement])
+	if !ok || n.typ != transformNodeType {
+		return center, axis, false
+	}
+	m, ok := transformMatrix(n.payload, transformMatrixOffset)
+	if !ok || !isRigidPlacement(m) {
+		return center, axis, false
+	}
+	center = [3]float64{m[0][3], m[1][3], m[2][3]}
+	x := [3]float64{m[0][0], m[1][0], m[2][0]}
+	y := [3]float64{m[0][1], m[1][1], m[2][1]}
+	axis = [3]float64{x[1]*y[2] - x[2]*y[1], x[2]*y[0] - x[0]*y[2], x[0]*y[1] - x[1]*y[0]}
+	return center, axis, true
 }
 
 // threadTypeKeywords mark a thread-type string (e.g. "ANSI Metric M Profile", "ANSI Unified

--- a/model/exchange/translators/inventor/ipt/hole_test.go
+++ b/model/exchange/translators/inventor/ipt/hole_test.go
@@ -2,7 +2,11 @@
 
 package ipt
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 // TestDecodeHole checks the two drilled-hole corpus parts decode to the right bore: both a
 // Ø1 cm bore, one Through All (depth reaches the 2 cm slab) and one blind at depth 1 cm.
@@ -17,11 +21,7 @@ func TestDecodeHole(t *testing.T) {
 	}
 	for _, tc := range cases {
 		d := openDoc(t, tc.file)
-		seg, ok := d.Segment("PmDCSegment")
-		if !ok {
-			t.Fatalf("%s: no PmDCSegment", tc.file)
-		}
-		h, ok := DecodeHole(seg)
+		h, ok := DecodeHole(d)
 		if !ok {
 			t.Fatalf("%s: no hole decoded", tc.file)
 		}
@@ -85,8 +85,7 @@ func TestDecodeTappedHole(t *testing.T) {
 func mustHole(t *testing.T, file string) Hole {
 	t.Helper()
 	d := openDoc(t, file)
-	seg, _ := d.Segment("PmDCSegment")
-	h, ok := DecodeHole(seg)
+	h, ok := DecodeHole(d)
 	if !ok {
 		t.Fatalf("%s: no hole decoded", file)
 	}
@@ -97,9 +96,37 @@ func mustHole(t *testing.T, file string) Hole {
 func TestDecodeHoleAbsentOnPlainParts(t *testing.T) {
 	for _, file := range []string{"10_box.ipt", "15_cylinder.ipt", "17_box_cut.ipt"} {
 		d := openDoc(t, file)
-		seg, _ := d.Segment("PmDCSegment")
-		if _, ok := DecodeHole(seg); ok {
+		if _, ok := DecodeHole(d); ok {
 			t.Errorf("%s: decoded a hole where there is none", file)
 		}
+	}
+}
+
+// TestDecodeHoleReadsRealPartBore pins the node-graph decode on a real corpus part: CapstainNut's
+// bore is Ø1.719 cm (its HoleFeature node's prop[1] parameter), a through hole. The predecessor
+// model-param-order scan read Ø0.55 (the extrude thickness) with depth π/4 (a chamfer angle), so the
+// nut built with no bore (1.62x). Corpus-gated: skips without IPT_CORPUS.
+func TestDecodeHoleReadsRealPartBore(t *testing.T) {
+	dir := os.Getenv("IPT_CORPUS")
+	if dir == "" {
+		dir = `P:\ReelToReel\Mechanical`
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "CapstainNut.ipt"))
+	if err != nil {
+		t.Skipf("corpus part not available (%v); set IPT_CORPUS", err)
+	}
+	d, err := Open(data)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	h, ok := DecodeHole(d)
+	if !ok {
+		t.Fatalf("no hole decoded")
+	}
+	if absf(h.Diameter-1.71881) > 1e-3 {
+		t.Errorf("CapstainNut bore Ø%.5f cm, want ~Ø1.719 (not the Ø0.55 extrude thickness the old scan read)", h.Diameter)
+	}
+	if !h.ThroughAll {
+		t.Errorf("CapstainNut bore should be Through All")
 	}
 }

--- a/model/exchange/translators/inventor/ipt/region.go
+++ b/model/exchange/translators/inventor/ipt/region.go
@@ -63,10 +63,22 @@ type RegionLoop struct {
 // RegionEdge is one curve of a region's boundary, identified by geometry so it can be matched
 // against a rebuilt profile's entities. Exactly one of the shapes is meaningful, per Kind.
 type RegionEdge struct {
-	Kind   EdgeKind
-	Line   Line
-	Circle Circle
-	Arc    Arc
+	Kind    EdgeKind
+	Line    Line
+	Circle  Circle
+	Arc     Arc
+	Ellipse EllipseArc
+}
+
+// EllipseArc is a region-boundary ellipse edge: the full ellipse geometry plus the span the face
+// walks (Start..End, ordered by the reference's posDir like an arc). Start == End (both zero) means
+// the loop names the whole ellipse, as a bore's hole loop does with a circle.
+type EllipseArc struct {
+	Center     Point2D
+	MajorAxis  Point2D // unit direction of the major axis
+	MajorR     float64
+	MinorR     float64
+	Start, End Point2D
 }
 
 // EdgeKind names which curve a RegionEdge carries.
@@ -76,6 +88,7 @@ const (
 	EdgeLine EdgeKind = iota
 	EdgeCircle
 	EdgeArc
+	EdgeEllipse
 )
 
 // ExtrudeRegions returns, for each extrude in feature order, the loops bounding the region it
@@ -170,7 +183,28 @@ func resolveRegionEdge(nodes []dcNode, ref int, assoc map[assocKey]dcNode, sketc
 	if e.Kind == EdgeCircle {
 		e = trimCircleEdge(e, er, assoc, sk)
 	}
+	if e.Kind == EdgeEllipse {
+		e = trimEllipseEdge(e, er, assoc, sk)
+	}
 	return e, true
+}
+
+// trimEllipseEdge records the span an ellipse-boundary edge walks, from the reference's own trim
+// points — the ellipse analogue of trimCircleEdge. The start/end points lie ON the ellipse; the
+// consumer (translate.ellipseArcPolyline) turns them into the swept parameter range. p1 == p2 (or an
+// unresolvable point) means the face uses the whole ellipse, left as Start == End for the consumer.
+func trimEllipseEdge(e RegionEdge, er dcNode, assoc map[assocKey]dcNode, sk int) RegionEdge {
+	p1, ok1 := entityRefPoint(er, entityRefPoint1Offset, assoc, sk)
+	p2, ok2 := entityRefPoint(er, entityRefPoint2Offset, assoc, sk)
+	if !ok1 || !ok2 || samePoint2D(p1, p2) {
+		return e // whole ellipse
+	}
+	start, end := p1, p2
+	if !entityRefPosDir(er) {
+		start, end = p2, p1
+	}
+	e.Ellipse.Start, e.Ellipse.End = start, end
+	return e
 }
 
 // trimCircleEdge cuts a named WHOLE circle back to the arc the face actually walks, from the
@@ -236,6 +270,11 @@ func regionEdgeOf(nodes []dcNode, n dcNode) (RegionEdge, bool) {
 	case arc2DNodeType:
 		a, ok := arc2DAt(nodes, n.payload)
 		return RegionEdge{Kind: EdgeArc, Arc: a}, ok
+	case ellipse2DNodeType:
+		el, ok := ellipse2DAt(nodes, n.payload)
+		return RegionEdge{Kind: EdgeEllipse, Ellipse: EllipseArc{
+			Center: el.Center, MajorAxis: el.MajorAxis, MajorR: el.MajorR, MinorR: el.MinorR,
+		}}, ok
 	}
 	return RegionEdge{}, false
 }

--- a/model/exchange/translators/inventor/ipt/revolveaxis.go
+++ b/model/exchange/translators/inventor/ipt/revolveaxis.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ipt
+
+import (
+	"encoding/binary"
+	"math"
+)
+
+// The revolve axis is a SketchLine3D (node type revolveAxisNodeType 0x8EF06C89, named at the
+// Revolution feature's property 2). InventorLoader's Read_8EF06C89 decodes its tail as pos(3 f64) +
+// dir(3 f64) + a u8 — a point and a direction in MODEL space. The heuristic revolveAxisIndex finds
+// the centreline only when it is an isolated or construction line in the profile sketch; when the
+// axis is instead an ordinary profile EDGE (CapstainMotorCap turns about its y=0 top edge, which is
+// neither isolated nor construction) the heuristic returns nothing and this reference supplies the
+// true axis.
+
+// axisLine3DTail is the fixed byte count of a SketchLine3D's pos(3)+dir(3)+u8 payload tail.
+const axisLine3DTail = 6*8 + 1
+
+// RevolveAxis2D returns the revolve's axis as a point and a direction in the PROFILE SKETCH's 2D
+// plane (the plane RevolveProfileSketch names), by projecting the decoded model-space SketchLine3D
+// onto that plane's axes. ok=false when the part has no revolve axis node, no resolvable profile
+// sketch, or that sketch states no readable plane — callers then fall back to the geometric
+// heuristic. The direction is not normalised; callers use its orientation, not its length.
+func RevolveAxis2D(d *Document) (ox, oy, dx, dy float64, ok bool) {
+	nodes := dcNodes(d)
+	pos, dir, ok := revolveAxisLine3D(nodes)
+	if !ok {
+		return 0, 0, 0, 0, false
+	}
+	idx, ok := RevolveProfileSketch(d)
+	if !ok {
+		return 0, 0, 0, 0, false
+	}
+	g := GraphSketches(d)
+	if idx < 0 || idx >= len(g) || !g[idx].PlaneOK {
+		return 0, 0, 0, 0, false
+	}
+	pl := g[idx].Plane
+	ox, oy = projectOntoPlane(pos, pl)
+	// A direction is a free vector: project the displacement (pos+dir) minus the projected origin,
+	// i.e. project dir against the plane axes without the plane origin offset.
+	dx = dot(dir, pl.XAxis)
+	dy = dot(dir, pl.YAxis)
+	if math.Hypot(dx, dy) < 1e-9 {
+		return 0, 0, 0, 0, false // axis is normal to the profile plane — not an in-plane centreline
+	}
+	return ox, oy, dx, dy, true
+}
+
+// revolveAxisLine3D decodes the Revolution feature's axis SketchLine3D into its model-space point and
+// direction, reading the pos/dir pair anchored at the payload tail (robust to the variable header).
+func revolveAxisLine3D(nodes []dcNode) (pos, dir [3]float64, ok bool) {
+	for _, n := range nodes {
+		if n.typ != featureNodeType {
+			continue
+		}
+		if _, isExtrude := extrudeDepth(nodes, n.payload); isExtrude {
+			continue
+		}
+		props, ok := featureProperties(n.payload)
+		if !ok || len(props) <= propDirection || !isRevolveFeature(nodes, props) {
+			continue
+		}
+		ax, ok := nodeAt(nodes, props[propDirection])
+		if !ok || len(ax.payload) < axisLine3DTail {
+			return pos, dir, false
+		}
+		b := len(ax.payload) - axisLine3DTail
+		f := func(o int) float64 { return math.Float64frombits(binary.LittleEndian.Uint64(ax.payload[b+o:])) }
+		return [3]float64{f(0), f(8), f(16)}, [3]float64{f(24), f(32), f(40)}, true
+	}
+	return pos, dir, false
+}
+
+// projectOntoPlane maps a model-space point to the plane's 2D coordinates (distance along X and Y
+// from the plane origin).
+func projectOntoPlane(p [3]float64, pl SketchPlacement) (x, y float64) {
+	rel := [3]float64{p[0] - pl.Origin[0], p[1] - pl.Origin[1], p[2] - pl.Origin[2]}
+	return dot(rel, pl.XAxis), dot(rel, pl.YAxis)
+}
+
+func dot(a, b [3]float64) float64 { return a[0]*b[0] + a[1]*b[1] + a[2]*b[2] }

--- a/model/exchange/translators/inventor/ipt/revolveaxis_test.go
+++ b/model/exchange/translators/inventor/ipt/revolveaxis_test.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ipt
+
+import (
+	"math"
+	"testing"
+)
+
+// TestRevolveAxis2DDecodesFixtureAxis: the Revolution feature's axis SketchLine3D projects into the
+// profile plane as an axis-aligned centreline. The generated revolve fixtures turn a profile about a
+// horizontal axis, so dir is along X and its Y component is ~0.
+func TestRevolveAxis2DDecodesFixtureAxis(t *testing.T) {
+	for _, f := range []string{"16_revolve.ipt", "24_revolve_270.ipt"} {
+		d := openDoc(t, f)
+		_, _, dx, dy, ok := RevolveAxis2D(d)
+		if !ok {
+			t.Errorf("%s: expected a decodable 2D axis", f)
+			continue
+		}
+		if math.Hypot(dx, dy) < 1e-6 {
+			t.Errorf("%s: axis direction is degenerate", f)
+		}
+		if math.Abs(dy) > 1e-6 {
+			t.Errorf("%s: fixture axis should be horizontal, got dir=(%.3f,%.3f)", f, dx, dy)
+		}
+	}
+}

--- a/model/exchange/translators/inventor/ipt/revprofile_test.go
+++ b/model/exchange/translators/inventor/ipt/revprofile_test.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ipt
+
+import "testing"
+
+// TestRevolveProfileSketchNamesProfile: the Revolution feature names its profile via a BoundaryPatch
+// property; RevolveProfileSketch resolves it to a valid GraphSketches index. On a single-revolve
+// fixture that is the sole profile sketch.
+func TestRevolveProfileSketchNamesProfile(t *testing.T) {
+	for _, f := range []string{"24_revolve_270.ipt", "16_revolve.ipt"} {
+		d := openDoc(t, f)
+		idx, ok := RevolveProfileSketch(d)
+		if !ok {
+			t.Errorf("%s: expected the revolve's profile sketch to resolve", f)
+			continue
+		}
+		if g := GraphSketches(d); idx < 0 || idx >= len(g) {
+			t.Errorf("%s: profile index %d out of range (%d sketches)", f, idx, len(g))
+		}
+	}
+}

--- a/model/exchange/translators/inventor/ipt/segment.go
+++ b/model/exchange/translators/inventor/ipt/segment.go
@@ -30,6 +30,11 @@ var zstdMagic = [4]byte{0x28, 0xB5, 0x2F, 0xFD}
 type Document struct {
 	segments map[string][]byte
 	metaRaw  map[string][]byte
+	// dcCache memoises the walked (and, for a pre-2023 save, layout-normalised) PmDCSegment nodes;
+	// the feature and sketch decoders each re-walk it, and the normalisation must run once. See
+	// dcNodes.
+	dcCache  []dcNode
+	dcCached bool
 }
 
 // Open parses the CFBF container and decompresses every B/M segment pair.

--- a/model/exchange/translators/inventor/ipt/sketch.go
+++ b/model/exchange/translators/inventor/ipt/sketch.go
@@ -76,6 +76,7 @@ type Sketch struct {
 	Circles  []Circle
 	Arcs     []Arc
 	Ellipses []Ellipse
+	Splines  []Spline
 	// Resolved is true when the curve endpoints were reconstructed exactly from their entity
 	// references (a faithful loop), false when the convex-ordering fallback guessed the
 	// connectivity — which mangles a non-convex profile. Revolve gates on this: a scrambled
@@ -94,6 +95,15 @@ type Sketch struct {
 	LineConstruction   []bool
 	CircleConstruction []bool
 	ArcConstruction    []bool
+	SplineConstruction []bool
+}
+
+// Spline is a decoded 2D sketch spline: its fit points in order, and whether the curve closes
+// back to the first. Inventor stores an interpolating (fit) spline through these points, so the
+// points lie ON the curve (they are not off-curve control vertices).
+type Spline struct {
+	Points []Point2D
+	Closed bool
 }
 
 // LineIsConstruction reports whether line i is construction geometry, tolerating an absent flag
@@ -105,6 +115,9 @@ func (s Sketch) CircleIsConstruction(i int) bool { return flagAt(s.CircleConstru
 
 // ArcIsConstruction reports whether arc i is construction geometry.
 func (s Sketch) ArcIsConstruction(i int) bool { return flagAt(s.ArcConstruction, i) }
+
+// SplineIsConstruction reports whether spline i is construction geometry.
+func (s Sketch) SplineIsConstruction(i int) bool { return flagAt(s.SplineConstruction, i) }
 
 func flagAt(flags []bool, i int) bool { return i < len(flags) && flags[i] }
 

--- a/model/exchange/translators/inventor/ipt/sketch.go
+++ b/model/exchange/translators/inventor/ipt/sketch.go
@@ -125,6 +125,14 @@ type Line struct{ A, B Point2D }
 type Circle struct {
 	Center Point2D
 	Radius float64
+	// ArcStart/ArcEnd are the circle node's two on-rim endpoints, when it carries a distinct
+	// resolvable pair. Inventor serialises a sketch arc as a SketchCircle with an open-flag bit (see
+	// arcFlag); a few real arcs carry that pair yet leave the bit CLEAR, so they decode as full
+	// circles. These endpoints let the revolve path recover the arc where a full circle would cross
+	// the axis — an impossible revolve profile — without touching the global arc/circle discriminator.
+	// ArcEndsOK reports the pair is present and distinct.
+	ArcStart, ArcEnd Point2D
+	ArcEndsOK        bool
 }
 
 // Arc is a decoded circular arc: its centre, radius, and the two endpoints (start → end in

--- a/model/exchange/translators/inventor/ipt/sketchgraph.go
+++ b/model/exchange/translators/inventor/ipt/sketchgraph.go
@@ -247,7 +247,13 @@ func circle2DAt(nodes []dcNode, pay []byte) (Circle, bool) {
 	if !ok {
 		return Circle{}, false
 	}
-	return Circle{Center: c, Radius: r}, true
+	out := Circle{Center: c, Radius: r}
+	// Keep the on-rim endpoints when the node carries a distinct pair (a mis-flagged arc), so the
+	// revolve path can recover the arc; a genuine full circle has no distinct pair (start == end).
+	if s, e, ok := edgeEndpoints(nodes, pay); ok && s != e {
+		out.ArcStart, out.ArcEnd, out.ArcEndsOK = s, e, true
+	}
+	return out, true
 }
 
 // arc2DAt reads a SketchArc: centre + radius like a circle, with the endpoints from the edge's

--- a/model/exchange/translators/inventor/ipt/sketchgraph.go
+++ b/model/exchange/translators/inventor/ipt/sketchgraph.go
@@ -30,6 +30,7 @@ const (
 	circle2DNodeType  = 0xCE52DF3B // SketchCircle — centre by reference, radius inline
 	arc2DNodeType     = 0x160915E2 // SketchArc — centre by reference, radius inline
 	ellipse2DNodeType = 0x4507D460 // SketchEllipse — centre by reference, axis + both radii inline
+	spline2DNodeType  = 0xF9372FD4 // SketchSpline — interpolating (fit) spline through point refs
 )
 
 // Byte layout of a 2D entity's payload for this Inventor generation. The content header runs to 34
@@ -42,6 +43,16 @@ const (
 	point2DPosOffset      = 42
 	edgePointsListOffset  = 42
 )
+
+// arcFlag marks a SketchCircle node that is really an ARC (open), sitting in the entity flag word
+// at offset 34 one bit below constructionFlag (0x00080000). This Inventor generation serialises a
+// sketch arc as a SketchCircle (0xCE52DF3B) node with this bit set and two on-circle endpoints,
+// NOT as a distinct SketchArc (0x160915E2) — that type does not occur in the ReelToReel corpus at
+// all. A full circle whose rim merely carries coincidence points (a slot's pin touched by two
+// tangent lines) leaves the bit clear, so it is still emitted as a circle. Verified across the
+// corpus: the linkage's tangent-point circles read clear (4 circles / 0 arcs, matching Inventor)
+// while BigChunkyPlate's and TorquimeterDisk's corner rounds read set.
+const arcFlag = 0x00040000
 
 // GraphSketches returns one sketch per Sketch2D node, in node order, decoded exactly: entities are
 // grouped by the sketch they declare as their owner, and every edge's endpoints are resolved
@@ -89,7 +100,7 @@ func sketchOrdinals(nodes []dcNode) ([]int, map[int]int) {
 // Sketch2D (a block definition, say) are declined.
 func entityOwner(n dcNode, index map[int]int) (int, bool) {
 	switch n.typ {
-	case point2DNodeType, line2DNodeType, circle2DNodeType, arc2DNodeType, ellipse2DNodeType:
+	case point2DNodeType, line2DNodeType, circle2DNodeType, arc2DNodeType, ellipse2DNodeType, spline2DNodeType:
 	default:
 		return 0, false
 	}
@@ -117,7 +128,12 @@ func addGraphEntity(s *Sketch, nodes []dcNode, n dcNode) {
 			s.LineConstruction = append(s.LineConstruction, c)
 		}
 	case circle2DNodeType:
-		if circ, ok := circle2DAt(nodes, n.payload); ok {
+		// A SketchCircle marked open (arcFlag) with two endpoints is an arc — see arcFlag. Fall
+		// through to a circle when the bit is clear, or when its endpoints don't resolve.
+		if a, ok := arcFromCircleNode(nodes, n.payload); ok {
+			s.Arcs = append(s.Arcs, a)
+			s.ArcConstruction = append(s.ArcConstruction, c)
+		} else if circ, ok := circle2DAt(nodes, n.payload); ok {
 			s.Circles = append(s.Circles, circ)
 			s.CircleConstruction = append(s.CircleConstruction, c)
 		}
@@ -129,6 +145,11 @@ func addGraphEntity(s *Sketch, nodes []dcNode, n dcNode) {
 	case ellipse2DNodeType:
 		if e, ok := ellipse2DAt(nodes, n.payload); ok {
 			s.Ellipses = append(s.Ellipses, e)
+		}
+	case spline2DNodeType:
+		if sp, ok := spline2DAt(nodes, n.payload); ok {
+			s.Splines = append(s.Splines, sp)
+			s.SplineConstruction = append(s.SplineConstruction, c)
 		}
 	}
 }
@@ -164,6 +185,27 @@ func ellipse2DAt(nodes []dcNode, pay []byte) (Ellipse, bool) {
 		return Ellipse{}, false
 	}
 	return e, true
+}
+
+// spline2DAt reads a SketchSpline: its fit points, in order, from the entity's point-reference
+// list. Inventor stores an interpolating spline whose referenced points lie ON the curve, so the
+// same points fed to a fit spline reproduce it. Needs at least two points; returns ok=false (the
+// caller then drops the curve) if any reference doesn't resolve to a Point2D. Closed is left false
+// until a closed-spline node is available to locate its flag — the corpus fixtures are all open.
+func spline2DAt(nodes []dcNode, pay []byte) (Spline, bool) {
+	refs, _, ok := refList2(pay, edgePointsListOffset)
+	if !ok || len(refs) < 2 {
+		return Spline{}, false
+	}
+	pts := make([]Point2D, 0, len(refs))
+	for _, r := range refs {
+		p, ok := referencedPoint(nodes, r)
+		if !ok {
+			return Spline{}, false
+		}
+		pts = append(pts, p)
+	}
+	return Spline{Points: pts}, true
 }
 
 // point2DAt reads a SketchPoint's inline coordinates (cm).
@@ -220,6 +262,24 @@ func arc2DAt(nodes []dcNode, pay []byte) (Arc, bool) {
 		return Arc{}, false
 	}
 	return Arc{Center: c, Radius: r, Start: start, End: end}, true
+}
+
+// arcFromCircleNode reads a SketchCircle node as an arc when the file marks it open (arcFlag at
+// offset 34) and it carries two resolvable endpoints. Returns ok=false — so the caller emits a
+// circle — when the bit is clear or the endpoints don't resolve. See arcFlag for why arcs live
+// under the SketchCircle type in this Inventor generation.
+func arcFromCircleNode(nodes []dcNode, pay []byte) (Arc, bool) {
+	if len(pay) < entityFlags2Offset+4 {
+		return Arc{}, false
+	}
+	if binary.LittleEndian.Uint32(pay[entityFlags2Offset:])&arcFlag == 0 {
+		return Arc{}, false
+	}
+	a, ok := arc2DAt(nodes, pay)
+	if !ok || a.Start == a.End { // a zero-span "arc" is a degenerate full circle
+		return Arc{}, false
+	}
+	return a, true
 }
 
 // centreAndRadius reads the centre reference and radius that follow an edge's header on a circle

--- a/model/exchange/translators/inventor/ipt/sketchgraph_test.go
+++ b/model/exchange/translators/inventor/ipt/sketchgraph_test.go
@@ -2,7 +2,10 @@
 
 package ipt
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 // TestGraphSketchesExact pins the graph decode against parts whose sketches are known from how the
 // corpus was authored: 14_box_two draws Rect(0,0,4,2) then Rect(1,0.5,3,1.5), one per sketch.
@@ -92,9 +95,11 @@ func TestGraphSketchesMultiPointEdges(t *testing.T) {
 	nodes := dcNodes(d)
 	_, index := sketchOrdinals(nodes)
 
+	// Count circles too: this generation stores arcs as SketchCircle nodes (some with >2 point
+	// refs), so an arc-vs-circle split must not change the total curve count — no edge may be lost.
 	declared, multi := 0, 0
 	for _, n := range nodes {
-		if n.typ != line2DNodeType && n.typ != arc2DNodeType {
+		if n.typ != line2DNodeType && n.typ != arc2DNodeType && n.typ != circle2DNodeType {
 			continue
 		}
 		if _, ok := entityOwner(n, index); !ok {
@@ -110,11 +115,54 @@ func TestGraphSketchesMultiPointEdges(t *testing.T) {
 	}
 	decoded := 0
 	for _, s := range GraphSketches(d) {
-		decoded += len(s.Lines) + len(s.Arcs)
+		decoded += len(s.Lines) + len(s.Arcs) + len(s.Circles)
 	}
 	if decoded != declared {
-		t.Errorf("decoded %d line/arc curves from %d the file declares — %d dropped; an edge with "+
-			"more than two point refs must keep its FIRST TWO as endpoints, not be discarded",
+		t.Errorf("decoded %d line/arc/circle curves from %d the file declares — %d dropped; an edge "+
+			"with more than two point refs must keep its FIRST TWO as endpoints, not be discarded",
 			decoded, declared, declared-decoded)
+	}
+}
+
+// TestGraphSketchesArcsFromCircleNodes pins that arcs serialised as SketchCircle nodes with the
+// open bit (arcFlag) are emitted as arcs, while a full circle carrying tangent/coincidence points
+// is NOT. TorquimeterDisk (real_multipoint_disk) marks 14 of its corner rounds open; the linkage's
+// rounded ends are full circles touched by two tangent lines and must stay circles (matching
+// Inventor and TestLinkageProfileMatchesTheFile). See arcFlag.
+func TestGraphSketchesArcsFromCircleNodes(t *testing.T) {
+	countArcsCircles := func(file string) (arcs, circles int) {
+		for _, s := range GraphSketches(openDoc(t, file)) {
+			arcs += len(s.Arcs)
+			circles += len(s.Circles)
+		}
+		return
+	}
+	if a, c := countArcsCircles("real_multipoint_disk.ipt"); a != 14 || c != 61 {
+		t.Errorf("disk: got %d arcs / %d circles, want 14 / 61 (14 open corner rounds decode as arcs)", a, c)
+	}
+	if a, c := countArcsCircles("real_arc_linkage.ipt"); a != 0 || c != 4 {
+		t.Errorf("linkage: got %d arcs / %d circles, want 0 / 4 (tangent-point full circles are not arcs)", a, c)
+	}
+}
+
+// TestGraphSketchesSpline pins the SketchSpline decode (0xF9372FD4): ke_spline holds one fit
+// spline through four points, decoded in order from the entity's point-reference list.
+func TestGraphSketchesSpline(t *testing.T) {
+	var splines []Spline
+	for _, s := range GraphSketches(openDoc(t, "ke_spline.ipt")) {
+		splines = append(splines, s.Splines...)
+	}
+	if len(splines) != 1 {
+		t.Fatalf("decoded %d splines, want 1", len(splines))
+	}
+	want := []Point2D{{0, 8}, {6, 12}, {2, 11}, {4, 9}}
+	got := splines[0].Points
+	if len(got) != len(want) {
+		t.Fatalf("spline has %d fit points, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if math.Abs(got[i].X-want[i].X) > 1e-4 || math.Abs(got[i].Y-want[i].Y) > 1e-4 {
+			t.Errorf("fit point %d = (%.4f,%.4f), want (%.1f,%.1f)", i, got[i].X, got[i].Y, want[i].X, want[i].Y)
+		}
 	}
 }

--- a/model/exchange/translators/inventor/ipt/version_test.go
+++ b/model/exchange/translators/inventor/ipt/version_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ipt
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+)
+
+// TestPadContentHeaderShiftsFields checks that inserting the missing pre-2023 gap moves a node's
+// entity fields to the 2027 offsets: a coordinate a pre-2023 SketchPoint holds at 38 must read back
+// at 42 after normalisation, and the bytes before the gap must be preserved.
+func TestPadContentHeaderShiftsFields(t *testing.T) {
+	gap := contentHeaderGapFor(point2DNodeType) // a sketch entity: gap at 22
+	pay := make([]byte, 60)
+	for i := 0; i < gap; i++ {
+		pay[i] = byte(i + 1) // distinctive header bytes to prove they survive
+	}
+	binary.LittleEndian.PutUint64(pay[38:], math.Float64bits(-13.75)) // x at the pre-2023 offset
+	binary.LittleEndian.PutUint64(pay[46:], math.Float64bits(29.75))  // y
+
+	out := padContentHeader(pay, point2DNodeType)
+	if len(out) != len(pay)+4 {
+		t.Fatalf("padded length = %d, want %d", len(out), len(pay)+4)
+	}
+	for i := 0; i < gap; i++ {
+		if out[i] != byte(i+1) {
+			t.Fatalf("header byte %d = %d, want %d (pre-gap bytes must survive)", i, out[i], i+1)
+		}
+	}
+	if x := math.Float64frombits(binary.LittleEndian.Uint64(out[42:])); x != -13.75 {
+		t.Errorf("x reads %.4f at offset 42 after padding, want -13.75", x)
+	}
+	if y := math.Float64frombits(binary.LittleEndian.Uint64(out[50:])); y != 29.75 {
+		t.Errorf("y reads %.4f at offset 50 after padding, want 29.75", y)
+	}
+}
+
+// TestOlderContentHeaderDetectsLayout checks the pre-2023 detector: a feature node whose property
+// List2 marker sits at offset 30 is older; at 34 is 2027; an unclassifiable set defaults to 2027.
+func TestOlderContentHeaderDetectsLayout(t *testing.T) {
+	featureWithMarkerAt := func(off int) dcNode {
+		pay := make([]byte, 64)
+		binary.LittleEndian.PutUint16(pay[off:], list2Marker)
+		binary.LittleEndian.PutUint16(pay[off+2:], list2Owner)
+		return dcNode{typ: featureNodeType, payload: pay}
+	}
+	older := []dcNode{featureWithMarkerAt(30), featureWithMarkerAt(30), featureWithMarkerAt(30)}
+	if !olderContentHeader(older) {
+		t.Error("markers at offset 30 not detected as pre-2023")
+	}
+	newer := []dcNode{featureWithMarkerAt(34), featureWithMarkerAt(34)}
+	if olderContentHeader(newer) {
+		t.Error("markers at offset 34 wrongly detected as pre-2023")
+	}
+	if olderContentHeader(nil) {
+		t.Error("empty segment must default to 2027 (no normalisation)")
+	}
+}
+
+// TestContentHeaderGapPerType pins the node-type-dependent gap positions: a Loop's shorter header
+// carries the gap at 14 (its operation@10 stays put, its edge list realigns 14→18), a
+// SketchEntityRef at 18 (associative id 18→22), and every other type at 22. A single uniform offset
+// leaves the low-offset region nodes misaligned, so no pre-2023 part's extrudes resolve a region.
+func TestContentHeaderGapPerType(t *testing.T) {
+	cases := []struct {
+		typ  uint32
+		want int
+	}{
+		{loopNodeType, 14}, {loop3DNodeType, 14}, {entityRefNodeType, 18},
+		{point2DNodeType, 22}, {featureNodeType, 22}, {faceBoundNodeType, 22},
+	}
+	for _, c := range cases {
+		if got := contentHeaderGapFor(c.typ); got != c.want {
+			t.Errorf("contentHeaderGapFor(0x%08X) = %d, want %d", c.typ, got, c.want)
+		}
+	}
+	// A Loop's edge-list marker at the pre-2023 offset 14 must land at 18 after padding.
+	loop := make([]byte, 40)
+	binary.LittleEndian.PutUint16(loop[14:], list2Marker)
+	binary.LittleEndian.PutUint16(loop[16:], list2Owner)
+	out := padContentHeader(loop, loopNodeType)
+	if !hasList2Marker(out, loopEdgesOffset) {
+		t.Errorf("Loop edge marker not at %d after padding", loopEdgesOffset)
+	}
+}

--- a/model/exchange/translators/inventor/translate/ellipse_region_test.go
+++ b/model/exchange/translators/inventor/translate/ellipse_region_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package translate
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/model/exchange/translators/inventor/ipt"
+)
+
+// onEllipse reports how far a point strays from the ellipse's rim (0 = exactly on it), using the
+// implicit form in the ellipse's own frame: (x'/a)^2 + (y'/b)^2 = 1.
+func onEllipse(e ipt.EllipseArc, p ipt.Point2D) float64 {
+	ux, uy := e.MajorAxis.X, e.MajorAxis.Y
+	dx, dy := p.X-e.Center.X, p.Y-e.Center.Y
+	x := dx*ux + dy*uy
+	y := -dx*uy + dy*ux
+	return stdmath.Abs((x/e.MajorR)*(x/e.MajorR) + (y/e.MinorR)*(y/e.MinorR) - 1)
+}
+
+// TestEllipseArcPolylineWholeOnEllipse checks the whole-ellipse sampling (Start==End): every sample
+// lands on the rim, for a rotated ellipse so the frame math is exercised, not just an axis-aligned one.
+func TestEllipseArcPolylineWholeOnEllipse(t *testing.T) {
+	// major axis at 30°, a=4, b=2, centred at (5,-3).
+	c, s := stdmath.Cos(stdmath.Pi/6), stdmath.Sin(stdmath.Pi/6)
+	e := ipt.EllipseArc{Center: ipt.Point2D{X: 5, Y: -3}, MajorAxis: ipt.Point2D{X: c, Y: s}, MajorR: 4, MinorR: 2}
+	poly := ellipseArcPolyline(e)
+	if len(poly) != arcSegments {
+		t.Fatalf("whole ellipse sampled %d points, want %d", len(poly), arcSegments)
+	}
+	for i, q := range poly {
+		if d := onEllipse(e, ipt.Point2D{X: float64(q.X), Y: float64(q.Y)}); d > 1e-9 {
+			t.Errorf("sample %d strays from rim by %.2e", i, d)
+		}
+	}
+}
+
+// TestEllipseArcPolylineArcEndpoints checks a trimmed span: the polyline starts at Start, ends at
+// End, and every intermediate point lies on the rim.
+func TestEllipseArcPolylineArcEndpoints(t *testing.T) {
+	e := ipt.EllipseArc{Center: ipt.Point2D{}, MajorAxis: ipt.Point2D{X: 1}, MajorR: 3, MinorR: 1}
+	// Start at t=0 -> (3,0); End at t=pi/2 -> (0,1). Points ON the ellipse.
+	e.Start = ipt.Point2D{X: 3, Y: 0}
+	e.End = ipt.Point2D{X: 0, Y: 1}
+	poly := ellipseArcPolyline(e)
+	if len(poly) < 2 {
+		t.Fatalf("arc sampled %d points", len(poly))
+	}
+	first, lastP := poly[0], poly[len(poly)-1]
+	if stdmath.Hypot(float64(first.X)-3, float64(first.Y)-0) > 1e-9 {
+		t.Errorf("arc start = (%.3f,%.3f), want (3,0)", first.X, first.Y)
+	}
+	if stdmath.Hypot(float64(lastP.X)-0, float64(lastP.Y)-1) > 1e-9 {
+		t.Errorf("arc end = (%.3f,%.3f), want (0,1)", lastP.X, lastP.Y)
+	}
+	for i, q := range poly {
+		if d := onEllipse(e, ipt.Point2D{X: float64(q.X), Y: float64(q.Y)}); d > 1e-9 {
+			t.Errorf("sample %d strays from rim by %.2e", i, d)
+		}
+	}
+	// The quarter-arc bows AWAY from the chord's midpoint through (>0,>0): a midpoint sample must have
+	// both coords positive (the short CCW span 0->pi/2), proving direction, not the long way round.
+	mid := poly[len(poly)/2]
+	if mid.X <= 0 || mid.Y <= 0 {
+		t.Errorf("arc midpoint (%.3f,%.3f) not in the +,+ quadrant — walked the wrong way", mid.X, mid.Y)
+	}
+}

--- a/model/exchange/translators/inventor/translate/mesh.go
+++ b/model/exchange/translators/inventor/translate/mesh.go
@@ -52,6 +52,25 @@ func SoupFromMesh(mesh ipt.Mesh) meshio.RawMesh {
 	return raw
 }
 
+// meshIsSpatial reports whether a triangle soup has a genuinely three-dimensional extent. It
+// rejects the FLAT footprint placeholder Inventor stores as the graphics mesh for some imported
+// parts — e.g. MBK_Keycap's 6-triangle 192×181×0 quad, whose real body lives only in the SAB. Such
+// a placeholder facets to a wrong flat sheet, so importing it would be worse than leaving the part
+// with no body. spatialEps is in cm; any real solid clears it in every axis (the thinnest corpus
+// import, a light pipe, is ~2.9 mm thick).
+func meshIsSpatial(raw meshio.RawMesh) bool {
+	if len(raw.Verts) == 0 {
+		return false
+	}
+	const spatialEps = 1e-4 // cm (1 micron)
+	lo, hi := raw.Verts[0], raw.Verts[0]
+	for _, v := range raw.Verts {
+		lo = m.P3(math.Min(lo.X, v.X), math.Min(lo.Y, v.Y), math.Min(lo.Z, v.Z))
+		hi = m.P3(math.Max(hi.X, v.X), math.Max(hi.Y, v.Y), math.Max(hi.Z, v.Z))
+	}
+	return hi.X-lo.X > spatialEps && hi.Y-lo.Y > spatialEps && hi.Z-lo.Z > spatialEps
+}
+
 // BodyFromBrep facets the B-rep and welds it into a watertight solid via
 // meshio.SolidOrSurface (which fixes inside-out winding). Used for in-memory validation.
 func BodyFromBrep(b ipt.Brep, feat string) (*topo.Body, []string, error) {

--- a/model/exchange/translators/inventor/translate/mesh_test.go
+++ b/model/exchange/translators/inventor/translate/mesh_test.go
@@ -9,10 +9,36 @@ import (
 	"testing"
 
 	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/exchange/meshio"
 	"oblikovati.org/kernel/topo"
+	m "oblikovati.org/math"
 	"oblikovati.org/model/analysis"
 	"oblikovati.org/model/exchange/translators/inventor/ipt"
 )
+
+// TestMeshIsSpatial guards the gate that keeps a body-only .ipt's import faithful: Inventor stores a
+// FLAT footprint placeholder as the graphics mesh for some parts (e.g. MBK_Keycap: a 6-triangle
+// 192×181×0 quad) whose real body lives in the SAB. Importing that would give a wrong flat sheet, so
+// a degenerate (non-3-D) mesh must be rejected while a real thin body is kept.
+func TestMeshIsSpatial(t *testing.T) {
+	flat := meshio.RawMesh{ // a 20×18×0 quad, two triangles — the placeholder shape
+		Verts: []m.Point3{m.P3(0, 0, 0), m.P3(2, 0, 0), m.P3(2, 1.8, 0), m.P3(0, 1.8, 0)},
+		Tris:  [][3]int{{0, 1, 2}, {0, 2, 3}},
+	}
+	if meshIsSpatial(flat) {
+		t.Error("flat placeholder mesh accepted; a z=0 footprint must be rejected")
+	}
+	thin := meshio.RawMesh{ // a real but thin body (0.29 cm deep, like the light pipe)
+		Verts: []m.Point3{m.P3(0, 0, 0), m.P3(2, 0, 0), m.P3(2, 1.8, 0.29), m.P3(0, 1.8, 0.29)},
+		Tris:  [][3]int{{0, 1, 2}, {0, 2, 3}},
+	}
+	if !meshIsSpatial(thin) {
+		t.Error("real thin body rejected; a mesh with 3-D extent must be kept")
+	}
+	if meshIsSpatial(meshio.RawMesh{}) {
+		t.Error("empty mesh accepted")
+	}
+}
 
 // TestSoupFromMesh checks that Inventor's decoded display tessellation adapts to a RawMesh
 // keeping vertex positions (cm) and triangle indices — the input to the graphics-mesh body

--- a/model/exchange/translators/inventor/translate/part.go
+++ b/model/exchange/translators/inventor/translate/part.go
@@ -120,7 +120,12 @@ func buildPart(ws *doc.Workspace, outPath string, d *ipt.Document, meshFallback 
 	// imported body too.
 	ex := ipt.DecodeExtrudes(d)
 	noBase := len(ex) > 0 && !hasBaseExtrude(ex)
-	if (meshFallback || noParametric || noBase) && (!built || !hasSolidBody(def)) {
+	// A parametric attempt that produced NO body at all — every extrude declined, or a revolve/
+	// loft/sweep base didn't reconstruct — leaves the def empty just like a body-only part. There is
+	// no partial parametric body to mask, so import the real shape rather than ship an empty part
+	// (HeadShield, CapstainFrontBody, MagneticShieldBlock and other decode-but-build-nothing parts).
+	noBody := len(def.SurfaceBodies().All()) == 0
+	if (meshFallback || noParametric || noBase || noBody) && (!built || !hasSolidBody(def)) {
 		warns = append(warns, addBodyIfPresent(def, d)...)
 		def.Recompute()
 	}
@@ -471,7 +476,12 @@ func buildExtrudeFeatures(def *compdef.PartComponentDefinition, d *ipt.Document,
 	// i" only ever held for the generated corpus.
 	profiles := ipt.ExtrudeProfiles(d)
 	regions := ipt.ExtrudeRegions(d)
-	var lastExtrude *feature.PartFeature
+	// patternSource is the last feature a pattern/mirror may legitimately replicate: a cut or a
+	// secondary boss (join), NEVER the base solid. Inventor's PatternFeature always references a
+	// feature placed AFTER the base; replicating the base itself only stamps coincident duplicates
+	// of the whole body — a centred base disk rotated about its own axis stacks N identical copies,
+	// inflating the volume N× (SmartKnobConnectingPlate: a Ø46 plate patterned 5× → 5×2098 mm³).
+	var patternSource *feature.PartFeature
 	for i, ex := range extrudes {
 		p := profileIndex(profiles, i)
 		if p < 0 || p >= len(emitted) || emitted[p].sk == nil {
@@ -486,8 +496,11 @@ func buildExtrudeFeatures(def *compdef.PartComponentDefinition, d *ipt.Document,
 			notes = append(notes, fmt.Sprintf("extrude %d: could not match its region (%d loops) to any rebuilt profile — skipped", i, len(region)))
 			continue
 		}
-		lastExtrude = feature.NewExtrudeFeatures(def.Features()).AddExtrude(
+		fx := feature.NewExtrudeFeatures(def.Features()).AddExtrude(
 			emitted[p].sk, idx, operationOf(ex.Operation), extentOf(ex), 0)
+		if ex.Operation != ipt.OpNewBody {
+			patternSource = fx // only a cut/join extrude is a valid pattern target
+		}
 		built = true
 	}
 	// A drilled hole cuts the base solid: place it on the extrude's top face (analytic), drilling
@@ -501,25 +514,27 @@ func buildExtrudeFeatures(def *compdef.PartComponentDefinition, d *ipt.Document,
 			notes = append(notes, "hole decoded but no base extrude to cut — skipped")
 		}
 	}
-	// A pattern or mirror replicates the last feature; it must run after the source feature so its
-	// occurrences re-cut the running body. Rectangular / circular / mirror are mutually exclusive.
+	// A pattern or mirror replicates a cut/boss feature; it must run after that source so its
+	// occurrences re-cut the running body. When the only feature built is the base solid,
+	// patternSource is nil and the pattern is skipped rather than stamping N coincident bodies.
+	// Rectangular / circular / mirror are mutually exclusive.
 	if rp, ok := ipt.DecodeRectPattern(d); ok {
-		if lastExtrude != nil {
-			addRectPattern(def, lastExtrude, rp)
+		if patternSource != nil {
+			addRectPattern(def, patternSource, rp)
 			built = true
 		} else {
-			notes = append(notes, "rectangular pattern decoded but no source feature — skipped")
+			notes = append(notes, "rectangular pattern decoded but only a base solid to replicate — skipped")
 		}
 	} else if cp, ok := ipt.DecodeCircPattern(d); ok {
-		if lastExtrude != nil {
-			addCircPattern(def, lastExtrude, cp)
+		if patternSource != nil {
+			addCircPattern(def, patternSource, cp)
 			built = true
 		} else {
-			notes = append(notes, "circular pattern decoded but no source feature — skipped")
+			notes = append(notes, "circular pattern decoded but only a base solid to replicate — skipped")
 		}
 	} else if mir, ok := ipt.DecodeMirror(d); ok {
-		if lastExtrude != nil {
-			addMirror(def, lastExtrude, mir)
+		if patternSource != nil {
+			addMirror(def, patternSource, mir)
 			built = true
 		} else {
 			notes = append(notes, "mirror decoded but no source feature — skipped")

--- a/model/exchange/translators/inventor/translate/part.go
+++ b/model/exchange/translators/inventor/translate/part.go
@@ -672,7 +672,7 @@ func buildExtrudeFeatures(def *compdef.PartComponentDefinition, d *ipt.Document,
 	if h, ok := ipt.DecodeHole(d); ok {
 		if len(extrudes) > 0 && len(placed) > 0 && len(emitted) > 0 && emitted[0].sk != nil {
 			cx, cy := profileCentroid(placed[0].geom)
-			addHole(def, h, cx, cy, extrudes[0].Distance)
+			addHole(def, h, placed[0].plane, cx, cy, extrudes[0].Distance)
 			built = true
 		} else {
 			notes = append(notes, "hole decoded but no base extrude to cut — skipped")
@@ -747,7 +747,7 @@ func addCircPattern(def *compdef.PartComponentDefinition, source *feature.PartFe
 // recompute (the externally-authored placement path, ADR-0040). Drilled, counterbore, and
 // countersink holes are built; v1 drills at the face centroid (explicit off-centre placement
 // is future work).
-func addHole(def *compdef.PartComponentDefinition, h ipt.Hole, cx, cy, thickness float64) {
+func addHole(def *compdef.PartComponentDefinition, h ipt.Hole, plane sketch.Plane, cx, cy, thickness float64) {
 	holes := feature.NewHoleFeatures(def.Features())
 	dia, depth := constF(h.Diameter), constF(h.Depth)
 	var pf *feature.PartFeature
@@ -765,7 +765,40 @@ func addHole(def *compdef.PartComponentDefinition, h ipt.Hole, cx, cy, thickness
 	}
 	hd := pf.Definition().(*feature.HoleFeature).Definition()
 	hd.ThroughAll = h.ThroughAll
-	hd.GeomFace = &topo.GeometricFaceRef{Centroid: m.P3(m.Scalar(cx), m.Scalar(cy), m.Scalar(thickness)), Normal: m.Vector3{X: 0, Y: 0, Z: 1}}
+	// A PLAIN drilled hole uses its OWN placement (its transform, decoded into h.Center/Axis): GeomFace
+	// finds the bored face and Center pins the exact drill point on it, so the bore lands where the
+	// file put it even when it is not centred on the base profile (CapstainNut's Ø1.7 bore sits at the
+	// origin with a +X axis, off the hex centroid — the profile-centroid guess missed it entirely). A
+	// plain bore is symmetric about its axis, so which face the placement resolves to is immaterial.
+	//
+	// The placement transform's translation is the hole's own coordinate-system ORIGIN, which equals
+	// the drill point only when the hole is centred there (as CapstainNut's is); on a hole offset from
+	// that datum (the generated box fixtures place a centred bore whose datum sits at a corner) it is
+	// NOT the bore centre. So the placement is used only where the top-face fallback is itself
+	// unreliable — a base sketch that is NOT the XY plane, the one case (CapstainNut, a hex extruded
+	// along +X) the fallback cannot place. XY-base holes (every fixture, MainFrame, WheelSlider) keep
+	// the fallback, which matches Inventor there. A plain bore is symmetric about its axis, so which
+	// face the placement resolves to is immaterial; a directional counterbore/countersink is excluded.
+	if h.Placed && h.Type == ipt.DrilledHole && !planeIsXY(plane) {
+		center := m.P3(m.Scalar(h.Center[0]), m.Scalar(h.Center[1]), m.Scalar(h.Center[2]))
+		hd.GeomFace = &topo.GeometricFaceRef{Centroid: center, Normal: m.Vector3{X: m.Scalar(h.Axis[0]), Y: m.Scalar(h.Axis[1]), Z: m.Scalar(h.Axis[2])}}
+		hd.Center = &center
+		return
+	}
+	// Fallback: drill on the base extrude's top face — the sketch-plane point (cx,cy) lifted into 3D
+	// and advanced along the plane normal by the extrude thickness. Hardcoding z=thickness / +Z drilled
+	// in empty space on any base sketch that was not the XY plane; this reduces to those old values on
+	// an XY sketch.
+	normal := plane.Normal()
+	top := plane.ToModel(m.P2(m.Scalar(cx), m.Scalar(cy)))
+	center := top.TranslateBy(normal.AsVector().Scale(m.Scalar(thickness)))
+	hd.GeomFace = &topo.GeometricFaceRef{Centroid: center, Normal: normal.AsVector()}
+}
+
+// planeIsXY reports whether a sketch plane is the world XY plane (its normal is ±Z), the case where
+// addHole's top-face fallback places a hole correctly.
+func planeIsXY(p sketch.Plane) bool {
+	return math.Abs(float64(p.Normal().AsVector().Z)) > 0.999
 }
 
 // constF returns a closure yielding the fixed value v — the func() float64 hole/pattern

--- a/model/exchange/translators/inventor/translate/part.go
+++ b/model/exchange/translators/inventor/translate/part.go
@@ -365,17 +365,35 @@ func revolveBinds(sketches []ipt.Sketch) bool {
 // verticalLine reports whether a decoded line is vertical (a revolve centreline is drawn upright).
 func verticalLine(l ipt.Line) bool { return math.Abs(l.A.X-l.B.X) < 1e-4 }
 
+// revolveAxisIndex returns the centreline's index in s.Lines. It prefers the isolated line
+// RevolveAxisLine finds (both endpoints shared with no other line — the clean shaft encoding); when
+// that is ambiguous — a real INTERNAL edge whose ends land on other edges' interiors also reads as
+// isolated (PressureRoller's x=0.8 splitter) — it falls back to the single VERTICAL CONSTRUCTION
+// line, which a revolve draws as its centreline. ok=false when neither names one unambiguous axis.
+func revolveAxisIndex(s ipt.Sketch) (int, bool) {
+	if ai, ok := ipt.RevolveAxisLine(s); ok && ai < len(s.Lines) && verticalLine(s.Lines[ai]) {
+		return ai, true
+	}
+	axis, n := -1, 0
+	for i, l := range s.Lines {
+		if s.LineIsConstruction(i) && verticalLine(l) {
+			axis, n = i, n+1
+		}
+	}
+	return axis, n == 1
+}
+
 // graphRevolveCandidate reports whether the node-graph sketches hold a plausible revolve the ipt
 // line-ring gate can't confirm: a vertical centreline inside a many-line profile. Such a profile
-// (a shaft with a keyway/notch) is a valid CLOSED region the KERNEL arranges — splitting the edge a
-// notch's mouth lands on — but ipt.isClosedRing, a naive head-to-tail line walk, rejects it. When
-// this holds, extractSketches keeps the graph so buildRevolve's kernel fallback can try it.
+// (a shaft with a keyway/notch, or a stepped roller split by an internal edge) is a valid region the
+// KERNEL arranges but ipt.isClosedRing (a naive head-to-tail line walk) rejects. When this holds,
+// extractSketches keeps the graph so buildRevolve's kernel fallback can try it.
 func graphRevolveCandidate(sketches []ipt.Sketch) bool {
 	for _, s := range sketches {
 		if !s.Resolved || len(s.Lines) < 4 {
 			continue
 		}
-		if ai, ok := ipt.RevolveAxisLine(s); ok && ai < len(s.Lines) && verticalLine(s.Lines[ai]) {
+		if _, ok := revolveAxisIndex(s); ok {
 			return true
 		}
 	}
@@ -411,35 +429,64 @@ func profileOneSideOfAxis(lines []ipt.Line, axisIdx int) bool {
 	return sign != 0
 }
 
-// tryKernelRevolve builds a revolve the ipt gate declined by trusting the KERNEL's arranged profile
+// tryKernelRevolve builds a revolve the ipt gate declined by trusting the KERNEL's arranged profiles
 // instead of the line-ring walk. It fires only after RevolveProfile fails, so no currently-building
-// revolve reaches it. Guards keep it honest: a vertical in-profile centreline, EXACTLY ONE closed
-// arranged profile (unambiguous), and that profile wholly one side of the axis. A wrong result is
-// still caught downstream — buildPart's gateBodyAgainstMesh drops a body that escapes Inventor's own
-// tessellation. Returns the built feature, or nil when no sketch qualifies.
-func tryKernelRevolve(def *compdef.PartComponentDefinition, seg []byte, placed []placedSketch, emitted []emittedSketch) *feature.PartFeature {
+// revolve reaches it. Guards keep it honest: an unambiguous vertical centreline (see
+// revolveAxisIndex), at least one CLOSED arranged profile, and the profile geometry wholly one side
+// of the axis. Every closed profile one side of the axis is revolved and unioned (a stepped roller's
+// internal edge splits one region into two, both part of the same solid). Returns the ids of the
+// features it added (empty when no sketch qualifies) so the caller can drop them if they don't close
+// to a solid.
+func tryKernelRevolve(def *compdef.PartComponentDefinition, seg []byte, placed []placedSketch, emitted []emittedSketch) []feature.ID {
 	for i := range emitted {
 		if emitted[i].sk == nil || i >= len(placed) {
 			continue
 		}
 		s := placed[i].geom
-		ai, ok := ipt.RevolveAxisLine(s)
-		if !ok || ai >= len(emitted[i].lines) || emitted[i].lines[ai] == nil || !verticalLine(s.Lines[ai]) {
+		ai, ok := revolveAxisIndex(s)
+		if !ok || ai >= len(emitted[i].lines) || emitted[i].lines[ai] == nil {
 			continue
 		}
-		if profs := emitted[i].sk.Profiles(); profs.Count() != 1 || !profs.Item(0).IsClosed() {
+		closed := closedProfileIndices(emitted[i].sk)
+		if len(closed) == 0 || !profileOneSideOfAxis(s.Lines, ai) {
 			continue
 		}
-		if !profileOneSideOfAxis(s.Lines, ai) {
-			continue
+		return revolveClosedProfiles(def, emitted[i], ai, closed, revolveAngleFn(seg))
+	}
+	return nil
+}
+
+// closedProfileIndices returns the indices of the sketch's closed arranged profiles.
+func closedProfileIndices(sk *sketch.Sketch) []int {
+	var out []int
+	profs := sk.Profiles()
+	for p := 0; p < profs.Count(); p++ {
+		if profs.Item(p).IsClosed() {
+			out = append(out, p)
 		}
-		var angle func() float64
-		if a, ok := ipt.RevolveAngle(seg); ok {
-			a := a
-			angle = func() float64 { return a }
+	}
+	return out
+}
+
+// revolveClosedProfiles turns each closed profile about the axis, the first starting the body and
+// the rest joining it (adjacent regions of one solid of revolution). Returns the added feature ids.
+func revolveClosedProfiles(def *compdef.PartComponentDefinition, e emittedSketch, axisLine int, closed []int, angle func() float64) []feature.ID {
+	var ids []feature.ID
+	for k, pi := range closed {
+		op := ops.NewBody
+		if k > 0 {
+			op = ops.Join
 		}
-		return feature.NewRevolveFeatures(def.Features()).AddAboutCenterlineLine(
-			emitted[i].sk, 0, emitted[i].sk, emitted[i].lines[ai], angle, ops.NewBody)
+		f := feature.NewRevolveFeatures(def.Features()).AddAboutCenterlineLine(e.sk, pi, e.sk, e.lines[axisLine], angle, op)
+		ids = append(ids, f.ID())
+	}
+	return ids
+}
+
+// revolveAngleFn returns the swept-angle accessor for a partial revolve, or nil for a full turn.
+func revolveAngleFn(seg []byte) func() float64 {
+	if a, ok := ipt.RevolveAngle(seg); ok {
+		return func() float64 { return a }
 	}
 	return nil
 }
@@ -528,9 +575,19 @@ func buildRevolve(def *compdef.PartComponentDefinition, seg []byte, placed []pla
 	if !ok {
 		// The line-ring gate declined. A profile with a notch/keyway (a curve whose end lands on
 		// another edge's interior) is a valid closed region the kernel arranges but that walk can't
-		// close — try the kernel's own profile before falling back to the mesh.
-		if tryKernelRevolve(def, seg, placed, emitted) != nil {
-			return true, nil
+		// close — try the kernel's own profile before falling back to the mesh. Keep the result ONLY
+		// if it closes to a solid: an open/self-intersecting revolve means a mis-decoded profile or
+		// axis, and the faithful display mesh is better than a wrong parametric body (a pre-2023
+		// PressureRoller copy built a half-open partial roller that way).
+		if ids := tryKernelRevolve(def, seg, placed, emitted); len(ids) > 0 {
+			def.Recompute()
+			if firstBodyIsSolid(def) {
+				return true, nil
+			}
+			for _, id := range ids {
+				def.Features().Remove(id)
+			}
+			return false, []string{"revolve: kernel profile did not close to a solid — imported body used"}
 		}
 		return false, []string{"revolve: no unambiguous closed profile + axis — sketches emitted, revolve not built"}
 	}

--- a/model/exchange/translators/inventor/translate/part.go
+++ b/model/exchange/translators/inventor/translate/part.go
@@ -452,32 +452,52 @@ func profileOneSideOfAxis(lines []ipt.Line, axisIdx int) bool {
 // internal edge splits one region into two, both part of the same solid). Returns the ids of the
 // features it added (empty when no sketch qualifies) so the caller can drop them if they don't close
 // to a solid.
-func tryKernelRevolve(def *compdef.PartComponentDefinition, seg []byte, placed []placedSketch, emitted []emittedSketch) []feature.ID {
+// A preferred sketch index >= 0 (from ipt.RevolveProfileSketch — the profile the Revolution feature
+// actually names) revolves EXACTLY that sketch: a machined part's cut profiles are never revolved by
+// mistake. If the named profile can't form a revolve here, it declines rather than guess another
+// sketch. preferred < 0 keeps the scan (used on the incidence line set, whose indices don't map to
+// the node graph the reference is keyed on).
+func tryKernelRevolve(def *compdef.PartComponentDefinition, seg []byte, placed []placedSketch, emitted []emittedSketch, preferred int) []feature.ID {
+	if preferred >= 0 {
+		if preferred < len(emitted) {
+			return revolveSketchAt(def, seg, placed, emitted, preferred)
+		}
+		return nil
+	}
 	for i := range emitted {
-		if emitted[i].sk == nil || i >= len(placed) {
-			continue
+		if ids := revolveSketchAt(def, seg, placed, emitted, i); ids != nil {
+			return ids
 		}
-		s := placed[i].geom
-		ai, ok := revolveAxisIndex(s)
-		if !ok || ai >= len(emitted[i].lines) || emitted[i].lines[ai] == nil {
-			continue
-		}
-		closed := closedProfileIndices(emitted[i].sk)
-		if len(closed) == 0 || !profileOneSideOfAxis(s.Lines, ai) {
-			continue
-		}
-		// A HORIZONTAL centreline forces a full turn: the partial-angle decode (soleSweepAngle) is
-		// unreliable about a horizontal axis — it mis-reads a profile chamfer's angle as the sweep
-		// (CapstainFrontBody's 125° is line[2]'s chamfer, not the extent), building a wrong pie-slice.
-		// A wrong full turn instead over-fills and is caught by the mesh gate; a mis-sized partial is
-		// not. Vertical-axis revolves keep the decoded angle (the 270° fixture depends on it).
-		angle := revolveAngleFn(seg)
-		if horizontalLine(s.Lines[ai]) {
-			angle = nil
-		}
-		return revolveClosedProfiles(def, emitted[i], ai, closed, angle)
 	}
 	return nil
+}
+
+// revolveSketchAt revolves the single sketch at index i if it forms a valid revolve (an unambiguous
+// axis-aligned centreline, at least one closed arranged profile, all geometry one side of the axis),
+// returning the added feature ids or nil when it does not qualify.
+func revolveSketchAt(def *compdef.PartComponentDefinition, seg []byte, placed []placedSketch, emitted []emittedSketch, i int) []feature.ID {
+	if emitted[i].sk == nil || i >= len(placed) {
+		return nil
+	}
+	s := placed[i].geom
+	ai, ok := revolveAxisIndex(s)
+	if !ok || ai >= len(emitted[i].lines) || emitted[i].lines[ai] == nil {
+		return nil
+	}
+	closed := closedProfileIndices(emitted[i].sk)
+	if len(closed) == 0 || !profileOneSideOfAxis(s.Lines, ai) {
+		return nil
+	}
+	// A HORIZONTAL centreline forces a full turn: the partial-angle decode (soleSweepAngle) is
+	// unreliable about a horizontal axis — it mis-reads a profile chamfer's angle as the sweep
+	// (CapstainFrontBody's 125° is line[2]'s chamfer, not the extent), building a wrong pie-slice.
+	// A wrong full turn instead over-fills and is caught by the mesh gate; a mis-sized partial is
+	// not. Vertical-axis revolves keep the decoded angle (the 270° fixture depends on it).
+	angle := revolveAngleFn(seg)
+	if horizontalLine(s.Lines[ai]) {
+		angle = nil
+	}
+	return revolveClosedProfiles(def, emitted[i], ai, closed, angle)
 }
 
 // closedProfileIndices returns the indices of the sketch's closed arranged profiles.
@@ -603,7 +623,7 @@ func buildRevolve(def *compdef.PartComponentDefinition, seg []byte, placed []pla
 		// if it closes to a solid: an open/self-intersecting revolve means a mis-decoded profile or
 		// axis, and the faithful display mesh is better than a wrong parametric body (a pre-2023
 		// PressureRoller copy built a half-open partial roller that way).
-		if ids := tryKernelRevolve(def, seg, placed, emitted); len(ids) > 0 {
+		if ids := tryKernelRevolve(def, seg, placed, emitted, -1); len(ids) > 0 {
 			def.Recompute()
 			if firstBodyIsSolid(def) {
 				return true, nil

--- a/model/exchange/translators/inventor/translate/part.go
+++ b/model/exchange/translators/inventor/translate/part.go
@@ -115,7 +115,12 @@ func buildPart(ws *doc.Workspace, outPath string, d *ipt.Document, meshFallback 
 	// thing it carries. So when nothing parametric decoded, import its body unconditionally, turning
 	// an empty translation into the real shape (31 of the corpus's ThirdParty + base-plate parts).
 	noParametric := def.Sketches().Count() == 0 && def.Features().Count() == 0
-	if (meshFallback || noParametric) && (!built || !hasSolidBody(def)) {
+	// A baseless extrude chain (extrudes exist but all cut/join, no New-Body — see
+	// buildExtrudeFeatures) also can't rebuild parametrically, so its real shape must come from the
+	// imported body too.
+	ex := ipt.DecodeExtrudes(d)
+	noBase := len(ex) > 0 && !hasBaseExtrude(ex)
+	if (meshFallback || noParametric || noBase) && (!built || !hasSolidBody(def)) {
 		warns = append(warns, addBodyIfPresent(def, d)...)
 		def.Recompute()
 	}
@@ -438,10 +443,30 @@ func buildRevolve(def *compdef.PartComponentDefinition, seg []byte, placed []pla
 // consumes the sketch at its index, then a hole cuts the base, then a pattern/mirror replicates
 // the last extrude. Each stage that is decoded but can't be built appends a note and is skipped;
 // whatever built stays. Returns whether any feature built.
+// hasBaseExtrude reports whether any extrude starts a body (New-Body). Without one the extrude chain
+// is all cut/join with nothing to act on, so it cannot rebuild a solid — its base is a feature type
+// this decoder does not produce.
+func hasBaseExtrude(extrudes []ipt.Extrude) bool {
+	for _, e := range extrudes {
+		if e.Operation == ipt.OpNewBody {
+			return true
+		}
+	}
+	return false
+}
+
 func buildExtrudeFeatures(def *compdef.PartComponentDefinition, d *ipt.Document, seg []byte, placed []placedSketch, emitted []emittedSketch) (bool, []string) {
 	built := false
 	var notes []string
 	extrudes := ipt.DecodeExtrudes(d)
+	// A part whose extrudes are ALL cut/join/intersect has no base body to apply them to: its base
+	// is a feature this decoder does not produce (a sheet-metal face on MainBaseSheet, say). Applying
+	// cuts to nothing builds a garbage sliver — 1% of the true volume — so build no extrude and leave
+	// the sketches standing; buildPart then imports the real body. Only a New-Body extrude starts a
+	// solid, so its absence means the whole extrude chain is baseless.
+	if len(extrudes) > 0 && !hasBaseExtrude(extrudes) {
+		return false, []string{fmt.Sprintf("%d extrude(s) but none starts a body — no parametric base; imported body used", len(extrudes))}
+	}
 	// Each extrude names the profile it consumes (see ipt.ExtrudeProfiles); "extrude i uses sketch
 	// i" only ever held for the generated corpus.
 	profiles := ipt.ExtrudeProfiles(d)

--- a/model/exchange/translators/inventor/translate/part.go
+++ b/model/exchange/translators/inventor/translate/part.go
@@ -333,7 +333,19 @@ func extractSketches(d *ipt.Document, seg []byte) []placedSketch {
 		if profiles := ipt.LineProfiles(seg); len(profiles) > 0 {
 			// Reunite a separate vertical centreline into the profile sketch (as Inventor authored
 			// it) so the revolve's radius dimensions can bind to the profile in one sketch.
-			decoded = ipt.ReuniteRevolveAxis(profiles)
+			lineSet := ipt.ReuniteRevolveAxis(profiles)
+			decoded = lineSet
+			// Incidence sometimes SPLITS the profile into isolated single-line sketches (EncoderWheel:
+			// a 13-line profile decoded as three 1-line sketches, none closed), so no revolve binds and
+			// the part falls back to its non-manifold display mesh. The node GRAPH keeps that profile
+			// whole; when the fragmented line set forms no valid revolve but the graph does (a vertical
+			// in-profile centreline, case A), revolve the graph instead. Preferring the line set first
+			// keeps every currently-building revolve — and the horizontal-axis test fixtures — unchanged.
+			if !revolveBinds(lineSet) {
+				if graph := ipt.GraphSketches(d); sketchEntityCount(graph) > 0 && revolveBinds(graph) {
+					decoded = graph
+				}
+			}
 		}
 	}
 	placed := make([]placedSketch, len(decoded))
@@ -341,6 +353,13 @@ func extractSketches(d *ipt.Document, seg []byte) []placedSketch {
 		placed[i] = placedSketch{geom: decoded[i], plane: sketchPlaneOf(decoded[i])}
 	}
 	return placed
+}
+
+// revolveBinds reports whether RevolveProfile finds a valid closed profile + axis in this sketch
+// set — the gate that decides whether a revolve can be built from it at all.
+func revolveBinds(sketches []ipt.Sketch) bool {
+	_, ok := ipt.RevolveProfile(sketches)
+	return ok
 }
 
 // sketchPlaneOf places a sketch where the file says it lives. A sketch's entity coordinates are 2D

--- a/model/exchange/translators/inventor/translate/part.go
+++ b/model/exchange/translators/inventor/translate/part.go
@@ -457,15 +457,15 @@ func profileOneSideOfAxis(lines []ipt.Line, axisIdx int) bool {
 // mistake. If the named profile can't form a revolve here, it declines rather than guess another
 // sketch. preferred < 0 keeps the scan (used on the incidence line set, whose indices don't map to
 // the node graph the reference is keyed on).
-func tryKernelRevolve(def *compdef.PartComponentDefinition, seg []byte, placed []placedSketch, emitted []emittedSketch, preferred int) []feature.ID {
+func tryKernelRevolve(def *compdef.PartComponentDefinition, seg []byte, placed []placedSketch, emitted []emittedSketch, preferred int, axis revolveAxisRef) []feature.ID {
 	if preferred >= 0 {
 		if preferred < len(emitted) {
-			return revolveSketchAt(def, seg, placed, emitted, preferred)
+			return revolveSketchAt(def, seg, placed, emitted, preferred, axis)
 		}
 		return nil
 	}
 	for i := range emitted {
-		if ids := revolveSketchAt(def, seg, placed, emitted, i); ids != nil {
+		if ids := revolveSketchAt(def, seg, placed, emitted, i, axis); ids != nil {
 			return ids
 		}
 	}
@@ -474,13 +474,19 @@ func tryKernelRevolve(def *compdef.PartComponentDefinition, seg []byte, placed [
 
 // revolveSketchAt revolves the single sketch at index i if it forms a valid revolve (an unambiguous
 // axis-aligned centreline, at least one closed arranged profile, all geometry one side of the axis),
-// returning the added feature ids or nil when it does not qualify.
-func revolveSketchAt(def *compdef.PartComponentDefinition, seg []byte, placed []placedSketch, emitted []emittedSketch, i int) []feature.ID {
+// returning the added feature ids or nil when it does not qualify. When the geometric heuristic can't
+// name the centreline but the feature's decoded axis reference (axis) can, the collinear profile edge
+// it points at is used — the case where the axis is an ordinary edge, neither isolated nor
+// construction (CapstainMotorCap turns about its y=0 top edge).
+func revolveSketchAt(def *compdef.PartComponentDefinition, seg []byte, placed []placedSketch, emitted []emittedSketch, i int, axis revolveAxisRef) []feature.ID {
 	if emitted[i].sk == nil || i >= len(placed) {
 		return nil
 	}
 	s := placed[i].geom
 	ai, ok := revolveAxisIndex(s)
+	if !ok && axis.ok {
+		ai, ok = axisLineFromReference(s, axis)
+	}
 	if !ok || ai >= len(emitted[i].lines) || emitted[i].lines[ai] == nil {
 		return nil
 	}
@@ -623,7 +629,7 @@ func buildRevolve(def *compdef.PartComponentDefinition, seg []byte, placed []pla
 		// if it closes to a solid: an open/self-intersecting revolve means a mis-decoded profile or
 		// axis, and the faithful display mesh is better than a wrong parametric body (a pre-2023
 		// PressureRoller copy built a half-open partial roller that way).
-		if ids := tryKernelRevolve(def, seg, placed, emitted, -1); len(ids) > 0 {
+		if ids := tryKernelRevolve(def, seg, placed, emitted, -1, revolveAxisRef{}); len(ids) > 0 {
 			def.Recompute()
 			if firstBodyIsSolid(def) {
 				return true, nil

--- a/model/exchange/translators/inventor/translate/part.go
+++ b/model/exchange/translators/inventor/translate/part.go
@@ -108,9 +108,14 @@ func buildPart(ws *doc.Workspace, outPath string, d *ipt.Document, meshFallback 
 			built = false
 		}
 	}
-	// Inventor's display mesh hides the sketch/feature history behind a single imported body,
-	// so it is imported ONLY on explicit opt-in — otherwise the partial parametric tree stands.
-	if meshFallback && (!built || !hasSolidBody(def)) {
+	// Inventor's display mesh hides the sketch/feature history behind a single imported body, so for
+	// a part that DID decode a partial parametric tree it is imported only on explicit opt-in — the
+	// tree stands. But a body-only .ipt (a derived/imported solid, or a downloaded vendor part) has
+	// NO sketches and NO features: there is no history to mask, and leaving it EMPTY discards the one
+	// thing it carries. So when nothing parametric decoded, import its body unconditionally, turning
+	// an empty translation into the real shape (31 of the corpus's ThirdParty + base-plate parts).
+	noParametric := def.Sketches().Count() == 0 && def.Features().Count() == 0
+	if (meshFallback || noParametric) && (!built || !hasSolidBody(def)) {
 		warns = append(warns, addBodyIfPresent(def, d)...)
 		def.Recompute()
 	}
@@ -269,11 +274,13 @@ func addFeatures(def *compdef.PartComponentDefinition, d *ipt.Document) (bool, [
 	sketches := ipt.DecodeSketches(seg)
 	if heights, ok := ipt.LoftSectionHeights(seg, len(sketches)); ok {
 		if addLoft(def, sketches, heights) {
+			emitDroppedCurveSketches(def, d) // keep splines/ellipses the line-only loft profile drops
 			return true, nil
 		}
 	}
 	if sw, ok := ipt.DecodeSweep(seg); ok {
 		if addSweep(def, sw) {
+			emitDroppedCurveSketches(def, d) // keep splines/ellipses the line-only sweep profile drops
 			return true, nil
 		}
 	}
@@ -281,7 +288,9 @@ func addFeatures(def *compdef.PartComponentDefinition, d *ipt.Document) (bool, [
 	placed := extractSketches(d, seg)
 	emitted := emitSketches(def, placed)
 	if ipt.HasRevolve(seg) {
-		return buildRevolve(def, seg, placed, emitted)
+		built, notes := buildRevolve(def, seg, placed, emitted)
+		emitDroppedCurveSketches(def, d) // keep splines/ellipses the line-only revolve profile drops
+		return built, notes
 	}
 	return buildExtrudeFeatures(def, d, seg, placed, emitted)
 }
@@ -297,7 +306,8 @@ func extractSketches(d *ipt.Document, seg []byte) []placedSketch {
 	// the byte-offset clustering, which both splits one sketch (Linkage1: 1 sketch decoded as 3)
 	// and loses most of the geometry (BigChunkyPlate: 2143 entities decoded as 19). Scoped to the
 	// extrude path: a revolve profile still goes through the incidence reconstruction below, whose
-	// closed-loop gate the revolve build depends on.
+	// closed-loop gate the revolve build depends on (RevolveProfile needs the centreline SPLIT into
+	// its own sketch, which the graph decode keeps in the profile sketch — see buildRevolve).
 	//
 	// Taken only when it actually decoded entities: some parts hold Sketch2D nodes whose entities
 	// this layout can't read (an older save generation, presumably), and an empty graph result must
@@ -356,6 +366,28 @@ func planeOf(pl ipt.SketchPlacement) (sketch.Plane, bool) {
 		return sketch.Plane{}, false
 	}
 	return p, true
+}
+
+// emitDroppedCurveSketches re-emits the freeform curves — splines and ellipses — that a whole-part
+// feature build (revolve, sweep, loft) drops because its profile extraction is line-only. Those
+// features replace the emitted set with a reconstructed line profile, silently discarding every
+// spline/ellipse the part also carries (Hose-Screen-Adapter, a revolve, lost all 3 of its sketch
+// splines this way). Only the curves are emitted — never the co-resident lines — so nothing can
+// duplicate the feature's profile: a revolve/loft profile is line-only and never holds a spline or
+// ellipse, so these sketches are disjoint from it. The extrude path already emits the full graph
+// set, so this is called ONLY on the whole-part feature branches.
+func emitDroppedCurveSketches(def *compdef.PartComponentDefinition, d *ipt.Document) {
+	for _, s := range ipt.GraphSketches(d) {
+		if len(s.Splines) == 0 && len(s.Ellipses) == 0 {
+			continue
+		}
+		curves := ipt.Sketch{
+			Splines: s.Splines, SplineConstruction: s.SplineConstruction,
+			Ellipses: s.Ellipses,
+			Plane:    s.Plane, PlaneOK: s.PlaneOK,
+		}
+		emitSketchOn(def, curves, sketchPlaneOf(curves))
+	}
 }
 
 // emitSketches adds every extracted sketch to the document and returns the handles in the same
@@ -616,7 +648,7 @@ func emitSketch(def *compdef.PartComponentDefinition, s ipt.Sketch) *sketch.Sket
 // per line (AddByTwoPoints) — gives the rebuilt sketch the same degrees of freedom as the original
 // (a closed N-gon: 2N free DOF, not 4N).
 func emitSketchOn(def *compdef.PartComponentDefinition, s ipt.Sketch, plane sketch.Plane) (*sketch.Sketch, []*sketch.Line) {
-	if len(s.Points) == 0 && len(s.Lines) == 0 && len(s.Circles) == 0 && len(s.Arcs) == 0 && len(s.Ellipses) == 0 {
+	if len(s.Points) == 0 && len(s.Lines) == 0 && len(s.Circles) == 0 && len(s.Arcs) == 0 && len(s.Ellipses) == 0 && len(s.Splines) == 0 {
 		return nil, nil
 	}
 	sk := def.Sketches().Add(plane)
@@ -646,6 +678,15 @@ func emitSketchOn(def *compdef.PartComponentDefinition, s ipt.Sketch, plane sket
 		// Share the centre with any coincident corner (pointAt), matching how Inventor stores an
 		// ellipse's centre by reference. The major-axis direction and both semi-axes are verbatim.
 		sk.Ellipses().AddWithCenter(pointAt(e.Center), m.V2(e.MajorAxis.X, e.MajorAxis.Y), m.Scalar(e.MajorR), m.Scalar(e.MinorR))
+	}
+	for i, sp := range s.Splines {
+		// Share the fit points with any coincident corner (pointAt), matching how Inventor references
+		// them. fit=true: Inventor's sketch spline interpolates these points rather than approximating.
+		pts := make([]*sketch.Point, len(sp.Points))
+		for j, p := range sp.Points {
+			pts[j] = pointAt(p)
+		}
+		sk.Splines().AddWithPoints(pts, sp.Closed, true).SetConstruction(s.SplineIsConstruction(i))
 	}
 	return sk, lines
 }
@@ -1327,7 +1368,10 @@ func operationOf(op int) ops.PartFeatureOperation {
 // tessellation (PmGraphicsSegment: curved faces and holes already meshed), and falls back to
 // the analytic ACIS planar reconstruction when the graphics mesh is absent/degenerate.
 func addBodyIfPresent(def *compdef.PartComponentDefinition, d *ipt.Document) []string {
-	if raw := SoupFromMesh(ipt.GraphicsMesh(d)); raw.TriangleCount() >= 4 {
+	// Prefer Inventor's display tessellation, but only when it is a real 3-D body — some parts store
+	// a flat footprint placeholder there and keep the true body in the SAB, so a degenerate mesh
+	// falls through to the B-rep (or to no body) rather than importing a wrong flat sheet.
+	if raw := SoupFromMesh(ipt.GraphicsMesh(d)); raw.TriangleCount() >= 4 && meshIsSpatial(raw) {
 		return importSoup(def, raw)
 	}
 	seg, ok := d.Segment("PmBRepSegment")
@@ -1401,7 +1445,7 @@ func profileIndex(profiles []int, i int) int {
 func sketchEntityCount(sketches []ipt.Sketch) int {
 	n := 0
 	for _, s := range sketches {
-		n += len(s.Points) + len(s.Lines) + len(s.Circles) + len(s.Arcs) + len(s.Ellipses)
+		n += len(s.Points) + len(s.Lines) + len(s.Circles) + len(s.Arcs) + len(s.Ellipses) + len(s.Splines)
 	}
 	return n
 }

--- a/model/exchange/translators/inventor/translate/part.go
+++ b/model/exchange/translators/inventor/translate/part.go
@@ -296,12 +296,12 @@ func addFeatures(def *compdef.PartComponentDefinition, d *ipt.Document) (bool, [
 	}
 	// Decoupled path: extract + emit all sketches unconditionally, then build features over them.
 	placed := extractSketches(d, seg)
-	emitted := emitSketches(def, placed)
 	if ipt.HasRevolve(seg) {
-		built, notes := buildRevolve(def, seg, placed, emitted)
-		emitDroppedCurveSketches(def, d) // keep splines/ellipses the line-only revolve profile drops
-		return built, notes
+		// The revolve path owns its own emission: a machined revolve part is rebuilt from the node
+		// graph (profile+centreline+cuts kept whole) when the incidence line set can't close it.
+		return buildRevolveDispatch(def, d, seg, placed)
 	}
+	emitted := emitSketches(def, placed)
 	return buildExtrudeFeatures(def, d, seg, placed, emitted)
 }
 

--- a/model/exchange/translators/inventor/translate/part.go
+++ b/model/exchange/translators/inventor/translate/part.go
@@ -669,7 +669,7 @@ func buildExtrudeFeatures(def *compdef.PartComponentDefinition, d *ipt.Document,
 	}
 	// A drilled hole cuts the base solid: place it on the extrude's top face (analytic), drilling
 	// at the profile centroid. Needs the base extrude to have built the body first.
-	if h, ok := ipt.DecodeHole(seg); ok {
+	if h, ok := ipt.DecodeHole(d); ok {
 		if len(extrudes) > 0 && len(placed) > 0 && len(emitted) > 0 && emitted[0].sk != nil {
 			cx, cy := profileCentroid(placed[0].geom)
 			addHole(def, h, cx, cy, extrudes[0].Distance)

--- a/model/exchange/translators/inventor/translate/part.go
+++ b/model/exchange/translators/inventor/translate/part.go
@@ -363,7 +363,13 @@ func revolveBinds(sketches []ipt.Sketch) bool {
 }
 
 // verticalLine reports whether a decoded line is vertical (a revolve centreline is drawn upright).
-func verticalLine(l ipt.Line) bool { return math.Abs(l.A.X-l.B.X) < 1e-4 }
+func verticalLine(l ipt.Line) bool   { return math.Abs(l.A.X-l.B.X) < 1e-4 }
+func horizontalLine(l ipt.Line) bool { return math.Abs(l.A.Y-l.B.Y) < 1e-4 }
+
+// axisAlignedLine reports whether a line runs along X or Y — the orientations a revolve centreline
+// takes in this corpus (a shaft turned about a vertical or a horizontal axis). An oblique axis is
+// not recognised (none observed), so it declines to the mesh rather than guess.
+func axisAlignedLine(l ipt.Line) bool { return verticalLine(l) || horizontalLine(l) }
 
 // revolveAxisIndex returns the centreline's index in s.Lines. It prefers the isolated line
 // RevolveAxisLine finds (both endpoints shared with no other line — the clean shaft encoding); when
@@ -371,12 +377,12 @@ func verticalLine(l ipt.Line) bool { return math.Abs(l.A.X-l.B.X) < 1e-4 }
 // isolated (PressureRoller's x=0.8 splitter) — it falls back to the single VERTICAL CONSTRUCTION
 // line, which a revolve draws as its centreline. ok=false when neither names one unambiguous axis.
 func revolveAxisIndex(s ipt.Sketch) (int, bool) {
-	if ai, ok := ipt.RevolveAxisLine(s); ok && ai < len(s.Lines) && verticalLine(s.Lines[ai]) {
+	if ai, ok := ipt.RevolveAxisLine(s); ok && ai < len(s.Lines) && axisAlignedLine(s.Lines[ai]) {
 		return ai, true
 	}
 	axis, n := -1, 0
 	for i, l := range s.Lines {
-		if s.LineIsConstruction(i) && verticalLine(l) {
+		if s.LineIsConstruction(i) && axisAlignedLine(l) {
 			axis, n = i, n+1
 		}
 	}
@@ -400,18 +406,27 @@ func graphRevolveCandidate(sketches []ipt.Sketch) bool {
 	return false
 }
 
-// profileOneSideOfAxis reports whether every profile-line endpoint lies on one side of the vertical
-// axis at axisIdx — a valid solid of revolution never crosses its axis. The ipt equivalent is
-// unexported; this handles the vertical-centreline case the kernel fallback needs.
+// profileOneSideOfAxis reports whether every profile-line endpoint lies on one side of the
+// axis-aligned centreline at axisIdx — a valid solid of revolution never crosses its axis. The signed
+// distance is measured perpendicular to the axis: across X for a vertical centreline, across Y for a
+// horizontal one (a shaft turned about the X axis, e.g. a bushing). The ipt equivalent is unexported.
 func profileOneSideOfAxis(lines []ipt.Line, axisIdx int) bool {
-	axisX := lines[axisIdx].A.X
+	ax := lines[axisIdx]
+	vertical := verticalLine(ax)
+	ref := ax.A.X
+	if !vertical {
+		ref = ax.A.Y
+	}
 	sign := 0
 	for i, l := range lines {
 		if i == axisIdx {
 			continue
 		}
 		for _, p := range []ipt.Point2D{l.A, l.B} {
-			d := p.X - axisX
+			d := p.X - ref
+			if !vertical {
+				d = p.Y - ref
+			}
 			if math.Abs(d) < 1e-6 {
 				continue
 			}
@@ -451,7 +466,16 @@ func tryKernelRevolve(def *compdef.PartComponentDefinition, seg []byte, placed [
 		if len(closed) == 0 || !profileOneSideOfAxis(s.Lines, ai) {
 			continue
 		}
-		return revolveClosedProfiles(def, emitted[i], ai, closed, revolveAngleFn(seg))
+		// A HORIZONTAL centreline forces a full turn: the partial-angle decode (soleSweepAngle) is
+		// unreliable about a horizontal axis — it mis-reads a profile chamfer's angle as the sweep
+		// (CapstainFrontBody's 125° is line[2]'s chamfer, not the extent), building a wrong pie-slice.
+		// A wrong full turn instead over-fills and is caught by the mesh gate; a mis-sized partial is
+		// not. Vertical-axis revolves keep the decoded angle (the 270° fixture depends on it).
+		angle := revolveAngleFn(seg)
+		if horizontalLine(s.Lines[ai]) {
+			angle = nil
+		}
+		return revolveClosedProfiles(def, emitted[i], ai, closed, angle)
 	}
 	return nil
 }

--- a/model/exchange/translators/inventor/translate/part.go
+++ b/model/exchange/translators/inventor/translate/part.go
@@ -342,7 +342,7 @@ func extractSketches(d *ipt.Document, seg []byte) []placedSketch {
 			// in-profile centreline, case A), revolve the graph instead. Preferring the line set first
 			// keeps every currently-building revolve — and the horizontal-axis test fixtures — unchanged.
 			if !revolveBinds(lineSet) {
-				if graph := ipt.GraphSketches(d); sketchEntityCount(graph) > 0 && revolveBinds(graph) {
+				if graph := ipt.GraphSketches(d); sketchEntityCount(graph) > 0 && (revolveBinds(graph) || graphRevolveCandidate(graph)) {
 					decoded = graph
 				}
 			}
@@ -360,6 +360,88 @@ func extractSketches(d *ipt.Document, seg []byte) []placedSketch {
 func revolveBinds(sketches []ipt.Sketch) bool {
 	_, ok := ipt.RevolveProfile(sketches)
 	return ok
+}
+
+// verticalLine reports whether a decoded line is vertical (a revolve centreline is drawn upright).
+func verticalLine(l ipt.Line) bool { return math.Abs(l.A.X-l.B.X) < 1e-4 }
+
+// graphRevolveCandidate reports whether the node-graph sketches hold a plausible revolve the ipt
+// line-ring gate can't confirm: a vertical centreline inside a many-line profile. Such a profile
+// (a shaft with a keyway/notch) is a valid CLOSED region the KERNEL arranges — splitting the edge a
+// notch's mouth lands on — but ipt.isClosedRing, a naive head-to-tail line walk, rejects it. When
+// this holds, extractSketches keeps the graph so buildRevolve's kernel fallback can try it.
+func graphRevolveCandidate(sketches []ipt.Sketch) bool {
+	for _, s := range sketches {
+		if !s.Resolved || len(s.Lines) < 4 {
+			continue
+		}
+		if ai, ok := ipt.RevolveAxisLine(s); ok && ai < len(s.Lines) && verticalLine(s.Lines[ai]) {
+			return true
+		}
+	}
+	return false
+}
+
+// profileOneSideOfAxis reports whether every profile-line endpoint lies on one side of the vertical
+// axis at axisIdx — a valid solid of revolution never crosses its axis. The ipt equivalent is
+// unexported; this handles the vertical-centreline case the kernel fallback needs.
+func profileOneSideOfAxis(lines []ipt.Line, axisIdx int) bool {
+	axisX := lines[axisIdx].A.X
+	sign := 0
+	for i, l := range lines {
+		if i == axisIdx {
+			continue
+		}
+		for _, p := range []ipt.Point2D{l.A, l.B} {
+			d := p.X - axisX
+			if math.Abs(d) < 1e-6 {
+				continue
+			}
+			s := 1
+			if d < 0 {
+				s = -1
+			}
+			if sign == 0 {
+				sign = s
+			} else if sign != s {
+				return false
+			}
+		}
+	}
+	return sign != 0
+}
+
+// tryKernelRevolve builds a revolve the ipt gate declined by trusting the KERNEL's arranged profile
+// instead of the line-ring walk. It fires only after RevolveProfile fails, so no currently-building
+// revolve reaches it. Guards keep it honest: a vertical in-profile centreline, EXACTLY ONE closed
+// arranged profile (unambiguous), and that profile wholly one side of the axis. A wrong result is
+// still caught downstream — buildPart's gateBodyAgainstMesh drops a body that escapes Inventor's own
+// tessellation. Returns the built feature, or nil when no sketch qualifies.
+func tryKernelRevolve(def *compdef.PartComponentDefinition, seg []byte, placed []placedSketch, emitted []emittedSketch) *feature.PartFeature {
+	for i := range emitted {
+		if emitted[i].sk == nil || i >= len(placed) {
+			continue
+		}
+		s := placed[i].geom
+		ai, ok := ipt.RevolveAxisLine(s)
+		if !ok || ai >= len(emitted[i].lines) || emitted[i].lines[ai] == nil || !verticalLine(s.Lines[ai]) {
+			continue
+		}
+		if profs := emitted[i].sk.Profiles(); profs.Count() != 1 || !profs.Item(0).IsClosed() {
+			continue
+		}
+		if !profileOneSideOfAxis(s.Lines, ai) {
+			continue
+		}
+		var angle func() float64
+		if a, ok := ipt.RevolveAngle(seg); ok {
+			a := a
+			angle = func() float64 { return a }
+		}
+		return feature.NewRevolveFeatures(def.Features()).AddAboutCenterlineLine(
+			emitted[i].sk, 0, emitted[i].sk, emitted[i].lines[ai], angle, ops.NewBody)
+	}
+	return nil
 }
 
 // sketchPlaneOf places a sketch where the file says it lives. A sketch's entity coordinates are 2D
@@ -444,6 +526,12 @@ func buildRevolve(def *compdef.PartComponentDefinition, seg []byte, placed []pla
 	}
 	b, ok := ipt.RevolveProfile(geoms)
 	if !ok {
+		// The line-ring gate declined. A profile with a notch/keyway (a curve whose end lands on
+		// another edge's interior) is a valid closed region the kernel arranges but that walk can't
+		// close — try the kernel's own profile before falling back to the mesh.
+		if tryKernelRevolve(def, seg, placed, emitted) != nil {
+			return true, nil
+		}
 		return false, []string{"revolve: no unambiguous closed profile + axis — sketches emitted, revolve not built"}
 	}
 	if b.ProfileSketch >= len(emitted) || emitted[b.ProfileSketch].sk == nil {

--- a/model/exchange/translators/inventor/translate/part_test.go
+++ b/model/exchange/translators/inventor/translate/part_test.go
@@ -1062,3 +1062,36 @@ func TestCapstainMotorCapRevolvesAboutItsEdge(t *testing.T) {
 		t.Errorf("volume = %.0f mm³, want within 3%% of Inventor's 31223", vol)
 	}
 }
+
+// TestSmartKnobFixedBaseCutsThroughStepped covers the through-cut retry: a blind/one-sided cut on
+// this turned knob lands its end face coincident with the stepped top and OPENS the body; applyRevolveCuts
+// retries such a cut as a symmetric through-all, which removes the full column and closes it. Reopens
+// as a SOLID within 2% of Inventor's STL volume (3549). Corpus-gated; set IPT_CORPUS.
+func TestSmartKnobFixedBaseCutsThroughStepped(t *testing.T) {
+	dir := os.Getenv("IPT_CORPUS")
+	if dir == "" {
+		dir = `P:\ReelToReel\Mechanical`
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "SmartKnobFixedBase.ipt"))
+	if err != nil {
+		t.Skipf("corpus part not available (%v); set IPT_CORPUS", err)
+	}
+	out := filepath.Join(t.TempDir(), "skfb.opd")
+	if _, err := FromInventor(data, out); err != nil {
+		t.Fatalf("FromInventor: %v", err)
+	}
+	ws := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
+	reopened, err := ws.Open(out, true)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	def := reopened.Content().(*compdef.PartComponentDefinition)
+	bodies := def.SurfaceBodies().All()
+	if len(bodies) == 0 || !bodies[0].IsSolid() {
+		t.Fatalf("want a SOLID turned+milled base, got %d bodies (solid=%v)", len(bodies), len(bodies) > 0 && bodies[0].IsSolid())
+	}
+	vol := analysis.MassPropertiesOf(bodies, 1, types.MassPropertiesLow).VolumeMm3
+	if math.Abs(vol-3549) > 0.02*3549 {
+		t.Errorf("volume = %.0f mm³, want within 2%% of Inventor's 3549", vol)
+	}
+}

--- a/model/exchange/translators/inventor/translate/part_test.go
+++ b/model/exchange/translators/inventor/translate/part_test.go
@@ -4,6 +4,7 @@ package translate
 
 import (
 	"math"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -239,6 +240,45 @@ func TestCircPatternTranslationRebuildsSolid(t *testing.T) {
 	want := (math.Pi*9 - 6*math.Pi*0.25) * 1000 // mm^3
 	if math.Abs(mp.VolumeMm3-want) > 0.02*want {
 		t.Errorf("circular-patterned volume = %.1f mm^3, want ~%.1f (within 2%%)", mp.VolumeMm3, want)
+	}
+}
+
+// TestCircPatternDoesNotReplicateBaseSolid guards the pattern-on-base fix: a Ø46 plate whose
+// only feature is the base extrude, with a circular pattern authored to replicate its bolt-hole
+// (already baked into the profile's inner loops), must NOT stamp the whole plate 5× — a centred
+// base disk rotated about its own axis makes 5 coincident copies, inflating the volume to 5×2098.
+// The pattern's source must be a cut/join, never the base, so with no such feature the pattern is
+// skipped and one plate stands (~2098 mm³ vs Inventor's 2122). Corpus-gated: this exact geometry
+// only exists in the real part (no generated fixture reproduces the centred-disk degeneracy), so
+// the test skips where the corpus is absent (CI) and runs on a dev checkout of the ReelToReel set.
+// Point IPT_CORPUS at the Mechanical directory to enable it.
+func TestCircPatternDoesNotReplicateBaseSolid(t *testing.T) {
+	dir := os.Getenv("IPT_CORPUS")
+	if dir == "" {
+		dir = `P:\ReelToReel\Mechanical`
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "SmartKnobConnectingPlate.ipt"))
+	if err != nil {
+		t.Skipf("corpus part not available (%v); set IPT_CORPUS to the ReelToReel Mechanical dir", err)
+	}
+	out := filepath.Join(t.TempDir(), "plate.opd")
+	if _, err := FromInventor(data, out); err != nil {
+		t.Fatalf("FromInventor: %v", err)
+	}
+	ws := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
+	reopened, err := ws.Open(out, true)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	def := reopened.Content().(*compdef.PartComponentDefinition)
+	bodies := def.SurfaceBodies().All()
+	if len(bodies) != 1 {
+		t.Fatalf("built %d bodies, want 1 (a circular pattern must not replicate the base solid)", len(bodies))
+	}
+	mp := analysis.MassPropertiesOf(bodies, 1, types.MassPropertiesLow)
+	const oracle = 2122.0 // Inventor STL volume, mm^3
+	if math.Abs(mp.VolumeMm3-oracle) > 0.05*oracle {
+		t.Errorf("plate volume = %.0f mm^3, want ~%.0f (within 5%%)", mp.VolumeMm3, oracle)
 	}
 }
 

--- a/model/exchange/translators/inventor/translate/part_test.go
+++ b/model/exchange/translators/inventor/translate/part_test.go
@@ -904,3 +904,43 @@ func TestCapstainNutBoreIsDrilledOnItsOwnFace(t *testing.T) {
 		t.Errorf("CapstainNut volume = %.0f mm³, want within 12%% of Inventor's %.0f", vol, oracle)
 	}
 }
+
+// TestFlangeReelMotorCutFitsItsScallops pins the containment area-fit guard. FlangeReelMotor's third
+// extrude is a through-all cut whose region is four ~13.7 cm² edge scallops. The +-shaped keep cell
+// (108 cm²) got a test point inside one scallop loop, so containment selected the whole + and the
+// through-cut gutted the flange (19468 mm³ = 0.11x). A cell far larger than the loop holding its
+// point cannot be that loop's interior, so it is now rejected; only the scallops are cut and the
+// flange survives (183104 vs Inventor's 175398 = 1.04x). Corpus-gated; set IPT_CORPUS.
+func TestFlangeReelMotorCutFitsItsScallops(t *testing.T) {
+	dir := os.Getenv("IPT_CORPUS")
+	if dir == "" {
+		dir = `P:\ReelToReel\Mechanical`
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "FlangeReelMotor.ipt"))
+	if err != nil {
+		t.Skipf("corpus part not available (%v); set IPT_CORPUS", err)
+	}
+	out := filepath.Join(t.TempDir(), "flange.opd")
+	if _, err := FromInventor(data, out); err != nil {
+		t.Fatalf("FromInventor: %v", err)
+	}
+	ws := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
+	reopened, err := ws.Open(out, true)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	def := reopened.Content().(*compdef.PartComponentDefinition)
+	bodies := def.SurfaceBodies().All()
+	if len(bodies) == 0 {
+		t.Fatalf("no body built")
+	}
+	vol := analysis.MassPropertiesOf(bodies, 1, types.MassPropertiesLow).VolumeMm3
+	const oracle = 175398.0 // Inventor STL volume, mm³
+	// Guard against a regression back to the gutted flange (19468 = 0.11x).
+	if vol < 0.5*oracle {
+		t.Errorf("FlangeReelMotor volume = %.0f mm³, want >= %.0f (the cut must not gut the flange)", vol, 0.5*oracle)
+	}
+	if math.Abs(vol-oracle) > 0.08*oracle {
+		t.Errorf("FlangeReelMotor volume = %.0f mm³, want within 8%% of Inventor's %.0f", vol, oracle)
+	}
+}

--- a/model/exchange/translators/inventor/translate/part_test.go
+++ b/model/exchange/translators/inventor/translate/part_test.go
@@ -865,3 +865,42 @@ func TestImportRoundTripsThroughOPD(t *testing.T) {
 		t.Errorf("reopened box volume = %.3f mm^3, want 8000", mp.VolumeMm3)
 	}
 }
+
+// TestCapstainNutBoreIsDrilledOnItsOwnFace pins the hole-placement fix: CapstainNut's hex is
+// extruded along +X, so addHole's top-face fallback (XY-plane assumption) drilled in empty space and
+// the Ø1.7 bore removed nothing (a solid nut, 3663 mm³ = 1.62x). Using the hole's own placement
+// (its transform's point + axis) as the GeomFace AND the drill Center bores it correctly — 2420 mm³
+// vs Inventor's 2261 (1.07x; the residual is the two 45° chamfers this decoder does not build).
+// Corpus-gated: the non-XY-face bore only exists in the real part; skips without IPT_CORPUS.
+func TestCapstainNutBoreIsDrilledOnItsOwnFace(t *testing.T) {
+	dir := os.Getenv("IPT_CORPUS")
+	if dir == "" {
+		dir = `P:\ReelToReel\Mechanical`
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "CapstainNut.ipt"))
+	if err != nil {
+		t.Skipf("corpus part not available (%v); set IPT_CORPUS", err)
+	}
+	out := filepath.Join(t.TempDir(), "nut.opd")
+	if _, err := FromInventor(data, out); err != nil {
+		t.Fatalf("FromInventor: %v", err)
+	}
+	ws := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
+	reopened, err := ws.Open(out, true)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	def := reopened.Content().(*compdef.PartComponentDefinition)
+	bodies := def.SurfaceBodies().All()
+	if len(bodies) == 0 {
+		t.Fatalf("no body built")
+	}
+	vol := analysis.MassPropertiesOf(bodies, 1, types.MassPropertiesLow).VolumeMm3
+	const oracle = 2261.0 // Inventor STL volume, mm³
+	if vol > 1.2*oracle {
+		t.Errorf("CapstainNut volume = %.0f mm³, want <= %.0f (the bore must be drilled, not missing)", vol, 1.2*oracle)
+	}
+	if math.Abs(vol-oracle) > 0.12*oracle {
+		t.Errorf("CapstainNut volume = %.0f mm³, want within 12%% of Inventor's %.0f", vol, oracle)
+	}
+}

--- a/model/exchange/translators/inventor/translate/part_test.go
+++ b/model/exchange/translators/inventor/translate/part_test.go
@@ -14,6 +14,7 @@ import (
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
+	"oblikovati.org/model/exchange/translators/inventor/ipt"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/sketch"
 	"oblikovati.org/persistence"
@@ -300,6 +301,51 @@ func TestEllipseTranslationRoundTrips(t *testing.T) {
 	}
 	if math.Abs(e.Center.X-10) > 1e-9 || math.Abs(e.Center.Y-5) > 1e-9 {
 		t.Errorf("centre = (%.4g,%.4g), want (10,5)", e.Center.X, e.Center.Y)
+	}
+}
+
+// TestSplineTranslationRoundTrips checks the reopened .opd carries a native Oblikovati fit spline
+// with the four fit points ke_spline declares — the SketchSpline (0xF9372FD4) decode/emit path.
+func TestSplineTranslationRoundTrips(t *testing.T) {
+	def := reopenPart(t, "ke_spline.ipt")
+	if def.Sketches().Count() != 1 {
+		t.Fatalf("got %d sketches, want 1", def.Sketches().Count())
+	}
+	sk := def.Sketches().Item(0)
+	if n := sk.Splines().Count(); n != 1 {
+		t.Fatalf("got %d splines, want 1", n)
+	}
+	sp := sk.Splines().Item(0)
+	if !sp.IsFitType() {
+		t.Error("spline is not a fit (interpolating) type")
+	}
+	if n := sp.PointCount(); n != 4 {
+		t.Errorf("spline has %d fit points, want 4", n)
+	}
+}
+
+// TestEmitDroppedCurveSketchesKeepsSplines guards that the freeform-curve rescue (used by the
+// revolve/sweep/loft paths, whose line-only profile extraction drops splines and ellipses) emits a
+// spline-bearing sketch's spline. Without it a revolve part like Hose-Screen-Adapter loses every
+// sketch spline it carries. Uses ke_spline (one fit spline) driven through the rescue directly.
+func TestEmitDroppedCurveSketchesKeepsSplines(t *testing.T) {
+	d, err := ipt.Open(readCorpus(t, "ke_spline.ipt"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	ws := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
+	document, err := compdef.AddPart(ws, filepath.Join(t.TempDir(), "p.opd"), true)
+	if err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	def := document.Content().(*compdef.PartComponentDefinition)
+	emitDroppedCurveSketches(def, d)
+	splines := 0
+	for k := 0; k < def.Sketches().Count(); k++ {
+		splines += def.Sketches().Item(k).Splines().Count()
+	}
+	if splines != 1 {
+		t.Errorf("rescue emitted %d splines, want 1 (the curve a line-only profile decode would drop)", splines)
 	}
 }
 

--- a/model/exchange/translators/inventor/translate/part_test.go
+++ b/model/exchange/translators/inventor/translate/part_test.go
@@ -1095,3 +1095,37 @@ func TestSmartKnobFixedBaseCutsThroughStepped(t *testing.T) {
 		t.Errorf("volume = %.0f mm³, want within 2%% of Inventor's 3549", vol)
 	}
 }
+
+// TestKnobBottomDomeWallRecoversArc covers the revolve-scoped arc recovery: the knob's r≈20 dome
+// wall is stored as a full circle (its open-flag clear) that crosses the axis; reviseAxisCrossingCircles
+// rebuilds it as the arc its endpoints describe, so the profile closes instead of revolving a giant
+// circle into a blob. Reopens as a SOLID within 15% of Inventor's STL volume (4361 — the wall's minor
+// thickness overage). Corpus-gated; set IPT_CORPUS.
+func TestKnobBottomDomeWallRecoversArc(t *testing.T) {
+	dir := os.Getenv("IPT_CORPUS")
+	if dir == "" {
+		dir = `P:\ReelToReel\Mechanical`
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "KnobBottom.ipt"))
+	if err != nil {
+		t.Skipf("corpus part not available (%v); set IPT_CORPUS", err)
+	}
+	out := filepath.Join(t.TempDir(), "kb.opd")
+	if _, err := FromInventor(data, out); err != nil {
+		t.Fatalf("FromInventor: %v", err)
+	}
+	ws := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
+	reopened, err := ws.Open(out, true)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	def := reopened.Content().(*compdef.PartComponentDefinition)
+	bodies := def.SurfaceBodies().All()
+	if len(bodies) == 0 || !bodies[0].IsSolid() {
+		t.Fatalf("want a SOLID domed knob, got %d bodies (solid=%v)", len(bodies), len(bodies) > 0 && bodies[0].IsSolid())
+	}
+	vol := analysis.MassPropertiesOf(bodies, 1, types.MassPropertiesLow).VolumeMm3
+	if math.Abs(vol-4361) > 0.15*4361 {
+		t.Errorf("volume = %.0f mm³, want within 15%% of Inventor's 4361", vol)
+	}
+}

--- a/model/exchange/translators/inventor/translate/part_test.go
+++ b/model/exchange/translators/inventor/translate/part_test.go
@@ -1029,3 +1029,36 @@ func TestMachinedHolderRevolveWithCuts(t *testing.T) {
 		}
 	}
 }
+
+// TestCapstainMotorCapRevolvesAboutItsEdge covers the axis-reference fallback (Phase 2): the revolve
+// turns about its y=0 top EDGE, which is neither isolated nor construction, so the geometric
+// heuristic returns nothing and the feature's decoded axis (ipt.RevolveAxis2D) supplies it. Reopens
+// as a SOLID within 3% of Inventor's STL volume (31223). Corpus-gated; set IPT_CORPUS.
+func TestCapstainMotorCapRevolvesAboutItsEdge(t *testing.T) {
+	dir := os.Getenv("IPT_CORPUS")
+	if dir == "" {
+		dir = `P:\ReelToReel\Mechanical`
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "CapstainMotorCap.ipt"))
+	if err != nil {
+		t.Skipf("corpus part not available (%v); set IPT_CORPUS", err)
+	}
+	out := filepath.Join(t.TempDir(), "cmc.opd")
+	if _, err := FromInventor(data, out); err != nil {
+		t.Fatalf("FromInventor: %v", err)
+	}
+	ws := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
+	reopened, err := ws.Open(out, true)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	def := reopened.Content().(*compdef.PartComponentDefinition)
+	bodies := def.SurfaceBodies().All()
+	if len(bodies) == 0 || !bodies[0].IsSolid() {
+		t.Fatalf("want a SOLID turned+milled cap, got %d bodies (solid=%v)", len(bodies), len(bodies) > 0 && bodies[0].IsSolid())
+	}
+	vol := analysis.MassPropertiesOf(bodies, 1, types.MassPropertiesLow).VolumeMm3
+	if math.Abs(vol-31223) > 0.03*31223 {
+		t.Errorf("volume = %.0f mm³, want within 3%% of Inventor's 31223", vol)
+	}
+}

--- a/model/exchange/translators/inventor/translate/part_test.go
+++ b/model/exchange/translators/inventor/translate/part_test.go
@@ -944,3 +944,46 @@ func TestFlangeReelMotorCutFitsItsScallops(t *testing.T) {
 		t.Errorf("FlangeReelMotor volume = %.0f mm³, want within 8%% of Inventor's %.0f", vol, oracle)
 	}
 }
+
+// TestHorizontalAxisRevolveBuildsSolids pins the horizontal-centreline revolve. A shaft/bushing
+// turned about a HORIZONTAL axis (an isolated line running along X, e.g. 1677K262's line at y=0)
+// was not recognised — revolveAxisIndex only accepted a vertical centreline — so the part fell back
+// to a 2x open-mesh SURFACE. Now an axis-aligned isolated line is a valid centreline and the profile
+// turns a full 360° (the partial-angle decode is unreliable about a horizontal axis). Corpus-gated;
+// set IPT_CORPUS.
+func TestHorizontalAxisRevolveBuildsSolids(t *testing.T) {
+	dir := os.Getenv("IPT_CORPUS")
+	if dir == "" {
+		dir = `P:\ReelToReel\Mechanical`
+	}
+	for _, tc := range []struct {
+		file   string
+		oracle float64
+	}{
+		{"1677K262.ipt", 2586},            // a turned bushing, full 360° about y=0
+		{"CapstainFrontBody.ipt", 114417}, // full turn about a horizontal axis (its 125° is a chamfer, not the sweep)
+	} {
+		data, err := os.ReadFile(filepath.Join(dir, tc.file))
+		if err != nil {
+			t.Skipf("corpus part not available (%v); set IPT_CORPUS", err)
+		}
+		out := filepath.Join(t.TempDir(), "r.opd")
+		if _, err := FromInventor(data, out); err != nil {
+			t.Fatalf("%s: FromInventor: %v", tc.file, err)
+		}
+		ws := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
+		reopened, err := ws.Open(out, true)
+		if err != nil {
+			t.Fatalf("%s: reopen: %v", tc.file, err)
+		}
+		def := reopened.Content().(*compdef.PartComponentDefinition)
+		bodies := def.SurfaceBodies().All()
+		if len(bodies) == 0 || !bodies[0].IsSolid() {
+			t.Fatalf("%s: want a SOLID revolve, got %d bodies (solid=%v)", tc.file, len(bodies), len(bodies) > 0 && bodies[0].IsSolid())
+		}
+		vol := analysis.MassPropertiesOf(bodies, 1, types.MassPropertiesLow).VolumeMm3
+		if math.Abs(vol-tc.oracle) > 0.05*tc.oracle {
+			t.Errorf("%s: volume = %.0f mm³, want within 5%% of Inventor's %.0f", tc.file, vol, tc.oracle)
+		}
+	}
+}

--- a/model/exchange/translators/inventor/translate/part_test.go
+++ b/model/exchange/translators/inventor/translate/part_test.go
@@ -987,3 +987,45 @@ func TestHorizontalAxisRevolveBuildsSolids(t *testing.T) {
 		}
 	}
 }
+
+// TestMachinedHolderRevolveWithCuts covers the ext,rev,hole path (buildRevolveDispatch's graph
+// branch): a turned base whose milled cut extrudes must be applied over it. The incidence line set
+// splits the revolve profile from its centreline, so the base is rebuilt from the node graph (which
+// keeps them whole) and the cuts are booleaned on top. Both parts reopen as a SOLID within 2% of
+// Inventor's STL volume (SpoolMotor 19441, CapstonMotor 17201). Corpus-gated; set IPT_CORPUS.
+func TestMachinedHolderRevolveWithCuts(t *testing.T) {
+	dir := os.Getenv("IPT_CORPUS")
+	if dir == "" {
+		dir = `P:\ReelToReel\Mechanical`
+	}
+	for _, tc := range []struct {
+		file   string
+		oracle float64
+	}{
+		{"SpoolMotorMachinedHolder.ipt", 19441},
+		{"CapstonMotorMachinedHolder.ipt", 17201},
+	} {
+		data, err := os.ReadFile(filepath.Join(dir, tc.file))
+		if err != nil {
+			t.Skipf("corpus part not available (%v); set IPT_CORPUS", err)
+		}
+		out := filepath.Join(t.TempDir(), "h.opd")
+		if _, err := FromInventor(data, out); err != nil {
+			t.Fatalf("%s: FromInventor: %v", tc.file, err)
+		}
+		ws := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
+		reopened, err := ws.Open(out, true)
+		if err != nil {
+			t.Fatalf("%s: reopen: %v", tc.file, err)
+		}
+		def := reopened.Content().(*compdef.PartComponentDefinition)
+		bodies := def.SurfaceBodies().All()
+		if len(bodies) == 0 || !bodies[0].IsSolid() {
+			t.Fatalf("%s: want a SOLID turned+milled body, got %d bodies (solid=%v)", tc.file, len(bodies), len(bodies) > 0 && bodies[0].IsSolid())
+		}
+		vol := analysis.MassPropertiesOf(bodies, 1, types.MassPropertiesLow).VolumeMm3
+		if math.Abs(vol-tc.oracle) > 0.02*tc.oracle {
+			t.Errorf("%s: volume = %.0f mm³, want within 2%% of Inventor's %.0f", tc.file, vol, tc.oracle)
+		}
+	}
+}

--- a/model/exchange/translators/inventor/translate/part_test.go
+++ b/model/exchange/translators/inventor/translate/part_test.go
@@ -349,6 +349,24 @@ func TestEmitDroppedCurveSketchesKeepsSplines(t *testing.T) {
 	}
 }
 
+// TestHasBaseExtrude guards the base-detection that keeps a baseless extrude chain (all cut/join,
+// no New-Body — MainBaseSheet, whose base plate is a sheet-metal face this decoder doesn't produce)
+// from building a garbage sliver: without a New-Body extrude the chain has nothing to cut, so the
+// caller imports the real body instead.
+func TestHasBaseExtrude(t *testing.T) {
+	allCuts := []ipt.Extrude{{Operation: ipt.OpCut}, {Operation: ipt.OpJoin}, {Operation: ipt.OpCut}}
+	if hasBaseExtrude(allCuts) {
+		t.Error("an all-cut/join chain has no base and must report false")
+	}
+	withBase := []ipt.Extrude{{Operation: ipt.OpNewBody}, {Operation: ipt.OpCut}}
+	if !hasBaseExtrude(withBase) {
+		t.Error("a chain containing a New-Body extrude must report true")
+	}
+	if hasBaseExtrude(nil) {
+		t.Error("no extrudes must report false")
+	}
+}
+
 // reopenPart translates an .ipt through the full pipeline and reopens it, returning the definition.
 func reopenPart(t *testing.T, file string) *compdef.PartComponentDefinition {
 	t.Helper()

--- a/model/exchange/translators/inventor/translate/regionpoly.go
+++ b/model/exchange/translators/inventor/translate/regionpoly.go
@@ -71,12 +71,27 @@ func containedProfileIndices(sk *sketch.Sketch, region []ipt.RegionLoop) ([]int,
 			// fallback over-built it 7.6x.
 			continue
 		}
-		if insideRegion(q, outers, holes) {
-			out = append(out, i)
+		if !insideRegion(q, outers, holes) {
+			continue
 		}
+		// A cell belongs to the region only if it FITS the loop that holds its test point. A single
+		// interior point being inside a loop is necessary but not sufficient: a large cell can have a
+		// corner poke into a small loop while the rest lies far outside it. FlangeReelMotor's +-shaped
+		// keep cell (108 cm²) had its point land in a 13.7 cm² edge scallop, so a through-cut selected
+		// the whole + and gutted the flange. A cell far larger than its containing loop cannot be that
+		// loop's interior, so it is rejected (the generous 1.5x slack passes reconstruction noise while
+		// catching this 7.9x mismatch).
+		if a, ok := smallestContainingArea(q, outers); ok && polygonArea(p.OuterLoop().Polygon()) > cellFitSlack*a {
+			continue
+		}
+		out = append(out, i)
 	}
 	return out, true
 }
+
+// cellFitSlack is how much larger than its containing region loop a cell may be and still count as
+// inside it — headroom for arc-sampling and boundary-chaining noise, well below any real over-select.
+const cellFitSlack = 1.5
 
 // profileInteriorPoint returns a point inside the cell's MATERIAL — inside its outer loop and
 // outside its own holes.

--- a/model/exchange/translators/inventor/translate/regionpoly.go
+++ b/model/exchange/translators/inventor/translate/regionpoly.go
@@ -13,9 +13,24 @@ import (
 // the arcs themselves are exact, trimmed by ipt.trimCircleEdge from the file's own point1AI /
 // point2AI / posDir, so nothing here guesses which way round a circle the face runs.
 
-// polyTol is the distance under which two boundary endpoints are the same point. The file's
-// coordinates meet exactly; this only absorbs float noise in re-deriving them.
-const polyTol = 1e-6 // tol:calibrated — region boundary endpoint join; see sketch arrMergeTol
+// polyTol is the distance (cm) under which two region-boundary endpoints are the same point when
+// chaining a loop's edges head-to-tail for the CONTAINMENT test. It is used ONLY to decide which
+// cells lie inside a region (regionBoundary/joinChains); it never touches built geometry.
+//
+// It cannot be float-noise-tight: a loop's edges do NOT always meet exactly. A thin (sub-mm) ribbon
+// where an end-cap arc meets the two side lines carries a real ~0.05 mm spread between the arc's
+// trimmed endpoint and the line's endpoint (TapePath's tape-guide loops: three curves meet at a
+// corner within a ~0.01 cm triangle). At 1e-6 those loops were UNCHAINABLE, so containment declined
+// and the caller fell back to the curve-set rule — which over-selected 13 cells (4.83 of 20.49 cm²)
+// and built the extrude at 7.6x its true volume.
+//
+// 7e-3 cm sits just above the real ~5e-3 cm endpoint spread and below the ~1.1e-2 cm separation of
+// genuinely-distinct corner points, so it joins the meant-to-coincide endpoints without collapsing a
+// real corner (a looser 1e-2 mis-closed TapePath's loop[2], halving its enclosed area). It stays far
+// below any feature size — negligible for a point-in-polygon test whose cell interiors sit well
+// inside the boundary. Only parts whose loops FAIL to chain at 1e-6 can change; a loop that already
+// closes is unaffected.
+const polyTol = 7e-3 // tol:calibrated — region containment endpoint join; see sketch arrMergeTol
 
 // arcSegments is how finely an arc is sampled for the containment test. Containment only asks which
 // side of the boundary a cell sits on — it is well inside or well outside — so this is a test
@@ -48,7 +63,13 @@ func containedProfileIndices(sk *sketch.Sketch, region []ipt.RegionLoop) ([]int,
 		}
 		q, ok := profileInteriorPoint(p)
 		if !ok {
-			return nil, false // cannot place a test point: decline rather than mis-select
+			// A cell with no placeable interior point is a degenerate sliver of the arrangement (a
+			// zero-width wedge between near-coincident curves); it bounds no material, so skip it
+			// rather than declining the WHOLE region. Declining sent the entire sketch to the
+			// curve-set fallback whenever one of many cells was degenerate — TapePath's 60-cell tape
+			// path had such slivers, so its thin ribbons were never containment-selected and the
+			// fallback over-built it 7.6x.
+			continue
 		}
 		if insideRegion(q, outers, holes) {
 			out = append(out, i)
@@ -81,11 +102,22 @@ func profileInteriorPoint(p *sketch.Profile) (math.Point2, bool) {
 }
 
 // regionBoundaries reconstructs the region's material outlines and its holes.
+//
+// A MATERIAL loop that will not chain into a closed polygon is an OPEN sliver — a degenerate
+// fragment that bounds no area, so it can be no face and is dropped rather than failing the whole
+// region (TapePath's tape-guide patch carries one such 2-edge stub — a ~0.005 cm arc joined to a
+// line at a single shared vertex — alongside five real thin-ribbon faces; failing on it sent the
+// whole region to the wrong curve-set rule, which over-selected 13 cells and built the extrude at
+// 7.6x volume). A CUT loop is NOT dropped: an unreadable hole would silently over-fill the face, so
+// its region still declines to containment and keeps the safer fallback.
 func regionBoundaries(region []ipt.RegionLoop) (outers, holes [][]math.Point2, ok bool) {
 	for _, l := range region {
 		poly, ok := regionBoundary(l)
 		if !ok || len(poly) < 3 {
-			return nil, nil, false
+			if l.Cut {
+				return nil, nil, false // a hole we cannot read: decline rather than over-fill
+			}
+			continue // an open material sliver bounds no face
 		}
 		if l.Cut {
 			holes = append(holes, poly)
@@ -93,7 +125,7 @@ func regionBoundaries(region []ipt.RegionLoop) (outers, holes [][]math.Point2, o
 			outers = append(outers, poly)
 		}
 	}
-	return outers, holes, true
+	return outers, holes, len(outers) > 0
 }
 
 // insideRegion reports whether q is inside some material outline and outside every hole.

--- a/model/exchange/translators/inventor/translate/regionpoly.go
+++ b/model/exchange/translators/inventor/translate/regionpoly.go
@@ -151,6 +151,12 @@ func loopChains(l ipt.RegionLoop) (chains [][]math.Point2, whole [][]math.Point2
 			chains = append(chains, arcPolyline(e.Arc))
 		case ipt.EdgeCircle:
 			whole = append(whole, sampleWholeCircle(e.Circle))
+		case ipt.EdgeEllipse:
+			if e.Ellipse.Start == (ipt.Point2D{}) && e.Ellipse.End == (ipt.Point2D{}) {
+				whole = append(whole, ellipseArcPolyline(e.Ellipse)) // a whole ellipse stands alone, like a bore
+			} else {
+				chains = append(chains, ellipseArcPolyline(e.Ellipse))
+			}
 		}
 	}
 	return chains, whole

--- a/model/exchange/translators/inventor/translate/regionpoly_geom.go
+++ b/model/exchange/translators/inventor/translate/regionpoly_geom.go
@@ -61,6 +61,52 @@ func arcPolyline(a ipt.Arc) []math.Point2 {
 	return out
 }
 
+// ellipseParam returns the eccentric angle t of a point on the ellipse, i.e. the t for which the
+// point is Center + MajorR*cos(t)*u + MinorR*sin(t)*v with u the major axis and v its CCW normal.
+func ellipseParam(e ipt.EllipseArc, p ipt.Point2D) float64 {
+	ux, uy := e.MajorAxis.X, e.MajorAxis.Y
+	dx, dy := p.X-e.Center.X, p.Y-e.Center.Y
+	x := dx*ux + dy*uy  // component along major axis
+	y := -dx*uy + dy*ux // component along minor axis (v = (-uy, ux))
+	return stdmath.Atan2(y/e.MinorR, x/e.MajorR)
+}
+
+// ellipsePoint maps an eccentric angle back to a boundary point.
+func ellipsePoint(e ipt.EllipseArc, t float64) math.Point2 {
+	ux, uy := e.MajorAxis.X, e.MajorAxis.Y
+	c, s := stdmath.Cos(t), stdmath.Sin(t)
+	x := e.Center.X + e.MajorR*c*ux - e.MinorR*s*uy
+	y := e.Center.Y + e.MajorR*c*uy + e.MinorR*s*ux
+	return math.P2(math.Scalar(x), math.Scalar(y))
+}
+
+// ellipseArcPolyline samples an ellipse boundary edge. When Start == End the loop names the whole
+// ellipse (sampled full turn); otherwise it walks the eccentric-angle span CCW from Start to End —
+// the same convention arcPolyline uses, since ipt.trimEllipseEdge ordered Start/End by posDir.
+func ellipseArcPolyline(e ipt.EllipseArc) []math.Point2 {
+	if e.Start == (ipt.Point2D{}) && e.End == (ipt.Point2D{}) {
+		out := make([]math.Point2, arcSegments)
+		for i := range out {
+			out[i] = ellipsePoint(e, 2*stdmath.Pi*float64(i)/float64(arcSegments))
+		}
+		return out
+	}
+	s, en := ellipseParam(e, e.Start), ellipseParam(e, e.End)
+	span := en - s
+	for span <= 0 {
+		span += 2 * stdmath.Pi
+	}
+	n := int(stdmath.Ceil(float64(arcSegments) * span / (2 * stdmath.Pi)))
+	if n < 2 {
+		n = 2
+	}
+	out := make([]math.Point2, 0, n+1)
+	for i := 0; i <= n; i++ {
+		out = append(out, ellipsePoint(e, s+span*float64(i)/float64(n)))
+	}
+	return out
+}
+
 // sampleWholeCircle samples a circle the loop names whole (a bore's hole loop).
 func sampleWholeCircle(c ipt.Circle) []math.Point2 {
 	out := make([]math.Point2, arcSegments)

--- a/model/exchange/translators/inventor/translate/regionpoly_geom.go
+++ b/model/exchange/translators/inventor/translate/regionpoly_geom.go
@@ -119,6 +119,35 @@ func sampleWholeCircle(c ipt.Circle) []math.Point2 {
 	return out
 }
 
+// polygonArea is the absolute area a closed polygon encloses (shoelace).
+func polygonArea(poly []math.Point2) float64 {
+	a := 0.0
+	for i := range poly {
+		j := (i + 1) % len(poly)
+		a += float64(poly[i].X)*float64(poly[j].Y) - float64(poly[j].X)*float64(poly[i].Y)
+	}
+	if a < 0 {
+		a = -a
+	}
+	return a / 2
+}
+
+// smallestContainingArea returns the area of the smallest region outer loop that contains q, and
+// whether any does. The smallest (tightest) loop is the one a cell inside q must fit — where outer
+// loops overlap, a cell can belong to at most the smaller of them.
+func smallestContainingArea(q math.Point2, outers [][]math.Point2) (float64, bool) {
+	best, found := 0.0, false
+	for _, o := range outers {
+		if !pointInPoly(q, o) {
+			continue
+		}
+		if a := polygonArea(o); !found || a < best {
+			best, found = a, true
+		}
+	}
+	return best, found
+}
+
 // pointInPoly is the even-odd containment test.
 func pointInPoly(q math.Point2, poly []math.Point2) bool {
 	in := false

--- a/model/exchange/translators/inventor/translate/regionpoly_openloop_test.go
+++ b/model/exchange/translators/inventor/translate/regionpoly_openloop_test.go
@@ -5,6 +5,7 @@ package translate
 import (
 	"testing"
 
+	m "oblikovati.org/math"
 	"oblikovati.org/model/exchange/translators/inventor/ipt"
 )
 
@@ -49,5 +50,29 @@ func TestRegionBoundariesDropsOpenMaterialSliver(t *testing.T) {
 func TestRegionBoundariesDeclinesOnOpenCut(t *testing.T) {
 	if _, _, ok := regionBoundaries([]ipt.RegionLoop{closedTriangle(), openSliver(true)}); ok {
 		t.Errorf("regionBoundaries accepted a region with an unreadable cut loop; want decline")
+	}
+}
+
+// TestSmallestContainingAreaPicksTightestLoop: a point inside two nested outer loops resolves to the
+// SMALLER loop's area (a cell there can belong to at most the tighter one), and polygonArea is the
+// enclosed area. This backs the containment area-fit guard that keeps a big keep-cell out of a small
+// cut loop (FlangeReelMotor).
+func TestSmallestContainingAreaPicksTightestLoop(t *testing.T) {
+	big := []m.Point2{m.P2(0, 0), m.P2(10, 0), m.P2(10, 10), m.P2(0, 10)} // 100
+	small := []m.Point2{m.P2(3, 3), m.P2(7, 3), m.P2(7, 7), m.P2(3, 7)}   // 16
+	if a := polygonArea(big); a != 100 {
+		t.Errorf("polygonArea(big) = %g, want 100", a)
+	}
+	// Point (5,5) is inside both; the tighter loop (16) wins.
+	if a, ok := smallestContainingArea(m.P2(5, 5), [][]m.Point2{big, small}); !ok || a != 16 {
+		t.Errorf("smallestContainingArea inside both = %g (ok=%v), want 16", a, ok)
+	}
+	// Point (1,1) is inside only the big loop.
+	if a, ok := smallestContainingArea(m.P2(1, 1), [][]m.Point2{big, small}); !ok || a != 100 {
+		t.Errorf("smallestContainingArea in big only = %g (ok=%v), want 100", a, ok)
+	}
+	// Point outside all loops.
+	if _, ok := smallestContainingArea(m.P2(20, 20), [][]m.Point2{big, small}); ok {
+		t.Errorf("smallestContainingArea outside all should be ok=false")
 	}
 }

--- a/model/exchange/translators/inventor/translate/regionpoly_openloop_test.go
+++ b/model/exchange/translators/inventor/translate/regionpoly_openloop_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package translate
+
+import (
+	"testing"
+
+	"oblikovati.org/model/exchange/translators/inventor/ipt"
+)
+
+// line builds a straight region edge between two points.
+func line(ax, ay, bx, by float64) ipt.RegionEdge {
+	return ipt.RegionEdge{Kind: ipt.EdgeLine, Line: ipt.Line{A: ipt.Point2D{X: ax, Y: ay}, B: ipt.Point2D{X: bx, Y: by}}}
+}
+
+// closedTriangle is a material loop that chains to a real face.
+func closedTriangle() ipt.RegionLoop {
+	return ipt.RegionLoop{Edges: []ipt.RegionEdge{
+		line(0, 0, 1, 0), line(1, 0, 0, 1), line(0, 1, 0, 0),
+	}}
+}
+
+// openSliver is a two-edge chain sharing one vertex whose other ends are far apart: it bounds no
+// closed area, the shape TapePath's tape-guide patch carries alongside its real ribbon faces.
+func openSliver(cut bool) ipt.RegionLoop {
+	return ipt.RegionLoop{Cut: cut, Edges: []ipt.RegionEdge{
+		line(0, 0, 0.001, 0.001), line(0, 0, 5, 5),
+	}}
+}
+
+// TestRegionBoundariesDropsOpenMaterialSliver: a region of one real face plus an open material
+// sliver reconstructs the face and drops the sliver (an open curve bounds no material), rather than
+// failing the whole region to the curve-set fallback.
+func TestRegionBoundariesDropsOpenMaterialSliver(t *testing.T) {
+	outers, holes, ok := regionBoundaries([]ipt.RegionLoop{closedTriangle(), openSliver(false)})
+	if !ok {
+		t.Fatalf("regionBoundaries declined; want it to keep the closed face and drop the open sliver")
+	}
+	if len(outers) != 1 {
+		t.Errorf("outers = %d, want 1 (the triangle; the open sliver bounds no face)", len(outers))
+	}
+	if len(holes) != 0 {
+		t.Errorf("holes = %d, want 0", len(holes))
+	}
+}
+
+// TestRegionBoundariesDeclinesOnOpenCut: an unreadable CUT loop is NOT dropped — silently losing a
+// hole would over-fill the face — so the region declines and keeps the safer fallback.
+func TestRegionBoundariesDeclinesOnOpenCut(t *testing.T) {
+	if _, _, ok := regionBoundaries([]ipt.RegionLoop{closedTriangle(), openSliver(true)}); ok {
+		t.Errorf("regionBoundaries accepted a region with an unreadable cut loop; want decline")
+	}
+}

--- a/model/exchange/translators/inventor/translate/revolve_axis_test.go
+++ b/model/exchange/translators/inventor/translate/revolve_axis_test.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package translate
+
+import (
+	"testing"
+
+	"oblikovati.org/model/exchange/translators/inventor/ipt"
+)
+
+func ln(ax, ay, bx, by float64) ipt.Line {
+	return ipt.Line{A: ipt.Point2D{X: ax, Y: ay}, B: ipt.Point2D{X: bx, Y: by}}
+}
+
+// TestAxisAlignedLineClassifies: a vertical and a horizontal line are both valid centrelines; an
+// oblique one is not.
+func TestAxisAlignedLineClassifies(t *testing.T) {
+	if !verticalLine(ln(1, 0, 1, 5)) || !axisAlignedLine(ln(1, 0, 1, 5)) {
+		t.Error("a constant-X line is vertical and axis-aligned")
+	}
+	if !horizontalLine(ln(0, 2, 9, 2)) || !axisAlignedLine(ln(0, 2, 9, 2)) {
+		t.Error("a constant-Y line is horizontal and axis-aligned")
+	}
+	if axisAlignedLine(ln(0, 0, 3, 5)) {
+		t.Error("an oblique line is not axis-aligned")
+	}
+}
+
+// TestProfileOneSideOfHorizontalAxis: a profile entirely above a horizontal centreline is one-sided;
+// one straddling it is not — measured across Y for a horizontal axis.
+func TestProfileOneSideOfHorizontalAxis(t *testing.T) {
+	// axis at index 0 runs along y=0; profile lines sit at y>0.
+	above := []ipt.Line{ln(0, 0, -1.8, 0), ln(-1.8, 0.9, 0, 0.9), ln(0, 0.9, 0, 1.3)}
+	if !profileOneSideOfAxis(above, 0) {
+		t.Error("a profile wholly above a y=0 axis should be one-sided")
+	}
+	straddle := []ipt.Line{ln(0, 0, -1.8, 0), ln(-1.8, -0.5, 0, 0.9)}
+	if profileOneSideOfAxis(straddle, 0) {
+		t.Error("a profile crossing the y=0 axis is not one-sided")
+	}
+}

--- a/model/exchange/translators/inventor/translate/revolve_graph_test.go
+++ b/model/exchange/translators/inventor/translate/revolve_graph_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package translate
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/model/analysis"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/contentset"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/persistence"
+)
+
+// TestRevolveGraphFallbackBuildsEncoderWheel guards the revolve graph-sketch fallback: EncoderWheel's
+// 13-line profile is SPLIT by incidence into three isolated single-line sketches, so no revolve binds
+// and the part fell back to its non-manifold display mesh (SURFACE, 3520 mm3 = 1.97x — an open-shell
+// artifact). The intact node graph keeps the profile whole with a vertical in-profile centreline, so
+// the revolve now builds parametrically: a solid ~1785 mm3 (Inventor's volume) with the revolve
+// feature preserved. Corpus-gated (no generated fixture reproduces the incidence split); point
+// IPT_CORPUS at the ReelToReel Mechanical directory to enable.
+func TestRevolveGraphFallbackBuildsEncoderWheel(t *testing.T) {
+	dir := os.Getenv("IPT_CORPUS")
+	if dir == "" {
+		dir = `P:\ReelToReel\Mechanical`
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "EncoderWheel.ipt"))
+	if err != nil {
+		t.Skipf("corpus part not available (%v); set IPT_CORPUS", err)
+	}
+	out := filepath.Join(t.TempDir(), "wheel.opd")
+	if _, err := FromInventor(data, out); err != nil {
+		t.Fatalf("FromInventor: %v", err)
+	}
+	ws := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
+	reopened, err := ws.Open(out, true)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	def := reopened.Content().(*compdef.PartComponentDefinition)
+	if def.Features().Count() == 0 {
+		t.Fatal("no features — revolve not rebuilt parametrically (fell back to mesh)")
+	}
+	bodies := def.SurfaceBodies().All()
+	if len(bodies) != 1 || !bodies[0].IsSolid() {
+		t.Fatalf("want 1 solid body, got %d (solid=%v) — the graph revolve did not close", len(bodies), len(bodies) == 1 && bodies[0].IsSolid())
+	}
+	mp := analysis.MassPropertiesOf(bodies, 1, types.MassPropertiesLow)
+	const oracle = 1785.0 // Inventor STL volume, mm^3
+	if math.Abs(mp.VolumeMm3-oracle) > 0.1*oracle {
+		t.Errorf("revolved volume = %.0f mm^3, want ~%.0f (within 10%%)", mp.VolumeMm3, oracle)
+	}
+}

--- a/model/exchange/translators/inventor/translate/revolve_notch_test.go
+++ b/model/exchange/translators/inventor/translate/revolve_notch_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package translate
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/model/analysis"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/contentset"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/persistence"
+)
+
+// TestRevolveKernelFallbackBuildsTorquimeterWheel guards the kernel revolve fallback: TorquimeterWheel's
+// profile has a notch whose mouth points land on the INTERIOR of a through-edge (a T-junction), so the
+// ipt line-ring gate (isClosedRing, a head-to-tail walk) can't close it and the part fell back to its
+// non-manifold mesh (SURFACE 1092 mm3 = 1.98x). The kernel arranges that profile correctly (splitting
+// the through-edge at the notch), so revolving the kernel's own profile builds the solid: ~552 mm3
+// (Inventor). Corpus-gated (no generated fixture reproduces the notch T-junction); set IPT_CORPUS.
+func TestRevolveKernelFallbackBuildsTorquimeterWheel(t *testing.T) {
+	dir := os.Getenv("IPT_CORPUS")
+	if dir == "" {
+		dir = `P:\ReelToReel\Mechanical`
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "TorquimeterWheel.ipt"))
+	if err != nil {
+		t.Skipf("corpus part not available (%v); set IPT_CORPUS", err)
+	}
+	out := filepath.Join(t.TempDir(), "tw.opd")
+	if _, err := FromInventor(data, out); err != nil {
+		t.Fatalf("FromInventor: %v", err)
+	}
+	ws := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
+	reopened, err := ws.Open(out, true)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	def := reopened.Content().(*compdef.PartComponentDefinition)
+	if def.Features().Count() == 0 {
+		t.Fatal("no features — revolve not rebuilt (fell back to mesh)")
+	}
+	bodies := def.SurfaceBodies().All()
+	if len(bodies) != 1 || !bodies[0].IsSolid() {
+		t.Fatalf("want 1 solid body, got %d (solid=%v)", len(bodies), len(bodies) == 1 && bodies[0].IsSolid())
+	}
+	mp := analysis.MassPropertiesOf(bodies, 1, types.MassPropertiesLow)
+	const oracle = 552.0 // Inventor STL volume, mm^3
+	if math.Abs(mp.VolumeMm3-oracle) > 0.1*oracle {
+		t.Errorf("revolved volume = %.0f mm^3, want ~%.0f (within 10%%)", mp.VolumeMm3, oracle)
+	}
+}

--- a/model/exchange/translators/inventor/translate/revolve_stepped_test.go
+++ b/model/exchange/translators/inventor/translate/revolve_stepped_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package translate
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/model/analysis"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/contentset"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/persistence"
+)
+
+// TestRevolveConstructionAxisBuildsPressureRoller guards two extensions of the kernel revolve
+// fallback. PressureRoller's centreline is a vertical CONSTRUCTION line at x=0 (not the isolated line
+// RevolveAxisLine keys on — a real internal edge at x=0.8 also reads as isolated, making it
+// ambiguous), and that internal edge splits the profile into TWO closed regions (an annulus 0.25-0.8
+// and 0.8-1.3). revolveAxisIndex falls back to the lone vertical construction line, and the fallback
+// revolves BOTH closed profiles and unions them, yielding the full roller ~4600 mm3 (Inventor). It
+// built a non-manifold mesh before (SURFACE 9106 = 1.98x). Corpus-gated; set IPT_CORPUS.
+func TestRevolveConstructionAxisBuildsPressureRoller(t *testing.T) {
+	dir := os.Getenv("IPT_CORPUS")
+	if dir == "" {
+		dir = `P:\ReelToReel\Mechanical`
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "PressureRoller.ipt"))
+	if err != nil {
+		t.Skipf("corpus part not available (%v); set IPT_CORPUS", err)
+	}
+	out := filepath.Join(t.TempDir(), "pr.opd")
+	if _, err := FromInventor(data, out); err != nil {
+		t.Fatalf("FromInventor: %v", err)
+	}
+	ws := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
+	reopened, err := ws.Open(out, true)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	def := reopened.Content().(*compdef.PartComponentDefinition)
+	bodies := def.SurfaceBodies().All()
+	if len(bodies) != 1 || !bodies[0].IsSolid() {
+		t.Fatalf("want 1 solid body, got %d (solid=%v)", len(bodies), len(bodies) == 1 && bodies[0].IsSolid())
+	}
+	mp := analysis.MassPropertiesOf(bodies, 1, types.MassPropertiesLow)
+	const oracle = 4600.0 // Inventor STL volume, mm^3
+	if math.Abs(mp.VolumeMm3-oracle) > 0.1*oracle {
+		t.Errorf("revolved volume = %.0f mm^3, want ~%.0f (within 10%%)", mp.VolumeMm3, oracle)
+	}
+}

--- a/model/exchange/translators/inventor/translate/revolvecuts.go
+++ b/model/exchange/translators/inventor/translate/revolvecuts.go
@@ -135,11 +135,6 @@ func buildRevolveDispatch(def *compdef.PartComponentDefinition, d *ipt.Document,
 // The whole attempt is speculative and self-contained: nothing here reaches a part whose primary
 // revolve already produced a good solid.
 func graphRevolveWithCuts(def *compdef.PartComponentDefinition, d *ipt.Document, seg []byte) (bool, []string) {
-	graph := ipt.GraphSketches(d)
-	if !graphRevolveCandidate(graph) {
-		return false, nil
-	}
-	clearFeaturesAndSketches(def) // drop the primary attempt; build fresh from the graph
 	// Revolve the sketch the Revolution feature actually names (ipt.RevolveProfileSketch), not the
 	// first sketch that looks revolvable — the latter mis-picks a cut profile on a machined part and
 	// builds garbage. -1 (no reference decoded) keeps the scan.
@@ -153,6 +148,27 @@ func graphRevolveWithCuts(def *compdef.PartComponentDefinition, d *ipt.Document,
 	if ox, oy, dx, dy, ok := ipt.RevolveAxis2D(d); ok {
 		axis = revolveAxisRef{ox: ox, oy: oy, dx: dx, dy: dy, ok: true}
 	}
+	hole, hasHole := ipt.DecodeHole(d)
+	solid, notes := buildGraphRevolveCuts(def, seg, ipt.GraphSketches(d), preferred, axis,
+		ipt.DecodeExtrudes(d), ipt.ExtrudeProfiles(d), ipt.ExtrudeRegions(d), hole, hasHole)
+	// Commit only a solid that also fits Inventor's stored tessellation; else leave the def cleared for
+	// the caller to restore the primary state.
+	if solid && bodyFitsMesh(def, d) {
+		return true, notes
+	}
+	return false, notes
+}
+
+// buildGraphRevolveCuts is graphRevolveWithCuts' decode-free core: given the node-graph sketches, the
+// named profile index, the decoded axis, and the decoded extrudes/regions/hole, it revolves the base
+// and cuts the milled features over it, returning whether the result closed to a solid. Split out so
+// the whole orchestration can be unit-tested with synthetic sketches (the document wrapper adds the
+// mesh-fit gate).
+func buildGraphRevolveCuts(def *compdef.PartComponentDefinition, seg []byte, graph []ipt.Sketch, preferred int, axis revolveAxisRef, extrudes []ipt.Extrude, profiles []int, regions [][]ipt.RegionLoop, hole ipt.Hole, hasHole bool) (bool, []string) {
+	if !graphRevolveCandidate(graph) {
+		return false, nil
+	}
+	clearFeaturesAndSketches(def) // drop the primary attempt; build fresh from the graph
 	// A full circle in the profile that crosses the axis is an impossible revolve profile — a
 	// mis-flagged wall arc (KnobBottom's r20.3 dome edge). Rebuild it as the arc its endpoints
 	// describe before emitting, so the profile closes instead of revolving a giant circle into a blob.
@@ -168,26 +184,16 @@ func graphRevolveWithCuts(def *compdef.PartComponentDefinition, d *ipt.Document,
 	if !firstBodyIsSolid(def) {
 		return false, nil // the revolve base didn't close — not a machined-holder we can rebuild
 	}
-	notes := applyRevolveCuts(def, d, placed, emitted)
+	notes := applyExtrudeCutsAndHole(def, extrudes, profiles, regions, hole, hasHole, placed, emitted)
 	def.Recompute()
-	if firstBodyIsSolid(def) && bodyFitsMesh(def, d) {
-		return true, notes
-	}
-	return false, notes
+	return firstBodyIsSolid(def), notes
 }
 
-// applyRevolveCuts applies the part's cut/join extrudes and its drilled hole over the revolve base
-// already built into def. It mirrors buildExtrudeFeatures' per-extrude region match, but consumes an
-// existing base (the revolve) instead of requiring a New-Body extrude to start one. A stage that
-// can't resolve its profile or region is skipped with a note; whatever cuts do bind stay.
-func applyRevolveCuts(def *compdef.PartComponentDefinition, d *ipt.Document, placed []placedSketch, emitted []emittedSketch) []string {
-	hole, hasHole := ipt.DecodeHole(d)
-	return applyExtrudeCutsAndHole(def, ipt.DecodeExtrudes(d), ipt.ExtrudeProfiles(d), ipt.ExtrudeRegions(d), hole, hasHole, placed, emitted)
-}
-
-// applyExtrudeCutsAndHole is applyRevolveCuts' decode-free core: given the already-decoded extrudes,
-// profile indices, regions, and hole, it cuts each over the base and drills the hole. Split out so the
-// cut/retry logic can be unit-tested with synthetic inputs (applyRevolveCuts wires in the document).
+// applyExtrudeCutsAndHole applies the part's cut/join extrudes and its drilled hole over the revolve
+// base already built into def, from already-decoded data. It mirrors buildExtrudeFeatures' per-extrude
+// region match, but consumes an existing base (the revolve) instead of requiring a New-Body extrude to
+// start one. A stage that can't resolve its profile or region is skipped with a note; whatever cuts do
+// bind stay. Decode-free so the cut/retry logic can be unit-tested with synthetic inputs.
 func applyExtrudeCutsAndHole(def *compdef.PartComponentDefinition, extrudes []ipt.Extrude, profiles []int, regions [][]ipt.RegionLoop, hole ipt.Hole, hasHole bool, placed []placedSketch, emitted []emittedSketch) []string {
 	var notes []string
 	for i, ex := range extrudes {

--- a/model/exchange/translators/inventor/translate/revolvecuts.go
+++ b/model/exchange/translators/inventor/translate/revolvecuts.go
@@ -145,8 +145,23 @@ func applyRevolveCuts(def *compdef.PartComponentDefinition, d *ipt.Document, pla
 			notes = append(notes, fmt.Sprintf("revolve cut %d: could not match its region (%d loops) — skipped", i, len(region)))
 			continue
 		}
-		feature.NewExtrudeFeatures(def.Features()).AddExtrude(
+		f := feature.NewExtrudeFeatures(def.Features()).AddExtrude(
 			emitted[p].sk, idx, operationOf(ex.Operation), extentOf(ex), 0)
+		// A cut on a machined revolve can OPEN the body: its end face lands coincident with the turned
+		// base's stepped top (a blind cut) or it runs one-sided the wrong way (a directional
+		// through-all), a boolean fault the kernel leaves as a non-manifold seam. A SYMMETRIC through
+		// cut removes the full column both ways and avoids it. Retry a cut that opened the body that
+		// way; a wrong retry (a real blind pocket) is still caught by the final solid + mesh-fit gate.
+		// Scoped to the revolve-cuts path, so no plain extrude part is touched.
+		if ex.Operation == ipt.OpCut {
+			def.Recompute()
+			if !firstBodyIsSolid(def) {
+				def.Features().Remove(f.ID())
+				feature.NewExtrudeFeatures(def.Features()).AddExtrude(
+					emitted[p].sk, idx, operationOf(ex.Operation),
+					feature.Extent{Type: feature.ThroughAllExtent, Direction: feature.SymmetricDir}, 0)
+			}
+		}
 	}
 	if h, ok := ipt.DecodeHole(d); ok && len(placed) > 0 && len(emitted) > 0 && emitted[0].sk != nil {
 		cx, cy := profileCentroid(placed[0].geom)

--- a/model/exchange/translators/inventor/translate/revolvecuts.go
+++ b/model/exchange/translators/inventor/translate/revolvecuts.go
@@ -181,10 +181,15 @@ func graphRevolveWithCuts(def *compdef.PartComponentDefinition, d *ipt.Document,
 // existing base (the revolve) instead of requiring a New-Body extrude to start one. A stage that
 // can't resolve its profile or region is skipped with a note; whatever cuts do bind stay.
 func applyRevolveCuts(def *compdef.PartComponentDefinition, d *ipt.Document, placed []placedSketch, emitted []emittedSketch) []string {
+	hole, hasHole := ipt.DecodeHole(d)
+	return applyExtrudeCutsAndHole(def, ipt.DecodeExtrudes(d), ipt.ExtrudeProfiles(d), ipt.ExtrudeRegions(d), hole, hasHole, placed, emitted)
+}
+
+// applyExtrudeCutsAndHole is applyRevolveCuts' decode-free core: given the already-decoded extrudes,
+// profile indices, regions, and hole, it cuts each over the base and drills the hole. Split out so the
+// cut/retry logic can be unit-tested with synthetic inputs (applyRevolveCuts wires in the document).
+func applyExtrudeCutsAndHole(def *compdef.PartComponentDefinition, extrudes []ipt.Extrude, profiles []int, regions [][]ipt.RegionLoop, hole ipt.Hole, hasHole bool, placed []placedSketch, emitted []emittedSketch) []string {
 	var notes []string
-	extrudes := ipt.DecodeExtrudes(d)
-	profiles := ipt.ExtrudeProfiles(d)
-	regions := ipt.ExtrudeRegions(d)
 	for i, ex := range extrudes {
 		p := profileIndex(profiles, i)
 		if p < 0 || p >= len(emitted) || emitted[p].sk == nil {
@@ -215,9 +220,9 @@ func applyRevolveCuts(def *compdef.PartComponentDefinition, d *ipt.Document, pla
 			}
 		}
 	}
-	if h, ok := ipt.DecodeHole(d); ok && len(placed) > 0 && len(emitted) > 0 && emitted[0].sk != nil {
+	if hasHole && len(placed) > 0 && len(emitted) > 0 && emitted[0].sk != nil {
 		cx, cy := profileCentroid(placed[0].geom)
-		addHole(def, h, placed[0].plane, cx, cy, 0)
+		addHole(def, hole, placed[0].plane, cx, cy, 0)
 	}
 	return notes
 }

--- a/model/exchange/translators/inventor/translate/revolvecuts.go
+++ b/model/exchange/translators/inventor/translate/revolvecuts.go
@@ -58,7 +58,14 @@ func graphRevolveWithCuts(def *compdef.PartComponentDefinition, d *ipt.Document,
 	clearFeaturesAndSketches(def) // drop the primary attempt; build fresh from the graph
 	placed := placeGraphSketches(graph)
 	emitted := emitSketches(def, placed)
-	if len(tryKernelRevolve(def, seg, placed, emitted)) == 0 {
+	// Revolve the sketch the Revolution feature actually names (ipt.RevolveProfileSketch), not the
+	// first sketch that looks revolvable — the latter mis-picks a cut profile on a machined part and
+	// builds garbage. -1 (no reference decoded) keeps the scan.
+	preferred := -1
+	if pi, ok := ipt.RevolveProfileSketch(d); ok {
+		preferred = pi
+	}
+	if len(tryKernelRevolve(def, seg, placed, emitted, preferred)) == 0 {
 		return false, nil
 	}
 	def.Recompute()

--- a/model/exchange/translators/inventor/translate/revolvecuts.go
+++ b/model/exchange/translators/inventor/translate/revolvecuts.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package translate
+
+import (
+	"fmt"
+
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/exchange/translators/inventor/ipt"
+	"oblikovati.org/model/feature"
+)
+
+// buildRevolveDispatch builds the revolve-based part. The common case — a plain turned shaft — is
+// the incidence/line-set path (buildRevolve), kept verbatim so every currently-solid revolve is
+// untouched. A MACHINED revolve part (a turned base with milled cut extrudes and drilled holes: the
+// ext,rev,hole cluster — SpoolMotorMachinedHolder, CapstonMotorMachinedHolder) needs its cuts
+// applied over the revolve base, and its profile+centreline decoded whole. Only when the primary
+// revolve yields no mesh-fitting solid is that second path tried, so the working set can't regress.
+func buildRevolveDispatch(def *compdef.PartComponentDefinition, d *ipt.Document, seg []byte, placed []placedSketch) (bool, []string) {
+	emitted := emitSketches(def, placed)
+	built, notes := buildRevolve(def, seg, placed, emitted)
+	// buildRevolve adds the feature but does not always recompute (the RevolveProfile success path
+	// leaves that to buildPart); recompute here so firstBodyIsSolid/bodyFitsMesh see the body.
+	def.Recompute()
+	if built && firstBodyIsSolid(def) && bodyFitsMesh(def, d) {
+		emitDroppedCurveSketches(def, d)
+		return true, notes
+	}
+	// The primary revolve gave no gate-passing solid (it didn't build, didn't close, or over-built
+	// past Inventor's tessellation). Rebuild from the node graph — which keeps the profile, its
+	// centreline, and each cut profile as whole sketches where the incidence line set fragments
+	// them — and apply the cut extrudes/holes over the revolve base.
+	if ok, gnotes := graphRevolveWithCuts(def, d, seg); ok {
+		emitDroppedCurveSketches(def, d)
+		return true, gnotes
+	}
+	// Neither path made a solid: restore the primary attempt so the part keeps its decoded sketches
+	// (and any partial body) for buildPart's mesh fallback, exactly as before this dispatch existed.
+	clearFeaturesAndSketches(def)
+	emitted = emitSketches(def, placed)
+	built, notes = buildRevolve(def, seg, placed, emitted)
+	emitDroppedCurveSketches(def, d)
+	return built, notes
+}
+
+// graphRevolveWithCuts rebuilds the part from the node-graph sketches: it revolves the graph's
+// profile about its centreline (the kernel arranges a closed profile the line-ring walk can't —
+// arcs, or a loop closed only along the axis), then cuts the milled extrudes and drills the hole
+// over that base. It commits only when the result closes to a solid that fits the tessellation;
+// otherwise it returns false with the def left cleared for the caller to restore the primary state.
+// The whole attempt is speculative and self-contained: nothing here reaches a part whose primary
+// revolve already produced a good solid.
+func graphRevolveWithCuts(def *compdef.PartComponentDefinition, d *ipt.Document, seg []byte) (bool, []string) {
+	graph := ipt.GraphSketches(d)
+	if !graphRevolveCandidate(graph) {
+		return false, nil
+	}
+	clearFeaturesAndSketches(def) // drop the primary attempt; build fresh from the graph
+	placed := placeGraphSketches(graph)
+	emitted := emitSketches(def, placed)
+	if len(tryKernelRevolve(def, seg, placed, emitted)) == 0 {
+		return false, nil
+	}
+	def.Recompute()
+	if !firstBodyIsSolid(def) {
+		return false, nil // the revolve base didn't close — not a machined-holder we can rebuild
+	}
+	notes := applyRevolveCuts(def, d, placed, emitted)
+	def.Recompute()
+	if firstBodyIsSolid(def) && bodyFitsMesh(def, d) {
+		return true, notes
+	}
+	return false, notes
+}
+
+// applyRevolveCuts applies the part's cut/join extrudes and its drilled hole over the revolve base
+// already built into def. It mirrors buildExtrudeFeatures' per-extrude region match, but consumes an
+// existing base (the revolve) instead of requiring a New-Body extrude to start one. A stage that
+// can't resolve its profile or region is skipped with a note; whatever cuts do bind stay.
+func applyRevolveCuts(def *compdef.PartComponentDefinition, d *ipt.Document, placed []placedSketch, emitted []emittedSketch) []string {
+	var notes []string
+	extrudes := ipt.DecodeExtrudes(d)
+	profiles := ipt.ExtrudeProfiles(d)
+	regions := ipt.ExtrudeRegions(d)
+	for i, ex := range extrudes {
+		p := profileIndex(profiles, i)
+		if p < 0 || p >= len(emitted) || emitted[p].sk == nil {
+			notes = append(notes, fmt.Sprintf("revolve cut %d: no profile sketch resolved — skipped", i))
+			continue
+		}
+		region := extrudeRegionAt(regions, i)
+		idx := regionProfileIndices(emitted[p].sk, region)
+		if len(idx) == 0 {
+			notes = append(notes, fmt.Sprintf("revolve cut %d: could not match its region (%d loops) — skipped", i, len(region)))
+			continue
+		}
+		feature.NewExtrudeFeatures(def.Features()).AddExtrude(
+			emitted[p].sk, idx, operationOf(ex.Operation), extentOf(ex), 0)
+	}
+	if h, ok := ipt.DecodeHole(d); ok && len(placed) > 0 && len(emitted) > 0 && emitted[0].sk != nil {
+		cx, cy := profileCentroid(placed[0].geom)
+		addHole(def, h, placed[0].plane, cx, cy, 0)
+	}
+	return notes
+}
+
+// placeGraphSketches pairs each node-graph sketch with the plane it lives on — the revolve-path
+// equivalent of the placement extractSketches does for the incidence/cluster decode.
+func placeGraphSketches(graph []ipt.Sketch) []placedSketch {
+	out := make([]placedSketch, len(graph))
+	for i := range graph {
+		out[i] = placedSketch{geom: graph[i], plane: sketchPlaneOf(graph[i])}
+	}
+	return out
+}
+
+// bodyFitsMesh reports whether the rebuilt body stays within Inventor's stored tessellation — the
+// non-destructive form of gateBodyAgainstMesh's containment test (it neither drops the body nor
+// reports). No stored tessellation ⇒ no oracle, so it does not block. Used to decide whether the
+// primary revolve is good enough to keep, and whether a graph rebuild is safe to commit.
+func bodyFitsMesh(def *compdef.PartComponentDefinition, d *ipt.Document) bool {
+	mesh, ok := meshExtents(d)
+	if !ok {
+		return true
+	}
+	body, ok := bodyExtents(def)
+	if !ok {
+		return false
+	}
+	_, _, escaped := escapingAxis(body, mesh)
+	return !escaped
+}
+
+// clearFeaturesAndSketches empties the feature tree and the sketch list, returning the definition to
+// its pre-feature state (parameters survive). It lets buildRevolveDispatch abandon one build attempt
+// cleanly and start another from a different sketch source.
+func clearFeaturesAndSketches(def *compdef.PartComponentDefinition) {
+	dropAllFeatures(def)
+	sk := def.Sketches()
+	for sk.Count() > 0 {
+		sk.Remove(sk.Item(sk.Count() - 1).ID())
+	}
+}

--- a/model/exchange/translators/inventor/translate/revolvecuts.go
+++ b/model/exchange/translators/inventor/translate/revolvecuts.go
@@ -48,6 +48,52 @@ func pointOnAxis(p ipt.Point2D, axis revolveAxisRef, n float64) bool {
 	return math.Abs(axis.dx*(p.Y-axis.oy)-axis.dy*(p.X-axis.ox))/n < 1e-3
 }
 
+// reviseAxisCrossingCircles rebuilds, as arcs, the profile's non-construction full circles that CROSS
+// the revolve axis but carry a distinct on-rim endpoint pair BOTH on one side of it. Such a circle
+// can't belong to a real revolve profile (a solid of revolution never crosses its axis), so it is a
+// mis-flagged arc (Inventor left its open-flag clear — see ipt.arcFlag); revolving the full circle
+// makes a huge blob (KnobBottom's r20.3 dome edge → 143M mm³). Scoped to the revolve profile and
+// guarded by the crossing + one-sided test, so a genuine bore (no distinct endpoints, or centred on
+// the axis with straddling ends) is untouched; the built revolve is still gated by solid + mesh-fit.
+func reviseAxisCrossingCircles(s ipt.Sketch, axis revolveAxisRef) ipt.Sketch {
+	if !axis.ok {
+		return s
+	}
+	n := math.Hypot(axis.dx, axis.dy)
+	if n < 1e-9 {
+		return s
+	}
+	var circles []ipt.Circle
+	var cons []bool
+	for i, c := range s.Circles {
+		isCons := s.CircleIsConstruction(i)
+		if !isCons && c.ArcEndsOK && circleCrossesAxis(c, axis, n) && sameSideOfAxis(c.ArcStart, c.ArcEnd, axis) {
+			s.Arcs = append(s.Arcs, ipt.Arc{Center: c.Center, Radius: c.Radius, Start: c.ArcStart, End: c.ArcEnd})
+			s.ArcConstruction = append(s.ArcConstruction, false)
+			continue
+		}
+		circles = append(circles, c)
+		cons = append(cons, isCons)
+	}
+	s.Circles, s.CircleConstruction = circles, cons
+	return s
+}
+
+// circleCrossesAxis reports whether the full circle intersects the axis line — its centre is closer
+// to the axis than its radius.
+func circleCrossesAxis(c ipt.Circle, axis revolveAxisRef, n float64) bool {
+	d := math.Abs(axis.dx*(c.Center.Y-axis.oy)-axis.dy*(c.Center.X-axis.ox)) / n
+	return d < c.Radius-1e-6
+}
+
+// sameSideOfAxis reports whether two points lie on the same side of the axis line (the signed
+// perpendicular offsets share a sign, or one is on the axis) — a real arc's ends never straddle it.
+func sameSideOfAxis(p, q ipt.Point2D, axis revolveAxisRef) bool {
+	sp := axis.dx*(p.Y-axis.oy) - axis.dy*(p.X-axis.ox)
+	sq := axis.dx*(q.Y-axis.oy) - axis.dy*(q.X-axis.ox)
+	return sp*sq >= 0
+}
+
 // buildRevolveDispatch builds the revolve-based part. The common case — a plain turned shaft — is
 // the incidence/line-set path (buildRevolve), kept verbatim so every currently-solid revolve is
 // untouched. A MACHINED revolve part (a turned base with milled cut extrudes and drilled holes: the
@@ -94,8 +140,6 @@ func graphRevolveWithCuts(def *compdef.PartComponentDefinition, d *ipt.Document,
 		return false, nil
 	}
 	clearFeaturesAndSketches(def) // drop the primary attempt; build fresh from the graph
-	placed := placeGraphSketches(graph)
-	emitted := emitSketches(def, placed)
 	// Revolve the sketch the Revolution feature actually names (ipt.RevolveProfileSketch), not the
 	// first sketch that looks revolvable — the latter mis-picks a cut profile on a machined part and
 	// builds garbage. -1 (no reference decoded) keeps the scan.
@@ -109,6 +153,14 @@ func graphRevolveWithCuts(def *compdef.PartComponentDefinition, d *ipt.Document,
 	if ox, oy, dx, dy, ok := ipt.RevolveAxis2D(d); ok {
 		axis = revolveAxisRef{ox: ox, oy: oy, dx: dx, dy: dy, ok: true}
 	}
+	// A full circle in the profile that crosses the axis is an impossible revolve profile — a
+	// mis-flagged wall arc (KnobBottom's r20.3 dome edge). Rebuild it as the arc its endpoints
+	// describe before emitting, so the profile closes instead of revolving a giant circle into a blob.
+	if preferred >= 0 && preferred < len(graph) {
+		graph[preferred] = reviseAxisCrossingCircles(graph[preferred], axis)
+	}
+	placed := placeGraphSketches(graph)
+	emitted := emitSketches(def, placed)
 	if len(tryKernelRevolve(def, seg, placed, emitted, preferred, axis)) == 0 {
 		return false, nil
 	}

--- a/model/exchange/translators/inventor/translate/revolvecuts.go
+++ b/model/exchange/translators/inventor/translate/revolvecuts.go
@@ -4,11 +4,49 @@ package translate
 
 import (
 	"fmt"
+	"math"
 
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/exchange/translators/inventor/ipt"
 	"oblikovati.org/model/feature"
 )
+
+// revolveAxisRef is the revolve's centreline decoded from the feature's own axis reference
+// (ipt.RevolveAxis2D — the SketchLine3D at Revolution property 2), expressed in the profile sketch's
+// 2D coordinates. It is the fallback when the geometric heuristic (revolveAxisIndex) can't name the
+// centreline: an axis that is an ordinary profile EDGE, neither isolated nor construction, is invisible
+// to the heuristic but stated outright by this reference.
+type revolveAxisRef struct {
+	ox, oy, dx, dy float64
+	ok             bool
+}
+
+// axisLineFromReference returns the index of the profile line collinear with the decoded axis — the
+// centreline edge the heuristic missed. It requires exactly one axis-aligned line lying on the axis
+// (both endpoints on the infinite line): more than one is ambiguous, and a non-axis-aligned match is
+// rejected because the downstream one-sided/angle logic only handles vertical and horizontal axes.
+func axisLineFromReference(s ipt.Sketch, axis revolveAxisRef) (int, bool) {
+	n := math.Hypot(axis.dx, axis.dy)
+	if n < 1e-9 {
+		return -1, false
+	}
+	idx, found := -1, 0
+	for i, l := range s.Lines {
+		if !axisAlignedLine(l) {
+			continue
+		}
+		if pointOnAxis(l.A, axis, n) && pointOnAxis(l.B, axis, n) {
+			idx, found = i, found+1
+		}
+	}
+	return idx, found == 1
+}
+
+// pointOnAxis reports whether a sketch point lies on the infinite line through (ox,oy) with direction
+// (dx,dy) — the perpendicular distance is within 10 microns.
+func pointOnAxis(p ipt.Point2D, axis revolveAxisRef, n float64) bool {
+	return math.Abs(axis.dx*(p.Y-axis.oy)-axis.dy*(p.X-axis.ox))/n < 1e-3
+}
 
 // buildRevolveDispatch builds the revolve-based part. The common case — a plain turned shaft — is
 // the incidence/line-set path (buildRevolve), kept verbatim so every currently-solid revolve is
@@ -65,7 +103,13 @@ func graphRevolveWithCuts(def *compdef.PartComponentDefinition, d *ipt.Document,
 	if pi, ok := ipt.RevolveProfileSketch(d); ok {
 		preferred = pi
 	}
-	if len(tryKernelRevolve(def, seg, placed, emitted, preferred)) == 0 {
+	// The feature's axis reference is the fallback centreline for a profile whose axis is an ordinary
+	// edge the heuristic can't spot (CapstainMotorCap turns about its y=0 top edge).
+	var axis revolveAxisRef
+	if ox, oy, dx, dy, ok := ipt.RevolveAxis2D(d); ok {
+		axis = revolveAxisRef{ox: ox, oy: oy, dx: dx, dy: dy, ok: true}
+	}
+	if len(tryKernelRevolve(def, seg, placed, emitted, preferred, axis)) == 0 {
 		return false, nil
 	}
 	def.Recompute()

--- a/model/exchange/translators/inventor/translate/revolvecuts_test.go
+++ b/model/exchange/translators/inventor/translate/revolvecuts_test.go
@@ -67,30 +67,56 @@ func TestTryKernelRevolveBuildsSolidFromSyntheticProfile(t *testing.T) {
 	}
 }
 
-// TestApplyExtrudeCutsAndHoleCutsTheBase drives the cut path over a synthetic revolve base: a Ø1
-// bore cut through a cylinder, with the region named as a lone full circle. No corpus part.
-func TestApplyExtrudeCutsAndHoleCutsTheBase(t *testing.T) {
+// TestBuildGraphRevolveCutsBuildsBaseAndCuts drives the whole revolve-with-cuts orchestration
+// (graphRevolveCandidate → revolve base → applyExtrudeCutsAndHole with the through-all retry) on
+// synthetic graph sketches, with no corpus part: an annular base with a Ø0.6 bore cut, region named
+// as a lone full circle.
+func TestBuildGraphRevolveCutsBuildsBaseAndCuts(t *testing.T) {
 	def := newPart(t)
-	// Base annular tube (rectangle x∈[1,2], h=3 revolved about x=0); a bore profile is sketch #1.
-	base := rectAboutAxis(1, 2, 3)
-	bore := ipt.Sketch{Circles: []ipt.Circle{{Center: ipt.Point2D{X: 1.5}, Radius: 0.3}}, Resolved: true}
-	placed := placeGraphSketches([]ipt.Sketch{base, bore})
-	emitted := emitSketches(def, placed)
-	if ids := tryKernelRevolve(def, nil, placed[:1], emitted[:1], 0, revolveAxisRef{}); len(ids) == 0 {
-		t.Fatal("base revolve built nothing")
+	graph := []ipt.Sketch{
+		rectAboutAxis(1, 2, 3), // profile sketch #0 → annular tube base
+		{Circles: []ipt.Circle{{Center: ipt.Point2D{X: 1.5}, Radius: 0.3}}, Resolved: true}, // bore sketch #1
 	}
-	def.Recompute()
-	if !firstBodyIsSolid(def) {
-		t.Fatal("base did not close to a solid")
-	}
-	// Cut the bore (region named as a lone full circle) — exercises the region match + AddExtrude +
-	// the through-all retry; the through-all retry guarantees the body stays closed.
 	extrudes := []ipt.Extrude{{Operation: ipt.OpCut, ThroughAll: true}}
+	profiles := []int{1}
 	regions := [][]ipt.RegionLoop{{{Edges: []ipt.RegionEdge{{Kind: ipt.EdgeCircle, Circle: ipt.Circle{Center: ipt.Point2D{X: 1.5}, Radius: 0.3}}}}}}
-	notes := applyExtrudeCutsAndHole(def, extrudes, []int{1}, regions, ipt.Hole{}, false, placed, emitted)
-	def.Recompute()
+	solid, notes := buildGraphRevolveCuts(def, nil, graph, 0, revolveAxisRef{}, extrudes, profiles, regions, ipt.Hole{}, false)
+	if !solid {
+		t.Fatalf("expected a solid turned+milled body; notes=%v", notes)
+	}
 	if !firstBodyIsSolid(def) {
-		t.Fatalf("cut left an open body; notes=%v", notes)
+		t.Error("firstBodyIsSolid disagrees with the returned solid flag")
+	}
+}
+
+// TestRevolveCutBranches covers the remaining revolve/cut branches: the preferred=-1 SCAN path, the
+// axis-reference fallback (a profile turning about an ordinary y=0 edge the heuristic can't spot), and
+// applyExtrudeCutsAndHole's skip note for an unresolvable profile.
+func TestRevolveCutBranches(t *testing.T) {
+	// Scan path: preferred=-1 finds the revolve by scanning the emitted sketches.
+	def := newPart(t)
+	placed := placeGraphSketches([]ipt.Sketch{rectAboutAxis(1, 2, 3)})
+	emitted := emitSketches(def, placed)
+	if len(tryKernelRevolve(def, nil, placed, emitted, -1, revolveAxisRef{})) == 0 {
+		t.Error("scan path built no revolve")
+	}
+
+	// Axis-reference fallback: a rectangle below y=0 with its top edge ON y=0 — no isolated/construction
+	// centreline, so revolveAxisIndex declines and the decoded horizontal axis supplies the edge.
+	def2 := newPart(t)
+	edge := ipt.Sketch{Lines: []ipt.Line{
+		ln(-2, 0, -1, 0), ln(-1, 0, -1, -3), ln(-1, -3, -2, -3), ln(-2, -3, -2, 0),
+	}, Resolved: true}
+	pl2 := placeGraphSketches([]ipt.Sketch{edge})
+	em2 := emitSketches(def2, pl2)
+	if len(tryKernelRevolve(def2, nil, pl2, em2, 0, revolveAxisRef{ox: 0, oy: 0, dx: -1, dy: 0, ok: true})) == 0 {
+		t.Error("axis-reference revolve built nothing")
+	}
+
+	// applyExtrudeCutsAndHole skip note: an extrude whose profile index is out of range.
+	notes := applyExtrudeCutsAndHole(newPart(t), []ipt.Extrude{{Operation: ipt.OpCut}}, []int{9}, nil, ipt.Hole{}, false, pl2, em2)
+	if len(notes) == 0 {
+		t.Error("expected a skip note for an unresolvable profile")
 	}
 }
 

--- a/model/exchange/translators/inventor/translate/revolvecuts_test.go
+++ b/model/exchange/translators/inventor/translate/revolvecuts_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package translate
+
+import (
+	"testing"
+
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/contentset"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/model/exchange/translators/inventor/ipt"
+	"oblikovati.org/model/sketch"
+	"oblikovati.org/persistence"
+)
+
+// TestPlaceGraphSketchesPairsEachWithAPlane: every graph sketch comes back paired with a plane and
+// its geometry preserved; a sketch stating no readable placement lands on XY (sketchPlaneOf's
+// fallback), never dropped.
+func TestPlaceGraphSketchesPairsEachWithAPlane(t *testing.T) {
+	graph := []ipt.Sketch{
+		{Lines: []ipt.Line{ln(0, 0, 0, 5)}}, // no plane → XY fallback
+		{Circles: []ipt.Circle{{Center: ipt.Point2D{}, Radius: 1}}},
+	}
+	placed := placeGraphSketches(graph)
+	if len(placed) != len(graph) {
+		t.Fatalf("placed %d sketches, want %d", len(placed), len(graph))
+	}
+	if len(placed[0].geom.Lines) != 1 || len(placed[1].geom.Circles) != 1 {
+		t.Error("placeGraphSketches must carry each sketch's geometry through unchanged")
+	}
+	if n := placed[0].plane.Normal().AsVector(); n.Z < 0.999 {
+		t.Errorf("a placement-less sketch should fall back to XY (normal +Z), got normal.Z=%v", n.Z)
+	}
+}
+
+// TestClearFeaturesAndSketchesEmptiesBoth: after emitting a sketch, clearFeaturesAndSketches returns
+// the definition to zero sketches and zero features — what buildRevolveDispatch relies on to abandon
+// one build attempt and start another from a different sketch source.
+func TestClearFeaturesAndSketchesEmptiesBoth(t *testing.T) {
+	ws := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
+	document, err := compdef.AddPart(ws, "clear.opd", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	def := document.Content().(*compdef.PartComponentDefinition)
+	emitSketchOn(def, ipt.Sketch{Lines: []ipt.Line{ln(0, 0, 2, 0), ln(2, 0, 2, 2)}}, sketch.XYPlane())
+	if def.Sketches().Count() == 0 {
+		t.Fatal("precondition: expected a sketch to have been emitted")
+	}
+	clearFeaturesAndSketches(def)
+	if def.Sketches().Count() != 0 || def.Features().Count() != 0 {
+		t.Errorf("after clear: sketches=%d features=%d, want 0/0", def.Sketches().Count(), def.Features().Count())
+	}
+}

--- a/model/exchange/translators/inventor/translate/revolvecuts_test.go
+++ b/model/exchange/translators/inventor/translate/revolvecuts_test.go
@@ -89,6 +89,40 @@ func TestBuildGraphRevolveCutsBuildsBaseAndCuts(t *testing.T) {
 	}
 }
 
+// TestGraphRevolveWithCutsWrapperOnFixture drives the document wrapper (decode profile/axis/extrudes
+// → build core → mesh-fit gate) and bodyFitsMesh on the generated 16_revolve fixture — a CI-available
+// revolve part, so the document-bound glue runs in CI without a corpus.
+func TestGraphRevolveWithCutsWrapperOnFixture(t *testing.T) {
+	d, err := ipt.Open(readCorpus(t, "16_revolve.ipt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	seg, _ := d.Segment("PmDCSegment")
+	def := newPart(t)
+	ok, _ := graphRevolveWithCuts(def, d, seg)
+	if !ok || !firstBodyIsSolid(def) {
+		t.Fatalf("graph revolve wrapper did not build a solid from 16_revolve (ok=%v)", ok)
+	}
+	if !bodyFitsMesh(def, d) {
+		t.Error("a solid should fit a fixture that stores no tessellation")
+	}
+}
+
+// TestBuildRevolveDispatchGraphFallback covers buildRevolveDispatch's graph-fallback branch: with no
+// primary sketches the incidence revolve makes no solid, so it rebuilds from the fixture's node graph.
+func TestBuildRevolveDispatchGraphFallback(t *testing.T) {
+	d, err := ipt.Open(readCorpus(t, "16_revolve.ipt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	seg, _ := d.Segment("PmDCSegment")
+	def := newPart(t)
+	ok, _ := buildRevolveDispatch(def, d, seg, nil) // nil placed → primary fails → graph fallback
+	if !ok || !firstBodyIsSolid(def) {
+		t.Fatalf("graph fallback did not build a solid (ok=%v)", ok)
+	}
+}
+
 // TestRevolveCutBranches covers the remaining revolve/cut branches: the preferred=-1 SCAN path, the
 // axis-reference fallback (a profile turning about an ordinary y=0 edge the heuristic can't spot), and
 // applyExtrudeCutsAndHole's skip note for an unresolvable profile.

--- a/model/exchange/translators/inventor/translate/revolvecuts_test.go
+++ b/model/exchange/translators/inventor/translate/revolvecuts_test.go
@@ -3,8 +3,11 @@
 package translate
 
 import (
+	"math"
 	"testing"
 
+	"oblikovati.org/api/types"
+	"oblikovati.org/model/analysis"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/contentset"
 	"oblikovati.org/model/doc"
@@ -12,6 +15,84 @@ import (
 	"oblikovati.org/model/sketch"
 	"oblikovati.org/persistence"
 )
+
+// newPart is a test helper: a fresh empty part definition.
+func newPart(t *testing.T) *compdef.PartComponentDefinition {
+	t.Helper()
+	ws := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
+	d, err := compdef.AddPart(ws, "t.opd", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d.Content().(*compdef.PartComponentDefinition)
+}
+
+// rectAboutAxis is a closed rectangle profile at x∈[x0,x1], y∈[0,h] plus an isolated vertical
+// centreline at x=0 — a synthetic revolve profile (its 360° sweep is an annular tube).
+func rectAboutAxis(x0, x1, h float64) ipt.Sketch {
+	return ipt.Sketch{
+		Lines: []ipt.Line{
+			ln(x0, 0, x1, 0), ln(x1, 0, x1, h), ln(x1, h, x0, h), ln(x0, h, x0, 0),
+			ln(0, 0, 0, h+2), // isolated vertical axis
+		},
+		Resolved: true,
+	}
+}
+
+// TestTryKernelRevolveBuildsSolidFromSyntheticProfile drives the whole kernel-revolve chain
+// (revolveAxisIndex → closedProfileIndices → profileOneSideOfAxis → revolveClosedProfiles) on a
+// synthetic profile, with no corpus part: the rectangle x∈[1,2], h=3 revolved about x=0 is an
+// annular tube of volume π(2²−1²)·3 = 9π cm³.
+func TestTryKernelRevolveBuildsSolidFromSyntheticProfile(t *testing.T) {
+	profile := rectAboutAxis(1, 2, 3)
+	if !graphRevolveCandidate([]ipt.Sketch{profile}) {
+		t.Fatal("expected a revolve candidate")
+	}
+	if graphRevolveCandidate([]ipt.Sketch{{Lines: []ipt.Line{ln(0, 0, 1, 0)}, Resolved: true}}) {
+		t.Error("a 1-line sketch is not a revolve candidate")
+	}
+	def := newPart(t)
+	placed := placeGraphSketches([]ipt.Sketch{profile})
+	emitted := emitSketches(def, placed)
+	if ids := tryKernelRevolve(def, nil, placed, emitted, 0, revolveAxisRef{}); len(ids) == 0 {
+		t.Fatal("tryKernelRevolve built nothing")
+	}
+	def.Recompute()
+	if !firstBodyIsSolid(def) {
+		t.Fatal("revolve did not close to a solid")
+	}
+	vol := analysis.MassPropertiesOf(def.SurfaceBodies().All(), 1, types.MassPropertiesHigh).VolumeMm3
+	if want := 9 * math.Pi * 1000; math.Abs(vol-want) > 0.03*want {
+		t.Errorf("tube volume = %.0f mm³, want ~%.0f", vol, want)
+	}
+}
+
+// TestApplyExtrudeCutsAndHoleCutsTheBase drives the cut path over a synthetic revolve base: a Ø1
+// bore cut through a cylinder, with the region named as a lone full circle. No corpus part.
+func TestApplyExtrudeCutsAndHoleCutsTheBase(t *testing.T) {
+	def := newPart(t)
+	// Base annular tube (rectangle x∈[1,2], h=3 revolved about x=0); a bore profile is sketch #1.
+	base := rectAboutAxis(1, 2, 3)
+	bore := ipt.Sketch{Circles: []ipt.Circle{{Center: ipt.Point2D{X: 1.5}, Radius: 0.3}}, Resolved: true}
+	placed := placeGraphSketches([]ipt.Sketch{base, bore})
+	emitted := emitSketches(def, placed)
+	if ids := tryKernelRevolve(def, nil, placed[:1], emitted[:1], 0, revolveAxisRef{}); len(ids) == 0 {
+		t.Fatal("base revolve built nothing")
+	}
+	def.Recompute()
+	if !firstBodyIsSolid(def) {
+		t.Fatal("base did not close to a solid")
+	}
+	// Cut the bore (region named as a lone full circle) — exercises the region match + AddExtrude +
+	// the through-all retry; the through-all retry guarantees the body stays closed.
+	extrudes := []ipt.Extrude{{Operation: ipt.OpCut, ThroughAll: true}}
+	regions := [][]ipt.RegionLoop{{{Edges: []ipt.RegionEdge{{Kind: ipt.EdgeCircle, Circle: ipt.Circle{Center: ipt.Point2D{X: 1.5}, Radius: 0.3}}}}}}
+	notes := applyExtrudeCutsAndHole(def, extrudes, []int{1}, regions, ipt.Hole{}, false, placed, emitted)
+	def.Recompute()
+	if !firstBodyIsSolid(def) {
+		t.Fatalf("cut left an open body; notes=%v", notes)
+	}
+}
 
 // TestPlaceGraphSketchesPairsEachWithAPlane: every graph sketch comes back paired with a plane and
 // its geometry preserved; a sketch stating no readable placement lands on XY (sketchPlaneOf's

--- a/model/exchange/translators/inventor/translate/revolvecuts_test.go
+++ b/model/exchange/translators/inventor/translate/revolvecuts_test.go
@@ -52,3 +52,23 @@ func TestClearFeaturesAndSketchesEmptiesBoth(t *testing.T) {
 		t.Errorf("after clear: sketches=%d features=%d, want 0/0", def.Sketches().Count(), def.Features().Count())
 	}
 }
+
+// TestAxisLineFromReferenceFindsTheEdge: given a decoded horizontal axis on y=0, the collinear
+// profile edge (the y=0 line) is selected, and an off-axis or oblique line is not. This is the
+// centreline the geometric heuristic misses when the axis is an ordinary profile edge.
+func TestAxisLineFromReferenceFindsTheEdge(t *testing.T) {
+	s := ipt.Sketch{Lines: []ipt.Line{
+		ln(0, 0, -1.29, 0), // on y=0 — the axis edge
+		ln(-1.29, 0, -1.29, -4.3),
+		ln(-1.29, -4.3, 0.3, -4.3),
+	}}
+	axis := revolveAxisRef{ox: 0, oy: 0, dx: -1.29, dy: 0, ok: true}
+	i, ok := axisLineFromReference(s, axis)
+	if !ok || i != 0 {
+		t.Fatalf("want the y=0 edge (index 0), got index %d ok=%v", i, ok)
+	}
+	// no line on a y=2 axis
+	if _, ok := axisLineFromReference(s, revolveAxisRef{ox: 0, oy: 2, dx: 1, dy: 0, ok: true}); ok {
+		t.Error("no profile edge lies on y=2, expected no match")
+	}
+}

--- a/model/exchange/translators/inventor/translate/revolvecuts_test.go
+++ b/model/exchange/translators/inventor/translate/revolvecuts_test.go
@@ -72,3 +72,30 @@ func TestAxisLineFromReferenceFindsTheEdge(t *testing.T) {
 		t.Error("no profile edge lies on y=2, expected no match")
 	}
 }
+
+// TestReviseAxisCrossingCirclesRecoversArc: a non-construction full circle that crosses the axis but
+// whose endpoints are one-sided is rebuilt as an arc; a genuine bore (no endpoints) and an
+// axis-straddling pair are left as circles.
+func TestReviseAxisCrossingCirclesRecoversArc(t *testing.T) {
+	s := ipt.Sketch{
+		Circles: []ipt.Circle{
+			{Center: ipt.Point2D{X: 17.779, Y: -0.001}, Radius: 20.329, // crosses x=0, ends one-sided → arc
+				ArcStart: ipt.Point2D{X: -2.466, Y: 1.85}, ArcEnd: ipt.Point2D{X: -2.55, Y: 0}, ArcEndsOK: true},
+			{Center: ipt.Point2D{X: 0, Y: 2.1}, Radius: 0.19}, // genuine bore, no endpoints → circle
+			{Center: ipt.Point2D{}, Radius: 1, // ends straddle x=0 → circle
+				ArcStart: ipt.Point2D{X: 1}, ArcEnd: ipt.Point2D{X: -1}, ArcEndsOK: true},
+		},
+		CircleConstruction: []bool{false, false, false},
+	}
+	axis := revolveAxisRef{ox: 0, oy: 0, dx: 0, dy: 1.7, ok: true}
+	got := reviseAxisCrossingCircles(s, axis)
+	if len(got.Arcs) != 1 {
+		t.Fatalf("want 1 recovered arc, got %d", len(got.Arcs))
+	}
+	if got.Arcs[0].Radius != 20.329 {
+		t.Errorf("recovered arc has radius %.3f, want 20.329", got.Arcs[0].Radius)
+	}
+	if len(got.Circles) != 2 {
+		t.Errorf("want 2 circles left (bore + straddling), got %d", len(got.Circles))
+	}
+}

--- a/model/exchange/translators/inventor/translate/tapepath_region_test.go
+++ b/model/exchange/translators/inventor/translate/tapepath_region_test.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package translate
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/model/analysis"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/contentset"
+	"oblikovati.org/model/doc"
+	"oblikovati.org/persistence"
+)
+
+// TestTapePathContainmentSelectsThinRibbons pins the containment fix for TapePath: its single extrude
+// consumes a 60-cell arrangement whose tape-guide faces are thin ribbons. Two things used to send the
+// whole sketch to the (wrong) curve-set fallback — a degenerate open sliver loop in the patch, and
+// degenerate zero-width cells that could not be given an interior test point. The fallback selected
+// 13 cells (4.83 of 20.49 cm²) and built the extrude at 7.6x its true volume (3069 vs Inventor's
+// 403 mm³). With open material slivers dropped and un-pointable cells skipped (regionpoly.go),
+// containment selects only the thin ribbons (~0.55 cm²), so the body lands near the oracle.
+//
+// Corpus-gated: the geometry only exists in the real part (no generated fixture reproduces the
+// 60-cell thin-ribbon arrangement), so the test skips where the corpus is absent (CI) and runs on a
+// dev checkout of the ReelToReel set. Point IPT_CORPUS at the Mechanical directory to enable it.
+func TestTapePathContainmentSelectsThinRibbons(t *testing.T) {
+	dir := os.Getenv("IPT_CORPUS")
+	if dir == "" {
+		dir = `P:\ReelToReel\Mechanical`
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "TapePath.ipt"))
+	if err != nil {
+		t.Skipf("corpus part not available (%v); set IPT_CORPUS to the ReelToReel Mechanical dir", err)
+	}
+	out := filepath.Join(t.TempDir(), "tapepath.opd")
+	if _, err := FromInventor(data, out); err != nil {
+		t.Fatalf("FromInventor: %v", err)
+	}
+	ws := doc.NewWorkspace(persistence.NewPackageStore(), contentset.Default())
+	reopened, err := ws.Open(out, true)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	def := reopened.Content().(*compdef.PartComponentDefinition)
+	bodies := def.SurfaceBodies().All()
+	if len(bodies) == 0 {
+		t.Fatalf("no body built")
+	}
+	vol := analysis.MassPropertiesOf(bodies, 1, types.MassPropertiesLow).VolumeMm3
+	const oracle = 403.0 // Inventor STL volume, mm³
+	// The old curve-set fallback shipped 3069 mm³ (7.6x). Guard against any regression back toward
+	// that over-build while allowing the ~14% under-fill from the one ribbon whose corner gap exceeds
+	// the containment join tolerance.
+	if vol > 1.5*oracle {
+		t.Errorf("TapePath volume = %.0f mm³, want <= %.0f (the 7.6x curve-set over-build must not return)", vol, 1.5*oracle)
+	}
+	if math.Abs(vol-oracle) > 0.20*oracle {
+		t.Errorf("TapePath volume = %.0f mm³, want within 20%% of Inventor's %.0f", vol, oracle)
+	}
+}

--- a/model/feature/serialize_extrude.go
+++ b/model/feature/serialize_extrude.go
@@ -26,6 +26,13 @@ type ExtrudeData struct {
 	Taper     float64 `yaml:"taper,omitempty"`
 	ToPlane   string  `yaml:"toPlane,omitempty"`   // WorkRef of the to-face / from-to end / distance-from-face target
 	FromPlane string  `yaml:"fromPlane,omitempty"` // WorkRef of the from-to start
+	// ToPlaneFixed / FromPlaneFixed carry the GEOMETRY of a fixed (keyless) to-face/from-face target
+	// — one authored from a plane rather than a datum in the part's work geometry (NewFixedWorkPlane,
+	// which the Inventor to-face translator uses). Such a target has no WorkRef, so without its
+	// geometry a to-face extrude lost its target on reopen (ext.ToPlane went nil, toPlaneSpan errored,
+	// the feature built nothing — ST3215Bracket's walls vanished on save/reopen).
+	ToPlaneFixed   *fixedPlaneData `yaml:"toPlaneFixed,omitempty"`
+	FromPlaneFixed *fixedPlaneData `yaml:"fromPlaneFixed,omitempty"`
 	// ProfilePoints selects the extruded region(s) by an interior seed point (sketch 2-D cm),
 	// one per region, instead of by index. An external author (e.g. the Inventor exporter) cannot
 	// predict the reader's DCEL region ordering, so it names regions by containment. When present
@@ -35,6 +42,43 @@ type ExtrudeData struct {
 	// whole-part fallback rebuilt without the dissolve reopens the same way — otherwise the reopened
 	// recipe would re-run with the dissolve on and regress to the open body again.
 	NoDissolve bool `yaml:"noDissolve,omitempty"`
+}
+
+// fixedPlaneData is a keyless work-plane target's geometry in model cm — origin and the two in-plane
+// axes, enough to rebuild the plane (its normal is X×Y). Serialized for a to-face/from-face target
+// authored as a fixed plane rather than a datum reference.
+type fixedPlaneData struct {
+	Origin [3]float64 `yaml:"origin"`
+	XAxis  [3]float64 `yaml:"xAxis"`
+	YAxis  [3]float64 `yaml:"yAxis"`
+}
+
+// fixedPlaneOf captures a plane's geometry for serialization.
+func fixedPlaneOf(p sketch.Plane) *fixedPlaneData {
+	o, x, y := p.Origin(), p.XAxis().AsVector(), p.YAxis().AsVector()
+	return &fixedPlaneData{
+		Origin: [3]float64{float64(o.X), float64(o.Y), float64(o.Z)},
+		XAxis:  [3]float64{float64(x.X), float64(x.Y), float64(x.Z)},
+		YAxis:  [3]float64{float64(y.X), float64(y.Y), float64(y.Z)},
+	}
+}
+
+// fixedWorkPlane rebuilds a keyless work-plane target from its serialized geometry, or an error when
+// the stored axes are not a valid orthonormal frame.
+func fixedWorkPlane(fp *fixedPlaneData) (*WorkPlane, error) {
+	x, err := math.NewUnitVector3(math.Scalar(fp.XAxis[0]), math.Scalar(fp.XAxis[1]), math.Scalar(fp.XAxis[2]))
+	if err != nil {
+		return nil, fmt.Errorf("to-face target: x axis: %w", err)
+	}
+	y, err := math.NewUnitVector3(math.Scalar(fp.YAxis[0]), math.Scalar(fp.YAxis[1]), math.Scalar(fp.YAxis[2]))
+	if err != nil {
+		return nil, fmt.Errorf("to-face target: y axis: %w", err)
+	}
+	pl, err := sketch.NewPlane(math.P3(math.Scalar(fp.Origin[0]), math.Scalar(fp.Origin[1]), math.Scalar(fp.Origin[2])), x, y)
+	if err != nil {
+		return nil, fmt.Errorf("to-face target: %w", err)
+	}
+	return NewFixedWorkPlane(pl), nil
 }
 
 // extrudeProfiles returns the region indices a payload selects, accepting both the
@@ -80,13 +124,27 @@ func serializeExtrude(def *ExtrudeDefinition, sk SketchIndexer) (*ExtrudeData, e
 		Distance: def.Extent.distance(), Distance2: def.Extent.distance2(), Taper: def.Taper,
 		NoDissolve: def.NoDissolve,
 	}
-	if def.Extent.ToPlane != nil {
-		d.ToPlane = string(def.Extent.ToPlane.Key())
-	}
-	if def.Extent.FromPlane != nil {
-		d.FromPlane = string(def.Extent.FromPlane.Key())
-	}
+	serializeExtentPlanes(def.Extent, d)
 	return d, nil
+}
+
+// serializeExtentPlanes records the extent's to-face/from-face targets: a datum target by its
+// WorkRef key, a fixed (keyless) target by its geometry so it survives reopen (see fixedPlaneData).
+func serializeExtentPlanes(ext Extent, d *ExtrudeData) {
+	if ext.ToPlane != nil {
+		if k := ext.ToPlane.Key(); k != "" {
+			d.ToPlane = string(k)
+		} else {
+			d.ToPlaneFixed = fixedPlaneOf(ext.ToPlane.Plane())
+		}
+	}
+	if ext.FromPlane != nil {
+		if k := ext.FromPlane.Key(); k != "" {
+			d.FromPlane = string(k)
+		} else {
+			d.FromPlaneFixed = fixedPlaneOf(ext.FromPlane.Plane())
+		}
+	}
 }
 
 // requireExtrude restores an extrude, erroring on a missing payload.
@@ -214,9 +272,21 @@ func restoreExtent(ed *ExtrudeData, work *WorkGeometry) (Extent, error) {
 			return Extent{}, err
 		}
 		ext.ToPlane = wp
+	} else if ed.ToPlaneFixed != nil {
+		wp, err := fixedWorkPlane(ed.ToPlaneFixed)
+		if err != nil {
+			return Extent{}, err
+		}
+		ext.ToPlane = wp
 	}
 	if ed.FromPlane != "" {
 		wp, err := resolvePlaneRef(work, ed.FromPlane)
+		if err != nil {
+			return Extent{}, err
+		}
+		ext.FromPlane = wp
+	} else if ed.FromPlaneFixed != nil {
+		wp, err := fixedWorkPlane(ed.FromPlaneFixed)
 		if err != nil {
 			return Extent{}, err
 		}

--- a/model/feature/serialize_extrude_toface_test.go
+++ b/model/feature/serialize_extrude_toface_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// TestFixedToFacePlaneRoundTrips pins the fix for a keyless to-face target. A to-face extrude whose
+// target is a NewFixedWorkPlane (authored from geometry, not a datum in the part's work geometry —
+// the form the Inventor to-face translator emits) has no WorkRef, so it was serialized as an empty
+// ref and lost on reopen: the restored extent's ToPlane went nil, toPlaneSpan errored, and the
+// feature built nothing (ST3215Bracket's walls vanished on save/reopen). Now the fixed plane's
+// geometry is written and restored, so the target survives.
+func TestFixedToFacePlaneRoundTrips(t *testing.T) {
+	x, _ := math.NewUnitVector3(1, 0, 0)
+	y, _ := math.NewUnitVector3(0, 1, 0)
+	pl, err := sketch.NewPlane(math.P3(1, 2, 3), x, y)
+	if err != nil {
+		t.Fatalf("plane: %v", err)
+	}
+	ext := Extent{Type: ToFaceExtent, ToPlane: NewFixedWorkPlane(pl)}
+
+	d := &ExtrudeData{Extent: "to-face"}
+	serializeExtentPlanes(ext, d)
+	if d.ToPlane != "" {
+		t.Errorf("a keyless target must not serialize a ref; got %q", d.ToPlane)
+	}
+	if d.ToPlaneFixed == nil {
+		t.Fatalf("keyless to-face target lost its geometry on serialize")
+	}
+
+	restored, err := restoreExtent(d, nil)
+	if err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if restored.ToPlane == nil {
+		t.Fatalf("to-face target went nil on restore — the reopened extrude would build nothing")
+	}
+	got := restored.ToPlane.Plane().Origin()
+	if stdmath.Abs(float64(got.X)-1) > 1e-9 || stdmath.Abs(float64(got.Y)-2) > 1e-9 || stdmath.Abs(float64(got.Z)-3) > 1e-9 {
+		t.Errorf("restored to-face origin = %v, want (1,2,3)", got)
+	}
+	n := restored.ToPlane.Plane().Normal().AsVector()
+	if stdmath.Abs(float64(n.Z)-1) > 1e-9 {
+		t.Errorf("restored to-face normal = %v, want +Z", n)
+	}
+}


### PR DESCRIPTION
Native Autodesk Inventor `.ipt` → Oblikovati `.opd` translator work: decode the DC node graph faithfully and rebuild the feature tree so real corpus parts translate to **parametric solids** validated against Inventor's own STL export. No live Inventor required.

## Impact

Measured on the 175-part ReelToReel `.ipt` corpus (`batch-translate`, which reopens each `.opd` and classifies the rebuilt body). Every commit was gated on the full corpus for **zero outcome regressions and zero volume change on already-correct solids**. Final tally:

| Outcome | Count |
|---|---:|
| **SOLID** (closed, parametric) | **96** |
| SURFACE (faithful imported mesh) | 76 |
| EMPTY / SKETCH | 3 |

Where a part can't rebuild parametrically it keeps Inventor's faithful display mesh — never a wrong solid (tessellation correctness is the #1 priority; a wrong solid is worse than none). Rebuilt solids that escape Inventor's stored tessellation are dropped by a containment gate.

## What's in it (19 commits)

**Decode foundation**
- Node-graph sketch decode (exact sketch membership + curve connectivity), sketch-plane decode, body-only import for derived/vendor parts, and **pre-2023 save support** (per-node-type content-header normalisation).
- Arcs stored as open `SketchCircle` nodes; splines; ellipse region edges.

**Features & regions**
- Extrude depth/direction/extent from the feature node's own property refs (not positional model-param order); region decode from BoundaryPatch loops with robust containment (degenerate loops/cells, cut-cell area-fit).
- **Holes** decoded from the HoleFeature node graph (order-independent bore/depth/counter), drilled on their own placement face.
- Persist a keyless to-face/from-face extent target (`model/feature`) — fixes To-plane walls silently vanishing on reopen.

**Revolves** — construction/horizontal/notched centrelines, intact-graph fallback when incidence fragments the profile.

**The `ext,rev,hole` machined-revolve cluster (all 5 recovered, ~1.0× oracle):**
- Rebuild turned base + milled cuts from the node graph (SpoolMotor/CapstonMotor holders).
- Revolve the sketch the Revolution feature **names** (BoundaryPatch ref), not a guessed one.
- Revolve about the **axis** the feature names (SketchLine3D at property 2) when it's an ordinary profile edge → CapstainMotorCap.
- Retry a cut that opens the body (coincident-face fault on a stepped top) as a through cut → SmartKnobFixedBase.
- Recover a revolve profile's mis-flagged wall arc from an axis-crossing full circle → KnobBottom.

## Testing

- `go test ./model/exchange/translators/inventor/...` green (unit + CI-safe decode tests).
- Corpus-gated tests (skip without `IPT_CORPUS`) assert each recovered part reopens as a SOLID within a few % of its Inventor STL volume.
- Full-corpus `batch-translate` diff at each commit: 0 regressions, 0 volume changes on unchanged solids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)