### PR TITLE
feat(sheet-metal): flange multi edge-set model (#2071 Gap 2)

### DIFF
--- a/addin/opregistry/sheet_metal_flange.go
+++ b/addin/opregistry/sheet_metal_flange.go
@@ -28,9 +28,10 @@ const sheetMetalFlangeSchema = `{
     "miterGap": {"type": "string", "description": "Gap left on the miter line, e.g. \"1 mm\"; absent uses the style's GapSize."},
     "options": {"type": "object", "description": "Override the sheet-metal style's bend properties for THIS bend only (Inventor's BendOptions). An omitted field defers to the style.", "properties": {"reliefShape": {"type": "string", "enum": ["round", "straight", "tear"], "description": "Notch shape at this bend's ends; tear cuts nothing."}, "reliefWidth": {"type": "string"}, "reliefDepth": {"type": "string"}, "minimumRemnant": {"type": "string", "description": "Thinnest strip of parent material a relief may leave; a notch that would leave less takes the sliver with it."}, "transition": {"type": "string", "enum": ["none", "intersection", "straightLine", "arc", "trimToBend", "default"], "description": "How this bend meets the face beside it. Only \"none\" is built; the others are refused where they would apply."}, "transitionArcRadius": {"type": "string"}}},
     "width": {"type": "object", "description": "Bound the wall to PART of the edge (Inventor's flange width extents): a bracket tab on a long edge, or a wall that stops short of the corners. Absent = the whole edge.", "properties": {"type": {"type": "string", "enum": ["edge", "centered", "offsets", "offsetWidth"], "default": "edge", "description": "centered takes width; offsets takes offset (from the edge start) and offset2 (from its end); offsetWidth takes offset and width."}, "width": {"type": "string", "description": "Wall length, e.g. \"20 mm\"."}, "offset": {"type": "string", "description": "Distance from the edge's start."}, "offset2": {"type": "string", "description": "Distance from the edge's end (offsets type)."}}},
-    "heightDatum": {"type": "string", "enum": ["tangent", "outer", "inner", "outerOrtho", "innerOrtho"], "default": "tangent", "description": "What height is measured FROM (Inventor HeightDatumTypeEnum). tangent measures the wall from where the bend ends; outer/inner measure from the sharp corner the outer/inner faces would make, the way a drawing dimensions it; the ortho pair measures those corners perpendicular to the base face."}
+    "heightDatum": {"type": "string", "enum": ["tangent", "outer", "inner", "outerOrtho", "innerOrtho"], "default": "tangent", "description": "What height is measured FROM (Inventor HeightDatumTypeEnum). tangent measures the wall from where the bend ends; outer/inner measure from the sharp corner the outer/inner faces would make, the way a drawing dimensions it; the ortho pair measures those corners perpendicular to the base face."},
+    "edgeSets": {"type": "array", "description": "Flange SEVERAL edges in one feature (Inventor's FlangeDefinition edge-set collection), each set with its own edges and width. Supersedes edge/width when present; the shared height, angle, radius, flip, bendPosition, heightDatum, options and miter apply to every set.", "items": {"type": "object", "properties": {"edges": {"type": "array", "items": {"type": "string"}, "description": "Reference keys of the edges in this set."}, "width": {"type": "object", "description": "This set's width extent (same shape as the top-level width); absent = each wall spans its whole edge."}}, "required": ["edges"]}}
   },
-  "required": ["edge", "height"]
+  "required": ["height"]
 }`
 
 // sheetMetalFlangeDescriptor is the self-describing "sheetMetalFlange" operation: fold a wall
@@ -53,8 +54,8 @@ func applySheetMetalFlange(s *app.Session, raw json.RawMessage) (json.RawMessage
 	if err := json.Unmarshal(raw, &in); err != nil {
 		return nil, fmt.Errorf("sheetMetalFlange: invalid args: %w", err)
 	}
-	if in.Edge == "" {
-		return nil, fmt.Errorf("sheetMetalFlange: edge is required")
+	if in.Edge == "" && len(in.EdgeSets) == 0 {
+		return nil, fmt.Errorf("sheetMetalFlange: an edge (or edgeSets) is required")
 	}
 	def, err := flangeDef(part, in)
 	if err != nil {
@@ -78,21 +79,51 @@ func flangeDef(part *compdef.PartComponentDefinition, in featureargs.SheetMetalF
 	if err := bindFlangePlacement(part, def, in); err != nil {
 		return nil, err
 	}
-	width, err := flangeWidthExtent(part, in.Width)
-	if err != nil {
+	if err := bindFlangeSpans(part, def, in); err != nil {
 		return nil, err
 	}
+	return def, nil
+}
+
+// bindFlangeSpans resolves the wall's width, its multi-edge edge sets (#2071), the per-bend option
+// override and the auto-miter onto the definition.
+func bindFlangeSpans(part *compdef.PartComponentDefinition, def *feature.SheetMetalFlangeDefinition, in featureargs.SheetMetalFlange) error {
+	width, err := flangeWidthExtent(part, in.Width)
+	if err != nil {
+		return err
+	}
 	def.Width = width
+	if def.EdgeSets, err = flangeEdgeSets(part, in.EdgeSets); err != nil {
+		return err
+	}
 	if def.Options, err = bendOptions(part, in.Options); err != nil {
-		return nil, err
+		return err
 	}
 	def.AutoMiter = in.ApplyAutoMiter
 	if in.MiterGap != "" {
-		if def.MiterGap, err = lengthClosure(part, in.MiterGap, "sheetMetalFlange: miterGap"); err != nil {
+		def.MiterGap, err = lengthClosure(part, in.MiterGap, "sheetMetalFlange: miterGap")
+	}
+	return err
+}
+
+// flangeEdgeSets resolves a multi-edge flange's edge-set collection (#2071): each set's edges and its
+// own width extent. Empty in ⇒ nil, the single-edge flange this feature has always built.
+func flangeEdgeSets(part *compdef.PartComponentDefinition, in []featureargs.FlangeEdgeSet) ([]feature.FlangeEdgeSet, error) {
+	if len(in) == 0 {
+		return nil, nil
+	}
+	out := make([]feature.FlangeEdgeSet, len(in))
+	for i, s := range in {
+		if len(s.Edges) == 0 {
+			return nil, fmt.Errorf("sheetMetalFlange: edge set %d has no edges", i)
+		}
+		width, err := flangeWidthExtent(part, s.Width)
+		if err != nil {
 			return nil, err
 		}
+		out[i] = feature.FlangeEdgeSet{EdgeKeys: refKeys(s.Edges), Width: width}
 	}
-	return def, nil
+	return out, nil
 }
 
 // bendOptions resolves this bend's overrides of the style (#1959). An omitted field stays nil so

--- a/addin/opregistry/sheet_metal_flange_edgesets_test.go
+++ b/addin/opregistry/sheet_metal_flange_edgesets_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package opregistry
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+)
+
+// topXEdgeKeys returns the reference keys of every X-aligned top-face edge of the part's first body
+// (the two opposite sides), so a test can flange several edges in one feature.
+func topXEdgeKeys(t *testing.T, def *compdef.PartComponentDefinition) []string {
+	t.Helper()
+	if def.SurfaceBodies().Count() == 0 {
+		t.Fatal("no body to fold")
+	}
+	b := def.SurfaceBodies().Item(0)
+	maxZ := math.Inf(-1)
+	for _, e := range b.Edges() {
+		if z := e.StartVertex().Point().Z; z > maxZ {
+			maxZ = z
+		}
+	}
+	var keys []string
+	for _, e := range b.Edges() {
+		a, c := e.StartVertex().Point(), e.EndVertex().Point()
+		if math.Abs(a.X-c.X) > 1e-6 && math.Abs(a.Y-c.Y) < 1e-6 &&
+			math.Abs(a.Z-maxZ) < 1e-6 && math.Abs(c.Z-maxZ) < 1e-6 {
+			keys = append(keys, string(e.ReferenceKey()))
+		}
+	}
+	return keys
+}
+
+// TestFlangeEdgeSetsReachTheDefinition drives a multi-edge flange over the wire (#2071): the
+// edgeSets collection, each with its own edges and width, must reach the definition and build a
+// merged solid.
+func TestFlangeEdgeSetsReachTheDefinition(t *testing.T) {
+	s, _ := seedSheetMetalSheet(t)
+	def := s.ActiveDocument().Content().(*compdef.PartComponentDefinition)
+	keys := topXEdgeKeys(t, def)
+	if len(keys) < 2 {
+		t.Fatalf("seed plate exposed %d top X-edges, want ≥2", len(keys))
+	}
+	out, err := applyMap(t, s, "sheetMetalFlange", map[string]any{
+		"height": "10 mm",
+		"edgeSets": []any{
+			map[string]any{"edges": []any{keys[0]}},
+			map[string]any{"edges": []any{keys[1]}, "width": map[string]any{"type": "centered", "width": "20 mm"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("multi-edge flange apply: %v", err)
+	}
+	expectMergedSolid(t, out, "multi-edge flange")
+
+	fdef := lastFlangeDef(t, s)
+	if len(fdef.EdgeSets) != 2 {
+		t.Fatalf("definition has %d edge sets, want 2", len(fdef.EdgeSets))
+	}
+	if string(fdef.EdgeSets[0].EdgeKeys[0]) != keys[0] {
+		t.Errorf("edge set 0 key = %q, want %q", string(fdef.EdgeSets[0].EdgeKeys[0]), keys[0])
+	}
+	if fdef.EdgeSets[1].Width.Type != feature.WidthCentered {
+		t.Errorf("edge set 1 width type = %v, want centered (its per-set width did not reach the def)", fdef.EdgeSets[1].Width.Type)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	golang.org/x/sys v0.47.0
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.147.0
+	oblikovati.org/api v0.148.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.147.0
+	oblikovati.org/api v0.148.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/compdef/sheet_metal_flange_edgesets_test.go
+++ b/model/compdef/sheet_metal_flange_edgesets_test.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/model/feature"
+)
+
+// topXEdges returns every X-aligned edge on the sheet's top face (the two opposite sides), so a test
+// can flange more than one edge in one feature.
+func topXEdges(t *testing.T, body *topo.Body) []*topo.Edge {
+	t.Helper()
+	maxZ := math.Inf(-1)
+	for _, e := range body.Edges() {
+		if z := e.StartVertex().Point().Z; z > maxZ {
+			maxZ = z
+		}
+	}
+	var out []*topo.Edge
+	for _, e := range body.Edges() {
+		a, b := e.StartVertex().Point(), e.EndVertex().Point()
+		if math.Abs(a.X-b.X) > 1e-6 && math.Abs(a.Y-b.Y) < 1e-6 &&
+			math.Abs(a.Z-maxZ) < 1e-6 && math.Abs(b.Z-maxZ) < 1e-6 {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// TestBendsMultiEdgeFlangeDevelopsEveryEdge is the flat-pattern half of #2071: one flange feature
+// spanning several edge sets must develop a bend for EACH edge, not just one. Before this the flat
+// read exactly one placement per feature, so the extra walls' bend allowances were missing.
+func TestBendsMultiEdgeFlangeDevelopsEveryEdge(t *testing.T) {
+	d := NewPartComponentDefinition()
+	if _, err := d.EnableSheetMetal(); err != nil {
+		t.Fatalf("EnableSheetMetal: %v", err)
+	}
+	addSquareFace(d, 4)
+	edges := topXEdges(t, d.Features().Result()[0])
+	if len(edges) < 2 {
+		t.Fatalf("seed plate has %d top X-edges, want ≥2", len(edges))
+	}
+	pf := feature.NewSheetMetalFlangeFeatures(d.Features()).Add(&feature.SheetMetalFlangeDefinition{
+		Height: func() float64 { return 1 },
+		EdgeSets: []feature.FlangeEdgeSet{
+			{EdgeKeys: [][]byte{edges[0].ReferenceKey()}},
+			{EdgeKeys: [][]byte{edges[1].ReferenceKey()}},
+		},
+	})
+	d.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("multi-edge flange sick: %s", pf.Health().Reason)
+	}
+
+	bends := d.Bends()
+	if len(bends) != 2 {
+		t.Fatalf("multi-edge flange developed %d bends, want 2 (one per flanged edge)", len(bends))
+	}
+	for i, b := range bends {
+		if b.Feature != pf.Name() {
+			t.Errorf("bend %d feature = %q, want %q", i, b.Feature, pf.Name())
+		}
+		if b.Allowance <= 0 {
+			t.Errorf("bend %d allowance = %g, want a real developed length", i, b.Allowance)
+		}
+	}
+	// Two identical 90° bends develop the same allowance, so the total is twice one bend's.
+	if got, one := d.TotalBendAllowance(), bends[0].Allowance; math.Abs(got-2*one) > 1e-9 {
+		t.Errorf("TotalBendAllowance = %g, want 2× one bend's %g", got, one)
+	}
+}

--- a/model/compdef/sheet_metal_flat.go
+++ b/model/compdef/sheet_metal_flat.go
@@ -156,33 +156,42 @@ func (d *PartComponentDefinition) flatTabs() []feature.FlatTab {
 	fs := d.features
 	var tabs []feature.FlatTab
 	for i := 0; i < fs.Count(); i++ {
-		if tab, ok := d.developTab(fs.Item(i), plane); ok {
-			tabs = append(tabs, tab)
-		}
+		tabs = append(tabs, d.developTabs(fs.Item(i), plane)...)
 	}
 	return tabs
 }
 
-// developTab develops one feature into a flat tab, or ok=false when it is not a healthy
-// placed edge bend. It projects the recorded bend line and outward direction into the base
-// plane and adds the rule's bend allowance to the flange's straight run.
-func (d *PartComponentDefinition) developTab(pf *feature.PartFeature, plane sketch.Plane) (feature.FlatTab, bool) {
+// developTabs develops a feature's edge bends into flat tabs — one per bend, so a multi-edge flange
+// lays out every wall (#2071); empty when the feature is not a healthy placed edge bend. Each tab
+// projects the recorded bend line and outward direction into the base plane and adds the rule's bend
+// allowance to the flange's straight run.
+func (d *PartComponentDefinition) developTabs(pf *feature.PartFeature, plane sketch.Plane) []feature.FlatTab {
 	if pf.Suppressed() || !pf.Health().OK() {
-		return feature.FlatTab{}, false
+		return nil
 	}
-	placed, ok := pf.Definition().(feature.PlacedBend)
-	if !ok {
-		return feature.FlatTab{}, false
+	var tabs []feature.FlatTab
+	for _, p := range featurePlacements(pf.Definition()) {
+		tabs = append(tabs, feature.FlatTab{
+			A:        plane.ToSketch(p.AxisStart),
+			B:        plane.ToSketch(p.AxisEnd),
+			Length:   d.sheetMetal.Unfold().BendAllowance(p.Angle, p.Radius, p.Thickness) + p.Length,
+			Angle:    p.Angle,
+			FoldDown: p.FoldDown,
+		})
 	}
-	p, ok := placed.Placement()
-	if !ok {
-		return feature.FlatTab{}, false
+	return tabs
+}
+
+// featurePlacements returns every edge-bend placement a feature recorded — all of them for a
+// PlacedBends (a multi-edge flange, #2071), or the single one for a PlacedBend.
+func featurePlacements(def feature.Feature) []feature.BendPlacement {
+	if many, ok := def.(feature.PlacedBends); ok {
+		return many.Placements()
 	}
-	return feature.FlatTab{
-		A:        plane.ToSketch(p.AxisStart),
-		B:        plane.ToSketch(p.AxisEnd),
-		Length:   d.sheetMetal.Unfold().BendAllowance(p.Angle, p.Radius, p.Thickness) + p.Length,
-		Angle:    p.Angle,
-		FoldDown: p.FoldDown,
-	}, true
+	if one, ok := def.(feature.PlacedBend); ok {
+		if p, ok := one.Placement(); ok {
+			return []feature.BendPlacement{p}
+		}
+	}
+	return nil
 }

--- a/model/compdef/sheet_metal_unfold.go
+++ b/model/compdef/sheet_metal_unfold.go
@@ -61,9 +61,7 @@ func (d *PartComponentDefinition) bendTransforms(op string) ([]feature.BendTrans
 	var out []feature.BendTransform
 	fs := d.features
 	for i := 0; i < fs.Count(); i++ {
-		if bt, ok := bakeBendTransform(fs.Item(i), d.sheetMetal); ok {
-			out = append(out, bt)
-		}
+		out = append(out, bakeBendTransforms(fs.Item(i), d.sheetMetal)...)
 	}
 	if len(out) == 0 {
 		return nil, fmt.Errorf("%s: the part has no bends to act on", op)
@@ -71,30 +69,29 @@ func (d *PartComponentDefinition) bendTransforms(op string) ([]feature.BendTrans
 	return out, nil
 }
 
-// bakeBendTransform turns one feature's recorded bend placement into a transform, or ok=false
-// when it is not a healthy placed edge bend. The neutral-fibre radius is the rule's developed
-// length for this bend divided by its angle (so it honours the active unfold method — K-factor,
-// bend table, or equation — not just a fixed K-factor).
-func bakeBendTransform(pf *feature.PartFeature, rule *sheetmetal.Rule) (feature.BendTransform, bool) {
+// bakeBendTransforms turns a feature's recorded bend placements into transforms — one per bend, so a
+// multi-edge flange bakes every wall (#2071); empty when it is not a healthy placed edge bend. The
+// neutral-fibre radius is the rule's developed length for each bend divided by its angle (so it
+// honours the active unfold method — K-factor, bend table, or equation — not just a fixed K-factor).
+func bakeBendTransforms(pf *feature.PartFeature, rule *sheetmetal.Rule) []feature.BendTransform {
 	if pf.Suppressed() || !pf.Health().OK() {
-		return feature.BendTransform{}, false
+		return nil
 	}
-	placed, ok := pf.Definition().(feature.PlacedBend)
-	if !ok {
-		return feature.BendTransform{}, false
+	var out []feature.BendTransform
+	for _, p := range featurePlacements(pf.Definition()) {
+		if p.Angle <= 0 {
+			continue
+		}
+		out = append(out, feature.BendTransform{
+			LinePoint: p.AxisStart,
+			LineDir:   p.AxisStart.VectorTo(p.AxisEnd),
+			Up:        p.Up.AsVector(),
+			Out:       p.Outward.AsVector(),
+			Angle:     p.Angle,
+			Radius:    p.Radius,
+			Thickness: p.Thickness,
+			Neutral:   rule.BendAllowance(p.Angle, p.Radius) / p.Angle,
+		})
 	}
-	p, ok := placed.Placement()
-	if !ok || p.Angle <= 0 {
-		return feature.BendTransform{}, false
-	}
-	return feature.BendTransform{
-		LinePoint: p.AxisStart,
-		LineDir:   p.AxisStart.VectorTo(p.AxisEnd),
-		Up:        p.Up.AsVector(),
-		Out:       p.Outward.AsVector(),
-		Angle:     p.Angle,
-		Radius:    p.Radius,
-		Thickness: p.Thickness,
-		Neutral:   rule.BendAllowance(p.Angle, p.Radius) / p.Angle,
-	}, true
+	return out
 }

--- a/model/feature/bend_lineage.go
+++ b/model/feature/bend_lineage.go
@@ -48,3 +48,10 @@ type BendPlacement struct {
 type PlacedBend interface {
 	Placement() (BendPlacement, bool)
 }
+
+// PlacedBends is a feature that places MORE THAN ONE edge bend in a single feature — a multi-edge
+// flange (#2071). The flat pattern lays out every one; a feature that implements both interfaces has
+// its Placement be the first of these. A single-edge feature can implement only PlacedBend.
+type PlacedBends interface {
+	Placements() []BendPlacement
+}

--- a/model/feature/serialize_sheet_metal_flange.go
+++ b/model/feature/serialize_sheet_metal_flange.go
@@ -20,6 +20,48 @@ type SheetMetalFlangeData struct {
 	HeightDatum    string  `yaml:"heightDatum,omitempty"`
 	// Width is how much of the edge the wall covers (#1958); absent ⇒ the whole edge.
 	Width *FlangeWidthData `yaml:"width,omitempty"`
+	// EdgeSets is the multi-edge flange's edge-set collection (#2071); absent ⇒ the single Edge/Width
+	// wall, so an older recipe reads back unchanged.
+	EdgeSets []FlangeEdgeSetData `yaml:"edgeSets,omitempty"`
+}
+
+// FlangeEdgeSetData is one persisted flange edge set: its edges and its own width extent (#2071).
+type FlangeEdgeSetData struct {
+	Edges []string         `yaml:"edges"`
+	Width *FlangeWidthData `yaml:"width,omitempty"`
+}
+
+// serializeFlangeEdgeSets projects the edge sets to their persisted form; nil for the single-edge
+// flange so its recipe is untouched.
+func serializeFlangeEdgeSets(sets []FlangeEdgeSet) []FlangeEdgeSetData {
+	if len(sets) == 0 {
+		return nil
+	}
+	out := make([]FlangeEdgeSetData, len(sets))
+	for i, s := range sets {
+		out[i] = FlangeEdgeSetData{Edges: encodeKeys(s.EdgeKeys), Width: serializeFlangeWidth(s.Width)}
+	}
+	return out
+}
+
+// restoreFlangeEdgeSets rebuilds the edge sets, erroring on an undecodable key or unknown width.
+func restoreFlangeEdgeSets(data []FlangeEdgeSetData) ([]FlangeEdgeSet, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	out := make([]FlangeEdgeSet, len(data))
+	for i, d := range data {
+		keys, err := decodeKeys(d.Edges)
+		if err != nil {
+			return nil, fmt.Errorf("sheet-metal flange edge set %d: %w", i, err)
+		}
+		width, err := restoreFlangeWidth(d.Width)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = FlangeEdgeSet{EdgeKeys: keys, Width: width}
+	}
+	return out, nil
 }
 
 // FlangeWidthData persists a flange's width extent and the distances it takes (#1958).
@@ -76,6 +118,7 @@ func serializeSheetMetalFlange(def *SheetMetalFlangeDefinition) *SheetMetalFlang
 		PositionOffset: evalFloat(def.PositionOffset),
 		HeightDatum:    HeightDatumName(def.HeightDatum),
 		Width:          serializeFlangeWidth(def.Width),
+		EdgeSets:       serializeFlangeEdgeSets(def.EdgeSets),
 	}
 }
 
@@ -101,9 +144,14 @@ func restoreSheetMetalFlange(fs *PartFeatures, d *SheetMetalFlangeData) (*PartFe
 	if err != nil {
 		return nil, err
 	}
+	edgeSets, err := restoreFlangeEdgeSets(d.EdgeSets)
+	if err != nil {
+		return nil, err
+	}
 	def := &SheetMetalFlangeDefinition{
 		EdgeKey:     key,
 		Width:       width,
+		EdgeSets:    edgeSets,
 		Height:      constFloat(d.Height),
 		Flip:        d.Flip,
 		Position:    position,

--- a/model/feature/sheet_metal_flange.go
+++ b/model/feature/sheet_metal_flange.go
@@ -3,6 +3,7 @@
 package feature
 
 import (
+	"errors"
 	"fmt"
 	stdmath "math"
 
@@ -55,13 +56,27 @@ type SheetMetalFlangeDefinition struct {
 	Position       BendPosition
 	PositionOffset func() float64 // explicit distance for the two edge-offset positions
 	HeightDatum    HeightDatum
+	// EdgeSets flanges SEVERAL edges in one feature, each set with its own edges and Width —
+	// Inventor's FlangeDefinition edge-set collection (#2071). When non-empty it SUPERSEDES
+	// EdgeKey/Width; every other option (height, angle, radius, flip, position, datum, options,
+	// miter) is shared across the sets. The zero value is the single-edge flange this feature has
+	// always built.
+	EdgeSets []FlangeEdgeSet
+}
+
+// FlangeEdgeSet is one edge group of a multi-edge flange (#2071): the edges to flange and the width
+// extent bounding their walls (the zero Width spans each whole edge).
+type FlangeEdgeSet struct {
+	EdgeKeys [][]byte
+	Width    FlangeWidth
 }
 
 // SheetMetalFlangeFeature folds a wall onto the sheet each recompute.
 type SheetMetalFlangeFeature struct {
-	def       *SheetMetalFlangeDefinition
-	featName  string
-	placement *BendPlacement // resolved bend geometry from the last recompute (for the flat pattern)
+	def        *SheetMetalFlangeDefinition
+	featName   string
+	placement  *BendPlacement  // the FIRST bend, for the single-placement PlacedBend interface
+	placements []BendPlacement // every bend this recompute placed (one per flanged edge), for the flat pattern
 }
 
 // Definition returns the flange recipe.
@@ -81,32 +96,78 @@ func (f *SheetMetalFlangeFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	edges, heals, err := resolveEdges(body, [][]byte{f.def.EdgeKey}, nil)
+	sets := f.edgeSets()
+	if len(sets) == 0 {
+		return Output{}, errors.New("sheet-metal flange: no edge to flange")
+	}
+	bodies, heals, err := f.flangeAllEdges(in, body, dims, sets)
 	if err != nil {
 		return Output{}, err
 	}
-	wall, placement, err := buildFoldedSolidAt(edges[0], dims.thickness, f.flangeSteps(dims),
-		dims.setback, f.def.Width, f.def.Flip, f.featName)
+	f.placement = &f.placements[0] // the first bend, for the single-placement PlacedBend interface
+	return Output{Bodies: bodies, Heals: heals}, nil
+}
+
+// flangeAllEdges folds a wall on every edge of every set onto the running sheet, chaining each
+// result into the next, and returns the final bodies plus the reference heals (#2071). It records
+// one bend placement per edge as it goes (f.placements).
+func (f *SheetMetalFlangeFeature) flangeAllEdges(in Input, body *topo.Body, dims flangeDims, sets []FlangeEdgeSet) ([]*topo.Body, []ReferenceHeal, error) {
+	run := in
+	f.placements = nil
+	var heals []ReferenceHeal
+	for _, set := range sets {
+		edges, h, err := resolveEdges(body, set.EdgeKeys, nil)
+		if err != nil {
+			return nil, nil, err
+		}
+		heals = append(heals, h...)
+		for _, edge := range edges {
+			if run.Bodies, err = f.flangeOneEdge(run, edge, dims, set.Width); err != nil {
+				return nil, nil, err
+			}
+		}
+	}
+	return run.Bodies, heals, nil
+}
+
+// flangeOneEdge folds one wall onto the running bodies from a single edge with the given width, cuts
+// its reliefs, and records its bend placement. It returns the new running body state so the caller
+// can chain several edges (and edge sets) through one feature (#2071).
+func (f *SheetMetalFlangeFeature) flangeOneEdge(run Input, edge *topo.Edge, dims flangeDims, width FlangeWidth) ([]*topo.Body, error) {
+	wall, placement, err := buildFoldedSolidAt(edge, dims.thickness, f.flangeSteps(dims),
+		dims.setback, width, f.def.Flip, f.featName)
 	if err != nil {
-		return Output{}, err
+		return nil, err
 	}
 	// Union the wall onto the sheet (combine planarizes both before the planar boolean).
-	bodies, err := combine(in, wall, ops.Join)
+	bodies, err := combine(run, wall, ops.Join)
 	if err != nil {
-		return Output{}, err
+		return nil, err
 	}
-	if bodies, err = f.relieve(bodies, edges[0], dims, placement, in); err != nil {
-		return Output{}, err
+	if bodies, err = f.relieve(bodies, edge, dims, placement, width, run); err != nil {
+		return nil, err
 	}
-	f.placement = &placement // record the resolved bend for the flat pattern (M13-F04)
-	return Output{Bodies: bodies, Heals: heals}, nil
+	f.placements = append(f.placements, placement) // record the bend for the flat pattern (M13-F04)
+	return bodies, nil
+}
+
+// edgeSets returns the flange's edge sets — the explicit EdgeSets, or the single EdgeKey/Width set
+// this feature has always built (#2071).
+func (f *SheetMetalFlangeFeature) edgeSets() []FlangeEdgeSet {
+	if len(f.def.EdgeSets) > 0 {
+		return f.def.EdgeSets
+	}
+	if len(f.def.EdgeKey) == 0 {
+		return nil
+	}
+	return []FlangeEdgeSet{{EdgeKeys: [][]byte{f.def.EdgeKey}, Width: f.def.Width}}
 }
 
 // relieve cuts both styled reliefs this wall calls for (#2072): the notches at its own bend's ends,
 // and the corner cut where that bend meets one an earlier wall placed.
 func (f *SheetMetalFlangeFeature) relieve(bodies []*topo.Body, edge *topo.Edge, dims flangeDims,
-	placement BendPlacement, in Input) ([]*topo.Body, error) {
-	bodies, err := f.relieveBend(bodies, edge, dims, in.Relief)
+	placement BendPlacement, width FlangeWidth, in Input) ([]*topo.Body, error) {
+	bodies, err := f.relieveBend(bodies, edge, dims, width, in.Relief)
 	if err != nil {
 		return nil, err
 	}
@@ -141,9 +202,9 @@ func (f *SheetMetalFlangeFeature) bendTransition(in Input) types.BendTransition 
 // the edge (#2072). A full-width flange reaches both ends of its edge and needs none, which is why
 // nothing was relieved before width extents existed (#1958).
 func (f *SheetMetalFlangeFeature) relieveBend(bodies []*topo.Body, edge *topo.Edge, dims flangeDims,
-	spec ReliefSpec) ([]*topo.Body, error) {
+	width FlangeWidth, spec ReliefSpec) ([]*topo.Body, error) {
 	v0, v1 := edge.StartVertex().Point(), edge.EndVertex().Point()
-	from, to, err := f.def.Width.span(float64(v0.DistanceTo(v1)))
+	from, to, err := width.span(float64(v0.DistanceTo(v1)))
 	if err != nil {
 		return nil, err
 	}
@@ -153,15 +214,19 @@ func (f *SheetMetalFlangeFeature) relieveBend(bodies []*topo.Body, edge *topo.Ed
 		f.def.Flip, featOr(f.featName, "flange"))
 }
 
-// Placement returns the resolved bend geometry captured by the last successful recompute,
-// for the flat pattern to lay this flange out as a tab. ok is false before the first
-// recompute.
+// Placement returns the FIRST resolved bend from the last successful recompute (the single-bend
+// PlacedBend surface); the flat pattern reads every bend through Placements. ok is false before the
+// first recompute.
 func (f *SheetMetalFlangeFeature) Placement() (BendPlacement, bool) {
 	if f.placement == nil {
 		return BendPlacement{}, false
 	}
 	return *f.placement, true
 }
+
+// Placements returns every bend this feature placed — one per flanged edge (#2071) — for the flat
+// pattern to lay each out as a tab. A single-edge flange returns one, matching Placement.
+func (f *SheetMetalFlangeFeature) Placements() []BendPlacement { return f.placements }
 
 // flangeDims is the resolved, validated set of flange dimensions for one recompute. run is the
 // straight wall length after the bend, which is the height once the datum's setback is taken off;
@@ -221,7 +286,20 @@ func (f *SheetMetalFlangeFeature) BendSpecs(_ float64) []BendSpec {
 	if f.def.Radius != nil {
 		radius = f.def.Radius()
 	}
-	return []BendSpec{{Angle: f.resolveAngle(), Radius: radius}}
+	// One bend per flanged edge (#2071): a multi-edge flange develops each edge's fold. The
+	// dimensions are shared, so every spec is identical — only the count follows the edges.
+	n := 0
+	for _, set := range f.edgeSets() {
+		n += len(set.EdgeKeys)
+	}
+	if n == 0 {
+		n = 1 // a definition without a resolved edge still reports its one fold
+	}
+	specs := make([]BendSpec, n)
+	for i := range specs {
+		specs[i] = BendSpec{Angle: f.resolveAngle(), Radius: radius}
+	}
+	return specs
 }
 
 // buildFoldedSolid extrudes a folded-section chain (see sheet_metal_band.go) along the picked
@@ -348,4 +426,9 @@ func (c *SheetMetalFlangeFeatures) Add(def *SheetMetalFlangeDefinition) *PartFea
 	return pf
 }
 
-var _ Feature = (*SheetMetalFlangeFeature)(nil)
+var (
+	_ Feature     = (*SheetMetalFlangeFeature)(nil)
+	_ PlacedBend  = (*SheetMetalFlangeFeature)(nil)
+	_ PlacedBends = (*SheetMetalFlangeFeature)(nil) // #2071: a multi-edge flange places several bends
+	_ BendLineage = (*SheetMetalFlangeFeature)(nil)
+)

--- a/model/feature/sheet_metal_flange_edgesets_test.go
+++ b/model/feature/sheet_metal_flange_edgesets_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+)
+
+// topEdgesAlongX returns every top-face boundary edge that runs in X (the two opposite sides of a
+// square plate), so a test can flange more than one edge in one feature.
+func topEdgesAlongX(t *testing.T, body *topo.Body) []*topo.Edge {
+	t.Helper()
+	maxZ := math.Inf(-1)
+	for _, e := range body.Edges() {
+		if z := float64(e.StartVertex().Point().Z); z > maxZ {
+			maxZ = z
+		}
+	}
+	var out []*topo.Edge
+	for _, e := range body.Edges() {
+		a, b := e.StartVertex().Point(), e.EndVertex().Point()
+		if math.Abs(float64(a.X-b.X)) > 1e-6 && math.Abs(float64(a.Y-b.Y)) < 1e-6 &&
+			math.Abs(float64(a.Z)-maxZ) < 1e-6 && math.Abs(float64(b.Z)-maxZ) < 1e-6 {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// TestFlangeEdgeSetsFlangesEveryEdge is the #2071 acceptance: one flange feature with several edge
+// sets folds a wall on every edge and records one bend per edge, so on two opposite edges it adds
+// twice a single flange's band and reports two placements.
+func TestFlangeEdgeSetsFlangesEveryEdge(t *testing.T) {
+	const side, r, h, th = 4.0, 0.2, 1.0, 0.2
+	fs, _ := seedSheetMetalSheet(t, side, nil)
+	edges := topEdgesAlongX(t, fs.Result()[0])
+	if len(edges) < 2 {
+		t.Fatalf("the seed plate has %d top X-edges, want ≥2 to flange", len(edges))
+	}
+	pf := NewSheetMetalFlangeFeatures(fs).Add(&SheetMetalFlangeDefinition{
+		Height: func() float64 { return h }, Radius: func() float64 { return r },
+		Angle: func() float64 { return math.Pi / 2 },
+		EdgeSets: []FlangeEdgeSet{
+			{EdgeKeys: [][]byte{edges[0].ReferenceKey()}},
+			{EdgeKeys: [][]byte{edges[1].ReferenceKey()}},
+		},
+	})
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("multi-edge flange went sick: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	if !body.IsSolid() || !ops.Validate(body).Valid {
+		t.Fatalf("multi-edge flange is not a valid solid: %+v", ops.Validate(body))
+	}
+	// One bend per flanged edge.
+	fl := pf.Definition().(*SheetMetalFlangeFeature)
+	if got := len(fl.Placements()); got != 2 {
+		t.Errorf("Placements() = %d, want 2 (one per edge)", got)
+	}
+	if got := len(fl.BendSpecs(th)); got != 2 {
+		t.Errorf("BendSpecs len = %d, want 2 (one bend per edge for the flat pattern)", got)
+	}
+	// Two opposite flanges add ~twice a single flange's band.
+	single := sheetWithFlange(t, side, r, h)
+	singleAdded := smSolidVolume(single[0]) - side*side*th
+	twoAdded := smSolidVolume(body) - side*side*th
+	if math.Abs(twoAdded-2*singleAdded) > 0.05*singleAdded {
+		t.Errorf("two-edge flange added %g cm³, want ~2× the single-edge %g", twoAdded, singleAdded)
+	}
+}
+
+// TestFlangeEdgeSetsRoundTrip persists and restores a multi-edge flange's edge-set collection,
+// including a per-set width; a legacy single-edge recipe (no edgeSets) reads back unchanged.
+func TestFlangeEdgeSetsRoundTrip(t *testing.T) {
+	def := &SheetMetalFlangeDefinition{
+		Height: func() float64 { return 1 },
+		EdgeSets: []FlangeEdgeSet{
+			{EdgeKeys: [][]byte{[]byte("e1"), []byte("e2")}},
+			{EdgeKeys: [][]byte{[]byte("e3")}, Width: FlangeWidth{Type: WidthCentered, Width: constFloat(2)}},
+		},
+	}
+	data := serializeSheetMetalFlange(def)
+	if len(data.EdgeSets) != 2 || len(data.EdgeSets[0].Edges) != 2 || data.EdgeSets[1].Width == nil {
+		t.Fatalf("persisted edge sets = %+v, want 2 sets (2 edges / 1 edge with a width)", data.EdgeSets)
+	}
+	restored, err := restoreSheetMetalFlange(NewPartFeatures(nil), data)
+	if err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	rdef := restored.Definition().(*SheetMetalFlangeFeature).Definition()
+	if len(rdef.EdgeSets) != 2 || len(rdef.EdgeSets[0].EdgeKeys) != 2 ||
+		string(rdef.EdgeSets[1].EdgeKeys[0]) != "e3" || rdef.EdgeSets[1].Width.Type != WidthCentered {
+		t.Errorf("restored edge sets = %+v, want the two sets back with the per-set width", rdef.EdgeSets)
+	}
+
+	legacy := serializeSheetMetalFlange(&SheetMetalFlangeDefinition{EdgeKey: []byte("only"), Height: func() float64 { return 1 }})
+	if legacy.EdgeSets != nil {
+		t.Errorf("a single-edge flange persisted edgeSets %+v, want none", legacy.EdgeSets)
+	}
+}


### PR DESCRIPTION
## What

Flange **multi edge-set** support — Inventor's `FlangeDefinition` edge-set collection (#2071 Gap 2). One flange feature can now flange several edges, each set with its own width, instead of one edge per feature.

Modelling each edge as its own flange feature already made the same solid; what this changes is the feature tree and the edit experience — one feature, one edit, several walls — and it teaches the flat pattern to develop every one.

## How

- **Model** (`model/feature/sheet_metal_flange.go`): `SheetMetalFlangeDefinition.EdgeSets []FlangeEdgeSet` (edges + a per-set `Width`). When non-empty it supersedes `EdgeKey`/`Width`; every other option (height, angle, radius, flip, position, datum, options, miter) is shared. Recompute folds a wall on each edge in turn, chaining the running body, and records one bend placement per edge. `Placements() []BendPlacement` (a new `PlacedBends` interface) and `BendSpecs` return one per edge; the single-edge path is byte-unchanged (`edgeSets()` synthesises the one `EdgeKey`/`Width` set).
- **Flat pattern** (`model/compdef/sheet_metal_flat.go`, `sheet_metal_unfold.go`): `developTab`→`developTabs` and `bakeBendTransform`→`bakeBendTransforms` now iterate a feature's placements (via `featurePlacements`, preferring `PlacedBends`), so a multi-edge flange develops a tab/transform per wall — before, the flat read exactly one per feature and the extra walls' bend allowances were missing.
- **Wire** (opregistry): reads the `edgeSets` collection (`flangeEdgeSets`, mirroring the corner round's `cornerRoundSets`); `edge` becomes optional when `edgeSets` is given. Uses the api change from the companion Oblikovati.API PR.
- **Serialization**: `EdgeSets` round-trips (per-set width included); a legacy single-edge recipe reads back unchanged.

## Verification

- Model: one feature over two opposite edges builds a valid solid, reports two placements/bend specs, and adds ~twice a single flange's band (mutation-proven — processing only the first set fails it).
- Flat: `compdef.Bends()` develops two bends with twice one bend's allowance.
- Wire: a two-edge-set flange (with a per-set width) reaches the definition and builds a merged solid.
- Recipe round-trip incl. the legacy single-edge default; the single-edge path's existing tests are unchanged; `golangci-lint` 0.

Deferred (noted): the `fromTo` width extent (#2071 Gap 1) still needs vertex/plane reference binding the host lacks; a same-feature auto-miter *between* its own edges (they'd need each other's bends mid-build) still relies on the prior-feature bend list.

## Cross-repo ordering (ADR-0018)

Needs the Apache-2.0 wire change: the **Oblikovati.API PR** merges first (auto-releases a new `oblikovati.org/api`), then this PR's `go.mod` pins it and CI goes green.

Implements **Gap 2** of #2071. Gap 1 (the `fromTo` width extent) stays blocked on vertex/plane reference binding the host lacks, so #2071 is left open for it rather than auto-closed.

Refs #2071

🤖 Generated with [Claude Code](https://claude.com/claude-code)
