### PR TITLE
test(archguard): run the api-contract guards in CI, not just local dev

### DIFF
--- a/archguard/api_module_test.go
+++ b/archguard/api_module_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package archguard
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// apiModuleDir resolves the on-disk directory of the Apache-2.0 oblikovati.org/api module,
+// honoring the go.mod `replace` (a sibling checkout / go.work locally, `_api` under CI via the
+// api-contract action). The archguard guards that read the contract source used to hardcode
+// ../../Oblikovati.API, a LOCAL-DEV layout CI does not have — so they skipped in CI and could not
+// catch, e.g., a newly declared contract interface with no host assertion (#1976 slipped through
+// this way; the completeness check only ran on a developer's machine). `go list -m` reports the
+// same directory whichever layout is in effect, so resolving through it lets these guards run
+// everywhere the contract is present — including CI, where it is checked out into _api.
+//
+// ok is false (skip, don't fail) only when the module genuinely cannot be located on disk — the
+// contract absent is not an architecture violation.
+func apiModuleDir(t *testing.T) (string, bool) {
+	t.Helper()
+	out, err := exec.Command("go", "list", "-m", "-f", "{{.Dir}}", "oblikovati.org/api").Output()
+	if err != nil {
+		return "", false
+	}
+	dir := strings.TrimSpace(string(out))
+	if dir == "" {
+		return "", false
+	}
+	if _, err := os.Stat(dir); err != nil {
+		return "", false
+	}
+	return dir, true
+}
+
+// apiSubdir resolves a package directory inside the api module (e.g. "contract", "wire"), skipping
+// the calling test when the contract module is not checked out.
+func apiSubdir(t *testing.T, sub string) string {
+	t.Helper()
+	dir, ok := apiModuleDir(t)
+	if !ok {
+		t.Skipf("api module not resolvable (go list -m oblikovati.org/api); contract source absent")
+	}
+	return filepath.Join(dir, sub)
+}

