### PR TITLE
M44 sign-off: sheet-metal geometry (#2085/#2086) + occurrence patterns (#1976) + watertight gate (#2079)

### DIFF
--- a/addin/router/assembly_patterns.go
+++ b/addin/router/assembly_patterns.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/occurrence"
+)
+
+// Persistent occurrence-pattern editing (#1976). assembly.patternCreate now records the pattern
+// (assembly_replication.go); these methods re-read it, suppress/unsuppress it as a whole or per
+// element, reposition an element off the grid, and delete the whole array. Each edit drives the
+// real occurrences the pattern generated, so suppressing an element hides its instance and
+// deleting the pattern removes the copies (the seed stays).
+
+// registerAssemblyPatternHandlers wires the pattern list + edit methods.
+func (r *Router) registerAssemblyPatternHandlers() {
+	r.readOnly(wire.MethodAssemblyPatternList, assemblyQuery(assemblyPatternList))
+	r.mutating(wire.MethodAssemblyPatternSetSuppressed, "Suppress Pattern", typedAssembly(assemblyPatternSetSuppressed))
+	r.mutating(wire.MethodAssemblyPatternElementSuppress, "Suppress Pattern Element", typedAssembly(assemblyPatternElementSetSuppressed))
+	r.mutating(wire.MethodAssemblyPatternElementReposition, "Reposition Pattern Element", typedAssembly(assemblyPatternElementReposition))
+	r.mutating(wire.MethodAssemblyPatternDelete, "Delete Pattern", typedAssembly(assemblyPatternDelete))
+}
+
+// assemblyPatternList re-reads every persistent pattern in the active assembly.
+func assemblyPatternList(_ *app.Session, asm *compdef.AssemblyComponentDefinition) (wire.PatternListResult, error) {
+	set := asm.Patterns()
+	out := make([]wire.PatternInfo, set.Count())
+	for i := 0; i < set.Count(); i++ {
+		out[i] = patternInfo(set.Item(i))
+	}
+	return wire.PatternListResult{Patterns: out}, nil
+}
+
+// assemblyPatternSetSuppressed suppresses or unsuppresses a whole pattern.
+func assemblyPatternSetSuppressed(_ *app.Session, asm *compdef.AssemblyComponentDefinition, in wire.SetPatternSuppressedArgs) (wire.PatternInfo, error) {
+	pat, err := patternByID(asm, in.Pattern, wire.MethodAssemblyPatternSetSuppressed)
+	if err != nil {
+		return wire.PatternInfo{}, err
+	}
+	pat.SetSuppressed(in.Suppressed)
+	return patternInfo(pat), nil
+}
+
+// assemblyPatternElementSetSuppressed suppresses or unsuppresses one element of a pattern.
+func assemblyPatternElementSetSuppressed(_ *app.Session, asm *compdef.AssemblyComponentDefinition, in wire.SetPatternElementSuppressedArgs) (wire.PatternInfo, error) {
+	pat, err := patternByID(asm, in.Pattern, wire.MethodAssemblyPatternElementSuppress)
+	if err != nil {
+		return wire.PatternInfo{}, err
+	}
+	if err := pat.SetElementSuppressed(in.Element, in.Suppressed); err != nil {
+		return wire.PatternInfo{}, fmt.Errorf("%s: %w", wire.MethodAssemblyPatternElementSuppress, err)
+	}
+	return patternInfo(pat), nil
+}
+
+// assemblyPatternElementReposition moves one element of a pattern to an explicit placement.
+func assemblyPatternElementReposition(_ *app.Session, asm *compdef.AssemblyComponentDefinition, in wire.RepositionPatternElementArgs) (wire.PatternInfo, error) {
+	pat, err := patternByID(asm, in.Pattern, wire.MethodAssemblyPatternElementReposition)
+	if err != nil {
+		return wire.PatternInfo{}, err
+	}
+	if err := pat.RepositionElement(in.Element, matrixFromWire(in.Transform)); err != nil {
+		return wire.PatternInfo{}, fmt.Errorf("%s: %w", wire.MethodAssemblyPatternElementReposition, err)
+	}
+	return patternInfo(pat), nil
+}
+
+// assemblyPatternDelete deletes a whole pattern and the occurrences it generated.
+func assemblyPatternDelete(_ *app.Session, asm *compdef.AssemblyComponentDefinition, in wire.DeletePatternArgs) (wire.DeletePatternResult, error) {
+	if _, err := patternByID(asm, in.Pattern, wire.MethodAssemblyPatternDelete); err != nil {
+		return wire.DeletePatternResult{}, err
+	}
+	asm.Patterns().Delete(in.Pattern)
+	return wire.DeletePatternResult{Deleted: in.Pattern}, nil
+}
+
+// patternByID resolves a pattern by session id, erroring with the method name when it is unknown.
+func patternByID(asm *compdef.AssemblyComponentDefinition, id uint64, method string) (*occurrence.OccurrencePattern, error) {
+	pat, ok := asm.Patterns().ByID(id)
+	if !ok {
+		return nil, fmt.Errorf("%s: no pattern with id %d", method, id)
+	}
+	return pat, nil
+}

--- a/addin/router/assembly_patterns_test.go
+++ b/addin/router/assembly_patterns_test.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package router
+
+import (
+	"fmt"
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+)
+
+// Persistent occurrence-pattern editing over the wire (#1976). A pattern created by patternCreate
+// is re-read, suppressed/unsuppressed as a whole or per element, repositioned, and deleted — the
+// group the router used to throw away.
+
+// makeCircularPattern creates a 4-up circular pattern of the seed and returns the session bits plus
+// the created pattern.
+func makeCircularPattern(t *testing.T) (*Router, *app.Session, wire.PatternInfo) {
+	t.Helper()
+	r, s, _, occs := assemblySessionWithBoxes(t, 0)
+	var created wire.CreatePatternResult
+	args := fmt.Sprintf(`{"seed":%d,"kind":"circular","origin":[0,0,0],"axis":[0,0,1],"angle":%g,"count":4}`,
+		occs[0].ID(), stdmath.Pi/2)
+	call(t, r, s, "assembly.patternCreate", args, &created)
+	if created.Pattern.ID == 0 {
+		t.Fatalf("patternCreate returned no pattern id: %+v", created.Pattern)
+	}
+	if len(created.Created) != 3 {
+		t.Fatalf("pattern created %d occurrences, want 3 (4 total minus the seed)", len(created.Created))
+	}
+	return r, s, created.Pattern
+}
+
+// TestAssemblyPatternPersistsAndLists patternCreate records the pattern (id, kind, 4 elements), and
+// patternList re-reads exactly it — the array is no longer thrown away.
+func TestAssemblyPatternPersistsAndLists(t *testing.T) {
+	r, s, pat := makeCircularPattern(t)
+	if pat.Kind != "circular" || len(pat.Elements) != 4 || pat.Suppression != "none" {
+		t.Errorf("pattern = %+v, want circular / 4 elements / none suppressed", pat)
+	}
+	var list wire.PatternListResult
+	call(t, r, s, "assembly.patternList", `{}`, &list)
+	if len(list.Patterns) != 1 || list.Patterns[0].ID != pat.ID {
+		t.Fatalf("patternList = %+v, want the one pattern id %d", list.Patterns, pat.ID)
+	}
+}
+
+// TestAssemblyPatternSuppressHidesAll suppressing the whole pattern reports "all" and hides every
+// generated occurrence; unsuppressing restores "none" and reveals them.
+func TestAssemblyPatternSuppressHidesAll(t *testing.T) {
+	r, s, pat := makeCircularPattern(t)
+	var info wire.PatternInfo
+	call(t, r, s, "assembly.patternSetSuppressed", fmt.Sprintf(`{"pattern":%d,"suppressed":true}`, pat.ID), &info)
+	if info.Suppression != "all" {
+		t.Errorf("suppressed pattern reports %q, want all", info.Suppression)
+	}
+	if got := unsuppressedOccurrences(t, r, s); got != 1 {
+		t.Errorf("a fully suppressed pattern leaves %d visible occurrences, want 1 (the seed)", got)
+	}
+	call(t, r, s, "assembly.patternSetSuppressed", fmt.Sprintf(`{"pattern":%d,"suppressed":false}`, pat.ID), &info)
+	if info.Suppression != "none" {
+		t.Errorf("unsuppressed pattern reports %q, want none", info.Suppression)
+	}
+	if got := unsuppressedOccurrences(t, r, s); got != 4 {
+		t.Errorf("an unsuppressed 4-up pattern leaves %d visible occurrences, want 4", got)
+	}
+}
+
+// TestAssemblyPatternElementSuppressReportsSome suppressing one element reports "some" at the
+// pattern level and flags that element.
+func TestAssemblyPatternElementSuppressReportsSome(t *testing.T) {
+	r, s, pat := makeCircularPattern(t)
+	var info wire.PatternInfo
+	call(t, r, s, "assembly.patternElementSetSuppressed",
+		fmt.Sprintf(`{"pattern":%d,"element":2,"suppressed":true}`, pat.ID), &info)
+	if info.Suppression != "some" {
+		t.Errorf("one suppressed element reports %q, want some", info.Suppression)
+	}
+	if !info.Elements[2].Suppressed {
+		t.Errorf("element 2 is not flagged suppressed: %+v", info.Elements[2])
+	}
+	if got := unsuppressedOccurrences(t, r, s); got != 3 {
+		t.Errorf("one suppressed element leaves %d visible occurrences, want 3", got)
+	}
+	// An out-of-range element is rejected, not silently ignored.
+	if _, err := r.Handle(s, "assembly.patternElementSetSuppressed",
+		[]byte(fmt.Sprintf(`{"pattern":%d,"element":99,"suppressed":true}`, pat.ID))); err == nil {
+		t.Error("suppressing an out-of-range element should fail")
+	}
+}
+
+// TestAssemblyPatternElementReposition repositioning one element flags it and moves its occurrence
+// off the regular grid.
+func TestAssemblyPatternElementReposition(t *testing.T) {
+	r, s, pat := makeCircularPattern(t)
+	var info wire.PatternInfo
+	call(t, r, s, "assembly.patternElementReposition",
+		fmt.Sprintf(`{"pattern":%d,"element":1,"transform":%s}`, pat.ID, transformJSON(9, 9, 0)), &info)
+	if !info.Elements[1].Repositioned {
+		t.Errorf("element 1 is not flagged repositioned: %+v", info.Elements[1])
+	}
+	if !occurrenceAt(t, r, s, 9, 9, 0) {
+		t.Error("no occurrence sits at the repositioned (9,9,0); the reposition did not move an instance")
+	}
+}
+
+// TestAssemblyPatternDelete deleting a pattern removes the occurrences it generated (the seed stays)
+// and drops it from the list.
+func TestAssemblyPatternDelete(t *testing.T) {
+	r, s, pat := makeCircularPattern(t)
+	var del wire.DeletePatternResult
+	call(t, r, s, "assembly.patternDelete", fmt.Sprintf(`{"pattern":%d}`, pat.ID), &del)
+	if del.Deleted != pat.ID {
+		t.Errorf("delete returned %d, want %d", del.Deleted, pat.ID)
+	}
+	var tree wire.OccurrencesResult
+	call(t, r, s, "assembly.occurrences", `{}`, &tree)
+	if len(tree.Occurrences) != 1 {
+		t.Errorf("after delete the tree has %d occurrences, want 1 (the seed)", len(tree.Occurrences))
+	}
+	var list wire.PatternListResult
+	call(t, r, s, "assembly.patternList", `{}`, &list)
+	if len(list.Patterns) != 0 {
+		t.Errorf("a deleted pattern still lists: %+v", list.Patterns)
+	}
+	// Deleting an unknown pattern is an error.
+	if _, err := r.Handle(s, "assembly.patternDelete", []byte(`{"pattern":99999}`)); err == nil {
+		t.Error("deleting an unknown pattern should fail")
+	}
+}
+
+// unsuppressedOccurrences counts the assembly's occurrences that are not suppressed.
+func unsuppressedOccurrences(t *testing.T, r *Router, s *app.Session) int {
+	t.Helper()
+	var tree wire.OccurrencesResult
+	call(t, r, s, "assembly.occurrences", `{}`, &tree)
+	n := 0
+	for _, o := range tree.Occurrences {
+		if !o.Suppressed {
+			n++
+		}
+	}
+	return n
+}
+
+// occurrenceAt reports whether any occurrence sits at (x,y,z).
+func occurrenceAt(t *testing.T, r *Router, s *app.Session, x, y, z float64) bool {
+	t.Helper()
+	var tree wire.OccurrencesResult
+	call(t, r, s, "assembly.occurrences", `{}`, &tree)
+	for _, o := range tree.Occurrences {
+		c := o.Transform.Cells
+		if c[3] == x && c[7] == y && c[11] == z {
+			return true
+		}
+	}
+	return false
+}

--- a/addin/router/assembly_replication.go
+++ b/addin/router/assembly_replication.go
@@ -33,18 +33,35 @@ func (r *Router) registerAssemblyReplicationHandlers() {
 }
 
 // assemblyPatternCreate replicates the seed occurrence across an arrangement, adding one
