### PR TITLE
feat(scene): make Free Orbit a trackball so the view can tumble underneath

### DIFF
--- a/scene/camera.go
+++ b/scene/camera.go
@@ -267,17 +267,17 @@ func (c Camera) cursorPlanePoint(px, py float64) (math.Point3, bool) {
 	return origin.TranslateBy(dir.Scale(t)), true
 }
 
-// Orbit rotates the eye around the fixed target — a turntable: yaw about the up axis,
-// then pitch about the current right axis (Inventor's Rotate). The eye–target distance
-// is preserved; a pitch that would flip over the up pole is skipped.
+// Orbit rotates the eye around the fixed target — a trackball (Inventor's Free Orbit): yaw
+// about the up axis, then pitch about the current right axis, with the up vector tumbling
+// along with the pitch so the view can roll over the pole and look at the model from any
+// side, including underneath. The eye–target distance is preserved.
 func (c Camera) Orbit(yaw, pitch float64) Camera {
 	up := unit(c.Up)
 	offset := rotateAboutAxis(c.Target.VectorTo(c.Eye), up, yaw)
 	forward := unit(offset.Scale(-1)) // eye → target after the yaw
 	right := unit(forward.Cross(up))
-	if pitched := rotateAboutAxis(offset, right, pitch); absDot(unit(pitched), up) < poleCos {
-		offset = pitched
-	}
+	offset = rotateAboutAxis(offset, right, pitch)
+	c.Up = unit(rotateAboutAxis(up, right, pitch))
 	c.Eye = c.Target.TranslateBy(offset)
 	return c
 }

--- a/scene/camera_test.go
+++ b/scene/camera_test.go
@@ -201,9 +201,14 @@ func TestOrbitPreservesDistanceAndYawsAroundUp(t *testing.T) {
 	if !c.Orbit(2*stdmath.Pi, 0).Eye.IsEqualTo(c.Eye, 1e-9) {
 		t.Error("full 360° yaw should return to the original eye")
 	}
-	// A pitch that would flip over the up pole is skipped (eye unchanged).
-	if !c.Orbit(0, stdmath.Pi/2).Eye.IsEqualTo(c.Eye, 1e-9) {
-		t.Error("near-pole pitch should be clamped (no change)")
+	// A quarter-turn pitch tumbles the eye over the pole to look from underneath (trackball,
+	// Inventor Free Orbit): eye (0,0,10) → (0,-10,0), up +Y → +Z.
+	p := c.Orbit(0, stdmath.Pi/2)
+	if !p.Eye.IsEqualTo(math.P3(0, -10, 0), 1e-9) {
+		t.Errorf("eye after 90° pitch = %v, want (0,-10,0) (tumbled underneath)", p.Eye)
+	}
+	if !p.Up.IsEqualTo(math.V3(0, 0, 1), 1e-9) {
+		t.Errorf("up after 90° pitch = %v, want (0,0,1)", p.Up)
 	}
 }
 


### PR DESCRIPTION
Free Orbit used a turntable implementation with a near-pole guard that skipped the pitch needed to view underneath a part or assembly. Use trackball rotation for unconstrained Orbit so the eye and up vector rotate together through the pole, while leaving OrbitConstrained unchanged.

Add regression coverage for the underside view and expected up-vector tumble. The change is pure scene math and does not alter the Vulkan, GLFW, or platform layers.

**Personal note to the maintainer**

Hey man, I appreciate your GUI! I made a bunch of what were originally plugins for my copy of your repo but I thought you might appreciate having them as PRs. Please feel free of course to ignore them and/or tell me how I can submit better PRs in the future for this repo (if you're happy for me to continue to do so). I'm using it because I love Inventor but hate the restrictive and expensive licensing at my job, and I also want to be able to change things on a whim to do things I want, so that's why I started using your repo to begin with! I use Hermes agents to help me do most of the work, so let me know if there's a problem in that regard as well. I'm putting this message in all of these PRs just in case you only see one of them or something. Thanks again! - Collin / coldsnit

### Evidence

- Scene tests — passed.
- Linux/amd64, Linux/arm64, macOS/amd64, macOS/arm64, and Windows/amd64 cgo-free cross-builds — passed.
- Exact full root run was stopped in the known long OCCT corpus after the changed packages had passed; the same corpus timeout is recorded for PR-4 and PR-7 below.
