### PR TITLE
feat(marking-menu): persist customization and enrich defaults to Inventor parity

### DIFF
--- a/app/marking_menu_save_error_test.go
+++ b/app/marking_menu_save_error_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"errors"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app/markingmenu"
+)
+
+var errMarkingMenuSave = errors.New("marking menu save failed")
+
+type failingMarkingMenuStore struct{}
+
+func (failingMarkingMenuStore) Load() (markingmenu.Customization, error) {
+	return markingmenu.Defaults(), nil
+}
+
+func (failingMarkingMenuStore) Save(markingmenu.Customization) error {
+	return errMarkingMenuSave
+}
+
+func newFailingMarkingMenuSession(t *testing.T) *Session {
+	t.Helper()
+	s := NewSession()
+	if err := s.UseMarkingMenuStore(failingMarkingMenuStore{}); err != nil {
+		t.Fatalf("UseMarkingMenuStore: %v", err)
+	}
+	return s
+}
+
+func TestSetMarkingMenuReportsSaveError(t *testing.T) {
+	s := newFailingMarkingMenuSession(t)
+	err := s.SetMarkingMenu(wire.MarkingMenuView{
+		Environment: BaseEnvironment,
+		Quadrants:   []wire.MarkingMenuItem{{Quadrant: types.QuadrantNorth, CommandID: "Sketch.Create2D"}},
+	})
+	if !errors.Is(err, errMarkingMenuSave) {
+		t.Fatalf("SetMarkingMenu error = %v, want %v", err, errMarkingMenuSave)
+	}
+}
+
+func TestMarkingMenuStyleSaveErrorReachesNotice(t *testing.T) {
+	s := newFailingMarkingMenuSession(t)
+	s.ToggleContextMenuStyle()
+	if want := "marking menu: " + errMarkingMenuSave.Error(); s.Notice() != want {
+		t.Fatalf("Notice() = %q, want %q", s.Notice(), want)
+	}
+}

--- a/app/marking_menu_store_test.go
+++ b/app/marking_menu_store_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app/markingmenu"
+)
+
+// TestMarkingMenuStorePersistsAndReloads mirrors TestKeymapStorePersistsAndReloads
+// (#831): customizing a marking menu persists through the store and reloads into a
+// fresh session.
+func TestMarkingMenuStorePersistsAndReloads(t *testing.T) {
+	store := markingmenu.NewMemStore()
+	s1 := NewSession()
+	if err := s1.UseMarkingMenuStore(store); err != nil {
+		t.Fatalf("UseMarkingMenuStore: %v", err)
+	}
+
+	custom := wire.MarkingMenuView{
+		Environment: BaseEnvironment,
+		Quadrants: []wire.MarkingMenuItem{
+			{Quadrant: types.QuadrantNorth, CommandID: "Create.Extrude"},
+		},
+	}
+	if err := s1.SetMarkingMenu(custom); err != nil {
+		t.Fatalf("SetMarkingMenu: %v", err)
+	}
+	if store.Saved == 0 {
+		t.Error("SetMarkingMenu should have persisted through the store")
+	}
+
+	s2 := NewSession()
+	if err := s2.UseMarkingMenuStore(store); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	got := s2.MarkingMenu(BaseEnvironment)
+	if len(got.Quadrants) != 1 || got.Quadrants[0].CommandID != "Create.Extrude" {
+		t.Errorf("reloaded base menu = %v, want one slot (Create.Extrude/north)", got.Quadrants)
+	}
+}
+
+// TestClassicTogglePersistsAndReloads: toggling the classic/radial style persists
+// across sessions.
+func TestClassicTogglePersistsAndReloads(t *testing.T) {
+	store := markingmenu.NewMemStore()
+	s1 := NewSession()
+	if err := s1.UseMarkingMenuStore(store); err != nil {
+		t.Fatalf("UseMarkingMenuStore: %v", err)
+	}
+	s1.ToggleContextMenuStyle()
+	if store.Saved == 0 {
+		t.Error("ToggleContextMenuStyle should have persisted through the store")
+	}
+
+	s2 := NewSession()
+	if err := s2.UseMarkingMenuStore(store); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if !s2.ClassicContextMenu() {
+		t.Error("reloaded session should have the classic menu style")
+	}
+}
+
+// TestFreshInstallUsesEnrichedDefaults: a fresh session (no stored customization)
+// has the enriched default menus — WorkPlane.Offset in base and Sketch.Finish as
+// a radial slot in sketch.
+func TestFreshInstallUsesEnrichedDefaults(t *testing.T) {
+	s := NewSession()
+	base := s.MarkingMenu(BaseEnvironment)
+	foundWP := false
+	for _, slot := range base.Quadrants {
+		if slot.CommandID == "WorkPlane.Offset" {
+			foundWP = true
+		}
+	}
+	if !foundWP {
+		t.Error("default base menu should include WorkPlane.Offset")
+	}
+
+	sketch := s.MarkingMenu(SketchEnvironment)
+	foundFinish := false
+	for _, slot := range sketch.Quadrants {
+		if slot.CommandID == "Sketch.Finish" {
+			foundFinish = true
+		}
+	}
+	if !foundFinish {
+		t.Error("default sketch menu should include Sketch.Finish as a radial slot")
+	}
+	if len(sketch.Overflow) != 0 {
+		t.Errorf("Sketch.Finish promoted from overflow; overflow should be empty, got %v", sketch.Overflow)
+	}
+}

