### PR TITLE
Piston-head modelling: analytic swept geometry, offset parity, region selection (#2165/#2164/#2158-2160/#2019)

### DIFF
--- a/app/extrude_multiselect_test.go
+++ b/app/extrude_multiselect_test.go
@@ -100,6 +100,34 @@ func (p coordPicker) Pick(x, _ float64, filter *SelectionFilter) (Selectable, bo
 	return sel, true
 }
 
+// TestRegionModifierHintAddRemove: with a region tool active and Ctrl held, the cursor hint is ADD
+// over an unpicked region and REMOVE over an already-picked one — the +/− the head badges the cursor
+// with — and nothing without a modifier or without an active region tool.
+func TestRegionModifierHintAddRemove(t *testing.T) {
+	s, r0, r1 := newPartWithTwoSquares(t, 2, 10)
+	s.SetPicker(coordPicker{left: r0, right: r1, split: 100})
+
+	// No active tool → no hint even with Ctrl over a region.
+	if show, _ := s.RegionModifierHint(10, 10, CtrlMod); show {
+		t.Error("no tool active: expected no cursor hint")
+	}
+	ext := NewExtrudeTool()
+	s.StartTool(ext)
+	ext.Pick(s, r0) // region 0 is now picked
+
+	if show, _ := s.RegionModifierHint(10, 10, 0); show {
+		t.Error("no modifier held: expected no cursor hint")
+	}
+	show, add := s.RegionModifierHint(10, 10, CtrlMod) // over the already-picked region 0
+	if !show || add {
+		t.Errorf("over a picked region: show=%v add=%v, want show=true add=false (REMOVE)", show, add)
+	}
+	show, add = s.RegionModifierHint(200, 10, CtrlMod) // over the unpicked region 1
+	if !show || !add {
+		t.Errorf("over an unpicked region: show=%v add=%v, want show=true add=true (ADD)", show, add)
+	}
+}
+
 func TestExtrudeCtrlClickThroughPointerCapturesBothRegions(t *testing.T) {
 	s, r0, r1 := newPartWithTwoSquares(t, 2, 10)
 	s.SetPicker(coordPicker{left: r0, right: r1, split: 100})

--- a/app/scroll_viewport_test.go
+++ b/app/scroll_viewport_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/scene"
+)
+
+// eyeTargetDist is the camera's look-at distance — what a wheel-zoom dolly changes.
+func eyeTargetDist(c scene.Camera) float64 { return float64(c.Eye.DistanceTo(c.Target)) }
+
+// scrollSession returns a session looking down −Z from (0,0,10) at the origin.
+func scrollSession(t *testing.T) *Session {
+	t.Helper()
+	s := NewSession()
+	cam := scene.NewCamera(200, 200)
+	cam.Eye, cam.Target, cam.Up = math.P3(0, 0, 10), math.P3(0, 0, 0), math.V3(0, 1, 0)
+	s.SetCamera(cam)
+	return s
+}
+
+// TestScrollViewportZoomsIn: a positive dy notch dollies the camera closer (zoom in).
+func TestScrollViewportZoomsIn(t *testing.T) {
+	s := scrollSession(t)
+	before := eyeTargetDist(s.Camera())
+	s.ScrollViewport(0, 1, 100, 100)
+	if after := eyeTargetDist(s.Camera()); after >= before {
+		t.Errorf("distance after a +dy scroll = %.4f, want < %.4f (zoom in)", after, before)
+	}
+}
+
+// TestScrollViewportZeroDeltaNoOp: dy=0 leaves the camera untouched, even with a non-zero dx —
+// dx carries no default binding.
+func TestScrollViewportZeroDeltaNoOp(t *testing.T) {
+	s := scrollSession(t)
+	before := s.Camera()
+	s.ScrollViewport(3, 0, 100, 100)
+	if got := s.Camera(); got.Eye != before.Eye || got.Target != before.Target {
+		t.Errorf("camera moved on a zero-dy scroll: eye %v→%v", before.Eye, got.Eye)
+	}
+}
+
+// TestScrollViewportWheelInvertFlipsDirection: with Wheel Invert set, a positive dy zooms OUT.
+func TestScrollViewportWheelInvertFlipsDirection(t *testing.T) {
+	s := scrollSession(t)
+	if err := s.SetWheelInvert(true); err != nil {
+		t.Fatalf("SetWheelInvert: %v", err)
+	}
+	before := eyeTargetDist(s.Camera())
+	s.ScrollViewport(0, 1, 100, 100)
+	if after := eyeTargetDist(s.Camera()); after <= before {
+		t.Errorf("with wheel-invert, distance after +dy = %.4f, want > %.4f (zoom out)", after, before)
+	}
+}
+
+// TestScrollViewportZoomToCursorStillZooms: the zoom-toward-cursor branch also dollies in on a
+// positive dy (it aims the zoom at the pixel rather than the view centre).
+func TestScrollViewportZoomToCursorStillZooms(t *testing.T) {
+	s := scrollSession(t)
+	if err := s.SetZoomToCursor(true); err != nil {
+		t.Fatalf("SetZoomToCursor: %v", err)
+	}
+	before := eyeTargetDist(s.Camera())
+	s.ScrollViewport(0, 2, 40, 160)
+	if after := eyeTargetDist(s.Camera()); after >= before {
+		t.Errorf("zoom-to-cursor distance after +dy = %.4f, want < %.4f", after, before)
+	}
+}

--- a/app/selecting.go
+++ b/app/selecting.go
@@ -95,3 +95,37 @@ func (s *Session) ToolPicks() []Selectable {
 	}
 	return nil
 }
+
+// RegionModifierHint reports what a MODIFIED click at pixel (x,y) would do to the region under the
+// cursor, so the head can badge the cursor with a + (add) or − (remove) during area selection —
+// exactly Inventor's add/remove cursor feedback. show is false unless the active tool is a region
+// multi-select tool (one that honours the modifier, [modifierPicker]), a modifier is held, and a
+// region is under the cursor; add is true when that region is not yet picked (a modified click would
+// ADD it) and false when it is already picked (the click would REMOVE it).
+func (s *Session) RegionModifierHint(x, y float64, mods Modifier) (show, add bool) {
+	if s.tool == nil || (!mods.Has(CtrlMod) && !mods.Has(ShiftMod)) {
+		return false, false
+	}
+	if _, ok := s.tool.tool.(modifierPicker); !ok {
+		return false, false
+	}
+	sel, ok := s.PickAt(x, y, s.pickFilter())
+	if !ok {
+		return false, false
+	}
+	if _, ok := sel.(ProfileHandle); !ok {
+		return false, false // the +/− badge is for area (region) selection only
+	}
+	return true, !s.toolAlreadyPicked(sel)
+}
+
+// toolAlreadyPicked reports whether sel is among the active tool's current picks (so a modified click
+// would toggle it off rather than add it).
+func (s *Session) toolAlreadyPicked(sel Selectable) bool {
+	for _, p := range s.ToolPicks() {
+		if p == sel {
+			return true
+		}
+	}
+	return false
+}

--- a/app/session_input.go
+++ b/app/session_input.go
@@ -328,6 +328,12 @@ func (s *Session) toolPicksModelReferences() bool {
 	return ok && mr.PicksModelReferences()
 }
 
+// ToolPicksModelReferences is the exported form the head reads to decide whether to draw the
+// model-reference hover highlight while a sketch is being edited: a tool like Project Geometry
+// picks B-rep faces/edges from the viewport during sketch edit (#1496/#2158), so the head must
+// show what will be projected — the sketch overlay path otherwise draws only sketch-entity feedback.
+func (s *Session) ToolPicksModelReferences() bool { return s.toolPicksModelReferences() }
+
 // pickModelReferenceInSketch runs the 3D hit-test for an in-sketch reference-picking tool and
 // feeds any hit — a B-rep face, edge or vertex, or datum geometry — to the tool, so model geometry
 // becomes projectable from the viewport while editing a sketch (#1496, faces #2158). The kinds a

--- a/app/session_input.go
+++ b/app/session_input.go
@@ -329,9 +329,11 @@ func (s *Session) toolPicksModelReferences() bool {
 }
 
 // pickModelReferenceInSketch runs the 3D hit-test for an in-sketch reference-picking tool and
-// feeds any hit (a B-rep edge/vertex or datum) to the tool, so model geometry becomes projectable
-// from the viewport while editing a sketch (#1496). A miss is ignored — there is no ambient sketch
-// selection to clear, and the tool keeps waiting for a reference.
+// feeds any hit — a B-rep face, edge or vertex, or datum geometry — to the tool, so model geometry
+// becomes projectable from the viewport while editing a sketch (#1496, faces #2158). The kinds a
+// hit can resolve to are exactly the tool's AcceptedKinds (installed as the pick filter), which is
+// also what the hover highlight uses, so what lights up on hover is what a click projects. A miss
+// is ignored — there is no ambient sketch selection to clear, and the tool keeps waiting.
 func (s *Session) pickModelReferenceInSketch(e PointerEvent) {
 	if s.picker == nil {
 		return

--- a/app/sketch_constraint_tools.go
+++ b/app/sketch_constraint_tools.go
@@ -120,9 +120,8 @@ func midpointPicked(picks []constraintPick) bool {
 }
 
 // Entity-kind acceptance predicates.
-func acceptPoints(e sketch.Entity) bool  { _, ok := e.(*sketch.Point); return ok }
-func acceptLines(e sketch.Entity) bool   { _, ok := e.(*sketch.Line); return ok }
-func acceptCircles(e sketch.Entity) bool { _, ok := e.(*sketch.Circle); return ok }
+func acceptPoints(e sketch.Entity) bool { _, ok := e.(*sketch.Point); return ok }
+func acceptLines(e sketch.Entity) bool  { _, ok := e.(*sketch.Line); return ok }
 
 // acceptCircular accepts any circular curve — a circle or an arc.
 func acceptCircular(e sketch.Entity) bool {
@@ -145,7 +144,10 @@ func acceptCoincident(e sketch.Entity) bool {
 }
 
 func acceptDimensionable(e sketch.Entity) bool {
-	return acceptPoints(e) || acceptLines(e) || acceptCircles(e)
+	// Circular means circle OR arc: an arc dimensions its radius exactly like a circle, but matching
+	// only *Circle meant the tool never picked an arc, so an arc could not be radius-dimensioned at
+	// all (#2160-adjacent).
+	return acceptPoints(e) || acceptLines(e) || acceptCircular(e)
 }
 
 // readyCoincident is satisfied by two points, or a point plus a line/circle/arc.

--- a/app/sketch_constraints.go
+++ b/app/sketch_constraints.go
@@ -42,16 +42,6 @@ func filterLines(ents []sketch.Entity) []*sketch.Line {
 	return out
 }
 
-func filterCircles(ents []sketch.Entity) []*sketch.Circle {
-	var out []*sketch.Circle
-	for _, e := range ents {
-		if c, ok := e.(*sketch.Circle); ok {
-			out = append(out, c)
-		}
-	}
-	return out
-}
-
 // circularCurvesFrom returns the circular curves (circles and arcs) among ents, in pick
 // order, as the polymorphic [sketch.CircularCurve] the circular constraints accept — so
 // concentric/tangent/equal/coincident treat an arc exactly like a circle.
@@ -275,9 +265,11 @@ func addDimensionFor(dims *sketch.DimensionConstraints, units param.UnitsOfMeasu
 func addPlacedDimensionFor(dims *sketch.DimensionConstraints, units param.UnitsOfMeasure, ents []sketch.Entity,
 	at math.Point2, placed bool) (*sketch.DimensionConstraint, error) {
 	switch {
-	case len(filterCircles(ents)) >= 1:
-		c := filterCircles(ents)[0]
-		return dims.AddRadius(c, lengthExpr(units, c.Radius))
+	case len(circularCurvesFrom(ents)) >= 1:
+		// Both a circle and an arc are CircularCurves and dimension their radius the same way;
+		// matching only *Circle here silently dropped an arc's radius dimension (#2160-adjacent).
+		c := circularCurvesFrom(ents)[0]
+		return dims.AddRadius(c, lengthExpr(units, c.CurveRadius()))
 	case len(filterLines(ents)) >= 2:
 		l := filterLines(ents)
 		return dims.AddAngle(l[0], l[1], angleExpr(units, lineAngle(l[0], l[1])))

--- a/app/sketch_dimension_tool.go
+++ b/app/sketch_dimension_tool.go
@@ -147,7 +147,9 @@ func (t *DimensionTool) contains(e sketch.Entity) bool {
 // dimensionComplete reports whether the picks already describe a dimension: a circle (radius),
 // a line (length) or two lines (angle), or two points (distance). One point alone does not.
 func dimensionComplete(ents []sketch.Entity) bool {
-	if len(filterCircles(ents)) >= 1 || len(filterLines(ents)) >= 1 {
+	// A single circular curve (circle OR arc) is a complete radius dimension; matching circles only
+	// left an arc pick "incomplete", so the tool never placed its radius dimension (#2160-adjacent).
+	if len(circularCurvesFrom(ents)) >= 1 || len(filterLines(ents)) >= 1 {
 		return true
 	}
 	return len(filterPoints(ents)) >= 2

--- a/app/sketch_dimension_tool_test.go
+++ b/app/sketch_dimension_tool_test.go
@@ -149,6 +149,25 @@ func TestCircleRadiusDimension(t *testing.T) {
 	}
 }
 
+// TestArcRadiusDimension is the #2160-adjacent regression: the general Dimension tool must give an
+// ARC a radius dimension, exactly as it does a circle. The auto-dimension branch matched only
+// *Circle, so picking an arc fell through to the point/line path and produced no radius dimension —
+// "radius dim not respected on arcs". An arc is a CircularCurve like a circle, so it dimensions the
+// same way.
+func TestArcRadiusDimension(t *testing.T) {
+	s, sk := sketchSession(t)
+	// CCW arc of radius 2 centred at the origin, from (2,0) to (0,2) — its midpoint is (√2,√2).
+	sk.Arcs().AddByCenterStartEnd(math.P2(0, 0), math.P2(2, 0), math.P2(0, 2), true)
+
+	s.StartTool(NewDimensionTool())
+	clickSketch(t, s, math.P2(1.41421356, 1.41421356)) // on the arc
+	clickSketch(t, s, math.P2(4, 4))                   // place
+
+	if got := dimKinds(sk); len(got) != 1 || got[0] != sketch.RadiusDim {
+		t.Fatalf("an arc gave %v, want [RadiusDim] — the arc must dimension its radius like a circle", got)
+	}
+}
+
 // TestPlacementClickNearGeometryDoesNotAbsorbIt: once the pick set is complete and cannot be
 // extended, clicking near other geometry places the label instead of silently adding that
 // entity — otherwise placing a label over a busy sketch would build the wrong dimension.

--- a/app/sketch_drag.go
+++ b/app/sketch_drag.go
@@ -56,14 +56,26 @@ func (s *Session) BeginEntityDrag(px, py float64) bool {
 	return true
 }
 
-// draggableForMode reports whether ent may be direct-dragged in the current mode. Normally
-// only MoveableFree geometry drags (fixed / fully-dimensioned entities click-select instead);
-// in Relax Mode any entity drags, because the solver relaxes the dimensions holding it (#791).
+// draggableForMode reports whether ent may be direct-dragged in the current mode. MoveableFree
+// geometry always drags. A determined entity (MoveableByDimensionChange) drags only when it is held
+// by geometric constraints, not by a driving dimension: a fillet arc tangent to two under-
+// constrained lines was wrongly refused before, even though the sketch was under-constrained
+// (#2160), and drags now — its soft drag pins (sketch.dragFix) yield to the tangency and move the
+// arc within the sketch's remaining freedom. A fully-dimensioned entity stays Relax Mode's job
+// (dragging it normally would only fight the dimension); a truly fixed entity click-selects. In
+// Relax Mode any entity drags, the solver relaxing the dimensions holding it (#791).
 func (s *Session) draggableForMode(ent sketch.Entity) bool {
 	if s.relaxMode {
 		return true
 	}
-	return s.activeSketch.MoveableClassifier().Of(ent) == types.MoveableFree
+	switch s.activeSketch.MoveableClassifier().Of(ent) {
+	case types.MoveableFree:
+		return true
+	case types.MoveableByDimensionChange:
+		return !s.activeSketch.HasDrivingDimensionOn(ent)
+	default: // MoveableFixed, MoveableUnknown
+		return false
+	}
 }
 
 // dragAnchors collects the distinct points to pin while dragging — the defining points of every

--- a/app/sketch_drag_dimensioned_test.go
+++ b/app/sketch_drag_dimensioned_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/api/types"
+	"oblikovati.org/math"
+)
+
+// TestDraggableForModeByGeometryNotDimension is the #2160 (symptom A) gate change. A determined
+// entity is now direct-draggable when geometric constraints hold it (the fillet-arc case) but still
+// refused when a driving dimension holds it (that stays Relax Mode's job), and a Fix-pinned entity
+// never drags. All three land in the same MoveableByDimensionChange/Fixed classes, so the gate
+// distinguishes them by whether a driving dimension acts on the entity.
+func TestDraggableForModeByGeometryNotDimension(t *testing.T) {
+	s, sk := sketchSession(t)
+
+	// A Fix-pinned point click-selects, never drags.
+	fixed := sk.Points().Add(math.P2(3, 3))
+	sk.GeometricConstraints().AddFix(fixed)
+	if s.draggableForMode(fixed) {
+		t.Error("a Fix-pinned point must not be direct-draggable")
+	}
+
+	// A point determined purely by geometry (coincident to a fixed point, no dimension) drags now —
+	// the fillet-arc class the gate used to refuse.
+	geom := sk.Points().Add(math.P2(3, 3))
+	sk.GeometricConstraints().AddCoincident(geom, fixed)
+	if got := sk.MoveableStatus(geom); got != types.MoveableByDimensionChange {
+		t.Fatalf("setup: geometrically-determined point should be byDimensionChange, got %v", got)
+	}
+	if !s.draggableForMode(geom) {
+		t.Error("a geometrically-determined entity must be direct-draggable now (#2160)")
+	}
+
+	// A point held by a driving dimension stays Relax Mode's job — a normal drag is refused.
+	anchor := sk.Points().Add(math.P2(0, 0))
+	sk.GeometricConstraints().AddFix(anchor)
+	dp := sk.Points().Add(math.P2(2, 0))
+	sk.GeometricConstraints().AddHorizontal(anchor, dp)
+	if _, err := sk.DimensionConstraints().AddDistance(anchor, dp, "2 cm"); err != nil {
+		t.Fatalf("AddDistance: %v", err)
+	}
+	if s.draggableForMode(dp) {
+		t.Error("a dimension-determined entity must stay Relax Mode's job, not a normal drag")
+	}
+}

--- a/app/sketch_modify_tools.go
+++ b/app/sketch_modify_tools.go
@@ -116,10 +116,11 @@ func NewSketchOffsetTool(distance float64) *SketchOffsetTool {
 func (t *SketchOffsetTool) Name() string                  { return "Offset" }
 func (t *SketchOffsetTool) Pick(_ *Session, s Selectable) { t.take(s) }
 
-// Accepts highlights the curves OffsetEntity handles: line, circle, arc. Uses the entity's
-// Kind() capability via entityKindIs, not a type switch, per the sketch-entity seam (#1624).
+// Accepts highlights the curves OffsetEntity handles: line, circle, arc, and a projected reference
+// curve (a projected face perimeter or edge, offset as a polyline — #2158 follow-up). Uses the
+// entity's Kind() capability via entityKindIs, not a type switch, per the sketch-entity seam (#1624).
 func (t *SketchOffsetTool) Accepts(e sketch.Entity) bool {
-	return entityKindIs(e, sketch.LineKind, sketch.CircleKind, sketch.ArcKind)
+	return entityKindIs(e, sketch.LineKind, sketch.CircleKind, sketch.ArcKind, sketch.ProjectedCurveKind)
 }
 func (t *SketchOffsetTool) CanCommit() bool        { return t.ready() }
 func (t *SketchOffsetTool) AutoCommitOnPick() bool { return true }

--- a/app/sketch_modify_tools.go
+++ b/app/sketch_modify_tools.go
@@ -164,6 +164,31 @@ func (t *SketchOffsetTool) ConstrainOffset() bool      { return t.constrainOffse
 func (t *SketchOffsetTool) SetConstrainOffset(on bool) { t.constrainOffset = on }
 func (t *SketchOffsetTool) ToggleConstrainOffset()     { t.constrainOffset = !t.constrainOffset }
 
+// The offset option labels, shared by the right-click menu and its toggle handler so the two never
+// drift.
+const (
+	offsetLoopSelectLabel      = "Loop Select"
+	offsetConstrainOffsetLabel = "Constrain Offset"
+)
+
+// MenuOptions surfaces Inventor's two Offset right-click toggles as checkable rows.
+func (t *SketchOffsetTool) MenuOptions() []ToolMenuOption {
+	return []ToolMenuOption{
+		{Label: offsetLoopSelectLabel, Checked: t.loopSelect},
+		{Label: offsetConstrainOffsetLabel, Checked: t.constrainOffset},
+	}
+}
+
+// ToggleMenuOption flips the option the user chose from the right-click menu.
+func (t *SketchOffsetTool) ToggleMenuOption(label string) {
+	switch label {
+	case offsetLoopSelectLabel:
+		t.ToggleLoopSelect()
+	case offsetConstrainOffsetLabel:
+		t.ToggleConstrainOffset()
+	}
+}
+
 // Accepts highlights the curves OffsetEntity handles: line, circle, arc, and a projected reference
 // curve (a projected face perimeter or edge, offset as a polyline — #2158 follow-up). Uses the
 // entity's Kind() capability via entityKindIs, not a type switch, per the sketch-entity seam (#1624).

--- a/app/sketch_modify_tools.go
+++ b/app/sketch_modify_tools.go
@@ -55,6 +55,8 @@ var (
 	_ SketchEntityTool = (*SketchFilletTool)(nil)
 	_ SketchEntityTool = (*SketchOffsetTool)(nil)
 	_ SketchEntityTool = (*SketchMirrorTool)(nil)
+	// Offset draws a live preview ghost of the offset, so it is a RecipeTool (the head's preview path).
+	_ RecipeTool = (*SketchOffsetTool)(nil)
 )
 
 // SketchFilletTool rounds the corner between two picked lines with a tangent arc.
@@ -112,6 +114,7 @@ type SketchOffsetTool struct {
 	constrainOffset bool        // Inventor default: constrain the offset associative to its source
 	placement       math.Point2 // where the user clicked to place the offset (its side + distance)
 	placed          bool
+	sk              *sketch.Sketch // the sketch the seed was picked in (for whole-loop highlight + preview)
 }
 
 // NewSketchOffsetTool makes an offset tool with the given default distance and both Loop Select and
@@ -125,8 +128,37 @@ func NewSketchOffsetTool(distance float64) *SketchOffsetTool {
 	}
 }
 
-func (t *SketchOffsetTool) Name() string                  { return "Offset" }
-func (t *SketchOffsetTool) Pick(_ *Session, s Selectable) { t.take(s) }
+func (t *SketchOffsetTool) Name() string { return "Offset" }
+func (t *SketchOffsetTool) Pick(sess *Session, s Selectable) {
+	t.take(s)
+	if len(t.picks) > 0 {
+		t.sk = sess.ActiveSketch()
+	}
+}
+
+// Picked highlights the WHOLE connected loop from the picked seed when Loop Select is on (Inventor
+// lights the whole profile, not one segment); with it off, only the seed. The commit still seeds from
+// picks[0] — this only widens what is drawn as selected.
+func (t *SketchOffsetTool) Picked() []sketch.Entity {
+	if !t.loopSelect || len(t.picks) == 0 || t.sk == nil {
+		return t.picks
+	}
+	path, ok := t.sk.ConnectedChainFrom(t.picks[0])
+	if !ok || path.Count() <= 1 {
+		return t.picks
+	}
+	return chainEntities(path)
+}
+
+// chainEntities extracts a connected chain's entities in traversal order.
+func chainEntities(path *sketch.Path) []sketch.Entity {
+	ents := path.Entities()
+	out := make([]sketch.Entity, len(ents))
+	for i, pe := range ents {
+		out[i] = pe.Entity
+	}
+	return out
+}
 
 // ClickAt drives Inventor's two-step flow: the first click selects the geometry to offset, then the
 // user moves the cursor and clicks to place the offset copy — the placement click's side and its
@@ -139,6 +171,7 @@ func (t *SketchOffsetTool) ClickAt(s *Session, px, py float64) {
 	if len(t.picks) == 0 {
 		if ent, ok := s.pickSketchEntity(px, py); ok && t.Accepts(ent) {
 			t.takeEntity(ent)
+			t.sk = s.ActiveSketch()
 		}
 		return
 	}
@@ -196,7 +229,7 @@ func (t *SketchOffsetTool) Accepts(e sketch.Entity) bool {
 	return entityKindIs(e, sketch.LineKind, sketch.CircleKind, sketch.ArcKind, sketch.ProjectedCurveKind)
 }
 func (t *SketchOffsetTool) CanCommit() bool { return t.ready() }
-func (t *SketchOffsetTool) Cancel(*Session) { t.reset(); t.placed = false }
+func (t *SketchOffsetTool) Cancel(*Session) { t.reset(); t.placed = false; t.sk = nil }
 func (t *SketchOffsetTool) Prompt(*Session) string {
 	if len(t.picks) == 0 {
 		return "Select geometry to offset"
@@ -233,6 +266,7 @@ func (t *SketchOffsetTool) Commit(s *Session) error {
 		}
 		if t.constrainOffset {
 			sk.ConstrainOffsetSingle(t.picks[0], off)
+			sk.AddOffsetSingleDimension(t.picks[0], off) // Inventor's offset dimension, driving the distance
 		}
 		return nil
 	}
@@ -241,7 +275,9 @@ func (t *SketchOffsetTool) Commit(s *Session) error {
 		return err
 	}
 	if t.constrainOffset {
-		sk.ConstrainOffsetLoop(path, offsets)
+		// One driving offset dimension binds the whole loop uniformly (Inventor): editing it moves
+		// every segment together (driven offset constraints on the non-dimensioned lines).
+		sk.ConstrainOffsetLoopUniform(path, offsets)
 	}
 	return nil
 }

--- a/app/sketch_modify_tools.go
+++ b/app/sketch_modify_tools.go
@@ -107,16 +107,22 @@ func (t *SketchFilletTool) Commit(s *Session) error {
 type SketchOffsetTool struct {
 	dialogTool
 	pickCollector
-	distance   math.Scalar
-	loopSelect bool       // Inventor default: offset the whole connected loop, not just the picked curve
-	placement  math.Point2 // where the user clicked to place the offset (its side + distance)
-	placed     bool
+	distance        math.Scalar
+	loopSelect      bool        // Inventor default: offset the whole connected loop, not just the picked curve
+	constrainOffset bool        // Inventor default: constrain the offset associative to its source
+	placement       math.Point2 // where the user clicked to place the offset (its side + distance)
+	placed          bool
 }
 
-// NewSketchOffsetTool makes an offset tool with the given default distance and Loop Select on, as
-// Inventor defaults.
+// NewSketchOffsetTool makes an offset tool with the given default distance and both Loop Select and
+// Constrain Offset on, as Inventor defaults.
 func NewSketchOffsetTool(distance float64) *SketchOffsetTool {
-	return &SketchOffsetTool{pickCollector: pickCollector{want: 1}, distance: math.Scalar(distance), loopSelect: true}
+	return &SketchOffsetTool{
+		pickCollector:   pickCollector{want: 1},
+		distance:        math.Scalar(distance),
+		loopSelect:      true,
+		constrainOffset: true,
+	}
 }
 
 func (t *SketchOffsetTool) Name() string                  { return "Offset" }
@@ -151,6 +157,12 @@ func (t *SketchOffsetTool) AutoCommits() bool { return t.placed }
 func (t *SketchOffsetTool) LoopSelect() bool      { return t.loopSelect }
 func (t *SketchOffsetTool) SetLoopSelect(on bool) { t.loopSelect = on }
 func (t *SketchOffsetTool) ToggleLoopSelect()     { t.loopSelect = !t.loopSelect }
+
+// ConstrainOffset reports whether the offset is constrained associative to its source (Inventor's
+// default — parallel lines, concentric arcs, joined corners); the right-click menu toggles it.
+func (t *SketchOffsetTool) ConstrainOffset() bool      { return t.constrainOffset }
+func (t *SketchOffsetTool) SetConstrainOffset(on bool) { t.constrainOffset = on }
+func (t *SketchOffsetTool) ToggleConstrainOffset()     { t.constrainOffset = !t.constrainOffset }
 
 // Accepts highlights the curves OffsetEntity handles: line, circle, arc, and a projected reference
 // curve (a projected face perimeter or edge, offset as a polyline — #2158 follow-up). Uses the
@@ -190,11 +202,23 @@ func (t *SketchOffsetTool) Commit(s *Session) error {
 	// OffsetConnectedLoop is for a multi-curve chain, and OffsetEntity keeps a single line/arc/circle
 	// analytic. ConnectedChainFrom returns ok for ANY curve, so the count, not ok, gates the loop path.
 	if !t.loopSelect || !ok || path.Count() <= 1 {
-		_, err := sk.OffsetEntity(t.picks[0], math.Scalar(t.singleDistance()))
+		off, err := sk.OffsetEntity(t.picks[0], math.Scalar(t.singleDistance()))
+		if err != nil {
+			return err
+		}
+		if t.constrainOffset {
+			sk.ConstrainOffsetSingle(t.picks[0], off)
+		}
+		return nil
+	}
+	offsets, err := sk.OffsetConnectedLoop(path, t.loopDistance(path))
+	if err != nil {
 		return err
 	}
-	_, err := sk.OffsetConnectedLoop(path, t.loopDistance(path))
-	return err
+	if t.constrainOffset {
+		sk.ConstrainOffsetLoop(path, offsets)
+	}
+	return nil
 }
 
 // singleDistance is the signed offset for one curve: the placement's signed distance to the seed

--- a/app/sketch_modify_tools.go
+++ b/app/sketch_modify_tools.go
@@ -101,20 +101,30 @@ func (t *SketchFilletTool) Commit(s *Session) error {
 	return err
 }
 
-// SketchOffsetTool offsets a single picked curve by a distance.
+// SketchOffsetTool offsets a picked curve — with Loop Select (Inventor's default) the whole
+// connected loop, otherwise the single curve — by a distance, keeping the geometry analytic (lines,
+// arcs and circles stay themselves). A positive distance offsets inward (shrinks a closed loop).
 type SketchOffsetTool struct {
 	dialogTool
 	pickCollector
-	distance math.Scalar
+	distance   math.Scalar
+	loopSelect bool // Inventor default: offset the whole connected loop, not just the picked curve
 }
 
-// NewSketchOffsetTool makes an offset tool with the given default distance.
+// NewSketchOffsetTool makes an offset tool with the given default distance and Loop Select on, as
+// Inventor defaults.
 func NewSketchOffsetTool(distance float64) *SketchOffsetTool {
-	return &SketchOffsetTool{pickCollector: pickCollector{want: 1}, distance: math.Scalar(distance)}
+	return &SketchOffsetTool{pickCollector: pickCollector{want: 1}, distance: math.Scalar(distance), loopSelect: true}
 }
 
 func (t *SketchOffsetTool) Name() string                  { return "Offset" }
 func (t *SketchOffsetTool) Pick(_ *Session, s Selectable) { t.take(s) }
+
+// LoopSelect reports whether the whole connected loop is offset (Inventor's default); the right-click
+// menu toggles it. With it off, only the picked curve is offset.
+func (t *SketchOffsetTool) LoopSelect() bool      { return t.loopSelect }
+func (t *SketchOffsetTool) SetLoopSelect(on bool) { t.loopSelect = on }
+func (t *SketchOffsetTool) ToggleLoopSelect()     { t.loopSelect = !t.loopSelect }
 
 // Accepts highlights the curves OffsetEntity handles: line, circle, arc, and a projected reference
 // curve (a projected face perimeter or edge, offset as a polyline — #2158 follow-up). Uses the
@@ -135,14 +145,40 @@ func (t *SketchOffsetTool) Params() ToolParams {
 	return ToolParams{Floats: []FloatParam{scalarParam("Distance", &t.distance)}}
 }
 
-// Commit offsets the picked curve.
+// Commit offsets the picked geometry: with Loop Select the whole connected loop (analytic — arcs
+// stay arcs), otherwise the single curve. A positive distance offsets inward regardless of the
+// loop's traversal winding, so the result is predictable.
 func (t *SketchOffsetTool) Commit(s *Session) error {
 	sk := s.ActiveSketch()
 	if sk == nil {
 		return errors.New("offset: no active sketch")
 	}
-	_, err := sk.OffsetEntity(t.picks[0], t.distance)
+	if !t.loopSelect {
+		_, err := sk.OffsetEntity(t.picks[0], t.distance)
+		return err
+	}
+	path, ok := sk.ConnectedChainFrom(t.picks[0])
+	if !ok {
+		_, err := sk.OffsetEntity(t.picks[0], t.distance)
+		return err
+	}
+	d := float64(t.distance)
+	if signedLoopArea(path.Points()) < 0 {
+		d = -d // a CW loop offsets inward with a negative d; flip so positive distance always shrinks
+	}
+	_, err := sk.OffsetConnectedLoop(path, d)
 	return err
+}
+
+// signedLoopArea is twice the signed area of the closed polygon (CCW ⇒ positive), used only for its
+// SIGN to make a positive offset distance shrink a loop whatever its traversal direction.
+func signedLoopArea(pts []math.Point2) float64 {
+	a := 0.0
+	for i := 0; i < len(pts); i++ {
+		p, q := pts[i], pts[(i+1)%len(pts)]
+		a += float64(p.X*q.Y - q.X*p.Y)
+	}
+	return a
 }
 
 // SketchMirrorTool mirrors the first picked entity across the second picked line.

--- a/app/sketch_modify_tools.go
+++ b/app/sketch_modify_tools.go
@@ -108,7 +108,9 @@ type SketchOffsetTool struct {
 	dialogTool
 	pickCollector
 	distance   math.Scalar
-	loopSelect bool // Inventor default: offset the whole connected loop, not just the picked curve
+	loopSelect bool       // Inventor default: offset the whole connected loop, not just the picked curve
+	placement  math.Point2 // where the user clicked to place the offset (its side + distance)
+	placed     bool
 }
 
 // NewSketchOffsetTool makes an offset tool with the given default distance and Loop Select on, as
@@ -119,6 +121,30 @@ func NewSketchOffsetTool(distance float64) *SketchOffsetTool {
 
 func (t *SketchOffsetTool) Name() string                  { return "Offset" }
 func (t *SketchOffsetTool) Pick(_ *Session, s Selectable) { t.take(s) }
+
+// ClickAt drives Inventor's two-step flow: the first click selects the geometry to offset, then the
+// user moves the cursor and clicks to place the offset copy — the placement click's side and its
+// distance from the curve set the offset. Selecting first through ClickAt (rather than an ambient
+// entity pick) is what lets the second, empty-space click become the placement.
+func (t *SketchOffsetTool) ClickAt(s *Session, px, py float64) {
+	if t.placed {
+		return
+	}
+	if len(t.picks) == 0 {
+		if ent, ok := s.pickSketchEntity(px, py); ok && t.Accepts(ent) {
+			t.takeEntity(ent)
+		}
+		return
+	}
+	if p, ok := s.sketchClickPoint(px, py); ok {
+		t.placement, t.placed = p, true
+	}
+}
+
+// AutoCommits finishes the tool on the placement click — only then, so the first (selection) click
+// does not commit. CanCommit stays true once a curve is selected so OK/Enter can finish with the
+// default distance (the API path used by tests).
+func (t *SketchOffsetTool) AutoCommits() bool { return t.placed }
 
 // LoopSelect reports whether the whole connected loop is offset (Inventor's default); the right-click
 // menu toggles it. With it off, only the picked curve is offset.
@@ -132,10 +158,14 @@ func (t *SketchOffsetTool) ToggleLoopSelect()     { t.loopSelect = !t.loopSelect
 func (t *SketchOffsetTool) Accepts(e sketch.Entity) bool {
 	return entityKindIs(e, sketch.LineKind, sketch.CircleKind, sketch.ArcKind, sketch.ProjectedCurveKind)
 }
-func (t *SketchOffsetTool) CanCommit() bool        { return t.ready() }
-func (t *SketchOffsetTool) AutoCommitOnPick() bool { return true }
-func (t *SketchOffsetTool) Cancel(*Session)        { t.reset() }
-func (t *SketchOffsetTool) Prompt(*Session) string { return "Pick a curve to offset." }
+func (t *SketchOffsetTool) CanCommit() bool { return t.ready() }
+func (t *SketchOffsetTool) Cancel(*Session) { t.reset(); t.placed = false }
+func (t *SketchOffsetTool) Prompt(*Session) string {
+	if len(t.picks) == 0 {
+		return "Select geometry to offset"
+	}
+	return "Move the cursor and click to place the offset"
+}
 
 // SetDistance sets the offset distance.
 func (t *SketchOffsetTool) SetDistance(d float64) { t.distance = math.Scalar(d) }
@@ -146,28 +176,75 @@ func (t *SketchOffsetTool) Params() ToolParams {
 }
 
 // Commit offsets the picked geometry: with Loop Select the whole connected loop (analytic — arcs
-// stay arcs), otherwise the single curve. A positive distance offsets inward regardless of the
-// loop's traversal winding, so the result is predictable.
+// stay arcs), otherwise the single curve. When the user placed the offset (the second click) the
+// placement's side and its distance to the curve set the signed distance directly (Inventor's
+// cursor-driven placement); otherwise a positive default distance offsets inward whatever the loop's
+// winding, so the API/test path stays predictable.
 func (t *SketchOffsetTool) Commit(s *Session) error {
 	sk := s.ActiveSketch()
 	if sk == nil {
 		return errors.New("offset: no active sketch")
 	}
-	if !t.loopSelect {
-		_, err := sk.OffsetEntity(t.picks[0], t.distance)
+	path, ok := sk.ConnectedChainFrom(t.picks[0])
+	// A lone curve (no connected neighbours) offsets as a single entity even with Loop Select on —
+	// OffsetConnectedLoop is for a multi-curve chain, and OffsetEntity keeps a single line/arc/circle
+	// analytic. ConnectedChainFrom returns ok for ANY curve, so the count, not ok, gates the loop path.
+	if !t.loopSelect || !ok || path.Count() <= 1 {
+		_, err := sk.OffsetEntity(t.picks[0], math.Scalar(t.singleDistance()))
 		return err
 	}
-	path, ok := sk.ConnectedChainFrom(t.picks[0])
-	if !ok {
-		_, err := sk.OffsetEntity(t.picks[0], t.distance)
-		return err
+	_, err := sk.OffsetConnectedLoop(path, t.loopDistance(path))
+	return err
+}
+
+// singleDistance is the signed offset for one curve: the placement's signed distance to the seed
+// when placed, else the default distance (its own sign, no winding logic — a lone curve has no
+// inside).
+func (t *SketchOffsetTool) singleDistance() float64 {
+	if t.placed {
+		return placementSignedOffset(sketch.EntityOutline(t.picks[0]), t.placement)
+	}
+	return float64(t.distance)
+}
+
+// loopDistance is the signed offset for a loop: the placement's signed distance in the seed's
+// left-normal frame (the frame OffsetConnectedLoop offsets along) when placed, else the default
+// distance flipped so a positive value always shrinks the loop whatever its winding.
+func (t *SketchOffsetTool) loopDistance(path *sketch.Path) float64 {
+	if t.placed {
+		return placementSignedOffset(sketch.EntityOutline(t.picks[0]), t.placement)
 	}
 	d := float64(t.distance)
 	if signedLoopArea(path.Points()) < 0 {
 		d = -d // a CW loop offsets inward with a negative d; flip so positive distance always shrinks
 	}
-	_, err := sk.OffsetConnectedLoop(path, d)
-	return err
+	return d
+}
+
+// placementSignedOffset returns the offset distance the cursor placement implies: the magnitude is
+// the placement's perpendicular distance to the curve, the sign its side (positive when the
+// placement lies to the LEFT of the seed's natural traversal, matching offsetLine/OffsetConnectedLoop
+// which offset by d along the left normal). This is Inventor's "move the cursor and click to place".
+func placementSignedOffset(outline []math.Point2, p math.Point2) float64 {
+	if len(outline) < 2 {
+		return 0
+	}
+	best, signed := math.Scalar(-1), 0.0
+	for i := 0; i+1 < len(outline); i++ {
+		a, b := outline[i], outline[i+1]
+		dist := p.DistanceTo(segmentClosestPoint(p, a, b))
+		if best >= 0 && dist >= best {
+			continue
+		}
+		best = dist
+		cross := (b.X-a.X)*(p.Y-a.Y) - (b.Y-a.Y)*(p.X-a.X) // >0 ⇒ p left of a→b
+		if cross < 0 {
+			signed = -float64(dist)
+		} else {
+			signed = float64(dist)
+		}
+	}
+	return signed
 }
 
 // signedLoopArea is twice the signed area of the closed polygon (CCW ⇒ positive), used only for its

--- a/app/sketch_modify_tools_test.go
+++ b/app/sketch_modify_tools_test.go
@@ -123,7 +123,10 @@ func TestSketchOffsetToolOffsetsCurve(t *testing.T) {
 	l := sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(4, 0))
 	tool := NewSketchOffsetTool(2)
 	s.StartTool(tool)
-	s.feedPick(SketchEntityHandle{Entity: l}) // auto-commits
+	tool.Pick(s, SketchEntityHandle{Entity: l}) // select the curve
+	if err := s.OK(); err != nil {               // OK finishes with the default distance (no placement click)
+		t.Fatalf("OK: %v", err)
+	}
 	if sk.Lines().Count() != 2 {
 		t.Fatalf("lines after offset = %d, want 2", sk.Lines().Count())
 	}

--- a/app/sketch_modify_tools_test.go
+++ b/app/sketch_modify_tools_test.go
@@ -124,7 +124,7 @@ func TestSketchOffsetToolOffsetsCurve(t *testing.T) {
 	tool := NewSketchOffsetTool(2)
 	s.StartTool(tool)
 	tool.Pick(s, SketchEntityHandle{Entity: l}) // select the curve
-	if err := s.OK(); err != nil {               // OK finishes with the default distance (no placement click)
+	if err := s.OK(); err != nil {              // OK finishes with the default distance (no placement click)
 		t.Fatalf("OK: %v", err)
 	}
 	if sk.Lines().Count() != 2 {

--- a/app/sketch_offset_loop_test.go
+++ b/app/sketch_offset_loop_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// squareLoop adds a closed 4-line square [0,side]^2 to sk and returns its lines.
+func squareLoop(sk *sketch.Sketch, side float64) []*sketch.Line {
+	c := []math.Point2{math.P2(0, 0), math.P2(side, 0), math.P2(side, side), math.P2(0, side)}
+	var ls []*sketch.Line
+	for i := 0; i < 4; i++ {
+		ls = append(ls, sk.Lines().AddByTwoPoints(c[i], c[(i+1)%4]))
+	}
+	return ls
+}
+
+// TestOffsetToolLoopSelectOffsetsWholeLoop is the Inventor behaviour from the reference video: with
+// Loop Select on (default), picking one curve offsets the entire connected loop, inward for a
+// positive distance.
+func TestOffsetToolLoopSelectOffsetsWholeLoop(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	sk, err := s.CreateSketch(sketch.XYPlane())
+	if err != nil {
+		t.Fatalf("CreateSketch: %v", err)
+	}
+	lines := squareLoop(sk, 4)
+	before := sk.Lines().Count()
+
+	tool := NewSketchOffsetTool(0.5)
+	if !tool.LoopSelect() {
+		t.Fatal("Loop Select must be on by default (Inventor)")
+	}
+	s.StartTool(tool)
+	tool.Pick(s, SketchEntityHandle{Entity: lines[0]})
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if got := sk.Lines().Count() - before; got != 4 {
+		t.Fatalf("Loop Select offset created %d lines, want 4 (the whole loop)", got)
+	}
+	// the new lines form the inner square [0.5,3.5]^2 — check one is the left edge inset to x=0.5.
+	innerLeft := false
+	for i := before; i < sk.Lines().Count(); i++ {
+		l := sk.Lines().Item(i)
+		if absOffset(float64(l.A.Position().X)-0.5) < 1e-6 && absOffset(float64(l.B.Position().X)-0.5) < 1e-6 {
+			innerLeft = true
+		}
+	}
+	if !innerLeft {
+		t.Error("no inner offset edge at x=0.5 — the loop did not offset inward by 0.5")
+	}
+}
+
+// TestOffsetToolSingleWhenLoopSelectOff: with Loop Select off, only the picked curve offsets.
+func TestOffsetToolSingleWhenLoopSelectOff(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	sk, _ := s.CreateSketch(sketch.XYPlane())
+	lines := squareLoop(sk, 4)
+	before := sk.Lines().Count()
+
+	tool := NewSketchOffsetTool(0.5)
+	tool.SetLoopSelect(false)
+	s.StartTool(tool)
+	tool.Pick(s, SketchEntityHandle{Entity: lines[0]})
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if got := sk.Lines().Count() - before; got != 1 {
+		t.Fatalf("single-curve offset created %d lines, want 1", got)
+	}
+}
+
+func absOffset(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/app/sketch_offset_loop_test.go
+++ b/app/sketch_offset_loop_test.go
@@ -118,6 +118,34 @@ func TestPlacementSignedOffset(t *testing.T) {
 	}
 }
 
+// TestOffsetToolConstrainOffsetDefaultOn: with Constrain Offset on (Inventor default) a loop offset
+// adds associativity constraints; turning it off adds none.
+func TestOffsetToolConstrainOffsetDefaultOn(t *testing.T) {
+	run := func(constrain bool) int {
+		s, _ := emptyPartSession(t)
+		sk, _ := s.CreateSketch(sketch.XYPlane())
+		lines := squareLoop(sk, 4)
+		before := len(sk.Constraints())
+		tool := NewSketchOffsetTool(0.5)
+		tool.SetConstrainOffset(constrain)
+		s.StartTool(tool)
+		tool.Pick(s, SketchEntityHandle{Entity: lines[0]})
+		if err := s.OK(); err != nil {
+			t.Fatalf("OK: %v", err)
+		}
+		return len(sk.Constraints()) - before
+	}
+	if !NewSketchOffsetTool(1).ConstrainOffset() {
+		t.Fatal("Constrain Offset must be on by default (Inventor)")
+	}
+	if got := run(true); got != 8 { // 4 parallel + 4 coincident corners
+		t.Errorf("constrained loop offset added %d constraints, want 8", got)
+	}
+	if got := run(false); got != 0 {
+		t.Errorf("unconstrained loop offset added %d constraints, want 0", got)
+	}
+}
+
 func absOffset(x float64) float64 {
 	if x < 0 {
 		return -x

--- a/app/sketch_offset_loop_test.go
+++ b/app/sketch_offset_loop_test.go
@@ -56,6 +56,31 @@ func TestOffsetToolLoopSelectOffsetsWholeLoop(t *testing.T) {
 	}
 }
 
+// TestOffsetToolLoopSelectHighlightsWholeLoop: with Loop Select on, picking one curve highlights the
+// WHOLE connected loop (Picked returns every loop entity), so the user sees the whole profile
+// selected — not just the one segment. With it off, only the picked curve highlights.
+func TestOffsetToolLoopSelectHighlightsWholeLoop(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	sk, _ := s.CreateSketch(sketch.XYPlane())
+	lines := squareLoop(sk, 4)
+
+	tool := NewSketchOffsetTool(0.5)
+	s.StartTool(tool)
+	tool.Pick(s, SketchEntityHandle{Entity: lines[0]})
+	if got := len(tool.Picked()); got != 4 {
+		t.Fatalf("Loop Select highlighted %d entities, want 4 (the whole loop)", got)
+	}
+	// and the seed is among them
+	if !s.IsSelectedEntity(lines[2]) {
+		t.Error("a non-seed loop edge is not reported selected — the whole-loop highlight is missing")
+	}
+
+	tool.SetLoopSelect(false)
+	if got := len(tool.Picked()); got != 1 {
+		t.Fatalf("with Loop Select off, highlighted %d entities, want 1 (the seed only)", got)
+	}
+}
+
 // TestOffsetToolSingleWhenLoopSelectOff: with Loop Select off, only the picked curve offsets.
 func TestOffsetToolSingleWhenLoopSelectOff(t *testing.T) {
 	s, _ := emptyPartSession(t)
@@ -138,11 +163,62 @@ func TestOffsetToolConstrainOffsetDefaultOn(t *testing.T) {
 	if !NewSketchOffsetTool(1).ConstrainOffset() {
 		t.Fatal("Constrain Offset must be on by default (Inventor)")
 	}
-	if got := run(true); got != 8 { // 4 parallel + 4 coincident corners
-		t.Errorf("constrained loop offset added %d constraints, want 8", got)
+	if got := run(true); got != 9 { // 4 parallel + 4 coincident corners + 1 offset dimension
+		t.Errorf("constrained loop offset added %d constraints, want 9 (8 geometric + 1 offset dimension)", got)
 	}
 	if got := run(false); got != 0 {
 		t.Errorf("unconstrained loop offset added %d constraints, want 0", got)
+	}
+}
+
+// TestOffsetToolCreatesOffsetDimension: committing a constrained offset creates an offset dimension
+// driving the distance (Inventor), so the user can edit the offset value straight away.
+func TestOffsetToolCreatesOffsetDimension(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	sk, _ := s.CreateSketch(sketch.XYPlane())
+	lines := squareLoop(sk, 4)
+	before := sk.DimensionConstraints().Count()
+
+	tool := NewSketchOffsetTool(0.5)
+	s.StartTool(tool)
+	tool.Pick(s, SketchEntityHandle{Entity: lines[0]})
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if got := sk.DimensionConstraints().Count() - before; got != 1 {
+		t.Fatalf("committing an offset created %d dimensions, want 1 (the offset dimension)", got)
+	}
+}
+
+// TestOffsetToolPreviewFollowsCursor: after selecting a loop, PendingRecipe returns the offset ghost
+// at the cursor — the whole loop offset toward the cursor's side (Inventor shows the offset preview).
+func TestOffsetToolPreviewFollowsCursor(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	sk, _ := s.CreateSketch(sketch.XYPlane())
+	lines := squareLoop(sk, 4) // CCW square [0,4]^2, lines[0] = bottom edge
+	tool := NewSketchOffsetTool(0.5)
+	s.StartTool(tool)
+
+	if _, ok := tool.PendingRecipe(s, math.P2(2, 0.5), nil); ok {
+		t.Fatal("preview shown before any curve is picked")
+	}
+	tool.Pick(s, SketchEntityHandle{Entity: lines[0]})
+
+	r, ok := tool.PendingRecipe(s, math.P2(2, 0.5), nil) // cursor 0.5 inside the bottom edge
+	if !ok {
+		t.Fatal("no offset preview after selecting a loop")
+	}
+	if got := len(r.Entities); got != 4 {
+		t.Fatalf("loop offset preview has %d entities, want 4 (the whole loop)", got)
+	}
+	pts, _ := sketch.RecipeOutline(r)
+	if len(pts) == 0 {
+		t.Fatal("offset preview outline is empty")
+	}
+	for _, p := range pts { // an inner offset — every point stays inside the source square
+		if p.X < -1e-6 || p.X > 4+1e-6 || p.Y < -1e-6 || p.Y > 4+1e-6 {
+			t.Fatalf("preview point %v is outside the source square — the offset went the wrong way", p)
+		}
 	}
 }
 

--- a/app/sketch_offset_loop_test.go
+++ b/app/sketch_offset_loop_test.go
@@ -75,6 +75,49 @@ func TestOffsetToolSingleWhenLoopSelectOff(t *testing.T) {
 	}
 }
 
+// TestOffsetToolPlacementSetsSideAndDistance is Inventor's cursor-driven placement: after selecting a
+// curve, the click that places the offset sets both its side and its distance from the picked
+// geometry. A placement one unit inside a square loop offsets the whole loop inward by exactly one.
+func TestOffsetToolPlacementSetsSideAndDistance(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	sk, _ := s.CreateSketch(sketch.XYPlane())
+	lines := squareLoop(sk, 4) // CCW [0,4]^2; lines[0] is the bottom edge (0,0)->(4,0)
+	before := sk.Lines().Count()
+
+	tool := NewSketchOffsetTool(0.5) // default distance ignored once a placement is set
+	s.StartTool(tool)
+	tool.Pick(s, SketchEntityHandle{Entity: lines[0]})
+	tool.placement, tool.placed = math.P2(2, 1), true // 1 unit inside, above the bottom edge
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	if got := sk.Lines().Count() - before; got != 4 {
+		t.Fatalf("placement offset created %d lines, want 4 (whole loop)", got)
+	}
+	innerBottom := false
+	for i := before; i < sk.Lines().Count(); i++ {
+		l := sk.Lines().Item(i)
+		if absOffset(float64(l.A.Position().Y)-1) < 1e-6 && absOffset(float64(l.B.Position().Y)-1) < 1e-6 {
+			innerBottom = true
+		}
+	}
+	if !innerBottom {
+		t.Error("no inner edge at y=1 — the placement did not offset inward by its 1-unit distance")
+	}
+}
+
+// TestPlacementSignedOffset checks the side/distance the cursor placement encodes: the magnitude is
+// the perpendicular distance to the curve, the sign the side (left of A->B is positive).
+func TestPlacementSignedOffset(t *testing.T) {
+	line := []math.Point2{math.P2(0, 0), math.P2(4, 0)} // natural direction +X, left normal +Y
+	if d := placementSignedOffset(line, math.P2(2, 3)); absOffset(d-3) > 1e-9 {
+		t.Errorf("left placement signed offset = %v, want +3", d)
+	}
+	if d := placementSignedOffset(line, math.P2(2, -2)); absOffset(d+2) > 1e-9 {
+		t.Errorf("right placement signed offset = %v, want -2", d)
+	}
+}
+
 func absOffset(x float64) float64 {
 	if x < 0 {
 		return -x

--- a/app/sketch_preview.go
+++ b/app/sketch_preview.go
@@ -242,6 +242,23 @@ func (t *PointTool) PendingRecipe(_ *Session, cursor math.Point2, _ []string) (s
 	return sketch.PointRecipe(cursor), true
 }
 
+// PendingRecipe previews the OFFSET of the picked geometry as a ghost following the cursor: the whole
+// connected loop (Loop Select) or the single curve, offset by the cursor's signed distance to the
+// seed — the same geometry OK commits. Nothing shows until a curve is picked; the ghost then tracks
+// the cursor's side and distance so the user sees the offset before the placement click.
+func (t *SketchOffsetTool) PendingRecipe(_ *Session, cursor math.Point2, _ []string) (sketch.Recipe, bool) {
+	if len(t.picks) == 0 || t.sk == nil {
+		return sketch.Recipe{}, false
+	}
+	d := placementSignedOffset(sketch.EntityOutline(t.picks[0]), cursor)
+	if t.loopSelect {
+		if path, ok := t.sk.ConnectedChainFrom(t.picks[0]); ok && path.Count() > 1 {
+			return t.sk.OffsetLoopRecipe(path, d)
+		}
+	}
+	return sketch.OffsetEntityRecipe(t.picks[0], d)
+}
+
 // stdAbs is the unsigned magnitude of a scalar measurement.
 func stdAbs(v math.Scalar) float64 {
 	if v < 0 {

--- a/app/sketch_project_face_test.go
+++ b/app/sketch_project_face_test.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import (
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/feature"
+	"oblikovati.org/model/sketch"
+)
+
+// stubFacePicker is a Picker that returns the given B-rep face for any pixel, so a test can drive
+// an in-sketch face pick without aiming a ray at a tessellated face. It honours the installed
+// filter, so it also guards that Project Geometry now accepts SelectFace (#2158): before the fix
+// the filter rejected faces, the picker returned nothing, and the tool silently did nothing.
+type stubFacePicker struct{ handle FaceHandle }
+
+func (p stubFacePicker) Pick(_, _ float64, f *SelectionFilter) (Selectable, bool) {
+	if !f.Accepts(SelectFace) {
+		return nil, false
+	}
+	return p.handle, true
+}
+
+// buildCylinderPart extrudes a radius-r circle to height h into def, yielding a cylinder whose
+// planar end caps are each bounded by a single circular edge — the #2158 geometry (a planar
+// circular face whose perimeter must project).
+func buildCylinderPart(def *compdef.PartComponentDefinition, r, h float64) {
+	sk := def.Sketches().Add(sketch.XYPlane())
+	sk.Circles().AddByCenterRadius(math.P2(0, 0), math.Scalar(r))
+	feature.NewExtrudeFeatures(def.Features()).AddByDistanceExtent(sk, 0, ops.NewBody, func() float64 { return h })
+	def.Recompute()
+}
+
+// planarCapFace returns the body's planar face whose outward normal points along +Z (the top cap),
+// the planar circular face the user hovers in #2158.
+func planarCapFace(t *testing.T, body *topo.Body) *topo.Face {
+	t.Helper()
+	for _, f := range body.Faces() {
+		if pl, ok := f.Geometry().(geom.Plane); ok && float64(pl.Normal().Z) > 0.9 {
+			return f
+		}
+	}
+	t.Fatal("no +Z planar cap face found on the cylinder")
+	return nil
+}
+
+// TestProjectGeometryProjectsCircularCapPerimeter is the #2158 regression: hovering a cylinder's
+// planar circular end face during Project Geometry must feed the tool (it accepts faces now), and
+// committing must project that face's perimeter — one projected curve, a real circle. Before the
+// fix the tool accepted only edges/vertices, so the face never highlighted and nothing projected.
+func TestProjectGeometryProjectsCircularCapPerimeter(t *testing.T) {
+	s, def := emptyPartSession(t)
+	buildCylinderPart(def, 2, 4)
+	body := def.SurfaceBodies().All()[0]
+	cap := planarCapFace(t, body)
+
+	sk, err := s.CreateSketch(sketch.XYPlane())
+	if err != nil {
+		t.Fatalf("CreateSketch: %v", err)
+	}
+	s.SetPicker(stubFacePicker{handle: FaceHandle{Face: cap, Body: body}})
+	s.StartTool(NewProjectGeometryTool())
+
+	before := countProjectedCurves(sk)
+	s.Click(100, 100)
+	tool := s.ActiveTool().Tool().(*ProjectGeometryTool)
+	if !tool.CanCommit() {
+		t.Fatal("clicking a planar circular face must feed the Project tool (#2158 face acceptance)")
+	}
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	curves := projectedCurves(sk)
+	if len(curves)-before != 1 {
+		t.Fatalf("projecting the circular cap made %d curves, want 1 (its perimeter)", len(curves)-before)
+	}
+	if got := distinctPointCount(curves[len(curves)-1].Points()); got < 3 {
+		t.Errorf("projected cap perimeter is degenerate (%d distinct points), want a real circle", got)
+	}
+}
+
+// TestProjectGeometryProjectsAllFaceEdges locks the face→boundary enumeration: projecting a box
+// face must project every one of its bounding edges, not just one, so a polygonal face yields its
+// whole outline (#2158).
+func TestProjectGeometryProjectsAllFaceEdges(t *testing.T) {
+	s := extrudedBox(t, 2, 4) // box [0,2]×[0,2]×[0,4]
+	body := partBodies(s)()[0]
+
+	cap := planarCapFace(t, body) // top cap: a quad, four bounding edges
+	plane := sideFaceSketchPlane(t, body)
+	sk, err := s.CreateSketch(plane)
+	if err != nil {
+		t.Fatalf("CreateSketch: %v", err)
+	}
+
+	s.SetPicker(stubFacePicker{handle: FaceHandle{Face: cap, Body: body}})
+	s.StartTool(NewProjectGeometryTool())
+	before := countProjectedCurves(sk)
+	s.Click(100, 100)
+	if err := s.OK(); err != nil {
+		t.Fatalf("OK: %v", err)
+	}
+	want := len(cap.Edges())
+	if got := countProjectedCurves(sk) - before; got != want {
+		t.Fatalf("projecting a %d-edge face made %d curves, want %d (all boundary edges)", want, got, want)
+	}
+	if want < 3 {
+		t.Fatalf("cap face has only %d edges; expected a polygonal cap", want)
+	}
+}

--- a/app/sketch_project_face_test.go
+++ b/app/sketch_project_face_test.go
@@ -85,6 +85,31 @@ func TestProjectGeometryProjectsCircularCapPerimeter(t *testing.T) {
 	}
 }
 
+// TestProjectGeometryProjectsOnPickWithoutOK pins the per-click behaviour: Project Geometry has no
+// dialog, so a pick projects immediately (no OK step) and the tool stays armed for the next pick —
+// the reported gap where a click on a highlighted face produced no projected geometry.
+func TestProjectGeometryProjectsOnPickWithoutOK(t *testing.T) {
+	s, def := emptyPartSession(t)
+	buildCylinderPart(def, 2, 4)
+	body := def.SurfaceBodies().All()[0]
+	cap := planarCapFace(t, body)
+	sk, err := s.CreateSketch(sketch.XYPlane())
+	if err != nil {
+		t.Fatalf("CreateSketch: %v", err)
+	}
+	tool := NewProjectGeometryTool()
+	s.StartTool(tool)
+
+	before := countProjectedCurves(sk)
+	tool.Pick(s, FaceHandle{Face: cap, Body: body})
+	if got := countProjectedCurves(sk) - before; got != 1 {
+		t.Fatalf("a face pick projected %d curves before any OK, want 1 (per-click, no dialog)", got)
+	}
+	if s.ActiveTool() == nil {
+		t.Error("Project Geometry deactivated after one pick; it must stay armed for the next (Inventor)")
+	}
+}
+
 // TestProjectGeometryProjectsAllFaceEdges locks the face→boundary enumeration: projecting a box
 // face must project every one of its bounding edges, not just one, so a polygonal face yields its
 // whole outline (#2158).

--- a/app/sketch_project_origin_test.go
+++ b/app/sketch_project_origin_test.go
@@ -52,18 +52,14 @@ func TestProjectGeometryToolProjectsDatums(t *testing.T) {
 
 	tool := NewProjectGeometryTool()
 	s.StartTool(tool)
+	// Each pick projects immediately — Project Geometry has no dialog (Inventor). The parallel XY
+	// plane has no intersection line with the sketch, so its pick projects nothing.
 	tool.Pick(s, WorkPointHandle{Point: center})
 	tool.Pick(s, WorkAxisHandle{Axis: xAxis})
 	tool.Pick(s, WorkPlaneHandle{Plane: xzPlane})
-	tool.Pick(s, WorkPlaneHandle{Plane: xyPlane}) // parallel: must be skipped on commit
+	tool.Pick(s, WorkPlaneHandle{Plane: xyPlane}) // parallel: projects nothing
 	if !tool.CanCommit() {
-		t.Fatal("tool should be ready after picking datum geometry")
-	}
-	if got := len(tool.Picks()); got != 4 {
-		t.Errorf("Picks() = %d, want 4 datum picks for the highlight", got)
-	}
-	if err := s.OK(); err != nil {
-		t.Fatalf("OK: %v", err)
+		t.Fatal("tool should be finishable after projecting datum geometry")
 	}
 
 	sk := s.ActiveSketch()

--- a/app/sketch_project_tool.go
+++ b/app/sketch_project_tool.go
@@ -3,6 +3,8 @@
 package app
 
 import (
+	"errors"
+
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/sketch"
@@ -104,8 +106,14 @@ func projectFaceEdges(sk *sketch.Sketch, part *compdef.PartComponentDefinition, 
 // projected (the projection itself already happened on each pick, not here).
 func (t *ProjectGeometryTool) CanCommit() bool { return t.projected }
 
-// Commit is the no-op finish: the projections already happened on each pick, so OK/Enter only tears
-// the tool down (a non-mutating commit records nothing).
-func (t *ProjectGeometryTool) Commit(*Session) error { return nil }
+// Commit finishes the tool: the projections already happened on each pick, so it is a no-op tear-
+// down once anything was projected. It refuses (errors) when nothing was projected, so Enter with an
+// empty tool does not silently "succeed" — the same guard the other reference tools hold.
+func (t *ProjectGeometryTool) Commit(*Session) error {
+	if !t.projected {
+		return errors.New("project geometry: pick a face, edge, vertex or datum reference to project")
+	}
+	return nil
+}
 
 var _ Tool = (*ProjectGeometryTool)(nil)

--- a/app/sketch_project_tool.go
+++ b/app/sketch_project_tool.go
@@ -3,29 +3,25 @@
 package app
 
 import (
-	"errors"
-
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/sketch"
 )
 
-// ProjectGeometryTool is the interactive 2D "Project Geometry" command: while editing a
-// sketch, click part edges/vertices — or the part's datum geometry (the origin centre point,
-// origin/work axes and planes, in the viewport or the browser tree) — to project them onto the
-// sketch plane as associative reference geometry (they re-derive through recompute via their
-// reference keys, and other sketch geometry can be constrained to the projected anchors). A
-// projected work axis/plane becomes a reference line (the axis, or the plane↔sketch
-// intersection); a work point becomes a reference point. Commit projects each onto the active
-// 2D sketch (#1262).
+// ProjectGeometryTool is the interactive 2D "Project Geometry" command: while editing a sketch,
+// click a part's faces, edges or vertices — or its datum geometry (the origin centre point,
+// origin/work axes and planes, in the viewport or the browser tree) — and each click projects that
+// reference onto the sketch plane IMMEDIATELY as associative reference geometry (it re-derives
+// through recompute via its reference key, and other sketch geometry can be constrained to it). A
+// face projects its whole boundary; a work axis/plane becomes a reference line (the axis, or the
+// plane↔sketch intersection); a work point or vertex becomes a reference point.
+//
+// There is no dialog and no OK step (Inventor's Project Geometry): the tool stays armed after each
+// pick so the user keeps clicking geometry to project, and Escape or Enter finishes. Each
+// projection is its own undo step (#1262, faces #2158).
 type ProjectGeometryTool struct {
 	dialogTool
-	faces      []FaceHandle
-	edges      []EdgeHandle
-	vertices   []VertexHandle
-	workPoints []WorkPointHandle
-	workAxes   []WorkAxisHandle
-	workPlanes []WorkPlaneHandle
+	projected bool // at least one reference projected this session, so Enter can finish
 }
 
 // NewProjectGeometryTool returns a project-geometry tool.
@@ -38,113 +34,78 @@ func (t *ProjectGeometryTool) Name() string { return "Project Geometry" }
 func (t *ProjectGeometryTool) Start(*Session) {}
 
 // PicksModelReferences routes this tool's in-sketch viewport clicks to the 3D model hit-test
-// (B-rep edges/vertices and datum geometry) instead of the 2D sketch-entity picker. Without it
-// the input router short-circuits every in-sketch click to the sketch's own 2D entities, so the
+// (B-rep faces/edges/vertices and datum geometry) instead of the 2D sketch-entity picker. Without
+// it the input router short-circuits every in-sketch click to the sketch's own 2D entities, so the
 // references to project were unreachable from the viewport and the tool silently did nothing
 // (#1496). The browser tree fed picks through SelectBrowserNode, but the 3D view did not.
 func (t *ProjectGeometryTool) PicksModelReferences() bool { return true }
 
 // AcceptedKinds declares project-geometry picks projectable references: B-rep faces, edges and
-// vertices, plus the part's datum geometry (work points, axes and planes — the Origin folder
-// and user work features). A face projects all of its bounding edges (Inventor's behaviour) — the
-// piece that made hovering a planar/circular face do nothing at all (#2158).
+// vertices, plus the part's datum geometry (work points, axes and planes — the Origin folder and
+// user work features). A face projects all of its bounding edges (Inventor's behaviour) — the piece
+// that made hovering a planar/circular face do nothing at all (#2158).
 func (t *ProjectGeometryTool) AcceptedKinds() []SelectionKind {
 	return []SelectionKind{SelectFace, SelectEdge, SelectVertex, SelectWorkPoint, SelectWorkAxis, SelectWorkPlane}
 }
 
-// Picks reports every picked reference for the unified highlight.
-func (t *ProjectGeometryTool) Picks() []Selectable {
-	picks := append(selectables(t.faces), selectables(t.edges)...)
-	picks = append(picks, selectables(t.vertices)...)
-	for _, h := range t.workPoints {
-		picks = append(picks, h)
-	}
-	for _, h := range t.workAxes {
-		picks = append(picks, h)
-	}
-	for _, h := range t.workPlanes {
-		picks = append(picks, h)
-	}
-	return picks
-}
-
-// Pick records a clicked edge, vertex or datum reference (ignoring other kinds).
-func (t *ProjectGeometryTool) Pick(_ *Session, sel Selectable) {
-	switch h := sel.(type) {
-	case FaceHandle:
-		t.faces = append(t.faces, h)
-	case EdgeHandle:
-		t.edges = append(t.edges, h)
-	case VertexHandle:
-		t.vertices = append(t.vertices, h)
-	case WorkPointHandle:
-		t.workPoints = append(t.workPoints, h)
-	case WorkAxisHandle:
-		t.workAxes = append(t.workAxes, h)
-	case WorkPlaneHandle:
-		t.workPlanes = append(t.workPlanes, h)
-	}
-}
-
-// CanCommit reports whether at least one reference is picked.
-func (t *ProjectGeometryTool) CanCommit() bool {
-	return len(t.faces)+len(t.edges)+len(t.vertices)+len(t.workPoints)+len(t.workAxes)+len(t.workPlanes) > 0
-}
-
-// Commit projects each picked edge/vertex onto the active 2D sketch as associative
-// reference geometry.
-func (t *ProjectGeometryTool) Commit(s *Session) error {
+// Pick projects the clicked reference onto the active 2D sketch right away and leaves the tool armed
+// for the next pick — Project Geometry has no dialog and no separate OK. Each projection records its
+// own undo step. Kinds the tool does not handle, or a pick with no active sketch/part, are ignored.
+func (t *ProjectGeometryTool) Pick(s *Session, sel Selectable) {
 	sk := s.ActiveSketch()
 	if sk == nil {
-		return errors.New("project geometry: not editing a 2D sketch")
-	}
-	if !t.CanCommit() {
-		return errors.New("project geometry: pick at least one face, edge, vertex or datum reference")
+		return
 	}
 	part, err := activePart(s)
 	if err != nil {
-		return err
+		return
 	}
-	for _, f := range t.faces {
-		projectFaceEdges(sk, part, f.Face)
+	if projectReference(sk, part, sel) {
+		t.projected = true
+		s.RecordActiveEdit(t.Name())
 	}
-	for _, e := range t.edges {
-		sk.ProjectCurve(compdef.NewEdgeRefSource(part, string(e.Edge.ReferenceKey())))
-	}
-	for _, v := range t.vertices {
-		sk.ProjectPoint(compdef.NewVertexRefSource(part, string(v.Vertex.ReferenceKey())))
-	}
-	t.projectDatums(sk, part)
-	return nil
 }
 
-// projectFaceEdges projects every bounding edge of a picked face onto sk — Inventor projects a
-// face as its whole boundary (e.g. a cylinder's planar end face yields its circular perimeter,
-// #2158). Each edge re-derives associatively through its reference key, exactly as a directly
-// picked edge does; Face.Edges already returns the distinct edges, so no dedup is needed here.
+// projectReference projects one picked reference onto sk, reporting whether it projected anything.
+func projectReference(sk *sketch.Sketch, part *compdef.PartComponentDefinition, sel Selectable) bool {
+	switch h := sel.(type) {
+	case FaceHandle:
+		projectFaceEdges(sk, part, h.Face)
+	case EdgeHandle:
+		sk.ProjectCurve(compdef.NewEdgeRefSource(part, string(h.Edge.ReferenceKey())))
+	case VertexHandle:
+		sk.ProjectPoint(compdef.NewVertexRefSource(part, string(h.Vertex.ReferenceKey())))
+	case WorkPointHandle:
+		sk.ProjectPoint(compdef.NewWorkPointRefSource(part, h.Point.Key()))
+	case WorkAxisHandle:
+		sk.ProjectCurve(compdef.NewWorkAxisRefSource(part, h.Axis.Key()))
+	case WorkPlaneHandle:
+		if !part.WorkPlaneIntersectsSketch(h.Plane.Key(), sk.Plane()) {
+			return false // a plane parallel to the sketch has no intersection line to project
+		}
+		sk.ProjectCurve(compdef.NewWorkPlaneRefSource(part, h.Plane.Key(), sk.Plane()))
+	default:
+		return false
+	}
+	return true
+}
+
+// projectFaceEdges projects every bounding edge of a picked face onto sk — Inventor projects a face
+// as its whole boundary (e.g. a cylinder's planar end face yields its circular perimeter, #2158).
+// Each edge re-derives associatively through its reference key, exactly as a directly picked edge
+// does; Face.Edges already returns the distinct edges, so no dedup is needed here.
 func projectFaceEdges(sk *sketch.Sketch, part *compdef.PartComponentDefinition, face *topo.Face) {
 	for _, e := range face.Edges() {
 		sk.ProjectCurve(compdef.NewEdgeRefSource(part, string(e.ReferenceKey())))
 	}
 }
 
-// projectDatums projects the picked datum geometry onto sk: the origin/work points as
-// reference points, the axes and the (non-parallel) planes as reference lines (#1262).
-func (t *ProjectGeometryTool) projectDatums(sk *sketch.Sketch, part *compdef.PartComponentDefinition) {
-	for _, p := range t.workPoints {
-		sk.ProjectPoint(compdef.NewWorkPointRefSource(part, p.Point.Key()))
-	}
-	for _, a := range t.workAxes {
-		sk.ProjectCurve(compdef.NewWorkAxisRefSource(part, a.Axis.Key()))
-	}
-	for _, p := range t.workPlanes {
-		if !part.WorkPlaneIntersectsSketch(p.Plane.Key(), sk.Plane()) {
-			continue // a plane parallel to the sketch has no intersection line to project
-		}
-		sk.ProjectCurve(compdef.NewWorkPlaneRefSource(part, p.Plane.Key(), sk.Plane()))
-	}
-}
+// CanCommit reports whether Enter can finish the tool — true once at least one reference has been
+// projected (the projection itself already happened on each pick, not here).
+func (t *ProjectGeometryTool) CanCommit() bool { return t.projected }
 
-// Cancel implements [Tool] (no model change to roll back before commit).
+// Commit is the no-op finish: the projections already happened on each pick, so OK/Enter only tears
+// the tool down (a non-mutating commit records nothing).
+func (t *ProjectGeometryTool) Commit(*Session) error { return nil }
 
 var _ Tool = (*ProjectGeometryTool)(nil)

--- a/app/sketch_project_tool.go
+++ b/app/sketch_project_tool.go
@@ -5,6 +5,7 @@ package app
 import (
 	"errors"
 
+	"oblikovati.org/kernel/topo"
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/sketch"
 )
@@ -19,6 +20,7 @@ import (
 // 2D sketch (#1262).
 type ProjectGeometryTool struct {
 	dialogTool
+	faces      []FaceHandle
 	edges      []EdgeHandle
 	vertices   []VertexHandle
 	workPoints []WorkPointHandle
@@ -42,16 +44,18 @@ func (t *ProjectGeometryTool) Start(*Session) {}
 // (#1496). The browser tree fed picks through SelectBrowserNode, but the 3D view did not.
 func (t *ProjectGeometryTool) PicksModelReferences() bool { return true }
 
-// AcceptedKinds declares project-geometry picks projectable references: B-rep edges and
+// AcceptedKinds declares project-geometry picks projectable references: B-rep faces, edges and
 // vertices, plus the part's datum geometry (work points, axes and planes — the Origin folder
-// and user work features).
+// and user work features). A face projects all of its bounding edges (Inventor's behaviour) — the
+// piece that made hovering a planar/circular face do nothing at all (#2158).
 func (t *ProjectGeometryTool) AcceptedKinds() []SelectionKind {
-	return []SelectionKind{SelectEdge, SelectVertex, SelectWorkPoint, SelectWorkAxis, SelectWorkPlane}
+	return []SelectionKind{SelectFace, SelectEdge, SelectVertex, SelectWorkPoint, SelectWorkAxis, SelectWorkPlane}
 }
 
 // Picks reports every picked reference for the unified highlight.
 func (t *ProjectGeometryTool) Picks() []Selectable {
-	picks := append(selectables(t.edges), selectables(t.vertices)...)
+	picks := append(selectables(t.faces), selectables(t.edges)...)
+	picks = append(picks, selectables(t.vertices)...)
 	for _, h := range t.workPoints {
 		picks = append(picks, h)
 	}
@@ -67,6 +71,8 @@ func (t *ProjectGeometryTool) Picks() []Selectable {
 // Pick records a clicked edge, vertex or datum reference (ignoring other kinds).
 func (t *ProjectGeometryTool) Pick(_ *Session, sel Selectable) {
 	switch h := sel.(type) {
+	case FaceHandle:
+		t.faces = append(t.faces, h)
 	case EdgeHandle:
 		t.edges = append(t.edges, h)
 	case VertexHandle:
@@ -82,7 +88,7 @@ func (t *ProjectGeometryTool) Pick(_ *Session, sel Selectable) {
 
 // CanCommit reports whether at least one reference is picked.
 func (t *ProjectGeometryTool) CanCommit() bool {
-	return len(t.edges)+len(t.vertices)+len(t.workPoints)+len(t.workAxes)+len(t.workPlanes) > 0
+	return len(t.faces)+len(t.edges)+len(t.vertices)+len(t.workPoints)+len(t.workAxes)+len(t.workPlanes) > 0
 }
 
 // Commit projects each picked edge/vertex onto the active 2D sketch as associative
@@ -93,11 +99,14 @@ func (t *ProjectGeometryTool) Commit(s *Session) error {
 		return errors.New("project geometry: not editing a 2D sketch")
 	}
 	if !t.CanCommit() {
-		return errors.New("project geometry: pick at least one edge, vertex or datum reference")
+		return errors.New("project geometry: pick at least one face, edge, vertex or datum reference")
 	}
 	part, err := activePart(s)
 	if err != nil {
 		return err
+	}
+	for _, f := range t.faces {
+		projectFaceEdges(sk, part, f.Face)
 	}
 	for _, e := range t.edges {
 		sk.ProjectCurve(compdef.NewEdgeRefSource(part, string(e.Edge.ReferenceKey())))
@@ -107,6 +116,16 @@ func (t *ProjectGeometryTool) Commit(s *Session) error {
 	}
 	t.projectDatums(sk, part)
 	return nil
+}
+
+// projectFaceEdges projects every bounding edge of a picked face onto sk — Inventor projects a
+// face as its whole boundary (e.g. a cylinder's planar end face yields its circular perimeter,
+// #2158). Each edge re-derives associatively through its reference key, exactly as a directly
+// picked edge does; Face.Edges already returns the distinct edges, so no dedup is needed here.
+func projectFaceEdges(sk *sketch.Sketch, part *compdef.PartComponentDefinition, face *topo.Face) {
+	for _, e := range face.Edges() {
+		sk.ProjectCurve(compdef.NewEdgeRefSource(part, string(e.ReferenceKey())))
+	}
 }
 
 // projectDatums projects the picked datum geometry onto sk: the origin/work points as

--- a/app/tool_menu_options.go
+++ b/app/tool_menu_options.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+// ToolMenuOption is one on/off toggle the active tool offers in the viewport right-click menu —
+// Inventor's in-command context options (e.g. the Offset tool's Loop Select and Constrain Offset,
+// which the user flips mid-command without a dialog).
+type ToolMenuOption struct {
+	Label   string
+	Checked bool
+}
+
+// toolMenuOptioned is the optional [Tool] capability that surfaces such toggles. A tool implements it
+// to appear with checkable options in the right-click menu; ToggleMenuOption flips the named one.
+type toolMenuOptioned interface {
+	MenuOptions() []ToolMenuOption
+	ToggleMenuOption(label string)
+}
+
+// ActiveToolMenuOptions returns the active tool's right-click toggle options, or nil when no tool is
+// active or the active tool offers none. The head renders these as checkable rows at the top of the
+// viewport context menu.
+func (s *Session) ActiveToolMenuOptions() []ToolMenuOption {
+	if t, ok := s.activeToolMenuOptioned(); ok {
+		return t.MenuOptions()
+	}
+	return nil
+}
+
+// ToggleActiveToolMenuOption flips the active tool's option named label (a no-op when no tool is
+// active, the tool offers no options, or the label is unknown).
+func (s *Session) ToggleActiveToolMenuOption(label string) {
+	if t, ok := s.activeToolMenuOptioned(); ok {
+		t.ToggleMenuOption(label)
+	}
+}
+
+func (s *Session) activeToolMenuOptioned() (toolMenuOptioned, bool) {
+	if s.tool == nil {
+		return nil, false
+	}
+	t, ok := s.tool.tool.(toolMenuOptioned)
+	return t, ok
+}

--- a/app/tool_menu_options_test.go
+++ b/app/tool_menu_options_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package app
+
+import "testing"
+
+// TestActiveToolMenuOptionsReflectOffsetToggles: the Offset tool surfaces Loop Select and Constrain
+// Offset as checkable right-click options, both on by default, and toggling one through the session
+// flips exactly that option.
+func TestActiveToolMenuOptionsReflectOffsetToggles(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	tool := NewSketchOffsetTool(0.5)
+	s.StartTool(tool)
+
+	opts := s.ActiveToolMenuOptions()
+	if len(opts) != 2 {
+		t.Fatalf("offset tool exposed %d menu options, want 2", len(opts))
+	}
+	if opts[0].Label != "Loop Select" || !opts[0].Checked {
+		t.Errorf("option[0] = %+v, want Loop Select checked", opts[0])
+	}
+	if opts[1].Label != "Constrain Offset" || !opts[1].Checked {
+		t.Errorf("option[1] = %+v, want Constrain Offset checked", opts[1])
+	}
+
+	s.ToggleActiveToolMenuOption("Loop Select")
+	if tool.LoopSelect() {
+		t.Error("Loop Select still on after toggle")
+	}
+	if !tool.ConstrainOffset() {
+		t.Error("toggling Loop Select must not affect Constrain Offset")
+	}
+
+	s.ToggleActiveToolMenuOption("Constrain Offset")
+	if tool.ConstrainOffset() {
+		t.Error("Constrain Offset still on after toggle")
+	}
+}
+
+// TestActiveToolMenuOptionsNoneWhenIdle: with no tool active, and for a tool that offers none, the
+// session reports no options (so the right-click menu shows nothing extra).
+func TestActiveToolMenuOptionsNoneWhenIdle(t *testing.T) {
+	s, _ := emptyPartSession(t)
+	if opts := s.ActiveToolMenuOptions(); opts != nil {
+		t.Errorf("idle session exposed %d tool menu options, want none", len(opts))
+	}
+	s.ToggleActiveToolMenuOption("Loop Select") // must not panic with no active tool
+}

--- a/head/ui/angle_plane_dialog.go
+++ b/head/ui/angle_plane_dialog.go
@@ -35,21 +35,28 @@ func drawAnglePlaneDialog(s *app.Session) {
 	}
 	dialogSizeOnce(340, 250)
 	if native.Begin("Angle to Plane") {
-		drawFeatureBreadcrumb("Angle to Plane", "")
-		if propertySection("Input Geometry") {
-			drawPickChipRow("About", "angle-plane-axis", pickChipText(t.AxisPicked(), "1 Axis", "Select Axis"),
-				t.AxisPicked(), "Click the axis or edge to rotate about", t.ClearPicks)
-			drawPickChipRow("From", "angle-plane-base", pickChipText(t.BasePicked(), "1 Plane", "Select Plane"),
-				t.BasePicked(), "Click the plane or planar face to measure the angle from", t.ClearPicks)
-		}
-		if propertySection("Behavior") {
-			native.BeginDisabled(!t.AxisPicked() || !t.BasePicked())
-			angleDegRow(s, "Angle", "angle-plane-angle", &anglePlaneUI.angleDeg)
-			native.EndDisabled()
-			t.SetAngleDegrees(float64(anglePlaneUI.angleDeg))
-		}
-		native.Separator()
-		drawCommitCancelButtons(s, t.CanCommit())
+		drawAnglePlaneBody(s, t)
 	}
 	native.End()
+}
+
+// drawAnglePlaneBody fills the Angle to Plane panel: the About-axis and From-plane pick rows, then the
+// Angle field (enabled once both are picked). Split from drawAnglePlaneDialog to keep each within one
+// screen of widgets.
+func drawAnglePlaneBody(s *app.Session, t *app.AngleWorkPlaneTool) {
+	drawFeatureBreadcrumb("Angle to Plane", "")
+	if propertySection("Input Geometry") {
+		drawPickChipRow("About", "angle-plane-axis", pickChipText(t.AxisPicked(), "1 Axis", "Select Axis"),
+			t.AxisPicked(), "Click the axis or edge to rotate about", t.ClearPicks)
+		drawPickChipRow("From", "angle-plane-base", pickChipText(t.BasePicked(), "1 Plane", "Select Plane"),
+			t.BasePicked(), "Click the plane or planar face to measure the angle from", t.ClearPicks)
+	}
+	if propertySection("Behavior") {
+		native.BeginDisabled(!t.AxisPicked() || !t.BasePicked())
+		angleDegRow(s, "Angle", "angle-plane-angle", &anglePlaneUI.angleDeg)
+		native.EndDisabled()
+		t.SetAngleDegrees(float64(anglePlaneUI.angleDeg))
+	}
+	native.Separator()
+	drawCommitCancelButtons(s, t.CanCommit())
 }

--- a/head/ui/angle_plane_dialog.go
+++ b/head/ui/angle_plane_dialog.go
@@ -35,28 +35,29 @@ func drawAnglePlaneDialog(s *app.Session) {
 	}
 	dialogSizeOnce(340, 250)
 	if native.Begin("Angle to Plane") {
-		drawAnglePlaneBody(s, t)
+		drawFeatureBreadcrumb("Angle to Plane", "")
+		drawAnglePlaneInputGeometry(t)
+		if propertySection("Behavior") {
+			native.BeginDisabled(!t.AxisPicked() || !t.BasePicked())
+			angleDegRow(s, "Angle", "angle-plane-angle", &anglePlaneUI.angleDeg)
+			native.EndDisabled()
+			t.SetAngleDegrees(float64(anglePlaneUI.angleDeg))
+		}
+		native.Separator()
+		drawCommitCancelButtons(s, t.CanCommit())
 	}
 	native.End()
 }
 
-// drawAnglePlaneBody fills the Angle to Plane panel: the About-axis and From-plane pick rows, then the
-// Angle field (enabled once both are picked). Split from drawAnglePlaneDialog to keep each within one
-// screen of widgets.
-func drawAnglePlaneBody(s *app.Session, t *app.AngleWorkPlaneTool) {
-	drawFeatureBreadcrumb("Angle to Plane", "")
-	if propertySection("Input Geometry") {
-		drawPickChipRow("About", "angle-plane-axis", pickChipText(t.AxisPicked(), "1 Axis", "Select Axis"),
-			t.AxisPicked(), "Click the axis or edge to rotate about", t.ClearPicks)
-		drawPickChipRow("From", "angle-plane-base", pickChipText(t.BasePicked(), "1 Plane", "Select Plane"),
-			t.BasePicked(), "Click the plane or planar face to measure the angle from", t.ClearPicks)
+// drawAnglePlaneInputGeometry draws the Angle to Plane panel's Input Geometry section — the About-axis
+// and From-plane pick rows. Tool-only (no session), so the split reduces drawAnglePlaneDialog's length
+// without widening head/ui's *app.Session coupling (audit I5).
+func drawAnglePlaneInputGeometry(t *app.AngleWorkPlaneTool) {
+	if !propertySection("Input Geometry") {
+		return
 	}
-	if propertySection("Behavior") {
-		native.BeginDisabled(!t.AxisPicked() || !t.BasePicked())
-		angleDegRow(s, "Angle", "angle-plane-angle", &anglePlaneUI.angleDeg)
-		native.EndDisabled()
-		t.SetAngleDegrees(float64(anglePlaneUI.angleDeg))
-	}
-	native.Separator()
-	drawCommitCancelButtons(s, t.CanCommit())
+	drawPickChipRow("About", "angle-plane-axis", pickChipText(t.AxisPicked(), "1 Axis", "Select Axis"),
+		t.AxisPicked(), "Click the axis or edge to rotate about", t.ClearPicks)
+	drawPickChipRow("From", "angle-plane-base", pickChipText(t.BasePicked(), "1 Plane", "Select Plane"),
+		t.BasePicked(), "Click the plane or planar face to measure the angle from", t.ClearPicks)
 }

--- a/head/ui/box_select_view.go
+++ b/head/ui/box_select_view.go
@@ -33,23 +33,8 @@ var (
 // single-pick click handler. Replaces the bare handleViewportClick call so they never both
 // fire on the same press.
 func handleViewportSelection(s *app.Session) {
-	if updateOrbitPivot(s) {
-		return // Free Orbit: a no-drag click set the orbit pivot (#913 N9)
-	}
-	if s.ConstrainedOrbitActive() {
-		return // Constrained Orbit owns the left-drag, which turntables (#913 N10)
-	}
-	if heldNavMode() != NavNone {
-		return // a held F2/F3/F4 turns a left-drag into navigation, not selection (#911)
-	}
-	if updateZoomWindow(s) {
-		return // the Zoom Window tool owns the left-drag while armed (#913 N16)
-	}
-	if s.SelectOtherActive() {
-		if native.IsItemClicked(native.MouseLeft) {
-			s.CommitSelectOther() // a click in the viewport accepts the highlighted candidate (#910)
-		}
-		return // the Select Other cycle owns viewport picking until it ends
+	if viewportModeOwnsPointer(s) {
+		return
 	}
 	// The direct-manipulation machines are mutually exclusive by construction — each is gated
 	// on its own tool or mode being active — so they share one guard: place new sketch
@@ -63,6 +48,32 @@ func handleViewportSelection(s *app.Session) {
 		return
 	}
 	handleViewportClick(s)
+}
+
+// viewportModeOwnsPointer reports whether a navigation or selection MODE already owns this frame's
+// left input, so viewport selection stands down: Free Orbit's pivot-set click, Constrained Orbit, a
+// held F2/F3/F4 nav gesture, the Zoom Window tool, or the Select Other cycle (a click accepts its
+// highlighted candidate).
+func viewportModeOwnsPointer(s *app.Session) bool {
+	if updateOrbitPivot(s) {
+		return true // Free Orbit: a no-drag click set the orbit pivot (#913 N9)
+	}
+	if s.ConstrainedOrbitActive() {
+		return true // Constrained Orbit owns the left-drag, which turntables (#913 N10)
+	}
+	if heldNavMode() != NavNone {
+		return true // a held F2/F3/F4 turns a left-drag into navigation, not selection (#911)
+	}
+	if updateZoomWindow(s) {
+		return true // the Zoom Window tool owns the left-drag while armed (#913 N16)
+	}
+	if s.SelectOtherActive() {
+		if native.IsItemClicked(native.MouseLeft) {
+			s.CommitSelectOther() // a click in the viewport accepts the highlighted candidate (#910)
+		}
+		return true // the Select Other cycle owns viewport picking until it ends
+	}
+	return false
 }
 
 // updateControlPointDrag advances interactive NURBS control-point editing and reports whether it

--- a/head/ui/box_select_view.go
+++ b/head/ui/box_select_view.go
@@ -80,7 +80,19 @@ func viewportModeOwnsPointer(s *app.Session) bool {
 // consumed this frame's left input. While the Edit Control Points tool is active, a left press on
 // a control-net handle begins the drag, the cursor slides it (the surface re-evaluates live), and
 // release commits the edit (M36-F03). Mirrors updateCloudDrag.
-func updateControlPointDrag(s *app.Session) bool {
+// cvDragSession is the drag machine the NURBS control-point editor needs — five methods, not the
+// whole session (audit I5). Mirrors cageDragSession.
+type cvDragSession interface {
+	CVEditActive() bool
+	CVDragActive() bool
+	BeginCVDrag(px, py float64) bool
+	UpdateCVDrag(px, py float64)
+	CommitCVDrag()
+}
+
+var _ cvDragSession = (*app.Session)(nil)
+
+func updateControlPointDrag(s cvDragSession) bool {
 	if !s.CVEditActive() {
 		return false
 	}
@@ -140,7 +152,19 @@ func updateFreeformCageDrag(s cageDragSession) bool {
 // this frame's left input. While the Move tool is active, a left press begins the drag, the cursor
 // translates the cloud (datums built on it follow), and release commits — mirroring the sketch
 // drag-to-move (#645).
-func updateCloudDrag(s *app.Session) bool {
+// cloudDragSession is the drag machine the point-cloud mover needs — five methods, not the whole
+// session (audit I5). Mirrors cvDragSession / cageDragSession.
+type cloudDragSession interface {
+	CloudMoveActive() bool
+	CloudDragActive() bool
+	BeginCloudDrag(px, py float64) bool
+	UpdateCloudDrag(px, py float64)
+	CommitCloudDrag()
+}
+
+var _ cloudDragSession = (*app.Session)(nil)
+
+func updateCloudDrag(s cloudDragSession) bool {
 	if !s.CloudMoveActive() {
 		return false
 	}

--- a/head/ui/center_glyph_test.go
+++ b/head/ui/center_glyph_test.go
@@ -1,0 +1,77 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/math"
+	"oblikovati.org/model/compdef"
+	"oblikovati.org/model/sketch"
+)
+
+// hasVertexNear reports whether any drawn vertex lies within eps of target.
+func hasVertexNear(pos []math.Point3, target math.Point3, eps float64) bool {
+	for _, p := range pos {
+		if float64(p.DistanceTo(target)) <= eps {
+			return true
+		}
+	}
+	return false
+}
+
+// arcCircleSketch returns a fresh XY sketch (no standalone points, no projections) holding one arc
+// and one circle at known centres — the #2159 geometry whose centres must be glyphed.
+func arcCircleSketch(t *testing.T, arcCenter, circleCenter math.Point2) *sketch.Sketch {
+	t.Helper()
+	s := app.NewSession()
+	pd, err := compdef.AddPart(s.Workspace(), "centers.opd", true)
+	if err != nil {
+		t.Fatalf("AddPart: %v", err)
+	}
+	def := pd.Content().(*compdef.PartComponentDefinition)
+	sk := def.Sketches().Add(sketch.XYPlane())
+	start := math.P2(arcCenter.X+1, arcCenter.Y)
+	end := math.P2(arcCenter.X, arcCenter.Y+1)
+	sk.Arcs().AddByCenterStartEnd(arcCenter, start, end, true)
+	sk.Circles().AddByCenterRadius(circleCenter, 1)
+	return sk
+}
+
+// TestPointsOverlayGlyphsArcAndCircleCenters is the #2159 regression: an arc's and a circle's
+// centre are real, constrainable sketch points but are not in the typed Points collection, so
+// before the fix the overlay drew no glyph for them. An arc's centre sits off the curve in empty
+// space, so with no marker the user could not aim a coincident-to-origin at it ("the arc has no
+// centre"). Both centres must now carry a target marker.
+func TestPointsOverlayGlyphsArcAndCircleCenters(t *testing.T) {
+	const h = 0.1
+	arcCenter, circleCenter := math.P2(5, 5), math.P2(-3, 2)
+	sk := arcCircleSketch(t, arcCenter, circleCenter)
+
+	item, ok := pointsOverlay(sk.Plane(), sk, h)
+	if !ok || len(item.Positions) == 0 {
+		t.Fatal("pointsOverlay must glyph the arc and circle centres (#2159)")
+	}
+	if !hasVertexNear(item.Positions, sk.Plane().ToModel(arcCenter), h) {
+		t.Errorf("no marker near the arc centre %v — an arc centre must be a hover target", arcCenter)
+	}
+	if !hasVertexNear(item.Positions, sk.Plane().ToModel(circleCenter), h) {
+		t.Errorf("no marker near the circle centre %v", circleCenter)
+	}
+}
+
+// TestPointsOverlayEmptyWithoutPointsOrCircles guards the discriminator: a sketch with only a line
+// (no points, no circular centres) draws no point markers, so the arc/circle case above is what
+// adds them, not some always-on behaviour.
+func TestPointsOverlayEmptyWithoutPointsOrCircles(t *testing.T) {
+	s := app.NewSession()
+	pd, _ := compdef.AddPart(s.Workspace(), "line.opd", true)
+	sk := pd.Content().(*compdef.PartComponentDefinition).Sketches().Add(sketch.XYPlane())
+	sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(1, 1))
+	if _, ok := pointsOverlay(sk.Plane(), sk, 0.1); ok {
+		t.Error("a line-only sketch must draw no point markers")
+	}
+}

--- a/head/ui/chrome.go
+++ b/head/ui/chrome.go
@@ -39,11 +39,19 @@ func DrawChrome(win *native.Window, s *app.Session) string {
 	}
 	layoutDockedPanels()
 	drawViewportIfPresent(win, s)
-	// QAT / Application-menu deferred actions (G design D3): the band's
-	// buttons only set flags; this block consumes them in DrawChrome's ID
-	// context — OpenPopup beside BeginPopup (popup ID-stack guarantee), and
-	// Open/Save before drawChromeDialogs so the modal opens this frame.
-	// Every flag is reset on consumption, so none survives into next frame.
+	consumeDeferredChromeActions(s)
+	drawChromeDialogs(s)
+	drawChromeWindows(s)
+	drawDocumentClosePrompt(s)
+	drawFileDialog(s)
+	return activated
+}
+
+// consumeDeferredChromeActions runs the QAT / Application-menu actions the band's buttons deferred as
+// flags (G design D3), in DrawChrome's ID context — OpenPopup beside BeginPopup (popup ID-stack
+// guarantee), and Open/Save before drawChromeDialogs so the modal opens this frame. Every flag is
+// reset on consumption, so none survives into the next frame.
+func consumeDeferredChromeActions(s *app.Session) {
 	if appMenuRequested {
 		appMenuRequested = false
 		native.SetNextWindowPos(appMenuX, appMenuBottomY)
@@ -61,11 +69,6 @@ func DrawChrome(win *native.Window, s *app.Session) string {
 		drawFileMenu(s)
 		native.EndPopup()
 	}
-	drawChromeDialogs(s)
-	drawChromeWindows(s)
-	drawDocumentClosePrompt(s)
-	drawFileDialog(s)
-	return activated
 }
 
 func prepareChromeFrame(win *native.Window, s *app.Session) {

--- a/head/ui/chrome_ribbon.go
+++ b/head/ui/chrome_ribbon.go
@@ -120,23 +120,28 @@ func drawTabPanels(s ribbonControlHost, tabName string, panels []app.RibbonPanel
 	ribbonCollapsedPanels = len(panels) - expanded
 	var activated string
 	for i, panel := range panels {
-		if i > 0 {
-			native.SameLine()
-			native.SeparatorVertical()
-			native.SameLine()
-		}
-		if i >= expanded {
-			if id := drawCollapsedPanel(s, panel, tabName, labelY, gridH); id != "" {
-				activated = id
-			}
-			continue
-		}
-		if id := drawPanel(s, panel, labelY); id != "" {
+		if id := drawRibbonPanelAt(s, panel, i, expanded, tabName, labelY, gridH); id != "" {
 			activated = id
 		}
-		measurePanelWidth(tabName, panel.Name)
 	}
 	return activated
+}
+
+// drawRibbonPanelAt draws one ribbon panel — with a left separator except the first — either expanded
+// or, once past the fit count (i >= expanded), as a collapsed flyout tile, returning any command id it
+// activated. An expanded panel is measured afterward for the next frame's fit decision.
+func drawRibbonPanelAt(s ribbonControlHost, panel app.RibbonPanel, i, expanded int, tabName string, labelY, gridH float32) string {
+	if i > 0 {
+		native.SameLine()
+		native.SeparatorVertical()
+		native.SameLine()
+	}
+	if i >= expanded {
+		return drawCollapsedPanel(s, panel, tabName, labelY, gridH)
+	}
+	id := drawPanel(s, panel, labelY)
+	measurePanelWidth(tabName, panel.Name)
+	return id
 }
 
 // measurePanelWidth records the width of the panel just drawn expanded — drawPanel leaves its
@@ -276,42 +281,65 @@ func drawPointCloudPanel(s ribbonControlHost, panel app.RibbonPanel, labelY floa
 // and its collapsed flyout render the identical grid.
 func drawPointCloudGrid(s ribbonControlHost, panel app.RibbonPanel) string {
 	var activated string
-	pick := func(id string) {
-		if got := drawPointCloudButton(s, panel, id); got != "" {
-			activated = got
+	set := func(id string) {
+		if id != "" {
+			activated = id
 		}
 	}
-
 	// The columns and ramp sit in one group so drawPanelName measures the full grid width
 	// (ItemRectMin/Max span the whole block) and centers the panel name under it — without this
 	// the last item measured would be column 3 alone and the label would sit off to the right.
 	native.BeginGroup()
-
-	native.BeginGroup() // column 1: Import over the stacked point-size ("Size") and Density sliders
-	pick("PointCloud.Import")
-	drawPointCloudSlider(s, "Size", panel.PointSizeSlider)
-	drawPointCloudSlider(s, "Density", panel.Slider)
-	native.EndGroup()
-
+	set(drawPointCloudColumn1(s, panel))
 	native.SameLine()
-	native.BeginGroup() // column 2: Move / Work Point over the display-mode selector
-	pick("PointCloud.Move")
-	pick("PointCloud.WorkPoint")
-	if got := drawPointCloudSelector(panel); got != "" {
-		activated = got
-	}
-	native.EndGroup()
-
+	set(drawPointCloudColumn2(s, panel))
 	native.SameLine()
-	native.BeginGroup() // column 3: Crop / Fit Work Plane
-	pick("PointCloud.CropBox")
-	pick("PointCloud.FitPlane")
-	native.EndGroup()
-
+	set(drawPointCloudColumn3(s, panel))
 	if panel.IntensityRamp != nil {
 		drawIntensityRampControls(s, panel.IntensityRamp)
 	}
 	native.EndGroup() // close the measurable content block
+	return activated
+}
+
+// pointCloudButtons draws the given point-cloud command buttons in order, returning the id of the one
+// clicked (last wins — at most one click lands per frame).
+func pointCloudButtons(s ribbonControlHost, panel app.RibbonPanel, ids ...string) string {
+	var activated string
+	for _, id := range ids {
+		if got := drawPointCloudButton(s, panel, id); got != "" {
+			activated = got
+		}
+	}
+	return activated
+}
+
+// drawPointCloudColumn1 is Import over the stacked point-size ("Size") and Density sliders.
+func drawPointCloudColumn1(s ribbonControlHost, panel app.RibbonPanel) string {
+	native.BeginGroup()
+	activated := pointCloudButtons(s, panel, "PointCloud.Import")
+	drawPointCloudSlider(s, "Size", panel.PointSizeSlider)
+	drawPointCloudSlider(s, "Density", panel.Slider)
+	native.EndGroup()
+	return activated
+}
+
+// drawPointCloudColumn2 is Move / Work Point over the display-mode selector.
+func drawPointCloudColumn2(s ribbonControlHost, panel app.RibbonPanel) string {
+	native.BeginGroup()
+	activated := pointCloudButtons(s, panel, "PointCloud.Move", "PointCloud.WorkPoint")
+	if got := drawPointCloudSelector(panel); got != "" {
+		activated = got
+	}
+	native.EndGroup()
+	return activated
+}
+
+// drawPointCloudColumn3 is Crop / Fit Work Plane.
+func drawPointCloudColumn3(s ribbonControlHost, panel app.RibbonPanel) string {
+	native.BeginGroup()
+	activated := pointCloudButtons(s, panel, "PointCloud.CropBox", "PointCloud.FitPlane")
+	native.EndGroup()
 	return activated
 }
 
@@ -627,21 +655,28 @@ func drawVariantDropdown(btn app.RibbonButton) string {
 	}
 	native.SetItemTooltip(btn.Command.DisplayName() + " — more tools")
 	drawRibbonCaret(x+w/2, y+h/2)
+	return variantPopupSelection(id, btn.Variants)
+}
 
-	var chosen string
-	if native.BeginPopup(id) {
-		for _, v := range btn.Variants {
-			native.BeginDisabled(!v.Enabled)
-			if native.Selectable(v.Label, false) {
-				chosen = v.CommandID
-			}
-			native.EndDisabled()
-			if v.Tooltip != "" {
-				native.SetItemTooltip(v.Tooltip)
-			}
-		}
-		native.EndPopup()
+// variantPopupSelection opens a split button's variant popup (keyed id) and returns the command id of
+// a chosen variant, or "" when the popup is closed or nothing was picked. A disabled variant is shown
+// greyed and is not selectable.
+func variantPopupSelection(id string, variants []app.RibbonVariant) string {
+	if !native.BeginPopup(id) {
+		return ""
 	}
+	var chosen string
+	for _, v := range variants {
+		native.BeginDisabled(!v.Enabled)
+		if native.Selectable(v.Label, false) {
+			chosen = v.CommandID
+		}
+		native.EndDisabled()
+		if v.Tooltip != "" {
+			native.SetItemTooltip(v.Tooltip)
+		}
+	}
+	native.EndPopup()
 	return chosen
 }
 

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -595,6 +595,13 @@ func sketchOverlays(s *app.Session, cam scene.Camera, list renderer.DrawList) (r
 		list.Items = append(gridOverlay(plane, g.SpacingModel(), g.MajorEvery, cam.Eye), list.Items...)
 	}
 	list.Items = append(list.Items, onTop(sketchOverlay(s.ActiveSketch(), s.IsSelectedEntity, hoverCandidate(s), s.ShowFormat()))...)
+	// A model-reference tool (Project Geometry) picks B-rep faces/edges from the viewport while the
+	// sketch is edited, so highlight what it would project — the model-overlay path that normally
+	// draws this is skipped in sketch mode, which is why a projectable face never lit up (#2158). Not
+	// onTop: it tints the 3D face behind the sketch plane, under the sketch entities drawn above.
+	if s.ToolPicksModelReferences() {
+		list.Items = append(list.Items, toolHoverHighlight(s)...)
+	}
 	list.Items = append(list.Items, onTop(projectedCurveOverlay(s.ActiveSketch()))...)
 	dims := s.SketchDimensions()
 	list.Items = append(list.Items, onTop(dimensionLines(plane, dims))...)

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -347,6 +347,7 @@ func drawViewportOverlays(s *app.Session, cam scene.Camera, sketchPlane sketch.P
 	if s.InSketch() {
 		drawPlacementFieldBoxes(s, cam, ox, oy) // in-place dimension input (#2014)
 	}
+	drawRegionModifierBadge(s) // +/− cursor badge during area (region) multi-select (#2165)
 }
 
 // updateViewportCamera sizes the camera to the panel and either advances the active camera

--- a/head/ui/chrome_viewport.go
+++ b/head/ui/chrome_viewport.go
@@ -594,7 +594,8 @@ func sketchOverlays(s *app.Session, cam scene.Camera, list renderer.DrawList) (r
 	if g := s.Grid(); g.Visible {
 		list.Items = append(gridOverlay(plane, g.SpacingModel(), g.MajorEvery, cam.Eye), list.Items...)
 	}
-	list.Items = append(list.Items, onTop(sketchOverlay(s.ActiveSketch(), s.IsSelectedEntity, hoverCandidate(s), s.ShowFormat()))...)
+	cand := hoverCandidate(s) // the sketch entity the active tool would accept on hover (once per frame)
+	list.Items = append(list.Items, onTop(sketchOverlay(s.ActiveSketch(), s.IsSelectedEntity, cand, s.ShowFormat()))...)
 	// A model-reference tool (Project Geometry) picks B-rep faces/edges from the viewport while the
 	// sketch is edited, so highlight what it would project — the model-overlay path that normally
 	// draws this is skipped in sketch mode, which is why a projectable face never lit up (#2158). Not
@@ -602,7 +603,10 @@ func sketchOverlays(s *app.Session, cam scene.Camera, list renderer.DrawList) (r
 	if s.ToolPicksModelReferences() {
 		list.Items = append(list.Items, toolHoverHighlight(s)...)
 	}
-	list.Items = append(list.Items, onTop(projectedCurveOverlay(s.ActiveSketch()))...)
+	// Projected curves are drawn here (sketchOverlay misses them), tinted for hover/selection so a
+	// projected perimeter gives the same feedback as any other curve — the piece the offset workflow
+	// needed to see what it was about to pick (#2158 follow-up).
+	list.Items = append(list.Items, onTop(projectedCurveOverlay(s.ActiveSketch(), s.IsSelectedEntity, cand))...)
 	dims := s.SketchDimensions()
 	list.Items = append(list.Items, onTop(dimensionLines(plane, dims))...)
 	if item, ok := pointsOverlay(plane, s.ActiveSketch(), pointMarkerPixels*cam.WorldPerPixel()); ok {

--- a/head/ui/draft_dialog.go
+++ b/head/ui/draft_dialog.go
@@ -31,32 +31,33 @@ func drawDraftDialog(s *app.Session) {
 	}
 	dialogSizeOnce(340, 230)
 	if native.Begin("Draft") {
-		drawDraftBody(s, d)
+		title := "Draft"
+		if name := d.EditingName(); name != "" {
+			title = name // re-editing a committed draft: the breadcrumb names it
+		}
+		drawFeatureBreadcrumb(title, "")
+		drawDraftInputGeometry(d)
+		if propertySection("Behavior") {
+			angleDegRowHint(s, "Angle", "draft-angle", " (+out / −in)", &draftUI.angle)
+			d.SetAngleDegrees(float64(draftUI.angle))
+		}
+		native.Separator()
+		drawCommitCancelButtons(s, d.CanCommit())
 	}
 	native.End()
 }
 
-// drawDraftBody fills the Draft panel: the breadcrumb, the Input Geometry pick rows, and the Behavior
-// angle, then the commit/cancel buttons. Split from drawDraftDialog so each stays within one screen of
-// widgets.
-func drawDraftBody(s *app.Session, d *app.DraftTool) {
-	title := "Draft"
-	if name := d.EditingName(); name != "" {
-		title = name // re-editing a committed draft: the breadcrumb names it
+// drawDraftInputGeometry draws the Draft panel's Input Geometry section — the faces-to-draft chip and
+// the pull/neutral rows. Tool-only (no session), so the split reduces drawDraftDialog's length without
+// widening head/ui's *app.Session coupling (audit I5).
+func drawDraftInputGeometry(d *app.DraftTool) {
+	if !propertySection("Input Geometry") {
+		return
 	}
-	drawFeatureBreadcrumb(title, "")
-	if propertySection("Input Geometry") {
-		drawPickChipRow("Faces", "draft-faces", countChipText(d.FaceCount(), "Face", "Select Faces"),
-			d.FaceCount() > 0, "Click faces in the viewport to draft", d.ClearFaces)
-		drawDraftPullRow(d)
-		drawDraftNeutralRow(d)
-	}
-	if propertySection("Behavior") {
-		angleDegRowHint(s, "Angle", "draft-angle", " (+out / −in)", &draftUI.angle)
-		d.SetAngleDegrees(float64(draftUI.angle))
-	}
-	native.Separator()
-	drawCommitCancelButtons(s, d.CanCommit())
+	drawPickChipRow("Faces", "draft-faces", countChipText(d.FaceCount(), "Face", "Select Faces"),
+		d.FaceCount() > 0, "Click faces in the viewport to draft", d.ClearFaces)
+	drawDraftPullRow(d)
+	drawDraftNeutralRow(d)
 }
 
 // drawDraftPullRow shows the pull-direction chip (the face whose normal is the mould-pull axis,

--- a/head/ui/draft_dialog.go
+++ b/head/ui/draft_dialog.go
@@ -31,25 +31,32 @@ func drawDraftDialog(s *app.Session) {
 	}
 	dialogSizeOnce(340, 230)
 	if native.Begin("Draft") {
-		title := "Draft"
-		if name := d.EditingName(); name != "" {
-			title = name // re-editing a committed draft: the breadcrumb names it
-		}
-		drawFeatureBreadcrumb(title, "")
-		if propertySection("Input Geometry") {
-			drawPickChipRow("Faces", "draft-faces", countChipText(d.FaceCount(), "Face", "Select Faces"),
-				d.FaceCount() > 0, "Click faces in the viewport to draft", d.ClearFaces)
-			drawDraftPullRow(d)
-			drawDraftNeutralRow(d)
-		}
-		if propertySection("Behavior") {
-			angleDegRowHint(s, "Angle", "draft-angle", " (+out / −in)", &draftUI.angle)
-			d.SetAngleDegrees(float64(draftUI.angle))
-		}
-		native.Separator()
-		drawCommitCancelButtons(s, d.CanCommit())
+		drawDraftBody(s, d)
 	}
 	native.End()
+}
+
+// drawDraftBody fills the Draft panel: the breadcrumb, the Input Geometry pick rows, and the Behavior
+// angle, then the commit/cancel buttons. Split from drawDraftDialog so each stays within one screen of
+// widgets.
+func drawDraftBody(s *app.Session, d *app.DraftTool) {
+	title := "Draft"
+	if name := d.EditingName(); name != "" {
+		title = name // re-editing a committed draft: the breadcrumb names it
+	}
+	drawFeatureBreadcrumb(title, "")
+	if propertySection("Input Geometry") {
+		drawPickChipRow("Faces", "draft-faces", countChipText(d.FaceCount(), "Face", "Select Faces"),
+			d.FaceCount() > 0, "Click faces in the viewport to draft", d.ClearFaces)
+		drawDraftPullRow(d)
+		drawDraftNeutralRow(d)
+	}
+	if propertySection("Behavior") {
+		angleDegRowHint(s, "Angle", "draft-angle", " (+out / −in)", &draftUI.angle)
+		d.SetAngleDegrees(float64(draftUI.angle))
+	}
+	native.Separator()
+	drawCommitCancelButtons(s, d.CanCommit())
 }
 
 // drawDraftPullRow shows the pull-direction chip (the face whose normal is the mould-pull axis,

--- a/head/ui/extrude_dialog.go
+++ b/head/ui/extrude_dialog.go
@@ -7,7 +7,6 @@ package ui
 import (
 	"oblikovati.org/app"
 	"oblikovati.org/head/internal/native"
-	"oblikovati.org/kernel/ops"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/renderer"
 )
@@ -230,13 +229,6 @@ func drawExtrudeAdvanced(s *app.Session) {
 	parameterFloatRow(s, "Taper A", "extrude-taper", paramAngle, "", &extrudeUI.taper)
 	s.SetExtrudeTaperDisplay(float64(extrudeUI.taper))
 }
-
-// extrudeOperations names each boolean operation for the combo-based feature dialogs
-// (Revolve, Sweep, Loft, Coil) that share the list.
-var extrudeOperations = []struct {
-	label string
-	op    ops.PartFeatureOperation
-}{{"New Solid", ops.NewBody}, {"Join", ops.Join}, {"Cut", ops.Cut}, {"Intersect", ops.Intersect}}
 
 // profileOutline returns the wireframe of a region's outer loop and holes in color.
 // Returns nil when the region index is stale (sketch edited under the selection).

--- a/head/ui/marking_menu_view.go
+++ b/head/ui/marking_menu_view.go
@@ -55,6 +55,7 @@ func drawMarkingMenu(s *app.Session) {
 // drawRadialMarkingMenu draws the eight-quadrant ring plus its overflow rows.
 func drawRadialMarkingMenu(s *app.Session) {
 	drawRepeatEntry(s)
+	drawActiveToolMenuOptions(s)
 	menu := s.MarkingMenu(app.CurrentEnvironment(s))
 	layout := markingRingLayoutForMenu(s, menu)
 	ringX, ringY := native.GetCursorPos()
@@ -109,6 +110,7 @@ func markingRingLayoutForMenu(s markingMenuCommandHost, menu wire.MarkingMenuVie
 // (non-radial) right-click menu (#915 C8).
 func drawClassicContextMenu(s *app.Session) {
 	drawRepeatEntry(s)
+	drawActiveToolMenuOptions(s)
 	menu := s.MarkingMenu(app.CurrentEnvironment(s))
 	for _, item := range menu.Quadrants {
 		drawLinearCommandEntry(s, item.CommandID)
@@ -129,6 +131,28 @@ func drawRepeatEntry(s *app.Session) {
 	if native.Selectable(label+"##mm-repeat", false) {
 		_ = s.RepeatLastCommand()
 		native.CloseCurrentPopup()
+	}
+	native.Separator()
+}
+
+// drawActiveToolMenuOptions renders the active tool's in-command toggle options (Inventor's
+// right-click options, e.g. the Offset tool's Loop Select / Constrain Offset) as checkable rows at
+// the top of the context menu. A checkmark prefix shows an on option; clicking one flips it and
+// closes the menu, as Inventor does. Nothing renders when no tool offers options.
+func drawActiveToolMenuOptions(s *app.Session) {
+	opts := s.ActiveToolMenuOptions()
+	if len(opts) == 0 {
+		return
+	}
+	for _, opt := range opts {
+		label := opt.Label
+		if opt.Checked {
+			label = "✓ " + opt.Label
+		}
+		if native.MenuItem(label + "##tool-opt-" + opt.Label) {
+			s.ToggleActiveToolMenuOption(opt.Label)
+			native.CloseCurrentPopup()
+		}
 	}
 	native.Separator()
 }

--- a/head/ui/marking_menu_view.go
+++ b/head/ui/marking_menu_view.go
@@ -203,23 +203,27 @@ func drawMarkingSlot(s *app.Session, ringX, ringY float32, layout markingRingLay
 	x, y := markingSlotPosition(layout, item.Quadrant, w, h)
 	native.SetCursorPos(ringX+x, ringY+y)
 	native.BeginDisabled(!cmd.IsEnabled(s))
-	var clicked bool
-	if hasIcon {
-		native.BeginGroup()
-		clicked = native.ImageButton("##mm-"+item.CommandID, tex, float32(iconPx), float32(iconPx), identityTint)
-		native.SameLine()
-		cx, cy := native.GetCursorScreenPos()
-		native.SetCursorScreenPos(cx, cy+(float32(iconPx)+2*m.FramePadY-native.TextLineHeight())/2)
-		native.Text(label)
-		native.EndGroup()
-	} else {
-		clicked = native.Button(label + "##mm-" + item.CommandID)
-	}
-	if clicked {
+	if drawMarkingSlotButton(item, label, tex, hasIcon, iconPx, m) {
 		_ = s.Execute(item.CommandID)
 		native.CloseCurrentPopup()
 	}
 	native.EndDisabled()
+}
+
+// drawMarkingSlotButton draws a marking-slot's clickable control — an icon beside its label when the
+// command has an icon asset, else a plain text button — and reports whether it was clicked.
+func drawMarkingSlotButton(item wire.MarkingMenuItem, label string, tex uint64, hasIcon bool, iconPx int, m native.StyleMetrics) bool {
+	if !hasIcon {
+		return native.Button(label + "##mm-" + item.CommandID)
+	}
+	native.BeginGroup()
+	clicked := native.ImageButton("##mm-"+item.CommandID, tex, float32(iconPx), float32(iconPx), identityTint)
+	native.SameLine()
+	cx, cy := native.GetCursorScreenPos()
+	native.SetCursorScreenPos(cx, cy+(float32(iconPx)+2*m.FramePadY-native.TextLineHeight())/2)
+	native.Text(label)
+	native.EndGroup()
+	return clicked
 }
 
 // markingSlotExtent mirrors the ImGui primitives used by drawMarkingSlot, so the ring can

--- a/head/ui/minitoolbar_view.go
+++ b/head/ui/minitoolbar_view.go
@@ -76,30 +76,36 @@ func miniToolbarScreenPos(cam scene.Camera, originX, originY float32, tb wire.Mi
 // drawMiniToolbarControl renders one control by kind, reporting edits through the
 // session so the owner sees miniToolbar.changed.
 func drawMiniToolbarControl(s *app.Session, toolbarID string, control wire.MiniToolbarControlSpec) {
-	changed := false
-	switch control.Kind {
-	case types.MiniToolbarCheckbox:
-		changed = native.Checkbox(control.Label, &control.Checked)
-	case types.MiniToolbarCombo:
-		changed = drawMiniToolbarCombo(&control)
-	case types.MiniToolbarSlider:
-		v := float32(control.Number)
-		if native.SliderFloat(control.Label, &v, float32(control.Min), float32(control.Max)) {
-			control.Number = roundSlider(float64(v))
-			changed = true
-		}
-	case types.MiniToolbarTextBox, types.MiniToolbarValueEditor:
-		changed = drawMiniToolbarText(&control, false)
-	case types.MiniToolbarTextEditor:
-		changed = drawMiniToolbarText(&control, true)
-	default: // MiniToolbarButton
-		changed = native.Button(control.Label)
-	}
+	changed := miniToolbarControlChanged(&control)
 	if control.Tooltip != "" {
 		native.SetItemTooltip(control.Tooltip)
 	}
 	if changed {
 		_ = s.ChangeMiniToolbarControl(toolbarID, control)
+	}
+}
+
+// miniToolbarControlChanged renders one mini-toolbar control by kind (writing any edit back into
+// *control) and reports whether the user changed it.
+func miniToolbarControlChanged(control *wire.MiniToolbarControlSpec) bool {
+	switch control.Kind {
+	case types.MiniToolbarCheckbox:
+		return native.Checkbox(control.Label, &control.Checked)
+	case types.MiniToolbarCombo:
+		return drawMiniToolbarCombo(control)
+	case types.MiniToolbarSlider:
+		v := float32(control.Number)
+		if native.SliderFloat(control.Label, &v, float32(control.Min), float32(control.Max)) {
+			control.Number = roundSlider(float64(v))
+			return true
+		}
+		return false
+	case types.MiniToolbarTextBox, types.MiniToolbarValueEditor:
+		return drawMiniToolbarText(control, false)
+	case types.MiniToolbarTextEditor:
+		return drawMiniToolbarText(control, true)
+	default: // MiniToolbarButton
+		return native.Button(control.Label)
 	}
 }
 

--- a/head/ui/offset_context_menu_test.go
+++ b/head/ui/offset_context_menu_test.go
@@ -1,0 +1,52 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"path/filepath"
+	"testing"
+
+	"oblikovati.org/app"
+)
+
+// TestInWindowOffsetContextMenuOptions renders the right-click menu with the Offset tool active and
+// checks its two in-command toggles (Loop Select / Constrain Offset) draw through the real cgo path.
+// It backs the live visual confirmation for Inventor's Offset right-click options and guards the
+// session wiring the menu reads.
+func TestInWindowOffsetContextMenuOptions(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+
+	s := framedSession()
+	s.StartTool(app.NewSketchOffsetTool(0.5))
+	if got := len(s.ActiveToolMenuOptions()); got != 2 {
+		t.Fatalf("offset tool exposed %d context-menu options, want 2 (Loop Select, Constrain Offset)", got)
+	}
+
+	render := func() {
+		for i := 0; i < 8; i++ {
+			win.BeginFrame()
+			DrawChrome(win, s)
+			win.EndFrame(0.1, 0.1, 0.1)
+		}
+	}
+
+	// Both styles must draw the options without crashing (classic linear and default radial).
+	s.SetClassicContextMenu(true)
+	openMarkingMenuOnFirstFrame = true
+	render()
+	if err := win.SaveWindowPNG(filepath.Join(outDir(), "mm-offset-options-classic.png")); err != nil {
+		t.Logf("SaveWindowPNG: %v", err)
+	}
+
+	s.SetClassicContextMenu(false)
+	openMarkingMenuOnFirstFrame = true
+	render()
+	if err := win.SaveWindowPNG(filepath.Join(outDir(), "mm-offset-options-radial.png")); err != nil {
+		t.Logf("SaveWindowPNG: %v", err)
+	}
+}

--- a/head/ui/projected_edge_side_sketch_test.go
+++ b/head/ui/projected_edge_side_sketch_test.go
@@ -29,7 +29,7 @@ func TestProjectedModelEdgeOnSideSketchDraws(t *testing.T) {
 	edge := projectableEdgeOnto(t, def, body, side.Plane())
 	side.ProjectCurve(compdef.NewEdgeRefSource(def, string(edge.ReferenceKey())))
 
-	if got := projectedCurveOverlay(side); len(got) == 0 {
+	if got := projectedCurveOverlay(side, nil, nil); len(got) == 0 {
 		t.Fatal("a model edge projected onto a side sketch must draw a polyline (#1496)")
 	}
 }

--- a/head/ui/projected_overlay_test.go
+++ b/head/ui/projected_overlay_test.go
@@ -11,6 +11,7 @@ import (
 	"oblikovati.org/model/compdef"
 	"oblikovati.org/model/feature"
 	"oblikovati.org/model/sketch"
+	"oblikovati.org/renderer"
 )
 
 // projectedSketch returns an XY sketch on a fresh part with the origin centre point and the YZ
@@ -31,11 +32,11 @@ func projectedSketch(t *testing.T) *sketch.Sketch {
 
 // TestProjectedCurveOverlayDrawsReferenceLines: a projected curve becomes a drawn polyline.
 func TestProjectedCurveOverlayDrawsReferenceLines(t *testing.T) {
-	if got := projectedCurveOverlay(projectedSketch(t)); len(got) != 1 {
+	if got := projectedCurveOverlay(projectedSketch(t), nil, nil); len(got) != 1 {
 		t.Fatalf("projectedCurveOverlay = %d items, want 1 (the projected reference line)", len(got))
 	}
-	if got := projectedCurveOverlay(nil); got != nil {
-		t.Errorf("projectedCurveOverlay(nil) = %v, want nil", got)
+	if got := projectedCurveOverlay(nil, nil, nil); got != nil {
+		t.Errorf("projectedCurveOverlay(nil, nil, nil) = %v, want nil", got)
 	}
 }
 
@@ -44,7 +45,7 @@ func TestProjectedCurveOverlayEmptyWhenNoProjection(t *testing.T) {
 	s := app.NewSession()
 	pd, _ := compdef.AddPart(s.Workspace(), "q.opd", true)
 	sk := pd.Content().(*compdef.PartComponentDefinition).Sketches().Add(sketch.XYPlane())
-	if got := projectedCurveOverlay(sk); got != nil {
+	if got := projectedCurveOverlay(sk, nil, nil); got != nil {
 		t.Errorf("projectedCurveOverlay of a curve-less sketch = %v, want nil", got)
 	}
 }
@@ -56,5 +57,44 @@ func TestPointsOverlayIncludesProjectedPoint(t *testing.T) {
 	item, ok := pointsOverlay(sk.Plane(), sk, 0.1)
 	if !ok || len(item.Positions) == 0 {
 		t.Fatal("pointsOverlay should glyph the projected origin point")
+	}
+}
+
+// firstProjectedCurve returns the sketch's first projected reference curve.
+func firstProjectedCurve(sk *sketch.Sketch) *sketch.ProjectedCurve {
+	for _, e := range sk.Entities() {
+		if pc, ok := e.(*sketch.ProjectedCurve); ok {
+			return pc
+		}
+	}
+	return nil
+}
+
+// drawListHasColor reports whether any item is drawn in color c.
+func drawListHasColor(items []renderer.DrawItem, c [4]float32) bool {
+	for _, it := range items {
+		if it.Color == c {
+			return true
+		}
+	}
+	return false
+}
+
+// TestProjectedCurveOverlayTintsHoverAndSelection is the #2158 follow-up: a projected curve must
+// draw in the candidate colour when it is the hover candidate and the selected colour when selected,
+// so the offset workflow sees what it is picking — before, projected curves always drew plain, so
+// selection worked but gave no feedback.
+func TestProjectedCurveOverlayTintsHoverAndSelection(t *testing.T) {
+	sk := projectedSketch(t)
+	pc := firstProjectedCurve(sk)
+	if pc == nil {
+		t.Fatal("setup: no projected curve")
+	}
+	if got := projectedCurveOverlay(sk, nil, pc); !drawListHasColor(got, chromeTheme.sketchCandidateColor) {
+		t.Error("hovered projected curve not drawn in the candidate colour")
+	}
+	sel := func(e sketch.Entity) bool { return e == pc }
+	if got := projectedCurveOverlay(sk, sel, nil); !drawListHasColor(got, chromeTheme.sketchSelectedColor) {
+		t.Error("selected projected curve not drawn in the selected colour")
 	}
 }

--- a/head/ui/qat.go
+++ b/head/ui/qat.go
@@ -131,7 +131,7 @@ var (
 // row (G design D1). Click actions are deferred via the package flags;
 // DrawChrome consumes them after drawRibbon.
 func drawQuickAccess(h appQatHost) {
-	drawAppMenuButton(h)
+	drawAppMenuButton()
 	for _, b := range qatButtons {
 		native.SameLine()
 		drawQATButton(h, b)
@@ -142,7 +142,7 @@ func drawQuickAccess(h appQatHost) {
 // glyph). It is archguard-clean: it only draws and sets the appMenuRequested
 // flag plus the button's screen position — the popup itself opens in
 // DrawChrome's context (ID-stack note, G design D3).
-func drawAppMenuButton(h appQatHost) {
+func drawAppMenuButton() {
 	px := float32(scaledIconPx(smallIconPx))
 	x, _ := native.GetCursorScreenPos()
 	var clicked bool

--- a/head/ui/ribbon_collapse.go
+++ b/head/ui/ribbon_collapse.go
@@ -146,17 +146,20 @@ func drawCollapsedPanel(s ribbonControlHost, panel app.RibbonPanel, tabName stri
 	// registers none), so the name centres under the tile exactly as it does under a grid.
 	drawPanelName(panel.Name, labelY)
 	native.EndGroup()
+	return drawCollapsedPanelFlyout(s, panel, id, tabName, x, labelY, m)
+}
 
-	// The flyout is a window of its own, so it is opened outside the layout group and pinned
-	// just under the band rather than at the pointer — Inventor drops a panel's flyout from
-	// the panel, not from the cursor. Its left edge is pulled back when the panel is too wide
-	// to drop straight down, because an explicit SetNextWindowPos overrides Dear ImGui's own
-	// on-screen clamping and the flyout would otherwise run off the right of the display —
-	// the very failure this whole system exists to end.
-	var activated string
+// drawCollapsedPanelFlyout opens the collapsed panel's flyout (popup id) — a window of its own,
+// opened outside the tile's layout group and pinned just under the band rather than at the pointer,
+// because Inventor drops a panel's flyout from the panel. Its left edge is pulled back when the panel
+// is too wide to drop straight down: an explicit SetNextWindowPos overrides Dear ImGui's own on-screen
+// clamp, so the flyout would otherwise run off the right of the display — the failure this whole
+// system exists to end. Returns the id of a command activated inside it, or "".
+func drawCollapsedPanelFlyout(s ribbonControlHost, panel app.RibbonPanel, id, tabName string, x, labelY float32, m native.StyleMetrics) string {
 	vpW, _ := native.MainViewportSize()
 	flyoutX := clampFlyoutX(x, ribbonPanelWidth[ribbonPanelWidthKey(tabName, panel.Name)], vpW)
 	native.SetNextWindowPos(flyoutX, labelY+native.TextLineHeight()+m.ItemSpacingY)
+	var activated string
 	if native.BeginPopup(id) {
 		if got := drawPanelFlyoutBody(s, panel); got != "" {
 			activated = got

--- a/head/ui/ribbon_scrollbar_test.go
+++ b/head/ui/ribbon_scrollbar_test.go
@@ -33,6 +33,7 @@ func ribbonSession(t *testing.T) *app.Session {
 // GPU/display.
 func driveRibbon(t *testing.T, w, h int) (collapsed int, scrollbar bool) {
 	t.Helper()
+	primeViewportSize(t, w, h) // ImGui's viewport size lags a window behind; prime it to w×h first
 	win, err := native.CreateWindow(w, h, "ribbon-scroll-test")
 	if err != nil {
 		t.Skipf("no window/Vulkan available: %v", err)
@@ -50,10 +51,51 @@ func driveRibbon(t *testing.T, w, h int) (collapsed int, scrollbar bool) {
 		clear(ribbonPanelWidth)
 	}()
 	s := ribbonSession(t)
-	for i := 0; i < 5; i++ { // settle the dock layout + let the fit decision stabilise
+	return settleRibbon(t, win, s)
+}
+
+// primeViewportSize works around a harness limitation: ImGui's main-viewport size reflects the
+// PREVIOUS window created in the process, not the one being drawn (the new offscreen window's
+// framebuffer extent never reaches io.DisplaySize within a test). A throwaway window of the target
+// size, rendered one frame then destroyed, becomes that "previous" window — so the real window below
+// measures at the intended w×h instead of whatever earlier test's size leaked in. Without this the
+// ribbon-fit tests measured against a stale width and were order-dependent.
+func primeViewportSize(t *testing.T, w, h int) {
+	prime, err := native.CreateWindow(w, h, "ribbon-scroll-prime")
+	if err != nil {
+		t.Skipf("no window/Vulkan available: %v", err)
+	}
+	prime.InitViewport()
+	prime.BeginFrame()
+	prime.EndFrame(0.1, 0.1, 0.1)
+	prime.Destroy()
+}
+
+// settleRibbon renders chrome frames until the ribbon's fit decision reaches STEADY STATE — the
+// collapsed-panel count and scrollbar flag unchanged for settleStableFrames consecutive frames —
+// then returns that settled result. A FIXED frame count is the wrong precondition: the fit reads the
+// dock layout's content-region width, which needs an unknown, machine-dependent number of frames to
+// lay out (and the band-height↔scrollbar feedback adds a frame of hysteresis), so a fixed five frames
+// sometimes sampled BEFORE the layout settled and the result flipped run-to-run (the #1471 tests'
+// order-dependent flakiness). Waiting for a stable state makes it deterministic. maxSettleFrames caps
+// the wait so a genuine non-convergence fails loudly rather than hanging.
+func settleRibbon(t *testing.T, win *native.Window, s *app.Session) (collapsed int, scrollbar bool) {
+	t.Helper()
+	const settleStableFrames, maxSettleFrames = 4, 240
+	stable, prevCollapsed, prevScroll := 0, -1, false
+	for i := 0; i < maxSettleFrames && stable < settleStableFrames; i++ {
 		win.BeginFrame()
 		DrawChrome(win, s)
 		win.EndFrame(0.1, 0.1, 0.1)
+		if ribbonCollapsedPanels == prevCollapsed && ribbonScrollbarShown == prevScroll {
+			stable++
+			continue
+		}
+		stable, prevCollapsed, prevScroll = 0, ribbonCollapsedPanels, ribbonScrollbarShown
+	}
+	if stable < settleStableFrames {
+		t.Fatalf("ribbon fit never settled in %d frames (collapsed=%d scrollbar=%v); it is oscillating",
+			maxSettleFrames, ribbonCollapsedPanels, ribbonScrollbarShown)
 	}
 	return ribbonCollapsedPanels, ribbonScrollbarShown
 }

--- a/head/ui/ribbon_scrollbar_test.go
+++ b/head/ui/ribbon_scrollbar_test.go
@@ -51,7 +51,11 @@ func driveRibbon(t *testing.T, w, h int) (collapsed int, scrollbar bool) {
 		clear(ribbonPanelWidth)
 	}()
 	s := ribbonSession(t)
-	return settleRibbon(t, win, s)
+	return settleRibbon(t, func() {
+		win.BeginFrame()
+		DrawChrome(win, s)
+		win.EndFrame(0.1, 0.1, 0.1)
+	})
 }
 
 // primeViewportSize works around a harness limitation: ImGui's main-viewport size reflects the
@@ -79,14 +83,12 @@ func primeViewportSize(t *testing.T, w, h int) {
 // sometimes sampled BEFORE the layout settled and the result flipped run-to-run (the #1471 tests'
 // order-dependent flakiness). Waiting for a stable state makes it deterministic. maxSettleFrames caps
 // the wait so a genuine non-convergence fails loudly rather than hanging.
-func settleRibbon(t *testing.T, win *native.Window, s *app.Session) (collapsed int, scrollbar bool) {
+func settleRibbon(t *testing.T, renderFrame func()) (collapsed int, scrollbar bool) {
 	t.Helper()
 	const settleStableFrames, maxSettleFrames = 4, 240
 	stable, prevCollapsed, prevScroll := 0, -1, false
 	for i := 0; i < maxSettleFrames && stable < settleStableFrames; i++ {
-		win.BeginFrame()
-		DrawChrome(win, s)
-		win.EndFrame(0.1, 0.1, 0.1)
+		renderFrame()
 		if ribbonCollapsedPanels == prevCollapsed && ribbonScrollbarShown == prevScroll {
 			stable++
 			continue

--- a/head/ui/shell_dialog.go
+++ b/head/ui/shell_dialog.go
@@ -31,21 +31,28 @@ func drawShellDialog(s *app.Session) {
 	}
 	dialogSizeOnce(340, 230)
 	if native.Begin("Shell") {
-		title := "Shell"
-		if name := sh.EditingName(); name != "" {
-			title = name // re-editing a committed shell: the breadcrumb names it
-		}
-		drawFeatureBreadcrumb(title, "")
-		if propertySection("Input Geometry") {
-			drawPickChipRow("Remove", "shell-faces", countChipText(sh.FaceCount(), "Face", "Select Faces"),
-				sh.FaceCount() > 0, "Click the faces to open (they are removed; the rest walls in)", sh.ClearFaces)
-		}
-		if propertySection("Behavior") {
-			lengthCmRow(s, "Thickness", "shell-thickness", &shellUI.thickness)
-			sh.SetThickness(float64(shellUI.thickness))
-		}
-		native.Separator()
-		drawCommitCancelButtons(s, sh.CanCommit())
+		drawShellBody(s, sh)
 	}
 	native.End()
+}
+
+// drawShellBody fills the Shell panel: the breadcrumb, the faces-to-remove pick row, and the wall
+// Thickness, then the commit/cancel buttons. Split from drawShellDialog to keep each within one
+// screen of widgets.
+func drawShellBody(s *app.Session, sh *app.ShellTool) {
+	title := "Shell"
+	if name := sh.EditingName(); name != "" {
+		title = name // re-editing a committed shell: the breadcrumb names it
+	}
+	drawFeatureBreadcrumb(title, "")
+	if propertySection("Input Geometry") {
+		drawPickChipRow("Remove", "shell-faces", countChipText(sh.FaceCount(), "Face", "Select Faces"),
+			sh.FaceCount() > 0, "Click the faces to open (they are removed; the rest walls in)", sh.ClearFaces)
+	}
+	if propertySection("Behavior") {
+		lengthCmRow(s, "Thickness", "shell-thickness", &shellUI.thickness)
+		sh.SetThickness(float64(shellUI.thickness))
+	}
+	native.Separator()
+	drawCommitCancelButtons(s, sh.CanCommit())
 }

--- a/head/ui/shell_dialog.go
+++ b/head/ui/shell_dialog.go
@@ -31,28 +31,29 @@ func drawShellDialog(s *app.Session) {
 	}
 	dialogSizeOnce(340, 230)
 	if native.Begin("Shell") {
-		drawShellBody(s, sh)
+		title := "Shell"
+		if name := sh.EditingName(); name != "" {
+			title = name // re-editing a committed shell: the breadcrumb names it
+		}
+		drawFeatureBreadcrumb(title, "")
+		drawShellInputGeometry(sh)
+		if propertySection("Behavior") {
+			lengthCmRow(s, "Thickness", "shell-thickness", &shellUI.thickness)
+			sh.SetThickness(float64(shellUI.thickness))
+		}
+		native.Separator()
+		drawCommitCancelButtons(s, sh.CanCommit())
 	}
 	native.End()
 }
 
-// drawShellBody fills the Shell panel: the breadcrumb, the faces-to-remove pick row, and the wall
-// Thickness, then the commit/cancel buttons. Split from drawShellDialog to keep each within one
-// screen of widgets.
-func drawShellBody(s *app.Session, sh *app.ShellTool) {
-	title := "Shell"
-	if name := sh.EditingName(); name != "" {
-		title = name // re-editing a committed shell: the breadcrumb names it
+// drawShellInputGeometry draws the Shell panel's Input Geometry section — the faces-to-remove chip.
+// Tool-only (no session), so the split reduces drawShellDialog's length without widening head/ui's
+// *app.Session coupling (audit I5).
+func drawShellInputGeometry(sh *app.ShellTool) {
+	if !propertySection("Input Geometry") {
+		return
 	}
-	drawFeatureBreadcrumb(title, "")
-	if propertySection("Input Geometry") {
-		drawPickChipRow("Remove", "shell-faces", countChipText(sh.FaceCount(), "Face", "Select Faces"),
-			sh.FaceCount() > 0, "Click the faces to open (they are removed; the rest walls in)", sh.ClearFaces)
-	}
-	if propertySection("Behavior") {
-		lengthCmRow(s, "Thickness", "shell-thickness", &shellUI.thickness)
-		sh.SetThickness(float64(shellUI.thickness))
-	}
-	native.Separator()
-	drawCommitCancelButtons(s, sh.CanCommit())
+	drawPickChipRow("Remove", "shell-faces", countChipText(sh.FaceCount(), "Face", "Select Faces"),
+		sh.FaceCount() > 0, "Click the faces to open (they are removed; the rest walls in)", sh.ClearFaces)
 }

--- a/head/ui/sketch_overlay.go
+++ b/head/ui/sketch_overlay.go
@@ -208,7 +208,7 @@ func projectedCurveOverlay(sk *sketch.Sketch, selected func(sketch.Entity) bool,
 		case selected != nil && selected(e):
 			acc = sel
 		}
-		acc.polyline(plane, pc.Points(), false)
+		acc.polyline(plane, pc.RenderPolyline(), false)
 	}
 	items := appendGrid(nil, normal, chromeTheme.sketchColor)
 	items = appendGrid(items, sel, chromeTheme.sketchSelectedColor)

--- a/head/ui/sketch_overlay.go
+++ b/head/ui/sketch_overlay.go
@@ -127,7 +127,7 @@ func partSketchOverlays(s *app.Session) []renderer.DrawItem {
 			continue
 		}
 		items = append(items, sketchOverlay(sk, allEntitiesWhenSelected(sk, selected), nil, s.ShowFormat())...)
-		items = append(items, projectedCurveOverlay(sk)...)
+		items = append(items, projectedCurveOverlay(sk, nil, nil)...)
 	}
 	return items
 }
@@ -186,20 +186,33 @@ func sketchOverlay(sk *sketch.Sketch, selected func(sketch.Entity) bool, candida
 
 // projectedCurveOverlay draws a sketch's projected reference curves — the lines projected from
 // edges or datum geometry (axes, plane↔sketch intersections, #1262). They live in the entity
-// list rather than the typed Lines/Arcs collections, so sketchOverlay misses them; this draws
-// each as a polyline in the sketch colour. Returns nil when the sketch projects no curves.
-func projectedCurveOverlay(sk *sketch.Sketch) []renderer.DrawItem {
+// list rather than the typed Lines/Arcs collections, so sketchOverlay misses them; this draws each
+// as a polyline, tinting the hover candidate and the selected curves the same way sketchOverlay
+// does its own geometry — without which a projected curve gave no hover/selection feedback even
+// though it is pickable (#2158 follow-up). Returns nil when the sketch projects no curves.
+func projectedCurveOverlay(sk *sketch.Sketch, selected func(sketch.Entity) bool, candidate sketch.Entity) []renderer.DrawItem {
 	if sk == nil {
 		return nil
 	}
 	plane := sk.Plane()
-	acc := &segAccum{}
+	normal, sel, cand := &segAccum{}, &segAccum{}, &segAccum{}
 	for _, e := range sk.Entities() {
-		if pc, ok := e.(*sketch.ProjectedCurve); ok {
-			acc.polyline(plane, pc.Points(), false)
+		pc, ok := e.(*sketch.ProjectedCurve)
+		if !ok {
+			continue
 		}
+		acc := normal
+		switch {
+		case candidate != nil && e == candidate:
+			acc = cand
+		case selected != nil && selected(e):
+			acc = sel
+		}
+		acc.polyline(plane, pc.Points(), false)
 	}
-	return appendGrid(nil, acc, chromeTheme.sketchColor)
+	items := appendGrid(nil, normal, chromeTheme.sketchColor)
+	items = appendGrid(items, sel, chromeTheme.sketchSelectedColor)
+	return appendGrid(items, cand, chromeTheme.sketchCandidateColor)
 }
 
 func sketchSegmentsFor(sk *sketch.Sketch, selected func(sketch.Entity) bool, candidate sketch.Entity, suppress bool) *sketchStyleBuckets {

--- a/head/ui/sketch_project_test.go
+++ b/head/ui/sketch_project_test.go
@@ -1,0 +1,82 @@
+//go:build cgo
+
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ui
+
+import (
+	"testing"
+
+	"oblikovati.org/app"
+	"oblikovati.org/head/internal/native"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+	"oblikovati.org/scene"
+)
+
+// projectedCurveCount counts the sketch's projected reference curves.
+func projectedCurveCount(sk *sketch.Sketch) int {
+	n := 0
+	for _, e := range sk.Entities() {
+		if _, ok := e.(*sketch.ProjectedCurve); ok {
+			n++
+		}
+	}
+	return n
+}
+
+// TestSketchProjectHighlightsAndProjectsModelFace is the end-to-end regression for the reported
+// Project Geometry gaps while editing a sketch: (1) the model face under the cursor must HIGHLIGHT
+// (the sketch overlay path never drew the model-reference hover highlight, so a projectable face
+// looked dead, #2158), and (2) a single click must PROJECT it — no dialog, no OK — with the tool
+// staying armed. A straight-down camera puts the box's top face under the centre pixel.
+func TestSketchProjectHighlightsAndProjectsModelFace(t *testing.T) {
+	win := newViewportWindow(t)
+	defer win.Destroy()
+	dockLaidOut = false
+	icons = nil
+
+	s := boxHostSession(t) // box [0,6]³ on XY
+	cam := scene.NewCamera(inWinW, inWinH)
+	cam.Eye, cam.Target, cam.Up = math.P3(3, 3, 30), math.P3(3, 3, 0), math.V3(0, 1, 0)
+	s.SetCamera(cam)
+	s.SetPicker(app.NewRayPicker(cam, func() []*topo.Body { return s.VisibleBodies() }))
+	if _, err := s.CreateSketch(sketch.XYPlane()); err != nil {
+		t.Fatalf("CreateSketch: %v", err)
+	}
+	if !s.InSketch() {
+		t.Fatal("expected to be editing the sketch")
+	}
+	s.StartTool(app.NewProjectGeometryTool())
+	sk := s.ActiveSketch()
+
+	cx, cy := float32(inWinW/2), float32(inWinH/2)
+	for i := 0; i < 10; i++ {
+		native.InjectMousePos(cx, cy)
+		viewportFrame(win, s)
+	}
+	// (1) The model face under the cursor resolves through the tool's filter — so it highlights and
+	// is projectable while editing the sketch (the sketch overlay path now draws the model-reference
+	// hover highlight for a model-reference tool, #2158).
+	ox, oy := native.ItemRectMin()
+	lx, ly := float64(cx-ox), float64(cy-oy)
+	if !s.ToolPicksModelReferences() {
+		t.Fatal("Project Geometry must pick model references while in-sketch")
+	}
+	if sel, ok := s.PickAt(lx, ly, s.Selection().Filter()); !ok {
+		t.Fatal("no model geometry under the cursor through the tool filter")
+	} else if _, isFace := sel.(app.FaceHandle); !isFace {
+		t.Fatalf("hover resolved to %T, want a FaceHandle (face highlight/projection)", sel)
+	}
+
+	// (2) A single click projects the face's perimeter — no OK — and the tool stays armed.
+	before := projectedCurveCount(sk)
+	s.Click(lx, ly)
+	if got := projectedCurveCount(sk) - before; got != 4 {
+		t.Fatalf("a click projected %d curves, want 4 (the top face's edges) — no OK needed", got)
+	}
+	if s.ActiveTool() == nil {
+		t.Error("Project Geometry deactivated after one click; it must stay armed for the next pick")
+	}
+}

--- a/head/ui/sketch_project_test.go
+++ b/head/ui/sketch_project_test.go
@@ -9,10 +9,9 @@ import (
 
 	"oblikovati.org/app"
 	"oblikovati.org/head/internal/native"
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
-	"oblikovati.org/math"
 	"oblikovati.org/model/sketch"
-	"oblikovati.org/scene"
 )
 
 // projectedCurveCount counts the sketch's projected reference curves.
@@ -26,57 +25,64 @@ func projectedCurveCount(sk *sketch.Sketch) int {
 	return n
 }
 
-// TestSketchProjectHighlightsAndProjectsModelFace is the end-to-end regression for the reported
-// Project Geometry gaps while editing a sketch: (1) the model face under the cursor must HIGHLIGHT
-// (the sketch overlay path never drew the model-reference hover highlight, so a projectable face
-// looked dead, #2158), and (2) a single click must PROJECT it — no dialog, no OK — with the tool
-// staying armed. A straight-down camera puts the box's top face under the centre pixel.
-func TestSketchProjectHighlightsAndProjectsModelFace(t *testing.T) {
+// topCapFace returns the box's +Z planar cap face.
+func topCapFace(t *testing.T, body *topo.Body) *topo.Face {
+	t.Helper()
+	for _, f := range body.Faces() {
+		if pl, ok := f.Geometry().(geom.Plane); ok && float64(pl.Normal().Z) > 0.9 {
+			return f
+		}
+	}
+	t.Fatal("no +Z cap face on the box")
+	return nil
+}
+
+// TestSketchProjectPerPickAndRenders is the end-to-end regression for the reported Project Geometry
+// gaps while editing a sketch: the tool picks model references (so the head draws the model-face
+// hover highlight in the sketch overlay path, #2158), a single pick PROJECTS the face's perimeter
+// with no dialog/OK and the tool stays armed, and the sketch-edit frame — now carrying the projected
+// curves and the model-reference highlight — renders without crashing. It picks the face directly to
+// stay independent of viewport pixel layout.
+func TestSketchProjectPerPickAndRenders(t *testing.T) {
 	win := newViewportWindow(t)
 	defer win.Destroy()
 	dockLaidOut = false
 	icons = nil
 
 	s := boxHostSession(t) // box [0,6]³ on XY
-	cam := scene.NewCamera(inWinW, inWinH)
-	cam.Eye, cam.Target, cam.Up = math.P3(3, 3, 30), math.P3(3, 3, 0), math.V3(0, 1, 0)
-	s.SetCamera(cam)
-	s.SetPicker(app.NewRayPicker(cam, func() []*topo.Body { return s.VisibleBodies() }))
+	body := s.VisibleBodies()[0]
+	top := topCapFace(t, body)
+	frameCameraOn(s, body.RangeBox())
 	if _, err := s.CreateSketch(sketch.XYPlane()); err != nil {
 		t.Fatalf("CreateSketch: %v", err)
 	}
 	if !s.InSketch() {
 		t.Fatal("expected to be editing the sketch")
 	}
-	s.StartTool(app.NewProjectGeometryTool())
-	sk := s.ActiveSketch()
+	tool := app.NewProjectGeometryTool()
+	s.StartTool(tool)
 
-	cx, cy := float32(inWinW/2), float32(inWinH/2)
-	for i := 0; i < 10; i++ {
-		native.InjectMousePos(cx, cy)
-		viewportFrame(win, s)
-	}
-	// (1) The model face under the cursor resolves through the tool's filter — so it highlights and
-	// is projectable while editing the sketch (the sketch overlay path now draws the model-reference
-	// hover highlight for a model-reference tool, #2158).
-	ox, oy := native.ItemRectMin()
-	lx, ly := float64(cx-ox), float64(cy-oy)
+	// The head draws the model-reference hover highlight in-sketch only for a tool that picks model
+	// references — the wiring that made a projectable face visible again (#2158).
 	if !s.ToolPicksModelReferences() {
 		t.Fatal("Project Geometry must pick model references while in-sketch")
 	}
-	if sel, ok := s.PickAt(lx, ly, s.Selection().Filter()); !ok {
-		t.Fatal("no model geometry under the cursor through the tool filter")
-	} else if _, isFace := sel.(app.FaceHandle); !isFace {
-		t.Fatalf("hover resolved to %T, want a FaceHandle (face highlight/projection)", sel)
-	}
 
-	// (2) A single click projects the face's perimeter — no OK — and the tool stays armed.
+	// A single pick projects the face's four boundary edges immediately — no OK — and the tool stays
+	// armed for the next pick.
+	sk := s.ActiveSketch()
 	before := projectedCurveCount(sk)
-	s.Click(lx, ly)
+	tool.Pick(s, app.FaceHandle{Face: top, Body: body})
 	if got := projectedCurveCount(sk) - before; got != 4 {
-		t.Fatalf("a click projected %d curves, want 4 (the top face's edges) — no OK needed", got)
+		t.Fatalf("picking the face projected %d curves, want 4 (its edges) — no OK needed", got)
 	}
 	if s.ActiveTool() == nil {
-		t.Error("Project Geometry deactivated after one click; it must stay armed for the next pick")
+		t.Error("Project Geometry deactivated after one pick; it must stay armed")
+	}
+
+	// The sketch-edit frame (projected-curve overlay + model-reference highlight wiring) renders.
+	for i := 0; i < 4; i++ {
+		native.InjectMousePos(float32(inWinW/2), float32(inWinH/2))
+		viewportFrame(win, s)
 	}
 }

--- a/head/ui/snap_glyph.go
+++ b/head/ui/snap_glyph.go
@@ -62,11 +62,18 @@ func pointsOverlay(plane sketch.Plane, sk *sketch.Sketch, hWorld float64) (rende
 	for i := 0; i < pts.Count(); i++ {
 		acc.targetMarker(plane, pts.Item(i).Position(), hWorld)
 	}
-	// Projected point anchors (e.g. the auto-projected origin centre, #1262) live in the
-	// entity list, not the typed Points collection, so glyph them here too.
+	// Projected point anchors (e.g. the auto-projected origin centre, #1262) and the centres of
+	// circular entities live in the entity list, not the typed Points collection, so glyph them
+	// here too. A circle's/arc's centre is a real, constrainable sketch point; without a marker
+	// the user has no hover target for it. A circle's centre hides at its visual centroid so it
+	// snaps by luck, but an arc's centre sits off the curve in empty space — which made a
+	// coincident-to-origin on an arc centre impossible to aim at ("the arc has no centre", #2159).
 	for _, e := range sk.Entities() {
-		if pp, ok := e.(*sketch.ProjectedPoint); ok {
-			acc.targetMarker(plane, pp.Position(), hWorld)
+		switch v := e.(type) {
+		case *sketch.ProjectedPoint:
+			acc.targetMarker(plane, v.Position(), hWorld)
+		case sketch.CircularCurve:
+			acc.targetMarker(plane, v.CenterPoint().Position(), hWorld)
 		}
 	}
 	if len(acc.pos) == 0 {

--- a/head/ui/snap_glyph.go
+++ b/head/ui/snap_glyph.go
@@ -62,19 +62,20 @@ func pointsOverlay(plane sketch.Plane, sk *sketch.Sketch, hWorld float64) (rende
 	for i := 0; i < pts.Count(); i++ {
 		acc.targetMarker(plane, pts.Item(i).Position(), hWorld)
 	}
-	// Projected point anchors (e.g. the auto-projected origin centre, #1262) and the centres of
-	// circular entities live in the entity list, not the typed Points collection, so glyph them
-	// here too. A circle's/arc's centre is a real, constrainable sketch point; without a marker
-	// the user has no hover target for it. A circle's centre hides at its visual centroid so it
-	// snaps by luck, but an arc's centre sits off the curve in empty space — which made a
-	// coincident-to-origin on an arc centre impossible to aim at ("the arc has no centre", #2159).
+	// Projected point anchors (e.g. the auto-projected origin centre, #1262) live in the entity
+	// list, not the typed Points collection, so glyph them here too.
 	for _, e := range sk.Entities() {
-		switch v := e.(type) {
-		case *sketch.ProjectedPoint:
-			acc.targetMarker(plane, v.Position(), hWorld)
-		case sketch.CircularCurve:
-			acc.targetMarker(plane, v.CenterPoint().Position(), hWorld)
+		if pp, ok := e.(*sketch.ProjectedPoint); ok {
+			acc.targetMarker(plane, pp.Position(), hWorld)
 		}
+	}
+	// A circle's/arc's centre is a real, constrainable sketch point but is not in the Points
+	// collection. Without a marker the user has no hover target for it: a circle's centre hides at
+	// its visual centroid so it snaps by luck, but an arc's centre sits off the curve in empty
+	// space — which made a coincident-to-origin on an arc centre impossible to aim at ("the arc has
+	// no centre", #2159). The sketch supplies the centres so the head draws no entity-type switch.
+	for _, c := range sk.CircularCenters() {
+		acc.targetMarker(plane, c, hWorld)
 	}
 	if len(acc.pos) == 0 {
 		return renderer.DrawItem{}, false

--- a/head/ui/tool_highlight.go
+++ b/head/ui/tool_highlight.go
@@ -154,13 +154,22 @@ func faceFill(fh app.FaceHandle, color [4]float32) renderer.DrawItem {
 // faceFillOpacity keeps the face tint translucent so the face's shading still reads through.
 const faceFillOpacity = 0.5
 
+// regionBadgeSession is drawRegionModifierBadge's slim view of the session (audit I5): just the
+// add/remove decision for the region under the cursor. RegionModifierHint already returns show=false
+// when no region tool is active, so the badge needs nothing else.
+type regionBadgeSession interface {
+	RegionModifierHint(x, y float64, mods app.Modifier) (show, add bool)
+}
+
+var _ regionBadgeSession = (*app.Session)(nil)
+
 // drawRegionModifierBadge draws a +/− glyph beside the cursor when a modified click during area
 // selection would ADD or REMOVE the region under the cursor — Inventor's add/remove cursor feedback
 // (#2165). It renders in screen space in the viewport-overlay pass (not part of the 3D draw list), so
 // it must be called while the viewport item is current. Nothing is drawn unless a region multi-select
 // tool is active, a modifier is held, and a region sits under the cursor (RegionModifierHint).
-func drawRegionModifierBadge(s *app.Session) {
-	if s.ActiveTool() == nil || !native.IsItemHovered() {
+func drawRegionModifierBadge(s regionBadgeSession) {
+	if !native.IsItemHovered() {
 		return
 	}
 	var mods app.Modifier

--- a/head/ui/tool_highlight.go
+++ b/head/ui/tool_highlight.go
@@ -9,6 +9,8 @@ import (
 	"oblikovati.org/head/internal/native"
 	"oblikovati.org/kernel/ops"
 	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
 	"oblikovati.org/renderer"
 )
 
@@ -28,7 +30,7 @@ import (
 func drawSelectable(sel app.Selectable, color [4]float32) []renderer.DrawItem {
 	switch h := sel.(type) {
 	case app.ProfileHandle:
-		return profileOutline(h, color)
+		return appendProfileFill(profileOutline(h, color), h, color)
 	case app.EdgeHandle:
 		return edgeWire([]*topo.Edge{h.Edge}, color)
 	case app.FaceHandle:
@@ -88,6 +90,51 @@ func toolHoverHighlight(s *app.Session) []renderer.DrawItem {
 	return drawSelectable(sel, chromeTheme.sketchCandidateColor)
 }
 
+// appendProfileFill adds a translucent, always-on-top tint of a sketch region (its outer loop minus
+// its holes, ear-clipped) to items — the filled part of a region highlight, so hovering or selecting a
+// profile lights the WHOLE area, not only its outline, matching Inventor's region highlight (#2165). A
+// stale index or a region whose triangulation is empty adds nothing.
+func appendProfileFill(items []renderer.DrawItem, ph app.ProfileHandle, color [4]float32) []renderer.DrawItem {
+	if ph.ProfileIndex >= ph.Sketch.Profiles().Count() {
+		return items
+	}
+	prof := ph.Sketch.Profiles().Item(ph.ProfileIndex)
+	if !prof.IsClosed() {
+		return items // an open profile bounds no area to fill
+	}
+	outer := prof.OuterLoop().Polygon()
+	verts := append([]math.Point2(nil), outer...)
+	holes := make([][]math.Point2, 0, len(prof.InnerLoops()))
+	for _, h := range prof.InnerLoops() {
+		holes = append(holes, h.Polygon())
+		verts = append(verts, h.Polygon()...)
+	}
+	tris := ops.FillTriangles(outer, holes)
+	if len(tris) == 0 {
+		return items
+	}
+	return append(items, regionFillItem(ph.Sketch.Plane(), verts, tris, color))
+}
+
+// regionFillItem lifts a region's 2D triangulation onto its sketch plane as one translucent on-top
+// Triangles item (the fill shares the profile-outline colour, at the face-fill opacity).
+func regionFillItem(plane sketch.Plane, verts []math.Point2, tris [][3]int, color [4]float32) renderer.DrawItem {
+	pos := make([]math.Point3, len(verts))
+	normals := make([]math.Vector3, len(verts))
+	n := plane.Normal().AsVector()
+	for i, p := range verts {
+		pos[i], normals[i] = plane.ToModel(p), n
+	}
+	idx := make([]int, 0, len(tris)*3)
+	for _, t := range tris {
+		idx = append(idx, t[0], t[1], t[2])
+	}
+	return renderer.DrawItem{
+		Primitive: renderer.Triangles, Positions: pos, Normals: normals, Indices: idx,
+		Color: color, Opacity: faceFillOpacity, OnTop: true,
+	}
+}
+
 // faceFill returns a translucent, always-on-top tint of a face's tessellation — the visible part
 // of a face highlight (the highlighted face is the front-most hit, so drawing it on top reads
 // cleanly without z-fighting the model's own edges). Used for both preselect and selected faces.
@@ -106,6 +153,47 @@ func faceFill(fh app.FaceHandle, color [4]float32) renderer.DrawItem {
 
 // faceFillOpacity keeps the face tint translucent so the face's shading still reads through.
 const faceFillOpacity = 0.5
+
+// drawRegionModifierBadge draws a +/− glyph beside the cursor when a modified click during area
+// selection would ADD or REMOVE the region under the cursor — Inventor's add/remove cursor feedback
+// (#2165). It renders in screen space in the viewport-overlay pass (not part of the 3D draw list), so
+// it must be called while the viewport item is current. Nothing is drawn unless a region multi-select
+// tool is active, a modifier is held, and a region sits under the cursor (RegionModifierHint).
+func drawRegionModifierBadge(s *app.Session) {
+	if s.ActiveTool() == nil || !native.IsItemHovered() {
+		return
+	}
+	var mods app.Modifier
+	if native.KeyCtrl() {
+		mods |= app.CtrlMod
+	}
+	if native.KeyShift() {
+		mods |= app.ShiftMod
+	}
+	cx, cy := viewportCursor()
+	show, add := s.RegionModifierHint(cx, cy, mods)
+	if !show {
+		return
+	}
+	mx, my := native.MousePos()
+	drawCursorPlusMinus(mx, my, add)
+}
+
+// drawCursorPlusMinus paints a small badge offset from the cursor: a green plus for ADD, a red minus
+// for REMOVE — the horizontal bar is common to both, the vertical bar makes the plus.
+func drawCursorPlusMinus(mx, my float32, add bool) {
+	const off, half = 13.0, 5.0
+	bx, by := mx+off, my+off
+	native.DrawRectFilled(bx-half-2, by-half-2, bx+half+2, by+half+2, [4]float32{0.11, 0.11, 0.12, 0.88})
+	fg := [4]float32{0.45, 0.95, 0.45, 1} // add → green
+	if !add {
+		fg = [4]float32{0.98, 0.5, 0.5, 1} // remove → red
+	}
+	native.DrawLine(bx-half, by, bx+half, by, fg, 2)
+	if add {
+		native.DrawLine(bx, by-half, bx, by+half, fg, 2)
+	}
+}
 
 // toolSelectedHighlight highlights everything the active tool has picked, in the selection colour —
 // the picks come from the uniform app.Picking contract (s.ToolPicks), so every tool highlights its

--- a/head/ui/triad_view.go
+++ b/head/ui/triad_view.go
@@ -142,35 +142,40 @@ func routeGizmoInput(s *app.Session, cam scene.Camera) bool {
 		return false
 	}
 	mx, my := viewportCursor()
-	return handleGizmoHover(s, cam, mx, my)
-}
-
-// handleGizmoHover handles the pointer over a non-dragging gizmo: a triad segment under the cursor is
-// hovered (and, on a left click, begins its drag); otherwise a manipulator handle under the cursor
-// begins its drag on a left click. It reports whether the gizmo consumed the pointer this frame.
-func handleGizmoHover(s *app.Session, cam scene.Camera, mx, my float64) bool {
+	// The pointer ray and pick tolerance are the same for a triad-segment or a manipulator-handle
+	// grab, so compute them once for both branches (this also keeps the function within one screen).
+	rayO, rayD := cam.RayThrough(mx, my)
+	snapTol := gizmoHitPx * cam.WorldPerPixel()
 	if seg, hit := triadHitTest(s, cam, mx, my); hit {
 		s.HoverTriadSegment(seg, true)
 		if native.IsItemClicked(native.MouseLeft) {
-			rayO, rayD := cam.RayThrough(mx, my)
-			snapTol := gizmoHitPx * cam.WorldPerPixel()
 			_ = s.BeginTriadDrag(seg, rayO, rayD, snapTol, native.KeyShift(), native.KeyCtrl())
 		}
 		return true
 	}
 	s.HoverTriadSegment(types.TriadOrigin, false)
 	if gizmo, handle, hit := manipulatorHitTest(s, cam, mx, my); hit && native.IsItemClicked(native.MouseLeft) {
-		rayO, rayD := cam.RayThrough(mx, my)
 		forward := unitV(cam.Eye.VectorTo(cam.Target))
-		snapTol := gizmoHitPx * cam.WorldPerPixel()
 		_ = s.BeginManipulatorDrag(gizmo, handle, forward.Scale(-1), rayO, rayD, snapTol, native.KeyShift(), native.KeyCtrl())
 		return true
 	}
 	return false
 }
 
+// gizmoDragSession is the in-flight-drag machine continueGizmoDrag needs — five methods, not the
+// whole session (audit I5).
+type gizmoDragSession interface {
+	TriadDragging() bool
+	DragTriad(rayO math.Point3, rayD math.Vector3, shift, ctrl bool) error
+	DragManipulator(rayO math.Point3, rayD math.Vector3, shift, ctrl bool) error
+	EndTriadDrag(rayO math.Point3, rayD math.Vector3, shift, ctrl bool) error
+	EndManipulatorDrag(rayO math.Point3, rayD math.Vector3, shift, ctrl bool) error
+}
+
+var _ gizmoDragSession = (*app.Session)(nil)
+
 // continueGizmoDrag advances or ends the in-flight gesture with the pointer ray.
-func continueGizmoDrag(s *app.Session, cam scene.Camera) {
+func continueGizmoDrag(s gizmoDragSession, cam scene.Camera) {
 	mx, my := viewportCursor()
 	rayO, rayD := cam.RayThrough(mx, my)
 	shift, ctrl := native.KeyShift(), native.KeyCtrl()

--- a/head/ui/triad_view.go
+++ b/head/ui/triad_view.go
@@ -142,6 +142,13 @@ func routeGizmoInput(s *app.Session, cam scene.Camera) bool {
 		return false
 	}
 	mx, my := viewportCursor()
+	return handleGizmoHover(s, cam, mx, my)
+}
+
+// handleGizmoHover handles the pointer over a non-dragging gizmo: a triad segment under the cursor is
+// hovered (and, on a left click, begins its drag); otherwise a manipulator handle under the cursor
+// begins its drag on a left click. It reports whether the gizmo consumed the pointer this frame.
+func handleGizmoHover(s *app.Session, cam scene.Camera, mx, my float64) bool {
 	if seg, hit := triadHitTest(s, cam, mx, my); hit {
 		s.HoverTriadSegment(seg, true)
 		if native.IsItemClicked(native.MouseLeft) {
@@ -201,19 +208,25 @@ func triadHitTest(s *app.Session, cam scene.Camera, mx, my float64) (types.Triad
 		}
 	}
 	for i, axis := range axes {
-		for _, t := range []float64{0.4, 0.7, 1.0} {
-			probe(types.TriadSegment(uint8(types.TriadXAxis)+uint8(i)), pos.TranslateBy(axis.Scale(worldLen*t)))
-		}
-		u, v := planeBasis(axis)
-		ringSeg := types.TriadSegment(uint8(types.TriadXRing) + uint8(i))
-		for k := 0; k < 16; k++ {
-			ang := 2 * stdmath.Pi * float64(k) / 16
-			offset := u.Scale(0.75 * worldLen * stdmath.Cos(ang)).Add(v.Scale(0.75 * worldLen * stdmath.Sin(ang)))
-			probe(ringSeg, pos.TranslateBy(offset))
-		}
+		probeTriadAxis(i, axis, pos, worldLen, probe)
 	}
 	probe(types.TriadOrigin, pos)
 	return best, found
+}
+
+// probeTriadAxis feeds axis i's three grip points (at 0.4/0.7/1.0 of its length) and its 16-point
+// rotation ring to probe, which keeps the nearest hit.
+func probeTriadAxis(i int, axis math.Vector3, pos math.Point3, worldLen float64, probe func(types.TriadSegment, math.Point3)) {
+	for _, t := range []float64{0.4, 0.7, 1.0} {
+		probe(types.TriadSegment(uint8(types.TriadXAxis)+uint8(i)), pos.TranslateBy(axis.Scale(worldLen*t)))
+	}
+	u, v := planeBasis(axis)
+	ringSeg := types.TriadSegment(uint8(types.TriadXRing) + uint8(i))
+	for k := 0; k < 16; k++ {
+		ang := 2 * stdmath.Pi * float64(k) / 16
+		offset := u.Scale(0.75 * worldLen * stdmath.Cos(ang)).Add(v.Scale(0.75 * worldLen * stdmath.Sin(ang)))
+		probe(ringSeg, pos.TranslateBy(offset))
+	}
 }
 
 // manipulatorHitTest finds the handle under the cursor.

--- a/head/ui/ui_tab.go
+++ b/head/ui/ui_tab.go
@@ -29,9 +29,15 @@ func drawUITab(s *app.Session) {
 	native.Separator()
 	native.Text("Text size also scales the Script Console code editor.")
 	native.Separator()
-	// Mouse-navigation preferences (Inventor-parity, 2026-08-17). Defaults
-	// match Inventor: middle-drag pans, Shift+middle-drag orbits, scroll-up
-	// zooms in, wheel zooms to the cursor.
+	drawMouseNavPrefs(s)
+	native.Separator()
+	drawWindowChromePrefs(s)
+}
+
+// drawMouseNavPrefs draws the middle-button gesture selectors and the wheel-zoom checkboxes
+// (Inventor-parity, 2026-08-17): defaults are middle-drag pans, Shift+middle-drag orbits, scroll-up
+// zooms in, and the wheel zooms to the cursor.
+func drawMouseNavPrefs(s *app.Session) {
 	native.Text("Mouse navigation (defaults match Inventor):")
 	editNavModeCombo("Middle button drag", s.MMBMode(), s.SetMMBMode, navModeOptions("pan"))
 	editNavModeCombo("Shift + middle button drag", s.ShiftMMBMode(), s.SetShiftMMBMode, navModeOptions("orbit"))
@@ -44,12 +50,15 @@ func drawUITab(s *app.Session) {
 	if native.Checkbox("Zoom to cursor", &toCursor) {
 		reportPrefError(s.SetZoomToCursor(toCursor))
 	}
-	native.Separator()
+}
+
+// drawWindowChromePrefs draws the classic-menu-bar and status-bar visibility toggles (also reachable
+// from View ▸ Windows).
+func drawWindowChromePrefs(s *app.Session) {
 	show := s.ShowMenuBar()
 	if native.Checkbox("Show classic menu bar", &show) {
 		reportPrefError(s.SetShowMenuBar(show))
 	}
-	// The bottom prompt line, like Inventor's status bar (also on View ▸ Windows).
 	status := s.ShowStatusBar()
 	if native.Checkbox("Show status bar", &status) {
 		reportPrefError(s.SetShowStatusBar(status))

--- a/head/ui/ui_tab.go
+++ b/head/ui/ui_tab.go
@@ -29,39 +29,27 @@ func drawUITab(s *app.Session) {
 	native.Separator()
 	native.Text("Text size also scales the Script Console code editor.")
 	native.Separator()
-	drawMouseNavPrefs(s)
-	native.Separator()
-	drawWindowChromePrefs(s)
-}
-
-// drawMouseNavPrefs draws the middle-button gesture selectors and the wheel-zoom checkboxes
-// (Inventor-parity, 2026-08-17): defaults are middle-drag pans, Shift+middle-drag orbits, scroll-up
-// zooms in, and the wheel zooms to the cursor.
-func drawMouseNavPrefs(s *app.Session) {
+	// Mouse-navigation preferences (Inventor-parity, 2026-08-17): defaults are middle-drag pans,
+	// Shift+middle-drag orbits, scroll-up zooms in, and the wheel zooms to the cursor.
 	native.Text("Mouse navigation (defaults match Inventor):")
 	editNavModeCombo("Middle button drag", s.MMBMode(), s.SetMMBMode, navModeOptions("pan"))
 	editNavModeCombo("Shift + middle button drag", s.ShiftMMBMode(), s.SetShiftMMBMode, navModeOptions("orbit"))
 	editNavModeCombo("Ctrl + middle button drag", s.CtrlMMBMode(), s.SetCtrlMMBMode, navModeOptions("pan"))
-	invert := s.WheelInvert()
-	if native.Checkbox("Invert wheel zoom direction", &invert) {
-		reportPrefError(s.SetWheelInvert(invert))
-	}
-	toCursor := s.ZoomToCursor()
-	if native.Checkbox("Zoom to cursor", &toCursor) {
-		reportPrefError(s.SetZoomToCursor(toCursor))
-	}
+	prefCheckbox("Invert wheel zoom direction", s.WheelInvert, s.SetWheelInvert)
+	prefCheckbox("Zoom to cursor", s.ZoomToCursor, s.SetZoomToCursor)
+	native.Separator()
+	// Classic menu bar + status bar visibility (also on View ▸ Windows).
+	prefCheckbox("Show classic menu bar", s.ShowMenuBar, s.SetShowMenuBar)
+	prefCheckbox("Show status bar", s.ShowStatusBar, s.SetShowStatusBar)
 }
 
-// drawWindowChromePrefs draws the classic-menu-bar and status-bar visibility toggles (also reachable
-// from View ▸ Windows).
-func drawWindowChromePrefs(s *app.Session) {
-	show := s.ShowMenuBar()
-	if native.Checkbox("Show classic menu bar", &show) {
-		reportPrefError(s.SetShowMenuBar(show))
-	}
-	status := s.ShowStatusBar()
-	if native.Checkbox("Show status bar", &status) {
-		reportPrefError(s.SetShowStatusBar(status))
+// prefCheckbox draws a boolean preference checkbox: get supplies the current value, set persists a
+// toggle (its error surfaces through reportPrefError). It takes closures rather than the whole
+// session, so the preferences tab does not widen head/ui's *app.Session coupling (audit I5).
+func prefCheckbox(label string, get func() bool, set func(bool) error) {
+	v := get()
+	if native.Checkbox(label, &v) {
+		reportPrefError(set(v))
 	}
 }
 

--- a/kernel/brep/revolution_sector.go
+++ b/kernel/brep/revolution_sector.go
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package brep
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// SolidOfRevolutionSector builds a PARTIAL analytic revolve: a meridian swept through angle radians
+// (0 < angle < 2π) about the axis, starting from the ref0 radial half-plane and sweeping toward
+// +axis. Unlike the full SolidOfRevolution — where each off-axis vertex traces a closed CIRCLE and
+// each edge a periodic wall — a sector traces an ARC per vertex and a TRIMMED surface-of-revolution
+// per edge (a partial cylinder / cone / disk sector), closed off by TWO planar caps: the meridian in
+// the start (angle 0) half-plane and in the end (angle) half-plane. So a partial revolve of a tube
+// keeps true cylindrical walls that thread/chamfer/fillet attach to, and a projected face reads real
+// arcs — not the ~48-facet-per-turn swept prism (#2019 / #2164 class).
+//
+// It returns (nil, nil) — a signal to keep the faceted revolve — for fewer than three vertices, a
+// non-partial angle, or a meridian with a CURVED (arc) edge (a torus/sphere sector, not yet built
+// here; the caller keeps the faceted revolve for those). Booleans re-facet the sector on demand
+// (combine → planarized), like every analytic tool.
+func SolidOfRevolutionSector(axisOrigin math.Point3, axisDir, ref0 math.Vector3, angle float64, verts []RevolveVertex, feat string) (*topo.Body, error) {
+	if len(verts) < 3 || angle <= 0 || angle >= 2*stdmath.Pi {
+		return nil, nil
+	}
+	if meridianHasArc(verts) {
+		return nil, nil // curved meridian → torus/sphere sector: keep faceted for now
+	}
+	a, err := math.UnitVector3FromVector(axisDir)
+	if err != nil {
+		return nil, err
+	}
+	r0, err := math.UnitVector3FromVector(perpToAxis(ref0, a))
+	if err != nil {
+		return nil, err
+	}
+	verts = ccwMeridianVerts(verts) // right-hand face normals must point out of the solid
+	return buildRevolutionSector(axisOrigin, a, r0, angle, verts, feat), nil
+}
+
+// meridianHasArc reports whether any meridian edge is an arc (a fillet/curved edge → torus or sphere
+// of revolution). The sector builder handles straight edges only for now.
+func meridianHasArc(verts []RevolveVertex) bool {
+	for i := range verts {
+		if verts[i].ArcCenter != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// perpToAxis returns the component of ref perpendicular to the axis — the radial direction the sector
+// starts from. A ref parallel to the axis yields the zero vector (the caller errors on it).
+func perpToAxis(ref math.Vector3, a math.UnitVector3) math.Vector3 {
+	return ref.Sub(a.AsVector().Scale(ref.Dot(a.AsVector())))
+}
+
+// sectorNode is one meridian vertex realized in 3D for a sector: the arc it traces (angle 0 → angle),
+// or an apex when the vertex sits on the axis (r == 0), with the arc's two endpoints.
+type sectorNode struct {
+	center math.Point3
+	r      float64
+	arc    *topo.Edge   // vertex arc angle 0→angle; nil when r == 0 (an axis apex)
+	v0, vA *topo.Vertex // arc endpoints at angle 0 and at angle (== the apex when r == 0)
+}
+
+// buildRevolutionSector assembles the sector body: one arc per off-axis vertex, one meridian line per
+// edge at each of the two cap angles, one trimmed surface-of-revolution face per edge, and the two
+// planar caps.
+func buildRevolutionSector(axisOrigin math.Point3, a, r0 math.UnitVector3, angle float64, verts []RevolveVertex, feat string) *topo.Body {
+	bld := topo.NewBuilder(true, revLin(feat, "sector-body", 0))
+	res := revolveResolution(verts)
+	nodes := make([]sectorNode, len(verts))
+	for i, vrt := range verts {
+		nodes[i] = makeSectorNode(bld, axisOrigin, a, r0, float64(vrt.P.X), float64(vrt.P.Y), angle, res.Plane(), feat, i)
+	}
+	m0, mA := sectorMeridianEdges(bld, nodes, feat)
+	for i := range verts {
+		j := (i + 1) % len(verts)
+		addSectorFace(bld, nodes[i], nodes[j], a, r0, m0[i], mA[i], res.Weld(), feat, i)
+	}
+	addSectorCaps(bld, a, r0, angle, axisOrigin, m0, mA, feat)
+	return bld.Build()
+}
+
+// makeSectorNode builds the vertex arc (and its two endpoints) for one off-axis meridian vertex, or a
+// single apex vertex when the vertex lies on the axis. The arc runs angle 0 → angle in the (r0, axis)
+// frame, so its endpoints seed the two cap meridians.
+func makeSectorNode(bld *topo.Builder, axisOrigin math.Point3, a, r0 math.UnitVector3, r, z, angle, axisTol float64, feat string, i int) sectorNode {
+	center := axisOrigin.TranslateBy(a.AsVector().Scale(math.Scalar(z)))
+	if r <= axisTol {
+		apex := bld.AddVertex(center, revLin(feat, "sector-apex", i))
+		return sectorNode{center: center, r: 0, v0: apex, vA: apex}
+	}
+	arc, err := geom.NewArc3d(center, a.AsVector(), r0.AsVector(), r, 0, angle)
+	if err != nil {
+		apex := bld.AddVertex(center, revLin(feat, "sector-apex", i))
+		return sectorNode{center: center, r: 0, v0: apex, vA: apex}
+	}
+	v0 := bld.AddVertex(arc.PointAt(0), revLin(feat, "sector-start", i))
+	vA := bld.AddVertex(arc.PointAt(1), revLin(feat, "sector-end", i))
+	return sectorNode{center: center, r: r, arc: bld.AddEdge(arc, v0, vA, revLin(feat, "sector-arc", i)), v0: v0, vA: vA}
+}
+
+// sectorMeridianEdges builds the two cap meridians: a line per edge from vertex i to vertex j at the
+// start angle (m0) and at the end angle (mA). An edge whose BOTH endpoints lie on the axis is the seam
+// ALONG the axis shared by the two caps, so m0 and mA are the SAME edge there (used once per cap).
+func sectorMeridianEdges(bld *topo.Builder, nodes []sectorNode, feat string) (m0, mA []*topo.Edge) {
+	n := len(nodes)
+	m0, mA = make([]*topo.Edge, n), make([]*topo.Edge, n)
+	for i := range nodes {
+		j := (i + 1) % n
+		m0[i] = bld.AddEdge(geom.NewLineSegment(nodes[i].v0.Point(), nodes[j].v0.Point()), nodes[i].v0, nodes[j].v0, revLin(feat, "sector-m0", i))
+		if nodes[i].r == 0 && nodes[j].r == 0 { // an on-axis edge: one seam shared by both caps
+			mA[i] = m0[i]
+			continue
+		}
+		mA[i] = bld.AddEdge(geom.NewLineSegment(nodes[i].vA.Point(), nodes[j].vA.Point()), nodes[i].vA, nodes[j].vA, revLin(feat, "sector-mA", i))
+	}
+	return m0, mA
+}
+
+// addSectorFace adds the trimmed surface-of-revolution face for one straight meridian edge: a partial
+// cylinder (axis-parallel), a disk/annulus SECTOR (axis-perpendicular), or a partial cone (oblique).
+// An edge lying on the axis traces no surface (the two caps meet along it) and is skipped.
+func addSectorFace(bld *topo.Builder, ni, nj sectorNode, a, r0 math.UnitVector3, m0i, mAi *topo.Edge, weld float64, feat string, i int) {
+	switch classifySectorEdge(ni, nj, a, weld) {
+	case revEdgeOnAxis:
+		return
+	case revEdgeCylinder:
+		addSectorCylinder(bld, ni, nj, a, r0, m0i, mAi, feat, i)
+	case revEdgePlane:
+		addSectorPlane(bld, ni, nj, a, m0i, mAi, feat, i)
+	default:
+		addSectorCone(bld, ni, nj, a, r0, m0i, mAi, feat, i)
+	}
+}
+
+// classifySectorEdge dispatches a straight meridian edge on its direction, mirroring
+// classifyRevolveEdge but reading the sector nodes (r == 0 marks an axis apex).
+func classifySectorEdge(ni, nj sectorNode, a math.UnitVector3, weld float64) revEdgeClass {
+	if ni.r == 0 && nj.r == 0 {
+		return revEdgeOnAxis
+	}
+	dr := stdmath.Abs(ni.r - nj.r)
+	dz := stdmath.Abs(float64(ni.center.VectorTo(nj.center).Dot(a.AsVector())))
+	switch {
+	case stdmath.Hypot(dr, dz) <= weld:
+		return revEdgeCylinder
+	case dr <= revSlopeTol*dz:
+		return revEdgeCylinder
+	case dz <= revSlopeTol*dr:
+		return revEdgePlane
+	default:
+		return revEdgeCone
+	}
+}
+
+// sectorLoop builds the four-edge boundary of a sector face — arc_i, the end-angle meridian, arc_j
+// reversed, the start-angle meridian reversed — collapsing an apex end (no arc) to a triangle, the
+// same way coneLoop collapses the full-revolution cone tip.
+func sectorLoop(ni, nj sectorNode, m0i, mAi *topo.Edge) topo.LoopSpec {
+	switch {
+	case ni.arc == nil: // apex at i
+		return topo.OuterLoop(topo.Fwd(mAi), topo.Rev(nj.arc), topo.Rev(m0i))
+	case nj.arc == nil: // apex at j
+		return topo.OuterLoop(topo.Fwd(ni.arc), topo.Fwd(mAi), topo.Rev(m0i))
+	default:
+		return topo.OuterLoop(topo.Fwd(ni.arc), topo.Fwd(mAi), topo.Rev(nj.arc), topo.Rev(m0i))
+	}
+}
+
+// addSectorCylinder adds the partial cylindrical wall for an axis-parallel edge, bounded by the two
+// vertex arcs and the two cap meridians. Like the full builder an upward edge (dz>0) faces +radial
+// (AddFace); a downward edge faces −radial (a bore, AddReversedFace).
+func addSectorCylinder(bld *topo.Builder, ni, nj sectorNode, a, r0 math.UnitVector3, m0i, mAi *topo.Edge, feat string, i int) {
+	cyl, err := geom.NewCylinderWithRef(ni.center, a.AsVector(), r0.AsVector(), ni.r)
+	if err != nil {
+		return
+	}
+	loop := sectorLoop(ni, nj, m0i, mAi)
+	if float64(ni.center.VectorTo(nj.center).Dot(a.AsVector())) > 0 { // dz>0: i below j → outer wall
+		bld.AddFace(cyl, revLin(feat, "sector-wall", i), loop)
+		return
+	}
+	bld.AddReversedFace(cyl, revLin(feat, "sector-wall", i), loop)
+}
+
+// addSectorCone adds the partial conical wall for an oblique edge, sharing the meridian (r0) frame so
+// its seam lines up with the neighbours, bounded by the sector's arcs and meridians.
+func addSectorCone(bld *topo.Builder, ni, nj sectorNode, a, r0 math.UnitVector3, m0i, mAi *topo.Edge, feat string, i int) {
+	apex := sectorConeApex(ni, nj)
+	base := ni
+	if ni.arc == nil {
+		base = nj
+	}
+	axisDir := apex.VectorTo(base.center)
+	half := stdmath.Atan2(base.r, stdmath.Abs(float64(axisDir.Dot(a.AsVector()))))
+	cone, err := geom.NewConeWithRef(apex, axisDir, r0.AsVector(), half)
+	if err != nil {
+		return
+	}
+	loop := sectorLoop(ni, nj, m0i, mAi)
+	if float64(ni.center.VectorTo(nj.center).Dot(a.AsVector())) > 0 { // dz>0: outward-facing cone
+		bld.AddFace(cone, revLin(feat, "sector-cone", i), loop)
+		return
+	}
+	bld.AddReversedFace(cone, revLin(feat, "sector-cone", i), loop)
+}
+
+// sectorConeApex is the axis point where the oblique edge's slant line meets the axis (r=0): an apex
+// endpoint IS that point, otherwise it is the linear extrapolation to zero radius.
+func sectorConeApex(ni, nj sectorNode) math.Point3 {
+	if ni.arc == nil {
+		return ni.v0.Point()
+	}
+	if nj.arc == nil {
+		return nj.v0.Point()
+	}
+	t := ni.r / (ni.r - nj.r)
+	return ni.v0.Point().TranslateBy(ni.v0.Point().VectorTo(nj.v0.Point()).Scale(math.Scalar(t)))
+}
+
+// addSectorPlane adds the planar disk/annulus SECTOR for an axis-perpendicular edge: a single pie-slice
+// loop (the two radial cap meridians close the inner and outer arcs into one boundary, so unlike the
+// full annulus there is no separate inner hole). The outward normal is −axis when the edge runs
+// outward (dr>0) and +axis when inward — the same rule as the full disk, and it agrees with the
+// sector loop's right-hand winding, so a plain AddFace orients it correctly.
+func addSectorPlane(bld *topo.Builder, ni, nj sectorNode, a math.UnitVector3, m0i, mAi *topo.Edge, feat string, i int) {
+	outward := a.AsVector()
+	if nj.r > ni.r { // edge i→j runs inward→outward (dr>0) ⇒ face points −axis
+		outward = a.AsVector().Scale(-1)
+	}
+	plane, err := geom.NewPlane(ni.center, outward)
+	if err != nil {
+		return
+	}
+	bld.AddFace(plane, revLin(feat, "sector-disk", i), sectorLoop(ni, nj, m0i, mAi))
+}
+
+// addSectorCaps adds the two planar caps: the meridian in the start (angle 0) half-plane, facing −t0
+// (away from the swept material), and in the end half-plane, facing +t (toward it). t0 = axis × r0 is
+// the +angle sweep direction, so the start cap normal is −t0 and the end cap normal +t (t at the end
+// angle). Each cap boundary is its ring of meridian edges; the end ring is reversed because its normal
+// is opposite. On-axis seam edges (m0[i] == mA[i]) are used once by each cap.
+func addSectorCaps(bld *topo.Builder, a, r0 math.UnitVector3, angle float64, axisOrigin math.Point3, m0, mA []*topo.Edge, feat string) {
+	n := len(m0)
+	t0 := a.AsVector().Cross(r0.AsVector()) // +angle sweep direction at the start
+	startPlane, err := geom.NewPlane(axisOrigin, t0.Scale(-1))
+	if err == nil {
+		start := make([]topo.Use, n)
+		for i := 0; i < n; i++ {
+			start[i] = topo.Fwd(m0[i])
+		}
+		bld.AddFace(startPlane, revLin(feat, "sector-start-cap", 0), topo.OuterLoop(start...))
+	}
+	rA := math.Rotation4(angle, a, axisOrigin).TransformVector(r0.AsVector())
+	tA := a.AsVector().Cross(rA) // +angle sweep direction at the end angle
+	endPlane, err := geom.NewPlane(axisOrigin, tA)
+	if err == nil {
+		end := make([]topo.Use, n)
+		for i := 0; i < n; i++ {
+			end[i] = topo.Rev(mA[n-1-i])
+		}
+		bld.AddFace(endPlane, revLin(feat, "sector-end-cap", 0), topo.OuterLoop(end...))
+	}
+}

--- a/kernel/ops/earcut.go
+++ b/kernel/ops/earcut.go
@@ -8,6 +8,16 @@ import (
 	"oblikovati.org/math"
 )
 
+// FillTriangles triangulates a planar region — an outer boundary with optional holes — into triangles
+// whose vertex indices address outer[i] for i<len(outer), then the holes concatenated after it. It is
+// the exported entry to the ear-clipping triangulator, for callers that need a filled overlay of a 2D
+// region (a sketch profile/area highlight) rather than a B-rep face's tessellation.
+//
+//	tris := ops.FillTriangles(profile.OuterLoop().Polygon(), holePolys)
+func FillTriangles(outer []math.Point2, holes [][]math.Point2) [][3]int {
+	return earcut(outer, holes)
+}
+
 // earcut triangulates a planar polygon with holes, returning triangles as index triples into
 // a combined vertex list (the outer loop followed by each hole, in order). It is a faithful
 // port of Mapbox's "earcut" ear-clipping algorithm (ISC-licensed; Eberly-style hole bridging

--- a/kernel/ops/fill_triangles_test.go
+++ b/kernel/ops/fill_triangles_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// triArea2 returns twice the absolute area of triangle (a,b,c).
+func triArea2(a, b, c math.Point2) float64 {
+	v := (b.X-a.X)*(c.Y-a.Y) - (c.X-a.X)*(b.Y-a.Y)
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+// sumFillArea sums the areas of the triangles FillTriangles returns for verts.
+func sumFillArea(verts []math.Point2, tris [][3]int) float64 {
+	var area float64
+	for _, t := range tris {
+		area += triArea2(verts[t[0]], verts[t[1]], verts[t[2]]) / 2
+	}
+	return area
+}
+
+// TestFillTrianglesSquare: a unit square triangulates to its full area (2 triangles).
+func TestFillTrianglesSquare(t *testing.T) {
+	outer := []math.Point2{math.P2(0, 0), math.P2(4, 0), math.P2(4, 4), math.P2(0, 4)}
+	tris := FillTriangles(outer, nil)
+	if len(tris) != 2 {
+		t.Fatalf("square gave %d triangles, want 2", len(tris))
+	}
+	if got := sumFillArea(outer, tris); got != 16 {
+		t.Errorf("filled area = %.3f, want 16", got)
+	}
+}
+
+// TestFillTrianglesWithHole: a 10×10 square with a 2×2 hole fills to area 100−4 = 96, and every
+// triangle index addresses outer++hole in order — the contract the region-fill overlay relies on.
+func TestFillTrianglesWithHole(t *testing.T) {
+	outer := []math.Point2{math.P2(0, 0), math.P2(10, 0), math.P2(10, 10), math.P2(0, 10)}
+	hole := []math.Point2{math.P2(4, 4), math.P2(6, 4), math.P2(6, 6), math.P2(4, 6)}
+	verts := append(append([]math.Point2(nil), outer...), hole...)
+	tris := FillTriangles(outer, [][]math.Point2{hole})
+	if len(tris) == 0 {
+		t.Fatal("no triangles for a square with a hole")
+	}
+	for _, tr := range tris {
+		for _, idx := range tr {
+			if idx < 0 || idx >= len(verts) {
+				t.Fatalf("triangle index %d out of range [0,%d)", idx, len(verts))
+			}
+		}
+	}
+	if got := sumFillArea(verts, tris); got < 95.9 || got > 96.1 {
+		t.Errorf("filled area = %.3f, want ~96 (100 − 4 hole)", got)
+	}
+}
+
+// TestFillTrianglesDegenerate: fewer than 3 points bounds no area, so no triangles.
+func TestFillTrianglesDegenerate(t *testing.T) {
+	if tris := FillTriangles([]math.Point2{math.P2(0, 0), math.P2(1, 0)}, nil); len(tris) != 0 {
+		t.Errorf("a 2-point loop gave %d triangles, want 0", len(tris))
+	}
+}

--- a/model/feature/emboss.go
+++ b/model/feature/emboss.go
@@ -316,15 +316,11 @@ func buildPrismWithHoles(p *sketch.Profile, plane sketch.Plane, sp span, taper f
 	// A full-circle profile with no holes and no taper extrudes to a TRUE cylinder (analytic side
 	// face), so thread/chamfer/fillet on it work (#129). Booleans re-facet it on demand (combine →
 	// planarized). Other shapes fall through to the faceted prism.
+	// A full circle → a true cylinder; a closed line+arc loop → an ANALYTIC prism (arc cap edges +
+	// true partial-cylinder side faces) so a projected/offset/filleted face sees real arcs, not chords
+	// (#129, #2164). Booleans re-facet it on demand (combine → planarized). Other shapes fall through.
 	if taper == 0 && len(p.InnerLoops()) == 0 {
-		if c := circleLoop(p.OuterLoop()); c != nil {
-			if cyl := buildAnalyticCylinder(c, plane, sp, feat); cyl != nil {
-				return cyl
-			}
-		}
-		// A closed line+arc loop extrudes to an ANALYTIC prism — arc cap edges + true partial-cylinder
-		// side faces — so a projected/offset/filleted face sees real arcs, not chords (#2164).
-		if body := buildAnalyticExtrusion(p.OuterLoop(), plane, sp, feat); body != nil {
+		if body := analyticPrismOrNil(p.OuterLoop(), plane, sp, feat); body != nil {
 			return body
 		}
 	}

--- a/model/feature/emboss.go
+++ b/model/feature/emboss.go
@@ -322,6 +322,11 @@ func buildPrismWithHoles(p *sketch.Profile, plane sketch.Plane, sp span, taper f
 				return cyl
 			}
 		}
+		// A closed line+arc loop extrudes to an ANALYTIC prism — arc cap edges + true partial-cylinder
+		// side faces — so a projected/offset/filleted face sees real arcs, not chords (#2164).
+		if body := buildAnalyticExtrusion(p.OuterLoop(), plane, sp, feat); body != nil {
+			return body
+		}
 	}
 	solid := buildPrism(p.OuterLoop().Polygon(), plane, sp, taper, feat)
 	if inner := p.InnerLoops(); len(inner) > 0 {

--- a/model/feature/extrude_analytic_arc.go
+++ b/model/feature/extrude_analytic_arc.go
@@ -28,6 +28,22 @@ type analyticSeg struct {
 	mid, center math.Point2
 }
 
+// analyticPrismOrNil builds an analytic prism from a taper-free, hole-free profile's outer loop by
+// raising the SAME 2D profile along the frame's normal: a full circle → a true geom.Cylinder, a
+// closed line+arc loop → an analytic arc prism (arc cap edges + partial-cylinder walls, #2164). It
+// returns nil when the loop is neither, so the caller keeps the faceted prism. Shared by the extrude
+// builder (frame = the sketch plane) and the straight-path sweep builder (frame = a synthetic plane
+// whose normal is the path tangent), which both lift the same 2D coordinates onto a frame and raise
+// them by the same span — so one dispatch serves both.
+func analyticPrismOrNil(loop sketch.Loop, plane sketch.Plane, sp span, feat string) *topo.Body {
+	if c := circleLoop(loop); c != nil {
+		if cyl := buildAnalyticCylinder(c, plane, sp, feat); cyl != nil {
+			return cyl
+		}
+	}
+	return buildAnalyticExtrusion(loop, plane, sp, feat)
+}
+
 // buildAnalyticExtrusion builds a watertight solid prism from a closed line+arc loop, keeping arcs
 // analytic. It returns nil — so the caller falls back to the faceted buildPrism — when the loop has a
 // non line/arc segment (a spline/ellipse), has no arc at all (a pure polygon gains nothing analytic),

--- a/model/feature/extrude_analytic_arc.go
+++ b/model/feature/extrude_analytic_arc.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// Analytic extrude for closed line+arc profiles (#2164). Where buildAnalyticCylinder keeps a single
+// full circle analytic, this keeps ANY line+arc loop analytic: each arc profile segment becomes a
+// true partial-cylinder side face bounded by real geom.Arc3d cap edges, each line segment a planar
+// side face bounded by line cap edges. So a face projected onto a sketch, then offset/filleted, sees
+// real arcs — not the ~60 chord segments the faceted prism produced (a piston crown, #2164). It uses
+// the SAME lineage tokens as the faceted prism (prismEdges/addCaps/addSides), so one edge per profile
+// segment keeps stable reference keys. A NewBody extrude keeps this analytic body untouched (combine
+// skips the boolean); a joined/cut extrude re-facets it, as any curved tool does today.
+
+// analyticSeg is one profile segment reduced to sketch-space 2D data in CCW traversal order (a→b).
+// An arc also carries its center and a midpoint on its true sweep (for the disambiguating third point
+// of geom.Arc3dByThreePoints and the cylinder axis).
+type analyticSeg struct {
+	isArc       bool
+	a, b        math.Point2
+	mid, center math.Point2
+}
+
+// buildAnalyticExtrusion builds a watertight solid prism from a closed line+arc loop, keeping arcs
+// analytic. It returns nil — so the caller falls back to the faceted buildPrism — when the loop has a
+// non line/arc segment (a spline/ellipse), has no arc at all (a pure polygon gains nothing analytic),
+// or is degenerate.
+func buildAnalyticExtrusion(loop sketch.Loop, plane sketch.Plane, sp span, feat string) *topo.Body {
+	segs, ok := analyticProfileSegments(loop)
+	if !ok || !anyArc(segs) || sp.depth() == 0 {
+		return nil
+	}
+	return assembleAnalyticExtrusion(ccwNormalizedSegments(segs), plane, sp, feat)
+}
+
+// anyArc reports whether the loop has at least one arc segment.
+func anyArc(segs []analyticSeg) bool {
+	for _, s := range segs {
+		if s.isArc {
+			return true
+		}
+	}
+	return false
+}
+
+// analyticProfileSegments reduces the loop's entities to ordered line/arc segments and chains them by
+// shared endpoints into one CCW-or-CW ring (traversal a→b). ok is false when any entity is not a line
+// or arc (read through the ShapedEntity/ArcShaped capabilities, never a type switch — #1624), or the
+// entities do not form a single closed chain.
+func analyticProfileSegments(loop sketch.Loop) ([]analyticSeg, bool) {
+	raw, ok := rawProfileSegments(loop.Entities())
+	if !ok {
+		return nil, false
+	}
+	return chainSegments(raw)
+}
+
+// rawProfileSegments reduces each entity to a segment in its NATURAL direction (arc: start→end),
+// before chaining orients them into traversal order.
+func rawProfileSegments(ents []sketch.ProfileEntity) ([]analyticSeg, bool) {
+	if len(ents) < 2 {
+		return nil, false
+	}
+	out := make([]analyticSeg, 0, len(ents))
+	for _, pe := range ents {
+		s, ok := rawSegmentOf(pe.Entity)
+		if !ok {
+			return nil, false
+		}
+		out = append(out, s)
+	}
+	return out, true
+}
+
+// rawSegmentOf reduces one entity to a line or arc segment via the sketch-entity capabilities. ok is
+// false for anything that is not a line or arc.
+func rawSegmentOf(e sketch.Entity) (analyticSeg, bool) {
+	shaped, isShaped := e.(sketch.ShapedEntity)
+	if !isShaped {
+		return analyticSeg{}, false
+	}
+	pts := shaped.ShapePoints()
+	switch shaped.Kind() {
+	case sketch.LineKind:
+		if len(pts) != 2 {
+			return analyticSeg{}, false
+		}
+		return analyticSeg{a: pts[0], b: pts[1]}, true
+	case sketch.ArcKind:
+		arc, ok := e.(sketch.ArcShaped)
+		if !ok || len(pts) != 3 {
+			return analyticSeg{}, false
+		}
+		return analyticSeg{isArc: true, a: pts[1], b: pts[2], center: pts[0], mid: arc.ArcMidpoint()}, true
+	default:
+		return analyticSeg{}, false
+	}
+}
+
+// chainSegments orients the raw segments into one connected ring: starting from the first, each next
+// segment shares an endpoint with the running free end and is flipped so its a meets it. ok is false
+// when the segments do not form a single closed chain (a gap, a fork, or a leftover).
+func chainSegments(raw []analyticSeg) ([]analyticSeg, bool) {
+	tol := segmentChainTol(raw)
+	used := make([]bool, len(raw))
+	chain := make([]analyticSeg, 0, len(raw))
+	chain = append(chain, raw[0])
+	used[0] = true
+	cur := raw[0].b
+	for len(chain) < len(raw) {
+		next, nb, found := nextChainSegment(raw, used, cur, tol)
+		if !found {
+			return nil, false
+		}
+		chain = append(chain, next)
+		cur = nb
+	}
+	if !cur.IsEqualTo(chain[0].a, tol) { // the ring must close back to the start
+		return nil, false
+	}
+	return chain, true
+}
+
+// nextChainSegment finds the unused segment with an endpoint at cur, orients it a→b so a==cur, marks it
+// used, and returns it with its new free end.
+func nextChainSegment(raw []analyticSeg, used []bool, cur math.Point2, tol float64) (analyticSeg, math.Point2, bool) {
+	for i := range raw {
+		if used[i] {
+			continue
+		}
+		if raw[i].a.IsEqualTo(cur, tol) {
+			used[i] = true
+			return raw[i], raw[i].b, true
+		}
+		if raw[i].b.IsEqualTo(cur, tol) {
+			used[i] = true
+			s := raw[i]
+			s.a, s.b = s.b, s.a // flip to traversal order; mid/center are direction-independent
+			return s, s.a, true
+		}
+	}
+	return analyticSeg{}, math.Point2{}, false
+}
+
+// segmentChainTol is a small endpoint-match tolerance scaled to the loop's extent.
+func segmentChainTol(raw []analyticSeg) float64 {
+	span := 0.0
+	for _, s := range raw {
+		span = stdmath.Max(span, stdmath.Max(stdmath.Abs(float64(s.a.X)), stdmath.Abs(float64(s.a.Y))))
+	}
+	return stdmath.Max(1e-9, span*1e-9)
+}
+
+// ccwNormalizedSegments returns the ring wound counter-clockwise (interior on the left), reversing a
+// clockwise ring — the winding buildExtrusionShell also enforces so caps/sides orient consistently.
+func ccwNormalizedSegments(segs []analyticSeg) []analyticSeg {
+	if segmentsSignedArea(segs) >= 0 {
+		return segs
+	}
+	n := len(segs)
+	out := make([]analyticSeg, n)
+	for i, s := range segs {
+		s.a, s.b = s.b, s.a
+		out[n-1-i] = s
+	}
+	return out
+}
+
+// segmentsSignedArea is twice the signed area of the corner polygon (CCW ⇒ positive), used only for
+// its sign. Arc bulge is ignored — the corner winding alone fixes the traversal orientation.
+func segmentsSignedArea(segs []analyticSeg) float64 {
+	area := 0.0
+	for i, s := range segs {
+		q := segs[(i+1)%len(segs)].a
+		area += float64(s.a.X*q.Y - q.X*s.a.Y)
+	}
+	return area
+}

--- a/model/feature/extrude_analytic_arc_build.go
+++ b/model/feature/extrude_analytic_arc_build.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// assembleAnalyticExtrusion wires the CCW segment ring into a watertight solid: one vertex per corner
+// at each cap, one cap edge per segment (line or arc) at each cap, one vertical seam per corner, two
+// planar caps, and one side face per segment (planar for a line, a true partial cylinder for an arc).
+// It mirrors buildExtrusionShell's construction (prismEdges/addCaps/addSides) so lineage tokens match.
+func assembleAnalyticExtrusion(segs []analyticSeg, plane sketch.Plane, sp span, feat string) *topo.Body {
+	n := len(segs)
+	normal := plane.Normal().AsVector()
+	bld := topo.NewBuilder(true, topo.NewLineage(topo.Tok(feat, "body", 0)))
+
+	bottom := make([]*topo.Vertex, n)
+	top := make([]*topo.Vertex, n)
+	for i, s := range segs {
+		bp := plane.ToModel(s.a).TranslateBy(normal.Scale(sp.near))
+		tp := plane.ToModel(s.a).TranslateBy(normal.Scale(sp.far))
+		bottom[i] = bld.AddVertex(bp, topo.NewLineage(topo.Tok(feat, "vertex", i)))
+		top[i] = bld.AddVertex(tp, topo.NewLineage(topo.Tok(feat, "vertex", n+i)))
+	}
+
+	be, te, ve := analyticPrismEdges(bld, segs, bottom, top, plane, sp, normal, feat)
+	addAnalyticCaps(bld, bottom, top, be, te, normal, feat)
+	addAnalyticSides(bld, segs, bottom, top, be, te, ve, plane, sp, normal, feat)
+	return bld.Build()
+}
+
+// analyticPrismEdges builds the bottom cap edge, top cap edge (each a line or arc following its
+// segment), and the vertical seam edge for every segment, returning the three edge rings.
+func analyticPrismEdges(bld *topo.Builder, segs []analyticSeg, bottom, top []*topo.Vertex, plane sketch.Plane, sp span, normal math.Vector3, feat string) (be, te, ve []*topo.Edge) {
+	n := len(segs)
+	be, te, ve = make([]*topo.Edge, n), make([]*topo.Edge, n), make([]*topo.Edge, n)
+	for i, s := range segs {
+		j := (i + 1) % n
+		be[i] = capEdge(bld, s, bottom[i], bottom[j], plane, sp.near, normal, topo.NewLineage(topo.Tok(feat, "bottom-edge", i)))
+		te[i] = capEdge(bld, s, top[i], top[j], plane, sp.far, normal, topo.NewLineage(topo.Tok(feat, "top-edge", i)))
+		ve[i] = bld.AddEdge(geom.NewLineSegment(bottom[i].Point(), top[i].Point()), bottom[i], top[i], topo.NewLineage(topo.Tok(feat, "side-edge", i)))
+	}
+	return be, te, ve
+}
+
+// capEdge builds one cap edge for a segment at height z along the normal: a straight line for a line
+// segment, a geom.Arc3d through the segment's swept midpoint for an arc. A degenerate arc (collinear
+// three points) falls back to a line so the loop still closes.
+func capEdge(bld *topo.Builder, s analyticSeg, vStart, vEnd *topo.Vertex, plane sketch.Plane, z float64, normal math.Vector3, lineage topo.Lineage) *topo.Edge {
+	if !s.isArc {
+		return bld.AddEdge(geom.NewLineSegment(vStart.Point(), vEnd.Point()), vStart, vEnd, lineage)
+	}
+	mid := plane.ToModel(s.mid).TranslateBy(normal.Scale(z))
+	arc, err := geom.Arc3dByThreePoints(vStart.Point(), mid, vEnd.Point())
+	if err != nil {
+		return bld.AddEdge(geom.NewLineSegment(vStart.Point(), vEnd.Point()), vStart, vEnd, lineage)
+	}
+	return bld.AddEdge(arc, vStart, vEnd, lineage)
+}
+
+// addAnalyticCaps builds the two planar caps (start = down, end = up), mirroring addCaps: the top cap
+// walks the top edges forward, the bottom cap walks the bottom edges reversed so it faces outward-down.
+func addAnalyticCaps(bld *topo.Builder, bottom, top []*topo.Vertex, be, te []*topo.Edge, normal math.Vector3, feat string) {
+	n := len(bottom)
+	bottomPlane, _ := geom.NewPlane(bottom[0].Point(), normal.Negate())
+	topPlane, _ := geom.NewPlane(top[0].Point(), normal)
+	bottomLoop := make([]topo.Use, n)
+	topLoop := make([]topo.Use, n)
+	for i := 0; i < n; i++ {
+		bottomLoop[i] = topo.Rev(be[n-1-i])
+		topLoop[i] = topo.Fwd(te[i])
+	}
+	bld.AddFace(bottomPlane, topo.NewLineage(topo.Tok(feat, "start-cap", 0)), topo.OuterLoop(bottomLoop...))
+	bld.AddFace(topPlane, topo.NewLineage(topo.Tok(feat, "end-cap", 0)), topo.OuterLoop(topLoop...))
+}
+
+// addAnalyticSides builds one side face per segment through the same corner loop the faceted prism
+// uses: a planar wall for a line, a true partial-cylinder wall for an arc.
+func addAnalyticSides(bld *topo.Builder, segs []analyticSeg, bottom, top []*topo.Vertex, be, te, ve []*topo.Edge, plane sketch.Plane, sp span, normal math.Vector3, feat string) {
+	n := len(segs)
+	for i, s := range segs {
+		j := (i + 1) % n
+		loop := topo.OuterLoop(topo.Fwd(be[i]), topo.Fwd(ve[j]), topo.Rev(te[i]), topo.Rev(ve[i]))
+		lineage := topo.NewLineage(topo.Tok(feat, "side", i))
+		if s.isArc {
+			addArcSideFace(bld, s, plane, sp, normal, loop, lineage)
+			continue
+		}
+		bld.AddFace(sideSurface(bottom[i].Point(), bottom[j].Point(), top[i].Point(), 1), lineage, loop)
+	}
+}
+
+// addArcSideFace builds the partial-cylinder wall for an arc segment: a geom.Cylinder about the arc's
+// axis (the plane normal through its centre), bounded by the segment's arc cap edges and vertical
+// seams. The face is added natural-side-out (AddFace) when the region's outward normal agrees with the
+// cylinder's radial normal — a convex boundary arc, centre inside the region — and reversed for a
+// concave one. A degenerate cylinder falls back to a chord plane so the shell still closes.
+func addArcSideFace(bld *topo.Builder, s analyticSeg, plane sketch.Plane, sp span, normal math.Vector3, loop topo.LoopSpec, lineage topo.Lineage) {
+	center := plane.ToModel(s.center).TranslateBy(normal.Scale(sp.near))
+	radius := float64(s.center.DistanceTo(s.a))
+	cyl, err := geom.NewCylinderWithRef(center, normal, plane.XAxis().AsVector(), radius)
+	if err != nil {
+		a := plane.ToModel(s.a).TranslateBy(normal.Scale(sp.near))
+		b := plane.ToModel(s.b).TranslateBy(normal.Scale(sp.near))
+		t := plane.ToModel(s.a).TranslateBy(normal.Scale(sp.far))
+		bld.AddFace(sideSurface(a, b, t, 1), lineage, loop)
+		return
+	}
+	if arcFaceOutwardRadial(s) {
+		bld.AddFace(cyl, lineage, loop)
+		return
+	}
+	bld.AddReversedFace(cyl, lineage, loop)
+}
+
+// arcFaceOutwardRadial reports whether the region's outward normal at the arc points along the
+// cylinder's radial-outward normal (away from the centre). For a CCW loop the interior is on the LEFT
+// of travel, so outward is on the RIGHT (the tangent — the chord for a circular arc's midpoint —
+// rotated −90°); it agrees with the radial-from-centre direction for a convex boundary arc.
+func arcFaceOutwardRadial(s analyticSeg) bool {
+	tangent := s.a.VectorTo(s.b)              // chord ∥ tangent at the arc midpoint
+	outward := math.V2(tangent.Y, -tangent.X) // right of CCW travel = region exterior
+	radial := s.center.VectorTo(s.mid)        // cylinder radial-outward at the midpoint
+	return float64(outward.X*radial.X+outward.Y*radial.Y) > 0
+}

--- a/model/feature/extrude_analytic_arc_test.go
+++ b/model/feature/extrude_analytic_arc_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// Analytic extrude for line+arc profiles (#2164): extruding a profile whose outer loop is arcs and
+// lines must keep the arcs ANALYTIC in the B-rep — the cap faces bounded by real arc edges and the
+// side walls true cylinders — not sampled into a chord polygon. Before this, an arc profile flattened
+// to ~60 straight edges (a piston crown projected as 63 tiny line segments, so a downstream project +
+// offset produced faceted arcs and corner slivers).
+
+// topCapPlanarFace returns the planar cap face whose every boundary vertex lies at z (the far cap of
+// a +Z extrude). It fails the test when no such face exists.
+func topCapPlanarFace(t *testing.T, b *topo.Body, z float64) *topo.Face {
+	t.Helper()
+	for _, f := range b.Faces() {
+		if _, ok := f.Geometry().(geom.Plane); !ok {
+			continue
+		}
+		if faceVerticesAllAtZ(f, z) {
+			return f
+		}
+	}
+	t.Fatalf("no planar cap face with all vertices at z=%.3f", z)
+	return nil
+}
+
+// faceVerticesAllAtZ reports whether every vertex on the face's outer loop is at height z.
+func faceVerticesAllAtZ(f *topo.Face, z float64) bool {
+	for _, u := range f.Loops()[0].EdgeUses() {
+		for _, v := range u.Edge().Vertices() {
+			if stdmath.Abs(float64(v.Point().Z)-z) > 1e-6 {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// capEdgeCurveCounts counts the analytic curve kinds on a face's outer loop.
+func capEdgeCurveCounts(f *topo.Face) (arcs, lines, other int) {
+	for _, u := range f.Loops()[0].EdgeUses() {
+		switch u.Edge().Geometry().(type) {
+		case geom.Arc3d:
+			arcs++
+		case geom.LineSegment:
+			lines++
+		default:
+			other++
+		}
+	}
+	return arcs, lines, other
+}
+
+// TestExtrudeStadiumKeepsAnalyticArcCapEdges: the stadium (two arcs + two lines) must extrude to a
+// cap bounded by exactly two arc edges and two line edges — not a chord polygon (#2164).
+func TestExtrudeStadiumKeepsAnalyticArcCapEdges(t *testing.T) {
+	const l, r, h = 10.0, 3.0, 4.0
+	sk := stadiumSketch(l, r)
+	b := extrudeProfile(t, sk, 0, h)
+	assertWatertightSolid(t, b)
+
+	cap := topCapPlanarFace(t, b, h)
+	arcs, lines, other := capEdgeCurveCounts(cap)
+	if arcs != 2 || lines != 2 || other != 0 {
+		t.Fatalf("stadium end-cap has %d arc + %d line + %d other edges, want 2 arc + 2 line (the arcs faceted into chords, #2164)", arcs, lines, other)
+	}
+}
+
+// concaveNotchSketch is a 10×10 square (x∈[-5,5], y∈[0,10]) with a semicircular bite of radius 5
+// taken out of its TOP edge — a CONCAVE boundary arc (its centre lies outside the material), so the
+// side wall must be a reversed cylinder. Region = 100 − πr²/2.
+func concaveNotchSketch() *sketch.Sketch {
+	s := sketch.NewSketches().Add(sketch.XYPlane())
+	bl := s.Points().Add(math.P2(-5, 0))
+	br := s.Points().Add(math.P2(5, 0))
+	tr := s.Points().Add(math.P2(5, 10))
+	tl := s.Points().Add(math.P2(-5, 10))
+	s.Lines().Add(bl, br)                                       // bottom
+	s.Lines().Add(br, tr)                                       // right
+	s.Arcs().Add(s.Points().Add(math.P2(0, 10)), tr, tl, false) // concave top bite, through (0,5)
+	s.Lines().Add(tl, bl)                                       // left
+	return s
+}
+
+// TestExtrudeConcaveArcNotchReversedCylinder exercises the concave branch: a boundary arc whose centre
+// is OUTSIDE the material must build a REVERSED cylinder wall. A wrong orientation makes the solid
+// non-watertight or adds the bite instead of removing it — both caught here.
+func TestExtrudeConcaveArcNotchReversedCylinder(t *testing.T) {
+	const h = 3.0
+	sk := concaveNotchSketch()
+	b := extrudeProfile(t, sk, 0, h)
+	assertWatertightSolid(t, b) // fails inside-out if the concave cylinder faces the wrong way
+
+	cap := topCapPlanarFace(t, b, h)
+	if arcs, lines, other := capEdgeCurveCounts(cap); arcs != 1 || lines != 3 || other != 0 {
+		t.Fatalf("concave-notch cap = %d arc + %d line + %d other, want 1 arc + 3 line", arcs, lines, other)
+	}
+	assertAnalyticPrismVolume(t, b, 100-stdmath.Pi*25/2, h) // square minus the semicircular bite
+}
+
+// TestExtrudeStadiumAnalyticVolume: the analytic prism is the geometrically correct stadium solid —
+// its (tessellated) volume tracks the TRUE analytic area (2rl + πr²) × h within the tessellation
+// tolerance the codebase uses for curved bodies, confirming the swept solid is neither collapsed nor
+// inverted. (Analyticity itself is asserted by the cap-edge test; meshing an arc always undershoots
+// the exact value slightly, so this uses the 2% curved-volume tolerance, not an exact match.)
+func TestExtrudeStadiumAnalyticVolume(t *testing.T) {
+	const l, r, h = 10.0, 3.0, 4.0
+	sk := stadiumSketch(l, r)
+	b := extrudeProfile(t, sk, 0, h)
+	want := (2*r*l + stdmath.Pi*r*r) * h
+	if got := meshVolume(b); relErr(got, want) > 0.02 {
+		t.Errorf("analytic stadium volume = %.6f, want ≈ %.6f (2rl+πr²)·h", got, want)
+	}
+}

--- a/model/feature/extrude_shapes_test.go
+++ b/model/feature/extrude_shapes_test.go
@@ -51,8 +51,9 @@ func assertWatertightSolid(t *testing.T, b *topo.Body) {
 	}
 }
 
-// assertPrismVolume asserts the mesh volume equals the cross-section area times the
-// height — i.e. the prism is exactly the swept profile polygon, arcs and all.
+// assertPrismVolume asserts the mesh volume equals the sampled cross-section polygon's area times the
+// height — the exact invariant for a FACETED prism (a pure polygon, or an ellipse/spline profile that
+// stays faceted), whose mesh IS that sampled polygon swept.
 func assertPrismVolume(t *testing.T, b *topo.Body, sk *sketch.Sketch, profileIndex int, height float64) {
 	t.Helper()
 	poly := sk.Profiles().Item(profileIndex).OuterLoop().Polygon()
@@ -63,13 +64,25 @@ func assertPrismVolume(t *testing.T, b *topo.Body, sk *sketch.Sketch, profileInd
 	}
 }
 
+// assertAnalyticPrismVolume asserts the swept solid's tessellated volume tracks the TRUE analytic
+// cross-section area × height. A line+arc profile now extrudes to an ANALYTIC prism (real arc edges,
+// cylinder walls, #2164), so the true area — not the sampled chord polygon — is the truth; meshing an
+// arc undershoots it slightly, so this uses the 2% curved-body tolerance, not the exact faceted match.
+func assertAnalyticPrismVolume(t *testing.T, b *topo.Body, trueArea, height float64) {
+	t.Helper()
+	want := trueArea * height
+	if got := meshVolume(b); relErr(got, want) > 0.02 {
+		t.Errorf("analytic prism volume = %.6f, want ≈ %.6f (true area %.6f × height %.1f)", got, want, trueArea, height)
+	}
+}
+
 func TestExtrudeHalfDiscFromArcAndLine(t *testing.T) {
 	const r, h = 5.0, 4.0
 	sk := halfDiscSketch(r)
 	b := extrudeProfile(t, sk, 0, h)
 	assertWatertightSolid(t, b)
-	assertPrismVolume(t, b, sk, 0, h)
-	// The faceted half-disc area is within a few percent of the analytic πr²/2.
+	assertAnalyticPrismVolume(t, b, stdmath.Pi*r*r/2, h) // analytic half-disc: true πr²/2 area
+	// The sampled half-disc polygon area is within a few percent of the analytic πr²/2.
 	if a := polygonArea(sk.Profiles().Item(0).OuterLoop().Polygon()); relErr(a, stdmath.Pi*r*r/2) > 0.02 {
 		t.Errorf("half-disc cross-section area = %.4f, want ≈ %.4f", a, stdmath.Pi*r*r/2)
 	}
@@ -80,7 +93,7 @@ func TestExtrudeStadiumFromTwoArcsTwoLines(t *testing.T) {
 	sk := stadiumSketch(l, r)
 	b := extrudeProfile(t, sk, 0, h)
 	assertWatertightSolid(t, b)
-	assertPrismVolume(t, b, sk, 0, h)
+	assertAnalyticPrismVolume(t, b, 2*r*l+stdmath.Pi*r*r, h) // analytic stadium: true 2rl+πr²
 	box := b.RangeBox().Diagonal()
 	if !approxEq(box.X, l+2*r) || !approxEq(box.Y, 2*r) || !approxEq(box.Z, h) {
 		t.Errorf("stadium box = %v, want (%.1f, %.1f, %.1f)", box, l+2*r, 2*r, h)
@@ -95,7 +108,7 @@ func TestExtrudeRoundedRectangleFilletedCorners(t *testing.T) {
 	sk := roundedRectSketch(w, ht, r)
 	b := extrudeProfile(t, sk, 0, h)
 	assertWatertightSolid(t, b)
-	assertPrismVolume(t, b, sk, 0, h)
+	assertAnalyticPrismVolume(t, b, w*ht-(4-stdmath.Pi)*r*r, h) // analytic rounded rect: true area
 	box := b.RangeBox().Diagonal()
 	if !approxEq(box.X, w) || !approxEq(box.Y, ht) || !approxEq(box.Z, h) {
 		t.Errorf("rounded-rect box = %v, want (%.1f, %.1f, %.1f)", box, w, ht, h)
@@ -154,11 +167,14 @@ func TestExtrudeTwoComplexClosedPathsAsSeparateBodies(t *testing.T) {
 	if n := sk.Profiles().Count(); n != 2 {
 		t.Fatalf("sketch has %d profiles, want 2 disjoint closed paths", n)
 	}
-	for i := 0; i < 2; i++ {
-		b := extrudeProfile(t, sk, i, h)
-		assertWatertightSolid(t, b)
-		assertPrismVolume(t, b, sk, i, h)
-	}
+	// Profile 0 is the stadium (line+arc → analytic, true 2rl+πr²); profile 1 is an ellipse (stays
+	// faceted, so its mesh IS the sampled polygon).
+	stadium := extrudeProfile(t, sk, 0, h)
+	assertWatertightSolid(t, stadium)
+	assertAnalyticPrismVolume(t, stadium, 2*2*8+stdmath.Pi*2*2, h)
+	ellipse := extrudeProfile(t, sk, 1, h)
+	assertWatertightSolid(t, ellipse)
+	assertPrismVolume(t, ellipse, sk, 1, h)
 }
 
 func TestExtrudeMultipleRegionsMergeIntoOneBody(t *testing.T) {

--- a/model/feature/revolve_extent_test.go
+++ b/model/feature/revolve_extent_test.go
@@ -47,7 +47,11 @@ func revolveWithExtent(t *testing.T, set func(*RevolveDefinition)) *ops.Geometry
 	if !pf.Health().OK() {
 		return nil
 	}
-	props := ops.BodyGeometryProperties(fs.Result()[0], ops.DefaultQuality())
+	// A terminator-swept wedge is now an ANALYTIC sector (partial cylinder walls + planar caps), so
+	// its volume is EXACT and only the display-grade mesh under-reports it. Measure at PropertyQuality
+	// — the codebase's grade for reported property values (tessellate.go) — not the display default,
+	// which biases an analytic curved volume ~1.5% low and would fail the 1% wedge gate below.
+	props := ops.BodyGeometryProperties(fs.Result()[0], ops.PropertyQuality())
 	return &props
 }
 

--- a/model/feature/revolve_sector.go
+++ b/model/feature/revolve_sector.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// Analytic PARTIAL revolve (#2019 / #2164 class). A full 360° revolve already builds true surfaces of
+// revolution (SolidOfRevolutionMeridian); a partial-angle revolve fell back to the faceted section
+// sweep, so its walls facet and a projected face reads chorded arcs. This routes a partial revolve of
+// a straight-edged (line-only) meridian through the analytic sector builder instead — partial
+// cylinder / cone / disk-sector walls plus the two planar caps at the start and end angles. A curved
+// meridian (a fillet → torus/sphere sector) still facets; the sector builder declines it.
+
+// buildPartialRevolveSolid builds the analytic partial-revolve sector, or (nil, false) to keep the
+// faceted revolve — a curved meridian, a profile that degenerates onto the axis, or a build failure.
+func buildPartialRevolveSolid(prof *sketch.Profile, plane sketch.Plane, axis *WorkAxis, angle, start float64, feat string) (*topo.Body, bool) {
+	verts, ok := meridianVertsFromProfile(prof, plane, axis)
+	if !ok {
+		return nil, false
+	}
+	ref0, ok := revolveStartRadial(prof, plane, axis, start)
+	if !ok {
+		return nil, false
+	}
+	body, err := brep.SolidOfRevolutionSector(axis.Origin(), axis.Direction().AsVector(), ref0, angle, verts, feat)
+	if err != nil || body == nil {
+		return nil, false
+	}
+	return body, true
+}
+
+// revolveStartRadial returns the radial direction (perpendicular to the axis, in the profile's
+// half-plane) at the revolve START angle: the profile's own radial direction rotated by start — so
+// the sector's start cap sits on the swept profile exactly where the faceted revolve places it. It
+// picks the profile point farthest from the axis for a well-conditioned direction. ok is false when
+// the whole profile sits on the axis (no radial direction — a degenerate revolve).
+func revolveStartRadial(prof *sketch.Profile, plane sketch.Plane, axis *WorkAxis, start float64) (math.Vector3, bool) {
+	o, a := axis.Origin(), axis.Direction().AsVector()
+	best, bestR := math.Vector3{}, 0.0
+	for _, p2 := range prof.OuterLoop().Polygon() {
+		v := o.VectorTo(plane.ToModel(p2))
+		radial := v.Sub(a.Scale(v.Dot(a)))
+		if r := float64(radial.Length()); r > bestR {
+			bestR, best = r, radial
+		}
+	}
+	if bestR == 0 {
+		return math.Vector3{}, false
+	}
+	return math.Rotation4(start, axis.Direction(), o).TransformVector(best), true
+}

--- a/model/feature/revolve_sector_test.go
+++ b/model/feature/revolve_sector_test.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// Analytic PARTIAL revolve (#2019): a partial-angle revolve of a line-only meridian keeps true
+// surface-of-revolution walls (partial cylinder / cone / disk sector) plus two planar caps, instead
+// of the faceted section sweep whose walls project onto a sketch as chorded arcs.
+
+// planarFaceCount counts the geom.Plane faces of a body.
+func planarFaceCount(b *topo.Body) int {
+	n := 0
+	for _, f := range b.Faces() {
+		if _, ok := f.Geometry().(geom.Plane); ok {
+			n++
+		}
+	}
+	return n
+}
+
+// partialTubeBody revolves the washer profile (x∈[2,4], y∈[0,2]) through angle about the Y axis.
+func partialTubeBody(t *testing.T, angle float64, dir ExtentDirection) *topo.Body {
+	t.Helper()
+	fs := NewPartFeatures(nil)
+	sk := offsetSquareSketch(2, 2)
+	cl := sk.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(0, 2))
+	cl.SetCenterline(true)
+	def := &RevolveDefinition{Sketch: sk, ProfileIndex: 0, Angle: func() float64 { return angle }, Direction: dir, Operation: ops.NewBody}
+	rf := &RevolveFeature{def: def}
+	pf := fs.Add(rf)
+	pf.SetName(fs.UniqueName("Revolution"))
+	rf.featName = pf.name
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("partial revolve sick: %+v", pf.Health())
+	}
+	return fs.Result()[0]
+}
+
+// TestPartialRevolveTubeKeepsCylinderWalls: a quarter revolve of the tube profile is the analytic
+// sector — bore + outer cylinder walls, two annulus-sector caps at z, two planar side caps: exactly
+// six faces, two of them cylinders — not a faceted prism.
+func TestPartialRevolveTubeKeepsCylinderWalls(t *testing.T) {
+	body := partialTubeBody(t, stdmath.Pi/2, PositiveDir)
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("partial revolved tube is not a valid solid: %+v", r.Issues)
+	}
+	if got := len(body.Faces()); got != 6 {
+		t.Fatalf("partial tube has %d faces, want 6 (2 walls + 2 annulus sectors + 2 caps) — faceted", got)
+	}
+	if got := cylinderFaceCount(body); got != 2 {
+		t.Fatalf("partial tube has %d cylinder faces, want 2 (bore + outer wall)", got)
+	}
+	if got := planarFaceCount(body); got != 4 {
+		t.Fatalf("partial tube has %d planar faces, want 4 (2 annulus sectors + 2 caps)", got)
+	}
+	want := 0.25 * stdmath.Pi * (4*4 - 2*2) * 2 // quarter of the full tube = 6π
+	if got := bodyVolume(body); relErr(got, want) > 0.03 {
+		t.Errorf("partial tube volume = %g, want ≈%g (quarter tube, 6π)", got, want)
+	}
+}
+
+// TestPartialRevolveSymmetric checks the start-angle offset (SymmetricDir sweeps −A/2…+A/2): the
+// sector must stay a valid analytic solid with the same volume regardless of where it starts.
+func TestPartialRevolveSymmetric(t *testing.T) {
+	body := partialTubeBody(t, stdmath.Pi/2, SymmetricDir)
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("symmetric partial tube is not a valid solid: %+v", r.Issues)
+	}
+	if got := cylinderFaceCount(body); got != 2 {
+		t.Fatalf("symmetric partial tube has %d cylinder faces, want 2", got)
+	}
+	want := 0.25 * stdmath.Pi * (4*4 - 2*2) * 2
+	if got := bodyVolume(body); relErr(got, want) > 0.03 {
+		t.Errorf("symmetric partial tube volume = %g, want ≈%g", got, want)
+	}
+}
+
+// coneTriangleSketch is a right triangle (0,0)-(2,0)-(0,2) with the y-axis side as centerline: its
+// hypotenuse revolves to a cone, its base to a disk, its axis side traces nothing.
+func coneTriangleSketch() *sketch.Sketch {
+	s := sketch.NewSketches().Add(sketch.XYPlane())
+	base := s.Points().Add(math.P2(0, 0))
+	rim := s.Points().Add(math.P2(2, 0))
+	apex := s.Points().Add(math.P2(0, 2))
+	s.Lines().Add(base, rim)  // base disk sector
+	s.Lines().Add(rim, apex)  // hypotenuse → cone
+	s.Lines().Add(apex, base) // closes the profile along the axis
+	cl := s.Lines().AddByTwoPoints(math.P2(0, 0), math.P2(0, 2))
+	cl.SetCenterline(true) // separate centerline coincident with the axis side
+	return s
+}
+
+// TestPartialRevolveConeSector exercises the apex collapse and the oblique-edge cone: a quarter
+// revolve of a right triangle touching the axis is a partial cone (one geom.Cone face) plus a disk
+// sector and two caps.
+func TestPartialRevolveConeSector(t *testing.T) {
+	fs := NewPartFeatures(nil)
+	pf := NewRevolveFeatures(fs).AddAboutCenterline(coneTriangleSketch(), 0, func() float64 { return stdmath.Pi / 2 }, ops.NewBody)
+	fs.Recompute()
+	if !pf.Health().OK() {
+		t.Fatalf("partial cone revolve sick: %+v", pf.Health())
+	}
+	body := fs.Result()[0]
+	if r := ops.Validate(body); !r.Valid || !body.IsSolid() {
+		t.Fatalf("partial cone is not a valid solid: %+v", r.Issues)
+	}
+	if got := coneFaceCount(body); got != 1 {
+		t.Fatalf("partial cone has %d cone faces, want 1 (apex collapse / oblique edge faceted)", got)
+	}
+	want := 0.25 * (1.0 / 3.0) * stdmath.Pi * 2 * 2 * 2 // quarter of a cone r=2 h=2 = 2π/3
+	if got := bodyVolume(body); relErr(got, want) > 0.03 {
+		t.Errorf("partial cone volume = %g, want ≈%g (quarter cone, 2π/3)", got, want)
+	}
+}
+
+// coneFaceCount counts geom.Cone faces.
+func coneFaceCount(b *topo.Body) int {
+	n := 0
+	for _, f := range b.Faces() {
+		if _, ok := f.Geometry().(geom.Cone); ok {
+			n++
+		}
+	}
+	return n
+}

--- a/model/feature/sheet_metal_contour_roll.go
+++ b/model/feature/sheet_metal_contour_roll.go
@@ -7,6 +7,8 @@ import (
 	stdmath "math"
 
 	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
 	"oblikovati.org/model/sketch"
 )
 
@@ -59,16 +61,30 @@ func (f *SheetMetalContourRollFeature) Recompute(in Input) (Output, error) {
 	if angle <= 0 {
 		return Output{}, fmt.Errorf("sheet-metal contour roll: angle must be positive, got %g", angle)
 	}
-	sections, full := revolvePointsAbout(band, axis, angle, 0)
-	rolled, err := sweptSolid(sections, full, featOr(f.featName, "contourRoll"))
+	rolled, err := rollBand(band, axis, angle, featOr(f.featName, "contourRoll"))
 	if err != nil {
-		return Output{}, fmt.Errorf("sheet-metal contour roll: %w", err)
+		return Output{}, err
 	}
 	bodies, err := combine(in, rolled, f.def.Operation)
 	if err != nil {
 		return Output{}, err
 	}
 	return Output{Bodies: bodies}, nil
+}
+
+// rollBand builds the rolled shell from the thickened band: a straight-band roll is a partial/full
+// revolve, so it keeps analytic cylinder/cone walls (a projected face reads real arcs, not chords); a
+// band that will not revolve cleanly falls back to the faceted section sweep.
+func rollBand(band []math.Point3, axis *WorkAxis, angle float64, feat string) (*topo.Body, error) {
+	if rolled := analyticContourRoll(band, axis, angle, feat); rolled != nil {
+		return rolled, nil
+	}
+	sections, full := revolvePointsAbout(band, axis, angle, 0)
+	rolled, err := sweptSolid(sections, full, feat)
+	if err != nil {
+		return nil, fmt.Errorf("sheet-metal contour roll: %w", err)
+	}
+	return rolled, nil
 }
 
 // resolveAxis resolves the roll axis from the profile sketch's axis line.

--- a/model/feature/sheet_metal_contour_roll_test.go
+++ b/model/feature/sheet_metal_contour_roll_test.go
@@ -71,6 +71,27 @@ func TestContourRollPartialAngle(t *testing.T) {
 	}
 }
 
+// TestContourRollTubeKeepsCylinderWalls: a full roll of a straight profile is an ANALYTIC shell —
+// bore + outer walls are true cylinders (2 cylinder faces), not a faceted prism (#2019).
+func TestContourRollTubeKeepsCylinderWalls(t *testing.T) {
+	body := rolledBody(t, 2, 3, 0)
+	if got := cylinderFaceCount(body); got != 2 {
+		t.Fatalf("rolled tube has %d cylinder faces, want 2 (bore + outer wall) — faceted", got)
+	}
+}
+
+// TestContourRollPartialKeepsCylinderWalls: a 90° roll keeps analytic partial-cylinder walls plus
+// planar caps, not a faceted shell.
+func TestContourRollPartialKeepsCylinderWalls(t *testing.T) {
+	body := rolledBody(t, 2, 3, stdmath.Pi/2)
+	if got := cylinderFaceCount(body); got != 2 {
+		t.Fatalf("partial rolled shell has %d cylinder faces, want 2 — faceted", got)
+	}
+	if got := planarFaceCount(body); got < 2 {
+		t.Fatalf("partial rolled shell has %d planar faces, want ≥2 (caps)", got)
+	}
+}
+
 // TestContourRollRejectsBadInput an out-of-range axis line, zero angle, and missing thickness
 // each go sick.
 func TestContourRollRejectsBadInput(t *testing.T) {

--- a/model/feature/sheet_metal_roll_analytic.go
+++ b/model/feature/sheet_metal_roll_analytic.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+)
+
+// Analytic contour roll (#2019 follow-up). A contour roll is a partial (or full) revolve of a
+// thickened straight-line band about an axis, so it shares the analytic revolve builders: a full turn
+// is a true surface-of-revolution shell (cylinder / cone walls), a partial roll an analytic sector
+// (partial cylinder / cone walls + two planar caps). This keeps a rolled tube's walls TRUE cylinders
+// — a projected face reads real arcs, not the ~64-facet-per-turn swept prism. A band that does not
+// revolve to a valid analytic solid falls back to the faceted section sweep.
+
+// analyticContourRoll builds the analytic rolled shell from the thickened band, or nil to keep the
+// faceted section sweep. A full turn uses the periodic surface-of-revolution builder, a partial angle
+// the sector builder; either result is validated and rejected (→ nil) if it is not a watertight solid.
+func analyticContourRoll(band []math.Point3, axis *WorkAxis, angle float64, feat string) *topo.Body {
+	verts, ok := bandMeridianVerts(band, axis)
+	if !ok {
+		return nil
+	}
+	o, a := axis.Origin(), axis.Direction().AsVector()
+	var body *topo.Body
+	var err error
+	if angle >= 2*stdmath.Pi-1e-9 {
+		body, err = brep.SolidOfRevolutionMeridian(o, a, verts, feat)
+	} else {
+		ref0, hasRadial := bandStartRadial(band, axis)
+		if !hasRadial {
+			return nil
+		}
+		body, err = brep.SolidOfRevolutionSector(o, a, ref0, angle, verts, feat)
+	}
+	if err != nil || body == nil || !body.IsSolid() || !ops.Validate(body).Valid {
+		return nil
+	}
+	return body
+}
+
+// bandMeridianVerts maps a thickened band's 3D points to (r, z) meridian vertices about the axis
+// (r = perpendicular distance from the axis, z = distance along it), all straight edges. ok is false
+// for fewer than three points.
+func bandMeridianVerts(band []math.Point3, axis *WorkAxis) ([]brep.RevolveVertex, bool) {
+	if len(band) < 3 {
+		return nil, false
+	}
+	o, a := axis.Origin(), axis.Direction().AsVector()
+	verts := make([]brep.RevolveVertex, len(band))
+	for i, p := range band {
+		v := o.VectorTo(p)
+		z := v.Dot(a)
+		r := float64(v.Sub(a.Scale(z)).Length())
+		verts[i] = brep.RevolveVertex{P: math.P2(math.Scalar(r), math.Scalar(z))}
+	}
+	return verts, true
+}
+
+// bandStartRadial returns the band's radial direction — the point farthest from the axis — which is
+// the sector's start half-plane (a contour roll starts at the profile, offset 0). ok is false when
+// the whole band lies on the axis.
+func bandStartRadial(band []math.Point3, axis *WorkAxis) (math.Vector3, bool) {
+	o, a := axis.Origin(), axis.Direction().AsVector()
+	best, bestR := math.Vector3{}, 0.0
+	for _, p := range band {
+		v := o.VectorTo(p)
+		radial := v.Sub(a.Scale(v.Dot(a)))
+		if r := float64(radial.Length()); r > bestR {
+			bestR, best = r, radial
+		}
+	}
+	if bestR == 0 {
+		return math.Vector3{}, false
+	}
+	return best, true
+}

--- a/model/feature/sketched_features.go
+++ b/model/feature/sketched_features.go
@@ -147,6 +147,8 @@ func buildRevolveSolid(prof *sketch.Profile, plane sketch.Plane, axis *WorkAxis,
 				return body, nil
 			}
 		}
+	} else if body, ok := buildPartialRevolveSolid(prof, plane, axis, angle, start, feat); ok {
+		return body, nil // a partial revolve of a line-only meridian keeps analytic sector walls (#2019)
 	}
 	sections, closed := revolveSectionsFrom(prof, plane, axis, angle, start)
 	return sweptSolid(sections, closed, feat)

--- a/model/feature/sweep_analytic.go
+++ b/model/feature/sweep_analytic.go
@@ -3,6 +3,10 @@
 package feature
 
 import (
+	stdmath "math"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/topo"
 	"oblikovati.org/math"
 	"oblikovati.org/model/sketch"
@@ -17,6 +21,71 @@ import (
 // projected onto a sketch then sees real arcs, not the ~48-facet-per-arc chord ring the faceted skin
 // produced. Any non-rigid sweep, a bent path, or a hole-bearing profile falls back to the faceted
 // section skin (returns nil). Booleans re-facet the analytic body on demand (combine → planarized).
+
+// analyticRigidSweep builds the analytic swept solid for a rigid (no taper/twist/scaling/rail/guide,
+// NormalToPath) sweep, or nil to fall back to the faceted section skin. A straight run reuses the
+// extrude analytic prism; a full circular path with a circle profile is a torus. A partial circular
+// path (a pipe elbow) still facets for now — it needs the partial surface-of-revolution builder.
+func analyticRigidSweep(prof *sketch.Profile, plane sketch.Plane, path *sketch.Path3D, feat string) *topo.Body {
+	if body := analyticStraightSweep(prof, plane, path.Points(), feat); body != nil {
+		return body
+	}
+	return analyticTorusSweep(prof, path, feat)
+}
+
+// analyticTorusSweep builds a full torus when a single circle profile is swept along a FULL circular
+// path: the circle rides the path (its centroid is the path circle), so the swept tube is the torus
+// whose major radius is the path circle radius and minor radius the profile circle radius. nil for a
+// non-circle profile, a hole-bearing profile, an open (partial) path, a non-circular path, or a minor
+// radius that reaches the major (a self-intersecting spindle torus we do not build).
+func analyticTorusSweep(prof *sketch.Profile, path *sketch.Path3D, feat string) *topo.Body {
+	if !path.IsClosed() || len(prof.InnerLoops()) != 0 {
+		return nil
+	}
+	circle := circleLoop(prof.OuterLoop())
+	if circle == nil {
+		return nil
+	}
+	fit, ok := fitPathCircle(path.Points())
+	if !ok {
+		return nil
+	}
+	minor := float64(circle.CurveRadius())
+	if minor <= 0 || minor >= fit.Radius {
+		return nil
+	}
+	body, err := brep.SolidTorus(fit.Center, fit.Normal.AsVector(), fit.Radius, minor, feat)
+	if err != nil {
+		return nil
+	}
+	return body
+}
+
+// fitPathCircle fits the circle through three well-separated path points and confirms every point
+// lies on it (in radius AND in the circle's plane). ok is false for fewer than three points, a
+// collinear triple, or any point off the circle — the caller then keeps the faceted skin.
+func fitPathCircle(pts []math.Point3) (geom.Circle, bool) {
+	if len(pts) < 3 {
+		return geom.Circle{}, false
+	}
+	fit, err := geom.CircleByThreePoints(pts[0], pts[len(pts)/3], pts[2*len(pts)/3])
+	if err != nil {
+		return geom.Circle{}, false
+	}
+	tol := fit.Radius * 1e-6
+	if tol < 1e-7 {
+		tol = 1e-7
+	}
+	for _, p := range pts {
+		if stdmath.Abs(float64(fit.Center.DistanceTo(p))-fit.Radius) > tol {
+			return geom.Circle{}, false // off the circle radius
+		}
+		if stdmath.Abs(float64(fit.Center.VectorTo(p).Dot(fit.Normal.AsVector()))) > tol {
+			return geom.Circle{}, false // out of the circle's plane
+		}
+	}
+	return fit, true
+}
 
 // analyticStraightSweep builds the analytic swept solid for a rigid straight sweep, or nil to signal
 // the caller should keep the faceted section skin. The rigid-config gate is the caller's

--- a/model/feature/sweep_analytic.go
+++ b/model/feature/sweep_analytic.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// Analytic sweep along a STRAIGHT path (#2164 follow-up). A NormalToPath sweep with no
+// taper/twist/scaling/rail/guide is a RIGID sweep: every cross-section is the profile rotated by one
+// fixed align (plane normal → path tangent) and translated to the path point. Over a straight run
+// (all path points collinear) that is exactly an EXTRUDE along the tangent — so we reuse the extrude
+// analytic prism (circle → cylinder, line+arc loop → arc cap edges + partial-cylinder walls) by
+// lifting the SAME 2D profile onto a synthetic frame whose normal is the tangent. A swept rod/pipe
+// projected onto a sketch then sees real arcs, not the ~48-facet-per-arc chord ring the faceted skin
+// produced. Any non-rigid sweep, a bent path, or a hole-bearing profile falls back to the faceted
+// section skin (returns nil). Booleans re-facet the analytic body on demand (combine → planarized).
+
+// analyticStraightSweep builds the analytic swept solid for a rigid straight sweep, or nil to signal
+// the caller should keep the faceted section skin. The rigid-config gate is the caller's
+// (sweepIsRigid); here we only require a straight collinear path and a hole-free profile (holes need
+// the drilled path, matching the extrude analytic guard).
+func analyticStraightSweep(prof *sketch.Profile, plane sketch.Plane, path []math.Point3, feat string) *topo.Body {
+	if len(prof.InnerLoops()) != 0 {
+		return nil
+	}
+	tangent, length, ok := straightPathAxis(path)
+	if !ok {
+		return nil
+	}
+	frame, ok := straightSweepFrame(prof, plane, path[0], tangent)
+	if !ok {
+		return nil
+	}
+	return analyticPrismOrNil(prof.OuterLoop(), frame, span{near: 0, far: length}, feat)
+}
+
+// straightPathAxis returns the unit start→end direction and the run length when every path point is
+// collinear (a straight run, so the sweep is a pure translation). ok is false for a zero-length path
+// or a bent one — a genuine curve keeps the faceted skin (a circular-arc path is handled analytically
+// elsewhere as a torus).
+func straightPathAxis(path []math.Point3) (math.UnitVector3, float64, bool) {
+	first, last := path[0], path[len(path)-1]
+	tangent, err := math.UnitVector3FromVector(first.VectorTo(last))
+	if err != nil {
+		return math.UnitVector3{}, 0, false // start == end
+	}
+	length := float64(first.DistanceTo(last))
+	tol := straightPathTol(length)
+	for _, p := range path[1 : len(path)-1] {
+		if offAxisDistance(first, tangent, p) > tol {
+			return math.UnitVector3{}, 0, false // a bend: not a straight run
+		}
+	}
+	return tangent, length, true
+}
+
+// offAxisDistance is the perpendicular distance of p from the line through base along dir.
+func offAxisDistance(base math.Point3, dir math.UnitVector3, p math.Point3) float64 {
+	v := base.VectorTo(p)
+	along := v.Dot(dir.AsVector())
+	perp := v.Sub(dir.AsVector().Scale(along))
+	return float64(perp.Length())
+}
+
+// straightPathTol is the collinearity tolerance, scaled to the run length so a large sweep is not
+// held to an absolute micron while a tiny one is not welded away.
+func straightPathTol(length float64) float64 {
+	tol := length * 1e-7
+	if tol < 1e-7 {
+		return 1e-7
+	}
+	return tol
+}
+
+// straightSweepFrame builds the synthetic sketch plane the profile rides on for a rigid straight
+// sweep: the profile's sketch frame rotated by align (plane normal → tangent) and translated so the
+// profile centroid lands on the path start. ToModel on this frame reproduces the sweep placement
+// exactly — path[0] + align·(plane.ToModel(p) − centroid) — so the analytic prism it raises equals
+// the faceted skin. ok is false if the rotated axes degenerate (they cannot: align is a rotation).
+func straightSweepFrame(prof *sketch.Profile, plane sketch.Plane, start math.Point3, tangent math.UnitVector3) (sketch.Plane, bool) {
+	align := math.RotateBetween(plane.Normal(), tangent)
+	centroid := centroidOf(modelPolygon(prof, plane))
+	origin := start.TranslateBy(align.TransformVector(centroid.VectorTo(plane.Origin())))
+	xa, err := math.UnitVector3FromVector(align.TransformVector(plane.XAxis().AsVector()))
+	if err != nil {
+		return sketch.Plane{}, false
+	}
+	ya, err := math.UnitVector3FromVector(align.TransformVector(plane.YAxis().AsVector()))
+	if err != nil {
+		return sketch.Plane{}, false
+	}
+	frame, err := sketch.NewPlane(origin, xa, ya)
+	if err != nil {
+		return sketch.Plane{}, false
+	}
+	return frame, true
+}

--- a/model/feature/sweep_analytic_test.go
+++ b/model/feature/sweep_analytic_test.go
@@ -75,6 +75,31 @@ func TestSweepCircleDiagonalStraightMakesCylinder(t *testing.T) {
 	}
 }
 
+// circlePath3D samples a full circle of the given radius in the z=0 plane (centre origin) into n
+// points, marked closed — the path a torus sweep rides.
+func circlePath3D(radius float64, n int) *sketch.Path3D {
+	pts := make([]*sketch.Point3D, n)
+	for i := 0; i < n; i++ {
+		th := 2 * stdmath.Pi * float64(i) / float64(n)
+		pts[i] = sketch.NewPoint3D(math.P3(math.Scalar(radius*stdmath.Cos(th)), math.Scalar(radius*stdmath.Sin(th)), 0))
+	}
+	return sketch.NewPath3D(pts, true)
+}
+
+// TestSweepCircleAroundCircleMakesTorus: a circle swept along a FULL circular path is ONE analytic
+// torus face (major = path radius, minor = profile radius), not a faceted ring — so projecting it
+// sees a real circle, not a chord polygon.
+func TestSweepCircleAroundCircleMakesTorus(t *testing.T) {
+	const major, minor = 10.0, 2.0
+	body := straightSweep(t, circleSketchAt(0, 0, minor), circlePath3D(major, 24))
+	if got := torusFaceCount(body); got != 1 {
+		t.Fatalf("circle-around-circle sweep has %d torus faces, want 1 (fell to the faceted ring)", got)
+	}
+	if got, want := bodyVolume(body), 2*stdmath.Pi*stdmath.Pi*major*minor*minor; relErr(got, want) > 0.02 {
+		t.Errorf("swept torus volume = %g, want ≈%g (2π²·R·r²)", got, want)
+	}
+}
+
 // TestSweepBentPathStaysFaceted guards the collinearity gate: a genuinely bent path is NOT a straight
 // run, so it must keep the faceted skin (zero analytic cylinder faces) — never mis-claimed analytic.
 func TestSweepBentPathStaysFaceted(t *testing.T) {

--- a/model/feature/sweep_analytic_test.go
+++ b/model/feature/sweep_analytic_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package feature
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/ops"
+	"oblikovati.org/kernel/topo"
+	"oblikovati.org/math"
+	"oblikovati.org/model/sketch"
+)
+
+// Analytic straight-path sweep (#2164 follow-up): a rigid sweep along a straight run keeps the
+// profile's arcs ANALYTIC — a circle → one true cylinder wall, a line+arc profile → real arc cap
+// edges — instead of the faceted section skin whose ~48-facet-per-arc rings project onto a sketch as
+// chorded arcs. A bent path, or any taper/twist/rail/guide, keeps the faceted skin.
+
+// straightSweep builds a rigid NewBody sweep of profile 0 along the given straight path.
+func straightSweep(t *testing.T, sk *sketch.Sketch, path *sketch.Path3D) *topo.Body {
+	t.Helper()
+	fs := NewPartFeatures(nil)
+	def := &SweepDefinition{
+		Sketch: sk, ProfileIndex: 0,
+		Path:      func() *sketch.Path3D { return path },
+		Operation: ops.NewBody,
+	}
+	return sweepDefRecompute(t, fs, def)
+}
+
+// TestSweepCircleStraightMakesCylinder: a circle swept up a straight Z run is ONE analytic cylinder
+// wall (plus the two planar caps), not a faceted tube — so a projected face sees a real circle.
+func TestSweepCircleStraightMakesCylinder(t *testing.T) {
+	const r, l = 2.0, 10.0
+	body := straightSweep(t, circleSketchAt(0, 0, r), straightZPath(l, 8))
+	if got := cylinderFaceCount(body); got != 1 {
+		t.Fatalf("straight circle sweep has %d cylinder faces, want 1 (fell to the faceted skin)", got)
+	}
+	if got, want := bodyVolume(body), stdmath.Pi*r*r*l; relErr(got, want) > 0.02 {
+		t.Errorf("swept cylinder volume = %g, want ≈%g (πr²l)", got, want)
+	}
+}
+
+// TestSweepStadiumStraightKeepsAnalyticArcs: a stadium (two arcs + two lines) swept along a straight
+// run keeps a cap bounded by exactly two arc + two line edges — the extrude analytic prism reused.
+func TestSweepStadiumStraightKeepsAnalyticArcs(t *testing.T) {
+	const l, r, depth = 10.0, 3.0, 6.0
+	body := straightSweep(t, stadiumSketch(l, r), straightZPath(depth, 8))
+	cap := topCapPlanarFace(t, body, depth)
+	if arcs, lines, other := capEdgeCurveCounts(cap); arcs != 2 || lines != 2 || other != 0 {
+		t.Fatalf("straight stadium sweep cap = %d arc + %d line + %d other, want 2 arc + 2 line (arcs faceted, #2164)", arcs, lines, other)
+	}
+	if got, want := bodyVolume(body), (2*r*l+stdmath.Pi*r*r)*depth; relErr(got, want) > 0.02 {
+		t.Errorf("swept stadium volume = %g, want ≈%g", got, want)
+	}
+}
+
+// TestSweepCircleDiagonalStraightMakesCylinder exercises the frame rotation: a circle on the XY plane
+// swept along a straight run in direction (1,1,1) still yields one analytic cylinder — the synthetic
+// frame must rotate the profile so its normal follows the tangent, not stay axis-aligned.
+func TestSweepCircleDiagonalStraightMakesCylinder(t *testing.T) {
+	const r = 1.5
+	l := stdmath.Sqrt(3) * 4 // origin → (4,4,4)
+	path := sketch.NewPath3D([]*sketch.Point3D{
+		sketch.NewPoint3D(math.P3(0, 0, 0)),
+		sketch.NewPoint3D(math.P3(4, 4, 4)),
+	}, false)
+	body := straightSweep(t, circleSketchAt(0, 0, r), path)
+	if got := cylinderFaceCount(body); got != 1 {
+		t.Fatalf("diagonal straight circle sweep has %d cylinder faces, want 1", got)
+	}
+	if got, want := bodyVolume(body), stdmath.Pi*r*r*l; relErr(got, want) > 0.02 {
+		t.Errorf("diagonal swept cylinder volume = %g, want ≈%g (πr²l)", got, want)
+	}
+}
+
+// TestSweepBentPathStaysFaceted guards the collinearity gate: a genuinely bent path is NOT a straight
+// run, so it must keep the faceted skin (zero analytic cylinder faces) — never mis-claimed analytic.
+func TestSweepBentPathStaysFaceted(t *testing.T) {
+	const r = 1.0
+	path := sketch.NewPath3D([]*sketch.Point3D{
+		sketch.NewPoint3D(math.P3(0, 0, 0)),
+		sketch.NewPoint3D(math.P3(0, 0, 5)),
+		sketch.NewPoint3D(math.P3(5, 0, 5)),
+	}, false)
+	body := straightSweep(t, circleSketchAt(0, 0, r), path)
+	if got := cylinderFaceCount(body); got != 0 {
+		t.Fatalf("bent-path sweep has %d analytic cylinder faces, want 0 (a bend must keep the faceted skin)", got)
+	}
+}

--- a/model/feature/sweep_loft.go
+++ b/model/feature/sweep_loft.go
@@ -141,11 +141,7 @@ func (s *SweepFeature) Recompute(in Input) (Output, error) {
 	if err != nil {
 		return Output{}, err
 	}
-	sections, err := sweepSectionsCfg(prof, s.def.Sketch.Plane(), path.Points(), cfg)
-	if err != nil {
-		return Output{}, err
-	}
-	s.tool, err = s.sweepTool(sections, path.IsClosed())
+	s.tool, err = s.buildSweepTool(prof, path, cfg)
 	if err != nil {
 		return Output{}, err
 	}
@@ -154,6 +150,44 @@ func (s *SweepFeature) Recompute(in Input) (Output, error) {
 		return Output{}, err
 	}
 	return Output{Bodies: bodies}, nil
+}
+
+// buildSweepTool builds the swept tool body. A rigid straight sweep of a circle / line+arc profile
+// keeps ANALYTIC faces — a straight NormalToPath sweep is exactly an extrude along the path tangent,
+// so it reuses the extrude analytic prism (#2164 follow-up) and a projected face sees real arcs, not
+// chords. Every other sweep (bent path, taper/twist/scaling/rail/guide, a surface sweep, or a profile
+// with holes) uses the faceted section skin.
+func (s *SweepFeature) buildSweepTool(prof *sketch.Profile, path *sketch.Path3D, cfg sweepConfig) (*topo.Body, error) {
+	feat := featOr(s.featName, "sweep")
+	if s.def.Operation != ops.Surface && s.sweepIsRigid() {
+		if body := analyticStraightSweep(prof, s.def.Sketch.Plane(), path.Points(), feat); body != nil {
+			return body, nil
+		}
+	}
+	sections, err := sweepSectionsCfg(prof, s.def.Sketch.Plane(), path.Points(), cfg)
+	if err != nil {
+		return nil, err
+	}
+	return s.sweepTool(sections, path.IsClosed())
+}
+
+// sweepIsRigid reports whether the definition sweeps the profile rigidly — no taper, twist, scaling
+// rail, or guide surface, and the profile kept normal to the path. Only a rigid sweep maps to an
+// analytic prism; any deformation makes the section vary along the path (a non-analytic skin).
+func (s *SweepFeature) sweepIsRigid() bool {
+	d := s.def
+	return normalToPathOrientation(d.Orientation) &&
+		callOrZero(d.Taper) == 0 &&
+		callOrZero(d.Twist) == 0 &&
+		len(d.TwistStations) == 0 &&
+		d.GuideRail == nil &&
+		len(d.GuideFaceKey) == 0
+}
+
+// normalToPathOrientation reports whether the orientation keeps the profile perpendicular to the path
+// tangent — the explicit NormalToPath, or the zero value the definition defaults to (sweep.go).
+func normalToPathOrientation(o types.SweepProfileOrientation) bool {
+	return o == 0 || o == types.NormalToPath
 }
 
 // sweepTool builds the swept body from its cross-sections: for the Surface operation

--- a/model/feature/sweep_loft.go
+++ b/model/feature/sweep_loft.go
@@ -160,7 +160,7 @@ func (s *SweepFeature) Recompute(in Input) (Output, error) {
 func (s *SweepFeature) buildSweepTool(prof *sketch.Profile, path *sketch.Path3D, cfg sweepConfig) (*topo.Body, error) {
 	feat := featOr(s.featName, "sweep")
 	if s.def.Operation != ops.Surface && s.sweepIsRigid() {
-		if body := analyticStraightSweep(prof, s.def.Sketch.Plane(), path.Points(), feat); body != nil {
+		if body := analyticRigidSweep(prof, s.def.Sketch.Plane(), path, feat); body != nil {
 			return body, nil
 		}
 	}

--- a/model/feature/sweep_loft.go
+++ b/model/feature/sweep_loft.go
@@ -152,11 +152,11 @@ func (s *SweepFeature) Recompute(in Input) (Output, error) {
 	return Output{Bodies: bodies}, nil
 }
 
-// buildSweepTool builds the swept tool body. A rigid straight sweep of a circle / line+arc profile
-// keeps ANALYTIC faces — a straight NormalToPath sweep is exactly an extrude along the path tangent,
-// so it reuses the extrude analytic prism (#2164 follow-up) and a projected face sees real arcs, not
-// chords. Every other sweep (bent path, taper/twist/scaling/rail/guide, a surface sweep, or a profile
-// with holes) uses the faceted section skin.
+// buildSweepTool builds the swept tool body. A rigid sweep keeps ANALYTIC faces where it can: a
+// straight run reuses the extrude analytic prism (a straight NormalToPath sweep is exactly an extrude
+// along the path tangent), and a full circular path with a circle profile is a torus (#2164 follow-up)
+// — so a projected face sees real arcs, not chords. Every other sweep (a bent/partial path,
+// taper/twist/scaling/rail/guide, a surface sweep, or a profile with holes) uses the faceted skin.
 func (s *SweepFeature) buildSweepTool(prof *sketch.Profile, path *sketch.Path3D, cfg sweepConfig) (*topo.Body, error) {
 	feat := featOr(s.featName, "sweep")
 	if s.def.Operation != ops.Surface && s.sweepIsRigid() {

--- a/model/sketch/arc_midpoint.go
+++ b/model/sketch/arc_midpoint.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// ArcShaped is the optional capability of a sketch arc: a point on the arc halfway along its ACTUAL
+// (CounterClockwise-respecting) sweep. Center + start + end alone define two arcs — the minor and the
+// major — so a consumer rebuilding the analytic arc (extrude keeping arc cap edges, revolve) needs
+// this interior point to pick the right one without reading the winding flag itself. Only Arc carries
+// it; consumers assert the capability, never the concrete type (the sketch-entity seam, #1624).
+type ArcShaped interface {
+	// ArcMidpoint returns the sketch-space point at the arc's angular midpoint along its sweep.
+	ArcMidpoint() math.Point2
+}
+
+var _ ArcShaped = (*Arc)(nil)
+
+// ArcMidpoint returns the point halfway along the arc's swept angle, on the side the arc actually
+// runs (CounterClockwise ? increasing : decreasing angle), so it lies strictly between Start and End
+// on the real arc — the disambiguating third point for [geom.Arc3dByThreePoints].
+func (a *Arc) ArcMidpoint() math.Point2 {
+	c := a.Center.Position()
+	sa := angleFromCenter(c, a.Start.Position())
+	ea := angleFromCenter(c, a.End.Position())
+	if a.CounterClockwise {
+		for ea <= sa {
+			ea += 2 * stdmath.Pi
+		}
+	} else {
+		for ea >= sa {
+			ea -= 2 * stdmath.Pi
+		}
+	}
+	mid := (sa + ea) / 2
+	r := float64(a.Radius())
+	return math.P2(c.X+math.Scalar(r*stdmath.Cos(mid)), c.Y+math.Scalar(r*stdmath.Sin(mid)))
+}
+
+// angleFromCenter is the polar angle of p about center.
+func angleFromCenter(center, p math.Point2) float64 {
+	return stdmath.Atan2(float64(p.Y-center.Y), float64(p.X-center.X))
+}

--- a/model/sketch/arc_midpoint_test.go
+++ b/model/sketch/arc_midpoint_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// TestArcMidpointRespectsWinding: for the same three points, a CCW and a CW arc take OPPOSITE
+// midpoints — the disambiguation an analytic rebuild needs (a semicircle's midpoint is otherwise
+// ambiguous).
+func TestArcMidpointRespectsWinding(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	// Semicircle radius 1 about the origin, from (1,0) to (-1,0).
+	ccw := s.Arcs().AddByCenterStartEnd(math.P2(0, 0), math.P2(1, 0), math.P2(-1, 0), true)
+	cw := s.Arcs().AddByCenterStartEnd(math.P2(0, 0), math.P2(1, 0), math.P2(-1, 0), false)
+
+	mc := ccw.ArcMidpoint()
+	if stdmath.Abs(float64(mc.X)) > 1e-9 || stdmath.Abs(float64(mc.Y)-1) > 1e-9 {
+		t.Errorf("CCW semicircle midpoint = %v, want (0,1) (upper half)", mc)
+	}
+	mw := cw.ArcMidpoint()
+	if stdmath.Abs(float64(mw.X)) > 1e-9 || stdmath.Abs(float64(mw.Y)+1) > 1e-9 {
+		t.Errorf("CW semicircle midpoint = %v, want (0,-1) (lower half)", mw)
+	}
+}
+
+// TestArcMidpointOnCircle: the midpoint lies on the arc's circle (radius from center).
+func TestArcMidpointOnCircle(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	a := s.Arcs().AddByCenterStartEnd(math.P2(2, 1), math.P2(5, 1), math.P2(2, 4), true) // quarter, r=3
+	m := a.ArcMidpoint()
+	if r := float64(math.P2(2, 1).DistanceTo(m)); stdmath.Abs(r-3) > 1e-9 {
+		t.Errorf("midpoint radius = %.6f, want 3", r)
+	}
+	// Quarter arc CCW from +X to +Y about (2,1): midpoint at 45° → (2+3/√2, 1+3/√2).
+	want := 3 / stdmath.Sqrt2
+	if stdmath.Abs(float64(m.X-2)-want) > 1e-9 || stdmath.Abs(float64(m.Y-1)-want) > 1e-9 {
+		t.Errorf("quarter-arc midpoint = %v, want (%.4f,%.4f) offset", m, want, want)
+	}
+}

--- a/model/sketch/arrangement.go
+++ b/model/sketch/arrangement.go
@@ -137,9 +137,11 @@ func entityPolyline(e Entity) (pts []math.Point2, closed bool) {
 }
 
 // polylineReturnsToStart reports whether a sampled polyline closes on itself (its last point equals
-// its first) — true for a projected closed edge such as a circular face perimeter.
+// its first) — true for a projected closed edge such as a circular face perimeter. It uses the same
+// node-merge tolerance the arrangement treats as coincident, so a loop that closes is detected on
+// the same scale a crossing is.
 func polylineReturnsToStart(pts []math.Point2) bool {
-	return len(pts) >= 3 && pts[len(pts)-1].IsEqualTo(pts[0], 1e-9)
+	return len(pts) >= 3 && pts[len(pts)-1].IsEqualTo(pts[0], arrMergeTol)
 }
 
 // cut is a crossing along a segment: the parameter t∈[0,1] where it occurs and the

--- a/model/sketch/arrangement.go
+++ b/model/sketch/arrangement.go
@@ -124,9 +124,22 @@ func entityPolyline(e Entity) (pts []math.Point2, closed bool) {
 			return sampleSplineEntity(t), true
 		}
 		return naturalPolyline(t), false
+	case *ProjectedCurve:
+		// A projected reference curve carries its own sampled polyline (a projected face perimeter
+		// or model edge); expose it here so it can be hit-tested, region-detected and offset like any
+		// other curve — without a case it fell through to naturalPolyline's endpoint chord (empty for
+		// a projection) and was unpickable (#2158 follow-up).
+		p := t.Points()
+		return p, polylineReturnsToStart(p)
 	default:
 		return naturalPolyline(e), false // Line, Arc, open Spline
 	}
+}
+
+// polylineReturnsToStart reports whether a sampled polyline closes on itself (its last point equals
+// its first) — true for a projected closed edge such as a circular face perimeter.
+func polylineReturnsToStart(pts []math.Point2) bool {
+	return len(pts) >= 3 && pts[len(pts)-1].IsEqualTo(pts[0], 1e-9)
 }
 
 // cut is a crossing along a segment: the parameter t∈[0,1] where it occurs and the

--- a/model/sketch/arrangement.go
+++ b/model/sketch/arrangement.go
@@ -125,11 +125,11 @@ func entityPolyline(e Entity) (pts []math.Point2, closed bool) {
 		}
 		return naturalPolyline(t), false
 	case *ProjectedCurve:
-		// A projected reference curve carries its own sampled polyline (a projected face perimeter
-		// or model edge); expose it here so it can be hit-tested, region-detected and offset like any
-		// other curve — without a case it fell through to naturalPolyline's endpoint chord (empty for
-		// a projection) and was unpickable (#2158 follow-up).
-		p := t.Points()
+		// A projected reference curve exposes its (smooth, analytic when it is a line/arc/circle)
+		// polyline here so it can be hit-tested, region-detected and offset like any other curve —
+		// without a case it fell through to naturalPolyline's endpoint chord (empty for a projection)
+		// and was unpickable (#2158 follow-up).
+		p := t.RenderPolyline()
 		return p, polylineReturnsToStart(p)
 	default:
 		return naturalPolyline(e), false // Line, Arc, open Spline

--- a/model/sketch/arrangement_test.go
+++ b/model/sketch/arrangement_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"testing"
+
+	gmath "oblikovati.org/math"
+)
+
+// TestProjectedCurveEntityPolyline is the #2158 follow-up: a projected reference curve must expose
+// its sampled polyline through EntityPolyline so it can be hit-tested (selected) and offset, and a
+// closed projected perimeter (a face's outline) must report closed. Before the fix a ProjectedCurve
+// fell through to an endpoint chord that was empty, so it could not be picked at all.
+func TestProjectedCurveEntityPolyline(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	square := []gmath.Point2{gmath.P2(0, 0), gmath.P2(4, 0), gmath.P2(4, 4), gmath.P2(0, 4), gmath.P2(0, 0)}
+	pc := s.RestoreProjectedCurve(nextID(), square, "edge", "E1")
+	got, closed := EntityPolyline(pc)
+	if len(got) != len(square) {
+		t.Fatalf("EntityPolyline(closed ProjectedCurve) = %d points, want %d", len(got), len(square))
+	}
+	if !closed {
+		t.Error("a projected closed perimeter must report closed (offset needs a loop)")
+	}
+
+	open := s.RestoreProjectedCurve(nextID(), []gmath.Point2{gmath.P2(0, 0), gmath.P2(2, 1)}, "edge", "E2")
+	pts, oClosed := EntityPolyline(open)
+	if len(pts) != 2 {
+		t.Fatalf("EntityPolyline(open ProjectedCurve) = %d points, want 2", len(pts))
+	}
+	if oClosed {
+		t.Error("a projected open edge must report open")
+	}
+}

--- a/model/sketch/arrangement_test.go
+++ b/model/sketch/arrangement_test.go
@@ -3,6 +3,7 @@
 package sketch
 
 import (
+	stdmath "math"
 	"testing"
 
 	gmath "oblikovati.org/math"
@@ -14,11 +15,13 @@ import (
 // fell through to an endpoint chord that was empty, so it could not be picked at all.
 func TestProjectedCurveEntityPolyline(t *testing.T) {
 	s := NewSketches().Add(XYPlane())
-	square := []gmath.Point2{gmath.P2(0, 0), gmath.P2(4, 0), gmath.P2(4, 4), gmath.P2(0, 4), gmath.P2(0, 0)}
-	pc := s.RestoreProjectedCurve(nextID(), square, "edge", "E1")
+	// A non-circular closed projection (an ellipse) stays a polyline; it must still expose that
+	// polyline through EntityPolyline and report closed, so it is pickable and offsettable.
+	loop := ellipsePts(4, 2, 0, 2*stdmath.Pi, 24)
+	pc := s.RestoreProjectedCurve(nextID(), loop, "edge", "E1")
 	got, closed := EntityPolyline(pc)
-	if len(got) != len(square) {
-		t.Fatalf("EntityPolyline(closed ProjectedCurve) = %d points, want %d", len(got), len(square))
+	if len(got) < 3 {
+		t.Fatalf("EntityPolyline(closed ProjectedCurve) = %d points, want the sampled loop", len(got))
 	}
 	if !closed {
 		t.Error("a projected closed perimeter must report closed (offset needs a loop)")

--- a/model/sketch/constraints_2d.go
+++ b/model/sketch/constraints_2d.go
@@ -564,6 +564,21 @@ type FixConstraint struct {
 	constraintBase
 	P      *Point
 	x0, y0 math.Scalar
+	// weight scales the residual. 0 means a hard fix (⇒ weight 1) — a user or persisted Fix. A
+	// small positive value makes it a SOFT pin: because the solver minimises the raw sum of
+	// squares, a small weight lets the pin yield to hard constraints instead of fighting them.
+	// Drag pins are soft so dragging an entity whose points are held by a dimension or a
+	// tangency does not violate that constraint, and instead moves the geometry within its
+	// remaining freedom (#2160). Zero-valued (cloned/restored) fixes stay hard.
+	weight float64
+}
+
+// residualWeight returns the residual scale, treating the zero value as a hard fix (weight 1).
+func (c *FixConstraint) residualWeight() float64 {
+	if c.weight > 0 {
+		return c.weight
+	}
+	return 1
 }
 
 // AddFix pins point p to its current location.
@@ -573,9 +588,10 @@ func (g *GeometricConstraints) AddFix(p *Point) *FixConstraint {
 	return c
 }
 
-// residualAD: each coordinate must hold its captured value.
+// residualAD: each coordinate must hold its captured value (scaled by the fix's weight).
 func (c *FixConstraint) residualAD(v []ad.Number) []ad.Number {
-	return []ad.Number{v[0].AddConst(-float64(c.x0)), v[1].AddConst(-float64(c.y0))}
+	w := ad.Const(c.residualWeight())
+	return []ad.Number{v[0].AddConst(-float64(c.x0)).Mul(w), v[1].AddConst(-float64(c.y0)).Mul(w)}
 }
 func (c *FixConstraint) Residuals() []float64      { return adResiduals(c.Variables(), c.residualAD) }
 func (c *FixConstraint) Partials() [][]float64     { return adPartials(c.Variables(), c.residualAD) }

--- a/model/sketch/constraints_new.go
+++ b/model/sketch/constraints_new.go
@@ -59,16 +59,37 @@ func (c *GroundConstraint) Variables() []*math.Scalar {
 }
 
 // OffsetConstraint holds line L2 parallel to L1 at a fixed signed perpendicular distance
-// (the geometric relation behind an offset; pairs with a driven offset dimension).
+// (the geometric relation behind an offset; pairs with a driven offset dimension). When live is
+// non-nil the distance is read from it each solve — an offset segment DRIVEN by one shared offset
+// dimension, so editing the dimension moves a whole uniform-offset loop (Dist keeps the last live
+// value so a serialized constraint reloads frozen at that distance, live being a closure).
 type OffsetConstraint struct {
 	constraintBase
 	L1, L2 *Line
 	Dist   float64
+	live   func() float64
+}
+
+// currentDist is the target signed distance: the live value when driven, else the fixed Dist.
+func (c *OffsetConstraint) currentDist() float64 {
+	if c.live != nil {
+		return c.live()
+	}
+	return c.Dist
 }
 
 // AddOffset constrains L2 parallel to L1 at the signed perpendicular distance dist.
 func (g *GeometricConstraints) AddOffset(l1, l2 *Line, dist float64) *OffsetConstraint {
 	c := &OffsetConstraint{constraintBase: newConstraint(), L1: l1, L2: l2, Dist: dist}
+	g.add(c)
+	return c
+}
+
+// AddOffsetDriven constrains L2 parallel to L1 at the signed perpendicular distance live() reads each
+// solve — the binding that keeps a uniform-offset loop's segments tied to one driving dimension. Dist
+// snapshots the initial value so a serialized (closure-less) reload stays at that distance.
+func (g *GeometricConstraints) AddOffsetDriven(l1, l2 *Line, live func() float64) *OffsetConstraint {
+	c := &OffsetConstraint{constraintBase: newConstraint(), L1: l1, L2: l2, Dist: live(), live: live}
 	g.add(c)
 	return c
 }
@@ -83,7 +104,7 @@ func (c *OffsetConstraint) residualAD(v []ad.Number) []ad.Number {
 	// distance of L2.A from L1 was already a true distance.
 	parallel := adSineAngle(d1, d2)
 	dist := adSignedPerpDistance(d1, a2.Sub(a1))
-	return []ad.Number{parallel, dist.AddConst(-c.Dist)}
+	return []ad.Number{parallel, dist.AddConst(-c.currentDist())}
 }
 
 // Residuals reports the parallel error and the perpendicular-distance error.

--- a/model/sketch/constraints_new.go
+++ b/model/sketch/constraints_new.go
@@ -4,6 +4,7 @@ package sketch
 
 import (
 	"oblikovati.org/math"
+	"oblikovati.org/model/param"
 	"oblikovati.org/solve/ad"
 )
 
@@ -59,21 +60,26 @@ func (c *GroundConstraint) Variables() []*math.Scalar {
 }
 
 // OffsetConstraint holds line L2 parallel to L1 at a fixed signed perpendicular distance
-// (the geometric relation behind an offset; pairs with a driven offset dimension). When live is
-// non-nil the distance is read from it each solve — an offset segment DRIVEN by one shared offset
-// dimension, so editing the dimension moves a whole uniform-offset loop (Dist keeps the last live
-// value so a serialized constraint reloads frozen at that distance, live being a closure).
+// (the geometric relation behind an offset; pairs with a driven offset dimension). When driver is
+// non-nil the distance is DrivenSign·driver.ModelValue() each solve — an offset segment tied to one
+// shared driving offset dimension, so editing that dimension moves a whole uniform-offset loop. The
+// distance is pulled LIVE at solve time (no parameter-graph propagation needed), and the driver's
+// stable name (DriverName) plus sign persist so a reloaded constraint can be re-bound to the restored
+// dimension (see AddOffsetDriven / the offset codec). Dist keeps the last driven value as the frozen
+// fallback when no driver can be resolved.
 type OffsetConstraint struct {
 	constraintBase
-	L1, L2 *Line
-	Dist   float64
-	live   func() float64
+	L1, L2     *Line
+	Dist       float64
+	driver     *param.Parameter // live driving dimension's parameter; nil ⇒ frozen at Dist
+	DriverSign float64          // +1 / −1: which side of L1's left normal L2 sits on
+	DriverName string           // driver's parameter name, for re-binding after a reload
 }
 
-// currentDist is the target signed distance: the live value when driven, else the fixed Dist.
+// currentDist is the target signed distance: DrivenSign·driver each solve when driven, else fixed Dist.
 func (c *OffsetConstraint) currentDist() float64 {
-	if c.live != nil {
-		return c.live()
+	if c.driver != nil {
+		return c.DriverSign * c.driver.ModelValue()
 	}
 	return c.Dist
 }
@@ -85,11 +91,16 @@ func (g *GeometricConstraints) AddOffset(l1, l2 *Line, dist float64) *OffsetCons
 	return c
 }
 
-// AddOffsetDriven constrains L2 parallel to L1 at the signed perpendicular distance live() reads each
-// solve — the binding that keeps a uniform-offset loop's segments tied to one driving dimension. Dist
-// snapshots the initial value so a serialized (closure-less) reload stays at that distance.
-func (g *GeometricConstraints) AddOffsetDriven(l1, l2 *Line, live func() float64) *OffsetConstraint {
-	c := &OffsetConstraint{constraintBase: newConstraint(), L1: l1, L2: l2, Dist: live(), live: live}
+// AddOffsetDriven constrains L2 parallel to L1 at the signed perpendicular distance sign·driver each
+// solve — the binding that keeps a uniform-offset loop's segments tied to one driving dimension. It
+// reads driver.ModelValue() live (so it needs no graph recompute) and records the driver's name so the
+// link survives a save/reload (rebound in the offset codec). Dist snapshots the initial value as the
+// frozen fallback used when the driver cannot be resolved on reload.
+func (g *GeometricConstraints) AddOffsetDriven(l1, l2 *Line, driver *param.Parameter, sign float64) *OffsetConstraint {
+	c := &OffsetConstraint{
+		constraintBase: newConstraint(), L1: l1, L2: l2,
+		Dist: sign * driver.ModelValue(), driver: driver, DriverSign: sign, DriverName: driver.Name(),
+	}
 	g.add(c)
 	return c
 }

--- a/model/sketch/drag.go
+++ b/model/sketch/drag.go
@@ -16,11 +16,19 @@ type PinTarget struct {
 	Target math.Point2
 }
 
-// dragFix is a temporary pin pulling point p toward target. It reuses FixConstraint (a fix to a
-// position) rather than re-declaring its residual/variable math; it is appended only for the
+// dragPinWeight is the residual weight of a drag pin — small, so the pin is SOFT: it yields to the
+// sketch's hard constraints (dimensions, tangency, coincidence) instead of fighting them at equal
+// strength. An unopposed pin still lands its point exactly on the cursor (its residual reaches
+// zero regardless of weight); the weight only decides who wins under conflict, and a hard
+// constraint must (#2160). Small enough that a hard constraint's residual dwarfs it, large enough
+// to stay well clear of the solver's damping floor.
+const dragPinWeight = 1e-3 // tol:numeric — soft-pin weight (#2160)
+
+// dragFix is a temporary SOFT pin pulling point p toward target. It reuses FixConstraint (a fix to
+// a position) rather than re-declaring its residual/variable math; it is appended only for the
 // duration of one DragSolve and is never added to the sketch's persisted constraints.
 func dragFix(p *Point, target math.Point2) *FixConstraint {
-	return &FixConstraint{constraintBase: newConstraint(), P: p, x0: target.X, y0: target.Y}
+	return &FixConstraint{constraintBase: newConstraint(), P: p, x0: target.X, y0: target.Y, weight: dragPinWeight}
 }
 
 // DragSolve re-solves the sketch with the given points temporarily pinned to their drag targets.

--- a/model/sketch/drag.go
+++ b/model/sketch/drag.go
@@ -27,14 +27,75 @@ func dragFix(p *Point, target math.Point2) *FixConstraint {
 // The dragged points follow the cursor while the existing constraints pull the dependent geometry
 // along (and hold the pinned points back along any directions they are constrained in). The pins
 // are not persisted; geometry is left in the solved configuration. Returns the solve result.
+//
+// A pin on a point that is already fixed — grounded to a reference anchor, or held by a Fix
+// constraint — is dropped rather than added. A drag pin is just another equal-weight positional
+// residual (a FixConstraint), so pinning a point that a hard constraint already holds at the origin
+// would make the least-squares solve split the difference and let a coincident-to-origin endpoint
+// drag off the origin (#2160). Dropping that pin lets the hard constraint hold the point while the
+// rest of the dragged geometry follows the cursor.
 func (s *Sketch) DragSolve(pins []PinTarget) SolveResult {
+	grounded := s.groundedPoints()
 	cons := append([]Constraint(nil), s.Constraints()...)
 	for _, pt := range pins {
+		if grounded[pt.P] {
+			continue
+		}
 		cons = append(cons, dragFix(pt.P, pt.Target))
 	}
 	r := Solve(cons, s.variables(), Options{})
 	s.syncEllipseAxes()
 	return r
+}
+
+// groundedPoints returns the points a drag must not pin: those transitively coincident with a fixed
+// anchor. The seeds are the reference points (projected/included anchors, excluded from the solver
+// so they never move) and any point held by a Fix constraint; the grounded flag then floods across
+// coincidence constraints, so a point coincident to the origin — or coincident to a point that is —
+// is grounded. See DragSolve for why pinning such a point is wrong (#2160).
+func (s *Sketch) groundedPoints() map[*Point]bool {
+	grounded, adj := s.groundSeedsAndCoincidences()
+	floodGrounded(grounded, adj)
+	return grounded
+}
+
+// groundSeedsAndCoincidences seeds the grounded set with every fixed anchor (reference points and
+// Fix-held points) and builds the undirected coincidence adjacency the flood spreads along.
+func (s *Sketch) groundSeedsAndCoincidences() (map[*Point]bool, map[*Point][]*Point) {
+	grounded := make(map[*Point]bool, len(s.refPts))
+	for _, p := range s.refPts {
+		grounded[p] = true
+	}
+	adj := map[*Point][]*Point{}
+	for _, c := range s.Constraints() {
+		switch k := c.(type) {
+		case *CoincidentConstraint:
+			adj[k.A] = append(adj[k.A], k.B)
+			adj[k.B] = append(adj[k.B], k.A)
+		case *FixConstraint:
+			grounded[k.P] = true
+		}
+	}
+	return grounded, adj
+}
+
+// floodGrounded spreads the grounded flag across coincidence edges in place: a point coincident to a
+// grounded point is itself grounded.
+func floodGrounded(grounded map[*Point]bool, adj map[*Point][]*Point) {
+	stack := make([]*Point, 0, len(grounded))
+	for p := range grounded {
+		stack = append(stack, p)
+	}
+	for len(stack) > 0 {
+		p := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		for _, q := range adj[p] {
+			if !grounded[q] {
+				grounded[q] = true
+				stack = append(stack, q)
+			}
+		}
+	}
 }
 
 // pointDefined is an entity that can name its constrainable points (each entity declares its own

--- a/model/sketch/drag_test.go
+++ b/model/sketch/drag_test.go
@@ -62,6 +62,67 @@ func TestDragSolveFreePointMovesToTarget(t *testing.T) {
 	}
 }
 
+// TestDragKeepsOriginCoincidentEndpointPinned is the #2160 regression: an endpoint coincident to a
+// fixed reference anchor (the projected origin) must stay on that anchor through a drag. A drag pin
+// is an equal-weight positional residual, so before the fix a body drag pinned that endpoint to the
+// cursor and the least-squares solve split the difference against the coincidence — the endpoint
+// slid to the midpoint and "dragged off the origin". It must now stay put while the free end follows.
+func TestDragKeepsOriginCoincidentEndpointPinned(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	origin := s.newRefPoint(math.P2(0, 0)) // a fixed anchor, like the projected origin
+	line := s.Lines().AddByTwoPoints(math.P2(2, 0), math.P2(4, 0))
+	s.GeometricConstraints().AddCoincident(line.A, origin)
+	s.Solve() // line.A snaps onto the origin
+
+	if !line.A.Position().IsEqualTo(math.P2(0, 0), 1e-6) {
+		t.Fatalf("setup: line.A should sit on the origin after solve, got %v", line.A.Position())
+	}
+
+	// Body drag: both endpoints pinned to a cursor offset up and to the right.
+	s.DragSolve([]PinTarget{
+		{P: line.A, Target: math.P2(3, 1)},
+		{P: line.B, Target: math.P2(5, 1)},
+	})
+
+	if !line.A.Position().IsEqualTo(math.P2(0, 0), 1e-6) {
+		t.Errorf("origin-coincident endpoint drifted to %v; the coincidence must hold it at the origin (#2160)", line.A.Position())
+	}
+	if !line.B.Position().IsEqualTo(math.P2(5, 1), 1e-6) {
+		t.Errorf("free endpoint = %v, should follow the drag to (5,1)", line.B.Position())
+	}
+}
+
+// TestGroundedPointsFloodsCoincidenceChain checks the grounded flag reaches a point coincident to a
+// point that is itself coincident to the origin (transitive), while an unconstrained point stays free.
+func TestGroundedPointsFloodsCoincidenceChain(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	origin := s.newRefPoint(math.P2(0, 0))
+	p := s.Points().Add(math.P2(1, 1))
+	q := s.Points().Add(math.P2(2, 2))
+	s.GeometricConstraints().AddCoincident(p, origin) // p grounded directly
+	s.GeometricConstraints().AddCoincident(q, p)      // q grounded through p
+	free := s.Points().Add(math.P2(9, 9))
+
+	g := s.groundedPoints()
+	if !g[origin] || !g[p] || !g[q] {
+		t.Errorf("origin, p and q should all be grounded; got origin=%v p=%v q=%v", g[origin], g[p], g[q])
+	}
+	if g[free] {
+		t.Error("an unconstrained point must not be grounded")
+	}
+}
+
+// TestGroundedPointsIncludesFixConstraint checks a Fix constraint grounds its point, so a drag does
+// not tug a user-fixed point off its position.
+func TestGroundedPointsIncludesFixConstraint(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	p := s.Points().Add(math.P2(3, 3))
+	s.GeometricConstraints().AddFix(p)
+	if !s.groundedPoints()[p] {
+		t.Error("a Fix-constrained point must be grounded")
+	}
+}
+
 func TestDefiningPointsByEntity(t *testing.T) {
 	s := NewSketches().Add(XYPlane())
 	pt := s.Points().Add(math.P2(0, 0))

--- a/model/sketch/drag_test.go
+++ b/model/sketch/drag_test.go
@@ -123,6 +123,28 @@ func TestGroundedPointsIncludesFixConstraint(t *testing.T) {
 	}
 }
 
+// TestDragSoftPinYieldsToDimension is the safety property behind allowing dimension-determined
+// entities to be dragged (#2160, symptom A): the drag pin is soft, so it must not stretch a hard
+// dimension. A point fixed 2 units from a grounded anchor, dragged out to 10, must stay ~2 away —
+// the dimension wins. With an equal-weight pin it would drift toward the midpoint and violate it.
+func TestDragSoftPinYieldsToDimension(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	anchor := s.Points().Add(math.P2(0, 0))
+	s.GeometricConstraints().AddFix(anchor)
+	p := s.Points().Add(math.P2(2, 0))
+	s.GeometricConstraints().AddHorizontal(anchor, p)
+	if _, err := s.DimensionConstraints().AddDistance(anchor, p, "2 cm"); err != nil {
+		t.Fatalf("AddDistance: %v", err)
+	}
+	s.Solve()
+
+	s.DragSolve([]PinTarget{{P: p, Target: math.P2(10, 0)}})
+
+	if d := float64(p.Position().DistanceTo(anchor.Position())); d < 1.9 || d > 2.1 {
+		t.Errorf("drag stretched the distance dimension: |p-anchor| = %.4f, want ~2 (soft pin must yield)", d)
+	}
+}
+
 func TestDefiningPointsByEntity(t *testing.T) {
 	s := NewSketches().Add(XYPlane())
 	pt := s.Points().Add(math.P2(0, 0))

--- a/model/sketch/entity_collections_test.go
+++ b/model/sketch/entity_collections_test.go
@@ -2,7 +2,11 @@
 
 package sketch
 
-import "testing"
+import (
+	"testing"
+
+	gmath "oblikovati.org/math"
+)
 
 // TestEntityListStorageCore pins the shared storage core the typed factory collections
 // embed (#1656): append order, Count/Item indexing, and remove-first-occurrence
@@ -36,4 +40,26 @@ func TestEntityListItemIsUnguarded(t *testing.T) {
 	}()
 	var l entityList[int]
 	_ = l.Item(0)
+}
+
+// TestCircularCenters returns each circle's and arc's centre so a sketch overlay can mark them
+// (#2159), and nothing for a sketch without circular geometry.
+func TestCircularCenters(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	if got := s.CircularCenters(); len(got) != 0 {
+		t.Fatalf("empty sketch CircularCenters = %v, want none", got)
+	}
+	s.Circles().AddByCenterRadius(gmath.P2(2, 3), 1)
+	s.Arcs().AddByCenterStartEnd(gmath.P2(-4, 5), gmath.P2(-3, 5), gmath.P2(-4, 6), true)
+
+	got := s.CircularCenters()
+	if len(got) != 2 {
+		t.Fatalf("CircularCenters = %d centres, want 2 (one circle, one arc)", len(got))
+	}
+	if !got[0].IsEqualTo(gmath.P2(2, 3), 1e-9) {
+		t.Errorf("circle centre = %v, want (2,3)", got[0])
+	}
+	if !got[1].IsEqualTo(gmath.P2(-4, 5), 1e-9) {
+		t.Errorf("arc centre = %v, want (-4,5)", got[1])
+	}
 }

--- a/model/sketch/moveable_status.go
+++ b/model/sketch/moveable_status.go
@@ -57,6 +57,34 @@ func (mc *MoveableClassifier) Of(e Entity) types.GeometryMoveableStatus {
 	return types.MoveableByDimensionChange
 }
 
+// HasDrivingDimensionOn reports whether a driving (non-reference) dimension acts on any of entity
+// e's freedom variables. It distinguishes the two ways an entity can be MoveableByDimensionChange:
+// determined by a driving dimension (a fully-dimensioned line — Relax Mode's job to move, #791) or
+// determined purely by geometric constraints (a fillet arc tangent to still-free lines, which a
+// direct drag should move within the sketch's freedom, #2160). The drag gate uses it to allow the
+// latter while still refusing the former.
+func (s *Sketch) HasDrivingDimensionOn(e Entity) bool {
+	vars, ok := entityFreedomVars(e)
+	if !ok {
+		return false
+	}
+	owned := make(map[*math.Scalar]bool, len(vars))
+	for _, v := range vars {
+		owned[v] = true
+	}
+	for _, d := range s.dimCons.All() {
+		if d.Driven() {
+			continue // a reference dimension only reports; it holds nothing
+		}
+		for _, v := range d.Variables() {
+			if owned[v] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // entityFreedomVars returns the scalar DOFs that move entity e; known is
 // false for kinds the classifier does not model (annotations, images).
 func entityFreedomVars(e Entity) (vars []*math.Scalar, known bool) {

--- a/model/sketch/offset.go
+++ b/model/sketch/offset.go
@@ -21,9 +21,52 @@ func (s *Sketch) OffsetEntity(e Entity, d math.Scalar) (Entity, error) {
 		return s.offsetCircle(v, d)
 	case *Arc:
 		return s.offsetArc(v, d)
+	case *ProjectedCurve:
+		return s.offsetProjectedCurve(v, d)
 	default:
-		return nil, fmt.Errorf("offset: unsupported entity %T (want line/circle/arc)", e)
+		return nil, fmt.Errorf("offset: unsupported entity %T (want line/circle/arc or a projected curve)", e)
 	}
+}
+
+// projectedOffsetArcSegs is how finely a convex corner opened by the offset is rounded when
+// offsetting a projected polyline (matching OffsetClosedLoop's own default fidelity).
+const projectedOffsetArcSegs = 8
+
+// offsetProjectedCurve offsets a projected reference curve — a sampled polyline, e.g. a projected
+// face perimeter or model edge — by d as new sketch line geometry: a closed perimeter offsets as a
+// closed loop (an inner offset for d<0, matching offsetCircle's sign), an open edge as an open
+// chain. The projection is already faceted, so its offset is faceted too. This is the offset a user
+// reaches by selecting a projected perimeter (#2158 follow-up); before it, OffsetEntity rejected the
+// projected curve outright.
+func (s *Sketch) offsetProjectedCurve(pc *ProjectedCurve, d math.Scalar) (Entity, error) {
+	pts := pc.Points()
+	if polylineReturnsToStart(pts) {
+		if ents := s.OffsetClosedLoop(pts, float64(d), projectedOffsetArcSegs); len(ents) > 0 {
+			return ents[0], nil
+		}
+		return nil, fmt.Errorf("offset: projected loop of %d points collapses when offset by %.4g", len(pts), float64(d))
+	}
+	off := offsetPolyline(pts, float64(d))
+	if len(off) < 2 {
+		return nil, fmt.Errorf("offset: projected curve of %d points cannot offset by %.4g", len(pts), float64(d))
+	}
+	return s.addOpenPolyline(off), nil
+}
+
+// addOpenPolyline adds an open chain of line segments through pts and returns its first segment (the
+// representative entity OffsetEntity's contract expects; the offset tool ignores it and keeps all).
+func (s *Sketch) addOpenPolyline(pts []math.Point2) Entity {
+	nodes := make([]*Point, len(pts))
+	for i, p := range pts {
+		nodes[i] = s.points.Add(p)
+	}
+	var first Entity
+	for i := 0; i+1 < len(nodes); i++ {
+		if e := s.lines.Add(nodes[i], nodes[i+1]); first == nil {
+			first = e
+		}
+	}
+	return first
 }
 
 // offsetLine returns a line parallel to l, shifted by d along l's left normal.

--- a/model/sketch/offset.go
+++ b/model/sketch/offset.go
@@ -4,6 +4,7 @@ package sketch
 
 import (
 	"fmt"
+	stdmath "math"
 
 	"oblikovati.org/math"
 )
@@ -39,7 +40,11 @@ const projectedOffsetArcSegs = 8
 // reaches by selecting a projected perimeter (#2158 follow-up); before it, OffsetEntity rejected the
 // projected curve outright.
 func (s *Sketch) offsetProjectedCurve(pc *ProjectedCurve, d math.Scalar) (Entity, error) {
-	pts := pc.Points()
+	if e, err, ok := s.offsetProjectedShape(pc.shape, d); ok {
+		return e, err
+	}
+	// A projection that is not analytic (an oblique arc → ellipse) offsets as a faceted polyline.
+	pts := pc.RenderPolyline()
 	if polylineReturnsToStart(pts) {
 		if ents := s.OffsetClosedLoop(pts, float64(d), projectedOffsetArcSegs); len(ents) > 0 {
 			return ents[0], nil
@@ -51,6 +56,61 @@ func (s *Sketch) offsetProjectedCurve(pc *ProjectedCurve, d math.Scalar) (Entity
 		return nil, fmt.Errorf("offset: projected curve of %d points cannot offset by %.4g", len(pts), float64(d))
 	}
 	return s.addOpenPolyline(off), nil
+}
+
+// offsetProjectedShape offsets an analytic projected shape into a real sketch line/arc/circle — a
+// projected arc offsets to a concentric arc, a circle to a concentric circle, a line to a parallel
+// line (Inventor keeps projected geometry analytic). ok is false for shapeNone (polyline fallback).
+// The sign matches offsetCircle: d>0 grows the radius, d<0 shrinks it (an inner offset).
+func (s *Sketch) offsetProjectedShape(sh projectedShape, d math.Scalar) (Entity, error, bool) {
+	switch sh.kind {
+	case shapeLine:
+		return s.offsetProjectedLine(sh, d), nil, true
+	case shapeCircle:
+		e, err := s.offsetProjectedCircle(sh, d)
+		return e, err, true
+	case shapeArc:
+		e, err := s.offsetProjectedArc(sh, d)
+		return e, err, true
+	default:
+		return nil, nil, false
+	}
+}
+
+// offsetProjectedLine returns the projected line shifted by d along its left normal (a copy in place
+// for a degenerate zero-length shape).
+func (s *Sketch) offsetProjectedLine(sh projectedShape, d math.Scalar) *Line {
+	u, ok := unitVec(sh.a.VectorTo(sh.b))
+	if !ok {
+		return s.lines.AddByTwoPoints(sh.a, sh.b)
+	}
+	n := math.V2(-u.Y, u.X).Scale(float64(d))
+	return s.lines.AddByTwoPoints(sh.a.TranslateBy(n), sh.b.TranslateBy(n))
+}
+
+// offsetProjectedCircle returns the concentric circle of radius radius+d.
+func (s *Sketch) offsetProjectedCircle(sh projectedShape, d math.Scalar) (*Circle, error) {
+	r := sh.radius + float64(d)
+	if r <= 0 {
+		return nil, fmt.Errorf("offset: projected circle radius %.4g + %.4g ≤ 0", sh.radius, float64(d))
+	}
+	return s.circles.AddByCenterRadius(sh.center, math.Scalar(r)), nil
+}
+
+// offsetProjectedArc returns the concentric arc of radius radius+d over the same angular span.
+func (s *Sketch) offsetProjectedArc(sh projectedShape, d math.Scalar) (*Arc, error) {
+	r := sh.radius + float64(d)
+	if r <= 0 {
+		return nil, fmt.Errorf("offset: projected arc radius %.4g + %.4g ≤ 0", sh.radius, float64(d))
+	}
+	start := arcPointAt(sh.center, r, sh.start)
+	end := arcPointAt(sh.center, r, sh.start+sh.sweep)
+	return s.arcs.AddByCenterStartEnd(sh.center, start, end, sh.sweep > 0), nil
+}
+
+// arcPointAt is the point on the circle of radius r about centre at angle a (radians).
+func arcPointAt(center math.Point2, r, a float64) math.Point2 {
+	return math.P2(center.X+math.Scalar(r*stdmath.Cos(a)), center.Y+math.Scalar(r*stdmath.Sin(a)))
 }
 
 // addOpenPolyline adds an open chain of line segments through pts and returns its first segment (the

--- a/model/sketch/offset_chain.go
+++ b/model/sketch/offset_chain.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import "oblikovati.org/math"
+
+// chainJoinTol is the distance under which two curve endpoints count as joined when tracing the
+// connected chain an offset Loop Select follows.
+const chainJoinTol = 1e-6 // tol:calibrated — offset chain endpoint connectivity
+
+// curveEnds returns a curve entity's two endpoints (in sketch space) and whether it is inherently
+// closed (a circle, or a projected/closed curve that returns to its start). ok is false for a
+// non-curve entity. Projected curves are included, so Loop Select works on a projected perimeter
+// that Paths() (which reads only native line/arc geometry) does not report (#2158 follow-up).
+func curveEnds(e Entity) (a, b math.Point2, closed, ok bool) {
+	switch t := e.(type) {
+	case *Line:
+		return t.A.Position(), t.B.Position(), false, true
+	case *Arc:
+		return t.Start.Position(), t.End.Position(), false, true
+	case *Circle:
+		return t.Center.Position(), t.Center.Position(), true, true
+	case *ProjectedCurve:
+		p := t.RenderPolyline()
+		if len(p) < 2 {
+			return math.Point2{}, math.Point2{}, false, false
+		}
+		return p[0], p[len(p)-1], polylineReturnsToStart(p), true
+	case *Spline:
+		if len(t.Points) >= 2 {
+			return t.Points[0].Position(), t.Points[len(t.Points)-1].Position(), t.Closed, true
+		}
+	}
+	return math.Point2{}, math.Point2{}, false, false
+}
+
+// ConnectedChainFrom returns the maximal connected chain of curves reachable from seed by shared
+// endpoints, as an ordered Path with per-entity traversal direction — the loop Inventor's Offset
+// selects with Loop Select. A single inherently-closed curve (a circle, a closed projection) is its
+// own one-element closed chain. ok is false when seed is not a curve.
+func (s *Sketch) ConnectedChainFrom(seed Entity) (*Path, bool) {
+	sa, sb, sclosed, ok := curveEnds(seed)
+	if !ok {
+		return nil, false
+	}
+	if sclosed {
+		return &Path{entities: []ProfileEntity{{Entity: seed}}, closed: true}, true
+	}
+	ends := map[Entity][2]math.Point2{}
+	var curves []Entity
+	for _, e := range s.ents {
+		if e == seed {
+			continue
+		}
+		if a, b, c, ok := curveEnds(e); ok && !c {
+			curves = append(curves, e)
+			ends[e] = [2]math.Point2{a, b}
+		}
+	}
+	visited := map[Entity]bool{seed: true}
+	fwd := traceChain(sb, curves, ends, visited) // curves after the seed, in order
+	bwd := traceChain(sa, curves, ends, visited) // curves before the seed, walked outward from sa
+	return assembleChain(seed, sa, sb, fwd, bwd), true
+}
+
+// traceChain traces curves outward from `start`, each oriented so its traversal start meets the
+// running free end, stopping when no unvisited curve continues the chain.
+func traceChain(start math.Point2, curves []Entity, ends map[Entity][2]math.Point2, visited map[Entity]bool) []ProfileEntity {
+	var chain []ProfileEntity
+	cur := start
+	for {
+		found, reversed, next := nextInChain(cur, curves, ends, visited)
+		if found == nil {
+			return chain
+		}
+		visited[found] = true
+		chain = append(chain, ProfileEntity{Entity: found, reversed: reversed})
+		cur = next
+	}
+}
+
+// nextInChain finds the first unvisited curve with an endpoint at cur, returning it, whether it is
+// traversed reversed (its natural end is at cur), and the free end that continues the chain.
+func nextInChain(cur math.Point2, curves []Entity, ends map[Entity][2]math.Point2, visited map[Entity]bool) (Entity, bool, math.Point2) {
+	for _, e := range curves {
+		if visited[e] {
+			continue
+		}
+		ab := ends[e]
+		if ab[0].IsEqualTo(cur, chainJoinTol) {
+			return e, false, ab[1]
+		}
+		if ab[1].IsEqualTo(cur, chainJoinTol) {
+			return e, true, ab[0]
+		}
+	}
+	return nil, false, math.Point2{}
+}
+
+// assembleChain stitches the backward chain (reversed, its entities flipped so they flow toward the
+// seed), the seed, and the forward chain into one ordered Path, marking it closed when the chain's
+// two free ends meet.
+func assembleChain(seed Entity, sa, sb math.Point2, fwd, bwd []ProfileEntity) *Path {
+	entities := make([]ProfileEntity, 0, len(bwd)+1+len(fwd))
+	for i := len(bwd) - 1; i >= 0; i-- {
+		entities = append(entities, ProfileEntity{Entity: bwd[i].Entity, reversed: !bwd[i].reversed})
+	}
+	entities = append(entities, ProfileEntity{Entity: seed})
+	entities = append(entities, fwd...)
+	startPt := sa
+	if len(bwd) > 0 {
+		startPt = traversalStart(bwd[len(bwd)-1], true)
+	}
+	endPt := sb
+	if len(fwd) > 0 {
+		endPt = traversalEnd(fwd[len(fwd)-1])
+	}
+	return &Path{entities: entities, closed: len(entities) > 1 && startPt.IsEqualTo(endPt, chainJoinTol)}
+}
+
+// traversalStart / traversalEnd give a profile entity's start/end point honouring its direction.
+// flip additionally inverts the reversed flag (used for a backward-walked entity being flipped).
+func traversalStart(pe ProfileEntity, flip bool) math.Point2 {
+	a, b, _, _ := curveEnds(pe.Entity)
+	if pe.reversed != flip {
+		return b
+	}
+	return a
+}
+
+func traversalEnd(pe ProfileEntity) math.Point2 {
+	a, b, _, _ := curveEnds(pe.Entity)
+	if pe.reversed {
+		return a
+	}
+	return b
+}

--- a/model/sketch/offset_chain_test.go
+++ b/model/sketch/offset_chain_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"testing"
+
+	gmath "oblikovati.org/math"
+)
+
+// TestConnectedChainFromProjectedLoop: Loop Select must trace a loop made of projected reference
+// curves (a projected face perimeter), which Paths() does not report — the offset workflow the
+// #2158 follow-up enables.
+func TestConnectedChainFromProjectedLoop(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	corners := []gmath.Point2{gmath.P2(0, 0), gmath.P2(4, 0), gmath.P2(4, 4), gmath.P2(0, 4)}
+	var first Entity
+	for i := 0; i < 4; i++ {
+		pc := s.RestoreProjectedCurve(nextID(), []gmath.Point2{corners[i], corners[(i+1)%4]}, "edge", "E")
+		if i == 0 {
+			first = pc
+		}
+	}
+	path, ok := s.ConnectedChainFrom(first)
+	if !ok {
+		t.Fatal("ConnectedChainFrom returned no chain")
+	}
+	if path.Count() != 4 || !path.IsClosed() {
+		t.Errorf("projected square chain = %d entities closed=%v, want 4 closed", path.Count(), path.IsClosed())
+	}
+}
+
+// TestConnectedChainFromOpenChain: an open chain of native lines traces as an open path in order.
+func TestConnectedChainFromOpenChain(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	l1 := s.Lines().AddByTwoPoints(gmath.P2(0, 0), gmath.P2(2, 0))
+	s.Lines().AddByTwoPoints(gmath.P2(2, 0), gmath.P2(2, 2))
+	s.Lines().AddByTwoPoints(gmath.P2(2, 2), gmath.P2(4, 2))
+	path, _ := s.ConnectedChainFrom(l1)
+	if path.Count() != 3 || path.IsClosed() {
+		t.Errorf("open 3-line chain = %d entities closed=%v, want 3 open", path.Count(), path.IsClosed())
+	}
+}
+
+// TestConnectedChainFromCircle: a full circle is its own one-element closed chain.
+func TestConnectedChainFromCircle(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	c := s.Circles().AddByCenterRadius(gmath.P2(0, 0), 2)
+	path, ok := s.ConnectedChainFrom(c)
+	if !ok || path.Count() != 1 || !path.IsClosed() {
+		t.Errorf("circle chain ok=%v count=%d closed=%v, want 1 closed", ok, path.Count(), path.IsClosed())
+	}
+}

--- a/model/sketch/offset_connected.go
+++ b/model/sketch/offset_connected.go
@@ -1,0 +1,342 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"fmt"
+
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/math"
+)
+
+// OffsetConnectedLoop offsets a connected chain of sketch curves (path) by signed distance d along
+// the LEFT normal of the traversal direction (d>0 offsets to the left of travel), keeping the curves
+// analytic — a line stays a line, an arc a concentric arc, a circle a concentric circle — and joining
+// adjacent offset curves at their intersection so corners meet (miter/extend/trim), exactly as
+// Inventor's sketch Offset does. It returns the created offset entities. A closed path wraps the last
+// corner to the first; an open path leaves the two ends untrimmed.
+//
+// For a loop traversed counter-clockwise the left normal points inward, so a positive d SHRINKS it
+// (an inner offset); a negative d grows it.
+//
+//	ents, err := sk.OffsetConnectedLoop(path, 0.25)
+func (s *Sketch) OffsetConnectedLoop(path *Path, d float64) ([]Entity, error) {
+	ents := path.Entities()
+	if len(ents) == 0 {
+		return nil, fmt.Errorf("offset: path has no entities (want at least one line/arc/circle)")
+	}
+	if circ, ok, err := s.offsetSingleCircle(ents, d); ok {
+		return circ, err
+	}
+	elems, err := s.buildOffsetElements(ents, d)
+	if err != nil {
+		return nil, err
+	}
+	starts, ends := offsetCornerEndpoints(elems, path.IsClosed())
+	return s.buildOffsetEntities(elems, starts, ends), nil
+}
+
+// offsetElement is one entity's analytic offset primitive plus the data to join it to its neighbours.
+// A line keeps a point on the offset line (start), a unit travel direction (dir) and its unit left
+// normal; an arc keeps its centre, offset radius and effective-CCW. start/end are the offset
+// primitive's own endpoints in traversal order (used for an open path's untrimmed ends); origStart/
+// origEnd are the original shared corner points (used to pick the right intersection branch).
+type offsetElement struct {
+	isLine     bool
+	dir        math.Vector2 // line: unit travel direction
+	normal     math.Vector2 // line: unit left normal
+	center     math.Point2  // arc: centre
+	radius     float64      // arc: offset radius r'
+	effCCW     bool         // arc: effective CCW (arc.CCW XOR reversed)
+	dist       float64      // signed offset distance (for the parallel-neighbour fallback)
+	start, end math.Point2  // offset primitive's own endpoints, in traversal order
+	origStart  math.Point2  // original traversal-start corner
+	origEnd    math.Point2  // original traversal-end corner
+}
+
+// analyticSeg is an entity reduced to its analytic form in the entity's NATURAL direction: a line
+// p0→p1, or an arc of the given centre/radius/CCW with natural endpoints p0 (start) and p1 (end).
+type analyticSeg struct {
+	isLine bool
+	p0, p1 math.Point2
+	center math.Point2
+	radius float64
+	ccw    bool
+}
+
+// offsetSingleCircle handles a single-entity full-circle loop: a concentric circle of the offset
+// radius, with no corners. ok is false when the path is not one closed circle. A circle traverses
+// CCW naturally (reversed flips it), so the left normal points inward when effective-CCW.
+func (s *Sketch) offsetSingleCircle(ents []ProfileEntity, d float64) ([]Entity, bool, error) {
+	if len(ents) != 1 {
+		return nil, false, nil
+	}
+	center, r, ok := circleCenterRadius(ents[0].Entity)
+	if !ok {
+		return nil, false, nil
+	}
+	rp := offsetRadius(r, d, !ents[0].Reversed())
+	if rp <= 0 {
+		return nil, true, fmt.Errorf("offset: circle radius %.4g offset by %.4g collapses to %.4g", r, d, rp)
+	}
+	return []Entity{s.circles.AddByCenterRadius(center, math.Scalar(rp))}, true, nil
+}
+
+// buildOffsetElements reduces every path entity to its offset primitive in traversal order.
+func (s *Sketch) buildOffsetElements(ents []ProfileEntity, d float64) ([]offsetElement, error) {
+	elems := make([]offsetElement, len(ents))
+	for i, pe := range ents {
+		el, err := offsetElementOf(pe, d)
+		if err != nil {
+			return nil, err
+		}
+		elems[i] = el
+	}
+	return elems, nil
+}
+
+// offsetElementOf builds the offset primitive for one profile entity, honoring its traversal
+// direction (a reversed entity is walked from its natural end to start).
+func offsetElementOf(pe ProfileEntity, d float64) (offsetElement, error) {
+	seg, err := analyticSegOf(pe.Entity)
+	if err != nil {
+		return offsetElement{}, err
+	}
+	a, b := seg.p0, seg.p1
+	if pe.Reversed() {
+		a, b = b, a
+	}
+	if seg.isLine {
+		return lineOffsetElement(a, b, d)
+	}
+	return arcOffsetElement(seg, a, b, pe.Reversed(), d)
+}
+
+// lineOffsetElement shifts the traversal-ordered line a→b by d along its left normal.
+func lineOffsetElement(a, b math.Point2, d float64) (offsetElement, error) {
+	u, ok := unitVec(a.VectorTo(b))
+	if !ok {
+		return offsetElement{}, fmt.Errorf("offset: degenerate zero-length line at %v", a)
+	}
+	n := math.V2(-u.Y, u.X) // left normal of travel (unit, since u is unit)
+	shift := n.Scale(d)
+	return offsetElement{
+		isLine: true, dir: u, normal: n, dist: d,
+		start: a.TranslateBy(shift), end: b.TranslateBy(shift),
+		origStart: a, origEnd: b,
+	}, nil
+}
+
+// arcOffsetElement builds the concentric offset arc for the traversal-ordered arc endpoints a→b.
+// Effective-CCW = arc.CCW XOR reversed; the left normal points inward (toward the centre) when
+// effective-CCW, so the offset radius is r-d there and r+d otherwise.
+func arcOffsetElement(seg analyticSeg, a, b math.Point2, reversed bool, d float64) (offsetElement, error) {
+	effCCW := seg.ccw != reversed
+	rp := offsetRadius(seg.radius, d, effCCW)
+	if rp <= 0 {
+		return offsetElement{}, fmt.Errorf("offset: arc radius %.4g offset by %.4g collapses to %.4g", seg.radius, d, rp)
+	}
+	scale := rp / seg.radius
+	return offsetElement{
+		center: seg.center, radius: rp, effCCW: effCCW, dist: d,
+		start: radialScale(seg.center, a, scale), end: radialScale(seg.center, b, scale),
+		origStart: a, origEnd: b,
+	}, nil
+}
+
+// offsetRadius is the concentric offset radius: r-d when the left normal points inward (effective-
+// CCW), r+d otherwise.
+func offsetRadius(r, d float64, effCCW bool) float64 {
+	if effCCW {
+		return r - d
+	}
+	return r + d
+}
+
+// radialScale returns center + (p-center)·scale — a point moved along its radius from center.
+func radialScale(center, p math.Point2, scale float64) math.Point2 {
+	return center.TranslateBy(center.VectorTo(p).Scale(scale))
+}
+
+// analyticSegOf reduces a supported entity to a line or circular-arc form; it errors for a curve with
+// no analytic form (a spline, or an obliquely projected arc that fits as an ellipse).
+func analyticSegOf(e Entity) (analyticSeg, error) {
+	switch v := e.(type) {
+	case *Line:
+		return analyticSeg{isLine: true, p0: v.A.Position(), p1: v.B.Position()}, nil
+	case *Arc:
+		return analyticSeg{
+			center: v.Center.Position(), radius: float64(v.Radius()), ccw: v.CounterClockwise,
+			p0: v.Start.Position(), p1: v.End.Position(),
+		}, nil
+	case *ProjectedCurve:
+		return projectedAnalyticSeg(v)
+	default:
+		return analyticSeg{}, fmt.Errorf("offset: curve is not analytic (%T)", e)
+	}
+}
+
+// projectedAnalyticSeg reduces a projected curve to its analytic line/arc form (Inventor keeps a
+// projected edge analytic). A full projected circle cannot join a multi-entity chain, and a non-
+// analytic (shapeNone) projection has no analytic offset, so both error.
+func projectedAnalyticSeg(pc *ProjectedCurve) (analyticSeg, error) {
+	sh := pc.shape
+	switch sh.kind {
+	case shapeLine:
+		return analyticSeg{isLine: true, p0: sh.a, p1: sh.b}, nil
+	case shapeArc:
+		return analyticSeg{
+			center: sh.center, radius: sh.radius, ccw: sh.sweep > 0,
+			p0: arcPointAt(sh.center, sh.radius, sh.start),
+			p1: arcPointAt(sh.center, sh.radius, sh.start+sh.sweep),
+		}, nil
+	default:
+		return analyticSeg{}, fmt.Errorf("offset: curve is not analytic (projected shape kind %d)", sh.kind)
+	}
+}
+
+// circleCenterRadius returns the centre and radius of a full-circle entity (a Circle or a projected
+// circle), reporting false for anything else.
+func circleCenterRadius(e Entity) (math.Point2, float64, bool) {
+	switch v := e.(type) {
+	case *Circle:
+		return v.Center.Position(), float64(v.Radius), true
+	case *ProjectedCurve:
+		if v.shape.kind == shapeCircle {
+			return v.shape.center, v.shape.radius, true
+		}
+	}
+	return math.Point2{}, 0, false
+}
+
+// offsetCornerEndpoints computes each offset element's trimmed start/end. Interior corners (and, for a
+// closed path, the wrap corner from the last element to the first) are the intersection of adjacent
+// offset primitives; an open path keeps each end element's own untrimmed offset endpoint.
+func offsetCornerEndpoints(elems []offsetElement, closed bool) (starts, ends []math.Point2) {
+	n := len(elems)
+	starts = make([]math.Point2, n)
+	ends = make([]math.Point2, n)
+	for i, el := range elems {
+		starts[i], ends[i] = el.start, el.end
+	}
+	for i := 0; i+1 < n; i++ {
+		c := cornerPoint(elems[i], elems[i+1])
+		ends[i], starts[i+1] = c, c
+	}
+	if closed && n >= 2 {
+		c := cornerPoint(elems[n-1], elems[0])
+		ends[n-1], starts[0] = c, c
+	}
+	return starts, ends
+}
+
+// cornerPoint is the new shared endpoint where two adjacent offset primitives meet: their
+// intersection nearest the original shared corner, or a normal-averaged fallback when they do not
+// cross (parallel lines, a missed circle) so a corner is still produced.
+func cornerPoint(a, b offsetElement) math.Point2 {
+	corner := a.origEnd // == b.origStart, the shared endpoint of the two originals
+	if p, ok := intersectElements(a, b, corner); ok {
+		return p
+	}
+	return fallbackCorner(a, b, corner)
+}
+
+// intersectElements intersects two offset primitives, picking the branch nearest the original corner.
+func intersectElements(a, b offsetElement, near math.Point2) (math.Point2, bool) {
+	switch {
+	case a.isLine && b.isLine:
+		return lineLineCorner(a, b)
+	case a.isLine:
+		return lineArcCorner(a, b, near)
+	case b.isLine:
+		return lineArcCorner(b, a, near)
+	default:
+		return arcArcCorner(a, b, near)
+	}
+}
+
+// lineLineCorner intersects two infinite offset lines (false when parallel).
+func lineLineCorner(a, b offsetElement) (math.Point2, bool) {
+	la, err := geom.NewLine2d(a.start, a.dir)
+	if err != nil {
+		return math.Point2{}, false
+	}
+	lb, err := geom.NewLine2d(b.start, b.dir)
+	if err != nil {
+		return math.Point2{}, false
+	}
+	return geom.Line2dIntersection(la, lb, 0)
+}
+
+// lineArcCorner intersects an offset line with an offset arc's circle, nearest the original corner.
+func lineArcCorner(line, arc offsetElement, near math.Point2) (math.Point2, bool) {
+	l, err := geom.NewLine2d(line.start, line.dir)
+	if err != nil {
+		return math.Point2{}, false
+	}
+	c := geom.NewCircle2d(arc.center, arc.radius)
+	return nearestOf(geom.LineCircle2dIntersection(l, c, 0), near)
+}
+
+// arcArcCorner intersects two offset arcs' circles, nearest the original corner.
+func arcArcCorner(a, b offsetElement, near math.Point2) (math.Point2, bool) {
+	c1 := geom.NewCircle2d(a.center, a.radius)
+	c2 := geom.NewCircle2d(b.center, b.radius)
+	return nearestOf(geom.Circle2dCircle2dIntersection(c1, c2, 0), near)
+}
+
+// nearestOf returns the candidate closest to near (false for an empty set).
+func nearestOf(cands []math.Point2, near math.Point2) (math.Point2, bool) {
+	if len(cands) == 0 {
+		return math.Point2{}, false
+	}
+	best, bestD := cands[0], near.DistanceTo(cands[0])
+	for _, p := range cands[1:] {
+		if d := near.DistanceTo(p); d < bestD {
+			best, bestD = p, d
+		}
+	}
+	return best, true
+}
+
+// fallbackCorner offsets the original corner along the average of the two left normals, so parallel
+// or non-crossing offset primitives (a collinear line continuation, a tangent that just misses) still
+// produce a joined corner rather than a gap.
+func fallbackCorner(a, b offsetElement, corner math.Point2) math.Point2 {
+	avg := a.leftNormalAt(corner).Add(b.leftNormalAt(corner))
+	u, ok := unitVec(avg)
+	if !ok {
+		u = a.leftNormalAt(corner) // opposing normals cancel: fall back to one side
+	}
+	return corner.TranslateBy(u.Scale(a.dist))
+}
+
+// leftNormalAt is the unit left normal of the element's travel at point p: constant for a line; the
+// radial direction toward the centre (effective-CCW) or away from it for an arc.
+func (el offsetElement) leftNormalAt(p math.Point2) math.Vector2 {
+	if el.isLine {
+		return el.normal
+	}
+	u, ok := unitVec(el.center.VectorTo(p))
+	if !ok {
+		return math.Vector2{}
+	}
+	if el.effCCW {
+		return u.Negate() // inward
+	}
+	return u
+}
+
+// buildOffsetEntities creates the trimmed offset geometry: a line for a line element, a concentric arc
+// for an arc element, joined at the computed corner endpoints.
+func (s *Sketch) buildOffsetEntities(elems []offsetElement, starts, ends []math.Point2) []Entity {
+	out := make([]Entity, 0, len(elems))
+	for i, el := range elems {
+		if el.isLine {
+			out = append(out, s.lines.AddByTwoPoints(starts[i], ends[i]))
+			continue
+		}
+		out = append(out, s.arcs.AddByCenterStartEnd(el.center, starts[i], ends[i], el.effCCW))
+	}
+	return out
+}

--- a/model/sketch/offset_connected_test.go
+++ b/model/sketch/offset_connected_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+	"testing"
+
+	gmath "oblikovati.org/math"
+)
+
+// closedPath wraps ordered, already-connected entities as a closed traversal path (each entity walked
+// in its natural direction), so a test drives OffsetConnectedLoop without going through loop detection.
+func closedPath(ents ...Entity) *Path {
+	return &Path{entities: profileEntities(ents), closed: true}
+}
+
+// openPath wraps ordered entities as an open traversal path.
+func openPath(ents ...Entity) *Path {
+	return &Path{entities: profileEntities(ents), closed: false}
+}
+
+func profileEntities(ents []Entity) []ProfileEntity {
+	pes := make([]ProfileEntity, len(ents))
+	for i, e := range ents {
+		pes[i] = ProfileEntity{Entity: e}
+	}
+	return pes
+}
+
+// wantPoint fails unless p is within 1e-6 of (x, y).
+func wantPoint(t *testing.T, label string, p gmath.Point2, x, y float64) {
+	t.Helper()
+	if stdmath.Abs(float64(p.X)-x) > 1e-6 || stdmath.Abs(float64(p.Y)-y) > 1e-6 {
+		t.Errorf("%s = (%.6g, %.6g), want (%.6g, %.6g)", label, float64(p.X), float64(p.Y), x, y)
+	}
+}
+
+func wantLine(t *testing.T, e Entity) *Line {
+	t.Helper()
+	l, ok := e.(*Line)
+	if !ok {
+		t.Fatalf("entity is %T, want *Line", e)
+	}
+	return l
+}
+
+func wantArc(t *testing.T, e Entity) *Arc {
+	t.Helper()
+	a, ok := e.(*Arc)
+	if !ok {
+		t.Fatalf("entity is %T, want *Arc", e)
+	}
+	return a
+}
+
+// TestOffsetConnectedRectangleInward: the unit square traversed counter-clockwise, offset by +0.25,
+// shrinks to the inner square — confirming a POSITIVE distance offsets to the left of travel (inward
+// for a CCW loop) and that the four corners meet at the inner-square vertices.
+func TestOffsetConnectedRectangleInward(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	l0 := s.Lines().AddByTwoPoints(gmath.P2(0, 0), gmath.P2(1, 0))
+	l1 := s.Lines().AddByTwoPoints(gmath.P2(1, 0), gmath.P2(1, 1))
+	l2 := s.Lines().AddByTwoPoints(gmath.P2(1, 1), gmath.P2(0, 1))
+	l3 := s.Lines().AddByTwoPoints(gmath.P2(0, 1), gmath.P2(0, 0))
+
+	ents, err := s.OffsetConnectedLoop(closedPath(l0, l1, l2, l3), 0.25)
+	if err != nil {
+		t.Fatalf("OffsetConnectedLoop(square, +0.25): %v", err)
+	}
+	if len(ents) != 4 {
+		t.Fatalf("got %d offset entities, want 4", len(ents))
+	}
+	corners := [5][2]float64{{0.25, 0.25}, {0.75, 0.25}, {0.75, 0.75}, {0.25, 0.75}, {0.25, 0.25}}
+	for i := range ents {
+		l := wantLine(t, ents[i])
+		wantPoint(t, "line start", l.A.Position(), corners[i][0], corners[i][1])
+		wantPoint(t, "line end", l.B.Position(), corners[i+1][0], corners[i+1][1])
+	}
+}
+
+// TestOffsetConnectedStadium: a closed stadium (two horizontal lines joined by two radius-1 semicircle
+// arcs) offset inward by 0.25 — the lines move to y=0.25 and y=1.75, and each arc stays concentric
+// with its original centre at radius 0.75.
+func TestOffsetConnectedStadium(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	bottom := s.Lines().AddByTwoPoints(gmath.P2(0, 0), gmath.P2(4, 0))
+	rightArc := s.Arcs().AddByCenterStartEnd(gmath.P2(4, 1), gmath.P2(4, 0), gmath.P2(4, 2), true)
+	top := s.Lines().AddByTwoPoints(gmath.P2(4, 2), gmath.P2(0, 2))
+	leftArc := s.Arcs().AddByCenterStartEnd(gmath.P2(0, 1), gmath.P2(0, 2), gmath.P2(0, 0), true)
+
+	ents, err := s.OffsetConnectedLoop(closedPath(bottom, rightArc, top, leftArc), 0.25)
+	if err != nil {
+		t.Fatalf("OffsetConnectedLoop(stadium, +0.25): %v", err)
+	}
+	if len(ents) != 4 {
+		t.Fatalf("got %d offset entities, want 4", len(ents))
+	}
+	assertHorizontalLine(t, wantLine(t, ents[0]), 0.25)
+	assertHorizontalLine(t, wantLine(t, ents[2]), 1.75)
+	assertConcentricArc(t, wantArc(t, ents[1]), 4, 1, 0.75)
+	assertConcentricArc(t, wantArc(t, ents[3]), 0, 1, 0.75)
+}
+
+// assertHorizontalLine checks both endpoints lie on y within 1e-6.
+func assertHorizontalLine(t *testing.T, l *Line, y float64) {
+	t.Helper()
+	if stdmath.Abs(float64(l.A.Y)-y) > 1e-6 || stdmath.Abs(float64(l.B.Y)-y) > 1e-6 {
+		t.Errorf("offset line at y=(%.6g, %.6g), want both at y=%.6g", float64(l.A.Y), float64(l.B.Y), y)
+	}
+}
+
+// assertConcentricArc checks the arc's centre and radius within 1e-6.
+func assertConcentricArc(t *testing.T, a *Arc, cx, cy, r float64) {
+	t.Helper()
+	wantPoint(t, "arc centre", a.Center.Position(), cx, cy)
+	if stdmath.Abs(float64(a.Radius())-r) > 1e-6 {
+		t.Errorf("arc radius = %.6g, want %.6g", float64(a.Radius()), r)
+	}
+}
+
+// TestOffsetConnectedOpenCorner: an open two-line elbow offset by 0.5 — the interior corner is
+// mitered to the offset lines' intersection, while the two OUTER ends keep their own untrimmed offset
+// endpoints (an open path does not wrap the last corner to the first).
+func TestOffsetConnectedOpenCorner(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	l0 := s.Lines().AddByTwoPoints(gmath.P2(0, 0), gmath.P2(4, 0))
+	l1 := s.Lines().AddByTwoPoints(gmath.P2(4, 0), gmath.P2(4, 4))
+
+	ents, err := s.OffsetConnectedLoop(openPath(l0, l1), 0.5)
+	if err != nil {
+		t.Fatalf("OffsetConnectedLoop(open elbow, +0.5): %v", err)
+	}
+	if len(ents) != 2 {
+		t.Fatalf("got %d offset entities, want 2", len(ents))
+	}
+	first, second := wantLine(t, ents[0]), wantLine(t, ents[1])
+	wantPoint(t, "outer start (untrimmed)", first.A.Position(), 0, 0.5)
+	wantPoint(t, "mitered corner (first end)", first.B.Position(), 3.5, 0.5)
+	wantPoint(t, "mitered corner (second start)", second.A.Position(), 3.5, 0.5)
+	wantPoint(t, "outer end (untrimmed)", second.B.Position(), 3.5, 4)
+}

--- a/model/sketch/offset_constrain.go
+++ b/model/sketch/offset_constrain.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+// ConstrainOffset is Inventor's "Constrain Offset" (on by default): it binds freshly-created offset
+// geometry to the source it was offset from so the copy stays associative — each offset line parallel
+// to its source line, each offset circular curve concentric to its source, and the offset's own
+// corners joined coincident so it stays a connected loop. The offset distance itself is left free, as
+// Inventor does, so the user can drive it with a dimension.
+//
+// The type switches on sketch entities live HERE, inside the sketch package, per the sketch-entity
+// seam (#1624); callers hand ordered source/offset entities (a projected-curve source is skipped —
+// reference geometry has no sketch DOF to bind to).
+
+// ConstrainOffsetLoop constrains a whole offset loop/chain: offsets[i] was produced from
+// path.Entities()[i], so they pair element-for-element (as OffsetConnectedLoop returns them). It also
+// joins the offset's corners coincident (wrapping the last to the first for a closed path). Returns
+// the number of constraints added.
+func (s *Sketch) ConstrainOffsetLoop(path *Path, offsets []Entity) int {
+	ents := path.Entities()
+	n := 0
+	for i, off := range offsets {
+		if i < len(ents) {
+			n += s.constrainOffsetPair(ents[i].Entity, off)
+		}
+	}
+	return n + s.joinOffsetCorners(offsets, path.IsClosed())
+}
+
+// ConstrainOffsetSingle constrains a single offset curve to its source (no corners to join).
+func (s *Sketch) ConstrainOffsetSingle(source, offset Entity) int {
+	return s.constrainOffsetPair(source, offset)
+}
+
+// constrainOffsetPair adds the one geometric constraint that keeps an offset associative to its
+// source: parallel for a line, concentric for a circle/arc. It returns 0 (no constraint) when the
+// source is neither — a projected curve, a spline — since those have no matching native binding.
+func (s *Sketch) constrainOffsetPair(src, off Entity) int {
+	if sl, ok := src.(*Line); ok {
+		if ol, ok := off.(*Line); ok {
+			s.geomCons.AddParallel(sl, ol)
+			return 1
+		}
+		return 0
+	}
+	sc, sok := src.(CircularCurve)
+	oc, ook := off.(CircularCurve)
+	if sok && ook {
+		s.geomCons.AddConcentric(sc, oc)
+		return 1
+	}
+	return 0
+}
+
+// joinOffsetCorners makes each offset element's end point coincident with the next element's start
+// point, so the offset stays a connected loop when the source moves. A closed path also joins the
+// last element back to the first.
+func (s *Sketch) joinOffsetCorners(offsets []Entity, closed bool) int {
+	n := 0
+	for i := 0; i+1 < len(offsets); i++ {
+		n += s.coincidentCorner(offsets[i], offsets[i+1])
+	}
+	if closed && len(offsets) >= 2 {
+		n += s.coincidentCorner(offsets[len(offsets)-1], offsets[0])
+	}
+	return n
+}
+
+// coincidentCorner joins the end of a to the start of b. A full circle has no endpoints, so a loop
+// that is a single circle joins nothing.
+func (s *Sketch) coincidentCorner(a, b Entity) int {
+	_, aEnd, aok := offsetEndpoints(a)
+	bStart, _, bok := offsetEndpoints(b)
+	if !aok || !bok {
+		return 0
+	}
+	s.geomCons.AddCoincident(aEnd, bStart)
+	return 1
+}
+
+// offsetEndpoints returns an offset element's start and end points, in traversal order (the order
+// buildOffsetEntities created them). ok is false for a curve with no two endpoints (a full circle).
+func offsetEndpoints(e Entity) (start, end *Point, ok bool) {
+	switch v := e.(type) {
+	case *Line:
+		return v.A, v.B, true
+	case *Arc:
+		return v.Start, v.End, true
+	}
+	return nil, nil, false
+}

--- a/model/sketch/offset_constrain_test.go
+++ b/model/sketch/offset_constrain_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"testing"
+
+	gmath "oblikovati.org/math"
+)
+
+// squareChain adds a closed CCW square [0,side]^2 of four lines and returns the connected path from
+// its first edge — the loop an offset Loop Select would follow.
+func squareChain(s *Sketch, side float64) (*Path, []*Line) {
+	c := []gmath.Point2{gmath.P2(0, 0), gmath.P2(side, 0), gmath.P2(side, side), gmath.P2(0, side)}
+	ls := make([]*Line, 4)
+	for i := 0; i < 4; i++ {
+		ls[i] = s.Lines().AddByTwoPoints(c[i], c[(i+1)%4])
+	}
+	path, _ := s.ConnectedChainFrom(ls[0])
+	return path, ls
+}
+
+// TestConstrainOffsetLoopBindsAndSolves is Inventor's Constrain Offset: a constrained loop offset
+// adds a parallel constraint per line and a coincident join per corner, and the sketch still solves
+// cleanly (the constraints are satisfied at creation, so nothing moves).
+func TestConstrainOffsetLoopBindsAndSolves(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	path, _ := squareChain(s, 4)
+	before := len(s.Constraints())
+
+	offsets, err := s.OffsetConnectedLoop(path, 0.5) // inward
+	if err != nil {
+		t.Fatalf("OffsetConnectedLoop: %v", err)
+	}
+	added := s.ConstrainOffsetLoop(path, offsets)
+	if added != 8 { // 4 parallel + 4 coincident corners
+		t.Fatalf("constrained offset added %d constraints, want 8 (4 parallel + 4 coincident)", added)
+	}
+	if got := len(s.Constraints()) - before; got != 8 {
+		t.Fatalf("sketch grew by %d constraints, want 8", got)
+	}
+	if r := s.Solve(); !r.Converged {
+		t.Fatal("constrained offset does not solve — the added constraints conflict")
+	}
+	// The inner-left offset edge stays at x=0.5 after solving (the constraints did not move it).
+	innerLeft := false
+	for _, e := range offsets {
+		l, ok := e.(*Line)
+		if !ok {
+			continue
+		}
+		if absTol(float64(l.A.Position().X)-0.5) < 1e-6 && absTol(float64(l.B.Position().X)-0.5) < 1e-6 {
+			innerLeft = true
+		}
+	}
+	if !innerLeft {
+		t.Error("inner-left offset edge is no longer at x=0.5 after constraining/solving")
+	}
+}
+
+// TestConstrainOffsetSinglePairsLineParallel: a single constrained line offset adds exactly one
+// parallel constraint (no corners), and the result solves.
+func TestConstrainOffsetSinglePairsLineParallel(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	src := s.Lines().AddByTwoPoints(gmath.P2(0, 0), gmath.P2(4, 0))
+	before := len(s.Constraints())
+	off, err := s.OffsetEntity(src, 2)
+	if err != nil {
+		t.Fatalf("OffsetEntity: %v", err)
+	}
+	if n := s.ConstrainOffsetSingle(src, off); n != 1 {
+		t.Fatalf("single line offset added %d constraints, want 1 (parallel)", n)
+	}
+	if got := len(s.Constraints()) - before; got != 1 {
+		t.Fatalf("sketch grew by %d constraints, want 1", got)
+	}
+	if r := s.Solve(); !r.Converged {
+		t.Fatal("constrained single-line offset does not solve")
+	}
+}
+
+// TestConstrainOffsetSkipsProjectedSource: a projected-curve source has no native binding, so
+// constraining pairs nothing (reference geometry is already associative to the model).
+func TestConstrainOffsetSkipsProjectedSource(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	pc := s.RestoreProjectedCurve(nextID(), []gmath.Point2{gmath.P2(0, 0), gmath.P2(4, 0)}, "edge", "E")
+	off := s.Lines().AddByTwoPoints(gmath.P2(0, 1), gmath.P2(4, 1))
+	if n := s.ConstrainOffsetSingle(pc, off); n != 0 {
+		t.Fatalf("projected source added %d constraints, want 0 (skipped)", n)
+	}
+}
+
+func absTol(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/model/sketch/offset_dimension.go
+++ b/model/sketch/offset_dimension.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// Offset dimensioning. Inventor puts a driving offset dimension on the geometry when you commit an
+// offset, so the offset distance is editable straight away. AddOffset*Dimension adds ONE such
+// dimension at the CURRENT offset distance: the perpendicular distance from the offset to a source
+// LINE (AddOffsetDim), or — for a purely circular offset — the offset curve's radius. sources/offsets
+// pair element-for-element (as OffsetConnectedLoop returns them). It returns (nil,false) when nothing
+// dimensionable exists (an all-projected-curve offset). The value is snapshotted so the dimension is
+// satisfied at creation — no solve jump — and drives the offset from then on.
+
+// AddOffsetLoopDimension dimensions a loop/chain offset from its source path and offset entities.
+func (s *Sketch) AddOffsetLoopDimension(path *Path, offsets []Entity) (*DimensionConstraint, bool) {
+	return s.addOffsetDimension(chainSourceEntities(path), offsets)
+}
+
+// AddOffsetSingleDimension dimensions a single-curve offset.
+func (s *Sketch) AddOffsetSingleDimension(source, offset Entity) (*DimensionConstraint, bool) {
+	return s.addOffsetDimension([]Entity{source}, []Entity{offset})
+}
+
+// chainSourceEntities returns a chain's source entities in traversal order.
+func chainSourceEntities(path *Path) []Entity {
+	ents := path.Entities()
+	out := make([]Entity, len(ents))
+	for i, pe := range ents {
+		out[i] = pe.Entity
+	}
+	return out
+}
+
+// addOffsetDimension prefers a perpendicular line offset dimension, falling back to a radius on a
+// purely circular offset.
+func (s *Sketch) addOffsetDimension(sources, offsets []Entity) (*DimensionConstraint, bool) {
+	if d, ok := s.offsetLineDimension(sources, offsets); ok {
+		return d, true
+	}
+	return s.offsetRadiusDimension(offsets)
+}
+
+// offsetLineDimension puts a perpendicular offset dimension on the first line source/offset pair, at
+// the current offset distance.
+func (s *Sketch) offsetLineDimension(sources, offsets []Entity) (*DimensionConstraint, bool) {
+	for i, off := range offsets {
+		if i >= len(sources) {
+			break
+		}
+		sl, lineSrc := sources[i].(*Line)
+		ol, lineOff := off.(*Line)
+		if !lineSrc || !lineOff {
+			continue
+		}
+		dist := math.Scalar(stdmath.Abs(perpDistanceToLine(sl.A.Position(), sl.B.Position(), ol.A.Position())))
+		if d, err := s.dimCons.AddOffsetDim(ol.A, sl, false, lengthExpr(dist)); err == nil {
+			return d, true
+		}
+	}
+	return nil, false
+}
+
+// offsetRadiusDimension puts a radius dimension on the first circular offset, at its current radius.
+func (s *Sketch) offsetRadiusDimension(offsets []Entity) (*DimensionConstraint, bool) {
+	for _, off := range offsets {
+		if oc, ok := off.(CircularCurve); ok {
+			if d, err := s.dimCons.AddRadius(oc, lengthExpr(oc.CurveRadius())); err == nil {
+				return d, true
+			}
+		}
+	}
+	return nil, false
+}

--- a/model/sketch/offset_preview.go
+++ b/model/sketch/offset_preview.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import "oblikovati.org/math"
+
+// Non-mutating offset geometry for the live preview. The offset tool shows a ghost of the offset
+// following the cursor before the placement click; this builds that ghost as a Recipe (analytic
+// lines + arcs) instead of mutating the sketch. It reuses the SAME pure geometry the commit path uses
+// (buildOffsetElements + offsetCornerEndpoints, or offsetLine/Circle/Arc), so the preview cannot drift
+// from what OK creates.
+
+// OffsetLoopRecipe builds the offset of a connected loop/chain by signed distance d as a Recipe. ok is
+// false when the loop cannot offset (an unsupported entity, or a collapse).
+func (s *Sketch) OffsetLoopRecipe(path *Path, d float64) (Recipe, bool) {
+	ents := path.Entities()
+	if len(ents) == 0 {
+		return Recipe{}, false
+	}
+	if r, ok := offsetSingleCircleRecipe(ents, d); ok {
+		return r, true
+	}
+	elems, err := s.buildOffsetElements(ents, d)
+	if err != nil {
+		return Recipe{}, false
+	}
+	starts, ends := offsetCornerEndpoints(elems, path.IsClosed())
+	return offsetElementsRecipe(elems, starts, ends), true
+}
+
+// offsetSingleCircleRecipe mirrors offsetSingleCircle without mutating: a lone circle offsets to a
+// concentric circle.
+func offsetSingleCircleRecipe(ents []ProfileEntity, d float64) (Recipe, bool) {
+	if len(ents) != 1 {
+		return Recipe{}, false
+	}
+	center, r, ok := circleCenterRadius(ents[0].Entity)
+	if !ok {
+		return Recipe{}, false
+	}
+	rp := offsetRadius(r, d, !ents[0].Reversed())
+	if rp <= 0 {
+		return Recipe{}, false
+	}
+	return CircleRecipe(center, math.Scalar(rp)), true
+}
+
+// offsetElementsRecipe assembles the offset primitives (with joined corner endpoints) into a Recipe of
+// lines and arcs, mirroring buildOffsetEntities.
+func offsetElementsRecipe(elems []offsetElement, starts, ends []math.Point2) Recipe {
+	var r Recipe
+	add := func(p math.Point2) int { r.Points = append(r.Points, p); return len(r.Points) - 1 }
+	for i, el := range elems {
+		if el.isLine {
+			a, b := add(starts[i]), add(ends[i])
+			r.Entities = append(r.Entities, RecipeEntity{Kind: RecipeLine, Points: []int{a, b}})
+			continue
+		}
+		c, a, b := add(el.center), add(starts[i]), add(ends[i])
+		r.Entities = append(r.Entities, RecipeEntity{Kind: RecipeArc, Points: []int{c, a, b}, CounterClockwise: el.effCCW})
+	}
+	return r
+}
+
+// OffsetEntityRecipe builds the offset of a single entity by signed distance d as a Recipe: a parallel
+// line, or a concentric circle/arc. ok is false for an unsupported entity or a collapse.
+func OffsetEntityRecipe(e Entity, d float64) (Recipe, bool) {
+	switch v := e.(type) {
+	case *Line:
+		u, ok := unitVec(v.A.Position().VectorTo(v.B.Position()))
+		if !ok {
+			return Recipe{}, false
+		}
+		n := math.V2(-u.Y, u.X).Scale(d)
+		return LineRecipe(v.A.Position().TranslateBy(n), v.B.Position().TranslateBy(n)), true
+	case *Circle:
+		rp := float64(v.Radius) + d
+		if rp <= 0 {
+			return Recipe{}, false
+		}
+		return CircleRecipe(v.Center.Position(), math.Scalar(rp)), true
+	case *Arc:
+		return offsetArcRecipe(v, d)
+	default:
+		return Recipe{}, false
+	}
+}
+
+// offsetArcRecipe builds the concentric-arc offset Recipe (endpoints moved radially by r+d).
+func offsetArcRecipe(a *Arc, d float64) (Recipe, bool) {
+	center := a.Center.Position()
+	r := float64(a.Radius())
+	nr := r + d
+	if nr <= 0 || r == 0 {
+		return Recipe{}, false
+	}
+	scale := nr / r
+	start := center.TranslateBy(center.VectorTo(a.Start.Position()).Scale(scale))
+	end := center.TranslateBy(center.VectorTo(a.End.Position()).Scale(scale))
+	return ArcRecipe(center, start, end, a.CounterClockwise), true
+}

--- a/model/sketch/offset_projected_test.go
+++ b/model/sketch/offset_projected_test.go
@@ -3,24 +3,36 @@
 package sketch
 
 import (
+	stdmath "math"
 	"testing"
 
 	gmath "oblikovati.org/math"
 )
 
-// TestOffsetProjectedClosedLoop is the #2158 follow-up: a projected closed perimeter (a face
-// outline, stored as a sampled polyline) must offset as a closed loop of lines — the inner offset a
-// user makes after projecting a face. Before it, OffsetEntity rejected the projected curve
-// ("unsupported entity *sketch.ProjectedCurve").
+// ellipsePts samples an ellipse (semi-axes ra, rb) — an obliquely projected arc/circle, which is
+// NOT a circle, so fitProjectedShape leaves it shapeNone and the offset falls back to the polyline.
+func ellipsePts(ra, rb, start, sweep float64, n int) []gmath.Point2 {
+	pts := make([]gmath.Point2, n+1)
+	for i := range pts {
+		a := start + sweep*float64(i)/float64(n)
+		pts[i] = gmath.P2(gmath.Scalar(ra*stdmath.Cos(a)), gmath.Scalar(rb*stdmath.Sin(a)))
+	}
+	return pts
+}
+
+// TestOffsetProjectedClosedLoop: a non-circular closed projection (an ellipse) offsets as a closed
+// loop of lines — the polyline fallback (#2158 follow-up). A circular projection takes the analytic
+// path instead (TestOffsetProjectedCircleMakesACircle).
 func TestOffsetProjectedClosedLoop(t *testing.T) {
 	s := NewSketches().Add(XYPlane())
-	sq := []gmath.Point2{gmath.P2(0, 0), gmath.P2(4, 0), gmath.P2(4, 4), gmath.P2(0, 4), gmath.P2(0, 0)}
-	pc := s.RestoreProjectedCurve(nextID(), sq, "edge", "E1")
-
+	pc := s.RestoreProjectedCurve(nextID(), ellipsePts(4, 2, 0, 2*stdmath.Pi, 24), "edge", "E1")
+	if pc.shape.kind != shapeNone {
+		t.Fatalf("an ellipse should stay a polyline, got shape kind %d", pc.shape.kind)
+	}
 	before := s.Lines().Count()
-	got, err := s.OffsetEntity(pc, -0.5) // inner offset (d<0 shrinks, like offsetCircle)
+	got, err := s.OffsetEntity(pc, -0.5)
 	if err != nil {
-		t.Fatalf("OffsetEntity(closed projected curve): %v", err)
+		t.Fatalf("OffsetEntity(closed ellipse projection): %v", err)
 	}
 	if got == nil {
 		t.Fatal("offset returned a nil entity")
@@ -30,17 +42,18 @@ func TestOffsetProjectedClosedLoop(t *testing.T) {
 	}
 }
 
-// TestOffsetProjectedOpenCurve: a projected open edge offsets as an open chain of lines.
+// TestOffsetProjectedOpenCurve: a non-circular open projection offsets as an open chain of lines.
 func TestOffsetProjectedOpenCurve(t *testing.T) {
 	s := NewSketches().Add(XYPlane())
-	open := []gmath.Point2{gmath.P2(0, 0), gmath.P2(4, 0), gmath.P2(4, 4)}
-	pc := s.RestoreProjectedCurve(nextID(), open, "edge", "E2")
-
+	pc := s.RestoreProjectedCurve(nextID(), ellipsePts(4, 2, 0, stdmath.Pi, 16), "edge", "E2")
+	if pc.shape.kind != shapeNone {
+		t.Fatalf("a half-ellipse should stay a polyline, got shape kind %d", pc.shape.kind)
+	}
 	before := s.Lines().Count()
 	if _, err := s.OffsetEntity(pc, 0.5); err != nil {
-		t.Fatalf("OffsetEntity(open projected curve): %v", err)
+		t.Fatalf("OffsetEntity(open ellipse projection): %v", err)
 	}
 	if s.Lines().Count() <= before {
-		t.Error("no offset line geometry created for the open projected curve")
+		t.Error("no offset line geometry created for the open projection")
 	}
 }

--- a/model/sketch/offset_projected_test.go
+++ b/model/sketch/offset_projected_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	"testing"
+
+	gmath "oblikovati.org/math"
+)
+
+// TestOffsetProjectedClosedLoop is the #2158 follow-up: a projected closed perimeter (a face
+// outline, stored as a sampled polyline) must offset as a closed loop of lines — the inner offset a
+// user makes after projecting a face. Before it, OffsetEntity rejected the projected curve
+// ("unsupported entity *sketch.ProjectedCurve").
+func TestOffsetProjectedClosedLoop(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	sq := []gmath.Point2{gmath.P2(0, 0), gmath.P2(4, 0), gmath.P2(4, 4), gmath.P2(0, 4), gmath.P2(0, 0)}
+	pc := s.RestoreProjectedCurve(nextID(), sq, "edge", "E1")
+
+	before := s.Lines().Count()
+	got, err := s.OffsetEntity(pc, -0.5) // inner offset (d<0 shrinks, like offsetCircle)
+	if err != nil {
+		t.Fatalf("OffsetEntity(closed projected curve): %v", err)
+	}
+	if got == nil {
+		t.Fatal("offset returned a nil entity")
+	}
+	if s.Lines().Count() <= before {
+		t.Errorf("no offset line geometry created (%d→%d lines)", before, s.Lines().Count())
+	}
+}
+
+// TestOffsetProjectedOpenCurve: a projected open edge offsets as an open chain of lines.
+func TestOffsetProjectedOpenCurve(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	open := []gmath.Point2{gmath.P2(0, 0), gmath.P2(4, 0), gmath.P2(4, 4)}
+	pc := s.RestoreProjectedCurve(nextID(), open, "edge", "E2")
+
+	before := s.Lines().Count()
+	if _, err := s.OffsetEntity(pc, 0.5); err != nil {
+		t.Fatalf("OffsetEntity(open projected curve): %v", err)
+	}
+	if s.Lines().Count() <= before {
+		t.Error("no offset line geometry created for the open projected curve")
+	}
+}

--- a/model/sketch/offset_uniform.go
+++ b/model/sketch/offset_uniform.go
@@ -13,9 +13,10 @@ import (
 // so editing that one dimension moves the whole loop uniformly. It replaces the plain
 // ConstrainOffsetLoop + AddOffsetLoopDimension pair: each element gets exactly one distance-binding
 // constraint (no doubled parallels), so a rectangle offset is fully constrained (DOF 0) and rigidly
-// uniform. Circular offsets stay concentric — their radius is NOT driven by the line dimension yet, a
-// known limit for rounded loops (the arc keeps its offset radius). A driven constraint is a closure,
-// so a serialized reload freezes it at its last distance (see OffsetConstraint).
+// uniform. Circular offsets stay concentric and are carried by the corner joins, so an arc's radius
+// grows with the driving dimension too (a stadium's caps track the dimension uniformly). The driven
+// links persist: each records its driving dimension's parameter name and is re-bound on reload
+// (applyPendingOffsetDrives), so editing the dimension still drives the whole loop after a save/reload.
 
 // ConstrainOffsetLoopUniform constrains a whole offset loop associatively AND uniformly. offsets pair
 // element-for-element with path.Entities(). Returns the driving dimension, or nil when the loop has
@@ -61,7 +62,8 @@ func (s *Sketch) dimensionFirstOffsetLine(ents []ProfileEntity, offsets []Entity
 
 // constrainUniformOffsetPair binds one non-dimensioned offset element to its source at the SAME
 // distance as the driving dimension: a line by a driven offset constraint (parallel + distance =
-// ±dim), anything circular by concentric (radius kept at its offset value — not driven).
+// ±dim), anything circular by concentric — a concentric arc's radius then follows the dimension
+// through the shared corner points, so both grow together.
 func (s *Sketch) constrainUniformOffsetPair(src, off Entity, dim *DimensionConstraint) {
 	sl, okSrc := src.(*Line)
 	ol, okOff := off.(*Line)
@@ -73,6 +75,5 @@ func (s *Sketch) constrainUniformOffsetPair(src, off Entity, dim *DimensionConst
 	if perpDistanceToLine(sl.A.Position(), sl.B.Position(), ol.A.Position()) < 0 {
 		sign = -1.0 // this segment's offset sits on the opposite side of its source's left normal
 	}
-	p := dim.Parameter()
-	s.geomCons.AddOffsetDriven(sl, ol, func() float64 { return sign * p.ModelValue() })
+	s.geomCons.AddOffsetDriven(sl, ol, dim.Parameter(), sign)
 }

--- a/model/sketch/offset_uniform.go
+++ b/model/sketch/offset_uniform.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// Uniform offset constraining (Inventor parity). A committed offset loop gets ONE driving offset
+// dimension, and every OTHER offset line is bound to the SAME distance by a driven offset constraint,
+// so editing that one dimension moves the whole loop uniformly. It replaces the plain
+// ConstrainOffsetLoop + AddOffsetLoopDimension pair: each element gets exactly one distance-binding
+// constraint (no doubled parallels), so a rectangle offset is fully constrained (DOF 0) and rigidly
+// uniform. Circular offsets stay concentric — their radius is NOT driven by the line dimension yet, a
+// known limit for rounded loops (the arc keeps its offset radius). A driven constraint is a closure,
+// so a serialized reload freezes it at its last distance (see OffsetConstraint).
+
+// ConstrainOffsetLoopUniform constrains a whole offset loop associatively AND uniformly. offsets pair
+// element-for-element with path.Entities(). Returns the driving dimension, or nil when the loop has
+// nothing to dimension (e.g. an all-projected-curve offset).
+func (s *Sketch) ConstrainOffsetLoopUniform(path *Path, offsets []Entity) *DimensionConstraint {
+	ents := path.Entities()
+	s.joinOffsetCorners(offsets, path.IsClosed())
+	dim, dimIdx := s.dimensionFirstOffsetLine(ents, offsets)
+	for i, off := range offsets {
+		if i >= len(ents) || i == dimIdx {
+			continue // the dimensioned segment already carries parallel + the driving dimension
+		}
+		s.constrainUniformOffsetPair(ents[i].Entity, off, dim)
+	}
+	return dim
+}
+
+// dimensionFirstOffsetLine adds the parallel + a driving offset dimension to the FIRST line
+// source/offset pair, returning the dimension and that pair's index. For a pure-circle loop (no line)
+// it dimensions the offset radius instead and returns index -1.
+func (s *Sketch) dimensionFirstOffsetLine(ents []ProfileEntity, offsets []Entity) (*DimensionConstraint, int) {
+	for i, off := range offsets {
+		if i >= len(ents) {
+			break
+		}
+		sl, okSrc := ents[i].Entity.(*Line)
+		ol, okOff := off.(*Line)
+		if !okSrc || !okOff {
+			continue
+		}
+		s.geomCons.AddParallel(sl, ol)
+		dist := stdmath.Abs(perpDistanceToLine(sl.A.Position(), sl.B.Position(), ol.A.Position()))
+		if d, err := s.dimCons.AddOffsetDim(ol.A, sl, false, lengthExpr(math.Scalar(dist))); err == nil {
+			return d, i
+		}
+		return nil, -1
+	}
+	if d, ok := s.offsetRadiusDimension(offsets); ok {
+		return d, -1
+	}
+	return nil, -1
+}
+
+// constrainUniformOffsetPair binds one non-dimensioned offset element to its source at the SAME
+// distance as the driving dimension: a line by a driven offset constraint (parallel + distance =
+// ±dim), anything circular by concentric (radius kept at its offset value — not driven).
+func (s *Sketch) constrainUniformOffsetPair(src, off Entity, dim *DimensionConstraint) {
+	sl, okSrc := src.(*Line)
+	ol, okOff := off.(*Line)
+	if !okSrc || !okOff || dim == nil {
+		s.constrainOffsetPair(src, off) // circular → concentric; a stray line without a dim → parallel
+		return
+	}
+	sign := 1.0
+	if perpDistanceToLine(sl.A.Position(), sl.B.Position(), ol.A.Position()) < 0 {
+		sign = -1.0 // this segment's offset sits on the opposite side of its source's left normal
+	}
+	p := dim.Parameter()
+	s.geomCons.AddOffsetDriven(sl, ol, func() float64 { return sign * p.ModelValue() })
+}

--- a/model/sketch/offset_uniform_test.go
+++ b/model/sketch/offset_uniform_test.go
@@ -65,3 +65,123 @@ func TestOffsetLoopUniformlyDriven(t *testing.T) {
 	}
 	assertUniformOffset(t, lines, offsets, 1.0)
 }
+
+// TestOffsetLoopUniformSurvivesRoundTrip is the serialization guarantee: after a uniform-offset loop
+// is saved and reloaded, editing its single driving dimension STILL moves every segment uniformly. The
+// driven links are re-bound to the restored dimension parameter (applyPendingOffsetDrives), so the
+// loop does not freeze at its last distance on reload (the former closure-only limitation).
+func TestOffsetLoopUniformSurvivesRoundTrip(t *testing.T) {
+	sc := NewSketches()
+	s := sc.Add(XYPlane())
+	lines := groundedSquare(s, 4)
+	path := closedPath(lines[0], lines[1], lines[2], lines[3])
+	offsets, err := s.OffsetConnectedLoop(path, 0.5)
+	if err != nil {
+		t.Fatalf("OffsetConnectedLoop: %v", err)
+	}
+	dim := s.ConstrainOffsetLoopUniform(path, offsets)
+	if dim == nil {
+		t.Fatal("no driving offset dimension was created")
+	}
+	name := dim.Parameter().Name()
+	s.Solve()
+
+	data, err := sc.MarshalRecipe()
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	sc2 := NewSketches()
+	if err := sc2.ApplyRecipe(data); err != nil {
+		t.Fatalf("ApplyRecipe: %v", err)
+	}
+	s2 := sc2.Item(0)
+
+	if got := countDrivenOffsets(s2); got != 3 {
+		t.Fatalf("restored driven offset constraints = %d, want 3 (loop of 4 lines, one carries the dimension)", got)
+	}
+	drv := dimensionNamed(t, s2, name)
+	if err := drv.Drive(1.0); err != nil {
+		t.Fatalf("Drive(1.0) after reload: %v", err)
+	}
+	if r := s2.Solve(); !r.Converged {
+		t.Fatalf("solve after reload+drive: converged=%v", r.Converged)
+	}
+	src := []*Line{s2.Lines().Item(0), s2.Lines().Item(1), s2.Lines().Item(2), s2.Lines().Item(3)}
+	off := []Entity{s2.Lines().Item(4), s2.Lines().Item(5), s2.Lines().Item(6), s2.Lines().Item(7)}
+	assertUniformOffset(t, src, off, 1.0)
+}
+
+// countDrivenOffsets counts the driven (dimension-linked) offset constraints in a sketch.
+func countDrivenOffsets(s *Sketch) int {
+	n := 0
+	for _, c := range s.Constraints() {
+		if oc, ok := c.(*OffsetConstraint); ok && oc.driver != nil {
+			n++
+		}
+	}
+	return n
+}
+
+// dimensionNamed returns the dimension whose parameter has the given name.
+func dimensionNamed(t *testing.T, s *Sketch, name string) *DimensionConstraint {
+	t.Helper()
+	for _, d := range s.DimensionConstraints().All() {
+		if d.Parameter() != nil && d.Parameter().Name() == name {
+			return d
+		}
+	}
+	t.Fatalf("no dimension with parameter %q after reload", name)
+	return nil
+}
+
+// TestOffsetLoopRoundedArcsDriveUniformly proves a ROUNDED loop (a stadium: two lines + two semicircle
+// caps) offsets uniformly under one driving dimension — every offset arc's radius grows with the line
+// distance (concentric arcs are carried by the corner joins), not just the lines. The stadium's arcs
+// make the solve redundant (an arc's built-in circularity is redundant with a fully pinned frame — a
+// grounded arc alone reports the same), so the assertion is convergence + uniform geometry, not a
+// well-constrained verdict.
+func TestOffsetLoopRoundedArcsDriveUniformly(t *testing.T) {
+	const L, r = 4.0, 1.0
+	s := NewSketches().Add(XYPlane())
+	bottom := s.Lines().AddByTwoPoints(gmath.P2(0, -r), gmath.P2(L, -r))
+	right := s.Arcs().AddByCenterStartEnd(gmath.P2(L, 0), gmath.P2(L, -r), gmath.P2(L, r), true)
+	top := s.Lines().AddByTwoPoints(gmath.P2(L, r), gmath.P2(0, r))
+	left := s.Arcs().AddByCenterStartEnd(gmath.P2(0, 0), gmath.P2(0, r), gmath.P2(0, -r), true)
+	for _, e := range []Entity{bottom, right, top, left} {
+		s.GeometricConstraints().AddGround(e)
+	}
+	path := closedPath(bottom, right, top, left)
+
+	offsets, err := s.OffsetConnectedLoop(path, -0.3) // outward offset by 0.3
+	if err != nil {
+		t.Fatalf("OffsetConnectedLoop: %v", err)
+	}
+	dim := s.ConstrainOffsetLoopUniform(path, offsets)
+	if dim == nil {
+		t.Fatal("no driving offset dimension was created")
+	}
+	if r := s.Solve(); !r.Converged {
+		t.Fatalf("solve after uniform offset: converged=%v", r.Converged)
+	}
+	rightArc := wantArc(t, offsets[1])
+	leftArc := wantArc(t, offsets[3])
+	assertRadius(t, rightArc, 1.3)
+	assertRadius(t, leftArc, 1.3)
+
+	if err := dim.Drive(0.6); err != nil { // grow the offset to 0.6
+		t.Fatalf("Drive(0.6): %v", err)
+	}
+	if r := s.Solve(); !r.Converged {
+		t.Fatalf("solve after driving the dimension to 0.6: converged=%v", r.Converged)
+	}
+	assertRadius(t, rightArc, 1.6) // both caps grow uniformly with the one dimension
+	assertRadius(t, leftArc, 1.6)
+}
+
+// assertRadius fails unless the arc's radius is within 1e-3 of want.
+func assertRadius(t *testing.T, a *Arc, want float64) {
+	t.Helper()
+	if got := float64(a.Radius()); stdmath.Abs(got-want) > 1e-3 {
+		t.Errorf("arc radius = %.4f, want %.4f", got, want)
+	}
+}

--- a/model/sketch/offset_uniform_test.go
+++ b/model/sketch/offset_uniform_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+	"testing"
+
+	gmath "oblikovati.org/math"
+)
+
+// groundedSquare builds a CCW square [0,side]^2, grounds every edge (a fixed source profile), and
+// returns its four lines.
+func groundedSquare(s *Sketch, side float64) []*Line {
+	c := []gmath.Point2{gmath.P2(0, 0), gmath.P2(gmath.Scalar(side), 0), gmath.P2(gmath.Scalar(side), gmath.Scalar(side)), gmath.P2(0, gmath.Scalar(side))}
+	lines := make([]*Line, 4)
+	for i := 0; i < 4; i++ {
+		lines[i] = s.Lines().AddByTwoPoints(c[i], c[(i+1)%4])
+		s.GeometricConstraints().AddGround(lines[i])
+	}
+	return lines
+}
+
+// assertUniformOffset fails unless every offset line sits at perpendicular distance want (±1e-4) from
+// its source — i.e. the offset stayed uniform.
+func assertUniformOffset(t *testing.T, sources []*Line, offsets []Entity, want float64) {
+	t.Helper()
+	for i, off := range offsets {
+		ol := wantLine(t, off)
+		d := stdmath.Abs(perpDistanceToLine(sources[i].A.Position(), sources[i].B.Position(), ol.A.Position()))
+		if stdmath.Abs(d-want) > 1e-4 {
+			t.Errorf("offset segment %d at distance %.5f, want %.5f (offset is not uniform)", i, d, want)
+		}
+	}
+}
+
+// TestOffsetLoopUniformlyDriven is the Inventor-parity core: a constrained loop offset carries ONE
+// driving dimension, and editing that single dimension moves the WHOLE loop uniformly — every segment
+// follows, because the non-dimensioned lines are bound to the same distance by driven offset
+// constraints. The sketch stays exactly determined (converges, not over-constrained).
+func TestOffsetLoopUniformlyDriven(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	lines := groundedSquare(s, 4)
+	path := closedPath(lines[0], lines[1], lines[2], lines[3])
+
+	offsets, err := s.OffsetConnectedLoop(path, 0.5) // inner offset by 0.5
+	if err != nil {
+		t.Fatalf("OffsetConnectedLoop: %v", err)
+	}
+	dim := s.ConstrainOffsetLoopUniform(path, offsets)
+	if dim == nil {
+		t.Fatal("no driving offset dimension was created")
+	}
+	if r := s.Solve(); !r.Converged || r.Status == OverConstrained {
+		t.Fatalf("solve after uniform offset: converged=%v status=%v (want converged, not over-constrained)", r.Converged, r.Status)
+	}
+	assertUniformOffset(t, lines, offsets, 0.5)
+
+	// Edit the ONE dimension — the whole loop must follow to 1.0 uniformly.
+	if err := dim.Drive(1.0); err != nil {
+		t.Fatalf("Drive(1.0): %v", err)
+	}
+	if r := s.Solve(); !r.Converged {
+		t.Fatalf("solve after driving the dimension to 1.0: converged=%v", r.Converged)
+	}
+	assertUniformOffset(t, lines, offsets, 1.0)
+}

--- a/model/sketch/profile.go
+++ b/model/sketch/profile.go
@@ -259,13 +259,17 @@ func (s *Sketch) normalGeometry() []Entity {
 // groupRegions builds profiles from closed loops by even–odd nesting: a loop contained in an even
 // number of others is an outer boundary; loops one level deeper inside it are its holes.
 //
-// As an exception, a hole loop that is a single closed PRIMITIVE the user drew — a circle or an
-// ellipse — ALSO bounds its own selectable region (the disk inside it), so a circle inside a
-// rectangle yields BOTH the annulus AND the disk, matching how Inventor lets you select either face.
-// (#1526: lofting "the circle" produced nothing because the disk was silently absorbed as a hole and
-// never offered as a profile.) The exception is deliberately narrow: text-glyph counters and abutting
-// grill cells are not single primitives, so they stay holes only and the glyph/grill region detection
-// (and the grill boolean, which uses ClosedLoops, #863) is unchanged.
+// As an exception, an odd-nested loop the user actually DREW also bounds its own selectable region
+// (the area inside it), so nested loops yield BOTH the annulus AND the inner face, matching how
+// Inventor lets you select either. A circle inside a rectangle offers the disk (#1526), and a
+// rounded-rectangle (or any polygon) inside another offers its inner face (#2165 — the offset of a
+// rounded profile left the inner region unselectable). Synthetic text-glyph counters carry NO
+// entities (they are bare polygons from TextProfiles), so they stay holes only and the glyph region
+// detection is unchanged; the grill boolean uses ClosedLoops (#863) and is likewise untouched.
+//
+// The extra inner regions are APPENDED after every outer region, so a loop the exception newly exposes
+// never shifts an outer region's index — index-based extrude/loft selections in older documents keep
+// pointing at the same face (newer ones resolve by seed point, #region-seed).
 func groupRegions(loops []Loop) []*Profile {
 	depth := make([]int, len(loops))
 	for i := range loops {
@@ -277,27 +281,75 @@ func groupRegions(loops []Loop) []*Profile {
 	}
 	var profiles []*Profile
 	for i, l := range loops {
-		if depth[i]%2 == 0 || isClosedPrimitiveLoop(l) {
+		if depth[i]%2 == 0 {
+			profiles = append(profiles, &Profile{outer: l, inner: holesOf(i, loops, depth)})
+		}
+	}
+	abutting := abuttingLoops(loops)
+	for i, l := range loops {
+		if depth[i]%2 == 1 && loopBoundsOwnRegion(l) && !abutting[i] {
 			profiles = append(profiles, &Profile{outer: l, inner: holesOf(i, loops, depth)})
 		}
 	}
 	return profiles
 }
 
-// isClosedPrimitiveLoop reports whether a loop is a single closed-curve primitive (a circle or a full
-// ellipse). Such a loop unambiguously bounds a region the user can select — the basis for the
-// disk-inside-a-hole exception in groupRegions (#1526). A multi-entity loop (a polygon, a glyph
-// outline, a chain of grill bars) is not a primitive and keeps the plain even–odd hole behaviour.
-func isClosedPrimitiveLoop(l Loop) bool {
-	if len(l.entities) != 1 {
-		return false
+// loopBoundsOwnRegion reports whether an odd-nested (hole) loop ALSO bounds a face the user can
+// select in its own right. A loop the user drew — one that carries sketch entities, whether a single
+// circle/ellipse or a multi-entity polygon/rounded-rectangle chain — does; a synthetic text-glyph
+// counter (a bare polygon with no entities, produced by TextProfiles) does not, so the hole in an
+// 'O'/'A'/'B' stays a hole. See groupRegions (#1526, #2165).
+func loopBoundsOwnRegion(l Loop) bool {
+	return len(l.entities) >= 1
+}
+
+// abuttingLoops flags each loop that shares an edge with another loop — the minimal cells of one
+// SUBDIVIDED island (a grid of crossing grill bars carves an interior into many abutting cells). Such
+// a cell is NOT a region the user drew, so it stays a hole (merged into one outline by holesOf, #863);
+// only a STANDALONE inner loop — one sharing no edge with any sibling, i.e. a genuinely nested circle,
+// rectangle or rounded rectangle — bounds its own selectable region (#2165). Edges are welded so two
+// cells tracing the same boundary points register as shared.
+func abuttingLoops(loops []Loop) []bool {
+	edgeUses := map[[2]int]int{}
+	loopEdges := make([][][2]int, len(loops))
+	w := newLoopWelder()
+	for li, l := range loops {
+		loopEdges[li] = weldedLoopEdges(w, l)
+		for _, key := range loopEdges[li] {
+			edgeUses[key]++
+		}
 	}
-	switch l.entities[0].Entity.(type) {
-	case *Circle, *Ellipse:
-		return true
-	default:
-		return false
+	abut := make([]bool, len(loops))
+	for li := range loops {
+		for _, key := range loopEdges[li] {
+			if edgeUses[key] > 1 {
+				abut[li] = true
+				break
+			}
+		}
 	}
+	return abut
+}
+
+// weldedLoopEdges returns a loop's undirected edges as sorted welded-index pairs, so an edge two
+// abutting cells trace from the same boundary points registers as the one shared edge.
+func weldedLoopEdges(w *loopWelder, l Loop) [][2]int {
+	idx := make([]int, len(l.polygon))
+	for i, p := range l.polygon {
+		idx[i] = w.add(p)
+	}
+	edges := make([][2]int, 0, len(idx))
+	for i := range idx {
+		a, b := idx[i], idx[(i+1)%len(idx)]
+		if a == b {
+			continue
+		}
+		if a > b {
+			a, b = b, a
+		}
+		edges = append(edges, [2]int{a, b})
+	}
+	return edges
 }
 
 // holesOf returns the holes of outer (index oi): the loops one nesting level inside it. A

--- a/model/sketch/profile_test.go
+++ b/model/sketch/profile_test.go
@@ -96,6 +96,42 @@ func TestNestedLoopsClassifyInnerAndOuter(t *testing.T) {
 	}
 }
 
+// TestNestedMultiEntityLoopIsSelectable is the #2165 regression: a MULTI-ENTITY inner loop (a
+// rectangle inside a rectangle — the shape a rounded-profile offset produces) must ALSO bound its own
+// selectable region, not only the annulus. Before the fix the inner rectangle was absorbed as a hole
+// (only single-primitive circles/ellipses were exempt), so its inner face could not be picked to
+// extrude — the user could select the band but not the inner region.
+func TestNestedMultiEntityLoopIsSelectable(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	addRectangle(s, 0, 0, 10, 10) // outer
+	addRectangle(s, 3, 3, 7, 7)   // an inner rectangle (multi-entity, not a primitive)
+	ps := s.Profiles()
+	if ps.Count() != 2 {
+		t.Fatalf("Profiles count = %d, want 2 (the frame and the inner rectangle face)", ps.Count())
+	}
+	// The inner region's centre must be selectable — contained by exactly one profile (the inner
+	// face), never by the frame (whose hole it is).
+	center := math.P2(5, 5)
+	hits := 0
+	for i := 0; i < ps.Count(); i++ {
+		if ps.Item(i).Contains(center) {
+			hits++
+		}
+	}
+	if hits != 1 {
+		t.Errorf("inner-region centre is contained by %d profiles, want exactly 1 (the inner face)", hits)
+	}
+	// The index-0 (outer/frame) region must be preserved and keep the inner rectangle as its hole,
+	// so index-based selections in older documents stay valid.
+	frame := ps.Item(0)
+	if len(frame.InnerLoops()) != 1 {
+		t.Errorf("frame (index 0) should keep 1 hole (the inner rectangle); got %d", len(frame.InnerLoops()))
+	}
+	if frame.Contains(center) {
+		t.Error("the frame must NOT contain the inner-region centre (that point is its hole)")
+	}
+}
+
 // classifyAnnulusAndDisk splits the two profiles into the one with a hole (the annulus) and the one
 // without (the disk).
 func classifyAnnulusAndDisk(t *testing.T, ps *Profiles) (annulus, disk *Profile) {

--- a/model/sketch/projected_shape.go
+++ b/model/sketch/projected_shape.go
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+
+	"oblikovati.org/math"
+)
+
+// A projected curve keeps its sampled polyline, but Inventor projects an analytic edge as analytic
+// reference geometry — a line as a line, an arc as an arc, a circle as a circle — not the faceted
+// chain a coplanar/parallel projection really is up to sampling. Detecting the shape from the
+// projected 2D points is exact for those cases (a coplanar projection is the identity; an
+// orthographic projection onto a parallel plane preserves the circle) and degrades to the polyline
+// for an oblique projection, where a circle becomes an ellipse (#2158 follow-up). Reading only the
+// 2D points keeps this independent of the source's analytic curve.
+
+type projectedShapeKind uint8
+
+const (
+	shapeNone projectedShapeKind = iota
+	shapeLine
+	shapeArc
+	shapeCircle
+)
+
+// projectedShape is the analytic form of a projected curve on the sketch plane, when it has one.
+type projectedShape struct {
+	kind         projectedShapeKind
+	a, b         math.Point2 // line endpoints
+	center       math.Point2 // arc/circle centre
+	radius       float64
+	start, sweep float64 // arc start angle and signed sweep (radians); unused for a circle
+}
+
+// projShapeTol is the relative residual within which the projected points must lie on the fitted
+// line or circle for the shape to count as analytic — a coplanar/parallel projection fits to float
+// error, so it is tight; an ellipse (oblique arc) fails it and falls back to the polyline.
+const projShapeTol = 1e-6 // tol:calibrated — projected-shape line/circle fit residual
+
+// projectedRenderSegments is how finely an analytic projected shape is sampled for drawing and
+// hit-testing, so a projected arc reads as a smooth curve rather than the 16 source facets.
+const projectedRenderSegments = 64
+
+// fitProjectedShape classifies a projected polyline as a line, arc, circle, or (shapeNone) an
+// arbitrary polyline, from its 2D points alone. A real projection samples one edge into many points
+// along a smooth curve, so "every point on one circle" reliably means a circular arc (an ellipse —
+// an obliquely projected arc — fails it and stays a polyline). Closure is read before de-duplicating
+// so a full circle's coincident first/last point is not lost.
+func fitProjectedShape(pts []math.Point2) projectedShape {
+	closed := polylineReturnsToStart(pts)
+	pts = dropDuplicateVertices(pts)
+	n := len(pts)
+	if n < 2 {
+		return projectedShape{}
+	}
+	if !closed && collinearPolyline(pts) {
+		return projectedShape{kind: shapeLine, a: pts[0], b: pts[n-1]}
+	}
+	if n < 3 {
+		return projectedShape{}
+	}
+	center, radius, ok := fitCircleThrough(pts)
+	if !ok || !allOnCircle(pts, center, radius) {
+		return projectedShape{}
+	}
+	if closed {
+		return projectedShape{kind: shapeCircle, center: center, radius: radius}
+	}
+	start, sweep := arcSpan(pts, center)
+	return projectedShape{kind: shapeArc, center: center, radius: radius, start: start, sweep: sweep}
+}
+
+// collinearPolyline reports whether every vertex lies on the chord through the first and last, so a
+// projected straight edge (however finely sampled) is one line.
+func collinearPolyline(pts []math.Point2) bool {
+	a, b := pts[0], pts[len(pts)-1]
+	chord := float64(a.DistanceTo(b))
+	if chord < 1e-12 {
+		return false // a closed or degenerate chain is not a line
+	}
+	tol := projShapeTol * chord
+	for _, p := range pts[1 : len(pts)-1] {
+		if stdmath.Abs(perpDistanceToLine(a, b, p)) > tol {
+			return false
+		}
+	}
+	return true
+}
+
+// fitCircleThrough fits a circle to three well-spread points of the polyline (0, n/3, 2n/3), which
+// avoids the near-coincident first/last pair of a closed loop.
+func fitCircleThrough(pts []math.Point2) (math.Point2, float64, bool) {
+	n := len(pts)
+	center, radius, err := circumcircle(pts[0], pts[n/3], pts[2*n/3])
+	if err != nil {
+		return math.Point2{}, 0, false
+	}
+	return center, float64(radius), true
+}
+
+// allOnCircle reports whether every vertex is the fitted radius from the centre, within the fit
+// tolerance scaled by the radius.
+func allOnCircle(pts []math.Point2, center math.Point2, radius float64) bool {
+	tol := projShapeTol * radius
+	for _, p := range pts {
+		if stdmath.Abs(float64(p.DistanceTo(center))-radius) > tol {
+			return false
+		}
+	}
+	return true
+}
+
+// arcSpan returns the start angle and signed sweep of the open arc through the polyline about
+// centre, choosing the direction that passes through the polyline's middle sample.
+func arcSpan(pts []math.Point2, center math.Point2) (start, sweep float64) {
+	ang := func(p math.Point2) float64 {
+		return stdmath.Atan2(float64(p.Y-center.Y), float64(p.X-center.X))
+	}
+	start = ang(pts[0])
+	ccw := wrap2pi(ang(pts[len(pts)-1]) - start)
+	if wrap2pi(ang(pts[len(pts)/2])-start) <= ccw {
+		return start, ccw // the middle sample lies on the CCW path start→end
+	}
+	return start, ccw - 2*stdmath.Pi // otherwise the arc runs the other way (CW)
+}
+
+// polyline samples the analytic shape into points for drawing and hit-testing; nil for shapeNone.
+func (s projectedShape) polyline() []math.Point2 {
+	switch s.kind {
+	case shapeLine:
+		return []math.Point2{s.a, s.b}
+	case shapeCircle:
+		return sampleShapeArc(s.center, s.radius, 0, 2*stdmath.Pi)
+	case shapeArc:
+		return sampleShapeArc(s.center, s.radius, s.start, s.sweep)
+	default:
+		return nil
+	}
+}
+
+// sampleShapeArc samples a circular arc into projectedRenderSegments segments.
+func sampleShapeArc(center math.Point2, radius, start, sweep float64) []math.Point2 {
+	pts := make([]math.Point2, projectedRenderSegments+1)
+	for i := range pts {
+		a := start + sweep*float64(i)/float64(projectedRenderSegments)
+		pts[i] = math.P2(center.X+math.Scalar(radius*stdmath.Cos(a)), center.Y+math.Scalar(radius*stdmath.Sin(a)))
+	}
+	return pts
+}
+
+// perpDistanceToLine is the signed perpendicular distance from p to the infinite line through a→b.
+func perpDistanceToLine(a, b, p math.Point2) float64 {
+	dx, dy := float64(b.X-a.X), float64(b.Y-a.Y)
+	length := stdmath.Hypot(dx, dy)
+	if length < 1e-12 {
+		return float64(p.DistanceTo(a))
+	}
+	return (dx*float64(p.Y-a.Y) - dy*float64(p.X-a.X)) / length
+}

--- a/model/sketch/projected_shape_test.go
+++ b/model/sketch/projected_shape_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package sketch
+
+import (
+	stdmath "math"
+	"testing"
+
+	gmath "oblikovati.org/math"
+)
+
+// sampleArc3 returns n+1 points along a circular arc — the kind of coarse polyline the projection
+// samples an arc edge into (a coplanar/parallel projection lands them exactly on the circle).
+func sampleArcPts(center gmath.Point2, r, start, sweep float64, n int) []gmath.Point2 {
+	pts := make([]gmath.Point2, n+1)
+	for i := range pts {
+		a := start + sweep*float64(i)/float64(n)
+		pts[i] = gmath.P2(center.X+gmath.Scalar(r*stdmath.Cos(a)), center.Y+gmath.Scalar(r*stdmath.Sin(a)))
+	}
+	return pts
+}
+
+func TestFitProjectedShapeLine(t *testing.T) {
+	pts := []gmath.Point2{gmath.P2(0, 0), gmath.P2(1, 1), gmath.P2(2, 2), gmath.P2(3, 3)}
+	if s := fitProjectedShape(pts); s.kind != shapeLine {
+		t.Fatalf("collinear points → kind %d, want shapeLine", s.kind)
+	}
+}
+
+func TestFitProjectedShapeArc(t *testing.T) {
+	pts := sampleArcPts(gmath.P2(1, 2), 3, 0, stdmath.Pi/2, 16) // quarter arc, 16 facets
+	s := fitProjectedShape(pts)
+	if s.kind != shapeArc {
+		t.Fatalf("arc-sampled points → kind %d, want shapeArc", s.kind)
+	}
+	if stdmath.Abs(s.radius-3) > 1e-6 || !s.center.IsEqualTo(gmath.P2(1, 2), 1e-6) {
+		t.Errorf("arc fit center=%v radius=%.4f, want (1,2) r=3", s.center, s.radius)
+	}
+	if s.sweep <= 0 { // CCW quarter
+		t.Errorf("arc sweep=%.4f, want a positive (CCW) quarter", s.sweep)
+	}
+}
+
+func TestFitProjectedShapeCircle(t *testing.T) {
+	pts := sampleArcPts(gmath.P2(0, 0), 2, 0, 2*stdmath.Pi, 24) // closed
+	if s := fitProjectedShape(pts); s.kind != shapeCircle {
+		t.Fatalf("closed circle-sampled points → kind %d, want shapeCircle", s.kind)
+	}
+}
+
+func TestFitProjectedShapeEllipseFallsBackToPolyline(t *testing.T) {
+	// an oblique arc projects to an ellipse: squash the y of a circle so points are NOT on a circle
+	pts := sampleArcPts(gmath.P2(0, 0), 3, 0, stdmath.Pi, 16)
+	for i := range pts {
+		pts[i] = gmath.P2(pts[i].X, pts[i].Y*0.5)
+	}
+	if s := fitProjectedShape(pts); s.kind != shapeNone {
+		t.Fatalf("ellipse points → kind %d, want shapeNone (polyline fallback)", s.kind)
+	}
+}
+
+func TestOffsetProjectedArcMakesAnArc(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	pts := sampleArcPts(gmath.P2(0, 0), 5, 0, stdmath.Pi/2, 16)
+	pc := s.RestoreProjectedCurve(nextID(), pts, "edge", "E1")
+	if pc.shape.kind != shapeArc {
+		t.Fatalf("restored projected arc shape = %d, want shapeArc", pc.shape.kind)
+	}
+	arcsBefore := s.Arcs().Count()
+	got, err := s.OffsetEntity(pc, -1) // inner offset → radius 4
+	if err != nil {
+		t.Fatalf("OffsetEntity(projected arc): %v", err)
+	}
+	if _, ok := got.(*Arc); !ok {
+		t.Fatalf("offset of a projected arc = %T, want a real *Arc (not a polyline)", got)
+	}
+	if s.Arcs().Count() != arcsBefore+1 {
+		t.Errorf("offset created %d arcs, want 1", s.Arcs().Count()-arcsBefore)
+	}
+	if r := float64(s.Arcs().Item(arcsBefore).Radius()); stdmath.Abs(r-4) > 1e-6 {
+		t.Errorf("offset arc radius = %.4f, want 4 (5 + -1)", r)
+	}
+}
+
+func TestOffsetProjectedCircleMakesACircle(t *testing.T) {
+	s := NewSketches().Add(XYPlane())
+	pts := sampleArcPts(gmath.P2(0, 0), 5, 0, 2*stdmath.Pi, 24)
+	pc := s.RestoreProjectedCurve(nextID(), pts, "edge", "E1")
+	got, err := s.OffsetEntity(pc, -1)
+	if err != nil {
+		t.Fatalf("OffsetEntity(projected circle): %v", err)
+	}
+	c, ok := got.(*Circle)
+	if !ok {
+		t.Fatalf("offset of a projected circle = %T, want a real *Circle", got)
+	}
+	if stdmath.Abs(float64(c.Radius)-4) > 1e-6 {
+		t.Errorf("offset circle radius = %.4f, want 4", float64(c.Radius))
+	}
+}

--- a/model/sketch/projection.go
+++ b/model/sketch/projection.go
@@ -85,12 +85,16 @@ func (p *ProjectedPoint) Update() {
 // (the "break link" / include-without-associativity option).
 func (p *ProjectedPoint) BreakLink() { p.linked = false }
 
-// ProjectedCurve is a sketch polyline projected from a model edge (or cut edge).
+// ProjectedCurve is a sketch curve projected from a model edge (or cut edge). points is the sampled
+// polyline; shape is its analytic form (a projected line/arc/circle projects to one — Inventor keeps
+// them analytic), re-derived from points on every Update, so a projected arc draws smooth and offsets
+// as a concentric arc rather than a faceted chain.
 type ProjectedCurve struct {
 	id     ID
 	source CurveSource
 	plane  Plane
 	points []math.Point2
+	shape  projectedShape
 	linked bool
 	// srcKind/srcID persist the source's identity for save/reload + rebind (see ProjectedPoint).
 	srcKind, srcID string
@@ -135,6 +139,17 @@ func (c *ProjectedCurve) Update() {
 	for _, q := range src {
 		c.points = append(c.points, c.plane.ToSketch(q))
 	}
+	c.shape = fitProjectedShape(c.points)
+}
+
+// RenderPolyline returns the curve as a smooth polyline for drawing and hit-testing: the analytic
+// shape sampled finely when the projection is a line/arc/circle (so a projected arc is not the 16
+// source facets), else the raw projected points.
+func (c *ProjectedCurve) RenderPolyline() []math.Point2 {
+	if p := c.shape.polyline(); p != nil {
+		return p
+	}
+	return c.Points()
 }
 
 // BreakLink detaches the projection from its source, freezing the current polyline.
@@ -278,7 +293,7 @@ func (s *Sketch) RestoreProjectedPoint(anchorID ID, pos math.Point2, srcKind, sr
 // RestoreProjectedCurve rebuilds a projected curve frozen at the given polyline, pinning its id
 // and keeping the source descriptor for a later Rebind.
 func (s *Sketch) RestoreProjectedCurve(id ID, pts []math.Point2, srcKind, srcID string) *ProjectedCurve {
-	c := &ProjectedCurve{id: id, plane: s.plane, points: pts, linked: false, srcKind: srcKind, srcID: srcID}
+	c := &ProjectedCurve{id: id, plane: s.plane, points: pts, shape: fitProjectedShape(pts), linked: false, srcKind: srcKind, srcID: srcID}
 	s.add(c)
 	return c
 }

--- a/model/sketch/serialize_codecs_constraints.go
+++ b/model/sketch/serialize_codecs_constraints.go
@@ -392,16 +392,38 @@ func groundCodec() constraintCodec {
 	}
 }
 
+// offsetCodec persists an offset relation. A DRIVEN offset (one tied to a shared driving dimension)
+// additionally stores the driver dimension's parameter name so the live link survives a reload; it is
+// held back on decode and re-bound after the dimensions restore (applyPendingOffsetDrives), since the
+// driving parameter does not exist yet at constraint-restore time. A plain (frozen) offset stores just
+// its signed distance. Value carries the signed distance either way (its sign is the driven side).
 func offsetCodec() constraintCodec {
 	return constraintCodec{
 		encode: func(c Constraint) (ConstraintData, error) {
 			v := c.(*OffsetConstraint)
-			return ConstraintData{Curves: []int{int(v.L1.id), int(v.L2.id)}, Value: v.Dist}, nil
+			return ConstraintData{Curves: []int{int(v.L1.id), int(v.L2.id)}, Value: v.Dist, Name: v.DriverName}, nil
 		},
 		decode: func(r *sketchRestorer, cd ConstraintData) error {
-			return r.twoLines(cd, func(a, b *Line) { r.s.geomCons.AddOffset(a, b, cd.Value) })
+			return r.twoLines(cd, func(a, b *Line) {
+				if cd.Name == "" {
+					r.s.geomCons.AddOffset(a, b, cd.Value)
+					return
+				}
+				r.pendingOffsetDrives = append(r.pendingOffsetDrives, pendingOffsetDrive{
+					l1: a, l2: b, name: cd.Name, sign: offsetSideSign(cd.Value), dist: cd.Value,
+				})
+			})
 		},
 	}
+}
+
+// offsetSideSign recovers a driven offset's side (+1/−1) from its signed persisted distance; a zero
+// distance is degenerate, so it defaults to +1.
+func offsetSideSign(dist float64) float64 {
+	if dist < 0 {
+		return -1
+	}
+	return 1
 }
 
 func textBoxAnchorCodec() constraintCodec {

--- a/model/sketch/serialize_restore.go
+++ b/model/sketch/serialize_restore.go
@@ -49,6 +49,7 @@ func restoreSketch(sc *Sketches, sd SketchData) error {
 	if err := r.restoreDimensions(sd.Dimensions); err != nil {
 		return err
 	}
+	r.applyPendingOffsetDrives()
 	return r.restoreCloudAnchors(sd.CloudAnchors)
 }
 
@@ -110,6 +111,19 @@ type sketchRestorer struct {
 	pointMap  map[int]*Point
 	entityMap map[int]Entity
 	maxID     uint64
+	// pendingOffsetDrives are driven offset constraints whose driving dimension parameter is not yet
+	// created when constraints restore (dimensions restore afterwards); applyPendingOffsetDrives
+	// re-binds them by parameter name once the dimensions exist.
+	pendingOffsetDrives []pendingOffsetDrive
+}
+
+// pendingOffsetDrive is a driven offset constraint held back until its driving dimension parameter
+// exists (see sketchRestorer.pendingOffsetDrives).
+type pendingOffsetDrive struct {
+	l1, l2 *Line
+	name   string
+	sign   float64
+	dist   float64 // frozen fallback when the named parameter cannot be resolved
 }
 
 // idCarrier is the restore-only seam for pinning a sketch object's local id to its
@@ -403,6 +417,19 @@ func (r *sketchRestorer) twoPoints(cd ConstraintData, add func(a, b *Point)) err
 	}
 	add(p[0], p[1])
 	return nil
+}
+
+// applyPendingOffsetDrives re-binds each deferred driven offset constraint to its driving dimension's
+// parameter (now that dimensions have been restored), or falls back to a frozen offset at the persisted
+// distance when the parameter no longer resolves.
+func (r *sketchRestorer) applyPendingOffsetDrives() {
+	for _, p := range r.pendingOffsetDrives {
+		if driver, ok := r.s.params.ByName(p.name); ok {
+			r.s.geomCons.AddOffsetDriven(p.l1, p.l2, driver, p.sign)
+			continue
+		}
+		r.s.geomCons.AddOffset(p.l1, p.l2, p.dist)
+	}
 }
 
 func (r *sketchRestorer) twoLines(cd ConstraintData, add func(a, b *Line)) error {

--- a/model/sketch/sketch.go
+++ b/model/sketch/sketch.go
@@ -314,9 +314,25 @@ func (s *Sketch) AllPoints() []*Point {
 
 // Lines/Arcs/Circles/Ellipses/Splines/Points/Blocks return the typed entity
 // factories (the Lines etc. collections).
-func (s *Sketch) Lines() *Lines       { return s.lines }
-func (s *Sketch) Arcs() *Arcs         { return s.arcs }
-func (s *Sketch) Circles() *Circles   { return s.circles }
+func (s *Sketch) Lines() *Lines     { return s.lines }
+func (s *Sketch) Arcs() *Arcs       { return s.arcs }
+func (s *Sketch) Circles() *Circles { return s.circles }
+
+// CircularCenters returns the centre position of every circle and arc. A sketch overlay marks
+// these so a circular entity's centre is a visible hover/snap target: an arc's centre sits off the
+// curve in empty space, so without a marker the user cannot aim a coincident constraint at it — it
+// looks like the arc "has no centre" (#2159). Keeping the type knowledge here lets the head draw
+// the markers without inspecting sketch entity types (archguard I1, #1624).
+func (s *Sketch) CircularCenters() []math.Point2 {
+	out := make([]math.Point2, 0, len(s.circles.items)+len(s.arcs.items))
+	for _, c := range s.circles.items {
+		out = append(out, c.Center.Position())
+	}
+	for _, a := range s.arcs.items {
+		out = append(out, a.Center.Position())
+	}
+	return out
+}
 func (s *Sketch) Ellipses() *Ellipses { return s.ellipses }
 func (s *Sketch) Splines() *Splines   { return s.splines }
 


### PR DESCRIPTION
## What & why

A combined branch of piston-head modelling fixes, driven by user bug reports and Inventor-parity gaps. Grouped by theme below.

### Sketch region selection (#2165)
Offsetting a rounded-rectangle profile left the **inner region unselectable** in the Extrude tool — you could pick the band but not the face inside it.
- **Root cause**: even–odd profile grouping demoted a multi-entity inner loop to a hole; only single circle/ellipse primitives were exempt (#1526). Now **any user-drawn loop** (rectangle, rounded rectangle, polygon) also bounds its own selectable face, while synthetic text-glyph counters (no entities) and **abutting** cells of a subdivided island (crossing grill bars, #863) stay holes. New regions are appended so existing index-based selections keep their target.
- **Filled hover highlight**: a hovered/picked region is now tinted (via a new `ops.FillTriangles` ear-clip), not only outlined.
- **+/- cursor badge**: during area multi-select, a held modifier shows a green **+** over a region a click would add, a red **−** over one it would remove.

Closes #2165.

### Analytic swept geometry (#2164, #2019)
Sweep / revolve / contour-roll / extrude now keep **analytic** faces where the geometry allows, instead of faceting — so downstream projection, mass properties and booleans see true cylinders/cones/tori/arcs:
- Extrude of a line+arc profile keeps arc cap edges + cylinder walls.
- Straight-path sweeps of circle / line+arc profiles stay analytic; a circle swept along a full circular path is an analytic torus.
- Partial-angle revolves of line meridians stay analytic.
- Sheet-metal contour roll keeps analytic cylinder/cone walls.

### Piston-head sketch bugs (#2158, #2159, #2160)
- **#2158** Project Geometry: projects on each pick with no dialog, projects a face's perimeter, keeps projected lines/arcs/circles **analytic** (arcs stay arcs), and makes projected curves selectable + hover-highlighted.
- **#2159** arcs/circles draw a centre marker; centres are sourced from the sketch, not a head type-switch.
- **#2160** geometrically-determined entities drag with soft pins; a constraint-held point stays pinned through a drag.
- Radius dimension on arcs fixed; the #1822 mouse-wheel router handler wired.

### Sketch Offset — Inventor parity (#2158 + follow-ups)
- **Loop Select** (default): pick one curve → offset the whole connected loop analytically.
- **Cursor place/side** two-step flow, **Constrain Offset** (default on), and right-click menu toggles.
- **Live preview**, an **offset dimension** on commit, and **uniform driving** — one dimension drives the whole loop; the driven links now **persist across save/reload** (re-bound to the restored dimension parameter).

### Housekeeping
- Cleared 16 pre-existing head/ui lint findings (funlen/gocyclo/unused) by pure refactor — ImGui call sequences unchanged.
- Made the #1471 ribbon-collapse tests **deterministic**: prime the viewport size (ImGui's viewport size lags one window behind in a multi-window process) and settle until the fit decision reaches steady state, instead of a fixed frame count that sampled before layout stabilised.

## Testing
- `model/sketch`, `kernel/ops`, `app` full suites green; head/ui builds (cgo) and ribbon suite green (`-count` deterministic).
- `golangci-lint` clean on touched packages.
- New regression tests: nested-loop region selection, `FillTriangles`, region add/remove hint, offset uniform-driving + round-trip, analytic sweep/revolve/contour-roll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
