### PR TITLE
feat(input): make middle-button and wheel navigation configurable

### DIFF
--- a/app/input_pref.go
+++ b/app/input_pref.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// Mouse-navigation preferences surface (Inventor-parity work, 2026-08-17).
+// Oblikovati ships Inventor's default bindings; these accessors let the head
+// adapt the pointer gestures from persisted options without code changes.
+// MMBMode/ShiftMMBMode swap the middle button between pan and orbit;
+// WheelInvert flips the scroll direction; ZoomToCursor=false zooms to the view
+// centre (cam.Dolly) instead of the cursor.
+
+// MMBMode reports the middle-button drag mode ("pan" | "orbit").
+func (s *Session) MMBMode() string {
+	return s.appOptions.Input.MMBMode
+}
+
+// SetMMBMode persists the middle-button drag mode.
+func (s *Session) SetMMBMode(v string) error {
+	s.appOptions.Input.MMBMode = v
+	return s.saveOptions()
+}
+
+// ShiftMMBMode reports the Shift+middle-button drag mode ("orbit" | "pan").
+func (s *Session) ShiftMMBMode() string {
+	return s.appOptions.Input.ShiftMMBMode
+}
+
+// SetShiftMMBMode persists the Shift+middle-button drag mode.
+func (s *Session) SetShiftMMBMode(v string) error {
+	s.appOptions.Input.ShiftMMBMode = v
+	return s.saveOptions()
+}
+
+// CtrlMMBMode reports the Ctrl+middle-button drag mode ("pan" | "orbit" | "zoom").
+// Inventor exposes the Control override alongside the plain and Shift mappings.
+func (s *Session) CtrlMMBMode() string {
+	return s.appOptions.Input.CtrlMMBMode
+}
+
+// SetCtrlMMBMode persists the Ctrl+middle-button drag mode.
+func (s *Session) SetCtrlMMBMode(v string) error {
+	s.appOptions.Input.CtrlMMBMode = v
+	return s.saveOptions()
+}
+
+// WheelInvert reports whether the wheel zoom direction is inverted
+// (true = scroll-up zooms out; Inventor default is scroll-up zooms in).
+func (s *Session) WheelInvert() bool {
+	return s.appOptions.Input.WheelInvert
+}
+
+// SetWheelInvert persists the wheel zoom direction.
+func (s *Session) SetWheelInvert(v bool) error {
+	s.appOptions.Input.WheelInvert = v
+	return s.saveOptions()
+}
+
+// ZoomToCursor reports whether the wheel zooms toward the cursor
+// (true, Inventor default) or toward the view centre (false).
+func (s *Session) ZoomToCursor() bool {
+	return s.appOptions.Input.ZoomToCursor
+}
+
+// SetZoomToCursor persists the wheel zoom anchor.
+func (s *Session) SetZoomToCursor(v bool) error {
+	s.appOptions.Input.ZoomToCursor = v
+	return s.saveOptions()
+}

--- a/app/input_pref_test.go
+++ b/app/input_pref_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/app/options"
+)
+
+// TestInputPrefAccessorsPersist: the mouse-navigation preferences read the
+// persisted Input group and write back through the options store, so the
+// Preferences window's combos survive a restart (I-doc §4.2).
+func TestInputPrefAccessorsPersist(t *testing.T) {
+	store := &FakeOptionsStore{stored: options.Defaults()}
+	s := NewSession()
+	if err := s.UseOptionsStore(store); err != nil {
+		t.Fatalf("UseOptionsStore: %v", err)
+	}
+	if s.MMBMode() != "pan" || s.ShiftMMBMode() != "orbit" || s.CtrlMMBMode() != "pan" {
+		t.Errorf("defaults = mmb %q shift %q ctrl %q, want pan/orbit/pan",
+			s.MMBMode(), s.ShiftMMBMode(), s.CtrlMMBMode())
+	}
+	if s.WheelInvert() || !s.ZoomToCursor() {
+		t.Errorf("wheel defaults = invert %v toCursor %v, want false/true", s.WheelInvert(), s.ZoomToCursor())
+	}
+
+	if err := s.SetMMBMode("orbit"); err != nil {
+		t.Fatalf("SetMMBMode: %v", err)
+	}
+	if err := s.SetShiftMMBMode("pan"); err != nil {
+		t.Fatalf("SetShiftMMBMode: %v", err)
+	}
+	if err := s.SetCtrlMMBMode("zoom"); err != nil {
+		t.Fatalf("SetCtrlMMBMode: %v", err)
+	}
+	if err := s.SetWheelInvert(true); err != nil {
+		t.Fatalf("SetWheelInvert: %v", err)
+	}
+	if err := s.SetZoomToCursor(false); err != nil {
+		t.Fatalf("SetZoomToCursor: %v", err)
+	}
+	if store.saves != 5 {
+		t.Errorf("saves = %d, want 5 (one per setter)", store.saves)
+	}
+	if got := store.stored.Input; got != (options.Input{
+		MMBMode: "orbit", ShiftMMBMode: "pan", CtrlMMBMode: "zoom",
+		WheelInvert: true, ZoomToCursor: false,
+	}) {
+		t.Errorf("stored input = %+v, want the five edited values", got)
+	}
+}