--- a/app/markingmenu/markingmenu.go
+++ b/app/markingmenu/markingmenu.go
@@ -7,6 +7,8 @@
 package markingmenu
 
 import (
+	"sort"
+
 	"oblikovati.org/api/types"
 	"oblikovati.org/api/wire"
 	"oblikovati.org/persistence/filestore"
@@ -75,7 +77,13 @@ func cloneStrings(ss []string) []string {
 // persisted form.
 func ToCustomization(menus map[types.Environment]wire.MarkingMenuView, classic bool) Customization {
 	c := Customization{Classic: classic}
-	for _, m := range menus {
+	environments := make([]types.Environment, 0, len(menus))
+	for env := range menus {
+		environments = append(environments, env)
+	}
+	sort.Slice(environments, func(i, j int) bool { return environments[i] < environments[j] })
+	for _, env := range environments {
+		m := menus[env]
 		entry := MenuEntry{Environment: int(m.Environment), Overflow: cloneStrings(m.Overflow)}
 		for _, slot := range m.Quadrants {
 			entry.Quadrants = append(entry.Quadrants, SlotEntry{

--- a/app/markingmenu/markingmenu.go
+++ b/app/markingmenu/markingmenu.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+// Package markingmenu persists the per-user radial marking menu customization
+// and the classic/radial style toggle across sessions. It mirrors the keymap
+// package pattern: a fresh install (no file) runs on the session's defaults.
+// Chords in the keymap analogue; environments and quadrant slots here.
+package markingmenu
+
+import (
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/persistence/filestore"
+	"oblikovati.org/userconfig"
+)
+
+// Customization is the stored marking-menu state: per-environment radial menus
+// and the classic/radial style toggle. The zero value (no menus, classic=false)
+// means "run on the session's enriched defaults with the radial style."
+//
+// Explicit yaml: tags are required because wire.MarkingMenuView and friends carry
+// only json: tags; yaml.v3 falls back to lowercased field names without them.
+type Customization struct {
+	Menus   []MenuEntry `yaml:"menus,omitempty"`
+	Classic bool        `yaml:"classic,omitempty"`
+}
+
+// MenuEntry is one environment's persisted radial menu.
+type MenuEntry struct {
+	Environment int         `yaml:"environment"`
+	Quadrants   []SlotEntry `yaml:"quadrants,omitempty"`
+	Overflow    []string    `yaml:"overflow,omitempty"`
+}
+
+// SlotEntry is one quadrant slot in a persisted radial menu.
+type SlotEntry struct {
+	Quadrant int    `yaml:"quadrant"`
+	Command  string `yaml:"command"`
+}
+
+// Defaults returns the empty customization: a fresh install runs on the session's
+// built-in defaults with the radial menu style.
+func Defaults() Customization { return Customization{} }
+
+// Clone returns a deep copy so callers mutate without aliasing stored slices.
+func (c Customization) Clone() Customization {
+	out := Customization{Classic: c.Classic}
+	if len(c.Menus) == 0 {
+		return out
+	}
+	out.Menus = make([]MenuEntry, len(c.Menus))
+	for i, m := range c.Menus {
+		entry := MenuEntry{
+			Environment: m.Environment,
+			Overflow:    cloneStrings(m.Overflow),
+		}
+		if len(m.Quadrants) > 0 {
+			entry.Quadrants = make([]SlotEntry, len(m.Quadrants))
+			copy(entry.Quadrants, m.Quadrants)
+		}
+		out.Menus[i] = entry
+	}
+	return out
+}
+
+func cloneStrings(ss []string) []string {
+	if len(ss) == 0 {
+		return nil
+	}
+	out := make([]string, len(ss))
+	copy(out, ss)
+	return out
+}
+
+// ToCustomization converts a map of MarkingMenuViews and the style flag into the
+// persisted form.
+func ToCustomization(menus map[types.Environment]wire.MarkingMenuView, classic bool) Customization {
+	c := Customization{Classic: classic}
+	for _, m := range menus {
+		entry := MenuEntry{Environment: int(m.Environment), Overflow: cloneStrings(m.Overflow)}
+		for _, slot := range m.Quadrants {
+			entry.Quadrants = append(entry.Quadrants, SlotEntry{
+				Quadrant: int(slot.Quadrant),
+				Command:  slot.CommandID,
+			})
+		}
+		c.Menus = append(c.Menus, entry)
+	}
+	return c
+}
+
+// ApplyToMenus rebuilds the MarkingMenuView map from a Customization, returning
+// the menus and the classic flag. Environments with no entries produce no map entry.
+func ApplyToMenus(c Customization) (map[types.Environment]wire.MarkingMenuView, bool) {
+	menus := make(map[types.Environment]wire.MarkingMenuView, len(c.Menus))
+	for _, entry := range c.Menus {
+		env := types.Environment(entry.Environment)
+		view := wire.MarkingMenuView{Environment: env, Overflow: cloneStrings(entry.Overflow)}
+		for _, slot := range entry.Quadrants {
+			view.Quadrants = append(view.Quadrants, wire.MarkingMenuItem{
+				Quadrant:  types.ScreenQuadrant(slot.Quadrant),
+				CommandID: slot.Command,
+			})
+		}
+		menus[env] = view
+	}
+	return menus, c.Classic
+}
+
+// Store persists the customization across sessions.
+type Store interface {
+	Load() (Customization, error)
+	Save(Customization) error
+}
+
+// DefaultPath is the per-user marking menu file (e.g. ~/.oblikovati/markingmenu.yaml).
+func DefaultPath() (string, error) { return userconfig.File("markingmenu.yaml") }
+
+// FileStore persists the customization to one YAML file in the user config directory
+// (the shared filestore core, #1651).
+type FileStore struct {
+	file *filestore.FileStore[Customization]
+}
+
+// NewFileStore returns a store backed by the file at path.
+func NewFileStore(path string) *FileStore {
+	return &FileStore{file: filestore.New[Customization](path)}
+}
+
+// Load reads the stored customization; a missing file (fresh install) is the empty
+// customization, so the session runs on its enriched defaults.
+func (s *FileStore) Load() (Customization, error) {
+	c, _, err := s.file.Load()
+	if err != nil {
+		return Defaults(), err
+	}
+	return c, nil
+}
+
+// Save writes the customization, creating the config directory on first use.
+func (s *FileStore) Save(c Customization) error { return s.file.Save(c) }
+
+// MemStore is an in-memory Store for tests, over the shared filestore fake (#1651).
+type MemStore struct {
+	filestore.MemStore[Customization]
+}
+
+// NewMemStore returns an empty in-memory store.
+func NewMemStore() *MemStore { return &MemStore{} }
+
+// Load returns the last saved customization (empty if none).
+func (s *MemStore) Load() (Customization, error) {
+	c, _, err := s.MemStore.Load()
+	return c, err
+}
+
+// Save records a deep copy of the customization and counts the call.
+func (s *MemStore) Save(c Customization) error { return s.MemStore.Save(c.Clone()) }

--- a/app/markingmenu/markingmenu_test.go
+++ b/app/markingmenu/markingmenu_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package markingmenu
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+)
+
+func TestToCustomizationSortsEnvironments(t *testing.T) {
+	menus := map[types.Environment]wire.MarkingMenuView{
+		types.Environment(3): {Environment: types.Environment(3)},
+		types.Environment(1): {Environment: types.Environment(1)},
+		types.Environment(2): {Environment: types.Environment(2)},
+	}
+	got := ToCustomization(menus, false)
+	if want := []int{1, 2, 3}; !reflect.DeepEqual(environmentIDs(got), want) {
+		t.Fatalf("environment order = %v, want %v", environmentIDs(got), want)
+	}
+}
+
+func environmentIDs(c Customization) []int {
+	ids := make([]int, len(c.Menus))
+	for i, menu := range c.Menus {
+		ids[i] = menu.Environment
+	}
+	return ids
+}
+
+func TestFileStoreRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "markingmenu.yaml")
+	store := NewFileStore(path)
+	want := Customization{
+		Classic: true,
+		Menus: []MenuEntry{{
+			Environment: int(types.BaseEnvironment),
+			Quadrants:   []SlotEntry{{Quadrant: int(types.QuadrantNorth), Command: "Sketch.Create2D"}},
+			Overflow:    []string{"Repeat"},
+		}},
+	}
+	if err := store.Save(want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("round trip = %#v, want %#v", got, want)
+	}
+}

--- a/app/reset_marking_menu_test.go
+++ b/app/reset_marking_menu_test.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app/markingmenu"
+)
+
+// TestResetMarkingMenuRestoresEnrichedDefaults: after overwriting a menu,
+// ResetMarkingMenu restores the enriched defaults (WorkPlane.Offset in base,
+// Sketch.Finish in sketch).
+func TestResetMarkingMenuRestoresEnrichedDefaults(t *testing.T) {
+	store := markingmenu.NewMemStore()
+	s := NewSession()
+	if err := s.UseMarkingMenuStore(store); err != nil {
+		t.Fatalf("UseMarkingMenuStore: %v", err)
+	}
+
+	// Overwrite base with a single-slot menu.
+	custom := wire.MarkingMenuView{
+		Environment: BaseEnvironment,
+		Quadrants: []wire.MarkingMenuItem{
+			{Quadrant: types.QuadrantNorth, CommandID: "Create.Extrude"},
+		},
+	}
+	if err := s.SetMarkingMenu(custom); err != nil {
+		t.Fatalf("SetMarkingMenu: %v", err)
+	}
+	if len(s.MarkingMenu(BaseEnvironment).Quadrants) != 1 {
+		t.Fatal("expected overwrite to leave 1 quadrant slot")
+	}
+
+	// Reset to defaults.
+	s.ResetMarkingMenu(BaseEnvironment)
+
+	got := s.MarkingMenu(BaseEnvironment)
+	if len(got.Quadrants) < 7 {
+		t.Errorf("after reset, base menu should have 7 quadrant slots; got %d", len(got.Quadrants))
+	}
+	foundWP := false
+	for _, slot := range got.Quadrants {
+		if slot.CommandID == "WorkPlane.Offset" {
+			foundWP = true
+		}
+	}
+	if !foundWP {
+		t.Errorf("after reset, base menu should include WorkPlane.Offset; got %v", got.Quadrants)
+	}
+	if store.Saved < 2 {
+		t.Errorf("ResetMarkingMenu should have persisted; store.Saved = %d", store.Saved)
+	}
+}
+
+// TestResetMarkingMenuSketch: ResetMarkingMenu restores sketch defaults, including
+// Sketch.Finish as a radial slot and empty overflow.
+func TestResetMarkingMenuSketch(t *testing.T) {
+	s := NewSession()
+	// Overwrite sketch with a single-slot menu.
+	custom := wire.MarkingMenuView{
+		Environment: SketchEnvironment,
+		Quadrants: []wire.MarkingMenuItem{
+			{Quadrant: types.QuadrantNorth, CommandID: "Sketch.Line"},
+		},
+		Overflow: []string{"Sketch.Rectangle"},
+	}
+	if err := s.SetMarkingMenu(custom); err != nil {
+		t.Fatalf("SetMarkingMenu: %v", err)
+	}
+
+	s.ResetMarkingMenu(SketchEnvironment)
+
+	got := s.MarkingMenu(SketchEnvironment)
+	foundFinish := false
+	for _, slot := range got.Quadrants {
+		if slot.CommandID == "Sketch.Finish" {
+			foundFinish = true
+		}
+	}
+	if !foundFinish {
+		t.Error("after reset, sketch menu should include Sketch.Finish as a radial slot")
+	}
+	if len(got.Overflow) != 0 {
+		t.Errorf("after reset, sketch overflow should be empty; got %v", got.Overflow)
+	}
+}

--- a/app/session.go
+++ b/app/session.go
@@ -495,13 +495,17 @@ func (s *Session) ClassicContextMenu() bool { return s.classicContextMenu }
 // radial marking menu).
 func (s *Session) SetClassicContextMenu(classic bool) {
 	s.classicContextMenu = classic
-	s.saveMarkingMenuCustomization()
+	if err := s.saveMarkingMenuCustomization(); err != nil {
+		s.SetNotice("marking menu: " + err.Error())
+	}
 }
 
 // ToggleContextMenuStyle flips between the radial marking menu and the classic linear menu.
 func (s *Session) ToggleContextMenuStyle() {
 	s.classicContextMenu = !s.classicContextMenu
-	s.saveMarkingMenuCustomization()
+	if err := s.saveMarkingMenuCustomization(); err != nil {
+		s.SetNotice("marking menu: " + err.Error())
+	}
 }
 
 // Invoke is the alias-driven entry (Inventor command alias): typing a command alias

--- a/app/session.go
+++ b/app/session.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 
 	"oblikovati.org/api/wire"
+	"oblikovati.org/app/markingmenu"
 	"oblikovati.org/app/options"
 	"oblikovati.org/clientgraphics"
 	"oblikovati.org/command"
@@ -123,6 +124,7 @@ type Session struct {
 	addinEnvironments         map[Environment]string                           // registered add-in environments (M05-F16)
 	activeAddInEnv            Environment                                      // the entered add-in environment (base when none)
 	markingMenus              map[Environment]wire.MarkingMenuView             // radial menus per environment (M05-F12)
+	markingMenuStore          markingmenu.Store                                // persists marking-menu customization (nil ⇒ session-only)
 	contextMenus              map[string]map[string][]wire.ContextMenuItemSpec // add-in menu injections by kind
 	lastCommandID             string                                           // the most recently invoked command, for right-click Repeat (#915 C5)
 	classicContextMenu        bool                                             // right-click shows the classic linear menu instead of the radial marking menu (#915 C8)
@@ -153,6 +155,7 @@ type Session struct {
 	chamferConcaveOut         bool                              // default concave-edge strategy for new chamfers (true ⇒ outward fill)
 	paramsDialogOpen          bool                              // the Manage ▸ Parameters dialog is open
 	keymapEditorOpen          bool                              // the Tools ▸ Customize Keyboard panel is open (M05-F17)
+	markingMenuEditorOpen     bool                              // the Tools ▸ Customize Marking Menu panel is open (REQ-005)
 	lightingPanelOpen         bool                              // the View ▸ Lighting settings panel is open
 	namedViewsPanelOpen       bool                              // the View ▸ Named Views panel is open (M16-F03 #404)
 	colorStylesPanelOpen      bool                              // the Color Styles panel is open (M16-F02 #403/#408)
@@ -490,10 +493,16 @@ func (s *Session) ClassicContextMenu() bool { return s.classicContextMenu }
 
 // SetClassicContextMenu chooses the right-click menu style (true = classic linear, false =
 // radial marking menu).
-func (s *Session) SetClassicContextMenu(classic bool) { s.classicContextMenu = classic }
+func (s *Session) SetClassicContextMenu(classic bool) {
+	s.classicContextMenu = classic
+	s.saveMarkingMenuCustomization()
+}
 
 // ToggleContextMenuStyle flips between the radial marking menu and the classic linear menu.
-func (s *Session) ToggleContextMenuStyle() { s.classicContextMenu = !s.classicContextMenu }
+func (s *Session) ToggleContextMenuStyle() {
+	s.classicContextMenu = !s.classicContextMenu
+	s.saveMarkingMenuCustomization()
+}
 
 // Invoke is the alias-driven entry (Inventor command alias): typing a command alias
 // runs the matching command.

--- a/app/session_markingmenu.go
+++ b/app/session_markingmenu.go
@@ -30,11 +30,11 @@ func (s *Session) UseMarkingMenuStore(store markingmenu.Store) error {
 
 // saveMarkingMenuCustomization persists the current marking-menu state when a store
 // is wired. Called by SetMarkingMenu, SetClassicContextMenu, and ToggleContextMenuStyle.
-func (s *Session) saveMarkingMenuCustomization() {
+func (s *Session) saveMarkingMenuCustomization() error {
 	if s.markingMenuStore == nil {
-		return
+		return nil
 	}
-	_ = s.markingMenuStore.Save(markingmenu.ToCustomization(s.markingMenus, s.classicContextMenu))
+	return s.markingMenuStore.Save(markingmenu.ToCustomization(s.markingMenus, s.classicContextMenu))
 }
 
 // OpenMarkingMenuEditor / CloseMarkingMenuEditor / MarkingMenuEditorOpen drive the
@@ -52,5 +52,7 @@ func (s *Session) ResetMarkingMenu(env Environment) {
 	} else {
 		s.markingMenus[env] = wire.MarkingMenuView{Environment: env}
 	}
-	s.saveMarkingMenuCustomization()
+	if err := s.saveMarkingMenuCustomization(); err != nil {
+		s.SetNotice("marking menu: " + err.Error())
+	}
 }

--- a/app/session_markingmenu.go
+++ b/app/session_markingmenu.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app/markingmenu"
+)
+
+// The session half of marking-menu persistence: wires a Store so customizations
+// and the classic/radial style toggle survive across sessions.
+
+// UseMarkingMenuStore installs persistence for the marking-menu customization,
+// loading the stored menus over the session's defaults and the stored style flag.
+func (s *Session) UseMarkingMenuStore(store markingmenu.Store) error {
+	loaded, err := store.Load()
+	if err != nil {
+		return err
+	}
+	s.markingMenuStore = store
+	if len(loaded.Menus) > 0 {
+		menus, _ := markingmenu.ApplyToMenus(loaded)
+		for env, menu := range menus {
+			s.markingMenus[env] = menu
+		}
+	}
+	s.classicContextMenu = loaded.Classic
+	return nil
+}
+
+// saveMarkingMenuCustomization persists the current marking-menu state when a store
+// is wired. Called by SetMarkingMenu, SetClassicContextMenu, and ToggleContextMenuStyle.
+func (s *Session) saveMarkingMenuCustomization() {
+	if s.markingMenuStore == nil {
+		return
+	}
+	_ = s.markingMenuStore.Save(markingmenu.ToCustomization(s.markingMenus, s.classicContextMenu))
+}
+
+// OpenMarkingMenuEditor / CloseMarkingMenuEditor / MarkingMenuEditorOpen drive the
+// Tools ▸ Customize Marking Menu panel's visibility.
+func (s *Session) OpenMarkingMenuEditor()      { s.markingMenuEditorOpen = true }
+func (s *Session) CloseMarkingMenuEditor()     { s.markingMenuEditorOpen = false }
+func (s *Session) MarkingMenuEditorOpen() bool { return s.markingMenuEditorOpen }
+
+// ResetMarkingMenu resets one environment's radial menu to the enriched defaults and
+// persists the change.
+func (s *Session) ResetMarkingMenu(env Environment) {
+	defaults := defaultMarkingMenus()
+	if menu, ok := defaults[env]; ok {
+		s.markingMenus[env] = menu
+	} else {
+		s.markingMenus[env] = wire.MarkingMenuView{Environment: env}
+	}
+	s.saveMarkingMenuCustomization()
+}

--- a/app/ui_shell.go
+++ b/app/ui_shell.go
@@ -77,8 +77,7 @@ func (s *Session) SetMarkingMenu(menu wire.MarkingMenuView) error {
 		seen[item.Quadrant] = true
 	}
 	s.markingMenus[menu.Environment] = menu
-	s.saveMarkingMenuCustomization()
-	return nil
+	return s.saveMarkingMenuCustomization()
 }
 
 // RepeatMenuEntry returns the right-click "Repeat <command>" entry shown when idle: its display

--- a/app/ui_shell.go
+++ b/app/ui_shell.go
@@ -24,29 +24,31 @@ func (EnvironmentChanged) EventID() event.TypeID { return tidEnvironmentChanged 
 
 // defaultMarkingMenus is the out-of-the-box radial layout per environment: the
 // modeling staples around the cursor in base, the sketch staples in sketch.
+// Matches Inventor §8 where commands exist (C-inventor-ui-reference.md).
 func defaultMarkingMenus() map[Environment]wire.MarkingMenuView {
 	return map[Environment]wire.MarkingMenuView{
 		BaseEnvironment: {
 			Environment: BaseEnvironment,
 			Quadrants: []wire.MarkingMenuItem{
 				{Quadrant: types.QuadrantNorth, CommandID: "Sketch.Create2D"},
-				{Quadrant: types.QuadrantEast, CommandID: "Create.Extrude"},
-				{Quadrant: types.QuadrantSouth, CommandID: "Modify.Hole"},
-				{Quadrant: types.QuadrantWest, CommandID: "Create.Revolve"},
 				{Quadrant: types.QuadrantNorthEast, CommandID: "Modify.Fillet"},
+				{Quadrant: types.QuadrantEast, CommandID: "Create.Extrude"},
 				{Quadrant: types.QuadrantSouthEast, CommandID: "Modify.Chamfer"},
+				{Quadrant: types.QuadrantSouth, CommandID: "Modify.Hole"},
+				{Quadrant: types.QuadrantSouthWest, CommandID: "WorkPlane.Offset"},
+				{Quadrant: types.QuadrantWest, CommandID: "Create.Revolve"},
 			},
 		},
 		SketchEnvironment: {
 			Environment: SketchEnvironment,
 			Quadrants: []wire.MarkingMenuItem{
 				{Quadrant: types.QuadrantNorth, CommandID: "Sketch.Line"},
+				{Quadrant: types.QuadrantNorthEast, CommandID: "Sketch.Dimension"},
 				{Quadrant: types.QuadrantEast, CommandID: "Sketch.Circle"},
 				{Quadrant: types.QuadrantSouth, CommandID: "Sketch.Rectangle"},
 				{Quadrant: types.QuadrantWest, CommandID: "Sketch.Arc"},
-				{Quadrant: types.QuadrantNorthEast, CommandID: "Sketch.Dimension"},
+				{Quadrant: types.QuadrantNorthWest, CommandID: "Sketch.Finish"},
 			},
-			Overflow: []string{"Sketch.Finish"},
 		},
 	}
 }
@@ -75,6 +77,7 @@ func (s *Session) SetMarkingMenu(menu wire.MarkingMenuView) error {
 		seen[item.Quadrant] = true
 	}
 	s.markingMenus[menu.Environment] = menu
+	s.saveMarkingMenuCustomization()
 	return nil
 }
 

--- a/head/cmd/oblikovati-head/main.go
+++ b/head/cmd/oblikovati-head/main.go
@@ -18,6 +18,7 @@ import (
 	"oblikovati.org/api/types"
 	"oblikovati.org/app"
 	"oblikovati.org/app/keymap"
+	"oblikovati.org/app/markingmenu"
 	"oblikovati.org/app/options"
 	"oblikovati.org/build"
 	"oblikovati.org/head/internal/appicon"
@@ -212,6 +213,7 @@ func newDemoSession() *app.Session {
 	}
 	registerCommands(s)
 	loadKeymap(s)                          // after registerCommands: CheckDefaults validates the registered shortcuts
+	loadMarkingMenu(s)                     // per-user radial menu customization + classic/radial style toggle
 	s.SetURLOpener(sysopen.SystemOpener{}) // web-view fallback (M05-F08)
 	loadAppOptions(s)
 	// StartupAction (M05-F11): the historical default seeds a demo part; the user can
@@ -311,6 +313,18 @@ func loadKeymap(s *app.Session) {
 	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "keymap: %v\n", err)
+	}
+}
+
+// loadMarkingMenu wires the per-user marking-menu customization file; a store
+// failure costs only persistence (enriched defaults still apply).
+func loadMarkingMenu(s *app.Session) {
+	path, err := markingmenu.DefaultPath()
+	if err == nil {
+		err = s.UseMarkingMenuStore(markingmenu.NewFileStore(path))
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "markingmenu: %v\n", err)
 	}
 }
 

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -114,6 +114,7 @@ func drawChromeWindows(s *app.Session) {
 	drawDockablePanels(s)
 	drawScriptConsole(s)
 	drawKeymapEditor(s)         // Tools ▸ Customize Keyboard (M05-F17)
+	drawMarkingMenuEditor(s)    // Tools ▸ Customize Marking Menu (REQ-005)
 	drawCommandInput(s)         // command-alias input box (M05-F17)
 	drawUpdateWindow(s)         // Help ▸ Check for Updates notification
 	drawReportBugDialog(s)      // Help ▸ Report Bug

--- a/head/ui/chrome_menubar.go
+++ b/head/ui/chrome_menubar.go
@@ -142,6 +142,9 @@ func drawToolsMenu(s *app.Session) {
 		if native.MenuItem("Customize Keyboard") { // M05-F17: rebind shortcuts / aliases
 			s.OpenKeymapEditor()
 		}
+		if native.MenuItem("Customize Marking Menu") { // REQ-005: assign commands to radial slots
+			s.OpenMarkingMenuEditor()
+		}
 		if native.MenuItem("Command Input") { // M05-F17: type an alias to run a command
 			s.BeginCommandInput()
 		}

--- a/head/ui/marking_menu_layout.go
+++ b/head/ui/marking_menu_layout.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import "oblikovati.org/api/types"
+
+// markingMenuRadius is the minimum distance from the popup centre to a ring slot.
+// The layout grows it when the live font or icon scale makes neighbouring labels
+// too tall to sit on separate radial rows.
+const markingMenuRadius = 72
+
+const (
+	markingMenuPadding = 12
+	markingMenuSlotGap = 8
+)
+
+// markingRingLayout is the geometry reserved for the radial portion of the popup.
+// Slot coordinates are relative to the cursor position at which the ring starts.
+type markingRingLayout struct {
+	size          float32
+	center        float32
+	radius        float32
+	maxSlotWidth  float32
+	maxSlotHeight float32
+}
+
+// newMarkingRingLayout grows the ring enough for the tallest live slot and reserves
+// the widest live slot on both sides of the radial centre. The fixed minimum keeps
+// the default menu compact while the dynamic terms make long labels and scaled fonts
+// safe instead of allowing them to overlap or clip at the popup edge.
+func newMarkingRingLayout(maxSlotWidth, maxSlotHeight float32) markingRingLayout {
+	if maxSlotWidth < 0 {
+		maxSlotWidth = 0
+	}
+	if maxSlotHeight < 0 {
+		maxSlotHeight = 0
+	}
+	radius := markingRingRequiredRadius(maxSlotWidth, maxSlotHeight)
+	content := maxSlotWidth
+	if maxSlotHeight > content {
+		content = maxSlotHeight
+	}
+	size := 2*radius + content + 2*markingMenuPadding
+	return markingRingLayout{
+		size:          size,
+		center:        size / 2,
+		radius:        radius,
+		maxSlotWidth:  maxSlotWidth,
+		maxSlotHeight: maxSlotHeight,
+	}
+}
+
+// markingRingRequiredRadius finds the smallest radius for which every adjacent pair
+// of slot rectangles has at least one non-overlapping axis. A radial pair may be
+// separated horizontally or vertically; requiring both axes would make the menu
+// needlessly large for wide command labels.
+func markingRingRequiredRadius(maxSlotWidth, maxSlotHeight float32) float32 {
+	radius := float32(markingMenuRadius)
+	quadrants := []types.ScreenQuadrant{
+		types.QuadrantNorth, types.QuadrantNorthEast, types.QuadrantEast,
+		types.QuadrantSouthEast, types.QuadrantSouth, types.QuadrantSouthWest,
+		types.QuadrantWest, types.QuadrantNorthWest,
+	}
+	widthSpan := maxSlotWidth + markingMenuSlotGap
+	heightSpan := maxSlotHeight + markingMenuSlotGap
+	for i, q := range quadrants {
+		next := quadrants[(i+1)%len(quadrants)]
+		qx, qy := markingQuadrantDirection(q)
+		nx, ny := markingQuadrantDirection(next)
+		dx, dy := absoluteF32(qx-nx), absoluteF32(qy-ny)
+		best := float32(1e9)
+		if dx > 0 {
+			best = widthSpan / dx
+		}
+		if dy > 0 && heightSpan/dy < best {
+			best = heightSpan / dy
+		}
+		if best > radius {
+			radius = best
+		}
+	}
+	return radius
+}
+
+func absoluteF32(v float32) float32 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+// markingQuadrantDirection returns the screen-space unit offset for one slot.
+// Screen Y grows downward, so north is negative Y.
+func markingQuadrantDirection(q types.ScreenQuadrant) (float32, float32) {
+	switch q {
+	case types.QuadrantNorth:
+		return 0, -1
+	case types.QuadrantNorthEast:
+		return 0.7, -0.7
+	case types.QuadrantEast:
+		return 1, 0
+	case types.QuadrantSouthEast:
+		return 0.7, 0.7
+	case types.QuadrantSouth:
+		return 0, 1
+	case types.QuadrantSouthWest:
+		return -0.7, 0.7
+	case types.QuadrantWest:
+		return -1, 0
+	case types.QuadrantNorthWest:
+		return -0.7, -0.7
+	default:
+		return 0, 0
+	}
+}
+
+// markingSlotPosition returns the top-left position of a slot rectangle relative
+// to the ring origin, centring the rectangle on its compass direction.
+func markingSlotPosition(layout markingRingLayout, q types.ScreenQuadrant, width, height float32) (float32, float32) {
+	dx, dy := markingQuadrantDirection(q)
+	return layout.center + dx*layout.radius - width/2,
+		layout.center + dy*layout.radius - height/2
+}

--- a/head/ui/marking_menu_layout_test.go
+++ b/head/ui/marking_menu_layout_test.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+)
+
+func TestMarkingRingLayoutKeepsScaledSlotsInsideAndSeparate(t *testing.T) {
+	layout := newMarkingRingLayout(160, 48)
+	quadrants := []types.ScreenQuadrant{
+		types.QuadrantNorth, types.QuadrantNorthEast, types.QuadrantEast,
+		types.QuadrantSouthEast, types.QuadrantSouth, types.QuadrantSouthWest,
+		types.QuadrantWest, types.QuadrantNorthWest,
+	}
+	for i, q := range quadrants {
+		x, y := markingSlotPosition(layout, q, layout.maxSlotWidth, layout.maxSlotHeight)
+		if x < 0 || y < 0 || x+layout.maxSlotWidth > layout.size || y+layout.maxSlotHeight > layout.size {
+			t.Fatalf("slot %d (%v) escapes ring bounds: (%.1f, %.1f) in %.1f", i, q, x, y, layout.size)
+		}
+		for j := 0; j < i; j++ {
+			px, py := markingSlotPosition(layout, quadrants[j], layout.maxSlotWidth, layout.maxSlotHeight)
+			if rectanglesOverlap(x, y, layout.maxSlotWidth, layout.maxSlotHeight, px, py, layout.maxSlotWidth, layout.maxSlotHeight) {
+				t.Fatalf("slots %v and %v overlap", q, quadrants[j])
+			}
+		}
+	}
+}
+
+func rectanglesOverlap(ax, ay, aw, ah, bx, by, bw, bh float32) bool {
+	return ax < bx+bw && bx < ax+aw && ay < by+bh && by < ay+ah
+}

--- a/head/ui/marking_menu_view.go
+++ b/head/ui/marking_menu_view.go
@@ -5,7 +5,6 @@
 package ui
 
 import (
-	"oblikovati.org/api/types"
 	"oblikovati.org/api/wire"
 	"oblikovati.org/app"
 	"oblikovati.org/head/internal/native"
@@ -19,32 +18,27 @@ import (
 // markingMenuPopupID names the popup; the viewport's right-click opens it.
 const markingMenuPopupID = "##marking-menu"
 
-// markingMenuRadius is the ring's pixel radius around the popup center.
-const markingMenuRadius = 72
-
 // openMarkingMenu arms the popup (called on a viewport right-click).
 func openMarkingMenu() { native.OpenPopup(markingMenuPopupID) }
+
+// markingMenuRequested is set by the viewport's right-click handler (inside the Viewport
+// window) and consumed here at the top level, so OpenPopup and BeginPopup run in the same
+// ImGui window context (the appMenuRequested pattern, chrome.go). Without this deferral the
+// popup opens in the Viewport's popup stack and the top-level BeginPopup never sees it.
+var markingMenuRequested bool
 
 // openMarkingMenuOnFirstFrame lets the visual harness show the menu without a
 // synthetic right-click; consumed on the first chrome frame.
 var openMarkingMenuOnFirstFrame bool
-
-// quadrantDirections maps each compass slot to its unit offset (screen y grows
-// downward, so north is -y).
-var quadrantDirections = map[types.ScreenQuadrant][2]float32{
-	types.QuadrantNorth: {0, -1}, types.QuadrantNorthEast: {0.7, -0.7},
-	types.QuadrantEast: {1, 0}, types.QuadrantSouthEast: {0.7, 0.7},
-	types.QuadrantSouth: {0, 1}, types.QuadrantSouthWest: {-0.7, 0.7},
-	types.QuadrantWest: {-1, 0}, types.QuadrantNorthWest: {-0.7, -0.7},
-}
 
 // drawMarkingMenu renders the right-click popup when open, in the user's chosen style: the radial
 // ring (default) or the classic linear menu (#915 C8). Both lead with the idle "Repeat <command>"
 // entry (#915 C5) and end with the style toggle. Unknown command ids are skipped, so a customized
 // menu can name commands before they register.
 func drawMarkingMenu(s *app.Session) {
-	if openMarkingMenuOnFirstFrame {
+	if openMarkingMenuOnFirstFrame || markingMenuRequested {
 		openMarkingMenuOnFirstFrame = false
+		markingMenuRequested = false
 		openMarkingMenu()
 	}
 	if !native.BeginPopup(markingMenuPopupID) {
@@ -62,14 +56,53 @@ func drawMarkingMenu(s *app.Session) {
 func drawRadialMarkingMenu(s *app.Session) {
 	drawRepeatEntry(s)
 	menu := s.MarkingMenu(app.CurrentEnvironment(s))
-	const size = 2*markingMenuRadius + 96 // ring + button width margin
-	centerX, centerY := float32(size)/2, float32(size)/2
-	native.InvisibleButton("##marking-area", size, size) // reserves the ring's space
+	layout := markingRingLayoutForMenu(s, menu)
+	ringX, ringY := native.GetCursorPos()
+	native.InvisibleButton("##marking-area", layout.size, layout.size) // reserves the ring's space
 	for _, item := range menu.Quadrants {
-		drawMarkingSlot(s, centerX, centerY, item)
+		drawMarkingSlot(s, ringX, ringY, layout, item)
 	}
+	// Slots are positioned manually, so restore the layout cursor after the reserved ring before
+	// drawing overflow and the style row. Otherwise those rows start at whichever slot happened
+	// to be last in the persisted slice and can overlap the ring (the observed right-click defect).
+	m := native.Metrics()
+	native.SetCursorPos(ringX, ringY+layout.size+m.ItemSpacingY)
 	drawMarkingOverflow(s, menu.Overflow)
 	drawContextMenuStyleToggle(s)
+}
+
+// markingMenuCommandHost is the narrow command lookup seam used while measuring the ring.
+// Keeping the measurement helper on this interface preserves the head/ui coupling ratchet.
+type markingMenuCommandHost interface {
+	Commands() *app.CommandManager
+}
+
+var _ markingMenuCommandHost = (*app.Session)(nil)
+
+// markingRingLayoutForMenu measures the commands that will actually render. Unknown
+// command ids are intentionally ignored, matching drawMarkingSlot's fallback.
+func markingRingLayoutForMenu(s markingMenuCommandHost, menu wire.MarkingMenuView) markingRingLayout {
+	m := native.Metrics()
+	iconPx := scaledIconPx(smallIconPx)
+	var maxWidth, maxHeight float32
+	for _, item := range menu.Quadrants {
+		cmd, ok := s.Commands().ByID(item.CommandID)
+		if !ok {
+			continue
+		}
+		hasIcon := false
+		if icons != nil {
+			_, hasIcon = icons.texture(cmd.Icon(), cmd.InlineIconSVG(), iconPx)
+		}
+		w, h := markingSlotExtent(cmd.DisplayName(), hasIcon, iconPx, m)
+		if w > maxWidth {
+			maxWidth = w
+		}
+		if h > maxHeight {
+			maxHeight = h
+		}
+	}
+	return newMarkingRingLayout(maxWidth, maxHeight)
 }
 
 // drawClassicContextMenu draws the same commands as a plain vertical list — the classic
@@ -129,24 +162,58 @@ func drawLinearCommandEntry(s *app.Session, id string) {
 	native.EndDisabled()
 }
 
-// drawMarkingSlot places one quadrant's command button on the ring.
-func drawMarkingSlot(s *app.Session, centerX, centerY float32, item wire.MarkingMenuItem) {
+// drawMarkingSlot places one quadrant's command button on the ring. When the command has an
+// icon asset, it draws icon + label side by side (the same composition as the ribbon's small
+// labelled icon buttons, drawLabeledIconButton, chrome_ribbon.go:613-624 — the icon is the click
+// target there too); a command with no icon falls back to the original text-only button.
+func drawMarkingSlot(s *app.Session, ringX, ringY float32, layout markingRingLayout, item wire.MarkingMenuItem) {
 	cmd, ok := s.Commands().ByID(item.CommandID)
 	if !ok {
 		return
 	}
-	dir := quadrantDirections[item.Quadrant]
 	label := cmd.DisplayName()
-	w := native.CalcTextWidth(label) + 16
-	x := centerX + dir[0]*markingMenuRadius - w/2
-	y := centerY + dir[1]*markingMenuRadius - 12
-	native.SetCursorPos(x, y)
+	iconPx := scaledIconPx(smallIconPx)
+	tex, hasIcon := icons.texture(cmd.Icon(), cmd.InlineIconSVG(), iconPx)
+	m := native.Metrics()
+	w, h := markingSlotExtent(label, hasIcon, iconPx, m)
+	x, y := markingSlotPosition(layout, item.Quadrant, w, h)
+	native.SetCursorPos(ringX+x, ringY+y)
 	native.BeginDisabled(!cmd.IsEnabled(s))
-	if native.Button(label + "##mm-" + item.CommandID) {
+	var clicked bool
+	if hasIcon {
+		native.BeginGroup()
+		clicked = native.ImageButton("##mm-"+item.CommandID, tex, float32(iconPx), float32(iconPx), identityTint)
+		native.SameLine()
+		cx, cy := native.GetCursorScreenPos()
+		native.SetCursorScreenPos(cx, cy+(float32(iconPx)+2*m.FramePadY-native.TextLineHeight())/2)
+		native.Text(label)
+		native.EndGroup()
+	} else {
+		clicked = native.Button(label + "##mm-" + item.CommandID)
+	}
+	if clicked {
 		_ = s.Execute(item.CommandID)
 		native.CloseCurrentPopup()
 	}
 	native.EndDisabled()
+}
+
+// markingSlotExtent mirrors the ImGui primitives used by drawMarkingSlot, so the ring can
+// reserve enough room before it places any command. ImageButton includes frame padding; the
+// label is a plain text item separated by the live item spacing.
+func markingSlotExtent(label string, hasIcon bool, iconPx int, m native.StyleMetrics) (float32, float32) {
+	textWidth := native.CalcTextWidth(label)
+	textHeight := native.FrameHeight()
+	if !hasIcon {
+		return textWidth + 2*m.FramePadX, textHeight
+	}
+	iconWidth := float32(iconPx) + 2*m.FramePadX
+	iconHeight := float32(iconPx) + 2*m.FramePadY
+	width := iconWidth + m.ItemSpacingX + textWidth
+	if textHeight > iconHeight {
+		iconHeight = textHeight
+	}
+	return width, iconHeight
 }
 
 // drawMarkingOverflow renders the linear rows beneath the ring.

--- a/head/ui/marking_menu_view.go
+++ b/head/ui/marking_menu_view.go
@@ -58,7 +58,7 @@ func drawRadialMarkingMenu(s *app.Session) {
 	menu := s.MarkingMenu(app.CurrentEnvironment(s))
 	layout := markingRingLayoutForMenu(s, menu)
 	ringX, ringY := native.GetCursorPos()
-	native.InvisibleButton("##marking-area", layout.size, layout.size) // reserves the ring's space
+	native.Dummy(layout.size, layout.size) // reserves space without capturing slot clicks
 	for _, item := range menu.Quadrants {
 		drawMarkingSlot(s, ringX, ringY, layout, item)
 	}

--- a/head/ui/marking_menu_window.go
+++ b/head/ui/marking_menu_window.go
@@ -1,0 +1,302 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"fmt"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/api/wire"
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// The Tools ▸ Customize Marking Menu panel (REQ-005): environment tab selector,
+// per-slot command assignment with search filter, overflow list, Restore Default,
+// and radial/classic style toggle. Session owns the data and persistence (REQ-004).
+
+// markingMenuEditorSession is the session surface the panel consumes (audit I5,
+// arrowSession pattern). *app.Session satisfies it implicitly.
+type markingMenuEditorSession interface {
+	MarkingMenuEditorOpen() bool
+	CloseMarkingMenuEditor()
+	MarkingMenu(env app.Environment) wire.MarkingMenuView
+	SetMarkingMenu(menu wire.MarkingMenuView) error
+	ResetMarkingMenu(env app.Environment)
+	SearchCommands(query string) []*app.CommandDefinition
+	ClassicContextMenu() bool
+	ToggleContextMenuStyle()
+}
+
+var _ markingMenuEditorSession = (*app.Session)(nil)
+
+const mmEditorFilterLen = 64
+const mmEditorNoSlot = -1
+
+// mmEditorSlotEntry pairs a display label with a quadrant constant.
+type mmEditorSlotEntry struct {
+	label    string
+	quadrant types.ScreenQuadrant
+}
+
+var mmEditorSlots = [8]mmEditorSlotEntry{
+	{"N", types.QuadrantNorth},
+	{"NE", types.QuadrantNorthEast},
+	{"E", types.QuadrantEast},
+	{"SE", types.QuadrantSouthEast},
+	{"S", types.QuadrantSouth},
+	{"SW", types.QuadrantSouthWest},
+	{"W", types.QuadrantWest},
+	{"NW", types.QuadrantNorthWest},
+}
+
+var mmEditorEnvLabels = [2]string{"Base", "Sketch"}
+var mmEditorEnvs = [2]app.Environment{app.BaseEnvironment, app.SketchEnvironment}
+
+// mmEditorUI holds the panel's cross-frame state: active environment tab, which
+// quadrant slot (or overflow entry) is selected for assignment, command search
+// filter, and the last error from SetMarkingMenu.
+var mmEditorUI = struct {
+	envTab  int
+	slot    int  // mmEditorNoSlot or index into mmEditorSlots (0-7)
+	isOver  bool // true when an overflow entry is selected instead
+	overIdx int  // index into Overflow when isOver
+	filter  []byte
+	lastErr string
+}{}
+
+// drawMarkingMenuEditor renders the panel while it is open. The title-bar X and
+// Done both close it.
+func drawMarkingMenuEditor(s markingMenuEditorSession) {
+	if !s.MarkingMenuEditorOpen() {
+		return
+	}
+	if mmEditorUI.filter == nil {
+		mmEditorUI.filter = make([]byte, mmEditorFilterLen)
+		mmEditorUI.slot = mmEditorNoSlot
+	}
+	dialogSizeOnce(620, 520)
+	visible, open := native.BeginClosable("Customize Marking Menu")
+	if visible {
+		drawMMEditorBody(s)
+	}
+	native.End()
+	if !open {
+		s.CloseMarkingMenuEditor()
+	}
+}
+
+// drawMMEditorBody renders the panel: optional error line, environment tabs,
+// command search section, style checkbox, and footer buttons.
+func drawMMEditorBody(s markingMenuEditorSession) {
+	if mmEditorUI.lastErr != "" {
+		native.Text("! " + mmEditorUI.lastErr)
+	}
+	drawMMEditorEnvTabs(s)
+	native.Separator()
+	drawMMEditorSearch(s)
+	native.Separator()
+	classic := s.ClassicContextMenu()
+	if native.Checkbox("Classic (linear) instead of radial", &classic) {
+		s.ToggleContextMenuStyle()
+	}
+	native.Separator()
+	env := mmEditorEnvs[mmEditorUI.envTab]
+	if native.Button("Restore Default") {
+		s.ResetMarkingMenu(env)
+		mmEditorUI.slot = mmEditorNoSlot
+		mmEditorUI.isOver = false
+		mmEditorUI.lastErr = ""
+	}
+	native.SameLine()
+	if native.Button("Done") {
+		s.CloseMarkingMenuEditor()
+	}
+}
+
+// drawMMEditorEnvTabs renders the Base/Sketch tab bar and the slot table for the
+// active environment.
+func drawMMEditorEnvTabs(s markingMenuEditorSession) {
+	if !native.BeginTabBar("##mm-env") {
+		return
+	}
+	for i, label := range mmEditorEnvLabels {
+		if native.BeginTabItem(label) {
+			if mmEditorUI.envTab != i {
+				mmEditorUI.envTab = i
+				mmEditorUI.slot = mmEditorNoSlot
+				mmEditorUI.isOver = false
+			}
+			env := mmEditorEnvs[i]
+			drawMMEditorSlotTable(s, env, s.MarkingMenu(env))
+			native.EndTabItem()
+		}
+	}
+	native.EndTabBar()
+}
+
+// drawMMEditorSlotTable renders the 8-slot quadrant table and overflow list for one
+// environment. Clicking a row selects it for command assignment.
+func drawMMEditorSlotTable(s markingMenuEditorSession, env app.Environment, menu wire.MarkingMenuView) {
+	assigned := map[types.ScreenQuadrant]string{}
+	for _, item := range menu.Quadrants {
+		assigned[item.Quadrant] = item.CommandID
+	}
+	if !native.BeginTable("##mm-slots", 3, 0, 0) {
+		return
+	}
+	native.TableSetupColumn("Slot")
+	native.TableSetupColumn("Command")
+	native.TableSetupColumn("")
+	native.TableSetupScrollFreeze(0, 1)
+	native.TableHeadersRow()
+	for i, entry := range mmEditorSlots {
+		drawMMEditorSlotRow(s, env, i, entry, assigned[entry.quadrant])
+	}
+	native.EndTable()
+	drawMMEditorOverflow(s, env, menu.Overflow)
+}
+
+// drawMMEditorSlotRow renders one quadrant row: slot label, assigned command, and a
+// clear button. Clicking the label column selects this slot for assignment.
+func drawMMEditorSlotRow(s markingMenuEditorSession, env app.Environment, i int, entry mmEditorSlotEntry, cmdID string) {
+	native.TableNextRow()
+	native.TableNextColumn()
+	selected := !mmEditorUI.isOver && mmEditorUI.slot == i
+	if native.Selectable(entry.label+"##q"+entry.label, selected) {
+		mmEditorUI.slot = i
+		mmEditorUI.isOver = false
+	}
+	native.TableNextColumn()
+	if cmdID == "" {
+		native.Text("(empty)")
+	} else {
+		native.Text(cmdID)
+	}
+	native.TableNextColumn()
+	if cmdID != "" && native.Button("×##q"+entry.label) {
+		mmEditorRemoveQuadrant(s, env, entry.quadrant)
+	}
+}
+
+// drawMMEditorOverflow renders the overflow list with remove buttons. Clicking a
+// command label selects it for reassignment.
+func drawMMEditorOverflow(s markingMenuEditorSession, env app.Environment, overflow []string) {
+	if len(overflow) == 0 {
+		return
+	}
+	native.Separator()
+	native.Text("Overflow")
+	for oi, cmdID := range overflow {
+		selected := mmEditorUI.isOver && mmEditorUI.overIdx == oi
+		if native.Selectable(cmdID+"##ov"+fmt.Sprintf("%d", oi), selected) {
+			mmEditorUI.isOver = true
+			mmEditorUI.overIdx = oi
+			mmEditorUI.slot = mmEditorNoSlot
+		}
+		native.SameLine()
+		if native.Button(fmt.Sprintf("×##ov%d", oi)) {
+			mmEditorRemoveOverflow(s, env, oi)
+		}
+	}
+}
+
+// drawMMEditorSearch renders the command filter box and the matching command list.
+// Clicking a command assigns it to the selected slot immediately.
+func drawMMEditorSearch(s markingMenuEditorSession) {
+	native.Text("Filter commands")
+	native.SameLine()
+	native.SetNextItemWidth(-1)
+	native.InputText("##mm-filter", mmEditorUI.filter)
+	query := bufString(mmEditorUI.filter)
+	if query == "" {
+		native.Text("(type to search, then click a result to assign to the selected slot)")
+		return
+	}
+	cmds := s.SearchCommands(query)
+	if len(cmds) == 0 {
+		native.Text("(no matches)")
+		return
+	}
+	for _, c := range cmds {
+		label := c.DisplayName() + " [" + c.ID() + "]"
+		if native.Selectable(label+"##mm-cmd", false) {
+			mmEditorAssign(s, c.ID())
+		}
+	}
+}
+
+// mmEditorAssign assigns commandID to the currently selected slot or overflow entry.
+func mmEditorAssign(s markingMenuEditorSession, commandID string) {
+	if mmEditorUI.slot == mmEditorNoSlot && !mmEditorUI.isOver {
+		mmEditorUI.lastErr = "select a slot first, then click a command"
+		return
+	}
+	mmEditorUI.lastErr = ""
+	env := mmEditorEnvs[mmEditorUI.envTab]
+	if mmEditorUI.isOver {
+		mmEditorAssignOverflow(s, env, commandID)
+		return
+	}
+	mmEditorAssignQuadrant(s, env, mmEditorSlots[mmEditorUI.slot].quadrant, commandID)
+}
+
+// mmEditorAssignQuadrant sets commandID on one quadrant, adding the slot if absent.
+func mmEditorAssignQuadrant(s markingMenuEditorSession, env app.Environment, q types.ScreenQuadrant, commandID string) {
+	menu := s.MarkingMenu(env)
+	for i, item := range menu.Quadrants {
+		if item.Quadrant == q {
+			menu.Quadrants[i].CommandID = commandID
+			recordMMEditorResult(s.SetMarkingMenu(menu))
+			return
+		}
+	}
+	menu.Quadrants = append(menu.Quadrants, wire.MarkingMenuItem{Quadrant: q, CommandID: commandID})
+	recordMMEditorResult(s.SetMarkingMenu(menu))
+}
+
+// mmEditorAssignOverflow replaces one overflow entry by index.
+func mmEditorAssignOverflow(s markingMenuEditorSession, env app.Environment, commandID string) {
+	menu := s.MarkingMenu(env)
+	if mmEditorUI.overIdx < len(menu.Overflow) {
+		menu.Overflow[mmEditorUI.overIdx] = commandID
+		recordMMEditorResult(s.SetMarkingMenu(menu))
+	}
+}
+
+// mmEditorRemoveQuadrant clears the assignment for one quadrant slot.
+func mmEditorRemoveQuadrant(s markingMenuEditorSession, env app.Environment, q types.ScreenQuadrant) {
+	menu := s.MarkingMenu(env)
+	for i, item := range menu.Quadrants {
+		if item.Quadrant == q {
+			menu.Quadrants = append(menu.Quadrants[:i], menu.Quadrants[i+1:]...)
+			break
+		}
+	}
+	recordMMEditorResult(s.SetMarkingMenu(menu))
+}
+
+// mmEditorRemoveOverflow removes one overflow entry by index.
+func mmEditorRemoveOverflow(s markingMenuEditorSession, env app.Environment, idx int) {
+	menu := s.MarkingMenu(env)
+	if idx >= len(menu.Overflow) {
+		return
+	}
+	menu.Overflow = append(menu.Overflow[:idx], menu.Overflow[idx+1:]...)
+	recordMMEditorResult(s.SetMarkingMenu(menu))
+	if mmEditorUI.isOver && mmEditorUI.overIdx >= len(menu.Overflow) {
+		mmEditorUI.isOver = false
+		mmEditorUI.overIdx = 0
+	}
+}
+
+// recordMMEditorResult clears the panel error on success or shows the reason.
+func recordMMEditorResult(err error) {
+	if err != nil {
+		mmEditorUI.lastErr = err.Error()
+		return
+	}
+	mmEditorUI.lastErr = ""
+}

--- a/head/ui/marking_menu_window_test.go
+++ b/head/ui/marking_menu_window_test.go
@@ -1,0 +1,41 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+)
+
+// TestInWindowMarkingMenuEditorDraws opens the Customize Marking Menu window and runs
+// frames, exercising the tab bar, slot table, search section, and footer buttons
+// without tripping Dear ImGui's Begin/End assertions (mirrors TestInWindowKeymapEditorDraws).
+func TestInWindowMarkingMenuEditorDraws(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+	s := framedSession()
+	if err := app.RegisterStandardCommands(s); err != nil {
+		t.Fatalf("RegisterStandardCommands: %v", err)
+	}
+
+	s.OpenMarkingMenuEditor()
+	defer s.CloseMarkingMenuEditor()
+
+	// Unfiltered: the slot table renders for the default Base environment.
+	drawKeymapFrames(win, s, 3)
+	if !s.MarkingMenuEditorOpen() {
+		t.Error("Customize Marking Menu should stay open across frames")
+	}
+
+	// Filtered: seed the filter buffer so the search path renders too.
+	copyText(mmEditorUI.filter, "ext")
+	drawKeymapFrames(win, s, 3)
+	if !s.MarkingMenuEditorOpen() {
+		t.Error("Customize Marking Menu should stay open while filtering")
+	}
+}

--- a/head/ui/select_other_view.go
+++ b/head/ui/select_other_view.go
@@ -28,7 +28,12 @@ func handleViewportRightClick(s *app.Session) {
 	}
 	lx, ly := viewportCursor()
 	if !beginSelectOtherAt(s, lx, ly) {
-		openMarkingMenu()
+		// Defer the OpenPopup to drawMarkingMenu's top-level context: OpenPopup and
+		// BeginPopup must run in the same ImGui window, and this is called inside the
+		// Viewport window while drawMarkingMenu runs at the top level (the appMenuRequested
+		// pattern, chrome.go). Calling OpenPopup here would open it in the Viewport's
+		// popup stack and the top-level BeginPopup would never see it.
+		markingMenuRequested = true
 	}
 }
 


### PR DESCRIPTION
Persist per-environment marking-menu customization, provide the Customize Marking Menu editor, render command icons, and route viewport right-clicks through the correct ImGui popup context.

Keep the radial ring readable by restoring the layout cursor below the reserved ring and sizing it from live command extents. Add focused persistence, editor, and geometry coverage.

This candidate adds no new SVG asset files; the icon rendering uses the existing command/icon surface. The radial command buttons now reserve layout space without capturing the clicks intended for the buttons themselves, and marking-menu persistence reports save failures instead of silently discarding them.

Related upstream issues: [#915](https://github.com/Oblikovati/Oblikovati/issues/915) is closed and covers the Repeat-last-command and classic/radial toggle; [#619](https://github.com/Oblikovati/Oblikovati/issues/619) is closed and covers the broader marking-menu/UI-shell scope. This candidate implements the missing UI/persistence slice and does not claim to reopen or close either issue.

**Personal note to the maintainer**

Hey man, I appreciate your GUI! I made a bunch of what were originally plugins for my copy of your repo but I thought you might appreciate having them as PRs. Please feel free of course to ignore them and/or tell me how I can submit better PRs in the future for this repo (if you're happy for me to continue to do so). I'm using it because I love Inventor but hate the restrictive and expensive licensing at my job, and I also want to be able to change things on a whim to do things I want, so that's why I started using your repo to begin with! I use Hermes agents to help me do most of the work, so let me know if there's a problem in that regard as well. I'm putting this message in all of these PRs just in case you only see one of them or something. Thanks again! - Collin / coldsnit

### Evidence

- Exact `obk_make test` — passed.
- Native head build — passed.
- Marking-ring geometry regression — passed.
- No new asset files in the candidate diff.
- Manual smoke check — user confirmed the radial buttons work in `bin/oblikovati-head-pr3.exe`.
