### PR TITLE
feat(sketch): visualize geometric constraints in 3D sketches (#1998)

### DIFF
--- a/app/commands_standard.go
+++ b/app/commands_standard.go
@@ -598,7 +598,24 @@ func sketch3DConstrainCommands() []*CommandDefinition {
 		}).WithTab(tab3DSketch).WithEnvironment(Sketch3DEnvironment).WithEnable(inSketch3D).WithTooltip(d.tooltip).
 			WithIcon(d.icon).WithButtonStyle(SmallIconButton))
 	}
+	cmds = append(cmds, show3DConstraintsCommand())
 	return cmds
+}
+
+// show3DConstraintsCommand is the 3D Constrain panel's Show/Hide Constraints toggle (#1998), the
+// counterpart of the 2D Sketch.ShowConstraints. It shares the session toggle, so flipping it in
+// either environment reveals the markers in both; in a 3D sketch each geometric constraint draws a
+// marker in model space (SketchConstraintGlyphs3D). No default chord — F8 is bound to the 2D command
+// and chords are globally unique here, so the 3D toggle is reached from the ribbon button. Display-
+// only for now: a 3D marker is deleted through the browser, not yet by clicking it.
+func show3DConstraintsCommand() *CommandDefinition {
+	return NewCommand("Sketch3D.ShowConstraints", "Show Constraints", "Constrain", func(s *Session) error {
+		s.ToggleSketchConstraints()
+		return nil
+	}).WithTab(tab3DSketch).WithEnvironment(Sketch3DEnvironment).WithEnable(inSketch3D).
+		WithActive(func(s *Session) bool { return s.ShowSketchConstraints() }).
+		WithIcon("show-constraints").WithButtonStyle(SmallIconButton).
+		WithTooltip("Show Constraints — mark every geometric constraint in the 3D sketch.")
 }
 
 // sketch3DDrawCommands are the 3D-sketch geometry-placement tools (line/point/circle/arc/

