### PR TITLE
Memoize the B-spline inversion seed lattice per surface

### DIFF
--- a/kernel/geom/bspline_seed_memo.go
+++ b/kernel/geom/bspline_seed_memo.go
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	stdmath "math"
+	"sync"
+
+	"oblikovati.org/math"
+)
+
+// bsplineSeedGrid memoizes a B-spline surface's inversion seed lattice: the knot-span seed
+// parameters in each direction and the surface point at every (u, v) seed pair. Both are pure
+// functions of the surface's knots, degrees and control net, which NewBSplineSurface deep-copies
+// and nothing mutates afterwards — the immutability the memo rests on. Before this, every ParamAt
+// call rebuilt the lattice and re-evaluated ≥256 seed points through basisFuns, and inversion sits
+// inside the SSI corrector and every closest-point recursion, which call it thousands of times per
+// trace (Oblikovati/Oblikovati#3490 — a blend-parity corpus body spent 8m30s of a CI leg there).
+//
+// The grid is shared by every copy of the surface value (the field is a pointer, set once at
+// construction) and filled lazily under sync.Once, so concurrent inversions race only on who fills
+// it first, never on its content.
+type bsplineSeedGrid struct {
+	once sync.Once
+	us   []float64
+	vs   []float64
+	pts  [][]math.Point3
+}
+
+// seedLattice returns the surface's seed parameters and their evaluated points, from the memo when
+// the surface was built by NewBSplineSurface. A zero-value literal (test fixtures) has no memo slot
+// to fill and computes the same lattice per call — the verdict is identical either way, which
+// TestSeedMemoChangesNoInversion asserts point for point rather than assumes.
+func (s BSplineSurface) seedLattice() (us, vs []float64, pts [][]math.Point3) {
+	if s.seed == nil {
+		us = knotSpanSeedParams(s.UKnots, s.UDegree)
+		vs = knotSpanSeedParams(s.VKnots, s.VDegree)
+		return us, vs, evalSeedGrid(s, us, vs)
+	}
+	s.seed.once.Do(func() {
+		s.seed.us = knotSpanSeedParams(s.UKnots, s.UDegree)
+		s.seed.vs = knotSpanSeedParams(s.VKnots, s.VDegree)
+		s.seed.pts = evalSeedGrid(s, s.seed.us, s.seed.vs)
+	})
+	return s.seed.us, s.seed.vs, s.seed.pts
+}
+
+// evalSeedGrid evaluates the surface at every seed pair — the once-per-surface half of the work.
+func evalSeedGrid(s BSplineSurface, us, vs []float64) [][]math.Point3 {
+	pts := make([][]math.Point3, len(us))
+	for i, u := range us {
+		row := make([]math.Point3, len(vs))
+		for j, v := range vs {
+			row[j] = s.PointAt(u, v)
+		}
+		pts[i] = row
+	}
+	return pts
+}
+
+// nearestSeedPoint returns the seed pair whose evaluated point lies closest to q — nearestSeed with
+// the evaluations already paid for.
+func nearestSeedPoint(us, vs []float64, pts [][]math.Point3, q math.Point3) (float64, float64) {
+	bu, bv, bd := us[0], vs[0], stdmath.Inf(1)
+	for i, u := range us {
+		for j, v := range vs {
+			if d := float64(pts[i][j].DistanceSquaredTo(q)); d < bd {
+				bu, bv, bd = u, v, d
+			}
+		}
+	}
+	return bu, bv
+}

