### PR TITLE
feat(head): left-hand thread + multi-tool/keep-bodies combine UI (#2069)

### DIFF
--- a/app/feature_modify_tools.go
+++ b/app/feature_modify_tools.go
@@ -166,12 +166,13 @@ func (t *MoveFaceTool) rotateParams() ToolParams {
 
 // --- Combine --------------------------------------------------------------
 
-// CombineTool booleans two picked bodies (Join/Cut/Intersect): the first pick is the
-// target, the second the tool body.
+// CombineTool booleans picked bodies (Join/Cut/Intersect): the first pick is the target, every
+// later pick a tool body. Keep-tool-bodies leaves the tools in the part afterwards (#2069).
 type CombineTool struct {
-	bodies []*topo.Body
-	op     ops.PartFeatureOperation
-	added  *feature.PartFeature
+	bodies    []*topo.Body
+	op        ops.PartFeatureOperation
+	keepTools bool // #2069: leave the tool bodies in the part after the boolean (KeepToolBodies)
+	added     *feature.PartFeature
 }
 
 func NewCombineTool() *CombineTool    { return &CombineTool{op: ops.Join} }
@@ -192,17 +193,17 @@ func (t *CombineTool) Cancel(s *Session) {
 }
 
 func (t *CombineTool) Prompt(*Session) string {
-	return "Pick the target body, then the tool body; set the operation; OK."
+	return "Pick the target body, then one or more tool bodies; set the operation; OK."
 }
 func (t *CombineTool) CanCommit() bool { return len(t.bodies) >= 2 }
 
 func (t *CombineTool) Commit(s *Session) error {
-	ti, tj, err := t.combineOperands(s)
+	target, tools, err := t.combineOperands(s)
 	if err != nil {
 		return err
 	}
 	part, _ := activePart(s) // combineOperands already vetted the part
-	t.added = t.addCombine(feature.NewModifyFeatures(part.Features()), ti, tj)
+	t.added = t.addCombine(feature.NewModifyFeatures(part.Features()), target, tools)
 	part.Recompute()
 	s.recordEdit(part, "Combine")
 	if !t.added.Health().OK() {
@@ -211,29 +212,34 @@ func (t *CombineTool) Commit(s *Session) error {
 	return nil
 }
 
-// combineOperands resolves the two picked bodies to indices in the active part's running
-// body list — Commit and DraftFeature (#1626) resolve identically, so the gate inspects
-// exactly what OK would build.
-func (t *CombineTool) combineOperands(s *Session) (int, int, error) {
+// combineOperands resolves the target (first pick) and every tool body (later picks) to indices in
+// the active part's running body list — Commit and DraftFeature (#1626) resolve identically, so the
+// gate inspects exactly what OK would build.
+func (t *CombineTool) combineOperands(s *Session) (int, []int, error) {
 	part, err := activePart(s)
 	if err != nil {
-		return 0, 0, err
+		return 0, nil, err
 	}
-	ti, tj := bodyIndexOf(part, t.bodies[0]), bodyIndexOf(part, t.bodies[1])
-	if ti < 0 || tj < 0 {
-		return 0, 0, errors.New("combine: a picked body is not in the active part")
+	target := bodyIndexOf(part, t.bodies[0])
+	if target < 0 {
+		return 0, nil, errors.New("combine: the target body is not in the active part")
 	}
-	return ti, tj, nil
+	tools := make([]int, 0, len(t.bodies)-1)
+	for _, b := range t.bodies[1:] {
+		j := bodyIndexOf(part, b)
+		if j < 0 {
+			return 0, nil, errors.New("combine: a picked tool body is not in the active part")
+		}
+		tools = append(tools, j)
+	}
+	return target, tools, nil
 }
 
 // addCombine builds the boolean into mods — the shared constructor used by both Commit
-// (the part's engine) and DraftFeature (a scratch engine), so the two cannot drift.
-//
-// The tool picks exactly two bodies and always consumes the second, so it authors the single-tool,
-// tool-consuming combine. The tool collection and keepToolBodies (#1894) are reachable over /api;
-// the pick loop and dialog control for them are a follow-up.
-func (t *CombineTool) addCombine(mods *feature.ModifyFeatures, target, tool int) *feature.PartFeature {
-	return mods.AddCombine(target, tool, t.op)
+// (the part's engine) and DraftFeature (a scratch engine), so the two cannot drift. It booleans the
+// target against every picked tool at once and honours keep-tool-bodies (#2069/#1894).
+func (t *CombineTool) addCombine(mods *feature.ModifyFeatures, target int, tools []int) *feature.PartFeature {
+	return mods.AddCombineTools(target, tools, t.op, t.keepTools)
 }
 
 // DraftFeature implements [PartFeatureTool] (#1626): the boolean it would commit, built
@@ -244,28 +250,36 @@ func (t *CombineTool) DraftFeature(s *Session) (feature.Feature, bool) {
 	if !t.CanCommit() {
 		return nil, false
 	}
-	ti, tj, err := t.combineOperands(s)
+	target, tools, err := t.combineOperands(s)
 	if err != nil {
 		return nil, false
 	}
 	return draftFromScratch(func(fs *feature.PartFeatures) (*feature.PartFeature, error) {
-		return t.addCombine(feature.NewModifyFeatures(fs), ti, tj), nil
+		return t.addCombine(feature.NewModifyFeatures(fs), target, tools), nil
 	})
 }
 
 // SetOperation chooses Join (0), Cut (1) or Intersect (2).
 func (t *CombineTool) SetOperation(op ops.PartFeatureOperation) { t.op = op }
 
+// KeepTools / SetKeepTools leave the tool bodies in the part after the boolean instead of consuming
+// them (Inventor's KeepToolBodies, #2069/#1894), so a tool can go on to cut something else.
+func (t *CombineTool) KeepTools() bool     { return t.keepTools }
+func (t *CombineTool) SetKeepTools(v bool) { t.keepTools = v }
+
 // Params exposes the boolean operation as a named dropdown. It was an IntParam whose long
 // self-documenting label ("Operation (0=Join 1=Cut 2=Intersect)") overflowed the 95px label
 // column and collided with the InputInt steppers, rendering as illegible garble (#1803). A
 // ChoiceParam puts the short label in the column and the named options in the control.
 func (t *CombineTool) Params() ToolParams {
-	return ToolParams{Choices: []ChoiceParam{
-		{Label: "Operation", Options: []string{"Join", "Cut", "Intersect"},
-			Get: func() int { return int(t.op) },
-			Set: func(n int) { t.op = ops.PartFeatureOperation(n) }},
-	}}
+	return ToolParams{
+		Choices: []ChoiceParam{
+			{Label: "Operation", Options: []string{"Join", "Cut", "Intersect"},
+				Get: func() int { return int(t.op) },
+				Set: func(n int) { t.op = ops.PartFeatureOperation(n) }},
+		},
+		Bools: []BoolParam{{Label: "Keep tool bodies", Get: t.KeepTools, Set: t.SetKeepTools}},
+	}
 }
 
 // --- Move (body) ----------------------------------------------------------

--- a/app/feature_modify_tools.go
+++ b/app/feature_modify_tools.go
@@ -236,9 +236,13 @@ func (t *CombineTool) combineOperands(s *Session) (int, []int, error) {
 }
 
 // addCombine builds the boolean into mods — the shared constructor used by both Commit
-// (the part's engine) and DraftFeature (a scratch engine), so the two cannot drift. It booleans the
-// target against every picked tool at once and honours keep-tool-bodies (#2069/#1894).
+// (the part's engine) and DraftFeature (a scratch engine), so the two cannot drift. The common
+// single-tool consuming combine takes the AddCombine convenience; several tools or keep-tool-bodies
+// (#2069/#1894) take the general AddCombineTools.
 func (t *CombineTool) addCombine(mods *feature.ModifyFeatures, target int, tools []int) *feature.PartFeature {
+	if len(tools) == 1 && !t.keepTools {
+		return mods.AddCombine(target, tools[0], t.op)
+	}
 	return mods.AddCombineTools(target, tools, t.op, t.keepTools)
 }
 

--- a/app/feature_modify_tools_test.go
+++ b/app/feature_modify_tools_test.go
@@ -61,6 +61,79 @@ func TestCombineTool(t *testing.T) {
 	}
 }
 
+// TestCombineToolCombinesMultipleTools is the #2069 regression: the tool must boolean the target
+// against EVERY picked tool body in one feature, not just the first — before this it consumed only
+// the second pick and ignored the rest.
+func TestCombineToolCombinesMultipleTools(t *testing.T) {
+	s, def, src := extrudedPart(t)
+	pat := NewFeatureRectPatternTool()
+	pat.countX = 3 // target + two tool copies → 3 bodies in a row
+	s.StartTool(pat)
+	s.feedPick(src)
+	if err := s.OK(); err != nil {
+		t.Fatalf("pattern setup OK: %v", err)
+	}
+	if def.SurfaceBodies().Count() != 3 {
+		t.Fatalf("setup wanted 3 bodies, got %d", def.SurfaceBodies().Count())
+	}
+
+	tool := NewCombineTool() // Join
+	s.StartTool(tool)
+	s.feedPick(BodyHandle{Body: def.SurfaceBodies().Item(0)})
+	s.feedPick(BodyHandle{Body: def.SurfaceBodies().Item(1)})
+	s.feedPick(BodyHandle{Body: def.SurfaceBodies().Item(2)})
+	if err := s.OK(); err != nil {
+		t.Fatalf("combine OK: %v", err)
+	}
+	if def.SurfaceBodies().Count() != 1 {
+		t.Fatalf("joining a target + two tools = %d bodies, want 1", def.SurfaceBodies().Count())
+	}
+}
+
+// TestCombineToolKeepsToolBodies is the #2069 regression for keep-tool-bodies: with the checkbox on,
+// the tool body must survive the boolean instead of being consumed. It also asserts the checkbox is
+// exposed as a BoolParam so the dialog can drive it.
+func TestCombineToolKeepsToolBodies(t *testing.T) {
+	s, def, src := extrudedPart(t)
+	pat := NewFeatureRectPatternTool() // 2×1 → target + one tool
+	s.StartTool(pat)
+	s.feedPick(src)
+	if err := s.OK(); err != nil {
+		t.Fatalf("pattern setup OK: %v", err)
+	}
+	if def.SurfaceBodies().Count() != 2 {
+		t.Fatalf("setup wanted 2 bodies, got %d", def.SurfaceBodies().Count())
+	}
+
+	tool := NewCombineTool()
+	keep, ok := boolParam(tool.Params(), "Keep tool bodies")
+	if !ok {
+		t.Fatal("Combine has no 'Keep tool bodies' checkbox — the dialog cannot reach KeepToolBodies (#2069)")
+	}
+	keep.Set(true) // drive it through the dialog's BoolParam, not the setter directly
+	s.StartTool(tool)
+	s.feedPick(BodyHandle{Body: def.SurfaceBodies().Item(0)})
+	s.feedPick(BodyHandle{Body: def.SurfaceBodies().Item(1)})
+	if err := s.OK(); err != nil {
+		t.Fatalf("combine OK: %v", err)
+	}
+	// Keep-tool-bodies drops only the target and appends the result, so the kept tool remains: 2
+	// bodies, not the 1 a consuming join leaves.
+	if def.SurfaceBodies().Count() != 2 {
+		t.Fatalf("keep-tool-bodies join = %d bodies, want 2 (result + kept tool)", def.SurfaceBodies().Count())
+	}
+}
+
+// boolParam finds a BoolParam by label in a tool's Params.
+func boolParam(p ToolParams, label string) (BoolParam, bool) {
+	for _, b := range p.Bools {
+		if b.Label == label {
+			return b, true
+		}
+	}
+	return BoolParam{}, false
+}
+
 // TestCombineToolOperationIsChoice is the #1803 regression: the Combine "Operation" input
 // must be a ChoiceParam (a named dropdown), NOT an IntParam whose long self-documenting
 // label overflowed the 95px column and collided with the InputInt steppers into garble. It

--- a/app/thread_tool.go
+++ b/app/thread_tool.go
@@ -25,7 +25,8 @@ type ThreadTool struct {
 	cut         bool
 	classIdx    int // index into ClassOptions (0 = unspecified)
 	tapered     bool
-	modelDiaIdx int // index into ModelDiameterOptions (0 = major, the default)
+	leftHanded  bool // #2069: author a left-hand thread (ThreadDefinition.LeftHanded)
+	modelDiaIdx int  // index into ModelDiameterOptions (0 = major, the default)
 	added       *feature.PartFeature
 }
 
@@ -90,6 +91,11 @@ func (t *ThreadTool) SetCut(cut bool) { t.cut = cut }
 // (it needs a conical face), so CanCommit blocks the combination.
 func (t *ThreadTool) Tapered() bool     { return t.tapered }
 func (t *ThreadTool) SetTapered(v bool) { t.tapered = v }
+
+// LeftHanded / SetLeftHanded toggle a left-hand thread (#2069). The flag reaches the modeled
+// groove and the cosmetic helix (ThreadDefinition.LeftHanded, #1892); the default is right-handed.
+func (t *ThreadTool) LeftHanded() bool     { return t.leftHanded }
+func (t *ThreadTool) SetLeftHanded(v bool) { t.leftHanded = v }
 
 // ClassOptions lists the tolerance-class choices for the current standard: unspecified
 // first, then the standard's external and internal classes (#325).
@@ -199,12 +205,11 @@ func (t *ThreadTool) addThread(dress *feature.DressUpFeatures) (*feature.PartFea
 	if err != nil {
 		return nil, err
 	}
-	// The tool always builds a RIGHT-hand thread: Designation() composes the designation from the
-	// standard/size/pitch tables, so the "-LH" spelling is not reachable here either, and the
-	// dialog has no handedness control yet. ThreadDefinition.LeftHanded (#1892) is authorable over
-	// /api today; the UI control is tracked as a follow-up.
+	// Handedness comes from the dialog's Left-hand checkbox (#2069) via ThreadDefinition.LeftHanded
+	// (#1892). Designation() composes the RIGHT-hand spelling from the standard/size/pitch tables, so
+	// the flag is what turns the thread left-handed; the "-LH" suffix and the flag agree either way.
 	return dress.AddThreadDef(&feature.ThreadDefinition{
-		FaceKey: t.face.Face.ReferenceKey(), Designation: designation, Cut: t.cut,
+		FaceKey: t.face.Face.ReferenceKey(), Designation: designation, Cut: t.cut, LeftHanded: t.leftHanded,
 		Class: t.class(), Tapered: t.tapered, ModelDiameter: threadModelDiameters[clampRange(t.modelDiaIdx, len(threadModelDiameters))],
 	}), nil
 }

--- a/app/thread_tool_test.go
+++ b/app/thread_tool_test.go
@@ -92,6 +92,34 @@ func TestThreadToolEndToEnd(t *testing.T) {
 	}
 }
 
+// TestThreadToolAuthorsLeftHandThread is the #2069 regression: the dialog's Left-hand checkbox
+// (SetLeftHanded) must reach ThreadDefinition.LeftHanded, so a left-hand thread is authorable from
+// the UI and not only over /api. The default stays right-handed.
+func TestThreadToolAuthorsLeftHandThread(t *testing.T) {
+	s, cyl := newPartWithCylinder(t)
+	face := cylinderFaceOf(t, cyl)
+	s.SetPicker(stubPicker{sel: FaceHandle{Face: face, Body: cyl}})
+
+	tool := NewThreadTool()
+	s.StartTool(tool)
+	s.Click(100, 100)
+	tool.SetStandardIndex(0)
+	tool.SetSizeIndex(6) // M8
+	tool.SetPitchIndex(0)
+	if tool.LeftHanded() {
+		t.Fatal("a new thread tool defaults to right-handed")
+	}
+	tool.SetLeftHanded(true)
+	if err := s.OK(); err != nil {
+		t.Fatalf("thread OK: %v", err)
+	}
+
+	def := tool.AddedFeature().Definition().(*feature.ThreadFeature).Definition()
+	if !def.LeftHanded {
+		t.Error("Left-hand checkbox set, but ThreadDefinition.LeftHanded is false — the flag did not reach the feature")
+	}
+}
+
 // TestThreadToolRejectsPlanarFace checks the tool ignores a non-cylindrical pick.
 func TestThreadToolRejectsPlanarFace(t *testing.T) {
 	s, block := newPartWithBlock(t, 4)

--- a/head/ui/thread_dialog.go
+++ b/head/ui/thread_dialog.go
@@ -124,6 +124,11 @@ func drawThreadBehavior(t *app.ThreadTool) {
 	if native.Checkbox("Tapered (pipe) thread", &tapered) {
 		t.SetTapered(tapered)
 	}
+	propertyRow("")
+	leftHanded := t.LeftHanded() // #2069: author a left-hand thread from the dialog
+	if native.Checkbox("Left-hand thread", &leftHanded) {
+		t.SetLeftHanded(leftHanded)
+	}
 	if i := propertyComboRow("Class", "thread-class", t.ClassOptions(), t.ClassIndex()); i >= 0 {
 		t.SetClassIndex(i)
 	}


### PR DESCRIPTION
## What

Two "dead UI" gaps where the API landed (tested) in #1892/#1894 but the dialogs never gained the controls, so the options were reachable **only over /api**:

- **Thread handedness** — a "Left-hand thread" checkbox in the Thread dialog.
- **Combine** — accept several tool bodies in one feature, and a "Keep tool bodies" checkbox.

## Why

The recurring UI↔backend wiring-gap shape: `ThreadDefinition.LeftHanded` and `ModifyFeatures.AddCombineTools(..., keepTools)` exist and are tested, but every thread the UI authored was right-handed and every combine consumed exactly one tool.

## Changes

**Thread (#1892):** `ThreadTool` gains a `leftHanded` field wired into `ThreadDefinition.LeftHanded`, `LeftHanded()`/`SetLeftHanded()` accessors, and a "Left-hand thread" checkbox in the dialog's Behavior section next to Tapered.

**Combine (#1894):** `CombineTool` now resolves the target (first pick) plus **every** later pick as tool bodies and builds through `AddCombineTools`, and gains a `keepTools` field surfaced as a "Keep tool bodies" `BoolParam` (data-driven checkbox). `combineOperands`/`addCombine`/`DraftFeature` updated so Commit and the draft preview stay identical.

## Verification

- `TestThreadToolAuthorsLeftHandThread` — the checkbox reaches `ThreadDefinition.LeftHanded`; default stays right-handed.
- `TestCombineToolCombinesMultipleTools` — target + two tools → one body in a single feature.
- `TestCombineToolKeepsToolBodies` — drives the `BoolParam`; keep-tool-bodies leaves the tool in the part (result + kept tool = 2 bodies). **Both combine guards proven by mutating `addCombine`** to drop the extra tools / keepTools (both fail, restore passes).
- Full `app` package green; head/ui dialog-render sweep green (covers the new checkbox draw path); `golangci-lint --new-from-rev` clean on both modules. No API surface change.

Closes #2069