--- a/app/environment_command_effect_test.go
+++ b/app/environment_command_effect_test.go
@@ -38,6 +38,7 @@ var environmentEffectExempt = map[string]string{
 	"Sketch3D.LineWeight":      "a selection list, as above",
 	"Sketch.RelaxMode":         "toggles a solver mode the fingerprint does not read",
 	"Sketch.ShowConstraints":   "toggles an overlay the fingerprint does not read",
+	"Sketch3D.ShowConstraints": "toggles the 3D constraint overlay the fingerprint does not read (#1998)",
 	"Sketch.ShowFormat":        "toggles a persisted application option, not sketch state",
 	"Sketch3D.ShowFormat":      "toggles a persisted application option, as above",
 	"Sketch.DimensionsVisible": "toggles a display flag the fingerprint does not read",

--- a/app/sketch_constraint_glyphs.go
+++ b/app/sketch_constraint_glyphs.go
@@ -70,6 +70,33 @@ func (s *Session) SketchConstraintGlyphs() []ConstraintGlyphView {
 	return views
 }
 
+// ConstraintGlyphView3D is one 3D-sketch constraint marker positioned for drawing (#1998): the
+// constraint, its glyph kind, and its model-space anchor. It carries no selection state — 3D
+// constraint markers are display-only for now (Show Constraints in a 3D sketch); viewport pick and
+// delete of a 3D marker are a follow-up, so a 3D constraint is removed through the browser.
+type ConstraintGlyphView3D struct {
+	Constraint sketch.Constraint
+	Kind       sketch.ConstraintKind
+	At         math.Point3
+}
+
+// SketchConstraintGlyphs3D returns the markers to draw for the active 3D sketch, empty when
+// constraints are hidden or no 3D sketch is open. It shares the Show Constraints toggle with the 2D
+// path, so F8 reveals both. The anchors are model-space points the head draws without a plane.
+//
+//	for _, g := range s.SketchConstraintGlyphs3D() { drawGlyph3D(g.Kind, g.At) }
+func (s *Session) SketchConstraintGlyphs3D() []ConstraintGlyphView3D {
+	if !s.showSketchConstraints || s.activeSketch3D == nil {
+		return nil
+	}
+	glyphs := s.activeSketch3D.ConstraintGlyphs()
+	views := make([]ConstraintGlyphView3D, len(glyphs))
+	for i, g := range glyphs {
+		views[i] = ConstraintGlyphView3D{Constraint: g.Constraint, Kind: g.Kind, At: g.At}
+	}
+	return views
+}
+
 // fannedGlyphAnchor offsets the nth marker sharing an anchor, so co-located markers sit in a row
 // beside the geometry rather than on top of one another.
 //

--- a/app/sketch_constraint_glyphs_3d_test.go
+++ b/app/sketch_constraint_glyphs_3d_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// TestSketchConstraintGlyphs3DFollowsTheToggle is the #1998 (3D) app wiring: a 3D sketch's
+// constraint markers appear only when Show Constraints is on, mirror the model glyphs, and the
+// Sketch3D.ShowConstraints command flips them.
+func TestSketchConstraintGlyphs3DFollowsTheToggle(t *testing.T) {
+	s, sk := sketch3DSession(t)
+	l1 := sk.AddLine3D(math.P3(0, 0, 0), math.P3(2, 0, 0))
+	l2 := sk.AddLine3D(math.P3(0, 1, 0), math.P3(2, 1, 0))
+	sk.GeometricConstraints3D().Add(sketch.NewParallel3D(l1, l2))
+
+	if got := s.SketchConstraintGlyphs3D(); len(got) != 0 {
+		t.Fatalf("constraints hidden by default, but got %d 3D markers", len(got))
+	}
+
+	if err := s.Execute("Sketch3D.ShowConstraints"); err != nil {
+		t.Fatalf("Sketch3D.ShowConstraints: %v", err)
+	}
+	if !s.ShowSketchConstraints() {
+		t.Fatal("Sketch3D.ShowConstraints did not turn the markers on")
+	}
+	got := s.SketchConstraintGlyphs3D()
+	if len(got) != 2 {
+		t.Fatalf("parallel of two 3D lines drew %d markers, want 2 (one per line)", len(got))
+	}
+	if got[0].Kind != sketch.ParallelKind {
+		t.Errorf("marker kind = %v, want ParallelKind", got[0].Kind)
+	}
+
+	// Toggling again hides them, so the 3D command drives the same state as F8 / the 2D toggle.
+	if err := s.Execute("Sketch3D.ShowConstraints"); err != nil {
+		t.Fatalf("Sketch3D.ShowConstraints (off): %v", err)
+	}
+	if got := s.SketchConstraintGlyphs3D(); len(got) != 0 {
+		t.Errorf("after toggling off, got %d 3D markers, want 0", len(got))
+	}
+}
+
+// TestSketchConstraintGlyphs3DEmptyWithout3DSketch: the accessor is safe (and empty) when no 3D
+// sketch is open, even with the toggle on.
+func TestSketchConstraintGlyphs3DEmptyWithout3DSketch(t *testing.T) {
+	s := NewSession()
+	s.SetShowSketchConstraints(true)
+	if got := s.SketchConstraintGlyphs3D(); got != nil {
+		t.Errorf("no active 3D sketch, but got %d markers", len(got))
+	}
+}

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -587,6 +587,8 @@ func modelOverlays(s *app.Session, cam scene.Camera, hovered *feature.WorkPlane,
 		list.Items = append(list.Items, cachedPartSketchOverlays(s)...)
 		list.Items = append(list.Items, partSketchPoints(s, pointMarkerPixels*cam.WorldPerPixel())...)
 		list.Items = append(list.Items, sketch3DOverlays(s, pointMarkerPixels*cam.WorldPerPixel())...)
+		// Show Constraints markers for the active 3D sketch (#1998), on top so they read over geometry.
+		list.Items = append(list.Items, onTop(constraint3DGlyphOverlay(s, cam, constraintGlyphPixels*cam.WorldPerPixel()))...)
 	}
 	list.Items = append(list.Items, selectedEdgeOverlay(s)...)
 	list.Items = append(list.Items, selectedMeshFacetOverlay(s)...) // picked placed-mesh facet (#1776)

--- a/head/ui/constraint_glyphs_3d.go
+++ b/head/ui/constraint_glyphs_3d.go
@@ -1,0 +1,68 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"oblikovati.org/app"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+	"oblikovati.org/renderer"
+	"oblikovati.org/scene"
+)
+
+// Show Constraints in a 3D sketch (#1998): a marker per geometric constraint, drawn at the
+// model-space anchor the app derives (SketchConstraintGlyphs3D). A 3D sketch has no host plane, so
+// each marker is a camera-facing BILLBOARD — the same glyph vocabulary as the 2D overlay
+// (constraint_glyphs.go), drawn in a plane whose axes are the camera's right and up so the pictogram
+// always faces the viewer and holds its screen size at any orbit. Display-only for now: 3D markers
+// are not yet pickable, so they draw in one colour (a 3D constraint is deleted from the browser).
+
+// constraint3DGlyphSource is the slice of the session this overlay reads — the 3D markers and
+// nothing else (the consumer-interface pattern, so the overlay cannot touch the model).
+type constraint3DGlyphSource interface {
+	SketchConstraintGlyphs3D() []app.ConstraintGlyphView3D
+}
+
+var _ constraint3DGlyphSource = (*app.Session)(nil)
+
+// constraint3DGlyphOverlay builds the camera-facing marker items for the active 3D sketch's
+// constraints. hWorld is the marker half-size in world units (screen-constant, as for the 2D
+// overlay). Empty when constraints are hidden, no 3D sketch is open, or the camera is degenerate.
+func constraint3DGlyphOverlay(s constraint3DGlyphSource, cam scene.Camera, hWorld float64) []renderer.DrawItem {
+	glyphs := s.SketchConstraintGlyphs3D()
+	if len(glyphs) == 0 {
+		return nil
+	}
+	right, up, ok := cameraBillboardAxes(cam)
+	if !ok {
+		return nil
+	}
+	acc := &segAccum{}
+	for _, g := range glyphs {
+		billboard, err := sketch.NewPlane(g.At, right, up)
+		if err != nil {
+			continue // right⊥up by construction, so this cannot happen for a real camera
+		}
+		constraintGlyphSegments(acc, billboard, math.P2(0, 0), hWorld, g.Kind)
+	}
+	return appendGrid(nil, acc, chromeTheme.sketchColor)
+}
+
+// cameraBillboardAxes returns an orthonormal (right, up) pair spanning the plane that faces the
+// camera: right = forward × up, then up = right × forward so the two are perpendicular by
+// construction. ok is false only for a degenerate camera (view direction parallel to its up
+// vector), where no facing plane exists.
+func cameraBillboardAxes(cam scene.Camera) (right, up math.UnitVector3, ok bool) {
+	forward := cam.Forward()
+	r, err := math.UnitVector3FromVector(forward.Cross(cam.Up))
+	if err != nil {
+		return math.UnitVector3{}, math.UnitVector3{}, false
+	}
+	u, err := math.UnitVector3FromVector(r.AsVector().Cross(forward))
+	if err != nil {
+		return math.UnitVector3{}, math.UnitVector3{}, false
+	}
+	return r, u, true
+}