--- a/archguard/boundary_test.go
+++ b/archguard/boundary_test.go
@@ -3,8 +3,8 @@
 package archguard
 
 import (
-	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -88,17 +88,13 @@ func listDeps(t *testing.T, dir string, patterns ...string) []string {
 	return deps
 }
 
-// apiModuleGoMod is the sibling Apache-2.0 contract module's go.mod, resolved via the workspace layout.
-const apiModuleGoMod = "../../Oblikovati.API/go.mod"
-
 // TestApiModuleDoesNotRequireSource fails if the Apache-2.0 api module requires ANY oblikovati.org module
 // — it is the root of the dependency graph, so it must require none (the GPL source requires it, never the
-// reverse). The license split (ADR-0018) depends on this direction. Skips when the sibling is not checked
-// out (a source-only build).
+// reverse). The license split (ADR-0018) depends on this direction. Skips when the api module is not
+// resolvable (a source-only build). The module dir is resolved through `go list -m` so this runs in CI
+// too, where the contract is checked out into _api rather than the ../../Oblikovati.API dev layout.
 func TestApiModuleDoesNotRequireSource(t *testing.T) {
-	if _, err := os.Stat(apiModuleGoMod); err != nil {
-		t.Skipf("api module not checked out at %s: %v", apiModuleGoMod, err)
-	}
+	apiModuleGoMod := filepath.Join(apiSubdir(t, ""), "go.mod")
 	for _, mod := range requiredInternalModules(t, apiModuleGoMod) {
 		t.Errorf("Oblikovati.API/go.mod requires %q — the Apache-2.0 contract must require no oblikovati.org "+
 			"module (the dependency flows source -> api, never the reverse). ADR-0018.", mod)

--- a/archguard/contract_assertions_test.go
+++ b/archguard/contract_assertions_test.go
@@ -22,9 +22,6 @@ import (
 // anywhere in this repo (all modules, head included) and fails on any interface that is
 // neither asserted nor justified in pendingContractAssertions.
 
-// apiContractDir is the sibling Apache-2.0 module's contract package.
-const apiContractDir = "../../Oblikovati.API/contract"
-
 // pendingContractAssertions lists contract interfaces knowingly without a host-side
 // assertion, each with the issue that owns closing the gap. Shrink-only: entries that
 // gain an assertion (or leave the contract) fail the guard until removed here.
@@ -67,10 +64,7 @@ var pendingContractAssertions = map[string]string{
 }
 
 func TestEveryContractInterfaceIsAsserted(t *testing.T) {
-	if _, err := os.Stat(apiContractDir); err != nil {
-		t.Skipf("api module not checked out at %s: %v", apiContractDir, err)
-	}
-	declared := contractInterfaceNames(t)
+	declared := contractInterfaceNames(t, apiSubdir(t, "contract"))
 	asserted := assertedContractNames(t)
 	for _, name := range declared {
 		if _, ok := asserted[name]; !ok && pendingContractAssertions[name] == "" {
@@ -101,12 +95,12 @@ func reportStaleAllowlist(t *testing.T, declared []string, asserted map[string]b
 
 // contractInterfaceNames parses the api/contract package and returns its exported
 // interface names (AST-level, no type checking — the contract package is plain Go).
-func contractInterfaceNames(t *testing.T) []string {
+func contractInterfaceNames(t *testing.T, contractDir string) []string {
 	t.Helper()
 	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, apiContractDir, notATestFile, parser.SkipObjectResolution)
+	pkgs, err := parser.ParseDir(fset, contractDir, notATestFile, parser.SkipObjectResolution)
 	if err != nil {
-		t.Fatalf("parse %s: %v", apiContractDir, err)
+		t.Fatalf("parse %s: %v", contractDir, err)
 	}
 	var names []string
 	for _, pkg := range pkgs {

--- a/archguard/contract_assertions_test.go
+++ b/archguard/contract_assertions_test.go
@@ -161,7 +161,14 @@ func skipNonSourceDir(name string) error {
 		return filepath.SkipDir
 	}
 	switch name {
-	case "experiments", "test-utilities", "node_modules", "testdata":
+	// _api is the Apache-2.0 contract checked out INSIDE the repo by the api-contract CI action
+	// (ADR-0018). Now that the contract guards run in CI, this subtree must be excluded from
+	// host-source walks: its client-side `var _ contract.X` assertions are not HOST assertions (the
+	// completeness guard would count them and call the client-implemented allowlist entries stale),
+	// and its wire package is the SOURCE of the method-name constants, not a re-declaration (the
+	// literal guard would flag every constant). Locally the contract is a sibling OUTSIDE the tree,
+	// so a repo walk never reaches it and this never matches.
+	case "experiments", "test-utilities", "node_modules", "testdata", "_api":
 		return filepath.SkipDir
 	}
 	return nil

--- a/archguard/wire_method_literal_test.go
+++ b/archguard/wire_method_literal_test.go
@@ -7,7 +7,6 @@ import (
 	"go/parser"
 	"go/token"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -26,22 +25,16 @@ import (
 // which both false-positives on unrelated dotted strings and false-negatives on gofmt
 // quirks) and, for each, requires call sites to reference the constant, not its value.
 
-// wireMethodPkgDir is the sibling Apache-2.0 module's wire package (the single source of
-// method-name truth). Skipped when the sibling is not checked out (a source-only build).
-const wireMethodPkgDir = "../../Oblikovati.API/wire"
-
 // wireMethodLiteralAllowlist justifies any bare occurrence of a wire method value that is
 // NOT a re-declaration (e.g. a doc example). Shrink-only, and empty by design: a real hit
 // is a bug to fix (import the constant), not to allowlist. Keyed "file:value".
 var wireMethodLiteralAllowlist = map[string]string{}
 
 func TestNoReDeclaredWireMethodLiterals(t *testing.T) {
-	if _, err := os.Stat(wireMethodPkgDir); err != nil {
-		t.Skipf("api wire package not checked out at %s: %v", wireMethodPkgDir, err)
-	}
-	values := wireMethodConstValues(t)
+	wireDir := apiSubdir(t, "wire") // resolved via go list -m, so this runs in CI (_api) too
+	values := wireMethodConstValues(t, wireDir)
 	if len(values) == 0 {
-		t.Fatalf("found no wire.Method* string constants in %s — the guard would be a no-op", wireMethodPkgDir)
+		t.Fatalf("found no wire.Method* string constants in %s — the guard would be a no-op", wireDir)
 	}
 	walkGoSourceFiles(t, "..", func(path string, file *ast.File, fset *token.FileSet) {
 		reportWireLiteralHits(t, path, file, fset, values)
@@ -50,12 +43,12 @@ func TestNoReDeclaredWireMethodLiterals(t *testing.T) {
 
 // wireMethodConstValues returns the string value -> constant-name map of every exported
 // `Method*` const in the wire package.
-func wireMethodConstValues(t *testing.T) map[string]string {
+func wireMethodConstValues(t *testing.T, wireDir string) map[string]string {
 	t.Helper()
 	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, wireMethodPkgDir, notATestFile, parser.SkipObjectResolution)
+	pkgs, err := parser.ParseDir(fset, wireDir, notATestFile, parser.SkipObjectResolution)
 	if err != nil {
-		t.Fatalf("parse %s: %v", wireMethodPkgDir, err)
+		t.Fatalf("parse %s: %v", wireDir, err)
 	}
 	values := map[string]string{}
 	for _, pkg := range pkgs {


### PR DESCRIPTION
## What

Three archguard guards that read the Apache-2.0 contract source silently **skipped in CI** and only ran on a developer's machine. Resolve the contract directory dynamically so they run everywhere the contract is present — including CI.

## Why

`TestEveryContractInterfaceIsAsserted`, `TestApiModuleDoesNotRequireSource` and `TestNoReDeclaredWireMethodLiterals` located the contract at the hardcoded `../../Oblikovati.API` dev layout. CI does not have that layout — the `api-contract` action checks the contract out into `_api/` and rewrites the go.mod `replace` — so `os.Stat(../../Oblikovati.API/...)` failed and every one of these guards hit `t.Skipf`.

The completeness guard is the important one: a newly declared `api/contract` interface with **no host-side compile-time assertion** was invisible to CI (exactly how #1976's five occurrence contracts slipped through — caught later only by running `go test ./archguard` locally with the sibling present). The compile-time assertions themselves are build-enforced; the *completeness* check was not.

## Fix

Resolve the module directory through `go list -m -f '{{.Dir}}' oblikovati.org/api` (new shared `apiModuleDir` / `apiSubdir` helpers). `go list -m` honors the go.mod `replace` / go.work and reports the same directory in every layout — sibling checkout, go.work, `_api` in CI, or the module cache for the pinned release. The guards now run wherever the contract is resolvable and skip cleanly only when it is genuinely absent (a source-only offline build). **No CI-workflow change is needed** — the contract is already checked out into `_api`.

## Verification

All three now execute (not skip) and pass locally; full `archguard` package green; `golangci-lint --new-from-rev` clean.