### PR TITLE
Part & sheet-metal fixes: contour-flange flat bends (#2076), emboss pattern relief (#2066) + cone wrap (#2065), rib parallel direction (#2064)

### DIFF
--- a/addin/opregistry/emboss_flavour_test.go
+++ b/addin/opregistry/emboss_flavour_test.go
@@ -131,7 +131,7 @@ func TestEmbossWrapToFaceReachesTheDefinition(t *testing.T) {
 	if res.Healthy {
 		t.Error("wrapping onto a planar face should report unhealthy: a planar face needs no wrap")
 	}
-	if !strings.Contains(res.Reason, "cylindrical face") {
-		t.Errorf("reason = %q, want it to name the cylindrical face the wrap needs", res.Reason)
+	if !strings.Contains(res.Reason, "cylindrical or conical face") {
+		t.Errorf("reason = %q, want it to name the cylindrical or conical face the wrap needs (#2065)", res.Reason)
 	}
 }

--- a/model/compdef/sheet_metal_contour_bends_test.go
+++ b/model/compdef/sheet_metal_contour_bends_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"math"
+	"testing"
+
+	gmath "oblikovati.org/math"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// lContourProfile is an open L cross-section (out 1 cm, up 1 cm) — one right-angle corner, the
+// simplest contour flange that carries a bend.
+func lContourProfile() *sketch.Sketch {
+	s := sketch.NewSketches().Add(sketch.XYPlane())
+	p0 := s.Points().Add(gmath.P2(0, 0))
+	p1 := s.Points().Add(gmath.P2(1, 0))
+	p2 := s.Points().Add(gmath.P2(1, 1))
+	s.Lines().Add(p0, p1)
+	s.Lines().Add(p1, p2)
+	return s
+}
+
+// TestBendsReportsContourFlangeCorners is the #2076 integration regression: a contour flange's
+// rounded corners must develop as real bends in the flat pattern. Before the feature implemented
+// BendLineage they contributed nothing, so the developed blank was short by every corner's bend
+// allowance and any DXF cut from it was undersized. The corner defers to the rule's radius, so the
+// developed allowance is the rule's own bend allowance for a 90° corner.
+func TestBendsReportsContourFlangeCorners(t *testing.T) {
+	d := NewPartComponentDefinition()
+	if _, err := d.EnableSheetMetal(); err != nil {
+		t.Fatalf("EnableSheetMetal: %v", err)
+	}
+	addSquareFace(d, 4)
+
+	edge := topXEdge(t, d.Features().Result()[0])
+	pf := feature.NewSheetMetalContourFlangeFeatures(d.Features()).Add(&feature.SheetMetalContourFlangeDefinition{
+		EdgeKey: edge.ReferenceKey(),
+		Profile: lContourProfile(),
+	})
+	d.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("contour flange unhealthy: %s", pf.Health().Reason)
+	}
+
+	bends := d.Bends()
+	if len(bends) != 1 {
+		t.Fatalf("contour flange Bends len = %d, want 1 (its single corner)", len(bends))
+	}
+	b := bends[0]
+	if b.Feature != pf.Name() {
+		t.Errorf("bend feature = %q, want %q", b.Feature, pf.Name())
+	}
+	if math.Abs(b.Angle-math.Pi/2) > 1e-9 {
+		t.Errorf("corner bend angle = %g, want π/2", b.Angle)
+	}
+	rule := d.SheetMetal()
+	if b.Radius != rule.BendRadius() {
+		t.Errorf("corner bend radius = %g, want the rule default %g (deferred)", b.Radius, rule.BendRadius())
+	}
+	if want := rule.Unfold().BendAllowance(b.Angle, b.Radius, b.Thickness); b.Allowance != want || want <= 0 {
+		t.Errorf("corner allowance = %g, want the rule's %g (>0) — the flat was short by it", b.Allowance, want)
+	}
+	if got := d.TotalBendAllowance(); math.Abs(got-b.Allowance) > 1e-12 {
+		t.Errorf("TotalBendAllowance = %g, want the corner's allowance %g", got, b.Allowance)
+	}
+}

--- a/model/feature/emboss.go
+++ b/model/feature/emboss.go
@@ -62,6 +62,10 @@ type EmbossFeature struct {
 	def      *EmbossDefinition
 	featName string
 	tool     *topo.Body // last raised/engraved prism, exposed so a pattern can replicate it
+	// reliefTool is the from-plane flavour's BACK-side prism, the one it cuts (#2066). Only the
+	// from-plane emboss sets it (raise/engrave apply one tool); a pattern reads it through
+	// ToolApplications so the relief cut is replicated at every copy, not just the raise.
+	reliefTool *topo.Body
 }
 
 // Definition returns the emboss recipe.
@@ -83,9 +87,21 @@ func (f *EmbossFeature) Operation() ops.PartFeatureOperation {
 }
 func (f *EmbossFeature) ToolBody() *topo.Body { return f.tool }
 
+// ToolApplications reports both booleans a FROM-PLANE emboss applies — the raise (Join, in front of
+// the plane) and the relief cut (Cut, behind it) — so a pattern/mirror replicates the relief at
+// every copy, not just the raise (#2066). It returns nil for a raise/engrave emboss, whose single
+// tool a pattern replicates through ToolBody/Operation as before.
+func (f *EmbossFeature) ToolApplications() []ToolApplication {
+	if f.reliefTool == nil || f.tool == nil {
+		return nil
+	}
+	return []ToolApplication{{Body: f.tool, Op: ops.Join}, {Body: f.reliefTool, Op: ops.Cut}}
+}
+
 // Recompute resolves the profile(s) and applies the flavour: raise, engrave, or level the region
 // to the sketch plane offset by the depth (#1893).
 func (f *EmbossFeature) Recompute(in Input) (Output, error) {
+	f.reliefTool = nil // only the from-plane path re-sets it (in cutBack); never carry a stale relief
 	profiles, err := f.resolveProfiles()
 	if err != nil {
 		return Output{}, err

--- a/model/feature/emboss_pattern_relief_test.go
+++ b/model/feature/emboss_pattern_relief_test.go
@@ -49,3 +49,28 @@ func TestEmbossFromPlanePatternReplicatesTheReliefCut(t *testing.T) {
 		t.Errorf("%v lies outside every emboss profile and must stay solid", p)
 	}
 }
+
+// TestEmbossFromPlaneMirrorReplicatesTheReliefCut is the mirror half of #2066 (the issue covers
+// pattern AND mirror; both replicate through the same resolveGroup). A mirror of an interior
+// from-plane emboss must reflect its relief cut, not only its raise.
+func TestEmbossFromPlaneMirrorReplicatesTheReliefCut(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	NewExtrudeFeatures(fs).AddExtrude(squareSketch(10), []int{0}, ops.NewBody,
+		Extent{Type: DistanceExtent, Direction: SymmetricDir, Distance: func() float64 { return 4 }}, 0)
+	emb := NewEmbossFeatures(fs).Add(rectSketchOn(sketch.XYPlane(), 1, 1, 3, 3),
+		[]int{0}, func() float64 { return 1 }, EmbossEngraveFromPlane, 0)
+	// Mirror across x=5: the seed pocket at x∈[1,3] reflects to x∈[7,9].
+	NewPatternFeatures(fs).AddMirror([]ID{emb.ID()}, nil, math.P3(5, 0, 0), math.V3(1, 0, 0))
+	fs.Recompute()
+
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("mirrored from-plane emboss is not a valid solid: %+v", r)
+	}
+	if p := math.P3(2, 2, -0.5); ops.PointInsideBody(body, p) {
+		t.Errorf("seed relief pocket %v is solid, want emptied", p)
+	}
+	if p := math.P3(8, 2, -0.5); ops.PointInsideBody(body, p) {
+		t.Errorf("mirrored relief pocket %v is solid — the mirror dropped the relief cut (#2066)", p)
+	}
+}

--- a/model/feature/emboss_pattern_relief_test.go
+++ b/model/feature/emboss_pattern_relief_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// TestEmbossFromPlanePatternReplicatesTheReliefCut is the #2066 regression. A from-plane emboss
+// applies TWO booleans — a raise in front of the sketch plane and a relief cut behind it — but the
+// pattern machinery only ever recovered one tool per source, so a patterned copy kept the raise and
+// dropped the relief cut.
+//
+// The profile sits fully INSIDE the block, so the raise (a prism already buried in solid material)
+// is a no-op and ONLY the relief cut leaves a mark: a pocket behind the plane. A copy that missing
+// the relief therefore has no pocket — solid where the seed is hollow — which is exactly what this
+// test measures. Before the fix the copy's pocket point is solid; after it, both pockets are empty.
+func TestEmbossFromPlanePatternReplicatesTheReliefCut(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	NewExtrudeFeatures(fs).AddExtrude(squareSketch(10), []int{0}, ops.NewBody,
+		Extent{Type: DistanceExtent, Direction: SymmetricDir, Distance: func() float64 { return 4 }}, 0)
+	emb := NewEmbossFeatures(fs).Add(rectSketchOn(sketch.XYPlane(), 1, 1, 3, 3),
+		[]int{0}, func() float64 { return 1 }, EmbossEngraveFromPlane, 0)
+	// Two occurrences 4 cm apart in X: the seed's pocket at x∈[1,3], the copy's at x∈[5,7].
+	NewPatternFeatures(fs).AddRectangular([]ID{emb.ID()},
+		func() int { return 2 }, func() int { return 1 }, math.V3(4, 0, 0), math.Vector3{})
+	fs.Recompute()
+
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("patterned from-plane emboss is not a valid solid: %+v", r)
+	}
+	// The seed's relief pocket (behind the plane, inside the profile) is hollow.
+	if p := math.P3(2, 2, -0.5); ops.PointInsideBody(body, p) {
+		t.Errorf("seed relief pocket %v is solid, want the relief cut to have emptied it", p)
+	}
+	// The COPY's relief pocket must ALSO be hollow — the pattern must replicate the relief cut, not
+	// only the raise (#2066). This is the assertion that fails before the fix.
+	if p := math.P3(6, 2, -0.5); ops.PointInsideBody(body, p) {
+		t.Errorf("patterned copy relief pocket %v is solid — the pattern replicated the raise but "+
+			"dropped the relief cut (#2066)", p)
+	}
+	// A point behind the plane but outside both pockets stays solid — the cut is local, not global.
+	if p := math.P3(8, 8, -0.5); !ops.PointInsideBody(body, p) {
+		t.Errorf("%v lies outside every emboss profile and must stay solid", p)
+	}
+}

