### PR TITLE
SSI-edge weld (ADR-0056 Layer 4): oblique cyl∪box reconstructs analytically

### DIFF
--- a/architecture/decisions/ADR-0056-analytic-face-reconstruction-boolean.md
+++ b/architecture/decisions/ADR-0056-analytic-face-reconstruction-boolean.md
@@ -200,10 +200,20 @@ default** — `reconstructionCutover = false` — because two frontiers remain:
      result, and drop the piston test's gate-aware skip. The gate stays off in this commit pending
      that decision.
 
-4. **Curved SSI-edge welding (e.g. cyl ∪ box).** Reconstruction recovers the analytic surfaces
-   but the plane∩cylinder ellipse/line edges do not yet weld watertight; Layer 4 (exact SSI conics
-   welded consistently on both incident faces) closes it. Reconstruction declines it (stays
-   faceted) — safe.
+4. **Curved SSI-edge welding — LANDED for the ellipse (Layer 4).** A clean oblique plane∩cylinder
+   cut (a cylinder bored through a box at an angle, cyl ∪/− box) now reconstructs analytically. Two
+   findings closed it, and neither was the welding premise this ADR originally assumed:
+   - The ellipse ALREADY welds. `geom.IntersectSurfacesAnalytic` canonicalises the plane∩cylinder
+     ellipse (the plane is always the first argument), so both incident faces synthesize the
+     bit-identical `EllipseFull`, and the endpoints+midpoint `edgeKey` fuses their copies into one
+     `topo.Edge`. `weldableSSICurve` simply widens to admit `EllipseFull`/`EllipticalArc`.
+   - The real defect was ARC-EXTENT, not welding. A closed conic restricted to two endpoints is
+     ambiguous between the direct sub-arc and its wrapping complement; the raw `[t0,t1]` stored the
+     wrong half (SlottedScrew's slanted bore removed ~5 mm³ too little). `orientRunEdge` now picks
+     the arc the run's INTERIOR vertex lies on (the analogue of `matchSubArc`'s three-point arc).
+   `reconstructBoolean` self-validates Euler-admissibility, so the one case still left faceted — an
+   oblique exit that crosses an operand CORNER, splitting its ellipse across two faces into an
+   inadmissible χ — declines safely. Cone∩plane parabola/hyperbola remain future work.
 
 ## Alternatives considered and rejected
 

--- a/kernel/ops/meshbool_reconstruct.go
+++ b/kernel/ops/meshbool_reconstruct.go
@@ -50,7 +50,12 @@ func reconstructBoolean(a, b *topo.Body, op meshbool.Op, q Quality) (*topo.Body,
 		return nil, false
 	}
 	body := brep.ReconstructBooleanBody(inputs)