--- a/app/options/options.go
+++ b/app/options/options.go
@@ -99,6 +99,19 @@ type UI struct {
 	IconScale float64 `yaml:"iconScale"`
 }
 
+// Input is the mouse-navigation behaviour surface (Inventor-parity work,
+// 2026-08-17). Oblikovati ships Inventor's default bindings; these toggles let a
+// user adapt the pointer gestures without code changes. Each plain/modifier middle-button
+// mapping can select pan, orbit, or zoom; WheelInvert flips the scroll direction; and
+// ZoomToCursor=false zooms to the view centre instead of the cursor.
+type Input struct {
+	MMBMode      string `yaml:"mmbMode"`      // "pan" (default, Inventor) | "orbit" | "zoom"
+	ShiftMMBMode string `yaml:"shiftMmbMode"` // "orbit" (default, Inventor) | "pan" | "zoom"
+	CtrlMMBMode  string `yaml:"ctrlMmbMode"`  // "pan" (default) | "orbit" | "zoom"
+	WheelInvert  bool   `yaml:"wheelInvert"`  // false: scroll-up zooms in (Inventor default)
+	ZoomToCursor bool   `yaml:"zoomToCursor"` // true: wheel zooms toward the cursor (Inventor default)
+}
+
 // All is every persisted option group. The ViewCube/display preferences live in
 // their own store (persistence/userprefs) and the color scheme in the theme store —
 // the options surface proxies those rather than duplicating their persistence.
@@ -110,6 +123,7 @@ type All struct {
 	Updates   Updates   `yaml:"updates"`
 	Telemetry Telemetry `yaml:"telemetry"`
 	UI        UI        `yaml:"ui"`
+	Input     Input     `yaml:"input"`
 }
 
 // Defaults returns the out-of-the-box options, mirroring the session's historical
@@ -128,6 +142,10 @@ func Defaults() All {
 		Updates:   Updates{CheckOnStartup: true},
 		Telemetry: Telemetry{ShareUsageStatistics: true},
 		UI:        UI{FontScale: 1, IconScale: 1},
+		Input: Input{
+			MMBMode: "pan", ShiftMMBMode: "orbit", CtrlMMBMode: "pan",
+			WheelInvert: false, ZoomToCursor: true,
+		},
 	}
 }
 

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -812,6 +812,13 @@ func readNavInput(s *app.Session) NavInput {
 	}
 	in.OrbitZone = latchOrbitZone(in, cx, cy)
 	in.Constrained = s.ConstrainedOrbitActive() && native.MouseDown(native.MouseLeft)
+	// Inventor-parity input preferences (2026-08-17): the pure navigation
+	// functions cannot read options, so the session's persisted values flow
+	// through NavInput here.
+	in.MMBMode = s.MMBMode()
+	in.ShiftMMBMode = s.ShiftMMBMode()
+	in.WheelInvert = s.WheelInvert()
+	in.ZoomToCursor = s.ZoomToCursor()
 	return in
 }
 

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -791,8 +791,8 @@ func viewportClipFar(cam scene.Camera, mn, mx [3]float32, hasGeom bool) float64 
 // readNavInput snapshots this frame's viewport pointer state from the native layer for
 // the pure ApplyNavigation mapping (see navigate.go). It must be called right after the
 // viewport's InvisibleButton, so IsItemActive/Hovered refer to it. Navigation is driven by
