### PR TITLE
test(sketch): guard that a dimension's line moves with its label (#1999)

### DIFF
--- a/app/sketch_dimension_interaction_test.go
+++ b/app/sketch_dimension_interaction_test.go
@@ -154,6 +154,21 @@ func TestDeleteSelectedStillRemovesEntities(t *testing.T) {
 	}
 }
 
+// TestDimensionDragMovesTheDimensionLine is the #1999 regression ("cannot move dimension line in
+// sketch"): repositioning a linear dimension's label moves the DIMENSION LINE with it, not just the
+// text. The line is drawn through the label (distanceView), so dragging the annotation relocates the
+// whole glyph — witness lines, arrows and all.
+func TestDimensionDragMovesTheDimensionLine(t *testing.T) {
+	s, _, d := dimensionedSketch(t)
+	dimLineY := func() float64 { return float64(viewOf(t, s, d).Segments[dimLineIndex][0].Y) }
+	before := dimLineY()
+	d.SetTextPoint(math.P2(2, math.Scalar(before-3))) // push the annotation 3 cm to the far side
+	after := dimLineY()
+	if stdmath.Abs(after-before) < 1 {
+		t.Fatalf("dimension line Y = %g → %g: moving the label did not move the dimension line (#1999)", before, after)
+	}
+}
+
 // TestDimensionDragMovesOnlyTheLabel: the drag stores a new TextPoint and leaves the measured
 // geometry untouched — moving an annotation must never move the model.
 func TestDimensionDragMovesOnlyTheLabel(t *testing.T) {


### PR DESCRIPTION
## What

#1999 — "[Drawing] Cannot move dimension line in sketch" (external report, 2026-07-15) — is **already fixed**. A 2D-sketch dimension can be dragged to reposition it, and the dimension **line** moves with the label (not just the text). This adds the missing regression guard and closes the issue.

## Why it's fixed

The sketch dimension-label drag shipped as #2017 (which postdates the issue): `BeginDimensionDrag`/`UpdateDimensionDrag`/`CommitDimensionDrag` store a `TextPoint`, wired into the viewport at `head/ui/box_select_view.go` (`updateDimensionDrag`, tested before the entity drag so the label wins). Crucially, `distanceView` draws the dimension line **through** the label — `a2`/`b2` are the measured points projected to the label's perpendicular offset — so moving the label relocates the whole glyph (line, witness lines, arrows).

## What this adds

The existing drag tests assert the label moves and the geometry does not, but none pinned that the **dimension line** follows. `TestDimensionDragMovesTheDimensionLine`: after moving the label perpendicular, the drawn dimension-line segment (`Segments[dimLineIndex]`) must move with it — non-vacuous (fails if the line decouples from the label).

## Verification

- New guard green; the full `TestDimensionDrag*` suite green; `golangci-lint --new-from-rev` clean.
- **Live** (throwaway before/after capture): the dimension line and its witness lines relocate from just above the geometry to well below it when the label is repositioned.

Closes #1999