### PR TITLE
feat(sheet-metal): relieve the corner where a hem meets an earlier wall (#2072)

### DIFF
--- a/model/feature/sheet_metal_hem.go
+++ b/model/feature/sheet_metal_hem.go
@@ -7,6 +7,7 @@ import (
 	stdmath "math"
 
 	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
 )
 
 // Sheet-metal Hem feature (M13-F02, types per #1956). A hem folds the material at an edge back on
@@ -69,25 +70,9 @@ func (f *SheetMetalHemFeature) Definition() *SheetMetalHemDefinition { return f.
 // Kind identifies the feature for serialization and the model tree.
 func (f *SheetMetalHemFeature) Kind() string { return "sheet-metal-hem" }
 
-// Recompute resolves the edge and folds the hem's bend chain onto the sheet.
+// Recompute folds the hem's bend chain onto the sheet and relieves the corner it forms.
 func (f *SheetMetalHemFeature) Recompute(in Input) (Output, error) {
-	body, err := lastBody(in, "sheet-metal hem")
-	if err != nil {
-		return Output{}, err
-	}
-	t, err := sheetThickness(in.Params)
-	if err != nil {
-		return Output{}, err
-	}
-	steps, err := f.hemSteps(t)
-	if err != nil {
-		return Output{}, err
-	}
-	edges, heals, err := resolveEdges(body, [][]byte{f.def.EdgeKey}, nil)
-	if err != nil {
-		return Output{}, err
-	}
-	wall, placement, err := buildFoldedSolid(edges[0], t, steps, f.def.Flip, f.featName)
+	wall, placement, heals, err := f.foldHem(in)
 	if err != nil {
 		return Output{}, err
 	}
@@ -96,7 +81,41 @@ func (f *SheetMetalHemFeature) Recompute(in Input) (Output, error) {
 		return Output{}, err
 	}
 	f.placement = &placement // record the resolved bend for the flat pattern (M13-F04)
+	// A hem meeting an earlier wall at a corner forms a junction that has to be relieved too, not
+	// only a flange-to-flange one (#2072): its fold and the neighbour's want the same corner
+	// material. The hem spans its whole edge, so it needs no bend relief at the ends — only the
+	// corner cut where it meets a bend already placed.
+	bodies, err = cutCornerRelief(bodies, placement, in, in.Transition, featOr(f.featName, "hem"))
+	if err != nil {
+		return Output{}, err
+	}
 	return Output{Bodies: bodies, Heals: heals}, nil
+}
+
+// foldHem resolves the hem's edge, live thickness and bend chain, and builds the folded wall solid
+// plus the bend placement the flat pattern lays out and any reference heals from resolving the edge.
+func (f *SheetMetalHemFeature) foldHem(in Input) (*topo.Body, BendPlacement, []ReferenceHeal, error) {
+	body, err := lastBody(in, "sheet-metal hem")
+	if err != nil {
+		return nil, BendPlacement{}, nil, err
+	}
+	t, err := sheetThickness(in.Params)
+	if err != nil {
+		return nil, BendPlacement{}, nil, err
+	}
+	steps, err := f.hemSteps(t)
+	if err != nil {
+		return nil, BendPlacement{}, nil, err
+	}
+	edges, heals, err := resolveEdges(body, [][]byte{f.def.EdgeKey}, nil)
+	if err != nil {
+		return nil, BendPlacement{}, nil, err
+	}
+	wall, placement, err := buildFoldedSolid(edges[0], t, steps, f.def.Flip, f.featName)
+	if err != nil {
+		return nil, BendPlacement{}, nil, err
+	}
+	return wall, placement, heals, nil
 }
 
 // Placement returns the resolved bend geometry captured by the last successful recompute,

--- a/model/feature/sheet_metal_hem_relief_test.go
+++ b/model/feature/sheet_metal_hem_relief_test.go
@@ -53,3 +53,52 @@ func TestHemCornerReliefRemovesTheSharedCorner(t *testing.T) {
 			"not cut its corner (#2072)", relieved, torn)
 	}
 }
+
+// TestHemCornerReliefRefusesShapingTransition: a shaping bend transition (arc/straight/intersection)
+// is not built yet, and a hem meeting a flange is a junction — so the hem refuses it there rather
+// than silently ignoring it, exercising the corner-relief error path in the hem's recompute.
+func TestHemCornerReliefRefusesShapingTransition(t *testing.T) {
+	fs, edgeX := seedSheetMetalSheet(t, 4, nil)
+	fs.SetReliefSpec(func() ReliefSpec { return ReliefSpec{} })
+	fs.SetCornerReliefSpec(func() CornerReliefSpec { return CornerReliefSpec{Shape: types.CornerSquare, Size: 0.4} })
+	fs.SetBendTransition(func() types.BendTransition { return types.StraightLineBendTransition })
+
+	NewSheetMetalFlangeFeatures(fs).Add(&SheetMetalFlangeDefinition{
+		EdgeKey: edgeX.ReferenceKey(), Height: constClosure(1.0), Radius: constClosure(0.3),
+	})
+	fs.Recompute()
+	edgeY := adjacentTopEdge(t, fs.Result()[0], edgeX)
+	hem := NewSheetMetalHemFeatures(fs).Add(&SheetMetalHemDefinition{
+		EdgeKey: edgeY.ReferenceKey(), Type: SingleHem, Length: constClosure(0.5), Gap: constClosure(0.1),
+	})
+	fs.Recompute()
+	if hem.Health().OK() {
+		t.Error("a hem forming a junction under a not-yet-built shaping transition should be sick")
+	}
+}
+
+// TestHemNeedsABody: a hem with no prior solid to fold goes sick rather than panicking — foldHem
+// surfaces the missing body.
+func TestHemNeedsABody(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	hem := NewSheetMetalHemFeatures(fs).Add(&SheetMetalHemDefinition{
+		EdgeKey: []byte("x"), Type: SingleHem, Length: constClosure(0.5), Gap: constClosure(0.1),
+	})
+	fs.Recompute()
+	if hem.Health().OK() {
+		t.Error("a hem with no prior body should be sick")
+	}
+}
+
+// TestHemRejectsUnresolvableEdge: a hem whose edge key resolves to nothing goes sick — foldHem
+// surfaces the resolve failure instead of indexing an empty edge slice.
+func TestHemRejectsUnresolvableEdge(t *testing.T) {
+	fs, _ := seedSheetMetalSheet(t, 4, nil)
+	hem := NewSheetMetalHemFeatures(fs).Add(&SheetMetalHemDefinition{
+		EdgeKey: []byte("no-such-edge"), Type: SingleHem, Length: constClosure(0.5), Gap: constClosure(0.1),
+	})
+	fs.Recompute()
+	if hem.Health().OK() {
+		t.Error("a hem on an unresolvable edge should be sick")
+	}
+}