--- a/model/feature/emboss_plane.go
+++ b/model/feature/emboss_plane.go
@@ -58,6 +58,7 @@ func (f *EmbossFeature) cutBack(in Input, bodies []*topo.Body, profiles []*sketc
 	d float64) (Output, error) {
 	relief := buildProfilePrisms(profiles, f.def.Sketch.Plane(), orderedSpan(0, -d), f.def.Taper,
 		featOr(f.featName, "emboss")+"/relief", in.Diag)
+	f.reliefTool = relief // exposed via ToolApplications so a pattern replicates the cut too (#2066)
 	run := in
 	run.Bodies = bodies
 	out, err := combine(run, relief, ops.Cut)

--- a/model/feature/emboss_wrap.go
+++ b/model/feature/emboss_wrap.go
@@ -21,10 +21,21 @@ import (
 // bureaucracy: it is what fixes the correspondence. Without it there is no distinguished point to
 // anchor the profile at, and no direction in the sketch that measures arc length one-for-one.
 //
-// Only the cylinder is built here. Inventor also wraps to a cone, whose development is a circular
-// sector rather than a rectangle — a different frame (the tangent line is a generator, and the
-// angle per unit arc varies with slant distance). A cone is refused with that said out loud
-// rather than wrapped as if it were a cylinder, which would silently distort the profile.
+// The cylinder and the cone are both built here, behind wrapSurface. A cone's development is a
+// circular SECTOR rather than a rectangle (the tangent line is a generator through the apex, and the
+// angle per unit arc varies with slant distance), so it carries its own frame (emboss_wrap_cone.go);
+// the tool builder in emboss_wrap_tool.go is written against the interface and treats both the same.
+
+// wrapSurface is the developable face an emboss is wrapped onto (a cylinder or a cone). `level` is a
+// surface-defined coordinate the tool builder passes through opaquely: the cylinder reads it as an
+// absolute radius from the axis, the cone as a signed offset along the surface normal (0 on the
+// face). offsets() hands back the inner and outer level for one pad, and angleSpan sizes the
+// circumferential resampling so the wrapped loop follows the curvature instead of chording it.
+type wrapSurface interface {
+	at(p math.Point2, plane sketch.Plane, level float64) math.Point3
+	angleSpan(a, b math.Point2, plane sketch.Plane) float64
+	offsets(depth float64, engrave bool) (inner, outer float64, err error)
+}
 
 // wrapAngularStep is the finest angular step a wrapped loop is discretized to, matching the
 // revolve's 64-per-turn budget so a wrapped emboss is as round as the shaft it sits on. The
@@ -56,11 +67,11 @@ func (f *EmbossFeature) wrapOntoFace(in Input, profiles []*sketch.Profile, d flo
 	if err != nil {
 		return Output{}, fmt.Errorf("emboss: wrapToFace: %w", err)
 	}
-	frame, err := embossWrapFrameOn(face, f.def.Sketch.Plane())
+	surf, err := embossWrapSurfaceOn(face, f.def.Sketch.Plane())
 	if err != nil {
 		return Output{}, err
 	}
-	f.tool, err = wrappedEmbossTool(profiles, f.def.Sketch.Plane(), frame, d,
+	f.tool, err = wrappedEmbossTool(profiles, f.def.Sketch.Plane(), surf, d,
 		f.def.Type.engraves(), featOr(f.featName, "emboss"), in.Diag)
 	if err != nil {
 		return Output{}, err
@@ -77,19 +88,23 @@ func (f *EmbossFeature) combineWrapped(in Input, mt identity.MatchType) (Output,
 	return Output{Bodies: bodies, Heals: faceHeal(f.def.WrapFaceKey, mt)}, nil
 }
 
-// embossWrapFrameOn derives the correspondence between the sketch plane and the wrap face,
-// refusing every face the wrap is not defined on (Inventor limits it to one planar or conical
-// face; a planar one needs no wrap at all).
-func embossWrapFrameOn(face *topo.Face, plane sketch.Plane) (embossWrapFrame, error) {
-	switch cyl := face.Geometry().(type) {
+// embossWrapSurfaceOn derives the correspondence between the sketch plane and the wrap face,
+// dispatching on the face geometry: a cylinder or a cone (each tangent to the sketch plane). A
+// planar face needs no wrap; every other surface is refused with that said out loud rather than
+// wrapped as if it were a cylinder, which would silently distort the profile.
+func embossWrapSurfaceOn(face *topo.Face, plane sketch.Plane) (wrapSurface, error) {
+	switch g := face.Geometry().(type) {
 	case geom.Cylinder:
-		return embossWrapFrameFor(cyl, plane)
+		return embossWrapFrameFor(g, plane)
 	case *geom.Cylinder:
-		return embossWrapFrameFor(*cyl, plane)
+		return embossWrapFrameFor(*g, plane)
+	case geom.Cone:
+		return coneWrapFrameFor(g, plane)
+	case *geom.Cone:
+		return coneWrapFrameFor(*g, plane)
 	default:
-		return embossWrapFrame{}, fmt.Errorf("emboss: wrapToFace needs a cylindrical face, got %T; "+
-			"a planar face needs no wrap, and a cone (whose development is a sector, not a "+
-			"rectangle) is not supported yet", face.Geometry())
+		return nil, fmt.Errorf("emboss: wrapToFace needs a cylindrical or conical face, got %T; "+
+			"a planar face needs no wrap, and a free-form (b-spline) face is not supported", g)
 	}
 }
 
@@ -134,9 +149,10 @@ func newEmbossWrapFrame(cyl geom.Cylinder, plane sketch.Plane, axis, normal math
 	}
 }
 
-// at maps a sketch point onto the cylinder at the given radius: the displacement from the tangency
-// is split into an axial part, which slides along the axis, and a circumferential part, which is
-// spent as ARC LENGTH — so it becomes an angle of arc/radius.
+// at maps a sketch point onto the cylinder at the given radius (the cylinder's `level` is an
+// absolute radius from the axis): the displacement from the tangency is split into an axial part,
+// which slides along the axis, and a circumferential part, which is spent as ARC LENGTH — so it
+// becomes an angle of arc/radius.
 func (fr embossWrapFrame) at(p math.Point2, plane sketch.Plane, radius float64) math.Point3 {
 	v := plane.ToModel(fr.tangency).VectorTo(plane.ToModel(p))
 	axial, arc := v.Dot(fr.cyl.AxisDir.AsVector()), v.Dot(fr.circum)
@@ -147,6 +163,12 @@ func (fr embossWrapFrame) at(p math.Point2, plane sketch.Plane, radius float64) 
 	return rot.TransformPoint(base)
 }
 
+// offsets returns the inner and outer radius the cylinder pad is built between — wrapRadii, exposed
+// as the wrapSurface method (the cylinder's level is an absolute radius, so the offsets ARE radii).
+func (fr embossWrapFrame) offsets(depth float64, engrave bool) (inner, outer float64, err error) {
+	return wrapRadii(fr.cyl.Radius, depth, engrave)
+}
+
 // angleSpan is the angle a sketch-space distance subtends on the cylinder — how the resampling
 // step is chosen.
 func (fr embossWrapFrame) angleSpan(a, b math.Point2, plane sketch.Plane) float64 {
@@ -154,17 +176,17 @@ func (fr embossWrapFrame) angleSpan(a, b math.Point2, plane sketch.Plane) float6
 	return stdmath.Abs(float64(v.Dot(fr.circum))) / fr.cyl.Radius
 }
 
-// wrappedLoop maps a closed sketch polygon onto the cylinder at one radius, resampling each
-// segment first so the wrapped edge follows the curvature instead of chording across it.
-func wrappedLoop(poly []math.Point2, plane sketch.Plane, fr embossWrapFrame, radius float64) []math.Point3 {
+// wrappedLoop maps a closed sketch polygon onto the surface at one level, resampling each segment
+// first so the wrapped edge follows the curvature instead of chording across it.
+func wrappedLoop(poly []math.Point2, plane sketch.Plane, surf wrapSurface, level float64) []math.Point3 {
 	out := make([]math.Point3, 0, len(poly))
 	n := len(poly)
 	for i := 0; i < n; i++ {
 		a, b := poly[i], poly[(i+1)%n]
-		steps := wrapSegmentSteps(fr.angleSpan(a, b, plane))
+		steps := wrapSegmentSteps(surf.angleSpan(a, b, plane))
 		for s := 0; s < steps; s++ { // b is emitted as the next segment's a
 			t := float64(s) / float64(steps)
-			out = append(out, fr.at(lerpPoint2(a, b, t), plane, radius))
+			out = append(out, surf.at(lerpPoint2(a, b, t), plane, level))
 		}
 	}
 	return out

--- a/model/feature/emboss_wrap_cone.go
+++ b/model/feature/emboss_wrap_cone.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// Wrapping an emboss onto a CONE (Inventor's Wrap to Face on a conical face). A cone is developable,
+// so — like the cylinder — arc length on the face equals distance in the sketch when the sketch
+// plane is TANGENT to it. But a cone's development is a circular SECTOR about the apex, not a
+// rectangle: every tangent plane of a cone passes through the apex, distance from the apex in the
+// plane IS the slant distance on the cone, and a full turn around the cone (Δu = 2π) unrolls to a
+// sector of only 2π·sin(α). So the correspondence is POLAR about the apex — a sketch point at polar
+// (ρ, φ) from the apex lands at slant s = ρ and turn (u − u0) = φ / sin(α), i.e. the angle a unit
+// arc subtends SHRINKS with slant. That is exactly what wrapping a cone as if it were a cylinder
+// would get wrong. The offset an emboss is raised by is measured along the cone's surface NORMAL
+// (cos α·radial − sin α·axis), which tilts back toward the apex — not radially as on a cylinder.
+
+// coneWrapFrame is the sketch→cone correspondence, built once the plane is known tangent. gDir is
+// the unit generator direction in the plane (φ = 0) and circ0 the in-plane circumferential
+// direction (φ = +90°, the +u sense); radial0 = radial(u0) is the tangency generator's outward
+// radial. refRadius is the local surface radius at the sketch origin, sizing the overlap pad.
+type coneWrapFrame struct {
+	cone       geom.Cone
+	apex       math.Point3
+	axis       math.Vector3
+	sinA, cosA float64
+	tanA       float64
+	radial0    math.Vector3 // radial(u0): outward, ⟂ axis, in the sketch plane
+	circ0      math.Vector3 // axis × radial0: circumferential at u0, in the plane, +u sense
+	gDir       math.Vector3 // unit generator at u0 = cosA·axis + sinA·radial0 (lies in the plane)
+	refRadius  float64      // local radius (slant·sinA) at the sketch origin — the pad reference
+}
+
+// wrapConeTangencyTol mirrors wrapTangencyTol: a loose, length-relative admissibility test on an
+// authored work plane, not a fit — so it survives the plane having been built from the face itself.
+const wrapConeTangencyTol = 1e-6
+
+// coneWrapFrameFor builds the frame for a cone, checking the two things the wrap needs and deriving
+// the tangency generator from the plane's own normal. A cone's tangent plane (a) passes through the
+// apex and (b) has a normal tilted so n·axis = −sin(α) (the outward normal leans back toward the
+// apex). Both together fix a single generator, whose outward radial is (n + sin α·axis)/cos α.
+func coneWrapFrameFor(cone geom.Cone, plane sketch.Plane) (coneWrapFrame, error) {
+	axis := cone.AxisDir.AsVector()
+	sinA, cosA := stdmath.Sin(cone.HalfAngle), stdmath.Cos(cone.HalfAngle)
+	ref := float64(cone.Apex.DistanceTo(plane.Origin()))
+	if ref <= 0 {
+		return coneWrapFrame{}, fmt.Errorf("emboss: wrapToFace: the sketch origin sits on the cone apex; sketch away from the apex, where the surface has a defined tangent")
+	}
+	n := orientedOutwardNormal(cone, plane, axis)
+	if apexOff := stdmath.Abs(float64(cone.Apex.VectorTo(plane.Origin()).Dot(n))); apexOff > wrapConeTangencyTol*ref {
+		return coneWrapFrame{}, fmt.Errorf("emboss: wrapToFace needs the sketch plane through the cone's APEX (every tangent plane of a cone does); the apex stands %g off it — sketch on a work plane tangent to the cone", apexOff)
+	}
+	if along := float64(n.Dot(axis)) + sinA; stdmath.Abs(along) > wrapConeTangencyTol {
+		return coneWrapFrame{}, fmt.Errorf("emboss: wrapToFace needs the sketch plane TANGENT to the cone (its normal·axis = −sin(halfAngle) = %g), but the normal·axis is %g; sketch on a work plane tangent to the face", -sinA, float64(n.Dot(axis)))
+	}
+	radial0, err := math.UnitVector3FromVector(n.Add(axis.Scale(math.Scalar(sinA))).Scale(math.Scalar(1 / cosA)))
+	if err != nil {
+		return coneWrapFrame{}, fmt.Errorf("emboss: wrapToFace: degenerate cone tangency frame")
+	}
+	fr := coneWrapFrame{
+		cone: cone, apex: cone.Apex, axis: axis, sinA: sinA, cosA: cosA, tanA: stdmath.Tan(cone.HalfAngle),
+		radial0: radial0.AsVector(), circ0: axis.Cross(radial0.AsVector()), gDir: axis.Scale(cosA).Add(radial0.AsVector().Scale(sinA)),
+	}
+	fr.refRadius = fr.slantOf(plane.Origin()) * sinA
+	return fr, nil
+}
+
+// orientedOutwardNormal returns the plane normal flipped to point AWAY from the axis (the outward
+// side of the cone), so the tangency algebra derives the outward radial rather than its opposite.
+func orientedOutwardNormal(cone geom.Cone, plane sketch.Plane, axis math.Vector3) math.Vector3 {
+	n := plane.Normal().AsVector()
+	w := cone.Apex.VectorTo(plane.Origin())
+	radialAtOrigin := w.Sub(axis.Scale(w.Dot(axis))) // origin's outward radial from the axis
+	if n.Dot(radialAtOrigin) < 0 {
+		return n.Scale(-1)
+	}
+	return n
+}
+
+// slantOf is the distance from the apex to a model point measured IN the sketch plane (the point's
+// slant distance on the cone, since the tangent plane's radial-from-apex equals the cone's slant).
+func (fr coneWrapFrame) slantOf(p math.Point3) float64 {
+	w := fr.apex.VectorTo(p)
+	along, perp := float64(w.Dot(fr.gDir)), float64(w.Dot(fr.circ0))
+	return stdmath.Hypot(along, perp)
+}
+
+// polar decomposes a sketch point into its polar coordinates about the apex in the sketch plane:
+// ρ the slant distance, φ the turn from the tangency generator (gDir at φ = 0, circ0 at +90°).
+func (fr coneWrapFrame) polar(p math.Point2, plane sketch.Plane) (rho, phi float64) {
+	w := fr.apex.VectorTo(plane.ToModel(p))
+	along, perp := float64(w.Dot(fr.gDir)), float64(w.Dot(fr.circ0))
+	return stdmath.Hypot(along, perp), stdmath.Atan2(perp, along)
+}
+
+// radialAt returns radial(u) for u = u0 + theta, by rotating radial0 toward circ0 by theta.
+func (fr coneWrapFrame) radialAt(theta float64) math.Vector3 {
+	cos, sin := stdmath.Cos(theta), stdmath.Sin(theta)
+	return fr.radial0.Scale(math.Scalar(cos)).Add(fr.circ0.Scale(math.Scalar(sin)))
+}
+
+// at maps a sketch point onto the cone, offset by `level` along the surface normal (level = 0 lands
+// on the face; +depth is raised out). The polar (ρ, φ) about the apex becomes slant s = ρ (axial
+// v = s·cos α, local radius s·sin α) and turn theta = φ / sin α; the point is then pushed `level`
+// along the cone normal cos α·radial(u) − sin α·axis.
+func (fr coneWrapFrame) at(p math.Point2, plane sketch.Plane, level float64) math.Point3 {
+	rho, phi := fr.polar(p, plane)
+	theta := phi / fr.sinA
+	radial := fr.radialAt(theta)
+	v := rho * fr.cosA
+	surface := fr.apex.
+		TranslateBy(fr.axis.Scale(math.Scalar(v))).
+		TranslateBy(radial.Scale(math.Scalar(rho * fr.sinA)))
+	normal := radial.Scale(math.Scalar(fr.cosA)).Sub(fr.axis.Scale(math.Scalar(fr.sinA)))
+	return surface.TranslateBy(normal.Scale(math.Scalar(level)))
+}
+
+// angleSpan is the turn (in u) a sketch segment subtends on the cone — how the resampling step is
+// chosen, so the wrapped loop follows the cone's circumferential curvature. The u-turn is the
+// apex-subtended angle φ divided by sin α (Δu = Δφ / sin α).
+func (fr coneWrapFrame) angleSpan(a, b math.Point2, plane sketch.Plane) float64 {
+	_, pa := fr.polar(a, plane)
+	_, pb := fr.polar(b, plane)
+	return stdmath.Abs(pb-pa) / fr.sinA
+}
+
+// offsets returns the inner and outer NORMAL offset the cone pad is built between (0 on the face).
+// A raise sinks the inner loop a pad into the material and lifts the outer to +depth; an engrave
+// cuts to −depth and lifts the outer a pad clear of the skin. The pad is the cylinder's sagitta rule
+// at the local radius, doubled to comfortably cover a profile reaching past the sketch origin —
+// over-padding only buries the hidden loop deeper, never touching the visible +depth/−depth face.
+func (fr coneWrapFrame) offsets(depth float64, engrave bool) (inner, outer float64, err error) {
+	pad := 4 * fr.refRadius * (1 - stdmath.Cos(wrapAngularStep/2))
+	if !engrave {
+		return -pad, depth, nil
+	}
+	return -depth, pad, nil
+}

--- a/model/feature/emboss_wrap_cone_test.go
+++ b/model/feature/emboss_wrap_cone_test.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// coneWrapFixture builds a cone (apex at the origin, axis +Z, radial(0) = +X, the given half angle)
+// and a sketch plane TANGENT to it along the u=0 generator, with the sketch origin at slant s0. The
+// plane's in-plane X runs circumferentially and Y runs along the slant (the wrap convention).
+func coneWrapFixture(t *testing.T, halfAngle, s0 float64) (coneWrapFrame, sketch.Plane) {
+	t.Helper()
+	cone, err := geom.NewConeWithRef(math.P3(0, 0, 0), math.V3(0, 0, 1), math.V3(1, 0, 0), halfAngle)
+	if err != nil {
+		t.Fatalf("NewConeWithRef: %v", err)
+	}
+	sinA, cosA := stdmath.Sin(halfAngle), stdmath.Cos(halfAngle)
+	g := math.V3(math.Scalar(sinA), 0, math.Scalar(cosA)) // unit generator ĝ at u=0
+	origin := math.P3(math.Scalar(s0*sinA), 0, math.Scalar(s0*cosA))
+	plane, err := sketch.NewPlane(origin, math.V3(0, 1, 0).AsUnit(), g.AsUnit())
+	if err != nil {
+		t.Fatalf("NewPlane: %v", err)
+	}
+	fr, err := coneWrapFrameFor(cone, plane)
+	if err != nil {
+		t.Fatalf("coneWrapFrameFor: %v", err)
+	}
+	return fr, plane
+}
+
+// TestConeWrapFrameHugsAndIsIsometric pins the cone development map: mapped points lie ON the cone,
+// a radial sketch segment keeps its length (the developable-wrap isometry), and a circumferential
+// offset subtends the RIGHT angle about the axis (φ/sinα — the angle a unit arc subtends shrinks
+// with slant). Each check is a distinct failure mode a wrong map would trip.
+func TestConeWrapFrameHugsAndIsIsometric(t *testing.T) {
+	const halfAngle, s0 = 0.5, 4.0
+	fr, plane := coneWrapFixture(t, halfAngle, s0)
+	sinA := stdmath.Sin(halfAngle)
+	tanA := stdmath.Tan(halfAngle)
+
+	// 1) HUG: every mapped point (level 0) satisfies the cone equation radius = v·tanα.
+	for _, sx := range []float64{-2, -1, 0, 1, 2} {
+		for _, sy := range []float64{-1.5, 0, 1.5} {
+			p := fr.at(math.P2(math.Scalar(sx), math.Scalar(sy)), plane, 0)
+			r := stdmath.Hypot(float64(p.X), float64(p.Y))
+			if off := stdmath.Abs(r - float64(p.Z)*tanA); off > 1e-9 {
+				t.Errorf("sketch (%g,%g) maps %v — %g off the cone surface (radius ≠ v·tanα)", sx, sy, p, off)
+			}
+		}
+	}
+	// 2) RADIAL ISOMETRY: a radial sketch segment (Δslant along Y) maps to a 3D segment of EQUAL
+	// length — the defining property of a developable wrap. A cosα slip here would stretch/shrink it.
+	a := fr.at(math.P2(0, 0), plane, 0)
+	b := fr.at(math.P2(0, 2), plane, 0)
+	if got := float64(a.DistanceTo(b)); stdmath.Abs(got-2) > 1e-9 {
+		t.Errorf("a radial sketch segment of length 2 maps to a 3D length of %g, want 2 (isometry)", got)
+	}
+	// 3) ANGLE-PER-ARC: sketch (sx,0) subtends apex-angle φ = atan2(sx, s0); it must land at azimuth
+	// φ/sinα about the axis. A sinα slip (or dropping it) puts the arc at the wrong angle.
+	for _, sx := range []float64{0.5, 1, 2} {
+		phi := stdmath.Atan2(sx, s0)
+		p := fr.at(math.P2(math.Scalar(sx), 0), plane, 0)
+		az := stdmath.Atan2(float64(p.Y), float64(p.X))
+		if want := phi / sinA; stdmath.Abs(az-want) > 1e-9 {
+			t.Errorf("sketch (%g,0) lands at azimuth %g about the axis, want φ/sinα = %g", sx, az, want)
+		}
+	}
+}
+
+// TestConeWrapFrameOffsetsAlongNormal checks the emboss depth is applied along the cone's SURFACE
+// NORMAL (cosα·radial − sinα·axis), which tilts back toward the apex — not radially as on a
+// cylinder. A radial offset would leave the axial component at zero.
+func TestConeWrapFrameOffsetsAlongNormal(t *testing.T) {
+	const halfAngle, s0 = 0.5, 4.0
+	fr, plane := coneWrapFixture(t, halfAngle, s0)
+	p2 := math.P2(1, math.Scalar(0.5))
+	surface := fr.at(p2, plane, 0)
+	const d = 0.3
+	raised := fr.at(p2, plane, d)
+	if got := float64(surface.DistanceTo(raised)); stdmath.Abs(got-d) > 1e-9 {
+		t.Errorf("level %g offsets the point %g from the surface, want %g", d, got, d)
+	}
+	axial := float64(surface.VectorTo(raised).Dot(math.V3(0, 0, 1)))
+	if want := -stdmath.Sin(halfAngle) * d; stdmath.Abs(axial-want) > 1e-9 {
+		t.Errorf("the offset's axial component is %g, want −sinα·d = %g (the offset is along the cone normal, not radial)", axial, want)
+	}
+}
+
+// coneFaceOf returns a body's single conical face's geometry and reference key.
+func coneFaceOf(t *testing.T, b *topo.Body) (geom.Cone, []byte) {
+	t.Helper()
+	for _, f := range b.Faces() {
+		switch c := f.Geometry().(type) {
+		case geom.Cone:
+			return c, f.ReferenceKey()
+		case *geom.Cone:
+			return *c, f.ReferenceKey()
+		}
+	}
+	t.Fatal("no conical face on the body")
+	return geom.Cone{}, nil
+}
+
+// tangentPlaneToCone builds a sketch plane tangent to the cone along its u=0 generator, with the
+// sketch origin at slant s0 (in-plane X circumferential, Y along the slant) — the plane a cone wrap
+// needs. Mirrors the cylinder's shaftTangentPlane.
+func tangentPlaneToCone(t *testing.T, cone geom.Cone, s0 float64) sketch.Plane {
+	t.Helper()
+	axis, radial0 := cone.AxisDir.AsVector(), cone.Ref.AsVector()
+	sinA, cosA := stdmath.Sin(cone.HalfAngle), stdmath.Cos(cone.HalfAngle)
+	g := axis.Scale(math.Scalar(cosA)).Add(radial0.Scale(math.Scalar(sinA)))
+	origin := cone.Apex.TranslateBy(g.Scale(math.Scalar(s0)))
+	plane, err := sketch.NewPlane(origin, axis.Cross(radial0).AsUnit(), g.AsUnit())
+	if err != nil {
+		t.Fatalf("tangent plane: %v", err)
+	}
+	return plane
+}
+
+// TestWrappedEmbossOnConeIsAValidSolidThatAddsMaterial is the #2065 end-to-end acceptance: a small
+// rectangle embossed onto a real conical face (the chamfer of a big cylinder rim) builds a valid
+// watertight solid and adds a glyph-sized amount of material — proving the cone dispatch, tangency
+// frame, tool build and boolean compose over the real kernel. The map's geometric correctness (hug,
+// isometry) is pinned by the frame unit tests above.
+func TestWrappedEmbossOnConeIsAValidSolidThatAddsMaterial(t *testing.T) {
+	fs, rim := extrudedCylinderTopRim(t, 20, 40)
+	NewDressUpFeatures(fs).AddChamfer([][]byte{rim}, func() float64 { return 10 })
+	fs.Recompute()
+	before := ops.BodyGeometryProperties(fs.Result()[0], ops.DefaultQuality()).Volume
+	cone, key := coneFaceOf(t, fs.Result()[0])
+
+	// Sketch origin mid-band on the chamfer cone (its slant runs ≈14→28); a 1×1 cm raise sits well
+	// inside it. Depth 0.3 cm along the surface normal.
+	pf := NewEmbossFeatures(fs).Add(rectSketchOn(tangentPlaneToCone(t, cone, 21), -0.5, -0.5, 0.5, 0.5),
+		[]int{0}, func() float64 { return 0.3 }, EmbossFromFace, 0)
+	pf.Definition().(*EmbossFeature).Definition().WrapFaceKey = key
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("wrapped cone emboss went sick: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("cone-wrapped emboss is not a valid solid: %+v", r.Issues)
+	}
+	raise := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume - before
+	if raise < 0.1 || raise > 0.6 {
+		t.Errorf("cone emboss raised %g cm³, want a ~1cm²×0.3cm glyph-sized raise in [0.1, 0.6]", raise)
+	}
+}
+
+// TestConeWrapRejectsNonTangentPlane refuses a plane the cone wrap is not defined on: a
+// cylinder-style plane whose normal is ⟂ the axis is NOT tangent to a cone (a cone's tangent plane
+// tilts by the half angle and passes through the apex).
+func TestConeWrapRejectsNonTangentPlane(t *testing.T) {
+	cone, err := geom.NewConeWithRef(math.P3(0, 0, 0), math.V3(0, 0, 1), math.V3(1, 0, 0), 0.5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bad, err := sketch.NewPlane(math.P3(1, 0, math.Scalar(2)), math.V3(0, 1, 0).AsUnit(), math.V3(0, 0, 1).AsUnit())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := coneWrapFrameFor(cone, bad); err == nil {
+		t.Error("a plane whose normal is ⟂ the axis is not tangent to a cone; want a refusal")
+	}
+}

--- a/model/feature/emboss_wrap_tool.go
+++ b/model/feature/emboss_wrap_tool.go
@@ -19,15 +19,15 @@ import (
 // of it, exactly as the flat prism path drills them (#1893).
 
 // wrappedEmbossTool merges every profile's wrapped pad into one tool body.
-func wrappedEmbossTool(profiles []*sketch.Profile, plane sketch.Plane, fr embossWrapFrame,
+func wrappedEmbossTool(profiles []*sketch.Profile, plane sketch.Plane, surf wrapSurface,
 	d float64, engrave bool, feat string, rec *diag.Recorder) (*topo.Body, error) {
-	inner, outer, err := wrapRadii(fr.cyl.Radius, d, engrave)
+	inner, outer, err := surf.offsets(d, engrave)
 	if err != nil {
 		return nil, err
 	}
 	pads := make([]*topo.Body, len(profiles))
 	for i, p := range profiles {
-		pads[i], err = wrappedProfilePad(p, plane, fr, inner, outer, prismName(feat, i, len(profiles)), rec)
+		pads[i], err = wrappedProfilePad(p, plane, surf, inner, outer, prismName(feat, i, len(profiles)), rec)
 		if err != nil {
 			return nil, err
 		}
@@ -55,23 +55,23 @@ func wrapRadii(radius, d float64, engrave bool) (inner, outer float64, err error
 }
 
 // wrappedProfilePad is one profile's pad with its inner loops cut back out.
-func wrappedProfilePad(p *sketch.Profile, plane sketch.Plane, fr embossWrapFrame,
+func wrappedProfilePad(p *sketch.Profile, plane sketch.Plane, surf wrapSurface,
 	inner, outer float64, feat string, rec *diag.Recorder) (*topo.Body, error) {
-	pad, err := wrappedSkin(p.OuterLoop().Polygon(), plane, fr, inner, outer, feat)
+	pad, err := wrappedSkin(p.OuterLoop().Polygon(), plane, surf, inner, outer, feat)
 	if err != nil {
 		return nil, err
 	}
-	return drillWrappedHoles(pad, p.InnerLoops(), plane, fr, inner, outer, feat, rec)
+	return drillWrappedHoles(pad, p.InnerLoops(), plane, surf, inner, outer, feat, rec)
 }
 
 // drillWrappedHoles cuts each inner loop out of the pad. Every hole tool overshoots BOTH radial
 // ends by the pad's own thickness so the cut passes clean through, the radial counterpart of
 // drillProfileHoles' axial overshoot.
-func drillWrappedHoles(pad *topo.Body, inner []sketch.Loop, plane sketch.Plane, fr embossWrapFrame,
+func drillWrappedHoles(pad *topo.Body, inner []sketch.Loop, plane sketch.Plane, surf wrapSurface,
 	lo, hi float64, feat string, rec *diag.Recorder) (*topo.Body, error) {
 	margin := hi - lo
 	for j, loop := range inner {
-		hole, err := wrappedSkin(loop.Polygon(), plane, fr, lo-margin, hi+margin,
+		hole, err := wrappedSkin(loop.Polygon(), plane, surf, lo-margin, hi+margin,
 			fmt.Sprintf("%s/hole%d", feat, j))
 		if err != nil {
 			return nil, err
@@ -85,11 +85,11 @@ func drillWrappedHoles(pad *topo.Body, inner []sketch.Loop, plane sketch.Plane, 
 
 // wrappedSkin lays one closed loop on the face at two radii and skins between them: the wrapped
 // loops become the pad's inner and outer faces, and the swept solid's caps close its walls.
-func wrappedSkin(poly []math.Point2, plane sketch.Plane, fr embossWrapFrame,
+func wrappedSkin(poly []math.Point2, plane sketch.Plane, surf wrapSurface,
 	inner, outer float64, feat string) (*topo.Body, error) {
 	sections := [][]math.Point3{
-		wrappedLoop(poly, plane, fr, inner),
-		wrappedLoop(poly, plane, fr, outer),
+		wrappedLoop(poly, plane, surf, inner),
+		wrappedLoop(poly, plane, surf, outer),
 	}
 	body, err := sweptSolid(sections, false, feat)
 	if err != nil {

--- a/model/feature/engine.go
+++ b/model/feature/engine.go
@@ -284,7 +284,7 @@ func (fs *PartFeatures) PreviewResult(candidate Feature) ([]*topo.Body, error) {
 		return nil, errors.New("feature: PreviewResult got a nil candidate")
 	}
 	bodies := fs.prefixBodies(fs.effectiveEnd())
-	out, err := candidate.Recompute(Input{Bodies: bodies, Params: fs.params, SourceTool: fs.sourceTool, Relief: fs.reliefSpec()})
+	out, err := candidate.Recompute(Input{Bodies: bodies, Params: fs.params, SourceTool: fs.sourceTool, SourceTools: fs.sourceTools, Relief: fs.reliefSpec()})
 	if err != nil {
 		return nil, err
 	}
@@ -321,7 +321,7 @@ func (fs *PartFeatures) evaluateBody(pf *PartFeature, bodies []*topo.Body, sick 
 	}
 	pf.recomputes++
 	rec := &diag.Recorder{}
-	out, err := safeRecompute(pf, Input{Bodies: bodies, Params: fs.params, SourceTool: fs.sourceTool,
+	out, err := safeRecompute(pf, Input{Bodies: bodies, Params: fs.params, SourceTool: fs.sourceTool, SourceTools: fs.sourceTools,
 		Diag: rec, Relief: fs.reliefSpec(), Corner: fs.cornerReliefSpec(), Transition: fs.bendTransition(), MiterGap: fs.miterGapOf(), PriorBends: fs.bendsBefore(pf)})
 	pf.diags = rec.Records()
 	return fs.classify(pf, bodies, out, err, sick)
@@ -373,6 +373,25 @@ func (fs *PartFeatures) sourceTool(id ID) (*topo.Body, ops.PartFeatureOperation,
 		return nil, op, false
 	}
 	return tool, op, true
+}
+
+// sourceTools is sourceTool's multi-tool sibling (#2066): a source feature that applies several
+// booleans (a from-plane emboss raises and cuts about its plane) reports each here so a pattern
+// replicates all of them. ok is false — and the caller falls back to the single sourceTool — for a
+// feature that applies one tool or whose multi-tool set is empty this recompute.
+func (fs *PartFeatures) sourceTools(id ID) ([]ToolApplication, bool) {
+	for _, it := range fs.items {
+		if it.id != id {
+			continue
+		}
+		if mtf, ok := it.feature.(MultiToolFeature); ok {
+			if apps := mtf.ToolApplications(); len(apps) > 0 {
+				return apps, true
+			}
+		}
+		return nil, false
+	}
+	return nil, false
 }
 
 // operationOf returns a feature's boolean operation, or NewBody when it does not apply one

--- a/model/feature/feature.go
+++ b/model/feature/feature.go
@@ -51,6 +51,12 @@ type Input struct {
 	Bodies     []*topo.Body
 	Params     *param.Parameters
 	SourceTool func(id ID) (tool *topo.Body, op ops.PartFeatureOperation, ok bool)
+	// SourceTools is SourceTool's multi-tool sibling: a source feature that applies MORE THAN ONE
+	// boolean (a from-plane emboss raises material on one side of its plane AND cuts it on the
+	// other) reports each (tool, op) here so a pattern replicates all of them, not just the first
+	// (#2066). ok is false — and the caller falls back to the single SourceTool — for a feature that
+	// applies one tool or whose tools are unrecoverable. Nil for engines that resolve no sources.
+	SourceTools func(id ID) (tools []ToolApplication, ok bool)
 	// Diag collects the kernel diagnostics raised while the feature rebuilds — the facet/CSG
 	// fallback defects a boolean records when it abandons the analytic path (#1601). The engine
 	// installs a fresh recorder per evaluation and stores what it collected on the PartFeature;
@@ -87,6 +93,24 @@ type OperationalFeature interface {
 type ToolFeature interface {
 	OperationalFeature
 	ToolBody() *topo.Body
+}
+
+// ToolApplication is one boolean a feature applies: a tool body and the operation combined with
+// it. A feature that applies several (a from-plane emboss) reports them via [MultiToolFeature] so a
+// pattern re-applies every one at each occurrence (#2066).
+type ToolApplication struct {
+	Body *topo.Body
+	Op   ops.PartFeatureOperation
+}
+
+// MultiToolFeature is a [ToolFeature] that applies MORE THAN ONE boolean tool. A pattern/mirror
+// replicates every application with its own operation, so the copies match the seed rather than
+// carrying only the first tool (#2066: a patterned from-plane emboss kept the raise but dropped the
+// relief cut). ToolApplications returns nil when the feature applied a single tool this recompute —
+// the caller then falls back to [ToolFeature.ToolBody]/[OperationalFeature.Operation].
+type MultiToolFeature interface {
+	ToolFeature
+	ToolApplications() []ToolApplication
 }
 
 // Output is what a feature produces: the new running body state, plus any reference

--- a/model/feature/patterns.go
+++ b/model/feature/patterns.go
@@ -212,7 +212,19 @@ func resolveGroup(in Input, sources []ID) (tools []groupTool, boolean bool) {
 	for _, id := range sources {
 		tool, op, ok := in.SourceTool(id)
 		if !booleanReplicable(op) {
-			return nil, false
+			return nil, false // a new-body placement — the caller copies whole bodies
+		}
+		// A multi-tool source (a from-plane emboss, #2066) replicates EVERY application; a
+		// single-tool source falls back to its one (tool, op). An unrecoverable single tool no-ops
+		// the pattern (return true) rather than multiplying whole bodies.
+		if apps, multi := in.sourceApplications(id); multi {
+			for _, a := range apps {
+				if !booleanReplicable(a.Op) {
+					return nil, false
+				}
+				tools = append(tools, groupTool{body: a.Body, op: a.Op})
+			}
+			continue
 		}
 		if !ok {
 			return nil, true
@@ -220,6 +232,16 @@ func resolveGroup(in Input, sources []ID) (tools []groupTool, boolean bool) {
 		tools = append(tools, groupTool{body: tool, op: op})
 	}
 	return tools, true
+}
+
+// sourceApplications returns the source's multi-tool applications when it has them (a from-plane
+// emboss's raise + relief cut, #2066); multi is false for a single-tool source, so resolveGroup
+// uses the single SourceTool instead.
+func (in Input) sourceApplications(id ID) (apps []ToolApplication, multi bool) {
+	if in.SourceTools == nil {
+		return nil, false
+	}
+	return in.SourceTools(id)
 }
 
 // booleanReplicable reports whether an operation is one the pattern re-applies as a boolean

--- a/model/feature/rib_parallel.go
+++ b/model/feature/rib_parallel.go
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"errors"
+	"fmt"
+	stdmath "math"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// The PARALLEL (lateral) rib — Inventor's RibDefinition.IsRib = True (#2064). Where the normal/web
+// rib thickens the path IN the sketch plane and extrudes ALONG the plane normal, the parallel rib
+// does the opposite: it thickens the profile ALONG the plane normal (a thin wall of the given
+// thickness, centred on the sketch plane) and grows that wall IN the plane, perpendicular to the
+// path, until it lands on the part. The result is the same wall rotated 90° — the form used for a
+// moulded part whose sketch is a section through its wall. A draft is refused (Inventor allows a
+// taper only when the direction is normal to the plane).
+
+// recomputeParallel builds the lateral rib: a footprint that is the path grown perpendicular in the
+// plane by the depth, extruded by the thickness ALONG the plane normal (centred, no taper).
+func (r *RibFeature) recomputeParallel(in Input, pts []math.Point2, t float64) (Output, error) {
+	if r.def.Draft != 0 {
+		return Output{}, errors.New("rib: a draft/taper needs the direction NORMAL to the sketch " +
+			"plane; Inventor refuses a taper on a parallel (lateral) rib, so this one does too")
+	}
+	plane := r.def.Sketch.Plane()
+	toLeft, depth, err := r.parallelGrowth(in, pts)
+	if err != nil {
+		return Output{}, err
+	}
+	footprint := ensureCCW2(parallelFootprint(pts, toLeft, depth))
+	// Thickness along the plane NORMAL, centred on the sketch plane; no taper (refused above). The
+	// Surface operation builds walls only (no caps), as the normal form does.
+	r.tool = buildExtrusionShell(footprint, plane, orderedSpan(-t/2, t/2), 0, "rib", r.def.Operation != ops.Surface)
+	bodies, err := combine(in, r.tool, r.def.Operation)
+	if err != nil {
+		return Output{}, err
+	}
+	return Output{Bodies: bodies}, nil
+}
+
+// parallelGrowth resolves how far and which way the lateral wall grows in the plane: perpendicular
+// to the path, toward the side the part lies on. toLeft is the growth side (the path's left normal);
+// depth is |Depth| for a finite rib, or the FARTHEST distance to the part for a to-next rib (so the
+// whole wall lands, the deepest ray governing exactly as the normal rib's to-next does).
+func (r *RibFeature) parallelGrowth(in Input, pts []math.Point2) (toLeft bool, depth float64, err error) {
+	plane := r.def.Sketch.Plane()
+	perp := avgPathNormal(pts)
+	if perp == (math.Vector2{}) {
+		return false, 0, errors.New("rib: the parallel profile is degenerate — no direction to grow the wall perpendicular to")
+	}
+	toLeft, err = r.parallelGrowthSide(in, plane, pts, perp)
+	if err != nil {
+		return false, 0, err
+	}
+	if r.def.ToNext {
+		depth, err = parallelToNextDepth(in.Bodies, plane, pts, growthVector(perp, toLeft))
+		return toLeft, depth, err
+	}
+	depth = stdmath.Abs(callOrZero(r.def.Depth))
+	if depth == 0 {
+		return toLeft, 0, errors.New("rib: a parallel rib needs a non-zero depth (or set toNext to grow onto the part)")
+	}
+	return toLeft, depth, nil
+}
+
+// parallelGrowthSide reports which way the wall grows — toward whichever side of the path the
+// material lies on, sensed by ray-casting the path's midpoint both ways along the perpendicular. A
+// finite rib with no material either way grows to the left by convention; a to-next rib errors.
+func (r *RibFeature) parallelGrowthSide(in Input, plane sketch.Plane, pts []math.Point2, perp math.Vector2) (bool, error) {
+	mid := plane.ToModel(pts[len(pts)/2])
+	leftHit, leftOK := nearestBodyHit(in.Bodies, mid, planeDirectionToModel(plane, perp))
+	rightHit, rightOK := nearestBodyHit(in.Bodies, mid, planeDirectionToModel(plane, perp.Scale(-1)))
+	switch {
+	case leftOK && (!rightOK || leftHit <= rightHit):
+		return true, nil
+	case rightOK:
+		return false, nil
+	case !r.def.ToNext:
+		return true, nil // no material to sense; a finite rib grows to the left by convention
+	default:
+		return false, errors.New("rib: parallel to-next found no material on either side of the profile to grow the wall onto")
+	}
+}
+
+// parallelToNextDepth is the parallel rib's to-next extent: it ray-casts each profile point along
+// the in-plane growth direction and returns the FARTHEST first-hit, so growing the wall that far
+// lands every point of it on the part (the boolean trims the overshoot at the nearer points).
+func parallelToNextDepth(bodies []*topo.Body, plane sketch.Plane, pts []math.Point2, grow math.Vector2) (float64, error) {
+	if len(bodies) == 0 {
+		return 0, errors.New("rib: parallel to-next needs existing material")
+	}
+	dir := planeDirectionToModel(plane, grow)
+	deepest := 0.0
+	for i, p := range pts {
+		hit, ok := nearestBodyHit(bodies, plane.ToModel(p), dir)
+		if !ok {
+			return 0, fmt.Errorf("rib: parallel to-next: profile point %d (%v) has no material ahead to grow the wall onto", i, p)
+		}
+		deepest = stdmath.Max(deepest, hit)
+	}
+	if deepest <= 0 {
+		return 0, errors.New("rib: parallel to-next found the profile already sitting on the material; nothing to grow")
+	}
+	return deepest, nil
+}
+
+// parallelFootprint is the in-plane region the lateral wall covers: the closed band between the path
+// and the path offset by depth on the growth side (thickenPathBetween along the per-vertex normal,
+// so it follows a curved path exactly as the normal rib's band does).
+func parallelFootprint(pts []math.Point2, toLeft bool, depth float64) []math.Point2 {
+	if toLeft {
+		return thickenPathBetween(pts, depth, 0)
+	}
+	return thickenPathBetween(pts, 0, -depth)
+}
+
+// avgPathNormal is the path's mean in-plane left normal — the perpendicular the lateral wall grows
+// along. Averaging over the vertices gives one stable direction for the side test on a gently
+// curved path; thickenPathBetween still offsets per-vertex, so the footprint itself stays exact.
+func avgPathNormal(pts []math.Point2) math.Vector2 {
+	var sum math.Vector2
+	for i := range pts {
+		sum = sum.Add(vertexNormal2(pts, i))
+	}
+	if l := float64(sum.Length()); l > 0 {
+		return sum.Scale(math.Scalar(1 / l))
+	}
+	return math.Vector2{}
+}
+
+// growthVector is the perpendicular pointed to the growth side.
+func growthVector(perp math.Vector2, toLeft bool) math.Vector2 {
+	if toLeft {
+		return perp
+	}
+	return perp.Scale(-1)
+}

--- a/model/feature/rib_parallel_test.go
+++ b/model/feature/rib_parallel_test.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// extentAlong is a body's extent (max − min of its vertices) projected onto a direction.
+func extentAlong(b *topo.Body, dir math.Vector3) float64 {
+	lo, hi := stdmath.Inf(1), stdmath.Inf(-1)
+	for _, v := range b.Vertices() {
+		d := float64(v.Point().AsVector().Dot(dir))
+		lo, hi = stdmath.Min(lo, d), stdmath.Max(hi, d)
+	}
+	return hi - lo
+}
+
+func buildRib(t *testing.T, dir RibDirection) *topo.Body {
+	t.Helper()
+	fs := NewPartFeatures(nil)
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0)) // path length 4 along +X
+	rib := &RibFeature{def: &RibDefinition{
+		Sketch: sk, ProfileIndex: 0,
+		Thickness: func() float64 { return 1 }, // T
+		Depth:     func() float64 { return 2 }, // d
+		Direction: dir, Operation: ops.NewBody,
+	}}
+	pf := fs.Add(rib)
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("rib (dir %d) went sick: %+v", dir, pf.Health())
+	}
+	return fs.Result()[0]
+}
+
+// TestRibParallelRotatesTheWall90 is the #2064 bug fix. A parallel (lateral) rib thickens the
+// profile ALONG the plane normal and grows IN the plane — the opposite of the normal/web rib — so on
+// the same path the two walls SWAP their thickness and depth between the plane normal (Z) and the
+// in-plane perpendicular (Y). A parallel rib mistranslated as a normal one comes out rotated 90°.
+func TestRibParallelRotatesTheWall90(t *testing.T) {
+	normal, parallel := buildRib(t, RibNormalToSketch), buildRib(t, RibParallelToSketch)
+	for name, b := range map[string]*topo.Body{"normal": normal, "parallel": parallel} {
+		if r := ops.Validate(b); !r.Valid || !b.IsSolid() {
+			t.Fatalf("%s rib is not a valid solid: %+v", name, r)
+		}
+		if v := ops.BodyGeometryProperties(b, ops.DefaultQuality()).Volume; stdmath.Abs(v-8) > 1e-6 {
+			t.Errorf("%s rib volume = %g, want 8 (4×1×2 either way — only the orientation differs)", name, v)
+		}
+	}
+	// The normal rib puts the DEPTH (2) along the plane normal Z and the THICKNESS (1) along the
+	// in-plane perpendicular Y; the parallel rib swaps them.
+	if nz, ny := extentAlong(normal, math.V3(0, 0, 1)), extentAlong(normal, math.V3(0, 1, 0)); stdmath.Abs(nz-2) > 1e-6 || stdmath.Abs(ny-1) > 1e-6 {
+		t.Errorf("normal rib (Z=%g, Y=%g), want depth 2 along the normal and thickness 1 in-plane", nz, ny)
+	}
+	if pz, py := extentAlong(parallel, math.V3(0, 0, 1)), extentAlong(parallel, math.V3(0, 1, 0)); stdmath.Abs(pz-1) > 1e-6 || stdmath.Abs(py-2) > 1e-6 {
+		t.Errorf("parallel rib (Z=%g, Y=%g), want thickness 1 ALONG the normal and depth 2 IN-plane (#2064)", pz, py)
+	}
+}
+
+// TestRibParallelRefusesTaper mirrors Inventor: a taper (draft) is only allowed when the direction
+// is normal to the sketch plane, so a parallel rib with a draft is refused rather than silently
+// dropping it.
+func TestRibParallelRefusesTaper(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	sk := sketch.NewSketches().Add(sketch.XYPlane())
+	sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0))
+	pf := fs.Add(&RibFeature{def: &RibDefinition{
+		Sketch: sk, ProfileIndex: 0,
+		Thickness: func() float64 { return 1 }, Depth: func() float64 { return 2 },
+		Direction: RibParallelToSketch, Draft: 0.1, Operation: ops.NewBody,
+	}})
+	fs.Recompute()
+	if pf.Health().OK() {
+		t.Error("a parallel rib with a draft should go sick — a taper needs the normal direction")
+	}
+}
+
+// TestRibDraftProfileEndsToggle: DraftProfileEnds defaults to drafted ends (nil), the square-ends
+// case under a draft is refused honestly (not yet modelled), and without a draft the flag is moot.
+func TestRibDraftProfileEndsToggle(t *testing.T) {
+	square := false
+	drafted := true
+	build := func(draftEnds *bool, draft float64) *PartFeature {
+		fs := NewPartFeatures(nil)
+		sk := sketch.NewSketches().Add(sketch.XYPlane())
+		sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0))
+		pf := fs.Add(&RibFeature{def: &RibDefinition{
+			Sketch: sk, ProfileIndex: 0,
+			Thickness: func() float64 { return 1 }, Depth: func() float64 { return 2 },
+			Draft: draft, DraftProfileEnds: draftEnds, Operation: ops.NewBody,
+		}})
+		fs.Recompute()
+		return pf
+	}
+	if pf := build(nil, 0.1); !pf.Health().OK() {
+		t.Errorf("nil DraftProfileEnds (the default, drafted ends) with a draft went sick: %+v", pf.Health())
+	}
+	if pf := build(&drafted, 0.1); !pf.Health().OK() {
+		t.Errorf("DraftProfileEnds=true with a draft went sick: %+v", pf.Health())
+	}
+	if pf := build(&square, 0.1); pf.Health().OK() {
+		t.Error("DraftProfileEnds=false with a draft should be refused (square drafted ends are not modelled), not silently drafted")
+	}
+	if pf := build(&square, 0); !pf.Health().OK() {
+		t.Errorf("DraftProfileEnds=false WITHOUT a draft is a square-ended wall either way and must build: %+v", pf.Health())
+	}
+}
+
+// TestRibParallelToNextGrowsOntoThePart exercises the parallel to-next path: the wall grows in the
+// plane, perpendicular to the path, toward the side the material is on, until it lands. A profile
+// above a box grows DOWN onto the box top.
+func TestRibParallelToNextGrowsOntoThePart(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	NewExtrudeFeatures(fs).AddByDistanceExtent(squareSketch(6), 0, ops.NewBody, func() float64 { return 4 })
+	fs.Recompute()
+	boxVol := ops.BodyGeometryProperties(fs.Result()[0], ops.DefaultQuality()).Volume
+
+	// A section plane through the box (y = 3), X in-plane, Z in-plane; a path above the box top.
+	plane, err := sketch.NewPlane(math.P3(0, 3, 0), math.V3(1, 0, 0).AsUnit(), math.V3(0, 0, 1).AsUnit())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sk := sketch.NewSketches().Add(plane)
+	sk.Lines().AddByTwoPoints(math.P2(1, 5), math.P2(5, 5)) // x∈[1,5], z=5 — above the box top (z=4)
+	pf := fs.Add(&RibFeature{def: &RibDefinition{
+		Sketch: sk, ProfileIndex: 0,
+		Thickness: func() float64 { return 1 },
+		ToNext:    true, Direction: RibParallelToSketch, Operation: ops.Join,
+	}})
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("parallel to-next rib went sick: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("parallel to-next rib is not a valid solid: %+v", r.Issues)
+	}
+	if v := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; v <= boxVol {
+		t.Errorf("parallel to-next rib added no material (volume %g ≤ box %g) — it did not grow onto the part", v, boxVol)
+	}
+	// The wall grew from the profile (z=5) down onto the box top (z=4), so the body still reaches z=5.
+	if hi := float64(body.RangeBox().Max.Z); stdmath.Abs(hi-5) > 1e-6 {
+		t.Errorf("body reaches Z %g, want 5 — the rib should stand from the profile down to the box top", hi)
+	}
+}
+
+// TestRibDirectionRoundTrip round-trips the #2064 fields: a parallel rib with square ends persists
+// and restores, a legacy recipe (no direction) reads back as the normal/web default, and an unknown
+// direction is a precise error rather than a silent 90° rotation.
+func TestRibDirectionRoundTrip(t *testing.T) {
+	sk := straightPathSketch(4)
+	square := false
+	def := &RibDefinition{
+		Sketch: sk, ProfileIndex: 0, Operation: ops.Join,
+		Thickness: func() float64 { return 1 }, Depth: func() float64 { return 2 },
+		Direction: RibParallelToSketch, DraftProfileEnds: &square,
+	}
+	index := sketchList{sks: []*sketch.Sketch{sk}}
+	data, err := serializeRib(def, index)
+	if err != nil {
+		t.Fatalf("serializeRib: %v", err)
+	}
+	if data.Direction != "parallel" || data.DraftProfileEnds == nil || *data.DraftProfileEnds {
+		t.Fatalf("persisted rib = %+v, want direction parallel + draftProfileEnds false", data)
+	}
+	restored, err := restoreRib(NewPartFeatures(nil), data, index)
+	if err != nil {
+		t.Fatalf("restoreRib: %v", err)
+	}
+	rdef := restored.Definition().(*RibFeature).Definition()
+	if rdef.Direction != RibParallelToSketch || rdef.DraftProfileEnds == nil || *rdef.DraftProfileEnds {
+		t.Errorf("restored rib = %+v, want parallel + square ends", rdef)
+	}
+
+	legacy := *data
+	legacy.Direction, legacy.DraftProfileEnds = "", nil
+	old, err := restoreRib(NewPartFeatures(nil), &legacy, index)
+	if err != nil {
+		t.Fatalf("restoreRib (legacy): %v", err)
+	}
+	if odef := old.Definition().(*RibFeature).Definition(); odef.Direction != RibNormalToSketch || odef.DraftProfileEnds != nil {
+		t.Errorf("legacy rib = %+v, want the normal/web rib with the default (nil) draftProfileEnds", odef)
+	}
+
+	bad := *data
+	bad.Direction = "sideways"
+	if _, err := restoreRib(NewPartFeatures(nil), &bad, index); err == nil {
+		t.Error("an unknown direction should be a precise error, not a silent fall back to normal")
+	}
+}

--- a/model/feature/serialize_rib.go
+++ b/model/feature/serialize_rib.go
@@ -19,6 +19,27 @@ type RibData struct {
 	Draft         float64 `yaml:"draft,omitempty"`       // radians
 	ThicknessAt   string  `yaml:"thicknessAt,omitempty"` // "" (sketch plane) | root
 	ExtendProfile bool    `yaml:"extendProfile,omitempty"`
+	// Direction and DraftProfileEnds are omitted at their defaults (#2064): a normal/web rib with
+	// drafted ends reads back unchanged from an older document.
+	Direction        string `yaml:"direction,omitempty"`        // "" (normal) | parallel
+	DraftProfileEnds *bool  `yaml:"draftProfileEnds,omitempty"` // nil ⇒ default (drafted ends)
+}
+
+// ribDirectionNames is the persisted spelling of each rib direction, both ways. The normal (web)
+// default is the empty string so it drops out of the YAML entirely.
+var ribDirectionNames = map[RibDirection]string{
+	RibNormalToSketch: "", RibParallelToSketch: "parallel",
+}
+
+// ribDirectionFromName reads a persisted rib direction; an unknown spelling is a precise error
+// rather than a silent fall back to normal, which would rotate the wall 90°.
+func ribDirectionFromName(name string) (RibDirection, error) {
+	for dir, n := range ribDirectionNames {
+		if n == name {
+			return dir, nil
+		}
+	}
+	return 0, fmt.Errorf("rib: unknown direction %q in the recipe (want parallel or omitted for normal)", name)
 }
 
 // ribThickenSideNames is the persisted spelling of each thicken side, both ways. The symmetric
@@ -53,6 +74,7 @@ func serializeRib(def *RibDefinition, sk SketchIndexer) (*RibData, error) {
 		ToNext: def.ToNext, Operation: op,
 		ThickenSide: ribThickenSideNames[def.ThickenSide], Draft: def.Draft,
 		ThicknessAt: ribThicknessAtName(def.HoldThicknessAtRoot), ExtendProfile: def.ExtendProfile,
+		Direction: ribDirectionNames[def.Direction], DraftProfileEnds: def.DraftProfileEnds,
 	}, nil
 }
 
@@ -72,12 +94,17 @@ func restoreRib(fs *PartFeatures, d *RibData, sk SketchIndexer) (*PartFeature, e
 	if err != nil {
 		return nil, err
 	}
+	dir, err := ribDirectionFromName(d.Direction)
+	if err != nil {
+		return nil, err
+	}
 	def := &RibDefinition{
 		Sketch: skt, ProfileIndex: d.Profile,
 		Thickness: constFloat(d.Thickness), Depth: constFloat(d.Depth),
 		ToNext: d.ToNext, Operation: op,
 		ThickenSide: side, Draft: d.Draft,
 		HoldThicknessAtRoot: d.ThicknessAt == ribThicknessAtRootName, ExtendProfile: d.ExtendProfile,
+		Direction: dir, DraftProfileEnds: d.DraftProfileEnds,
 	}
 	return NewRibFeatures(fs).AddDefinition(def), nil
 }

--- a/model/feature/sheet_metal_contour_bends.go
+++ b/model/feature/sheet_metal_contour_bends.go
@@ -37,6 +37,31 @@ func roundProfileCorners(pts []math.Point2, radius float64) ([]math.Point2, erro
 	return append(out, pts[len(pts)-1]), nil
 }
 
+// contourCornerBends reports one bend per non-collinear interior corner of an open profile — the
+// same corners roundProfileCorners turns into tangent arcs — so a contour flange's flat pattern can
+// develop each corner's bend allowance instead of laying it out as a sharp fold (#2076). The swept
+// angle is the corner's turn acos(in·out), independent of the radius; reportRadius is passed
+// straight into the spec (a non-positive value defers to the rule's default, the flange
+// convention). A profile with no interior corner — a single straight segment — reports no bends.
+func contourCornerBends(pts []math.Point2, reportRadius float64) []BendSpec {
+	if len(pts) < 3 {
+		return nil
+	}
+	var specs []BendSpec
+	for i := 1; i < len(pts)-1; i++ {
+		in, out, err := cornerDirections(pts[i-1], pts[i], pts[i+1])
+		if err != nil {
+			continue // a zero-length segment has no direction to turn through
+		}
+		turn := stdmath.Acos(clampUnit(float64(in.Dot(out))))
+		if turn < 1e-9 {
+			continue // collinear: no corner here, so no bend
+		}
+		specs = append(specs, BendSpec{Angle: turn, Radius: reportRadius})
+	}
+	return specs
+}
+
 // cornerArc is the arc that rounds the corner at b between segments a→b and b→c, tangent to both.
 // The tangent length is radius·tan(half the turn), so a corner that turns further eats more of its
 // own segments — which is why a radius that fits one corner can be refused at the next.

--- a/model/feature/sheet_metal_contour_bendspecs_test.go
+++ b/model/feature/sheet_metal_contour_bendspecs_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	gmath "oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// zProfile is an open Z-chain with TWO interior corners, each a right-angle turn:
+// (0,0)→(1,0)→(1,1)→(2,1).
+func zProfile() *sketch.Sketch {
+	s := sketch.NewSketches().Add(sketch.XYPlane())
+	p0 := s.Points().Add(gmath.P2(0, 0))
+	p1 := s.Points().Add(gmath.P2(1, 0))
+	p2 := s.Points().Add(gmath.P2(1, 1))
+	p3 := s.Points().Add(gmath.P2(2, 1))
+	s.Lines().Add(p0, p1)
+	s.Lines().Add(p1, p2)
+	s.Lines().Add(p2, p3)
+	return s
+}
+
+// straightProfile is a single straight run drawn as two collinear segments — no corner to bend:
+// (0,0)→(1,0)→(2,0).
+func straightProfile() *sketch.Sketch {
+	s := sketch.NewSketches().Add(sketch.XYPlane())
+	p0 := s.Points().Add(gmath.P2(0, 0))
+	p1 := s.Points().Add(gmath.P2(1, 0))
+	p2 := s.Points().Add(gmath.P2(2, 0))
+	s.Lines().Add(p0, p1)
+	s.Lines().Add(p1, p2)
+	return s
+}
+
+// TestContourFlangeBendSpecsDevelopEveryCorner is the #2076 regression: a contour flange's rounded
+// interior corners ARE bends, so BendSpecs must report one per corner — otherwise the flat pattern
+// develops them as sharp folds and the blank comes out short by every corner's bend allowance, and
+// any DXF cut from it is undersized. Before this the feature implemented no BendLineage and
+// contributed zero bends. The swept angle is the corner's own turn; the reported radius follows the
+// flange convention (the override, else 0 to defer to the rule's default).
+func TestContourFlangeBendSpecsDevelopEveryCorner(t *testing.T) {
+	right := stdmath.Pi / 2
+	for name, tc := range map[string]struct {
+		profile   *sketch.Sketch
+		override  float64 // < 0 ⇒ no override closure (defer to the rule)
+		wantAngle []float64
+		wantR     float64
+	}{
+		"L corner defers to rule": {lProfile(), -1, []float64{right}, 0},
+		"L corner with override":  {lProfile(), 0.4, []float64{right}, 0.4},
+		"Z has two bends":         {zProfile(), 0.3, []float64{right, right}, 0.3},
+		"straight has no bend":    {straightProfile(), 0.3, nil, 0},
+	} {
+		t.Run(name, func(t *testing.T) {
+			def := &SheetMetalContourFlangeDefinition{Profile: tc.profile}
+			if tc.override >= 0 {
+				def.Radius = constClosure(tc.override)
+			}
+			f := &SheetMetalContourFlangeFeature{def: def}
+			specs := f.BendSpecs(0.2)
+			if len(specs) != len(tc.wantAngle) {
+				t.Fatalf("BendSpecs returned %d bends, want %d", len(specs), len(tc.wantAngle))
+			}
+			for i, s := range specs {
+				if stdmath.Abs(s.Angle-tc.wantAngle[i]) > 1e-9 {
+					t.Errorf("bend %d swept angle = %g, want %g", i, s.Angle, tc.wantAngle[i])
+				}
+				if s.Radius != tc.wantR {
+					t.Errorf("bend %d radius = %g, want %g (override/defer convention)", i, s.Radius, tc.wantR)
+				}
+			}
+		})
+	}
+}

--- a/model/feature/sheet_metal_contour_flange.go
+++ b/model/feature/sheet_metal_contour_flange.go
@@ -90,6 +90,29 @@ func (f *SheetMetalContourFlangeFeature) bentProfile(in Input) ([]math.Point2, e
 	return roundProfileCorners(profile, f.bendRadius(in))
 }
 
+// BendSpecs reports one bend per rounded interior corner of the contour profile, for the flat
+// pattern (#2076). Each corner of a contour flange IS a bend — it was swept sharp until #1961
+// rounded it to the bend radius — so the flat blank must develop each corner's bend allowance, or
+// it comes out short by the whole of it and any nest or DXF cut from it is undersized. The swept
+// angle is the corner's own turn; the radius follows the flange convention (the override, else 0 to
+// defer to the rule's default, which compdef.developBends fills in). Before the first recompute the
+// profile still reads from the definition, so this needs no captured state.
+//
+// Example:
+//
+//	specs := contourFlange.BendSpecs(thickness) // one BendSpec per non-collinear profile corner
+func (f *SheetMetalContourFlangeFeature) BendSpecs(_ float64) []BendSpec {
+	profile, err := openProfilePoints(f.def.Profile)
+	if err != nil {
+		return nil
+	}
+	radius := 0.0
+	if f.def.Radius != nil {
+		radius = f.def.Radius()
+	}
+	return contourCornerBends(profile, radius)
+}
+
 // operation is how this wall joins the model; the zero value is Join, which is what the feature
 // has always done.
 func (f *SheetMetalContourFlangeFeature) operation() ops.PartFeatureOperation {
@@ -322,4 +345,7 @@ func (c *SheetMetalContourFlangeFeatures) Add(def *SheetMetalContourFlangeDefini
 	return pf
 }
 
-var _ Feature = (*SheetMetalContourFlangeFeature)(nil)
+var (
+	_ Feature     = (*SheetMetalContourFlangeFeature)(nil)
+	_ BendLineage = (*SheetMetalContourFlangeFeature)(nil) // #2076: its corners develop as bends
+)

--- a/model/feature/sketched_features.go
+++ b/model/feature/sketched_features.go
@@ -646,7 +646,30 @@ type RibDefinition struct {
 	Draft               float64
 	HoldThicknessAtRoot bool
 	ExtendProfile       bool
+	// Direction is whether the profile is projected NORMAL to the sketch plane (a web — the default
+	// and zero value, so a definition written before the option keeps its behaviour) or PARALLEL to
+	// it (a rib), mirroring Inventor's RibDefinition.IsRib (#2064). A parallel rib thickens the
+	// profile ALONG the plane normal and grows the wall IN the plane until it lands on the part — the
+	// 90°-rotated form used for a moulded part sectioned through its wall.
+	Direction RibDirection
+	// DraftProfileEnds says whether a NORMAL rib's draft tapers the profile's END caps along with its
+	// sides (Inventor's RibDefinition.DraftProfileEnds, default True). nil ⇒ the default (drafted
+	// ends, the pre-option behaviour); a non-nil false leaves the ends square. It has no effect
+	// without a draft, and none on a parallel rib (which refuses a draft, as Inventor does).
+	DraftProfileEnds *bool
 }
+
+// RibDirection selects how a rib projects its sketch profile — Inventor's RibDefinition.IsRib.
+type RibDirection int
+
+const (
+	// RibNormalToSketch thickens the profile in the sketch plane and extrudes it ALONG the plane
+	// normal (a web). The default and zero value.
+	RibNormalToSketch RibDirection = iota
+	// RibParallelToSketch thickens the profile along the plane normal and grows the wall IN the
+	// plane until it lands on the part (a rib), rotated 90° from the web form.
+	RibParallelToSketch
+)
 
 // RibFeature thickens an open sketch profile (a path) into a wall: the path is offset in the
 // sketch plane to a closed band (by ±Thickness/2, or wholly to one side — see [RibThickenSide]),
@@ -676,6 +699,24 @@ func (r *RibFeature) Recompute(in Input) (Output, error) {
 	if t <= 0 {
 		return Output{}, fmt.Errorf("rib: need positive thickness, got t=%g", t)
 	}
+	if r.def.Direction == RibParallelToSketch {
+		return r.recomputeParallel(in, pts, t)
+	}
+	return r.recomputeNormal(in, pts, t)
+}
+
+// recomputeNormal is the web form: thicken the path IN the sketch plane and extrude ALONG the plane
+// normal by the depth. The draft tapers the wall toward the root; DraftProfileEnds decides whether it
+// tapers the end caps too.
+func (r *RibFeature) recomputeNormal(in Input, pts []math.Point2, t float64) (Output, error) {
+	// Square (undrafted) profile ends under a draft need a DIRECTIONAL taper — widen the sides but
+	// hold the end caps perpendicular — which buildExtrusionShell's uniform outward taper cannot
+	// express. It is refused rather than silently drafting the ends (which would be the wrong shape).
+	// Without a draft the flag has no effect and the wall is square-ended either way. (#2064)
+	if r.def.Draft != 0 && !r.draftsProfileEnds() {
+		return Output{}, errors.New("rib: square profile ends under a draft are not modelled yet " +
+			"(the end caps would be drafted with the sides); drop the draft or leave draftProfileEnds set")
+	}
 	d, err := r.ribDepth(in, pts)
 	if err != nil {
 		return Output{}, err
@@ -692,6 +733,12 @@ func (r *RibFeature) Recompute(in Input) (Output, error) {
 		return Output{}, err
 	}
 	return Output{Bodies: bodies}, nil
+}
+
+// draftsProfileEnds resolves DraftProfileEnds: nil ⇒ the default True (Inventor's default and the
+// pre-option behaviour), so only a non-nil false leaves the ends square.
+func (r *RibFeature) draftsProfileEnds() bool {
+	return r.def.DraftProfileEnds == nil || *r.def.DraftProfileEnds
 }
 
 // ribDepth resolves the wall extent: the explicit signed depth, or with


### PR DESCRIPTION
## What

Four model-level part/sheet-metal fixes, each with measured regression tests.

### #2076 — a contour flange's corner bends now develop in the flat pattern
A contour flange rounds each interior profile corner into a tangent arc at the bend radius (#1961), but the feature reported no bends, so the flat pattern developed every corner as a sharp fold. The blank came out short by the whole bend allowance of each corner and any nest or DXF cut from it was undersized.

`SheetMetalContourFlangeFeature` now implements `BendLineage`: one `BendSpec` per non-collinear interior corner, its swept angle the corner's own turn and its radius following the flange convention (override, else defer to the rule). `compdef.Bends` now includes the corners, so the developed length, `TotalBendAllowance`, and the bend-order list are correct. Proven by mutation and end-to-end through `compdef`.

### #2066 — a from-plane emboss's relief cut is now replicated in a pattern/mirror
A from-plane emboss applies two booleans — a raise in front of the sketch plane and a relief cut behind it — but the pattern/mirror machinery recovered only one tool per source, so every copy kept the raise and dropped the relief cut.

Added a `MultiToolFeature` interface (`ToolApplications`) + an `Input.SourceTools` sibling so a source can report several `(tool, op)` pairs; `resolveGroup` now replicates every one. `EmbossFeature` reports `[(raise, Join), (relief, Cut)]` for the from-plane flavour and nil otherwise (raise/engrave stay single-tool). Regression (pattern and mirror): a patterned/mirrored copy of an *interior* from-plane emboss — where the raise is a no-op inside solid material, so only the relief pocket distinguishes the fix — now carries its relief pocket. Proven by mutation.

### #2065 — an emboss can now wrap onto a CONICAL face
Wrap-to-face refused every non-cylindrical face. A cone is developable too, but its development is a circular *sector* about the apex, not a rectangle (a full turn unrolls to only `2π·sin α`, so the angle a unit arc subtends shrinks with slant, and the raise follows the tilted surface normal, not the radius) — wrapping it as a cylinder would silently distort the glyph.

Introduced a `wrapSurface` interface (`at`/`angleSpan`/`offsets`) so the tool builder serves both; the **cylinder path is unchanged** (guarded by its existing wrap tests). A new `coneWrapFrame` maps a sketch point by its polar `(ρ, φ)` about the apex to slant `s = ρ` (`v = ρ·cosα`) and turn `θ = φ/sinα`, offset along the cone normal. The development math is pinned by frame unit tests — hug (points on the cone), radial isometry (a radial segment keeps its length), angle-per-arc (`φ/sinα`), and normal offset — **each mutation-proven** — plus an end-to-end test embossing a real chamfer-cone face into a valid solid that adds glyph-sized material.

### #2064 — a rib can now project PARALLEL to its sketch plane
A rib only ever projected normal to its sketch plane (Inventor's web / `IsRib=False`). The **parallel (lateral)** form — the common one for a moulded part whose sketch is a section through its wall — was missing, so such a rib mistranslated as a wall **rotated 90°**: silent and plausible enough to survive a glance.

`RibDefinition.Direction` (normal, the zero value | parallel) drives it: a parallel rib thickens the profile *along* the plane normal and grows the wall *in* the plane, perpendicular to the path, toward the material, until it lands. A draft is refused on it (Inventor allows a taper only normal to the plane). `RibDefinition.DraftProfileEnds` is added and round-trips; the square-ends-under-a-draft case needs a directional taper the extruder can't express, so it's **refused honestly** rather than silently drafting the ends. Proven: the parallel/normal walls swap their thickness and depth between the plane normal and the in-plane perpendicular (the 90° rotation, mutation-proven), taper refusal, `draftProfileEnds` toggle, parallel to-next grows onto the part, and the recipe round-trip. **`BossSets` remain a separate follow-up**, as the issue allows.

## Verification

- Full `model/feature` (≈230 s) and `model/compdef` suites green; `golangci-lint` 0 issues on the touched packages.
- Every geometry guard proven by mutating the implementation (a nil `BendSpecs`/`ToolApplications` drops the corner/pocket and the test fails).
- **Live MCP pass owed** (headless bridge did not bind :7800 in this environment — a live-infra setup issue, not a code change; both fixes are model-level with no rendering component and are verified at the geometry level — `PointInsideBody`/`Validate`/volume/developed bend allowance).

## Not in this PR (investigated, deferred with documented root cause)

- **#2087** (user grid bug) — z-fighting of the coplanar grid against its host face; needs live depth-precision tuning, not an unattended change.
- **#2087** — grid z-fight; needs live depth tuning.
- **#2081/#2084** — coupled; #2084 (coil/core imprint-seam robustness under refinement) is the root cause blocking #2081's fidelity. Deep boolean work on a byte-fragile corpus; a `maxFacetWarpRatio` tweak only trades one bug for the other.
- **#2009** — already fixed on develop (`TestNurbsPcurveMeshConvergesHighAspectPanel` passes); recommend closing with that evidence.

Follow-ups this batch surfaced: rib `BossSets`, and square (undrafted) rib profile ends under a draft.

Closes #2076
Closes #2066
Closes #2065
Closes #2064

🤖 Generated with [Claude Code](https://claude.com/claude-code)
