### PR TITLE
Measure the mesh convergence test on the mesh integrator

### DIFF
--- a/kernel/ops/massprops_orientation_test.go
+++ b/kernel/ops/massprops_orientation_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"oblikovati.org/kernel/brep"
+	"oblikovati.org/kernel/topo"
 	m "oblikovati.org/math"
 )
 
@@ -21,7 +22,17 @@ func sphereVolume(r float64) float64 { return 4.0 / 3.0 * math.Pi * r * r * r }
 // TestCoarseSphereVolumeConvergesMonotonically tessellates a sphere at successively finer qualities
 // and asserts the volume rises monotonically toward the analytic value from below (an inscribed
 // polyhedron under-fills), with no spike. A random saddle flip would break monotonicity or sign.
+//
+// It measures meshGeometryProperties DIRECTLY, because that is its subject. It used to drive
+// BodyGeometryProperties, which since M48/C3 (#3453) integrates the analytic B-rep and consults its
+// Quality argument only for a fallback this body never takes — so all four qualities returned the
+// SAME exact volume, the "error" was a constant at machine epsilon, and the convergence assertion
+// compared 2.51e-16 against 5.03e-17 and tipped on floating-point noise (green on amd64, red on CI's
+// arm64, where FMA contraction rounds differently). The mesh integrator is still the thing that can
+// suffer an orientation spike, and it is still reached — as the fallback, and by every consumer of a
+// mesh with no B-rep behind it.
 func TestCoarseSphereVolumeConvergesMonotonically(t *testing.T) {
+	t.Parallel()
 	const r = 3.0
 	want := sphereVolume(r)
 	sphere, err := brep.SolidSphere(m.P3(0, 0, 0), r, "sphere")
@@ -36,7 +47,8 @@ func TestCoarseSphereVolumeConvergesMonotonically(t *testing.T) {
 	}
 	var coarseErr, prevErr = 0.0, math.Inf(1)
 	for i, q := range qualities {
-		v := BodyGeometryProperties(sphere, q).Volume
+		mesh, _ := TessellateBody(sphere, q)
+		v := meshGeometryProperties(mesh).Volume
 		if v <= 0 {
 			t.Fatalf("q[%d]: non-positive volume %g (sign flip)", i, v)
 		}
@@ -60,12 +72,29 @@ func TestCoarseSphereVolumeConvergesMonotonically(t *testing.T) {
 	if prevErr > 1e-2 {
 		t.Errorf("finest rel error %g too large for a converged sphere mesh", prevErr)
 	}
+	assertAnalyticVolumeIgnoresQuality(t, sphere, want, qualities)
+}
+
+// assertAnalyticVolumeIgnoresQuality pins what replaced the convergence above: BodyGeometryProperties
+// integrates the analytic B-rep, so a sphere's volume is EXACT at every quality rather than
+// converging toward exactness. This is the stronger contract, and stating it here keeps the two
+// meters distinguishable — the reason the convergence assertion had to move off this entry point.
+func assertAnalyticVolumeIgnoresQuality(t *testing.T, sphere *topo.Body, want float64, qualities []Quality) {
+	t.Helper()
+	for i, q := range qualities {
+		got := BodyGeometryProperties(sphere, q).Volume
+		if rel := math.Abs(got-want) / want; rel > 1e-12 {
+			t.Errorf("q[%d]: analytic volume %.17g vs exact %.17g (rel %.3g) — the analytic path must not "+
+				"depend on tessellation quality", i, got, want, rel)
+		}
+	}
 }
 
 // TestCoarseSphereVolumeWithinChordBound asserts that even at the COARSEST quality the volume error
 // is bounded by O(chord²)/R² — the geometric chord-deviation bound — not an O(1) spike. Pre-fix, a
 // flipped saddle facet on a coarse sphere produced errors far beyond this bound.
 func TestCoarseSphereVolumeWithinChordBound(t *testing.T) {
+	t.Parallel()
 	const r = 3.0
 	want := sphereVolume(r)
 	sphere, err := brep.SolidSphere(m.P3(0, 0, 0), r, "sphere")
@@ -88,6 +117,7 @@ func TestCoarseSphereVolumeWithinChordBound(t *testing.T) {
 // must track the analytic 2π²·R·r² across qualities with no spike. The summed-normal test was most
 // fragile exactly on this saddle band.
 func TestSaddleRichTorusVolumeStable(t *testing.T) {
+	t.Parallel()
 	const major, minor = 5.0, 1.5
 	want := 2 * math.Pi * math.Pi * major * minor * minor
 	torus, err := brep.SolidTorus(m.P3(0, 0, 0), m.V3(0, 0, 1), major, minor, "torus")
@@ -120,6 +150,7 @@ func TestSaddleRichTorusVolumeStable(t *testing.T) {
 // (2/5)·V·R² and the products of inertia vanish. A saddle-flipped covariance contribution would
 // break the isotropy or the diagonal value.
 func TestSolidSphereInertiaIsotropic(t *testing.T) {
+	t.Parallel()
 	const r = 3.0
 	sphere, err := brep.SolidSphere(m.P3(0, 0, 0), r, "sphere")
 	if err != nil {
@@ -188,6 +219,7 @@ func inconsistentCubeMesh(s float64) *Mesh {
 // correct volume magnitude from a mesh whose triangles are inconsistently wound and whose shading
 // normals are useless — the case the old summed-normal test got wrong (Oblikovati/Oblikovati#1318).
 func TestInconsistentlyWoundMeshVolumeMagnitude(t *testing.T) {
+	t.Parallel()
 	const s = 2.0
 	mesh := inconsistentCubeMesh(s)
 	gp := meshGeometryProperties(mesh)


### PR DESCRIPTION
## What

`TestCoarseSphereVolumeConvergesMonotonically` fails on develop (CI `test (macos-latest)`, arm64). It drove `BodyGeometryProperties` across four tessellation qualities and asserted the error shrank at least 5×. Since #3453 that entry point integrates the analytic B-rep and consults its `Quality` argument only for a fallback this body never takes — so all four qualities return the **same exact volume**, the "error" is a constant at machine epsilon, and the assertion compared `2.51e-16` against `5.03e-17`.

That is floating-point noise, not a measurement: green on amd64, red on arm64 where FMA contraction rounds differently. It was invisible locally for the same reason.

## Fix

The test's subject is `meshGeometryProperties` — whether a coarse high-curvature mesh can suffer an orientation spike (#1318). It now measures that directly. The mesh integrator is still reached, as the analytic path's fallback and by every consumer of a mesh with no B-rep behind it, so the regression keeps its teeth.

What *replaced* the convergence is pinned alongside it, and it is the stronger contract: the analytic volume is **exact at every quality** rather than converging toward exactness.

No tolerance was loosened and no assertion dropped — the convergence bound (5×), the monotonicity check and the under-fill check all still run, on the integrator they describe.

`kernel/ops` green; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cRDEfz5RsT9mwwSgLL8aU