--- a/kernel/geom/bspline_seed_memo_test.go
+++ b/kernel/geom/bspline_seed_memo_test.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+package geom
+
+import (
+	"sync"
+	"testing"
+
+	"oblikovati.org/math"
+)
+
+// The seed-lattice memo must change NO inversion verdict — asserted directly, cold against warm,
+// rather than inferred from "a cache cannot change answers" (#3490).
+
+// memoTestSurface is a modest bicubic patch with a wave, so inversions have non-trivial basins.
+func memoTestSurface(t *testing.T) BSplineSurface {
+	t.Helper()
+	const n = 6
+	ctrl := make([][]math.Point3, n)
+	w := make([][]float64, n)
+	for i := range n {
+		ctrl[i] = make([]math.Point3, n)
+		w[i] = make([]float64, n)
+		for j := range n {
+			z := 0.4 * float64((i*j)%3)
+			ctrl[i][j] = math.P3(math.Scalar(i), math.Scalar(j), math.Scalar(z))
+			w[i][j] = 1
+		}
+	}
+	knots := []float64{0, 0, 0, 0, 1, 2, 3, 3, 3, 3}
+	s, err := NewBSplineSurface(3, 3, ctrl, w, knots, knots)
+	if err != nil {
+		t.Fatalf("NewBSplineSurface: %v", err)
+	}
+	return s
+}
+
+// TestSeedMemoChangesNoInversion inverts a grid of query points on the SAME geometry twice: once
+// through a zero-value copy whose memo slot is nil (the compute-per-call path, byte-for-byte the
+// pre-memo behaviour) and once through the constructed surface with its memo warm. Every (u, v)
+// must agree exactly — not approximately — because the memo stores the identical lattice the cold
+// path computes.
+func TestSeedMemoChangesNoInversion(t *testing.T) {
+	warm := memoTestSurface(t)
+	cold := BSplineSurface{UDegree: warm.UDegree, VDegree: warm.VDegree,
+		Ctrl: warm.Ctrl, Weights: warm.Weights, UKnots: warm.UKnots, VKnots: warm.VKnots}
+	if cold.seed != nil {
+		t.Fatal("the cold copy must have no memo slot for this comparison to mean anything")
+	}
+	for i := 0; i <= 8; i++ {
+		for j := 0; j <= 8; j++ {
+			q := math.P3(math.Scalar(0.61*float64(i)), math.Scalar(0.55*float64(j)), 1.3)
+			cu, cv := cold.ParamAt(q)
+			wu, wv := warm.ParamAt(q)
+			if cu != wu || cv != wv {
+				t.Fatalf("inversion of (%v) differs: cold (%.17g, %.17g) vs warm (%.17g, %.17g)", q, cu, cv, wu, wv)
+			}
+		}
+	}
+}
+
+// TestSeedMemoFillsOnceUnderConcurrency: parallel inversions may race only on who fills the memo,
+// never on its content.
+func TestSeedMemoFillsOnceUnderConcurrency(t *testing.T) {
+	s := memoTestSurface(t)
+	var wg sync.WaitGroup
+	results := make([][2]float64, 32)
+	for k := range results {
+		wg.Add(1)
+		go func(k int) {
+			defer wg.Done()
+			u, v := s.ParamAt(math.P3(1.7, 2.2, 0.9))
+			results[k] = [2]float64{u, v}
+		}(k)
+	}
+	wg.Wait()
+	for k := 1; k < len(results); k++ {
+		if results[k] != results[0] {
+			t.Fatalf("concurrent inversion %d returned %v, want %v", k, results[k], results[0])
+		}
+	}
+}

--- a/kernel/geom/bspline_surface.go
+++ b/kernel/geom/bspline_surface.go
@@ -16,6 +16,10 @@ type BSplineSurface struct {
 	Ctrl             [][]math.Point3
 	Weights          [][]float64
 	UKnots, VKnots   []float64
+	// seed shares the lazily-filled inversion seed lattice across every copy of this value — see
+	// bsplineSeedGrid. Set once by NewBSplineSurface; nil on a zero-value literal, which then
+	// computes the same lattice per call.
+	seed *bsplineSeedGrid
 }
 
 // NewBSplineSurface builds a rational B-spline surface, validating that the
@@ -39,6 +43,7 @@ func NewBSplineSurface(uDeg, vDeg int, ctrl [][]math.Point3, weights [][]float64
 	return BSplineSurface{
 		UDegree: uDeg, VDegree: vDeg, Ctrl: copyNet(ctrl), Weights: copyWeights(weights),
 		UKnots: append([]float64(nil), uKnots...), VKnots: append([]float64(nil), vKnots...),
+		seed: &bsplineSeedGrid{},
 	}, nil
 }
 

