### PR TITLE
fix(sketch): make line-chain editing transactional

### DIFF
--- a/app/session.go
+++ b/app/session.go
@@ -55,6 +55,7 @@ type Session struct {
 	selection                 *Selection
 	highlightSets             *HighlightSets // named, colored emphasis groups for add-ins (#157)
 	tool                      *ToolInstance
+	toolTxn                   toolTransaction  // the bounded transaction the active tool holds open (#1750)
 	featureEditors            featureEditorSet // full-panel editors, assembled at the composition root (#1617)
 	picker                    Picker
 	regionPicker              RegionPicker          // resolves a box-select rectangle (nil ⇒ box-select disabled)

--- a/app/session_input.go
+++ b/app/session_input.go
@@ -48,6 +48,7 @@ func (s *Session) StartFeatureTool(t PartFeatureTool) { s.StartTool(t) }
 func (s *Session) StartTool(t Tool) {
 	if s.tool != nil {
 		s.tool.tool.Cancel(s)
+		s.endToolTransaction()          // the outgoing tool's group dies with it (#1750)
 		s.Graphics().ClearInteraction() // drop the previous tool's preview/overlay graphics
 		s.dropCommandMiniToolbars()     // and its mini-toolbars (M05-F07)
 		s.dropCommandGizmos()           // and its triad/manipulators (M05-F13)
@@ -55,6 +56,9 @@ func (s *Session) StartTool(t Tool) {
 	s.notice = ""
 	s.tool = &ToolInstance{tool: t}
 	s.placementStartedByClick = false // a fresh command may still take its first point by typing
+	// Open the bounded transaction BEFORE Start: an opted-in tool's guard must be live the
+	// moment it is armed, not only once a point is placed (#1750 acceptance sub-case b).
+	s.beginToolTransaction(t)
 	t.Start(s)
 	s.installToolFilter() // derive the filter from the tool's declared AcceptedKinds (engine)
 }
@@ -122,6 +126,9 @@ func (s *Session) OK() error {
 // tool, and retire its transient UI (selection filter, preview graphics, mini-toolbars, gizmos).
 func (s *Session) finishToolCommit() {
 	s.notice = ""
+	// Close the tool's group AFTER OK recorded the edit (session_input.go:115): the deferred
+	// delta is committed here as the one undo step named for the tool (#1750).
+	s.endToolTransaction()
 	s.tool = nil
 	s.placementStartedByClick = false
 	s.restoreSelectionFilter()      // hand selection back to the ambient filter (engine)
@@ -162,6 +169,9 @@ func (s *Session) CancelTool() {
 // chaining-tool finish branch: the geometry it would commit belongs to the document that is
 // going away (#2040).
 func (s *Session) abandonTool() {
+	// Unconditionally, and before the nil check: a group must never survive its tool even if
+	// the tool has already been dropped by another path (#1750).
+	s.endToolTransaction()
 	if s.tool == nil {
 		return
 	}

--- a/app/sketch_line_transaction_test.go
+++ b/app/sketch_line_transaction_test.go
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// #1750 GUI trigger: the in-transaction Undo/Redo guard had no interactive path to fire on —
+// BeginTransaction/EndTransaction were called only by the add-in wire router, so a smoke test
+// found QAT Undo mid-sketch-line undoing normally instead of being blocked. The line chain now
+// holds a bounded transaction for its whole session (tool_transaction.go).
+//
+// The tests below split into two halves, and BOTH matter:
+//   - the guard is live across the session (the feature), and
+//   - every exit path closes the group (the invariant) — a leaked group pins InTransaction()
+//     true forever and kills Undo/Redo for the rest of the document session, which is strictly
+//     worse than the missing guard.
+
+// lineChainSession is a part with an open sketch holding one committed, undoable step. The
+// committed step is what makes the guard observable: with an empty stack Undo is a no-op for
+// the boring reason (nothing to undo) and would pass these tests for the wrong reason.
+func lineChainSession(t *testing.T) *Session {
+	t.Helper()
+	s, _ := emptyPartSession(t)
+	sk, err := s.CreateSketch(sketch.XYPlane()) // CreateSketch establishes the undo baseline
+	if err != nil {
+		t.Fatalf("CreateSketch: %v", err)
+	}
+	sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0))
+	s.RecordActiveEdit("Sketch Geometry")
+	if !s.CanUndo() {
+		t.Fatal("fixture: expected an undoable step")
+	}
+	return s
+}
+
+// TestLineToolOpensTransactionOnActivation is smoke-test acceptance sub-case (b): the tool is
+// armed and NOT yet edited, and the guard must already hold. Opening the group only once a
+// point exists would leave this case failing exactly as it did before the fix.
+func TestLineToolOpensTransactionOnActivation(t *testing.T) {
+	s := lineChainSession(t)
+	s.StartTool(NewLineTool())
+
+	if !s.InTransaction() {
+		t.Fatal("no transaction open with the line tool merely armed — sub-case (b) guard is dead")
+	}
+	if !s.CanUndo() {
+		t.Error("arming the tool must not empty the undo stack; the guard, not the grey-out, must block")
+	}
+}
+
+// TestUndoBlockedWhileLineChainOpen is acceptance sub-case (a): mid-chain, with an undoable step
+// behind the cursor, Undo must do nothing. It drives the real keyboard path AND the pure QAT
+// decision function's inputs, since both read InTransaction().
+func TestUndoBlockedWhileLineChainOpen(t *testing.T) {
+	s := lineChainSession(t)
+	s.StartTool(NewLineTool())
+	s.Click(40, 40)
+	s.Click(80, 40) // mid-chain: points placed, chain not finished
+
+	if err := s.PressKey(KeyEvent{Key: "z", Mods: CtrlMod}); err != nil { // Ctrl+Z — must no-op
+		t.Fatalf("PressKey(Ctrl+Z): %v", err)
+	}
+
+	if n := s.ActiveSketch().Lines().Count(); n != 1 {
+		t.Errorf("undo fired mid-chain: sketch has %d lines, want the 1 committed by the fixture", n)
+	}
+	if !s.CanUndo() || s.UndoLabel() != "Sketch Geometry" {
+		t.Errorf("the committed step must survive a blocked undo; CanUndo=%v label=%q",
+			s.CanUndo(), s.UndoLabel())
+	}
+}
+
+// TestRedoBlockedWhileLineChainOpen is sub-case (b) end to end: undo a step so the redo branch
+// is populated, arm the line tool WITHOUT editing, and Redo must not fire. Arming must not
+// truncate the forward branch either — a recorded edit would (undo.go TruncateTo).
+func TestRedoBlockedWhileLineChainOpen(t *testing.T) {
+	s := lineChainSession(t)
+	if err := s.Undo(); err != nil {
+		t.Fatalf("Undo: %v", err)
+	}
+	if !s.CanRedo() {
+		t.Fatal("fixture: expected a redoable step")
+	}
+
+	s.StartTool(NewLineTool()) // armed, no click
+
+	if err := s.PressKey(KeyEvent{Key: "y", Mods: CtrlMod}); err != nil { // Ctrl+Y — must no-op
+		t.Fatalf("PressKey(Ctrl+Y): %v", err)
+	}
+	if n := s.ActiveSketch().Lines().Count(); n != 0 {
+		t.Errorf("redo fired with the tool armed: sketch has %d lines, want 0", n)
+	}
+	if !s.CanRedo() {
+		t.Error("arming the tool truncated the redo branch; it must leave the stream untouched")
+	}
+}
+
+// TestFinishedLineChainCommitsAndReleases is the commit path: finishing normally closes the
+// group, records the chain as ONE step still labelled "Line" (the granularity and label the
+// tool produced before the wrap), and hands Undo/Redo back.
+func TestFinishedLineChainCommitsAndReleases(t *testing.T) {
+	s := lineChainSession(t)
+	s.StartTool(NewLineTool())
+	s.Click(40, 40)
+	s.Click(80, 40)
+	s.Click(80, 80)
+	_ = s.PressKey(KeyEvent{Key: "Enter"})
+
+	if s.InTransaction() || s.ToolHoldsTransaction() {
+		t.Fatal("finishing the chain left the transaction open")
+	}
+	if got := s.UndoLabel(); got != "Line" {
+		t.Errorf("undo label %q, want %q — the wrap must not rename the step", got, "Line")
+	}
+	before := s.ActiveSketch().Lines().Count()
+	if before != 3 { // the fixture's 1 + the chain's 2
+		t.Fatalf("chain drew %d lines total, want 3", before)
+	}
+
+	if err := s.Undo(); err != nil {
+		t.Fatalf("Undo after finish: %v", err)
+	}
+	if got := s.ActiveSketch().Lines().Count(); got != 1 {
+		t.Errorf("one undo left %d lines, want 1 — the chain must be a single undo step", got)
+	}
+	if err := s.Redo(); err != nil {
+		t.Fatalf("Redo after finish: %v", err)
+	}
+	if got := s.ActiveSketch().Lines().Count(); got != 3 {
+		t.Errorf("redo restored %d lines, want 3", got)
+	}
+}
+
+// TestEscapeMidChainCommitsAndReleases pins that the wrap did not change Escape's meaning: with
+// segments placed, Escape FINISHES the chain and keeps them (#2024) — so it takes the commit
+// path, and the group must close there too.
+func TestEscapeMidChainCommitsAndReleases(t *testing.T) {
+	s := lineChainSession(t)
+	s.StartTool(NewLineTool())
+	s.Click(40, 40)
+	s.Click(80, 40)
+	_ = s.PressKey(KeyEvent{Key: "Escape"})
+
+	if s.InTransaction() || s.ToolHoldsTransaction() {
+		t.Fatal("Escape mid-chain left the transaction open")
+	}
+	if got := s.ActiveSketch().Lines().Count(); got != 2 {
+		t.Errorf("Escape kept %d lines, want 2 (fixture's 1 + the placed segment)", got)
+	}
+	if !s.CanUndo() {
+		t.Error("Undo must work immediately after Escape")
+	}
+}
+
+// TestCancelledLineChainReleasesWithoutRecording is the critical regression: a session cancelled
+// before it can commit anything must close its group AND add no undo entry. One click places no
+// segment, so Escape abandons rather than finishing (LineTool.FinishesOnCancel needs two points).
+func TestCancelledLineChainReleasesWithoutRecording(t *testing.T) {
+	s := lineChainSession(t)
+	labelBefore := s.UndoLabel()
+	s.StartTool(NewLineTool())
+	s.Click(40, 40)
+	_ = s.PressKey(KeyEvent{Key: "Escape"}) // abandons: nothing placed yet
+
+	if s.InTransaction() || s.ToolHoldsTransaction() {
+		t.Fatal("cancelling the tool leaked an open transaction — Undo/Redo are now dead for the session")
+	}
+	if s.ActiveTool() != nil {
+		t.Error("Escape should end the tool")
+	}
+	if got := s.UndoLabel(); got != labelBefore {
+		t.Errorf("a cancelled session recorded an undo step (%q, was %q); it must record nothing",
+			got, labelBefore)
+	}
+	if got := s.ActiveSketch().Lines().Count(); got != 1 {
+		t.Errorf("cancelling changed the model: %d lines, want the fixture's 1", got)
+	}
+
+	// The whole point of closing the group: Undo works again immediately afterwards.
+	if err := s.Undo(); err != nil {
+		t.Fatalf("Undo after a cancelled chain: %v", err)
+	}
+	if got := s.ActiveSketch().Lines().Count(); got != 0 {
+		t.Errorf("undo after cancel left %d lines, want 0", got)
+	}
+}
+
+// TestSwitchingToolMidChainReleases covers the exit path with no explicit cancel gesture: the
+// user picks a different command while the chain is open. StartTool cancels the outgoing tool,
+// and its group must die with it rather than be inherited by the incoming one.
+func TestSwitchingToolMidChainReleases(t *testing.T) {
+	s := lineChainSession(t)
+	s.StartTool(NewLineTool())
+	s.Click(40, 40)
+	if !s.InTransaction() {
+		t.Fatal("fixture: the chain should hold a transaction")
+	}
+
+	s.StartTool(NewRectangleTool()) // a different, non-transactional command
+
+	if s.InTransaction() || s.ToolHoldsTransaction() {
+		t.Fatal("switching tools inherited the line chain's transaction — it must close with its tool")
+	}
+	if err := s.Undo(); err != nil {
+		t.Fatalf("Undo after a tool switch: %v", err)
+	}
+}
+
+// TestRestartingLineToolDoesNotNestTransactions is the leak that a naive begin-per-activation
+// would cause: groups nest by depth (undo.go groupDepth), so re-arming the line tool five times
+// without closing would need five Ends. One close must always be enough.
+func TestRestartingLineToolDoesNotNestTransactions(t *testing.T) {
+	s := lineChainSession(t)
+	for i := 0; i < 5; i++ {
+		s.StartTool(NewLineTool())
+		s.Click(40, 40)
+	}
+	s.CancelTool()
+
+	if s.InTransaction() || s.ToolHoldsTransaction() {
+		t.Fatal("re-arming the line tool nested transactions; one cancel left a group open")
+	}
+	if err := s.Undo(); err != nil {
+		t.Fatalf("Undo after repeated re-arming: %v", err)
+	}
+}
+
+// TestClosingDocumentMidChainReleases is the exit path with no user gesture at all. The tool's
+// group is tracked by document id, so closing must not leave the flag set (which would make the
+// NEXT document's first teardown close a group it never opened).
+func TestClosingDocumentMidChainReleases(t *testing.T) {
+	s := lineChainSession(t)
+	d := s.ActiveDocument()
+	s.StartTool(NewLineTool())
+	s.Click(40, 40)
+	if !s.ToolHoldsTransaction() {
+		t.Fatal("fixture: the chain should hold a transaction")
+	}
+
+	if err := s.CloseDocument(d, true); err != nil {
+		t.Fatalf("CloseDocument: %v", err)
+	}
+
+	if s.ToolHoldsTransaction() {
+		t.Fatal("closing the document mid-chain left the tool transaction flagged open")
+	}
+	if s.InTransaction() {
+		t.Fatal("a transaction is reported open after the document holding it closed")
+	}
+	if s.ActiveTool() != nil {
+		t.Error("closing the document should abandon the armed tool (#2040)")
+	}
+}
+
+// TestNonTransactionalSketchToolIsUnchanged is the blast-radius check: the wrap is opt-in, so a
+// sketch tool that did not opt in must behave exactly as before — no group, undo live throughout.
+func TestNonTransactionalSketchToolIsUnchanged(t *testing.T) {
+	s := lineChainSession(t)
+	s.StartTool(NewRectangleTool())
+
+	if s.InTransaction() || s.ToolHoldsTransaction() {
+		t.Fatal("a tool that did not opt in opened a transaction")
+	}
+	s.Click(40, 40)
+	if s.InTransaction() {
+		t.Fatal("a non-transactional tool opened a transaction on its first click")
+	}
+	if err := s.Undo(); err != nil { // undo stays live for tools outside the opt-in (#1750)
+		t.Fatalf("Undo with a non-transactional tool armed: %v", err)
+	}
+}

--- a/app/tool_transaction.go
+++ b/app/tool_transaction.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "oblikovati.org/model/doc"
+
+// Tool-session transactions (#1750 GUI trigger).
+//
+// The in-transaction Undo/Redo guard — dispatchUndo/dispatchRedo (bindings.go:89,96) and
+// the QAT buttons (head/ui/qat.go:69,74) — is driven entirely by [Session.InTransaction].
+// Until now the ONLY caller of BeginTransaction/EndTransaction was the add-in wire router
+// (addin/router/transactions.go:38,47), so no interactive gesture could ever make the guard
+// fire: a smoke test found Undo mid-sketch-line undid normally instead of being blocked.
+//
+// A multi-click tool is exactly the interactive analogue of an add-in batch — it is midway
+// through composing ONE unit of work across many events — so an opted-in tool now holds a
+// bounded transaction open for its whole session, from activation to finish or cancel.
+//
+// The invariant this file exists to hold: a tool transaction NEVER outlives its tool. A
+// leaked open group would pin InTransaction() true forever and kill Undo/Redo for the rest
+// of the document session — strictly worse than the missing guard it replaces. Every tool
+// teardown path therefore routes through endToolTransaction:
+//
+//	OK          → finishToolCommit → endToolTransaction   (commit)
+//	CancelTool  → abandonTool      → endToolTransaction   (Escape / cancel)
+//	StartTool   → endToolTransaction                      (tool switch: the outgoing tool)
+//	CloseDocument → releaseEditStateFor → abandonTool      (document close)
+//
+// session_input.go:56,124,166 are the only three sites that create or drop s.tool, so those
+// four paths are the complete set (verified by grep for `s.tool = `).
+
+// transactionalTool is an interactive tool whose ENTIRE session is one bounded transaction:
+// the guard is live from activation, before the first click, not merely once geometry
+// exists. Opt-in per tool (the capability-interface idiom this package already uses for
+// chainingTool, autoCommitter and modelReferencePicker) — a tool that does not implement it
+// behaves exactly as it did before.
+//
+// The multi-click line chain is the case (#2024): it accumulates points in the tool and
+// creates every segment at once in Commit, so mid-chain the document holds no geometry yet
+// and an Undo aimed at "the line I am drawing" would silently rewind some UNRELATED earlier
+// step instead — with the placed points still live in the tool.
+type transactionalTool interface {
+	// RunsInTransaction reports whether this tool's session should be bounded.
+	RunsInTransaction() bool
+}
+
+// toolTransaction remembers the bounded transaction the active tool holds open, and — this
+// is the point of the type — WHICH document it was opened on. BeginTransaction/
+// EndTransaction/AbortTransaction all act on whatever document is active when they are
+// called (undo.go:439,455,483), so closing by "the active document" would, after a document
+// switch mid-tool, leave the real group open on the original document and (worse) decrement
+// an add-in's unrelated group on the new one. Closing by id cannot make that mistake.
+type toolTransaction struct {
+	open bool
+	doc  doc.ID
+}
+
+// beginToolTransaction opens the bounded transaction spanning an opted-in tool's session.
+// It is deliberately quiet: a tool armed with no active document, or on a document with no
+// undo stream (a non-recipe document), simply runs unbounded exactly as before — arming a
+// tool must never surface an error the user did not cause.
+//
+// The group is labelled with the tool's Name(), which is the SAME label OK() would have
+// passed to RecordActiveEdit (session_input.go:101,115), so the coalesced step the outermost
+// EndTransaction records is named exactly as it is today ("Line") — the wrap changes when
+// the step is recorded, never what it is called.
+func (s *Session) beginToolTransaction(t Tool) {
+	tt, ok := t.(transactionalTool)
+	if !ok || !tt.RunsInTransaction() {
+		return
+	}
+	d := s.ActiveDocument()
+	if d == nil {
+		return
+	}
+	if _, ok := metaStoreFor(d); !ok {
+		return // no recipe content ⇒ no undo stream to bound
+	}
+	if err := s.BeginTransaction(t.Name()); err != nil {
+		return
+	}
+	s.toolTxn = toolTransaction{open: true, doc: d.ID()}
+}
+
+// endToolTransaction closes the tool's bounded transaction, on the document it was opened
+// on. It is idempotent and safe to call on every teardown path, including paths where no
+// transaction was ever opened.
+//
+// It ENDS rather than aborts, and that choice is load-bearing for the cancel path.
+// AbortTransaction (undo.go:483) unconditionally RestoreSnapshot()s the pre-group recipe and
+// — unlike undo/redo (undo.go:544,555) — does NOT call reattachActiveSketchAfterRestore, so
+// aborting while a sketch is open would rebuild the sketch objects and leave s.activeSketch
+// dangling into the discarded ones (#1270 is that exact bug). EndTransaction needs no
+// restore: a cancelled tool session leaves the recipe byte-identical to the pre-group
+// snapshot, and commitRecipeDelta's no-op guard (undo.go:282-284) then records nothing. So
+// cancel closes the group and adds no undo entry — the pre-change behaviour, reached without
+// touching the model.
+//
+// The state is cleared BEFORE the close so an error path cannot leave the flag set and pin
+// InTransaction() true; a document that has since been closed took its history with it
+// (watchDocumentCloses, undo.go:403-416), so there is nothing left to close.
+func (s *Session) endToolTransaction() {
+	if !s.toolTxn.open {
+		return
+	}
+	id := s.toolTxn.doc
+	s.toolTxn = toolTransaction{}
+	d, ok := s.workspace.ByID(id)
+	if !ok {
+		return
+	}
+	_ = s.endTransactionOn(d) // ErrNoOpenTransaction here means already closed: nothing to do
+}
+
+// ToolHoldsTransaction reports whether the active interactive tool is holding a bounded
+// transaction open. It exists for tests and diagnostics — the guard itself reads
+// InTransaction(), which is true for an add-in group too.
+func (s *Session) ToolHoldsTransaction() bool { return s.toolTxn.open }
+
+// RunsInTransaction bounds the line tool's whole multi-click chain in one transaction, so
+// Undo/Redo are inert from the moment the tool is armed until the chain is finished or
+// cancelled (#1750). The chain already committed as a single undo step
+// (TestChainedLineIsOneUndoStep), and this does not change that: the step is recorded by the
+// closing EndTransaction under the same "Line" label instead of by OK's RecordActiveEdit.
+func (t *LineTool) RunsInTransaction() bool { return true }
+
+// The line tool is the transactional tool; the assertion keeps the capability wired.
+var _ transactionalTool = (*LineTool)(nil)

--- a/app/undo.go
+++ b/app/undo.go
@@ -457,8 +457,19 @@ func (s *Session) EndTransaction() error {
 	if d == nil {
 		return ErrNoActiveDoc
 	}
-	dh := s.documentHistory(d)
-	if dh.groupDepth == 0 {
+	s.documentHistory(d) // open the stream if this is the document's first touch
+	return s.endTransactionOn(d)
+}
+
+// endTransactionOn is EndTransaction against a NAMED document rather than whichever one is
+// active now. An interactive tool holds its group open across many events, during which the
+// active document can change (a document switch, or a close that activates another), so the
+// tool path closes by document id and cannot decrement a different document's group by
+// mistake (see toolTransaction, tool_transaction.go). Everything below it is already
+// document-scoped: commitRecipeDelta takes d and emits against d.ID().
+func (s *Session) endTransactionOn(d *doc.Document) error {
+	dh, ok := s.histories[d.ID()]
+	if !ok || dh.groupDepth == 0 {
 		return ErrNoOpenTransaction
 	}
 	dh.groupDepth--

--- a/app/undo_keyboard_test.go
+++ b/app/undo_keyboard_test.go
@@ -38,9 +38,16 @@ func sketchWithPerpConstraint(t *testing.T) *Session {
 // an interactive tool is armed — the state a user is in for the ENTIRE duration of sketch drawing.
 // The old guard `s.tool != nil` silently no-op'd here, so undo appeared dead during sketching; the
 // fix narrows the guard to an actually-open transaction (s.InTransaction()).
+//
+// The armed tool was the LINE tool until the line chain became a transactional tool
+// (tool_transaction.go) — it now deliberately DOES open a group on activation, so it can no
+// longer stand for "merely armed". The rectangle tool is the same shape of sketch drawing tool
+// and does not opt in, so it still pins the exact property this test was written for: arming a
+// tool is not, by itself, a transaction. TestKeyboardUndoBlockedWhileLineChainOpen below covers
+// the tool that now is one.
 func TestKeyboardUndoWorksWhileToolArmed(t *testing.T) {
 	s := sketchWithPerpConstraint(t)
-	s.StartTool(NewLineTool()) // arm a tool: this is precisely the old guard's kill condition
+	s.StartTool(NewRectangleTool()) // arm a tool: this is precisely the old guard's kill condition
 	if s.InTransaction() {
 		t.Fatal("fixture: no bounded transaction should be open with a merely-armed tool")
 	}


### PR DESCRIPTION
Keep Undo and Redo from modifying an unrelated earlier step while the interactive line-chain tool is still collecting points.

Open the bounded transaction at activation, close it on commit, cancellation, replacement, and document teardown, and tie closure to the document that opened it. Preserve upstream #2024 Escape-to-commit semantics and cover activation, guards, teardown, document close, and non-transactional tools with focused tests.

Issue #2024 is already closed as completed: upstream implemented continuous line-chain Escape-to-commit behaviour. This PR is a follow-on transaction-boundary fix that prevents Undo/Redo from disturbing unrelated history while that chain is active; it preserves #2024's visible behaviour and does not reopen or duplicate the issue.

**Personal note to the maintainer**

Hey man, I appreciate your GUI! I made a bunch of what were originally plugins for my copy of your repo but I thought you might appreciate having them as PRs. Please feel free of course to ignore them and/or tell me how I can submit better PRs in the future for this repo (if you're happy for me to continue to do so). I'm using it because I love Inventor but hate the restrictive and expensive licensing at my job, and I also want to be able to change things on a whim to do things I want, so that's why I started using your repo to begin with! I use Hermes agents to help me do most of the work, so let me know if there's a problem in that regard as well. I'm putting this message in all of these PRs just in case you only see one of them or something. Thanks again! - Collin / coldsnit

### Evidence

- Focused line/transaction/Undo tests — passed.
- Archguard passed before the long corpus stage.
- The exact root run reached the known OCCT corpus timeout in `model/feature`; the failure was `TestOCCTBlendSimple`/conformance work, not a transaction assertion.
