### PR TITLE
build: update local lint and test tool pins for Go 1.26

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,10 @@ LDFLAGS     := -s -w \
 	-X $(MODULE)/build.Date=$(DATE)
 
 # Pinned dev tools (installed on demand into $GOBIN by `make tools`).
-GOLANGCI_VERSION  ?= v1.59.1
-GOTESTSUM_VERSION ?= v1.12.0
+# golangci-lint v2 lives at the /v2 module path; v1.59.1 and gotestsum v1.12.0
+# no longer compile under Go 1.26 (x/tools tokeninternal array-length error).
+GOLANGCI_VERSION  ?= v2.12.2
+GOTESTSUM_VERSION ?= v1.13.0
 
 # Cross-build matrix for `make build-all`.
 PLATFORMS := linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64
@@ -101,7 +103,7 @@ ci: fmt-check vet lint test-race cover ## Everything CI runs, locally
 
 .PHONY: tools
 tools: ## Install pinned dev tools into $GOBIN
-	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_VERSION)
+	$(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_VERSION)
 	$(GO) install gotest.tools/gotestsum@$(GOTESTSUM_VERSION)
 
 .PHONY: hooks


### PR DESCRIPTION
The previous golangci-lint and gotestsum pins no longer compile with the repository's Go 1.26 toolchain. Update the local developer-tool pins to golangci-lint v2.12.2 and gotestsum v1.13.0, then verify installation, exact versions, lint, and the full cgo-free test gate.

**Personal note to the maintainer**

Hey man, I appreciate your GUI! I made a bunch of what were originally plugins for my copy of your repo but I thought you might appreciate having them as PRs. Please feel free of course to ignore them and/or tell me how I can submit better PRs in the future for this repo (if you're happy for me to continue to do so). I'm using it because I love Inventor but hate the restrictive and expensive licensing at my job, and I also want to be able to change things on a whim to do things I want, so that's why I started using your repo to begin with! I use Hermes agents to help me do most of the work, so let me know if there's a problem in that regard as well. I'm putting this message in all of these PRs just in case you only see one of them or something. Thanks again! - Collin / coldsnit

### Evidence

- `obk_make tools` — passed.
- golangci-lint v2.12.2 — verified.
- gotestsum v1.13.0 — verified.
- golangci-lint — `0 issues`.
- Exact `obk_make test` — passed.