-	if body == nil || !body.IsSolid() || len(body.Faces()) == 0 {
+	if body == nil || len(body.Faces()) == 0 || !validBooleanSolid(body) {
+		// Reconstruction can assemble a solid that is closed+manifold yet Euler-inadmissible
+		// (an oblique conic exit that crosses an operand CORNER splits its ellipse across two
+		// faces, doubling a loop → χ too large). Decline those to the exact faceted fallback;
+		// a CLEAN oblique cut (an ellipse bounding one hole per face) validates and rebuilds
+		// analytically (ADR-0056 Layer 4).
 		return nil, false
 	}
 	return body, true

--- a/kernel/ops/meshbool_reconstruct_ssi.go
+++ b/kernel/ops/meshbool_reconstruct_ssi.go
@@ -3,6 +3,8 @@
 package ops
 
 import (
+	stdmath "math"
+
 	"oblikovati.org/kernel/brep"
 	"oblikovati.org/kernel/geom"
 	"oblikovati.org/kernel/meshbool"
@@ -39,17 +41,16 @@ func intersectionRunEdge(run meshbool.ArrangementRun, surface, neighbor geom.Sur
 
 // weldableSSICurve reports whether a synthesized surface-surface intersection curve is one
 // reconstruction can reuse and close watertight: a LINE (plane∩plane, plane∩cylinder along a
-// ruling) or a CIRCLE (cylinder/cone/sphere cut by a plane ⊥ its axis). These are exact and,
-// crucially, identical to the same curve computed from the neighbour face, so the two incident
-// faces' copies WELD. An oblique conic — an EllipseFull (cylinder∩tilted plane), parabola, or
-// hyperbola — is exact as a curve but not yet welded consistently across both faces (each face
-// samples it independently), so a face bounded by one closes to a VALID but wrong-volume solid
-// (the #2167-sibling disjoint/oblique cut, e.g. SlottedScrew's slanted-hex bore exit). Until the
-// numeric-SSI weld layer lands (ADR-0056 Layer 4), reconstruction DECLINES those runs so the
-// caller falls back to the exact faceted boolean — no wrong geometry, no regression.
+// ruling), a CIRCLE (cylinder/cone/sphere cut by a plane ⊥ its axis), or an ELLIPSE
+// (cylinder∩tilted plane). geom.IntersectSurfacesAnalytic canonicalises the plane∩cylinder
+// ellipse — the plane operand is always the first argument, so both incident faces synthesize
+// the BIT-IDENTICAL EllipseFull — and the endpoints+midpoint weld key (curved_stitch.edgeKey)
+// therefore fuses the two faces' copies into ONE topo.Edge (ADR-0056 Layer 4). The remaining
+// closed forms with no consistent weld yet (cone∩plane parabola/hyperbola) still fall through
+// to the exact faceted boolean.
 func weldableSSICurve(c geom.Curve3) bool {
 	switch c.(type) {
-	case geom.Line, geom.Circle:
+	case geom.Line, geom.Circle, geom.EllipseFull, geom.EllipticalArc:
 		return true
 	default:
 		return false
@@ -101,7 +102,11 @@ func runMatchTol(run meshbool.ArrangementRun, verts []meshbool.Point, res geom.R
 
 // orientRunEdge restricts c to the run's extent, oriented so the loop walks it start to
 // end. A closed run (endpoints coincide) spans the whole domain, swept in the run's
-// direction; an open run runs between its endpoint parameters.
+// direction; an open run runs between its endpoint parameters. For a PERIODIC curve (a
+// closed ellipse) the two endpoints leave the arc ambiguous — the boundary is either the
+// direct [t0,t1] interval or its wrapping complement — so the run's interior vertex fixes
+// which arc, and thus the sweep sign and extent (ADR-0056 Layer 4; the analogue of
+// matchSubArc's three-point arc for original circle edges).
 func orientRunEdge(c geom.Curve3, run meshbool.ArrangementRun, verts []meshbool.Point, tol float64) brep.ReconEdge {
 	n := len(run.Verts)
 	p0, pn := verts[run.Verts[0]].Round(), verts[run.Verts[n-1]].Round()
@@ -110,7 +115,34 @@ func orientRunEdge(c geom.Curve3, run meshbool.ArrangementRun, verts []meshbool.
 	}
 	t0, _ := geom.CurveParamAtPoint3(c, p0)
 	t1, _ := geom.CurveParamAtPoint3(c, pn)
+	if _, periodic := c.(geom.EllipseFull); periodic {
+		t1 = ellipseArcEndThroughMid(c, t0, t1, verts[run.Verts[n/2]].Round())
+	}
 	return brep.ReconEdge{Curve: c, T0: t0, T1: t1}
+}
+
+// ellipseArcEndThroughMid returns the end parameter (a signed offset from t0, so the
+// sweep sign is right) of the sub-arc of a closed ellipse that RUNS THROUGH the interior
+// vertex mid. A closed conic on [0,1] restricted to two endpoints spans either the forward
+// interval or its wrapping complement; the mid vertex disambiguates. Without this the raw
+// [t0,t1] stores the wrong half (SlottedScrew's slanted bore exit removed too little).
+func ellipseArcEndThroughMid(c geom.Curve3, t0, t1 float64, mid math.Point3) float64 {
+	tm, _ := geom.CurveParamAtPoint3(c, mid)
+	forward := frac01(t1 - t0) // increasing-param distance t0→t1
+	toMid := frac01(tm - t0)   // increasing-param distance t0→mid
+	if toMid <= forward {
+		return t0 + forward // the forward sub-arc holds the mid vertex
+	}
+	return t0 - (1 - forward) // the boundary runs the wrapping complement (negative sweep)
+}
+
+// frac01 maps x to its fractional part in [0,1).
+func frac01(x float64) float64 {
+	x -= stdmath.Floor(x)
+	if x < 0 {
+		x++
+	}
+	return x
 }
 
 // closedRunEdge spans a closed curve's whole domain, swept in the run's direction (set

--- a/kernel/ops/meshbool_reconstruct_ssi_guard_test.go
+++ b/kernel/ops/meshbool_reconstruct_ssi_guard_test.go
@@ -11,20 +11,20 @@ import (
 	m "oblikovati.org/math"
 )
 
-// The disjoint-region cut layer (ADR-0056). A boolean whose exact soup is correct can still
-// reconstruct to a VALID-but-wrong-volume analytic B-rep when a boundary run is an OBLIQUE
-// conic surface-surface intersection (a cylinder cut by a tilted plane = ellipse): the ellipse
-// is exact as a curve, but each incident face samples it independently, so the two copies do
-// not weld and the closed solid encloses the wrong region (SlottedScrew's slanted-hex bore
-// exit removed ~5 mm³ too little). weldableSSICurve confines SSI reuse to LINES and CIRCLES —
-// exact and identical from both faces — so reconstruction DECLINES an oblique-conic run and the
-// caller falls back to the exact faceted boolean. These lock that boundary: an oblique cut
-// declines, while a perpendicular cut (circular exits) — even across a disjoint void — rebuilds.
+// The corner-crossing decline boundary (ADR-0056 Layer 4). A CLEAN oblique cut — a cylinder
+// bored through a box at an angle, one ellipse per pierced face — now reconstructs analytically
+// (the ellipse SSI edge welds, and orientRunEdge picks the arc half the run traces; see
+// meshbool_reconstruct_ssi_weld_test.go). What still declines is a cut whose ellipse crosses an
+// operand CORNER: the exit ellipse splits across two adjacent faces, doubling a face loop into an
+// Euler-inadmissible assembly (χ too large for one shell). reconstructBoolean self-validates and
+// declines that, so the caller falls back to the exact faceted boolean — no wrong geometry. These
+// lock the boundary: a corner-crossing oblique cut declines; a perpendicular cut (circular exits),
+// even across a disjoint void, rebuilds.
 
-// TestReconstructDeclinesObliqueConicCut: a cylinder cut through a box at an angle needs an
-// ELLIPSE at each face exit. Reconstruction must decline (leaving the caller on the exact
-// faceted path) rather than emit a valid-but-wrong analytic solid.
-func TestReconstructDeclinesObliqueConicCut(t *testing.T) {
+// TestReconstructDeclinesCornerCrossingObliqueCut: an oblique bore whose exit ellipse crosses a box
+// corner (the tool axis leaves through the top AND a side) assembles an Euler-inadmissible B-rep.
+// Reconstruction must decline (leaving the caller on the exact faceted path) rather than emit it.
+func TestReconstructDeclinesCornerCrossingObliqueCut(t *testing.T) {
 	box, err := brep.SolidBlock(m.P3(0, 0, 0), m.P3(1, 1, 1), "box")
 	if err != nil {
 		t.Fatalf("box: %v", err)
@@ -34,7 +34,7 @@ func TestReconstructDeclinesObliqueConicCut(t *testing.T) {
 		t.Fatalf("cyl: %v", err)
 	}
 	if _, ok := reconstructBoolean(box, oblique, meshbool.Difference, DefaultQuality()); ok {
-		t.Fatal("oblique-conic cut reconstructed; must decline (ellipse SSI does not weld — ADR-0056 Layer 4)")
+		t.Fatal("corner-crossing oblique cut reconstructed; must decline (Euler-inadmissible — ADR-0056 Layer 4)")
 	}
 	// Declining loses nothing: the exact faceted boolean still produces a valid solid that
 	// removes real material (the tool axis pierces the box, so the result is strictly smaller

--- a/kernel/ops/meshbool_reconstruct_ssi_weld_test.go
+++ b/kernel/ops/meshbool_reconstruct_ssi_weld_test.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package ops
+
+import (
+	stdmath "math"
+	"testing"
+
+	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/diag"
+	"oblikovati.org/kernel/geom"
+	"oblikovati.org/kernel/meshbool"
+	"oblikovati.org/kernel/topo"
+	m "oblikovati.org/math"
+)
+
+// ADR-0056 Layer 4 — SSI-edge weld. An oblique plane∩cylinder cut is an ELLIPSE. The
+// endpoints+midpoint weld key (curved_stitch.edgeKey) fuses the two incident faces'
+// copies of the ellipse into ONE topo.Edge (IntersectSurfacesAnalytic canonicalises the
+// curve, so both copies are bit-identical), and orientRunEdge picks the arc HALF through
+// the run's interior vertex so the stored elliptical arc is the boundary the run actually
+// traces. A CLEAN oblique cut (one ellipse per pierced face) now rebuilds analytically;
+// only a cut that crosses an operand CORNER (its ellipse split across two faces, an
+// Euler-inadmissible assembly) still declines to the exact faceted fallback.
+
+// hasEllipseEdge reports whether the body carries an analytic elliptical boundary edge.
+func hasEllipseEdge(b *topo.Body) bool {
+	for _, e := range b.Edges() {
+		switch e.Geometry().(type) {
+		case geom.EllipticalArc, geom.EllipseFull:
+			return true
+		}
+	}
+	return false
+}
+
+// facetedVolume is the exact mesh-arrangement volume of `target op tool`, built straight from
+// the soup (soupToBody) — independent of the reconstruction path, so it is a valid oracle for
+// the reconstructed body's volume.
+func facetedVolume(t *testing.T, op PartFeatureOperation, target, tool *topo.Body) float64 {
+	t.Helper()
+	faceted := meshArrangementFallback(op, target, tool, &diag.Recorder{})
+	if faceted == nil {
+		t.Fatal("faceted oracle produced no body")
+	}
+	return BodyGeometryProperties(faceted, PropertyQuality()).Volume
+}
+
+// TestReconstructObliqueBoreRebuilds: a tilted cylinder bored cleanly through a slab's top and
+// bottom faces (an ellipse at each) reconstructs to a valid analytic genus-1 solid — both
+// elliptical rims analytic, the bore wall a single cylinder face, the exact volume.
+func TestReconstructObliqueBoreRebuilds(t *testing.T) {
+	slab, err := brep.SolidBlock(m.P3(-1, -1, 0), m.P3(1, 1, 0.5), "slab")
+	if err != nil {
+		t.Fatalf("slab: %v", err)
+	}
+	bore, err := brep.SolidCylinder(m.P3(0, 0, -0.2), m.V3(0.3, 0, 1), 0.2, 1.0)
+	if err != nil {
+		t.Fatalf("bore: %v", err)
+	}
+	recon, ok := reconstructBoolean(slab, bore, meshbool.Difference, DefaultQuality())
+	if !ok {
+		t.Fatal("clean oblique bore declined; the ellipse SSI must reconstruct (ADR-0056 Layer 4)")
+	}
+	if r := Validate(recon); !r.Valid || !r.Closed || !r.Manifold || !recon.IsSolid() {
+		t.Fatalf("oblique bore is not a valid closed manifold solid: %+v", r)
+	}
+	if n := cylinderFaceCount(recon); n != 1 {
+		t.Fatalf("oblique bore kept %d cylinder walls, want 1", n)
+	}
+	if !hasEllipseEdge(recon) {
+		t.Fatal("oblique bore has no analytic elliptical rim edge — it faceted the ellipse")
+	}
+	want := facetedVolume(t, Cut, slab, bore)
+	if v := BodyGeometryProperties(recon, PropertyQuality()).Volume; stdmath.Abs(v-want) > 5e-3*want {
+		t.Fatalf("oblique bore volume = %.5f, want ~%.5f (the exact mesh union)", v, want)
+	}
+}
+
+// TestReconstructObliqueCylinderBoxUnion: a tilted cylinder UNIONed with a box, poking out
+// through the box top at an angle, reconstructs analytically — the ellipse where the cylinder
+// wall meets the box top is a shared analytic edge, and the exposed stub keeps its cylinder wall
+// and circular cap. This is the #2167-sibling "cyl∪box" the Layer-4 weld unlocks.
+func TestReconstructObliqueCylinderBoxUnion(t *testing.T) {
+	box, err := brep.SolidBlock(m.P3(-1, -1, 0), m.P3(1, 1, 1), "box")
+	if err != nil {
+		t.Fatalf("box: %v", err)
+	}
+	stub, err := brep.SolidCylinder(m.P3(0, 0, 0.5), m.V3(0.4, 0, 1), 0.3, 1.2)
+	if err != nil {
+		t.Fatalf("stub: %v", err)
+	}
+	recon, ok := reconstructBoolean(box, stub, meshbool.Union, DefaultQuality())
+	if !ok {
+		t.Fatal("oblique cyl∪box declined; the ellipse seam must reconstruct (ADR-0056 Layer 4)")
+	}
+	if r := Validate(recon); !r.Valid || !r.Closed || !r.Manifold || !recon.IsSolid() {
+		t.Fatalf("cyl∪box union is not a valid closed manifold solid: %+v", r)
+	}
+	if n := cylinderFaceCount(recon); n < 1 {
+		t.Fatalf("cyl∪box union kept %d cylinder walls, want >=1", n)
+	}
+	if !hasEllipseEdge(recon) {
+		t.Fatal("cyl∪box union has no analytic elliptical seam edge — it faceted the ellipse")
+	}
+	want := facetedVolume(t, Join, box, stub)
+	if v := BodyGeometryProperties(recon, PropertyQuality()).Volume; stdmath.Abs(v-want) > 5e-3*want {
+		t.Fatalf("cyl∪box union volume = %.5f, want ~%.5f (the exact mesh union)", v, want)
+	}
+}


### PR DESCRIPTION
## What

ADR-0056 **Layer 4 — SSI-edge weld**: an oblique plane∩cylinder cut (an ellipse) now reconstructs analytically instead of declining to the faceted fallback. A cylinder bored through a box at an angle — **cyl ∪ box**, cyl − box — keeps its analytic cylinder wall and elliptical rims.

## Why

The reconstruction (ADR-0056) rebuilds curved boolean results on their exact surfaces, but `weldableSSICurve` admitted only lines and circles; any **ellipse** (a tilted plane cutting a cylinder) declined, so the whole join faceted. This was the last frontier called out when the reconstruction landed.

## How — two findings, neither the welding premise the ADR assumed

1. **The ellipse already welds.** `geom.IntersectSurfacesAnalytic` canonicalises the plane∩cylinder ellipse (the plane is always the first argument), so both incident faces synthesize the **bit-identical** `EllipseFull`, and the endpoints+midpoint `edgeKey` (`curved_stitch`) fuses their copies into one `topo.Edge`. `weldableSSICurve` just widens to admit `EllipseFull`/`EllipticalArc`. (I proved order-independence, struct-equality, and actual edge fusion before touching the gate.)

2. **The real defect was ARC-EXTENT, not welding.** A closed conic restricted to two endpoints is ambiguous between the direct sub-arc and its wrapping complement; the raw `[t0,t1]` stored the wrong half — which is what made **SlottedScrew's slanted bore remove ~5 mm³ too little**. `orientRunEdge` now picks the arc the run's **interior vertex** lies on (the analogue of `matchSubArc`'s three-point arc for original circle edges).

`reconstructBoolean` now self-validates Euler-admissibility, so the one case still left faceted — an oblique exit that crosses an operand **corner**, splitting its ellipse across two faces into an inadmissible χ — declines safely to the exact faceted boolean. Cone∩plane parabola/hyperbola remain future work.

## Verification

- New tests: `TestReconstructObliqueBoreRebuilds` (clean bore → valid genus-1 solid, 1 cylinder wall, analytic elliptical rims, exact volume vs the mesh oracle) and **`TestReconstructObliqueCylinderBoxUnion`** (cyl∪box → valid, analytic ellipse seam, exact volume).
- `model/feature.TestSlottedScrewRebuildsWithoutOffsettingErrors` passes (cross-hole removal now 32.4 mm³, was 26.1); #2167 piston still passes.
- Guard rewritten: `TestReconstructDeclinesCornerCrossingObliqueCut` locks the corner-crossing decline (Euler-inadmissible), replacing the old "ellipse doesn't weld" premise.
- **Full `go test ./...` — 0 failures**; `golangci-lint ./...` — 0 issues; docs-lint — 0; head (cgo) builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