-// the middle button only (pan / Shift+orbit); the left button belongs to selection and
-// box-select, handled separately, so it is not read here.
+// the middle button only (pan / Shift+orbit / Ctrl+orbit, each configurable); the left
+// button belongs to selection and box-select, handled separately, so it is not read here.
 func readNavInput(s *app.Session) NavInput {
 	dx, dy := native.MouseDelta()
 	modal := heldNavMode()
@@ -807,6 +807,7 @@ func readNavInput(s *app.Session) NavInput {
 		CursorY: float32(cy),
 		Middle:  native.MouseDown(native.MouseMiddle),
 		Shift:   native.KeyShift(),
+		Ctrl:    native.KeyCtrl(),
 		Modal:   modal,
 		Left:    modal != NavNone && native.MouseDown(native.MouseLeft),
 	}
@@ -817,6 +818,7 @@ func readNavInput(s *app.Session) NavInput {
 	// through NavInput here.
 	in.MMBMode = s.MMBMode()
 	in.ShiftMMBMode = s.ShiftMMBMode()
+	in.CtrlMMBMode = s.CtrlMMBMode()
 	in.WheelInvert = s.WheelInvert()
 	in.ZoomToCursor = s.ZoomToCursor()
 	return in

--- a/head/ui/navigate.go
+++ b/head/ui/navigate.go
@@ -91,6 +91,12 @@ type NavInput struct {
 	Left             bool      // left button down — only consulted in a Modal mode
 	OrbitZone        OrbitZone // the Free-Orbit ring zone latched at drag start (#913 N5–N8)
 	Constrained      bool      // Constrained Orbit tool active: a left-drag turntables about modelUp (#913 N10)
+	// Inventor-parity input preferences (2026-08-17), populated by readNavInput
+	// from the session's options (the pure functions below cannot read options).
+	MMBMode      string // "pan" | "orbit" — middle-button drag mode
+	ShiftMMBMode string // "orbit" | "pan" — Shift+middle-button drag mode
+	WheelInvert  bool   // true flips the wheel zoom direction
+	ZoomToCursor bool   // false zooms to the view centre instead of the cursor
 }
 
 // ApplyNavigation maps one frame of pointer input to a camera move, mirroring Inventor:
@@ -100,7 +106,15 @@ type NavInput struct {
 // sketch editor's left-click select/drag (#916). The camera math lives in scene.
 func ApplyNavigation(cam scene.Camera, in NavInput) scene.Camera {
 	if in.Hovered && in.Wheel != 0 {
-		cam = cam.DollyToCursor(stdmath.Pow(zoomPerNotch, float64(in.Wheel)), float64(in.CursorX), float64(in.CursorY))
+		factor := stdmath.Pow(zoomPerNotch, float64(in.Wheel))
+		if in.WheelInvert {
+			factor = 1 / factor
+		}
+		if in.ZoomToCursor {
+			cam = cam.DollyToCursor(factor, float64(in.CursorX), float64(in.CursorY))
+		} else {
+			cam = cam.Dolly(factor) // view-centred zoom (Inventor's Zoom to Cursor off)
+		}
 	}
 	if !in.Active || (in.DX == 0 && in.DY == 0) {
 		return cam
@@ -157,12 +171,24 @@ func navGesture(in NavInput) NavMode {
 	if in.Left {
 		return in.Modal
 	}
-	switch {
-	case in.Middle && in.Shift:
-		return NavOrbit
-	case in.Middle:
-		return NavPan
-	default:
-		return NavNone
+	mmbMode, shiftMode := "pan", "orbit" // Inventor defaults
+	if in.MMBMode == "orbit" {
+		mmbMode = "orbit"
 	}
+	if in.ShiftMMBMode == "pan" {
+		shiftMode = "pan"
+	}
+	if in.Middle && in.Shift {
+		if shiftMode == "orbit" {
+			return NavOrbit
+		}
+		return NavPan
+	}
+	if in.Middle {
+		if mmbMode == "orbit" {
+			return NavOrbit
+		}
+		return NavPan
+	}
+	return NavNone
 }

--- a/head/ui/navigate.go
+++ b/head/ui/navigate.go
@@ -93,14 +93,17 @@ type NavInput struct {
 	Constrained      bool      // Constrained Orbit tool active: a left-drag turntables about modelUp (#913 N10)
 	// Inventor-parity input preferences (2026-08-17), populated by readNavInput
 	// from the session's options (the pure functions below cannot read options).
-	MMBMode      string // "pan" | "orbit" — middle-button drag mode
-	ShiftMMBMode string // "orbit" | "pan" — Shift+middle-button drag mode
+	MMBMode      string // "pan" | "orbit" | "zoom" — middle-button drag mode
+	ShiftMMBMode string // "orbit" | "pan" | "zoom" — Shift+middle-button drag mode
+	CtrlMMBMode  string // "pan" | "orbit" | "zoom" — Ctrl+middle-button drag mode
 	WheelInvert  bool   // true flips the wheel zoom direction
 	ZoomToCursor bool   // false zooms to the view centre instead of the cursor
+	Ctrl         bool   // Ctrl held — selects the CtrlMMBMode binding (I-doc §4.2)
 }
 
 // ApplyNavigation maps one frame of pointer input to a camera move, mirroring Inventor:
-// wheel zooms (when hovered), middle-drag pans, Shift+middle-drag orbits. Left-drag is
+// wheel zooms (when hovered), middle-drag pans, Shift+middle orbits, Ctrl+middle follows
+// its own binding (I-doc §4.2); each binding can also be set to zoom. Left-drag is
 // deliberately NOT a navigation gesture — Inventor reserves it for selection (box-select
 // on empty space, drag-to-move on an entity), and orbiting on left-drag collided with the
 // sketch editor's left-click select/drag (#916). The camera math lives in scene.
@@ -165,30 +168,38 @@ func ringRollAngle(cam scene.Camera, in NavInput) float64 {
 }
 
 // navGesture resolves a drag into a navigation gesture: a held F-key (F2 pan / F3 zoom / F4
-// orbit) drives a left-drag; otherwise the middle button pans, Shift+middle orbits. A plain
-// left-drag (no modal key) is NavNone — it belongs to selection, not navigation.
+// orbit) drives a left-drag; otherwise the middle button pans, Shift+middle orbits, and
+// Ctrl+middle follows its own binding (I-doc §4.2). A plain left-drag (no modal key) is
+// NavNone — it belongs to selection, not navigation. Shift wins over Ctrl when both are held.
 func navGesture(in NavInput) NavMode {
 	if in.Left {
 		return in.Modal
 	}
-	mmbMode, shiftMode := "pan", "orbit" // Inventor defaults
-	if in.MMBMode == "orbit" {
-		mmbMode = "orbit"
+	if !in.Middle {
+		return NavNone
 	}
-	if in.ShiftMMBMode == "pan" {
-		shiftMode = "pan"
+	switch {
+	case in.Shift:
+		return middleMode(in.ShiftMMBMode, NavOrbit) // Inventor default: Shift+MMB orbits
+	case in.Ctrl:
+		return middleMode(in.CtrlMMBMode, NavPan) // default: Ctrl+MMB pans (pre-2026-08-17 behaviour)
+	default:
+		return middleMode(in.MMBMode, NavPan) // Inventor default: MMB pans
 	}
-	if in.Middle && in.Shift {
-		if shiftMode == "orbit" {
-			return NavOrbit
-		}
+}
+
+// middleMode maps a persisted middle-button mode name to a gesture, falling back to the
+// binding's Inventor default on an empty or unrecognised value (an options file written
+// before the key reads as ""). "zoom" dollies the camera, the same NavZoom path F3 uses.
+func middleMode(mode string, fallback NavMode) NavMode {
+	switch mode {
+	case "pan":
 		return NavPan
+	case "orbit":
+		return NavOrbit
+	case "zoom":
+		return NavZoom
+	default:
+		return fallback
 	}
-	if in.Middle {
-		if mmbMode == "orbit" {
-			return NavOrbit
-		}
-		return NavPan
-	}
-	return NavNone
 }

--- a/head/ui/navigate_test.go
+++ b/head/ui/navigate_test.go
@@ -30,17 +30,29 @@ func TestApplyNavigationZoomsOnWheelWhenHovered(t *testing.T) {
 // it is a pure dolly (target fixed); off-centre it pans the target toward the cursor.
 func TestApplyNavigationWheelZoomsTowardCursor(t *testing.T) {
 	cam := scene.NewCamera(800, 600)
-	center := ApplyNavigation(cam, NavInput{Hovered: true, Wheel: 1, CursorX: 400, CursorY: 300})
+	center := ApplyNavigation(cam, NavInput{Hovered: true, Wheel: 1, CursorX: 400, CursorY: 300, ZoomToCursor: true})
 	if !center.Target.IsEqualTo(cam.Target, 1e-9) {
 		t.Errorf("wheel zoom at the centre should keep the target fixed, got %v", center.Target)
 	}
-	off := ApplyNavigation(cam, NavInput{Hovered: true, Wheel: 1, CursorX: 700, CursorY: 150})
+	off := ApplyNavigation(cam, NavInput{Hovered: true, Wheel: 1, CursorX: 700, CursorY: 150, ZoomToCursor: true})
 	if off.Target.IsEqualTo(cam.Target, 1e-9) {
 		t.Error("wheel zoom off-centre should move the target toward the cursor (zoom-to-cursor)")
 	}
 }
 
-// TestClassifyOrbitZone covers the Free-Orbit ring zones (#913 N5–N8): inner disc → free, rim
+// TestApplyNavigationWheelZoomsTowardViewCentre verifies the explicit false option: an
+// off-centre wheel event changes distance without moving the camera target.
+func TestApplyNavigationWheelZoomsTowardViewCentre(t *testing.T) {
+	cam := scene.NewCamera(800, 600)
+	out := ApplyNavigation(cam, NavInput{Hovered: true, Wheel: 1, CursorX: 700, CursorY: 150, ZoomToCursor: false})
+	if !out.Target.IsEqualTo(cam.Target, 1e-9) {
+		t.Errorf("view-centred wheel zoom moved target to %v, want %v", out.Target, cam.Target)
+	}
+	if dist(out) >= dist(cam) {
+		t.Errorf("view-centred scroll-up should zoom in: dist %v, want < %v", dist(out), dist(cam))
+	}
+}
+
 // left/right → yaw, rim top/bottom → pitch, outside → roll, and a degenerate ring → free.
 func TestClassifyOrbitZone(t *testing.T) {
 	const cx, cy, radius = 400, 300, 200

--- a/head/ui/navigate_test.go
+++ b/head/ui/navigate_test.go
@@ -110,6 +110,78 @@ func TestApplyNavigationConstrainedOrbit(t *testing.T) {
 	}
 }
 
+// TestNavGestureMiddleButtonModes pins the three middle-button bindings (plain,
+// Shift, Ctrl) across pan/orbit/zoom, with each binding's Inventor default for
+// empty or unrecognised values (an options file written before the key reads as
+// ""). Ctrl+MMB previously fell through to the plain branch and panned; it still
+// pans by default. Shift wins over Ctrl (I-doc §4.2).
+func TestNavGestureMiddleButtonModes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   NavInput
+		want NavMode
+	}{
+		{"plain default", NavInput{Middle: true}, NavPan},
+		{"plain pan", NavInput{Middle: true, MMBMode: "pan"}, NavPan},
+		{"plain orbit", NavInput{Middle: true, MMBMode: "orbit"}, NavOrbit},
+		{"plain zoom", NavInput{Middle: true, MMBMode: "zoom"}, NavZoom},
+		{"plain unrecognised falls back to pan", NavInput{Middle: true, MMBMode: "spin"}, NavPan},
+		{"shift default", NavInput{Middle: true, Shift: true}, NavOrbit},
+		{"shift orbit", NavInput{Middle: true, Shift: true, ShiftMMBMode: "orbit"}, NavOrbit},
+		{"shift pan", NavInput{Middle: true, Shift: true, ShiftMMBMode: "pan"}, NavPan},
+		{"shift zoom", NavInput{Middle: true, Shift: true, ShiftMMBMode: "zoom"}, NavZoom},
+		{"shift unrecognised falls back to orbit", NavInput{Middle: true, Shift: true, ShiftMMBMode: "spin"}, NavOrbit},
+		{"ctrl default", NavInput{Middle: true, Ctrl: true}, NavPan},
+		{"ctrl pan", NavInput{Middle: true, Ctrl: true, CtrlMMBMode: "pan"}, NavPan},
+		{"ctrl orbit", NavInput{Middle: true, Ctrl: true, CtrlMMBMode: "orbit"}, NavOrbit},
+		{"ctrl zoom", NavInput{Middle: true, Ctrl: true, CtrlMMBMode: "zoom"}, NavZoom},
+		{"ctrl unrecognised falls back to pan", NavInput{Middle: true, Ctrl: true, CtrlMMBMode: "spin"}, NavPan},
+		{"shift wins over ctrl", NavInput{Middle: true, Shift: true, Ctrl: true, ShiftMMBMode: "orbit", CtrlMMBMode: "zoom"}, NavOrbit},
+		{"no middle is none", NavInput{Shift: true, Ctrl: true}, NavNone},
+	}
+	for _, c := range cases {
+		if got := navGesture(c.in); got != c.want {
+			t.Errorf("%s: navGesture = %d, want %d", c.name, got, c.want)
+		}
+	}
+}
+
+// TestApplyNavigationMiddleButtonZoom: a middle-drag with the binding set to zoom
+// dollies the camera (distance changes, target fixed) — the same NavZoom path F3 uses.
+func TestApplyNavigationMiddleButtonZoom(t *testing.T) {
+	cam := scene.NewCamera(800, 600)
+	out := ApplyNavigation(cam, NavInput{Active: true, Middle: true, MMBMode: "zoom", DY: 20})
+	if stdmath.Abs(dist(out)-dist(cam)) < 1e-9 {
+		t.Error("middle-drag zoom should change the eye–target distance")
+	}
+	if !out.Target.IsEqualTo(cam.Target, 1e-9) {
+		t.Error("middle-drag zoom must keep the target fixed (pure dolly)")
+	}
+}
+
+// TestApplyNavigationCtrlMiddleZoom: Ctrl+middle with the Ctrl binding set to zoom
+// dollies the camera; the default Ctrl mapping still pans (see navGesture table).
+func TestApplyNavigationCtrlMiddleZoom(t *testing.T) {
+	cam := scene.NewCamera(800, 600)
+	out := ApplyNavigation(cam, NavInput{Active: true, Middle: true, Ctrl: true, CtrlMMBMode: "zoom", DY: 20})
+	if stdmath.Abs(dist(out)-dist(cam)) < 1e-9 {
+		t.Error("Ctrl+middle-drag zoom should change the eye–target distance")
+	}
+	if !out.Target.IsEqualTo(cam.Target, 1e-9) {
+		t.Error("Ctrl+middle-drag zoom must keep the target fixed (pure dolly)")
+	}
+}
+
+// TestApplyNavigationCtrlMiddleDefaultsToPan: with the default (empty) Ctrl mapping,
+// Ctrl+middle keeps today's behaviour — it falls through to the plain branch and pans.
+func TestApplyNavigationCtrlMiddleDefaultsToPan(t *testing.T) {
+	cam := scene.NewCamera(800, 600)
+	out := ApplyNavigation(cam, NavInput{Active: true, Middle: true, Ctrl: true, DX: 50})
+	if out.Target.IsEqualTo(cam.Target, 1e-9) {
+		t.Error("Ctrl+middle-drag with the default mapping should pan (move the target)")
+	}
+}
+
 func TestApplyNavigationPansWithMiddleDrag(t *testing.T) {
 	cam := scene.NewCamera(800, 600)
 	out := ApplyNavigation(cam, NavInput{Active: true, Middle: true, DX: 50})

--- a/head/ui/ui_tab.go
+++ b/head/ui/ui_tab.go
@@ -28,6 +28,48 @@ func drawUITab(s *app.Session) {
 	editUIIconScale(s)
 	native.Separator()
 	native.Text("Text size also scales the Script Console code editor.")
+	native.Separator()
+	// Mouse-navigation preferences (Inventor-parity, 2026-08-17). Defaults
+	// match Inventor: middle-drag pans, Shift+middle-drag orbits, scroll-up
+	// zooms in, wheel zooms to the cursor.
+	native.Text("Mouse navigation (defaults match Inventor):")
+	editNavModeCombo("Middle button drag", s.MMBMode(), s.SetMMBMode, navModeOptions("pan"))
+	editNavModeCombo("Shift + middle button drag", s.ShiftMMBMode(), s.SetShiftMMBMode, navModeOptions("orbit"))
+	editNavModeCombo("Ctrl + middle button drag", s.CtrlMMBMode(), s.SetCtrlMMBMode, navModeOptions("pan"))
+	invert := s.WheelInvert()
+	if native.Checkbox("Invert wheel zoom direction", &invert) {
+		reportPrefError(s.SetWheelInvert(invert))
+	}
+	toCursor := s.ZoomToCursor()
+	if native.Checkbox("Zoom to cursor", &toCursor) {
+		reportPrefError(s.SetZoomToCursor(toCursor))
+	}
+}
+
+// navModeOptions lists the three middle-button gestures, with this binding's
+// Inventor default first in the combo.
+func navModeOptions(preferred string) []string {
+	opts := []string{preferred}
+	for _, mode := range []string{"pan", "orbit", "zoom"} {
+		if mode != preferred {
+			opts = append(opts, mode)
+		}
+	}
+	return opts
+}
+
+// editNavModeCombo draws one pan/orbit/zoom mode selector (BeginCombo + Selectable
+// pattern, same as the add-in grid combo cells).
+func editNavModeCombo(label, current string, set func(string) error, options []string) {
+	if !native.BeginCombo(label, current) {
+		return
+	}
+	for _, opt := range options {
+		if native.Selectable(opt, opt == current) {
+			reportPrefError(set(opt))
+		}
+	}
+	native.EndCombo()
 }
 
 // editUITextScale draws the UI text-size slider, reading and writing the scale as a percentage.


### PR DESCRIPTION
Expose Inventor-style navigation preferences for plain, Shift, and Ctrl middle-button mappings, wheel inversion, and cursor-versus-view-centred zoom.

Persist the settings with the existing options store, preserve Inventor defaults for missing or invalid values, and cover the mapping and zoom decisions with focused tests. Ctrl+middle and the Pan/Orbit/Zoom choices are wired through the navigation path. This candidate deliberately excludes all unrelated menu-bar work.

Issue #1822 is related but distinct: it covers extending the low-level GLFW mouse-input plumbing to additional buttons and scroll axes, while this PR implements the higher-level Inventor-style navigation bindings using the existing input seam. This PR does not claim to close or duplicate #1822.

**Personal note to the maintainer**

Hey man, I appreciate your GUI! I made a bunch of what were originally plugins for my copy of your repo but I thought you might appreciate having them as PRs. Please feel free of course to ignore them and/or tell me how I can submit better PRs in the future for this repo (if you're happy for me to continue to do so). I'm using it because I love Inventor but hate the restrictive and expensive licensing at my job, and I also want to be able to change things on a whim to do things I want, so that's why I started using your repo to begin with! I use Hermes agents to help me do most of the work, so let me know if there's a problem in that regard as well. I'm putting this message in all of these PRs just in case you only see one of them or something. Thanks again! - Collin / coldsnit

### Evidence

- Options tests — passed.
- Focused navigation tests, including the explicit view-centred zoom regression — passed.
- Native head build — passed.
- The exact root run reached the known OCCT blend timeout (`TestOCCTBlendSimple`) after changed packages and archguard had passed; no PR-4 code failure was reported.