--- a/head/ui/constraint_glyphs_3d_test.go
+++ b/head/ui/constraint_glyphs_3d_test.go
@@ -1,0 +1,82 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+	"oblikovati.org/scene"
+)
+
+// fake3DGlyphs is a constraint3DGlyphSource returning a fixed marker list, so the overlay can be
+// exercised without a live session.
+type fake3DGlyphs []app.ConstraintGlyphView3D
+
+func (f fake3DGlyphs) SketchConstraintGlyphs3D() []app.ConstraintGlyphView3D { return f }
+
+func lookingDownCamera() scene.Camera {
+	cam := scene.NewCamera(400, 400)
+	cam.Eye, cam.Target, cam.Up = math.P3(0, 0, 10), math.P3(0, 0, 0), math.V3(0, 1, 0)
+	return cam
+}
+
+// TestConstraint3DGlyphOverlayDrawsAMarkerPerGlyph: each 3D marker becomes camera-facing line
+// strokes; two markers with strokes produce a non-empty line item. An empty source draws nothing.
+func TestConstraint3DGlyphOverlayDrawsAMarkerPerGlyph(t *testing.T) {
+	cam := lookingDownCamera()
+	if got := constraint3DGlyphOverlay(fake3DGlyphs(nil), cam, 0.2); got != nil {
+		t.Errorf("no glyphs: got %d items, want nil", len(got))
+	}
+	src := fake3DGlyphs{
+		{Kind: sketch.ParallelKind, At: math.P3(1, 0, 0)},
+		{Kind: sketch.CoincidentKind, At: math.P3(0, 1, 0)},
+	}
+	items := constraint3DGlyphOverlay(src, cam, 0.2)
+	if len(items) == 0 {
+		t.Fatal("two 3D markers drew no items")
+	}
+	segs := 0
+	for _, it := range items {
+		segs += len(it.Positions)
+	}
+	if segs == 0 {
+		t.Error("marker items carry no stroke vertices")
+	}
+	// A camera looking down −Z billboards into the XY plane, so a marker at (1,0,0) has strokes
+	// spread around z=0 with x near 1 — i.e. it renders where the constraint lives, not at the origin.
+	var sawNearAnchor bool
+	for _, it := range items {
+		for _, p := range it.Positions {
+			if stdmath.Abs(float64(p.X)-1) <= 0.5 && stdmath.Abs(float64(p.Z)) <= 0.5 {
+				sawNearAnchor = true
+			}
+		}
+	}
+	if !sawNearAnchor {
+		t.Error("no stroke vertex near the (1,0,0) anchor — the billboard is not placed at the marker")
+	}
+}
+
+// TestCameraBillboardAxesArePerpendicular: the billboard basis is orthonormal for a real camera and
+// declines a degenerate one (view direction parallel to up).
+func TestCameraBillboardAxesArePerpendicular(t *testing.T) {
+	right, up, ok := cameraBillboardAxes(lookingDownCamera())
+	if !ok {
+		t.Fatal("a camera looking down −Z has a valid facing plane")
+	}
+	if d := float64(right.AsVector().Dot(up.AsVector())); stdmath.Abs(d) > 1e-9 {
+		t.Errorf("right·up = %g, want 0 (orthonormal billboard axes)", d)
+	}
+
+	degenerate := scene.NewCamera(400, 400)
+	degenerate.Eye, degenerate.Target, degenerate.Up = math.P3(0, 0, 10), math.P3(0, 0, 0), math.V3(0, 0, 1)
+	if _, _, ok := cameraBillboardAxes(degenerate); ok {
+		t.Error("a view direction parallel to up has no facing plane; want ok=false")
+	}
+}

