### PR TITLE
fix(assembly): rebind relationships after snapshot restore

### DIFF
--- a/model/compdef/assembly_restore_relationships_test.go
+++ b/model/compdef/assembly_restore_relationships_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package compdef_test
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/math"
+	"oblikovati.org/model/assembly"
+)
+
+// TestRestoreSnapshotRewiresRelationshipSets verifies that an assembly snapshot restore
+// replaces the relationship sets and that reference resolution reconnects them to the
+// restored live occurrence collection. A relationship created after rebind must be usable
+// by the solver; a relationship created before the snapshot must not survive the restore.
+func TestRestoreSnapshotRewiresRelationshipSets(t *testing.T) {
+	_, _, asm, widget, asmDef := placedAssembly(t)
+	base := placeFromFile(t, asm, widget, asmDef, "widget:1", math.Identity4())
+	moving := placeFromFile(t, asm, widget, asmDef, "widget:2", math.Translation4(math.V3(0, 0, 10)))
+
+	baseline, err := asmDef.MarshalSnapshot()
+	if err != nil {
+		t.Fatalf("marshal baseline: %v", err)
+	}
+
+	zUp, _ := math.NewUnitVector3(0, 0, 1)
+	zDown, _ := math.NewUnitVector3(0, 0, -1)
+	asmDef.Constraints().AddMate(
+		assembly.Ref{Occurrence: base, Primitive: assembly.PlanePrimitive(math.P3(0, 0, 0), zUp)},
+		assembly.Ref{Occurrence: moving, Primitive: assembly.PlanePrimitive(math.P3(0, 0, 0), zDown)},
+		0, types.MateSolutionOpposed)
+	if got := asmDef.Constraints().Count(); got != 1 {
+		t.Fatalf("after pre-restore AddMate: constraint count = %d, want 1", got)
+	}
+
+	if err := asmDef.RestoreSnapshot(baseline); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if got := asmDef.Constraints().Count(); got != 0 {
+		t.Fatalf("constraint count before reference rebind = %d, want 0", got)
+	}
+	if err := asmDef.ResolveReferences(asm); err != nil {
+		t.Fatalf("resolve references: %v", err)
+	}
+	if got := asmDef.Occurrences().Count(); got != 2 {
+		t.Fatalf("restored occurrence count = %d, want 2", got)
+	}
+
+	baseRestored := asmDef.Occurrences().Item(0)
+	movingRestored := asmDef.Occurrences().Item(1)
+	asmDef.Constraints().AddMate(
+		assembly.Ref{Occurrence: baseRestored, Primitive: assembly.PlanePrimitive(math.P3(0, 0, 0), zUp)},
+		assembly.Ref{Occurrence: movingRestored, Primitive: assembly.PlanePrimitive(math.P3(0, 0, 0), zDown)},
+		0, types.MateSolutionOpposed)
+	if got := asmDef.Constraints().Count(); got != 1 {
+		t.Fatalf("after post-restore AddMate: constraint count = %d, want 1", got)
+	}
+	if report := asmDef.SolveConstraints(); !report.Converged {
+		t.Fatalf("post-restore solve did not converge: %+v", report)
+	}
+}

--- a/model/compdef/assembly_serialize.go
+++ b/model/compdef/assembly_serialize.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"oblikovati.org/math"
+	"oblikovati.org/model/assembly"
 	"oblikovati.org/model/attr"
 	"oblikovati.org/model/bom"
 	"oblikovati.org/model/doc"
@@ -308,6 +309,17 @@ func (a *AssemblyComponentDefinition) resetOccurrences() {
 	a.features = NewAssemblyFeatures()                             // the program rebuilds from the snapshot (#785)
 	a.features.SetBus(a.events.Bus())                              // re-wire the recompute event bus the fresh program needs
 	a.patterns = occurrence.NewOccurrencePatternSet(a.occurrences) // re-bind to the fresh occurrences (#1976)
+	// The relationship sets were constructed once against the ORIGINAL occurrence collection
+	// (NewAssemblyComponentDefinition) and hold that pointer. A restore swaps in a fresh
+	// collection, so leaving them untouched would make the solver walk a detached ghost
+	// collection while the live assembly is untouched — and, because the snapshot recipe carries
+	// no relationship data, a full-replace restore must yield an empty relationship set anyway.
+	// Re-wire them empty against the fresh collection, exactly as the constructor does.
+	a.constraints = assembly.NewConstraintSet(a.occurrences, a.events)
+	a.joints = assembly.NewJointSet(a.occurrences, a.events)
+	a.dsJoints = assembly.NewDSJointSet()
+	a.representations = assembly.NewRepresentations(a.occurrences, a.constraints, a.joints)
+	a.contacts = assembly.NewContactSolver()
 	a.pendingFeatures = nil
 	a.pendingPatterns = nil
 	a.pending = nil


### PR DESCRIPTION
Restoring an assembly snapshot replaces the occurrence collection, but the relationship sets could continue to reference the detached collection. Re-wire constraints, joints, derived joints, representations, and contacts against the restored occurrences so undo and snapshot restore cannot leave ghost relationships behind.

Add a store-backed regression that drops a pre-restore mate, resolves the restored occurrences, creates a new mate against the live collection, and solves it successfully.

**Personal note to the maintainer**

Hey man, I appreciate your GUI! I made a bunch of what were originally plugins for my copy of your repo but I thought you might appreciate having them as PRs. Please feel free of course to ignore them and/or tell me how I can submit better PRs in the future for this repo (if you're happy for me to continue to do so). I'm using it because I love Inventor but hate the restrictive and expensive licensing at my job, and I also want to be able to change things on a whim to do things I want, so that's why I started using your repo to begin with! I use Hermes agents to help me do most of the work, so let me know if there's a problem in that regard as well. I'm putting this message in all of these PRs just in case you only see one of them or something. Thanks again! - Collin / coldsnit

### Evidence

- `obk_make test` — passed, including archguard.
- Focused compdef/assembly tests — passed.
- Regression strengthened to exercise a post-rebind relationship.