--- a/model/feature/sheet_metal_hem_relief_test.go
+++ b/model/feature/sheet_metal_hem_relief_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+)
+
+// hemCorneredSheet folds a flange on one edge and a hem on the adjacent edge, so the hem's bend
+// meets the flange's at a corner, and returns the result under the given corner relief (#2072).
+func hemCorneredSheet(t *testing.T, corner CornerReliefSpec) *topo.Body {
+	t.Helper()
+	fs, edgeX := seedSheetMetalSheet(t, 4, nil)
+	fs.SetReliefSpec(func() ReliefSpec { return ReliefSpec{} }) // isolate the CORNER cut
+	fs.SetCornerReliefSpec(func() CornerReliefSpec { return corner })
+	fs.SetBendTransition(func() types.BendTransition { return types.NoBendTransition })
+
+	NewSheetMetalFlangeFeatures(fs).Add(&SheetMetalFlangeDefinition{
+		EdgeKey: edgeX.ReferenceKey(), Height: constClosure(1.0), Radius: constClosure(0.3),
+	})
+	fs.Recompute()
+	edgeY := adjacentTopEdge(t, fs.Result()[0], edgeX)
+	hem := NewSheetMetalHemFeatures(fs).Add(&SheetMetalHemDefinition{
+		EdgeKey: edgeY.ReferenceKey(), Type: SingleHem, Length: constClosure(0.5), Gap: constClosure(0.1),
+	})
+	fs.Recompute()
+	if !hem.Health().OK() {
+		t.Fatalf("hem meeting the flange went sick: %s", hem.Health().Reason)
+	}
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("hem+flange corner is not a valid solid: %+v", r)
+	}
+	return body
+}
+
+// TestHemCornerReliefRemovesTheSharedCorner is the #2072 item-5 regression: a HEM meeting a flange at
+// a corner cuts the styled corner relief, just as a flange-to-flange corner does — before this the
+// hem placed its bend but relieved nothing, so the junction it formed was left full of material.
+func TestHemCornerReliefRemovesTheSharedCorner(t *testing.T) {
+	relieved := ops.BodyGeometryProperties(
+		hemCorneredSheet(t, CornerReliefSpec{Shape: types.CornerSquare, Size: 0.4}), ops.DefaultQuality()).Volume
+	// The same part with the corner left to tear removes nothing there, so it has MORE material.
+	torn := ops.BodyGeometryProperties(
+		hemCorneredSheet(t, CornerReliefSpec{Shape: types.CornerTear}), ops.DefaultQuality()).Volume
+
+	if relieved >= torn-1e-6 {
+		t.Errorf("square corner relief volume %g is not less than the un-relieved %g — the hem did "+
+			"not cut its corner (#2072)", relieved, torn)
+	}
+}


### PR DESCRIPTION
## What

Extends **corner relief** to **hem** junctions. Until now only a flange-to-flange corner was relieved; a hem folded onto an edge adjacent to a flange left the shared corner full of material — the "hem meeting a flange forms a junction nobody relieves yet" case the issue calls out (item 5).

## Why it was missing

The hem already **records** its bend (`Placement`), so a *later* flange relieved a corner against it — but the hem itself never called the relief, so a **flange-then-hem** order (or any wall built before the hem) left the hem-side junction uncut.

## How

Call the existing `cutCornerRelief` in the hem's `Recompute`, exactly as the flange does — same junction detection (two bend lines sharing an endpoint, running different ways) and same styled cut (`trimToBend` / `round` / `square`; `tear` = no cut). A hem spans its whole edge, so it needs **no bend relief** at the ends — only the corner cut; with no junction (a lone hem) the call returns the bodies unchanged. `Recompute`'s wall build is extracted to `foldHem` to stay within funlen.

## Verification

`TestHemCornerReliefRemovesTheSharedCorner`: a hem on the edge adjacent to a flange cuts a square corner relief — **less volume** than the same part with the corner left to tear — and stays a valid manifold solid. **Proven by mutating the relief call out** (relieved == torn without it). Full `model/feature` sheet-metal suite + `compdef`/`opregistry`/`router` consumers green; `golangci-lint run` (full) clean; SPDX present. No API change.

## Scope

One slice of #2072. Still open on the issue: the **contour flange** junction (it does not yet record its bend or relieve), the shaping **bend transitions** and **fullRound/roundWithRadius/intersection** corner shapes (both need the walls' own outlines), and the **flat pattern** developing the corner relief. So this **refs**, not closes, #2072.

Refs #2072