-// occurrence per generated element beyond the seed.
-func assemblyPatternCreate(_ *app.Session, asm *compdef.AssemblyComponentDefinition, in wire.CreatePatternArgs) (wire.NewOccurrencesResult, error) {
+// occurrence per generated element beyond the seed and RECORDING the pattern so it can be
+// re-read, suppressed, and deleted as a group (#1976).
+func assemblyPatternCreate(_ *app.Session, asm *compdef.AssemblyComponentDefinition, in wire.CreatePatternArgs) (wire.CreatePatternResult, error) {
 	seed, err := occurrenceByID(asm, in.Seed, wire.MethodAssemblyPatternCreate)
 	if err != nil {
-		return wire.NewOccurrencesResult{}, err
+		return wire.CreatePatternResult{}, err
 	}
 	arr, err := arrangementFromArgs(in)
 	if err != nil {
-		return wire.NewOccurrencesResult{}, err
+		return wire.CreatePatternResult{}, err
 	}
 	pat := occurrence.NewOccurrencePattern(seed.Definition(), seed.Transform(), arr)
-	return newOccurrencesReply(occurrence.PatternComponents(asm.Occurrences(), seed, pat)), nil
+	generated := occurrence.PatternComponents(asm.Occurrences(), seed, pat)
+	name := fmt.Sprintf("Pattern%d", asm.Patterns().Count()+1)
+	asm.Patterns().Add(pat, name, seed, generated)
+	return wire.CreatePatternResult{Pattern: patternInfo(pat), Created: newOccurrencesReply(generated).Created}, nil
+}
+
+// patternInfo renders a persistent occurrence pattern for the wire (#1976): its id/name/kind, the
+// whole-pattern suppression state, and each element's suppress/reposition flags.
+func patternInfo(p *occurrence.OccurrencePattern) wire.PatternInfo {
+	elems := make([]wire.PatternElementInfo, p.Count())
+	for i := 0; i < p.Count(); i++ {
+		e := p.Element(i)
+		elems[i] = wire.PatternElementInfo{Index: i, Suppressed: e.Suppressed(), Repositioned: e.Repositioned()}
+	}
+	return wire.PatternInfo{
+		ID: p.ID(), Name: p.Name(), Kind: p.Kind(), Suppression: p.Suppression().String(), Elements: elems,
+	}
 }
 
 // assemblyMirror adds a mirror of each source occurrence across the plane (origin, normal).

--- a/addin/router/router.go
+++ b/addin/router/router.go
@@ -138,6 +138,7 @@ func New(ops *opregistry.Registry) *Router {
 	r.registerRepresentationHandlers()
 	r.registerContactHandlers()
 	r.registerAssemblyReplicationHandlers()
+	r.registerAssemblyPatternHandlers()
 	r.registerAssemblyBOMHandlers()
 	r.registerAssemblyOptionsHandlers()
 	r.registerDocumentPropertyHandlers()

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	golang.org/x/sys v0.47.0
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.146.0
+	oblikovati.org/api v0.147.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.146.0
+	oblikovati.org/api v0.147.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/compdef/assembly.go
+++ b/model/compdef/assembly.go
@@ -33,11 +33,12 @@ var (
 // joints, and representations attach to it from M12.
 type AssemblyComponentDefinition struct {
 	occurrences *occurrence.Occurrences
-	units       param.UnitsOfMeasure    // document display units (length/angle/…)
-	events      *AssemblyEvents         // occurrence-lifecycle event source (M11-F07)
-	constraints *assembly.ConstraintSet // constraint relationships + positioning solver (M12-F01)
-	joints      *assembly.JointSet      // joint relationships (reduced-DOF, M12-F02)
-	dsJoints    *assembly.DSJointSet    // DS-joint (DOF/imposed-motion) view (M12-F02)
+	units       param.UnitsOfMeasure             // document display units (length/angle/…)
+	events      *AssemblyEvents                  // occurrence-lifecycle event source (M11-F07)
+	constraints *assembly.ConstraintSet          // constraint relationships + positioning solver (M12-F01)
+	joints      *assembly.JointSet               // joint relationships (reduced-DOF, M12-F02)
+	dsJoints    *assembly.DSJointSet             // DS-joint (DOF/imposed-motion) view (M12-F02)
+	patterns    *occurrence.OccurrencePatternSet // persistent, editable occurrence patterns (#1976)
 
 	representations *assembly.Representations // design-view/positional/LOD override layers + model states (M12-F04)
 	contacts        *assembly.ContactSolver   // contact sets + interpenetration toggle (M12-F05)
@@ -53,6 +54,9 @@ type AssemblyComponentDefinition struct {
 	// features bind after the occurrences resolve (they snapshot participation), so they wait
 	// for ResolveReferences like the occurrences do (#785). Empty outside a reopen/restore.
 	pendingFeatures []assemblyFeatureProgramRecipe
+	// pendingPatterns holds occurrence patterns parsed by ApplyRecipe but not yet rebuilt — a
+	// pattern re-links to its occurrences by name, so it waits for ResolveReferences too (#1976).
+	pendingPatterns []occurrencePatternRecipe
 	// props are the assembly document's iProperties (metadata sets), like a part's (#156).
 	props *attr.PropertySets
 	// options are the assembly-editing defaults (#1981); updatePending records a recompute deferred
@@ -85,6 +89,7 @@ func NewAssemblyComponentDefinition() *AssemblyComponentDefinition {
 	a.constraints = assembly.NewConstraintSet(occ, a.events)
 	a.joints = assembly.NewJointSet(occ, a.events)
 	a.dsJoints = assembly.NewDSJointSet()
+	a.patterns = occurrence.NewOccurrencePatternSet(occ)
 	a.representations = assembly.NewRepresentations(occ, a.constraints, a.joints)
 	a.contacts = assembly.NewContactSolver()
 	// Accept occurrence-qualified datum refs ("occ/<path>/plane/N") as inputs to the assembly's
@@ -207,6 +212,9 @@ func (a *AssemblyComponentDefinition) Constraints() *assembly.ConstraintSet { re
 // establish a degree-of-freedom set between occurrences (M12-F02). Author with its Add*
 // methods, then position with [AssemblyComponentDefinition.SolveConstraints].
 func (a *AssemblyComponentDefinition) Joints() *assembly.JointSet { return a.joints }
+
+// Patterns returns the assembly's persistent occurrence patterns (#1976).
+func (a *AssemblyComponentDefinition) Patterns() *occurrence.OccurrencePatternSet { return a.patterns }
 
 // DSJoints returns the assembly's DS-joint (degrees-of-freedom / imposed-motion) set (M12-F02).
 func (a *AssemblyComponentDefinition) DSJoints() *assembly.DSJointSet { return a.dsJoints }

--- a/model/compdef/assembly_pattern_serialize.go
+++ b/model/compdef/assembly_pattern_serialize.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"fmt"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/occurrence"
+)
+
+// Persistence for the persistent occurrence patterns (#1976). A pattern is rebuilt from its
+// arrangement and re-linked to the occurrences it drives — resolved by instance name, since the
+// generated occurrences persist independently through the occurrence recipe. It restores AFTER the
+// occurrences are bound (in ResolveReferences), and the same path serves the fast-undo snapshot.
+
+// occurrencePatternRecipe persists one occurrence pattern: its name, the occurrences each element
+// drives (element 0 = seed), the arrangement, and each element's suppress/reposition state.
+type occurrencePatternRecipe struct {
+	Name     string   `yaml:"name"`
+	Kind     string   `yaml:"kind"`
+	OccNames []string `yaml:"occurrences"`
+	// Circular arrangement.
+	Origin []float64 `yaml:"origin,omitempty"`
+	Axis   []float64 `yaml:"axis,omitempty"`
+	Angle  float64   `yaml:"angle,omitempty"`
+	Count  int       `yaml:"count,omitempty"`
+	// Rectangular arrangement.
+	Dir1     []float64 `yaml:"dir1,omitempty"`
+	Spacing1 float64   `yaml:"spacing1,omitempty"`
+	Count1   int       `yaml:"count1,omitempty"`
+	Dir2     []float64 `yaml:"dir2,omitempty"`
+	Spacing2 float64   `yaml:"spacing2,omitempty"`
+	Count2   int       `yaml:"count2,omitempty"`
+
+	Elements []patternElementRecipe `yaml:"elements,omitempty"`
+}
+
+// patternElementRecipe persists one element's editable state: whether it is suppressed and, if it
+// was repositioned off the grid, its 16-cell override transform.
+type patternElementRecipe struct {
+	Suppressed bool      `yaml:"suppressed,omitempty"`
+	Override   []float64 `yaml:"override,omitempty"`
+}
+
+// patternsRecipe snapshots every persistent pattern for the assembly recipe.
+func (a *AssemblyComponentDefinition) patternsRecipe() []occurrencePatternRecipe {
+	var out []occurrencePatternRecipe
+	for i := 0; i < a.patterns.Count(); i++ {
+		out = append(out, patternRecipeOf(a.patterns.Item(i)))
+	}
+	return out
+}
+
+// patternRecipeOf renders one pattern to its recipe.
+func patternRecipeOf(p *occurrence.OccurrencePattern) occurrencePatternRecipe {
+	rec := occurrencePatternRecipe{Name: p.Name(), Kind: p.Kind()}
+	for _, o := range p.Occurrences() {
+		rec.OccNames = append(rec.OccNames, o.Name())
+	}
+	switch arr := p.Arrangement().(type) {
+	case occurrence.CircularArrangement:
+		rec.Origin, rec.Axis = point3Cells(arr.Origin), vec3Cells(arr.Axis.AsVector())
+		rec.Angle, rec.Count = float64(arr.Step), arr.Count
+	case occurrence.RectangularArrangement:
+		rec.Dir1, rec.Spacing1, rec.Count1 = vec3Cells(arr.Dir1.AsVector()), float64(arr.Spacing1), arr.Count1
+		rec.Dir2, rec.Spacing2, rec.Count2 = vec3Cells(arr.Dir2.AsVector()), float64(arr.Spacing2), arr.Count2
+	}
+	for i := 0; i < p.Count(); i++ {
+		e := p.Element(i)
+		er := patternElementRecipe{Suppressed: e.Suppressed()}
+		if e.Repositioned() {
+			cells := e.Transform().Cells()
+			er.Override = cells[:]
+		}
+		rec.Elements = append(rec.Elements, er)
+	}
+	return rec
+}
+
+// restorePatterns rebuilds every pending pattern now that the occurrences are bound, re-linking each
+// to its occurrences by name.
+func (a *AssemblyComponentDefinition) restorePatterns() error {
+	pending := a.pendingPatterns
+	a.pendingPatterns = nil
+	byName := make(map[string]*occurrence.Occurrence, a.occurrences.Count())
+	for _, o := range a.occurrences.All() {
+		byName[o.Name()] = o
+	}
+	for _, rec := range pending {
+		if err := a.restorePattern(rec, byName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// restorePattern rebuilds one pattern: resolve its seed + generated occurrences by name, rebuild the
+// arrangement, record it, then re-apply each element's suppress/reposition state.
+func (a *AssemblyComponentDefinition) restorePattern(rec occurrencePatternRecipe, byName map[string]*occurrence.Occurrence) error {
+	if len(rec.OccNames) == 0 {
+		return fmt.Errorf("compdef: occurrence pattern %q has no occurrences to restore", rec.Name)
+	}
+	seed, ok := byName[rec.OccNames[0]]
+	if !ok {
+		return fmt.Errorf("compdef: occurrence pattern %q seed %q was not restored", rec.Name, rec.OccNames[0])
+	}
+	arr, err := arrangementFromRecipe(rec)
+	if err != nil {
+		return err
+	}
+	generated := make([]*occurrence.Occurrence, 0, len(rec.OccNames)-1)
+	for _, name := range rec.OccNames[1:] {
+		o, ok := byName[name]
+		if !ok {
+			return fmt.Errorf("compdef: occurrence pattern %q element %q was not restored", rec.Name, name)
+		}
+		generated = append(generated, o)
+	}
+	pat := occurrence.NewOccurrencePattern(seed.Definition(), seed.Transform(), arr)
+	a.patterns.Add(pat, rec.Name, seed, generated)
+	return applyPatternElementStates(pat, rec.Elements)
+}
+
+// applyPatternElementStates re-applies the per-element suppress/reposition state onto a restored
+// pattern. Its occurrences already carry their own restored state, so these calls are idempotent.
+func applyPatternElementStates(pat *occurrence.OccurrencePattern, elems []patternElementRecipe) error {
+	for i, er := range elems {
+		if er.Suppressed {
+			if err := pat.SetElementSuppressed(i, true); err != nil {
+				return err
+			}
+		}
+		if len(er.Override) == 16 {
+			var cells [16]float64
+			copy(cells[:], er.Override)
+			if err := pat.RepositionElement(i, math.Matrix4FromCells(cells)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// arrangementFromRecipe rebuilds a pattern arrangement from its persisted parameters.
+func arrangementFromRecipe(rec occurrencePatternRecipe) (occurrence.Arrangement, error) {
+	switch rec.Kind {
+	case "circular":
+		axis, err := unitFromCells(rec.Axis)
+		if err != nil {
+			return nil, fmt.Errorf("compdef: pattern %q axis: %w", rec.Name, err)
+		}
+		return occurrence.CircularArrangement{Origin: pointFromCells(rec.Origin), Axis: axis, Step: math.Scalar(rec.Angle), Count: rec.Count}, nil
+	case "rectangular":
+		d1, err := unitFromCells(rec.Dir1)
+		if err != nil {
+			return nil, fmt.Errorf("compdef: pattern %q dir1: %w", rec.Name, err)
+		}
+		d2, err := unitFromCells(rec.Dir2)
+		if err != nil {
+			return nil, fmt.Errorf("compdef: pattern %q dir2: %w", rec.Name, err)
+		}
+		return occurrence.RectangularArrangement{Dir1: d1, Spacing1: math.Scalar(rec.Spacing1), Count1: rec.Count1, Dir2: d2, Spacing2: math.Scalar(rec.Spacing2), Count2: rec.Count2}, nil
+	}
+	return nil, fmt.Errorf("compdef: pattern %q has unknown arrangement kind %q", rec.Name, rec.Kind)
+}
+
+// point3Cells / vec3Cells flatten a point/vector to [x,y,z]; pointFromCells / unitFromCells rebuild.
+func point3Cells(p math.Point3) []float64 { return []float64{float64(p.X), float64(p.Y), float64(p.Z)} }
+func vec3Cells(v math.Vector3) []float64  { return []float64{float64(v.X), float64(v.Y), float64(v.Z)} }
+func pointFromCells(c []float64) math.Point3 {
+	if len(c) != 3 {
+		return math.P3(0, 0, 0)
+	}
+	return math.P3(c[0], c[1], c[2])
+}
+
+// unitFromCells rebuilds a unit direction from [x,y,z], erroring on a zero/short vector.
+func unitFromCells(c []float64) (math.UnitVector3, error) {
+	if len(c) != 3 {
+		return math.UnitVector3{}, fmt.Errorf("direction has %d cells, want 3", len(c))
+	}
+	return math.NewUnitVector3(c[0], c[1], c[2])
+}

--- a/model/compdef/assembly_pattern_test.go
+++ b/model/compdef/assembly_pattern_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/math"
+	"oblikovati.org/model/occurrence"
+)
+
+// TestAssemblyPatternRoundTrips a persistent occurrence pattern — with one element suppressed and
+// another repositioned off the grid — survives save/reopen: the pattern is re-recorded and re-linked
+// to its (independently persisted) occurrences by name, and the per-element edits come back (#1976).
+func TestAssemblyPatternRoundTrips(t *testing.T) {
+	store, ws, asm, widget, asmDef := placedAssembly(t)
+	seed := placeFromFile(t, asm, widget, asmDef, "widget:1", math.Identity4())
+
+	axis, _ := math.NewUnitVector3(0, 0, 1)
+	arr := occurrence.CircularArrangement{Origin: math.P3(0, 0, 0), Axis: axis, Step: math.Scalar(stdmath.Pi / 2), Count: 4}
+	pat := occurrence.NewOccurrencePattern(seed.Definition(), seed.Transform(), arr)
+	generated := occurrence.PatternComponents(asmDef.Occurrences(), seed, pat)
+	asmDef.Patterns().Add(pat, "Pattern1", seed, generated)
+	if err := pat.SetElementSuppressed(2, true); err != nil {
+		t.Fatalf("suppress element 2: %v", err)
+	}
+	if err := pat.RepositionElement(1, math.Translation4(math.V3(9, 9, 0))); err != nil {
+		t.Fatalf("reposition element 1: %v", err)
+	}
+
+	def := reopenAssembly(t, store, ws, asm)
+	if def.Patterns().Count() != 1 {
+		t.Fatalf("reopened assembly has %d patterns, want 1", def.Patterns().Count())
+	}
+	rp := def.Patterns().Item(0)
+	if rp.Name() != "Pattern1" || rp.Kind() != "circular" || rp.Count() != 4 {
+		t.Errorf("restored pattern = {name:%q kind:%q count:%d}, want Pattern1/circular/4", rp.Name(), rp.Kind(), rp.Count())
+	}
+	if rp.Suppression() != types.SomeElementsSuppressed {
+		t.Errorf("restored pattern suppression = %v, want some (element 2 suppressed)", rp.Suppression())
+	}
+	if !rp.Element(2).Suppressed() {
+		t.Error("element 2 lost its suppression on reopen")
+	}
+	if !rp.Element(1).Repositioned() {
+		t.Error("element 1 lost its reposition on reopen")
+	}
+	if got := rp.Element(1).Transform().Cells(); got != math.Translation4(math.V3(9, 9, 0)).Cells() {
+		t.Errorf("element 1 override = %v, want the (9,9,0) translation", got)
+	}
+}

--- a/model/compdef/assembly_serialize.go
+++ b/model/compdef/assembly_serialize.go
@@ -39,7 +39,8 @@ type assemblyRecipe struct {
 	Sketches          []sketch.SketchData            `yaml:"sketches,omitempty"`   // assembly-space sketches (#785)
 	Features          []assemblyFeatureProgramRecipe `yaml:"features,omitempty"`   // the machining program (#785)
 	EndOfFeatures     *int                           `yaml:"endOfFeatures,omitempty"`
-	Options           *assemblyOptionsRecipe         `yaml:"options,omitempty"` // assembly editing options (#1981)
+	Options           *assemblyOptionsRecipe         `yaml:"options,omitempty"`  // assembly editing options (#1981)
+	Patterns          []occurrencePatternRecipe      `yaml:"patterns,omitempty"` // persistent occurrence patterns (#1976)
 }
 
 // assemblyOptionsRecipe persists the assembly editing options (#1981); the transient DeferUpdate flag
@@ -120,6 +121,7 @@ func (a *AssemblyComponentDefinition) buildRecipe() (assemblyRecipe, error) {
 		r.EndOfFeatures = &eof
 	}
 	r.Options = optionsRecipeOf(a.options)
+	r.Patterns = a.patternsRecipe()
 	return r, nil
 }
 
@@ -287,6 +289,7 @@ func (a *AssemblyComponentDefinition) applyRecipeStruct(r assemblyRecipe) error 
 	}
 	a.restoreOptions(r.Options)
 	a.pending = r.Occurrences
+	a.pendingPatterns = r.Patterns // patterns re-link to occurrences by name, after they resolve (#1976)
 	a.pendingFeatures = r.Features // features bind after occurrences resolve (they snapshot participation)
 	return nil
 }
@@ -301,10 +304,12 @@ func (a *AssemblyComponentDefinition) resetOccurrences() {
 	a.props = attr.NewPropertySets() // a restore re-applies the snapshot's properties onto a clean set (#156)
 	a.params = param.NewParameters() // a snapshot restore is a full replace; re-add params onto a clean table (#1557)
 	a.sketches = sketch.NewSketches()
-	a.sketches.ShareParameters(a.params) // re-wire so restored sketches resolve dimension expressions (#1557)
-	a.features = NewAssemblyFeatures()   // the program rebuilds from the snapshot (#785)
-	a.features.SetBus(a.events.Bus())    // re-wire the recompute event bus the fresh program needs
+	a.sketches.ShareParameters(a.params)                           // re-wire so restored sketches resolve dimension expressions (#1557)
+	a.features = NewAssemblyFeatures()                             // the program rebuilds from the snapshot (#785)
+	a.features.SetBus(a.events.Bus())                              // re-wire the recompute event bus the fresh program needs
+	a.patterns = occurrence.NewOccurrencePatternSet(a.occurrences) // re-bind to the fresh occurrences (#1976)
 	a.pendingFeatures = nil
+	a.pendingPatterns = nil
 	a.pending = nil
 }
 
@@ -334,6 +339,9 @@ func (a *AssemblyComponentDefinition) ResolveReferences(owner *doc.Document) err
 		occ.SetChildOverrides(parseChildOverrides(rec.ChildTransforms))
 		occ.SetSubstitute(rec.Substitute)
 		occ.SetBOMStructureOverride(rec.BOMStructure)
+	}
+	if err := a.restorePatterns(); err != nil { // patterns re-link to the now-bound occurrences (#1976)
+		return err
 	}
 	return a.restoreFeatures()
 }

--- a/model/feature/occtparity/tangent_chain_debt_test.go
+++ b/model/feature/occtparity/tangent_chain_debt_test.go
@@ -173,7 +173,8 @@ func tangentChainDebtIndex() map[string]int {
 // through ops.TangentEdgeChain, whose gates were aligned to PerformElement's FaceTangency + π/2
 // no-turn-back rule, replacing the KNOWN-divergent 1° antiparallel band + same-convexity gates).
 // Re-measured across every importable record after the alignment: 0 uncovered edges corpus-wide —
-// including the two FAIL(area) deciders (complex/D8/F2, the closed 8-edge rim spine), the seven
+// including the closed 8-edge rim-spine deciders (complex/D8 FAIL(area), complex/F2 FAIL(faulty)
+// since #2079's self-intersection gate), the seven
 // no-body faulties (complex/B9 C1 C5 F1, simple/P3 P7 U5), the pre-fillet skips (buildevol/K6,
 // complex/E1 E2, encoderegularity/A5's 14-edge spine), and the acquitted simple/N4.
 //

--- a/model/feature/occtparity/w6_w8_concave_boss_rim_test.go
+++ b/model/feature/occtparity/w6_w8_concave_boss_rim_test.go
@@ -81,10 +81,13 @@ func TestConcaveBossBaseRimArea(t *testing.T) {
 	}
 }
 
-// TestSpillingConcaveRimsStayDeep pins that R8 and W9 — the concave boss-base rims whose R+r cove spills
-// past the cap onto the side walls (the deep #2012 boss-root weld) — are NOT claimed by
-// solveConcaveBossRim's cap-fit gate: they must remain FAIL(area) on the unchanged solveRim ladder, not
-// silently regress to FAIL(faulty) or a false green.
+// TestSpillingConcaveRimsStayDeep pins that R8 and W9 — the concave boss-base rims whose R+r cove
+// spills past the cap onto the side walls (the deep #2012 boss-root weld) — are NOT claimed by
+// solveConcaveBossRim's cap-fit gate and stay FAIL on the unchanged solveRim ladder, never a false
+// green. They score FAIL(faulty), not FAIL(area): #2079 found the spilling cove drives the plate face
+// and the side wall straight THROUGH each other (interpenetration 3-15 model units), so the body was
+// never the clean "valid solid, wrong footprint" the old topology-only gate reported — the hardened
+// isWatertightSolid now names it faulty. A future fix frees them by DELETING this pin, not by widening.
 func TestSpillingConcaveRimsStayDeep(t *testing.T) {
 	t.Parallel()
 	byCase := map[string]Record{}
@@ -95,8 +98,8 @@ func TestSpillingConcaveRimsStayDeep(t *testing.T) {
 	}
 	dir := CorpusFixtureDir()
 	for _, id := range []string{"R8", "W9"} {
-		if got := ScoreCase(byCase[id], dir); got != FailArea {
-			t.Errorf("simple/%s scored %v, want FAIL(area) (deep #2012 boss-root; cap-fit gate must reject its spilling cove)", id, got)
+		if got := ScoreCase(byCase[id], dir); got != FailFaulty {
+			t.Errorf("simple/%s scored %v, want FAIL(faulty) (deep #2012 boss-root; its spilling cove self-intersects, #2079)", id, got)
 		}
 	}
 }

--- a/model/feature/occtparity/watertight.go
+++ b/model/feature/occtparity/watertight.go
@@ -28,9 +28,7 @@ func isWatertightSolid(res []*topo.Body, filletOK bool, props ops.GeometryProper
 		return false
 	}
 	rep := ops.Validate(res[0])
-	if !(rep.Valid && rep.Closed && rep.Manifold && rep.HolesContained && res[0].IsSolid()) {
-		return false
-	}
+	topologyOK := rep.Valid && rep.Closed && rep.Manifold && rep.HolesContained && res[0].IsSolid()
 	// ops.Validate is TOPOLOGY-ONLY: a body whose faces are driven straight through each other still
 	// satisfies Valid && Closed && Manifold && HolesContained && IsSolid (#2079 — R8/W9/complex-F2 in
 	// the corpus interpenetrate by 3-15 model units, three orders of magnitude past any tessellation
@@ -38,5 +36,5 @@ func isWatertightSolid(res []*topo.Body, filletOK bool, props ops.GeometryProper
 	// PropertyQuality — the SAME quality caseProperties already tessellated at — so it reuses the
 	// memoized tessellation rather than re-tessellating (the perf regression watertight must not
 	// reintroduce), adding only the face-pair crossing test.
-	return len(ops.SelfIntersections(res[0], ops.PropertyQuality())) == 0
+	return topologyOK && len(ops.SelfIntersections(res[0], ops.PropertyQuality())) == 0
 }

--- a/model/feature/occtparity/watertight.go
+++ b/model/feature/occtparity/watertight.go
@@ -28,5 +28,15 @@ func isWatertightSolid(res []*topo.Body, filletOK bool, props ops.GeometryProper
 		return false
 	}
 	rep := ops.Validate(res[0])
-	return rep.Valid && rep.Closed && rep.Manifold && rep.HolesContained && res[0].IsSolid()
+	if !(rep.Valid && rep.Closed && rep.Manifold && rep.HolesContained && res[0].IsSolid()) {
+		return false
+	}
+	// ops.Validate is TOPOLOGY-ONLY: a body whose faces are driven straight through each other still
+	// satisfies Valid && Closed && Manifold && HolesContained && IsSolid (#2079 — R8/W9/complex-F2 in
+	// the corpus interpenetrate by 3-15 model units, three orders of magnitude past any tessellation
+	// error). A genuine watertight solid does not self-intersect, so gate on it too. The scan runs at
+	// PropertyQuality — the SAME quality caseProperties already tessellated at — so it reuses the
+	// memoized tessellation rather than re-tessellating (the perf regression watertight must not
+	// reintroduce), adding only the face-pair crossing test.
+	return len(ops.SelfIntersections(res[0], ops.PropertyQuality())) == 0
 }

--- a/model/feature/occtparity/watertight_test.go
+++ b/model/feature/occtparity/watertight_test.go
@@ -44,6 +44,28 @@ func TestIsWatertightSolidAcceptsGenuineSolid(t *testing.T) {
 	}
 }
 
+// TestIsWatertightSolidRejectsInterpenetration is the #2079 regression: R8 and W9 (the deep concave
+// boss-base rims whose R+r cove spills onto the side walls) build a body that is topologically valid —
+// Valid && Closed && Manifold && HolesContained && IsSolid — yet drives the plate face and the side wall
+// straight THROUGH each other (interpenetration 3-15 model units, far past any tessellation error). The
+// old topology-only gate called that watertight; the hardened isWatertightSolid rejects it via the
+// self-intersection scan. The three parts below pin each half: the blind spot, the defect, the fix.
+func TestIsWatertightSolidRejectsInterpenetration(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"R8", "W9"} {
+		res, filletOK, props, ok := rawFilletResult(t, name)
+		if rep := ops.Validate(res[0]); !(rep.Valid && rep.Closed && rep.Manifold && rep.HolesContained && res[0].IsSolid()) {
+			t.Fatalf("%s: expected topology-valid (the #2079 blind spot the old gate trusted); got %+v", name, rep)
+		}
+		if len(ops.SelfIntersections(res[0], ops.PropertyQuality())) == 0 {
+			t.Fatalf("%s: expected a self-intersection (the #2079 defect); found none", name)
+		}
+		if isWatertightSolid(res, filletOK, props, ok) {
+			t.Errorf("%s: isWatertightSolid must REJECT a self-intersecting body, not report it watertight (#2079)", name)
+		}
+	}
+}
+
 // TestTheCorpusHoldsNoCase pins the quarantine list EMPTY — the corpus's last blind spot, closed.
 //
 // WHY THIS IS THE ASSERTION NOW. A quarantined case is SKIPPED by RunCase before it ever builds, so it is

--- a/model/feature/occtparity/watertight_test.go
+++ b/model/feature/occtparity/watertight_test.go
@@ -54,7 +54,9 @@ func TestIsWatertightSolidRejectsInterpenetration(t *testing.T) {
 	t.Parallel()
 	for _, name := range []string{"R8", "W9"} {
 		res, filletOK, props, ok := rawFilletResult(t, name)
-		if rep := ops.Validate(res[0]); !(rep.Valid && rep.Closed && rep.Manifold && rep.HolesContained && res[0].IsSolid()) {
+		rep := ops.Validate(res[0])
+		topologyOK := rep.Valid && rep.Closed && rep.Manifold && rep.HolesContained && res[0].IsSolid()
+		if !topologyOK {
 			t.Fatalf("%s: expected topology-valid (the #2079 blind spot the old gate trusted); got %+v", name, rep)
 		}
 		if len(ops.SelfIntersections(res[0], ops.PropertyQuality())) == 0 {

--- a/model/feature/occtparity/welded_mesh_leak_test.go
+++ b/model/feature/occtparity/welded_mesh_leak_test.go
@@ -243,7 +243,7 @@ func knownMeshLeaks() []meshDebtEntry {
 func knownFoldedMeshes() []meshDebtEntry {
 	return []meshDebtEntry{
 		{"T9", "simple", 6, 15}, // FAIL(faulty) — all on one geom.BSplineSurface
-		{"F2", "complex", 1, 2}, // FAIL(area) — folds but does NOT leak
+		{"F2", "complex", 1, 2}, // FAIL(faulty) since #2079 (self-intersects) — folds but does NOT leak
 	}
 }
 

--- a/model/feature/sheet_metal_corner_seam.go
+++ b/model/feature/sheet_metal_corner_seam.go
@@ -95,14 +95,11 @@ func (f *SheetMetalCornerSeamFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	// Only the gap style removes material from this single-body sheet; the lap/butt styles differ
-	// in which wall laps over the other, which a watertight union cannot express (#2085). Record
-	// the seam and report honestly rather than pass off an unrelieved corner as an overlap.
+	// The gap style cuts a notch on this one body; the butt/lap styles finish the corner where two
+	// flange walls meet, so they build from the walls' bends instead (#2085) — and fall back to an
+	// honest report when there is no bent corner to finish.
 	if f.def.Type != GapSeam {
-		in.Diag.Recordf(codeCornerSeamUnmodeled, diag.Warning,
-			"corner seam %q leaves the corner unrelieved: its lap/butt solid is not modelled yet (#2085); recorded overlap %g%%",
-			f.def.Type, f.def.Overlap)
-		return Output{Bodies: in.Bodies, Heals: heals}, nil
+		return f.finishLapSeam(in, edges, gap, heals)
 	}
 	return f.cutGapSeam(in, body, edges, gap, heals)
 }

--- a/model/feature/sheet_metal_corner_seam_lap.go
+++ b/model/feature/sheet_metal_corner_seam_lap.go
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// CORNER SEAM — lap / butt SOLID geometry (#2085, carved from #1964). The gap style cuts a notch on
+// a single sheet; the other three styles finish the corner where two flange WALLS meet, so they need
+// the two walls modelled as distinct material. That material is exactly what the auto-miter (#1961)
+// already builds from each wall's [BendPlacement], so the seam reuses it:
+//
+//   - no-overlap    → the two walls are carried past the corner and butted (a watertight miter fill);
+//   - overlap(p)    → the butt fill PLUS a proud tab that laps the first wall over the second's outer
+//                     face by the overlap percent, so the finished solid genuinely gains material;
+//   - reverse(p)    → the same tab lapping the OTHER wall, which distinguishes the two on a part
+//                     whose walls differ.
+//
+// A watertight union hides an internal seam (why #1964 deferred this), so the lap is modelled as
+// PROUD material — a tab sitting on the lapped wall's outer face — which the union keeps and which is
+// therefore measurable and monotone in the percent. Without a bend junction there are no two walls to
+// lap, so the feature keeps its honest "unmodelled" report rather than fake a flat-sheet corner.
+
+// seamCornerMatchTol caps how far a selected corner edge may sit from a bend junction and still be
+// finished by it. The vertical corner edge stands over the corner but is offset out by the walls'
+// stand-offs, so the match is generous; the NEAREST junction wins, which keeps a multi-corner part's
+// edges assigned to their own corners.
+const seamCornerMatchTol = 3.0
+
+// lapEmbed is how far the proud lap tab reaches back INTO the lapped wall (in thicknesses) so the
+// Join welds cleanly instead of meeting a coincident face; the embedded part is inside existing
+// material and so adds no volume — only the proud thickness does.
+const lapEmbed = 1.0
+
+// seamCorner pairs a selected corner edge with the bend junction beneath it.
+type seamCorner struct {
+	j    bendJunction
+	edge *topo.Edge
+}
+
+// finishLapSeam models the butt / overlap / reverse-overlap styles as real solid (#2085). It finds
+// the bent corners under the selected edges and finishes each; with no corner it records the
+// deferral honestly, because a lap needs two walls a flat sheet does not have.
+func (f *SheetMetalCornerSeamFeature) finishLapSeam(in Input, edges []*topo.Edge, gap float64,
+	heals []ReferenceHeal) (Output, error) {
+	corners := seamCorners(edges, in.PriorBends)
+	if len(corners) == 0 {
+		in.Diag.Recordf(codeCornerSeamUnmodeled, diag.Warning,
+			"corner seam %q has no bent corner to finish: its lap/butt solid needs two flange walls "+
+				"meeting at a bend junction; recorded overlap %g%%", f.def.Type, f.def.Overlap)
+		return Output{Bodies: in.Bodies, Heals: heals}, nil
+	}
+	out := in.Bodies
+	for i, c := range corners {
+		var err error
+		if out, err = f.finishOneCorner(out, c, gap, i); err != nil {
+			return Output{}, err
+		}
+	}
+	return Output{Bodies: out, Heals: heals}, nil
+}
+
+// finishOneCorner butts the two walls (all styles), laps the tab (overlap styles), and cuts the
+// seam-root relief (when sized), in that order — the butt closes the corner, the tab adds proud
+// material over it, and the relief opens the shared root.
+func (f *SheetMetalCornerSeamFeature) finishOneCorner(bodies []*topo.Body, c seamCorner, gap float64,
+	i int) ([]*topo.Body, error) {
+	feat := seamCornerTag(f.featName, i)
+	out, err := mitreFillAtJunction(bodies, c.j, gap, feat)
+	if err != nil {
+		return nil, err
+	}
+	if tab := f.lapTabFor(c, feat); tab != nil {
+		if out, err = combine(Input{Bodies: out}, tab, ops.Join); err != nil {
+			return nil, err
+		}
+	}
+	tool, err := f.seamReliefTool(c, feat)
+	if err != nil {
+		return nil, err
+	}
+	if tool != nil {
+		if out, err = cutFrom(out, tool); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+// lapTabFor builds the proud lap tab for the current style, or nil for no-overlap. Overlap laps the
+// first-placed wall (j.a) over the second (j.b); reverse-overlap swaps which wall is lapped, so the
+// tab moves to the other face — the one difference between the two styles.
+func (f *SheetMetalCornerSeamFeature) lapTabFor(c seamCorner, feat string) *topo.Body {
+	var lapped BendPlacement
+	switch f.def.Type {
+	case OverlapSeam:
+		lapped = c.j.b
+	case ReverseOverlapSeam:
+		lapped = c.j.a
+	default: // NoOverlapSeam butts the walls with no lap.
+		return nil
+	}
+	return lapTab(c.j, lapped, c.edge, f.def.Overlap, feat)
+}
+
+// seamReliefTool builds the seam-root relief cut when a relief size is given, reusing the corner-
+// relief infrastructure (#2072). No size, or a tear shape, means no cut.
+func (f *SheetMetalCornerSeamFeature) seamReliefTool(c seamCorner, feat string) (*topo.Body, error) {
+	if f.def.ReliefSize == nil {
+		return nil, nil
+	}
+	spec := CornerReliefSpec{Shape: f.def.ReliefShape, Size: evalFloat(f.def.ReliefSize)}
+	if !spec.cuts() {
+		return nil, nil
+	}
+	reach, err := cornerReach(c.j, spec)
+	if err != nil {
+		return nil, err
+	}
+	return cornerReliefTool(c.j, spec, reach, feat+"/seamRelief")
+}
+
+// lapTab is the proud tab that laps one wall over the lapped wall's FLAT outer face: a slab lying on
+// that face, extending along the lapped wall's run from the corner by the overlap fraction of its
+// stand-off, spanning the vertical face, and proud of the face by one thickness. The embedded root
+// (lapEmbed thicknesses inward) welds it to the wall without adding volume, so the finished solid
+// gains exactly thickness × lapLength × faceHeight — measurable and monotone in the percent.
+//
+// The tab must sit on the FLAT face only: the band curves through its bend near the base, so a tab
+// carried down to the bend line juts into the concave corner and adds wall-independent bulk that
+// hides the lap. The selected corner edge is the flat face's vertical edge, so its span sets where
+// the tab starts and how tall it is — clear of the arc.
+func lapTab(j bendJunction, lapped BendPlacement, edge *topo.Edge, overlapPct float64,
+	feat string) *topo.Body {
+	lapLen := overlapPct / 100 * wallStandOff(lapped)
+	if lapLen <= 0 {
+		return nil
+	}
+	away, err := awayFromCorner(j.at, lapped)
+	if err != nil {
+		return nil
+	}
+	// A horizontal in-face axis (Up × Outward) so the tab plane's Y is exactly Up; the run axis then
+	// points toward the wall (runSign) rather than off its free end.
+	ref, err := math.UnitVector3FromVector(lapped.Up.Cross(lapped.Outward))
+	if err != nil {
+		return nil
+	}
+	runSign := signOf(float64(ref.AsVector().Dot(away.AsVector())))
+	start, height := edgeVerticalSpan(edge, j.at, lapped.Up)
+	if height <= 0 {
+		return nil
+	}
+	origin := j.at.TranslateBy(lapped.Up.AsVector().Scale(start))
+	plane := planeFromFrame(origin, lapped.Outward, ref)
+	poly := ensureCCW2([]math.Point2{
+		math.P2(0, 0), math.P2(lapLen*runSign, 0), math.P2(lapLen*runSign, height), math.P2(0, height),
+	})
+	standOff, t := wallStandOff(lapped), lapped.Thickness
+	return buildPrism(poly, plane, span{near: standOff - lapEmbed*t, far: standOff + t}, 0, feat+"/lap")
+}
+
+// edgeVerticalSpan returns where the corner edge starts above the junction along the wall's up
+// direction and how tall it is — the flat vertical face the lap tab lies on.
+func edgeVerticalSpan(edge *topo.Edge, at math.Point3, up math.UnitVector3) (start, height float64) {
+	h0 := float64(at.VectorTo(edge.StartVertex().Point()).Dot(up.AsVector()))
+	h1 := float64(at.VectorTo(edge.EndVertex().Point()).Dot(up.AsVector()))
+	if h0 > h1 {
+		h0, h1 = h1, h0
+	}
+	return h0, h1 - h0
+}
+
+// signOf is +1 for a non-negative value and -1 otherwise.
+func signOf(x float64) float64 {
+	if x < 0 {
+		return -1
+	}
+	return 1
+}
+
+// seamCornerTag names one corner's tool bodies uniquely within the feature.
+func seamCornerTag(feat string, i int) string { return fmt.Sprintf("%s/c%d", feat, i) }
+
+// seamCorners matches each selected corner edge to the bend junction it stands over, finishing each
+// junction ONCE: the two walls of a corner share several vertical edges, and all of them resolve to
+// the same corner, so the first match wins and the rest are dropped.
+func seamCorners(edges []*topo.Edge, prior []BendPlacement) []seamCorner {
+	junctions := allBendJunctions(prior)
+	out := make([]seamCorner, 0, len(edges))
+	seen := map[string]bool{}
+	for _, e := range edges {
+		j, ok := junctionOnEdge(e, junctions)
+		if !ok {
+			continue
+		}
+		key := fmt.Sprintf("%.4f,%.4f,%.4f", j.at.X, j.at.Y, j.at.Z)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, seamCorner{j: j, edge: e})
+	}
+	return out
+}
+
+// allBendJunctions returns every corner among the placed bends: each non-parallel pair whose bend
+// lines share an end, with the earlier-placed bend as a. It complements findBendJunction (one bend
+// vs the rest) for the corner seam, which owns no bend and must find the corners from the walls.
+func allBendJunctions(prior []BendPlacement) []bendJunction {
+	var out []bendJunction
+	for i := 0; i < len(prior); i++ {
+		for k := i + 1; k < len(prior); k++ {
+			if parallelBends(prior[i], prior[k]) {
+				continue
+			}
+			if at, ok := sharedEnd(prior[i], prior[k]); ok {
+				out = append(out, bendJunction{at: at, a: prior[i], b: prior[k]})
+			}
+		}
+	}
+	return out
+}
+
+// junctionOnEdge picks the bend junction nearest the corner edge's horizontal footprint: the
+// vertical edge stands over the corner, offset out by the walls' stand-offs, so the closest corner
+// (within seamCornerMatchTol) is the one this seam finishes.
+func junctionOnEdge(e *topo.Edge, junctions []bendJunction) (bendJunction, bool) {
+	mid := e.StartVertex().Point().Midpoint(e.EndVertex().Point())
+	best, bestD := -1, seamCornerMatchTol
+	for i, j := range junctions {
+		if d := stdmath.Hypot(float64(j.at.X-mid.X), float64(j.at.Y-mid.Y)); d < bestD {
+			bestD, best = d, i
+		}
+	}
+	if best < 0 {
+		return bendJunction{}, false
+	}
+	return junctions[best], true
+}

--- a/model/feature/sheet_metal_corner_seam_lap_test.go
+++ b/model/feature/sheet_metal_corner_seam_lap_test.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/topo"
+)
+
+// Corner-seam lap / butt SOLID geometry (#2085). These drive the two-flange open corner the seam
+// finishes, and MEASURE the result — a butt fill that closes the corner, a proud lap tab that grows
+// with the overlap percent, and the two lap styles differing by which wall is lapped — because a
+// plausible watertight solid is not enough (the tranche's measured-check rule).
+
+// twoFlangeCorner folds two flanges on adjacent edges of a square sheet, leaving the corner between
+// them OPEN (no auto-miter), and returns the engine plus the walls' vertical corner edges — the
+// fixture the corner-seam lap/butt styles finish. Separate radii give the two walls different stand-
+// offs so overlap and reverse-overlap lap by different amounts and can be told apart by volume.
+func twoFlangeCorner(t *testing.T, radiusX, radiusY float64) (*PartFeatures, []*topo.Edge) {
+	t.Helper()
+	fs, edgeX := seedSheetMetalSheet(t, 4, nil)
+	fs.SetReliefSpec(func() ReliefSpec { return ReliefSpec{} })
+	fs.SetCornerReliefSpec(func() CornerReliefSpec { return CornerReliefSpec{Shape: types.CornerTear} })
+	flanges := NewSheetMetalFlangeFeatures(fs)
+	flanges.Add(&SheetMetalFlangeDefinition{
+		EdgeKey: edgeX.ReferenceKey(), Height: constClosure(1.0), Radius: constClosure(radiusX),
+	})
+	fs.Recompute()
+	edgeY := adjacentTopEdge(t, fs.Result()[0], edgeX)
+	flanges.Add(&SheetMetalFlangeDefinition{
+		EdgeKey: edgeY.ReferenceKey(), Height: constClosure(1.0), Radius: constClosure(radiusY),
+	})
+	fs.Recompute()
+	return fs, verticalCornerEdges(t, fs.Result()[0])
+}
+
+// addCornerSeam attaches a corner seam of the given style to the engine and recomputes.
+func addCornerSeam(t *testing.T, fs *PartFeatures, edges []*topo.Edge, seam SeamType, overlap float64) *PartFeature {
+	t.Helper()
+	pf := NewSheetMetalCornerSeamFeatures(fs).Add(&SheetMetalCornerSeamDefinition{
+		EdgeKeys: edgeKeys(edges), Gap: constClosure(0.05), Type: seam, Overlap: overlap,
+	})
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("%v corner seam sick: %+v", seam, pf.Health())
+	}
+	return pf
+}
+
+// edgeKeys collects the reference keys of a set of edges.
+func edgeKeys(edges []*topo.Edge) [][]byte {
+	keys := make([][]byte, len(edges))
+	for i, e := range edges {
+		keys[i] = e.ReferenceKey()
+	}
+	return keys
+}
+
+// TestCornerSeamNoOverlapButtsTheWalls: the no-overlap style carries both walls past the corner and
+// butts them into a watertight solid — material the open corner did not have — and no longer reports
+// the deferral, because the corner is now modelled.
+func TestCornerSeamNoOverlapButtsTheWalls(t *testing.T) {
+	fs, edges := twoFlangeCorner(t, 0.3, 0.3)
+	openVol := smSolidVolume(fs.Result()[0])
+	pf := addCornerSeam(t, fs, edges, NoOverlapSeam, 0)
+	body := fs.Result()[0]
+	assertWatertightSolid(t, body)
+	if hasDiagCode(pf.Diagnostics(), codeCornerSeamUnmodeled) {
+		t.Errorf("no-overlap seam is modelled now and must not report %q: %v", codeCornerSeamUnmodeled, pf.Diagnostics())
+	}
+	if got := smSolidVolume(body); !(got > openVol) {
+		t.Errorf("no-overlap butt volume %.4f did not fill the open corner %.4f", got, openVol)
+	}
+}
+
+// TestCornerSeamOverlapAddsProudTab: the overlap style adds a proud tab on top of the no-overlap
+// butt, so its volume is strictly greater, and the tab grows with the overlap percent. The added
+// material is measured against the analytic tab thickness × lapLength × height.
+func TestCornerSeamOverlapAddsProudTab(t *testing.T) {
+	butt := seamVolume(t, NoOverlapSeam, 0, 0.3, 0.3)
+	lap40 := seamVolume(t, OverlapSeam, 40, 0.3, 0.3)
+	lap80 := seamVolume(t, OverlapSeam, 80, 0.3, 0.3)
+	if !(lap40 > butt) {
+		t.Errorf("overlap(40%%) %.4f is not proud of the butt %.4f — no lap was added", lap40, butt)
+	}
+	if !(lap80 > lap40) {
+		t.Errorf("lap is not monotone: overlap(80%%) %.4f <= overlap(40%%) %.4f", lap80, lap40)
+	}
+	// Analytic proud tab = thickness 0.2 × lapLength (percent·standOff, standOff=radius+thickness=0.5)
+	// × the flat-face height 1.0. The lap must match it, and halving the percent must halve the tab.
+	const t0, standOff, height = 0.2, 0.5, 1.0
+	tab := func(pct float64) float64 { return t0 * (pct / 100 * standOff) * height }
+	if got := lap80 - butt; stdmath.Abs(got-tab(80)) > 0.008 {
+		t.Errorf("overlap(80%%) added %.4f cm³, want the analytic tab %.4f", got, tab(80))
+	}
+	if got := lap40 - butt; stdmath.Abs(got-tab(40)) > 0.008 {
+		t.Errorf("overlap(40%%) added %.4f cm³, want the analytic tab %.4f", got, tab(40))
+	}
+}
+
+// TestCornerSeamOverlapVsReverseLapDifferentWalls: overlap laps the first wall over the second and
+// reverse-overlap laps the other way. With the two walls at different radii the lapped wall's stand-
+// off differs, so the two styles add different tabs — proof the choice of lapping wall is honoured,
+// not just recorded.
+func TestCornerSeamOverlapVsReverseLapDifferentWalls(t *testing.T) {
+	// Wall a (radius 0.3, stand-off 0.5) is placed first, wall b (radius 0.6, stand-off 0.8) second.
+	// Overlap laps a over b — the tab sits on b's wider face; reverse laps b over a — the smaller
+	// tab sits on a. So overlap must add strictly MORE than reverse, by the stand-off difference.
+	over := seamVolume(t, OverlapSeam, 80, 0.3, 0.6)
+	reverse := seamVolume(t, ReverseOverlapSeam, 80, 0.3, 0.6)
+	if !(over-reverse > 0.02) {
+		t.Errorf("overlap %.4f is not proud of reverse-overlap %.4f by the lapped-wall stand-off — "+
+			"the lapping wall was ignored", over, reverse)
+	}
+}
+
+// TestCornerSeamRootReliefIsCut: a sized seam-root relief opens the corner where the two bends meet,
+// so a relieved overlap seam has less material than the same seam with no relief.
+func TestCornerSeamRootReliefIsCut(t *testing.T) {
+	noRelief := seamVolume(t, OverlapSeam, 80, 0.3, 0.3)
+	fs, edges := twoFlangeCorner(t, 0.3, 0.3)
+	pf := NewSheetMetalCornerSeamFeatures(fs).Add(&SheetMetalCornerSeamDefinition{
+		EdgeKeys: edgeKeys(edges), Gap: constClosure(0.05), Type: OverlapSeam, Overlap: 80,
+		ReliefShape: types.CornerSquare, ReliefSize: constClosure(0.2),
+	})
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("relieved overlap seam sick: %+v", pf.Health())
+	}
+	relieved := smSolidVolume(fs.Result()[0])
+	if !(relieved < noRelief) {
+		t.Errorf("seam-root relief removed nothing: relieved %.4f vs unrelieved %.4f", relieved, noRelief)
+	}
+}
+
+// seamVolume builds a two-flange corner, finishes it with the given seam, and returns the solid's
+// volume — the shared measurement for the lap/butt tests.
+func seamVolume(t *testing.T, seam SeamType, overlap, radiusX, radiusY float64) float64 {
+	t.Helper()
+	fs, edges := twoFlangeCorner(t, radiusX, radiusY)
+	addCornerSeam(t, fs, edges, seam, overlap)
+	return smSolidVolume(fs.Result()[0])
+}

--- a/model/feature/sheet_metal_corner_seam_test.go
+++ b/model/feature/sheet_metal_corner_seam_test.go
@@ -68,10 +68,11 @@ func TestParseSeamType(t *testing.T) {
 	}
 }
 
-// TestCornerSeamOverlapDeferred a non-gap seam is a valid, healthy feature that records its
-// intent but does NOT remove material yet: the lap/butt solid is a follow-up (#2085), so the
-// feature reports an "unmodelled" diagnostic and leaves the sheet's volume untouched.
-func TestCornerSeamOverlapDeferred(t *testing.T) {
+// TestCornerSeamOverlapOnFlatSheetIsUnmodelled a non-gap seam on a FLAT sheet has no two flange
+// walls to lap, so its lap/butt solid (#2085) cannot be built there: the feature stays healthy,
+// leaves the volume untouched, and reports the "unmodelled" diagnostic honestly. (The modelled lap
+// on a real two-flange corner is exercised in sheet_metal_corner_seam_lap_test.go.)
+func TestCornerSeamOverlapOnFlatSheetIsUnmodelled(t *testing.T) {
 	fs, _ := seedSheetMetalSheet(t, 4, nil)
 	edge := verticalCornerEdge(t, fs.Result()[0])
 	pf := NewSheetMetalCornerSeamFeatures(fs).Add(&SheetMetalCornerSeamDefinition{

--- a/model/feature/sheet_metal_lofted_flange.go
+++ b/model/feature/sheet_metal_lofted_flange.go
@@ -80,15 +80,14 @@ func (f *SheetMetalLoftedFlangeFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	// The output type (die-formed / press-brake facets) IS modelled; converge and the end-bend
-	// radius are recorded but their solid is a follow-up (#2086), so report rather than pass off a
-	// sharp-cornered wall as converged.
-	if f.def.Converge || evalFloat(f.def.Radius) > 0 {
+	// Converge (corner pinch) is a follow-up increment (#2086); the end-bend radius IS modelled
+	// below, so only converge still reports here.
+	if f.def.Converge {
 		in.Diag.Recordf(codeLoftedFlangeUnmodeled, diag.Warning,
-			"lofted flange: converge=%v and end-bend radius are recorded but not modelled yet (#2086)", f.def.Converge)
+			"lofted flange: converge is recorded but its corner-pinch solid is not modelled yet (#2086)")
 	}
-	sections := loftedFlangeSections(bandA, bandB, f.def.ProfileA.Plane().Normal(),
-		f.def.ProfileB.Plane().Normal(), f.def.Output, f.def.FacetTolerance)
+	nA, nB := f.def.ProfileA.Plane().Normal(), f.def.ProfileB.Plane().Normal()
+	sections := f.transitionSections(bandA, bandB, nA, nB)
 	wall, err := sweptSolid(sections, false, featOr(f.featName, "loftedFlange"))
 	if err != nil {
 		return Output{}, fmt.Errorf("sheet-metal lofted flange: %w", err)
@@ -98,6 +97,16 @@ func (f *SheetMetalLoftedFlangeFeature) Recompute(in Input) (Output, error) {
 		return Output{}, err
 	}
 	return Output{Bodies: bodies}, nil
+}
+
+// transitionSections builds the loft sections between the two bands: a rounded end bend (lip + fold)
+// when a bend radius is set, otherwise the plain profile-to-profile die-formed / press-brake wall.
+func (f *SheetMetalLoftedFlangeFeature) transitionSections(bandA, bandB []math.Point3,
+	nA, nB math.UnitVector3) [][]math.Point3 {
+	if r := evalFloat(f.def.Radius); r > 0 {
+		return endBendSections(bandA, bandB, nA, nB, r, f.def.Output, f.def.FacetTolerance)
+	}
+	return loftedFlangeSections(bandA, bandB, nA, nB, f.def.Output, f.def.FacetTolerance)
 }
 
 // loftBands thickens both profiles into their 3D bands, erroring when a profile cannot be read or

--- a/model/feature/sheet_metal_lofted_flange.go
+++ b/model/feature/sheet_metal_lofted_flange.go
@@ -8,14 +8,18 @@ import (
 	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/diag"
 	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 	"oblikovati.org/model/param"
 	"oblikovati.org/model/sketch"
 )
 
-// codeLoftedFlangeUnmodeled marks a lofted flange whose converge / end-bend-radius solid is not
-// modelled yet (#2086).
+// codeLoftedFlangeUnmodeled marks a lofted flange whose converge input found nothing to model (#2086).
 const codeLoftedFlangeUnmodeled diag.Code = "sheet-metal.lofted-flange-unmodeled"
+
+// codeLoftedFlangeLipDropped marks an end-bend radius whose flat lip would self-intersect on this
+// profile, so only the rounded fold was kept (#2086).
+const codeLoftedFlangeLipDropped diag.Code = "sheet-metal.lofted-flange-lip-dropped"
 
 // Sheet-metal Lofted Flange feature (M13-F02). A lofted flange is a constant-thickness wall
 // that transitions between TWO open profiles on two sketch planes — the sheet-metal way to
@@ -89,8 +93,7 @@ func (f *SheetMetalLoftedFlangeFeature) Recompute(in Input) (Output, error) {
 		bandB = converged
 	}
 	nA, nB := f.def.ProfileA.Plane().Normal(), f.def.ProfileB.Plane().Normal()
-	sections := f.transitionSections(bandA, bandB, nA, nB)
-	wall, err := sweptSolid(sections, false, featOr(f.featName, "loftedFlange"))
+	wall, err := f.buildTransitionWall(bandA, bandB, nA, nB, in.Diag)
 	if err != nil {
 		return Output{}, fmt.Errorf("sheet-metal lofted flange: %w", err)
 	}
@@ -101,15 +104,31 @@ func (f *SheetMetalLoftedFlangeFeature) Recompute(in Input) (Output, error) {
 	return Output{Bodies: bodies}, nil
 }
 
-// transitionSections builds the loft sections between the two bands: a rounded end bend (lip + fold)
-// when a bend radius is set, otherwise the plain profile-to-profile die-formed / press-brake wall.
+// buildTransitionWall skins the wall between the two bands. Without a bend radius it is the plain
+// profile-to-profile die-formed / press-brake wall; with one it is the rounded end bend (lip + fold).
 // Converge, when on, has already retargeted bandB's corners.
-func (f *SheetMetalLoftedFlangeFeature) transitionSections(bandA, bandB []math.Point3,
-	nA, nB math.UnitVector3) [][]math.Point3 {
-	if r := evalFloat(f.def.Radius); r > 0 {
-		return endBendSections(bandA, bandB, nA, nB, r, f.def.Output, f.def.FacetTolerance)
+func (f *SheetMetalLoftedFlangeFeature) buildTransitionWall(bandA, bandB []math.Point3,
+	nA, nB math.UnitVector3, rec *diag.Recorder) (*topo.Body, error) {
+	feat := featOr(f.featName, "loftedFlange")
+	r := evalFloat(f.def.Radius)
+	if r <= 0 {
+		return sweptSolid(loftedFlangeSections(bandA, bandB, nA, nB, f.def.Output, f.def.FacetTolerance), false, feat)
 	}
-	return loftedFlangeSections(bandA, bandB, nA, nB, f.def.Output, f.def.FacetTolerance)
+	return f.buildRoundedWall(bandA, bandB, nA, nB, r, feat, rec)
+}
+
+// buildRoundedWall prefers the flat lip + fold, but the lip is an inward offset of the thickened
+// band, so at a tight radius it can self-intersect. When it does, the wall falls back to the fold
+// alone (always valid) and reports it, rather than ship a self-intersecting solid (#2086).
+func (f *SheetMetalLoftedFlangeFeature) buildRoundedWall(bandA, bandB []math.Point3,
+	nA, nB math.UnitVector3, r float64, feat string, rec *diag.Recorder) (*topo.Body, error) {
+	withLip, err := sweptSolid(endBendSections(bandA, bandB, nA, nB, r, r, f.def.Output, f.def.FacetTolerance), false, feat)
+	if err == nil && len(ops.SelfIntersections(withLip, ops.DefaultQuality())) == 0 {
+		return withLip, nil
+	}
+	rec.Recordf(codeLoftedFlangeLipDropped, diag.Warning,
+		"lofted flange: the flat end-bend lip would self-intersect at radius %g; kept the rounded fold without the lip (#2086)", r)
+	return sweptSolid(endBendSections(bandA, bandB, nA, nB, r, 0, f.def.Output, f.def.FacetTolerance), false, feat)
 }
 
 // loftBands thickens both profiles into their 3D bands, erroring when a profile cannot be read or

--- a/model/feature/sheet_metal_lofted_flange.go
+++ b/model/feature/sheet_metal_lofted_flange.go
@@ -80,11 +80,13 @@ func (f *SheetMetalLoftedFlangeFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	// Converge (corner pinch) is a follow-up increment (#2086); the end-bend radius IS modelled
-	// below, so only converge still reports here.
 	if f.def.Converge {
-		in.Diag.Recordf(codeLoftedFlangeUnmodeled, diag.Warning,
-			"lofted flange: converge is recorded but its corner-pinch solid is not modelled yet (#2086)")
+		converged, n := convergeCorners(bandA, bandB)
+		if n == 0 {
+			in.Diag.Recordf(codeLoftedFlangeUnmodeled, diag.Warning,
+				"lofted flange: converge is on but the profiles have no corners to pinch (#2086)")
+		}
+		bandB = converged
 	}
 	nA, nB := f.def.ProfileA.Plane().Normal(), f.def.ProfileB.Plane().Normal()
 	sections := f.transitionSections(bandA, bandB, nA, nB)
@@ -101,6 +103,7 @@ func (f *SheetMetalLoftedFlangeFeature) Recompute(in Input) (Output, error) {
 
 // transitionSections builds the loft sections between the two bands: a rounded end bend (lip + fold)
 // when a bend radius is set, otherwise the plain profile-to-profile die-formed / press-brake wall.
+// Converge, when on, has already retargeted bandB's corners.
 func (f *SheetMetalLoftedFlangeFeature) transitionSections(bandA, bandB []math.Point3,
 	nA, nB math.UnitVector3) [][]math.Point3 {
 	if r := evalFloat(f.def.Radius); r > 0 {

--- a/model/feature/sheet_metal_lofted_flange_converge.go
+++ b/model/feature/sheet_metal_lofted_flange_converge.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// Lofted-flange CONVERGE (#2086, carved from #1966). By default a cornered profile carries its
+// corners through the whole transition, so a square-to-round wall keeps a rounded corner tube all the
+// way across. Inventor's Converge pinches each corner to a point at the far profile instead: the two
+// panels meeting at the corner run to a sharp edge that converges away, removing the carried-through
+// corner material.
+//
+// It is modelled by retargeting each corner's far end. A corner band point normally lofts to its own
+// far-profile point; converged, it lofts to the midpoint of its two neighbours' far points, which
+// lies on the straight edge between them — so the corner protrusion tapers from full at the near
+// profile to flush (a point on the panel line) at the far one.
+
+// convergeTurnLo / convergeTurnHi bound the turning angle that counts as a corner: sharp enough to be
+// a real corner (a straight run turns ~0), but short of the ~180° reversal at an open profile's
+// thickness caps, which are not corners to converge.
+const (
+	convergeTurnLo = stdmath.Pi / 3    // 60°
+	convergeTurnHi = stdmath.Pi * 0.95 // 171°
+)
+
+// convergeCorners returns a copy of the far band whose corner points (found on the near band) are
+// moved to the midpoint of their neighbours, so each corner tapers to a flush point at the far
+// profile, and how many corners it pinched. The near band is unchanged, so the corners stay full
+// where the wall meets it. A count of zero means the profiles have no corners to converge.
+func convergeCorners(nearBand, farBand []math.Point3) ([]math.Point3, int) {
+	out := append([]math.Point3(nil), farBand...)
+	n, count := len(nearBand), 0
+	for i := range nearBand {
+		if isConvergingCorner(nearBand, i) {
+			out[i] = farBand[(i-1+n)%n].Midpoint(farBand[(i+1)%n])
+			count++
+		}
+	}
+	return out, count
+}
+
+// isConvergingCorner reports whether band point i turns sharply enough to be a corner that converges.
+func isConvergingCorner(band []math.Point3, i int) bool {
+	n := len(band)
+	in := band[(i-1+n)%n].VectorTo(band[i])
+	out := band[i].VectorTo(band[(i+1)%n])
+	turn := angleBetween(in, out)
+	return turn > convergeTurnLo && turn < convergeTurnHi
+}

--- a/model/feature/sheet_metal_lofted_flange_converge_test.go
+++ b/model/feature/sheet_metal_lofted_flange_converge_test.go
@@ -68,8 +68,8 @@ func TestLoftedFlangeConvergeRemovesCornerMaterial(t *testing.T) {
 		if hasDiagCode(pf.Diagnostics(), codeLoftedFlangeUnmodeled) {
 			unmodelled = 1
 		}
-		return ops.BodyGeometryProperties(body, ops.Quality{ChordTolerance: 1e-3}).Volume,
-			ops.Validate(body).Valid, unmodelled
+		valid, _ := ops.ValidateBodyEntities(body, ops.CheckGeometry, ops.DefaultQuality())
+		return ops.BodyGeometryProperties(body, ops.Quality{ChordTolerance: 1e-3}).Volume, valid, unmodelled
 	}
 	ref, refValid, _ := build(false)
 	conv, convValid, unmodelled := build(true)

--- a/model/feature/sheet_metal_lofted_flange_converge_test.go
+++ b/model/feature/sheet_metal_lofted_flange_converge_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// Lofted-flange converge (#2086). Converge pinches the cornered profile's corners to points at the
+// far profile, so it must (a) retarget exactly the corner points to their neighbour midpoints and
+// (b) remove the carried-through corner material — a measurably smaller wall than the un-converged
+// reference.
+
+// TestConvergeCornersRetargetsOnlyCorners a square near band has four 90° corners, so converge moves
+// exactly those four far points to their neighbour midpoints and leaves a smooth (many-sided) band
+// untouched.
+func TestConvergeCornersRetargetsOnlyCorners(t *testing.T) {
+	square := []math.Point3{math.P3(0, 0, 0), math.P3(2, 0, 0), math.P3(2, 2, 0), math.P3(0, 2, 0)}
+	farSquare := []math.Point3{math.P3(-1, -1, 3), math.P3(3, -1, 3), math.P3(3, 3, 3), math.P3(-1, 3, 3)}
+	got, count := convergeCorners(square, farSquare)
+	if count != 4 {
+		t.Fatalf("converge pinched %d corners, want 4", count)
+	}
+	// Corner 1 (index 1) must move to the midpoint of far corners 0 and 2.
+	want := farSquare[0].Midpoint(farSquare[2])
+	if d := float64(got[1].DistanceTo(want)); d > 1e-9 {
+		t.Errorf("converged corner 1 at %v, want the neighbour midpoint %v (off %.4f)", got[1], want, d)
+	}
+	// A smooth many-sided ring turns too gently to have corners: nothing converges.
+	ring := regularRing(24, 2, 0)
+	if _, c := convergeCorners(ring, regularRing(24, 3, 3)); c != 0 {
+		t.Errorf("a smooth 24-gon converged %d corners, want 0", c)
+	}
+}
+
+// regularRing is an m-gon of radius r in the z-plane — a stand-in for a rounded profile.
+func regularRing(m int, r, z float64) []math.Point3 {
+	pts := make([]math.Point3, m)
+	for k := 0; k < m; k++ {
+		a := 2 * stdmath.Pi * float64(k) / float64(m)
+		pts[k] = math.P3(r*stdmath.Cos(a), r*stdmath.Sin(a), z)
+	}
+	return pts
+}
+
+// TestLoftedFlangeConvergeRemovesCornerMaterial a converged wall pinches the profile corners to
+// points, so it holds less material than the same wall carried through un-converged, stays a valid
+// watertight solid, and no longer reports the deferral.
+func TestLoftedFlangeConvergeRemovesCornerMaterial(t *testing.T) {
+	build := func(converge bool) (float64, bool, int) {
+		planeB, _ := sketch.NewPlane(math.P3(0, 0, 3), math.V3(1, 0, 0).AsUnit(), math.V3(0, 1, 0).AsUnit())
+		fs := NewPartFeatures(thicknessParams(t))
+		pf := NewSheetMetalLoftedFlangeFeatures(fs).Add(&SheetMetalLoftedFlangeDefinition{
+			ProfileA: lProfileOnPlane(sketch.XYPlane(), 1, 1), ProfileB: lProfileOnPlane(planeB, 2, 2),
+			Operation: ops.NewBody, Converge: converge,
+		})
+		fs.Recompute()
+		if !pf.Health().OK() {
+			t.Fatalf("lofted flange (converge=%v) sick: %+v", converge, pf.Health())
+		}
+		body := fs.Result()[0]
+		unmodelled := 0
+		if hasDiagCode(pf.Diagnostics(), codeLoftedFlangeUnmodeled) {
+			unmodelled = 1
+		}
+		return ops.BodyGeometryProperties(body, ops.Quality{ChordTolerance: 1e-3}).Volume,
+			ops.Validate(body).Valid, unmodelled
+	}
+	ref, refValid, _ := build(false)
+	conv, convValid, unmodelled := build(true)
+	if !refValid || !convValid {
+		t.Fatalf("invalid solids: reference valid=%v, converged valid=%v", refValid, convValid)
+	}
+	if !(conv < ref) {
+		t.Errorf("converge did not remove corner material: converged %.4f, reference %.4f", conv, ref)
+	}
+	if unmodelled != 0 {
+		t.Errorf("a converged wall with corners must not report %q", codeLoftedFlangeUnmodeled)
+	}
+}

--- a/model/feature/sheet_metal_lofted_flange_endbend.go
+++ b/model/feature/sheet_metal_lofted_flange_endbend.go
@@ -20,11 +20,11 @@ import (
 const endBendFoldSamples = 6
 
 // endBendSections builds the loft sections for a lofted flange with a rounded end bend of radius r.
-// The middle keeps the die-formed / press-brake behaviour (its section count comes from the same
-// tolerance logic), sampled between the fold ends rather than the profiles.
-func endBendSections(bandA, bandB []math.Point3, nA, nB math.UnitVector3, r float64,
+// lipLen is how far the flat lip extends before the fold (0 ⇒ the fold alone, no lip). The middle
+// keeps the die-formed / press-brake behaviour (its section count comes from the same tolerance
+// logic), sampled between the fold ends rather than the profiles.
+func endBendSections(bandA, bandB []math.Point3, nA, nB math.UnitVector3, r, lipLen float64,
 	output LoftedFlangeOutputType, tol float64) [][]math.Point3 {
-	lipLen := r // a short lip, as long as the bend radius
 	cA, cB := centroid(bandA), centroid(bandB)
 	ends := make([]endBend, len(bandA))
 	for i := range bandA {

--- a/model/feature/sheet_metal_lofted_flange_endbend.go
+++ b/model/feature/sheet_metal_lofted_flange_endbend.go
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// Lofted-flange END-BEND RADIUS (#2086, carved from #1966). Without a bend radius the transition
+// wall leaves each profile perpendicular to its plane, meeting it at a sharp knuckle. A bend radius
+// rounds that end bend: the wall gains a short flat LIP lying in the profile plane, then a true
+// circular FOLD of the radius turns the lip up into the transition, exactly as a flange bends off a
+// face. Each corresponding band point therefore traces a composite path — lipA → foldA → the
+// die-formed / press-brake middle → foldB → lipB — all sharing one sample partition so the points
+// still transpose into corresponding loft sections.
+
+// endBendFoldSamples is how many segments each quarter-fold arc is sampled into.
+const endBendFoldSamples = 6
+
+// endBendSections builds the loft sections for a lofted flange with a rounded end bend of radius r.
+// The middle keeps the die-formed / press-brake behaviour (its section count comes from the same
+// tolerance logic), sampled between the fold ends rather than the profiles.
+func endBendSections(bandA, bandB []math.Point3, nA, nB math.UnitVector3, r float64,
+	output LoftedFlangeOutputType, tol float64) [][]math.Point3 {
+	lipLen := r // a short lip, as long as the bend radius
+	cA, cB := centroid(bandA), centroid(bandB)
+	ends := make([]endBend, len(bandA))
+	for i := range bandA {
+		a1A := inPlaneOutward(nA, bandNeighbourTangent(bandA, i), cA.VectorTo(bandA[i]))
+		a1B := inPlaneOutward(nB, bandNeighbourTangent(bandB, i), cB.VectorTo(bandB[i]))
+		ends[i] = newEndBend(bandA[i], bandB[i], nA, nB, r, lipLen, a1A, a1B)
+	}
+	mid := loftSectionCount(middleCurves(ends), output, tol)
+	return assembleEndBendSections(ends, mid)
+}
+
+// endBend holds one band point's composite-path geometry: the flat-lip outer ends, the two sampled
+// fold arcs, and the fold ends where each fold hands off to the middle transition.
+type endBend struct {
+	lipOutA, lipOutB math.Point3
+	arcA, arcB       []math.Point3 // arcA: p0→ea; arcB: eb→p1 (already oriented for the path)
+	ea, eb           math.Point3
+	nA, nB           math.UnitVector3
+}
+
+// newEndBend resolves one band point's composite path. The wall leaves A along u0 (its plane normal
+// oriented toward B) and folds up from the in-plane lip over radius r; B mirrors it, with the fold
+// built by running it backward from the profile so it joins the middle without a kink.
+func newEndBend(p0, p1 math.Point3, nA, nB math.UnitVector3, r, lipLen float64,
+	a1A, a1B math.Vector3) endBend {
+	chord := p0.VectorTo(p1)
+	u0 := unitOr(orientedTangent(nA, chord), nA.AsVector())
+	w1 := unitOr(orientedTangent(nB, chord), nB.AsVector())
+	arcA, ea := foldArc(p0, a1A.Negate(), u0, r, endBendFoldSamples)
+	// B's fold from the profile up into the transition, run backward (p1→eb), then reversed so the
+	// path enters it heading +w1 to match the middle's arrival.
+	arcBback, eb := foldArc(p1, a1B.Negate(), w1.Negate(), r, endBendFoldSamples)
+	return endBend{
+		lipOutA: p0.TranslateBy(a1A.Scale(math.Scalar(lipLen))),
+		lipOutB: p1.TranslateBy(a1B.Scale(math.Scalar(lipLen))),
+		arcA:    arcA, arcB: reversePoints(arcBback),
+		ea: ea, eb: eb, nA: nA, nB: nB,
+	}
+}
+
+// middleCurves are the die-formed Hermite curves between the two fold ends — the same construction
+// as the profile-to-profile bundle, so the middle's faceting logic is unchanged.
+func middleCurves(ends []endBend) []hermiteCurve {
+	if len(ends) == 0 {
+		return nil
+	}
+	ea := make([]math.Point3, len(ends))
+	eb := make([]math.Point3, len(ends))
+	for i, e := range ends {
+		ea[i], eb[i] = e.ea, e.eb
+	}
+	return hermiteBundle(ea, eb, ends[0].nA, ends[0].nB)
+}
+
+// assembleEndBendSections samples every band point's composite path at the shared partition and
+// transposes the samples into loft sections: lip A, fold A, the mid-1 middle interiors, fold B, lip
+// B. The fold ends ea/eb are shared with the middle, so they are not sampled twice.
+func assembleEndBendSections(ends []endBend, mid int) [][]math.Point3 {
+	paths := make([][]math.Point3, len(ends))
+	middle := middleCurves(ends)
+	for i, e := range ends {
+		path := []math.Point3{e.lipOutA}
+		path = append(path, e.arcA...) // p0 … ea
+		for j := 1; j < mid; j++ {
+			path = append(path, middle[i].at(float64(j)/float64(mid)))
+		}
+		path = append(path, e.arcB...) // eb … p1
+		paths[i] = append(path, e.lipOutB)
+	}
+	return transposeToSections(paths)
+}
+
+// transposeToSections turns per-band-point paths (all the same length) into per-parameter sections.
+func transposeToSections(paths [][]math.Point3) [][]math.Point3 {
+	if len(paths) == 0 {
+		return nil
+	}
+	m := len(paths[0])
+	sections := make([][]math.Point3, m)
+	for s := 0; s < m; s++ {
+		section := make([]math.Point3, len(paths))
+		for i := range paths {
+			section[i] = paths[i][s]
+		}
+		sections[s] = section
+	}
+	return sections
+}
+
+// foldArc samples a circular arc of radius r starting at pStart tangent to tStart and turning until
+// it is tangent to tEnd (a quarter turn when the two are perpendicular). It returns the sample points
+// (both ends included) and the arc's end point, so callers do not have to place the end by hand. The
+// centre sits r from pStart along the component of tEnd perpendicular to tStart.
+func foldArc(pStart math.Point3, tStart, tEnd math.Vector3, r float64, samples int) ([]math.Point3, math.Point3) {
+	ts, e1 := math.UnitVector3FromVector(tStart)
+	te, e2 := math.UnitVector3FromVector(tEnd)
+	if e1 != nil || e2 != nil {
+		return []math.Point3{pStart}, pStart
+	}
+	nu, err := math.UnitVector3FromVector(te.AsVector().Sub(ts.AsVector().Scale(te.AsVector().Dot(ts.AsVector()))))
+	if err != nil {
+		return []math.Point3{pStart}, pStart
+	}
+	center := pStart.TranslateBy(nu.AsVector().Scale(math.Scalar(r)))
+	r0 := center.VectorTo(pStart)
+	axis, err := math.UnitVector3FromVector(ts.AsVector().Cross(nu.AsVector()))
+	if err != nil {
+		return []math.Point3{pStart}, pStart
+	}
+	sweep := angleBetween(ts.AsVector(), te.AsVector())
+	pts := make([]math.Point3, samples+1)
+	for k := 0; k <= samples; k++ {
+		pts[k] = center.TranslateBy(rotateAbout(r0, axis, sweep*float64(k)/float64(samples)))
+	}
+	return pts, pts[samples]
+}
+
+// rotateAbout rotates v about the unit axis by angle (Rodrigues). Used to sweep a fold's radius
+// vector from its start to its end.
+func rotateAbout(v math.Vector3, axis math.UnitVector3, angle float64) math.Vector3 {
+	a := axis.AsVector()
+	cos, sin := stdmath.Cos(angle), stdmath.Sin(angle)
+	return v.Scale(math.Scalar(cos)).
+		Add(a.Cross(v).Scale(math.Scalar(sin))).
+		Add(a.Scale(math.Scalar(float64(a.Dot(v)) * (1 - cos))))
+}
+
+// inPlaneOutward is the unit in-plane direction, perpendicular to the local profile edge, oriented
+// away from the band's centroid (the direction the flat lip extends). The perpendicular keeps the
+// lip square to the profile; the centroid reference orients it consistently for both thickness
+// offsets — unlike the chord, which vanishes where the two profiles coincide. It falls back to the
+// pure radial direction when the edge is degenerate (the thickness caps).
+func inPlaneOutward(n math.UnitVector3, edge, fromCentroid math.Vector3) math.Vector3 {
+	radial := fromCentroid.Sub(n.AsVector().Scale(fromCentroid.Dot(n.AsVector())))
+	u, err := math.UnitVector3FromVector(n.AsVector().Cross(edge))
+	if err != nil {
+		if ru, err2 := math.UnitVector3FromVector(radial); err2 == nil {
+			return ru.AsVector()
+		}
+		return math.V3(0, 0, 0)
+	}
+	if u.AsVector().Dot(radial) < 0 {
+		return u.AsVector().Negate()
+	}
+	return u.AsVector()
+}
+
+// bandNeighbourTangent is the local edge direction at band point i, from its two neighbours on the
+// closed band loop.
+func bandNeighbourTangent(band []math.Point3, i int) math.Vector3 {
+	n := len(band)
+	return band[(i-1+n)%n].VectorTo(band[(i+1)%n])
+}
+
+// centroid is the mean of a band's points — a robust interior reference for orienting the flat lip
+// outward.
+func centroid(band []math.Point3) math.Point3 {
+	var sx, sy, sz float64
+	for _, p := range band {
+		sx, sy, sz = sx+float64(p.X), sy+float64(p.Y), sz+float64(p.Z)
+	}
+	n := float64(len(band))
+	return math.P3(sx/n, sy/n, sz/n)
+}
+
+// reversePoints returns the points in reverse order (a fresh slice).
+func reversePoints(pts []math.Point3) []math.Point3 {
+	out := make([]math.Point3, len(pts))
+	for i, p := range pts {
+		out[len(pts)-1-i] = p
+	}
+	return out
+}
+
+// unitOr returns v as a unit vector, or fallback (unit) if v is degenerate.
+func unitOr(v, fallback math.Vector3) math.Vector3 {
+	u, err := math.UnitVector3FromVector(v)
+	if err != nil {
+		f, _ := math.UnitVector3FromVector(fallback)
+		return f.AsVector()
+	}
+	return u.AsVector()
+}

--- a/model/feature/sheet_metal_lofted_flange_endbend_test.go
+++ b/model/feature/sheet_metal_lofted_flange_endbend_test.go
@@ -65,7 +65,7 @@ func TestEndBendLipLiesInProfilePlane(t *testing.T) {
 	bandA := []math.Point3{math.P3(-1, -1, 0), math.P3(1, -1, 0), math.P3(1, 1, 0), math.P3(-1, 1, 0)}
 	bandB := []math.Point3{math.P3(-2, -2, 3), math.P3(2, -2, 3), math.P3(2, 2, 3), math.P3(-2, 2, 3)}
 	const r = 0.3
-	sections := endBendSections(bandA, bandB, up, up, r, DieFormedLoftedFlange, 0)
+	sections := endBendSections(bandA, bandB, up, up, r, r, DieFormedLoftedFlange, 0)
 	lipA := sections[0]
 	for i, p := range lipA {
 		if stdmath.Abs(float64(p.Z)) > 1e-9 {
@@ -85,8 +85,10 @@ func TestEndBendLipLiesInProfilePlane(t *testing.T) {
 }
 
 // loftedFlangeWall builds a square-to-larger-square lofted flange with the given end-bend radius and
-// returns its solid — the shared fixture for the end-bend tests.
-func loftedFlangeWall(t *testing.T, radius float64) *topo.Body {
+// returns its solid and feature. It gates on the SELF-INTERSECTION scan (CheckGeometry), not just
+// topology — a rounded end bend can be topologically valid yet interpenetrate, which the live test
+// caught and a topology-only check would miss.
+func loftedFlangeWall(t *testing.T, radius float64) (*topo.Body, *PartFeature) {
 	t.Helper()
 	planeB, _ := sketch.NewPlane(math.P3(0, 0, 3), math.V3(1, 0, 0).AsUnit(), math.V3(0, 1, 0).AsUnit())
 	def := &SheetMetalLoftedFlangeDefinition{
@@ -103,49 +105,40 @@ func loftedFlangeWall(t *testing.T, radius float64) *topo.Body {
 		t.Fatalf("lofted flange (radius %.2f) sick: %+v", radius, pf.Health())
 	}
 	body := fs.Result()[0]
-	if r := ops.Validate(body); !r.Valid {
-		t.Fatalf("lofted flange (radius %.2f) invalid: %v", radius, r.Issues)
+	if ok, probs := ops.ValidateBodyEntities(body, ops.CheckGeometry, ops.DefaultQuality()); !ok {
+		t.Fatalf("lofted flange (radius %.2f) self-intersects: %d problem(s)", radius, len(probs))
 	}
 	if open := ops.BoundaryEdges(body); len(open) != 0 {
 		t.Errorf("lofted flange (radius %.2f) not watertight: %d boundary edges", radius, len(open))
 	}
-	return body
+	return body, pf
 }
 
-// TestLoftedFlangeEndBendFlaresLip the flat lip extends the wall OUTWARD in the profile plane, so the
-// finished wall reaches farther than the sharp reference, and a larger bend radius flares farther. A
-// bend also insets the wall by its radius (bend allowance), so volume is NOT the measure here — the
-// outward reach is.
-func TestLoftedFlangeEndBendFlaresLip(t *testing.T) {
-	reach := func(b *topo.Body) float64 {
-		box := b.RangeBox()
-		return float64(box.Min.DistanceTo(box.Max)) // range-box diagonal
+// TestLoftedFlangeEndBendKeepsLipWhenItFits at a small radius the flat lip does not self-intersect,
+// so the wall keeps it: the solid is self-intersection-free, reports no lip-dropped fallback, and
+// flares OUTWARD past the sharp reference (the lip really extends the wall in the profile plane).
+func TestLoftedFlangeEndBendKeepsLipWhenItFits(t *testing.T) {
+	reach := func(b *topo.Body) float64 { box := b.RangeBox(); return float64(box.Min.DistanceTo(box.Max)) }
+	sharp, _ := loftedFlangeWall(t, 0)
+	body, pf := loftedFlangeWall(t, 0.05) // small enough that the lip fits the L-profile band
+	if hasDiagCode(pf.Diagnostics(), codeLoftedFlangeLipDropped) {
+		t.Errorf("a lip that fits must not be dropped: %v", pf.Diagnostics())
 	}
-	sharp := reach(loftedFlangeWall(t, 0))
-	small := reach(loftedFlangeWall(t, 0.2))
-	large := reach(loftedFlangeWall(t, 0.4))
-	if !(small > sharp) {
-		t.Errorf("a rounded end bend (reach %.4f) did not flare the lip past the sharp wall (%.4f)", small, sharp)
-	}
-	if !(large > small) {
-		t.Errorf("a larger bend radius does not flare farther: R=0.4 %.4f <= R=0.2 %.4f", large, small)
+	if !(reach(body) > reach(sharp)) {
+		t.Errorf("the kept lip did not flare the wall past the sharp reference (%.4f vs %.4f)", reach(body), reach(sharp))
 	}
 }
 
-// TestLoftedFlangeEndBendModelledNoWarning a bend radius alone (no converge) is modelled now, so the
-// feature no longer reports the unmodelled deferral.
-func TestLoftedFlangeEndBendModelledNoWarning(t *testing.T) {
-	planeB, _ := sketch.NewPlane(math.P3(0, 0, 3), math.V3(1, 0, 0).AsUnit(), math.V3(0, 1, 0).AsUnit())
-	fs := NewPartFeatures(thicknessParams(t))
-	pf := NewSheetMetalLoftedFlangeFeatures(fs).Add(&SheetMetalLoftedFlangeDefinition{
-		ProfileA: lProfileOnPlane(sketch.XYPlane(), 1, 1), ProfileB: lProfileOnPlane(planeB, 2, 2),
-		Operation: ops.NewBody, Radius: constFloat(0.3),
-	})
-	fs.Recompute()
-	if !pf.Health().OK() {
-		t.Fatalf("rounded lofted flange sick: %+v", pf.Health())
+// TestLoftedFlangeEndBendFallsBackOnTightRadius a large radius makes the flat lip self-intersect, so
+// the wall must fall back to the fold alone — still a valid (self-intersection-free) solid — and
+// report the lip-dropped diagnostic rather than ship an interpenetrating wall.
+func TestLoftedFlangeEndBendFallsBackOnTightRadius(t *testing.T) {
+	_, pf := loftedFlangeWall(t, 0.3) // fatals inside if the solid self-intersects
+	if !hasDiagCode(pf.Diagnostics(), codeLoftedFlangeLipDropped) {
+		t.Errorf("a self-intersecting lip must report %q so the fallback is visible: %v",
+			codeLoftedFlangeLipDropped, pf.Diagnostics())
 	}
 	if hasDiagCode(pf.Diagnostics(), codeLoftedFlangeUnmodeled) {
-		t.Errorf("a modelled end-bend radius must not report %q: %v", codeLoftedFlangeUnmodeled, pf.Diagnostics())
+		t.Errorf("the end-bend radius is modelled, not deferred: %v", pf.Diagnostics())
 	}
 }

--- a/model/feature/sheet_metal_lofted_flange_endbend_test.go
+++ b/model/feature/sheet_metal_lofted_flange_endbend_test.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// Lofted-flange end-bend radius (#2086). The fold is a TRUE circular arc, so the arc sampler is
+// measured against the radius directly, and the finished wall must be a valid watertight solid that
+// gains the lip + fold material the sharp end bend did not have.
+
+// TestFoldArcHasRadiusAndTangents the fold is a true circular arc of the given radius: from the
+// origin tangent to +Y, turning to +X, every point sits on the circle of radius r about (r,0,0), and
+// the sampled tangents match +Y at the start and +X at the end.
+func TestFoldArcHasRadiusAndTangents(t *testing.T) {
+	const r = 0.5
+	pts, end := foldArc(math.P3(0, 0, 0), math.V3(0, 1, 0), math.V3(1, 0, 0), r, endBendFoldSamples)
+	if len(pts) != endBendFoldSamples+1 {
+		t.Fatalf("arc has %d points, want %d", len(pts), endBendFoldSamples+1)
+	}
+	center := math.P3(r, 0, 0)
+	for k, p := range pts {
+		if d := float64(center.DistanceTo(p)); stdmath.Abs(d-r) > 1e-9 {
+			t.Errorf("arc point %d at radius %.6f, want %.6f", k, d, r)
+		}
+	}
+	if d := float64(pts[0].DistanceTo(math.P3(0, 0, 0))); d > 1e-9 {
+		t.Errorf("arc does not start at pStart: off by %.6f", d)
+	}
+	if d := float64(end.DistanceTo(math.P3(r, r, 0))); d > 1e-9 {
+		t.Errorf("arc end %v is not the expected quarter point (%.1f,%.1f,0)", end, r, r)
+	}
+	assertDir(t, pts[0].VectorTo(pts[1]), math.V3(0, 1, 0), "start tangent +Y")
+	assertDir(t, pts[len(pts)-2].VectorTo(pts[len(pts)-1]), math.V3(1, 0, 0), "end tangent +X")
+}
+
+// assertDir checks that got points the same way as want (unit-dot ≈ 1).
+func assertDir(t *testing.T, got, want math.Vector3, label string) {
+	t.Helper()
+	gu, err := math.UnitVector3FromVector(got)
+	if err != nil {
+		t.Errorf("%s: zero vector", label)
+		return
+	}
+	wu, _ := math.UnitVector3FromVector(want)
+	// A sampled chord sits half a segment angle (~7.5° at 6 samples) off the true tangent, so accept
+	// anything within that of the intended direction.
+	if d := float64(gu.AsVector().Dot(wu.AsVector())); d < 0.99 {
+		t.Errorf("%s: direction dot %.4f (got %v, want %v)", label, d, got, want)
+	}
+}
+
+// TestEndBendLipLiesInProfilePlane the first and last loft sections are the flat lips: they lie IN
+// each profile's plane and sit outboard of the profile by the lip length, so the wall really gains a
+// flat lip before it folds up.
+func TestEndBendLipLiesInProfilePlane(t *testing.T) {
+	up := math.V3(0, 0, 1).AsUnit()
+	bandA := []math.Point3{math.P3(-1, -1, 0), math.P3(1, -1, 0), math.P3(1, 1, 0), math.P3(-1, 1, 0)}
+	bandB := []math.Point3{math.P3(-2, -2, 3), math.P3(2, -2, 3), math.P3(2, 2, 3), math.P3(-2, 2, 3)}
+	const r = 0.3
+	sections := endBendSections(bandA, bandB, up, up, r, DieFormedLoftedFlange, 0)
+	lipA := sections[0]
+	for i, p := range lipA {
+		if stdmath.Abs(float64(p.Z)) > 1e-9 {
+			t.Errorf("lip A point %d is off plane A (z=%.4f, want 0)", i, float64(p.Z))
+		}
+		// The centroid of a symmetric square band is the origin; the lip sits farther out than the
+		// profile by the lip length (= r).
+		out := float64(math.P3(0, 0, 0).DistanceTo(math.P3(p.X, p.Y, 0)))
+		prof := float64(math.P3(0, 0, 0).DistanceTo(math.P3(bandA[i].X, bandA[i].Y, 0)))
+		if got := out - prof; stdmath.Abs(got-r) > 1e-6 {
+			t.Errorf("lip A point %d flares %.4f, want the lip length %.4f", i, got, r)
+		}
+	}
+	if z := float64(sections[len(sections)-1][0].Z); stdmath.Abs(z-3) > 1e-9 {
+		t.Errorf("lip B is off plane B (z=%.4f, want 3)", z)
+	}
+}
+
+// loftedFlangeWall builds a square-to-larger-square lofted flange with the given end-bend radius and
+// returns its solid — the shared fixture for the end-bend tests.
+func loftedFlangeWall(t *testing.T, radius float64) *topo.Body {
+	t.Helper()
+	planeB, _ := sketch.NewPlane(math.P3(0, 0, 3), math.V3(1, 0, 0).AsUnit(), math.V3(0, 1, 0).AsUnit())
+	def := &SheetMetalLoftedFlangeDefinition{
+		ProfileA: lProfileOnPlane(sketch.XYPlane(), 1, 1), ProfileB: lProfileOnPlane(planeB, 2, 2),
+		Operation: ops.NewBody,
+	}
+	if radius > 0 {
+		def.Radius = constFloat(radius)
+	}
+	fs := NewPartFeatures(thicknessParams(t))
+	pf := NewSheetMetalLoftedFlangeFeatures(fs).Add(def)
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("lofted flange (radius %.2f) sick: %+v", radius, pf.Health())
+	}
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid {
+		t.Fatalf("lofted flange (radius %.2f) invalid: %v", radius, r.Issues)
+	}
+	if open := ops.BoundaryEdges(body); len(open) != 0 {
+		t.Errorf("lofted flange (radius %.2f) not watertight: %d boundary edges", radius, len(open))
+	}
+	return body
+}
+
+// TestLoftedFlangeEndBendFlaresLip the flat lip extends the wall OUTWARD in the profile plane, so the
+// finished wall reaches farther than the sharp reference, and a larger bend radius flares farther. A
+// bend also insets the wall by its radius (bend allowance), so volume is NOT the measure here — the
+// outward reach is.
+func TestLoftedFlangeEndBendFlaresLip(t *testing.T) {
+	reach := func(b *topo.Body) float64 {
+		box := b.RangeBox()
+		return float64(box.Min.DistanceTo(box.Max)) // range-box diagonal
+	}
+	sharp := reach(loftedFlangeWall(t, 0))
+	small := reach(loftedFlangeWall(t, 0.2))
+	large := reach(loftedFlangeWall(t, 0.4))
+	if !(small > sharp) {
+		t.Errorf("a rounded end bend (reach %.4f) did not flare the lip past the sharp wall (%.4f)", small, sharp)
+	}
+	if !(large > small) {
+		t.Errorf("a larger bend radius does not flare farther: R=0.4 %.4f <= R=0.2 %.4f", large, small)
+	}
+}
+
+// TestLoftedFlangeEndBendModelledNoWarning a bend radius alone (no converge) is modelled now, so the
+// feature no longer reports the unmodelled deferral.
+func TestLoftedFlangeEndBendModelledNoWarning(t *testing.T) {
+	planeB, _ := sketch.NewPlane(math.P3(0, 0, 3), math.V3(1, 0, 0).AsUnit(), math.V3(0, 1, 0).AsUnit())
+	fs := NewPartFeatures(thicknessParams(t))
+	pf := NewSheetMetalLoftedFlangeFeatures(fs).Add(&SheetMetalLoftedFlangeDefinition{
+		ProfileA: lProfileOnPlane(sketch.XYPlane(), 1, 1), ProfileB: lProfileOnPlane(planeB, 2, 2),
+		Operation: ops.NewBody, Radius: constFloat(0.3),
+	})
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("rounded lofted flange sick: %+v", pf.Health())
+	}
+	if hasDiagCode(pf.Diagnostics(), codeLoftedFlangeUnmodeled) {
+		t.Errorf("a modelled end-bend radius must not report %q: %v", codeLoftedFlangeUnmodeled, pf.Diagnostics())
+	}
+}

--- a/model/feature/sheet_metal_miter.go
+++ b/model/feature/sheet_metal_miter.go
@@ -28,6 +28,15 @@ func mitreCorner(bodies []*topo.Body, bend BendPlacement, in Input, gap float64,
 	if !ok {
 		return bodies, nil
 	}
+	return mitreFillAtJunction(bodies, junction, gap, feat)
+}
+
+// mitreFillAtJunction carries both walls of a junction past the corner, joins them, then cuts the
+// styled gap on the bisector so the folded part has clearance. It is the shared corner fill used by
+// the auto-miter (#1961) and by the corner-seam butt/lap styles (#2085) — the latter own no bend,
+// so they discover the junction themselves and hand it here. A gap <= 0 butts the two walls tight.
+func mitreFillAtJunction(bodies []*topo.Body, junction bendJunction, gap float64,
+	feat string) ([]*topo.Body, error) {
 	out := bodies
 	for _, e := range mitreExtensions(junction) {
 		wall, err := extendWall(e, feat)

--- a/model/occurrence/pattern.go
+++ b/model/occurrence/pattern.go
@@ -2,7 +2,12 @@
 
 package occurrence
 
-import "oblikovati.org/math"
+import (
+	"fmt"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/math"
+)
 
 // OccurrencePatternElement is one replicated instance of an occurrence pattern: its
 // computed placement plus per-element state — a suppression flag and an optional
@@ -49,6 +54,13 @@ type OccurrencePattern struct {
 	base        math.Matrix4
 	arrangement Arrangement
 	elements    []*OccurrencePatternElement
+
+	// Persistent identity + the occurrences each element drives (#1976). occs is aligned to
+	// elements: occs[0] is the seed occurrence, occs[i>=1] the generated copy for element i, so
+	// suppressing/repositioning an element acts on the real occurrence. Set by BindOccurrences.
+	id   uint64
+	name string
+	occs []*Occurrence
 }
 
 // NewOccurrencePattern builds a pattern of seed (placed at base) over arrangement and
@@ -86,6 +98,9 @@ func (p *OccurrencePattern) Regenerate() {
 // Seed returns the component this pattern replicates.
 func (p *OccurrencePattern) Seed() Definition { return p.seed }
 
+// Arrangement returns the layout the pattern replicates the seed across — read for persistence.
+func (p *OccurrencePattern) Arrangement() Arrangement { return p.arrangement }
+
 // Count returns the number of pattern elements (including suppressed ones).
 func (p *OccurrencePattern) Count() int { return len(p.elements) }
 
@@ -97,6 +112,113 @@ func (p *OccurrencePattern) Elements() []*OccurrencePatternElement {
 	out := make([]*OccurrencePatternElement, len(p.elements))
 	copy(out, p.elements)
 	return out
+}
+
+// ID returns the pattern's session id, assigned when it is recorded in an
+// [OccurrencePatternSet].
+func (p *OccurrencePattern) ID() uint64 { return p.id }
+
+// Name returns the pattern's display name; SetName renames it.
+func (p *OccurrencePattern) Name() string     { return p.name }
+func (p *OccurrencePattern) SetName(n string) { p.name = n }
+
+// Kind reports the arrangement family — "circular", "rectangular", or "" for another
+// arrangement — so a client can tell how the pattern was laid out.
+func (p *OccurrencePattern) Kind() string {
+	switch p.arrangement.(type) {
+	case *CircularArrangement, CircularArrangement:
+		return "circular"
+	case *RectangularArrangement, RectangularArrangement:
+		return "rectangular"
+	default:
+		return ""
+	}
+}
+
+// BindOccurrences links the pattern's elements to the occurrences they drive: the seed (element
+// 0) and one generated occurrence per element beyond it, in element order. Editing an element
+// then moves or suppresses the real occurrence.
+func (p *OccurrencePattern) BindOccurrences(seed *Occurrence, generated []*Occurrence) {
+	p.occs = append([]*Occurrence{seed}, generated...)
+}
+
+// Occurrences returns the occurrences the pattern drives, element 0 (the seed) first.
+func (p *OccurrencePattern) Occurrences() []*Occurrence {
+	out := make([]*Occurrence, len(p.occs))
+	copy(out, p.occs)
+	return out
+}
+
+// SetSuppressed suppresses or unsuppresses the WHOLE pattern, moving every GENERATED element
+// together (#1976). Element 0 is the seed — the pre-existing component — so it is left in place; an
+// all-suppressed pattern leaves just the seed.
+func (p *OccurrencePattern) SetSuppressed(suppressed bool) {
+	for i := 1; i < len(p.elements); i++ {
+		p.setElementSuppressed(i, suppressed)
+	}
+}
+
+// SetElementSuppressed suppresses or unsuppresses one generated element by index (1..Count-1),
+// erroring on the seed (element 0) or an out-of-range index.
+func (p *OccurrencePattern) SetElementSuppressed(i int, suppressed bool) error {
+	if err := p.checkGenerated(i); err != nil {
+		return err
+	}
+	p.setElementSuppressed(i, suppressed)
+	return nil
+}
+
+// checkGenerated rejects the seed (element 0, which the pattern does not own) and out-of-range
+// indices, so pattern edits only ever touch the generated instances.
+func (p *OccurrencePattern) checkGenerated(i int) error {
+	if i < 1 || i >= len(p.elements) {
+		return fmt.Errorf("occurrence pattern element %d out of range [1,%d) (element 0 is the seed)", i, len(p.elements))
+	}
+	return nil
+}
+
+// setElementSuppressed sets the element flag and the driven occurrence together.
+func (p *OccurrencePattern) setElementSuppressed(i int, suppressed bool) {
+	p.elements[i].SetSuppressed(suppressed)
+	if i < len(p.occs) && p.occs[i] != nil {
+		p.occs[i].SetSuppressed(suppressed)
+	}
+}
+
+// RepositionElement moves one element (by index) to an explicit placement, off the regular grid,
+// erroring when the index is out of range. The driven occurrence moves with it.
+func (p *OccurrencePattern) RepositionElement(i int, m math.Matrix4) error {
+	if err := p.checkGenerated(i); err != nil {
+		return err
+	}
+	p.elements[i].Reposition(m)
+	if i < len(p.occs) && p.occs[i] != nil {
+		p.occs[i].SetTransform(m)
+	}
+	return nil
+}
+
+// Suppression reports whether none, some, or all of the pattern's elements are suppressed —
+// the pattern-level state Inventor's OccurrencePatternSuppressionEnum reports (#1976).
+func (p *OccurrencePattern) Suppression() types.OccurrencePatternSuppression {
+	generated := len(p.elements) - 1 // element 0 is the seed, not part of the pattern's suppression
+	if generated <= 0 {
+		return types.NoneSuppressed
+	}
+	suppressed := 0
+	for i := 1; i < len(p.elements); i++ {
+		if p.elements[i].suppressed {
+			suppressed++
+		}
+	}
+	switch suppressed {
+	case 0:
+		return types.NoneSuppressed
+	case generated:
+		return types.AllElementsSuppressed
+	default:
+		return types.SomeElementsSuppressed
+	}
 }
 
 // RangeBox returns the axis-aligned box enclosing the seed placed at every

--- a/model/occurrence/pattern_set.go
+++ b/model/occurrence/pattern_set.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package occurrence
+
+// OccurrencePatternSet is the collection of PERSISTENT occurrence patterns an assembly owns
+// (#1976). Before this, a pattern was built, its copies placed, and the pattern object thrown
+// away — so a patterned array could not be re-read, suppressed, or deleted as a group. The set
+// keeps each pattern, mints its id, and deletes an array (dropping the generated occurrences but
+// keeping the seed) as one operation. It mirrors [Occurrences]' id-minting shape.
+type OccurrencePatternSet struct {
+	occs   *Occurrences
+	items  []*OccurrencePattern
+	nextID uint64
+}
+
+// NewOccurrencePatternSet binds the set to the assembly's occurrences, which it removes from on
+// delete.
+func NewOccurrencePatternSet(occs *Occurrences) *OccurrencePatternSet {
+	return &OccurrencePatternSet{occs: occs}
+}
+
+// Add records a created pattern under name, assigns it the next id, binds its element
+// occurrences (seed first, then the generated copies in element order), and returns it.
+func (s *OccurrencePatternSet) Add(pat *OccurrencePattern, name string, seed *Occurrence, generated []*Occurrence) *OccurrencePattern {
+	s.nextID++
+	pat.id = s.nextID
+	pat.name = name
+	pat.BindOccurrences(seed, generated)
+	s.items = append(s.items, pat)
+	return pat
+}
+
+// Count returns how many patterns the assembly holds; Item returns the i-th in creation order.
+func (s *OccurrencePatternSet) Count() int                    { return len(s.items) }
+func (s *OccurrencePatternSet) Item(i int) *OccurrencePattern { return s.items[i] }
+
+// ByID returns the pattern with the given id.
+func (s *OccurrencePatternSet) ByID(id uint64) (*OccurrencePattern, bool) {
+	for _, p := range s.items {
+		if p.id == id {
+			return p, true
+		}
+	}
+	return nil, false
+}
+
+// Delete removes the pattern (by id) and the occurrences it generated — every element beyond the
+// seed — leaving the seed component in place. It reports whether the pattern was present.
+func (s *OccurrencePatternSet) Delete(id uint64) bool {
+	for i, p := range s.items {
+		if p.id != id {
+			continue
+		}
+		for e := 1; e < len(p.occs); e++ { // element 0 is the seed; keep it
+			if p.occs[e] != nil {
+				s.occs.Remove(p.occs[e])
+			}
+		}
+		s.items = append(s.items[:i], s.items[i+1:]...)
+		return true
+	}
+	return false
+}

--- a/model/occurrence/pattern_test.go
+++ b/model/occurrence/pattern_test.go
@@ -6,6 +6,7 @@ import (
 	stdmath "math"
 	"testing"
 
+	"oblikovati.org/api/types"
 	"oblikovati.org/math"
 )
 
@@ -100,5 +101,38 @@ func TestFeatureArrangementFollowsSuppliedOffsets(t *testing.T) {
 	}
 	if got := p.Element(1).Transform().TransformPoint(math.P3(0, 0, 0)); got != (math.P3(7, 0, 0)) {
 		t.Errorf("feature-driven element 1 = %v, want {7 0 0}", got)
+	}
+}
+
+// TestPatternSuppressionExcludesSeed the persistent pattern-level suppression (#1976) counts only
+// the GENERATED elements: element 0 is the seed, never suppressed by the pattern, so a fully
+// suppressed 4-up pattern still leaves the seed, and the seed cannot be suppressed or repositioned.
+func TestPatternSuppressionExcludesSeed(t *testing.T) {
+	p := NewOccurrencePattern(unitComponent(), math.Identity4(),
+		CircularArrangement{Origin: math.P3(0, 0, 0), Axis: unitZ(t), Step: math.Scalar(stdmath.Pi / 2), Count: 4})
+	if p.Suppression() != types.NoneSuppressed {
+		t.Errorf("fresh pattern suppression = %v, want none", p.Suppression())
+	}
+	if err := p.SetElementSuppressed(1, true); err != nil {
+		t.Fatalf("suppress element 1: %v", err)
+	}
+	if p.Suppression() != types.SomeElementsSuppressed {
+		t.Errorf("one suppressed element = %v, want some", p.Suppression())
+	}
+	p.SetSuppressed(true)
+	if p.Suppression() != types.AllElementsSuppressed {
+		t.Errorf("all suppressed = %v, want all", p.Suppression())
+	}
+	if p.Element(0).Suppressed() {
+		t.Error("SetSuppressed must not suppress the seed (element 0)")
+	}
+	if err := p.SetElementSuppressed(0, true); err == nil {
+		t.Error("suppressing the seed (element 0) should be rejected")
+	}
+	if err := p.RepositionElement(0, math.Identity4()); err == nil {
+		t.Error("repositioning the seed (element 0) should be rejected")
+	}
+	if err := p.SetElementSuppressed(4, true); err == nil {
+		t.Error("an out-of-range element should be rejected")
 	}
 }


### PR DESCRIPTION
## What

The outstanding M44 sign-off work plus a related watertight-gate correctness fix, consolidated into one PR. Four issues, all with granular commits (no squash).

### Sheet-metal SOLID geometry (M44)
- **#2085 — corner seam overlap / reverse / no-overlap.** A watertight union hides an internal seam, so the lap styles could not be told from a butt one (#1964 deferred them). Now each yields a *measurably distinct* solid: `no-overlap` butts the two flange walls (shared auto-miter fill); `overlap(p)`/`reverse` add a proud lap tab on the lapped wall's flat face (`thickness × lapLength × faceHeight`, monotone in p, different wall per style).
- **#2086 — lofted flange converge + end-bend radius.** Converge pinches the cornered profile's corners to a point at the far profile (less material). The bend radius rounds where the wall meets each profile with a flat lip + a true radius-R fold (a tested `foldArc` primitive, radius exact to 1e-9). The live MCP test caught a self-intersection the pure-Go tests missed (they used topology-only validation); the feature now validates geometry and falls back to the fold when the lip would self-intersect.

### Assembly (M44)
- **#1976 — persistent, editable/suppressible occurrence patterns.** The router built the pattern, spawned its copies, and threw the pattern away. Now it is kept: `OccurrencePatternSet` on the component definition, pattern-level + per-element suppress / reposition / delete (acting on the real occurrences — element 0 is the seed and stays), and a recipe round-trip that re-links to its occurrences by name. Uses the api types/wire/client from the companion Oblikovati.API PR.

### Correctness (related)
- **#2079 — watertight gate must reject face interpenetration.** `isWatertightSolid` gated on topology only, so the corpus scored bodies whose faces drive straight through each other (3–15 model units) as watertight. A full sweep found 3 such cases (simple/R8, simple/W9 at the issue's exact witness, complex/F2). The gate now also rejects self-intersection, scanning at `PropertyQuality` to reuse the memoized tessellation (no perf regression; full corpus green in ~307s). No green flips — the 3 were mislabeled FAIL(area) and now report FAIL(faulty).

## Why one PR

M44's remaining subsystem-parity work (#2085/#2086/#1976) plus the watertight-gate fix (#2079) were developed on separate branches and are merged here for a single sign-off. The **iMate** subsystem (#1969) was descoped from M44 as a large standalone feature.

## Verification

- Full `model/feature`, `model/feature/occtparity`, `model/occurrence`, `model/compdef`, `addin/router` suites green on the consolidated branch; `golangci-lint` 0 issues on touched packages.
- Every new geometry/behaviour guard proven by mutating the implementation.
- **Live MCP test on the real head** for #2085/#2086 (two-flange corner seam + converged/rounded lofted flange, level-2 self-intersection valid, visually confirmed); live drivers in the companion MCPBridge PR.

## Cross-repo ordering (ADR-0018)

#1976 needs the Apache-2.0 contract: merge the **Oblikovati.API PR #278** first (auto-releases a new `oblikovati.org/api`), then this PR's `go.mod` pins it and CI goes green. The **MCPBridge PR** (live drivers) follows.

Closes #2085
Closes #2086
Closes #1976
Closes #2079

🤖 Generated with [Claude Code](https://claude.com/claude-code)