### PR TITLE
feat(ui): collapse ribbon panels that do not fit the band

### DIFF
--- a/head/internal/native/imgui.go
+++ b/head/internal/native/imgui.go
@@ -20,6 +20,7 @@ void obk_ig_end(void);
 void obk_ig_text(const char* s);
 void obk_ig_text_wrapped(const char* s);
 int  obk_ig_button(const char* label);
+int  obk_ig_button_sized(const char* label, float w, float h);
 void obk_ig_same_line(void);
 void obk_ig_separator(void);
 void obk_ig_separator_text(const char* s);
@@ -110,6 +111,7 @@ void obk_ig_get_cursor_pos(float* x, float* y);
 void obk_ig_set_cursor_pos(float x, float y);
 void obk_ig_dummy(float w, float h);
 int  obk_ig_begin_ribbon_band(const char* name, float height);
+float obk_ig_scroll_x(void);
 float obk_ig_scroll_max_x(void);
 float obk_ig_scrollbar_size(void);
 void obk_ig_get_cursor_screen_pos(float* x, float* y);
@@ -285,6 +287,16 @@ func Button(label string) bool {
 	c, free := cstr(label)
 	defer free()
 	return C.obk_ig_button(c) != 0
+}
+
+// ButtonSized draws a button of an explicit size and reports whether it was clicked this
+// frame. A zero component means "size to the label", exactly as Dear ImGui's own default.
+// The ribbon's collapsed-panel tile needs this: it must stand the full height of the band's
+// button grid whatever its label measures.
+func ButtonSized(label string, w, h float32) bool {
+	c, free := cstr(label)
+	defer free()
+	return C.obk_ig_button_sized(c, C.float(w), C.float(h)) != 0
 }
 
 func SameLine()  { C.obk_ig_same_line() }
@@ -1158,6 +1170,11 @@ func BeginRibbonBand(name string, height float32) bool {
 	return C.obk_ig_begin_ribbon_band(c, C.float(height)) != 0
 }
 
+// ScrollX is the current window's horizontal scroll offset. The ribbon subtracts it from the
+// content region so its fit arithmetic measures the band's real width rather than the width
+// left to the right of a scrolled-away cursor — otherwise how far the user had scrolled would
+// feed back into how many panels collapse.
+func ScrollX() float32 { return float32(C.obk_ig_scroll_x()) }
 // ScrollMaxX is the current window's maximum horizontal scroll offset; >0 means its content
 // overflows the window width (the ribbon band's horizontal scrollbar is showing, #1471).
 func ScrollMaxX() float32 { return float32(C.obk_ig_scroll_max_x()) }

--- a/head/internal/native/imgui_wrap.cpp
+++ b/head/internal/native/imgui_wrap.cpp
@@ -54,6 +54,11 @@ void obk_ig_text(const char* s)              { ImGui::TextUnformatted(s); }
 // "%s" guard: the text is user/add-in supplied and may contain '%' — never pass it as the format.
 void obk_ig_text_wrapped(const char* s)      { ImGui::TextWrapped("%s", s); }
 int  obk_ig_button(const char* label)        { return ImGui::Button(label) ? 1 : 0; }
+// button_sized draws a button at an explicit size (0 in a component = size to the label), for
+// the ribbon's collapsed-panel tile, which must stand the full height of the band's grid.
+int  obk_ig_button_sized(const char* label, float w, float h) {
+    return ImGui::Button(label, ImVec2(w, h)) ? 1 : 0;
+}
 void obk_ig_same_line(void)                  { ImGui::SameLine(); }
 void obk_ig_separator(void)                  { ImGui::Separator(); }
 void obk_ig_separator_text(const char* s)    { ImGui::SeparatorText(s); }