--- a/model/sketch/constraint_glyph_3d.go
+++ b/model/sketch/constraint_glyph_3d.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import "oblikovati.org/math"
+
+// Where a 3D sketch's geometric-constraint markers belong (Show Constraints in a 3D sketch, #1998).
+//
+// This is the 3D counterpart of ConstraintGlyphs (constraint_glyph.go). It follows the same rule —
+// a marker per operand, derived from each constraint's Variables() so every kind is drawn without a
+// per-kind table — but anchors in model space: a 3D sketch has no host plane to map through, so the
+// head draws each anchor directly. The anchor is the operand's constrained-points centroid (a
+// line's midpoint, a point's own position); the 2D path's extra pass that slides a marker onto a
+// curve's contact point is a refinement left out here, because the centroid already sits on or
+// beside the operand it marks and never floats between two.
+
+// ConstraintGlyph3D is one 3D geometric constraint's marker: the constraint, its kind, and the
+// model-space point it annotates.
+type ConstraintGlyph3D struct {
+	Constraint Constraint
+	Kind       ConstraintKind
+	At         math.Point3
+}
+
+// ConstraintGlyphs returns the markers for every geometric constraint the 3D sketch carries, in
+// creation order — one per operand the constraint relates, so a relation between two lines is marked
+// on each (at its midpoint) and a relation whose operands coincide is marked once at the shared
+// point. Two kinds are left out for the same reasons as the 2D path: a system-owned constraint (a
+// marker the user cannot delete is a dead end) and a record with no numeric footprint (it has
+// nowhere on the sketch to sit). What is drawn is exactly what Delete can remove.
+//
+//	for _, g := range sk.ConstraintGlyphs() { draw(g.Kind, g.At) }
+func (s *Sketch3D) ConstraintGlyphs() []ConstraintGlyph3D {
+	owners := s.variableOwners3D()
+	var out []ConstraintGlyph3D
+	for _, c := range s.geomCons.All() {
+		kc, named := c.(kindedConstraint)
+		if !named || !userDeletable(c) {
+			continue
+		}
+		for _, at := range s.constraintAnchors3D(kc, owners) {
+			out = append(out, ConstraintGlyph3D{Constraint: c, Kind: kc.ConstraintKind(), At: at})
+		}
+	}
+	return out
+}
+
+// variableOwners3D maps every 3D point coordinate to its point — the free position points and the
+// fixed reference anchors, both of which a constraint may name. A constraint's Variables() are
+// pointers straight into these coordinates, so the map turns them back into the points it moves.
+func (s *Sketch3D) variableOwners3D() map[*math.Scalar]*Point3D {
+	owners := make(map[*math.Scalar]*Point3D, (len(s.pts)+len(s.refPts))*3)
+	for _, group := range [][]*Point3D{s.pts, s.refPts} {
+		for _, p := range group {
+			owners[&p.X], owners[&p.Y], owners[&p.Z] = p, p, p
+		}
+	}
+	return owners
+}

