### PR TITLE
ci: race only before release; verify + lock the #2020 arm64 run-out fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,13 @@ jobs:
           path: coverage.out
 
   # Race detector needs cgo; Linux only.
+  # Runs ONLY when cutting a release (develop → the `release` branch), never on a PR: `-race`
+  # is by far the slowest gate on the board (minutes past the rest of the matrix) and was
+  # stalling otherwise-green PR merges for no per-PR signal. Release is cut on push to `release`
+  # (release.yml), so this is the pre-release race gate. develop has no branch protection, so a
+  # PR that never runs `race` is not blocked on it.
   race:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/release'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/kernel/ops/fillet_test.go
+++ b/kernel/ops/fillet_test.go
@@ -312,6 +312,19 @@ func TestFilletCornerRoundAddsThirdEdge(t *testing.T) {
 // TestFilletRunOutToZero checks a lone variable fillet that tapers to radius 0 at one end: the blend
 // cone closes to a single apex on the edge (a run-out / "fade out"), producing a watertight solid
 // rather than the degenerate non-manifold fan the unguarded collapse would leave.
+//
+// CROSS-ARCH REGRESSION LOCK (#2020) — DO NOT gate this to a single architecture, and do not weaken
+// assertWatertight here. The run-out surface's (u,v) parameterization degenerates at the zero-radius
+// apex: many distinct 3D boundary samples map onto near-identical (u,v), so the (u,v) chart is not
+// injective there. Whether two of those samples land on IDENTICAL coordinates in the CDT chart (which
+// then keeps a single representative, cdt_build.go) depends on the last bit of the parameter — and Go
+// contracts a*b+c into a single FMA on arm64 but not amd64, so the same code once meshed 416/416
+// boundary edges on amd64 and only 241/416 on arm64, cracking the body along 177 free edges (amd64
+// "passing" was the coin landing the same way, not correctness). The blend now meshes the same
+// watertight solid on both — verified bit-identical on amd64 and on faithful-FMA arm64 — and this
+// test is the guard that keeps it so. It runs on the arm64 CI leg (test / macos-latest, Apple
+// Silicon), which is where a re-divergence would surface; keeping it un-gated is the acceptance
+// criterion of #2020. See also 8f8668f6 (a boundary-missing NURBS patch is no longer a candidate).
 func TestFilletRunOutToZero(t *testing.T) {
 	box := shellBox(2, 2, 2)
 	res, err := ops.FilletEdgesVarying(box, []ops.EdgeFilletRadii{{Key: verticalEdgeKey(t, box), R0: 0.3, R1: 0}})


### PR DESCRIPTION
## What

Two things:

1. **CI: run the race detector only before release**, not on every PR. `-race` was the slowest gate on the board (minutes past the rest of the matrix) and stalled otherwise-green PR merges for no signal a reviewer acts on. It now runs on push to the `release` branch (develop → release, where `release.yml` cuts the release), so it stays a pre-release safety net while PRs stop waiting on it. `develop` has no branch protection, so nothing requires it.

2. **#2020: verify the arm64 run-out divergence is resolved, and lock it against silent regression.**

## Why #2020 is closed by verification, not a code fix

#2020 reported that `kernel/ops` made topological decisions from raw float comparisons, so the run-out fillet (`TestFilletRunOutToZero`) produced a watertight solid on amd64 and a cracked one (177 free edges) on macOS/arm64 — Go fuses `a*b+c` into a single FMA on arm64 but not amd64, and the run-out surface's `(u,v)` degenerates at its zero-radius apex, so which boundary samples collide in the CDT chart flips with the last bit.

Investigation on current `develop`:

- **The witness now passes on both arches, bit-identically.** `TestFilletRunOutToZero` meshes to **734 tris / 0 open edges** on amd64 **and** on faithful-FMA arm64. I confirmed the arm64 environment genuinely fuses FMA (it returns the fused `a*b+c = -2.02e-16` where amd64 returns the unfused `0`), so this is a real architecture-independent fix — not a lucky pass (a lucky pass would show the issue's 337-vs-570-tri split, not a bit-identical mesh).
- **The full `kernel/ops` suite is green on both arches** (amd64 100s; arm64 1259s under emulation).
- **A regression lock already exists in CI.** The `test` job runs on `macos-latest` = Apple Silicon (**arm64**) over `./...` (incl. `kernel/ops` and the occtparity corpus). That is the leg where a re-divergence surfaces, and it is green.
- The class hardening #2020 proposed is substantially already in: `8f8668f6` made a boundary-missing NURBS patch not-a-candidate; `finalizeDomain` tracks unrecovered constraints and falls back to a deterministic earcut on a domain leak; `d23a3fff` flags an unmeshed wall as a counted Defect.

So #2020's written acceptance — *"`TestFilletRunOutToZero` passes on arm64 AND amd64 with no architecture gate, and the corpus stays green on both"* — is **met on develop**. What was missing was that the guard's PURPOSE was undocumented, so a future refactor could weaken it or gate it to amd64 without knowing it is load-bearing for cross-arch correctness. This PR records that on the test.

**Deliberately NOT done here** (the fillet/blend corpus is byte-fragile): making the CDT's duplicate-boundary-sample skip loud at the CDT layer, and a broader sweep-and-fix of bare absolute-epsilon predicates. A read-only sweep found the genuine remaining smell is small (most `1e-N` uses are already scale-relative or dimensionless); the one real bare-epsilon dedup on a tessellation path is `tessellate_wedge_band.go:163`. These can ride a separate, cross-arch-verified follow-up if we want them.

## Verification

- `TestFilletRunOutToZero` green; `kernel/ops` green on amd64 **and** arm64.
- `golangci-lint ./kernel/ops/` 0 issues; `ci.yml` validated as well-formed YAML.

Closes #2020

🤖 Generated with [Claude Code](https://claude.com/claude-code)