@@ -80,6 +85,10 @@ int  obk_ig_begin_ribbon_band(const char* name, float height) {
 // scroll_max_x reports the current window's maximum horizontal scroll — >0 exactly when its content
 // overflows the window width, i.e. the ribbon's horizontal scrollbar is showing (#1471).
 float obk_ig_scroll_max_x(void) { return ImGui::GetScrollMaxX(); }
+// scroll_x is the current window's horizontal scroll offset. The ribbon's panel-fit arithmetic
+// subtracts it from the content region so the band's usable width is measured independently of
+// how far the user has scrolled it.
+float obk_ig_scroll_x(void) { return ImGui::GetScrollX(); }
 // scrollbar_size is the style thickness of a scrollbar, so the ribbon can grow its band height by
 // exactly that to seat the horizontal scrollbar without covering content (#1471).
 float obk_ig_scrollbar_size(void) { return ImGui::GetStyle().ScrollbarSize; }

--- a/head/ui/chrome_ribbon.go
+++ b/head/ui/chrome_ribbon.go
@@ -27,7 +27,7 @@ func drawRibbon(s *app.Session) string {
 	if bandOpen && native.BeginTabBar("##ribbon-tabs") {
 		for _, tab := range app.BuildRibbon(s).Tabs {
 			if native.BeginTabItemSelected(tab.Name, tab.Name == force) {
-				if id := drawTabPanels(s, tab.Panels); id != "" {
+				if id := drawTabPanels(s, tab.Name, tab.Panels); id != "" {
 					activated = id
 				}
 				native.EndTabItem()
@@ -55,13 +55,22 @@ const ribbonMaxRows = 3
 const ribbonControlRows = 4
 
 // ribbonGridHeight is the height of the band's button-grid area: the tallest column
-// shape, ribbonMaxRows rows of small icon buttons.
+// shape — ribbonMaxRows rows of small icon buttons, the stateful-control column, or a
+// large icon button under a caption wrapped to its full largeCaptionMaxLines.
 func ribbonGridHeight(m native.StyleMetrics) float32 {
 	buttonRow := float32(scaledIconPx(smallIconPx)) + 2*m.FramePadY
 	buttonGrid := ribbonRowsHeight(ribbonMaxRows, buttonRow, m.ItemSpacingY)
 	controlRow := maxF32(native.FrameHeight(), intensityChartHeight)
 	controlGrid := ribbonRowsHeight(ribbonControlRows, controlRow, m.ItemSpacingY)
-	return maxF32(buttonGrid, controlGrid)
+	return maxF32(maxF32(buttonGrid, controlGrid), largeButtonHeight(m))
+}
+
+// largeButtonHeight is the tallest a large icon button can stand: its glyph frame plus a
+// caption wrapped to the maximum number of lines. The band reserves this so a two-line
+// caption is never clipped by the panel-name strip beneath it.
+func largeButtonHeight(m native.StyleMetrics) float32 {
+	frame := float32(scaledIconPx(largeIconPx)) + 2*m.FramePadY
+	return frame + largeCaptionMaxLines*native.TextLineHeight()
 }
 
 func ribbonRowsHeight(rows int, row, spacing float32) float32 {
@@ -88,10 +97,19 @@ func ribbonBandHeight() float32 {
 // (button columns + name strip) separated by a full-height vertical divider. Every
 // panel pins its name at the same band-bottom Y (labelY), which both matches the
 // reference ribbon's footer strip and makes the dividers span the full band.
-func drawTabPanels(s ribbonControlHost, panels []app.RibbonPanel) string {
+//
+// Panels wider than the band collapse from the right to flyout tiles, so a tab that cannot
+// fit the window never runs commands off the edge (see ribbon_collapse.go). The decision uses
+// last frame's measured widths; this frame re-measures every panel it draws expanded.
+func drawTabPanels(s ribbonControlHost, tabName string, panels []app.RibbonPanel) string {
 	m := native.Metrics()
+	gridH := ribbonGridHeight(m)
 	_, gridTop := native.GetCursorScreenPos()
-	labelY := gridTop + ribbonGridHeight(m) + m.ItemSpacingY
+	labelY := gridTop + gridH + m.ItemSpacingY
+	availW, _ := native.ContentRegionAvail()
+	expanded := panelsThatFit(cachedPanelWidths(tabName, panels), ribbonSeparatorWidth(m),
+		widestCollapsedPanel(panels, m), availW-native.ScrollX())
+	ribbonCollapsedPanels = len(panels) - expanded
 	var activated string
 	for i, panel := range panels {
 		if i > 0 {
@@ -99,11 +117,29 @@ func drawTabPanels(s ribbonControlHost, panels []app.RibbonPanel) string {
 			native.SeparatorVertical()
 			native.SameLine()
 		}
+		if i >= expanded {
+			if id := drawCollapsedPanel(s, panel, tabName, labelY, gridH); id != "" {
+				activated = id
+			}
+			continue
+		}
 		if id := drawPanel(s, panel, labelY); id != "" {
 			activated = id
 		}
+		measurePanelWidth(tabName, panel.Name)
 	}
 	return activated
+}
+
+// measurePanelWidth records the width of the panel just drawn expanded — drawPanel leaves its
+// whole layout group as the last item, so its rect is the panel's laid-out width — for the
+// next frame's fit decision.
+func measurePanelWidth(tabName, panelName string) {
+	x0, _ := native.ItemRectMin()
+	x1, _ := native.ItemRectMax()
+	if w := x1 - x0; w > 0 {
+		ribbonPanelWidth[ribbonPanelWidthKey(tabName, panelName)] = w
+	}
 }
 
 // contextualTab returns the ribbon tab to force-select on the frame the ribbon environment
@@ -171,6 +207,19 @@ func drawPanel(s ribbonControlHost, panel app.RibbonPanel, labelY float32) strin
 	return activated
 }
 
+// drawPanelFlyoutBody draws a collapsed panel's contents inside its flyout popup: the same
+// controls the expanded panel shows, minus the band-bottom name strip — the flyout is its own
+// window, not part of the band, and the tile it drops from already carries the name.
+func drawPanelFlyoutBody(s ribbonControlHost, panel app.RibbonPanel) string {
+	if panel.Name == app.PanelPointCloud {
+		return drawPointCloudGrid(s, panel)
+	}
+	if panel.Selector != nil {
+		return drawSelectorCombo(panel)
+	}
+	return drawPanelColumns(s, packPanelColumns(panel.Buttons))
+}
+
 const (
 	pointCloudSliderWidth = 82
 	pointCloudComboWidth  = 124
@@ -207,15 +256,25 @@ var _ ribbonControlHost = (*app.Session)(nil)
 // beneath, but only when the target cloud is in Intensity mode (the app leaves IntensityRamp nil
 // otherwise). Returns the id of a clicked tool or a chosen display mode, or "".
 func drawPointCloudPanel(s ribbonControlHost, panel app.RibbonPanel, labelY float32) string {
+	native.BeginGroup()
+	activated := drawPointCloudGrid(s, panel)
+	drawPanelName(panel.Name, labelY)
+	native.EndGroup()
+	return activated
+}
+
+// drawPointCloudGrid draws the Point Cloud panel's control block on its own — the three tool
+// columns plus the intensity ramp — without the band's name strip, so both the in-band panel
+// and its collapsed flyout render the identical grid.
+func drawPointCloudGrid(s ribbonControlHost, panel app.RibbonPanel) string {
 	var activated string
 	pick := func(id string) {
 		if got := drawPointCloudButton(s, panel, id); got != "" {
 			activated = got
 		}
 	}
-	native.BeginGroup()
 
-	// The columns and ramp sit in one inner group so drawPanelName measures the full grid width
+	// The columns and ramp sit in one group so drawPanelName measures the full grid width
 	// (ItemRectMin/Max span the whole block) and centers the panel name under it — without this
 	// the last item measured would be column 3 alone and the label would sit off to the right.
 	native.BeginGroup()
@@ -245,9 +304,6 @@ func drawPointCloudPanel(s ribbonControlHost, panel app.RibbonPanel, labelY floa
 		drawIntensityRampControls(s, panel.IntensityRamp)
 	}
 	native.EndGroup() // close the measurable content block
-
-	drawPanelName(panel.Name, labelY)
-	native.EndGroup()
 	return activated
 }
 
@@ -350,13 +406,22 @@ const selectorWidth = 230
 // caller runs it (which sets the new selection); the box reflects the session state on
 // the next frame.
 func drawSelectorPanel(panel app.RibbonPanel, labelY float32) string {
+	native.BeginGroup()
+	activated := drawSelectorCombo(panel)
+	drawPanelName(panel.Name, labelY)
+	native.EndGroup()
+	return activated
+}
+
+// drawSelectorCombo draws a selector panel's drop-down on its own, without the band's name
+// strip, so the in-band panel and its collapsed flyout share one control.
+func drawSelectorCombo(panel app.RibbonPanel) string {
 	sel := panel.Selector
 	preview := ""
 	if sel.SelectedIndex >= 0 && sel.SelectedIndex < len(sel.Options) {
 		preview = sel.Options[sel.SelectedIndex].Label
 	}
 	var activated string
-	native.BeginGroup()
 	native.SetNextItemWidth(selectorWidth)
 	if native.BeginCombo("##"+panel.Name, preview) {
 		for i, opt := range sel.Options {
@@ -369,8 +434,6 @@ func drawSelectorPanel(panel app.RibbonPanel, labelY float32) string {
 		}
 		native.EndCombo()
 	}
-	drawPanelName(panel.Name, labelY)
-	native.EndGroup()
 	return activated
 }
 
@@ -526,19 +589,39 @@ func drawPopupMenuButton(btn app.RibbonButton) string {
 	return chosen
 }
 
-// variantArrowWidth is the pixel width of a split button's dropdown arrow box — just wide
-// enough for the combo's caret, since its preview text is empty (the head shows the label).
+// variantArrowWidth is the base pixel width of a split button's dropdown arrow tile, before
+// the icon-scale preference is applied.
 const variantArrowWidth = 18
 
-// drawVariantDropdown renders a split button's dropdown next to its head: a narrow combo
-// whose entries are the variant tools. Choosing one returns its command id so the caller
-// runs it; a disabled variant is shown greyed and is not selectable. Returns "" if nothing
-// was chosen this frame.
+// drawVariantDropdown renders a split button's dropdown beside its head: a narrow tile
+// carrying a drop-down caret, standing the same height as the head's glyph frame so the two
+// read as one control, and opening a menu of the variant tools. Choosing one returns its
+// command id so the caller runs it; a disabled variant is shown greyed and is not selectable.
+// Returns "" if nothing was chosen this frame.
+//
+// This was a zero-preview BeginCombo of a fixed 18px, which Dear ImGui lays out as a text box
+// plus a caret button of FrameHeight — at any font where FrameHeight exceeds 18 the caret is
+// clipped away entirely and the control renders as a blank sliver. On this machine's 4K chrome
+// that hid the drop-down on every split button in the ribbon, so Work Plane's eleven plane
+// constructors, Work Axis's six and Work Point's seven had no visible affordance at all. Drawing
+// the caret ourselves cannot be clipped by the font metrics, and reuses the collapsed panel's
+// caret so both drop-downs in the band look the same.
 func drawVariantDropdown(btn app.RibbonButton) string {
+	m := native.Metrics()
+	w := float32(scaledIconPx(variantArrowWidth))
+	h := variantArrowHeight(btn.Command.ButtonStyle(), m)
+	id := "##" + btn.Command.ID() + "-variants"
+
 	native.SameLine()
-	native.SetNextItemWidth(variantArrowWidth)
+	x, y := native.GetCursorScreenPos()
+	if native.ButtonSized(id, w, h) {
+		native.OpenPopup(id)
+	}
+	native.SetItemTooltip(btn.Command.DisplayName() + " — more tools")
+	drawRibbonCaret(x+w/2, y+h/2)
+
 	var chosen string
-	if native.BeginCombo("##"+btn.Command.ID()+"-variants", "") {
+	if native.BeginPopup(id) {
 		for _, v := range btn.Variants {
 			native.BeginDisabled(!v.Enabled)
 			if native.Selectable(v.Label, false) {
@@ -549,9 +632,20 @@ func drawVariantDropdown(btn app.RibbonButton) string {
 				native.SetItemTooltip(v.Tooltip)
 			}
 		}
-		native.EndCombo()
+		native.EndPopup()
 	}
 	return chosen
+}
+
+// variantArrowHeight is how tall a split button's caret tile stands: exactly its head's glyph
+// frame, so the caret sits beside the icon rather than overhanging the caption beneath it. A
+// text-only head has no glyph frame, so the arrow takes the standard control height.
+func variantArrowHeight(style app.ButtonStyle, m native.StyleMetrics) float32 {
+	px, ok := iconSizeFor(style)
+	if !ok {
+		return native.FrameHeight()
+	}
+	return float32(px) + 2*m.FramePadY
 }
 
 // drawButtonControl draws the command's clickable control and its tooltip, returning
@@ -623,16 +717,21 @@ func drawLabeledIconButton(btn app.RibbonButton, tex uint64, px float32) bool {
 	return clicked
 }
 
-// drawLargeIconButton renders a large button as a panel heading: the icon centered over
-// its caption, the cell as wide as the wider of the two — so "Start 2D Sketch" doesn't
-// hang off a 40px icon.
+// drawLargeIconButton renders a large button as a panel heading: the icon centred over its
+// caption, the cell as wide as the wider of the two. A caption too wide for the glyph frame
+// wraps onto a second line at a word boundary rather than stretching the cell — a multi-word
+// label like "New 2D Sketch" or "Replace Face" would otherwise make its tile several times the
+// width of its icon, which is most of why a maximized 4K window's Create & Modify tab could
+// not fit. See ribbon_caption.go for why this is ours rather than a documented Inventor rule.
 func drawLargeIconButton(btn app.RibbonButton, tex uint64, px float32) bool {
 	m := native.Metrics()
 	frameW := px + 2*m.FramePadX // ImageButton draws its frame padding around the glyph
-	textW := native.CalcTextWidth(btn.Command.DisplayName())
+	lines := wrapCaption(btn.Command.DisplayName(), frameW, native.CalcTextWidth)
 	cellW := frameW
-	if textW > cellW {
-		cellW = textW
+	for _, line := range lines {
+		if w := native.CalcTextWidth(line); w > cellW {
+			cellW = w
+		}
 	}
 	native.BeginGroup()
 	x, y := native.GetCursorScreenPos()
@@ -640,8 +739,11 @@ func drawLargeIconButton(btn app.RibbonButton, tex uint64, px float32) bool {
 	clicked := native.ImageButton(btn.Command.ID(), tex, px, px, identityTint)
 	setCommandTooltip(btn.Command)
 	_, captionY := native.GetCursorScreenPos()
-	native.SetCursorScreenPos(x+(cellW-textW)/2, captionY)
-	native.Text(btn.Command.DisplayName())
+	for i, line := range lines {
+		lineW := native.CalcTextWidth(line)
+		native.SetCursorScreenPos(x+(cellW-lineW)/2, captionY+float32(i)*native.TextLineHeight())
+		native.Text(line)
+	}
 	native.EndGroup()
 	return clicked
 }

--- a/head/ui/ribbon_caption.go
+++ b/head/ui/ribbon_caption.go
@@ -1,0 +1,48 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import "strings"
+
+// Large ribbon buttons stack their caption under the glyph, so an unwrapped multi-word label
+// sets the tile's width all by itself: at the chrome's default font "Replace Face" measures
+// roughly three times the 40px glyph frame, and a Modify panel of thirteen such tiles ran off
+// the right of a maximized 3840px window. Wrapping the caption to a second line at a word
+// boundary keeps each tile near its glyph width, which is the cheapest way to make a tab fit
+// before the panel-collapse system (ribbon_collapse.go) has to hide anything behind a flyout.
+//
+// This lives apart from chrome_ribbon.go and takes its text measurer as a parameter so the
+// wrap decision is a pure function, testable without a window or a font atlas.
+
+// largeCaptionMaxLines is how many lines a large button's caption may wrap onto. Two: enough
+// for every registered command name, and the ceiling the band reserves height for
+// (largeButtonHeight). A label still too wide at two lines is left long rather than truncated —
+// a clipped command name is worse than a wide tile, and the panel it widens can still collapse.
+const largeCaptionMaxLines = 2
+
+// wrapCaption splits a large button's caption so no line is wider than maxW, up to
+// largeCaptionMaxLines lines, measuring with the given text measurer. The split point is the
+// word boundary that minimises the widest resulting line, so "New 2D Sketch" breaks as
+// "New 2D" / "Sketch" rather than "New" / "2D Sketch". A label that already fits, a
+// single-word label, and an empty label all come back as one line — there is nothing to break.
+func wrapCaption(label string, maxW float32, width func(string) float32) []string {
+	if width(label) <= maxW {
+		return []string{label}
+	}
+	words := strings.Fields(label)
+	if len(words) < 2 {
+		return []string{label} // one long word: no boundary to break at
+	}
+	best, bestWidest := 1, float32(-1)
+	for split := 1; split < len(words); split++ {
+		head := strings.Join(words[:split], " ")
+		tail := strings.Join(words[split:], " ")
+		widest := maxF32(width(head), width(tail))
+		if bestWidest < 0 || widest < bestWidest {
+			best, bestWidest = split, widest
+		}
+	}
+	return []string{strings.Join(words[:best], " "), strings.Join(words[best:], " ")}
+}

--- a/head/ui/ribbon_caption_test.go
+++ b/head/ui/ribbon_caption_test.go
@@ -1,0 +1,71 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+// monoWidth is a stand-in text measurer: every character is 10 units wide. It makes the wrap
+// arithmetic exact and independent of any font atlas, so these tests need no window.
+func monoWidth(s string) float32 { return float32(len(s)) * 10 }
+
+func TestWrapCaptionLeavesShortLabelsAlone(t *testing.T) {
+	for _, label := range []string{"Hole", "Rib", "", "Extrude"} {
+		got := wrapCaption(label, 100, monoWidth)
+		if len(got) != 1 || got[0] != label {
+			t.Errorf("wrapCaption(%q, 100) = %q, want the label on one line", label, got)
+		}
+	}
+}
+
+// TestWrapCaptionBalancesTheSplit is the reason wrapCaption picks the minimising boundary
+// rather than the first one that fits: "New 2D Sketch" must read "New 2D" / "Sketch", not
+// "New" / "2D Sketch", so the tile is as narrow as the label allows.
+func TestWrapCaptionBalancesTheSplit(t *testing.T) {
+	got := wrapCaption("New 2D Sketch", 60, monoWidth)
+	want := []string{"New 2D", "Sketch"}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Errorf("wrapCaption(\"New 2D Sketch\", 60) = %q, want %q", got, want)
+	}
+}
+
+func TestWrapCaptionSplitsTwoWordLabels(t *testing.T) {
+	got := wrapCaption("Replace Face", 60, monoWidth)
+	want := []string{"Replace", "Face"}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Errorf("wrapCaption(\"Replace Face\", 60) = %q, want %q", got, want)
+	}
+}
+
+// TestWrapCaptionCannotBreakOneWord: a single long word has no boundary, so it stays whole and
+// widens its tile — clipping a command name would be worse, and the panel can still collapse.
+func TestWrapCaptionCannotBreakOneWord(t *testing.T) {
+	got := wrapCaption("Circumference", 20, monoWidth)
+	if len(got) != 1 || got[0] != "Circumference" {
+		t.Errorf("wrapCaption on a single long word = %q, want it left whole on one line", got)
+	}
+}
+
+// TestWrapCaptionNeverExceedsTheLineBudget: the band reserves height for exactly
+// largeCaptionMaxLines, so wrapCaption must never return more however long the label.
+func TestWrapCaptionNeverExceedsTheLineBudget(t *testing.T) {
+	got := wrapCaption("Extract Shape From Selected Surface Body", 30, monoWidth)
+	if len(got) > largeCaptionMaxLines {
+		t.Errorf("wrapCaption returned %d lines, want at most largeCaptionMaxLines=%d",
+			len(got), largeCaptionMaxLines)
+	}
+}
+
+// TestWrapCaptionKeepsEveryWord: wrapping is a layout change, never a content change — no word
+// of a command name may be dropped on the way to the second line.
+func TestWrapCaptionKeepsEveryWord(t *testing.T) {
+	const label = "Delete Face From Body"
+	got := strings.Join(wrapCaption(label, 40, monoWidth), " ")
+	if got != label {
+		t.Errorf("wrapCaption round-trip = %q, want %q (no word lost)", got, label)
+	}
+}

--- a/head/ui/ribbon_collapse.go
+++ b/head/ui/ribbon_collapse.go
@@ -1,0 +1,194 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+)
+
+// Ribbon panel collapse — the ribbon's answer to a tab wider than the window.
+//
+// Reference behaviour. Inventor's ribbon can be "minimized to tabs / panel titles / panel
+// buttons" (C-inventor-ui-reference.md:29, citations [2][29]), and a panel that cannot show
+// everything puts the remainder behind "a drop-down arrow for additional commands"
+// (C-inventor-ui-reference.md:8 and :27, citation [1][2]; the flyout's own affordances —
+// expand, pushpin, tear-off — are C-inventor-ui-reference.md:183, citation [2][29][64]). The
+// collapsed form is therefore a documented part of Inventor's ribbon: a panel shrunk to one
+// button whose drop-down flies its full contents out.
+//
+// Deliberate v1 divergence. Inventor's minimize is a GLOBAL, USER-CHOSEN ribbon state (picked
+// from the right-click Ribbon Appearance menu) and applies to every panel at once; the
+// reference doc does not document a width-driven, per-panel automatic resize, so we do not
+// claim one. What Oblikovati does here is apply the same collapsed FORM automatically and per
+// panel: when the active tab's panels are wider than the band, the rightmost panels collapse
+// to flyout tiles until the rest fit. That keeps every command reachable at any window width —
+// the defect this replaces let the right-hand panels run off a maximized 3840px window with
+// only a thin accent-coloured scrollbar to hint at it. A user-selectable minimize state and
+// Inventor's medium button tier are deferred; see F-visual-gaps-implementation.md.
+//
+// Measure-then-decide. Dear ImGui is immediate mode, so a panel's laid-out width is only
+// knowable after it has been drawn. Frame N measures each expanded panel and caches its width;
+// frame N+1 decides from the cache. The ribbon already uses this idiom for its overflow
+// scrollbar (chrome_ribbon.go, ribbonScrollbarShown), and it converges in one frame because a
+// panel's expanded width does not depend on how many of its neighbours are expanded.
+
+// ribbonPanelWidth caches each panel's measured expanded width in screen pixels, keyed by tab
+// and panel name (panels are unique per tab; the tab is in the key because a command may be
+// registered onto several tabs, app/ribbon.go ribbonBuilder.add). A panel absent from the map
+// has never been drawn: it is assumed to fit so that it gets drawn once and measured.
+var ribbonPanelWidth = map[string]float32{}
+
+// ribbonCollapsedPanels is how many of the active tab's panels the last frame drew collapsed —
+// 0 when the whole tab fitted the band. Kept at package scope, like ribbonScrollbarShown, so a
+// test can drive real chrome frames at a given window width and assert that collapse engaged.
+var ribbonCollapsedPanels int
+
+func ribbonPanelWidthKey(tab, panel string) string { return tab + "\x00" + panel }
+
+// cachedPanelWidths returns the measured expanded widths of a tab's panels in order, with 0
+// for a panel not yet measured.
+func cachedPanelWidths(tab string, panels []app.RibbonPanel) []float32 {
+	out := make([]float32, len(panels))
+	for i, p := range panels {
+		out[i] = ribbonPanelWidth[ribbonPanelWidthKey(tab, p.Name)]
+	}
+	return out
+}
+
+// panelsThatFit reports how many LEADING panels of a tab can stay expanded within avail
+// pixels, the rest collapsing to flyout tiles of width collapsed with sep pixels of divider
+// between every pair. Panels collapse from the right, so a tab's leading panels — the ones
+// Inventor puts first because they carry the tab's primary task — keep their full tiles
+// longest. widths[i] is panel i's measured expanded width, or 0 when it has never been drawn.
+// Returns len(widths) when everything fits, and 0 when even an all-collapsed row does not (the
+// band's horizontal scrollbar is the last-resort tier under that, #1471).
+func panelsThatFit(widths []float32, sep, collapsed, avail float32) int {
+	for n := len(widths); n > 0; n-- {
+		if ribbonRowWidth(widths, n, sep, collapsed) <= avail {
+			return n
+		}
+	}
+	return 0
+}
+
+// ribbonRowWidth is the laid-out width of a tab whose first n panels are expanded and whose
+// remaining panels are collapsed, dividers included.
+func ribbonRowWidth(widths []float32, n int, sep, collapsed float32) float32 {
+	total := float32(0)
+	for i, w := range widths {
+		if i < n {
+			total += w
+			continue
+		}
+		total += collapsed
+	}
+	if len(widths) > 1 {
+		total += sep * float32(len(widths)-1)
+	}
+	return total
+}
+
+// ribbonSeparatorWidth is the horizontal cost of the divider drawn between two panels: the
+// rule itself plus the item spacing on either side of it (drawTabPanels lays it out as
+// SameLine / SeparatorVertical / SameLine).
+func ribbonSeparatorWidth(m native.StyleMetrics) float32 { return 2*m.ItemSpacingX + 1 }
+
+// collapsedPanelWidth is the width of one collapsed panel's tile: wide enough for the panel
+// name that sits beneath it in the band's footer strip, and never narrower than a large icon
+// button, so a row of collapsed tiles keeps the band's rhythm.
+func collapsedPanelWidth(name string, m native.StyleMetrics) float32 {
+	w := native.CalcTextWidth(name) + 2*m.FramePadX
+	if min := float32(scaledIconPx(largeIconPx)) + 2*m.FramePadX; w < min {
+		w = min
+	}
+	return w
+}
+
+// widestCollapsedPanel is the collapsed-tile width used for the fit arithmetic: the widest
+// tile any of the tab's panels would need, so the estimate can never under-count and leave the
+// row overflowing after a collapse.
+func widestCollapsedPanel(panels []app.RibbonPanel, m native.StyleMetrics) float32 {
+	var w float32
+	for _, p := range panels {
+		if c := collapsedPanelWidth(p.Name, m); c > w {
+			w = c
+		}
+	}
+	return w
+}
+
+// ribbonCaretPx is the half-width of a ribbon drop-down caret, before the
+// icon-scale preference is applied. The caret is drawn with the draw list rather than typed as
+// a glyph because the chrome font carries no guaranteed arrow codepoint.
+const ribbonCaretPx = 7
+
+// drawCollapsedPanel renders a panel in its collapsed form: one full-height tile carrying a
+// drop-down caret, the panel name pinned in the band's footer strip beneath it — so a
+// collapsed panel reads in the same grammar as an expanded one, name and all — and a flyout
+// holding the panel's real contents. Returns the id of a command activated inside the flyout,
+// or "".
+func drawCollapsedPanel(s ribbonControlHost, panel app.RibbonPanel, tabName string, labelY, gridH float32) string {
+	m := native.Metrics()
+	w := collapsedPanelWidth(panel.Name, m)
+	id := "##ribbon-panel-flyout-" + panel.Name
+
+	native.BeginGroup()
+	x, y := native.GetCursorScreenPos()
+	if native.ButtonSized(id, w, gridH) {
+		native.OpenPopup(id)
+	}
+	native.SetItemTooltip(panel.Name + " — show this panel's commands")
+	drawRibbonCaret(x+w/2, y+gridH/2)
+	// The tile is still the last item here (the caret is a draw-list call and the tooltip
+	// registers none), so the name centres under the tile exactly as it does under a grid.
+	drawPanelName(panel.Name, labelY)
+	native.EndGroup()
+
+	// The flyout is a window of its own, so it is opened outside the layout group and pinned
+	// just under the band rather than at the pointer — Inventor drops a panel's flyout from
+	// the panel, not from the cursor. Its left edge is pulled back when the panel is too wide
+	// to drop straight down, because an explicit SetNextWindowPos overrides Dear ImGui's own
+	// on-screen clamping and the flyout would otherwise run off the right of the display —
+	// the very failure this whole system exists to end.
+	var activated string
+	vpW, _ := native.MainViewportSize()
+	flyoutX := clampFlyoutX(x, ribbonPanelWidth[ribbonPanelWidthKey(tabName, panel.Name)], vpW)
+	native.SetNextWindowPos(flyoutX, labelY+native.TextLineHeight()+m.ItemSpacingY)
+	if native.BeginPopup(id) {
+		if got := drawPanelFlyoutBody(s, panel); got != "" {
+			activated = got
+			native.CloseCurrentPopup()
+		}
+		native.EndPopup()
+	}
+	return activated
+}
+
+// clampFlyoutX places a flyout of the given content width inside a viewport vpW wide: dropping
+// straight down from x when it fits there, otherwise pulled left until its right edge is on
+// screen, and never past the left edge. A width of 0 (the panel has somehow never been measured
+// expanded) drops straight down and leaves the rest to Dear ImGui. The viewport width is a
+// parameter rather than a native call so the arithmetic is testable without a window.
+func clampFlyoutX(x, width, vpW float32) float32 {
+	if width <= 0 {
+		return x
+	}
+	if right := x + width; right > vpW {
+		x = vpW - width
+	}
+	if x < 0 {
+		x = 0
+	}
+	return x
+}
+
+// drawRibbonCaret draws a downward drop-down caret centred at (cx, cy) — the collapsed panel's
+// tile and a split button's variant arrow — in the theme accent, so it reads as the interactive
+// drop-down it is. Drawn rather than typed because the chrome font carries no arrow codepoint.
+func drawRibbonCaret(cx, cy float32) {
+	half := float32(scaledIconPx(ribbonCaretPx))
+	native.DrawTriangleFilled(cx-half, cy-half/2, cx+half, cy-half/2, cx, cy+half/2, chromeTheme.accentColor)
+}

--- a/head/ui/ribbon_collapse_test.go
+++ b/head/ui/ribbon_collapse_test.go
@@ -1,0 +1,102 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import "testing"
+
+// TestPanelsThatFitEverythingFits: a band wide enough for every panel collapses none.
+func TestPanelsThatFitEverythingFits(t *testing.T) {
+	widths := []float32{100, 200, 300}
+	// 600 of panels + 2 dividers of 10 = 620.
+	if got := panelsThatFit(widths, 10, 50, 620); got != 3 {
+		t.Errorf("panelsThatFit at exactly the needed width = %d, want 3 (all expanded)", got)
+	}
+	if got := panelsThatFit(widths, 10, 50, 5000); got != 3 {
+		t.Errorf("panelsThatFit in a very wide band = %d, want 3 (all expanded)", got)
+	}
+}
+
+// TestPanelsThatFitCollapsesFromTheRight: one pixel too narrow collapses the LAST panel only,
+// and the leading panels keep their full tiles.
+func TestPanelsThatFitCollapsesFromTheRight(t *testing.T) {
+	widths := []float32{100, 200, 300}
+	// 619 cannot seat all three (620); with the last collapsed the row is 100+200+50+20 = 370.
+	if got := panelsThatFit(widths, 10, 50, 619); got != 2 {
+		t.Errorf("panelsThatFit one pixel short = %d, want 2 (rightmost panel collapsed)", got)
+	}
+	// 369 cannot seat two expanded either; one expanded is 100+50+50+20 = 220.
+	if got := panelsThatFit(widths, 10, 50, 369); got != 1 {
+		t.Errorf("panelsThatFit at 369 = %d, want 1 (two rightmost panels collapsed)", got)
+	}
+}
+
+// TestPanelsThatFitAllCollapsed: when not even an all-collapsed row fits, every panel collapses
+// and the band's horizontal scrollbar (#1471) is the last-resort tier beneath it.
+func TestPanelsThatFitAllCollapsed(t *testing.T) {
+	widths := []float32{100, 200, 300}
+	if got := panelsThatFit(widths, 10, 50, 40); got != 0 {
+		t.Errorf("panelsThatFit in a hopelessly narrow band = %d, want 0 (all collapsed)", got)
+	}
+}
+
+// TestPanelsThatFitUnmeasuredPanelIsAssumedToFit: a panel the ribbon has never drawn has no
+// cached width (0), so it must be drawn — and hence measured — rather than pre-emptively
+// collapsed, otherwise a freshly-opened tab could never learn its own widths.
+func TestPanelsThatFitUnmeasuredPanelIsAssumedToFit(t *testing.T) {
+	if got := panelsThatFit([]float32{0, 0, 0}, 10, 50, 30); got != 3 {
+		t.Errorf("panelsThatFit with no measurements = %d, want 3 (draw once to measure)", got)
+	}
+}
+
+// TestPanelsThatFitEmptyTab guards the degenerate tab (no panels → nothing to expand).
+func TestPanelsThatFitEmptyTab(t *testing.T) {
+	if got := panelsThatFit(nil, 10, 50, 500); got != 0 {
+		t.Errorf("panelsThatFit on an empty tab = %d, want 0", got)
+	}
+}
+
+// TestRibbonRowWidthCountsDividersOnce checks the arithmetic the fit decision rests on: n-1
+// dividers for n panels, whatever their collapse state.
+func TestRibbonRowWidthCountsDividersOnce(t *testing.T) {
+	widths := []float32{100, 200}
+	if got := ribbonRowWidth(widths, 2, 10, 50); got != 310 {
+		t.Errorf("ribbonRowWidth(all expanded) = %v, want 310 (100+200+one 10px divider)", got)
+	}
+	if got := ribbonRowWidth(widths, 0, 10, 50); got != 110 {
+		t.Errorf("ribbonRowWidth(all collapsed) = %v, want 110 (50+50+one 10px divider)", got)
+	}
+	if got := ribbonRowWidth([]float32{100}, 1, 10, 50); got != 100 {
+		t.Errorf("ribbonRowWidth(single panel) = %v, want 100 (no divider)", got)
+	}
+}
+
+// TestRibbonPanelWidthKeyIsPerTab: a command may be registered onto several tabs
+// (app/ribbon.go ribbonBuilder.add), so a panel of the same name can appear on two tabs with
+// different contents — and must not share one cached width.
+func TestRibbonPanelWidthKeyIsPerTab(t *testing.T) {
+	if ribbonPanelWidthKey("Create & Modify", "Sketch") == ribbonPanelWidthKey("Surfaces & Mesh", "Sketch") {
+		t.Error("the same panel name on two tabs shares one width-cache key")
+	}
+}
+
+// TestClampFlyoutXStaysOnScreen: a flyout wider than the room to the right of its tile is
+// pulled left rather than allowed off the display — an explicit SetNextWindowPos defeats Dear
+// ImGui's own clamping, so this arithmetic is the only thing keeping the flyout reachable.
+func TestClampFlyoutXStaysOnScreen(t *testing.T) {
+	const vpW = 3840 // this machine's 4K display, where the overflow defect was reproduced
+	if got := clampFlyoutX(10, 400, vpW); got != 10 {
+		t.Errorf("a flyout that fits where it drops moved to %v, want 10", got)
+	}
+	if got := clampFlyoutX(2147, 1747, vpW); got != vpW-1747 {
+		t.Errorf("the overhanging Modify flyout landed at %v, want %v (right edge on screen)",
+			got, float32(vpW-1747))
+	}
+	if got := clampFlyoutX(2000, 2*vpW, vpW); got != 0 {
+		t.Errorf("a flyout wider than the display landed at %v, want 0 (never past the left edge)", got)
+	}
+	if got := clampFlyoutX(123, 0, vpW); got != 123 {
+		t.Errorf("an unmeasured flyout moved to %v, want 123 (drop straight down)", got)
+	}
+}

--- a/head/ui/ribbon_scrollbar_test.go
+++ b/head/ui/ribbon_scrollbar_test.go
@@ -27,9 +27,11 @@ func ribbonSession(t *testing.T) *app.Session {
 	return s
 }
 
-// driveRibbon opens a window of the given size, runs a few real chrome frames, and reports whether
-// the ribbon ended up overflowing (its horizontal scrollbar showing). Skips when no GPU/display.
-func driveRibbon(t *testing.T, w, h int) bool {
+// driveRibbon opens a window of the given size, runs a few real chrome frames, and reports how
+// the ribbon settled: how many of the active tab's panels collapsed to flyout tiles, and whether
+// the band still overflowed after that (its horizontal scrollbar showing). Skips when no
+// GPU/display.
+func driveRibbon(t *testing.T, w, h int) (collapsed int, scrollbar bool) {
 	t.Helper()
 	win, err := native.CreateWindow(w, h, "ribbon-scroll-test")
 	if err != nil {
@@ -40,29 +42,54 @@ func driveRibbon(t *testing.T, w, h int) bool {
 	dockLaidOut = false
 	icons = nil
 	ribbonScrollbarShown = false
-	defer func() { ribbonScrollbarShown = false }()
+	ribbonCollapsedPanels = 0
+	clear(ribbonPanelWidth) // measured widths are per-style, not per-window, but start each case clean
+	defer func() {
+		ribbonScrollbarShown = false
+		ribbonCollapsedPanels = 0
+		clear(ribbonPanelWidth)
+	}()
 	s := ribbonSession(t)
-	for i := 0; i < 5; i++ { // settle the dock layout + let the overflow flag stabilise
+	for i := 0; i < 5; i++ { // settle the dock layout + let the fit decision stabilise
 		win.BeginFrame()
 		DrawChrome(win, s)
 		win.EndFrame(0.1, 0.1, 0.1)
 	}
-	return ribbonScrollbarShown
+	return ribbonCollapsedPanels, ribbonScrollbarShown
 }
 
-// TestRibbonShowsScrollbarWhenNarrow is the #1471 guard: a window too narrow to fit the active tab's
-// buttons must overflow, so the band reports its horizontal scrollbar is showing.
-func TestRibbonShowsScrollbarWhenNarrow(t *testing.T) {
-	if !driveRibbon(t, 360, 600) {
-		t.Error("a 360px-wide window should overflow the ribbon and show a horizontal scrollbar (#1471)")
+// TestRibbonCollapsesPanelsWhenNarrow is the overflow guard: a window too narrow to fit the
+// active tab's panels must collapse panels to flyout tiles, so every command stays reachable
+// rather than running off the edge of the band.
+func TestRibbonCollapsesPanelsWhenNarrow(t *testing.T) {
+	if collapsed, _ := driveRibbon(t, 360, 600); collapsed == 0 {
+		t.Error("a 360px-wide window should collapse ribbon panels to flyout tiles, none collapsed")
 	}
 }
 
-// TestRibbonNoScrollbarWhenWide is the converse: a wide window fits the active tab, so no scrollbar
-// is shown and the band keeps its compact height.
+// TestRibbonCollapseAvoidsTheScrollbar is the point of the collapse system: at a width that
+// cannot seat the tab's panels expanded, collapsing them must bring the band back within the
+// window — so the #1471 horizontal scrollbar stays the last-resort tier rather than the routine
+// overflow story it had become (it showed even on a maximized 3840px 4K window).
+func TestRibbonCollapseAvoidsTheScrollbar(t *testing.T) {
+	collapsed, scrollbar := driveRibbon(t, 1400, 600)
+	if collapsed == 0 {
+		t.Fatal("a 1400px-wide window should have collapsed at least one panel")
+	}
+	if scrollbar {
+		t.Error("collapsing panels should have fitted the band; the scrollbar is still showing")
+	}
+}
+
+// TestRibbonNoScrollbarWhenWide is the converse: a wide window fits the active tab, so nothing
+// collapses, no scrollbar is shown, and the band keeps its compact height.
 func TestRibbonNoScrollbarWhenWide(t *testing.T) {
-	if driveRibbon(t, 3200, 600) {
+	collapsed, scrollbar := driveRibbon(t, 3200, 600)
+	if scrollbar {
 		t.Error("a 3200px-wide window should fit the default tab without a ribbon scrollbar (#1471)")
+	}
+	if collapsed != 0 {
+		t.Errorf("a 3200px-wide window collapsed %d panels, want 0 (everything fits)", collapsed)
 	}
 }
 


### PR DESCRIPTION
A ribbon tab could run its right-hand panels off the edge of the window, leaving commands undiscoverable even when the band scrollbar was present.

Collapse panels from the right into full-height flyout tiles, wrap large captions, and keep split-button carets visible while reusing the same panel bodies in-band and in flyouts. Add deterministic width/layout tests and retain the existing scrollbar as a last-resort tier.

Related upstream issue: [#1471](https://github.com/Oblikovati/Oblikovati/issues/1471) is closed and reported toolbar controls being cut off without an obvious scroll affordance. This candidate addresses the ribbon-overflow presentation while retaining the scrollbar fallback.

**Personal note to the maintainer**

Hey man, I appreciate your GUI! I made a bunch of what were originally plugins for my copy of your repo but I thought you might appreciate having them as PRs. Please feel free of course to ignore them and/or tell me how I can submit better PRs in the future for this repo (if you're happy for me to continue to do so). I'm using it because I love Inventor but hate the restrictive and expensive licensing at my job, and I also want to be able to change things on a whim to do things I want, so that's why I started using your repo to begin with! I use Hermes agents to help me do most of the work, so let me know if there's a problem in that regard as well. I'm putting this message in all of these PRs just in case you only see one of them or something. Thanks again! - Collin / coldsnit

### Evidence

- Pure ribbon geometry, packing, caption, and icon tests — passed.
- Native head build — passed.
- No new asset files.
- The in-window ribbon smoke tests were not used as an unattended gate: `TestRibbonCollapsesPanelsWhenNarrow` hangs in `Window.BeginFrame` on this Windows desktop and is covered by the project's human-supervised GUI rule.

### Manual GUI smoke checklist

1. Launch `bin/oblikovati-head-pr5c.exe` specifically; it is the PR-5c candidate binary.
2. Start with the window wide on the **Modeling** ribbon tab. Confirm the normal panel bodies and captions are visible and there is no unnecessary horizontal scrollbar.
3. Slowly drag the window's right edge left until the ribbon can no longer fit. Expected result: panels disappear from the **right-hand end first** and become narrow, full-height flyout tiles. The left-hand panels remain expanded.
4. Click one collapsed tile. A flyout should open directly below the ribbon, stay inside the window, and contain the same commands that were in that panel. Click one command in the flyout and confirm it activates; click elsewhere to dismiss the flyout.
5. Make the window very narrow. Confirm the remaining collapsed tiles are still visible and usable; if the whole row cannot fit, the existing horizontal scrollbar may appear as the last-resort fallback.
6. Switch to the **Sketch** tab and repeat the narrow-window check. The collapsed panel set should be recalculated for that tab rather than reusing the Modeling tab's panel widths.
7. On a split-button command with a small caret, click the **caret area**, not only the main icon. Confirm a variant menu opens, select a variant, and verify the selected command runs. Check that the caret remains visible at the narrow and scaled layouts.
8. On a panel with a long two-word caption, narrow the window until it collapses and then widen it again. Confirm the caption wraps into balanced lines when expanded and is not clipped.