--- a/model/sketch/constraint_glyph_3d_test.go
+++ b/model/sketch/constraint_glyph_3d_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// near3D reports whether two model points are within a small tolerance.
+func near3D(a, b math.Point3) bool { return float64(a.DistanceTo(b)) < 1e-9 }
+
+// glyphAt returns the first glyph within tolerance of at, or false.
+func glyphAt(glyphs []ConstraintGlyph3D, at math.Point3) (ConstraintGlyph3D, bool) {
+	for _, g := range glyphs {
+		if near3D(g.At, at) {
+			return g, true
+		}
+	}
+	return ConstraintGlyph3D{}, false
+}
+
+// TestConstraintGlyphs3DMarksEachLineOfAParallel is the #1998 (3D) core: a relation between two
+// lines draws one marker per line, at the line's midpoint — not four (one per endpoint) and not one
+// floating between them.
+func TestConstraintGlyphs3DMarksEachLineOfAParallel(t *testing.T) {
+	s := NewSketches3D().Add()
+	l1 := s.AddLine3D(math.P3(0, 0, 0), math.P3(2, 0, 0)) // midpoint (1,0,0)
+	l2 := s.AddLine3D(math.P3(0, 1, 0), math.P3(2, 1, 0)) // midpoint (1,1,0)
+	s.GeometricConstraints3D().add(NewParallel3D(l1, l2))
+
+	glyphs := s.ConstraintGlyphs()
+	if len(glyphs) != 2 {
+		t.Fatalf("parallel of two lines drew %d markers, want 2 (one per line)", len(glyphs))
+	}
+	for _, at := range []math.Point3{math.P3(1, 0, 0), math.P3(1, 1, 0)} {
+		g, ok := glyphAt(glyphs, at)
+		if !ok {
+			t.Errorf("no marker at %v (a line midpoint); got %v", at, anchorsOf(glyphs))
+			continue
+		}
+		if g.Kind != ParallelKind {
+			t.Errorf("marker at %v kind = %v, want ParallelKind", at, g.Kind)
+		}
+	}
+}
+
+// TestConstraintGlyphs3DCollapsesCoincidentPoints: a coincidence between two points that no line
+// owns as an operand draws ONE marker at their shared place, not two stacked on it.
+func TestConstraintGlyphs3DCollapsesCoincidentPoints(t *testing.T) {
+	s := NewSketches3D().Add()
+	l1 := s.AddLine3D(math.P3(0, 0, 0), math.P3(2, 0, 0))
+	l2 := s.AddLine3D(math.P3(2, 0, 0), math.P3(2, 2, 0))
+	s.GeometricConstraints3D().add(NewCoincident3D(l1.B, l2.A)) // both at (2,0,0)
+
+	glyphs := s.ConstraintGlyphs()
+	if len(glyphs) != 1 {
+		t.Fatalf("coincidence of two points drew %d markers, want 1 at the shared point; got %v",
+			len(glyphs), anchorsOf(glyphs))
+	}
+	if !near3D(glyphs[0].At, math.P3(2, 0, 0)) {
+		t.Errorf("coincidence marker at %v, want the shared point (2,0,0)", glyphs[0].At)
+	}
+	if glyphs[0].Kind != CoincidentKind {
+		t.Errorf("coincidence marker kind = %v, want CoincidentKind", glyphs[0].Kind)
+	}
+}
+
+// TestConstraintGlyphs3DCoversEveryEntityKind guards the entityDefiningPoints3D type switch: every
+// concrete 3D entity that carries points must return them, or its constraints are silently unmarked.
+func TestConstraintGlyphs3DCoversEveryEntityKind(t *testing.T) {
+	p := &Point3D{X: 1, Y: 2, Z: 3}
+	cases := map[string]Entity{
+		"Line3D":    &Line3D{A: p, B: &Point3D{}},
+		"Circle3D":  &Circle3D{Center: p},
+		"Arc3D":     &Arc3D{Center: p, Start: &Point3D{}, End: &Point3D{}},
+		"Ellipse3D": &Ellipse3D{Center: p},
+		"Spline3D":  &Spline3D{Points: []*Point3D{p, {}}},
+		"Point3D":   p,
+	}
+	for name, e := range cases {
+		if len(entityDefiningPoints3D(e)) == 0 {
+			t.Errorf("entityDefiningPoints3D(%s) returned no points — its constraints would be unmarked", name)
+		}
+	}
+}
+
+// anchorsOf lists glyph anchors for a failure message.
+func anchorsOf(glyphs []ConstraintGlyph3D) []math.Point3 {
+	out := make([]math.Point3, len(glyphs))
+	for i, g := range glyphs {
+		out[i] = g.At
+	}
+	return out
+}
+
+// TestCentroid3DAveragesPoints pins the midpoint math the anchor rests on.
+func TestCentroid3DAveragesPoints(t *testing.T) {
+	c := centroid3D([]*Point3D{{X: 0, Y: 0, Z: 0}, {X: 4, Y: 2, Z: 6}})
+	if !near3D(c, math.P3(2, 1, 3)) {
+		t.Errorf("centroid3D = %v, want (2,1,3)", c)
+	}
+}

