### PR TITLE
fix(head): stop the sketch grid z-fighting its coplanar host face (#2087)

### DIFF
--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -541,7 +541,7 @@ func sketchOverlays(s *app.Session, cam scene.Camera, list renderer.DrawList) (r
 	// so it draws in the depth-disabled lane in submission order — entities first, then dimensions,
 	// then interaction feedback. So grid < entities < dimensions, as intended (#909).
 	if g := s.Grid(); g.Visible {
-		list.Items = append(gridOverlay(plane, g.SpacingModel(), g.MajorEvery), list.Items...)
+		list.Items = append(gridOverlay(plane, g.SpacingModel(), g.MajorEvery, cam.Eye), list.Items...)
 	}
 	list.Items = append(list.Items, onTop(sketchOverlay(s.ActiveSketch(), s.IsSelectedEntity, hoverCandidate(s), s.ShowFormat()))...)
 	list.Items = append(list.Items, onTop(projectedCurveOverlay(s.ActiveSketch()))...)

--- a/head/ui/grid_overlay.go
+++ b/head/ui/grid_overlay.go
@@ -5,6 +5,8 @@
 package ui
 
 import (
+	stdmath "math"
+
 	"oblikovati.org/math"
 	"oblikovati.org/model/sketch"
 	"oblikovati.org/renderer"
@@ -15,19 +17,31 @@ import (
 // spacing.
 const gridCells = 20
 
+// gridCoplanarNudge is the fraction of the local coordinate magnitude by which the sketch grid is
+// pushed off its host plane toward the eye (#2087). The grid is coplanar with the face it is drawn
+// on; a constant depth bias cannot win that z-fight at every zoom, because the fixed world-space
+// coplanarity error maps to an ever-larger NDC gap as the plane approaches the near plane on
+// zoom-in (the reported "zooming in hides the grid"). A world-space nudge that scales with the
+// coordinate magnitude — the float32 rounding error's own scale, ~1.2e-7·|coord| — instead of with
+// zoom stays a fixed few-hundred-ULP push at all zooms: always above the coplanarity error, always
+// far below any real feature gap (sub-micron for a centimetre-scale part), so nearer model geometry
+// still occludes the grid as intended (#909).
+const gridCoplanarNudge = 1e-5
+
 // gridOverlay builds the sketch grid: lines parallel to the plane's axes, spaced by
 // spacing (model units), centred on the plane origin (the sketch's 0,0). Minor, major
 // (every `major` lines) and the two origin axis lines are separate colored items: the
 // origin lines take the universal CAD axis colors (X red, Y green) so users read axis
 // identity by color exactly as on the orientation triad. Returns nil when spacing is
 // non-positive.
-func gridOverlay(plane sketch.Plane, spacing float64, major int) []renderer.DrawItem {
+func gridOverlay(plane sketch.Plane, spacing float64, major int, eye math.Point3) []renderer.DrawItem {
 	if spacing <= 0 {
 		return nil
 	}
 	minor, maj := &segAccum{}, &segAccum{}
 	xAxis, yAxis := &segAccum{}, &segAccum{}
 	half := float64(gridCells) * spacing
+	plane = nudgedTowardEye(plane, eye, half) // #2087: lift the grid a hair off its host face
 	for i := -gridCells; i <= gridCells; i++ {
 		c := float64(i) * spacing
 		uAcc, vAcc := gridLineAccum(i, major, minor, maj, xAxis, yAxis)
@@ -40,6 +54,25 @@ func gridOverlay(plane sketch.Plane, spacing float64, major int) []renderer.Draw
 	items = appendGrid(items, xAxis, axisColorX)
 	items = appendGrid(items, yAxis, axisColorY)
 	return items
+}
+
+// nudgedTowardEye returns plane translated along its normal toward eye by a tiny, zoom-independent
+// offset, so the coplanar grid wins the depth test against its host face at any zoom (#2087). The
+// offset scales with the coordinate magnitude (the plane origin's distance from the world origin,
+// or the grid's own half-extent, whichever is larger) — the scale of the float32 rounding error it
+// must overcome — never with the eye distance, so zooming in does not shrink it below that error.
+func nudgedTowardEye(plane sketch.Plane, eye math.Point3, halfExtent float64) sketch.Plane {
+	n := plane.Normal().AsVector()
+	scale := stdmath.Max(halfExtent, float64(plane.Origin().DistanceTo(math.P3(0, 0, 0))))
+	eps := gridCoplanarNudge * stdmath.Max(scale, 1)
+	if plane.Origin().VectorTo(eye).Dot(n) < 0 { // eye on the −normal side: push that way instead
+		eps = -eps
+	}
+	shifted, err := sketch.NewPlane(plane.Origin().TranslateBy(n.Scale(math.Scalar(eps))), plane.XAxis(), plane.YAxis())
+	if err != nil {
+		return plane // degenerate axes can't happen for a real host plane; keep the grid on-plane
+	}
+	return shifted
 }
 
 // gridLineAccum returns the accumulators for the two grid lines at index i: the

--- a/head/ui/grid_overlay_test.go
+++ b/head/ui/grid_overlay_test.go
@@ -5,6 +5,7 @@
 package ui
 
 import (
+	stdmath "math"
 	"testing"
 
 	"oblikovati.org/math"
@@ -32,38 +33,75 @@ func itemWithColor(items []renderer.DrawItem, color [4]float32) (renderer.DrawIt
 	return renderer.DrawItem{}, false
 }
 
+// eyeAbove looks straight down the +Z axis, so the XY-plane grid nudges toward +Z (#2087).
+var eyeAbove = math.P3(0, 0, 100)
+
 func TestGridOverlayNonPositiveSpacing(t *testing.T) {
-	if got := gridOverlay(xyPlane(t), 0, 5); got != nil {
+	if got := gridOverlay(xyPlane(t), 0, 5, eyeAbove); got != nil {
 		t.Errorf("spacing 0: got %d items, want nil", len(got))
 	}
-	if got := gridOverlay(xyPlane(t), -1, 5); got != nil {
+	if got := gridOverlay(xyPlane(t), -1, 5, eyeAbove); got != nil {
 		t.Errorf("spacing -1: got %d items, want nil", len(got))
 	}
 }
 
 // TestGridOverlayOriginAxisColors: the line through the origin along X is red (axisColorX)
-// and the line along Y is green (axisColorY), each a single segment spanning the grid.
+// and the line along Y is green (axisColorY), each a single segment spanning the grid. Both sit at
+// the #2087 nudge height (a hair toward the eye off the host plane), not exactly on z=0.
 func TestGridOverlayOriginAxisColors(t *testing.T) {
 	const spacing = 1.0
 	half := float64(gridCells) * spacing
-	items := gridOverlay(xyPlane(t), spacing, 5)
+	z := gridCoplanarNudge * half // the grid is lifted toward +Z (eye above); |origin| == 0 < half
+	items := gridOverlay(xyPlane(t), spacing, 5, eyeAbove)
 
 	xItem, ok := itemWithColor(items, axisColorX)
 	if !ok {
 		t.Fatalf("no X-axis (red) grid item; colors=%v", colorsOf(items))
 	}
-	assertAxisSegment(t, "X", xItem, math.P3(-half, 0, 0), math.P3(half, 0, 0))
+	assertAxisSegment(t, "X", xItem, math.P3(-half, 0, math.Scalar(z)), math.P3(half, 0, math.Scalar(z)))
 
 	yItem, ok := itemWithColor(items, axisColorY)
 	if !ok {
 		t.Fatalf("no Y-axis (green) grid item; colors=%v", colorsOf(items))
 	}
-	assertAxisSegment(t, "Y", yItem, math.P3(0, -half, 0), math.P3(0, half, 0))
+	assertAxisSegment(t, "Y", yItem, math.P3(0, -half, math.Scalar(z)), math.P3(0, half, math.Scalar(z)))
+}
+
+// TestGridOverlayNudgesTowardEye is the #2087 regression: the coplanar grid must be lifted off its
+// host plane TOWARD the eye — strictly off the plane (never left at z=0, where it z-fights the host
+// face) and on the eye's side (never pushed away). Asserting a strict sign, not an exact value,
+// keeps the guard honest: dropping the nudge (offset → 0) leaves the grid on the plane and fails
+// here, which an assertion derived from the nudge constant would not catch. The lift stays a hair —
+// far under one grid cell — so it wins the depth test without visibly floating above the face.
+func TestGridOverlayNudgesTowardEye(t *testing.T) {
+	const spacing = 1.0
+	aboveZ := float64(gridZ(t, gridOverlay(xyPlane(t), spacing, 5, math.P3(0, 0, 100))))
+	if aboveZ <= 0 || aboveZ >= spacing {
+		t.Errorf("eye above the XY plane: grid Z = %g, want a small +Z lift in (0, %g)", aboveZ, spacing)
+	}
+	belowZ := float64(gridZ(t, gridOverlay(xyPlane(t), spacing, 5, math.P3(0, 0, -100))))
+	if belowZ >= 0 || belowZ <= -spacing {
+		t.Errorf("eye below the XY plane: grid Z = %g, want a small −Z lift in (-%g, 0)", belowZ, spacing)
+	}
+	if stdmath.Abs(aboveZ+belowZ) > 1e-12 {
+		t.Errorf("lift is not symmetric about the plane: above=%g below=%g", aboveZ, belowZ)
+	}
+}
+
+// gridZ returns the Z of the X-axis grid item's first endpoint — the height the whole grid was
+// lifted to (every vertex shares the same normal offset on the XY plane).
+func gridZ(t *testing.T, items []renderer.DrawItem) math.Scalar {
+	t.Helper()
+	it, ok := itemWithColor(items, axisColorX)
+	if !ok {
+		t.Fatalf("no X-axis grid item; colors=%v", colorsOf(items))
+	}
+	return it.Positions[0].Z
 }
 
 // TestGridOverlayKeepsMinorAndMajor: the axis split does not drop the minor/major groups.
 func TestGridOverlayKeepsMinorAndMajor(t *testing.T) {
-	items := gridOverlay(xyPlane(t), 1.0, 5)
+	items := gridOverlay(xyPlane(t), 1.0, 5, eyeAbove)
 	if _, ok := itemWithColor(items, chromeTheme.gridMinorColor); !ok {
 		t.Errorf("no minor grid item; colors=%v", colorsOf(items))
 	}


### PR DESCRIPTION
## What

Zooming in on a 2D sketch started on a solid **face** made the sketch-plane grid randomly disappear (user report #2087, windows/amd64). This lifts the grid a hair off its host plane toward the eye so it reliably wins the depth test at every zoom.

## Why

The grid is the one sketch overlay left **depth-tested** — every other overlay is drawn `OnTop` — so that nearer model geometry occludes it (design #909: grid < entities < model). But the grid is exactly **coplanar** with the face it is drawn on. The shared `-1.0` line depth bias cannot win that z-fight at every zoom:

- the grid/face coplanarity error is fixed in **world** space (float32 rounding between the two vertex paths);
- NDC depth is **non-linear**, so as the plane approaches the near plane on zoom-in, that fixed world error maps to an ever-larger NDC gap;
- past some zoom the constant bias no longer covers it and the grid loses the depth test and vanishes — exactly "zooming in randomly hides the grid".

## Fix

Nudge the grid off its host plane toward the eye in **world** space, by an offset that scales with the coordinate magnitude (the float32 rounding error's own scale, `~1.2e-7·|coord|`) instead of with zoom. A world-space offset that is in front of the face is in front at *every* zoom, and scaling it to the coordinate magnitude keeps a fixed few-hundred-ULP push: always above the coplanarity error, always far below any real feature gap (sub-micron for a centimetre-scale part), so nearer geometry still occludes the grid as intended.

## Verification

Live offscreen capture of the real `DrawChrome` viewport, a sketch on a cuboid cap:

- **before** — grid breaks up / drops out over the face while crisp on the background (z-fight against the coplanar face);
- **after** — grid renders crisp and complete over the face, matching the background.

- `TestGridOverlayNudgesTowardEye` — regression guard: grid is lifted strictly toward the eye (fails if the nudge is dropped; proven by mutating the constant to 0).
- `TestGridOverlayOriginAxisColors` / `KeepsMinorAndMajor` updated for the nudged height; full `head/ui` suite green; `golangci-lint --new-from-rev` clean.

Closes #2087