--- a/kernel/geom/evaluator_surface_query.go
+++ b/kernel/geom/evaluator_surface_query.go
@@ -254,9 +254,8 @@ type surfaceSeed struct{ u, v float64 }
 // refines the near-minimal cells with the seeded projector, and clusters the winners so
 // a point equidistant from several feet is reported as DistinctlyManySolutions.
 func bsplineParamAtPoint(g BSplineSurface, p math.Point3) (float64, float64, SolutionNature) {
-	uSeeds := knotSpanSeedParams(g.UKnots, g.UDegree)
-	vSeeds := knotSpanSeedParams(g.VKnots, g.VDegree)
-	us, vs, ds, best := seedLatticeDistances(g, p, uSeeds, vSeeds)
+	uSeeds, vSeeds, pts := g.seedLattice() // memoized per surface (#3490)
+	us, vs, ds, best := seedLatticeDistances(pts, p, uSeeds, vSeeds)
 	uW, vW := minSeedSpacing(uSeeds), minSeedSpacing(vSeeds)
 	bestU, bestV, clusters := refineSeedClusters(g, p, us, vs, ds, best, uW, vW)
 	if len(clusters) > 1 {
@@ -289,11 +288,11 @@ func refineSeedClusters(g BSplineSurface, p math.Point3, us, vs, ds []float64, b
 
 // seedLatticeDistances evaluates the distance field on the uSeeds×vSeeds knot-span lattice,
 // returning the flattened (u, v, d) samples and the minimum distance found.
-func seedLatticeDistances(s Surface, p math.Point3, uSeeds, vSeeds []float64) (us, vs, ds []float64, best float64) {
+func seedLatticeDistances(pts [][]math.Point3, p math.Point3, uSeeds, vSeeds []float64) (us, vs, ds []float64, best float64) {
 	best = stdmath.Inf(1)
-	for _, u := range uSeeds {
-		for _, v := range vSeeds {
-			d := s.PointAt(u, v).DistanceTo(p)
+	for i, u := range uSeeds {
+		for j, v := range vSeeds {
+			d := float64(pts[i][j].DistanceTo(p))
 			us, vs, ds = append(us, u), append(vs, v), append(ds, d)
 			best = stdmath.Min(best, d)
 		}

--- a/kernel/geom/intersect_surface_trace.go
+++ b/kernel/geom/intersect_surface_trace.go
@@ -151,7 +151,8 @@ type ssiTracer struct {
 // so any guard generous enough not to decline correct work still admits millions of corrections across
 // one self-intersection scan. Each of those corrections is a NURBS point inversion that rebuilds a
 // knot-span seed lattice and rescans it (geom.BSplineSurface.ParamAt → nearestSeed), which is the
-// actual cost and is tracked as Oblikovati/Oblikovati#3490. Lowering this constant to make such a body
+// actual cost and is tracked as Oblikovati/Oblikovati#3490; the seed lattice itself is memoized
+// per surface now, which removes the rebuild-and-rescan half of that term. Lowering this constant to make such a body
 // finish would decline correct work instead of making the work cheaper, and is the wrong trade.
 const ssiMaxCorrections = 1000000
 

--- a/kernel/geom/nurbs_seed_params.go
+++ b/kernel/geom/nurbs_seed_params.go
@@ -4,8 +4,6 @@ package geom
 
 import (
 	stdmath "math"
-
-	"oblikovati.org/math"
 )
 
 // Knot-structure-aware seeding for NURBS point/surface inversion (Oblikovati#1608).
@@ -56,20 +54,6 @@ func domainBreakpoints(knots []float64, degree int) []float64 {
 	out = append(out, hi)
 	sortFloats(out)
 	return out
-}
-
-// nearestSeed returns the (u, v) from the us×vs seed lattice whose surface point is
-// closest to q — the Gauss–Newton starting guess for point inversion.
-func nearestSeed(s Surface, q math.Point3, us, vs []float64) (float64, float64) {
-	bu, bv, bd := us[0], vs[0], stdmath.Inf(1)
-	for _, u := range us {
-		for _, v := range vs {
-			if d := s.PointAt(u, v).DistanceSquaredTo(q); d < bd {
-				bu, bv, bd = u, v, d
-			}
-		}
-	}
-	return bu, bv
 }
 
 // ssiSpanCounter reports a surface's distinct-knot-span counts so the SSI seeder can start its

--- a/kernel/geom/paramat.go
+++ b/kernel/geom/paramat.go
@@ -67,9 +67,8 @@ const (
 // point inversion (Piegl & Tiller §6.1), with an early convergence exit — and finally a
 // retry from the opposite bound when the foot came back pinned on one (retryAcrossPinnedBound).
 func (s BSplineSurface) ParamAt(q math.Point3) (u, v float64) {
-	us := knotSpanSeedParams(s.UKnots, s.UDegree)
-	vs := knotSpanSeedParams(s.VKnots, s.VDegree)
-	u, v = nearestSeed(s, q, us, vs)
+	us, vs, pts := s.seedLattice() // memoized: the lattice and its evaluations are per-surface work (#3490)
+	u, v = nearestSeedPoint(us, vs, pts, q)
 	u, v, _, _ = refineSurfaceParam(s, q, u, v, surfaceInvertMaxIter)
 	return retryAcrossPinnedBound(s, q, u, v)
 }

--- a/kernel/geom/surface_inversion_test.go
+++ b/kernel/geom/surface_inversion_test.go
@@ -102,7 +102,8 @@ func TestParamAtConvergesAndStopsEarly(t *testing.T) {
 		t.Errorf("ParamAt foot not perpendicular: residual %g", r)
 	}
 	// Re-run the refinement from ParamAt's knot-span seed to observe the iteration count.
-	su, sv := nearestSeed(s, q, knotSpanSeedParams(s.UKnots, s.UDegree), knotSpanSeedParams(s.VKnots, s.VDegree))
+	sus, svs, spts := s.seedLattice()
+	su, sv := nearestSeedPoint(sus, svs, spts, q)
 	_, _, iters, _ := refineSurfaceParam(s, q, su, sv, surfaceInvertMaxIter)
 	if iters >= surfaceInvertMaxIter {
 		t.Errorf("ParamAt refinement ran the full %d iterations — early exit not working", surfaceInvertMaxIter)


### PR DESCRIPTION
## What

Follow-up to #3492, which merged before this commit reached it: the exact self-intersection scan it introduced (#3477) made `BSplineSurface.ParamAt`'s per-call seed-lattice rebuild the dominant cost on blend-parity bodies, and develop's CI `test` jobs now time out at the 1-hour limit (`TestOCCTBlendTolblend/B8` alone 8m30s deep in that rebuild). This lands the fix for #3490: the lattice parameters and their ≥256 evaluated seed points are pure functions of the immutable surface, memoized behind a pointer shared by every copy and filled under `sync.Once`. The superseded per-call scanner is deleted.

## Why it changes no verdict — asserted, not inferred

A cold zero-value copy (the compute-per-call path, byte-for-byte the old behaviour) and the warm memoized surface invert an 81-point grid to **bitwise-identical** parameters, and 32 concurrent inversions agree exactly under `-race`.

## Measured

| | before | after |
|---|---|---|
| tolblend grid | 28m27s, unfinished (CI timeout) | **161.6 s** |
| `model/feature` | 2278 s | **849 s** |
| `occtparity` | 2632 s | **398 s** |
| kernel/geom | 5.5 s | 2.1 s |

OCC corpus holds at 68/72 analytic; kernel/geom, brep, ops, topo, blend, predicates, model/analysis, compdef, feature and occtparity all green; lint clean.

Closes #3490

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cRDEfz5RsT9mwwSgLL8aU