--- a/model/sketch/constraint_glyph_anchor_3d.go
+++ b/model/sketch/constraint_glyph_anchor_3d.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import "oblikovati.org/math"
+
+// Where a 3D relation's markers sit — the 3D counterpart of constraint_glyph_anchor.go.
+//
+// A relation is anchored once per operand, each marker at that operand's constrained-points
+// centroid: a line's midpoint, a circle's centre, a lone point's own position. Anchoring per
+// operand (not per point) is what keeps a parallel between two lines to two markers rather than
+// four, and a relation whose operands coincide (a coincidence, a concentricity) collapses to the
+// single marker at the shared place.
+
+// constraintAnchors3D returns one anchor per operand the constraint acts on. Operands that end up in
+// the same place — a coincidence's two points, a tangency's contact — collapse to a single marker.
+func (s *Sketch3D) constraintAnchors3D(c Constraint, owners map[*math.Scalar]*Point3D) []math.Point3 {
+	groups := s.operandGroups3D(involvedPoints3D(c, owners))
+	ats := make([]math.Point3, 0, len(groups))
+	for _, g := range groups {
+		ats = append(ats, centroid3D(g))
+	}
+	return dedupeAnchors3D(ats)
+}
+
+// involvedPoints3D lists the distinct 3D points a constraint's variables live in, in the order the
+// constraint names them.
+func involvedPoints3D(c Constraint, owners map[*math.Scalar]*Point3D) []*Point3D {
+	seen := map[*Point3D]bool{}
+	var pts []*Point3D
+	for _, v := range c.Variables() {
+		p, known := owners[v]
+		if !known || seen[p] {
+			continue
+		}
+		seen[p] = true
+		pts = append(pts, p)
+	}
+	return pts
+}
+
+// operandGroups3D splits a constraint's points into one group per operand. An entity claims a group
+// when the constraint moves enough of its points to identify it — two, or one for a circular curve
+// reached through its centre. The points no entity claims (standalone points, a curve endpoint a
+// relation only grazes) fall into ONE group: a relation between bare points marks their meeting
+// place once, not each point.
+func (s *Sketch3D) operandGroups3D(involved []*Point3D) [][]*Point3D {
+	claimed := map[*Point3D]bool{}
+	var groups [][]*Point3D
+	for _, e := range s.Entities() {
+		owned := entityPoints3DAmong(e, involved)
+		if !claimsOperand3D(e, owned) {
+			continue
+		}
+		for _, p := range owned {
+			claimed[p] = true
+		}
+		groups = append(groups, owned)
+	}
+	var loose []*Point3D
+	for _, p := range involved {
+		if !claimed[p] {
+			loose = append(loose, p)
+		}
+	}
+	if len(loose) > 0 {
+		groups = append(groups, loose)
+	}
+	return groups
+}
+
+// claimsOperand3D reports whether an entity is one of the constraint's operands. Two of its points
+// identify it; one does not, because a shared endpoint belongs to every line meeting there. A
+// circular curve is the exception: the constraint reaches it through its centre alone.
+func claimsOperand3D(e Entity, owned []*Point3D) bool {
+	if len(owned) >= 2 {
+		return true
+	}
+	return len(owned) == 1 && isCircular3D(e)
+}
+
+// isCircular3D reports whether a 3D entity is a circular curve reached through its centre.
+func isCircular3D(e Entity) bool {
+	switch e.(type) {
+	case *Circle3D, *Arc3D, *Ellipse3D:
+		return true
+	}
+	return false
+}
+
+// entityPoints3DAmong returns the entity's own defining points that appear in involved.
+func entityPoints3DAmong(e Entity, involved []*Point3D) []*Point3D {
+	mine := map[*Point3D]bool{}
+	for _, p := range entityDefiningPoints3D(e) {
+		mine[p] = true
+	}
+	var out []*Point3D
+	for _, p := range involved {
+		if mine[p] {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// entityDefiningPoints3D returns the constrainable points a 3D entity owns — the 3D counterpart of
+// entityDefiningPoints (blocks_create.go). A new 3D entity kind that carries points must be added
+// here to be marked; TestConstraintGlyphs3DCoversEveryEntityKind guards the omission.
+func entityDefiningPoints3D(e Entity) []*Point3D {
+	switch t := e.(type) {
+	case *Point3D:
+		return []*Point3D{t}
+	case *Line3D:
+		return []*Point3D{t.A, t.B}
+	case *Circle3D:
+		return []*Point3D{t.Center}
+	case *Arc3D:
+		return []*Point3D{t.Center, t.Start, t.End}
+	case *Ellipse3D:
+		return []*Point3D{t.Center}
+	case *Spline3D:
+		return append([]*Point3D(nil), t.Points...)
+	}
+	return nil
+}
+
+// centroid3D averages a group's points — where its marker sits.
+func centroid3D(pts []*Point3D) math.Point3 {
+	var sum math.Vector3
+	for _, p := range pts {
+		sum = sum.Add(math.V3(p.X, p.Y, p.Z))
+	}
+	return math.P3(0, 0, 0).TranslateBy(sum.Scale(1 / float64(len(pts))))
+}
+
+// dedupeAnchors3D collapses anchors that settled on the same place, so a relation whose operands
+// coincide draws one marker rather than two stacked on the contact point.
+func dedupeAnchors3D(ats []math.Point3) []math.Point3 {
+	var out []math.Point3
+	for _, at := range ats {
+		if !containsAnchor3D(out, at) {
+			out = append(out, at)
+		}
+	}
+	return out
+}
+
+// containsAnchor3D reports whether at is already present, within a tolerance relative to how far
+// from the origin the sketch works — an absolute epsilon would merge nothing on a micron-scale
+// sketch and everything on a kilometre-scale one. It shares anchorEpsilon with the 2D path.
+func containsAnchor3D(ats []math.Point3, at math.Point3) bool {
+	for _, other := range ats {
+		if float64(other.DistanceTo(at)) <= anchorEpsilon*(1+float64(at.DistanceTo(math.P3(0, 0, 0)))) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What

Completes **Show Constraints** for **3D** sketches. The 2D half already existed (F8 `Sketch.ShowConstraints`, glyph overlay, pick/delete); a 3D sketch had no equivalent, so its geometric relations were invisible. This adds 3D constraint visualization across model → app → head.

## Why

Filed as "Missing Constraints Visualization in SketchEditor (2D & 3D)". The 2D path was built out after the issue was filed; the 3D path — `Sketch3D` carries `GeometricConstraints3D()` but had no glyph derivation or overlay — remained. (Triage comment on the issue scoped exactly this.)

## How

**model/sketch** — `Sketch3D.ConstraintGlyphs()` derives a marker **per operand** from each constraint's `Variables()`, the same total, per-kind-free approach as the 2D path, but anchored in **model space** at the operand's constrained-points centroid (a line's midpoint, a point's own position). A parallel of two lines draws one marker per line; a coincidence collapses to one at the shared point. `entityDefiningPoints3D` is guarded (`TestConstraintGlyphs3DCoversEveryEntityKind`) so a new 3D entity kind can't be silently unmarked. The 2D per-kind curve-projection *settle* is deliberately omitted — in 3D the centroid already sits on/beside its operand and never floats between two.

**app** — `SketchConstraintGlyphs3D()` exposes the model-space markers, gated on the **shared** Show Constraints toggle; a `Sketch3D.ShowConstraints` command on the 3D Constrain panel flips it. No default chord — F8 is bound to the 2D command and chords are globally unique in this binding system, so the 3D toggle is a ribbon button (making chords environment-scoped would be a separate refactor).

**head** — `constraint3DGlyphOverlay` reuses the **entire** 2D glyph vocabulary by drawing each marker in a **camera-facing billboard plane** (axes = the camera's right/up), so the pictograms hold their shape and screen size at any orbit; drawn on-top.

## Scope

**Visualization only** for now — 3D markers are display-only (a 3D constraint is deleted through the browser). Viewport **pick/delete** of a 3D marker is a follow-up (tracked on #1998).

## Verification

- Model: `TestConstraintGlyphs3DMarksEachLineOfAParallel` (2 markers at line midpoints, `ParallelKind`), `TestConstraintGlyphs3DCollapsesCoincidentPoints` (1 at the shared point), entity-kind coverage, centroid math.
- App: `TestSketchConstraintGlyphs3DFollowsTheToggle` (hidden by default → 2 on show → 0 on toggle-off, via the `Sketch3D.ShowConstraints` command), empty-without-3D-sketch.
- Head: overlay produces camera-facing stroke items at the anchor; billboard axes orthonormal / degenerate-camera declined.
- **Live**: an offscreen `DrawChrome` capture of a 3D sketch shows the "=" parallel glyph on each of two parallel lines and a diamond at their coincident endpoint, all facing the camera.
- Full `model/sketch`, `app`, `head/ui`, `archguard` green; both `golangci-lint --new-from-rev` clean; SPDX headers present. No API surface change.

Closes #1998