### PR TITLE
Adopt Go 1.27 generic methods for event.Bus and dashCursor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,10 @@ jobs:
       # light/environment sampling, intersector) is the SAME failure mode: -coverpkg restricts
       # instrumentation to exactly the listed packages for every binary, so a package left out
       # gets none, even for its own tests — renderer read 0% on new code despite each file having
-      # a same-named _test.go beside it, purely because it was missing from this list.
+      # a same-named _test.go beside it, purely because it was missing from this list. `event/...`
+      # (the pub/sub Bus, #2170's generic-methods conversion) hit the identical failure mode the
+      # moment its new code grew past a handful of lines: 0% on new code despite `go test
+      # ./event/...` itself reading 100% locally.
       #
       # Ubuntu-only because that is the single leg whose profile feeds the `sonar` job (see the
       # upload step below); the macOS/Windows legs keep the uninstrumented command so the slowest
@@ -148,7 +151,7 @@ jobs:
         run: |
           COVERPKG=""
           if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
-            COVERPKG="-coverpkg=./kernel/...,./model/...,./app/...,./addin/...,./renderer/..."
+            COVERPKG="-coverpkg=./kernel/...,./model/...,./app/...,./addin/...,./renderer/...,./event/..."
           fi
           gotestsum --junitfile test-results-${{ matrix.os }}.xml -- \
             -coverprofile=coverage.out -covermode=count $COVERPKG -timeout 60m ./...

--- a/app/file_ui_hooks.go
+++ b/app/file_ui_hooks.go
@@ -20,19 +20,19 @@ const maxRecentDocuments = 10
 // supplies a path replaces the dialog: the head opens the returned path
 // directly instead of showing it.
 func (s *Session) HookFileOpenDialog() (string, bool) {
-	return runDialogHook(s, FileOpenDialog{answer: new(string)})
+	return s.runDialogHook(FileOpenDialog{answer: new(string)})
 }
 
 // HookFileSaveAsDialog announces File ▸ Save As is about to present; a supplied
 // path replaces the dialog.
 func (s *Session) HookFileSaveAsDialog(saveCopyAs bool) (string, bool) {
-	return runDialogHook(s, FileSaveAsDialog{SaveCopyAs: saveCopyAs, answer: new(string)})
+	return s.runDialogHook(FileSaveAsDialog{SaveCopyAs: saveCopyAs, answer: new(string)})
 }
 
 // HookFileNewDialog announces a new-document template chooser is about to
 // present; a supplied template replaces the dialog.
 func (s *Session) HookFileNewDialog() (string, bool) {
-	return runDialogHook(s, FileNewDialog{answer: new(string)})
+	return s.runDialogHook(FileNewDialog{answer: new(string)})
 }
 
 // dialogHook is the shape the three dialog hooks share: an answer slot readable
@@ -42,11 +42,12 @@ type dialogHook interface {
 	Supplied() string
 }
 
