### PR TITLE
feat(sketch): pick & delete geometric constraints in a 3D sketch (#1998 follow-up)

### DIFF
--- a/app/bindings.go
+++ b/app/bindings.go
@@ -141,10 +141,17 @@ func dispatchToggleVisibility(s *Session) error {
 	return nil
 }
 
-// dispatchDelete is the Delete key: it removes the selected sketch entities while editing a
-// sketch (issue #1232). With no sketch open / nothing selected it is a no-op, so it never
-// destroys 3D geometry by accident — feature/body delete stays on the browser menu.
-func dispatchDelete(s *Session) error { return s.DeleteSelectedSketchEntities() }
+// dispatchDelete is the Delete key: while editing a 2D sketch it removes the selected entities,
+// dimensions and constraints (issue #1232); while editing a 3D sketch it removes only selected
+// constraint markers (#1998 follow-up), so a stray Delete never destroys 3D geometry — feature/body
+// and 3D-entity delete stay on the browser menu. With no sketch open / nothing selected it is a
+// no-op.
+func dispatchDelete(s *Session) error {
+	if s.InSketch3D() {
+		return s.DeleteSelectedSketch3DConstraints()
+	}
+	return s.DeleteSelectedSketchEntities()
+}
 
 // dispatchSave saves the active document (Ctrl+S / the "SAVE" command word, M26 F05).
 func dispatchSave(s *Session) error { return s.SaveActiveDocument() }

--- a/app/session_input.go
+++ b/app/session_input.go
@@ -273,6 +273,11 @@ func (s *Session) Pointer(e PointerEvent) {
 		s.sketchEntityPointer(e)
 		return
 	}
+	// A 3D sketch's constraint markers sit on the geometry too, so test them before the RayPicker
+	// picks the curve underneath — only when no tool is consuming picks (#1998 follow-up).
+	if s.InSketch3D() && s.tool == nil && s.SelectSketchConstraint3DAt(e.X, e.Y, e.Mods) {
+		return
+	}
 	if s.picker == nil {
 		return
 	}

--- a/app/session_input.go
+++ b/app/session_input.go
@@ -278,6 +278,13 @@ func (s *Session) Pointer(e PointerEvent) {
 	if s.InSketch3D() && s.tool == nil && s.SelectSketchConstraint3DAt(e.X, e.Y, e.Mods) {
 		return
 	}
+	s.routeModelPointer(e)
+}
+
+// routeModelPointer runs the RayPicker for a left click that the 2D-sketch and 3D-constraint paths
+// did not consume: it feeds a hit to the active tool or updates the selection, and clears the
+// selection on an empty click.
+func (s *Session) routeModelPointer(e PointerEvent) {
 	if s.picker == nil {
 		return
 	}

--- a/app/sketch_constraint_glyphs.go
+++ b/app/sketch_constraint_glyphs.go
@@ -71,13 +71,13 @@ func (s *Session) SketchConstraintGlyphs() []ConstraintGlyphView {
 }
 
 // ConstraintGlyphView3D is one 3D-sketch constraint marker positioned for drawing (#1998): the
-// constraint, its glyph kind, and its model-space anchor. It carries no selection state — 3D
-// constraint markers are display-only for now (Show Constraints in a 3D sketch); viewport pick and
-// delete of a 3D marker are a follow-up, so a 3D constraint is removed through the browser.
+// constraint, its glyph kind, its model-space anchor, and whether it is selected — a picked 3D
+// marker highlights just like a 2D one, so the Delete key has a visible target.
 type ConstraintGlyphView3D struct {
 	Constraint sketch.Constraint
 	Kind       sketch.ConstraintKind
 	At         math.Point3
+	Selected   bool
 }
 
 // SketchConstraintGlyphs3D returns the markers to draw for the active 3D sketch, empty when
@@ -89,10 +89,11 @@ func (s *Session) SketchConstraintGlyphs3D() []ConstraintGlyphView3D {
 	if !s.showSketchConstraints || s.activeSketch3D == nil {
 		return nil
 	}
+	selected := s.selectedConstraintSet()
 	glyphs := s.activeSketch3D.ConstraintGlyphs()
 	views := make([]ConstraintGlyphView3D, len(glyphs))
 	for i, g := range glyphs {
-		views[i] = ConstraintGlyphView3D{Constraint: g.Constraint, Kind: g.Kind, At: g.At}
+		views[i] = ConstraintGlyphView3D{Constraint: g.Constraint, Kind: g.Kind, At: g.At, Selected: selected[g.Constraint]}
 	}
 	return views
 }

--- a/app/sketch_constraint_pick_3d.go
+++ b/app/sketch_constraint_pick_3d.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "oblikovati.org/model/sketch"
+
+// Picking a 3D-sketch constraint marker (#1998 follow-up). A 3D marker sits at a model-space point,
+// so it is picked the way a standalone 3D point is: by the pick ray's distance of closest approach
+// (rayPointDistance), within the same screen-space radius the marker is drawn at. Selecting one puts
+// a SketchConstraintHandle in the selection — the same handle the 2D path uses — so Delete removes
+// it through the shared selected-constraints path.
+
+// PickSketchConstraint3DAt returns the 3D-sketch constraint whose marker the pick ray through
+// (px, py) passes nearest, within the marker's screen radius, or false. Later markers win ties, so
+// the most recently placed one is grabbed first — the topmost-first rule the 2D pick uses.
+func (s *Session) PickSketchConstraint3DAt(px, py float64) (sketch.Constraint, bool) {
+	if s.activeSketch3D == nil {
+		return nil, false
+	}
+	origin, dir := s.camera.RayThrough(px, py)
+	tol := constraintGlyphPixels * s.camera.WorldPerPixel()
+	var best sketch.Constraint
+	bestD := tol
+	for _, g := range s.SketchConstraintGlyphs3D() {
+		if d, _, ok := rayPointDistance(origin, dir, g.At); ok && d <= bestD {
+			best, bestD = g.Constraint, d
+		}
+	}
+	return best, best != nil
+}
+
+// SelectSketchConstraint3DAt selects the 3D constraint marker under (px, py), extending the
+// selection when mods carry Shift/Ctrl, and reports whether one was hit. The input router tests it
+// before the RayPicker, since a marker sits on top of the geometry it annotates.
+func (s *Session) SelectSketchConstraint3DAt(px, py float64, mods Modifier) bool {
+	c, ok := s.PickSketchConstraint3DAt(px, py)
+	if !ok {
+		return false
+	}
+	s.applyPickToSelection(SketchConstraintHandle{Constraint: c}, mods)
+	return true
+}

--- a/app/sketch_constraint_pick_3d_test.go
+++ b/app/sketch_constraint_pick_3d_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+	"oblikovati.org/scene"
+)
+
+// topDown800 is a camera looking straight down the −Z axis, so the centre pixel (400,400) casts a
+// ray through the world origin — a marker anchored there is picked by a click at the centre.
+func topDown800(s *Session) {
+	cam := scene.NewCamera(800, 800)
+	cam.Eye, cam.Target, cam.Up = math.P3(0, 0, 10), math.P3(0, 0, 0), math.V3(0, 1, 0)
+	s.SetCamera(cam)
+}
+
+// TestSelectAndDeleteSketch3DConstraint is the #1998 pick/delete follow-up: clicking a 3D
+// constraint marker selects it (and it highlights), and Delete removes the relation from the 3D
+// sketch. A coincidence of two points at the origin puts its marker on the centre-pixel ray.
+func TestSelectAndDeleteSketch3DConstraint(t *testing.T) {
+	s, sk := sketch3DSession(t)
+	topDown800(s)
+	l1 := sk.AddLine3D(math.P3(-1, 0, 0), math.P3(0, 0, 0))
+	l2 := sk.AddLine3D(math.P3(0, 0, 0), math.P3(1, 0, 0))
+	c := sketch.NewCoincident3D(l1.B, l2.A) // marker at (0,0,0), on the centre ray
+	sk.GeometricConstraints3D().Add(c)
+	s.SetShowSketchConstraints(true)
+
+	if !s.SelectSketchConstraint3DAt(400, 400, 0) {
+		t.Fatal("clicking the centre pixel over the (0,0,0) marker selected nothing")
+	}
+	got := s.SelectedSketchConstraints()
+	if len(got) != 1 || got[0] != c {
+		t.Fatalf("selection = %v, want the coincidence", got)
+	}
+	views := s.SketchConstraintGlyphs3D()
+	if len(views) != 1 || !views[0].Selected {
+		t.Errorf("picked marker not flagged Selected: %+v", views)
+	}
+
+	before := sk.GeometricConstraints3D().Count()
+	if err := s.DeleteSelectedSketch3DConstraints(); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if after := sk.GeometricConstraints3D().Count(); after != before-1 {
+		t.Errorf("constraint count %d → %d, want one fewer after Delete", before, after)
+	}
+	if n := len(s.SelectedSketchConstraints()); n != 0 {
+		t.Errorf("selection not cleared after delete: %d left", n)
+	}
+}
+
+// TestPickSketchConstraint3DMissesEmptySpace: a click far from any marker selects nothing, so the
+// constraint pick does not swallow a click meant for the geometry or empty space.
+func TestPickSketchConstraint3DMissesEmptySpace(t *testing.T) {
+	s, sk := sketch3DSession(t)
+	topDown800(s)
+	l1 := sk.AddLine3D(math.P3(4, 4, 0), math.P3(5, 4, 0))
+	l2 := sk.AddLine3D(math.P3(4, 5, 0), math.P3(5, 5, 0))
+	sk.GeometricConstraints3D().Add(sketch.NewParallel3D(l1, l2)) // markers far from the origin
+	s.SetShowSketchConstraints(true)
+
+	if _, ok := s.PickSketchConstraint3DAt(400, 400); ok {
+		t.Error("centre-pixel pick hit a marker that is off near (4.5,4/5), want a miss")
+	}
+}
+
+// TestPickSketchConstraint3DEmptyWhenHidden: with Show Constraints off there are no markers to pick,
+// even directly over where one would sit.
+func TestPickSketchConstraint3DEmptyWhenHidden(t *testing.T) {
+	s, sk := sketch3DSession(t)
+	topDown800(s)
+	l1 := sk.AddLine3D(math.P3(-1, 0, 0), math.P3(0, 0, 0))
+	l2 := sk.AddLine3D(math.P3(0, 0, 0), math.P3(1, 0, 0))
+	sk.GeometricConstraints3D().Add(sketch.NewCoincident3D(l1.B, l2.A))
+	// Show Constraints left OFF.
+	if _, ok := s.PickSketchConstraint3DAt(400, 400); ok {
+		t.Error("picked a marker while constraints are hidden")
+	}
+}

--- a/app/sketch_delete.go
+++ b/app/sketch_delete.go
@@ -41,6 +41,41 @@ func (s *Session) DeleteSelectedSketchEntities() error {
 	return nil
 }
 
+// DeleteSelectedSketch3DConstraints removes the geometric constraints selected in the active 3D
+// sketch — the Delete-key action once a 3D constraint marker can be clicked (#1998 follow-up). It is
+// scoped to CONSTRAINTS on purpose: 3D sketch entities are not deleted from the viewport (that stays
+// on the browser, so a stray Delete never destroys 3D geometry), only the relations a marker
+// selects. Removing one frees the degrees of freedom it held, so the part recomputes and re-solves.
+// A no-op (nil) when not editing a 3D sketch, a tool is mid-operation, or nothing is selected.
+func (s *Session) DeleteSelectedSketch3DConstraints() error {
+	if s.activeSketch3D == nil || s.tool != nil {
+		return nil
+	}
+	cons := s.SelectedSketchConstraints()
+	if len(cons) == 0 {
+		return nil
+	}
+	part, err := activePart(s)
+	if err != nil {
+		return err
+	}
+	gc := s.activeSketch3D.GeometricConstraints3D()
+	n := 0
+	for _, c := range cons {
+		if err := gc.DeleteAllowed(c); err == nil {
+			n++
+		}
+	}
+	if n == 0 {
+		return nil
+	}
+	s.selection.Clear()
+	event.Emit(s.bus, event.After, SelectionChanged{Count: 0})
+	part.Recompute()
+	s.recordEdit(part, "Delete Sketch Constraints")
+	return nil
+}
+
 // deleteSketchConstraints drops each selected geometric constraint, returning how many were
 // removed. It goes through DeleteAllowed rather than Delete so a system-owned relation is refused
 // even if one somehow reached the selection — Show Constraints already declines to draw those, and

--- a/head/ui/constraint_glyphs_3d.go
+++ b/head/ui/constraint_glyphs_3d.go
@@ -28,8 +28,10 @@ type constraint3DGlyphSource interface {
 var _ constraint3DGlyphSource = (*app.Session)(nil)
 
 // constraint3DGlyphOverlay builds the camera-facing marker items for the active 3D sketch's
-// constraints. hWorld is the marker half-size in world units (screen-constant, as for the 2D
-// overlay). Empty when constraints are hidden, no 3D sketch is open, or the camera is degenerate.
+// constraints — one item for the unselected markers and one for the selected, so a picked marker
+// reads at a glance (the target for Delete). hWorld is the marker half-size in world units
+// (screen-constant, as for the 2D overlay). Empty when constraints are hidden, no 3D sketch is open,
+// or the camera is degenerate.
 func constraint3DGlyphOverlay(s constraint3DGlyphSource, cam scene.Camera, hWorld float64) []renderer.DrawItem {
 	glyphs := s.SketchConstraintGlyphs3D()
 	if len(glyphs) == 0 {
@@ -39,15 +41,20 @@ func constraint3DGlyphOverlay(s constraint3DGlyphSource, cam scene.Camera, hWorl
 	if !ok {
 		return nil
 	}
-	acc := &segAccum{}
+	plain, chosen := &segAccum{}, &segAccum{}
 	for _, g := range glyphs {
 		billboard, err := sketch.NewPlane(g.At, right, up)
 		if err != nil {
 			continue // right⊥up by construction, so this cannot happen for a real camera
 		}
+		acc := plain
+		if g.Selected {
+			acc = chosen
+		}
 		constraintGlyphSegments(acc, billboard, math.P2(0, 0), hWorld, g.Kind)
 	}
-	return appendGrid(nil, acc, chromeTheme.sketchColor)
+	items := appendGrid(nil, plain, chromeTheme.sketchColor)
+	return appendGrid(items, chosen, chromeTheme.sketchSelectedColor)
 }
 
 // cameraBillboardAxes returns an orthonormal (right, up) pair spanning the plane that faces the


### PR DESCRIPTION
## What

Makes the 3D constraint markers from #2098 **clickable**: pick a marker to select the relation (it highlights), press **Delete** to remove it. Previously 3D constraints were display-only — visible but removable only from the browser.

## How

**app**
- `PickSketchConstraint3DAt` — finds the constraint whose marker the pick ray through `(px,py)` passes nearest, via `rayPointDistance` (the same closest-approach primitive that picks a standalone 3D point), within the marker's screen-space radius.
- `SelectSketchConstraint3DAt` — puts the shared `SketchConstraintHandle` in the selection, so the marker highlights and Delete already knows how to consume it.
- Routing: `Pointer` tests the constraint pick **before** the RayPicker while editing a 3D sketch with no tool active — a marker sits on top of the geometry it annotates, so the curve underneath would otherwise always win.
- Delete: in a 3D sketch the Delete key runs `DeleteSelectedSketch3DConstraints`, scoped to **constraints only** — 3D entity/body delete stays on the browser, so a stray Delete never destroys geometry. Frees the held DOF and recomputes.
- `ConstraintGlyphView3D` gains a `Selected` flag.

**head** — `constraint3DGlyphOverlay` splits markers into an unselected and a selected colour, so a picked marker highlights (the visible Delete target).

## Verification

- `TestSelectAndDeleteSketch3DConstraint` — a centre-pixel click over a marker at the origin selects the constraint, flags it Selected, and Delete drops the count by one and clears the selection.
- `TestPickSketchConstraint3DMissesEmptySpace` — a click away from any marker is a miss (doesn't swallow geometry/empty clicks).
- `TestPickSketchConstraint3DEmptyWhenHidden` — nothing is pickable while Show Constraints is off.
- **Live**: an offscreen capture selects a parallel constraint (both its markers highlight), then Delete removes them while the two lines stay.
- Full `app` + `head/ui` + `archguard` green; both `golangci-lint --new-from-rev` clean; SPDX present. No API surface change.

Refs #1998