### PR TITLE
feat(kernel): split faces along a projected sketch path (#2068)

### DIFF
--- a/addin/opregistry/feature_advanced.go
+++ b/addin/opregistry/feature_advanced.go
@@ -543,7 +543,7 @@ const splitSolidSchema = `{
     "workPlaneIndex": {"type": "integer", "minimum": 0, "description": "Index of the work plane to split along (see list_work_planes)."},
     "keep": {"type": "string", "enum": ["both", "positive", "negative"], "default": "both", "description": "Which side(s) of the plane to keep (trim modes)."},
     "type": {"type": "string", "enum": ["trimSolid", "splitFaces", "splitBody"], "description": "Split kind: trimSolid keeps one side (per keep, default positive); splitFaces imprints the plane onto the faces without removing material; splitBody keeps both pieces as separate solids. Absent: derived from keep."},
-    "tool": {"type": "string", "enum": ["workPlane", "workSurface", "surfaceBody", "path"], "default": "workPlane", "description": "What the split cuts WITH (Inventor's SplitToolTypeEnum), independent of type. workSurface and surfaceBody take toolIndex and cut along the sheet's plane extended, so a PLANAR sheet is required — a curved one is refused rather than approximated. path is not yet buildable: it is the split-face geometry."},
+    "tool": {"type": "string", "enum": ["workPlane", "workSurface", "surfaceBody", "path"], "default": "workPlane", "description": "What the split cuts WITH (Inventor's SplitToolTypeEnum), independent of type. workSurface and surfaceBody take toolIndex and cut along the sheet's plane extended, so a PLANAR sheet is required — a curved one is refused rather than approximated. path projects a 2D sketch profile onto the faces and scores them (split-face geometry, #2068); it is buildable through the model API but not yet over the wire (no sketch field here), so it is refused."},
     "toolIndex": {"type": "integer", "minimum": 0, "description": "The surface tool: a work-surface position for tool \"workSurface\", or a body index for \"surfaceBody\"."}
   },
   "required": []
@@ -591,6 +591,14 @@ func splitWorkPlane(part *compdef.PartComponentDefinition, tool feature.SplitToo
 // split cuts with, the type decides what it does (#1891).
 func addSplitOfType(part *compdef.PartComponentDefinition, wp *feature.WorkPlane,
 	tool feature.SplitToolKind, in featureargs.SplitSolid) (*feature.PartFeature, error) {
+	if tool == feature.SplitByPath {
+		// The geometry is implemented (feature.AddSplitFacesByPath imprints a projected sketch
+		// profile), but the wire DTO carries no sketch reference yet, so the path tool is not
+		// reachable over /api. Refuse cleanly rather than build a sketch-less split that goes sick.
+		return nil, fmt.Errorf("splitSolid: the path tool needs a sketch profile, which the wire " +
+			"does not carry yet; it is buildable through the model API (AddSplitFacesByPath) — " +
+			"exposing the sketch reference over /api is a follow-up (#2068)")
+	}
 	def := &feature.SplitSolidDefinition{Tool: tool, Plane: wp, ToolIndex: in.ToolIndex, Keep: splitSide(in.Keep)}
 	if in.Type == "" {
 		return feature.NewModifyFeatures(part.Features()).AddSplitByDefinition(def), nil

--- a/addin/opregistry/split_tool_test.go
+++ b/addin/opregistry/split_tool_test.go
@@ -3,6 +3,7 @@
 package opregistry
 
 import (
+	"strings"
 	"testing"
 
 	"oblikovati.org/app"
@@ -35,7 +36,6 @@ func TestSplitToolReachesTheDefinition(t *testing.T) {
 	}{
 		{"workSurface", feature.SplitByWorkSurface},
 		{"surfaceBody", feature.SplitBySurfaceBody},
-		{"path", feature.SplitByPath},
 	} {
 		t.Run(c.spelling, func(t *testing.T) {
 			s, _, _ := extrudedSolid(t)
@@ -49,6 +49,20 @@ func TestSplitToolReachesTheDefinition(t *testing.T) {
 				t.Errorf("tool %q reached the definition as %v/%d, want %v/1", c.spelling, def.Tool, def.ToolIndex, c.want)
 			}
 		})
+	}
+}
+
+// TestSplitPathToolRefusedOverWire: the path tool's geometry is implemented (model API), but the
+// wire DTO carries no sketch reference yet, so a splitSolid with tool:"path" is refused with a
+// pointer to the follow-up rather than building a sketch-less split that goes sick (#2068).
+func TestSplitPathToolRefusedOverWire(t *testing.T) {
+	s, _, _ := extrudedSolid(t)
+	_, err := applyMap(t, s, "splitSolid", map[string]any{"tool": "path"})
+	if err == nil {
+		t.Fatal("tool:\"path\" should be refused over the wire (no sketch field yet)")
+	}
+	if !strings.Contains(err.Error(), "sketch") {
+		t.Errorf("path refusal = %q, want it to mention the missing sketch reference", err)
 	}
 }
 

--- a/archguard/authoring_surface_test.go
+++ b/archguard/authoring_surface_test.go
@@ -27,7 +27,8 @@ var authoringMethodDecl = regexp.MustCompile(`^func \(\w+ \*(\w*Features)\) ((?:
 // yet, with the issue that will give it one. Entries go stale loudly — a method that gains a
 // caller fails this test until its entry is deleted.
 var authoringMethodsWithoutCaller = map[string]string{
-	"AddFromCage": "#2048 — freeform cage editing has no UI; the builder lands with that work",
+	"AddFromCage":         "#2048 — freeform cage editing has no UI; the builder lands with that work",
+	"AddSplitFacesByPath": "#2068 — split-face-along-a-path is buildable via the model API; the wire sketch reference + UI tool that call it are the follow-up",
 }
 
 // TestExportedAuthoringMethodsHaveACaller fails on an exported model/feature authoring method

--- a/kernel/ops/split.go
+++ b/kernel/ops/split.go
@@ -44,6 +44,88 @@ func SplitFacesByPlane(body *topo.Body, plane geom.Plane) (*topo.Body, error) {
 	return ra.Body, nil
 }
 
+// SplitFacesByPath imprints a projected polyline path onto a body's faces (the split-FACE-by-path
+// mode, #2068): each path segment, extruded along dir far enough to cross the body, is a planar
+// strip; together they form an open sheet tool whose intersection with each face scores it — like
+// SplitFacesByPlane, but along an arbitrary polyline rather than a straight plane section. No
+// material is removed, so the volume is unchanged.
+//
+// path is the polyline in MODEL space (already projected onto the sketch plane); dir is the
+// projection direction (the sketch plane normal). Straight segments only — a curved path segment
+// has no planar extrusion, so the caller facets it or refuses it. Needs at least two points.
+func SplitFacesByPath(body *topo.Body, path []math.Point3, dir math.Vector3) (*topo.Body, error) {
+	if len(path) < 2 {
+		return nil, fmt.Errorf("split faces by path: need at least 2 path points, got %d", len(path))
+	}
+	tool, err := pathSheetTool(body, path, dir)
+	if err != nil {
+		return nil, err
+	}
+	ra, _, err := brep.ImprintBodies(body, tool)
+	if err != nil {
+		return nil, fmt.Errorf("split faces by path: %w", err)
+	}
+	return ra.Body, nil
+}
+
+// pathSheetTool builds the open sheet whose faces are the path segments extruded ±ext along dir, so
+// the sheet reaches through the body on both sides of every face it must score. One planar quad per
+// segment, sharing the extruded rail edges at each interior path point.
+func pathSheetTool(body *topo.Body, path []math.Point3, dir math.Vector3) (*topo.Body, error) {
+	d, err := math.UnitVector3FromVector(dir)
+	if err != nil {
+		return nil, fmt.Errorf("split faces by path: projection direction is degenerate: %w", err)
+	}
+	ext := math.Scalar(splitExtent(body, path[0]))
+	off := d.AsVector().Scale(ext)
+	bld := topo.NewBuilder(false, topo.NewLineage(topo.Tok("splitpath", "sheet", 0)))
+	// Two rail vertices per path point: bottom (−dir) and top (+dir).
+	bot := make([]*topo.Vertex, len(path))
+	top := make([]*topo.Vertex, len(path))
+	for i, p := range path {
+		bot[i] = bld.AddVertex(p.TranslateBy(off.Scale(-1)), topo.NewLineage(topo.Tok("splitpath", "vbot", i)))
+		top[i] = bld.AddVertex(p.TranslateBy(off), topo.NewLineage(topo.Tok("splitpath", "vtop", i)))
+	}
+	rail := make([]*topo.Edge, len(path)) // the ±dir edge at each path point, shared by adjacent quads
+	rail[0] = bld.AddEdge(geom.NewLineSegment(bot[0].Point(), top[0].Point()), bot[0], top[0],
+		topo.NewLineage(topo.Tok("splitpath", "rail", 0)))
+	for i := 0; i+1 < len(path); i++ {
+		if err := addPathSheetQuad(bld, i, bot, top, rail); err != nil {
+			return nil, err
+		}
+	}
+	return bld.Build(), nil
+}
+
+// addPathSheetQuad adds the strip quad for segment i (path[i]→path[i+1]): its two along-path edges
+// (bottom and top) plus the shared rail edge at path[i+1], wound CCW about the segment's newell
+// normal so the loop and the face plane agree.
+func addPathSheetQuad(bld *topo.Builder, i int, bot, top []*topo.Vertex, rail []*topo.Edge) error {
+	corners := []math.Point3{bot[i].Point(), bot[i+1].Point(), top[i+1].Point(), top[i].Point()}
+	n := newellUnit(corners)
+	pl, err := geom.NewPlane(quadCentroid(corners), n)
+	if err != nil {
+		return fmt.Errorf("split faces by path: segment %d is degenerate (a zero-length step or a "+
+			"step along the projection direction): %w", i, err)
+	}
+	bottom := bld.AddEdge(geom.NewLineSegment(bot[i].Point(), bot[i+1].Point()), bot[i], bot[i+1],
+		topo.NewLineage(topo.Tok("splitpath", "bottom", i)))
+	upper := bld.AddEdge(geom.NewLineSegment(top[i].Point(), top[i+1].Point()), top[i], top[i+1],
+		topo.NewLineage(topo.Tok("splitpath", "top", i)))
+	rail[i+1] = bld.AddEdge(geom.NewLineSegment(bot[i+1].Point(), top[i+1].Point()), bot[i+1], top[i+1],
+		topo.NewLineage(topo.Tok("splitpath", "rail", i+1)))
+	// Ring bot[i] → bot[i+1] → top[i+1] → top[i], reversing the shared rail edges that are stored
+	// bottom→top so the loop still travels the ring direction.
+	uses := []topo.Use{
+		{Edge: bottom, Reversed: false},
+		{Edge: rail[i+1], Reversed: false},
+		{Edge: upper, Reversed: true},
+		{Edge: rail[i], Reversed: true},
+	}
+	bld.AddFace(pl, topo.NewLineage(topo.Tok("splitpath", "face", i)), topo.OuterLoop(uses...))
+	return nil
+}
+
 // splitExtent returns a half-width large enough for a cutting half-space anchored at the plane
 // origin to cover the whole body — twice the farthest body-corner distance from that origin, so
 // the box reaches the body even when the plane sits well outside it.

--- a/kernel/ops/split_faces_by_path_test.go
+++ b/kernel/ops/split_faces_by_path_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops_test
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+)
+
+// TestSplitFacesByPathScoresFaceWithoutRemovingMaterial is the #2068 core: imprinting a projected
+// polyline onto a plate scores its faces (adding edges/faces) while leaving the volume untouched —
+// the split-FACE contract, along a path rather than a straight plane section.
+func TestSplitFacesByPathScoresFaceWithoutRemovingMaterial(t *testing.T) {
+	box := csgBox(math.P3(0, 0, 0), 4, 4, 2) // plate [0,4]×[0,4]×[0,2]
+	before := csgVolume(box)
+	beforeFaces := len(box.Faces())
+
+	// A zig-zag from the x=0 edge to the x=4 edge across the top cap (z=2); its ends touch the
+	// boundary so the imprint divides the face rather than leaving a dangling scratch.
+	path := []math.Point3{math.P3(0, 1, 2), math.P3(2, 3, 2), math.P3(4, 1, 2)}
+	got, err := ops.SplitFacesByPath(box, path, math.V3(0, 0, 1))
+	if err != nil {
+		t.Fatalf("SplitFacesByPath: %v", err)
+	}
+	if r := ops.Validate(got); !r.Valid || !got.IsSolid() {
+		t.Fatalf("imprinted body is not a valid solid: %+v", r)
+	}
+	if after := csgVolume(got); stdmath.Abs(after-before) > 1e-6*before {
+		t.Errorf("volume %g → %g: a face split must remove no material (#2068)", before, after)
+	}
+	if after := len(got.Faces()); after <= beforeFaces {
+		t.Errorf("faces %d → %d: the path did not score any face", beforeFaces, after)
+	}
+}
+
+// TestSplitFacesByPathRejectsBadInput: fewer than two points, or a projection direction with no
+// length, are refused rather than producing a degenerate tool.
+func TestSplitFacesByPathRejectsBadInput(t *testing.T) {
+	box := csgBox(math.P3(0, 0, 0), 2, 2, 2)
+	if _, err := ops.SplitFacesByPath(box, []math.Point3{math.P3(0, 0, 2)}, math.V3(0, 0, 1)); err == nil {
+		t.Error("a one-point path should be refused")
+	}
+	path := []math.Point3{math.P3(0, 1, 2), math.P3(2, 1, 2)}
+	if _, err := ops.SplitFacesByPath(box, path, math.V3(0, 0, 0)); err == nil {
+		t.Error("a zero-length projection direction should be refused")
+	}
+}

--- a/model/feature/serialize_codecs_solid.go
+++ b/model/feature/serialize_codecs_solid.go
@@ -118,13 +118,13 @@ func (r featureCodecSet) registerSolidCodecs() {
 		},
 	})
 	r.register("splitSolid", featureCodec{
-		encode: func(fd *FeatureData, f Feature, _ SketchIndexer, _ map[ID]int) error {
-			sd, err := serializeSplitSolid(f.(*SplitSolidFeature).def)
+		encode: func(fd *FeatureData, f Feature, sk SketchIndexer, _ map[ID]int) error {
+			sd, err := serializeSplitSolid(f.(*SplitSolidFeature).def, sk)
 			fd.SplitSolid = sd
 			return err
 		},
 		decode: func(rc *restoreContext, fd FeatureData) (*PartFeature, error) {
-			return restoreSplitSolid(rc.fs, fd.SplitSolid, rc.work)
+			return restoreSplitSolid(rc.fs, fd.SplitSolid, rc.work, rc.sk)
 		},
 	})
 	r.register("delete-body", featureCodec{

--- a/model/feature/serialize_split.go
+++ b/model/feature/serialize_split.go
@@ -15,6 +15,10 @@ type SplitSolidData struct {
 	FacesOnly bool   `yaml:"facesOnly,omitempty"`
 	Tool      string `yaml:"tool,omitempty"`
 	ToolIndex int    `yaml:"toolIndex,omitempty"`
+	// Sketch/ProfileIndex reference the SplitByPath tool's sketch by its index in the part (#2068);
+	// both absent for every other tool, so an older document reads back unchanged.
+	Sketch       int `yaml:"sketch,omitempty"`
+	ProfileIndex int `yaml:"profileIndex,omitempty"`
 }
 
 // splitSideNames map the kept-side enum to/from a stable name.
@@ -39,20 +43,26 @@ func parseSplitSide(name string) (SplitSide, error) {
 	return SplitBoth, fmt.Errorf("unknown split side %q", name)
 }
 
-func serializeSplitSolid(def *SplitSolidDefinition) (*SplitSolidData, error) {
+func serializeSplitSolid(def *SplitSolidDefinition, sk SketchIndexer) (*SplitSolidData, error) {
 	d := &SplitSolidData{Keep: splitSideName(def.Keep), FacesOnly: def.FacesOnly,
 		Tool: SplitToolName(def.Tool), ToolIndex: def.ToolIndex}
-	if def.Tool != SplitByWorkPlane {
-		return d, nil
+	switch def.Tool {
+	case SplitByWorkPlane:
+		if def.Plane == nil {
+			return nil, fmt.Errorf("split references no cutting plane")
+		}
+		d.Plane = string(def.Plane.Key())
+	case SplitByPath:
+		idx, ok := sk.IndexOf(def.Sketch)
+		if !ok {
+			return nil, fmt.Errorf("split: the path tool's sketch is not in the part")
+		}
+		d.Sketch, d.ProfileIndex = idx, def.ProfileIndex
 	}
-	if def.Plane == nil {
-		return nil, fmt.Errorf("split references no cutting plane")
-	}
-	d.Plane = string(def.Plane.Key())
 	return d, nil
 }
 
-func restoreSplitSolid(fs *PartFeatures, d *SplitSolidData, work *WorkGeometry) (*PartFeature, error) {
+func restoreSplitSolid(fs *PartFeatures, d *SplitSolidData, work *WorkGeometry, sk SketchIndexer) (*PartFeature, error) {
 	if d == nil {
 		return nil, fmt.Errorf("split feature is missing its payload")
 	}
@@ -65,10 +75,17 @@ func restoreSplitSolid(fs *PartFeatures, d *SplitSolidData, work *WorkGeometry) 
 		return nil, err
 	}
 	def := &SplitSolidDefinition{Tool: tool, ToolIndex: d.ToolIndex, Keep: keep, FacesOnly: d.FacesOnly}
-	if tool == SplitByWorkPlane {
+	switch tool {
+	case SplitByWorkPlane:
 		if def.Plane, err = resolvePlaneRef(work, d.Plane); err != nil {
 			return nil, err
 		}
+	case SplitByPath:
+		skt, ok := sk.At(d.Sketch)
+		if !ok {
+			return nil, fmt.Errorf("split references sketch index %d, which does not exist", d.Sketch)
+		}
+		def.Sketch, def.ProfileIndex = skt, d.ProfileIndex
 	}
 	return NewModifyFeatures(fs).AddSplitByDefinition(def), nil
 }

--- a/model/feature/split_faces_by_path_test.go
+++ b/model/feature/split_faces_by_path_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// straddleSketch is a 2D sketch on the XY plane whose rectangle [1,3]×[−1,5] straddles the box in Y,
+// so projecting it +Z scores the box's top/bottom caps edge-to-edge (at x=1 and x=3) rather than
+// leaving an interior island.
+func straddleSketch() *sketch.Sketch {
+	s := sketch.NewSketches().Add(sketch.XYPlane())
+	c := []*sketch.Point{
+		s.Points().Add(math.P2(1, -1)),
+		s.Points().Add(math.P2(3, -1)),
+		s.Points().Add(math.P2(3, 5)),
+		s.Points().Add(math.P2(1, 5)),
+	}
+	s.Lines().Add(c[0], c[1])
+	s.Lines().Add(c[1], c[2])
+	s.Lines().Add(c[2], c[3])
+	s.Lines().Add(c[3], c[0])
+	return s
+}
+
+// TestSplitFacesByPathScoresTheBox is the #2068 feature acceptance: the SplitByPath tool projects a
+// sketch profile onto the running solid and scores its faces, adding faces while removing no
+// material and keeping one body.
+func TestSplitFacesByPathScoresTheBox(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	NewBaseFeatures(fs).AddBase(boxBody()) // [0,4]³
+	split := NewModifyFeatures(fs).AddSplitFacesByPath(straddleSketch(), 0)
+	fs.Recompute()
+
+	if !split.Health().OK() {
+		t.Fatalf("split-by-path went sick: %s", split.Health().Reason)
+	}
+	pieces := fs.Result()
+	if len(pieces) != 1 {
+		t.Fatalf("split-by-path result = %d bodies, want 1 (no material removed)", len(pieces))
+	}
+	body := pieces[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("imprinted body is not a valid solid: %+v", r)
+	}
+	if v := ops.BodyGeometryProperties(body, ops.DefaultQuality()).Volume; stdmath.Abs(v-64) > 1e-6 {
+		t.Errorf("volume = %g, want 64 (a face split removes no material)", v)
+	}
+	if n := len(body.Faces()); n <= 6 {
+		t.Errorf("scored box has %d faces, want more than the original 6", n)
+	}
+}
+
+// TestSplitFacesByPathRoundTrip persists the path split and reads it back, resolving the sketch by
+// index, so a document carrying a split-by-path re-resolves its profile.
+func TestSplitFacesByPathRoundTrip(t *testing.T) {
+	sk := straddleSketch()
+	idx := oneSketch{s: sk}
+	fs := NewPartFeatures(nil)
+	NewModifyFeatures(fs).AddSplitFacesByPath(sk, 0)
+
+	data, err := fs.MarshalRecipe(idx)
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	fresh := NewPartFeatures(nil)
+	if err := fresh.ApplyRecipe(data, idx, NewWorkGeometry()); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	def := fresh.Item(0).Definition().(*SplitSolidFeature).Definition()
+	if def.Tool != SplitByPath || def.Sketch != sk || def.ProfileIndex != 0 || !def.FacesOnly {
+		t.Errorf("restored split = tool %d sketch %p profile %d facesOnly %v, want path + the sketch + 0 + true",
+			def.Tool, def.Sketch, def.ProfileIndex, def.FacesOnly)
+	}
+}

--- a/model/feature/split_solid.go
+++ b/model/feature/split_solid.go
@@ -3,12 +3,15 @@
 package feature
 
 import (
+	"errors"
 	"fmt"
 
 	"oblikovati.org/api/types"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
 )
 
 // SplitSide selects which side(s) of the cutting plane a solid split keeps: both pieces (a true
@@ -33,6 +36,11 @@ type SplitSolidDefinition struct {
 	ToolIndex int
 	Keep      SplitSide
 	FacesOnly bool
+	// Sketch/ProfileIndex drive the SplitByPath tool (#2068): the profile's boundary, projected onto
+	// the running solids along the sketch plane normal, scores their faces (no material removed).
+	// Re-resolved each recompute, so editing the sketch reshapes the split.
+	Sketch       *sketch.Sketch
+	ProfileIndex int
 }
 
 // SplitSolidFeature divides the running solid bodies by a plane (the reference's Split
@@ -62,6 +70,9 @@ func (f *SplitSolidFeature) SplitType() types.SplitType {
 // requested side(s) — or imprinting faces only. A lost plane → Sick; surface (non-solid)
 // bodies pass through unchanged.
 func (f *SplitSolidFeature) Recompute(in Input) (Output, error) {
+	if f.def.Tool == SplitByPath {
+		return f.recomputePath(in)
+	}
 	plane, err := f.def.cuttingPlane(in.Bodies)
 	if err != nil {
 		return Output{}, err
@@ -96,6 +107,73 @@ func (f *SplitSolidFeature) splitOne(b *topo.Body, plane geom.Plane) ([]*topo.Bo
 		return nil, err
 	}
 	return keepSplitSides(pieces, plane, f.def.Keep), nil
+}
+
+// recomputePath scores every running solid's faces along the projected sketch path (#2068), leaving
+// the volume untouched. Surface (non-solid) bodies pass through unchanged.
+func (f *SplitSolidFeature) recomputePath(in Input) (Output, error) {
+	path, dir, err := f.def.projectedPath()
+	if err != nil {
+		return Output{}, err
+	}
+	var out []*topo.Body
+	for _, b := range in.Bodies {
+		if !b.IsSolid() {
+			out = append(out, b)
+			continue
+		}
+		scored, err := ops.SplitFacesByPath(b, path, dir)
+		if err != nil {
+			return Output{}, err
+		}
+		out = append(out, scored)
+	}
+	return Output{Bodies: out}, nil
+}
+
+// projectedPath resolves the split's profile to a closed model-space polyline plus the projection
+// direction (the sketch plane normal). The profile boundary is sampled to a polygon, so a profile
+// made of arcs/splines is imprinted as its faceted approximation — the plane split is exact, this is
+// not (#2068). The loop is closed (first point repeated) so the extruded tool sheet has no open end.
+func (d *SplitSolidDefinition) projectedPath() ([]math.Point3, math.Vector3, error) {
+	if d.Sketch == nil {
+		return nil, math.Vector3{}, errors.New("split: the path tool needs a sketch to project")
+	}
+	profs := d.Sketch.Profiles()
+	if d.ProfileIndex < 0 || d.ProfileIndex >= profs.Count() {
+		return nil, math.Vector3{}, fmt.Errorf("split: profile %d out of range (the sketch has %d)",
+			d.ProfileIndex, profs.Count())
+	}
+	poly := profs.Item(d.ProfileIndex).OuterLoop().Polygon()
+	if len(poly) < 2 {
+		return nil, math.Vector3{}, fmt.Errorf("split: profile %d has %d points, need at least 2",
+			d.ProfileIndex, len(poly))
+	}
+	plane := d.Sketch.Plane()
+	path := make([]math.Point3, 0, len(poly)+1)
+	for _, p := range poly {
+		m := plane.ToModel(p)
+		if len(path) > 0 && float64(path[len(path)-1].DistanceTo(m)) < 1e-9 {
+			continue // drop a repeated point so no sheet quad is degenerate
+		}
+		path = append(path, m)
+	}
+	if len(path) < 2 {
+		return nil, math.Vector3{}, fmt.Errorf("split: profile %d collapses to a single point", d.ProfileIndex)
+	}
+	if float64(path[0].DistanceTo(path[len(path)-1])) > 1e-9 {
+		path = append(path, path[0]) // close the loop unless the polygon already does
+	}
+	return path, plane.Normal().AsVector(), nil
+}
+
+// AddSplitFacesByPath adds a faces-only split that scores the running solids along a sketch
+// profile projected onto them (#2068), removing no material.
+func (c *ModifyFeatures) AddSplitFacesByPath(sk *sketch.Sketch, profileIndex int) *PartFeature {
+	pf := c.engine.Add(&SplitSolidFeature{def: &SplitSolidDefinition{
+		Tool: SplitByPath, FacesOnly: true, Sketch: sk, ProfileIndex: profileIndex}})
+	pf.SetName(c.engine.UniqueName("Split"))
+	return pf
 }
 
 // geomPlaneOf converts a work plane's sketch plane to a kernel plane for the split.

--- a/model/feature/split_tool_test.go
+++ b/model/feature/split_tool_test.go
@@ -120,7 +120,7 @@ func TestSplitRefusesANonPlanarTool(t *testing.T) {
 }
 
 // TestSplitToolMisuseIsRefused: a solid tool is a combine, an out-of-range index names nothing,
-// and the path tool is the split-FACE geometry. Each case asserts the REASON as well as the
+// and a path tool with no sketch has nothing to project. Each case asserts the REASON as well as the
 // refusal — a solid tool would fail anyway for having no single plane, and "not planar" would
 // send the caller looking for a flatter solid instead of the surface they meant to pick.
 func TestSplitToolMisuseIsRefused(t *testing.T) {
@@ -128,11 +128,11 @@ func TestSplitToolMisuseIsRefused(t *testing.T) {
 		def  *SplitSolidDefinition
 		want string
 	}{
-		"solid as tool": {&SplitSolidDefinition{Tool: SplitBySurfaceBody, ToolIndex: 0}, "is a SOLID"},
-		"out of range":  {&SplitSolidDefinition{Tool: SplitBySurfaceBody, ToolIndex: 9}, "out of range"},
-		"no surfaces":   {&SplitSolidDefinition{Tool: SplitByWorkSurface, ToolIndex: 3}, "out of range"},
-		"path":          {&SplitSolidDefinition{Tool: SplitByPath}, "split-FACE"},
-		"no plane":      {&SplitSolidDefinition{Tool: SplitByWorkPlane}, "no cutting plane"},
+		"solid as tool":  {&SplitSolidDefinition{Tool: SplitBySurfaceBody, ToolIndex: 0}, "is a SOLID"},
+		"out of range":   {&SplitSolidDefinition{Tool: SplitBySurfaceBody, ToolIndex: 9}, "out of range"},
+		"no surfaces":    {&SplitSolidDefinition{Tool: SplitByWorkSurface, ToolIndex: 3}, "out of range"},
+		"path no sketch": {&SplitSolidDefinition{Tool: SplitByPath}, "needs a sketch"},
+		"no plane":       {&SplitSolidDefinition{Tool: SplitByWorkPlane}, "no cutting plane"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			fs := boxAndSheetPart()


### PR DESCRIPTION
## What

Implements the **SplitByPath** tool: project a 2D sketch profile onto the running solids and **score their faces** along it (Inventor's split-face-with-a-sketch). The tool spelling was accepted by the recipe/wire since #1891 but refused when built — this fills the deferred geometry.

## How

**kernel/ops `SplitFacesByPath`** — extrudes each path segment ±dir into a planar strip, forming an open **sheet tool**, and imprints it onto the body's faces via `brep.ImprintBodies` (the same scorer `SplitFacesByPlane` uses). Faces crossing the path split along it; **no material is removed**, so the volume is unchanged. Straight segments only; a curved profile is imprinted as its faceted polygon (the plane split is exact, this is not — decided explicitly per the issue).

**model/feature** — `SplitSolidDefinition` gains `Sketch` + `ProfileIndex`. When the tool is `SplitByPath`, `Recompute` projects that profile onto the running solids along the sketch-plane normal and scores them (faces-only). **Re-resolved each recompute**, so editing the sketch reshapes the split; the reference **round-trips** through the recipe by sketch index. `AddSplitFacesByPath` is the model entry point.

**addin/opregistry** — the wire DTO carries **no sketch reference yet**, so `tool:"path"` is refused with a pointer to the model API and the follow-up, rather than building a sketch-less split that goes sick (keeps `/api` clean).

## Scope / follow-up

This lands the **kernel + model** halves — buildable and persistable through the model API, re-parametric. **Exposing the sketch reference over `/api`** (the wire DTO field + opregistry conversion, an additive SemVer-minor API change) and the **UI split tool** are the documented follow-up; that is what will make `tool:"path"` build over the wire. So this **refs**, not closes, #2068.

## Verification

- `kernel/ops`: `SplitFacesByPath` scores a plate's faces (face count up) with the volume unchanged and a valid **manifold solid**; bad input (fewer than two points, degenerate direction) refused.
- `model/feature`: the feature builds and scores the box (valid solid, volume 64 unchanged, more faces), and **round-trips** through the recipe (tool + sketch + profile + facesOnly); a sketch-less path split is refused clearly.
- `addin/opregistry`: `tool:"path"` refused over the wire with the #2068 pointer.
- Full `kernel/ops` / `model/feature` / `addin/opregistry` split suites green; `golangci-lint run` (full) clean on all three; SPDX present. No API change.

Acceptance criteria status:
- [x] Split picked faces along a projected sketch path (model API)
- [x] Curved path segments — faceted approximation, decided explicitly
- [ ] `tool:"path"` builds over the wire — follow-up (needs the wire sketch field)

Refs #2068