-// runDialogHook emits one dialog hook in both phases and returns the answer.
-// Generic because the bus dispatches on the event's static type.
-func runDialogHook[E dialogHook](s *Session, ev E) (string, bool) {
-	event.Emit(s.bus, event.Before, ev)
-	event.Emit(s.bus, event.After, ev)
+// runDialogHook emits one dialog hook in both phases and returns the answer. A
+// generic method (Go 1.27): the bus dispatches on the event's static type, so it
+// needs its own type parameter rather than accepting the dialogHook interface.
+func (s *Session) runDialogHook[E dialogHook](ev E) (string, bool) {
+	s.bus.Emit(event.Before, ev)
+	s.bus.Emit(event.After, ev)
 	return ev.Supplied(), ev.Supplied() != ""
 }
 

--- a/app/sheet_metal_session.go
+++ b/app/sheet_metal_session.go
@@ -7,8 +7,8 @@ package app
 // loop calls them to show the matching property panel.
 
 // activeSheetMetalTool returns the running tool as T, or the zero value (nil) when the active
-// tool is not of that type.
-func activeSheetMetalTool[T Tool](s *Session) T {
+// tool is not of that type. A generic method (Go 1.27), private to this file's own use.
+func (s *Session) activeSheetMetalTool[T Tool]() T {
 	var zero T
 	if s.tool == nil {
 		return zero
@@ -19,90 +19,90 @@ func activeSheetMetalTool[T Tool](s *Session) T {
 
 // ActiveSheetMetalFace returns the running Sheet Metal Face tool, or nil.
 func (s *Session) ActiveSheetMetalFace() *SheetMetalFaceTool {
-	return activeSheetMetalTool[*SheetMetalFaceTool](s)
+	return s.activeSheetMetalTool[*SheetMetalFaceTool]()
 }
 
 // ActiveSheetMetalFlange returns the running Sheet Metal Flange tool, or nil.
 func (s *Session) ActiveSheetMetalFlange() *SheetMetalFlangeTool {
-	return activeSheetMetalTool[*SheetMetalFlangeTool](s)
+	return s.activeSheetMetalTool[*SheetMetalFlangeTool]()
 }
 
 // ActiveSheetMetalHem returns the running Sheet Metal Hem tool, or nil.
 func (s *Session) ActiveSheetMetalHem() *SheetMetalHemTool {
-	return activeSheetMetalTool[*SheetMetalHemTool](s)
+	return s.activeSheetMetalTool[*SheetMetalHemTool]()
 }
 
 // ActiveSheetMetalContourFlange returns the running Sheet Metal Contour Flange tool, or nil.
 func (s *Session) ActiveSheetMetalContourFlange() *SheetMetalContourFlangeTool {
-	return activeSheetMetalTool[*SheetMetalContourFlangeTool](s)
+	return s.activeSheetMetalTool[*SheetMetalContourFlangeTool]()
 }
 
 // ActiveSheetMetalLoftedFlange returns the running Sheet Metal Lofted Flange tool, or nil.
 func (s *Session) ActiveSheetMetalLoftedFlange() *SheetMetalLoftedFlangeTool {
-	return activeSheetMetalTool[*SheetMetalLoftedFlangeTool](s)
+	return s.activeSheetMetalTool[*SheetMetalLoftedFlangeTool]()
 }
 
 // ActiveSheetMetalContourRoll returns the running Sheet Metal Contour Roll tool, or nil.
 func (s *Session) ActiveSheetMetalContourRoll() *SheetMetalContourRollTool {
-	return activeSheetMetalTool[*SheetMetalContourRollTool](s)
+	return s.activeSheetMetalTool[*SheetMetalContourRollTool]()
 }
 
 // ActiveSheetMetalBend returns the running Sheet Metal Bend tool, or nil.
 func (s *Session) ActiveSheetMetalBend() *SheetMetalBendTool {
-	return activeSheetMetalTool[*SheetMetalBendTool](s)
+	return s.activeSheetMetalTool[*SheetMetalBendTool]()
 }
 
 // ActiveSheetMetalFold returns the running Sheet Metal Fold tool, or nil.
 func (s *Session) ActiveSheetMetalFold() *SheetMetalFoldTool {
-	return activeSheetMetalTool[*SheetMetalFoldTool](s)
+	return s.activeSheetMetalTool[*SheetMetalFoldTool]()
 }
 
 // ActiveSheetMetalCorner returns the running Sheet Metal Corner tool, or nil.
 func (s *Session) ActiveSheetMetalCorner() *SheetMetalCornerTool {
-	return activeSheetMetalTool[*SheetMetalCornerTool](s)
+	return s.activeSheetMetalTool[*SheetMetalCornerTool]()
 }
 
 // ActiveSheetMetalCornerSeam returns the running Sheet Metal Corner Seam tool, or nil.
 func (s *Session) ActiveSheetMetalCornerSeam() *SheetMetalCornerSeamTool {
-	return activeSheetMetalTool[*SheetMetalCornerSeamTool](s)
+	return s.activeSheetMetalTool[*SheetMetalCornerSeamTool]()
 }
 
 // ActiveSheetMetalCut returns the running Sheet Metal Cut tool, or nil.
 func (s *Session) ActiveSheetMetalCut() *SheetMetalCutTool {
-	return activeSheetMetalTool[*SheetMetalCutTool](s)
+	return s.activeSheetMetalTool[*SheetMetalCutTool]()
 }
 
 // ActiveSheetMetalUnfold returns the running Sheet Metal Unfold tool, or nil.
 func (s *Session) ActiveSheetMetalUnfold() *SheetMetalUnfoldTool {
-	return activeSheetMetalTool[*SheetMetalUnfoldTool](s)
+	return s.activeSheetMetalTool[*SheetMetalUnfoldTool]()
 }
 
 // ActiveSheetMetalRefold returns the running Sheet Metal Refold tool, or nil.
 func (s *Session) ActiveSheetMetalRefold() *SheetMetalRefoldTool {
-	return activeSheetMetalTool[*SheetMetalRefoldTool](s)
+	return s.activeSheetMetalTool[*SheetMetalRefoldTool]()
 }
 
 // ActiveSheetMetalStyle returns the running Sheet Metal Style editor tool, or nil.
 func (s *Session) ActiveSheetMetalStyle() *SheetMetalStyleTool {
-	return activeSheetMetalTool[*SheetMetalStyleTool](s)
+	return s.activeSheetMetalTool[*SheetMetalStyleTool]()
 }
 
 // ActiveSheetMetalLip returns the running Sheet Metal Lip tool, or nil.
 func (s *Session) ActiveSheetMetalLip() *SheetMetalLipTool {
-	return activeSheetMetalTool[*SheetMetalLipTool](s)
+	return s.activeSheetMetalTool[*SheetMetalLipTool]()
 }
 
 // ActiveSheetMetalRip returns the running Sheet Metal Rip tool, or nil.
 func (s *Session) ActiveSheetMetalRip() *SheetMetalRipTool {
-	return activeSheetMetalTool[*SheetMetalRipTool](s)
+	return s.activeSheetMetalTool[*SheetMetalRipTool]()
 }
 
 // ActiveSheetMetalPunch returns the running Sheet Metal Punch tool, or nil.
 func (s *Session) ActiveSheetMetalPunch() *SheetMetalPunchTool {
-	return activeSheetMetalTool[*SheetMetalPunchTool](s)
+	return s.activeSheetMetalTool[*SheetMetalPunchTool]()
 }
 
 // ActiveSheetMetalCosmeticBend returns the running Sheet Metal Cosmetic Bend tool, or nil.
 func (s *Session) ActiveSheetMetalCosmeticBend() *SheetMetalCosmeticBendTool {
-	return activeSheetMetalTool[*SheetMetalCosmeticBendTool](s)
+	return s.activeSheetMetalTool[*SheetMetalCosmeticBendTool]()
 }

--- a/app/undo.go
+++ b/app/undo.go
@@ -549,22 +549,22 @@ func (s *Session) Redo() error {
 func (s *Session) undoDocument(d *doc.Document) error {
 	dh := s.documentHistory(d)
 	ev := TransactionUndone{Document: d.ID(), Label: lastLabel(dh.hist.UndoLabels())}
-	if err := cursorMove(s, d, dh, ev, dh.hist.Undo); err != nil {
+	if err := s.cursorMove(d, dh, ev, dh.hist.Undo); err != nil {
 		return err
 	}
 	s.reattachActiveSketchAfterRestore(d) // restore rebuilt the sketch objects; re-bind the edit (#1270)
-	event.Emit(s.bus, event.After, ev)
+	s.bus.Emit(event.After, ev)
 	return nil
 }
 
 func (s *Session) redoDocument(d *doc.Document) error {
 	dh := s.documentHistory(d)
 	ev := TransactionRedone{Document: d.ID(), Label: firstLabel(dh.hist.RedoLabels())}
-	if err := cursorMove(s, d, dh, ev, dh.hist.Redo); err != nil {
+	if err := s.cursorMove(d, dh, ev, dh.hist.Redo); err != nil {
 		return err
 	}
 	s.reattachActiveSketchAfterRestore(d) // restore rebuilt the sketch objects; re-bind the edit (#1270)
-	event.Emit(s.bus, event.After, ev)
+	s.bus.Emit(event.After, ev)
 	return nil
 }
 
@@ -640,10 +640,11 @@ func (s *Session) DocumentHistoryView(id doc.ID) (DocumentTimeline, bool) {
 // cursorMove runs one undo/redo navigation behind its Before event: a handler may
 // veto the move (e.g. external state cannot roll back, M04-F05), and a failed
 // move surfaces in the status bar. The caller emits the matching After event.
-// Generic (and free, since methods cannot be) because the bus dispatches on the
-// event's static type — an interface-typed emit would reach no subscriber.
-func cursorMove[E event.Event](s *Session, d *doc.Document, dh *docHistory, ev E, move func() error) error {
-	if out := event.Emit(s.bus, event.Before, ev); out.Vetoed() {
+// A generic method (Go 1.27): the bus dispatches on the event's static type, so
+// it needs its own type parameter rather than accepting the event.Event interface
+// — an interface-typed emit would reach no subscriber.
+func (s *Session) cursorMove[E event.Event](d *doc.Document, dh *docHistory, ev E, move func() error) error {
+	if out := s.bus.Emit(event.Before, ev); out.Vetoed() {
 		s.notice = out.Reason
 		return &doc.VetoError{Operation: "transaction", Reason: out.Reason}
 	}

--- a/architecture/decisions/ADR-0001-go-language.md
+++ b/architecture/decisions/ADR-0001-go-language.md
@@ -4,7 +4,7 @@
 
 ## Decision
 
-Implement the application in **Go** (1.22+), targeting Linux, macOS, Windows.
+Implement the application in **Go** (1.27+), targeting Linux, macOS, Windows.
 
 ## Why
 
@@ -26,7 +26,10 @@ Implement the application in **Go** (1.22+), targeting Linux, macOS, Windows.
   (ADR-0007). (realtime-3d §13)
 - **Generics are newer/less expressive** than C++ templates → the kernel leans on
   `float64` concrete types and a small set of generic containers, not deep
-  template metaprogramming.
+  template metaprogramming. [ADR-0054](ADR-0054-generic-methods-policy.md) extends
+  this appetite to Go 1.27's generic methods: adopted only where a non-generic
+  receiver's own free-function helper exists purely for lack of the feature, or
+  where it collapses genuinely duplicated logic — not merely because it's now possible.
 - **No exceptions** → errors as typed values (realtime-3d §15); modeling failures
   are *health state*, not panics (parametric-cad skill).
 

--- a/architecture/decisions/ADR-0054-generic-methods-policy.md
+++ b/architecture/decisions/ADR-0054-generic-methods-policy.md
@@ -14,10 +14,15 @@ package-scope functions could be generic — a non-generic receiver type whose o
 needed its own type parameter had no choice but a free function taking the receiver as an
 explicit first argument (`Emit(bus, phase, event)` instead of `bus.Emit(phase, event)`).
 
-This ADR records the outcome of evaluating every plausible candidate in the codebase for
-this specific new capability, as a deliberate extension of ADR-0001's low-generics appetite:
-the bar is real duplication removed or a genuine receiver-owns-this-operation fit, not
-"could technically become a method."
+This ADR records the outcome of a systematic sweep for this specific new capability across
+both `Oblikovati` and `Oblikovati.API` — every top-level generic function whose first
+parameter is a pointer to a concrete (non-generic) type, the exact shape this feature
+retires — evaluated as a deliberate extension of ADR-0001's low-generics appetite: the bar
+is real duplication removed or a genuine receiver-owns-this-operation fit, not "could
+technically become a method." A function whose flagged first parameter turns out to live in
+a *different* package from the receiver type is automatically disqualified regardless of
+shape — Go methods can only be declared in the receiver type's own package, which generic
+methods don't change.
 
 ## Decision
 
@@ -36,9 +41,9 @@ the function doesn't use the receiver's state, or the "receiver" is arbitrary/in
 at the call site, it stays a free function — a method implies "this operates on my state,"
 and a method that doesn't earn that implication misleads readers.
 
-## Candidates evaluated
+## Candidates adopted
 
-- **`event.Bus.Subscribe`/`Emit`/`EmitContext`** (`event/bus.go`) — **ADOPTED.** These were
+- **`event.Bus.Subscribe`/`Emit`/`EmitContext`** (`event/bus.go`) — These were
   free functions (`Subscribe[E Event](b *Bus, p Phase, h Handler[E])`, etc.) taking `*Bus` as
   their first argument purely because `Bus` (non-generic, stateful — holds the subscription
   map and a monotonic sequence counter) couldn't carry a generic method before 1.27. Converted
@@ -48,15 +53,48 @@ and a method that doesn't earn that implication misleads readers.
   return b.Emit(p, e) }`), matching `math/rand/v2`'s own precedent of keeping the top-level
   `N[Int](r, n)` alongside the new `r.N[Int](n)` method rather than forcing a migration. New
   code should prefer `bus.Emit(...)`/`bus.Subscribe(...)` directly.
-- **`linetype.dashCursor.walkEdge`** (`model/linetype/dash.go`) — **ADOPTED.** `walkEdge[P
+- **`linetype.dashCursor.walkEdge`** (`model/linetype/dash.go`) — `walkEdge[P
   dashable[P]](c *dashCursor, segs [][2]P, p, q P) [][2]P` mutates `c`'s own pattern-position
   state (via `c.advance`) on every call — it is exactly "an operation the cursor performs,"
   parameterized per call by point dimensionality (2D/3D). Converted to `(c *dashCursor)
   walkEdge[P dashable[P]](segs [][2]P, p, q P) [][2]P`; the single call site in
   `dashPolyline` reads as `cur.walkEdge(segs, pts[i-1], pts[i])` instead of `walkEdge(&cur,
   segs, pts[i-1], pts[i])`.
+- **`sketch.cloneMap`'s six `carryXxx` helpers** (`model/sketch/copy_constraints.go`) —
+  `cloneMap` already had six non-generic lookup methods (`point`, `line`, `curve`, `arc`,
+  `entity`, `ellipse`, `smoothCurve`); `carryPoints[R any](m *cloneMap, ...)` and its five
+  siblings sat right next to them as free functions purely because the factory callback's
+  return type `R` couldn't be a method-level type parameter before 1.27. Converted all six to
+  `(m *cloneMap) carryPoints[R any](...)` etc.; updated their 14 call sites in
+  `copy_constraints_registry.go` (`carryPoints(m, a, b, add)` → `m.carryPoints(a, b, add)`) —
+  private to this package, so no compatibility wrapper was needed.
+- **`app.Session`'s `activeSheetMetalTool`, `runDialogHook`, `cursorMove`**
+  (`app/sheet_metal_session.go`, `app/file_ui_hooks.go`, `app/undo.go`) — three separate free
+  functions taking `*Session` (the central per-document app-state type) as their first
+  argument. `cursorMove`'s own doc comment said it outright: *"Generic (and free, since
+  methods cannot be) because the bus dispatches on the event's static type"* — exactly the
+  limitation this ADR retires. All three are private to the `app` package (18, 3, and 2 call
+  sites respectively, all internal), so — unlike `event.Bus` — converted directly with no
+  compatibility wrapper needed: `s.activeSheetMetalTool[*SheetMetalFaceTool]()`,
+  `s.runDialogHook(ev)`, `s.cursorMove(d, dh, ev, move)`. `runDialogHook` and `cursorMove`
+  also switched their internal `event.Emit(s.bus, ...)` calls to `s.bus.Emit(...)`, the
+  method form this ADR's `event.Bus` conversion added.
+- **`client.Client.call`** (`Oblikovati.API/client/client.go`) — the Apache-2.0 API client's
+  single most-used internal helper: every typed wire method funnels through
+  `call[Resp any](c *Client, method string, req any) (Resp, error)`, ~641 call sites across
+  101 files. Its own doc comment: *"Go has no generic methods, hence a package-level function
+  taking the `*Client`"* — the textbook case. The existing non-generic 3-arg helper (used
+  directly by ~12 void/no-typed-response call sites, e.g. deletes) was renamed `invoke` to
+  free up the name; the new `(c *Client) call[Resp any](method string, req any) (Resp,
+  error)` method now holds it, calling `c.invoke(method, req, &r)`. The package-level `call`
+  free function is kept as a one-line wrapper (`return c.call[Resp](method, req)`) for the
+  641 existing call sites; new client methods should prefer `c.call[Resp](method, req)`
+  directly, matching the doc comment's now-updated example.
+
+## Candidates rejected
+
 - **`renderer.LightDistribution`/`EnvironmentDistribution`** (`renderer/light_sampling.go`,
-  `renderer/environment_sampling.go`) — **REJECTED.** Both do CDF-based importance sampling,
+  `renderer/environment_sampling.go`) — both do CDF-based importance sampling,
   but that similarity is superficial on closer reading: `LightDistribution.Sample` is a 1D
   discrete pick over a fixed item list returning `(index, item, pdf)`; `EnvironmentDistribution
   .Sample` is a 2D continuous pick over a pixel grid (row marginal CDF + per-row conditional
@@ -68,28 +106,47 @@ and a method that doesn't earn that implication misleads readers.
   actually duplicated).
 - **`addin/router/typed.go`'s ten handler-adapter functions** (`typed`, `typedCtx`,
   `ctxQuery`, `typedPart`, `partQuery`, `typedAssembly`, `assemblyQuery`, `typedHolder`,
-  `holderQuery`, `projectAll`) — **REJECTED.** These are combinators that build a
+  `holderQuery`, `projectAll`) — these are combinators that build a
   `handlerFunc` value (e.g. `typedPart(getX)`), evaluated *before* any `Router` is in scope —
   the call site is `r.readOnly(wire.MethodX, typedPart(getX))`. None of them read or use a
   `Router`'s state; there is no receiver to hang a method off without inventing one. Router
   methods here would misleadingly imply these adapters depend on router identity.
-- **`kernel/topo.buildKeyIndex`/`scanByKey`** (`kernel/topo/key_index.go`) — **REJECTED.**
-  Both are pure functions of their `items []T` argument, called from three sites inside
+- **`kernel/topo.buildKeyIndex`/`scanByKey`** (`kernel/topo/key_index.go`) —
+  both are pure functions of their `items []T` argument, called from three sites inside
   `*Body`'s own methods (`b.cachedEdges`/`cachedFaces`/`cachedVertices`), each with a
   different concrete `T`. `Body` itself is non-generic, so nothing is lost by leaving these
   as free functions — a method would need the caller to pass `b`'s own field back into `b`'s
   method (`b.buildKeyIndex(b.cachedEdges)`), which is not more readable than today's
   `buildKeyIndex(b.cachedEdges)` and ties a stateless pure function to `*Body` for no reason.
+- **Disqualified by package boundary** (a distinct, larger rejection class the sweep
+  surfaced): `addin/opregistry.decodeFeatureArgs`, `addin/router.commitAssemblyProgramChange`,
+  `addin/router.twoRefArgs` (all take `*app.Session`); `model/compdef.raiseBefore`,
+  `model/doc.vetoed` (both take `*event.Bus`); the SolidWorks translator's
+  `applyToLinePairs`/`applyToCurvePairs` (take `*sketch.Sketch`). Every one of these lives in a
+  *different* package from the type it takes as first argument — Go methods can only be
+  declared in the receiver type's own package, a rule generic methods don't relax. These stay
+  free functions regardless of how well they'd otherwise fit the pattern.
+- **Constraint-narrowing over an already-generic type's own parameter**:
+  `model/proxy/geometry.go`'s `RangeBoxInContext[E Boxed](p Proxy[E])`,
+  `PointInContext[E Pointed]`, `DirectionInContext[E Directed]`. `Proxy[E any]` is itself
+  generic with an unconstrained `E`; these functions need a *narrower* constraint (`Boxed`,
+  `Pointed`, `Directed`) than the type declares, for one operation each. That is not what Go
+  1.27 generic methods add — a method's parameter list can't re-constrain a receiver's own
+  already-bound type parameter — so these were never candidates, independent of any
+  duplication judgment.
 
 ## Consequences
 
-- New concurrency/dispatch types with the `Bus` shape (a non-generic hub whose per-call
-  operation needs its own type parameter) should default to generic methods, not the
-  free-function-plus-explicit-receiver-argument workaround this ADR retired for `event.Bus`.
+- New concurrency/dispatch/state-hub types with the `Bus`/`Session`/`Client` shape (a
+  non-generic type whose per-call operation needs its own type parameter) should default to
+  generic methods, not the free-function-plus-explicit-receiver-argument workaround this ADR
+  retired for the five types above.
 - A generic free function stays the right shape whenever the "receiver" is either stateless,
-  interchangeable, or not actually part of the call — most of this codebase's existing
-  generics (per ADR-0001's small deliberate set) fall in exactly that bucket and are
-  unaffected by this ADR.
-- This is not a mandate to audit every existing free generic function for method-conversion
-  potential — the bar above is the filter for new code and for reviewing this ADR's five
-  evaluated candidates going forward, not a backlog item.
+  interchangeable, cross-package from its own type, or not actually part of the call — most
+  of this codebase's existing generics (per ADR-0001's small deliberate set) fall in exactly
+  that bucket and are unaffected by this ADR.
+- This sweep already covered every top-level generic function with a concrete-pointer first
+  parameter in both repos (via `grep -rnE '^func [A-Za-z_]+\[[A-Za-z_]+ '`, cross-checked by
+  hand); it is not a mandate to re-run that audit on every future free generic function — the
+  bar above is the filter for new code and for revisiting this ADR's evaluated candidates,
+  not a standing backlog item.

--- a/architecture/decisions/ADR-0054-generic-methods-policy.md
+++ b/architecture/decisions/ADR-0054-generic-methods-policy.md
@@ -1,0 +1,95 @@
+<!-- SPDX-License-Identifier: GPL-2.0-only -->
+
+# ADR-0054 — Generic methods: when they earn their keep
+
+**Status:** Accepted (2026-08-27). Extends [ADR-0001](ADR-0001-go-language.md)'s "small set of
+generic containers, not deep template metaprogramming" policy to cover Go 1.27's generic
+methods, without changing that policy's underlying appetite.
+
+## Context
+
+Go 1.27 lets a method declare its own type parameters (`func (r *Rand) N[Int intType](Int)
+Int` in the stdlib's own `math/rand/v2` is the reference example). Before 1.27, only
+package-scope functions could be generic — a non-generic receiver type whose operation
+needed its own type parameter had no choice but a free function taking the receiver as an
+explicit first argument (`Emit(bus, phase, event)` instead of `bus.Emit(phase, event)`).
+
+This ADR records the outcome of evaluating every plausible candidate in the codebase for
+this specific new capability, as a deliberate extension of ADR-0001's low-generics appetite:
+the bar is real duplication removed or a genuine receiver-owns-this-operation fit, not
+"could technically become a method."
+
+## Decision
+
+Adopt generic methods where **either**:
+
+1. A non-generic, stateful receiver type has a free-function helper that takes the receiver
+   as its first parameter purely because a generic method wasn't available — converting it
+   to a method makes the operation read as what it already conceptually is (an operation
+   the receiver performs), with no other design change.
+2. Genuinely duplicated logic across two or more types can be collapsed into one generic
+   method, and the collapse doesn't force an artificial abstraction onto types whose
+   underlying operations differ in more than the substituted type.
+
+Do **not** convert a free generic function to a method merely because Go now allows it. If
+the function doesn't use the receiver's state, or the "receiver" is arbitrary/interchangeable
+at the call site, it stays a free function — a method implies "this operates on my state,"
+and a method that doesn't earn that implication misleads readers.
+
+## Candidates evaluated
+
+- **`event.Bus.Subscribe`/`Emit`/`EmitContext`** (`event/bus.go`) — **ADOPTED.** These were
+  free functions (`Subscribe[E Event](b *Bus, p Phase, h Handler[E])`, etc.) taking `*Bus` as
+  their first argument purely because `Bus` (non-generic, stateful — holds the subscription
+  map and a monotonic sequence counter) couldn't carry a generic method before 1.27. Converted
+  to `(b *Bus) Subscribe[E Event](...)` etc. The ~176 existing call sites
+  (`event.Emit(bus, ...)`) across ~90 files are untouched: the free functions are now thin
+  wrappers delegating to the methods (`func Emit[E Event](b *Bus, p Phase, e E) Outcome {
+  return b.Emit(p, e) }`), matching `math/rand/v2`'s own precedent of keeping the top-level
+  `N[Int](r, n)` alongside the new `r.N[Int](n)` method rather than forcing a migration. New
+  code should prefer `bus.Emit(...)`/`bus.Subscribe(...)` directly.
+- **`linetype.dashCursor.walkEdge`** (`model/linetype/dash.go`) — **ADOPTED.** `walkEdge[P
+  dashable[P]](c *dashCursor, segs [][2]P, p, q P) [][2]P` mutates `c`'s own pattern-position
+  state (via `c.advance`) on every call — it is exactly "an operation the cursor performs,"
+  parameterized per call by point dimensionality (2D/3D). Converted to `(c *dashCursor)
+  walkEdge[P dashable[P]](segs [][2]P, p, q P) [][2]P`; the single call site in
+  `dashPolyline` reads as `cur.walkEdge(segs, pts[i-1], pts[i])` instead of `walkEdge(&cur,
+  segs, pts[i-1], pts[i])`.
+- **`renderer.LightDistribution`/`EnvironmentDistribution`** (`renderer/light_sampling.go`,
+  `renderer/environment_sampling.go`) — **REJECTED.** Both do CDF-based importance sampling,
+  but that similarity is superficial on closer reading: `LightDistribution.Sample` is a 1D
+  discrete pick over a fixed item list returning `(index, item, pdf)`; `EnvironmentDistribution
+  .Sample` is a 2D continuous pick over a pixel grid (row marginal CDF + per-row conditional
+  CDF) returning `(direction, pdf)` via a coordinate transform with its own solid-angle
+  Jacobian. The only literally-shared logic is a one-line binary-search-a-CDF idiom already
+  expressed via `sort.Search`/`sort.SearchFloat64s` — too thin to justify a shared generic
+  type, and forcing the two into one abstraction would actively hurt readability for a
+  one-line saving (CLAUDE.md's no-code-duplication rule doesn't apply to logic that isn't
+  actually duplicated).
+- **`addin/router/typed.go`'s ten handler-adapter functions** (`typed`, `typedCtx`,
+  `ctxQuery`, `typedPart`, `partQuery`, `typedAssembly`, `assemblyQuery`, `typedHolder`,
+  `holderQuery`, `projectAll`) — **REJECTED.** These are combinators that build a
+  `handlerFunc` value (e.g. `typedPart(getX)`), evaluated *before* any `Router` is in scope —
+  the call site is `r.readOnly(wire.MethodX, typedPart(getX))`. None of them read or use a
+  `Router`'s state; there is no receiver to hang a method off without inventing one. Router
+  methods here would misleadingly imply these adapters depend on router identity.
+- **`kernel/topo.buildKeyIndex`/`scanByKey`** (`kernel/topo/key_index.go`) — **REJECTED.**
+  Both are pure functions of their `items []T` argument, called from three sites inside
+  `*Body`'s own methods (`b.cachedEdges`/`cachedFaces`/`cachedVertices`), each with a
+  different concrete `T`. `Body` itself is non-generic, so nothing is lost by leaving these
+  as free functions — a method would need the caller to pass `b`'s own field back into `b`'s
+  method (`b.buildKeyIndex(b.cachedEdges)`), which is not more readable than today's
+  `buildKeyIndex(b.cachedEdges)` and ties a stateless pure function to `*Body` for no reason.
+
+## Consequences
+
+- New concurrency/dispatch types with the `Bus` shape (a non-generic hub whose per-call
+  operation needs its own type parameter) should default to generic methods, not the
+  free-function-plus-explicit-receiver-argument workaround this ADR retired for `event.Bus`.
+- A generic free function stays the right shape whenever the "receiver" is either stateless,
+  interchangeable, or not actually part of the call — most of this codebase's existing
+  generics (per ADR-0001's small deliberate set) fall in exactly that bucket and are
+  unaffected by this ADR.
+- This is not a mandate to audit every existing free generic function for method-conversion
+  potential — the bar above is the filter for new code and for reviewing this ADR's five
+  evaluated candidates going forward, not a backlog item.

--- a/event/bus.go
+++ b/event/bus.go
@@ -44,7 +44,12 @@ type Subscription struct {
 
 // Subscribe registers h for events of type E in phase p and returns a handle to
 // cancel it. Subscribing the same type in both phases takes two calls.
-func Subscribe[E Event](b *Bus, p Phase, h Handler[E]) Subscription {
+//
+// A generic method (Go 1.27) on the non-generic *Bus, parameterized per call by
+// event type — the top-level Subscribe below is kept as a thin wrapper so the
+// ~90 existing call sites (event.Subscribe(bus, ...)) don't need mechanical
+// migration; new code can prefer bus.Subscribe(...) directly.
+func (b *Bus) Subscribe[E Event](p Phase, h Handler[E]) Subscription {
 	k := subKey{typ: typeOf[E](), phase: p}
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -52,6 +57,11 @@ func Subscribe[E Event](b *Bus, p Phase, h Handler[E]) Subscription {
 	id := b.seq
 	b.subs[k] = append(b.subs[k], handlerEntry{id: id, fn: h})
 	return Subscription{bus: b, key: k, id: id}
+}
+
+// Subscribe is Bus.Subscribe as a free function, kept for existing call sites.
+func Subscribe[E Event](b *Bus, p Phase, h Handler[E]) Subscription {
+	return b.Subscribe(p, h)
 }
 
 // Cancel removes the subscription, reporting whether it was found.
@@ -69,16 +79,22 @@ func (s Subscription) Cancel() bool {
 }
 
 // Emit delivers e to every Before-or-After handler for its type and returns the
-// aggregate outcome. It uses a background context; see [EmitContext] for deadlines.
+// aggregate outcome. It uses a background context; see [Bus.EmitContext] for
+// deadlines.
+func (b *Bus) Emit[E Event](p Phase, e E) Outcome {
+	return b.EmitContext(context.Background(), p, e)
+}
+
+// Emit is Bus.Emit as a free function, kept for existing call sites.
 func Emit[E Event](b *Bus, p Phase, e E) Outcome {
-	return EmitContext(context.Background(), b, p, e)
+	return b.Emit(p, e)
 }
 
 // EmitContext delivers e with an explicit context (e.g. a veto deadline for
 // add-ins). Every handler runs; the aggregate outcome is the strongest disposition
 // any handler returned (Abort > Handled > NotHandled), carrying the first veto
 // reason. A vetoing Before outcome tells the caller to cancel the operation.
-func EmitContext[E Event](ctx context.Context, b *Bus, p Phase, e E) Outcome {
+func (b *Bus) EmitContext[E Event](ctx context.Context, p Phase, e E) Outcome {
 	handlers := b.snapshot(subKey{typ: typeOf[E](), phase: p})
 	result := Continue()
 	for _, entry := range handlers {
@@ -86,6 +102,11 @@ func EmitContext[E Event](ctx context.Context, b *Bus, p Phase, e E) Outcome {
 		result = stronger(result, out)
 	}
 	return result
+}
+
+// EmitContext is Bus.EmitContext as a free function, kept for existing call sites.
+func EmitContext[E Event](ctx context.Context, b *Bus, p Phase, e E) Outcome {
+	return b.EmitContext(ctx, p, e)
 }
 
 // snapshot copies the handler slice for a key under the read lock, so handlers can

--- a/event/bus_test.go
+++ b/event/bus_test.go
@@ -132,6 +132,42 @@ func TestContextCarriesPhaseAndDeadline(t *testing.T) {
 	}
 }
 
+// TestBusMethodFormMatchesFreeFunctions exercises the Go 1.27 generic methods
+// (Bus.Subscribe/Emit/EmitContext) directly rather than through the free-function
+// wrappers the rest of this file uses, proving the method form behaves identically
+// (Subscribe/Emit/EmitContext above already cover dispatch semantics in depth).
+func TestBusMethodFormMatchesFreeFunctions(t *testing.T) {
+	b := NewBus()
+	var seen []string
+	sub := b.Subscribe(After, func(_ Context, e docSaved) Outcome {
+		seen = append(seen, e.name)
+		return Continue()
+	})
+
+	if out := b.Emit(After, docSaved{name: "part.obk"}); out.Vetoed() {
+		t.Errorf("Emit outcome = %+v, want not vetoed", out)
+	}
+	if len(seen) != 1 || seen[0] != "part.obk" {
+		t.Errorf("handler saw %v, want [part.obk]", seen)
+	}
+
+	type ctxKey string
+	ctx := context.WithValue(context.Background(), ctxKey("k"), "v")
+	var gotVal any
+	b.Subscribe(Before, func(c Context, _ docClosing) Outcome {
+		gotVal = c.Ctx.Value(ctxKey("k"))
+		return Continue()
+	})
+	b.EmitContext(ctx, Before, docClosing{})
+	if gotVal != "v" {
+		t.Errorf("EmitContext context value = %v, want v", gotVal)
+	}
+
+	if !sub.Cancel() {
+		t.Error("Cancel returned false for an active subscription")
+	}
+}
+
 func TestHandlerMaySubscribeDuringEmit(_ *testing.T) {
 	b := NewBus()
 	added := false

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	golang.org/x/sys v0.47.0
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.0
-	oblikovati.org/api v0.151.1
+	oblikovati.org/api v0.152.0
 )
 
 require (

--- a/head/go.mod
+++ b/head/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	oblikovati.org v0.0.0
-	oblikovati.org/api v0.151.1
+	oblikovati.org/api v0.152.0
 )
 
 require golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // icon glyph normalization (x/image/draw)

--- a/model/linetype/dash.go
+++ b/model/linetype/dash.go
@@ -48,7 +48,7 @@ func dashPolyline[P dashable[P]](pts []P, closed bool, pattern []float64) [][2]P
 	segs := [][2]P{}
 	cur := dashCursor{steps: steps, rem: steps[0].length}
 	for i := 1; i < len(pts); i++ {
-		segs = walkEdge(&cur, segs, pts[i-1], pts[i])
+		segs = cur.walkEdge(segs, pts[i-1], pts[i])
 	}
 	return segs
 }
@@ -86,8 +86,10 @@ type dashCursor struct {
 }
 
 // walkEdge appends the pen-down sub-segments of one polyline edge, advancing the
-// pattern cursor so the pattern continues seamlessly onto the next edge.
-func walkEdge[P dashable[P]](c *dashCursor, segs [][2]P, p, q P) [][2]P {
+// cursor's own pattern position so the pattern continues seamlessly onto the next
+// edge. A generic method (Go 1.27) rather than a free function taking *dashCursor:
+// the operation belongs to the cursor's state, parameterized per call by point type.
+func (c *dashCursor) walkEdge[P dashable[P]](segs [][2]P, p, q P) [][2]P {
 	total := float64(p.DistanceTo(q))
 	for at := 0.0; total-at > minCycle; {
 		step := c.rem

--- a/model/sketch/copy_constraints.go
+++ b/model/sketch/copy_constraints.go
@@ -134,11 +134,12 @@ func allOperandsRequested(c Constraint, requested map[Entity]bool) bool {
 	return true
 }
 
-// The carry* helpers remap a fixed operand shape and invoke the matching factory iff every
+// The carry* methods remap a fixed operand shape and invoke the matching factory iff every
 // operand is inside the copied set. The factory's return value is discarded — the relation is
-// already registered by Add — so they are generic over it (R).
+// already registered by Add — so they are generic over it (R). Generic methods (Go 1.27) on
+// the non-generic *cloneMap, alongside its existing point/line/curve/... lookups above.
 
-func carryPoints[R any](m *cloneMap, a, b *Point, add func(*Point, *Point) R) bool {
+func (m *cloneMap) carryPoints[R any](a, b *Point, add func(*Point, *Point) R) bool {
 	na, ok1 := m.point(a)
 	nb, ok2 := m.point(b)
 	if !ok1 || !ok2 {
@@ -148,7 +149,7 @@ func carryPoints[R any](m *cloneMap, a, b *Point, add func(*Point, *Point) R) bo
 	return true
 }
 
-func carryPointLine[R any](m *cloneMap, p *Point, l *Line, add func(*Point, *Line) R) bool {
+func (m *cloneMap) carryPointLine[R any](p *Point, l *Line, add func(*Point, *Line) R) bool {
 	np, ok1 := m.point(p)
 	nl, ok2 := m.line(l)
 	if !ok1 || !ok2 {
@@ -158,7 +159,7 @@ func carryPointLine[R any](m *cloneMap, p *Point, l *Line, add func(*Point, *Lin
 	return true
 }
 
-func carryPointCurve[R any](m *cloneMap, p *Point, c CircularCurve, add func(*Point, CircularCurve) R) bool {
+func (m *cloneMap) carryPointCurve[R any](p *Point, c CircularCurve, add func(*Point, CircularCurve) R) bool {
 	np, ok1 := m.point(p)
 	nc, ok2 := m.curve(c)
 	if !ok1 || !ok2 {
@@ -168,7 +169,7 @@ func carryPointCurve[R any](m *cloneMap, p *Point, c CircularCurve, add func(*Po
 	return true
 }
 
-func carryLines[R any](m *cloneMap, l1, l2 *Line, add func(*Line, *Line) R) bool {
+func (m *cloneMap) carryLines[R any](l1, l2 *Line, add func(*Line, *Line) R) bool {
 	n1, ok1 := m.line(l1)
 	n2, ok2 := m.line(l2)
 	if !ok1 || !ok2 {
@@ -178,7 +179,7 @@ func carryLines[R any](m *cloneMap, l1, l2 *Line, add func(*Line, *Line) R) bool
 	return true
 }
 
-func carryCurves[R any](m *cloneMap, c1, c2 CircularCurve, add func(CircularCurve, CircularCurve) R) bool {
+func (m *cloneMap) carryCurves[R any](c1, c2 CircularCurve, add func(CircularCurve, CircularCurve) R) bool {
 	n1, ok1 := m.curve(c1)
 	n2, ok2 := m.curve(c2)
 	if !ok1 || !ok2 {
@@ -188,7 +189,7 @@ func carryCurves[R any](m *cloneMap, c1, c2 CircularCurve, add func(CircularCurv
 	return true
 }
 
-func carryLineCurve[R any](m *cloneMap, l *Line, c CircularCurve, add func(*Line, CircularCurve) R) bool {
+func (m *cloneMap) carryLineCurve[R any](l *Line, c CircularCurve, add func(*Line, CircularCurve) R) bool {
 	nl, ok1 := m.line(l)
 	nc, ok2 := m.curve(c)
 	if !ok1 || !ok2 {

--- a/model/sketch/copy_constraints_registry.go
+++ b/model/sketch/copy_constraints_registry.go
@@ -108,15 +108,15 @@ func (g *GeometricConstraints) carryFrom(c Constraint, m *cloneMap) (carried boo
 // outside the copied set.
 
 func carryCoincident(g *GeometricConstraints, v *CoincidentConstraint, m *cloneMap) bool {
-	return carryPoints(m, v.A, v.B, g.AddCoincident)
+	return m.carryPoints(v.A, v.B, g.AddCoincident)
 }
 
 func carryHorizontal(g *GeometricConstraints, v *HorizontalConstraint, m *cloneMap) bool {
-	return carryPoints(m, v.A, v.B, g.AddHorizontal)
+	return m.carryPoints(v.A, v.B, g.AddHorizontal)
 }
 
 func carryVertical(g *GeometricConstraints, v *VerticalConstraint, m *cloneMap) bool {
-	return carryPoints(m, v.A, v.B, g.AddVertical)
+	return m.carryPoints(v.A, v.B, g.AddVertical)
 }
 
 // carryLineHorizontal / carryLineVertical remap the single line of a single-line
@@ -140,47 +140,47 @@ func carryLineVertical(g *GeometricConstraints, v *SingleLineVerticalConstraint,
 }
 
 func carryPointOnLine(g *GeometricConstraints, v *PointOnLineConstraint, m *cloneMap) bool {
-	return carryPointLine(m, v.P, v.L, g.AddPointOnLine)
+	return m.carryPointLine(v.P, v.L, g.AddPointOnLine)
 }
 
 func carryMidpoint(g *GeometricConstraints, v *MidpointConstraint, m *cloneMap) bool {
-	return carryPointLine(m, v.P, v.L, g.AddMidpoint)
+	return m.carryPointLine(v.P, v.L, g.AddMidpoint)
 }
 
 func carryPointOnCircle(g *GeometricConstraints, v *PointOnCircleConstraint, m *cloneMap) bool {
-	return carryPointCurve(m, v.P, v.C, g.AddPointOnCircle)
+	return m.carryPointCurve(v.P, v.C, g.AddPointOnCircle)
 }
 
 func carryParallel(g *GeometricConstraints, v *ParallelConstraint, m *cloneMap) bool {
-	return carryLines(m, v.L1, v.L2, g.AddParallel)
+	return m.carryLines(v.L1, v.L2, g.AddParallel)
 }
 
 func carryPerpendicular(g *GeometricConstraints, v *PerpendicularConstraint, m *cloneMap) bool {
-	return carryLines(m, v.L1, v.L2, g.AddPerpendicular)
+	return m.carryLines(v.L1, v.L2, g.AddPerpendicular)
 }
 
 func carryCollinear(g *GeometricConstraints, v *CollinearConstraint, m *cloneMap) bool {
-	return carryLines(m, v.L1, v.L2, g.AddCollinear)
+	return m.carryLines(v.L1, v.L2, g.AddCollinear)
 }
 
 func carryEqualLength(g *GeometricConstraints, v *EqualLengthConstraint, m *cloneMap) bool {
-	return carryLines(m, v.L1, v.L2, g.AddEqualLength)
+	return m.carryLines(v.L1, v.L2, g.AddEqualLength)
 }
 
 func carryConcentric(g *GeometricConstraints, v *ConcentricConstraint, m *cloneMap) bool {
-	return carryCurves(m, v.C1, v.C2, g.AddConcentric)
+	return m.carryCurves(v.C1, v.C2, g.AddConcentric)
 }
 
 func carryEqualRadius(g *GeometricConstraints, v *EqualRadiusConstraint, m *cloneMap) bool {
-	return carryCurves(m, v.C1, v.C2, g.AddEqualRadius)
+	return m.carryCurves(v.C1, v.C2, g.AddEqualRadius)
 }
 
 func carryCircularTangent(g *GeometricConstraints, v *CircularTangentConstraint, m *cloneMap) bool {
-	return carryCurves(m, v.C1, v.C2, g.AddCircularTangent)
+	return m.carryCurves(v.C1, v.C2, g.AddCircularTangent)
 }
 
 func carryTangent(g *GeometricConstraints, v *TangentConstraint, m *cloneMap) bool {
-	return carryLineCurve(m, v.L, v.C, g.AddTangent)
+	return m.carryLineCurve(v.L, v.C, g.AddTangent)
 }
 
 func carrySymmetryKind(g *GeometricConstraints, v *SymmetryConstraint, m *cloneMap) bool {


### PR DESCRIPTION
## Summary
First feature-evaluation follow-up to the Go 1.27 migration (#2169): a systematic
sweep of every plausible generic-methods candidate across both `Oblikovati` and
`Oblikovati.API` — every top-level generic function whose first parameter is a
pointer to a concrete (non-generic) type, the exact shape this feature retires.
Landed 5 candidates that earn it (3 in this repo, 2 more via companion PR
[Oblikovati.API#286](https://github.com/Oblikovati/Oblikovati.API/pull/286)),
rejected several with recorded reasoning. New **ADR-0054** captures the decision
framework and every evaluated candidate so future work has a clear bar for "does
this earn a generic method."

## What changed (this repo)
- **`event.Bus.Subscribe`/`Emit`/`EmitContext`** (`event/bus.go`) — were free
  functions taking `*Bus` as their first argument purely because `Bus`
  (non-generic, stateful) couldn't carry a generic method before 1.27. Converted
  to methods; the free functions are now thin wrappers delegating to them
  (matching `math/rand/v2`'s own precedent), so the ~176 existing call sites
  across ~90 files need **no migration**.
- **`linetype.dashCursor.walkEdge`** (`model/linetype/dash.go`) — mutates the
  cursor's own pattern-position state every call. Converted to a method.
- **`sketch.cloneMap`'s six `carryXxx` helpers** (`model/sketch/copy_constraints.go`)
  — `cloneMap` already had six non-generic lookup methods; these six free
  functions sat right next to them purely for lack of a method-level type
  parameter. Converted all six; updated their 14 call sites (private to the
  package, no compatibility wrapper needed).
- **`app.Session`'s `activeSheetMetalTool`, `runDialogHook`, `cursorMove`**
  (`app/sheet_metal_session.go`, `app/file_ui_hooks.go`, `app/undo.go`) — three
  free functions taking `*Session`. `cursorMove`'s own doc comment said it
  outright: *"Generic (and free, since methods cannot be) because the bus
  dispatches on the event's static type."* All three are private to `app` (18,
  3, 2 call sites), converted directly with no wrapper needed.
- **ADR-0054** (new): the decision framework plus reasoning for every evaluated
  candidate — 5 adopted, several rejected (including two rejection *classes* the
  sweep surfaced: functions disqualified purely by package boundary, and
  constraint-narrowing over an already-generic type's own parameter, which isn't
  what generic methods address at all).
- **ADR-0001**: floor bumped "1.22+" → "1.27+", cross-referenced to ADR-0054.
- **`ci.yml`**: added `event/...` to the coverage `-coverpkg` scope — the same
  measurement artifact already hit and fixed twice before for `addin/...` and
  `renderer/...` (a package left out of `-coverpkg` gets zero coverage credit
  even for its own tests); `event/bus.go`'s new code was the first change there
  large enough to trip SonarCloud's 80%-on-new-code gate on it.

## Rejected candidates (see ADR-0054 for full reasoning)
- `renderer.LightDistribution`/`EnvironmentDistribution` — superficially similar
  (both do "CDF-based importance sampling"), but one is a 1D discrete pick and
  the other a 2D continuous pick with a solid-angle Jacobian; only a one-line
  binary-search idiom is truly shared.
- `addin/router/typed.go`'s ten handler-adapter functions — no real `Router`
  receiver to hang a method off.
- `kernel/topo.buildKeyIndex`/`scanByKey` — already-optimal free functions.
- A cluster disqualified purely by package boundary (Go methods can only live
  in the receiver type's own package) and `model/proxy/geometry.go`'s three
  functions, which need a *narrower* constraint than their generic type already
  declares — not something generic methods address.

## Test plan
- [x] `go build`/`vet`/`test ./...` clean on the root module (zero failures)
  under go1.27.0.
- [x] `head` module: all packages clean; two known-flaky real-hardware
  GPU-driver tests reproduced clean on isolated re-run — unrelated to this
  change.
- [x] `golangci-lint run ./...` clean (0 issues) on both modules.
- [x] `gofmt -l` clean; `markdownlint-cli2` clean on the new/edited ADRs.
- [x] SonarCloud coverage gate: root-caused the initial 20%-on-new-code failure
  to the `-coverpkg` scoping gap above (confirmed 100% locally via
  `go test -coverprofile`), not a real test gap; fixed.