### PR TITLE
fix(head): scroll a programmatically-selected PanelTable row into view (#1933)

### DIFF
--- a/head/ui/addin_browse_render_test.go
+++ b/head/ui/addin_browse_render_test.go
@@ -5,6 +5,7 @@
 package ui
 
 import (
+	"strconv"
 	"testing"
 
 	"oblikovati.org/api/client"
@@ -42,10 +43,10 @@ func TestAddInPanelTreeTableRender(t *testing.T) {
 				}},
 			},
 		}}, "fam-deep-groove"),
-		client.PanelTable("members", []string{"designation", "d", "D", "B"}, []wire.TableRow{
-			{Key: "6200", Cells: []string{"6200", "10", "30", "9"}},
-			{Key: "6202", Cells: []string{"6202", "15", "35", "11"}}, // selected row (Value below)
-		}, "6202"),
+		// A member table taller than addInTableRows (8) with the selection BELOW the fold, so the
+		// render exercises the #1933 scroll-into-view path (tableSelectionChanged → SetScrollHereY)
+		// and not just the top-of-table case.
+		client.PanelTable("members", []string{"designation", "d", "D", "B"}, offFoldMemberRows(), "62-10"),
 	}
 
 	frame := func() {
@@ -58,4 +59,15 @@ func TestAddInPanelTreeTableRender(t *testing.T) {
 	}
 	frame() // first render seeds the tree's open state via SetNextItemOpen(..., firstUse=true)
 	frame() // second render takes the treeFirstUse == false path
+}
+
+// offFoldMemberRows returns a member table taller than addInTableRows, so the selection at index 10
+// ("62-10") sits below the visible fold — the #1933 scenario the render must scroll into view.
+func offFoldMemberRows() []wire.TableRow {
+	rows := make([]wire.TableRow, 0, 12)
+	for i := 0; i < 12; i++ {
+		key := "62-" + strconv.Itoa(i)
+		rows = append(rows, wire.TableRow{Key: key, Cells: []string{key, "10", "30", "9"}})
+	}
+	return rows
 }

--- a/head/ui/addin_table.go
+++ b/head/ui/addin_table.go
@@ -11,6 +11,25 @@ import (
 // and the Place button below; the table scrolls internally past this many rows.
 const addInTableRows = 8
 
+// tableScrolledValue records the selection value each PanelTable last scrolled into view, keyed
+// windowID+"/"+controlID (mirroring treeSeeded). It lets drawTableRow scroll a programmatically
+// selected row into view ONCE when the selection changes, instead of every frame — an unconditional
+// scroll would fight the user's own scrolling (#1933).
+var tableScrolledValue = map[string]string{}
+
+// tableSelectionChanged reports (and records) whether a PanelTable's selection changed to value
+// since it last scrolled there. True exactly once per programmatic selection change, so the
+// below-the-fold pre-selected row scrolls into view on that frame and manual scrolling is left
+// alone while the selection is unchanged.
+func tableSelectionChanged(windowID, controlID, value string) bool {
+	key := windowID + "/" + controlID
+	if tableScrolledValue[key] == value {
+		return false
+	}
+	tableScrolledValue[key] = value
+	return true
+}
+
 // rowHeight is one table row's pixel height: the font's line height plus a small padding margin.
 // No table-sizing helper existed outside the Parameters dialog's own paramTableHeight (which bakes
 // in a fixed row px and an 8-row cap tuned for that grid), so PanelTable gets its own — this stays
@@ -75,6 +94,12 @@ func drawTableRow(s panelEditSession, windowID string, control wire.PanelControl
 			// is never itself "selected" (that fill would be the near-invisible dark Header).
 			if native.SelectableSpanAllColumns(cellAt(row, 0), false) {
 				s.PanelValueChanged(windowID, control.ID, row.Key)
+			}
+			// Scroll a below-the-fold pre-selected row into view once, when an add-in changes the
+			// selection programmatically — otherwise the table stays at the top with the highlighted
+			// row off-screen (#1933). Guarded so it fires only on a selection change, not every frame.
+			if row.Key == control.Value && tableSelectionChanged(windowID, control.ID, control.Value) {
+				native.SetScrollHereY()
 			}
 			continue
 		}

--- a/head/ui/addin_table_test.go
+++ b/head/ui/addin_table_test.go
@@ -19,3 +19,34 @@ func TestCellAt(t *testing.T) {
 		t.Fatalf("cellAt out-of-range = %q, want empty", got)
 	}
 }
+
+// TestTableSelectionChanged is the #1933 regression: a PanelTable must scroll a pre-selected row
+// into view ONCE per programmatic selection change and NOT every frame (an unconditional scroll
+// would fight the user's own scrolling). tableSelectionChanged gates the SetScrollHereY call, so it
+// must return true the first time a value is seen, false while that value is unchanged, and true
+// again when the add-in selects a different row.
+func TestTableSelectionChanged(t *testing.T) {
+	const win, ctl = "test-window-1933", "members"
+	delete(tableScrolledValue, win+"/"+ctl) // isolate from other tests sharing the package map
+
+	if !tableSelectionChanged(win, ctl, "row20") {
+		t.Fatal("first selection of row20: want true (scroll it into view)")
+	}
+	if tableSelectionChanged(win, ctl, "row20") {
+		t.Error("same selection on the next frame: want false (do not fight the user's scrolling)")
+	}
+	if tableSelectionChanged(win, ctl, "row20") {
+		t.Error("same selection again: want false (still no re-scroll)")
+	}
+	if !tableSelectionChanged(win, ctl, "row35") {
+		t.Error("add-in changed the selection to row35: want true (scroll the new row into view)")
+	}
+	if tableSelectionChanged(win, ctl, "row35") {
+		t.Error("row35 unchanged next frame: want false")
+	}
+	// A different control keeps its own last-scrolled value, so one table's selection does not
+	// suppress another's scroll.
+	if !tableSelectionChanged(win, "other-control", "row35") {
+		t.Error("a different control selecting row35: want true (independent scroll state)")
+	}
+}


### PR DESCRIPTION
## What

A `PanelTable` highlighted the selected row but never scrolled it into view. When an add-in set the selection to a row **below the internally-scrolling table's fold**, the table rendered at the top with the highlighted row off-screen — the user had to scroll to find their own pre-selection.

## Why it happened

`drawTableRow` painted the accent row background for `row.Key == control.Value` but never told imgui to scroll there. The classic failure (from PartDesigner #48): **Change-Size** re-shows the member table with `selected = <active member>` on, say, row 20 of a 40-row family (8 rows visible) — the table shows the top and the highlight is off-screen.

## Fix

Call `native.SetScrollHereY()` on the selected row, **guarded so it fires once when the selection value changes**, not every frame — an unconditional scroll would fight the user's own scrolling. The guard (`tableSelectionChanged`) mirrors the tree's `treeSeeded` first-use idiom, keyed `windowID+"/"+controlID` → last-scrolled value: scroll once on a programmatic selection change, then leave manual scrolling alone while the selection is unchanged.

No API surface change — `SetScrollHereY` and the widget both already exist. Head-only.

## Verification

- `TestTableSelectionChanged` — the once-per-change guard logic: true on first appearance of a value, false while unchanged, true again on a new selection, independent per control (pure Go, runs everywhere).
- `TestAddInPanelTreeTableRender` extended to drive a member table **taller than the fold with an off-fold selection**, so the scroll path (`tableSelectionChanged → SetScrollHereY`) executes in-window under xvfb+lavapipe without panicking.
- Full `head/ui` package green; `golangci-lint --new-from-rev` clean.

Closes #1933